### PR TITLE
daemon: gate process_channel_health + process_usage_monitor on BRIDGE_*_ENABLED env (split #239 wave 4)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -544,6 +544,7 @@ process_usage_monitor() {
   local source=""
   local body_file=""
 
+  [[ "${BRIDGE_USAGE_MONITOR_ENABLED:-1}" == "1" ]] || return 1
   [[ -n "$admin_agent" ]] || return 1
   bridge_agent_exists "$admin_agent" || return 1
   bridge_usage_due || return 1
@@ -2671,6 +2672,7 @@ process_memory_daily_refresh_requests() {
 process_channel_health() {
   local agent
 
+  [[ "${BRIDGE_CHANNEL_HEALTH_ENABLED:-1}" == "1" ]] || return 1
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do
     [[ -z "$agent" ]] && continue
     bridge_report_channel_health_miss "$agent" || true


### PR DESCRIPTION
## Summary

Wave 4 split from closed PR #239. Bullet 11 daemon-side gates only. Pairs with PR #282 (smoke env exports already in main).

## Files
`bridge-daemon.sh` (+2/-0)

Adds:
- `[[ "${BRIDGE_USAGE_MONITOR_ENABLED:-1}" == "1" ]] || return 1` at start of process_usage_monitor
- `[[ "${BRIDGE_CHANNEL_HEALTH_ENABLED:-1}" == "1" ]] || return 1` at start of process_channel_health

Without these guards the smoke env exports from PR #282 (`BRIDGE_CHANNEL_HEALTH_ENABLED=0`, `BRIDGE_USAGE_MONITOR_ENABLED=0`) were silently dead — both processes still ran on every daemon sync. This restores the gating pattern from PR #239's bullet 11 daemon-side hunks.

## Test plan
- [x] bash -n + shellcheck clean
- [x] Default behavior preserved (env unset → `:-1` default → guard passes → process runs)
- [x] Pairs cleanly with PR #282 smoke env block

🤖 Generated with [Claude Code](https://claude.com/claude-code)