### PR TITLE
isolate: grant isolated UID readable access to git-source marketplace tree (#362)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1669,9 +1669,13 @@ bridge_linux_share_plugin_catalog() {
     # Even when known_marketplaces.json carries an entry, the on-disk
     # mirror tree may not yet exist (common for git-source marketplaces
     # on a fresh checkout, or directory-source marketplaces whose cache
-    # has been pruned). Skip silently rather than creating a dangling
-    # symlink — the issue spec calls this out as the expected shape.
-    [[ -d "$_mkt_src" ]] || continue
+    # has been pruned). Surface a warn so operators can act on the
+    # diagnostic — the alternative is silent plugin drop at session
+    # start with zero log signal (#362).
+    if [[ ! -d "$_mkt_src" ]]; then
+      bridge_warn "marketplace ${_mkt_id} is in known_marketplaces.json but the controller-side tree at ${_mkt_src} is missing — declared plugins from this marketplace will not load. Operator must run \`/plugin marketplace add\` once with credentials, then re-run isolation prepare."
+      continue
+    fi
     if (( _marketplaces_root_created == 0 )); then
       bridge_linux_sudo_root mkdir -p "$_isolated_marketplaces"
       bridge_linux_sudo_root chown root:root "$_isolated_marketplaces"
@@ -1683,10 +1687,21 @@ bridge_linux_share_plugin_catalog() {
     bridge_linux_sudo_root rm -f "$_mkt_dst" >/dev/null 2>&1 || true
     bridge_linux_sudo_root ln -s "$_mkt_src" "$_mkt_dst"
     bridge_linux_sudo_root chown -h root:root "$_mkt_dst" >/dev/null 2>&1 || true
-    # Same r-X chain as the install-path grant: traverse first so the
-    # mask doesn't end up `--x` on entries we then bump to r--/r-x.
-    bridge_linux_grant_traverse_chain "$os_user" "$_mkt_src" "$controller_home"
-    bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$_mkt_src"
+    # r#362: end-to-end readability for the symlinked marketplace tree.
+    # Without all three steps, the symlink is planted but EACCES on first
+    # read and Claude silently drops the plugin from the session. Order
+    # matters: traverse_chain stamps `--x` on every node from target up
+    # to controller_home (including target). The recursive r-X grant
+    # must run AFTER so target/<file> entries end up with r--/r-x rather
+    # than --x. Default-ACL inheritance covers files added on the next
+    # marketplace refresh. Fail-loud throughout: a partially-applied ACL
+    # leaves the symlink planted but unusable, which defeats the fix.
+    bridge_linux_grant_traverse_chain "$os_user" "$_mkt_src" "$controller_home" || \
+      bridge_die "marketplace tree: failed to grant traverse chain to $_mkt_src"
+    bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$_mkt_src" || \
+      bridge_die "marketplace tree: failed to grant recursive r-X ACL on $_mkt_src"
+    bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:r-X" "$_mkt_src" || \
+      bridge_die "marketplace tree: failed to set default ACL inheritance on $_mkt_src"
   done
 
   # 5c. Persist the new grant set so the next reapply / unisolate sees


### PR DESCRIPTION
## Summary

Closes the propagation gap that makes declared `<plugin>@<my-mkt>` plugins silently drop on isolated agents. Without recursive r-X ACL on the controller-side marketplace tree and a traverse chain from that tree up to controller home, the symlink the bridge plants at `~/<isolated>/.claude/plugins/marketplaces/<my-mkt>` resolves to EACCES, and Claude drops the plugin from the session with zero log signal.

## Changes (lib/bridge-agents.sh, bridge_linux_share_plugin_catalog)

After the existing #348 r2 marketplace symlink plant, the previously naked traverse_chain + recursive r-X pair becomes a fail-loud three-step chain:

- `bridge_linux_grant_traverse_chain "$os_user" "$_mkt_src" "$controller_home"` — `--x` chain up to (but not including) controller home, matching the #233 stop-guard pattern used elsewhere in the same function.
- `bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$_mkt_src"` — makes the existing tree readable.
- `bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:r-X" "$_mkt_src"` — keeps newly-fetched marketplace files readable on next refresh (NEW — was missing from the original block).

All three are `|| bridge_die` rather than naked invocations — a partially-applied ACL leaves the symlink planted but unusable, which defeats the fix.

Also: when a marketplace is in `known_marketplaces.json` but the on-disk tree is missing, surface a `bridge_warn` instead of silent skip — operators can act on the diagnostic.

## What this PR does NOT change

- Isolated UID's git auth — none granted; controller-side fetch + ACL is the only propagation.
- `installed_plugins.json` writer — already handled by PR #348.
- Non-git-source marketplace ACL — built-in marketplaces are publicly readable.
- PR #363's channel symlink helper — different surface, same file.

## Verification

- `bash -n lib/bridge-agents.sh` PASS
- `shellcheck lib/bridge-agents.sh` PASS
- Live Linux verification required: declared `<plugin>@<my-mkt>` should now load on the isolated agent without manual setfacl post-run.

## Related

- #348 (per-UID installed_plugins.json — already merged)
- #346 (preflight install loop — already merged)
- #363 (channel symlink auto-creation — companion isolation surface in same file, already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)