### PR TITLE
fix: remove redundant NEXT-SESSION tmux send-keys bootstrap

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -251,39 +251,6 @@ bridge_run_reconcile_next_session_state() {
   fi
 }
 
-bridge_run_schedule_next_session_prompt() {
-  local next_file="$WORK_DIR/NEXT-SESSION.md"
-  local marker_file=""
-  local digest=""
-
-  [[ "$ENGINE" == "claude" ]] || return 0
-  [[ $SAFE_MODE -eq 0 ]] || return 0
-  [[ -f "$next_file" ]] || return 0
-
-  marker_file="$(bridge_agent_next_session_marker_file "$AGENT")"
-  digest="$(bridge_sha1 "$(cat "$next_file")")"
-  if [[ -f "$marker_file" && "$(cat "$marker_file" 2>/dev/null || true)" == "$digest" ]]; then
-    return 0
-  fi
-
-  (
-    "$BRIDGE_BASH_BIN" -lc '
-      set -euo pipefail
-      script_dir="$1"
-      session="$2"
-      agent="$3"
-      marker_file="$4"
-      digest="$5"
-      source "$script_dir/bridge-lib.sh"
-      if bridge_tmux_wait_for_prompt "$session" claude 20; then
-        bridge_tmux_send_and_submit "$session" claude "You have just restarted under Agent Bridge. Read NEXT-SESSION.md now, run the verification commands listed there, open with a short user-facing resume summary, and then delete NEXT-SESSION.md before doing unrelated work."
-        mkdir -p "$(dirname "$marker_file")"
-        printf "%s" "$digest" >"$marker_file"
-      fi
-    ' -- "$SCRIPT_DIR" "$SESSION" "$AGENT" "$marker_file" "$digest"
-  ) >/dev/null 2>&1 &
-}
-
 bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
   local next_file="$WORK_DIR/NEXT-SESSION.md"
   local marker_file=""
@@ -467,7 +434,6 @@ while true; do
     bridge_ensure_claude_launch_channel_plugins "$AGENT"
     bridge_run_schedule_dev_channels_accept "$LAUNCH_CMD"
     bridge_run_schedule_idle_marker_and_inbox_bootstrap
-    bridge_run_schedule_next_session_prompt
   fi
 
   log_line "실행: ${LAUNCH_CMD}"

--- a/docs/developer-handover.md
+++ b/docs/developer-handover.md
@@ -165,6 +165,10 @@ Python으로 빠지는 패턴이 많다.
 - urgent send는 prompt state에 민감하다
 - trust prompt, blocker state, copy-mode 같은 예외 상태가 있다
 - tmux option 변경은 operator 체감 품질에 바로 반영된다
+- `NEXT-SESSION.md` handoff는 SessionStart hook(`hooks/bridge_hook_common.py`의
+  `bootstrap_artifact_context`)으로만 전달된다. `bridge-run.sh`에서 tmux
+  send-keys로 동일 메시지를 재주입하던 경로(`bridge_run_schedule_next_session_prompt`)는
+  제거됐다 — 재도입하지 말 것
 
 ### 3. upgrade / deploy
 


### PR DESCRIPTION
## Summary

- `bridge_run_schedule_next_session_prompt` in `bridge-run.sh` duplicates the `NEXT-SESSION.md` handoff that the SessionStart hook (`hooks/bridge_hook_common.py::bootstrap_artifact_context`) already emits as first-turn additional context. The send-keys path also has a 50ms race that sometimes leaves the trailing `C-m` unsubmitted — Claude's input buffer gets populated but the handoff never runs.
- Delete the send-keys scheduler and its single call site. Keep `bridge_run_reconcile_next_session_state` (TTL auto-clear is independent) and `bridge_agent_next_session_marker_file` (still read by the reconcile function's audit detail).
- Intentionally NOT changed in this PR: (a) the general 50ms grace race in `bridge_tmux_type_and_submit` still affects `bridge-notify.sh` and other callers — its own tracking issue; (b) the undefined `bridge_agent_maybe_expire_next_session` helper called at `bridge-run.sh:237` and `scripts/smoke-test.sh:2965` is a pre-existing gap orthogonal to this fix.

## Test plan

- [x] `bash -n bridge-run.sh bridge-*.sh agent-bridge agb lib/*.sh` — clean
- [x] `./scripts/smoke-test.sh` — passes through the pre-existing failure at `[smoke] creating queue task` (fails identically on unedited `main`, unrelated to this change). All earlier assertions (shell integration, runtime clean start, isolated daemon/tmux, discord relay, session alias, worktree replace) pass.
- [x] `shellcheck` — skipped (not installed on host)
- [x] Code path verified: `bootstrap_artifact_context` covers the same NEXT-SESSION.md locations as the deleted scheduler (both `agent_workdir` and `agent_default_home`); `session_start_context` prepends it to the queue protocol string emitted by `hooks/session_start.py::main`; `bridge-start.sh:171` wires the SessionStart hook on every claude agent start.

## Codex review trail

- **Plan review** (read-only `codex exec`): verified hook delivery chain (workdir+default-home paths, `additionalContext=true` wiring in `agents/.claude/settings.json` and `bridge-hooks.py`), sole-caller check on the deleted function, marker-file writer benignly goes away (no reader asserts its existence), smoke-test assertions unaffected. Verdict: "Plan is sound, no changes needed." Pre-existing gap surfaced (`bridge_agent_maybe_expire_next_session` undefined) — noted above, out of scope.
- **Code review** (read-only `codex exec` on final diff): verified the diff matches the plan exactly, no accidental edits elsewhere, `bridge_agent_next_session_marker_file` still live (not dead code), idle-inbox-bootstrap call still correctly placed in the claude+non-safe-mode branch, `bash -n` clean, docs bullet factually accurate. Verdict: "LGTM, ship it."

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)