### PR TITLE
bootstrap-memory: --backfill-history N for first-run harvest gap (#322 Track C)

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -80,6 +80,12 @@ source "$SCRIPT_DIR/scripts/_common.sh"
 MODE="apply"
 INDEX_STALE_DAYS=7
 TARGET_AGENT=""
+# Issue #322 Track C: opt-in historical backfill of memory-daily harvests.
+# Default empty = OFF. When set, must be a strict integer in [1, 90].
+# Active only in --apply mode; ignored under --dry-run / --check (those modes
+# already report what apply would do; the backfill is purely an apply-time
+# side-effect that piggy-backs on `harvest-daily --missing-only`).
+BACKFILL_HISTORY_DAYS=""
 while (( $# > 0 )); do
   case "$1" in
     --dry-run) MODE="dry-run" ;;
@@ -87,9 +93,13 @@ while (( $# > 0 )); do
     --apply)   MODE="apply" ;;
     --agent)   TARGET_AGENT="${2:-}"; shift ;;
     --stale-days) INDEX_STALE_DAYS="${2:-7}"; shift ;;
+    --backfill-history)
+      BACKFILL_HISTORY_DAYS="${2:-}"
+      shift
+      ;;
     -h|--help)
       cat <<EOF
-usage: $(basename "$0") [--apply|--dry-run|--check] [--agent <name>] [--stale-days N]
+usage: $(basename "$0") [--apply|--dry-run|--check] [--agent <name>] [--stale-days N] [--backfill-history N]
 
 Steps:
   1. PreCompact hook per active claude agent.
@@ -97,6 +107,12 @@ Steps:
   3. Ensure the dynamic 'librarian' agent is provisioned.
   4. Register the wiki-* + librarian-watchdog cron set on the admin
      agent (default: 'patch'; override with BRIDGE_ADMIN_AGENT env).
