### PR TITLE
template: bidirectional channel routing rule in Task Processing Protocol (#342)

### DIFF
--- a/agents/_template/CLAUDE.md
+++ b/agents/_template/CLAUDE.md
@@ -29,6 +29,7 @@ task를 수신하면 아래 순서를 반드시 따른다:
 3. **결과 전달**: 처리 결과를 요청자가 볼 수 있는 surface에 반드시 전달
    - 사람이 최종 수신자 → 연결된 채널 세션(Discord/Telegram)에 메시지
    - 다른 에이전트가 요청자 → `agent-bridge task create --to <요청자>`로 결과 전달
+   - 응답 surface 룰: input에 source 태그(`<channel source="discord|telegram">` 등) 있으면 그 surface 의 reply tool로 답한다. 태그가 없으면 TUI 세션이므로 transcript 출력으로 답한다. 한 turn 안에 여러 source가 섞이면 각 input마다 그 source의 surface로 답한다. 직전 메시지가 어디서 왔든 다음 메시지의 surface 선택을 일반화하지 않는다.
 4. **done**: `agb done <task_id> --note "요약"` — 반드시 note에 무엇을 했는지 기록
 - `NEXT-SESSION.md`은 **표준 파일명**이고, 에이전트 home의 `NEXT-SESSION.md`만 SessionStart hook이 자동으로 인지한다. `handoff-*.md`, `NEXT-SESSION-*.md` (suffix 추가), `next-session.md` (소문자) 같은 변형은 hook이 인지하지 못하는 **개인 노트**일 뿐이다. cross-session continuity 용도로는 정확히 `<agent-home>/NEXT-SESSION.md` 한 파일만 사용한다. 자세한 contract는 [`docs/agent-runtime/handoff-protocol.md`](../../docs/agent-runtime/handoff-protocol.md)에 있다.
 - **조용한 done 금지**: 결과를 아무에게도 전달하지 않은 채 done만 치는 것은 금지


### PR DESCRIPTION
## Summary

Closes the cross-routing pattern where channel-connected agents send TUI prompt answers to Discord/Telegram (or vice versa) by adding a single bidirectional surface rule to `agents/_template/CLAUDE.md` step 3 of the Task Processing Protocol.

Per operator decision (#342 body, plus Sean's quoted preference: "굳이 그렇게까지 해야해?"), this is a **text-only fix** — no source-labeling enforcement hook, no validation layer.

The added rule (Korean, matching the rest of the template's voice):

> 응답 surface 룰: input에 source 태그(`<channel source="discord|telegram">` 등) 있으면 그 surface 의 reply tool로 답한다. 태그가 없으면 TUI 세션이므로 transcript 출력으로 답한다. 한 turn 안에 여러 source가 섞이면 각 input마다 그 source의 surface로 답한다. 직전 메시지가 어디서 왔든 다음 메시지의 surface 선택을 일반화하지 않는다.

## Why this is enough

- The 16+ Claude/Codex agents that have Discord or Telegram plugins enabled all read this template's protocol when their `CLAUDE.md` is materialized from `_template/`.
- The current rule covered only "사람 = 채널" — silently leaving TUI operator inputs without a documented landing surface, which let the agent over-generalize from the previous turn's plugin reply.
- The new bullet sits inside step 3 (결과 전달), at the exact decision point where surface routing is chosen — so it shows up where it's needed.

## Out of scope (intentional)

- Discord/Telegram plugin `server.ts` instruction strings (line ~453 / ~385) carry the symmetric one-direction-only guide. **They are not vendored in this repo** — they live in the plugin marketplace repo. That is a separate follow-up PR against the plugin repo, tracked in #342's "다른 agent 동일 취약 분석" section.
- No source-labeling enforcement hook, no per-channel-id audit, no VERSION bump, no CHANGELOG entry.
- Issue #341 (system config mutation also being a text-only rule) is the same shape but a separate concern.

## Test plan

This is a text-only documentation change inside an agent profile template — no runtime code path is exercised, and there is no command to run that would verify the rule is followed (the rule is enforced by the agent reading its own `CLAUDE.md`).

- [x] `git diff` confirms a single-line addition under step 3 with no other content moved.
- [x] Bullet reads coherently in context of the surrounding step-3 sub-bullets (사람 수신 / agent 수신 / new surface rule).
- [x] No conflict with the Queue & Delivery section's "사람에게 보이는 Discord/Telegram 응답은 연결된 Claude 세션 안에서 처리한다" rule — the new bullet refines *which* surface inside a connected session.
- [ ] Manual confirmation post-merge: pull a fresh agent profile from `_template/`, ask a question on Discord and a question in TUI within the same turn, verify replies land on their respective surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)