### PR TITLE
feat: metadata-only injection payload helper + opt-in flag (Axis B part 1 of #132)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -910,7 +910,7 @@ bridge_send_stall_nudge() {
   local text=""
 
   text="$(bridge_notification_text "stall detected" "$(bridge_stall_nudge_message "$classification")" "" normal)"
-  bridge_tmux_send_and_submit "$session" "$engine" "$text"
+  bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"
 }
 
 process_stall_reports() {
@@ -2102,6 +2102,30 @@ PY
   daemon_info "nudged ${agent} (queued=${live_queued}, claimed=${live_claimed}, idle=${idle}s)"
 }
 
+flush_pending_attention_spools() {
+  # Issue #132a: per-sync-pass flush of the per-agent pending-attention spool.
+  # Covers every engine that the tmux inject gate applies to (claude + codex)
+  # so a busy Codex session does not permanently accumulate entries either.
+  # The flush itself is bounded by the spool size and skips over agents with
+  # empty spools in O(1).
+  local agent=""
+  local session=""
+  local engine=""
+  local count=0
+
+  for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+    engine="$(bridge_agent_engine "$agent")"
+    [[ -n "$engine" ]] || continue
+    session="$(bridge_agent_session "$agent")"
+    [[ -n "$session" ]] || continue
+    bridge_tmux_session_exists "$session" || continue
+    count="$(bridge_tmux_pending_attention_count "$agent" 2>/dev/null || printf '0')"
+    [[ "$count" =~ ^[0-9]+$ ]] || count=0
+    (( count > 0 )) || continue
+    bridge_tmux_pending_attention_flush "$session" "$engine" "$agent" >/dev/null 2>&1 || true
+  done
+}
+
 recover_claude_bootstrap_blockers() {
   local agent
   local session
@@ -3118,6 +3142,7 @@ cmd_sync_cycle() {
   fi
   bridge_reconcile_idle_markers || true
   recover_claude_bootstrap_blockers || true
+  flush_pending_attention_spools || true
   process_channel_health || true
   process_plugin_liveness || true
 

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -312,7 +312,7 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
         if [[ ! -f "$next_file" && ! -f "$marker_file" ]]; then
           task_id="$(bridge_queue_cli find-open --agent "$agent" 2>/dev/null | head -n 1 || true)"
           if [[ -n "$task_id" ]]; then
-            bridge_tmux_send_and_submit "$session" claude "[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent"
+            bridge_tmux_send_and_submit "$session" claude "[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent" "$agent"
           fi
           mkdir -p "$(dirname "$marker_file")"
           printf "%s\n" "$(date +%s)" >"$marker_file"

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -312,7 +312,12 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
         if [[ ! -f "$next_file" && ! -f "$marker_file" ]]; then
           task_id="$(bridge_queue_cli find-open --agent "$agent" 2>/dev/null | head -n 1 || true)"
           if [[ -n "$task_id" ]]; then
-            bridge_tmux_send_and_submit "$session" claude "[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent" "$agent"
+            if bridge_inject_metadata_only_enabled; then
+              inject_text="$(bridge_format_injection_meta inbox-bootstrap agent="$agent" top="$task_id")"
+            else
+              inject_text="[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent"
+            fi
+            bridge_tmux_send_and_submit "$session" claude "$inject_text" "$agent"
           fi
           mkdir -p "$(dirname "$marker_file")"
           printf "%s\n" "$(date +%s)" >"$marker_file"

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -245,6 +245,26 @@ def bootstrap_artifact_context(agent: str) -> str:
             "Stay in onboarding flow until it is complete before doing unrelated work."
         )
 
+    # Issue #132a: surface any pending-attention spool entries queued while the
+    # agent was busy so the operator knows replays will follow once the input
+    # box becomes idle. The spool path mirrors lib/bridge-state.sh.
+    spool_path = (
+        bridge_state_dir() / "agents" / agent / "pending-attention.env"
+    )
+    try:
+        pending_count = sum(
+            1
+            for line in spool_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+    except (OSError, UnicodeDecodeError):
+        pending_count = 0
+    if pending_count > 0:
+        lines.append(
+            f"Agent Bridge has {pending_count} queued external event(s); "
+            "they will replay into this session as the input box becomes idle."
+        )
+
     if not lines:
         return ""
     return "\n".join(lines)

--- a/lib/bridge-notify.sh
+++ b/lib/bridge-notify.sh
@@ -159,7 +159,9 @@ bridge_dispatch_notification() {
       fi
 
       text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
-      if bridge_tmux_send_and_submit "$session" "$engine" "$text"; then
+      # Issue #132a: pass $agent so a busy gate at inject time routes through
+      # the pending-attention spool instead of silently dropping the wake.
+      if bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"; then
         return 0
       fi
       bridge_warn "Claude idle wake delivery failed for '${agent}'"
@@ -176,7 +178,7 @@ bridge_dispatch_notification() {
         return 1
       fi
       text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
-      bridge_tmux_send_and_submit "$session" "$engine" "$text"
+      bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"
       ;;
   esac
 }

--- a/lib/bridge-notify.sh
+++ b/lib/bridge-notify.sh
@@ -109,6 +109,73 @@ bridge_notification_text() {
   printf '%s' "$header"
 }
 
+# ---------------------------------------------------------------------------
+# Issue #132b: metadata-only injection payload helper.
+#
+# Legacy injections embed an execution verb
+# ("Run exactly: ~/.agent-bridge/agb inbox $agent"). The redesigned payload
+# is metadata-only so the main agent can parse the event, read the task
+# spec via `agb show-task`, compose its own subagent prompt with acceptance
+# criteria, dispatch via Task, verify, and report one line — keeping the
+# main context clean. See upstream #132 Axis B and the external-push-handling
+# shared skill (#132c) for the handling routine.
+#
+# This PR adds the helper + opt-in flag only. Call sites emit legacy output
+# unless BRIDGE_INJECT_METADATA_ONLY=1. Flip the flag only after the
+# external-push-handling skill is shipped — otherwise agents would receive
+# metadata without a handler.
+#
+# Payload shape:
+#   [Agent Bridge] event=inbox count=3 top=X12 title='fix docs typo' from=patch
+#
+# Value encoding: bare token for letters/digits/.-_@:/, otherwise
+# single-quoted with '\'' escape for embedded single quotes.
+# ---------------------------------------------------------------------------
+
+bridge_inject_metadata_only_enabled() {
+  [[ "${BRIDGE_INJECT_METADATA_ONLY:-0}" == "1" ]]
+}
+
+bridge_inject_meta_escape_value() {
+  local v="$1"
+  if [[ -z "$v" ]]; then
+    printf "''"
+    return 0
+  fi
+  # Metadata injections are a single logical line — so any embedded CR/LF in
+  # a value (e.g., a task title that survived `.strip()` but contained a
+  # newline) must be folded to an ASCII sentinel to avoid producing a
+  # payload the parser would split into two events. The "\\n" sentinel is
+  # chosen so a consumer can reliably reverse it when displaying the title.
+  v="${v//$'\r'/}"
+  v="${v//$'\n'/\\n}"
+  if [[ "$v" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+    printf '%s' "$v"
+    return 0
+  fi
+  local escaped="${v//\'/\'\\\'\'}"
+  printf "'%s'" "$escaped"
+}
+
+bridge_format_injection_meta() {
+  # Usage: bridge_format_injection_meta <kind> [<key>=<val> ...]
+  # Emits: [Agent Bridge] event=<kind> <key>=<escaped-val> ...
+  local kind="$1"
+  shift
+  local out="[Agent Bridge] event="
+  out+="$(bridge_inject_meta_escape_value "$kind")"
+  local pair=""
+  local key=""
+  local val=""
+  for pair in "$@"; do
+    key="${pair%%=*}"
+    val="${pair#*=}"
+    [[ -n "$key" ]] || continue
+    out+=" ${key}=$(bridge_inject_meta_escape_value "$val")"
+  done
+  printf '%s' "$out"
+}
+
 bridge_queue_attention_title() {
   local queued="$1"
   printf '%s' "ACTION REQUIRED — queued tasks (${queued})"
@@ -120,6 +187,21 @@ bridge_queue_attention_message() {
   local task_id="${3:-}"
   local task_priority="${4:-normal}"
   local task_title="${5:-}"
+
+  if bridge_inject_metadata_only_enabled; then
+    # Issue #132b: no execution verb; main agent parses metadata and drives
+    # the flow via the external-push-handling shared skill (#132c). Emit a
+    # single logical line — no trailing newline — so the injected payload is
+    # one event, not two (the blank follow-up would otherwise be read as a
+    # separate message by the injection path).
+    bridge_format_injection_meta inbox \
+      agent="$agent" \
+      count="$queued" \
+      top="${task_id:-}" \
+      priority="$task_priority" \
+      title="${task_title:-}"
+    return 0
+  fi
 
   printf '[Agent Bridge] %s pending task(s) for %s.\n' "$queued" "$agent"
   if [[ -n "$task_id" && -n "$task_title" ]]; then
@@ -158,7 +240,20 @@ bridge_dispatch_notification() {
         fi
       fi
 
-      text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
+      # Issue #132b: bridge_dispatch_notification is a shared helper called
+      # from many places (bridge-task.sh, bridge-send.sh, bridge-intake.sh,
+      # bridge-review.sh, bridge-bundle.sh) with PLAIN messages that still
+      # need the legacy header. Only skip header-wrapping when the caller
+      # has already produced a metadata payload — i.e., $message begins
+      # with the "[Agent Bridge] event=" header emitted by
+      # bridge_format_injection_meta. This keeps legacy callers' output
+      # byte-identical even when the flag is on.
+      if bridge_inject_metadata_only_enabled \
+         && [[ "$message" == "[Agent Bridge] event="* ]]; then
+        text="$message"
+      else
+        text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
+      fi
       # Issue #132a: pass $agent so a busy gate at inject time routes through
       # the pending-attention spool instead of silently dropping the wake.
       if bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"; then

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1090,6 +1090,16 @@ bridge_agent_next_session_marker_file() {
   printf '%s/next-session.sha' "$(bridge_agent_runtime_state_dir "$agent")"
 }
 
+bridge_agent_pending_attention_file() {
+  local agent="$1"
+  printf '%s/pending-attention.env' "$(bridge_agent_runtime_state_dir "$agent")"
+}
+
+bridge_agent_pending_attention_lock_dir() {
+  local agent="$1"
+  printf '%s/pending-attention.lock' "$(bridge_agent_runtime_state_dir "$agent")"
+}
+
 bridge_agent_initial_inbox_marker_file() {
   local agent="$1"
   printf '%s/initial-inbox.started' "$(bridge_agent_runtime_state_dir "$agent")"

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -141,13 +141,28 @@ bridge_tmux_codex_prompt_line_ready() {
 bridge_tmux_prompt_line_has_pending_input() {
   local engine="$1"
   local trimmed="$2"
+  local remainder=""
 
   case "$engine" in
     claude)
-      if [[ "$trimmed" == ❯* || "$trimmed" == '>'* ]]; then
-        ! bridge_tmux_claude_prompt_line_ready "$trimmed"
-        return
+      # Issue #132: the previous implementation inverted bridge_tmux_claude_prompt_line_ready
+      # which only flagged blocker menus (`1. Yes 2. No`), so "> typed text"
+      # — an operator mid-compose — was NOT classified as pending. That is
+      # precisely why a post-3s-pause daemon injection could interleave with
+      # the operator's keystrokes. Here we detect any non-empty remainder
+      # after the prompt glyph as pending, except for the numbered-menu
+      # blocker pattern (which is handled separately via blocker_state).
+      if [[ "$trimmed" == ❯* ]]; then
+        remainder="${trimmed#❯}"
+      elif [[ "$trimmed" == '>'* ]]; then
+        remainder="${trimmed#>}"
+      else
+        return 1
       fi
+      remainder="${remainder#"${remainder%%[![:space:]]*}"}"
+      [[ -n "$remainder" ]] || return 1
+      [[ "$remainder" =~ ^[0-9]+\.[[:space:]] ]] && return 1
+      return 0
       ;;
     codex)
       return 1
@@ -215,6 +230,7 @@ bridge_tmux_session_has_pending_input_from_text() {
   local recent="$2"
   local line=""
   local trimmed=""
+  local last_prompt_line=""
 
   bridge_tmux_engine_requires_prompt "$engine" || return 1
   [[ -n "$recent" ]] || return 1
@@ -225,15 +241,34 @@ bridge_tmux_session_has_pending_input_from_text() {
     fi
   fi
 
+  # Issue #132: the Claude input box is always the last prompt-glyph line in
+  # the TUI. Earlier lines that happen to start with "> " are scrollback
+  # (quoted text in an agent response, markdown blockquotes). Remember the
+  # LAST line that looks like a prompt and evaluate pending-input on that
+  # one only, so quoted content above cannot trigger a permanent defer.
   while IFS= read -r line; do
     line="${line//$'\r'/}"
     line="${line//$'\u00A0'/ }"
     trimmed="${line#"${line%%[![:space:]]*}"}"
     trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
-    if bridge_tmux_prompt_line_has_pending_input "$engine" "$trimmed"; then
-      return 0
-    fi
+    case "$engine" in
+      claude)
+        if [[ "$trimmed" == ❯* || "$trimmed" == '>'* ]]; then
+          last_prompt_line="$trimmed"
+        fi
+        ;;
+      *)
+        if bridge_tmux_prompt_line_has_pending_input "$engine" "$trimmed"; then
+          return 0
+        fi
+        ;;
+    esac
   done <<<"$recent"
+
+  if [[ "$engine" == "claude" && -n "$last_prompt_line" ]]; then
+    bridge_tmux_prompt_line_has_pending_input "$engine" "$last_prompt_line"
+    return
+  fi
 
   return 1
 }
@@ -244,7 +279,12 @@ bridge_tmux_session_has_pending_input() {
   local recent=""
 
   bridge_tmux_engine_requires_prompt "$engine" || return 1
-  recent="$(bridge_capture_recent "$session" 20 2>/dev/null || true)"
+  # Issue #132: use tmux -J so a wrapped prompt line (long mid-compose input
+  # that wraps the "> " glyph off to the next visual line on narrow panes) is
+  # still detectable as a single logical line. And widen the capture window
+  # from 20 to 40 lines so agent output churn cannot push the input box out
+  # of view between daemon passes.
+  recent="$(bridge_capture_recent "$session" 40 join 2>/dev/null || true)"
   [[ -n "$recent" ]] || return 1
   bridge_tmux_session_has_pending_input_from_text "$engine" "$recent"
 }
@@ -411,7 +451,14 @@ bridge_tmux_send_and_submit() {
   local session="$1"
   local engine="$2"
   local text="$3"
-  local inject_grace="${BRIDGE_TMUX_INJECT_IDLE_GRACE_SECONDS:-3}"
+  # Issue #132: previous default was 3s. Operators frequently pause >3s while
+  # composing (reading, thinking, switching windows), which left a window for
+  # daemon injections to land mid-compose. The input-buffer-content check
+  # (bridge_tmux_session_has_pending_input) is the primary gate; this
+  # timestamp gate is the fallback for cases where the input line itself
+  # couldn't be matched. A 10s default is still well under the operator's
+  # tolerance for a deferred notification but materially reduces the leak.
+  local inject_grace="${BRIDGE_TMUX_INJECT_IDLE_GRACE_SECONDS:-10}"
 
   if ! bridge_tmux_wait_for_prompt "$session" "$engine"; then
     bridge_warn "session prompt unavailable; skipping send to '$session'"
@@ -435,7 +482,17 @@ bridge_tmux_send_and_submit() {
 bridge_capture_recent() {
   local session="$1"
   local lines="${2:-30}"
-  tmux capture-pane -t "$(bridge_tmux_pane_target "$session")" -p -S "-$lines"
+  # Pass "join" as $3 to join visually wrapped lines (-J). Needed when the
+  # caller regexes single-line artifacts (e.g., the Claude "> <typed text>"
+  # input box at the bottom of the TUI) that can wrap across physical pane
+  # lines on narrow terminals. Default behavior (unjoined) preserves every
+  # historical caller's output verbatim.
+  local mode="${3:-}"
+  if [[ "$mode" == "join" ]]; then
+    tmux capture-pane -t "$(bridge_tmux_pane_target "$session")" -p -J -S "-$lines"
+  else
+    tmux capture-pane -t "$(bridge_tmux_pane_target "$session")" -p -S "-$lines"
+  fi
 }
 
 bridge_sanitize_text() {

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -451,6 +451,12 @@ bridge_tmux_send_and_submit() {
   local session="$1"
   local engine="$2"
   local text="$3"
+  # Issue #132a: optional 4th arg turns on the pending-attention spool so a
+  # busy-gate hit no longer silently drops the event. Unspecified → legacy
+  # hard-failure behavior for callers that want immediate operator feedback
+  # (e.g., bridge-action.sh: the operator ran `agb send` and should see
+  # the failure rather than a background deferral).
+  local spool_agent="${4:-}"
   # Issue #132: previous default was 3s. Operators frequently pause >3s while
   # composing (reading, thinking, switching windows), which left a window for
   # daemon injections to land mid-compose. The input-buffer-content check
@@ -462,9 +468,19 @@ bridge_tmux_send_and_submit() {
 
   if ! bridge_tmux_wait_for_prompt "$session" "$engine"; then
     bridge_warn "session prompt unavailable; skipping send to '$session'"
+    if bridge_tmux_spool_enabled "$spool_agent"; then
+      bridge_tmux_pending_attention_append "$spool_agent" "$text"
+      bridge_tmux_session_ring_bell "$session"
+      return 0
+    fi
     return 1
   fi
   if bridge_tmux_session_inject_busy "$session" "$engine" "$inject_grace"; then
+    if bridge_tmux_spool_enabled "$spool_agent"; then
+      bridge_tmux_pending_attention_append "$spool_agent" "$text"
+      bridge_tmux_session_ring_bell "$session"
+      return 0
+    fi
     bridge_warn "session busy; deferring send to '$session'"
     return 1
   fi
@@ -477,6 +493,239 @@ bridge_tmux_send_and_submit() {
       bridge_tmux_paste_and_submit "$session" "$text"
       ;;
   esac
+}
+
+# ---------------------------------------------------------------------------
+# Issue #132a: pending-attention spool.
+#
+# When a daemon-initiated inject hits the busy gate, rather than silently
+# dropping it, the text is escaped and appended to the per-agent spool file
+# (bridge_agent_pending_attention_file). A subsequent daemon pass calls
+# bridge_tmux_pending_attention_flush, which drains the spool in FIFO order
+# and re-injects while the gate is clear. Entries aged past
+# BRIDGE_TMUX_INJECT_MAX_DEFER_SECONDS (default 600s) get a `[deferred]`
+# marker so the operator can see they are older than a live signal.
+#
+# The lock is a mkdir spinlock (matches the repo's existing convention in
+# lib/bridge-channels.sh::bridge_allocate_dynamic_webhook_port) so the path
+# works on Linux and macOS without requiring `flock`.
+# ---------------------------------------------------------------------------
+
+bridge_tmux_spool_enabled() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  [[ "${BRIDGE_TMUX_INJECT_SPOOL_ENABLED:-1}" == "1" ]] || return 1
+  return 0
+}
+
+bridge_tmux_pending_attention_escape() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+  text="${text//$'\t'/\\t}"
+  text="${text//$'\r'/\\r}"
+  text="${text//$'\n'/\\n}"
+  printf '%s' "$text"
+}
+
+bridge_tmux_pending_attention_unescape() {
+  local text="$1"
+  local out=""
+  local i=0
+  local ch=""
+  local next=""
+  local len=${#text}
+  while (( i < len )); do
+    ch="${text:$i:1}"
+    if [[ "$ch" == "\\" && $((i + 1)) -lt $len ]]; then
+      next="${text:$((i + 1)):1}"
+      case "$next" in
+        n) out+=$'\n' ;;
+        r) out+=$'\r' ;;
+        t) out+=$'\t' ;;
+        \\) out+=$'\\' ;;
+        *) out+="\\$next" ;;
+      esac
+      i=$((i + 2))
+    else
+      out+="$ch"
+      i=$((i + 1))
+    fi
+  done
+  printf '%s' "$out"
+}
+
+bridge_tmux_pending_attention_with_lock() {
+  local agent="$1"
+  local action="$2"
+  shift 2
+  local lock_dir=""
+  local attempts=0
+  local max_attempts=200
+  local rc=0
+
+  lock_dir="$(bridge_agent_pending_attention_lock_dir "$agent")"
+  mkdir -p "$(dirname "$lock_dir")"
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if (( attempts >= max_attempts )); then
+      bridge_warn "pending-attention lock stuck for '$agent'; forcing"
+      rmdir "$lock_dir" >/dev/null 2>&1 || true
+    fi
+    sleep 0.05
+  done
+
+  "$action" "$agent" "$@"
+  rc=$?
+  rmdir "$lock_dir" >/dev/null 2>&1 || true
+  return $rc
+}
+
+_bridge_tmux_pending_attention_append_locked() {
+  local agent="$1"
+  local text="$2"
+  local spool_file=""
+  local escaped=""
+  local ts=""
+
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  mkdir -p "$(dirname "$spool_file")"
+  ts="$(date +%s)"
+  escaped="$(bridge_tmux_pending_attention_escape "$text")"
+  printf '%s\t%s\n' "$ts" "$escaped" >>"$spool_file"
+}
+
+bridge_tmux_pending_attention_append() {
+  local agent="$1"
+  local text="$2"
+  [[ -n "$agent" ]] || return 1
+  bridge_tmux_pending_attention_with_lock "$agent" \
+    _bridge_tmux_pending_attention_append_locked "$text"
+}
+
+_bridge_tmux_pending_attention_drain_locked() {
+  local agent="$1"
+  local spool_file=""
+
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  [[ -f "$spool_file" ]] || return 0
+  cat "$spool_file"
+  : >"$spool_file"
+}
+
+bridge_tmux_pending_attention_drain() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  bridge_tmux_pending_attention_with_lock "$agent" \
+    _bridge_tmux_pending_attention_drain_locked
+}
+
+_bridge_tmux_pending_attention_prepend_locked() {
+  local agent="$1"
+  local lines="$2"
+  local spool_file=""
+  local tmp=""
+
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  mkdir -p "$(dirname "$spool_file")"
+  tmp="$(mktemp "${spool_file}.XXXXXX")"
+  printf '%s' "$lines" >"$tmp"
+  if [[ -f "$spool_file" ]]; then
+    cat "$spool_file" >>"$tmp"
+  fi
+  mv "$tmp" "$spool_file"
+}
+
+bridge_tmux_pending_attention_prepend() {
+  local agent="$1"
+  local lines="$2"
+  [[ -n "$agent" ]] || return 1
+  [[ -n "$lines" ]] || return 0
+  bridge_tmux_pending_attention_with_lock "$agent" \
+    _bridge_tmux_pending_attention_prepend_locked "$lines"
+}
+
+bridge_tmux_pending_attention_count() {
+  local agent="$1"
+  local spool_file=""
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  [[ -f "$spool_file" ]] || { printf '0'; return 0; }
+  awk 'NF>0' "$spool_file" | wc -l | awk '{print $1}'
+}
+
+bridge_tmux_session_ring_bell() {
+  local session="$1"
+  [[ -n "$session" ]] || return 0
+  # Best-effort operator cue when an inject is deferred. Rationale for this
+  # exact mechanism: `tmux send-keys -l $'\a'` would feed BEL as keyboard
+  # input to the pane program, which Claude/Codex TUIs just absorb as
+  # Ctrl-G — the operator sees nothing. `display-message` is more reliable:
+  # tmux renders it on the status line of any attached client, which is a
+  # visible cue on its own. The embedded `\a` is kept on the hope that some
+  # clients' terminals still honor it; tmux may sanitize it, which is fine.
+  # The durable signal remains the spool file + the session-start context
+  # line added in hooks/bridge_hook_common.py::bootstrap_artifact_context.
+  tmux display-message -t "$(bridge_tmux_pane_target "$session")" \
+    $'\a[Agent Bridge] deferred event queued — input busy' \
+    >/dev/null 2>&1 || true
+}
+
+bridge_tmux_pending_attention_flush() {
+  local session="$1"
+  local engine="$2"
+  local agent="$3"
+  local max_defer="${BRIDGE_TMUX_INJECT_MAX_DEFER_SECONDS:-600}"
+  local drained=""
+  local now=""
+  local unflushed=""
+  local line=""
+  local ts=""
+  local escaped=""
+  local decoded=""
+  local age=0
+
+  [[ -n "$agent" ]] || return 0
+  bridge_tmux_spool_enabled "$agent" || return 0
+  drained="$(bridge_tmux_pending_attention_drain "$agent" || true)"
+  [[ -n "$drained" ]] || return 0
+
+  now="$(date +%s)"
+  [[ "$now" =~ ^[0-9]+$ ]] || now=0
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    ts="${line%%$'\t'*}"
+    escaped="${line#*$'\t'}"
+    decoded="$(bridge_tmux_pending_attention_unescape "$escaped")"
+    if [[ "$ts" =~ ^[0-9]+$ ]]; then
+      age=$((now - ts))
+      if (( age > max_defer )); then
+        decoded="[deferred] $decoded"
+      fi
+    else
+      # Unknown age — safer to warn the operator that the replay is stale
+      # than to present it as a live signal.
+      decoded="[deferred] $decoded"
+    fi
+
+    # Pass no agent so send_and_submit returns hard failure on busy instead
+    # of re-spooling. Remaining entries go back to the spool via prepend.
+    if bridge_tmux_send_and_submit "$session" "$engine" "$decoded"; then
+      continue
+    fi
+
+    unflushed+="$line"$'\n'
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      unflushed+="$line"$'\n'
+    done
+    break
+  done <<<"$drained"
+
+  if [[ -n "$unflushed" ]]; then
+    bridge_tmux_pending_attention_prepend "$agent" "$unflushed"
+    return 1
+  fi
+  return 0
 }
 
 bridge_capture_recent() {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -147,6 +147,153 @@ expect_idle "no prompt glyph anywhere" \
   $'just text, nothing composable'
 BASH_UT
 
+log "tmux pending-attention spool: escape/drain/prepend/deferral-cap (issue #132a)"
+"$BASH4_BIN" -s "$REPO_ROOT" <<'SPOOL_UT'
+set -u
+repo="$1"
+# shellcheck disable=SC1090
+source "$repo/bridge-lib.sh"
+
+fail() { printf '[smoke][error] spool: %s\n' "$*" >&2; exit 1; }
+
+scratch="$(mktemp -d)"
+export BRIDGE_HOME="$scratch"
+export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+agent="spool-test"
+
+# Round-trip escape/unescape over the four escape classes.
+for text in "plain" $'two\nlines' $'tab\there' "back\\slash" $'mixed\n\ta\\b'; do
+  esc="$(bridge_tmux_pending_attention_escape "$text")"
+  dec="$(bridge_tmux_pending_attention_unescape "$esc")"
+  if [[ "$dec" == "$text" ]]; then
+    printf '[smoke]   [ok] round-trip: %q\n' "$text"
+  else
+    fail "round-trip mismatch for: $(printf '%q' "$text") -> $(printf '%q' "$esc") -> $(printf '%q' "$dec")"
+  fi
+done
+
+# FIFO append/drain
+bridge_tmux_pending_attention_append "$agent" "first"
+bridge_tmux_pending_attention_append "$agent" "second"
+bridge_tmux_pending_attention_append "$agent" $'third\nwith-newline'
+count="$(bridge_tmux_pending_attention_count "$agent")"
+[[ "$count" == "3" ]] || fail "count after 3 appends: expected 3, got $count"
+printf '[smoke]   [ok] append: count=3\n'
+
+drained="$(bridge_tmux_pending_attention_drain "$agent")"
+[[ -n "$drained" ]] || fail "drain returned empty"
+# Expect 3 lines in FIFO order
+line1="$(printf '%s\n' "$drained" | sed -n '1p' | cut -f2)"
+line2="$(printf '%s\n' "$drained" | sed -n '2p' | cut -f2)"
+line3="$(printf '%s\n' "$drained" | sed -n '3p' | cut -f2)"
+[[ "$line1" == "first" ]] || fail "drain line1: expected 'first', got '$line1'"
+[[ "$line2" == "second" ]] || fail "drain line2: expected 'second', got '$line2'"
+[[ "$line3" == $'third\\nwith-newline' ]] || fail "drain line3: expected 'third\\\\nwith-newline', got '$line3'"
+printf '[smoke]   [ok] drain: FIFO order preserved, newline escaped\n'
+
+# Drain empties the spool
+count_after="$(bridge_tmux_pending_attention_count "$agent")"
+[[ "$count_after" == "0" ]] || fail "count after drain: expected 0, got $count_after"
+printf '[smoke]   [ok] drain: spool emptied\n'
+
+# Prepend preserves head insertion
+bridge_tmux_pending_attention_append "$agent" "new-A"
+bridge_tmux_pending_attention_append "$agent" "new-B"
+bridge_tmux_pending_attention_prepend "$agent" $'99\told-X\n99\told-Y\n'
+file="$(bridge_agent_pending_attention_file "$agent")"
+actual="$(cat "$file")"
+expected=$'99\told-X\n99\told-Y\n'"$(date +%s | head -c 10)"  # ts prefix will differ; check structurally
+head1="$(sed -n '1p' "$file" | cut -f2)"
+head2="$(sed -n '2p' "$file" | cut -f2)"
+tail1="$(sed -n '3p' "$file" | cut -f2)"
+tail2="$(sed -n '4p' "$file" | cut -f2)"
+[[ "$head1" == "old-X" && "$head2" == "old-Y" ]] \
+  || fail "prepend head: expected old-X,old-Y, got '$head1','$head2'"
+[[ "$tail1" == "new-A" && "$tail2" == "new-B" ]] \
+  || fail "prepend tail: expected new-A,new-B, got '$tail1','$tail2'"
+printf '[smoke]   [ok] prepend: head preserved, original tail intact\n'
+
+# Deferral-cap + flush requeue. Mock bridge_tmux_send_and_submit to avoid
+# needing a real tmux and drive the gate's bounce/accept from a state var.
+cap_agent="cap-test"
+
+# One fresh entry + one aged entry (ts = 0 = far in the past)
+now="$(date +%s)"
+bridge_tmux_pending_attention_append "$cap_agent" "fresh-event"
+fresh_file="$(bridge_agent_pending_attention_file "$cap_agent")"
+# Append a second record with an ancient timestamp by rewriting the file.
+cat >>"$fresh_file" <<'EOF'
+0	very-old-event
+EOF
+
+# Override the real tmux send path with a stub that succeeds and records
+# every injection that flush attempts.
+captured_log="$(mktemp)"
+bridge_tmux_send_and_submit() {
+  printf '%s\n' "$3" >>"$captured_log"
+  return 0
+}
+# Override wait-for-prompt and the gate so flush's internal send_and_submit
+# call (which uses them) is a no-op — but our function stub above shadows
+# send_and_submit anyway.
+bridge_tmux_pending_attention_flush "mock-session" claude "$cap_agent" \
+  || fail "flush returned non-zero with all-success stub"
+
+# Expect two lines in the capture log: "fresh-event" (no marker) and
+# "[deferred] very-old-event" (marker applied).
+line_fresh="$(sed -n '1p' "$captured_log")"
+line_aged="$(sed -n '2p' "$captured_log")"
+[[ "$line_fresh" == "fresh-event" ]] \
+  || fail "flush line 1: expected 'fresh-event', got '$line_fresh'"
+[[ "$line_aged" == "[deferred] very-old-event" ]] \
+  || fail "flush line 2: expected '[deferred] very-old-event', got '$line_aged'"
+printf '[smoke]   [ok] flush: deferral-cap marker applied to aged entry\n'
+
+# Spool empty after successful flush
+remaining="$(bridge_tmux_pending_attention_count "$cap_agent")"
+[[ "$remaining" == "0" ]] || fail "spool should be empty after flush, got $remaining"
+printf '[smoke]   [ok] flush: spool emptied after all entries delivered\n'
+
+# Requeue-on-busy: stub returns 1 on first call, success after that
+rm -f "$captured_log" "$fresh_file"
+bridge_tmux_pending_attention_append "$cap_agent" "entry-1"
+bridge_tmux_pending_attention_append "$cap_agent" "entry-2"
+bridge_tmux_pending_attention_append "$cap_agent" "entry-3"
+busy_count=0
+bridge_tmux_send_and_submit() {
+  busy_count=$((busy_count + 1))
+  printf '%s\n' "$3" >>"$captured_log"
+  # First call bounces (simulating busy gate), rest succeed. But flush
+  # treats a return 1 as "prepend remainder and stop", so we only expect
+  # one line in the log from this run.
+  if (( busy_count == 1 )); then
+    return 1
+  fi
+  return 0
+}
+bridge_tmux_pending_attention_flush "mock-session" claude "$cap_agent" \
+  && fail "flush should report 1 when gate bounces mid-drain"
+
+logged_lines="$(wc -l <"$captured_log" | awk '{print $1}')"
+[[ "$logged_lines" == "1" ]] \
+  || fail "flush should stop after first busy bounce, logged=$logged_lines"
+spooled_after="$(bridge_tmux_pending_attention_count "$cap_agent")"
+[[ "$spooled_after" == "3" ]] \
+  || fail "flush should re-prepend all 3 entries after bounce, got $spooled_after"
+head_after="$(sed -n '1p' "$fresh_file" | cut -f2)"
+[[ "$head_after" == "entry-1" ]] \
+  || fail "flush requeue: head should be entry-1, got '$head_after'"
+printf '[smoke]   [ok] flush: busy bounce re-prepends FIFO remainder\n'
+
+# Restore real send function for cleanliness if later code re-sources.
+unset -f bridge_tmux_send_and_submit
+rm -f "$captured_log"
+rm -rf "$scratch"
+SPOOL_UT
+
 TMP_ROOT="$(mktemp -d)"
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -147,6 +147,106 @@ expect_idle "no prompt glyph anywhere" \
   $'just text, nothing composable'
 BASH_UT
 
+log "injection metadata-only payload format (issue #132b)"
+# Self-contained coverage for bridge_format_injection_meta and the opt-in
+# flag. Placed early alongside the other #132* regressions.
+"$BASH4_BIN" -s "$REPO_ROOT" <<'META_UT'
+set -u
+repo="$1"
+# shellcheck disable=SC1090
+source "$repo/bridge-lib.sh"
+fail() { printf '[smoke][error] meta: %s\n' "$*" >&2; exit 1; }
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf '[smoke]   [ok] %s\n' "$label"
+  else
+    fail "$label: expected [$expected], got [$actual]"
+  fi
+}
+
+# Bare-token values preserve shape; quoted values only when necessary.
+assert_eq "meta bare" "[Agent Bridge] event=inbox count=3 top=X12 from=patch" \
+  "$(bridge_format_injection_meta inbox count=3 top=X12 from=patch)"
+assert_eq "meta quoted title with spaces" \
+  "[Agent Bridge] event=inbox count=1 top=Y55 title='fix docs typo' from=patch" \
+  "$(bridge_format_injection_meta inbox count=1 top=Y55 title='fix docs typo' from=patch)"
+assert_eq "meta empty value quoted" \
+  "[Agent Bridge] event=idle agent=worker-a from=''" \
+  "$(bridge_format_injection_meta idle agent=worker-a from=)"
+# Value with an embedded single quote uses '\''  escape
+assert_eq "meta single-quote escape" \
+  "[Agent Bridge] event=inbox title='it'\\''s fine'" \
+  "$(bridge_format_injection_meta inbox title="it's fine")"
+assert_eq "meta dot-dash-underscore bare" \
+  "[Agent Bridge] event=context-pressure agent=admin.1 severity=warning" \
+  "$(bridge_format_injection_meta context-pressure agent=admin.1 severity=warning)"
+# Embedded newline in value is folded to literal "\n" so the payload stays
+# on one logical line (protects parser from mis-splitting).
+assert_eq "meta newline folded to sentinel" \
+  "[Agent Bridge] event=inbox title='line-1\\nline-2'" \
+  "$(bridge_format_injection_meta inbox title="$(printf 'line-1\nline-2')")"
+
+# Flag gating — default off emits legacy text; on emits metadata-only.
+unset BRIDGE_INJECT_METADATA_ONLY
+default_text="$(bridge_queue_attention_message "claude-static" 2 X1 urgent "do the thing")"
+case "$default_text" in
+  *"ACTION REQUIRED"*"Run exactly"*) printf '[smoke]   [ok] flag off: legacy format retained\n' ;;
+  *) fail "flag off should emit legacy text, got: $default_text" ;;
+esac
+
+meta_text="$(BRIDGE_INJECT_METADATA_ONLY=1 bridge_queue_attention_message "claude-static" 2 X1 urgent "do the thing")"
+expected_meta="[Agent Bridge] event=inbox agent=claude-static count=2 top=X1 priority=urgent title='do the thing'"
+[[ "$meta_text" == "$expected_meta" ]] \
+  || fail "flag on: expected exact meta, got '$meta_text'"
+# $() strips trailing newlines — so re-run with explicit byte capture to
+# verify the payload really is single-line (no \n tail). Required coverage
+# per codex review: `wc -c` / `od -c` style byte check.
+meta_raw_file="$(mktemp)"
+BRIDGE_INJECT_METADATA_ONLY=1 bridge_queue_attention_message \
+  "claude-static" 2 X1 urgent "do the thing" >"$meta_raw_file"
+last_byte_octal="$(tail -c 1 "$meta_raw_file" | od -An -c | tr -d ' ')"
+# Expect the last byte to be the closing "'" of the quoted title, NOT \n.
+[[ "$last_byte_octal" == "'" ]] \
+  || fail "metadata-only must not end with newline; last byte octal: $last_byte_octal"
+rm -f "$meta_raw_file"
+printf '[smoke]   [ok] flag on: metadata-only single logical line, no trailing newline (byte-verified)\n'
+
+# Passthrough is GATED on the payload already being a metadata header. A
+# plain message must still go through bridge_notification_text wrapping so
+# the bridge-task.sh / bridge-send.sh / bridge-intake.sh / bridge-review.sh /
+# bridge-bundle.sh callers don't lose their legacy header under the flag.
+BRIDGE_INJECT_METADATA_ONLY=1
+# Shadow `bridge_tmux_send_and_submit` to capture the emitted text rather
+# than hitting tmux, then invoke dispatcher through the public helper.
+captured_text=""
+bridge_tmux_send_and_submit() { captured_text="$3"; return 0; }
+bridge_agent_engine() { printf 'claude'; }
+bridge_agent_session() { printf 'fake-session'; }
+bridge_tmux_session_exists() { return 0; }
+bridge_agent_has_wake_channel() { return 0; }
+bridge_claude_session_can_wake() { return 0; }
+bridge_claude_session_try_mark_prompt_ready() { return 0; }
+
+# Plain message (legacy caller style) — should get the legacy header wrap
+# even when the flag is on.
+bridge_dispatch_notification "claude-static" "review needed" "plain reviewer note." "" "normal" >/dev/null 2>&1 || true
+case "$captured_text" in
+  "[Agent Bridge]"*"plain reviewer note."*) \
+    printf '[smoke]   [ok] passthrough gate: plain message still gets legacy header wrap under flag\n' ;;
+  *) fail "plain msg under flag should get legacy header, got: $captured_text" ;;
+esac
+
+# Metadata-prefixed message should pass through unchanged.
+captured_text=""
+bridge_dispatch_notification "claude-static" "" "[Agent Bridge] event=inbox agent=claude-static count=1" "" "normal" >/dev/null 2>&1 || true
+case "$captured_text" in
+  "[Agent Bridge] event=inbox agent=claude-static count=1") \
+    printf '[smoke]   [ok] passthrough gate: metadata message passes through verbatim\n' ;;
+  *) fail "metadata msg should pass through, got: $captured_text" ;;
+esac
+META_UT
+
 log "tmux pending-attention spool: escape/drain/prepend/deferral-cap (issue #132a)"
 "$BASH4_BIN" -s "$REPO_ROOT" <<'SPOOL_UT'
 set -u

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -104,6 +104,49 @@ else
   log "shellcheck not installed; skipping"
 fi
 
