### PR TITLE
fix(bridge-agent): reject ephemeral BRIDGE_HOME when seeding autoMemoryDirectory

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -232,18 +232,26 @@ resolved_home = os.path.realpath(bridge_home)
 # invokes bridge-agent from an ephemeral BRIDGE_HOME without also scoping
 # the agent workdir to that same ephemeral root is violating the
 # isolation contract; refuse here so the leak cannot reach live state.
-_EPHEMERAL_PREFIXES = (
-    "/tmp/",
-    "/private/tmp/",
-    "/var/folders/",
-    "/private/var/folders/",
-)
+_EPHEMERAL_ROOTS = [
+    "/tmp",
+    "/private/tmp",
+    "/var/folders",
+    "/private/var/folders",
+]
 tmpdir = os.environ.get("TMPDIR")
 if tmpdir:
-    tmpdir_resolved = os.path.realpath(tmpdir)
-    # Normalize with trailing sep so we match directory boundary, not prefix.
-    _EPHEMERAL_PREFIXES = _EPHEMERAL_PREFIXES + (tmpdir_resolved.rstrip("/") + "/",)
-if any(resolved_home.startswith(prefix) for prefix in _EPHEMERAL_PREFIXES):
+    _EPHEMERAL_ROOTS.append(os.path.realpath(tmpdir).rstrip("/") or "/")
+
+def _is_ephemeral(path: str) -> bool:
+    # Match the root itself (BRIDGE_HOME=/tmp) AND any descendant
+    # (BRIDGE_HOME=/tmp/xyz). Plain startswith() with a trailing slash
+    # would miss the exact-root case, letting a caller bypass the guard.
+    for root in _EPHEMERAL_ROOTS:
+        if path == root or path.startswith(root + os.sep):
+            return True
+    return False
+
+if _is_ephemeral(resolved_home):
     sys.stderr.write(
         f"[bridge-agent] refusing to seed autoMemoryDirectory for "
         f"'{agent}' from ephemeral BRIDGE_HOME {resolved_home!r}. "

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -221,6 +221,38 @@ agent = sys.argv[2]
 bridge_home = sys.argv[3]
 
 resolved_home = os.path.realpath(bridge_home)
+
+# Issue #185: reject ephemeral BRIDGE_HOME values before deriving the
+# per-agent auto-memory slug. Claude Code's built-in `fewer-permission-
+# prompts` smoke test ran this path with `BRIDGE_HOME=$(mktemp -d)` and
+# then — because the agent workdir was the live path — wrote a
+# settings.local.json into the live agent home whose autoMemoryDirectory
+# pointed at a tmp slug. The tmp dir disappeared after the smoke, leaving
+# pref-smoke stuck on a dangling auto-memory target. Any caller that
+# invokes bridge-agent from an ephemeral BRIDGE_HOME without also scoping
+# the agent workdir to that same ephemeral root is violating the
+# isolation contract; refuse here so the leak cannot reach live state.
+_EPHEMERAL_PREFIXES = (
+    "/tmp/",
+    "/private/tmp/",
+    "/var/folders/",
+    "/private/var/folders/",
+)
+tmpdir = os.environ.get("TMPDIR")
+if tmpdir:
+    tmpdir_resolved = os.path.realpath(tmpdir)
+    # Normalize with trailing sep so we match directory boundary, not prefix.
+    _EPHEMERAL_PREFIXES = _EPHEMERAL_PREFIXES + (tmpdir_resolved.rstrip("/") + "/",)
+if any(resolved_home.startswith(prefix) for prefix in _EPHEMERAL_PREFIXES):
+    sys.stderr.write(
+        f"[bridge-agent] refusing to seed autoMemoryDirectory for "
+        f"'{agent}' from ephemeral BRIDGE_HOME {resolved_home!r}. "
+        "If a smoke test wants isolation, scope BOTH BRIDGE_HOME and the "
+        "agent workdir to the same tmp root; do not call bridge-agent "
+        "with a live workdir under a tmp BRIDGE_HOME (issue #185).\n"
+    )
+    sys.exit(1)
+
 # Match Anthropic's ~/.claude/projects/ slug convention: replace both
 # os.sep and "." with "-" so two installs never share a directory.
 slug = resolved_home.replace(os.sep, "-").replace(".", "-")


### PR DESCRIPTION
## Summary

- Root cause: `bridge_ensure_auto_memory_isolation` derives the per-agent auto-memory slug from the resolved `BRIDGE_HOME`. Claude Code's built-in `fewer-permission-prompts` smoke test called `bridge-agent register` with `BRIDGE_HOME=$(mktemp -d)` but left the agent workdir under the live runtime — the seeder wrote a tmp slug into the live agent home's `settings.local.json`, the tmp dir disappeared after the smoke, and the live agent was permanently broken (the state documented in issue #185).
- Fix: add a defensive guard at the python seeder. If the resolved `BRIDGE_HOME` is under `/tmp/`, `/private/tmp/`, `/var/folders/`, `/private/var/folders/`, or the current `$TMPDIR`, refuse to write and emit a clear error naming the issue and the contract expected of smoke-test callers (scope BOTH BRIDGE_HOME and the agent workdir to the same ephemeral root, or don't use ephemeral BRIDGE_HOME at all).
- Scope: purely preventive. Does not clean up a stale managed-role block that already exists on an installed host — that is operator work (remove the managed block from the local roster + `rm -rf` the leaked agent home). The guard prevents future leaks of the same shape from any caller, including re-invocations of the same CC built-in.
- The skill's own source is bundled with the Claude Code CLI and not reachable from this repo, so an upstream fix to the skill is not possible here. The defensive guard is the most this repo can do.

## Test plan

- [x] `bash -n bridge-agent.sh` — PASS
- [x] Embedded-python compile check — PASS
- [x] Ad-hoc repro: `BRIDGE_HOME=\$(mktemp -d)` → seeder exits 1, nothing written; `BRIDGE_HOME=~/.agent-bridge-test-\<pid\>` → seeder runs as before.
- [ ] `./scripts/smoke-test.sh` — not re-run for this change; smoke-test does not currently exercise `bridge_ensure_auto_memory_isolation`. A follow-up smoke case that asserts the refusal on ephemeral BRIDGE_HOME is a reasonable next step but out of scope for this focused fix.

## Follow-ups (not in this PR)

- Install-time / upgrade-time sweeper that detects roster entries whose agent home has an `autoMemoryDirectory` pointing at a non-existent ephemeral path, and offers to clean them up (would have cleaned up the leftover on this host).
- Symmetric guard on any other path that consumes `BRIDGE_HOME` to write live state (e.g., direct `BRIDGE_AGENT_WORKDIR` writes in `bridge_write_role_block`).

Fixes #185