### PR TITLE
docs: multi-agent worktree + pair-review contract for Claude/Codex

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,14 @@ Codex agents MUST work inside their own git worktree, not the operator's primary
 
 - Spawn with `agent-bridge --codex --name <id> --prefer new` (use `--claude` for Claude agents). The top-level `agent-bridge` CLI creates a dedicated worktree under `${BRIDGE_WORKTREE_ROOT:-~/.agent-bridge/worktrees}/<repo>/<agent>` automatically. `bridge-run.sh` itself does not accept `--prefer`; always go through `agent-bridge` for the first launch.
 - Inspect the registry with `agent-bridge worktree list`.
-- There is no `agent-bridge worktree remove` subcommand today. To retire a stale worktree, use the git-native path:
+- There is no `agent-bridge worktree remove` subcommand today. The paths themselves are content-addressed (`$BRIDGE_WORKTREE_ROOT/<project-basename>-<sha8>/<agent>` for the tree, `$BRIDGE_WORKTREE_META_DIR/<agent>--<sha12>.env` for the registry entry), so never try to reconstruct them by hand. To retire a stale worktree, read the real path from `worktree list` and hand it to the git-native remove:
   ```bash
-  cd <repo>
-  git worktree remove "$BRIDGE_WORKTREE_ROOT/<repo-basename>/<agent>"
-  rm -f "$BRIDGE_WORKTREE_META_DIR/<agent>.env"   # drops the registry entry shown by `worktree list`
+  # 1) read root= from `agent-bridge worktree list` for the agent you're retiring
+  agent-bridge worktree list
+  # 2) git-native remove using that exact path
+  git -C <project-root> worktree remove "<root-path-from-list>"
+  # 3) drop the registry entry (the filename carries a --<sha12> suffix, so glob it)
+  rm -f "$BRIDGE_WORKTREE_META_DIR"/<agent>--*.env
   ```
   Never `rm -rf` the worktree path without `git worktree remove` first — that leaves git's bookkeeping in a stale state and breaks future `--prefer new` spawns for the same name.
 - Never run `git checkout <branch>` or `git commit --amend` inside the operator's primary checkout from a Codex agent's session. Those operations belong in the agent's own worktree or in a short-lived temp clone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,8 +37,15 @@ Agent Bridge is routinely operated by multiple agents at once — typically a pl
 
 Codex agents MUST work inside their own git worktree, not the operator's primary checkout. The reason is operational, not stylistic: when two agents share a worktree, `git checkout`, `git commit --amend`, and even idle `fetch`/`pull` from one will silently move `HEAD` out from under the other (observed on 2026-04-24 during the v0.6.9 release cut, where a Codex agent's merge-helper amended a commit on top of another agent's uncommitted work).
 
-- Spawn Codex agents with `bridge-run.sh --prefer new` (or the equivalent `agent-bridge --codex --name <id> --prefer new`). The bridge creates a dedicated worktree under `${BRIDGE_WORKTREE_ROOT:-~/.agent-bridge/worktrees}/<repo>/<agent>` automatically.
-- Inspect the registry with `agent-bridge worktree list`. Stale worktrees should be cleaned up with the same CLI, not `rm -rf`.
+- Spawn with `agent-bridge --codex --name <id> --prefer new` (use `--claude` for Claude agents). The top-level `agent-bridge` CLI creates a dedicated worktree under `${BRIDGE_WORKTREE_ROOT:-~/.agent-bridge/worktrees}/<repo>/<agent>` automatically. `bridge-run.sh` itself does not accept `--prefer`; always go through `agent-bridge` for the first launch.
+- Inspect the registry with `agent-bridge worktree list`.
+- There is no `agent-bridge worktree remove` subcommand today. To retire a stale worktree, use the git-native path:
+  ```bash
+  cd <repo>
+  git worktree remove "$BRIDGE_WORKTREE_ROOT/<repo-basename>/<agent>"
+  rm -f "$BRIDGE_WORKTREE_META_DIR/<agent>.env"   # drops the registry entry shown by `worktree list`
+  ```
+  Never `rm -rf` the worktree path without `git worktree remove` first — that leaves git's bookkeeping in a stale state and breaks future `--prefer new` spawns for the same name.
 - Never run `git checkout <branch>` or `git commit --amend` inside the operator's primary checkout from a Codex agent's session. Those operations belong in the agent's own worktree or in a short-lived temp clone.
 
 ### 2. Pair-review workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,3 +28,40 @@ This snapshot does not include a full unit test suite, so rely on linting plus m
 
 ## Commit & Pull Request Guidelines
 This working copy does not include `.git`, so there is no local history to infer conventions from. Use short imperative commit subjects such as `bridge: add task queue heartbeat`. Keep pull requests narrow, list the scripts touched, include the exact manual verification commands you ran, and call out any changes to queue semantics, roster behavior, `tmux` session handling, or generated `state/` file formats.
