### PR TITLE
feat: pending-attention spool + daemon flush (Axis A remainder of #132)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -910,7 +910,7 @@ bridge_send_stall_nudge() {
   local text=""
 
   text="$(bridge_notification_text "stall detected" "$(bridge_stall_nudge_message "$classification")" "" normal)"
-  bridge_tmux_send_and_submit "$session" "$engine" "$text"
+  bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"
 }
 
 process_stall_reports() {
@@ -2102,6 +2102,30 @@ PY
   daemon_info "nudged ${agent} (queued=${live_queued}, claimed=${live_claimed}, idle=${idle}s)"
 }
 
+flush_pending_attention_spools() {
+  # Issue #132a: per-sync-pass flush of the per-agent pending-attention spool.
+  # Covers every engine that the tmux inject gate applies to (claude + codex)
+  # so a busy Codex session does not permanently accumulate entries either.
+  # The flush itself is bounded by the spool size and skips over agents with
+  # empty spools in O(1).
+  local agent=""
+  local session=""
+  local engine=""
+  local count=0
+
+  for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+    engine="$(bridge_agent_engine "$agent")"
+    [[ -n "$engine" ]] || continue
+    session="$(bridge_agent_session "$agent")"
+    [[ -n "$session" ]] || continue
+    bridge_tmux_session_exists "$session" || continue
+    count="$(bridge_tmux_pending_attention_count "$agent" 2>/dev/null || printf '0')"
+    [[ "$count" =~ ^[0-9]+$ ]] || count=0
+    (( count > 0 )) || continue
+    bridge_tmux_pending_attention_flush "$session" "$engine" "$agent" >/dev/null 2>&1 || true
+  done
+}
+
 recover_claude_bootstrap_blockers() {
   local agent
   local session
@@ -3118,6 +3142,7 @@ cmd_sync_cycle() {
   fi
   bridge_reconcile_idle_markers || true
   recover_claude_bootstrap_blockers || true
+  flush_pending_attention_spools || true
   process_channel_health || true
   process_plugin_liveness || true
 

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -279,7 +279,7 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
         if [[ ! -f "$next_file" && ! -f "$marker_file" ]]; then
           task_id="$(bridge_queue_cli find-open --agent "$agent" 2>/dev/null | head -n 1 || true)"
           if [[ -n "$task_id" ]]; then
-            bridge_tmux_send_and_submit "$session" claude "[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent"
+            bridge_tmux_send_and_submit "$session" claude "[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent" "$agent"
           fi
           mkdir -p "$(dirname "$marker_file")"
           printf "%s\n" "$(date +%s)" >"$marker_file"

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -245,6 +245,26 @@ def bootstrap_artifact_context(agent: str) -> str:
             "Stay in onboarding flow until it is complete before doing unrelated work."
         )
 
+    # Issue #132a: surface any pending-attention spool entries queued while the
+    # agent was busy so the operator knows replays will follow once the input
+    # box becomes idle. The spool path mirrors lib/bridge-state.sh.
+    spool_path = (
+        bridge_state_dir() / "agents" / agent / "pending-attention.env"
+    )
+    try:
+        pending_count = sum(
+            1
+            for line in spool_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+    except (OSError, UnicodeDecodeError):
+        pending_count = 0
+    if pending_count > 0:
+        lines.append(
+            f"Agent Bridge has {pending_count} queued external event(s); "
+            "they will replay into this session as the input box becomes idle."
+        )
+
     if not lines:
         return ""
     return "\n".join(lines)

--- a/lib/bridge-notify.sh
+++ b/lib/bridge-notify.sh
@@ -159,7 +159,9 @@ bridge_dispatch_notification() {
       fi
 
       text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
-      if bridge_tmux_send_and_submit "$session" "$engine" "$text"; then
+      # Issue #132a: pass $agent so a busy gate at inject time routes through
+      # the pending-attention spool instead of silently dropping the wake.
+      if bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"; then
         return 0
       fi
       bridge_warn "Claude idle wake delivery failed for '${agent}'"
@@ -176,7 +178,7 @@ bridge_dispatch_notification() {
         return 1
       fi
       text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
-      bridge_tmux_send_and_submit "$session" "$engine" "$text"
+      bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"
       ;;
   esac
 }

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1090,6 +1090,16 @@ bridge_agent_next_session_marker_file() {
   printf '%s/next-session.sha' "$(bridge_agent_runtime_state_dir "$agent")"
 }
 
+bridge_agent_pending_attention_file() {
+  local agent="$1"
+  printf '%s/pending-attention.env' "$(bridge_agent_runtime_state_dir "$agent")"
+}
+
+bridge_agent_pending_attention_lock_dir() {
+  local agent="$1"
+  printf '%s/pending-attention.lock' "$(bridge_agent_runtime_state_dir "$agent")"
+}
+
 bridge_agent_initial_inbox_marker_file() {
   local agent="$1"
   printf '%s/initial-inbox.started' "$(bridge_agent_runtime_state_dir "$agent")"

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -451,6 +451,12 @@ bridge_tmux_send_and_submit() {
   local session="$1"
   local engine="$2"
   local text="$3"
+  # Issue #132a: optional 4th arg turns on the pending-attention spool so a
+  # busy-gate hit no longer silently drops the event. Unspecified → legacy
+  # hard-failure behavior for callers that want immediate operator feedback
+  # (e.g., bridge-action.sh: the operator ran `agb send` and should see
+  # the failure rather than a background deferral).
+  local spool_agent="${4:-}"
   # Issue #132: previous default was 3s. Operators frequently pause >3s while
   # composing (reading, thinking, switching windows), which left a window for
   # daemon injections to land mid-compose. The input-buffer-content check
@@ -462,9 +468,19 @@ bridge_tmux_send_and_submit() {
 
   if ! bridge_tmux_wait_for_prompt "$session" "$engine"; then
     bridge_warn "session prompt unavailable; skipping send to '$session'"
+    if bridge_tmux_spool_enabled "$spool_agent"; then
+      bridge_tmux_pending_attention_append "$spool_agent" "$text"
+      bridge_tmux_session_ring_bell "$session"
+      return 0
+    fi
     return 1
   fi
   if bridge_tmux_session_inject_busy "$session" "$engine" "$inject_grace"; then
+    if bridge_tmux_spool_enabled "$spool_agent"; then
+      bridge_tmux_pending_attention_append "$spool_agent" "$text"
+      bridge_tmux_session_ring_bell "$session"
+      return 0
+    fi
     bridge_warn "session busy; deferring send to '$session'"
     return 1
   fi
@@ -477,6 +493,239 @@ bridge_tmux_send_and_submit() {
       bridge_tmux_paste_and_submit "$session" "$text"
       ;;
   esac
+}
+
+# ---------------------------------------------------------------------------
+# Issue #132a: pending-attention spool.
+#
+# When a daemon-initiated inject hits the busy gate, rather than silently
+# dropping it, the text is escaped and appended to the per-agent spool file
+# (bridge_agent_pending_attention_file). A subsequent daemon pass calls
+# bridge_tmux_pending_attention_flush, which drains the spool in FIFO order
+# and re-injects while the gate is clear. Entries aged past
+# BRIDGE_TMUX_INJECT_MAX_DEFER_SECONDS (default 600s) get a `[deferred]`
+# marker so the operator can see they are older than a live signal.
+#
+# The lock is a mkdir spinlock (matches the repo's existing convention in
+# lib/bridge-channels.sh::bridge_allocate_dynamic_webhook_port) so the path
+# works on Linux and macOS without requiring `flock`.
+# ---------------------------------------------------------------------------
+
+bridge_tmux_spool_enabled() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  [[ "${BRIDGE_TMUX_INJECT_SPOOL_ENABLED:-1}" == "1" ]] || return 1
+  return 0
+}
+
+bridge_tmux_pending_attention_escape() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+  text="${text//$'\t'/\\t}"
+  text="${text//$'\r'/\\r}"
+  text="${text//$'\n'/\\n}"
+  printf '%s' "$text"
+}
+
+bridge_tmux_pending_attention_unescape() {
+  local text="$1"
+  local out=""
+  local i=0
+  local ch=""
+  local next=""
+  local len=${#text}
+  while (( i < len )); do
+    ch="${text:$i:1}"
+    if [[ "$ch" == "\\" && $((i + 1)) -lt $len ]]; then
+      next="${text:$((i + 1)):1}"
+      case "$next" in
+        n) out+=$'\n' ;;
+        r) out+=$'\r' ;;
+        t) out+=$'\t' ;;
+        \\) out+=$'\\' ;;
+        *) out+="\\$next" ;;
+      esac
+      i=$((i + 2))
+    else
+      out+="$ch"
+      i=$((i + 1))
+    fi
+  done
+  printf '%s' "$out"
+}
+
+bridge_tmux_pending_attention_with_lock() {
+  local agent="$1"
+  local action="$2"
+  shift 2
+  local lock_dir=""
+  local attempts=0
+  local max_attempts=200
+  local rc=0
+
+  lock_dir="$(bridge_agent_pending_attention_lock_dir "$agent")"
+  mkdir -p "$(dirname "$lock_dir")"
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if (( attempts >= max_attempts )); then
+      bridge_warn "pending-attention lock stuck for '$agent'; forcing"
+      rmdir "$lock_dir" >/dev/null 2>&1 || true
+    fi
+    sleep 0.05
+  done
+
+  "$action" "$agent" "$@"
+  rc=$?
+  rmdir "$lock_dir" >/dev/null 2>&1 || true
+  return $rc
+}
+
+_bridge_tmux_pending_attention_append_locked() {
+  local agent="$1"
+  local text="$2"
+  local spool_file=""
+  local escaped=""
+  local ts=""
+
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  mkdir -p "$(dirname "$spool_file")"
+  ts="$(date +%s)"
+  escaped="$(bridge_tmux_pending_attention_escape "$text")"
+  printf '%s\t%s\n' "$ts" "$escaped" >>"$spool_file"
+}
+
+bridge_tmux_pending_attention_append() {
+  local agent="$1"
+  local text="$2"
+  [[ -n "$agent" ]] || return 1
+  bridge_tmux_pending_attention_with_lock "$agent" \
+    _bridge_tmux_pending_attention_append_locked "$text"
+}
+
+_bridge_tmux_pending_attention_drain_locked() {
+  local agent="$1"
+  local spool_file=""
+
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  [[ -f "$spool_file" ]] || return 0
+  cat "$spool_file"
+  : >"$spool_file"
+}
+
+bridge_tmux_pending_attention_drain() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  bridge_tmux_pending_attention_with_lock "$agent" \
+    _bridge_tmux_pending_attention_drain_locked
+}
+
+_bridge_tmux_pending_attention_prepend_locked() {
+  local agent="$1"
+  local lines="$2"
+  local spool_file=""
+  local tmp=""
+
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  mkdir -p "$(dirname "$spool_file")"
+  tmp="$(mktemp "${spool_file}.XXXXXX")"
+  printf '%s' "$lines" >"$tmp"
+  if [[ -f "$spool_file" ]]; then
+    cat "$spool_file" >>"$tmp"
+  fi
+  mv "$tmp" "$spool_file"
+}
+
+bridge_tmux_pending_attention_prepend() {
+  local agent="$1"
+  local lines="$2"
+  [[ -n "$agent" ]] || return 1
+  [[ -n "$lines" ]] || return 0
+  bridge_tmux_pending_attention_with_lock "$agent" \
+    _bridge_tmux_pending_attention_prepend_locked "$lines"
+}
+
+bridge_tmux_pending_attention_count() {
+  local agent="$1"
+  local spool_file=""
+  spool_file="$(bridge_agent_pending_attention_file "$agent")"
+  [[ -f "$spool_file" ]] || { printf '0'; return 0; }
+  awk 'NF>0' "$spool_file" | wc -l | awk '{print $1}'
+}
+
+bridge_tmux_session_ring_bell() {
+  local session="$1"
+  [[ -n "$session" ]] || return 0
+  # Best-effort operator cue when an inject is deferred. Rationale for this
+  # exact mechanism: `tmux send-keys -l $'\a'` would feed BEL as keyboard
+  # input to the pane program, which Claude/Codex TUIs just absorb as
+  # Ctrl-G — the operator sees nothing. `display-message` is more reliable:
+  # tmux renders it on the status line of any attached client, which is a
+  # visible cue on its own. The embedded `\a` is kept on the hope that some
+  # clients' terminals still honor it; tmux may sanitize it, which is fine.
+  # The durable signal remains the spool file + the session-start context
+  # line added in hooks/bridge_hook_common.py::bootstrap_artifact_context.
+  tmux display-message -t "$(bridge_tmux_pane_target "$session")" \
+    $'\a[Agent Bridge] deferred event queued — input busy' \
+    >/dev/null 2>&1 || true
+}
+
+bridge_tmux_pending_attention_flush() {
+  local session="$1"
+  local engine="$2"
+  local agent="$3"
+  local max_defer="${BRIDGE_TMUX_INJECT_MAX_DEFER_SECONDS:-600}"
+  local drained=""
+  local now=""
+  local unflushed=""
+  local line=""
+  local ts=""
+  local escaped=""
+  local decoded=""
+  local age=0
+
+  [[ -n "$agent" ]] || return 0
+  bridge_tmux_spool_enabled "$agent" || return 0
+  drained="$(bridge_tmux_pending_attention_drain "$agent" || true)"
+  [[ -n "$drained" ]] || return 0
+
+  now="$(date +%s)"
+  [[ "$now" =~ ^[0-9]+$ ]] || now=0
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    ts="${line%%$'\t'*}"
+    escaped="${line#*$'\t'}"
+    decoded="$(bridge_tmux_pending_attention_unescape "$escaped")"
+    if [[ "$ts" =~ ^[0-9]+$ ]]; then
+      age=$((now - ts))
+      if (( age > max_defer )); then
+        decoded="[deferred] $decoded"
+      fi
+    else
+      # Unknown age — safer to warn the operator that the replay is stale
+      # than to present it as a live signal.
+      decoded="[deferred] $decoded"
+    fi
+
+    # Pass no agent so send_and_submit returns hard failure on busy instead
+    # of re-spooling. Remaining entries go back to the spool via prepend.
+    if bridge_tmux_send_and_submit "$session" "$engine" "$decoded"; then
+      continue
+    fi
+
+    unflushed+="$line"$'\n'
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      unflushed+="$line"$'\n'
+    done
+    break
+  done <<<"$drained"
+
+  if [[ -n "$unflushed" ]]; then
+    bridge_tmux_pending_attention_prepend "$agent" "$unflushed"
+    return 1
+  fi
+  return 0
 }
 
 bridge_capture_recent() {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -186,6 +186,153 @@ expect_idle "no prompt glyph anywhere" \
   $'just text, nothing composable'
 BASH_UT
 
+log "tmux pending-attention spool: escape/drain/prepend/deferral-cap (issue #132a)"
+"$BASH4_BIN" -s "$REPO_ROOT" <<'SPOOL_UT'
+set -u
+repo="$1"
+# shellcheck disable=SC1090
+source "$repo/bridge-lib.sh"
+
+fail() { printf '[smoke][error] spool: %s\n' "$*" >&2; exit 1; }
+
+scratch="$(mktemp -d)"
+export BRIDGE_HOME="$scratch"
+export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+agent="spool-test"
+
+# Round-trip escape/unescape over the four escape classes.
+for text in "plain" $'two\nlines' $'tab\there' "back\\slash" $'mixed\n\ta\\b'; do
+  esc="$(bridge_tmux_pending_attention_escape "$text")"
+  dec="$(bridge_tmux_pending_attention_unescape "$esc")"
+  if [[ "$dec" == "$text" ]]; then
+    printf '[smoke]   [ok] round-trip: %q\n' "$text"
+  else
+    fail "round-trip mismatch for: $(printf '%q' "$text") -> $(printf '%q' "$esc") -> $(printf '%q' "$dec")"
+  fi
+done
+
+# FIFO append/drain
+bridge_tmux_pending_attention_append "$agent" "first"
+bridge_tmux_pending_attention_append "$agent" "second"
+bridge_tmux_pending_attention_append "$agent" $'third\nwith-newline'
+count="$(bridge_tmux_pending_attention_count "$agent")"
+[[ "$count" == "3" ]] || fail "count after 3 appends: expected 3, got $count"
+printf '[smoke]   [ok] append: count=3\n'
+
+drained="$(bridge_tmux_pending_attention_drain "$agent")"
+[[ -n "$drained" ]] || fail "drain returned empty"
+# Expect 3 lines in FIFO order
+line1="$(printf '%s\n' "$drained" | sed -n '1p' | cut -f2)"
+line2="$(printf '%s\n' "$drained" | sed -n '2p' | cut -f2)"
+line3="$(printf '%s\n' "$drained" | sed -n '3p' | cut -f2)"
+[[ "$line1" == "first" ]] || fail "drain line1: expected 'first', got '$line1'"
+[[ "$line2" == "second" ]] || fail "drain line2: expected 'second', got '$line2'"
+[[ "$line3" == $'third\\nwith-newline' ]] || fail "drain line3: expected 'third\\\\nwith-newline', got '$line3'"
+printf '[smoke]   [ok] drain: FIFO order preserved, newline escaped\n'
+
+# Drain empties the spool
+count_after="$(bridge_tmux_pending_attention_count "$agent")"
+[[ "$count_after" == "0" ]] || fail "count after drain: expected 0, got $count_after"
+printf '[smoke]   [ok] drain: spool emptied\n'
+
+# Prepend preserves head insertion
+bridge_tmux_pending_attention_append "$agent" "new-A"
+bridge_tmux_pending_attention_append "$agent" "new-B"
+bridge_tmux_pending_attention_prepend "$agent" $'99\told-X\n99\told-Y\n'
+file="$(bridge_agent_pending_attention_file "$agent")"
+actual="$(cat "$file")"
+expected=$'99\told-X\n99\told-Y\n'"$(date +%s | head -c 10)"  # ts prefix will differ; check structurally
+head1="$(sed -n '1p' "$file" | cut -f2)"
+head2="$(sed -n '2p' "$file" | cut -f2)"
+tail1="$(sed -n '3p' "$file" | cut -f2)"
+tail2="$(sed -n '4p' "$file" | cut -f2)"
+[[ "$head1" == "old-X" && "$head2" == "old-Y" ]] \
+  || fail "prepend head: expected old-X,old-Y, got '$head1','$head2'"
+[[ "$tail1" == "new-A" && "$tail2" == "new-B" ]] \
+  || fail "prepend tail: expected new-A,new-B, got '$tail1','$tail2'"
+printf '[smoke]   [ok] prepend: head preserved, original tail intact\n'
+
+# Deferral-cap + flush requeue. Mock bridge_tmux_send_and_submit to avoid
+# needing a real tmux and drive the gate's bounce/accept from a state var.
+cap_agent="cap-test"
+
+# One fresh entry + one aged entry (ts = 0 = far in the past)
+now="$(date +%s)"
+bridge_tmux_pending_attention_append "$cap_agent" "fresh-event"
+fresh_file="$(bridge_agent_pending_attention_file "$cap_agent")"
+# Append a second record with an ancient timestamp by rewriting the file.
+cat >>"$fresh_file" <<'EOF'
+0	very-old-event
+EOF
+
+# Override the real tmux send path with a stub that succeeds and records
+# every injection that flush attempts.
+captured_log="$(mktemp)"
+bridge_tmux_send_and_submit() {
+  printf '%s\n' "$3" >>"$captured_log"
+  return 0
+}
+# Override wait-for-prompt and the gate so flush's internal send_and_submit
+# call (which uses them) is a no-op — but our function stub above shadows
+# send_and_submit anyway.
+bridge_tmux_pending_attention_flush "mock-session" claude "$cap_agent" \
+  || fail "flush returned non-zero with all-success stub"
+
+# Expect two lines in the capture log: "fresh-event" (no marker) and
+# "[deferred] very-old-event" (marker applied).
+line_fresh="$(sed -n '1p' "$captured_log")"
+line_aged="$(sed -n '2p' "$captured_log")"
+[[ "$line_fresh" == "fresh-event" ]] \
+  || fail "flush line 1: expected 'fresh-event', got '$line_fresh'"
+[[ "$line_aged" == "[deferred] very-old-event" ]] \
+  || fail "flush line 2: expected '[deferred] very-old-event', got '$line_aged'"
+printf '[smoke]   [ok] flush: deferral-cap marker applied to aged entry\n'
+
+# Spool empty after successful flush
+remaining="$(bridge_tmux_pending_attention_count "$cap_agent")"
+[[ "$remaining" == "0" ]] || fail "spool should be empty after flush, got $remaining"
+printf '[smoke]   [ok] flush: spool emptied after all entries delivered\n'
+
+# Requeue-on-busy: stub returns 1 on first call, success after that
+rm -f "$captured_log" "$fresh_file"
+bridge_tmux_pending_attention_append "$cap_agent" "entry-1"
+bridge_tmux_pending_attention_append "$cap_agent" "entry-2"
+bridge_tmux_pending_attention_append "$cap_agent" "entry-3"
+busy_count=0
+bridge_tmux_send_and_submit() {
+  busy_count=$((busy_count + 1))
+  printf '%s\n' "$3" >>"$captured_log"
+  # First call bounces (simulating busy gate), rest succeed. But flush
+  # treats a return 1 as "prepend remainder and stop", so we only expect
+  # one line in the log from this run.
+  if (( busy_count == 1 )); then
+    return 1
+  fi
+  return 0
+}
+bridge_tmux_pending_attention_flush "mock-session" claude "$cap_agent" \
+  && fail "flush should report 1 when gate bounces mid-drain"
+
+logged_lines="$(wc -l <"$captured_log" | awk '{print $1}')"
+[[ "$logged_lines" == "1" ]] \
+  || fail "flush should stop after first busy bounce, logged=$logged_lines"
+spooled_after="$(bridge_tmux_pending_attention_count "$cap_agent")"
+[[ "$spooled_after" == "3" ]] \
+  || fail "flush should re-prepend all 3 entries after bounce, got $spooled_after"
+head_after="$(sed -n '1p' "$fresh_file" | cut -f2)"
+[[ "$head_after" == "entry-1" ]] \
+  || fail "flush requeue: head should be entry-1, got '$head_after'"
+printf '[smoke]   [ok] flush: busy bounce re-prepends FIFO remainder\n'
+
+# Restore real send function for cleanliness if later code re-sources.
+unset -f bridge_tmux_send_and_submit
+rm -f "$captured_log"
+rm -rf "$scratch"
+SPOOL_UT
+
 TMP_ROOT="$(mktemp -d)"
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"


### PR DESCRIPTION
Reopened from #136 after base branch was deleted by merge of #135. Single commit rebased onto current main. See #136 for original review trail.

Codex review: 2 rounds, LGTM. See #136 description for full notes.