### PR TITLE
cron: stagger wiki-daily-ingest to 06:00 to avoid memory-daily race (#320 Track A)

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -323,7 +323,12 @@ CRON_SPECS=(
   "wiki-dedup-weekly|0 4 * * 0|Asia/Seoul|wiki-dedup-weekly.sh"
   # Daily-note two-lane ingest. Lane A (wiki-daily-copy.py) runs inside
   # the shell script; Lane B queues [librarian-ingest] for non-daily.
-  "wiki-daily-ingest|0 3 * * *|Asia/Seoul|wiki-daily-ingest.sh"
+  # Scheduled at 06:00 to stagger 3 hours after the 03:00 memory-daily-*
+  # fan-out. Co-scheduling at 03:00 produced a same-slot daemon-runner race
+  # in which Lane A's wiki-daily-copy invocation observed files=0 every day
+  # (issue #320 Track A). Existing 0.6.17 installs that already have this
+  # cron at "0 3 * * *" are migrated to "0 6 * * *" by step_cron_one below.
+  "wiki-daily-ingest|0 6 * * *|Asia/Seoul|wiki-daily-ingest.sh"
   # L1 observation scanner. Populates shared/wiki/_index/mentions.db and
   # the distribution-report snapshot. Offset :17 misses top-of-hour cluster.
   "wiki-mention-scan|17 * * * *|Asia/Seoul|wiki-mention-scan.sh"
@@ -421,11 +426,50 @@ step_cron_one() {
     if [[ "$norm_existing" == "$norm_expected" && "$effective_existing_tz" == "$tz" ]]; then
       record "$BRIDGE_ADMIN_AGENT" "cron:$title" "already-registered" "$existing_sched tz=$effective_existing_tz"
       return 0
-    else
-      record "$BRIDGE_ADMIN_AGENT" "cron:$title" "conflict" "existing=$existing_sched tz=$effective_existing_tz want=$sched tz=$tz — refusing"
-      note_drift
+    fi
+    # Planned migration: wiki-daily-ingest moved from 0 3 * * * → 0 6 * * *
+    # in #320 Track A. 0.6.17 installs already have it at the legacy slot;
+    # treat that exact pair as a managed re-registration (not an operator
+    # override) so the apply step can move it forward without manual edits.
+    if [[ "$title" == "wiki-daily-ingest" \
+          && "$norm_existing" == "0 3 * * *" \
+          && "$norm_expected" == "0 6 * * *" \
+          && "$effective_existing_tz" == "$tz" ]]; then
+      local existing_id
+      existing_id="$(printf '%s' "$found" | awk -F'\t' '{print $1}')"
+      if [[ "$MODE" == "check" ]]; then
+        record "$BRIDGE_ADMIN_AGENT" "cron:$title" "drift-migration-pending" \
+          "existing=$existing_sched want=$sched tz=$tz reason=#320-trackA"
+        note_drift
+        return 0
+      fi
+      if [[ "$MODE" == "dry-run" ]]; then
+        record "$BRIDGE_ADMIN_AGENT" "cron:$title" "would-migrate" \
+          "id=$existing_id 0 3 * * * → 0 6 * * * tz=$tz"
+        return 0
+      fi
+      if [[ -z "$existing_id" ]]; then
+        record "$BRIDGE_ADMIN_AGENT" "cron:$title" "migrate-failed" \
+          "no id from cron_lookup; existing=$existing_sched want=$sched"
+        note_drift
+        return 0
+      fi
+      if "$BRIDGE_AGB" cron update "$existing_id" \
+            --schedule "$sched" \
+            --tz "$tz" \
+            >/dev/null 2>&1; then
+        record "$BRIDGE_ADMIN_AGENT" "cron:$title" "migrated" \
+          "id=$existing_id 0 3 * * * → 0 6 * * * tz=$tz reason=#320-trackA"
+      else
+        record "$BRIDGE_ADMIN_AGENT" "cron:$title" "migrate-failed" \
+          "id=$existing_id 0 3 * * * → 0 6 * * *"
+        note_drift
+      fi
       return 0
     fi
+    record "$BRIDGE_ADMIN_AGENT" "cron:$title" "conflict" "existing=$existing_sched tz=$effective_existing_tz want=$sched tz=$tz — refusing"
+    note_drift
+    return 0
   fi
 
   if [[ "$MODE" == "check" ]]; then


### PR DESCRIPTION
## Summary

`wiki-daily-ingest` and the `memory-daily-<agent>` fan-out both fire at 03:00 KST, and the same-slot daemon-runner race causes Lane A's `wiki-daily-copy.py` invocation to observe `files=0` every day on 0.6.17. Moving `wiki-daily-ingest` to 06:00 KST gives Lane A a clean, dedicated slot 3 hours after the memory-daily wave drains.

## What changed

`bootstrap-memory-system.sh`:

1. `CRON_SPECS` registration row for `wiki-daily-ingest` switched from `0 3 * * *` to `0 6 * * *` (Asia/Seoul, unchanged).
2. `step_cron_one` gains a one-shot migration branch: when the live cron is exactly `0 3 * * *` and the desired is `0 6 * * *` for `wiki-daily-ingest`, re-register via `agent-bridge cron update <id> --schedule '0 6 * * *' --tz Asia/Seoul` instead of refusing as `conflict`. The drift report logs `migrated wiki-daily-ingest 0 3 * * * → 0 6 * * * tz=Asia/Seoul reason=#320-trackA`. `check` and `dry-run` modes report `drift-migration-pending` / `would-migrate` respectively without touching live state.

The legacy `0 3 * * *` value still appears in the file in two places that are intentional and out of scope:

- `local sched="0 3 * * *"` (memory-daily-`<agent>` cron at line 589) — Track A scope is the wiki ingester only; the memory-daily slot stays where it is.
- migration-detection literals (`norm_existing == "0 3 * * *"`) and reporting strings — these *must* match the legacy value for the apply-time migration to fire.

## Verification

```
$ bash -n bootstrap-memory-system.sh && echo OK
OK

$ shellcheck bootstrap-memory-system.sh && echo OK
OK

$ grep -nE "wiki-daily-ingest\|" bootstrap-memory-system.sh
331:  "wiki-daily-ingest|0 6 * * *|Asia/Seoul|wiki-daily-ingest.sh"

$ grep -n "0 3 \* \* \*" bootstrap-memory-system.sh
330:  # cron at "0 3 * * *" are migrated to "0 6 * * *" by step_cron_one below.
430:    # Planned migration: wiki-daily-ingest moved from 0 3 * * * → 0 6 * * *
435:          && "$norm_existing" == "0 3 * * *" \
448:          "id=$existing_id 0 3 * * * → 0 6 * * * tz=$tz"
462:          "id=$existing_id 0 3 * * * → 0 6 * * * tz=$tz reason=#320-trackA"
465:          "id=$existing_id 0 3 * * * → 0 6 * * *"
589:  local sched="0 3 * * *"
```

All four checks clean. Remaining `0 3 * * *` matches are migration-detection literals (lines 430/435/448/462/465), the explanatory comment (line 330), and the unrelated memory-daily slot (line 589) — no leaked schedule changes.

A live migration smoke (pre-seed `cron/jobs.json` with `wiki-daily-ingest @ 0 3 * * *`, run `bootstrap-memory-system.sh apply`, expect `expr=0 6 * * *` in the report and the live job) is most reliable on a real `BRIDGE_HOME` and is left for the orchestrator to verify against the live install (run `--check` first to preview the `drift-migration-pending` row before `--apply`).

## Migration

Existing 0.6.17 installs are picked up automatically on the next `bootstrap-memory-system.sh apply` pass. The drift report will show one `migrated wiki-daily-ingest 0 3 * * * → 0 6 * * *` row. Operators who run `--check` or `--dry-run` first will see the migration previewed (`drift-migration-pending` / `would-migrate`) before any live cron is touched. No manual `agent-bridge cron edit` is required.

## CI status

CI smoke on `main` may carry pre-existing failures unrelated to this change. Track A here only modifies the cron registration table and the apply-time conflict branch in `bootstrap-memory-system.sh`; nothing in the smoke matrix exercises bootstrap-memory-system in a way that distinguishes 03:00 vs 06:00.

## Scope discipline

- No VERSION bump, no CHANGELOG entry. Release contract = `release/vX.Y.Z` branch only.
- One file changed: `bootstrap-memory-system.sh`. One commit.
- No other crons touched (`memory-daily-*`, `librarian-watchdog`, `wiki-mention-scan`, `wiki-hub-audit`, `wiki-repair-links`, `wiki-v2-rebuild`, `wiki-dedup-weekly`, `wiki-weekly-summarize`, `wiki-monthly-summarize` all unchanged).
- Cron scripts (`scripts/wiki-daily-ingest.sh`, `scripts/wiki-daily-copy.py`) untouched — schedule is owned by the registration table.
- No new cron jobs added.

Addresses Track A of #320. Tracks B (catch-all weekly) / C (assert-no-collision test) stay open.