### PR TITLE
queue: protect fresh and pre-fire cron slots from supersede dedup (closes #266)

### DIFF
--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -1565,10 +1565,35 @@ def cmd_daemon_step(args: argparse.Namespace) -> int:
             job_name = m.group(1) if m else row["title"]
             key = (str(row["assigned_to"]), job_name)
             _cron_groups.setdefault(key, []).append(row)
+        # Issue #266: in recovery scenarios (worker pool backlog, daemon hang
+        # recovery), the newest slot itself often has not been fired by the
+        # time the next cron tick adds a still-newer slot. The previous logic
+        # cancelled every non-newest open slot, which meant a high-frequency
+        # cron with worker latency > cron interval never actually ran — every
+        # fresh slot got superseded by the next before a worker could claim it
+        # (cs-line-poll-5m: zero successful runs across 144 slots in 36h).
+        # Two layered guards: (1) preserve any sibling that is still inside
+        # the grace window (worker may still pick it up); (2) if the newest
+        # slot has not itself been fired yet, leave older un-claimed siblings
+        # in place so the worker can pick whichever it reaches first instead
+        # of seeing an empty queue while a stuck cron quietly drops fires.
+        try:
+            _supersede_grace = int(os.environ.get("BRIDGE_CRON_SUPERSEDE_GRACE_SECONDS", "60"))
+        except (TypeError, ValueError):
+            _supersede_grace = 60
+        if _supersede_grace < 0:
+            _supersede_grace = 0
         for _key, group in _cron_groups.items():
             if len(group) < 2:
                 continue
+            newest = group[0]
+            newest_fired = bool(newest["claimed_by"]) or newest["status"] == "claimed"
             for row in group[1:]:
+                created_ts = row["created_ts"] or 0
+                if (current_ts - created_ts) < _supersede_grace and not row["claimed_by"]:
+                    continue
+                if not newest_fired and not row["claimed_by"]:
+                    continue
                 conn.execute(
                     """
                     UPDATE tasks


### PR DESCRIPTION
## Summary

Issue #266 documents `cs-line-poll-5m` running zero successful fires across 144 slots in 36 hours during a worker-pool backlog. Every fresh `*/5` slot got superseded by the next before any worker could claim it, because the dedup pass cancelled every non-newest open slot regardless of whether the newest had even been fired.

## Fix

Two layered guards in `bridge-queue.py` cron-dispatch dedup:

1. **Grace window** — env `BRIDGE_CRON_SUPERSEDE_GRACE_SECONDS` (default 60s). An unclaimed sibling within the grace window is preserved.
2. **Newest-not-fired guard** — if the newest slot itself has not been claimed (still queued), no unclaimed sibling is cancelled. Worker can pick whichever it reaches.

Claimed-but-not-newest siblings are still cancelled (genuine duplicate work).

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Normal: newest fires quickly | Older sibling cancelled | Older sibling cancelled (newest_fired guard inactive) |
| Recovery: newest unfired, sibling fresh | Sibling cancelled | Sibling preserved |
| Recovery: newest unfired, sibling expired | Sibling cancelled | Sibling preserved (newest_fired guard kicks in) |
| Newest fired, sibling fresh | Sibling cancelled | Sibling preserved (grace window) |
| Newest fired, sibling expired | Sibling cancelled | Sibling cancelled |
| Newest queued, sibling claimed by worker | Sibling cancelled | Sibling cancelled (claimed != newest = stale) |

## Risk

- In normal operation (worker fire latency < cron interval), newest is claimed quickly → siblings are cancelled as before. Zero behavior change.
- In recovery, queue size grows briefly until worker pool drains. This is the desired behavior per the issue body — running a couple of extra fires of old slots is far less harmful than silently dropping 30+ consecutive monitoring fires.
- The grace window default (60s) is a tunable lower-bound. Operators with worker fire latency > 60s should consider increasing it.

## Test plan

- [x] Python compile clean
- [x] 7-case unit harness covers: grace boundary, claimed/unclaimed sibling, fired/unfired newest, grace=0 disabled
  - fresh siblings + newest queued → both stay
  - grace-expired sibling + newest unfired → sibling stays (newest_not_fired guard)
  - grace-expired sibling + newest fired → sibling cancelled (normal dedup)
  - claimed sibling not newest → cancelled regardless of grace
  - newest fired + 2 mixed siblings → fresh stays, expired cancelled
  - grace=0 + newest fired → sibling cancelled (env disabled)
  - grace=0 + newest queued → sibling stays (newest_not_fired still kicks in)
- [ ] Production reproducer (deferred to reviewer): register `*/5` cron with 4-minute payload → all slots eventually fire instead of being supersede-cancelled.

Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)