### PR TITLE
fix(daemon): dedupe crash_loop_report refresh mode by (error_hash, cooldown)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1972,15 +1972,29 @@ process_crash_reports() {
         body_file="$(bridge_agent_crash_report_body_file "$agent")"
         bridge_write_crash_report_body "$agent" "$body_file" "$fail_count" "$exit_code" "$engine" "$stderr_file" "$tail_file" "$launch_cmd"
         if [[ "$existing_id" =~ ^[0-9]+$ ]]; then
-          bridge_queue_cli update "$existing_id" --actor daemon --title "$title" --priority urgent --body-file "$body_file" >/dev/null 2>&1 || true
-          bridge_audit_log daemon crash_loop_report "$admin_agent" \
-            --detail agent="$agent" \
-            --detail mode=refresh \
-            --detail fail_count="$fail_count" \
-            --detail exit_code="$exit_code" \
-            --detail error_hash="$error_hash" \
-            --detail body_file="$body_file"
-          reported=1
+          # Issue #204: refresh-mode used to fire every scan cycle regardless
+          # of whether anything changed since the last refresh. If the admin
+          # left the existing [crash-loop] task queued (the normal case until
+          # they investigate), the daemon updated the same task body and
+          # emitted a `crash_loop_report mode=refresh` audit every ~10 s with
+          # an identical error_hash — inbox / audit.jsonl / notify transports
+          # all saw duplicate noise on the same signal. Apply the same
+          # `error_hash != last_hash || cooldown elapsed` guard the create
+          # branch already uses, so a stable signal refreshes at most once
+          # per cooldown window (default 1800 s).
+          if [[ "$error_hash" == "$last_hash" && $(( now_ts - last_report_ts )) -lt "$cooldown" ]]; then
+            :
+          else
+            bridge_queue_cli update "$existing_id" --actor daemon --title "$title" --priority urgent --body-file "$body_file" >/dev/null 2>&1 || true
+            bridge_audit_log daemon crash_loop_report "$admin_agent" \
+              --detail agent="$agent" \
+              --detail mode=refresh \
+              --detail fail_count="$fail_count" \
+              --detail exit_code="$exit_code" \
+              --detail error_hash="$error_hash" \
+              --detail body_file="$body_file"
+            reported=1
+          fi
         elif [[ "$error_hash" != "$last_hash" || $(( now_ts - last_report_ts )) -ge "$cooldown" ]]; then
           create_output="$(bridge_queue_cli create --to "$admin_agent" --from daemon --priority urgent --title "$title" --body-file "$body_file" 2>/dev/null || true)"
           if [[ "$create_output" =~ created\ task\ \#([0-9]+) ]]; then


### PR DESCRIPTION
## Summary

- Root cause: `process_crash_reports` in `bridge-daemon.sh` fired a `mode=refresh` emit — `bridge_queue_cli update` + `bridge_audit_log crash_loop_report` — on every scan cycle as long as an existing `[crash-loop] <agent>` task was queued in the admin inbox. No cooldown, no hash comparison.
- Live repro on v0.6.3: pref-smoke `error_hash dd89a2b8…` re-emitted every ~10 s for an hour+, same body, same signal. Inbox / audit.jsonl / notify transports all double-fired.
- Fix: apply the same `error_hash != last_hash || cooldown elapsed` guard the `create` branch already uses. A stable signal now refreshes at most once per cooldown window (default 1800 s from `BRIDGE_CRASH_REPORT_COOLDOWN_SECONDS`). Escalation still fires when `error_hash` changes or cooldown elapses.
- Same bug class and fix shape as #184 (context-pressure dedupe).

## Test plan

- [x] `bash -n bridge-daemon.sh` — PASS
- [x] Traced the guard path by hand: with `error_hash == last_hash && now - last_report_ts < cooldown`, the `:` branch runs, `reported` stays 0, and the state file write at line 2001 is skipped — so `last_hash` / `last_report_ts` do not shift and the next scan re-evaluates against the same reference.
- [ ] Live: apply via `agent-bridge upgrade`, observe `audit.jsonl` — existing refresh spam on pref-smoke should stop after the first cooldown window (1800 s default) and not re-start while the error_hash is unchanged.

Fixes #204