### PR TITLE
diagnose: add `agent-bridge diagnose acl` scanner (closes #233 stage 3)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -29,6 +29,7 @@ Usage:
   $CLI_NAME review <policy|request|complete> ...
   $CLI_NAME user <set|show> ...
   $CLI_NAME guard <status|scan|sanitize> ...
+  $CLI_NAME diagnose <acl> [--json]
   $CLI_NAME knowledge <init|operator|capture|promote|search|lint> ...
   $CLI_NAME bundle <create|show> ...
   $CLI_NAME intake <triage|show> ...
@@ -498,6 +499,10 @@ PY
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-guard.sh" "$@"
       ;;
+    diagnose)
+      shift
+      exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-diagnose.sh" "$@"
+      ;;
     knowledge)
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-knowledge.sh" "$@"
@@ -657,7 +662,7 @@ PY
   # sqlite3 fallback path. Reject with an intent-recovery suggestion
   # before the spawn parser sees it.
   if [[ -n "${1:-}" && "${1:0:1}" != "-" ]]; then
-    _top_valid="admin bootstrap init version upgrade escalate upstream review user guard knowledge bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
+    _top_valid="admin bootstrap init version upgrade escalate upstream review user guard diagnose knowledge bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
     _hint="$(bridge_suggest_subcommand "$1" "$_top_valid")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 명령입니다: $1"

