### PR TITLE
hooks: SessionStart auto-clears AGENT_SESSION_ID on /clear matcher (#314 Layer 1)

### DIFF
--- a/hooks/session_start.py
+++ b/hooks/session_start.py
@@ -3,9 +3,13 @@
 
 Matcher handling (Track 2):
 - Claude Code fires this hook with a `matcher` field when settings.json
-  uses matcher-based entries. Known values: `startup`, `resume`, `compact`.
+  uses matcher-based entries. Known values: `startup`, `resume`, `clear`,
+  `compact`.
 - The hook reads the matcher from `--matcher` first, then a JSON payload
   on stdin (Claude Code hands `{"matcher": "compact", ...}` in via stdin).
+- For `clear`, the hook auto-clears the agent's persisted AGENT_SESSION_ID
+  so the next `bridge-run.sh <agent> --continue` does not resume the stale
+  pre-clear session id (issue #314 Layer 1).
 - For `compact`, the hook appends a short note telling the session that
   it just came out of a compaction, pointing at the raw capture store.
 """
@@ -15,6 +19,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -26,7 +31,7 @@ from bridge_hook_common import (
 )
 
 
-_KNOWN_MATCHERS = {"startup", "resume", "compact"}
+_KNOWN_MATCHERS = {"startup", "resume", "clear", "compact"}
 # Compaction typically fires the SessionStart hook once, but upstream may
 # redeliver (retries, nested session-resumes). Suppress duplicate compact
 # notes that arrive within this window so the note is emitted at most once
@@ -89,13 +94,46 @@ def _compact_note_should_emit(agent: str, now_epoch: int | None = None) -> bool:
     return True
 
 
+def _forget_session_on_clear(agent: str) -> None:
+    """Auto-forget the persisted resume id when /clear forks the session.
+
+    Issue #314 Layer 1: when an operator runs /clear in a Claude session,
+    the persisted AGENT_SESSION_ID still points at the pre-clear id. A
+    later restart picks up the stale id and `claude --resume <stale>`
+    lands on the context-saturated old session instead of the live forked
+    one. Calling forget-session here keeps the persisted id in sync with
+    what the operator actually has live.
+
+    The CLI wrapper does the auditing and the lock dance; we just invoke
+    it. Best-effort — the SessionStart hook has a 3s timeout and must
+    never block the session, so we suppress all errors and fall back to
+    the manual `agb agent forget-session <agent>` recovery path.
+    """
+    bridge_home = os.environ.get("BRIDGE_HOME") or os.path.expanduser("~/.agent-bridge")
+    cli = os.path.join(bridge_home, "agent-bridge")
+    if not os.path.isfile(cli):
+        return
+    try:
+        subprocess.run(
+            [cli, "agent", "forget-session", agent],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        # Best-effort: if forget-session fails for any reason, the manual
+        # `agb agent forget-session <agent>` recovery path (PR #268) still
+        # works.
+        pass
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--format", choices=("text", "codex"), default="text")
     parser.add_argument(
         "--matcher",
         default="",
-        help="Claude Code matcher (startup|resume|compact); overrides stdin payload",
+        help="Claude Code matcher (startup|resume|clear|compact); overrides stdin payload",
     )
     args = parser.parse_args(argv)
 
@@ -111,6 +149,8 @@ def main(argv: list[str] | None = None) -> int:
         matcher = ""
 
     remember_session_start(agent)
+    if matcher == "clear":
+        _forget_session_on_clear(agent)
     context = session_start_context(agent)
     if matcher == "compact" and _compact_note_should_emit(agent):
         context = context + _compact_note()

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2662,6 +2662,91 @@ CLAUDE_STATIC_CUSTOM_MARKER_FILE="$(BRIDGE_ACTIVE_AGENT_DIR="$CLAUDE_STATIC_CUST
 [[ -f "$CLAUDE_STATIC_CUSTOM_MARKER_FILE" ]] || die "session_start hook did not honour BRIDGE_ACTIVE_AGENT_DIR override — marker missing at $CLAUDE_STATIC_CUSTOM_MARKER_FILE"
 rm -f "$CLAUDE_STATIC_WORKDIR/NEXT-SESSION.md" "$CLAUDE_STATIC_CUSTOM_MARKER_FILE"
 rm -rf "$CLAUDE_STATIC_CUSTOM_ACTIVE_DIR"
+
+# Issue #314 Layer 1: SessionStart with matcher=clear must auto-clear the
+# persisted AGENT_SESSION_ID. Without this, a Claude /clear leaves the
+# agent's resume id pointing at the pre-clear session, and the next
+# `bridge-run.sh <agent> --continue` resumes the stale, context-saturated
+# session instead of the freshly forked one. The hook shells out to
+# `$BRIDGE_HOME/agent-bridge agent forget-session <agent>`. The smoke
+# `$BRIDGE_HOME` is not a copied install layout (the source CLI cannot be
+# symlinked here because it resolves SCRIPT_DIR via realpath and would
+# fail to find sibling lib/), so we install a stub shim that records its
+# invocation and performs the same persisted-id clear via the real
+# `bridge_clear_persisted_session_id`. This proves the hook is wired to
+# fork the CLI when matcher=clear and to skip it for matcher=startup.
+log "session_start hook auto-clears persisted session id on /clear matcher (#314 Layer 1)"
+SESSION_CLEAR_CLI_SHIM="$BRIDGE_HOME/agent-bridge"
+SESSION_CLEAR_SHIM_LOG="$TMP_ROOT/session-start-clear-shim.log"
+[[ -e "$SESSION_CLEAR_CLI_SHIM" ]] && SESSION_CLEAR_HAD_PRIOR_CLI=yes || SESSION_CLEAR_HAD_PRIOR_CLI=no
+cat >"$SESSION_CLEAR_CLI_SHIM" <<EOF
+#!/usr/bin/env bash
+# Stub agent-bridge CLI used only by the #314 Layer 1 smoke fixture.
+# Records every invocation and, when called as 'agent forget-session
+# <agent>', delegates to the real bridge_clear_persisted_session_id.
+printf 'invoked: %s\n' "\$*" >>"$SESSION_CLEAR_SHIM_LOG"
+if [[ "\${1:-}" == "agent" && "\${2:-}" == "forget-session" && -n "\${3:-}" ]]; then
+  source "$REPO_ROOT/bridge-lib.sh"
+  bridge_load_roster
+  bridge_clear_persisted_session_id "\$3" >/dev/null
+fi
+EOF
+chmod +x "$SESSION_CLEAR_CLI_SHIM"
+: >"$SESSION_CLEAR_SHIM_LOG"
+SESSION_CLEAR_FAKE_ID="smoke-pre-clear-id-$$"
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_SESSION_ID["claude-static"]="'"$SESSION_CLEAR_FAKE_ID"'"
+  bridge_persist_agent_state "claude-static"
+'
+SESSION_CLEAR_SEEDED_ID="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  bridge_agent_persisted_session_id "claude-static"
+')"
+[[ "$SESSION_CLEAR_SEEDED_ID" == "$SESSION_CLEAR_FAKE_ID" ]] || die "smoke seed for #314 fixture failed: persisted id=$SESSION_CLEAR_SEEDED_ID expected=$SESSION_CLEAR_FAKE_ID"
+BRIDGE_AGENT_ID="claude-static" BRIDGE_AGENT_WORKDIR="$CLAUDE_STATIC_WORKDIR" BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents" python3 "$REPO_ROOT/hooks/session_start.py" --matcher clear >/dev/null
+SESSION_CLEAR_AFTER_ID="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  bridge_agent_persisted_session_id "claude-static"
+')"
+[[ -z "$SESSION_CLEAR_AFTER_ID" ]] || die "session_start --matcher clear did not clear persisted id (still: $SESSION_CLEAR_AFTER_ID)"
+assert_contains "$(cat "$SESSION_CLEAR_SHIM_LOG")" "agent forget-session claude-static"
+# Idempotent re-run: clearing an already-empty id must not error and the
+# shim must still be invoked (forget-session itself is responsible for
+# the no-op behavior on an already-empty id).
+BRIDGE_AGENT_ID="claude-static" BRIDGE_AGENT_WORKDIR="$CLAUDE_STATIC_WORKDIR" BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents" python3 "$REPO_ROOT/hooks/session_start.py" --matcher clear >/dev/null
+SESSION_CLEAR_INVOCATIONS="$(grep -c '^invoked:' "$SESSION_CLEAR_SHIM_LOG" || true)"
+[[ "$SESSION_CLEAR_INVOCATIONS" -ge 2 ]] || die "expected at least 2 shim invocations after two --matcher clear runs, saw $SESSION_CLEAR_INVOCATIONS"
+# Regression guard: matcher=startup must NOT clear a freshly seeded id
+# and must NOT invoke the forget-session CLI.
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_SESSION_ID["claude-static"]="'"$SESSION_CLEAR_FAKE_ID"'-2"
+  bridge_persist_agent_state "claude-static"
+'
+: >"$SESSION_CLEAR_SHIM_LOG"
+BRIDGE_AGENT_ID="claude-static" BRIDGE_AGENT_WORKDIR="$CLAUDE_STATIC_WORKDIR" BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents" python3 "$REPO_ROOT/hooks/session_start.py" --matcher startup >/dev/null
+SESSION_STARTUP_AFTER_ID="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  bridge_agent_persisted_session_id "claude-static"
+')"
+[[ "$SESSION_STARTUP_AFTER_ID" == "$SESSION_CLEAR_FAKE_ID-2" ]] || die "session_start --matcher startup unexpectedly mutated persisted id (got: $SESSION_STARTUP_AFTER_ID)"
+[[ ! -s "$SESSION_CLEAR_SHIM_LOG" ]] || die "session_start --matcher startup unexpectedly forked the CLI: $(cat "$SESSION_CLEAR_SHIM_LOG")"
+# Clean up: drop the seeded id and remove the stub CLI shim so downstream
+# fixtures see the same state they did before this block.
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  bridge_clear_persisted_session_id "claude-static" >/dev/null
+'
+rm -f "$SESSION_CLEAR_SHIM_LOG"
+[[ "$SESSION_CLEAR_HAD_PRIOR_CLI" == "yes" ]] || rm -f "$SESSION_CLEAR_CLI_SHIM"
+
 CODEX_PROMPT_OUTPUT="$(BRIDGE_AGENT_ID="$SMOKE_AGENT" BRIDGE_HOME="$BRIDGE_HOME" python3 "$REPO_ROOT/hooks/prompt_timestamp.py" --format codex)"
 assert_contains "$CODEX_PROMPT_OUTPUT" "\"hookEventName\": \"UserPromptSubmit\""
 assert_contains "$CODEX_PROMPT_OUTPUT" "now:"


### PR DESCRIPTION
## Summary

Claude Code fires the SessionStart hook with one of four matcher values: `startup | resume | clear | compact`. Agent Bridge's hook only knew three of those, so a Claude `/clear` was silently treated as a no-op: the persisted `AGENT_SESSION_ID` was never refreshed, and a later restart re-launched with `claude --resume <stale-pre-clear-id>`, landing the agent back on the context-saturated old session that `/clear` had forked away from. This was the root of the #314 morning-`/clear` → afternoon-restart incident.

This PR is **Layer 1** of #314: tighten the SessionStart hook so `/clear` triggers the existing `agent forget-session` recovery primitive automatically, instead of leaving the persisted id stale until an operator notices and runs the manual recovery.

## What's new

1. **`hooks/session_start.py::_KNOWN_MATCHERS`** now includes `"clear"` (was: `{"startup", "resume", "compact"}`). The `--matcher` argparse help advertises the same set.
2. **New `_forget_session_on_clear(agent)` helper** in the same file. Shells out to `$BRIDGE_HOME/agent-bridge agent forget-session <agent>` when the hook fires with `matcher == "clear"`. Best-effort with a 2s subprocess timeout — the SessionStart hook has a 3s budget (`.claude/settings.json`) and must never block the session, so failures fall back to the manual `agb agent forget-session <agent>` recovery path that PR #268 shipped.
3. **`main()` wiring** — after `remember_session_start(agent)` and before the existing `compact` branch, call `_forget_session_on_clear(agent)` when the normalized matcher is `"clear"`. The `compact` branch and its dedup window are untouched.
4. **Module docstring** lists `clear` as a fourth known matcher and describes its effect (one line + cross-reference to issue #314 Layer 1).
5. **Smoke fixture** in `scripts/smoke-test.sh` (just after the existing SessionStart fixture). Seeds a synthetic `BRIDGE_AGENT_SESSION_ID` for `claude-static`, fires the hook with `--matcher clear`, asserts the persisted id is cleared via the real `bridge_clear_persisted_session_id`, re-runs idempotently, then re-seeds and asserts `--matcher startup` does NOT clear (regression guard) and does NOT fork the CLI. The fixture installs a tiny stub `agent-bridge` shim into the smoke `$BRIDGE_HOME` because the smoke harness is not a copied install layout — the real CLI resolves `SCRIPT_DIR` via realpath and would not find sibling `lib/` from a symlink. The shim records every invocation and delegates the actual clear to the real `bridge_clear_persisted_session_id`, so the fixture proves the wiring end-to-end.

## What's preserved

- `lib/bridge-state.sh::bridge_clear_persisted_session_id` — unchanged. The hook reuses the existing primitive (audit log, per-agent lock, multi-file rewrite) instead of re-implementing.
- `bridge-agent.sh::run_forget_session` — unchanged. The hook calls the existing `agent forget-session <agent>` CLI surface; the audit row is `agent_session_forgotten`, same as a manual operator invocation.
- `compact` matcher branch and the 5-minute dedup window — unchanged. Independent track.
- `.claude/settings.json` template — unchanged. The hook is already wired into all SessionStart fires; the matcher discrimination happens inside the hook.
- Hook stays best-effort (no exception escapes `_forget_session_on_clear`); the 2s subprocess timeout sits well inside the 3s SessionStart budget.

## Verification

| check | result |
|---|---|
| `python3 -c "import ast; ast.parse(open('hooks/session_start.py').read())"` | OK |
| `bash -n scripts/smoke-test.sh` | OK |
| `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh` | OK |
| `shellcheck scripts/smoke-test.sh` | clean (no warnings, no errors) |
| Negative path: `BRIDGE_AGENT_ID=fake-test python3 hooks/session_start.py --matcher fake` | exit 0; unknown matcher normalized to `""`; no CLI fork |
| Isolated `BRIDGE_HOME` repro (seed → `--matcher clear` → assert cleared → idempotent re-run → re-seed → `--matcher startup` → assert not cleared, no CLI fork → unknown matcher → no CLI fork) | all pass |
| `./scripts/smoke-test.sh` | aborted at the chronic upstream halt point (auto-start `time.sleep(30)` chain — pre-existing in `main`); the new fixture is line-distance gated behind it. Isolated repro covers the same matrix end-to-end. |

The smoke fixture itself was validated by reproducing its exact bash + python pipeline against an isolated `BRIDGE_HOME`:

```
=== Step 3: fire SessionStart hook with --matcher clear ===
=== Step 4: verify shim was invoked ===
invoked: agent forget-session claude-static
=== Step 5: verify persisted id is now empty ===
persisted=[]
=== Step 6: idempotent re-run ===
  exit=0
=== Step 8: verify startup did NOT invoke shim, did NOT clear ===
  shim-log-size=0
persisted=[seed-startup-id-99]
=== Step 9: unknown matcher must not invoke shim either ===
  shim-log-size=0
```

## CI

Pre-existing CI failure on `main` since 2026-04-21 (same root cause as every recent PR — chronic queue-task assertion in the upstream smoke harness). Not blocking.

---

Addresses Layer 1 of #314. Layers 2 (`bridge-daemon.sh stop` cascade investigation) and 3 (`bridge-daemon.sh stop` active-agent guard + `--force`) stay open.

Generated with [Claude Code](https://claude.com/claude-code)