### PR TITLE
isolate: grant ACLs on the per-agent queue-gateway directory and root

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1009,6 +1009,10 @@ bridge_linux_prepare_agent_isolation() {
   history_file="$(bridge_history_file_for_agent "$agent")"
   request_dir="$(bridge_queue_gateway_requests_dir "$agent")"
   response_dir="$(bridge_queue_gateway_responses_dir "$agent")"
+  local queue_gateway_root=""
+  local queue_gateway_agent_dir=""
+  queue_gateway_root="$(bridge_queue_gateway_root)"
+  queue_gateway_agent_dir="$(bridge_queue_gateway_agent_dir "$agent")"
 
   bridge_linux_ensure_os_user "$os_user" "$user_home"
   bridge_linux_ensure_user_home "$os_user" "$user_home"
@@ -1022,7 +1026,7 @@ bridge_linux_prepare_agent_isolation() {
   [[ -d "$BRIDGE_HOME/scripts" ]] && recursive_read_paths+=("$BRIDGE_HOME/scripts")
   [[ -d "$BRIDGE_AGENT_HOME_ROOT/.claude" ]] && recursive_read_paths+=("$BRIDGE_AGENT_HOME_ROOT/.claude")
   bridge_linux_acl_remove_recursive "u:${os_user}" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR"
-  bridge_linux_sudo_root mkdir -p "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir" "$(dirname "$history_file")"
+  bridge_linux_sudo_root mkdir -p "$runtime_state_dir" "$log_dir" "$queue_gateway_root" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$(dirname "$history_file")"
   bridge_linux_sudo_root touch "$audit_file" "$history_file"
 
   # memory-daily state trees for the harvester (issue #219):
@@ -1049,7 +1053,14 @@ bridge_linux_prepare_agent_isolation() {
     fi
   done
 
-  recursive_write_paths+=("$workdir" "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir")
+  recursive_write_paths+=("$workdir" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir")
+  # Issue: per-agent queue-gateway dir was missing isolated/controller ACLs
+  # because only its children (requests/, responses/) were granted. The
+  # daemon's controller-side glob of the queue-gateway root and the
+  # isolated UID's own inbox traversal both fail without these grants.
+  # Root traverse-only on the gateway root for the isolated UID prevents
+  # cross-agent dir-name enumeration while keeping its own subtree reachable.
+  bridge_linux_acl_add "u:${os_user}:--x" "$queue_gateway_root" >/dev/null 2>&1 || true
   hidden_paths+=("$BRIDGE_ROSTER_FILE" "$BRIDGE_ROSTER_LOCAL_FILE" "$BRIDGE_RUNTIME_CREDENTIALS_DIR" "$BRIDGE_RUNTIME_SECRETS_DIR" "$BRIDGE_RUNTIME_CONFIG_FILE" "$BRIDGE_TASK_DB" "${BRIDGE_LOG_DIR}/audit.jsonl")
 
   # Issue #233: every traverse_chain call used to climb unconditionally
@@ -1097,7 +1108,7 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_grant_claude_credentials_access "$os_user" "$user_home" "$controller_user" "$(bridge_agent_engine "$agent")"
   bridge_linux_acl_add_recursive "u:${os_user}:r-X" "${recursive_read_paths[@]}"
   bridge_linux_acl_add_recursive "u:${os_user}:rwX" "${recursive_write_paths[@]}"
-  bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:rwX" "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
+  bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:rwX" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
   bridge_linux_acl_add "u:${os_user}:rw-" "$history_file"
 
   for other in "${BRIDGE_AGENT_IDS[@]}"; do
@@ -1120,7 +1131,14 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_sudo_root chown "$os_user" "$audit_file" "$history_file"
   bridge_linux_acl_add_recursive "u:${controller_user}:rwX" "$workdir"
   bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:rwX" "$workdir"
-  bridge_linux_acl_add_recursive "u:${controller_user}:rwX" "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
+  # Controller (daemon) needs to glob the queue-gateway root to find
+  # per-agent requests; r-x on the root + rwX on the agent dir + default
+  # ACLs on both keep the daemon's pathlib glob working without exposing
+  # other agents' dir contents to isolated UIDs.
+  bridge_linux_acl_add "u:${controller_user}:r-x" "$queue_gateway_root"
+  bridge_linux_sudo_root setfacl -d -m "u:${controller_user}:r-X" "$queue_gateway_root" >/dev/null 2>&1 || true
+  bridge_linux_acl_add_recursive "u:${controller_user}:rwX" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
+  bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:rwX" "$queue_gateway_agent_dir" "$request_dir" "$response_dir"
 
   # memory-daily transcripts read-access (issue #219 v1.3): grant the
   # controller user r-X on the isolated user's ~/.claude/projects/ so the

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -285,8 +285,12 @@ bridge_migration_unisolate() {
   # $log_dir, so the chown -R above misses them, leaving the operator
   # unable to start the agent post-rollback (issue #112).
   local audit_file history_file request_dir response_dir
+  local queue_gateway_root=""
+  local queue_gateway_agent_dir=""
   audit_file="$(bridge_agent_audit_log_file "$agent" 2>/dev/null || true)"
   history_file="$(bridge_history_file_for_agent "$agent" 2>/dev/null || true)"
+  queue_gateway_root="$(bridge_queue_gateway_root 2>/dev/null || true)"
+  queue_gateway_agent_dir="$(bridge_queue_gateway_agent_dir "$agent" 2>/dev/null || true)"
   request_dir="$(bridge_queue_gateway_requests_dir "$agent" 2>/dev/null || true)"
   response_dir="$(bridge_queue_gateway_responses_dir "$agent" 2>/dev/null || true)"
 
@@ -312,6 +316,23 @@ bridge_migration_unisolate() {
     bridge_migration_print_step "$dry_run" "chown -R $controller_user $response_dir"
     if [[ "$dry_run" != "1" ]]; then
       bridge_linux_sudo_root chown -R "$controller_user" "$response_dir" || true
+    fi
+  fi
+  if [[ -n "$queue_gateway_agent_dir" && -d "$queue_gateway_agent_dir" ]]; then
+    bridge_migration_print_step "$dry_run" "chown -R $controller_user $queue_gateway_agent_dir"
+    if [[ "$dry_run" != "1" ]]; then
+      bridge_linux_sudo_root chown -R "$controller_user" "$queue_gateway_agent_dir" || true
+    fi
+  fi
+  # Strip the target os_user from the queue-gateway root (preserve the
+  # controller r-x and any other agents' ACLs). The OS user itself is
+  # intentionally preserved after rollback, so without this the stale
+  # u:<os_user>:--x entry would survive on the shared root.
+  if [[ -n "$queue_gateway_root" && -d "$queue_gateway_root" ]]; then
+    bridge_migration_print_step "$dry_run" "setfacl -x u:${os_user} $queue_gateway_root"
+    if [[ "$dry_run" != "1" ]]; then
+      bridge_linux_sudo_root setfacl -x "u:${os_user}" "$queue_gateway_root" >/dev/null 2>&1 || true
+      bridge_linux_sudo_root setfacl -d -x "u:${os_user}" "$queue_gateway_root" >/dev/null 2>&1 || true
     fi
   fi
 
@@ -394,6 +415,7 @@ bridge_migration_unisolate() {
   [[ -n "$workdir" && -d "$workdir" ]] && acl_strip_paths_recursive+=("$workdir")
   [[ -n "$runtime_state_dir" && -d "$runtime_state_dir" ]] && acl_strip_paths_recursive+=("$runtime_state_dir")
   [[ -n "$log_dir" && -d "$log_dir" ]] && acl_strip_paths_recursive+=("$log_dir")
+  [[ -n "$queue_gateway_agent_dir" && -d "$queue_gateway_agent_dir" ]] && acl_strip_paths_recursive+=("$queue_gateway_agent_dir")
   [[ -n "$request_dir" && -d "$request_dir" ]] && acl_strip_paths_recursive+=("$request_dir")
   [[ -n "$response_dir" && -d "$response_dir" ]] && acl_strip_paths_recursive+=("$response_dir")
   [[ -n "$memory_daily_agent_dir" && -d "$memory_daily_agent_dir" ]] && acl_strip_paths_recursive+=("$memory_daily_agent_dir")

--- a/tests/isolation-queue-gateway-acl.sh
+++ b/tests/isolation-queue-gateway-acl.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# tests/isolation-queue-gateway-acl.sh
+#
+# Targeted regression test for the queue-gateway ACL fix in
+# bridge_linux_prepare_agent_isolation + bridge_migration_unisolate.
+#
+# Verifies:
+#   1. After isolate, the queue-gateway root has controller r-x and isolated
+#      UID --x (traverse-only). The per-agent gateway dir has both UIDs at
+#      rwX with default ACL.
+#   2. The isolated UID cannot enumerate the gateway root (cross-agent
+#      directory-name leak), but its own subtree is reachable.
+#   3. bridge-queue-gateway.py serve-once consumes a synthetic request from
+#      <root>/<agent>/requests and writes a response to
+#      <root>/<agent>/responses.
+#   4. After unisolate, both the access and default ACL entries for the
+#      target os_user are stripped from the gateway root and the per-agent
+#      directory, while the controller's ACLs remain intact.
+#
+# Skip preconditions: Linux, passwordless sudo, setfacl, useradd available.
+# This test creates a temporary system user (default agent-bridge-test-uX)
+# and removes it at the end. Run on a host where you can do that safely.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+log() { printf '[isolate-acl] %s\n' "$*"; }
+die() { printf '[isolate-acl][error] %s\n' "$*" >&2; exit 1; }
+skip() { printf '[isolate-acl][skip] %s\n' "$*"; exit 0; }
+
+# Preconditions.
+[[ "$(uname -s)" == "Linux" ]] || skip "Linux-only test"
+command -v sudo >/dev/null 2>&1 || skip "sudo required"
+sudo -n true >/dev/null 2>&1 || skip "passwordless sudo required"
+command -v setfacl >/dev/null 2>&1 || skip "setfacl (acl package) required"
+command -v useradd >/dev/null 2>&1 || skip "useradd required"
+command -v userdel >/dev/null 2>&1 || skip "userdel required"
+
+# Sandbox under a temp BRIDGE_HOME so we never touch a live install.
+TMP_ROOT="$(mktemp -d -t isolate-acl-test.XXXXXX)"
+SAFE_TMP_PREFIX=""
+for _candidate in "${TMPDIR%/}" "/tmp" "/var/tmp"; do
+  [[ -n "$_candidate" ]] || continue
+  case "$TMP_ROOT" in
+    "$_candidate"|"$_candidate"/*) SAFE_TMP_PREFIX="$_candidate"; break ;;
+  esac
+done
+[[ -n "$SAFE_TMP_PREFIX" ]] || die "TMP_ROOT did not land under a recognised tempdir prefix: $TMP_ROOT"
+
+export BRIDGE_HOME="$TMP_ROOT/bridge-home"
+export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
+export BRIDGE_ROSTER_FILE="$BRIDGE_HOME/agent-roster.sh"
+export BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_HOME/agent-roster.local.sh"
+export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+mkdir -p "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR" "$BRIDGE_SHARED_DIR"
+: > "$BRIDGE_ROSTER_FILE"
+: > "$BRIDGE_ROSTER_LOCAL_FILE"
+
+# Pick a unique temp user. If a previous run left the user behind, reuse it.
+TEST_AGENT="qg-acl-test"
+TEST_OS_USER="agent-bridge-${TEST_AGENT}"
+TEST_OS_HOME="/home/${TEST_OS_USER}"
+
+cleanup_test_user_locked=0
+
+cleanup() {
+  set +e
+  if [[ "$cleanup_test_user_locked" -eq 0 ]] && id "$TEST_OS_USER" >/dev/null 2>&1; then
+    sudo -n userdel "$TEST_OS_USER" >/dev/null 2>&1 || true
+    sudo -n rm -rf "$TEST_OS_HOME" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Make sure the test user exists. If it already exists, we won't delete it
+# at the end (it could belong to a manual run); just clean up the home tree.
+if id "$TEST_OS_USER" >/dev/null 2>&1; then
+  cleanup_test_user_locked=1
+  log "reusing existing OS user $TEST_OS_USER"
+else
+  sudo -n useradd --system --home-dir "$TEST_OS_HOME" --shell /usr/sbin/nologin "$TEST_OS_USER" >/dev/null \
+    || die "useradd failed for $TEST_OS_USER"
+fi
+sudo -n mkdir -p "$TEST_OS_HOME"
+sudo -n chown "$TEST_OS_USER:$TEST_OS_USER" "$TEST_OS_HOME"
+sudo -n chmod 0700 "$TEST_OS_HOME"
+
+# Write a minimal roster entry so bridge_linux_prepare_agent_isolation finds
+# the agent. This emulates what bridge_migration_isolate would have written.
+TEST_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$TEST_AGENT"
+mkdir -p "$TEST_WORKDIR"
+cat > "$BRIDGE_ROSTER_LOCAL_FILE" <<ROSTER
+#!/usr/bin/env bash
+bridge_add_agent_id_if_missing() { :; }
+declare -gA BRIDGE_AGENT_ENGINE BRIDGE_AGENT_SESSION BRIDGE_AGENT_WORKDIR BRIDGE_AGENT_LAUNCH_CMD
+declare -gA BRIDGE_AGENT_ISOLATION_MODE BRIDGE_AGENT_OS_USER
+BRIDGE_AGENT_IDS=("$TEST_AGENT")
+BRIDGE_AGENT_ENGINE[$TEST_AGENT]=claude
+BRIDGE_AGENT_SESSION[$TEST_AGENT]=$TEST_AGENT
+BRIDGE_AGENT_WORKDIR[$TEST_AGENT]=$TEST_WORKDIR
+BRIDGE_AGENT_LAUNCH_CMD[$TEST_AGENT]='true'
+BRIDGE_AGENT_ISOLATION_MODE[$TEST_AGENT]=linux-user
+BRIDGE_AGENT_OS_USER[$TEST_AGENT]=$TEST_OS_USER
+ROSTER
+
+# Run the isolate prepare directly, in the same way bridge_migration_isolate
+# does at the end of its first-time path.
+log "running bridge_linux_prepare_agent_isolation"
+# shellcheck source=../bridge-lib.sh
+source "$REPO_ROOT/bridge-lib.sh"
+bridge_load_roster
+bridge_linux_prepare_agent_isolation "$TEST_AGENT" "$TEST_OS_USER" "$TEST_WORKDIR" "$(id -un)"
+
+# Locate the gateway dirs the prepare function set up.
+QG_ROOT="$(bridge_queue_gateway_root)"
+QG_AGENT_DIR="$(bridge_queue_gateway_agent_dir "$TEST_AGENT")"
+QG_REQUESTS="$(bridge_queue_gateway_requests_dir "$TEST_AGENT")"
+QG_RESPONSES="$(bridge_queue_gateway_responses_dir "$TEST_AGENT")"
+
+# Helper that asserts a getfacl line exists.
+assert_acl_has() {
+  local target="$1" expected="$2"
+  sudo -n getfacl --no-effective "$target" 2>/dev/null | grep -Fq -- "$expected" \
+    || die "expected ACL '$expected' on $target"
+}
+assert_acl_lacks() {
+  local target="$1" forbidden="$2"
+  if sudo -n getfacl --no-effective "$target" 2>/dev/null | grep -Fq -- "$forbidden"; then
+    die "unexpected ACL '$forbidden' present on $target"
+  fi
+}
+
+log "verifying queue-gateway root ACL shape"
+assert_acl_has "$QG_ROOT" "user:$(id -un):r-x"
+assert_acl_has "$QG_ROOT" "user:${TEST_OS_USER}:--x"
+
+log "verifying per-agent dir ACL shape"
+for path in "$QG_AGENT_DIR" "$QG_REQUESTS" "$QG_RESPONSES"; do
+  assert_acl_has "$path" "user:${TEST_OS_USER}:rwx"
+  assert_acl_has "$path" "user:$(id -un):rwx"
+  assert_acl_has "$path" "default:user:${TEST_OS_USER}:rwx"
+  assert_acl_has "$path" "default:user:$(id -un):rwx"
+done
+
+log "verifying isolated UID cannot enumerate the gateway root"
+if sudo -n -u "$TEST_OS_USER" ls "$QG_ROOT" >/dev/null 2>&1; then
+  die "isolated UID should not be able to ls $QG_ROOT"
+fi
+
+log "verifying isolated UID can write+read its own request path"
+sudo -n -u "$TEST_OS_USER" bash -c "echo probe > '$QG_REQUESTS/probe.tmp' && cat '$QG_REQUESTS/probe.tmp' >/dev/null" \
+  || die "isolated UID should be able to write+read its own requests/"
+sudo -n -u "$TEST_OS_USER" rm -f "$QG_REQUESTS/probe.tmp"
+
+log "running bridge-queue-gateway.py serve-once with a Python stub"
+QSTUB="$TMP_ROOT/queue-stub.py"
+cat > "$QSTUB" <<'PY'
+#!/usr/bin/env python3
+import sys
+print("[stub] argv:", sys.argv[1:])
+sys.exit(0)
+PY
+chmod +x "$QSTUB"
+
+# Synthesize a minimal request file the gateway will consume.
+REQ_ID="probe-$(date +%s)"
+REQ_FILE="$QG_REQUESTS/${REQ_ID}.request.json"
+cat > "$REQ_FILE" <<JSON
+{"id": "$REQ_ID", "argv": ["inbox", "$TEST_AGENT"], "agent": "$TEST_AGENT"}
+JSON
+
+PROCESSED="$(python3 "$REPO_ROOT/bridge-queue-gateway.py" serve-once \
+  --root "$QG_ROOT" \
+  --queue-script "$QSTUB" \
+  --max-requests 5 2>&1 || true)"
+[[ "$PROCESSED" == *"1"* ]] || die "serve-once should have processed exactly 1 request, got: $PROCESSED"
+[[ ! -e "$REQ_FILE" ]] || die "serve-once should have consumed $REQ_FILE"
+RESP_FILE="$QG_RESPONSES/${REQ_ID}.json"
+[[ -f "$RESP_FILE" ]] || die "expected serve-once to write response file at $RESP_FILE"
+
+log "running bridge_migration_unisolate to verify the strip path"
+# shellcheck source=../lib/bridge-migration.sh
+source "$REPO_ROOT/lib/bridge-migration.sh"
+bridge_migration_unisolate "$TEST_AGENT" 0
+
+log "verifying gateway root has no leftover entries for the test os_user"
+assert_acl_lacks "$QG_ROOT" "user:${TEST_OS_USER}:"
+assert_acl_lacks "$QG_ROOT" "default:user:${TEST_OS_USER}:"
+assert_acl_has "$QG_ROOT" "user:$(id -un):r-x"
+
+log "verifying per-agent dir has no leftover entries for the test os_user"
+for path in "$QG_AGENT_DIR" "$QG_REQUESTS" "$QG_RESPONSES"; do
+  [[ -d "$path" ]] || continue
+  assert_acl_lacks "$path" "user:${TEST_OS_USER}:"
+  assert_acl_lacks "$path" "default:user:${TEST_OS_USER}:"
+done
+
+log "isolation queue-gateway ACL test passed"


### PR DESCRIPTION
## Summary

`bridge_linux_prepare_agent_isolation` was granting the isolated UID
write access on `<state>/queue-gateway/<agent>/requests` and
`responses` but skipping the parent `<state>/queue-gateway/<agent>/`
directory itself. The same path also never granted the controller
traverse on the gateway root, so the daemon's `bridge-queue-gateway.py
serve-once` glob over the root silently returned an empty list whenever
the root was `root:root 700`.

After today's per-UID Claude credentials fix (#125) shipped, isolation
otherwise worked: an isolated `<agent>` Claude session resumed cleanly,
the sudo wrap engaged, and the agent could read its own credentials.
But as soon as that session ran `agb inbox <agent>`, it hit
`PermissionError` on its own queue-gateway directory, and the daemon's
serve-once silently saw no requests. The shared queue round trip was
broken end-to-end for isolated agents.

This PR adds the missing access/default ACLs in the prepare path and
the matching cleanup in the unisolate path, plus a targeted regression
test that exercises the real `serve-once` entrypoint with a Python
queue-script stub.

## Changes

`lib/bridge-agents.sh`:

* Add the per-agent gateway directory and the gateway root to the
  isolation prepare path. `mkdir -p` ensures both exist before ACLs
  are applied. `recursive_write_paths` includes the per-agent
  directory, so the isolated UID gets `rwX` access plus default ACL.
* Grant the isolated UID `--x` (traverse only) on the gateway root so
  it can reach its own subtree without enumerating peer agents'
  directory names.
* Grant the controller `r-x` on the gateway root and add a default
  ACL so the daemon's `serve-once` glob keeps working and any newly
  created per-agent gateway directory inherits controller access.
* Mirror the controller `rwX` recursive grant + default ACL on the
  per-agent gateway directory.
* Split the new `local` declarations to avoid SC2155.

`lib/bridge-migration.sh` (`bridge_migration_unisolate`):

* `chown -R` the per-agent gateway directory back to the controller.
* Strip the target os_user from the gateway root (access + default)
  while preserving the controller's `r-x` (other isolated agents
  may still depend on it).
* Add the per-agent gateway directory to the recursive ACL strip list.

`tests/isolation-queue-gateway-acl.sh` (new):

* Skips clearly when not Linux, no passwordless sudo, no `setfacl`,
  or no `useradd`/`userdel`.
* Creates a temporary system user, runs `bridge_linux_prepare_agent_isolation`
  + `bridge_migration_unisolate` end to end against a temp BRIDGE_HOME.
* Asserts:
  * Gateway root has controller `r-x` and isolated UID `--x`.
  * Per-agent dir + `requests`/`responses` have rwX access and default
    ACLs for both isolated UID and controller.
  * `sudo -u <os_user> ls <root>` is denied (no cross-agent dir-name
    enumeration).
  * `sudo -u <os_user>` can write+read its own `requests/` path.
  * `bridge-queue-gateway.py serve-once` consumes a synthetic request
    from `requests/` and writes a response to `responses/`, using a
    Python queue-script stub (the gateway invokes the queue script as
    `[sys.executable, str(queue_script), *argv]`).
  * After `unisolate`, both access and default ACL entries for the
    test UID are stripped from the gateway root and per-agent
    directory, while the controller's entries remain.

## Verified

End-to-end on a private deployment with one Claude agent flipped from
`shared` to `linux-user`:

* Fresh `unisolate` → `isolate --install-sudoers` produced the expected
  ACL shape on the gateway root and per-agent directory (verified with
  `getfacl`).
* The isolated session resumed cleanly (no login picker, sudo wrap
  active, `pgrep -f '[b]ridge-run.sh <agent>' | xargs ps -o uid` matched
  the expected `agent-bridge-<agent>` UID).
* A queue `ping` task round-tripped through the gateway:
  isolated UID → gateway request → daemon `serve-once` →
  `bridge-queue.py` → response file → isolated UID claim/done.
  Same cycle that previously hard-failed with permission denied on
  the per-agent gateway directory.
* `unisolate` returned ownership and stripped both the access and
  default ACL entries for the test UID from the gateway root and the
  per-agent directory; the controller's entries remained.

## Test plan

- [x] `bash -n lib/bridge-agents.sh lib/bridge-migration.sh tests/isolation-queue-gateway-acl.sh`
- [x] In-place verification on the affected deployment (described
      above).
- [ ] CI: full smoke + shellcheck.
- [ ] CI: `tests/isolation-queue-gateway-acl.sh` on a Linux runner with
      passwordless sudo + acl + useradd available (skips otherwise).

One non-blocking observation from the in-place verification on this
deployment's smoke: the unrelated MCP orphan-cleanup smoke step
`MCP_ORPHAN_ALIVE=no` reports an unmet expectation. It does not exercise
isolation or queue-gateway code, so I do not believe it is caused by
this change, but flagging it so reviewers can confirm via CI.

## Cross-references

- #125 (closed): per-UID Claude credentials fix that unblocked the
  bridge-run sudo wrap.
- #68 (closed): multi-tenant isolation parent issue.
- The per-agent-dir gap was visible only after #125 made everything
  upstream of it work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
