### PR TITLE
isolation: symlink Claude credentials into isolated UID home

### DIFF
--- a/docs/isolation-acceptance-runbook.md
+++ b/docs/isolation-acceptance-runbook.md
@@ -167,6 +167,39 @@ roster_exit=1
 - **FAIL** on any other combination — especially `other_exit=0` (cross-agent
   snapshot leak) or `roster_exit=0` (token leak via the shared roster).
 
+### 1.4 Claude credentials reachable via per-UID symlink
+
+Under isolation the isolated UID's `$HOME/.claude/.credentials.json` is
+a symlink back to the operator's credentials file, with `u:<os_user>:r--`
+ACL on the target and a default ACL on the operator's `.claude/` so
+atomic-rename re-auths (new inode) still inherit the grant. Without
+this, Claude on the isolated UID lands at the first-launch login
+picker and the agent cannot process work. See issue `#125`.
+
+```bash
+sudo -u agent-bridge-agenta bash -lc \
+  'readlink ~/.claude/.credentials.json'
+sudo -u agent-bridge-agenta bash -lc \
+  'test -r ~/.claude/.credentials.json && echo own_read=ok || echo own_read=fail'
+sudo -u agent-bridge-agenta bash -lc \
+  'test -r /home/agent-bridge-agentb/.claude/.credentials.json 2>/dev/null && echo other_read=leak || echo other_read=blocked'
+```
+
+Expected output (substitute your operator home for the first line):
+
+```
+/home/<operator>/.claude/.credentials.json
+own_read=ok
+other_read=blocked
+```
+
+- **PASS** if `own_read=ok` (isolated UID follows the symlink and reads
+  the operator's credentials) and `other_read=blocked` (cannot reach
+  another agent's home chain).
+- **FAIL** if `own_read=fail` (Claude will land at the login picker) or
+  `other_read=leak` (cross-agent home leak that the mode-0700 on
+  `/home/agent-bridge-<slug>/` should have prevented).
+
 ---
 
 ## 2. Queue gateway round-trip

--- a/docs/isolation-migration-guide.md
+++ b/docs/isolation-migration-guide.md
@@ -42,6 +42,16 @@ After this guide has been run on an agent, expect:
   entry without read access to the shared `agent-roster.local.sh`. This
   is how `bridge-run.sh` and the hook runtime load roster state on an
   isolated host; see issue `#116`.
+- For Claude-engine agents, a symlink
+  `/home/agent-bridge-<slug>/.claude/.credentials.json` pointing at the
+  operator's `~/.claude/.credentials.json`, plus `u:<os_user>:r--` ACL
+  on the target file and a default ACL on the operator's `.claude/` so
+  Claude's atomic-rename re-auth still inherits the grant. This is the
+  only part of the operator's `.claude/` that is exposed — projects,
+  sessions, plugins, and settings remain per-agent. Run `claude login`
+  as the operator first if `~/.claude/.credentials.json` does not yet
+  exist; `isolate` warns and skips that step otherwise. See issue
+  `#125`.
 - Runtime UID switch on tmux launch — **only if** the sudoers drop-in
   exists. Install it with `agent-bridge isolate <agent> --install-sudoers`
   (validated via `visudo -cf`) or manually per the hint printed by

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -595,6 +595,77 @@ bridge_linux_grant_engine_cli_access() {
   fi
 }
 
+# Claude Code reads its auth from $CLAUDE_CONFIG_DIR/.credentials.json
+# (default $HOME/.claude/.credentials.json). Under linux-user isolation
+# the agent runs as a dedicated UID whose $HOME is /home/<os_user>/,
+# and the operator's `.credentials.json` is not present there — Claude
+# falls back to the first-launch login picker and the agent cannot
+# process work. Fix (#125):
+#
+# - Symlink /home/<os_user>/.claude/.credentials.json to the
+#   controller's credentials file so Claude on the isolated UID resolves
+#   `$HOME/.claude/.credentials.json` to the operator's file.
+# - Grant the isolated UID traverse + read-exec ACL on the controller's
+#   `.claude/` and r-- on the file itself.
+# - Set a default ACL (u:<os_user>:r--) on the controller's `.claude/`
+#   so a re-auth — which Claude performs via atomic rename, producing a
+#   new inode — still inherits the grant without another `isolate` run.
+#
+# Intentionally does NOT share the whole `.claude/` via
+# `CLAUDE_CONFIG_DIR`: projects/, sessions/, plugins/, and
+# settings.json benefit from per-agent write isolation. Only the
+# credentials file is shared across the controller's agents, matching
+# the reality that there is one Claude account per controller.
+bridge_linux_grant_claude_credentials_access() {
+  local os_user="$1"
+  local user_home="$2"
+  local controller_user="$3"
+  local engine="$4"
+  local controller_home=""
+  local controller_claude_dir=""
+  local controller_cred_file=""
+  local isolated_claude_dir=""
+  local isolated_cred_link=""
+  local current_target=""
+
+  [[ "$engine" == "claude" ]] || return 0
+  [[ -n "$os_user" && -n "$user_home" && -n "$controller_user" ]] || return 0
+
+  controller_home="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  [[ -n "$controller_home" && -d "$controller_home" ]] || return 0
+
+  controller_claude_dir="$controller_home/.claude"
+  controller_cred_file="$controller_claude_dir/.credentials.json"
+  isolated_claude_dir="$user_home/.claude"
+  isolated_cred_link="$isolated_claude_dir/.credentials.json"
+
+  if [[ ! -f "$controller_cred_file" ]]; then
+    bridge_warn "claude credentials not found at $controller_cred_file — run 'claude login' as the operator, then re-run 'agent-bridge isolate <agent>' to wire them into the isolated UID"
+    return 0
+  fi
+
+  bridge_linux_sudo_root mkdir -p "$isolated_claude_dir"
+  bridge_linux_sudo_root chown "$os_user" "$isolated_claude_dir"
+  bridge_linux_sudo_root chmod 0700 "$isolated_claude_dir"
+
+  bridge_linux_grant_traverse_chain "$os_user" "$controller_claude_dir"
+  bridge_linux_acl_add "u:${os_user}:r-x" "$controller_claude_dir" >/dev/null 2>&1 || true
+  bridge_linux_acl_add "u:${os_user}:r--" "$controller_cred_file" >/dev/null 2>&1 || true
+  bridge_linux_sudo_root setfacl -d -m "u:${os_user}:r--" "$controller_claude_dir" >/dev/null 2>&1 || true
+
+  if [[ -L "$isolated_cred_link" ]]; then
+    current_target="$(readlink "$isolated_cred_link" 2>/dev/null || printf '')"
+    if [[ "$current_target" == "$controller_cred_file" ]]; then
+      return 0
+    fi
+    bridge_linux_sudo_root rm -f "$isolated_cred_link"
+  elif [[ -e "$isolated_cred_link" ]]; then
+    bridge_linux_sudo_root rm -f "$isolated_cred_link"
+  fi
+  bridge_linux_sudo_root ln -s "$controller_cred_file" "$isolated_cred_link"
+  bridge_linux_sudo_root chown -h "$os_user" "$isolated_cred_link" >/dev/null 2>&1 || true
+}
+
 bridge_linux_acl_add_recursive() {
   local spec="$1"
   shift || true
@@ -907,6 +978,7 @@ bridge_linux_prepare_agent_isolation() {
   done
   shopt -u nullglob
   bridge_linux_grant_engine_cli_access "$os_user" "$(bridge_agent_engine "$agent")"
+  bridge_linux_grant_claude_credentials_access "$os_user" "$user_home" "$controller_user" "$(bridge_agent_engine "$agent")"
   bridge_linux_acl_add_recursive "u:${os_user}:r-X" "${recursive_read_paths[@]}"
   bridge_linux_acl_add_recursive "u:${os_user}:rwX" "${recursive_write_paths[@]}"
   bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:rwX" "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir"

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -308,6 +308,20 @@ bridge_migration_unisolate() {
     fi
   fi
 
+  # Remove the per-UID Claude credentials symlink installed by
+  # bridge_linux_grant_claude_credentials_access (#125). The ACL on the
+  # controller's ~/.claude/.credentials.json is intentionally kept — other
+  # isolated agents on the same host may still rely on it, and the entry
+  # is per-UID so it is harmless once this agent's UID is no longer in use.
+  local isolated_cred_link=""
+  isolated_cred_link="$(bridge_migration_user_home "$os_user")/.claude/.credentials.json"
+  if [[ -L "$isolated_cred_link" ]]; then
+    bridge_migration_print_step "$dry_run" "rm $isolated_cred_link"
+    if [[ "$dry_run" != "1" ]]; then
+      bridge_linux_sudo_root rm -f "$isolated_cred_link" || true
+    fi
+  fi
+
   bridge_migration_roster_upsert "$dry_run" "$agent" "shared" ""
 
   if [[ "$dry_run" == "1" ]]; then


### PR DESCRIPTION
## Summary

- Root cause: on v0.3.7, \`agent-bridge isolate <agent> --install-sudoers\` successfully installs all ACL / PATH plumbing and \`claude\` reaches its process start, but the isolated UID's \`\$HOME/.claude/.credentials.json\` does not exist. The operator's file at \`~/.claude/.credentials.json\` is \`0600\` controller-only. Claude on the isolated UID therefore lands at the first-launch theme / login method picker and the agent cannot process work.
- Fix: new helper \`bridge_linux_grant_claude_credentials_access\` shares only the credentials file (not the whole \`.claude/\`) via an ACL-granted symlink. Default ACL on the operator's \`.claude/\` keeps the grant alive across Claude's atomic-rename re-auths.
- Intentionally NOT changed: we do not share the whole \`.claude/\` via \`CLAUDE_CONFIG_DIR\`. \`projects/\`, \`sessions/\`, \`plugins/\`, \`settings.json\` benefit from per-agent write isolation. \`hooks/tool-policy.py\` untouched.

## Mechanism

Applied inside \`bridge_linux_prepare_agent_isolation\` when the agent engine is \`claude\`:

1. Resolve the controller's home via \`getent passwd <controller_user>\`. If \`<home>/.claude/.credentials.json\` does not yet exist, warn and skip (operator runs \`claude login\`, then re-runs \`agent-bridge isolate <agent>\`).
2. Ensure \`/home/<os_user>/.claude/\` exists, owned by the os_user, mode 0700.
3. Traverse + \`r-x\` on the controller's \`.claude/\`, \`r--\` on \`.credentials.json\`.
4. Default ACL \`u:<os_user>:r--\` on the controller's \`.claude/\` so an atomic-rename re-auth (new inode) inherits the grant.
5. Symlink \`/home/<os_user>/.claude/.credentials.json\` -> controller's path; \`chown -h <os_user>\`.

\`bridge_migration_unisolate\` removes the symlink on rollback; the ACL on the controller's credentials file is preserved (per-UID, harmless once the isolated UID is no longer in use, and other isolated agents on the same host may still need it).

## Test plan

- [x] \`bash -n\` on \`lib/bridge-agents.sh\` and \`lib/bridge-migration.sh\`: clean.
- [x] Early-return guards verified on macOS: non-claude engine and empty args both short-circuit before any sudo op.
- [x] Docs updated — \`isolation-migration-guide.md\` ("what to expect after isolate") and \`isolation-acceptance-runbook.md\` (§1.4 new containment check: own symlink read works; cross-agent home chain still blocked).
- [ ] Live Linux verification on EC2 (\`isolate --install-sudoers\` -> \`agent start\` -> Claude reaches prompt instead of login picker; \`unisolate\` -> symlink removed, ACL preserved): to be run by operator post-merge.
- [ ] shellcheck: not installed on host; skipped.
- [ ] \`./scripts/smoke-test.sh\`: pre-existing \`creating queue task\` assertion still fails on clean main; no new regression.

## Limitations

- Refresh/rotation: Claude's token refresh happens on API calls. If Claude atomic-renames \`.credentials.json\` via a same-directory temp-then-rename, the default ACL on \`.claude/\` propagates the grant to the new inode. If Claude writes to \`/tmp\` then renames across filesystems, the default ACL does not propagate and the isolated UID loses read access until the next \`isolate\` cycle. This is documented as a known caveat. No behavior regression vs today (today the credentials aren't reachable at all).
- Scoped to \`claude\` engine. \`codex\` has a different auth path (\`~/.codex/\`) and is not addressed here — would be a separate fix if the same bug shape is reported.

Fixes #125