### PR TITLE
runtime: restore bridge_build_safe_launch_cmd lost in 7bf4e7d (unblocks #239/#247 CI)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -60,6 +60,51 @@ bridge_claude_dynamic_launch_cmd() {
   bridge_join_quoted "${argv[@]}"
 }
 
+bridge_build_safe_launch_cmd() {
+  # Safe-mode launch helper shared between `bridge-run.sh --safe-mode`
+  # and the post-232 CI smoke fixture. Introduced in 15ed07b
+  # (`runtime: add safe-mode recovery and crash-loop breaker`) and
+  # silently dropped in 7bf4e7d (the same lib trim that lost the
+  # next-session helpers restored in #229). Both call sites have been
+  # referencing it ever since, so `bridge-run.sh --safe-mode` and
+  # `smoke-test.sh` hit `command not found` on any host that resolved
+  # the path. Restore the original body verbatim.
+  local agent="$1"
+  local engine=""
+  local continue_mode=""
+  local session_id=""
+
+  engine="$(bridge_agent_engine "$agent")"
+  continue_mode="$(bridge_agent_continue "$agent")"
+
+  case "$engine" in
+    codex)
+      bridge_normalize_agent_session_id "$agent"
+      session_id="$(bridge_agent_session_id "$agent")"
+      if [[ "$continue_mode" == "1" && -n "$session_id" ]]; then
+        bridge_join_quoted codex resume "$session_id" -c "features.codex_hooks=true" --dangerously-bypass-approvals-and-sandbox --no-alt-screen
+      else
+        bridge_join_quoted codex -c "features.codex_hooks=true" --dangerously-bypass-approvals-and-sandbox --no-alt-screen
+      fi
+      ;;
+    claude)
+      if [[ "$continue_mode" == "1" ]]; then
+        session_id="$(bridge_claude_resume_session_id_for_agent "$agent" || true)"
+        if [[ -n "$session_id" ]]; then
+          bridge_join_quoted claude --resume "$session_id" --dangerously-skip-permissions --name "$agent"
+        else
+          bridge_join_quoted claude --continue --dangerously-skip-permissions --name "$agent"
+        fi
+      else
+        bridge_join_quoted claude --dangerously-skip-permissions --name "$agent"
+      fi
+      ;;
+    *)
+      bridge_die "safe-mode launch is only supported for claude/codex agents: $agent"
+      ;;
+  esac
+}
+
 bridge_build_dynamic_launch_cmd() {
   local agent="$1"
   local engine continue_mode session_id continue_fallback effective_continue


### PR DESCRIPTION
## Summary

Restores `bridge_build_safe_launch_cmd` to `lib/bridge-state.sh`. The function was introduced in commit 15ed07b (`runtime: add safe-mode recovery and crash-loop breaker`) and silently dropped in commit 7bf4e7d — the same "lib trim" that lost the next-session expiry helpers which PR #229 already restored.

Two live call sites have been broken ever since:

- `bridge-run.sh:100` and `bridge-run.sh:431` — the `--safe-mode` launch path.
- `scripts/smoke-test.sh:3878` and `:3911` — the post-232 smoke fixture that exercises that path and is the current red CI blocker for PR #239.

Every invocation of either path fails with `bridge_build_safe_launch_cmd: command not found`. Codex round-1 on PR #239 called this out as the next domino to fall; it's a clean upstream fix rather than a per-PR patch, so doing it here keeps `fix/718-smoke-ci-followup` focused on its intended scope and lets the related PR #247 (watchdog dynamic onboarding) rebase to green at the same time.

## Body of the restored function

Lifted verbatim from 15ed07b — not rewritten. All helpers it depends on (`bridge_agent_engine`, `bridge_agent_continue`, `bridge_normalize_agent_session_id`, `bridge_claude_resume_session_id_for_agent`, `bridge_join_quoted`, `bridge_die`) already live in `lib/bridge-state.sh` and `lib/bridge-agents.sh`, so no follow-up restoration is needed.

Handles:
- `codex` + `continue_mode=1` + non-empty `session_id` → `codex resume …`
- `codex` fresh → `codex -c features.codex_hooks=true …`
- `claude` + `continue_mode=1` + resumable session → `claude --resume …`
- `claude` + `continue_mode=1` without resumable session → `claude --continue …`
- `claude` fresh → `claude --dangerously-skip-permissions --name …`
- anything else → `bridge_die "safe-mode launch is only supported for claude/codex agents"`

## Test plan

- [x] `bash -n lib/bridge-state.sh` clean.
- [x] `shellcheck lib/bridge-state.sh` clean.
- [x] `source bridge-lib.sh && declare -F bridge_build_safe_launch_cmd` → resolves.
- [ ] Full smoke — the two relevant assertions (`scripts/smoke-test.sh:3878` and `:3911`) pass in a scratch `BRIDGE_HOME` run. PR #239 rebased onto this merge commit will pick it up.
- [ ] Live: operator confirms `agent-bridge agent safe-mode <claude-agent> --dry-run` prints a valid claude launch cmd instead of failing.

## Closes / unblocks

- Unblocks PR #239 (`smoke: stabilize post-232 CI follow-ups`) and PR #247 (`watchdog dynamic/cron onboarding bypass`). Both are red on the same shared smoke baseline that depends on this symbol being present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
