### PR TITLE
feat(memory): promote --kind agent-pref + ACTIVE-PREFERENCES.md + conditional CLAUDE pointer (#162 Phase 2)

### DIFF
--- a/bridge-docs.py
+++ b/bridge-docs.py
@@ -839,6 +839,15 @@ def render_agent_bridge_block(agent_dir: Path, session_type: str | None = None) 
         "- `COMMON-INSTRUCTIONS.md`는 전 에이전트 공통 규칙 SSOT다. 역할별 문서보다 먼저 우회하면 안 된다.",
         "- `CHANGE-POLICY.md`는 기술 변경의 upstream/downstream 분류 계약이다.",
         "- `TOOLS.md`와 `SKILLS.md`는 현재 bridge-native runtime reference다.",
+        # Issue #162 Phase 2: conditional bullet — only rendered when the
+        # agent actually has promoted role-specific preferences. Zero
+        # overhead when absent (file-exists gate, same pattern as Phase 1's
+        # USER.md cross-agent canonical).
+        *(
+            ["- `ACTIVE-PREFERENCES.md`: 이 에이전트 역할 전용 운영 규칙이다. 매 세션 시작 시 읽는다."]
+            if (agent_dir / "ACTIVE-PREFERENCES.md").exists()
+            else []
+        ),
         "",
         "## Queue & Delivery",
         "- inbox / task 상태 확인은 `~/.agent-bridge/agb inbox|show|claim|done`를 사용한다.",

--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -559,6 +559,61 @@ def build_page_promotion_block(
     return "\n".join(lines).rstrip() + "\n"
 
 
+def build_agent_pref_block(
+    created_at: str,
+    title: str,
+    summary: str,
+    capture: dict | None,
+) -> str:
+    # Issue #162 Phase 2: agent-role rule format per
+    # docs/agent-runtime/user-preference-injection.md §2. Each promotion is
+    # a self-contained `## <title> (YYYY-MM-DD, scope: agent)` section.
+    # Why / How-to-apply fall back to `(see source)` when the capture body
+    # does not carry explicit keys — Phase 2 deliberately avoids new CLI
+    # flags and keeps the Source attribution at the real capture id so it
+    # traces back to the canonical raw/captures/* payload.
+    date_str = created_at[:10]
+    rule_body = summary.strip() or "(see source)"
+    source_ref = "(inline)"
+    if capture:
+        source_ref = f"capture `{capture['capture_id']}`"
+        if capture.get("source"):
+            source_ref += f" ({capture['source']})"
+    lines = [
+        "",
+        f"## {title} ({date_str}, scope: agent)",
+        "",
+        f"**Rule:** {rule_body}",
+        "**Why:** (see source)",
+        "**How to apply:** (see source)",
+        f"**Source:** {source_ref}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def ensure_active_preferences_page(path: Path, dry_run: bool) -> None:
+    # Issue #162 Phase 2: file is created lazily on first promote only —
+    # NOT at scaffold time. bridge-docs.py's Runtime Canon renderer keys
+    # the CLAUDE pointer on file existence, so agents without promoted
+    # role-specific preferences pay zero startup overhead.
+    if path.exists():
+        return
+    intro = (
+        "# Active Preferences\n\n"
+        "이 파일은 이 에이전트 역할에만 적용되는 운영 규칙을 담는다.\n"
+        "새 규칙은 `agent-bridge memory promote --kind agent-pref ...` 로 추가한다 — 직접 편집하지 말 것.\n"
+    )
+    write_text(path, intro, dry_run)
+
+
+def append_agent_pref_block(path: Path, block: str, dry_run: bool) -> None:
+    existing = read_text(path) if path.exists() else ""
+    if existing and not existing.endswith("\n"):
+        existing += "\n"
+    write_text(path, existing + block, dry_run)
+
+
 def cmd_promote(args: argparse.Namespace) -> int:
     home = Path(args.home)
     template_root = Path(args.template_root)
@@ -604,6 +659,19 @@ def cmd_promote(args: argparse.Namespace) -> int:
         target_path = home / "users" / user.user_id / "USER.md"
         append_under_section(
             target_path, "Stable Preferences", block, args.dry_run
+        )
+    elif kind == "agent-pref":
+        # Issue #162 Phase 2: agent-role-specific operating rules. Unlike
+        # user-profile (cross-agent for a given user via shared symlink),
+        # these stay scoped to this single agent's home. File is created
+        # lazily on first promote and lives at the agent home root so
+        # bridge-docs.py's Runtime Canon bullet is keyed on presence.
+        target_path = home / "ACTIVE-PREFERENCES.md"
+        ensure_active_preferences_page(target_path, args.dry_run)
+        append_agent_pref_block(
+            target_path,
+            build_agent_pref_block(created_at, title, summary, capture),
+            args.dry_run,
         )
     else:
         page_slug = slugify(args.page or title)
@@ -873,6 +941,10 @@ def iter_search_candidates(home: Path, scope: str, user_id: str | None) -> list[
     if include_wiki:
         candidates.extend(
             [
+                # Issue #162 Phase 2: agent-role rules (if any) are high-signal
+                # for "what are my operating constraints" searches. File is
+                # optional — iter loop below filters non-existent paths.
+                ("agent-pref", home / "ACTIVE-PREFERENCES.md"),
                 ("agent-memory", home / "MEMORY.md"),
                 ("wiki-index", home / "memory" / "index.md"),
                 ("wiki-log", home / "memory" / "log.md"),
@@ -931,6 +1003,7 @@ def search_score(kind: str, path: Path, text: str, tokens: list[str]) -> tuple[i
             score += 10
     base_scores = {
         "user-profile": 80,
+        "agent-pref": 75,
         "user-memory": 70,
         "daily": 60,
         "agent-memory": 55,
@@ -1022,6 +1095,10 @@ def collect_index_documents(home: Path, shared_root: Path | None = None, include
     add_markdown(home / "CLAUDE.md", "agent-contract")
     add_markdown(home / "MEMORY-SCHEMA.md", "memory-schema")
     add_markdown(home / "MEMORY.md", "agent-memory")
+    # Issue #162 Phase 2: add_markdown is a no-op when the file is absent,
+    # so unused agents do not pollute the index and indexed agents surface
+    # role-specific rules under `memory search` without further wiring.
+    add_markdown(home / "ACTIVE-PREFERENCES.md", "agent-pref")
     add_markdown(home / "memory" / "index.md", "wiki-index")
     add_markdown(home / "memory" / "log.md", "wiki-log")
 
@@ -2219,12 +2296,14 @@ def build_parser() -> argparse.ArgumentParser:
     promote_parser.add_argument("--template-root", required=True)
     promote_parser.add_argument(
         "--kind",
-        choices=("user", "user-profile", "shared", "project", "decision"),
+        choices=("user", "user-profile", "agent-pref", "shared", "project", "decision"),
         required=True,
         help=(
             "user = per-user memory bucket; "
             "user-profile = Stable Preferences section of shared/users/<uid>/USER.md "
             "(auto-loaded at every session start, cross-agent via canonical USER.md); "
+            "agent-pref = agent-role rules in this agent's ACTIVE-PREFERENCES.md "
+            "(file-exists-only load, zero overhead when unused); "
             "shared|project|decision = agent-local wiki pages"
         ),
     )

--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import fcntl
 import hashlib
+import importlib.util
 import json
 import os
 import re
@@ -614,6 +615,21 @@ def append_agent_pref_block(path: Path, block: str, dry_run: bool) -> None:
     write_text(path, existing + block, dry_run)
 
 
+def _load_bridge_docs_module():
+    # Hyphenated filename workaround mirroring bridge-migrate.py. Always
+    # load the bridge-docs.py that lives alongside this script so we get
+    # the current render_agent_bridge_block behaviour, not whatever old
+    # copy might sit under BRIDGE_HOME.
+    script = Path(__file__).resolve().parent / "bridge-docs.py"
+    spec = importlib.util.spec_from_file_location("_bridge_docs_memory", str(script))
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load bridge-docs.py from {script}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_bridge_docs_memory"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def cmd_promote(args: argparse.Namespace) -> int:
     home = Path(args.home)
     template_root = Path(args.template_root)
@@ -624,7 +640,12 @@ def cmd_promote(args: argparse.Namespace) -> int:
         capture = json.loads(read_text(resolve_any_capture_path(home, args.capture)))
     user_id = args.user or (capture.get("user") if capture else "default") or "default"
     user = UserSpec(user_id=user_id, display_name=user_id)
-    ensure_user_partition(home, template_root, user, args.dry_run, [])
+    if args.kind != "agent-pref":
+        # Issue #162 Phase 2 (codex review finding): agent-pref is
+        # user-agnostic and lives only in ACTIVE-PREFERENCES.md. Scaffolding
+        # a users/<uid>/ partition for this kind produces unrelated state
+        # churn — skip the partition ensure for that kind specifically.
+        ensure_user_partition(home, template_root, user, args.dry_run, [])
 
     summary = args.summary or (capture.get("text") if capture else "")
     if not summary:
@@ -673,6 +694,17 @@ def cmd_promote(args: argparse.Namespace) -> int:
             build_agent_pref_block(created_at, title, summary, capture),
             args.dry_run,
         )
+        # Issue #162 Phase 2 (codex review finding): the Runtime Canon
+        # pointer in CLAUDE.md is keyed on file existence, so the first
+        # promote MUST trigger a managed-block re-render — otherwise the
+        # rule does not auto-load until the next `agent-bridge upgrade`
+        # or `setup agent` run, breaking the Phase 2 "auto-loaded once
+        # promoted" contract.
+        if not args.dry_run:
+            bridge_docs = _load_bridge_docs_module()
+            backup_root = home / "state" / "promote-backups"
+            backup_root.mkdir(parents=True, exist_ok=True)
+            bridge_docs.normalize_claude(home, args.dry_run, backup_root)
     else:
         page_slug = slugify(args.page or title)
         if kind == "shared":
@@ -1454,7 +1486,13 @@ def cmd_query(args: argparse.Namespace) -> int:
         clauses = ["chunks_fts MATCH ?"]
         params: list[object] = [fts_query]
         if args.user:
-            clauses.append("chunks.user_id = ?")
+            # Issue #162 Phase 2 (codex review finding): agent-pref rows
+            # are indexed with empty user_id (kind is user-agnostic), so a
+            # naive `user_id = ?` filter drops them for any --user query.
+            # cmd_search does not apply this clause and correctly returns
+            # agent-pref; mirror that behaviour here by letting agent-pref
+            # rows through regardless of the user filter.
+            clauses.append("(chunks.user_id = ? OR chunks.kind = 'agent-pref')")
             params.append(args.user)
         if args.scope != "all":
             if args.scope == "wiki":

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2675,6 +2675,31 @@ assert_contains "$(cat "$SMOKE_USER_PROFILE_CANONICAL")" "답변 없으면 Disco
 # Same canonical means the agent-visible file and the shared file are the same bytes.
 diff -q "$SMOKE_USER_PROFILE_AGENT" "$SMOKE_USER_PROFILE_CANONICAL" >/dev/null \
   || die "user-profile promote wrote to agent-local path instead of shared canonical"
+# Issue #162 Phase 2: agent-pref is scoped to this agent role only and
+# lives at the agent home root. Three invariants: (1) file must NOT exist
+# at scaffold time, (2) first promote creates it with the spec section
+# format, (3) the CLAUDE.md Runtime Canon pointer appears only AFTER the
+# file exists, and disappears when the file is absent.
+SMOKE_AGENT_PREF_PATH="$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/ACTIVE-PREFERENCES.md"
+SMOKE_AGENT_CLAUDE_PATH="$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/CLAUDE.md"
+[[ ! -f "$SMOKE_AGENT_PREF_PATH" ]] || die "ACTIVE-PREFERENCES.md leaked into scaffold (#162 Phase 2)"
+if grep -q "ACTIVE-PREFERENCES.md" "$SMOKE_AGENT_CLAUDE_PATH"; then
+  die "Runtime Canon pointer rendered before any agent-pref promotion (#162 Phase 2)"
+fi
+MEMORY_AGENT_PREF_OUTPUT="$("$REPO_ROOT/agent-bridge" memory promote --agent "$CREATED_AGENT" --kind agent-pref --title "Confirm destructive commands" --summary "삭제/리셋 계열 명령은 실행 전에 반드시 operator 확인을 받는다.")"
+assert_contains "$MEMORY_AGENT_PREF_OUTPUT" "kind: agent-pref"
+[[ -f "$SMOKE_AGENT_PREF_PATH" ]] || die "agent-pref promote did not create ACTIVE-PREFERENCES.md"
+assert_contains "$(cat "$SMOKE_AGENT_PREF_PATH")" "Confirm destructive commands"
+assert_contains "$(cat "$SMOKE_AGENT_PREF_PATH")" "scope: agent"
+assert_contains "$(cat "$SMOKE_AGENT_PREF_PATH")" "**Rule:**"
+# Re-run setup agent so bridge-docs.py re-renders the managed block now
+# that the file exists. Pointer must appear (conditional rendering).
+"$REPO_ROOT/agent-bridge" setup agent "$CREATED_AGENT" --skip-discord >/dev/null
+assert_contains "$(cat "$SMOKE_AGENT_CLAUDE_PATH")" "ACTIVE-PREFERENCES.md"
+# search/index plumbing — rebuild-index then search for the rule body.
+"$REPO_ROOT/agent-bridge" memory rebuild-index --agent "$CREATED_AGENT" >/dev/null
+MEMORY_AGENT_PREF_SEARCH_JSON="$("$REPO_ROOT/agent-bridge" memory search --agent "$CREATED_AGENT" --query "destructive commands" --json)"
+assert_contains "$MEMORY_AGENT_PREF_SEARCH_JSON" "ACTIVE-PREFERENCES.md"
 MEMORY_LINT_JSON="$("$REPO_ROOT/agent-bridge" memory lint --agent "$CREATED_AGENT" --json)"
 assert_contains "$MEMORY_LINT_JSON" "\"ok\": true"
 MEMORY_SEARCH_JSON="$("$REPO_ROOT/agent-bridge" memory search --agent "$CREATED_AGENT" --user owner --query "concise morning updates" --json)"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2686,20 +2686,36 @@ SMOKE_AGENT_CLAUDE_PATH="$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/CLAUDE.md"
 if grep -q "ACTIVE-PREFERENCES.md" "$SMOKE_AGENT_CLAUDE_PATH"; then
   die "Runtime Canon pointer rendered before any agent-pref promotion (#162 Phase 2)"
 fi
+# Capture the users/ partition snapshot before promote so we can assert the
+# codex review finding: agent-pref must not provision a users/default/
+# partition (it is user-agnostic, owner already exists from Phase 1).
+# shellcheck disable=SC2012 # user dir names are alphanumeric, ls is fine
+SMOKE_USERS_BEFORE="$(cd "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/users/" 2>/dev/null && ls -1 | sort)"
 MEMORY_AGENT_PREF_OUTPUT="$("$REPO_ROOT/agent-bridge" memory promote --agent "$CREATED_AGENT" --kind agent-pref --title "Confirm destructive commands" --summary "삭제/리셋 계열 명령은 실행 전에 반드시 operator 확인을 받는다.")"
 assert_contains "$MEMORY_AGENT_PREF_OUTPUT" "kind: agent-pref"
 [[ -f "$SMOKE_AGENT_PREF_PATH" ]] || die "agent-pref promote did not create ACTIVE-PREFERENCES.md"
 assert_contains "$(cat "$SMOKE_AGENT_PREF_PATH")" "Confirm destructive commands"
 assert_contains "$(cat "$SMOKE_AGENT_PREF_PATH")" "scope: agent"
 assert_contains "$(cat "$SMOKE_AGENT_PREF_PATH")" "**Rule:**"
-# Re-run setup agent so bridge-docs.py re-renders the managed block now
-# that the file exists. Pointer must appear (conditional rendering).
-"$REPO_ROOT/agent-bridge" setup agent "$CREATED_AGENT" --skip-discord >/dev/null
+# codex review finding #1: agent-pref promote MUST trigger CLAUDE.md
+# re-render in-band, not "on next upgrade". No setup agent call should
+# be required — the pointer is expected to appear immediately.
 assert_contains "$(cat "$SMOKE_AGENT_CLAUDE_PATH")" "ACTIVE-PREFERENCES.md"
-# search/index plumbing — rebuild-index then search for the rule body.
+# codex review finding #2: agent-pref must not scaffold users/default/
+# (or any user partition not already present). Snapshot diff.
+# shellcheck disable=SC2012 # user dir names are alphanumeric, ls is fine
+SMOKE_USERS_AFTER="$(cd "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/users/" 2>/dev/null && ls -1 | sort)"
+[[ "$SMOKE_USERS_BEFORE" == "$SMOKE_USERS_AFTER" ]] \
+  || die "agent-pref promote leaked users/ partition: before='$SMOKE_USERS_BEFORE' after='$SMOKE_USERS_AFTER'"
+# search/index plumbing — rebuild-index then search + query for the rule body.
 "$REPO_ROOT/agent-bridge" memory rebuild-index --agent "$CREATED_AGENT" >/dev/null
 MEMORY_AGENT_PREF_SEARCH_JSON="$("$REPO_ROOT/agent-bridge" memory search --agent "$CREATED_AGENT" --query "destructive commands" --json)"
 assert_contains "$MEMORY_AGENT_PREF_SEARCH_JSON" "ACTIVE-PREFERENCES.md"
+# codex review finding #3: cmd_query --user must not drop agent-pref rows
+# (they index with empty user_id). Search already worked; query with
+# --user set previously returned zero matches before the fix.
+MEMORY_AGENT_PREF_QUERY_JSON="$("$REPO_ROOT/agent-bridge" memory query --agent "$CREATED_AGENT" --user owner --query "destructive commands" --json)"
+assert_contains "$MEMORY_AGENT_PREF_QUERY_JSON" "ACTIVE-PREFERENCES.md"
 MEMORY_LINT_JSON="$("$REPO_ROOT/agent-bridge" memory lint --agent "$CREATED_AGENT" --json)"
 assert_contains "$MEMORY_LINT_JSON" "\"ok\": true"
 MEMORY_SEARCH_JSON="$("$REPO_ROOT/agent-bridge" memory search --agent "$CREATED_AGENT" --user owner --query "concise morning updates" --json)"


### PR DESCRIPTION
## Summary

- Adds `--kind agent-pref` to `bridge-memory.py::cmd_promote`. Writes to `agents/<agent>/ACTIVE-PREFERENCES.md` under `## <title> (YYYY-MM-DD, scope: agent)` sections per `docs/agent-runtime/user-preference-injection.md` §2.
- File is created **lazily on first promote only** — never at scaffold time. `bridge-docs.py::render_agent_bridge_block` renders the Runtime Canon pointer **conditionally** (only when the file exists). Renderer simulation: +0 bytes when absent, ~135 bytes when present. Matches Phase 1's overhead-zero-when-unused pattern.
- Reuses `--title + --summary + --capture` — **no new CLI flags** (per design consult). `**Why:**` / `**How to apply:**` default to `(see source)` so the CLI stays lean for a rarely-promoted kind.
- `**Source:**` attribution references the real `raw/captures/*` capture id (not the `memory/feedback_<slug>.md` path in the initial spec — runtime reality observed by the codex reviewer during design).
- Search/index integration: `iter_search_candidates` + `search_score` (base 75, between user-profile=80 and user-memory=70) + `collect_index_documents` all register the file so `memory search` and `memory rebuild-index` surface promoted rules in normal queries.
- smoke-test: three Phase 2 invariants — file absent at scaffold, file created + correct section format after first promote, CLAUDE pointer only appears after file exists. Plus a search-index verification cycle.

Closes #162 Phase 2.

## Test plan

- [x] `python3 -m py_compile bridge-memory.py bridge-docs.py bridge-cron.py` (clean)
- [x] `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh` (clean)
- [x] `shellcheck *.sh agent-bridge agb lib/*.sh scripts/*.sh agent-roster.local.example.sh` (clean)
- [x] Direct unit check of `render_agent_bridge_block` — confirms the conditional bullet renders **only** when `ACTIVE-PREFERENCES.md` exists.
- [ ] `./scripts/smoke-test.sh` — new Phase 2 block runs in the existing `$CREATED_AGENT` scaffold (engine=claude, has CLAUDE.md). Skipped locally due to concurrent-smoke env churn; CI will exercise.
- [ ] Codex review round — a pre-dissolution design consult from `agb-dev-codex-2` has already landed via task #90 (deduplicated: no new CLI flags, conditional pointer, search-index gap flagged + addressed here, Source path corrected to raw/captures/*). A short post-implementation review would close the loop.

## Design feedback applied (from codex-2 relay task #90)

1. ✅ No new `--why` / `--how-to-apply` flags — reuse `--title + --summary + --capture`. Defaults to `(see source)`.
2. ✅ Conditional pointer (file-exists gate), not always-present.
3. ✅ Search/index plumbing gap addressed — `iter_search_candidates`, `search_score`, `collect_index_documents` all updated.
4. ✅ Source path corrected to capture id (raw/captures/*), not the spec's `memory/feedback_<slug>.md` (which doesn't exist at the runtime layer the spec assumed).
5. ✅ Smoke-test covers scaffold-time absence, first-promote creation, and the conditional CLAUDE pointer invariant.

## Notes

- Phase 3 (team-wide rules via admin gate, heuristic candidates, 90-day lifecycle) intentionally deferred per the issue body.
- `build_agent_pref_block` deliberately does NOT parse structured `Why:` / `How to apply:` fields from the capture body — that would lock the schema prematurely. If Phase 3 telemetry shows the defaults get overridden often we can add flags then.
- Originally assigned as parallel team work with a `dev-162` teammate; the teammate never got past "waiting on design consult" because the consult response landed on the orchestrator's relay queue (task #90) and wasn't forwarded. Implementation done directly by orchestrator after team dissolution. Design feedback is fully preserved — PR body reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)