### PR TITLE
gitignore: ignore local developer harness dirs under .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ agents/*/.claude/
 !agents/_template/session-type-files/**
 agents/.claude/settings.local.json
 agents/.claude/settings.effective.json
+
+# Local developer harness (worker agents + orchestrator skills for repo
+# workflow). Tracked plugin skills under .claude/skills/<name>/ stay
+# committed via explicit git add; everything else under these paths is
+# machine-local.
+.claude/agents/
+.claude/skills/upstream-issue-fix/


### PR DESCRIPTION
## Summary

- Adds `.claude/agents/` and `.claude/skills/upstream-issue-fix/` to `.gitignore` so the local developer harness (worker agents + the upstream-issue-fix orchestrator used to drive repeated "GitHub issue → focused fix → PR" loops against this repo) does not accumulate in tracked source.
- The existing plugin skills under `.claude/skills/agent-bridge-runtime`, `.claude/skills/cron-manager`, `.claude/skills/memory-wiki` stay tracked — they were added via explicit `git add` and don't match the new rules.

## Test plan

- [x] `git check-ignore -v .claude/agents/upstream-issue-fixer.md .claude/skills/upstream-issue-fix/SKILL.md` — both match the new rules.
- [x] `git status` on a tree containing the plugin skills still shows them as tracked and unchanged.