### PR TITLE
audit: record target_agent when a tool call crosses into another agent's home

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -63,6 +63,51 @@ def other_agent_homes(agent: str) -> list[Path]:
     return homes
 
 
+def target_agent_for_path(path: Path, agent: str) -> str | None:
+    for other_home in other_agent_homes(agent):
+        if path_within(path, other_home):
+            return other_home.name
+    return None
+
+
+def target_agent_for_text(text: str, agent: str) -> str | None:
+    home_root = agent_home_root()
+    for other in other_agent_homes(agent):
+        name = other.name
+        needles = [
+            f"{home_root}/{name}/",
+            f"{home_root}/{name}",
+            f"~/.agent-bridge/agents/{name}/",
+            f"~/.agent-bridge/agents/{name}",
+            f"$HOME/.agent-bridge/agents/{name}/",
+            f"$HOME/.agent-bridge/agents/{name}",
+        ]
+        for needle in needles:
+            if needle in text:
+                return name
+    return None
+
+
+def detect_target_agent(tool_name: str, tool_input: dict[str, Any], agent: str) -> str | None:
+    if tool_name == "Bash":
+        command = str(tool_input.get("command") or "")
+        if command:
+            return target_agent_for_text(command, agent)
+        return None
+    for key in ("file_path", "path"):
+        raw = str(tool_input.get(key) or "").strip()
+        if not raw:
+            continue
+        try:
+            candidate = Path(raw).expanduser()
+        except Exception:
+            continue
+        target = target_agent_for_path(candidate, agent)
+        if target:
+            return target
+    return None
+
+
 def protected_path_reason(path: Path, agent: str) -> str | None:
     if path == roster_local_path():
         return "shared roster secrets are not available inside Claude tool calls"
@@ -70,9 +115,9 @@ def protected_path_reason(path: Path, agent: str) -> str | None:
         return "direct queue DB access is blocked; use `agb` queue commands instead"
     if is_admin_agent(agent):
         return None
-    for other_home in other_agent_homes(agent):
-        if path_within(path, other_home):
-            return f"cross-agent access is blocked: {other_home.name}"
+    target = target_agent_for_path(path, agent)
+    if target:
+        return f"cross-agent access is blocked: {target}"
     return None
 
 
@@ -167,6 +212,9 @@ def handle_pretool(payload: dict[str, Any], agent: str) -> int:
         "session_id": str(payload.get("session_id") or ""),
         "summary": tool_input_summary(tool_name, tool_input),
     }
+    target_agent = detect_target_agent(tool_name, tool_input, agent)
+    if target_agent:
+        detail["target_agent"] = target_agent
 
     if tool_name == "Bash":
         reason = protected_alias_reason(str(tool_input.get("command") or ""), agent)
@@ -204,6 +252,9 @@ def handle_posttool_common(payload: dict[str, Any], agent: str, action: str) -> 
         "cwd": str(payload.get("cwd") or current_agent_workdir()),
         "summary": tool_input_summary(tool_name, tool_input),
     }
+    target_agent = detect_target_agent(tool_name, tool_input, agent)
+    if target_agent:
+        detail["target_agent"] = target_agent
     if action == "agent_tool_failure":
         detail["error"] = truncate_text(str(payload.get("error") or ""), 240)
         detail["is_interrupt"] = bool(payload.get("is_interrupt"))


### PR DESCRIPTION
## Summary

Builds on #83 (acting OS UID, landed in #92) and #70 (admin cross-agent exemption, landed in #79). When the admin agent reads/edits another agent's home — or when a non-admin attempt is denied — the audit record now carries a `target_agent` field identifying whose home was touched. This closes the "admin UID X acted on agent Y" search gap in the audit trail.

## Implementation

- New `hooks/tool-policy.py` helpers: `target_agent_for_path` / `target_agent_for_text` / `detect_target_agent`. They reuse the existing `other_agent_homes` + `path_within` + alias scan used by `protected_alias_reason`, so path and Bash-command-with-alias flows both resolve.
- `handle_pretool` and `handle_posttool_common` annotate `detail["target_agent"]` when a cross-agent match is found. `write_audit` already persists `detail` verbatim, so the new field lands in every relevant record without schema churn.
- Admin exemption logic untouched — just the annotation is added.

## Test plan

- [x] `python3 -m py_compile hooks/tool-policy.py`
- [x] Isolated BRIDGE_HOME: admin Read + admin Bash alias + non-admin Read — all three emit `"target_agent": "victim"` in their audit records (alongside `acting_os_uid` from #83).
- [x] Non-admin case continues to deny with `agent_tool_denied` audit + `target_agent` annotation.

Fixes #88