### PR TITLE
ms365: add plugin with auth-code pairing and Teams chat tools

### DIFF
--- a/plugins/ms365/.claude-plugin/plugin.json
+++ b/plugins/ms365/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "ms365",
+  "description": "Microsoft 365 / Graph API tools for Claude Code. Per-UPN delegated token management via OAuth authorization code flow (paired through the Teams plugin's /auth/callback handler). Tools for mail, calendar, people, directory, and Teams chat.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Agent Bridge",
+    "email": "maintainers@agent-bridge.local"
+  },
+  "keywords": [
+    "microsoft",
+    "m365",
+    "graph",
+    "mail",
+    "calendar",
+    "teams",
+    "chat",
+    "mcp"
+  ]
+}

--- a/plugins/ms365/.mcp.json
+++ b/plugins/ms365/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "ms365": {
+      "command": "bun",
+      "args": ["run", "--cwd", "${CLAUDE_PLUGIN_ROOT}", "--shell=bun", "--silent", "start"]
+    }
+  }
+}

--- a/plugins/ms365/README.md
+++ b/plugins/ms365/README.md
@@ -1,0 +1,123 @@
+# Microsoft 365 / Graph Plugin
+
+This Claude Code MCP plugin exposes Microsoft Graph tools — mail, calendar,
+directory, and Teams chat — to a Claude agent running under Agent Bridge.
+Each user principal (UPN) gets its own delegated access + refresh token
+stored under `~/.claude/channels/ms365/tokens/`.
+
+Pairing happens through the authorization code flow, with the browser
+redirect captured by the Teams plugin's `/auth/callback` handler — the
+Teams plugin already runs an HTTPS-reachable listener for bot webhooks, so
+this plugin piggybacks on that ingress rather than standing up a second
+loopback server.
+
+## Runtime Files
+
+By default the plugin reads:
+
+- `~/.claude/channels/ms365/.env`
+- `~/.claude/channels/ms365/tokens/<slug-of-upn>.json`
+- `~/.claude/channels/ms365/pending/<slug-of-upn>.json`
+
+When Agent Bridge starts an agent with `plugin:ms365@agent-bridge`, it
+sets `MS365_STATE_DIR` to the agent-local directory, for example:
+
+```bash
+~/.agent-bridge/agents/<agent>/.ms365
+```
+
+## Environment
+
+```dotenv
+MS365_TENANT_ID=<entra-tenant-id-guid>
+MS365_CLIENT_ID=<app-registration-client-id>
+MS365_CLIENT_SECRET=<app-registration-client-secret>
+MS365_DEFAULT_UPN=<default-user-principal-name>
+MS365_DEFAULT_SCOPES="openid profile offline_access User.Read Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite People.Read User.Read.All Directory.Read.All Chat.ReadWrite"
+MS365_REDIRECT_URI=http://localhost:3978/auth/callback
+```
+
+The Azure AD app registration must have `MS365_REDIRECT_URI` registered as
+a redirect URI exactly (including scheme, host, and path) and must have a
+client secret (confidential client — this plugin will not start without
+`MS365_CLIENT_SECRET`).
+
+For a hosted deployment where the Teams plugin sits behind a public
+ingress, point `MS365_REDIRECT_URI` at the public URL (for example
+`https://bot.example.com/auth/callback`) and make sure the ingress routes
+both `/api/messages` (Teams bot webhook) and `/auth/callback` (this
+plugin's redirect) to the Teams plugin listener.
+
+## Pairing Flow
+
+1. Call `pair_start(upn=user@tenant.com)`. The tool returns an
+   `authorize_url` plus an opaque state.
+2. The user opens the URL in a browser, signs in, and approves the scopes.
+3. Microsoft redirects to `MS365_REDIRECT_URI?code=...&state=...`.
+4. The Teams plugin's `/auth/callback` handler validates the state shape,
+   atomically writes `{state, code, received_at}` into
+   `$BRIDGE_HOME/shared/ms365-callbacks/<state>.json`, and shows a short
+   success page.
+5. Call `pair_poll(upn=user@tenant.com)`. The tool sees the callback
+   file, POSTs `grant_type=authorization_code` to the token endpoint,
+   saves the token, and cleans up the pending + callback files.
+6. Tokens auto-refresh when within five minutes of expiry.
+
+State expires 15 minutes after `pair_start`. Call `pair_start` again to
+restart the flow. `logout(upn=...)` deletes the token.
+
+## Tools
+
+### Pairing / session
+- `pair_start(upn, scopes?)`
+- `pair_poll(upn)`
+- `pair_status(upn)`
+- `logout(upn)`
+
+### Identity / directory
+- `me(upn, select?)`
+- `user_get(upn, lookup, select?)`
+- `people_search(upn, query, top?)`
+
+### Mail
+- `mail_list(upn, folder?, top?, search?, filter?, select?)`
+- `mail_get(upn, message_id)`
+- `mail_send(upn, to, cc?, subject, body, body_type?)`
+
+### Calendar
+- `calendar_upcoming(upn, days?, top?)` — `/me/calendarview` over the next N days
+- `calendar_create(upn, subject, start, end, timezone?, attendees?, body?, location?, online?)`
+
+### Teams chat
+- `chat_list(upn, top?, filter?)` — `/me/chats` with member + last message preview
+- `chat_messages(upn, chat_id, top?)`
+- `chat_send(upn, chat_id, body, content_type?)`
+- `chat_create(upn, targets, topic?)` — 1:1 or group; Graph returns the
+  existing chat id if the same member set already has one, so this is
+  find-or-create rather than always-create
+- `chat_delete(upn, chat_id, message_id)` — `softDelete` via
+  `/me/chats/{id}/messages/{id}/softDelete`
+- `chat_undo_delete(upn, chat_id, message_id)` — mirror of `chat_delete`
+- `joined_teams(upn)`
+
+## Scopes
+
+The plugin doesn't pin scopes — whatever the user consents to at
+pair time ends up in the stored token. The default scope list above
+covers every tool this plugin exposes. A minimal setup can drop
+`Directory.Read.All`, `User.Read.All`, `Chat.ReadWrite` if the
+corresponding tools are not used.
+
+## Security Notes
+
+- Tokens are stored with mode `0600` under `$MS365_STATE_DIR/tokens/`
+  along with the refresh token. Agent sandboxing should isolate this
+  directory to the owning agent.
+- `MS365_CLIENT_SECRET` is required at startup. Rotate it through Azure
+  AD and update `.env` as needed.
+- The plugin never logs access tokens or refresh tokens; error messages
+  include only the Graph API error body truncated to 500 characters.
+- `MS365_REDIRECT_URI` validation is enforced by the Teams plugin's
+  callback handler: the incoming `state` parameter must match
+  `/^[A-Za-z0-9_-]{8,128}$/` before anything is written to
+  `shared/ms365-callbacks/`.

--- a/plugins/ms365/bun.lock
+++ b/plugins/ms365/bun.lock
@@ -1,0 +1,195 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "claude-ms365-mcp",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@hono/node-server": ["@hono/node-server@1.19.13", "", { "peerDependencies": { "hono": "^4" } }, "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.2", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+  }
+}

