### PR TITLE
fix(context-pressure): skip prose fallback for engines without HUD (codex)

### DIFF
--- a/bridge-context-pressure.py
+++ b/bridge-context-pressure.py
@@ -60,6 +60,15 @@ PATTERN_GROUPS: list[tuple[str, list[str]]] = [
     ),
 ]
 
+# Engines with no trustworthy authoritative HUD of their own. When the HUD
+# regex fails for these, we skip the prose fallback rather than emitting a
+# warning, because their scrollback routinely contains literal UI phrases
+# ("Context compacted", "compact the conversation") and doc excerpts that
+# false-positive the fallback regex (issue #183). Claude keeps the existing
+# HUD-or-fallback behavior because the fallback is the only signal on
+# pre-HUD builds.
+ENGINES_WITHOUT_HUD = frozenset({"codex"})
+
 IGNORED_PREFIXES = ("[Agent Bridge]",)
 
 
@@ -118,7 +127,7 @@ def hud_context_pct(normalized: str) -> int | None:
     return pct
 
 
-def classify(normalized: str, full: str | None = None) -> tuple[str, str]:
+def classify(normalized: str, full: str | None = None, engine: str = "") -> tuple[str, str]:
     """Classify context pressure.
 
     The Claude HUD ("Context <bar> NN%") is the authoritative live signal: if
@@ -130,7 +139,10 @@ def classify(normalized: str, full: str | None = None) -> tuple[str, str]:
 
     If no HUD line is visible (pre-HUD Claude builds, Codex, or very fresh
     sessions), fall back to the existing pattern groups so genuine textual
-    signals still fire.
+    signals still fire — except for engines in ``ENGINES_WITHOUT_HUD`` where
+    the fallback has no authoritative ceiling and reliably false-positives on
+    UI prose (issue #183). For those engines we emit nothing when the HUD is
+    absent rather than raise a noisy warning task.
     """
     scan_target = full if full is not None else normalized
     pct = hud_context_pct(scan_target)
@@ -149,6 +161,9 @@ def classify(normalized: str, full: str | None = None) -> tuple[str, str]:
         # post-/compact scrollback mimicking a banner while HUD was low.
         return "", f"hud:context_pct={pct}"
 
+    if engine and engine.lower() in ENGINES_WITHOUT_HUD:
+        return "", ""
+
     lowered = normalized.lower()
     for severity, patterns in PATTERN_GROUPS:
         for pattern in patterns:
@@ -164,12 +179,20 @@ def main() -> int:
     parser.add_argument("--max-bytes", type=int, default=4096)
     parser.add_argument("--format", choices=("json", "shell"), default="json")
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--engine",
+        default="",
+        help=(
+            "Owning agent's engine name (e.g. 'claude', 'codex'). Engines in "
+            "ENGINES_WITHOUT_HUD skip the fallback regex when no HUD is visible."
+        ),
+    )
     args = parser.parse_args()
 
     raw_capture = read_capture(args.capture_file)
     full = normalize_full(raw_capture)
     normalized = normalize_excerpt(raw_capture, max(args.max_bytes, 256))
