### PR TITLE
bridge-docs: cleanup legacy shared ROSTER/SYRS docs and fix intermediate CLAUDE.md step-6 rewrite

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -8,9 +8,10 @@ If you are resuming development, read in this order:
 
 1. [`README.md`](./README.md)
 2. [`ARCHITECTURE.md`](./ARCHITECTURE.md)
-3. [`OPERATIONS.md`](./OPERATIONS.md)
-4. [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md)
-5. [`AGENTS.md`](./AGENTS.md)
+3. [`docs/developer-handover.md`](./docs/developer-handover.md)
+4. [`OPERATIONS.md`](./OPERATIONS.md)
+5. [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md)
+6. [`AGENTS.md`](./AGENTS.md)
 
 ## Core Model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,116 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Repo Is
+
+Agent Bridge is a thin local orchestration layer that wires Claude Code and Codex sessions together over `tmux` + SQLite queue + a Bash daemon. It does not implement its own agent runtime — Claude/Codex are the agents. Design priorities, in order, are **queue-first**, **daemon-safe**, and **runtime-preserving**.
+
+## Read These Before Editing
+
+These four files hold the context that is not derivable from the code:
+
+1. [`ARCHITECTURE.md`](./ARCHITECTURE.md) — entry points, shell module layout, queue/state boundaries.
+2. [`docs/developer-handover.md`](./docs/developer-handover.md) — concrete "where/how to edit" walkthrough and the biggest foot-guns.
+3. [`OPERATIONS.md`](./OPERATIONS.md) — live-install behavior and upgrade contract.
+4. [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md) — live-session quirks (trust prompt, urgent-send edge cases, channel wake status).
+
+[`AGENTS.md`](./AGENTS.md) is the repo-guidelines doc — treat it as authoritative for style.
+
+## Source Checkout vs Live Runtime (critical)
+
+Never confuse these two trees:
+
+- **Source checkout** (where you usually are): this git repo. Canonical location is `~/.agent-bridge-source`, but `~/Projects/agent-bridge-public` is also supported via `AGENT_BRIDGE_SOURCE_DIR` / `agent-bridge upgrade --source ...`.
+- **Live runtime**: `~/.agent-bridge`. Contains `state/`, `logs/`, `shared/`, `agents/<name>/` runtime homes, `agent-roster.local.sh`, the queue DB, and daemon state. Do **not** commit anything derived from live runtime into the source tree, and do **not** hand-copy source files over live runtime — use `agb upgrade` (see OPERATIONS.md).
+
+Generated / runtime artifacts that should never be edited as source: `state/`, `logs/`, `shared/` (live), `agents/<name>` runtime homes.
+
+## Queue-First Is a Contract
+
+Normal inter-agent work goes through `bridge-task.sh` / the SQLite queue. `bridge-send.sh` and `bridge-action.sh` are for *urgent interrupts only*. Any change that touches queue semantics, roster loading, session resume, worktree handling, cron behavior, or the upgrader is high-risk and must include manual verification notes in the PR.
+
+Tracked source must stay machine-agnostic. Machine-specific roster overrides, channel IDs, tokens, and private team data belong in `agent-roster.local.sh` (git-ignored), never in tracked files.
+
+## Layout at a Glance
+
+- Root `bridge-*.sh` and `bridge-*.py`: primary CLI entry points. New logic should generally go into a `lib/bridge-*.sh` helper rather than growing root scripts.
+- [`lib/`](./lib): shared Bash implementation (`bridge-core.sh`, `bridge-agents.sh`, `bridge-tmux.sh`, `bridge-state.sh`, `bridge-cron.sh`, `bridge-skills.sh`, `bridge-hooks.sh`).
+- Python is used for structured work: queue backend (`bridge-queue.py`), cron inventory (`bridge-cron.py`), docs/audit/intake/dashboard helpers.
+- [`agents/`](./agents): tracked portable agent profile templates (not runtime homes).
+- [`scripts/`](./scripts): install + smoke + deploy helpers.
+
+## Common Commands
+
+There is no build step.
+
+**Validation before a PR (required):**
+
+```bash
+bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh
+shellcheck *.sh agent-bridge agb lib/*.sh scripts/*.sh agent-roster.local.example.sh
+./scripts/smoke-test.sh
+```
+
+`scripts/smoke-test.sh` runs isolated daemon/queue/static-role checks without touching live bridge state. It does **not** exercise real Claude/Codex CLI behavior — changes to tmux submit paths, hooks, prompt state, or urgent-send logic require a live manual check in an isolated `BRIDGE_HOME`.
+
+**Inspecting bridge state during development:**
+
+```bash
+./agent-bridge status              # dashboard
+./agent-bridge list                # agent inventory
+bash bridge-daemon.sh status       # daemon
+bash bridge-daemon.sh sync         # force a reconciliation pass
+bash bridge-start.sh --list        # static roles
+bash bridge-start.sh <role> --dry-run
+```
+
+**Queue smoke flow:**
+
+```bash
+bash bridge-task.sh create --to tester --title "t" --body "b"
+./agent-bridge inbox tester
+./agent-bridge claim <id> --agent tester
+./agent-bridge done  <id> --agent tester --note "ok"
+```
+
+**Dynamic agent / worktree:**
+
+```bash
+./agent-bridge --codex --name smoke --workdir /tmp/demo --no-attach
+./agent-bridge --codex --name worker-a --prefer new    # isolated git worktree
+./agent-bridge worktree list
+```
+
+**Release preflight (when touching shipped surface):**
+
+```bash
+bash ./scripts/oss-preflight.sh
+```
+
+## Environment Variables Worth Knowing
+
+- `BRIDGE_HOME` — override live runtime root; essential for isolated tests.
+- `AGENT_BRIDGE_SOURCE_DIR` — tell the upgrader where the source checkout is when it's not at `~/.agent-bridge-source`.
+- `BRIDGE_ROSTER_FILE`, `BRIDGE_ROSTER_LOCAL_FILE`, `BRIDGE_STATE_DIR`, `BRIDGE_TASK_DB`, `BRIDGE_WORKTREE_ROOT`, `BRIDGE_CRON_STATE_DIR`.
+
+## High-Risk Areas (edit with care)
+
+1. **Queue / daemon / status** — strongly coupled; touching one usually needs re-checking the other two.
+2. **`lib/bridge-tmux.sh`** — Claude and Codex have different submit semantics; urgent sends are sensitive to prompt state (trust, blocker, copy-mode).
+3. **Upgrade path (`bridge-upgrade.sh`, `bridge-upgrade.py`, `scripts/deploy-live-install.sh`)** — must preserve `state/`, `logs/`, `shared/`, local roster, and live agent homes. The upgrader must also tolerate non-standard source-checkout paths.
+4. **Worktree isolation (`state/worktrees/`, `~/.agent-bridge/worktrees/<repo>/<agent>`)** — getting this wrong can corrupt a shared repo or run an agent against the wrong branch.
+5. **Hooks / tool policy / prompt guard (`hooks/`, `bridge-hooks.py`, `bridge-guard.py`)** — containment/audit layer, not a sandbox. Changes here affect every Claude session's settings.
+
+## Platform Notes
+
+- Requires Bash 4+ (associative arrays). macOS ships Bash 3.2 — install Homebrew Bash and put it ahead of `/bin` in `PATH`.
+- Requires `tmux`, `python3`, `git`.
+- If shell integration was installed from a source checkout, moving the checkout requires rerunning `scripts/install-shell-integration.sh --apply` so the rc-managed block re-points.
+
+## Editing Principles
+
+- Prefer small, targeted changes over refactors. `AGENTS.md` style applies.
+- Prefer adding a `lib/bridge-*.sh` helper over growing root scripts.
+- If you change documented behavior, update the corresponding doc (`README.md`, `ARCHITECTURE.md`, `OPERATIONS.md`, `KNOWN_ISSUES.md`, or `docs/developer-handover.md`) in the same change.
+- Do not put private team names, channel tokens, or machine paths into tracked files — this repo is a public snapshot.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,9 @@ Install and verify the local toolchain before changing code.
 
 1. Read [`README.md`](./README.md)
 2. Read [`ARCHITECTURE.md`](./ARCHITECTURE.md)
