### PR TITLE
daemon: route admin-gateway escalations to affected agent's own surface (#345 Track B)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1376,7 +1376,17 @@ process_permission_task_timeout_fanout() {
   [[ "$timeout_seconds" =~ ^[0-9]+$ ]] || timeout_seconds=1800
   (( timeout_seconds > 0 )) || return 1
 
-  bridge_agent_has_notify_transport "$admin_agent" || return 1
+  # Issue #345 Track B (instance #5): the requesting agent's own
+  # notify-target is the primary surface for permission decisions, since
+  # the operator who owns the decision is closer to that agent than to
+  # admin. Admin's notify is now a fallback used only when the requester
+  # has no working transport. We therefore drop the prior "admin must
+  # have transport" early gate — the per-row branch below decides which
+  # surface (or both) gets the notify.
+  local admin_has_notify=0
+  if bridge_agent_has_notify_transport "$admin_agent"; then
+    admin_has_notify=1
+  fi
 
   local tasks_json
   tasks_json="$(bridge_queue_cli find-open --agent "$admin_agent" --title-prefix '[PERMISSION] ' --all --format json 2>/dev/null || true)"
@@ -1417,6 +1427,7 @@ PY
   [[ -n "$expired_rows" ]] || return 1
 
   local task_id age_seconds created_by status title marker age_minutes body_text
+  local primary="" notify_target_agent="" requester_has_notify
   while IFS=$'\t' read -r task_id age_seconds created_by status title; do
     [[ "$task_id" =~ ^[0-9]+$ ]] || continue
     marker="$(bridge_permission_escalation_marker_file "$task_id")"
@@ -1425,9 +1436,27 @@ PY
     fi
 
     age_minutes=$(( age_seconds / 60 ))
-    body_text="[PERMISSION] task #${task_id} unclaimed for ${age_minutes}m — admin ${admin_agent} has not responded. Requested by ${created_by:-unknown}. Status: ${status}. Title: ${title}"
+    body_text="[PERMISSION] task #${task_id} unclaimed for ${age_minutes}m — awaiting operator decision. Requested by ${created_by:-unknown}. Status: ${status}. Title: ${title}"
 
-    bridge_notify_send "$admin_agent" "Permission request timed out" "$body_text" "$task_id" urgent "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
+    # Primary path: requester's own notify-target. Falls back to admin
+    # notify only when the requester has none (or is the admin itself).
+    primary=""
+    notify_target_agent=""
+    requester_has_notify=0
+    if [[ -n "$created_by" && "$created_by" != "$admin_agent" ]] \
+        && bridge_agent_exists "$created_by" \
+        && bridge_agent_has_notify_transport "$created_by"; then
+      requester_has_notify=1
+      primary="requester"
+      notify_target_agent="$created_by"
+    elif (( admin_has_notify == 1 )); then
+      primary="admin"
+      notify_target_agent="$admin_agent"
+    fi
+
+    if [[ -n "$notify_target_agent" ]]; then
+      bridge_notify_send "$notify_target_agent" "Permission request timed out" "$body_text" "$task_id" urgent "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
+    fi
 
     bridge_queue_cli update "$task_id" --actor daemon \
       --note "daemon-timeout-escalated (awaiting human) after ${age_minutes}m" >/dev/null 2>&1 || true
@@ -1436,7 +1465,14 @@ PY
       --detail task_id="$task_id" \
       --detail age_seconds="$age_seconds" \
       --detail requested_by="${created_by:-unknown}" \
-      --detail timeout_seconds="$timeout_seconds"
+      --detail timeout_seconds="$timeout_seconds" \
+      --detail primary="${primary:-none}"
+
+    bridge_audit_log daemon permission_fanout "${created_by:-unknown}" \
+      --detail task_id="$task_id" \
+      --detail primary="${primary:-none}" \
+      --detail requester_has_notify="$requester_has_notify" \
+      --detail admin_has_notify="$admin_has_notify"
 
     printf '%s\n' "$now_ts" >"$marker"
     changed=0