--- a/bridge-diagnose.sh
+++ b/bridge-diagnose.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# Agent Bridge health / hygiene scanners. `agent-bridge diagnose <subcommand>`.
+#
+# Currently exposes:
+#   agent-bridge diagnose acl    — scan `/`, `/home`, the operator's home,
+#                                  BRIDGE_HOME and BRIDGE_AGENT_HOME_ROOT for
+#                                  stale named-user ACL entries that isolate
+#                                  may have left behind (issue #233). Outputs
+#                                  the exact `setfacl -x` command the operator
+#                                  can run to drain each one.
+#
+# Everything here is read-only — no ACL mutation, no root sudo — so the
+# scanner is safe to run from the same shell the operator uses for
+# normal work.
+
+set -euo pipefail
+
+BRIDGE_DIAGNOSE_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=bridge-lib.sh
+source "$BRIDGE_DIAGNOSE_SCRIPT_DIR/bridge-lib.sh"
+
+bridge_diagnose_usage() {
+  cat <<'USAGE'
+Usage:
+  agent-bridge diagnose acl [--json]
+
+Scan for stale Agent Bridge named-user ACL entries on shared roots.
+Reads only — does not modify any ACL. Lists `setfacl -x` commands the
+operator can run to drain any entry that shouldn't still be there.
+
+Linux only. macOS installs don't use POSIX ACLs for this path and
+always report "[ok]".
+USAGE
+}
+
+bridge_diagnose_acl_is_suspicious() {
+  local entry_user="$1"
+  local controller="$2"
+
+  [[ -n "$entry_user" ]] || return 1
+  case "$entry_user" in
+    agent-bridge-*)
+      return 0
+      ;;
+  esac
+  if [[ -n "$controller" && "$entry_user" == "$controller" ]]; then
+    return 0
+  fi
+  return 1
+}
+
+bridge_diagnose_acl_scan_path() {
+  # Emit one `[<path>]` header + lines per suspicious entry. No output if
+  # the path is missing or clean. Writes to stdout; returns 0 unless
+  # getfacl itself fails.
+  local path="$1"
+  local controller="$2"
+  local json_mode="${3:-0}"
+  local output=""
+  local entries=""
+  local entry=""
+  local entry_user=""
+  local kind="access"
+  local any=0
+
+  [[ -e "$path" ]] || return 0
+  command -v getfacl >/dev/null 2>&1 || return 0
+  output="$(getfacl -p "$path" 2>/dev/null)" || return 0
+  # `user:<name>:...` lines carry named entries. `user::...` is the base
+  # owner entry and is never suspicious. `default:user:<name>:...` is
+  # the inherited-default ACL; classify it separately so the operator
+  # can see which setfacl -x flag (access vs. default) to use.
+  entries="$(printf '%s\n' "$output" \
+    | grep -E '^(default:)?user:[^:]+:' \
+    | grep -vE '^(default:)?user::' || true)"
+  [[ -n "$entries" ]] || return 0
+
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    if [[ "$entry" == default:* ]]; then
+      kind="default"
+      entry_user="${entry#default:user:}"
+    else
+      kind="access"
+      entry_user="${entry#user:}"
+    fi
+    entry_user="${entry_user%%:*}"
+    bridge_diagnose_acl_is_suspicious "$entry_user" "$controller" || continue
+    if (( any == 0 )); then
+      if [[ "$json_mode" != "1" ]]; then
+        printf '[%s]\n' "$path"
+      fi
+      any=1
+    fi
+    if [[ "$json_mode" == "1" ]]; then
+      printf '{"path":%s,"user":%s,"kind":%s,"raw":%s}\n' \
+        "$(bridge_diagnose_json_str "$path")" \
+        "$(bridge_diagnose_json_str "$entry_user")" \
+        "$(bridge_diagnose_json_str "$kind")" \
+        "$(bridge_diagnose_json_str "$entry")"
+    else
+      local flag=""
+      if [[ "$kind" == "default" ]]; then
+        flag="-d "
+      fi
+      printf '  suspicious (%s): %s\n' "$kind" "$entry"
+      printf '  fix: sudo setfacl %s-x u:%s %s\n' "$flag" "$entry_user" "$path"
+    fi
+  done <<<"$entries"
+
+  return 0
+}
+
+bridge_diagnose_json_str() {
+  # Emit a JSON-encoded string using python3 so weird paths (spaces,
+  # quotes, UTF-8) don't break the output. getfacl output is already
+  # UTF-8 in practice.
+  bridge_require_python
+  python3 - "$1" <<'PY'
+import json
+import sys
+print(json.dumps(sys.argv[1]))
+PY
+}
+
+bridge_diagnose_acl_targets() {
+  # Build the canonical scan target list. `/` and `/home` are always in
+  # scope because they're the two paths #233's isolate regression most
+  # commonly poisoned. The controller's home is checked separately
+  # because named-user entries there also strip operator access. Any
+  # agent-bridge-specific roots that exist on the host get scanned too.
+  local controller_user="$1"
+  local controller_home=""
+
+  printf '/\n'
+  printf '/home\n'
+
+  controller_home="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  if [[ -n "$controller_home" && -d "$controller_home" && "$controller_home" != "/" ]]; then
+    printf '%s\n' "$controller_home"
+  fi
+
+  if [[ -n "${BRIDGE_HOME:-}" && -d "$BRIDGE_HOME" ]]; then
+    printf '%s\n' "$BRIDGE_HOME"
+  fi
+  if [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" && -d "$BRIDGE_AGENT_HOME_ROOT" ]]; then
+    printf '%s\n' "$BRIDGE_AGENT_HOME_ROOT"
+  fi
+  if [[ -n "${BRIDGE_STATE_DIR:-}" && -d "$BRIDGE_STATE_DIR" ]]; then
+    printf '%s\n' "$BRIDGE_STATE_DIR"
+  fi
+}
+
+bridge_diagnose_acl_main() {
+  local json_mode=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)
+        json_mode=1
+        shift
+        ;;
+      -h|--help)
+        bridge_diagnose_usage
+        return 0
+        ;;
+      *)
+        printf 'unknown argument: %s\n' "$1" >&2
+        bridge_diagnose_usage >&2
+        return 2
+        ;;
+    esac
+  done
+
+  if [[ "$(uname -s 2>/dev/null || printf '')" != "Linux" ]]; then
+    if [[ "$json_mode" == "1" ]]; then
+      printf '{"platform":"non-linux","findings":[]}\n'
+    else
+      printf '[ok] non-linux host — POSIX ACL scanner does not apply\n'
+    fi
+    return 0
+  fi
+  if ! command -v getfacl >/dev/null 2>&1; then
+    printf '[skip] getfacl not installed — install the acl package to scan\n' >&2
+    return 0
+  fi
+
+  local controller_user=""
+  controller_user="$(bridge_current_user 2>/dev/null || id -un 2>/dev/null || printf '')"
+
+  local targets=()
+  while IFS= read -r target; do
+    [[ -n "$target" ]] && targets+=("$target")
+  done < <(bridge_diagnose_acl_targets "$controller_user")
+
+  local any=0
+  local findings=""
+  local result=""
+  local target=""
+
+  if [[ "$json_mode" == "1" ]]; then
+    printf '{"platform":"linux","controller":%s,"findings":[' \
+      "$(bridge_diagnose_json_str "$controller_user")"
+  fi
+
+  for target in "${targets[@]}"; do
+    result="$(bridge_diagnose_acl_scan_path "$target" "$controller_user" "$json_mode" || true)"
+    [[ -n "$result" ]] || continue
+    if [[ "$json_mode" == "1" ]]; then
+      findings+="$result"
+    else
+      if (( any == 1 )); then
+        printf '\n'
+      fi
+      printf '%s' "$result"
+    fi
+    any=1
+  done
+
+  if [[ "$json_mode" == "1" ]]; then
+    if [[ -n "$findings" ]]; then
+      # Join on commas; each row already has a trailing newline.
+      printf '%s' "$findings" \
+        | awk 'NF' \
+        | paste -sd, -
+    fi
+    printf ']}\n'
+    return 0
+  fi
+
+  if (( any == 0 )); then
+    printf '[ok] no suspicious named-user ACL entries found on %s\n' "${targets[*]}"
+    return 0
+  fi
+
+  cat <<EOF
+
+[note] each "fix:" line above removes exactly one stale entry.
+       You can apply them directly, or run:
+         agent-bridge unisolate <agent>
+       for every previously-isolated agent to let the shipped
+       cleanup (PR #235) drain the residue in one shot.
+EOF
+}
+
+bridge_diagnose_cli() {
+  local subcommand="${1:-}"
+  shift || true
+
+  case "$subcommand" in
+    acl)
+      bridge_diagnose_acl_main "$@"
+      ;;
+    ""|-h|--help|help)
+      bridge_diagnose_usage
+      ;;
+    *)
+      printf 'unknown diagnose subcommand: %s\n' "$subcommand" >&2
+      bridge_diagnose_usage >&2
+      return 2
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  bridge_diagnose_cli "$@"
+fi

