### PR TITLE
fix(upgrade): backup-extend-live records children under a parent-symlink pointing outside target_root (#150)

### DIFF
--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -924,6 +924,12 @@ def cmd_backup_extend_live(args: argparse.Namespace) -> int:
     path treats them identically to the primary backup set.
     """
     target_root = Path(args.target_root).expanduser().resolve()
+    # Issue #150: keep a parallel unresolved form of target_root for the
+    # fallback relative-path check. On macOS `/tmp` resolves to `/private/tmp`,
+    # and operator-supplied paths typically use the unresolved form — a
+    # resolve-vs-literal string mismatch would otherwise turn the fallback
+    # into a no-op and leave parent-symlink-outside children dropped.
+    target_root_literal = Path(args.target_root).expanduser().absolute()
     backup_root = Path(args.backup_root).expanduser()
     payload = {
         "mode": "backup-extend-live",
@@ -981,8 +987,25 @@ def cmd_backup_extend_live(args: argparse.Namespace) -> int:
         try:
             relpath = abs_path.relative_to(target_root).as_posix()
         except ValueError:
-            payload["skipped_outside_target"] += 1
-            continue
+            # Issue #150: the parent `.resolve()` above follows intermediate
+            # symlinks. If an operator has retargeted a directory symlink
+            # inside `target_root` to an absolute path outside (e.g.
+            # `agents/shared -> /opt/external-shared`), the resolved parent
+            # lands outside `target_root` and the entry was silently
+            # dropped from the manifest — so rollback later cannot restore
+            # the child file. Retry using the unresolved path against the
+            # unresolved target root: the operator-supplied path is
+            # guaranteed to be under `target_root` at the literal level
+            # (otherwise it would not have been emitted by bridge-docs.py
+            # for this install). Only truly-outside paths — e.g. an
+            # absolute path that does not syntactically start with
+            # `target_root` under either resolution — fall through to the
+            # outside-target bucket now.
+            try:
+                relpath = raw.relative_to(target_root_literal).as_posix()
+            except ValueError:
+                payload["skipped_outside_target"] += 1
+                continue
         if relpath in existing_relpaths:
             payload["skipped_existing"] += 1
             continue

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -4382,6 +4382,30 @@ ROLLBACK_JSON="$("$REPO_ROOT/agent-bridge" upgrade rollback --target "$ROLLBACK_
 assert_contains "$ROLLBACK_JSON" "\"mode\": \"upgrade-rollback\""
 assert_not_contains "$(cat "$ROLLBACK_ROOT/bridge-task.sh")" "rollback smoke drift"
 
+log "backup-extend-live records child paths under a parent-symlink pointing outside target_root (issue #150)"
+EXT_ROOT="$TMP_ROOT/extend-live-root"
+EXT_BACKUP_ROOT="$TMP_ROOT/extend-live-backup"
+EXT_EXTERNAL="$TMP_ROOT/extend-live-external"
+# Plant a realistic retarget: agents/shared inside target_root is a symlink
+# to an absolute path OUTSIDE target_root. Then report a changed path
+# underneath that symlink and confirm backup-extend-live stops dropping
+# it into skipped_outside_target — previously the parent.resolve() chased
+# the symlink and relative_to() failed silently.
+mkdir -p "$EXT_ROOT/agents" "$EXT_EXTERNAL" "$EXT_BACKUP_ROOT/live"
+ln -s "$EXT_EXTERNAL" "$EXT_ROOT/agents/shared"
+printf 'external shared doc\n' >"$EXT_EXTERNAL/TOOLS.md"
+printf '{"entries": []}\n' >"$EXT_BACKUP_ROOT/manifest.json"
+EXT_PAYLOAD="$(python3 -c 'import json,sys; print(json.dumps({"changed_paths":[sys.argv[1]+"/agents/shared/TOOLS.md"]}))' "$EXT_ROOT")"
+EXT_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" backup-extend-live \
+  --target-root "$EXT_ROOT" --backup-root "$EXT_BACKUP_ROOT" --paths-json "$EXT_PAYLOAD")"
+assert_contains "$EXT_JSON" "\"skipped_outside_target\": 0"
+assert_contains "$EXT_JSON" "\"added_entries\": 1"
+# The manifest entry now exists and points at the operator-visible relpath,
+# not the external canonical.
+assert_contains "$(cat "$EXT_BACKUP_ROOT/manifest.json")" "\"path\": \"agents/shared/TOOLS.md\""
+[[ -f "$EXT_BACKUP_ROOT/live/agents/shared/TOOLS.md" ]] || die "backup-extend-live did not copy the symlink-child file"
+assert_contains "$(cat "$EXT_BACKUP_ROOT/live/agents/shared/TOOLS.md")" "external shared doc"
+
 log "smart upgrade clean-merges text drift"
 UPGRADE_SIM_REPO="$TMP_ROOT/upgrade-sim-repo"
 mkdir -p "$UPGRADE_SIM_REPO"


### PR DESCRIPTION
## Summary

- `cmd_backup_extend_live`'s parent-symlink blind spot: when a directory symlink **inside** `target_root` points to a path **outside** (e.g. `agents/shared -> /opt/external-shared`), `parent.resolve()` followed the link and `abs_path.relative_to(target_root)` raised `ValueError`. The entry was silently dropped into `skipped_outside_target` and never made it into the manifest — so `upgrade rollback` could not restore that file.
- Fix: after the resolved-parent check fails, retry against the **literal** target_root. Operator-supplied paths are guaranteed to be under `target_root` at the literal level for this install (that's how `bridge-docs.py` emits them), so the fallback correctly recovers the child. Only genuinely-outside paths still fall through to `skipped_outside_target`.
- Separate literal target root needed on macOS where `/tmp` resolves to `/private/tmp` — keeping both forms stops the resolve-vs-literal string mismatch that would otherwise make the fallback a no-op.

## Root cause (v0.4.2 known limitation)

Flagged during the v0.4.2 review. Defensive blind spot that did not reproduce on in-tree code paths (no shipped caller emits a path under a symlinked parent today), but closed off silently on any future install that retargets `agents/shared` to an external mount.

## Side-effect scope

Verified four scenarios locally:

| Scenario | Before | After |
|---|---|---|
| Normal path under target_root | added_entries=1 | added_entries=1 (no regression) |
| Genuinely outside target_root | skipped_outside_target=1 | skipped_outside_target=1 (still blocked) |
| Terminal symlink (v0.4.2 case) | added_entries=1, link preserved | added_entries=1, link preserved (no regression) |
| Parent-symlink outside (#150 case) | skipped_outside_target=1, **data lost on rollback** | added_entries=1, **manifest records operator-visible relpath**, backup copies external canonical file |

Fallback intentionally runs only when the primary `.relative_to(target_root)` (resolved form) fails — no behavior change for the common path.

## Test plan

- [x] `python3 -m py_compile bridge-upgrade.py`
- [x] `bash -n scripts/smoke-test.sh` + `shellcheck` clean
- [x] Isolated E2E: four-scenario regression table above, each with clean temp roots
- [x] Smoke-test block added: plants `target/agents/shared` → external dir, feeds `backup-extend-live` the operator-visible path, asserts `added_entries=1` + `skipped_outside_target=0` + manifest records the operator-visible relpath + backup file copied on disk

Fixes #150