### PR TITLE
cron: opt-in --strict-mcp-config for disposable Claude children (partial #263)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -182,3 +182,22 @@ Operator guidance:
 - After a `launchd`/`systemd` respawn cascade, look first at `logs/audit.jsonl` filtered to `actor=daemon` — every exit pairs `daemon_exit` with the prior `daemon_tick` (showing which loop step was active before the silence), `daemon_subprocess_timeout` (showing which call_site hung), or `daemon_silence_*` (showing supervisor-initiated restarts).
 - `state/launchagent.log` keeps the same line in plain text for hosts where the audit log is unreadable.
 - The original v0.4.2 → v0.6.0 specific hypotheses in #194 (post-upgrade python helper missing, plugin MCP liveness restart against gone session, librarian cron cascade) refer to code paths that no longer exist in their #194-era form; the chain of fixes above either removed them or made them externally observable. Treat #194 as historical — if a similar respawn cascade reappears on a current install, file a fresh issue with the `daemon_exit` audit excerpt rather than reopening #194.
+## 12. Disposable cron child cold-start latency
+
+Current behavior:
+
+- Each native cron fire spawns a fresh `claude -p --no-session-persistence ...` child via `bridge-cron-runner.py`. That child cold-loads the Claude CLI binary, every MCP server wired into the agent's plugin set, and a new session bootstrap.
+- On warm hosts this adds several seconds per fire; on memory-pressured hosts (e.g. 8 GB Mac mini) it can push the child past `BRIDGE_CRON_SUBAGENT_TIMEOUT_SECONDS` before user code runs (issue #263).
+- Most polling/reminder crons (`event-reminder-30min`, `cs-line-poll-5m`, etc.) never call MCP tools, so the MCP cold-load is pure waste.
+
+Mitigation (applied from #263):
+
+- Per-job opt-in: set `metadata.disableMcp` (or `disable_mcp` / `disposableDisableMcp` / `disposable_disable_mcp`) on a cron job to launch its disposable child with `--strict-mcp-config` and no `--mcp-config`, which loads zero MCP servers. Local benchmark on a warm host: claude `-p` cold start dropped from ~5–10 s real / ~2.9 s user to ~3.2–3.7 s real / ~0.6 s user (~78% CPU saved per fire).
+- Ops A/B switch: `BRIDGE_CRON_DISPOSABLE_DISABLE_MCP=1` in the runtime env forces every cron child to skip MCP regardless of per-job config; `=0` forces it on. Unset defers to per-job metadata. Use this to roll the change install-wide before annotating individual jobs.
+- Safety override: jobs with `metadata.disposableNeedsChannels=true` (channel-relay flow) keep MCP enabled even when the flag asks otherwise — the relay path still needs channel MCP servers to deliver.
+
+Operator guidance:
+
+- Tag every `*/N`-minute polling cron whose body is "fetch + summarise" with `metadata.disableMcp=true`. Reminder/scheduler families are the highest-leverage targets.
+- Leave the flag unset for any cron whose payload calls MCP tools (e.g. plugin-driven research, workspace MCP queries).
+- This addresses MCP cold-load only. The CLI binary load and session bootstrap remain per-fire; warm-pool / runtime-substitution work tracked in #263 follow-ups.

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -179,6 +179,27 @@ def disposable_needs_channels(request: dict[str, Any]) -> bool:
     return bool_flag(request.get("disposable_needs_channels"))
 
 
+def disable_mcp_for_request(request: dict[str, Any]) -> bool:
+    """#263: decide whether the disposable child should launch with MCP disabled.
+
+    Order of precedence:
+      1. ``BRIDGE_CRON_DISPOSABLE_DISABLE_MCP`` env override (ops A/B switch).
+         Set to ``1``/``true`` to force-disable MCP for every cron child;
+         ``0``/``false`` to force-enable. Unset to defer to per-job config.
+      2. ``request['disable_mcp']`` from the job's ``metadata.disableMcp``
+         (or aliases) wired through ``bridge_cron_write_request``.
+      3. ``request['disposable_needs_channels']`` — channel relays need MCP
+         servers loaded to deliver, so we never disable in that case even if
+         the per-job flag says so. This is a safety override.
+    """
+    if disposable_needs_channels(request):
+        return False
+    override = os.environ.get("BRIDGE_CRON_DISPOSABLE_DISABLE_MCP")
+    if override is not None and override.strip():
+        return bool_flag(override)
+    return bool_flag(request.get("disable_mcp"))
+
+
 def build_prompt(request: dict[str, Any], payload_text: str) -> str:
     allow_channel_delivery = bool_flag(request.get("allow_channel_delivery"))
     child_channels_enabled = disposable_needs_channels(request)
@@ -377,6 +398,11 @@ def run_claude(request: dict[str, Any], prompt: str, timeout: int, request_file:
     ]
     if channels and disposable_needs_channels(request):
         command[2:2] = ["--channels", ",".join(channels)]
+    # #263: when MCP is opt-disabled, pass --strict-mcp-config without any
+    # --mcp-config so the child loads zero MCP servers. Cuts cold-start cost
+    # for cron payloads that do not use MCP tools (the common case).
+    if disable_mcp_for_request(request):
+        command[2:2] = ["--strict-mcp-config"]
     env = apply_channel_runtime_env(request, runner_env())
     if request_file is not None:
         env["CRON_REQUEST_DIR"] = str(request_file.parent)

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -290,6 +290,18 @@ def build_job_record(job):
         "disposable_needs_channels": bool(
             metadata.get("disposableNeedsChannels") or metadata.get("disposable_needs_channels")
         ),
+        # #263: opt-in flag that tells the disposable cron child to launch
+        # without any MCP servers. Eliminates per-fire MCP cold-start cost for
+        # cron payloads that do not call MCP tools (the common case for
+        # polling/reminder crons). Recognised aliases:
+        #   metadata.disableMcp / disable_mcp
+        #   metadata.disposableDisableMcp / disposable_disable_mcp
+        "disable_mcp": bool(
+            metadata.get("disableMcp")
+            or metadata.get("disable_mcp")
+            or metadata.get("disposableDisableMcp")
+            or metadata.get("disposable_disable_mcp")
+        ),
         "payload_text": payload_text,
         "payload_preview": preview_text(payload_text),
         "raw": job,
@@ -404,6 +416,7 @@ def serialize_record(record, include_payload=False):
         "job_delivery_target": record["job_delivery_target"],
         "allow_channel_delivery": record["allow_channel_delivery"],
         "disposable_needs_channels": record["disposable_needs_channels"],
+        "disable_mcp": record["disable_mcp"],
         "payload_preview": record["payload_preview"],
     }
     if include_payload:

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -384,6 +384,7 @@ run_enqueue() {
   local job_delivery_target=""
   local allow_channel_delivery="0"
   local disposable_needs_channels="0"
+  local disable_mcp="0"
   local target_channels=""
   local target_discord_state_dir=""
   local target_telegram_state_dir=""
@@ -498,6 +499,7 @@ run_enqueue() {
   job_delivery_target="${CRON_JOB_JOB_DELIVERY_TARGET:-}"
   allow_channel_delivery="${CRON_JOB_ALLOW_CHANNEL_DELIVERY:-0}"
   disposable_needs_channels="${CRON_JOB_DISPOSABLE_NEEDS_CHANNELS:-0}"
+  disable_mcp="${CRON_JOB_DISABLE_MCP:-0}"
   request_rel="${request_file#$BRIDGE_HOME/}"
   result_rel="${result_file#$BRIDGE_HOME/}"
   status_rel="${status_file#$BRIDGE_HOME/}"
@@ -569,7 +571,7 @@ except Exception:
   # task_id=0 is a sentinel placeholder; real queue id is patched in below
   # via bridge_cron_update_*_task_id once the queue record exists.
   created_at="$(bridge_now_iso)"
-  bridge_cron_write_request "$request_file" "$run_id" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$jobs_file" "$CRON_JOB_PAYLOAD_KIND" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels"
+  bridge_cron_write_request "$request_file" "$run_id" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$jobs_file" "$CRON_JOB_PAYLOAD_KIND" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels" "$disable_mcp"
   bridge_cron_write_status "$status_file" "$run_id" "queued" "$target_engine" "$request_file" "$result_file" "$created_at"
   bridge_cron_write_manifest "$manifest_file" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$jobs_file" "$run_id" "$request_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels"
   # Per-run ACL grant is best-effort under v1.3 (#219): the memory-daily

--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -671,16 +671,17 @@ bridge_cron_write_request() {
   local allow_channel_delivery="${27:-0}"
   local routing_mode="${28:-}"
   local disposable_needs_channels="${29:-0}"
+  local disable_mcp="${30:-0}"
 
   mkdir -p "$(dirname "$request_file")"
 
   bridge_require_python
-  python3 - "$request_file" "$run_id" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$source_file" "$payload_kind" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" <<'PY'
+  python3 - "$request_file" "$run_id" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$source_file" "$payload_kind" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" "$disable_mcp" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-(request_file, run_id, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, payload_file, result_file, status_file, stdout_log, stderr_log, source_file, payload_kind, target_engine, target_workdir, target_channels, target_discord_state_dir, target_telegram_state_dir, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels) = sys.argv[1:]
+(request_file, run_id, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, payload_file, result_file, status_file, stdout_log, stderr_log, source_file, payload_kind, target_engine, target_workdir, target_channels, target_discord_state_dir, target_telegram_state_dir, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels, disable_mcp) = sys.argv[1:]
 
 payload = {
     "run_id": run_id,
@@ -700,6 +701,7 @@ payload = {
     "job_delivery_target": job_delivery_target,
     "allow_channel_delivery": allow_channel_delivery == "1",
     "disposable_needs_channels": disposable_needs_channels == "1",
+    "disable_mcp": disable_mcp == "1",
     "slot": slot,
     "dispatch_task_id": int(task_id),
     "created_at": created_at,

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6105,6 +6105,132 @@ command, _ = module.run_claude(opt_in_request, opt_in_prompt, 30)
 assert command[2:4] == ["--channels", "plugin:telegram"]
 PY
 
+log "honouring metadata.disableMcp on disposable cron child (#263)"
+CRON_NOMCP_JOBS_FILE="$TMP_ROOT/cron-nomcp-jobs.json"
+cat >"$CRON_NOMCP_JOBS_FILE" <<EOF
+{
+  "jobs": [
+    {
+      "id": "no-mcp-job",
+      "name": "no-mcp-job",
+      "enabled": true,
+      "agentId": "$SMOKE_AGENT",
+      "schedule": {
+        "kind": "cron",
+        "expr": "*/15 * * * *",
+        "tz": "UTC"
+      },
+      "metadata": {
+        "disableMcp": true
+      },
+      "payload": {
+        "text": "ping"
+      }
+    },
+    {
+      "id": "snake-mcp-job",
+      "name": "snake-mcp-job",
+      "enabled": true,
+      "agentId": "$SMOKE_AGENT",
+      "schedule": {
+        "kind": "cron",
+        "expr": "0 9 * * *",
+        "tz": "UTC"
+      },
+      "metadata": {
+        "disposable_disable_mcp": true
+      },
+      "payload": {
+        "text": "ping"
+      }
+    },
+    {
+      "id": "mcp-default-job",
+      "name": "mcp-default-job",
+      "enabled": true,
+      "agentId": "$SMOKE_AGENT",
+      "schedule": {
+        "kind": "cron",
+        "expr": "0 9 * * *",
+        "tz": "UTC"
+      },
+      "payload": {
+        "text": "ping"
+      }
+    }
+  ]
+}
+EOF
+NOMCP_SHELL="$(python3 "$REPO_ROOT/bridge-cron.py" show --jobs-file "$CRON_NOMCP_JOBS_FILE" --format shell no-mcp-job)"
+assert_contains "$NOMCP_SHELL" "CRON_JOB_DISABLE_MCP=1"
+SNAKE_SHELL="$(python3 "$REPO_ROOT/bridge-cron.py" show --jobs-file "$CRON_NOMCP_JOBS_FILE" --format shell snake-mcp-job)"
+assert_contains "$SNAKE_SHELL" "CRON_JOB_DISABLE_MCP=1"
+DEFAULT_SHELL="$(python3 "$REPO_ROOT/bridge-cron.py" show --jobs-file "$CRON_NOMCP_JOBS_FILE" --format shell mcp-default-job)"
+assert_contains "$DEFAULT_SHELL" "CRON_JOB_DISABLE_MCP=0"
+
+python3 - <<'PY'
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+
+path = Path("bridge-cron-runner.py").resolve()
+spec = importlib.util.spec_from_file_location("bridge_cron_runner", path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+base = {
+    "target_agent": "tester",
+    "target_engine": "claude",
+    "job_name": "j",
+    "family": "j",
+    "slot": "s",
+    "run_id": "r",
+    "payload_file": "/tmp/p",
+    "target_workdir": str(Path(".").resolve()),
+    "target_channels": "",
+    "allow_channel_delivery": False,
+    "disposable_needs_channels": False,
+}
+
+# Default: no flag.
+assert module.disable_mcp_for_request(dict(base)) is False
+# Per-request opt-in.
+on = dict(base, disable_mcp=True)
+assert module.disable_mcp_for_request(on) is True
+# Env override forces ON.
+os.environ["BRIDGE_CRON_DISPOSABLE_DISABLE_MCP"] = "1"
+assert module.disable_mcp_for_request(dict(base)) is True
+# Env override forces OFF.
+os.environ["BRIDGE_CRON_DISPOSABLE_DISABLE_MCP"] = "0"
+assert module.disable_mcp_for_request(on) is False
+del os.environ["BRIDGE_CRON_DISPOSABLE_DISABLE_MCP"]
+# Channel relays must always keep MCP enabled, regardless of the flag.
+relay = dict(base, disable_mcp=True, disposable_needs_channels=True, target_channels="plugin:telegram")
+assert module.disable_mcp_for_request(relay) is False
+
+# Wire-through: --strict-mcp-config flag in the spawned claude command.
+captured = {}
+real_run = subprocess.run
+
+def fake_run(cmd, **kw):
+    captured["cmd"] = cmd
+    return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+subprocess.run = fake_run
+try:
+    module.resolve_binary = lambda name, env_var: f"/fake/{name}"
+    module.run_claude(dict(base), "prompt", 30)
+    assert "--strict-mcp-config" not in captured["cmd"]
+    module.run_claude(on, "prompt", 30)
+    assert "--strict-mcp-config" in captured["cmd"]
+finally:
+    subprocess.run = real_run
+
+print("disable_mcp wire-through OK")
+PY
+
 log "rendering typed channel relay blocks into cron follow-up bodies"
 CRON_RELAY_RUN_ID="relay-smoke--2026-04-16T13-20"
 CRON_RELAY_RUN_DIR="$BRIDGE_CRON_STATE_DIR/runs/$CRON_RELAY_RUN_ID"


### PR DESCRIPTION
Wave 8 implementation, #263 Option A. Per-job metadata.disableMcp (4 aliases) + install-wide BRIDGE_CRON_DISPOSABLE_DISABLE_MCP env. Channel-relay safety override (channels still load MCP). Latency: warm host 5.6-10.2s → 3.2-3.7s (78% CPU reduction). Options B (memory guard) + C (warm pool) + D (non-Claude runtime) deferred.