### PR TITLE
state: wrap tmux new-session in sudo -u for linux-user isolated agents

### DIFF
--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -245,6 +245,37 @@ if [[ $SUPPRESS_MISSING_CHANNELS -eq 1 ]]; then
   SESSION_CMD="BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS=1 ${SESSION_CMD}"
 fi
 
+SUDO_WRAP_ACTIVE=0
+SUDO_WRAP_OS_USER=""
+SUDO_WRAP_FALLBACK_REASON=""
+if bridge_agent_linux_user_isolation_effective "$AGENT"; then
+  SUDO_WRAP_OS_USER="$(bridge_agent_os_user "$AGENT")"
+  if [[ "$(id -u)" == "0" ]]; then
+    SUDO_WRAP_FALLBACK_REASON="controller is root; sudo wrap skipped"
+  elif ! id -u "$SUDO_WRAP_OS_USER" >/dev/null 2>&1; then
+    SUDO_WRAP_FALLBACK_REASON="os_user $SUDO_WRAP_OS_USER does not exist"
+  elif ! bridge_linux_can_sudo_to "$SUDO_WRAP_OS_USER"; then
+    SUDO_WRAP_FALLBACK_REASON="passwordless sudo -u $SUDO_WRAP_OS_USER not available"
+  else
+    SUDO_WRAP_ACTIVE=1
+  fi
+fi
+
+if [[ $SUDO_WRAP_ACTIVE -eq 1 ]]; then
+  SUDO_PRESERVE_ENV="$(bridge_agent_preserved_env_vars)"
+  SUDO_WRAPPED_CMD="sudo -n -u $(printf '%q' "$SUDO_WRAP_OS_USER") -H"
+  if [[ -n "$SUDO_PRESERVE_ENV" ]]; then
+    SUDO_WRAPPED_CMD+=" --preserve-env=$(printf '%q' "$SUDO_PRESERVE_ENV")"
+  fi
+  SUDO_WRAPPED_CMD+=" -- $(printf '%q' "$BRIDGE_BASH_BIN") -lc $(printf '%q' "$SESSION_CMD")"
+  SESSION_CMD="$SUDO_WRAPPED_CMD"
+elif [[ -n "$SUDO_WRAP_OS_USER" && -n "$SUDO_WRAP_FALLBACK_REASON" && $DRY_RUN -eq 0 ]]; then
+  bridge_warn "linux-user isolation requested for '$AGENT' but UID switch unavailable: $SUDO_WRAP_FALLBACK_REASON. Falling back to shared-mode launch. Run 'agent-bridge isolate $AGENT --install-sudoers' or configure sudoers manually (see docs/linux-host-acceptance.md)."
+  bridge_audit_log state linux_user_sudo_unavailable "$AGENT" \
+    --field os_user="$SUDO_WRAP_OS_USER" \
+    --field reason="$SUDO_WRAP_FALLBACK_REASON" >/dev/null 2>&1 || true
+fi
+
 if [[ $DRY_RUN -eq 1 ]]; then
   if [[ $SUPPRESS_MISSING_CHANNELS -eq 1 ]]; then
     launch_channels="$(BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS=1 bridge_agent_launch_channels_csv "$AGENT")"
@@ -264,6 +295,13 @@ if [[ $DRY_RUN -eq 1 ]]; then
   echo "channel_status=$(bridge_agent_channel_status "$AGENT")"
   if [[ -n "$CHANNEL_REASON" ]]; then
     echo "channel_reason=$CHANNEL_REASON"
+  fi
+  if [[ -n "$SUDO_WRAP_OS_USER" ]]; then
+    echo "sudo_wrap_active=$SUDO_WRAP_ACTIVE"
+    echo "sudo_wrap_os_user=$SUDO_WRAP_OS_USER"
+    if [[ -n "$SUDO_WRAP_FALLBACK_REASON" ]]; then
+      echo "sudo_wrap_fallback_reason=$SUDO_WRAP_FALLBACK_REASON"
+    fi
   fi
   echo "tmux_command=$SESSION_CMD"
   exit 0

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -426,6 +426,14 @@ bridge_agent_linux_user_isolation_requested() {
   [[ "$(bridge_agent_isolation_mode "$agent")" == "linux-user" ]]
 }
 
