### PR TITLE
daemon: classify interactive pickers and escalate to admin instead of nudging

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -759,6 +759,12 @@ bridge_stall_retry_seconds() {
     network)
       printf '%s' "${BRIDGE_STALL_NETWORK_RETRY_SECONDS:-60}"
       ;;
+    interactive_picker)
+      # Pickers expect a single keystroke (Enter / 1 / n), not a text nudge.
+      # Daemon does not retry; the main loop routes the picker straight to
+      # the admin escalation branch, so any retry value would be dead config.
+      printf '%s' "0"
+      ;;
     unknown)
       printf '%s' "${BRIDGE_STALL_UNKNOWN_RETRY_SECONDS:-300}"
       ;;
@@ -772,6 +778,14 @@ bridge_stall_escalate_after_seconds() {
   local classification="$1"
   case "$classification" in
     auth)
+      printf '%s' "0"
+      ;;
+    interactive_picker)
+      # Picker stalls block all forward progress on the affected agent
+      # and require a deliberate keypress decision; escalate immediately
+      # like auth. The main loop hardwires this path and ignores any
+      # configured delay, so we hardcode 0 instead of reading an env var
+      # the daemon would silently disregard.
       printf '%s' "0"
       ;;
     network)
@@ -789,7 +803,15 @@ bridge_stall_escalate_after_seconds() {
 bridge_stall_title_prefix() {
   local classification="$1"
   local agent="$2"
-  printf '[STALL/%s] %s ' "${classification^^}" "$agent"
+  case "$classification" in
+    interactive_picker)
+      # Short alias keeps the dedupe prefix in sync with bridge_stall_title.
+      printf '[STALL/PICKER] %s ' "$agent"
+      ;;
+    *)
+      printf '[STALL/%s] %s ' "${classification^^}" "$agent"
+      ;;
+  esac
 }
 
 bridge_stall_title() {
@@ -804,6 +826,9 @@ bridge_stall_title() {
       ;;
     network)
       printf '[STALL/NETWORK] %s retry failed' "$agent"
+      ;;
+    interactive_picker)
+      printf '[STALL/PICKER] %s blocked on interactive picker' "$agent"
       ;;
     *)
       printf '[STALL/UNKNOWN] %s appears stuck' "$agent"
@@ -820,6 +845,11 @@ bridge_stall_nudge_message() {
     network)
       printf '%s' "A transient network or provider error was detected. Retry the current task and continue if the connection is healthy now."
       ;;
+    interactive_picker)
+      # Never typed into the pane (picker would treat it as a stray keypress);
+      # surfaces only in audit/report context strings.
+      printf '%s' "An interactive picker is blocking the session. Routing to the admin agent for a keypress decision."
+      ;;
     *)
       printf '%s' "The current task appears stalled. Check the current state, summarize what is blocking progress, and continue if work can proceed."
       ;;
@@ -832,6 +862,7 @@ bridge_stall_reason_label() {
     rate_limit) printf '%s' "rate-limit/capacity" ;;
     auth) printf '%s' "authentication/session" ;;
     network) printf '%s' "network/provider" ;;
+    interactive_picker) printf '%s' "interactive-picker" ;;
     *) printf '%s' "unknown" ;;
   esac
 }
