### PR TITLE
memory: harvest-daily --from/--to range + --missing-only (#322 Track A) [re-PR after #332]

### DIFF
--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -3264,14 +3264,15 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
 
     Single-date dispatcher (`--date` or default). When ``--from`` is supplied,
     iterates over a date range, optionally skipping dates that already have a
-    canonical daily note flagged ``semantic_nonempty=True`` via
-    ``--missing-only``, and emits an aggregate ``{"results": [...]}`` JSON to
-    stdout. The single-date stdout shape is unchanged.
+    sidecar harvest manifest via ``--missing-only``, and emits an aggregate
+    ``{"results": [...]}`` JSON to stdout. The single-date stdout shape is
+    unchanged. ``--missing-only`` also applies to the single-date path: when
+    the manifest already exists for the target date, exit 0 with a stderr line
+    and no harvest run.
     """
     agent = args.agent
     workdir = args.workdir
     tz_name = args.tz or "Asia/Seoul"
-    home = Path(args.home).expanduser()
 
     if not workdir:
         sys.stderr.write("harvest-daily: --workdir is required (no fallback)\n")
@@ -3280,6 +3281,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
     date_from = getattr(args, "date_from", None)
     date_to = getattr(args, "date_to", None)
     missing_only = bool(getattr(args, "missing_only", False))
+    state_dir = _harvest_state_dir(args)
 
     # --- Range-mode validation + dispatch ----------------------------------
     if date_to and not date_from:
@@ -3319,17 +3321,41 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
         ]
         results: list[dict] = []
         rc_max = 0
+        ok_count = 0
+        fail_count = 0
+        skipped_count = 0
         for tdate in target_dates:
-            if missing_only:
-                existing = _load_canonical_daily_note(home, tdate)
-                if existing and existing.get("semantic_nonempty"):
-                    results.append({
-                        "date": tdate,
-                        "skipped": "exists",
-                    })
-                    continue
-            payload = _harvest_one_date(args, tdate)
+            if missing_only and _manifest_path(state_dir, agent, tdate).exists():
+                # Sidecar manifest is the SSOT for "this date has been
+                # harvested" — Lane B reads the same path. Manual-note-without-
+                # manifest dates must still be harvested.
+                results.append({
+                    "date": tdate,
+                    "skipped": "exists",
+                })
+                skipped_count += 1
+                continue
+            try:
+                payload = _harvest_one_date(args, tdate)
+            except Exception as exc:  # noqa: BLE001 — per-date isolation
+                sys.stderr.write(
+                    f"[bridge-memory] harvest-daily date={tdate} failed: {exc}\n"
+                )
+                results.append({
+                    "date": tdate,
+                    "error": f"{type(exc).__name__}: {exc}",
+                })
+                rc_max = max(rc_max, 1)
+                fail_count += 1
+                continue
             results.append({"date": tdate, "result": payload})
+            ok_count += 1
+        sys.stderr.write(
+            f"[bridge-memory] harvest-daily range complete: "
+            f"{ok_count + fail_count + skipped_count} dates, "
+            f"{ok_count} succeeded, {fail_count} failed, "
+            f"{skipped_count} skipped\n"
+        )
         aggregate = {
             "schema": "memory-daily-harvest-range-v1",
             "agent": agent,
@@ -3352,8 +3378,18 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
             pass
         return rc_max
 
-    # --- Single-date path (preserved byte-identical) -----------------------
+    # --- Single-date path --------------------------------------------------
+    # `--missing-only` is propagated here too (Option A — symmetric semantics
+    # with the range path). When the manifest already exists, skip the harvest
+    # run and exit 0 with a stderr breadcrumb. This lets operators run
+    # `harvest-daily --date YYYY-MM-DD --missing-only` opportunistically.
     single_date = args.date or _harvest_default_date(tz_name)
+    if missing_only and _manifest_path(state_dir, agent, single_date).exists():
+        sys.stderr.write(
+            f"[bridge-memory] harvest-daily date={single_date} already harvested "
+            f"(manifest exists); --missing-only skip\n"
+        )
+        return 0
     payload = _harvest_one_date(args, single_date)
     return _emit_result(args, payload)
 
@@ -3361,19 +3397,6 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
 def _today_date_str(tz_name: str) -> str:
     zone = _harvest_tz_zone(tz_name)
     return datetime.now(zone).date().isoformat()
-
-
-def _load_canonical_daily_note(home: Path, date: str) -> dict | None:
-    """Return ``{"semantic_nonempty": bool}`` if the canonical note exists.
-
-    Reuses ``_probe_daily_note`` so the predicate matches the harvester's own
-    classification. Returns ``None`` when the file is absent.
-    """
-    path = _daily_note_path(home, date)
-    if not path.exists():
-        return None
-    probe = _probe_daily_note(home, date)
-    return {"semantic_nonempty": bool(probe.get("semantic_nonempty"))}
 
 
 def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
@@ -3974,7 +3997,11 @@ def build_parser() -> argparse.ArgumentParser:
     )
     hd_parser.add_argument(
         "--missing-only", dest="missing_only", action="store_true", default=False,
-        help="With --from, skip dates whose canonical daily note already has semantic_nonempty=True.",
+        help=(
+            "Skip dates whose sidecar harvest manifest already exists. "
+            "Applies to both range mode (--from/--to) and single-date mode "
+            "(--date or default)."
+        ),
     )
     hd_parser.add_argument("--tz", default="Asia/Seoul")
     hd_parser.add_argument("--state-dir", help="override $BRIDGE_STATE_DIR/memory-daily")

--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -3250,21 +3250,142 @@ def _build_result_payload(
     }
 
 
+def _parse_harvest_date_arg(value: str) -> "datetime":
+    """Parse a YYYY-MM-DD argument used by harvest-daily flags.
+
+    Returns a naive ``datetime`` at midnight (callers compare via .date()).
+    Raises ValueError on malformed input — caller surfaces via stderr.
+    """
+    return datetime.strptime(value, "%Y-%m-%d")
+
+
 def cmd_harvest_daily(args: argparse.Namespace) -> int:
-    """Detection-only daily note harvester (issue #216)."""
+    """Detection-only daily note harvester (issue #216).
+
+    Single-date dispatcher (`--date` or default). When ``--from`` is supplied,
+    iterates over a date range, optionally skipping dates that already have a
+    canonical daily note flagged ``semantic_nonempty=True`` via
+    ``--missing-only``, and emits an aggregate ``{"results": [...]}`` JSON to
+    stdout. The single-date stdout shape is unchanged.
+    """
     agent = args.agent
-    home = Path(args.home).expanduser()
     workdir = args.workdir
     tz_name = args.tz or "Asia/Seoul"
-    date = args.date or _harvest_default_date(tz_name)
-    state_dir = _harvest_state_dir(args)
-    db_path = _harvest_task_db(args)
-    now_iso = _harvest_now_iso(tz_name)
-    run_id = os.environ.get("CRON_RUN_ID", "")
+    home = Path(args.home).expanduser()
 
     if not workdir:
         sys.stderr.write("harvest-daily: --workdir is required (no fallback)\n")
         return 2
+
+    date_from = getattr(args, "date_from", None)
+    date_to = getattr(args, "date_to", None)
+    missing_only = bool(getattr(args, "missing_only", False))
+
+    # --- Range-mode validation + dispatch ----------------------------------
+    if date_to and not date_from:
+        sys.stderr.write("harvest-daily: --to requires --from\n")
+        return 2
+
+    if date_from:
+        try:
+            from_dt = _parse_harvest_date_arg(date_from)
+        except ValueError:
+            sys.stderr.write(f"harvest-daily: --from {date_from!r} is not YYYY-MM-DD\n")
+            return 2
+        today_dt = datetime.strptime(_today_date_str(tz_name), "%Y-%m-%d")
+        if date_to:
+            try:
+                to_dt = _parse_harvest_date_arg(date_to)
+            except ValueError:
+                sys.stderr.write(f"harvest-daily: --to {date_to!r} is not YYYY-MM-DD\n")
+                return 2
+        else:
+            to_dt = today_dt
+        if from_dt > to_dt:
+            sys.stderr.write(
+                f"harvest-daily: --from {from_dt.date().isoformat()} is later than "
+                f"--to {to_dt.date().isoformat()}\n"
+            )
+            return 2
+        if to_dt > today_dt:
+            sys.stderr.write(
+                f"harvest-daily: --to {to_dt.date().isoformat()} is in the future "
+                f"(today={today_dt.date().isoformat()} tz={tz_name})\n"
+            )
+            return 2
+        span = (to_dt - from_dt).days + 1
+        target_dates = [
+            (from_dt + timedelta(days=i)).date().isoformat() for i in range(span)
+        ]
+        results: list[dict] = []
+        rc_max = 0
+        for tdate in target_dates:
+            if missing_only:
+                existing = _load_canonical_daily_note(home, tdate)
+                if existing and existing.get("semantic_nonempty"):
+                    results.append({
+                        "date": tdate,
+                        "skipped": "exists",
+                    })
+                    continue
+            payload = _harvest_one_date(args, tdate)
+            results.append({"date": tdate, "result": payload})
+        aggregate = {
+            "schema": "memory-daily-harvest-range-v1",
+            "agent": agent,
+            "from": from_dt.date().isoformat(),
+            "to": to_dt.date().isoformat(),
+            "missing_only": missing_only,
+            "count": len(results),
+            "results": results,
+        }
+        sidecar_out = getattr(args, "sidecar_out", None)
+        if sidecar_out:
+            try:
+                _atomic_write_json(Path(sidecar_out).expanduser(), aggregate)
+            except OSError as exc:
+                sys.stderr.write(f"harvest-daily: sidecar write failed: {exc}\n")
+                return 2
+        try:
+            print(json.dumps(aggregate, ensure_ascii=True))
+        except OSError:
+            pass
+        return rc_max
+
+    # --- Single-date path (preserved byte-identical) -----------------------
+    single_date = args.date or _harvest_default_date(tz_name)
+    payload = _harvest_one_date(args, single_date)
+    return _emit_result(args, payload)
+
+
+def _today_date_str(tz_name: str) -> str:
+    zone = _harvest_tz_zone(tz_name)
+    return datetime.now(zone).date().isoformat()
+
+
+def _load_canonical_daily_note(home: Path, date: str) -> dict | None:
+    """Return ``{"semantic_nonempty": bool}`` if the canonical note exists.
+
+    Reuses ``_probe_daily_note`` so the predicate matches the harvester's own
+    classification. Returns ``None`` when the file is absent.
+    """
+    path = _daily_note_path(home, date)
+    if not path.exists():
+        return None
+    probe = _probe_daily_note(home, date)
+    return {"semantic_nonempty": bool(probe.get("semantic_nonempty"))}
+
+
+def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
+    """Per-date harvest body. Returns the RESULT_SCHEMA payload (no emit)."""
+    agent = args.agent
+    home = Path(args.home).expanduser()
+    workdir = args.workdir
+    tz_name = args.tz or "Asia/Seoul"
+    state_dir = _harvest_state_dir(args)
+    db_path = _harvest_task_db(args)
+    now_iso = _harvest_now_iso(tz_name)
+    run_id = os.environ.get("CRON_RUN_ID", "")
 
     # --- Skipped-permission branch -----------------------------------------
     # Stub detected linux-user isolation but could not assume the target OS
@@ -3343,7 +3464,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
             ],
             confidence="high",
         )
