### PR TITLE
cli: bare agent-bridge prints help summary (#283 Track D)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -355,6 +355,16 @@ start_static_agent() {
   exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" "${start_args[@]}"
 }
 
+# Issue #283 Track D: bare invocation prints help instead of falling through
+# to the legacy ad-hoc spawn parser, which dies with the misleading
+# "--codex 또는 --claude 중 하나를 지정하세요" error. The legacy spawn path is
+# rare; the common path is queue/inbox dispatching, which is what the help
+# summary highlights.
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
 if [[ $# -gt 0 ]]; then
   case "$1" in
     admin)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -296,6 +296,14 @@ run_suggest_case "cron logs -> cron errors report (#283 Track C)" \
 run_suggest_case "help -> --help (#283 Track C)" \
   "help" "" "agent-bridge --help"
 
+# Issue #283 Track D: bare agent-bridge / agb prints help instead of erroring.
+log "agent-bridge bare invocation prints help summary (#283 Track D)"
+BARE_HELP_OUT="$(env BRIDGE_HOME="$(mktemp -d)" "$BASH4_BIN" "$REPO_ROOT/agent-bridge" 2>&1 || true)"
+assert_contains "$BARE_HELP_OUT" "Usage:"
+assert_contains "$BARE_HELP_OUT" "agent-bridge status"
+[[ "$BARE_HELP_OUT" != *"--codex 또는 --claude 중 하나를 지정하세요"* ]] \
+  || die "bare agent-bridge should not error with engine-required message"
+
 run_dispatch_suggest_case() {
   local label="$1"
   local expected_substring="$2"


### PR DESCRIPTION
## Summary

Bare \`agent-bridge\` (and its \`agb\` shim) previously errored with `--codex 또는 --claude 중 하나를 지정하세요` because the script fell through to the legacy ad-hoc spawn parser. That message is correct only for the rare interactive-spawn path; for the common queue/inbox use case it just sends agents into option-guessing.

This PR adds an early bail at the top of the dispatcher: if \`$# -eq 0\`, print the existing \`usage()\` summary and exit 0. The legacy spawn path is preserved for explicit \`--codex\` / \`--claude\` invocations.

## What changed

- `agent-bridge` (+10): early `if [[ $# -eq 0 ]]; then usage; exit 0; fi` after the helper functions and before the existing top-level case dispatcher.
- `scripts/smoke-test.sh` (+8): new fixture exercises bare invocation. Asserts:
  - output contains \`Usage:\` and \`agent-bridge status\`
  - output does **not** contain \`--codex 또는 --claude 중 하나를 지정하세요\`

## Verification

```
$ ./agent-bridge ; echo "rc=$?"
Usage:
  agent-bridge status [--watch] ...
  agent-bridge version [--json]
  ...
rc=0

$ ./agent-bridge --codex --name foo --dry-run    # legacy spawn path still routes here
[오류] 알 수 없는 옵션: --dry-run
```

The legacy spawn path is unchanged — \`--codex\` / \`--claude\` still drive into the spawn flag parser; only the no-args case is intercepted.

## CI

Pre-existing CI failure on \`main\` (200 most recent runs all \`failure\`, going back to 2026-04-21; assert at \`scripts/smoke-test.sh:3885\` for \`session=\$CREATED_SESSION\`). Not caused by this PR. The new fixture lands at line ~298, well before the failing assertion.

## Scope discipline

- Two files, single commit.
- No VERSION bump, no CHANGELOG. Release contract preserved.

Issue #283 stays open only for Track A (CLI-help-driven generator that replaces the hand-maintained skill heredocs and curated alias table). Tracks B (PR #307 + #308) and C (PR #309) shipped earlier today.

Addresses Track D of #283.