### PR TITLE
wiki-daily-ingest: persist last-successful-ingest watermark (#321 Track A)

### DIFF
--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -25,16 +25,69 @@ set -u
 : "${BRIDGE_SHARED_ROOT:=$BRIDGE_HOME/shared}"
 : "${BRIDGE_WIKI_ROOT:=$BRIDGE_SHARED_ROOT/wiki}"
 : "${BRIDGE_SCRIPTS_ROOT:=$BRIDGE_HOME/scripts}"
+: "${BRIDGE_STATE_DIR:=$BRIDGE_HOME/state}"
 : "${BRIDGE_AGB:=$BRIDGE_HOME/agent-bridge}"
 : "${BRIDGE_ADMIN_AGENT:=${BRIDGE_ADMIN_AGENT_ID:-patch}}"
+
+# Watermark of the last successful Lane A ingest. Persisted between runs so
+# late-arriving daily notes (written after the previous run's window) are
+# still picked up on the next run instead of being stranded by the static
+# 2-day rolling window. See issue #321 Track A.
+WIKI_INGEST_STATE_DIR="$BRIDGE_STATE_DIR/wiki"
+WIKI_INGEST_WATERMARK_FILE="$WIKI_INGEST_STATE_DIR/last-ingest.txt"
 
 AGENTS_ROOT="$BRIDGE_AGENTS_ROOT"
 WIKI="$BRIDGE_WIKI_ROOT"
 SCRIPTS_ROOT="$BRIDGE_SCRIPTS_ROOT"
 DATE=$(date +%Y-%m-%d)
-YESTERDAY=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
+
+# compute_since_date — resolve effective --since for Lane A.
+#
+# Reads the persisted watermark if it exists and parses as YYYY-MM-DD.
+# Falls back to "yesterday" on missing/empty/malformed input. Clamps the
+# result to max(watermark, today-14d) so a long-stale watermark cannot
+# trigger an unbounded backfill. The 14-day floor matches the practical
+# lookback window operators care about; revisit if data shows otherwise.
+compute_since_date() {
+  local watermark=""
+  if [ -f "$WIKI_INGEST_WATERMARK_FILE" ]; then
+    watermark="$(head -n1 "$WIKI_INGEST_WATERMARK_FILE" 2>/dev/null | tr -d '[:space:]')"
+    if ! [[ "$watermark" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+      watermark=""
+    fi
+  fi
+  local default_since
+  default_since=$(date -v-1d +%Y-%m-%d 2>/dev/null || date -d 'yesterday' +%Y-%m-%d)
+  if [ -z "$watermark" ]; then
+    printf '%s' "$default_since"
+    return 0
+  fi
+  local floor
+  floor=$(date -v-14d +%Y-%m-%d 2>/dev/null || date -d '14 days ago' +%Y-%m-%d)
+  # Lexicographic compare is correct for ISO-8601 YYYY-MM-DD.
+  if [[ "$watermark" < "$floor" ]]; then
+    printf '%s' "$floor"
+  else
+    printf '%s' "$watermark"
+  fi
+}
+
+YESTERDAY="$(compute_since_date)"
 LOG="$WIKI/_audit/ingest-$DATE.md"
 mkdir -p "$(dirname "$LOG")"
+
+# write_watermark_atomic — durable, crash-safe watermark write.
+#
+# Writes to a tempfile in the same directory and renames into place so a
+# crash mid-write cannot leave a partial / corrupt watermark behind.
+write_watermark_atomic() {
+  local date_str="$1"
+  mkdir -p "$WIKI_INGEST_STATE_DIR" || return 1
+  local tmp
+  tmp="$(mktemp "$WIKI_INGEST_STATE_DIR/.last-ingest.XXXXXX")" || return 1
+  printf '%s\n' "$date_str" >"$tmp" || { rm -f "$tmp"; return 1; }
+  mv -f "$tmp" "$WIKI_INGEST_WATERMARK_FILE"
+}
 
 # -------------------------------------------------------------------------
 # Lane A — daily-note byte-replica copy (no librarian involvement)
@@ -66,6 +119,21 @@ print(
     f"unchanged={data.get('unchanged',0)} "
     f"errors={data.get('errors',0)}"
 )
+PYEOF
+)
+
+# Extract Lane A error count for watermark gating. Treat parse failure /
+# missing field as non-zero so we never advance the watermark on a run we
+# could not verify succeeded.
+copy_errors=$(python3 - "$COPY_JSON" <<'PYEOF'
+import json
+import sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        data = json.load(handle)
+    print(int(data.get("errors", 1)))
+except Exception:
+    print(1)
 PYEOF
 )
 
@@ -121,4 +189,11 @@ if [ "$non_daily_total" -gt 0 ]; then
     --body-file "$LOG" >/dev/null 2>&1 || true
 fi
 
-echo "wiki-daily-ingest: date=$DATE lane-a ${copy_summary} lane-b research=$research_count other=$other_count total=$non_daily_total log=$LOG"
+# Advance the watermark only when Lane A reported errors=0 AND the copy
+# subprocess exited cleanly. Any failure leaves the previous watermark in
+# place so the next run retries the same window.
+if [ "$copy_rc" -eq 0 ] && [ "$copy_errors" = "0" ]; then
+  write_watermark_atomic "$DATE" || true
+fi
+
+echo "wiki-daily-ingest: date=$DATE since=$YESTERDAY lane-a ${copy_summary} lane-b research=$research_count other=$other_count total=$non_daily_total log=$LOG"


### PR DESCRIPTION
## Summary

`wiki-daily-ingest.sh` previously ran with a static 2-day rolling window
(`yesterday..today`). Daily notes that landed late (after the prior run's
window closed) were stranded permanently. This PR adds a persistent
last-successful-ingest watermark, falls back to yesterday when missing,
and clamps to `max(watermark, today-14d)` so a stale watermark cannot
trigger unbounded backfill.

## What changed

- `scripts/wiki-daily-ingest.sh` (1 file)
  - Resolve `BRIDGE_STATE_DIR` (default `$BRIDGE_HOME/state`) and define
    `WIKI_INGEST_STATE_DIR`/`WIKI_INGEST_WATERMARK_FILE`.
  - New `compute_since_date` helper: read watermark, validate
    `^[0-9]{4}-[0-9]{2}-[0-9]{2}$` regex (no eval), fall back to yesterday
    on missing/empty/malformed, clamp to `max(watermark, today-14d)`.
  - New `write_watermark_atomic` helper: tmpfile + `mv -f` rename.
  - Watermark advances only when `copy_rc=0 && copy_errors=0` (Lane A
    success); failed runs leave the previous watermark in place so the
    next run retries the same window.
  - Final summary line now includes `since=<resolved-date>` for operator
    visibility.

## Verification

All 5 smokes ran in an isolated `BRIDGE_HOME=/tmp/wm-test-*` and PASSED.

```
$ bash -n scripts/wiki-daily-ingest.sh && echo OK
OK
$ shellcheck scripts/wiki-daily-ingest.sh; echo exit=$?
exit=0
```

First-run (no watermark) — falls back to yesterday, then writes watermark:
```
wiki-daily-ingest: date=2026-04-26 since=2026-04-25 lane-a agents=1 files=0 created=0 replaced=0 unchanged=0 errors=0 lane-b research=0 other=0 total=0 log=...
PASS: since= in output
PASS: fallback to yesterday (2026-04-25)
PASS: watermark written: 2026-04-26
```

Watermark honored (`echo 2026-04-20 > last-ingest.txt`):
```
wiki-daily-ingest: date=2026-04-26 since=2026-04-20 lane-a ... errors=0 ...
PASS: watermark honored (since=2026-04-20)
```

Stale watermark clamped (`echo 2025-01-01 > last-ingest.txt`):
```
wiki-daily-ingest: date=2026-04-26 since=2026-04-12 lane-a ... errors=0 ...
expected_since=2026-04-12
PASS: stale watermark clamped to today-14 (2026-04-12)
```

Malformed watermark (`echo 'garbage; rm -rf /' > last-ingest.txt`) safely
falls back without command injection:
```
wiki-daily-ingest: date=2026-04-26 since=2026-04-25 lane-a ... errors=0 ...
expected_since=2026-04-25
PASS: malformed safely fell back to yesterday (2026-04-25)
```

The smokes set `BRIDGE_SCRIPTS_ROOT=$WORKTREE/scripts` so the script can
find `wiki-daily-copy.py` from the worktree (rather than the live
`$BRIDGE_HOME/scripts/`). All assertions match the matrix in the issue.

## State path

`${BRIDGE_STATE_DIR}/wiki/last-ingest.txt` (default
`~/.agent-bridge/state/wiki/last-ingest.txt`). Format: single line
`YYYY-MM-DD\n`. Written atomically via tempfile + `mv -f`.

## Backwards compatibility

First run after upgrade has no watermark → falls back to `YESTERDAY`
exactly as the previous behavior did. No migration required. On the
first successful run the watermark is created.

## CI

Pre-existing CI failures on `main` are not addressed here. Not blocking
this PR.

## Scope discipline

- Single file changed: `scripts/wiki-daily-ingest.sh` (+77/-2).
- No VERSION bump.
- No CHANGELOG entry.
- No edits to `wiki-daily-copy.py`, no cron schedule changes, no new CLI
  flags. Internal-only state.
- 14-day clamp matches the brief; if usage shows a different floor is
  warranted, surface it as a follow-up.

Addresses Track A of #321. Tracks B (clamp test fixture) / C
(wiki-daily-copy.py --since assertion smoke) stay open.