### PR TITLE
upgrade: rename restart labels to restart_eligible / restart_attempted_ok (closes #257)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -175,6 +175,18 @@ bridge_upgrade_agent_restart_json() {
   local enabled="$2"
   local dry_run="${3:-0}"
 
+  # JSON key contract (post-#257): dry-run reports *eligibility*, not success;
+  # apply reports the `bridge-agent.sh restart` exit-0 count, not agent health.
+  #   - restart_eligible / restart_eligible_agents: dry-run candidates. This
+  #     is what we would attempt; it does NOT predict whether the agent will
+  #     stay stably up after launch (plugin resolution, settings corruption,
+  #     dependency outages can still surface at apply).
+  #   - restart_attempted_ok / restart_attempted_ok_agents: apply tally of
+  #     `bridge-agent.sh restart` commands that returned exit 0. Does NOT
+  #     prove the agent survived the first few seconds after launch; that
+  #     requires post-restart health reconciliation (tracked in #256).
+  # The prior keys `would_restart`/`restarted` over-promised at both layers
+  # and caused the #253→#254 misdiagnosis. Renamed here per issue #257.
   python3 - "$enabled" "$dry_run" "$report" <<'PY'
 import json
 import sys
@@ -187,12 +199,12 @@ payload = {
     "dry_run": dry_run,
     "considered": 0,
     "eligible": 0,
-    "would_restart": 0,
-    "restarted": 0,
+    "restart_eligible": 0,
+    "restart_attempted_ok": 0,
     "failed": 0,
     "skipped": 0,
-    "restarted_agents": [],
-    "would_restart_agents": [],
+    "restart_attempted_ok_agents": [],
+    "restart_eligible_agents": [],
     "failed_agents": [],
     "skipped_reasons": {},
 }
@@ -206,11 +218,11 @@ for raw in report.splitlines():
     if reason == "eligible":
         payload["eligible"] += 1
     if status == "would-restart":
-        payload["would_restart"] += 1
-        payload["would_restart_agents"].append(agent)
+        payload["restart_eligible"] += 1
+        payload["restart_eligible_agents"].append(agent)
     elif status == "restarted":
-        payload["restarted"] += 1
-        payload["restarted_agents"].append(agent)
+        payload["restart_attempted_ok"] += 1
+        payload["restart_attempted_ok_agents"].append(agent)
     elif status == "failed":
         payload["failed"] += 1
         payload["failed_agents"].append(agent)
@@ -225,6 +237,12 @@ PY
 bridge_upgrade_print_agent_restart_summary() {
   local payload="$1"
 
+  # Text-summary labels align with the JSON contract above: eligibility
+  # vs restart-attempted-ok. A dry-run-only disclaimer warns that the
+  # count is pre-launch eligibility; runtime failures (plugin resolution,
+  # settings corruption, dependency outages) only surface at apply. See
+  # issue #257 for why the prior "would_restart/restarted" labels misled
+  # operators into reading accurate planning where none existed.
   python3 - "$payload" <<'PY'
 import json
 import sys
@@ -233,19 +251,25 @@ payload = json.loads(sys.argv[1])
 print(f"agent_restart_enabled: {'yes' if payload.get('enabled') else 'no'}")
 print(f"agent_restart_considered: {payload.get('considered', 0)}")
 print(f"agent_restart_eligible: {payload.get('eligible', 0)}")
-print(f"agent_restart_restarted: {payload.get('restarted', 0)}")
+print(f"agent_restart_attempted_ok: {payload.get('restart_attempted_ok', 0)}")
 print(f"agent_restart_failed: {payload.get('failed', 0)}")
 print(f"agent_restart_skipped: {payload.get('skipped', 0)}")
-if payload.get("would_restart"):
-    print(f"agent_restart_would_restart: {payload.get('would_restart', 0)}")
-if payload.get("restarted_agents"):
-    print(f"agent_restart_agents: {','.join(payload['restarted_agents'])}")
-if payload.get("would_restart_agents"):
-    print(f"agent_restart_would_agents: {','.join(payload['would_restart_agents'])}")
+if payload.get("restart_eligible"):
+    print(f"agent_restart_eligible_count: {payload.get('restart_eligible', 0)}")
+if payload.get("restart_attempted_ok_agents"):
+    print(f"agent_restart_attempted_ok_agents: {','.join(payload['restart_attempted_ok_agents'])}")
+if payload.get("restart_eligible_agents"):
+    print(f"agent_restart_eligible_agents: {','.join(payload['restart_eligible_agents'])}")
 if payload.get("failed_agents"):
     print(f"agent_restart_failed_agents: {','.join(payload['failed_agents'])}")
 for reason in sorted(payload.get("skipped_reasons", {})):
     print(f"agent_restart_skipped_{reason}: {payload['skipped_reasons'][reason]}")
+if payload.get("dry_run") and payload.get("restart_eligible"):
+    print(
+        "agent_restart_note: dry-run reports pre-launch eligibility only. "
+        "Runtime failures (plugin resolution, settings corruption, "
+        "dependency outages) will surface only in the actual apply run."
+    )
 PY
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5016,9 +5016,42 @@ agent = sys.argv[2]
 restart = payload["agent_restart"]
 
 assert restart["enabled"] is True, restart
-assert restart["restarted"] >= 1, restart
-assert agent in restart["restarted_agents"], restart
+# Post-#257 contract: `restart_attempted_ok` replaces the prior `restarted`
+# (the count of `bridge-agent.sh restart` commands that returned exit 0).
+# The old `restarted` / `restarted_agents` keys are gone; the new names
+# must faithfully appear in the JSON.
+assert restart["restart_attempted_ok"] >= 1, restart
+assert agent in restart["restart_attempted_ok_agents"], restart
+assert "restarted" not in restart, "legacy key restarted must be gone after #257"
+assert "restarted_agents" not in restart, "legacy key restarted_agents must be gone after #257"
+assert "would_restart" not in restart, "legacy key would_restart must be gone after #257"
+assert "would_restart_agents" not in restart, "legacy key would_restart_agents must be gone after #257"
 PY
+
+log "upgrade dry-run surfaces the eligibility-only disclaimer (#257)"
+UPGRADE_DRY_RUN_JSON="$("$REPO_ROOT/agent-bridge" upgrade --source "$REPO_ROOT" --target "$BRIDGE_HOME" --allow-dirty --dry-run --json)"
+python3 - "$UPGRADE_DRY_RUN_JSON" "$ALWAYS_ON_AGENT" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+agent = sys.argv[2]
+restart = payload["agent_restart"]
+
+# Dry-run must use the new key names too.
+assert restart["dry_run"] is True, restart
+assert restart["restart_eligible"] >= 1, restart
+assert agent in restart["restart_eligible_agents"], restart
+# The apply-only count stays zero on dry-run.
+assert restart["restart_attempted_ok"] == 0, restart
+PY
+UPGRADE_DRY_RUN_TEXT="$("$REPO_ROOT/agent-bridge" upgrade --source "$REPO_ROOT" --target "$BRIDGE_HOME" --allow-dirty --dry-run)"
+assert_contains "$UPGRADE_DRY_RUN_TEXT" "agent_restart_eligible_agents: $ALWAYS_ON_AGENT"
+assert_contains "$UPGRADE_DRY_RUN_TEXT" "agent_restart_note: dry-run reports pre-launch eligibility only"
+# Text summary must not leak the retired labels either.
+assert_not_contains "$UPGRADE_DRY_RUN_TEXT" "agent_restart_would_restart:"
+assert_not_contains "$UPGRADE_DRY_RUN_TEXT" "agent_restart_would_agents:"
+assert_not_contains "$UPGRADE_DRY_RUN_TEXT" "agent_restart_restarted:"
 
 log "rolling back from an upgrade backup snapshot"
 ROLLBACK_ROOT="$TMP_ROOT/rollback-root"


### PR DESCRIPTION
## Summary

Closes #257. Renames the upgrade restart summary labels so they stop over-promising at both layers:

- Dry-run now reports `restart_eligible` / `restart_eligible_agents` (pre-launch eligibility, not success prediction). Apply reports `restart_attempted_ok` / `restart_attempted_ok_agents` (the count of `bridge-agent.sh restart` commands that returned exit 0, not agent health).
- Dry-run summaries additionally print a disclaimer line explaining that runtime failures (plugin resolution, settings corruption, dependency outages) only surface at apply.

Background: the #253→#254 misdiagnosis on 2026-04-24 fell out of the prior labels reading like accurate restart planning. `would_restart: 5` followed by `restarted: 3 / failed: 2` was parsed as "upgrade-level bug broke 2 of the 5 it planned," when in fact the restart planning was accurate and the startup failures were agent-specific (the #246 channel-policy regression, fixed in #255 / v0.6.12).

Post-restart health reconciliation (the `stable_after_restart` count from the issue's third suggestion) is deliberately **not** landed here — it depends on #256's `state/agents/<agent>/last-launch-failure.env` diagnostic file, which ships separately.

## Changes

- `bridge-upgrade.sh` — `bridge_upgrade_agent_restart_json` and `bridge_upgrade_print_agent_restart_summary` use the new key names; dry-run disclaimer line added.
- `scripts/smoke-test.sh` — existing upgrade-restart smoke asserts the new key names + the absence of every retired legacy key; a new dry-run smoke exercises the disclaimer line and confirms none of the retired text labels leak.

## Test plan

- [x] `bash -n` + `shellcheck` on both files (under `/opt/homebrew/bin/bash` 4+).
- [x] Stand-alone python reproduction of `bridge_upgrade_agent_restart_json` + `bridge_upgrade_print_agent_restart_summary` against a synthetic report with one would-restart and one restarted agent:
  - Dry-run JSON: `restart_eligible=1, restart_eligible_agents=[a1], restart_attempted_ok=0`, no legacy keys.
  - Apply JSON: `restart_attempted_ok=1, restart_attempted_ok_agents=[a2], restart_eligible=0`.
  - Dry-run text: includes `agent_restart_eligible_agents: a1` and `agent_restart_note: dry-run reports pre-launch eligibility only…`.
  - Apply text: includes `agent_restart_attempted_ok_agents: a2`, no disclaimer.
- [ ] Full `scripts/smoke-test.sh` — current full-run exit is red on the pre-existing `audit log expected output to contain "actor": "queue"` baseline (PR #239's domain) that fires before reaching the upgrade-restart block. Once #239 lands, the rerun should cover the new assertions.

## Breaking change note

The JSON `agent_restart` payload keys are the observable API. The only in-tree consumer was `scripts/smoke-test.sh` (updated in the same commit). External scripts parsing `would_restart` / `restarted` / `restarted_agents` / `would_restart_agents` will need to follow the rename. On `0.6.x` this is a small breaking change; ship with the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)