### PR TITLE
context-pressure: anchor HUD regex to bar block + invalidate cache on /clear (#338 Tracks A + B)

### DIFF
--- a/bridge-context-pressure.py
+++ b/bridge-context-pressure.py
@@ -16,19 +16,34 @@ ANSI_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
 # Claude HUD renders a live context meter like:
 #   Context ████████░░ 40%
-# We require the word "Context" followed within a short window by one of the
-# bar glyphs (█ ░ ▓ ▒ ■), then a 1-3 digit percent. The glyph requirement is
-# what distinguishes the authoritative HUD from prose text such as
-# "Context remaining 8%" that happens to live in post-/compact scrollback
-# after --continue/--resume (issue #126).
+# We anchor on "Context" at the start of a line (leading whitespace is
+# tolerated for the indent prefix Claude renders before the meter), then
+# require an immediate run of bar-block glyphs (█ ░ ▒ ▓ ■), then the
+# trailing percent. Only whitespace is allowed between "Context" and the
+# first bar glyph; this preserves the #126 distinction from prose like
+# "Context remaining 8%" while also rejecting the wrong-window false-
+# positives flagged in #338 Track A — sentences such as
+# "In this Context we should ████████ 100% of …" no longer match because
+# arbitrary words between "Context" and the bar block are excluded.
 #
 # Defense in depth against pane wrapping: the daemon's capture-pane call
 # passes tmux -J (see lib/bridge-tmux.sh bridge_capture_recent "join"), but
-# we also tolerate a single newline inside the short glyph-neighborhood so
-# captures from non-joined callers (or older recordings used in tests) still
-# match when the HUD wraps on a narrow terminal.
+# the whitespace tolerance (\s+ includes \n) still lets the HUD match when
+# it wraps across "Context" and the bar block on a narrow terminal.
 HUD_RE = re.compile(
-    r"Context[\s\S]{0,60}?[\u2588\u2591\u2592\u2593\u25A0][\u2588\u2591\u2592\u2593\u25A0\s]{0,40}?(\d{1,3})\s*%",
+    r"(?m)^\s*Context\s+[\u2588\u2591\u2592\u2593\u25A0][\u2588\u2591\u2592\u2593\u25A0\s]*?\s*(\d{1,3})\s*%",
+)
+
+# Fresh-session markers — when one of these appears in the captured pane
+# *after* the latest HUD-line match, the HUD line is stale scrollback from
+# the pre-reset session and must not drive classification (issue #338
+# Track B). The post-/clear and post-/new banners both render the literal
+# "Welcome to Claude Code" / "Welcome to Codex" string verbatim. The B1
+# strategy keeps the analyzer purely text-based — no daemon-side state
+# coordination is needed because the captured pane buffer carries both the
+# stale HUD and the fresh-session banner side-by-side.
+RESET_MARKER_RE = re.compile(
+    r"Welcome to (?:Claude Code|Codex)",
     re.IGNORECASE,
 )
 
@@ -117,12 +132,25 @@ def _env_threshold(name: str, default: int) -> int:
 
 
 def hud_context_pct(normalized: str) -> int | None:
-    """Return the latest HUD context percentage, or None if no HUD line seen."""
+    """Return the latest HUD context percentage, or None if no HUD line seen.
+
+    Issue #338 Track B: if a fresh-session marker (post-/clear or post-/new
+    "Welcome to …" banner) appears *after* the latest HUD-line match in the
+    captured pane, the HUD line is stale scrollback from the pre-reset
+    session. Treat it the same as "no HUD seen" so the analyzer does not
+    cache a critical reading from a session the operator has already
+    cleared. The captured pane buffer carries both lines simultaneously,
+    so the reset detection happens here in the extractor without any
+    daemon-side state coordination.
+    """
     matches = list(HUD_RE.finditer(normalized))
     if not matches:
         return None
+    last_match = matches[-1]
+    if RESET_MARKER_RE.search(normalized, last_match.end()):
+        return None
     try:
-        pct = int(matches[-1].group(1))
+        pct = int(last_match.group(1))
     except (TypeError, ValueError):
         return None
     if pct < 0 or pct > 100:

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -299,6 +299,54 @@ run_cp_case "codex + 'must compact before continuing' banner -> critical" \
   $'must compact before continuing before the next turn\n' \
   "codex"
 
+# Issue #338 Track A — anchor the HUD-pct extractor so it only matches the
+# canonical "Context <bar block> NN%" line, not free-floating numerics
+# elsewhere in the captured pane (cron summaries, stash prefixes,
+# [Agent Bridge] task bodies, codex placeholder strings, prose that
+# mentions "Context" alongside an unrelated percentage).
+# Positive: realistic HUD shapes at 36% (admin reproducer), 70%, 95%.
+run_cp_case "338 A+: HUD 36% (admin reproducer) -> warning silenced (below 60)" \
+  "" "hud:context_pct=36" \
+  $'Context ███░░░░░░░ 36%\n'
+run_cp_case "338 A+: HUD 70% on canonical bar shape -> warning" \
+  "warning" "hud:context_pct=70" \
+  $'Context ███████░░░ 70%\n'
+run_cp_case "338 A+: HUD 95% on canonical bar shape -> critical" \
+  "critical" "hud:context_pct=95" \
+  $'Context █████████░ 95%\n'
+# Negative: wrong-window matches the issue called out as the false-positive
+# sources. None should produce hud:context_pct=… and Claude (no engine
+# override) must fall through to the prose pattern groups, which also do
+# not match these strings, so SEVERITY stays empty.
+run_cp_case "338 A-: bare '100% complete' (no HUD prefix)" \
+  "" "" \
+  $'100% complete\n'
+run_cp_case "338 A-: 'cron job exit code 100' (numeric scrollback)" \
+  "" "" \
+  $'cron job exit code 100\n'
+run_cp_case "338 A-: '[Agent Bridge] body mentioning 100% as the previous threshold'" \
+  "" "" \
+  $'[Agent Bridge] body mentioning 100% as the previous threshold\n'
+run_cp_case "338 A-: git stash prefix '+100 lines' scrollback" \
+  "" "" \
+  $'+100 lines (ctrl+o to expand)\n'
+run_cp_case "338 A-: codex 'Working (100s · esc to interrupt)' placeholder" \
+  "" "" \
+  $'Working (100s · esc to interrupt)\n' \
+  "codex"
+# Issue #338 Track B — when a fresh-session marker (Welcome to Claude Code)
+# appears after a stale HUD line in the captured pane, the HUD line is
+# scrollback from the pre-/clear session and must not drive classification.
+run_cp_case "338 B1: stale 100% HUD followed by /clear + Welcome banner -> silent" \
+  "" "" \
+  $'Context ███████████ 100%\n> /clear\n\nWelcome to Claude Code!\n\nHuman: hi\n'
+run_cp_case "338 B1: only Welcome banner, no HUD line -> silent" \
+  "" "" \
+  $'Welcome to Claude Code!\n\n  Tip: try /help to see commands\n\n> '
+run_cp_case "338 B1: Welcome banner above a fresh 36% HUD -> warning silenced (below 60)" \
+  "" "hud:context_pct=36" \
+  $'Welcome to Claude Code!\n\n> hi\n\nContext ███░░░░░░░ 36%\n'
+
 log "stall-detector rate_limit/auth regex narrowing (#329 Track A)"
 # Self-contained classifier checks for the bare `\b429\b` / `\bunauthorized\b`
 # narrowing. Mirrors the #161 timeout fix: bare numerics/keywords now require


### PR DESCRIPTION
## Summary

Fixes the two failure modes in #338 that drove the daemon to emit
`severity=critical, matched_pattern=hud:context_pct=100` against an admin
session whose actual HUD was at ~36%.

### Track A — anchor `HUD_RE` to the canonical HUD line

The previous regex (`Context[\s\S]{0,60}?[bar-glyphs]…`) allowed up to 60
arbitrary characters between `Context` and the first bar glyph, so prose
like *"In this Context we should ████████ 100% of users …"* satisfied
the pattern. The replacement is line-anchored and only allows whitespace
between `Context` and the first bar glyph:

```python
HUD_RE = re.compile(
    r"(?m)^\s*Context\s+[█░▒▓■][█░▒▓■\s]*?\s*(\d{1,3})\s*%",
)
```

This rejects every wrong-window source the issue named — bare `100%
complete`, `cron job exit code 100`, `[Agent Bridge]` task bodies that
mention `100%`, `git stash` `+100 lines (ctrl+o to expand)` prefixes,
codex's `Working (100s · esc to interrupt)` placeholder — while
preserving the HUD wrap defense (`\s+` includes `\n`).

### Track B (Option B1) — invalidate stale HUD on `/clear`

Strategy chosen: **B1 (extractor self-detects)**. B2 (daemon-side state
file removal) was deferred because B1's data flow already sees the full
pane buffer.

When a fresh-session marker — the post-`/clear` and post-`/new` banners
both render `Welcome to Claude Code` / `Welcome to Codex` verbatim —
appears in the captured pane *after* the most recent HUD-line match,
`hud_context_pct` returns `None`. The captured buffer carries both the
stale HUD and the new banner side-by-side, so the reset detection lives
purely in the analyzer; no daemon-side state coordination is needed.

### Smoke fixtures

Extended `scripts/smoke-test.sh` `# context-pressure detector …` block
with 11 new cases:

- **A+ (3)**: HUD 36% (admin reproducer), 70%, 95% — extract the right
  pct and apply default thresholds.
- **A- (5)**: bare `100% complete`; `cron job exit code 100`;
  `[Agent Bridge]` body mentioning `100%`; git stash `+100 lines …`;
  codex `Working (100s · esc to interrupt)` (with `--engine codex`
  so the warning fallback is suppressed). All silent.
- **B1 (3)**: stale `100%` HUD followed by `Welcome to Claude Code` →
  silent; banner only with no HUD → silent; banner *above* a fresh 36%
  HUD → correctly extracted as 36 (still below the 60% warning
  threshold so SEVERITY stays empty, but `matched_pattern` carries
  `hud:context_pct=36`).

### Verification

- `python3 -c "import ast; ast.parse(open('bridge-context-pressure.py').read())"` — pass
- `bash -n scripts/smoke-test.sh` — pass
- `shellcheck scripts/smoke-test.sh` — pass (no new warnings)
- `./scripts/smoke-test.sh` — all 11 new fixtures (`338 A+`, `338 A-`,
  `338 B1`) pass; original 9 `#126`-era fixtures still pass. The smoke
  run hangs later in the daemon-integration phase on the
  pre-existing CI failure noted in the brief — unrelated to these
  files.
- Direct unit test of `hud_context_pct` against all 11 fixture inputs
  via `importlib` — all expected values match (8/8 brief-spec cases
  plus the 3 reset-marker cases).

### Out of scope

- **Track C** (telemetry counter for analyzer false-positive rate) —
  separate wave per the brief.
- Codex HUD handling (`ENGINES_WITHOUT_HUD`) is unchanged.
- HUD threshold defaults (`BRIDGE_CONTEXT_PRESSURE_HUD_CRITICAL_PCT=85`,
  `BRIDGE_CONTEXT_PRESSURE_HUD_WARNING_PCT=60`) are unchanged.
- No new env knobs — the anchored regex is the contract.
- No `VERSION` / `CHANGELOG` bump.

(#338 Tracks A + B)

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-context-pressure.py').read())"`
- [x] `bash -n scripts/smoke-test.sh`
- [x] `shellcheck scripts/smoke-test.sh`
- [x] `./scripts/smoke-test.sh` — confirm all `338 A+`, `338 A-`,
      `338 B1` lines emit `[ok]` and the original `#126` fixtures
      still pass
- [ ] Pair-review by `agb-dev-codex-2` per AGENTS.md — orchestrator
      will dispatch after PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)