### PR TITLE
daemon: queue state as delivery oracle for session_nudge_sent (#331 Track A)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2318,11 +2318,46 @@ PY
     return 1
   fi
   bridge_task_note_nudge "$agent" "${live_nudge_key:-$nudge_key}" || true
+
+  # Issue #331 Track A: bridge_dispatch_notification's success only proves the
+  # tmux paste/submit helper returned 0 — it does not prove the codex/claude
+  # composer actually consumed the C-m. Codex agents have a real race where
+  # the paste lands and C-m fires but the placeholder lifecycle eats the
+  # submission, leaving the task `queued` while the daemon logs
+  # session_nudge_sent. Use the queue itself as the delivery oracle: a
+  # successful nudge causes the agent to claim within ~1s; if the task is
+  # still queued after $BRIDGE_NUDGE_VERIFY_GRACE_SECONDS (default 2s), flip
+  # the audit row to session_nudge_dropped and return non-zero so the next
+  # idle-nudge tick (post-cooldown) retries instead of leaving a stale
+  # success on the audit log. We do NOT retry inline — a tight loop on a
+  # sticky tmux race wastes ticks. Skip when we have no task_id to verify.
+  local nudge_grace_seconds="${BRIDGE_NUDGE_VERIFY_GRACE_SECONDS:-2}"
+  local post_status=""
+  if [[ -n "$task_id" ]]; then
+    if [[ "$nudge_grace_seconds" =~ ^[0-9]+$ ]] && (( nudge_grace_seconds > 0 )); then
+      sleep "$nudge_grace_seconds"
+    fi
+    post_status="$(bridge_queue_task_status "$task_id" 2>/dev/null || true)"
+    if [[ "$post_status" == "queued" ]]; then
+      bridge_audit_log daemon session_nudge_dropped "$agent" \
+        --detail task_id="$task_id" \
+        --detail reason=submit_lost_post_grace \
+        --detail grace_seconds="$nudge_grace_seconds" \
+        --detail queued="$live_queued" \
+        --detail claimed="$live_claimed" \
+        --detail idle_seconds="$idle" \
+        --detail title="$title"
+      daemon_info "nudge to ${agent} appears dropped (task #${task_id} still queued after ${nudge_grace_seconds}s); will retry on next idle-nudge tick"
+      return 1
+    fi
+  fi
+
   bridge_audit_log daemon session_nudge_sent "$agent" \
     --detail queued="$live_queued" \
     --detail claimed="$live_claimed" \
     --detail idle_seconds="$idle" \
     --detail task_id="${task_id:-0}" \
+    --detail post_status="${post_status:-unknown}" \
     --detail title="$title"
   daemon_info "nudged ${agent} (queued=${live_queued}, claimed=${live_claimed}, idle=${idle}s)"
 }

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2718,6 +2718,22 @@ bridge_task_note_nudge() {
   bridge_queue_cli "${args[@]}" >/dev/null
 }
 
