### PR TITLE
daemon: heartbeat file + launchd/systemd liveness watcher (issue #265 proposal D)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -51,6 +51,23 @@ cd ~/.agent-bridge
 launchctl print gui/$UID/ai.agent-bridge.daemon
 ```
 
+`agb bootstrap` also installs a sibling LaunchAgent / systemd timer
+(`ai.agent-bridge.daemon-liveness` on macOS,
+`agent-bridge-daemon-liveness.timer` on Linux) that watches
+`state/daemon.heartbeat`. KeepAlive only catches process death; the
+liveness watcher catches the silent-hang case (issue #265) where the
+daemon process is alive but its main loop has frozen. It restarts the
+daemon when the heartbeat mtime exceeds
+`BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS` (default 600s) and honours
+`BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS` (default 600s) to avoid
+restart loops on a broken daemon. Pass `--skip-liveness` to `bootstrap`
+to opt out, or invoke the installer directly:
+
+```bash
+./scripts/install-daemon-liveness-launchagent.sh --apply --load    # macOS
+./scripts/install-daemon-liveness-systemd.sh --apply --enable      # Linux
+```
+
 Check overall status:
 
 ```bash
@@ -64,6 +81,8 @@ If the daemon misbehaves, inspect live runtime logs:
 tail -n 80 ~/.agent-bridge/state/daemon.log
 tail -n 80 ~/.agent-bridge/state/daemon-crash.log
 tail -n 80 ~/.agent-bridge/state/launchagent.log
+tail -n 80 ~/.agent-bridge/state/launchagent-liveness.log     # macOS liveness watcher
+tail -n 80 ~/.agent-bridge/state/systemd-daemon-liveness.log  # Linux liveness watcher
 ```
 
 ## Upgrade

--- a/bridge-bootstrap.sh
+++ b/bridge-bootstrap.sh
@@ -19,6 +19,7 @@ Bootstrap options:
   --skip-daemon
   --skip-launchagent      Do not install/load the macOS LaunchAgent
   --skip-systemd          Do not install/enable the Linux systemd user unit
+  --skip-liveness         Do not install the daemon liveness watcher (issue #265 D)
   --dry-run
   --json
 
@@ -37,6 +38,7 @@ skip_shell_integration=0
 skip_daemon=0
 skip_launchagent=0
 skip_systemd=0
+skip_liveness=0
 dry_run=0
 json_mode=0
 init_args=()
@@ -67,6 +69,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-systemd)
       skip_systemd=1
+      shift
+      ;;
+    --skip-liveness)
+      skip_liveness=1
       shift
       ;;
     --dry-run)
@@ -113,6 +119,7 @@ shell_status="skipped"
 daemon_status="skipped"
 launchagent_status="skipped"
 systemd_status="skipped"
+liveness_status="skipped"
 next_command="agb admin"
 reload_command="source \"$bootstrap_rcfile\" || export PATH=\"\$HOME/.agent-bridge:\$PATH\""
 bootstrap_os="${BRIDGE_BOOTSTRAP_OS:-$(uname -s)}"
@@ -161,8 +168,42 @@ if [[ $skip_systemd -eq 0 ]]; then
   fi
 fi
 
+# Issue #265 proposal D: install the OS-level liveness watcher alongside the
+# daemon plist/unit. Skip if the operator opted out, if the matching daemon
+# install was skipped (no point watching a heartbeat that nothing writes), or
+# if the platform is unsupported.
+if [[ $skip_liveness -eq 0 ]]; then
+  case "$bootstrap_os" in
+    Darwin)
+      if [[ $skip_launchagent -eq 1 ]]; then
+        liveness_status="skipped"
+      else
+        liveness_status="planned"
+        if [[ $dry_run -eq 0 ]]; then
+          "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/scripts/install-daemon-liveness-launchagent.sh" --apply --load >/dev/null
+          liveness_status="loaded"
+        fi
+      fi
+      ;;
+    Linux)
+      if [[ $skip_systemd -eq 1 ]]; then
+        liveness_status="skipped"
+      else
+        liveness_status="planned"
+        if [[ $dry_run -eq 0 ]]; then
+          "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/scripts/install-daemon-liveness-systemd.sh" --apply --enable >/dev/null
+          liveness_status="enabled"
+        fi
+      fi
+      ;;
+    *)
+      liveness_status="unsupported"
+      ;;
+  esac
+fi
+
 if [[ $json_mode -eq 1 ]]; then
-  python3 - "$init_json" "$shell_status" "$bootstrap_shell" "$bootstrap_rcfile" "$daemon_status" "$launchagent_status" "$systemd_status" "$next_command" "$reload_command" <<'PY'
+  python3 - "$init_json" "$shell_status" "$bootstrap_shell" "$bootstrap_rcfile" "$daemon_status" "$launchagent_status" "$systemd_status" "$next_command" "$reload_command" "$liveness_status" <<'PY'
 import json
 import sys
 
@@ -178,6 +219,7 @@ payload = {
     "daemon": {"status": sys.argv[5]},
     "launchagent": {"status": sys.argv[6]},
     "systemd": {"status": sys.argv[7]},
+    "liveness": {"status": sys.argv[10]},
     "next_command": sys.argv[8],
     "reload_command": sys.argv[9],
     "handoff_steps": [
@@ -204,6 +246,7 @@ printf 'shell_integration: %s\n' "$shell_status"
 printf 'daemon: %s\n' "$daemon_status"
 printf 'launchagent: %s\n' "$launchagent_status"
 printf 'systemd: %s\n' "$systemd_status"
+printf 'liveness: %s\n' "$liveness_status"
 printf 'rc_reload_command: %s\n' "$reload_command"
 echo
 echo "handoff:"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3688,6 +3688,14 @@ cmd_run() {
         --detail interval_seconds="$BRIDGE_DAEMON_INTERVAL" \
         --detail heartbeat_interval_seconds="$heartbeat_interval" \
         2>/dev/null || true
+      # Issue #265 proposal D: also touch a heartbeat file so an OS-level
+      # watcher (launchd LaunchAgent on macOS, systemd .timer unit on Linux)
+      # can compare its mtime against a staleness threshold and restart the
+      # daemon when the main loop stops advancing. The file lives outside the
+      # daemon process tree, so a hung daemon cannot interfere with it being
+      # observed. See scripts/bridge-daemon-liveness.sh and
+      # scripts/install-daemon-liveness-{launchagent,systemd}.sh.
+      printf '%s\n' "$now_ts" >"$BRIDGE_STATE_DIR/daemon.heartbeat" 2>/dev/null || true
       last_heartbeat_ts="$now_ts"
     fi
     BRIDGE_DAEMON_LAST_STEP="idle_sleep"

--- a/scripts/bridge-daemon-liveness.sh
+++ b/scripts/bridge-daemon-liveness.sh
@@ -113,7 +113,7 @@ cooldown_active() {
   # Returns 0 (true) when last restart attempt is within cooldown window.
   local last_ts now
   [[ -f "$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" ]] || return 1
-  last_ts="$(cat "$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" 2>/dev/null | tr -d '[:space:]')"
+  last_ts="$(tr -d '[:space:]' <"$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" 2>/dev/null)"
   [[ "$last_ts" =~ ^[0-9]+$ ]] || return 1
   now="$(now_ts)"
   (( now - last_ts < BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS ))

--- a/scripts/bridge-daemon-liveness.sh
+++ b/scripts/bridge-daemon-liveness.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# bridge-daemon-liveness.sh — issue #265 proposal D
+#
+# OS-level liveness watcher for the Agent Bridge daemon. Designed to run
+# OUTSIDE the daemon process tree (under launchd on macOS or systemd .timer
+# on Linux) so a hung daemon main loop cannot prevent the watcher from
+# observing it.
+#
+# Behavior:
+#   1. Read mtime of $BRIDGE_STATE_DIR/daemon.heartbeat (touched by
+#      bridge-daemon.sh::cmd_run on every BRIDGE_DAEMON_HEARTBEAT_SECONDS
+#      tick — see commit that added the printf next to bridge_audit_log
+#      daemon_tick).
+#   2. If the file does not exist, do nothing — fresh install or daemon
+#      not yet started; let the daemon's normal start path establish the
+#      baseline.
+#   3. If mtime is younger than BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS
+#      (default 600s = 10 min), do nothing.
+#   4. If stale AND the daemon pid is recorded AND alive, AND the cooldown
+#      since the last restart attempt has elapsed, run
+#      `bridge-daemon.sh stop && bridge-daemon.sh start`. Cooldown prevents
+#      a broken daemon from triggering a restart-loop every minute.
+#   5. If stale but the daemon is not running, do nothing — the normal
+#      start path (launchd KeepAlive / systemd Restart=always) will bring
+#      it back; the liveness watcher only addresses the silent-hang case
+#      where the process is alive but the loop has frozen.
+#
+# Audit:
+#   Writes one of `daemon_liveness_ok`, `daemon_liveness_skip_no_baseline`,
+#   `daemon_liveness_skip_not_running`, `daemon_liveness_skip_cooldown`,
+#   `daemon_liveness_restart_attempt`, or `daemon_liveness_restart_failed`
+#   to $BRIDGE_AUDIT_LOG when bridge-audit.py is invokable. Failures to
+#   write audit are non-fatal — the watcher's job is restarting, not
+#   logging.
+#
+# Environment:
+#   BRIDGE_HOME                                  default $HOME/.agent-bridge
+#   BRIDGE_STATE_DIR                             default $BRIDGE_HOME/state
+#   BRIDGE_AUDIT_LOG                             default $BRIDGE_HOME/logs/audit.jsonl
+#   BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS     default 600
+#   BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS      default 600
+#   BRIDGE_DAEMON_HEARTBEAT_FILE                 default $BRIDGE_STATE_DIR/daemon.heartbeat
+#   BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE         default $BRIDGE_STATE_DIR/daemon-liveness-cooldown.ts
+#   BRIDGE_DAEMON_LIVENESS_DRY_RUN               set to 1 to log the decision but skip the actual stop/start
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+: "${BRIDGE_HOME:=$HOME/.agent-bridge}"
+: "${BRIDGE_STATE_DIR:=$BRIDGE_HOME/state}"
+: "${BRIDGE_AUDIT_LOG:=$BRIDGE_HOME/logs/audit.jsonl}"
+: "${BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS:=600}"
+: "${BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS:=600}"
+: "${BRIDGE_DAEMON_HEARTBEAT_FILE:=$BRIDGE_STATE_DIR/daemon.heartbeat}"
+: "${BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE:=$BRIDGE_STATE_DIR/daemon-liveness-cooldown.ts}"
+: "${BRIDGE_DAEMON_LIVENESS_DRY_RUN:=0}"
+
+# Sanitize numeric envs — fall back to defaults on garbage so a typo in a
+# launchd EnvironmentVariables block can't disable the watcher.
+[[ "$BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS" =~ ^[0-9]+$ ]] || BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS=600
+[[ "$BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS" =~ ^[0-9]+$ ]]  || BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS=600
+
+DAEMON_SH="$REPO_ROOT/bridge-daemon.sh"
+DAEMON_PID_FILE="${BRIDGE_DAEMON_PID_FILE:-$BRIDGE_STATE_DIR/daemon.pid}"
+
+now_ts() { date +%s; }
+
+file_mtime() {
+  # macOS / BSD: stat -f %m. Linux / GNU coreutils: stat -c %Y.
+  local f="$1"
+  local mtime
+  if mtime="$(stat -f %m "$f" 2>/dev/null)"; then
+    printf '%s\n' "$mtime"
+    return 0
+  fi
+  if mtime="$(stat -c %Y "$f" 2>/dev/null)"; then
+    printf '%s\n' "$mtime"
+    return 0
+  fi
+  return 1
+}
+
+emit_audit() {
+  # Best-effort JSON-line audit. We deliberately do not source bridge-lib.sh
+  # (heavy: pulls in tmux/queue/state modules) just for one log line — the
+  # python script is small and standalone.
+  local action="$1"
+  shift || true
+  local audit_py="$REPO_ROOT/bridge-audit.py"
+  [[ -x "$audit_py" || -f "$audit_py" ]] || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+  mkdir -p "$(dirname "$BRIDGE_AUDIT_LOG")" 2>/dev/null || true
+  python3 "$audit_py" write \
+    --file "$BRIDGE_AUDIT_LOG" \
+    --actor daemon_liveness \
+    --action "$action" \
+    --target daemon \
+    "$@" >/dev/null 2>&1 || true
+}
+
+daemon_pid_alive() {
+  local pid
+  [[ -f "$DAEMON_PID_FILE" ]] || return 1
+  pid="$(head -n1 "$DAEMON_PID_FILE" 2>/dev/null | tr -d '[:space:]')"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  printf '%s\n' "$pid"
+}
+
+cooldown_active() {
+  # Returns 0 (true) when last restart attempt is within cooldown window.
+  local last_ts now
+  [[ -f "$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" ]] || return 1
+  last_ts="$(cat "$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" 2>/dev/null | tr -d '[:space:]')"
+  [[ "$last_ts" =~ ^[0-9]+$ ]] || return 1
+  now="$(now_ts)"
+  (( now - last_ts < BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS ))
+}
+
+record_cooldown() {
+  mkdir -p "$(dirname "$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE")" 2>/dev/null || true
+  printf '%s\n' "$(now_ts)" >"$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" 2>/dev/null || true
+}
+
+restart_daemon() {
+  local pid="$1"
+  local age="$2"
+  local stop_rc=0
+  local start_rc=0
+  emit_audit daemon_liveness_restart_attempt \
+    --detail pid="$pid" \
+    --detail heartbeat_age_seconds="$age" \
+    --detail threshold_seconds="$BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS"
+  record_cooldown
+  if [[ "$BRIDGE_DAEMON_LIVENESS_DRY_RUN" == "1" ]]; then
+    printf '[liveness] DRY_RUN — would restart daemon pid=%s age=%ss\n' "$pid" "$age"
+    return 0
+  fi
+  # Use BRIDGE_HOME's daemon script so the watcher targets the same install
+  # root the heartbeat file was observed in. The launchd plist sets
+  # BRIDGE_HOME explicitly; override via env if running by hand.
+  if ! bash "$DAEMON_SH" stop >/dev/null 2>&1; then
+    stop_rc=$?
+  fi
+  if ! bash "$DAEMON_SH" start >/dev/null 2>&1; then
+    start_rc=$?
+    emit_audit daemon_liveness_restart_failed \
+      --detail stop_rc="$stop_rc" \
+      --detail start_rc="$start_rc"
+    return 1
+  fi
+  printf '[liveness] restarted daemon pid=%s age=%ss\n' "$pid" "$age"
+  return 0
+}
+
+main() {
+  local mtime now age pid
+
+  if [[ ! -f "$BRIDGE_DAEMON_HEARTBEAT_FILE" ]]; then
+    emit_audit daemon_liveness_skip_no_baseline \
+      --detail heartbeat_file="$BRIDGE_DAEMON_HEARTBEAT_FILE"
+    return 0
+  fi
+
+  if ! mtime="$(file_mtime "$BRIDGE_DAEMON_HEARTBEAT_FILE")"; then
+    emit_audit daemon_liveness_skip_no_baseline \
+      --detail heartbeat_file="$BRIDGE_DAEMON_HEARTBEAT_FILE" \
+      --detail reason="stat_failed"
+    return 0
+  fi
+
+  now="$(now_ts)"
+  age=$(( now - mtime ))
+
+  if (( age < BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS )); then
+    emit_audit daemon_liveness_ok \
+      --detail heartbeat_age_seconds="$age" \
+      --detail threshold_seconds="$BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS"
+    return 0
+  fi
+
+  if ! pid="$(daemon_pid_alive)"; then
+    # No live process to kill. launchd's KeepAlive / systemd's Restart=always
+    # handles the "process gone" case; the liveness watcher exists for the
+    # silent-hang case. Be conservative and stay out of the way.
+    emit_audit daemon_liveness_skip_not_running \
+      --detail heartbeat_age_seconds="$age" \
+      --detail threshold_seconds="$BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS"
+    return 0
+  fi
+
+  if cooldown_active; then
+    emit_audit daemon_liveness_skip_cooldown \
+      --detail pid="$pid" \
+      --detail heartbeat_age_seconds="$age" \
+      --detail cooldown_seconds="$BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS"
+    return 0
+  fi
+
+  restart_daemon "$pid" "$age"
+}
+
+main "$@"

--- a/scripts/install-daemon-liveness-launchagent.sh
+++ b/scripts/install-daemon-liveness-launchagent.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# install-daemon-liveness-launchagent.sh — issue #265 proposal D
+#
+# Installs a separate macOS LaunchAgent that runs
+# scripts/bridge-daemon-liveness.sh every BRIDGE_DAEMON_LIVENESS_INTERVAL
+# seconds (default 60s). The watcher itself decides whether to restart the
+# daemon based on the heartbeat-file mtime — see scripts/bridge-daemon-liveness.sh.
+#
+# This is intentionally a sibling LaunchAgent of ai.agent-bridge.daemon, not
+# a property added to the daemon plist itself, because the daemon plist's
+# KeepAlive only restarts on process exit. The hang vector documented in
+# issue #265 leaves the process alive but the loop frozen, which KeepAlive
+# does not detect.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+BRIDGE_HOME_DEFAULT="${HOME}/.agent-bridge"
+BRIDGE_HOME_TARGET="$BRIDGE_HOME_DEFAULT"
+LABEL_DEFAULT="ai.agent-bridge.daemon-liveness"
+LABEL="$LABEL_DEFAULT"
+PLIST_PATH=""
+LOG_PATH=""
+APPLY=0
+LOAD=0
+BASH_PATH=""
+INTERVAL="${BRIDGE_DAEMON_LIVENESS_INTERVAL:-60}"
+THRESHOLD="${BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS:-600}"
+COOLDOWN="${BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS:-600}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--bridge-home <dir>] [--label <launchd-label>] [--plist <path>] [--log-path <path>] [--interval <secs>] [--threshold <secs>] [--cooldown <secs>] [--apply] [--load]
+
+Without --apply, prints the LaunchAgent plist for the daemon liveness watcher.
+With --apply, writes the plist to ~/Library/LaunchAgents (or --plist target).
+With --load, also bootstraps and kickstarts the LaunchAgent after writing.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bridge-home)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      BRIDGE_HOME_TARGET="$2"
+      shift 2
+      ;;
+    --label)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      LABEL="$2"
+      shift 2
+      ;;
+    --plist)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      PLIST_PATH="$2"
+      shift 2
+      ;;
+    --log-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      LOG_PATH="$2"
+      shift 2
+      ;;
+    --interval)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      INTERVAL="$2"
+      shift 2
+      ;;
+    --threshold)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      THRESHOLD="$2"
+      shift 2
+      ;;
+    --cooldown)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      COOLDOWN="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --load)
+      APPLY=1
+      LOAD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[error] unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+[[ "$INTERVAL" =~ ^[0-9]+$ ]]  || { echo "[error] --interval must be an integer (got: $INTERVAL)" >&2; exit 1; }
+[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || { echo "[error] --threshold must be an integer (got: $THRESHOLD)" >&2; exit 1; }
+[[ "$COOLDOWN" =~ ^[0-9]+$ ]]  || { echo "[error] --cooldown must be an integer (got: $COOLDOWN)" >&2; exit 1; }
+
+[[ -n "$PLIST_PATH" ]] || PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+[[ -n "$LOG_PATH" ]] || LOG_PATH="$BRIDGE_HOME_TARGET/state/launchagent-liveness.log"
+
+for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+  [[ -n "$candidate" && -x "$candidate" ]] || continue
+  BASH_PATH="$candidate"
+  break
+done
+
+if [[ -z "$BASH_PATH" ]]; then
+  echo "[error] bash not found" >&2
+  exit 1
+fi
+
+# We deliberately point at $BRIDGE_HOME_TARGET/scripts/bridge-daemon-liveness.sh
+# (the deployed live-install copy), not at the source checkout. That way the
+# watcher tracks whatever the upgrader laid down, same convention the daemon
+# plist uses.
+PLIST_CONTENT="$(cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>${BASH_PATH}</string>
+    <string>${BRIDGE_HOME_TARGET}/scripts/bridge-daemon-liveness.sh</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>${BRIDGE_HOME_TARGET}</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>BRIDGE_HOME</key>
+    <string>${BRIDGE_HOME_TARGET}</string>
+    <key>BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS</key>
+    <string>${THRESHOLD}</string>
+    <key>BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS</key>
+    <string>${COOLDOWN}</string>
+  </dict>
+
+  <key>StartInterval</key>
+  <integer>${INTERVAL}</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>${LOG_PATH}</string>
+
+  <key>StandardErrorPath</key>
+  <string>${LOG_PATH}</string>
+</dict>
+</plist>
+EOF
+)"
+
+if [[ $APPLY -eq 0 ]]; then
+  printf 'plist_path: %s\n' "$PLIST_PATH"
+  printf 'bridge_home: %s\n' "$BRIDGE_HOME_TARGET"
+  printf 'log_path: %s\n' "$LOG_PATH"
+  printf 'interval_seconds: %s\n' "$INTERVAL"
+  printf 'threshold_seconds: %s\n' "$THRESHOLD"
+  printf 'cooldown_seconds: %s\n\n' "$COOLDOWN"
+  printf '%s\n' "$PLIST_CONTENT"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$PLIST_PATH")" "$(dirname "$LOG_PATH")"
+printf '%s\n' "$PLIST_CONTENT" >"$PLIST_PATH"
+echo "[info] wrote LaunchAgent plist: $PLIST_PATH"
+
+if [[ $LOAD -eq 1 ]]; then
+  launchctl bootout "gui/$UID/$LABEL" >/dev/null 2>&1 || true
+  launchctl bootstrap "gui/$UID" "$PLIST_PATH"
+  launchctl enable "gui/$UID/$LABEL" >/dev/null 2>&1 || true
+  launchctl kickstart "gui/$UID/$LABEL"
+  echo "[info] loaded LaunchAgent: $LABEL"
+  echo "[info] inspect with: launchctl print gui/$UID/$LABEL"
+fi
+
+echo "[info] bridge_home: $BRIDGE_HOME_TARGET"
+echo "[info] log_path: $LOG_PATH"
+echo "[info] plist_path: $PLIST_PATH"
+echo "[info] interval_seconds: $INTERVAL"
+echo "[info] threshold_seconds: $THRESHOLD"
+echo "[info] cooldown_seconds: $COOLDOWN"

--- a/scripts/install-daemon-liveness-systemd.sh
+++ b/scripts/install-daemon-liveness-systemd.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# install-daemon-liveness-systemd.sh — issue #265 proposal D
+#
+# Installs a systemd --user .service + .timer pair that runs
+# scripts/bridge-daemon-liveness.sh every BRIDGE_DAEMON_LIVENESS_INTERVAL
+# seconds (default 60s). Same role as the macOS LaunchAgent variant — see
+# scripts/install-daemon-liveness-launchagent.sh and
+# scripts/bridge-daemon-liveness.sh for the design rationale.
+#
+# We pair the .service with a .timer rather than using a Path-unit on the
+# heartbeat file, because the silent-hang case is `mtime stops advancing`,
+# not `mtime changes`. A timer-driven poll is the natural fit.
+
+set -euo pipefail
+
+BRIDGE_HOME_TARGET="${HOME}/.agent-bridge"
+SERVICE_NAME="agent-bridge-daemon-liveness.service"
+TIMER_NAME="agent-bridge-daemon-liveness.timer"
+SERVICE_PATH=""
+TIMER_PATH=""
+LOG_PATH=""
+APPLY=0
+ENABLE=0
+BASH_PATH=""
+INTERVAL="${BRIDGE_DAEMON_LIVENESS_INTERVAL:-60}"
+THRESHOLD="${BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS:-600}"
+COOLDOWN="${BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS:-600}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--bridge-home <dir>] [--service <name>] [--timer <name>] [--service-path <path>] [--timer-path <path>] [--log-path <path>] [--interval <secs>] [--threshold <secs>] [--cooldown <secs>] [--apply] [--enable]
+
+Without --apply, prints the systemd user .service and .timer unit files.
+With --apply, writes both units to ~/.config/systemd/user (or --service-path / --timer-path targets).
+With --enable, also runs systemctl --user daemon-reload and enable --now on the timer.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bridge-home)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      BRIDGE_HOME_TARGET="$2"
+      shift 2
+      ;;
+    --service)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SERVICE_NAME="$2"
+      shift 2
+      ;;
+    --timer)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      TIMER_NAME="$2"
+      shift 2
+      ;;
+    --service-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SERVICE_PATH="$2"
+      shift 2
+      ;;
+    --timer-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      TIMER_PATH="$2"
+      shift 2
+      ;;
+    --log-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      LOG_PATH="$2"
+      shift 2
+      ;;
+    --interval)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      INTERVAL="$2"
+      shift 2
+      ;;
+    --threshold)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      THRESHOLD="$2"
+      shift 2
+      ;;
+    --cooldown)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      COOLDOWN="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --enable)
+      APPLY=1
+      ENABLE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[error] unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+[[ "$INTERVAL" =~ ^[0-9]+$ ]]  || { echo "[error] --interval must be an integer (got: $INTERVAL)" >&2; exit 1; }
+[[ "$THRESHOLD" =~ ^[0-9]+$ ]] || { echo "[error] --threshold must be an integer (got: $THRESHOLD)" >&2; exit 1; }
+[[ "$COOLDOWN" =~ ^[0-9]+$ ]]  || { echo "[error] --cooldown must be an integer (got: $COOLDOWN)" >&2; exit 1; }
+
+[[ -n "$SERVICE_PATH" ]] || SERVICE_PATH="$HOME/.config/systemd/user/$SERVICE_NAME"
+[[ -n "$TIMER_PATH" ]] || TIMER_PATH="$HOME/.config/systemd/user/$TIMER_NAME"
+[[ -n "$LOG_PATH" ]] || LOG_PATH="$BRIDGE_HOME_TARGET/state/systemd-daemon-liveness.log"
+
+for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)" /bin/bash; do
+  [[ -n "$candidate" && -x "$candidate" ]] || continue
+  BASH_PATH="$candidate"
+  break
+done
+
+if [[ -z "$BASH_PATH" ]]; then
+  echo "[error] bash not found" >&2
+  exit 1
+fi
+
+SERVICE_CONTENT="$(cat <<EOF
+[Unit]
+Description=Agent Bridge Daemon Liveness Watcher
+After=agent-bridge-daemon.service
+
+[Service]
+Type=oneshot
+ExecStart=${BASH_PATH} ${BRIDGE_HOME_TARGET}/scripts/bridge-daemon-liveness.sh
+WorkingDirectory=${BRIDGE_HOME_TARGET}
+Environment=BRIDGE_HOME=${BRIDGE_HOME_TARGET}
+Environment=BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS=${THRESHOLD}
+Environment=BRIDGE_DAEMON_LIVENESS_COOLDOWN_SECONDS=${COOLDOWN}
+StandardOutput=append:${LOG_PATH}
+StandardError=append:${LOG_PATH}
+EOF
+)"
+
+TIMER_CONTENT="$(cat <<EOF
+[Unit]
+Description=Agent Bridge Daemon Liveness Watcher (timer)
+
+[Timer]
+OnBootSec=${INTERVAL}
+OnUnitInactiveSec=${INTERVAL}
+Unit=${SERVICE_NAME}
+
+[Install]
+WantedBy=timers.target
+EOF
+)"
+
+if [[ $APPLY -eq 0 ]]; then
+  printf 'service_path: %s\n' "$SERVICE_PATH"
+  printf 'timer_path: %s\n' "$TIMER_PATH"
+  printf 'bridge_home: %s\n' "$BRIDGE_HOME_TARGET"
+  printf 'log_path: %s\n' "$LOG_PATH"
+  printf 'service: %s\n' "$SERVICE_NAME"
+  printf 'timer: %s\n' "$TIMER_NAME"
+  printf 'interval_seconds: %s\n' "$INTERVAL"
+  printf 'threshold_seconds: %s\n' "$THRESHOLD"
+  printf 'cooldown_seconds: %s\n\n' "$COOLDOWN"
+  printf '# %s\n' "$SERVICE_NAME"
+  printf '%s\n\n' "$SERVICE_CONTENT"
+  printf '# %s\n' "$TIMER_NAME"
+  printf '%s\n' "$TIMER_CONTENT"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$SERVICE_PATH")" "$(dirname "$TIMER_PATH")" "$(dirname "$LOG_PATH")"
+printf '%s\n' "$SERVICE_CONTENT" >"$SERVICE_PATH"
+printf '%s\n' "$TIMER_CONTENT" >"$TIMER_PATH"
+echo "[info] wrote systemd user service: $SERVICE_PATH"
+echo "[info] wrote systemd user timer:   $TIMER_PATH"
+
+if [[ $ENABLE -eq 1 ]]; then
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "[error] systemctl not found; wrote units but cannot enable" >&2
+    exit 1
+  fi
+  systemctl --user daemon-reload
+  systemctl --user enable --now "$TIMER_NAME"
+  echo "[info] enabled systemd user timer: $TIMER_NAME"
+  echo "[info] inspect with: systemctl --user status $TIMER_NAME"
+fi
+
+echo "[info] bridge_home: $BRIDGE_HOME_TARGET"
+echo "[info] log_path: $LOG_PATH"
+echo "[info] service_path: $SERVICE_PATH"
+echo "[info] timer_path: $TIMER_PATH"
+echo "[info] interval_seconds: $INTERVAL"
+echo "[info] threshold_seconds: $THRESHOLD"
+echo "[info] cooldown_seconds: $COOLDOWN"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -4001,7 +4001,103 @@ payload = json.loads(sys.argv[1])
 assert payload["mode"] == "bootstrap"
 assert payload["launchagent"]["status"] == "skipped"
 assert payload["systemd"]["status"] == "planned"
+# Issue #265 D: when systemd is planned and the operator did not pass
+# --skip-liveness, the liveness watcher should be planned alongside it.
+assert payload["liveness"]["status"] == "planned", payload["liveness"]
 PY
+
+# Issue #265 proposal D — render the OS liveness installers without
+# touching launchctl/systemctl, then exercise the checker against fake
+# heartbeat states in an isolated state dir. Keeps the tests safe to run
+# on any host (no daemon restart side effects).
+log "rendering daemon-liveness launchagent + systemd installers (issue #265 D)"
+LIVENESS_LAUNCHAGENT_OUTPUT="$("$REPO_ROOT/scripts/install-daemon-liveness-launchagent.sh" --bridge-home "$BRIDGE_HOME")"
+assert_contains "$LIVENESS_LAUNCHAGENT_OUTPUT" "<key>Label</key>"
+assert_contains "$LIVENESS_LAUNCHAGENT_OUTPUT" "ai.agent-bridge.daemon-liveness"
+assert_contains "$LIVENESS_LAUNCHAGENT_OUTPUT" "<key>StartInterval</key>"
+assert_contains "$LIVENESS_LAUNCHAGENT_OUTPUT" "bridge-daemon-liveness.sh"
+assert_contains "$LIVENESS_LAUNCHAGENT_OUTPUT" "BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS"
+
+LIVENESS_SYSTEMD_OUTPUT="$("$REPO_ROOT/scripts/install-daemon-liveness-systemd.sh" --bridge-home "$BRIDGE_HOME")"
+assert_contains "$LIVENESS_SYSTEMD_OUTPUT" "agent-bridge-daemon-liveness.service"
+assert_contains "$LIVENESS_SYSTEMD_OUTPUT" "agent-bridge-daemon-liveness.timer"
+assert_contains "$LIVENESS_SYSTEMD_OUTPUT" "OnUnitInactiveSec="
+assert_contains "$LIVENESS_SYSTEMD_OUTPUT" "BRIDGE_DAEMON_LIVENESS_THRESHOLD_SECONDS="
+
+log "exercising daemon-liveness checker decisions (issue #265 D)"
+LIVENESS_TMP="$TMP_ROOT/liveness"
+mkdir -p "$LIVENESS_TMP/state" "$LIVENESS_TMP/logs"
+LIVENESS_HEARTBEAT="$LIVENESS_TMP/state/daemon.heartbeat"
+LIVENESS_PIDFILE="$LIVENESS_TMP/state/daemon.pid"
+LIVENESS_AUDIT="$LIVENESS_TMP/logs/audit.jsonl"
+LIVENESS_COOLDOWN="$LIVENESS_TMP/state/daemon-liveness-cooldown.ts"
+
+# 1. No baseline: no heartbeat file at all -> skip_no_baseline, no restart.
+rm -f "$LIVENESS_HEARTBEAT" "$LIVENESS_PIDFILE" "$LIVENESS_COOLDOWN" "$LIVENESS_AUDIT"
+BRIDGE_HOME="$LIVENESS_TMP" \
+  BRIDGE_STATE_DIR="$LIVENESS_TMP/state" \
+  BRIDGE_AUDIT_LOG="$LIVENESS_AUDIT" \
+  BRIDGE_DAEMON_PID_FILE="$LIVENESS_PIDFILE" \
+  BRIDGE_DAEMON_LIVENESS_DRY_RUN=1 \
+  bash "$REPO_ROOT/scripts/bridge-daemon-liveness.sh" >/dev/null 2>&1 \
+  || die "liveness checker no-baseline run exited non-zero"
+assert_contains "$(cat "$LIVENESS_AUDIT" 2>/dev/null)" "daemon_liveness_skip_no_baseline"
+
+# 2. Fresh heartbeat: file mtime is now -> ok, no restart.
+rm -f "$LIVENESS_AUDIT"
+date +%s >"$LIVENESS_HEARTBEAT"
+BRIDGE_HOME="$LIVENESS_TMP" \
+  BRIDGE_STATE_DIR="$LIVENESS_TMP/state" \
+  BRIDGE_AUDIT_LOG="$LIVENESS_AUDIT" \
+  BRIDGE_DAEMON_PID_FILE="$LIVENESS_PIDFILE" \
+  BRIDGE_DAEMON_LIVENESS_DRY_RUN=1 \
+  bash "$REPO_ROOT/scripts/bridge-daemon-liveness.sh" >/dev/null 2>&1 \
+  || die "liveness checker fresh-heartbeat run exited non-zero"
+assert_contains "$(cat "$LIVENESS_AUDIT" 2>/dev/null)" "daemon_liveness_ok"
+
+# 3. Stale heartbeat but daemon not running: skip_not_running.
+rm -f "$LIVENESS_AUDIT" "$LIVENESS_PIDFILE"
+date +%s >"$LIVENESS_HEARTBEAT"
+# Backdate to 1 hour ago via touch -t (works on macOS BSD touch and GNU touch).
+LIVENESS_PAST="$(date -v-1H +%Y%m%d%H%M.%S 2>/dev/null || date -d '1 hour ago' +%Y%m%d%H%M.%S)"
+touch -t "$LIVENESS_PAST" "$LIVENESS_HEARTBEAT"
+BRIDGE_HOME="$LIVENESS_TMP" \
+  BRIDGE_STATE_DIR="$LIVENESS_TMP/state" \
+  BRIDGE_AUDIT_LOG="$LIVENESS_AUDIT" \
+  BRIDGE_DAEMON_PID_FILE="$LIVENESS_PIDFILE" \
+  BRIDGE_DAEMON_LIVENESS_DRY_RUN=1 \
+  bash "$REPO_ROOT/scripts/bridge-daemon-liveness.sh" >/dev/null 2>&1 \
+  || die "liveness checker stale-no-pid run exited non-zero"
+assert_contains "$(cat "$LIVENESS_AUDIT" 2>/dev/null)" "daemon_liveness_skip_not_running"
+
+# 4. Stale heartbeat AND a live daemon pid: dry-run records restart_attempt
+# and writes the cooldown file. Use the smoke shell's own pid as the
+# "alive daemon" — kill -0 succeeds and we never actually call stop/start
+# because BRIDGE_DAEMON_LIVENESS_DRY_RUN=1.
+rm -f "$LIVENESS_AUDIT" "$LIVENESS_COOLDOWN"
+echo "$$" >"$LIVENESS_PIDFILE"
+touch -t "$LIVENESS_PAST" "$LIVENESS_HEARTBEAT"
+BRIDGE_HOME="$LIVENESS_TMP" \
+  BRIDGE_STATE_DIR="$LIVENESS_TMP/state" \
+  BRIDGE_AUDIT_LOG="$LIVENESS_AUDIT" \
+  BRIDGE_DAEMON_PID_FILE="$LIVENESS_PIDFILE" \
+  BRIDGE_DAEMON_LIVENESS_DRY_RUN=1 \
+  bash "$REPO_ROOT/scripts/bridge-daemon-liveness.sh" >/dev/null 2>&1 \
+  || die "liveness checker stale-with-pid dry-run exited non-zero"
+assert_contains "$(cat "$LIVENESS_AUDIT" 2>/dev/null)" "daemon_liveness_restart_attempt"
+[[ -f "$LIVENESS_COOLDOWN" ]] || die "liveness checker did not record cooldown ts"
+
+# 5. Stale heartbeat, live pid, but cooldown still active: skip_cooldown.
+rm -f "$LIVENESS_AUDIT"
+touch -t "$LIVENESS_PAST" "$LIVENESS_HEARTBEAT"
+BRIDGE_HOME="$LIVENESS_TMP" \
+  BRIDGE_STATE_DIR="$LIVENESS_TMP/state" \
+  BRIDGE_AUDIT_LOG="$LIVENESS_AUDIT" \
+  BRIDGE_DAEMON_PID_FILE="$LIVENESS_PIDFILE" \
+  BRIDGE_DAEMON_LIVENESS_DRY_RUN=1 \
+  bash "$REPO_ROOT/scripts/bridge-daemon-liveness.sh" >/dev/null 2>&1 \
+  || die "liveness checker cooldown run exited non-zero"
+assert_contains "$(cat "$LIVENESS_AUDIT" 2>/dev/null)" "daemon_liveness_skip_cooldown"
 
 log "surfacing bootstrap failure output and parsing tokenFile dotenv values"
 cat >"$TOKENFILE_ENV" <<'EOF'


### PR DESCRIPTION
Proposal D from #265. External OS-level watcher restarts daemon when heartbeat file ages past 600s threshold. Test: bash -n + shellcheck clean, targeted stale/fresh paths verified. Real install deferred to operator.