+log "tmux inject gate: input-buffer-content detection (issue #132)"
+# Self-contained coverage for bridge_tmux_session_has_pending_input_from_text.
+# Placed early so the harness's downstream pre-existing failures do not gate
+# this regression check. Uses an in-process bash sourcing of bridge-lib.sh so
+# the tmux helper functions become invokable without a real tmux session.
+"$BASH4_BIN" -s "$REPO_ROOT" <<'BASH_UT'
+set -u
+repo="$1"
+# shellcheck disable=SC1090
+source "$repo/bridge-lib.sh"
+fail() { printf '[smoke][error] inject-gate: %s\n' "$*" >&2; exit 1; }
+expect_pending() {
+  local label="$1"
+  local text="$2"
+  if bridge_tmux_session_has_pending_input_from_text claude "$text"; then
+    printf '[smoke]   [ok] %s\n' "$label"
+  else
+    fail "expected PENDING for: $label"
+  fi
+}
+expect_idle() {
+  local label="$1"
+  local text="$2"
+  if bridge_tmux_session_has_pending_input_from_text claude "$text"; then
+    fail "expected idle for: $label"
+  else
+    printf '[smoke]   [ok] %s\n' "$label"
+  fi
+}
+expect_pending "operator composing single word (> glyph)" \
+  $'some prior agent output\n> hello'
+expect_pending "operator composing (❯ glyph)" \
+  $'some prior agent output\n❯ thinking about this...'
+expect_pending "operator composing after scrollback quote" \
+  $'agent output\n> an earlier quoted line\nmore agent output\n> typed input'
+expect_idle "empty input box at bottom" \
+  $'agent output\n> an earlier quoted line\nmore agent output\n> '
+expect_idle "numbered-menu blocker (not a compose state)" \
+  $'Do you trust the files in this folder?\n> 1. Yes, proceed\n  2. No, exit'
+expect_idle "no prompt glyph anywhere" \
+  $'just text, nothing composable'
+BASH_UT
+
 TMP_ROOT="$(mktemp -d)"
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"


