### PR TITLE
stall: matched_line_hash dedup key for nudge cap (#329 Track D)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -998,6 +998,9 @@ bridge_note_stall_state() {
   local escalated_ts="${11}"
   local task_id="${12}"
   local matched_pattern="${13:-}"
+  # Issue #329 Track D: matched_line_hash is the stable dedup key. Persist it
+  # alongside excerpt_hash so a daemon restart resumes the cap correctly.
+  local matched_line_hash="${14:-}"
   local state_file
 
   state_file="$(bridge_agent_stall_state_file "$agent")"
@@ -1005,6 +1008,7 @@ bridge_note_stall_state() {
   cat >"$state_file" <<EOF
 STALL_ACTIVE_CLASSIFICATION=$(printf '%q' "$classification")
 STALL_ACTIVE_EXCERPT_HASH=$(printf '%q' "$excerpt_hash")
+STALL_ACTIVE_MATCHED_LINE_HASH=$(printf '%q' "$matched_line_hash")
 STALL_FIRST_DETECTED_TS=$(printf '%q' "$first_detected_ts")
 STALL_LAST_DETECTED_TS=$(printf '%q' "$last_detected_ts")
 STALL_LAST_SCAN_TS=$(printf '%q' "$last_scan_ts")
@@ -1053,6 +1057,7 @@ process_stall_reports() {
   local had_state=0
   local active_classification=""
   local active_hash=""
+  local active_matched_line_hash=""
   local first_detected_ts=0
   local last_detected_ts=0
   local last_scan_ts=0
@@ -1061,6 +1066,7 @@ process_stall_reports() {
   local escalated_ts=0
   local task_id=""
   local matched_pattern=""
+  local matched_line_hash=""
   local scan_interval="${BRIDGE_STALL_SCAN_INTERVAL_SECONDS:-30}"
   local explicit_idle="${BRIDGE_STALL_EXPLICIT_IDLE_SECONDS:-30}"
   local unknown_idle="${BRIDGE_STALL_UNKNOWN_IDLE_SECONDS:-900}"
@@ -1080,6 +1086,9 @@ process_stall_reports() {
   local existing_id=""
   local create_output=""
   local recommended=""
+  # Issue #329 Track D: composite dedup keys, recomputed each iteration.
+  local current_dedup_key=""
+  local prior_dedup_key=""
 
   [[ "${BRIDGE_STALL_SCAN_ENABLED:-1}" == "1" ]] || return 1
   if [[ -n "$admin_agent" ]] && bridge_agent_exists "$admin_agent"; then
@@ -1097,6 +1106,7 @@ process_stall_reports() {
     had_state=0
     active_classification=""
     active_hash=""
+    active_matched_line_hash=""
     first_detected_ts=0
     last_detected_ts=0
     last_scan_ts=0
@@ -1112,6 +1122,7 @@ process_stall_reports() {
       source "$state_file"
       active_classification="${STALL_ACTIVE_CLASSIFICATION:-}"
       active_hash="${STALL_ACTIVE_EXCERPT_HASH:-}"
+      active_matched_line_hash="${STALL_ACTIVE_MATCHED_LINE_HASH:-}"
       first_detected_ts="${STALL_FIRST_DETECTED_TS:-0}"
       last_detected_ts="${STALL_LAST_DETECTED_TS:-0}"
       last_scan_ts="${STALL_LAST_SCAN_TS:-0}"
@@ -1143,6 +1154,7 @@ process_stall_reports() {
     classification=""
     matched_pattern=""
     excerpt_hash=""
+    matched_line_hash=""
     excerpt_b64=""
     excerpt=""
 
@@ -1166,12 +1178,14 @@ process_stall_reports() {
             if [[ -n "$analysis_shell" ]]; then
               STALL_CLASSIFICATION=""
               STALL_MATCHED_PATTERN=""
+              STALL_MATCHED_LINE_HASH=""
               STALL_EXCERPT_HASH=""
               STALL_EXCERPT_B64=""
               # shellcheck disable=SC1091
               source /dev/stdin <<<"$analysis_shell"
               classification="${STALL_CLASSIFICATION:-}"
               matched_pattern="${STALL_MATCHED_PATTERN:-}"
+              matched_line_hash="${STALL_MATCHED_LINE_HASH:-}"
               excerpt_hash="${STALL_EXCERPT_HASH:-}"
               excerpt_b64="${STALL_EXCERPT_B64:-}"
               excerpt="$(bridge_stall_decode_excerpt "$excerpt_b64")"
@@ -1199,7 +1213,23 @@ process_stall_reports() {
       continue
     fi
 
-    if [[ "$active_classification" != "$classification" || "$active_hash" != "$excerpt_hash" ]]; then
+    # Issue #329 Track D: dedup on matched_line_hash so a single false-positive
+    # line in scrollback no longer re-fires every loop. excerpt_hash churns on
+    # every idle tick because the captured pane window shifts; matched_line_hash
+    # is stable as long as the offending line itself is. When the classifier
+    # produced no matched line (unknown-classification idle stall), fall back
+    # to the legacy excerpt_hash dedup so behavior there is unchanged.
+    if [[ -n "$matched_line_hash" ]]; then
+      current_dedup_key="line:$matched_line_hash"
+    else
+      current_dedup_key="excerpt:$excerpt_hash"
+    fi
+    if [[ -n "$active_matched_line_hash" ]]; then
+      prior_dedup_key="line:$active_matched_line_hash"
+    else
+      prior_dedup_key="excerpt:$active_hash"
+    fi
+    if [[ "$active_classification" != "$classification" || "$current_dedup_key" != "$prior_dedup_key" ]]; then
       first_detected_ts="$now_ts"
       nudge_count=0
       last_nudge_ts=0
@@ -1209,7 +1239,8 @@ process_stall_reports() {
         --detail classification="$classification" \
         --detail idle_seconds="$idle" \
         --detail claimed="$claimed" \
-        --detail excerpt_hash="$excerpt_hash"
+        --detail excerpt_hash="$excerpt_hash" \
+        --detail matched_line_hash="$matched_line_hash"
       changed=0
     fi
 
@@ -1317,7 +1348,7 @@ process_stall_reports() {
       fi
     fi
 
-    bridge_note_stall_state "$agent" "$classification" "$excerpt_hash" "$first_detected_ts" "$last_detected_ts" "$now_ts" "$idle" "$claimed" "$nudge_count" "$last_nudge_ts" "$escalated_ts" "$task_id" "$matched_pattern"
+    bridge_note_stall_state "$agent" "$classification" "$excerpt_hash" "$first_detected_ts" "$last_detected_ts" "$now_ts" "$idle" "$claimed" "$nudge_count" "$last_nudge_ts" "$escalated_ts" "$task_id" "$matched_pattern" "$matched_line_hash"
   done <<<"$summary_output"
 
   return "$changed"

--- a/bridge-stall.py
+++ b/bridge-stall.py
@@ -174,7 +174,19 @@ def normalize_excerpt(text: str, max_bytes: int) -> str:
     return encoded[-max_bytes:].decode("utf-8", errors="ignore").lstrip()
 
 
-def classify(normalized: str) -> tuple[str, str]:
+def _normalize_matched_line(line: str) -> str:
+    # Issue #329 Track D: produce a stable representation of the offending
+    # line so the daemon can dedup on the line itself instead of the
+    # surrounding excerpt window (which shifts every idle tick). Lower-case
+    # plus collapsed whitespace plus trim absorbs cosmetic diffs; truncating
+    # to 240 chars bounds the hash input for pathological lines.
+    collapsed = re.sub(r"\s+", " ", line.lower()).strip()
+    if len(collapsed) > 240:
+        collapsed = collapsed[:240]
+    return collapsed
+
+
+def classify(normalized: str) -> tuple[str, str, str]:
     # Issue #264: skip agent-authored lines so the classifier never matches
     # the agent narrating a previous error (e.g. "⏺ inbox empty, no 429
     # reoccurrence"). Without this, agent replies referencing past errors
@@ -184,15 +196,21 @@ def classify(normalized: str) -> tuple[str, str]:
         stripped = raw.strip()
         if not stripped or stripped.startswith(AGENT_GLYPH_PREFIXES):
             continue
-        candidate_lines.append(stripped.lower())
+        candidate_lines.append(stripped)
     if not candidate_lines:
-        return "", ""
-    haystack = "\n".join(candidate_lines)
-    for classification, patterns in PATTERN_GROUPS:
-        for pattern in patterns:
-            if re.search(pattern, haystack, flags=re.IGNORECASE):
-                return classification, pattern
-    return "", ""
+        return "", "", ""
+    # Issue #329 Track D: walk lines individually so the classifier can return
+    # the actual matched line. Previously classify() searched the joined
+    # haystack and only knew which (group, pattern) fired; the daemon dedup
+    # therefore had to fall back on excerpt_hash, which churned every loop
+    # whenever any other text moved through the pane.
+    for line in candidate_lines:
+        haystack = line.lower()
+        for classification, patterns in PATTERN_GROUPS:
+            for pattern in patterns:
+                if re.search(pattern, haystack, flags=re.IGNORECASE):
+                    return classification, pattern, _normalize_matched_line(line)
+    return "", "", ""
 
 
 def main() -> int:
@@ -205,10 +223,22 @@ def main() -> int:
     args = parser.parse_args()
 
     normalized = normalize_excerpt(read_capture(args.capture_file), max(args.max_bytes, 256))
-    classification, matched = classify(normalized)
+    classification, matched, matched_line = classify(normalized)
+    # Issue #329 Track D: matched_line_hash is the dedup key the daemon uses
+    # to decide "same stall as last loop". 16 hex chars (64 bits) is enough
+    # collision-resistance for one host's roster. Empty when no line matched
+    # (e.g. unknown-classification idle stalls), in which case the daemon
+    # falls back to excerpt_hash for the legacy behavior.
+    matched_line_hash = (
+        hashlib.sha256(matched_line.encode("utf-8")).hexdigest()[:16]
+        if matched_line
+        else ""
+    )
     payload = {
         "classification": classification,
         "matched_pattern": matched,
+        "matched_line": matched_line,
+        "matched_line_hash": matched_line_hash,
         "excerpt": normalized,
         "excerpt_hash": hashlib.sha256(normalized.encode("utf-8")).hexdigest() if normalized else "",
         "excerpt_lines": len(normalized.splitlines()) if normalized else 0,
@@ -216,6 +246,7 @@ def main() -> int:
     if args.format == "shell":
         print(f"STALL_CLASSIFICATION={json.dumps(payload['classification'])}")
         print(f"STALL_MATCHED_PATTERN={json.dumps(payload['matched_pattern'])}")
+        print(f"STALL_MATCHED_LINE_HASH={json.dumps(payload['matched_line_hash'])}")
         print(f"STALL_EXCERPT_HASH={json.dumps(payload['excerpt_hash'])}")
         print(f"STALL_EXCERPT_LINES={int(payload['excerpt_lines'])}")
         print(f"STALL_EXCERPT_B64={json.dumps(base64.b64encode(payload['excerpt'].encode('utf-8')).decode('ascii'))}")

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -399,6 +399,58 @@ run_stall_classify_case "CJK prose discussing access -> silent" \
   "" \
   $'승인 안 된 액세스를 묘님이 검토 중\n'
 
+log "stall-detector matched_line_hash dedup (#329 Track D)"
+# Track D fallback: even if a future false-positive slips past the narrowed
+# regex, dedup on the matched line itself (not the shifting excerpt window)
+# so nudge_count cannot re-fire past max_nudges. Verify (a) the same
+# offending line hashes identically across two scans even when surrounding
+# scrollback changes, (b) two genuinely different stall causes hash
+# differently so a fresh stall still gets a fresh nudge, and (c) the
+# normalized form survives whitespace/case shifts on the matched line.
+extract_matched_line_hash() {
+  printf '%s\n' "$1" | sed -n 's/^STALL_MATCHED_LINE_HASH="\(.*\)"$/\1/p'
+}
+
+stall_d_loop1_out="$(printf 'foo\nbar\nerror: HTTP 429 Too Many Requests\nbaz\n' | python3 "$REPO_ROOT/bridge-stall.py" analyze --format shell)"
+stall_d_loop2_out="$(printf 'qux\nzot\nerror: HTTP 429 Too Many Requests\nplugh\nxyzzy\n' | python3 "$REPO_ROOT/bridge-stall.py" analyze --format shell)"
+stall_d_loop1_hash="$(extract_matched_line_hash "$stall_d_loop1_out")"
+stall_d_loop2_hash="$(extract_matched_line_hash "$stall_d_loop2_out")"
+[[ -n "$stall_d_loop1_hash" ]] || die "stall #329 Track D: loop1 produced empty matched_line_hash for a 429 line"
+if [[ "$stall_d_loop1_hash" != "$stall_d_loop2_hash" ]]; then
+  die "stall #329 Track D: same matched line should hash identically across scrollback shifts (loop1=$stall_d_loop1_hash loop2=$stall_d_loop2_hash)"
+fi
+log "  [ok] same matched line stable across shifting scrollback"
+
+# Different stall cause → different matched_line → different hash → fresh nudge.
+stall_d_diff_out="$(printf 'error: 503 service unavailable\n' | python3 "$REPO_ROOT/bridge-stall.py" analyze --format shell)"
+stall_d_diff_hash="$(extract_matched_line_hash "$stall_d_diff_out")"
+[[ -n "$stall_d_diff_hash" ]] || die "stall #329 Track D: 503 line produced empty matched_line_hash"
+if [[ "$stall_d_diff_hash" == "$stall_d_loop1_hash" ]]; then
+  die "stall #329 Track D: distinct stall causes (429 vs 503) must produce distinct matched_line_hash"
+fi
+log "  [ok] distinct stall causes hash differently"
+
+# Whitespace + case shifts on the matched line should collapse via the
+# normalized form (lowercase + collapsed whitespace + trim).
+stall_d_norm_out="$(printf '   ERROR:\tHTTP   429    Too Many Requests   \n' | python3 "$REPO_ROOT/bridge-stall.py" analyze --format shell)"
+stall_d_norm_hash="$(extract_matched_line_hash "$stall_d_norm_out")"
+if [[ "$stall_d_norm_hash" != "$stall_d_loop1_hash" ]]; then
+  die "stall #329 Track D: whitespace/case-shifted variant of the same line should normalize to the same hash (norm=$stall_d_norm_hash loop1=$stall_d_loop1_hash)"
+fi
+log "  [ok] whitespace/case shifts collapse to the same hash"
+
+# Daemon-level dedup: simulate the comparison process_stall_reports() runs
+# against the prior stall.env. With matched_line_hash as the dedup key the
+# second loop's key matches the persisted prior key, so first_detected_ts
+# stays put and nudge_count is NOT reset → the max_nudges cap holds even
+# if the same false-positive line keeps appearing in scrollback.
+prior_dedup_key="line:$stall_d_loop1_hash"
+current_dedup_key="line:$stall_d_loop2_hash"
+if [[ "$prior_dedup_key" != "$current_dedup_key" ]]; then
+  die "stall #329 Track D: daemon dedup key mismatch despite identical matched line (prior=$prior_dedup_key current=$current_dedup_key)"
+fi
+log "  [ok] daemon dedup key stable → nudge_count not reset across loops"
+
 log "CLI subcommand suggestion helper (issue #163)"
 run_suggest_case() {
   local label="$1"


### PR DESCRIPTION
## Summary

Track A of #329 (regex narrowing — HTTP/error/status qualifier required for bare `\b429\b` / `\bunauthorized\b`) already shipped via PR #336. Tracks B (skip rule expansion) and C (CJK heuristic) are design-territory or brittle. **Track D** is the alarm-spam cap: even if a future false-positive slips past the narrowed regex, dedup on the matched line itself (not the shifting excerpt window) keeps `nudge_count` from re-firing past `max_nudges=2`.

## Why excerpt_hash isn't enough

`process_stall_reports()` in `bridge-daemon.sh` currently dedups on `excerpt_hash`, which changes every idle tick because the captured pane window shifts whenever any other text moves through. A single false-positive pattern in scrollback therefore re-fires on every daemon loop, and the `max_nudges=2` cap never holds — the operator sees endless nudges on the same stale matched text.

## What changed

- `bridge-stall.py` `classify()` now walks candidate lines individually and returns the actual matched line. Output gains `matched_line` and `matched_line_hash` (`sha256[:16]` of `lower() + re.sub(r'\s+', ' ', ...) + strip()` capped at 240 chars).
- `bridge-daemon.sh` `process_stall_reports()` switches its dedup key to `matched_line_hash`. When the classifier produced no matched line (unknown-classification idle stall), it falls back to `excerpt_hash` so legacy behavior is unchanged.
- `STALL_ACTIVE_MATCHED_LINE_HASH` persisted in stall.env so a daemon restart resumes the cap correctly.
- `scripts/smoke-test.sh` adds 4 sub-assertions: same line hash stable across scrollback shifts, distinct causes hash differently, whitespace/case shifts collapse to the same hash, daemon-level dedup key stable across loops.

## Verification

- `bash -n bridge-daemon.sh` PASS
- `shellcheck bridge-daemon.sh scripts/smoke-test.sh` PASS
- `python3 -c "import ast; ast.parse(open('bridge-stall.py').read())"` PASS
- Unit-driver: same 429 line across two scans → identical hash (`668a9421ba1b2ed9`); 503 line → distinct hash (`e58adb7eeca71a6a`).

## Pair-review

Required per AGENTS.md. Orchestrator dispatches codex.

Addresses Track D of #329. Tracks B/C deferred.