### PR TITLE
daemon: guard ensured always-on against attached tmux sessions

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2888,6 +2888,8 @@ process_on_demand_agents() {
   local live_queued=0
   local live_claimed=0
   local live_blocked=0
+  local configured_session=""
+  local attached_count=0
 
   while IFS=$'\t' read -r agent queued claimed blocked active idle _last_seen _last_nudge session _engine _workdir; do
     [[ -z "$agent" ]] && continue
@@ -2907,6 +2909,26 @@ process_on_demand_agents() {
     if [[ "$active" == "0" ]]; then
       if ! bridge_daemon_autostart_allowed "$agent"; then
         continue
+      fi
+      # Defensive guard (issue #190 symptom D): even when the summary reports
+      # active=0 (e.g. fresh daemon, state drift, or roster/tmux name mismatch),
+      # never auto-start on top of a tmux session that currently has a human
+      # client attached. bridge-start.sh without --replace is idempotent today,
+      # but skipping early avoids spurious "ensured always-on" log spam that
+      # masks real restarts and guards the attached path from future refactors.
+      configured_session="$(bridge_agent_session "$agent")"
+      if [[ -n "$configured_session" ]] && bridge_tmux_session_exists "$configured_session"; then
+        attached_count="$(bridge_tmux_session_attached_count "$configured_session" 2>/dev/null || printf '0')"
+        [[ "$attached_count" =~ ^[0-9]+$ ]] || attached_count=0
+        if (( attached_count > 0 )); then
+          bridge_daemon_clear_autostart_failure "$agent"
+          bridge_audit_log daemon autostart_skipped_attached "$agent" \
+            --detail session="$configured_session" \
+            --detail attached="$attached_count" \
+            --detail always_on="$always_on"
+          daemon_info "skipped-attached ${agent} (session=${configured_session} attached=${attached_count})"
+          continue
+        fi
       fi
       if ((( always_on == 1 ))) && ! bridge_agent_is_active "$agent"; then
         if "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Root cause: inside `process_on_demand_agents`, the always-on autostart branch reached `bridge-start.sh` (which emits the `ensured always-on <agent>` log) for an agent whose tmux session was alive AND had an attached tmux client. The reporter saw `ensured always-on patch` emitted 22:11:41 while Claude Code was actively attached to `patch` — the `SessionStart:resume` hook then had to recover the user's in-progress conversation.
- Fix: before either the always-on branch or the queued-work branch runs, probe the configured tmux session. If it exists and `bridge_tmux_session_attached_count > 0`, emit a `daemon autostart_skipped_attached` audit + `skipped-attached <agent>` info line, clear the autostart-failure marker, and `continue`. Mirrors the three-way fan-out (not-loop / no-session / attached) that `bridge-upgrade.sh::bridge_upgrade_collect_agent_restart_report` has used since before #198.

## Test plan

- [x] `bash -n bridge-daemon.sh` — PASS (Homebrew bash)
- [x] `shellcheck bridge-daemon.sh` — PASS (clean, no new warnings)
- [x] Isolated repro (`/tmp/test_symptom_d.sh`, 3 scenarios):
  - Session alive + attached=1 → logs `skipped-attached`, `bridge-start.sh` NOT invoked, no `ensured always-on`. **This is the symptom-D fix.**
  - Session missing → `bridge-start.sh` invoked, preserves recreate path.
  - Session alive + attached=0 → `bridge-start.sh` invoked, preserves existing idempotent path.
- [ ] `./scripts/smoke-test.sh` — hangs on main at a pre-existing point (`smoke-agent-* busy-loop` under `bridge-agent.sh restart claude-static`). Same hang reproduces without this change. Not the code path edited here.

## Scope

- Hardens the specific observed class: false-positive restart on an attached-and-alive session.
- The reporter's trace also mentions an actual tmux kill+recreate. `bridge-start.sh` without `--replace` does not kill, so this PR doesn't address that additional symptom. If it lies in `process_plugin_liveness`, MCP orphan cleanup, or a pre-#193 crash signature, it belongs in a separate issue — not worsened by this PR.

Fixes #190 (symptom D)