### PR TITLE
state: re-apply named-user ACL on agent-env.sh after chmod resets the mask

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -762,6 +762,25 @@ BRIDGE_AGENT_ISOLATION_MODE["$agent"]=$(printf '%q' "$isolation_mode")
 BRIDGE_AGENT_OS_USER["$agent"]=$(printf '%q' "$os_user")
 EOF
   chmod 600 "$file"
+  # `chmod 600` maps to mask::--- on a file that already carries named-user
+  # ACLs (POSIX ACL: chmod's group bits drive the mask when named entries
+  # exist). isolate originally grants the isolated UID `u:<os_user>:r--` so
+  # it can read agent-env.sh under sudo-wrap, but the mask wipe makes that
+  # entry effective `---`, so subsequent `agent start` cycles fail silently
+  # — bridge-run.sh sources nothing, sees an empty roster, and exits before
+  # tmux is created. Re-apply the named-user ACL so setfacl recomputes the
+  # mask back to rw- (or whatever covers the named entries).
+  if [[ "$isolation_mode" == "linux-user" \
+        && -n "$os_user" \
+        && "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]] \
+      && command -v bridge_linux_acl_add >/dev/null 2>&1; then
+    local _controller_user
+    _controller_user="$(bridge_current_user 2>/dev/null || printf '')"
+    bridge_linux_acl_add "u:${os_user}:r--" "$file" >/dev/null 2>&1 || true
+    if [[ -n "$_controller_user" ]]; then
+      bridge_linux_acl_add "u:${_controller_user}:rw-" "$file" >/dev/null 2>&1 || true
+    fi
+  fi
 }
 
 bridge_linux_prepare_agent_isolation() {


### PR DESCRIPTION
## Summary
- `bridge_write_linux_agent_env_file` ends with `chmod 600`. POSIX ACL semantics map that group-bit clear to `mask::---` whenever named-user entries already exist, which silently demotes the `u:<os_user>:r--` ACL that `bridge_linux_prepare_agent_isolation` granted the isolated UID to effective `---`.
- The isolate path's own setfacl call right after writing the file is correct, but every later `agent start` cycle re-enters `bridge_write_linux_agent_env_file` without re-applying the ACL, so the mask gets wiped on each restart and the sudo-wrapped `bridge-run.sh` fails its source/lookup of `agent-env.sh` with EACCES.
- The visible failure mode is a silent one: `agent start <agent>` prints `세션 시작 완료`, but `tmux ls` under both UIDs is empty, the agent log gets no new lines, and `getfacl` shows `mask::---`.
- Fix: after `chmod 600`, re-apply the named-user ACL when isolation_mode is `linux-user`. setfacl recomputes the mask when adding a named entry, so this restores `mask::rw-` and the isolated UID can read the env file again on every subsequent start.

## Reproducer (AL2023, v0.3.6)
```
agent-bridge agent stop sales_sean
agent-bridge isolate sales_sean --install-sudoers
getfacl <state>/agents/sales_sean/agent-env.sh   # mask::rw-, ok
agent-bridge agent start sales_sean              # prints 세션 시작 완료
getfacl <state>/agents/sales_sean/agent-env.sh   # mask::---  <-- bug
sudo -u agent-bridge-sales_sean -H cat <env>     # EACCES
tmux ls                                          # no sales_sean session
```

## Test plan
- [x] Reproduced silent start failure on v0.3.6 against `sales_sean` (AL2023, ec2-user controller).
- [x] Applied this patch to live runtime, repeated `isolate -> start` cycle.
  - `getfacl` after start shows `mask::rw-`.
  - `sudo -n -u <os_user> -H test -r agent-env.sh` returns CAN_READ.
  - `bridge-run.sh` proceeds past the env source step (no longer "등록된 에이전트가 없음").
- [ ] Smoke test (`./scripts/smoke-test.sh`) — runs but environment lacks shellcheck and exits 0 with one unrelated warning about a missing smoke-agent name; not a regression from this patch.

## Follow-ups (out of scope, will file separately)
After this fix, isolation gets further on AL2023 but two additional gaps appear before tmux can come up:
1. `bridge-dev-plugin-cache.py` is mode 600 with no ACL grant for the isolated UID, so `[dev-plugin-cache] python3: can't open file ... Permission denied`.
2. The `claude` CLI lives in the operator's `~/.local/bin/claude` and is not on the isolated UID's PATH, so `claude: command not found` from `bridge-agents.sh:2518`.

Both warrant their own PRs once their fix shape is decided (per-user `claude` install vs system shim, ACL grant vs world-readable for `bridge-*.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)