### PR DESCRIPTION
## Summary

Stacked on PR #136 (`fix/132a-pending-attention-spool`). Axis B part 1 of issue #132 — introduces a metadata-only daemon injection payload shape + `format_injection` helper + opt-in flag. Default keeps the legacy execution-verb text. Maintainer flips `BRIDGE_INJECT_METADATA_ONLY=1` only after the agent-side handler skill ships in a parallel PR (`fix/132c-external-push-policy`).

## Legacy vs. new payload

```
legacy:     [Agent Bridge] ACTION REQUIRED — queued tasks detected.
            Run exactly: ~/.agent-bridge/agb inbox <agent>

metadata:   [Agent Bridge] event=inbox agent=<agent> count=<n> top=<id>
            priority=<p> title='<title>'
```

## Why the flag gate

Flipping the payload without agents having a handler would leave them parsing unfamiliar text. The shared skill in `fix/132c-external-push-policy` defines the 7-step handling routine. Merge sequence: #135 → #136 → this PR → #132c → THEN set the flag.

## Changes

- **`lib/bridge-notify.sh`**:
  - `bridge_inject_metadata_only_enabled()` reads the flag.
  - `bridge_inject_meta_escape_value(v)` — bare when `v` matches `^[A-Za-z0-9._/@:-]+$`, otherwise single-quoted with `'\''` escape for embedded single quotes. CR stripped, LF folded to literal `\n` sentinel so the payload is guaranteed single-line.
  - `bridge_format_injection_meta(kind, k=v …)` — emits `[Agent Bridge] event=<kind> k=<escaped> …`.
  - `bridge_queue_attention_message` branches on the flag; metadata branch emits one logical line with NO trailing newline.
  - `bridge_dispatch_notification` passthrough GATED on `$message` starting with `[Agent Bridge] event=` so plain callers (`bridge-task.sh`, `bridge-send.sh`, `bridge-intake.sh`, `bridge-review.sh`, `bridge-bundle.sh`) still get legacy header wrapping under the flag.
