### PR TITLE
context-pressure: 7-day FP-rate counter in agent-bridge status (#338 Track C)

### DIFF
--- a/bridge-status.py
+++ b/bridge-status.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import argparse
 import csv
+import json
 import os
 import signal
 import sqlite3
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -155,6 +156,88 @@ def daemon_status(pid_file: str) -> tuple[bool, str]:
     except OSError:
         return (False, pid)
     return (True, pid)
+
+
+def _audit_input_files(base: Path) -> list[Path]:
+    # Mirror bridge-audit.py rotation_candidates so the dashboard counts
+    # rolled-over fragments alongside the live `audit.jsonl`. Without this,
+    # operators on long-running hosts whose log just rotated would see the
+    # FP rate snap to 0/0 (#338 Track C — observability counter).
+    files: list[Path] = []
+    if base.parent.exists():
+        files.extend(
+            sorted(
+                base.parent.glob(f"{base.stem}.*{base.suffix}"),
+                key=lambda item: item.name,
+            )
+        )
+    if base.is_file():
+        files.append(base)
+    return files
+
+
+def context_pressure_fp_rate(audit_log: str, window_days: int = 7) -> tuple[int, int]:
+    """Compute the (false-positive count, critical task count) tuple over the
+    last `window_days` for `agent-bridge status` to render. Both numbers are
+    derived from the JSONL audit log written by `bridge-audit.py`.
+
+    Numerator: rows with `action=context_pressure_false_positive` (one row per
+    operator-marked false-positive done; emitted by bridge-task.sh on any
+    `[context-pressure] <agent> (critical)` task whose --note matches the
+    "false-positive" / "HUD says <85%" markers in #338 Track C).
+
+    Denominator: unique `task_id` values from `action=context_pressure_report`
+    rows whose detail carries `severity=critical`. Counting unique task ids
+    deduplicates the rebroadcast/cooldown emissions the daemon writes for the
+    same critical task across syncs (issue #184 cooldown semantics) so the
+    rate reflects "1 task = 1 critical event".
+    """
+    if not audit_log:
+        return (0, 0)
+    base = Path(audit_log).expanduser()
+    files = _audit_input_files(base)
+    if not files:
+        return (0, 0)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max(1, int(window_days)))
+    fp_count = 0
+    critical_task_ids: set[str] = set()
+    for path in files:
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                for raw in fh:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    ts_raw = record.get("ts")
+                    if not isinstance(ts_raw, str):
+                        continue
+                    try:
+                        ts_str = ts_raw[:-1] + "+00:00" if ts_raw.endswith("Z") else ts_raw
+                        ts = datetime.fromisoformat(ts_str)
+                    except ValueError:
+                        continue
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    if ts < cutoff:
+                        continue
+                    action = record.get("action")
+                    detail = record.get("detail") if isinstance(record.get("detail"), dict) else {}
+                    if action == "context_pressure_false_positive":
+                        fp_count += 1
+                        continue
+                    if action == "context_pressure_report" and detail.get("severity") == "critical":
+                        task_id = detail.get("task_id")
+                        if isinstance(task_id, (str, int)) and str(task_id):
+                            critical_task_ids.add(str(task_id))
+        except OSError:
+            continue
+    return (fp_count, len(critical_task_ids))
 
 
 def fetch_agent_metrics(conn: sqlite3.Connection) -> dict[str, dict[str, int | str | None]]:
@@ -351,6 +434,20 @@ def render_dashboard(args: argparse.Namespace) -> str:
         f"health warn>={fmt_age(int(datetime.now(timezone.utc).timestamp()) - args.stale_warn_seconds) if args.stale_warn_seconds > 0 else 'off'} "
         f"crit>={fmt_age(int(datetime.now(timezone.utc).timestamp()) - args.stale_critical_seconds) if args.stale_critical_seconds > 0 else 'off'}"
     )