-        return _emit_result(args, payload)
+        return payload
 
     # --- Gate check ---------------------------------------------------------
     if args.disabled_gate or _gate_disabled(agent):
@@ -3390,7 +3511,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
             recommended_next_steps=[],
             confidence="high",
         )
-        return _emit_result(args, payload)
+        return payload
 
     # --- Probe canonical + legacy ------------------------------------------
     daily_note = _probe_daily_note(home, date)
@@ -3593,7 +3714,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
         ),
         confidence=confidence,
     )
-    return _emit_result(args, payload)
+    return payload
 
 
 def _emit_result(args: argparse.Namespace, payload: dict) -> int:
@@ -3839,7 +3960,22 @@ def build_parser() -> argparse.ArgumentParser:
     hd_parser.add_argument("--agent", required=True)
     hd_parser.add_argument("--home", required=True, help="agent profile home root")
     hd_parser.add_argument("--workdir", required=True, help="agent workdir (no fallback)")
-    hd_parser.add_argument("--date", help="YYYY-MM-DD; defaults to yesterday in --tz")
+    hd_date_group = hd_parser.add_mutually_exclusive_group()
+    hd_date_group.add_argument(
+        "--date", help="YYYY-MM-DD; defaults to yesterday in --tz",
+    )
+    hd_date_group.add_argument(
+        "--from", dest="date_from", default=None,
+        help="Start date YYYY-MM-DD (inclusive); pair with --to. Mutually exclusive with --date.",
+    )
+    hd_parser.add_argument(
+        "--to", dest="date_to", default=None,
+        help="End date YYYY-MM-DD (inclusive); requires --from. Defaults to today in --tz.",
+    )
+    hd_parser.add_argument(
+        "--missing-only", dest="missing_only", action="store_true", default=False,
+        help="With --from, skip dates whose canonical daily note already has semantic_nonempty=True.",
+    )
     hd_parser.add_argument("--tz", default="Asia/Seoul")
     hd_parser.add_argument("--state-dir", help="override $BRIDGE_STATE_DIR/memory-daily")
     hd_parser.add_argument("--sidecar-out", help="authoritative RESULT_SCHEMA JSON path")

