### PR TITLE
ms365: add mail_reply/mail_reply_all + optional MS365_MAIL_DISCLAIMER

### DIFF
--- a/plugins/ms365/README.md
+++ b/plugins/ms365/README.md
@@ -38,6 +38,14 @@ MS365_REDIRECT_URI=http://localhost:3978/auth/callback
 # Optional: if set, prepended to every outgoing mail_send/mail_reply/mail_reply_all body.
 # Useful for AI-agent disclaimers. Plain text; HTML bodies get the disclaimer as an
 # escaped blockquote-style div at the top.
+#
+# May contain the literal token `{operator}`, which is resolved at send time from
+# Azure AD via Graph `/me` displayName (cached per UPN). Falls back to the UPN
+# local-part if the lookup fails. This lets a single fleet-wide config line
+# personalize the disclaimer per agent without hard-coding names.
+#
+# Example:
+#   MS365_MAIL_DISCLAIMER="{operator}님의 에이전트가 대신 보내는 메시지입니다. 에이전트가 보내는 메시지에는 [AI Agent] 라고 태그가 붙어있고 실수를 할 수 있으니 참고 바랍니다."
 MS365_MAIL_DISCLAIMER=
 ```
 

--- a/plugins/ms365/README.md
+++ b/plugins/ms365/README.md
@@ -35,6 +35,10 @@ MS365_CLIENT_SECRET=<app-registration-client-secret>
 MS365_DEFAULT_UPN=<default-user-principal-name>
 MS365_DEFAULT_SCOPES="openid profile offline_access User.Read Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite People.Read User.Read.All Directory.Read.All Chat.ReadWrite"
 MS365_REDIRECT_URI=http://localhost:3978/auth/callback
+# Optional: if set, prepended to every outgoing mail_send/mail_reply/mail_reply_all body.
+# Useful for AI-agent disclaimers. Plain text; HTML bodies get the disclaimer as an
+# escaped blockquote-style div at the top.
+MS365_MAIL_DISCLAIMER=
 ```
 
 The Azure AD app registration must have `MS365_REDIRECT_URI` registered as
@@ -83,6 +87,8 @@ restart the flow. `logout(upn=...)` deletes the token.
 - `mail_list(upn, folder?, top?, search?, filter?, select?)`
 - `mail_get(upn, message_id)`
 - `mail_send(upn, to, cc?, subject, body, body_type?)`
+- `mail_reply(upn, message_id, body, body_type?)` — Graph-native `/me/messages/{id}/reply`. Preserves conversation threading.
+- `mail_reply_all(upn, message_id, body, body_type?)` — Graph-native `/me/messages/{id}/replyAll`. Preserves conversation threading and the original To/Cc set.
 
 ### Calendar
 - `calendar_upcoming(upn, days?, top?)` — `/me/calendarview` over the next N days

--- a/plugins/ms365/server.ts
+++ b/plugins/ms365/server.ts
@@ -379,6 +379,29 @@ function textResult(data: unknown) {
   return { content: [{ type: 'text', text: typeof data === 'string' ? data : JSON.stringify(data, null, 2) }] }
 }
 
