### PR TITLE
status + list: flag agents with missing workdir at dashboard layer (#305 Track C)

### DIFF
--- a/bridge-status.py
+++ b/bridge-status.py
@@ -77,6 +77,19 @@ def short_path(path: str) -> str:
     return expanded
 
 
+def workdir_display(path: str) -> str:
+    # Issue #305 Track C: surface a missing workdir at the dashboard layer so a
+    # leaked smoke-fixture roster block (or any deleted/renamed/expired
+    # registration) is visible without opening agent-roster.local.sh manually.
+    short = short_path(path)
+    if not path or short == "-":
+        return short
+    expanded = str(Path(path).expanduser())
+    if not Path(expanded).is_dir():
+        return f"{short}  [missing]"
+    return short
+
+
 def read_roster(path: str) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
     with open(path, "r", encoding="utf-8") as handle:
@@ -351,7 +364,7 @@ def render_dashboard(args: argparse.Namespace) -> str:
             f"{channel_state:>4} "
             f"{fmt_age(int(last_nudge_ts) if last_nudge_ts else None):>5}  "
             f"{load_bar:<12}  "
-            f"{(row.get('session') or '-')[:12]:<12}  {short_path(row.get('workdir', ''))}"
+            f"{(row.get('session') or '-')[:12]:<12}  {workdir_display(row.get('workdir', ''))}"
         )
 
     if channel_warning_rows:

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3359,12 +3359,21 @@ bridge_list_active_agents_numbered() {
       session_id="-"
     fi
 
+    # Issue #305 Track C: flag stale registrations whose workdir no longer
+    # exists on disk so a leaked smoke fixture or deleted-repo agent is
+    # visible in `agent-bridge list` without inspecting the roster file.
+    local _workdir
+    _workdir="$(bridge_agent_workdir "$agent")"
+    if [[ -n "$_workdir" && ! -d "$_workdir" ]]; then
+      _workdir="$_workdir [missing]"
+    fi
+
     printf '%d. %s | engine=%s | tmux=%s | cwd=%s | source=%s | loop=%s | inbox=%s | claimed=%s | session_id=%s\n' \
       "$index" \
       "$agent" \
       "$(bridge_agent_engine "$agent")" \
       "$(bridge_agent_session "$agent")" \
-      "$(bridge_agent_workdir "$agent")" \
+      "$_workdir" \
       "$(bridge_agent_source "$agent")" \
       "$(bridge_agent_loop "$agent")" \
       "${queue_counts[$agent]-0}" \


### PR DESCRIPTION
## Summary

Closes the third track of #305. Tracks A (smoke fixture teardown) and B (\`bridge_project_root_for_path\` silence) shipped in PR #311 (\`7feb929\`); Track C surfaces stale registrations whose workdir no longer exists on disk so a polluted host is visible at \`agent-bridge status\` / \`list\` instead of requiring the operator to grep \`agent-roster.local.sh\`.

## What changed

`bridge-status.py`:
- New `workdir_display(path)` helper. Returns the same `short_path` output for empty / existing dirs, and appends a literal \`  [missing]\` suffix when the registered workdir does not resolve to a real directory.
- Swap the agent row's workdir column to use the helper.

`lib/bridge-agents.sh::bridge_active_agent_ids` printer (the body of \`agent-bridge list\`):
- Compute the workdir once via \`bridge_agent_workdir\`, then append \` [missing]\` before substituting into the \`cwd=\` field when the path does not exist on disk. Preserves the source path so the operator can still see what the registration claims.

Both surfaces are **observability-only** — no behavior change. Render-only displays for agents whose workdir disappeared (deleted repo, expired worktree, leaked smoke fixture, renamed home).

## Verification

```
$ /opt/homebrew/bin/bash -c 'cd .; python3 -c "
import importlib.util
spec = importlib.util.spec_from_file_location(\"bs\", \"./bridge-status.py\")
m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
print(\"existing:\", repr(m.workdir_display(\"/tmp\")))
print(\"missing:\", repr(m.workdir_display(\"/tmp/does-not-exist-xxxxx\")))
print(\"empty:\", repr(m.workdir_display(\"\")))
"'
existing: '/tmp'
missing: '/tmp/does-not-exist-xxxxx  [missing]'
empty: '-'

$ /opt/homebrew/bin/bash -n lib/bridge-agents.sh && shellcheck lib/bridge-agents.sh
(clean)
$ python3 -c "import ast; ast.parse(open('bridge-status.py').read())"
(clean)
```

## CI

Pre-existing CI failure on \`main\` since 2026-04-21 (assert at \`scripts/smoke-test.sh:3885\` for \`session=\$CREATED_SESSION\`). Not caused by this PR.

## Scope discipline

- Two files, single commit (24 LOC total).
- No VERSION bump, no CHANGELOG. Release contract preserved.
- PR title uses \`(#305 Track C)\` — close-keyword footgun avoided.
- No behavior change. Observability-only.

Tracks A + B + C of #305 are all now landed.