### PR TITLE
memory: per-agent autoMemoryDirectory seed

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -178,10 +178,12 @@ PY
 #
 #   ~/.claude/auto-memory/<bridge-home-slug>/<agent>/
 #
-# The slug is derived from the resolved $SCRIPT_DIR path (Claude-style
+# The slug is derived from the resolved $BRIDGE_HOME path (Claude-style
 # replacement of "/" with "-"), matching the naming Anthropic already uses
 # under ~/.claude/projects/. That keeps two bridge installs on the same
-# machine from colliding even when they share agent ids.
+# machine from colliding even when they share agent ids — and it keeps
+# the slug stable whether bridge-agent.sh is invoked from the live runtime
+# (~/.agent-bridge) or from a source checkout managing that same runtime.
 #
 # Merge policy (fail-closed):
 #   - no file           → create with { autoMemoryDirectory: <path> }
@@ -196,7 +198,7 @@ PY
 bridge_ensure_auto_memory_isolation() {
   local agent="$1"
   local workdir="$2"
-  local bridge_home="${SCRIPT_DIR:-}"
+  local bridge_home="${BRIDGE_HOME:-}"
   local settings_local="$workdir/.claude/settings.local.json"
 
   if [[ -z "$agent" || -z "$workdir" || -z "$bridge_home" ]]; then

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -164,6 +164,120 @@ print(text, end="")
 PY
 }
 