+  5. (apply only, opt-in) When --backfill-history N is supplied, run
+     \`bridge-memory.py harvest-daily --from \$(today-N) --to \$(today-1)
+     --agent <agent> --missing-only\` for each registered claude agent.
+     N is an integer in [1, 90]; default is OFF (no historical backfill).
+     Re-running with the same N is a no-op because --missing-only skips
+     dates that already have a sidecar manifest. Issue #322 Track C.
 
 JSON report written to \$BRIDGE_STATE_ROOT/bootstrap-memory/report-<stamp>.json
 EOF
@@ -106,6 +122,20 @@ EOF
   esac
   shift
 done
+
+# Validate --backfill-history once, up-front, so a bad value fails fast
+# before any provisioning side-effects. Empty (unset) is the default; only
+# values that survive validation participate in the backfill loop.
+if [[ -n "$BACKFILL_HISTORY_DAYS" ]]; then
+  if ! [[ "$BACKFILL_HISTORY_DAYS" =~ ^[0-9]+$ ]]; then
+    echo "bootstrap-memory: --backfill-history requires a non-negative integer (got: $BACKFILL_HISTORY_DAYS)" >&2
+    exit 2
+  fi
+  if (( BACKFILL_HISTORY_DAYS < 1 || BACKFILL_HISTORY_DAYS > 90 )); then
+    echo "bootstrap-memory: --backfill-history must be in [1, 90] days (got: $BACKFILL_HISTORY_DAYS); 0 is treated as OFF — omit the flag instead" >&2
+    exit 2
+  fi
+fi
 
 # -----------------------------------------------------------------------------
 # output / report setup
@@ -848,6 +878,92 @@ bootstrap_migrate_memory_daily_aggregate() {
 }
 
 # -----------------------------------------------------------------------------
+# step 4: opt-in historical backfill of memory-daily harvests (issue #322 Track C)
+# -----------------------------------------------------------------------------
+# When the operator passes `--backfill-history N`, fan harvest-daily out across
+# the [today-N, today-1] window for every active claude agent in the bootstrap
+# scope, with `--missing-only` so re-runs are no-ops. The flag is OFF by
+# default — opt-in is the contract because a real backfill of N=14 days across
+# 5 agents queues up to 70 [memory-daily-backfill] tasks at once. Tracks A+B
+# (PR #335 + PR #340) shipped the range mode and --missing-only filter that
+# this loop drives; this step is the post-install ergonomic that prevents
+# the pre-cron-registration coverage gap from going unnoticed.
+step_backfill_history_one() {
+  local agent="$1" home="$2" from_date="$3" to_date="$4"
+  local rc=0
+  local stderr_log="$REPORT_DIR/.backfill-history-$agent-$STAMP.stderr"
+  if "$BRIDGE_PYTHON" "$BRIDGE_HOME/bridge-memory.py" harvest-daily \
+        --agent "$agent" \
+        --home "$home" \
+        --workdir "$home" \
+        --from "$from_date" --to "$to_date" \
+        --tz Asia/Seoul \
+        --missing-only \
+        >/dev/null 2>"$stderr_log"; then
+    record "$agent" "backfill-history" "ok" \
+      "from=$from_date to=$to_date days=$BACKFILL_HISTORY_DAYS missing-only"
+    return 0
+  fi
+  rc=$?
+  # Per-agent failures must NOT abort the loop — tracked in the JSON report
+  # with the stderr tail so the operator can triage one agent without losing
+  # the rest.
+  local stderr_tail
+  stderr_tail="$(tr '\n' ' ' <"$stderr_log" 2>/dev/null | head -c 200)"
+  record "$agent" "backfill-history" "failed" \
+    "rc=$rc from=$from_date to=$to_date stderr=$stderr_tail"
+  return 1
+}
+
+run_backfill_history() {
+  # Caller guarantees BACKFILL_HISTORY_DAYS is a validated [1, 90] integer
+  # and MODE == "apply".
+  local n="$BACKFILL_HISTORY_DAYS"
+  local from_date to_date
+  # `date -v-Nd` is BSD/macOS; `date -d "N days ago"` is GNU. Try both so the
+  # bootstrap stays portable across the same OS matrix the rest of the bridge
+  # supports (Bash 4+, macOS + Linux).
+  from_date="$(date -v-"${n}"d +%Y-%m-%d 2>/dev/null \
+            || date -d "${n} days ago" +%Y-%m-%d 2>/dev/null \
+            || true)"
+  to_date="$(date -v-1d +%Y-%m-%d 2>/dev/null \
+          || date -d 'yesterday' +%Y-%m-%d 2>/dev/null \
+          || true)"
+  if [[ -z "$from_date" || -z "$to_date" ]]; then
+    record "$BRIDGE_ADMIN_AGENT" "backfill-history" "skip-date-resolve-failed" \
+      "n=$n from=$from_date to=$to_date"
+    note_drift
+    return 0
+  fi
+
+  if [[ "$AGENT_COUNT" -eq 0 ]]; then
+    record "$BRIDGE_ADMIN_AGENT" "backfill-history" "skip-no-agents" \
+      "n=$n from=$from_date to=$to_date"
+    return 0
+  fi
+
+  # Resolve agent (name, home) pairs from the cached snapshot taken at script
+  # start. We can't re-run list_active_claude_agents here without paying for
+  # another `agb agent list --json` round-trip; the snapshot is fresh enough
+  # for a single bootstrap run.
+  local ok_count=0 fail_count=0
+  while IFS=$'\t' read -r agent home; do
+    [[ -z "$agent" || -z "$home" ]] && continue
+    if step_backfill_history_one "$agent" "$home" "$from_date" "$to_date"; then
+      ok_count=$((ok_count + 1))
+    else
+      fail_count=$((fail_count + 1))
+    fi
+  done < "$AGENT_LIST_TMP"
+
+  record "$BRIDGE_ADMIN_AGENT" "backfill-history-summary" "complete" \
+    "n=$n from=$from_date to=$to_date agents=$AGENT_COUNT ok=$ok_count fail=$fail_count"
+  if (( fail_count > 0 )); then
+    note_drift
+  fi
+}
+
+# -----------------------------------------------------------------------------
 # run all steps
 # -----------------------------------------------------------------------------
 bootstrap_install_scripts
@@ -865,6 +981,18 @@ for spec in "${CRON_SPECS[@]}"; do
   IFS='|' read -r title sched tz script <<<"$spec"
   step_cron_one "$title" "$sched" "$tz" "$script"
 done
+
+# Issue #322 Track C — opt-in, apply-only. Runs after cron registration so a
+# fresh install ends with both forward (cron-driven) and backward (this loop)
+# coverage. dry-run / check skip the loop entirely; the harvester itself is
+# the SSOT for "what would be queued", and exposing a synthetic dry-run here
+# would double-code that decision logic.
+if [[ "$MODE" == "apply" && -n "$BACKFILL_HISTORY_DAYS" ]]; then
+  run_backfill_history
+elif [[ -n "$BACKFILL_HISTORY_DAYS" ]]; then
+  record "$BRIDGE_ADMIN_AGENT" "backfill-history" "skip-non-apply-mode" \
+    "mode=$MODE n=$BACKFILL_HISTORY_DAYS"
+fi
 
 rm -f "$EXISTING_CRONS_JSON" "$AGENT_LIST_TMP"
 

--- a/tests/bootstrap-backfill-history/check_invocation.py
+++ b/tests/bootstrap-backfill-history/check_invocation.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Static check helper for tests/bootstrap-backfill-history/smoke.sh.
+
+Parses bootstrap-memory-system.sh and reports whether the
+`step_backfill_history_one` and `run_backfill_history` functions contain the
+exact harvest-daily invocation contract from issue #322 Track C, plus whether
+the only call site of `run_backfill_history` is gated on both
+`BACKFILL_HISTORY_DAYS` (non-empty) and `MODE == "apply"`.
+
+Kept as a sibling script (instead of an inline heredoc inside smoke.sh) so
+unbalanced parentheses inside the Python body don't trip bash's
+command-substitution tokenizer — same workaround as
+tests/bootstrap-cron-schedules/parse_specs.py.
+
+Two subcommands:
+
+  invocation <bootstrap.sh>   prints {"missing": [...], "error": "..."}
+  gate       <bootstrap.sh>   prints {"errors": [...]}
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+
+def check_invocation(src_path: str) -> dict:
+    src = open(src_path, encoding="utf-8").read()
+
+    m = re.search(
+        r"step_backfill_history_one\s*\(\)\s*\{(.*?)\n\}",
+        src,
+        re.DOTALL,
+    )
+    if not m:
+        return {"error": "step_backfill_history_one function not found"}
+    body = m.group(1)
+
+    required = [
+        "harvest-daily",
+        "--agent",
+        "--from",
+        "--to",
+        "--missing-only",
+        "--tz Asia/Seoul",
+    ]
+    missing = [tok for tok in required if tok not in body]
+
+    # Confirm the harvester is invoked through bridge-memory.py at $BRIDGE_HOME
+    # (downstream installs run the harvester from $BRIDGE_HOME/bridge-memory.py
+    # per the upgrade contract).
+    if "bridge-memory.py" not in body:
+        missing.append("bridge-memory.py")
+
+    # Confirm per-agent failures don't abort the loop. step_backfill_history_one
+    # returns 1 on failure but the run_backfill_history caller swallows the rc
+    # into ok_count/fail_count counters.
+    m2 = re.search(
+        r"run_backfill_history\s*\(\)\s*\{(.*?)\n\}",
+        src,
+        re.DOTALL,
+    )
+    if not m2:
+        return {"error": "run_backfill_history function not found"}
+    caller = m2.group(1)
+    if "fail_count" not in caller or "ok_count" not in caller:
+        missing.append("per-agent failure isolation (ok_count/fail_count)")
+
+    # Confirm the cap stays at 90 days as documented in the brief.
+    if not re.search(r"BACKFILL_HISTORY_DAYS\s*>\s*90", src):
+        missing.append("upper bound check '> 90'")
+
+    return {"missing": missing}
+
+
+def check_gate(src_path: str) -> dict:
+    src = open(src_path, encoding="utf-8").read()
+
+    call_sites = []
+    for m in re.finditer(r"\brun_backfill_history\b", src):
+        pos = m.start()
+        line_start = src.rfind("\n", 0, pos) + 1
+        line_end = src.find("\n", pos)
+        line = src[line_start:line_end]
+        # Skip the function definition itself.
+        stripped = line.strip()
+        if stripped.startswith("run_backfill_history()"):
+            continue
+        # Skip any single-line definition variant.
+        if "()" in stripped and "{" in stripped:
+            continue
+        call_sites.append((pos, stripped))
+
+    errors = []
+    if not call_sites:
+        errors.append("run_backfill_history is never called")
+
+    for pos, line in call_sites:
+        # Walk backwards to find the enclosing `if [[ ... ]]; then` block.
+        # A 600-byte window is wide enough to span the multi-condition
+        # composite while staying inside the same block.
+        window = src[max(0, pos - 600):pos]
+        if "BACKFILL_HISTORY_DAYS" not in window:
+            errors.append(
+                f"call site '{line}' is not gated on BACKFILL_HISTORY_DAYS"
+            )
+        if "MODE" not in window or "apply" not in window:
+            errors.append(
+                f"call site '{line}' is not gated on MODE==apply"
+            )
+
+    return {"errors": errors}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(json.dumps({"error": "usage: check_invocation.py <invocation|gate> <bootstrap.sh>"}))
+        return 2
+    cmd = argv[1]
+    src_path = argv[2]
+    if cmd == "invocation":
+        print(json.dumps(check_invocation(src_path)))
+        return 0
+    if cmd == "gate":
+        print(json.dumps(check_gate(src_path)))
+        return 0
+    print(json.dumps({"error": f"unknown subcommand: {cmd}"}))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/bootstrap-backfill-history/smoke.sh
+++ b/tests/bootstrap-backfill-history/smoke.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# bootstrap-backfill-history smoke — regression guard for issue #322 Track C.
+#
+# What this asserts (against bootstrap-memory-system.sh):
+#
+#   1. --backfill-history is exposed in the --help output, the arg parser
+#      treats it as a non-negative integer in [1, 90], and rejects every
+#      out-of-range form (negative, zero, > 90, non-numeric) with exit 2
+#      and a stderr message. Validation must happen before any provisioning
+#      side-effect, so a bad N can't half-converge an install.
+#
+#   2. The bootstrap source contains the harvest-daily invocation that the
+#      brief specifies: per-agent loop, --from $(today-N) --to $(today-1)
+#      --agent <agent> --missing-only --tz Asia/Seoul. Static parse, not a
+#      live run, because the full apply path requires `agb cron create`,
+#      agent roster, and the librarian provisioner — none of which are
+#      reproducible inside an isolated tempdir without forking the entire
+#      daemon. Issue #322 Track A (PR #335) and Track B (PR #340) ship the
+#      harvest-daily flags this loop drives, so confirming the exact argv
+#      shape is enough to prevent drift.
+#
+#   3. Without --backfill-history, the bootstrap script never references the
+#      backfill code path. Idempotency-in-the-other-direction: a routine
+#      apply must NOT trigger a harvest fan-out.
+#
+# The Python static-parse logic lives in check_invocation.py (sibling). It
+# is a separate file because unbalanced parens inside a heredoc body trip
+# bash's command-substitution tokenizer (same workaround as
+# tests/bootstrap-cron-schedules/parse_specs.py).
+#
+# Usage:   ./tests/bootstrap-backfill-history/smoke.sh
+# Exit 0 if every assertion PASSes; exit 1 otherwise.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+BOOTSTRAP="$REPO_ROOT/bootstrap-memory-system.sh"
+HELPER="$(dirname "${BASH_SOURCE[0]}")/check_invocation.py"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+PASS=0
+FAIL=0
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$*"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  printf '[smoke][fail] %s\n' "$*" >&2
+}
+
+if [[ ! -r "$BOOTSTRAP" ]]; then
+  printf '[smoke][error] cannot find %s\n' "$BOOTSTRAP" >&2
+  exit 1
+fi
+if [[ ! -r "$HELPER" ]]; then
+  printf '[smoke][error] cannot find helper: %s\n' "$HELPER" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Isolated BRIDGE_HOME — the bootstrap script writes its first-run report
+# under $BRIDGE_HOME/state/bootstrap-memory/, so a clean tempdir keeps the
+# arg-parser-failure cases from polluting the operator's live install.
+# ---------------------------------------------------------------------------
+SMOKE_ROOT="$(mktemp -d -t bootstrap-backfill-smoke.XXXXXX)"
+trap 'rm -rf "$SMOKE_ROOT" 2>/dev/null || true' EXIT
+TEST_BRIDGE_HOME="$SMOKE_ROOT/bridge-home"
+mkdir -p "$TEST_BRIDGE_HOME/state"
+export BRIDGE_HOME="$TEST_BRIDGE_HOME"
+
+# ---------------------------------------------------------------------------
+# Assertion 1 — --help advertises --backfill-history.
+# ---------------------------------------------------------------------------
+HELP_OUT="$(bash "$BOOTSTRAP" --help 2>&1)"
+if printf '%s' "$HELP_OUT" | grep -q -- '--backfill-history'; then
+  pass "--help mentions --backfill-history"
+else
+  fail "--help missing --backfill-history flag"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 2 — every invalid value rejects with exit 2 + stderr message.
+#
+# We pass --apply explicitly so the validator runs the same code path the
+# operator hits in production. The fixture deliberately uses an empty
+# BRIDGE_HOME with no agb binary; that's fine because validation runs
+# before any subprocess is spawned.
+# ---------------------------------------------------------------------------
+assert_reject() {
+  local label="$1" value="$2" expected_substr="$3"
+  local out rc
+  out="$(bash "$BOOTSTRAP" --backfill-history "$value" --apply 2>&1)"
+  rc=$?
+  if [[ "$rc" -ne 2 ]]; then
+    fail "$label: expected exit 2, got $rc (out=${out:0:120})"
+    return
+  fi
+  if ! printf '%s' "$out" | grep -q -- "$expected_substr"; then
+    fail "$label: stderr missing substring '$expected_substr' (out=${out:0:160})"
+    return
+  fi
+  pass "$label rejected with exit 2"
+}
+
+assert_reject "non-numeric (abc)" "abc" "non-negative integer"
+assert_reject "negative (-5)"     "-5"  "non-negative integer"
+assert_reject "zero"              "0"   "must be in \[1, 90\]"
+assert_reject "out of range (91)" "91"  "must be in \[1, 90\]"
+
+# ---------------------------------------------------------------------------
+# Assertion 3 — the bootstrap source contains the harvest-daily invocation
+# the brief specifies. Static parse, because a live `apply --backfill-history`
+# requires the full daemon stack.
+# ---------------------------------------------------------------------------
+INVOCATION_JSON="$("$PYTHON" "$HELPER" invocation "$BOOTSTRAP" 2>&1)" || {
+  fail "invocation parse failed: $INVOCATION_JSON"
+  printf '\n[smoke] %d pass / %d fail\n' "$PASS" "$FAIL"
+  exit 1
+}
+
+PARSE_ERR="$(printf '%s' "$INVOCATION_JSON" | "$PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("error",""))')"
+if [[ -n "$PARSE_ERR" ]]; then
+  fail "source parse: $PARSE_ERR"
+else
+  MISSING_CSV="$(printf '%s' "$INVOCATION_JSON" | "$PYTHON" -c 'import json,sys; print(",".join(json.loads(sys.stdin.read()).get("missing",[])))')"
+  if [[ -z "$MISSING_CSV" ]]; then
+    pass "step_backfill_history_one invokes harvest-daily with --agent/--from/--to/--missing-only/--tz"
+  else
+    fail "step_backfill_history_one missing tokens: $MISSING_CSV"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 4 — opt-in only. When --backfill-history is omitted, the source
+# guards the harvester invocation behind a non-empty BACKFILL_HISTORY_DAYS
+# check AND MODE==apply.
+# ---------------------------------------------------------------------------
+GATE_JSON="$("$PYTHON" "$HELPER" gate "$BOOTSTRAP" 2>&1)" || {
+  fail "gate parse failed: $GATE_JSON"
+  printf '\n[smoke] %d pass / %d fail\n' "$PASS" "$FAIL"
+  exit 1
+}
+
+GATE_ERRORS_CSV="$(printf '%s' "$GATE_JSON" | "$PYTHON" -c 'import json,sys; print("|".join(json.loads(sys.stdin.read()).get("errors",[])))')"
+if [[ -z "$GATE_ERRORS_CSV" ]]; then
+  pass "run_backfill_history is gated on BACKFILL_HISTORY_DAYS + MODE=apply"
+else
+  fail "opt-in gate broken: $GATE_ERRORS_CSV"
+fi
+
+# ---------------------------------------------------------------------------
+# Assertion 5 — re-running --backfill-history is documented as a no-op via
+# --missing-only. The brief calls this out explicitly: idempotency.
+# ---------------------------------------------------------------------------
+if grep -qE 'Re-running .*no-op .*--missing-only' "$BOOTSTRAP"; then
+  pass "--help documents idempotency via --missing-only"
+else
+  fail "--help text missing idempotency note for repeated --backfill-history runs"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n[smoke] %d pass / %d fail\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Tracks A+B of #322 already shipped via PR #335 + PR #340 (harvest-daily `--from`/`--to` range mode + `--missing-only` filter). **Track C** is the post-install ergonomic: a `bootstrap-memory-system.sh apply --backfill-history N` flag (opt-in, default OFF) that fans `harvest-daily --missing-only` across every active claude agent for the `[today-N, today-1]` window. Closes the pre-cron-registration coverage gap without surprise queue spam.

## What changed

- `bootstrap-memory-system.sh`: new `--backfill-history N` arg (strict integer in [1, 90]), validated up-front so a bad N exits 2 before any provisioning side-effects. Two new helpers — `step_backfill_history_one` (per-agent harvest-daily invocation, captures stderr tail on failure) and `run_backfill_history` (cross-agent loop with ok/fail summary into the bootstrap JSON report).
- The fan-out runs after cron registration so a fresh install ends with both forward (cron-driven) and backward (this loop) coverage.
- `--dry-run` / `--check` modes skip the loop entirely; the harvester is the SSOT for "what would be queued" and we don't double-code that decision logic.
- BSD/GNU `date` portability: tries `date -v-Nd` first, falls back to `date -d 'N days ago'`.
- `tests/bootstrap-backfill-history/smoke.sh` + `check_invocation.py` — 8 sub-assertions covering: `--help` exposure, validation rejects non-numeric / negative / 0 / >90 with exit 2, `step_backfill_history_one` invokes harvest-daily with the expected argv, `run_backfill_history` gated on flag + apply mode.

## Verification

- `bash -n bootstrap-memory-system.sh tests/bootstrap-backfill-history/smoke.sh` PASS
- `shellcheck bootstrap-memory-system.sh tests/bootstrap-backfill-history/smoke.sh` PASS
- `python3 -c 'import ast; ast.parse(...)'` PASS
- `tests/bootstrap-backfill-history/smoke.sh` → **8 pass / 0 fail**

## Why static-parse smoke

The full apply path requires `agb cron create`, agent roster, and the librarian provisioner — none of which reproduce inside an isolated tempdir without forking the entire daemon. The smoke parses the bootstrap source statically to confirm the harvest-daily invocation has the expected argv shape (per-agent loop, `--from $(today-N)` `--to $(today-1)` `--agent X` `--missing-only` `--tz Asia/Seoul`). Tracks A+B already cover the harvester behavior; this smoke catches drift in how bootstrap drives it.

## Pair-review

Required per AGENTS.md. Orchestrator dispatches codex.

Addresses Track C of #322. Tracks A+B already merged.