### PR TITLE
fix: tighten daemon tmux-inject gate against mid-compose leaks

### DIFF
--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -141,13 +141,28 @@ bridge_tmux_codex_prompt_line_ready() {
 bridge_tmux_prompt_line_has_pending_input() {
   local engine="$1"
   local trimmed="$2"
+  local remainder=""
 
   case "$engine" in
     claude)
-      if [[ "$trimmed" == ❯* || "$trimmed" == '>'* ]]; then
-        ! bridge_tmux_claude_prompt_line_ready "$trimmed"
-        return
+      # Issue #132: the previous implementation inverted bridge_tmux_claude_prompt_line_ready
+      # which only flagged blocker menus (`1. Yes 2. No`), so "> typed text"
+      # — an operator mid-compose — was NOT classified as pending. That is
+      # precisely why a post-3s-pause daemon injection could interleave with
+      # the operator's keystrokes. Here we detect any non-empty remainder
+      # after the prompt glyph as pending, except for the numbered-menu
+      # blocker pattern (which is handled separately via blocker_state).
+      if [[ "$trimmed" == ❯* ]]; then
+        remainder="${trimmed#❯}"
+      elif [[ "$trimmed" == '>'* ]]; then
+        remainder="${trimmed#>}"
+      else
+        return 1
       fi
+      remainder="${remainder#"${remainder%%[![:space:]]*}"}"
+      [[ -n "$remainder" ]] || return 1
+      [[ "$remainder" =~ ^[0-9]+\.[[:space:]] ]] && return 1
+      return 0
       ;;
     codex)
       return 1
@@ -215,6 +230,7 @@ bridge_tmux_session_has_pending_input_from_text() {
   local recent="$2"
   local line=""
   local trimmed=""
+  local last_prompt_line=""
 
   bridge_tmux_engine_requires_prompt "$engine" || return 1
   [[ -n "$recent" ]] || return 1
@@ -225,15 +241,34 @@ bridge_tmux_session_has_pending_input_from_text() {
     fi
   fi
 
+  # Issue #132: the Claude input box is always the last prompt-glyph line in
+  # the TUI. Earlier lines that happen to start with "> " are scrollback
+  # (quoted text in an agent response, markdown blockquotes). Remember the
+  # LAST line that looks like a prompt and evaluate pending-input on that
+  # one only, so quoted content above cannot trigger a permanent defer.
   while IFS= read -r line; do
     line="${line//$'\r'/}"
     line="${line//$'\u00A0'/ }"
     trimmed="${line#"${line%%[![:space:]]*}"}"
     trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
-    if bridge_tmux_prompt_line_has_pending_input "$engine" "$trimmed"; then
-      return 0
-    fi
+    case "$engine" in
+      claude)
+        if [[ "$trimmed" == ❯* || "$trimmed" == '>'* ]]; then
+          last_prompt_line="$trimmed"
+        fi
+        ;;
+      *)
+        if bridge_tmux_prompt_line_has_pending_input "$engine" "$trimmed"; then
+          return 0
+        fi
+        ;;
+    esac
   done <<<"$recent"
+
+  if [[ "$engine" == "claude" && -n "$last_prompt_line" ]]; then
+    bridge_tmux_prompt_line_has_pending_input "$engine" "$last_prompt_line"
+    return
+  fi
 
   return 1
 }
@@ -244,7 +279,12 @@ bridge_tmux_session_has_pending_input() {
   local recent=""
 
   bridge_tmux_engine_requires_prompt "$engine" || return 1
-  recent="$(bridge_capture_recent "$session" 20 2>/dev/null || true)"
+  # Issue #132: use tmux -J so a wrapped prompt line (long mid-compose input
+  # that wraps the "> " glyph off to the next visual line on narrow panes) is
+  # still detectable as a single logical line. And widen the capture window
+  # from 20 to 40 lines so agent output churn cannot push the input box out
+  # of view between daemon passes.
+  recent="$(bridge_capture_recent "$session" 40 join 2>/dev/null || true)"
   [[ -n "$recent" ]] || return 1
   bridge_tmux_session_has_pending_input_from_text "$engine" "$recent"
 }
