### PR TITLE
hooks: tool-policy no longer treats shared alias as a peer (closes #240)

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -70,14 +70,38 @@ def is_admin_agent(agent: str) -> bool:
 
 
 def other_agent_homes(agent: str) -> list[Path]:
+    """Return every sibling agent home under `agent_home_root()`.
+
+    Intentionally filters out:
+
+    - Symlinks. `~/.agent-bridge/agents/shared` is historically a symlink
+      pointing at `BRIDGE_SHARED_DIR`, and `is_dir()` reports True for it.
+      Treating that alias as an "other agent home" made the later
+      `target_agent_for_path` check resolve every write under
+      `BRIDGE_SHARED_DIR` to the same canonical tree and reject it as
+      cross-agent access (issue #240).
+    - Names starting with `.` — internal state like `.claude`.
+    - Names starting with `_` — templates / fixtures (`_template`).
+
+    Everything else is a real agent home (patch, librarian, dev_mun, …)
+    and stays in the list so legitimate cross-agent isolation still
+    triggers.
+    """
     homes: list[Path] = []
     root = agent_home_root()
     if not root.exists():
         return homes
     for candidate in root.iterdir():
+        if candidate.is_symlink():
+            continue
         if not candidate.is_dir():
             continue
-        if candidate.name == agent:
+        name = candidate.name
+        if not name:
+            continue
+        if name[0] in (".", "_"):
+            continue
+        if name == agent:
             continue
         homes.append(candidate)
     return homes

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -69,39 +69,54 @@ def is_admin_agent(agent: str) -> bool:
     return False
 
 
+_NON_AGENT_ENTRIES: frozenset[str] = frozenset({
+    # `shared` is the canonical symlink to BRIDGE_SHARED_DIR. Treating it
+    # as a peer agent home used to collapse every shared-dir write into
+    # the "cross-agent access blocked" rejection (issue #240).
+    "shared",
+    # Profile template shipped under agents/; never a real agent, but
+    # `is_dir()` returns True for it so it used to false-positive as a
+    # peer.
+    "_template",
+})
+
+
 def other_agent_homes(agent: str) -> list[Path]:
     """Return every sibling agent home under `agent_home_root()`.
 
-    Intentionally filters out:
+    Excludes entries that are never real agents on a standard install:
 
-    - Symlinks. `~/.agent-bridge/agents/shared` is historically a symlink
-      pointing at `BRIDGE_SHARED_DIR`, and `is_dir()` reports True for it.
-      Treating that alias as an "other agent home" made the later
-      `target_agent_for_path` check resolve every write under
-      `BRIDGE_SHARED_DIR` to the same canonical tree and reject it as
-      cross-agent access (issue #240).
-    - Names starting with `.` — internal state like `.claude`.
-    - Names starting with `_` — templates / fixtures (`_template`).
+    - The `shared` symlink alias (→ BRIDGE_SHARED_DIR). This was the
+      direct trigger for issue #240 — `path.resolve()` collapsed the
+      alias into the shared tree and blocked every legitimate write.
+    - `_template`, the shipped agent profile template.
+    - Dot-prefixed entries (`.claude`, `.cache`, …). POSIX hidden
+      convention reserves these for framework state, and
+      `bridge_validate_agent_name` refuses to mint agent names that
+      would conflict on that shape.
 
-    Everything else is a real agent home (patch, librarian, dev_mun, …)
-    and stays in the list so legitimate cross-agent isolation still
-    triggers.
+    Everything else — including non-alias symlink homes a site may
+    legitimately introduce — stays in the list so cross-agent
+    isolation continues to trigger on real peer paths. A real agent
+    named `_real` or similar would still be detected, which is what
+    Codex round-1 flagged as the over-filter regression in the first
+    cut.
     """
     homes: list[Path] = []
     root = agent_home_root()
     if not root.exists():
         return homes
     for candidate in root.iterdir():
-        if candidate.is_symlink():
-            continue
         if not candidate.is_dir():
             continue
         name = candidate.name
         if not name:
             continue
-        if name[0] in (".", "_"):
-            continue
         if name == agent:
+            continue
+        if name in _NON_AGENT_ENTRIES:
+            continue
+        if name.startswith("."):
             continue
         homes.append(candidate)
     return homes

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -78,29 +78,33 @@ _NON_AGENT_ENTRIES: frozenset[str] = frozenset({
     # `is_dir()` returns True for it so it used to false-positive as a
     # peer.
     "_template",
+    # Framework-internal dotfile. `bridge-agent.sh create` does not
+    # reserve leading-dot names today (Codex round-2 repro: `create
+    # .real --dry-run` succeeds), so the exclusion has to be an exact
+    # match, not a prefix rule — otherwise a legitimate `.real` agent
+    # would silently lose cross-agent detection.
+    ".claude",
 })
 
 
 def other_agent_homes(agent: str) -> list[Path]:
     """Return every sibling agent home under `agent_home_root()`.
 
-    Excludes entries that are never real agents on a standard install:
+    Excludes only entries that are never real agents on a standard
+    install — an exact-name allowlist, no prefix heuristic:
 
     - The `shared` symlink alias (→ BRIDGE_SHARED_DIR). This was the
       direct trigger for issue #240 — `path.resolve()` collapsed the
       alias into the shared tree and blocked every legitimate write.
     - `_template`, the shipped agent profile template.
-    - Dot-prefixed entries (`.claude`, `.cache`, …). POSIX hidden
-      convention reserves these for framework state, and
-      `bridge_validate_agent_name` refuses to mint agent names that
-      would conflict on that shape.
+    - `.claude`, framework-internal runtime directory.
 
-    Everything else — including non-alias symlink homes a site may
-    legitimately introduce — stays in the list so cross-agent
-    isolation continues to trigger on real peer paths. A real agent
-    named `_real` or similar would still be detected, which is what
-    Codex round-1 flagged as the over-filter regression in the first
-    cut.
+    Everything else — including agents whose names start with `_` or
+    `.`, and non-alias symlink homes a site may legitimately
+    introduce — stays in the list so cross-agent isolation continues
+    to trigger on real peer paths. Codex rounds 1 and 2 on PR #242
+    both landed on this over-filter class, so we deliberately avoid
+    any prefix-based skip.
     """
     homes: list[Path] = []
     root = agent_home_root()
@@ -115,8 +119,6 @@ def other_agent_homes(agent: str) -> list[Path]:
         if name == agent:
             continue
         if name in _NON_AGENT_ENTRIES:
-            continue
-        if name.startswith("."):
             continue
         homes.append(candidate)
     return homes

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1218,6 +1218,7 @@ rm -rf "$TOOL_POLICY_FIXTURE_ROOT"
 mkdir -p "$TOOL_POLICY_AGENT_HOME_ROOT/self" \
          "$TOOL_POLICY_AGENT_HOME_ROOT/peer" \
          "$TOOL_POLICY_AGENT_HOME_ROOT/_real_agent_name" \
+         "$TOOL_POLICY_AGENT_HOME_ROOT/.real_dot_agent" \
          "$TOOL_POLICY_AGENT_HOME_ROOT/_template" \
          "$TOOL_POLICY_AGENT_HOME_ROOT/.claude" \
          "$TOOL_POLICY_SHARED_DIR"
@@ -1238,11 +1239,11 @@ spec.loader.exec_module(tp)
 
 homes = tp.other_agent_homes("self")
 names = sorted(h.name for h in homes)
-# Expect every real agent home to survive: `peer` plus `_real_agent_name`
-# (Codex round-1 flagged that blanket underscore-prefix skip would miss
-# real agents). Only exact non-agent entries get filtered: `shared`
-# alias, `_template`, and `.claude`.
-assert names == ["_real_agent_name", "peer"], f"expected ['_real_agent_name', 'peer'], got {names}"
+# Exact-name blocklist only. Both `_real_agent_name` and `.real_dot_agent`
+# are real agents (bridge-agent.sh create does not reserve either
+# prefix today) and must survive. Non-agents `shared`, `_template`,
+# and `.claude` are filtered.
+assert names == [".real_dot_agent", "_real_agent_name", "peer"], f"expected ['.real_dot_agent', '_real_agent_name', 'peer'], got {names}"
 
 # Writing into shared/ must not be classified as cross-agent.
 target = tp.target_agent_for_path(shared_dir / "note.md", "self")
@@ -1252,11 +1253,14 @@ assert target is None, f"shared/ write misclassified as cross-agent: {target}"
 peer_target = tp.target_agent_for_path(agents_root / "peer" / "foo.md", "self")
 assert peer_target == "peer", f"peer write not detected: {peer_target}"
 
-# Underscore-prefixed real agents are still detected (issue #240 r2).
+# Prefix-bearing real agents (underscore or dot) are still detected
+# (Codex r1 + r2 both flagged these over-filter regressions).
 underscore_target = tp.target_agent_for_path(agents_root / "_real_agent_name" / "foo.md", "self")
 assert underscore_target == "_real_agent_name", f"underscore-prefixed peer not detected: {underscore_target}"
+dot_target = tp.target_agent_for_path(agents_root / ".real_dot_agent" / "foo.md", "self")
+assert dot_target == ".real_dot_agent", f"dot-prefixed peer not detected: {dot_target}"
 
-print("[ok] tool-policy other_agent_homes: shared/_template/.claude filtered; _real_agent_name kept; shared write allowed; peer write blocked")
+print("[ok] tool-policy other_agent_homes: shared/_template/.claude filtered; prefixed real agents kept; shared write allowed; peer write blocked")
 PY
 )
 printf '%s\n' "$TOOL_POLICY_PY_CHECK"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1217,6 +1217,7 @@ TOOL_POLICY_SHARED_DIR="$TOOL_POLICY_FIXTURE_ROOT/shared"
 rm -rf "$TOOL_POLICY_FIXTURE_ROOT"
 mkdir -p "$TOOL_POLICY_AGENT_HOME_ROOT/self" \
          "$TOOL_POLICY_AGENT_HOME_ROOT/peer" \
