### PR TITLE
ms365: add users_list tool + graph() extraHeaders support

### DIFF
--- a/plugins/ms365/server.ts
+++ b/plugins/ms365/server.ts
@@ -320,6 +320,7 @@ async function graph(
   body?: unknown,
   query?: Record<string, string | number | undefined>,
   version: 'v1.0' | 'beta' = 'v1.0',
+  extraHeaders?: Record<string, string>,
 ): Promise<any> {
   const token = await getAccessToken(upn)
   let url = `https://graph.microsoft.com/${version}${path}`
@@ -337,6 +338,7 @@ async function graph(
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
       Accept: 'application/json',
+      ...(extraHeaders ?? {}),
     },
     body: body != null ? JSON.stringify(body) : undefined,
   })
@@ -709,6 +711,63 @@ const tools: ToolDef[] = [
         id: p.id,
       }))
       return textResult({ query: q, count: people.length, people })
+    },
+  },
+  {
+    name: 'users_list',
+    description:
+      'Enumerate users from the directory via Graph /users. Supports OData $filter / $search / $top / $select for department-, jobTitle-, or displayName-scoped queries. Uses ConsistencyLevel=eventual + $count=true so advanced filters (startsWith, endsWith, contains, $search) work. Requires User.Read.All or Directory.Read.All.',
+    schema: {
+      type: 'object',
+      properties: {
+        upn: { type: 'string', description: 'Caller UPN (default MS365_DEFAULT_UPN).' },
+        filter: { type: 'string', description: "OData $filter expression, e.g. \"department eq 'Sales 7'\" or \"startsWith(department,'Sales')\"." },
+        search: { type: 'string', description: 'OData $search expression (fully quoted), e.g. "\\"department:Sales\\"".' },
+        top: { type: 'number', description: 'Default 25, max 200.' },
+        select: { type: 'string', description: 'Comma-separated $select field list.' },
+        orderby: { type: 'string', description: 'Optional $orderby, e.g. "displayName".' },
+      },
+    },
+    handler: async args => {
+      const caller = resolveUpn(args.upn)
+      const top = Math.max(1, Math.min(Number(args.top ?? 25), 200))
+      const select = String(
+        args.select ??
+          'id,displayName,userPrincipalName,mail,jobTitle,department,officeLocation,companyName',
+      )
+      const query: Record<string, string | number | undefined> = {
+        $top: top,
+        $select: select,
+        $count: 'true',
+      }
+      if (args.filter) query.$filter = String(args.filter)
+      if (args.search) query.$search = String(args.search)
+      if (args.orderby) query.$orderby = String(args.orderby)
+      const data = await graph(
+        caller,
+        'GET',
+        '/users',
+        undefined,
+        query,
+        'v1.0',
+        { ConsistencyLevel: 'eventual' },
+      )
+      const users = (data?.value ?? []).map((u: any) => ({
+        id: u.id,
+        name: u.displayName,
+        upn: u.userPrincipalName,
+        mail: u.mail,
+        jobTitle: u.jobTitle,
+        department: u.department,
+        office: u.officeLocation,
+        company: u.companyName,
+      }))
+      return textResult({
+        count: users.length,
+        total_at_server: data?.['@odata.count'] ?? null,
+        next_link: data?.['@odata.nextLink'] ?? null,
+        users,
+      })
     },
   },
   {


### PR DESCRIPTION
## Summary

Follow-up to the merged #46 (ms365 plugin add). Adds one more tool, \`users_list\`, plus a small \`graph()\` helper extension that made it clean to implement.

## Why

Within the first few hours of the plugin being used in a multi-agent deployment, a real operator task hit a gap: "send a message to all G4-grade members of the sales organization." The original toolset has two user-lookup paths — \`people_search\` (relevance-ranked, only returns people the signed-in user has already interacted with) and \`user_get\` (single UPN / email lookup) — and neither can enumerate a department. The operator task failed with \"tool gap\" as the root cause.

This PR adds the missing third path:

### \`users_list(filter?, search?, top?, select?, orderby?)\`

Wraps Graph \`/users\` with:
- \`\$filter\` / \`\$search\` / \`\$top\` / \`\$select\` / \`\$orderby\` pass-through
- \`\$count=true\` always included
- \`ConsistencyLevel: eventual\` header always included

Those two together unlock the advanced query capabilities (\`startsWith\`, \`endsWith\`, \`contains\`, \`\$search\`) that Graph locks behind the header. The tool returns a compact shape: \`{count, total_at_server, next_link, users: [{id, name, upn, mail, jobTitle, department, office, company}]}\`.

Requires \`User.Read.All\` or \`Directory.Read.All\` — both are already in the default scope list the plugin requests at pair time.

### \`graph()\` helper gains optional \`extraHeaders\`

\`\`\`ts
async function graph(
  upn, method, path, body?, query?, version = 'v1.0',
  extraHeaders?: Record<string, string>,
)
\`\`\`

So \`ConsistencyLevel\` (and any future per-call header need) can be threaded without duplicating the client. Every existing caller passes nothing and gets the same baseline headers they had before the change — backwards compatible.

## Verification

Tested against a live Entra tenant:

- \`users_list({filter: \"startsWith(department, '영업')\"})\` → 44 users across 8 sales subteams, full \`department\` + \`jobTitle\` fields present
- Client-side \`jobTitle\` filter on \`'G4'\` → 3 members
- Forwarded through \`chat_send\` to the requesting VP's 1:1 Teams → delivered
- No raw curl escape hatch used

All the other tools continue to work (\`chat_list\`, \`mail_send\`, \`calendar_upcoming\`, etc.). The helper change is a pure signature extension with a defaulted optional parameter.

## Timing note

I originally pushed this commit to the #46 PR branch (commit \`8823a9c\`) around the time it was being reviewed, but #46 was merged first. This PR cherry-picks that commit onto current \`main\` so it lands cleanly without the old branch noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)