### PR TITLE
isolate: peer A2A through gateway — scoped env carries peer ids + non-secret metadata + explicit proxy signal (#294)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -311,6 +311,28 @@ For the step-by-step operator walkthrough for transitioning an existing
 Linux fleet from shared mode to per-UID isolation one agent at a time,
 see [docs/isolation-migration-guide.md](./docs/isolation-migration-guide.md).
 
+Isolated agents reach peer agents through the queue gateway, not the
+SQLite DB directly. The per-agent scoped env file
+(`<state>/agents/<agent>/agent-env.sh`) carries every static peer's id and
+non-secret metadata (description, engine, session, workdir, isolation
+mode, prompt-guard policy) so client-side validation
+(`bridge_require_agent`, prompt-guard) passes for any registered peer.
+Peer `BRIDGE_AGENT_LAUNCH_CMD` is **never** emitted into the scoped env —
+the array entry is present-but-empty so callers fall through to the
+controller-side path. Direct sqlite access from the isolated UID stays
+blocked by the `BRIDGE_TASK_DB` ACL strip; gateway routing is selected
+explicitly via the `BRIDGE_GATEWAY_PROXY=1` flag the scoped env writer
+emits when `BRIDGE_AGENT_ISOLATION_MODE=linux-user`. See issue
+[#294](https://github.com/SYRS-AI/agent-bridge-public/issues/294).
+
+> **Upgrading from <0.6.13:** the gateway-proxy gate now requires
+> `BRIDGE_GATEWAY_PROXY=1` in the scoped env. Restart isolated agents
+> (`agent-bridge agent stop <agent>` then `agent-bridge agent start
+> <agent> --no-attach`) so the env file is rewritten with the new flag.
+> Sessions started under the old code keep working until restart, but
+> A2A queue tasks from those sessions stop routing through the gateway
+> until they pick up the new env.
+
 ## Release Checklist
 
 Before pushing bridge changes:

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1457,7 +1457,12 @@ BRIDGE_ACTIVE_ROSTER_MD=$(printf '%q' "$BRIDGE_ACTIVE_ROSTER_MD")
 BRIDGE_DAEMON_PID_FILE=$(printf '%q' "$BRIDGE_DAEMON_PID_FILE")
 BRIDGE_DAEMON_LOG=$(printf '%q' "$BRIDGE_DAEMON_LOG")
 BRIDGE_DAEMON_CRASH_LOG=$(printf '%q' "$BRIDGE_DAEMON_CRASH_LOG")
-BRIDGE_TASK_DB=$(printf '%q' "$BRIDGE_TASK_DB")
+# BRIDGE_TASK_DB is sentineled (not the live path) for isolated UIDs: every
+# queue read/write must route through the gateway proxy when
+# BRIDGE_GATEWAY_PROXY=1. Emitting the real path would disclose operator state
+# layout (#287 / #294 r1 finding 4) and re-open a direct-DB code path. Setting
+# /dev/null fails loudly if any caller bypasses the gateway and tries sqlite.
+BRIDGE_TASK_DB=/dev/null
 BRIDGE_PROFILE_STATE_DIR=$(printf '%q' "$BRIDGE_PROFILE_STATE_DIR")
 BRIDGE_CRON_STATE_DIR=$(printf '%q' "$BRIDGE_CRON_STATE_DIR")
 BRIDGE_CRON_HOME_DIR=$(printf '%q' "$BRIDGE_CRON_HOME_DIR")
@@ -1536,24 +1541,27 @@ BRIDGE_AGENT_ISOLATION_MODE[$(printf '%q' "$agent")]=$(printf '%q' "$isolation_m
 BRIDGE_AGENT_OS_USER[$(printf '%q' "$agent")]=$(printf '%q' "$os_user")
 BRIDGE_AGENT_PROMPT_GUARD[$(printf '%q' "$agent")]=$(printf '%q' "${BRIDGE_AGENT_PROMPT_GUARD[$agent]-}")
 EOF
-  # Peer entries: id + non-secret metadata + guard policy. NEVER emit a peer's
-  # LAUNCH_CMD (token-bearing). The empty LAUNCH_CMD entry is written
-  # explicitly so the array shape stays consistent across map keys; downstream
-  # callers that require the launch command for a peer must fall through to
-  # the controller (queue gateway path). See issue #294.
+  # Peer entries: id + non-secret metadata. NEVER emit a peer's LAUNCH_CMD
+  # (token-bearing) or PROMPT_GUARD policy (canary tokens at
+  # lib/bridge-guard.sh:123 are sensitive — see #294 r1 finding 3). The empty
+  # LAUNCH_CMD / PROMPT_GUARD entries are written explicitly so the array shape
+  # stays consistent across map keys; downstream callers that require the
+  # launch command for a peer must fall through to the controller (queue
+  # gateway path). Client-side guard parity for peers is intentionally dropped:
+  # gateway-side enforcement remains, and a follow-up issue covers the case if
+  # peer-targeted prompt blocking before queue submission is actually needed.
   local peer=""
   for peer in "${BRIDGE_AGENT_IDS[@]}"; do
     [[ "$peer" == "$agent" ]] && continue
     [[ "$(bridge_agent_source "$peer")" == "static" ]] || continue
     local peer_desc peer_engine peer_session peer_workdir peer_isolation
-    local peer_source peer_guard
+    local peer_source
     peer_desc="$(bridge_agent_desc "$peer")"
     peer_engine="$(bridge_agent_engine "$peer")"
     peer_session="$(bridge_agent_session "$peer")"
     peer_workdir="$(bridge_agent_workdir "$peer")"
     peer_isolation="$(bridge_agent_isolation_mode "$peer")"
     peer_source="$(bridge_agent_source "$peer")"
-    peer_guard="${BRIDGE_AGENT_PROMPT_GUARD[$peer]-}"
     cat >>"$file" <<EOF
 bridge_add_agent_id_if_missing $(printf '%q' "$peer")
 BRIDGE_AGENT_DESC[$(printf '%q' "$peer")]=$(printf '%q' "$peer_desc")
@@ -1563,7 +1571,7 @@ BRIDGE_AGENT_WORKDIR[$(printf '%q' "$peer")]=$(printf '%q' "$peer_workdir")
 BRIDGE_AGENT_SOURCE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_source")
 BRIDGE_AGENT_ISOLATION_MODE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_isolation")
 BRIDGE_AGENT_LAUNCH_CMD[$(printf '%q' "$peer")]=''
-BRIDGE_AGENT_PROMPT_GUARD[$(printf '%q' "$peer")]=$(printf '%q' "$peer_guard")
+BRIDGE_AGENT_PROMPT_GUARD[$(printf '%q' "$peer")]=''
 EOF
   done
   # Explicit gateway-proxy signal for isolated agents. Decouples gateway

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1506,29 +1506,76 @@ declare -g -A BRIDGE_AGENT_OS_USER=()
 declare -g -A BRIDGE_AGENT_MODEL=()
 declare -g -A BRIDGE_AGENT_EFFORT=()
 declare -g -A BRIDGE_AGENT_PERMISSION_MODE=()
-bridge_add_agent_id_if_missing $(printf '%q' "$agent")
-BRIDGE_AGENT_DESC["$agent"]=$(printf '%q' "$description")
-BRIDGE_AGENT_ENGINE["$agent"]=$(printf '%q' "$engine")
-BRIDGE_AGENT_SESSION["$agent"]=$(printf '%q' "$session")
-BRIDGE_AGENT_WORKDIR["$agent"]=$(printf '%q' "$workdir")
-BRIDGE_AGENT_PROFILE_HOME["$agent"]=$(printf '%q' "$profile_home")
-BRIDGE_AGENT_LAUNCH_CMD["$agent"]=$(printf '%q' "$launch_cmd")
-BRIDGE_AGENT_SOURCE["$agent"]="static"
-BRIDGE_AGENT_LOOP["$agent"]=$(printf '%q' "$loop_mode")
-BRIDGE_AGENT_CONTINUE["$agent"]=$(printf '%q' "$continue_mode")
-BRIDGE_AGENT_SESSION_ID["$agent"]=$(printf '%q' "$session_id")
-BRIDGE_AGENT_HISTORY_KEY["$agent"]=$(printf '%q' "$history_key")
-BRIDGE_AGENT_CREATED_AT["$agent"]=$(printf '%q' "$created_at")
-BRIDGE_AGENT_UPDATED_AT["$agent"]=$(printf '%q' "$updated_at")
-BRIDGE_AGENT_IDLE_TIMEOUT["$agent"]=$(printf '%q' "$idle_timeout")
-BRIDGE_AGENT_NOTIFY_KIND["$agent"]=$(printf '%q' "$notify_kind")
-BRIDGE_AGENT_NOTIFY_TARGET["$agent"]=$(printf '%q' "$notify_target")
-BRIDGE_AGENT_NOTIFY_ACCOUNT["$agent"]=$(printf '%q' "$notify_account")
-BRIDGE_AGENT_DISCORD_CHANNEL_ID["$agent"]=$(printf '%q' "$discord_channel")
-BRIDGE_AGENT_CHANNELS["$agent"]=$(printf '%q' "$channels")
-BRIDGE_AGENT_ISOLATION_MODE["$agent"]=$(printf '%q' "$isolation_mode")
-BRIDGE_AGENT_OS_USER["$agent"]=$(printf '%q' "$os_user")
+declare -g -A BRIDGE_AGENT_PROMPT_GUARD=()
 EOF
+  # Self entry first: full record including LAUNCH_CMD (the calling agent's
+  # own launch command may legitimately carry tokens; ACLs already restrict
+  # the file to the calling UID + controller).
+  cat >>"$file" <<EOF
+bridge_add_agent_id_if_missing $(printf '%q' "$agent")
+BRIDGE_AGENT_DESC[$(printf '%q' "$agent")]=$(printf '%q' "$description")
+BRIDGE_AGENT_ENGINE[$(printf '%q' "$agent")]=$(printf '%q' "$engine")
+BRIDGE_AGENT_SESSION[$(printf '%q' "$agent")]=$(printf '%q' "$session")
+BRIDGE_AGENT_WORKDIR[$(printf '%q' "$agent")]=$(printf '%q' "$workdir")
+BRIDGE_AGENT_PROFILE_HOME[$(printf '%q' "$agent")]=$(printf '%q' "$profile_home")
+BRIDGE_AGENT_LAUNCH_CMD[$(printf '%q' "$agent")]=$(printf '%q' "$launch_cmd")
+BRIDGE_AGENT_SOURCE[$(printf '%q' "$agent")]="static"
+BRIDGE_AGENT_LOOP[$(printf '%q' "$agent")]=$(printf '%q' "$loop_mode")
+BRIDGE_AGENT_CONTINUE[$(printf '%q' "$agent")]=$(printf '%q' "$continue_mode")
+BRIDGE_AGENT_SESSION_ID[$(printf '%q' "$agent")]=$(printf '%q' "$session_id")
+BRIDGE_AGENT_HISTORY_KEY[$(printf '%q' "$agent")]=$(printf '%q' "$history_key")
+BRIDGE_AGENT_CREATED_AT[$(printf '%q' "$agent")]=$(printf '%q' "$created_at")
+BRIDGE_AGENT_UPDATED_AT[$(printf '%q' "$agent")]=$(printf '%q' "$updated_at")
+BRIDGE_AGENT_IDLE_TIMEOUT[$(printf '%q' "$agent")]=$(printf '%q' "$idle_timeout")
+BRIDGE_AGENT_NOTIFY_KIND[$(printf '%q' "$agent")]=$(printf '%q' "$notify_kind")
+BRIDGE_AGENT_NOTIFY_TARGET[$(printf '%q' "$agent")]=$(printf '%q' "$notify_target")
+BRIDGE_AGENT_NOTIFY_ACCOUNT[$(printf '%q' "$agent")]=$(printf '%q' "$notify_account")
+BRIDGE_AGENT_DISCORD_CHANNEL_ID[$(printf '%q' "$agent")]=$(printf '%q' "$discord_channel")
+BRIDGE_AGENT_CHANNELS[$(printf '%q' "$agent")]=$(printf '%q' "$channels")
+BRIDGE_AGENT_ISOLATION_MODE[$(printf '%q' "$agent")]=$(printf '%q' "$isolation_mode")
+BRIDGE_AGENT_OS_USER[$(printf '%q' "$agent")]=$(printf '%q' "$os_user")
+BRIDGE_AGENT_PROMPT_GUARD[$(printf '%q' "$agent")]=$(printf '%q' "${BRIDGE_AGENT_PROMPT_GUARD[$agent]-}")
+EOF
+  # Peer entries: id + non-secret metadata + guard policy. NEVER emit a peer's
+  # LAUNCH_CMD (token-bearing). The empty LAUNCH_CMD entry is written
+  # explicitly so the array shape stays consistent across map keys; downstream
+  # callers that require the launch command for a peer must fall through to
+  # the controller (queue gateway path). See issue #294.
+  local peer=""
+  for peer in "${BRIDGE_AGENT_IDS[@]}"; do
+    [[ "$peer" == "$agent" ]] && continue
+    [[ "$(bridge_agent_source "$peer")" == "static" ]] || continue
+    local peer_desc peer_engine peer_session peer_workdir peer_isolation
+    local peer_source peer_guard
+    peer_desc="$(bridge_agent_desc "$peer")"
+    peer_engine="$(bridge_agent_engine "$peer")"
+    peer_session="$(bridge_agent_session "$peer")"
+    peer_workdir="$(bridge_agent_workdir "$peer")"
+    peer_isolation="$(bridge_agent_isolation_mode "$peer")"
+    peer_source="$(bridge_agent_source "$peer")"
+    peer_guard="${BRIDGE_AGENT_PROMPT_GUARD[$peer]-}"
+    cat >>"$file" <<EOF
+bridge_add_agent_id_if_missing $(printf '%q' "$peer")
+BRIDGE_AGENT_DESC[$(printf '%q' "$peer")]=$(printf '%q' "$peer_desc")
+BRIDGE_AGENT_ENGINE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_engine")
+BRIDGE_AGENT_SESSION[$(printf '%q' "$peer")]=$(printf '%q' "$peer_session")
+BRIDGE_AGENT_WORKDIR[$(printf '%q' "$peer")]=$(printf '%q' "$peer_workdir")
+BRIDGE_AGENT_SOURCE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_source")
+BRIDGE_AGENT_ISOLATION_MODE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_isolation")
+BRIDGE_AGENT_LAUNCH_CMD[$(printf '%q' "$peer")]=''
+BRIDGE_AGENT_PROMPT_GUARD[$(printf '%q' "$peer")]=$(printf '%q' "$peer_guard")
+EOF
+  done
+  # Explicit gateway-proxy signal for isolated agents. Decouples gateway
+  # routing from `${#BRIDGE_AGENT_IDS[@]}` so the peer-id additions above do
+  # not accidentally drop the agent off the gateway. See issue #294 +
+  # bridge_queue_gateway_proxy_agent.
+  if [[ "$isolation_mode" == "linux-user" ]]; then
+    cat >>"$file" <<'EOF'
+BRIDGE_GATEWAY_PROXY=1
+export BRIDGE_GATEWAY_PROXY
+EOF
+  fi
   # Inject engine CLI directory into PATH for sudo-wrapped launchers when
   # isolation is active. Under sudo, PATH falls back to secure_path which
   # almost never contains the operator's per-user bin (e.g.

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -350,13 +350,26 @@ bridge_queue_gateway_responses_dir() {
 }
 
 bridge_queue_gateway_proxy_agent() {
+  # Resolve the calling agent that should route through the queue gateway
+  # instead of touching the SQLite DB directly. Returns the agent id on stdout
+  # when proxy mode applies; empty + non-zero rc otherwise.
+  #
+  # Decoupled from `${#BRIDGE_AGENT_IDS[@]}` so the scoped env can carry every
+  # peer's id (needed for client-side bridge_require_agent on A2A queue tasks)
+  # without simultaneously dropping the isolated UID off the gateway path.
+  # The explicit `BRIDGE_GATEWAY_PROXY=1` flag is emitted by
+  # bridge_write_linux_agent_env_file whenever the agent runs in linux-user
+  # isolation. See issue #294.
   local agent=""
-  local count=0
 
   [[ -n "${BRIDGE_AGENT_ENV_FILE:-}" ]] || return 1
-  count="${#BRIDGE_AGENT_IDS[@]}"
-  [[ "$count" -eq 1 ]] || return 1
-  agent="${BRIDGE_AGENT_IDS[0]}"
+  [[ "${BRIDGE_GATEWAY_PROXY:-}" == "1" ]] || return 1
+  agent="${BRIDGE_AGENT_ID:-}"
+  if [[ -z "$agent" ]]; then
+    # Fallback: scoped envs always emit the calling agent's id first.
+    agent="${BRIDGE_AGENT_IDS[0]:-}"
+  fi
+  [[ -n "$agent" ]] || return 1
   bridge_agent_linux_user_isolation_effective "$agent" || return 1
   printf '%s' "$agent"
 }

--- a/tests/isolation-peer-routing.sh
+++ b/tests/isolation-peer-routing.sh
@@ -6,16 +6,21 @@
 # Verifies (portable, runs on macOS with bash 4+):
 #   1. bridge_write_linux_agent_env_file emits BRIDGE_AGENT_IDS for every
 #      static peer, plus non-secret metadata (description, engine, session,
-#      workdir, isolation_mode, source, prompt_guard policy).
+#      workdir, isolation_mode, source).
 #   2. The scoped env NEVER contains a peer's BRIDGE_AGENT_LAUNCH_CMD value.
 #      The peer's LAUNCH_CMD entry is present-but-empty so the array shape
 #      stays consistent.
-#   3. The scoped env emits the explicit BRIDGE_GATEWAY_PROXY=1 flag when the
+#   3. The scoped env NEVER contains a peer's BRIDGE_AGENT_PROMPT_GUARD
+#      policy value (canary tokens leak otherwise — #294 r1 finding 3). The
+#      peer's PROMPT_GUARD entry is present-but-empty.
+#   4. The scoped env hides the live BRIDGE_TASK_DB path; queue access must
+#      route through the gateway proxy (#294 r1 finding 4 / #287 ACL).
+#   5. The scoped env emits the explicit BRIDGE_GATEWAY_PROXY=1 flag when the
 #      calling agent is in linux-user isolation, and omits it otherwise.
-#   4. bridge_queue_gateway_proxy_agent() returns the calling agent when
+#   6. bridge_queue_gateway_proxy_agent() returns the calling agent when
 #      BRIDGE_GATEWAY_PROXY=1, even with multiple BRIDGE_AGENT_IDS — i.e.,
 #      decoupled from roster cardinality.
-#   5. Shared-mode regression guard: bridge_queue_gateway_proxy_agent returns
+#   7. Shared-mode regression guard: bridge_queue_gateway_proxy_agent returns
 #      empty when BRIDGE_GATEWAY_PROXY is unset.
 #
 # The Linux-only ACL/sudo path lives in tests/isolation-queue-gateway-acl.sh.
@@ -79,7 +84,7 @@ BRIDGE_AGENT_SOURCE[$ADMIN_AGENT]=static
 BRIDGE_AGENT_ISOLATION_MODE[$ISOLATED_AGENT]=linux-user
 BRIDGE_AGENT_ISOLATION_MODE[$ADMIN_AGENT]=shared
 BRIDGE_AGENT_OS_USER[$ISOLATED_AGENT]=agent-bridge-peer-a
-BRIDGE_AGENT_PROMPT_GUARD[$ADMIN_AGENT]="enabled:1;task_body_min_block:high"
+BRIDGE_AGENT_PROMPT_GUARD[$ADMIN_AGENT]="enabled:1;task_body_min_block:high;canary:ADMIN-CANARY-DO-NOT-LEAK"
 ROSTER
 
 # shellcheck source=../bridge-lib.sh
@@ -112,9 +117,18 @@ grep -Eq "BRIDGE_AGENT_ISOLATION_MODE\[$ADMIN_AGENT\]=" "$ENV_FILE" \
 grep -Eq "BRIDGE_AGENT_SOURCE\[$ADMIN_AGENT\]=" "$ENV_FILE" \
   || die "peer source missing"
 
-log "asserting peer guard policy is emitted (non-secret)"
-grep -Eq "BRIDGE_AGENT_PROMPT_GUARD\[$ADMIN_AGENT\]=" "$ENV_FILE" \
-  || die "peer prompt_guard missing"
+log "asserting peer guard policy entry exists but is empty (canary-leak guard, #294 r1 finding 3)"
+peer_guard_line="$(grep -E "^BRIDGE_AGENT_PROMPT_GUARD\[$ADMIN_AGENT\]=" "$ENV_FILE" || true)"
+[[ -n "$peer_guard_line" ]] || die "peer prompt_guard entry missing (must be present-but-empty)"
+case "$peer_guard_line" in
+  "BRIDGE_AGENT_PROMPT_GUARD[$ADMIN_AGENT]=''") ;;
+  *) die "peer prompt_guard must be empty string, got: $peer_guard_line" ;;
+esac
+
+log "asserting peer prompt_guard canary token is NEVER leaked"
+if grep -Fq "ADMIN-CANARY-DO-NOT-LEAK" "$ENV_FILE"; then
+  die "peer prompt_guard canary leaked into scoped env"
+fi
 
 log "asserting peer LAUNCH_CMD entry exists but is empty"
 peer_launch_line="$(grep -E "^BRIDGE_AGENT_LAUNCH_CMD\[$ADMIN_AGENT\]=" "$ENV_FILE" || true)"
@@ -131,6 +145,38 @@ fi
 # Self launch_cmd should still be present (calling agent's own command).
 if ! grep -Fq "PEER-TOKEN-DO-NOT-LEAK" "$ENV_FILE"; then
   die "self launch_cmd missing from scoped env"
+fi
+
+log "asserting BRIDGE_TASK_DB live path is hidden from scoped env (#294 r1 finding 4 / #287 ACL)"
+# The scoped env must not disclose the operator's queue DB layout. Either
+# absent OR explicitly empty OR /dev/null sentinel is acceptable; the live
+# path under \$BRIDGE_STATE_DIR/tasks.db is NOT.
+if grep -Fq "$BRIDGE_TASK_DB" "$ENV_FILE"; then
+  die "BRIDGE_TASK_DB live path leaked into scoped env: $BRIDGE_TASK_DB"
+fi
+task_db_line="$(grep -E '^BRIDGE_TASK_DB=' "$ENV_FILE" || true)"
+if [[ -n "$task_db_line" ]]; then
+  case "$task_db_line" in
+    'BRIDGE_TASK_DB='|'BRIDGE_TASK_DB=""'|"BRIDGE_TASK_DB=''"|'BRIDGE_TASK_DB=/dev/null'|"BRIDGE_TASK_DB='/dev/null'"|'BRIDGE_TASK_DB="/dev/null"')
+      log "  [ok] BRIDGE_TASK_DB sentineled: $task_db_line"
+      ;;
+    *)
+      die "BRIDGE_TASK_DB sentinel violation in scoped env: $task_db_line"
+      ;;
+  esac
+fi
+
+log "asserting no peer BRIDGE_AGENT_PROMPT_GUARD entry carries non-empty value (#294 r1 finding 3)"
+# Walk every BRIDGE_AGENT_PROMPT_GUARD["<id>"] line; only the calling agent
+# (ISOLATED_AGENT) may carry a non-empty value. Peer entries must be empty.
+nonempty_peer_guard="$(
+  grep -E '^BRIDGE_AGENT_PROMPT_GUARD\[[^]]+\]=' "$ENV_FILE" \
+    | grep -vE "^BRIDGE_AGENT_PROMPT_GUARD\[$ISOLATED_AGENT\]=" \
+    | grep -vE "=(''|\"\")\s*\$" \
+    || true
+)"
+if [[ -n "$nonempty_peer_guard" ]]; then
+  die "peer BRIDGE_AGENT_PROMPT_GUARD entries are non-empty (potential canary leak): $nonempty_peer_guard"
 fi
 
 log "asserting BRIDGE_GATEWAY_PROXY=1 emitted for isolated agent"

