### PR TITLE
feat(cli): suggestion helper in remaining dispatchers + generated TOOLS recipes (#163 Phase 2)

### DIFF
--- a/agents/_template/TOOLS.md
+++ b/agents/_template/TOOLS.md
@@ -1,25 +1,7 @@
 # Tools
 
-이 홈에서 일반적으로 사용하는 bridge-native 도구:
+<!-- Seeded from agents/_template/TOOLS.md; overwritten by agent-bridge upgrade. -->
 
-- `~/.agent-bridge/agent-bridge status`
-- `~/.agent-bridge/agb inbox <agent>`
-- `~/.agent-bridge/agb show <task-id>`
-- `~/.agent-bridge/agb claim <task-id> --agent <agent>`
-- `~/.agent-bridge/agb done <task-id> --agent <agent> --note "..."`
-- `~/.agent-bridge/agent-bridge task create --to <agent> ...`
-- `~/.agent-bridge/agent-bridge bundle create --to <agent> ...`
-- `~/.agent-bridge/agent-bridge intake triage --capture <id> --owner <agent> --route`
-- `~/.agent-bridge/agent-bridge urgent <agent> "..."`
-- `~/.agent-bridge/agent-bridge escalate question --agent <agent> --question "..." --context "..."`
-- `~/.agent-bridge/agent-bridge cron ...`
-- `~/.agent-bridge/agent-bridge memory capture --agent <agent> ...`
-- `~/.agent-bridge/agent-bridge memory ingest --agent <agent> --latest`
-- `~/.agent-bridge/agent-bridge memory promote --agent <agent> ...`
-- `~/.agent-bridge/agent-bridge memory remember --agent <agent> --source <source> --text "..." --kind user|shared|project|decision`
-- `~/.agent-bridge/agent-bridge memory search --agent <agent> --query "..."`
-- `~/.agent-bridge/agent-bridge memory rebuild-index --agent <agent>`
-- `~/.agent-bridge/agent-bridge memory query --agent <agent> --query "..."`
+이 파일은 agent 홈이 처음 세팅될 때 임시로 놓인 자리표지이다. 실제 최신 도구 목록과 의도→명령 매핑(Ops Recipes)은 `bridge-docs.py`의 `render_shared_tools_md`가 생성하며, `agent-bridge upgrade` 또는 `agent-bridge setup agent <agent>` 이후 이 파일은 `~/.agent-bridge/shared/TOOLS.md`를 가리키는 심볼릭 링크로 교체된다.
 
-채널 응답은 연결된 Claude/Codex 세션 안에서 처리한다. queue와 roster 상태는 `~/.agent-bridge` live runtime 기준으로 본다.
-메모리 판정 기준은 shared `memory-wiki` skill을 우선 따른다.
+아직 교체 전이라면 바로 `cat ~/.agent-bridge/shared/TOOLS.md`로 최신 목록을 확인하고, 필요하면 `agent-bridge upgrade`를 실행한다.

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1522,6 +1522,10 @@ case "$subcommand" in
     usage
     ;;
   *)
