### PR TITLE
escalate: skip admin relay for dynamic agents (#343 Track A)

### DIFF
--- a/bridge-escalate.sh
+++ b/bridge-escalate.sh
@@ -69,6 +69,8 @@ cmd_question() {
   local wait_seconds=""
   local dry_run=0
   local json_mode=0
+  local force_admin_relay=0
+  local agent_source=""
   local admin_agent=""
   local title=""
   local now_iso=""
@@ -122,6 +124,13 @@ cmd_question() {
         json_mode=1
         shift
         ;;
+      --force-admin-relay)
+        # Explicit opt-in: relay through admin even when the calling agent is
+        # dynamic. Default off so a dynamic agent whose operator is in its TUI
+        # does not produce a wasted admin nudge (#343 Track A).
+        force_admin_relay=1
+        shift
+        ;;
       -h|--help)
         usage
         exit 0
@@ -135,6 +144,17 @@ cmd_question() {
   [[ -n "$agent" ]] || bridge_die "--agent는 필수입니다."
   [[ -n "$question" ]] || bridge_die "--question은 필수입니다."
   bridge_require_agent "$agent"
+
+  agent_source="$(bridge_agent_source "$agent")"
+  if [[ "$agent_source" == "dynamic" && "$force_admin_relay" -ne 1 ]]; then
+    # Dynamic agents have direct operator attachment in their own TUI; the
+    # agent's own conversation is the human-facing channel for this question.
+    # Refuse to escalate (exit 0 — the call succeeded by deciding "no
+    # escalation needed"). Use --force-admin-relay to override.
+    printf 'agent-bridge: skipping admin escalation — "%s" is a dynamic agent. The operator should answer in the agent'\''s TUI directly. No queue task created. Use --force-admin-relay to override.\n' "$agent" >&2
+    exit 0
+  fi
+
   admin_agent="$(bridge_require_admin_agent)"
   [[ "$admin_agent" != "$agent" ]] || bridge_die "질문 에스컬레이션은 관리자 자신이 아닌 다른 에이전트에서만 사용하세요."
   [[ -n "$session" ]] || session="$(bridge_agent_session "$agent")"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5578,6 +5578,46 @@ assert payload["notify"]["status"] == "sent"
 PY
 assert_contains "$(cat "$FAKE_DISCORD_REQUESTS")" "Should I deploy now?"
 
+log "verifying escalate question source-aware routing for dynamic agents (#343 Track A)"
+ESCALATE_DYNAMIC_AGENT="escalate-dynamic-$$"
+cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+
+# BEGIN AGENT BRIDGE MANAGED ROLE: $ESCALATE_DYNAMIC_AGENT
+bridge_add_agent_id_if_missing "$ESCALATE_DYNAMIC_AGENT"
+BRIDGE_AGENT_DESC["$ESCALATE_DYNAMIC_AGENT"]="Dynamic escalate fixture"
+BRIDGE_AGENT_ENGINE["$ESCALATE_DYNAMIC_AGENT"]="claude"
+BRIDGE_AGENT_SESSION["$ESCALATE_DYNAMIC_AGENT"]="$ESCALATE_DYNAMIC_AGENT"
+BRIDGE_AGENT_WORKDIR["$ESCALATE_DYNAMIC_AGENT"]="$PROJECT_ROOT"
+BRIDGE_AGENT_SOURCE["$ESCALATE_DYNAMIC_AGENT"]="dynamic"
+# END AGENT BRIDGE MANAGED ROLE: $ESCALATE_DYNAMIC_AGENT
+EOF
+smoke_track_managed_role_id "$ESCALATE_DYNAMIC_AGENT"
+
+ESCALATE_DYNAMIC_STDERR="$TMP_ROOT/escalate-dynamic.stderr"
+set +e
+"$REPO_ROOT/agent-bridge" escalate question --agent "$ESCALATE_DYNAMIC_AGENT" --question "Should I deploy now?" --wait-seconds 30 2>"$ESCALATE_DYNAMIC_STDERR" >/dev/null
+ESCALATE_DYNAMIC_RC=$?
+set -e
+[[ "$ESCALATE_DYNAMIC_RC" == "0" ]] || die "dynamic escalate should exit 0 (got $ESCALATE_DYNAMIC_RC)"
+assert_contains "$(cat "$ESCALATE_DYNAMIC_STDERR")" "skipping admin escalation"
+assert_contains "$(cat "$ESCALATE_DYNAMIC_STDERR")" "$ESCALATE_DYNAMIC_AGENT"
+ESCALATE_DYNAMIC_TASK_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[question-escalation] $ESCALATE_DYNAMIC_AGENT " 2>/dev/null || true)"
+[[ -z "$ESCALATE_DYNAMIC_TASK_ID" ]] || die "dynamic escalate should not create admin task (got #$ESCALATE_DYNAMIC_TASK_ID)"
+
+ESCALATE_FORCE_JSON="$("$REPO_ROOT/agent-bridge" escalate question --agent "$ESCALATE_DYNAMIC_AGENT" --question "Force relay through admin." --wait-seconds 30 --force-admin-relay --json)"
+python3 - "$ESCALATE_FORCE_JSON" "$SMOKE_AGENT" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+admin_agent = sys.argv[2]
+
+assert payload["admin_agent"] == admin_agent, payload
+assert payload["task_id"], payload
+PY
+ESCALATE_FORCE_TASK_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[question-escalation] $ESCALATE_DYNAMIC_AGENT ")"
+[[ "$ESCALATE_FORCE_TASK_ID" =~ ^[0-9]+$ ]] || die "force-admin-relay should create admin task (got '$ESCALATE_FORCE_TASK_ID')"
+
 STATIC_START_DRY_RUN="$("$REPO_ROOT/bridge-start.sh" "$SMOKE_AGENT" --dry-run --no-continue 2>&1 || true)"
 
 log "ensuring Claude Stop hook settings merge"


### PR DESCRIPTION
## Summary

- `agent-bridge escalate question` was unconditionally creating an admin task even when the calling agent was dynamic — the operator was already in the agent's own TUI, so the relay produced a stray admin nudge for a question whose target human had already answered in the originating pane (#343).
- Branch on `bridge_agent_source` before `bridge_require_admin_agent`: dynamic agents print a clear stderr warning and `exit 0` (the call succeeded by deciding "no escalation needed"); static agents keep the existing admin-relay behavior.
- Add `--force-admin-relay` for the unattended-dynamic-host escape hatch the issue calls out.

Tracks B (`--target self/admin`) and C (docs) deferred to follow-ups.

## Files

- `bridge-escalate.sh` — source check + flag.
- `scripts/smoke-test.sh` — dynamic-skip / force-relay / static-still-escalates fixture.

## Test plan

- [x] `bash -n bridge-escalate.sh scripts/smoke-test.sh`
- [x] `shellcheck bridge-escalate.sh scripts/smoke-test.sh`
- [x] Isolated `BRIDGE_HOME` repro: dynamic without flag → `rc=0`, stderr `agent-bridge: skipping admin escalation — "<agent>" is a dynamic agent. …`, no admin task in queue.
- [x] Isolated `BRIDGE_HOME` repro: dynamic with `--force-admin-relay` → admin task created (`task_id` set in JSON, `find-open` finds the task).
- [x] Isolated `BRIDGE_HOME` repro: static escalate → admin task created (regression preserved).
- [ ] `./scripts/smoke-test.sh` — see note below.

## Note on `scripts/smoke-test.sh`

The full smoke run on `main` (without these changes) currently halts before reaching the existing escalate fixture (flaky pre-existing failures around `auto-start role did not start with timeout=0` / `daemon stop` on this machine). The new dynamic-fixture block runs after the existing escalate test, so the same pre-existing flake masks our addition during a single end-to-end run. Coverage was therefore validated by a minimal isolated `BRIDGE_HOME` reproduction (commands above) instead of relying on the smoke harness for this specific block. The fixture itself is shellcheck-clean and re-uses the same managed-role pattern as the existing `CIRCUIT_AGENT` and `WORKTREE_AGENT` fixtures.

Closes part of the work in #343 (#343 Track A). Tracks B and C remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)