### PR TITLE
fix(stall): narrow network timeout regex to transport-qualified forms (#161)

### DIFF
--- a/bridge-stall.py
+++ b/bridge-stall.py
@@ -45,9 +45,20 @@ PATTERN_GROUPS: list[tuple[str, list[str]]] = [
         [
             r"econnreset",
             r"econnrefused",
+            r"etimedout",
             r"connection refused",
-            r"timeout",
-            r"timed out",
+            r"\bconnection\s+reset\s+by\s+peer\b",
+            r"\bconnection\s+aborted\b",
+            r"\bname\s+or\s+service\s+not\s+known\b",
+            r"\bcontext\s+deadline\s+exceeded\b",
+            # Issue #161: bare `timeout` / `timed out` matched benign scrollback
+            # like Claude Code's `⎿  (timeout 5m)` tool-budget hint, shell
+            # `timeout 120000ms`, and documentation strings — producing
+            # repeated "retry the transient network error" nudges to idle
+            # agents. Require a network-ish subject word next to the timeout
+            # so only real transport errors classify as network.
+            r"\b(?:connection|request|socket|read|write|fetch|network|upstream|gateway|dns|tcp|tls|ssl|i/o)\s+timed?\s*out\b",
+            r"network\s+timeout",
             r"503 service unavailable",
             r"502 bad gateway",
             r"upstream connect error",


### PR DESCRIPTION
## Summary

- `bridge-stall.py::PATTERN_GROUPS[\"network\"]` matched bare `timeout` / `timed out`. Benign scrollback — Claude Code's `⎿  (timeout 5m)` tool-budget hint, shell `timeout 120000ms`, documentation strings — classified as a network transport error, producing repeated `retry the transient network error` nudges at idle agents. The `excerpt_hash` changed on every scan so `max_nudges=2` never clamped.
- Replace with context-qualified alternates: a transport subject word (`connection|request|socket|read|write|fetch|network|upstream|gateway|dns|tcp|tls|ssl`) next to `timed out`, plus `etimedout` and `network timeout` as standalone forms.

## Verification

Positive set (must still classify as network):
- `connection timed out`, `request timeout`, `ETIMEDOUT`, `socket timed out`, `503 Service Unavailable`, `ECONNREFUSED`, `upstream connect error`, `DNS timed out` — all classify ✓

Negative set (must NOT classify — previously false-positive):
- `⎿  (timeout 5m)`, `Bash timeout: 120000ms`, `export TIMEOUT=30`, `timeout 30 curl foo`, `bare timeout word`, `pytest.timeout = 5`, `docs about timed out scenarios` — none classify ✓

No production smoke tests touch `PATTERN_GROUPS`, so the regex unit check above is the verification.

## Side-effect scope

Only `analyze` output changes — if a new scrollback previously classified as `network`, it may now classify as `""` (empty) and skip the network-flavored nudge. The other pattern groups (`rate_limit`, `auth`) are untouched, so legitimate rate-limit / auth stalls still trigger normally. The stall nudge itself still fires on the `stalled` generic classification when `claimed > 0 && idle >= 30s`.

Fixes #161