-    severity, matched = classify(normalized, full=full)
+    severity, matched = classify(normalized, full=full, engine=args.engine)
     payload = {
         "severity": severity,
         "matched_pattern": matched,

--- a/bridge-context-pressure.py
+++ b/bridge-context-pressure.py
@@ -61,12 +61,15 @@ PATTERN_GROUPS: list[tuple[str, list[str]]] = [
 ]
 
 # Engines with no trustworthy authoritative HUD of their own. When the HUD
-# regex fails for these, we skip the prose fallback rather than emitting a
-# warning, because their scrollback routinely contains literal UI phrases
+# regex fails for these, we skip the WARNING-severity fallback group to
+# avoid false-positives on scrollback containing literal UI phrases
 # ("Context compacted", "compact the conversation") and doc excerpts that
-# false-positive the fallback regex (issue #183). Claude keeps the existing
-# HUD-or-fallback behavior because the fallback is the only signal on
-# pre-HUD builds.
+# hit the warning prose patterns (issue #183). CRITICAL-severity patterns
+# ("context window exceeded", "must compact before continuing", etc.) still
+# fire — those are genuine hard-stop banners and are rare enough in
+# scrollback that the false-positive budget is effectively zero.
+# Claude keeps the existing HUD-or-fallback behavior because the fallback
+# is the only signal on pre-HUD builds.
 ENGINES_WITHOUT_HUD = frozenset({"codex"})
 
 IGNORED_PREFIXES = ("[Agent Bridge]",)
@@ -139,10 +142,12 @@ def classify(normalized: str, full: str | None = None, engine: str = "") -> tupl
 
     If no HUD line is visible (pre-HUD Claude builds, Codex, or very fresh
     sessions), fall back to the existing pattern groups so genuine textual
-    signals still fire — except for engines in ``ENGINES_WITHOUT_HUD`` where
-    the fallback has no authoritative ceiling and reliably false-positives on
-    UI prose (issue #183). For those engines we emit nothing when the HUD is
-    absent rather than raise a noisy warning task.
+    signals still fire. For engines in ``ENGINES_WITHOUT_HUD`` the WARNING-
+    severity group is skipped because it false-positives reliably on UI
+    prose and doc excerpts (issue #183); the CRITICAL-severity group still
+    runs so genuine hard-stop banners like "context window exceeded" or
+    "must compact before continuing" still raise a task (PR #188 review
+    feedback — silencing critical outright would hide real failures).
     """
     scan_target = full if full is not None else normalized
     pct = hud_context_pct(scan_target)
@@ -161,11 +166,12 @@ def classify(normalized: str, full: str | None = None, engine: str = "") -> tupl
         # post-/compact scrollback mimicking a banner while HUD was low.
         return "", f"hud:context_pct={pct}"
 
-    if engine and engine.lower() in ENGINES_WITHOUT_HUD:
-        return "", ""
+    skip_warning_fallback = bool(engine) and engine.lower() in ENGINES_WITHOUT_HUD
 
     lowered = normalized.lower()
     for severity, patterns in PATTERN_GROUPS:
+        if skip_warning_fallback and severity == "warning":
+            continue
         for pattern in patterns:
             if re.search(pattern, lowered, flags=re.IGNORECASE | re.DOTALL):
                 return severity, pattern

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1512,7 +1512,7 @@ process_context_pressure_reports() {
     excerpt_b64=""
     excerpt=""
     if [[ -n "$capture" ]]; then
-      analysis_shell="$(printf '%s' "$capture" | python3 "$SCRIPT_DIR/bridge-context-pressure.py" analyze --format shell 2>/dev/null || true)"
+      analysis_shell="$(printf '%s' "$capture" | python3 "$SCRIPT_DIR/bridge-context-pressure.py" analyze --format shell --engine "$engine" 2>/dev/null || true)"
       if [[ -n "$analysis_shell" ]]; then
         CONTEXT_PRESSURE_SEVERITY=""
         CONTEXT_PRESSURE_MATCHED_PATTERN=""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -165,6 +165,17 @@ run_cp_case "claude + 'compact the conversation' prose -> warning" \
   "warning" "" \
   $'Consider whether to compact the conversation before continuing.\n' \
   "claude"
+# PR #188 review: critical banners must still fire on codex even though the
+# warning fallback is suppressed. Silencing critical-severity patterns would
+# hide genuine hard-stop failures on codex agents.
+run_cp_case "codex + 'context window exceeded' banner -> critical" \
+  "critical" "context window exceeded" \
+  $'context window exceeded — model refused to continue\n' \
+  "codex"
+run_cp_case "codex + 'must compact before continuing' banner -> critical" \
+  "critical" "must compact before continuing" \
+  $'must compact before continuing before the next turn\n' \
+  "codex"
 
 log "CLI subcommand suggestion helper (issue #163)"
 run_suggest_case() {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -113,8 +113,13 @@ run_cp_case() {
   local expected_severity="$2"
   local expected_pattern_substring="$3"
   local input="$4"
+  local engine="${5:-}"
   local out
-  out="$(printf '%s' "$input" | python3 "$REPO_ROOT/bridge-context-pressure.py" analyze --format shell)"
+  if [[ -n "$engine" ]]; then
+    out="$(printf '%s' "$input" | python3 "$REPO_ROOT/bridge-context-pressure.py" analyze --format shell --engine "$engine")"
+  else
+    out="$(printf '%s' "$input" | python3 "$REPO_ROOT/bridge-context-pressure.py" analyze --format shell)"
+  fi
   assert_contains "$out" "CONTEXT_PRESSURE_SEVERITY=\"$expected_severity\""
   if [[ -n "$expected_pattern_substring" ]]; then
     assert_contains "$out" "$expected_pattern_substring"
@@ -142,6 +147,24 @@ run_cp_case "HUD wrapped after 'Context' -> still matches" \
 run_cp_case "prose 'Context remaining 8%' -> warning via fallback" \
   "warning" "" \
   $'Context remaining 8%. Please compact soon.\n'
+# Codex has no HUD of its own; fallback regex historically false-positived on
+# UI strings ("Context compacted") and doc excerpts ("compact the
+# conversation"). With --engine codex the detector must emit nothing when the
+# HUD is absent (issue #183).
+run_cp_case "codex + 'Context compacted' UI string -> silent" \
+  "" "" \
+  $'Context compacted (ctrl+o for history)\n> \n' \
+  "codex"
+run_cp_case "codex + docs 'compact the conversation' prose -> silent" \
+  "" "" \
+  $'Consider whether to compact the conversation before continuing.\n' \
+  "codex"
+# Claude path unchanged: same prose still yields a fallback warning because
+# --engine claude (or unset) keeps the pattern groups active.
+run_cp_case "claude + 'compact the conversation' prose -> warning" \
+  "warning" "" \
+  $'Consider whether to compact the conversation before continuing.\n' \
+  "claude"
 
 log "CLI subcommand suggestion helper (issue #163)"
 run_suggest_case() {


### PR DESCRIPTION
## Summary
- `bridge-context-pressure.py` treats the Claude CLI's `Context ██████ NN%` HUD as the authoritative live signal. Codex has no such HUD, so every codex scan fell through to the prose regex fallback — which false-positived on literal UI strings ("Context compacted"), doc excerpts ("compact the conversation"), and scrollback percents ("60% context"), drowning admin inbox with noise.
- Add `ENGINES_WITHOUT_HUD = {"codex"}` and a new `--engine` argument on `bridge-context-pressure.py analyze`. When the HUD is absent and the engine is on the list, emit nothing instead of raising a warning. Claude behavior is unchanged (it keeps HUD-or-fallback so pre-HUD builds still fire on genuine prose signals). If Codex ever ships a HUD that matches the existing regex the authoritative path still wins for codex too.
- Plumb `engine` through the daemon's `process_context_pressure_reports` loop; extend `scripts/smoke-test.sh run_cp_case` with an optional 5th `engine` arg and add three cases covering the silent codex paths and the preserved claude fallback.

## Verification
- `python3 -m py_compile bridge-context-pressure.py` -> PASS
- `bash -n bridge-daemon.sh scripts/smoke-test.sh` -> PASS
- `shellcheck` on the touched shell files -> PASS
- Unit-level in-process `classify()` probe (codex + Context compacted / compact the conversation / 60% context -> silent; claude + same prose -> warning; claude HUD 70% -> warning; codex HUD 70% if ever present -> warning; empty engine backward-compat -> warning; `CODEX` uppercase -> silent) -> ALL PASS
- `./scripts/smoke-test.sh` -> all 8 context-pressure cases pass (lines 2-10 of the log), including the three new codex/claude cases for this issue. The pre-existing `[smoke] creating queue task` / `smoke-agent-<id>` daemon-sync failure still trips the run; it reproduces on `main` without this patch and is unrelated.

## Test plan
- [x] Codex agent with `Context compacted` in scrollback no longer emits `[context-pressure] warning` task.
- [x] Codex agent with `compact the conversation` prose in scrollback no longer emits warning.
- [x] Codex agent with `60% context` prose no longer emits warning.
- [x] Claude agent with the same prose still emits warning (backward compat preserved).
- [x] Claude agent with an authoritative HUD reading >= warning/critical threshold still classifies correctly.
- [x] Empty `--engine` argument (legacy callers) preserves current fallback behavior.
- [ ] Live verification in a real bridge runtime: start a codex session that was previously firing warnings, confirm no fresh `[context-pressure]` tasks appear across a full scan interval.

Fixes #183

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>