--- a/bridge-diagnose.sh
+++ b/bridge-diagnose.sh
@@ -182,7 +182,16 @@ bridge_diagnose_acl_main() {
     return 0
   fi
   if ! command -v getfacl >/dev/null 2>&1; then
-    printf '[skip] getfacl not installed — install the acl package to scan\n' >&2
+    # The skip banner has to land on stdout in both modes: callers
+    # (including the smoke harness) capture stdout, so writing to
+    # stderr would leave them with an empty string that looked like
+    # success on a host that actually can't scan. JSON mode still has
+    # to emit a parseable payload even in the "skipped" case.
+    if [[ "$json_mode" == "1" ]]; then
+      printf '{"platform":"linux","skipped":"getfacl-missing","findings":[]}\n'
+    else
+      printf '[skip] getfacl not installed — install the acl package to scan\n'
+    fi
     return 0
   fi
 
@@ -194,38 +203,46 @@ bridge_diagnose_acl_main() {
     [[ -n "$target" ]] && targets+=("$target")
   done < <(bridge_diagnose_acl_targets "$controller_user")
 
+  # Aggregate JSON findings through a bash array so cross-target results
+  # keep their per-finding boundary. Command substitution strips trailing
+  # newlines, so concatenating stdout from two scan_path calls used to
+  # yield `{a}\n{b}{c}\n{d}` — invalid JSON as soon as a second target
+  # added anything. Feeding scan_path's stdout through `while read` into
+  # an array preserves the one-finding-per-element contract.
   local any=0
-  local findings=""
+  local -a json_findings=()
   local result=""
   local target=""
 
-  if [[ "$json_mode" == "1" ]]; then
-    printf '{"platform":"linux","controller":%s,"findings":[' \
-      "$(bridge_diagnose_json_str "$controller_user")"
-  fi
-
   for target in "${targets[@]}"; do
-    result="$(bridge_diagnose_acl_scan_path "$target" "$controller_user" "$json_mode" || true)"
-    [[ -n "$result" ]] || continue
     if [[ "$json_mode" == "1" ]]; then
-      findings+="$result"
+      while IFS= read -r result; do
+        [[ -n "$result" ]] || continue
+        json_findings+=("$result")
+        any=1
+      done < <(bridge_diagnose_acl_scan_path "$target" "$controller_user" "$json_mode" || true)
     else
+      result="$(bridge_diagnose_acl_scan_path "$target" "$controller_user" "$json_mode" || true)"
+      [[ -n "$result" ]] || continue
       if (( any == 1 )); then
         printf '\n'
       fi
       printf '%s' "$result"
+      any=1
     fi
-    any=1
   done
 
   if [[ "$json_mode" == "1" ]]; then
-    if [[ -n "$findings" ]]; then
-      # Join on commas; each row already has a trailing newline.
-      printf '%s' "$findings" \
-        | awk 'NF' \
-        | paste -sd, -
+    local joined=""
+    if (( ${#json_findings[@]} > 0 )); then
+      local _old_ifs="$IFS"
+      IFS=','
+      joined="${json_findings[*]}"
+      IFS="$_old_ifs"
     fi
-    printf ']}\n'
+    printf '{"platform":"linux","controller":%s,"findings":[%s]}\n' \
+      "$(bridge_diagnose_json_str "$controller_user")" \
+      "$joined"
     return 0
   fi
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1210,6 +1210,21 @@ cp "$TMP_ROOT/openclaw.json" "$BRIDGE_RUNTIME_CONFIG_FILE"
 log "verifying empty runtime starts clean"
 BRIDGE_ROSTER_LOCAL_FILE=/nonexistent bash "$REPO_ROOT/bridge-start.sh" --list >/dev/null
 
+log "diagnose acl reports clean on macOS (non-Linux host)"
+DIAGNOSE_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl)"
+if [[ "$(uname -s)" == "Linux" ]]; then
+  # On Linux getfacl may or may not be installed; either way the
+  # scanner exits 0 with an "[ok]" or "[skip]" banner. The only thing
+  # smoke needs to assert is that it did not explode.
+  assert_contains "$DIAGNOSE_OUTPUT" "["
+else
+  assert_contains "$DIAGNOSE_OUTPUT" "non-linux"
+fi
+DIAGNOSE_JSON_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl --json)"
+assert_contains "$DIAGNOSE_JSON_OUTPUT" "\"findings\""
+DIAGNOSE_HELP="$("$REPO_ROOT/agent-bridge" diagnose 2>&1 || true)"
+assert_contains "$DIAGNOSE_HELP" "diagnose acl"
+
 log "starting isolated daemon"
 bash "$REPO_ROOT/bridge-daemon.sh" ensure >/dev/null
 DAEMON_STATUS=""


### PR DESCRIPTION
## Summary

Stage **3 of 3** for issue #233. Adds a read-only scanner that surfaces stale named-user ACL entries an earlier isolate/unisolate cycle may have left on shared roots.

- PR #235 (stage 1, merged) teaches `unisolate` to drain residue going forward.
- PR #236 (stage 2, merged) tightens `isolate`'s ancestor walk so a fresh isolate never poisons `/`, `/home`, the operator's home, or any other shared root again.
- This PR closes the loop: an operator on an already-poisoned install can run one command and see exactly which entries still need cleaning, plus the `setfacl -x` line to drain each one.

## Usage

```bash
agent-bridge diagnose acl          # text output
agent-bridge diagnose acl --json   # machine-readable
agent-bridge diagnose              # help
```

Sample text output when residue is present:

```
[/]
  suspicious (access): user:ec2-user:--x
  fix: sudo setfacl -x u:ec2-user /
  suspicious (access): user:agent-bridge-sales_sean:--x
  fix: sudo setfacl -x u:agent-bridge-sales_sean /
[/home]
  suspicious (access): user:agent-bridge-sales_sean:--x
  fix: sudo setfacl -x u:agent-bridge-sales_sean /home

[note] each "fix:" line above removes exactly one stale entry.
       You can apply them directly, or run:
         agent-bridge unisolate <agent>
       for every previously-isolated agent to let the shipped
       cleanup (PR #235) drain the residue in one shot.
```

Clean install: `[ok] no suspicious named-user ACL entries found on / /home /home/ec2-user ...`.

## Changes

- `bridge-diagnose.sh` (new, 268 lines). Entry points: `bridge_diagnose_cli`, `bridge_diagnose_acl_main`.
  - Walks a fixed set of shared roots (`/`, `/home`, controller home, `BRIDGE_HOME`, `BRIDGE_AGENT_HOME_ROOT`, `BRIDGE_STATE_DIR`). `getfacl -p` each one.
  - A named-user entry is "suspicious" when the user name matches `agent-bridge-*` or equals the operator itself. Those are both always wrong per issue #233 §2 — the operator has base-perm access, and any `agent-bridge-*` entry after `unisolate` is stale.
  - Distinguishes access vs. default ACL entries; the suggested `setfacl` command carries `-d -x` for default and `-x` for access.
  - `--json` mode emits `{"platform":..., "controller":..., "findings":[{"path":..., "user":..., "kind":..., "raw":...}, ...]}` via python3 for quoting-safe strings.
  - Linux-only. macOS hosts and Linux hosts without `getfacl` exit 0 with a benign banner rather than erroring.
- `agent-bridge`: `diagnose` dispatched to the new script, added to `_top_valid` subcommand fuzzy-match list, usage block updated.
- `scripts/smoke-test.sh`: right after the existing "verifying empty runtime starts clean" block, assert `diagnose acl`, `diagnose acl --json`, and `diagnose` (help) all exit 0 with expected banners. macOS branch keys on the non-linux hint; Linux branch accepts `[ok]` / `[skip]` / findings output.

## Closes

#233 — with PRs #235 (unisolate cleanup) and #236 (isolate boundary) already merged, this third PR completes the coverage.

## Test plan

- [x] `bash -n` + `shellcheck` clean on all modified files.
- [x] Ad-hoc on macOS: `agent-bridge diagnose acl` → `[ok] non-linux host — POSIX ACL scanner does not apply`. `--json` → `{"platform":"non-linux","findings":[]}`. Help banner lists the acl subcommand.
- [ ] Full `./scripts/smoke-test.sh` — pre-existing `agb inbox codex-cli-agent-XXXX` early abort unchanged.
- [ ] **Live verification requested** on CM-PRD-InS-LiteLLM:
  1. Run `agent-bridge diagnose acl`. After the morning `setfacl -x` workaround there should be no suspicious entries → `[ok]` banner.
  2. Deliberately re-seed a single stale entry (e.g. `sudo setfacl -m u:agent-bridge-test:--x /home`) and confirm the scanner prints it + the exact reverse command.
  3. Confirm `agent-bridge diagnose acl --json` is parseable by `jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)