### PR TITLE
bundle: stage --artifact files into shared/a2a-files/<id>/artifacts

### DIFF
--- a/bridge-bundle.py
+++ b/bridge-bundle.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shutil
 from datetime import datetime
 from pathlib import Path
 
@@ -137,9 +138,34 @@ def write_bundle(payload: dict[str, object], dry_run: bool) -> None:
     if not dry_run:
         bundle_dir_path.mkdir(parents=True, exist_ok=True)
         artifact_dir_path.mkdir(parents=True, exist_ok=True)
+        bundle_dir_path.chmod(0o755)
+        artifact_dir_path.chmod(0o755)
         (artifact_dir_path / ".gitkeep").write_text("", encoding="utf-8")
     write_text(Path(payload["paths"]["bundle_json"]), json.dumps(payload, ensure_ascii=False, indent=2) + "\n", dry_run)
     write_text(Path(payload["paths"]["task_body"]), render_bundle_markdown(payload), dry_run)
+
+
+def stage_artifacts(artifacts: list[dict[str, str]], artifact_dir: Path, shared_root: Path, dry_run: bool) -> None:
+    used_names: set[str] = set()
+    for artifact in artifacts:
+        src = Path(artifact["path"])
+        base = src.name
+        name = base
+        index = 1
+        while name in used_names:
+            name = f"{src.stem}-{index}{src.suffix}"
+            index += 1
+        used_names.add(name)
+        dst = artifact_dir / name
+        artifact["staged_path"] = str(dst)
+        try:
+            artifact["staged_relative_path"] = str(dst.relative_to(shared_root))
+        except ValueError:
+            artifact["staged_relative_path"] = ""
+        if dry_run or not src.exists():
+            continue
+        shutil.copy2(src, dst)
+        dst.chmod(0o644)
 
 
 def cmd_create(args: argparse.Namespace) -> int:
@@ -178,6 +204,9 @@ def cmd_create(args: argparse.Namespace) -> int:
         },
     }
     write_bundle(payload, args.dry_run)
+    stage_artifacts(artifacts, Path(payload["paths"]["artifact_dir"]), shared_root, args.dry_run)
+    if not args.dry_run:
+        write_text(Path(payload["paths"]["bundle_json"]), json.dumps(payload, ensure_ascii=False, indent=2) + "\n", args.dry_run)
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     return 0
 


### PR DESCRIPTION
## Summary

- Root cause: `cmd_create` recorded the sender's absolute source path in `bundle.json` but never copied the file into the bundle's `artifact_dir`. Receivers could not reach the source because per-agent homes are mode 700 and cross-agent reads are hook-blocked.
- Fix: add `stage_artifacts` that `shutil.copy2`'s each `--artifact` source into the bundle's `artifact_dir` with mode 0644, and `chmod 0755` the bundle dir + artifact dir so recipients can traverse. Each artifact now carries `staged_path` and `staged_relative_path` in `bundle.json` alongside the original `path` for traceability. Name collisions are disambiguated as `stem-N.ext`.
- Intentionally unchanged: `handoff.md` still renders the original `path` (the structured consumer path is `bundle.json[].staged_path`); the `attach-task` / `show` paths are untouched since they don't introduce new artifacts.

## Test plan

- [x] `python3 -c 'import py_compile; py_compile.compile(\"bridge-bundle.py\", doraise=True)'`
- [x] End-to-end `create --artifact` in an isolated `shared-root`:
  - Two artifacts with same basename → staged as `daily.md` and `daily-1.md`.
  - Bundle dir mode `drwxr-xr-x`, artifact dir `drwxr-xr-x`, files `-rw-r--r--`.
  - `bundle.json[].staged_path` and `staged_relative_path` populated correctly.
- [x] `--dry-run`: fills `staged_path`/`staged_relative_path` in the printed payload but writes nothing to disk.
- [ ] `shellcheck` — N/A (no shell changes).

Fixes #74