### PR TITLE
fix(tmux): set-option target form for session mouse bootstrap (#139)

### DIFF
--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -60,8 +60,16 @@ bridge_attach_tmux_session() {
 
 bridge_tmux_bootstrap_session_options() {
   local session="$1"
-  tmux set-option -t "$(bridge_tmux_session_target "$session")" mouse on >/dev/null 2>&1 || true
-  tmux set-option -t "$(bridge_tmux_session_target "$session")" history-limit 10000 >/dev/null 2>&1 || true
+  # tmux's set-option requires the `=<session>:` exact-match form (with
+  # trailing colon). The bare `=<session>` form returned by
+  # bridge_tmux_session_target fails with "no such session" and the
+  # silent `|| true` swallowed it, leaving session-level `mouse` off
+  # and wheel events dead (issue #139). Reuse pane target which already
+  # appends the colon.
+  local target
+  target="$(bridge_tmux_pane_target "$session")"
+  tmux set-option -t "$target" mouse on >/dev/null 2>&1 || true
+  tmux set-option -t "$target" history-limit 10000 >/dev/null 2>&1 || true
 }
 
 bridge_tmux_engine_requires_prompt() {


### PR DESCRIPTION
## Summary

- Session-level `mouse on` / `history-limit` never took effect on spawned bridge sessions because `bridge_tmux_bootstrap_session_options` called `tmux set-option -t '=<name>'` — tmux wants `=<name>:` (exact-match form with trailing colon).
- The errors were swallowed by `|| true`, so wheel scroll silently died on every bridge-spawned session (static and dynamic).
- Fix routes through `bridge_tmux_pane_target` which already emits the colon form. No change to the other call sites of `bridge_tmux_session_target`.

## Reproduction (tmux 3.6a)

```
$ tmux set-option -t "=repro" mouse on
no such session: =repro
$ tmux set-option -t "=repro:" mouse on      # works
```

## Test plan

- [x] `bash -n lib/bridge-tmux.sh`
- [x] `shellcheck lib/bridge-tmux.sh`
- [x] Live repro on local tmux session: `mouse on` now takes effect; confirmed with `tmux show-options -t <name> mouse`

Fixes #139