+    # Issue #163 Phase 2: surface an intent-recovery hint before dying.
+    _hint="$(bridge_suggest_subcommand "$subcommand" \
+      "create list show start safe-mode stop restart ack-crash attach")"
+    [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 agent 명령입니다: $subcommand"
     ;;
 esac

--- a/bridge-docs.py
+++ b/bridge-docs.py
@@ -439,6 +439,24 @@ def render_shared_tools_md(bridge_home: Path) -> str:
 - inventory/list/create/update/delete: `{home}/agent-bridge cron ...`
 - 옛 cron helper 예시는 더 이상 기준이 아니다.
 
+## Ops Recipes (intent → command)
+에이전트가 운영 점검 명령을 반복적으로 잘못 추측해서 blocked 된 사례가 있다(issue #163). 이름을 처음부터 찾는 대신 아래 의도→명령 매핑을 먼저 본다.
+
+| intent | command |
+| --- | --- |
+| 상태/헬스 확인 | `{home}/agent-bridge status` |
+| 실시간 프로세스 점검 | `{home}/agent-bridge watchdog scan` |
+| cron 실패/에러 리포트 | `{home}/agent-bridge cron errors report` |
+| cron job 목록 | `{home}/agent-bridge cron list` |
+| queue 요약 (누가 뭘 들고 있나) | `{home}/agent-bridge summary` |
+| 에이전트 인벤토리 | `{home}/agent-bridge list` |
+| 감사 로그 실시간 추적 | `{home}/agent-bridge audit follow` |
+| 메모리 위키 정합성 점검 | `{home}/agent-bridge memory lint --agent <agent>` |
+| 다른 에이전트로 작업 넘기기 | `{home}/agent-bridge task create --to <agent> ...` |
+| 긴급 인터럽트 | `{home}/agent-bridge urgent <agent> "..."` |
+
+CLI가 모르는 이름을 추측하면 `혹시 이 명령이었나요?` 힌트가 함께 뜬다. 자주 빗맞는 케이스(`health`, `diag`, `cron stats`, `cron list --failed`, `ps`, `agents`, `task stats`)는 `lib/bridge-core.sh`의 `bridge_suggest_subcommand` curated alias 테이블에 이미 들어 있다.
+
 ## Queue State
 - live queue는 `{home}/state/tasks.db`에 있다.
 - 하지만 직접 sqlite를 두드리는 대신 `agb inbox/show/claim/done/summary`를 사용한다.

--- a/bridge-memory.sh
+++ b/bridge-memory.sh
@@ -566,7 +566,12 @@ case "$command" in
     exit 0
     ;;
   *)
-    usage
-    exit 1
+    # Issue #163 Phase 2: surface an intent-recovery hint before dying so
+    # "memory <typo>" is aligned with the other dispatchers instead of
+    # silently printing usage and exiting 1.
+    _hint="$(bridge_suggest_subcommand "$command" \
+      "init capture ingest promote remember lint search rebuild-index query")"
+    [[ -n "$_hint" ]] && bridge_warn "$_hint"
+    bridge_die "지원하지 않는 memory 명령입니다: $command"
     ;;
 esac

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -1028,6 +1028,10 @@ case "$subcommand" in
     usage
     ;;
   *)
+    # Issue #163 Phase 2: surface an intent-recovery hint before dying.
+    _hint="$(bridge_suggest_subcommand "$subcommand" \
+      "discord telegram teams agent admin")"
+    [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 setup 명령입니다: $subcommand"
     ;;
 esac

--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -598,6 +598,15 @@ case "$COMMAND" in
     usage
     ;;
   *)
