### PR TITLE
skills: bridge-commands.md auto-discovers subcommand reference from CLI help (#283 Track A)

### DIFF
--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -129,6 +129,86 @@ PY
   fi
 }
 
+# bridge_cli_subcommand_help_summary — extract Usage lines for one subcommand.
+#
+# Issue #283 Track A: skill content (`bridge-commands.md`) was hand-maintained
+# and drifted out of sync with the real CLI surface. This helper parses
+# `<cli> --help` and returns every Usage line whose first token after the CLI
+# name matches `$1`. Caller renders the result however it wants (one bullet
+# per line, in the auto-discovered "Full Subcommand Reference" section).
+#
+# Defensive contract: missing CLI, unreadable CLI, malformed --help output, or
+# a subcommand that has no Usage entries all return empty stdout with rc=0.
+# Never fails. Never writes to stderr.
+#
+# Usage:
+#   bridge_cli_subcommand_help_summary cron "$BRIDGE_HOME/agent-bridge"
+#
+# Args:
+#   $1 — top-level subcommand name (e.g. "cron", "task"). Required; empty
+#        returns empty.
+#   $2 — path to the agent-bridge CLI binary. Optional; defaults to
+#        ${BRIDGE_CLI_NAME:-${BRIDGE_SCRIPT_DIR}/agent-bridge} so the helper
+#        works inside the source checkout without explicit wiring.
+bridge_cli_subcommand_help_summary() {
+  local subcommand="$1"
+  local cli="${2:-${BRIDGE_CLI_NAME:-${BRIDGE_SCRIPT_DIR:-.}/agent-bridge}}"
+
+  [[ -n "$subcommand" ]] || return 0
+  [[ -n "$cli" && -f "$cli" ]] || return 0
+
+  "$cli" --help 2>/dev/null | awk -v cmd="$subcommand" '
+    BEGIN { in_usage = 0 }
+    /^Usage:/                    { in_usage = 1; next }
+    in_usage == 0                { next }
+    /^[^[:space:]]/              { in_usage = 0; next }
+    /^[[:space:]]*$/             { next }
+    {
+      sub(/^[[:space:]]+/, "")
+      if (NF < 2) next
+      if ($2 == cmd) print $0
+    }
+  '
+}
+
+# bridge_cli_top_level_subcommands — list unique top-level subcommand names.
+#
+# Issue #283 Track A: the auto-discovered subcommand reference renders one
+# section per top-level subcommand. This helper returns the unique
+# second-tokens of every Usage line in `<cli> --help`, skipping flag-shaped
+# entries like `--codex|--claude` so the renderer doesn't produce a section
+# titled with a flag union.
+#
+# Defensive contract: missing or unreadable CLI returns empty stdout with rc=0.
+# Output is one subcommand per line, in the order they first appear in --help
+# (so the rendered reference mirrors the operator-facing layout).
+bridge_cli_top_level_subcommands() {
+  local cli="${1:-${BRIDGE_CLI_NAME:-${BRIDGE_SCRIPT_DIR:-.}/agent-bridge}}"
+
+  [[ -n "$cli" && -f "$cli" ]] || return 0
+
+  "$cli" --help 2>/dev/null | awk '
+    BEGIN { in_usage = 0 }
+    /^Usage:/                    { in_usage = 1; next }
+    in_usage == 0                { next }
+    /^[^[:space:]]/              { in_usage = 0; next }
+    /^[[:space:]]*$/             { next }
+    {
+      sub(/^[[:space:]]+/, "")
+      if (NF < 2) next
+      sub_cmd = $2
+      # Skip flag-shaped pseudo-subcommands (e.g. "--codex|--claude") so
+      # the rendered reference does not produce a `### --codex|--claude`
+      # section header.
+      if (sub_cmd ~ /^-/) next
+      if (!(sub_cmd in seen)) {
+        seen[sub_cmd] = 1
+        print sub_cmd
+      }
+    }
+  '
+}
+
 bridge_warn() {
   echo -e "${YELLOW}[경고] $*${NC}" >&2
 }

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -412,6 +412,35 @@ Use this guide when a task involves tmux-based agent coordination through \`${br
 - Prefer task queue entries plus file paths over direct message pastes
 - Runtime state under \`${bridge_home}/state/\` and logs under \`${bridge_home}/logs/\` are generated files and should not be hand-edited
 EOF
+
+  # Issue #283 Track A — root fix for skill staleness. The intent-grouped
+  # sections above are still hand-curated narrative (they tell the reader
+  # *which* command to reach for given an intent). The section below is the
+  # complement: a flat enumeration of every Usage line `agent-bridge --help`
+  # currently emits, so newly added subcommands cannot drift out of the skill
+  # surface without a corresponding regeneration. If `agent-bridge` is missing
+  # or its --help output is malformed, the helpers degrade to empty output
+  # and we emit nothing — never an exit failure during skill regeneration.
+  #
+  # The CLI source-of-truth here is the source-checkout binary
+  # (`$BRIDGE_SCRIPT_DIR/agent-bridge`), not `${bridge_home}/agent-bridge` —
+  # the runtime path is a symlink back into the source checkout, so reading
+  # the source binary keeps the render reproducible from a fresh checkout
+  # before any live runtime has been linked. The helpers' default fallback
+  # picks this up automatically when called with no explicit CLI path.
+  local auto_subcommand=""
+  local auto_usage_line=""
+
+  printf '\n## Full Subcommand Reference\n\n'
+  printf '_Auto-generated from `agent-bridge --help` at agent setup time. If a command is missing here, run `%s/agent-bridge upgrade --restart-daemon` to refresh the runtime, then `%s/bridge-setup.sh` to regenerate the skill._\n' "$bridge_home" "$bridge_home"
+  while IFS= read -r auto_subcommand; do
+    [[ -n "$auto_subcommand" ]] || continue
+    printf '\n### %s\n\n' "$auto_subcommand"
+    while IFS= read -r auto_usage_line; do
+      [[ -n "$auto_usage_line" ]] || continue
+      printf -- '- `%s`\n' "$auto_usage_line"
+    done < <(bridge_cli_subcommand_help_summary "$auto_subcommand")
+  done < <(bridge_cli_top_level_subcommands)
 }
 
 bridge_render_codex_project_skill() {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -350,6 +350,46 @@ run_suggest_case "cron logs -> cron errors report (#283 Track C)" \
 run_suggest_case "help -> --help (#283 Track C)" \
   "help" "" "agent-bridge --help"
 
+# Issue #283 Track A: skill content is now derived from the live CLI surface
+# via two helpers in lib/bridge-core.sh. The four checks below mirror the
+# verification matrix in the Track A brief: helper returns Usage lines for a
+# real subcommand, returns empty for an unknown subcommand, and the rendered
+# bridge-commands.md contains both the new auto-discovered section and every
+# existing intent-grouped section (regression guard).
+log "CLI-help-driven skill reference (#283 Track A)"
+TRACK_A_OUT="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_cli_subcommand_help_summary cron "'"$REPO_ROOT"'/agent-bridge"
+')"
+assert_contains "$TRACK_A_OUT" "cron list"
+assert_contains "$TRACK_A_OUT" "cron create"
+assert_contains "$TRACK_A_OUT" "cron errors report"
+log "  [ok] bridge_cli_subcommand_help_summary cron returns live CLI surface"
+
+TRACK_A_EMPTY="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_cli_subcommand_help_summary nonexistent-subcommand "'"$REPO_ROOT"'/agent-bridge"
+')"
+[[ -z "$TRACK_A_EMPTY" ]] \
+  || die "expected empty summary for nonexistent subcommand, got: $TRACK_A_EMPTY"
+log "  [ok] bridge_cli_subcommand_help_summary returns empty for unknown subcommand"
+
+TRACK_A_RENDER="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_render_project_bridge_reference /tmp/test-bridge-home
+')"
+assert_contains "$TRACK_A_RENDER" "## Full Subcommand Reference"
+assert_contains "$TRACK_A_RENDER" "### cron"
+assert_contains "$TRACK_A_RENDER" "### task"
+log "  [ok] bridge-commands.md renders auto-discovered Full Subcommand Reference"
+
+for _track_a_hdr in "## Roster" "## Start Or Resume Agents" "## Task Queue" \
+                    "## Cron" "## Urgent Interrupts" "## Stop Sessions" \
+                    "## Share Larger Files"; do
+  assert_contains "$TRACK_A_RENDER" "$_track_a_hdr"
+done
+log "  [ok] intent-grouped sections preserved (Roster/Start/Task Queue/Cron/Urgent/Stop/Share)"
+
 # Issue #283 Track D: bare agent-bridge / agb prints help instead of erroring.
 log "agent-bridge bare invocation prints help summary (#283 Track D)"
 BARE_HELP_OUT="$(env BRIDGE_HOME="$(mktemp -d)" "$BASH4_BIN" "$REPO_ROOT/agent-bridge" 2>&1 || true)"


### PR DESCRIPTION
## Summary

- Make the `## Full Subcommand Reference` section of `bridge-commands.md` a function of `agent-bridge --help`, so newly added subcommands cannot drift out of the auto-linked skill surface.
- Add two helpers in `lib/bridge-core.sh` that parse the CLI's Usage block; `bridge_render_project_bridge_reference` consumes them to append the auto-discovered section.
- Hand-curated intent-grouped sections (Roster / Start / Task Queue / Cron / Urgent / Stop / Share) remain unchanged — this PR is additive, not a replacement.

