### PR TITLE
admin: cron body, hook, daemon body, handoff filename — wire role-spec rules into runtime (#303 B+D, #304 C+D)

### DIFF
--- a/agents/_template/CLAUDE.md
+++ b/agents/_template/CLAUDE.md
@@ -30,6 +30,7 @@ task를 수신하면 아래 순서를 반드시 따른다:
    - 사람이 최종 수신자 → 연결된 채널 세션(Discord/Telegram)에 메시지
    - 다른 에이전트가 요청자 → `agent-bridge task create --to <요청자>`로 결과 전달
 4. **done**: `agb done <task_id> --note "요약"` — 반드시 note에 무엇을 했는지 기록
+- `NEXT-SESSION.md`은 **표준 파일명**이고, 에이전트 home의 `NEXT-SESSION.md`만 SessionStart hook이 자동으로 인지한다. `handoff-*.md`, `NEXT-SESSION-*.md` (suffix 추가), `next-session.md` (소문자) 같은 변형은 hook이 인지하지 못하는 **개인 노트**일 뿐이다. cross-session continuity 용도로는 정확히 `<agent-home>/NEXT-SESSION.md` 한 파일만 사용한다. 자세한 contract는 [`docs/agent-runtime/handoff-protocol.md`](../../docs/agent-runtime/handoff-protocol.md)에 있다.
 - **조용한 done 금지**: 결과를 아무에게도 전달하지 않은 채 done만 치는 것은 금지
 - **빈 note done 금지**: --note 없이 done 금지
 - queue의 open status는 `queued`, `claimed`, `blocked`만 공식 상태다. 작업 시작 표시는 별도 `in_progress`가 아니라 `claim` 또는 `--status claimed`를 사용한다.

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1470,6 +1470,8 @@ if ts > 0:
     print(datetime.fromtimestamp(ts, timezone.utc).astimezone().isoformat())
 PY
 )"
+  local source_kind=""
+  source_kind="$(bridge_agent_source "$agent")"
   mkdir -p "$(dirname "$body_file")"
   {
     echo "# Context Pressure Report"
@@ -1478,6 +1480,7 @@ PY
     echo "- session: ${session:--}"
     echo "- severity: $severity"
     echo "- idle_seconds: $idle"
+    echo "- agent_source: ${source_kind:-static}"
     echo "- first_detected_at: ${first_detected_iso:-$(bridge_now_iso)}"
     echo "- detected_at: $(bridge_now_iso)"
     if [[ -n "$matched_pattern" ]]; then
@@ -1486,7 +1489,13 @@ PY
     echo
     echo "## Recommended Next Action"
     echo
-    echo "Ask the agent to compact, summarize, or restart with a NEXT-SESSION handoff before context pressure degrades task quality. Treat this separately from process liveness: the session can be running but still need context management."
+    if [[ "$source_kind" == "dynamic" ]]; then
+      echo "**Operator-managed.** This is a dynamic agent — the operator manages it directly in the TUI. Close this task with a one-line note \`dynamic agent — operator-managed\` and take no further action. See CLAUDE.md \`## Admin Static vs Dynamic Agent Boundary\` for the rule."
+    else
+      echo "**Resolve autonomously.** This is a static agent (end-user is on Discord/Telegram/Teams; cannot run any Claude Code command). Do not nudge the agent or its end-user."
+      echo
+      echo "Until \`agent-bridge agent autopilot-compact <agent>\` and \`agent-bridge agent handoff-restart <agent>\` ship (issue #304 Track B), escalate to the human operator on the shared external channel rather than asking the static agent or its end-user to run \`/compact\`, \`/clear\`, or write \`NEXT-SESSION.md\`. Close this task with the action you took. See CLAUDE.md \`## Admin Static vs Dynamic Agent Boundary\` for the rule."
+    fi
     echo
     echo "## Recent Output"
     echo

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -1296,10 +1296,31 @@ def blocked_task_reminder_body(task: sqlite3.Row, age_seconds: int, reminder_sec
             "",
             "This task has stayed blocked without a status refresh.",
             "",
-            "Please do one of the following:",
-            f"1. refresh the blocked status: `agb update {task_id} --status blocked --note \"...\"`",
-            f"2. hand it off if ownership changed: `agb handoff {task_id} --to <agent> --note \"...\"`",
-            f"3. resolve it and close it: `agb done {task_id} --agent {assigned_to} --note \"...\"`",
+            "## Self-Cleanup Decision Tree",
+            "",
+            "(admin contract; see CLAUDE.md `## Admin Self-Cleanup of Own Queue`)",
+            "",
+            "Apply (a)-(f) in order, ruling each one out in writing in your refresh note "
+            "before reaching `refresh blocked`. Refresh is the exception, not the equilibrium.",
+            "",
+            "(a) original premise satisfied / invalidated by later events",
+            f"    → `agb done {task_id} --agent {assigned_to} --note \"stale: <why>\"`",
+            "(b) source agent moved on / closed its driving cycle",
+            f"    → `agb done {task_id} --agent {assigned_to} --note \"source moved on\"`",
+            "(c) another active task already covers this work",
+            f"    → `agb handoff {task_id} --to <agent> --note \"<cross-ref>\"`"
+            f" OR `agb done {task_id} --agent {assigned_to} --note \"duplicate of #<id>\"`",
+            "(d) doable in <15 minutes by you alone",
+            "    → unblock and do it now; do NOT defer as `tech debt`",
+            "(e) operator decision required AND obtainable on the shared channel today",
+            "    → escalate via Discord/Telegram, then refresh blocked with deadline",
+            "(f) none of the above",
+            f"    → `agb update {task_id} --status blocked --note \"I will revisit when "
+            "<verifiable trigger>. Decision tree: ruled out (a)-(e) because: <one line>.\"`",
+            "",
+            "The `note` on a refresh-blocked must include both the verifiable trigger AND "
+            "the one-line summary of why (a)-(e) were ruled out. Empty notes and bare-refresh "
+            "notes are rejected by the contract.",
         ]
     )
     return "\n".join(lines).rstrip() + "\n"
