### PR TITLE
tmux: codex composer state-machine + type_and_submit fallback (#331 Track B)

### DIFF
--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -528,6 +528,107 @@ bridge_tmux_paste_landed() {
   (( post_hits > pre_hits ))
 }
 
+bridge_tmux_codex_post_paste_is_clean() {
+  # Issue #331 Track B: pure-text helper. After paste, the codex composer's
+  # last `›` line should now hold the pasted nudge text — NOT the dim
+  # placeholder ghost ("› Find and fix a bug in @filename" etc.). When the
+  # paste lands visually but composer focus resets the line back to the
+  # placeholder, downstream C-m hits an empty input. The classic symptom is
+  # `paste_landed` returns true (the signature DOES appear in the post
+  # capture, just not on the actual composer line) and yet submit never
+  # fires. Reject that state explicitly so the caller can fall back to
+  # per-key input.
+  #
+  # Returns 0 iff the last prompt-glyph line in $1 (ANSI-preserving capture)
+  # contains $2 (the paste signature) AND that line is not rendered with the
+  # SGR 2 (dim) attribute. Returns 1 otherwise — caller treats as not-clean.
+  local ansi_text="$1"
+  local signature="$2"
+  [[ -n "$ansi_text" ]] || return 1
+  [[ -n "$signature" ]] || return 1
+  local last_line=""
+  local line=""
+  while IFS= read -r line; do
+    if [[ "$line" == *›* ]]; then
+      last_line="$line"
+    fi
+  done <<<"$ansi_text"
+  [[ -n "$last_line" ]] || return 1
+  case "$last_line" in
+    *$'\x1b[2m'*|*$'\x1b[0;2m'*|*$'\x1b[22;2m'*|*$'\x1b[2;'*)
+      # Last `›` line is dim — placeholder restored, paste did not stick.
+      return 1
+      ;;
+  esac
+  case "$last_line" in
+    *"$signature"*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+bridge_tmux_codex_submit_landed() {
+  # Issue #331 Track B: pure-text helper. After C-m, decide whether the
+  # codex TUI actually consumed the submission or whether the keystroke was
+  # absorbed (focus race, placeholder lifecycle reset) and dropped on the
+  # floor.
+  #
+  # Inputs: $1 ANSI-preserving post-C-m capture, $2 the paste signature.
+  #
+  # Returns 0 (submit landed) iff one of:
+  #   (a) the last `›` line in the capture is the dim placeholder AND the
+  #       paste signature is no longer present on that line — meaning the
+  #       composer cleared and codex is back to its idle ghost-text state
+  #       AFTER having something to submit; OR
+  #   (b) a "Working" banner / esc-to-interrupt status line is visible —
+  #       codex started processing the submission.
+  #
+  # Returns 1 (submit lost) iff:
+  #   - the last `›` line still contains the paste signature (composer kept
+  #     the text, never submitted); or
+  #   - no `›` line is present at all, no Working banner, capture is empty.
+  #
+  # Note: the issue #331 failure mode is specifically the case where the
+  # last `›` line goes BACK to dim placeholder *without* a Working banner
+  # firing. In live captures we cannot reliably tell that apart from "codex
+  # submitted then immediately returned to placeholder" except by waiting
+  # for the Working banner; treat absence of both signature and Working as
+  # ambiguous-fail so the caller falls back. This is the conservative
+  # choice — a false-fall-back resends per-key input, which is idempotent
+  # at the queue level (the receiving agent claims once even if nudged
+  # twice). A false-success wedges the task; we prefer to fall back.
+  local ansi_text="$1"
+  local signature="$2"
+  [[ -n "$ansi_text" ]] || return 1
+  [[ -n "$signature" ]] || return 1
+
+  if [[ "$ansi_text" == *"Working"* || "$ansi_text" == *"esc to interrupt"* ]]; then
+    return 0
+  fi
+
+  local last_prompt_line=""
+  local line=""
+  while IFS= read -r line; do
+    if [[ "$line" == *›* ]]; then
+      last_prompt_line="$line"
+    fi
+  done <<<"$ansi_text"
+
+  if [[ -n "$last_prompt_line" && "$last_prompt_line" == *"$signature"* ]]; then
+    # Signature still on the composer line — submit did not fire.
+    return 1
+  fi
+  # No Working banner, no signature on the last `›` line. This is the
+  # ambiguous case (#331): codex may have submitted and immediately
+  # restored the placeholder, or the C-m was absorbed and the placeholder
+  # never went anywhere. Treat as fail so the caller retries via the
+  # per-key path. The downside is a duplicate nudge if the original
+  # actually landed; the receiving agent's claim semantics dedupe at the
+  # queue layer.
+  return 1
+}
+
 bridge_tmux_paste_and_submit() {
   local session="$1"
   local text="$2"
@@ -578,6 +679,30 @@ bridge_tmux_paste_and_submit() {
   fi
   tmux delete-buffer -b "$buffer_name" 2>/dev/null || true
 
+  # Issue #331 Track B: codex-specific pre-submit composer state check.
+  # The plain `paste_landed` test above asks "does the signature appear
+  # somewhere in the recent capture" — it does not distinguish between
+  # "signature is on the composer line" and "signature is in scrollback
+  # while the composer line snapped back to the dim placeholder." The
+  # latter is exactly the #331 failure: paste lands visually for one
+  # frame, focus lifecycle restores the placeholder, the impending C-m
+  # hits an empty input and is dropped. Reject placeholder-restored state
+  # before the C-m and fall back to per-key input.
+  if [[ "$engine" == "codex" ]]; then
+    local pre_submit_ansi
+    pre_submit_ansi="$(bridge_capture_recent_ansi "$session" 15 2>/dev/null || true)"
+    if [[ -n "$pre_submit_ansi" ]] \
+        && ! bridge_tmux_codex_post_paste_is_clean "$pre_submit_ansi" "$signature"; then
+      bridge_warn "codex composer placeholder restored after paste in '${session}'; falling back to type_and_submit"
+      bridge_audit_log daemon tmux_codex_composer_placeholder_restored "$session" \
+        --detail engine="$engine" \
+        --detail signature="$signature" \
+        --detail stage=pre_submit
+      bridge_tmux_type_and_submit "$session" "$text" "$engine"
+      return $?
+    fi
+  fi
+
   # Issue #175: symmetric verify/retry mirrors bridge_tmux_type_and_submit
   # (issue #146). Fresh codex sessions can miss the first C-m when the TUI
   # hasn't absorbed the paste within the 50ms grace — the submit lands on
@@ -591,6 +716,29 @@ bridge_tmux_paste_and_submit() {
     sleep 0.15
     bridge_tmux_send_keys_with_timeout tmux_send_paste_submit_retry \
       -t "$pane_target" C-m
+  fi
+
+  # Issue #331 Track B: codex post-submit state-machine verification. The
+  # `pending_input` retry above catches the case where the composer still
+  # holds the signature (a clean "C-m absorbed, text intact" race). It
+  # does NOT catch the worse #331 case where C-m fired, composer cleared
+  # to placeholder, but no Working banner appeared — submit was lost
+  # without leaving a trace on the composer line. Capture an ANSI post-
+  # state and require either a Working banner or a positive transition
+  # away from the signature; otherwise fall back to per-key input.
+  if [[ "$engine" == "codex" ]]; then
+    sleep 0.1
+    local post_submit_ansi
+    post_submit_ansi="$(bridge_capture_recent_ansi "$session" 20 2>/dev/null || true)"
+    if [[ -n "$post_submit_ansi" ]] \
+        && ! bridge_tmux_codex_submit_landed "$post_submit_ansi" "$signature"; then
+      bridge_warn "codex submit not observed in '${session}' (no Working banner, signature gone); falling back to type_and_submit"
+      bridge_audit_log daemon tmux_codex_submit_lost "$session" \
+        --detail engine="$engine" \
+        --detail signature="$signature"
+      bridge_tmux_type_and_submit "$session" "$text" "$engine"
+      return $?
+    fi
   fi
 }
 

--- a/tests/codex-composer/smoke.sh
+++ b/tests/codex-composer/smoke.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# tests/codex-composer/smoke.sh
+#
+# Regression test for issue #331 Track B — codex composer state-machine
+# hardening + type_and_submit fallback.
+#
+# The live failure mode (from the issue body):
+#   1. daemon nudges a codex agent via paste-buffer + C-m
+#   2. paste lands visually but the codex composer focus race restores
+#      the dim placeholder ghost text on the composer line
+#   3. C-m hits an empty input; submit is dropped silently
+#   4. session_nudge_sent is logged as success even though the agent
+#      never received the message
+#
+# This test exercises the pure-text helpers added in lib/bridge-tmux.sh:
+#   - bridge_tmux_codex_post_paste_is_clean
+#   - bridge_tmux_codex_submit_landed
+# These are the predicates that gate the new fallback path. We do not
+# spin up a real tmux session — the helpers operate on ANSI-preserving
+# capture text and are testable in isolation.
+#
+# We also exercise bridge_tmux_paste_and_submit indirectly by stubbing
+# tmux + the capture helpers, then asserting the stubbed
+# bridge_tmux_type_and_submit fallback fires when the post-paste state
+# is the dim placeholder, and does NOT fire when the post-paste state
+# carries the real signature on the composer line followed by a
+# Working banner.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+log() { printf '[codex-composer] %s\n' "$*"; }
+die() { printf '[codex-composer][error] %s\n' "$*" >&2; exit 1; }
+skip() { printf '[codex-composer][skip] %s\n' "$*"; exit 0; }
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  skip "bash 4+ required (have ${BASH_VERSION})"
+fi
+
+TMP_ROOT="$(mktemp -d -t codex-composer-test.XXXXXX)"
+trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
+
+# ---------------------------------------------------------------------------
+# Source bridge-tmux.sh in isolation. We stub the few external
+# dependencies the helpers reach for (bridge_warn, bridge_audit_log,
+# bridge_nonce, bridge_with_timeout) so the file sources cleanly without
+# pulling the rest of bridge-lib.sh.
+# ---------------------------------------------------------------------------
+
+bridge_warn() { printf '[stub-warn] %s\n' "$*" >&2; }
+# shellcheck disable=SC2329  # shadowed below for case-by-case capture
+bridge_audit_log() { :; }
+bridge_nonce() { printf '%s' "$RANDOM"; }
+bridge_with_timeout() { shift 2; "$@"; }
+# These globals are referenced by some helpers but not by the code paths
+# we exercise here — define defensively so `set -u` in callers stays
+# happy if behavior shifts.
+BRIDGE_TMUX_PROMPT_WAIT_SECONDS="${BRIDGE_TMUX_PROMPT_WAIT_SECONDS:-15}"
+
+# shellcheck disable=SC1090
+source "$REPO_ROOT/lib/bridge-tmux.sh"
+
+# ---------------------------------------------------------------------------
+# Step 1 — bridge_tmux_codex_post_paste_is_clean
+#
+# Real-paste capture: the last `›` line carries the [Agent Bridge] header
+# without dim attribute. Helper must return 0.
+# ---------------------------------------------------------------------------
+
+ESC=$'\x1b'
+
+log "step 1 — clean paste with signature on composer line is accepted"
+SIGNATURE="[Agent Bridge] task #1533"
+CLEAN_CAPTURE=$(cat <<CAP
+some scrollback line
+${ESC}[1mwarm pane content${ESC}[0m
+> typed something earlier
+› ${SIGNATURE} please claim and respond
+  gpt-5.5 xhigh · ~/Projects/cosmax-crm-cli
+CAP
+)
+if ! bridge_tmux_codex_post_paste_is_clean "$CLEAN_CAPTURE" "$SIGNATURE"; then
+  die "expected clean post-paste to be accepted (signature on composer line, no dim)"
+fi
+
+log "step 1 — placeholder-restored capture (dim last \`›\` line) is rejected"
+PLACEHOLDER_CAPTURE=$(cat <<CAP
+${SIGNATURE} body line one
+${SIGNATURE} body line two
+some other scrollback
+${ESC}[2m› Find and fix a bug in @filename${ESC}[0m
+  gpt-5.5 xhigh · ~/Projects/cosmax-crm-cli
+CAP
+)
+if bridge_tmux_codex_post_paste_is_clean "$PLACEHOLDER_CAPTURE" "$SIGNATURE"; then
+  die "expected placeholder-restored capture to be rejected (last \`›\` line is dim)"
+fi
+
+log "step 1 — empty capture is rejected"
+if bridge_tmux_codex_post_paste_is_clean "" "$SIGNATURE"; then
+  die "expected empty capture to be rejected"
+fi
+
+log "step 1 — capture with no \`›\` line is rejected"
+NO_PROMPT_CAPTURE=$(cat <<CAP
+just some output
+no codex composer here
+CAP
+)
+if bridge_tmux_codex_post_paste_is_clean "$NO_PROMPT_CAPTURE" "$SIGNATURE"; then
+  die "expected capture without \`›\` line to be rejected"
+fi
+
+log "step 1 — capture where last \`›\` line lacks signature is rejected"
+WRONG_SIGNATURE_CAPTURE=$(cat <<CAP
+› unrelated content
+› still unrelated content
+CAP
+)
+if bridge_tmux_codex_post_paste_is_clean "$WRONG_SIGNATURE_CAPTURE" "$SIGNATURE"; then
+  die "expected capture without signature on last \`›\` line to be rejected"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2 — bridge_tmux_codex_submit_landed
+#
+# Real submit lands when:
+#   (a) Working banner visible
+#   (b) signature no longer on composer line BUT only via the Working banner
+#
+# Real submit lost when:
+#   - signature still on composer line (input never cleared)
+#   - composer back to placeholder/empty AND no Working banner
+# ---------------------------------------------------------------------------
+
+log "step 2 — Working banner present → submit landed"
+WORKING_CAPTURE=$(cat <<CAP
+• Working (3s • esc to interrupt)
+${ESC}[2m› Find and fix a bug in @filename${ESC}[0m
+  gpt-5.5 xhigh · ~/Projects/cosmax-crm-cli
+CAP
+)
+if ! bridge_tmux_codex_submit_landed "$WORKING_CAPTURE" "$SIGNATURE"; then
+  die "expected submit-landed when 'Working' banner is visible"
+fi
+
+log "step 2 — esc-to-interrupt only → submit landed"
+ESC_BANNER_CAPTURE=$(cat <<CAP
+some thinking output
+press esc to interrupt the task
+› ready
+CAP
+)
+if ! bridge_tmux_codex_submit_landed "$ESC_BANNER_CAPTURE" "$SIGNATURE"; then
+  die "expected submit-landed when 'esc to interrupt' is visible"
+fi
+
+log "step 2 — signature still on composer line → submit lost"
+STUCK_CAPTURE=$(cat <<CAP
+› ${SIGNATURE} please claim and respond
+  gpt-5.5 xhigh · ~/Projects/cosmax-crm-cli
+CAP
+)
+if bridge_tmux_codex_submit_landed "$STUCK_CAPTURE" "$SIGNATURE"; then
+  die "expected submit-lost when signature is still on the composer line"
+fi
+
+log "step 2 — placeholder restored without Working banner → submit lost (#331)"
+LOST_SUBMIT_CAPTURE=$(cat <<CAP
+some scrollback above
+${ESC}[2m› Find and fix a bug in @filename${ESC}[0m
+  gpt-5.5 xhigh · ~/Projects/cosmax-crm-cli
+CAP
+)
+if bridge_tmux_codex_submit_landed "$LOST_SUBMIT_CAPTURE" "$SIGNATURE"; then
+  die "expected submit-lost when placeholder restored without Working banner (#331 root cause)"
+fi
+
+log "step 2 — empty capture → submit lost"
+if bridge_tmux_codex_submit_landed "" "$SIGNATURE"; then
+  die "expected submit-lost on empty capture"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3 — bridge_tmux_paste_and_submit fallback path integration
+#
+# Stub tmux, capture helpers, and bridge_tmux_type_and_submit. Drive
+# paste_and_submit twice:
+#
+#   case A: post-paste capture is the dim placeholder restoration (#331).
+#           The helper must call bridge_tmux_type_and_submit AND emit the
+#           tmux_codex_composer_placeholder_restored audit signal.
+#
+#   case B: post-paste capture has the signature on the live composer
+#           line, AND the post-submit capture has a Working banner.
+#           The helper must NOT call bridge_tmux_type_and_submit.
+# ---------------------------------------------------------------------------
+
+
+# Test harness state. The capture stubs are called from inside `$(...)`
+# command substitutions in bridge_tmux_paste_and_submit, which means any
+# variable increments happen in a subshell and do not propagate back to
+# the parent. We use a file-backed scratch dir to script the response
+# sequence so each invocation reads the next entry deterministically.
+case_label=""
+SCRATCH_DIR="$TMP_ROOT/scratch"
+mkdir -p "$SCRATCH_DIR"
+fallback_called=0
+audit_records=()
+
+# Helper: write each scripted capture to plain-NN/ansi-NN files. The
+# stubs read the file matching their current index and bump a counter
+# file using a flock-free renames-only protocol that also survives
+# subshell calls.
+bridge_capture_recent() {
+  local kind="plain"
+  local idx_file="$SCRATCH_DIR/${kind}.idx"
+  local idx
+  idx="$(cat "$idx_file" 2>/dev/null || echo 0)"
+  local entry_file="$SCRATCH_DIR/${kind}-${idx}"
+  printf '%d' "$((idx + 1))" >"$idx_file"
+  if [[ -f "$entry_file" ]]; then
+    cat "$entry_file"
+  fi
+}
+
+bridge_capture_recent_ansi() {
+  local kind="ansi"
+  local idx_file="$SCRATCH_DIR/${kind}.idx"
+  local idx
+  idx="$(cat "$idx_file" 2>/dev/null || echo 0)"
+  local entry_file="$SCRATCH_DIR/${kind}-${idx}"
+  printf '%d' "$((idx + 1))" >"$idx_file"
+  if [[ -f "$entry_file" ]]; then
+    cat "$entry_file"
+  fi
+}
+
+scripted_capture() {
+  # scripted_capture <kind> <idx> <text>
+  printf '%s' "$3" >"$SCRATCH_DIR/${1}-${2}"
+}
+
+# Stub tmux invocations entirely — the helper only uses set-buffer,
+# paste-buffer, delete-buffer, send-keys (via wrapper) for codex.
+tmux() { :; }
+
+# Stub the per-key fallback so we can detect when paste_and_submit chose
+# to escalate. type_and_submit also runs sleep + tmux stuff, but those
+# are no-ops in this stubbed env.
+bridge_tmux_type_and_submit() {
+  fallback_called=1
+}
+
+# Capture audit signals so we can assert which branch fired.
+# Signature: bridge_audit_log <component> <action> <agent> [--detail k=v ...]
+bridge_audit_log() {
+  audit_records+=("$2")
+}
+
+# Stubs for things paste_and_submit calls but which are fine as no-ops
+# here.
+bridge_tmux_send_keys_with_timeout() { :; }
+bridge_tmux_session_has_pending_input() { return 1; }
+
+# Helper to reset state between cases.
+reset_case() {
+  case_label="$1"
+  rm -f "$SCRATCH_DIR"/plain-* "$SCRATCH_DIR"/ansi-* \
+        "$SCRATCH_DIR/plain.idx" "$SCRATCH_DIR/ansi.idx" 2>/dev/null
+  fallback_called=0
+  audit_records=()
+}
+
+# ----- Case A: placeholder restored after paste -----
+log "step 3 — case A: placeholder restored after paste triggers fallback"
+reset_case A
+case_a_text="[Agent Bridge] task #1533 please claim"
+case_a_sig="$(bridge_tmux_paste_signature "$case_a_text")"
+# bridge_tmux_paste_and_submit calls bridge_capture_recent twice:
+#   plain[0] = pre_capture (before paste)
+#   plain[1] = post_capture after first paste-buffer -p
+# Then bridge_capture_recent_ansi once for pre_submit_ansi.
+#
+# We need plain post-capture to satisfy paste_landed (signature appears
+# more often than in pre), then the ANSI capture must fail
+# codex_post_paste_is_clean (last `›` line is the dim placeholder).
+scripted_capture plain 0 "some scrollback
+> typed text earlier
+› idle"
+scripted_capture plain 1 "some scrollback
+> typed text earlier
+› idle
+${case_a_sig} body landed in scrollback
+› ${case_a_sig} body line"
+scripted_capture ansi 0 "some scrollback
+${case_a_sig} body landed in scrollback
+${ESC}[2m› Find and fix a bug in @filename${ESC}[0m
+  gpt-5.5 xhigh"
+
+bridge_tmux_paste_and_submit "fake-session" "$case_a_text" "codex" || true
+
+[[ "$fallback_called" == "1" ]] \
+  || die "case A: expected type_and_submit fallback when placeholder restored"
+matched_audit=0
+for action in "${audit_records[@]}"; do
+  if [[ "$action" == "tmux_codex_composer_placeholder_restored" ]]; then
+    matched_audit=1
+    break
+  fi
+done
+[[ "$matched_audit" == "1" ]] \
+  || die "case A: expected tmux_codex_composer_placeholder_restored audit signal; got: ${audit_records[*]:-<none>}"
+
+# ----- Case B: paste landed cleanly + Working banner -> no fallback -----
+log "step 3 — case B: clean paste + Working banner does NOT trigger fallback"
+reset_case B
+case_b_text="[Agent Bridge] task #1533 please claim"
+case_b_sig="$(bridge_tmux_paste_signature "$case_b_text")"
+[[ -n "$case_b_sig" ]] || die "case B: paste_signature should be non-empty"
+
+scripted_capture plain 0 "some scrollback
+> typed text earlier
+› idle"
+scripted_capture plain 1 "some scrollback
+> typed text earlier
+› idle
+[Agent Bridge] task #1533 please claim and respond
+› ${case_b_sig} body"
+# pre-submit ANSI: clean composer line carrying signature, no dim escape
+scripted_capture ansi 0 "some scrollback
+[Agent Bridge] task #1533 please claim and respond
+› ${case_b_sig} body line
+  gpt-5.5 xhigh"
+# post-submit ANSI: Working banner present
+scripted_capture ansi 1 "• Working (2s • esc to interrupt)
+${ESC}[2m› Find and fix a bug in @filename${ESC}[0m
+  gpt-5.5 xhigh"
+
+bridge_tmux_paste_and_submit "fake-session" "$case_b_text" "codex" || true
+
+[[ "$fallback_called" == "0" ]] \
+  || die "case B: type_and_submit must NOT fire when paste landed cleanly and Working banner is visible"
+for action in "${audit_records[@]}"; do
+  if [[ "$action" == "tmux_codex_composer_placeholder_restored" \
+      || "$action" == "tmux_codex_submit_lost" \
+      || "$action" == "tmux_paste_landing_failed" ]]; then
+    die "case B: unexpected audit action fired: $action"
+  fi
+done
+
+# ----- Case C: clean paste, but submit lost (no Working, signature gone) -----
+log "step 3 — case C: clean paste then submit lost triggers fallback"
+reset_case C
+case_c_text="[Agent Bridge] task #1601 please claim"
+case_c_sig="$(bridge_tmux_paste_signature "$case_c_text")"
+
+scripted_capture plain 0 "some scrollback
+> typed text earlier
+› idle"
+scripted_capture plain 1 "some scrollback
+> typed text earlier
+› idle
+[Agent Bridge] task #1601 please claim and respond
+› ${case_c_sig} body"
+# pre-submit ANSI: clean composer line, no dim
+scripted_capture ansi 0 "some scrollback
+[Agent Bridge] task #1601 please claim and respond
+› ${case_c_sig} body line
+  gpt-5.5 xhigh"
+# post-submit ANSI: placeholder restored, no Working banner — the #331
+# lost-submit signature.
+scripted_capture ansi 1 "some scrollback
+${ESC}[2m› Find and fix a bug in @filename${ESC}[0m
+  gpt-5.5 xhigh"
+
+bridge_tmux_paste_and_submit "fake-session" "$case_c_text" "codex" || true
+
+[[ "$fallback_called" == "1" ]] \
+  || die "case C: expected type_and_submit fallback when submit was lost (placeholder + no Working)"
+matched_audit=0
+for action in "${audit_records[@]}"; do
+  if [[ "$action" == "tmux_codex_submit_lost" ]]; then
+    matched_audit=1
+    break
+  fi
+done
+[[ "$matched_audit" == "1" ]] \
+  || die "case C: expected tmux_codex_submit_lost audit signal; got: ${audit_records[*]:-<none>}"
+
+log "all steps passed"


### PR DESCRIPTION
## Summary

Track B of #331 — codex tmux paste-and-submit silent loss root fix. Track A (queue-state oracle, PR #337) detects silent loss but doesn't prevent it; Track B fixes the underlying composer state-machine race that lets a paste land but the submit drop without retry.

## Root cause (codex analysis)

codex composer renders an ANSI dim placeholder (`› Find and fix...`) when the input area is empty. `bridge_tmux_paste_and_submit`'s post-submit `bridge_tmux_session_has_pending_input` check classified placeholder-restored composer as "no pending input" (which is correct for an idle session) — but post-C-m this is the wrong call when the C-m was actually consumed by an input-disabled state and never delivered the submission. claude doesn't hit this because it uses `type_and_submit` (per-key input) and has no placeholder exception.

## What changed

- `lib/bridge-tmux.sh` (+148 lines):
  - **`bridge_tmux_codex_post_paste_is_clean`**: ANSI capture-aware helper. Rejects post-paste state when the last `›` line is the dim SGR 2 placeholder, even if the signature appears in scrollback. Catches the "paste-landed-then-snapped-back" trap.
  - **`bridge_tmux_codex_submit_landed`**: post-C-m verifier. Returns success only when a `Working` / `esc to interrupt` banner is visible. Returns failure when the signature is still on the composer (submit dropped) — this is the #331 lost-submit signal.
  - Both wired into `bridge_tmux_paste_and_submit` for `engine == codex`. On miss, falls back to `bridge_tmux_type_and_submit` (the per-key path Claude already uses) and emits new audit actions:
    - `tmux_codex_composer_placeholder_restored` (pre-submit)
    - `tmux_codex_submit_lost` (post-submit)
- `tests/codex-composer/smoke.sh` (new, +393 LOC):
  - 5 unit assertions on `bridge_tmux_codex_post_paste_is_clean`
  - 5 unit assertions on `bridge_tmux_codex_submit_landed`
  - 3 integration cases driving end-to-end with stubbed tmux + capture helpers

## Verification

- `bash -n` PASS
- `shellcheck` PASS (clean)
- `tests/codex-composer/smoke.sh` PASS (3 integration + 10 unit assertions)

## Out of scope

- Track A (queue-state oracle) already merged via PR #337 — kept as detection signal even after Track B lands.
- Track C (ack-probe round-trip) deferred — only needed if Track B's positive Working-banner check has false-negatives in production.

## Pair-review

Required per AGENTS.md. Orchestrator dispatches codex.

Addresses Track B of #331. Track C remains.