### PR TITLE
fix(state): skip --continue on Claude first wake with no resumable transcript

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -76,7 +76,15 @@ bridge_build_dynamic_launch_cmd() {
       session_id=""
     fi
     if [[ "$effective_continue" == "1" && -z "$session_id" ]]; then
-      continue_fallback=1
+      if bridge_claude_has_resumable_session_state "$(bridge_agent_workdir "$agent")"; then
+        continue_fallback=1
+      else
+        bridge_warn "Claude agent '$agent' has continue=1 but no resumable session yet (first wake); launching fresh."
+        bridge_audit_log state claude_session_resume_skipped_first_wake "$agent" \
+          --field "continue_mode=$continue_mode" \
+          --field "reason=no_transcript" \
+          2>/dev/null || true
+      fi
     fi
   else
     bridge_normalize_agent_session_id "$agent"
@@ -499,7 +507,15 @@ bridge_build_static_claude_launch_cmd() {
     effective_continue=1
     session_id="$(bridge_claude_resume_session_id_for_agent "$agent" || true)"
     if [[ "$effective_continue" == "1" && -z "$session_id" ]]; then
-      continue_fallback=1
+      if bridge_claude_has_resumable_session_state "$(bridge_agent_workdir "$agent")"; then
+        continue_fallback=1
+      else
+        bridge_warn "Claude agent '$agent' has continue=1 but no resumable session yet (first wake); launching fresh."
+        bridge_audit_log state claude_session_resume_skipped_first_wake "$agent" \
+          --field "continue_mode=$continue_mode" \
+          --field "reason=no_transcript" \
+          2>/dev/null || true
+      fi
     fi
   fi
 
@@ -1464,6 +1480,53 @@ if best is None:
             best = (mtime_ms, stem)
 
 print(best[1] if best else "")
+PY
+}
+
+# Returns 0 (true) if the given workdir has any `~/.claude/projects/<slug>/*.jsonl`
+# transcript on disk. On first-wake (e.g. a freshly provisioned agent that has
+# never run) the directory is missing or empty and `claude --continue` would
+# fail with "No deferred tool marker found in the resumed session". Callers use
+# this to skip the `--continue` fallback until a real transcript exists.
+bridge_claude_has_resumable_session_state() {
+  local workdir="$1"
+  [[ -n "$workdir" ]] || return 1
+
+  python3 - "$workdir" <<'PY'
+import os
+import re
+import sys
+
+workdir = os.path.realpath(sys.argv[1])
+
+
+def workdir_slug_candidates(path):
+    slash_only = path.replace("/", "-")
+    slash_and_dot = re.sub(r"[/.]", "-", path)
+    candidates = [slash_only]
+    if slash_and_dot != slash_only:
+        candidates.append(slash_and_dot)
+    return candidates
+
+
+for slug in workdir_slug_candidates(workdir):
+    base = os.path.expanduser(f"~/.claude/projects/{slug}")
+    if not os.path.isdir(base):
+        continue
+    try:
+        entries = os.listdir(base)
+    except OSError:
+        continue
+    for entry in entries:
+        if not entry.endswith(".jsonl"):
+            continue
+        full = os.path.join(base, entry)
+        try:
+            if os.path.isfile(full) and os.path.getsize(full) > 0:
+                raise SystemExit(0)
+        except OSError:
+            continue
+raise SystemExit(1)
 PY
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3444,9 +3444,12 @@ CLAUDE_LAUNCH_RESTART_CONTINUE="$("$BASH4_BIN" -c '
   BRIDGE_AGENT_CONTINUE["claude-static"]="1"
   BRIDGE_AGENT_LOOP_RESTART_COUNT=1
   unset BRIDGE_AGENT_SESSION_ID["claude-static"]
-  bridge_agent_launch_cmd "claude-static"
+  bridge_agent_launch_cmd "claude-static" 2>&1
 ')"
-assert_contains "$CLAUDE_LAUNCH_RESTART_CONTINUE" "claude --continue --dangerously-skip-permissions --name claude-static --channels plugin:discord@claude-plugins-official"
+# Issue #189: without a resumable transcript in ~/.claude/projects/<slug>/,
+# emitting `--continue` would crash the claude CLI. Skip it and warn instead.
+assert_not_contains "$CLAUDE_LAUNCH_RESTART_CONTINUE" "claude --continue"
+assert_contains "$CLAUDE_LAUNCH_RESTART_CONTINUE" "no resumable session yet (first wake)"
 
 cat >"$CLAUDE_STATIC_WORKDIR/NEXT-SESSION.md" <<'EOF'
 # NEXT SESSION
@@ -3531,10 +3534,14 @@ CLAUDE_LAUNCH_STALE_DETECTED_SESSION="$(HOME="$FAKE_CLAUDE_STALE_HOME" "$BASH4_B
   BRIDGE_AGENT_CONTINUE["claude-static"]="1"
   BRIDGE_AGENT_LOOP_RESTART_COUNT=1
   unset BRIDGE_AGENT_SESSION_ID["claude-static"]
-  bridge_agent_launch_cmd "claude-static"
+  bridge_agent_launch_cmd "claude-static" 2>&1
 ')"
-assert_contains "$CLAUDE_LAUNCH_STALE_DETECTED_SESSION" "claude --continue --dangerously-skip-permissions --name claude-static --channels plugin:discord@claude-plugins-official"
+# Issue #189: when sessions/*.json references a session whose transcript is
+# missing AND the projects cache for this workdir is empty, `--continue` would
+# crash with "No deferred tool marker found". Skip the flag instead and warn.
+assert_not_contains "$CLAUDE_LAUNCH_STALE_DETECTED_SESSION" "claude --continue"
 assert_not_contains "$CLAUDE_LAUNCH_STALE_DETECTED_SESSION" "--resume stale-detected-session-id"
+assert_contains "$CLAUDE_LAUNCH_STALE_DETECTED_SESSION" "no resumable session yet (first wake)"
 cat >"$CLAUDE_STATIC_WORKDIR/NEXT-SESSION.md" <<'EOF'
 # SAFE MODE NEXT SESSION
 


### PR DESCRIPTION
## Summary

- Root cause: any Claude-engine agent with `BRIDGE_AGENT_CONTINUE=1` (e.g., freshly-provisioned `librarian`) crash-loops on first wake because `claude --continue` fails with `No deferred tool marker found in the resumed session` — there is no resumable session yet. The watchdog cron respawns on the same fail path every ~10 min → 5 rapid failures → circuit breaker → safe-mode → repeat.
- Fix: add `bridge_claude_has_resumable_session_state` in `lib/bridge-state.sh` (stat-only helper — checks whether any non-empty transcript exists under `~/.claude/projects/<slug>/`). Gate `continue_fallback=1` in both `bridge_build_dynamic_launch_cmd` and `bridge_build_static_claude_launch_cmd` on it. When no transcript is present we emit the launch command without `--continue` and log a one-line warning `no resumable session yet (first wake)`.
- Scope: read-only filesystem stat. No writes. On the next wake after a successful first launch the transcript exists and the existing `--resume`/`--continue` path runs unchanged.

## Test plan

- [x] `bash -n lib/bridge-state.sh lib/bridge-agents.sh scripts/smoke-test.sh` — PASS
- [x] `shellcheck lib/bridge-state.sh scripts/smoke-test.sh` — PASS (no output)
- [x] Embedded python heredoc — exit 1 when no transcripts, exit 0 when a non-empty `.jsonl` exists.
- [x] Isolated `BRIDGE_HOME` repro, 5 cases:
  - No `~/.claude/projects/<slug>/` → no `--continue`, first-wake warning logged.
  - Projects dir exists but empty → no `--continue`.
  - Zero-byte `.jsonl` in projects dir → no `--continue`.
  - Non-empty transcript → `--resume <sid>` preserved.
  - `sessions/*.json` session id with missing transcript (previously fell back to `--continue`) → no `--continue`, first-wake warning.
- [x] Smoke-test: two assertions (`CLAUDE_LAUNCH_RESTART_CONTINUE`, `CLAUDE_LAUNCH_STALE_DETECTED_SESSION`) updated to reflect the new first-wake contract.
- [ ] Full `./scripts/smoke-test.sh` green — this machine has pre-existing contaminated state + known flaky `codex-cli-agent` nudge assertion that reproduces without any of these edits. Recommend re-running smoke in a clean env before merge if required as a gate.

## Note

`bridge_build_safe_launch_cmd` is referenced in `bridge-run.sh:100,431` and `smoke-test.sh:3519,3548` but is not defined anywhere in the tree. Pre-existing unrelated bug; not touched here.

Fixes #189