@@ -1328,6 +1349,35 @@ def blocked_task_escalation_body(
         "",
         "This blocked task has gone stale past the escalation threshold.",
         "Please review whether the assignee needs intervention, handoff, or closure.",
+        "",
+        "## Self-Cleanup Decision Tree",
+        "",
+        "(admin contract; see CLAUDE.md `## Admin Self-Cleanup of Own Queue`)",
+        "",
+        "Apply (a)-(f) in order, ruling each one out in writing in your refresh note "
+        "before reaching `refresh blocked`. Refresh is the exception, not the equilibrium.",
+        "",
+        "(a) original premise satisfied / invalidated by later events",
+        f"    → `agb done {task_id} --agent {assigned_to} --note \"stale: <why>\"`",
+        "(b) source agent moved on / closed its driving cycle",
+        f"    → `agb done {task_id} --agent {assigned_to} --note \"source moved on\"`",
+        "(c) another active task already covers this work",
+        f"    → `agb handoff {task_id} --to <agent> --note \"<cross-ref>\"`"
+        f" OR `agb done {task_id} --agent {assigned_to} --note \"duplicate of #<id>\"`",
+        "(d) doable in <15 minutes by you alone",
+        "    → unblock and do it now; do NOT defer as `tech debt`",
+        "(e) operator decision required AND obtainable on the shared channel today",
+        "    → escalate via Discord/Telegram, then refresh blocked with deadline",
+        "(f) none of the above",
+        f"    → `agb update {task_id} --status blocked --note \"I will revisit when "
+        "<verifiable trigger>. Decision tree: ruled out (a)-(e) because: <one line>.\"`",
+        "",
+        "The `note` on a refresh-blocked must include both the verifiable trigger AND "
+        "the one-line summary of why (a)-(e) were ruled out. Empty notes and bare-refresh "
+        "notes are rejected by the contract.",
+        "",
+        "This is the second escalation cycle for this id. If you cannot reach (a)-(e) this "
+        "round, the operator will be paged via the shared channel; do not bare-refresh.",
     ]
     return "\n".join(lines).rstrip() + "\n"
 