@@ -411,7 +451,14 @@ bridge_tmux_send_and_submit() {
   local session="$1"
   local engine="$2"
   local text="$3"
-  local inject_grace="${BRIDGE_TMUX_INJECT_IDLE_GRACE_SECONDS:-3}"
+  # Issue #132: previous default was 3s. Operators frequently pause >3s while
+  # composing (reading, thinking, switching windows), which left a window for
+  # daemon injections to land mid-compose. The input-buffer-content check
+  # (bridge_tmux_session_has_pending_input) is the primary gate; this
+  # timestamp gate is the fallback for cases where the input line itself
+  # couldn't be matched. A 10s default is still well under the operator's
+  # tolerance for a deferred notification but materially reduces the leak.
+  local inject_grace="${BRIDGE_TMUX_INJECT_IDLE_GRACE_SECONDS:-10}"
 
   if ! bridge_tmux_wait_for_prompt "$session" "$engine"; then
     bridge_warn "session prompt unavailable; skipping send to '$session'"
@@ -436,9 +483,11 @@ bridge_capture_recent() {
   local session="$1"
   local lines="${2:-30}"
   # Pass "join" as $3 to join visually wrapped lines (-J). Needed when the
-  # caller regexes single-line artifacts (e.g., Claude HUD "Context <bar> NN%")
-  # that can wrap across physical pane lines on narrow terminals. Default
-  # behavior (unjoined) preserves every historical caller's output verbatim.
+  # caller regexes single-line artifacts that can wrap across physical pane
+  # lines on narrow terminals — e.g., the Claude HUD "Context <bar> NN%"
+  # meter (issue #126) and the Claude "> <typed text>" input box at the
+  # bottom of the TUI (issue #132). Default behavior (unjoined) preserves
+  # every historical caller's output verbatim.
   local mode="${3:-}"
   if [[ "$mode" == "join" ]]; then
     tmux capture-pane -t "$(bridge_tmux_pane_target "$session")" -p -J -S "-$lines"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -143,6 +143,49 @@ run_cp_case "prose 'Context remaining 8%' -> warning via fallback" \
   "warning" "" \
   $'Context remaining 8%. Please compact soon.\n'
 
+log "tmux inject gate: input-buffer-content detection (issue #132)"
+# Self-contained coverage for bridge_tmux_session_has_pending_input_from_text.
+# Placed early so the harness's downstream pre-existing failures do not gate
+# this regression check. Uses an in-process bash sourcing of bridge-lib.sh so
+# the tmux helper functions become invokable without a real tmux session.
+"$BASH4_BIN" -s "$REPO_ROOT" <<'BASH_UT'
+set -u
+repo="$1"
+# shellcheck disable=SC1090
+source "$repo/bridge-lib.sh"
+fail() { printf '[smoke][error] inject-gate: %s\n' "$*" >&2; exit 1; }
+expect_pending() {
+  local label="$1"
+  local text="$2"
+  if bridge_tmux_session_has_pending_input_from_text claude "$text"; then
+    printf '[smoke]   [ok] %s\n' "$label"
+  else
+    fail "expected PENDING for: $label"
+  fi
+}
+expect_idle() {
+  local label="$1"
+  local text="$2"
+  if bridge_tmux_session_has_pending_input_from_text claude "$text"; then
+    fail "expected idle for: $label"
+  else
+    printf '[smoke]   [ok] %s\n' "$label"
+  fi
+}
+expect_pending "operator composing single word (> glyph)" \
+  $'some prior agent output\n> hello'
+expect_pending "operator composing (❯ glyph)" \
+  $'some prior agent output\n❯ thinking about this...'
+expect_pending "operator composing after scrollback quote" \
+  $'agent output\n> an earlier quoted line\nmore agent output\n> typed input'
+expect_idle "empty input box at bottom" \
+  $'agent output\n> an earlier quoted line\nmore agent output\n> '
+expect_idle "numbered-menu blocker (not a compose state)" \
+  $'Do you trust the files in this folder?\n> 1. Yes, proceed\n  2. No, exit'
+expect_idle "no prompt glyph anywhere" \
+  $'just text, nothing composable'
+BASH_UT
+
 TMP_ROOT="$(mktemp -d)"
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"


### PR DESCRIPTION
## Summary

- Issue #132 reports daemon injections landing mid-compose: 3s keyboard pause lets the gate fall through, operator's keystrokes interleave with the injected text, trailing `C-m` submits merged garbage to Claude.
- **Two root causes** in the gate:
  1. `bridge_tmux_prompt_line_has_pending_input` inverted `bridge_tmux_claude_prompt_line_ready`, which only flagged the numbered-menu blocker pattern. So `> typed text` (operator mid-compose) was NOT classified as pending — the gate fell through to the 3s timestamp fallback, easily beaten by any >3s pause.
  2. Even with a corrected matcher, earlier `>`-quoted scrollback lines (markdown blockquotes in agent output) would false-positive-defer permanently.
- **MVP scope**: tighten the gate only. The full issue body covers a redesign with pending-attention spool, BEL, poll-flush, deferral cap, metadata-only injection format, and main-agent-supervised subagent delegation — all of those are deferred to follow-up issues. This PR fixes case #2 end-to-end.

## Changes (`lib/bridge-tmux.sh`)

- `bridge_tmux_prompt_line_has_pending_input` (claude): strips the `>`/`❯` glyph + leading whitespace; any non-empty remainder that is NOT a `"1. …"` menu entry is pending. Empty or menu remainders stay idle.
- `bridge_tmux_session_has_pending_input_from_text` (claude): track the LAST prompt-glyph line in the capture and evaluate pending-input only on that one. Quoted scrollback lines above the actual input box are ignored. Other engines keep the prior per-line scan.
- `bridge_tmux_session_has_pending_input`: capture 40 lines (up from 20) and pass tmux `-J` via new `"join"` mode on `bridge_capture_recent` so a wrapped long compose line is seen as one logical line.
- `bridge_capture_recent`: optional 3rd arg `"join"` appends `-J`. Every existing caller passes 1–2 args and keeps byte-identical output.
- `bridge_tmux_send_and_submit`: default `inject_grace` 3s → 10s (env-tunable via `BRIDGE_TMUX_INJECT_IDLE_GRACE_SECONDS`). Fallback timestamp gate only matters when the input-line matcher cannot match; widening it materially shrinks the leak window without meaningfully delaying genuine daemon events.

## Coverage (`scripts/smoke-test.sh`)

6 assertions against `bridge_tmux_session_has_pending_input_from_text`, placed early so the harness's pre-existing queue-task failure does not gate them:

- operator composing with `>` glyph → pending
- operator composing with `❯` glyph → pending
- composing after scrollback quote → pending (last-glyph-line logic)
- empty `> ` input box at bottom → idle
- `> 1. Yes` numbered-menu blocker → idle (blocker path handles this separately)
- no prompt glyph anywhere → idle

## Scope deliberately NOT covered in this PR (follow-up issues)

- `pending-attention.env` spool + FIFO flush + deferral cap + `[deferred]` marker.
- tmux BEL on deferred injection (operator visual cue).
- Axis B: metadata-only injection payload (`[Agent Bridge] event=inbox count=N top=X title=…`) + main-agent supervised subagent delegation policy in `runtime-templates/_template/CLAUDE.md`.
- PreCompact / `external-push-handling` shared skill.

## Related asymmetry (noted, not fixed here)

`bridge_tmux_session_has_prompt` still captures 20 unjoined lines while the pending-input path now captures 40 joined lines. An extreme long-wrap compose could fail earlier as "prompt unavailable" rather than "busy" (caller retries on next daemon pass). Out of scope for this fix.

## Test plan

- [x] `bash -n lib/bridge-tmux.sh scripts/smoke-test.sh` clean.
- [x] `./scripts/smoke-test.sh` — new inject-gate block passes all 6 cases; script then dies at the unrelated pre-existing `[smoke] creating queue task` failure present on `main` without any edits.
- [x] `shellcheck` — skipped (not installed on host).
- [x] Unit trace: `> hi` → PENDING; `❯ composing` → PENDING; `> ` → idle; `> 1. Yes` → idle; scrollback `> quoted\n> typed` → PENDING (last-glyph logic); prose only → idle.

## Codex review trail (2 rounds, read-only `codex exec`)

1. R1 BLOCKER: the matcher rewrite was missing — `> typed text` still resolved to "no pending" because the original implementation inverted `prompt_line_ready` which only flagged numbered-menu blockers. Fixed by rewriting the matcher directly and adding the last-glyph-line scan.
2. R2 verdict: **LGTM-with-notes**. Confirmed the rewrite closes case #2 end-to-end. Notes: add `❯` smoke case (done), and `bridge_tmux_session_has_prompt` asymmetry worth tracking (noted above).

Fixes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)