### PR TITLE
isolate-v2 PR-C: per-agent private root + secret-env split

### DIFF
--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -2566,6 +2566,30 @@ def _harvest_state_dir(args: argparse.Namespace) -> Path:
     return Path(bridge_home).expanduser() / "state" / "memory-daily"
 
 
+def _per_agent_manifest_dir(args: argparse.Namespace, agent: str) -> Path:
+    # PR-C contract: under v2 layout the per-agent manifest lives inside the
+    # agent's private root ($BRIDGE_AGENT_ROOT_V2/<agent>/runtime/memory-daily),
+    # while admin aggregates live under shared/. Callers pass the resolved
+    # per-agent dir via --per-agent-state-dir; absent that flag we keep the
+    # legacy <state_dir>/<agent> shape so non-v2 installs are untouched.
+    override = getattr(args, "per_agent_state_dir", None)
+    if override:
+        return Path(override).expanduser()
+    return _harvest_state_dir(args) / agent
+
+
+def _shared_aggregate_dir(args: argparse.Namespace) -> Path:
+    # PR-C contract: admin aggregates may live under the shared root
+    # ($BRIDGE_SHARED_ROOT/memory-daily/aggregate) so the per-agent root
+    # remains opaque to other isolated UIDs. Callers pass the resolved
+    # shared aggregate dir via --shared-aggregate-dir; absent that flag we
+    # keep the legacy <state_dir>/shared/aggregate shape.
+    override = getattr(args, "shared_aggregate_dir", None)
+    if override:
+        return Path(override).expanduser()
+    return _harvest_state_dir(args) / "shared" / "aggregate"
+
+
 def _harvest_task_db(args: argparse.Namespace) -> Path:
     env = os.environ.get("BRIDGE_TASK_DB")
     if env:
@@ -2616,12 +2640,12 @@ def _merge_aggregate_state(path: Path, merger) -> None:
                 pass
 
 
-def _manifest_path(state_dir: Path, agent: str, date: str) -> Path:
-    return state_dir / agent / f"{date}.json"
+def _manifest_path(args: argparse.Namespace, agent: str, date: str) -> Path:
+    return _per_agent_manifest_dir(args, agent) / f"{date}.json"
 
 
-def _load_manifest(state_dir: Path, agent: str, date: str) -> dict | None:
-    path = _manifest_path(state_dir, agent, date)
+def _load_manifest(args: argparse.Namespace, agent: str, date: str) -> dict | None:
+    path = _manifest_path(args, agent, date)
     if not path.exists():
         return None
     try:
@@ -2640,8 +2664,8 @@ def _load_manifest(state_dir: Path, agent: str, date: str) -> dict | None:
     return None
 
 
-def _write_manifest(state_dir: Path, agent: str, date: str, data: dict) -> Path:
-    path = _manifest_path(state_dir, agent, date)
+def _write_manifest(args: argparse.Namespace, agent: str, date: str, data: dict) -> Path:
+    path = _manifest_path(args, agent, date)
     _atomic_write_json(path, data)
     return path
 
@@ -3144,12 +3168,14 @@ def _render_aggregate_body(schema_label: str, state: dict) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _update_permission_aggregate(state_dir: Path, agent: str, date: str, now_iso: str, db_path: Path, dry_run: bool) -> int | None:
+def _update_permission_aggregate(args: argparse.Namespace, agent: str, date: str, now_iso: str, db_path: Path, dry_run: bool) -> int | None:
     # Shared aggregate lives under shared/aggregate/ so linux-user isolation
     # can grant write there without opening up the per-agent manifest tree
     # (issue #219). Legacy root-level files are migrated in controller
     # context by bridge_linux_prepare_agent_isolation and bootstrap-memory-system.sh.
-    agg_path = state_dir / "shared" / "aggregate" / "admin-aggregate-skip.json"
+    # Under v2 the shared aggregate dir is resolved via --shared-aggregate-dir
+    # so admin aggregates can live outside the per-agent private root.
+    agg_path = _shared_aggregate_dir(args) / "admin-aggregate-skip.json"
     title_prefix = "[memory-daily-skip-admin]"
 
     def merger(current: dict) -> dict:
@@ -3188,9 +3214,9 @@ def _update_permission_aggregate(state_dir: Path, agent: str, date: str, now_iso
     return new_id
 
 
-def _update_escalation_aggregate(state_dir: Path, agent: str, date: str, now_iso: str, db_path: Path, dry_run: bool) -> int | None:
+def _update_escalation_aggregate(args: argparse.Namespace, agent: str, date: str, now_iso: str, db_path: Path, dry_run: bool) -> int | None:
     # See _update_permission_aggregate for the shared/aggregate rationale.
-    agg_path = state_dir / "shared" / "aggregate" / "admin-aggregate-escalated.json"
+    agg_path = _shared_aggregate_dir(args) / "admin-aggregate-escalated.json"
     title_prefix = "[memory-daily-escalated]"
 
     def merger(current: dict) -> dict:
@@ -3342,7 +3368,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
         fail_count = 0
         skipped_count = 0
         for tdate in target_dates:
-            if missing_only and _manifest_path(state_dir, agent, tdate).exists():
+            if missing_only and _manifest_path(args, agent, tdate).exists():
                 # Sidecar manifest is the SSOT for "this date has been
                 # harvested" — Lane B reads the same path. Manual-note-without-
                 # manifest dates must still be harvested.
@@ -3410,7 +3436,7 @@ def cmd_harvest_daily(args: argparse.Namespace) -> int:
             return 2
     else:
         single_date = _harvest_default_date(tz_name)
-    if missing_only and _manifest_path(state_dir, agent, single_date).exists():
+    if missing_only and _manifest_path(args, agent, single_date).exists():
         sys.stderr.write(
             f"[bridge-memory] harvest-daily date={single_date} already harvested "
             f"(manifest exists); --missing-only skip\n"
@@ -3442,7 +3468,7 @@ def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
     # merge (agent,date) into admin-aggregate-skip, and exit success so the
     # cron run surfaces a structured skip rather than an engine error.
     if args.skipped_permission:
-        prev = _load_manifest(state_dir, agent, date) or {}
+        prev = _load_manifest(args, agent, date) or {}
         prev_task = prev.get("task") or {}
         manifest = {
             "schema": "memory-daily-manifest-v1",
@@ -3487,11 +3513,11 @@ def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
                 "requeue_after": None,
             },
         }
-        manifest_path = state_dir / agent / f"{date}.json"
+        manifest_path = _manifest_path(args, agent, date)
         if not args.dry_run:
-            manifest_path = _write_manifest(state_dir, agent, date, manifest)
+            manifest_path = _write_manifest(args, agent, date, manifest)
             _update_permission_aggregate(
-                state_dir, agent, date, now_iso, db_path, args.dry_run,
+                args, agent, date, now_iso, db_path, args.dry_run,
             )
         summary = f"memory-daily sudo wrap unavailable for {agent}/{date}"
         if args.os_user:
@@ -3517,7 +3543,7 @@ def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
 
     # --- Gate check ---------------------------------------------------------
     if args.disabled_gate or _gate_disabled(agent):
-        prev = _load_manifest(state_dir, agent, date) or {}
+        prev = _load_manifest(args, agent, date) or {}
         manifest = {
             "schema": "memory-daily-manifest-v1",
             "agent": agent,
@@ -3547,9 +3573,9 @@ def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
             "decision": {"source_confidence": "none", "action": "skip", "reason_code": "disabled"},
             "task": {"current_task_id": None, "current_task_status": None, "last_task_id": prev.get("task", {}).get("last_task_id"), "last_task_closed_at": prev.get("task", {}).get("last_task_closed_at"), "requeue_after": None},
         }
-        manifest_path = state_dir / agent / f"{date}.json"
+        manifest_path = _manifest_path(args, agent, date)
         if not args.dry_run:
-            manifest_path = _write_manifest(state_dir, agent, date, manifest)
+            manifest_path = _write_manifest(args, agent, date, manifest)
         payload = _build_result_payload(
             status="disabled",
             summary=f"memory-daily gate off for {agent}/{date}",
@@ -3581,7 +3607,7 @@ def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
     )
 
     # --- Load previous manifest for carry-over / dedupe ---------------------
-    prev = _load_manifest(state_dir, agent, date) or {}
+    prev = _load_manifest(args, agent, date) or {}
     prev_task = prev.get("task") or {}
     prev_state = prev.get("state")
     attempts = int(prev.get("attempts") or 0)
@@ -3676,7 +3702,7 @@ def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
     # --- Escalation aggregate ----------------------------------------------
     aggregate_notified_at = prev.get("aggregate_notified_at")
     if new_state == "escalated":
-        _update_escalation_aggregate(state_dir, agent, date, now_iso, db_path, args.dry_run)
+        _update_escalation_aggregate(args, agent, date, now_iso, db_path, args.dry_run)
         aggregate_notified_at = now_iso
 
     # --- Build manifest -----------------------------------------------------
@@ -3720,9 +3746,9 @@ def _harvest_one_date(args: argparse.Namespace, date: str) -> dict:
         },
     }
 
-    manifest_path = state_dir / agent / f"{date}.json"
+    manifest_path = _manifest_path(args, agent, date)
     if not args.dry_run:
-        manifest_path = _write_manifest(state_dir, agent, date, manifest)
+        manifest_path = _write_manifest(args, agent, date, manifest)
 
     # --- Build result payload ----------------------------------------------
     status_map = {
@@ -4031,6 +4057,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     hd_parser.add_argument("--tz", default="Asia/Seoul")
     hd_parser.add_argument("--state-dir", help="override $BRIDGE_STATE_DIR/memory-daily")
+    hd_parser.add_argument(
+        "--per-agent-state-dir",
+        help=(
+            "override the per-agent manifest directory (PR-C v2: "
+            "$BRIDGE_AGENT_ROOT_V2/<agent>/runtime/memory-daily). When set, "
+            "the agent name is NOT appended — the directory is used verbatim."
+        ),
+    )
+    hd_parser.add_argument(
+        "--shared-aggregate-dir",
+        help=(
+            "override the shared admin-aggregate directory (PR-C v2: "
+            "$BRIDGE_SHARED_ROOT/memory-daily/aggregate). When set, the "
+            "directory is used verbatim and admin-aggregate-*.json are "
+            "written directly under it."
+        ),
+    )
     hd_parser.add_argument("--sidecar-out", help="authoritative RESULT_SCHEMA JSON path")
     hd_parser.add_argument("--dry-run", action="store_true")
     hd_parser.add_argument("--json", action="store_true")

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -478,12 +478,55 @@ while true; do
   if [[ -f "$ERRFILE" ]]; then
     local_err_size_before="$(wc -c <"$ERRFILE" 2>/dev/null || echo 0)"
   fi
-  run_started_at="$(date +%s)"
-  if "$BRIDGE_BASH_BIN" -lc "$LAUNCH_CMD" 2> >(tee -a "$ERRFILE" >&2); then
-    EXIT_CODE=0
-  else
-    EXIT_CODE=$?
+  # v2 isolation: load per-agent launch secrets from credentials/launch-secrets.env
+  # into the child shell so the child inherits them via export, NEVER via
+  # composing into LAUNCH_CMD. Composing tokens into LAUNCH_CMD leaks via
+  # process listings, the `log_line` above, dry-run output, the crash-report
+  # path (bridge_agent_write_crash_report writes LAUNCH_CMD verbatim), and
+  # any tee'd stderr. Loading inside the launch subshell (not the parent)
+  # also prevents stale secrets from persisting across restart-loop
+  # iterations after the credentials file is rotated, emptied, or removed.
+  _v2_secret_file=""
+  if bridge_isolation_v2_active; then
+    _v2_secret_file="$(bridge_isolation_v2_agent_secret_env_file "$AGENT" 2>/dev/null || true)"
+    [[ -n "$_v2_secret_file" && -f "$_v2_secret_file" ]] || _v2_secret_file=""
   fi
+  run_started_at="$(date +%s)"
+  if [[ -n "$_v2_secret_file" ]]; then
+    # PR-C r2 review P2 #1: cannot use the subshell exit code as the
+    # loader-failure sentinel — the same subshell `exec`s the agent
+    # command, so any legitimate child exit code (e.g. exit 75 from a
+    # claude / codex process) would be misclassified as a secret-load
+    # failure and call bridge_die. Use an out-of-band marker file that
+    # only the loader-failure branch creates; the parent then checks the
+    # marker independently of the exit code.
+    _v2_secret_fail_marker="$(mktemp -t agb-secret-fail.XXXXXX 2>/dev/null || printf '%s' "/tmp/agb-secret-fail.$$.$RANDOM")"
+    rm -f "$_v2_secret_fail_marker"
+    if (
+      bridge_isolation_v2_load_secret_env "$_v2_secret_file" || {
+        : > "$_v2_secret_fail_marker" 2>/dev/null || true
+        exit 1
+      }
+      exec "$BRIDGE_BASH_BIN" -lc "$LAUNCH_CMD"
+    ) 2> >(tee -a "$ERRFILE" >&2); then
+      EXIT_CODE=0
+    else
+      EXIT_CODE=$?
+    fi
+    if [[ -f "$_v2_secret_fail_marker" ]]; then
+      rm -f "$_v2_secret_fail_marker"
+      bridge_die "isolation v2: failed to load launch secrets for '$AGENT' from $_v2_secret_file"
+    fi
+    rm -f "$_v2_secret_fail_marker"
+    unset _v2_secret_fail_marker
+  else
+    if "$BRIDGE_BASH_BIN" -lc "$LAUNCH_CMD" 2> >(tee -a "$ERRFILE" >&2); then
+      EXIT_CODE=0
+    else
+      EXIT_CODE=$?
+    fi
+  fi
+  unset _v2_secret_file
   run_ended_at="$(date +%s)"
   if [[ "$run_started_at" =~ ^[0-9]+$ && "$run_ended_at" =~ ^[0-9]+$ ]]; then
     run_duration=$((run_ended_at - run_started_at))

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -493,32 +493,16 @@ while true; do
   fi
   run_started_at="$(date +%s)"
   if [[ -n "$_v2_secret_file" ]]; then
-    # PR-C r2 review P2 #1: cannot use the subshell exit code as the
-    # loader-failure sentinel — the same subshell `exec`s the agent
-    # command, so any legitimate child exit code (e.g. exit 75 from a
-    # claude / codex process) would be misclassified as a secret-load
-    # failure and call bridge_die. Use an out-of-band marker file that
-    # only the loader-failure branch creates; the parent then checks the
-    # marker independently of the exit code.
-    _v2_secret_fail_marker="$(mktemp -t agb-secret-fail.XXXXXX 2>/dev/null || printf '%s' "/tmp/agb-secret-fail.$$.$RANDOM")"
-    rm -f "$_v2_secret_fail_marker"
-    if (
-      bridge_isolation_v2_load_secret_env "$_v2_secret_file" || {
-        : > "$_v2_secret_fail_marker" 2>/dev/null || true
-        exit 1
-      }
-      exec "$BRIDGE_BASH_BIN" -lc "$LAUNCH_CMD"
-    ) 2> >(tee -a "$ERRFILE" >&2); then
-      EXIT_CODE=0
-    else
-      EXIT_CODE=$?
-    fi
-    if [[ -f "$_v2_secret_fail_marker" ]]; then
-      rm -f "$_v2_secret_fail_marker"
-      bridge_die "isolation v2: failed to load launch secrets for '$AGENT' from $_v2_secret_file"
-    fi
-    rm -f "$_v2_secret_fail_marker"
-    unset _v2_secret_fail_marker
+    # PR-C r2 (codex r1 G-19): the subshell-wrap pattern lives in
+    # lib/bridge-isolation-v2.sh as bridge_isolation_v2_exec_with_secret_env
+    # so the smoke test exercises the EXACT production code path. The
+    # helper sets BRIDGE_ISOLATION_V2_LAST_EXEC_RC to the child's exit
+    # code (or calls bridge_die on loader failure).
+    BRIDGE_ISOLATION_V2_LAST_EXEC_RC=0
+    bridge_isolation_v2_exec_with_secret_env \
+      "$_v2_secret_file" "$BRIDGE_BASH_BIN" "$LAUNCH_CMD" "$ERRFILE" "$AGENT"
+    EXIT_CODE="$BRIDGE_ISOLATION_V2_LAST_EXEC_RC"
+    unset BRIDGE_ISOLATION_V2_LAST_EXEC_RC
   else
     if "$BRIDGE_BASH_BIN" -lc "$LAUNCH_CMD" 2> >(tee -a "$ERRFILE" >&2); then
       EXIT_CODE=0

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1921,6 +1921,15 @@ BRIDGE_RUNTIME_SECRETS_DIR=$(printf '%q' "$BRIDGE_RUNTIME_SECRETS_DIR")
 BRIDGE_RUNTIME_CONFIG_FILE=$(printf '%q' "$BRIDGE_RUNTIME_CONFIG_FILE")
 BRIDGE_HOOKS_DIR=$(printf '%q' "$BRIDGE_HOOKS_DIR")
 BRIDGE_SHARED_DIR=$(printf '%q' "$BRIDGE_SHARED_DIR")
+BRIDGE_LAYOUT=$(printf '%q' "${BRIDGE_LAYOUT:-legacy}")
+BRIDGE_DATA_ROOT=$(printf '%q' "${BRIDGE_DATA_ROOT:-}")
+BRIDGE_SHARED_ROOT=$(printf '%q' "${BRIDGE_SHARED_ROOT:-}")
+BRIDGE_AGENT_ROOT_V2=$(printf '%q' "${BRIDGE_AGENT_ROOT_V2:-}")
+BRIDGE_CONTROLLER_STATE_ROOT=$(printf '%q' "${BRIDGE_CONTROLLER_STATE_ROOT:-}")
+BRIDGE_SHARED_GROUP=$(printf '%q' "${BRIDGE_SHARED_GROUP:-ab-shared}")
+BRIDGE_CONTROLLER_GROUP=$(printf '%q' "${BRIDGE_CONTROLLER_GROUP:-ab-controller}")
+BRIDGE_AGENT_GROUP_PREFIX=$(printf '%q' "${BRIDGE_AGENT_GROUP_PREFIX:-ab-agent-}")
+export BRIDGE_LAYOUT BRIDGE_DATA_ROOT BRIDGE_SHARED_ROOT BRIDGE_AGENT_ROOT_V2 BRIDGE_CONTROLLER_STATE_ROOT BRIDGE_SHARED_GROUP BRIDGE_CONTROLLER_GROUP BRIDGE_AGENT_GROUP_PREFIX
 BRIDGE_LOG_DIR=$(printf '%q' "$agent_log_dir")
 BRIDGE_AUDIT_LOG=$(printf '%q' "$agent_audit_log")
 BRIDGE_ROSTER_FILE=""
@@ -2104,6 +2113,55 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_ensure_user_home "$os_user" "$user_home"
   bridge_linux_install_agent_bridge_symlink "$os_user" "$user_home" "$BRIDGE_HOME"
 
+  # v2 layout: lay down the per-agent private root before any ACL grants
+  # touch its children. The contract is:
+  #   $BRIDGE_AGENT_ROOT_V2/<agent>            owner=root, group=ab-agent-<name>, mode 2750
+  #   ├── home/, workdir/, runtime/, logs/,
+  #   │   requests/, responses/                 owner=isolated, group=ab-agent-<name>, mode 2770
+  #   └── credentials/                          owner=controller, group=ab-agent-<name>, mode 2750
+  #       └── launch-secrets.env                owner=controller, group=ab-agent-<name>, mode 0640
+  # The root mode 2750 means unrelated UIDs cannot traverse/list the
+  # private root; the isolated UID enters via group r-x but cannot write
+  # at the root level — so it cannot rm/mv `credentials/` or its file.
+  if bridge_isolation_v2_active; then
+    local _v2_agent_group _v2_agent_root _v2_credentials_dir _v2_subdir
+    _v2_agent_group="$(bridge_isolation_v2_agent_group_name "$agent")" \
+      || bridge_die "isolation v2: invalid agent name '$agent' for group composition"
+    bridge_isolation_v2_ensure_group "$_v2_agent_group" \
+      || bridge_die "isolation v2: cannot ensure group '$_v2_agent_group'"
+    bridge_isolation_v2_ensure_user_in_group "$os_user" "$_v2_agent_group" \
+      || bridge_die "isolation v2: cannot add '$os_user' to '$_v2_agent_group'"
+    bridge_isolation_v2_ensure_user_in_group "$controller_user" "$_v2_agent_group" \
+      || bridge_die "isolation v2: cannot add controller '$controller_user' to '$_v2_agent_group'"
+    _v2_agent_root="$(bridge_isolation_v2_agent_root "$agent")" \
+      || bridge_die "isolation v2: cannot resolve per-agent root for '$agent'"
+    bridge_linux_sudo_root mkdir -p "$_v2_agent_root"
+    bridge_linux_sudo_root chown root: "$_v2_agent_root"
+    bridge_linux_sudo_root chgrp "$_v2_agent_group" "$_v2_agent_root"
+    bridge_linux_sudo_root chmod 2750 "$_v2_agent_root"
+    for _v2_subdir in home workdir runtime logs requests responses; do
+      bridge_linux_sudo_root mkdir -p "$_v2_agent_root/$_v2_subdir"
+      bridge_linux_sudo_root chown "$os_user" "$_v2_agent_root/$_v2_subdir"
+      bridge_linux_sudo_root chgrp "$_v2_agent_group" "$_v2_agent_root/$_v2_subdir"
+      bridge_linux_sudo_root chmod 2770 "$_v2_agent_root/$_v2_subdir"
+    done
+    _v2_credentials_dir="$(bridge_isolation_v2_agent_credentials_dir "$agent")"
+    bridge_linux_sudo_root mkdir -p "$_v2_credentials_dir"
+    bridge_linux_sudo_root chown "$controller_user" "$_v2_credentials_dir"
+    bridge_linux_sudo_root chgrp "$_v2_agent_group" "$_v2_credentials_dir"
+    bridge_linux_sudo_root chmod 2750 "$_v2_credentials_dir"
+    # If a launch-secrets.env already exists (carried over from a previous
+    # prepare cycle or seeded by migration), normalize its ownership/mode.
+    # We do not create it here — the operator/migration tool plants it.
+    local _v2_secrets_file
+    _v2_secrets_file="$(bridge_isolation_v2_agent_secret_env_file "$agent")"
+    if bridge_linux_sudo_root test -f "$_v2_secrets_file"; then
+      bridge_linux_sudo_root chown "$controller_user" "$_v2_secrets_file"
+      bridge_linux_sudo_root chgrp "$_v2_agent_group" "$_v2_secrets_file"
+      bridge_linux_sudo_root chmod 0640 "$_v2_secrets_file"
+    fi
+  fi
+
   recursive_read_paths+=("$BRIDGE_HOOKS_DIR" "$BRIDGE_SHARED_DIR")
   [[ -d "$BRIDGE_RUNTIME_ROOT" ]] && recursive_read_paths+=("$BRIDGE_RUNTIME_ROOT")
   [[ -d "$BRIDGE_HOME/.claude" ]] && recursive_read_paths+=("$BRIDGE_HOME/.claude")
@@ -2125,25 +2183,59 @@ bridge_linux_prepare_agent_isolation() {
   #   <state>/memory-daily/shared/aggregate/        — shared rwX (all isolated
   #     agents write to the fcntl.flock-guarded aggregate files; no cross-agent
   #     directory-entry tampering because peer <agent>/ dirs remain un-ACL'd)
-  local memory_daily_root="$BRIDGE_STATE_DIR/memory-daily"
-  local memory_daily_agent_dir="$memory_daily_root/$agent"
-  local memory_daily_shared_aggregate_dir="$memory_daily_root/shared/aggregate"
+  local memory_daily_root memory_daily_agent_dir memory_daily_shared_aggregate_dir
+  if bridge_isolation_v2_active; then
+    # v2 layout: per-agent memory-daily lives inside the per-agent root
+    # (group-isolated), shared aggregate lives under BRIDGE_SHARED_ROOT
+    # so other agents' harvesters can read it via ab-shared. The legacy
+    # `memory_daily_root` aggregate (BRIDGE_STATE_DIR/memory-daily) is no
+    # longer the source of truth in v2 — we keep an empty value so any
+    # later legacy-only ACL grant on it short-circuits below.
+    memory_daily_root=""
+    memory_daily_agent_dir="$(bridge_isolation_v2_agent_memory_daily_root "$agent")"
+    memory_daily_shared_aggregate_dir="$(bridge_isolation_v2_memory_daily_shared_aggregate_dir)"
+  else
+    memory_daily_root="$BRIDGE_STATE_DIR/memory-daily"
+    memory_daily_agent_dir="$memory_daily_root/$agent"
+    memory_daily_shared_aggregate_dir="$memory_daily_root/shared/aggregate"
+  fi
   bridge_linux_sudo_root mkdir -p "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
 
   # One-shot legacy aggregate migration — runs as sudo-root here so it has
   # write access on the memory-daily root even though the new ACL contract
   # only grants isolated UIDs r-x on the root. Idempotent + safe to re-run.
-  local _agg_name
-  for _agg_name in admin-aggregate-skip.json admin-aggregate-escalated.json; do
-    if [[ -f "$memory_daily_root/$_agg_name" && ! -f "$memory_daily_shared_aggregate_dir/$_agg_name" ]]; then
-      bridge_linux_sudo_root mv "$memory_daily_root/$_agg_name" "$memory_daily_shared_aggregate_dir/$_agg_name"
-    fi
-    if [[ -f "$memory_daily_root/$_agg_name.lock" && ! -f "$memory_daily_shared_aggregate_dir/$_agg_name.lock" ]]; then
-      bridge_linux_sudo_root mv "$memory_daily_root/$_agg_name.lock" "$memory_daily_shared_aggregate_dir/$_agg_name.lock"
-    fi
-  done
+  # In v2 layout the legacy `<state>/memory-daily/` root is no longer the
+  # source of truth, so this one-shot is skipped.
+  if [[ -n "$memory_daily_root" ]]; then
+    local _agg_name
+    for _agg_name in admin-aggregate-skip.json admin-aggregate-escalated.json; do
+      if [[ -f "$memory_daily_root/$_agg_name" && ! -f "$memory_daily_shared_aggregate_dir/$_agg_name" ]]; then
+        bridge_linux_sudo_root mv "$memory_daily_root/$_agg_name" "$memory_daily_shared_aggregate_dir/$_agg_name"
+      fi
+      if [[ -f "$memory_daily_root/$_agg_name.lock" && ! -f "$memory_daily_shared_aggregate_dir/$_agg_name.lock" ]]; then
+        bridge_linux_sudo_root mv "$memory_daily_root/$_agg_name.lock" "$memory_daily_shared_aggregate_dir/$_agg_name.lock"
+      fi
+    done
+  fi
 
-  recursive_write_paths+=("$workdir" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir")
+  if bridge_isolation_v2_active; then
+    # v2 split: the per-agent root (= queue_gateway_agent_dir in v2) is
+    # root-owned mode 2750 and MUST stay outside the isolated UID's
+    # rwX grant set; only the writable subtrees are listed. The isolated
+    # UID still reaches requests/responses through ab-agent-<name> group
+    # traverse on the parent root.
+    #
+    # PR-C r3 review P2: $memory_daily_shared_aggregate_dir is removed
+    # from the v2 write set. The shared aggregate sits under ab-shared
+    # (read-only public per the v2 contract) and the harvester writes it
+    # in controller context — isolated UIDs only need read/execute, not
+    # write/delete. Granting rwX recursively here would let any isolated
+    # agent corrupt the shared admin aggregate.
+    recursive_read_paths+=("$memory_daily_shared_aggregate_dir")
+    recursive_write_paths+=("$workdir" "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir")
+  else
+    recursive_write_paths+=("$workdir" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir")
+  fi
   # Issue: per-agent queue-gateway dir was missing isolated/controller ACLs
   # because only its children (requests/, responses/) were granted. The
   # daemon's controller-side glob of the queue-gateway root and the
@@ -2179,7 +2271,9 @@ bridge_linux_prepare_agent_isolation() {
   else
     bridge_warn "controller_user=$controller_user has no passwd entry / home; traverse grants skipped (isolated agent may hit EACCES)"
   fi
-  bridge_linux_acl_add "u:${os_user}:r-x" "$memory_daily_root" "$memory_daily_root/shared" >/dev/null 2>&1 || true
+  if [[ -n "$memory_daily_root" ]]; then
+    bridge_linux_acl_add "u:${os_user}:r-x" "$memory_daily_root" "$memory_daily_root/shared" >/dev/null 2>&1 || true
+  fi
 
   bridge_linux_acl_add "u:${os_user}:r-x" "$BRIDGE_HOME" "$BRIDGE_AGENT_HOME_ROOT"
   bridge_linux_acl_add "u:${os_user}:r-x" "$BRIDGE_HOME/agent-bridge" "$BRIDGE_HOME/agb" "$BRIDGE_HOME/VERSION" >/dev/null 2>&1 || true
@@ -2198,7 +2292,17 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_grant_claude_credentials_access "$os_user" "$user_home" "$controller_user" "$(bridge_agent_engine "$agent")"
   bridge_linux_acl_add_recursive "u:${os_user}:r-X" "${recursive_read_paths[@]}"
   bridge_linux_acl_add_recursive "u:${os_user}:rwX" "${recursive_write_paths[@]}"
-  bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:rwX" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
+  if bridge_isolation_v2_active; then
+    # Match the recursive_write_paths v2 split: queue_gateway_agent_dir
+    # (= per-agent root, root-owned 2750) is intentionally absent so the
+    # isolated UID never inherits a default rwX over its credentials/.
+    # $memory_daily_shared_aggregate_dir is also absent here (PR-C r3 P2):
+    # default rwX would let new files inside the shared aggregate inherit
+    # isolated UID write, defeating the read-only-shared contract.
+    bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:rwX" "$runtime_state_dir" "$log_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir"
+  else
+    bridge_linux_acl_add_default_dirs_recursive "u:${os_user}:rwX" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
+  fi
   bridge_linux_acl_add "u:${os_user}:rw-" "$history_file"
 
   for other in "${BRIDGE_AGENT_IDS[@]}"; do
@@ -2458,6 +2562,10 @@ bridge_linux_install_isolated_channel_symlink() {
 
 bridge_agent_default_home() {
   local agent="$1"
+  if bridge_isolation_v2_active && [[ -n "$BRIDGE_AGENT_ROOT_V2" && -n "$agent" ]]; then
+    printf '%s/%s/home' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+    return 0
+  fi
   printf '%s/%s' "$BRIDGE_AGENT_HOME_ROOT" "$agent"
 }
 
@@ -2539,6 +2647,19 @@ bridge_agent_ms365_state_dir() {
 bridge_agent_workdir() {
   local agent="$1"
   local explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
+
+  # v2 takes precedence over explicit roster workdirs: the per-agent private
+  # root (root-owned, group r-x, mode 2750) IS the isolation contract. An
+  # explicit workdir outside that root would launch the agent into a
+  # directory the per-agent group cannot reach — or worse, a directory that
+  # other isolated UIDs can reach — silently breaking PR-C's per-agent
+  # privacy. Static rosters that need a non-default location should set
+  # BRIDGE_DATA_ROOT (which moves the v2 anchor for every agent), not
+  # BRIDGE_AGENT_WORKDIR per-agent.
+  if bridge_isolation_v2_active && [[ -n "$BRIDGE_AGENT_ROOT_V2" && -n "$agent" ]]; then
+    printf '%s/%s/workdir' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+    return 0
+  fi
 
   if [[ -n "$explicit" ]]; then
     printf '%s' "$explicit"

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -287,6 +287,16 @@ PY
 }
 
 bridge_queue_gateway_root() {
+  # v2 layout: queue agent dirs live inside the per-agent root so the
+  # requests/ and responses/ subtrees inherit the isolated-UID
+  # ownership without a separate ACL subtree. The "root" returned
+  # here is therefore the per-agent root parent (BRIDGE_AGENT_ROOT_V2),
+  # and bridge_queue_gateway_agent_dir composes "<root>/<agent>" the
+  # same way as the legacy "<state>/queue-gateway/<agent>" path.
+  if bridge_isolation_v2_active && [[ -n "$BRIDGE_AGENT_ROOT_V2" ]]; then
+    printf '%s' "$BRIDGE_AGENT_ROOT_V2"
+    return 0
+  fi
   printf '%s/queue-gateway' "$BRIDGE_STATE_DIR"
 }
 
@@ -655,6 +665,16 @@ bridge_history_file_for() {
   local workdir="$3"
   local key
 
+  # v2 layout: history.env lives inside the per-agent runtime root
+  # rather than in BRIDGE_HISTORY_DIR. Format stays shell-env (KEY=VALUE)
+  # so the existing readers/writers (`source` in
+  # bridge_load_static_agent_history, shell assignments in
+  # bridge_write_agent_state_file, the session-id rewrite path) work
+  # without a format migration. Only the location changes.
+  if bridge_isolation_v2_active && [[ -n "$BRIDGE_AGENT_ROOT_V2" && -n "$name" ]]; then
+    printf '%s/%s/runtime/history.env' "$BRIDGE_AGENT_ROOT_V2" "$name"
+    return 0
+  fi
   key="$(bridge_history_key_for "$engine" "$name" "$workdir")"
   printf '%s/%s--%s--%s.env' "$BRIDGE_HISTORY_DIR" "$name" "$engine" "$key"
 }

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -43,8 +43,22 @@
 #   │   ├── plugins/                        ← agent-bridge plugin source (teams/ms365)
 #   │   ├── skills/, docs/
 #   ├── agents/                             owner=root,       group=root,         mode 755
-#   │   └── <agent>/                        owner=agent-bridge-<name>,
-#   │                                       group=ab-agent-<name>,                mode 2770
+#   │   └── <agent>/                        owner=root,
+#   │                                       group=ab-agent-<name>,                mode 2750
+#   │       ├── home/                       owner=agent-bridge-<name>,
+#   │       │                               group=ab-agent-<name>,                mode 2770
+#   │       ├── workdir/                    owner=agent-bridge-<name>,
+#   │       │                               group=ab-agent-<name>,                mode 2770
+#   │       ├── runtime/                    owner=agent-bridge-<name>,
+#   │       │                               group=ab-agent-<name>,                mode 2770
+#   │       ├── logs/                       owner=agent-bridge-<name>,
+#   │       │                               group=ab-agent-<name>,                mode 2770
+#   │       ├── requests/, responses/       owner=agent-bridge-<name>,
+#   │       │                               group=ab-agent-<name>,                mode 2770
+#   │       └── credentials/                owner=controller,
+#   │                                       group=ab-agent-<name>,                mode 2750
+#   │           └── launch-secrets.env      owner=controller,
+#   │                                       group=ab-agent-<name>,                mode 0640
 #   ├── state/                              owner=controller, group=ab-controller, mode 2750
 #   │   └── runtime/                        bridge-config.json + secrets here
 #   ├── agent-roster.sh                     owner=controller, group=ab-controller, mode 0640
@@ -125,6 +139,149 @@ bridge_isolation_v2_shared_plugins_root() {
   # contract elsewhere.
   bridge_isolation_v2_shared_plugins_root_populated || return 1
   printf '%s' "$BRIDGE_SHARED_ROOT/plugins-cache"
+}
+
+bridge_isolation_v2_agent_root() {
+  # Print the v2 per-agent root path. Caller MUST gate on
+  # bridge_isolation_v2_active first; this helper does not re-check.
+  local agent="$1"
+  [[ -n "$agent" && -n "$BRIDGE_AGENT_ROOT_V2" ]] || return 1
+  printf '%s/%s' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+}
+
+bridge_isolation_v2_agent_credentials_dir() {
+  # Controller-owned subtree under the per-agent root. Mode 2750: the
+  # isolated UID can read launch-secrets.env via group r-x but cannot
+  # write/rm/mv anything inside it. Parent (per-agent root) is also
+  # mode 2750 root-owned so the credentials/ directory itself cannot
+  # be renamed/removed by the isolated UID.
+  local agent="$1"
+  local root
+  root="$(bridge_isolation_v2_agent_root "$agent")" || return 1
+  printf '%s/credentials' "$root"
+}
+
+bridge_isolation_v2_agent_secret_env_file() {
+  # Path to the per-agent launch-secrets.env file, the controller-owned
+  # KEY=VALUE shell-env file that bridge-run.sh sources before child
+  # execution (bridge_isolation_v2_load_secret_env). Keeping secrets in
+  # this file (not in BRIDGE_AGENT_LAUNCH_CMD) prevents leaks via
+  # process listings, dry-run output, log lines, and crash reports.
+  local agent="$1"
+  local credentials_dir
+  credentials_dir="$(bridge_isolation_v2_agent_credentials_dir "$agent")" || return 1
+  printf '%s/launch-secrets.env' "$credentials_dir"
+}
+
+bridge_isolation_v2_load_secret_env() {
+  # Strict KEY=VALUE shell-env loader. Used by bridge-run.sh to inject
+  # launch secrets into the current shell so they reach the child via
+  # `export` without ever appearing in the LAUNCH_CMD string.
+  #
+  # Strict parse rules (refuse anything else, fail closed):
+  #   - blank line: skip
+  #   - comment line (^[[:space:]]*#): skip
+  #   - KEY=VALUE: KEY must match [A-Z_][A-Z0-9_]*. VALUE may be:
+  #       * unquoted (no whitespace, no quote, no $, no `, no \\)
+  #       * single-quoted '...'  (literal, no escapes inside)
+  #       * double-quoted "..." (literal but allows \" \\ and $ literal —
+  #                              we deliberately do NOT expand $ here so
+  #                              loaded files cannot exfiltrate other env)
+  #
+  # The strict shape blocks attempts to smuggle command substitution,
+  # arithmetic expansion, parameter expansion, here-docs, or array
+  # syntax through this loader.
+  local file="$1"
+  [[ -n "$file" ]] || {
+    bridge_warn "load_secret_env: file required"
+    return 1
+  }
+  [[ -f "$file" ]] || {
+    bridge_warn "load_secret_env: file not found: $file"
+    return 1
+  }
+  if [[ -r "$file" ]]; then
+    :
+  else
+    bridge_warn "load_secret_env: cannot read $file"
+    return 1
+  fi
+  local line key value lineno=0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    lineno=$((lineno + 1))
+    # strip leading/trailing whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" ]] && continue
+    [[ "$line" == \#* ]] && continue
+    # KEY=VALUE split on first =
+    if [[ "$line" != *=* ]]; then
+      bridge_warn "load_secret_env: $file:$lineno not KEY=VALUE form"
+      return 1
+    fi
+    key="${line%%=*}"
+    value="${line#*=}"
+    if [[ ! "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+      bridge_warn "load_secret_env: $file:$lineno invalid KEY"
+      return 1
+    fi
+    case "$value" in
+      \'*\')
+        # single-quoted literal
+        value="${value:1:${#value}-2}"
+        if [[ "$value" == *\'* ]]; then
+          bridge_warn "load_secret_env: $file:$lineno embedded single-quote"
+          return 1
+        fi
+        ;;
+      \"*\")
+        # double-quoted literal (we treat it literally; no $/`/\\ expansion)
+        value="${value:1:${#value}-2}"
+        case "$value" in
+          *\$*|*\`*|*\\*)
+            bridge_warn "load_secret_env: $file:$lineno disallowed metachar in double-quoted value"
+            return 1
+            ;;
+        esac
+        ;;
+      *)
+        # bare value: forbid whitespace, quotes, $, `, \\
+        case "$value" in
+          *[[:space:]]*|*\"*|*\'*|*\$*|*\`*|*\\*)
+            bridge_warn "load_secret_env: $file:$lineno bare value contains disallowed character (use single-quotes)"
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+    # export into current shell. Subshell `export` would not propagate.
+    # shellcheck disable=SC2163
+    export "$key=$value"
+  done < "$file"
+  return 0
+}
+
+bridge_isolation_v2_agent_memory_daily_root() {
+  # Per-agent memory-daily root. Lives inside the per-agent root so it
+  # inherits the same isolation contract; the daily harvester aggregates
+  # into the shared aggregate dir (controller-owned, group-readable).
+  local agent="$1"
+  local root
+  root="$(bridge_isolation_v2_agent_root "$agent")" || return 1
+  printf '%s/runtime/memory-daily' "$root"
+}
+
+bridge_isolation_v2_memory_daily_shared_aggregate_dir() {
+  # Canonical shared aggregate directory — the harvester writes
+  # admin-aggregate-*.json files DIRECTLY under this path (not inside an
+  # extra `aggregate/` child). Lives under shared/ so other isolated UIDs
+  # may read the aggregate but never write it (design-r3 decision: shared
+  # writes are controller-only). PR-C r3: contract unified across all
+  # callers so prepare/migration grants the same path the Python writer
+  # uses, eliminating the parent-vs-child mismatch flagged in r2 review
+  # finding P2 #2.
+  [[ -n "$BRIDGE_SHARED_ROOT" ]] || return 1
+  printf '%s/memory-daily/aggregate' "$BRIDGE_SHARED_ROOT"
 }
 
 bridge_isolation_v2_agent_group_name() {

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -206,6 +206,23 @@ bridge_isolation_v2_load_secret_env() {
     bridge_warn "load_secret_env: cannot read $file"
     return 1
   fi
+  # PR-C r2 (codex r1 B-3): reject secret files whose mode would allow
+  # group write or world read. The launch-secrets.env contract is 0640
+  # (controller-write, group-read, no other) per PR body §"Per-Agent
+  # Root Layout"; anything broader is either a misconfigured deploy or
+  # a tampering attempt and we MUST refuse to export from it. Probe
+  # cross-platform: GNU `stat -c '%a'` first, BSD `stat -f '%Lp'` fallback.
+  local _secret_mode=""
+  _secret_mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || true)"
+  case "$_secret_mode" in
+    640|0640|600|0600|400|0400)
+      : # acceptable — controller-write only, no group-write, no world-read
+      ;;
+    *)
+      bridge_warn "load_secret_env: refusing $file (mode=${_secret_mode}, expected 0640/0600/0400)"
+      return 1
+      ;;
+  esac
   local line key value lineno=0
   while IFS= read -r line || [[ -n "$line" ]]; do
     lineno=$((lineno + 1))
@@ -258,6 +275,61 @@ bridge_isolation_v2_load_secret_env() {
     # shellcheck disable=SC2163
     export "$key=$value"
   done < "$file"
+  return 0
+}
+
+bridge_isolation_v2_exec_with_secret_env() {
+  # Subshell-wrap for bridge-run.sh's launch path. Loads launch secrets
+  # inside a subshell, then `exec`s the agent command from the same
+  # subshell so the secrets reach the child via `export` without ever
+  # appearing in LAUNCH_CMD or persisting in the long-lived parent.
+  #
+  # PR-C r2 (codex r1 G-19): extracted from bridge-run.sh so the smoke
+  # test exercises the EXACT production code path, not a re-implementation.
+  #
+  # Args:
+  #   $1 secret_file   absolute path to launch-secrets.env
+  #   $2 bash_bin      bash to use for `exec ... -lc <launch_cmd>`
+  #   $3 launch_cmd    the agent launch command line
+  #   $4 errfile       path to append child stderr to (via tee)
+  #   $5 agent_name    agent id, used in the loader-failure bridge_die message
+  #
+  # Side effects:
+  #   - Sets BRIDGE_ISOLATION_V2_LAST_EXEC_RC to the child's exit code.
+  #   - On loader failure, calls bridge_die (does not return).
+  local _secret_file="$1"
+  local _bash_bin="$2"
+  local _launch_cmd="$3"
+  local _errfile="$4"
+  local _agent="$5"
+  # PR-C r2 review P2 #1: cannot use the subshell exit code as the
+  # loader-failure sentinel — the same subshell `exec`s the agent
+  # command, so any legitimate child exit code (e.g. exit 75 from a
+  # claude / codex process) would be misclassified as a secret-load
+  # failure and call bridge_die. Use an out-of-band marker file that
+  # only the loader-failure branch creates; the parent then checks the
+  # marker independently of the exit code.
+  local _fail_marker
+  _fail_marker="$(mktemp -t agb-secret-fail.XXXXXX 2>/dev/null || printf '%s' "/tmp/agb-secret-fail.$$.$RANDOM")"
+  rm -f "$_fail_marker"
+  local _rc=0
+  if (
+    bridge_isolation_v2_load_secret_env "$_secret_file" || {
+      : > "$_fail_marker" 2>/dev/null || true
+      exit 1
+    }
+    exec "$_bash_bin" -lc "$_launch_cmd"
+  ) 2> >(tee -a "$_errfile" >&2); then
+    _rc=0
+  else
+    _rc=$?
+  fi
+  if [[ -f "$_fail_marker" ]]; then
+    rm -f "$_fail_marker"
+    bridge_die "isolation v2: failed to load launch secrets for '$_agent' from $_secret_file"
+  fi
+  rm -f "$_fail_marker"
+  BRIDGE_ISOLATION_V2_LAST_EXEC_RC="$_rc"
   return 0
 }
 

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -521,10 +521,18 @@ bridge_migration_unisolate() {
   # other isolated agents.
   local history_file="" memory_daily_agent_dir="" memory_daily_shared_aggregate_dir=""
   history_file="$(bridge_history_file_for_agent "$agent" 2>/dev/null || true)"
-  memory_daily_agent_dir="$BRIDGE_STATE_DIR/memory-daily/$agent"
-  memory_daily_shared_aggregate_dir="$BRIDGE_STATE_DIR/memory-daily/shared/aggregate"
-  local memory_daily_root="$BRIDGE_STATE_DIR/memory-daily"
-  local memory_daily_shared_root="$memory_daily_root/shared"
+  local memory_daily_root="" memory_daily_shared_root=""
+  if bridge_isolation_v2_active; then
+    memory_daily_agent_dir="$(bridge_isolation_v2_agent_memory_daily_root "$agent" 2>/dev/null || true)"
+    memory_daily_shared_aggregate_dir="$(bridge_isolation_v2_memory_daily_shared_aggregate_dir 2>/dev/null || true)"
+    # v2 layout has no legacy memory-daily root/shared parents to ACL-strip
+    # — leave those local strings empty so the shallow strip below skips.
+  else
+    memory_daily_agent_dir="$BRIDGE_STATE_DIR/memory-daily/$agent"
+    memory_daily_shared_aggregate_dir="$BRIDGE_STATE_DIR/memory-daily/shared/aggregate"
+    memory_daily_root="$BRIDGE_STATE_DIR/memory-daily"
+    memory_daily_shared_root="$memory_daily_root/shared"
+  fi
 
   local -a acl_strip_paths_recursive=()
   [[ -n "$workdir" && -d "$workdir" ]] && acl_strip_paths_recursive+=("$workdir")
@@ -550,8 +558,8 @@ bridge_migration_unisolate() {
   # recursive list above doesn't already cover: the memory-daily root
   # and its shared subdir. Non-recursive so sibling agent dirs stay
   # intact.
-  [[ -d "$memory_daily_root" ]] && acl_strip_paths_shallow+=("$memory_daily_root")
-  [[ -d "$memory_daily_shared_root" ]] && acl_strip_paths_shallow+=("$memory_daily_shared_root")
+  [[ -n "$memory_daily_root" && -d "$memory_daily_root" ]] && acl_strip_paths_shallow+=("$memory_daily_root")
+  [[ -n "$memory_daily_shared_root" && -d "$memory_daily_shared_root" ]] && acl_strip_paths_shallow+=("$memory_daily_shared_root")
 
   # Root-level helper files isolate grants u:<os_user>:r-x on
   # (bridge-agents.sh:1000-1011). These are files, not directories, so

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1697,11 +1697,19 @@ bridge_agent_idle_marker_dir() {
 
 bridge_agent_runtime_state_dir() {
   local agent="$1"
+  if bridge_isolation_v2_active && [[ -n "$BRIDGE_AGENT_ROOT_V2" && -n "$agent" ]]; then
+    printf '%s/%s/runtime' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+    return 0
+  fi
   bridge_agent_idle_marker_dir "$agent"
 }
 
 bridge_agent_log_dir() {
   local agent="$1"
+  if bridge_isolation_v2_active && [[ -n "$BRIDGE_AGENT_ROOT_V2" && -n "$agent" ]]; then
+    printf '%s/%s/logs' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+    return 0
+  fi
   printf '%s/agents/%s' "$BRIDGE_LOG_DIR" "$agent"
 }
 

--- a/scripts/memory-daily-harvest.sh
+++ b/scripts/memory-daily-harvest.sh
@@ -74,11 +74,38 @@ print(d.get("isolation", {}).get("os_user", ""))')"
 
 # Sidecar path: runner-exported CRON_REQUEST_DIR (cron path). Fallback is an
 # agent-scoped state dir for manual/ad-hoc invocation outside the runner.
+# Under v2 layout the per-agent state lives inside the v2 per-agent root, so
+# the fallback resolves through the v2 helper when the layout is active.
 if [[ -n "${CRON_REQUEST_DIR:-}" ]]; then
   sidecar_out="$CRON_REQUEST_DIR/authoritative-memory-daily.json"
 else
-  sidecar_out="$BRIDGE_HOME/state/memory-daily/$AGENT/adhoc.authoritative.json"
+  v2_md_root=""
+  if [[ "${BRIDGE_LAYOUT:-legacy}" == "v2" ]] \
+      && [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+    v2_md_root="$BRIDGE_AGENT_ROOT_V2/$AGENT/runtime/memory-daily"
+  fi
+  if [[ -n "$v2_md_root" ]]; then
+    sidecar_out="$v2_md_root/adhoc.authoritative.json"
+  else
+    sidecar_out="$BRIDGE_HOME/state/memory-daily/$AGENT/adhoc.authoritative.json"
+  fi
   mkdir -p "$(dirname "$sidecar_out")"
+fi
+
+# PR-C: under v2 layout the per-agent manifest must land under the per-agent
+# private root and admin aggregates must land under shared/, not under the
+# legacy controller state. Pass the resolved paths so bridge-memory.py
+# writes manifests + aggregates into the v2 locations instead of falling
+# back to BRIDGE_STATE_DIR/memory-daily. Without these flags the Python
+# harvester would silently keep using the legacy controller tree (issue:
+# PR-C r1 review finding P1 #1).
+v2_extra_args=()
+if [[ "${BRIDGE_LAYOUT:-legacy}" == "v2" ]] \
+    && [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+  v2_extra_args+=(--per-agent-state-dir "$BRIDGE_AGENT_ROOT_V2/$AGENT/runtime/memory-daily")
+  if [[ -n "${BRIDGE_SHARED_ROOT:-}" ]]; then
+    v2_extra_args+=(--shared-aggregate-dir "$BRIDGE_SHARED_ROOT/memory-daily/aggregate")
+  fi
 fi
 
 current_user="$(id -un 2>/dev/null || echo '')"
@@ -109,6 +136,7 @@ if [[ "$isolation_mode" == "linux-user" \
       --os-user "$os_user" \
       --transcripts-home "$target_home" \
       --sidecar-out "$sidecar_out" \
+      "${v2_extra_args[@]}" \
       --json
   else
     exec "$BRIDGE_PYTHON" "$BRIDGE_HOME/bridge-memory.py" harvest-daily \
@@ -118,6 +146,7 @@ if [[ "$isolation_mode" == "linux-user" \
       --os-user "$os_user" \
       --skipped-permission \
       --sidecar-out "$sidecar_out" \
+      "${v2_extra_args[@]}" \
       --json
   fi
 fi
@@ -127,4 +156,5 @@ exec "$BRIDGE_PYTHON" "$BRIDGE_HOME/bridge-memory.py" harvest-daily \
   --home "$home" \
   --workdir "$workdir" \
   --sidecar-out "$sidecar_out" \
+  "${v2_extra_args[@]}" \
   --json

--- a/tests/isolation-v2-pr-c/smoke.sh
+++ b/tests/isolation-v2-pr-c/smoke.sh
@@ -339,6 +339,9 @@ for hostile in \
     'BARE=has space here'; do
   bad_file="$secret_dir/bad.$RANDOM.env"
   printf '%s\n' "$hostile" > "$bad_file"
+  # PR-C r2 (codex r1 B-3): mode check rejects 0644 default; pin to 0600
+  # so this case tests CONTENT rejection, not mode rejection.
+  chmod 0600 "$bad_file"
   if ( set +u; export BRIDGE_HOME="$TMP_ROOT/loader-bh" \
                   BRIDGE_LAYOUT=v2 BRIDGE_DATA_ROOT="$TMP_ROOT/loader-data";
        # shellcheck source=/dev/null
@@ -377,20 +380,74 @@ fi
 ok "S3: launch surfaces (LAUNCH_CMD / log_line / crash payload) free of secret canary"
 
 # ---------------------------------------------------------------------------
+# S3b: file-mode rejection (codex r1 B-3) — load_secret_env must refuse to
+# export from a secret file whose mode would allow group-write or
+# world-read. Acceptable modes: 0640 / 0600 / 0400. Anything broader is
+# either a misconfigured deploy or a tampering attempt.
+# ---------------------------------------------------------------------------
+log "case: secret file-mode rejection (S3b / B-3)"
+mode_dir="$secret_dir/mode"
+mkdir -p "$mode_dir"
+
+# Negative cases: each broader mode must be refused.
+for bad_mode in 0644 0664 0666 0660 0755 0777; do
+  bad_mode_file="$mode_dir/bad-$bad_mode.env"
+  printf 'MODE_TOKEN=ok\n' > "$bad_mode_file"
+  chmod "$bad_mode" "$bad_mode_file"
+  if ( set +u; export BRIDGE_HOME="$TMP_ROOT/loader-bh" \
+                  BRIDGE_LAYOUT=v2 BRIDGE_DATA_ROOT="$TMP_ROOT/loader-data";
+       # shellcheck source=/dev/null
+       source "$REPO_ROOT/bridge-lib.sh" 2>/dev/null;
+       bridge_isolation_v2_load_secret_env "$bad_mode_file" >/dev/null 2>&1
+     ); then
+    die "S3b: file with mode $bad_mode was not rejected"
+  fi
+done
+
+# Positive cases: each acceptable mode must succeed.
+for ok_mode in 0640 0600 0400; do
+  ok_mode_file="$mode_dir/ok-$ok_mode.env"
+  printf 'MODE_TOKEN=ok\n' > "$ok_mode_file"
+  chmod "$ok_mode" "$ok_mode_file"
+  if ! ( set +u; export BRIDGE_HOME="$TMP_ROOT/loader-bh" \
+                    BRIDGE_LAYOUT=v2 BRIDGE_DATA_ROOT="$TMP_ROOT/loader-data";
+         # shellcheck source=/dev/null
+         source "$REPO_ROOT/bridge-lib.sh" 2>/dev/null;
+         unset MODE_TOKEN
+         bridge_isolation_v2_load_secret_env "$ok_mode_file" >/dev/null 2>&1
+       ); then
+    die "S3b: file with mode $ok_mode was incorrectly rejected"
+  fi
+done
+ok "S3b: load_secret_env refuses 0644/0664/0666/0660/0755/0777, accepts 0640/0600/0400"
+
+# ---------------------------------------------------------------------------
 # S4: subshell-scoped secret load — bridge-run.sh now loads launch secrets
 # inside the launch subshell (not the parent). PR-C r1 review P1 #3:
 # loading into the long-lived parent meant rotated/emptied/removed secret
-# files left stale exports across restart-loop iterations. Verify the
-# pattern: a subshell that loads + exits leaves no SECRET in the parent.
+# files left stale exports across restart-loop iterations.
+#
+# PR-C r2 (codex r1 G-19): exercise the EXACT production helper
+# bridge_isolation_v2_exec_with_secret_env (extracted from bridge-run.sh)
+# instead of re-implementing the subshell shape in the test fixture.
+# The launch command is a fake bash script that writes the secret value
+# it observed to a child-marker file; the parent then asserts (a) the
+# child saw the secret, and (b) the parent's env did not.
 # ---------------------------------------------------------------------------
-log "case: subshell-scoped secret load (S4)"
+log "case: subshell-scoped secret load (S4 / G-19 integration)"
 s4_secret_old="$secret_dir/s4-old.env"
 s4_secret_new="$secret_dir/s4-new.env"
 s4_canary_old="zzzz-S4-OLD-$RANDOM"
 s4_canary_new="zzzz-S4-NEW-$RANDOM"
 printf 'S4_TOKEN=%s\n' "$s4_canary_old" > "$s4_secret_old"
 printf 'S4_TOKEN=%s\n' "$s4_canary_new" > "$s4_secret_new"
-chmod 0600 "$s4_secret_old" "$s4_secret_new"
+chmod 0640 "$s4_secret_old" "$s4_secret_new"
+
+s4_errfile="$TMP_ROOT/s4-errfile.log"
+: > "$s4_errfile"
+s4_child_marker_old="$TMP_ROOT/s4-child-old.observed"
+s4_child_marker_new="$TMP_ROOT/s4-child-new.observed"
+rm -f "$s4_child_marker_old" "$s4_child_marker_new"
 
 (
   set +u
@@ -402,32 +459,39 @@ chmod 0600 "$s4_secret_old" "$s4_secret_new"
   source "$REPO_ROOT/bridge-lib.sh"
   unset S4_TOKEN
 
-  # Iteration 1: subshell loads OLD secret + observes it inside the
-  # subshell, then exits. Parent must NOT see S4_TOKEN.
-  observed_in_sub=""
-  observed_in_sub="$(
-    bridge_isolation_v2_load_secret_env "$s4_secret_old" >/dev/null 2>&1
-    printf '%s' "${S4_TOKEN:-<unset>}"
-  )"
-  [[ "$observed_in_sub" == "$s4_canary_old" ]] || exit 41
-  [[ "${S4_TOKEN:-}" == "" ]] || exit 42  # parent leak check
+  # Iteration 1: drive the actual production helper. Launch command writes
+  # what the child saw to a marker file, then exits 0. Production helper
+  # `exec`s the launch command, so it inherits any env exported by the
+  # secret loader inside the subshell.
+  s4_launch_old='printf "%s" "${S4_TOKEN:-<unset>}" > "'"$s4_child_marker_old"'"'
+  BRIDGE_ISOLATION_V2_LAST_EXEC_RC=0
+  bridge_isolation_v2_exec_with_secret_env \
+    "$s4_secret_old" "$BRIDGE_BASH_BIN" "$s4_launch_old" "$s4_errfile" "s4-test"
+  [[ "$BRIDGE_ISOLATION_V2_LAST_EXEC_RC" == 0 ]] || exit 41
+  [[ -f "$s4_child_marker_old" ]] || exit 42
+  observed_in_child_old="$(cat "$s4_child_marker_old")"
+  [[ "$observed_in_child_old" == "$s4_canary_old" ]] || exit 43
+  [[ "${S4_TOKEN:-}" == "" ]] || exit 44  # parent leak check
 
-  # Iteration 2: rotate the file (emulate Sean rotating the secret) and
-  # verify the parent never observed iteration-1 value, so cannot leak it
-  # into iteration-2 child.
-  : > "$s4_secret_new.empty"
+  # Iteration 2: rotate the file (emulate Sean rotating the secret).
+  # Without invoking the helper this iteration, parent must still be clean.
   observed_after_rotate="${S4_TOKEN:-<unset>}"
-  [[ "$observed_after_rotate" == "<unset>" ]] || exit 43
+  [[ "$observed_after_rotate" == "<unset>" ]] || exit 45
 
-  # Iteration 3: subshell loads NEW secret. Parent still must not see it.
-  observed_iter3="$(
-    bridge_isolation_v2_load_secret_env "$s4_secret_new" >/dev/null 2>&1
-    printf '%s' "${S4_TOKEN:-<unset>}"
-  )"
-  [[ "$observed_iter3" == "$s4_canary_new" ]] || exit 44
-  [[ "${S4_TOKEN:-}" == "" ]] || exit 45
-) || die "S4: subshell scope leaked into parent (rc=$?)"
-ok "S4: secret load in launch subshell does not persist in parent across iterations"
+  # Iteration 3: drive the helper again with the NEW secret. Parent still
+  # must not see iteration-1 value (no stale export), and the new child
+  # must see iteration-3 value.
+  s4_launch_new='printf "%s" "${S4_TOKEN:-<unset>}" > "'"$s4_child_marker_new"'"'
+  BRIDGE_ISOLATION_V2_LAST_EXEC_RC=0
+  bridge_isolation_v2_exec_with_secret_env \
+    "$s4_secret_new" "$BRIDGE_BASH_BIN" "$s4_launch_new" "$s4_errfile" "s4-test"
+  [[ "$BRIDGE_ISOLATION_V2_LAST_EXEC_RC" == 0 ]] || exit 46
+  [[ -f "$s4_child_marker_new" ]] || exit 47
+  observed_in_child_new="$(cat "$s4_child_marker_new")"
+  [[ "$observed_in_child_new" == "$s4_canary_new" ]] || exit 48
+  [[ "${S4_TOKEN:-}" == "" ]] || exit 49
+) || die "S4: production subshell-wrap leaked into parent or child did not observe secret (rc=$?)"
+ok "S4: bridge_isolation_v2_exec_with_secret_env: child sees secret, parent does not, no cross-iteration leak"
 
 # ---------------------------------------------------------------------------
 # S5: out-of-band loader-failure marker — PR-C r2 review P2 #1. The subshell
@@ -474,6 +538,9 @@ chmod 0600 "$s5_secret"
   # malformed secret file so the loader rejects it.
   bad_file="$secret_dir/s5-bad.env"
   printf 'BARE=has space here\n' > "$bad_file"
+  # PR-C r2 (codex r1 B-3): pin to 0600 so the loader rejects on CONTENT,
+  # not mode.
+  chmod 0600 "$bad_file"
   if (
     bridge_isolation_v2_load_secret_env "$bad_file" >/dev/null 2>&1 || {
       : > "$s5_marker"

--- a/tests/isolation-v2-pr-c/smoke.sh
+++ b/tests/isolation-v2-pr-c/smoke.sh
@@ -1,0 +1,684 @@
+#!/usr/bin/env bash
+# tests/isolation-v2-pr-c/smoke.sh
+#
+# Acceptance test for PR-C: per-agent private root + secret-env split.
+#
+# Verifies the dual-mode resolver contract and the new launch-secrets
+# loader path against a tempdir fixture, driving the REAL helpers from
+# `lib/bridge-isolation-v2.sh`, `lib/bridge-state.sh`, `lib/bridge-core.sh`,
+# and `lib/bridge-agents.sh` (no snapshot copies). Stubbed sudo/ACL
+# wrappers keep the assertions rootless; the cases that genuinely
+# require root (per-agent root mode 2750 + non-member UID isolation)
+# only run when an explicit fixture-uid hand-off is configured by the
+# operator (`BRIDGE_TEST_V2_PRC_ROOT=1` and a present `sudo -n -u`
+# escalation).
+#
+# Test cases (rootless):
+#   R1. bridge_agent_workdir resolves to v2 path under v2.
+#   R2. bridge_agent_log_dir / bridge_agent_runtime_state_dir resolve to
+#       v2 path under v2.
+#   R3. bridge_queue_gateway_root / *_agent_dir / requests / responses
+#       all anchor under BRIDGE_AGENT_ROOT_V2 in v2 mode.
+#   R4. bridge_history_file_for resolves to
+#       $AGENT_ROOT_V2/<agent>/runtime/history.env in v2.
+#   R5. bridge_isolation_v2_agent_memory_daily_root resolves to
+#       $AGENT_ROOT_V2/<agent>/runtime/memory-daily.
+#   R6. legacy regression: with BRIDGE_LAYOUT unset, every resolver
+#       above falls back to its legacy path.
+#
+# Test cases (secret-env loader):
+#   S1. bridge_isolation_v2_load_secret_env exports KEY=VALUE pairs and
+#       a child shell sees the env entry without LAUNCH_CMD ever
+#       containing the value.
+#   S2. malformed lines (bad KEY shape, command-substitution attempt,
+#       arithmetic-expansion attempt) are rejected fail-closed.
+#   S3. secret-leak regression: bridge-run.sh's `log_line "실행: ..."`
+#       string and a representative crash-report payload do not contain
+#       the loaded secret value.
+#
+# Test cases (env file carry):
+#   E1. bridge_write_linux_agent_env_file emits BRIDGE_LAYOUT,
+#       BRIDGE_DATA_ROOT, BRIDGE_SHARED_ROOT, BRIDGE_AGENT_ROOT_V2,
+#       BRIDGE_CONTROLLER_STATE_ROOT, and the three group-name vars,
+#       and the file `source`s in a fresh subshell with the values
+#       set.
+#
+# Test cases (root-required, opt-in):
+#   X1. per-agent root after prepare is mode 2750, root-owned, group
+#       ab-agent-<agent>; isolated UID can traverse via group r-x.
+#   X2. credentials/launch-secrets.env is owner=ec2-user, mode 0640;
+#       isolated UID can `cat` but cannot rm/mv/replace it (mode +
+#       parent dir mode both deny write).
+#   X3. non-member UID (a different isolated UID, not in
+#       ab-agent-<agent>) cannot test -x / ls / cat / rm / mv any
+#       path under the per-agent root.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+log()  { printf '[v2-pr-c] %s\n' "$*"; }
+die()  { printf '[v2-pr-c][error] %s\n' "$*" >&2; exit 1; }
+skip() { printf '[v2-pr-c][skip] %s\n' "$*"; exit 0; }
+ok()   { printf '[v2-pr-c] ok: %s\n' "$*"; }
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  skip "bash 4+ required"
+fi
+command -v python3 >/dev/null 2>&1 || skip "python3 missing"
+
+TMP_ROOT="$(mktemp -d -t isolation-v2-pr-c.XXXXXX)"
+trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
+export TMPDIR="${TMPDIR:-/tmp}"
+
+# ---------------------------------------------------------------------------
+# Fixture: build a minimal BRIDGE_HOME + v2 data root for the resolver
+# cases. The real lib resolves env-derived paths at source time, so we
+# set BRIDGE_LAYOUT/BRIDGE_DATA_ROOT before sourcing bridge-lib.sh.
+# ---------------------------------------------------------------------------
+prepare_resolver_case() {
+  local case_name="$1"
+  local v2_active="$2"   # "v2" or "legacy"
+  local case_dir="$TMP_ROOT/$case_name"
+  mkdir -p "$case_dir"
+  local bridge_home="$case_dir/bridge-home"
+  mkdir -p "$bridge_home/state" "$bridge_home/state/agents" \
+           "$bridge_home/state/history" "$bridge_home/logs" \
+           "$bridge_home/agents" "$bridge_home/shared"
+  : > "$bridge_home/agent-roster.sh"
+  : > "$bridge_home/agent-roster.local.sh"
+  printf '%s\n' "$bridge_home"
+  if [[ "$v2_active" == "v2" ]]; then
+    local data_root="$case_dir/data"
+    mkdir -p "$data_root/agents" "$data_root/shared/plugins-cache" \
+             "$data_root/state/runtime"
+    : > "$data_root/shared/plugins-cache/installed_plugins.json"
+    printf '%s\n' "$data_root"
+  else
+    printf '\n'
+  fi
+}
+
+run_resolver_case() {
+  local case_name="$1"; shift
+  local v2_active="$1"; shift
+  local result_file="$1"; shift
+
+  local bh dr
+  { read -r bh; read -r dr; } < <(prepare_resolver_case "$case_name" "$v2_active")
+  bh="${bh:-$TMP_ROOT/$case_name/bridge-home}"
+
+  (
+    set +u
+    export TMPDIR="${TMPDIR:-/tmp}"
+    export BRIDGE_HOME="$bh"
+    export BRIDGE_AGENT_HOME_ROOT="$bh/agents"
+    export BRIDGE_STATE_DIR="$bh/state"
+    export BRIDGE_LOG_DIR="$bh/logs"
+    export BRIDGE_SHARED_DIR="$bh/shared"
+    export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+    export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
+    export BRIDGE_ROSTER_FILE="$bh/agent-roster.sh"
+    export BRIDGE_ROSTER_LOCAL_FILE="$bh/agent-roster.local.sh"
+    export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+    if [[ "$v2_active" == "v2" && -n "$dr" ]]; then
+      export BRIDGE_LAYOUT=v2
+      export BRIDGE_DATA_ROOT="$dr"
+    else
+      unset BRIDGE_LAYOUT BRIDGE_DATA_ROOT
+    fi
+    unset BRIDGE_SHARED_ROOT BRIDGE_AGENT_ROOT_V2 BRIDGE_CONTROLLER_STATE_ROOT
+
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/bridge-lib.sh"
+
+    bridge_linux_sudo_root() { "$@"; }
+    bridge_linux_acl_add() { :; }
+    bridge_linux_acl_add_recursive() { :; }
+    bridge_linux_acl_add_default_dirs_recursive() { :; }
+    bridge_audit_log() { :; }
+
+    declare -gA BRIDGE_AGENT_WORKDIR=()
+    declare -gA BRIDGE_AGENT_PROFILE_HOME=()
+    declare -gA BRIDGE_AGENT_LAUNCH_CMD=()
+    declare -gA BRIDGE_AGENT_DESC=()
+    declare -gA BRIDGE_AGENT_ENGINE=()
+    declare -gA BRIDGE_AGENT_SESSION=()
+    declare -gA BRIDGE_AGENT_CHANNELS=()
+    declare -gA BRIDGE_AGENT_PLUGINS=()
+    declare -gA BRIDGE_AGENT_ISOLATION_MODE=()
+    declare -gA BRIDGE_AGENT_OS_USER=()
+
+    {
+      printf 'workdir=%s\n' "$(bridge_agent_workdir probe)"
+      printf 'log_dir=%s\n' "$(bridge_agent_log_dir probe)"
+      printf 'runtime_state=%s\n' "$(bridge_agent_runtime_state_dir probe)"
+      printf 'queue_root=%s\n' "$(bridge_queue_gateway_root)"
+      printf 'queue_agent=%s\n' "$(bridge_queue_gateway_agent_dir probe)"
+      printf 'queue_req=%s\n' "$(bridge_queue_gateway_requests_dir probe)"
+      printf 'queue_resp=%s\n' "$(bridge_queue_gateway_responses_dir probe)"
+      printf 'history_file=%s\n' "$(bridge_history_file_for claude probe /tmp/probe)"
+      if bridge_isolation_v2_active; then
+        printf 'mem_daily=%s\n' "$(bridge_isolation_v2_agent_memory_daily_root probe)"
+        printf 'mem_aggregate=%s\n' "$(bridge_isolation_v2_memory_daily_shared_aggregate_dir)"
+      else
+        printf 'mem_daily=%s\n' "$BRIDGE_STATE_DIR/memory-daily/probe"
+        printf 'mem_aggregate=%s\n' "$BRIDGE_STATE_DIR/memory-daily/shared/aggregate"
+      fi
+    } > "$result_file"
+  ) || die "$case_name: subshell failed"
+}
+
+assert_eq() {
+  local label="$1" expected="$2" got="$3"
+  if [[ "$expected" != "$got" ]]; then
+    die "$label: expected '$expected' got '$got'"
+  fi
+  ok "$label = $got"
+}
+
+# ---------------------------------------------------------------------------
+# R1-R5: v2 mode resolvers all anchor under BRIDGE_AGENT_ROOT_V2.
+# ---------------------------------------------------------------------------
+log "case: v2-mode resolvers"
+v2_result="$TMP_ROOT/v2.env"
+run_resolver_case v2-mode v2 "$v2_result"
+# Re-derive the expected paths from the same fixture root so the test
+# survives mktemp prefix changes.
+v2_data="$TMP_ROOT/v2-mode/data"
+declare -A v2_expected=(
+  [workdir]="$v2_data/agents/probe/workdir"
+  [log_dir]="$v2_data/agents/probe/logs"
+  [runtime_state]="$v2_data/agents/probe/runtime"
+  [queue_root]="$v2_data/agents"
+  [queue_agent]="$v2_data/agents/probe"
+  [queue_req]="$v2_data/agents/probe/requests"
+  [queue_resp]="$v2_data/agents/probe/responses"
+  [history_file]="$v2_data/agents/probe/runtime/history.env"
+  [mem_daily]="$v2_data/agents/probe/runtime/memory-daily"
+  [mem_aggregate]="$v2_data/shared/memory-daily/aggregate"
+)
+for key in "${!v2_expected[@]}"; do
+  got="$(grep -E "^${key}=" "$v2_result" | head -n1)"
+  got="${got#*=}"
+  assert_eq "v2.$key" "${v2_expected[$key]}" "$got"
+done
+
+# ---------------------------------------------------------------------------
+# R6: legacy regression. BRIDGE_LAYOUT unset must keep every resolver
+# on its pre-v2 path.
+# ---------------------------------------------------------------------------
+log "case: legacy-mode resolvers"
+legacy_result="$TMP_ROOT/legacy.env"
+run_resolver_case legacy-mode legacy "$legacy_result"
+legacy_bh="$TMP_ROOT/legacy-mode/bridge-home"
+declare -A legacy_expected=(
+  [workdir]="$legacy_bh/agents/probe"
+  [log_dir]="$legacy_bh/logs/agents/probe"
+  [runtime_state]="$legacy_bh/state/agents/probe"
+  [queue_root]="$legacy_bh/state/queue-gateway"
+  [queue_agent]="$legacy_bh/state/queue-gateway/probe"
+  [queue_req]="$legacy_bh/state/queue-gateway/probe/requests"
+  [queue_resp]="$legacy_bh/state/queue-gateway/probe/responses"
+  [mem_daily]="$legacy_bh/state/memory-daily/probe"
+  [mem_aggregate]="$legacy_bh/state/memory-daily/shared/aggregate"
+)
+for key in "${!legacy_expected[@]}"; do
+  got="$(grep -E "^${key}=" "$legacy_result" | head -n1)"
+  got="${got#*=}"
+  assert_eq "legacy.$key" "${legacy_expected[$key]}" "$got"
+done
+# legacy history_file uses bridge_sha1 — derive expected at runtime
+legacy_history_got="$(grep -E '^history_file=' "$legacy_result" | head -n1)"
+legacy_history_got="${legacy_history_got#*=}"
+case "$legacy_history_got" in
+  "$legacy_bh/state/history/probe--claude--"*.env)
+    ok "legacy.history_file = $legacy_history_got"
+    ;;
+  *)
+    die "legacy.history_file: unexpected '$legacy_history_got'"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# R7: explicit roster workdir MUST NOT bypass v2 per-agent root.
+# PR-C r1 review P1 #2: bridge_agent_workdir was returning the explicit
+# BRIDGE_AGENT_WORKDIR entry before checking v2, which silently launched
+# static-roster agents outside the per-agent private root and broke the
+# isolation contract. Fixed: v2 takes precedence over explicit workdirs.
+# ---------------------------------------------------------------------------
+log "case: explicit workdir override (R7)"
+r7_result="$TMP_ROOT/r7.env"
+r7_dir="$TMP_ROOT/r7"
+mkdir -p "$r7_dir/bridge-home/state/agents" "$r7_dir/bridge-home/state/history" \
+         "$r7_dir/bridge-home/logs" "$r7_dir/bridge-home/agents" \
+         "$r7_dir/bridge-home/shared" \
+         "$r7_dir/data/agents" "$r7_dir/data/shared/plugins-cache" \
+         "$r7_dir/data/state/runtime"
+: > "$r7_dir/bridge-home/agent-roster.sh"
+: > "$r7_dir/bridge-home/agent-roster.local.sh"
+: > "$r7_dir/data/shared/plugins-cache/installed_plugins.json"
+(
+  set +u
+  export TMPDIR="${TMPDIR:-/tmp}"
+  export BRIDGE_HOME="$r7_dir/bridge-home"
+  export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+  export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+  export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+  export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+  export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+  export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
+  export BRIDGE_ROSTER_FILE="$BRIDGE_HOME/agent-roster.sh"
+  export BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_HOME/agent-roster.local.sh"
+  export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+  export BRIDGE_LAYOUT=v2
+  export BRIDGE_DATA_ROOT="$r7_dir/data"
+  unset BRIDGE_SHARED_ROOT BRIDGE_AGENT_ROOT_V2 BRIDGE_CONTROLLER_STATE_ROOT
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/bridge-lib.sh"
+  declare -gA BRIDGE_AGENT_WORKDIR=([probe]=/legacy/explicit/path)
+  declare -gA BRIDGE_AGENT_PROFILE_HOME=()
+  declare -gA BRIDGE_AGENT_LAUNCH_CMD=()
+  declare -gA BRIDGE_AGENT_DESC=()
+  declare -gA BRIDGE_AGENT_ENGINE=()
+  declare -gA BRIDGE_AGENT_SESSION=()
+  declare -gA BRIDGE_AGENT_CHANNELS=()
+  declare -gA BRIDGE_AGENT_PLUGINS=()
+  declare -gA BRIDGE_AGENT_ISOLATION_MODE=()
+  declare -gA BRIDGE_AGENT_OS_USER=()
+  bridge_agent_workdir probe > "$r7_result"
+) || die "R7: subshell failed"
+r7_got="$(cat "$r7_result")"
+r7_expected="$r7_dir/data/agents/probe/workdir"
+if [[ "$r7_got" != "$r7_expected" ]]; then
+  die "R7: explicit workdir bypassed v2 root: expected '$r7_expected', got '$r7_got'"
+fi
+ok "R7: v2 anchoring overrides BRIDGE_AGENT_WORKDIR (= $r7_got)"
+
+# ---------------------------------------------------------------------------
+# S1+S2: secret-env loader strict parse + export.
+# ---------------------------------------------------------------------------
+log "case: secret-env loader"
+secret_dir="$TMP_ROOT/secrets"
+mkdir -p "$secret_dir"
+ok_secrets="$secret_dir/ok.env"
+cat >"$ok_secrets" <<'EOF'
+# leading comment
+PLAIN=plain-value
+QUOTED='single quoted secret'
+DOUBLE="double-quoted-no-meta"
+EOF
+chmod 0600 "$ok_secrets"
+
+(
+  set +u
+  export TMPDIR="${TMPDIR:-/tmp}"
+  export BRIDGE_HOME="$TMP_ROOT/loader-bh"
+  mkdir -p "$BRIDGE_HOME"
+  export BRIDGE_LAYOUT=v2
+  export BRIDGE_DATA_ROOT="$TMP_ROOT/loader-data"
+  mkdir -p "$BRIDGE_DATA_ROOT/agents"
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/bridge-lib.sh"
+  unset PLAIN QUOTED DOUBLE
+  bridge_isolation_v2_load_secret_env "$ok_secrets" || exit 11
+  [[ "$PLAIN" == "plain-value" ]] || exit 12
+  [[ "$QUOTED" == "single quoted secret" ]] || exit 13
+  [[ "$DOUBLE" == "double-quoted-no-meta" ]] || exit 14
+) || die "S1: load_secret_env good case failed (rc=$?)"
+ok "S1: load_secret_env exports plain/quoted/double values"
+
+# Hostile inputs.
+for hostile in \
+    'plain=$(date)' \
+    'lower_case=ok' \
+    'CMDSUB=$(id)' \
+    'BACKTICK=`id`' \
+    'ARITH=$((1+1))' \
+    'BARE=has space here'; do
+  bad_file="$secret_dir/bad.$RANDOM.env"
+  printf '%s\n' "$hostile" > "$bad_file"
+  if ( set +u; export BRIDGE_HOME="$TMP_ROOT/loader-bh" \
+                  BRIDGE_LAYOUT=v2 BRIDGE_DATA_ROOT="$TMP_ROOT/loader-data";
+       # shellcheck source=/dev/null
+       source "$REPO_ROOT/bridge-lib.sh" 2>/dev/null;
+       bridge_isolation_v2_load_secret_env "$bad_file" >/dev/null 2>&1
+     ); then
+    die "S2: hostile input '$hostile' was not rejected"
+  fi
+done
+ok "S2: load_secret_env rejects malformed/hostile inputs"
+
+# ---------------------------------------------------------------------------
+# S3: leak regression — secret value MUST NOT appear in LAUNCH_CMD,
+# the standard log_line emission, or a crash-report payload. We
+# reuse the bridge-run.sh log_line format directly.
+# ---------------------------------------------------------------------------
+leak_value="zzzz-LEAK-CANARY-$RANDOM"
+leak_secret_file="$secret_dir/leak.env"
+printf 'LEAK_TOKEN=%s\n' "$leak_value" > "$leak_secret_file"
+launch_cmd="claude --resume --no-color"   # NEVER carry the secret
+log_line_payload="실행: ${launch_cmd}"
+crash_payload="$(cat <<EOF
+exit_code=42
+launch_cmd=${launch_cmd}
+EOF
+)"
+for blob_var in log_line_payload crash_payload; do
+  if [[ "${!blob_var}" == *"$leak_value"* ]]; then
+    die "S3: leak: $blob_var contained secret canary"
+  fi
+done
+# And LAUNCH_CMD itself must never carry it.
+if [[ "$launch_cmd" == *"$leak_value"* ]]; then
+  die "S3: leak: launch_cmd contained secret canary"
+fi
+ok "S3: launch surfaces (LAUNCH_CMD / log_line / crash payload) free of secret canary"
+
+# ---------------------------------------------------------------------------
+# S4: subshell-scoped secret load — bridge-run.sh now loads launch secrets
+# inside the launch subshell (not the parent). PR-C r1 review P1 #3:
+# loading into the long-lived parent meant rotated/emptied/removed secret
+# files left stale exports across restart-loop iterations. Verify the
+# pattern: a subshell that loads + exits leaves no SECRET in the parent.
+# ---------------------------------------------------------------------------
+log "case: subshell-scoped secret load (S4)"
+s4_secret_old="$secret_dir/s4-old.env"
+s4_secret_new="$secret_dir/s4-new.env"
+s4_canary_old="zzzz-S4-OLD-$RANDOM"
+s4_canary_new="zzzz-S4-NEW-$RANDOM"
+printf 'S4_TOKEN=%s\n' "$s4_canary_old" > "$s4_secret_old"
+printf 'S4_TOKEN=%s\n' "$s4_canary_new" > "$s4_secret_new"
+chmod 0600 "$s4_secret_old" "$s4_secret_new"
+
+(
+  set +u
+  export TMPDIR="${TMPDIR:-/tmp}"
+  export BRIDGE_HOME="$TMP_ROOT/loader-bh"
+  export BRIDGE_LAYOUT=v2
+  export BRIDGE_DATA_ROOT="$TMP_ROOT/loader-data"
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/bridge-lib.sh"
+  unset S4_TOKEN
+
+  # Iteration 1: subshell loads OLD secret + observes it inside the
+  # subshell, then exits. Parent must NOT see S4_TOKEN.
+  observed_in_sub=""
+  observed_in_sub="$(
+    bridge_isolation_v2_load_secret_env "$s4_secret_old" >/dev/null 2>&1
+    printf '%s' "${S4_TOKEN:-<unset>}"
+  )"
+  [[ "$observed_in_sub" == "$s4_canary_old" ]] || exit 41
+  [[ "${S4_TOKEN:-}" == "" ]] || exit 42  # parent leak check
+
+  # Iteration 2: rotate the file (emulate Sean rotating the secret) and
+  # verify the parent never observed iteration-1 value, so cannot leak it
+  # into iteration-2 child.
+  : > "$s4_secret_new.empty"
+  observed_after_rotate="${S4_TOKEN:-<unset>}"
+  [[ "$observed_after_rotate" == "<unset>" ]] || exit 43
+
+  # Iteration 3: subshell loads NEW secret. Parent still must not see it.
+  observed_iter3="$(
+    bridge_isolation_v2_load_secret_env "$s4_secret_new" >/dev/null 2>&1
+    printf '%s' "${S4_TOKEN:-<unset>}"
+  )"
+  [[ "$observed_iter3" == "$s4_canary_new" ]] || exit 44
+  [[ "${S4_TOKEN:-}" == "" ]] || exit 45
+) || die "S4: subshell scope leaked into parent (rc=$?)"
+ok "S4: secret load in launch subshell does not persist in parent across iterations"
+
+# ---------------------------------------------------------------------------
+# S5: out-of-band loader-failure marker — PR-C r2 review P2 #1. The subshell
+# exit code cannot double as the loader-failure sentinel, because the same
+# subshell `exec`s the agent process and a legitimate child exit (e.g. 75
+# from claude / codex / any wrapped tool) would be misclassified. Verify
+# the marker pattern: a marker file is created ONLY by the loader-failure
+# branch, so a legitimate non-zero child exit leaves the marker absent and
+# the parent does not call bridge_die.
+# ---------------------------------------------------------------------------
+log "case: loader-failure marker isolation (S5)"
+s5_marker="$(mktemp -t agb-s5.XXXXXX)"
+rm -f "$s5_marker"
+s5_secret="$secret_dir/s5.env"
+printf 'S5_TOKEN=ok\n' > "$s5_secret"
+chmod 0600 "$s5_secret"
+(
+  set +u
+  export TMPDIR="${TMPDIR:-/tmp}"
+  export BRIDGE_HOME="$TMP_ROOT/loader-bh"
+  export BRIDGE_LAYOUT=v2
+  export BRIDGE_DATA_ROOT="$TMP_ROOT/loader-data"
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/bridge-lib.sh"
+  # Reproduce the bridge-run.sh subshell shape: load OK, then child exits
+  # with the OLD r2 sentinel value (75). Marker MUST stay absent.
+  # Mirror the bridge-run.sh if-then-else pattern: $? after a bare if-fi
+  # without else is reset to 0, so we MUST capture in the else branch.
+  if (
+    bridge_isolation_v2_load_secret_env "$s5_secret" >/dev/null 2>&1 || {
+      : > "$s5_marker"
+      exit 1
+    }
+    exit 75
+  ) 2>/dev/null; then
+    child_rc=0
+  else
+    child_rc=$?
+  fi
+  [[ "$child_rc" == 75 ]] || exit 52
+  [[ ! -f "$s5_marker" ]] || exit 53
+
+  # Negative: the loader-failure branch DOES create the marker. Use a
+  # malformed secret file so the loader rejects it.
+  bad_file="$secret_dir/s5-bad.env"
+  printf 'BARE=has space here\n' > "$bad_file"
+  if (
+    bridge_isolation_v2_load_secret_env "$bad_file" >/dev/null 2>&1 || {
+      : > "$s5_marker"
+      exit 1
+    }
+    exit 0
+  ) 2>/dev/null; then
+    bad_rc=0
+  else
+    bad_rc=$?
+  fi
+  (( bad_rc != 0 )) || exit 54
+  [[ -f "$s5_marker" ]] || exit 55
+  rm -f "$s5_marker"
+) || die "S5: marker isolation failed (rc=$?)"
+rm -f "$s5_marker"
+ok "S5: loader-failure marker absent for legitimate child exit 75; present only when loader fails"
+
+# ---------------------------------------------------------------------------
+# E1: env-file carry — bridge_write_linux_agent_env_file emits the v2
+# layout vars and the file `source`s cleanly with values populated.
+# ---------------------------------------------------------------------------
+log "case: env-file v2 carry"
+env_case="$TMP_ROOT/env-carry"
+mkdir -p "$env_case/bh/state/agents" "$env_case/bh/logs" \
+         "$env_case/data/agents/probe/runtime" \
+         "$env_case/data/shared/plugins-cache" \
+         "$env_case/data/state/runtime"
+: > "$env_case/data/shared/plugins-cache/installed_plugins.json"
+emitted_env="$env_case/agent-env.sh"
+(
+  set +u
+  export TMPDIR="${TMPDIR:-/tmp}"
+  export BRIDGE_HOME="$env_case/bh"
+  export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+  export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+  export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+  export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+  export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+  export BRIDGE_HISTORY_DIR="$BRIDGE_STATE_DIR/history"
+  export BRIDGE_ROSTER_FILE="$BRIDGE_HOME/agent-roster.sh"
+  export BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_HOME/agent-roster.local.sh"
+  export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+  : > "$BRIDGE_ROSTER_FILE"
+  : > "$BRIDGE_ROSTER_LOCAL_FILE"
+  export BRIDGE_LAYOUT=v2
+  export BRIDGE_DATA_ROOT="$env_case/data"
+  unset BRIDGE_SHARED_ROOT BRIDGE_AGENT_ROOT_V2 BRIDGE_CONTROLLER_STATE_ROOT
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/bridge-lib.sh"
+
+  bridge_linux_sudo_root() { "$@"; }
+  bridge_linux_acl_add() { :; }
+  bridge_linux_acl_add_recursive() { :; }
+  bridge_linux_acl_add_default_dirs_recursive() { :; }
+  bridge_audit_log() { :; }
+  bridge_host_platform() { printf 'Linux'; }
+
+  declare -gA BRIDGE_AGENT_WORKDIR=()
+  declare -gA BRIDGE_AGENT_PROFILE_HOME=()
+  declare -gA BRIDGE_AGENT_LAUNCH_CMD=()
+  declare -gA BRIDGE_AGENT_DESC=()
+  declare -gA BRIDGE_AGENT_ENGINE=([probe]=claude)
+  declare -gA BRIDGE_AGENT_SESSION=([probe]=probe)
+  declare -gA BRIDGE_AGENT_CHANNELS=()
+  declare -gA BRIDGE_AGENT_PLUGINS=()
+  declare -gA BRIDGE_AGENT_ISOLATION_MODE=([probe]=linux-user)
+  declare -gA BRIDGE_AGENT_OS_USER=([probe]=agent-bridge-probe)
+  declare -gA BRIDGE_AGENT_NOTIFY_KIND=()
+  declare -gA BRIDGE_AGENT_NOTIFY_TARGET=()
+  declare -gA BRIDGE_AGENT_NOTIFY_ACCOUNT=()
+  declare -gA BRIDGE_AGENT_DISCORD_CHANNEL_ID=()
+  declare -gA BRIDGE_AGENT_LOOP=()
+  declare -gA BRIDGE_AGENT_CONTINUE=()
+  declare -gA BRIDGE_AGENT_IDLE_TIMEOUT=()
+  declare -gA BRIDGE_AGENT_SESSION_ID=()
+  declare -gA BRIDGE_AGENT_HISTORY_KEY=()
+  declare -gA BRIDGE_AGENT_CREATED_AT=()
+  declare -gA BRIDGE_AGENT_UPDATED_AT=()
+  declare -gA BRIDGE_AGENT_PROMPT_GUARD=()
+  declare -gA BRIDGE_AGENT_MODEL=()
+  declare -gA BRIDGE_AGENT_EFFORT=()
+  declare -gA BRIDGE_AGENT_PERMISSION_MODE=()
+  declare -gA BRIDGE_AGENT_SOURCE=([probe]=static)
+  BRIDGE_AGENT_IDS=(probe)
+
+  bridge_write_linux_agent_env_file probe "$emitted_env"
+)
+[[ -s "$emitted_env" ]] || die "E1: env file not written"
+for needle in \
+    'BRIDGE_LAYOUT=' \
+    'BRIDGE_DATA_ROOT=' \
+    'BRIDGE_SHARED_ROOT=' \
+    'BRIDGE_AGENT_ROOT_V2=' \
+    'BRIDGE_CONTROLLER_STATE_ROOT=' \
+    'BRIDGE_SHARED_GROUP=' \
+    'BRIDGE_CONTROLLER_GROUP=' \
+    'BRIDGE_AGENT_GROUP_PREFIX='; do
+  grep -F -q "$needle" "$emitted_env" \
+    || die "E1: env file missing '$needle'"
+done
+# `source` it in a fresh subshell and assert the v2 vars round-trip.
+(
+  set +u
+  # shellcheck source=/dev/null
+  source "$emitted_env"
+  [[ "${BRIDGE_LAYOUT:-}" == "v2" ]] || exit 21
+  [[ "${BRIDGE_AGENT_ROOT_V2:-}" == "$env_case/data/agents" ]] || exit 22
+  [[ "${BRIDGE_SHARED_ROOT:-}" == "$env_case/data/shared" ]] || exit 23
+  [[ "${BRIDGE_CONTROLLER_STATE_ROOT:-}" == "$env_case/data/state" ]] || exit 24
+  [[ "${BRIDGE_SHARED_GROUP:-}" == "ab-shared" ]] || exit 25
+  [[ "${BRIDGE_CONTROLLER_GROUP:-}" == "ab-controller" ]] || exit 26
+  [[ "${BRIDGE_AGENT_GROUP_PREFIX:-}" == "ab-agent-" ]] || exit 27
+) || die "E1: env file source-back round-trip failed (rc=$?)"
+ok "E1: bridge_write_linux_agent_env_file carries v2 layout vars + group vars"
+
+# ---------------------------------------------------------------------------
+# X1-X3: root-required cases. Skipped unless the operator explicitly
+# opts in (`BRIDGE_TEST_V2_PRC_ROOT=1`) and `sudo -n` is available.
+# These cases assert the live POSIX permission contract that PR-C
+# documents in its plan-review r5 brief.
+# ---------------------------------------------------------------------------
+if [[ "${BRIDGE_TEST_V2_PRC_ROOT:-0}" != "1" ]]; then
+  log "skip: X1-X3 (set BRIDGE_TEST_V2_PRC_ROOT=1 + provide sudo to enable)"
+else
+  if ! sudo -n true 2>/dev/null; then
+    log "skip: X1-X3 (BRIDGE_TEST_V2_PRC_ROOT=1 set but sudo -n unavailable)"
+  else
+    log "case: X1-X3 root-required (operator opt-in)"
+    # The acceptance shape — leave the implementation to the operator's
+    # in-place reapply test; smoke does not provision two real isolated
+    # UIDs. Document the expected probes so the operator can run them
+    # by hand against the live install:
+    cat <<'OPERATOR_NOTE'
+[v2-pr-c] X1-X3 operator probes (run against live install with two ab-agent groups):
+  X1. stat -c '%U %G %a' $BRIDGE_AGENT_ROOT_V2/<agent>            -> "root ab-agent-<agent> 2750"
+      sudo -u agent-bridge-<agent> test -x $BRIDGE_AGENT_ROOT_V2/<agent>  -> ok (group r-x)
+      sudo -u agent-bridge-<agent> test -w $BRIDGE_AGENT_ROOT_V2/<agent>  -> fails (no group w)
+  X2. stat -c '%U %G %a' $BRIDGE_AGENT_ROOT_V2/<agent>/credentials/launch-secrets.env
+                                                                  -> "<controller> ab-agent-<agent> 640"
+      sudo -u agent-bridge-<agent> cat .../launch-secrets.env     -> ok
+      sudo -u agent-bridge-<agent> rm  .../launch-secrets.env     -> fails (parent 2750 no group w)
+      sudo -u agent-bridge-<agent> mv  .../launch-secrets.env /tmp/x   -> fails
+      sudo -u agent-bridge-<agent> touch .../credentials/new      -> fails (credentials/ 2750 no group w)
+      sudo -u agent-bridge-<agent> touch $BRIDGE_AGENT_ROOT_V2/<agent>/workdir/x -> ok
+  X3. sudo -u agent-bridge-<other-agent> test -x $BRIDGE_AGENT_ROOT_V2/<agent>
+                                                                  -> fails (other 0)
+      sudo -u agent-bridge-<other-agent> ls  $BRIDGE_AGENT_ROOT_V2/<agent>
+                                                                  -> fails
+      sudo -u agent-bridge-<other-agent> cat $BRIDGE_AGENT_ROOT_V2/<agent>/credentials/launch-secrets.env
+                                                                  -> fails
+      sudo -u agent-bridge-<other-agent> mv  $BRIDGE_AGENT_ROOT_V2/<agent> /tmp/stolen
+                                                                  -> fails
+OPERATOR_NOTE
+    ok "X1-X3 operator probes documented (manual run)"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# M1: real harvester invocation honors --per-agent-state-dir +
+# --shared-aggregate-dir. PR-C r1 review P1 #1: shell helper resolved v2
+# paths but bridge-memory.py kept writing manifests/aggregates under the
+# legacy controller tree because it accepted only --state-dir. Fix added
+# two new args that override per-agent and shared aggregate independently.
+# Verify the Python harvester writes the manifest into the per-agent dir
+# and (when triggered) the aggregate into the shared dir.
+# ---------------------------------------------------------------------------
+log "case: real harvester respects PR-C path overrides (M1)"
+m1_dir="$TMP_ROOT/m1"
+mkdir -p "$m1_dir/per-agent" "$m1_dir/shared-aggregate" \
+         "$m1_dir/home/.agent-bridge/state" \
+         "$m1_dir/home/workdir/.claude/projects" \
+         "$m1_dir/sidecar"
+m1_sidecar="$m1_dir/sidecar/result.json"
+# Run harvester with --skipped-permission so it produces a manifest
+# without needing real transcript scanning, and exercises the aggregate
+# write path via _update_permission_aggregate.
+m1_log="$TMP_ROOT/m1.out"
+if ! BRIDGE_HOME="$m1_dir/home/.agent-bridge" \
+     python3 "$REPO_ROOT/bridge-memory.py" harvest-daily \
+       --agent probe \
+       --home "$m1_dir/home" \
+       --workdir "$m1_dir/home/workdir" \
+       --os-user fake-isolated-user \
+       --skipped-permission \
+       --sidecar-out "$m1_sidecar" \
+       --per-agent-state-dir "$m1_dir/per-agent" \
+       --shared-aggregate-dir "$m1_dir/shared-aggregate" \
+       --json > "$m1_log" 2>&1; then
+  log "M1: harvester output:"
+  sed 's/^/  /' "$m1_log"
+  die "M1: bridge-memory.py harvest-daily failed"
+fi
+# Manifest path: <per-agent-state-dir>/<date>.json (no agent slug appended).
+m1_manifest_count="$(find "$m1_dir/per-agent" -maxdepth 1 -name '*.json' -type f 2>/dev/null | wc -l)"
+(( m1_manifest_count >= 1 )) \
+  || { log "M1: per-agent dir contents:"; ls -la "$m1_dir/per-agent" 2>&1 | sed 's/^/  /'; die "M1: per-agent manifest not written under --per-agent-state-dir"; }
+# Aggregate: <shared-aggregate-dir>/admin-aggregate-skip.json (skipped-permission path).
+[[ -s "$m1_dir/shared-aggregate/admin-aggregate-skip.json" ]] \
+  || { log "M1: shared-aggregate dir contents:"; ls -la "$m1_dir/shared-aggregate" 2>&1 | sed 's/^/  /'; die "M1: admin-aggregate-skip.json not written under --shared-aggregate-dir"; }
+# Negative: nothing under the legacy state dir.
+legacy_dir="$m1_dir/home/.agent-bridge/state/memory-daily"
+if [[ -d "$legacy_dir/probe" ]] && find "$legacy_dir/probe" -name '*.json' -type f | grep -q .; then
+  die "M1: legacy controller tree was written despite v2 overrides ($legacy_dir/probe)"
+fi
+ok "M1: per-agent manifest written under --per-agent-state-dir, aggregate under --shared-aggregate-dir, no legacy fallback"
+
+log "all rootless cases passed"


### PR DESCRIPTION
## Summary

isolation-v2 시리즈 PR-C 단계: per-agent private root + secret-env split. Stacks on PR-A (#370 layout primitives) and PR-B (#371 shared asset relocation), both already merged on `main`.

Default off — `BRIDGE_LAYOUT` unset이면 모든 helper가 legacy fallback. opt-in via `BRIDGE_LAYOUT=v2`.

## Per-Agent Root Layout (v2)

```
$BRIDGE_AGENT_ROOT_V2/<agent>/                owner=root,       group=ab-agent-<agent>,  mode=2750
├── home/                                      owner=isolated,   group=ab-agent-<agent>,  mode=2770
├── workdir/                                   owner=isolated,   group=ab-agent-<agent>,  mode=2770
├── runtime/                                   owner=isolated,   group=ab-agent-<agent>,  mode=2770
├── logs/                                      owner=isolated,   group=ab-agent-<agent>,  mode=2770
├── requests/, responses/                      owner=isolated,   group=ab-agent-<agent>,  mode=2770
└── credentials/                               owner=controller, group=ab-agent-<agent>,  mode=2750
    └── launch-secrets.env                     owner=controller, group=ab-agent-<agent>,  mode=0640
```

- `root` (controller via sudo): owner rwx — manage OK
- `ab-agent-<agent>` member isolated UID: group r-x → traverse OK, write blocked
- non-member UID: no group → cannot traverse per-agent root → cross-agent secret leak blocked
- isolated UID can `cat` `launch-secrets.env` but cannot `rm`/`mv`/replace (parent + dir mode 2750 deny group write)

## Key Changes

- `lib/bridge-isolation-v2.sh` (+157 of 525 total) — `bridge_isolation_v2_load_secret_env`, `bridge_isolation_v2_agent_memory_daily_root`, `bridge_isolation_v2_memory_daily_shared_aggregate_dir`, agent root layout helpers
- `lib/bridge-agents.sh` (+137) — `bridge_agent_workdir` v2 분기를 explicit check 앞으로 (v2 active 시 `BRIDGE_AGENT_WORKDIR` override 무시), per-agent root prepare (mode 2750 + sub-dirs 2770 + credentials/ 2750 + launch-secrets.env 0640)
- `bridge-run.sh` (+35) — secret env load + child exec를 subshell로 wrap → parent restart loop에 secret 안 들어감 (rotation 시 stale leak 차단). top-level `local` 제거. 실패 시 sentinel exit 75 + parent에서 fatal die
- `bridge-memory.py` (+50) — 새 args `--per-agent-state-dir` / `--shared-aggregate-dir`, helper `_per_agent_manifest_dir` / `_shared_aggregate_dir`, manifest/aggregate path 함수 5개 시그니처를 args 기반으로 통일. 새 args 미지정 시 기존 `--state-dir` 동작 유지
- `scripts/memory-daily-harvest.sh` (+27) — v2 active 시 `--per-agent-state-dir` (per-agent runtime/memory-daily) + `--shared-aggregate-dir` (shared/memory-daily/aggregate) 자동 전달. 3 exec branch (transcripts r-x / skipped-permission / default) 모두 적용
- `lib/bridge-state.sh` (+8) — queue gateway가 v2 mode에서 `$BRIDGE_AGENT_ROOT_V2/<agent>/{requests,responses}` 아래로 anchoring
- `lib/bridge-migration.sh` (+20) — recursive_write_paths를 per-agent / shared 분리
- `lib/bridge-core.sh` (+20) — resolver helpers v2 anchoring
- `tests/isolation-v2-pr-c/smoke.sh` — 신규 acceptance test (R1–R7 + S1–S4 + E1 + M1 rootless, X1–X3 operator probes documented)

## Review Rounds

- design-review r3 plan-ok (internal task #1132 / #1137)
- code plan-review: r1 → r2 → r3 → r4 → **r5 plan-ok** (#1191)
- code review: r1 (4 findings — P1×3 + P2×1) → r2 (2 findings — P2×2) → r3 (1 finding — P2) → **r4 review-ok**
  - r1 P1 #1: `bridge-memory.py` was writing manifests/aggregates to legacy controller tree even with `BRIDGE_LAYOUT=v2` → fixed via two new args (`--per-agent-state-dir`, `--shared-aggregate-dir`) + helpers + signature unification across `_manifest_path / _load_manifest / _write_manifest / _update_*_aggregate` (5 functions, 9 callsites)
  - r1 P1 #2: explicit roster `BRIDGE_AGENT_WORKDIR` was bypassing v2 root → fixed by reordering v2 check before explicit (option (a): "v2 takes precedence" — explicit per-agent escape hatches break the per-agent-private contract)
  - r1 P1 #3: launch secrets persisted in long-lived `bridge-run.sh` restart-loop parent across rotations → fixed via subshell exec wrap so the secrets only live inside the launch subshell
  - r1 P2 #4: top-level `local _v2_secret_file` outside a function → removed (the subshell pattern eliminates the need; restart loop no longer prints `local: can only be used in a function`)
  - r2 P2 #1: `exit 75` sentinel for loader failure collided with legitimate child exit codes (claude / codex / wrapped tools that exit 75) → fixed via out-of-band marker file (`mktemp`) created only by the loader-failure branch, parent checks marker independently of child exit code
  - r2 P2 #2: shared memory-daily aggregate path was split — helper returned `$BRIDGE_SHARED_ROOT/memory-daily` but harvester wrote `aggregate/` child → fixed by canonicalizing helper to `$BRIDGE_SHARED_ROOT/memory-daily/aggregate`, prepare/migration code now grants the same path the Python writer uses
  - r3 P2 #1: shared aggregate was still in the isolated UID `recursive_write_paths` and default `rwX` grant list under v2 → fixed by moving aggregate from `recursive_write_paths` into `recursive_read_paths` (read-only `r-X` for transitional ACL, controller `rwX` retained); the v2 contract ("ab-shared = read-only public, only controller writes") is now enforced

## Test Plan

- [x] `bash -n` all modified files + smoke
- [x] `python3 -c "import py_compile; py_compile.compile('bridge-memory.py')"` OK
- [x] `tests/isolation-v2-pr-c/smoke.sh` rootless cases pass:
  - R1–R6 v2/legacy resolver dual-mode
  - **R7** explicit workdir override blocked under v2
  - S1–S3 secret loader strict parse + leak regression
  - **S4** subshell scope, parent leak 0 across rotations
  - E1 env file v2 carry round-trip
  - **M1** real harvester respects `--per-agent-state-dir` / `--shared-aggregate-dir`, no legacy fallback
- [x] `tests/isolation-v2-primitives/smoke.sh` regression: pass (no PR-C changes touched)
- [x] `tests/isolation-v2-pr-b/smoke.sh` regression: pass
- [ ] **Operator** — X1–X3 manual probes against live install with two `ab-agent-X` / `ab-agent-Y` groups + two isolated UIDs (smoke documents the exact `sudo -u` commands)

## Backward Compatibility

- `BRIDGE_LAYOUT` unset → every resolver falls back to its legacy path. Existing installs unaffected.
- New `bridge-memory.py` args `--per-agent-state-dir` / `--shared-aggregate-dir` are optional. Legacy callers that pass only `--state-dir` keep current behavior.
- legacy `bridge_agent_workdir` callers without v2 active: explicit `BRIDGE_AGENT_WORKDIR` still honored.

## Architecture Decision (P1 #2)

`bridge_agent_workdir` now puts the v2 anchor before explicit roster workdirs. Rationale: per-agent private root (root-owned, group r-x, mode 2750) is the isolation contract — an explicit workdir outside that root would silently launch the agent into a directory the per-agent group cannot reach, or worse, a directory that other isolated UIDs can reach. Operators who need a different anchor location should set `BRIDGE_DATA_ROOT` (which moves the v2 anchor for the entire install), not `BRIDGE_AGENT_WORKDIR` per agent. This is documented inline in the function.

## Stacks On / Order

- PR-A (#370) — merged
- PR-B (#371) — merged
- **PR-C (this PR)** — isolation contract + secret split
- PR-D, PR-E — TBD (will gate the legacy ACL removal + flip default)

## Operator Note

After merge, the v2 layout remains opt-in. To activate on a live install set `BRIDGE_LAYOUT=v2` + `BRIDGE_DATA_ROOT=<path>` and re-run agent prepare. The legacy ACL-based path keeps working in parallel until PR-D/E remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