+bridge_queue_task_status() {
+  # Issue #331 Track A: lightweight status read used by the daemon's nudge
+  # verifier. Reuses the existing `show --format shell` payload (TASK_STATUS)
+  # so we don't introduce a new queue subcommand.
+  local task_id="${1:-}"
+  local status_shell=""
+
+  [[ -n "$task_id" ]] || return 1
+  status_shell="$(bridge_queue_cli show "$task_id" --format shell 2>/dev/null)" || return 1
+  TASK_STATUS=""
+  # shellcheck disable=SC1090
+  source /dev/stdin <<<"$status_shell"
+  [[ -n "$TASK_STATUS" ]] || return 1
+  printf '%s' "$TASK_STATUS"
+}
+
 bridge_render_active_roster() {
   local tmp_tsv tmp_md updated session_id
   local agent

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3071,6 +3071,102 @@ STALE_NUDGE_RESULT="$("$BASH4_BIN" "$STALE_NUDGE_CHECKER" "$STALE_NUDGE_ROW" "$S
 [[ ! -f "$STALE_NUDGE_SEND_LOG" ]] || die "stale nudge unexpectedly dispatched"
 tmux_kill_session_exact "$CODEX_CLI_SESSION" || true
 
+# Issue #331 Track A: queue state as the delivery oracle for session_nudge_sent.
+# When the tmux paste/submit helper returns 0 but the agent never actually
+# claims the task (the codex composer race described in the issue), the
+# daemon must record session_nudge_dropped instead of session_nudge_sent and
+# return non-zero so the next idle-nudge tick can retry.
+log "Issue #331: marking session_nudge_dropped when the task stays queued past the verify grace"
+NUDGE_VERIFY_AUDIT="$TMP_ROOT/nudge-verify-audit.jsonl"
+NUDGE_VERIFY_CHECKER="$TMP_ROOT/nudge-verify-check.sh"
+cat >"$NUDGE_VERIFY_CHECKER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="\$1"
+task_id="\$2"
+audit_file="\$3"
+daemon_lib="$TMP_ROOT/bridge-daemon-functions.sh"
+
+awk -v repo_root="$REPO_ROOT" '
+  BEGIN { q="\"" }
+  index(\$0, "CMD=\"\${1:-}\"") == 1 { exit }
+  /^SCRIPT_DIR=/ { print "SCRIPT_DIR=" q repo_root q; next }
+  { print }
+' "$REPO_ROOT/bridge-daemon.sh" >"\$daemon_lib"
+
+# shellcheck disable=SC1090
+source "\$daemon_lib"
+
+export BRIDGE_AUDIT_LOG="\$audit_file"
+export BRIDGE_NUDGE_VERIFY_GRACE_SECONDS=0
+: >"\$audit_file"
+
+daemon_info() { :; }
+
+if [[ "\$mode" == "claimed" ]]; then
+  bridge_dispatch_notification() {
+    # Simulate the agent observing the nudge and claiming the task.
+    python3 "$REPO_ROOT/bridge-queue.py" claim "\$task_id" --agent "$CODEX_CLI_AGENT" >/dev/null
+    return 0
+  }
+else
+  bridge_dispatch_notification() {
+    # Paste/submit returned 0 but the codex composer ate the C-m: task
+    # remains queued (the post-#331 race the audit log used to lie about).
+    return 0
+  }
+fi
+
+set +e
+nudge_agent_session "$CODEX_CLI_AGENT" "$CODEX_CLI_SESSION" "1" "0" "0" "\$task_id"
+rc=\$?
+set -e
+printf 'RC=%s\n' "\$rc"
+EOF
+chmod +x "$NUDGE_VERIFY_CHECKER"
+
+NUDGE_DROP_OUTPUT="$(python3 "$REPO_ROOT/bridge-queue.py" create --to "$CODEX_CLI_AGENT" --title "verify drop oracle" --body "pickup" --from "$REQUESTER_AGENT")"
+NUDGE_DROP_TASK_ID="$(printf '%s\n' "$NUDGE_DROP_OUTPUT" | sed -n 's/^created task #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+[[ -n "$NUDGE_DROP_TASK_ID" ]] || die "expected verify-drop task id"
+NUDGE_DROP_RUN="$("$BASH4_BIN" "$NUDGE_VERIFY_CHECKER" queued "$NUDGE_DROP_TASK_ID" "$NUDGE_VERIFY_AUDIT")"
+assert_contains "$NUDGE_DROP_RUN" "RC=1"
+NUDGE_DROP_ACTION="$(python3 - "$NUDGE_VERIFY_AUDIT" "$NUDGE_DROP_TASK_ID" <<'PY'
+import json, sys
+audit_path, task_id = sys.argv[1], sys.argv[2]
+last = ""
+for raw in open(audit_path, encoding="utf-8"):
+    item = json.loads(raw)
+    detail = item.get("detail") or {}
+    if str(detail.get("task_id")) == task_id:
+        last = item.get("action", "")
+print(last)
+PY
+)"
+[[ "$NUDGE_DROP_ACTION" == "session_nudge_dropped" ]] || die "expected session_nudge_dropped audit row, got '$NUDGE_DROP_ACTION'"
+python3 "$REPO_ROOT/bridge-queue.py" cancel "$NUDGE_DROP_TASK_ID" --agent "$REQUESTER_AGENT" --note "verify drop cleanup" >/dev/null
+
+log "Issue #331: marking session_nudge_sent when the task moves out of queued before the grace expires"
+NUDGE_SENT_OUTPUT="$(python3 "$REPO_ROOT/bridge-queue.py" create --to "$CODEX_CLI_AGENT" --title "verify sent oracle" --body "pickup" --from "$REQUESTER_AGENT")"
+NUDGE_SENT_TASK_ID="$(printf '%s\n' "$NUDGE_SENT_OUTPUT" | sed -n 's/^created task #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+[[ -n "$NUDGE_SENT_TASK_ID" ]] || die "expected verify-sent task id"
+NUDGE_SENT_RUN="$("$BASH4_BIN" "$NUDGE_VERIFY_CHECKER" claimed "$NUDGE_SENT_TASK_ID" "$NUDGE_VERIFY_AUDIT")"
+assert_contains "$NUDGE_SENT_RUN" "RC=0"
+NUDGE_SENT_ACTION="$(python3 - "$NUDGE_VERIFY_AUDIT" "$NUDGE_SENT_TASK_ID" <<'PY'
+import json, sys
+audit_path, task_id = sys.argv[1], sys.argv[2]
+last = ""
+for raw in open(audit_path, encoding="utf-8"):
+    item = json.loads(raw)
+    detail = item.get("detail") or {}
+    if str(detail.get("task_id")) == task_id:
+        last = item.get("action", "")
+print(last)
+PY
+)"
+[[ "$NUDGE_SENT_ACTION" == "session_nudge_sent" ]] || die "expected session_nudge_sent audit row, got '$NUDGE_SENT_ACTION'"
+python3 "$REPO_ROOT/bridge-queue.py" done "$NUDGE_SENT_TASK_ID" --agent "$CODEX_CLI_AGENT" --note "verify sent cleanup" >/dev/null
+
 log "waking a prompt-ready Claude session even when the idle marker is missing"
 tmux_kill_session_exact "$CLAUDE_STATIC_SESSION" || true
 tmux new-session -d -s "$CLAUDE_STATIC_SESSION" "$BASH4_BIN -lc 'printf \"❯ ready\\n\"; sleep 30'"


