### PR TITLE
bootstrap: fix bash 3.2 abort + hyphen agent id regression (task #886)

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -469,17 +469,21 @@ step_cron_one() {
 # Bootstrap cannot source bridge-lib safely without pulling in the roster, so we
 # approximate: the default is ON (matching the bash helper). An install that
 # disables the refresh sets BRIDGE_AGENT_MEMORY_DAILY_REFRESH_<agent>=0 in the
-# bootstrap env (agent id hyphens are normalised to underscores so the env name
-# is a valid bash identifier — e.g. agent `agb-dev-claude` → env key
-# `BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude`), or writes
+# bootstrap env (every char that isn't a bash identifier char is normalised to
+# `_` so the env name is valid — e.g. agent `agb-dev-claude` → env key
+# `BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude`, agent `foo.bar` →
+# `BRIDGE_AGENT_MEMORY_DAILY_REFRESH_foo_bar`), or writes
 # BRIDGE_AGENT_MEMORY_DAILY_REFRESH[<agent>]=0 into the roster (which the daemon
-# enforces at dispatch time regardless).
+# enforces at dispatch time regardless, using the raw agent id as the key).
 memory_daily_gate_on() {
   local agent="$1"
-  # Agent ids commonly contain hyphens (e.g. agb-dev-claude). Bash identifiers
-  # forbid hyphens, so indirect expansion via `${!key}` would abort with
-  # "invalid variable name". Normalise to underscores before building the key.
-  local safe_agent="${agent//-/_}"
+  # `bridge_validate_agent_name` accepts `[A-Za-z0-9._-]+`, but bash identifiers
+  # are restricted to `[A-Za-z_][A-Za-z0-9_]*`. Indirect expansion via `${!key}`
+  # aborts with "invalid variable name" on hyphens, dots, or anything else
+  # outside the identifier alphabet. Normalise *all* non-identifier chars to
+  # `_` before building the env key — not just hyphens — so every valid agent
+  # id is safely mappable.
+  local safe_agent="${agent//[!A-Za-z0-9_]/_}"
   local key="BRIDGE_AGENT_MEMORY_DAILY_REFRESH_${safe_agent}"
   local val
   val="${!key:-}"

--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -17,6 +17,21 @@
 # IMPORTANT: this script targets a *downstream* reference install. Never
 # commit to applying on production without review.
 
+# Re-exec under bash 4+ if we got picked up by macOS's default /bin/bash (3.2),
+# which lacks associative arrays. Mirrors the guard in bridge-lib.sh so this
+# script stays runnable standalone without sourcing the bridge library.
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for bridge_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+    [[ -n "$bridge_candidate_bash" && -x "$bridge_candidate_bash" ]] || continue
+    if "$bridge_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$bridge_candidate_bash" "$0" "$@"
+    fi
+  done
+
+  echo "[bootstrap-memory] Agent Bridge requires Bash 4+ (current: ${BASH_VERSION:-unknown}). Install homebrew bash or set PATH accordingly." >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # -----------------------------------------------------------------------------
@@ -454,11 +469,18 @@ step_cron_one() {
 # Bootstrap cannot source bridge-lib safely without pulling in the roster, so we
 # approximate: the default is ON (matching the bash helper). An install that
 # disables the refresh sets BRIDGE_AGENT_MEMORY_DAILY_REFRESH_<agent>=0 in the
-# bootstrap env, or writes BRIDGE_AGENT_MEMORY_DAILY_REFRESH[<agent>]=0 into the
-# roster (which the daemon enforces at dispatch time regardless).
+# bootstrap env (agent id hyphens are normalised to underscores so the env name
+# is a valid bash identifier — e.g. agent `agb-dev-claude` → env key
+# `BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude`), or writes
+# BRIDGE_AGENT_MEMORY_DAILY_REFRESH[<agent>]=0 into the roster (which the daemon
+# enforces at dispatch time regardless).
 memory_daily_gate_on() {
   local agent="$1"
-  local key="BRIDGE_AGENT_MEMORY_DAILY_REFRESH_${agent}"
+  # Agent ids commonly contain hyphens (e.g. agb-dev-claude). Bash identifiers
+  # forbid hyphens, so indirect expansion via `${!key}` would abort with
+  # "invalid variable name". Normalise to underscores before building the key.
+  local safe_agent="${agent//-/_}"
+  local key="BRIDGE_AGENT_MEMORY_DAILY_REFRESH_${safe_agent}"
   local val
   val="${!key:-}"
   val="${val,,}"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1346,6 +1346,26 @@ ROSTER_POLICY_OVERLAY="$CHANNEL_POLICY_ROSTER_HOME/agents/admin_from_roster/.cla
 [[ -f "$ROSTER_POLICY_OVERLAY" ]] || die "apply-channel-policy.sh did not pick admin id up from the roster"
 assert_contains "$(cat "$ROSTER_POLICY_OVERLAY")" "\"telegram@claude-plugins-official\": true"
 
+log "bootstrap-memory-system.sh memory_daily_gate_on handles hyphenated agent ids (task #886 regression)"
+GATE_FN="$(awk '/^memory_daily_gate_on\(\) \{$/,/^\}$/' "$REPO_ROOT/bootstrap-memory-system.sh")"
+[[ -n "$GATE_FN" ]] || die "could not extract memory_daily_gate_on from bootstrap-memory-system.sh"
+# Default must be ON for a hyphenated agent id (no env override) — exit 0.
+if ! env -u BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude \
+       "$BASH4_BIN" -c "$GATE_FN"$'\n''memory_daily_gate_on agb-dev-claude'; then
+  die "memory_daily_gate_on defaulted off for hyphenated agent id (should be on)"
+fi
+# Explicit off via the underscore-normalised env key — exit 1.
+if BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude=0 \
+     "$BASH4_BIN" -c "$GATE_FN"$'\n''memory_daily_gate_on agb-dev-claude'; then
+  die "BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude=0 did not gate off hyphenated agent"
+fi
+# Regression guard: stderr must not mention the pre-fix "invalid variable name"
+# abort (English or Korean locale) for a hyphenated agent.
+GATE_ERR="$(env -u BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude \
+              "$BASH4_BIN" -c "$GATE_FN"$'\n''memory_daily_gate_on agb-dev-claude' 2>&1 >/dev/null || true)"
+assert_not_contains "$GATE_ERR" "invalid variable name"
+assert_not_contains "$GATE_ERR" "부적절한 변수 이름"
+
 log "starting isolated daemon"
 bash "$REPO_ROOT/bridge-daemon.sh" ensure >/dev/null
 DAEMON_STATUS=""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1365,6 +1365,20 @@ GATE_ERR="$(env -u BRIDGE_AGENT_MEMORY_DAILY_REFRESH_agb_dev_claude \
               "$BASH4_BIN" -c "$GATE_FN"$'\n''memory_daily_gate_on agb-dev-claude' 2>&1 >/dev/null || true)"
 assert_not_contains "$GATE_ERR" "invalid variable name"
 assert_not_contains "$GATE_ERR" "부적절한 변수 이름"
+# Dot-named agent ids are also valid per `bridge_validate_agent_name` and must
+# take the same underscore-normalised path (task #886 round-2).
+if ! env -u BRIDGE_AGENT_MEMORY_DAILY_REFRESH_foo_bar \
+       "$BASH4_BIN" -c "$GATE_FN"$'\n''memory_daily_gate_on foo.bar'; then
+  die "memory_daily_gate_on defaulted off for dotted agent id (should be on)"
+fi
+if BRIDGE_AGENT_MEMORY_DAILY_REFRESH_foo_bar=0 \
+     "$BASH4_BIN" -c "$GATE_FN"$'\n''memory_daily_gate_on foo.bar'; then
+  die "BRIDGE_AGENT_MEMORY_DAILY_REFRESH_foo_bar=0 did not gate off dotted agent"
+fi
+GATE_ERR_DOT="$(env -u BRIDGE_AGENT_MEMORY_DAILY_REFRESH_foo_bar \
+                  "$BASH4_BIN" -c "$GATE_FN"$'\n''memory_daily_gate_on foo.bar' 2>&1 >/dev/null || true)"
+assert_not_contains "$GATE_ERR_DOT" "invalid variable name"
+assert_not_contains "$GATE_ERR_DOT" "부적절한 변수 이름"
 
 log "starting isolated daemon"
 bash "$REPO_ROOT/bridge-daemon.sh" ensure >/dev/null


### PR DESCRIPTION
## Summary

Two regressions in v0.6.10's `bootstrap-memory-system.sh` block post-upgrade bootstrap on standard macOS installs whose active agents have hyphenated ids. Reported by `patch` as urgent task #886.

- **Bug #1** — `declare -A MEMORY_DAILY_EXISTING_JSON` aborts under macOS's stock `/bin/bash` (3.2). The script now re-execs under a bash 4+ candidate if the running interpreter is older. Mirrors the guard already in `bridge-lib.sh`.
- **Bug #2** — `memory_daily_gate_on` built `BRIDGE_AGENT_MEMORY_DAILY_REFRESH_<agent>` as an env key and dereferenced it via `${!key}`. Agent ids routinely contain hyphens (`agb-dev-claude`, `crm-dev`, …) which are not valid bash identifiers, so indirect expansion aborted with "invalid variable name" on the first hyphenated agent. The key now normalises hyphens to underscores before lookup; operators setting the override must use the same convention (documented inline).

Impact: v0.6.10 installs with hyphenated agent ids fail `bootstrap-memory-system.sh --apply`, leaving `memory-daily-<agent>` cron from #216 un-registered.

## Test plan

- [x] `bash -n` + `shellcheck` on touched files — clean.
- [x] `/bin/bash bootstrap-memory-system.sh --help` on arm64 mac (bash 3.2 stock) → guard re-execs under `/opt/homebrew/bin/bash`, help prints, rc=0, no `declare`/`invalid variable name` errors.
- [x] New smoke block extracts the gate function and asserts: default-ON for a hyphenated agent id; explicit OFF via the underscore-normalised env key; stderr has no `invalid variable name` abort (English + Korean locale). Uses `$BASH4_BIN` so the assertion runs under bash 4+ even when `bash` on PATH is 3.2.
- [x] Full `scripts/smoke-test.sh` under isolated `BRIDGE_HOME` — new block passes; the unrelated `audit log …"actor": "queue"` failure later in the run is the same baseline red PR #239 is addressing and is not introduced by this diff.
- [ ] Downstream `agb upgrade` + `bootstrap-memory-system.sh --apply` drift=0 on the impacted install — patch's verify loop (task #886) will handle this after merge.

Closes task #886 (urgent). Needs a v0.6.11 hotfix release since the failure mode blocks #216 on already-upgraded hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)