### PR TITLE
upgrade: surface restart-failure diagnostics on apply summary (#256 Gap 1)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -251,7 +251,14 @@ payload = {
 }
 
 
-def _decode_log_tail(raw_b64: str) -> str | None:
+def _decode_log_tail(raw_b64):
+    """Return the decoded log-tail string or None when absent/corrupt.
+
+    Deliberately plain-Python (no PEP 604 annotation) because the
+    reference install's system python is 3.9.6 — `str | None` would
+    raise `TypeError` at function-definition time before the summary
+    ever ran. See PR #261 round-1 review.
+    """
     if not raw_b64:
         return None
     try:

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -118,6 +118,17 @@ bridge_upgrade_collect_agent_restart_report() {
   local target_root="$1"
   local dry_run="${2:-0}"
 
+  # Tuple format (tab-separated, 7 columns — grew from 5 to capture
+  # restart-failure diagnostics per issue #256 Gap 1):
+  #   <agent>\t<status>\t<reason>\t<attached>\t<session>\t<exit_code>\t<log_tail_b64>
+  #
+  # - exit_code is the return of `bridge-agent.sh restart <agent>` and is
+  #   only meaningful when status == "failed"; empty otherwise.
+  # - log_tail_b64 is the base64-encoded last ~5 lines of the agent's
+  #   most recently modified `.err.log`, or the `.log` when `.err.log`
+  #   is empty (the silent-exit common case). Base64 keeps newlines from
+  #   breaking the tab framing. Empty when status != "failed" or the
+  #   agent has no log directory yet. See `bridge_agent_log_dir`.
   "$BRIDGE_BASH_BIN" -lc '
     set -euo pipefail
     target_root="$1"
@@ -131,6 +142,8 @@ bridge_upgrade_collect_agent_restart_report() {
     attached=0
     status=""
     reason=""
+    exit_code=""
+    log_tail_b64=""
 
     for agent in "${BRIDGE_AGENT_IDS[@]}"; do
       [[ "$(bridge_agent_source "$agent")" == "static" ]] || continue
@@ -139,6 +152,8 @@ bridge_upgrade_collect_agent_restart_report() {
       attached=0
       status="skipped"
       reason="inactive"
+      exit_code=""
+      log_tail_b64=""
 
       if [[ "$(bridge_agent_loop "$agent")" != "1" ]]; then
         reason="not-loop"
@@ -159,13 +174,37 @@ bridge_upgrade_collect_agent_restart_report() {
         elif "$BRIDGE_BASH_BIN" "$target_root/bridge-agent.sh" restart "$agent" >/dev/null 2>&1; then
           status="restarted"
           reason="eligible"
+          exit_code=0
         else
+          exit_code=$?
           status="failed"
           reason="restart-failed"
+          # Capture last ~5 log lines for the summary. Prefer .err.log;
+          # fall back to .log when .err.log is empty (silent-exit case).
+          # All subshell errors are tolerated so a missing log dir does
+          # not mask the original restart failure.
+          log_dir="$(bridge_agent_log_dir "$agent" 2>/dev/null || true)"
+          log_tail=""
+          if [[ -n "${log_dir:-}" && -d "$log_dir" ]]; then
+            err_latest="$(ls -t "$log_dir"/*.err.log 2>/dev/null | head -n 1 || true)"
+            if [[ -n "${err_latest:-}" && -s "$err_latest" ]]; then
+              log_tail="$(tail -n 5 "$err_latest" 2>/dev/null || true)"
+            else
+              log_latest="$(ls -t "$log_dir"/*.log 2>/dev/null | head -n 1 || true)"
+              if [[ -n "${log_latest:-}" ]]; then
+                log_tail="$(tail -n 5 "$log_latest" 2>/dev/null || true)"
+              fi
+            fi
+          fi
+          if [[ -n "$log_tail" ]]; then
+            log_tail_b64="$(printf "%s" "$log_tail" | base64 | tr -d "\n")"
+          fi
         fi
       fi
 
-      printf "%s\t%s\t%s\t%s\t%s\n" "$agent" "$status" "$reason" "$attached" "$session"
+      printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+        "$agent" "$status" "$reason" "$attached" "$session" \
+        "${exit_code:-}" "${log_tail_b64:-}"
     done
   ' -- "$target_root" "$dry_run"
 }
@@ -188,6 +227,7 @@ bridge_upgrade_agent_restart_json() {
   # The prior keys `would_restart`/`restarted` over-promised at both layers
   # and caused the #253→#254 misdiagnosis. Renamed here per issue #257.
   python3 - "$enabled" "$dry_run" "$report" <<'PY'
+import base64
 import json
 import sys
 
@@ -206,14 +246,30 @@ payload = {
     "restart_attempted_ok_agents": [],
     "restart_eligible_agents": [],
     "failed_agents": [],
+    "failed_details": [],
     "skipped_reasons": {},
 }
+
+
+def _decode_log_tail(raw_b64: str) -> str | None:
+    if not raw_b64:
+        return None
+    try:
+        decoded = base64.b64decode(raw_b64, validate=False)
+    except Exception:  # noqa: BLE001 — b64 is operator-captured log; failing open with None is fine
+        return None
+    return decoded.decode("utf-8", errors="replace")
+
 
 for raw in report.splitlines():
     raw = raw.rstrip("\n")
     if not raw:
         continue
-    agent, status, reason, _attached, _session = (raw.split("\t", 4) + ["", "", "", "", ""])[:5]
+    # Tuple format (see bridge_upgrade_collect_agent_restart_report): 7 cols.
+    # Older builds may emit 5 cols (pre-#256); tolerate that shape so a
+    # half-upgraded host doesn't crash the aggregator.
+    parts = (raw.split("\t", 6) + ["", "", "", "", "", "", ""])[:7]
+    agent, status, reason, _attached, _session, exit_code, log_tail_b64 = parts
     payload["considered"] += 1
     if reason == "eligible":
         payload["eligible"] += 1
@@ -226,6 +282,13 @@ for raw in report.splitlines():
     elif status == "failed":
         payload["failed"] += 1
         payload["failed_agents"].append(agent)
+        detail = {"agent": agent}
+        try:
+            detail["exit_code"] = int(exit_code) if exit_code else None
+        except ValueError:
+            detail["exit_code"] = None
+        detail["last_log_tail"] = _decode_log_tail(log_tail_b64)
+        payload["failed_details"].append(detail)
     else:
         payload["skipped"] += 1
         payload["skipped_reasons"][reason] = payload["skipped_reasons"].get(reason, 0) + 1
@@ -262,6 +325,22 @@ if payload.get("restart_eligible_agents"):
     print(f"agent_restart_eligible_agents: {','.join(payload['restart_eligible_agents'])}")
 if payload.get("failed_agents"):
     print(f"agent_restart_failed_agents: {','.join(payload['failed_agents'])}")
+# #256 Gap 1: surface per-agent exit code + last log tail when a restart
+# failed, so the operator can triage without hand-grepping log dirs.
+for detail in payload.get("failed_details", []) or []:
+    agent_id = detail.get("agent") or "unknown"
+    exit_code = detail.get("exit_code")
+    exit_label = str(exit_code) if isinstance(exit_code, int) else "n/a"
+    tail = detail.get("last_log_tail") or ""
+    # Flatten newlines + cap to keep the summary one line per agent;
+    # the full decoded tail is always available in the JSON payload.
+    tail_flat = " ".join(tail.split())
+    if len(tail_flat) > 240:
+        tail_flat = tail_flat[:237] + "..."
+    if tail_flat:
+        print(f"agent_restart_failed_detail_{agent_id}: exit={exit_label} tail={tail_flat}")
+    else:
+        print(f"agent_restart_failed_detail_{agent_id}: exit={exit_label} tail=<no log tail captured>")
 for reason in sorted(payload.get("skipped_reasons", {})):
     print(f"agent_restart_skipped_{reason}: {payload['skipped_reasons'][reason]}")
 if payload.get("dry_run") and payload.get("restart_eligible"):

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5185,77 +5185,35 @@ assert restart["failed_details"] == [], \
 PY
 
 log "upgrade restart report aggregator surfaces failed_details with decoded log tail (#256 Gap 1)"
-# The aggregator is a pure python function emitted inside a bash heredoc.
-# Reproduce its logic against a synthetic 7-column report with one failed
-# agent and confirm the decoded JSON shape. Drift risk is small because
-# the python body is copied verbatim from the aggregator — keep in sync.
+# Exercise the live aggregator body extracted from `bridge-upgrade.sh` so a
+# Python-version regression in the real file (e.g. a PEP 604 `str | None`
+# annotation under a python3.9 host, see PR #261 r1) reproduces in smoke
+# rather than passing a divergent copy. The extractor pulls the heredoc
+# between `<<'PY'` and the matching `PY` line on the aggregator's `python3
+# -` invocation, then feeds it a synthetic 7-column report.
 GAP1_TAIL_B64="$("$BASH4_BIN" -c 'printf "%s" "plugin telegram@claude-plugins-official failed to load\nprocess exited with code 1" | base64 | tr -d "\n"')"
 GAP1_SYNTH_REPORT=$(printf 'a1\twould-restart\teligible\t0\ts1\t\t\na2\trestarted\teligible\t0\ts2\t0\t\na3\tfailed\trestart-failed\t0\ts3\t7\t%s\n' "$GAP1_TAIL_B64")
-GAP1_AGG_OUTPUT="$(python3 - "$GAP1_SYNTH_REPORT" <<'PY'
-import base64
-import json
-import sys
+GAP1_AGG_BODY_FILE="$TMP_ROOT/gap1_aggregator_body.py"
+python3 - "$REPO_ROOT/bridge-upgrade.sh" "$GAP1_AGG_BODY_FILE" <<'EXTRACT'
+import pathlib, re, sys
 
-report = sys.argv[1]
-payload = {
-    "enabled": True,
-    "dry_run": False,
-    "considered": 0,
-    "eligible": 0,
-    "restart_eligible": 0,
-    "restart_attempted_ok": 0,
-    "failed": 0,
-    "skipped": 0,
-    "restart_attempted_ok_agents": [],
-    "restart_eligible_agents": [],
-    "failed_agents": [],
-    "failed_details": [],
-    "skipped_reasons": {},
-}
-
-
-def _decode_log_tail(raw_b64):
-    if not raw_b64:
-        return None
-    try:
-        decoded = base64.b64decode(raw_b64, validate=False)
-    except Exception:
-        return None
-    return decoded.decode("utf-8", errors="replace")
-
-
-for raw in report.splitlines():
-    raw = raw.rstrip("\n")
-    if not raw:
-        continue
-    parts = (raw.split("\t", 6) + ["", "", "", "", "", "", ""])[:7]
-    agent, status, reason, _attached, _session, exit_code, log_tail_b64 = parts
-    payload["considered"] += 1
-    if reason == "eligible":
-        payload["eligible"] += 1
-    if status == "would-restart":
-        payload["restart_eligible"] += 1
-        payload["restart_eligible_agents"].append(agent)
-    elif status == "restarted":
-        payload["restart_attempted_ok"] += 1
-        payload["restart_attempted_ok_agents"].append(agent)
-    elif status == "failed":
-        payload["failed"] += 1
-        payload["failed_agents"].append(agent)
-        detail = {"agent": agent}
-        try:
-            detail["exit_code"] = int(exit_code) if exit_code else None
-        except ValueError:
-            detail["exit_code"] = None
-        detail["last_log_tail"] = _decode_log_tail(log_tail_b64)
-        payload["failed_details"].append(detail)
-    else:
-        payload["skipped"] += 1
-        payload["skipped_reasons"][reason] = payload["skipped_reasons"].get(reason, 0) + 1
-
-print(json.dumps(payload, ensure_ascii=False))
-PY
-)"
+src = pathlib.Path(sys.argv[1]).read_text()
+# Match the exact aggregator invocation and capture everything between
+# `<<'PY'` and the matching closing `PY` line. Anchored on the function
+# name so we do not accidentally pick up the summary helper below.
+pattern = re.compile(
+    r"bridge_upgrade_agent_restart_json\(\) \{.*?"
+    r"python3 - \"\$enabled\" \"\$dry_run\" \"\$report\" <<'PY'\n"
+    r"(?P<body>.*?)\nPY\n",
+    re.DOTALL,
+)
+match = pattern.search(src)
+if not match:
+    raise SystemExit("aggregator heredoc not located in bridge-upgrade.sh")
+pathlib.Path(sys.argv[2]).write_text(match.group("body"))
+EXTRACT
+[[ -s "$GAP1_AGG_BODY_FILE" ]] || die "aggregator body extraction produced an empty file"
+GAP1_AGG_OUTPUT="$(python3 "$GAP1_AGG_BODY_FILE" 1 0 "$GAP1_SYNTH_REPORT")"
 python3 - "$GAP1_AGG_OUTPUT" <<'PY'
 import json
 import sys
@@ -5275,6 +5233,7 @@ assert "code 1" in tail, detail
 assert payload["restart_attempted_ok"] == 1, payload
 assert payload["restart_eligible"] == 1, payload
 PY
+rm -f "$GAP1_AGG_BODY_FILE"
 
 log "upgrade dry-run surfaces the eligibility-only disclaimer (#257)"
 UPGRADE_DRY_RUN_JSON="$("$REPO_ROOT/agent-bridge" upgrade --source "$REPO_ROOT" --target "$BRIDGE_HOME" --allow-dirty --dry-run --json)"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5174,6 +5174,106 @@ assert "restarted" not in restart, "legacy key restarted must be gone after #257
 assert "restarted_agents" not in restart, "legacy key restarted_agents must be gone after #257"
 assert "would_restart" not in restart, "legacy key would_restart must be gone after #257"
 assert "would_restart_agents" not in restart, "legacy key would_restart_agents must be gone after #257"
+# #256 Gap 1: failed_details structure must exist on every apply payload,
+# even when no agent failed (empty list). Aggregator logic is validated
+# in the dedicated stand-alone block below so downstream consumers can
+# rely on the key always being present.
+assert "failed_details" in restart, "failed_details must be present on apply payload"
+assert isinstance(restart["failed_details"], list), restart["failed_details"]
+assert restart["failed_details"] == [], \
+    f"no failed agents expected in smoke fixture; got {restart['failed_details']!r}"
+PY
+
+log "upgrade restart report aggregator surfaces failed_details with decoded log tail (#256 Gap 1)"
+# The aggregator is a pure python function emitted inside a bash heredoc.
+# Reproduce its logic against a synthetic 7-column report with one failed
+# agent and confirm the decoded JSON shape. Drift risk is small because
+# the python body is copied verbatim from the aggregator — keep in sync.
+GAP1_TAIL_B64="$("$BASH4_BIN" -c 'printf "%s" "plugin telegram@claude-plugins-official failed to load\nprocess exited with code 1" | base64 | tr -d "\n"')"
+GAP1_SYNTH_REPORT=$(printf 'a1\twould-restart\teligible\t0\ts1\t\t\na2\trestarted\teligible\t0\ts2\t0\t\na3\tfailed\trestart-failed\t0\ts3\t7\t%s\n' "$GAP1_TAIL_B64")
+GAP1_AGG_OUTPUT="$(python3 - "$GAP1_SYNTH_REPORT" <<'PY'
+import base64
+import json
+import sys
+
+report = sys.argv[1]
+payload = {
+    "enabled": True,
+    "dry_run": False,
+    "considered": 0,
+    "eligible": 0,
+    "restart_eligible": 0,
+    "restart_attempted_ok": 0,
+    "failed": 0,
+    "skipped": 0,
+    "restart_attempted_ok_agents": [],
+    "restart_eligible_agents": [],
+    "failed_agents": [],
+    "failed_details": [],
+    "skipped_reasons": {},
+}
+
+
+def _decode_log_tail(raw_b64):
+    if not raw_b64:
+        return None
+    try:
+        decoded = base64.b64decode(raw_b64, validate=False)
+    except Exception:
+        return None
+    return decoded.decode("utf-8", errors="replace")
+
+
+for raw in report.splitlines():
+    raw = raw.rstrip("\n")
+    if not raw:
+        continue
+    parts = (raw.split("\t", 6) + ["", "", "", "", "", "", ""])[:7]
+    agent, status, reason, _attached, _session, exit_code, log_tail_b64 = parts
+    payload["considered"] += 1
+    if reason == "eligible":
+        payload["eligible"] += 1
+    if status == "would-restart":
+        payload["restart_eligible"] += 1
+        payload["restart_eligible_agents"].append(agent)
+    elif status == "restarted":
+        payload["restart_attempted_ok"] += 1
+        payload["restart_attempted_ok_agents"].append(agent)
+    elif status == "failed":
+        payload["failed"] += 1
+        payload["failed_agents"].append(agent)
+        detail = {"agent": agent}
+        try:
+            detail["exit_code"] = int(exit_code) if exit_code else None
+        except ValueError:
+            detail["exit_code"] = None
+        detail["last_log_tail"] = _decode_log_tail(log_tail_b64)
+        payload["failed_details"].append(detail)
+    else:
+        payload["skipped"] += 1
+        payload["skipped_reasons"][reason] = payload["skipped_reasons"].get(reason, 0) + 1
+
+print(json.dumps(payload, ensure_ascii=False))
+PY
+)"
+python3 - "$GAP1_AGG_OUTPUT" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+assert payload["failed"] == 1, payload
+assert payload["failed_agents"] == ["a3"], payload
+details = payload.get("failed_details")
+assert isinstance(details, list) and len(details) == 1, payload
+detail = details[0]
+assert detail["agent"] == "a3", detail
+assert detail["exit_code"] == 7, detail
+tail = detail.get("last_log_tail") or ""
+assert "plugin telegram" in tail, detail
+assert "code 1" in tail, detail
+# Non-failed agents must NOT get entries.
+assert payload["restart_attempted_ok"] == 1, payload
+assert payload["restart_eligible"] == 1, payload
 PY
 
 log "upgrade dry-run surfaces the eligibility-only disclaimer (#257)"


### PR DESCRIPTION
## Summary

Addresses Gap 1 of issue #256: the upgrade apply summary used to say only `agent_restart_failed: N / agent_restart_failed_agents: a,b` when `bridge-agent.sh restart <agent>` returned non-zero. During the #253→#254 repro on 2026-04-24 that forced a multi-directory hand-grep across six log locations to figure out *why* the restart failed. This PR threads the per-agent exit code + last log tail through the report tuple and surfaces them in the JSON + text summaries.

Gaps 2 (daemon retry cap + `launch-persistent-failure.json`) and 3 (pre-exec snapshot + silent-exit detection via `last-launch-failure.env`) stay out of scope here and will land as separate PRs.

## Changes

- `bridge-upgrade.sh`
  - `bridge_upgrade_collect_agent_restart_report` tuple grew from 5 to 7 columns, adding `exit_code` + `log_tail_b64`. On `status=failed` the function reads the agent's most recent `.err.log` (or `.log` when `.err.log` is empty — the silent-exit common case #254) and base64-encodes the last ~5 lines so the tab-delimited framing survives multi-line output.
  - `bridge_upgrade_agent_restart_json` grows a `failed_details` list. Each entry carries `agent`, `exit_code` (int or null), and `last_log_tail` (decoded UTF-8 string or null). Always present, empty on a clean upgrade.
  - `bridge_upgrade_print_agent_restart_summary` prints one `agent_restart_failed_detail_<agent>: exit=<N> tail=<flattened>` line per failed agent, capped at 240 chars per line. Full decoded tail remains in the JSON payload.
  - Aggregator tolerates older 5-column tuples (half-upgraded host).

- `scripts/smoke-test.sh`
  - Existing apply-path restart assertions now check `failed_details` key presence + empty list (no real failure in smoke fixture).
  - New stand-alone block feeds a synthetic 3-row 7-column report (one would-restart, one restarted, one failed with exit=7 and a two-line encoded tail) through the aggregator's Python body and asserts the decoded JSON shape.

## Test plan

- [x] `bash -n bridge-upgrade.sh scripts/smoke-test.sh` under `/opt/homebrew/bin/bash` — clean.
- [x] `shellcheck` — clean.
- [x] Stand-alone reproduction of the aggregator body against a synthetic failed-agent report:
  - `failed_details[0] = {agent: "a3", exit_code: 7, last_log_tail: "plugin telegram@… failed to load\nprocess exited with code 1"}`.
  - Non-failed agents absent from `failed_details`.
  - `restart_attempted_ok` / `restart_eligible` counts correct.
- [ ] Full `scripts/smoke-test.sh` — blocked on the pre-existing `"actor": "queue"` baseline PR #239 is addressing. The new assertions live under the existing upgrade-restart block in a linear extension; the stand-alone aggregator block uses only python3, no daemon state.

## Follow-ups queued under #256

- Gap 2: daemon retry cap, exponential backoff (15s / 60s / 240s), `launch-persistent-failure.json`, `[watchdog] agent persistent launch failure` task emission, operator `agent start` unblock.
- Gap 3: `state/agents/<agent>/last-launch.env` pre-exec snapshot + silent-exit rename to `last-launch-failure.env`.

Both gaps will consume this PR's `failed_details` output and add the `stable_after_restart` count PR #259 (#257) held for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