### PR DESCRIPTION
## Summary

Track A only of #331: paste/submit returning 0 is necessary but not sufficient — codex agents have a real race where the composer placeholder lifecycle eats the C-m, leaving the task \`queued\` while the daemon logs \`session_nudge_sent\`. Use the queue itself as the delivery oracle.

## What changed

`bridge-daemon.sh`:
- After \`bridge_dispatch_notification\` returns success, sleep \`BRIDGE_NUDGE_VERIFY_GRACE_SECONDS\` (default 2s) and poll the task status.
- If the task is still \`queued\`, audit row becomes \`session_nudge_dropped\` and the function returns 1 so the next idle-nudge tick retries (no inline retry — sticky tmux races burn ticks).
- If the task moved to any non-\`queued\` state, audit row stays \`session_nudge_sent\` with a new \`post_status\` detail so operators can grep the actual state.
- \`daemon_info\` line tells operators the next tick will retry.

`lib/bridge-state.sh`:
- New \`bridge_queue_task_status\` helper reuses the existing \`bridge-queue.py show --format shell\` payload (TASK_STATUS) — no new queue subcommand.

`scripts/smoke-test.sh`:
- Two fixtures via a temp daemon-functions extract:
  1. paste/submit returns 0 but task stays \`queued\` → RC=1 + \`session_nudge_dropped\` audit row
  2. paste/submit returns 0 and the simulated agent claims → RC=0 + \`session_nudge_sent\` audit row

## What's preserved

- \`lib/bridge-tmux.sh::bridge_tmux_paste_and_submit\` is **untouched**. Tracks B (codex composer state machine) and C (synthetic ack-probe) stay open and address the deeper paste/C-m race separately.
- The audit-log row format on the success path is unchanged; the new \`post_status\` detail is additive.

## Knobs

- \`BRIDGE_NUDGE_VERIFY_GRACE_SECONDS\` — default 2. Set to 0 to bypass the verify (e.g., during smoke).

## Pair-review

Awaiting \`codex-rescue\` review per AGENTS.md. Merge only after \`implement-ok\`.

## CI

Pre-existing CI smoke failure on main since 2026-04-21. Not caused by this PR.

Addresses Track A of #331. Tracks B + C stay open as separate proposals.