### PR TITLE
fix(cli): intent-recovery suggestion on unknown subcommand (#163 Phase 1)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -647,6 +647,20 @@ PY
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-task.sh" "$@"
       ;;
   esac
+
+  # Issue #163: if the first arg survived the top-level case and does not
+  # start with `-` it is overwhelmingly a mistyped subcommand (e.g.
+  # `agent-bridge health`, `agent-bridge diag`). Letting it fall through
+  # into the spawn-flag parser surfaces the misleading "알 수 없는 옵션"
+  # error, which previously redirected agents into option-guessing or the
+  # sqlite3 fallback path. Reject with an intent-recovery suggestion
+  # before the spawn parser sees it.
+  if [[ -n "${1:-}" && "${1:0:1}" != "-" ]]; then
+    _top_valid="admin bootstrap init version upgrade escalate upstream review user guard knowledge bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
+    _hint="$(bridge_suggest_subcommand "$1" "$_top_valid")"
+    [[ -n "$_hint" ]] && bridge_warn "$_hint"
+    bridge_die "지원하지 않는 명령입니다: $1"
+  fi
 fi
 
 ENGINE=""

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -153,6 +153,8 @@ run_list() {
         exit 0
         ;;
       *)
+        _hint="$(bridge_suggest_subcommand "cron list $1" "")"
+        [[ -n "$_hint" ]] && bridge_warn "$_hint"
         bridge_die "지원하지 않는 list 옵션입니다: $1"
         ;;
     esac
@@ -997,6 +999,11 @@ case "$subcommand" in
     usage
     ;;
   *)
