### PR TITLE
hooks: gate system-config mutation behind admin + operator wrapper (#341)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -31,6 +31,7 @@ Usage:
   $CLI_NAME guard <status|scan|sanitize> ...
   $CLI_NAME diagnose <acl> [--json]
   $CLI_NAME knowledge <init|operator|capture|promote|search|lint> ...
+  $CLI_NAME config <set|get|list-protected> ...
   $CLI_NAME bundle <create|show> ...
   $CLI_NAME intake <triage|show> ...
   $CLI_NAME agent <create|list|show|start|safe-mode|stop|restart|attach> ...
@@ -150,6 +151,9 @@ Examples:
   $CLI_NAME bundle show 20260411T130000+0900-qa-handoff --json
   $CLI_NAME intake show 20260411T130000+0900-mail --json
   $CLI_NAME knowledge search --query "primary operator"
+  $CLI_NAME config list-protected
+  $CLI_NAME config get --path \$BRIDGE_HOME/agents/foo/.discord/access.json
+  $CLI_NAME config set --path \$BRIDGE_HOME/agents/foo/.discord/access.json --change groups.append=12345
   $CLI_NAME list
   $CLI_NAME kill 1
   $CLI_NAME kill all
@@ -517,6 +521,10 @@ PY
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-knowledge.sh" "$@"
       ;;
+    config)
+      shift
+      exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-config.sh" "$@"
+      ;;
     bundle)
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-bundle.sh" "$@"
@@ -672,7 +680,7 @@ PY
   # sqlite3 fallback path. Reject with an intent-recovery suggestion
   # before the spawn parser sees it.
   if [[ -n "${1:-}" && "${1:0:1}" != "-" ]]; then
-    _top_valid="admin bootstrap init version upgrade escalate upstream review user guard diagnose knowledge bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
+    _top_valid="admin bootstrap init version upgrade escalate upstream review user guard diagnose knowledge config bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
     _hint="$(bridge_suggest_subcommand "$1" "$_top_valid")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 명령입니다: $1"

