### PR TITLE
feat: metadata-only injection payload helper + opt-in flag (Axis B part 1 of #132)

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -279,7 +279,12 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
         if [[ ! -f "$next_file" && ! -f "$marker_file" ]]; then
           task_id="$(bridge_queue_cli find-open --agent "$agent" 2>/dev/null | head -n 1 || true)"
           if [[ -n "$task_id" ]]; then
-            bridge_tmux_send_and_submit "$session" claude "[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent" "$agent"
+            if bridge_inject_metadata_only_enabled; then
+              inject_text="$(bridge_format_injection_meta inbox-bootstrap agent="$agent" top="$task_id")"
+            else
+              inject_text="[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent"
+            fi
+            bridge_tmux_send_and_submit "$session" claude "$inject_text" "$agent"
           fi
           mkdir -p "$(dirname "$marker_file")"
           printf "%s\n" "$(date +%s)" >"$marker_file"

--- a/lib/bridge-notify.sh
+++ b/lib/bridge-notify.sh
@@ -109,6 +109,73 @@ bridge_notification_text() {
   printf '%s' "$header"
 }
 
+# ---------------------------------------------------------------------------
+# Issue #132b: metadata-only injection payload helper.
+#
+# Legacy injections embed an execution verb
+# ("Run exactly: ~/.agent-bridge/agb inbox $agent"). The redesigned payload
+# is metadata-only so the main agent can parse the event, read the task
+# spec via `agb show-task`, compose its own subagent prompt with acceptance
+# criteria, dispatch via Task, verify, and report one line — keeping the
+# main context clean. See upstream #132 Axis B and the external-push-handling
+# shared skill (#132c) for the handling routine.
+#
+# This PR adds the helper + opt-in flag only. Call sites emit legacy output
+# unless BRIDGE_INJECT_METADATA_ONLY=1. Flip the flag only after the
+# external-push-handling skill is shipped — otherwise agents would receive
+# metadata without a handler.
+#
+# Payload shape:
+#   [Agent Bridge] event=inbox count=3 top=X12 title='fix docs typo' from=patch
+#
+# Value encoding: bare token for letters/digits/.-_@:/, otherwise
+# single-quoted with '\'' escape for embedded single quotes.
+# ---------------------------------------------------------------------------
+
+bridge_inject_metadata_only_enabled() {
+  [[ "${BRIDGE_INJECT_METADATA_ONLY:-0}" == "1" ]]
+}
+
+bridge_inject_meta_escape_value() {
+  local v="$1"
+  if [[ -z "$v" ]]; then
+    printf "''"
+    return 0
+  fi
+  # Metadata injections are a single logical line — so any embedded CR/LF in
+  # a value (e.g., a task title that survived `.strip()` but contained a
+  # newline) must be folded to an ASCII sentinel to avoid producing a
+  # payload the parser would split into two events. The "\\n" sentinel is
+  # chosen so a consumer can reliably reverse it when displaying the title.
+  v="${v//$'\r'/}"
+  v="${v//$'\n'/\\n}"
+  if [[ "$v" =~ ^[A-Za-z0-9._/@:-]+$ ]]; then
+    printf '%s' "$v"
+    return 0
+  fi
+  local escaped="${v//\'/\'\\\'\'}"
+  printf "'%s'" "$escaped"
+}
+
+bridge_format_injection_meta() {
+  # Usage: bridge_format_injection_meta <kind> [<key>=<val> ...]
+  # Emits: [Agent Bridge] event=<kind> <key>=<escaped-val> ...
+  local kind="$1"
+  shift
+  local out="[Agent Bridge] event="
+  out+="$(bridge_inject_meta_escape_value "$kind")"
+  local pair=""
+  local key=""
+  local val=""
+  for pair in "$@"; do
+    key="${pair%%=*}"
+    val="${pair#*=}"
+    [[ -n "$key" ]] || continue
+    out+=" ${key}=$(bridge_inject_meta_escape_value "$val")"
+  done
+  printf '%s' "$out"
+}
+
 bridge_queue_attention_title() {
   local queued="$1"
   printf '%s' "ACTION REQUIRED — queued tasks (${queued})"
@@ -120,6 +187,21 @@ bridge_queue_attention_message() {
   local task_id="${3:-}"
   local task_priority="${4:-normal}"
   local task_title="${5:-}"
+
+  if bridge_inject_metadata_only_enabled; then
+    # Issue #132b: no execution verb; main agent parses metadata and drives
+    # the flow via the external-push-handling shared skill (#132c). Emit a
+    # single logical line — no trailing newline — so the injected payload is
+    # one event, not two (the blank follow-up would otherwise be read as a
+    # separate message by the injection path).
+    bridge_format_injection_meta inbox \
+      agent="$agent" \
+      count="$queued" \
+      top="${task_id:-}" \
+      priority="$task_priority" \
+      title="${task_title:-}"
+    return 0
+  fi
 
   printf '[Agent Bridge] %s pending task(s) for %s.\n' "$queued" "$agent"
   if [[ -n "$task_id" && -n "$task_title" ]]; then
@@ -158,7 +240,20 @@ bridge_dispatch_notification() {
         fi
       fi
 
-      text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
+      # Issue #132b: bridge_dispatch_notification is a shared helper called
+      # from many places (bridge-task.sh, bridge-send.sh, bridge-intake.sh,
+      # bridge-review.sh, bridge-bundle.sh) with PLAIN messages that still
+      # need the legacy header. Only skip header-wrapping when the caller
+      # has already produced a metadata payload — i.e., $message begins
+      # with the "[Agent Bridge] event=" header emitted by
+      # bridge_format_injection_meta. This keeps legacy callers' output
+      # byte-identical even when the flag is on.
+      if bridge_inject_metadata_only_enabled \
+         && [[ "$message" == "[Agent Bridge] event="* ]]; then
+        text="$message"
+      else
+        text="$(bridge_notification_text "$title" "$message" "$task_id" "$priority")"
+      fi
       # Issue #132a: pass $agent so a busy gate at inject time routes through
       # the pending-attention spool instead of silently dropping the wake.
       if bridge_tmux_send_and_submit "$session" "$engine" "$text" "$agent"; then

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -186,6 +186,106 @@ expect_idle "no prompt glyph anywhere" \
   $'just text, nothing composable'
 BASH_UT
 
+log "injection metadata-only payload format (issue #132b)"
+# Self-contained coverage for bridge_format_injection_meta and the opt-in
+# flag. Placed early alongside the other #132* regressions.
+"$BASH4_BIN" -s "$REPO_ROOT" <<'META_UT'
+set -u
+repo="$1"
+# shellcheck disable=SC1090
+source "$repo/bridge-lib.sh"
+fail() { printf '[smoke][error] meta: %s\n' "$*" >&2; exit 1; }
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    printf '[smoke]   [ok] %s\n' "$label"
+  else
+    fail "$label: expected [$expected], got [$actual]"
+  fi
+}
+
+# Bare-token values preserve shape; quoted values only when necessary.
+assert_eq "meta bare" "[Agent Bridge] event=inbox count=3 top=X12 from=patch" \
+  "$(bridge_format_injection_meta inbox count=3 top=X12 from=patch)"
+assert_eq "meta quoted title with spaces" \
+  "[Agent Bridge] event=inbox count=1 top=Y55 title='fix docs typo' from=patch" \
+  "$(bridge_format_injection_meta inbox count=1 top=Y55 title='fix docs typo' from=patch)"
+assert_eq "meta empty value quoted" \
+  "[Agent Bridge] event=idle agent=worker-a from=''" \
+  "$(bridge_format_injection_meta idle agent=worker-a from=)"
+# Value with an embedded single quote uses '\''  escape
+assert_eq "meta single-quote escape" \
+  "[Agent Bridge] event=inbox title='it'\\''s fine'" \
+  "$(bridge_format_injection_meta inbox title="it's fine")"
+assert_eq "meta dot-dash-underscore bare" \
+  "[Agent Bridge] event=context-pressure agent=admin.1 severity=warning" \
+  "$(bridge_format_injection_meta context-pressure agent=admin.1 severity=warning)"
+# Embedded newline in value is folded to literal "\n" so the payload stays
+# on one logical line (protects parser from mis-splitting).
+assert_eq "meta newline folded to sentinel" \
+  "[Agent Bridge] event=inbox title='line-1\\nline-2'" \
+  "$(bridge_format_injection_meta inbox title="$(printf 'line-1\nline-2')")"
+
+# Flag gating — default off emits legacy text; on emits metadata-only.
+unset BRIDGE_INJECT_METADATA_ONLY
+default_text="$(bridge_queue_attention_message "claude-static" 2 X1 urgent "do the thing")"
+case "$default_text" in
+  *"ACTION REQUIRED"*"Run exactly"*) printf '[smoke]   [ok] flag off: legacy format retained\n' ;;
+  *) fail "flag off should emit legacy text, got: $default_text" ;;
+esac
+
+meta_text="$(BRIDGE_INJECT_METADATA_ONLY=1 bridge_queue_attention_message "claude-static" 2 X1 urgent "do the thing")"
+expected_meta="[Agent Bridge] event=inbox agent=claude-static count=2 top=X1 priority=urgent title='do the thing'"
+[[ "$meta_text" == "$expected_meta" ]] \
+  || fail "flag on: expected exact meta, got '$meta_text'"
+# $() strips trailing newlines — so re-run with explicit byte capture to
+# verify the payload really is single-line (no \n tail). Required coverage
+# per codex review: `wc -c` / `od -c` style byte check.
+meta_raw_file="$(mktemp)"
+BRIDGE_INJECT_METADATA_ONLY=1 bridge_queue_attention_message \
+  "claude-static" 2 X1 urgent "do the thing" >"$meta_raw_file"
+last_byte_octal="$(tail -c 1 "$meta_raw_file" | od -An -c | tr -d ' ')"
+# Expect the last byte to be the closing "'" of the quoted title, NOT \n.
+[[ "$last_byte_octal" == "'" ]] \
+  || fail "metadata-only must not end with newline; last byte octal: $last_byte_octal"
+rm -f "$meta_raw_file"
+printf '[smoke]   [ok] flag on: metadata-only single logical line, no trailing newline (byte-verified)\n'
+
+# Passthrough is GATED on the payload already being a metadata header. A
+# plain message must still go through bridge_notification_text wrapping so
+# the bridge-task.sh / bridge-send.sh / bridge-intake.sh / bridge-review.sh /
+# bridge-bundle.sh callers don't lose their legacy header under the flag.
+BRIDGE_INJECT_METADATA_ONLY=1
+# Shadow `bridge_tmux_send_and_submit` to capture the emitted text rather
+# than hitting tmux, then invoke dispatcher through the public helper.
+captured_text=""
+bridge_tmux_send_and_submit() { captured_text="$3"; return 0; }
+bridge_agent_engine() { printf 'claude'; }
+bridge_agent_session() { printf 'fake-session'; }
+bridge_tmux_session_exists() { return 0; }
+bridge_agent_has_wake_channel() { return 0; }
+bridge_claude_session_can_wake() { return 0; }
+bridge_claude_session_try_mark_prompt_ready() { return 0; }
+
+# Plain message (legacy caller style) — should get the legacy header wrap
+# even when the flag is on.
+bridge_dispatch_notification "claude-static" "review needed" "plain reviewer note." "" "normal" >/dev/null 2>&1 || true
+case "$captured_text" in
+  "[Agent Bridge]"*"plain reviewer note."*) \
+    printf '[smoke]   [ok] passthrough gate: plain message still gets legacy header wrap under flag\n' ;;
+  *) fail "plain msg under flag should get legacy header, got: $captured_text" ;;
+esac
+
+# Metadata-prefixed message should pass through unchanged.
+captured_text=""
+bridge_dispatch_notification "claude-static" "" "[Agent Bridge] event=inbox agent=claude-static count=1" "" "normal" >/dev/null 2>&1 || true
+case "$captured_text" in
+  "[Agent Bridge] event=inbox agent=claude-static count=1") \
+    printf '[smoke]   [ok] passthrough gate: metadata message passes through verbatim\n' ;;
+  *) fail "metadata msg should pass through, got: $captured_text" ;;
+esac
+META_UT
+
 log "tmux pending-attention spool: escape/drain/prepend/deferral-cap (issue #132a)"
 "$BASH4_BIN" -s "$REPO_ROOT" <<'SPOOL_UT'
 set -u


### PR DESCRIPTION
Reopened from #137 after base branch was deleted by merge. Single commit rebased onto current main. See #137 for full review trail.

Codex review: 3 rounds, LGTM. Default flag OFF for safety; flip BRIDGE_INJECT_METADATA_ONLY=1 only after #138 (handler skill) is deployed.