### PR TITLE
context-pressure: anchor HUD-pct extractor to literal Context line (#338 Track A)

### DIFF
--- a/bridge-context-pressure.py
+++ b/bridge-context-pressure.py
@@ -14,22 +14,22 @@ from pathlib import Path
 
 ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
-# Claude HUD renders a live context meter like:
+# Claude HUD renders a live context meter on its own line, like:
 #   Context ████████░░ 40%
-# We require the word "Context" followed within a short window by one of the
-# bar glyphs (█ ░ ▓ ▒ ■), then a 1-3 digit percent. The glyph requirement is
-# what distinguishes the authoritative HUD from prose text such as
-# "Context remaining 8%" that happens to live in post-/compact scrollback
-# after --continue/--resume (issue #126).
-#
-# Defense in depth against pane wrapping: the daemon's capture-pane call
-# passes tmux -J (see lib/bridge-tmux.sh bridge_capture_recent "join"), but
-# we also tolerate a single newline inside the short glyph-neighborhood so
-# captures from non-joined callers (or older recordings used in tests) still
-# match when the HUD wraps on a narrow terminal.
-HUD_RE = re.compile(
-    r"Context[\s\S]{0,60}?[\u2588\u2591\u2592\u2593\u25A0][\u2588\u2591\u2592\u2593\u25A0\s]{0,40}?(\d{1,3})\s*%",
-    re.IGNORECASE,
+# We anchor the regex to line-start and require the literal "Context "
+# prefix, a run of block-element bar glyphs (U+2580-U+259F, which covers
+# the canonical full/light/medium/dark shades plus relatives, and the
+# legacy U+25A0 filled square), whitespace, and a 1-3 digit percent
+# terminator. This rejects free-standing percentages elsewhere in
+# scrollback ("100% complete" in tool output, doc excerpts, etc.) which a
+# looser regex would previously misclassify as a critical HUD reading
+# (issue #338). Prose fallback still covers post-/compact scrollback via
+# PATTERN_GROUPS—this anchor is purely the HUD path.
+_HUD_LINE_RE = re.compile(
+    r"^\s*Context\s+"
+    r"[▀-▟■]"
+    r"[▀-▟■\s]*"
+    r"\s+(\d{1,3})\s*%",
 )
 
 PATTERN_GROUPS: list[tuple[str, list[str]]] = [
@@ -117,17 +117,38 @@ def _env_threshold(name: str, default: int) -> int:
 
 
 def hud_context_pct(normalized: str) -> int | None:
-    """Return the latest HUD context percentage, or None if no HUD line seen."""
-    matches = list(HUD_RE.finditer(normalized))
-    if not matches:
+    """Return the most-recent Claude HUD context percentage, anchored to the
+    canonical HUD line, or None if no HUD line is seen.
+
+    The Claude Code HUD renders one status block of the shape::
+
+        Context ███░░░░░░░ 36%
+
+    on its own line. We split the captured pane into lines and walk them
+    bottom-up (most recent wins), applying ``_HUD_LINE_RE`` which requires
+    the literal "Context " prefix, a run of block-element bar glyphs, and
+    a 1-3 digit percent. Free-standing percentages elsewhere in scrollback
+    ("100% complete", "see report 80%", etc.) are intentionally rejected —
+    that was the false-positive driving issue #338, where tool output
+    embedded `100%` and an unanchored regex classified the session critical.
+
+    The caller already handles a ``None`` return by falling back to
+    ``PATTERN_GROUPS`` (subject to ``ENGINES_WITHOUT_HUD``); we do not need
+    to preserve any compatibility path here.
+    """
+    if not normalized:
         return None
-    try:
-        pct = int(matches[-1].group(1))
-    except (TypeError, ValueError):
-        return None
-    if pct < 0 or pct > 100:
-        return None
-    return pct
+    for line in reversed(normalized.splitlines()):
+        m = _HUD_LINE_RE.match(line)
+        if not m:
+            continue
+        try:
+            pct = int(m.group(1))
+        except (TypeError, ValueError):
+            continue
+        if 0 <= pct <= 100:
+            return pct
+    return None
 
 
 def classify(normalized: str, full: str | None = None, engine: str = "") -> tuple[str, str]:
@@ -178,7 +199,41 @@ def classify(normalized: str, full: str | None = None, engine: str = "") -> tupl
     return "", ""
 
 
+def _self_test() -> int:
+    """Inline smoke for ``hud_context_pct`` (issue #338).
+
+    Run via ``python3 bridge-context-pressure.py --self-test``. Exits 0 on
+    success, 1 on first failure with a diagnostic line on stderr. This is
+    intentionally tiny and dependency-free so it can run from a smoke
+    script without pytest.
+    """
+    cases: list[tuple[str, int | None]] = [
+        ("Context ███░░░░░░░ 36%", 36),
+        ("some preamble\nContext ████████░░ 80%\nfooter", 80),
+        ("Context ███████░░░ 70%\nContext ███░░░░░░░ 36%", 36),
+        ("100% complete — see report", None),
+        ("Context: 100", None),
+        ("", None),
+        ("Context ████████░░ 999%", None),
+    ]
+    failures: list[str] = []
+    for idx, (sample, expected) in enumerate(cases):
+        got = hud_context_pct(sample)
+        if got != expected:
+            failures.append(
+                f"case {idx}: input={sample!r} expected={expected!r} got={got!r}"
+            )
+    if failures:
+        for line in failures:
+            print(f"FAIL {line}", file=sys.stderr)
+        return 1
+    print("OK")
+    return 0
+
+
 def main() -> int:
+    if "--self-test" in sys.argv[1:]:
+        return _self_test()
     parser = argparse.ArgumentParser()
     parser.add_argument("command", choices=("analyze",))
     parser.add_argument("--capture-file")


### PR DESCRIPTION
## Summary

Free-standing `100%` strings elsewhere in captured pane scrollback (e.g. tool output containing `100% complete`) were matching the loose `HUD_RE` and forcing sessions into critical classification — see #338 for the live `patch` repro at 36% actual / 100 reported. This anchors the HUD-pct extractor to the canonical `Context <bar> NN%` line shape, walked bottom-up so the most-recent HUD reading wins.

## What changed

- `bridge-context-pressure.py`
  - Replace the looser module-level `HUD_RE` with a line-anchored `_HUD_LINE_RE` (`^\s*Context\s+[bar][bar\s]*\s+(\d{1,3})\s*%`).
  - Rewrite `hud_context_pct(normalized)` to `splitlines()` + walk in reverse, returning the first match's percentage. Returns `None` when no anchored line is present so the existing `PATTERN_GROUPS` fallback path runs unchanged.
  - Add `_self_test()` and a `--self-test` CLI flag covering: canonical HUD line, multi-line preamble/footer, most-recent-wins ordering across two HUD readings, free-standing `100%`, `Context: 100` (no bar), empty input, 999% out-of-range guard.

The threshold-classify dispatcher (`classify` lines 188-203) and the `ENGINES_WITHOUT_HUD` warning-skip path (`classify` lines 205-214) are intentionally untouched. The WARNING-severity prose fallback (#183 territory) and CRITICAL prose fallback are unchanged.

## Verification

```
$ python3 -c "import ast; ast.parse(open('bridge-context-pressure.py').read()); print('OK')"
OK

$ python3 bridge-context-pressure.py --self-test
OK

$ python3 -c "
import runpy
ns = runpy.run_path('bridge-context-pressure.py')
hud = ns['hud_context_pct']
assert hud('Context ███░░░░░░░ 36%') == 36
assert hud('Context ████████░░ 80%') == 80
assert hud('100% complete') is None
assert hud('Context: 100') is None
assert hud('') is None
print('OK')"
OK

$ python3 -c "
import runpy
ns = runpy.run_path('bridge-context-pressure.py')
hud = ns['hud_context_pct']
multi = 'Context ███████░░░ 70%\nContext ███░░░░░░░ 36%'
assert hud(multi) == 36
print('OK')"
OK
```

I also re-ran the full `analyze --format shell` smoke matrix against the file. The cases that still pass: low HUD + post-compact scrollback (silent), HUD 70% (warning), HUD 95% (critical), prose `Context remaining 8%` (warning via fallback), codex + `Context compacted` (silent), codex + `context window exceeded` (critical), claude + prose (warning).

The one pre-existing smoke case the new behavior changes is the wrapped-across-newline HUD (`"Context\n████████░░ 70%"`). That asserted `warning`; the anchored matcher now returns silent because the literal line shape is required. This is the deliberate behavior tightening called out in the issue — pane wrapping is already mitigated upstream by tmux `-J` in `bridge_capture_recent`, and the false-positive cost of accepting cross-line context+bar pairs is what motivated #338. Calling it out as a smoke-suite update follow-up rather than auto-editing the smoke script in this PR (per spec: 1 file, 1 commit).

## Backwards compatibility

- **codex** (in `ENGINES_WITHOUT_HUD`) was already on the prose-only path — behavior unchanged.
- **Claude** with a live HUD line in the captured pane: same percentage returned, same severity classification.
- **Claude** without a live HUD but with scrollback noise containing `100%`: previously force-critical; now correctly returns `None` from `hud_context_pct` and either matches a prose pattern in `PATTERN_GROUPS` or stays silent. This is the issue #338 fix.

## CI

Pre-existing CI failures on `main` are not addressed by this change. Track A scope only.

## Scope discipline

No `VERSION` bump, no `CHANGELOG.md` entry. Single file (`bridge-context-pressure.py`), single commit. Only the extractor function, its module-level regex, and an inline `_self_test()` + `--self-test` flag added.

Addresses Track A of #338. Tracks B (cache invalidation on `/clear`) / C (false-positive telemetry) stay open.