### PR TITLE
fix: use Claude HUD as authoritative context-pressure signal

### DIFF
--- a/bridge-context-pressure.py
+++ b/bridge-context-pressure.py
@@ -7,11 +7,30 @@ import argparse
 import base64
 import hashlib
 import json
+import os
 import re
 import sys
 from pathlib import Path
 
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+# Claude HUD renders a live context meter like:
+#   Context ████████░░ 40%
+# We require the word "Context" followed within a short window by one of the
+# bar glyphs (█ ░ ▓ ▒ ■), then a 1-3 digit percent. The glyph requirement is
+# what distinguishes the authoritative HUD from prose text such as
+# "Context remaining 8%" that happens to live in post-/compact scrollback
+# after --continue/--resume (issue #126).
+#
+# Defense in depth against pane wrapping: the daemon's capture-pane call
+# passes tmux -J (see lib/bridge-tmux.sh bridge_capture_recent "join"), but
+# we also tolerate a single newline inside the short glyph-neighborhood so
+# captures from non-joined callers (or older recordings used in tests) still
+# match when the HUD wraps on a narrow terminal.
+HUD_RE = re.compile(
+    r"Context[\s\S]{0,60}?[\u2588\u2591\u2592\u2593\u25A0][\u2588\u2591\u2592\u2593\u25A0\s]{0,40}?(\d{1,3})\s*%",
+    re.IGNORECASE,
+)
 
 PATTERN_GROUPS: list[tuple[str, list[str]]] = [
     (
@@ -50,7 +69,8 @@ def read_capture(path: str | None) -> str:
     return sys.stdin.read()
 
 
-def normalize_excerpt(text: str, max_bytes: int) -> str:
+def normalize_full(text: str) -> str:
+    """Strip ANSI + ignored prefixes; DO NOT tail-truncate. Used for HUD scan."""
     text = ANSI_RE.sub("", text.replace("\r", ""))
     lines: list[str] = []
     for raw in text.splitlines():
@@ -60,7 +80,11 @@ def normalize_excerpt(text: str, max_bytes: int) -> str:
         lines.append(raw)
     while lines and not lines[-1].strip():
         lines.pop()
-    normalized = "\n".join(lines).strip()
+    return "\n".join(lines).strip()
+
+
+def normalize_excerpt(text: str, max_bytes: int) -> str:
+    normalized = normalize_full(text)
     if not normalized:
         return ""
     encoded = normalized.encode("utf-8")
@@ -69,7 +93,62 @@ def normalize_excerpt(text: str, max_bytes: int) -> str:
     return encoded[-max_bytes:].decode("utf-8", errors="ignore").lstrip()
 
 
-def classify(normalized: str) -> tuple[str, str]:
+def _env_threshold(name: str, default: int) -> int:
+    raw = os.environ.get(name, "")
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    if 0 <= value <= 100:
+        return value
+    return default
+
+
+def hud_context_pct(normalized: str) -> int | None:
+    """Return the latest HUD context percentage, or None if no HUD line seen."""
+    matches = list(HUD_RE.finditer(normalized))
+    if not matches:
+        return None
+    try:
+        pct = int(matches[-1].group(1))
+    except (TypeError, ValueError):
+        return None
+    if pct < 0 or pct > 100:
+        return None
+    return pct
+
+
+def classify(normalized: str, full: str | None = None) -> tuple[str, str]:
+    """Classify context pressure.
+
+    The Claude HUD ("Context <bar> NN%") is the authoritative live signal: if
+    present anywhere in the full (un-truncated) capture, it alone drives the
+    classification and fallback patterns are skipped. This fixes the #126
+    false-positive where post-/compact scrollback leftover from a previous
+    session ("Conversation compacted" banner and prior /compact prompt) kept
+    matching the 'conversation.+compact' fallback regex every daemon scan.
+
+    If no HUD line is visible (pre-HUD Claude builds, Codex, or very fresh
+    sessions), fall back to the existing pattern groups so genuine textual
+    signals still fire.
+    """
+    scan_target = full if full is not None else normalized
+    pct = hud_context_pct(scan_target)
+    if pct is not None:
+        critical_th = _env_threshold("BRIDGE_CONTEXT_PRESSURE_HUD_CRITICAL_PCT", 85)
+        warning_th = _env_threshold("BRIDGE_CONTEXT_PRESSURE_HUD_WARNING_PCT", 60)
+        if pct >= critical_th:
+            return "critical", f"hud:context_pct={pct}"
+        if pct >= warning_th:
+            return "warning", f"hud:context_pct={pct}"
+        # HUD says below threshold: authoritative, do not fall back.
+        # Trade-off: if Claude ever renders a live low-HUD alongside a
+        # simultaneously-live hard-block banner (e.g., "must compact before
+        # continuing"), the banner is suppressed here. We bias to trusting
+        # the HUD because the #126 false-positive volume came entirely from
+        # post-/compact scrollback mimicking a banner while HUD was low.
+        return "", f"hud:context_pct={pct}"
+
     lowered = normalized.lower()
     for severity, patterns in PATTERN_GROUPS:
         for pattern in patterns:
@@ -87,8 +166,10 @@ def main() -> int:
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
-    normalized = normalize_excerpt(read_capture(args.capture_file), max(args.max_bytes, 256))
-    severity, matched = classify(normalized)
+    raw_capture = read_capture(args.capture_file)
+    full = normalize_full(raw_capture)
+    normalized = normalize_excerpt(raw_capture, max(args.max_bytes, 256))
+    severity, matched = classify(normalized, full=full)
     payload = {
         "severity": severity,
         "matched_pattern": matched,

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1504,7 +1504,7 @@ process_context_pressure_reports() {
       continue
     fi
 
-    capture="$(bridge_capture_recent "$session" "${BRIDGE_CONTEXT_PRESSURE_CAPTURE_LINES:-160}" 2>/dev/null || true)"
+    capture="$(bridge_capture_recent "$session" "${BRIDGE_CONTEXT_PRESSURE_CAPTURE_LINES:-160}" join 2>/dev/null || true)"
     analysis_shell=""
     severity=""
     matched_pattern=""

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -435,7 +435,16 @@ bridge_tmux_send_and_submit() {
 bridge_capture_recent() {
   local session="$1"
   local lines="${2:-30}"
-  tmux capture-pane -t "$(bridge_tmux_pane_target "$session")" -p -S "-$lines"
+  # Pass "join" as $3 to join visually wrapped lines (-J). Needed when the
+  # caller regexes single-line artifacts (e.g., Claude HUD "Context <bar> NN%")
+  # that can wrap across physical pane lines on narrow terminals. Default
+  # behavior (unjoined) preserves every historical caller's output verbatim.
+  local mode="${3:-}"
+  if [[ "$mode" == "join" ]]; then
+    tmux capture-pane -t "$(bridge_tmux_pane_target "$session")" -p -J -S "-$lines"
+  else
+    tmux capture-pane -t "$(bridge_tmux_pane_target "$session")" -p -S "-$lines"
+  fi
 }
 
 bridge_sanitize_text() {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -104,6 +104,45 @@ else
   log "shellcheck not installed; skipping"
 fi
 
+log "context-pressure detector: HUD-authoritative classification (issue #126)"
+# Self-contained coverage for bridge-context-pressure.py analyze. Placed
+# early so it runs even when the downstream integration block at smoke-test
+# line ~5408 is gated by unrelated pre-existing failures.
+run_cp_case() {
+  local label="$1"
+  local expected_severity="$2"
+  local expected_pattern_substring="$3"
+  local input="$4"
+  local out
+  out="$(printf '%s' "$input" | python3 "$REPO_ROOT/bridge-context-pressure.py" analyze --format shell)"
+  assert_contains "$out" "CONTEXT_PRESSURE_SEVERITY=\"$expected_severity\""
+  if [[ -n "$expected_pattern_substring" ]]; then
+    assert_contains "$out" "$expected_pattern_substring"
+  fi
+  log "  [ok] $label"
+}
+# HUD authoritative — low reading silences the post-/compact scrollback that
+# previously fired the false-positive "conversation.+compact" match.
+run_cp_case "low HUD + post-compact scrollback -> no severity" \
+  "" "hud:context_pct=5" \
+  $'Conversation compacted (ctrl+o for history)\nContext ████ 5%\n> '
+# HUD warning threshold (default 60%)
+run_cp_case "HUD 70% -> warning" \
+  "warning" "hud:context_pct=70" \
+  $'Context ████████░░ 70%\n'
+# HUD critical threshold (default 85%)
+run_cp_case "HUD 95% -> critical" \
+  "critical" "hud:context_pct=95" \
+  $'Context ████████████ 95%\n'
+# HUD wrapped across a newline (defense-in-depth for non-joined captures)
+run_cp_case "HUD wrapped after 'Context' -> still matches" \
+  "warning" "hud:context_pct=70" \
+  $'Context\n████████░░ 70%\n'
+# Non-HUD prose with explicit compact hint -> fallback pattern groups still fire
+run_cp_case "prose 'Context remaining 8%' -> warning via fallback" \
+  "warning" "" \
+  $'Context remaining 8%. Please compact soon.\n'
+
 TMP_ROOT="$(mktemp -d)"
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"


### PR DESCRIPTION
## Summary

- The context-pressure daemon detector regexes patterns like `conversation.+compact` and `context remaining NN%` against recent pane text. After a Claude restart with `--continue`/`--resume` the post-`/compact` scrollback ("Conversation compacted..." banner + prior `/compact` prompt) sits in the visible pane and keeps matching those fallback patterns — reported as 15 false-positive warnings in a few hours on a live install while HUDs showed Context 0-5%.
- Use the HUD meter (`Context <bar> NN%`) as the authoritative live signal. Two env thresholds (`BRIDGE_CONTEXT_PRESSURE_HUD_CRITICAL_PCT` default 85, `BRIDGE_CONTEXT_PRESSURE_HUD_WARNING_PCT` default 60) drive severity; the fallback prose patterns are bypassed when the HUD is present, so stale scrollback can no longer drive a warning.
- Scoped change — no behavior change for agents that don't emit the HUD (older Claude, Codex, fresh panes): PATTERN_GROUPS fires unchanged.

## Changes

- `bridge-context-pressure.py`: `HUD_RE` (Context + bar glyph + percent), `normalize_full()` (no tail-truncation so HUD scan sees the whole capture), authoritative-HUD branch in `classify()` with an inline comment on the trade-off.
- `lib/bridge-tmux.sh`: `bridge_capture_recent` gains optional 3rd arg `"join"` that appends `tmux -J`. Every existing caller passes 1–2 args — byte-identical output.
- `bridge-daemon.sh`: the context-pressure capture passes `join` so wrapped HUD lines arrive as one physical line. Stall-detection's capture remains un-joined (it wants the original pane shape).
- `scripts/smoke-test.sh`: 5 assertions over `bridge-context-pressure.py analyze` covering the exact #126 scenario (low HUD + post-`/compact` scrollback → no severity), HUD warning/critical thresholds, wrapped-HUD defense-in-depth, and the prose-fallback backwards-compat path. Placed early so the harness's pre-existing queue-task failure does not gate this coverage.

## Test plan

- [x] `bash -n` — bridge-run.sh / bridge-daemon.sh / lib/*.sh / scripts/smoke-test.sh clean.
- [x] `python3 -m py_compile bridge-context-pressure.py` clean.
- [x] `./scripts/smoke-test.sh` — new HUD block passes all 5 cases; script then dies at the unrelated pre-existing `[smoke] creating queue task` failure present on `main` without any edits.
- [x] `shellcheck` — skipped (not installed on host).
- [x] Unit trace: low HUD + post-compact scrollback classifies as `("", "hud:context_pct=5")`; HUD 70% → warning; HUD 95% → critical; wrapped HUD still matches; prose "Context remaining 8%" → warning via fallback.

## Codex review trail (3 rounds, read-only `codex exec`)

1. R1 flagged BLOCKER: `tmux capture-pane` had no `-J`, so wrapped HUD lines could evade `HUD_RE`. Fixed by the new `bridge_capture_recent "join"` mode + a broader `[\s\S]` character class in `HUD_RE` for defense in depth.
2. R2 flagged BLOCKER: no checked-in CI coverage for the new HUD path. Fixed by the `scripts/smoke-test.sh` unit block (5 cases).
3. R3 verdict: **LGTM** with one non-blocking gap — no end-to-end smoke for the live tmux capture + join path (parser-only coverage). Adding that would require controlled terminal width in the harness and is out of scope for this fix.

Fixes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)