### PR TITLE
daemon: reconcile dynamic agents from live tmux sessions (#190 symptom B)

### DIFF
--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -153,6 +153,7 @@ bridge_source_module() {
   source "$path"
 }
 
+bridge_source_module "bridge-session-patterns.sh"
 bridge_source_module "bridge-core.sh"
 bridge_source_module "bridge-agents.sh"
 bridge_source_module "bridge-guard.sh"

--- a/lib/bridge-session-patterns.sh
+++ b/lib/bridge-session-patterns.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Centralized list of tmux session-name globs that represent smoke-test
+# or ad hoc harness sessions. Consumed by:
+#   - scripts/smoke-test.sh::kill_stale_smoke_tmux_sessions
+#   - lib/bridge-state.sh::bridge_reconcile_dynamic_agents_from_tmux
+# Keep the pattern list here so the two consumers cannot drift.
+
+bridge_session_is_smoke_or_adhoc() {
+  local session="$1"
+  case "$session" in
+    bridge-smoke-*|bridge-requester-*|auto-start-session-*|\
+    always-on-session-*|static-session-*|claude-static-bridge-smoke-*|\
+    worker-reuse-*|late-dynamic-agent-*|created-session-*|\
+    bootstrap-session-*|bootstrap-wrapper-session-*|broken-channel-*|\
+    context-pressure-bridge-smoke-*|codex-cli-session-*|\
+    project-claude-session-bridge-smoke-*|stall-auth-*|stall-rate-*|\
+    stall-unknown-*|roster-reload-session-*|smoke-admin-test*|\
+    stall-rate-test-*|memtest*|bootstrap-fail*|memphase4-*)
+      return 0
+      ;;
+  esac
+  return 1
+}

--- a/lib/bridge-session-patterns.sh
+++ b/lib/bridge-session-patterns.sh
@@ -16,7 +16,7 @@ bridge_session_is_smoke_or_adhoc() {
     context-pressure-bridge-smoke-*|codex-cli-session-*|\
     project-claude-session-bridge-smoke-*|stall-auth-*|stall-rate-*|\
     stall-unknown-*|roster-reload-session-*|smoke-admin-test*|\
-    stall-rate-test-*|memtest*|bootstrap-fail*|memphase4-*)
+    memtest*|bootstrap-fail*|memphase4-*)
       return 0
       ;;
   esac

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -759,6 +759,149 @@ bridge_restore_dynamic_agents_from_history() {
   shopt -u nullglob
 }
 
