### PR TITLE
state: warn when continue=1 claude agent launches as new session

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -61,6 +61,14 @@ bridge_build_dynamic_launch_cmd() {
       elif [[ "$continue_fallback" == "1" ]]; then
         bridge_join_quoted claude --continue --dangerously-skip-permissions --name "$agent"
       else
+        if [[ "$continue_mode" == "1" && "$effective_continue" == "1" ]]; then
+          bridge_warn "Claude agent '$agent' has continue=1 but no resumable session was found; launching fresh (restart_count=${BRIDGE_AGENT_LOOP_RESTART_COUNT:-0})."
+          bridge_audit_log state claude_session_resume_drift "$agent" \
+            --field "continue_mode=$continue_mode" \
+            --field "effective_continue=$effective_continue" \
+            --field "restart_count=${BRIDGE_AGENT_LOOP_RESTART_COUNT:-0}" \
+            2>/dev/null || true
+        fi
         bridge_join_quoted claude --dangerously-skip-permissions --name "$agent"
       fi
       ;;


### PR DESCRIPTION
## Summary

- Root cause: when `bridge_detect_claude_session_id` silently returns empty (due to pruned `~/.claude/sessions`, cwd realpath mismatch, or a 0-byte transcript), `bridge_build_dynamic_launch_cmd` falls through to the brand-new session arm without telemetry. Operators only notice after the agent forgets prior state.
- Fix: emit a `bridge_warn` (stderr) and a `bridge_audit_log state claude_session_resume_drift` record whenever a Claude agent with `continue_mode=1` AND `effective_continue=1` lands in the new-session branch. This is purely a visibility change; launch decision logic is untouched.
- Intentionally out of scope: changing the launch decision (trying `--continue` when detection fails, persisting `last_known_session_id`, or separating "unknown" from "confirmed missing"). Those deserve their own PRs with careful thought about first-launch vs restart semantics.

## Test plan

- [x] `bash -n lib/bridge-state.sh`
- [x] `source lib/bridge-core.sh; source lib/bridge-state.sh` — clean load, no errors.
- [x] `./scripts/smoke-test.sh` — reaches and fails at the pre-existing `[smoke] creating queue task` assertion (unrelated to this change; reproduces on `main` without edits).
- [ ] Full live-runtime verification of the warning emission requires a static Claude agent whose `~/.claude/sessions` drifts — left to operators to confirm once the commit lands. The code path is straightforward and the warning is gated conservatively (`continue_mode == 1 && effective_continue == 1`).
- [ ] `shellcheck` — not installed on this host.

Fixes #71