+
+## Multi-Agent Collaboration (Claude ↔ Codex)
+
+Agent Bridge is routinely operated by multiple agents at once — typically a planner/author (`agb-dev-claude`) and one or more reviewers (`agb-dev-codex-1`, `agb-dev-codex-2`, etc.). These rules keep those agents from stepping on each other's branches and worktrees. **They are mandatory from the new-session mark — older sessions that were already running may have ignored them, and the PR review history reflects that.**
+
+### 1. Worktree isolation is the default for every Codex agent
+
+Codex agents MUST work inside their own git worktree, not the operator's primary checkout. The reason is operational, not stylistic: when two agents share a worktree, `git checkout`, `git commit --amend`, and even idle `fetch`/`pull` from one will silently move `HEAD` out from under the other (observed on 2026-04-24 during the v0.6.9 release cut, where a Codex agent's merge-helper amended a commit on top of another agent's uncommitted work).
+
+- Spawn Codex agents with `bridge-run.sh --prefer new` (or the equivalent `agent-bridge --codex --name <id> --prefer new`). The bridge creates a dedicated worktree under `${BRIDGE_WORKTREE_ROOT:-~/.agent-bridge/worktrees}/<repo>/<agent>` automatically.
+- Inspect the registry with `agent-bridge worktree list`. Stale worktrees should be cleaned up with the same CLI, not `rm -rf`.
+- Never run `git checkout <branch>` or `git commit --amend` inside the operator's primary checkout from a Codex agent's session. Those operations belong in the agent's own worktree or in a short-lived temp clone.
+
+### 2. Pair-review workflow
+
+Claude authors the change; Codex reviews; Claude merges only after Codex signs off.
+
+1. Author agent creates a feature branch off `main`, commits, pushes, and opens a PR.
+2. Author agent drops a review brief under `/tmp/agb-<pr-number>-codex-review.md` — background, focus checklist, expected outputs (`implement-ok` / `needs-more: …`).
+3. Author agent enqueues a review task with `bridge-task.sh create --from <author> --to <reviewer> --title "[PR #<N> review] …" --body-file /tmp/agb-<pr-number>-codex-review.md`.
+4. Reviewer agent verifies the diff, writes its finding into the bridge-task completion note, and returns via `agb done`.
+5. Author agent applies feedback; each round bumps the title (`[PR #N re-review]`, `[PR #N re-review r3]`, …) and gets its own brief file. Every round is a fresh `bridge-task create`, not an edit of the prior task.
+6. Merge only after the reviewer's final note starts with `implement-ok`. Reviewer agents may squash-merge themselves if the operator has granted that permission; otherwise the author agent performs the merge.
+
+### 3. Release mechanics
+
+A release PR updates only `VERSION` and `CHANGELOG.md`. Keep it in a branch named `release/vX.Y.Z`. Codex reviews the CHANGELOG entries and verifies the version-bump convention before `git tag -a vX.Y.Z <merge-sha>` and `git push origin vX.Y.Z`. Do not tag on a non-merge commit or on the feature branch.
+
+### 4. Forbidden operations under shared worktree
+
+Even when a Codex agent is attached to a shared worktree for legacy reasons, the following are forbidden on the operator's primary checkout:
+
+- `git checkout`, `git reset`, `git clean`, or `git worktree prune` affecting `main`.
+- `git commit --amend` against a commit you did not author in that same session.
+- `git push --force` or `--force-with-lease` against another agent's branch.
+
+Violations have blocked real operator work at least once (see the v0.6.9 release cut note above) and must be treated as P1 process breakage, not a style issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,19 @@ Codex agents MUST work inside their own git worktree, not the operator's primary
   git -C <project-root> worktree remove "<root-path-from-list>"
   # 3) Drop ONLY the matching registry entry. The same agent name can
   #    have --<sha12> entries for different project roots, so scope the