- **`bridge-run.sh`**: inbox-bootstrap injection branches on the flag; metadata form uses `event=inbox-bootstrap agent=<a> top=<id>`.
- **`scripts/smoke-test.sh`**: 10 new assertions — bare/quoted/empty/single-quote-escape/extended-char payload shapes, newline folded to `\n`, flag gating (legacy vs. metadata), passthrough gate (plain-under-flag still wraps; metadata-prefixed passes verbatim), byte-verified no-trailing-newline (`tail -c 1` + `od`).

## Intentionally NOT migrated

- **Stall wake** (`bridge_send_stall_nudge`) — its message format carries stall-detection context from `bridge_stall_nudge_message`, no clean metadata mapping; kept legacy.
- **`/new` control command** (`bridge-daemon.sh`) — not a queue event.
- **Other `bridge_notification_text` callers** — `bridge-task.sh`, `bridge-send.sh`, etc. already emit plain header-only text, no execution verb to strip.

## Conflict with existing skill (resolved in #132c)

The shipped `agent-bridge-runtime` skill still says "When you see `[Agent Bridge]`, run exact `agb inbox`." That policy contradicts the delegate-via-subagent redesign. `fix/132c-external-push-policy` replaces/adjusts the skill. Do NOT flip the flag before #132c lands.

