### PR TITLE
upgrade: pre-flight clean-source check on tag/release/* targets (#380)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -25,6 +25,7 @@ RESTART_AGENTS=1
 RESTART_AGENTS_EXPLICIT=0
 JSON=0
 ALLOW_DIRTY=0
+ALLOW_DIRTY_SOURCE=0
 STRICT_MERGE=0
 BACKUP=1
 MIGRATE_AGENTS=1
@@ -40,7 +41,7 @@ SOURCE_HEAD=""
 usage() {
   cat <<EOF
 Usage:
-  $(basename "$0") [--source <repo-dir>] [--target <bridge-home>] [--check] [--channel stable|dev|current] [--version <semver>] [--ref <git-ref>] [--pull|--no-pull] [--restart-daemon|--no-restart-daemon] [--restart-agents|--no-restart-agents] [--dry-run] [--json] [--allow-dirty] [--strict-merge] [--no-backup] [--no-migrate-agents]
+  $(basename "$0") [--source <repo-dir>] [--target <bridge-home>] [--check] [--channel stable|dev|current] [--version <semver>] [--ref <git-ref>] [--pull|--no-pull] [--restart-daemon|--no-restart-daemon] [--restart-agents|--no-restart-agents] [--dry-run] [--json] [--allow-dirty] [--allow-dirty-source] [--strict-merge] [--no-backup] [--no-migrate-agents]
   $(basename "$0") analyze [--source <repo-dir>] [--target <bridge-home>] [--json]
   $(basename "$0") rollback [--target <bridge-home>] [--backup-root <dir>] [--restart-daemon|--no-restart-daemon] [--restart-agents|--no-restart-agents] [--dry-run] [--json]
 
@@ -615,6 +616,10 @@ while [[ $# -gt 0 ]]; do
       ALLOW_DIRTY=1
       shift
       ;;
+    --allow-dirty-source)
+      ALLOW_DIRTY_SOURCE=1
+      shift
+      ;;
     --strict-merge)
       STRICT_MERGE=1
       shift
@@ -820,6 +825,37 @@ PY
       echo "update_available: $([[ $UPDATE_AVAILABLE -eq 1 ]] && printf yes || printf no)"
     fi
     exit 0
+  fi
+
+  # Pre-flight: when the target ref is a tag (v*) or a release/* branch, the
+  # operator's expectation (per --check / --dry-run output `target_ref: vX.Y.Z`)
+  # is that the tag's content drives the merge. The merge resolution actually
+  # uses the source checkout's working tree, so any uncommitted edits or a
+  # non-release feature branch get silently folded in. Refuse to proceed for
+  # release-style targets when the source is dirty so dry-run/apply produce
+  # the same surprise-free abort. Fires for both dry-run and apply (issue #380).
+  if [[ -n "$TARGET_REF" ]] \
+    && [[ "$TARGET_REF" =~ ^v[0-9] || "$TARGET_REF" == release/* ]] \
+    && [[ $ALLOW_DIRTY_SOURCE -eq 0 && $ALLOW_DIRTY -eq 0 ]]; then
+    if [[ -n "$(git -C "$SOURCE_ROOT" status --porcelain)" ]]; then
+      cat >&2 <<EOF
+error: source checkout at $SOURCE_ROOT has uncommitted changes (or is on a non-release branch).
+The current behavior would fold those changes into the merge source, producing
+surprise conflicts on core files even though the $TARGET_REF release ref is clean.
+
+Resolve one of:
+  1. Commit or stash your changes:
+       (cd $SOURCE_ROOT && git stash push -u)
+     ... then re-run \`agent-bridge upgrade --apply\`. After the upgrade:
+       (cd $SOURCE_ROOT && git stash pop)
+  2. Point AGENT_BRIDGE_SOURCE_DIR at a clean checkout:
+       AGENT_BRIDGE_SOURCE_DIR=/path/to/clean/checkout agent-bridge upgrade --apply
+  3. If you genuinely want to fold the working-tree changes in (uncommon —
+     usually only maintainers testing a release candidate locally):
+       agent-bridge upgrade --apply --allow-dirty-source
+EOF
+      exit 64
+    fi
   fi
 
   if [[ $ALLOW_DIRTY -eq 0 && $DRY_RUN -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Reference: #380. `agent-bridge upgrade --apply` (and `--dry-run`) was silently folding uncommitted source-checkout edits into the merge source, producing surprise conflicts on core files even when the target tag was clean. Adds a pre-flight check that aborts on dirty source for tag (`v*`) / `release/*` targets so dry-run and apply both surface the same surprise-free abort.

## Changes

### Pre-flight in `bridge-upgrade.sh`

When the resolved `TARGET_REF` matches `^v[0-9]` or `release/*`:

- Run `git status --porcelain` in `$SOURCE_ROOT` after target-ref resolution and before any merge work.
- On non-empty output, **abort** with a structured message offering three resolution paths: (1) commit/stash, (2) point `AGENT_BRIDGE_SOURCE_DIR` at a clean checkout, (3) explicit `--allow-dirty-source` opt-in for maintainers — and exit 64 (`EX_USAGE`).
- Pre-flight runs for both `--dry-run` and `--apply` so the abort surfaces before any merge is attempted (the original failure mode reported on #380 happened on dry-run with `files_merged_conflict: 9`; this turns that surprise into a clear refusal up-front).

### `--allow-dirty-source` flag

New CLI flag (default off) that bypasses the new pre-flight. For maintainers who genuinely want to test a release candidate against an in-flight working tree. The existing `--allow-dirty` also bypasses the new pre-flight, preserving back-compat for operators who already opted into dirty-source upgrades.

## What this PR does NOT change

- The merge resolution logic itself is unchanged. The pre-flight aborts earlier; the existing flow runs normally on a clean source checkout.
- `--check` is unchanged — it still reports `target_ref` truthfully and exits before the pre-flight.
- The scratch-clone alternative (clone target_ref into `$BRIDGE_HOME/state/upgrade-scratch/<ref>/` for merge source) is documented in the issue as a follow-up — not landed in this PR.

## Verification

- `bash -n bridge-upgrade.sh`: PASS
- `shellcheck bridge-upgrade.sh`: PASS
- `python3 -m ast bridge-upgrade.py`: PASS

Manual smoke matrix (mktemp -d clone with `M bridge-daemon.sh`, patched script copied in):

| Case | Command | Expected | Result |
|---|---|---|---|
| A | `--dry-run --version v0.6.19` | abort, exit 64 | PASS |
| B | `--dry-run --version v0.6.19 --allow-dirty-source` | proceeds, exit 0 | PASS |
| C | `--check --version v0.6.19` | unchanged, exit 0 | PASS |
| D | `--dry-run --ref <non-release>` | pre-flight skipped | PASS |
| E | `--dry-run --version v0.6.19 --allow-dirty` | proceeds (back-compat), exit 0 | PASS |
| F | `--dry-run --ref release/v0.7.0` | abort, exit 64 | PASS |

Reference: #380