### PR TITLE
agent: add forget-session command + --no-continue warning + show source-of-truth (closes #268)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -18,6 +18,7 @@ Usage:
   $(basename "$0") safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $(basename "$0") stop <agent>
   $(basename "$0") restart <agent> [--attach|--no-attach] [--continue|--no-continue] [--dry-run]
+  $(basename "$0") forget-session <agent>
   $(basename "$0") attach <agent>
 
 Options:
@@ -984,16 +985,23 @@ run_show() {
 
   output="$(bridge_agent_records_tsv "$agent")"
   if [[ $json_mode -eq 1 ]]; then
+    # session_source surfaces which authoritative state file currently
+    # supplies AGENT_SESSION_ID for this agent (issue #268). Default text
+    # output is intentionally unchanged; only --json exposes the path so
+    # operators can pipe it into recovery scripts (e.g. forget-session
+    # follow-ups) without parsing the human format.
     bridge_agent_manage_python \
       "$(emit_agent_records_json show "$output")" \
       "$(bridge_agent_channel_diagnostics_json "$agent")" \
-      "$(bridge_agent_session_health_json "$agent")" <<'PY'
+      "$(bridge_agent_session_health_json "$agent")" \
+      "$(bridge_agent_session_source_path "$agent")" <<'PY'
 import json
 import sys
 
 payload = json.loads(sys.argv[1])
 payload.setdefault("channels", {})["diagnostics"] = json.loads(sys.argv[2])
 payload["session_health"] = json.loads(sys.argv[3])
+payload["session_source"] = sys.argv[4] if len(sys.argv) > 4 and sys.argv[4] else None
 print(json.dumps(payload, ensure_ascii=False, indent=2))
 PY
     return 0
@@ -1535,6 +1543,79 @@ run_attach() {
   exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" attach "$agent"
 }
 
+# run_forget_session — clear the persisted Claude/Codex resume id for <agent>
+# from every authoritative state file (history env, dynamic active env, and
+# the linux-user agent-env.sh overlay when present), so the next normal
+# restart launches without `--resume`. The running tmux session is NOT
+# killed; an active agent must be restarted manually before the cleared id
+# takes effect. Idempotent — running it twice on an already-empty id exits
+# 0 with `changed=no`.
+#
+# This is the supported recovery path for issue #268 (stale Claude resume
+# target). The companion warning in bridge-start.sh / bridge-run.sh tells an
+# operator who used `--no-continue` that the persisted id is still there.
+run_forget_session() {
+  local agent="${1:-}"
+  local active="no"
+  local clear_output=""
+  local prior_id_hash=""
+  local changed=""
+  local cleared_csv=""
+  local token=""
+
+  shift || true
+  [[ -n "$agent" ]] || bridge_die "Usage: $(basename "$0") forget-session <agent>"
+  [[ $# -eq 0 ]] || bridge_die "지원하지 않는 agent forget-session 옵션입니다: $1"
+  bridge_require_agent "$agent"
+
+  if bridge_agent_is_active "$agent"; then
+    active="yes"
+  fi
+
+  # The lock + read-modify-write happens inside bridge_clear_persisted_session_id.
+  # When two callers race, only the holder that observes a non-empty prior id
+  # comes back with `changed=yes`; the others see `changed=no` and we record
+  # a separate `already_forgotten` audit row for them.
+  clear_output="$(bridge_clear_persisted_session_id "$agent")"
+  for token in $clear_output; do
+    case "$token" in
+      prior_id_hash=*) prior_id_hash="${token#prior_id_hash=}" ;;
+      changed=*)       changed="${token#changed=}" ;;
+      cleared_files=*) cleared_csv="${token#cleared_files=}" ;;
+    esac
+  done
+  changed="${changed:-no}"
+
+  if [[ "$changed" != "yes" ]]; then
+    bridge_audit_log daemon agent_session_forgotten "$agent" \
+      --detail cleared_files= \
+      --detail prior_id_hash= \
+      --detail active="$active" \
+      --detail changed=no \
+      --detail reason=already_forgotten >/dev/null 2>&1 || true
+    printf 'agent: %s\n' "$agent"
+    printf 'changed: no\n'
+    printf 'reason: already_forgotten\n'
+    printf 'active: %s\n' "$active"
+    return 0
+  fi
+
+  bridge_audit_log daemon agent_session_forgotten "$agent" \
+    --detail cleared_files="$cleared_csv" \
+    --detail prior_id_hash="$prior_id_hash" \
+    --detail active="$active" \
+    --detail changed=yes >/dev/null 2>&1 || true
+
+  printf 'agent: %s\n' "$agent"
+  printf 'changed: yes\n'
+  printf 'cleared_files: %s\n' "${cleared_csv:--}"
+  printf 'prior_id_hash: %s\n' "${prior_id_hash:--}"
+  printf 'active: %s\n' "$active"
+  if [[ "$active" == "yes" ]]; then
+    bridge_warn "active=yes — running tmux session must be restarted fresh to pick up cleared id; suggested next: bridge-agent.sh restart $agent --no-continue"
+  fi
+}
+
 subcommand="${1:-}"
 shift || true
 
@@ -1563,6 +1644,9 @@ case "$subcommand" in
   ack-crash)
     run_ack_crash "$@"
     ;;
