### PR TITLE
status: add 'garden' column for admin's stale blocked tasks (#303 Track C)

### DIFF
--- a/bridge-status.py
+++ b/bridge-status.py
@@ -15,6 +15,16 @@ from pathlib import Path
 
 PRIORITY_ORDER = {"urgent": 0, "high": 1, "normal": 2, "low": 3}
 
+# Issue #303 Track C — queue-gardening dashboard column. The `garden` column
+# surfaces blocked tasks the assignee has not refreshed (or closed) recently,
+# i.e. the admin's failure mode where blocked becomes a write-only parking
+# lot. Thresholds are in seconds and intentionally tracked here so future
+# tuning is one place; without an ANSI color path in this dashboard we emit
+# the raw stale-blocked count + `d` suffix (the issue's "yellow at 1 day, red
+# at 3 days" rendering degrades to plain text).
+GARDEN_STALE_SECONDS = 86400        # 1 day — yellow tier; below this, render `-`
+GARDEN_CRITICAL_SECONDS = 86400 * 3  # 3 days — red tier (informational only)
+
 
 def iso_now() -> str:
     return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
@@ -50,6 +60,23 @@ def fmt_remaining(ts: int | None) -> str:
     if delta < 86400:
         return f"{delta // 3600}h"
     return f"{delta // 86400}d"
+
+
+def fmt_garden(blocked_count: int, oldest_blocked_ts: int | None) -> str:
+    """Render the queue-gardening signal for a single agent.
+
+    Returns `-` when the agent has no blocked tasks aged past
+    GARDEN_STALE_SECONDS, and `<N>d` otherwise where N is the count of
+    blocked tasks the agent owns. The `d` suffix marks "stale-blocked"
+    rather than the day count itself; without an ANSI color path the
+    yellow/red tier (#303 Track C) collapses to one stale tier.
+    """
+    if not blocked_count or not oldest_blocked_ts:
+        return "-"
+    age = int(datetime.now(timezone.utc).timestamp()) - int(oldest_blocked_ts)
+    if age < GARDEN_STALE_SECONDS:
+        return "-"
+    return f"{int(blocked_count)}d"
 
 
 def classify_stale(active: bool, activity_ts: int | None, warn_seconds: int, critical_seconds: int) -> str:
@@ -147,7 +174,8 @@ def fetch_agent_metrics(conn: sqlite3.Connection) -> dict[str, dict[str, int | s
         SELECT
           assigned_to AS agent,
           SUM(CASE WHEN status = 'queued' THEN 1 ELSE 0 END) AS queued_count,
-          SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END) AS blocked_count
+          SUM(CASE WHEN status = 'blocked' THEN 1 ELSE 0 END) AS blocked_count,
+          MIN(CASE WHEN status = 'blocked' THEN updated_ts END) AS oldest_blocked_ts
         FROM tasks
         GROUP BY assigned_to
       ),