+    # Issue #163: attach an intent-recovery suggestion before dying so the
+    # caller sees "혹시 X?" instead of just the bare rejection.
+    _hint="$(bridge_suggest_subcommand "cron $subcommand" \
+      "inventory show import list create update delete rebalance-memory-daily enqueue sync run-subagent finalize-run errors cleanup")"
+    [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 cron 명령입니다: $subcommand"
     ;;
 esac

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -6,6 +6,123 @@ bridge_die() {
   exit 1
 }
 
+# bridge_suggest_subcommand — intent-recovery for unknown CLI subcommands.
+#
+# Issue #163: agents repeatedly guessed CLI subcommand names that don't exist
+# (`agent-bridge cron stats`, `cron list --failed`, `agent-bridge health`) and
+# the dispatchers only emitted "지원하지 않는 X 명령입니다: Y" with no hint.
+# Failed attempts often cascaded into blocked fallbacks (direct `sqlite3`).
+#
+# This helper produces a single-line "혹시 X 이었나요?" suggestion from a
+# curated intent alias table (primary) plus a Levenshtein nearest-match
+# fallback (secondary). Callers print the suggestion right before `bridge_die`
+# so the operator / agent sees the recovery hint in the same error frame.
+#
+# Usage:
+#   hint="$(bridge_suggest_subcommand "cron stats" "inventory show list create ... errors cleanup")"
+#   [[ -n "$hint" ]] && bridge_warn "$hint"
+#   bridge_die "지원하지 않는 cron 명령입니다: cron stats"
+#
+# Args:
+#   $1 — the unknown input (may be a multi-token phrase like "cron stats" or
+#        a single token like "health"). Case-sensitive; callers should
+#        normalize to the form the user typed.
+#   $2 — space-separated list of valid subcommand names for the current
+#        dispatcher (may be empty; helper then skips fuzzy match and only
+#        consults the curated alias table).
+#
+# Emits: a Korean suggestion line on stdout, or empty if no suggestion
+# reaches the confidence threshold. Never exits. Never contaminates stderr.
+bridge_suggest_subcommand() {
+  local unknown="$1"
+  local valid_list="$2"
+  local suggestions=""
+
+  [[ -n "$unknown" ]] || return 0
+
+  # Curated intent → command table. Keys are the phrases agents actually
+  # typed in the wild (Issue #163 실측 + future telemetry); values are the
+  # canonical commands. Extend conservatively — one wrong alias is worse
+  # than no alias.
+  case "$unknown" in
+    health|diag|diagnose|diagnostic|diagnostics)
+      suggestions="agent-bridge status  |  agent-bridge watchdog scan"
+      ;;
+    "cron stats"|"cron stat"|"cron status"|"cron metrics")
+      suggestions="agent-bridge cron errors report  |  agent-bridge cron list"
+      ;;
+    "cron list --failed"|"cron failed"|"cron failures"|"cron errors"|"cron error")
+      suggestions="agent-bridge cron errors report"
+      ;;
+    "queue status"|"queue stats"|"task stats")
+      suggestions="agent-bridge summary  |  agent-bridge status"
+      ;;
+    ps|processes|agents)
+      suggestions="agent-bridge list  |  agent-bridge status"
+      ;;
+  esac
+
+  if [[ -n "$suggestions" ]]; then
+    printf '혹시 이 명령이었나요?  %s' "$suggestions"
+    return 0
+  fi
+
+  # Fallback: Levenshtein nearest-match against the caller-supplied valid
+  # list. Only emits when a candidate is strictly closer than the next-best
+  # (prevents "cron" → equidistant ambiguity from false-suggesting). Uses
+  # python for the distance calc since the helper is already python-gated
+  # elsewhere and we need unicode-safe comparison for Korean argument words.
+  [[ -n "$valid_list" ]] || return 0
+
+  bridge_require_python
+  local match
+  match="$(python3 - "$unknown" "$valid_list" <<'PY'
+import sys
+
+def levenshtein(a, b):
+    if a == b:
+        return 0
+    if not a or not b:
+        return max(len(a), len(b))
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        curr = [i] + [0] * len(b)
+        for j, cb in enumerate(b, 1):
+            cost = 0 if ca == cb else 1
+            curr[j] = min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+        prev = curr
+    return prev[-1]
+
+unknown = sys.argv[1].strip()
+candidates = [c for c in sys.argv[2].split() if c]
+
+if not candidates:
+    sys.exit(0)
+
+scored = sorted(((levenshtein(unknown.lower(), c.lower()), c) for c in candidates))
+best = scored[0]
+second = scored[1] if len(scored) > 1 else None
+
+# Require: (a) distance <= 2, (b) distance < len(unknown) (reject wild
+# matches where the "closest" valid word shares almost nothing), and
+# (c) a strict margin over second-best to avoid ambiguous ties.
+if best[0] > 2:
+    sys.exit(0)
+if best[0] >= len(unknown):
+    sys.exit(0)
+if second and second[0] <= best[0]:
+    # Tie — suggesting one of several equally-near is noisier than silence.
+    sys.exit(0)
+
+print(best[1])
+PY
+  )"
+
+  if [[ -n "$match" ]]; then
+    printf '혹시 %q 이었나요?' "$match"
+  fi
+}
+
 bridge_warn() {
   echo -e "${YELLOW}[경고] $*${NC}" >&2
 }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -143,6 +143,41 @@ run_cp_case "prose 'Context remaining 8%' -> warning via fallback" \
   "warning" "" \
   $'Context remaining 8%. Please compact soon.\n'
 
+log "CLI subcommand suggestion helper (issue #163)"
+run_suggest_case() {
+  local label="$1"
+  local unknown="$2"
+  local valid_list="$3"
+  local expected_substring="$4"
+  local out
+  out="$("$BASH4_BIN" -c '
+    source "'"$REPO_ROOT"'/bridge-lib.sh"
+    bridge_suggest_subcommand "$1" "$2"
+  ' _ "$unknown" "$valid_list")"
+  if [[ -z "$expected_substring" ]]; then
+    [[ -z "$out" ]] || die "expected empty suggestion for $label, got: $out"
+  else
+    assert_contains "$out" "$expected_substring"
+  fi
+  log "  [ok] $label"
+}
+# Curated table — the 3 measured cases from the issue all must recover.
+run_suggest_case "health -> status/watchdog" \
+  "health" "" "agent-bridge status"
+run_suggest_case "cron stats -> cron errors report" \
+  "cron stats" "" "agent-bridge cron errors report"
+run_suggest_case "cron list --failed -> cron errors report" \
+  "cron list --failed" "" "agent-bridge cron errors report"
+# Fuzzy fallback — simple Levenshtein hit.
+run_suggest_case "fuzzy: satus -> status" \
+  "satus" "status summary attach kill" "status"
+# Silent on truly-novel input so we don't hallucinate a command.
+run_suggest_case "unrelated -> silent" \
+  "completely-unrelated" "status summary attach" ""
+# Silent on ambiguous near-ties (margin-of-distance gate).
+run_suggest_case "ambiguous tie -> silent" \
+  "xx" "status attach" ""
+
 log "tmux inject gate: input-buffer-content detection (issue #132)"
 # Self-contained coverage for bridge_tmux_session_has_pending_input_from_text.
 # Placed early so the harness's downstream pre-existing failures do not gate