-3. Read [`OPERATIONS.md`](./OPERATIONS.md)
-4. Read [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md)
+3. Read [`docs/developer-handover.md`](./docs/developer-handover.md)
+4. Read [`OPERATIONS.md`](./OPERATIONS.md)
+5. Read [`KNOWN_ISSUES.md`](./KNOWN_ISSUES.md)
 
 ## Local Workflow
 

--- a/MEMORY-WIKI-PLAN.md
+++ b/MEMORY-WIKI-PLAN.md
@@ -31,7 +31,7 @@ It also adopts the "LLM-maintained wiki" model:
 - Do not restore the entire OpenClaw document set as-is.
 - Do not make SQLite or embeddings the source of truth.
 - Do not mix multiple humans into one flat `MEMORY.md`.
-- Do not put team-specific SYRS behavior into the public template.
+- Do not put team-specific private behavior into the public template.
 
 ## Target Model
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ If you think this README has no concrete install steps, stop and reread this `CL
    - On macOS, if `/opt/homebrew/bin/bash` exists, prefer it. If not, warn the user that macOS system Bash 3.2 may be unsupported and ask them to install Homebrew Bash if the scripts fail.
 
 2. Clone or update the public source checkout, then pin it to the latest stable release tag.
-   Keep the source checkout hidden at `~/.agent-bridge-source`. If an older visible checkout exists at `~/agent-bridge-public`, move it automatically only when it is clean and points to this public repository.
+   Keep the source checkout hidden at `~/.agent-bridge-source`. If an older visible checkout exists at `~/agent-bridge-public`, move it automatically only when it is clean and points to this public repository. If you intentionally keep the source checkout elsewhere, such as `~/Projects/agent-bridge-public`, set `AGENT_BRIDGE_SOURCE_DIR` or pass `agent-bridge upgrade --source /path/to/agent-bridge-public` when upgrading from the live install.
 
    ```bash
    REPO_URL="https://github.com/SYRS-AI/agent-bridge-public"
