### PR TITLE
isolate: preflight repair POSIX ACL mask drift on channel state .env files

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2489,6 +2489,10 @@ ${reason:-unknown channel health mismatch}
 
 $(bridge_agent_channel_diagnostics_text "$agent")
 
+## ACL state
+
+$(bridge_agent_channel_acl_diagnostics_text "$agent")
+
 ## Session Health
 
 $(bridge_agent_session_guidance_text "$agent")
@@ -2525,6 +2529,20 @@ bridge_report_channel_health_miss() {
   [[ -n "$admin_agent" ]] || return 0
   bridge_agent_exists "$admin_agent" || return 0
   [[ "$admin_agent" != "$agent" ]] || return 0
+
+  # Preflight: repair sticky POSIX ACL mask drift on channel state .env
+  # files for Linux-isolated agents BEFORE evaluating channel status.
+  # Without this preflight, an unrelated chmod elsewhere can leave
+  # mask=--- on .teams/.env / .ms365/.env, the daemon's grep against
+  # those files returns EACCES, the status reads "miss", and we enqueue
+  # a noisy channel-health task even though the only thing wrong is
+  # the ACL mask. Repair recovers both a dropped mask and a missing
+  # controller named-user entry; helper is best-effort, so a real
+  # credentials problem still falls through to the existing miss path.
+  if bridge_agent_linux_user_isolation_requested "$agent" 2>/dev/null \
+      && [[ "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]]; then
+    bridge_linux_acl_repair_channel_env_files "$agent" >/dev/null 2>&1 || true
+  fi
 
   status="$(bridge_agent_channel_status "$agent")"
   if [[ "$status" != "miss" ]]; then

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -728,6 +728,146 @@ bridge_linux_acl_add_default_dirs_recursive() {
   done
 }
 
+# Iterate the agent's declared channel state .env files and re-apply the
+# controller named-user ACL plus mask::rwX. Recovers from two observed
+# failure modes in v0.6.17:
+#   - POSIX ACL mask drifted to `---` after an unrelated chmod elsewhere
+#     reset the mask to the file's group bits (group is 0 on these .env
+#     files), which silently nullifies all named-user entries' effective
+#     bits. Daemon's grep against the file then returns EACCES, the
+#     channel status reads "miss", and a noisy channel-health task is
+#     enqueued every cycle.
+#   - The controller named-user entry was lost entirely (a fresh write
+#     of the file by an external tool dropped the named-user ACL).
+#
+# Scope is intentionally narrow: known channel state .env files for one
+# isolated agent. Other files and other agents are out of scope so the
+# blast radius stays bounded. Helper is best-effort throughout (any
+# setfacl failure is swallowed) so the caller can still fall through to
+# the existing miss/credentials path on a real credentials problem.
+#
+# bridge_plugin_channel_state_dir lookup is sidestepped here so this
+# helper works whether or not PR #363's ms365 case has merged into the
+# tree being deployed: each declared `plugin:<id>` channel is mapped
+# directly to `${workdir}/.<id>` for the four channel kinds we ship.
+bridge_linux_acl_repair_channel_env_files() {
+  local agent="$1"
+
+  local controller_user
+  controller_user="$(bridge_current_user 2>/dev/null || true)"
+  [[ -n "$controller_user" ]] || return 0
+
+  local workdir
+  workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
+  [[ -n "$workdir" ]] || return 0
+
+  local channels_csv
+  channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+  [[ -n "$channels_csv" ]] || return 0
+
+  local IFS=',' tokens=()
+  read -ra tokens <<<"$channels_csv"
+
+  local token id state_dir env_file
+  for token in "${tokens[@]}"; do
+    token="${token// /}"
+    [[ "$token" == plugin:* ]] || continue
+    id="${token#plugin:}"
+    id="${id%%@*}"
+    case "$id" in
+      discord|telegram|teams|ms365) ;;
+      *) continue ;;
+    esac
+    state_dir="$workdir/.$id"
+
+    # Use sudo test, not bash `[[ -d ... ]]`, because the controller
+    # named-user traverse on the workdir may have drifted too — the
+    # check needs to succeed via root.
+    bridge_linux_sudo_root test -d "$state_dir" || continue
+
+    # Repair the state dir's ACL too (small hardening — mask drift on
+    # the dir would make file-level repair unreachable on the next
+    # daemon read).
+    bridge_linux_sudo_root setfacl \
+      -m "u:${controller_user}:rwX" \
+      -m "m::rwX" \
+      "$state_dir" >/dev/null 2>&1 || true
+
+    env_file="$state_dir/.env"
+    bridge_linux_sudo_root test -f "$env_file" || continue
+
+    bridge_linux_sudo_root setfacl \
+      -m "u:${controller_user}:rw-" \
+      -m "m::rwX" \
+      "$env_file" >/dev/null 2>&1 || true
+  done
+}
+
+# Emit ACL metadata (not file contents) for each declared channel state
+# dir + its .env, suitable for inclusion in a channel-health miss task
+# body. Bounded by design:
+#   - declared channels only (discord/telegram/teams/ms365);
+#   - per-target output capped at 12 lines via head;
+#   - never reads .env content; only `getfacl -p` metadata;
+#   - graceful when getfacl is missing, target is missing, or sudo fails.
+bridge_agent_channel_acl_diagnostics_text() {
+  local agent="$1"
+
+  command -v getfacl >/dev/null 2>&1 || {
+    printf '_getfacl unavailable; skipping ACL diagnostics_\n'
+    return 0
+  }
+
+  local workdir
+  workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
+  [[ -n "$workdir" ]] || return 0
+
+  local channels_csv
+  channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+  [[ -n "$channels_csv" ]] || return 0
+
+  local IFS=',' tokens=()
+  read -ra tokens <<<"$channels_csv"
+
+  local token id state_dir env_file
+  local emitted=0
+  for token in "${tokens[@]}"; do
+    token="${token// /}"
+    [[ "$token" == plugin:* ]] || continue
+    id="${token#plugin:}"
+    id="${id%%@*}"
+    case "$id" in
+      discord|telegram|teams|ms365) ;;
+      *) continue ;;
+    esac
+    state_dir="$workdir/.$id"
+    env_file="$state_dir/.env"
+
+    if ! bridge_linux_sudo_root test -d "$state_dir" 2>/dev/null; then
+      printf '_state_dir missing: %s_\n\n' "$state_dir"
+      emitted=1
+      continue
+    fi
+
+    printf '### %s state-dir ACL\n\n' "$id"
+    printf '```\n'
+    ( bridge_linux_sudo_root getfacl -p "$state_dir" 2>&1 || true ) | head -12
+    printf '```\n\n'
+    emitted=1
+
+    if bridge_linux_sudo_root test -f "$env_file" 2>/dev/null; then
+      printf '### %s .env ACL\n\n' "$id"
+      printf '```\n'
+      ( bridge_linux_sudo_root getfacl -p "$env_file" 2>&1 || true ) | head -12
+      printf '```\n\n'
+    fi
+  done
+
+  if (( emitted == 0 )); then
+    printf '_no declared channel state dirs to diagnose_\n'
+  fi
+}
+
 bridge_linux_grant_traverse_chain() {
   # Grant `u:${os_user}:--x` on every directory from $target up to
   # (and including) $stop_path. Callers must pass an explicit stop_path

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -490,6 +490,16 @@ bridge_linux_can_sudo_to() {
   sudo -n -u "$os_user" -- "$bash_bin" -c 'exit 0' 2>/dev/null
 }
 
+# Internal: non-fatal sudo presence probe. Returns 0 if the helper can
+# safely call bridge_linux_sudo_root, 1 if sudo is absent (so the helper
+# must early-return and the daemon is not killed by bridge_die).
+bridge_linux_have_sudo_or_skip() {
+  if [[ "$(id -u)" == "0" ]]; then
+    return 0
+  fi
+  command -v sudo >/dev/null 2>&1
+}
+
 bridge_agent_preserved_env_vars() {
   # Intentionally conservative: the ENV_PREFIX inlined in the SESSION_CMD
   # re-exports all BRIDGE_* runtime paths inside the bash -c child, so sudo
@@ -753,6 +763,8 @@ bridge_linux_acl_add_default_dirs_recursive() {
 bridge_linux_acl_repair_channel_env_files() {
   local agent="$1"
 
+  bridge_linux_have_sudo_or_skip || return 0
+
   local controller_user
   controller_user="$(bridge_current_user 2>/dev/null || true)"
   [[ -n "$controller_user" ]] || return 0
@@ -812,6 +824,11 @@ bridge_linux_acl_repair_channel_env_files() {
 #   - graceful when getfacl is missing, target is missing, or sudo fails.
 bridge_agent_channel_acl_diagnostics_text() {
   local agent="$1"
+
+  if ! bridge_linux_have_sudo_or_skip; then
+    printf '_ACL diagnostics unavailable: sudo not present_\n'
+    return 0
+  fi
 
   command -v getfacl >/dev/null 2>&1 || {
     printf '_getfacl unavailable; skipping ACL diagnostics_\n'


### PR DESCRIPTION
## Summary

Isolated linux-user agents periodically have their channel state `.env` files (\`.teams/.env\`, \`.ms365/.env\`) hit a POSIX ACL mask drift to \`---\`. This silently nullifies the controller named-user entry, daemon's grep against the file returns EACCES, channel status reads \"miss\", and a noisy \`[channel-health] (miss)\` task is enqueued every 5-minute heartbeat. Operators manually run \`setfacl -m mask::rwX\`, the cycle repeats hours later.

This PR lands a scoped daemon-side mitigation: preflight repair runs before channel status is evaluated, mask-only failures self-heal, no task is enqueued for them. Real credentials problems still fall through to the existing miss path.

## Changes

### `lib/bridge-agents.sh` — two new helpers

- \`bridge_linux_acl_repair_channel_env_files\`: iterates declared \`plugin:<id>\` channels (discord/telegram/teams/ms365), re-applies the controller named-user ACL entry (\`u:\${controller_user}:rw-\` on the .env, \`u:\${controller_user}:rwX\` on the state dir) plus \`m::rwX\` mask. Best-effort throughout (every setfacl is \`|| true\`); idempotent; uses \`bridge_linux_sudo_root test\` for existence checks so traverse drift on the controller home doesn't short-circuit the repair. Channel id mapping is direct (\`\${workdir}/.<id>\`) so the helper works whether or not PR #363's ms365 case has merged.
- \`bridge_agent_channel_acl_diagnostics_text\`: bounded ACL metadata output for inclusion in channel-health miss task bodies. Per-target capped at 12 lines via \`head\`, never reads .env content (only \`getfacl -p\` metadata), graceful when getfacl is missing or sudo fails.

### `bridge-daemon.sh` — preflight + diagnostics integration

- \`bridge_report_channel_health_miss\` calls the repair helper as a preflight (gated on \`bridge_agent_linux_user_isolation_requested\` + Linux host) before computing \`bridge_agent_channel_status\`. After repair, status is recomputed; mask-drift-only cases self-heal silently.
- \`bridge_write_channel_health_body\` adds an \`## ACL state\` section that calls the diagnostics helper. When the repair did not recover the case (e.g. credentials genuinely missing on top of mask drift), the operator sees the ACL state directly in the task body and can diagnose without sudo'ing into the isolated UID.

## What this PR does not fix

The trigger that drives mask drift in the first place is not yet identified. POSIX ACL semantics make \`chmod\` on a file with named ACL entries reset mask to the file's group bits — the lib already mitigates this for \`agent-env.sh\` (lib/bridge-agents.sh:1849), but no equivalent protection exists for channel state .env files. A follow-up should locate the chmod call site (no in-tree match found on this pass; likely an external tool or a generated path) and either re-apply the named ACL after the chmod, or use setfacl in place of chmod where the file already carries named entries.

This PR also intentionally does **not** change the global \`bridge_linux_acl_add\` helper to enforce \`m::rwX\` everywhere — that would be a much wider blast radius and is tracked as a separate candidate.

## Verification

- \`bash -n lib/bridge-agents.sh bridge-daemon.sh\` passes.
- Plan reviewed by reviewer-only \`dev-codex\` agent through 2 rounds (plan-needs-more 3 items → plan-ok). r2 review notes (sudo test for existence, state-dir-level repair, ms365 case independent of PR #363) reflected in the implementation.

Manual verification matrix the operator will run on a live isolated install:

1. Force \`mask::---\` on \`.teams/.env\`: \`sudo setfacl -m m::--- .../sales_sean/.teams/.env\`. Wait for next daemon heartbeat. Expected: no \`[channel-health] (miss)\` task is enqueued; \`getfacl\` shows mask back to \`rw-\`.
2. Remove a real credential (\`sudo setfacl -x u:agent-bridge-sales_sean:r-- .../sales_sean/.teams/.env\` or rename the file). Wait for next heartbeat. Expected: existing miss task fires with the new \`## ACL state\` section showing the missing entry — operator diagnoses without sudo'ing into the isolated UID.
3. Confirm the diagnostics section shows ACL entries only and never the .env file's contents.

## Out of scope

- Locating the underlying mask-drift trigger (separate fact-finding).
- Global \`bridge_linux_acl_add\` mask hardening (much wider blast radius).
- Migration/unisolate cleanup parity for the new ACL entries (helper only re-applies what already existed; nothing new to clean up).

## Related

- #348 (declared-plugin-only manifest), #346 (preflight install loop), #362 (marketplace propagation), PR #363 (channel symlink auto-creation), PR #364 (picker auto-accept reliability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)