### PR TITLE
fix(bootstrap-memory): avoid set -e abort when templates converged

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -516,7 +516,7 @@ bootstrap_install_scripts() {
       templ_changed=$((templ_changed + 1))
       record "install" "template:agents/$rel" "installed" ""
     done < <(find "$agents_src" -type f -name '*.md' -print0 2>/dev/null)
-    [[ "$templ_changed" -gt 0 ]] && log "agent templates changed: $templ_changed"
+    if [[ "$templ_changed" -gt 0 ]]; then log "agent templates changed: $templ_changed"; fi
   fi
 }
 


### PR DESCRIPTION
## Summary

- Root cause: `bootstrap_install_scripts()` ended with `[[ "$templ_changed" -gt 0 ]] && log ...`, which evaluates to exit 1 when `templ_changed=0`. Under `set -euo pipefail` this aborts the whole script.
- Fix: rewrite as `if [[ "$templ_changed" -gt 0 ]]; then log ...; fi` (matches the style of the surrounding block in the same function). Return is now 0 regardless of the counter, so `step_librarian_provision` and cron registration run on converged installs. `--check` and `--dry-run` no longer falsely return 1 either — they `continue` before incrementing the counter, so they hit the same line.
- Scope: single-line edit in `bootstrap-memory-system.sh`. No other logic, no behavior change on non-converged installs.

## Test plan

- [x] `bash -n bootstrap-memory-system.sh` — PASS
- [x] `shellcheck bootstrap-memory-system.sh` — PASS (clean)
- [x] Minimal pre/post-fix repro under `set -euo pipefail`: pre-fix → outer exit=1, `step_librarian_provision` unreached; post-fix → outer exit=0, `step_librarian_provision` reached.
- [x] Isolated `BRIDGE_HOME` repro (mktemp, pre-populated `scripts/agents/librarian/*.md` identical to source so `templ_changed=0`): patched function now returns 0 and control flows into librarian/cron steps.
- [ ] `./scripts/smoke-test.sh` — not run for this change; smoke-test covers daemon/queue/static-role paths and does not exercise `bootstrap-memory-system.sh`. (Pre-existing `[smoke] creating queue task` failure unrelated to this fix per project guidance.)

Fixes #182