### PR TITLE
fix(stall): narrow rate_limit / auth regex (#329 Track A)

### DIFF
--- a/bridge-stall.py
+++ b/bridge-stall.py
@@ -46,7 +46,15 @@ PATTERN_GROUPS: list[tuple[str, list[str]]] = [
             r"rate limit exceeded",
             r"rate_limit_exceeded",
             r"too many requests",
-            r"\b429\b",
+            # Issue #329 Track A: bare `\b429\b` matched non-glyph scrollback
+            # like A2A task bodies, [cron-dispatch] payloads, vendor incident
+            # transcripts, and meta-text quoting the regex itself — producing
+            # repeated rate-limit nudges to idle agents because excerpt_hash
+            # changed each scan and the max_nudges cap never tripped. Mirror
+            # the #161 timeout narrowing: require an HTTP/status/error/code
+            # transport qualifier adjacent to the bare 429.
+            r"(?:http[\s/]?|status[\s:=]+|error[\s:=]+|code[\s:=]+|api_error_status[\s:=]?)\s*\b429\b",
+            r"\b429\b\s*(?:too many|rate|throttl)",
             r"please wait before trying",
             r"try a different model",
             r"quota exceeded",
@@ -56,7 +64,13 @@ PATTERN_GROUPS: list[tuple[str, list[str]]] = [
         "auth",
         [
             r"session expired",
-            r"unauthorized",
+            # Issue #329 Track A: bare `unauthorized` matched non-glyph
+            # scrollback (A2A bodies, cron-dispatch payloads, CJK prose
+            # quoting the term). Require a transport qualifier adjacent to
+            # the bare keyword/numeric, mirroring the rate_limit narrowing.
+            r"(?:http[\s/]?|status[\s:=]+|error[\s:=]+|code[\s:=]+)\s*\b40[13]\b",
+            r"\bunauthorized\b\s*(?:request|access\s+denied|401|api_error)",
+            r"\b40[13]\b\s*unauthorized",
             r"login required",
             r"authentication failed",
             r"token expired",

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -299,6 +299,58 @@ run_cp_case "codex + 'must compact before continuing' banner -> critical" \
   $'must compact before continuing before the next turn\n' \
   "codex"
 
+log "stall-detector rate_limit/auth regex narrowing (#329 Track A)"
+# Self-contained classifier checks for the bare `\b429\b` / `\bunauthorized\b`
+# narrowing. Mirrors the #161 timeout fix: bare numerics/keywords now require
+# an HTTP/status/error/code transport qualifier adjacent so non-glyph
+# scrollback (A2A task body inject, [cron-dispatch] payload, vendor incident
+# transcripts, meta-text quoting the regex itself, CJK prose) no longer
+# false-positives. Existing positives (real provider error lines) keep
+# classifying.
+run_stall_classify_case() {
+  local label="$1"
+  local expected_classification="$2"  # "" means must NOT classify
+  local input="$3"
+  local out classification
+  out="$(printf '%s' "$input" | python3 "$REPO_ROOT/bridge-stall.py" analyze --format shell)"
+  classification="$(printf '%s\n' "$out" | sed -n 's/^STALL_CLASSIFICATION="\(.*\)"$/\1/p')"
+  if [[ "$classification" != "$expected_classification" ]]; then
+    die "stall classify [$label]: expected '$expected_classification' got '$classification' for input <<<$input>>>"
+  fi
+  log "  [ok] $label"
+}
+# Positive: must still classify as rate_limit / auth (real provider errors).
+run_stall_classify_case "HTTP 429 Too Many Requests -> rate_limit" \
+  "rate_limit" \
+  $'error: HTTP 429 Too Many Requests\n'
+run_stall_classify_case "status: 401 unauthorized -> auth" \
+  "auth" \
+  $'status: 401 unauthorized\n'
+run_stall_classify_case "api_error_status=429 -> rate_limit" \
+  "rate_limit" \
+  $'api_error_status=429\n'
+run_stall_classify_case "Please wait before trying -> rate_limit" \
+  "rate_limit" \
+  $'Please wait before trying again in 30 seconds\n'
+# Negative regression guards: non-glyph scrollback that bare \b429\b
+# / \bunauthorized\b previously matched. None of these have an HTTP
+# transport qualifier adjacent and must not classify.
+run_stall_classify_case "[cron-dispatch] payload mentioning 429 -> silent" \
+  "" \
+  $'[cron-dispatch] cs-line-poll-5m payload includes 429 references\n'
+run_stall_classify_case "[A2A] task body mentioning 429 -> silent" \
+  "" \
+  $'[A2A] task body: 429 references in incident report\n'
+run_stall_classify_case "external vendor incident transcript -> silent" \
+  "" \
+  $'Vendor incident: 429 reported by upstream\n'
+run_stall_classify_case "meta-text quoting the regex itself -> silent" \
+  "" \
+  $'매칭 정규식: \\b429\\b\n'
+run_stall_classify_case "CJK prose discussing access -> silent" \
+  "" \
+  $'승인 안 된 액세스를 묘님이 검토 중\n'
+
 log "CLI subcommand suggestion helper (issue #163)"
 run_suggest_case() {
   local label="$1"


### PR DESCRIPTION
## Summary

- `bridge-stall.py` `PATTERN_GROUPS`: replace bare `\b429\b` / `\bunauthorized\b` with HTTP/status/error/code/api_error_status qualifier-prefixed forms (plus a symmetric `\b429\b\s*(?:too many|rate|throttl)` and `\b40[13]\b\s*unauthorized` fallback). Mirrors the #161 timeout narrowing applied in `61e6368`.
- `scripts/smoke-test.sh`: add 4 positive (real provider errors must still classify) + 5 negative (non-glyph scrollback false-positives must stay silent) classifier-level fixtures. Self-contained block placed early next to the context-pressure unit checks (#126/#183 shape) so the regression guard does not depend on the live tmux/queue stall block.
- No VERSION bump.

## Why

`#264` (`2d0ac2e`, v0.6.14+) only skips agent-narration lines that start with a Claude Code UI glyph (⏺/›/⎿/…). `classify` still ran the bare `\b429\b` and `\bunauthorized\b` regexes against **non-glyph** scrollback:

- A2A task body inject (other agent's task body containing "429" rendered as raw text)
- `[cron-dispatch]` payload (debug trace, alerts)
- External error transcripts (vendor incident notices)
- Bridge nudge wraps in narrow panes
- Meta-text quoting the regex itself (e.g. `매칭 정규식: \b429\b`)

The daemon kept firing `[STALL/RATE_LIMIT]` / `[STALL/AUTH]` nudges at idle agents because `excerpt_hash` differed each scan and the `max_nudges=2` cap never tripped. 2026-04-26 11:54 KST `syrs-cs` reproduced this on `v0.6.17` — single matched line, `STALL_FIRST_DETECTED_TS == STALL_LAST_DETECTED_TS`, agent had no pending work other than approval-wait.

This is **Track A** of the issue's proposed fixes (lowest-risk regex narrowing). Tracks B (skip-rule expansion to `[cron-dispatch]` / `[A2A]` prefixes), C (CJK prose heuristic), and D (`matched_line` + dedup) remain open under issue #329.

## Verification

```
python3 -c "import ast; ast.parse(open('bridge-stall.py').read())"   # OK
bash -n scripts/smoke-test.sh                                         # OK
shellcheck scripts/smoke-test.sh                                      # OK (exit 0)
```

Self-contained classifier audit (the new smoke block, run inline):

```
[ok] HTTP 429 Too Many Requests -> rate_limit
[ok] status: 401 unauthorized -> auth
[ok] api_error_status=429 -> rate_limit
[ok] Please wait before trying -> rate_limit
[ok] [cron-dispatch] payload mentioning 429 -> silent
[ok] [A2A] task body mentioning 429 -> silent
[ok] external vendor incident transcript -> silent
[ok] meta-text quoting the regex itself -> silent
[ok] CJK prose discussing access -> silent
```

Existing tmux-driven stall fixtures (`hit your limit`, `session expired`, picker prompt) still classify under the narrowed regex — they did not depend on bare `\b429\b` / `\bunauthorized\b`. Edge-case audit confirmed bare `401`/`403` no longer fires, while real auth errors with HTTP/error/status prefix and the symmetric `401 Unauthorized` form still do.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-stall.py').read())"`
- [x] `bash -n scripts/smoke-test.sh`
- [x] `shellcheck scripts/smoke-test.sh`
- [x] 4 positive fixtures classify (rate_limit / auth) post-narrowing
- [x] 5 negative fixtures stay silent post-narrowing
- [x] Existing smoke tmux fixtures (`hit your limit`, `session expired`, picker) still classify — unaffected
- [ ] Pair review by `agb-dev-codex-2` per AGENTS.md (orchestrator dispatches)

## Notes

- Pair-review required per AGENTS.md. **Do not auto-merge.** Orchestrator will dispatch codex review.
- Closes Track A only; do not write `closes #329`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)