@@ -2099,6 +2135,30 @@ process_crash_reports() {
           --detail error_hash="$error_hash"
         reported=1
       fi
+    elif bridge_agent_has_notify_transport "$agent"; then
+      # Issue #345 Track B (instance #2): the affected agent's operator-attached
+      # surface is closer to the human than admin's queue. Push the crash
+      # report to the affected agent's own notify-target with one re-prod,
+      # then idle. The admin agent has no special authority to repair a
+      # per-agent crash, so the legacy admin-queue path is reserved for the
+      # admin == affected case above (no other surface available) and for
+      # affected agents with no notify transport (handled in the else branch).
+      if [[ "$error_hash" != "$last_hash" || $(( now_ts - last_report_ts )) -ge "$cooldown" ]]; then
+        body="Crash loop detected for ${agent}: ${fail_count} failures (exit ${exit_code}). Inspect the session and repair the root cause before relaunch."
+        bridge_notify_send "$agent" "Crash loop detected" "$body" "" urgent "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
+        bridge_audit_log daemon crash_notified_origin "$agent" \
+          --detail target=affected-notify \
+          --detail engine="$engine" \
+          --detail fail_count="$fail_count" \
+          --detail exit_code="$exit_code" \
+          --detail error_hash="$error_hash"
+        reported=1
+      else
+        bridge_audit_log daemon crash_notified_origin_suppressed "$agent" \
+          --detail reason=cooldown \
+          --detail fail_count="$fail_count" \
+          --detail error_hash="$error_hash"
+      fi
     else
       title="[crash-loop] ${agent} (${fail_count} failures)"
       title_prefix="[crash-loop] ${agent} "
@@ -2515,12 +2575,11 @@ bridge_report_channel_health_miss() {
   local now_ts=""
   local state_file=""
   local body_file=""
-  local title=""
-  local title_prefix=""
-  local existing_id=""
-  local create_output=""
   local last_key=""
   local last_report_ts=0
+  local cooldown="${BRIDGE_CHANNEL_HEALTH_REPORT_COOLDOWN_SECONDS:-1800}"
+  local fallback_used=0
+  local notify_body=""
 
   [[ -n "$admin_agent" ]] || return 0
   bridge_agent_exists "$admin_agent" || return 0
@@ -2538,8 +2597,6 @@ bridge_report_channel_health_miss() {
   now_ts="$(date +%s)"
   state_file="$(bridge_channel_health_state_file "$agent")"
   body_file="$(bridge_channel_health_body_file "$agent")"
-  title="[channel-health] ${agent} (miss)"
-  title_prefix="[channel-health] ${agent} "
 
   if [[ -f "$state_file" ]]; then
     # shellcheck source=/dev/null
@@ -2547,29 +2604,39 @@ bridge_report_channel_health_miss() {
     last_key="${LAST_KEY:-}"
     last_report_ts="${LAST_REPORT_TS:-0}"
   fi
+  [[ "$last_report_ts" =~ ^[0-9]+$ ]] || last_report_ts=0
+  [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=1800
+
+  # Issue #345 Track B (instance #3): channel-health miss is a per-agent
+  # surface problem. The admin agent has no authority over the affected
+  # agent's tokens or channel binding, so dumping a task into admin's queue
+  # only generates noise. Try to surface to the affected agent's own
+  # notify transport when available (fallback path); otherwise emit an
+  # audit row + dashboard flag and let `agent-bridge status` carry the
+  # config-drift counter. Never enqueue an admin task for this case.
+  if [[ "$key" == "$last_key" && $(( now_ts - last_report_ts )) -lt "$cooldown" ]]; then
+    return 0
+  fi
 
   bridge_write_channel_health_body "$agent" "$body_file"
-  existing_id="$(bridge_queue_cli find-open --agent "$admin_agent" --title-prefix "$title_prefix" 2>/dev/null || true)"
-  if [[ "$existing_id" =~ ^[0-9]+$ ]]; then
-    bridge_queue_cli update "$existing_id" --actor "daemon" --title "$title" --priority urgent --body-file "$body_file" >/dev/null 2>&1 || true
-    bridge_audit_log daemon channel_health_report "$agent" \
-      --detail admin_agent="$admin_agent" \
-      --detail mode=refresh \
-      --detail body_file="$body_file" \
-      --detail reason="$reason"
-  elif [[ "$key" != "$last_key" || $(( now_ts - last_report_ts )) -ge ${BRIDGE_CHANNEL_HEALTH_REPORT_COOLDOWN_SECONDS:-1800} ]]; then
-    create_output="$(bridge_queue_cli create --to "$admin_agent" --title "$title" --from daemon --priority urgent --body-file "$body_file" 2>/dev/null || true)"
-    if [[ "$create_output" =~ created\ task\ \#([0-9]+) ]]; then
-      bridge_audit_log daemon channel_health_report "$agent" \
-        --detail admin_agent="$admin_agent" \
-        --detail mode=create \
-        --detail task_id="${BASH_REMATCH[1]}" \
-        --detail body_file="$body_file" \
-        --detail reason="$reason"
-      daemon_info "reported channel-health miss for ${agent} -> ${admin_agent} (#${BASH_REMATCH[1]})"
-    fi
+
+  if bridge_agent_has_notify_transport "$agent"; then
+    notify_body="Channel health mismatch detected for ${agent}: ${reason}. Repair the affected channel binding and rerun \`agent-bridge agent show ${agent}\` to confirm."
+    bridge_notify_send "$agent" "Channel health mismatch" "$notify_body" "" urgent "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
+    fallback_used=1
+  fi
+
+  bridge_audit_log daemon channel_health_miss "$agent" \
+    --detail surface="$(bridge_agent_channels_csv "$agent")" \
+    --detail reason="$reason" \
+    --detail body_file="$body_file" \
+    --detail fallback_used="$fallback_used" \
+    --detail dashboard_flag=1
+
+  if (( fallback_used == 1 )); then
+    daemon_info "channel-health miss for ${agent} surfaced via affected-notify (reason=${reason})"
   else
-    return 0
+    daemon_info "channel-health miss for ${agent} recorded as audit + dashboard flag (reason=${reason})"
   fi
 
   mkdir -p "$(dirname "$state_file")"
@@ -2987,6 +3054,7 @@ cmd_run_cron_worker() {
   local CRON_STDERR_LOG=""
   local CRON_PROMPT_FILE=""
   local CRON_NEEDS_HUMAN_FOLLOWUP=""
+  local CRON_FAILURE_CLASS=""
 
   [[ "$task_id" =~ ^[0-9]+$ ]] || bridge_die "Usage: bash $SCRIPT_DIR/bridge-daemon.sh run-cron-worker <task-id>"
 
@@ -3111,6 +3179,32 @@ cmd_run_cron_worker() {
     followup_actor="cron:${CRON_JOB_NAME:-$run_id}"
     followup_title="[cron-followup] ${CRON_JOB_NAME:-$run_id} (${CRON_SLOT:-$run_id})"
     followup_title_prefix="[cron-followup] ${CRON_JOB_NAME:-$run_id} ("
+    # Issue #345 Track B (instance #4): split cron-followup destinations by
+    # failure class. `human-config` failures (config drift, binding
+    # mismatch, retired-agent cleanup) cannot be closed by admin acting on a
+    # queue task; they require operator attention. Surface those via a
+    # `cron_human_config_drift` audit row that the dashboard config-drift
+    # counter (Track C) reads for the rolling 7d window. Only
+    # `admin-resolvable` failures (the default) flow into admin's queue.
+    if [[ "$CRON_FAILURE_CLASS" == "human-config" ]]; then
+      bridge_audit_log daemon cron_human_config_drift "$TASK_ASSIGNED_TO" \
+        --detail run_id="$run_id" \
+        --detail job_name="${CRON_JOB_NAME:-$run_id}" \
+        --detail family="${CRON_FAMILY:-}" \
+        --detail slot="${CRON_SLOT:-}" \
+        --detail body_file="$followup_body_file" \
+        --detail dashboard_flag=1
+      daemon_info "cron-followup human-config drift recorded for ${CRON_JOB_NAME:-$run_id} (no admin task created)"
+      # Reset burst counter so a follow-up admin-resolvable failure does
+      # not trip the threshold against accumulated drift counts.
+      if (( _has_flock == 1 )); then
+        { flock -x 9
+          rm -f "$fail_burst_file" 2>/dev/null || true
+        } 9>"$fail_burst_lock"
+      else
+        rm -f "$fail_burst_file" 2>/dev/null || true
+      fi
+    else
     existing_followup_id="$(bridge_queue_cli find-open --agent "$TASK_ASSIGNED_TO" --title-prefix "$followup_title_prefix" 2>/dev/null || true)"
     if [[ "$existing_followup_id" =~ ^[0-9]+$ ]]; then
       bridge_queue_cli update "$existing_followup_id" --actor "$followup_actor" --title "$followup_title" --priority "$followup_priority" --body-file "$followup_body_file" >/dev/null 2>&1 || true
@@ -3143,6 +3237,7 @@ cmd_run_cron_worker() {
         --detail fail_burst_count="$fail_burst_count" \
         --detail fail_burst_threshold="$fail_burst_threshold" \
         --detail reason=below_threshold
+    fi
     fi
   fi
 

--- a/bridge-status.py
+++ b/bridge-status.py
@@ -240,6 +240,57 @@ def context_pressure_fp_rate(audit_log: str, window_days: int = 7) -> tuple[int,
     return (fp_count, len(critical_task_ids))
 
 
+def config_drift_count(audit_log: str, window_days: int = 7) -> int:
+    """Count `cron_human_config_drift` and `channel_health_miss` audit rows
+    over the last `window_days`. Renders as the `config-drift` line on the
+    `agent-bridge status` dashboard (issue #345 Track C). The audit actions
+    are emitted by bridge-daemon's cron-followup classifier and the
+    channel-health-miss helper when a per-agent surface problem cannot be
+    resolved by admin acting on a queue task; surfacing the count on the
+    dashboard moves human-config drift out of admin's noisy inbox.
+    """
+    if not audit_log:
+        return 0
+    base = Path(audit_log).expanduser()
+    files = _audit_input_files(base)
+    if not files:
+        return 0
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max(1, int(window_days)))
+    drift_actions = {"cron_human_config_drift", "channel_health_miss"}
+    count = 0
+    for path in files:
+        try:
+            with path.open("r", encoding="utf-8") as fh:
+                for raw in fh:
+                    line = raw.strip()
+                    if not line:
+                        continue
+                    try:
+                        record = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(record, dict):
+                        continue
+                    if record.get("action") not in drift_actions:
+                        continue
+                    ts_raw = record.get("ts")
+                    if not isinstance(ts_raw, str):
+                        continue
+                    try:
+                        ts_str = ts_raw[:-1] + "+00:00" if ts_raw.endswith("Z") else ts_raw
+                        ts = datetime.fromisoformat(ts_str)
+                    except ValueError:
+                        continue
+                    if ts.tzinfo is None:
+                        ts = ts.replace(tzinfo=timezone.utc)
+                    if ts < cutoff:
+                        continue
+                    count += 1
+        except OSError:
+            continue
+    return count
+
+
 def fetch_agent_metrics(conn: sqlite3.Connection) -> dict[str, dict[str, int | str | None]]:
     agent_state_columns = table_columns(conn, "agent_state")
     nudge_fail_expr = (
@@ -448,6 +499,16 @@ def render_dashboard(args: argparse.Namespace) -> str:
             f"context-pressure FP rate ({fp_window_days}d): "
             f"{fp_count}/{critical_count} ({pct}%)"
         )
+    # Issue #345 Track C — config-drift counter. Aggregates
+    # `cron_human_config_drift` and `channel_health_miss` audit rows over
+    # the rolling `--config-drift-window-days` window so operators see
+    # human-config drift without it polluting admin's queue.
+    drift_window_days = max(1, int(args.config_drift_window_days))
+    drift_count = config_drift_count(args.audit_log, drift_window_days)
+    if drift_count > 0:
+        lines.append(
+            f"config-drift ({drift_window_days}d): {drift_count}"
+        )
     lines.append("")
     lines.append("Agents")
     lines.append("  #  agent           eng     src     loop on  state    q   c   b   garden  idle  stale wake chan  nudge  load        session        workdir")
@@ -541,6 +602,12 @@ def main() -> int:
         type=int,
         default=7,
         help="Rolling window for the context-pressure FP-rate dashboard line (#338 Track C).",
+    )
+    parser.add_argument(
+        "--config-drift-window-days",
+        type=int,
+        default=7,
+        help="Rolling window for the config-drift dashboard line (#345 Track C).",
     )
     parser.add_argument("--version", default="")
     parser.add_argument("--open-limit", type=int, default=8)

--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -320,6 +320,17 @@ fields = {
     "CRON_STDERR_LOG": request.get("stderr_log", ""),
     "CRON_PROMPT_FILE": str(request_file.parent / "prompt.txt"),
     "CRON_NEEDS_HUMAN_FOLLOWUP": "1" if result.get("needs_human_followup") else "0",
+    # Issue #345 Track B (instance #4): cron failures split into
+    # admin-resolvable (close/refresh/retry) and human-config (config drift,
+    # binding mismatch, retired-agent cleanup). Subagents may set
+    # `failure_class` in result.json; jobs may carry a static
+    # `failure_class` in request.json. Default `admin-resolvable` keeps
+    # the legacy admin-queue path for unclassified failures.
+    "CRON_FAILURE_CLASS": str(
+        result.get("failure_class")
+        or request.get("failure_class")
+        or "admin-resolvable"
+    ).strip().lower() or "admin-resolvable",
 }
 
 for key, value in fields.items():

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7911,7 +7911,7 @@ task_id = sys.argv[2]
 assert any(str(row.get("detail", {}).get("task_id")) == task_id for row in rows), rows
 PY
 
-log "reporting channel health misses to the admin role"
+log "channel health miss surfaces via audit + dashboard flag (no admin queue task — issue #345 Track B)"
 cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
 
 bridge_add_agent_id_if_missing "$BROKEN_CHANNEL_AGENT"
@@ -7924,10 +7924,12 @@ BRIDGE_AGENT_CHANNELS["$BROKEN_CHANNEL_AGENT"]="plugin:discord"
 EOF
 
 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
-CHANNEL_HEALTH_INBOX="$(bash "$REPO_ROOT/bridge-task.sh" inbox "$SMOKE_AGENT" --all)"
-assert_contains "$CHANNEL_HEALTH_INBOX" "[channel-health] $BROKEN_CHANNEL_AGENT (miss)"
+# Issue #345 Track B (instance #3): channel-health miss must NOT enqueue an
+# admin task. Admin has no authority over the affected agent's tokens or
+# channel binding. The new contract is audit row + dashboard flag, with a
+# fallback notify to the affected agent's own surface when available.
 CHANNEL_HEALTH_OPEN_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[channel-health] $BROKEN_CHANNEL_AGENT " 2>/dev/null || true)"
-[[ "$CHANNEL_HEALTH_OPEN_ID" =~ ^[0-9]+$ ]] || die "expected channel-health task for $BROKEN_CHANNEL_AGENT"
+[[ -z "$CHANNEL_HEALTH_OPEN_ID" ]] || die "channel-health miss must not create admin task; got #$CHANNEL_HEALTH_OPEN_ID"
 CHANNEL_HEALTH_BODY_FILE="$BRIDGE_SHARED_DIR/channel-health/$BROKEN_CHANNEL_AGENT.md"
 [[ -f "$CHANNEL_HEALTH_BODY_FILE" ]] || die "expected channel-health body file"
 CHANNEL_HEALTH_BODY="$(cat "$CHANNEL_HEALTH_BODY_FILE")"
@@ -7937,9 +7939,13 @@ assert_contains "$CHANNEL_HEALTH_BODY" "runtime: state_dir=missing access=missin
 assert_contains "$CHANNEL_HEALTH_BODY" "## Session Health"
 assert_contains "$CHANNEL_HEALTH_BODY" "detach_to_shell: Ctrl-b then d"
 assert_not_contains "$CHANNEL_HEALTH_BODY" "smoke-token"
+CHANNEL_HEALTH_AUDIT_OUTPUT="$("$REPO_ROOT/agent-bridge" audit --agent "$BROKEN_CHANNEL_AGENT" --action channel_health_miss --limit 5 --json 2>/dev/null || true)"
+[[ -n "$CHANNEL_HEALTH_AUDIT_OUTPUT" ]] || die "expected channel_health_miss audit row for $BROKEN_CHANNEL_AGENT"
+assert_contains "$CHANNEL_HEALTH_AUDIT_OUTPUT" "channel_health_miss"
+assert_contains "$CHANNEL_HEALTH_AUDIT_OUTPUT" "\"dashboard_flag\": \"1\""
 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 CHANNEL_HEALTH_OPEN_ID_AGAIN="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[channel-health] $BROKEN_CHANNEL_AGENT " 2>/dev/null || true)"
-[[ "$CHANNEL_HEALTH_OPEN_ID_AGAIN" == "$CHANNEL_HEALTH_OPEN_ID" ]] || die "channel-health alert should be deduped"
+[[ -z "$CHANNEL_HEALTH_OPEN_ID_AGAIN" ]] || die "second sync must not create admin channel-health task either"
 
 log "detecting plugin MCP descendants and watchdog-restarting static Claude roles"
 PLUGIN_TREE_SCRIPT="$TMP_ROOT/fake-plugin-tree.sh"

--- a/tests/admin-gateway-refactor/smoke.sh
+++ b/tests/admin-gateway-refactor/smoke.sh
@@ -1,0 +1,486 @@
+#!/usr/bin/env bash
+# tests/admin-gateway-refactor/smoke.sh
+#
+# Issue #345 Track B + C — admin gateway hardcoding refactor.
+# Verifies, in an isolated BRIDGE_HOME (mktemp, no live state):
+#
+#   1. process_crash_reports redirects a non-admin agent's crash to its
+#      own notify-target (audit `crash_notified_origin`) and does NOT
+#      enqueue a `[crash-loop]` task on admin's queue.
+#   2. process_crash_reports falls back to the admin queue when the
+#      affected agent has no notify transport (legacy contract preserved
+#      so installs without per-agent notify still get a surface).
+#   3. bridge_report_channel_health_miss emits a `channel_health_miss`
+#      audit row with `dashboard_flag=1` and does NOT enqueue an admin
+#      `[channel-health]` task.
+#   4. cron-followup classifier — `failure_class=human-config` writes a
+#      `cron_human_config_drift` audit row and does NOT create an admin
+#      task; `admin-resolvable` (the default) still creates a task once
+#      the burst threshold is met.
+#   5. process_permission_task_timeout_fanout uses the requesting
+#      agent's notify-target as primary when the requester has one,
+#      falling back to admin notify otherwise. Audit
+#      `permission_fanout` carries `primary=requester` / `primary=admin`.
+#   6. bridge-status.py renders a `config-drift (Nd): <count>` line
+#      derived from the `cron_human_config_drift` and
+#      `channel_health_miss` audit rows.
+#
+# This test does not require tmux, live Claude/Codex, or the daemon
+# main loop. It seeds the minimum pre-state each path expects and
+# invokes `bridge-daemon.sh sync` (or the helper directly) once.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+log() { printf '[admin-gateway] %s\n' "$*"; }
+die() { printf '[admin-gateway][error] %s\n' "$*" >&2; exit 1; }
+skip() { printf '[admin-gateway][skip] %s\n' "$*"; exit 0; }
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  skip "bash 4+ required (have ${BASH_VERSION})"
+fi
+command -v python3 >/dev/null 2>&1 || skip "python3 missing"
+command -v sqlite3 >/dev/null 2>&1 || skip "sqlite3 missing"
+
+TMP_ROOT="$(mktemp -d -t admin-gateway-test.XXXXXX)"
+trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
+
+export BRIDGE_HOME="$TMP_ROOT/bridge-home"
+export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
+export BRIDGE_ROSTER_FILE="$BRIDGE_HOME/agent-roster.sh"
+export BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_HOME/agent-roster.local.sh"
+export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+export BRIDGE_AUDIT_LOG="$BRIDGE_LOG_DIR/audit.jsonl"
+# Pin cron state dir under the temp BRIDGE_HOME so a parent shell that
+# inherited the live install's BRIDGE_CRON_STATE_DIR cannot leak in.
+export BRIDGE_CRON_STATE_DIR="$BRIDGE_STATE_DIR/cron"
+export BRIDGE_DAEMON_NOTIFY_DRY_RUN=1
+# Disable noisy / slow subsystems irrelevant to this smoke.
+export BRIDGE_SKIP_PLUGIN_LIVENESS=1
+mkdir -p "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT" "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR" "$BRIDGE_SHARED_DIR"
+: > "$BRIDGE_ROSTER_FILE"
+
+ADMIN_AGENT="gateway-admin"
+NOTIFY_AGENT="gateway-notify"
+SILENT_AGENT="gateway-silent"
+REQUESTER_AGENT="gateway-requester"
+ADMIN_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$ADMIN_AGENT"
+NOTIFY_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$NOTIFY_AGENT"
+SILENT_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$SILENT_AGENT"
+REQUESTER_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$REQUESTER_AGENT"
+mkdir -p "$ADMIN_WORKDIR" "$NOTIFY_WORKDIR" "$SILENT_WORKDIR" "$REQUESTER_WORKDIR"
+
+# Roster fixture:
+#   - admin: has notify transport (discord)
+#   - notify: has notify transport (discord, distinct channel)
+#   - silent: no notify transport (forces admin-fallback paths)
+#   - requester: has notify transport (telegram) — used for
+#                permission-fanout primary path
+cat > "$BRIDGE_ROSTER_LOCAL_FILE" <<ROSTER
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+BRIDGE_AGENT_IDS=("$ADMIN_AGENT" "$NOTIFY_AGENT" "$SILENT_AGENT" "$REQUESTER_AGENT")
+BRIDGE_AGENT_DESC[$ADMIN_AGENT]="admin"
+BRIDGE_AGENT_DESC[$NOTIFY_AGENT]="agent with notify"
+BRIDGE_AGENT_DESC[$SILENT_AGENT]="agent without notify"
+BRIDGE_AGENT_DESC[$REQUESTER_AGENT]="permission requester"
+BRIDGE_AGENT_ENGINE[$ADMIN_AGENT]=claude
+BRIDGE_AGENT_ENGINE[$NOTIFY_AGENT]=claude
+BRIDGE_AGENT_ENGINE[$SILENT_AGENT]=claude
+BRIDGE_AGENT_ENGINE[$REQUESTER_AGENT]=claude
+BRIDGE_AGENT_SESSION[$ADMIN_AGENT]=$ADMIN_AGENT
+BRIDGE_AGENT_SESSION[$NOTIFY_AGENT]=$NOTIFY_AGENT
+BRIDGE_AGENT_SESSION[$SILENT_AGENT]=$SILENT_AGENT
+BRIDGE_AGENT_SESSION[$REQUESTER_AGENT]=$REQUESTER_AGENT
+BRIDGE_AGENT_WORKDIR[$ADMIN_AGENT]=$ADMIN_WORKDIR
+BRIDGE_AGENT_WORKDIR[$NOTIFY_AGENT]=$NOTIFY_WORKDIR
+BRIDGE_AGENT_WORKDIR[$SILENT_AGENT]=$SILENT_WORKDIR
+BRIDGE_AGENT_WORKDIR[$REQUESTER_AGENT]=$REQUESTER_WORKDIR
+BRIDGE_AGENT_LAUNCH_CMD[$ADMIN_AGENT]=\$(printf '%q' "claude")
+BRIDGE_AGENT_LAUNCH_CMD[$NOTIFY_AGENT]=\$(printf '%q' "claude")
+BRIDGE_AGENT_LAUNCH_CMD[$SILENT_AGENT]=\$(printf '%q' "claude")
+BRIDGE_AGENT_LAUNCH_CMD[$REQUESTER_AGENT]=\$(printf '%q' "claude")
+BRIDGE_AGENT_SOURCE[$ADMIN_AGENT]=static
+BRIDGE_AGENT_SOURCE[$NOTIFY_AGENT]=static
+BRIDGE_AGENT_SOURCE[$SILENT_AGENT]=static
+BRIDGE_AGENT_SOURCE[$REQUESTER_AGENT]=static
+BRIDGE_AGENT_NOTIFY_KIND[$ADMIN_AGENT]=discord
+BRIDGE_AGENT_NOTIFY_KIND[$NOTIFY_AGENT]=discord
+BRIDGE_AGENT_NOTIFY_KIND[$REQUESTER_AGENT]=telegram
+BRIDGE_AGENT_NOTIFY_TARGET[$ADMIN_AGENT]=111111111111111111
+BRIDGE_AGENT_NOTIFY_TARGET[$NOTIFY_AGENT]=222222222222222222
+BRIDGE_AGENT_NOTIFY_TARGET[$REQUESTER_AGENT]=333333333333333333
+BRIDGE_AGENT_NOTIFY_ACCOUNT[$ADMIN_AGENT]=fixture
+BRIDGE_AGENT_NOTIFY_ACCOUNT[$NOTIFY_AGENT]=fixture
+BRIDGE_AGENT_NOTIFY_ACCOUNT[$REQUESTER_AGENT]=fixture
+BRIDGE_ADMIN_AGENT_ID=$ADMIN_AGENT
+ROSTER
+
+# Initialize tasks.db schema via an empty inbox query.
+log "initializing tasks.db via empty inbox query"
+"$REPO_ROOT/agent-bridge" inbox "$ADMIN_AGENT" >/dev/null 2>&1 || true
+[[ -f "$BRIDGE_TASK_DB" ]] || die "tasks.db not initialized at $BRIDGE_TASK_DB"
+
+count_open_for_title_prefix() {
+  local agent="$1"
+  local prefix="$2"
+  sqlite3 "$BRIDGE_TASK_DB" \
+    "SELECT COUNT(*) FROM tasks WHERE assigned_to='$agent' AND title LIKE '${prefix}%' AND status IN ('queued','claimed')" \
+    2>/dev/null || echo 0
+}
+
+audit_count_action() {
+  local action="$1"
+  if [[ ! -f "$BRIDGE_AUDIT_LOG" ]]; then
+    echo 0
+    return
+  fi
+  python3 - "$BRIDGE_AUDIT_LOG" "$action" <<'PY'
+import json, sys
+path, action = sys.argv[1], sys.argv[2]
+count = 0
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("action") == action:
+            count += 1
+print(count)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: process_crash_reports redirects to affected agent's notify-target
+# ---------------------------------------------------------------------------
+
+log "step 1 — crash report for agent with notify-target redirects to its own surface"
+
+CRASH_ERR="$TMP_ROOT/notify-crash.err"
+cat >"$CRASH_ERR" <<'EOF'
+fatal: token expired
+unable to open runtime config
+EOF
+
+bash -c "
+  set -e
+  source '$REPO_ROOT/bridge-lib.sh'
+  bridge_load_roster
+  bridge_agent_write_crash_report '$NOTIFY_AGENT' 'claude' 5 1 '$CRASH_ERR' 'claude --dangerously-skip-permissions'
+" || die "failed to seed crash report for $NOTIFY_AGENT"
+
+before_redirect="$(audit_count_action crash_notified_origin)"
+before_admin_alert="$(audit_count_action crash_loop_admin_alert)"
+before_admin_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[crash-loop] $NOTIFY_AGENT ")"
+
+bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null 2>&1 || die "daemon sync failed (notify-agent crash)"
+
+after_redirect="$(audit_count_action crash_notified_origin)"
+after_admin_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[crash-loop] $NOTIFY_AGENT ")"
+
+(( after_redirect > before_redirect )) \
+  || die "expected crash_notified_origin audit row to grow (before=$before_redirect after=$after_redirect)"
+[[ "$after_admin_task" == "0" ]] \
+  || die "admin must NOT receive [crash-loop] task for non-admin notify-agent (count=$after_admin_task)"
+[[ "$before_admin_task" == "0" ]] \
+  || die "fixture preconditions wrong: admin queue not empty before sync"
+
+# ---------------------------------------------------------------------------
+# Step 2: process_crash_reports falls back to admin queue for silent agent
+# ---------------------------------------------------------------------------
+
+log "step 2 — crash report for agent without notify falls back to admin queue"
+
+bash -c "
+  set -e
+  source '$REPO_ROOT/bridge-lib.sh'
+  bridge_load_roster
+  bridge_agent_write_crash_report '$SILENT_AGENT' 'claude' 5 1 '$CRASH_ERR' 'claude --dangerously-skip-permissions'
+" || die "failed to seed crash report for $SILENT_AGENT"
+
+before_silent_admin_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[crash-loop] $SILENT_AGENT ")"
+bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null 2>&1 || die "daemon sync failed (silent-agent crash)"
+after_silent_admin_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[crash-loop] $SILENT_AGENT ")"
+
+(( after_silent_admin_task > before_silent_admin_task )) \
+  || die "expected admin queue to receive [crash-loop] for silent agent (before=$before_silent_admin_task after=$after_silent_admin_task)"
+
+# ---------------------------------------------------------------------------
+# Step 3: bridge_report_channel_health_miss emits audit + dashboard flag,
+#         does not create admin task
+# ---------------------------------------------------------------------------
+
+log "step 3 — channel-health miss surfaces via audit + dashboard flag (no admin task)"
+
+CHANNEL_HEALTH_AGENT="gateway-broken-channel"
+CHANNEL_HEALTH_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$CHANNEL_HEALTH_AGENT"
+mkdir -p "$CHANNEL_HEALTH_WORKDIR"
+cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<ROSTER
+
+bridge_add_agent_id_if_missing "$CHANNEL_HEALTH_AGENT"
+BRIDGE_AGENT_DESC["$CHANNEL_HEALTH_AGENT"]="Broken channel role"
+BRIDGE_AGENT_ENGINE["$CHANNEL_HEALTH_AGENT"]="claude"
+BRIDGE_AGENT_SESSION["$CHANNEL_HEALTH_AGENT"]="$CHANNEL_HEALTH_AGENT"
+BRIDGE_AGENT_WORKDIR["$CHANNEL_HEALTH_AGENT"]="$CHANNEL_HEALTH_WORKDIR"
+BRIDGE_AGENT_LAUNCH_CMD["$CHANNEL_HEALTH_AGENT"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CHANNELS["$CHANNEL_HEALTH_AGENT"]="plugin:discord"
+ROSTER
+
+before_health_miss="$(audit_count_action channel_health_miss)"
+before_health_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[channel-health] $CHANNEL_HEALTH_AGENT ")"
+bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null 2>&1 || die "daemon sync failed (channel-health)"
+after_health_miss="$(audit_count_action channel_health_miss)"
+after_health_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[channel-health] $CHANNEL_HEALTH_AGENT ")"
+
+(( after_health_miss > before_health_miss )) \
+  || die "expected channel_health_miss audit row to grow (before=$before_health_miss after=$after_health_miss)"
+[[ "$after_health_task" == "0" ]] \
+  || die "admin must NOT receive [channel-health] task (count=$after_health_task)"
+[[ "$before_health_task" == "0" ]] \
+  || die "fixture preconditions wrong: admin queue had channel-health task before sync"
+
+python3 - "$BRIDGE_AUDIT_LOG" "$CHANNEL_HEALTH_AGENT" <<'PY' || die "channel_health_miss audit row missing dashboard_flag=1"
+import json, sys
+path, agent = sys.argv[1], sys.argv[2]
+found = False
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("action") != "channel_health_miss":
+            continue
+        if row.get("target") != agent:
+            continue
+        detail = row.get("detail") or {}
+        if str(detail.get("dashboard_flag")) == "1":
+            found = True
+            break
+if not found:
+    sys.exit(1)
+PY
+
+# ---------------------------------------------------------------------------
+# Step 4: cron-followup classifier — human-config vs admin-resolvable
+# ---------------------------------------------------------------------------
+
+log "step 4 — cron-followup human-config drift writes audit, no admin task"
+
+# Helper: stage a cron-dispatch task with a chosen failure_class and run
+# the cron worker once. Mirrors the smoke pattern used by the existing
+# scripts/smoke-test.sh cron block.
+stage_and_run_cron_followup() {
+  local run_id="$1"
+  local failure_class="$2"
+  local job_name="$3"
+  local target_agent="$4"
+  local run_dir="$BRIDGE_STATE_DIR/cron/runs/$run_id"
+  local request_file="$run_dir/request.json"
+  local result_file="$run_dir/result.json"
+  local status_file="$run_dir/status.json"
+  local prompt_file="$run_dir/prompt.txt"
+  # Dispatch body filename is `<run_id>.md` so that
+  # `bridge_cron_run_id_from_body_path` recovers the correct run_id from
+  # the queue task's body_path. Mirrors scripts/smoke-test.sh:7801.
+  local dispatch_body="$BRIDGE_SHARED_DIR/cron-dispatch/$run_id.md"
+
+  mkdir -p "$run_dir" "$(dirname "$dispatch_body")"
+  : >"$prompt_file"
+  cat >"$request_file" <<EOF
+{
+  "run_id": "$run_id",
+  "job_id": "$job_name",
+  "job_name": "$job_name",
+  "family": "$job_name",
+  "slot": "$run_id",
+  "target_agent": "$target_agent",
+  "target_engine": "claude",
+  "result_file": "$result_file",
+  "status_file": "$status_file",
+  "request_file": "$request_file",
+  "stdout_log": "$run_dir/stdout.log",
+  "stderr_log": "$run_dir/stderr.log",
+  "failure_class": "$failure_class"
+}
+EOF
+  cat >"$status_file" <<EOF
+{
+  "run_id": "$run_id",
+  "state": "success",
+  "engine": "claude",
+  "request_file": "$request_file",
+  "result_file": "$result_file"
+}
+EOF
+  # Subagent reports an error so cron-followup classifier branch fires.
+  cat >"$result_file" <<EOF
+{
+  "status": "error",
+  "summary": "fixture failure ($failure_class)",
+  "needs_human_followup": true,
+  "failure_class": "$failure_class",
+  "recommended_next_steps": ["fixture only"],
+  "actions_taken": [],
+  "artifacts": [],
+  "confidence": "high"
+}
+EOF
+  cat >"$dispatch_body" <<EOF
+# [cron-dispatch] $job_name
+
+- run_id: $run_id
+- failure_class: $failure_class
+EOF
+  local create_output
+  create_output="$(bash "$REPO_ROOT/bridge-task.sh" create --to "$target_agent" --title "[cron-dispatch] $job_name ($run_id)" --body-file "$dispatch_body" --from gateway-smoke 2>/dev/null)"
+  local dispatch_id=""
+  [[ "$create_output" =~ created\ task\ \#([0-9]+) ]] && dispatch_id="${BASH_REMATCH[1]}"
+  [[ "$dispatch_id" =~ ^[0-9]+$ ]] || die "could not parse cron-dispatch task id ($create_output)"
+  bash "$REPO_ROOT/bridge-queue.py" claim "$dispatch_id" --agent "$target_agent" --lease-seconds 900 >/dev/null 2>&1 || true
+  bash "$REPO_ROOT/bridge-daemon.sh" run-cron-worker "$dispatch_id" >/dev/null 2>&1 || true
+}
+
+# Bump fail-burst threshold to 1 so a single admin-resolvable failure is
+# enough to verify task creation in this fixture. Default 3 keeps the
+# default smoke quiet on transient errors.
+export BRIDGE_CRON_FOLLOWUP_FAIL_BURST_THRESHOLD=1
+
+before_drift="$(audit_count_action cron_human_config_drift)"
+before_drift_admin_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[cron-followup] gateway-drift-job ")"
+stage_and_run_cron_followup "gateway-drift-run--2026-04-26" "human-config" "gateway-drift-job" "$ADMIN_AGENT"
+after_drift="$(audit_count_action cron_human_config_drift)"
+after_drift_admin_task="$(count_open_for_title_prefix "$ADMIN_AGENT" "[cron-followup] gateway-drift-job ")"
+
+(( after_drift > before_drift )) \
+  || die "expected cron_human_config_drift audit row to grow (before=$before_drift after=$after_drift)"
+[[ "$after_drift_admin_task" == "0" ]] \
+  || die "human-config cron-followup must NOT enqueue admin task (count=$after_drift_admin_task)"
+
+log "step 4 — cron-followup admin-resolvable still creates admin task"
+
+before_admin_followup="$(count_open_for_title_prefix "$ADMIN_AGENT" "[cron-followup] gateway-admin-job ")"
+stage_and_run_cron_followup "gateway-admin-run--2026-04-26" "admin-resolvable" "gateway-admin-job" "$ADMIN_AGENT"
+after_admin_followup="$(count_open_for_title_prefix "$ADMIN_AGENT" "[cron-followup] gateway-admin-job ")"
+
+(( after_admin_followup > before_admin_followup )) \
+  || die "admin-resolvable cron-followup must enqueue admin task (before=$before_admin_followup after=$after_admin_followup)"
+
+# ---------------------------------------------------------------------------
+# Step 5: PERMISSION fan-out — requester primary, admin fallback
+# ---------------------------------------------------------------------------
+
+log "step 5 — PERMISSION fan-out picks requester's notify-target as primary"
+
+# Stage an aged [PERMISSION] task. We can't easily backdate created_ts via
+# the public CLI, so we update tasks.created_ts directly via sqlite3.
+PERM_CREATE_OUTPUT="$(bash "$REPO_ROOT/bridge-task.sh" create --to "$ADMIN_AGENT" --title "[PERMISSION] $REQUESTER_AGENT needs approval for tool" --body "permission body" --from "$REQUESTER_AGENT" 2>/dev/null)"
+[[ "$PERM_CREATE_OUTPUT" =~ created\ task\ \#([0-9]+) ]] || die "could not parse permission task id ($PERM_CREATE_OUTPUT)"
+PERM_TASK_ID="${BASH_REMATCH[1]}"
+sqlite3 "$BRIDGE_TASK_DB" "UPDATE tasks SET created_ts=strftime('%s','now')-9999 WHERE id=$PERM_TASK_ID;" 2>/dev/null
+
+before_fanout="$(audit_count_action permission_fanout)"
+BRIDGE_DAEMON_PERMISSION_TIMEOUT_SECONDS=60 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null 2>&1 || die "daemon sync failed (permission fanout primary path)"
+after_fanout="$(audit_count_action permission_fanout)"
+(( after_fanout > before_fanout )) \
+  || die "expected permission_fanout audit row to grow (before=$before_fanout after=$after_fanout)"
+
+python3 - "$BRIDGE_AUDIT_LOG" "$REQUESTER_AGENT" <<'PY' || die "permission_fanout audit row should mark primary=requester for $REQUESTER_AGENT"
+import json, sys
+path, agent = sys.argv[1], sys.argv[2]
+found = False
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("action") != "permission_fanout":
+            continue
+        if row.get("target") != agent:
+            continue
+        if (row.get("detail") or {}).get("primary") == "requester":
+            found = True
+            break
+if not found:
+    sys.exit(1)
+PY
+
+log "step 5 — PERMISSION fan-out falls back to admin when requester has no notify"
+
+# Re-issue the same fanout for a requester WITHOUT notify (silent agent).
+# Need a NEW permission task because the prior one was marker-deduped.
+PERM2_CREATE_OUTPUT="$(bash "$REPO_ROOT/bridge-task.sh" create --to "$ADMIN_AGENT" --title "[PERMISSION] $SILENT_AGENT needs approval for tool" --body "permission body 2" --from "$SILENT_AGENT" 2>/dev/null)"
+[[ "$PERM2_CREATE_OUTPUT" =~ created\ task\ \#([0-9]+) ]] || die "could not parse second permission task id"
+PERM2_TASK_ID="${BASH_REMATCH[1]}"
+sqlite3 "$BRIDGE_TASK_DB" "UPDATE tasks SET created_ts=strftime('%s','now')-9999 WHERE id=$PERM2_TASK_ID;" 2>/dev/null
+
+before_admin_primary="$(audit_count_action permission_fanout)"
+BRIDGE_DAEMON_PERMISSION_TIMEOUT_SECONDS=60 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null 2>&1 || die "daemon sync failed (permission fanout admin fallback)"
+after_admin_primary="$(audit_count_action permission_fanout)"
+(( after_admin_primary > before_admin_primary )) \
+  || die "expected second permission_fanout audit row (before=$before_admin_primary after=$after_admin_primary)"
+
+python3 - "$BRIDGE_AUDIT_LOG" "$SILENT_AGENT" <<'PY' || die "permission_fanout audit row should mark primary=admin for $SILENT_AGENT"
+import json, sys
+path, agent = sys.argv[1], sys.argv[2]
+found = False
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("action") != "permission_fanout":
+            continue
+        if row.get("target") != agent:
+            continue
+        if (row.get("detail") or {}).get("primary") == "admin":
+            found = True
+            break
+if not found:
+    sys.exit(1)
+PY
+
+# ---------------------------------------------------------------------------
+# Step 6: bridge-status.py renders the config-drift line
+# ---------------------------------------------------------------------------
+
+log "step 6 — bridge-status.py renders config-drift counter"
+
+ROSTER_SNAPSHOT="$TMP_ROOT/roster-snapshot.tsv"
+: > "$ROSTER_SNAPSHOT"
+DAEMON_PID_FILE="$BRIDGE_STATE_DIR/daemon.pid"
+[[ -f "$DAEMON_PID_FILE" ]] || : > "$DAEMON_PID_FILE"
+STATUS_OUTPUT="$(python3 "$REPO_ROOT/bridge-status.py" \
+  --roster-snapshot "$ROSTER_SNAPSHOT" \
+  --db "$BRIDGE_TASK_DB" \
+  --daemon-pid-file "$DAEMON_PID_FILE" \
+  --audit-log "$BRIDGE_AUDIT_LOG" \
+  --config-drift-window-days 7)" \
+  || die "bridge-status.py render failed"
+
+echo "$STATUS_OUTPUT" | grep -Eq '^config-drift \(7d\): [1-9][0-9]*$' \
+  || die "expected config-drift line in status output: $STATUS_OUTPUT"
+
+log "all steps passed"

--- a/tests/admin-gateway-refactor/smoke.sh
+++ b/tests/admin-gateway-refactor/smoke.sh
@@ -480,7 +480,10 @@ STATUS_OUTPUT="$(python3 "$REPO_ROOT/bridge-status.py" \
   --config-drift-window-days 7)" \
   || die "bridge-status.py render failed"
 
-echo "$STATUS_OUTPUT" | grep -Eq '^config-drift \(7d\): [1-9][0-9]*$' \
-  || die "expected config-drift line in status output: $STATUS_OUTPUT"
+expected_drift="$(audit_count_action cron_human_config_drift)"
+[[ "$expected_drift" -ge 1 ]] \
+  || die "fixture invariant broken: cron_human_config_drift audit count is $expected_drift, expected >=1"
+echo "$STATUS_OUTPUT" | grep -Eq "^config-drift \(7d\): ${expected_drift}\$" \
+  || die "config-drift counter mismatch: status=\"$(echo "$STATUS_OUTPUT" | grep '^config-drift')\", expected count=${expected_drift}"
 
 log "all steps passed"


### PR DESCRIPTION
## Summary

Refactors the four remaining `bridge-daemon.sh` admin-gateway hardcoding sites flagged by #345's audit (instance #1 was already handled by #343 Track A in PR #351), plus the Track C dashboard counter the cron-followup split needs. Track A (admin role contract doc) shipped via PR #349.

The unifying fix shape: surface to the originating agent's operator-attached notify-target instead of admin's queue, because admin has no special authority over per-agent config and is not a guaranteed human-channel gateway. Admin queue / admin notify remain as the *fallback* for cases where the affected agent has no operator-attached surface (e.g. admin self-crash, requester with no notify transport).

### Per-instance contract

- **#2 `process_crash_reports`** — when the affected agent has its own notify transport, push the crash report to that surface and write a `crash_notified_origin` audit row. Admin self-crashes keep the legacy admin-notify path. Agents without notify transport fall back to the legacy admin queue task so installs without per-agent notify still get a surface.
- **#3 `bridge_report_channel_health_miss`** — channel-binding mismatches are per-agent secret problems the admin cannot resolve. Replaced the admin queue task with `channel_health_miss` audit + `dashboard_flag=1`, plus a fallback notify to the affected agent's own surface when one exists. Cooldown semantics preserved via the existing state file.
- **#4 cron-followup classifier** — `bridge_cron_load_run_shell` now exports `CRON_FAILURE_CLASS` (read from `result.json` then `request.json`, default `admin-resolvable`). `human-config` failures (config drift, binding mismatch, retired-agent cleanup) bypass admin's queue and write a `cron_human_config_drift` audit row + dashboard flag instead. Burst counter is reset on the human-config branch so the next admin-resolvable failure starts cleanly.
- **#5 `process_permission_task_timeout_fanout`** — requester's own notify transport is now the primary fanout target; admin notify is a fallback used only when the requester has none (or is the admin itself). Each fanout writes a new `permission_fanout` audit row with `primary=requester|admin|none` so reviewers can see which surface was used. The early `bridge_agent_has_notify_transport "$admin_agent" || return 1` gate is gone — fanout is still useful when the requester has notify but the admin does not.

### Track C — dashboard config-drift counter

`bridge-status.py` gains `config_drift_count(audit_log, window_days)` and a `config-drift (Nd): <count>` dashboard line aggregating `cron_human_config_drift` + `channel_health_miss` audit rows over the rolling `--config-drift-window-days` window (default 7). Hidden when count is 0 to keep healthy hosts quiet.

## Test plan

- [x] New isolated smoke at `tests/admin-gateway-refactor/smoke.sh` covers all 5 paths + the dashboard line under a `mktemp -d` BRIDGE_HOME with `BRIDGE_DAEMON_NOTIFY_DRY_RUN=1`. Passes on macOS bash 5.3 / python3 / sqlite3.
- [x] `scripts/smoke-test.sh` channel-health block updated to assert the new contract (audit row + `dashboard_flag=1`, **no** admin task). Existing crash-loop block continues to exercise the silent-agent admin-queue fallback (the `BROKEN_CHANNEL_AGENT` fixture has no notify transport, so it follows the legacy path).
- [x] `bash -n bridge-daemon.sh lib/bridge-cron.sh scripts/smoke-test.sh tests/admin-gateway-refactor/smoke.sh` clean.
- [x] `shellcheck` clean across all modified shell files.
- [x] `python3 -c "import ast; ast.parse(open('bridge-status.py').read())"` and `py_compile` clean.
- [ ] Pair-review on this PR (default reviewer `agb-dev-codex-2`). Reviewer should re-run `tests/admin-gateway-refactor/smoke.sh` from a fresh worktree and verify each step's audit row matches the brief.

## Out of scope

- Track A (already shipped, PR #349).
- Instance #1 `bridge-escalate.sh escalate question` (already shipped via #343 Track A / PR #351).
- Track D (CI greppable regression guard for the assumption pattern). Will be filed as a follow-up.
- VERSION bump / CHANGELOG (not a release PR).

(#345 Track B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)