--- a/tests/memory-daily-harvest/smoke.sh
+++ b/tests/memory-daily-harvest/smoke.sh
@@ -671,6 +671,258 @@ else
 fi
 
 # =============================================================================
+# scenario R1 — --missing-only skips dates with manifest, harvests dates
+# without manifest even when canonical note exists (Lane B SSOT semantics).
+# =============================================================================
+banner "R1 — --missing-only checks manifest, not canonical note"
+
+r1_dir="$SMOKE_ROOT/r1"
+r1_home="$r1_dir/agents/r1-agent"
+r1_workdir="$r1_dir/workdir"
+r1_state="$r1_dir/bridge-home/state/memory-daily"
+r1_sidecar="$r1_dir/r1.sidecar.json"
+mkdir -p "$r1_home/memory" "$r1_workdir" "$r1_state/r1-agent"
+
+# Two dates inside the range:
+#   D1 (2026-04-20): pre-existing manifest → must be skipped
+#   D2 (2026-04-21): canonical note only, NO manifest → must be harvested
+#                    (this is the regression case the brief calls out)
+r1_d1="2026-04-20"
+r1_d2="2026-04-21"
+r1_d3="2026-04-22"  # nothing — must also be harvested (or no-op'd) but NOT skipped
+
+# Pre-write a manifest for D1.
+cat >"$r1_state/r1-agent/$r1_d1.json" <<EOF
+{"schema":"memory-daily-manifest-v1","agent":"r1-agent","date":"$r1_d1","state":"checked"}
+EOF
+
+# Canonical note (substantial enough to be semantic_nonempty) for D2.
+cat >"$r1_home/memory/$r1_d2.md" <<EOF
+# $r1_d2 — r1-agent
+
+- kickoff: this is a manually-written daily note with no harvester manifest.
+- decision: the harvester must still run because the manifest is the SSOT.
+
+## Work log
+
+Filling out enough body so semantic_nonempty=True, and proving the legacy
+canonical-note-only short-circuit no longer skips this date.
+EOF
+
+BRIDGE_HOME="$r1_dir/bridge-home" \
+"$PYTHON" "$REPO_ROOT/bridge-memory.py" harvest-daily \
+  --agent r1-agent \
+  --home "$r1_home" \
+  --workdir "$r1_workdir" \
+  --from "$r1_d1" --to "$r1_d3" \
+  --tz Asia/Seoul \
+  --missing-only \
+  --state-dir "$r1_state" \
+  --sidecar-out "$r1_sidecar" \
+  >"$r1_dir/stdout" 2>"$r1_dir/stderr"
+rc=$?
+
+# Expected: D1 skipped:exists, D2 has a "result" entry, D3 has a "result" entry.
+r1_d1_skipped="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+for r in data.get("results", []):
+    if r.get("date") == sys.argv[2]:
+        print("yes" if r.get("skipped") == "exists" else "no")
+        break
+else:
+    print("missing")
+' "$r1_sidecar" "$r1_d1" 2>/dev/null || echo "err")"
+
+r1_d2_harvested="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+for r in data.get("results", []):
+    if r.get("date") == sys.argv[2]:
+        print("yes" if "result" in r else "no")
+        break
+else:
+    print("missing")
+' "$r1_sidecar" "$r1_d2" 2>/dev/null || echo "err")"
+
+r1_d2_manifest_after="$([[ -f "$r1_state/r1-agent/$r1_d2.json" ]] && echo "yes" || echo "no")"
+r1_summary_line="$(grep -c 'harvest-daily range complete' "$r1_dir/stderr" || true)"
+
+if [[ $rc -eq 0 \
+      && "$r1_d1_skipped" == "yes" \
+      && "$r1_d2_harvested" == "yes" \
+      && "$r1_d2_manifest_after" == "yes" \
+      && "$r1_summary_line" -ge 1 ]]; then
+  pass "R1"
+else
+  fail "R1" "rc=$rc d1_skipped=$r1_d1_skipped d2_harvested=$r1_d2_harvested d2_manifest=$r1_d2_manifest_after summary_line=$r1_summary_line"
+fi
+
+# =============================================================================
+# scenario R2 — one bad date in a range does NOT abort the run; rc_max
+# reflects the failure; final summary line lists ok/fail counts.
+# =============================================================================
+banner "R2 — per-date error capture continues the range"
+
+r2_dir="$SMOKE_ROOT/r2"
+r2_home="$r2_dir/agents/r2-agent"
+r2_workdir="$r2_dir/workdir"
+r2_state="$r2_dir/bridge-home/state/memory-daily"
+r2_sidecar="$r2_dir/r2.sidecar.json"
+mkdir -p "$r2_home/memory" "$r2_workdir"
+
+# Wrap bridge-memory.py via a Python shim that monkey-patches
+# `_harvest_one_date` to raise on date == 2026-04-21 only. This proves the
+# range loop catches and continues.
+r2_shim="$r2_dir/shim.py"
+cat >"$r2_shim" <<'PY'
+import importlib.util, runpy, sys, pathlib
+mem_path = pathlib.Path(sys.argv[1])
+spec = importlib.util.spec_from_file_location("bridge_memory", mem_path)
+mod = importlib.util.module_from_spec(spec)
+sys.modules["bridge_memory"] = mod
+spec.loader.exec_module(mod)
+
+orig = mod._harvest_one_date
+def patched(args, date):
+    if date == "2026-04-21":
+        raise RuntimeError(f"synthetic-failure for {date}")
+    return orig(args, date)
+mod._harvest_one_date = patched
+
+# Re-execute argparse dispatch with the rest of argv.
+sys.argv = ["bridge-memory.py", *sys.argv[2:]]
+parser = mod.build_parser()
+ns = parser.parse_args()
+sys.exit(ns.func(ns))
+PY
+
+BRIDGE_HOME="$r2_dir/bridge-home" \
+"$PYTHON" "$r2_shim" "$REPO_ROOT/bridge-memory.py" \
+  harvest-daily \
+  --agent r2-agent \
+  --home "$r2_home" \
+  --workdir "$r2_workdir" \
+  --from 2026-04-20 --to 2026-04-22 \
+  --tz Asia/Seoul \
+  --state-dir "$r2_state" \
+  --sidecar-out "$r2_sidecar" \
+  >"$r2_dir/stdout" 2>"$r2_dir/stderr"
+rc=$?
+
+r2_d1_ok="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+for r in data.get("results", []):
+    if r.get("date") == "2026-04-20":
+        print("yes" if "result" in r else "no")
+        break
+else:
+    print("missing")
+' "$r2_sidecar" 2>/dev/null || echo "err")"
+
+r2_d2_failed="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+for r in data.get("results", []):
+    if r.get("date") == "2026-04-21":
+        print("yes" if "error" in r and "synthetic-failure" in (r.get("error") or "") else "no")
+        break
+else:
+    print("missing")
+' "$r2_sidecar" 2>/dev/null || echo "err")"
+
+r2_d3_ok="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+for r in data.get("results", []):
+    if r.get("date") == "2026-04-22":
+        print("yes" if "result" in r else "no")
+        break
+else:
+    print("missing")
+' "$r2_sidecar" 2>/dev/null || echo "err")"
+
+r2_summary="$(grep -E 'harvest-daily range complete: 3 dates, 2 succeeded, 1 failed' "$r2_dir/stderr" || true)"
+r2_failure_line="$(grep -E 'harvest-daily date=2026-04-21 failed: synthetic-failure' "$r2_dir/stderr" || true)"
+
+if [[ $rc -eq 1 \
+      && "$r2_d1_ok" == "yes" \
+      && "$r2_d2_failed" == "yes" \
+      && "$r2_d3_ok" == "yes" \
+      && -n "$r2_summary" \
+      && -n "$r2_failure_line" ]]; then
+  pass "R2"
+else
+  fail "R2" "rc=$rc d1=$r2_d1_ok d2=$r2_d2_failed d3=$r2_d3_ok summary='${r2_summary:0:80}' failure_line='${r2_failure_line:0:80}'"
+fi
+
+# =============================================================================
+# scenario R3 — single-date --missing-only (Option A): skips when manifest
+# exists, harvests when missing. Symmetric with the range-mode semantics.
+# =============================================================================
+banner "R3 — single-date --missing-only Option A"
+
+r3_dir="$SMOKE_ROOT/r3"
+r3_home="$r3_dir/agents/r3-agent"
+r3_workdir="$r3_dir/workdir"
+r3_state="$r3_dir/bridge-home/state/memory-daily"
+mkdir -p "$r3_home/memory" "$r3_workdir" "$r3_state/r3-agent"
+
+# Pre-existing manifest for the target date.
+r3_d="2026-04-19"
+cat >"$r3_state/r3-agent/$r3_d.json" <<EOF
+{"schema":"memory-daily-manifest-v1","agent":"r3-agent","date":"$r3_d","state":"checked"}
+EOF
+
+# 3a — manifest exists → skip with stderr breadcrumb, exit 0.
+r3a_sidecar="$r3_dir/r3a.sidecar.json"
+BRIDGE_HOME="$r3_dir/bridge-home" \
+"$PYTHON" "$REPO_ROOT/bridge-memory.py" harvest-daily \
+  --agent r3-agent \
+  --home "$r3_home" \
+  --workdir "$r3_workdir" \
+  --date "$r3_d" \
+  --tz Asia/Seoul \
+  --missing-only \
+  --state-dir "$r3_state" \
+  --sidecar-out "$r3a_sidecar" \
+  --json \
+  >"$r3_dir/r3a.stdout" 2>"$r3_dir/r3a.stderr"
+r3a_rc=$?
+
+r3a_breadcrumb="$(grep -E "already harvested .*--missing-only skip" "$r3_dir/r3a.stderr" || true)"
+r3a_sidecar_present="$([[ -f "$r3a_sidecar" ]] && echo "yes" || echo "no")"
+
+# 3b — manifest absent → harvest runs, returns success, writes a manifest.
+r3b_d="2026-04-18"
+r3b_sidecar="$r3_dir/r3b.sidecar.json"
+BRIDGE_HOME="$r3_dir/bridge-home" \
+"$PYTHON" "$REPO_ROOT/bridge-memory.py" harvest-daily \
+  --agent r3-agent \
+  --home "$r3_home" \
+  --workdir "$r3_workdir" \
+  --date "$r3b_d" \
+  --tz Asia/Seoul \
+  --missing-only \
+  --state-dir "$r3_state" \
+  --sidecar-out "$r3b_sidecar" \
+  --json \
+  >"$r3_dir/r3b.stdout" 2>"$r3_dir/r3b.stderr"
+r3b_rc=$?
+r3b_manifest_after="$([[ -f "$r3_state/r3-agent/$r3b_d.json" ]] && echo "yes" || echo "no")"
+
+if [[ $r3a_rc -eq 0 \
+      && -n "$r3a_breadcrumb" \
+      && "$r3a_sidecar_present" == "no" \
+      && $r3b_rc -eq 0 \
+      && "$r3b_manifest_after" == "yes" ]]; then
+  pass "R3"
+else
+  fail "R3" "r3a_rc=$r3a_rc breadcrumb='${r3a_breadcrumb:0:80}' r3a_sidecar=$r3a_sidecar_present r3b_rc=$r3b_rc r3b_manifest=$r3b_manifest_after"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n================================\n'


