### PR TITLE
cron: pre-flight memory guard defers dispatch on pressured hosts (#263 Track B)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -238,6 +238,14 @@ Legacy variables `BRIDGE_LEGACY_CRON_SYNC_ENABLED` and
 compatibility; any of the three explicitly set to `0` disables automatic
 enqueue.
 
+A pre-flight memory guard (#263 Track B) probes host memory before spawning
+the cron disposable child. On Darwin the probe rejects dispatch when swap
+usage meets or exceeds `BRIDGE_CRON_SWAP_PCT_LIMIT` (default `80`). On Linux
+it rejects when `MemAvailable` drops below `BRIDGE_CRON_MIN_AVAIL_MB`
+megabytes (default `512`). A deferred run writes `state=deferred` to the run's
+`status.json`, emits a `cron_dispatch_deferred` audit row, and pings the
+admin agent; the next scheduler tick re-fires the slot.
+
 Inspect runtime state directly when needed:
 
 ```bash

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -179,6 +179,197 @@ def disposable_needs_channels(request: dict[str, Any]) -> bool:
     return bool_flag(request.get("disposable_needs_channels"))
 
 
+# Issue #263 Track B — pre-flight memory guard for the disposable child spawn.
+# The actual subprocess.run() of the Claude CLI cold-loads the binary plus
+# every wired MCP server. On a pressured host that cold-load is what tips
+# `event-reminder-30min` past its 1800s timeout. We probe vm.swapusage on
+# Darwin and /proc/meminfo MemAvailable on Linux, returning True only when
+# we have positive evidence the host is constrained. Any probe glitch is
+# treated as "healthy" so a scheduling pass never wedges on a transient.
+DEFAULT_SWAP_PCT_LIMIT = 80
+DEFAULT_MIN_AVAIL_MB = 512
+PRESSURE_DEFER_SECONDS = 900  # +15 min
+
+
+def _swap_pct_limit() -> int:
+    raw = os.environ.get("BRIDGE_CRON_SWAP_PCT_LIMIT", "").strip()
+    if not raw:
+        return DEFAULT_SWAP_PCT_LIMIT
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_SWAP_PCT_LIMIT
+    return value if value > 0 else DEFAULT_SWAP_PCT_LIMIT
+
+
+def _min_avail_mb() -> int:
+    raw = os.environ.get("BRIDGE_CRON_MIN_AVAIL_MB", "").strip()
+    if not raw:
+        return DEFAULT_MIN_AVAIL_MB
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MIN_AVAIL_MB
+    return value if value > 0 else DEFAULT_MIN_AVAIL_MB
+
+
+def check_memory_pressure() -> dict[str, Any] | None:
+    """Return a probe dict when the host is pressured, else None.
+
+    The dict is shaped for direct merge into audit / status / notify payloads:
+      {"reason": "memory_pressure", "kind": "darwin"|"linux",
+       "metric": "<name>", "value": <int>, "limit": <int>}
+    """
+    kind = "unknown"
+    try:
+        kind = (subprocess.check_output(["uname", "-s"], text=True) or "").strip().lower()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if kind == "darwin":
+        try:
+            usage_line = subprocess.check_output(
+                ["sysctl", "-n", "vm.swapusage"], text=True, timeout=5
+            ).strip()
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if not usage_line:
+            return None
+        # Format: "total = 4096.00M  used = 3500.00M  free = 596.00M  (encrypted)"
+        tokens = usage_line.split()
+        used_raw = total_raw = None
+        for idx, token in enumerate(tokens):
+            if token == "used" and idx + 2 < len(tokens):
+                used_raw = tokens[idx + 2]
+            elif token == "total" and idx + 2 < len(tokens):
+                total_raw = tokens[idx + 2]
+        if not used_raw or not total_raw:
+            return None
+        try:
+            used_mb = float(used_raw.rstrip("M"))
+            total_mb = float(total_raw.rstrip("M"))
+        except ValueError:
+            return None
+        if total_mb <= 0:
+            return None
+        pct = int(used_mb * 100 / total_mb)
+        limit = _swap_pct_limit()
+        if pct >= limit:
+            return {
+                "reason": "memory_pressure",
+                "kind": "darwin",
+                "metric": "swap_pct",
+                "value": pct,
+                "limit": limit,
+                "swap_used_mb": int(used_mb),
+                "swap_total_mb": int(total_mb),
+            }
+        return None
+
+    if kind == "linux":
+        meminfo_path = Path("/proc/meminfo")
+        if not meminfo_path.is_file():
+            return None
+        try:
+            text = meminfo_path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        avail_kb: int | None = None
+        for line in text.splitlines():
+            if line.startswith("MemAvailable:"):
+                parts = line.split()
+                if len(parts) >= 2 and parts[1].isdigit():
+                    avail_kb = int(parts[1])
+                break
+        if avail_kb is None:
+            return None
+        threshold_mb = _min_avail_mb()
+        threshold_kb = threshold_mb * 1024
+        if avail_kb < threshold_kb:
+            return {
+                "reason": "memory_pressure",
+                "kind": "linux",
+                "metric": "available_mb",
+                "value": avail_kb // 1024,
+                "limit": threshold_mb,
+            }
+        return None
+
+    # Other platforms: no probe; assume healthy.
+    return None
+
+
+def emit_pressure_audit(run_id: str, target_agent: str, probe: dict[str, Any]) -> None:
+    """Best-effort audit row for a deferred dispatch. Failure is non-fatal."""
+    audit_log = os.environ.get("BRIDGE_AUDIT_LOG")
+    if not audit_log:
+        return
+    audit_script = Path(__file__).resolve().parent / "bridge-audit.py"
+    if not audit_script.is_file():
+        return
+    cmd = [
+        sys.executable,
+        str(audit_script),
+        "write",
+        "--file",
+        audit_log,
+        "--actor",
+        "daemon",
+        "--action",
+        "cron_dispatch_deferred",
+        "--target",
+        target_agent or "daemon",
+        "--detail",
+        f"run_id={run_id}",
+    ]
+    for key, value in probe.items():
+        cmd.extend(["--detail", f"{key}={value}"])
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
+def notify_admin_pressure_defer(run_id: str, job_name: str, probe: dict[str, Any]) -> None:
+    """Best-effort admin task creation. Failure is non-fatal — the deferred
+    status file is the durable record; this is the surfacing layer."""
+    admin_agent = os.environ.get("BRIDGE_ADMIN_AGENT_ID", "").strip()
+    if not admin_agent:
+        return
+    task_script = Path(__file__).resolve().parent / "bridge-task.sh"
+    if not task_script.is_file():
+        return
+    bash_bin = os.environ.get("BRIDGE_BASH_BIN") or os.environ.get("BASH") or "bash"
+    title = f"[cron-deferred] {job_name or run_id} memory pressure"
+    detail_lines = [f"- {key}: {value}" for key, value in probe.items()]
+    body = (
+        f"Cron dispatch deferred +{PRESSURE_DEFER_SECONDS // 60} min by pre-flight memory guard.\n\n"
+        f"- run_id: {run_id}\n"
+        f"- job_name: {job_name}\n"
+        + "\n".join(detail_lines)
+        + "\n\nThe disposable child was not spawned. The next scheduler tick will re-fire the slot.\n"
+    )
+    cmd = [
+        bash_bin,
+        str(task_script),
+        "create",
+        "--to",
+        admin_agent,
+        "--from",
+        "daemon",
+        "--priority",
+        "normal",
+        "--title",
+        title,
+        "--body",
+        body,
+    ]
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
 def disable_mcp_for_request(request: dict[str, Any]) -> bool:
     """#263: decide whether the disposable child should launch with MCP disabled.
 
@@ -551,6 +742,43 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"status_file: {rel_for_output(str(status_file))}")
         print(f"stdout_log: {rel_for_output(str(stdout_log))}")
         print(f"stderr_log: {rel_for_output(str(stderr_log))}")
+        return 0
+
+    # Issue #263 Track B — pre-flight memory guard.
+    # Probe BEFORE materialising prompt artifacts or spawning the child. On a
+    # pressured host the child cold-load is what tips the disposable run past
+    # its timeout (see issue body for the event-reminder-30min stall). We skip
+    # the spawn, mark the run deferred, audit the decision, and ping admin.
+    # The next scheduler tick re-fires the slot once memory recovers.
+    pressure = check_memory_pressure()
+    if pressure is not None:
+        deferred_at = now_iso()
+        target_agent = str(request.get("target_agent") or "")
+        job_name = str(request.get("job_name") or "")
+        deferred_payload: dict[str, Any] = {
+            "run_id": run_id,
+            "state": "deferred",
+            "engine": engine,
+            "updated_at": deferred_at,
+            "request_file": str(request_file),
+            "result_file": str(result_file),
+            "deferred_at": deferred_at,
+            "deferred_reason": "memory_pressure",
+            "deferred_seconds": PRESSURE_DEFER_SECONDS,
+            "memory_probe": pressure,
+        }
+        write_json(status_file, deferred_payload)
+        emit_pressure_audit(run_id, target_agent, pressure)
+        notify_admin_pressure_defer(run_id, job_name, pressure)
+        print(f"status: deferred")
+        print(f"run_id: {run_id}")
+        print(f"engine: {engine}")
+        print(f"reason: memory_pressure")
+        for key, value in pressure.items():
+            print(f"{key}: {value}")
+        # Return 0: this is an intentional defer, not a failure. The cron
+        # worker that invoked us closes the queue task with a deferred note;
+        # the scheduler enqueues the next slot on its next pass.
         return 0
 
     payload_text = payload_file.read_text(encoding="utf-8")

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -237,7 +237,9 @@ def agent_matches(agent_id, expected):
 
 
 def is_error_record(record):
-    return record["consecutive_errors"] > 0 or record["last_status"] not in ("-", "ok", "success")
+    # "deferred" is a deliberate skip (e.g. #263 Track B pre-flight memory
+    # guard). It is not a failure; the next scheduler tick re-fires the slot.
+    return record["consecutive_errors"] > 0 or record["last_status"] not in ("-", "ok", "success", "deferred")
 
 
 def build_job_record(job):
@@ -1083,7 +1085,18 @@ def run_native_finalize(args):
     run_state = str(status.get("state") or "")
     result_status = str(result.get("status") or "")
     now_ms_value = now_epoch_ms()
-    final_status = "success" if run_state == "success" and result_status != "error" else "error"
+    # Three terminal run states feed finalize:
+    #   * "success"  — engine ran and produced a non-error result.
+    #   * "deferred" — runner short-circuited (e.g. #263 Track B pre-flight
+    #                  memory guard). NOT a failure; the slot must re-fire and
+    #                  the consecutive-error counter must NOT advance.
+    #   * anything else (incl. "error") — treated as failure.
+    if run_state == "deferred":
+        final_status = "deferred"
+    elif run_state == "success" and result_status != "error":
+        final_status = "success"
+    else:
+        final_status = "error"
     duration_ms = result.get("duration_ms")
     try:
         duration_ms = int(duration_ms) if duration_ms not in (None, "") else None
@@ -1093,15 +1106,32 @@ def run_native_finalize(args):
     job_state["lastRunAtMs"] = now_ms_value
     job_state["lastStatus"] = final_status
     job_state["lastRunStatus"] = final_status
-    job_state["nextRunAtMs"] = 0
     if duration_ms is not None:
         job_state["lastDurationMs"] = duration_ms
 
     if final_status == "success":
+        job_state["nextRunAtMs"] = 0
         job_state["consecutiveErrors"] = 0
         job_state.pop("lastErrorAtMs", None)
         job_state.pop("lastError", None)
+    elif final_status == "deferred":
+        # #263 Track B: the runner asked us to defer this slot for
+        # `deferred_seconds`. Push nextRunAtMs forward by that window so
+        # operators reading the dashboard see the actual re-fire time, and
+        # leave the consecutive-error counter / lastError fields untouched.
+        try:
+            deferred_seconds = int(status.get("deferred_seconds") or 0)
+        except (TypeError, ValueError):
+            deferred_seconds = 0
+        if deferred_seconds <= 0:
+            deferred_seconds = 900  # mirror PRESSURE_DEFER_SECONDS default
+        job_state["nextRunAtMs"] = now_ms_value + (deferred_seconds * 1000)
+        job_state["lastDeferredAtMs"] = now_ms_value
+        deferred_reason = str(status.get("deferred_reason") or "").strip()
+        if deferred_reason:
+            job_state["lastDeferredReason"] = deferred_reason
     else:
+        job_state["nextRunAtMs"] = 0
         try:
             previous_errors = int(job_state.get("consecutiveErrors") or 0)
         except (TypeError, ValueError):
@@ -1117,7 +1147,13 @@ def run_native_finalize(args):
 
     action = "updated"
     if schedule.get("kind") == "at":
-        if job.get("deleteAfterRun") is True:
+        if final_status == "deferred":
+            # One-shot "at" runs that deferred must stay enabled and pending so
+            # the next scheduler pass re-fires the slot.
+            job["state"] = job_state
+            job["updatedAtMs"] = now_ms_value
+            jobs[job_index] = job
+        elif job.get("deleteAfterRun") is True:
             del jobs[job_index]
             action = "deleted"
         else:

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -352,11 +352,11 @@ def summarize(records):
             for item in records
             if item["kind"] == "one-shot" and item["next_run_at"] is not None and item["next_run_at"] < now
         ),
-        "error_jobs": sum(
-            1
-            for item in records
-            if item["consecutive_errors"] > 0 or item["last_status"] not in ("-", "ok", "success")
-        ),
+        # Source of truth for the "is this an error?" predicate is
+        # is_error_record(); summarize() must defer to it so deferred jobs
+        # (#263 Track B pre-flight memory guard) are not over-counted in the
+        # operator-visible inventory aggregate.
+        "error_jobs": sum(1 for item in records if is_error_record(item)),
         "schedule_kinds": dict(Counter(item["schedule_kind"] for item in records)),
         "payload_kinds": dict(Counter(item["payload_kind"] for item in records)),
     }

--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -926,3 +926,73 @@ for job in data.get("jobs", []):
 print("0")
 PY
 }
+
+# bridge_check_memory_pressure — issue #263 Track B.
+#
+# Defense-in-depth pre-flight probe for the cron disposable child spawn site.
+# A pressured host cold-loads the Claude CLI + MCP stack into swap, which is
+# the failure mode behind the observed `event-reminder-30min` 1800s timeouts.
+# Returns:
+#   0 — host appears healthy; the caller should proceed with dispatch.
+#   1 — host is pressured; the caller should defer +15 min instead of spawning.
+#
+# Probes:
+#   Darwin → `sysctl vm.swapusage`. If `used / total >= BRIDGE_CRON_SWAP_PCT_LIMIT`
+#            (default 80) percent, return 1.
+#   Linux  → `/proc/meminfo` MemAvailable. If below `BRIDGE_CRON_MIN_AVAIL_MB`
+#            kilobytes (default 512 MB), return 1.
+#   Other  → return 0 (we don't model BSD/Windows; assume healthy).
+#
+# The probe fails open: if any read fails (sysctl unavailable, /proc not
+# mounted, malformed output), we return 0 so a probe glitch never blocks
+# scheduled work. The pressure case is a *strict* yes — only triggered when
+# we have positive evidence the host is constrained.
+bridge_check_memory_pressure() {
+  local kind
+  kind="$(uname -s 2>/dev/null || true)"
+
+  case "$kind" in
+    Darwin)
+      local usage_line used_raw total_raw used_int total_int pct
+      local limit="${BRIDGE_CRON_SWAP_PCT_LIMIT:-80}"
+      [[ "$limit" =~ ^[0-9]+$ ]] || limit=80
+
+      usage_line="$(sysctl -n vm.swapusage 2>/dev/null || true)"
+      [[ -n "$usage_line" ]] || return 0
+
+      # Format: total = 4096.00M  used = 3500.00M  free = 596.00M  (encrypted)
+      used_raw="$(awk '{ for (i=1; i<=NF; i++) if ($i == "used") print $(i+2) }' <<<"$usage_line")"
+      total_raw="$(awk '{ for (i=1; i<=NF; i++) if ($i == "total") print $(i+2) }' <<<"$usage_line")"
+      used_raw="${used_raw%M}"
+      total_raw="${total_raw%M}"
+      [[ -n "$used_raw" && -n "$total_raw" ]] || return 0
+
+      # Strip the decimal portion in pure bash so we don't depend on python
+      # for a probe that runs on every dispatch. `2400.00` → `2400`.
+      used_int="${used_raw%%.*}"
+      total_int="${total_raw%%.*}"
+      [[ "$used_int" =~ ^[0-9]+$ && "$total_int" =~ ^[0-9]+$ ]] || return 0
+      (( total_int > 0 )) || return 0
+
+      pct=$(( used_int * 100 / total_int ))
+      (( pct >= limit )) && return 1
+      return 0
+      ;;
+    Linux)
+      local avail_kb threshold_mb threshold_kb
+      threshold_mb="${BRIDGE_CRON_MIN_AVAIL_MB:-512}"
+      [[ "$threshold_mb" =~ ^[0-9]+$ ]] || threshold_mb=512
+      threshold_kb=$(( threshold_mb * 1024 ))
+
+      [[ -r /proc/meminfo ]] || return 0
+      avail_kb="$(awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo 2>/dev/null || true)"
+      [[ "$avail_kb" =~ ^[0-9]+$ ]] || return 0
+
+      (( avail_kb < threshold_kb )) && return 1
+      return 0
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6831,6 +6831,128 @@ log "bridge_check_memory_pressure bash helper handles probe failure as healthy"
   esac
 "
 
+log "native-finalize-run treats deferred state as +deferred_seconds reschedule, not error (#263 Track B)"
+# Regression guard for PR #330 round-1 finding 5: the runner writes
+# state="deferred" and deferred_seconds into status.json, but finalize used
+# to collapse anything non-success into the error branch — clearing
+# nextRunAtMs and incrementing consecutiveErrors. Build a minimal jobs.json
+# + status.json + request.json fixture and verify finalize bumps
+# nextRunAtMs forward by ≥895s and leaves the error counter alone.
+CRON_DEFERRED_DIR="$TMP_ROOT/cron-deferred-finalize"
+CRON_DEFERRED_RUN_DIR="$CRON_DEFERRED_DIR/run"
+CRON_DEFERRED_JOBS_FILE="$CRON_DEFERRED_DIR/jobs.json"
+CRON_DEFERRED_REQUEST_FILE="$CRON_DEFERRED_RUN_DIR/request.json"
+CRON_DEFERRED_RESULT_FILE="$CRON_DEFERRED_RUN_DIR/result.json"
+CRON_DEFERRED_STATUS_FILE="$CRON_DEFERRED_RUN_DIR/status.json"
+mkdir -p "$CRON_DEFERRED_RUN_DIR"
+
+CRON_DEFERRED_JOBS_FILE="$CRON_DEFERRED_JOBS_FILE" \
+CRON_DEFERRED_REQUEST_FILE="$CRON_DEFERRED_REQUEST_FILE" \
+CRON_DEFERRED_RESULT_FILE="$CRON_DEFERRED_RESULT_FILE" \
+CRON_DEFERRED_STATUS_FILE="$CRON_DEFERRED_STATUS_FILE" \
+python3 - <<'PY'
+import json, os
+from pathlib import Path
+
+jobs_file = Path(os.environ["CRON_DEFERRED_JOBS_FILE"])
+request_file = Path(os.environ["CRON_DEFERRED_REQUEST_FILE"])
+result_file = Path(os.environ["CRON_DEFERRED_RESULT_FILE"])
+status_file = Path(os.environ["CRON_DEFERRED_STATUS_FILE"])
+
+jobs_file.write_text(json.dumps({
+    "format": "agent-bridge-cron-v1",
+    "updatedAt": "2026-04-26T00:00:00+00:00",
+    "jobs": [
+        {
+            "id": "deferred-smoke-job",
+            "name": "deferred-smoke",
+            "agentId": "tester",
+            "enabled": True,
+            "schedule": {"kind": "cron", "expr": "*/5 * * * *", "tz": "UTC"},
+            "payload": {"kind": "text", "text": "ping"},
+            "state": {
+                "consecutiveErrors": 0,
+                "lastStatus": "ok",
+                "nextRunAtMs": 0,
+            },
+        }
+    ],
+}, indent=2) + "\n", encoding="utf-8")
+
+# Runner-style status.json from a pressure-defer run.
+status_file.write_text(json.dumps({
+    "run_id": "deferred-smoke-run",
+    "state": "deferred",
+    "engine": "claude",
+    "deferred_reason": "memory_pressure",
+    "deferred_seconds": 900,
+    "memory_probe": {"reason": "memory_pressure", "metric": "swap_pct", "value": 92, "limit": 80},
+}, indent=2) + "\n", encoding="utf-8")
+
+# Empty result is fine; deferred runs do not produce a result payload.
+result_file.write_text("{}\n", encoding="utf-8")
+
+request_file.write_text(json.dumps({
+    "run_id": "deferred-smoke-run",
+    "job_id": "deferred-smoke-job",
+    "source_file": str(jobs_file.resolve()),
+    "result_file": str(result_file.resolve()),
+    "status_file": str(status_file.resolve()),
+}, indent=2) + "\n", encoding="utf-8")
+PY
+
+CRON_DEFERRED_BEFORE_MS="$(python3 -c 'import time; print(int(time.time()*1000))')"
+python3 "$REPO_ROOT/bridge-cron.py" native-finalize-run \
+    --jobs-file "$CRON_DEFERRED_JOBS_FILE" \
+    --request-file "$CRON_DEFERRED_REQUEST_FILE" \
+    --json >"$CRON_DEFERRED_DIR/finalize-output.json"
+
+CRON_DEFERRED_JOBS_FILE="$CRON_DEFERRED_JOBS_FILE" \
+CRON_DEFERRED_BEFORE_MS="$CRON_DEFERRED_BEFORE_MS" \
+python3 - <<'PY'
+import json, os, sys
+
+jobs_file = os.environ["CRON_DEFERRED_JOBS_FILE"]
+before_ms = int(os.environ["CRON_DEFERRED_BEFORE_MS"])
+
+payload = json.loads(open(jobs_file, encoding="utf-8").read())
+job = next(j for j in payload["jobs"] if j["id"] == "deferred-smoke-job")
+state = job.get("state") or {}
+
+next_run_at_ms = int(state.get("nextRunAtMs") or 0)
+last_status = state.get("lastStatus")
+last_run_status = state.get("lastRunStatus")
+consecutive_errors = int(state.get("consecutiveErrors") or 0)
+last_error = state.get("lastError")
+last_error_at_ms = state.get("lastErrorAtMs")
+
+# nextRunAtMs must be bumped by at least 895_000 ms past finalize-call time
+# (deferred_seconds=900, allowing 5s slack for execution overhead).
+expected_min = before_ms + 895_000
+assert next_run_at_ms >= expected_min, (
+    f"deferred finalize did not bump nextRunAtMs by +15min "
+    f"(before_ms={before_ms}, nextRunAtMs={next_run_at_ms}, expected ≥ {expected_min})"
+)
+
+# Error counter MUST NOT advance for a deferred run.
+assert consecutive_errors == 0, (
+    f"deferred finalize incorrectly incremented consecutiveErrors "
+    f"(expected 0, got {consecutive_errors})"
+)
+assert last_error is None, f"deferred finalize wrote lastError={last_error!r}"
+assert last_error_at_ms is None, f"deferred finalize wrote lastErrorAtMs={last_error_at_ms!r}"
+
+# lastStatus / lastRunStatus must reflect the deferred branch so dashboards
+# and errors-report do not flag the job.
+assert last_status == "deferred", f"expected lastStatus=deferred, got {last_status!r}"
+assert last_run_status == "deferred", f"expected lastRunStatus=deferred, got {last_run_status!r}"
+
+# Job must remain enabled so the scheduler re-fires the next slot.
+assert job.get("enabled") is True, f"deferred finalize disabled the job: {job!r}"
+
+print("native-finalize-run deferred branch OK")
+PY
+
 log "rendering typed channel relay blocks into cron follow-up bodies"
 CRON_RELAY_RUN_ID="relay-smoke--2026-04-16T13-20"
 CRON_RELAY_RUN_DIR="$BRIDGE_CRON_STATE_DIR/runs/$CRON_RELAY_RUN_ID"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6992,6 +6992,55 @@ assert filtered_error_jobs == 0, (
 print("inventory aggregate excludes deferred job OK")
 PY
 
+# #263 Track B r4: negative regression — a real errored job must still
+# count in inventory.totals.error_jobs even when a deferred job is also
+# present. Without this assertion, a future change that accidentally
+# silenced the entire error-counting path would still pass smoke as long
+# as the deferred-only assertion above held.
+log "  [ok] inventory: real errored job alongside deferred still counts as error_jobs=1"
+CRON_DEFERRED_JOBS_FILE="$CRON_DEFERRED_JOBS_FILE" \
+REPO_ROOT="$REPO_ROOT" \
+python3 - <<'PY'
+import json, os, subprocess, sys
+from pathlib import Path
+
+repo_root = Path(os.environ["REPO_ROOT"])
+jobs_file = os.environ["CRON_DEFERRED_JOBS_FILE"]
+
+payload = json.loads(open(jobs_file, encoding="utf-8").read())
+payload["jobs"].append({
+    "id": "errored-smoke-job",
+    "name": "errored-smoke",
+    "agentId": "tester",
+    "enabled": True,
+    "schedule": {"kind": "cron", "expr": "*/5 * * * *", "tz": "UTC"},
+    "payload": {"kind": "text", "text": "ping"},
+    "state": {
+        "consecutiveErrors": 3,
+        "lastStatus": "error",
+        "lastError": "stale failure",
+        "nextRunAtMs": 0,
+    },
+})
+open(jobs_file, "w", encoding="utf-8").write(json.dumps(payload, indent=2) + "\n")
+
+inventory_proc = subprocess.run(
+    [sys.executable, str(repo_root / "bridge-cron.py"),
+     "inventory", "--jobs-file", jobs_file, "--json"],
+    capture_output=True, text=True, check=True,
+)
+inventory = json.loads(inventory_proc.stdout)
+totals = inventory.get("totals") or {}
+error_jobs = int(totals.get("error_jobs") or 0)
+assert error_jobs == 1, (
+    f"mixed deferred+errored should count error_jobs=1, got {error_jobs}; "
+    f"a real errored row alongside a deferred row must still increment "
+    f"the operator-visible error aggregate"
+)
+
+print("inventory aggregate counts errored job alongside deferred OK")
+PY
+
 log "rendering typed channel relay blocks into cron follow-up bodies"
 CRON_RELAY_RUN_ID="relay-smoke--2026-04-16T13-20"
 CRON_RELAY_RUN_DIR="$BRIDGE_CRON_STATE_DIR/runs/$CRON_RELAY_RUN_ID"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6953,6 +6953,45 @@ assert job.get("enabled") is True, f"deferred finalize disabled the job: {job!r}
 print("native-finalize-run deferred branch OK")
 PY
 
+# #263 Track B r3: a deferred job MUST NOT inflate the operator-visible
+# inventory error_jobs aggregate. The previous fixture only checked the
+# row-level consecutiveErrors counter; this guards summarize() against
+# regressing to its inline whitelist that did not recognize "deferred".
+CRON_DEFERRED_JOBS_FILE="$CRON_DEFERRED_JOBS_FILE" \
+REPO_ROOT="$REPO_ROOT" \
+python3 - <<'PY'
+import json, os, subprocess, sys
+from pathlib import Path
+
+repo_root = Path(os.environ["REPO_ROOT"])
+jobs_file = os.environ["CRON_DEFERRED_JOBS_FILE"]
+
+inventory_proc = subprocess.run(
+    [sys.executable, str(repo_root / "bridge-cron.py"),
+     "inventory", "--jobs-file", jobs_file, "--json"],
+    capture_output=True, text=True, check=True,
+)
+inventory = json.loads(inventory_proc.stdout)
+totals = inventory.get("totals") or {}
+error_jobs = int(totals.get("error_jobs") or 0)
+assert error_jobs == 0, (
+    f"deferred run incorrectly counted in inventory.totals.error_jobs "
+    f"(expected 0, got {error_jobs}); summarize() may not be deferring to "
+    f"is_error_record()"
+)
+
+# filtered_totals is computed from the same predicate; double-check it too so
+# any future divergence between the two summaries is caught.
+filtered_totals = inventory.get("filtered_totals") or {}
+filtered_error_jobs = int(filtered_totals.get("error_jobs") or 0)
+assert filtered_error_jobs == 0, (
+    f"deferred run incorrectly counted in inventory.filtered_totals.error_jobs "
+    f"(expected 0, got {filtered_error_jobs})"
+)
+
+print("inventory aggregate excludes deferred job OK")
+PY
+
 log "rendering typed channel relay blocks into cron follow-up bodies"
 CRON_RELAY_RUN_ID="relay-smoke--2026-04-16T13-20"
 CRON_RELAY_RUN_DIR="$BRIDGE_CRON_STATE_DIR/runs/$CRON_RELAY_RUN_ID"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6637,6 +6637,200 @@ finally:
 print("disable_mcp wire-through OK")
 PY
 
+log "pre-flight memory guard defers cron dispatch on pressured hosts (#263 Track B)"
+# Mock check_memory_pressure to return a pressured probe and assert that
+# cmd_run skips the engine spawn, writes a deferred status, and surfaces the
+# probe metadata. Then mock the probe to clear and confirm the engine spawn
+# path executes normally.
+CRON_PREFLIGHT_RUN_DIR="$TMP_ROOT/cron-preflight-run"
+mkdir -p "$CRON_PREFLIGHT_RUN_DIR"
+CRON_PREFLIGHT_REQUEST_FILE="$CRON_PREFLIGHT_RUN_DIR/request.json"
+python3 - "$CRON_PREFLIGHT_REQUEST_FILE" "$CRON_PREFLIGHT_RUN_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+request_path = Path(sys.argv[1])
+run_dir = Path(sys.argv[2])
+request_path.write_text(
+    json.dumps(
+        {
+            "run_id": "preflight-smoke",
+            "job_name": "preflight-smoke-job",
+            "family": "preflight-smoke",
+            "slot": "2026-04-26T00:00",
+            "target_agent": "tester",
+            "target_engine": "claude",
+            "target_workdir": str(run_dir),
+            "target_channels": "",
+            "allow_channel_delivery": False,
+            "disposable_needs_channels": False,
+            "payload_file": str(run_dir / "payload.txt"),
+            "result_file": str(run_dir / "result.json"),
+            "status_file": str(run_dir / "status.json"),
+            "stdout_log": str(run_dir / "stdout.log"),
+            "stderr_log": str(run_dir / "stderr.log"),
+        },
+        ensure_ascii=True,
+        indent=2,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+(run_dir / "payload.txt").write_text("ping\n", encoding="utf-8")
+PY
+
+CRON_PREFLIGHT_REQUEST_FILE="$CRON_PREFLIGHT_REQUEST_FILE" \
+CRON_PREFLIGHT_RUN_DIR="$CRON_PREFLIGHT_RUN_DIR" \
+python3 - <<'PY'
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+path = Path("bridge-cron-runner.py").resolve()
+spec = importlib.util.spec_from_file_location("bridge_cron_runner", path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+request_file = os.environ["CRON_PREFLIGHT_REQUEST_FILE"]
+run_dir = Path(os.environ["CRON_PREFLIGHT_RUN_DIR"])
+status_file = run_dir / "status.json"
+
+# --- Pressured path -----------------------------------------------------
+spawn_calls = []
+real_run = subprocess.run
+
+def fake_run(cmd, **kw):
+    spawn_calls.append(list(cmd))
+    return subprocess.CompletedProcess(cmd, 0, "{}", "")
+
+pressure_probe = {
+    "reason": "memory_pressure",
+    "kind": "darwin",
+    "metric": "swap_pct",
+    "value": 92,
+    "limit": 80,
+    "swap_used_mb": 3700,
+    "swap_total_mb": 4096,
+}
+module.check_memory_pressure = lambda: dict(pressure_probe)
+audit_calls = []
+notify_calls = []
+module.emit_pressure_audit = lambda run_id, target, probe: audit_calls.append((run_id, target, dict(probe)))
+module.notify_admin_pressure_defer = lambda run_id, job, probe: notify_calls.append((run_id, job, dict(probe)))
+subprocess.run = fake_run
+try:
+    args = argparse.Namespace(request_file=request_file, dry_run=False)
+    rc = module.cmd_run(args)
+finally:
+    subprocess.run = real_run
+
+assert rc == 0, f"deferred cmd_run should return 0, got {rc}"
+status = json.loads(status_file.read_text(encoding="utf-8"))
+assert status.get("state") == "deferred", f"expected deferred state, got {status!r}"
+assert status.get("deferred_reason") == "memory_pressure", status
+assert status.get("deferred_seconds") == module.PRESSURE_DEFER_SECONDS, status
+assert status.get("memory_probe", {}).get("metric") == "swap_pct", status
+assert status.get("memory_probe", {}).get("value") == 92, status
+# No engine spawn should have happened on the pressured path.
+spawn_bins = [cmd[0] for cmd in spawn_calls if cmd]
+assert not any("claude" in os.path.basename(b) for b in spawn_bins), (
+    f"expected no Claude spawn on pressured host, got {spawn_calls!r}"
+)
+assert not any("codex" in os.path.basename(b) for b in spawn_bins), (
+    f"expected no Codex spawn on pressured host, got {spawn_calls!r}"
+)
+assert audit_calls, "expected emit_pressure_audit to be called"
+assert audit_calls[0][2]["reason"] == "memory_pressure"
+assert notify_calls, "expected notify_admin_pressure_defer to be called"
+
+# Reset for the healthy-path probe.
+status_file.unlink(missing_ok=True)
+
+# --- Healthy path -------------------------------------------------------
+# Probe returns None → cmd_run continues into the engine spawn. Stub the
+# Claude binary spawn so we don't need a real CLI on PATH.
+module.check_memory_pressure = lambda: None
+module.resolve_binary = lambda name, env_var: f"/fake/{name}"
+
+healthy_spawn_calls = []
+healthy_completed_payload = json.dumps(
+    {
+        "structured_output": {
+            "status": "completed",
+            "summary": "ok",
+            "findings": [],
+            "actions_taken": [],
+            "needs_human_followup": False,
+            "recommended_next_steps": [],
+            "artifacts": [],
+            "confidence": "high",
+        }
+    },
+    ensure_ascii=True,
+)
+
+def healthy_fake_run(cmd, **kw):
+    healthy_spawn_calls.append(list(cmd))
+    return subprocess.CompletedProcess(cmd, 0, healthy_completed_payload, "")
+
+subprocess.run = healthy_fake_run
+try:
+    args = argparse.Namespace(request_file=request_file, dry_run=False)
+    rc = module.cmd_run(args)
+finally:
+    subprocess.run = real_run
+
+assert rc == 0, f"healthy cmd_run should return 0 on success, got {rc}"
+final_status = json.loads(status_file.read_text(encoding="utf-8"))
+assert final_status.get("state") == "success", f"expected success state on healthy host, got {final_status!r}"
+assert healthy_spawn_calls, "expected the healthy path to spawn the engine"
+assert any("claude" in os.path.basename(cmd[0]) for cmd in healthy_spawn_calls), (
+    f"expected Claude spawn on healthy path, got {healthy_spawn_calls!r}"
+)
+
+# --- Probe knob handling ------------------------------------------------
+# Default Darwin limit is 80, default Linux threshold is 512MB. Confirm
+# the env knobs are honoured.
+os.environ["BRIDGE_CRON_SWAP_PCT_LIMIT"] = "55"
+assert module._swap_pct_limit() == 55
+os.environ["BRIDGE_CRON_SWAP_PCT_LIMIT"] = "not-a-number"
+assert module._swap_pct_limit() == module.DEFAULT_SWAP_PCT_LIMIT
+del os.environ["BRIDGE_CRON_SWAP_PCT_LIMIT"]
+assert module._swap_pct_limit() == module.DEFAULT_SWAP_PCT_LIMIT
+
+os.environ["BRIDGE_CRON_MIN_AVAIL_MB"] = "1024"
+assert module._min_avail_mb() == 1024
+os.environ["BRIDGE_CRON_MIN_AVAIL_MB"] = "garbage"
+assert module._min_avail_mb() == module.DEFAULT_MIN_AVAIL_MB
+del os.environ["BRIDGE_CRON_MIN_AVAIL_MB"]
+assert module._min_avail_mb() == module.DEFAULT_MIN_AVAIL_MB
+
+print("pre-flight memory guard OK")
+PY
+
+log "bridge_check_memory_pressure bash helper handles probe failure as healthy"
+"$BASH4_BIN" -lc "
+  set -euo pipefail
+  source \"$REPO_ROOT/bridge-lib.sh\"
+  # Probe runs cleanly on the smoke host. Whatever the local memory state
+  # is, the helper must terminate without erroring; on a non-pressured
+  # smoke host it should return 0.
+  if bridge_check_memory_pressure; then
+    rc=0
+  else
+    rc=\$?
+  fi
+  case \"\$rc\" in
+    0|1) ;;
+    *) echo \"unexpected return code from bridge_check_memory_pressure: \$rc\" >&2; exit 1 ;;
+  esac
+"
+
 log "rendering typed channel relay blocks into cron follow-up bodies"
 CRON_RELAY_RUN_ID="relay-smoke--2026-04-16T13-20"
 CRON_RELAY_RUN_DIR="$BRIDGE_CRON_STATE_DIR/runs/$CRON_RELAY_RUN_ID"


### PR DESCRIPTION
## Summary
- Defense-in-depth pre-flight memory probe at the cron disposable child spawn site (`bridge-cron-runner.py cmd_run`). Darwin parses `sysctl vm.swapusage` and rejects when used/total ≥ `BRIDGE_CRON_SWAP_PCT_LIMIT` (default 80%). Linux reads `/proc/meminfo` and rejects when `MemAvailable` < `BRIDGE_CRON_MIN_AVAIL_MB` (default 512 MB). Other platforms and any probe error fail open as healthy so a transient never wedges scheduled work.
- On pressure the runner writes `state=deferred` to `status.json` (with `memory_probe`, `deferred_reason=memory_pressure`, `deferred_seconds=900`), emits a `cron_dispatch_deferred` audit row, creates an admin queue task `[cron-deferred] <job> memory pressure`, and returns 0 without spawning the child. The next scheduler tick re-fires the slot once memory recovers.
- Parallel bash helper `bridge_check_memory_pressure` in `lib/bridge-cron.sh` for any future shell consumer; same sources, same knobs.
- Smoke fixture asserts pressured path skips spawn + writes deferred status, and healthy path reaches `run_claude`. OPERATIONS.md documents the two new knobs.

Track A shipped in #297 (`--strict-mcp-config` opt-in). Tracks C (warm pool) and D (non-Claude runtime) remain open under #263. This PR does **not** close #263.

## Files changed
- `bridge-cron-runner.py` — `check_memory_pressure()`, `emit_pressure_audit()`, `notify_admin_pressure_defer()`, and the `cmd_run` pre-flight gate.
- `lib/bridge-cron.sh` — `bridge_check_memory_pressure` bash helper (Darwin sysctl + Linux /proc/meminfo).
- `scripts/smoke-test.sh` — pressured + healthy fixture for `cron-runner.py`, plus a live-host probe for the bash helper.
- `OPERATIONS.md` — paragraph on the two knobs.

## Test plan
- [x] `python3 -c \"import py_compile; py_compile.compile('bridge-cron-runner.py', doraise=True)\"` → PASS
- [x] `bash -n bridge-cron.sh lib/bridge-cron.sh lib/bridge-core.sh scripts/smoke-test.sh` → PASS
- [x] `shellcheck bridge-cron.sh lib/bridge-cron.sh lib/bridge-core.sh scripts/smoke-test.sh` → PASS
- [x] Inline reproduction of the smoke fixture: pressured path returns rc=0, writes `state=deferred`, emits 1 audit + 1 notify, no Claude/Codex spawn. Healthy path reaches `run_claude`, writes `state=success`. Knob fallbacks work for both `BRIDGE_CRON_SWAP_PCT_LIMIT` and `BRIDGE_CRON_MIN_AVAIL_MB`.
- [x] Live Darwin probe against actual `vm.swapusage` on a healthy host: rc=0; with `BRIDGE_CRON_SWAP_PCT_LIMIT=1` → rc=1 (pressured triggers correctly); with `BRIDGE_CRON_SWAP_PCT_LIMIT=garbage` → rc=0 (default 80 restored).
- [x] `./scripts/smoke-test.sh` reproduces a pre-existing host-fragility failure on clean `main` HEAD around `syncing live roster` — well before the new fixture (line ~6638). Not introduced by this PR.

## Manual verification recommended before merge
- Force the helper into the pressure branch on a real install: `BRIDGE_CRON_SWAP_PCT_LIMIT=1 ~/.agent-bridge/bridge-cron.sh run-subagent <run-id>` against a stale run, and verify `state=deferred` lands in the run's `status.json`, the admin agent gets a `[cron-deferred]` task, and the audit log gets a `cron_dispatch_deferred` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)