### PR TITLE
docs: lead upgrade guidance with 'upgrade --apply'; admin role spec adds Upgrade Protocol (#315 Tracks 1 + 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,22 +51,30 @@ version bumps via the `VERSION` file.
   intent in your local roster and continue indexing-only via
   `collect_index_documents` (still walks both roots). See
   `docs/agent-runtime/memory-schema.md`.
+- **Do not run `bridge-daemon.sh stop` separately before `upgrade --apply`** —
+  the upgrader handles daemon orchestration internally. Stopping the daemon
+  manually on a v0.6.13 host can cascade into all-agent tmux respawn with
+  stale `AGENT_SESSION_ID` resume (see issue #314). On hosts upgraded past
+  v0.6.13 the cascade is mitigated by hardening waves shipped in v0.6.14-0.6.16,
+  but `upgrade --apply` remains the only sanctioned entrypoint.
 - **Recommended upgrade order on a host with running agents**:
   ```bash
-  # 1. Stop the daemon (sweeps any pre-#273 orphans)
-  bash ~/.agent-bridge/bridge-daemon.sh stop
-  # 2. Pull source + upgrade (auto: apply-channel-policy, restart agents)
+  # Recommended upgrade on a host with running agents — single entrypoint
   agent-bridge upgrade --apply
-  # 3. (Linux) verify single daemon PID
+
+  # (Linux) verify single daemon PID
   pgrep -af 'bridge-daemon\.sh run$'
-  # 4. (Optional) per-agent plugin allowlist + restart specific agents
+
+  # (Optional) per-agent plugin allowlist + restart specific agents
   $EDITOR ~/.agent-bridge/agent-roster.local.sh   # add BRIDGE_AGENT_PLUGINS
   bash ~/.agent-bridge/scripts/apply-channel-policy.sh
   agb agent restart <agent>
-  # 5. (Optional, per agent) daily-note migration
+
+  # (Optional, per agent) daily-note migration
   bridge-memory.py migrate-canonical --home ~/.agent-bridge/agents/<agent> \
     --user default --apply --i-know-this-is-live
-  # 6. (Optional, per host) liveness watcher install
+
+  # (Optional, per host) liveness watcher install
   bash ~/.agent-bridge/scripts/install-daemon-liveness-launchagent.sh \
     --apply --load
   ```

--- a/agents/_template/CLAUDE.md
+++ b/agents/_template/CLAUDE.md
@@ -131,6 +131,14 @@ When the daemon injects a line that starts with `[Agent Bridge] event=` (queue i
 - 유지보수 trigger는 이 admin이 오늘 사용할 수 있는 bridge primitive만으로 전부 해소한다. (#304 Track B에서 bridge-managed `autopilot-compact` / `handoff-restart` primitive가 요청되어 있고, 그것이 들어오기 전까지는 static 에이전트를 nudge하는 대신 외부 채널의 사람 operator에게 에스컬레이션하는 것이 옳은 경로다. nudge는 옳지 않다.)
 - end-user에게는 그들이 실제로 체감할 만한 동작 변화가 있을 때만 알린다. 그 외 admin이 처리한 유지보수는 조용히 끝낸다.
 
+## Admin Upgrade Protocol
+- 이 섹션은 `SESSION-TYPE.md`의 Session Type이 `admin`일 때만 적용된다.
+- 실행 중인 에이전트가 있는 호스트에서 `~/.agent-bridge/agent-bridge upgrade --apply`는 **유일하게 허가된 업그레이드 엔트리포인트**다. 업그레이더가 daemon stop, restart, 에이전트 재기동을 내부적으로 모두 처리한다.
+- `bash bridge-daemon.sh stop`이나 `agb daemon stop`을 `upgrade --apply` 이전 단계로 분리해서 실행하지 않는다. v0.6.14+ daemon hardening wave가 적용되지 않은 호스트에서 이를 실행하면, 모든 에이전트의 tmux 세션이 재생성되며 stale `AGENT_SESSION_ID`로 resume되는 cascade가 발생할 수 있다 (이슈 #314, #315 참고).
+- 어떤 문서가 "stop → upgrade → verify"를 분리된 단계로 보여주더라도 그 sequence를 만들지 않는다. 업그레이드는 단일 atomic 명령으로 취급한다.
+- `agent-bridge upgrade --apply` 자체가 실패하면(network, source-checkout drift, 중간 abort), daemon을 수동으로 stop하지 말고 공유 외부 채널로 사람 operator에게 실패를 보고한다. manual daemon-stop은 표준 업그레이드 경로의 일부가 아니라 recovery action이며, 실패를 본 operator의 명시적 승인 후에만 사용한다.
+- 업그레이드 후 daemon health 확인은 read-only 명령으로 한다: Linux에서는 `pgrep -af 'bridge-daemon\.sh run$'`, 어느 OS에서든 `agb daemon status`를 사용한다.
+
 ## Channel Setup Protocol
 - 사용자가 어떤 에이전트든 새로 만들거나 설정하면서 채널을 언급하면, 먼저 선택지를 명확히 확인한다: `터미널만`, `Discord`, `Telegram`, `Discord와 Telegram 둘 다`.
 - Discord 또는 Telegram을 하나라도 선택하면 해당 에이전트는 Claude Code 엔진이어야 한다. Codex 요청과 외부 채널 요청이 충돌하면, 이유를 한 문장으로 설명하고 Claude Code로 진행한다.


### PR DESCRIPTION
## Summary

Removes the documented "stop daemon first, then upgrade" sequence that drove the v0.6.13 patch admin agent into the all-agent tmux respawn cascade described in companion issue #314. Leads upgrade guidance with the single sanctioned entrypoint, `agent-bridge upgrade --apply`, and adds an admin-role-spec rule so any future admin agent treats upgrade as one atomic command. Docs-only; no code paths touched.

## Track 1 — CHANGELOG upgrade block

`CHANGELOG.md` v0.6.17 entry, "Recommended upgrade order on a host with running agents" block.

**Before** (lead):
```bash
# 1. Stop the daemon (sweeps any pre-#273 orphans)
bash ~/.agent-bridge/bridge-daemon.sh stop
# 2. Pull source + upgrade (auto: apply-channel-policy, restart agents)
agent-bridge upgrade --apply
```

**After** (lead):
```bash
# Recommended upgrade on a host with running agents — single entrypoint
agent-bridge upgrade --apply
```

A warning paragraph now sits above the bullet explaining that manual `bridge-daemon.sh stop` is not part of the standard path on v0.6.13, and that on hosts past v0.6.13 the cascade is mitigated by hardening waves shipped in v0.6.14-0.6.16 but `upgrade --apply` remains the only sanctioned entrypoint.

The remaining steps (Linux PID verify, optional plugin allowlist, optional daily-note migration, optional liveness watcher install) are unchanged — only the lead step was unsafe.

## Track 2 — Admin Upgrade Protocol section

New section in `agents/_template/CLAUDE.md`:

```
## Admin Upgrade Protocol
- 이 섹션은 `SESSION-TYPE.md`의 Session Type이 `admin`일 때만 적용된다.
- 실행 중인 에이전트가 있는 호스트에서 `~/.agent-bridge/agent-bridge upgrade --apply`는 **유일하게 허가된 업그레이드 엔트리포인트**다 …
```

Placed immediately after the two PR #306 admin-only sections (`## Admin Self-Cleanup of Own Queue`, `## Admin Static vs Dynamic Agent Boundary`) and immediately before `## Channel Setup Protocol`. Same gating convention (`SESSION-TYPE.md` Session Type = `admin`). 6 bullets: scope gate, single-entrypoint rule, no-separate-stop rule, atomic-command rule, failure-recovery rule (escalate to operator on the shared external channel; manual daemon-stop is recovery, not part of the standard flow), and read-only post-upgrade health check.

## What's preserved

- v0.6.13 / v0.6.14 / v0.6.15 / v0.6.16 historical CHANGELOG entries — untouched.
- `OPERATIONS.md` `## Upgrade` — untouched (already led with `agb upgrade`, which is the safe shape).
- The two prior PR #306 admin sections (`## Admin Self-Cleanup of Own Queue`, `## Admin Static vs Dynamic Agent Boundary`) — untouched.
- All other `_template/CLAUDE.md` sections (`## Autonomy & Anti-Stall` regression-guarded by `scripts/smoke-test.sh:5408`) — untouched.
- No `VERSION` bump. No new CHANGELOG entry — the fix is *inside* the existing v0.6.17 entry's upgrade-order block.

## Verification

```
$ grep -n '^## ' agents/_template/CLAUDE.md
…
126:## Admin Static vs Dynamic Agent Boundary
134:## Admin Upgrade Protocol
142:## Channel Setup Protocol
…
$ grep -F '## Admin Upgrade Protocol' agents/_template/CLAUDE.md
## Admin Upgrade Protocol
$ grep -F '## Admin Self-Cleanup of Own Queue' agents/_template/CLAUDE.md
## Admin Self-Cleanup of Own Queue
$ grep -F '## Admin Static vs Dynamic Agent Boundary' agents/_template/CLAUDE.md
## Admin Static vs Dynamic Agent Boundary

$ grep -A 3 'Recommended upgrade order on a host with running agents' CHANGELOG.md | grep -F 'agent-bridge upgrade --apply'
  agent-bridge upgrade --apply
$ grep -A 8 'Recommended upgrade order on a host with running agents' CHANGELOG.md | head -12 | grep -F 'bridge-daemon.sh stop' && echo "FAIL: stop still in upgrade block" || echo "OK: stop removed from upgrade block"
OK: stop removed from upgrade block

$ grep -F 'Do not run `bridge-daemon.sh stop` separately' CHANGELOG.md
- **Do not run `bridge-daemon.sh stop` separately before `upgrade --apply`** —

$ grep -F '## Autonomy & Anti-Stall' agents/_template/CLAUDE.md
## Autonomy & Anti-Stall

$ bash -n scripts/smoke-test.sh && echo OK
OK
```

All five brief-mandated checks pass.

## CI

Pre-existing CI failure on `main` since 2026-04-21 (mcp-restart.log relaunch / created-session smoke step). Not caused by this PR — this is a docs-only change touching `CHANGELOG.md` and `agents/_template/CLAUDE.md` only.

Addresses Tracks 1 + 2 of #315. Track 3 (`bridge-daemon.sh stop` active-agent guard) stays open and will be handled in a separate wave together with companion #314 Layer 3. The mechanical bug in #314 is also separate.