+         "$TOOL_POLICY_AGENT_HOME_ROOT/_real_agent_name" \
          "$TOOL_POLICY_AGENT_HOME_ROOT/_template" \
          "$TOOL_POLICY_AGENT_HOME_ROOT/.claude" \
          "$TOOL_POLICY_SHARED_DIR"
@@ -1237,8 +1238,11 @@ spec.loader.exec_module(tp)
 
 homes = tp.other_agent_homes("self")
 names = sorted(h.name for h in homes)
-# Expect exactly ["peer"]. shared(symlink), _template(underscore), .claude(dot), self(current) all excluded.
-assert names == ["peer"], f"expected ['peer'], got {names}"
+# Expect every real agent home to survive: `peer` plus `_real_agent_name`
+# (Codex round-1 flagged that blanket underscore-prefix skip would miss
+# real agents). Only exact non-agent entries get filtered: `shared`
+# alias, `_template`, and `.claude`.
+assert names == ["_real_agent_name", "peer"], f"expected ['_real_agent_name', 'peer'], got {names}"
 
 # Writing into shared/ must not be classified as cross-agent.
 target = tp.target_agent_for_path(shared_dir / "note.md", "self")
@@ -1248,7 +1252,11 @@ assert target is None, f"shared/ write misclassified as cross-agent: {target}"
 peer_target = tp.target_agent_for_path(agents_root / "peer" / "foo.md", "self")
 assert peer_target == "peer", f"peer write not detected: {peer_target}"
 