## Test plan

- [x] `bash -n` clean on touched shell files.
- [x] `./scripts/smoke-test.sh` — 10 new `#132b` assertions pass; byte-verified no-trailing-newline. Script then dies at the pre-existing `[smoke] creating queue task` unrelated failure.
- [x] `shellcheck` — skipped (not installed on host).
- [x] Flag gating traced: flag off → legacy byte-identical wake text; flag on → metadata-only single line; plain message under flag → still wrapped with legacy header.

## Codex review trail (3 rounds, read-only `codex exec`)

1. **R1** (plan + code): flagged (a) mixed double-header wake path because `bridge_dispatch_notification` wraps `$message` via `bridge_notification_text`, (b) call-site scope questions, (c) shell-quote vs. simpler escape (non-blocker, kept).
2. **R2** (post-passthrough-fix): flagged (a) passthrough too broad — strips legacy header from all shared-helper callers, (b) trailing `\n` from `printf` in metadata branch creates a 2-event payload, (c) embedded newline in value. All three fixed.
3. **R3** (v3 confirm): **LGTM** with a single test-gap note — `$()` strips trailing newlines so the "no trailing newline" assertion didn't actually verify it. Fixed with `tail -c 1 | od` byte check.

## Follow-ups tracked separately

- `#132c` (parallel): agent policy text + shared skill + 7-step handling routine.
- `#132d` (hypothetical): parser for metadata payload + subagent dispatch primitive (lives in the agent's handler skill, not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)