+  forget-session)
+    run_forget_session "$@"
+    ;;
   attach)
     run_attach "$@"
     ;;
@@ -1572,7 +1656,7 @@ case "$subcommand" in
   *)
     # Issue #163 Phase 2: surface an intent-recovery hint before dying.
     _hint="$(bridge_suggest_subcommand "$subcommand" \
-      "create list show start safe-mode stop restart ack-crash attach")"
+      "create list show start safe-mode stop restart ack-crash forget-session attach")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 agent 명령입니다: $subcommand"
     ;;

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -89,6 +89,18 @@ if [[ $CONTINUE_EXPLICIT -eq 1 ]]; then
   BRIDGE_AGENT_CONTINUE["$AGENT"]="$CONTINUE_MODE"
 fi
 
+# Issue #268: same warning as bridge-start.sh, repeated here because operators
+# can invoke bridge-run.sh directly (and tmux session_cmd injects --no-continue
+# without going through bridge-start.sh on FORCE_FRESH_SESSION paths). Goes to
+# stderr so dry-run callers parsing stdout for `session_id=...` keep working.
+if [[ $CONTINUE_EXPLICIT -eq 1 && "$CONTINUE_MODE" == "0" ]]; then
+  _persisted_session_id="$(bridge_agent_persisted_session_id "$AGENT")"
+  if [[ -n "$_persisted_session_id" ]]; then
+    bridge_warn "launched fresh for this run, but saved session_id=${_persisted_session_id} remains; next normal restart will resume it. Use 'agb agent forget-session $AGENT' to clear permanently."
+  fi
+  unset _persisted_session_id
+fi
+
 if [[ $SAFE_MODE -eq 1 ]]; then
   ONCE=1
 fi

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -206,6 +206,18 @@ elif [[ $CONTINUE_EXPLICIT -eq 1 ]]; then
   EFFECTIVE_CONTINUE_MODE="$CONTINUE_MODE"
 fi
 
+# Issue #268: warn the operator when --no-continue is launching fresh but a
+# stale resume id is still persisted. Without this, an operator who used
+# --no-continue to escape a broken `claude --resume` does not realise the
+# next normal restart will pick the bad id back up.
+if [[ $CONTINUE_EXPLICIT -eq 1 && "$CONTINUE_MODE" == "0" ]]; then
+  _persisted_session_id="$(bridge_agent_persisted_session_id "$AGENT")"
+  if [[ -n "$_persisted_session_id" ]]; then
+    bridge_warn "launched fresh for this run, but saved session_id=${_persisted_session_id} remains; next normal restart will resume it. Use 'agb agent forget-session $AGENT' to clear permanently."
+  fi
+  unset _persisted_session_id
+fi
+
 if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
   CHANNEL_REASON="$(bridge_agent_channel_status_reason "$AGENT")"
   if [[ -n "$CHANNEL_REASON" ]]; then

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1250,6 +1250,308 @@ bridge_write_dynamic_agent_file() {
   bridge_write_agent_state_file "$agent" "$file"
 }
 