@@ -1183,15 +1214,21 @@ process_stall_reports() {
     escalate_after="$(bridge_stall_escalate_after_seconds "$classification")"
     [[ "$escalate_after" =~ ^[0-9]+$ ]] || escalate_after=0
 
-    if [[ "$classification" == "auth" ]]; then
+    if [[ "$classification" == "auth" || "$classification" == "interactive_picker" ]]; then
       if (( escalated_ts == 0 )); then
         title="$(bridge_stall_title "$classification" "$agent")"
         title_prefix="$(bridge_stall_title_prefix "$classification" "$agent")"
-        recommended="Manual repair is required. Re-authenticate the agent and restart the session once credentials are healthy."
+        if [[ "$classification" == "interactive_picker" ]]; then
+          recommended="An interactive picker is blocking the agent's tmux pane. Inspect the captured output, choose a key for the safe default (Enter selects the first option — usually 'Stop and wait for limit to reset' or 'Resume from summary'), and send it via tmux send-keys. Escalate to the operator before choosing options that change billing or plan ('Switch to extra usage', 'Switch to Team plan')."
+          notify_summary="Interactive picker is blocking ${agent}. The admin agent must choose a keypress (Enter for default) or escalate to the operator before any billing-impact option."
+        else
+          recommended="Manual repair is required. Re-authenticate the agent and restart the session once credentials are healthy."
+          notify_summary="Authentication/session stall detected for ${agent}. Manual re-login is required."
+        fi
         body_file="$(bridge_agent_stall_report_file "$agent" "$classification")"
         bridge_write_stall_report_body "$agent" "$session" "$classification" "$idle" "$claimed" "$nudge_count" "$first_detected_ts" "$matched_pattern" "$excerpt" "$body_file" "$recommended"
         if [[ "$agent" == "$admin_agent" ]] && bridge_agent_has_notify_transport "$admin_agent"; then
-          bridge_notify_send "$admin_agent" "$title" "Authentication/session stall detected for ${agent}. Manual re-login is required." "" urgent "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
+          bridge_notify_send "$admin_agent" "$title" "$notify_summary" "" urgent "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
           escalated_ts="$now_ts"
           bridge_audit_log daemon stall_escalated "$admin_agent" \
             --detail agent="$agent" \

--- a/bridge-stall.py
+++ b/bridge-stall.py
@@ -14,6 +14,29 @@ from pathlib import Path
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 PATTERN_GROUPS: list[tuple[str, list[str]]] = [
+    # interactive_picker comes first: when a session shows the rate-limit
+    # picker the pane also contains "hit your limit" (rate_limit), but the
+    # correct action is to escalate to the admin agent for a keypress
+    # decision — not to retry-nudge the picker, which would type generic
+    # text into the picker prompt and be ignored. first-match-wins routes
+    # mixed-pane cases to the picker handler.
+    (
+        "interactive_picker",
+        # Each pattern is line-anchored with re.MULTILINE so that prose like
+        # "if billing permits, switch to extra usage for this job" cannot
+        # classify as a picker. Real Claude Code pickers render each option
+        # on its own line as "<glyph or whitespace> <number>. <option text>",
+        # and the prompt tail is the verbatim "Enter to confirm · Esc to
+        # cancel" line.
+        [
+            r"(?m)^[ \t❯>]*\d+\.\s+Stop and wait for limit to reset\s*$",
+            r"(?m)^[ \t❯>]*\d+\.\s+Switch to extra usage\s*$",
+            r"(?m)^[ \t❯>]*\d+\.\s+Switch to Team plan\s*$",
+            r"(?m)^[ \t❯>]*\d+\.\s+Resume from summary \(recommended\)\s*$",
+            r"(?m)^[ \t❯>]*\d+\.\s+Resume full session as-is\s*$",
+            r"(?m)^Enter to confirm · Esc to cancel\s*$",
+        ],
+    ),
     (
         "rate_limit",
         [

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7163,10 +7163,12 @@ log "detecting and recovering stalled sessions"
 STALL_RATE_AGENT="stall-rate-$SESSION_NAME"
 STALL_AUTH_AGENT="stall-auth-$SESSION_NAME"
 STALL_UNKNOWN_AGENT="stall-unknown-$SESSION_NAME"
+STALL_PICKER_AGENT="stall-picker-$SESSION_NAME"
 STALL_RATE_WORKDIR="$TMP_ROOT/$STALL_RATE_AGENT"
 STALL_AUTH_WORKDIR="$TMP_ROOT/$STALL_AUTH_AGENT"
 STALL_UNKNOWN_WORKDIR="$TMP_ROOT/$STALL_UNKNOWN_AGENT"
-mkdir -p "$STALL_RATE_WORKDIR" "$STALL_AUTH_WORKDIR" "$STALL_UNKNOWN_WORKDIR"
+STALL_PICKER_WORKDIR="$TMP_ROOT/$STALL_PICKER_AGENT"
+mkdir -p "$STALL_RATE_WORKDIR" "$STALL_AUTH_WORKDIR" "$STALL_UNKNOWN_WORKDIR" "$STALL_PICKER_WORKDIR"
 cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
 
 bridge_add_agent_id_if_missing "$STALL_RATE_AGENT"
@@ -7189,6 +7191,13 @@ BRIDGE_AGENT_ENGINE["$STALL_UNKNOWN_AGENT"]="claude"
 BRIDGE_AGENT_SESSION["$STALL_UNKNOWN_AGENT"]="$STALL_UNKNOWN_AGENT"
 BRIDGE_AGENT_WORKDIR["$STALL_UNKNOWN_AGENT"]="$STALL_UNKNOWN_WORKDIR"
 BRIDGE_AGENT_LAUNCH_CMD["$STALL_UNKNOWN_AGENT"]='claude --dangerously-skip-permissions'
+
+bridge_add_agent_id_if_missing "$STALL_PICKER_AGENT"
+BRIDGE_AGENT_DESC["$STALL_PICKER_AGENT"]="Stall interactive picker role"
+BRIDGE_AGENT_ENGINE["$STALL_PICKER_AGENT"]="claude"
+BRIDGE_AGENT_SESSION["$STALL_PICKER_AGENT"]="$STALL_PICKER_AGENT"
+BRIDGE_AGENT_WORKDIR["$STALL_PICKER_AGENT"]="$STALL_PICKER_WORKDIR"
+BRIDGE_AGENT_LAUNCH_CMD["$STALL_PICKER_AGENT"]='claude --dangerously-skip-permissions'
 EOF
 
 STALL_RATE_SCRIPT="$TMP_ROOT/stall-rate.py"
@@ -7221,10 +7230,31 @@ sys.stdout.flush()
 for _ in sys.stdin:
     pass
 PY
-chmod +x "$STALL_RATE_SCRIPT" "$STALL_AUTH_SCRIPT" "$STALL_UNKNOWN_SCRIPT"
+STALL_PICKER_SCRIPT="$TMP_ROOT/stall-picker.py"
+cat >"$STALL_PICKER_SCRIPT" <<'PY'
+#!/usr/bin/env python3
+# Simulates the Claude Code /rate-limit-options picker. Mixed-pane case
+# (rate_limit phrase + picker text) — first-match-wins must classify the
+# pane as interactive_picker so the daemon escalates instead of nudging.
+import sys
+print("You've hit your limit · resets in 1h")
+print("")
+print("What do you want to do?")
+print("")
+print("❯ 1. Stop and wait for limit to reset")
+print("  2. Switch to extra usage")
+print("  3. Switch to Team plan")
+print("")
+print("Enter to confirm · Esc to cancel")
+sys.stdout.flush()
+for _ in sys.stdin:
+    pass
+PY
+chmod +x "$STALL_RATE_SCRIPT" "$STALL_AUTH_SCRIPT" "$STALL_UNKNOWN_SCRIPT" "$STALL_PICKER_SCRIPT"
 tmux new-session -d -s "$STALL_RATE_AGENT" "$STALL_RATE_SCRIPT"
 tmux new-session -d -s "$STALL_AUTH_AGENT" "$STALL_AUTH_SCRIPT"
 tmux new-session -d -s "$STALL_UNKNOWN_AGENT" "$STALL_UNKNOWN_SCRIPT"
+tmux new-session -d -s "$STALL_PICKER_AGENT" "$STALL_PICKER_SCRIPT"
 sleep 1
 bash "$REPO_ROOT/bridge-sync.sh" >/dev/null
 
@@ -7301,7 +7331,42 @@ bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 UNKNOWN_STALL_TASK_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[STALL/UNKNOWN] $STALL_UNKNOWN_AGENT " 2>/dev/null || true)"
 [[ "$UNKNOWN_STALL_TASK_ID" =~ ^[0-9]+$ ]] || die "expected unknown stall escalation"
 
+STALL_PICKER_CREATE_OUTPUT="$("$REPO_ROOT/agent-bridge" task create --to "$STALL_PICKER_AGENT" --title "stall picker" --body "smoke" --from smoke)"
+STALL_PICKER_TASK_ID="$(printf '%s\n' "$STALL_PICKER_CREATE_OUTPUT" | sed -n 's/^created task #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+[[ "$STALL_PICKER_TASK_ID" =~ ^[0-9]+$ ]] || die "expected picker stall task id"
+python3 "$REPO_ROOT/bridge-queue.py" claim "$STALL_PICKER_TASK_ID" --agent "$STALL_PICKER_AGENT" >/dev/null
+BRIDGE_STALL_SCAN_ENABLED=1 \
+BRIDGE_STALL_SCAN_INTERVAL_SECONDS=0 \
+BRIDGE_STALL_EXPLICIT_IDLE_SECONDS=0 \
+bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
+PICKER_STALL_TASK_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[STALL/PICKER] $STALL_PICKER_AGENT " 2>/dev/null || true)"
+[[ "$PICKER_STALL_TASK_ID" =~ ^[0-9]+$ ]] || die "expected picker stall escalation"
+BRIDGE_STALL_SCAN_ENABLED=1 \
+BRIDGE_STALL_SCAN_INTERVAL_SECONDS=0 \
+BRIDGE_STALL_EXPLICIT_IDLE_SECONDS=0 \
+bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
+# Use --all so dedupe is proven by *count* of open tasks, not just by the
+# first match (which would be stable even if a duplicate were also created).
+PICKER_OPEN_COUNT="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[STALL/PICKER] $STALL_PICKER_AGENT " --all --format json 2>/dev/null | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))')"
+[[ "$PICKER_OPEN_COUNT" == "1" ]] || die "expected exactly one open [STALL/PICKER] task after second sync (got $PICKER_OPEN_COUNT)"
+PICKER_STALL_TASK_ID_AGAIN="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[STALL/PICKER] $STALL_PICKER_AGENT " 2>/dev/null || true)"
+[[ "$PICKER_STALL_TASK_ID_AGAIN" == "$PICKER_STALL_TASK_ID" ]] || die "expected deduped picker stall escalation, got '$PICKER_STALL_TASK_ID_AGAIN' vs '$PICKER_STALL_TASK_ID'"
+PICKER_NUDGE_COUNT="$(python3 - "$BRIDGE_HOME/logs/audit.jsonl" "$STALL_PICKER_AGENT" <<'PY'
+import json, sys
+count = 0
+for raw in open(sys.argv[1], encoding="utf-8"):
+    item = json.loads(raw)
+    if item.get("action") == "stall_nudge_sent" and item.get("target") == sys.argv[2]:
+        count += 1
+print(count)
+PY
+)"
+[[ "$PICKER_NUDGE_COUNT" == "0" ]] || die "expected zero stall nudges for picker stall, got '$PICKER_NUDGE_COUNT'"
+
 tmux_kill_session_exact "$STALL_RATE_AGENT" || true
