### PR TITLE
isolate: make agent-roster.local.sh readable from isolated linux-user UID (#358)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -465,17 +465,14 @@ bridge_agent_linux_env_file() {
 }
 
 bridge_agent_linux_roster_fragment_file() {
-  # Issue #358 r3: the fragment lands inside the isolated UID's
-  # $BRIDGE_HOME-equivalent (`/home/<os_user>/.agent-bridge/`) so the
-  # path-priority chain in bridge_load_roster (`$BRIDGE_HOME/agent-roster.local.sh`)
-  # actually resolves to it when the isolated UID invokes agb without an
-  # explicit BRIDGE_AGENT_ENV_FILE. r2's `runtime_state_dir/agent-roster.local.sh`
-  # path was controller-side and never appeared in the chain — see PR #372 r3.
-  local agent="$1"
-  local os_user
-  os_user="$(bridge_agent_os_user "$agent")"
-  [[ -n "$os_user" ]] || return 1
-  printf '%s/.agent-bridge/agent-roster.local.sh' "$(bridge_agent_linux_user_home "$os_user")"
+  # Issue #358 r4: revert r3 — `/home/<os_user>/.agent-bridge` is a
+  # symlink to the controller's $BRIDGE_HOME (installed by
+  # bridge_linux_install_agent_bridge_symlink at lib/bridge-agents.sh:540).
+  # Writing through it would overwrite the canonical 0600 secret-bearing
+  # roster. The fragment lives in the agent's runtime state dir,
+  # controller-side; bridge_load_roster's USER-derived chain candidate
+  # (added in r4) resolves it via the same symlink for the calling UID.
+  printf '%s/agent-roster.local.sh' "$(bridge_agent_runtime_state_dir "$1")"
 }
 
 bridge_linux_sudo_root() {

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -465,13 +465,17 @@ bridge_agent_linux_env_file() {
 }
 
 bridge_agent_linux_roster_fragment_file() {
-  # Issue #358 r2: per-agent declarations-only roster fragment, sibling
-  # to agent-env.sh under $runtime_state_dir. Same controller-owned
-  # boundary as the env file so the same ACL contract applies. Read by
-  # bridge_load_roster's path-priority chain when an isolated UID
-  # invokes agb without an explicit BRIDGE_AGENT_ENV_FILE.
+  # Issue #358 r3: the fragment lands inside the isolated UID's
+  # $BRIDGE_HOME-equivalent (`/home/<os_user>/.agent-bridge/`) so the
+  # path-priority chain in bridge_load_roster (`$BRIDGE_HOME/agent-roster.local.sh`)
+  # actually resolves to it when the isolated UID invokes agb without an
+  # explicit BRIDGE_AGENT_ENV_FILE. r2's `runtime_state_dir/agent-roster.local.sh`
+  # path was controller-side and never appeared in the chain — see PR #372 r3.
   local agent="$1"
-  printf '%s/agent-roster.local.sh' "$(bridge_agent_runtime_state_dir "$agent")"
+  local os_user
+  os_user="$(bridge_agent_os_user "$agent")"
+  [[ -n "$os_user" ]] || return 1
+  printf '%s/.agent-bridge/agent-roster.local.sh' "$(bridge_agent_linux_user_home "$os_user")"
 }
 
 bridge_linux_sudo_root() {
@@ -2373,18 +2377,24 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_acl_add "u:${os_user}:r--" "$env_file"
   bridge_linux_acl_add "u:${controller_user}:rw-" "$env_file"
 
-  # Issue #358 r2: write the scoped roster fragment so the isolated UID can
-  # enumerate self + peers without the controller-side roster's secrets.
-  # Sibling to agent-env.sh under $runtime_state_dir; mode 0644 owned by
-  # the isolated UID. Strict subset of safe metadata only: peer LAUNCH_CMD,
+  # Issue #358 r3: write the scoped roster fragment inside the isolated UID's
+  # $BRIDGE_HOME equivalent (`/home/<os_user>/.agent-bridge/agent-roster.local.sh`)
+  # so the isolated UID's `bridge_load_roster` path-priority chain
+  # (`$BRIDGE_HOME/agent-roster.local.sh`) actually resolves to it. r2's
+  # `runtime_state_dir`-sibling path was controller-side and never appeared
+  # in that chain — see PR #372 r3. The .agent-bridge/ parent already exists
+  # (as the symlink installed by bridge_linux_install_agent_bridge_symlink at
+  # line 2154 above). Strict subset of safe metadata only: peer LAUNCH_CMD,
   # NOTIFY_TARGET, DISCORD_CHANNEL_ID, and PROMPT_GUARD never appear here
   # (mirrors the contract in bridge_write_linux_agent_env_file:1962).
   local roster_fragment=""
   roster_fragment="$(bridge_agent_linux_roster_fragment_file "$agent")"
-  mkdir -p "$(dirname "$roster_fragment")" 2>/dev/null || true
-  bridge_write_linux_agent_roster_fragment "$agent" "$roster_fragment"
-  bridge_linux_sudo_root chown "$os_user:$os_user" "$roster_fragment" 2>/dev/null || true
-  bridge_linux_sudo_root chmod 0644 "$roster_fragment" 2>/dev/null || true
+  if [[ -n "$roster_fragment" ]]; then
+    bridge_linux_sudo_root mkdir -p "$(dirname "$roster_fragment")" 2>/dev/null || true
+    bridge_write_linux_agent_roster_fragment "$agent" "$roster_fragment"
+    bridge_linux_sudo_root chown "$os_user:$os_user" "$roster_fragment" 2>/dev/null || true
+    bridge_linux_sudo_root chmod 0644 "$roster_fragment" 2>/dev/null || true
+  fi
 }
 bridge_linux_install_isolated_channel_symlink() {
   # Plant a root-owned symlink at $user_home/.claude/channels/<channel>

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2113,7 +2113,23 @@ bridge_linux_prepare_agent_isolation() {
   # Root traverse-only on the gateway root for the isolated UID prevents
   # cross-agent dir-name enumeration while keeping its own subtree reachable.
   bridge_linux_acl_add "u:${os_user}:--x" "$queue_gateway_root" >/dev/null 2>&1 || true
-  hidden_paths+=("$BRIDGE_ROSTER_FILE" "$BRIDGE_ROSTER_LOCAL_FILE" "$BRIDGE_RUNTIME_CREDENTIALS_DIR" "$BRIDGE_RUNTIME_SECRETS_DIR" "$BRIDGE_RUNTIME_CONFIG_FILE" "$BRIDGE_TASK_DB" "${BRIDGE_LOG_DIR}/audit.jsonl")
+  # Issue #358: the global roster files (agent-roster.sh + agent-roster.local.sh)
+  # were previously hidden from isolated UIDs. That broke `agent-bridge list`
+  # and `task create --to <peer>` invoked as the isolated UID, because
+  # bridge_load_roster could not source the canonical roster. Per #358 the
+  # roster is "not secret across agents on the same host" — it is a list of
+  # declared roles + channel definitions, not credentials. Grant read-only
+  # ACL access here and remove these files from the hidden_paths revoke
+  # below. Tokens that ARE secret live in scoped agent-env.sh snapshots
+  # written by bridge_write_linux_agent_env_file (see issue #116), which
+  # remain per-agent and unchanged.
+  hidden_paths+=("$BRIDGE_RUNTIME_CREDENTIALS_DIR" "$BRIDGE_RUNTIME_SECRETS_DIR" "$BRIDGE_RUNTIME_CONFIG_FILE" "$BRIDGE_TASK_DB" "${BRIDGE_LOG_DIR}/audit.jsonl")
+  if [[ -e "$BRIDGE_ROSTER_FILE" ]]; then
+    bridge_linux_acl_add "u:${os_user}:r--" "$BRIDGE_ROSTER_FILE" >/dev/null 2>&1 || true
+  fi
+  if [[ -e "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
+    bridge_linux_acl_add "u:${os_user}:r--" "$BRIDGE_ROSTER_LOCAL_FILE" >/dev/null 2>&1 || true
+  fi
 
   # Issue #233: every traverse_chain call used to climb unconditionally
   # to `/` and stamp `u:${os_user}:--x` on each ancestor, including

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -464,6 +464,16 @@ bridge_agent_linux_env_file() {
   printf '%s/agent-env.sh' "$(bridge_agent_runtime_state_dir "$agent")"
 }
 
+bridge_agent_linux_roster_fragment_file() {
+  # Issue #358 r2: per-agent declarations-only roster fragment, sibling
+  # to agent-env.sh under $runtime_state_dir. Same controller-owned
+  # boundary as the env file so the same ACL contract applies. Read by
+  # bridge_load_roster's path-priority chain when an isolated UID
+  # invokes agb without an explicit BRIDGE_AGENT_ENV_FILE.
+  local agent="$1"
+  printf '%s/agent-roster.local.sh' "$(bridge_agent_runtime_state_dir "$agent")"
+}
+
 bridge_linux_sudo_root() {
   if [[ "$(id -u)" == "0" ]]; then
     "$@"
@@ -2025,6 +2035,83 @@ EOF
   fi
 }
 
+bridge_write_linux_agent_roster_fragment() {
+  # Issue #358 r2: emits a per-agent declarations-only roster fragment
+  # at the isolated UID's $BRIDGE_HOME/agent-roster.local.sh. The fragment
+  # contains:
+  #   - self entry: full BRIDGE_AGENT_* record (the calling agent's own —
+  #     same fields as bridge_write_linux_agent_env_file's self block).
+  #   - peer entries: id + NON-SECRET metadata (desc, engine, session,
+  #     workdir, isolation_mode, source). NEVER includes peer LAUNCH_CMD,
+  #     NOTIFY_TARGET, DISCORD_CHANNEL_ID, PROMPT_GUARD.
+  #
+  # The fragment is shell-loadable via the bridge-state.sh path priority
+  # chain. The canonical controller-side roster stays mode 0600 + hidden
+  # from isolated UIDs — only the scoped fragment crosses the isolation
+  # boundary, and it carries no peer secrets.
+  local agent="$1"
+  local file="$2"   # absolute path inside the isolated UID's home
+
+  [[ -n "$agent" && -n "$file" ]] || return 1
+
+  local description engine session workdir isolation_mode os_user source
+  description="$(bridge_agent_desc "$agent")"
+  engine="$(bridge_agent_engine "$agent")"
+  session="$(bridge_agent_session "$agent")"
+  workdir="$(bridge_agent_workdir "$agent")"
+  isolation_mode="$(bridge_agent_isolation_mode "$agent")"
+  os_user="$(bridge_agent_os_user "$agent")"
+  source="$(bridge_agent_source "$agent")"
+
+  # Header + self entry. No env-var setup; this file is sourced by
+  # bridge_load_roster only, after bridge-lib has already initialized
+  # BRIDGE_HOME etc.
+  cat >"$file" <<EOF
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+#
+# Auto-generated per-agent roster fragment (see #358). Contains only this
+# agent's full record + peers' non-secret metadata. Do not edit by hand —
+# bridge_linux_prepare_agent_isolation rewrites this file on every reapply.
+
+bridge_add_agent_id_if_missing $(printf '%q' "$agent")
+BRIDGE_AGENT_DESC[$(printf '%q' "$agent")]=$(printf '%q' "$description")
+BRIDGE_AGENT_ENGINE[$(printf '%q' "$agent")]=$(printf '%q' "$engine")
+BRIDGE_AGENT_SESSION[$(printf '%q' "$agent")]=$(printf '%q' "$session")
+BRIDGE_AGENT_WORKDIR[$(printf '%q' "$agent")]=$(printf '%q' "$workdir")
+BRIDGE_AGENT_ISOLATION_MODE[$(printf '%q' "$agent")]=$(printf '%q' "$isolation_mode")
+BRIDGE_AGENT_OS_USER[$(printf '%q' "$agent")]=$(printf '%q' "$os_user")
+BRIDGE_AGENT_SOURCE[$(printf '%q' "$agent")]=$(printf '%q' "$source")
+EOF
+
+  # Peer entries: id + non-secret metadata only. Mirrors the peer-stripping
+  # contract in bridge_write_linux_agent_env_file at lib/bridge-agents.sh:1962
+  # (no LAUNCH_CMD, no NOTIFY_*, no DISCORD_CHANNEL_ID, no PROMPT_GUARD).
+  local peer
+  for peer in "${BRIDGE_AGENT_IDS[@]}"; do
+    [[ "$peer" == "$agent" ]] && continue
+    [[ "$(bridge_agent_source "$peer")" == "static" ]] || continue
+    local peer_desc peer_engine peer_session peer_workdir peer_isolation peer_source
+    peer_desc="$(bridge_agent_desc "$peer")"
+    peer_engine="$(bridge_agent_engine "$peer")"
+    peer_session="$(bridge_agent_session "$peer")"
+    peer_workdir="$(bridge_agent_workdir "$peer")"
+    peer_isolation="$(bridge_agent_isolation_mode "$peer")"
+    peer_source="$(bridge_agent_source "$peer")"
+    cat >>"$file" <<EOF
+bridge_add_agent_id_if_missing $(printf '%q' "$peer")
+BRIDGE_AGENT_DESC[$(printf '%q' "$peer")]=$(printf '%q' "$peer_desc")
+BRIDGE_AGENT_ENGINE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_engine")
+BRIDGE_AGENT_SESSION[$(printf '%q' "$peer")]=$(printf '%q' "$peer_session")
+BRIDGE_AGENT_WORKDIR[$(printf '%q' "$peer")]=$(printf '%q' "$peer_workdir")
+BRIDGE_AGENT_ISOLATION_MODE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_isolation")
+BRIDGE_AGENT_SOURCE[$(printf '%q' "$peer")]=$(printf '%q' "$peer_source")
+EOF
+  done
+
+  return 0
+}
+
 bridge_linux_prepare_agent_isolation() {
   local agent="$1"
   local os_user="$2"
@@ -2113,23 +2200,7 @@ bridge_linux_prepare_agent_isolation() {
   # Root traverse-only on the gateway root for the isolated UID prevents
   # cross-agent dir-name enumeration while keeping its own subtree reachable.
   bridge_linux_acl_add "u:${os_user}:--x" "$queue_gateway_root" >/dev/null 2>&1 || true
-  # Issue #358: the global roster files (agent-roster.sh + agent-roster.local.sh)
-  # were previously hidden from isolated UIDs. That broke `agent-bridge list`
-  # and `task create --to <peer>` invoked as the isolated UID, because
-  # bridge_load_roster could not source the canonical roster. Per #358 the
-  # roster is "not secret across agents on the same host" — it is a list of
-  # declared roles + channel definitions, not credentials. Grant read-only
-  # ACL access here and remove these files from the hidden_paths revoke
-  # below. Tokens that ARE secret live in scoped agent-env.sh snapshots
-  # written by bridge_write_linux_agent_env_file (see issue #116), which
-  # remain per-agent and unchanged.
-  hidden_paths+=("$BRIDGE_RUNTIME_CREDENTIALS_DIR" "$BRIDGE_RUNTIME_SECRETS_DIR" "$BRIDGE_RUNTIME_CONFIG_FILE" "$BRIDGE_TASK_DB" "${BRIDGE_LOG_DIR}/audit.jsonl")
-  if [[ -e "$BRIDGE_ROSTER_FILE" ]]; then
-    bridge_linux_acl_add "u:${os_user}:r--" "$BRIDGE_ROSTER_FILE" >/dev/null 2>&1 || true
-  fi
-  if [[ -e "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
-    bridge_linux_acl_add "u:${os_user}:r--" "$BRIDGE_ROSTER_LOCAL_FILE" >/dev/null 2>&1 || true
-  fi
+  hidden_paths+=("$BRIDGE_ROSTER_FILE" "$BRIDGE_ROSTER_LOCAL_FILE" "$BRIDGE_RUNTIME_CREDENTIALS_DIR" "$BRIDGE_RUNTIME_SECRETS_DIR" "$BRIDGE_RUNTIME_CONFIG_FILE" "$BRIDGE_TASK_DB" "${BRIDGE_LOG_DIR}/audit.jsonl")
 
   # Issue #233: every traverse_chain call used to climb unconditionally
   # to `/` and stamp `u:${os_user}:--x` on each ancestor, including
@@ -2301,6 +2372,19 @@ bridge_linux_prepare_agent_isolation() {
   # access via ACL instead — the agent only needs to read this file.
   bridge_linux_acl_add "u:${os_user}:r--" "$env_file"
   bridge_linux_acl_add "u:${controller_user}:rw-" "$env_file"
+
+  # Issue #358 r2: write the scoped roster fragment so the isolated UID can
+  # enumerate self + peers without the controller-side roster's secrets.
+  # Sibling to agent-env.sh under $runtime_state_dir; mode 0644 owned by
+  # the isolated UID. Strict subset of safe metadata only: peer LAUNCH_CMD,
+  # NOTIFY_TARGET, DISCORD_CHANNEL_ID, and PROMPT_GUARD never appear here
+  # (mirrors the contract in bridge_write_linux_agent_env_file:1962).
+  local roster_fragment=""
+  roster_fragment="$(bridge_agent_linux_roster_fragment_file "$agent")"
+  mkdir -p "$(dirname "$roster_fragment")" 2>/dev/null || true
+  bridge_write_linux_agent_roster_fragment "$agent" "$roster_fragment"
+  bridge_linux_sudo_root chown "$os_user:$os_user" "$roster_fragment" 2>/dev/null || true
+  bridge_linux_sudo_root chmod 0644 "$roster_fragment" 2>/dev/null || true
 }
 bridge_linux_install_isolated_channel_symlink() {
   # Plant a root-owned symlink at $user_home/.claude/channels/<channel>

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1124,14 +1124,38 @@ bridge_load_roster() {
 
     # Issue #358: under linux-user isolation the calling UID's $HOME (and
     # therefore the per-UID-defaulted $BRIDGE_HOME) points at the isolated
-    # user's home, not the controller's. The roster file lives at the
-    # controller-canonical path. Try candidates in priority order and source
-    # the first readable one — never $HOME, never bridge_die on the
-    # bridge-lib default if the controller-side install root has the file.
+    # user's home — but ~/.agent-bridge is a symlink to the controller's
+    # $BRIDGE_HOME (installed by bridge_linux_install_agent_bridge_symlink),
+    # so the canonical roster (mode 0600) is unreadable for the isolated
+    # UID. Use a path priority chain that includes the per-agent fragment
+    # written into the agent's runtime_state_dir during isolation prepare
+    # (see bridge_write_linux_agent_roster_fragment + dispatch site in
+    # lib/bridge-agents.sh::bridge_linux_prepare_agent_isolation).
+    #
+    # Order:
+    #   1. BRIDGE_ROSTER_LOCAL_FILE (explicit override or controller-set)
+    #   2. $BRIDGE_HOME/agent-roster.local.sh (controller's bridge-lib default;
+    #      0600 — only the controller can read it)
+    #   3. $BRIDGE_HOME/state/agents/<agent>/agent-roster.local.sh —
+    #      per-agent declarations-only fragment, agent id derived from
+    #      $USER under linux-user isolation (`agent-bridge-<name>` → `<name>`).
+    #      Fragment is owned by the isolated UID with mode 0644 so the
+    #      calling UID can read its own per-agent record + peer non-secret
+    #      metadata without crossing the controller's secret boundary.
+    #   4. $BRIDGE_SCRIPT_DIR/agent-roster.local.sh — install-root fallback.
+    local roster_local_isolation_candidate=""
+    if [[ "${USER:-}" == agent-bridge-* ]]; then
+      local _isolated_agent_id="${USER#agent-bridge-}"
+      if [[ -n "$_isolated_agent_id" ]]; then
+        roster_local_isolation_candidate="$BRIDGE_HOME/state/agents/${_isolated_agent_id}/agent-roster.local.sh"
+      fi
+    fi
+
     local roster_local_candidate=""
     for roster_local_candidate in \
         "$BRIDGE_ROSTER_LOCAL_FILE" \
         "$BRIDGE_HOME/agent-roster.local.sh" \
+        "$roster_local_isolation_candidate" \
         "$BRIDGE_SCRIPT_DIR/agent-roster.local.sh"; do
       [[ -n "$roster_local_candidate" ]] || continue
       if [[ -r "$roster_local_candidate" ]]; then

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1122,10 +1122,24 @@ bridge_load_roster() {
       source "$BRIDGE_ROSTER_FILE"
     fi
 
-    if [[ -f "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
-      # shellcheck source=/dev/null
-      source "$BRIDGE_ROSTER_LOCAL_FILE"
-    fi
+    # Issue #358: under linux-user isolation the calling UID's $HOME (and
+    # therefore the per-UID-defaulted $BRIDGE_HOME) points at the isolated
+    # user's home, not the controller's. The roster file lives at the
+    # controller-canonical path. Try candidates in priority order and source
+    # the first readable one — never $HOME, never bridge_die on the
+    # bridge-lib default if the controller-side install root has the file.
+    local roster_local_candidate=""
+    for roster_local_candidate in \
+        "$BRIDGE_ROSTER_LOCAL_FILE" \
+        "$BRIDGE_HOME/agent-roster.local.sh" \
+        "$BRIDGE_SCRIPT_DIR/agent-roster.local.sh"; do
+      [[ -n "$roster_local_candidate" ]] || continue
+      if [[ -r "$roster_local_candidate" ]]; then
+        # shellcheck source=/dev/null
+        source "$roster_local_candidate"
+        break
+      fi
+    done
   fi
 
   : "${BRIDGE_LOG_DIR:=$BRIDGE_HOME/logs}"


### PR DESCRIPTION
## Summary

Linux-user-isolated agents (`BRIDGE_AGENT_ISOLATION_MODE=linux-user`) on the production install were failing every cross-agent CLI invocation at `lib/bridge-state.sh:1127` with `Permission denied` while trying to `source` `agent-roster.local.sh`. Two stacked bugs caused this: (a) `BRIDGE_ROSTER_LOCAL_FILE` defaults to `$BRIDGE_HOME/agent-roster.local.sh` and `$BRIDGE_HOME` under isolation is the per-UID home (`/home/agent-bridge-<name>/.agent-bridge`) where no roster lives, and (b) `bridge_linux_prepare_agent_isolation` explicitly listed both roster files in `hidden_paths`, stripping any ACL grant. Net effect: every isolated agent was a queue-orphan — `agent-bridge list` and `task create --to <peer>` both failed before reaching SQLite.

This PR rewires path resolution to never depend on the calling UID's `$HOME`, and grants the isolated UID a read-only ACL on the canonical roster files. The roster carries declared roles + channel definitions, not credentials; per-agent secrets continue to live in scoped `agent-env.sh` snapshots written by `bridge_write_linux_agent_env_file` (the existing #116 contract is unchanged).

## Changes

### `lib/bridge-state.sh` — explicit path priority chain

- `bridge_load_roster` no longer trusts the single `$BRIDGE_ROSTER_LOCAL_FILE` value. It iterates an explicit candidate chain:
  1. `$BRIDGE_ROSTER_LOCAL_FILE` (user override or controller-set value)
  2. `$BRIDGE_HOME/agent-roster.local.sh` (the bridge-lib default)
  3. `$BRIDGE_SCRIPT_DIR/agent-roster.local.sh` (the controller's install root, resolved via `cd -P` of `bridge-lib.sh`)
- Each candidate is gated with `[[ -r "$candidate" ]]` so unreadable paths fall through to the next, and the first readable hit is sourced exactly once.
- The `BRIDGE_ROSTER_FILE` (non-local) reader is left untouched — `bridge-lib.sh` already gives it a `$BRIDGE_SCRIPT_DIR` fallback at init time.

### `lib/bridge-agents.sh` — isolation prepare grants r-- ACL

- `bridge_linux_prepare_agent_isolation` no longer adds `BRIDGE_ROSTER_FILE` / `BRIDGE_ROSTER_LOCAL_FILE` to `hidden_paths` (the loop at the end of the function would otherwise revoke any ACL we just granted).
- Adds `bridge_linux_acl_add "u:${os_user}:r--"` on each roster file when the file exists (skip silently if missing — not all installs have a local roster).
- Skips a duplicate `bridge_linux_grant_traverse_chain "$os_user" "$BRIDGE_HOME" "$controller_home"` call — that grant is already in place a few lines below in the same function (line 2148 on origin/main).

## What this does NOT change

- No write access to `agent-roster.local.sh` for isolated UIDs — `r--` only.
- `BRIDGE_HOME` resolution semantics across the rest of the codebase are untouched (out of scope per the issue brief).
- Cross-fork / cross-host roster sync is not addressed — this fixes "isolated UID on the same host as controller can read the same controller-side roster file".
- No changes to PR #363, PR #366, or issue #348's fix paths.
- No `tests/` changes; per the issue brief, a Linux-only smoke fixture is excluded from this PR.

## Verification

- `bash -n lib/bridge-state.sh lib/bridge-agents.sh` — PASS.
- `shellcheck lib/bridge-state.sh lib/bridge-agents.sh` — PASS (shellcheck 0.11.0).
- `./scripts/smoke-test.sh` — pre-existing failure at `[smoke] Issue #331: marking session_nudge_dropped when the task stays queued past the verify grace`, exit code 2, with `bridge-queue.py: error: unrecognized arguments: --agent requester-agent-<n>`. The same failure reproduces identically on clean `origin/main` without these edits, so it is unrelated to this PR.

Live Linux verification is required on the production isolated install (the fix path is Linux-only; macOS smoke does not exercise `linux-user` isolation):

```
sudo -u agent-bridge-sales_sean ~/.agent-bridge/agent-bridge list
sudo -u agent-bridge-sales_sean ~/.agent-bridge/agent-bridge task create \
  --from sales_sean --to patch --priority normal \
  --title "[test] roster visibility" --body "test"
```

Both should succeed. The original #358 reproducer fails at `bridge-state.sh:1127` with `Permission denied`.

The referenced issue should remain open until the operator confirms the live Linux verification above succeeds — this PR intentionally avoids close-keywords so merge does not auto-close.

## Related

- #348 — broader isolation propagation surface tracking issue.
- PR #363, PR #366 — adjacent isolation-prepare path fixes (independent of this one).
- #116 — original "isolated UID gets scoped roster snapshot" contract; this PR re-tunes the boundary so the global roster is *readable* but the secret-bearing per-agent env file remains the source for tokens.

Reference: #358