### PR TITLE
tool-policy: exempt admin agent from cross-agent access block

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -40,6 +40,15 @@ def task_db_path() -> Path:
     return bridge_home_dir() / "state" / "tasks.db"
 
 
+def admin_agent_id() -> str:
+    return os.environ.get("BRIDGE_ADMIN_AGENT_ID", "").strip()
+
+
+def is_admin_agent(agent: str) -> bool:
+    admin = admin_agent_id()
+    return bool(admin) and agent == admin
+
+
 def other_agent_homes(agent: str) -> list[Path]:
     homes: list[Path] = []
     root = agent_home_root()
@@ -59,6 +68,8 @@ def protected_path_reason(path: Path, agent: str) -> str | None:
         return "shared roster secrets are not available inside Claude tool calls"
     if path == task_db_path():
         return "direct queue DB access is blocked; use `agb` queue commands instead"
+    if is_admin_agent(agent):
+        return None
     for other_home in other_agent_homes(agent):
         if path_within(path, other_home):
             return f"cross-agent access is blocked: {other_home.name}"
@@ -71,6 +82,8 @@ def protected_alias_reason(text: str, agent: str) -> str | None:
         return "shared roster secrets are not available inside Claude tool calls"
     if "state/tasks.db" in text:
         return "direct queue DB access is blocked; use `agb` queue commands instead"
+    if is_admin_agent(agent):
+        return None
     aliases = [
         f"{home_root}/{other.name}/"
         for other in other_agent_homes(agent)


### PR DESCRIPTION
## Summary

- Root cause: `hooks/tool-policy.py::protected_path_reason` and `protected_alias_reason` blocked any path or alias inside another agent's home without consulting the roster. The admin agent (e.g. `patch` / system-doctor) needs cross-agent access for health checks, 1-on-1 coaching, and migration ops.
- Fix: add `admin_agent_id()` / `is_admin_agent()` that reads `BRIDGE_ADMIN_AGENT_ID` (already the SSOT for daemon escalation targets) and short-circuits the cross-agent check when the calling agent matches. The roster-secrets file and queue DB remain blocked for everyone — those protect bot tokens and audit integrity, not isolation.
- Non-admin agents see no behavior change.

## Test plan

- [x] `python3 -c 'import py_compile; py_compile.compile("hooks/tool-policy.py", doraise=True)'`
- [x] Isolated stdin-payload test with `BRIDGE_HOME` seeded:
  - non-admin + cross-agent file → `deny` (unchanged)
  - admin + cross-agent file → allowed
  - admin + `agent-roster.local.sh` → still `deny` (secrets)
  - admin + `state/tasks.db` → still `deny` (queue integrity)
  - admin + `Bash("ls .../other-agent/")` → allowed
  - non-admin + same Bash alias → `deny` (unchanged)
- [ ] `shellcheck` — N/A (no shell changes).

Fixes #70