+    # Issue #338 Track C — observability counter for the context-pressure
+    # analyzer. Hidden when the denominator is zero (no critical task in the
+    # rolling window, nothing to report); operators on healthy hosts should
+    # not see a noisy `0/0` line. When the denominator is non-zero the line
+    # always renders, even with `0` numerator, so an analyzer that just
+    # stopped mis-firing is visibly distinct from one that never has.
+    fp_window_days = max(1, int(args.fp_window_days))
+    fp_count, critical_count = context_pressure_fp_rate(args.audit_log, fp_window_days)
+    if critical_count > 0:
+        pct = int(round(100.0 * fp_count / critical_count))
+        lines.append(
+            f"context-pressure FP rate ({fp_window_days}d): "
+            f"{fp_count}/{critical_count} ({pct}%)"
+        )
     lines.append("")
     lines.append("Agents")
     lines.append("  #  agent           eng     src     loop on  state    q   c   b   garden  idle  stale wake chan  nudge  load        session        workdir")
@@ -438,6 +535,13 @@ def main() -> int:
     parser.add_argument("--roster-snapshot", required=True)
     parser.add_argument("--db", required=True)
     parser.add_argument("--daemon-pid-file", required=True)
+    parser.add_argument("--audit-log", default="")
+    parser.add_argument(
+        "--fp-window-days",
+        type=int,
+        default=7,
+        help="Rolling window for the context-pressure FP-rate dashboard line (#338 Track C).",
+    )
     parser.add_argument("--version", default="")
     parser.add_argument("--open-limit", type=int, default=8)
     parser.add_argument("--stale-warn-seconds", type=int, default=3600)

--- a/bridge-status.sh
+++ b/bridge-status.sh
@@ -65,6 +65,7 @@ render_once() {
     --roster-snapshot "$roster_snapshot"
     --db "$BRIDGE_TASK_DB"
     --daemon-pid-file "$BRIDGE_DAEMON_PID_FILE"
+    --audit-log "$BRIDGE_AUDIT_LOG"
     --version "$(bridge_version)"
     --open-limit "$OPEN_LIMIT"
     --stale-warn-seconds "$BRIDGE_HEALTH_WARN_SECONDS"

--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -139,7 +139,12 @@ PY
 )" || return 0
   [[ -n "$note_excerpt" ]] || return 0
 
+  # `agent` is duplicated as a detail key (in addition to the audit row's
+  # `target` field) so FP-rate aggregators that filter purely on detail
+  # fields don't have to special-case the target column. (#338 Track C
+  # r1 codex review flagged this absence.)
   bridge_audit_log daemon context_pressure_false_positive "$impacted_agent" \
+    --detail agent="$impacted_agent" \
     --detail task_id="$task_id" \
     --detail severity=critical \
     --detail matched_pattern="$matched_pattern" \

--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -58,6 +58,95 @@ emit_inferred_actor_hint() {
   echo "[hint] --from omitted; inferred sender: ${inferred_actor}. Use --from <agent> to override." >&2
 }
 
