### PR TITLE
fix(isolate): trust controller-managed per-UID manifest in plugin status (#346)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3422,6 +3422,8 @@ bridge_agent_channel_status() {
 bridge_claude_plugin_status() {
   local plugin_spec="$1"
   local registry="${BRIDGE_CLAUDE_INSTALLED_PLUGINS_FILE:-}"
+  local default_manifest=""
+  local manifest_owner=""
   local output=""
 
   if [[ -n "$registry" && -f "$registry" ]]; then
@@ -3443,6 +3445,47 @@ plugins = payload.get("plugins") or {}
 print("enabled" if spec in plugins else "missing")
 PY
     return 0
+  fi
+
+  # #346 isolate: when bridge-run.sh executes under an isolated linux-user
+  # UID and the per-UID installed_plugins.json is root-owned, that file
+  # was written by bridge_write_isolated_installed_plugins_manifest as the
+  # authoritative declared-plugin-only catalog. Trusting it here lets a
+  # third-party marketplace plugin (whose marketplace metadata is not
+  # exposed inside the isolated home) pass preflight without an install
+  # attempt that would otherwise crash bridge-run.sh and trigger a tmux
+  # respawn loop. Controller (non-root) UIDs do not match the
+  # owner==root guard, so the existing claude-plugin-list fallback
+  # remains in effect for the controller side.
+  default_manifest="${HOME:-}/.claude/plugins/installed_plugins.json"
+  if [[ -n "${HOME:-}" && "$(id -u 2>/dev/null || echo 0)" != "0" && -f "$default_manifest" ]]; then
+    manifest_owner="$(stat -c '%u' "$default_manifest" 2>/dev/null || echo -1)"
+    if [[ "$manifest_owner" == "0" ]]; then
+      bridge_require_python
+      python3 - "$default_manifest" "$plugin_spec" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+spec = sys.argv[2]
+try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+except Exception:
+    print("missing")
+    raise SystemExit(0)
+
+entries = (payload.get("plugins") or {}).get(spec) or []
+for entry in entries:
+    install_path = entry.get("installPath", "")
+    if install_path and os.access(install_path, os.R_OK | os.X_OK):
+        print("enabled")
+        raise SystemExit(0)
+print("missing")
+PY
+      return 0
+    fi
   fi
 
   if ! command -v claude >/dev/null 2>&1; then

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -141,6 +141,15 @@ cleanup() {
   if id "$TEST_OS_USER" >/dev/null 2>&1; then
     sudo -n setfacl -Rx "u:${TEST_OS_USER}" "$CONTROLLER_HOME_FAKE" >/dev/null 2>&1 || true
     sudo -n setfacl -Rx "u:${TEST_OS_USER}" "$BRIDGE_HOME/plugins" >/dev/null 2>&1 || true
+    # Strip the temporary repo-traverse ACL granted for the
+    # trust-controller-manifest assertion (#346 r2 fixture).
+    sudo -n setfacl -Rx "u:${TEST_OS_USER}" "$REPO_ROOT" >/dev/null 2>&1 || true
+    _ancestor_cleanup="$REPO_ROOT"
+    while [[ "$_ancestor_cleanup" != "/" && "$_ancestor_cleanup" != "/tmp" ]]; do
+      _ancestor_cleanup="$(dirname "$_ancestor_cleanup")"
+      [[ -d "$_ancestor_cleanup" ]] || break
+      sudo -n setfacl -x "u:${TEST_OS_USER}" "$_ancestor_cleanup" >/dev/null 2>&1 || true
+    done
   fi
   if [[ "$cleanup_test_user_locked" -eq 0 ]] && id "$TEST_OS_USER" >/dev/null 2>&1; then
     sudo -n userdel "$TEST_OS_USER" >/dev/null 2>&1 || true
@@ -284,6 +293,156 @@ data = json.load(sys.stdin)
 chans = data.get("channels", [])
 assert chans == ["plugin:declared-plugin@td-mkt"], f"unexpected persisted channels: {chans!r}"
 ' || die "persisted grant-set contents do not match"
+
+log "trust-controller-manifest short-circuit (#346 regression)"
+
+# Regression coverage for #346: when an isolated agent declares a plugin
+# from a third-party marketplace, the controller does not expose that
+# marketplace's metadata in known_marketplaces.json under the isolated
+# home (only the directory-source 'agent-bridge' marketplace and similar
+# vetted entries are passed through). bridge_claude_plugin_status must
+# therefore trust the controller-managed per-UID installed_plugins.json
+# as authoritative — otherwise bridge-run.sh:451 preflight would invoke
+# `claude plugin install`, which crashes inside the isolated UID and
+# triggers a tmux respawn loop. Verify the short-circuit fires AND no
+# `claude` shell-out happens for the third-party plugin id.
+
+THIRD_PLUGIN_ID="third-party-plugin@third-marketplace"
+mkdir -p "$BRIDGE_HOME/plugins/third-party-plugin"
+echo 'third-party plugin (dir-marketplace)' \
+  > "$BRIDGE_HOME/plugins/third-party-plugin/server.ts"
+chmod -R o+rX "$BRIDGE_HOME/plugins"
+
+# Add the third-party plugin entry to the controller's manifest with a
+# valid installPath, but DO NOT add 'third-marketplace' to
+# known_marketplaces.json — that's the whole point of #346.
+python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$BRIDGE_HOME/plugins/third-party-plugin" <<'PY'
+import json, sys
+manifest_path, install_path = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["third-party-plugin@third-marketplace"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": install_path}
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+
+# Sanity: confirm the marketplace metadata is intentionally absent.
+python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+assert "third-marketplace" not in data, \
+    f"test setup invariant broken: third-marketplace must not be in known_marketplaces.json"
+' "$CONTROLLER_PLUGINS/known_marketplaces.json" \
+  || die "test setup: third-marketplace unexpectedly present in known_marketplaces.json"
+
+# Re-issue the share with the augmented channel set so the per-UID
+# manifest picks up the third-party plugin.
+BRIDGE_AGENT_CHANNELS["$TEST_AGENT"]='plugin:declared-plugin@td-mkt,plugin:third-party-plugin@third-marketplace'
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+log "verifying per-UID manifest contains the third-party plugin entry"
+sudo -n cat "$ISOLATED_PLUGINS/installed_plugins.json" | python3 -c '
+import json, sys
+m = json.load(sys.stdin)
+plugins = m.get("plugins", {})
+assert "third-party-plugin@third-marketplace" in plugins, \
+    f"per-UID manifest missing third-party plugin: {sorted(plugins)!r}"
+entry = plugins["third-party-plugin@third-marketplace"][0]
+assert entry.get("installPath", "").endswith("/third-party-plugin"), \
+    f"unexpected installPath: {entry!r}"
+' || die "per-UID manifest does not include third-party plugin"
+
+log "verifying isolated UID's known_marketplaces.json hides 'third-marketplace'"
+sudo -n -u "$TEST_OS_USER" python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+assert "third-marketplace" not in data, \
+    f"isolation boundary broken: third-marketplace leaked into known_marketplaces.json visible to isolated UID"
+' "$ISOLATED_PLUGINS/known_marketplaces.json" \
+  || die "isolated UID can see third-marketplace metadata; expected hidden"
+
+# Stub `claude` so any accidental shell-out is observable. The short-
+# circuit path must NOT touch this stub; the negative case below MUST.
+STUB_DIR="$TMP_ROOT/stubs"
+STUB_LOG="$TMP_ROOT/claude-stub-calls.log"
+mkdir -p "$STUB_DIR"
+: > "$STUB_LOG"
+chmod 0777 "$STUB_LOG"          # writable by the isolated UID
+chmod 0755 "$STUB_DIR" "$TMP_ROOT"
+cat > "$STUB_DIR/claude" <<STUB
+#!/usr/bin/env bash
+echo "stub-claude-invoked: \$*" >> "$STUB_LOG"
+exit 0
+STUB
+chmod 0755 "$STUB_DIR/claude"
+
+# Grant the isolated UID r-x access to the source checkout so it can
+# source bridge-lib.sh from the test user's shell. setfacl is already a
+# hard prerequisite for this test; the cleanup hook strips the ACL.
+sudo -n setfacl -R -m "u:${TEST_OS_USER}:r-X" "$REPO_ROOT" \
+  || die "failed to grant r-X ACL on $REPO_ROOT to $TEST_OS_USER"
+# Traverse chain up to /tmp so the test user can reach the worktree.
+_ancestor="$REPO_ROOT"
+while [[ "$_ancestor" != "/" && "$_ancestor" != "/tmp" ]]; do
+  _ancestor="$(dirname "$_ancestor")"
+  [[ -d "$_ancestor" ]] || break
+  sudo -n setfacl -m "u:${TEST_OS_USER}:--x" "$_ancestor" >/dev/null 2>&1 || true
+done
+
+log "asserting bridge_ensure_claude_plugin_enabled short-circuits without invoking claude"
+sudo -n -u "$TEST_OS_USER" env \
+    HOME="$TEST_OS_HOME" \
+    PATH="$STUB_DIR:/usr/bin:/bin" \
+    REPO_ROOT="$REPO_ROOT" \
+    PLUGIN_SPEC="$THIRD_PLUGIN_ID" \
+    BRIDGE_HOME="$BRIDGE_HOME" \
+  bash -c '
+    set -euo pipefail
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/bridge-lib.sh"
+    status="$(bridge_claude_plugin_status "$PLUGIN_SPEC")"
+    if [[ "$status" != "enabled" ]]; then
+      echo "FAIL: expected enabled, got $status" >&2
+      exit 1
+    fi
+    bridge_ensure_claude_plugin_enabled "$PLUGIN_SPEC" >/dev/null
+  ' || die "bridge_ensure_claude_plugin_enabled did not short-circuit on third-party plugin"
+
+if [[ -s "$STUB_LOG" ]]; then
+  die "claude stub was invoked during short-circuit path; log: $(cat "$STUB_LOG")"
+fi
+
+log "asserting fall-through path still invokes claude when manifest is absent"
+# Negative case: when HOME has no per-UID root-owned manifest (shared-mode
+# semantics), bridge_claude_plugin_status falls through to `claude plugin
+# list`. Stub returns no matching status line so the function reports
+# "missing"; the key assertion is that the stub WAS called — proving the
+# short-circuit gate is correctly scoped to the isolated-UID/root-owned
+# manifest case.
+NEG_HOME="$TMP_ROOT/no-manifest-home"
+mkdir -p "$NEG_HOME"
+chmod 0755 "$NEG_HOME"
+: > "$STUB_LOG"
+neg_status="$(env HOME="$NEG_HOME" PATH="$STUB_DIR:$PATH" \
+  bash -c 'source "'"$REPO_ROOT"'/bridge-lib.sh"; bridge_claude_plugin_status "'"$THIRD_PLUGIN_ID"'"')"
+if [[ "$neg_status" == "enabled" ]]; then
+  die "negative case: expected fall-through to report 'missing', got '$neg_status'"
+fi
+if [[ ! -s "$STUB_LOG" ]]; then
+  die "negative case: claude stub was NOT invoked; short-circuit gate is too loose"
+fi
+
+# Drop the third-party plugin from the channel set so the existing
+# stale-ACL-revoke assertion below operates on the original baseline
+# (declared-plugin only -> replacement-plugin only).
+BRIDGE_AGENT_CHANNELS["$TEST_AGENT"]='plugin:declared-plugin@td-mkt'
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
 
 log "stale-ACL revoke on channel change (Blocking 1 regression)"
 


### PR DESCRIPTION
## Summary
- Lets `bridge_claude_plugin_status` recognize the controller-managed root-owned per-UID `installed_plugins.json` as authoritative when bridge-run.sh executes inside an isolated linux-user runtime, so a third-party marketplace plugin (whose marketplace metadata is intentionally not exposed inside the isolated home) passes preflight without an install attempt that would otherwise crash bridge-run.sh and trigger a tmux respawn loop.
- Closes the live-host respawn loop reproduced on v0.6.17 with a private `cosmax-marketplace` (described in #346).

## Why
Under linux-user isolation:
- `bridge_write_isolated_installed_plugins_manifest` writes a root-owned per-UID `installed_plugins.json` containing only the plugins declared in `BRIDGE_AGENT_CHANNELS`, with `installPath` resolved to the actually-existing controller cache (or directory marketplace) path.
- `bridge_linux_share_plugin_catalog` ACL-grants `r-X` on each declared `installPath` and the traverse chain.
- That manifest is supposed to be the authoritative declared-plugin-only catalog the runtime trusts.

But `bridge_ensure_claude_launch_channel_plugins` (called by bridge-run.sh under the isolated UID) calls `bridge_claude_plugin_status` for each declared plugin spec. The current implementation, when no test-mode override file is set, falls through to `claude plugin list` — which inside the isolated UID does not see plugins coming from a third-party marketplace because the isolated `~/.claude/plugins/marketplaces/<third-party>` is intentionally empty. Status returns `missing`, so `bridge_ensure_claude_plugin_enabled` runs `claude plugin install --scope user <plugin>@<third-party-marketplace>`, which fails with `Plugin not found in marketplace`. `bridge_die` then exits 1, the tmux session terminates, the daemon respawns it, and the loop repeats indefinitely.

## What this PR does
Extends `bridge_claude_plugin_status` to consult `$HOME/.claude/plugins/installed_plugins.json` when **all** of the following hold:
1. `BRIDGE_CLAUDE_INSTALLED_PLUGINS_FILE` (test override) is not set,
2. the current UID is not root (i.e. we are inside the isolated runtime via sudo, not the controller process),
3. the file exists,
4. the file owner is `root` (the v0.6.16+ ACL contract).

In that case, the function returns `enabled` if the manifest entry's `installPath` is readable + executable to the current UID, else `missing`. Test override keeps top precedence; controller-side behaviour is unchanged because the controller home's manifest is owned by the operator UID, not root.

## Diff scope
- `lib/bridge-agents.sh`: 43 lines added in `bridge_claude_plugin_status`, no removals.
- No changes to security model: declared-plugin-only contract, root-owned manifest, ACL-managed installPath read access — all preserved. We are not granting the isolated UID any marketplace fetch privilege; this is purely a preflight read of an already-controller-managed file.

## Test plan
- [x] `bash -n lib/bridge-agents.sh` syntax check
- [ ] `shellcheck lib/bridge-agents.sh` (host has no shellcheck installed; CI will cover)
- [ ] `./scripts/smoke-test.sh` (running locally; will report)
- [ ] live host verification on the v0.6.17 install where the bug was reproduced — apply the patched `lib/bridge-agents.sh`, declare the four plugins (`teams + ms365 + cosmax-ep-approval + cosmax-crm`) in `BRIDGE_AGENT_CHANNELS["sales_sean"]`, `agent-bridge isolate sales_sean --reapply`, `agent-bridge agent start sales_sean`, observe (a) no install attempt for cosmax plugins, (b) `Claude plugin ready: ...` for all four, (c) tmux session stable for >5min with no respawn, (d) ToolSearch lists the four plugins' MCP tools

## Backwards compatibility
- Test override (`BRIDGE_CLAUDE_INSTALLED_PLUGINS_FILE`) precedence preserved.
- Controller-side behaviour unchanged (manifest owner is the operator, not root, so the new branch is never taken).
- Pre-v0.6.16 isolated installs that don't have a root-owned per-UID manifest also fall through unchanged (`-f` and `owner==root` guards).

Refs: #346
