### PR TITLE
daemon: refuse 'stop' when active agents present unless --force (#314 Layer 3, #315 Track 3)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -261,6 +261,19 @@ Stop the daemon:
 agb daemon stop
 ```
 
+**Active-agent guard** (issues #314 / #315): `bridge-daemon.sh stop` refuses
+to stop the daemon when active bridge agents are running on the host, and
+prints a banner pointing at the sanctioned upgrade entrypoint. To stop the
+daemon during a recovery scenario, pass `--force`:
+
+```bash
+bash ~/.agent-bridge/bridge-daemon.sh stop --force
+```
+
+For a routine upgrade, prefer `agent-bridge upgrade --apply` — it handles
+daemon stop + restart + agent re-launch internally and does not need
+`--force`.
+
 Remove only runtime artifacts if you need a clean local reset:
 
 ```bash

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/bridge-lib.sh"
 bridge_load_roster
 
 usage() {
-  echo "Usage: bash $SCRIPT_DIR/bridge-daemon.sh [--skip-plugin-liveness] <start|ensure|run|stop|status|sync>"
+  echo "Usage: bash $SCRIPT_DIR/bridge-daemon.sh [--skip-plugin-liveness] <start|ensure|run|status|sync|stop [--force]>"
 }
 
 daemon_log_event() {
@@ -24,6 +24,11 @@ daemon_log_event() {
 daemon_info() {
   local message="$1"
   printf '[%s] [info] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$message"
+}
+
+daemon_warn() {
+  local message="$1"
+  printf '[%s] [warn] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$message" >&2
 }
 
 # --- Daemon exit observability (issue #193) ----------------------------------
@@ -3830,6 +3835,58 @@ cmd_stop() {
   local orphans=0
   local first_pid=""
   local is_orphan
+  local force=0
+  local arg
+
+  # Issue #314 Layer 3 / #315 Track 3 — accept --force/-f to bypass the
+  # active-agent guard below. Sanctioned callers (the upgrader, the daemon
+  # liveness watchdog, the repair-task-db / deploy-live-install scripts)
+  # must pass --force so they aren't blocked. Bare operator/admin-agent
+  # invocations get the guard.
+  for arg in "$@"; do
+    case "$arg" in
+      --force|-f)
+        force=1
+        ;;
+      *)
+        daemon_warn "stop: unknown argument: $arg"
+        return 2
+        ;;
+    esac
+  done
+
+  # Issue #314 Layer 3 / #315 Track 3 — Active-agent guard.
+  # A bare `bridge-daemon.sh stop` on a host with running always-on agents
+  # is the unsafe path documented in the #314 incident: a subsequent daemon
+  # restart picks up stale AGENT_SESSION_IDs and `claude --resume` lands on
+  # the wrong (often context-saturated) session. The sanctioned entrypoint
+  # is `agent-bridge upgrade --apply`, which orchestrates daemon stop+start
+  # internally. Refuse the bare call when active agents exist; require
+  # --force for the recovery / wedged-host case.
+  if (( force != 1 )); then
+    local active_count=0
+    active_count="$(bridge_active_agent_ids | grep -c . || true)"
+    if [[ "$active_count" =~ ^[0-9]+$ ]] && (( active_count > 0 )); then
+      daemon_warn ""
+      daemon_warn "============================================================"
+      daemon_warn "Refusing to stop the bridge daemon: $active_count active agent session(s) detected."
+      daemon_warn ""
+      daemon_warn "On a host with running agents, use the sanctioned upgrade entrypoint:"
+      daemon_warn "    agent-bridge upgrade --apply"
+      daemon_warn ""
+      daemon_warn "It handles daemon stop + restart + agent re-launch internally"
+      daemon_warn "without the cascade risks documented in issues #314 / #315."
+      daemon_warn ""
+      daemon_warn "If you really intend to stop the daemon directly (e.g. recovery"
+      daemon_warn "or wedged-host scenario), re-run with --force:"
+      daemon_warn "    bash bridge-daemon.sh stop --force"
+      daemon_warn "============================================================"
+      bridge_audit_log daemon daemon_stop_refused daemon \
+        --detail reason=active_agents_present \
+        --detail active_count="$active_count" >/dev/null 2>&1 || true
+      return 1
+    fi
+  fi
 
   # Stop the silence watchdog *before* killing the daemon so it doesn't
   # observe the stop-induced silence and race a fresh start against ours.
@@ -3920,7 +3977,8 @@ case "$CMD" in
     cmd_run_cron_worker "$@"
     ;;
   stop)
-    cmd_stop
+    shift || true
+    cmd_stop "$@"
     ;;
   status)
     cmd_status

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -903,7 +903,9 @@ if [[ "$SUBCOMMAND" == "rollback" ]]; then
   fi
   ROLLBACK_JSON="$(python3 "$SOURCE_ROOT/bridge-upgrade.py" "${rollback_args[@]}")"
   if [[ $RESTART_DAEMON -eq 1 && $DRY_RUN -eq 0 ]]; then