--- a/plugins/ms365/package.json
+++ b/plugins/ms365/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "claude-ms365-mcp",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": "./server.ts",
+  "scripts": {
+    "start": "bun install --no-summary && bun server.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  }
+}

--- a/plugins/ms365/server.ts
+++ b/plugins/ms365/server.ts
@@ -1,0 +1,1016 @@
+#!/usr/bin/env bun
+/**
+ * Microsoft 365 / Graph API MCP plugin for Claude Code, local dev channel.
+ *
+ * - Per-UPN delegated token storage via OAuth authorization code flow with a
+ *   local HTTPS redirect (the Teams plugin multiplexes /auth/callback through
+ *   its existing webhook listener and writes the code to a shared directory).
+ * - Auto refresh with refresh_token.
+ * - Tools for Mail, Calendar, People, User, Directory.
+ *
+ * Env (loaded from $MS365_STATE_DIR/.env if present):
+ *   MS365_TENANT_ID       - Entra tenant id (GUID)
+ *   MS365_CLIENT_ID       - App registration client id (GUID)
+ *   MS365_CLIENT_SECRET   - Confidential client secret (required for web app flow)
+ *   MS365_DEFAULT_UPN     - Default user principal when tools are called without upn
+ *   MS365_STATE_DIR       - Override state dir (defaults to ~/.claude/channels/ms365)
+ *   MS365_DEFAULT_SCOPES  - Space-separated scopes to request during pairing
+ *   MS365_REDIRECT_URI    - Redirect URI registered on the app registration.
+ *                           Must match the Azure AD app configuration exactly.
+ *                           In local dev this points at the Teams plugin's
+ *                           /auth/callback listener; in a hosted deployment
+ *                           it points at the public ingress fronting the
+ *                           Teams plugin. Defaults to
+ *                           http://localhost:3978/auth/callback.
+ *   MS365_CALLBACK_SHARED_DIR - Where the Teams plugin drops captured callback
+ *                           payloads (default $BRIDGE_HOME/shared/ms365-callbacks)
+ *   BRIDGE_HOME           - Agent Bridge install root (default ~/.agent-bridge)
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js'
+import {
+  chmodSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+
+const STATE_DIR = process.env.MS365_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'ms365')
+const ENV_FILE = join(STATE_DIR, '.env')
+const TOKENS_DIR = join(STATE_DIR, 'tokens')
+const PENDING_DIR = join(STATE_DIR, 'pending')
+
+const BRIDGE_HOME = process.env.BRIDGE_HOME ?? join(homedir(), '.agent-bridge')
+const MS365_CALLBACK_DIR =
+  process.env.MS365_CALLBACK_SHARED_DIR ?? join(BRIDGE_HOME, 'shared', 'ms365-callbacks')
+
+function ensureDirs(): void {
+  mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
+  mkdirSync(TOKENS_DIR, { recursive: true, mode: 0o700 })
+  mkdirSync(PENDING_DIR, { recursive: true, mode: 0o700 })
+  mkdirSync(MS365_CALLBACK_DIR, { recursive: true, mode: 0o700 })
+}
+
+ensureDirs()
+
+try {
+  chmodSync(ENV_FILE, 0o600)
+  for (const line of readFileSync(ENV_FILE, 'utf8').split('\n')) {
+    const m = line.match(/^(\w+)=(.*)$/)
+    if (m && process.env[m[1]] === undefined) process.env[m[1]] = m[2]
+  }
+} catch {}
+
+const TENANT_ID = process.env.MS365_TENANT_ID ?? ''
+const CLIENT_ID = process.env.MS365_CLIENT_ID ?? ''
+const CLIENT_SECRET = process.env.MS365_CLIENT_SECRET ?? ''
+const DEFAULT_UPN = process.env.MS365_DEFAULT_UPN ?? ''
+const DEFAULT_SCOPES =
+  process.env.MS365_DEFAULT_SCOPES ??
+  'openid profile offline_access User.Read Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite People.Read User.Read.All Directory.Read.All'
+const REDIRECT_URI =
+  process.env.MS365_REDIRECT_URI ?? 'http://localhost:3978/auth/callback'
+
+if (!TENANT_ID || !CLIENT_ID || !CLIENT_SECRET) {
+  process.stderr.write(
+    `ms365: MS365_TENANT_ID, MS365_CLIENT_ID, and MS365_CLIENT_SECRET are required\n` +
+      `  set them in ${ENV_FILE}\n`,
+  )
+  process.exit(1)
+}
+
+type TokenFile = {
+  upn: string
+  access_token: string
+  refresh_token?: string
+  expires_at: number
+  scope: string
+  saved_at: number
+}
+
+type PendingFile = {
+  upn: string
+  state: string
+  scopes: string
+  created_at: number
+  expires_at: number
+  authorize_url: string
+}
+
+type CallbackFile = {
+  state: string
+  code: string
+  error?: string
+  error_description?: string
+  received_at: number
+}
+
+function slugUpn(upn: string): string {
+  return upn.replace(/[^A-Za-z0-9._-]/g, '_').toLowerCase()
+}
+
+function tokenPath(upn: string): string {
+  return join(TOKENS_DIR, `${slugUpn(upn)}.json`)
+}
+
+function pendingPath(upn: string): string {
+  return join(PENDING_DIR, `${slugUpn(upn)}.json`)
+}
+
+function saveJson(path: string, payload: unknown): void {
+  const tmp = `${path}.tmp`
+  writeFileSync(tmp, JSON.stringify(payload, null, 2) + '\n', { mode: 0o600 })
+  renameSync(tmp, path)
+  chmodSync(path, 0o600)
+}
+
+function loadJson<T>(path: string): T | null {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as T
+  } catch {
+    return null
+  }
+}
+
+function resolveUpn(arg: unknown): string {
+  const s = (arg == null ? DEFAULT_UPN : String(arg)).trim()
+  if (!s) {
+    throw new Error(
+      'upn is required (no default configured; pass upn or set MS365_DEFAULT_UPN in .env)',
+    )
+  }
+  return s
+}
+
+async function postForm(
+  url: string,
+  body: Record<string, string>,
+): Promise<any> {
+  const form = new URLSearchParams(body)
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: form.toString(),
+  })
+  const text = await res.text()
+  try {
+    return JSON.parse(text)
+  } catch {
+    return { _raw: text, _status: res.status }
+  }
+}
+
+function callbackPath(state: string): string {
+  return join(MS365_CALLBACK_DIR, `${state}.json`)
+}
+
+function startAuthCode(upn: string, scopes: string): PendingFile {
+  const state = randomUUID()
+  const now = Math.floor(Date.now() / 1000)
+  const authorizeParams = new URLSearchParams({
+    client_id: CLIENT_ID,
+    response_type: 'code',
+    redirect_uri: REDIRECT_URI,
+    response_mode: 'query',
+    scope: scopes,
+    state,
+    prompt: 'select_account',
+    login_hint: upn,
+  })
+  const authorizeUrl =
+    `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/authorize?` + authorizeParams.toString()
+  const pending: PendingFile = {
+    upn,
+    state,
+    scopes,
+    created_at: now,
+    expires_at: now + 900,
+    authorize_url: authorizeUrl,
+  }
+  saveJson(pendingPath(upn), pending)
+  return pending
+}
+
+async function exchangeAuthCode(
+  upn: string,
+): Promise<
+  | { status: 'success'; token: TokenFile }
+  | { status: 'pending'; hint: string }
+  | { status: 'expired' }
+  | { status: 'error'; error: string; description: string }
+> {
+  const pending = loadJson<PendingFile>(pendingPath(upn))
+  if (!pending) {
+    return { status: 'error', error: 'no_pending', description: `no pending pairing for ${upn}; call pair_start first` }
+  }
+  const now = Math.floor(Date.now() / 1000)
+  if (now >= pending.expires_at) {
+    try { unlinkSync(pendingPath(upn)) } catch {}
+    try { unlinkSync(callbackPath(pending.state)) } catch {}
+    return { status: 'expired' }
+  }
+
+  const cb = loadJson<CallbackFile>(callbackPath(pending.state))
+  if (!cb) {
+    return { status: 'pending', hint: 'waiting for user to complete sign-in via authorize_url' }
+  }
+  if (cb.error) {
+    try { unlinkSync(callbackPath(pending.state)) } catch {}
+    try { unlinkSync(pendingPath(upn)) } catch {}
+    return { status: 'error', error: cb.error, description: String(cb.error_description ?? '').slice(0, 500) }
+  }
+  if (!cb.code) {
+    return { status: 'error', error: 'empty_code', description: 'callback file had no code' }
+  }
+
+  const data = await postForm(
+    `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`,
+    {
+      grant_type: 'authorization_code',
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      code: cb.code,
+      redirect_uri: REDIRECT_URI,
+      scope: pending.scopes,
+    },
+  )
+  if (data.error) {
+    return {
+      status: 'error',
+      error: data.error,
+      description: String(data.error_description ?? '').slice(0, 500),
+    }
+  }
+  if (!data.access_token) {
+    return {
+      status: 'error',
+      error: 'malformed_response',
+      description: JSON.stringify(data).slice(0, 400),
+    }
+  }
+  const token: TokenFile = {
+    upn,
+    access_token: data.access_token,
+    refresh_token: data.refresh_token,
+    expires_at: now + Number(data.expires_in ?? 3600),
+    scope: String(data.scope ?? pending.scopes),
+    saved_at: now,
+  }
+  saveJson(tokenPath(upn), token)
+  try { unlinkSync(pendingPath(upn)) } catch {}
+  try { unlinkSync(callbackPath(pending.state)) } catch {}
+  return { status: 'success', token }
+}
+
+async function refreshToken(upn: string): Promise<TokenFile> {
+  const cur = loadJson<TokenFile>(tokenPath(upn))
+  if (!cur) throw new Error(`no token for ${upn}; run pair_start + pair_poll`)
+  if (!cur.refresh_token) throw new Error(`no refresh_token for ${upn}; re-pair`)
+  const data = await postForm(
+    `https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token`,
+    {
+      grant_type: 'refresh_token',
+      client_id: CLIENT_ID,
+      refresh_token: cur.refresh_token,
+      scope: cur.scope || DEFAULT_SCOPES,
+      ...(CLIENT_SECRET ? { client_secret: CLIENT_SECRET } : {}),
+    },
+  )
+  if (data.error) {
+    throw new Error(
+      `refresh failed for ${upn}: ${data.error} — ${String(data.error_description ?? '').slice(0, 300)}`,
+    )
+  }
+  const now = Math.floor(Date.now() / 1000)
+  const next: TokenFile = {
+    upn,
+    access_token: data.access_token,
+    refresh_token: data.refresh_token ?? cur.refresh_token,
+    expires_at: now + Number(data.expires_in ?? 3600),
+    scope: String(data.scope ?? cur.scope),
+    saved_at: now,
+  }
+  saveJson(tokenPath(upn), next)
+  return next
+}
+
+async function getAccessToken(upn: string): Promise<string> {
+  const cur = loadJson<TokenFile>(tokenPath(upn))
+  if (!cur) throw new Error(`no token for ${upn}; run pair_start then pair_poll to authenticate`)
+  const now = Math.floor(Date.now() / 1000)
+  if (cur.expires_at - now > 300) return cur.access_token
+  const refreshed = await refreshToken(upn)
+  return refreshed.access_token
+}
+
+async function graph(
+  upn: string,
+  method: string,
+  path: string,
+  body?: unknown,
+  query?: Record<string, string | number | undefined>,
+  version: 'v1.0' | 'beta' = 'v1.0',
+): Promise<any> {
+  const token = await getAccessToken(upn)
+  let url = `https://graph.microsoft.com/${version}${path}`
+  if (query) {
+    const qs = new URLSearchParams()
+    for (const [k, v] of Object.entries(query)) {
+      if (v != null && v !== '') qs.append(k, String(v))
+    }
+    const s = qs.toString()
+    if (s) url += (url.includes('?') ? '&' : '?') + s
+  }
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: body != null ? JSON.stringify(body) : undefined,
+  })
+  const text = await res.text()
+  let data: any = null
+  try { data = text ? JSON.parse(text) : null } catch { data = { _raw: text } }
+  if (!res.ok) {
+    const err = data?.error?.message ?? data?._raw ?? `HTTP ${res.status}`
+    throw new Error(`graph ${method} ${path} failed (${res.status}): ${String(err).slice(0, 500)}`)
+  }
+  return data
+}
+
+// -------- MCP server -----------------------------------------------------------
+
+const mcp = new Server(
+  { name: 'ms365', version: '0.1.0' },
+  {
+    capabilities: { tools: {} },
+    instructions: [
+      'Microsoft 365 / Graph API tools for Claude Code.',
+      'Before any mail/calendar/people call, ensure the target UPN has a paired token.',
+      'Pair flow (authorization code): call pair_start → give the user the authorize_url → user signs in and approves → call pair_poll (status=success|pending|expired|error) until success.',
+      'Default UPN may be bound via MS365_DEFAULT_UPN env; otherwise pass upn explicitly to every tool.',
+      'Tokens auto-refresh when within 5 minutes of expiry. Call logout to delete a token.',
+    ].join('\n'),
+  },
+)
+
+type ToolDef = {
+  name: string
+  description: string
+  schema: Record<string, unknown>
+  handler: (args: Record<string, unknown>) => Promise<unknown>
+}
+
+function textResult(data: unknown) {
+  return { content: [{ type: 'text', text: typeof data === 'string' ? data : JSON.stringify(data, null, 2) }] }
+}
+
+const tools: ToolDef[] = [
+  {
+    name: 'pair_start',
+    description:
+      'Begin authorization-code pairing for a user principal (UPN). Returns an authorize_url the user must open in a browser. Follow up with pair_poll to exchange the code for tokens.',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string', description: 'User principal name (email-like). Defaults to MS365_DEFAULT_UPN.' },
+        scopes: { type: 'string', description: 'Space-separated OAuth scopes. Defaults to MS365_DEFAULT_SCOPES.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const scopes = String(args.scopes ?? DEFAULT_SCOPES)
+      const pending = startAuthCode(upn, scopes)
+      return textResult({
+        upn,
+        authorize_url: pending.authorize_url,
+        redirect_uri: REDIRECT_URI,
+        state: pending.state,
+        expires_in_seconds: pending.expires_at - Math.floor(Date.now() / 1000),
+        instructions: `Open the authorize_url in a browser, sign in as ${upn}, approve the requested permissions. The browser will redirect to ${REDIRECT_URI}. Then call pair_poll to finish.`,
+      })
+    },
+  },
+  {
+    name: 'pair_poll',
+    description:
+      'Check whether the user has completed the authorization-code redirect, and if so, exchange the code for access + refresh tokens. Returns status=success|pending|expired|error.',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const result = await exchangeAuthCode(upn)
+      if (result.status === 'success') {
+        return textResult({
+          status: 'success',
+          upn,
+          scope: result.token.scope,
+          expires_in_seconds: result.token.expires_at - Math.floor(Date.now() / 1000),
+          has_refresh_token: Boolean(result.token.refresh_token),
+        })
+      }
+      return textResult(result)
+    },
+  },
+  {
+    name: 'pair_status',
+    description: 'Report whether a UPN currently has a stored token and when it expires.',
+    schema: { type: 'object', properties: { upn: { type: 'string' } } },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const cur = loadJson<TokenFile>(tokenPath(upn))
+      if (!cur) return textResult({ upn, paired: false })
+      const now = Math.floor(Date.now() / 1000)
+      return textResult({
+        upn,
+        paired: true,
+        expires_in_seconds: cur.expires_at - now,
+        has_refresh_token: Boolean(cur.refresh_token),
+        scope: cur.scope,
+        saved_at_iso: new Date(cur.saved_at * 1000).toISOString(),
+      })
+    },
+  },
+  {
+    name: 'logout',
+    description: 'Delete the stored token for a UPN. User must re-run pair_start next time.',
+    schema: { type: 'object', properties: { upn: { type: 'string' } } },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      try {
+        unlinkSync(tokenPath(upn))
+        return textResult({ upn, removed: true })
+      } catch (e) {
+        return textResult({ upn, removed: false, reason: String(e) })
+      }
+    },
+  },
+  {
+    name: 'me',
+    description: 'Return the signed-in user profile (GET /me).',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string' },
+        select: { type: 'string', description: 'OData $select fields, comma-separated.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const select = String(args.select ?? 'displayName,userPrincipalName,mail,jobTitle,officeLocation,id')
+      return textResult(await graph(upn, 'GET', '/me', undefined, { $select: select }))
+    },
+  },
+  {
+    name: 'mail_list',
+    description:
+      'List recent messages from the user\'s mailbox. Default folder is Inbox. Supports $top, $search, $filter.',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string' },
+        folder: { type: 'string', description: 'Well-known folder name or folder id. Default: inbox.' },
+        top: { type: 'number', description: 'Max messages to return (default 10, max 50).' },
+        search: { type: 'string', description: 'Graph $search KQL expression.' },
+        filter: { type: 'string', description: 'Graph $filter expression.' },
+        select: { type: 'string' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const folder = String(args.folder ?? 'inbox')
+      const top = Math.max(1, Math.min(Number(args.top ?? 10), 50))
+      const select = String(
+        args.select ?? 'id,subject,from,toRecipients,receivedDateTime,bodyPreview,isRead,hasAttachments,importance',
+      )
+      const query: Record<string, string | number | undefined> = {
+        $top: top,
+        $select: select,
+      }
+      if (args.search) query.$search = `"${String(args.search).replace(/"/g, '\\"')}"`
+      if (args.filter) query.$filter = String(args.filter)
+      else if (!args.search) query.$orderby = 'receivedDateTime desc'
+      const path = folder === 'inbox'
+        ? '/me/mailFolders/inbox/messages'
+        : folder === 'sent'
+        ? '/me/mailFolders/sentitems/messages'
+        : `/me/mailFolders/${encodeURIComponent(folder)}/messages`
+      const data = await graph(upn, 'GET', path, undefined, query)
+      const rows = (data?.value ?? []).map((m: any) => ({
+        id: m.id,
+        received: m.receivedDateTime,
+        from: m.from?.emailAddress
+          ? `${m.from.emailAddress.name ?? ''} <${m.from.emailAddress.address ?? ''}>`.trim()
+          : '',
+        subject: m.subject,
+        preview: m.bodyPreview,
+        unread: !m.isRead,
+        attachments: !!m.hasAttachments,
+        importance: m.importance,
+      }))
+      return textResult({ count: rows.length, messages: rows })
+    },
+  },
+  {
+    name: 'mail_get',
+    description: 'Fetch a single message with full body. Pass the id returned from mail_list.',
+    schema: {
+      type: 'object',
+      required: ['message_id'],
+      properties: {
+        upn: { type: 'string' },
+        message_id: { type: 'string' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const id = String(args.message_id ?? '').trim()
+      if (!id) throw new Error('message_id is required')
+      const data = await graph(upn, 'GET', `/me/messages/${encodeURIComponent(id)}`)
+      return textResult({
+        id: data.id,
+        received: data.receivedDateTime,
+        from: data.from?.emailAddress,
+        to: (data.toRecipients ?? []).map((r: any) => r.emailAddress),
+        cc: (data.ccRecipients ?? []).map((r: any) => r.emailAddress),
+        subject: data.subject,
+        body_type: data.body?.contentType,
+        body: data.body?.content,
+        hasAttachments: data.hasAttachments,
+      })
+    },
+  },
+  {
+    name: 'mail_send',
+    description:
+      'Send an email as the signed-in user. to is a comma-separated list of email addresses. body is plain text by default, set body_type to \"html\" for HTML.',
+    schema: {
+      type: 'object',
+      required: ['to', 'subject', 'body'],
+      properties: {
+        upn: { type: 'string' },
+        to: { type: 'string', description: 'Comma-separated recipient addresses.' },
+        cc: { type: 'string' },
+        subject: { type: 'string' },
+        body: { type: 'string' },
+        body_type: { type: 'string', enum: ['text', 'html'], description: 'Default text.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const to = String(args.to ?? '').split(',').map(s => s.trim()).filter(Boolean)
+      if (to.length === 0) throw new Error('to is required (comma-separated)')
+      const cc = String(args.cc ?? '').split(',').map(s => s.trim()).filter(Boolean)
+      const message = {
+        subject: String(args.subject ?? ''),
+        body: {
+          contentType: String(args.body_type ?? 'text'),
+          content: String(args.body ?? ''),
+        },
+        toRecipients: to.map(a => ({ emailAddress: { address: a } })),
+        ccRecipients: cc.map(a => ({ emailAddress: { address: a } })),
+      }
+      await graph(upn, 'POST', '/me/sendMail', { message, saveToSentItems: true })
+      return textResult({ sent: true, to, cc, subject: message.subject })
+    },
+  },
+  {
+    name: 'calendar_upcoming',
+    description: 'List calendar events in the next N days (default 7). Uses /me/calendarview.',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string' },
+        days: { type: 'number', description: 'Default 7, max 60.' },
+        top: { type: 'number', description: 'Default 50, max 200.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const days = Math.max(1, Math.min(Number(args.days ?? 7), 60))
+      const top = Math.max(1, Math.min(Number(args.top ?? 50), 200))
+      const start = new Date()
+      const end = new Date(start.getTime() + days * 86_400_000)
+      const data = await graph(upn, 'GET', '/me/calendarview', undefined, {
+        startDateTime: start.toISOString(),
+        endDateTime: end.toISOString(),
+        $top: top,
+        $orderby: 'start/dateTime',
+        $select: 'id,subject,organizer,start,end,location,isAllDay,attendees,onlineMeeting,isCancelled',
+      })
+      const events = (data?.value ?? []).map((e: any) => ({
+        id: e.id,
+        subject: e.subject,
+        start: e.start?.dateTime,
+        end: e.end?.dateTime,
+        tz: e.start?.timeZone,
+        location: e.location?.displayName,
+        organizer: e.organizer?.emailAddress?.address,
+        attendees: (e.attendees ?? []).map((a: any) => a.emailAddress?.address).filter(Boolean),
+        online: !!e.onlineMeeting,
+        cancelled: !!e.isCancelled,
+      }))
+      return textResult({ days, count: events.length, events })
+    },
+  },
+  {
+    name: 'calendar_create',
+    description: 'Create a calendar event. start and end accept ISO 8601 strings. Attendees comma-separated.',
+    schema: {
+      type: 'object',
+      required: ['subject', 'start', 'end'],
+      properties: {
+        upn: { type: 'string' },
+        subject: { type: 'string' },
+        start: { type: 'string', description: 'ISO 8601 (e.g. 2026-04-12T14:00:00)' },
+        end: { type: 'string' },
+        timezone: { type: 'string', description: 'IANA tz (default Asia/Seoul).' },
+        attendees: { type: 'string', description: 'Comma-separated email list.' },
+        body: { type: 'string' },
+        location: { type: 'string' },
+        online: { type: 'boolean', description: 'Create as Teams online meeting.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const tz = String(args.timezone ?? 'Asia/Seoul')
+      const attendees = String(args.attendees ?? '')
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+      const payload: any = {
+        subject: String(args.subject),
+        start: { dateTime: String(args.start), timeZone: tz },
+        end: { dateTime: String(args.end), timeZone: tz },
+        body: { contentType: 'text', content: String(args.body ?? '') },
+        attendees: attendees.map(a => ({
+          emailAddress: { address: a },
+          type: 'required',
+        })),
+      }
+      if (args.location) payload.location = { displayName: String(args.location) }
+      if (args.online) {
+        payload.isOnlineMeeting = true
+        payload.onlineMeetingProvider = 'teamsForBusiness'
+      }
+      const data = await graph(upn, 'POST', '/me/events', payload)
+      return textResult({
+        created: true,
+        id: data.id,
+        webLink: data.webLink,
+        joinUrl: data.onlineMeeting?.joinUrl,
+      })
+    },
+  },
+  {
+    name: 'people_search',
+    description: 'Search the signed-in user\'s relevant people (colleagues, frequent contacts).',
+    schema: {
+      type: 'object',
+      required: ['query'],
+      properties: {
+        upn: { type: 'string' },
+        query: { type: 'string' },
+        top: { type: 'number' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const q = String(args.query ?? '').trim()
+      if (!q) throw new Error('query is required')
+      const top = Math.max(1, Math.min(Number(args.top ?? 10), 25))
+      const data = await graph(upn, 'GET', '/me/people', undefined, {
+        $search: `"${q.replace(/"/g, '\\"')}"`,
+        $top: top,
+        $select: 'id,displayName,givenName,surname,scoredEmailAddresses,jobTitle,companyName,department',
+      })
+      const people = (data?.value ?? []).map((p: any) => ({
+        name: p.displayName,
+        email: p.scoredEmailAddresses?.[0]?.address,
+        job: p.jobTitle,
+        dept: p.department,
+        company: p.companyName,
+        id: p.id,
+      }))
+      return textResult({ query: q, count: people.length, people })
+    },
+  },
+  {
+    name: 'user_get',
+    description: 'Look up a user in the directory by UPN or email. Requires User.Read.All on the calling principal.',
+    schema: {
+      type: 'object',
+      required: ['lookup'],
+      properties: {
+        upn: { type: 'string', description: 'Who is making the call (default MS365_DEFAULT_UPN).' },
+        lookup: { type: 'string', description: 'UPN/email of the user to look up.' },
+        select: { type: 'string' },
+      },
+    },
+    handler: async args => {
+      const caller = resolveUpn(args.upn)
+      const lookup = String(args.lookup ?? '').trim()
+      if (!lookup) throw new Error('lookup is required')
+      const select = String(
+        args.select ?? 'id,displayName,userPrincipalName,mail,jobTitle,officeLocation,department,companyName',
+      )
+      const data = await graph(caller, 'GET', `/users/${encodeURIComponent(lookup)}`, undefined, { $select: select })
+      return textResult(data)
+    },
+  },
+  {
+    name: 'chat_list',
+    description:
+      'List the signed-in user\'s recent Teams chats (1:1, group, and meeting chats). Requires Chat.ReadBasic or Chat.Read scope. Expands members and lastMessagePreview.',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string' },
+        top: { type: 'number', description: 'Max chats to return (default 20, max 50).' },
+        filter: { type: 'string', description: 'OData $filter, e.g. chatType eq \'oneOnOne\'.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const top = Math.max(1, Math.min(Number(args.top ?? 20), 50))
+      const query: Record<string, string | number | undefined> = {
+        $top: top,
+        $expand: 'members,lastMessagePreview',
+        $orderby: 'lastMessagePreview/createdDateTime desc',
+      }
+      if (args.filter) query.$filter = String(args.filter)
+      const data = await graph(upn, 'GET', '/me/chats', undefined, query)
+      const chats = (data?.value ?? []).map((c: any) => {
+        const members = (c.members ?? [])
+          .map((m: any) => m.displayName ?? m.email ?? m.userId)
+          .filter(Boolean)
+        const lastMsg = c.lastMessagePreview
+        return {
+          id: c.id,
+          chat_type: c.chatType,
+          topic: c.topic ?? null,
+          members,
+          last_updated: c.lastUpdatedDateTime,
+          last_message: lastMsg
+            ? {
+                created: lastMsg.createdDateTime,
+                from:
+                  lastMsg.from?.user?.displayName ??
+                  lastMsg.from?.application?.displayName ??
+                  null,
+                preview: stripHtml(String(lastMsg.body?.content ?? '')).slice(0, 240),
+                content_type: lastMsg.body?.contentType,
+              }
+            : null,
+          web_url: c.webUrl,
+        }
+      })
+      return textResult({ count: chats.length, chats })
+    },
+  },
+  {
+    name: 'chat_messages',
+    description:
+      'Fetch recent messages from a specific Teams chat. Requires Chat.Read or ChatMessage.Read scope. Pass chat_id returned by chat_list.',
+    schema: {
+      type: 'object',
+      required: ['chat_id'],
+      properties: {
+        upn: { type: 'string' },
+        chat_id: { type: 'string' },
+        top: { type: 'number', description: 'Max messages to return (default 20, max 50).' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const chatId = String(args.chat_id ?? '').trim()
+      if (!chatId) throw new Error('chat_id is required')
+      const top = Math.max(1, Math.min(Number(args.top ?? 20), 50))
+      const data = await graph(
+        upn,
+        'GET',
+        `/chats/${encodeURIComponent(chatId)}/messages`,
+        undefined,
+        { $top: top },
+      )
+      const messages = (data?.value ?? []).map((m: any) => ({
+        id: m.id,
+        created: m.createdDateTime,
+        from:
+          m.from?.user?.displayName ??
+          m.from?.application?.displayName ??
+          null,
+        from_id: m.from?.user?.id ?? null,
+        content_type: m.body?.contentType,
+        content: stripHtml(String(m.body?.content ?? '')),
+        importance: m.importance,
+        message_type: m.messageType,
+        deleted: !!m.deletedDateTime,
+      }))
+      return textResult({ chat_id: chatId, count: messages.length, messages })
+    },
+  },
+  {
+    name: 'chat_send',
+    description:
+      'Send a message to a specific Teams chat as the signed-in user. Requires ChatMessage.Send or Chat.ReadWrite scope.',
+    schema: {
+      type: 'object',
+      required: ['chat_id', 'body'],
+      properties: {
+        upn: { type: 'string' },
+        chat_id: { type: 'string' },
+        body: { type: 'string' },
+        content_type: { type: 'string', enum: ['text', 'html'], description: 'Default text.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const chatId = String(args.chat_id ?? '').trim()
+      if (!chatId) throw new Error('chat_id is required')
+      const body = String(args.body ?? '')
+      if (!body) throw new Error('body is required')
+      const contentType = String(args.content_type ?? 'text')
+      const data = await graph(
+        upn,
+        'POST',
+        `/chats/${encodeURIComponent(chatId)}/messages`,
+        { body: { contentType, content: body } },
+      )
+      return textResult({
+        sent: true,
+        chat_id: chatId,
+        message_id: data.id,
+        created: data.createdDateTime,
+      })
+    },
+  },
+  {
+    name: 'joined_teams',
+    description: 'List the Teams the signed-in user is a member of. Requires Team.ReadBasic.All or User.Read scope depending on tenant.',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const data = await graph(upn, 'GET', '/me/joinedTeams')
+      const teams = (data?.value ?? []).map((t: any) => ({
+        id: t.id,
+        name: t.displayName,
+        description: t.description,
+        visibility: t.visibility,
+      }))
+      return textResult({ count: teams.length, teams })
+    },
+  },
+  {
+    name: 'chat_delete',
+    description:
+      'Soft-delete a previously sent chat message. Only the original author can delete their own message. Requires Chat.ReadWrite scope. The message is hidden for all participants but can be restored via chat_undo_delete.',
+    schema: {
+      type: 'object',
+      required: ['chat_id', 'message_id'],
+      properties: {
+        upn: { type: 'string' },
+        chat_id: { type: 'string' },
+        message_id: { type: 'string' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const chatId = String(args.chat_id ?? '').trim()
+      const msgId = String(args.message_id ?? '').trim()
+      if (!chatId) throw new Error('chat_id is required')
+      if (!msgId) throw new Error('message_id is required')
+      await graph(
+        upn,
+        'POST',
+        `/me/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(msgId)}/softDelete`,
+      )
+      return textResult({ deleted: true, chat_id: chatId, message_id: msgId })
+    },
+  },
+  {
+    name: 'chat_undo_delete',
+    description:
+      'Restore a previously soft-deleted chat message. Mirror of chat_delete using the Graph /undoSoftDelete action.',
+    schema: {
+      type: 'object',
+      required: ['chat_id', 'message_id'],
+      properties: {
+        upn: { type: 'string' },
+        chat_id: { type: 'string' },
+        message_id: { type: 'string' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const chatId = String(args.chat_id ?? '').trim()
+      const msgId = String(args.message_id ?? '').trim()
+      if (!chatId) throw new Error('chat_id is required')
+      if (!msgId) throw new Error('message_id is required')
+      await graph(
+        upn,
+        'POST',
+        `/me/chats/${encodeURIComponent(chatId)}/messages/${encodeURIComponent(msgId)}/undoSoftDelete`,
+      )
+      return textResult({ restored: true, chat_id: chatId, message_id: msgId })
+    },
+  },
+  {
+    name: 'chat_create',
+    description:
+      'Create (or retrieve, if it already exists) a 1:1 or group Teams chat including the signed-in user and the listed target UPNs. Requires Chat.Create or Chat.ReadWrite scope. Returns the chat_id that can then be used with chat_send / chat_messages.',
+    schema: {
+      type: 'object',
+      required: ['targets'],
+      properties: {
+        upn: { type: 'string', description: 'Caller UPN (default MS365_DEFAULT_UPN). Will be added as owner.' },
+        targets: {
+          type: 'string',
+          description: 'Comma-separated list of target user UPNs/emails to include. For a 1:1 pass exactly one.',
+        },
+        topic: { type: 'string', description: 'Optional topic. Required for group chats (>=3 members total), ignored for 1:1.' },
+      },
+    },
+    handler: async args => {
+      const caller = resolveUpn(args.upn)
+      const targets = String(args.targets ?? '')
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+      if (targets.length === 0) throw new Error('targets is required (comma-separated UPNs)')
+      const allMembers = [caller, ...targets]
+      const isOneOnOne = allMembers.length === 2
+      const payload: any = {
+        chatType: isOneOnOne ? 'oneOnOne' : 'group',
+        members: allMembers.map(u => ({
+          '@odata.type': '#microsoft.graph.aadUserConversationMember',
+          roles: ['owner'],
+          'user@odata.bind': `https://graph.microsoft.com/v1.0/users('${u}')`,
+        })),
+      }
+      if (!isOneOnOne) {
+        if (!args.topic) throw new Error('topic is required for group chats (3+ members)')
+        payload.topic = String(args.topic)
+      }
+      const data = await graph(caller, 'POST', '/chats', payload)
+      return textResult({
+        id: data.id,
+        chat_type: data.chatType,
+        topic: data.topic ?? null,
+        web_url: data.webUrl,
+        created: data.createdDateTime,
+      })
+    },
+  },
+]
+
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, '').replace(/&nbsp;/g, ' ').replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/\s+/g, ' ').trim()
+}
+
+mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: tools.map(t => ({ name: t.name, description: t.description, inputSchema: t.schema })),
+}))
+
+mcp.setRequestHandler(CallToolRequestSchema, async req => {
+  const tool = tools.find(t => t.name === req.params.name)
+  if (!tool) throw new Error(`unknown tool: ${req.params.name}`)
+  const args = (req.params.arguments ?? {}) as Record<string, unknown>
+  try {
+    return (await tool.handler(args)) as any
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    return { content: [{ type: 'text', text: `error: ${msg}` }], isError: true }
+  }
+})
+
+process.on('unhandledRejection', err => {
+  process.stderr.write(`ms365 channel: unhandled rejection: ${err}\n`)
+})
+process.on('uncaughtException', err => {
+  process.stderr.write(`ms365 channel: uncaught exception: ${err}\n`)
+})
+
+await mcp.connect(new StdioServerTransport())
+process.stderr.write(`ms365: MCP connected (tenant=${TENANT_ID.slice(0, 8)}..., client=${CLIENT_ID.slice(0, 8)}..., secret_len=${CLIENT_SECRET.length}, default_upn=${DEFAULT_UPN}, state_dir=${STATE_DIR})\n`)


### PR DESCRIPTION
## Summary

Adds a new `plugins/ms365/` MCP plugin: Microsoft 365 / Graph API tools for Claude Code agents running under Agent Bridge. Covers mail, calendar, people/directory, and Teams chat, all behind delegated per-UPN tokens.

Pairing uses the **authorization code flow** routed through the existing `plugins/teams/` listener's `/auth/callback` handler. This piggybacks on the Teams plugin's already-exposed HTTPS ingress instead of spinning up a second loopback server, and replaces a device-code implementation that was proving non-deterministic in production (AADSTS7000218 from ``bun fetch`` during polling).

## Tools (19)

| category | tools |
|---|---|
| pairing / session | `pair_start`, `pair_poll`, `pair_status`, `logout` |
| identity / directory | `me`, `user_get`, `people_search` |
| mail | `mail_list`, `mail_get`, `mail_send` |
| calendar | `calendar_upcoming`, `calendar_create` |
| Teams chat | `chat_list`, `chat_messages`, `chat_send`, `chat_create`, `chat_delete`, `chat_undo_delete`, `joined_teams` |

## Configuration

All secrets and tenant configuration come from env (see `plugins/ms365/README.md` for the full list):

- `MS365_TENANT_ID`
- `MS365_CLIENT_ID`
- `MS365_CLIENT_SECRET` (required — confidential client)
- `MS365_DEFAULT_UPN`
- `MS365_DEFAULT_SCOPES`
- `MS365_REDIRECT_URI` — defaults to `http://localhost:3978/auth/callback` for first-run dev; hosted deployments override it to whatever public ingress fronts the Teams plugin
- `MS365_STATE_DIR`, `MS365_CALLBACK_SHARED_DIR`, `BRIDGE_HOME`

Tokens (access + refresh) are stored with mode `0600` under `$MS365_STATE_DIR/tokens/` and auto-refresh five minutes before expiry.

## Pairing Flow

1. Agent calls `pair_start(upn=user@tenant.com)` → receives `authorize_url` + opaque state (UUID validated against `/^[A-Za-z0-9_-]{8,128}$/`).
2. User opens the URL, signs in, approves.
3. Microsoft redirects to `MS365_REDIRECT_URI?code=...&state=...`.
4. The Teams plugin's `/auth/callback` handler validates the state shape and atomically writes `{state, code, received_at}` into `$BRIDGE_HOME/shared/ms365-callbacks/<state>.json` via tmp+rename.
5. Agent calls `pair_poll(upn=...)` → plugin reads the callback file, POSTs `grant_type=authorization_code` to the token endpoint, saves the token, cleans up pending + callback.
6. State expires 15 minutes after `pair_start`. `logout(upn=...)` deletes the token.

## Notable implementation detail: chat message softDelete path

Graph documents two paths for `chatMessage: softDelete`:

- Channel messages: `POST /teams/{team-id}/channels/{channel-id}/messages/{id}/softDelete`
- Chat (1:1/group) messages: `POST /users/{user-id}/chats/{chat-id}/messages/{id}/softDelete`

**The chat case requires an explicit user context prefix.** `POST /chats/{chat-id}/messages/{id}/softDelete` (without `/me` or `/users/{id}`) returns `405 Method Not Allowed`, even though `/chats/{chat-id}/messages` itself is a valid path for `chat_send` and `chat_messages`. Other Graph actions on the same subtree work without the user prefix; softDelete is one of the few that doesn't. This plugin uses the `/me/chats/...` form.

## Test Plan

- [x] `bun build server.ts` — 216 modules bundled, no errors
- [x] End-to-end pair flow against a real Entra tenant:
  - `pair_start` → browser consent → redirect → `pair_poll` → `has_refresh_token=true`, scope includes `Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite People.Read User.Read.All Directory.Read.All Chat.ReadWrite`
- [x] `me` / `user_get` / `people_search` on a real directory
- [x] `mail_list` top=10, `mail_send` to an external Gmail address — Graph `sent=true`
- [x] `chat_list` top=5, `joined_teams` — expected shapes, `stripHtml` preview handling correct
- [x] `chat_create` find-or-create (reused existing 1:1 when same member pair)
- [x] `chat_send` to a real user, message landed in Teams UI
- [x] `chat_delete` → `chat_messages` shows `deleted=true`, content empty string
- [x] `chat_undo_delete` → `chat_messages` shows `deleted=false`, original content restored
- [x] Final `chat_delete` for cleanup

## Sanitization notes for reviewers

The plugin was developed and operated inside a Cosmax-internal Agent Bridge deployment. Everything tenant-specific (tenant ID, client ID, client secret, redirect URI, allowed UPNs) has always been env-driven, so the only sanitization needed for this PR was:

- `REDIRECT_URI` default: `https://bottest.cosmax.com/auth/callback` → `http://localhost:3978/auth/callback`
- Plugin manifest description: mentioned "device code flow" (stale since Phase 1.5 pivot) → updated to "authorization code flow"
- Added `plugins/ms365/README.md`

No secrets, tokens, user PII, or internal URLs remain in the diff — please grep if you'd like to double-check.

## Relation to earlier filed issues

- #42 — OAuth device code `bun fetch` AADSTS7000218 non-determinism. This PR removes the device code path entirely, so #42 becomes moot (feel free to close as superseded).
- #43 — SessionStart hook should load `NEXT-SESSION.md`. Unrelated to this PR.
- #44 — Dev-loaded plugin cache symlink workaround. Unrelated.
- #45 — Nudger fires stale `ACTION REQUIRED` alerts. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)