--- a/docs/agent-runtime/handoff-protocol.md
+++ b/docs/agent-runtime/handoff-protocol.md
@@ -1,0 +1,17 @@
+# Handoff Protocol — `NEXT-SESSION.md`
+
+Agent Bridge auto-consumes exactly **one** handoff filename: `<agent-home>/NEXT-SESSION.md`.
+
+- SessionStart hook (`hooks/bridge_hook_common.py`, `next_session_marker`) computes a SHA-1 marker for that file and surfaces "new handoff present" to the agent on the next session.
+- The hook does **NOT** scan for `handoff-*.md`, `NEXT-SESSION-*.md` (with extra suffix), `next-session.md` (lowercase), or any other naming variant. Such files are **private notes** that bridge cannot see.
+- For cross-session continuity, write to exactly `<agent-home>/NEXT-SESSION.md`. Delete the file after the next session has consumed it (the role spec and the existing template instruction already say this).
+
+## Why this matters
+
+On 2026-04-25, an agent wrote a handoff to `~/migration-logs/.../handoff-next-session-v2.md` — a self-chosen path the bridge does not look at on session start. The next session would have idled until the next inbound message, even though a handoff existed.
+
+For static agents (where the end-user is on Discord/Telegram/Teams and cannot run any CLI), this is a silent failure mode: the operator never sees that handoff was supposed to land. The filename contract is the only thing keeping handoffs reliable across the static-agent population.
+
+## Optional future hardening
+
+The SessionStart hook can be extended to scan the agent home for `handoff-*.md` or `NEXT-SESSION-*.md` (with suffix) on first turn and emit a one-line warning if any are present. This is **not** done in this PR — the warning would be noisy without a contract first, and the filename contract here is the contract.

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -440,6 +440,35 @@ def prompt_timestamp_context(agent: str, now: datetime | None = None) -> str:
     return context
 
 
+def admin_blocked_self_cleanup_context(agent: str) -> str:
+    """Return a single-line self-cleanup pressure note when admin starts a session
+    with blocked tasks in its own queue. Empty string for non-admin agents or when
+    the admin has no blocked tasks. Filename contract for the role spec is in
+    docs/agent-runtime/handoff-protocol.md.
+    """
+    admin_id = os.environ.get("BRIDGE_ADMIN_AGENT_ID", "").strip()
+    if not admin_id or agent != admin_id:
+        return ""
+    summary_proc = queue_cli(["summary", "--agent", agent, "--format", "json"])
+    if summary_proc.returncode != 0 or not summary_proc.stdout.strip():
+        return ""
+    try:
+        rows = json.loads(summary_proc.stdout)
+    except json.JSONDecodeError:
+        return ""
+    if not isinstance(rows, list) or not rows or not isinstance(rows[0], dict):
+        return ""
+    blocked = int(rows[0].get("blocked_count", 0) or 0)
+    if blocked <= 0:
+        return ""
+    return (
+        f"[Self-cleanup] {blocked} blocked task(s) in your queue. "
+        "Self-cleanup contract requires evaluating each per the role spec "
+        "(CLAUDE.md `## Admin Self-Cleanup of Own Queue`) before any other work. "
+        "If you cannot reach a close decision today, refresh with a verifiable trigger."
+    )
+
+
 def session_start_context(agent: str) -> str:
     queue_context = (
         f"Agent Bridge queue protocol applies to {agent}. "
@@ -449,6 +478,9 @@ def session_start_context(agent: str) -> str:
         f"If a task is queued, claim the highest-priority one first. "
         f"If a task is already claimed by you, continue that task."
     )
+    self_cleanup = admin_blocked_self_cleanup_context(agent)
+    if self_cleanup:
+        queue_context = f"{self_cleanup}\n\n{queue_context}"
     bootstrap_context = bootstrap_artifact_context(agent)
     if bootstrap_context:
         return f"{bootstrap_context}\n\n{queue_context}"


### PR DESCRIPTION
## Summary

PR #306 documented the admin self-cleanup decision tree and the static vs dynamic agent boundary. This PR makes those rules visible at runtime — in cron-emitted task bodies, the daemon's context-pressure report, and the SessionStart hook — so the admin doesn't have to re-derive them from the role spec on each pass.