+emit_context_pressure_false_positive_if_match() {
+  # Issue #338 Track C: when an operator marks a [context-pressure]
+  # severity=critical task done with a "false-positive" / "HUD says <85%"
+  # note, append a `context_pressure_false_positive` audit row so the
+  # observability counter rendered in `agent-bridge status` can flag a
+  # mis-firing analyzer. Tracks A + B (anchor regex + cache invalidation
+  # on /clear) already landed; this is the metrics-surfacing follow-up
+  # and intentionally has no behavioral effect on the analyzer or the
+  # task itself.
+  local task_id="$1"
+  local note="$2"
+  local note_file="$3"
+  local task_shell=""
+  local TASK_ID=""
+  local TASK_TITLE=""
+  local TASK_BODY_PATH=""
+  local impacted_agent=""
+  local matched_pattern=""
+  local body_text=""
+  local note_text=""
+  local note_excerpt=""
+
+  task_shell="$(bridge_queue_cli show "$task_id" --format shell 2>/dev/null || true)"
+  [[ -n "$task_shell" ]] || return 0
+  # shellcheck disable=SC1091
+  source /dev/stdin <<<"$task_shell"
+
+  # Title shape is `[context-pressure] <agent> (<severity>)`; only critical
+  # participates per the issue's scope. warning is informational and out of
+  # scope for the FP counter.
+  [[ "${TASK_TITLE:-}" =~ ^\[context-pressure\]\ (.+)\ \(critical\)$ ]] || return 0
+  impacted_agent="${BASH_REMATCH[1]}"
+
+  # The daemon writes the report body to a file; the inline DB body_text is
+  # therefore the same content but we read body_path so the existing on-disk
+  # representation stays the source of truth.
+  if [[ -n "${TASK_BODY_PATH:-}" && -f "$TASK_BODY_PATH" ]]; then
+    body_text="$(cat "$TASK_BODY_PATH" 2>/dev/null || true)"
+  fi
+  [[ -n "$body_text" ]] || return 0
+
+  # Confirm the daemon's HUD pattern actually fired this report. The body
+  # carries lines like `- severity: critical` and `- matched_pattern:
+  # hud:context_pct=NN`; we only count rows where the matched pattern came
+  # from the HUD anchor (issue #338 Track A scope). Other criticals — e.g.
+  # "context window exceeded" hard banners — are not the HUD analyzer's
+  # output and stay out of the false-positive counter.
+  printf '%s' "$body_text" | grep -Eq '^- severity: critical$' || return 0
+  # BSD sed (macOS) does not understand `\+`; use ERE so the regex is portable
+  # across macOS and Linux.
+  matched_pattern="$(printf '%s' "$body_text" | sed -nE 's/^- matched_pattern: (hud:context_pct=[0-9]+)$/\1/p' | head -n1)"
+  [[ -n "$matched_pattern" ]] || return 0
+
+  if [[ -n "$note" ]]; then
+    note_text="$note"
+  elif [[ -n "$note_file" && -f "$note_file" ]]; then
+    note_text="$(cat "$note_file" 2>/dev/null || true)"
+  fi
+  [[ -n "$note_text" ]] || return 0
+
+  note_excerpt="$(NOTE="$note_text" python3 - <<'PY'
+import os
+import re
+import sys
+
+note = os.environ.get("NOTE", "")
+if not note:
+    sys.exit(1)
+fp_phrase = re.search(r"false[-\s]?positive", note, re.IGNORECASE)
+hud_claim = re.search(
+    r"\b(?:actual|hud says|hud shows|actual hud|hud reports)\b[^0-9]*\b(?:[0-9]|[1-7][0-9]|8[0-4])\s*%",
+    note,
+    re.IGNORECASE,
+)
+if not (fp_phrase or hud_claim):
+    sys.exit(1)
+print(note[:200])
+PY
+)" || return 0
+  [[ -n "$note_excerpt" ]] || return 0
+
+  bridge_audit_log daemon context_pressure_false_positive "$impacted_agent" \
+    --detail task_id="$task_id" \
+    --detail severity=critical \
+    --detail matched_pattern="$matched_pattern" \
+    --detail done_note_excerpt="$note_excerpt" \
+    >/dev/null 2>&1 || true
+}
+
 ack_crash_loop_task_if_needed() {
   local task_id="$1"
   local task_shell=""
@@ -388,6 +477,7 @@ cmd_done() {
     args+=(--note-file "$note_file")
   fi
   bridge_queue_cli "${args[@]}"
+  emit_context_pressure_false_positive_if_match "$task_id" "$note" "$note_file"
   ack_crash_loop_task_if_needed "$task_id"
   notify_task_requester "$task_id" "$agent" "$note" "$note_file"
 }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -8695,4 +8695,65 @@ rows = json.loads(sys.argv[1])
 assert any(row.get("target") == sys.argv[2] for row in rows), rows
 PY
 
+log "context-pressure FP-rate counter (#338 Track C)"
+# Fixture: emit a fake [context-pressure] critical task body (the daemon's
+# own format), seed a context_pressure_report audit row so the dashboard
+# denominator picks it up, then close the task with a "false-positive"
+# operator note via bridge-task.sh and assert (a) the audit row was
+# written by bridge-task.sh and (b) `agent-bridge status` renders the
+# 1/1 (100%) line.
+FP_AGENT="fp-counter-$SESSION_NAME"
+FP_BODY_DIR="$BRIDGE_SHARED_DIR/context-pressure"
+FP_BODY_FILE="$FP_BODY_DIR/$FP_AGENT-critical.md"
+mkdir -p "$FP_BODY_DIR"
+cat >"$FP_BODY_FILE" <<EOF
+# Context Pressure Report
+
+- agent: $FP_AGENT
+- session: $FP_AGENT
+- severity: critical
+- idle_seconds: 0
+- agent_source: static
+- first_detected_at: $(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+- detected_at: $(date -u +%Y-%m-%dT%H:%M:%S+00:00)
+- matched_pattern: hud:context_pct=92
+
+## Recommended Next Action
+
+**Resolve autonomously.** Smoke fixture body.
+
+## Recent Output
+
+\`\`\`text
+Context ████████░░ 92%
+\`\`\`
+EOF
+FP_TASK_CREATE_OUTPUT="$(BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 "$REPO_ROOT/bridge-queue.py" create --to "$SMOKE_AGENT" --from daemon --priority urgent --title "[context-pressure] $FP_AGENT (critical)" --body-file "$FP_BODY_FILE" --format shell)"
+FP_TASK_ID="$(printf '%s\n' "$FP_TASK_CREATE_OUTPUT" | sed -n "s/^TASK_ID=//p" | tr -d "'\"" | head -n1)"
+[[ "$FP_TASK_ID" =~ ^[0-9]+$ ]] || die "expected fp-counter task id, got: $FP_TASK_ID"
+# Seed the denominator row exactly as the daemon would (process_context_pressure_reports).
+python3 "$REPO_ROOT/bridge-audit.py" write --file "$BRIDGE_AUDIT_LOG" \
+  --actor daemon --action context_pressure_report --target "$SMOKE_AGENT" \
+  --detail agent="$FP_AGENT" \
+  --detail severity=critical \
+  --detail task_id="$FP_TASK_ID" >/dev/null
+bash "$REPO_ROOT/bridge-task.sh" claim "$FP_TASK_ID" --agent "$SMOKE_AGENT" >/dev/null
+bash "$REPO_ROOT/bridge-task.sh" "done" "$FP_TASK_ID" --agent "$SMOKE_AGENT" --note "false-positive — HUD shows 36%" >/dev/null
+FP_AUDIT_JSON="$("$REPO_ROOT/agent-bridge" audit --action context_pressure_false_positive --target "$FP_AGENT" --limit 5 --json)"
+python3 - "$FP_AUDIT_JSON" "$FP_AGENT" "$FP_TASK_ID" <<'PY'
+import json, sys
+rows = json.loads(sys.argv[1])
+target = sys.argv[2]
+task_id = sys.argv[3]
+matches = [r for r in rows if r.get("target") == target]
+assert matches, f"expected context_pressure_false_positive audit row for {target}: {rows}"
+detail = matches[-1].get("detail") or {}
+assert str(detail.get("task_id")) == task_id, detail
+assert detail.get("severity") == "critical", detail
+assert detail.get("matched_pattern", "").startswith("hud:context_pct="), detail
+assert "false-positive" in (detail.get("done_note_excerpt") or "").lower(), detail
+PY
+FP_STATUS_OUTPUT="$("$REPO_ROOT/agent-bridge" status --all-agents)"
+assert_contains "$FP_STATUS_OUTPUT" "context-pressure FP rate (7d): 1/1 (100%)"
+
 log "smoke test passed"


### PR DESCRIPTION
## Summary

- New `context_pressure_false_positive` audit row when operator marks a `[context-pressure] <agent> (critical)` task done with a `false-positive` / `actual HUD <85%` note.
- New dashboard line in `agent-bridge status`: `context-pressure FP rate (7d): <fp>/<critical> (<pct>%)`. Hidden when no critical task fired in the window.
- Denominator counts unique `task_id`s from `context_pressure_report` rows with `severity=critical` so cooldown/rebroadcast emissions for the same task collapse to one event.

Tracks A + B (anchor HUD regex + cache invalidation on `/clear`) shipped in PR #344. Track C is the observability follow-up — no behavioral change to the analyzer itself.

## Where the changes live

- `bridge-task.sh` — adds `emit_context_pressure_false_positive_if_match` helper, hooked into the `done` flow after the queue cli succeeds. Title-prefixed (`[context-pressure] … (critical)`), body-confirmed (`hud:context_pct=NN` matched_pattern), note-matched (`false-positive` phrase or `actual HUD <85%` regex). BSD-portable sed (uses `-nE`).
- `bridge-status.py` — adds `context_pressure_fp_rate(audit_log, window_days)` that walks the JSONL audit log (including rotated fragments) and a single dashboard line. New `--audit-log` and `--fp-window-days` CLI flags.
- `bridge-status.sh` — passes `BRIDGE_AUDIT_LOG` to the renderer.
- `scripts/smoke-test.sh` — new fixture `context-pressure FP-rate counter (#338 Track C)` exercising the round-trip end-to-end.

## Verification

- `bash -n bridge-task.sh scripts/smoke-test.sh bridge-status.sh` — clean.
- `shellcheck bridge-task.sh scripts/smoke-test.sh bridge-status.sh` — clean.
- `python3 -c "import ast; ast.parse(open('bridge-status.py').read())"` — clean.
- Isolated end-to-end manual test (fresh `BRIDGE_HOME` under `/tmp`) covering 6 cases:
  - critical + `false-positive` note → audit row written, dashboard `1/1 (100%)`.
  - critical + `compacted, all good` (no FP) → no audit row.
  - critical + `actual HUD 36%` → audit row written.
  - critical + no note → no audit row, no crash.
  - critical with non-HUD `matched_pattern` (e.g. `context window exceeded`) + FP note → no audit row (only HUD-anchor criticals participate in the counter; matches the issue's "HUD says <85%" framing).
  - non-`[context-pressure]` title + FP note → no audit row.
- `./scripts/smoke-test.sh` — pre-existing failures on this host (worktree-spawn block, queue-task argv divergence) unchanged. The new context-pressure fixture is independent of those.

## Edge-case decisions worth flagging for review

- **Actor=`daemon` on the FP audit row**: matches the brief and keeps every context-pressure audit row under the same actor key. Target=`<impacted_agent>` (parsed from the title), not the admin who claimed the task — operators auditing FP rates by analyzer-impacted agent get clean filtering with `--target <agent>`.
- **HUD-anchor only**: the FP counter is scoped to `matched_pattern` lines starting with `hud:context_pct=`. Hard-stop banners ("context window exceeded", "must compact before continuing") are real failures and are not the analyzer's mis-fires — keeping them out of the FP rate avoids a noisy denominator.
- **Window default 7d**, configurable via `--fp-window-days`. Hidden when denominator is zero so healthy hosts stay quiet; rendered with `0/N (0%)` once any critical fires so an analyzer that just stopped mis-firing is visibly distinct from one that never has.

## Test plan

- [ ] Codex review (dispatched by orchestrator).
- [ ] Manual: trigger one HUD-critical task in a live `BRIDGE_HOME`, mark it done with `--note "false-positive — HUD shows 36%"`, run `agent-bridge status`, verify the FP-rate line.