### PR TITLE
memory-daily: source-class filter on registration + harvester refusal (#376 Tracks A+C)

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -172,6 +172,22 @@ fi
 AGENT_COUNT=$(wc -l < "$AGENT_LIST_TMP" | tr -d ' ')
 log "active claude agents: $AGENT_COUNT"
 
+# Issue #376: memory-daily-<agent> crons require a stable per-agent home
+# (~/.agent-bridge/agents/<n>/) which only static roster entries have. Build
+# a separate static-only set so step_memory_daily_cron_one is gated on it
+# without changing what hook/rebuild see.
+STATIC_AGENT_LIST_TMP="$(mktemp -t bootstrap-memory-static-agents.XXXXXX)"
+list_active_static_claude_agents > "$STATIC_AGENT_LIST_TMP"
+if [[ -n "$TARGET_AGENT" ]]; then
+  grep -E "^${TARGET_AGENT}"$'\t' "$STATIC_AGENT_LIST_TMP" > "$STATIC_AGENT_LIST_TMP.filt" || true
+  mv "$STATIC_AGENT_LIST_TMP.filt" "$STATIC_AGENT_LIST_TMP"
+fi
+declare -A STATIC_AGENT_SET
+while IFS=$'\t' read -r _sa _sh; do
+  [[ -z "$_sa" ]] && continue
+  STATIC_AGENT_SET["$_sa"]=1
+done < "$STATIC_AGENT_LIST_TMP"
+
 # -----------------------------------------------------------------------------
 # step 1: PreCompact hook
 # -----------------------------------------------------------------------------
@@ -974,7 +990,12 @@ while IFS=$'\t' read -r agent home; do
   [[ -z "$agent" || -z "$home" ]] && continue
   step_hook_one "$agent" "$home"
   step_rebuild_one "$agent" "$home"
-  step_memory_daily_cron_one "$agent"
+  # Issue #376: only register memory-daily-<agent> crons for static agents.
+  # Dynamic agents have no stable per-agent home; the harvester would fail
+  # every morning with exit 2 and spam admin's queue with cron-followup tasks.
+  if [[ -n "${STATIC_AGENT_SET[$agent]:-}" ]]; then
+    step_memory_daily_cron_one "$agent"
+  fi
 done < "$AGENT_LIST_TMP"
 
 for spec in "${CRON_SPECS[@]}"; do
@@ -994,7 +1015,7 @@ elif [[ -n "$BACKFILL_HISTORY_DAYS" ]]; then
     "mode=$MODE n=$BACKFILL_HISTORY_DAYS"
 fi
 
-rm -f "$EXISTING_CRONS_JSON" "$AGENT_LIST_TMP"
+rm -f "$EXISTING_CRONS_JSON" "$AGENT_LIST_TMP" "$STATIC_AGENT_LIST_TMP"
 
 # -----------------------------------------------------------------------------
 # first-run post-bootstrap signal — queue the "do the first scan + hub

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -96,6 +96,43 @@ for a in data:
 '
 }
 
