### PR TITLE
memory: harvest-daily --from/--to range + --missing-only (#322 Track A)

### DIFF
--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -3250,21 +3250,142 @@ def _build_result_payload(
     }
 
 
+def _parse_harvest_date_arg(value: str) -> "datetime":
+    """Parse a YYYY-MM-DD argument used by harvest-daily flags.
+
+    Returns a naive ``datetime`` at midnight (callers compare via .date()).
+    Raises ValueError on malformed input — caller surfaces via stderr.
+    """
+    return datetime.strptime(value, "%Y-%m-%d")
+
+
 def cmd_harvest_daily(args: argparse.Namespace) -> int:
-    """Detection-only daily note harvester (issue #216)."""
+    """Detection-only daily note harvester (issue #216).
+
+    Single-date dispatcher (`--date` or default). When ``--from`` is supplied,
+    iterates over a date range, optionally skipping dates that already have a
+    canonical daily note flagged ``semantic_nonempty=True`` via
+    ``--missing-only``, and emits an aggregate ``{"results": [...]}`` JSON to
+    stdout. The single-date stdout shape is unchanged.
+    """
     agent = args.agent
-    home = Path(args.home).expanduser()
     workdir = args.workdir
     tz_name = args.tz or "Asia/Seoul"
-    date = args.date or _harvest_default_date(tz_name)
-    state_dir = _harvest_state_dir(args)
-    db_path = _harvest_task_db(args)
-    now_iso = _harvest_now_iso(tz_name)
-    run_id = os.environ.get("CRON_RUN_ID", "")
+    home = Path(args.home).expanduser()
 
     if not workdir:
         sys.stderr.write("harvest-daily: --workdir is required (no fallback)\n")
         return 2
+
+    date_from = getattr(args, "date_from", None)
+    date_to = getattr(args, "date_to", None)
+    missing_only = bool(getattr(args, "missing_only", False))
+
+    # --- Range-mode validation + dispatch ----------------------------------
+    if date_to and not date_from:
+        sys.stderr.write("harvest-daily: --to requires --from\n")
+        return 2
+
+    if date_from:
+        try:
+            from_dt = _parse_harvest_date_arg(date_from)
+        except ValueError:
+            sys.stderr.write(f"harvest-daily: --from {date_from!r} is not YYYY-MM-DD\n")
+            return 2
+        today_dt = datetime.strptime(_today_date_str(tz_name), "%Y-%m-%d")
+        if date_to:
+            try:
+                to_dt = _parse_harvest_date_arg(date_to)
+            except ValueError:
+                sys.stderr.write(f"harvest-daily: --to {date_to!r} is not YYYY-MM-DD\n")
+                return 2
+        else:
+            to_dt = today_dt
+        if from_dt > to_dt:
+            sys.stderr.write(
+                f"harvest-daily: --from {from_dt.date().isoformat()} is later than "
+                f"--to {to_dt.date().isoformat()}\n"
+            )
+            return 2
+        if to_dt > today_dt:
+            sys.stderr.write(
+                f"harvest-daily: --to {to_dt.date().isoformat()} is in the future "
+                f"(today={today_dt.date().isoformat()} tz={tz_name})\n"
+            )
+            return 2
+        span = (to_dt - from_dt).days + 1
+        target_dates = [
+            (from_dt + timedelta(days=i)).date().isoformat() for i in range(span)
+        ]
+        results: list[dict] = []
+        rc_max = 0
+        for tdate in target_dates:
+            if missing_only:
+                existing = _load_canonical_daily_note(home, tdate)
+                if existing and existing.get("semantic_nonempty"):
+                    results.append({
+                        "date": tdate,
+                        "skipped": "exists",
+                    })
+                    continue
+            payload = _harvest_one_date(args, tdate)
+            results.append({"date": tdate, "result": payload})
+        aggregate = {
+            "schema": "memory-daily-harvest-range-v1",
+            "agent": agent,
+            "from": from_dt.date().isoformat(),
+            "to": to_dt.date().isoformat(),
+            "missing_only": missing_only,
+            "count": len(results),
+            "results": results,
+        }
+        sidecar_out = getattr(args, "sidecar_out", None)
+        if sidecar_out:
+            try:
+                _atomic_write_json(Path(sidecar_out).expanduser(), aggregate)
+            except OSError as exc:
+                sys.stderr.write(f"harvest-daily: sidecar write failed: {exc}\n")
+                return 2
+        try:
+            print(json.dumps(aggregate, ensure_ascii=True))
+        except OSError:
+            pass
+        return rc_max
+
+    # --- Single-date path (preserved byte-identical) -----------------------
+    single_date = args.date or _harvest_default_date(tz_name)
+    payload = _harvest_one_date(args, single_date)
+    return _emit_result(args, payload)
+
+
+def _today_date_str(tz_name: str) -> str:
+    zone = _harvest_tz_zone(tz_name)
+    return datetime.now(zone).date().isoformat()
+
+
+def _load_canonical_daily_note(home: Path, date: str) -> dict | None:
+    """Return ``{"semantic_nonempty": bool}`` if the canonical note exists.
+
+    Reuses ``_probe_daily_note`` so the predicate matches the harvester's own
+    classification. Returns ``None`` when the file is absent.
+    """
+    path = _daily_note_path(home, date)
+    if not path.exists():
+        return None
+    probe = _probe_daily_note(home, date)
+    return {"semantic_nonempty": bool(probe.get("semantic_nonempty"))}
+
+
+def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
+    """Per-date harvest body. Returns the RESULT_SCHEMA payload (no emit)."""
+    agent = args.agent
+    home = Path(args.home).expanduser()
+    workdir = args.workdir
+    tz_name = args.tz or "Asia/Seoul"
+    state_dir = _harvest_state_dir(args)
+    db_path = _harvest_task_db(args)
+    now_iso = _harvest_now_iso(tz_name)
+    run_id = os.environ.get("CRON_RUN_ID", "")
 
     # --- Skipped-permission branch -----------------------------------------
     # Stub detected linux-user isolation but could not assume the target OS
@@ -3343,7 +3464,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
             ],
             confidence="high",
         )