+# Last-resort dynamic-agent reconciliation: if a live tmux session looks like
+# a dynamic agent (session name equals agent name by construction) but neither
+# the active .env nor the history .env restored it, rebuild the entry from:
+#   1) a history file prefixed by the session name (preferred — has the real
+#      engine + workdir + session_id), or
+#   2) the tmux pane itself (engine detected from the pane command, workdir
+#      from pane_current_path) when no history exists.
+# Without this, a prune followed by loss of the active .env leaves the agent
+# invisible on the dashboard even though the tmux session is still the source
+# of truth (#190B).
+bridge_reconcile_dynamic_agents_from_tmux() {
+  local session
+  local file
+  local active_file
+  local pane_cmd
+  local pane_path
+  local derived_engine
+
+  command -v tmux >/dev/null 2>&1 || return 0
+
+  while IFS= read -r session; do
+    [[ -n "$session" ]] || continue
+    if bridge_agent_exists "$session"; then
+      continue
+    fi
+    # Skip obvious non-agent sessions used by smoke tests and ad hoc patterns.
+    case "$session" in
+      bridge-smoke-*|bridge-requester-*|auto-start-session-*|always-on-session-*|\
+      static-session-*|claude-static-bridge-smoke-*|worker-reuse-*|\
+      late-dynamic-agent-*|created-session-*|bootstrap-session-*|\
+      bootstrap-wrapper-session-*|broken-channel-*|codex-cli-session-*|\
+      project-claude-session-bridge-smoke-*|memtest*|bootstrap-fail*|memphase4-*)
+        continue
+        ;;
+    esac
+
+    # Prefer any history file whose filename starts with `<session>--`, which
+    # means it was previously written for this exact agent name. Keep only
+    # the newest match.
+    file=""
+    _bridge_pick_newest_history_for_session file "$session"
+    if [[ -n "$file" ]]; then
+      _bridge_register_dynamic_from_env_file "$session" "$file" && continue
+    fi
+
+    # Fall back to tmux pane inspection: we can only recover agents whose pane
+    # command is a recognizable engine binary, since otherwise we have no
+    # reliable way to set AGENT_ENGINE.
+    pane_cmd="$(tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_current_command}' 2>/dev/null || true)"
+    pane_path="$(tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_current_path}' 2>/dev/null || true)"
+    derived_engine=""
+    case "$pane_cmd" in
+      *claude*) derived_engine="claude" ;;
+      *codex*)  derived_engine="codex" ;;
+    esac
+    [[ -n "$derived_engine" && -d "$pane_path" ]] || continue
+
+    bridge_add_agent_id_if_missing "$session"
+    BRIDGE_AGENT_DESC["$session"]="Recovered ${derived_engine} agent (${pane_path})"
+    BRIDGE_AGENT_ENGINE["$session"]="$derived_engine"
+    BRIDGE_AGENT_SESSION["$session"]="$session"
+    BRIDGE_AGENT_WORKDIR["$session"]="$pane_path"
+    BRIDGE_AGENT_SOURCE["$session"]="dynamic"
+    BRIDGE_AGENT_LOOP["$session"]="1"
+    BRIDGE_AGENT_CONTINUE["$session"]="1"
+    BRIDGE_AGENT_SESSION_ID["$session"]=""
+    BRIDGE_AGENT_HISTORY_KEY["$session"]="$(bridge_history_key_for "$derived_engine" "$session" "$pane_path")"
+    BRIDGE_AGENT_CREATED_AT["$session"]="$(date +%s)"
+    BRIDGE_AGENT_UPDATED_AT["$session"]="$(bridge_now_iso)"
+
+    active_file="$(bridge_dynamic_agent_file_for "$session")"
+    BRIDGE_AGENT_META_FILE["$session"]="$active_file"
+    bridge_write_dynamic_agent_file "$session" "$active_file"
+  done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)
+}
+
+_bridge_pick_newest_history_for_session() {
+  local -n __out_ref="$1"
+  local session="$2"
+  local candidate
+  local -a candidates=()
+
+  shopt -s nullglob
+  candidates=("$BRIDGE_HISTORY_DIR/${session}--"*.env)
+  shopt -u nullglob
+
+  __out_ref=""
+  for candidate in "${candidates[@]}"; do
+    [[ -f "$candidate" ]] || continue
+    if [[ -z "$__out_ref" || "$candidate" -nt "$__out_ref" ]]; then
+      __out_ref="$candidate"
+    fi
+  done
+}
+
+_bridge_register_dynamic_from_env_file() {
+  local session="$1"
+  local file="$2"
+  local active_file
+  local AGENT_ID=""
+  local AGENT_DESC=""
+  local AGENT_ENGINE=""
+  local AGENT_SESSION=""
+  local AGENT_WORKDIR=""
+  local AGENT_LOOP=""
+  local AGENT_CONTINUE=""
+  local AGENT_SESSION_ID=""
+  local AGENT_HISTORY_KEY=""
+  local AGENT_CREATED_AT=""
+  local AGENT_UPDATED_AT=""
+
+  # shellcheck source=/dev/null
+  source "$file"
+
+  if [[ -z "$AGENT_ID" || -z "$AGENT_ENGINE" || -z "$AGENT_SESSION" || -z "$AGENT_WORKDIR" ]]; then
+    return 1
+  fi
+  if [[ "$AGENT_ID" != "$session" || "$AGENT_SESSION" != "$session" ]]; then
+    return 1
+  fi
+
+  bridge_add_agent_id_if_missing "$AGENT_ID"
+  BRIDGE_AGENT_DESC["$AGENT_ID"]="${AGENT_DESC:-$AGENT_ID}"
+  BRIDGE_AGENT_ENGINE["$AGENT_ID"]="$AGENT_ENGINE"
+  BRIDGE_AGENT_SESSION["$AGENT_ID"]="$AGENT_SESSION"
+  BRIDGE_AGENT_WORKDIR["$AGENT_ID"]="$AGENT_WORKDIR"
+  BRIDGE_AGENT_SOURCE["$AGENT_ID"]="dynamic"
+  BRIDGE_AGENT_LOOP["$AGENT_ID"]="${AGENT_LOOP:-1}"
+  BRIDGE_AGENT_CONTINUE["$AGENT_ID"]="${AGENT_CONTINUE:-1}"
+  if [[ -n "$AGENT_SESSION_ID" && "$AGENT_ENGINE" == "claude" ]] && ! bridge_claude_session_id_exists "$AGENT_SESSION_ID" "$AGENT_WORKDIR"; then
+    BRIDGE_AGENT_SESSION_ID["$AGENT_ID"]=""
+  else
+    BRIDGE_AGENT_SESSION_ID["$AGENT_ID"]="${AGENT_SESSION_ID:-}"
+  fi
+  BRIDGE_AGENT_HISTORY_KEY["$AGENT_ID"]="${AGENT_HISTORY_KEY:-}"
+  BRIDGE_AGENT_CREATED_AT["$AGENT_ID"]="${AGENT_CREATED_AT:-}"
+  BRIDGE_AGENT_UPDATED_AT["$AGENT_ID"]="${AGENT_UPDATED_AT:-}"
+
+  active_file="$(bridge_dynamic_agent_file_for "$AGENT_ID")"
+  BRIDGE_AGENT_META_FILE["$AGENT_ID"]="$active_file"
+  bridge_write_dynamic_agent_file "$AGENT_ID" "$active_file"
+}
+
 bridge_load_static_agent_history() {
   local agent="$1"
   local file
@@ -913,6 +1056,7 @@ bridge_load_roster() {
   if [[ "$fast_load" != "1" ]]; then
     bridge_load_static_histories
     bridge_restore_dynamic_agents_from_history
+    bridge_reconcile_dynamic_agents_from_tmux
   fi
 }
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -784,16 +784,11 @@ bridge_reconcile_dynamic_agents_from_tmux() {
     if bridge_agent_exists "$session"; then
       continue
     fi
-    # Skip obvious non-agent sessions used by smoke tests and ad hoc patterns.
-    case "$session" in
-      bridge-smoke-*|bridge-requester-*|auto-start-session-*|always-on-session-*|\
-      static-session-*|claude-static-bridge-smoke-*|worker-reuse-*|\
-      late-dynamic-agent-*|created-session-*|bootstrap-session-*|\
-      bootstrap-wrapper-session-*|broken-channel-*|codex-cli-session-*|\
-      project-claude-session-bridge-smoke-*|memtest*|bootstrap-fail*|memphase4-*)
-        continue
-        ;;
-    esac
+    # Skip smoke-test / ad hoc harness sessions using the centralized
+    # matcher shared with scripts/smoke-test.sh.
+    if bridge_session_is_smoke_or_adhoc "$session"; then
+      continue
+    fi
 
     # Prefer any history file whose filename starts with `<session>--`, which
     # means it was previously written for this exact agent name. Keep only

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
 
+# shellcheck source=../lib/bridge-session-patterns.sh
+source "$REPO_ROOT/lib/bridge-session-patterns.sh"
+
 # Safety: refuse to run against a live BRIDGE_HOME. smoke deliberately stops
 # its own daemon on cleanup, adopts/kills tmux sessions, and wipes state under
 # $TMP_ROOT. If BRIDGE_HOME is inherited from the parent shell and points at a
@@ -98,11 +101,9 @@ kill_stale_smoke_tmux_sessions() {
 
   while IFS= read -r session; do
     [[ -n "$session" ]] || continue
-    case "$session" in
-      bridge-smoke-*|bridge-requester-*|auto-start-session-*|always-on-session-*|static-session-*|claude-static-bridge-smoke-*|worker-reuse-*|late-dynamic-agent-*|created-session-*|bootstrap-session-*|bootstrap-wrapper-session-*|broken-channel-*|context-pressure-bridge-smoke-*|codex-cli-session-*|project-claude-session-bridge-smoke-*|stall-auth-*|stall-rate-*|stall-unknown-*|roster-reload-session-*|smoke-admin-test*|stall-rate-test-*)
-        tmux_kill_session_exact "$session" || true
-        ;;
-    esac
+    if bridge_session_is_smoke_or_adhoc "$session"; then
+      tmux_kill_session_exact "$session" || true
+    fi
   done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)
 }
 