### PR DESCRIPTION
## Summary

Re-opens the work originally landed as PR #325 (commit `1daf7a7`) and reverted as part of PR #332. Source branch `feat/harvest-daily-range` is unchanged from the original PR; pair-review required this time.

## What changed

`bridge-memory.py harvest-daily` gains `--from` / `--to` range mode and `--missing-only` filter. Previously, dates before a per-agent `memory-daily-*` cron's `createdAtMs` had no harvester run, no sidecar manifest, and no backfill task ever queued — they remained permanently invisible. The range mode lets the operator (or admin) backfill those days (#322 Track A).

## Round-2 follow-ups (codex r1 needs-more)

- **Fix #2 — `--missing-only` checks the sidecar harvest manifest**, not the canonical daily-note path. The manifest at `state-dir/<agent>/<date>.json` is what Lane B reads to decide a date has been harvested; that is the SSOT. Manual-note-without-manifest dates are now re-harvested instead of silently skipped.
- **Fix #5 — per-date error capture in the range loop.** A single failing date no longer aborts the run. Failures emit `[bridge-memory] harvest-daily date=YYYY-MM-DD failed: <reason>` to stderr, record `{"date": ..., "error": ...}` in the aggregate, bump `rc_max` to 1, and the loop continues. A summary line `harvest-daily range complete: <N> dates, <ok> succeeded, <fail> failed, <skipped> skipped` is printed at the end.
- **Concern — single-date `--missing-only` semantics: Option A (symmetric).** `--missing-only` now applies to the single-date path too. When the manifest exists, the single-date dispatcher exits 0 with a stderr breadcrumb and no harvest run, matching the range-mode skip semantics. Operators can do `harvest-daily --date YYYY-MM-DD --missing-only` to opportunistically harvest only when missing.

## Smoke fixture

`tests/memory-daily-harvest/smoke.sh` gains three scenarios (R1/R2/R3) covering: (a) `--missing-only` skips dates with a manifest and harvests dates without one even when a canonical note exists, (b) one bad date in a range does not abort the run and the summary reports ok/fail counts, (c) single-date `--missing-only` skips when the manifest exists and harvests when it does not. All 13 scenarios PASS locally.

## Pair-review

Awaiting `codex-rescue` round-2 review per AGENTS.md. Merge only after `implement-ok`.

## CI

Pre-existing CI smoke failure on main since 2026-04-21. Not caused by this PR.

Addresses Track A of #322.