-        return _emit_result(args, payload)
+        return payload
 
     # --- Gate check ---------------------------------------------------------
     if args.disabled_gate or _gate_disabled(agent):
@@ -3390,7 +3511,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
             recommended_next_steps=[],
             confidence="high",
         )
-        return _emit_result(args, payload)
+        return payload
 
     # --- Probe canonical + legacy ------------------------------------------
     daily_note = _probe_daily_note(home, date)
@@ -3593,7 +3714,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
         ),
         confidence=confidence,
     )
-    return _emit_result(args, payload)
+    return payload
 
 
 def _emit_result(args: argparse.Namespace, payload: dict) -> int:
@@ -3839,7 +3960,22 @@ def build_parser() -> argparse.ArgumentParser:
     hd_parser.add_argument("--agent", required=True)
     hd_parser.add_argument("--home", required=True, help="agent profile home root")
     hd_parser.add_argument("--workdir", required=True, help="agent workdir (no fallback)")
-    hd_parser.add_argument("--date", help="YYYY-MM-DD; defaults to yesterday in --tz")
+    hd_date_group = hd_parser.add_mutually_exclusive_group()
+    hd_date_group.add_argument(
+        "--date", help="YYYY-MM-DD; defaults to yesterday in --tz",
+    )
+    hd_date_group.add_argument(
+        "--from", dest="date_from", default=None,
+        help="Start date YYYY-MM-DD (inclusive); pair with --to. Mutually exclusive with --date.",
+    )
+    hd_parser.add_argument(
+        "--to", dest="date_to", default=None,
+        help="End date YYYY-MM-DD (inclusive); requires --from. Defaults to today in --tz.",
+    )
+    hd_parser.add_argument(
+        "--missing-only", dest="missing_only", action="store_true", default=False,
+        help="With --from, skip dates whose canonical daily note already has semantic_nonempty=True.",
+    )
     hd_parser.add_argument("--tz", default="Asia/Seoul")
     hd_parser.add_argument("--state-dir", help="override $BRIDGE_STATE_DIR/memory-daily")
     hd_parser.add_argument("--sidecar-out", help="authoritative RESULT_SCHEMA JSON path")


### PR DESCRIPTION
## Summary

`bridge-memory.py harvest-daily` only accepted a single `--date`. Days before a per-agent `memory-daily-<agent>` cron's `createdAtMs` had no harvester run, no sidecar manifest, and no backfill task ever queued — they remained permanently invisible to the pipeline. This PR adds the operator backfill workflow.

## What changed

- `bridge-memory.py` only.
  - Argparse: `--date` and `--from` are now in a mutually exclusive group; `--to` and `--missing-only` are new flags.
  - Refactor: per-date harvester body extracted into `_harvest_one_date()` returning the existing RESULT_SCHEMA payload (no emit). The dispatcher in `cmd_harvest_daily()` decides single-date vs. range mode.
  - Range mode: validates `--to requires --from`, rejects `--from > --to`, rejects `--to` in the future. Iterates target dates, optionally skipping dates whose canonical daily note already has `semantic_nonempty=True` (reuses `_probe_daily_note`). Emits an aggregate `{"results": [...]}` JSON under schema `memory-daily-harvest-range-v1`.
  - Single-date stdout, sidecar manifest, and existing per-date `state/memory-daily/<agent>/<date>.json` are unchanged.

## Verification

