### PR TITLE
isolate: channel-ownership-aware plugin sharing for isolated UIDs

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -844,7 +844,11 @@ bridge_resolve_plugin_install_path() {
   # Tries installed_plugins.json's installPath first; falls back to the
   # marketplace's source.path/plugins/<plugin> for directory-source
   # marketplaces (used by Agent Bridge's own teams/ms365 plugins, where
-  # installed_plugins.json may carry a stale cache path).
+  # installed_plugins.json may carry a stale cache path). The fallback
+  # is only used for directory-source marketplaces — non-directory
+  # sources (git, http, etc.) resolve solely via installed_plugins.json
+  # so we don't accidentally synthesise a path that does not match how
+  # the controller actually fetched the plugin (Risk 2 in PR #302 r1).
   local plugin_id="$1"
   local plugins_root="$2"
   local manifest="$plugins_root/installed_plugins.json"
@@ -858,39 +862,166 @@ plugin_id = sys.argv[1]
 manifest_path = sys.argv[2]
 marketplaces_path = sys.argv[3]
 
+
+def warn(msg):
+    sys.stderr.write("[bridge-isolate] " + msg + "\n")
+
+
 resolved = ""
 
 if os.path.isfile(manifest_path):
     try:
-        manifest = json.load(open(manifest_path))
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+    except (OSError, ValueError) as exc:
+        # Loud failure: corrupt controller manifest is operator-actionable
+        # state. Refuse to resolve from it and let the caller fall back to
+        # the directory marketplace path (which is independent of the
+        # broken manifest); if that also fails the caller will skip the
+        # grant rather than silently degrade.
+        warn(
+            "controller installed_plugins.json unreadable (%s): %s — refusing to resolve %s from manifest"
+            % (type(exc).__name__, manifest_path, plugin_id)
+        )
+        manifest = None
+    if isinstance(manifest, dict):
         for entry in manifest.get("plugins", {}).get(plugin_id, []):
             ip = entry.get("installPath")
             if ip and os.path.isdir(ip):
                 resolved = ip
                 break
-    except Exception:
-        pass
 
 if not resolved and "@" in plugin_id and os.path.isfile(marketplaces_path):
     try:
+        with open(marketplaces_path) as f:
+            markets = json.load(f)
+    except (OSError, ValueError) as exc:
+        # known_marketplaces.json is not strictly required (manifest path
+        # already failed; the directory-marketplace fallback only applies
+        # when this file is parseable). Log it but don't escalate.
+        warn(
+            "controller known_marketplaces.json unreadable (%s): %s — directory-marketplace fallback skipped for %s"
+            % (type(exc).__name__, marketplaces_path, plugin_id)
+        )
+        markets = None
+    if isinstance(markets, dict):
         plugin_name, marketplace = plugin_id.split("@", 1)
-        markets = json.load(open(marketplaces_path))
         entry = markets.get(marketplace, {})
-        candidate = ""
-        src = entry.get("source")
-        if isinstance(src, dict) and src.get("source") == "directory":
-            candidate = src.get("path", "")
-        if not candidate:
-            candidate = entry.get("installLocation", "")
-        if candidate:
-            guess = os.path.join(candidate, "plugins", plugin_name)
-            if os.path.isdir(guess):
-                resolved = guess
-    except Exception:
-        pass
+        if isinstance(entry, dict):
+            src = entry.get("source")
+            candidate = ""
+            # Risk 2 (PR #302 r1): the installLocation/plugins/<name>
+            # fallback only matches reality for directory-source
+            # marketplaces. For git/http/etc. sources, installLocation
+            # is the cache root, not the source-of-truth, so synthesising
+            # a path there would mis-grant ACLs.
+            if isinstance(src, dict) and src.get("source") == "directory":
+                candidate = src.get("path", "") or entry.get("installLocation", "")
+            if candidate:
+                guess = os.path.join(candidate, "plugins", plugin_name)
+                if os.path.isdir(guess):
+                    resolved = guess
 
 print(resolved or "")
 PY
+}
+
+bridge_isolated_plugin_grants_state_file() {
+  # State file recording the channel set last granted plugin-share ACLs to
+  # an isolated agent. Lives under $BRIDGE_ACTIVE_AGENT_DIR/<agent>/ — the
+  # same per-agent state pattern used by other isolation helpers. Used by
+  # bridge_linux_share_plugin_catalog (to compute added/removed channels
+  # across reapply) and by bridge_migration_unisolate (to revoke channels
+  # the live roster may already have dropped).
+  local agent="$1"
+  printf '%s/%s/isolated-plugin-grants.json' "$BRIDGE_ACTIVE_AGENT_DIR" "$agent"
+}
+
+bridge_isolated_plugin_grants_read() {
+  # Read the persisted plugin-channel set for $1. Emits a CSV (channel
+  # ids without the `plugin:` prefix would lose round-trip fidelity, so
+  # we store the full `plugin:<id>` form). Returns the empty string when
+  # the file is missing or unreadable. Channels are deduped + sorted on
+  # write so callers can rely on stable ordering.
+  local agent="$1"
+  local state_file=""
+  state_file="$(bridge_isolated_plugin_grants_state_file "$agent")"
+  [[ -e "$state_file" ]] || { printf ''; return 0; }
+  bridge_require_python
+  bridge_linux_sudo_root python3 - "$state_file" <<'PY'
+import json, os, sys
+path = sys.argv[1]
+try:
+    with open(path) as f:
+        data = json.load(f)
+except (OSError, ValueError) as exc:
+    sys.stderr.write(
+        "[bridge-isolate] isolated-plugin-grants.json unreadable (%s): %s — treating as empty grant set\n"
+        % (type(exc).__name__, path)
+    )
+    sys.exit(0)
+channels = data.get("channels", []) if isinstance(data, dict) else []
+print(",".join(c for c in channels if isinstance(c, str)))
+PY
+}
+
+bridge_isolated_plugin_grants_write() {
+  # Persist the channel set as JSON, root-owned 0640 so the isolated UID
+  # cannot tamper with the recorded grant set (a tamper there could trick
+  # a future unisolate into skipping a still-granted channel).
+  local agent="$1"
+  local channels_csv="$2"
+  local state_file=""
+  local state_dir=""
+  local tmp_file=""
+  state_file="$(bridge_isolated_plugin_grants_state_file "$agent")"
+  state_dir="$(dirname "$state_file")"
+  bridge_linux_sudo_root mkdir -p "$state_dir"
+  # Place the temp file in the destination dir so the mv is always within
+  # one filesystem (atomic rename); see Blocking 2 in PR #302 r1.
+  tmp_file="$(bridge_linux_sudo_root mktemp "${state_file}.tmp.XXXXXX")"
+  bridge_require_python
+  bridge_linux_sudo_root python3 - "$tmp_file" "$channels_csv" <<'PY'
+import json, sys
+out_path, csv = sys.argv[1], sys.argv[2]
+channels = sorted({c.strip() for c in csv.split(",") if c.strip()})
+with open(out_path, "w") as f:
+    json.dump({"channels": channels}, f, indent=2)
+PY
+  bridge_linux_sudo_root mv "$tmp_file" "$state_file"
+  bridge_linux_sudo_root chown root:root "$state_file"
+  bridge_linux_sudo_root chmod 0640 "$state_file"
+  bridge_linux_sudo_root chown root:root "$state_dir" >/dev/null 2>&1 || true
+  bridge_linux_sudo_root chmod 0750 "$state_dir" >/dev/null 2>&1 || true
+}
+
+bridge_isolated_plugin_grants_remove() {
+  # Delete the persisted grant-set file (called from unisolate after the
+  # ACL strip completes successfully).
+  local agent="$1"
+  local state_file=""
+  state_file="$(bridge_isolated_plugin_grants_state_file "$agent")"
+  [[ -e "$state_file" ]] || return 0
+  bridge_linux_sudo_root rm -f "$state_file" >/dev/null 2>&1 || true
+}
+
+bridge_linux_revoke_plugin_channel_grants() {
+  # Strip the per-channel install-path ACL + traverse-chain + isolated
+  # catalog symlink for one plugin channel. Mirror of the per-channel
+  # grant block in bridge_linux_share_plugin_catalog and the per-channel
+  # strip block in bridge_migration_unisolate; factored here so both
+  # reapply (when a channel is removed mid-run) and unisolate (full
+  # teardown) share one implementation.
+  local os_user="$1"
+  local plugin_id="$2"
+  local controller_plugins="$3"
+  local controller_home="$4"
+  local install_path=""
+  install_path="$(bridge_resolve_plugin_install_path "$plugin_id" "$controller_plugins")"
+  if [[ -n "$install_path" && -d "$install_path" ]]; then
+    bridge_linux_sudo_root setfacl -Rx "u:${os_user}" "$install_path" >/dev/null 2>&1 || true
+    bridge_linux_revoke_traverse_chain "$os_user" "$install_path" "$controller_home"
+  fi
 }
 
 bridge_write_isolated_installed_plugins_manifest() {
@@ -907,26 +1038,60 @@ bridge_write_isolated_installed_plugins_manifest() {
   local manifest_tmp=""
 
   bridge_require_python
-  manifest_tmp="$(mktemp)"
-  python3 - "$controller_plugins" "$channels_csv" "$manifest_tmp" <<'PY'
+  # Place the temp file in the destination dir so the subsequent mv is
+  # always within one filesystem and therefore an atomic rename. Plain
+  # mktemp(1) honours $TMPDIR, which can land on /tmp while $manifest is
+  # under /home/<user>/.claude/plugins/ — across mounts mv degrades to
+  # copy+unlink and a concurrent reader can see a half-written or
+  # transiently missing manifest. (Blocking 2 in PR #302 r1.)
+  manifest_tmp="$(bridge_linux_sudo_root mktemp "${manifest}.tmp.XXXXXX")"
+  if ! bridge_linux_sudo_root python3 - "$controller_plugins" "$channels_csv" "$manifest_tmp" <<'PY'
 import json, os, sys
 
 controller_plugins, channels_csv, out_path = sys.argv[1:]
 controller_manifest = os.path.join(controller_plugins, "installed_plugins.json")
 markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
 
+
+def warn(msg):
+    sys.stderr.write("[bridge-isolate] " + msg + "\n")
+
+
+# Distinguish "controller manifest exists but is corrupt" (operator-
+# actionable; refuse to proceed for that plugin entry) from "controller
+# manifest absent" (legitimate — fresh install or pre-plugin Claude;
+# directory-marketplace fallback is acceptable).
 source = {}
-if os.path.isfile(controller_manifest):
+manifest_present = os.path.isfile(controller_manifest)
+if manifest_present:
     try:
-        source = json.load(open(controller_manifest))
-    except Exception:
-        source = {}
+        with open(controller_manifest) as f:
+            source = json.load(f)
+        if not isinstance(source, dict):
+            raise ValueError("expected JSON object at root, got %r" % type(source).__name__)
+    except (OSError, ValueError) as exc:
+        warn(
+            "controller installed_plugins.json unparseable (%s): %s — refusing to write per-UID manifest"
+            % (type(exc).__name__, controller_manifest)
+        )
+        sys.exit(2)
 
 markets = {}
 if os.path.isfile(markets_path):
     try:
-        markets = json.load(open(markets_path))
-    except Exception:
+        with open(markets_path) as f:
+            markets = json.load(f)
+        if not isinstance(markets, dict):
+            raise ValueError("expected JSON object at root, got %r" % type(markets).__name__)
+    except (OSError, ValueError) as exc:
+        # Marketplace data missing/corrupt is informational: the manifest
+        # write can still succeed for entries whose installPath is valid
+        # in the controller manifest. The directory-marketplace fallback
+        # is the only thing we lose.
+        warn(
+            "controller known_marketplaces.json unparseable (%s): %s — directory-marketplace fallback disabled"
+            % (type(exc).__name__, markets_path)
+        )
         markets = {}
 
 
@@ -935,12 +1100,14 @@ def directory_marketplace_path(plugin_id):
         return ""
     plugin_name, marketplace = plugin_id.split("@", 1)
     entry = markets.get(marketplace, {})
+    if not isinstance(entry, dict):
+        return ""
     candidate = ""
     src = entry.get("source")
+    # Risk 2 (PR #302 r1): match bridge_resolve_plugin_install_path —
+    # only fall back for directory-source marketplaces.
     if isinstance(src, dict) and src.get("source") == "directory":
-        candidate = src.get("path", "")
-    if not candidate:
-        candidate = entry.get("installLocation", "")
+        candidate = src.get("path", "") or entry.get("installLocation", "")
     if not candidate:
         return ""
     guess = os.path.join(candidate, "plugins", plugin_name)
@@ -981,6 +1148,11 @@ for plugin_id in sorted(declared):
 with open(out_path, "w") as f:
     json.dump(out, f, indent=2)
 PY
+  then
+    bridge_linux_sudo_root rm -f "$manifest_tmp" >/dev/null 2>&1 || true
+    bridge_warn "bridge_write_isolated_installed_plugins_manifest: refused to write per-UID manifest for $os_user (controller state unparseable)"
+    return 1
+  fi
 
   bridge_linux_sudo_root mv "$manifest_tmp" "$manifest"
   bridge_linux_sudo_root chown root:root "$manifest"
@@ -999,13 +1171,47 @@ bridge_linux_share_plugin_catalog() {
   # Leaves the isolated UID's plugins/ root and the per-UID manifest
   # root-owned (the agent cannot tamper with what it loads), and leaves
   # plugins/data/ writable so plugins can persist runtime state.
+  #
+  # Reapply contract: the helper is rerun on every isolate refresh. To
+  # keep the isolation boundary tight, the previously-granted channel
+  # set is persisted under $BRIDGE_ACTIVE_AGENT_DIR/<agent>/ and diffed
+  # against the current channels — channels removed from the roster
+  # have their ACLs and catalog symlinks revoked here, not just at
+  # unisolate. (Blocking 1 in PR #302 r1.)
   local os_user="$1"
   local user_home="$2"
   local controller_user="$3"
   local agent="$4"
 
   local controller_home=""
-  controller_home="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  # Test-only seam: BRIDGE_CONTROLLER_HOME_OVERRIDE replaces the getent
+  # passwd lookup so the regression test in tests/isolation-plugin-sharing.sh
+  # can drive the helper against a fake controller plugin tree without
+  # touching the operator's real ~/.claude/plugins/. The override is
+  # ignored unless BRIDGE_HOME points under a recognised tempdir prefix
+  # (/tmp, /var/tmp, or $TMPDIR), which guards against accidental
+  # production use.
+  if [[ -n "${BRIDGE_CONTROLLER_HOME_OVERRIDE:-}" ]]; then
+    local _override_ok=0
+    local _bridge_home_norm="${BRIDGE_HOME:-}"
+    case "$_bridge_home_norm" in
+      /tmp/*|/var/tmp/*) _override_ok=1 ;;
+    esac
+    if [[ "$_override_ok" -eq 0 && -n "${TMPDIR:-}" ]]; then
+      local _tmpdir_trimmed="${TMPDIR%/}"
+      case "$_bridge_home_norm" in
+        "$_tmpdir_trimmed"/*) _override_ok=1 ;;
+      esac
+    fi
+    if [[ "$_override_ok" -eq 1 ]]; then
+      controller_home="$BRIDGE_CONTROLLER_HOME_OVERRIDE"
+    else
+      bridge_warn "bridge_linux_share_plugin_catalog: ignoring BRIDGE_CONTROLLER_HOME_OVERRIDE because BRIDGE_HOME is not under a tempdir prefix (got '${BRIDGE_HOME:-<unset>}')"
+    fi
+  fi
+  if [[ -z "$controller_home" ]]; then
+    controller_home="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  fi
   [[ -n "$controller_home" && -d "$controller_home/.claude/plugins" ]] || return 0
 
   local controller_plugins="$controller_home/.claude/plugins"
@@ -1022,17 +1228,18 @@ bridge_linux_share_plugin_catalog() {
   bridge_linux_sudo_root chown "$os_user" "$isolated_plugins/data"
   bridge_linux_sudo_root chmod 0700 "$isolated_plugins/data"
 
-  # 3. Read-only catalog metadata symlinks. Stale links from a prior reapply
-  #    are removed first so we always end up pointing at the live controller
-  #    files.
+  # 3. Read-only catalog metadata symlinks. Always remove the prior dst
+  #    first (independent of source presence) so a controller-side delete
+  #    invalidates the isolated symlink rather than leaving it dangling at
+  #    a now-stale target. (Risk 1 in PR #302 r1.)
   local catalog_file=""
   local src=""
   local dst=""
   for catalog_file in "${BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES[@]}"; do
     src="$controller_plugins/$catalog_file"
     dst="$isolated_plugins/$catalog_file"
-    [[ -e "$src" ]] || continue
     bridge_linux_sudo_root rm -f "$dst" >/dev/null 2>&1 || true
+    [[ -e "$src" ]] || continue
     bridge_linux_sudo_root ln -s "$src" "$dst"
     bridge_linux_sudo_root chown -h root:root "$dst" >/dev/null 2>&1 || true
     bridge_linux_grant_traverse_chain "$os_user" "$src" "$controller_home"
@@ -1044,15 +1251,56 @@ bridge_linux_share_plugin_catalog() {
   channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
   bridge_write_isolated_installed_plugins_manifest "$os_user" "$isolated_plugins" "$controller_plugins" "$channels_csv"
 
-  # 5. Per-channel plugin install path read access + traverse chain.
-  [[ -n "$channels_csv" ]] || return 0
-  local _channels=()
+  # 5. Compute the channel diff against the persisted grant set so we can
+  #    revoke channels that were previously granted but are no longer in
+  #    the roster (Blocking 1 in PR #302 r1). Only entries with a
+  #    `plugin:` prefix participate; non-plugin channels are ignored on
+  #    both sides of the diff.
+  local prior_channels_csv=""
+  prior_channels_csv="$(bridge_isolated_plugin_grants_read "$agent" 2>/dev/null || true)"
+  local -a _current_plugin_channels=()
+  local -a _prior_plugin_channels=()
+  if [[ -n "$channels_csv" ]]; then
+    local _cur_split=()
+    local _cur_chan=""
+    IFS=',' read -ra _cur_split <<<"$channels_csv"
+    for _cur_chan in "${_cur_split[@]}"; do
+      _cur_chan="${_cur_chan// /}"
+      [[ "$_cur_chan" == plugin:* ]] || continue
+      _current_plugin_channels+=("$_cur_chan")
+    done
+  fi
+  if [[ -n "$prior_channels_csv" ]]; then
+    local _prior_split=()
+    local _prior_chan=""
+    IFS=',' read -ra _prior_split <<<"$prior_channels_csv"
+    for _prior_chan in "${_prior_split[@]}"; do
+      _prior_chan="${_prior_chan// /}"
+      [[ "$_prior_chan" == plugin:* ]] || continue
+      _prior_plugin_channels+=("$_prior_chan")
+    done
+  fi
+
+  # 5a. Revoke removed channels (in prior set but not in current set).
+  local _prior_entry=""
+  local _cur_entry=""
+  local _found=0
+  for _prior_entry in "${_prior_plugin_channels[@]+"${_prior_plugin_channels[@]}"}"; do
+    _found=0
+    for _cur_entry in "${_current_plugin_channels[@]+"${_current_plugin_channels[@]}"}"; do
+      [[ "$_cur_entry" == "$_prior_entry" ]] && { _found=1; break; }
+    done
+    if [[ "$_found" -eq 0 ]]; then
+      bridge_linux_revoke_plugin_channel_grants \
+        "$os_user" "${_prior_entry#plugin:}" "$controller_plugins" "$controller_home"
+    fi
+  done
+
+  # 5b. Grant current plugin channel install paths + traverse chain.
   local channel=""
   local plugin_id=""
   local install_path=""
-  IFS=',' read -ra _channels <<<"$channels_csv"
-  for channel in "${_channels[@]}"; do
-    [[ "$channel" == plugin:* ]] || continue
+  for channel in "${_current_plugin_channels[@]+"${_current_plugin_channels[@]}"}"; do
     plugin_id="${channel#plugin:}"
     install_path="$(bridge_resolve_plugin_install_path "$plugin_id" "$controller_plugins")"
     [[ -n "$install_path" && -d "$install_path" ]] || continue
@@ -1062,6 +1310,68 @@ bridge_linux_share_plugin_catalog() {
     bridge_linux_grant_traverse_chain "$os_user" "$install_path" "$controller_home"
     bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$install_path"
   done
+
+  # 5c. Persist the new grant set so the next reapply / unisolate sees
+  #     exactly what we touched here.
+  local _persist_csv=""
+  if [[ "${#_current_plugin_channels[@]}" -gt 0 ]]; then
+    _persist_csv="$(IFS=','; printf '%s' "${_current_plugin_channels[*]}")"
+  fi
+  bridge_isolated_plugin_grants_write "$agent" "$_persist_csv"
+}
+
+bridge_linux_unshare_plugin_catalog() {
+  # Tear down the isolated-side artifacts created by
+  # bridge_linux_share_plugin_catalog: catalog symlinks under
+  # $user_home/.claude/plugins/, the per-UID installed_plugins.json,
+  # and the plugins/ directory itself if it ends up empty after the
+  # symlink + manifest cleanup. plugins/data/ is preserved on purpose —
+  # it is owned by the isolated UID and contains plugin-runtime state
+  # the agent has produced; resetting that is a separate concern. The
+  # function is dry-run aware so it can compose with
+  # bridge_migration_unisolate's existing dry_run gate. (Blocking 4 in
+  # PR #302 r1.)
+  local os_user="$1"
+  local user_home="$2"
+  local dry_run="$3"
+
+  local isolated_plugins="$user_home/.claude/plugins"
+  [[ -n "$user_home" ]] || return 0
+  [[ -d "$isolated_plugins" ]] || return 0
+
+  local catalog_file=""
+  local link=""
+  for catalog_file in "${BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES[@]}"; do
+    link="$isolated_plugins/$catalog_file"
+    [[ -e "$link" || -L "$link" ]] || continue
+    bridge_migration_print_step "$dry_run" "rm $link (isolated catalog symlink)"
+    if [[ "$dry_run" != "1" ]]; then
+      bridge_linux_sudo_root rm -f "$link" >/dev/null 2>&1 || true
+    fi
+  done
+
+  local manifest="$isolated_plugins/installed_plugins.json"
+  if [[ -e "$manifest" ]]; then
+    bridge_migration_print_step "$dry_run" "rm $manifest (per-UID installed_plugins.json)"
+    if [[ "$dry_run" != "1" ]]; then
+      bridge_linux_sudo_root rm -f "$manifest" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  # Only rmdir plugins/ when it ends up empty after the strip. If
+  # plugins/data/ (or anything else the agent has produced) still
+  # exists, leave the directory alone — its contents belong to the
+  # isolated UID, not to bridge isolation.
+  if [[ "$dry_run" != "1" ]]; then
+    if bridge_linux_sudo_root bash -c "shopt -s nullglob dotglob; entries=(\"$isolated_plugins\"/*); ((\${#entries[@]} == 0))" >/dev/null 2>&1; then
+      bridge_migration_print_step "$dry_run" "rmdir $isolated_plugins (empty)"
+      bridge_linux_sudo_root rmdir "$isolated_plugins" >/dev/null 2>&1 || true
+    else
+      bridge_migration_print_step "$dry_run" "$isolated_plugins not empty (preserving plugins/data/ etc.)"
+    fi
+  else
+    bridge_migration_print_step "$dry_run" "rmdir $isolated_plugins if empty (skipped in dry-run)"
+  fi
 }
 
 bridge_write_linux_agent_env_file() {

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -790,6 +790,280 @@ PY
 )
 }
 
+bridge_linux_revoke_traverse_chain() {
+  # Mirror of bridge_linux_grant_traverse_chain: remove `u:${os_user}` from
+  # every directory between $target and $stop_path (inclusive). Stop_path
+  # follows the same `/` and empty-string guards as the grant function so
+  # an accidental call cannot strip ACLs from filesystem ancestors.
+  local os_user="$1"
+  local target="$2"
+  local stop_path="${3:-}"
+
+  if [[ -z "$stop_path" ]]; then
+    bridge_warn "bridge_linux_revoke_traverse_chain: missing stop_path for target=$target (skipping)"
+    return 0
+  fi
+  case "$stop_path" in
+    "/"|"")
+      bridge_warn "bridge_linux_revoke_traverse_chain: refusing stop_path=\"$stop_path\" for target=$target"
+      return 0
+      ;;
+  esac
+
+  bridge_require_python
+  local path=""
+  while IFS= read -r path; do
+    [[ -d "$path" ]] || continue
+    bridge_linux_sudo_root setfacl -x "u:${os_user}" "$path" >/dev/null 2>&1 || true
+  done < <(python3 - "$target" "$stop_path" <<'PY'
+from pathlib import Path
+import sys
+
+target = Path(sys.argv[1]).expanduser().resolve()
+stop_raw = Path(sys.argv[2]).expanduser().resolve()
+stop = stop_raw if stop_raw.is_dir() else stop_raw.parent
+if target != stop and stop not in target.parents:
+    sys.exit(0)
+items = []
+current = target
+while True:
+    items.append(str(current))
+    if current == stop:
+        break
+    if current.parent == current:
+        break
+    current = current.parent
+for item in reversed(items):
+    print(item)
+PY
+)
+}
+
+bridge_resolve_plugin_install_path() {
+  # Resolve <plugin>@<marketplace> to its on-disk install directory.
+  # Tries installed_plugins.json's installPath first; falls back to the
+  # marketplace's source.path/plugins/<plugin> for directory-source
+  # marketplaces (used by Agent Bridge's own teams/ms365 plugins, where
+  # installed_plugins.json may carry a stale cache path).
+  local plugin_id="$1"
+  local plugins_root="$2"
+  local manifest="$plugins_root/installed_plugins.json"
+  local marketplaces_json="$plugins_root/known_marketplaces.json"
+
+  bridge_require_python
+  python3 - "$plugin_id" "$manifest" "$marketplaces_json" <<'PY'
+import json, os, sys
+
+plugin_id = sys.argv[1]
+manifest_path = sys.argv[2]
+marketplaces_path = sys.argv[3]
+
+resolved = ""
+
+if os.path.isfile(manifest_path):
+    try:
+        manifest = json.load(open(manifest_path))
+        for entry in manifest.get("plugins", {}).get(plugin_id, []):
+            ip = entry.get("installPath")
+            if ip and os.path.isdir(ip):
+                resolved = ip
+                break
+    except Exception:
+        pass
+
+if not resolved and "@" in plugin_id and os.path.isfile(marketplaces_path):
+    try:
+        plugin_name, marketplace = plugin_id.split("@", 1)
+        markets = json.load(open(marketplaces_path))
+        entry = markets.get(marketplace, {})
+        candidate = ""
+        src = entry.get("source")
+        if isinstance(src, dict) and src.get("source") == "directory":
+            candidate = src.get("path", "")
+        if not candidate:
+            candidate = entry.get("installLocation", "")
+        if candidate:
+            guess = os.path.join(candidate, "plugins", plugin_name)
+            if os.path.isdir(guess):
+                resolved = guess
+    except Exception:
+        pass
+
+print(resolved or "")
+PY
+}
+
+bridge_write_isolated_installed_plugins_manifest() {
+  # Write a per-isolated-UID installed_plugins.json containing only the
+  # plugins this agent declared in BRIDGE_AGENT_CHANNELS, with installPath
+  # rewritten to the actually-existing location resolved by
+  # bridge_resolve_plugin_install_path. The file is owned by root so the
+  # isolated UID cannot tamper with which plugins it loads.
+  local os_user="$1"
+  local isolated_plugins="$2"
+  local controller_plugins="$3"
+  local channels_csv="$4"
+  local manifest="$isolated_plugins/installed_plugins.json"
+  local manifest_tmp=""
+
+  bridge_require_python
+  manifest_tmp="$(mktemp)"
+  python3 - "$controller_plugins" "$channels_csv" "$manifest_tmp" <<'PY'
+import json, os, sys
+
+controller_plugins, channels_csv, out_path = sys.argv[1:]
+controller_manifest = os.path.join(controller_plugins, "installed_plugins.json")
+markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
+
+source = {}
+if os.path.isfile(controller_manifest):
+    try:
+        source = json.load(open(controller_manifest))
+    except Exception:
+        source = {}
+
+markets = {}
+if os.path.isfile(markets_path):
+    try:
+        markets = json.load(open(markets_path))
+    except Exception:
+        markets = {}
+
+
+def directory_marketplace_path(plugin_id):
+    if "@" not in plugin_id:
+        return ""
+    plugin_name, marketplace = plugin_id.split("@", 1)
+    entry = markets.get(marketplace, {})
+    candidate = ""
+    src = entry.get("source")
+    if isinstance(src, dict) and src.get("source") == "directory":
+        candidate = src.get("path", "")
+    if not candidate:
+        candidate = entry.get("installLocation", "")
+    if not candidate:
+        return ""
+    guess = os.path.join(candidate, "plugins", plugin_name)
+    return guess if os.path.isdir(guess) else ""
+
+
+def resolve(plugin_id):
+    # Preserve controller entry metadata (version, gitCommitSha, etc.) when
+    # we can; only rewrite installPath if it is missing or stale.
+    for entry in source.get("plugins", {}).get(plugin_id, []):
+        ip = entry.get("installPath")
+        if ip and os.path.isdir(ip):
+            return entry, ip
+        fallback = directory_marketplace_path(plugin_id)
+        if fallback:
+            return entry, fallback
+    fallback = directory_marketplace_path(plugin_id)
+    if fallback:
+        return {"scope": "user", "installPath": fallback}, fallback
+    return None, None
+
+
+declared = set()
+for chan in channels_csv.split(","):
+    chan = chan.strip()
+    if chan.startswith("plugin:"):
+        declared.add(chan[len("plugin:"):])
+
+out = {"version": source.get("version", 2), "plugins": {}}
+for plugin_id in sorted(declared):
+    entry, real_path = resolve(plugin_id)
+    if not entry or not real_path:
+        continue
+    new_entry = dict(entry)
+    new_entry["installPath"] = real_path
+    out["plugins"][plugin_id] = [new_entry]
+
+with open(out_path, "w") as f:
+    json.dump(out, f, indent=2)
+PY
+
+  bridge_linux_sudo_root mv "$manifest_tmp" "$manifest"
+  bridge_linux_sudo_root chown root:root "$manifest"
+  bridge_linux_sudo_root chmod 0640 "$manifest"
+  bridge_linux_acl_add "u:${os_user}:r--" "$manifest"
+}
+
+bridge_linux_share_plugin_catalog() {
+  # Channel-ownership-aware plugin sharing for an isolated agent.
+  # Grants the isolated UID read-only access to:
+  #   - the controller's catalog metadata files (audit-level disclosure),
+  #   - a per-UID generated installed_plugins.json that only lists the
+  #     plugins declared in BRIDGE_AGENT_CHANNELS for this agent,
+  #   - each declared plugin's install-path tree, with a traverse chain
+  #     up to the controller home (#233 stop guard).
+  # Leaves the isolated UID's plugins/ root and the per-UID manifest
+  # root-owned (the agent cannot tamper with what it loads), and leaves
+  # plugins/data/ writable so plugins can persist runtime state.
+  local os_user="$1"
+  local user_home="$2"
+  local controller_user="$3"
+  local agent="$4"
+
+  local controller_home=""
+  controller_home="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  [[ -n "$controller_home" && -d "$controller_home/.claude/plugins" ]] || return 0
+
+  local controller_plugins="$controller_home/.claude/plugins"
+  local isolated_plugins="$user_home/.claude/plugins"
+
+  # 1. plugins/ root: root-owned, isolated UID r-x.
+  bridge_linux_sudo_root mkdir -p "$isolated_plugins"
+  bridge_linux_sudo_root chown root:root "$isolated_plugins"
+  bridge_linux_sudo_root chmod 0750 "$isolated_plugins"
+  bridge_linux_acl_add "u:${os_user}:r-x" "$isolated_plugins"
+
+  # 2. plugins/data/: isolated UID owns this so plugin runtime state writes work.
+  bridge_linux_sudo_root mkdir -p "$isolated_plugins/data"
+  bridge_linux_sudo_root chown "$os_user" "$isolated_plugins/data"
+  bridge_linux_sudo_root chmod 0700 "$isolated_plugins/data"
+
+  # 3. Read-only catalog metadata symlinks. Stale links from a prior reapply
+  #    are removed first so we always end up pointing at the live controller
+  #    files.
+  local catalog_file=""
+  local src=""
+  local dst=""
+  for catalog_file in "${BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES[@]}"; do
+    src="$controller_plugins/$catalog_file"
+    dst="$isolated_plugins/$catalog_file"
+    [[ -e "$src" ]] || continue
+    bridge_linux_sudo_root rm -f "$dst" >/dev/null 2>&1 || true
+    bridge_linux_sudo_root ln -s "$src" "$dst"
+    bridge_linux_sudo_root chown -h root:root "$dst" >/dev/null 2>&1 || true
+    bridge_linux_grant_traverse_chain "$os_user" "$src" "$controller_home"
+    bridge_linux_acl_add "u:${os_user}:r--" "$src"
+  done
+
+  # 4. Per-UID installed_plugins.json — declared plugins only, real install paths.
+  local channels_csv=""
+  channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+  bridge_write_isolated_installed_plugins_manifest "$os_user" "$isolated_plugins" "$controller_plugins" "$channels_csv"
+
+  # 5. Per-channel plugin install path read access + traverse chain.
+  [[ -n "$channels_csv" ]] || return 0
+  local _channels=()
+  local channel=""
+  local plugin_id=""
+  local install_path=""
+  IFS=',' read -ra _channels <<<"$channels_csv"
+  for channel in "${_channels[@]}"; do
+    [[ "$channel" == plugin:* ]] || continue
+    plugin_id="${channel#plugin:}"
+    install_path="$(bridge_resolve_plugin_install_path "$plugin_id" "$controller_plugins")"
+    [[ -n "$install_path" && -d "$install_path" ]] || continue
+    # Order matters: traverse_chain stamps `--x` on every node from target up
+    # to controller_home (including target). The recursive r-X grant must run
+    # AFTER so target/<file> entries end up with r--/r-x rather than --x.
+    bridge_linux_grant_traverse_chain "$os_user" "$install_path" "$controller_home"
+    bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$install_path"
+  done
+}
+
 bridge_write_linux_agent_env_file() {
   local agent="$1"
   local file="${2:-$(bridge_agent_linux_env_file "$agent")}"
@@ -1023,7 +1297,11 @@ bridge_linux_prepare_agent_isolation() {
   [[ -d "$BRIDGE_RUNTIME_ROOT" ]] && recursive_read_paths+=("$BRIDGE_RUNTIME_ROOT")
   [[ -d "$BRIDGE_HOME/.claude" ]] && recursive_read_paths+=("$BRIDGE_HOME/.claude")
   [[ -d "$BRIDGE_HOME/lib" ]] && recursive_read_paths+=("$BRIDGE_HOME/lib")
-  [[ -d "$BRIDGE_HOME/plugins" ]] && recursive_read_paths+=("$BRIDGE_HOME/plugins")
+  # Note: $BRIDGE_HOME/plugins (directory-marketplace source for agent-bridge
+  # plugins like teams/ms365) is intentionally NOT in the broad recursive_read
+  # set. bridge_linux_share_plugin_catalog grants r-X to declared plugin code
+  # paths only, keyed off BRIDGE_AGENT_CHANNELS, so each isolated UID sees
+  # only its own plugins.
   [[ -d "$BRIDGE_HOME/scripts" ]] && recursive_read_paths+=("$BRIDGE_HOME/scripts")
   [[ -d "$BRIDGE_AGENT_HOME_ROOT/.claude" ]] && recursive_read_paths+=("$BRIDGE_AGENT_HOME_ROOT/.claude")
   bridge_linux_acl_remove_recursive "u:${os_user}" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR"
@@ -1156,6 +1434,14 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_sudo_root mkdir -p "$isolated_claude_dir"
   bridge_linux_sudo_root chown "$os_user" "$isolated_claude_dir" >/dev/null 2>&1 || true
   bridge_linux_sudo_root chmod 0700 "$isolated_claude_dir" >/dev/null 2>&1 || true
+  # Channel-ownership-aware plugin sharing. Without this the isolated UID's
+  # ~/.claude/plugins/ is empty and Claude starts with no MCP servers loaded
+  # (Teams/ms365/cosmax-* all silently missing). The helper writes a per-UID
+  # installed_plugins.json that lists only this agent's declared channel
+  # plugins, grants r-X on each declared plugin's install path, and exposes
+  # catalog metadata read-only. plugins/data/ stays writable by the isolated
+  # UID so plugin runtime state still works.
+  bridge_linux_share_plugin_catalog "$os_user" "$user_home" "$controller_user" "$agent"
   # Issue #233: the previous `bridge_linux_grant_traverse_chain
   # $controller_user $isolated_claude_dir` call walked from
   # /home/agent-bridge-<agent>/.claude all the way up to / and left

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1154,10 +1154,15 @@ PY
     return 1
   fi
 
+  # Set final ownership/perm/ACL on the temp file BEFORE the atomic rename
+  # so the destination never exists with the wrong metadata even
+  # momentarily. Readers see either the previous manifest or the new one
+  # with correct ownership/perm/ACL — never an in-between state.
+  # (Blocking 2 in PR #302 r2.)
+  bridge_linux_sudo_root chown root:root "$manifest_tmp"
+  bridge_linux_sudo_root chmod 0640 "$manifest_tmp"
+  bridge_linux_acl_add "u:${os_user}:r--" "$manifest_tmp"
   bridge_linux_sudo_root mv "$manifest_tmp" "$manifest"
-  bridge_linux_sudo_root chown root:root "$manifest"
-  bridge_linux_sudo_root chmod 0640 "$manifest"
-  bridge_linux_acl_add "u:${os_user}:r--" "$manifest"
 }
 
 bridge_linux_share_plugin_catalog() {

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -204,6 +204,17 @@ bridge_queue_gateway_root() {
   printf '%s/queue-gateway' "$BRIDGE_STATE_DIR"
 }
 
+# Plugin catalog metadata files exposed read-only to isolated UIDs as
+# symlinks into the controller's ~/.claude/plugins/. We treat these as
+# "audit-level" disclosure — they reveal plugin names/versions but no
+# secrets and no plugin source code. The matching strip in
+# bridge_migration_unisolate iterates the same constant.
+declare -ga BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES=(
+  known_marketplaces.json
+  install-counts-cache.json
+  blocklist.json
+)
+
 # Returns 0 (success) if the cron sync path should run, 1 otherwise.
 # Contract: walk the new name and its two legacy aliases.
 #   - If any variable is a recognized off-form (0, false, no, off), disable.

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -336,6 +336,62 @@ bridge_migration_unisolate() {
     fi
   fi
 
+  # Strip plugin-share ACLs granted by bridge_linux_share_plugin_catalog.
+  # Mirrors the catalog file list and per-channel install path grants, plus
+  # the traverse chain that reached up to controller_home. The isolated
+  # UID's plugins/ directory itself lives under user_home (already torn
+  # down by the workdir/state ownership reset above when applicable);
+  # what we need to strip is the u:<os_user> ACL entries we left on
+  # controller-side surfaces.
+  local controller_home_for_plugins=""
+  controller_home_for_plugins="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  if [[ -n "$controller_home_for_plugins" && -d "$controller_home_for_plugins/.claude/plugins" ]]; then
+    local controller_plugins="$controller_home_for_plugins/.claude/plugins"
+    local catalog_file=""
+    local src=""
+    for catalog_file in "${BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES[@]}"; do
+      src="$controller_plugins/$catalog_file"
+      [[ -e "$src" ]] || continue
+      bridge_migration_print_step "$dry_run" "setfacl -x u:${os_user} $src + revoke traverse chain"
+      if [[ "$dry_run" != "1" ]]; then
+        bridge_linux_sudo_root setfacl -x "u:${os_user}" "$src" >/dev/null 2>&1 || true
+        bridge_linux_revoke_traverse_chain "$os_user" "$src" "$controller_home_for_plugins"
+      fi
+    done
+
+    local plugin_channels_csv=""
+    plugin_channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+    if [[ -n "$plugin_channels_csv" ]]; then
+      local _plugin_channels=()
+      local _plugin_channel=""
+      local _plugin_id=""
+      local _plugin_install_path=""
+      IFS=',' read -ra _plugin_channels <<<"$plugin_channels_csv"
+      for _plugin_channel in "${_plugin_channels[@]}"; do
+        [[ "$_plugin_channel" == plugin:* ]] || continue
+        _plugin_id="${_plugin_channel#plugin:}"
+        _plugin_install_path="$(bridge_resolve_plugin_install_path "$_plugin_id" "$controller_plugins")"
+        [[ -n "$_plugin_install_path" && -d "$_plugin_install_path" ]] || continue
+        bridge_migration_print_step "$dry_run" "setfacl -Rx u:${os_user} $_plugin_install_path + revoke traverse chain"
+        if [[ "$dry_run" != "1" ]]; then
+          bridge_linux_sudo_root setfacl -Rx "u:${os_user}" "$_plugin_install_path" >/dev/null 2>&1 || true
+          bridge_linux_revoke_traverse_chain "$os_user" "$_plugin_install_path" "$controller_home_for_plugins"
+        fi
+      done
+    fi
+  fi
+
+  # Backward-compat: prior versions broadly granted u:<os_user>:r-X on the
+  # entire $BRIDGE_HOME/plugins tree (independent of BRIDGE_AGENT_CHANNELS).
+  # Strip any leftover entries for this os_user; only this UID's entries are
+  # affected, other agents' grants on the same path are preserved.
+  if [[ -n "${BRIDGE_HOME:-}" && -d "$BRIDGE_HOME/plugins" ]]; then
+    bridge_migration_print_step "$dry_run" "setfacl -Rx u:${os_user} $BRIDGE_HOME/plugins (legacy cleanup)"
+    if [[ "$dry_run" != "1" ]]; then
+      bridge_linux_sudo_root setfacl -Rx "u:${os_user}" "$BRIDGE_HOME/plugins" >/dev/null 2>&1 || true
+    fi
+  fi
+
   # Remove the scoped roster snapshot (agent-env.sh). In shared mode the
   # snapshot is stale — it still carries linux-user isolation metadata and
   # would be picked up by bridge_load_roster's BRIDGE_AGENT_ID fallback,

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -232,7 +232,7 @@ bridge_migration_isolate() {
 bridge_migration_unisolate() {
   local agent="$1"
   local dry_run="$2"
-  local current_mode os_user workdir controller_user runtime_state_dir log_dir
+  local current_mode os_user workdir controller_user runtime_state_dir log_dir user_home
 
   bridge_migration_require_linux
   bridge_require_agent "$agent"
@@ -253,6 +253,7 @@ bridge_migration_unisolate() {
 
   workdir="$(bridge_agent_workdir "$agent")"
   controller_user="$(bridge_current_user)"
+  user_home="$(bridge_migration_user_home "$os_user" 2>/dev/null || true)"
 
   printf '[plan] unisolate %s -> shared mode\n' "$agent"
   printf '       reverting ownership from os_user=%s back to controller=%s\n' "$os_user" "$controller_user"
@@ -338,11 +339,16 @@ bridge_migration_unisolate() {
 
   # Strip plugin-share ACLs granted by bridge_linux_share_plugin_catalog.
   # Mirrors the catalog file list and per-channel install path grants, plus
-  # the traverse chain that reached up to controller_home. The isolated
-  # UID's plugins/ directory itself lives under user_home (already torn
-  # down by the workdir/state ownership reset above when applicable);
-  # what we need to strip is the u:<os_user> ACL entries we left on
-  # controller-side surfaces.
+  # the traverse chain that reached up to controller_home.
+  #
+  # Channel set source-of-truth: the persisted grant-set state file
+  # written by bridge_isolated_plugin_grants_write. Reading from the
+  # live roster is unsafe here because by the time unisolate runs the
+  # operator may have already edited BRIDGE_AGENT_CHANNELS to drop
+  # channels, and we still need to revoke the ACLs they earned.
+  # Falls back to the live roster only when the state file is missing
+  # (older agents that pre-date the grant-set persistence). (Blocking 1
+  # in PR #302 r1.)
   local controller_home_for_plugins=""
   controller_home_for_plugins="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
   if [[ -n "$controller_home_for_plugins" && -d "$controller_home_for_plugins/.claude/plugins" ]]; then
@@ -360,7 +366,14 @@ bridge_migration_unisolate() {
     done
 
     local plugin_channels_csv=""
-    plugin_channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+    plugin_channels_csv="$(bridge_isolated_plugin_grants_read "$agent" 2>/dev/null || true)"
+    if [[ -z "$plugin_channels_csv" ]]; then
+      # No persisted state file (older isolate, or it was hand-removed).
+      # Fall back to the live roster's channels — better than skipping
+      # the strip entirely, even if it misses channels the operator has
+      # since dropped.
+      plugin_channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+    fi
     if [[ -n "$plugin_channels_csv" ]]; then
       local _plugin_channels=()
       local _plugin_channel=""
@@ -379,6 +392,24 @@ bridge_migration_unisolate() {
         fi
       done
     fi
+  fi
+
+  # Tear down the isolated-side artifacts (catalog symlinks, per-UID
+  # installed_plugins.json, plugins/ root if empty) that
+  # bridge_linux_share_plugin_catalog created under
+  # $user_home/.claude/plugins/. plugins/data/ is preserved on purpose.
+  # (Blocking 4 in PR #302 r1.)
+  if [[ -n "$user_home" ]]; then
+    bridge_linux_unshare_plugin_catalog "$os_user" "$user_home" "$dry_run"
+  fi
+
+  # Drop the persisted grant set last so that, on dry-run, the file
+  # survives for inspection; on a real run, by this point both the
+  # controller-side and isolated-side strips have completed.
+  if [[ "$dry_run" != "1" ]]; then
+    bridge_isolated_plugin_grants_remove "$agent"
+  else
+    bridge_migration_print_step "$dry_run" "rm $(bridge_isolated_plugin_grants_state_file "$agent") (persisted grant-set)"
   fi
 
   # Backward-compat: prior versions broadly granted u:<os_user>:r-X on the

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -350,7 +350,35 @@ bridge_migration_unisolate() {
   # (older agents that pre-date the grant-set persistence). (Blocking 1
   # in PR #302 r1.)
   local controller_home_for_plugins=""
-  controller_home_for_plugins="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  # Test-only seam: BRIDGE_CONTROLLER_HOME_OVERRIDE replaces the getent
+  # passwd lookup so the regression test in tests/isolation-plugin-sharing.sh
+  # can drive unisolate cleanup against the same fake controller plugin
+  # tree it uses for the share path. The override is ignored unless
+  # BRIDGE_HOME points under a recognised tempdir prefix (/tmp, /var/tmp,
+  # or $TMPDIR), which guards against accidental production use. Mirrors
+  # the seam in bridge_linux_share_plugin_catalog. (Blocking 5(b) in PR
+  # #302 r2.)
+  if [[ -n "${BRIDGE_CONTROLLER_HOME_OVERRIDE:-}" ]]; then
+    local _override_ok=0
+    local _bridge_home_norm="${BRIDGE_HOME:-}"
+    case "$_bridge_home_norm" in
+      /tmp/*|/var/tmp/*) _override_ok=1 ;;
+    esac
+    if [[ "$_override_ok" -eq 0 && -n "${TMPDIR:-}" ]]; then
+      local _tmpdir_trimmed="${TMPDIR%/}"
+      case "$_bridge_home_norm" in
+        "$_tmpdir_trimmed"/*) _override_ok=1 ;;
+      esac
+    fi
+    if [[ "$_override_ok" -eq 1 ]]; then
+      controller_home_for_plugins="$BRIDGE_CONTROLLER_HOME_OVERRIDE"
+    else
+      bridge_warn "bridge_migration_unisolate: ignoring BRIDGE_CONTROLLER_HOME_OVERRIDE because BRIDGE_HOME is not under a tempdir prefix (got '${BRIDGE_HOME:-<unset>}')"
+    fi
+  fi
+  if [[ -z "$controller_home_for_plugins" ]]; then
+    controller_home_for_plugins="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
+  fi
   if [[ -n "$controller_home_for_plugins" && -d "$controller_home_for_plugins/.claude/plugins" ]]; then
     local controller_plugins="$controller_home_for_plugins/.claude/plugins"
     local catalog_file=""

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -285,6 +285,72 @@ chans = data.get("channels", [])
 assert chans == ["plugin:declared-plugin@td-mkt"], f"unexpected persisted channels: {chans!r}"
 ' || die "persisted grant-set contents do not match"
 
+log "stale-ACL revoke on channel change (Blocking 1 regression)"
+
+# At this point declared-plugin@td-mkt has been granted (line ~195 above).
+# Confirm the grant landed on the original install path before flipping
+# channels — without this baseline we can't tell a true revoke from a
+# never-granted state.
+sudo -n getfacl --no-effective "$BRIDGE_HOME/plugins/declared-plugin" 2>/dev/null \
+  | grep -Eq "^user:${TEST_OS_USER}:r(-x|wx)" \
+  || die "expected u:${TEST_OS_USER}:r-x on declared-plugin before channel flip"
+
+# Add a fresh plugin (replacement-plugin) to both the directory marketplace
+# tree and the controller's installed_plugins.json, then flip the agent's
+# channel to it — drops declared-plugin, adds replacement-plugin.
+mkdir -p "$CONTROLLER_PLUGINS/cache/td-mkt/replacement-plugin/0.1.0"
+echo 'replacement plugin source (cache)' \
+  > "$CONTROLLER_PLUGINS/cache/td-mkt/replacement-plugin/0.1.0/index.js"
+mkdir -p "$BRIDGE_HOME/plugins/replacement-plugin"
+echo 'replacement plugin (dir-marketplace)' \
+  > "$BRIDGE_HOME/plugins/replacement-plugin/server.ts"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
+
+python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$BRIDGE_HOME/plugins/replacement-plugin" <<'PY'
+import json, sys
+manifest_path, install_path = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["replacement-plugin@td-mkt"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": install_path}
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+
+BRIDGE_AGENT_CHANNELS["$TEST_AGENT"]='plugin:replacement-plugin@td-mkt'
+
+# Re-apply with the new channel set. This is the call shape that
+# triggers the stale-revoke path on declared-plugin (prior set) and the
+# grant path on replacement-plugin (current set).
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+log "verifying old plugin's u:${TEST_OS_USER} ACL is gone after channel flip"
+stale_count="$(sudo -n getfacl --no-effective "$BRIDGE_HOME/plugins/declared-plugin" 2>/dev/null \
+  | grep -cE "^user:${TEST_OS_USER}:" || true)"
+[[ "$stale_count" == "0" ]] \
+  || die "expected u:${TEST_OS_USER} ACL gone from declared-plugin after channel flip; still has $stale_count entr(ies)"
+
+log "verifying new plugin's u:${TEST_OS_USER}:r-x ACL is present after channel flip"
+sudo -n getfacl --no-effective "$BRIDGE_HOME/plugins/replacement-plugin" 2>/dev/null \
+  | grep -Eq "^user:${TEST_OS_USER}:r(-x|wx)" \
+  || die "expected u:${TEST_OS_USER}:r-x on replacement-plugin after channel flip"
+
+log "verifying persisted grant-set reflects the new channel set, not the old"
+sudo -n cat "$state_file" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+chans = data.get("channels", [])
+assert chans == ["plugin:replacement-plugin@td-mkt"], f"unexpected persisted channels after flip: {chans!r}"
+' || die "persisted grant-set did not reflect channel flip (expected only replacement-plugin)"
+
+# After the channel flip the saved grant-set persists replacement-plugin
+# only, so the upcoming unisolate-cleanup assertions need to target that
+# path. Reassign declared_path here rather than introducing a parallel
+# variable so the existing assertion loop below stays intact.
+declared_path="$BRIDGE_HOME/plugins/replacement-plugin"
+
 log "running bridge_migration_unisolate (dry_run=0) and verifying full ACL strip"
 BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
   bridge_migration_unisolate "$TEST_AGENT" 0 \

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -3,20 +3,31 @@
 #
 # Regression test for the channel-ownership-aware plugin sharing fix.
 #
-# Verifies:
+# Verifies, against a fully synthetic controller plugin tree (driven via
+# the BRIDGE_CONTROLLER_HOME_OVERRIDE seam in
+# bridge_linux_share_plugin_catalog) so the operator's real
+# ~/.claude/plugins/ is never touched:
+#
 #   1. After isolate, the per-UID installed_plugins.json contains only
-#      plugins declared in BRIDGE_AGENT_CHANNELS, with installPath rewritten
-#      to the actually-existing on-disk location.
-#   2. Per-UID installed_plugins.json is root-owned and read-only to the
-#      isolated UID (the agent cannot tamper with which plugins it loads).
-#   3. plugins/ root is root-owned with isolated UID r-x; plugins/data/
-#      is isolated UID-owned and writable.
+#      the plugin declared in BRIDGE_AGENT_CHANNELS, with installPath
+#      rewritten to the actually-existing on-disk location.
+#   2. Per-UID installed_plugins.json is root-owned 0640 and the
+#      isolated UID has u:<uid>:r--; the agent cannot tamper with it.
+#   3. plugins/ root is root-owned 0750 with isolated UID r-x;
+#      plugins/data/ is isolated UID-owned 0700 and writable.
 #   4. The declared plugin's directory-source install path receives a
-#      u:<os_user>:r-X recursive ACL, while an undeclared plugin under the
-#      same marketplace receives no ACL.
-#   5. After unisolate, the catalog metadata files, declared plugin install
-#      paths, traverse chain, and the legacy BRIDGE_HOME/plugins tree all
-#      have no remaining u:<os_user> ACL entries.
+#      u:<os_user>:r-X recursive ACL (r-- on files, r-x on directories);
+#      the undeclared plugin's install path has NO u:<os_user> ACL
+#      entry — the isolated UID cannot read sources for plugins it did
+#      not declare in its channel set.
+#   5. Catalog symlinks (known_marketplaces.json, install-counts-cache.json,
+#      blocklist.json) under <isolated>/.claude/plugins/ exist and resolve
+#      to the controller's copies.
+#   6. After bridge_migration_unisolate, every u:<os_user> ACL on the
+#      controller-side plugin tree is gone, the per-UID manifest is
+#      removed, the catalog symlinks under the isolated home are gone,
+#      and the legacy $BRIDGE_HOME/plugins recursive ACL strip leaves no
+#      residue (regression guard for the backward-compat cleanup).
 #
 # Skip preconditions: Linux, passwordless sudo, setfacl, useradd available.
 # Creates a temporary system user and tears it down at the end.
@@ -34,6 +45,7 @@ skip() { printf '[isolate-plugin][skip] %s\n' "$*"; exit 0; }
 command -v sudo >/dev/null 2>&1 || skip "sudo required"
 sudo -n true >/dev/null 2>&1 || skip "passwordless sudo required"
 command -v setfacl >/dev/null 2>&1 || skip "setfacl (acl package) required"
+command -v getfacl >/dev/null 2>&1 || skip "getfacl (acl package) required"
 command -v useradd >/dev/null 2>&1 || skip "useradd required"
 command -v userdel >/dev/null 2>&1 || skip "userdel required"
 
@@ -49,7 +61,8 @@ done
 
 # Temp BRIDGE_HOME with a tiny directory marketplace ("td-mkt") containing
 # both a declared plugin (declared-plugin) and an undeclared plugin
-# (undeclared-plugin).
+# (undeclared-plugin). BRIDGE_HOME must live under SAFE_TMP_PREFIX so the
+# bridge_linux_share_plugin_catalog seam guard accepts our override.
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
 export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
@@ -60,13 +73,14 @@ export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
 export BRIDGE_ROSTER_FILE="$BRIDGE_HOME/agent-roster.sh"
 export BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_HOME/agent-roster.local.sh"
 export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
-mkdir -p "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR" "$BRIDGE_SHARED_DIR"
+mkdir -p "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR" "$BRIDGE_SHARED_DIR" "$BRIDGE_ACTIVE_AGENT_DIR"
 : > "$BRIDGE_ROSTER_FILE"
 : > "$BRIDGE_ROSTER_LOCAL_FILE"
 
 # Set up a fake controller .claude/plugins/ tree so the helper has a
-# realistic surface to share. This stays under the controller's own home
-# layout: $TMP_ROOT/controller-home/.claude/plugins/.
+# realistic surface to share. This stays under a fake controller home
+# that the helper picks up via BRIDGE_CONTROLLER_HOME_OVERRIDE — the
+# operator's real $HOME is never touched.
 CONTROLLER_HOME_FAKE="$TMP_ROOT/controller-home"
 CONTROLLER_PLUGINS="$CONTROLLER_HOME_FAKE/.claude/plugins"
 mkdir -p "$CONTROLLER_PLUGINS/cache/td-mkt/declared-plugin/0.1.0" \
@@ -81,11 +95,11 @@ cat > "$CONTROLLER_PLUGINS/installed_plugins.json" <<JSON
   "plugins": {
     "declared-plugin@td-mkt": [
       {"scope": "user", "version": "0.1.0",
-       "installPath": "$CONTROLLER_PLUGINS/cache/td-mkt/declared-plugin/0.1.0"}
+       "installPath": "$BRIDGE_HOME/plugins/declared-plugin"}
     ],
     "undeclared-plugin@td-mkt": [
       {"scope": "user", "version": "0.1.0",
-       "installPath": "$CONTROLLER_PLUGINS/cache/td-mkt/undeclared-plugin/0.1.0"}
+       "installPath": "$BRIDGE_HOME/plugins/undeclared-plugin"}
     ]
   }
 }
@@ -101,10 +115,18 @@ JSON
 echo '{}' > "$CONTROLLER_PLUGINS/install-counts-cache.json"
 echo '{}' > "$CONTROLLER_PLUGINS/blocklist.json"
 
-# Directory-marketplace shape: $BRIDGE_HOME/plugins/{declared-plugin,undeclared-plugin}
+# Directory-marketplace shape: $BRIDGE_HOME/plugins/{declared,undeclared}.
+# These are the actual install paths bridge_resolve_plugin_install_path
+# will land on for the directory-source marketplace.
 mkdir -p "$BRIDGE_HOME/plugins/declared-plugin" "$BRIDGE_HOME/plugins/undeclared-plugin"
 echo 'declared plugin (dir-marketplace)' > "$BRIDGE_HOME/plugins/declared-plugin/server.ts"
 echo 'undeclared plugin (dir-marketplace)' > "$BRIDGE_HOME/plugins/undeclared-plugin/server.ts"
+
+# Make the controller-side plugin tree readable by everyone so the
+# isolated UID can actually traverse it once we grant the per-UID ACLs.
+# (The traverse chain stamps `--x` on parents up to controller_home;
+#  base mode bits also need to allow read on files we explicitly grant.)
+chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
 
 TEST_AGENT="qpa-test"
 TEST_OS_USER="agent-bridge-${TEST_AGENT}"
@@ -113,6 +135,13 @@ TEST_OS_HOME="/home/${TEST_OS_USER}"
 cleanup_test_user_locked=0
 cleanup() {
   set +e
+  # Belt-and-suspenders: strip every u:<TEST_OS_USER> ACL we might have
+  # left on the controller plugin tree so the host doesn't end up with
+  # poisoned ACLs if a step blew up between grant and revoke.
+  if id "$TEST_OS_USER" >/dev/null 2>&1; then
+    sudo -n setfacl -Rx "u:${TEST_OS_USER}" "$CONTROLLER_HOME_FAKE" >/dev/null 2>&1 || true
+    sudo -n setfacl -Rx "u:${TEST_OS_USER}" "$BRIDGE_HOME/plugins" >/dev/null 2>&1 || true
+  fi
   if [[ "$cleanup_test_user_locked" -eq 0 ]] && id "$TEST_OS_USER" >/dev/null 2>&1; then
     sudo -n userdel "$TEST_OS_USER" >/dev/null 2>&1 || true
     sudo -n rm -rf "$TEST_OS_HOME" >/dev/null 2>&1 || true
@@ -155,42 +184,16 @@ ROSTER
 source "$REPO_ROOT/bridge-lib.sh"
 bridge_load_roster
 
-# Override the controller_home lookup the helper uses by spoofing the
-# passwd entry — easiest is to rely on the actual operator's $HOME having
-# .claude/plugins/, which we don't want to touch in this test. Instead we
-# call the helper with our own controller_user that resolves to
-# CONTROLLER_HOME_FAKE.
-#
-# The helper resolves controller_home via getent passwd <controller>; we
-# create a temp passwd hook by exporting HOME for the controller_user
-# evaluation isn't going to work. Approach: use the live operator user
-# but redirect through a per-test fake home via a wrapper that the helper
-# does not currently support.
-#
-# Simpler: skip this test until a controller-home injection seam is added,
-# OR run the helper with controller_user=<a fake user we create in /etc/passwd>.
-# The latter is too invasive for a regression test. So we test by:
-#   - calling bridge_linux_share_plugin_catalog with user_home=$TEST_OS_HOME
-#     and controller_user=$(id -un), and pointing the helper's path probes
-#     at our fake controller via a temporary HOME redirect for the helper's
-#     getent fallback.
-#
-# Since the helper does `getent passwd "$controller_user" | cut -d: -f6`,
-# we only need that getent to return our fake controller home for the test
-# user. Use unshare/mount to overlay /etc/passwd? Too invasive for CI.
-#
-# Pragmatic: temporarily replace $HOME and call a wrapper that the helper
-# uses. But the helper does NOT use $HOME; it uses getent. So this is the
-# real seam gap.
-#
-# To keep this test runnable today without a code change, we rely on the
-# operator having a real $HOME/.claude/plugins/ and verify only the
-# *isolated*-side effects (per-UID manifest, ownership, ACLs on the
-# plugins/ root). The cross-grant assertions on the controller-side
-# install paths are covered by the in-host verification in the PR body.
-log "running bridge_linux_share_plugin_catalog with operator's own controller home"
+# Drive the helper against the fake controller home via the test seam
+# (BRIDGE_CONTROLLER_HOME_OVERRIDE). The seam refuses to honor the
+# override unless BRIDGE_HOME is under a tempdir prefix; we asserted that
+# above. The controller_user passed in is unused once the override is
+# active, but we still pass the operator's name so the call-shape
+# matches production.
+log "running bridge_linux_share_plugin_catalog against fake controller home $CONTROLLER_HOME_FAKE"
 CONTROLLER_USER="$(id -un)"
-bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
 
 ISOLATED_PLUGINS="$TEST_OS_HOME/.claude/plugins"
 
@@ -218,12 +221,106 @@ if sudo -n -u "$TEST_OS_USER" bash -c "echo broken > '$ISOLATED_PLUGINS/installe
   die "isolated UID should not be able to write its own installed_plugins.json"
 fi
 if sudo -n -u "$TEST_OS_USER" rm -f "$ISOLATED_PLUGINS/installed_plugins.json" 2>/dev/null; then
-  # rm may succeed since plugins/ is r-x to isolated UID and the manifest is
-  # in a parent dir owned by root, so unlink requires write on the parent.
-  # Confirm the file actually disappeared. If it did, that is the failure.
   if [[ ! -e "$ISOLATED_PLUGINS/installed_plugins.json" ]]; then
     die "isolated UID was able to unlink its own installed_plugins.json"
   fi
+fi
+
+log "verifying per-UID manifest contents only list the declared plugin"
+manifest_dump="$(sudo -n cat "$ISOLATED_PLUGINS/installed_plugins.json")"
+echo "$manifest_dump" | python3 -c '
+import json, sys
+m = json.load(sys.stdin)
+plugins = list(m.get("plugins", {}).keys())
+assert plugins == ["declared-plugin@td-mkt"], f"unexpected manifest plugins: {plugins!r}"
+entry = m["plugins"]["declared-plugin@td-mkt"][0]
+assert "installPath" in entry and entry["installPath"], "missing installPath"
+' || die "per-UID manifest contents do not match the channel boundary"
+
+log "verifying catalog symlinks resolve to controller copies"
+for catalog in known_marketplaces.json install-counts-cache.json blocklist.json; do
+  link="$ISOLATED_PLUGINS/$catalog"
+  [[ -L "$link" ]] || die "expected $link to be a symlink"
+  resolved="$(sudo -n readlink -f "$link" 2>/dev/null || true)"
+  expected="$CONTROLLER_PLUGINS/$catalog"
+  [[ "$resolved" == "$expected" ]] || die "catalog symlink $link resolved to $resolved (expected $expected)"
+done
+
+log "verifying declared plugin's install path has u:${TEST_OS_USER}:r-X recursively"
+declared_path="$BRIDGE_HOME/plugins/declared-plugin"
+sudo -n getfacl --no-effective "$declared_path" 2>/dev/null \
+  | grep -Eq "^user:${TEST_OS_USER}:r(-x|wx)" \
+  || die "declared plugin dir missing u:${TEST_OS_USER}:r-x ACL ($declared_path)"
+sudo -n getfacl --no-effective "$declared_path/server.ts" 2>/dev/null \
+  | grep -Eq "^user:${TEST_OS_USER}:r--" \
+  || die "declared plugin file missing u:${TEST_OS_USER}:r-- ACL"
+
+log "verifying isolated UID can read declared plugin sources"
+sudo -n -u "$TEST_OS_USER" cat "$declared_path/server.ts" >/dev/null \
+  || die "isolated UID should be able to read declared plugin source"
+
+log "verifying undeclared plugin's install path has NO u:${TEST_OS_USER} ACL entry"
+undeclared_path="$BRIDGE_HOME/plugins/undeclared-plugin"
+undeclared_acl_count="$(sudo -n getfacl --no-effective "$undeclared_path" 2>/dev/null \
+  | grep -cE "^user:${TEST_OS_USER}:" || true)"
+[[ "$undeclared_acl_count" == "0" ]] \
+  || die "undeclared plugin dir has $undeclared_acl_count u:${TEST_OS_USER} ACL entr(ies); expected 0"
+undeclared_file_acl_count="$(sudo -n getfacl --no-effective "$undeclared_path/server.ts" 2>/dev/null \
+  | grep -cE "^user:${TEST_OS_USER}:" || true)"
+[[ "$undeclared_file_acl_count" == "0" ]] \
+  || die "undeclared plugin file has $undeclared_file_acl_count u:${TEST_OS_USER} ACL entr(ies); expected 0"
+
+log "verifying isolated UID is denied access to undeclared plugin sources"
+if sudo -n -u "$TEST_OS_USER" cat "$undeclared_path/server.ts" >/dev/null 2>&1; then
+  die "isolated UID should NOT be able to read undeclared plugin source"
+fi
+
+log "verifying persisted grant-set state file recorded the channel"
+state_file="$BRIDGE_ACTIVE_AGENT_DIR/$TEST_AGENT/isolated-plugin-grants.json"
+sudo -n test -e "$state_file" || die "expected persisted grant-set at $state_file"
+sudo -n cat "$state_file" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+chans = data.get("channels", [])
+assert chans == ["plugin:declared-plugin@td-mkt"], f"unexpected persisted channels: {chans!r}"
+' || die "persisted grant-set contents do not match"
+
+log "running bridge_migration_unisolate (dry_run=0) and verifying full ACL strip"
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_migration_unisolate "$TEST_AGENT" 0 \
+  || die "bridge_migration_unisolate failed"
+
+log "verifying every controller-side u:${TEST_OS_USER} ACL is gone"
+for path in \
+  "$declared_path" \
+  "$declared_path/server.ts" \
+  "$CONTROLLER_PLUGINS/known_marketplaces.json" \
+  "$CONTROLLER_PLUGINS/install-counts-cache.json" \
+  "$CONTROLLER_PLUGINS/blocklist.json"; do
+  [[ -e "$path" ]] || continue
+  count="$(sudo -n getfacl --no-effective "$path" 2>/dev/null \
+    | grep -cE "^user:${TEST_OS_USER}:" || true)"
+  [[ "$count" == "0" ]] \
+    || die "post-unisolate u:${TEST_OS_USER} ACL still present on $path ($count entr(ies))"
+done
+
+log "verifying legacy \$BRIDGE_HOME/plugins ACL strip leaves no u:${TEST_OS_USER} residue"
+residue="$(sudo -n getfacl --no-effective -R "$BRIDGE_HOME/plugins" 2>/dev/null \
+  | grep -cE "^user:${TEST_OS_USER}:" || true)"
+[[ "$residue" == "0" ]] \
+  || die "legacy \$BRIDGE_HOME/plugins still has $residue u:${TEST_OS_USER} ACL entr(ies)"
+
+log "verifying isolated-side cleanup removed catalog symlinks + per-UID manifest"
+for catalog in known_marketplaces.json install-counts-cache.json blocklist.json installed_plugins.json; do
+  link="$ISOLATED_PLUGINS/$catalog"
+  if sudo -n test -e "$link" 2>/dev/null || sudo -n test -L "$link" 2>/dev/null; then
+    die "post-unisolate $link still exists; expected isolated-side cleanup to remove it"
+  fi
+done
+
+log "verifying persisted grant-set state file was removed"
+if sudo -n test -e "$state_file" 2>/dev/null; then
+  die "post-unisolate $state_file still exists; expected grant-set teardown"
 fi
 
 log "isolation plugin sharing test passed"

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# tests/isolation-plugin-sharing.sh
+#
+# Regression test for the channel-ownership-aware plugin sharing fix.
+#
+# Verifies:
+#   1. After isolate, the per-UID installed_plugins.json contains only
+#      plugins declared in BRIDGE_AGENT_CHANNELS, with installPath rewritten
+#      to the actually-existing on-disk location.
+#   2. Per-UID installed_plugins.json is root-owned and read-only to the
+#      isolated UID (the agent cannot tamper with which plugins it loads).
+#   3. plugins/ root is root-owned with isolated UID r-x; plugins/data/
+#      is isolated UID-owned and writable.
+#   4. The declared plugin's directory-source install path receives a
+#      u:<os_user>:r-X recursive ACL, while an undeclared plugin under the
+#      same marketplace receives no ACL.
+#   5. After unisolate, the catalog metadata files, declared plugin install
+#      paths, traverse chain, and the legacy BRIDGE_HOME/plugins tree all
+#      have no remaining u:<os_user> ACL entries.
+#
+# Skip preconditions: Linux, passwordless sudo, setfacl, useradd available.
+# Creates a temporary system user and tears it down at the end.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+log() { printf '[isolate-plugin] %s\n' "$*"; }
+die() { printf '[isolate-plugin][error] %s\n' "$*" >&2; exit 1; }
+skip() { printf '[isolate-plugin][skip] %s\n' "$*"; exit 0; }
+
+[[ "$(uname -s)" == "Linux" ]] || skip "Linux-only test"
+command -v sudo >/dev/null 2>&1 || skip "sudo required"
+sudo -n true >/dev/null 2>&1 || skip "passwordless sudo required"
+command -v setfacl >/dev/null 2>&1 || skip "setfacl (acl package) required"
+command -v useradd >/dev/null 2>&1 || skip "useradd required"
+command -v userdel >/dev/null 2>&1 || skip "userdel required"
+
+TMP_ROOT="$(mktemp -d -t isolate-plugin-test.XXXXXX)"
+SAFE_TMP_PREFIX=""
+for _candidate in "${TMPDIR%/}" "/tmp" "/var/tmp"; do
+  [[ -n "$_candidate" ]] || continue
+  case "$TMP_ROOT" in
+    "$_candidate"|"$_candidate"/*) SAFE_TMP_PREFIX="$_candidate"; break ;;
+  esac
+done
+[[ -n "$SAFE_TMP_PREFIX" ]] || die "TMP_ROOT did not land under a recognised tempdir prefix: $TMP_ROOT"
+
+# Temp BRIDGE_HOME with a tiny directory marketplace ("td-mkt") containing
+# both a declared plugin (declared-plugin) and an undeclared plugin
+# (undeclared-plugin).
+export BRIDGE_HOME="$TMP_ROOT/bridge-home"
+export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
+export BRIDGE_ROSTER_FILE="$BRIDGE_HOME/agent-roster.sh"
+export BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_HOME/agent-roster.local.sh"
+export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+mkdir -p "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR" "$BRIDGE_SHARED_DIR"
+: > "$BRIDGE_ROSTER_FILE"
+: > "$BRIDGE_ROSTER_LOCAL_FILE"
+
+# Set up a fake controller .claude/plugins/ tree so the helper has a
+# realistic surface to share. This stays under the controller's own home
+# layout: $TMP_ROOT/controller-home/.claude/plugins/.
+CONTROLLER_HOME_FAKE="$TMP_ROOT/controller-home"
+CONTROLLER_PLUGINS="$CONTROLLER_HOME_FAKE/.claude/plugins"
+mkdir -p "$CONTROLLER_PLUGINS/cache/td-mkt/declared-plugin/0.1.0" \
+         "$CONTROLLER_PLUGINS/cache/td-mkt/undeclared-plugin/0.1.0" \
+         "$CONTROLLER_PLUGINS/data" \
+         "$CONTROLLER_PLUGINS/marketplaces"
+echo 'declared plugin source' > "$CONTROLLER_PLUGINS/cache/td-mkt/declared-plugin/0.1.0/index.js"
+echo 'undeclared plugin source' > "$CONTROLLER_PLUGINS/cache/td-mkt/undeclared-plugin/0.1.0/index.js"
+cat > "$CONTROLLER_PLUGINS/installed_plugins.json" <<JSON
+{
+  "version": 2,
+  "plugins": {
+    "declared-plugin@td-mkt": [
+      {"scope": "user", "version": "0.1.0",
+       "installPath": "$CONTROLLER_PLUGINS/cache/td-mkt/declared-plugin/0.1.0"}
+    ],
+    "undeclared-plugin@td-mkt": [
+      {"scope": "user", "version": "0.1.0",
+       "installPath": "$CONTROLLER_PLUGINS/cache/td-mkt/undeclared-plugin/0.1.0"}
+    ]
+  }
+}
+JSON
+cat > "$CONTROLLER_PLUGINS/known_marketplaces.json" <<JSON
+{
+  "td-mkt": {
+    "source": {"source": "directory", "path": "$BRIDGE_HOME"},
+    "installLocation": "$BRIDGE_HOME"
+  }
+}
+JSON
+echo '{}' > "$CONTROLLER_PLUGINS/install-counts-cache.json"
+echo '{}' > "$CONTROLLER_PLUGINS/blocklist.json"
+
+# Directory-marketplace shape: $BRIDGE_HOME/plugins/{declared-plugin,undeclared-plugin}
+mkdir -p "$BRIDGE_HOME/plugins/declared-plugin" "$BRIDGE_HOME/plugins/undeclared-plugin"
+echo 'declared plugin (dir-marketplace)' > "$BRIDGE_HOME/plugins/declared-plugin/server.ts"
+echo 'undeclared plugin (dir-marketplace)' > "$BRIDGE_HOME/plugins/undeclared-plugin/server.ts"
+
+TEST_AGENT="qpa-test"
+TEST_OS_USER="agent-bridge-${TEST_AGENT}"
+TEST_OS_HOME="/home/${TEST_OS_USER}"
+
+cleanup_test_user_locked=0
+cleanup() {
+  set +e
+  if [[ "$cleanup_test_user_locked" -eq 0 ]] && id "$TEST_OS_USER" >/dev/null 2>&1; then
+    sudo -n userdel "$TEST_OS_USER" >/dev/null 2>&1 || true
+    sudo -n rm -rf "$TEST_OS_HOME" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if id "$TEST_OS_USER" >/dev/null 2>&1; then
+  cleanup_test_user_locked=1
+  log "reusing existing OS user $TEST_OS_USER"
+else
+  sudo -n useradd --system --home-dir "$TEST_OS_HOME" --shell /usr/sbin/nologin "$TEST_OS_USER" >/dev/null \
+    || die "useradd failed for $TEST_OS_USER"
+fi
+sudo -n mkdir -p "$TEST_OS_HOME"
+sudo -n chown "$TEST_OS_USER:$TEST_OS_USER" "$TEST_OS_HOME"
+sudo -n chmod 0700 "$TEST_OS_HOME"
+
+TEST_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$TEST_AGENT"
+mkdir -p "$TEST_WORKDIR"
+
+# Roster declares declared-plugin@td-mkt only.
+cat > "$BRIDGE_ROSTER_LOCAL_FILE" <<ROSTER
+#!/usr/bin/env bash
+bridge_add_agent_id_if_missing() { :; }
+declare -gA BRIDGE_AGENT_ENGINE BRIDGE_AGENT_SESSION BRIDGE_AGENT_WORKDIR BRIDGE_AGENT_LAUNCH_CMD
+declare -gA BRIDGE_AGENT_ISOLATION_MODE BRIDGE_AGENT_OS_USER BRIDGE_AGENT_CHANNELS
+BRIDGE_AGENT_IDS=("$TEST_AGENT")
+BRIDGE_AGENT_ENGINE[$TEST_AGENT]=claude
+BRIDGE_AGENT_SESSION[$TEST_AGENT]=$TEST_AGENT
+BRIDGE_AGENT_WORKDIR[$TEST_AGENT]=$TEST_WORKDIR
+BRIDGE_AGENT_LAUNCH_CMD[$TEST_AGENT]='true'
+BRIDGE_AGENT_CHANNELS[$TEST_AGENT]='plugin:declared-plugin@td-mkt'
+BRIDGE_AGENT_ISOLATION_MODE[$TEST_AGENT]=linux-user
+BRIDGE_AGENT_OS_USER[$TEST_AGENT]=$TEST_OS_USER
+ROSTER
+
+# shellcheck source=../bridge-lib.sh
+source "$REPO_ROOT/bridge-lib.sh"
+bridge_load_roster
+
+# Override the controller_home lookup the helper uses by spoofing the
+# passwd entry — easiest is to rely on the actual operator's $HOME having
+# .claude/plugins/, which we don't want to touch in this test. Instead we
+# call the helper with our own controller_user that resolves to
+# CONTROLLER_HOME_FAKE.
+#
+# The helper resolves controller_home via getent passwd <controller>; we
+# create a temp passwd hook by exporting HOME for the controller_user
+# evaluation isn't going to work. Approach: use the live operator user
+# but redirect through a per-test fake home via a wrapper that the helper
+# does not currently support.
+#
+# Simpler: skip this test until a controller-home injection seam is added,
+# OR run the helper with controller_user=<a fake user we create in /etc/passwd>.
+# The latter is too invasive for a regression test. So we test by:
+#   - calling bridge_linux_share_plugin_catalog with user_home=$TEST_OS_HOME
+#     and controller_user=$(id -un), and pointing the helper's path probes
+#     at our fake controller via a temporary HOME redirect for the helper's
+#     getent fallback.
+#
+# Since the helper does `getent passwd "$controller_user" | cut -d: -f6`,
+# we only need that getent to return our fake controller home for the test
+# user. Use unshare/mount to overlay /etc/passwd? Too invasive for CI.
+#
+# Pragmatic: temporarily replace $HOME and call a wrapper that the helper
+# uses. But the helper does NOT use $HOME; it uses getent. So this is the
+# real seam gap.
+#
+# To keep this test runnable today without a code change, we rely on the
+# operator having a real $HOME/.claude/plugins/ and verify only the
+# *isolated*-side effects (per-UID manifest, ownership, ACLs on the
+# plugins/ root). The cross-grant assertions on the controller-side
+# install paths are covered by the in-host verification in the PR body.
+log "running bridge_linux_share_plugin_catalog with operator's own controller home"
+CONTROLLER_USER="$(id -un)"
+bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+ISOLATED_PLUGINS="$TEST_OS_HOME/.claude/plugins"
+
+log "verifying plugins/ root is root-owned with isolated UID r-x"
+sudo -n stat -c '%U:%G %a' "$ISOLATED_PLUGINS" | grep -Fq "root:root 750" \
+  || die "expected $ISOLATED_PLUGINS to be root:root 0750"
+sudo -n getfacl --no-effective "$ISOLATED_PLUGINS" 2>/dev/null | grep -Fq "user:${TEST_OS_USER}:r-x" \
+  || die "expected u:${TEST_OS_USER}:r-x ACL on $ISOLATED_PLUGINS"
+
+log "verifying plugins/data is isolated UID-owned and writable"
+sudo -n stat -c '%U:%G %a' "$ISOLATED_PLUGINS/data" | grep -Fq "${TEST_OS_USER}:${TEST_OS_USER} 700" \
+  || die "expected $ISOLATED_PLUGINS/data to be ${TEST_OS_USER}:${TEST_OS_USER} 0700"
+sudo -n -u "$TEST_OS_USER" bash -c "echo probe > '$ISOLATED_PLUGINS/data/x' && cat '$ISOLATED_PLUGINS/data/x' >/dev/null" \
+  || die "isolated UID should be able to write+read its own plugins/data/"
+sudo -n -u "$TEST_OS_USER" rm -f "$ISOLATED_PLUGINS/data/x"
+
+log "verifying per-UID installed_plugins.json is root-owned r-- to isolated UID"
+sudo -n stat -c '%U:%G %a' "$ISOLATED_PLUGINS/installed_plugins.json" | grep -Fq "root:root 640" \
+  || die "expected per-UID installed_plugins.json to be root:root 0640"
+sudo -n getfacl --no-effective "$ISOLATED_PLUGINS/installed_plugins.json" 2>/dev/null | grep -Fq "user:${TEST_OS_USER}:r--" \
+  || die "expected u:${TEST_OS_USER}:r-- ACL on per-UID installed_plugins.json"
+
+log "verifying isolated UID cannot tamper with its own manifest"
+if sudo -n -u "$TEST_OS_USER" bash -c "echo broken > '$ISOLATED_PLUGINS/installed_plugins.json'" 2>/dev/null; then
+  die "isolated UID should not be able to write its own installed_plugins.json"
+fi
+if sudo -n -u "$TEST_OS_USER" rm -f "$ISOLATED_PLUGINS/installed_plugins.json" 2>/dev/null; then
+  # rm may succeed since plugins/ is r-x to isolated UID and the manifest is
+  # in a parent dir owned by root, so unlink requires write on the parent.
+  # Confirm the file actually disappeared. If it did, that is the failure.
+  if [[ ! -e "$ISOLATED_PLUGINS/installed_plugins.json" ]]; then
+    die "isolated UID was able to unlink its own installed_plugins.json"
+  fi
+fi
+
+log "isolation plugin sharing test passed"


### PR DESCRIPTION
## Summary

Isolated agents started with an empty `~/.claude/plugins/` tree. The sudo wrap engaged, the per-UID Claude credentials path (#125) loaded, but Claude itself loaded zero MCP servers — Teams, ms365, and any other channel plugin all silently missing. The only mitigation in `bridge_linux_prepare_agent_isolation` was a recursive `r-X` grant on `$BRIDGE_HOME/plugins`, which broke the single-tenant intent: every isolated UID could read every directory-source plugin's source, regardless of which channels the agent had declared.

This PR replaces the broad grant with a channel-ownership-aware sharing model keyed off `BRIDGE_AGENT_CHANNELS["<agent>"]` (already the SSOT used by `apply-channel-policy.sh` from #246/#254). Each isolated UID sees only the catalog metadata plus the install paths of the plugins it has declared.

## What the isolated UID gets

| Surface | Owner / mode | Isolated UID access | Notes |
|---|---|---|---|
| `<isolated>/.claude/plugins/` | `root:root 0750` | `r-x` (ACL) | Can traverse and read directory entries; cannot mutate. |
| `<isolated>/.claude/plugins/installed_plugins.json` | `root:root 0640` | `r--` (ACL) | Per-UID generated; lists only `BRIDGE_AGENT_CHANNELS` entries with `installPath` rewritten to the actual on-disk directory. |
| `<isolated>/.claude/plugins/{known_marketplaces, install-counts-cache, blocklist}.json` | symlink → controller | `r--` on the targets | Catalog metadata; treated as audit-level disclosure. |
| `<isolated>/.claude/plugins/data/` | `<os_user>:<os_user> 0700` | `rwx` (own) | Plugin runtime state writable by the agent. |
| `<controller>/.claude/plugins/cache/<owned>` or `<bridge_home>/plugins/<owned>` | controller | `r-X` recursive + traverse chain | Channel-owned plugin code. |
| `<controller>/.claude/plugins/<not-owned>` | controller | none | Cross-agent code isolation enforced. |
| `<controller>/.claude/plugins/data/` | controller | none | Controller plugin runtime state stays private. |

## Notable details

* `bridge_resolve_plugin_install_path` first reads `installed_plugins.json` and only falls back to `known_marketplaces[<marketplace>].source.path/plugins/<plugin>` when the manifest's `installPath` is missing or stale (the case for Agent Bridge's own directory-source `teams`/`ms365` after a cache rebuild).
* `bridge_write_isolated_installed_plugins_manifest` preserves the controller entry's metadata (`version`, `gitCommitSha`, etc.) when only the install path needed rewriting.
* Order is: `bridge_linux_grant_traverse_chain` first (stamps `--x` from target up to controller home), then `bridge_linux_acl_add_recursive ":r-X"` on the target tree. Doing them in the other order lets the chain's `--x` overwrite the target's `r-X`.
* `bridge_linux_revoke_traverse_chain` mirrors the grant function and runs in `bridge_migration_unisolate` to strip the same parent ACLs.
* `bridge_migration_unisolate` also strips `$BRIDGE_HOME/plugins` recursively for the target os_user as a backward-compat cleanup; hosts that ran the prior broad-grant code accumulate stale ACL entries until they are unisolated and re-isolated.
* `lib/bridge-core.sh` declares `BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES` so the isolate and unisolate paths iterate the exact same list. Adding a new catalog file is a one-line change in one place.

## What is intentionally not in scope

If an agent in shared mode loads a plugin via a user-level `enabledPlugins` entry that is not in its `BRIDGE_AGENT_CHANNELS`, that plugin will not load under linux-user isolation after this PR. Changing the source of truth from `BRIDGE_AGENT_CHANNELS` to `enabledPlugins` is a wider design question (it affects `apply-channel-policy.sh` and the per-agent `settings.json` model from #246/#254). Filing that as a separate issue if maintainers want to broaden the sharing rule; this PR keeps the existing channel-ownership SSOT.

The isolated UID's `plugins/` directory itself is root-owned, but the parent `~/.claude/` is still isolated-UID-owned, so the agent can in principle unlink the entire `plugins/` tree and recreate it locally. That is outside the threat model this PR targets (controller's plugin state is what we are protecting; preventing the agent from breaking its own home is a separate hardening discussion).

## Verified end-to-end

On a private deployment with one Claude agent flipped from `shared` to `linux-user` isolation:

* `BRIDGE_AGENT_CHANNELS["<agent>"]="plugin:teams@agent-bridge"` declared.
* `agent-bridge isolate <agent> --install-sudoers` then `agent-bridge isolate <agent> --reapply`.
* `getfacl <bridge_home>/plugins/teams` → `user:agent-bridge-<agent>:r-x` (recursive).
* `getfacl <bridge_home>/plugins/ms365` → no `u:agent-bridge-<agent>` entries.
* Per-UID `installed_plugins.json` contained only `teams@agent-bridge`, `installPath` rewritten to the live directory-source path; `root:root 0640`.
* `<isolated_home>/.claude/plugins` was `root:root 0750`; `<isolated_home>/.claude/plugins/data` was `<os_user>:<os_user> 0700` and writable by the agent.
* `unisolate <agent>` cleared catalog, install-path, traverse-chain, and the legacy `$BRIDGE_HOME/plugins` ACLs for the test UID without touching the controller's own grants.

## Test plan

- [x] `bash -n lib/bridge-agents.sh lib/bridge-core.sh lib/bridge-migration.sh tests/isolation-plugin-sharing.sh`
- [x] In-place verification on the affected deployment.
- [ ] CI: full smoke + shellcheck.
- [ ] CI: `tests/isolation-plugin-sharing.sh` on a Linux runner with passwordless sudo + acl + useradd available (skips otherwise).

## Cross-references

* #287 (merged): queue-gateway agent-dir ACL fix. Until that landed, isolated agents could not even reach their own inbox; until this PR lands, even a successful gateway round trip cannot bring up plugin MCP servers in the isolated UID.
* #246 / #254: `apply-channel-policy.sh` already uses `BRIDGE_AGENT_CHANNELS` to scope plugin enablement per agent in shared mode. This PR extends the same model to filesystem ACLs for isolated mode.
* #233: traverse-chain `stop_path` discipline preserved end-to-end (no walk past controller home).
* #294: companion issue for the scoped roster + gateway proxy detection coupling that surfaced together with this gap. Filed separately because the failure modes and tests are different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
