### PR TITLE
feat(memory): promote --kind user-profile — user preferences via canonical USER.md (#162 Phase 1)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -175,6 +175,7 @@ Examples:
   $CLI_NAME memory capture --agent assistant --source telegram --user owner --author "Alice" --text "I prefer morning updates."
   $CLI_NAME memory ingest --agent assistant --latest
   $CLI_NAME memory promote --agent assistant --kind user --user owner --summary "User prefers concise morning updates."
+  $CLI_NAME memory promote --agent assistant --kind user-profile --user owner --summary "답변 없으면 Discord로 에스컬레이션."   # appends to shared users/<uid>/USER.md Stable Preferences
   $CLI_NAME memory remember --agent assistant --source chat --user owner --text "User prefers concise morning updates." --kind user
   $CLI_NAME memory lint --agent assistant
   $CLI_NAME memory search --agent assistant --user owner --query "concise morning updates"

--- a/agents/_template/MEMORY-SCHEMA.md
+++ b/agents/_template/MEMORY-SCHEMA.md
@@ -60,6 +60,17 @@ If a message naturally contains durable preferences, stable context, or importan
 - it improves future interaction quality
 - it is stable enough not to churn every day
 
+### Promote to user-profile (Stable Preferences) when:
+
+- the user stated a durable preference for how the agent should behave
+  ("앞으로 / 항상 / from now on / whenever / always ...")
+- the preference is about this specific user, not every user of the agent
+- applying it crosses sessions and other agents linked to the same user
+
+Use `agent-bridge memory promote --kind user-profile --user <uid> --summary "..."`.
+The entry lands in `shared/users/<uid>/USER.md` "Stable Preferences" and
+propagates to every agent whose `users/<uid>/` is linked to that canonical.
+
 ### Promote to shared memory when:
 
 - the fact applies across users

--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -591,6 +591,20 @@ def cmd_promote(args: argparse.Namespace) -> int:
     if kind == "user":
         target_path = home / "users" / user.user_id / "MEMORY.md"
         append_under_section(target_path, "Promotions", block, args.dry_run)
+    elif kind == "user-profile":
+        # Issue #162 Phase 1: shared user profile is the canonical surface
+        # for persistent user preferences. Writing through the agent's
+        # symlinked `users/<uid>/USER.md` hits the canonical
+        # `shared/users/<uid>/USER.md`, so every other agent linked to the
+        # same user sees the preference at next session start without a
+        # separate promotion chain. The "Stable Preferences" section is
+        # intentionally distinct from the hand-edited "Stable preferences"
+        # bullet in the Identity/Working Notes skeleton so promoted
+        # entries do not fight the operator's manual edits.
+        target_path = home / "users" / user.user_id / "USER.md"
+        append_under_section(
+            target_path, "Stable Preferences", block, args.dry_run
+        )
     else:
         page_slug = slugify(args.page or title)
         if kind == "shared":
@@ -2203,7 +2217,17 @@ def build_parser() -> argparse.ArgumentParser:
     promote_parser.add_argument("--agent", required=True)
     promote_parser.add_argument("--home", required=True)
     promote_parser.add_argument("--template-root", required=True)
-    promote_parser.add_argument("--kind", choices=("user", "shared", "project", "decision"), required=True)
+    promote_parser.add_argument(
+        "--kind",
+        choices=("user", "user-profile", "shared", "project", "decision"),
+        required=True,
+        help=(
+            "user = per-user memory bucket; "
+            "user-profile = Stable Preferences section of shared/users/<uid>/USER.md "
+            "(auto-loaded at every session start, cross-agent via canonical USER.md); "
+            "shared|project|decision = agent-local wiki pages"
+        ),
+    )
     promote_parser.add_argument("--user")
     promote_parser.add_argument("--capture")
     promote_parser.add_argument("--page")

--- a/docs/agent-runtime/common-instructions.md
+++ b/docs/agent-runtime/common-instructions.md
@@ -79,13 +79,20 @@ task를 수신하면 아래 순서를 반드시 따른다:
 
 > **Local override precedence**: 개별 에이전트(예: patch)는 위의 기본 정책 위에 local override를 둘 수 있다. override는 해당 에이전트의 `CLAUDE.md` 내 관리 블록 **바깥**의 별도 섹션에서 선언하고, 충돌 시 override가 우선한다. override의 존재는 `<!-- BEGIN/END AGENT BRIDGE DOC MIGRATION -->` 블록 아래쪽에 한 줄 주석 (`> Upstream Issue Policy — Local Override: see below`)으로 표기한다.
 
-## User Preference Promotion (active-preferences)
+## User Preference Promotion
 
-사용자가 "앞으로 계속 이렇게 해" 식의 **지속 preference**를 말하면, 일회성 이후에도 유지되도록 `active-preferences.md` 계층으로 승격한다. 규칙은 [`user-preference-injection.md`](user-preference-injection.md)를 따른다. 요약:
+사용자가 "앞으로 계속 이렇게 해" 식의 **지속 preference**를 말하면 일회성 세션을 넘어 유지되도록 승격한다. Scope에 따라 자리가 다르다 ([`memory-schema.md`](memory-schema.md) §7 / [`user-preference-injection.md`](user-preference-injection.md) 참조):
 
-- 본문에 `앞으로 / 항상 / 계속 / 매번 / from now on / whenever` 등의 signal이 있거나 사용자가 명시적으로 "앞으로 적용해라"라고 하면 후보로 등록한다.
-- Agent-local feedback → `agents/<agent>/ACTIVE-PREFERENCES.md`. Team-wide feedback → `docs/agent-runtime/active-preferences.md` (admin 승인 필요).
-- 승격 전에 엔트리 포맷(`Rule/Why/How to apply/Source`)으로 정돈하고, 원본 feedback 파일에 `promoted_to: <path>` 헤더를 단다.
+- 본문에 `앞으로 / 항상 / 계속 / 매번 / from now on / whenever` signal이 있거나 사용자가 명시적으로 "앞으로 적용해라"라고 하면 후보로 등록한다.
+- **user-specific** (이 사용자가 일하는 방식. 기본값) → `shared/users/<uid>/USER.md` "Stable Preferences" 섹션.
+  ```
+  agent-bridge memory promote --agent <agent> --kind user-profile \
+    --user <uid> --summary "<한 줄 규칙>"
+  ```
+  이미 `CLAUDE.md` read-order가 `users/<user-id>/USER.md`를 읽으므로 별도 pointer 없이 다음 세션부터 로드된다. 같은 canonical에 링크된 다른 에이전트도 함께 인식한다.
+- **agent-role-specific** (이 에이전트 역할에만 해당) → `agents/<agent>/ACTIVE-PREFERENCES.md` (Phase 2, 아직 미구현).
+- **team-wide** (모든 에이전트가 따라야 함) → `docs/agent-runtime/active-preferences.md` + admin 승인 (Phase 3, 아직 미구현).
+- 승격 전에 한 줄로 정돈하고, 원본 feedback 파일에 `promoted_to: <path>` 헤더를 단다.
 
 ## First Session Onboarding (non-admin)
 

--- a/docs/agent-runtime/memory-schema.md
+++ b/docs/agent-runtime/memory-schema.md
@@ -175,7 +175,28 @@ CLI: `agent-bridge memory mode set <agent> shared|isolated` (land with Track 3 P
 
 ## 7. User preference promotion (feedback → overhead)
 
-The admin-curated "ACTIVE-PREFERENCES" layer is the third short-term continuity surface — see [`user-preference-injection.md`](user-preference-injection.md). Summary here: feedback memory tagged as a persistent preference is promoted to `agents/<agent>/ACTIVE-PREFERENCES.md` (agent-local) or `docs/agent-runtime/active-preferences.md` (team-wide, admin approval). The `CLAUDE.md` pointer template includes `ACTIVE-PREFERENCES.md` in the "read order" list.
+Three scopes, in order of implementation effort and blast radius:
+
+### 7.1 User-specific preferences → shared user profile (Issue #162 Phase 1, landed v0.5.x)
+
+The default path for "this user wants the agent(s) working with them to behave this way." Write with:
+
+```
+agent-bridge memory promote --agent <agent> --kind user-profile \
+    --user <uid> --summary "<one-line rule>"
+```
+
+The entry lands in `shared/users/<uid>/USER.md` under the `## Stable Preferences` section. Every agent whose `users/<uid>/` is linked to the canonical picks it up at next session start via the existing `CLAUDE.md` read-order step (`users/<user-id>/USER.md`). No new file, no new pointer chain — reuses the surface the agent already reads early in boot.
+
+The promoted `## Stable Preferences` section is intentionally distinct from the hand-edited `- Stable preferences:` bullet in the Identity/Working Notes skeleton, so promoted rules do not clobber the operator's manual edits.
+
+### 7.2 Agent-role-specific operating rules → ACTIVE-PREFERENCES.md (Phase 2, spec'd, not yet landed)
+
+When a rule applies only to one agent's role (not to every agent working with the user), it belongs in `agents/<agent>/ACTIVE-PREFERENCES.md`. Pointer added to the agent's `CLAUDE.md` read-order list; file is silently skipped when absent. See [`user-preference-injection.md`](user-preference-injection.md) for the full spec.
+
+### 7.3 Team-wide operating rules → `docs/agent-runtime/active-preferences.md` (Phase 3, admin-gated)
+
+For rules every agent in the team must follow (comms protocols, escalation patterns). Admin-only write gate; other agents propose via a queue task to admin. See [`user-preference-injection.md`](user-preference-injection.md).
 
 ## 8. Legacy migration
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2625,6 +2625,21 @@ MEMORY_SHARED_PROMOTE_OUTPUT="$("$REPO_ROOT/agent-bridge" memory promote --agent
 assert_contains "$MEMORY_SHARED_PROMOTE_OUTPUT" "kind: shared"
 [[ -f "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/memory/shared/communication-preferences.md" ]] || die "memory promote did not create shared page"
 assert_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/memory/shared/communication-preferences.md")" "bias toward concise updates"
+# Issue #162 Phase 1: user-profile promotion must write to the canonical
+# shared user profile so every agent symlinked to that user sees it.
+MEMORY_PROFILE_PROMOTE_OUTPUT="$("$REPO_ROOT/agent-bridge" memory promote --agent "$CREATED_AGENT" --kind user-profile --user owner --summary "답변 없으면 Discord로 에스컬레이션해라.")"
+assert_contains "$MEMORY_PROFILE_PROMOTE_OUTPUT" "kind: user-profile"
+# Write target is users/owner/USER.md; when that path is a symlink into
+# $BRIDGE_SHARED_DIR/users/<uid>/ the canonical file is what gets mutated.
+SMOKE_USER_PROFILE_AGENT="$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/users/owner/USER.md"
+SMOKE_USER_PROFILE_CANONICAL="$BRIDGE_SHARED_DIR/users/owner/USER.md"
+assert_contains "$(cat "$SMOKE_USER_PROFILE_AGENT")" "## Stable Preferences"
+assert_contains "$(cat "$SMOKE_USER_PROFILE_AGENT")" "답변 없으면 Discord로 에스컬레이션"
+[[ -f "$SMOKE_USER_PROFILE_CANONICAL" ]] || die "user-profile promote did not reach the canonical shared user profile"
+assert_contains "$(cat "$SMOKE_USER_PROFILE_CANONICAL")" "답변 없으면 Discord로 에스컬레이션"
+# Same canonical means the agent-visible file and the shared file are the same bytes.
+diff -q "$SMOKE_USER_PROFILE_AGENT" "$SMOKE_USER_PROFILE_CANONICAL" >/dev/null \
+  || die "user-profile promote wrote to agent-local path instead of shared canonical"
 MEMORY_LINT_JSON="$("$REPO_ROOT/agent-bridge" memory lint --agent "$CREATED_AGENT" --json)"
 assert_contains "$MEMORY_LINT_JSON" "\"ok\": true"
 MEMORY_SEARCH_JSON="$("$REPO_ROOT/agent-bridge" memory search --agent "$CREATED_AGENT" --user owner --query "concise morning updates" --json)"


### PR DESCRIPTION
## Summary

- Adds `user-profile` as a new `--kind` for `agent-bridge memory promote`. When selected, the promotion block lands under `## Stable Preferences` in `users/<uid>/USER.md`.
- `bridge_scaffold_user_partitions` already symlinks `agents/<agent>/users/<uid>/` to the canonical `shared/users/<uid>/` — so the write goes to the shared canonical, and every agent linked to that user sees the new rule at next session start (via the existing `CLAUDE.md` read-order step).
- No new file, no new pointer chain, no heuristic auto-promote. Phase 2/3 (agent-role-only + team-wide rules, heuristic candidates, lifecycle) remain spec'd in `docs/agent-runtime/user-preference-injection.md` and are explicitly out of scope here.

## Root cause (codex pair-design, `/tmp/codex-162-design-out.md`)

The original draft proposed introducing a whole new `ACTIVE-PREFERENCES.md` file + pointer. Codex's deeper analysis: `bridge-memory.py` promote currently writes to `users/<uid>/MEMORY.md` or `memory/<kind>/<slug>.md` — **none** of which are in the session-boot read order. Meanwhile `agents/_template/CLAUDE.md:148-150` already reads `users/<user-id>/USER.md` early, and scaffold already points that to the canonical shared copy. So the fix is just "extend promote to write through the surface the agent already reads."

Sean's actual 2026-04-19 incident ("답변 없으면 Discord로 에스컬레이션") is a user-specific preference. The canonical shared `USER.md` is the correct home. Other scopes (agent-role-only, team-wide) are different problems that deserve their own PR if/when they reproduce.

## Behavior

### New agent + scaffolded symlink (the normal path)

```
$ agent-bridge memory promote --agent patch --kind user-profile \
    --user sean --summary "답변 없으면 Discord로 에스컬레이션해라"

$ cat ~/.agent-bridge/shared/users/sean/USER.md
# User Profile
## Identity
...
## Stable Preferences
- 2026-04-21T15:34:...: 답변 없으면 Discord로 에스컬레이션해라
```

Every other agent whose `users/sean/` is linked to `shared/users/sean/` sees the new rule at next session start.

### The `## Stable Preferences` section is distinct from the skeleton bullet

Template USER.md has a `- Stable preferences:` bullet under `## Working Notes` — that is the operator's hand-edit slot. Promoted entries land under a separate `## Stable Preferences` header appended to the file, so the two do not fight each other.

## Side-effect scope

- Existing promote kinds (`user`, `shared`, `project`, `decision`) are unchanged — the new `user-profile` branch is a pure addition with its own target.
- `append_under_section()` is reused (same helper that powers the other kinds), so section-creation semantics are consistent.
- No change to scaffold. Agents whose shared symlink was never created still get an agent-local write — Phase 2 will add an explicit migration / `ensure_shared_user_profile` wiring if that pattern needs cleaning up.
- Doc updates (`memory-schema.md`, `common-instructions.md`) reflect the new 3-scope layering so `CLAUDE.md` pointer chain tells every agent the right flow without adding a new pointer.

## Test plan

- [x] `python3 -m py_compile bridge-memory.py`
- [x] `bash -n agent-bridge scripts/smoke-test.sh` + `shellcheck` clean
- [x] Isolated E2E: build shared canonical USER.md, symlink agent's `users/<uid>/` to it, run `memory promote --kind user-profile`, verify the write lands in canonical and the agent-visible path stays byte-identical (same file via symlink)
- [x] Smoke-test block added that reproduces the above against the already-scaffolded smoke agent (`CREATED_AGENT` / `owner` user) and asserts canonical + symlink-visible match

Refs #162