-    bash "$TARGET_ROOT/bridge-daemon.sh" stop >/dev/null 2>&1 || true
+    # --force: the upgrader is the sanctioned daemon stop+restart path
+    # (issue #314 Layer 3 / #315 Track 3). Bypass the active-agent guard.
+    bash "$TARGET_ROOT/bridge-daemon.sh" stop --force >/dev/null 2>&1 || true
     bash "$TARGET_ROOT/bridge-daemon.sh" ensure >/dev/null
   fi
   if [[ $RESTART_AGENTS -eq 1 ]]; then
@@ -1047,7 +1049,9 @@ if [[ $MIGRATE_AGENTS -eq 1 ]]; then
 fi
 
 if [[ $RESTART_DAEMON -eq 1 && $DRY_RUN -eq 0 ]]; then
-  bash "$TARGET_ROOT/bridge-daemon.sh" stop >/dev/null 2>&1 || true
+  # --force: the upgrader is the sanctioned daemon stop+restart path
+  # (issue #314 Layer 3 / #315 Track 3). Bypass the active-agent guard.
+  bash "$TARGET_ROOT/bridge-daemon.sh" stop --force >/dev/null 2>&1 || true
   bash "$TARGET_ROOT/bridge-daemon.sh" ensure >/dev/null
 fi
 

--- a/bridge-watchdog-silence.py
+++ b/bridge-watchdog-silence.py
@@ -241,20 +241,22 @@ def emit_audit(action: str, detail: dict) -> None:
         log.error("audit write failed for %s: %s", action, exc)
 
 