```bash
# Test 1 — ast parse
$ python3 -c "import ast; ast.parse(open('bridge-memory.py').read()); print('OK')"
OK

# Test 1b — help shows new flags
$ python3 bridge-memory.py harvest-daily --help 2>&1 | grep -E "(--from|--to|--missing-only|--date)"
                                      WORKDIR [--date DATE | --from DATE_FROM]
                                      [--to DATE_TO] [--missing-only]
  --date DATE           YYYY-MM-DD; defaults to yesterday in --tz
  --from DATE_FROM      Start date YYYY-MM-DD (inclusive); pair with --to.
                        Mutually exclusive with --date.
  --to DATE_TO          End date YYYY-MM-DD (inclusive); requires --from.
  --missing-only        With --from, skip dates whose canonical daily note

# Test 2 — argparse mutex (--date + --from rejected)
$ python3 bridge-memory.py harvest-daily --date 2026-04-20 --from 2026-04-20 2>&1 | grep -E "not allowed|mutually"
bridge-memory.py harvest-daily: error: argument --from: not allowed with argument --date

# Test 3 — --to without --from rejected (with required args supplied)
$ python3 bridge-memory.py harvest-daily --to 2026-04-25 --agent _x --home /tmp --workdir /tmp 2>&1 | grep "requires --from"
harvest-daily: --to requires --from

# Test 4 — --from later than --to rejected
$ python3 bridge-memory.py harvest-daily --from 2026-04-25 --to 2026-04-20 --agent _x --home /tmp --workdir /tmp 2>&1 | grep "later than"
harvest-daily: --from 2026-04-25 is later than --to 2026-04-20

# Test 5 — --to in future rejected
$ python3 bridge-memory.py harvest-daily --from 2026-04-20 --to 2999-01-01 --agent _x --home /tmp --workdir /tmp 2>&1 | grep "future"
harvest-daily: --to 2999-01-01 is in the future (today=2026-04-26 tz=Asia/Seoul)

# Test 6 — single-date stdout shape unchanged (byte-identical)
$ git stash && python3 bridge-memory.py harvest-daily --date 2026-04-20 --agent _no_such_agent --home /tmp/agb-322-test/home --workdir /tmp/agb-322-test/workdir --dry-run --json > /tmp/pre.json && git stash pop
$ python3 bridge-memory.py harvest-daily --date 2026-04-20 --agent _no_such_agent --home /tmp/agb-322-test/home --workdir /tmp/agb-322-test/workdir --dry-run --json > /tmp/post.json
$ diff /tmp/pre.json /tmp/post.json && echo "BYTE-IDENTICAL"
BYTE-IDENTICAL
# Same diff for non-json plain stdout: BYTE-IDENTICAL.

# Test 7 — range mode shape
$ python3 bridge-memory.py harvest-daily --from 2026-04-20 --to 2026-04-22 --agent _no_such_agent --home /tmp/agb-322-test/home --workdir /tmp/agb-322-test/workdir --dry-run | python3 -c "import sys, json; d=json.loads(sys.stdin.read()); assert 'results' in d; assert len(d['results']) == 3; print('OK count=' + str(d['count']))"
OK count=3

# Test 8 — --missing-only smoke (against fixture with one nonempty daily note)
$ python3 bridge-memory.py harvest-daily --from 2026-04-20 --to 2026-04-22 --missing-only --agent _x --home /tmp/agb-322-mo/home --workdir /tmp/agb-322-mo/workdir --dry-run | python3 -c "import json,sys; d=json.loads(sys.stdin.read()); [print(' -', r['date'], 'skipped='+r.get('skipped','-')) for r in d['results']]"
 - 2026-04-20 skipped=exists
 - 2026-04-21 skipped=-
 - 2026-04-22 skipped=-
```

Note on the verification commands as written in the issue brief: the brief's literal forms of tests 3-5 omit the `--agent`/`--home`/`--workdir` required args, so argparse intercepts with "the following arguments are required" before our runtime checks fire. The augmented forms above (with required args supplied) demonstrate that the new range validation produces the expected substrings.

## Backwards compatibility

- `--date` semantics unchanged: same default (yesterday in `--tz`), same dispatch path, same RESULT_SCHEMA payload, same per-date sidecar manifest at `state/memory-daily/<agent>/<date>.json`. Verified byte-identical stdout against `main` for both `--json` and plain forms.
- New flags (`--from`, `--to`, `--missing-only`) are purely additive. Existing cron entries that invoke `harvest-daily --date <yesterday>` are unaffected.
- Queue-backfill task body shape unchanged. Sidecar manifest schema unchanged.

## Sample usage

```bash
python3 bridge-memory.py harvest-daily \
  --from 2026-04-12 --to 2026-04-23 \
  --agent patch \
  --home ~/.agent-bridge/agents/patch \
  --workdir <agent-workdir> \
  --missing-only
```

## CI

Pre-existing CI failures on `main` are not addressed here; not blocking per brief.

## Scope discipline

No VERSION bump. No CHANGELOG entry. Only `bridge-memory.py` touched. Single commit.

Addresses Track A of #322. Tracks B (`--missing-only` is partially folded in here) / C (`bootstrap-memory-system.sh` first-run backfill option) stay open.