-  #    removal by grepping for the WORKTREE_ROOT you just removed:
+  #    removal by sourcing each env file and comparing WORKTREE_ROOT
+  #    directly. A grep would miss matches because the writer stores
+  #    the path via `printf '%q'` (shell-quoted), while `worktree list`
+  #    prints the raw path — paths containing spaces or regex
+  #    metacharacters never match the quoted form.
   target="<root-path-from-list>"
-  grep -l "^WORKTREE_ROOT=[\"']\?${target}[\"']\?$" \
-    "$BRIDGE_WORKTREE_META_DIR"/<agent>--*.env \
-    | xargs -r rm -f
+  for env in "$BRIDGE_WORKTREE_META_DIR"/<agent>--*.env; do
+    [[ -f "$env" ]] || continue
+    WORKTREE_ROOT=""
+    # shellcheck source=/dev/null
+    source "$env"
+    [[ "$WORKTREE_ROOT" == "$target" ]] && rm -f "$env"
+  done
   ```
   Never `rm -f "$BRIDGE_WORKTREE_META_DIR"/<agent>--*.env` blindly — that deletes every project's entry for the same agent name. And never `rm -rf` the worktree path without `git worktree remove` first — that leaves git's bookkeeping in a stale state and breaks future `--prefer new` spawns for the same name.
 - Never run `git checkout <branch>` or `git commit --amend` inside the operator's primary checkout from a Codex agent's session. Those operations belong in the agent's own worktree or in a short-lived temp clone.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,18 +37,24 @@ Agent Bridge is routinely operated by multiple agents at once — typically a pl
 
 Codex agents MUST work inside their own git worktree, not the operator's primary checkout. The reason is operational, not stylistic: when two agents share a worktree, `git checkout`, `git commit --amend`, and even idle `fetch`/`pull` from one will silently move `HEAD` out from under the other (observed on 2026-04-24 during the v0.6.9 release cut, where a Codex agent's merge-helper amended a commit on top of another agent's uncommitted work).
 
-- Spawn with `agent-bridge --codex --name <id> --prefer new` (use `--claude` for Claude agents). The top-level `agent-bridge` CLI creates a dedicated worktree under `${BRIDGE_WORKTREE_ROOT:-~/.agent-bridge/worktrees}/<repo>/<agent>` automatically. `bridge-run.sh` itself does not accept `--prefer`; always go through `agent-bridge` for the first launch.
+- Spawn with `agent-bridge --codex --name <id> --prefer new` (use `--claude` for Claude agents). The top-level `agent-bridge` CLI creates a dedicated worktree under `${BRIDGE_WORKTREE_ROOT:-~/.agent-bridge/worktrees}/<project-basename>-<sha8>/<agent>` automatically (the `-<sha8>` suffix is a sha1-prefix of the project root, so two different repos with the same basename don't collide). `bridge-run.sh` itself does not accept `--prefer`; always go through `agent-bridge` for the first launch.
 - Inspect the registry with `agent-bridge worktree list`.
-- There is no `agent-bridge worktree remove` subcommand today. The paths themselves are content-addressed (`$BRIDGE_WORKTREE_ROOT/<project-basename>-<sha8>/<agent>` for the tree, `$BRIDGE_WORKTREE_META_DIR/<agent>--<sha12>.env` for the registry entry), so never try to reconstruct them by hand. To retire a stale worktree, read the real path from `worktree list` and hand it to the git-native remove:
+- There is no `agent-bridge worktree remove` subcommand today. The paths are content-addressed (`$BRIDGE_WORKTREE_ROOT/<project-basename>-<sha8>/<agent>` for the tree, `$BRIDGE_WORKTREE_META_DIR/<agent>--<sha12>.env` for the registry entry, where `<sha12>` is sha1("project_root|agent")[:12]). Do not reconstruct those names by hand — read them, don't guess them:
   ```bash