+# list_active_static_claude_agents — same as list_active_claude_agents, but
+# also filters to source=="static". Issue #376: per-agent pipelines like
+# memory-daily-<agent> assume a stable agent home (~/.agent-bridge/agents/<n>/)
+# that only static roster entries provide. Dynamic agents (--codex/--name from
+# `agent-bridge`) are ephemeral and have no per-agent daily-note pipeline; if
+# they appear in the broader list, registering memory-daily crons for them
+# causes daily exit-2 failures and a [cron-followup] task storm in admin's
+# queue. Use this helper for any registration that targets static-only flows.
+list_active_static_claude_agents() {
+  if [[ ! -x "$BRIDGE_AGB" ]]; then
+    echo "BRIDGE_AGB not executable: $BRIDGE_AGB" >&2
+    return 1
+  fi
+  "$BRIDGE_AGB" agent list --json 2>/dev/null \
+    | "$BRIDGE_PYTHON" -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for a in data:
+    if not isinstance(a, dict):
+        continue
+    if a.get("engine") != "claude":
+        continue
+    if not a.get("active"):
+        continue
+    if a.get("source") != "static":
+        continue
+    name = a.get("agent") or ""
+    wd = a.get("workdir") or ""
+    if not name or not wd:
+        continue
+    print(f"{name}\t{wd}")
+'
+}
+
 # agent_home_for <agent> — print the workdir for <agent> or empty string.
 agent_home_for() {
   local agent="$1"

--- a/scripts/memory-daily-harvest.sh
+++ b/scripts/memory-daily-harvest.sh
@@ -22,6 +22,23 @@ json="$("$BRIDGE_AGB" agent show "$AGENT" --json 2>/dev/null)" \
   || { echo "error: agent show failed for $AGENT" >&2; exit 2; }
 [[ -n "$json" ]] || { echo "error: empty agent show output for $AGENT" >&2; exit 2; }
 
+# Issue #376 Track C: defense-in-depth source-class refusal. Track A filters
+# memory-daily-<agent> registration to static-only agents, but an operator
+# might create a cron manually or a future helper might forget to filter.
+# Exit 0 (success / no-op) — NOT exit 2 — so the cron's run-state stays
+# "success" and the daemon does not generate a [cron-followup] task.
+agent_source="$(printf '%s' "$json" | "$BRIDGE_PYTHON" -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(d.get("source") or "")')"
+if [[ "$agent_source" == "dynamic" ]]; then
+  printf '[memory-daily-harvest] dynamic agent %s has no per-agent daily-note pipeline; nothing to harvest. exiting cleanly.\n' "$AGENT" >&2
+  exit 0
+fi
+
 # Parse JSON twice to stay whitespace-safe (paths may contain spaces).
 workdir="$(printf '%s' "$json" | "$BRIDGE_PYTHON" -c '
 import json, sys


### PR DESCRIPTION
## Summary

Reference: (#376 Tracks A+C). Stops memory-daily harvester from failing every morning on every dynamic claude agent.

`bootstrap-memory-system.sh` step 3b registers `memory-daily-<agent>` crons for every claude+active agent without distinguishing static vs dynamic source class. Dynamic agents have no `~/.agent-bridge/agents/<name>/` home, so the harvester aborts with exit 2 every morning, the daemon emits a `[cron-followup]` task to admin, and admin's queue collects them with no resolution path (dynamic agents do not produce per-agent daily notes by design — see issue #376 §"What dynamic agents actually need").

## Tracks shipped this PR (A + C of 4 proposed)

### Track A — registration filter

- New `list_active_static_claude_agents` helper in `scripts/_common.sh` filters on `source == "static"` in addition to engine + active.
- `bootstrap-memory-system.sh` builds a separate static-only set (kept distinct from `AGENT_LIST_TMP` so hook + rebuild + backfill steps still see all active claude agents) and gates the `step_memory_daily_cron_one` call on membership in that set.

### Track C — harvester defense-in-depth

- `scripts/memory-daily-harvest.sh` checks the agent's source class at start (reusing the `agent show --json` blob it already fetches a few lines later — no extra round-trip) and exits 0 cleanly (no `[cron-followup]` generated) for dynamic agents. Catches operator-created or future-helper-created crons that escape Track A.

## Tracks deferred (B + D, follow-up PR)

- **Track B** — apply-time migration to remove existing dynamic-agent memory-daily crons. Operators with already-polluted installs can clear them manually or via a one-off cleanup until that PR lands.
- **Track D** — `docs/agent-runtime/memory-daily-harvest.md` static-only contract documentation.

## Verification

- `bash -n scripts/_common.sh bootstrap-memory-system.sh scripts/memory-daily-harvest.sh` — PASS
- `shellcheck scripts/_common.sh bootstrap-memory-system.sh scripts/memory-daily-harvest.sh` — PASS

Reference: #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)