--- a/bridge-config.py
+++ b/bridge-config.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""bridge-config.py — operator-gated wrapper for system-config mutations.
+
+Issue #341 makes this the only normal mutation path for the protected
+file list (see `lib/system_config_paths.py`). Direct Edit/Write tool
+calls against those paths are denied by `hooks/tool-policy.py`; the
+wrapper layers the caller-agent + caller-source check that the hook
+deliberately does not enforce.
+
+CLI shape mirrors the brief:
+
+    bridge-config.py set  --path <p> --change <expr> [--from <agent>]
+    bridge-config.py get  --path <p>
+    bridge-config.py list-protected [--json]
+
+`set` accepts:
+
+    key=value                     # top-level scalar set
+    a.b.c=value                   # nested scalar set (creates intermediate dicts)
+    a.b.append=value              # append to a list at a.b
+    a.b.remove=value              # remove first occurrence from a.b list
+
+Both before-sha256 and after-sha256 are recorded in the audit row so the
+operator can compare a wrapper-apply event against the file's at-rest
+hash on disk.
+
+Trust model recap (from the issue's "신뢰 경계 정의" table):
+
+    operator-tui          interactive shell (stdin+stdout are TTYs)
+    operator-trusted-id   set explicitly by a verified channel handler
+                          via BRIDGE_CALLER_SOURCE env
+    agent-direct          everything else — denied
+
+This file is invoked through `bridge-config.sh`, which is in turn dispatched
+by the `agent-bridge config …` subcommand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parent
+LIB_DIR = ROOT / "lib"
+if LIB_DIR.is_dir() and str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from system_config_paths import (  # noqa: E402
+    PROTECTED_GLOBS,
+    bridge_home_dir,
+    is_protected_path,
+    matched_pattern,
+)
+
+
+CALLER_SOURCE_OPERATOR_TUI = "operator-tui"
+CALLER_SOURCE_OPERATOR_TRUSTED_ID = "operator-trusted-id"
+CALLER_SOURCE_AGENT_DIRECT = "agent-direct"
+
+# Caller sources allowed to mutate. The operator can extend this set via
+# the env var below at deploy time, but the default set is deliberately
+# narrow — issue #341 §"권한 모델이 코드에 없고 가이드 텍스트에만 있음" is
+# the failure mode we are correcting.
+ALLOWED_CALLER_SOURCES = frozenset(
+    {CALLER_SOURCE_OPERATOR_TUI, CALLER_SOURCE_OPERATOR_TRUSTED_ID}
+)
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def detect_caller_source() -> str:
+    """Resolve which trust bucket the current process belongs to.
+
+    `BRIDGE_CALLER_SOURCE` is the explicit override a verified channel
+    handler uses to declare it has already validated the operator's
+    user_id against the canonical roster (issue #341 §B). When unset,
+    we fall back to TTY detection: an interactive shell invoking
+    `agent-bridge config set` is treated as operator-tui. Any
+    non-interactive non-overridden caller is `agent-direct` and the
+    wrapper denies the mutation.
+    """
+    explicit = os.environ.get("BRIDGE_CALLER_SOURCE", "").strip().lower()
+    if explicit in {CALLER_SOURCE_OPERATOR_TUI, CALLER_SOURCE_OPERATOR_TRUSTED_ID}:
+        return explicit
+    if explicit:
+        return CALLER_SOURCE_AGENT_DIRECT
+    try:
+        if sys.stdin.isatty() and sys.stdout.isatty():
+            return CALLER_SOURCE_OPERATOR_TUI
+    except (OSError, ValueError):
+        pass
+    return CALLER_SOURCE_AGENT_DIRECT
+
+
+def admin_agent_id() -> str:
+    return os.environ.get("BRIDGE_ADMIN_AGENT_ID", "").strip()
+
+
+def caller_agent_id(args: argparse.Namespace) -> str:
+    explicit = getattr(args, "from_agent", None)
+    if explicit:
+        return str(explicit).strip()
+    return os.environ.get("BRIDGE_AGENT_ID", "").strip()
+
+
+def caller_is_admin(agent: str) -> bool:
+    """The wrapper requires the caller to either be the explicit admin
+    agent or to invoke from operator-TUI without claiming an agent
+    identity at all (the human operator typing the command).
+
+    The check is intentionally stricter than the hook's `is_admin_agent`
+    — the hook gates by session-type files that an agent could in theory
+    plant; the wrapper requires either an env-declared admin id or a
+    TTY-resolved operator identity.
+    """
+    admin = admin_agent_id()
+    if admin and agent == admin:
+        return True
+    # Operator typing at a TTY without setting BRIDGE_AGENT_ID is the
+    # canonical "operator personally invoking" surface — accept it as
+    # admin-equivalent only when the caller-source is operator-tui.
+    if not agent and detect_caller_source() == CALLER_SOURCE_OPERATOR_TUI:
+        return True
+    return False
+
+
+def write_audit(detail: dict[str, Any]) -> Path:
+    """Write a `system_config_mutation` row to the bridge audit log.
+
+    Uses bridge-audit.py write to keep the hash chain intact — the
+    wrapper's rows hash-link with hook rows so an operator can verify
+    the audit log end-to-end.
+    """
+    log_path = audit_log_path()
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    detail_json = json.dumps(detail, ensure_ascii=True, sort_keys=True)
+    cmd = [
+        sys.executable,
+        str(ROOT / "bridge-audit.py"),
+        "write",
+        "--file",
+        str(log_path),
+        "--actor",
+        "wrapper",
+        "--action",
+        "system_config_mutation",
+        "--target",
+        detail.get("path", "") or "",
+        "--detail-json",
+        detail_json,
+    ]
+    try:
+        subprocess.run(cmd, check=False, capture_output=True)
+    except OSError:
+        # Fallback: append the raw record directly so a missing python
+        # interpreter does not silently swallow the audit row. Best-effort.
+        record = {
+            "ts": now_iso(),
+            "actor": "wrapper",
+            "action": "system_config_mutation",
+            "target": detail.get("path", ""),
+            "detail": detail,
+            "pid": os.getpid(),
+            "host": socket.gethostname(),
+        }
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=True) + "\n")
+    return log_path
+
+
+def audit_log_path() -> Path:
+    explicit = os.environ.get("BRIDGE_AUDIT_LOG", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return bridge_home_dir() / "logs" / "audit.jsonl"
+
+
+def file_sha256(path: Path) -> str:
+    if not path.exists():
+        return ""
+    try:
+        with path.open("rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        return ""
+
+
+def parse_change_expr(expr: str) -> tuple[list[str], str, str]:
+    """Split a change expression into (key path, operator, value).
+
+    The operator is one of `set` / `append` / `remove`. The brief lists
+    `<key=val|json-patch>` as syntax — we deliberately implement only the
+    bounded set that's enough for the four test scenarios. JSON patch is
+    out of scope for the v1 wrapper; an operator who needs full patch
+    semantics can run multiple set calls or extend this parser later.
+    """
+    if "=" not in expr:
+        raise SystemExit(f"--change must be 'key=value': {expr}")
+    raw_key, value = expr.split("=", 1)
+    raw_key = raw_key.strip()
+    if not raw_key:
+        raise SystemExit(f"--change key is empty: {expr}")
+    parts = raw_key.split(".")
+    if parts[-1] in {"append", "remove"}:
+        op = parts[-1]
+        keys = parts[:-1]
+    else:
+        op = "set"
+        keys = parts
+    if not keys:
+        raise SystemExit(f"--change key path is empty: {expr}")
+    return keys, op, value
+
+
+def apply_change_to_json(payload: Any, keys: list[str], op: str, value: str) -> Any:
+    if not isinstance(payload, dict):
+        raise SystemExit("config root must be a JSON object")
+    cursor: dict[str, Any] = payload
+    for key in keys[:-1]:
+        next_value = cursor.get(key)
+        if not isinstance(next_value, dict):
+            next_value = {}
+            cursor[key] = next_value
+        cursor = next_value
+    last_key = keys[-1]
+    if op == "set":
+        cursor[last_key] = _coerce_value(value)
+    elif op == "append":
+        existing = cursor.get(last_key)
+        if existing is None:
+            existing = []
+        if not isinstance(existing, list):
+            raise SystemExit(f"cannot append: {'.'.join(keys)} is not a list")
+        existing.append(_coerce_value(value))
+        cursor[last_key] = existing
+    elif op == "remove":
+        existing = cursor.get(last_key)
+        if not isinstance(existing, list):
+            raise SystemExit(f"cannot remove: {'.'.join(keys)} is not a list")
+        coerced = _coerce_value(value)
+        # Match either the coerced form or the literal string so the
+        # operator does not have to know whether the list stores ints
+        # or strings.
+        for candidate in (coerced, value):
+            if candidate in existing:
+                existing.remove(candidate)
+                break
+        cursor[last_key] = existing
+    else:
+        raise SystemExit(f"unsupported change op: {op}")
+    return payload
+
+
+def _coerce_value(value: str) -> Any:
+    """Best-effort scalar coercion: try JSON literal first, fall back to str.
+
+    `groups.append=1476851882533191681` is the obvious case — we want
+    the int form to land in JSON, not the quoted string.
+    """
+    stripped = value.strip()
+    if not stripped:
+        return value
+    try:
+        return json.loads(stripped)
+    except (ValueError, TypeError):
+        return value
+
+
+def atomic_write(path: Path, payload: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(payload, fh, ensure_ascii=False, indent=2)
+            fh.write("\n")
+        # Preserve mode if the original existed; default to 0600 otherwise
+        # so secrets-bearing config files (access.json) do not loosen.
+        if path.exists():
+            shutil.copymode(path, tmp_name)
+        else:
+            os.chmod(tmp_name, 0o600)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+def cmd_list_protected(args: argparse.Namespace) -> int:
+    if args.json:
+        print(json.dumps(list(PROTECTED_GLOBS), ensure_ascii=True, indent=2))
+        return 0
+    print(f"BRIDGE_HOME: {bridge_home_dir()}")
+    print("protected globs (relative to BRIDGE_HOME):")
+    for pattern in PROTECTED_GLOBS:
+        print(f"  {pattern}")
+    return 0
+
+
+def cmd_get(args: argparse.Namespace) -> int:
+    path = Path(args.path).expanduser()
+    if not is_protected_path(path):
+        print(
+            f"refusing: {path} is not in the system-config protected list",
+            file=sys.stderr,
+        )
+        return 2
+    if not path.exists():
+        print(f"missing: {path}", file=sys.stderr)
+        return 1
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"read failed: {exc}", file=sys.stderr)
+        return 1
+    sys.stdout.write(text)
+    if not text.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+def cmd_set(args: argparse.Namespace) -> int:
+    path = Path(args.path).expanduser()
+    caller_agent = caller_agent_id(args)
+    caller_source = detect_caller_source()
+
+    deny_reason: str | None = None
+    if not is_protected_path(path):
+        deny_reason = "path not in system-config protected list"
+    elif not caller_is_admin(caller_agent):
+        deny_reason = (
+            f"caller agent {caller_agent or '(none)'} is not the admin "
+            "agent — refusing system-config mutation"
+        )
+    elif caller_source not in ALLOWED_CALLER_SOURCES:
+        deny_reason = (
+            f"caller source {caller_source} is not allowed to mutate "
+            "system config (need operator-tui or operator-trusted-id)"
+        )
+
+    actor_label = caller_agent or (
+        "operator" if caller_source == CALLER_SOURCE_OPERATOR_TUI else "unknown"
+    )
+    if deny_reason is not None:
+        write_audit(
+            {
+                "kind": "system_config_mutation",
+                "actor": actor_label,
+                "actor_source": caller_source,
+                "trigger": "wrapper-deny",
+                "path": str(path),
+                "before_sha256": file_sha256(path),
+                "after_sha256": file_sha256(path),
+                "operation": args.change,
+                "matched_pattern": matched_pattern(path) or "",
+                "reason": deny_reason,
+            }
+        )
+        print(f"deny: {deny_reason}", file=sys.stderr)
+        return 3
+
+    # Limit to JSON files. Roster (`agent-roster.local.sh`) is a shell
+    # file; mutating it through this wrapper would require shell-aware
+    # editing that is well out of scope for v1. We still record a
+    # `wrapper-deny` row so the operator sees the attempt.
+    if path.suffix != ".json":
+        write_audit(
+            {
+                "kind": "system_config_mutation",
+                "actor": actor_label,
+                "actor_source": caller_source,
+                "trigger": "wrapper-deny",
+                "path": str(path),
+                "before_sha256": file_sha256(path),
+                "after_sha256": file_sha256(path),
+                "operation": args.change,
+                "matched_pattern": matched_pattern(path) or "",
+                "reason": "non-JSON system config files are not yet wrapper-mutable",
+            }
+        )
+        print(
+            f"deny: {path.suffix} files are not yet wrapper-mutable — "
+            "edit at the operator-TUI manually and re-run `agent-bridge config get` to verify",
+            file=sys.stderr,
+        )
+        return 4
+
+    keys, op, value = parse_change_expr(args.change)
+
+    before_sha = file_sha256(path)
+    payload: Any
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"read failed: {exc}", file=sys.stderr)
+            return 1
+    else:
+        payload = {}
+
+    payload = apply_change_to_json(payload, keys, op, value)
+    atomic_write(path, payload)
+    after_sha = file_sha256(path)
+
+    write_audit(
+        {
+            "kind": "system_config_mutation",
+            "actor": actor_label,
+            "actor_source": caller_source,
+            "trigger": "wrapper-apply",
+            "path": str(path),
+            "before_sha256": before_sha,
+            "after_sha256": after_sha,
+            "operation": args.change,
+            "matched_pattern": matched_pattern(path) or "",
+        }
+    )
+    print(f"applied: {path} ({op} {'.'.join(keys)})")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="agent-bridge config — gated system-config mutations (issue #341)",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    set_parser = sub.add_parser("set", help="apply a change to a protected path")
+    set_parser.add_argument("--path", required=True)
+    set_parser.add_argument(
+        "--change",
+        required=True,
+        help="change expression: key=value | a.b=value | a.b.append=value | a.b.remove=value",
+    )
+    set_parser.add_argument("--from", dest="from_agent", help="caller agent id (defaults to $BRIDGE_AGENT_ID)")
+    set_parser.set_defaults(handler=cmd_set)
+
+    get_parser = sub.add_parser("get", help="read a protected path")
+    get_parser.add_argument("--path", required=True)
+    get_parser.set_defaults(handler=cmd_get)
+
+    list_parser = sub.add_parser("list-protected", help="print the protected glob list")
+    list_parser.add_argument("--json", action="store_true")
+    list_parser.set_defaults(handler=cmd_list_protected)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bridge-config.py
+++ b/bridge-config.py
@@ -116,24 +116,28 @@ def caller_agent_id(args: argparse.Namespace) -> str:
 
 
 def caller_is_admin(agent: str) -> bool:
-    """The wrapper requires the caller to either be the explicit admin
-    agent or to invoke from operator-TUI without claiming an agent
-    identity at all (the human operator typing the command).
+    """Return True only when the caller has explicitly identified as the
+    admin agent.
 
-    The check is intentionally stricter than the hook's `is_admin_agent`
-    — the hook gates by session-type files that an agent could in theory
-    plant; the wrapper requires either an env-declared admin id or a
-    TTY-resolved operator identity.
+    Strict identity check (codex r1 #341 CP5): the caller must pass
+    ``--from <admin>`` *or* run with ``BRIDGE_AGENT_ID=<admin>`` set.
+    A missing caller agent is rejected even from operator-TUI — the
+    wrapper does not accept "operator at a TTY" as an implicit admin
+    bypass. Bridge-managed TUI sessions already export
+    ``BRIDGE_AGENT_ID``; operators running from a raw shell must pass
+    ``--from`` explicitly.
+
+    The check is intentionally stricter than the hook's
+    ``is_admin_agent`` — the hook gates by session-type files that an
+    agent could in theory plant; the wrapper requires an env- or
+    flag-declared admin id and refuses anonymous callers.
     """
     admin = admin_agent_id()
-    if admin and agent == admin:
-        return True
-    # Operator typing at a TTY without setting BRIDGE_AGENT_ID is the
-    # canonical "operator personally invoking" surface — accept it as
-    # admin-equivalent only when the caller-source is operator-tui.
-    if not agent and detect_caller_source() == CALLER_SOURCE_OPERATOR_TUI:
-        return True
-    return False
+    if not admin:
+        return False
+    if not agent:
+        return False
+    return agent == admin
 
 
 def write_audit(detail: dict[str, Any]) -> Path:
@@ -341,9 +345,18 @@ def cmd_set(args: argparse.Namespace) -> int:
     deny_reason: str | None = None
     if not is_protected_path(path):
         deny_reason = "path not in system-config protected list"
+    elif not caller_agent:
+        # Strict admin check (codex r1 #341 CP5): the caller must
+        # explicitly identify via --from or BRIDGE_AGENT_ID. Anonymous
+        # callers (raw shell with neither set) cannot satisfy the
+        # admin requirement, even from operator-TUI.
+        deny_reason = (
+            "caller_agent unspecified — pass `--from <admin-agent>` or set "
+            "BRIDGE_AGENT_ID before invoking `agent-bridge config set`"
+        )
     elif not caller_is_admin(caller_agent):
         deny_reason = (
-            f"caller agent {caller_agent or '(none)'} is not the admin "
+            f"caller agent {caller_agent} is not the admin "
             "agent — refusing system-config mutation"
         )
     elif caller_source not in ALLOWED_CALLER_SOURCES:
@@ -356,6 +369,10 @@ def cmd_set(args: argparse.Namespace) -> int:
         "operator" if caller_source == CALLER_SOURCE_OPERATOR_TUI else "unknown"
     )
     if deny_reason is not None:
+        # `after_sha256` is intentionally omitted on wrapper-deny — the
+        # change was prevented, so there is no "after" state (codex r1
+        # #341 CP3). The wrapper-apply row below is the only place
+        # `after_sha256` is meaningful.
         write_audit(
             {
                 "kind": "system_config_mutation",
@@ -364,7 +381,6 @@ def cmd_set(args: argparse.Namespace) -> int:
                 "trigger": "wrapper-deny",
                 "path": str(path),
                 "before_sha256": file_sha256(path),
-                "after_sha256": file_sha256(path),
                 "operation": args.change,
                 "matched_pattern": matched_pattern(path) or "",
                 "reason": deny_reason,
@@ -376,7 +392,8 @@ def cmd_set(args: argparse.Namespace) -> int:
     # Limit to JSON files. Roster (`agent-roster.local.sh`) is a shell
     # file; mutating it through this wrapper would require shell-aware
     # editing that is well out of scope for v1. We still record a
-    # `wrapper-deny` row so the operator sees the attempt.
+    # `wrapper-deny` row (without `after_sha256`, codex r1 #341 CP3) so
+    # the operator sees the attempt.
     if path.suffix != ".json":
         write_audit(
             {
@@ -386,7 +403,6 @@ def cmd_set(args: argparse.Namespace) -> int:
                 "trigger": "wrapper-deny",
                 "path": str(path),
                 "before_sha256": file_sha256(path),
-                "after_sha256": file_sha256(path),
                 "operation": args.change,
                 "matched_pattern": matched_pattern(path) or "",
                 "reason": "non-JSON system config files are not yet wrapper-mutable",
@@ -446,7 +462,16 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="change expression: key=value | a.b=value | a.b.append=value | a.b.remove=value",
     )
-    set_parser.add_argument("--from", dest="from_agent", help="caller agent id (defaults to $BRIDGE_AGENT_ID)")
+    set_parser.add_argument(
+        "--from",
+        dest="from_agent",
+        help=(
+            "caller agent id; required when BRIDGE_AGENT_ID is unset. "
+            "Operator workflows from a raw shell must pass --from <admin-agent> "
+            "explicitly — anonymous callers cannot satisfy the admin check "
+            "(codex r1 #341 CP5)."
+        ),
+    )
     set_parser.set_defaults(handler=cmd_set)
 
     get_parser = sub.add_parser("get", help="read a protected path")

--- a/bridge-config.sh
+++ b/bridge-config.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# bridge-config.sh — operator-gated system-config mutations (issue #341)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/bridge-lib.sh"
+bridge_load_roster
+bridge_require_python
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename "$0") set --path <p> --change <expr> [--from <agent>]
+  $(basename "$0") get --path <p>
+  $(basename "$0") list-protected [--json]
+
+Change expressions:
+  key=value                top-level set
+  a.b.c=value              nested set (creates intermediate dicts)
+  a.b.append=value         append to list at a.b
+  a.b.remove=value         remove first occurrence from a.b list
+
+Trust model (issue #341):
+  - Caller must be the admin agent (\$BRIDGE_ADMIN_AGENT_ID) or the
+    human operator at a TTY without \$BRIDGE_AGENT_ID set.
+  - Caller source must be operator-tui (TTY-detected) or
+    operator-trusted-id (set via \$BRIDGE_CALLER_SOURCE by a verified
+    channel handler).
+
+Examples:
+  $(basename "$0") list-protected
+  $(basename "$0") get  --path \$BRIDGE_HOME/agents/foo/.discord/access.json
+  $(basename "$0") set  --path \$BRIDGE_HOME/agents/foo/.discord/access.json \\
+                         --change groups.append=12345
+EOF
+}
+
+case "${1:-}" in
+  ""|-h|--help|help)
+    usage
+    [[ "${1:-}" == "" ]] && exit 1
+    exit 0
+    ;;
+esac
+
+exec python3 "$SCRIPT_DIR/bridge-config.py" "$@"

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -33,6 +33,18 @@ from bridge_hook_common import (  # noqa: E402
     write_audit,
 )
 
+# Importing the system-config protected-path SSOT requires lib/ on sys.path.
+# Keep this scoped to tool-policy.py rather than mutating bridge_hook_common
+# so the additional import surface stays auditable in one place.
+_LIB_DIR = ROOT / "lib"
+if _LIB_DIR.is_dir() and str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from system_config_paths import (  # noqa: E402
+    is_protected_path,
+    matched_pattern,
+)
+
 
 def roster_local_path() -> Path:
     return bridge_home_dir() / "agent-roster.local.sh"
@@ -171,14 +183,32 @@ def detect_target_agent(tool_name: str, tool_input: dict[str, Any], agent: str) 
     return None
 
 
+SYSTEM_CONFIG_DENY_REASON = (
+    "system config path requires `agent-bridge config set` "
+    "(direct Edit/Write blocked by issue #341 gating)"
+)
+
+
 def protected_path_reason(path: Path, agent: str) -> str | None:
     admin = is_admin_agent(agent)
+    # Order matters: keep the more-specific error messages (roster
+    # secrets / queue DB) ahead of the generic system-config deny so
+    # existing assertions in scripts/smoke-test.sh continue to find the
+    # narrower wording. The system-config gate (issue #341) catches the
+    # additional protected paths that don't map to a specific helper —
+    # access.json, cron job files, hooks settings, runtime config.
     if path == roster_local_path():
         if admin:
             return None
         return "shared roster secrets are not available inside Claude tool calls"
     if path == task_db_path():
         return "direct queue DB access is blocked; use `agb` queue commands instead"
+    # Issue #341: remaining system-config paths must flow through the
+    # wrapper. Even admin agents are denied at the hook level — the
+    # wrapper layers the operator-source check on top, so a hook bypass
+    # would defeat that check entirely.
+    if is_protected_path(path):
+        return SYSTEM_CONFIG_DENY_REASON
     if admin:
         return None
     target = target_agent_for_path(path, agent)
@@ -346,6 +376,75 @@ def _bash_argv_references_path(command: str, protected: Path) -> bool:
     return False
 
 
+def _bash_argv_references_system_config(command: str) -> bool:
+    """Return True if any positional/file-valued argv token in *command*
+    points at a path that :func:`is_protected_path` matches.
+
+    Uses the same skip/treat rules as ``_bash_argv_references_path`` so a
+    `--body "agents/foo/.discord/access.json"` mention does not trigger.
+    A `shlex.split` ``ValueError`` (unbalanced quotes etc.) falls back to
+    a substring scan of the static suffixes that uniquely identify
+    protected globs; this is a weaker check but keeps us no worse than
+    the pre-#341 baseline.
+    """
+    if not command:
+        return False
+    try:
+        tokens = shlex.split(command, posix=True, comments=False)
+    except ValueError:
+        for needle in (".discord/access.json", ".telegram/access.json",
+                       "cron/jobs.json", "runtime/openclaw.json",
+                       "runtime/bridge-config.json"):
+            if needle in command:
+                return True
+        return False
+
+    def _check_value(value: str) -> bool:
+        for fragment in _alias_path_fragments(value):
+            expanded = os.path.expandvars(os.path.expanduser(fragment))
+            if not expanded:
+                continue
+            try:
+                candidate = Path(expanded)
+            except Exception:
+                continue
+            if is_protected_path(candidate):
+                return True
+        return False
+
+    skip_next_payload = False
+    treat_next_as_value = False
+    for tok in tokens:
+        if skip_next_payload:
+            skip_next_payload = False
+            continue
+        if treat_next_as_value:
+            treat_next_as_value = False
+            if _check_value(tok):
+                return True
+            continue
+        if tok in _STRING_PAYLOAD_FLAGS:
+            skip_next_payload = True
+            continue
+        if tok in _FILE_VALUED_FLAGS:
+            treat_next_as_value = True
+            continue
+        if tok.startswith("--") and "=" in tok:
+            flag, _, value = tok.partition("=")
+            if flag in _STRING_PAYLOAD_FLAGS:
+                continue
+            if flag in _FILE_VALUED_FLAGS:
+                if _check_value(value):
+                    return True
+                continue
+            if _check_value(value):
+                return True
+            continue
+        if _check_value(tok):
+            return True
+    return False
+
+
 def protected_alias_reason(text: str, agent: str) -> str | None:
     home_root = agent_home_root()
     admin = is_admin_agent(agent)
@@ -356,12 +455,21 @@ def protected_alias_reason(text: str, agent: str) -> str | None:
     # `--description "…"`, etc.) is skipped. `protected_path_reason`
     # continues to guard the non-Bash tool surfaces (Read/Write) with the
     # structurally-correct `Path ==` check.
+    #
+    # Order mirrors `protected_path_reason`: narrow roster / queue DB
+    # messages first so existing smoke tests find their specific wording,
+    # then the issue #341 generic system-config gate.
     if _bash_argv_references_path(text, roster_local_path()):
         if admin:
             return None
         return "shared roster secrets are not available inside Claude tool calls"
     if _bash_argv_references_path(text, task_db_path()):
         return "direct queue DB access is blocked; use `agb` queue commands instead"
+    # Issue #341: system-config paths get the same argv-based check; the
+    # wrapper command is the only normal mutation surface. Applies to
+    # admin too — wrapper enforces the operator-source layer.
+    if _bash_argv_references_system_config(text):
+        return SYSTEM_CONFIG_DENY_REASON
     if admin:
         return None
     aliases = [
@@ -433,6 +541,111 @@ def pretool_block_response(reason: str, detail: dict[str, Any]) -> None:
     sys.stdout.write("\n")
 
 
+def _system_config_path_from_input(tool_name: str, tool_input: dict[str, Any]) -> Path | None:
+    """Return the protected-path argument that triggered the hook deny.
+
+    Read from `file_path` / `path` for non-Bash tools; for Bash, scan the
+    shlex-tokenised command for the first token that resolves under the
+    protected list. Returns None when no protected path is identifiable —
+    in that case the audit row falls back to a path-less detail.
+    """
+    if tool_name != "Bash":
+        for key in ("file_path", "path"):
+            raw = str(tool_input.get(key) or "").strip()
+            if not raw:
+                continue
+            try:
+                candidate = Path(raw).expanduser()
+            except Exception:
+                continue
+            if is_protected_path(candidate):
+                return candidate
+        return None
+    command = str(tool_input.get("command") or "")
+    try:
+        tokens = shlex.split(command, posix=True, comments=False)
+    except ValueError:
+        return None
+    for tok in tokens:
+        for fragment in _alias_path_fragments(tok):
+            expanded = os.path.expandvars(os.path.expanduser(fragment))
+            if not expanded:
+                continue
+            try:
+                candidate = Path(expanded)
+            except Exception:
+                continue
+            if is_protected_path(candidate):
+                return candidate
+    return None
+
+
+def _path_sha256(path: Path) -> str:
+    """sha256 of *path* contents, or empty string if unreadable.
+
+    The hook records both before and after sha to satisfy the audit shape
+    in issue #341. On hook-deny no mutation actually happens, so before
+    and after are the same value — that's the documented invariant the
+    operator can rely on when distinguishing hook-deny rows from wrapper
+    rows.
+    """
+    try:
+        import hashlib
+        with path.open("rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        return ""
+
+
+def _write_system_config_audit_row(
+    agent: str,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    target_path: Path | None,
+) -> None:
+    """Write the issue #341 `system_config_mutation` audit row.
+
+    Shape mirrors the brief exactly: actor, actor_source, trigger,
+    path, before/after sha, operation. Hook-side actor_source is always
+    `agent-direct` — the hook fires before any caller-source promotion
+    that the wrapper would otherwise apply.
+    """
+    if target_path is None:
+        path_str = ""
+        before = ""
+        after = ""
+    else:
+        path_str = str(target_path)
+        sha = _path_sha256(target_path)
+        before = sha
+        after = sha
+    if tool_name == "Bash":
+        operation = truncate_text(str(tool_input.get("command") or ""), 240)
+    else:
+        operation = json.dumps(
+            {
+                key: truncate_text(str(value), 120)
+                for key, value in tool_input.items()
+                if value
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    detail = {
+        "kind": "system_config_mutation",
+        "actor": agent or "unknown",
+        "actor_source": "agent-direct",
+        "trigger": "hook-deny",
+        "path": path_str,
+        "before_sha256": before,
+        "after_sha256": after,
+        "operation": truncate_text(operation, 240),
+        "tool_name": tool_name,
+        "matched_pattern": matched_pattern(target_path) or "" if target_path else "",
+    }
+    write_audit("system_config_mutation", agent or "unknown", detail)
+
+
 def handle_pretool(payload: dict[str, Any], agent: str) -> int:
     tool_name = str(payload.get("tool_name") or "")
     tool_input = payload.get("tool_input") or {}
@@ -469,6 +682,13 @@ def handle_pretool(payload: dict[str, Any], agent: str) -> int:
     if reason:
         detail["reason"] = reason
         write_audit("agent_tool_denied", agent or "unknown", detail)
+        if reason == SYSTEM_CONFIG_DENY_REASON:
+            _write_system_config_audit_row(
+                agent,
+                tool_name,
+                tool_input,
+                _system_config_path_from_input(tool_name, tool_input),
+            )
         pretool_block_response(reason, detail)
         return 0
     return 0

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -43,6 +43,7 @@ if _LIB_DIR.is_dir() and str(_LIB_DIR) not in sys.path:
 from system_config_paths import (  # noqa: E402
     is_protected_path,
     matched_pattern,
+    protected_literal_suffixes,
 )
 
 
@@ -188,6 +189,12 @@ SYSTEM_CONFIG_DENY_REASON = (
     "(direct Edit/Write blocked by issue #341 gating)"
 )
 
+ROSTER_LOCAL_DENY_REASON = (
+    "agent-roster.local.sh is a protected system config path. "
+    "Use `agent-bridge config set` instead. Admin role does not exempt "
+    "this path — the wrapper preserves the audit chain."
+)
+
 
 def protected_path_reason(path: Path, agent: str) -> str | None:
     admin = is_admin_agent(agent)
@@ -197,9 +204,15 @@ def protected_path_reason(path: Path, agent: str) -> str | None:
     # narrower wording. The system-config gate (issue #341) catches the
     # additional protected paths that don't map to a specific helper —
     # access.json, cron job files, hooks settings, runtime config.
+    #
+    # Admin agents do NOT bypass roster_local_path (codex r1 #341 CP2):
+    # the file is in PROTECTED_GLOBS and the wrapper is the only sound
+    # mutation surface even for admin. The wrapper itself runs from
+    # operator-TUI, so legitimate operator workflows still succeed —
+    # only direct Edit/Write attempts are blocked.
     if path == roster_local_path():
         if admin:
-            return None
+            return ROSTER_LOCAL_DENY_REASON
         return "shared roster secrets are not available inside Claude tool calls"
     if path == task_db_path():
         return "direct queue DB access is blocked; use `agb` queue commands instead"
@@ -383,19 +396,20 @@ def _bash_argv_references_system_config(command: str) -> bool:
     Uses the same skip/treat rules as ``_bash_argv_references_path`` so a
     `--body "agents/foo/.discord/access.json"` mention does not trigger.
     A `shlex.split` ``ValueError`` (unbalanced quotes etc.) falls back to
-    a substring scan of the static suffixes that uniquely identify
-    protected globs; this is a weaker check but keeps us no worse than
-    the pre-#341 baseline.
+    a substring scan of the literal suffixes derived from
+    :func:`system_config_paths.protected_literal_suffixes` — the single
+    source of truth. The fallback is weaker than the structural argv
+    check but keeps us no worse than the pre-#341 baseline, and it
+    cannot drift from ``PROTECTED_GLOBS`` because the suffix list is
+    derived at call time.
     """
     if not command:
         return False
     try:
         tokens = shlex.split(command, posix=True, comments=False)
     except ValueError:
-        for needle in (".discord/access.json", ".telegram/access.json",
-                       "cron/jobs.json", "runtime/openclaw.json",
-                       "runtime/bridge-config.json"):
-            if needle in command:
+        for needle in protected_literal_suffixes():
+            if needle and needle in command:
                 return True
         return False
 
@@ -460,8 +474,10 @@ def protected_alias_reason(text: str, agent: str) -> str | None:
     # messages first so existing smoke tests find their specific wording,
     # then the issue #341 generic system-config gate.
     if _bash_argv_references_path(text, roster_local_path()):
+        # Admin no longer bypasses the roster path (codex r1 #341 CP2);
+        # mutations route through `agent-bridge config set`.
         if admin:
-            return None
+            return ROSTER_LOCAL_DENY_REASON
         return "shared roster secrets are not available inside Claude tool calls"
     if _bash_argv_references_path(text, task_db_path()):
         return "direct queue DB access is blocked; use `agb` queue commands instead"
@@ -583,11 +599,11 @@ def _system_config_path_from_input(tool_name: str, tool_input: dict[str, Any]) -
 def _path_sha256(path: Path) -> str:
     """sha256 of *path* contents, or empty string if unreadable.
 
-    The hook records both before and after sha to satisfy the audit shape
-    in issue #341. On hook-deny no mutation actually happens, so before
-    and after are the same value — that's the documented invariant the
-    operator can rely on when distinguishing hook-deny rows from wrapper
-    rows.
+    The hook records the at-rest sha as `before_sha256`. There is
+    intentionally no `after_sha256` on hook-deny rows — the change was
+    prevented, so there is no "after" state to record (codex r1 #341
+    CP3). The wrapper-apply row is the only place `after_sha256` is
+    meaningful.
     """
     try:
         import hashlib
@@ -605,20 +621,19 @@ def _write_system_config_audit_row(
 ) -> None:
     """Write the issue #341 `system_config_mutation` audit row.
 
-    Shape mirrors the brief exactly: actor, actor_source, trigger,
-    path, before/after sha, operation. Hook-side actor_source is always
-    `agent-direct` — the hook fires before any caller-source promotion
-    that the wrapper would otherwise apply.
+    Shape mirrors the brief: actor, actor_source, trigger, path,
+    before_sha256, operation. ``after_sha256`` is intentionally omitted
+    on hook-deny — no mutation occurred, so an "after" hash would
+    misrepresent the audit chain (codex r1 #341 CP3). Hook-side
+    actor_source is always `agent-direct` — the hook fires before any
+    caller-source promotion that the wrapper would otherwise apply.
     """
     if target_path is None:
         path_str = ""
         before = ""
-        after = ""
     else:
         path_str = str(target_path)
-        sha = _path_sha256(target_path)
-        before = sha
-        after = sha
+        before = _path_sha256(target_path)
     if tool_name == "Bash":
         operation = truncate_text(str(tool_input.get("command") or ""), 240)
     else:
@@ -638,7 +653,6 @@ def _write_system_config_audit_row(
         "trigger": "hook-deny",
         "path": path_str,
         "before_sha256": before,
-        "after_sha256": after,
         "operation": truncate_text(operation, 240),
         "tool_name": tool_name,
         "matched_pattern": matched_pattern(target_path) or "" if target_path else "",
@@ -682,7 +696,11 @@ def handle_pretool(payload: dict[str, Any], agent: str) -> int:
     if reason:
         detail["reason"] = reason
         write_audit("agent_tool_denied", agent or "unknown", detail)
-        if reason == SYSTEM_CONFIG_DENY_REASON:
+        # Both the generic system-config deny and the more-specific
+        # roster-local deny (codex r1 #341 CP2) are protected-path
+        # mutations and need a `system_config_mutation` audit row so
+        # the operator can attribute the attempt.
+        if reason in (SYSTEM_CONFIG_DENY_REASON, ROSTER_LOCAL_DENY_REASON):
             _write_system_config_audit_row(
                 agent,
                 tool_name,

--- a/lib/system_config_paths.py
+++ b/lib/system_config_paths.py
@@ -114,3 +114,45 @@ def matched_pattern(path: Path) -> str | None:
             if fnmatch.fnmatchcase(relative, pattern):
                 return pattern
     return None
+
+
+def protected_literal_suffixes() -> tuple[str, ...]:
+    """Return literal substrings derived from PROTECTED_GLOBS that uniquely
+    identify a protected path inside a free-form command string.
+
+    Used by `hooks/tool-policy.py` as its degraded substring-scan fallback
+    when ``shlex.split`` rejects a command (unbalanced quotes etc.). For
+    each glob we pick the longest literal segment between wildcards (or
+    the whole pattern when there is no wildcard) and strip leading slashes
+    so the needle matches whether the command quoted the absolute or
+    relative form.
+
+    Examples (matching ``PROTECTED_GLOBS`` at the top of this file):
+
+    - ``agents/*/.discord/access.json`` → ``.discord/access.json``
+    - ``state/cron/*.json``             → ``state/cron/``
+    - ``hooks/*``                       → ``hooks/``
+    - ``agent-roster.local.sh``         → ``agent-roster.local.sh``
+
+    The returned tuple is the single source of truth for that fallback —
+    do not maintain a parallel list anywhere else (codex r1 #341 CP1).
+    """
+    suffixes: list[str] = []
+    seen: set[str] = set()
+    for pattern in PROTECTED_GLOBS:
+        if "*" in pattern:
+            # Pick the longest literal segment between (or around) `*`s.
+            segments = [seg for seg in pattern.split("*") if seg]
+            if not segments:
+                continue
+            needle = max(segments, key=len)
+        else:
+            needle = pattern
+        # Drop a leading slash so the needle matches both the absolute
+        # form (`/a/b/c`) and the relative form (`a/b/c`) of the path.
+        if needle.startswith("/"):
+            needle = needle[1:]
+        if needle and needle not in seen:
+            seen.add(needle)
+            suffixes.append(needle)
+    return tuple(suffixes)

--- a/lib/system_config_paths.py
+++ b/lib/system_config_paths.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Single source of truth for system-config protected paths (issue #341).
+
+The PreToolUse hook (`hooks/tool-policy.py`) and the `agent-bridge config`
+wrapper (`bridge-config.py`) both consult this module to decide whether a
+given path is "system config" and therefore blocked for direct Edit/Write
+mutation. New protected paths land here; both surfaces pick them up.
+
+Path patterns are expressed as fnmatch globs anchored to BRIDGE_HOME.  We
+intentionally do not collapse them into regexes: globs are easier to audit
+when the operator extends the list, and the matcher already runs against
+both literal and resolved forms so symlink games do not bypass the gate.
+
+Hook-side denial vs wrapper-side denial differ in *what* they block:
+
+- The hook always denies an Edit/Write tool call to a protected path,
+  regardless of which agent is making the call. The denial points the
+  agent at the wrapper. This is the line-of-defence the issue's drift
+  case study (4 agents' access.json silently mutated) needs.
+- The wrapper layers caller-agent + caller-source on top. Even an admin
+  agent can only mutate when the call comes from operator-attached TUI
+  or a trusted-id-match channel surface.
+
+Tests under `tests/system-config-gating/` exercise both paths.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+from pathlib import Path
+
+
+# The canonical glob list. Each pattern is matched against the path made
+# relative to BRIDGE_HOME. `agents/*/...` means "any direct child agent".
+# This is the list called out in issue #341 §"Protected paths".
+PROTECTED_GLOBS: tuple[str, ...] = (
+    "agents/*/.discord/access.json",
+    "agents/*/.telegram/access.json",
+    "agent-roster.local.sh",
+    "cron/jobs.json",
+    "runtime/openclaw.json",
+    "runtime/bridge-config.json",
+    "state/cron/*.json",
+    "hooks/*",
+)
+
+
+def bridge_home_dir() -> Path:
+    """Mirror of bridge_hook_common.bridge_home_dir() for in-tree use.
+
+    Duplicated here so this module has zero imports from `hooks/`; the
+    wrapper (`bridge-config.py`) lives at the repo root and would otherwise
+    have to set sys.path before importing.
+    """
+    explicit = os.environ.get("BRIDGE_HOME", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return Path.home() / ".agent-bridge"
+
+
+def _candidate_relatives(path: Path, home: Path) -> list[str]:
+    """Return BRIDGE_HOME-relative path strings to compare against globs.
+
+    Includes both the literal path and `path.resolve()` so a symlink that
+    points at a protected file is matched. `relative_to` failure on either
+    leg is silently dropped — the caller treats no-match as "not protected".
+    """
+    candidates: list[Path] = [path, path.expanduser()]
+    try:
+        candidates.append(path.expanduser().resolve())
+    except OSError:
+        pass
+
+    relatives: list[str] = []
+    home_resolved: Path
+    try:
+        home_resolved = home.resolve()
+    except OSError:
+        home_resolved = home
+    for candidate in candidates:
+        for root in (home, home_resolved):
+            try:
+                rel = candidate.relative_to(root)
+            except (ValueError, OSError):
+                continue
+            relatives.append(str(rel))
+    return relatives
+
+
+def is_protected_path(path: Path) -> bool:
+    """Return True when *path* falls inside the protected system-config list.
+
+    Used by both the PreToolUse hook and the wrapper; the wrapper wraps
+    its own additional caller checks around this call.
+    """
+    home = bridge_home_dir()
+    for relative in _candidate_relatives(path, home):
+        for pattern in PROTECTED_GLOBS:
+            if fnmatch.fnmatchcase(relative, pattern):
+                return True
+    return False
+
+
+def matched_pattern(path: Path) -> str | None:
+    """Return the protected glob *path* matches, or None.
+
+    Convenience helper for audit detail — the caller logs which glob fired
+    so the operator can see whether the gate is over- or under-reaching.
+    """
+    home = bridge_home_dir()
+    for relative in _candidate_relatives(path, home):
+        for pattern in PROTECTED_GLOBS:
+            if fnmatch.fnmatchcase(relative, pattern):
+                return pattern
+    return None

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# system-config-gating smoke — issue #341 hook + wrapper coverage.
+#
+# Asserts:
+#
+#   1. Hook denial path: feed a synthetic Claude PreToolUse Edit payload
+#      against agents/x/.discord/access.json into hooks/tool-policy.py.
+#      Expect deny + a `system_config_mutation` audit row with
+#      `trigger=hook-deny`.
+#
+#   2. Wrapper happy path: invoke `bridge-config.py set` from operator-
+#      attached TUI context (BRIDGE_CALLER_SOURCE=operator-tui). Expect
+#      the file mutated + a `system_config_mutation` audit row with
+#      `trigger=wrapper-apply` and matching before/after sha256.
+#
+#   3. Wrapper denial — non-admin caller: invoke from a non-admin
+#      BRIDGE_AGENT_ID. Expect refusal + `wrapper-deny` audit row.
+#
+#   4. Wrapper denial — untrusted ID-match attempt: caller-source falls
+#      back to `agent-direct` (no TTY, no env override). Expect refusal
+#      + `wrapper-deny` audit row.
+#
+# Uses an isolated mktemp BRIDGE_HOME — never touches the live install.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+if [[ ! -x "$PYTHON" && ! -r "$PYTHON" ]]; then
+  printf '[smoke][error] python3 not found at %s\n' "$PYTHON" >&2
+  exit 2
+fi
+
+BRIDGE_HOME="$(mktemp -d -t agb-341-smoke.XXXXXX)"
+export BRIDGE_HOME
+trap 'rm -rf "$BRIDGE_HOME"' EXIT
+
+ADMIN_AGENT="patch"
+NON_ADMIN_AGENT="huchu"
+ACCESS_PATH="$BRIDGE_HOME/agents/$ADMIN_AGENT/.discord/access.json"
+AUDIT_LOG="$BRIDGE_HOME/logs/audit.jsonl"
+
+mkdir -p "$BRIDGE_HOME/agents/$ADMIN_AGENT/.discord"
+mkdir -p "$BRIDGE_HOME/logs"
+cat >"$ACCESS_PATH" <<'JSON'
+{
+  "version": 1,
+  "groups": [],
+  "policy": "owner-only"
+}
+JSON
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+}
+
+audit_has_kind_trigger() {
+  local kind="$1"
+  local trigger="$2"
+  [[ -f "$AUDIT_LOG" ]] || return 1
+  "$PYTHON" - "$AUDIT_LOG" "$kind" "$trigger" <<'PY'
+import json, sys
+path, kind, trigger = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        detail = row.get("detail")
+        if not isinstance(detail, dict):
+            continue
+        if detail.get("kind") == kind and detail.get("trigger") == trigger:
+            sys.exit(0)
+sys.exit(1)
+PY
+}
+
+run_hook_pretool_payload() {
+  local payload="$1"
+  local agent="$2"
+  BRIDGE_AGENT_ID="$agent" \
+    BRIDGE_HOME="$BRIDGE_HOME" \
+    BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
+    BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT" \
+    "$PYTHON" "$REPO_ROOT/hooks/tool-policy.py" <<<"$payload"
+}
+
+# --- Scenario 1: hook denial path ---------------------------------------
+sce1_payload=$(cat <<JSON
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Edit",
+  "tool_use_id": "test-1",
+  "session_id": "test-session-1",
+  "tool_input": {
+    "file_path": "$ACCESS_PATH",
+    "old_string": "[]",
+    "new_string": "[12345]"
+  }
+}
+JSON
+)
+
+sce1_out="$(run_hook_pretool_payload "$sce1_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce1_out" == *'"permissionDecision"'*'"deny"'* ]] && [[ "$sce1_out" == *"system config path"* ]]; then
+  pass "scenario 1: hook denied Edit on protected access.json"
+else
+  fail "scenario 1: hook did not deny — output: $sce1_out"
+fi
+
+if audit_has_kind_trigger "system_config_mutation" "hook-deny"; then
+  pass "scenario 1: audit row trigger=hook-deny present"
+else
+  fail "scenario 1: missing system_config_mutation/hook-deny audit row"
+fi
+
+# --- Scenario 2: wrapper happy path -------------------------------------
+# Operator at a TTY → BRIDGE_CALLER_SOURCE=operator-tui. caller agent
+# unset (operator personally). Should mutate the file.
+before_sha="$("$PYTHON" -c "import hashlib,sys; sys.stdout.write(hashlib.sha256(open('$ACCESS_PATH','rb').read()).hexdigest())")"
+sce2_out="$(BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
+  BRIDGE_CALLER_SOURCE="operator-tui" \
+  BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT" \
+  BRIDGE_AGENT_ID="" \
+  "$PYTHON" "$REPO_ROOT/bridge-config.py" set \
+    --path "$ACCESS_PATH" \
+    --change "groups.append=12345" 2>&1 || true)"
+after_sha="$("$PYTHON" -c "import hashlib,sys; sys.stdout.write(hashlib.sha256(open('$ACCESS_PATH','rb').read()).hexdigest())")"
+if [[ "$sce2_out" == applied:* ]] && [[ "$before_sha" != "$after_sha" ]]; then
+  pass "scenario 2: wrapper applied groups.append=12345"
+else
+  fail "scenario 2: wrapper did not apply — output: $sce2_out / before=$before_sha after=$after_sha"
+fi
+
+if "$PYTHON" -c "
+import json,sys
+data=json.load(open('$ACCESS_PATH'))
+sys.exit(0 if data.get('groups')==[12345] else 1)
+"; then
+  pass "scenario 2: groups list now [12345]"
+else
+  fail "scenario 2: groups list did not become [12345]"
+fi
+
+if audit_has_kind_trigger "system_config_mutation" "wrapper-apply"; then
+  pass "scenario 2: audit row trigger=wrapper-apply present"
+else
+  fail "scenario 2: missing system_config_mutation/wrapper-apply audit row"
+fi
+
+# --- Scenario 3: wrapper denial — non-admin caller ----------------------
+sce3_out="$(BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
+  BRIDGE_CALLER_SOURCE="operator-tui" \
+  BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT" \
+  BRIDGE_AGENT_ID="$NON_ADMIN_AGENT" \
+  "$PYTHON" "$REPO_ROOT/bridge-config.py" set \
+    --path "$ACCESS_PATH" \
+    --change "groups.append=99999" 2>&1 || true)"
+if [[ "$sce3_out" == *"deny:"* ]] && [[ "$sce3_out" == *"not the admin"* ]]; then
+  pass "scenario 3: wrapper rejected non-admin caller"
+else
+  fail "scenario 3: wrapper did not reject non-admin — output: $sce3_out"
+fi
+
+if audit_has_kind_trigger "system_config_mutation" "wrapper-deny"; then
+  pass "scenario 3: audit row trigger=wrapper-deny present"
+else
+  fail "scenario 3: missing system_config_mutation/wrapper-deny audit row"
+fi
+
+# Confirm the file was NOT mutated.
+if "$PYTHON" -c "
+import json,sys
+data=json.load(open('$ACCESS_PATH'))
+sys.exit(1 if 99999 in data.get('groups',[]) else 0)
+"; then
+  pass "scenario 3: file unchanged after non-admin deny"
+else
+  fail "scenario 3: file was mutated despite deny"
+fi
+
+# --- Scenario 4: wrapper denial — untrusted source -----------------------
+# Caller is the admin id but caller-source is agent-direct (no TTY, no env
+# override). Mirrors the channel-message path: the message sender is not
+# a verified operator, so even if the queue task says "patch please run X"
+# the wrapper refuses.
+sce4_out="$(BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
+  BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT" \
+  BRIDGE_AGENT_ID="$ADMIN_AGENT" \
+  BRIDGE_CALLER_SOURCE="agent-direct" \
+  "$PYTHON" "$REPO_ROOT/bridge-config.py" set \
+    --path "$ACCESS_PATH" \
+    --change "groups.append=88888" \
+    </dev/null 2>&1 || true)"
+if [[ "$sce4_out" == *"deny:"* ]] && [[ "$sce4_out" == *"agent-direct"* ]]; then
+  pass "scenario 4: wrapper rejected untrusted-source admin call"
+else
+  fail "scenario 4: wrapper did not reject untrusted source — output: $sce4_out"
+fi
+
+# --- Scenario 5: list-protected is read-only and unrestricted -----------
+sce5_out="$(BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
+  BRIDGE_AGENT_ID="$NON_ADMIN_AGENT" \
+  "$PYTHON" "$REPO_ROOT/bridge-config.py" list-protected 2>&1 || true)"
+if [[ "$sce5_out" == *"agents/*/.discord/access.json"* ]]; then
+  pass "scenario 5: list-protected shows access.json glob"
+else
+  fail "scenario 5: list-protected did not include access.json — output: $sce5_out"
+fi
+
+# --- Summary -------------------------------------------------------------
+printf '\n[smoke] system-config-gating: %d pass, %d fail\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf '[smoke] failing scenarios:\n' >&2
+  for failure in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$failure" >&2
+  done
+  exit 1
+fi
+exit 0

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -1,24 +1,38 @@
 #!/usr/bin/env bash
 # system-config-gating smoke — issue #341 hook + wrapper coverage.
 #
-# Asserts:
+# Asserts the runtime contract for every audit row trigger:
 #
 #   1. Hook denial path: feed a synthetic Claude PreToolUse Edit payload
 #      against agents/x/.discord/access.json into hooks/tool-policy.py.
 #      Expect deny + a `system_config_mutation` audit row with
-#      `trigger=hook-deny`.
+#      `trigger=hook-deny`, no `after_sha256` field (codex r1 #341 CP3).
 #
 #   2. Wrapper happy path: invoke `bridge-config.py set` from operator-
-#      attached TUI context (BRIDGE_CALLER_SOURCE=operator-tui). Expect
-#      the file mutated + a `system_config_mutation` audit row with
-#      `trigger=wrapper-apply` and matching before/after sha256.
+#      attached TUI context (BRIDGE_CALLER_SOURCE=operator-tui) with
+#      --from <admin>. Expect the file mutated + a `system_config_mutation`
+#      audit row with `trigger=wrapper-apply` and matching before/after
+#      sha256. `after_sha256` MUST be present (the only trigger that
+#      records it).
 #
 #   3. Wrapper denial — non-admin caller: invoke from a non-admin
-#      BRIDGE_AGENT_ID. Expect refusal + `wrapper-deny` audit row.
+#      BRIDGE_AGENT_ID. Expect refusal + `wrapper-deny` audit row,
+#      no `after_sha256`.
 #
 #   4. Wrapper denial — untrusted ID-match attempt: caller-source falls
 #      back to `agent-direct` (no TTY, no env override). Expect refusal
-#      + `wrapper-deny` audit row.
+#      + `wrapper-deny` audit row, no `after_sha256`.
+#
+#   5. list-protected is read-only and unrestricted (no audit row).
+#
+#   6. Wrapper denial — non-JSON path: invoke `set` against
+#      agent-roster.local.sh (a shell file in PROTECTED_GLOBS). Expect
+#      refusal + `wrapper-deny` audit row with reason mentioning the
+#      manual flow, no `after_sha256` (codex r1 #341 CP10).
+#
+# Every audit row is structurally validated (Fix CP8): kind, trigger,
+# path, before_sha256, actor, actor_source, operation, conditional
+# after_sha256.
 #
 # Uses an isolated mktemp BRIDGE_HOME — never touches the live install.
 
@@ -39,6 +53,7 @@ trap 'rm -rf "$BRIDGE_HOME"' EXIT
 ADMIN_AGENT="patch"
 NON_ADMIN_AGENT="huchu"
 ACCESS_PATH="$BRIDGE_HOME/agents/$ADMIN_AGENT/.discord/access.json"
+ROSTER_PATH="$BRIDGE_HOME/agent-roster.local.sh"
 AUDIT_LOG="$BRIDGE_HOME/logs/audit.jsonl"
 
 mkdir -p "$BRIDGE_HOME/agents/$ADMIN_AGENT/.discord"
@@ -50,6 +65,11 @@ cat >"$ACCESS_PATH" <<'JSON'
   "policy": "owner-only"
 }
 JSON
+
+cat >"$ROSTER_PATH" <<'SH'
+# agent-roster.local.sh fixture for #341 smoke
+export BRIDGE_AGENT_CHANNELS_patch="discord:fixture"
+SH
 
 PASS=0
 FAIL=0
@@ -66,14 +86,29 @@ fail() {
   printf '[smoke][fail] %s\n' "$1" >&2
 }
 
-audit_has_kind_trigger() {
-  local kind="$1"
-  local trigger="$2"
+# audit_row_shape_check <expected_trigger> <expected_path> <expect_after_sha256: 0|1>
+#
+# Walks the audit log for the most recent system_config_mutation row whose
+# trigger and path match the expected values, then validates the field
+# contract (codex r1 #341 CP8):
+#   - kind == "system_config_mutation"
+#   - trigger ∈ {hook-deny, wrapper-apply, wrapper-deny}
+#   - path matches expected
+#   - before_sha256 non-empty
+#   - after_sha256 present iff trigger == wrapper-apply (per CP3)
+#   - actor and actor_source non-empty strings
+#   - operation field present
+audit_row_shape_check() {
+  local trigger="$1"
+  local expected_path="$2"
+  local expect_after="$3"
   [[ -f "$AUDIT_LOG" ]] || return 1
-  "$PYTHON" - "$AUDIT_LOG" "$kind" "$trigger" <<'PY'
+  "$PYTHON" - "$AUDIT_LOG" "$trigger" "$expected_path" "$expect_after" <<'PY'
 import json, sys
-path, kind, trigger = sys.argv[1], sys.argv[2], sys.argv[3]
-with open(path, "r", encoding="utf-8") as fh:
+log_path, trigger, expected_path, expect_after_raw = sys.argv[1:5]
+expect_after = expect_after_raw == "1"
+matches = []
+with open(log_path, "r", encoding="utf-8") as fh:
     for line in fh:
         line = line.strip()
         if not line:
@@ -85,9 +120,51 @@ with open(path, "r", encoding="utf-8") as fh:
         detail = row.get("detail")
         if not isinstance(detail, dict):
             continue
-        if detail.get("kind") == kind and detail.get("trigger") == trigger:
-            sys.exit(0)
-sys.exit(1)
+        if detail.get("kind") != "system_config_mutation":
+            continue
+        if detail.get("trigger") != trigger:
+            continue
+        if expected_path and detail.get("path") != expected_path:
+            continue
+        matches.append(detail)
+if not matches:
+    print(f"no row matched trigger={trigger} path={expected_path}", file=sys.stderr)
+    sys.exit(2)
+detail = matches[-1]
+errors = []
+allowed_triggers = {"hook-deny", "wrapper-apply", "wrapper-deny"}
+if detail.get("trigger") not in allowed_triggers:
+    errors.append(f"unexpected trigger {detail.get('trigger')!r}")
+before = detail.get("before_sha256")
+if not isinstance(before, str) or not before:
+    errors.append("before_sha256 missing/empty")
+has_after = "after_sha256" in detail
+if expect_after:
+    if not has_after:
+        errors.append("after_sha256 missing on wrapper-apply row")
+    else:
+        after = detail.get("after_sha256")
+        if not isinstance(after, str) or not after:
+            errors.append("after_sha256 empty on wrapper-apply row")
+else:
+    if has_after:
+        errors.append(
+            f"after_sha256 must be absent on trigger={detail.get('trigger')!r} "
+            "(codex r1 #341 CP3)"
+        )
+actor = detail.get("actor")
+if not isinstance(actor, str) or not actor:
+    errors.append("actor missing/empty")
+actor_source = detail.get("actor_source")
+if not isinstance(actor_source, str) or not actor_source:
+    errors.append("actor_source missing/empty")
+if "operation" not in detail:
+    errors.append("operation field missing")
+if errors:
+    for err in errors:
+        print(err, file=sys.stderr)
+    sys.exit(3)
+sys.exit(0)
 PY
 }
 
@@ -124,21 +201,21 @@ else
   fail "scenario 1: hook did not deny — output: $sce1_out"
 fi
 
-if audit_has_kind_trigger "system_config_mutation" "hook-deny"; then
-  pass "scenario 1: audit row trigger=hook-deny present"
+if sce1_shape_err="$(audit_row_shape_check "hook-deny" "$ACCESS_PATH" 0 2>&1)"; then
+  pass "scenario 1: hook-deny audit row shape valid (no after_sha256)"
 else
-  fail "scenario 1: missing system_config_mutation/hook-deny audit row"
+  fail "scenario 1: hook-deny audit row shape invalid — $sce1_shape_err"
 fi
 
 # --- Scenario 2: wrapper happy path -------------------------------------
 # Operator at a TTY → BRIDGE_CALLER_SOURCE=operator-tui. caller agent
-# unset (operator personally). Should mutate the file.
+# must be the admin id (codex r1 #341 CP5: anonymous caller is denied).
 before_sha="$("$PYTHON" -c "import hashlib,sys; sys.stdout.write(hashlib.sha256(open('$ACCESS_PATH','rb').read()).hexdigest())")"
 sce2_out="$(BRIDGE_HOME="$BRIDGE_HOME" \
   BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
   BRIDGE_CALLER_SOURCE="operator-tui" \
   BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT" \
-  BRIDGE_AGENT_ID="" \
+  BRIDGE_AGENT_ID="$ADMIN_AGENT" \
   "$PYTHON" "$REPO_ROOT/bridge-config.py" set \
     --path "$ACCESS_PATH" \
     --change "groups.append=12345" 2>&1 || true)"
@@ -159,10 +236,10 @@ else
   fail "scenario 2: groups list did not become [12345]"
 fi
 
-if audit_has_kind_trigger "system_config_mutation" "wrapper-apply"; then
-  pass "scenario 2: audit row trigger=wrapper-apply present"
+if sce2_shape_err="$(audit_row_shape_check "wrapper-apply" "$ACCESS_PATH" 1 2>&1)"; then
+  pass "scenario 2: wrapper-apply audit row shape valid (after_sha256 present)"
 else
-  fail "scenario 2: missing system_config_mutation/wrapper-apply audit row"
+  fail "scenario 2: wrapper-apply audit row shape invalid — $sce2_shape_err"
 fi
 
 # --- Scenario 3: wrapper denial — non-admin caller ----------------------
@@ -180,10 +257,10 @@ else
   fail "scenario 3: wrapper did not reject non-admin — output: $sce3_out"
 fi
 
-if audit_has_kind_trigger "system_config_mutation" "wrapper-deny"; then
-  pass "scenario 3: audit row trigger=wrapper-deny present"
+if sce3_shape_err="$(audit_row_shape_check "wrapper-deny" "$ACCESS_PATH" 0 2>&1)"; then
+  pass "scenario 3: wrapper-deny audit row shape valid (no after_sha256)"
 else
-  fail "scenario 3: missing system_config_mutation/wrapper-deny audit row"
+  fail "scenario 3: wrapper-deny audit row shape invalid — $sce3_shape_err"
 fi
 
 # Confirm the file was NOT mutated.
@@ -217,6 +294,12 @@ else
   fail "scenario 4: wrapper did not reject untrusted source — output: $sce4_out"
 fi
 
+if sce4_shape_err="$(audit_row_shape_check "wrapper-deny" "$ACCESS_PATH" 0 2>&1)"; then
+  pass "scenario 4: wrapper-deny audit row shape valid (no after_sha256)"
+else
+  fail "scenario 4: wrapper-deny audit row shape invalid — $sce4_shape_err"
+fi
+
 # --- Scenario 5: list-protected is read-only and unrestricted -----------
 sce5_out="$(BRIDGE_HOME="$BRIDGE_HOME" \
   BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
@@ -226,6 +309,45 @@ if [[ "$sce5_out" == *"agents/*/.discord/access.json"* ]]; then
   pass "scenario 5: list-protected shows access.json glob"
 else
   fail "scenario 5: list-protected did not include access.json — output: $sce5_out"
+fi
+
+if [[ "$sce5_out" == *"agent-roster.local.sh"* ]]; then
+  pass "scenario 5: list-protected shows agent-roster.local.sh"
+else
+  fail "scenario 5: list-protected did not include agent-roster.local.sh — output: $sce5_out"
+fi
+
+# --- Scenario 6: wrapper denial — non-JSON protected path ---------------
+# agent-roster.local.sh is a shell file in PROTECTED_GLOBS. Wrapper must
+# refuse with a wrapper-deny row + a manual-flow message; the operator
+# uses the queued admin task to edit the shell file by hand. Codex r1
+# #341 CP10 surfaced this gap — the path was implemented but never
+# exercised by smoke.
+sce6_out="$(BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
+  BRIDGE_CALLER_SOURCE="operator-tui" \
+  BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT" \
+  BRIDGE_AGENT_ID="$ADMIN_AGENT" \
+  "$PYTHON" "$REPO_ROOT/bridge-config.py" set \
+    --path "$ROSTER_PATH" \
+    --change "BRIDGE_AGENT_CHANNELS_patch=discord:other" 2>&1 || true)"
+if [[ "$sce6_out" == *"deny:"* ]] && [[ "$sce6_out" == *"not yet wrapper-mutable"* ]]; then
+  pass "scenario 6: wrapper rejected non-JSON protected path (agent-roster.local.sh)"
+else
+  fail "scenario 6: wrapper did not reject non-JSON path — output: $sce6_out"
+fi
+
+if sce6_shape_err="$(audit_row_shape_check "wrapper-deny" "$ROSTER_PATH" 0 2>&1)"; then
+  pass "scenario 6: non-JSON wrapper-deny audit row shape valid (no after_sha256)"
+else
+  fail "scenario 6: non-JSON wrapper-deny audit row shape invalid — $sce6_shape_err"
+fi
+
+# Confirm the roster file was NOT mutated by the failed call.
+if grep -q "discord:fixture" "$ROSTER_PATH" && ! grep -q "discord:other" "$ROSTER_PATH"; then
+  pass "scenario 6: agent-roster.local.sh contents unchanged after deny"
+else
+  fail "scenario 6: roster file was mutated despite deny"
 fi
 
 # --- Summary -------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause** — `agents/<>/.discord/access.json` and the rest of the system-config surface (roster, cron jobs, runtime/openclaw, hooks settings) had no runtime gate. Issue #341 documented a real drift case where 4 agents' access.json silently grew adjacent-channel groups post-upgrade with no audit row to attribute the mutation. The protection was guidance text in `ACCESS.md`, not enforced code.
- **Fix mechanism** — Three-piece gate per the issue's proposal:
  1. `lib/system_config_paths.py` carries the protected glob list as the single SSOT.
  2. `hooks/tool-policy.py` denies any Edit/Write tool call (Bash argv or file_path/path) against a protected path and writes a `system_config_mutation` audit row tagged `trigger=hook-deny`. Existing #252/#240/roster/queue-DB assertions are preserved by ordering: narrow messages fire before the new generic system-config deny.
  3. `agent-bridge config set|get|list-protected` (new wrapper) is the only normal mutation surface. `set` requires caller agent == admin **and** caller-source ∈ {`operator-tui`, `operator-trusted-id`} (TTY-detected by default, override via `BRIDGE_CALLER_SOURCE` for verified channel handlers). Atomic write, sha256 before/after, audit row `wrapper-apply` / `wrapper-deny`.
- **Out of scope** — full file-level ACL matrix (Track A), drift cron (Track E), text-file (.sh) mutations through the wrapper. Roster lives in the protected list but stays gated by the existing more-specific roster-secrets path; non-JSON mutations get a `wrapper-deny` row pointing the operator at the manual flow.

## Test plan

- [x] `python3 -m py_compile` on `lib/system_config_paths.py`, `hooks/tool-policy.py`, `bridge-config.py` — pass.
- [x] `bash -n` on `bridge-config.sh`, `tests/system-config-gating/smoke.sh`, `agent-bridge` — pass.
- [x] `shellcheck` on `bridge-config.sh` and the smoke fixture — pass.
- [x] **`./tests/system-config-gating/smoke.sh` (new)** — 10/10 assertions green under an isolated mktemp `BRIDGE_HOME`. Covers hook denial, wrapper happy path, non-admin caller deny, untrusted-source admin deny, list-protected read.
- [x] Manual regression: `protected_alias_reason("cat <roster>", "self")` still returns the specific "shared roster secrets…" wording; `protected_alias_reason("sqlite3 <db>", "self")` still returns "direct queue DB…". Existing #252 fixture in `scripts/smoke-test.sh` continues to pass.
- [ ] Live verification deferred to operator: invoke `agent-bridge config set --path agents/foo/.discord/access.json --change groups.append=12345` on a runtime install and confirm the audit row in `~/.agent-bridge/logs/audit.jsonl`.

## Verification commands (reproducible)

```bash
git checkout fix/341-system-config-gating
python3 -m py_compile lib/system_config_paths.py hooks/tool-policy.py bridge-config.py
bash -n bridge-config.sh tests/system-config-gating/smoke.sh agent-bridge
shellcheck bridge-config.sh tests/system-config-gating/smoke.sh
./tests/system-config-gating/smoke.sh
```

(#341)

## Round 2 update (5f49d65)

Codex r1 returned `needs-more` with 6 FAIL. Round 2 commit `5f49d65` addresses every callout:

- **CP1 SSOT** — `hooks/tool-policy.py` no longer carries a hardcoded
  protected-suffix list. The `shlex.split` fallback now consumes
  `protected_literal_suffixes()` derived from `PROTECTED_GLOBS` at call
  time, so the substring scan cannot drift from the SSOT.
- **CP2 admin bypass** — `agent-roster.local.sh` is now denied even for
  admin agents at the hook layer. The wrapper itself runs from
  operator-TUI so legitimate operator workflows still succeed; only
  direct Edit/Write/Bash attempts are blocked. New deny reason:
  `agent-roster.local.sh is a protected system config path. Use
  \`agent-bridge config set\` instead. Admin role does not exempt this
  path — the wrapper preserves the audit chain.`
- **CP3 audit row contract** — `after_sha256` is now omitted (not
  empty-stringed) on `hook-deny` and `wrapper-deny` rows. The field is
  present only on `wrapper-apply`. Both `hooks/tool-policy.py` and
  `bridge-config.py` updated.
- **CP5 strict admin check** — `caller_is_admin` requires the caller
  to identify via `--from <admin>` or `BRIDGE_AGENT_ID=<admin>`.
  Anonymous callers (raw shell with neither set) are rejected with
  `caller_agent unspecified — pass --from <admin-agent> or set
  BRIDGE_AGENT_ID before invoking 'agent-bridge config set'`. The
  `--from` help text documents this.
- **CP8 smoke shape coverage** — every audit row in the smoke fixture
  is now structurally validated: `kind`, `trigger`, `path`,
  `before_sha256`, `actor`, `actor_source`, `operation`, and the
  conditional `after_sha256` contract from CP3.
- **CP10 non-JSON path** — new scenario 6 invokes `set` against
  `agent-roster.local.sh` (the shell file in PROTECTED_GLOBS) and
  asserts the wrapper-deny row + manual-flow message. The roster file
  is verified unchanged after the deny.

**Intentional gap (CP10 follow-up).** Non-JSON paths (shell, env files)
are rejected from the wrapper because automated `key=val` patching of
bash syntax is unsafe. Manual edits via the protected admin agent's
queued maintenance task are the documented flow. JSON-patch and
shell-rewriter wrappers are deferred follow-ups.

### r2 verification

- `python3 -m py_compile lib/system_config_paths.py hooks/tool-policy.py
  bridge-config.py` — pass
- `bash -n bridge-config.sh tests/system-config-gating/smoke.sh` — pass
- `shellcheck bridge-config.sh tests/system-config-gating/smoke.sh` — pass
- `./tests/system-config-gating/smoke.sh` — **15/15 pass across 6
  scenarios** (was 10/10 across 5 in r1)
- `./scripts/smoke-test.sh` #240 + #252 tool-policy assertions still
  pass — no regression to the existing roster/queue-DB wording
