### PR TITLE
channels: enforce singleton-plugin policy via shared overlay (closes #244)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -153,11 +153,12 @@ Current behavior:
 
 Fix (applied by default from #244):
 
-- `scripts/apply-channel-policy.sh` writes the shared overlay at `agents/.claude/settings.local.json` so every non-admin agent's `.claude/settings.json` symlink resolves to an effective settings that explicitly disables `telegram@claude-plugins-official` and `discord@claude-plugins-official`.
-- The admin agent keeps its own non-shared `settings.json` and acts as the sole router for those channels.
+- `scripts/apply-channel-policy.sh` writes the shared overlay at `agents/.claude/settings.local.json` so every agent whose `.claude/settings.json` resolves to the shared effective settings gets `telegram@claude-plugins-official` and `discord@claude-plugins-official` explicitly disabled.
+- When an admin agent is configured (`BRIDGE_ADMIN_AGENT_ID` in env or roster), the same script writes a per-agent local overlay at `agents/<admin>/.claude/settings.local.json` re-enabling those singleton plugins for the router. Claude Code's settings merge order prefers the project `.claude/settings.local.json` over the project `.claude/settings.json` (the shared-effective symlink), so the admin keeps the channels while every other agent stops contending.
 - `bridge-upgrade.sh` re-runs the policy on every upgrade (idempotent).
 
 Operator guidance:
 
 - Run `bash scripts/apply-channel-policy.sh` manually after adding or removing agents if the policy has drifted.
+- If you change the admin agent (`BRIDGE_ADMIN_AGENT_ID`), re-run `apply-channel-policy.sh` and then remove `agents/<previous-admin>/.claude/settings.local.json` — the script only writes the new admin's overlay, it does not clean up prior admins.
 - If a non-admin agent needs its own DM endpoint, provision a dedicated bot token per agent and add the plugin id to that agent's `.claude/settings.json` explicitly, rather than relying on the shared token.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -143,3 +143,21 @@ Operator guidance:
 
 - do not expose the Teams plugin's `/auth/callback` to the public internet without additional ingress-level auth (mTLS, ingress token, IP allowlist)
 - if you operate a multi-tenant hosted Teams plugin, layer your own `state` allowlist or HMAC before this handler
+
+## 10. Singleton channel plugins (Telegram / Discord) poll-lock across concurrent agents
+
+Current behavior:
+
+- Telegram and Discord bots enforce one-poller-per-bot-token: only one process at a time may hold the `getUpdates` long-poll (Telegram) or the gateway websocket (Discord). A second connection on the same token gets a `409 Conflict` (Telegram) or a session-kick (Discord).
+- Claude Code auto-spawns every `~/.claude/settings.json` `enabledPlugins` entry for every agent session, so absent an override every agent's claude process tries to run its own telegram/discord MCP child. The most recently restarted agent holds the lease; every earlier agent has been silently kicked off.
+
+Fix (applied by default from #244):
+
+- `scripts/apply-channel-policy.sh` writes the shared overlay at `agents/.claude/settings.local.json` so every non-admin agent's `.claude/settings.json` symlink resolves to an effective settings that explicitly disables `telegram@claude-plugins-official` and `discord@claude-plugins-official`.
+- The admin agent keeps its own non-shared `settings.json` and acts as the sole router for those channels.
+- `bridge-upgrade.sh` re-runs the policy on every upgrade (idempotent).
+
+Operator guidance:
+
+- Run `bash scripts/apply-channel-policy.sh` manually after adding or removing agents if the policy has drifted.
+- If a non-admin agent needs its own DM endpoint, provision a dedicated bot token per agent and add the plugin id to that agent's `.claude/settings.json` explicitly, rather than relying on the shared token.

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -871,6 +871,18 @@ if [[ $MIGRATE_AGENTS -eq 1 ]]; then
       --bridge-home "$TARGET_ROOT" \
       --target-root "$TARGET_ROOT/agents" >/dev/null 2>&1 || true
   fi
+
+  # Enforce the singleton channel plugin policy (closes #244). Running this
+  # on every upgrade is idempotent — it only writes the overlay when an
+  # entry would change. `--quiet` keeps upgrade output terse; failures are
+  # tolerated so an unexpected overlay error never blocks the upgrade.
+  policy_args=(--quiet)
+  if [[ $DRY_RUN -eq 1 ]]; then
+    policy_args+=(--dry-run)
+  fi
+  BRIDGE_HOME="$TARGET_ROOT" \
+    "$BRIDGE_BASH_BIN" "$SOURCE_ROOT/scripts/apply-channel-policy.sh" "${policy_args[@]}" \
+    >/dev/null 2>&1 || true
 fi
 
 if [[ $RESTART_DAEMON -eq 1 && $DRY_RUN -eq 0 ]]; then

--- a/scripts/apply-channel-policy.sh
+++ b/scripts/apply-channel-policy.sh
@@ -10,11 +10,20 @@
 # agent operation this silently leaves the admin / router agent without a
 # Telegram channel, and operator DMs go nowhere.
 #
-# Fix: write the shared overlay (`agents/.claude/settings.local.json`) so
-# every non-admin agent's `.claude/settings.json` symlink resolves to an
-# effective settings that explicitly disables the singleton plugins. The
-# admin agent (which has its own non-shared settings.json) keeps them
-# enabled and acts as the sole router.
+# Fix has two parts:
+#
+# 1. Write the shared overlay (`agents/.claude/settings.local.json`) so every
+#    agent whose `.claude/settings.json` resolves to the shared effective
+#    settings gets `enabledPlugins[telegram@…]=false` and
+#    `enabledPlugins[discord@…]=false`.
+# 2. When an admin agent is configured, write a per-agent local overlay at
+#    `agents/<admin>/.claude/settings.local.json` that re-enables the same
+#    singleton plugins. Claude Code's settings merge order prefers a project
+#    `.claude/settings.local.json` over the project `.claude/settings.json`,
+#    so the admin keeps the singleton plugins even when its
+#    `.claude/settings.json` is the shared-effective symlink. Without this
+#    bypass, #242's shared-symlink bootstrap means the admin loses exactly
+#    the channels it is supposed to hold — see the PR #246 review.
 #
 # This script is idempotent. It is safe to re-run on every upgrade.
 
@@ -142,5 +151,91 @@ if [[ $DRY_RUN -eq 0 ]]; then
     [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] re-rendered $EFFECTIVE_SETTINGS"
   else
     [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] warning: bridge-hooks.py not found under BRIDGE_HOME or repo; overlay written but effective not re-rendered" >&2
+  fi
+fi
+
+# Admin bypass: re-enable singleton plugins in the admin's per-agent local
+# overlay. We resolve admin id only from an explicit signal (env or roster
+# grep) — we never fall back to a default, because this bypass must be a
+# no-op on installs that have not configured an admin yet (e.g. smoke
+# fixtures, pre-bootstrap hosts).
+admin_agent_id=""
+if [[ -n "${BRIDGE_ADMIN_AGENT_ID:-}" ]]; then
+  admin_agent_id="$BRIDGE_ADMIN_AGENT_ID"
+else
+  for _admin_roster in "$BRIDGE_HOME/agent-roster.local.sh" "$BRIDGE_HOME/agent-roster.sh"; do
+    if [[ -r "$_admin_roster" ]]; then
+      _admin_line="$(grep -E '^[[:space:]]*(export[[:space:]]+)?BRIDGE_ADMIN_AGENT_ID=' "$_admin_roster" 2>/dev/null | head -n 1 | sed -E 's/^[[:space:]]*(export[[:space:]]+)?BRIDGE_ADMIN_AGENT_ID=//; s/^"([^"]*)".*/\1/; s/^'"'"'([^'"'"']*)'"'"'.*/\1/; s/[[:space:]]*#.*$//')"
+      if [[ -n "$_admin_line" ]]; then
+        admin_agent_id="$_admin_line"
+        break
+      fi
+    fi
+  done
+fi
+
+if [[ -n "$admin_agent_id" ]]; then
+  ADMIN_HOME="$BRIDGE_AGENT_HOME_ROOT/$admin_agent_id"
+  ADMIN_LOCAL_SETTINGS="$ADMIN_HOME/.claude/settings.local.json"
+
+  # Only write the bypass if the admin home already exists. During upgrade the
+  # admin is already bootstrapped; in smoke fixtures or pre-bootstrap hosts the
+  # directory is absent and we must stay a no-op rather than materialise an
+  # empty agent dir from an env var that might be a stale default.
+  if [[ ! -d "$ADMIN_HOME" ]]; then
+    [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] skip admin re-enable: '$admin_agent_id' home not present under $BRIDGE_AGENT_HOME_ROOT"
+  else
+    admin_plan="$("$BRIDGE_PYTHON" - "$ADMIN_LOCAL_SETTINGS" "${SINGLETON_PLUGINS[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+overlay_path = Path(sys.argv[1])
+singleton_plugins = sys.argv[2:]
+
+if overlay_path.exists():
+    try:
+        payload = json.loads(overlay_path.read_text() or "{}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"admin overlay is not valid JSON: {overlay_path}: {exc}")
+else:
+    payload = {}
+
+if not isinstance(payload, dict):
+    raise SystemExit(f"admin overlay root must be a JSON object: {overlay_path}")
+
+enabled = payload.get("enabledPlugins")
+if not isinstance(enabled, dict):
+    enabled = {}
+
+changed = False
+for plugin_id in singleton_plugins:
+    if enabled.get(plugin_id) is not True:
+        enabled[plugin_id] = True
+        changed = True
+
+payload["enabledPlugins"] = enabled
+print(json.dumps({"changed": changed, "payload": payload}))
+PY
+)"
+
+    admin_changed="$(printf '%s' "$admin_plan" | "$BRIDGE_PYTHON" -c 'import json,sys;print(json.loads(sys.stdin.read())["changed"])')"
+
+    if [[ "$admin_changed" == "True" ]]; then
+      if [[ $DRY_RUN -eq 1 ]]; then
+        [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] would write $ADMIN_LOCAL_SETTINGS (re-enable for admin '$admin_agent_id': ${SINGLETON_PLUGINS[*]})"
+      else
+        printf '%s' "$admin_plan" | "$BRIDGE_PYTHON" -c '
+import json,sys,pathlib
+plan=json.loads(sys.stdin.read())
+p=pathlib.Path(sys.argv[1])
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(json.dumps(plan["payload"], indent=2, sort_keys=True) + "\n")
+' "$ADMIN_LOCAL_SETTINGS"
+        [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] wrote $ADMIN_LOCAL_SETTINGS (admin re-enable)"
+      fi
+    else
+      [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] admin overlay for '$admin_agent_id' already re-enables singleton policy (no change)"
+    fi
   fi
 fi

--- a/scripts/apply-channel-policy.sh
+++ b/scripts/apply-channel-policy.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# apply-channel-policy.sh — enforce the agent-bridge singleton channel policy.
+#
+# Closes upstream #244. Claude Code auto-spawns every user-level enabledPlugins
+# entry for every agent session. For "singleton channel" plugins (Telegram,
+# Discord) only one process per bot token can poll `getUpdates` or hold the
+# gateway websocket — so when multiple agents run concurrently, every restart
+# of any agent kicks the previous holder off its lease with a 409 Conflict
+# and the last one to restart becomes the sole holder. Under normal multi-
+# agent operation this silently leaves the admin / router agent without a
+# Telegram channel, and operator DMs go nowhere.
+#
+# Fix: write the shared overlay (`agents/.claude/settings.local.json`) so
+# every non-admin agent's `.claude/settings.json` symlink resolves to an
+# effective settings that explicitly disables the singleton plugins. The
+# admin agent (which has its own non-shared settings.json) keeps them
+# enabled and acts as the sole router.
+#
+# This script is idempotent. It is safe to re-run on every upgrade.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/_common.sh
+source "$SCRIPT_DIR/_common.sh"
+
+: "${BRIDGE_AGENT_HOME_ROOT:=$BRIDGE_HOME/agents}"
+: "${BRIDGE_AGENTS_CLAUDE_DIR:=$BRIDGE_AGENT_HOME_ROOT/.claude}"
+
+BASE_SETTINGS="$BRIDGE_AGENTS_CLAUDE_DIR/settings.json"
+OVERLAY_SETTINGS="$BRIDGE_AGENTS_CLAUDE_DIR/settings.local.json"
+EFFECTIVE_SETTINGS="$BRIDGE_AGENTS_CLAUDE_DIR/settings.effective.json"
+
+# Plugins that enforce one-connection-per-bot-token upstream. Adding a plugin
+# here is a declaration that "multiple concurrent instances are broken by the
+# service the plugin talks to, not by the plugin itself." Plugins that talk to
+# stateless HTTP APIs (teams, ms365) do NOT belong here.
+SINGLETON_PLUGINS=(
+  "telegram@claude-plugins-official"
+  "discord@claude-plugins-official"
+)
+
+DRY_RUN=0
+QUIET=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1 ;;
+    --quiet)   QUIET=1 ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: apply-channel-policy.sh [--dry-run] [--quiet]
+
+Idempotently enforce the singleton channel plugin policy by writing the
+shared overlay at $BRIDGE_HOME/agents/.claude/settings.local.json and
+re-rendering the effective settings.
+
+With --dry-run, prints the planned action but does not modify any file.
+USAGE
+      exit 0 ;;
+    *) echo "apply-channel-policy.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+mkdir -p "$BRIDGE_AGENTS_CLAUDE_DIR"
+
+python_plan="$(BRIDGE_PYTHON_HOME="$BRIDGE_HOME" "$BRIDGE_PYTHON" - "$OVERLAY_SETTINGS" "${SINGLETON_PLUGINS[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+overlay_path = Path(sys.argv[1])
+singleton_plugins = sys.argv[2:]
+
+if overlay_path.exists():
+    try:
+        payload = json.loads(overlay_path.read_text() or "{}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"overlay is not valid JSON: {overlay_path}: {exc}")
+else:
+    payload = {}
+
+if not isinstance(payload, dict):
+    raise SystemExit(f"overlay root must be a JSON object: {overlay_path}")
+
+enabled = payload.get("enabledPlugins")
+if not isinstance(enabled, dict):
+    enabled = {}
+
+changed = False
+for plugin_id in singleton_plugins:
+    if enabled.get(plugin_id) is not False:
+        enabled[plugin_id] = False
+        changed = True
+
+if changed:
+    payload["enabledPlugins"] = enabled
+    plan = {"changed": True, "payload": payload}
+else:
+    plan = {"changed": False, "payload": payload}
+
+print(json.dumps(plan))
+PY
+)"
+
+changed="$(printf '%s' "$python_plan" | "$BRIDGE_PYTHON" -c 'import json,sys;print(json.loads(sys.stdin.read())["changed"])')"
+
+if [[ "$changed" == "True" ]]; then
+  if [[ $DRY_RUN -eq 1 ]]; then
+    [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] would write $OVERLAY_SETTINGS (disable: ${SINGLETON_PLUGINS[*]})"
+  else
+    printf '%s' "$python_plan" | "$BRIDGE_PYTHON" -c '
+import json,sys,pathlib
+plan=json.loads(sys.stdin.read())
+p=pathlib.Path(sys.argv[1])
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(json.dumps(plan["payload"], indent=2, sort_keys=True) + "\n")
+' "$OVERLAY_SETTINGS"
+    [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] wrote $OVERLAY_SETTINGS"
+  fi
+else
+  [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] overlay already enforces singleton policy (no change)"
+fi
+
+# Re-render the shared effective settings so every non-admin agent's
+# `.claude/settings.json` symlink immediately picks up the new overlay. The
+# admin agent owns its own non-shared settings.json and is not affected.
+if [[ $DRY_RUN -eq 0 ]]; then
+  # Prefer the live-runtime copy; fall back to the source-root copy so this
+  # script works in smoke tests where BRIDGE_HOME is a scratch dir.
+  bridge_hooks_py=""
+  if [[ -f "$BRIDGE_HOME/bridge-hooks.py" ]]; then
+    bridge_hooks_py="$BRIDGE_HOME/bridge-hooks.py"
+  elif [[ -f "$SCRIPT_DIR/../bridge-hooks.py" ]]; then
+    bridge_hooks_py="$(cd -P "$SCRIPT_DIR/.." && pwd -P)/bridge-hooks.py"
+  fi
+  if [[ -n "$bridge_hooks_py" ]]; then
+    "$BRIDGE_PYTHON" "$bridge_hooks_py" render-shared-settings \
+      --base-settings-file "$BASE_SETTINGS" \
+      --overlay-settings-file "$OVERLAY_SETTINGS" \
+      --effective-settings-file "$EFFECTIVE_SETTINGS" >/dev/null
+    [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] re-rendered $EFFECTIVE_SETTINGS"
+  else
+    [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] warning: bridge-hooks.py not found under BRIDGE_HOME or repo; overlay written but effective not re-rendered" >&2
+  fi
+fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1286,7 +1286,7 @@ log "apply-channel-policy.sh writes overlay disabling singleton channel plugins 
 CHANNEL_POLICY_HOME="$TMP_ROOT/channel-policy-home"
 mkdir -p "$CHANNEL_POLICY_HOME/agents/.claude"
 printf '{}' > "$CHANNEL_POLICY_HOME/agents/.claude/settings.json"
-env -u BRIDGE_AGENT_HOME_ROOT BRIDGE_HOME="$CHANNEL_POLICY_HOME" \
+env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID BRIDGE_HOME="$CHANNEL_POLICY_HOME" \
   bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
 CHANNEL_POLICY_OVERLAY="$CHANNEL_POLICY_HOME/agents/.claude/settings.local.json"
 [[ -f "$CHANNEL_POLICY_OVERLAY" ]] || die "apply-channel-policy.sh did not write overlay"
@@ -1298,10 +1298,53 @@ CHANNEL_POLICY_EFFECTIVE="$CHANNEL_POLICY_HOME/agents/.claude/settings.effective
 assert_contains "$(cat "$CHANNEL_POLICY_EFFECTIVE")" "\"telegram@claude-plugins-official\": false"
 # Idempotency: second run must be a no-op (overlay byte-identical).
 CHANNEL_POLICY_OVERLAY_FIRST="$(cat "$CHANNEL_POLICY_OVERLAY")"
-env -u BRIDGE_AGENT_HOME_ROOT BRIDGE_HOME="$CHANNEL_POLICY_HOME" \
+env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID BRIDGE_HOME="$CHANNEL_POLICY_HOME" \
   bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
 CHANNEL_POLICY_OVERLAY_SECOND="$(cat "$CHANNEL_POLICY_OVERLAY")"
 [[ "$CHANNEL_POLICY_OVERLAY_FIRST" == "$CHANNEL_POLICY_OVERLAY_SECOND" ]] || die "apply-channel-policy.sh was not idempotent"
+# Admin was not declared in this fixture — script must not create any
+# per-agent overlay. (`_common.sh` defaults `BRIDGE_ADMIN_AGENT` to `patch`
+# for cron helpers, so we specifically assert that path is NOT touched.)
+[[ ! -e "$CHANNEL_POLICY_HOME/agents/patch/.claude/settings.local.json" ]] \
+  || die "apply-channel-policy.sh wrote admin overlay without an explicit BRIDGE_ADMIN_AGENT_ID"
+
+log "apply-channel-policy.sh re-enables singleton plugins for configured admin (PR #246 admin bypass)"
+CHANNEL_POLICY_ADMIN_HOME="$TMP_ROOT/channel-policy-admin-home"
+mkdir -p "$CHANNEL_POLICY_ADMIN_HOME/agents/.claude" "$CHANNEL_POLICY_ADMIN_HOME/agents/admin_smoke/.claude"
+printf '{}' > "$CHANNEL_POLICY_ADMIN_HOME/agents/.claude/settings.json"
+env -u BRIDGE_AGENT_HOME_ROOT BRIDGE_HOME="$CHANNEL_POLICY_ADMIN_HOME" \
+  BRIDGE_ADMIN_AGENT_ID="admin_smoke" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+ADMIN_POLICY_OVERLAY="$CHANNEL_POLICY_ADMIN_HOME/agents/admin_smoke/.claude/settings.local.json"
+[[ -f "$ADMIN_POLICY_OVERLAY" ]] || die "apply-channel-policy.sh did not write admin bypass overlay"
+ADMIN_POLICY_OVERLAY_PAYLOAD="$(cat "$ADMIN_POLICY_OVERLAY")"
+assert_contains "$ADMIN_POLICY_OVERLAY_PAYLOAD" "\"telegram@claude-plugins-official\": true"
+assert_contains "$ADMIN_POLICY_OVERLAY_PAYLOAD" "\"discord@claude-plugins-official\": true"
+# Shared overlay must still disable the plugins — the fix is two layers,
+# not a replacement for the shared enforcement.
+ADMIN_SHARED_OVERLAY="$CHANNEL_POLICY_ADMIN_HOME/agents/.claude/settings.local.json"
+[[ -f "$ADMIN_SHARED_OVERLAY" ]] || die "shared overlay missing under admin fixture"
+assert_contains "$(cat "$ADMIN_SHARED_OVERLAY")" "\"telegram@claude-plugins-official\": false"
+# Idempotency for the admin path too.
+ADMIN_POLICY_OVERLAY_FIRST="$(cat "$ADMIN_POLICY_OVERLAY")"
+env -u BRIDGE_AGENT_HOME_ROOT BRIDGE_HOME="$CHANNEL_POLICY_ADMIN_HOME" \
+  BRIDGE_ADMIN_AGENT_ID="admin_smoke" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+ADMIN_POLICY_OVERLAY_SECOND="$(cat "$ADMIN_POLICY_OVERLAY")"
+[[ "$ADMIN_POLICY_OVERLAY_FIRST" == "$ADMIN_POLICY_OVERLAY_SECOND" ]] || die "apply-channel-policy.sh admin bypass was not idempotent"
+# Roster-file fallback: admin id picked up from agent-roster.local.sh when
+# env is unset.
+CHANNEL_POLICY_ROSTER_HOME="$TMP_ROOT/channel-policy-roster-home"
+mkdir -p "$CHANNEL_POLICY_ROSTER_HOME/agents/.claude" "$CHANNEL_POLICY_ROSTER_HOME/agents/admin_from_roster/.claude"
+printf '{}' > "$CHANNEL_POLICY_ROSTER_HOME/agents/.claude/settings.json"
+printf 'BRIDGE_ADMIN_AGENT_ID="admin_from_roster"\n' \
+  > "$CHANNEL_POLICY_ROSTER_HOME/agent-roster.local.sh"
+env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID \
+  BRIDGE_HOME="$CHANNEL_POLICY_ROSTER_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+ROSTER_POLICY_OVERLAY="$CHANNEL_POLICY_ROSTER_HOME/agents/admin_from_roster/.claude/settings.local.json"
+[[ -f "$ROSTER_POLICY_OVERLAY" ]] || die "apply-channel-policy.sh did not pick admin id up from the roster"
+assert_contains "$(cat "$ROSTER_POLICY_OVERLAY")" "\"telegram@claude-plugins-official\": true"
 
 log "starting isolated daemon"
 bash "$REPO_ROOT/bridge-daemon.sh" ensure >/dev/null

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1282,6 +1282,27 @@ assert_contains "$DIAGNOSE_JSON_OUTPUT" "\"findings\""
 DIAGNOSE_HELP="$("$REPO_ROOT/agent-bridge" diagnose 2>&1 || true)"
 assert_contains "$DIAGNOSE_HELP" "diagnose acl"
 
+log "apply-channel-policy.sh writes overlay disabling singleton channel plugins (#244)"
+CHANNEL_POLICY_HOME="$TMP_ROOT/channel-policy-home"
+mkdir -p "$CHANNEL_POLICY_HOME/agents/.claude"
+printf '{}' > "$CHANNEL_POLICY_HOME/agents/.claude/settings.json"
+env -u BRIDGE_AGENT_HOME_ROOT BRIDGE_HOME="$CHANNEL_POLICY_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+CHANNEL_POLICY_OVERLAY="$CHANNEL_POLICY_HOME/agents/.claude/settings.local.json"
+[[ -f "$CHANNEL_POLICY_OVERLAY" ]] || die "apply-channel-policy.sh did not write overlay"
+CHANNEL_POLICY_OVERLAY_PAYLOAD="$(cat "$CHANNEL_POLICY_OVERLAY")"
+assert_contains "$CHANNEL_POLICY_OVERLAY_PAYLOAD" "\"telegram@claude-plugins-official\": false"
+assert_contains "$CHANNEL_POLICY_OVERLAY_PAYLOAD" "\"discord@claude-plugins-official\": false"
+CHANNEL_POLICY_EFFECTIVE="$CHANNEL_POLICY_HOME/agents/.claude/settings.effective.json"
+[[ -f "$CHANNEL_POLICY_EFFECTIVE" ]] || die "apply-channel-policy.sh did not render effective settings"
+assert_contains "$(cat "$CHANNEL_POLICY_EFFECTIVE")" "\"telegram@claude-plugins-official\": false"
+# Idempotency: second run must be a no-op (overlay byte-identical).
+CHANNEL_POLICY_OVERLAY_FIRST="$(cat "$CHANNEL_POLICY_OVERLAY")"
+env -u BRIDGE_AGENT_HOME_ROOT BRIDGE_HOME="$CHANNEL_POLICY_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+CHANNEL_POLICY_OVERLAY_SECOND="$(cat "$CHANNEL_POLICY_OVERLAY")"
+[[ "$CHANNEL_POLICY_OVERLAY_FIRST" == "$CHANNEL_POLICY_OVERLAY_SECOND" ]] || die "apply-channel-policy.sh was not idempotent"
+
 log "starting isolated daemon"
 bash "$REPO_ROOT/bridge-daemon.sh" ensure >/dev/null
 DAEMON_STATUS=""


### PR DESCRIPTION
Closes #244.

## Problem

Telegram and Discord bots enforce one-poller-per-bot-token upstream: only one process at a time may hold the Telegram `getUpdates` long-poll or the Discord gateway websocket. A second connection on the same token gets a `409 Conflict` (Telegram) or a session-kick (Discord).

Claude Code auto-spawns every `~/.claude/settings.json` `enabledPlugins` entry for every agent session, so absent an override every concurrent agent runs its own telegram/discord MCP child. The most recently restarted agent holds the lease; every earlier agent has been silently kicked off. In the worst case a restart-storm takes every poller down (verified on v0.6.8 host during GO-2 ACL verification run on 2026-04-24) and the admin agent is left with no channel at all — operator DMs go nowhere.

## Fix shape

Write the shared overlay `agents/.claude/settings.local.json` so every non-admin agent's `.claude/settings.json` symlink (which resolves to the shared `settings.effective.json`) gets an `enabledPlugins` override that explicitly disables the singleton channel plugins. The admin agent owns its own non-shared `settings.json` and is unaffected, so it remains the sole router for Telegram/Discord.

- `scripts/apply-channel-policy.sh` — new, idempotent. Writes the overlay (no-op if already converged) and re-renders `settings.effective.json` via the existing `bridge-hooks.py render-shared-settings` command.
- `bridge-upgrade.sh` — calls the policy script after `bridge-docs.py apply --all` runs; same dry-run semantics as the surrounding migration block; failures are tolerated so a surprise overlay error never blocks an upgrade.
- `scripts/smoke-test.sh` — new test asserts (a) the overlay file is written with the expected shape, (b) the effective settings merge picks up the override, and (c) a second run is byte-identical (idempotent).
- `KNOWN_ISSUES.md` §10 — documents the behaviour for operators.

## Singleton plugin set

Intentionally limited to plugins whose upstream service enforces one-connection-per-token:

```
BRIDGE_SINGLETON_CHANNEL_PLUGINS=(
  telegram@claude-plugins-official
  discord@claude-plugins-official
)
```

HTTP-based plugins (`teams@agent-bridge`, `ms365@agent-bridge`) are not affected — they can safely coexist across agents.

## Blast radius

- **Write target**: one new file (`agents/.claude/settings.local.json`) plus the re-render of `settings.effective.json`. Both are already within the shared settings lifecycle managed by `lib/bridge-hooks.sh`; no new filesystem surface.
- **Non-admin agents** lose their telegram/discord MCP child on next restart. This is the desired behaviour — they were never supposed to hold those leases.
- **Admin agent** unchanged (owns its own settings.json; user-level `enabledPlugins` still applies).
- **Reversibility**: delete the `enabledPlugins` key from the overlay (or the file itself) and re-run `apply-channel-policy.sh` / let the next upgrade re-converge.

## Verified

- `scripts/apply-channel-policy.sh --dry-run` on a clean dir reports the planned write.
- Fresh run on a scratch `BRIDGE_HOME` writes `settings.local.json` with the expected shape and `settings.effective.json` merges the override.
- Second run on the same dir is a no-op (`[apply-channel-policy] overlay already enforces singleton policy (no change)`).
- Smoke-test addition asserts the above.

Manual verification still needed on a live multi-agent host: restart a non-admin agent after apply and confirm `pstree` on its claude pane shows no telegram/discord bun child, while the admin keeps its Telegram lease.

## Out of scope

- Per-plugin router roster (`BRIDGE_CHANNEL_ROUTER["telegram@..."]="patch"`). This PR hard-codes admin as the router, which matches every currently-deployed install. A future PR can lift this if operators need non-admin routers.
- Discord gateway shard-aware multi-instance coexistence. For now Discord is simply gated the same way as Telegram.
- `agent-bridge diagnose channels` — a scanner that surfaces policy drift on demand. Can land as a follow-up alongside the `diagnose acl` precedent.

## Reference

- Issue #244 (root cause + symptom trace).
- Related: #227 (`--continue` bun respawn), #234 (parent bun → server.ts orphan). This PR closes the multi-agent orchestration side that neither of those addresses.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>