### PR TITLE
fix(plugin-liveness): restart verify via descendant probe (#143)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1310,20 +1310,26 @@ run_restart() {
   (( verify_max_attempts >= 1 )) || verify_max_attempts=1
 
   verify_attempts=1
-  if bridge_tmux_wait_for_claude_channel_banner "$session" "$launch_channels" "$verify_timeout"; then
+  # Verify via descendant process probe (issue #143). The banner-based
+  # verifier read only the last 80 tmux lines, so busy sessions (`--resume`
+  # + `/compact` + first task dispatch) scrolled the startup banner off
+  # within seconds and restart verify kept returning failure even when
+  # every plugin bun was alive. Align with the daemon's steady-state
+  # liveness check so the two signals no longer disagree.
+  if bridge_tmux_wait_for_claude_plugin_mcp_alive "$agent" "$verify_timeout"; then
     return 0
   fi
 
   # Retry with fresh sessions up to verify_max_attempts total. Keep going
   # only while the session restarts cleanly. If we exhaust attempts without
-  # seeing the banner, leave the session running and return non-zero so
-  # the daemon's next cooldown cycle can take another look. Previously we
-  # killed the session after 2 attempts, which — combined with the too-short
-  # 12s default timeout and reparented bun holding the port — produced the
-  # observed permanent death loop (issue #69 Defect C).
+  # the plugin MCP coming alive, leave the session running and return
+  # non-zero so the daemon's next cooldown cycle can take another look.
+  # Previously we killed the session after 2 attempts, which — combined
+  # with the too-short 12s default timeout and reparented bun holding the
+  # port — produced the observed permanent death loop (issue #69 Defect C).
   while (( verify_attempts < verify_max_attempts )); do
     verify_attempts=$(( verify_attempts + 1 ))
-    bridge_warn "Claude channel runtime banner missing after restart for '$agent' (attempt ${verify_attempts}/${verify_max_attempts}). Retrying with a fresh session."
+    bridge_warn "Claude plugin MCP liveness missing after restart for '$agent' (attempt ${verify_attempts}/${verify_max_attempts}). Retrying with a fresh session."
     if bridge_tmux_session_exists "$session"; then
       bridge_kill_agent_session "$agent" >/dev/null 2>&1 || true
       bridge_refresh_runtime_state
@@ -1331,12 +1337,12 @@ run_restart() {
     if ! restart_once; then
       return 1
     fi
-    if bridge_tmux_wait_for_claude_channel_banner "$session" "$launch_channels" "$verify_timeout"; then
+    if bridge_tmux_wait_for_claude_plugin_mcp_alive "$agent" "$verify_timeout"; then
       return 0
     fi
   done
 
-  bridge_warn "Claude channel runtime banner still missing after ${verify_max_attempts} attempts for '$agent'. Leaving the session alive so the daemon's next cycle can re-check (avoids the plugin-port death loop from issue #69)."
+  bridge_warn "Claude plugin MCP liveness still missing after ${verify_max_attempts} attempts for '$agent'. Leaving the session alive so the daemon's next cycle can re-check (avoids the plugin-port death loop from issue #69)."
   return 1
 }
 

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2348,6 +2348,52 @@ bridge_tmux_wait_for_claude_channel_banner() {
   done
 }
 
+# bridge_tmux_wait_for_claude_plugin_mcp_alive — descendant-based readiness
+# verifier for required Claude plugin MCP channels. Issue #143.
+#
+# The banner-based verifier (bridge_tmux_wait_for_claude_channel_banner)
+# scans the last 80 tmux lines for a startup-only banner; busy sessions
+# scroll the banner off-window in seconds, so restart verify keeps
+# failing even when every plugin bun process is healthy. The daemon's
+# steady-state liveness already uses a descendant process probe
+# (bridge_agent_missing_plugin_mcp_channels_csv → *_alive_for_item →
+# bridge_plugin_mcp_descendant_ready_for_item); route restart verify
+# through the same signal for consistency.
+#
+# Polls until every required plugin MCP is alive under the pane PID or
+# timeout elapses. Returns 0 when no channels are required, when
+# liveness is already clean, or when the loop observes it cleanly.
+# Returns 1 if timeout expires with at least one channel still missing.
+bridge_tmux_wait_for_claude_plugin_mcp_alive() {
+  local agent="$1"
+  local timeout="${2:-12}"
+  local required=""
+  local missing=""
+  local start_ts=0
+  local elapsed=0
+
+  [[ -n "$agent" ]] || return 0
+  [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || return 0
+  required="$(bridge_agent_effective_launch_plugin_channels_csv "$agent")"
+  [[ -n "$required" ]] || return 0
+  [[ "$timeout" =~ ^[0-9]+$ ]] || timeout=12
+  (( timeout > 0 )) || timeout=12
+
+  missing="$(bridge_agent_missing_plugin_mcp_channels_csv "$agent")"
+  [[ -z "$missing" ]] && return 0
+
+  start_ts="$(date +%s)"
+  while true; do
+    sleep 0.5
+    missing="$(bridge_agent_missing_plugin_mcp_channels_csv "$agent")"
+    [[ -z "$missing" ]] && return 0
+    elapsed=$(( $(date +%s) - start_ts ))
+    if (( elapsed >= timeout )); then
+      return 1
+    fi
+  done
+}
+
 bridge_agent_launch_channel_status_reason() {
   local agent="$1"
   local required=""


### PR DESCRIPTION
## Summary

- Restart verifier read only the last 80 tmux lines for a startup-only banner; busy sessions scrolled it off-window in seconds, producing a permanent restart → verify-fail → leave loop even when every plugin `bun` child was healthy. The daemon's steady-state liveness already uses a descendant process probe; this PR unifies the two signals.
- Adds `bridge_tmux_wait_for_claude_plugin_mcp_alive` next to the existing banner helper. Polls `bridge_agent_missing_plugin_mcp_channels_csv` until empty or timeout. Returns 0 when no plugin channels are required (same semantics as the banner helper).
- Routes `run_agent_restart`'s two verify calls through the new helper. Warn messages updated to describe the new signal.
- Leaves the banner helper in place so existing smoke scaffolding and any out-of-tree callers keep working.

## Design trade-off (from the issue's Codex review)

Descendant-based liveness proves the `bun` child exists under the pane PID, not end-to-end bot health. That's the same contract daemon steady-state already runs on, so restart verify now matches the existing definition rather than widening or narrowing it.

## Test plan

- [x] `bash -n bridge-agent.sh lib/bridge-agents.sh`
- [x] `shellcheck bridge-agent.sh lib/bridge-agents.sh`
- [x] Existing plugin-liveness smoke tests (lib/bridge-tmux.sh banner helper + daemon `process_plugin_liveness` stub tests at smoke-test.sh:5421/5458) untouched — no regression on daemon path
- [ ] Live Telegram death-loop repro not exercised here — covered by the issue's 30h outage observation + the local stopgap that Sean has already been running

Fixes #143