### PR TITLE
isolate: per-UID installed_plugins.json honors BRIDGE_AGENT_PLUGINS allowlist (#348)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1026,14 +1026,25 @@ bridge_linux_revoke_plugin_channel_grants() {
 
 bridge_write_isolated_installed_plugins_manifest() {
   # Write a per-isolated-UID installed_plugins.json containing only the
-  # plugins this agent declared in BRIDGE_AGENT_CHANNELS, with installPath
-  # rewritten to the actually-existing location resolved by
+  # plugins this agent declared via BRIDGE_AGENT_CHANNELS (transport
+  # plugins) and BRIDGE_AGENT_PLUGINS (#272 per-agent allowlist of
+  # non-channel domain plugins), with installPath rewritten to the
+  # actually-existing location resolved by
   # bridge_resolve_plugin_install_path. The file is owned by root so the
   # isolated UID cannot tamper with which plugins it loads.
+  #
+  # Arguments:
+  #   os_user             — isolated UID
+  #   isolated_plugins    — destination ~/.claude/plugins root for the UID
+  #   controller_plugins  — controller's ~/.claude/plugins (read-only source)
+  #   channels_csv        — CSV of `plugin:<id>` (and other) channel tokens
+  #   plugins_csv         — CSV of bare `<id>` (or `<id>@<mkt>`) tokens from
+  #                         BRIDGE_AGENT_PLUGINS["<agent>"]; may be empty.
   local os_user="$1"
   local isolated_plugins="$2"
   local controller_plugins="$3"
   local channels_csv="$4"
+  local plugins_csv="${5-}"
   local manifest="$isolated_plugins/installed_plugins.json"
   local manifest_tmp=""
 
@@ -1045,10 +1056,10 @@ bridge_write_isolated_installed_plugins_manifest() {
   # copy+unlink and a concurrent reader can see a half-written or
   # transiently missing manifest. (Blocking 2 in PR #302 r1.)
   manifest_tmp="$(bridge_linux_sudo_root mktemp "${manifest}.tmp.XXXXXX")"
-  if ! bridge_linux_sudo_root python3 - "$controller_plugins" "$channels_csv" "$manifest_tmp" <<'PY'
+  if ! bridge_linux_sudo_root python3 - "$controller_plugins" "$channels_csv" "$manifest_tmp" "$plugins_csv" <<'PY'
 import json, os, sys
 
-controller_plugins, channels_csv, out_path = sys.argv[1:]
+controller_plugins, channels_csv, out_path, plugins_csv = sys.argv[1:]
 controller_manifest = os.path.join(controller_plugins, "installed_plugins.json")
 markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
 
@@ -1135,6 +1146,18 @@ for chan in channels_csv.split(","):
     chan = chan.strip()
     if chan.startswith("plugin:"):
         declared.add(chan[len("plugin:"):])
+
+# BRIDGE_AGENT_PLUGINS allowlist (#272) — bare plugin ids, optionally
+# `<plugin>@<marketplace>`. Merged here so the isolated manifest covers
+# the union of channel-declared transport plugins AND domain plugins
+# the operator allowlisted per-agent. Dedupe via the shared `declared`
+# set so an entry that lives in both arrays appears once. (#348)
+for token in plugins_csv.split(","):
+    token = token.strip()
+    if token.startswith("plugin:"):
+        token = token[len("plugin:"):]
+    if token:
+        declared.add(token)
 
 out = {"version": source.get("version", 2), "plugins": {}}
 for plugin_id in sorted(declared):
@@ -1251,20 +1274,31 @@ bridge_linux_share_plugin_catalog() {
     bridge_linux_acl_add "u:${os_user}:r--" "$src"
   done
 
-  # 4. Per-UID installed_plugins.json — declared plugins only, real install paths.
+  # 4. Per-UID installed_plugins.json — declared plugins only (union of
+  #    BRIDGE_AGENT_CHANNELS plugin entries and BRIDGE_AGENT_PLUGINS allowlist
+  #    per #348 / #272), real install paths.
   local channels_csv=""
+  local plugins_csv=""
   channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
-  bridge_write_isolated_installed_plugins_manifest "$os_user" "$isolated_plugins" "$controller_plugins" "$channels_csv"
+  plugins_csv="$(bridge_agent_plugins_csv "$agent" 2>/dev/null || true)"
+  bridge_write_isolated_installed_plugins_manifest \
+    "$os_user" "$isolated_plugins" "$controller_plugins" \
+    "$channels_csv" "$plugins_csv"
 
   # 5. Compute the channel diff against the persisted grant set so we can
   #    revoke channels that were previously granted but are no longer in
-  #    the roster (Blocking 1 in PR #302 r1). Only entries with a
-  #    `plugin:` prefix participate; non-plugin channels are ignored on
-  #    both sides of the diff.
+  #    the roster (Blocking 1 in PR #302 r1). The "current" set is the
+  #    union of BRIDGE_AGENT_CHANNELS `plugin:<id>` tokens and
+  #    BRIDGE_AGENT_PLUGINS bare ids (#348). Allowlist entries are
+  #    promoted to `plugin:<id>` form here so they share the same
+  #    persisted-state shape and revoke pipeline as channel-declared
+  #    plugins. Non-plugin channel tokens are ignored on both sides.
   local prior_channels_csv=""
   prior_channels_csv="$(bridge_isolated_plugin_grants_read "$agent" 2>/dev/null || true)"
   local -a _current_plugin_channels=()
   local -a _prior_plugin_channels=()
+  local _seen_marker=$'\x1f'
+  local _seen=""
   if [[ -n "$channels_csv" ]]; then
     local _cur_split=()
     local _cur_chan=""
@@ -1272,7 +1306,27 @@ bridge_linux_share_plugin_catalog() {
     for _cur_chan in "${_cur_split[@]}"; do
       _cur_chan="${_cur_chan// /}"
       [[ "$_cur_chan" == plugin:* ]] || continue
+      case "$_seen" in
+        *"${_seen_marker}${_cur_chan}${_seen_marker}"*) continue ;;
+      esac
+      _seen="${_seen}${_seen_marker}${_cur_chan}${_seen_marker}"
       _current_plugin_channels+=("$_cur_chan")
+    done
+  fi
+  if [[ -n "$plugins_csv" ]]; then
+    local _plg_split=()
+    local _plg_token=""
+    local _plg_full=""
+    IFS=',' read -ra _plg_split <<<"$plugins_csv"
+    for _plg_token in "${_plg_split[@]}"; do
+      _plg_token="${_plg_token// /}"
+      [[ -n "$_plg_token" ]] || continue
+      _plg_full="plugin:${_plg_token}"
+      case "$_seen" in
+        *"${_seen_marker}${_plg_full}${_seen_marker}"*) continue ;;
+      esac
+      _seen="${_seen}${_seen_marker}${_plg_full}${_seen_marker}"
+      _current_plugin_channels+=("$_plg_full")
     done
   fi
   if [[ -n "$prior_channels_csv" ]]; then
@@ -1286,7 +1340,9 @@ bridge_linux_share_plugin_catalog() {
     done
   fi
 
-  # 5a. Revoke removed channels (in prior set but not in current set).
+  # 5a. Revoke removed entries (in prior set but not in current set).
+  #     This covers both channel removals and BRIDGE_AGENT_PLUGINS
+  #     removals — both are persisted in the same `plugin:<id>` form.
   local _prior_entry=""
   local _cur_entry=""
   local _found=0
@@ -1301,7 +1357,8 @@ bridge_linux_share_plugin_catalog() {
     fi
   done
 
-  # 5b. Grant current plugin channel install paths + traverse chain.
+  # 5b. Grant current plugin install paths + traverse chain (channel-declared
+  #     plus BRIDGE_AGENT_PLUGINS allowlist entries).
   local channel=""
   local plugin_id=""
   local install_path=""
@@ -1316,13 +1373,71 @@ bridge_linux_share_plugin_catalog() {
     bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$install_path"
   done
 
+  # 5b'. Marketplace symlinks (#348). For every union plugin in
+  #     `<plugin>@<marketplace>` form whose marketplace exists in the
+  #     controller's `~/.claude/plugins/marketplaces/<marketplace>` tree,
+  #     mirror the marketplace subtree under the isolated UID's plugins
+  #     root as a read-only symlink so Claude can resolve the marketplace
+  #     reference recorded in installed_plugins.json. Symlink + traverse +
+  #     recursive r-X mirrors the channel install-path pattern (5b).
+  local _isolated_marketplaces="$isolated_plugins/marketplaces"
+  local _marketplaces_root_created=0
+  local _mkt_seen=""
+  local _channel_full=""
+  local _mkt_id=""
+  local _mkt_src=""
+  local _mkt_dst=""
+  for _channel_full in "${_current_plugin_channels[@]+"${_current_plugin_channels[@]}"}"; do
+    plugin_id="${_channel_full#plugin:}"
+    [[ "$plugin_id" == *@* ]] || continue
+    _mkt_id="${plugin_id#*@}"
+    [[ -n "$_mkt_id" ]] || continue
+    case "$_mkt_seen" in
+      *"${_seen_marker}${_mkt_id}${_seen_marker}"*) continue ;;
+    esac
+    _mkt_seen="${_mkt_seen}${_seen_marker}${_mkt_id}${_seen_marker}"
+    _mkt_src="$controller_plugins/marketplaces/$_mkt_id"
+    [[ -d "$_mkt_src" ]] || continue
+    if (( _marketplaces_root_created == 0 )); then
+      bridge_linux_sudo_root mkdir -p "$_isolated_marketplaces"
+      bridge_linux_sudo_root chown root:root "$_isolated_marketplaces"
+      bridge_linux_sudo_root chmod 0750 "$_isolated_marketplaces"
+      bridge_linux_acl_add "u:${os_user}:r-x" "$_isolated_marketplaces"
+      _marketplaces_root_created=1
+    fi
+    _mkt_dst="$_isolated_marketplaces/$_mkt_id"
+    bridge_linux_sudo_root rm -f "$_mkt_dst" >/dev/null 2>&1 || true
+    bridge_linux_sudo_root ln -s "$_mkt_src" "$_mkt_dst"
+    bridge_linux_sudo_root chown -h root:root "$_mkt_dst" >/dev/null 2>&1 || true
+    # Same r-X chain as the install-path grant: traverse first so the
+    # mask doesn't end up `--x` on entries we then bump to r--/r-x.
+    bridge_linux_grant_traverse_chain "$os_user" "$_mkt_src" "$controller_home"
+    bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$_mkt_src"
+  done
+
   # 5c. Persist the new grant set so the next reapply / unisolate sees
-  #     exactly what we touched here.
+  #     exactly what we touched here. Persisted entries cover both the
+  #     channel-derived and BRIDGE_AGENT_PLUGINS-derived plugins (both
+  #     stored in `plugin:<id>` form), so the unisolate revoke loop in
+  #     bridge_migration_unisolate strips the union without further
+  #     wiring.
   local _persist_csv=""
   if [[ "${#_current_plugin_channels[@]}" -gt 0 ]]; then
     _persist_csv="$(IFS=','; printf '%s' "${_current_plugin_channels[*]}")"
   fi
   bridge_isolated_plugin_grants_write "$agent" "$_persist_csv"
+
+  # 5d. Audit row so operators can confirm exactly which plugins landed
+  #     on the isolated UID after each reapply (#348). The detail rows
+  #     carry the union list (channel + allowlist) and its size so a
+  #     follow-up `bridge-audit` query can surface domain-plugin
+  #     propagation gaps without a manual sudo into the UID's home.
+  local _audit_csv="$_persist_csv"
+  local _audit_count="${#_current_plugin_channels[@]}"
+  bridge_audit_log daemon isolated_plugin_manifest_written "$agent" \
+    --detail os_user="$os_user" \
+    --detail plugin_count="$_audit_count" \
+    --detail plugins="$_audit_csv" >/dev/null 2>&1 || true
 }
 
 bridge_linux_unshare_plugin_catalog() {
@@ -1360,6 +1475,20 @@ bridge_linux_unshare_plugin_catalog() {
     bridge_migration_print_step "$dry_run" "rm $manifest (per-UID installed_plugins.json)"
     if [[ "$dry_run" != "1" ]]; then
       bridge_linux_sudo_root rm -f "$manifest" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  # Marketplaces/ symlinks (#348) — created by share for plugins in
+  # `<plugin>@<marketplace>` form whose marketplace tree exists at the
+  # controller. Strip the symlinks the share path planted, then rmdir the
+  # marketplaces/ dir if it ends up empty so the outer rmdir below can
+  # also tear down plugins/. plugins/data/ remains untouched.
+  local isolated_marketplaces="$isolated_plugins/marketplaces"
+  if [[ -d "$isolated_marketplaces" || -L "$isolated_marketplaces" ]]; then
+    bridge_migration_print_step "$dry_run" "rm $isolated_marketplaces/* symlinks (isolated marketplace symlinks)"
+    if [[ "$dry_run" != "1" ]]; then
+      bridge_linux_sudo_root bash -c "shopt -s nullglob dotglob; for entry in \"$isolated_marketplaces\"/*; do [[ -L \"\$entry\" ]] && rm -f \"\$entry\"; done" >/dev/null 2>&1 || true
+      bridge_linux_sudo_root rmdir "$isolated_marketplaces" >/dev/null 2>&1 || true
     fi
   fi
 
@@ -2295,6 +2424,47 @@ bridge_agent_channels_csv() {
 bridge_agent_dev_channels_csv() {
   local agent="$1"
   bridge_filter_development_channels_csv "$(bridge_agent_channels_csv "$agent")"
+}
+
+bridge_agent_plugins_csv() {
+  # Emit the per-agent BRIDGE_AGENT_PLUGINS allowlist (#272) as a normalized
+  # CSV of plugin ids (no `plugin:` prefix). Tokens in the roster value may be
+  # space- or comma-separated and may carry an optional `plugin:` prefix; both
+  # forms are accepted and normalised here so isolation helpers can treat the
+  # output as a flat plugin-id list (`<plugin>` or `<plugin>@<marketplace>`).
+  # Returns the empty string when the entry is unset or contains no tokens.
+  local agent="$1"
+  local raw="${BRIDGE_AGENT_PLUGINS[$agent]-}"
+  [[ -n "$raw" ]] || { printf ''; return 0; }
+
+  local -a tokens=()
+  local seen_marker=$'\x1f'
+  local seen=""
+  local token=""
+  # shellcheck disable=SC2206 # split on whitespace+comma is intentional here.
+  local IFS_orig="$IFS"
+  IFS=$' \t\n,'
+  read -ra _split <<<"$raw"
+  IFS="$IFS_orig"
+  for token in "${_split[@]}"; do
+    token="${token## }"
+    token="${token%% }"
+    [[ -n "$token" ]] || continue
+    # Accept `plugin:<id>` and `<id>` interchangeably; normalise to `<id>`.
+    [[ "$token" == plugin:* ]] && token="${token#plugin:}"
+    [[ -n "$token" ]] || continue
+    case "$seen" in
+      *"${seen_marker}${token}${seen_marker}"*) continue ;;
+    esac
+    seen="${seen}${seen_marker}${token}${seen_marker}"
+    tokens+=("$token")
+  done
+
+  if (( ${#tokens[@]} == 0 )); then
+    printf ''
+    return 0
+  fi
+  (IFS=','; printf '%s' "${tokens[*]}")
 }
 
 bridge_agent_auto_accept_dev_channels_csv() {

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -926,6 +926,87 @@ print(resolved or "")
 PY
 }
 
+bridge_known_marketplaces_lookup() {
+  # Inspect `known_marketplaces.json` and return whether a marketplace is
+  # registered. Mirrors the lookup shape used by the manifest writer's
+  # `:1092` block (and the directory-source fallback at `:894` in
+  # bridge_resolve_plugin_install_path) so the symlink path in
+  # bridge_linux_share_plugin_catalog gates on the same source-of-truth.
+  #
+  # Output protocol — exactly one line:
+  #   present:directory   — registered with a directory source
+  #   present:git         — registered with a git source
+  #   present:other       — registered with another source kind (http, etc.)
+  #   missing             — not registered (caller should silently skip)
+  #   unparseable         — JSON missing / unreadable / not an object
+  #                         (caller should warn-and-skip the whole 5b'
+  #                          block; this helper has already logged the
+  #                          warning to stderr).
+  #
+  # The `<source-kind>` half of `present:*` is informational — current
+  # callers symlink `<plugins_root>/marketplaces/<mkt>` regardless of
+  # source kind because that mirror tree is what Claude actually reads
+  # at runtime; the source-kind disclosure exists so a future caller
+  # that wants to special-case directory vs git can do so without
+  # re-parsing the JSON. (#348 r2.)
+  local marketplace_id="$1"
+  local plugins_root="$2"
+  local marketplaces_json="$plugins_root/known_marketplaces.json"
+
+  bridge_require_python
+  python3 - "$marketplace_id" "$marketplaces_json" <<'PY'
+import json, os, sys
+
+marketplace_id = sys.argv[1]
+marketplaces_path = sys.argv[2]
+
+
+def warn(msg):
+    sys.stderr.write("[bridge-isolate] " + msg + "\n")
+
+
+if not os.path.isfile(marketplaces_path):
+    # Treat missing as unparseable for caller-side simplicity: the
+    # whole 5b' block is a no-op without it. Mirrors the manifest
+    # writer's behaviour (it also short-circuits the directory-
+    # marketplace fallback when the JSON is absent).
+    print("unparseable")
+    sys.exit(0)
+
+try:
+    with open(marketplaces_path) as f:
+        markets = json.load(f)
+    if not isinstance(markets, dict):
+        raise ValueError("expected JSON object at root, got %r" % type(markets).__name__)
+except (OSError, ValueError) as exc:
+    # Mirror the manifest writer's :1092 pattern: log once and let
+    # the caller skip the marketplace symlink path entirely. This
+    # is informational, not fatal — isolation refresh continues.
+    warn(
+        "controller known_marketplaces.json unparseable (%s): %s — marketplace symlinks disabled this pass"
+        % (type(exc).__name__, marketplaces_path)
+    )
+    print("unparseable")
+    sys.exit(0)
+
+entry = markets.get(marketplace_id)
+if not isinstance(entry, dict):
+    print("missing")
+    sys.exit(0)
+
+src = entry.get("source")
+if isinstance(src, dict):
+    kind = src.get("source")
+    if kind == "directory":
+        print("present:directory")
+        sys.exit(0)
+    if kind == "git":
+        print("present:git")
+        sys.exit(0)
+print("present:other")
+PY
+}
+
 bridge_isolated_plugin_grants_state_file() {
   # State file recording the channel set last granted plugin-share ACLs to
   # an isolated agent. Lives under $BRIDGE_ACTIVE_AGENT_DIR/<agent>/ — the
@@ -1374,12 +1455,19 @@ bridge_linux_share_plugin_catalog() {
   done
 
   # 5b'. Marketplace symlinks (#348). For every union plugin in
-  #     `<plugin>@<marketplace>` form whose marketplace exists in the
-  #     controller's `~/.claude/plugins/marketplaces/<marketplace>` tree,
-  #     mirror the marketplace subtree under the isolated UID's plugins
-  #     root as a read-only symlink so Claude can resolve the marketplace
-  #     reference recorded in installed_plugins.json. Symlink + traverse +
-  #     recursive r-X mirrors the channel install-path pattern (5b).
+  #     `<plugin>@<marketplace>` form whose marketplace is registered
+  #     in the controller's `known_marketplaces.json` AND whose mirror
+  #     tree exists at `~/.claude/plugins/marketplaces/<marketplace>`,
+  #     plant a read-only symlink under the isolated UID's plugins root
+  #     so Claude can resolve the marketplace reference recorded in
+  #     installed_plugins.json. The `known_marketplaces.json` lookup is
+  #     the source-of-truth gate (matches the issue spec wording and the
+  #     manifest writer's :1092 / `:894` directory-source fallback);
+  #     the on-disk `marketplaces/<mkt>` dir is the symlink target, so
+  #     git-source marketplaces whose tree has not been cached yet
+  #     silently skip rather than synthesising a broken symlink.
+  #     Symlink + traverse + recursive r-X mirrors the channel install-
+  #     path pattern (5b). (#348 r2.)
   local _isolated_marketplaces="$isolated_plugins/marketplaces"
   local _marketplaces_root_created=0
   local _mkt_seen=""
@@ -1387,7 +1475,10 @@ bridge_linux_share_plugin_catalog() {
   local _mkt_id=""
   local _mkt_src=""
   local _mkt_dst=""
+  local _mkt_lookup=""
+  local _mkt_block_disabled=0
   for _channel_full in "${_current_plugin_channels[@]+"${_current_plugin_channels[@]}"}"; do
+    (( _mkt_block_disabled == 0 )) || break
     plugin_id="${_channel_full#plugin:}"
     [[ "$plugin_id" == *@* ]] || continue
     _mkt_id="${plugin_id#*@}"
@@ -1396,7 +1487,29 @@ bridge_linux_share_plugin_catalog() {
       *"${_seen_marker}${_mkt_id}${_seen_marker}"*) continue ;;
     esac
     _mkt_seen="${_mkt_seen}${_seen_marker}${_mkt_id}${_seen_marker}"
+    # Source-of-truth gate: marketplace must be registered in
+    # known_marketplaces.json. The helper warns once (and we abandon
+    # the whole 5b' block) when the JSON is missing/unparseable —
+    # same shape the manifest writer uses at :1092.
+    _mkt_lookup="$(bridge_known_marketplaces_lookup "$_mkt_id" "$controller_plugins")"
+    case "$_mkt_lookup" in
+      unparseable)
+        _mkt_block_disabled=1
+        break
+        ;;
+      missing|"")
+        # marketplace not registered → silent skip, no broken symlink.
+        continue
+        ;;
+      present:*) ;;  # fall through to the symlink path
+      *) continue ;;
+    esac
     _mkt_src="$controller_plugins/marketplaces/$_mkt_id"
+    # Even when known_marketplaces.json carries an entry, the on-disk
+    # mirror tree may not yet exist (common for git-source marketplaces
+    # on a fresh checkout, or directory-source marketplaces whose cache
+    # has been pruned). Skip silently rather than creating a dangling
+    # symlink — the issue spec calls this out as the expected shape.
     [[ -d "$_mkt_src" ]] || continue
     if (( _marketplaces_root_created == 0 )); then
       bridge_linux_sudo_root mkdir -p "$_isolated_marketplaces"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -939,9 +939,11 @@ bridge_known_marketplaces_lookup() {
   #   present:other       — registered with another source kind (http, etc.)
   #   missing             — not registered (caller should silently skip)
   #   unparseable         — JSON missing / unreadable / not an object
-  #                         (caller should warn-and-skip the whole 5b'
-  #                          block; this helper has already logged the
-  #                          warning to stderr).
+  #                         (caller should skip the whole 5b' block;
+  #                          this helper stays silent because the
+  #                          manifest writer at :1183 already emitted
+  #                          the canonical warning earlier in the same
+  #                          share pass — see #348 r3).
   #
   # The `<source-kind>` half of `present:*` is informational — current
   # callers symlink `<plugins_root>/marketplaces/<mkt>` regardless of
@@ -961,10 +963,6 @@ marketplace_id = sys.argv[1]
 marketplaces_path = sys.argv[2]
 
 
-def warn(msg):
-    sys.stderr.write("[bridge-isolate] " + msg + "\n")
-
-
 if not os.path.isfile(marketplaces_path):
     # Treat missing as unparseable for caller-side simplicity: the
     # whole 5b' block is a no-op without it. Mirrors the manifest
@@ -978,14 +976,18 @@ try:
         markets = json.load(f)
     if not isinstance(markets, dict):
         raise ValueError("expected JSON object at root, got %r" % type(markets).__name__)
-except (OSError, ValueError) as exc:
-    # Mirror the manifest writer's :1092 pattern: log once and let
-    # the caller skip the marketplace symlink path entirely. This
-    # is informational, not fatal — isolation refresh continues.
-    warn(
-        "controller known_marketplaces.json unparseable (%s): %s — marketplace symlinks disabled this pass"
-        % (type(exc).__name__, marketplaces_path)
-    )
+except (OSError, ValueError):
+    # Stay silent on the corrupt-JSON branch: the manifest writer
+    # (`bridge_write_isolated_installed_plugins_manifest`, step 4 of
+    # bridge_linux_share_plugin_catalog) always runs before this
+    # helper (step 5b') and already emitted the canonical
+    # `[bridge-isolate] controller known_marketplaces.json unparseable …`
+    # warning at :1183-1186 for the same file. Re-emitting here would
+    # log the same condition twice (once per share pass, plus once per
+    # `_mkt_id` iteration before the 5b' loop short-circuits on
+    # `unparseable`). Returning `unparseable` is sufficient — the
+    # caller's `case` arm sets `_mkt_block_disabled=1` and skips the
+    # symlink path silently. (#348 r3.)
     print("unparseable")
     sys.exit(0)
 
@@ -1488,9 +1490,11 @@ bridge_linux_share_plugin_catalog() {
     esac
     _mkt_seen="${_mkt_seen}${_seen_marker}${_mkt_id}${_seen_marker}"
     # Source-of-truth gate: marketplace must be registered in
-    # known_marketplaces.json. The helper warns once (and we abandon
-    # the whole 5b' block) when the JSON is missing/unparseable —
-    # same shape the manifest writer uses at :1092.
+    # known_marketplaces.json. On `unparseable` we abandon the whole
+    # 5b' block; the manifest writer at :1183-1186 already logged the
+    # canonical warning earlier in the same share pass, so the helper
+    # itself stays silent (no duplicate stderr line per share pass —
+    # #348 r3).
     _mkt_lookup="$(bridge_known_marketplaces_lookup "$_mkt_id" "$controller_plugins")"
     case "$_mkt_lookup" in
       unparseable)

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -285,6 +285,162 @@ chans = data.get("channels", [])
 assert chans == ["plugin:declared-plugin@td-mkt"], f"unexpected persisted channels: {chans!r}"
 ' || die "persisted grant-set contents do not match"
 
+log "BRIDGE_AGENT_PLUGINS allowlist propagates into isolated manifest (#348)"
+
+# Phase: with the channel set already granted (declared-plugin@td-mkt),
+# add a non-channel domain plugin via BRIDGE_AGENT_PLUGINS["<agent>"].
+# That allowlist (#272) was previously invisible to
+# bridge_write_isolated_installed_plugins_manifest /
+# bridge_linux_share_plugin_catalog (#348). The reapply below should now:
+#   - merge `allowlisted-plugin@allowlist-mkt` into the isolated
+#     installed_plugins.json (union with channel-declared plugins),
+#   - grant u:<os_user>:r-X to the allowlisted plugin's install path,
+#   - symlink marketplaces/allowlist-mkt under the isolated plugins root,
+#   - emit an `isolated_plugin_manifest_written` audit row carrying both
+#     plugin ids.
+mkdir -p "$CONTROLLER_PLUGINS/cache/allowlist-mkt/allowlisted-plugin/0.1.0" \
+         "$CONTROLLER_PLUGINS/marketplaces/allowlist-mkt"
+echo 'allowlisted plugin source (cache)' \
+  > "$CONTROLLER_PLUGINS/cache/allowlist-mkt/allowlisted-plugin/0.1.0/index.js"
+echo '{"name":"allowlist-mkt","plugins":["allowlisted-plugin"]}' \
+  > "$CONTROLLER_PLUGINS/marketplaces/allowlist-mkt/marketplace.json"
+mkdir -p "$BRIDGE_HOME/plugins/allowlisted-plugin"
+echo 'allowlisted plugin (dir-marketplace)' \
+  > "$BRIDGE_HOME/plugins/allowlisted-plugin/server.ts"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
+
+python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$BRIDGE_HOME/plugins/allowlisted-plugin" <<'PY'
+import json, sys
+manifest_path, install_path = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["allowlisted-plugin@allowlist-mkt"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": install_path}
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+
+# known_marketplaces.json needs the allowlist-mkt entry so
+# bridge_resolve_plugin_install_path's directory-marketplace fallback
+# path is exercised the same way as td-mkt.
+python3 - "$CONTROLLER_PLUGINS/known_marketplaces.json" "$BRIDGE_HOME" <<'PY'
+import json, sys
+markets_path, bridge_home = sys.argv[1], sys.argv[2]
+with open(markets_path) as f:
+    data = json.load(f)
+data["allowlist-mkt"] = {
+    "source": {"source": "directory", "path": bridge_home},
+    "installLocation": bridge_home,
+}
+with open(markets_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+
+# Roster declares the allowlist alongside the existing channel; both
+# tokens should land in the isolated manifest after the reapply.
+BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]='allowlisted-plugin@allowlist-mkt'
+
+# Truncate the audit log so the post-reapply assertion does not match
+# audit rows produced by the earlier share-call. The default location
+# is $BRIDGE_LOG_DIR/audit.jsonl per bridge_load_roster's defaulting.
+audit_log_file="${BRIDGE_AUDIT_LOG:-$BRIDGE_LOG_DIR/audit.jsonl}"
+mkdir -p "$(dirname "$audit_log_file")"
+: > "$audit_log_file"
+
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+log "verifying per-UID manifest now lists union of channel + allowlist plugins"
+sudo -n cat "$ISOLATED_PLUGINS/installed_plugins.json" | python3 -c '
+import json, sys
+m = json.load(sys.stdin)
+plugins = sorted(m.get("plugins", {}).keys())
+expected = ["allowlisted-plugin@allowlist-mkt", "declared-plugin@td-mkt"]
+assert plugins == expected, f"unexpected manifest plugins: {plugins!r} (expected {expected!r})"
+for pid in expected:
+    entry = m["plugins"][pid][0]
+    assert "installPath" in entry and entry["installPath"], f"missing installPath for {pid}"
+' || die "per-UID manifest did not include BRIDGE_AGENT_PLUGINS allowlist entry (#348)"
+
+log "verifying allowlisted plugin's install path has u:${TEST_OS_USER}:r-X recursively"
+allowlisted_path="$BRIDGE_HOME/plugins/allowlisted-plugin"
+sudo -n getfacl --no-effective "$allowlisted_path" 2>/dev/null \
+  | grep -Eq "^user:${TEST_OS_USER}:r(-x|wx)" \
+  || die "allowlisted plugin dir missing u:${TEST_OS_USER}:r-x ACL ($allowlisted_path)"
+sudo -n getfacl --no-effective "$allowlisted_path/server.ts" 2>/dev/null \
+  | grep -Eq "^user:${TEST_OS_USER}:r--" \
+  || die "allowlisted plugin file missing u:${TEST_OS_USER}:r-- ACL"
+
+log "verifying isolated UID can read allowlisted plugin sources"
+sudo -n -u "$TEST_OS_USER" cat "$allowlisted_path/server.ts" >/dev/null \
+  || die "isolated UID should be able to read allowlisted plugin source"
+
+log "verifying marketplaces/allowlist-mkt symlink landed under isolated plugins root"
+allowlisted_mkt_link="$ISOLATED_PLUGINS/marketplaces/allowlist-mkt"
+sudo -n test -L "$allowlisted_mkt_link" \
+  || die "expected $allowlisted_mkt_link to be a symlink"
+allowlisted_mkt_resolved="$(sudo -n readlink -f "$allowlisted_mkt_link" 2>/dev/null || true)"
+allowlisted_mkt_expected="$CONTROLLER_PLUGINS/marketplaces/allowlist-mkt"
+[[ "$allowlisted_mkt_resolved" == "$allowlisted_mkt_expected" ]] \
+  || die "marketplace symlink resolved to $allowlisted_mkt_resolved (expected $allowlisted_mkt_expected)"
+sudo -n -u "$TEST_OS_USER" cat "$allowlisted_mkt_expected/marketplace.json" >/dev/null \
+  || die "isolated UID should be able to read allowlisted marketplace metadata"
+
+log "verifying persisted grant-set carries union (allowlist promoted to plugin:<id>)"
+sudo -n cat "$state_file" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+chans = sorted(data.get("channels", []))
+expected = ["plugin:allowlisted-plugin@allowlist-mkt", "plugin:declared-plugin@td-mkt"]
+assert chans == expected, f"unexpected persisted channels: {chans!r} (expected {expected!r})"
+' || die "persisted grant-set did not include BRIDGE_AGENT_PLUGINS allowlist entry (#348)"
+
+log "verifying isolated_plugin_manifest_written audit row carries both plugin ids"
+python3 - "$audit_log_file" "$TEST_AGENT" "$TEST_OS_USER" <<'PY' \
+  || die "isolated_plugin_manifest_written audit row missing or malformed"
+import json, sys
+path, agent, os_user = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as f:
+    rows = [json.loads(line) for line in f if line.strip()]
+matches = [
+    r for r in rows
+    if r.get("action") == "isolated_plugin_manifest_written" and r.get("target") == agent
+]
+assert matches, f"no isolated_plugin_manifest_written rows for {agent} in {path}"
+row = matches[-1]
+detail = row.get("detail", {})
+assert detail.get("os_user") == os_user, f"unexpected os_user: {detail!r}"
+plugins_csv = detail.get("plugins") or ""
+ids = sorted(filter(None, plugins_csv.split(",")))
+expected = sorted([
+    "plugin:allowlisted-plugin@allowlist-mkt",
+    "plugin:declared-plugin@td-mkt",
+])
+assert ids == expected, f"audit plugins mismatch: {ids!r} (expected {expected!r})"
+count = detail.get("plugin_count")
+# plugin_count is recorded as a string by bridge-audit.py's --detail
+# normaliser (everything goes through ensure_ascii=True/json.dumps with
+# the value as-is — bash always passes it as a string).
+assert str(count) == str(len(expected)), f"plugin_count mismatch: {count!r}"
+PY
+
+# Reset BRIDGE_AGENT_PLUGINS so the existing channel-flip phase below
+# runs in its original shape (channel-only) and the prior assertions
+# stay semantically unchanged.
+unset 'BRIDGE_AGENT_PLUGINS[$TEST_AGENT]'
+
+# Re-apply once with the allowlist removed so the persisted grant set
+# returns to channel-only state before the channel-flip phase.
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+log "verifying allowlist removal revoked ACLs on the allowlisted plugin"
+post_revoke_count="$(sudo -n getfacl --no-effective "$allowlisted_path" 2>/dev/null \
+  | grep -cE "^user:${TEST_OS_USER}:" || true)"
+[[ "$post_revoke_count" == "0" ]] \
+  || die "expected u:${TEST_OS_USER} ACL gone from allowlisted plugin after allowlist removal; still has $post_revoke_count"
+
 log "stale-ACL revoke on channel change (Blocking 1 regression)"
 
 # At this point declared-plugin@td-mkt has been granted (line ~195 above).

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -425,6 +425,82 @@ count = detail.get("plugin_count")
 assert str(count) == str(len(expected)), f"plugin_count mismatch: {count!r}"
 PY
 
+log "marketplace symlink path now gates on known_marketplaces.json (#348 r2)"
+
+# r2 changed the 5b' marketplace-symlink loop from a directory-existence
+# gate (was: `[[ -d "$controller_plugins/marketplaces/$mkt" ]]`) to an
+# explicit `known_marketplaces.json` lookup. Exercise that gate by
+# adding a BRIDGE_AGENT_PLUGINS entry whose marketplace is *not*
+# registered in known_marketplaces.json. The plugin should still land
+# in the union manifest + audit row, but no marketplace symlink should
+# be created (and no error should bubble up).
+mkdir -p "$BRIDGE_HOME/plugins/unregistered-plugin"
+echo 'unregistered plugin (no known_marketplaces entry)' \
+  > "$BRIDGE_HOME/plugins/unregistered-plugin/server.ts"
+# Materialise the on-disk mirror tree so the OLD directory-existence
+# gate would have happily symlinked it. The r2 gate must skip it
+# anyway because `unregistered-mkt` is missing from the JSON — that's
+# the regression this assertion guards against.
+mkdir -p "$CONTROLLER_PLUGINS/marketplaces/unregistered-mkt"
+echo '{"name":"unregistered-mkt","plugins":["unregistered-plugin"]}' \
+  > "$CONTROLLER_PLUGINS/marketplaces/unregistered-mkt/marketplace.json"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
+
+python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$BRIDGE_HOME/plugins/unregistered-plugin" <<'PY'
+import json, sys
+manifest_path, install_path = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["unregistered-plugin@unregistered-mkt"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": install_path}
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+
+# Allowlist both the original allowlist-mkt entry (registered with a
+# directory source) and the new unregistered-mkt entry — only the
+# former should produce a marketplace symlink after the r2 gate.
+BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]='allowlisted-plugin@allowlist-mkt,unregistered-plugin@unregistered-mkt'
+
+: > "$audit_log_file"
+
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+log "verifying unregistered-mkt symlink was NOT created (known_marketplaces.json gate)"
+unregistered_mkt_link="$ISOLATED_PLUGINS/marketplaces/unregistered-mkt"
+if sudo -n test -e "$unregistered_mkt_link" 2>/dev/null; then
+  die "expected NO symlink at $unregistered_mkt_link (marketplace absent from known_marketplaces.json)"
+fi
+
+log "verifying allowlist-mkt symlink still landed (registered marketplace path)"
+sudo -n test -L "$ISOLATED_PLUGINS/marketplaces/allowlist-mkt" \
+  || die "expected allowlist-mkt symlink to remain after r2 gate"
+
+log "verifying audit row still carries the unregistered-mkt plugin id"
+python3 - "$audit_log_file" "$TEST_AGENT" <<'PY' \
+  || die "audit row missing unregistered-mkt plugin after known_marketplaces.json gate"
+import json, sys
+path, agent = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    rows = [json.loads(line) for line in f if line.strip()]
+matches = [
+    r for r in rows
+    if r.get("action") == "isolated_plugin_manifest_written" and r.get("target") == agent
+]
+assert matches, f"no isolated_plugin_manifest_written rows for {agent}"
+detail = matches[-1].get("detail", {})
+plugins_csv = detail.get("plugins") or ""
+ids = set(filter(None, plugins_csv.split(",")))
+# The plugin id must still be in the union — only the marketplace
+# symlink is gated on known_marketplaces.json; the manifest + audit
+# union is independent.
+assert "plugin:unregistered-plugin@unregistered-mkt" in ids, (
+    f"unregistered plugin missing from audit union: {ids!r}"
+)
+PY
+
 # Reset BRIDGE_AGENT_PLUGINS so the existing channel-flip phase below
 # runs in its original shape (channel-only) and the prior assertions
 # stay semantically unchanged.


### PR DESCRIPTION
## Summary

`bridge_write_isolated_installed_plugins_manifest` and `bridge_linux_share_plugin_catalog` (`lib/bridge-agents.sh`) only consumed `BRIDGE_AGENT_CHANNELS`, so the v0.6.16 `BRIDGE_AGENT_PLUGINS` per-agent allowlist (#272) silently dropped out of the per-UID manifest and the read-only catalog ACL chain. Domain plugins (cosmax-* MCP servers, internal marketplace tools) declared via the allowlist were invisible to isolated agents — the agents themselves filed STALL/PICKER tasks because the plugins looked uninstalled from inside the isolated UID.

Both helpers now consume the **union** of:
- `BRIDGE_AGENT_CHANNELS["<agent>"]` plugin entries (current behavior), and
- `BRIDGE_AGENT_PLUGINS["<agent>"]` bare plugin ids (#272), normalised through a new `bridge_agent_plugins_csv` helper.

For union entries in `<plugin>@<mkt>` form whose marketplace tree exists at the controller, a read-only symlink + recursive r-X ACL chain is also planted under the isolated UID's `~/.claude/plugins/marketplaces/<mkt>/` so Claude can resolve the marketplace reference recorded in `installed_plugins.json`. Allowlist-only entries are promoted to `plugin:<id>` form before persistence so `bridge_migration_unisolate`'s existing revoke loop strips them on teardown without further wiring. An `isolated_plugin_manifest_written` audit row is emitted on each reapply with the union list and isolated `os_user`, so operators can confirm domain plugins landed without `sudo`-ing into the UID. (#348)

## Files

- `lib/bridge-agents.sh`
  - new helper: `bridge_agent_plugins_csv` (next to `bridge_agent_channels_csv`).
  - `bridge_write_isolated_installed_plugins_manifest`: 5th `plugins_csv` arg, merged into the python `declared` set with dedupe.
  - `bridge_linux_share_plugin_catalog`: builds the union, drives manifest writer + ACL loop + persisted grants off the union, plants `marketplaces/<mkt>` symlinks for union plugins with `<plugin>@<mkt>` form, emits the audit row.
  - `bridge_linux_unshare_plugin_catalog`: removes the new `marketplaces/` symlinks during isolated-side cleanup so the empty-`plugins/` rmdir guard still fires.
- `tests/isolation-plugin-sharing.sh`: new fixture phase exercising BRIDGE_AGENT_PLUGINS — asserts (1) per-UID manifest contains both channel + allowlist plugins, (2) ACL on allowlist install path, (3) marketplace symlink resolves to controller tree, (4) persisted grant-set carries the union in `plugin:<id>` form, (5) audit row records both ids, (6) removing the allowlist value revokes the allowlist plugin's ACLs (regression guard against stuck grants).

## Test plan

- [x] `bash -n lib/bridge-agents.sh tests/isolation-plugin-sharing.sh`
- [x] `shellcheck lib/bridge-agents.sh tests/isolation-plugin-sharing.sh`
- [x] `bridge_agent_plugins_csv` unit-exercised in an isolated bash 5 driver: dedupe across `plugin:<id>`/bare-id forms, space + comma split, empty roster value handled.
- [x] manifest python merge unit-exercised in a temp tree: union of channel + allowlist plugin ids resolved through the existing resolve()/skip pipeline; non-resolvable entries skipped silently.
- [ ] `tests/isolation-plugin-sharing.sh` (Linux + passwordless sudo + setfacl + useradd) — `bash -n`/`shellcheck` clean here; the test self-skips on macOS so live execution requires a Linux host with the existing prereqs.
- [ ] `./scripts/smoke-test.sh` — `[smoke] starting isolated tmux role` failure reproduces on `main` HEAD without any edits and is pre-existing (not caused by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)