### PR TITLE
isolation: extend ACL grants to root-level bridge-*.py and resolve engine CLI on operator PATH

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -560,6 +560,41 @@ bridge_linux_acl_add() {
   bridge_linux_sudo_root setfacl -m "$spec" "$@"
 }
 
+# Resolve the absolute path of an engine CLI (claude/codex) on the
+# controller's PATH. Returns empty string if not found.
+bridge_resolve_engine_cli() {
+  local engine="$1"
+  case "$engine" in
+    claude|codex) command -v "$engine" 2>/dev/null || true ;;
+    *) printf '' ;;
+  esac
+}
+
+# Engine binaries are typically installed under the operator's home
+# (e.g. ~/.local/bin/claude -> ~/.local/share/claude/versions/X). The
+# isolated UID has no PATH entry pointing there and no traverse/read
+# perms on the chain, so `claude --continue` fails with "command not
+# found" inside the sudo wrap. Grant the isolated UID exec on both the
+# symlink path and its realpath, plus traverse on every parent dir of
+# both. PATH injection happens in bridge_write_linux_agent_env_file.
+bridge_linux_grant_engine_cli_access() {
+  local os_user="$1"
+  local engine="$2"
+  local cli_path=""
+  local cli_real=""
+
+  cli_path="$(bridge_resolve_engine_cli "$engine")"
+  [[ -n "$cli_path" ]] || return 0
+  cli_real="$(readlink -f "$cli_path" 2>/dev/null || printf '%s' "$cli_path")"
+
+  bridge_linux_grant_traverse_chain "$os_user" "$cli_path"
+  bridge_linux_acl_add "u:${os_user}:r-x" "$cli_path" >/dev/null 2>&1 || true
+  if [[ -n "$cli_real" && "$cli_real" != "$cli_path" ]]; then
+    bridge_linux_grant_traverse_chain "$os_user" "$cli_real"
+    bridge_linux_acl_add "u:${os_user}:r-x" "$cli_real" >/dev/null 2>&1 || true
+  fi
+}
+
 bridge_linux_acl_add_recursive() {
   local spec="$1"
   shift || true
@@ -761,6 +796,22 @@ BRIDGE_AGENT_CHANNELS["$agent"]=$(printf '%q' "$channels")
 BRIDGE_AGENT_ISOLATION_MODE["$agent"]=$(printf '%q' "$isolation_mode")
 BRIDGE_AGENT_OS_USER["$agent"]=$(printf '%q' "$os_user")
 EOF
+  # Inject engine CLI directory into PATH for sudo-wrapped launchers when
+  # isolation is active. Under sudo, PATH falls back to secure_path which
+  # almost never contains the operator's per-user bin (e.g.
+  # ~/.local/bin/claude), so the launcher's bare `claude` / `codex` call
+  # would die with "command not found". Resolving on every start picks up
+  # CLI upgrades automatically; the matching ACL grant lives in
+  # bridge_linux_grant_engine_cli_access (one-shot at isolate time).
+  if [[ "$isolation_mode" == "linux-user" && -n "$engine" ]]; then
+    local _engine_cli _engine_dir
+    _engine_cli="$(bridge_resolve_engine_cli "$engine" 2>/dev/null || printf '')"
+    if [[ -n "$_engine_cli" ]]; then
+      _engine_dir="$(dirname "$_engine_cli")"
+      printf '\nexport PATH=%s:"${PATH:-/usr/local/bin:/usr/bin:/bin}"\n' \
+        "$(printf '%q' "$_engine_dir")" >>"$file"
+    fi
+  fi
   chmod 600 "$file"
   # `chmod 600` maps to mask::--- on a file that already carries named-user
   # ACLs (POSIX ACL: chmod's group bits drive the mask when named entries
@@ -844,6 +895,18 @@ bridge_linux_prepare_agent_isolation() {
 
   bridge_linux_acl_add "u:${os_user}:r-x" "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT"
   bridge_linux_acl_add "u:${os_user}:r-x" "$BRIDGE_HOME/agent-bridge" "$BRIDGE_HOME/agb" "$BRIDGE_HOME/VERSION" >/dev/null 2>&1 || true
+  # Root-level Bash and Python helpers (bridge-*.sh, bridge-*.py) live next
+  # to agent-bridge/agb. lib/scripts/ are already covered by recursive_read_paths,
+  # but root helpers like bridge-dev-plugin-cache.py default to mode 600 and
+  # have no ACL grant, so things like dev-plugin-cache sync fail with EACCES
+  # under the sudo wrap during agent start.
+  local _bridge_root_helper
+  shopt -s nullglob
+  for _bridge_root_helper in "$BRIDGE_HOME"/bridge-*.sh "$BRIDGE_HOME"/bridge-*.py; do
+    bridge_linux_acl_add "u:${os_user}:r-x" "$_bridge_root_helper" >/dev/null 2>&1 || true
+  done
+  shopt -u nullglob
+  bridge_linux_grant_engine_cli_access "$os_user" "$(bridge_agent_engine "$agent")"
   bridge_linux_acl_add_recursive "u:${os_user}:r-X" "${recursive_read_paths[@]}"
   bridge_linux_acl_add_recursive "u:${os_user}:rwX" "${recursive_write_paths[@]}"
   bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:rwX" "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -762,6 +762,25 @@ BRIDGE_AGENT_ISOLATION_MODE["$agent"]=$(printf '%q' "$isolation_mode")
 BRIDGE_AGENT_OS_USER["$agent"]=$(printf '%q' "$os_user")
 EOF
   chmod 600 "$file"
+  # `chmod 600` maps to mask::--- on a file that already carries named-user
+  # ACLs (POSIX ACL: chmod's group bits drive the mask when named entries
+  # exist). isolate originally grants the isolated UID `u:<os_user>:r--` so
+  # it can read agent-env.sh under sudo-wrap, but the mask wipe makes that
+  # entry effective `---`, so subsequent `agent start` cycles fail silently
+  # — bridge-run.sh sources nothing, sees an empty roster, and exits before
+  # tmux is created. Re-apply the named-user ACL so setfacl recomputes the
+  # mask back to rw- (or whatever covers the named entries).
+  if [[ "$isolation_mode" == "linux-user" \
+        && -n "$os_user" \
+        && "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]] \
+      && command -v bridge_linux_acl_add >/dev/null 2>&1; then
+    local _controller_user
+    _controller_user="$(bridge_current_user 2>/dev/null || printf '')"
+    bridge_linux_acl_add "u:${os_user}:r--" "$file" >/dev/null 2>&1 || true
+    if [[ -n "$_controller_user" ]]; then
+      bridge_linux_acl_add "u:${_controller_user}:rw-" "$file" >/dev/null 2>&1 || true
+    fi
+  fi
 }
 
 bridge_linux_prepare_agent_isolation() {


### PR DESCRIPTION
## Summary
Two follow-up fixes for AL2023 linux-user isolation that surface immediately after the agent-env.sh ACL mask fix in #122 lets `bridge-run.sh` make it past sourcing the env file. Without these, the launcher dies before tmux even has a working agent in it.

### 1. Root-level `bridge-*.{sh,py}` ACL grant
Helpers like `bridge-dev-plugin-cache.py` live next to `agent-bridge` / `agb` at `$BRIDGE_HOME/`, default to mode 600, and have no isolation ACL. The first failure logged is `python3: can't open file ... [Errno 13] Permission denied` followed by `[경고] development plugin cache sync failed`. Existing isolation grants r-x only on the entry-point launchers (`agent-bridge`, `agb`, `VERSION`); this PR extends that grant to `$BRIDGE_HOME/bridge-*.{sh,py}` via `shopt -s nullglob` + `setfacl -m`.

### 2. Engine CLI (`claude` / `codex`) PATH + ACL chain
Engine CLIs install under the operator's `~/.local/bin` (a symlink to a versioned ELF in `~/.local/share`). The isolated UID has no PATH entry pointing there and no traverse/exec ACLs on either the symlink chain or the realpath chain, so `bridge-run.sh` invokes a bare `claude` and exits with `claude: command not found` from `bridge-agents.sh`.

Two-part fix:
- **One-shot at isolate time** (`bridge_linux_grant_engine_cli_access`): resolve `command -v <engine>`, then `bridge_linux_grant_traverse_chain` + `bridge_linux_acl_add r-x` on both the symlink path and the readlink-resolved target. So both `~/.local/bin/claude` and `~/.local/share/claude/versions/2.1.114` (and every parent) are reachable.
- **On every `agent start`** (`bridge_write_linux_agent_env_file`): append `export PATH=<engine_dir>:"${PATH:-/usr/local/bin:/usr/bin:/bin}"` to `agent-env.sh` so the sudo-wrapped launcher (which only inherits sudoers' `secure_path`) can actually find the binary. Re-resolving on every start picks up CLI upgrades automatically.

Both helpers are scoped to engines named `claude` or `codex`. Other engines fall through to no-op.

## Reproducer (AL2023, v0.3.6 + #122 applied)
```
agent-bridge agent stop sales_sean
agent-bridge isolate sales_sean --install-sudoers
agent-bridge agent start sales_sean
# bridge-run.sh sources env (mask fix from #122 lets this work)
# then immediately fails with:
#   [dev-plugin-cache] python3: can't open file ... Permission denied
#   bridge-agents.sh: line 2518: claude: command not found
```

## Test plan
- [x] Reproduced both failures on v0.3.6 + #122 against `sales_sean`.
- [x] Applied this patch to live runtime, repeated isolate -> start cycle.
  - `getfacl bridge-dev-plugin-cache.py` shows `user:<os_user>:r-x` mask `r-x`.
  - `getfacl ~/.local/bin/claude` and the readlink target both show `user:<os_user>:r-x` mask `r-x`.
  - Traverse ACL on `/home/ec2-user/.local` shows `--x`.
  - `agent-env.sh` ends with `export PATH=/home/ec2-user/.local/bin:"${PATH:-/usr/local/bin:/usr/bin:/bin}"`.
  - `pstree` of the isolated UID shows `bash -> claude --continue --name sales_sean` running as `agent-bridge-sales_sean` (UID 991) inside the expected tmux pane.
  - `tmux capture-pane -t sales_sean` shows the live Claude UI (theme picker on a fresh isolated home).
- [ ] Smoke test (`./scripts/smoke-test.sh`) — runs but environment lacks shellcheck and exits 0 with one unrelated warning about a missing smoke-agent name; not a regression from this patch.
- Tested only with `claude` engine. `codex` is in the same case-arm but unverified end-to-end.

## Dependency
This PR is built on top of #122. Merging without #122 leaves the env-file mask broken, so `bridge-run.sh` never even reaches the code these fixes unblock.

## Out of scope
- Daemon's in-memory roster cache vs disk roster: when `isolate` writes the new mode to disk and immediately calls `bridge_linux_prepare_agent_isolation`, the in-memory `BRIDGE_AGENT_ISOLATION_MODE` can still report the previous value (so the env-file's `BRIDGE_AGENT_ISOLATION_MODE["agent"]=shared` line is wrong at isolate-time write). On the next `agent start`, the roster is re-sourced and the value becomes correct, so this PR's PATH-injection branch fires correctly. Worth a separate cleanup.
- `agent show` field-label/value misalignment under isolated agents (cosmetic display bug, separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)