### PR TITLE
orphan: match bun plugin roots in mcp-cleanup (closes #223)

### DIFF
--- a/bridge-mcp-cleanup.py
+++ b/bridge-mcp-cleanup.py
@@ -28,6 +28,16 @@ DEFAULT_PATTERNS = [
     r"\bnode\b.*context7.*mcp",
     r"\bnode\b.*playwright.*mcp",
     r"\bnode\b.*firebase.*mcp",
+    # Issue #223: bun plugin roots accumulate as PID-1 orphans across
+    # agent restarts (shared-mode + tmux-kill-session + daemon reconcile
+    # all leave them reparented). Matching only `bun server.ts` was not
+    # enough — its parent `bun run --cwd .../plugins/<kind>` is
+    # unmatched, so the chain check in is_orphan_candidate() refused the
+    # server.ts child too. Restrict the patterns to Agent Bridge plugin
+    # paths so a developer's own `bun run --cwd ./myapp build` never
+    # matches.
+    r"\bbun\s+run\s+--cwd\s+\S*\.agent-bridge/plugins/",
+    r"\bbun\s+run\s+--cwd\s+\S*/claude-plugins-official/",
 ]
 
 

--- a/bridge-mcp-cleanup.py
+++ b/bridge-mcp-cleanup.py
@@ -36,8 +36,8 @@ DEFAULT_PATTERNS = [
     # server.ts child too. Restrict the patterns to Agent Bridge plugin
     # paths so a developer's own `bun run --cwd ./myapp build` never
     # matches.
-    r"\bbun\s+run\s+--cwd\s+\S*\.agent-bridge/plugins/",
-    r"\bbun\s+run\s+--cwd\s+\S*/claude-plugins-official/",
+    r"\bbun\s+run\s+--cwd\s+.+?\.agent-bridge/plugins/",
+    r"\bbun\s+run\s+--cwd\s+.+?/claude-plugins-official/",
 ]
 
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2102,6 +2102,11 @@ cases_should_match = [
     "bun run --cwd /home/ec2-user/.agent-bridge/plugins/teams --shell=bun --silent start",
     "bun run --cwd /Users/x/.agent-bridge/plugins/telegram --silent start",
     "bun run --cwd /home/ec2-user/.bun/install/claude-plugins-official/telegram/0.0.6 start",
+    # ps stitches argv with single spaces, so a cwd containing a space
+    # (macOS user dir like "Space User") shows up verbatim. Match must
+    # still see the plugin-root fragment.
+    "bun run --cwd /Users/Space User/.agent-bridge/plugins/teams --silent start",
+    "bun run --cwd /Users/Space User/.bun/install/claude-plugins-official/telegram/0.0.6 start",
     "/home/ec2-user/.bun/bin/bun server.ts",
 ]
 for cmd in cases_should_match:

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2077,6 +2077,64 @@ assert_contains "$IDLE_REAP_OUTPUT" "DYNAMIC_ALIVE=no"
 assert_contains "$IDLE_REAP_OUTPUT" "ORPHAN_ALIVE=no"
 assert_contains "$IDLE_REAP_OUTPUT" "DYNAMIC_META=no"
 
+log "bun plugin root + child match the orphan patterns (issue #223)"
+python3 - "$REPO_ROOT" <<'PY'
+import importlib.util
+import pathlib
+import sys
+
+repo_root = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location(
+    "bridge_mcp_cleanup", repo_root / "bridge-mcp-cleanup.py"
+)
+mod = importlib.util.module_from_spec(spec)
+# dataclass annotation resolution needs the module present in sys.modules
+# before exec_module runs (Python 3.9 requirement).
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+patterns = mod.compile_patterns(mod.DEFAULT_PATTERNS)
+
+def proc(pid, command, ppid=1):
+    return mod.Proc(pid=pid, ppid=ppid, age_seconds=999, rss_kb=0, command=command)
+
+cases_should_match = [
+    "bun run --cwd /home/ec2-user/.agent-bridge/plugins/teams --shell=bun --silent start",
+    "bun run --cwd /Users/x/.agent-bridge/plugins/telegram --silent start",
+    "bun run --cwd /home/ec2-user/.bun/install/claude-plugins-official/telegram/0.0.6 start",
+    "/home/ec2-user/.bun/bin/bun server.ts",
+]
+for cmd in cases_should_match:
+    matched = mod.matched_pattern(proc(10, cmd), patterns)
+    assert matched, f"expected match for: {cmd}"
+
+cases_should_not_match = [
+    # Generic user `bun run` against a project dir must never match — we
+    # restrict to .agent-bridge/plugins or claude-plugins-official roots.
+    "bun run --cwd /home/user/myproject build",
+    "bun run --cwd /tmp/foo test",
+    "bun run dev",
+    "node server.ts",  # without the bun word-boundary the server.ts-only rule must not false-positive
+]
+for cmd in cases_should_not_match:
+    matched = mod.matched_pattern(proc(20, cmd), patterns)
+    assert not matched, f"unexpected match for: {cmd} (matched={matched})"
+
+# Orphan chain: plugin root PPID=1 matches; bun server.ts child with
+# parent=plugin-root must also be classified as an orphan (the old bug
+# rejected it because the parent's command did not match anything).
+procs = {
+    100: proc(100, "bun run --cwd /home/u/.agent-bridge/plugins/teams --silent start", ppid=1),
+    101: proc(101, "/home/u/.bun/bin/bun server.ts", ppid=100),
+}
+matches = {pid: mod.matched_pattern(p, patterns) for pid, p in procs.items()}
+assert matches[100], "plugin root must match"
+assert matches[101], "server.ts child must match"
+assert mod.is_orphan_candidate(procs[100], procs, matches, 0), "plugin root ppid=1 must be orphan"
+assert mod.is_orphan_candidate(procs[101], procs, matches, 0), "server.ts child must chain through matched orphan parent"
+print("[ok] bun plugin orphan patterns + chain")
+PY
+
 log "cleaning orphan MCP processes conservatively"
 MCP_ORPHAN_PATTERN="agent-bridge-smoke-orphan-mcp-$SESSION_NAME"
 MCP_ATTACHED_PATTERN="agent-bridge-smoke-attached-mcp-$SESSION_NAME"


### PR DESCRIPTION
## Summary

- Teaches `bridge-mcp-cleanup.py` to recognize Agent Bridge plugin roots (`bun run --cwd .../.agent-bridge/plugins/` and the legacy `.../claude-plugins-official/` path) as candidates for orphan reaping.
- Fixes the accumulation documented in #223: 19 teams + 1 telegram `PPID=1` plugin trees on a single v0.3.7 host, each with a `bun server.ts` child burning ~16% CPU. The existing `\bbun\b.*server\.ts` pattern matched only the child, but `is_orphan_candidate()` refused to chain through the unmatched plugin-root parent — so the child was never killed either. Matching the root collapses that chain and both processes get reaped on the next daemon sweep.
- Patterns are restricted to the Agent Bridge plugin directory fragment, not `bun run` generally, so a developer running `bun run --cwd ~/myproject build` is unaffected.

Closes #223.

## Test plan

- [x] `bash -n scripts/smoke-test.sh` clean.
- [x] `shellcheck scripts/smoke-test.sh` clean.
- [x] `python3 -m py_compile bridge-mcp-cleanup.py` clean.
- [x] Ad-hoc: the four plugin-path command lines from the #223 report match, three non-Agent-Bridge `bun run` command lines do not match, and the plugin-root → `server.ts` child chain is classified as two orphans when the root is reparented to PID 1.
- [ ] Full `./scripts/smoke-test.sh` — aborts early on the pre-existing `agb inbox codex-cli-agent-XXXX` failure documented in the migration handoff.
- [ ] Live verification on a host that has actually accumulated bun plugin orphans (CM-PRD-InS-LiteLLM or a dockerized repro); the next daemon sync cycle should drain them. Not gating for this PR because the detection logic is exercised by the inline unit test and the failure mode (false negative → leak persists, false positive → a user's bun build gets killed) is mitigated by the plugin-path prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)