### PR TITLE
cron: weekly wiki-copy-full-backfill catch-all + same-slot regression guard (#320)

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -329,6 +329,14 @@ CRON_SPECS=(
   # (issue #320 Track A). Existing 0.6.17 installs that already have this
   # cron at "0 3 * * *" are migrated to "0 6 * * *" by step_cron_one below.
   "wiki-daily-ingest|0 6 * * *|Asia/Seoul|wiki-daily-ingest.sh"
+  # Weekly Lane A catch-all (issue #320 Track B). The daily wiki-daily-ingest
+  # advances a watermark per #321; an agent that never processes its backfill
+  # task in time can leave a daily note stranded. wiki-daily-copy.py --all
+  # walks every date present under each agent's memory/ and re-copies any
+  # missing wiki replica. Hash idempotency (wiki-daily-copy.py:93) keeps the
+  # pass cheap on subsequent runs. Sundays 07:00 KST = one hour after the
+  # 06:00 daily stagger so the two never overlap on the same wall minute.
+  "wiki-copy-full-backfill|0 7 * * 0|Asia/Seoul|wiki-copy-full-backfill.sh"
   # L1 observation scanner. Populates shared/wiki/_index/mentions.db and
   # the distribution-report snapshot. Offset :17 misses top-of-hour cluster.
   "wiki-mention-scan|17 * * * *|Asia/Seoul|wiki-mention-scan.sh"
@@ -690,7 +698,7 @@ bootstrap_install_scripts() {
   local changed=0
   for f in _common.sh wiki-weekly-summarize.sh wiki-monthly-summarize.sh \
            wiki-repair-links.sh wiki-v2-rebuild.sh wiki-dedup-weekly.sh \
-           wiki-daily-ingest.sh wiki-daily-copy.py \
+           wiki-daily-ingest.sh wiki-daily-copy.py wiki-copy-full-backfill.sh \
            wiki-mention-scan.py wiki-mention-scan.sh \
            wiki-hub-audit.py wiki-hub-audit.sh \
            sync-memory-schema.py \

--- a/docs/agent-runtime/wiki-onboarding.md
+++ b/docs/agent-runtime/wiki-onboarding.md
@@ -50,7 +50,11 @@ This does five things, all idempotent:
     - `wiki-repair-links` (Sat 05:00 KST)
     - `wiki-v2-rebuild` (Sat 06:00 KST)
     - `wiki-dedup-weekly` (Sun 04:00 KST)
-    - `wiki-daily-ingest` (03:00 KST daily)
+    - `wiki-daily-ingest` (06:00 KST daily — staggered 3h after the
+      03:00 `memory-daily-*` fan-out so Lane A sees the day's notes
+      before copying)
+    - `wiki-copy-full-backfill` (Sun 07:00 KST — weekly Lane A catch-all
+      via `wiki-daily-copy.py --all`; hash idempotency makes it cheap)
     - `wiki-mention-scan` (hourly :17)
     - `librarian-watchdog` (*/10 min)
     - `wiki-hub-audit` (Thu 23:00 KST)

--- a/scripts/wiki-copy-full-backfill.sh
+++ b/scripts/wiki-copy-full-backfill.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# wiki-copy-full-backfill — weekly catch-all for Lane A daily-note copy.
+#
+# Issue #320 Track B. The daily wiki-daily-ingest.sh runs at 06:00 KST
+# with a watermark-driven --since/--until window (issue #321). If an
+# agent's per-day backfill task is never processed (long-running work,
+# missed window) the daily note can be written to agent-home after the
+# next morning's Lane A has already advanced its watermark past the
+# stranded date. This weekly catch-all sweeps every date present under
+# every agent's memory/ directory and copies any missing replicas into
+# shared/wiki/agents/<agent>/daily/. wiki-daily-copy.py:93 (sha256)
+# guarantees the pass is idempotent — unchanged sources are skipped.
+#
+# Cron: "cron 0 7 * * 0 Asia/Seoul" (Sundays 07:00 KST, one hour after
+# the daily 06:00 stagger so it never overlaps with Lane A on the same
+# wall-clock minute).
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$HERE/_common.sh"
+
+JOB="wiki-copy-full-backfill"
+LOG="$(audit_path "$JOB")"
+log_audit "$JOB" "starting $JOB" >/dev/null
+
+trap 'file_failure_task "$JOB" "$LOG"' ERR
+
+SUMMARY_JSON="$(mktemp -t wiki-copy-full-backfill.XXXXXX.json)"
+# shellcheck disable=SC2064
+trap "rm -f '$SUMMARY_JSON'; file_failure_task '$JOB' '$LOG'" ERR
+
+if ! run_with_timeout 1800 "$BRIDGE_PYTHON" "$HERE/wiki-daily-copy.py" \
+      --all --json \
+      >"$SUMMARY_JSON" 2>>"$LOG"; then
+  rc=$?
+  log_audit "$JOB" "wiki-daily-copy.py --all FAILED rc=$rc" >/dev/null
+  file_failure_task "$JOB" "$LOG"
+  rm -f "$SUMMARY_JSON"
+  exit "$rc"
+fi
+
+# Mirror the JSON summary to the audit log so trend reviews can see the
+# weekly catch-all reach (agents_seen / files_seen / replaced).
+log_audit "$JOB" "result $(cat "$SUMMARY_JSON")" >/dev/null
+
+rm -f "$SUMMARY_JSON"
+trap - ERR
+log_audit "$JOB" "finished $JOB" >/dev/null

--- a/scripts/wiki-copy-full-backfill.sh
+++ b/scripts/wiki-copy-full-backfill.sh
@@ -31,10 +31,15 @@ SUMMARY_JSON="$(mktemp -t wiki-copy-full-backfill.XXXXXX.json)"
 # shellcheck disable=SC2064
 trap "rm -f '$SUMMARY_JSON'; file_failure_task '$JOB' '$LOG'" ERR
 
-if ! run_with_timeout 1800 "$BRIDGE_PYTHON" "$HERE/wiki-daily-copy.py" \
-      --all --json \
-      >"$SUMMARY_JSON" 2>>"$LOG"; then
-  rc=$?
+# Capture rc *before* an `if` test — `if ! cmd` makes `$?` reflect the
+# negated test, not the underlying command, so a real failure would be
+# logged as `rc=0` and re-exited as success. Run the command bare, snap
+# the status into rc, then branch on it. (#320 r2 codex)
+run_with_timeout 1800 "$BRIDGE_PYTHON" "$HERE/wiki-daily-copy.py" \
+    --all --json \
+    >"$SUMMARY_JSON" 2>>"$LOG" \
+  && rc=0 || rc=$?
+if (( rc != 0 )); then
   log_audit "$JOB" "wiki-daily-copy.py --all FAILED rc=$rc" >/dev/null
   file_failure_task "$JOB" "$LOG"
   rm -f "$SUMMARY_JSON"

--- a/tests/bootstrap-cron-schedules/parse_specs.py
+++ b/tests/bootstrap-cron-schedules/parse_specs.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Helper for tests/bootstrap-cron-schedules/smoke.sh.
+
+Parses the CRON_SPECS array and step_memory_daily_cron_one schedule out
+of bootstrap-memory-system.sh and prints a JSON summary on stdout.
+
+Kept as a sibling script (instead of an inline heredoc inside smoke.sh)
+because bash command substitution mishandles unbalanced parentheses
+inside a heredoc body — see the comment in smoke.sh for context.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def parse(src_path: str) -> dict:
+    src = open(src_path, encoding="utf-8").read()
+
+    # Find the CRON_SPECS=( ... ) array and walk byte-by-byte to the
+    # matching top-level close-paren. A simple [^)]* regex would stop
+    # early because the array body contains close-paren characters
+    # inside comment text.
+    start = src.find("CRON_SPECS=(")
+    if start < 0:
+        return {"error": "CRON_SPECS array not found"}
+    cursor = start + len("CRON_SPECS=(")
+    depth = 1
+    end = -1
+    while cursor < len(src):
+        ch = src[cursor]
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                end = cursor
+                break
+        cursor += 1
+    if end < 0:
+        return {"error": "CRON_SPECS array not closed"}
+    body = src[start + len("CRON_SPECS=("): end]
+
+    specs = []
+    for line in body.splitlines():
+        line = line.strip()
+        if not line.startswith('"') or not line.endswith('"'):
+            continue
+        inner = line[1:-1]
+        parts = inner.split("|")
+        if len(parts) < 4:
+            continue
+        title = parts[0].strip()
+        expr = parts[1].strip()
+        tz = parts[2].strip()
+        script = parts[3].strip()
+        specs.append({"title": title, "expr": expr, "tz": tz, "script": script})
+
+    md_match = re.search(
+        r'step_memory_daily_cron_one\s*\(\)\s*\{[^}]*?local\s+sched=\"([^\"]+)\"',
+        src,
+        re.DOTALL,
+    )
+    memory_daily_expr = md_match.group(1) if md_match else None
+
+    return {"specs": specs, "memory_daily_expr": memory_daily_expr}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(json.dumps({"error": "usage: parse_specs.py <bootstrap.sh>"}))
+        return 2
+    print(json.dumps(parse(argv[1])))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/bootstrap-cron-schedules/smoke.sh
+++ b/tests/bootstrap-cron-schedules/smoke.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# bootstrap-cron-schedules smoke — regression guard for issue #320 Track C.
+#
+# What this asserts (against the bootstrap-memory-system.sh source):
+#
+#   1. The wiki-daily-ingest cron is registered at "0 6 * * *", not the
+#      legacy "0 3 * * *" slot that raced with memory-daily-* on every
+#      install (issue #320 root cause).
+#
+#   2. The per-agent memory-daily-* family is registered at "0 3 * * *".
+#      This pins the producer-side schedule so future drift in either
+#      half of the stagger pair is caught immediately.
+#
+#   3. No two cron specs share the same schedule.expr unless explicitly
+#      enumerated in INTENTIONAL_COFIRE below. Future cron additions that
+#      land on an existing slot will fail this test until the author
+#      either picks a different slot or documents the co-fire as
+#      intentional. The guard fires for the CRON_SPECS array
+#      (admin-owned wiki-* family) and the per-agent memory-daily-*
+#      schedule that step_memory_daily_cron_one hardcodes.
+#
+# This test parses the bootstrap script statically rather than running
+# `bootstrap-memory-system.sh apply` against a mktemp BRIDGE_HOME — a
+# real apply requires `agb cron create`, an agent roster, the librarian
+# provisioner, and live `claude` CLI integration, none of which are
+# reproducible in an isolated harness. Static parsing is sufficient for
+# the regression contract because every cron schedule registered by the
+# bootstrap is sourced from one of two literals in the script:
+# CRON_SPECS (lines starting with `"<title>|<expr>|<tz>|<script>"` inside
+# the array) and the `sched=` assignment in step_memory_daily_cron_one.
+#
+# The actual parser lives in parse_specs.py (sibling file). Inlining it
+# as a heredoc trips a bash command-substitution quirk where unbalanced
+# parens inside the heredoc body confuse the outer "$(...)" tokenizer
+# even when the heredoc opener is quoted.
+#
+# Usage:   ./tests/bootstrap-cron-schedules/smoke.sh
+# Exit 0 if every assertion PASSes; exit 1 otherwise.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+BOOTSTRAP="$REPO_ROOT/bootstrap-memory-system.sh"
+PARSER="$(dirname "${BASH_SOURCE[0]}")/parse_specs.py"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+# Schedules that are legitimately allowed to share a slot. Keep this list
+# short and require a comment in the bootstrap source explaining the
+# co-fire. The pair is encoded as "<title-a>=<expr>|<title-b>=<expr>"; an
+# empty list means no co-fires are permitted.
+INTENTIONAL_COFIRE=(
+  # No intentional co-fires today. wiki-daily-ingest moved to 06:00 to
+  # break the memory-daily-* race that motivated this test.
+  ""
+)
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$*"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '[smoke][fail] %s\n' "$*" >&2
+}
+
+if [[ ! -r "$BOOTSTRAP" ]]; then
+  printf '[smoke][error] cannot find %s\n' "$BOOTSTRAP" >&2
+  exit 1
+fi
+
+if [[ ! -r "$PARSER" ]]; then
+  printf '[smoke][error] cannot find parser helper: %s\n' "$PARSER" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Run the parser. JSON shape:
+#   {"specs": [{"title","expr","tz","script"}, ...],
+#    "memory_daily_expr": "0 3 * * *"}
+# or {"error": "..."} on failure.
+# ---------------------------------------------------------------------------
+SCHED_JSON="$("$PYTHON" "$PARSER" "$BOOTSTRAP" 2>&1)" || {
+  fail "parser failed: $SCHED_JSON"
+  printf '\n[smoke] %d pass / %d fail\n' "$PASS" "$FAIL"
+  exit 1
+}
+
+if ! printf '%s' "$SCHED_JSON" | "$PYTHON" -c 'import json, sys; json.loads(sys.stdin.read())' >/dev/null 2>&1; then
+  fail "parser returned non-JSON: $SCHED_JSON"
+  printf '\n[smoke] %d pass / %d fail\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
+PARSE_ERROR="$(printf '%s' "$SCHED_JSON" | "$PYTHON" -c 'import json,sys; d=json.loads(sys.stdin.read()); print(d.get("error",""))')"
+if [[ -n "$PARSE_ERROR" ]]; then
+  fail "$PARSE_ERROR"
+  printf '\n[smoke] %d pass / %d fail\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — wiki-daily-ingest is at 0 6 * * *.
+# ---------------------------------------------------------------------------
+WIKI_DAILY_EXPR="$(printf '%s' "$SCHED_JSON" | "$PYTHON" -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+for s in d["specs"]:
+    if s["title"] == "wiki-daily-ingest":
+        print(s["expr"]); break
+')"
+
+if [[ "$WIKI_DAILY_EXPR" == "0 6 * * *" ]]; then
+  pass "wiki-daily-ingest schedule = '0 6 * * *' (post-#320 stagger)"
+else
+  fail "wiki-daily-ingest schedule expected '0 6 * * *', got '$WIKI_DAILY_EXPR' — issue #320 regression"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — memory-daily-* family is at 0 3 * * *.
+# ---------------------------------------------------------------------------
+MEM_DAILY_EXPR="$(printf '%s' "$SCHED_JSON" | "$PYTHON" -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+print(d.get("memory_daily_expr") or "")
+')"
+
+if [[ "$MEM_DAILY_EXPR" == "0 3 * * *" ]]; then
+  pass "memory-daily-* schedule = '0 3 * * *' (producer side of the #320 stagger pair)"
+else
+  fail "memory-daily-* schedule expected '0 3 * * *', got '$MEM_DAILY_EXPR' — producer side moved without updating this test"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 3 — no two distinct cron specs share the same expr unless on
+# the intentional co-fire allowlist.
+# ---------------------------------------------------------------------------
+COFIRE_BLOB="$(printf '%s\n' "${INTENTIONAL_COFIRE[@]:-}")"
+DUPES="$(printf '%s' "$SCHED_JSON" | MEM_DAILY_EXPR="$MEM_DAILY_EXPR" COFIRE="$COFIRE_BLOB" "$PYTHON" -c '
+import json, os, sys
+d = json.loads(sys.stdin.read())
+buckets = {}
+for s in d["specs"]:
+    buckets.setdefault(s["expr"], []).append(s["title"])
+
+mem_expr = os.environ.get("MEM_DAILY_EXPR", "").strip()
+if mem_expr:
+    buckets.setdefault(mem_expr, []).append("memory-daily-<agent>")
+
+# Build the allowlist as a set of frozenset({title,title}) pairs.
+allowed = set()
+for line in (os.environ.get("COFIRE") or "").splitlines():
+    line = line.strip()
+    if not line or line.startswith("#"):
+        continue
+    pair = line.split("|")
+    titles = []
+    for p in pair:
+        p = p.strip()
+        if "=" not in p:
+            continue
+        t, _ = p.split("=", 1)
+        titles.append(t.strip())
+    if len(titles) == 2:
+        allowed.add(frozenset(titles))
+
+dupes = []
+for expr, titles in buckets.items():
+    uniq = sorted(set(titles))
+    if len(uniq) <= 1:
+        continue
+    bucket_ok = True
+    for i in range(len(uniq)):
+        for j in range(i + 1, len(uniq)):
+            if frozenset({uniq[i], uniq[j]}) not in allowed:
+                bucket_ok = False
+                break
+        if not bucket_ok:
+            break
+    if not bucket_ok:
+        dupes.append(f"{expr}: {uniq}")
+
+for d_ in dupes:
+    print(d_)
+')"
+
+if [[ -z "$DUPES" ]]; then
+  pass "no two cron specs share a schedule.expr (issue #320 same-slot regression guard)"
+else
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    fail "schedule.expr collision — $line"
+  done <<<"$DUPES"
+fi
+
+printf '\n[smoke] %d pass / %d fail\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes Tracks B and C of issue #320. Track A (stagger `wiki-daily-ingest` from `0 3 * * *` to `0 6 * * *`) already shipped in PR #333; this finishes the issue.

- **Track B** — Register `wiki-copy-full-backfill` cron at `0 7 * * 0` (Sundays 07:00 KST). It runs `scripts/wiki-daily-copy.py --all`, sweeping every date present under each agent's `memory/` and re-copying anything missing into `shared/wiki/agents/<agent>/daily/`. The existing sha256 idempotency at `wiki-daily-copy.py:113` keeps repeat passes cheap. This catches daily notes stranded after the watermark advances when an agent fails to process its `memory-daily-*` backfill within the daily Lane A window.
- **Track C** — `tests/bootstrap-cron-schedules/smoke.sh` is a static-analysis regression guard. It parses `CRON_SPECS` and the per-agent `memory-daily` schedule out of `bootstrap-memory-system.sh` and asserts (a) `wiki-daily-ingest=0 6 * * *`, (b) `memory-daily=0 3 * * *`, and (c) no two cron specs collide on `schedule.expr` unless explicitly listed in `INTENTIONAL_COFIRE`. The parser lives in a sibling `.py` to dodge a bash heredoc/`$(...)` paren-balancing quirk.
- **Doc** — `docs/agent-runtime/wiki-onboarding.md` cron list updated to reflect the 06:00 stagger and the new Sunday catch-all (was still showing `wiki-daily-ingest (03:00 KST daily)`).

Why static parsing for the test instead of a real `bootstrap-memory-system.sh apply` against `mktemp -d` BRIDGE_HOME: a real apply requires `agb cron create`, an agent roster, the librarian provisioner, and live `claude` CLI integration — none of which are reproducible in an isolated harness. Every cron schedule the bootstrap registers is sourced from one of two literal sites in the script, so static parsing is sufficient for the regression contract.

## Test plan

- [x] `bash -n bootstrap-memory-system.sh scripts/wiki-copy-full-backfill.sh tests/bootstrap-cron-schedules/smoke.sh` — PASS
- [x] `shellcheck bootstrap-memory-system.sh scripts/wiki-copy-full-backfill.sh tests/bootstrap-cron-schedules/smoke.sh` — PASS
- [x] `python3 -c "import ast; ast.parse(open('scripts/wiki-daily-copy.py').read()); ast.parse(open('tests/bootstrap-cron-schedules/parse_specs.py').read())"` — PASS
- [x] `./tests/bootstrap-cron-schedules/smoke.sh` — 3/3 pass
- [x] Negative test: temporarily replaced `wiki-mention-scan` schedule with `0 6 * * *` to force a collision; the new test correctly reported `[smoke][fail] schedule.expr collision — 0 6 * * *: ['wiki-daily-ingest', 'wiki-mention-scan']` and exited 1. Bootstrap restored after.
- [ ] Manual operator verification (post-merge): on next `bootstrap-memory-system.sh apply`, `agb cron list --agent <admin>` should show `wiki-copy-full-backfill` registered at `0 7 * * 0 Asia/Seoul`. Re-running `apply` should report `already-registered` for it (idempotent).