@@ -161,6 +189,7 @@ def fetch_agent_metrics(conn: sqlite3.Connection) -> dict[str, dict[str, int | s
         agent_state.agent,
         COALESCE(assigned.queued_count, 0) AS queued_count,
         COALESCE(assigned.blocked_count, 0) AS blocked_count,
+        assigned.oldest_blocked_ts AS oldest_blocked_ts,
         COALESCE(claimed.claimed_count, 0) AS claimed_count,
         COALESCE(agent_state.active, 0) AS active,
         agent_state.last_seen_ts,
@@ -178,6 +207,7 @@ def fetch_agent_metrics(conn: sqlite3.Connection) -> dict[str, dict[str, int | s
         data[row["agent"]] = {
             "queued_count": row["queued_count"],
             "blocked_count": row["blocked_count"],
+            "oldest_blocked_ts": row["oldest_blocked_ts"],
             "claimed_count": row["claimed_count"],
             "active": row["active"],
             "last_seen_ts": row["last_seen_ts"],
@@ -323,7 +353,7 @@ def render_dashboard(args: argparse.Namespace) -> str:
     )
     lines.append("")
     lines.append("Agents")
-    lines.append("  #  agent           eng     src     loop on  state    q   c   b   idle  stale wake chan  nudge  load        session        workdir")
+    lines.append("  #  agent           eng     src     loop on  state    q   c   b   garden  idle  stale wake chan  nudge  load        session        workdir")
 
     active_index = 0
     for row in roster:
@@ -338,6 +368,11 @@ def render_dashboard(args: argparse.Namespace) -> str:
         queued = int(metric.get("queued_count", 0) or 0)
         claimed = int(metric.get("claimed_count", 0) or 0)
         blocked = int(metric.get("blocked_count", 0) or 0)
+        oldest_blocked_ts = metric.get("oldest_blocked_ts")
+        garden_str = fmt_garden(
+            blocked,
+            int(oldest_blocked_ts) if oldest_blocked_ts else None,
+        )
         activity_ts = metric.get("session_activity_ts") or metric.get("last_seen_ts")
         last_nudge_ts = metric.get("last_nudge_ts")
         zombie = int(metric.get("zombie", 0) or 0)
@@ -358,6 +393,7 @@ def render_dashboard(args: argparse.Namespace) -> str:
             f"{'yes' if active else 'no ':<3} "
             f"{activity_state:<7} "
             f"{queued:>2}  {claimed:>2}  {blocked:>2}  "
+            f"{garden_str:>6}  "
             f"{fmt_idle(int(activity_ts) if activity_ts else None):>4}  "
             f"{stale:>5} "
             f"{wake_state:>6} "

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2503,6 +2503,88 @@ python3 "$REPO_ROOT/bridge-queue.py" cancel "$BLOCKED_REMINDER_ID" --actor smoke
 python3 "$REPO_ROOT/bridge-queue.py" cancel "$BLOCKED_ESCALATION_ID" --actor smoke-test --note "blocked aging smoke cleanup" >/dev/null
 python3 "$REPO_ROOT/bridge-queue.py" cancel "$BLOCKED_AGING_TASK_ID" --actor smoke-test --note "blocked aging smoke cleanup" >/dev/null
 
+# Issue #303 Track C — `garden` column surfaces stale blocked tasks the
+# assignee owns. Seed a blocked task whose updated_ts is 2 days old, run
+# `agent-bridge status --all-agents`, and assert the smoke agent's row
+# carries the `Nd` stale-blocked tag. Refresh the task and assert the
+# column collapses back to `-`.
+log "garden column reports stale blocked tasks (#303 Track C)"
+GARDEN_CREATE_OUTPUT="$(python3 "$REPO_ROOT/bridge-queue.py" create --to "$SMOKE_AGENT" --title "garden column smoke" --body "queue gardening signal" --from "$REQUESTER_AGENT")"
+assert_contains "$GARDEN_CREATE_OUTPUT" "created task #"
+GARDEN_TASK_ID="$(printf '%s\n' "$GARDEN_CREATE_OUTPUT" | sed -n 's/^created task #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+[[ "$GARDEN_TASK_ID" =~ ^[0-9]+$ ]] || die "could not parse garden column task id"
+python3 "$REPO_ROOT/bridge-queue.py" update "$GARDEN_TASK_ID" --status blocked --note "garden column smoke" >/dev/null
+GARDEN_TASK_ID="$GARDEN_TASK_ID" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 - <<'PY'
+import os
+import sqlite3
+import time
+
+db = os.environ["BRIDGE_TASK_DB"]
+task_id = int(os.environ["GARDEN_TASK_ID"])
+stale_ts = int(time.time()) - 86400 * 2
+with sqlite3.connect(db) as conn:
+    conn.execute(
+        "UPDATE tasks SET updated_ts = ? WHERE id = ?",
+        (stale_ts, task_id),
+    )
+    conn.commit()
+PY
+GARDEN_STATUS_STALE="$("$REPO_ROOT/agent-bridge" status --all-agents)"
+assert_contains "$GARDEN_STATUS_STALE" "garden"
+GARDEN_PARSER="$(cat <<'PY'
+import os
+import sys
+
+agent = os.environ["SMOKE_AGENT"]
+header = None
+for line in sys.stdin.read().splitlines():
+    stripped = line.strip()
+    if stripped.startswith("#") and "agent" in stripped and "garden" in stripped:
+        header = stripped.split()
+        continue
+    if header is None:
+        continue
+    parts = stripped.split()
+    if len(parts) < len(header) or agent not in parts:
+        continue
+    try:
+        garden_idx = header.index("garden")
+        agent_idx_header = header.index("agent")
+        agent_idx_row = parts.index(agent)
+        # The row leading "#" cell is either an active index or "-";
+        # aligning on the agent token gives the right offset for garden.
+        garden_offset = garden_idx - agent_idx_header
+        garden_value = parts[agent_idx_row + garden_offset]
+    except (ValueError, IndexError):
+        continue
+    print(garden_value)
+    break
+else:
+    print("missing-row")
+PY
+)"
+GARDEN_STALE_VALUE="$(printf '%s\n' "$GARDEN_STATUS_STALE" | SMOKE_AGENT="$SMOKE_AGENT" python3 -c "$GARDEN_PARSER")"
+[[ "$GARDEN_STALE_VALUE" =~ ^[0-9]+d$ ]] || die "status garden column should mark $SMOKE_AGENT as stale-blocked while task #$GARDEN_TASK_ID has 2d-old updated_ts (got '$GARDEN_STALE_VALUE')"
+GARDEN_TASK_ID="$GARDEN_TASK_ID" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 - <<'PY'
+import os
+import sqlite3
+import time
+
+db = os.environ["BRIDGE_TASK_DB"]
+task_id = int(os.environ["GARDEN_TASK_ID"])
+fresh_ts = int(time.time())
+with sqlite3.connect(db) as conn:
+    conn.execute(
+        "UPDATE tasks SET updated_ts = ? WHERE id = ?",
+        (fresh_ts, task_id),
+    )
+    conn.commit()
+PY
+GARDEN_STATUS_FRESH="$("$REPO_ROOT/agent-bridge" status --all-agents)"
+GARDEN_FRESH_VALUE="$(printf '%s\n' "$GARDEN_STATUS_FRESH" | SMOKE_AGENT="$SMOKE_AGENT" python3 -c "$GARDEN_PARSER")"
+[[ "$GARDEN_FRESH_VALUE" == "-" ]] || die "status garden column should clear to '-' after task #$GARDEN_TASK_ID is refreshed (got '$GARDEN_FRESH_VALUE')"
+python3 "$REPO_ROOT/bridge-queue.py" cancel "$GARDEN_TASK_ID" --actor smoke-test --note "garden column smoke cleanup" >/dev/null
+
 log "claiming and completing queue task"
 SMOKE_AGENT="$SMOKE_AGENT" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 - <<'PY'
 import os


### PR DESCRIPTION
## Summary

Track C of #303. Surface the admin's queue-gardening failure mode at the dashboard layer so operators see stale blocked tasks at a glance instead of having to `agb show` every entry.

The admin agent (e.g. `patch` in the originating deployment) accumulates `blocked` tasks and reaches the same `agb update --status blocked --note "..."` daily for each entry — refresh only, no close. The new `garden` column on `agent-bridge status --all-agents` shows the count of blocked tasks each agent owns whose oldest `updated_ts` has gone stale (>= 1 day), rendered as `<N>d`. Agents with no stale-blocked tasks render `-`.

## Changes

- `bridge-status.py`
  - New constants `GARDEN_STALE_SECONDS = 1d` (yellow tier) and `GARDEN_CRITICAL_SECONDS = 3d` (red tier, informational only — see "ANSI" note below). Constants live at module top so future tuning is one place.
  - `fmt_garden(blocked_count, oldest_blocked_ts)` returns `-` when the agent has no blocked tasks aged past `GARDEN_STALE_SECONDS`; otherwise `<blocked_count>d`.
  - `fetch_agent_metrics` extends the existing per-agent CTE with `MIN(updated_ts) AS oldest_blocked_ts` filtered to `status='blocked'`. The gardening signal lands as one extra column on a single SQL query — no per-agent round trip.
  - Header (line 326) gains `garden` right of `b`; the row substitution inserts a 6-wide right-aligned cell. Width math matches the existing loose tabular layout.

- `scripts/smoke-test.sh`
  - New fixture under the existing blocked-aging test block: seeds a `blocked` task with `updated_ts` 2 days old, runs `agent-bridge status --all-agents`, asserts the smoke agent's row carries `<N>d` in the `garden` column. Refreshes the task and asserts the column collapses to `-`. Cleans up.
  - Parses the dashboard by header position (not regex against the row) so it does not collide with `idle`/`nudge` columns that share the `Nd` suffix shape.

## Out of scope (deferred)

- **Body-text-not-changed signal** (signal 2 from the issue body). Requires a schema change to track `body_hash_at_creation` or an audit-log lookup; out of scope for this PR.
- **ANSI yellow/red rendering.** This dashboard has no color path (verified via `grep` — no `\x1b`, no `\033`, no tty branching in `bridge-status.py`). The issue's "yellow at 1 day, red at 3 days" tier collapses to one stale tier in plain text; both render `<N>d`. `GARDEN_CRITICAL_SECONDS` is kept reserved for when a color path lands.
- Tracks A and B+D of #303 (admin role contract text + cron body upgrade + session-start hint) are out of scope. B+D have already landed via #326. Track A remains. Issue #303 stays open until A merges, hence `(#303 Track C)` rather than `closes #303`.

## Verification

```
$ python3 -c "import ast; ast.parse(open('bridge-status.py').read())" && echo "py OK"
py OK

$ python3 -c "import py_compile; py_compile.compile('bridge-status.py', doraise=True)" && echo "py_compile OK"
py_compile OK

$ bash -n scripts/smoke-test.sh && echo "bash -n OK"
bash -n OK

$ shellcheck scripts/smoke-test.sh
(no output)
```

Synthetic dashboard render against an isolated SQLite fixture (3 agents: admin with 2 blocked tasks oldest 2d stale, worker with 1 fresh-blocked, idle with no blocked):

```
Agents
  #  agent           eng     src     loop on  state    q   c   b   garden  idle  stale wake chan  nudge  load        session        workdir
  1  admin           claude  static  new  yes working  0   0   2      2d    0s     ok     ok   ok    0s  q:.... c:....  s1            /tmp/...
  2  worker          codex   static  new  yes working  0   0   1       -    0s     ok     ok   ok    0s  q:.... c:....  s2            /tmp/...
  -  idle            claude  static  new  no  stopped  1   0   0       -    0s      -      -    -    0s  q:=... c:....  -             /tmp/...
```

After refreshing admin's stale task, admin's `garden` cell collapses to `-`. Confirms the column moves both directions on a single render pass.

The full `./scripts/smoke-test.sh` halts at the pre-existing `[smoke] starting isolated tmux role` failure on this host (line 2034, `wait_for_tmux_session` timeout), well before reaching the new fixture at line ~2510. That failure reproduces on `main` without any edits and is unrelated to this PR.

## Test plan

- [ ] CI: pre-existing `[smoke] starting isolated tmux role` failure is the only break (not introduced here).
- [ ] In a live install, run `agent-bridge status --all-agents` and confirm the `garden` column header is present.
- [ ] If the admin queue has any blocked task with `updated_ts` >= 1 day old, confirm the admin row shows `<N>d`. Otherwise it should show `-`.
- [ ] After `agb update <id> --status blocked --note "..."` on the stale task (which advances `updated_ts`), the column should collapse to `-` on the next render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)