+tmux_kill_session_exact "$STALL_AUTH_AGENT" || true
+tmux_kill_session_exact "$STALL_UNKNOWN_AGENT" || true
+tmux_kill_session_exact "$STALL_PICKER_AGENT" || true
 BRIDGE_STALL_SCAN_ENABLED=1 \
 BRIDGE_STALL_SCAN_INTERVAL_SECONDS=0 \
 BRIDGE_STALL_EXPLICIT_IDLE_SECONDS=0 \


### PR DESCRIPTION
## Summary

- Adds `interactive_picker` stall classification with line-anchored multiline regexes for the Claude Code `/rate-limit-options` picker, the `claude --resume` long-resume picker, and the verbatim picker tail.
- Routes picker stalls through the same admin-escalation branch as `auth` (no nudge — picker takes a keystroke, not text — and an immediate `[STALL/PICKER]` task to the admin agent) with a picker-specific recommended message and notify summary that distinguishes safe-default keys (Enter) from billing-impact options that the admin must escalate to the operator.
- Smoke coverage: a picker-shaped fixture session asserts (a) one `[STALL/PICKER]` task on first sync, (b) `find-open --all` count stays at 1 on second sync (true dedupe, not first-id stability), (c) zero `stall_nudge_sent` rows for the picker agent.