+# bridge_ensure_auto_memory_isolation — seed per-agent autoMemoryDirectory.
+#
+# Claude Code's auto-memory is shared per git repository. Since all Agent
+# Bridge agents live under a single git repo (~/.agent-bridge), every
+# agent writes to the same ~/.claude/projects/<repo-slug>/memory/ dir by
+# default. This leaks one agent's memory to the others.
+#
+# Anthropic exposes an official override — `autoMemoryDirectory` — that
+# is only accepted from user/local/policy settings (NOT from project
+# `settings.json`). We seed `.claude/settings.local.json` inside each
+# agent's home so every agent writes to its own per-agent directory:
+#
+#   ~/.claude/auto-memory/<bridge-home-slug>/<agent>/
+#
+# The slug is derived from the resolved $SCRIPT_DIR path (Claude-style
+# replacement of "/" with "-"), matching the naming Anthropic already uses
+# under ~/.claude/projects/. That keeps two bridge installs on the same
+# machine from colliding even when they share agent ids.
+#
+# Merge policy (fail-closed):
+#   - no file           → create with { autoMemoryDirectory: <path> }
+#   - blank content     → fail (operator must inspect; no silent reset)
+#   - valid JSON, no    → upsert autoMemoryDirectory
+#   - valid JSON, same  → no-op
+#   - valid JSON, diff  → fail (operator must resolve)
+#   - parse failure     → fail (operator must inspect; no silent reset)
+#
+# Safe to call multiple times; fails loudly if another tool left the
+# file in an unexpected state. Only applies to claude engine.
+bridge_ensure_auto_memory_isolation() {
+  local agent="$1"
+  local workdir="$2"
+  local bridge_home="${SCRIPT_DIR:-}"
+  local settings_local="$workdir/.claude/settings.local.json"
+
+  if [[ -z "$agent" || -z "$workdir" || -z "$bridge_home" ]]; then
+    return 0
+  fi
+  if [[ ! -d "$workdir" ]]; then
+    return 0
+  fi
+
+  mkdir -p "$workdir/.claude"
+
+  bridge_agent_manage_python "$settings_local" "$agent" "$bridge_home" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+settings_path = Path(sys.argv[1])
+agent = sys.argv[2]
+bridge_home = sys.argv[3]
+
+resolved_home = os.path.realpath(bridge_home)
+# Match Anthropic's ~/.claude/projects/ slug convention: replace both
+# os.sep and "." with "-" so two installs never share a directory.
+slug = resolved_home.replace(os.sep, "-").replace(".", "-")
+expected = f"~/.claude/auto-memory/{slug}/{agent}"
+
+if not settings_path.exists():
+    settings_path.write_text(
+        json.dumps({"autoMemoryDirectory": expected}, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    sys.exit(0)
+
+raw = settings_path.read_text(encoding="utf-8")
+if not raw.strip():
+    sys.stderr.write(
+        f"[bridge-agent] {settings_path} is empty. "
+        "Refusing to overwrite blank content; inspect or remove the file, "
+        "then retry.\n"
+    )
+    sys.exit(1)
+
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError as exc:
+    sys.stderr.write(
+        f"[bridge-agent] {settings_path} is not valid JSON ({exc}). "
+        "Not touching it. Fix or remove the file, then retry.\n"
+    )
+    sys.exit(1)
+
+if not isinstance(data, dict):
+    sys.stderr.write(
+        f"[bridge-agent] {settings_path} is not a JSON object. "
+        "Not touching it. Fix or remove the file, then retry.\n"
+    )
+    sys.exit(1)
+
+current = data.get("autoMemoryDirectory")
+if current == expected:
+    sys.exit(0)
+
+if current not in (None, ""):
+    sys.stderr.write(
+        f"[bridge-agent] {settings_path} already sets autoMemoryDirectory "
+        f"to {current!r}; expected {expected!r}. Refusing to overwrite. "
+        "Resolve manually.\n"
+    )
+    sys.exit(1)
+
+data["autoMemoryDirectory"] = expected
+tmp_path = settings_path.with_suffix(settings_path.suffix + ".tmp")
+tmp_path.write_text(
+    json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+    encoding="utf-8",
+)
+os.replace(tmp_path, settings_path)
+PY
+}
+
 bridge_scaffold_agent_home() {
   local agent="$1"
   local home="$2"
@@ -1112,6 +1226,7 @@ run_create() {
     bridge_scaffold_user_partitions "$workdir" "$users_json"
     if [[ "$engine" == "claude" ]]; then
       bridge_ensure_project_claude_guidance "$workdir" >/dev/null 2>&1 || true
+      bridge_ensure_auto_memory_isolation "$agent" "$workdir"
     fi
     bridge_bootstrap_project_skill "$engine" "$workdir" >/dev/null 2>&1 || true
     if [[ "$engine" == "claude" ]]; then

--- a/docs/agent-runtime/auto-memory-isolation.md
+++ b/docs/agent-runtime/auto-memory-isolation.md
@@ -1,0 +1,147 @@
+# Per-agent auto-memory isolation
+
+> Status: landed in PR 1A (scaffold only). PR 1B will add the migration
+> CLI for existing installs.
+
+## Why
+
+Claude Code's **auto memory** is scoped per git repository: all sessions
+that run under the same git root share one `~/.claude/projects/<slug>/memory/`
+directory. Anthropic documents this behaviour explicitly:
+
+> "The `<project>` path is derived from the git repository, so all worktrees
+> and subdirectories within the same repo share one auto memory directory."
+> — <https://code.claude.com/docs/en/memory>
+
+Agent Bridge places every agent home under a single git repo
+(`~/.agent-bridge`), so by default `agents/patch`, `agents/syrs-*`,
+`agents/huchu`, etc. all write to the same shared auto-memory folder. That
+breaks the "one agent's memory is private to that agent" expectation and
+allows last-write-wins conflicts between concurrent agents.
+
+## Fix
+
+Anthropic exposes an official override: `autoMemoryDirectory`. It is
+accepted only from **policy / user / local** settings, not from project
+`settings.json` (Anthropic deliberately refuses the project scope to stop a
+shared repo from redirecting auto-memory writes).
+
+Bridge now seeds `.claude/settings.local.json` inside each agent's home
+with a per-agent path:
+
+```json
+{
+  "autoMemoryDirectory": "~/.claude/auto-memory/<bridge-home-slug>/<agent>"
+}
+```
+
+`<bridge-home-slug>` is the resolved bridge install path with `/` and `.`
+replaced by `-`, matching Anthropic's `~/.claude/projects/` convention.
+For a default install at `/Users/you/.agent-bridge` the slug is
+`-Users-you--agent-bridge`, so two bridge installs on the same machine
+keep their auto-memories separate even when they share agent ids.
+
+## When it runs
+
+The scaffold calls `bridge_ensure_auto_memory_isolation` at the end of
+`bridge-agent create` for **claude** engines. Codex agents are skipped:
+codex does not consume Anthropic's auto-memory.
+
+The seed only touches `settings.local.json`. `.gitignore` already hides
+this file (`agents/*/.claude/`), so the per-agent path never leaks into
+commits.
+
+## Merge policy (fail-closed)
+
+| existing state                                      | action                                  |
+| --------------------------------------------------- | --------------------------------------- |
+| no file                                             | create with `{autoMemoryDirectory: …}`  |
+| valid JSON, no `autoMemoryDirectory`                | upsert; preserve other keys             |
+| valid JSON, same value                              | no-op                                   |
+| valid JSON, different `autoMemoryDirectory` value   | **fail** — operator must resolve        |
+| invalid JSON                                        | **fail** — operator must inspect/repair |
+
+The function never silently overwrites a local setting and never resets a
+broken JSON file to `{}`. If it complains, the fix is to read the file
+yourself and decide.
+
+## Operator checklist
+
+**New agents (after this PR is live):** nothing to do — scaffolding seeds
+the setting automatically.
+
+**Existing agents (pre-PR state):** the seed won't backfill automatically;
+that work belongs to PR 1B. Until then you can opt in manually. Set
+`BRIDGE_HOME` to the install you're operating on (the snippet below
+defaults to `~/.agent-bridge` but you **must** override it when running
+against a checkout, worktree, or alternate install — the slug depends on
+the real path). The snippet preserves any other keys already in
+`settings.local.json`; an empty or malformed file is rejected rather
+than silently rewritten:
+
+```bash
+# Point this at the install you want to patch — different paths produce
+# different per-agent slugs, so this value matters.
+BRIDGE_HOME="$(cd -P "${BRIDGE_HOME:-$HOME/.agent-bridge}" && pwd -P)"
+AGENT=<agent>
+SLUG="$(printf '%s' "$BRIDGE_HOME" | tr '/.' '--')"
+SETTINGS="$BRIDGE_HOME/agents/$AGENT/.claude/settings.local.json"
+TARGET="~/.claude/auto-memory/$SLUG/$AGENT"
+
+python3 - "$SETTINGS" "$TARGET" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, target = Path(sys.argv[1]), sys.argv[2]
+if path.exists():
+    raw = path.read_text(encoding="utf-8")
+    if not raw.strip():
+        sys.exit(f"error: {path} is empty; inspect or remove before running")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        sys.exit(f"error: {path} is not valid JSON ({exc}); fix or remove before running")
+    if not isinstance(data, dict):
+        sys.exit(f"error: {path} is not a JSON object")
+    current = data.get("autoMemoryDirectory")
+    if current == target:
+        sys.exit(0)
+    if current:
+        sys.exit(f"error: {path} already sets autoMemoryDirectory={current!r}; resolve manually")
+else:
+    data = {}
+    path.parent.mkdir(parents=True, exist_ok=True)
+data["autoMemoryDirectory"] = target
+path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+PY
+
+# The slug also picks the physical dir Claude will write into.
+mkdir -p "$HOME/.claude/auto-memory/$SLUG/$AGENT"
+```
+
+Claude Code picks up the new value on the next session start. Existing
+files in the shared parent dir stay where they are until PR 1B's migration
+CLI ships.
+
+**Requirements.** Claude Code **v2.1.59+** (the release that introduced
+auto memory). Check with `claude --version`.
+
+## Rollback
+
+To revert a single agent back to the shared behaviour:
+
+1. Remove the `autoMemoryDirectory` key from `~/.agent-bridge/agents/<agent>/.claude/settings.local.json`
+   (leave other keys in place; delete the file only if it's empty afterwards).
+2. Restart the agent. Auto-memory resumes at `~/.claude/projects/<repo-slug>/memory/`.
+
+No data moves during rollback: PR 1A does not touch existing memory files.
+Migration and restore flows land in PR 1B.
+
+## Related
+
+- PR 1B — migration CLI, `originSessionId` → agent routing, manifest-based
+  restore, doctor drift checks.
+- PR 2 — session-primary daily note (`/wrap-up` command + hooks + cron
+  reconcile). Independent of this change, but shares the
+  "agent-local memory is the right default" direction.


### PR DESCRIPTION
## Summary

- Claude Code's auto memory is scoped per git repository, so every Agent Bridge agent under a single bridge install writes to the same shared `~/.claude/projects/<slug>/memory/` directory by default — one agent's memory leaks into the others.
- Seed each agent's `.claude/settings.local.json` at scaffold time with a per-install, per-agent `autoMemoryDirectory` (`~/.claude/auto-memory/<bridge-home-slug>/<agent>`). The slug matches Anthropic's own `~/.claude/projects/` naming, so two bridge installs on the same host stay isolated even when they share agent ids.
- Merge policy is fail-closed: blank, conflicting, or malformed `settings.local.json` aborts instead of silently rewriting local state.

This PR covers new agents only. A follow-up PR adds `scripts/migrate-auto-memory.py` for the existing shared corpus.

## Review history (private fork, 3 rounds)

Reviewed with a peer agent (`agb-dev-syrs`). Five findings fixed before landing on the private fork:

1. Empty `settings.local.json` is treated as the same fail-closed case as malformed JSON (originally silently mapped to `{}` and overwritten).
2. Path is install-scoped via `<bridge-home-slug>` (originally product-scoped `agent-bridge/<agent>`, which would collide across installs sharing agent ids).
3. Docs opt-in snippet no longer clobbers existing keys; it merges.
4. Docs snippet is install-aware via `BRIDGE_HOME` (was hardcoded `~/.agent-bridge`).
5. Docs snippet catches `json.JSONDecodeError` with a readable message instead of a raw traceback.

Fork PR: <https://github.com/SYRS-AI/agent-bridge/pull/86>

## Test plan

- [x] `bash -n bridge-agent.sh`
- [x] 5-case merge policy: no file / blank / conflicting / same / other keys — all behave per spec
- [x] Install slug matches Anthropic convention (`/Users/…/.agent-bridge` → `-Users-…--agent-bridge`)
- [x] Manual opt-in snippet runs with default `BRIDGE_HOME` and with an override
- [x] Live scaffold verified on reference install

## Files

- `bridge-agent.sh` (+113) — new `bridge_ensure_auto_memory_isolation` function + one new call site in the `agent create` flow
- `docs/agent-runtime/auto-memory-isolation.md` (+149 new) — operator-facing doc

Tracks Anthropic's official `autoMemoryDirectory` field: <https://code.claude.com/docs/en/memory>

🤖 Generated with [Claude Code](https://claude.com/claude-code)