### PR TITLE
channels: per-agent re-enable for singleton plugins declared in BRIDGE_AGENT_CHANNELS (closes #254)

### DIFF
--- a/scripts/apply-channel-policy.sh
+++ b/scripts/apply-channel-policy.sh
@@ -27,6 +27,23 @@
 #
 # This script is idempotent. It is safe to re-run on every upgrade.
 
+# Re-exec under bash 4+ if we got picked up by macOS's default /bin/bash (3.2),
+# which lacks `${val,,}`-style bash-4 parameter expansions used downstream and
+# chokes `bash -n` on the embedded Python heredoc bodies. Mirrors the guard in
+# bridge-lib.sh so the script stays runnable standalone from an operator shell
+# that isn't loading the bridge library (e.g. post-upgrade bootstrap of #254).
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for bridge_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+    [[ -n "$bridge_candidate_bash" && -x "$bridge_candidate_bash" ]] || continue
+    if "$bridge_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$bridge_candidate_bash" "$0" "$@"
+    fi
+  done
+
+  echo "[apply-channel-policy] Agent Bridge requires Bash 4+ (current: ${BASH_VERSION:-unknown}). Install homebrew bash or set PATH accordingly." >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
@@ -185,10 +202,16 @@ admin_agent_id=""
 if [[ -n "${BRIDGE_ADMIN_AGENT_ID:-}" ]]; then
   admin_agent_id="$BRIDGE_ADMIN_AGENT_ID"
 else
+  # `BRIDGE_ADMIN_AGENT_ID` is optional in the roster (agent-roster.local.example.sh
+  # leaves the line commented out), so the grep below must not abort the script
+  # when no admin line exists. Without `|| true` the pipeline exits 1 under
+  # `set -euo pipefail` and every downstream step — including the non-admin
+  # per-agent re-enable — is skipped, which is exactly the #254 symptom we are
+  # supposed to prevent.
   for _admin_roster in "$BRIDGE_HOME/agent-roster.local.sh" "$BRIDGE_HOME/agent-roster.sh"; do
     if [[ -r "$_admin_roster" ]]; then
-      _admin_line="$(grep -E '^[[:space:]]*(export[[:space:]]+)?BRIDGE_ADMIN_AGENT_ID=' "$_admin_roster" 2>/dev/null | head -n 1 | sed -E 's/^[[:space:]]*(export[[:space:]]+)?BRIDGE_ADMIN_AGENT_ID=//; s/^"([^"]*)".*/\1/; s/^'"'"'([^'"'"']*)'"'"'.*/\1/; s/[[:space:]]*#.*$//')"
-      if [[ -n "$_admin_line" ]]; then
+      _admin_line="$(grep -E '^[[:space:]]*(export[[:space:]]+)?BRIDGE_ADMIN_AGENT_ID=' "$_admin_roster" 2>/dev/null | head -n 1 | sed -E 's/^[[:space:]]*(export[[:space:]]+)?BRIDGE_ADMIN_AGENT_ID=//; s/^"([^"]*)".*/\1/; s/^'"'"'([^'"'"']*)'"'"'.*/\1/; s/[[:space:]]*#.*$//' || true)"
+      if [[ -n "${_admin_line:-}" ]]; then
         admin_agent_id="$_admin_line"
         break
       fi
@@ -306,8 +329,13 @@ roster_files = argv[2 + singleton_count :]
 # With either single or double quotes around the value. We keep this
 # tolerant because the roster file is hand-edited and may grow extra
 # whitespace or `export` prefixes.
+# Agent id charset matches bridge_validate_agent_name (lib/bridge-core.sh):
+# `[A-Za-z0-9._-]+` — includes dots so dotted agent ids like `foo.bar` are
+# parsed here. The earlier pattern dropped dots, leaving a valid singleton
+# owner in the exact silent-disable state this PR is meant to fix (see PR
+# #255 round-1 review, finding #1).
 channels_line = re.compile(
-    r'^\s*(?:export\s+)?BRIDGE_AGENT_CHANNELS\[\s*["\']?([A-Za-z0-9_\-]+)["\']?\s*\]\s*='
+    r'^\s*(?:export\s+)?BRIDGE_AGENT_CHANNELS\[\s*["\']?([A-Za-z0-9._\-]+)["\']?\s*\]\s*='
     r'\s*["\']([^"\']*)["\']\s*(?:#.*)?$'
 )
 
@@ -324,11 +352,11 @@ for path_str in roster_files:
             continue
         agent = match.group(1)
         value = match.group(2)
-        # Later roster overrides earlier (agent-roster.local.sh wins over
-        # tracked agent-roster.sh — last-read wins because we feed roster
-        # files in local-first order at the bash layer, but to be safe
-        # compute it explicitly: only overwrite if not already set by a
-        # higher-priority file).
+        # First-read wins. The bash layer feeds roster files in local-first
+        # priority order (`agent-roster.local.sh` before `agent-roster.sh`
+        # before the source-root fallbacks), so honouring the first entry we
+        # see is how local overrides the tracked roster. Do not flip this to
+        # last-read-wins without also reversing the file order above.
         if agent not in agent_channels:
             agent_channels[agent] = value
 

--- a/scripts/apply-channel-policy.sh
+++ b/scripts/apply-channel-policy.sh
@@ -154,11 +154,33 @@ if [[ $DRY_RUN -eq 0 ]]; then
   fi
 fi
 
-# Admin bypass: re-enable singleton plugins in the admin's per-agent local
-# overlay. We resolve admin id only from an explicit signal (env or roster
-# grep) — we never fall back to a default, because this bypass must be a
-# no-op on installs that have not configured an admin yet (e.g. smoke
-# fixtures, pre-bootstrap hosts).
+# -- Per-agent re-enable bypass --
+#
+# The shared overlay above disables the singleton plugins for every agent whose
+# `.claude/settings.json` resolves to `settings.effective.json`. That is safe as
+# long as every singleton plugin is owned by the admin. On installs where the
+# roster distributes channel ownership via `BRIDGE_AGENT_CHANNELS["<agent>"]="plugin:..."`
+# (one persona per channel), the blanket disable breaks exactly the non-admin
+# agent that is supposed to hold that channel — claude silently exits during
+# plugin resolution. See #254.
+#
+# Fix: for every agent (admin or non-admin) that declares ownership of a
+# singleton plugin, write a per-agent `.claude/settings.local.json` that
+# re-enables the owned plugin(s). Claude Code's settings merge prefers the
+# project `.claude/settings.local.json` over the project `.claude/settings.json`
+# symlink, so the override re-enables only for that owner.
+#
+# Multi-owner case (two or more agents declare the same singleton plugin) is
+# flagged with a warning: the upstream bot API still enforces one-connection-
+# per-token, so whichever agent restarts last grabs the lease. Writing the
+# re-enable for both agents does not make the conflict worse — it just means
+# the current behaviour (most recent restart wins) surfaces rather than the
+# silent-exit mode.
+#
+# Admin id is still resolved first because (a) the admin is always a valid
+# owner of every singleton plugin by convention and (b) the per-agent loop
+# below skips an agent whose id matches `admin_agent_id` so the admin bypass
+# block that follows does not double-write.
 admin_agent_id=""
 if [[ -n "${BRIDGE_ADMIN_AGENT_ID:-}" ]]; then
   admin_agent_id="$BRIDGE_ADMIN_AGENT_ID"
@@ -238,4 +260,188 @@ p.write_text(json.dumps(plan["payload"], indent=2, sort_keys=True) + "\n")
       [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] admin overlay for '$admin_agent_id' already re-enables singleton policy (no change)"
     fi
   fi
+fi
+
+# -- Non-admin per-agent re-enable (closes #254) --
+#
+# Walk the roster and, for each non-admin agent that declares ownership of a
+# singleton plugin via `BRIDGE_AGENT_CHANNELS["<agent>"]="plugin:..."`, write
+# a per-agent `.claude/settings.local.json` that selectively re-enables only
+# the plugins that agent actually owns. Agents that declare no singleton
+# plugin inherit the shared disable and remain quiet polling-wise.
+#
+# Python does the roster read because bash assoc-array handling across
+# sourced files is fragile and we want to stay compatible with installs that
+# do not have `bridge-lib.sh` reachable from BRIDGE_HOME (smoke fixtures).
+
+roster_files=()
+for _candidate in \
+  "$BRIDGE_HOME/agent-roster.local.sh" \
+  "$BRIDGE_HOME/agent-roster.sh" \
+  "$SCRIPT_DIR/../agent-roster.local.sh" \
+  "$SCRIPT_DIR/../agent-roster.sh"; do
+  if [[ -r "$_candidate" ]]; then
+    roster_files+=("$_candidate")
+  fi
+done
+
+if (( ${#roster_files[@]} == 0 )); then
+  [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] no roster file found; non-admin per-agent bypass skipped"
+else
+  owner_json="$("$BRIDGE_PYTHON" - "$admin_agent_id" "${#SINGLETON_PLUGINS[@]}" "${SINGLETON_PLUGINS[@]}" "${roster_files[@]}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+argv = sys.argv[1:]
+admin_id = argv[0]
+singleton_count = int(argv[1])
+singleton_plugins = argv[2 : 2 + singleton_count]
+roster_files = argv[2 + singleton_count :]
+
+# Regex picks up lines of the form:
+#   BRIDGE_AGENT_CHANNELS["agent"]="plugin:x@y,plugin:z@w"
+#   BRIDGE_AGENT_CHANNELS[agent]='plugin:x@y'
+# With either single or double quotes around the value. We keep this
+# tolerant because the roster file is hand-edited and may grow extra
+# whitespace or `export` prefixes.
+channels_line = re.compile(
+    r'^\s*(?:export\s+)?BRIDGE_AGENT_CHANNELS\[\s*["\']?([A-Za-z0-9_\-]+)["\']?\s*\]\s*='
+    r'\s*["\']([^"\']*)["\']\s*(?:#.*)?$'
+)
+
+agent_channels: dict[str, str] = {}
+for path_str in roster_files:
+    path = Path(path_str)
+    try:
+        text = path.read_text(errors="replace")
+    except OSError:
+        continue
+    for raw in text.splitlines():
+        match = channels_line.match(raw)
+        if not match:
+            continue
+        agent = match.group(1)
+        value = match.group(2)
+        # Later roster overrides earlier (agent-roster.local.sh wins over
+        # tracked agent-roster.sh — last-read wins because we feed roster
+        # files in local-first order at the bash layer, but to be safe
+        # compute it explicitly: only overwrite if not already set by a
+        # higher-priority file).
+        if agent not in agent_channels:
+            agent_channels[agent] = value
+
+# Build owner map: singleton_plugin_id -> [agent_ids that declare it]
+owners: dict[str, list[str]] = {pid: [] for pid in singleton_plugins}
+for agent, channels in agent_channels.items():
+    if agent == admin_id:
+        # Admin is handled by the admin bypass above; skip here.
+        continue
+    tokens = [tok.strip() for tok in channels.split(",") if tok.strip()]
+    for tok in tokens:
+        # Tokens may be "plugin:telegram@claude-plugins-official" or raw ids.
+        plugin_id = tok[len("plugin:") :] if tok.startswith("plugin:") else tok
+        if plugin_id in owners:
+            owners[plugin_id].append(agent)
+
+# Invert: agent_id -> [plugin_ids to re-enable for that agent]
+agent_enables: dict[str, list[str]] = {}
+multi_owner_warnings: list[str] = []
+for plugin_id, declared_by in owners.items():
+    if len(declared_by) >= 2:
+        multi_owner_warnings.append(
+            f"[apply-channel-policy] WARNING: '{plugin_id}' declared by multiple "
+            f"agents ({', '.join(declared_by)}); upstream bot API enforces "
+            "one-connection-per-token so only the most recently restarted "
+            "agent will hold the lease at runtime. Re-enable will be written "
+            "for each owner, but the conflict will still surface."
+        )
+    for agent in declared_by:
+        agent_enables.setdefault(agent, []).append(plugin_id)
+
+print(
+    json.dumps(
+        {
+            "agent_enables": agent_enables,
+            "warnings": multi_owner_warnings,
+        }
+    )
+)
+PY
+)"
+
+  # Emit multi-owner warnings line-by-line to stderr. Use `while read` with
+  # explicit IFS so embedded spaces inside each warning survive intact.
+  "$BRIDGE_PYTHON" -c 'import json,sys; [print(w) for w in json.loads(sys.stdin.read())["warnings"]]' <<<"$owner_json" \
+    | while IFS= read -r _warn; do
+        [[ -n "$_warn" ]] && printf '%s\n' "$_warn" >&2
+      done
+
+  # Iterate owners: agent_id, plugins-it-owns. One call per owner to reuse the
+  # same per-agent write logic used for the admin bypass.
+  "$BRIDGE_PYTHON" -c 'import json,sys; [print(a+"\t"+",".join(p)) for a,p in json.loads(sys.stdin.read())["agent_enables"].items()]' <<<"$owner_json" | \
+  while IFS=$'\t' read -r owner_id owner_plugins_csv; do
+    [[ -z "$owner_id" ]] && continue
+    IFS=',' read -r -a owner_plugins <<<"$owner_plugins_csv"
+    OWNER_HOME="$BRIDGE_AGENT_HOME_ROOT/$owner_id"
+    OWNER_LOCAL="$OWNER_HOME/.claude/settings.local.json"
+    if [[ ! -d "$OWNER_HOME" ]]; then
+      [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] skip owner re-enable: '$owner_id' home not present under $BRIDGE_AGENT_HOME_ROOT"
+      continue
+    fi
+
+    owner_plan="$("$BRIDGE_PYTHON" - "$OWNER_LOCAL" "${owner_plugins[@]}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+overlay_path = Path(sys.argv[1])
+plugins_to_enable = sys.argv[2:]
+
+if overlay_path.exists():
+    try:
+        payload = json.loads(overlay_path.read_text() or "{}")
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"owner overlay is not valid JSON: {overlay_path}: {exc}")
+else:
+    payload = {}
+
+if not isinstance(payload, dict):
+    raise SystemExit(f"owner overlay root must be a JSON object: {overlay_path}")
+
+enabled = payload.get("enabledPlugins")
+if not isinstance(enabled, dict):
+    enabled = {}
+
+changed = False
+for plugin_id in plugins_to_enable:
+    if enabled.get(plugin_id) is not True:
+        enabled[plugin_id] = True
+        changed = True
+
+payload["enabledPlugins"] = enabled
+print(json.dumps({"changed": changed, "payload": payload}))
+PY
+)"
+
+    owner_changed="$(printf '%s' "$owner_plan" | "$BRIDGE_PYTHON" -c 'import json,sys;print(json.loads(sys.stdin.read())["changed"])')"
+
+    if [[ "$owner_changed" == "True" ]]; then
+      if [[ $DRY_RUN -eq 1 ]]; then
+        [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] would write $OWNER_LOCAL (re-enable for owner '$owner_id': ${owner_plugins[*]})"
+      else
+        printf '%s' "$owner_plan" | "$BRIDGE_PYTHON" -c '
+import json,sys,pathlib
+plan=json.loads(sys.stdin.read())
+p=pathlib.Path(sys.argv[1])
+p.parent.mkdir(parents=True, exist_ok=True)
+p.write_text(json.dumps(plan["payload"], indent=2, sort_keys=True) + "\n")
+' "$OWNER_LOCAL"
+        [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] wrote $OWNER_LOCAL (owner re-enable: ${owner_plugins[*]})"
+      fi
+    else
+      [[ $QUIET -eq 1 ]] || echo "[apply-channel-policy] owner overlay for '$owner_id' already re-enables singleton policy (no change)"
+    fi
+  done
 fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1346,6 +1346,79 @@ ROSTER_POLICY_OVERLAY="$CHANNEL_POLICY_ROSTER_HOME/agents/admin_from_roster/.cla
 [[ -f "$ROSTER_POLICY_OVERLAY" ]] || die "apply-channel-policy.sh did not pick admin id up from the roster"
 assert_contains "$(cat "$ROSTER_POLICY_OVERLAY")" "\"telegram@claude-plugins-official\": true"
 
+log "apply-channel-policy.sh selectively re-enables per-agent singleton channels (closes #254)"
+CHANNEL_POLICY_OWNER_HOME="$TMP_ROOT/channel-policy-owner-home"
+mkdir -p \
+  "$CHANNEL_POLICY_OWNER_HOME/agents/.claude" \
+  "$CHANNEL_POLICY_OWNER_HOME/agents/admin_owner/.claude" \
+  "$CHANNEL_POLICY_OWNER_HOME/agents/dev_discord/.claude" \
+  "$CHANNEL_POLICY_OWNER_HOME/agents/dev_telegram/.claude" \
+  "$CHANNEL_POLICY_OWNER_HOME/agents/sales_teams_only/.claude"
+printf '{}' > "$CHANNEL_POLICY_OWNER_HOME/agents/.claude/settings.json"
+cat > "$CHANNEL_POLICY_OWNER_HOME/agent-roster.local.sh" <<'ROSTER'
+BRIDGE_ADMIN_AGENT_ID="admin_owner"
+BRIDGE_AGENT_CHANNELS["dev_discord"]="plugin:discord@claude-plugins-official"
+BRIDGE_AGENT_CHANNELS["dev_telegram"]="plugin:teams@agent-bridge,plugin:telegram@claude-plugins-official"
+BRIDGE_AGENT_CHANNELS["sales_teams_only"]="plugin:teams@agent-bridge"
+ROSTER
+env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID \
+  BRIDGE_HOME="$CHANNEL_POLICY_OWNER_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+# Owner of discord gets discord re-enable only (not telegram).
+OWNER_DISCORD_OVERLAY="$CHANNEL_POLICY_OWNER_HOME/agents/dev_discord/.claude/settings.local.json"
+[[ -f "$OWNER_DISCORD_OVERLAY" ]] || die "apply-channel-policy.sh did not write overlay for discord-owning agent"
+assert_contains "$(cat "$OWNER_DISCORD_OVERLAY")" "\"discord@claude-plugins-official\": true"
+assert_not_contains "$(cat "$OWNER_DISCORD_OVERLAY")" "\"telegram@claude-plugins-official\""
+# Owner of telegram gets telegram re-enable only (teams is not in the singleton set).
+OWNER_TELEGRAM_OVERLAY="$CHANNEL_POLICY_OWNER_HOME/agents/dev_telegram/.claude/settings.local.json"
+[[ -f "$OWNER_TELEGRAM_OVERLAY" ]] || die "apply-channel-policy.sh did not write overlay for telegram-owning agent"
+assert_contains "$(cat "$OWNER_TELEGRAM_OVERLAY")" "\"telegram@claude-plugins-official\": true"
+assert_not_contains "$(cat "$OWNER_TELEGRAM_OVERLAY")" "\"discord@claude-plugins-official\""
+# Agent that owns only a non-singleton plugin (teams) gets no overlay at all —
+# the shared disable does not affect it, and we must not materialise an empty
+# enabledPlugins dict on its behalf.
+[[ ! -e "$CHANNEL_POLICY_OWNER_HOME/agents/sales_teams_only/.claude/settings.local.json" ]] \
+  || die "apply-channel-policy.sh wrote overlay for agent that owns no singleton plugin"
+# Admin still re-enables everything.
+OWNER_ADMIN_OVERLAY="$CHANNEL_POLICY_OWNER_HOME/agents/admin_owner/.claude/settings.local.json"
+[[ -f "$OWNER_ADMIN_OVERLAY" ]] || die "apply-channel-policy.sh did not write admin bypass overlay under roster-aware mode"
+assert_contains "$(cat "$OWNER_ADMIN_OVERLAY")" "\"telegram@claude-plugins-official\": true"
+assert_contains "$(cat "$OWNER_ADMIN_OVERLAY")" "\"discord@claude-plugins-official\": true"
+# Idempotency.
+OWNER_DISCORD_FIRST="$(cat "$OWNER_DISCORD_OVERLAY")"
+OWNER_TELEGRAM_FIRST="$(cat "$OWNER_TELEGRAM_OVERLAY")"
+env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID \
+  BRIDGE_HOME="$CHANNEL_POLICY_OWNER_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+[[ "$(cat "$OWNER_DISCORD_OVERLAY")" == "$OWNER_DISCORD_FIRST" ]] \
+  || die "apply-channel-policy.sh per-agent discord overlay was not idempotent"
+[[ "$(cat "$OWNER_TELEGRAM_OVERLAY")" == "$OWNER_TELEGRAM_FIRST" ]] \
+  || die "apply-channel-policy.sh per-agent telegram overlay was not idempotent"
+
+log "apply-channel-policy.sh emits a multi-owner warning when 2+ agents claim the same singleton channel (#254)"
+CHANNEL_POLICY_MULTI_HOME="$TMP_ROOT/channel-policy-multi-home"
+mkdir -p \
+  "$CHANNEL_POLICY_MULTI_HOME/agents/.claude" \
+  "$CHANNEL_POLICY_MULTI_HOME/agents/multi_admin/.claude" \
+  "$CHANNEL_POLICY_MULTI_HOME/agents/a1/.claude" \
+  "$CHANNEL_POLICY_MULTI_HOME/agents/a2/.claude"
+printf '{}' > "$CHANNEL_POLICY_MULTI_HOME/agents/.claude/settings.json"
+cat > "$CHANNEL_POLICY_MULTI_HOME/agent-roster.local.sh" <<'ROSTER'
+BRIDGE_ADMIN_AGENT_ID="multi_admin"
+BRIDGE_AGENT_CHANNELS["a1"]="plugin:telegram@claude-plugins-official"
+BRIDGE_AGENT_CHANNELS["a2"]="plugin:telegram@claude-plugins-official"
+ROSTER
+MULTI_OUTPUT="$(env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID \
+  BRIDGE_HOME="$CHANNEL_POLICY_MULTI_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" 2>&1)"
+assert_contains "$MULTI_OUTPUT" "WARNING: 'telegram@claude-plugins-official' declared by multiple agents"
+# Both owners still get the re-enable (so the runtime behaviour is "last restarter wins"
+# rather than "both silently fail to load the plugin").
+[[ -f "$CHANNEL_POLICY_MULTI_HOME/agents/a1/.claude/settings.local.json" ]] \
+  || die "multi-owner case did not write a1 overlay"
+[[ -f "$CHANNEL_POLICY_MULTI_HOME/agents/a2/.claude/settings.local.json" ]] \
+  || die "multi-owner case did not write a2 overlay"
+
 log "bootstrap-memory-system.sh memory_daily_gate_on handles hyphenated agent ids (task #886 regression)"
 GATE_FN="$(awk '/^memory_daily_gate_on\(\) \{$/,/^\}$/' "$REPO_ROOT/bootstrap-memory-system.sh")"
 [[ -n "$GATE_FN" ]] || die "could not extract memory_daily_gate_on from bootstrap-memory-system.sh"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1419,6 +1419,41 @@ assert_contains "$MULTI_OUTPUT" "WARNING: 'telegram@claude-plugins-official' dec
 [[ -f "$CHANNEL_POLICY_MULTI_HOME/agents/a2/.claude/settings.local.json" ]] \
   || die "multi-owner case did not write a2 overlay"
 
+log "apply-channel-policy.sh parses dotted agent ids in BRIDGE_AGENT_CHANNELS (#255 r1 finding 1)"
+CHANNEL_POLICY_DOT_HOME="$TMP_ROOT/channel-policy-dotted-home"
+mkdir -p \
+  "$CHANNEL_POLICY_DOT_HOME/agents/.claude" \
+  "$CHANNEL_POLICY_DOT_HOME/agents/dot_admin/.claude" \
+  "$CHANNEL_POLICY_DOT_HOME/agents/foo.bar/.claude"
+printf '{}' > "$CHANNEL_POLICY_DOT_HOME/agents/.claude/settings.json"
+cat > "$CHANNEL_POLICY_DOT_HOME/agent-roster.local.sh" <<'ROSTER'
+BRIDGE_ADMIN_AGENT_ID="dot_admin"
+BRIDGE_AGENT_CHANNELS["foo.bar"]="plugin:discord@claude-plugins-official"
+ROSTER
+env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID \
+  BRIDGE_HOME="$CHANNEL_POLICY_DOT_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null
+DOTTED_OVERLAY="$CHANNEL_POLICY_DOT_HOME/agents/foo.bar/.claude/settings.local.json"
+[[ -f "$DOTTED_OVERLAY" ]] || die "apply-channel-policy.sh did not write overlay for dotted agent id"
+assert_contains "$(cat "$DOTTED_OVERLAY")" "\"discord@claude-plugins-official\": true"
+
+log "apply-channel-policy.sh still runs when roster has no BRIDGE_ADMIN_AGENT_ID line (#255 r1 finding 2)"
+CHANNEL_POLICY_NOADMIN_HOME="$TMP_ROOT/channel-policy-noadmin-home"
+mkdir -p \
+  "$CHANNEL_POLICY_NOADMIN_HOME/agents/.claude" \
+  "$CHANNEL_POLICY_NOADMIN_HOME/agents/dev_discord/.claude"
+printf '{}' > "$CHANNEL_POLICY_NOADMIN_HOME/agents/.claude/settings.json"
+cat > "$CHANNEL_POLICY_NOADMIN_HOME/agent-roster.local.sh" <<'ROSTER'
+BRIDGE_AGENT_CHANNELS["dev_discord"]="plugin:discord@claude-plugins-official"
+ROSTER
+env -u BRIDGE_AGENT_HOME_ROOT -u BRIDGE_ADMIN_AGENT_ID \
+  BRIDGE_HOME="$CHANNEL_POLICY_NOADMIN_HOME" \
+  bash "$REPO_ROOT/scripts/apply-channel-policy.sh" >/dev/null \
+  || die "apply-channel-policy.sh aborted on admin-less roster"
+NOADMIN_OVERLAY="$CHANNEL_POLICY_NOADMIN_HOME/agents/dev_discord/.claude/settings.local.json"
+[[ -f "$NOADMIN_OVERLAY" ]] || die "apply-channel-policy.sh skipped non-admin owner when roster has no admin id"
+assert_contains "$(cat "$NOADMIN_OVERLAY")" "\"discord@claude-plugins-official\": true"
+
 log "bootstrap-memory-system.sh memory_daily_gate_on handles hyphenated agent ids (task #886 regression)"
 GATE_FN="$(awk '/^memory_daily_gate_on\(\) \{$/,/^\}$/' "$REPO_ROOT/bootstrap-memory-system.sh")"
 [[ -n "$GATE_FN" ]] || die "could not extract memory_daily_gate_on from bootstrap-memory-system.sh"


### PR DESCRIPTION
Closes #254.

## Problem

`scripts/apply-channel-policy.sh` (from #246, shipped in v0.6.11) blanket-disables `telegram@claude-plugins-official` and `discord@claude-plugins-official` for every agent that shares the effective settings via symlink. That is correct for installs where the admin owns every singleton channel. It breaks installs where the roster distributes channel ownership across personas via `BRIDGE_AGENT_CHANNELS["<agent>"]`: the disabled plugin is exactly the one the owning agent needs to load, and its claude process silently exits during plugin resolution.

Live repro on the reference host 2026-04-24:

```
BRIDGE_AGENT_CHANNELS["dev"]="plugin:discord@claude-plugins-official"
BRIDGE_AGENT_CHANNELS["dev_mun"]="plugin:teams@agent-bridge,plugin:telegram@claude-plugins-official"
```

After the #246 overlay was applied, both `dev` and `dev_mun` entered a 137-iteration daemon relaunch loop with empty stderr. Removing the overlay and starting with `--no-continue` immediately restored them. The three teams-only agents (`sales_sean`/`sales_choi`/`mgt_ahn`) were unaffected because teams is not in the singleton set.

The symptom was originally mis-filed as #253 ("silent crash-restart loop, 100+ retries, no stderr"). #253 has been closed and re-pointed here now that the root cause is clear: the #246 regression, not a generic upgrade-restart bug.

## Fix shape

Extend `scripts/apply-channel-policy.sh` with a roster-aware per-agent re-enable pass. Three invariants preserved from #246:

1. Shared overlay still disables every singleton plugin at `agents/.claude/settings.local.json`.
2. Admin bypass still writes `agents/<admin>/.claude/settings.local.json` with every singleton plugin re-enabled.
3. Idempotent, dry-run respecting, and tolerates a missing roster file (smoke fixtures) as a no-op.

New pass:

4. Walk the roster files (`$BRIDGE_HOME/agent-roster.local.sh`, `$BRIDGE_HOME/agent-roster.sh`, plus repo-local siblings) with a tolerant regex and extract `BRIDGE_AGENT_CHANNELS["<agent>"]="<comma-csv>"` entries.
5. Compute `owners = [agent for agent in non-admin if plugin_id in agent_channels[agent]]` for each singleton plugin.
6. For every non-admin owner, write `agents/<owner>/.claude/settings.local.json` that re-enables only the plugins that agent actually owns. Teams-only agents (no singleton ownership) get no overlay.
7. Multi-owner case (2+ agents declare the same singleton plugin) emits a loud stderr `WARNING: '<plugin>' declared by multiple agents (...)` — the upstream bot API still enforces one-connection-per-token, so runtime behaviour collapses to "last-restarter wins"; the re-enable is still written for each owner (silencing all but one would introduce a different class of silent failure).

The regex in step 4 is tolerant: it matches `BRIDGE_AGENT_CHANNELS["agent"]="..."`, `BRIDGE_AGENT_CHANNELS[agent]='...'`, and `export BRIDGE_AGENT_CHANNELS[...]=...` forms. Roster parsing happens in Python inside the script (no `bridge-lib.sh` source dependency), so the script stays self-contained and smoke-fixture-portable.

## Behaviour matrix

| roster state | outcome |
|--------------|---------|
| admin declared, no non-admin singleton owner | #246 behaviour unchanged: shared disable + admin re-enable. |
| admin + one non-admin owner per singleton plugin | Shared disable, admin re-enable, one per-agent overlay per non-admin owner — only the plugin(s) that owner declared. |
| admin + multiple non-admin owners of the same singleton plugin | Same as above, plus stderr WARNING. Every owner still gets their overlay so the upstream-service-level conflict surfaces rather than all polls silently failing. |
| no admin, no roster | No-op (existing safety). |
| agent declares only non-singleton plugins (teams, ms365) | No per-agent overlay written for that agent; inherits shared disable which is a no-op for its plugin set. |

## Test coverage

`scripts/smoke-test.sh` adds two new scenarios.

**Scenario A — selective re-enable (#254 happy path)**:

```
BRIDGE_ADMIN_AGENT_ID="admin_owner"
BRIDGE_AGENT_CHANNELS["dev_discord"]="plugin:discord@claude-plugins-official"
BRIDGE_AGENT_CHANNELS["dev_telegram"]="plugin:teams@agent-bridge,plugin:telegram@claude-plugins-official"
BRIDGE_AGENT_CHANNELS["sales_teams_only"]="plugin:teams@agent-bridge"
```

Asserts:
- `dev_discord/.claude/settings.local.json` enables discord, does not enable telegram.
- `dev_telegram/.claude/settings.local.json` enables telegram, does not enable discord.
- `sales_teams_only/.claude/settings.local.json` does **not** exist.
- `admin_owner/.claude/settings.local.json` enables both (admin bypass).
- Second run is byte-identical for all three per-agent overlays.

**Scenario B — multi-owner warning**:

```
BRIDGE_AGENT_CHANNELS["a1"]="plugin:telegram@claude-plugins-official"
BRIDGE_AGENT_CHANNELS["a2"]="plugin:telegram@claude-plugins-official"
```

Asserts stderr contains `WARNING: 'telegram@claude-plugins-official' declared by multiple agents`, and that both `a1` and `a2` still receive their overlay.

## Out of scope

- Automatic reconciliation of live agent sessions after the policy changes. Operators still need to restart affected agents for the new settings to take effect; no `agent-bridge agent restart <owner>` step is added here. A follow-up could add `agent-bridge diagnose channels` to detect drift, mirroring the `diagnose acl` precedent from #233 stage 3.
- Moving the singleton set (`telegram@claude-plugins-official`, `discord@claude-plugins-official`) into a roster-level constant or per-install knob. Hard-coded here to match existing precedent in the merged script.

## Reference

- #244 (original symptom — multi-agent poll-lock contention).
- #246 (this PR's parent; the regression this PR corrects).
- #253 (closed, original mis-framing of the regression as "silent crash loop").
- Live repro on host CM-PRD-InS-LiteLLM, 2026-04-24 ~15:34 UTC: removing the stale overlay + restarting `dev`/`dev_mun` with `--no-continue` brought both back cleanly; the patch in this PR, if applied before the next overlay run, prevents the regression from recurring.