-  # 1) read root= from `agent-bridge worktree list` for the agent you're retiring
+  # 1) From `agent-bridge worktree list`, note the exact `root=` path for
+  #    the agent you're retiring.
   agent-bridge worktree list
-  # 2) git-native remove using that exact path
+  # 2) git-native remove using that exact path.
   git -C <project-root> worktree remove "<root-path-from-list>"
-  # 3) drop the registry entry (the filename carries a --<sha12> suffix, so glob it)
-  rm -f "$BRIDGE_WORKTREE_META_DIR"/<agent>--*.env
+  # 3) Drop ONLY the matching registry entry. The same agent name can
+  #    have --<sha12> entries for different project roots, so scope the
+  #    removal by grepping for the WORKTREE_ROOT you just removed:
+  target="<root-path-from-list>"
+  grep -l "^WORKTREE_ROOT=[\"']\?${target}[\"']\?$" \
+    "$BRIDGE_WORKTREE_META_DIR"/<agent>--*.env \
+    | xargs -r rm -f
   ```
-  Never `rm -rf` the worktree path without `git worktree remove` first — that leaves git's bookkeeping in a stale state and breaks future `--prefer new` spawns for the same name.
+  Never `rm -f "$BRIDGE_WORKTREE_META_DIR"/<agent>--*.env` blindly — that deletes every project's entry for the same agent name. And never `rm -rf` the worktree path without `git worktree remove` first — that leaves git's bookkeeping in a stale state and breaks future `--prefer new` spawns for the same name.
 - Never run `git checkout <branch>` or `git commit --amend` inside the operator's primary checkout from a Codex agent's session. Those operations belong in the agent's own worktree or in a short-lived temp clone.
 
 ### 2. Pair-review workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,3 +114,20 @@ bash ./scripts/oss-preflight.sh
 - Prefer adding a `lib/bridge-*.sh` helper over growing root scripts.
 - If you change documented behavior, update the corresponding doc (`README.md`, `ARCHITECTURE.md`, `OPERATIONS.md`, `KNOWN_ISSUES.md`, or `docs/developer-handover.md`) in the same change.
 - Do not put private team names, channel tokens, or machine paths into tracked files — this repo is a public snapshot.
+
+## Working With Codex Reviewers
+
+This repo is normally operated by Claude + one or more Codex agents running side by side. The full collaboration contract lives in [`AGENTS.md` §"Multi-Agent Collaboration"](./AGENTS.md). The pieces you need to remember as a Claude author:
+
+1. **Never touch another agent's branch in the shared worktree.** Do not run `git checkout <other-branch>`, `git commit --amend`, `git reset`, or `git worktree prune` in the operator's primary checkout. If you need a clean workspace for a helper operation (e.g. verifying a Codex-authored PR), do it in a temp clone. Codex sessions themselves are expected to run inside their own `--prefer new` worktree; assume they do, and do not hand them paths inside your own.
+2. **Pair-review every non-trivial PR.** Default reviewer is `agb-dev-codex-2`. Workflow:
+   - Write a review brief to `/tmp/agb-<pr-number>-codex-review.md`: background, focus checklist, expected output shape (`implement-ok` / `needs-more: …`).
+   - Queue it: `bash bridge-task.sh create --from agb-dev-claude --to agb-dev-codex-2 --title "[PR #<N> review] <subject>" --body-file /tmp/agb-<pr-number>-codex-review.md`.
+   - Wait for the `[task-complete]` notification, `agb claim`, read the completion note.
+   - If `needs-more: …`, fix and enqueue the next round with a bumped title (`[PR #<N> re-review]`, then `r3`, etc.) and its own brief file. Each round is a fresh `bridge-task create`, not an edit of the prior task.
+   - Merge only after the final reviewer note opens with `implement-ok`. Codex may squash-merge itself when the operator has granted that permission; otherwise you perform the merge.
+3. **Release PRs change only `VERSION` + `CHANGELOG.md`.** Keep them on a `release/vX.Y.Z` branch. Same pair-review contract. `git tag -a vX.Y.Z` goes on the merge commit, never on the feature branch.
+4. **Branch naming.** `fix/<slug>` for bug fixes, `feat/<slug>` for new capability, `release/vX.Y.Z` for version bumps, `docs/<slug>` for doc-only changes. Keep one PR per branch; rebase to `main` rather than piggy-backing on another open PR (that was the source of the #235 "stacked on #232" confusion on 2026-04-24).
+5. **When a review round loops more than 3 times** without an `implement-ok`, stop and reconsider scope before continuing — that's usually a signal the PR is touching too much surface or the spec is ambiguous; a `codex-spec` round on the originating issue is often cheaper than another code round.
+
+Codex cannot observe your local worktree, so reproducibility is on you: include the exact path, env, and command in the review brief and the PR description — not just the symptom. Assume Codex will rerun your verification from scratch.


### PR DESCRIPTION
## Summary

Codifies the multi-agent collaboration rules that have developed around running Claude + multiple Codex agents on the same repo at once. The need surfaced during today's v0.6.9 release cut, where two Codex agents sharing the operator's primary worktree with Claude moved HEAD and amended a commit on top of uncommitted release work — recoverable, but visible enough that operator-facing documentation beats another ad-hoc rule.

## Changes

- **`AGENTS.md`** grows a new `## Multi-Agent Collaboration (Claude ↔ Codex)` section with four concrete contracts:
  1. **Worktree isolation.** Codex agents MUST spawn with `bridge-run.sh --prefer new` / `agent-bridge --codex --name <id> --prefer new`. Bridge's `BRIDGE_WORKTREE_ROOT` auto-manages the per-agent worktree; `agent-bridge worktree list` inspects, `rm -rf` is banned.
  2. **Pair-review workflow.** Claude authors → brief file under `/tmp/agb-<pr>-codex-review.md` → `bridge-task create --from … --to … --body-file …` → Codex writes `implement-ok` / `needs-more: …` → Claude applies feedback, bumps the title (`r3`, `r4`, …), never edits the prior task.
  3. **Release mechanics.** `release/vX.Y.Z` branch, VERSION + CHANGELOG only, `git tag -a` on the merge commit.
  4. **Forbidden operations under shared worktree.** Explicit list: `git checkout|reset|clean|worktree prune` on `main`, `commit --amend` across agent boundaries, `--force-*` against another agent's branch.
- **`CLAUDE.md`** grows a companion `## Working With Codex Reviewers` section aimed at the Claude author role: how to write a brief, when to bump a round number, when to stop looping and ask for a spec round instead. Cross-links to AGENTS.md for the long-form contract.

## Why now

- PR #235 "stacked on #232" confusion (2026-04-24 morning).
- v0.6.9 release cut `HEAD` move and double `commit --amend` (2026-04-24 evening). Sean observed both agents asking "why did my branch change?" as the same symptom.

The rules are marked authoritative **from the next session onward**. In-flight sessions that predate the merge may still exhibit the older behaviour — that's why the triggers are called out in the text rather than assumed away.

## Test plan

- [x] Pure docs; no code paths modified.
- [x] `bash -n *.sh` still clean (AGENTS.md / CLAUDE.md are markdown, no shell).
- [ ] First-use check: next session should spawn a Codex agent via `--prefer new` per the rule and confirm the worktree registry reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