--- a/tests/isolation-peer-routing.sh
+++ b/tests/isolation-peer-routing.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# tests/isolation-peer-routing.sh
+#
+# Regression test for issue #294 — isolated peer A2A through the queue gateway.
+#
+# Verifies (portable, runs on macOS with bash 4+):
+#   1. bridge_write_linux_agent_env_file emits BRIDGE_AGENT_IDS for every
+#      static peer, plus non-secret metadata (description, engine, session,
+#      workdir, isolation_mode, source, prompt_guard policy).
+#   2. The scoped env NEVER contains a peer's BRIDGE_AGENT_LAUNCH_CMD value.
+#      The peer's LAUNCH_CMD entry is present-but-empty so the array shape
+#      stays consistent.
+#   3. The scoped env emits the explicit BRIDGE_GATEWAY_PROXY=1 flag when the
+#      calling agent is in linux-user isolation, and omits it otherwise.
+#   4. bridge_queue_gateway_proxy_agent() returns the calling agent when
+#      BRIDGE_GATEWAY_PROXY=1, even with multiple BRIDGE_AGENT_IDS — i.e.,
+#      decoupled from roster cardinality.
+#   5. Shared-mode regression guard: bridge_queue_gateway_proxy_agent returns
+#      empty when BRIDGE_GATEWAY_PROXY is unset.
+#
+# The Linux-only ACL/sudo path lives in tests/isolation-queue-gateway-acl.sh.
+# This test focuses on the env-file content + proxy-detection contract.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+log() { printf '[peer-routing] %s\n' "$*"; }
+die() { printf '[peer-routing][error] %s\n' "$*" >&2; exit 1; }
+skip() { printf '[peer-routing][skip] %s\n' "$*"; exit 0; }
+
+# Bash 4+ is required for associative arrays (the entire roster API).
+if (( BASH_VERSINFO[0] < 4 )); then
+  skip "bash 4+ required (have ${BASH_VERSION})"
+fi
+
+TMP_ROOT="$(mktemp -d -t peer-routing-test.XXXXXX)"
+trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
+
+export BRIDGE_HOME="$TMP_ROOT/bridge-home"
+export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
+export BRIDGE_ROSTER_FILE="$BRIDGE_HOME/agent-roster.sh"
+export BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_HOME/agent-roster.local.sh"
+export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+mkdir -p "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR" "$BRIDGE_SHARED_DIR"
+: > "$BRIDGE_ROSTER_FILE"
+
+# Two static agents: peer (linux-user isolated) + admin (shared).
+ISOLATED_AGENT="peer-a"
+ADMIN_AGENT="admin-a"
+PEER_LAUNCH_CMD="claude --token=PEER-TOKEN-DO-NOT-LEAK"
+ADMIN_LAUNCH_CMD="claude --token=ADMIN-TOKEN-DO-NOT-LEAK"
+PEER_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$ISOLATED_AGENT"
+ADMIN_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$ADMIN_AGENT"
+mkdir -p "$PEER_WORKDIR" "$ADMIN_WORKDIR"
+
+cat > "$BRIDGE_ROSTER_LOCAL_FILE" <<ROSTER
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+BRIDGE_AGENT_IDS=("$ISOLATED_AGENT" "$ADMIN_AGENT")
+BRIDGE_AGENT_DESC[$ISOLATED_AGENT]="peer agent"
+BRIDGE_AGENT_DESC[$ADMIN_AGENT]="admin agent"
+BRIDGE_AGENT_ENGINE[$ISOLATED_AGENT]=claude
+BRIDGE_AGENT_ENGINE[$ADMIN_AGENT]=claude
+BRIDGE_AGENT_SESSION[$ISOLATED_AGENT]=$ISOLATED_AGENT
+BRIDGE_AGENT_SESSION[$ADMIN_AGENT]=$ADMIN_AGENT
+BRIDGE_AGENT_WORKDIR[$ISOLATED_AGENT]=$PEER_WORKDIR
+BRIDGE_AGENT_WORKDIR[$ADMIN_AGENT]=$ADMIN_WORKDIR
+BRIDGE_AGENT_LAUNCH_CMD[$ISOLATED_AGENT]=$(printf '%q' "$PEER_LAUNCH_CMD")
+BRIDGE_AGENT_LAUNCH_CMD[$ADMIN_AGENT]=$(printf '%q' "$ADMIN_LAUNCH_CMD")
+BRIDGE_AGENT_SOURCE[$ISOLATED_AGENT]=static
+BRIDGE_AGENT_SOURCE[$ADMIN_AGENT]=static
+BRIDGE_AGENT_ISOLATION_MODE[$ISOLATED_AGENT]=linux-user
+BRIDGE_AGENT_ISOLATION_MODE[$ADMIN_AGENT]=shared
+BRIDGE_AGENT_OS_USER[$ISOLATED_AGENT]=agent-bridge-peer-a
+BRIDGE_AGENT_PROMPT_GUARD[$ADMIN_AGENT]="enabled:1;task_body_min_block:high"
+ROSTER
+
+# shellcheck source=../bridge-lib.sh
+source "$REPO_ROOT/bridge-lib.sh"
+bridge_load_roster
+
+ENV_FILE="$TMP_ROOT/agent-env.sh"
+
+log "writing scoped env for isolated peer"
+bridge_write_linux_agent_env_file "$ISOLATED_AGENT" "$ENV_FILE"
+[[ -f "$ENV_FILE" ]] || die "env file not written at $ENV_FILE"
+
+log "asserting peer id is present in scoped env"
+grep -Fq "bridge_add_agent_id_if_missing $ADMIN_AGENT" "$ENV_FILE" \
+  || die "peer id $ADMIN_AGENT missing from scoped env"
+grep -Fq "bridge_add_agent_id_if_missing $ISOLATED_AGENT" "$ENV_FILE" \
+  || die "self id $ISOLATED_AGENT missing from scoped env"
+
+log "asserting peer non-secret metadata is emitted"
+grep -Eq "BRIDGE_AGENT_DESC\[$ADMIN_AGENT\]=" "$ENV_FILE" \
+  || die "peer description missing"
+grep -Eq "BRIDGE_AGENT_ENGINE\[$ADMIN_AGENT\]=" "$ENV_FILE" \
+  || die "peer engine missing"
+grep -Eq "BRIDGE_AGENT_SESSION\[$ADMIN_AGENT\]=" "$ENV_FILE" \
+  || die "peer session missing"
+grep -Eq "BRIDGE_AGENT_WORKDIR\[$ADMIN_AGENT\]=" "$ENV_FILE" \
+  || die "peer workdir missing"
+grep -Eq "BRIDGE_AGENT_ISOLATION_MODE\[$ADMIN_AGENT\]=" "$ENV_FILE" \
+  || die "peer isolation_mode missing"
+grep -Eq "BRIDGE_AGENT_SOURCE\[$ADMIN_AGENT\]=" "$ENV_FILE" \
+  || die "peer source missing"
+
+log "asserting peer guard policy is emitted (non-secret)"
+grep -Eq "BRIDGE_AGENT_PROMPT_GUARD\[$ADMIN_AGENT\]=" "$ENV_FILE" \
+  || die "peer prompt_guard missing"
+
+log "asserting peer LAUNCH_CMD entry exists but is empty"
+peer_launch_line="$(grep -E "^BRIDGE_AGENT_LAUNCH_CMD\[$ADMIN_AGENT\]=" "$ENV_FILE" || true)"
+[[ -n "$peer_launch_line" ]] || die "peer launch_cmd entry missing (must be present-but-empty)"
+case "$peer_launch_line" in
+  "BRIDGE_AGENT_LAUNCH_CMD[$ADMIN_AGENT]=''") ;;
+  *) die "peer launch_cmd must be empty string, got: $peer_launch_line" ;;
+esac
+
+log "asserting peer launch_cmd token is NEVER leaked"
+if grep -Fq "ADMIN-TOKEN-DO-NOT-LEAK" "$ENV_FILE"; then
+  die "peer launch_cmd leaked into scoped env"
+fi
+# Self launch_cmd should still be present (calling agent's own command).
+if ! grep -Fq "PEER-TOKEN-DO-NOT-LEAK" "$ENV_FILE"; then
+  die "self launch_cmd missing from scoped env"
+fi
+
+log "asserting BRIDGE_GATEWAY_PROXY=1 emitted for isolated agent"
+grep -Eq '^BRIDGE_GATEWAY_PROXY=1' "$ENV_FILE" \
+  || die "BRIDGE_GATEWAY_PROXY=1 not emitted for linux-user isolated agent"
+
+log "asserting BRIDGE_GATEWAY_PROXY is NOT emitted for shared-mode agent"
+SHARED_ENV_FILE="$TMP_ROOT/admin-env.sh"
+bridge_write_linux_agent_env_file "$ADMIN_AGENT" "$SHARED_ENV_FILE"
+if grep -Eq '^BRIDGE_GATEWAY_PROXY=1' "$SHARED_ENV_FILE"; then
+  die "BRIDGE_GATEWAY_PROXY=1 must not be emitted for shared-mode agents"
+fi
+
+log "asserting bridge_queue_gateway_proxy_agent triggers via the explicit flag"
+# Source the scoped env in a subshell so we don't pollute the test process.
+# Override BRIDGE_HOST_PLATFORM so this assertion runs identically on macOS:
+# bridge_agent_linux_user_isolation_effective normally requires the real
+# host to be Linux. The test target here is the proxy-flag contract, not
+# the platform gate.
+# shellcheck disable=SC2030,SC2031
+(
+  export BRIDGE_HOST_PLATFORM_OVERRIDE=Linux
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+  export BRIDGE_AGENT_ENV_FILE="$ENV_FILE"
+  export BRIDGE_AGENT_ID="$ISOLATED_AGENT"
+  result="$(bridge_queue_gateway_proxy_agent 2>/dev/null || true)"
+  if [[ "$result" != "$ISOLATED_AGENT" ]]; then
+    printf '[peer-routing][error] expected proxy_agent=%s, got=%q\n' \
+      "$ISOLATED_AGENT" "$result" >&2
+    exit 1
+  fi
+  # Multi-id roster + explicit flag must still trigger proxy mode (the bug
+  # before the fix was that `${#BRIDGE_AGENT_IDS[@]} == 1` gated detection).
+  if (( ${#BRIDGE_AGENT_IDS[@]} < 2 )); then
+    printf '[peer-routing][error] expected multi-id BRIDGE_AGENT_IDS in scoped env, got %d\n' \
+      "${#BRIDGE_AGENT_IDS[@]}" >&2
+    exit 1
+  fi
+) || die "proxy detection failed for isolated agent"
+
+log "asserting bridge_queue_gateway_proxy_agent is OFF for shared-mode (regression guard)"
+# shellcheck disable=SC2030,SC2031
+(
+  export BRIDGE_HOST_PLATFORM_OVERRIDE=Linux
+  # shellcheck source=/dev/null
+  source "$SHARED_ENV_FILE"
+  export BRIDGE_AGENT_ENV_FILE="$SHARED_ENV_FILE"
+  export BRIDGE_AGENT_ID="$ADMIN_AGENT"
+  unset BRIDGE_GATEWAY_PROXY
+  result="$(bridge_queue_gateway_proxy_agent 2>/dev/null || true)"
+  if [[ -n "$result" ]]; then
+    printf '[peer-routing][error] shared-mode must not trigger proxy, got=%q\n' "$result" >&2
+    exit 1
+  fi
+) || die "shared-mode regression guard failed"
+
+# Linux-only: full live-isolation peer-routing roundtrip lives in
+# tests/isolation-queue-gateway-acl.sh. Skipping that here keeps this test
+# portable across macOS dev hosts.
+if [[ "$(uname -s)" != "Linux" ]]; then
+  log "macOS host — skipping live linux-user isolation roundtrip"
+  log "isolation peer-routing test passed (env-file + proxy-flag contract)"
+  exit 0
+fi
+
+log "Linux host — sudo+setfacl roundtrip lives in isolation-queue-gateway-acl.sh"
+log "isolation peer-routing test passed"


### PR DESCRIPTION
## Summary

Isolated `linux-user` agents could not send queue tasks to any peer because the scoped roster snapshot was self-only and the gateway-proxy detector was keyed off roster cardinality. This PR ships three coupled changes so isolated peers can A2A-message via the gateway with prompt-guard enforced and zero peer-token leakage.

## What changed

- **`lib/bridge-core.sh::bridge_queue_gateway_proxy_agent`** — replaced the `${#BRIDGE_AGENT_IDS[@]} == 1` cardinality check with an explicit `BRIDGE_GATEWAY_PROXY=1` env-flag check. Shared-mode agents continue on the direct path; the calling agent id resolves from `BRIDGE_AGENT_ID` first, falling back to `BRIDGE_AGENT_IDS[0]`.

- **`lib/bridge-agents.sh::bridge_write_linux_agent_env_file`** —
  - Splits the heredoc into a self-record block and a peer-record loop.
  - Self block: full record (LAUNCH_CMD legitimately scoped to the calling UID via existing ACLs).
  - Peer block: `BRIDGE_AGENT_IDS` entry + non-secret metadata (`DESC`, `ENGINE`, `SESSION`, `WORKDIR`, `SOURCE`, `ISOLATION_MODE`, `PROMPT_GUARD`). `BRIDGE_AGENT_LAUNCH_CMD[<peer>]` is explicitly written as `''` (present-but-empty) so the array shape stays consistent across map keys.
  - Adds the `BRIDGE_AGENT_PROMPT_GUARD` map declaration to the boilerplate so prompt-guard policy lookups resolve correctly client-side (Step 3 direction (a)).
  - Appends `BRIDGE_GATEWAY_PROXY=1; export BRIDGE_GATEWAY_PROXY` when `BRIDGE_AGENT_ISOLATION_MODE=linux-user`.

- **`tests/isolation-peer-routing.sh`** (new) — portable regression covering all five acceptance points:
  1. peer ids + non-secret metadata emitted in scoped env
  2. peer `BRIDGE_AGENT_LAUNCH_CMD` is explicitly `''`, peer token strings absent
  3. `BRIDGE_GATEWAY_PROXY=1` emitted for isolated agent, omitted for shared agent
  4. multi-id roster + flag still triggers proxy mode (regression for the original cardinality bug)
  5. shared-mode regression guard — proxy detector returns empty when flag is unset

  Runs on macOS bash 4+ (uses `BRIDGE_HOST_PLATFORM_OVERRIDE=Linux` for the proxy assertions). The live sudo+setfacl roundtrip stays in `tests/isolation-queue-gateway-acl.sh`.

- **`OPERATIONS.md`** — adds a peer-routing paragraph (what the scoped env exposes, what it never exposes) and an upgrade note instructing operators to restart isolated agents so the env file is rewritten with the new flag.

## What's preserved

- **No peer launch_cmd ever leaked.** Test asserts via grep on a fixture token string (`ADMIN-TOKEN-DO-NOT-LEAK`) that the peer's launch command is not present anywhere in the scoped env, while the calling agent's own launch command (`PEER-TOKEN-DO-NOT-LEAK`) is preserved.
- **Direct sqlite hidden-path strip stays intact.** The `BRIDGE_TASK_DB` ACL guard from #287 is untouched; this PR only restores the gateway-proxy routing path that #287 unblocked.
- **Shared-mode agents unchanged.** `BRIDGE_GATEWAY_PROXY` is never emitted for shared agents and is not set in their environment, so `bridge_queue_gateway_proxy_agent` returns empty and they keep using `bridge_queue_cli_direct`.

## Verification

```
$ bash -n lib/bridge-agents.sh lib/bridge-core.sh tests/isolation-peer-routing.sh tests/isolation-queue-gateway-acl.sh   # OK (with bash 4+)
$ shellcheck lib/bridge-agents.sh lib/bridge-core.sh tests/isolation-peer-routing.sh tests/isolation-queue-gateway-acl.sh   # clean
$ ./tests/isolation-peer-routing.sh
[peer-routing] writing scoped env for isolated peer
[peer-routing] asserting peer id is present in scoped env
[peer-routing] asserting peer non-secret metadata is emitted
[peer-routing] asserting peer guard policy is emitted (non-secret)
[peer-routing] asserting peer LAUNCH_CMD entry exists but is empty
[peer-routing] asserting peer launch_cmd token is NEVER leaked
[peer-routing] asserting BRIDGE_GATEWAY_PROXY=1 emitted for isolated agent
[peer-routing] asserting BRIDGE_GATEWAY_PROXY is NOT emitted for shared-mode agent
[peer-routing] asserting bridge_queue_gateway_proxy_agent triggers via the explicit flag
[peer-routing] asserting bridge_queue_gateway_proxy_agent is OFF for shared-mode (regression guard)
[peer-routing] macOS host — skipping live linux-user isolation roundtrip
[peer-routing] isolation peer-routing test passed (env-file + proxy-flag contract)

$ ./tests/isolation-queue-gateway-acl.sh
[isolate-acl][skip] Linux-only test   # expected on macOS dev host
```

## CI

Pre-existing CI failure on `main` since 2026-04-21 is unrelated to this PR. The local smoke test halts at the chronic `[smoke] starting isolated tmux role` step on both `main` and this branch (verified by stashing the diff and re-running).

Addresses #294. Issue stays open until live verification on a Linux host with passwordless sudo + setfacl.