### PR TITLE
daemon: per-call timeout on high-risk subprocess sites (partial #265 proposal A)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -632,7 +632,10 @@ process_release_monitor() {
   bridge_release_paths_valid || return 1
   bridge_release_due || return 1
 
-  if ! monitor_json="$(python3 "$SCRIPT_DIR/bridge-release.py" monitor --repo "$BRIDGE_RELEASE_REPO" --installed-version "$(bridge_version)" --state-file "$BRIDGE_RELEASE_CHECK_STATE_FILE" --json 2>/dev/null)"; then
+  # Issue #265 proposal A: release monitor hits the GitHub releases endpoint
+  # over the network; a stuck SSL handshake here would freeze the main loop
+  # at __wait4 with no recovery. Per-call timeout caps the worst case.
+  if ! monitor_json="$(bridge_with_timeout "" release_monitor python3 "$SCRIPT_DIR/bridge-release.py" monitor --repo "$BRIDGE_RELEASE_REPO" --installed-version "$(bridge_version)" --state-file "$BRIDGE_RELEASE_CHECK_STATE_FILE" --json 2>/dev/null)"; then
     bridge_note_release_poll
     return 1
   fi
@@ -715,7 +718,11 @@ process_daily_backup() {
   [[ "$retain_days" =~ ^[0-9]+$ ]] || retain_days=30
   (( retain_days > 0 )) || retain_days=30
 
-  if ! backup_json="$(python3 "$SCRIPT_DIR/bridge-upgrade.py" daily-backup-live --target-root "$BRIDGE_HOME" --backup-dir "$BRIDGE_DAILY_BACKUP_DIR" --retain-days "$retain_days" 2>/dev/null)"; then
+  # Issue #265 proposal A: daily-backup walks BRIDGE_HOME (large file tree on
+  # long-lived installs) and writes a tarball; a hung filesystem (NFS,
+  # external mount, full disk waiting on flush) would otherwise stall the
+  # daemon main loop. 120s ceiling is well above the observed normal runtime.
+  if ! backup_json="$(bridge_with_timeout 120 daily_backup python3 "$SCRIPT_DIR/bridge-upgrade.py" daily-backup-live --target-root "$BRIDGE_HOME" --backup-dir "$BRIDGE_DAILY_BACKUP_DIR" --retain-days "$retain_days" 2>/dev/null)"; then
     return 1
   fi
 
@@ -1115,7 +1122,10 @@ process_stall_reports() {
           # (context-pressure: bridge-daemon.sh:1583) already use `join`.
           capture="$(bridge_capture_recent "$session" "${BRIDGE_STALL_CAPTURE_LINES:-120}" join 2>/dev/null || true)"
           if [[ -n "$capture" ]]; then
-            analysis_shell="$(printf '%s' "$capture" | python3 "$SCRIPT_DIR/bridge-stall.py" analyze --format shell 2>/dev/null || true)"
+            # Issue #265 proposal A: stall analyzer runs once per active agent
+            # per cycle; a single hang would multiply across the roster on
+            # every tick. Wrap so a stuck child cannot freeze the whole loop.
+            analysis_shell="$(bridge_with_timeout "" stall_analyze python3 "$SCRIPT_DIR/bridge-stall.py" analyze --format shell <<<"$capture" 2>/dev/null || true)"
             if [[ -n "$analysis_shell" ]]; then
               STALL_CLASSIFICATION=""
               STALL_MATCHED_PATTERN=""
@@ -1594,7 +1604,9 @@ process_context_pressure_reports() {
     excerpt_b64=""
     excerpt=""
     if [[ -n "$capture" ]]; then
-      analysis_shell="$(printf '%s' "$capture" | python3 "$SCRIPT_DIR/bridge-context-pressure.py" analyze --format shell --engine "$engine" 2>/dev/null || true)"
+      # Issue #265 proposal A: same risk profile as the stall analyzer above
+      # (per-agent per-cycle); cap subprocess time to keep the loop moving.
+      analysis_shell="$(bridge_with_timeout "" context_pressure_analyze python3 "$SCRIPT_DIR/bridge-context-pressure.py" analyze --format shell --engine "$engine" <<<"$capture" 2>/dev/null || true)"
       if [[ -n "$analysis_shell" ]]; then
         CONTEXT_PRESSURE_SEVERITY=""
         CONTEXT_PRESSURE_MATCHED_PATTERN=""
@@ -2142,7 +2154,11 @@ bridge_dashboard_post_if_changed() {
   printf '%s\n' "$summary_output" >"$summary_file"
 
   bridge_require_python
-  python3 "$SCRIPT_DIR/bridge-dashboard.py" \
+  # Issue #265 proposal A: dashboard post issues an outbound HTTP request to
+  # the configured webhook URL; a hung handshake or unreachable host would
+  # otherwise block the daemon's main-loop tail. Wrap so it can never freeze
+  # the scheduler.
+  bridge_with_timeout "" dashboard_post python3 "$SCRIPT_DIR/bridge-dashboard.py" \
     --summary-tsv "$summary_file" \
     --state-file "$BRIDGE_DASHBOARD_STATE_FILE" \
     --webhook-url "$BRIDGE_DASHBOARD_WEBHOOK_URL" \
@@ -3385,7 +3401,11 @@ PY
 process_queue_gateway_requests() {
   local processed=0
 
-  processed="$(python3 "$SCRIPT_DIR/bridge-queue-gateway.py" serve-once \
+  # Issue #265 proposal A: queue-gateway is mostly local (sqlite + filesystem),
+  # but it shells out into bridge-queue.py per pending request — a stuck DB
+  # lock or a runaway request batch would otherwise block the loop. Wrap the
+  # whole serve-once invocation under one ceiling.
+  processed="$(bridge_with_timeout "" queue_gateway_serve_once python3 "$SCRIPT_DIR/bridge-queue-gateway.py" serve-once \
     --root "$(bridge_queue_gateway_root)" \
     --queue-script "$SCRIPT_DIR/bridge-queue.py" \
     --max-requests "${BRIDGE_QUEUE_GATEWAY_MAX_REQUESTS_PER_CYCLE:-100}" 2>/dev/null || printf '0')"

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1070,6 +1070,82 @@ bridge_audit_log() {
   python3 "$BRIDGE_SCRIPT_DIR/bridge-audit.py" write --file "$BRIDGE_AUDIT_LOG" --actor "$actor" --action "$action" --target "$target" "$@" >/dev/null
 }
 
+# bridge_with_timeout — issue #265 proposal A.
+#
+# Wraps an external command with `timeout(1)` so a single hung subprocess in
+# the daemon main loop cannot block the scheduler indefinitely (the canonical
+# stack the issue describes is bash blocked at __wait4 on a tmux send-keys
+# child whose far end is a closed Discord SSL pipe). On 124/137 (timeout or
+# SIGKILL after timeout) the helper writes a `daemon_subprocess_timeout`
+# audit row tagged with the call-site label so the operator can see which
+# step actually hung; the exit code is propagated so existing `|| true` /
+# `|| return 1` handling at the call site keeps working.
+#
+# Usage:
+#   bridge_with_timeout <secs> <call_site_label> <cmd> [args...]
+#
+# - <secs> defaults to BRIDGE_DAEMON_SUBPROCESS_TIMEOUT_SECONDS (default 30s)
+#   when passed as empty string.
+# - <call_site_label> is the symbolic name used in the audit detail
+#   (e.g. "release_monitor", "stall_analyze").
+# - When neither `timeout` nor `gtimeout` is on PATH, the helper falls
+#   through to a plain exec so behavior on bare hosts matches today; a
+#   one-time `daemon_subprocess_timeout_unavailable` audit row is written
+#   the first time so the gap is visible without spamming the log.
+#
+# Caveat: only wrappable around *external* commands. Bash functions cannot be
+# wrapped with `timeout(1)` directly — those must be exposed through a
+# subshell + `bash -c` first, which is out of scope for this helper.
+_BRIDGE_WITH_TIMEOUT_BIN_CACHED=0
+_BRIDGE_WITH_TIMEOUT_BIN=""
+_BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED=0
+
+bridge_with_timeout() {
+  local secs="${1:-}"
+  local label="${2:-unknown}"
+  shift 2 || true
+  local default_secs="${BRIDGE_DAEMON_SUBPROCESS_TIMEOUT_SECONDS:-30}"
+  local started_ts=0
+  local elapsed=0
+  local rc=0
+
+  [[ "$secs" =~ ^[0-9]+$ ]] || secs="$default_secs"
+  [[ "$secs" =~ ^[0-9]+$ ]] || secs=30
+
+  if (( _BRIDGE_WITH_TIMEOUT_BIN_CACHED == 0 )); then
+    _BRIDGE_WITH_TIMEOUT_BIN="$(command -v timeout 2>/dev/null || command -v gtimeout 2>/dev/null || true)"
+    _BRIDGE_WITH_TIMEOUT_BIN_CACHED=1
+  fi
+
+  started_ts="$(date +%s 2>/dev/null || echo 0)"
+
+  if [[ -z "$_BRIDGE_WITH_TIMEOUT_BIN" ]]; then
+    if (( _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED == 0 )); then
+      bridge_audit_log daemon daemon_subprocess_timeout_unavailable daemon \
+        --detail call_site="$label" \
+        --detail requested_seconds="$secs" \
+        --detail note="neither timeout nor gtimeout on PATH; running unwrapped" \
+        2>/dev/null || true
+      _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED=1
+    fi
+    "$@"
+    return $?
+  fi
+
+  "$_BRIDGE_WITH_TIMEOUT_BIN" "$secs" "$@"
+  rc=$?
+  if [[ "$rc" == "124" || "$rc" == "137" ]]; then
+    elapsed=$(( $(date +%s 2>/dev/null || echo "$started_ts") - started_ts ))
+    bridge_audit_log daemon daemon_subprocess_timeout daemon \
+      --detail call_site="$label" \
+      --detail timeout_seconds="$secs" \
+      --detail elapsed_seconds="$elapsed" \
+      --detail exit_code="$rc" \
+      2>/dev/null || true
+  fi
+  return "$rc"
+}
+
 bridge_mcp_orphan_cleanup_state_dir() {
   printf '%s/mcp-orphan-cleanup' "$BRIDGE_STATE_DIR"
 }


### PR DESCRIPTION
Partial #265 proposal A. Helper bridge_with_timeout + 6 daemon call sites. Out of scope: lib/bridge-tmux.sh tmux send-keys (separate PR), audit_log (recursion), nudge heredoc (low risk). Full body: see commit message in c2e7d5b.