### PR TITLE
daemon: honour broken-launch quarantine marker (#256 Gap 2)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1380,13 +1380,6 @@ run_restart() {
   local agent="${1:-}"
   local session=""
   local start_args=()
-  # #256 Gap 2: explicit operator restart clears the rapid-fail
-  # quarantine marker so the daemon's autostart gate lets the agent
-  # come back up. If the agent is still crashing, `bridge-run.sh` will
-  # trip the circuit breaker again and re-write the marker.
-  if [[ -n "$agent" ]]; then
-    bridge_agent_clear_broken_launch "$agent" 2>/dev/null || true
-  fi
   local attach_mode=0
   local dry_run_mode=0
   local engine=""
@@ -1446,6 +1439,14 @@ run_restart() {
   if [[ -n "$preflight_reason" ]]; then
     bridge_die "$(bridge_agent_restart_preflight_guidance "$agent" "$preflight_reason")"
   fi
+
+  # #256 Gap 2: clear the rapid-fail quarantine marker only after the
+  # dry-run short-circuit (handled above) and the preflight guidance
+  # check have both allowed the restart to proceed. An aborted restart
+  # must not silently unquarantine the agent — the daemon would then
+  # resume auto-starting it and recreate the crash loop before
+  # `bridge-run.sh` had a chance to re-trip the circuit breaker.
+  bridge_agent_clear_broken_launch "$agent" 2>/dev/null || true
 
   if bridge_tmux_session_exists "$session"; then
     bridge_kill_agent_session "$agent"

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1380,6 +1380,13 @@ run_restart() {
   local agent="${1:-}"
   local session=""
   local start_args=()
+  # #256 Gap 2: explicit operator restart clears the rapid-fail
+  # quarantine marker so the daemon's autostart gate lets the agent
+  # come back up. If the agent is still crashing, `bridge-run.sh` will
+  # trip the circuit breaker again and re-write the marker.
+  if [[ -n "$agent" ]]; then
+    bridge_agent_clear_broken_launch "$agent" 2>/dev/null || true
+  fi
   local attach_mode=0
   local dry_run_mode=0
   local engine=""

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2062,6 +2062,19 @@ bridge_daemon_autostart_allowed() {
   local next_retry_ts=0
   local now=0
 
+  # #256 Gap 2: a `broken-launch` state file means `bridge-run.sh` tripped
+  # its rapid-fail circuit breaker on this agent. The daemon must stop
+  # relaunching until an operator clears the quarantine with `agent-bridge
+  # agent start <agent>` / `safe-mode <agent>` / `restart <agent>`. Before
+  # this gate was wired, the daemon's 1s post-start liveness heuristic saw
+  # a session that was still inside claude's ~5–10s startup window, called
+  # `bridge_daemon_clear_autostart_failure`, then relaunched on the next
+  # reconcile tick — reproducing 137 cycles in 2h13m on the reference
+  # host during the #254 crash loop.
+  if [[ -f "$(bridge_agent_broken_launch_file "$agent")" ]]; then
+    return 1
+  fi
+
   file="$(bridge_daemon_autostart_state_file "$agent")"
   [[ -f "$file" ]] || return 0
   # shellcheck source=/dev/null

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -93,6 +93,12 @@ fi
 
 bridge_require_agent "$AGENT"
 bridge_agent_clear_manual_stop "$AGENT"
+# #256 Gap 2: an explicit start/safe-mode from the operator is the
+# documented way out of a rapid-fail quarantine. Clear the broken-launch
+# marker so the daemon's autostart gate stops blocking this agent. If
+# the underlying cause is still present, `bridge-run.sh` will trip the
+# circuit breaker again and re-write the marker.
+bridge_agent_clear_broken_launch "$AGENT"
 
 SESSION="$(bridge_agent_session "$AGENT")"
 WORK_DIR="$(bridge_agent_workdir "$AGENT")"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -93,12 +93,6 @@ fi
 
 bridge_require_agent "$AGENT"
 bridge_agent_clear_manual_stop "$AGENT"
-# #256 Gap 2: an explicit start/safe-mode from the operator is the
-# documented way out of a rapid-fail quarantine. Clear the broken-launch
-# marker so the daemon's autostart gate stops blocking this agent. If
-# the underlying cause is still present, `bridge-run.sh` will trip the
-# circuit breaker again and re-write the marker.
-bridge_agent_clear_broken_launch "$AGENT"
 
 SESSION="$(bridge_agent_session "$AGENT")"
 WORK_DIR="$(bridge_agent_workdir "$AGENT")"
@@ -322,6 +316,16 @@ if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
 fi
 
 bridge_agent_clear_idle_marker "$AGENT"
+
+# #256 Gap 2: an explicit operator start/safe-mode here is the documented
+# way out of a rapid-fail quarantine. Clear the broken-launch marker only
+# once we are past dry-run short-circuits, workdir validation, and the
+# channel-plugin preflight — so a `--dry-run` inspect or a failed-start
+# (missing workdir / channel setup error) does not silently unquarantine
+# the agent before any relaunch actually runs. If the underlying cause
+# is still present, `bridge-run.sh` will trip the circuit breaker again
+# and re-write the marker on the first post-unblock failure cycle.
+bridge_agent_clear_broken_launch "$AGENT"
 
 # Refresh the launch window so a new session id can be detected for this run.
 # shellcheck disable=SC2034

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1376,6 +1376,64 @@ bridge_agent_clear_crash_report() {
     "$(bridge_agent_crash_state_file "$agent")" >/dev/null 2>&1 || true
 }
 
+# #256 Gap 2: persist the rapid-fail circuit-breaker trip so the daemon's
+# autostart gate can honour it and stop relaunching a quarantined agent.
+# `bridge-run.sh` has been calling this helper since the circuit breaker
+# landed (line 512), but the helper itself was missing — the unbound-function
+# call raised `command not found` under `set -e`, the broken-launch file was
+# never written, and the daemon kept relaunching the crashing agent (137×
+# in 2h13m on the reference host during the #254 repro). This definition
+# closes that loop.
+bridge_agent_write_broken_launch_state() {
+  local agent="$1"
+  local engine="${2:-}"
+  local fail_count="${3:-0}"
+  local exit_code="${4:-0}"
+  local stderr_file="${5:-}"
+  local launch_cmd="${6:-}"
+  local err_size_before="${7:-0}"
+  local file=""
+
+  file="$(bridge_agent_broken_launch_file "$agent")"
+  mkdir -p "$(dirname "$file")"
+  bridge_require_python
+  python3 - "$file" "$agent" "$engine" "$fail_count" "$exit_code" "$stderr_file" "$launch_cmd" "$err_size_before" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _as_int(value):
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+path = Path(sys.argv[1])
+agent, engine, fail_count, exit_code, stderr_file, launch_cmd, err_size_before = sys.argv[2:]
+
+payload = {
+    "agent": agent,
+    "engine": engine,
+    "fail_count": _as_int(fail_count),
+    "exit_code": _as_int(exit_code),
+    "stderr_file": stderr_file,
+    "launch_cmd": launch_cmd,
+    "err_size_before": _as_int(err_size_before),
+    "quarantined_at": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
+}
+
+path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n")
+PY
+}
+
+bridge_agent_clear_broken_launch() {
+  local agent="$1"
+  rm -f "$(bridge_agent_broken_launch_file "$agent")" >/dev/null 2>&1 || true
+}
+
 bridge_agent_ack_crash_report() {
   local agent="$1"
   local report_file=""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1415,6 +1415,68 @@ printf '%s\n' "$TOOL_POLICY_ALIAS_CHECK"
 assert_contains "$TOOL_POLICY_ALIAS_CHECK" "[ok] tool-policy protected_alias_reason"
 rm -rf "$TOOL_POLICY_ALIAS_FIXTURE"
 
+log "daemon autostart gate honours broken-launch quarantine marker (#256 Gap 2)"
+BROKEN_LAUNCH_HOME="$TMP_ROOT/broken-launch-home"
+rm -rf "$BROKEN_LAUNCH_HOME"
+mkdir -p "$BROKEN_LAUNCH_HOME/state/agents/broken-smoke"
+: > "$BROKEN_LAUNCH_HOME/state/agents/broken-smoke/broken-launch"
+GATE_BODY="$(awk '/^bridge_daemon_autostart_allowed\(\) \{/,/^\}$/' "$REPO_ROOT/bridge-daemon.sh")"
+[[ -n "$GATE_BODY" ]] || die "could not extract bridge_daemon_autostart_allowed from bridge-daemon.sh"
+"$BASH4_BIN" -c '
+  set -euo pipefail
+  export BRIDGE_STATE_DIR="'"$BROKEN_LAUNCH_HOME/state"'"
+  # Minimal stubs for the helpers the gate calls; the real definitions live
+  # in lib/bridge-{agents,state,daemon}.sh and are sourced by the daemon at
+  # runtime. We reproduce just enough to exercise the broken-launch path.
+  bridge_agent_broken_launch_file() { printf "%s/agents/%s/broken-launch" "$BRIDGE_STATE_DIR" "$1"; }
+  bridge_daemon_autostart_state_file() { printf "%s/agents/%s/autostart" "$BRIDGE_STATE_DIR" "$1"; }
+  '"$GATE_BODY"'
+  if bridge_daemon_autostart_allowed broken-smoke; then
+    echo "[fail] daemon autostart gate allowed relaunch while broken-launch file present" >&2
+    exit 1
+  fi
+  rm -f "$BRIDGE_STATE_DIR/agents/broken-smoke/broken-launch"
+  if ! bridge_daemon_autostart_allowed broken-smoke; then
+    echo "[fail] daemon autostart gate still blocked after broken-launch cleared" >&2
+    exit 1
+  fi
+' || die "daemon autostart gate broken-launch regression test failed"
+
+log "bridge_agent_write_broken_launch_state / clear round-trip (#256 Gap 2)"
+BROKEN_LAUNCH_AGENT=broken-smoke
+BRIDGE_STATE_DIR="$BROKEN_LAUNCH_HOME/state" "$BASH4_BIN" -lc '
+  set -euo pipefail
+  export BRIDGE_HOME="'"$BROKEN_LAUNCH_HOME"'"
+  # `bridge_load_roster` would error without a roster file; skip it — the two
+  # helpers we are exercising only touch $BRIDGE_STATE_DIR.
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_agent_write_broken_launch_state "'"$BROKEN_LAUNCH_AGENT"'" "claude" 5 1 "/tmp/err.log" "bash bridge-run.sh broken-smoke" 0
+'
+BROKEN_FILE="$BROKEN_LAUNCH_HOME/state/agents/$BROKEN_LAUNCH_AGENT/broken-launch"
+[[ -s "$BROKEN_FILE" ]] || die "bridge_agent_write_broken_launch_state did not create the quarantine file"
+python3 - "$BROKEN_FILE" "$BROKEN_LAUNCH_AGENT" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(Path(sys.argv[1]).read_text())
+assert payload.get("agent") == sys.argv[2], payload
+assert payload.get("fail_count") == 5, payload
+assert payload.get("exit_code") == 1, payload
+assert payload.get("engine") == "claude", payload
+assert payload.get("launch_cmd"), payload
+assert payload.get("stderr_file") == "/tmp/err.log", payload
+assert payload.get("quarantined_at"), payload
+PY
+BRIDGE_STATE_DIR="$BROKEN_LAUNCH_HOME/state" "$BASH4_BIN" -lc '
+  set -euo pipefail
+  export BRIDGE_HOME="'"$BROKEN_LAUNCH_HOME"'"
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_agent_clear_broken_launch "'"$BROKEN_LAUNCH_AGENT"'"
+'
+[[ ! -e "$BROKEN_FILE" ]] || die "bridge_agent_clear_broken_launch did not remove the quarantine file"
+rm -rf "$BROKEN_LAUNCH_HOME"
+
 log "diagnose acl reports clean on macOS (non-Linux host)"
 DIAGNOSE_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl)"
 if [[ "$(uname -s)" == "Linux" ]]; then

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1477,6 +1477,85 @@ BRIDGE_STATE_DIR="$BROKEN_LAUNCH_HOME/state" "$BASH4_BIN" -lc '
 [[ ! -e "$BROKEN_FILE" ]] || die "bridge_agent_clear_broken_launch did not remove the quarantine file"
 rm -rf "$BROKEN_LAUNCH_HOME"
 
+log "bridge-start.sh / bridge-agent.sh guard broken-launch clear behind dry-run + preflight (#256 Gap 2 r2)"
+python3 - "$REPO_ROOT/bridge-start.sh" "$REPO_ROOT/bridge-agent.sh" <<'PY'
+"""Regression test for PR #262 round-1 finding.
+
+The quarantine marker must survive:
+  * A `--dry-run` invocation (bridge-start.sh should exit before clearing).
+  * A preflight failure (bridge-agent.sh::run_restart must call the preflight
+    guard before clearing).
+
+Static line-order check — executes on every smoke run, catches a reorder even
+when the integration path is not available in the current fixture.
+"""
+import sys
+from pathlib import Path
+
+start_src = Path(sys.argv[1]).read_text().splitlines()
+agent_src = Path(sys.argv[2]).read_text().splitlines()
+
+clear_calls = [i for i, line in enumerate(start_src) if "bridge_agent_clear_broken_launch" in line]
+assert clear_calls, "bridge-start.sh must call bridge_agent_clear_broken_launch (broken after r1 -> r2 rewrite?)"
+first_clear = clear_calls[0]
+
+# Find the DRY_RUN block's terminating `exit 0`.
+in_dry = False
+dry_exit = None
+for i, line in enumerate(start_src):
+    if "if [[ $DRY_RUN -eq 1 ]]; then" in line:
+        in_dry = True
+    elif in_dry and line.strip() == "exit 0":
+        dry_exit = i
+        break
+assert dry_exit is not None, "bridge-start.sh no longer has a DRY_RUN exit 0 block"
+assert first_clear > dry_exit, (
+    f"bridge-start.sh clears broken-launch at line {first_clear + 1}, "
+    f"which is before the DRY_RUN exit at line {dry_exit + 1}. "
+    "That lets a --dry-run silently unquarantine an agent — see PR #262 round-1."
+)
+
+# run_restart must guard the clear behind bridge_agent_restart_preflight_reason.
+restart_start = next(
+    (i for i, l in enumerate(agent_src) if l.startswith("run_restart() {")),
+    None,
+)
+assert restart_start is not None, "run_restart() not found in bridge-agent.sh"
+# Function end: walk forward until a line that is exactly '}' at column 0.
+restart_end = None
+for i in range(restart_start + 1, len(agent_src)):
+    if agent_src[i] == "}":
+        restart_end = i
+        break
+assert restart_end is not None, "run_restart end `}` not found"
+
+preflight_idx = None
+clear_idx_agent = None
+dry_run_idx_agent = None
+for i in range(restart_start, restart_end + 1):
+    line = agent_src[i]
+    if "bridge_agent_restart_preflight_reason" in line and preflight_idx is None:
+        preflight_idx = i
+    if "bridge_agent_clear_broken_launch" in line:
+        clear_idx_agent = i
+    if "if [[ $dry_run_mode -eq 1 ]]; then" in line and dry_run_idx_agent is None:
+        dry_run_idx_agent = i
+assert preflight_idx is not None, "run_restart no longer calls bridge_agent_restart_preflight_reason"
+assert clear_idx_agent is not None, "run_restart must call bridge_agent_clear_broken_launch"
+assert dry_run_idx_agent is not None, "run_restart no longer branches on dry_run_mode"
+assert clear_idx_agent > preflight_idx, (
+    f"run_restart clears broken-launch at line {clear_idx_agent + 1}, "
+    f"which is before the preflight guard at line {preflight_idx + 1}. "
+    "That lets a preflight-blocked restart silently unquarantine an agent."
+)
+assert clear_idx_agent > dry_run_idx_agent, (
+    f"run_restart clears broken-launch at line {clear_idx_agent + 1}, "
+    f"which is before the dry-run branch at line {dry_run_idx_agent + 1}. "
+    "That lets `agent restart --dry-run` silently unquarantine an agent."
+)
+print("[ok] broken-launch clear guarded behind dry-run + preflight in both entry points")
+PY
+
 log "diagnose acl reports clean on macOS (non-Linux host)"
 DIAGNOSE_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl)"
 if [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
## Summary

Closes #256 Gap 2. The #254 repro's 137 relaunches of `dev_mun` in a 2h13m window were NOT caused by a missing rapid-fail policy. `bridge-run.sh` has counted consecutive rapid failures since the circuit breaker landed and calls `bridge_agent_write_broken_launch_state` on trip (line 512) — but **the helper itself was never defined**. The unbound-function call under `set -e` killed `bridge-run.sh` at circuit-breaker time, the broken-launch file was never written, and the daemon's autostart loop had nothing to honour anyway because its gate only consulted a soft backoff window that kept resetting on every sleep-1 liveness heuristic hit.

This PR closes the loop at both ends.

## Changes

- `lib/bridge-state.sh`
  - Adds `bridge_agent_write_broken_launch_state` (writes a JSON payload to `$BRIDGE_STATE_DIR/agents/<agent>/broken-launch` with agent / engine / fail_count / exit_code / stderr_file / launch_cmd / err_size_before / quarantined_at).
  - Adds matching `bridge_agent_clear_broken_launch`.

- `bridge-daemon.sh::bridge_daemon_autostart_allowed`
  - Short-circuits to "block" when the broken-launch file exists for an agent. Was previously soft-backoff only (5/30/60/300s), which sailed straight through any 5s-to-die crash loop because `bridge_daemon_clear_autostart_failure` fired on the post-spawn liveness heuristic.

- `bridge-start.sh`
  - Clears the quarantine marker after `bridge_agent_clear_manual_stop`. If the underlying cause is still present `bridge-run.sh` will trip the circuit breaker again and rewrite the marker — the operator does not need to manually `rm` the file.

- `bridge-agent.sh::run_restart`
  - Same clear at the top of the explicit-restart path so `agent-bridge agent restart <agent>` unblocks symmetrically.

- `scripts/smoke-test.sh`
  - New daemon-gate block extracts `bridge_daemon_autostart_allowed` from `bridge-daemon.sh`, stubs its two path helpers, and asserts "block with marker / allow after clear".
  - New round-trip block verifies `bridge_agent_write_broken_launch_state` + `bridge_agent_clear_broken_launch` via `bridge-lib.sh`: JSON payload shape, fail_count/exit_code int coercion, clear removes file.

## Out of scope

- **Gap 3** (pre-exec `last-launch.env` snapshot + silent-exit rename to `last-launch-failure.env`). The existing crash-state file already records most of the snapshot fields the issue calls for; the "write every launch, rename on silent exit" behaviour is much larger surface than the Gap 2 fix. Deferred to a follow-up PR once there's more evidence on which snapshot fields operators actually read during triage.
- **Retry backoff tuning (15s / 60s / 240s exponential)**. The current tree already has a 5/30/60/300s backoff in `bridge_daemon_note_autostart_failure`. Gap 2 as filed asked for a different schedule, but wiring the broken-launch gate makes the backoff a second-order concern — a rapid-fail trip now terminates the loop at the broken-launch marker, not at the Nth retry. Keeping the backoff tuning separate means we can ship the quarantine immediately and revisit the cadence when we see real post-Gap-2 behaviour.

## Test plan

- [x] `bash -n` + `shellcheck` on all five touched files under `/opt/homebrew/bin/bash` 4+.
- [x] Stand-alone extraction of `bridge_daemon_autostart_allowed` against a fixture `broken-launch` file: gate returns non-zero (block), then zero (allow) once the file is removed.
- [x] Stand-alone `bridge_agent_write_broken_launch_state` round-trip via `bridge-lib.sh`: JSON payload carries the expected fields, `bridge_agent_clear_broken_launch` removes the file.
- [ ] Full `scripts/smoke-test.sh` — still gated on the pre-existing baseline (`"actor": "queue"` audit fixture PR #239 is addressing). Both new blocks live early in the file, before the tmux-heavy fixtures that currently block the run from reaching them in isolation.

## Why this is the minimal fix

The issue originally framed Gap 2 as "add retry cap + backoff + quarantine file + `[watchdog]` task + operator unblock". Analysis showed:

- Rapid-fail counting + circuit breaker → already in `bridge-run.sh`.
- `broken-launch` file format → helpers referenced everywhere except one (missing) writer.
- `[watchdog]` task emission → existing `process_crash_reports` in `bridge-daemon.sh:1890` already fires on crash-state; a broken-launch flag just becomes another path into the same emitter on follow-up.
- Operator unblock → `agent-bridge agent start`/`safe-mode`/`restart` are the natural unblock paths; this PR wires the clear helpers onto all three.

So the real defect was "three out of four pieces were in place, but the file never got written and the daemon wasn't looking at it." Writing the missing helper + honouring the marker is the whole fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