### PR DESCRIPTION
## Summary

- Adds `bridge_suggest_subcommand` helper in `lib/bridge-core.sh` — curated intent-alias table + Levenshtein nearest-match fallback with strict margin-of-distance gating so ambiguous / wild inputs emit no suggestion.
- Wires the helper into three dispatcher sites that reproduce the three measured cases from #163:
  - `agent-bridge` top-level fall-through — intercepts unknown non-`-` first args **before** the spawn-flag parser, replacing the misleading `알 수 없는 옵션: health` with `지원하지 않는 명령입니다: health` + a concrete hint.
  - `bridge-cron.sh` unknown subcommand (`cron stats` → `cron errors report | cron list`).
  - `bridge-cron.sh` unknown `cron list` option (`--failed` → `cron errors report`).
- Smoke-test block added covering all three measured cases, a fuzzy hit, an unrelated input (silent), and an ambiguous tie (silent).

Phase 2 / 3 (explicitly out of scope here) are captured in the updated issue body — they extend the helper to the remaining dispatchers + generated `TOOLS.md` recipe section, then telemetry-driven alias additions.

## Root cause

From codex pair-design analysis: the real gap is the **error path does not recover intent**, not that `--help` is thin. Three layers contribute:

1. Top-level parser passes unknown bare words to the spawn-flag parser → `agent-bridge health` hits `알 수 없는 옵션: health`.
2. Nested dispatchers call `bridge_die` with no suggestion → `cron stats` / `cron list --failed` end in bare rejection.
3. `TOOLS.md` is a flat inventory — no intent→command recipe surface.

This PR addresses (1) and (2). (3) is Phase 2.

## Behavior samples

```
$ ./agent-bridge health
[경고] 혹시 이 명령이었나요?  agent-bridge status  |  agent-bridge watchdog scan
[오류] 지원하지 않는 명령입니다: health

$ ./agent-bridge cron stats
[경고] 혹시 이 명령이었나요?  agent-bridge cron errors report  |  agent-bridge cron list
[오류] 지원하지 않는 cron 명령입니다: stats

$ ./agent-bridge cron list --failed
[경고] 혹시 이 명령이었나요?  agent-bridge cron errors report
[오류] 지원하지 않는 list 옵션입니다: --failed

$ ./agent-bridge satus         # fuzzy fallback
[경고] 혹시 status 이었나요?
[오류] 지원하지 않는 명령입니다: satus

$ ./agent-bridge status         # valid path unchanged
Agent Bridge Status v0.5.1 ...
```

## Side-effect scope

- Valid CLI paths: unchanged (validated `status`, `cron list --agent patch`, spawn `--codex --name` flows).
- Silent on truly-novel or ambiguous inputs (margin gate) to avoid hallucinating a wrong command.
- Suggestion emitted via `bridge_warn` to stderr before `bridge_die` — same frame the operator / agent already reads.

## Test plan

- [x] `bash -n agent-bridge bridge-cron.sh lib/bridge-core.sh scripts/smoke-test.sh`
- [x] `shellcheck agent-bridge bridge-cron.sh lib/bridge-core.sh scripts/smoke-test.sh`
- [x] Standalone runner against `bridge_suggest_subcommand` — 6 cases (3 measured + fuzzy + unrelated silent + ambiguous silent) all pass
- [x] Live execution of the three measured cases — suggestion rendered correctly
- [x] Spawn-flag path unaffected: `agent-bridge --codex --name x --workdir /tmp/x` reaches the existing flag parser

Refs #163