### PR TITLE
stall: skip per-agent scan for loop=1 idle admin (claimed=0, refresh_pending=0) (#374)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1162,7 +1162,18 @@ process_stall_reports() {
       attached="$(bridge_tmux_session_attached_count "$session" 2>/dev/null || printf '0')"
       [[ "$attached" =~ ^[0-9]+$ ]] || attached=0
       if (( attached == 0 )) && [[ "$engine" == "claude" || "$engine" == "codex" ]]; then
-        if (( claimed > 0 || refresh_pending == 1 )) || [[ "$loop_mode" == "1" ]]; then
+        # Issue #374: a loop=1 agent with no claimed work and no pending
+        # refresh is genuinely idle -- there is nothing to be stalled on.
+        # Skip the per-agent stall scan in this state to avoid classifier
+        # false-positives on benign Claude UI text (transcript snippets,
+        # tool-call results, system-reminder echoes, etc.) which were
+        # repeatedly firing `[Agent Bridge]: stall detected` nudges every
+        # 20-30 minutes against admin agents drained to inbox=empty.
+        # Non-loop agents and loop agents with active work are unaffected;
+        # the trigger_stall==0 cleanup path below still clears stale state.
+        if [[ "$loop_mode" == "1" ]] && (( claimed == 0 && refresh_pending == 0 )); then
+          :  # fall through to trigger_stall==0 handling
+        elif (( claimed > 0 || refresh_pending == 1 )) || [[ "$loop_mode" == "1" ]]; then
           # Issue #264 r3: pass `join` so tmux capture-pane runs with `-J`.
           # Without -J, a long agent reply wraps onto multiple physical lines
           # and only the first carries the glyph prefix; classify() then


### PR DESCRIPTION
## Summary

The stall watchdog was re-firing `[Agent Bridge]: stall detected` against `loop=1` admin agents drained to `claimed=0 inbox=empty` every 20-30 minutes, because `process_stall_reports`' decision-to-scan condition runs whenever any of `claimed > 0`, `refresh_pending == 1`, OR `loop_mode == "1"` is true. A `loop=1` admin with empty inbox hit the third clause and was scanned every cycle; the classifier then false-positived on benign Claude UI text (transcript snippets, tool-call results, system-reminder echoes) and emitted the nudge.

## Change

Single guard added inside `process_stall_reports` (in `bridge-daemon.sh`): for `loop=1` agents with `claimed == 0` AND `refresh_pending == 0`, skip the per-agent stall scan. Non-loop agents and loop agents with active work are unaffected; the existing `trigger_stall==0` cleanup path below still clears any stale stall state.

## What this PR does NOT change

- Classifier logic in `bridge-stall.py classify()`. Issue #374 lists this as a defense-in-depth option but the blast radius is wider; the gate-the-scan approach is the smaller, sufficient fix.
- Stall taxonomy, state-file logic, or `bridge_clear_stall_state`.
- Any config knob — the gate is unconditional for the stated state combination.

## Verification

- `bash -n bridge-daemon.sh` PASS
- `shellcheck bridge-daemon.sh` PASS

Reference: #374