### PR TITLE
docs: skill heredocs — Cron section + agb dispatcher note (#283 Track B follow-up)

### DIFF
--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -385,6 +385,15 @@ Use this guide when a task involves tmux-based agent coordination through \`${br
 - Mark a task done: \`${bridge_home}/agent-bridge done 12 --agent developer --note "재현 불가"\`
 - Hand off a task: \`${bridge_home}/agent-bridge handoff 12 --to tester --note "수정 반영 후 재확인 부탁"\`
 
+## Cron
+
+- Cron is documented in detail in the \`cron-manager\` skill (auto-linked into every static agent's skill set).
+- List jobs for an agent: \`${bridge_home}/agent-bridge cron list --agent <agent>\`
+- Inspect a job: \`${bridge_home}/agent-bridge cron show <job-name-or-id>\`
+- Failed-run report (the answer to "show me cron history / cron logs / cron status" — those do not exist): \`${bridge_home}/agent-bridge cron errors report --agent <agent>\`
+- Trigger a job ad-hoc: \`${bridge_home}/agent-bridge cron enqueue <job-name-or-id> --target <agent>\`
+- Create / update / delete: see \`cron-manager\` skill or \`${bridge_home}/agent-bridge cron --help\`.
+
 ## Urgent Interrupts
 
 - Send a direct urgent message only when interrupting is necessary: \`bash ${bridge_home}/bridge-send.sh --urgent developer "[TESTER] 프로덕션 장애 확인 필요" --wait 5\`
@@ -439,6 +448,7 @@ Use this skill when the task depends on the shared agent bridge in \`${bridge_ho
 - Prefer the live roster over guesswork when identifying active tmux sessions.
 - Treat \`${bridge_home}/state/\` and \`${bridge_home}/logs/\` as generated runtime artifacts.
 - Prefer queued tasks over direct messages so agents can pull work at task boundaries.
+- \`agb\` is a compact dispatcher for the queue/inbox subset of \`agent-bridge\` (\`agb inbox|show|claim|done|summary|create\`). Everything else (status, list, cron, watchdog, audit, urgent, action, kill, worktree, ...) is on \`agent-bridge\`. There is no \`agb help\` or \`agb status\` — only \`agb --help\` (with the dashes).
 EOF
 }
 
@@ -475,6 +485,7 @@ Use this skill when work depends on the shared agent bridge in \`${bridge_home}\
 - Do not edit generated runtime files under \`${bridge_home}/state/\` or \`${bridge_home}/logs/\`.
 - Check the static roster in \`${bridge_home}/agent-roster.sh\` before assuming an agent name or action exists.
 - Keep urgent interrupts short and move details into task queue entries or shared files.
+- \`agb\` is a compact dispatcher for the queue/inbox subset of \`agent-bridge\` (\`agb inbox|show|claim|done|summary|create\`). Everything else (status, list, cron, watchdog, audit, urgent, action, kill, worktree, ...) is on \`agent-bridge\`. There is no \`agb help\` or \`agb status\` — only \`agb --help\` (with the dashes).
 EOF
 }
 


### PR DESCRIPTION
## Summary

Companion to PR #307 (which expanded the committed `.claude/skills/cron-manager/SKILL.md` template). The other two surfaces named in #283 Track B (`agent-bridge/references/bridge-commands.md` and `agent-bridge/SKILL.md`) are not committed source — they are heredoc strings inside `lib/bridge-skills.sh::bridge_render_*_project_skill`. PR #307 correctly stopped at the docs-only boundary; this PR completes Track B by patching the heredocs.

## What changed

`lib/bridge-skills.sh`, three additions:

1. `bridge_render_project_bridge_reference`: new `## Cron` section between `## Task Queue` and `## Urgent Interrupts`. Documents `list`, `show`, `errors report`, `enqueue`. Explicitly names \`cron history\` / \`cron logs\` / \`cron status\` as common agent guesses with \`cron errors report\` as the actual answer.
2. `bridge_render_codex_project_skill`: appends a Guardrails bullet distinguishing the \`agb\` compact dispatcher (queue/inbox-only) from the full \`agent-bridge\` surface. Names \`agb help\` / \`agb status\` as not-recognised; only \`agb --help\` works.
3. `bridge_render_claude_project_skill`: same Guardrails bullet, mirrored for the Claude project skill.

## Verification

```
$ bash -n lib/bridge-skills.sh
$ shellcheck lib/bridge-skills.sh   # clean
$ /opt/homebrew/bin/bash -c 'cd .; source bridge-lib.sh; bridge_render_project_bridge_reference /tmp/test'  # contains '## Cron' block
$ /opt/homebrew/bin/bash -c 'cd .; source bridge-lib.sh; bridge_render_claude_project_skill /tmp/test'       # contains 'compact dispatcher' bullet
$ /opt/homebrew/bin/bash -c 'cd .; source bridge-lib.sh; bridge_render_codex_project_skill /tmp/test'        # contains 'compact dispatcher' bullet
```

All four checks pass.

## CI

Pre-existing CI failure on \`main\` (200 most recent runs are all \`failure\`, going back to 2026-04-21; assert at \`scripts/smoke-test.sh:3885\` for \`session=\$CREATED_SESSION\`). Not caused by this PR.

## Scope discipline

- Single commit, single file (`lib/bridge-skills.sh`).
- No VERSION bump, no CHANGELOG. Release contract preserved.
- Issue #283 stays open for Tracks A (CLI-help-driven generator — replaces this hand-maintained heredoc with a generated one), C (\`agb help\` / \`cron <unknown>\` suggestions; partial coverage already exists in \`bridge_suggest_subcommand\`), and D (\`agb\` bare-call ergonomics).

Addresses the second half of Track B of #283. The remaining tracks stay open.