### PR TITLE
isolate: harden dev-channels picker auto-accept for isolated runtime

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -336,16 +336,37 @@ bridge_run_schedule_dev_channels_accept() {
   local launch_cmd="$1"
 
   bridge_run_should_auto_accept_dev_channels "$launch_cmd" || return 0
-  log_line "[info] auto-accepting Claude development-channels prompt for allowlisted dev channel(s)"
+
+  # Operator-tunable timeout. Default 60s covers 4-plugin cold-start
+  # (bun teams + bun ms365 + node cosmax-* MCP servers) on isolated
+  # linux-user agents where claude takes longer than the historic 15s
+  # budget to draw the development-channels picker. Reduce to 5–15s in
+  # diagnosis to fail-loud quickly.
+  local accept_timeout="${BRIDGE_RUN_DEV_CHANNELS_ACCEPT_TIMEOUT_SECONDS:-60}"
+  [[ "$accept_timeout" =~ ^[0-9]+$ ]] || accept_timeout=60
+  (( accept_timeout > 0 )) || accept_timeout=60
+
+  log_line "[info] auto-accepting Claude development-channels prompt for allowlisted dev channel(s) (timeout=${accept_timeout}s)"
+
+  # Background child must not silently swallow stderr — that hid every
+  # picker-stuck warning before. Route its output to the agent log files
+  # the parent already maintains so wait_for_prompt's bridge_warn lines
+  # land where operators look. accept_timeout is passed in as $3 because
+  # the child runs in a fresh `bash -lc` shell with `set -u` — outer
+  # locals are not visible.
   (
     "$BRIDGE_BASH_BIN" -lc '
       set -euo pipefail
       script_dir="$1"
       session="$2"
+      accept_timeout="$3"
       source "$script_dir/bridge-lib.sh"
-      bridge_tmux_wait_for_prompt "$session" claude 15 1 >/dev/null 2>&1 || true
-    ' -- "$SCRIPT_DIR" "$SESSION"
-  ) >/dev/null 2>&1 &
+      if ! bridge_tmux_wait_for_prompt "$session" claude "$accept_timeout" 1; then
+        printf "[%s] [warn] auto-accept dev-channels: bridge_tmux_wait_for_prompt failed/timeout on session=%s\n" \
+          "$(date "+%Y-%m-%d %H:%M:%S")" "$session" >&2
+      fi
+    ' -- "$SCRIPT_DIR" "$SESSION" "$accept_timeout"
+  ) </dev/null >>"$LOGFILE" 2>>"$ERRFILE" &
 }
 
 bridge_run_sync_dev_plugin_cache() {

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -408,9 +408,18 @@ bridge_tmux_session_inject_busy() {
 bridge_tmux_claude_advance_blocker() {
   local session="$1"
   local allow_devchannels="${2:-0}"
+  local expected_state="${3:-}"
   local state=""
 
   state="$(bridge_tmux_claude_blocker_state "$session")"
+  # If the caller specified an expected state and the live state has
+  # diverged (e.g. devchannels picker cleared and trust prompt appeared
+  # in the same poll), refuse to advance — the caller's counter would
+  # otherwise mis-attribute the action and widen the budget cap that
+  # belongs to the new state.
+  if [[ -n "$expected_state" && "$state" != "$expected_state" ]]; then
+    return 1
+  fi
   case "$state" in
     trust|summary)
       bridge_tmux_send_keys_with_timeout "tmux_send_advance_blocker_${state}" \
@@ -471,7 +480,7 @@ bridge_tmux_wait_for_prompt() {
       state="$(bridge_tmux_claude_blocker_state "$session" 2>/dev/null || printf 'none')"
       case "$state" in
         trust|summary)
-          if bridge_tmux_claude_advance_blocker "$session" 0; then
+          if bridge_tmux_claude_advance_blocker "$session" 0 "$state"; then
             trust_summary_actions=$((trust_summary_actions + 1))
             # Re-check prompt before declaring failure; the just-sent C-m
             # may have cleared the blocker.
@@ -488,7 +497,7 @@ bridge_tmux_wait_for_prompt() {
           ;;
         devchannels)
           if [[ "$allow_devchannels" == "1" ]]; then
-            if bridge_tmux_claude_advance_blocker "$session" 1; then
+            if bridge_tmux_claude_advance_blocker "$session" 1 devchannels; then
               devchannels_actions=$((devchannels_actions + 1))
               # Re-check prompt before failing — the picker often clears
               # on the final allowed Enter and we don't want to declare

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -440,7 +440,23 @@ bridge_tmux_wait_for_prompt() {
   local allow_devchannels="${4:-0}"
   local start_ts
   local elapsed
-  local bootstrap_actions=0
+  local state=""
+
+  # State-specific advance budgets:
+  # - trust/summary: existing 4-action limit, preserved to avoid regressing
+  #   non-devchannels callers (regular agent restarts, codex sessions, etc.).
+  # - devchannels: separate, larger, env-overridable budget so an isolated
+  #   agent that needs a 2-step picker confirm + concurrent trust prompt
+  #   doesn't exhaust on the 4th attempt before claude finishes drawing.
+  #   Default 12 covers picker-confirm-2-step plus a few stale-pane redraws;
+  #   operators can tighten it via BRIDGE_TMUX_DEV_CHANNELS_MAX_ADVANCE for
+  #   faster fail-loud during diagnosis.
+  local trust_summary_actions=0
+  local trust_summary_max=4
+  local devchannels_actions=0
+  local devchannels_max="${BRIDGE_TMUX_DEV_CHANNELS_MAX_ADVANCE:-12}"
+  [[ "$devchannels_max" =~ ^[0-9]+$ ]] || devchannels_max=12
+  (( devchannels_max > 0 )) || devchannels_max=12
 
   bridge_tmux_engine_requires_prompt "$engine" || return 0
   if bridge_tmux_session_has_prompt "$session" "$engine"; then
@@ -452,14 +468,51 @@ bridge_tmux_wait_for_prompt() {
   start_ts="$(date +%s)"
   while true; do
     if [[ "$engine" == "claude" ]]; then
-      if bridge_tmux_claude_advance_blocker "$session" "$allow_devchannels"; then
-        bootstrap_actions=$((bootstrap_actions + 1))
-        if (( bootstrap_actions >= 4 )); then
-          return 1
-        fi
-      else
-        sleep 0.2
-      fi
+      state="$(bridge_tmux_claude_blocker_state "$session" 2>/dev/null || printf 'none')"
+      case "$state" in
+        trust|summary)
+          if bridge_tmux_claude_advance_blocker "$session" 0; then
+            trust_summary_actions=$((trust_summary_actions + 1))
+            # Re-check prompt before declaring failure; the just-sent C-m
+            # may have cleared the blocker.
+            if bridge_tmux_session_has_prompt "$session" "$engine"; then
+              return 0
+            fi
+            if (( trust_summary_actions >= trust_summary_max )); then
+              bridge_warn "wait_for_prompt: trust/summary advance budget (${trust_summary_max}) exhausted on session=${session}"
+              return 1
+            fi
+          else
+            sleep 0.2
+          fi
+          ;;
+        devchannels)
+          if [[ "$allow_devchannels" == "1" ]]; then
+            if bridge_tmux_claude_advance_blocker "$session" 1; then
+              devchannels_actions=$((devchannels_actions + 1))
+              # Re-check prompt before failing — the picker often clears
+              # on the final allowed Enter and we don't want to declare
+              # failure when the work is actually done.
+              if bridge_tmux_session_has_prompt "$session" "$engine"; then
+                return 0
+              fi
+              if (( devchannels_actions >= devchannels_max )); then
+                bridge_warn "wait_for_prompt: devchannels advance budget (${devchannels_max}) exhausted on session=${session}; picker may need manual intervention"
+                return 1
+              fi
+            else
+              sleep 0.2
+            fi
+          else
+            # devchannels picker present but auto-accept not allowed —
+            # operator must intervene; we cannot bypass it.
+            return 1
+          fi
+          ;;
+        *)
+          sleep 0.2
+          ;;
+      esac
     else
       sleep 0.2
     fi


### PR DESCRIPTION
## Summary

Isolated linux-user agents that declare a development-channels plugin (e.g. \`plugin:teams@agent-bridge\` + \`plugin:ms365@agent-bridge\`) get stuck on Claude's \`WARNING: Loading development channels\` confirm picker on every restart. The auto-accept scheduler reports \`[info] auto-accepting Claude development-channels prompt\` but the picker stays on screen, requiring an operator to type \`Enter\` manually before the agent can reach its prompt.

Two contributing root causes, both fixed here:

1. \`bridge_tmux_wait_for_prompt\`'s single 4-action advance budget was shared between trust/summary blockers and dev-channels picker advances. The dev-channels picker is a 2-step confirm (\`select option 1\` + \`confirm\`), so on isolated agents whose claude startup is busy spawning bun/node MCP plugin servers, the budget exhausted before the picker fully cleared.
2. The background child in \`bridge_run_schedule_dev_channels_accept\` ran with a 15s timeout and \`>/dev/null 2>&1\`, so the only failure signal an operator ever saw was the picker still being on screen — every \`bridge_warn\` was discarded.

## Changes

- \`lib/bridge-tmux.sh\` (\`bridge_tmux_wait_for_prompt\`):
  - Separate counters for \`trust|summary\` (existing 4-action limit preserved) and \`devchannels\` (new, env-overridable via \`BRIDGE_TMUX_DEV_CHANNELS_MAX_ADVANCE\`, default 12).
  - Inspect blocker state once per loop and route the advance through the correct counter, so non-devchannels callers' regression risk is zero.
  - After each successful advance, re-check \`bridge_tmux_session_has_prompt\` before enforcing the action-budget failure — the just-sent \`C-m\` may have cleared the picker.
  - Failure path now emits \`bridge_warn\` so operators can see *which* state's budget exhausted, not just \"stuck\".
- \`bridge-run.sh\` (\`bridge_run_schedule_dev_channels_accept\`):
  - Timeout raised to 60s (was 15s), env-overridable via \`BRIDGE_RUN_DEV_CHANNELS_ACCEPT_TIMEOUT_SECONDS\`.
  - \`accept_timeout\` passed as \`\$3\` into the \`bash -lc\` child (the child runs with \`set -u\` and would otherwise unset-fail on the outer \`local\`).
  - Background child stdout/stderr now route to \`\$LOGFILE\` / \`\$ERRFILE\` instead of \`/dev/null 2>&1\`. The child also writes a dated \`[warn] auto-accept dev-channels: bridge_tmux_wait_for_prompt failed/timeout\` line on failure so the diagnostic survives.

## Why state-specific budgets, not a single larger budget

Single budget made it impossible to widen dev-channels timeout without also widening trust/summary timeout. Trust/summary is a security prompt and we want it to fail-fast if our keypress isn't clearing it (something is wrong; manual intervention is correct). Dev-channels is a known cold-start race and we want to wait it out within bounds. The two cases don't share a budget cleanly.

## Why log redirect, not silent fallback

\`bridge_warn\` is the only signal a developer has when picker auto-advance fails on a customer's isolated install. Discarding it to \`/dev/null\` made every regression invisible — operators only ever saw \"the picker is still there\" with no idea whether the scheduler ran, timed out, or never started. The agent log path is already operator-visible, so funneling the child output there is the lowest-friction fix.

## Verification

- \`bash -n bridge-run.sh lib/bridge-tmux.sh\` passes.
- Plan reviewed by reviewer-only \`dev-codex\` agent through 2 rounds (plan-needs-more → plan-ok). r1 review notes (state-specific budgets, explicit child arg-passing, fail-loud logging) reflected in the implementation.

Manual verification matrix the operator will run on a live isolated install:

1. Sales-line isolated agent restart with default budgets → picker auto-accepts within 60s, no manual Enter needed.
2. \`BRIDGE_TMUX_DEV_CHANNELS_MAX_ADVANCE=2 BRIDGE_RUN_DEV_CHANNELS_ACCEPT_TIMEOUT_SECONDS=5\` → fails by ~5s with the new \`[warn] auto-accept dev-channels: ...\` line in the agent's daily log.
3. Trust prompt regression check (claude credentials missing) → still fails after the preserved 4-action budget; trust/summary path unchanged.

Smoke test was attempted earlier in this issue's investigation but hung in our local environment (separate \`scripts/smoke-test.sh\` issue tracked elsewhere); only \`bash -n\` was run here.

## Out of scope

- Daemon-side self-advance on \`interactive_picker\` stall classification (\`bridge-daemon.sh:835\`). Worth doing as a defense-in-depth, but a different surface; tracked separately.

## Related

- #346 (preflight install loop, separate symptom).
- #348 (declared-plugin-only manifest), #362 (marketplace propagation), PR #363 (channel symlink auto-creation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)