@@ -190,6 +190,8 @@ print(tags[-1] if tags else "")'
    fi
    git -C "$SOURCE_DIR" checkout --detach "$LATEST_TAG"
    ```
+
+   If your shell rc sources the source checkout directly rather than `~/.agent-bridge`, rerun `bash scripts/install-shell-integration.sh --shell zsh --apply` or the matching bash variant after moving the checkout so the managed block points at the new path.
 
 3. Deploy tracked source files into the live install at `~/.agent-bridge`.
    Runtime files, agent homes, queue state, logs, backups, and local roster files must be preserved.

--- a/bridge-docs.py
+++ b/bridge-docs.py
@@ -15,17 +15,17 @@ from pathlib import Path
 
 MANAGED_START = "<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->"
 MANAGED_END = "<!-- END AGENT BRIDGE DOC MIGRATION -->"
-TODAY = datetime.now().strftime("%Y-%m-%d")
 HOME_DIR = str(Path.home())
 HOME_DIR_RE = re.escape(HOME_DIR)
 REPO_ROOT = Path(__file__).resolve().parent
 
 REMOVABLE_DOCS = ("AGENTS.md", "IDENTITY.md", "BOOTSTRAP.md")
-SHARED_SOURCE_FILES = ("ROSTER.md", "SYRS-CONTEXT.md", "SYRS-RULES.md", "SYRS-USER.md")
 AGENT_SHARED_LINKS = (
     "COMMON-INSTRUCTIONS.md",
     "CHANGE-POLICY.md",
     "TOOLS.md",
+)
+DEPRECATED_SHARED_FILES = (
     "ROSTER.md",
     "SYRS-CONTEXT.md",
     "SYRS-RULES.md",
@@ -344,7 +344,7 @@ def backup_file(src: Path, backup_root: Path, dry_run: bool) -> None:
     if dry_run:
         return
     backup_root.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(src, backup_root / src.name)
+    shutil.copy2(src, backup_root / src.name, follow_symlinks=False)
 
 
 def list_agent_dirs(target_root: Path, selected: list[str], all_agents: bool) -> list[Path]:
@@ -408,46 +408,6 @@ def audit_agent(agent_dir: Path) -> AgentAudit:
     )
 
 
-def render_shared_override(name: str) -> str:
-    bullets_by_file = {
-        "ROSTER.md": [
-            "이 파일은 현재 `~/.agent-bridge/shared/ROSTER.md`에서 관리된다.",
-            "에이전트 간 durable 통신의 기본값은 `~/.agent-bridge/agent-bridge task create|urgent|handoff`다.",
-            "본문에 남아 있는 옛 queue/send/gateway 설명은 역사적 참고 정보다.",
-            "현재 live roster/queue 상태는 `~/.agent-bridge/agent-bridge status`와 `~/.agent-bridge/state/active-roster.md`가 기준이다.",
-        ],
-        "SYRS-RULES.md": [
-            "이 파일은 현재 Agent Bridge 런타임 기준으로 읽는다.",
-            "본문에 남아 있는 옛 message/cron 예시는 역사적 참고 정보다.",
-            "사람에게 보이는 Discord/Telegram 출력은 연결된 Claude 세션 또는 bridge notify path를 사용한다.",
-            "시스템 전역 변경 승인 규칙은 Agent Bridge, 남은 OpenClaw compatibility layer, Claude/Codex runtime 전부에 적용된다.",
-        ],
-        "SYRS-CONTEXT.md": [
-            "이 파일의 비즈니스 팩트는 그대로 SSOT다.",
-            "문서 위치만 `~/.agent-bridge/shared/SYRS-CONTEXT.md`로 옮겼다.",
-            "툴/전송 메커니즘은 `TOOLS.md`와 각 에이전트 `CLAUDE.md`의 Agent Bridge block을 따른다.",
-        ],
-    }
-    bullets = bullets_by_file.get(name)
-    if not bullets:
-        return ""
-    lines = [
-        f"## Agent Bridge Migration Override ({TODAY})",
-        *(f"- {bullet}" for bullet in bullets),
-        "- 아래 본문과 충돌하면 이 override가 우선이다.",
-    ]
-    return "\n".join(lines) + "\n"
-
-
-def inject_after_heading(text: str, block: str) -> str:
-    if not block:
-        return text
-    if text.startswith("# "):
-        first, rest = text.split("\n", 1) if "\n" in text else (text, "")
-        return f"{first}\n\n{block}\n{rest.lstrip()}"
-    return f"{block}\n{text}"
-
-
 def render_shared_tools_md(bridge_home: Path) -> str:
     home = pretty_path(bridge_home)
     return f"""# TOOLS.md — Agent Bridge Shared Runtime
@@ -484,10 +444,11 @@ def render_shared_tools_md(bridge_home: Path) -> str:
 ## Shared References
 - 공통 규칙: `{home}/shared/COMMON-INSTRUCTIONS.md`
 - upstream/downstream 분류: `{home}/shared/CHANGE-POLICY.md`
-- 비즈니스 SSOT: `{home}/shared/SYRS-CONTEXT.md`
-- 팀 규칙: `{home}/shared/SYRS-RULES.md`
-- 사용자 정보: `{home}/shared/SYRS-USER.md`
-- roster: `{home}/shared/ROSTER.md`
+- 팀 지식 인덱스: `{home}/shared/wiki/index.md`
+- 사용자/운영자 프로필: `{home}/shared/wiki/people.md`
+- 에이전트 역할/구성: `{home}/shared/wiki/agents.md`
+- 팀 운영 규칙: `{home}/shared/wiki/operating-rules.md`
+- 데이터 소스/도구: `{home}/shared/wiki/data-sources.md`, `{home}/shared/wiki/tools.md`
 - 스킬 가이드: `{home}/shared/SKILLS.md`
 """
 
@@ -642,61 +603,6 @@ def render_shared_skills_md(bridge_home: Path, registry: dict[str, SkillEntry]) 
     return "\n".join(lines).rstrip() + "\n"
 
 
-def rewrite_shared_legacy_text(name: str, bridge_home: Path, text: str) -> str:
-    runtime_root = pretty_path(bridge_home / "runtime")
-    replacements = {
-        "~/.openclaw/credentials/": f"{runtime_root}/credentials/",
-        "$HOME/.openclaw/credentials/": f"{runtime_root}/credentials/",
-        f"{HOME_DIR}/.openclaw/credentials/": f"{runtime_root}/credentials/",
-        "~/.openclaw/secrets/": f"{runtime_root}/secrets/",
-        "$HOME/.openclaw/secrets/": f"{runtime_root}/secrets/",
-        f"{HOME_DIR}/.openclaw/secrets/": f"{runtime_root}/secrets/",
-        "~/.openclaw/openclaw.json": f"{runtime_root}/bridge-config.json",
-        "$HOME/.openclaw/openclaw.json": f"{runtime_root}/bridge-config.json",
-        f"{HOME_DIR}/.openclaw/openclaw.json": f"{runtime_root}/bridge-config.json",
-        "~/.openclaw/scripts/": f"{runtime_root}/scripts/",
-        "$HOME/.openclaw/scripts/": f"{runtime_root}/scripts/",
-        f"{HOME_DIR}/.openclaw/scripts/": f"{runtime_root}/scripts/",
-        "~/.openclaw/skills/": f"{runtime_root}/skills/",
-        "$HOME/.openclaw/skills/": f"{runtime_root}/skills/",
-        f"{HOME_DIR}/.openclaw/skills/": f"{runtime_root}/skills/",
-        "~/.openclaw/data/": f"{runtime_root}/data/",
-        "$HOME/.openclaw/data/": f"{runtime_root}/data/",
-        f"{HOME_DIR}/.openclaw/data/": f"{runtime_root}/data/",
-        "~/.openclaw/assets/": f"{runtime_root}/assets/",
-        "$HOME/.openclaw/assets/": f"{runtime_root}/assets/",
-        f"{HOME_DIR}/.openclaw/assets/": f"{runtime_root}/assets/",
-        "~/.openclaw/extensions/": f"{runtime_root}/extensions/",
-        "$HOME/.openclaw/extensions/": f"{runtime_root}/extensions/",
-        f"{HOME_DIR}/.openclaw/extensions/": f"{runtime_root}/extensions/",
-        "~/.openclaw/shared/a2a-files/": "~/.agent-bridge/shared/a2a-files/",
-        "$HOME/.openclaw/shared/a2a-files/": "~/.agent-bridge/shared/a2a-files/",
-        f"{HOME_DIR}/.openclaw/shared/a2a-files/": "~/.agent-bridge/shared/a2a-files/",
-        "bash ~/.openclaw/scripts/codex-review.sh review main": "agent-bridge task create --to <review-agent> --title \"[REVIEW] 변경 검토\" --body \"변경 내용과 검토 포인트를 함께 전달\"",
-        "bash ~/.openclaw/scripts/codex-review.sh plan /path/to/plan.md": "agent-bridge task create --to <review-agent> --title \"[PLAN-REVIEW] 계획 검토\" --body-file /path/to/plan.md",
-        "bash ~/.openclaw/scripts/codex-review.sh review [base] [instructions]": "agent-bridge task create --to <review-agent> --title \"[REVIEW] 변경 검토\" --body \"base와 검토 포인트를 함께 전달\"",
-        "bash ~/.openclaw/scripts/codex-review.sh plan <file>": "agent-bridge task create --to <review-agent> --title \"[PLAN-REVIEW] 계획 검토\" --body-file <file>",
-        "bash ~/.openclaw/scripts/codex-review.sh challenge [focus]": "agent-bridge task create --to <review-agent> --title \"[CHALLENGE] 적대적 분석\" --body \"focus를 함께 전달\"",
-        "bash ~/.openclaw/scripts/codex-review.sh consult \"<prompt>\"": "agent-bridge task create --to <review-agent> --title \"[CONSULT]\" --body \"<prompt>\"",
-        "python3 ~/.openclaw/skills/task-log/scripts/task-log.py": f"python3 {runtime_root}/skills/task-log/scripts/task-log.py",
-        "Discord #patch 채널 웹훅": "`agent-bridge task create --to <admin-agent>` 또는 `agent-bridge urgent <admin-agent>`",
-        "localhost:8787/hooks/patch-trigger": "`agent-bridge urgent <admin-agent>`",
-    }
-    for old, new in replacements.items():
-        text = text.replace(old, new)
-
-    if name in {"SYRS-RULES.md", "ROSTER.md", "SYRS-CONTEXT.md"}:
-        text = text.replace("A2A(sessions_send)", "A2A(agent-bridge task create)")
-        text = text.replace("sessions_send/sessions_spawn", "agent-bridge task create/urgent")
-        text = text.replace("sessions_spawn", "bridge disposable child")
-        text = text.replace("sessions_history", "bridge task/MEMORY context")
-        text = text.replace("sessions_send", "agent-bridge task create")
-        text = text.replace("openclaw message send", "연결된 Claude 세션 응답")
-        text = text.replace("패치는 OpenClaw 에이전트가 아님", "관리자 에이전트는 Agent Bridge 역할")
-
-    return text
-
-
 def rewrite_agent_runtime_text(agent_dir: Path, text: str) -> str:
     text = normalize_legacy_paths(text)
     runtime_root = "~/.agent-bridge/runtime"
@@ -753,7 +659,7 @@ def normalize_agent_runtime_file(path: Path, agent_dir: Path, dry_run: bool, bac
     return True
 
 
-def sync_shared_docs(bridge_home: Path, source_shared: Path, dry_run: bool, registry: dict[str, SkillEntry]) -> list[str]:
+def sync_shared_docs(bridge_home: Path, source_shared: Path, dry_run: bool, stamp: str, registry: dict[str, SkillEntry]) -> list[str]:
     changed: list[str] = []
     target_shared = bridge_home / "shared"
     target_refs = target_shared / "references"
@@ -761,18 +667,15 @@ def sync_shared_docs(bridge_home: Path, source_shared: Path, dry_run: bool, regi
         target_shared.mkdir(parents=True, exist_ok=True)
     ensure_symlink(bridge_home / "agents" / "shared", "../shared", dry_run)
 
-    for name in SHARED_SOURCE_FILES:
-        src = source_shared / name
-        if not src.exists():
+    deprecated_backup_root = bridge_home / "state" / "doc-migration" / "backups" / stamp / "_shared"
+    for name in DEPRECATED_SHARED_FILES:
+        path = target_shared / name
+        if not path.exists() and not path.is_symlink():
             continue
-        text = inject_after_heading(read_text(src), render_shared_override(name))
-        text = normalize_legacy_paths(text)
-        text = rewrite_shared_legacy_text(name, bridge_home, text)
-        dst = target_shared / name
-        old = read_text(dst) if dst.exists() else None
-        if old != text:
-            write_text(dst, text, dry_run)
-            changed.append(str(dst))
+        backup_file(path, deprecated_backup_root, dry_run)
+        if not dry_run:
+            path.unlink()
+        changed.append(f"removed:{path}")
 
     source_refs = source_shared / "references"
     if source_refs.exists():
@@ -928,7 +831,8 @@ def render_agent_bridge_block(agent_dir: Path) -> str:
 
 COMMON_CLAUDE_REPLACEMENTS = {
     '5. Run the DB preflight steps described in `AGENTS.md` before sending anything; if compaction recovery is pending, wait for verification rather than guessing.': '5. Run the DB preflight steps described in `TOOLS.md` before sending anything; if compaction recovery is pending, wait for verification rather than guessing.',
-    '6. Confirm that the workspace files you need (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `ROSTER.md`, the user files, and the memory tree) are accessible. If something is missing, document it in your notes before you proceed.': '6. Confirm that the workspace files you need (`SOUL.md`, `TOOLS.md`, `ROSTER.md`, the user files, and the memory tree) are accessible. If something is missing, document it in your notes before you proceed.',
+    '6. Confirm that the workspace files you need (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `ROSTER.md`, the user files, and the memory tree) are accessible. If something is missing, document it in your notes before you proceed.': '6. Confirm that the workspace files you need (`SOUL.md`, `TOOLS.md`, the shared wiki pages, the user files, and the memory tree) are accessible. If something is missing, document it in your notes before you proceed.',
+    '6. Confirm that the workspace files you need (`SOUL.md`, `TOOLS.md`, `ROSTER.md`, the user files, and the memory tree) are accessible. If something is missing, document it in your notes before you proceed.': '6. Confirm that the workspace files you need (`SOUL.md`, `TOOLS.md`, the shared wiki pages, the user files, and the memory tree) are accessible. If something is missing, document it in your notes before you proceed.',
     '- Replace `sessions_send(sessionKey="agent:<id>:main", …)` calls with `agent-bridge task create --to <agent>` for the intended recipient, and `agent-bridge urgent` for interrupts. Add context so the receiving agent knows why the request exists.': '- Durable delegation uses `agent-bridge task create --to <agent>`. True interrupts use `agent-bridge urgent <agent> "..."`. Always include enough context for the receiver to work from the queue alone.',
     '- **Telegram** – respond through Claude Code `--channels plugin:telegram@claude-plugins-official`. The plugin mimics the old `openclaw message send` behavior; you do not run that CLI anymore. If a job needs a Telegram nudge, craft the message inside Claude Code and let the plugin deliver it.': '- **Telegram** – respond through Claude Code `--channels plugin:telegram@claude-plugins-official`. If a job needs a Telegram nudge, craft it in the live session and let the plugin deliver it.',
     '- **Bridge queue** – when another agent asks you to do something, create a durable task rather than replying via `sessions_send`. Always include the full context so the queue consumer does not have to open the old gateway stacks.': '- **Bridge queue** – when another agent asks you to do something, create a durable task with enough context for the receiver to work from the queue alone.',
@@ -1063,10 +967,28 @@ def ensure_agent_shared_links(agent_dir: Path, dry_run: bool, backup_root: Path)
     return changed
 
 
+def cleanup_broken_shared_doc_links(agent_dir: Path, dry_run: bool, backup_root: Path) -> list[str]:
+    changed: list[str] = []
+    for path in sorted(agent_dir.iterdir()):
+        if not path.is_symlink() or path.name in AGENT_SHARED_LINKS:
+            continue
+        target = os.readlink(path)
+        if not target.startswith("../shared/") or not target.endswith(".md"):
+            continue
+        if path.exists():
+            continue
+        backup_file(path, backup_root, dry_run)
+        if not dry_run:
+            path.unlink()
+        changed.append(f"removed:{path}")
+    return changed
+
+
 def sync_agent_docs(agent_dir: Path, bridge_home: Path, dry_run: bool, stamp: str, registry: dict[str, SkillEntry]) -> list[str]:
     changed: list[str] = []
     backup_root = bridge_home / "state" / "doc-migration" / "backups" / stamp / agent_dir.name
 
+    changed.extend(cleanup_broken_shared_doc_links(agent_dir, dry_run, backup_root))
     changed.extend(ensure_agent_shared_links(agent_dir, dry_run, backup_root))
 
     if normalize_claude(agent_dir, dry_run, backup_root):
@@ -1184,7 +1106,7 @@ def main() -> int:
     stamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     registry_path, registry_changed = write_skill_registry(bridge_home, registry, args.dry_run)
     changed = [str(registry_path)] if registry_changed else []
-    changed.extend(sync_shared_docs(bridge_home, source_shared, args.dry_run, registry))
+    changed.extend(sync_shared_docs(bridge_home, source_shared, args.dry_run, stamp, registry))
     for agent_dir in agent_dirs:
         changed.extend(sync_agent_docs(agent_dir, bridge_home, args.dry_run, stamp, registry))
 

--- a/bridge-runtime-inventory.py
+++ b/bridge-runtime-inventory.py
@@ -49,12 +49,8 @@ AGENT_RUNTIME_FILES = {
     "CLAUDE.md",
     "HEARTBEAT.md",
     "MEMORY.md",
-    "ROSTER.md",
     "SOUL.md",
     "SKILLS.md",
-    "SYRS-CONTEXT.md",
-    "SYRS-RULES.md",
-    "SYRS-USER.md",
     "TOOLS.md",
 }
 AGENT_RUNTIME_DIRS = {"references", "skills"}
@@ -112,7 +108,7 @@ def category_patterns(legacy_home: Path) -> dict[str, list[re.Pattern[str]]]:
             re.compile(rf"(?:{legacy_root})/data/"),
             re.compile(r"\bagent-db\b"),
             re.compile(r"\b(?:postgres|psql|supabase)\b", re.IGNORECASE),
-            re.compile(r"\b(?:pinchtab|railway-db|vendor-db|production-db|cost-db|syrs-commerce-db)\b"),
+            re.compile(r"\b(?:pinchtab|railway-db|vendor-db|production-db|cost-db|commerce-db)\b"),
             re.compile(r"\.sqlite\b"),
             re.compile(r"\.db\b"),
         ],
@@ -528,10 +524,6 @@ def legacy_rewrite_rules(bridge_home: Path, legacy_home: Path) -> list[tuple[str
     rules.extend(dir_rules("agents", "agents", runtime["agents"]))
     rules.extend(dir_rules("watchdog", "watchdog", runtime["watchdog"]))
     rules.extend(dir_rules("patch_home", "patch", runtime["patch_home"]))
-    rules.extend(file_rules("shared", "shared/ROSTER.md", f"{runtime['shared']}/ROSTER.md"))
-    rules.extend(file_rules("shared", "shared/SYRS-CONTEXT.md", f"{runtime['shared']}/SYRS-CONTEXT.md"))
-    rules.extend(file_rules("shared", "shared/SYRS-RULES.md", f"{runtime['shared']}/SYRS-RULES.md"))
-    rules.extend(file_rules("shared", "shared/SYRS-USER.md", f"{runtime['shared']}/SYRS-USER.md"))
     rules.extend(file_rules("shared", "shared/TOOLS.md", f"{runtime['shared']}/TOOLS.md"))
     rules.extend(file_rules("shared", "shared/TOOLS-REGISTRY.md", f"{runtime['shared']}/TOOLS-REGISTRY.md"))
     rules.extend(file_rules("config", "openclaw.json", runtime["config"]))

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -512,10 +512,13 @@ PY
     fi
   else
     for CANDIDATE_SOURCE_ROOT in \
+      "${AGENT_BRIDGE_SOURCE_DIR:-}" \
       "$HOME/.agent-bridge-source" \
+      "$HOME/Projects/agent-bridge-public" \
       "$HOME/agent-bridge-public" \
       "$HOME/agent-bridge"
     do
+      [[ -n "$CANDIDATE_SOURCE_ROOT" ]] || continue
       if [[ -d "$CANDIDATE_SOURCE_ROOT/.git" ]]; then
         SOURCE_ROOT="$(cd -P "$CANDIDATE_SOURCE_ROOT" && pwd -P)"
         if [[ "$SUBCOMMAND" == "apply" && $PULL_EXPLICIT -eq 0 ]]; then
@@ -549,7 +552,8 @@ if ! git -C "$SOURCE_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
   if [[ $SOURCE_EXPLICIT -eq 0 && "$SOURCE_ROOT" == "$TARGET_ROOT" ]]; then
     bridge_die "live install은 git repo가 아니고 source checkout 기록도 없습니다: $TARGET_ROOT
 복구: git clone https://github.com/SYRS-AI/agent-bridge-public \"\$HOME/.agent-bridge-source\" 후 다시 실행하거나,
-명시적으로 실행하세요: $TARGET_ROOT/agent-bridge upgrade --source \"\$HOME/.agent-bridge-source\""
+AGENT_BRIDGE_SOURCE_DIR를 설정하거나,
+명시적으로 실행하세요: $TARGET_ROOT/agent-bridge upgrade --source /path/to/agent-bridge-public"
   fi
   bridge_die "git repo가 아닙니다: $SOURCE_ROOT"
 fi

--- a/docs/developer-handover.md
+++ b/docs/developer-handover.md
@@ -1,0 +1,387 @@
+# Developer Handover
+
+이 문서는 Agent Bridge를 처음 맡는 개발 에이전트가 빠르게 맥락을 잡고,
+실수를 줄이면서 바로 개발에 참여할 수 있도록 만든 인수인계 문서다.
+
+목표는 "이 프로젝트가 무엇인지"보다 "어디를 건드려야 하고 무엇을
+건드리면 안 되는지"를 빠르게 이해시키는 것이다.
+
+## 1. 먼저 이해해야 할 핵심
+
+Agent Bridge는 Claude Code와 Codex 자체를 에이전트 런타임으로 사용하고,
+그 위에 `tmux` + SQLite queue + daemon을 덧붙여 여러 에이전트를 협업시키는
+얇은 로컬 orchestration layer다.
+
+중요한 전제:
+
+- 자체 모델 런타임을 만드는 프로젝트가 아니다.
+- 업스트림 Claude/Codex 기능을 대체하기보다 연결하고 보완하는 프로젝트다.
+- "queue-first", "daemon-safe", "runtime-preserving"이 설계 우선순위다.
+- public repo는 특정 사설 팀의 private workflow를 그대로 담으면 안 된다.
+
+## 2. 가장 먼저 읽을 문서 순서
+
+새로 투입되면 아래 순서대로 읽는 것이 가장 빠르다.
+
+1. [`README.md`](../README.md)
+2. [`ARCHITECTURE.md`](../ARCHITECTURE.md)
+3. 이 문서
+4. [`OPERATIONS.md`](../OPERATIONS.md)
+5. [`KNOWN_ISSUES.md`](../KNOWN_ISSUES.md)
+6. [`AGENTS.md`](../AGENTS.md)
+
+문서 역할 구분:
+
+- `README.md`: 제품 개요, 설치, 운영자 관점의 사용법
+- `ARCHITECTURE.md`: 엔트리포인트와 모듈 구조
+- `OPERATIONS.md`: live install 운영과 업그레이드 절차
+- `KNOWN_ISSUES.md`: 이미 알려진 함정
+- `AGENTS.md`: 이 저장소에서 작업할 때의 개발 규칙
+
+## 3. 절대 헷갈리면 안 되는 것
+
+### Source checkout과 live runtime은 다르다
+
+권장 레이아웃:
+
+- source checkout: `~/.agent-bridge-source`
+- live runtime: `~/.agent-bridge`
+
+source checkout은 git으로 pull/push하는 개발 트리다.
+live runtime은 실제 운영 상태가 쌓이는 설치본이다.
+
+live runtime에는 아래가 섞여 있다.
+
+- `state/`
+- `logs/`
+- `shared/`
+- `agent-roster.local.sh`
+- 실제 agent home
+- queue DB와 daemon 상태
+
+이 값들은 사용자/머신별 상태이므로, source repo처럼 다루면 안 된다.
+
+### queue-first가 기본 계약이다
+
+정상적인 에이전트 협업은 direct message가 아니라 queue를 통해 흘러야 한다.
+
+기본 규칙:
+
+- 일반 업무 전달: `task create`
+- 진짜 인터럽트: `urgent` 또는 `bridge-send.sh --urgent`
+- 에이전트 간 durable handoff 우선
+- tmux 직접 입력은 예외 경로로 취급
+
+queue semantics를 건드리는 변경은 항상 high-risk 변경이다.
+
+### tracked source와 machine-local config를 섞지 않는다
+
+tracked source에 두면 안 되는 것:
+
+- 개인 머신 경로
+- 채널 토큰
+- Discord/Telegram/Teams ID
+- private roster override
+- 사설 팀 전용 프롬프트/규칙/사람 정보
+
+machine-local 값은 `agent-roster.local.sh` 같은 local runtime 쪽에 둔다.
+
+### generated/runtime artifact를 source처럼 수정하지 않는다
+
+개발 중 직접 수정하면 안 되는 대상:
+
+- `state/`
+- `logs/`
+- live runtime의 `shared/`
+- 운영 중 생성된 `agents/<name>` runtime home
+
+이 프로젝트에서 수정해야 하는 대상은 대체로 tracked script, tracked docs,
+tracked templates다.
+
+## 4. 저장소 구조를 이렇게 보면 된다
+
+### 루트 엔트리포인트
+
+주요 루트 스크립트:
+
+- [`agent-bridge`](../agent-bridge): operator-facing 메인 CLI
+- [`agb`](../agb): 짧은 wrapper
+- [`bridge-start.sh`](../bridge-start.sh): static role 시작
+- [`bridge-run.sh`](../bridge-run.sh): tmux 세션 내부 루프/런처
+- [`bridge-task.sh`](../bridge-task.sh): queue wrapper
+- [`bridge-send.sh`](../bridge-send.sh): urgent direct send
+- [`bridge-action.sh`](../bridge-action.sh): predefined action send
+- [`bridge-daemon.sh`](../bridge-daemon.sh): background orchestration loop
+- [`bridge-sync.sh`](../bridge-sync.sh): live roster/state sync
+- [`bridge-status.sh`](../bridge-status.sh): dashboard 출력
+- [`bridge-upgrade.sh`](../bridge-upgrade.sh): live install 업그레이드
+
+### `lib/` 모듈
+
+공통 shell 구현은 [`lib/`](../lib)에 분리되어 있다.
+
+- `bridge-core.sh`: 공통 helper, path/hash/util
+- `bridge-agents.sh`: roster accessor, agent lookup, worktree helper
+- `bridge-tmux.sh`: tmux 세션 조작과 prompt/submit 처리
+- `bridge-state.sh`: roster load, dynamic/static state persistence
+- `bridge-cron.sh`: cron inventory, enqueue manifest helper
+- `bridge-skills.sh`: project skill bootstrap/sync
+- `bridge-hooks.sh`: Claude hook 관련 helper
+
+새 로직을 추가할 때는 루트 스크립트에 큰 함수를 쌓기보다 `lib/`로 내리는 편이
+맞다.
+
+### Python 보조 스크립트
+
+Python은 보조 역할이다. 대표적으로:
+
+- [`bridge-queue.py`](../bridge-queue.py): SQLite queue backend
+- [`bridge-cron.py`](../bridge-cron.py): cron inventory/metadata
+- `bridge-*.py` 일부: docs, release, audit, guard, intake, dashboard 등
+
+핵심 orchestration은 Bash 중심이지만, structured state 처리나 JSON/SQLite 작업은
+Python으로 빠지는 패턴이 많다.
+
+## 5. 신규 개발자가 자주 건드리게 되는 영역
+
+### 1. queue / daemon / status
+
+가장 중요한 흐름은 이 세 축이다.
+
+- queue에 task 생성
+- daemon이 live 상태를 보고 nudge/restart/health 판단
+- status/dashboard가 이를 요약
+
+이 셋은 서로 강하게 연결되어 있으므로, 하나를 바꾸면 나머지 관찰면도 같이
+확인해야 한다.
+
+### 2. tmux I/O
+
+`bridge-tmux.sh`는 deceptively simple해 보여도 실패 시 영향이 크다.
+
+주의할 점:
+
+- Claude와 Codex는 submit 방식이 다르다
+- urgent send는 prompt state에 민감하다
+- trust prompt, blocker state, copy-mode 같은 예외 상태가 있다
+- tmux option 변경은 operator 체감 품질에 바로 반영된다
+
+### 3. upgrade / deploy
+
+업그레이드는 단순 덮어쓰기가 아니다.
+
+지켜야 할 것:
+
+- live runtime의 local data를 보존해야 한다
+- tracked source만 복사해야 한다
+- `state/`, `logs/`, `shared/`, local roster, live agent homes는 보존 대상이다
+- source checkout 경로가 달라도 upgrade가 source를 찾을 수 있어야 한다
+
+최근처럼 source checkout이 `~/agent-bridge-public`에서
+`~/Projects/agent-bridge-public`로 바뀌는 경우도 고려해야 한다.
+
+### 4. worktree isolation
+
+동일 git repo를 여러 에이전트가 동시에 수정하는 흐름은 중요한 기능이다.
+
+관련 포인트:
+
+- `agent-bridge --prefer new`
+- managed worktree metadata는 `state/worktrees/`
+- 실제 worktree는 `~/.agent-bridge/worktrees/<repo-slug>/<agent>`
+
+여기서 잘못 건드리면 공유 repo를 오염시키거나, 잘못된 branch/workdir로 실행될 수
+있다.
+
+### 5. Claude hook / tool policy / prompt guard
+
+보안이나 containment 레이어를 건드릴 때는 특히 주의해야 한다.
+
+- hook 설정은 Claude settings/shared settings와 연결된다
+- tool policy는 다른 agent home, `agent-roster.local.sh`, `state/tasks.db` 접근을 제한한다
+- prompt guard는 optional이며 완전한 sandbox가 아니다
+
+이 레이어는 "보안 제품"이 아니라 shared-user runtime의 containment/audit layer다.
+
+## 6. 개발할 때의 기본 작업 흐름
+
+### 상태 파악
+
+먼저 할 것:
+
+```bash
+git status --short
+./agent-bridge status
+./agent-bridge list
+```
+
+live runtime에서 작업 중이라면:
+
+```bash
+bash bridge-daemon.sh status
+cat state/active-roster.md
+```
+
+### 정적 역할 확인
+
+정적 role 관련 수정이면:
+
+```bash
+bash bridge-start.sh --list
+bash bridge-start.sh tester --dry-run
+```
+
+### 동적 에이전트 흐름 확인
+
+동적 agent 관련 수정이면:
+
+```bash
+./agent-bridge --codex --name smoke --workdir /tmp/demo --no-attach
+./agent-bridge worktree list
+```
+
+### queue 동작 확인
+
+```bash
+bash bridge-task.sh create --to tester --title "retest" --body "check"
+./agent-bridge inbox tester
+./agent-bridge claim 1 --agent tester
+./agent-bridge done 1 --agent tester --note "ok"
+```
+
+### daemon 관련 확인
+
+```bash
+bash bridge-daemon.sh sync
+bash bridge-daemon.sh status
+```
+
+## 7. 테스트 기대치
+
+이 프로젝트에는 전통적인 unit test suite보다 smoke/manual 검증 비중이 높다.
+
+최소 기대치:
+
+```bash
+bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh
+shellcheck *.sh agent-bridge agb lib/*.sh scripts/*.sh agent-roster.local.example.sh
+./scripts/smoke-test.sh
+```
+
+여기에 추가로 권장되는 것:
+
+- 수정한 스크립트의 `--dry-run` 경로 1개 이상 확인
+- `bash bridge-daemon.sh sync` 1회 확인
+- heartbeat/tmux 관련 변경이면 isolated `BRIDGE_HOME`에서 직접 확인
+
+### smoke test의 한계
+
+`scripts/smoke-test.sh`는 중요하지만 완전하지 않다.
+
+검증하는 것:
+
+- shell syntax
+- isolated daemon startup
+- static role launch
+- queue create/claim/done
+- status/list/summary/sync의 대표 경로
+
+검증하지 못하는 것:
+
+- 실제 Claude CLI의 모든 상호작용
+- 실제 Codex CLI의 모든 상호작용
+- 실제 model-side resume semantics
+
+즉, tmux submit/path, hook, prompt state 변경은 live-like 수동 검증이 필요하다.
+
+## 8. 새 개발자가 가장 많이 실수하는 지점
+
+### 1. 운영 런타임을 source tree처럼 다룸
+
+`~/.agent-bridge`는 배포 대상이지, git source checkout이 아니다.
+live runtime에 들어 있는 상태를 보고 repo에 그대로 복붙하면 오염될 가능성이 높다.
+
+### 2. private 운영 습관을 public template에 집어넣음
+
+이 repo는 public snapshot이다.
+
+피해야 할 것:
+
+- 특정 회사/팀의 private naming
+- private workflow를 SSOT처럼 박아 넣기
+- 공개하기 어려운 사람/도구/데이터 구조를 일반 기능처럼 넣기
+
+### 3. queue 대신 direct send를 중심 흐름으로 바꿈
+
+direct send는 빠르지만 durable하지 않다.
+대부분의 협업은 queue가 기준이어야 한다.
+
+### 4. upgrade를 단순 복사 문제로 오해함
+
+upgrade는 "tracked source를 live install에 안전하게 반영"하는 문제다.
+runtime 보존이 핵심이므로, 파일 복사 최적화보다 보존 규칙이 우선이다.
+
+### 5. macOS 기본 Bash를 가정함
+
+macOS 기본 Bash는 3.2다.
+이 프로젝트는 associative array를 쓰므로 Bash 4+가 필요하다.
+
+### 6. shell integration이 한 번 설치되면 영원히 안전하다고 생각함
+
+source checkout을 직접 source하는 방식으로 shell integration을 설치한 경우,
+repo 경로가 바뀌면 rc 파일의 managed block도 갱신되어야 한다.
+
+현재는 `scripts/install-shell-integration.sh --apply`가 기존 managed block을
+업데이트하도록 되어 있다.
+
+## 9. 경로와 환경변수 관련 메모
+
+중요한 환경변수:
+
+- `BRIDGE_HOME`
+- `BRIDGE_ROSTER_FILE`
+- `BRIDGE_ROSTER_LOCAL_FILE`
+- `BRIDGE_STATE_DIR`
+- `BRIDGE_TASK_DB`
+- `BRIDGE_WORKTREE_ROOT`
+- `BRIDGE_CRON_STATE_DIR`
+- `AGENT_BRIDGE_SOURCE_DIR`
+
+특히 `AGENT_BRIDGE_SOURCE_DIR`는 source checkout이 표준 위치
+`~/.agent-bridge-source`가 아닐 때 중요하다.
+
+예:
+
+- source checkout을 `~/Projects/agent-bridge-public`에 둔 경우
+- live runtime에서 `agent-bridge upgrade`가 source를 자동 추론해야 하는 경우
+
+## 10. 문서/코드 수정 시 권장 원칙
+
+- 작은 변경으로 끝낼 수 있으면 큰 리팩터링을 하지 않는다
+- root script보다 `lib/bridge-*.sh` helper 추가를 우선 검토한다
+- queue semantics, roster loading, session resume, worktree handling 변경은 별도 검증 메모를 남긴다
+- live runtime 보존 규칙을 깨는 변경은 매우 신중하게 다룬다
+- README 설치 절차는 Claude installer flow와 연결되어 있으므로 함부로 바꾸지 않는다
+- 문서와 실제 동작이 어긋나면 코드만 고치지 말고 문서도 함께 고친다
+
+## 11. 작업 시작 전 체크리스트
+
+1. `git status`로 현재 변경 상태 확인
+2. 어떤 레이어를 만지는지 결정
+3. live runtime 보존/queue-first 원칙에 영향이 있는지 판단
+4. 변경할 파일과 검증 계획을 먼저 잡기
+5. 관련 문서와 smoke/manual 검증 범위를 정하기
+
+## 12. 작업 종료 전 체크리스트
+
+1. syntax check
+2. smoke test 또는 최소 검증 실행
+3. 변경이 queue/daemon/tmux/upgrade/worktree에 미치는 영향 요약
+4. 문서 업데이트 필요 여부 확인
+5. operator나 다음 개발자가 바로 이어받을 수 있게 검증 결과 정리
+
+## 13. 한 문장으로 요약
+
+이 프로젝트에서 가장 중요한 것은 "에이전트 실행 자체"가 아니라, 여러
+Claude/Codex 세션이 로컬에서 durable하고 예측 가능하게 협업하도록 만드는
+얇은 glue layer를 안전하게 유지하는 것이다.

--- a/docs/shared-team-knowledge-contract.md
+++ b/docs/shared-team-knowledge-contract.md
@@ -230,8 +230,8 @@ Canonical home:
 - queue body / operator-readable summary: `shared/raw/intake/<capture-id>.md`
 - built with `agent-bridge knowledge capture` plus `agent-bridge intake triage|show`
 
-This generalizes the live mail triage pattern without copying a SYRS-specific
-mail workflow into core.
+This generalizes the live mail triage pattern without copying a private
+team-specific mail workflow into core.
 
 ## Migration Map From Private/Live Runtime
 
@@ -239,9 +239,9 @@ These mappings are the intended refactor direction, not a direct file copy.
 
 | Live/Private Pattern | Public Destination |
 | --- | --- |
-| `shared/SYRS-USER.md` | `shared/wiki/people.md` plus operator profile rules |
-| `shared/SYRS-CONTEXT.md` | `shared/wiki/projects/`, `decisions/`, `data-sources.md`, `tools.md`, and team rules |
-| `shared/ROSTER.md` | `shared/wiki/agents.md` |
+| legacy shared operator profile docs | `shared/wiki/people.md` plus operator profile rules |
+| legacy shared context/rules docs | `shared/wiki/projects/`, `decisions/`, `data-sources.md`, `tools.md`, and team rules |
+| legacy shared agent roster docs | `shared/wiki/agents.md` |
 | `shared/a2a-files/...` | structured handoff bundle artifact storage (`#23`) |
 | `shared/mailbot-triage/*.md` | external intake triage contract (`#24`) |
 | ad hoc human/addressing facts embedded in many agent homes | shared operator profile (`#25`) |

--- a/scripts/install-shell-integration.sh
+++ b/scripts/install-shell-integration.sh
@@ -13,7 +13,7 @@ usage() {
 Usage: $0 [--shell zsh|bash] [--rcfile <path>] [--apply]
 
 Without --apply, prints the snippet to add to your shell rc file.
-With --apply, appends a managed block to the rc file if it is not already present.
+With --apply, writes or updates a managed block in the rc file.
 EOF
 }
 
@@ -76,7 +76,51 @@ mkdir -p "$(dirname "$RCFILE")"
 touch "$RCFILE"
 
 if grep -Fq "$START_MARKER" "$RCFILE"; then
-  echo "[info] shell integration already present in $RCFILE"
+  UPDATE_RESULT="$(
+    python3 - "$RCFILE" "$START_MARKER" "$END_MARKER" "$SNIPPET" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+start_marker, end_marker, snippet = sys.argv[2:]
+text = path.read_text(encoding="utf-8")
+managed_block = f"{start_marker}\n{snippet}\n{end_marker}"
+pattern = re.compile(
+    re.escape(start_marker) + r"\n.*?\n" + re.escape(end_marker),
+    re.DOTALL,
+)
+
+if not pattern.search(text):
+    print("malformed")
+    raise SystemExit(0)
+
+updated = pattern.sub(managed_block, text, count=1)
+if updated == text:
+    print("unchanged")
+    raise SystemExit(0)
+
+path.write_text(updated, encoding="utf-8")
+print("updated")
+PY
+  )"
+  case "$UPDATE_RESULT" in
+    updated)
+      echo "[info] updated agent-bridge shell integration in $RCFILE"
+      echo "[info] restart your shell or run: exec ${TARGET_SHELL}"
+      ;;
+    unchanged)
+      echo "[info] shell integration already up to date in $RCFILE"
+      ;;
+    malformed)
+      echo "[error] existing managed block in $RCFILE is malformed; fix it manually or remove it and rerun." >&2
+      exit 1
+      ;;
+    *)
+      echo "[error] unexpected shell integration update result: $UPDATE_RESULT" >&2
+      exit 1
+      ;;
+  esac
   exit 0
 fi
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -313,6 +313,20 @@ tmux new-session -d -s "$PREFIX_SUFFIX_SESSION" "sleep 30"
 "$BASH4_BIN" -lc 'source "'"$REPO_ROOT"'/bridge-lib.sh"; ! bridge_tmux_session_exists "'"$PREFIX_SESSION"'"' || die "bridge_tmux_session_exists matched prefix session"
 tmux_kill_session_exact "$PREFIX_SUFFIX_SESSION" || true
 
+log "updating shell integration managed block when repo path changes"
+SHELL_RC="$TMP_ROOT/install-shell-integration.zshrc"
+cat >"$SHELL_RC" <<EOF
+# >>> agent-bridge zsh >>>
+source "$HOME/agent-bridge-public/shell/agent-bridge.zsh"
+# <<< agent-bridge zsh <<<
+EOF
+SHELL_UPDATE_OUTPUT="$("$REPO_ROOT/scripts/install-shell-integration.sh" --shell zsh --rcfile "$SHELL_RC" --apply)"
+assert_contains "$SHELL_UPDATE_OUTPUT" "updated agent-bridge shell integration"
+assert_contains "$(cat "$SHELL_RC")" "source \"$REPO_ROOT/shell/agent-bridge.zsh\""
+assert_not_contains "$(cat "$SHELL_RC")" "source \"$HOME/agent-bridge-public/shell/agent-bridge.zsh\""
+SHELL_UPTODATE_OUTPUT="$("$REPO_ROOT/scripts/install-shell-integration.sh" --shell zsh --rcfile "$SHELL_RC" --apply)"
+assert_contains "$SHELL_UPTODATE_OUTPUT" "shell integration already up to date"
+
 cat >"$FAKE_BIN/codex" <<'EOF'
 #!/usr/bin/env bash
 cat <<'JSON'
@@ -2482,7 +2496,7 @@ log "scanning agent homes with watchdog"
 WATCHDOG_JSON="$("$REPO_ROOT/agent-bridge" watchdog scan "$CREATED_AGENT" --json)"
 assert_contains "$WATCHDOG_JSON" "\"agent\": \"$CREATED_AGENT\""
 assert_contains "$WATCHDOG_JSON" "\"onboarding_state\": \"complete\""
-assert_contains "$WATCHDOG_JSON" "\"problem_count\": 1"
+assert_contains "$WATCHDOG_JSON" "\"problem_count\": 0"
 
 log "bootstrapping a manager role with init"
 INIT_DRY_RUN_JSON="$("$REPO_ROOT/agent-bridge" init --admin "$INIT_AGENT" --engine claude --session "$INIT_SESSION" --channels plugin:telegram --dry-run --json 2>&1)" || die "init dry-run failed: $INIT_DRY_RUN_JSON"


### PR DESCRIPTION
## Summary

- Fixes #75 by unlinking stale `shared/ROSTER.md` and `shared/SYRS-{CONTEXT,RULES,USER}.md` in `sync_shared_docs`, backed up under `state/doc-migration/backups/<stamp>/_shared/`. Once the target files are gone, `cleanup_broken_shared_doc_links` naturally removes the per-agent symlinks in the same run.
- Fixes #76 by adding a second `COMMON_CLAUDE_REPLACEMENTS` entry keyed on the post-v0.1.0 intermediate form (``SOUL.md``/``TOOLS.md``/``ROSTER.md``, no ``AGENTS.md``) so upgraded installs also get step 6 rewritten to the shared-wiki form.
- Folds in the companion sweep already staged in the working tree: CLAUDE.md rewrite (`claude.md` → `CLAUDE.md`), `AGENT_BRIDGE_SOURCE_DIR`/upgrade-path documentation, generalized shared-team-knowledge-contract language, and the new `docs/developer-handover.md`.

## Test plan

- [x] `python3 -c "import py_compile; py_compile.compile('bridge-docs.py', doraise=True)"`
- [x] `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh`
- [x] `./scripts/smoke-test.sh` — failure at `[smoke] creating queue task` reproduces on `main` without this PR (pre-existing, unrelated).
- [x] Isolated `BRIDGE_HOME` manual check:
  - Seeded `shared/{ROSTER,SYRS-CONTEXT,SYRS-RULES,SYRS-USER}.md` plus matching per-agent `../shared/*` symlinks and an intermediate-form `CLAUDE.md` step 6.
  - Ran `bridge-docs.py apply --all` once.
  - Observed all four shared targets deleted, all four per-agent symlinks removed, step 6 rewritten to the shared-wiki form, and backups written to `state/doc-migration/backups/<stamp>/_shared/` and `.../testagent/CLAUDE.md`.
  - Post-apply audit reports `broken links: 0`.
- [ ] `shellcheck` — not installed in this sandbox; verified bash syntax via `bash -n` instead.