## Why this is the root fix

From issue #283:

> Track A — generator parses CLI `--help` (canonical)
>
> Skill template generators … should parse `agent-bridge <subcommand> --help` (and `agb --help`) at regeneration time and emit one Commands subsection per actual subcommand. Schema-driven, no hand-maintained lists.
>
> This way the skill template is a generated reflection of the CLI surface and cannot drift.

Tracks B/C/D (PRs #307–#310) plugged specific staleness symptoms; Track A removes the staleness mechanism itself for the highest-impact piece (`bridge-commands.md`). Cron-manager `SKILL.md` is a separate, larger change because it has narrative + guidance + metadata that aren't 1:1 with `--help` (per the issue's out-of-scope list).

## What's new

`lib/bridge-core.sh`:

- `bridge_cli_subcommand_help_summary <subcommand> [<cli-path>]` — returns every Usage line whose first token after the CLI name matches `<subcommand>`, leading whitespace stripped. Empty input or unreadable CLI → empty stdout, rc=0.
- `bridge_cli_top_level_subcommands [<cli-path>]` — returns unique second-tokens across all Usage lines, in first-seen order, skipping flag-shaped pseudo-subcommands like `--codex|--claude` so the renderer doesn't emit a flag-titled section.

Both helpers default to `${BRIDGE_CLI_NAME:-${BRIDGE_SCRIPT_DIR}/agent-bridge}` so they work from a fresh source checkout without explicit wiring; both degrade to empty output when `--help` is missing or malformed (never an exit failure during skill regeneration).

`lib/bridge-skills.sh::bridge_render_project_bridge_reference`:

- After the existing heredoc, append `## Full Subcommand Reference` with one `### <subcommand>` block per top-level subcommand, one bullet per Usage line. The section opens with a regeneration hint so operators know how to refresh it.

## What's preserved (regression guard)

The seven intent-grouped sections still appear ahead of the auto-discovered block:

- `## Roster`
- `## Start Or Resume Agents`
- `## Task Queue`
- `## Cron`
- `## Urgent Interrupts`
- `## Stop Sessions`
- `## Share Larger Files`

The hand-curated narrative there steers agents from *intent* to *command*; the auto-discovered section complements it with a flat enumeration the operator can grep.

## Verification matrix

```
$ bash -n lib/bridge-core.sh lib/bridge-skills.sh scripts/smoke-test.sh
(no output)

$ shellcheck lib/bridge-core.sh lib/bridge-skills.sh scripts/smoke-test.sh
(no output)

# Helper unit checks
$ /opt/homebrew/bin/bash -c '
    cd .
    source ./bridge-lib.sh
    out="$(bridge_cli_subcommand_help_summary cron ./agent-bridge)"
    echo "$out" | grep -qF "cron list" || { echo FAIL; exit 1; }
    echo "$out" | grep -qF "cron create" || { echo FAIL; exit 1; }
    echo "$out" | grep -qF "cron errors report" || { echo FAIL; exit 1; }
    empty="$(bridge_cli_subcommand_help_summary nonexistent-cmd ./agent-bridge)"
    [[ -z "$empty" ]] || { echo FAIL; exit 1; }
    echo OK helper
  '
OK helper

# Render checks (uses /tmp/test-bridge-home — helpers fall back to source CLI)
$ /opt/homebrew/bin/bash -c '
    cd .
    source ./bridge-lib.sh
    out="$(bridge_render_project_bridge_reference /tmp/test-bridge-home)"
    echo "$out" | grep -F "## Full Subcommand Reference" >/dev/null && echo OK header
    echo "$out" | grep -F "### cron" >/dev/null && echo OK cron
    echo "$out" | grep -F "### task" >/dev/null && echo OK task
    for hdr in "## Roster" "## Start Or Resume Agents" "## Task Queue" \
               "## Cron" "## Urgent Interrupts" "## Stop Sessions" \
               "## Share Larger Files"; do
      echo "$out" | grep -qF "$hdr" && echo "OK preserved: $hdr"
    done
  '
OK header
OK cron
OK task
OK preserved: ## Roster
OK preserved: ## Start Or Resume Agents
OK preserved: ## Task Queue
OK preserved: ## Cron
OK preserved: ## Urgent Interrupts
OK preserved: ## Stop Sessions
OK preserved: ## Share Larger Files
```

Smoke fixtures for these checks land in `scripts/smoke-test.sh` under the `CLI-help-driven skill reference (#283 Track A)` log block (lines added near the `run_suggest_case` sequence).

## CI status note

`./scripts/smoke-test.sh` halts at the pre-existing `expected bridge-run to relaunch the restart orphan cleanup smoke role` failure (mcp-restart.log not found). This failure has been on `main` since 2026-04-21 and is unrelated to this change — same root cause as every recent PR. Track A's smoke fixtures verify successfully when the block is run in isolation against this branch (`/opt/homebrew/bin/bash` + `source bridge-lib.sh`, output above).

---

Addresses Track A of #283. Issue closes when this lands plus the matching changes for `cron-manager/SKILL.md` and the curated alias table — those are out of scope for this PR.