### PR TITLE
state + smoke: safe-mode launch helpers + admin manual-stop guard (split #239 wave 5 bullets 5+13)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -571,6 +571,144 @@ else:
 PY
 }
 
+bridge_build_safe_claude_launch_cmd() {
+  local agent="$1"
+  local fallback=""
+  local continue_mode=""
+  local session_id=""
+
+  fallback="${BRIDGE_AGENT_LAUNCH_CMD[$agent]-}"
+  if [[ -z "$fallback" ]]; then
+    fallback="$(bridge_claude_dynamic_launch_cmd "$agent" 0 0 "")"
+  fi
+
+  continue_mode="$(bridge_agent_continue "$agent")"
+  if [[ "$continue_mode" == "1" ]]; then
+    session_id="$(bridge_claude_resume_session_id_for_agent "$agent" 2>/dev/null || true)"
+  fi
+
+  bridge_require_python
+  python3 - "$agent" "$continue_mode" "$session_id" "$fallback" <<'PY'
+import re
+import shlex
+import sys
+
+agent, continue_mode, session_id, original = sys.argv[1:]
+match = re.match(r"^(?P<prefix>.*?)(?P<command>claude(?:\s|$).*)$", original)
+if not match:
+    print(original)
+    raise SystemExit(0)
+
+env_prefix = match.group("prefix")
+args = shlex.split(match.group("command"))
+if not args or args[0] != "claude":
+    print(original)
+    raise SystemExit(0)
+
+rest = args[1:]
+extras = []
+i = 0
+while i < len(rest):
+    token = rest[i]
+    if token in {"-c", "--continue", "--dangerously-skip-permissions"}:
+        i += 1
+        continue
+    if token in {"--resume", "--name", "--channels"}:
+        i += 2 if i + 1 < len(rest) else 1
+        continue
+    if token.startswith("--channels="):
+        i += 1
+        continue
+    if token == "--dangerously-load-development-channels":
+        i += 1
+        while i < len(rest) and not rest[i].startswith("-"):
+            i += 1
+        continue
+    if token.startswith("--dangerously-load-development-channels="):
+        i += 1
+        continue
+    extras.append(token)
+    if token.startswith("--") and i + 1 < len(rest) and not rest[i + 1].startswith("-"):
+        extras.append(rest[i + 1])
+        i += 2
+        continue
+    i += 1
+
+base = ["claude"]
+if continue_mode == "1" and session_id:
+    base.extend(["--resume", session_id])
+elif continue_mode == "1":
+    base.append("--continue")
+base.extend(["--dangerously-skip-permissions", "--name", agent])
+base.extend(extras)
+
+quoted = " ".join(shlex.quote(token) for token in base)
+if env_prefix:
+    print(f"{env_prefix}{quoted}")
+else:
+    print(quoted)
+PY
+}
+
+bridge_safe_mode_resume_mode() {
+  local agent="$1"
+  local engine=""
+  local session_id=""
+
+  [[ "$(bridge_agent_continue "$agent")" == "1" ]] || {
+    printf '%s' "fresh"
+    return 0
+  }
+
+  engine="$(bridge_agent_engine "$agent")"
+  case "$engine" in
+    claude)
+      session_id="$(bridge_claude_resume_session_id_for_agent "$agent" 2>/dev/null || true)"
+      if [[ -n "$session_id" ]]; then
+        printf '%s' "resume"
+      else
+        printf '%s' "continue"
+      fi
+      ;;
+    codex)
+      bridge_normalize_agent_session_id "$agent"
+      session_id="$(bridge_agent_session_id "$agent")"
+      if [[ -n "$session_id" ]]; then
+        printf '%s' "resume"
+      else
+        printf '%s' "fresh"
+      fi
+      ;;
+    *)
+      printf '%s' "fresh"
+      ;;
+  esac
+}
+
+bridge_build_safe_launch_cmd() {
+  local agent="$1"
+  local engine=""
+  local launch_cmd=""
+
+  engine="$(bridge_agent_engine "$agent")"
+  case "$engine" in
+    claude)
+      bridge_build_safe_claude_launch_cmd "$agent"
+      ;;
+    codex)
+      if launch_cmd="$(bridge_build_resume_launch_cmd "$agent")"; then
+        bridge_codex_launch_with_hooks "$launch_cmd"
+      else
+        launch_cmd="$(bridge_build_dynamic_launch_cmd "$agent")"
+        bridge_codex_launch_with_hooks "$launch_cmd"
+      fi
+      ;;
+    *)
+      printf '%s' "${BRIDGE_AGENT_LAUNCH_CMD[$agent]-}"
+      ;;
+  esac
+}
+
 bridge_agent_launch_cmd() {
   local agent="$1"
   local fallback=""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7041,6 +7041,9 @@ cat >"$ADMIN_CRASH_ERRFILE" <<'EOF'
 admin fatal: runtime auth missing
 EOF
 "$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_write_crash_report \"$SMOKE_AGENT\" \"codex\" \"5\" \"2\" \"$ADMIN_CRASH_ERRFILE\" 'codex --dangerously-bypass-approvals-and-sandbox --no-alt-screen'"
+# The upgrade-restart fixture manual-stops most static roles; this block needs
+# the admin path to be active so the daemon exercises direct admin alerting.
+"$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_clear_manual_stop \"$SMOKE_AGENT\""
 PRE_ADMIN_CRASH_ALERTS="$("$REPO_ROOT/agent-bridge" audit --action crash_loop_admin_alert --limit 20 --json)"
 BRIDGE_DAEMON_NOTIFY_DRY_RUN=1 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 POST_ADMIN_CRASH_ALERTS="$("$REPO_ROOT/agent-bridge" audit --action crash_loop_admin_alert --limit 20 --json)"


### PR DESCRIPTION
Wave 5 split from closed PR #239. Final bullets — 5 (safe-mode launch helpers, 138 LOC in lib/bridge-state.sh) + 13 (admin manual-stop guard, 3 LOC in scripts/smoke-test.sh). All dependent helpers (bridge_agent_clear_manual_stop, bridge_manual_stop_agent_session, bridge-run.sh --safe-mode wiring) already in main from earlier work. Diff matches PR #239 surface area. See commit message for detail.