## Why

Claude Code sessions that block on `/rate-limit-options` or "Resume from summary" pickers used to classify as `rate_limit` / `unknown`. The daemon then typed a text nudge into the pane; the picker, waiting for a single keystroke, ignored it. Every daemon tick re-typed the same nudge, agents stayed stuck, and queue items piled up until an operator noticed by eye (observed 2026-04-25: `syrs-buzz`, `syrs-derm` blocked on rate-limit picker; 22 cron-followups accumulated for the admin agent before the pattern was caught).

The intent of the daemon is to be a dumb watchdog: detect, not decide. Picker stalls require a deliberate keypress decision (which key, and when to escalate billing changes to the operator) — that belongs in the admin agent's queue, not in a generic retry loop.

This PR closes [#272 \(comment\)-class fragility](https://github.com/SYRS-AI/agent-bridge-public/issues/272) on the daemon side: the daemon now hands picker decisions back to the admin AI instead of typing text into a UI that cannot consume it.

## Design intent

- daemon = stateless watchdog: classify the pane, route. No keystrokes, no judgment calls.
- patch (admin agent) = AI: reads the captured pane, picks the safe default for `Stop and wait`/`Resume from summary recommended`, **escalates** to the operator for billing-impact options (`Switch to extra usage`, `Switch to Team plan`).
- This mirrors how `auth` stalls are already handled today — `interactive_picker` joins the same fast path.

## Pattern hardening

The picker patterns are line-anchored (`(?m)^[ \t❯>]*\d+\.\s+<option>\s*$`) so prose like `if billing permits, switch to extra usage for this job` does not classify as a picker. The picker tail (`Enter to confirm · Esc to cancel`) is a verbatim full-line match. Verified against:

- false-positive prose: `Switch to extra usage`, `Stop and wait for limit to reset`, `Resume full session as-is`, `Don't ask me again` substring forms — all `(empty)` classification ✓
- real multi-line picker fixtures (rate-limit + long-resume) — both classify as `interactive_picker` ✓
- regression: pure `rate_limit_exceeded` prose still classifies as `rate_limit` ✓

## Files

- `bridge-stall.py` — new `interactive_picker` group, ordered before `rate_limit` so mixed panes (picker + "hit your limit") classify as picker (first-match-wins routes to escalation, which is the safer action).
- `bridge-daemon.sh` — `bridge_stall_retry_seconds`, `bridge_stall_escalate_after_seconds`, `bridge_stall_title`, `bridge_stall_title_prefix`, `bridge_stall_reason_label`, `bridge_stall_nudge_message` all gain a `PICKER` arm. Title/title-prefix use the short alias `[STALL/PICKER]` so `find-open` dedupe stays consistent. Main trigger merges `auth || interactive_picker` into the same admin-escalation block, but the `recommended`/`notify_summary` strings are split per classification so a picker stall on the admin agent does not surface as "Authentication/session stall detected".
- `scripts/smoke-test.sh` — `STALL_PICKER_AGENT` fixture + assertions.

## Test plan

- [x] `python3 -m py_compile bridge-stall.py`
- [x] `bash -n bridge-daemon.sh scripts/smoke-test.sh`
- [x] targeted `bridge-stall.py analyze` probes (false-positive prose, both picker fixtures, rate-limit regression) — see `Pattern hardening` above
- [ ] full `scripts/smoke-test.sh` end-to-end — not run on this machine (sandbox/launchd restrictions); the picker assertions are line-shaped after the existing rate/auth/unknown blocks so any harness that runs the suite will exercise them. Reviewer's note in the review thread confirms static review only.

## Process notes

This change went through one plan-review round and three code-review rounds with `agb-dev-syrs`:

- plan: `bridge_stall_title_prefix` sync, direct-notify body picker arm, `bridge_stall_reason_label` arm, smoke assertion shape — all integrated.
- code r1 → r2: pattern over-broad on generic phrases (`Don't ask me again`, `Resume from summary`); env vars added but not honored; smoke dedupe used `find-open` first-match (LIMIT 1) which would not detect duplicates → tightened patterns, dropped env vars (now hardcoded `0`), switched smoke check to `find-open --all` count.
- code r2 → r3: remaining picker patterns were still substring matches, not anchored picker lines → switched to `(?m)^[ \t❯>]*\d+\.\s+<option>\s*$`.
- code r3: approved (no findings).

## Related

- #272 (per-agent MCP/plugin isolation) — same operator-pain incident surfaced this picker-stall path; this PR addresses the picker side, #272 covers the broader plugin-spawn side.
- #161 stall-detector bare timeout regex — same family of detector-precision work.
- #264 stall-detector classifies agent's own output as fresh stall — adjacent detector hygiene.
- #265 daemon main loop child timeout watchdog — different family of daemon-side fragility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)