-def run_daemon_command(verb: str) -> tuple[int, str]:
-    """Run `bash bridge-daemon.sh <verb>` with a hard timeout. Returns
+def run_daemon_command(*verb_args: str) -> tuple[int, str]:
+    """Run `bash bridge-daemon.sh <verb_args>` with a hard timeout. Returns
     (exit_code, last-line-of-output) so the audit row can record why a
     restart attempt failed."""
     bash = os.environ.get("BRIDGE_BASH_BIN", "bash")
+    cmd = [bash, str(DAEMON_SCRIPT), *verb_args]
+    label = " ".join(verb_args)
     try:
         result = subprocess.run(
-            [bash, str(DAEMON_SCRIPT), verb],
+            cmd,
             capture_output=True, text=True, timeout=RESTART_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
-        return 124, f"bridge-daemon.sh {verb} timed out after {RESTART_TIMEOUT}s"
+        return 124, f"bridge-daemon.sh {label} timed out after {RESTART_TIMEOUT}s"
     except OSError as exc:
-        return 127, f"bridge-daemon.sh {verb} spawn failed: {exc}"
+        return 127, f"bridge-daemon.sh {label} spawn failed: {exc}"
     output = (result.stdout or "") + (result.stderr or "")
     last = output.strip().splitlines()[-1] if output.strip() else ""
     return result.returncode, last
@@ -265,7 +267,10 @@ def attempt_restart(reason_detail: dict) -> None:
     emit_audit("daemon_silence_detected", reason_detail)
     log.warning("daemon silence detected — %s", reason_detail)
 
-    stop_code, stop_msg = run_daemon_command("stop")
+    # --force: the silence watchdog only fires on a wedged/silent daemon.
+    # Bypass the issue #314/#315 active-agent guard so a stuck daemon can
+    # still be restarted on a host with running agents.
+    stop_code, stop_msg = run_daemon_command("stop", "--force")
     if stop_code != 0:
         emit_audit(
             "daemon_silence_restart_attempted",

--- a/scripts/bridge-daemon-liveness.sh
+++ b/scripts/bridge-daemon-liveness.sh
@@ -18,7 +18,7 @@
 #      (default 600s = 10 min), do nothing.
 #   4. If stale AND the daemon pid is recorded AND alive, AND the cooldown
 #      since the last restart attempt has elapsed, run
-#      `bridge-daemon.sh stop && bridge-daemon.sh start`. Cooldown prevents
+#      `bridge-daemon.sh stop --force && bridge-daemon.sh start`. Cooldown prevents
 #      a broken daemon from triggering a restart-loop every minute.
 #   5. If stale but the daemon is not running, do nothing — the normal
 #      start path (launchd KeepAlive / systemd Restart=always) will bring
@@ -141,7 +141,10 @@ restart_daemon() {
   # Use BRIDGE_HOME's daemon script so the watcher targets the same install
   # root the heartbeat file was observed in. The launchd plist sets
   # BRIDGE_HOME explicitly; override via env if running by hand.
-  if ! bash "$DAEMON_SH" stop >/dev/null 2>&1; then
+  # --force: the liveness watchdog only fires on a wedged daemon (heartbeat
+  # past threshold). Bypass the #314/#315 active-agent guard so a stuck
+  # daemon can still be restarted on a host with running agents.
+  if ! bash "$DAEMON_SH" stop --force >/dev/null 2>&1; then
     stop_rc=$?
   fi
   if ! bash "$DAEMON_SH" start >/dev/null 2>&1; then

--- a/scripts/deploy-live-install.sh
+++ b/scripts/deploy-live-install.sh
@@ -184,10 +184,12 @@ fi
 
 if [[ "$RESTART_DAEMON" == "1" ]]; then
   if [[ "$DRY_RUN" == "1" ]]; then
-    printf '[dry-run] bash %s/bridge-daemon.sh stop\n' "$TARGET_ROOT"
+    printf '[dry-run] bash %s/bridge-daemon.sh stop --force\n' "$TARGET_ROOT"
     printf '[dry-run] bash %s/bridge-daemon.sh ensure\n' "$TARGET_ROOT"
   else
-    bash "$TARGET_ROOT/bridge-daemon.sh" stop >/dev/null 2>&1 || true
+    # --force: deploy-live-install is a sanctioned daemon stop+restart path
+    # and must not be blocked by the #314/#315 active-agent guard.
+    bash "$TARGET_ROOT/bridge-daemon.sh" stop --force >/dev/null 2>&1 || true
     bash "$TARGET_ROOT/bridge-daemon.sh" ensure >/dev/null
   fi
 fi

--- a/scripts/repair-task-db.sh
+++ b/scripts/repair-task-db.sh
@@ -93,9 +93,11 @@ SOURCE_BACKUP="${SOURCE_DB}.snapshot-${TIMESTAMP}"
 
 if [[ "$RESTART_DAEMON" == "1" ]]; then
   if [[ "$DRY_RUN" == "1" ]]; then
-    printf '[dry-run] bash %s/bridge-daemon.sh stop\n' "$DAEMON_HOME"
+    printf '[dry-run] bash %s/bridge-daemon.sh stop --force\n' "$DAEMON_HOME"
   else
-    bash "$DAEMON_HOME/bridge-daemon.sh" stop >/dev/null 2>&1 || true
+    # --force: repair-task-db is a sanctioned recovery script and must not
+    # be blocked by the #314/#315 active-agent guard.
+    bash "$DAEMON_HOME/bridge-daemon.sh" stop --force >/dev/null 2>&1 || true
   fi
 fi
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -929,7 +929,10 @@ cleanup() {
   # Pin BRIDGE_HOME on the subshell explicitly so the stop command can never
   # target a live install even if some earlier code path unset or rewrote
   # the exported value. See issue #207.
-  env BRIDGE_HOME="$TMP_ROOT/bridge-home" bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null 2>&1 || true
+  # --force: cleanup runs after the smoke fixture has spun up tmux fixture
+  # agents; without --force the #314/#315 active-agent guard would refuse
+  # the stop and leave the test daemon running.
+  env BRIDGE_HOME="$TMP_ROOT/bridge-home" bash "$REPO_ROOT/bridge-daemon.sh" stop --force >/dev/null 2>&1 || true
   # Kill every tmux session that did not exist before the smoke test started.
   if [[ -n "${SMOKE_PRE_SESSIONS_FILE:-}" && -f "$SMOKE_PRE_SESSIONS_FILE" ]]; then
     local _new_session=""
@@ -2042,6 +2045,109 @@ assert_contains "$STATUS_OUTPUT" "$SMOKE_AGENT"
 assert_contains "$STATUS_OUTPUT" "state"
 assert_contains "$STATUS_OUTPUT" "$WORKDIR"
 printf '%s\n' "$STATUS_OUTPUT" | grep -E "${SMOKE_AGENT}[[:space:]].*(idle|working)" >/dev/null || die "status should show activity state for $SMOKE_AGENT"
+
+# Issue #314 Layer 3 / #315 Track 3 — bridge-daemon.sh stop active-agent
+# guard. With $SMOKE_AGENT and $REQUESTER_AGENT active, a bare `stop` must
+# refuse with the redirect banner and leave the daemon running; `--force`
+# must bypass the guard; and a bare `stop` with no active agents must
+# succeed normally.
+log "daemon stop refuses while active agents are present (#314 Layer 3 / #315 Track 3)"
+GUARD_STDERR_FILE="$TMP_ROOT/daemon-stop-guard.stderr"
+GUARD_RC=0
+bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null 2>"$GUARD_STDERR_FILE" || GUARD_RC=$?
+if (( GUARD_RC == 0 )); then
+  die "bare 'bridge-daemon.sh stop' should refuse with active agents present (rc=$GUARD_RC)"
+fi
+GUARD_STDERR="$(cat "$GUARD_STDERR_FILE")"
+assert_contains "$GUARD_STDERR" "Refusing to stop the bridge daemon"
+assert_contains "$GUARD_STDERR" "agent-bridge upgrade --apply"
+assert_contains "$GUARD_STDERR" "stop --force"
+GUARD_STATUS="$(bash "$REPO_ROOT/bridge-daemon.sh" status || true)"
+assert_contains "$GUARD_STATUS" "running pid="
+
+log "daemon stop --force bypasses the active-agent guard"
+FORCE_RC=0
+bash "$REPO_ROOT/bridge-daemon.sh" stop --force >/dev/null 2>&1 || FORCE_RC=$?
+if (( FORCE_RC != 0 )); then
+  die "'bridge-daemon.sh stop --force' should succeed despite active agents (rc=$FORCE_RC)"
+fi
+FORCE_STATUS=""
+for _ in {1..20}; do
+  FORCE_STATUS="$(bash "$REPO_ROOT/bridge-daemon.sh" status || true)"
+  [[ "$FORCE_STATUS" == "stopped" ]] && break
+  sleep 0.2
+done
+assert_contains "$FORCE_STATUS" "stopped"
+
+log "daemon stop without --force succeeds when no agents are active"
+# Use a completely empty isolated BRIDGE_HOME so no roster always-on agents
+# auto-start during ensure. The smoke fixture's roster registers several
+# always-on agents (claude-static, ALWAYS_ON_AGENT, etc.) that the daemon
+# would respawn during sync, polluting the "no active agents" precondition
+# for this test. We must use `env -i` to also strip the smoke fixture's
+# many BRIDGE_* path exports (BRIDGE_STATE_DIR, BRIDGE_ACTIVE_AGENT_DIR,
+# BRIDGE_ROSTER_LOCAL_FILE, etc.) — those have absolute paths that would
+# otherwise pull the smoke roster back in.
+GUARD_EMPTY_HOME="$TMP_ROOT/guard-empty-home"
+GUARD_EMPTY_ROSTER="$TMP_ROOT/guard-empty-roster.sh"
+GUARD_EMPTY_LOCAL_ROSTER="$TMP_ROOT/guard-empty-roster.local.sh"
+mkdir -p "$GUARD_EMPTY_HOME"
+: >"$GUARD_EMPTY_ROSTER"
+: >"$GUARD_EMPTY_LOCAL_ROSTER"
+GUARD_BARE_RC=0
+GUARD_BARE_OUT="$(env -i HOME="$HOME" PATH="$PATH" \
+  BRIDGE_HOME="$GUARD_EMPTY_HOME" \
+  BRIDGE_ROSTER_FILE="$GUARD_EMPTY_ROSTER" \
+  BRIDGE_ROSTER_LOCAL_FILE="$GUARD_EMPTY_LOCAL_ROSTER" \
+  BRIDGE_SKIP_PLUGIN_LIVENESS=1 \
+  bash "$REPO_ROOT/bridge-daemon.sh" ensure 2>&1)" || true
+for _ in {1..20}; do
+  GUARD_EMPTY_STATUS="$(env -i HOME="$HOME" PATH="$PATH" \
+    BRIDGE_HOME="$GUARD_EMPTY_HOME" \
+    BRIDGE_ROSTER_FILE="$GUARD_EMPTY_ROSTER" \
+    BRIDGE_ROSTER_LOCAL_FILE="$GUARD_EMPTY_LOCAL_ROSTER" \
+    BRIDGE_SKIP_PLUGIN_LIVENESS=1 \
+    bash "$REPO_ROOT/bridge-daemon.sh" status 2>/dev/null || true)"
+  [[ "$GUARD_EMPTY_STATUS" == *"running pid="* ]] && break
+  sleep 0.2
+done
+assert_contains "$GUARD_EMPTY_STATUS" "running pid="
+env -i HOME="$HOME" PATH="$PATH" \
+  BRIDGE_HOME="$GUARD_EMPTY_HOME" \
+  BRIDGE_ROSTER_FILE="$GUARD_EMPTY_ROSTER" \
+  BRIDGE_ROSTER_LOCAL_FILE="$GUARD_EMPTY_LOCAL_ROSTER" \
+  BRIDGE_SKIP_PLUGIN_LIVENESS=1 \
+  bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null 2>&1 || GUARD_BARE_RC=$?
+if (( GUARD_BARE_RC != 0 )); then
+  die "bare 'bridge-daemon.sh stop' should succeed when no agents are active (rc=$GUARD_BARE_RC, ensure_out=$GUARD_BARE_OUT)"
+fi
+GUARD_EMPTY_STOPPED=""
+for _ in {1..20}; do
+  GUARD_EMPTY_STOPPED="$(env -i HOME="$HOME" PATH="$PATH" \
+    BRIDGE_HOME="$GUARD_EMPTY_HOME" \
+    BRIDGE_ROSTER_FILE="$GUARD_EMPTY_ROSTER" \
+    BRIDGE_ROSTER_LOCAL_FILE="$GUARD_EMPTY_LOCAL_ROSTER" \
+    BRIDGE_SKIP_PLUGIN_LIVENESS=1 \
+    bash "$REPO_ROOT/bridge-daemon.sh" status 2>/dev/null || true)"
+  [[ "$GUARD_EMPTY_STOPPED" == "stopped" ]] && break
+  sleep 0.2
+done
+assert_contains "$GUARD_EMPTY_STOPPED" "stopped"
+
+# Restore the smoke fixture: daemon running, both agent sessions up, so the
+# rest of the suite sees the same precondition it had before this block.
+bash "$REPO_ROOT/bridge-daemon.sh" ensure >/dev/null
+for _ in {1..20}; do
+  RESTORED_DAEMON="$(bash "$REPO_ROOT/bridge-daemon.sh" status || true)"
+  [[ "$RESTORED_DAEMON" == *"running pid="* ]] && break
+  sleep 0.2
+done
+assert_contains "$RESTORED_DAEMON" "running pid="
+bash "$REPO_ROOT/bridge-start.sh" "$SMOKE_AGENT" >/dev/null
+bash "$REPO_ROOT/bridge-start.sh" "$REQUESTER_AGENT" >/dev/null
+wait_for_tmux_session "$SESSION_NAME" up 20 0.2 || die "smoke tmux session did not restart after guard tests"
+wait_for_tmux_session "$REQUESTER_SESSION" up 20 0.2 || die "requester tmux session did not restart after guard tests"
+bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 
 RELAY_ROWS="$("$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
@@ -6911,7 +7017,9 @@ assert all("memory-daily busy" not in line for line in output)
 PY
 
 log "stopping background daemon before deterministic cron-dispatch tail"
-env BRIDGE_HOME="$BRIDGE_HOME" bash "$REPO_ROOT/bridge-daemon.sh" stop >/dev/null
+# --force: smoke fixture may have active agents at this point; the
+# #314/#315 active-agent guard would block a bare stop.
+env BRIDGE_HOME="$BRIDGE_HOME" bash "$REPO_ROOT/bridge-daemon.sh" stop --force >/dev/null
 
 log "processing one queued cron-dispatch task through the daemon"
 RUN_ID="smoke-job-1234--2026-04-05T10-00-00Z"


### PR DESCRIPTION
## Summary

The #314 incident on v0.6.13 showed that a bare \`bridge-daemon.sh stop\` on a host with running always-on agents can cascade: the daemon supervisor restarts, agents respawn from persisted env, and \`claude --resume\` lands on the wrong (often context-saturated) session. The sanctioned entrypoint on a host with active agents is \`agent-bridge upgrade --apply\`, which atomically orchestrates daemon stop + start + agent re-launch.

This adds the defensive UX both #314 (Layer 3) and #315 (Track 3) describe: \`bridge-daemon.sh stop\` now refuses to stop the daemon when active agents are present and points the operator (or admin agent) at the safe path. \`--force\` bypasses the guard for recovery / wedged-host scenarios. Combined into a single PR because the surface is identical.

## What's new

- \`bridge-daemon.sh stop\` requires \`--force\` when one or more agents have a live tmux session. Without \`--force\`, the command writes a multi-line banner to stderr, returns rc=1, and emits a \`daemon_stop_refused\` audit row (\`reason=active_agents_present\`, \`active_count=N\`).
- The banner names \`agent-bridge upgrade --apply\` as the sanctioned entrypoint and shows the exact \`stop --force\` invocation to use for recovery.
- All sanctioned internal callers pass \`--force\` so they aren't blocked:
  - \`bridge-upgrade.sh\` rollback restart (line 906) and forward-upgrade restart (line 1050).
  - \`scripts/bridge-daemon-liveness.sh\` restart_daemon().
  - \`bridge-watchdog-silence.py\` attempt_restart() (the in-daemon silence supervisor).
  - \`scripts/repair-task-db.sh\` --apply path.
  - \`scripts/deploy-live-install.sh\` --restart-daemon path.
- The smoke fixture's own cleanup() and mid-run daemon stop also pass \`--force\`.
- Three new smoke assertions cover: refused bare stop with banner + daemon still running; \`stop --force\` succeeds; bare stop succeeds with no agents active (in an isolated empty-roster BRIDGE_HOME).
- OPERATIONS.md \`## Safe Cleanup\` adds a short note for the \`--force\` recovery path.

## What's preserved

- Bare \`stop\` on a host without active agents is unchanged — still rc=0.
- \`bridge-daemon.sh start\` / \`ensure\` / \`status\` / \`sync\` / \`run\` are untouched.
- \`agent-bridge upgrade --apply\` public behavior is unchanged. Internally it now calls \`stop --force\`, but operators don't see that.
- Top-level \`--skip-plugin-liveness\` flag still parses identically.

## Verification

```
$ bash -n bridge-daemon.sh bridge-upgrade.sh scripts/smoke-test.sh \
    scripts/bridge-daemon-liveness.sh scripts/repair-task-db.sh \
    scripts/deploy-live-install.sh
$ shellcheck bridge-daemon.sh bridge-upgrade.sh scripts/smoke-test.sh \
    scripts/bridge-daemon-liveness.sh scripts/repair-task-db.sh \
    scripts/deploy-live-install.sh
$ python3 -c "import py_compile; py_compile.compile('bridge-watchdog-silence.py', doraise=True)"
```

All pass with no output.

Manual bench in an isolated BRIDGE_HOME with one fake active agent:

```
[2026-04-26T01:41:23+0900] [warn] Refusing to stop the bridge daemon: 1 active agent session(s) detected.
[2026-04-26T01:41:23+0900] [warn] On a host with running agents, use the sanctioned upgrade entrypoint:
[2026-04-26T01:41:23+0900] [warn]     agent-bridge upgrade --apply
...
rc=1
```

audit log row written:

```json
{"actor":"daemon","action":"daemon_stop_refused","target":"daemon","detail":{"reason":"active_agents_present","active_count":"1"}}
```

\`stop --force\` from the same state stops the daemon (rc=0). Bare \`stop\` on an empty-roster BRIDGE_HOME stops the daemon (rc=0).

\`./scripts/smoke-test.sh\` runs all three new assertions to PASS, then continues until the chronic mcp-restart.log halt that exists on \`main\` (pre-existing CI failure since 2026-04-21, not caused by this PR).

## CI

Pre-existing smoke failure on \`main\` (\`expected bridge-run to relaunch the restart orphan cleanup smoke role\` / missing \`mcp-restart.log\`) reproduces independently of this change.

---

Addresses Layer 3 of #314 and Track 3 of #315. The remaining items in both issues stay open: #314 Layer 2 cascade investigation is a separate diagnostic effort; #315 has no remaining tracks (T1 + T2 landed in PR #316; T3 is here).