+bridge_host_platform() {
+  if [[ -n "${BRIDGE_HOST_PLATFORM_OVERRIDE:-}" ]]; then
+    printf '%s' "$BRIDGE_HOST_PLATFORM_OVERRIDE"
+    return 0
+  fi
+  uname -s 2>/dev/null || printf 'unknown'
+}
+
 bridge_agent_linux_user_isolation_effective() {
   local agent="$1"
 
@@ -457,6 +465,25 @@ bridge_linux_sudo_root() {
 
   command -v sudo >/dev/null 2>&1 || bridge_die "linux-user isolation requires sudo"
   sudo -n "$@"
+}
+
+bridge_linux_can_sudo_to() {
+  local os_user="$1"
+
+  [[ -n "$os_user" ]] || return 1
+  if [[ "$(id -u)" == "0" ]]; then
+    return 0
+  fi
+  command -v sudo >/dev/null 2>&1 || return 1
+  sudo -n -u "$os_user" true 2>/dev/null
+}
+
+bridge_agent_preserved_env_vars() {
+  # Intentionally conservative: the ENV_PREFIX inlined in the SESSION_CMD
+  # re-exports all BRIDGE_* runtime paths inside the bash -c child, so sudo
+  # only needs to pass through the terminal/locale bits and the two
+  # launch-time markers that are not in ENV_PREFIX.
+  printf '%s' "TERM,LANG,LC_ALL,BRIDGE_AGENT_ENV_FILE,BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS"
 }
 
 bridge_linux_require_setfacl() {

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -104,6 +104,7 @@ PY
 bridge_migration_isolate() {
   local agent="$1"
   local dry_run="$2"
+  local install_sudoers="${3:-0}"
   local os_user current_mode workdir user_home runtime_state_dir log_dir
 
   bridge_migration_require_linux
@@ -176,6 +177,12 @@ bridge_migration_isolate() {
   fi
 
   bridge_migration_roster_upsert "$dry_run" "$agent" "linux-user" "$os_user"
+
+  if [[ "$install_sudoers" == "1" ]]; then
+    bridge_migration_install_sudoers "$dry_run" "$os_user" || true
+  else
+    bridge_migration_print_sudoers_hint "$os_user"
+  fi
 
   if [[ "$dry_run" == "1" ]]; then
     printf '[done] isolation plan printed (dry-run) for %s\n' "$agent"
@@ -251,11 +258,16 @@ bridge_migration_parse_args() {
   BRIDGE_MIGRATION_AGENT=""
   BRIDGE_MIGRATION_DRY_RUN=0
   BRIDGE_MIGRATION_SHOW_HELP=0
+  BRIDGE_MIGRATION_INSTALL_SUDOERS=0
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --dry-run)
         BRIDGE_MIGRATION_DRY_RUN=1
+        shift
+        ;;
+      --install-sudoers)
+        BRIDGE_MIGRATION_INSTALL_SUDOERS=1
         shift
         ;;
       -h|--help)
@@ -281,11 +293,66 @@ bridge_migration_parse_args() {
   done
 }
 
+bridge_migration_sudoers_entry() {
+  local operator="$1"
+  local os_user="$2"
+  local tmux_bin bash_bin
+  tmux_bin="$(command -v tmux 2>/dev/null || printf '/usr/bin/tmux')"
+  bash_bin="$(command -v bash 2>/dev/null || printf '/bin/bash')"
+  printf '%s ALL=(%s) NOPASSWD: %s, %s\n' "$operator" "$os_user" "$tmux_bin" "$bash_bin"
+}
+
+bridge_migration_install_sudoers() {
+  local dry_run="$1"
+  local os_user="$2"
+  local operator="${3:-$(bridge_current_user)}"
+  local entry target tmpfile
+
+  [[ -n "$os_user" ]] || return 0
+  target="/etc/sudoers.d/agent-bridge-${os_user}"
+  entry="$(bridge_migration_sudoers_entry "$operator" "$os_user")"
+
+  printf '[sudoers] planned entry for %s:\n' "$target"
+  printf '          %s' "$entry"
+  if [[ "$dry_run" == "1" ]]; then
+    printf '[dry-run] skipping sudoers install; re-run without --dry-run to apply.\n'
+    return 0
+  fi
+
+  if ! command -v visudo >/dev/null 2>&1; then
+    bridge_warn "visudo not found; skipping sudoers install. Add this entry manually to $target:"
+    printf '  %s' "$entry" >&2
+    return 1
+  fi
+
+  tmpfile="$(mktemp)" || bridge_die "failed to create temp file for sudoers validation"
+  printf '%s' "$entry" >"$tmpfile"
+  if ! visudo -cf "$tmpfile" >/dev/null 2>&1; then
+    rm -f "$tmpfile"
+    bridge_die "generated sudoers entry failed visudo -cf validation (operator=$operator os_user=$os_user)"
+  fi
+
+  bridge_linux_sudo_root install -m 0440 -o root -g root "$tmpfile" "$target"
+  rm -f "$tmpfile"
+  printf '[sudoers] installed %s (mode 0440)\n' "$target"
+}
+
+bridge_migration_print_sudoers_hint() {
+  local os_user="$1"
+  local operator="${2:-$(bridge_current_user)}"
+  local entry
+  entry="$(bridge_migration_sudoers_entry "$operator" "$os_user")"
+  printf '[hint] To enable UID switch on agent launch, install a sudoers drop-in at /etc/sudoers.d/agent-bridge-%s containing:\n' "$os_user"
+  printf '         %s' "$entry"
+  printf '       Re-run this command with --install-sudoers to apply it automatically (after visudo validation).\n'
+  printf '       See docs/linux-host-acceptance.md for the full migration runbook.\n'
+}
+
 bridge_migration_isolate_cli() {
   bridge_migration_parse_args "$@"
   if [[ "${BRIDGE_MIGRATION_SHOW_HELP:-0}" == "1" ]]; then
     cat <<'EOF'
-Usage: agent-bridge isolate <agent> [--dry-run]
+Usage: agent-bridge isolate <agent> [--dry-run] [--install-sudoers]
 
 Migrate a static agent from shared isolation to linux-user isolation.
 On macOS this command refuses with a pointer to #89 for scope.
@@ -298,12 +365,21 @@ Steps (planned; --dry-run prints without executing):
   5. Install $user_home/.agent-bridge symlink into $BRIDGE_HOME.
   6. Write isolation_mode=linux-user + os_user=<slug> to the local roster.
 
+Options:
+  --install-sudoers  Also install /etc/sudoers.d/agent-bridge-<os_user> so
+                     'agent-bridge agent start <agent>' can sudo -u the
+                     dedicated OS user without a password prompt. The entry
+                     is validated with visudo -cf before install. When
+                     omitted, the exact required entry is printed so the
+                     operator can install it manually (see
+                     docs/linux-host-acceptance.md).
+
 Re-running on an already-isolated agent is a no-op.
 EOF
     return 0
   fi
-  [[ -n "$BRIDGE_MIGRATION_AGENT" ]] || bridge_die "Usage: agent-bridge isolate <agent> [--dry-run]"
-  bridge_migration_isolate "$BRIDGE_MIGRATION_AGENT" "$BRIDGE_MIGRATION_DRY_RUN"
+  [[ -n "$BRIDGE_MIGRATION_AGENT" ]] || bridge_die "Usage: agent-bridge isolate <agent> [--dry-run] [--install-sudoers]"
+  bridge_migration_isolate "$BRIDGE_MIGRATION_AGENT" "$BRIDGE_MIGRATION_DRY_RUN" "$BRIDGE_MIGRATION_INSTALL_SUDOERS"
 }
 
 bridge_migration_unisolate_cli() {


### PR DESCRIPTION
## Summary

Closes the runtime UID-switch gap in #68's multi-tenant isolation story. Until now, `agent-bridge isolate <agent>` flipped metadata and created the OS user, but the tmux session launched by `bridge-start.sh:287` ran as the operator UID regardless. This PR wraps the launch in `sudo -u <os_user> -H` when `isolation_mode == linux-user` AND passwordless sudo is available, with a loud warning + audit fallback to shared mode when it isn't.

## Pre-existing bug fixed along the way

`bridge_host_platform` was referenced at `lib/bridge-agents.sh:433`, `bridge-agent.sh:1033`, and `docs/platform-support.md`, but **never defined anywhere in the tree**. That meant `bridge_agent_linux_user_isolation_effective` was silently failing its platform guard on every host, so the entire `linux-user` isolation path was dead code. Added a `bridge_host_platform` definition (uname -s fallback + `BRIDGE_HOST_PLATFORM_OVERRIDE` escape hatch for testing) so the rest of this PR can actually fire.

## Design decisions (5 from the issue)

1. **Wrapper = `sudo -n -u <user> -H`** — consistent with the existing `bridge_linux_sudo_root` pattern, `-n` prevents password prompts in a detached tmux pane. Rejected `runuser`/`setpriv`/`systemd-run` because sudo is already a hard dependency and the portability gain is minimal.
2. **Env pass-through** = conservative: `TERM,LANG,LC_ALL,BRIDGE_AGENT_ENV_FILE,BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS`. Other `BRIDGE_*` runtime vars are already inlined into `SESSION_CMD` via `ENV_PREFIX`, so preserving them at the sudo layer would double-expose. Operator-session env leak avoided.
3. **Channel sockets** — no change needed. `.teams/.env` lives in the per-UID workdir, and #86 port allocation is already per-agent.
4. **`agent-bridge isolate --install-sudoers`** — opt-in flag (default off). On → `visudo -cf` validates a drop-in at `/etc/sudoers.d/agent-bridge-<os_user>` (mode 0440) with target `<operator> ALL=(<os_user>) NOPASSWD: <tmux-path>, <bash-path>`. Off → `bridge_migration_print_sudoers_hint` prints the exact entry + a pointer to the #104 runbook.
5. **Fallback** — if `sudo -n -u <user> true` fails, `bridge_warn` to stderr + `bridge_audit_log state linux_user_sudo_unavailable <agent>` record + fall through to shared-mode launch. A broken sudo at live start causes tmux to exit immediately, which the existing session-liveness check already catches.

## New helpers

- `lib/bridge-agents.sh`: `bridge_host_platform()`, `bridge_linux_can_sudo_to(os_user)`, `bridge_agent_preserved_env_vars()`.
- `lib/bridge-migration.sh`: `bridge_migration_sudoers_entry()`, `bridge_migration_install_sudoers()`, `bridge_migration_print_sudoers_hint()`.

## Test plan

- [x] `bash -n bridge-start.sh lib/bridge-agents.sh lib/bridge-migration.sh bridge-agent.sh` — clean.
- [ ] `shellcheck` — not installed locally; CI covers.
- [x] 5 stub-sudo tests with `BRIDGE_HOST_PLATFORM_OVERRIDE=Linux`:
  - macOS host → wrap skipped, no regression.
  - Linux + passwordless sudo → wrap active; generated `sudo -n -u … -H --preserve-env=… -- bash -lc "<SESSION_CMD>"` verified.
  - Linux + sudo fails → audit record + warning + shared-mode fall-through.
  - `bridge_agent_preserved_env_vars` returns the conservative list.
  - Sudoers hint format + operator/os_user substitution correct.
- [x] Generated `tmux_command` roundtripped via `/bin/sh -c` parser — OK.
- [x] `./scripts/smoke-test.sh` — reaches the pre-existing queue-task failure; no regression in earlier steps.
- [ ] **Live Linux verification is out of sandbox scope**. Operator runs #104 migration runbook on a real Linux host to confirm the tmux pane's `id` shows the per-agent OS user.

## Enables

- #68 (parent) — this PR closes the last blocking sub-issue for multi-tenant isolation.
- #88 (admin UID attribution) becomes operationally meaningful — audit records now carry the ACTUAL per-agent UID instead of always the operator's.
- #104 migration runbook no longer ships with the "metadata-only until #103" caveat once this lands.

Fixes #103