### PR TITLE
hooks/codex-stop: drop unsupported hookSpecificOutput (fix codex Stop error)

### DIFF
--- a/hooks/check_inbox.py
+++ b/hooks/check_inbox.py
@@ -53,10 +53,6 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "decision": "block",
                 "reason": codex_stop_reason(agent, row),
-                "hookSpecificOutput": {
-                    "hookEventName": "Stop",
-                    "additionalContext": f"Queue DB is source of truth for {agent}.",
-                },
             },
             sys.stdout,
             ensure_ascii=False,

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1795,6 +1795,7 @@ CODEX_STOP_TASK_ID="$(printf '%s\n' "$CODEX_STOP_TASK_OUTPUT" | sed -n 's/^creat
 CODEX_STOP_OUTPUT="$(printf '%s' '{"stop_hook_active": false}' | BRIDGE_AGENT_ID="$SMOKE_AGENT" BRIDGE_HOME="$BRIDGE_HOME" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 "$REPO_ROOT/hooks/codex-stop.py")"
 assert_contains "$CODEX_STOP_OUTPUT" "\"decision\": \"block\""
 assert_contains "$CODEX_STOP_OUTPUT" "agb inbox $SMOKE_AGENT"
+assert_not_contains "$CODEX_STOP_OUTPUT" "\"hookSpecificOutput\""
 CODEX_STOP_ACTIVE_OUTPUT="$(printf '%s' '{"stop_hook_active": true}' | BRIDGE_AGENT_ID="$SMOKE_AGENT" BRIDGE_HOME="$BRIDGE_HOME" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 "$REPO_ROOT/hooks/codex-stop.py")"
 assert_contains "$CODEX_STOP_ACTIVE_OUTPUT" "{}"
 python3 "$REPO_ROOT/bridge-queue.py" done "$CODEX_STOP_TASK_ID" --agent "$SMOKE_AGENT" --note "codex hook smoke cleanup" >/dev/null


### PR DESCRIPTION
## Summary

Codex agents were logging `hook returned invalid stop hook JSON output` after every Stop and dropping the Agent Bridge queue-context we inject there. The queue pending-count hook was effectively broken for every Codex session.

## Root cause

`hooks/check_inbox.py` in `--format codex` was emitting the Claude-shaped Stop payload:

```json
{
  "decision": "block",
  "reason": "...",
  "hookSpecificOutput": {
    "hookEventName": "Stop",
    "additionalContext": "..."
  }
}
```

Codex's `StopCommandOutputWire` uses `#[serde(deny_unknown_fields)]`:

- schema: https://github.com/openai/codex/blob/main/codex-rs/hooks/src/schema.rs
- parser: https://github.com/openai/codex/blob/main/codex-rs/hooks/src/engine/output_parser.rs
- docs: https://developers.openai.com/codex/hooks

The Codex Stop schema only defines `decision` / `reason` on the top-level wire — there is no `hookSpecificOutput`. The JSON parses fine but deny-unknown-fields rejects the whole object and Codex falls back to the generic `invalid stop hook JSON output` message with no hint at which field was at fault.

## Fix

`hooks/check_inbox.py` — when `--format codex`, emit only `decision` + `reason`. The existing `codex_stop_reason()` helper already rolls the inbox-summary context into the `reason` string, so the user-visible signal does not regress.

`scripts/smoke-test.sh` — new regression guard on the codex stop-hook smoke asserting the output does NOT contain `"hookSpecificOutput"`. Prevents silent reintroduction of the Claude-shaped payload.

## Test plan

- [x] `python3 -m py_compile hooks/check_inbox.py` — PASS
- [x] `bash -n scripts/smoke-test.sh` — PASS
- [x] `shellcheck scripts/smoke-test.sh` — PASS
- [x] Manual: output keys are exactly `['decision', 'reason']` after the change.
- [ ] Full `./scripts/smoke-test.sh` run was started but a pre-existing unrelated hang in the late integration stage prevented full completion. The codex-stop section of smoke runs before that hang and passes.

## Upstream

Upstream diagnostic request filed at openai/codex#18887 — asks Codex to surface which unsupported field tripped `deny_unknown_fields` instead of the opaque `invalid stop hook JSON output`.

## Impact

Every Codex session gets the queue-context block restored on Stop. No behavior change for Claude (the Claude Stop path is untouched; the dropped block was only ever reachable when `--format codex` was passed).