### PR TITLE
cli: extend bridge_suggest_subcommand curated aliases (#283 Track C)

### DIFF
--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -54,11 +54,17 @@ bridge_suggest_subcommand() {
     "cron list --failed"|"cron failed"|"cron failures"|"cron errors"|"cron error")
       suggestions="agent-bridge cron errors report"
       ;;
+    "cron history"|"cron log"|"cron logs"|"cron audit"|"cron runs")
+      suggestions="agent-bridge cron errors report  |  agent-bridge cron show <job>"
+      ;;
     "queue status"|"queue stats"|"task stats")
       suggestions="agent-bridge summary  |  agent-bridge status"
       ;;
     ps|processes|agents)
       suggestions="agent-bridge list  |  agent-bridge status"
+      ;;
+    help)
+      suggestions="agent-bridge --help"
       ;;
   esac
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -287,6 +287,14 @@ run_suggest_case "task stats -> summary (task dispatcher intent)" \
   "task stats" "" "agent-bridge summary"
 run_suggest_case "diagnose -> status/watchdog (top-level intent)" \
   "diagnose" "" "agent-bridge status"
+# Issue #283 Track C: cron history / logs / audit / runs all redirect to
+# cron errors report (the actual answer); plain `help` redirects to --help.
+run_suggest_case "cron history -> cron errors report (#283 Track C)" \
+  "cron history" "" "agent-bridge cron errors report"
+run_suggest_case "cron logs -> cron errors report (#283 Track C)" \
+  "cron logs" "" "agent-bridge cron errors report"
+run_suggest_case "help -> --help (#283 Track C)" \
+  "help" "" "agent-bridge --help"
 
 run_dispatch_suggest_case() {
   local label="$1"


### PR DESCRIPTION
## Summary

Extends the existing `bridge_suggest_subcommand` curated alias table in `lib/bridge-core.sh` so agents stop burning turns on a small set of common false guesses identified in #283.

## What changed

Three new aliases in the curated table:

| Unknown input | Suggested commands |
|---|---|
| `cron history` / `cron log` / `cron logs` / `cron audit` / `cron runs` | `agent-bridge cron errors report  \|  agent-bridge cron show <job>` |
| `help` | `agent-bridge --help` |

The cron-history family is the canonical example from the issue body — agents reach for `cron history` / `cron logs` / `cron status` first because of \`git\` / \`docker\` / \`systemd\` ergonomics, but none of those exist. \`cron status\` was already in the curated table; this PR adds the rest of the obvious aliases.

\`help\` (plain, no dashes) is rejected by the dispatcher today — only \`--help\` works. The new alias makes the suggestion explicit when an agent (or human) types \`agent-bridge help\` or \`agb help\`.

## Smoke fixtures

Three new \`run_suggest_case\` invocations in \`scripts/smoke-test.sh\` cover the new aliases. Existing fixtures untouched. Verified locally:

```
$ /opt/homebrew/bin/bash -c 'cd .; source ./bridge-lib.sh; bridge_suggest_subcommand "cron history" ""'
혹시 이 명령이었나요?  agent-bridge cron errors report  |  agent-bridge cron show <job>
$ /opt/homebrew/bin/bash -c 'cd .; source ./bridge-lib.sh; bridge_suggest_subcommand "help" ""'
혹시 이 명령이었나요?  agent-bridge --help
$ /opt/homebrew/bin/bash -c 'cd .; source ./bridge-lib.sh; bridge_suggest_subcommand "blarghgz" "admin bootstrap"'
(empty — no false suggestion)
```

## CI

Pre-existing CI failure on \`main\` (200 most recent runs are all \`failure\`, going back to 2026-04-21; assert at \`scripts/smoke-test.sh:3885\` for \`session=\$CREATED_SESSION\`). Not caused by this PR. The new \`run_suggest_case\` fixtures land before the failing assertion and run cleanly.

## Scope discipline

- \`lib/bridge-core.sh\`: +6 lines (two new \`case\` arms in the existing curated table).
- \`scripts/smoke-test.sh\`: +8 lines (three new fixture cases).
- No VERSION bump, no CHANGELOG. Release contract preserved.
- Single commit.

Issue #283 stays open for Tracks A (CLI-help-driven generator — replaces hand-maintained tables) and D (\`agb\` bare-call ergonomics — invokes help summary instead of erroring on no args). Track B fully shipped in PR #307 + PR #308.

Addresses Track C of #283. The remaining tracks stay open.