Surface: 5 files, ~114 lines net.

## Track-by-track

- **#303 Track B** — `bridge-queue.py`'s `blocked_task_reminder_body` and `blocked_task_escalation_body` now embed the (a)-(f) self-cleanup decision tree from the role spec, with per-task `agb` commands inline. The escalation body adds a second-cycle warning that bare-refresh will trigger operator paging on the next round.
- **#303 Track D** — `hooks/bridge_hook_common.py::session_start_context` now prepends a single-line `[Self-cleanup] N blocked task(s) in your queue. ...` note when the admin (`BRIDGE_ADMIN_AGENT_ID`) starts a session with blocked tasks in its own queue. Non-admin agents and admins with zero blocked tasks see the existing `queue_context` unchanged.
- **#304 Track C** — `bridge-daemon.sh::bridge_write_context_pressure_report_body` now branches on `bridge_agent_source`. Dynamic targets get an operator-managed close instruction; static targets get autonomous-resolution guidance that explicitly forbids nudging the static agent or its non-developer end-user. Both branches reference `## Admin Static vs Dynamic Agent Boundary` in the role spec. The body now also exposes `agent_source` as a metadata field for downstream consumers. The stall body builder takes its `recommended` text as a caller-supplied argument and was left alone for this round; happy to revisit in a follow-up.
- **#304 Track D** — `agents/_template/CLAUDE.md` gains one new bullet under `## Task Processing Protocol` naming `<agent-home>/NEXT-SESSION.md` as the only filename SessionStart auto-consumes; `handoff-*.md`, `NEXT-SESSION-*.md` (with suffix), and `next-session.md` (lowercase) are private notes that bridge cannot see. New `docs/agent-runtime/handoff-protocol.md` publishes the contract and records the 2026-04-25 silent-failure incident as the motivation.

## What's preserved

- Role-spec text in `agents/_template/CLAUDE.md` (`## Admin Self-Cleanup of Own Queue`, `## Admin Static vs Dynamic Agent Boundary`) is unchanged. This PR only wires those existing rules into runtime mechanisms.
- All original metadata fields in the reminder/escalation bodies (`original_task_id`, `original_title`, `assigned_to`, `claimed_by`, `blocked_age`, `last_updated_at`, `reminder_interval`, `escalation_threshold`, `reminder_cycles_elapsed`) are preserved exactly. The smoke-fixture assertions on those fields and on the audit-log entries `blocked_reminder by daemon` / `blocked_escalated by daemon` continue to hold.
- `session_start_context` behaviour for non-admin agents and admins with empty/clean queues is byte-for-byte identical.
- No VERSION bump, no CHANGELOG entry (release contract: only `release/vX.Y.Z` branches change those).

## Verification

- `python3 -c \"import ast; ast.parse(open('bridge-queue.py').read())\"` → PASS
- `python3 -c \"import ast; ast.parse(open('hooks/bridge_hook_common.py').read())\"` → PASS
- `bash -n bridge-daemon.sh` → PASS
- `shellcheck bridge-daemon.sh` → clean
- Isolated body-builder check (Python): reminder + escalation contain the new tree and preserve all original metadata fields the smoke fixtures assert
- Isolated daemon body-builder check (Bash 4 with stub roster): static branch emits `**Resolve autonomously.**`; dynamic branch emits `**Operator-managed.**`; branches do not bleed into each other; both contain `Admin Static vs Dynamic Agent Boundary`
- Isolated hook check: `admin_blocked_self_cleanup_context` returns `\"\"` for non-admin agents, admin/agent id mismatch, and empty queue; `session_start_context` still returns the queue protocol line unchanged in those cases
- `./scripts/smoke-test.sh` halts at the same step (`claiming and completing queue task` / `mcp-restart.log`) it halts on `main` — pre-existing, not caused by this PR

## CI status

Pre-existing CI failure on `main` since 2026-04-21. Not caused by this PR.

Addresses #303 Tracks B + D and #304 Tracks C + D. #303 Track C (status dashboard column) and #304 Track B (autopilot-compact / handoff-restart CLI) stay open as separate waves. Both issues remain open until those land.