+    # Issue #163 Phase 2: preserve the dispatcher-specific `task stats`
+    # alias from the curated table, then fall back to fuzzy matching
+    # against the bare task subcommands for ordinary typos.
+    _hint="$(bridge_suggest_subcommand "task $COMMAND" "")"
+    if [[ -z "$_hint" ]]; then
+      _hint="$(bridge_suggest_subcommand "$COMMAND" \
+        "create inbox show claim done cancel handoff update summary")"
+    fi
+    [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 명령입니다: $COMMAND"
     ;;
 esac

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -177,6 +177,42 @@ run_suggest_case "unrelated -> silent" \
 # Silent on ambiguous near-ties (margin-of-distance gate).
 run_suggest_case "ambiguous tie -> silent" \
   "xx" "status attach" ""
+# Phase 2: exercise additional curated intents used by the new dispatcher
+# wiring (agent list / task summary / top-level diagnose).
+run_suggest_case "ps -> list/status (agent dispatcher intent)" \
+  "ps" "" "agent-bridge list"
+run_suggest_case "task stats -> summary (task dispatcher intent)" \
+  "task stats" "" "agent-bridge summary"
+run_suggest_case "diagnose -> status/watchdog (top-level intent)" \
+  "diagnose" "" "agent-bridge status"
+
+run_dispatch_suggest_case() {
+  local label="$1"
+  local expected_substring="$2"
+  shift 2
+  local home_dir
+  local out
+  home_dir="$(mktemp -d)"
+  out="$(env BRIDGE_HOME="$home_dir" "$BASH4_BIN" "$@" 2>&1 || true)"
+  rm -rf "$home_dir"
+  assert_contains "$out" "$expected_substring"
+  assert_contains "$out" "[오류]"
+  log "  [ok] $label"
+}
+
+log "dispatcher suggestion wiring (issue #163 phase 2)"
+run_dispatch_suggest_case "agent dispatcher: ps -> list" \
+  "agent-bridge list" \
+  "$REPO_ROOT/bridge-agent.sh" ps
+run_dispatch_suggest_case "memory dispatcher: captur -> capture" \
+  "capture" \
+  "$REPO_ROOT/bridge-memory.sh" captur
+run_dispatch_suggest_case "setup dispatcher: telegra -> telegram" \
+  "telegram" \
+  "$REPO_ROOT/bridge-setup.sh" telegra
+run_dispatch_suggest_case "task dispatcher: stats -> summary" \
+  "agent-bridge summary" \
+  "$REPO_ROOT/bridge-task.sh" stats
 
 log "tmux inject gate: input-buffer-content detection (issue #132)"
 # Self-contained coverage for bridge_tmux_session_has_pending_input_from_text.


### PR DESCRIPTION
## Summary

- Wires `bridge_suggest_subcommand` (Phase 1 helper in `lib/bridge-core.sh`) into the unknown-subcommand error paths of `bridge-agent.sh`, `bridge-memory.sh`, `bridge-setup.sh`, and `bridge-task.sh`, matching the Phase 1 `bridge-cron.sh` pattern. `bash bridge-agent.sh ps` now hints `list / status`; `bash bridge-memory.sh captur` hints `capture`; `bash bridge-setup.sh telegra` hints `telegram`; `bash bridge-task.sh stats` hints `agent-bridge summary` via the curated two-step lookup.
- Adds an **Ops Recipes** section (intent → command table) to the generated shared runtime TOOLS renderer in `bridge-docs.py:render_shared_tools_md`. Ships through the existing `agents/<agent>/TOOLS.md → ../shared/TOOLS.md` symlink installed by `ensure_agent_shared_links`, so every agent picks it up on next upgrade without per-template drift.
- Collapses `agents/_template/TOOLS.md` to a short placeholder that points at the shared renderer. Addresses codex review finding: previously `ensure_memory_layout` seeded fresh agent homes from the old flat inventory and missed the new intent table. Now fresh init drops a pointer, and upgrade replaces it with the symlink.
- Extends `scripts/smoke-test.sh`: three new helper-level curated-intent cases (`ps`, `task stats`, `diagnose`) plus a new block that spawns each of the four dispatchers under an isolated `BRIDGE_HOME` and asserts real stderr hint + `[오류]` line — call-site coverage, not just the helper table.

Closes #163 Phase 2.

## Test plan

- [x] `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh` (clean)
- [x] `shellcheck *.sh agent-bridge agb lib/*.sh scripts/*.sh agent-roster.local.example.sh` (clean)
- [x] `python3 -m py_compile bridge-docs.py bridge-memory.py bridge-cron.py` (clean)
- [ ] Manual: spawn fresh agent, inspect TOOLS.md pre-upgrade (placeholder) and post-upgrade (symlink → rendered Ops Recipes). Reproduce a typo on each wired dispatcher and confirm `[경고] 혹시 이 명령이었나요: ...` fires before `[오류]`.
- [ ] Review by `agb-dev-codex` (one round already landed — see commit message and closed task #93 review note; follow-up on placeholder approach may round out).

## Notes

- Phase 3 (telemetry-driven alias expansion) intentionally deferred per the issue body — no log sink added here.
- Option-level branches stayed unwired by design. `bridge-cron.sh`'s `--failed` typo is covered by the curated `cron list --failed` alias from Phase 1 already; other option-level cases deferred to Phase 3 telemetry.
- Work originally drafted by a team member (`dev-163`) under pair protocol with `agb-dev-codex`; final commits and this PR authored by the orchestrator after the team was dissolved for delivery simplicity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)