+/**
+ * If MS365_MAIL_DISCLAIMER is set in the environment, prepend it to an outgoing
+ * mail body. This is opt-in so upstream users who don't need it are unaffected.
+ * Idempotent: if the disclaimer is already inside the body (e.g. the caller
+ * passed a body that already had it), the body is returned unchanged.
+ */
+function withDisclaimer(body: string, bodyType: string): string {
+  const raw = process.env.MS365_MAIL_DISCLAIMER
+  if (!raw) return body
+  const disclaimer = raw.trim()
+  if (!disclaimer) return body
+  if (body.includes(disclaimer)) return body
+  if (bodyType === 'html') {
+    const escaped = disclaimer
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/\n/g, '<br>')
+    return `<div style="color:#666;font-size:0.9em;border-left:3px solid #ccc;padding-left:8px;margin-bottom:12px">${escaped}</div>\n${body}`
+  }
+  return `${disclaimer}\n\n${body}`
+}
+
 const tools: ToolDef[] = [
   {
     name: 'pair_start',
@@ -561,7 +584,7 @@ const tools: ToolDef[] = [
   {
     name: 'mail_send',
     description:
-      'Send an email as the signed-in user. to is a comma-separated list of email addresses. body is plain text by default, set body_type to \"html\" for HTML.',
+      'Send an email as the signed-in user. to is a comma-separated list of email addresses. body is plain text by default, set body_type to \"html\" for HTML. When MS365_MAIL_DISCLAIMER is set, it is automatically prepended to every outgoing message body.',
     schema: {
       type: 'object',
       required: ['to', 'subject', 'body'],
@@ -579,17 +602,80 @@ const tools: ToolDef[] = [
       const to = String(args.to ?? '').split(',').map(s => s.trim()).filter(Boolean)
       if (to.length === 0) throw new Error('to is required (comma-separated)')
       const cc = String(args.cc ?? '').split(',').map(s => s.trim()).filter(Boolean)
+      const bodyType = String(args.body_type ?? 'text')
       const message = {
         subject: String(args.subject ?? ''),
         body: {
-          contentType: String(args.body_type ?? 'text'),
-          content: String(args.body ?? ''),
+          contentType: bodyType,
+          content: withDisclaimer(String(args.body ?? ''), bodyType),
         },
         toRecipients: to.map(a => ({ emailAddress: { address: a } })),
         ccRecipients: cc.map(a => ({ emailAddress: { address: a } })),
       }
       await graph(upn, 'POST', '/me/sendMail', { message, saveToSentItems: true })
       return textResult({ sent: true, to, cc, subject: message.subject })
+    },
+  },
+  {
+    name: 'mail_reply',
+    description:
+      'Reply to the sender of a message, preserving Graph conversation threading. Pass the message_id from mail_list/mail_get. body is plain text by default; set body_type to \"html\" for HTML. The original message is quoted by Graph automatically. When MS365_MAIL_DISCLAIMER is set, it is automatically prepended.',
+    schema: {
+      type: 'object',
+      required: ['message_id', 'body'],
+      properties: {
+        upn: { type: 'string' },
+        message_id: { type: 'string' },
+        body: { type: 'string' },
+        body_type: { type: 'string', enum: ['text', 'html'], description: 'Default text.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const id = String(args.message_id ?? '').trim()
+      if (!id) throw new Error('message_id is required')
+      const bodyType = String(args.body_type ?? 'text')
+      const payload = {
+        message: {
+          body: {
+            contentType: bodyType,
+            content: withDisclaimer(String(args.body ?? ''), bodyType),
+          },
+        },
+      }
+      await graph(upn, 'POST', `/me/messages/${encodeURIComponent(id)}/reply`, payload)
+      return textResult({ replied: true, message_id: id })
+    },
+  },
+  {
+    name: 'mail_reply_all',
+    description:
+      'Reply-all to a message, preserving Graph conversation threading and the original To/Cc recipient set. Pass the message_id from mail_list/mail_get. body is plain text by default; set body_type to \"html\" for HTML. The original message is quoted by Graph automatically. When MS365_MAIL_DISCLAIMER is set, it is automatically prepended.',
+    schema: {
+      type: 'object',
+      required: ['message_id', 'body'],
+      properties: {
+        upn: { type: 'string' },
+        message_id: { type: 'string' },
+        body: { type: 'string' },
+        body_type: { type: 'string', enum: ['text', 'html'], description: 'Default text.' },
+      },
+    },
+    handler: async args => {
+      const upn = resolveUpn(args.upn)
+      const id = String(args.message_id ?? '').trim()
+      if (!id) throw new Error('message_id is required')
+      const bodyType = String(args.body_type ?? 'text')
+      const payload = {
+        message: {
+          body: {
+            contentType: bodyType,
+            content: withDisclaimer(String(args.body ?? ''), bodyType),
+          },
+        },
+      }
+      await graph(upn, 'POST', `/me/messages/${encodeURIComponent(id)}/replyAll`, payload)
+      return textResult({ replied_all: true, message_id: id })
     },
   },
   {

--- a/plugins/ms365/server.ts
+++ b/plugins/ms365/server.ts
@@ -382,13 +382,47 @@ function textResult(data: unknown) {
 /**
  * If MS365_MAIL_DISCLAIMER is set in the environment, prepend it to an outgoing
  * mail body. This is opt-in so upstream users who don't need it are unaffected.
+ *
+ * The env value may contain the literal token `{operator}`, which is replaced at
+ * send time with the display name resolved from Azure AD via Graph `/me`
+ * (cached per UPN). This avoids hard-coding operator names in config files —
+ * the authoritative name always comes from the directory. Falls back to the UPN
+ * local-part if the Graph lookup fails for any reason.
+ *
  * Idempotent: if the disclaimer is already inside the body (e.g. the caller
  * passed a body that already had it), the body is returned unchanged.
  */
-function withDisclaimer(body: string, bodyType: string): string {
+const operatorNameCache = new Map<string, string>()
+
+async function resolveOperatorDisplayName(upn: string): Promise<string> {
+  const cached = operatorNameCache.get(upn)
+  if (cached) return cached
+  try {
+    const me = await graph(upn, 'GET', '/me', undefined, { $select: 'displayName' })
+    const name = String(me?.displayName ?? '').trim()
+    if (name) {
+      operatorNameCache.set(upn, name)
+      return name
+    }
+  } catch {
+    /* fall through to upn fallback */
+  }
+  const fallback = upn.split('@')[0] ?? upn
+  operatorNameCache.set(upn, fallback)
+  return fallback
+}
+
+async function resolveDisclaimer(upn: string): Promise<string> {
   const raw = process.env.MS365_MAIL_DISCLAIMER
-  if (!raw) return body
-  const disclaimer = raw.trim()
+  if (!raw) return ''
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  if (!trimmed.includes('{operator}')) return trimmed
+  const name = await resolveOperatorDisplayName(upn)
+  return trimmed.replace(/\{operator\}/g, name)
+}
+
+function withDisclaimer(body: string, bodyType: string, disclaimer: string): string {
   if (!disclaimer) return body
   if (body.includes(disclaimer)) return body
   if (bodyType === 'html') {
@@ -603,11 +637,12 @@ const tools: ToolDef[] = [
       if (to.length === 0) throw new Error('to is required (comma-separated)')
       const cc = String(args.cc ?? '').split(',').map(s => s.trim()).filter(Boolean)
       const bodyType = String(args.body_type ?? 'text')
+      const disclaimer = await resolveDisclaimer(upn)
       const message = {
         subject: String(args.subject ?? ''),
         body: {
           contentType: bodyType,
-          content: withDisclaimer(String(args.body ?? ''), bodyType),
+          content: withDisclaimer(String(args.body ?? ''), bodyType, disclaimer),
         },
         toRecipients: to.map(a => ({ emailAddress: { address: a } })),
         ccRecipients: cc.map(a => ({ emailAddress: { address: a } })),
@@ -635,11 +670,12 @@ const tools: ToolDef[] = [
       const id = String(args.message_id ?? '').trim()
       if (!id) throw new Error('message_id is required')
       const bodyType = String(args.body_type ?? 'text')
+      const disclaimer = await resolveDisclaimer(upn)
       const payload = {
         message: {
           body: {
             contentType: bodyType,
-            content: withDisclaimer(String(args.body ?? ''), bodyType),
+            content: withDisclaimer(String(args.body ?? ''), bodyType, disclaimer),
           },
         },
       }
@@ -666,11 +702,12 @@ const tools: ToolDef[] = [
       const id = String(args.message_id ?? '').trim()
       if (!id) throw new Error('message_id is required')
       const bodyType = String(args.body_type ?? 'text')
+      const disclaimer = await resolveDisclaimer(upn)
       const payload = {
         message: {
           body: {
             contentType: bodyType,
-            content: withDisclaimer(String(args.body ?? ''), bodyType),
+            content: withDisclaimer(String(args.body ?? ''), bodyType, disclaimer),
           },
         },
       }


### PR DESCRIPTION
Closes part of #51 (reply/replyAll) and adds an opt-in disclaimer hook for AI-agent use cases.

## Summary
- **New tools**: `mail_reply` and `mail_reply_all` call Graph's native `/me/messages/{id}/reply` and `/replyAll` endpoints. Unlike reconstructing recipients via `mail_send`, these preserve Outlook conversation threading and the original To/Cc set, and let Graph auto-quote the original message.
- **Optional disclaimer**: new env var `MS365_MAIL_DISCLAIMER`. When set, it is auto-prepended to every outgoing `mail_send` / `mail_reply` / `mail_reply_all` body. Off by default — zero behavior change for existing users.
  - Plain-text: disclaimer + blank line + original body.
  - HTML: escaped `<div>` at the top of the body.
  - Idempotent: if the caller's body already contains the disclaimer string, it's left alone.
- README updated with both tools and the new env var.

## Motivation
Fleet of internal agents needs to participate in existing mail threads (status updates, approvals). Reconstructing To/Cc via `mail_send` breaks Outlook conversation linkage and forces the caller to own recipient logic — this was encountered in production. The new tools fix that with ~60 lines that reuse the existing `graph()` helper.

Separately, AI-agent fleets typically need a standing "this message is sent by an agent on behalf of X, agents make mistakes" disclaimer on every outbound mail. Baking that into the plugin as an opt-in env keeps call sites clean and makes the policy impossible to forget at the prompt layer.

## Scopes
No new Graph scopes. `Mail.Send` already covers `reply` and `replyAll`.

## Test plan
- [x] `bun build plugins/ms365/server.ts` — clean.
- [ ] `mail_reply_all` against a real received message → Outlook shows the reply inside the original conversation.
- [ ] `MS365_MAIL_DISCLAIMER` set → disclaimer appears at top of sent body (plain + HTML).
- [ ] `MS365_MAIL_DISCLAIMER` unset → no behavior change.

## Related
- Issue #51 (feature request for reply/replyAll).
- Follow-up issue to be filed for the broader cross-channel (email + messenger) AI-disclaimer policy; this PR lands the email half.

🤖 Drafted by the patch agent (Cosmax Agent Bridge deployment).