### PR TITLE
audit: attribute hook records with acting OS UID and isolation mode (pilot for #68)

### DIFF
--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import pwd
 import re
 import socket
 import subprocess
@@ -110,6 +111,22 @@ def truncate_text(text: str, limit: int = 400) -> str:
     return cleaned[: limit - 3].rstrip() + "..."
 
 
+def _acting_os_user() -> str:
+    try:
+        return pwd.getpwuid(os.geteuid()).pw_name
+    except (KeyError, OSError):
+        pass
+    try:
+        return os.getlogin()
+    except OSError:
+        return ""
+
+
+def _current_isolation_mode() -> str:
+    mode = os.environ.get("BRIDGE_AGENT_ISOLATION_MODE", "").strip()
+    return mode or "shared"
+
+
 def write_audit(action: str, target: str, detail: dict[str, Any]) -> None:
     path = audit_log_path()
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -121,6 +138,9 @@ def write_audit(action: str, target: str, detail: dict[str, Any]) -> None:
         "detail": detail,
         "pid": os.getpid(),
         "host": socket.gethostname(),
+        "acting_os_uid": os.geteuid(),
+        "acting_os_user": _acting_os_user(),
+        "isolation_mode": _current_isolation_mode(),
     }
     with path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(record, ensure_ascii=True) + "\n")


### PR DESCRIPTION
## Summary

Pilot PR for issue #68 (multi-tenant isolation and audit trail). Lowest-risk, highest-visibility sub-piece: add acting-OS-UID attribution to every hook audit record.

- `write_audit` now captures `os.geteuid()`, the login name of that UID, and the current `BRIDGE_AGENT_ISOLATION_MODE` on every record.
- In shared mode the UID is informational. Under `linux-user` isolation it closes acceptance criterion 6 of #68 ("agent-side Bash/file/MCP activity is not logged with OS attribution").
- Purely additive. Existing audit readers ignore unknown keys.

## Test plan

- [x] `python3 -m py_compile hooks/bridge_hook_common.py`
- [x] Isolated `BRIDGE_HOME` smoke with `BRIDGE_AGENT_ISOLATION_MODE=linux-user`: record includes `acting_os_uid`, `acting_os_user`, `isolation_mode`.
- [x] `./scripts/smoke-test.sh` — pre-existing queue-task failure is unrelated.

## Context

This PR closes sub-issue #83 of the #68 decomposition. Other sub-issues:

- #84 Linux acceptance validation runbook
- #85 `agent-bridge isolate/unisolate` helper
- #86 Plugin port allocation under per-UID
- #88 Admin-mediated UID attribution (depends on #83)
- #89 macOS scope doc

Partially addresses #68 (see #83)