### PR TITLE
watchdog: bypass onboarding-pending warn for dynamic/cron agents (closes #241)

### DIFF
--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -81,10 +81,31 @@ def heartbeat_age_seconds(agent_dir: Path) -> tuple[bool, int | None]:
     return True, max(age, 0)
 
 
-def classify_status(missing_files: list[str], broken_links: list[str], onboarding_state: str, missing_block: bool) -> str:
+# Session types that have no interactive first-session onboarding by
+# design. `dynamic` agents (e.g. `librarian`) are provisioned by
+# `bootstrap-memory-system.sh` to drain a task family mechanically; they
+# never get a human-facing onboarding flow and therefore stay at
+# `Onboarding State: pending` forever. `cron` is the same shape —
+# non-interactive, no human ever flips it to complete. Treating those
+# as `warn` swamps the admin inbox with a false-positive
+# `[watchdog] agent profile drift` task every sweep (issue #241).
+NON_ONBOARDING_SESSION_TYPES: frozenset[str] = frozenset({"dynamic", "cron"})
+
+
+def classify_status(
+    missing_files: list[str],
+    broken_links: list[str],
+    onboarding_state: str,
+    missing_block: bool,
+    session_type: str,
+) -> str:
     if missing_files:
         return "error"
-    if broken_links or missing_block or onboarding_state in {"pending", "missing"}:
+    onboarding_stale = (
+        onboarding_state in {"pending", "missing"}
+        and session_type not in NON_ONBOARDING_SESSION_TYPES
+    )
+    if broken_links or missing_block or onboarding_stale:
         return "warn"
     return "ok"
 
@@ -96,7 +117,7 @@ def scan_agent(agent_dir: Path) -> AgentWatch:
     session_type, onboarding_state = parse_session_type(agent_dir)
     heartbeat_present, heartbeat_age = heartbeat_age_seconds(agent_dir)
     broken_links = collect_broken_links(agent_dir)
-    status = classify_status(missing_files, broken_links, onboarding_state, missing_block)
+    status = classify_status(missing_files, broken_links, onboarding_state, missing_block, session_type)
     return AgentWatch(
         agent=agent_dir.name,
         session_type=session_type,

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3344,6 +3344,37 @@ assert_contains "$WATCHDOG_JSON" "\"agent\": \"$CREATED_AGENT\""
 assert_contains "$WATCHDOG_JSON" "\"onboarding_state\": \"complete\""
 assert_contains "$WATCHDOG_JSON" "\"problem_count\": 0"
 
+log "watchdog classify_status bypasses dynamic/cron pending onboarding (issue #241)"
+python3 - "$REPO_ROOT" <<'PY'
+import importlib.util
+import pathlib
+import sys
+
+repo_root = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("wd", repo_root / "bridge-watchdog.py")
+wd = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = wd
+spec.loader.exec_module(wd)
+
+# Bug: `dynamic` + pending used to be classified as warn, filing a
+# recurring `[watchdog] agent profile drift` task for every sweep.
+assert wd.classify_status([], [], "pending", False, "dynamic") == "ok"
+assert wd.classify_status([], [], "missing", False, "dynamic") == "ok"
+assert wd.classify_status([], [], "pending", False, "cron") == "ok"
+
+# Non-onboarding session types still trip the other checks.
+assert wd.classify_status([], ["bad-link"], "complete", False, "dynamic") == "warn"
+assert wd.classify_status([], [], "complete", True, "dynamic") == "warn"
+assert wd.classify_status(["CLAUDE.md"], [], "complete", False, "dynamic") == "error"
+
+# Regular agents keep the original pending → warn behaviour.
+assert wd.classify_status([], [], "pending", False, "admin") == "warn"
+assert wd.classify_status([], [], "missing", False, "router") == "warn"
+assert wd.classify_status([], [], "complete", False, "admin") == "ok"
+
+print("[ok] bridge-watchdog classify_status: dynamic/cron bypass + regression guard")
+PY
+
 log "bootstrapping a manager role with init"
 INIT_DRY_RUN_JSON="$("$REPO_ROOT/agent-bridge" init --admin "$INIT_AGENT" --engine claude --session "$INIT_SESSION" --channels plugin:telegram --dry-run --json 2>&1)" || die "init dry-run failed: $INIT_DRY_RUN_JSON"
 python3 - "$INIT_DRY_RUN_JSON" "$INIT_AGENT" "$INIT_SESSION" <<'PY'


### PR DESCRIPTION
## Summary

Closes #241. `bridge-watchdog.py::classify_status` was classifying every agent with `Onboarding State: pending` as `warn` regardless of `session_type`. That's a permanent false positive for agents whose session type is non-interactive by design (`dynamic`, `cron`) — they never get a human onboarding flow, so `SESSION-TYPE.md` stays `pending` forever. The daemon then filed a recurring `[watchdog] agent profile drift` task for `patch` on every sweep.

## Fix

- New `NON_ONBOARDING_SESSION_TYPES = {"dynamic", "cron"}`.
- `classify_status` accepts `session_type` and ANDs the onboarding-state check with `session_type not in NON_ONBOARDING_SESSION_TYPES`.
- `scan_agent` passes `session_type` through.
- Every other classification (missing_files → error, broken_links / missing_block → warn) is unchanged, so dynamic agents with real drift still trip.
- Regular agents keep the original pending → warn behaviour.

## Smoke regression

Added inline python block right after the existing `watchdog scan` assertion. Asserts:

- `classify_status([], [], "pending", False, "dynamic") == "ok"` (the #241 fix)
- `classify_status([], [], "missing", False, "dynamic") == "ok"`
- `classify_status([], [], "pending", False, "cron") == "ok"`
- `classify_status([], ["bad-link"], "complete", False, "dynamic") == "warn"` (other checks still fire)
- `classify_status([], [], "complete", True, "dynamic") == "warn"`
- `classify_status(["CLAUDE.md"], [], "complete", False, "dynamic") == "error"`
- `classify_status([], [], "pending", False, "admin") == "warn"` (regression guard)
- `classify_status([], [], "missing", False, "router") == "warn"`
- `classify_status([], [], "complete", False, "admin") == "ok"`

## Test plan

- [x] `python3 -m py_compile bridge-watchdog.py`
- [x] `bash -n scripts/smoke-test.sh`
- [x] `shellcheck scripts/smoke-test.sh`
- [x] Inline unit test passes.
- [ ] Full smoke — pre-existing failures addressed separately by PR #239.
- [ ] Live: on the reporting install, run `agent-bridge watchdog scan --json` after upgrade; `librarian` (dynamic) should now report `status: "ok"` with `problem_count: 0`.

## Closes

#241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