-print("[ok] tool-policy other_agent_homes filters symlink/dot/underscore; shared/ write allowed; peer write blocked")
+# Underscore-prefixed real agents are still detected (issue #240 r2).
+underscore_target = tp.target_agent_for_path(agents_root / "_real_agent_name" / "foo.md", "self")
+assert underscore_target == "_real_agent_name", f"underscore-prefixed peer not detected: {underscore_target}"
+
+print("[ok] tool-policy other_agent_homes: shared/_template/.claude filtered; _real_agent_name kept; shared write allowed; peer write blocked")
 PY
 )
 printf '%s\n' "$TOOL_POLICY_PY_CHECK"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1210,6 +1210,51 @@ cp "$TMP_ROOT/openclaw.json" "$BRIDGE_RUNTIME_CONFIG_FILE"
 log "verifying empty runtime starts clean"
 BRIDGE_ROSTER_LOCAL_FILE=/nonexistent bash "$REPO_ROOT/bridge-start.sh" --list >/dev/null
 
+log "tool-policy: shared symlink + dot/underscore dirs are not treated as other agents (issue #240)"
+TOOL_POLICY_FIXTURE_ROOT="$TMP_ROOT/tool-policy-fixture"
+TOOL_POLICY_AGENT_HOME_ROOT="$TOOL_POLICY_FIXTURE_ROOT/agents"
+TOOL_POLICY_SHARED_DIR="$TOOL_POLICY_FIXTURE_ROOT/shared"
+rm -rf "$TOOL_POLICY_FIXTURE_ROOT"
+mkdir -p "$TOOL_POLICY_AGENT_HOME_ROOT/self" \
+         "$TOOL_POLICY_AGENT_HOME_ROOT/peer" \
+         "$TOOL_POLICY_AGENT_HOME_ROOT/_template" \
+         "$TOOL_POLICY_AGENT_HOME_ROOT/.claude" \
+         "$TOOL_POLICY_SHARED_DIR"
+# The regression trigger: an `agents/shared` symlink that points at the
+# real BRIDGE_SHARED_DIR outside the agents tree. Before the fix,
+# target_agent_for_path resolved every write under shared/ back into
+# this alias and rejected it as cross-agent access.
+ln -s "$TOOL_POLICY_SHARED_DIR" "$TOOL_POLICY_AGENT_HOME_ROOT/shared"
+TOOL_POLICY_PY_CHECK=$(BRIDGE_AGENT_ID=self BRIDGE_AGENT_HOME_ROOT="$TOOL_POLICY_AGENT_HOME_ROOT" PYTHONPATH="$REPO_ROOT/hooks" python3 - "$TOOL_POLICY_SHARED_DIR" "$TOOL_POLICY_AGENT_HOME_ROOT" "$REPO_ROOT" <<'PY'
+import importlib.util, pathlib, sys
+shared_dir = pathlib.Path(sys.argv[1])
+agents_root = pathlib.Path(sys.argv[2])
+repo_root = pathlib.Path(sys.argv[3])
+spec = importlib.util.spec_from_file_location("tp", repo_root / "hooks" / "tool-policy.py")
+tp = importlib.util.module_from_spec(spec)
+sys.modules["tp"] = tp
+spec.loader.exec_module(tp)
+
+homes = tp.other_agent_homes("self")
+names = sorted(h.name for h in homes)
+# Expect exactly ["peer"]. shared(symlink), _template(underscore), .claude(dot), self(current) all excluded.
+assert names == ["peer"], f"expected ['peer'], got {names}"
+
+# Writing into shared/ must not be classified as cross-agent.
+target = tp.target_agent_for_path(shared_dir / "note.md", "self")
+assert target is None, f"shared/ write misclassified as cross-agent: {target}"
+
+# Writing into a real peer home must still trigger.
+peer_target = tp.target_agent_for_path(agents_root / "peer" / "foo.md", "self")
+assert peer_target == "peer", f"peer write not detected: {peer_target}"
+
+print("[ok] tool-policy other_agent_homes filters symlink/dot/underscore; shared/ write allowed; peer write blocked")
+PY
+)
+printf '%s\n' "$TOOL_POLICY_PY_CHECK"
+assert_contains "$TOOL_POLICY_PY_CHECK" "[ok] tool-policy"
+rm -rf "$TOOL_POLICY_FIXTURE_ROOT"
+
 log "diagnose acl reports clean on macOS (non-Linux host)"
 DIAGNOSE_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl)"
 if [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
## Summary

Hotfix for #240. Every Claude agent's Write/Read/Bash against `$BRIDGE_SHARED_DIR` was being blocked with `cross-agent access is blocked: shared`, because `hooks/tool-policy.py::other_agent_homes()` treated the shared-alias symlink under the agents dir (→ real `$BRIDGE_SHARED_DIR`) as a peer agent home. `target_agent_for_path` then resolved both sides and matched, rejecting every legitimate shared-dir write.

## Root cause

- Standard installs have a `shared` entry under the agents dir as a symlink to the real `$BRIDGE_SHARED_DIR`.
- `is_dir()` returns True for the symlink → it lands in the peer list.
- `target_agent_for_path` → `path_within` → `.resolve()` both sides → same canonical tree → rejection.
- Same false-positive class catches `.claude/` and `_template/` siblings under the agents dir.

## Fix

Tighten `other_agent_homes()` with three structural filters:

```python
if candidate.is_symlink():
    continue
if not candidate.is_dir():
    continue
name = candidate.name
if name[0] in (".", "_"):
    continue
if name == agent:
    continue
```

Real agent homes (patch, librarian, dev_mun, sales_*, mgt_*, etc.) keep passing → cross-agent isolation still triggers on genuine peer paths.

## Smoke regression

New block at the top of `scripts/smoke-test.sh` (right after "verifying empty runtime starts clean"):

- Builds a self-contained fixture under `$TMP_ROOT`:
  - `agents/self/`, `agents/peer/`, `agents/_template/`, `agents/.claude/`, `shared/` (real dir)
  - shared symlink under agents → points at the real shared/
- Loads `hooks/tool-policy.py` via `importlib` and asserts:
  - `other_agent_homes("self") == ["peer"]` — symlink + dot + underscore all filtered.
  - `target_agent_for_path(shared/note.md, "self") is None` — shared write allowed.
  - `target_agent_for_path(peer/foo.md, "self") == "peer"` — real cross-agent write still blocked.

## Test plan

- [x] `bash -n`, `shellcheck`, `python3 -m py_compile` clean.
- [x] Ad-hoc run of the new smoke block passes.
- [x] Verified live on the reporting install: `other_agent_homes("agb-dev-claude")` post-fix returns only real agent homes (librarian, pref-smoke, patch); `BRIDGE_SHARED_DIR` write path no longer classifies as cross-agent.
- [ ] Full `./scripts/smoke-test.sh` — pre-existing `agb inbox codex-cli-agent-XXXX` early abort unchanged; new block runs before that point.

## Closes

#240

## Release

Warrants a v0.6.10 patch release on merge — this is a user-facing regression that blocks every Claude-authored write to `$BRIDGE_SHARED_DIR` on v0.6.9 (and earlier releases where the alias symlink under the agents dir exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