### PR DESCRIPTION
## Summary

- Root cause: over a daemon crash-restart sequence (see #190 repro, 21:38-22:02 window), the dynamic-agent active `.env` files can be lost while the tmux sessions hosting the agent processes remain alive. `bridge_restore_dynamic_agents_from_history` can only rehydrate entries it can match against `state/agent-history/*.env`. If history is also pruned or never existed, the dashboard shows just the static agents and the live tmux sessions become invisible — user-visible as "업그레이드 했더니 작업 중이던 세션이 다 사라졌다".
- Fix: add `bridge_reconcile_dynamic_agents_from_tmux` and call it at the tail of `bridge_load_roster` after the existing history-restore pass. For each live tmux session that (a) is not already registered and (b) does not match known smoke / ad-hoc session patterns, rebuild the entry — preferring a history file prefixed `<session>--` (preserves engine / workdir / session_id), else falling back to tmux pane inspection (`pane_current_command` → engine, `pane_current_path` → workdir). On success, rewrite the active `.env` so subsequent fast-path loads pick it up.
- Primary restore (`bridge_restore_dynamic_agents_from_history`) stays the source of truth; this only fills gaps it leaves.

## Test plan

- [x] `bash -n lib/bridge-state.sh` — PASS
- [x] `shellcheck lib/bridge-state.sh lib/bridge-core.sh lib/bridge-agents.sh lib/bridge-tmux.sh` — PASS (no new warnings)
- [ ] Live: on an install where a dynamic agent's active `.env` has been deleted but the tmux session is still alive, `bridge_load_roster` should now re-register the agent on the next sync pass and rewrite the `.env`. Smoke-test coverage for this reconciliation path is not yet added; left as follow-up because the failure mode requires manual state-file tampering to reproduce deterministically.

## Scope

- Fallback only: if the history-based restore succeeds, this new pass is a no-op (agent already registered, skipped via `bridge_agent_exists`).
- Conservative inclusion: unknown session names without a matching `claude`/`codex` pane command are ignored — no random tmux sessions are force-adopted as agents.
- Pre-existing CI `smoke` failure (`sending an immediate normal task nudge when the target session is prompt-ready`) reproduces on `main` with identical output; not a regression from this change.

Fixes #190 (symptom B).