### PR TITLE
smoke: refuse to run against live BRIDGE_HOME (closes #207)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5,6 +5,31 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
 
+# Safety: refuse to run against a live BRIDGE_HOME. smoke deliberately stops
+# its own daemon on cleanup, adopts/kills tmux sessions, and wipes state under
+# $TMP_ROOT. If BRIDGE_HOME is inherited from the parent shell and points at a
+# real install (e.g. $HOME/.agent-bridge), we would terminate the running
+# daemon, drop dynamic agent sessions, and trash live state. See issue #207.
+if [[ -n "${BRIDGE_HOME:-}" ]]; then
+  _smoke_allowed_tmp_prefix=""
+  for _smoke_tmp_candidate in "${TMPDIR%/}" "/tmp" "/private/tmp" "/var/folders"; do
+    [[ -n "$_smoke_tmp_candidate" ]] || continue
+    case "$BRIDGE_HOME" in
+      "$_smoke_tmp_candidate"|"$_smoke_tmp_candidate"/*)
+        _smoke_allowed_tmp_prefix="$_smoke_tmp_candidate"
+        break
+        ;;
+    esac
+  done
+  if [[ -z "$_smoke_allowed_tmp_prefix" ]]; then
+    printf '[smoke][error] refusing to run against non-temp BRIDGE_HOME: %s\n' "$BRIDGE_HOME" >&2
+    printf '[smoke][error] smoke-test.sh will stop its own daemon and kill tmux sessions; this would destroy a live install.\n' >&2
+    printf '[smoke][error] unset BRIDGE_HOME or point it under a temp prefix ($TMPDIR, /tmp, /private/tmp, /var/folders) before running smoke.\n' >&2
+    exit 1
+  fi
+  unset _smoke_allowed_tmp_prefix _smoke_tmp_candidate
+fi
+
 log() {
   printf '[smoke] %s\n' "$*"
 }
@@ -716,7 +741,10 @@ fi
 cleanup() {
   local status=$?
   local _cleanup_attempt=""
-  bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null 2>&1 || true
+  # Pin BRIDGE_HOME on the subshell explicitly so the stop command can never
+  # target a live install even if some earlier code path unset or rewrote
+  # the exported value. See issue #207.
+  env BRIDGE_HOME="$TMP_ROOT/bridge-home" bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null 2>&1 || true
   # Kill every tmux session that did not exist before the smoke test started.
   if [[ -n "${SMOKE_PRE_SESSIONS_FILE:-}" && -f "$SMOKE_PRE_SESSIONS_FILE" ]]; then
     local _new_session=""
@@ -5316,7 +5344,7 @@ assert all("memory-daily busy" not in line for line in output)
 PY
 
 log "stopping background daemon before deterministic cron-dispatch tail"
-bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null
+env BRIDGE_HOME="$BRIDGE_HOME" bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null
 
 log "processing one queued cron-dispatch task through the daemon"
 RUN_ID="smoke-job-1234--2026-04-05T10-00-00Z"


### PR DESCRIPTION
## Summary

- Root cause (#207): running `scripts/smoke-test.sh` from a development checkout with `BRIDGE_HOME` inherited from (or already pointing at) the live install killed the live daemon via the cleanup trap's `bridge-daemon.sh stop` and dropped every dynamic agent tmux session. The reporter traced 5 SIGTERM→respawn cycles in a 15-min window back to smoke invocations; no `daemon_stopped` audit entries appeared (introduced by #193 / PR #198) which rules out the intentional stop path.
- Three defensive changes in `scripts/smoke-test.sh`, all at the entry point:
  1. **Early refusal**: if `BRIDGE_HOME` is inherited and does not resolve under a disposable temp prefix (`$TMPDIR`, `/tmp`, `/private/tmp`, `/var/folders`), exit before any setup runs. Parallels the #185 ephemeral-home guard.
  2. **Pin BRIDGE_HOME on cleanup stop**: the cleanup trap's `bridge-daemon.sh stop` now runs under `env BRIDGE_HOME="$TMP_ROOT/bridge-home"` so it can never target a live daemon even if some earlier code path has unset or rewritten the exported value.
  3. **Pin BRIDGE_HOME on the mid-run stop** before the deterministic cron-dispatch tail, same reasoning.
- Developers who intentionally reuse an already-isolated BRIDGE_HOME can still do so as long as it lives under a temp prefix.

## Test plan

- [x] `bash -n scripts/smoke-test.sh` — PASS
- [x] `shellcheck scripts/smoke-test.sh` — PASS (no new warnings)
- [x] Guard logic self-checked by hand:
  - `unset BRIDGE_HOME` → script proceeds and sets its own `BRIDGE_HOME="$TMP_ROOT/bridge-home"` as before.
  - `BRIDGE_HOME=/tmp/smoke-x` → loop matches `/tmp/*`, sets `_smoke_allowed_tmp_prefix=/tmp`, proceeds.
  - `BRIDGE_HOME=$HOME/.agent-bridge` → loop exhausts with no match, error messages print to stderr, `exit 1` before any daemon / tmux side effect.
- [ ] Live rerun of the reporter's scenario (smoke from source checkout against live install) blocked locally until this change is in; once merged, the next admin-side verification pass can confirm.

## Notes

- Does not depend on any other in-flight #190 work; pure smoke-entry-point hardening.
- CI smoke on this repo has been failing on `main` since at least v0.6.0 at an unrelated step (`sending an immediate normal task nudge when the target session is prompt-ready`); that failure is pre-existing and out of scope here.

Fixes #207.