+# bridge_agent_session_lock_file — per-agent lock that serialises mutations of
+# the persisted AGENT_SESSION_ID across the dynamic-agent env, the static
+# history env, and (when present) the linux-user-scoped agent-env.sh overlay.
+# Lives under BRIDGE_ACTIVE_AGENT_DIR/<agent>/ alongside the other per-agent
+# runtime markers; created lazily by callers that need to take it.
+bridge_agent_session_lock_file() {
+  local agent="$1"
+  printf '%s/session.lock' "$(bridge_agent_runtime_state_dir "$agent")"
+}
+
+# bridge_agent_session_id_file_paths — emit the absolute paths of every
+# authoritative state file that records AGENT_SESSION_ID for <agent>, one per
+# line. Only paths that currently exist on disk are returned. Static agents
+# normally have only the history file; a dynamic agent additionally has the
+# active state file. The linux-user agent-env.sh overlay is included when
+# present so isolated UIDs do not reload a stale id from their per-agent
+# snapshot. Used by `agent forget-session` and `agent show --json`
+# (session_source).
+bridge_agent_session_id_file_paths() {
+  local agent="$1"
+  local history_file=""
+  local active_file=""
+  local overlay_file=""
+
+  history_file="$(bridge_history_file_for_agent "$agent" 2>/dev/null || true)"
+  if [[ -n "$history_file" && -f "$history_file" ]]; then
+    printf '%s\n' "$history_file"
+  fi
+  active_file="$(bridge_dynamic_agent_file_for "$agent" 2>/dev/null || true)"
+  if [[ -n "$active_file" && -f "$active_file" ]]; then
+    printf '%s\n' "$active_file"
+  fi
+  if declare -f bridge_agent_linux_env_file >/dev/null 2>&1; then
+    overlay_file="$(bridge_agent_linux_env_file "$agent" 2>/dev/null || true)"
+    if [[ -n "$overlay_file" && -f "$overlay_file" ]]; then
+      printf '%s\n' "$overlay_file"
+    fi
+  fi
+}
+
+# bridge_agent_persisted_session_id — read the persisted AGENT_SESSION_ID for
+# <agent> directly from the authoritative state files, without trusting the
+# in-memory BRIDGE_AGENT_SESSION_ID map (which is filtered by
+# bridge_claude_session_id_exists during load and would hide a stale-but-
+# present id from the operator's view). Returns the first non-empty value
+# found, in source-of-truth precedence: history, then active, then overlay.
+bridge_agent_persisted_session_id() {
+  local agent="$1"
+  local file=""
+  local AGENT_SESSION_ID=""
+
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    AGENT_SESSION_ID=""
+    # The overlay is a roster snapshot that sets values via associative-array
+    # assignment, not flat AGENT_SESSION_ID=... keys, so a plain `source`
+    # would not populate the local. Grep the literal active-id assignment
+    # used by bridge_write_linux_agent_env_file before falling back to the
+    # env-style files.
+    if [[ "$file" == *"/agent-env.sh" ]]; then
+      AGENT_SESSION_ID="$(
+        awk -v agent="$agent" '
+          $0 ~ "BRIDGE_AGENT_SESSION_ID\\[\"" agent "\"\\]=" {
+            sub(/.*\]=/, "")
+            gsub(/^[\047"]|[\047"]$/, "")
+            print
+            exit
+          }
+        ' "$file" 2>/dev/null || true
+      )"
+    else
+      # shellcheck source=/dev/null
+      source "$file" 2>/dev/null || true
+    fi
+    if [[ -n "$AGENT_SESSION_ID" ]]; then
+      printf '%s' "$AGENT_SESSION_ID"
+      return 0
+    fi
+  done < <(bridge_agent_session_id_file_paths "$agent")
+  printf ''
+}
+
+# bridge_agent_session_source_path — return the absolute path of the file
+# whose AGENT_SESSION_ID is currently the live id. Empty when no persisted
+# id exists. This is the field exposed by `agent show --json` so an operator
+# can see which file `forget-session` would rewrite.
+bridge_agent_session_source_path() {
+  local agent="$1"
+  local file=""
+  local AGENT_SESSION_ID=""
+
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    AGENT_SESSION_ID=""
+    if [[ "$file" == *"/agent-env.sh" ]]; then
+      AGENT_SESSION_ID="$(
+        awk -v agent="$agent" '
+          $0 ~ "BRIDGE_AGENT_SESSION_ID\\[\"" agent "\"\\]=" {
+            sub(/.*\]=/, "")
+            gsub(/^[\047"]|[\047"]$/, "")
+            print
+            exit
+          }
+        ' "$file" 2>/dev/null || true
+      )"
+    else
+      # shellcheck source=/dev/null
+      source "$file" 2>/dev/null || true
+    fi
+    if [[ -n "$AGENT_SESSION_ID" ]]; then
+      printf '%s' "$file"
+      return 0
+    fi
+  done < <(bridge_agent_session_id_file_paths "$agent")
+  printf ''
+}
+
+# _bridge_rewrite_session_id_in_file — atomically clear AGENT_SESSION_ID in
+# <file>. Honours the file's existing mode by chmod'ing the new inode after
+# the rename, so 0600 overlay snapshots stay 0600. Returns 0 if the file was
+# rewritten, 1 if no rewrite was needed, 2 on hard failure.
+_bridge_rewrite_session_id_in_file() {
+  local agent="$1"
+  local file="$2"
+  local tmp=""
+  local mode=""
+
+  [[ -n "$file" && -f "$file" ]] || return 1
+
+  # `stat` flag differs between BSD (macOS) and GNU; fall back to a portable
+  # python probe so the helper works on both supported platforms.
+  if mode="$(stat -f '%Lp' "$file" 2>/dev/null)"; then
+    :
+  elif mode="$(stat -c '%a' "$file" 2>/dev/null)"; then
+    :
+  else
+    mode="$(python3 - "$file" <<'PY' 2>/dev/null || true
+import os
+import sys
+print(format(os.stat(sys.argv[1]).st_mode & 0o7777, 'o'))
+PY
+)"
+  fi
+
+  tmp="$(mktemp "${file}.XXXXXX")" || return 2
+  if [[ "$file" == *"/agent-env.sh" ]]; then
+    # Roster snapshot: rewrite the associative-array assignment inline so the
+    # rest of the file (paths, channels, isolation flags) survives untouched.
+    # awk is preferred over sed here so the agent literal can be passed
+    # without escaping concerns.
+    if ! awk -v agent="$agent" '
+      $0 ~ "^BRIDGE_AGENT_SESSION_ID\\[\"" agent "\"\\]=" {
+        printf "BRIDGE_AGENT_SESSION_ID[\"%s\"]=\"\"\n", agent
+        next
+      }
+      { print }
+    ' "$file" >"$tmp"; then
+      rm -f "$tmp"
+      return 2
+    fi
+  else
+    # Plain env file (active or history): only touch the AGENT_SESSION_ID
+    # line. Other keys (engine, workdir, history_key, timestamps) must
+    # round-trip so the next `bridge_load_roster` keeps the agent intact.
+    if ! awk '
+      /^AGENT_SESSION_ID=/ {
+        print "AGENT_SESSION_ID=\047\047"
+        next
+      }
+      { print }
+    ' "$file" >"$tmp"; then
+      rm -f "$tmp"
+      return 2
+    fi
+  fi
+
+  if [[ -n "$mode" ]]; then
+    chmod "$mode" "$tmp" 2>/dev/null || true
+  fi
+  if ! mv -f "$tmp" "$file"; then
+    rm -f "$tmp"
+    return 2
+  fi
+  return 0
+}
+
+# _bridge_clear_session_id_critical — the read-modify-write that must be
+# serialised by the per-agent session lock. Re-reads the prior id from disk
+# inside the locked block (so a concurrent caller that beat us to the write
+# observes an empty id and reports `changed=no`), rewrites every file that
+# still carries it, and prints a single line to fd 1 of the form
+# `prior_id_hash=<sha256-prefix> changed=<yes|no> cleared_files=<csv>` for
+# the caller to feed straight into the audit log.
+_bridge_clear_session_id_critical() {
+  local agent="$1"
+  local file=""
+  local -a cleared=()
+  local prior_id=""
+  local prior_id_hash=""
+  local changed="no"
+  local rc=0
+
+  prior_id="$(bridge_agent_persisted_session_id "$agent")"
+  if [[ -n "$prior_id" ]]; then
+    prior_id_hash="$(
+      python3 - "$prior_id" <<'PY' 2>/dev/null || true
+import hashlib
+import sys
+
+print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())
+PY
+    )"
+    prior_id_hash="${prior_id_hash:0:12}"
+    while IFS= read -r file; do
+      [[ -n "$file" ]] || continue
+      if _bridge_rewrite_session_id_in_file "$agent" "$file"; then
+        cleared+=("$file")
+      else
+        rc=$?
+        if (( rc == 2 )); then
+          bridge_warn "failed to rewrite '$file' while clearing session id for '$agent'"
+        fi
+      fi
+    done < <(bridge_agent_session_id_file_paths "$agent")
+    if (( ${#cleared[@]} > 0 )); then
+      changed="yes"
+    fi
+  fi
+
+  local csv=""
+  local item=""
+  for item in "${cleared[@]}"; do
+    if [[ -z "$csv" ]]; then
+      csv="$item"
+    else
+      csv+=",${item}"
+    fi
+  done
+  printf 'prior_id_hash=%s changed=%s cleared_files=%s\n' \
+    "$prior_id_hash" "$changed" "$csv"
+}
+
+# bridge_clear_persisted_session_id — clear AGENT_SESSION_ID across every
+# authoritative state file for <agent>. Acquires a per-agent lock under
+# state/agents/<agent>/session.lock so concurrent callers serialise on the
+# read-modify-write; only the holder that finds a non-empty prior id
+# reports `changed=yes`. Emits one line on stdout:
+#   prior_id_hash=<sha256-prefix> changed=<yes|no> cleared_files=<csv>
+# Returns 0 always; per-file failures are logged via bridge_warn.
+bridge_clear_persisted_session_id() {
+  local agent="$1"
+  local lock_file=""
+  local lock_dir=""
+  local result_file=""
+
+  lock_file="$(bridge_agent_session_lock_file "$agent")"
+  lock_dir="$(dirname "$lock_file")"
+  mkdir -p "$lock_dir"
+  result_file="$(mktemp "${lock_file}.result.XXXXXX")"
+
+  if command -v flock >/dev/null 2>&1; then
+    {
+      # Acquire with a bounded wait so a stuck holder cannot freeze the CLI.
+      # 30s is well above any legitimate rewrite (single awk + mv per file)
+      # and matches the pattern used by other forget/recovery commands.
+      if ! flock -w 30 9; then
+        bridge_warn "session lock busy after 30s, refusing forget-session for '$agent' to avoid losing a concurrent rewrite"
+        printf 'prior_id_hash= changed=no cleared_files=\n' >"$result_file"
+      else
+        _bridge_clear_session_id_critical "$agent" >"$result_file"
+      fi
+    } 9>"$lock_file"
+  else
+    # Portable fallback when flock is missing (older macOS hosts, minimal
+    # busybox containers). `mkdir` is atomic on POSIX, so a directory-based
+    # mutex is safe; we retry with a short backoff before giving up.
+    local lock_dir_path="${lock_file}.d"
+    local attempt=0
+    while ! mkdir "$lock_dir_path" 2>/dev/null; do
+      attempt=$(( attempt + 1 ))
+      if (( attempt >= 30 )); then
+        bridge_warn "mkdir-based session lock busy after 30 retries, refusing forget-session for '$agent'"
+        printf 'prior_id_hash= changed=no cleared_files=\n' >"$result_file"
+        cat "$result_file"
+        rm -f "$result_file"
+        return 1
+      fi
+      sleep 1
+    done
+    _bridge_clear_session_id_critical "$agent" >"$result_file" || true
+    rmdir "$lock_dir_path" 2>/dev/null || true
+  fi
+
+  # Reflect the cleared id in the in-memory map so any follow-up call in the
+  # same process (e.g. `agent show` after forget-session) sees the new state
+  # without a fresh roster reload.
+  BRIDGE_AGENT_SESSION_ID["$agent"]=""
+
+  cat "$result_file"
+  rm -f "$result_file"
+}
+
 bridge_agent_idle_marker_dir() {
   local agent="$1"
   printf '%s/%s' "$BRIDGE_ACTIVE_AGENT_DIR" "$agent"


### PR DESCRIPTION
## Summary

Closes #268. Implements minimum 1차 PR per codex-1 spec: `agb agent forget-session <agent>` command, `--no-continue` warning when persisted id remains, `agent show --json` exposes `session_source`.

## Files (412+, 2-)

- `lib/bridge-state.sh` (+302) — helpers: lock, source-of-truth path enumeration, persisted-id reader, atomic env-file rewrite, clear-with-audit
- `bridge-agent.sh` (+86 / -2) — usage line, run_show JSON field, run_forget_session handler, dispatcher, suggestions
- `bridge-start.sh` (+12) — --no-continue warning at start path
- `bridge-run.sh` (+12) — same warning at runner layer

## Behavior

- Subcommand: `bridge-agent.sh forget-session <agent>` — clears persisted `AGENT_SESSION_ID` from all authoritative state files (active env, history env, linux-user overlay if present) under per-agent lock.
- Active agent: clears + warns (does NOT kill tmux). Operator runs `restart --no-continue` separately.
- Idempotent: second run reports `changed=no` / `already_forgotten`.
- Locking: flock if available, mkdir fallback (matches existing _has_flock pattern).
- Atomic file rewrite: mktemp + mv, mode preserved.
- Audit row: `agent_session_forgotten` with cleared_files CSV + prior_id_hash (12-char sha256 prefix) + active=yes/no + changed=yes/no.

## Sean's open-question defaults applied
1. Two-command OK (this is just forget; restart is separate)
2. Active agent: clear + warn (not refuse)
3. Tombstone: out of scope (separate PR)
4. Show file paths: --json only (default text unchanged)

## Test plan
- [x] bash -n + shellcheck clean
- [x] Targeted: `forget-session` clears env file, audit row written, second run reports already_forgotten
- [x] Concurrent: 5 background calls, exactly 1 changed=yes + 4 already_forgotten
- [x] `agent show --json` round-trip: session_source path before, null after
- [ ] Linux-user overlay path not exercised on macOS (low risk; declare -f gating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)