### PR TITLE
teams: break bun orphan + banner verify timeout death loop for static agents

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1183,7 +1183,16 @@ run_restart() {
   local engine=""
   local launch_channels=""
   local preflight_reason=""
-  local verify_timeout="${BRIDGE_AGENT_RESTART_CHANNEL_VERIFY_SECONDS:-12}"
+  # Default raised from 12s to 30s: measured teams-plugin cold-start on a
+  # healthy host is ~14s, 12s lost the race deterministically (issue #69
+  # Defect B). Operators can still override via the env var.
+  local verify_timeout="${BRIDGE_AGENT_RESTART_CHANNEL_VERIFY_SECONDS:-30}"
+  # Kill-on-repeated-fail threshold: how many consecutive banner-verify
+  # timeouts before we stop the session and let the daemon's cooldown retry
+  # later. Previously hardcoded at 2, which combined with a too-short
+  # timeout created a death loop (issue #69 Defect C). Default 5.
+  local verify_max_attempts="${BRIDGE_AGENT_RESTART_CHANNEL_VERIFY_MAX_ATTEMPTS:-5}"
+  local verify_attempts=0
 
   shift || true
   [[ -n "$agent" ]] || bridge_die "Usage: $(basename "$0") restart <agent> [...]"
@@ -1251,8 +1260,25 @@ run_restart() {
   fi
 
   launch_channels="$(bridge_agent_effective_launch_plugin_channels_csv "$agent")"
-  if ! bridge_tmux_wait_for_claude_channel_banner "$session" "$launch_channels" "$verify_timeout"; then
-    bridge_warn "Claude channel runtime banner missing after restart for '$agent'. Retrying once with a fresh session."
+
+  [[ "$verify_max_attempts" =~ ^[0-9]+$ ]] || verify_max_attempts=5
+  (( verify_max_attempts >= 1 )) || verify_max_attempts=1
+
+  verify_attempts=1
+  if bridge_tmux_wait_for_claude_channel_banner "$session" "$launch_channels" "$verify_timeout"; then
+    return 0
+  fi
+
+  # Retry with fresh sessions up to verify_max_attempts total. Keep going
+  # only while the session restarts cleanly. If we exhaust attempts without
+  # seeing the banner, leave the session running and return non-zero so
+  # the daemon's next cooldown cycle can take another look. Previously we
+  # killed the session after 2 attempts, which — combined with the too-short
+  # 12s default timeout and reparented bun holding the port — produced the
+  # observed permanent death loop (issue #69 Defect C).
+  while (( verify_attempts < verify_max_attempts )); do
+    verify_attempts=$(( verify_attempts + 1 ))
+    bridge_warn "Claude channel runtime banner missing after restart for '$agent' (attempt ${verify_attempts}/${verify_max_attempts}). Retrying with a fresh session."
     if bridge_tmux_session_exists "$session"; then
       bridge_kill_agent_session "$agent" >/dev/null 2>&1 || true
       bridge_refresh_runtime_state
@@ -1260,17 +1286,13 @@ run_restart() {
     if ! restart_once; then
       return 1
     fi
-    if ! bridge_tmux_wait_for_claude_channel_banner "$session" "$launch_channels" "$verify_timeout"; then
-      bridge_warn "Claude channel runtime banner still missing after retry for '$agent'. Stopping the session to avoid a half-ready channel agent."
-      if bridge_tmux_session_exists "$session"; then
-        bridge_kill_agent_session "$agent" >/dev/null 2>&1 || true
-        bridge_refresh_runtime_state
-      fi
-      return 1
+    if bridge_tmux_wait_for_claude_channel_banner "$session" "$launch_channels" "$verify_timeout"; then
+      return 0
     fi
-  fi
+  done
 
-  return 0
+  bridge_warn "Claude channel runtime banner still missing after ${verify_max_attempts} attempts for '$agent'. Leaving the session alive so the daemon's next cycle can re-check (avoids the plugin-port death loop from issue #69)."
+  return 1
 }
 
 run_attach() {

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2928,6 +2928,129 @@ bridge_refresh_runtime_state() {
   fi
 }
 
+bridge_agent_plugin_port_from_env_file() {
+  # Read a single <KEY>=<value> line from a plugin .env file and echo the
+  # value if it parses as a port. Empty output on miss.
+  local env_file="$1"
+  local key="$2"
+  local line=""
+  local value=""
+
+  [[ -n "$env_file" && -f "$env_file" ]] || return 0
+  [[ -n "$key" ]] || return 0
+  # Grab the last occurrence — plugin .env files are append-style in places.
+  line="$(grep -E "^${key}=" "$env_file" 2>/dev/null | tail -n 1 || true)"
+  [[ -n "$line" ]] || return 0
+  value="${line#${key}=}"
+  # Strip optional surrounding quotes and whitespace.
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+  value="${value//[[:space:]]/}"
+  [[ "$value" =~ ^[0-9]+$ ]] || return 0
+  printf '%s' "$value"
+}
+
+bridge_agent_plugin_ports() {
+  # Enumerate known plugin ports for an agent. Currently only teams binds
+  # a long-lived port inside the tmux pane tree, but the helper is built
+  # to grow: each entry is "<port>\t<binary-name>\t<plugin-label>".
+  local agent="$1"
+  local teams_env=""
+  local port=""
+
+  teams_env="$(bridge_agent_teams_state_dir "$agent")/.env"
+  port="$(bridge_agent_plugin_port_from_env_file "$teams_env" "TEAMS_WEBHOOK_PORT" 2>/dev/null || true)"
+  if [[ -n "$port" ]]; then
+    printf '%s\t%s\t%s\n' "$port" "bun" "teams"
+  fi
+}
+
+bridge_kill_port_holder_if_orphan() {
+  # Port-aware fallback to the generic orphan cleanup: if $port is still
+  # bound after session stop, find the pid holding it, confirm it is
+  # rooted at pid 1 (reparented to init) and that its command matches the
+  # plugin binary name, then SIGTERM → wait → SIGKILL it specifically.
+  # See issue #69 Defect A.
+  local port="$1"
+  local binary_name="$2"
+  local plugin_label="$3"
+  local -a holders=()
+  local pid=""
+  local ppid_value=""
+  local cmd=""
+  local attempt=0
+
+  [[ "$port" =~ ^[0-9]+$ ]] || return 0
+  [[ -n "$binary_name" ]] || return 0
+
+  # Enumerate PIDs holding the port. Prefer ss -tlnp, fall back to lsof.
+  if command -v ss >/dev/null 2>&1; then
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] && holders+=("$pid")
+    done < <(
+      ss -H -tlnp "sport = :${port}" 2>/dev/null \
+        | grep -oE 'pid=[0-9]+' \
+        | awk -F= '{print $2}' \
+        | sort -u
+    )
+  fi
+  if [[ ${#holders[@]} -eq 0 ]] && command -v lsof >/dev/null 2>&1; then
+    while IFS= read -r pid; do
+      [[ -n "$pid" ]] && holders+=("$pid")
+    done < <(lsof -ti ":${port}" 2>/dev/null | sort -u)
+  fi
+
+  [[ ${#holders[@]} -gt 0 ]] || return 0
+
+  for pid in "${holders[@]}"; do
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    # Only touch processes that have been reparented to init/launchd (ppid=1
+    # or 0). A live session's bun child still parented to a tmux pane
+    # process must not be killed from under it.
+    ppid_value="$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    [[ "$ppid_value" =~ ^[0-9]+$ ]] || continue
+    (( ppid_value == 0 || ppid_value == 1 )) || continue
+    cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+    # Require the recognized binary name in the command line to avoid
+    # killing an unrelated process that happened to bind the same port.
+    [[ "$cmd" == *"${binary_name}"* ]] || continue
+
+    bridge_info "[info] killing reparented ${plugin_label} port holder pid=${pid} port=${port} cmd='${cmd}' (issue #69)"
+    kill -TERM "$pid" >/dev/null 2>&1 || true
+    for attempt in {1..20}; do
+      if ! kill -0 "$pid" >/dev/null 2>&1; then
+        break
+      fi
+      sleep 0.1
+    done
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      kill -KILL "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+}
+
+bridge_agent_port_aware_orphan_cleanup_after_session_stop() {
+  # Complement to bridge_mcp_orphan_cleanup_after_session_stop: walk the
+  # plugin ports this agent reserves and make sure nothing is still
+  # holding them after the tmux tree comes down. Belt-and-suspenders for
+  # issue #69 Defect A, where reparented bun processes have been observed
+  # to survive the pattern-based cleanup.
+  local agent="$1"
+  local port=""
+  local binary=""
+  local label=""
+
+  [[ "${BRIDGE_PLUGIN_PORT_ORPHAN_CLEANUP_ENABLED:-1}" == "1" ]] || return 0
+
+  while IFS=$'\t' read -r port binary label; do
+    [[ -n "$port" ]] || continue
+    bridge_kill_port_holder_if_orphan "$port" "$binary" "$label" \
+      >/dev/null 2>&1 || true
+  done < <(bridge_agent_plugin_ports "$agent" 2>/dev/null || true)
+}
+
 bridge_kill_agent_session() {
   local agent="$1"
   local session
@@ -2957,6 +3080,8 @@ bridge_kill_agent_session() {
   fi
   sleep 0.2
   bridge_mcp_orphan_cleanup_after_session_stop "$agent" >/dev/null 2>&1 || true
+  bridge_agent_port_aware_orphan_cleanup_after_session_stop "$agent" \
+    >/dev/null 2>&1 || true
   bridge_agent_clear_idle_marker "$agent"
   bridge_info "[info] killed ${agent}/${session}"
 }

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -93,6 +93,46 @@ process.on('uncaughtException', err => {
   process.stderr.write(`teams channel: uncaught exception: ${err}\n`)
 })
 
+/**
+ * Graceful shutdown: close the HTTP listener (releasing the bound port) and
+ * exit. This is referenced by the signal handlers and the parent-death
+ * watchdog below. See issue #69.
+ */
+let shuttingDown = false
+function gracefulShutdown(reason: string): void {
+  if (shuttingDown) return
+  shuttingDown = true
+  process.stderr.write(`teams channel: shutting down (${reason})\n`)
+  try {
+    httpServer.close(() => process.exit(0))
+  } catch {
+    process.exit(0)
+  }
+  // Safety: if close() hangs (open keep-alive sockets), force exit quickly.
+  setTimeout(() => process.exit(0), 1500).unref?.()
+}
+
+// Signal handlers: without these, bun does not release the port when tmux
+// SIGKILLs the pane process tree — the bun child is reparented to init and
+// keeps holding the port. See issue #69 Defect A.
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'))
+process.on('SIGHUP', () => gracefulShutdown('SIGHUP'))
+process.on('SIGINT', () => gracefulShutdown('SIGINT'))
+
+// Parent-death watchdog: poll process.ppid every 2s. If the parent has been
+// reaped and we got reparented to init (ppid=1), shut down. This catches the
+// abrupt `tmux kill-session` path, where no signal is delivered to the
+// grandchild bun process.
+const parentDeathWatch = setInterval(() => {
+  try {
+    if (process.ppid === 1) {
+      clearInterval(parentDeathWatch)
+      gracefulShutdown('parent-died')
+    }
+  } catch {}
+}, 2000)
+parentDeathWatch.unref?.()
+
 function ensureStateDir(): void {
   mkdirSync(STATE_DIR, { recursive: true, mode: 0o700 })
 }


### PR DESCRIPTION
## Summary

Three compounding defects turned any ungraceful tmux kill of a static Claude agent with a channel plugin into a permanent restart death loop (observed on `mgt_ahn` and `dev_mun`, v0.2.16, 2+ hours of consecutive `plugin_mcp_liveness_restart_failed`). This PR lands the coordinated fix across all three layers.

### Defect A — plugins/teams/server.ts

No `SIGTERM` / `SIGHUP` / `SIGINT` handler and no parent-death detection. When tmux killed the session, the bun child reparented to init and kept holding its webhook port for hours.

- Added `gracefulShutdown(reason)` that closes the HTTP listener (releasing the port) and calls `process.exit(0)`, with a 1.5s safety timeout in case keep-alive sockets stall `close()`.
- `SIGTERM` / `SIGHUP` / `SIGINT` handlers all funnel into `gracefulShutdown`.
- 2s-poll watchdog on `process.ppid`: if it becomes `1`, the parent tmux was reaped and we shut down voluntarily.

### Defect B — BRIDGE_AGENT_RESTART_CHANNEL_VERIFY_SECONDS default

Default was 12s, but the measured teams-plugin cold start on a healthy host is ~14s. The banner verification lost the race deterministically on every restart. Raised default to **30s**. Env-var override preserved.

### Defect C — bridge-agent.sh run_restart kill threshold + port-aware orphan cleanup

`run_restart` killed the session permanently after only 2 banner-verify timeouts. Combined with A + B and the daemon's 60s cooldown, this produced the infinite kill loop.

- Replaced the fixed 2-strike kill with a loop that runs up to `BRIDGE_AGENT_RESTART_CHANNEL_VERIFY_MAX_ATTEMPTS` (default **5**). On exhaustion the session is *not* killed — the function returns non-zero so the daemon's next cooldown cycle can re-check instead of tearing the session down.
- Added port-aware orphan cleanup in `bridge_kill_agent_session`: reads `TEAMS_WEBHOOK_PORT` from the agent's `.teams/.env`, enumerates holders via `ss` (preferred) or `lsof` (fallback), and **only** kills PIDs whose `ppid` is `0` or `1` (reparented to init) AND whose command contains the plugin binary name (`bun`). Gated by `BRIDGE_PLUGIN_PORT_ORPHAN_CLEANUP_ENABLED` (default on).

## Test plan

- [x] `bash -n bridge-agent.sh lib/bridge-agents.sh` — PASS.
- [x] `bun build plugins/teams/server.ts --target=bun` — 984 modules bundled cleanly.
- [ ] `shellcheck` — not installed on this host; skipped with `bash -n` as fallback.
- [ ] **Live operator verification required.** The bun signal handlers, parent-death watchdog, port-aware cleanup, and new timeout/retry semantics cannot be exercised by `scripts/smoke-test.sh`. Suggested operator checks on a host with a real teams plugin:
  1. Start a static Claude agent with teams channel; confirm banner appears within 30s.
  2. `tmux kill-session` the agent; within a few seconds bun should exit voluntarily (SIGHUP or ppid watchdog) and release its port. Confirm with `ss -ltnp | grep <port>` — no holder.
  3. If something did survive reparent, `agb agent restart <agent>` should now invoke port-aware cleanup and remove only the orphaned bun.
  4. Simulate slow banner: set `BRIDGE_AGENT_RESTART_CHANNEL_VERIFY_SECONDS=5` and restart; observe up to 5 attempts in log, then session stays alive (not killed).

## Known follow-ups (not in this PR)

- Per-agent `BRIDGE_AGENT_CHANNEL_VERIFY_SECONDS["<agent>"]` roster override.
- Same signal-handler + parent-death hardening for `plugins/ms365/` (no port, but same orphan-reparent risk).

Fixes #69