### PR TITLE
isolate-v2 PR-D: migration tool + docs

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -219,3 +219,43 @@ Operator guidance:
 - Declare an allowlist for each long-lived agent role. Start by listing the plugins the agent actually uses (channel transports, role-specific MCP servers like `syrs-gmail`, etc.) and re-run `bash scripts/apply-channel-policy.sh`.
 - Restart the agent to pick up the overlay (`agb agent restart <agent>`).
 - The allowlist is enforced at MCP-spawn time via `enabledPlugins=false`, not via `--strict-mcp-config`. A `--strict-mcp-config` track is feasible as a follow-up if `enabledPlugins` is found insufficient on a given Claude Code release; today the overlay is the lowest-risk path because the same machinery already enforces the singleton channel policy.
+## 14. Layout v2 retains legacy install-root profile / memory after migration
+
+PR-D's `agent-bridge migrate isolation-v2 commit` does NOT delete profile,
+skill, or memory files from `$BRIDGE_HOME/agents/<agent>/` — those are
+copied to the v2 workdir with `delete_eligible=0` and the install-root
+copies are kept as a frozen snapshot.
+
+Practical effect:
+
+- Edits to `CLAUDE.md`, `MEMORY.md`, `SKILLS.md`, `SOUL.md`, `HEARTBEAT.md`,
+  `MEMORY-SCHEMA.md`, `COMMON-INSTRUCTIONS.md`, `CHANGE-POLICY.md`,
+  `TOOLS.md`, `SESSION-TYPE.md`, `NEXT-SESSION.md`, `.agents/`, `memory/`,
+  `users/`, `references/`, `skills/` after activation must go into the v2
+  workdir (`$BRIDGE_DATA_ROOT/agents/<agent>/workdir/`). The install-root
+  copy is left in place but goes stale.
+- `agent-bridge profile deploy <agent>` writes to the v2 workdir under
+  v2 because PR-D ships the matching `bridge_agent_default_profile_home`
+  v2 branch (lib/bridge-agents.sh). The two locations therefore can drift
+  if an admin hand-edits the install-root copy.
+
+Plan: PR-G will either unify the two locations (single source-of-truth in
+the v2 workdir) or mark the install-root copy read-only and point all
+admin tooling at the v2 path explicitly.
+
+## 15. `_common.sh` `list_active_claude_agents` retains silent success on malformed JSON
+
+`scripts/_common.sh:71-96` parses `agb agent list --json` with a broad
+`try/except: sys.exit(0)` clause, so a malformed JSON payload or a failed
+`agb` invocation produces an empty agent list rather than a non-zero exit.
+
+PR-D switched `scripts/wiki-daily-ingest.sh` to a strict inline enumerator
+because Lane B silent-zero would have masked v2 memory updates, but it
+deliberately did NOT change `_common.sh` to avoid touching every other
+caller (`bootstrap-memory-system.sh`, `scripts/wiki-v2-rebuild.sh`,
+`scripts/wiki-weekly-summarize.sh`, `scripts/wiki-monthly-summarize.sh`).
+Those callers retain the original silent-OK behaviour for now.
+
+A follow-up PR (PR-G review) is expected to flip `_common.sh` to fail-closed
+and adjust each caller, replacing the local strict block in
+`wiki-daily-ingest.sh` with the shared helper at that point.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -341,6 +341,87 @@ emits when `BRIDGE_AGENT_ISOLATION_MODE=linux-user`. See issue
 > A2A queue tasks from those sessions stop routing through the gateway
 > until they pick up the new env.
 
+## Migrating to layout v2
+
+The v2 layout (PR-A/B/C, shipped in v0.6.19) replaces named-ACL access on
+per-agent runtime data with group-based ownership under a single
+`$BRIDGE_DATA_ROOT`. PR-D adds the operator tool to migrate an existing
+legacy install onto v2.
+
+Activation criteria: marker file at `$BRIDGE_HOME/state/layout-marker.sh`
+present, owner root or controller, mode 0640, content limited to an
+allowlist of `BRIDGE_LAYOUT=v2` / `BRIDGE_DATA_ROOT=<absolute path>` / a
+small set of group overrides. Anything else is rejected at load time and
+the install falls back to legacy.
+
+**Phases** (run from an out-of-band controller shell, NOT from inside an
+Agent Bridge agent session — the migration tool's self-stop guard refuses
+otherwise):
+
+1. **dry-run** — print the legacy → v2 mirror plan and the
+   profile_home preflight. No mutation. Use `--data-root` to choose the
+   target (e.g. `/srv/agent-bridge`).
+
+   ```bash
+   agent-bridge migrate isolation-v2 dry-run --data-root /srv/agent-bridge
+   ```
+
+2. **apply** — stop active agents one by one, stop the daemon
+   (active=0 path, no `--force`), ensure the v2 groups exist (sudo),
+   real-copy mirror legacy → v2 (rsync, no hardlinks), write the marker
+   atomically, restart daemon and the agents from the snapshot, post-flight
+   probe each agent UID's groups via fresh `sudo -u <user> id -nG`.
+
+   ```bash
+   agent-bridge migrate isolation-v2 apply --data-root /srv/agent-bridge --yes
+   ```
+
+   Apply refuses if any agent's roster has an explicit
+   `BRIDGE_AGENT_PROFILE_HOME` that is not `<data_root>/agents/<agent>/workdir`.
+   Edit `agent-roster.local.sh` (via `agent-bridge config set`) to align
+   the override and re-run, or unset it and re-run.
+
+3. **soak** — operate on v2 for as long as you want to be sure things
+   work. Rollback is cheap (legacy tree is intact until commit).
+
+   ```bash
+   agent-bridge migrate isolation-v2 status
+   agent-bridge migrate isolation-v2 rollback --yes   # if needed
+   ```
+
+4. **commit** — tar-zst backup + delete the legacy paths recorded in the
+   manifest as `verify_status=ok && delete_eligible=1`. Profile/skill/memory
+   files (delete_eligible=0, see below) are NOT deleted.
+
+   ```bash
+   agent-bridge migrate isolation-v2 commit --yes
+   ```
+
+### Editing profile / skills / memory after activation
+
+After v2 activation, runtime resolvers (`bridge-skills.sh`,
+`bridge-setup.sh`, `bridge-agent.sh`, `bridge-upgrade.sh`,
+`bootstrap-memory-system.sh`, the wiki cron suite) read from the v2
+workdir (`$BRIDGE_DATA_ROOT/agents/<agent>/workdir/`). PR-D additionally
+fixes `bridge_agent_default_profile_home` so that `agent-bridge profile
+deploy` writes to the v2 workdir as well — closing a gap left by PR-A/B/C
+where the profile alias still pointed at v2 `home/`.
+
+These files are mirrored to the v2 workdir with `delete_eligible=0`,
+meaning the install-root copy is **retained as a frozen snapshot** through
+`--commit`:
+
+- `agents/<agent>/CLAUDE.md`, `MEMORY.md`, `SKILLS.md`, `SOUL.md`,
+  `HEARTBEAT.md`, `MEMORY-SCHEMA.md`, `COMMON-INSTRUCTIONS.md`,
+  `CHANGE-POLICY.md`, `TOOLS.md`
+- `agents/<agent>/SESSION-TYPE.md`, `NEXT-SESSION.md` (dual-read)
+- `agents/<agent>/.agents/`, `memory/`, `users/`, `references/`, `skills/`
+
+**Edit at the v2 workdir.** The runtime resolver reads the v2 path first;
+the install-root copy is left in place so existing admin tooling and a
+clean rollback remain possible. A future PR (PR-G) is expected to either
+unify the two locations or mark the install-root copy read-only.
+
 ## Release Checklist
 
 Before pushing bridge changes:

--- a/agent-bridge
+++ b/agent-bridge
@@ -64,6 +64,11 @@ Usage:
   $CLI_NAME migrate overhead dry-run [--agent <name>|--all] [--json]
   $CLI_NAME migrate overhead apply [--agent <name>|--all] --yes [--dry-run] [--json]
   $CLI_NAME migrate overhead rollback --stamp <YYYYMMDD-HHMMSS-<pid>> [--json]
+  $CLI_NAME migrate isolation-v2 dry-run --data-root <path>
+  $CLI_NAME migrate isolation-v2 apply --data-root <path> --yes
+  $CLI_NAME migrate isolation-v2 rollback --yes
+  $CLI_NAME migrate isolation-v2 commit --yes
+  $CLI_NAME migrate isolation-v2 status
   $CLI_NAME wiki bootstrap [--agent <name>] [--shared-root <path>] [--dry-run] [--json]
   $CLI_NAME wiki validate [--full|--frontmatter|--broken-link|--tree-edge] [--json]
   $CLI_NAME wiki dedup-scan [--output <file>] [--json]

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -155,6 +155,11 @@ bridge_source_module() {
 
 bridge_source_module "bridge-session-patterns.sh"
 bridge_source_module "bridge-core.sh"
+# Read the v2 layout marker (state/layout-marker.sh) before any module
+# snapshots BRIDGE_LAYOUT/BRIDGE_DATA_ROOT. Sourced after bridge-core.sh
+# so bridge_warn is available, before bridge-agents.sh / bridge-isolation-v2.sh
+# so v2 helpers see the marker values. Safe no-op when the marker is absent.
+bridge_source_module "bridge-marker-bootstrap.sh"
 bridge_source_module "bridge-agents.sh"
 bridge_source_module "bridge-guard.sh"
 bridge_source_module "bridge-tmux.sh"

--- a/bridge-migrate.sh
+++ b/bridge-migrate.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
+# shellcheck source=lib/bridge-isolation-v2-migrate.sh
+source "$SCRIPT_DIR/lib/bridge-isolation-v2-migrate.sh"
 bridge_load_roster
 
 usage() {
@@ -23,6 +25,11 @@ Usage:
   bash $SCRIPT_DIR/bridge-migrate.sh workspace cutover <agent> --dry-run
   bash $SCRIPT_DIR/bridge-migrate.sh overhead pre-migrate [--output <file>] [--json]
   bash $SCRIPT_DIR/bridge-migrate.sh overhead dry-run [--agent <name>|--all] [--json]
+  bash $SCRIPT_DIR/bridge-migrate.sh isolation-v2 dry-run --data-root <path>
+  bash $SCRIPT_DIR/bridge-migrate.sh isolation-v2 apply   --data-root <path> --yes
+  bash $SCRIPT_DIR/bridge-migrate.sh isolation-v2 rollback --yes
+  bash $SCRIPT_DIR/bridge-migrate.sh isolation-v2 commit  --yes
+  bash $SCRIPT_DIR/bridge-migrate.sh isolation-v2 status
   bash $SCRIPT_DIR/bridge-migrate.sh overhead apply [--agent <name>|--all] --yes [--dry-run] [--json]
   bash $SCRIPT_DIR/bridge-migrate.sh overhead rollback --stamp <YYYYMMDD-HHMMSS-<pid>> [--json]
 EOF
@@ -821,6 +828,9 @@ case "$subcommand" in
         bridge_die "지원하지 않는 migrate workspace 명령입니다: $1"
         ;;
     esac
+    ;;
+  isolation-v2)
+    bridge_isolation_v2_migrate_cli "$@"
     ;;
   ""|-h|--help|help)
     usage

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2601,6 +2601,17 @@ bridge_agent_should_stop_on_attached_clean_exit() {
 
 bridge_agent_default_profile_home() {
   local agent="$1"
+  # v2: profile lives under workdir, not home. Every runtime resolver
+  # (bridge-skills.sh:230, bridge-setup.sh:90/823, bridge-agent.sh:1275)
+  # reads CLAUDE.md from workdir, so the deploy target (this function)
+  # must point at workdir too, otherwise `agent-bridge profile deploy`
+  # would land in v2 home/ where nothing reads it. PR-A/B/C made
+  # bridge_agent_default_home v2-aware but left this profile alias
+  # passing through to it. PR-D closes that gap.
+  if bridge_isolation_v2_active && [[ -n "$BRIDGE_AGENT_ROOT_V2" && -n "$agent" ]]; then
+    printf '%s/%s/workdir' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+    return 0
+  fi
   bridge_agent_default_home "$agent"
 }
 

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -1,0 +1,792 @@
+#!/usr/bin/env bash
+# bridge-isolation-v2-migrate.sh — Operator tooling for migrating a legacy
+# Agent Bridge install onto the v2 layout (BRIDGE_LAYOUT=v2, BRIDGE_DATA_ROOT=...).
+#
+# Public entrypoint: bridge_isolation_v2_migrate_cli (dispatched from
+# bridge-migrate.sh). Subcommands:
+#   dry-run --data-root <path>            print plan + manifest preview, no mutation
+#   apply   --data-root <path> --yes      stop, mirror, normalize, marker flip, restart
+#   rollback --yes                        marker remove + restart legacy
+#   commit  --yes                         delete legacy paths recorded in manifest
+#   status                                print current marker + manifest summary
+#
+# Contracts (agreed via 9 dev-codex review rounds):
+#   * --apply / --rollback refuse to run when invoked from inside a managed
+#     agent session whose own id appears in the active snapshot.
+#   * Active-agent stop uses real CLI primitives (per-agent `bridge-agent.sh
+#     stop <agent>`, then plain `bridge-daemon.sh stop` after active=0).
+#   * Daemon presence/absence is verified via process-based polling
+#     (`bridge_daemon_all_pids`), bounded with an integer attempt counter.
+#   * Mirror is real copy (rsync -aHX --numeric-ids --no-links). No hardlinks
+#     so subsequent chgrp/chmod can not mutate legacy inodes.
+#   * Manifest schema (TSV, 9 columns):
+#       ts  mapping_id  legacy_src_abs  v2_dst_abs  bytes  sha256_legacy
+#       sha256_v2  verify_status  delete_eligible
+#     commit candidate filter: $8 == "ok" && $9 == "1".
+#   * Profile/memory/skills mirror to v2 workdir with delete_eligible=0 —
+#     install-root retained as frozen snapshot, runtime reads from v2 workdir.
+#   * Plugin catalog: only controller-managed (~/.claude/plugins/
+#     installed_plugins.json + known_marketplaces.json + marketplaces/)
+#     copied to $BRIDGE_DATA_ROOT/shared/plugins-cache/. Per-UID plugins/data
+#     never merged into shared.
+#   * Marker file written via tmpfile + atomic mv; loaded only after strict
+#     validation in lib/bridge-marker-bootstrap.sh.
+#   * Explicit BRIDGE_AGENT_PROFILE_HOME override that does not match the
+#     v2 workdir is treated as roster intent — preflight prints a remediation
+#     warning in dry-run and dies in apply, never silently rewrites roster.
+#   * Group changes use sudo metadata ops; current shell's id -nG is
+#     untrusted (warm-cache problem). Postflight probes each agent UID and
+#     the controller via fresh `sudo -u <user> id -nG`.
+#   * Self-cleanup in this module never installs a long-lived EXIT trap
+#     (would clobber the existing COPY_JSON trap conventions in scripts/).
+#
+# shellcheck shell=bash disable=SC2034
+
+# ---------------------------------------------------------------------------
+# 0. helper: paths and constants
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_state_dir() {
+  printf '%s/migration' "${BRIDGE_STATE_DIR}"
+}
+
+bridge_isolation_v2_migrate_active_snapshot_path() {
+  printf '%s/active-agents.snapshot' "$(bridge_isolation_v2_migrate_state_dir)"
+}
+
+bridge_isolation_v2_migrate_lock_path() {
+  printf '%s/migrate-isolation-v2.lock' "$(bridge_isolation_v2_migrate_state_dir)"
+}
+
+bridge_isolation_v2_migrate_manifest_path() {
+  # Single rolling manifest. apply truncates + appends; commit reads.
+  printf '%s/manifest.tsv' "$(bridge_isolation_v2_migrate_state_dir)"
+}
+
+bridge_isolation_v2_migrate_backup_tarball_path() {
+  local stamp="$1"
+  printf '%s/legacy-backup-%s.tar.zst' "$(bridge_isolation_v2_migrate_state_dir)" "$stamp"
+}
+
+bridge_isolation_v2_migrate_mkstate() {
+  install -d -m 0750 "$(bridge_isolation_v2_migrate_state_dir)" 2>/dev/null \
+    || mkdir -p "$(bridge_isolation_v2_migrate_state_dir)"
+}
+
+# ---------------------------------------------------------------------------
+# 1. self-stop guard
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_self_stop_guard() {
+  local self="${BRIDGE_AGENT_ID:-}"
+  [[ -n "$self" ]] || return 0
+
+  local snapshot_path="$1"
+  [[ -f "$snapshot_path" ]] || return 0
+
+  local line
+  while IFS= read -r line; do
+    if [[ "$line" == "$self" ]]; then
+      bridge_die "self-stop guard: '$self' is in the active snapshot. \
+Run this command from an out-of-band controller shell (unset BRIDGE_AGENT_ID), \
+not from inside an Agent Bridge agent session. No state has been mutated."
+    fi
+  done < "$snapshot_path"
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# 2. lock + active-agent snapshot
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_acquire_lock() {
+  bridge_isolation_v2_migrate_mkstate
+  local lock_path
+  lock_path="$(bridge_isolation_v2_migrate_lock_path)"
+  exec 9>"$lock_path"
+  if ! flock -n 9; then
+    bridge_die "another isolation-v2 migrate operation is in progress (lock=$lock_path)"
+  fi
+}
+
+bridge_isolation_v2_migrate_capture_active_snapshot() {
+  bridge_isolation_v2_migrate_mkstate
+  local snapshot
+  snapshot="$(bridge_isolation_v2_migrate_active_snapshot_path)"
+  bridge_active_agent_ids > "$snapshot"
+}
+
+# ---------------------------------------------------------------------------
+# 3. profile_home override preflight
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_check_profile_home_overrides() {
+  # Returns 0 when no agent in the snapshot has a misaligned explicit
+  # BRIDGE_AGENT_PROFILE_HOME. Returns 1 otherwise; warns to stderr.
+  # Caller is responsible for the dry-run-vs-apply policy decision.
+  local snapshot_path="$1"
+  local data_root="$2"
+  [[ -f "$snapshot_path" && -n "$data_root" ]] || return 0
+
+  local agent override expected mismatch=0
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    override="${BRIDGE_AGENT_PROFILE_HOME[$agent]-}"
+    [[ -n "$override" ]] || continue
+    override="$(bridge_expand_user_path "$override")"
+    expected="$data_root/agents/$agent/workdir"
+    if [[ "$override" != "$expected" ]]; then
+      bridge_warn "agent '$agent' has explicit BRIDGE_AGENT_PROFILE_HOME=$override which is not the v2 workdir ($expected). agent-bridge profile deploy will land in the wrong location after marker flip. Edit roster (agent-roster.local.sh or agent-roster.sh) to unset or align this entry, then re-run --apply."
+      mismatch=1
+    fi
+  done < "$snapshot_path"
+  return $(( mismatch ))
+}
+
+# ---------------------------------------------------------------------------
+# 4. mirror map enumeration
+# ---------------------------------------------------------------------------
+
+# Print one TSV row per planned mirror op:
+#   <mapping_id> TAB <legacy_src> TAB <v2_dst> TAB <delete_eligible>
+# Only paths whose legacy src exists are emitted. v2 dst dirs are created
+# at mirror time, not here.
+bridge_isolation_v2_migrate_emit_plan() {
+  local data_root="$1"
+  local snapshot_path="$2"
+  local controller_user="${SUDO_USER:-${USER:-}}"
+  local controller_home
+  controller_home="$(bridge_linux_resolve_user_home "$controller_user" 2>/dev/null \
+    || printf '%s' "$HOME")"
+
+  # ---- per-agent rows ----
+  local agent
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    local legacy_root="$BRIDGE_AGENT_HOME_ROOT/$agent"
+    local v2_agent_root="$data_root/agents/$agent"
+
+    # runtime, delete_eligible=1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_claude:$agent" "$legacy_root/.claude" "$v2_agent_root/home/.claude" 1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_discord:$agent" "$legacy_root/.discord" "$v2_agent_root/workdir/.discord" 1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_telegram:$agent" "$legacy_root/.telegram" "$v2_agent_root/workdir/.telegram" 1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_teams:$agent" "$legacy_root/.teams" "$v2_agent_root/workdir/.teams" 1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_ms365:$agent" "$legacy_root/.ms365" "$v2_agent_root/workdir/.ms365" 1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_credentials:$agent" "$legacy_root/credentials" "$v2_agent_root/credentials" 1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_workdir:$agent" "$legacy_root/workdir" "$v2_agent_root/workdir" 1
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_logs:$agent" "$legacy_root/logs" "$v2_agent_root/logs" 1
+
+    # dual-read (delete_eligible=0)
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_session_type:$agent" "$legacy_root/SESSION-TYPE.md" "$v2_agent_root/workdir/SESSION-TYPE.md" 0
+    bridge_isolation_v2_migrate_emit_row \
+      "agent_next_session:$agent" "$legacy_root/NEXT-SESSION.md" "$v2_agent_root/workdir/NEXT-SESSION.md" 0
+
+    # profile / instruction (delete_eligible=0)
+    local pf
+    for pf in CLAUDE.md MEMORY.md SKILLS.md SOUL.md HEARTBEAT.md \
+              MEMORY-SCHEMA.md COMMON-INSTRUCTIONS.md CHANGE-POLICY.md TOOLS.md; do
+      bridge_isolation_v2_migrate_emit_row \
+        "agent_profile_${pf}:$agent" "$legacy_root/$pf" "$v2_agent_root/workdir/$pf" 0
+    done
+
+    # profile / skills / memory subtrees (delete_eligible=0)
+    local sd
+    for sd in .agents memory users references skills; do
+      bridge_isolation_v2_migrate_emit_row \
+        "agent_subtree_${sd}:$agent" "$legacy_root/$sd" "$v2_agent_root/workdir/$sd" 0
+    done
+  done < "$snapshot_path"
+
+  # ---- global rows ----
+  bridge_isolation_v2_migrate_emit_row \
+    "runtime_root" "$BRIDGE_RUNTIME_ROOT" "$data_root/state/runtime" 1
+  bridge_isolation_v2_migrate_emit_row \
+    "runtime_shared" "$BRIDGE_RUNTIME_SHARED_DIR" "$data_root/shared" 1
+  if [[ "$BRIDGE_WORKTREE_ROOT" == "$BRIDGE_HOME"/* ]]; then
+    bridge_isolation_v2_migrate_emit_row \
+      "worktree_root" "$BRIDGE_WORKTREE_ROOT" "$data_root/worktrees" 1
+  fi
+
+  # ---- plugin catalog (controller-managed only) ----
+  if [[ -n "$controller_home" ]]; then
+    local plugins_root="$controller_home/.claude/plugins"
+    if [[ -f "$plugins_root/installed_plugins.json" ]]; then
+      bridge_isolation_v2_migrate_emit_row \
+        "plugin_installed_json" \
+        "$plugins_root/installed_plugins.json" \
+        "$data_root/shared/plugins-cache/installed_plugins.json" 1
+    fi
+    if [[ -f "$plugins_root/known_marketplaces.json" ]]; then
+      bridge_isolation_v2_migrate_emit_row \
+        "plugin_known_markets_json" \
+        "$plugins_root/known_marketplaces.json" \
+        "$data_root/shared/plugins-cache/known_marketplaces.json" 1
+    fi
+    if [[ -d "$plugins_root/marketplaces" ]]; then
+      bridge_isolation_v2_migrate_emit_row \
+        "plugin_marketplaces_tree" \
+        "$plugins_root/marketplaces" \
+        "$data_root/shared/plugins-cache/marketplaces" 1
+    fi
+  fi
+}
+
+bridge_isolation_v2_migrate_emit_row() {
+  local mapping_id="$1" legacy_src="$2" v2_dst="$3" delete_eligible="$4"
+  [[ -e "$legacy_src" ]] || return 0
+  printf '%s\t%s\t%s\t%s\n' "$mapping_id" "$legacy_src" "$v2_dst" "$delete_eligible"
+}
+
+# ---------------------------------------------------------------------------
+# 5. mirror execution + manifest
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_sha256_of() {
+  # Print sha256 of a path. For files, hash the bytes. For dirs, hash
+  # the sorted concatenation of (relpath, sha256) lines so two trees
+  # with identical content compare equal regardless of inode/atime.
+  local target="$1"
+  if [[ -f "$target" && ! -L "$target" ]]; then
+    sha256sum "$target" 2>/dev/null | awk '{print $1}'
+    return
+  fi
+  if [[ -d "$target" ]]; then
+    (
+      cd "$target" 2>/dev/null || exit 0
+      find . -type f -print0 2>/dev/null \
+        | sort -z \
+        | xargs -0 sha256sum 2>/dev/null
+    ) | sha256sum | awk '{print $1}'
+    return
+  fi
+  printf 'absent'
+}
+
+bridge_isolation_v2_migrate_bytes_of() {
+  local target="$1"
+  if [[ -f "$target" && ! -L "$target" ]]; then
+    stat -c '%s' "$target" 2>/dev/null || printf '0'
+    return
+  fi
+  if [[ -d "$target" ]]; then
+    du -sb "$target" 2>/dev/null | awk '{print $1}'
+    return
+  fi
+  printf '0'
+}
+
+bridge_isolation_v2_migrate_mirror_one() {
+  local mapping_id="$1" legacy_src="$2" v2_dst="$3" delete_eligible="$4"
+  local manifest_path="$5"
+  local ts bytes sha_legacy sha_v2 verify
+
+  ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  bytes="$(bridge_isolation_v2_migrate_bytes_of "$legacy_src")"
+  sha_legacy="$(bridge_isolation_v2_migrate_sha256_of "$legacy_src")"
+
+  # Make destination parent.
+  local dst_parent
+  if [[ -d "$legacy_src" ]]; then
+    mkdir -p "$v2_dst" 2>/dev/null
+  else
+    dst_parent="$(dirname "$v2_dst")"
+    mkdir -p "$dst_parent" 2>/dev/null
+  fi
+
+  # Real copy. -a preserves perm/owner/time. -X xattrs. --numeric-ids
+  # avoids name lookups on the destination side. --no-links so symlinks
+  # are followed (rare in the layouts we mirror; if a symlink is later
+  # discovered we treat it as runtime).
+  local rc=0
+  if [[ -d "$legacy_src" ]]; then
+    rsync -aHX --numeric-ids --no-links --delete-excluded \
+      "$legacy_src/" "$v2_dst/" >/dev/null 2>&1 || rc=$?
+  else
+    rsync -aHX --numeric-ids --no-links \
+      "$legacy_src" "$v2_dst" >/dev/null 2>&1 || rc=$?
+  fi
+  if (( rc != 0 )); then
+    verify="rsync_fail_$rc"
+    sha_v2="absent"
+  else
+    sha_v2="$(bridge_isolation_v2_migrate_sha256_of "$v2_dst")"
+    if [[ "$sha_legacy" == "$sha_v2" ]]; then
+      verify="ok"
+    else
+      verify="checksum_mismatch"
+    fi
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$ts" "$mapping_id" "$legacy_src" "$v2_dst" "$bytes" \
+    "$sha_legacy" "$sha_v2" "$verify" "$delete_eligible" \
+    >> "$manifest_path"
+
+  [[ "$verify" == "ok" ]] || return 1
+  return 0
+}
+
+bridge_isolation_v2_migrate_mirror_all() {
+  local data_root="$1" snapshot_path="$2" manifest_path="$3"
+  : > "$manifest_path"
+
+  local row mapping_id legacy_src v2_dst delete_eligible
+  local fail=0
+  while IFS=$'\t' read -r mapping_id legacy_src v2_dst delete_eligible; do
+    [[ -n "$mapping_id" ]] || continue
+    if ! bridge_isolation_v2_migrate_mirror_one \
+        "$mapping_id" "$legacy_src" "$v2_dst" "$delete_eligible" "$manifest_path"; then
+      fail=$(( fail + 1 ))
+    fi
+  done < <(bridge_isolation_v2_migrate_emit_plan "$data_root" "$snapshot_path")
+
+  if (( fail > 0 )); then
+    bridge_warn "mirror: $fail row(s) failed (see $manifest_path verify_status column)"
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# 6. group ensure + post-flight probe
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_ensure_groups() {
+  local snapshot_path="$1"
+  local _g
+  for _g in "ab-shared" "ab-controller"; do
+    bridge_isolation_v2_ensure_group "$_g" || return 1
+  done
+  local agent
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    bridge_isolation_v2_ensure_group "$(bridge_isolation_v2_agent_group_name "$agent")" \
+      || return 1
+  done < "$snapshot_path"
+  return 0
+}
+
+bridge_isolation_v2_migrate_postflight_groups() {
+  local snapshot_path="$1"
+  local controller_user="${SUDO_USER:-${USER:-}}"
+  local agent groups os_user
+  local mismatch=0
+
+  # Controller fresh probe.
+  if [[ -n "$controller_user" ]]; then
+    groups="$(sudo -n -u "$controller_user" id -nG 2>/dev/null || true)"
+    if [[ -z "$groups" ]]; then
+      bridge_warn "postflight: cannot fresh-probe controller groups for $controller_user"
+      mismatch=1
+    fi
+  fi
+
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || true)"
+    [[ -n "$os_user" ]] || continue
+    groups="$(sudo -n -u "$os_user" id -nG 2>/dev/null || true)"
+    if [[ -z "$groups" ]]; then
+      bridge_warn "postflight: cannot fresh-probe groups for $os_user (agent $agent)"
+      mismatch=1
+      continue
+    fi
+    local agent_group
+    agent_group="$(bridge_isolation_v2_agent_group_name "$agent")"
+    if ! grep -qw "$agent_group" <<<"$groups"; then
+      bridge_warn "postflight: $os_user (agent $agent) missing group $agent_group; got: $groups"
+      mismatch=1
+    fi
+    if ! grep -qw "ab-shared" <<<"$groups"; then
+      bridge_warn "postflight: $os_user (agent $agent) missing group ab-shared; got: $groups"
+      mismatch=1
+    fi
+  done < "$snapshot_path"
+
+  return $(( mismatch ))
+}
+
+# ---------------------------------------------------------------------------
+# 7. daemon poll (process-based, bounded, integer attempts)
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_wait_daemon_gone() {
+  local timeout_s="${1:-10}"
+  local interval_s=0.2
+  local max_attempts=$(( timeout_s * 5 ))
+  local attempt
+  for (( attempt = 0; attempt < max_attempts; attempt++ )); do
+    if [[ -z "$(bridge_daemon_all_pids 2>/dev/null || true)" ]]; then
+      return 0
+    fi
+    sleep "$interval_s"
+  done
+  bridge_die "daemon stop verification failed: still running PIDs after ${timeout_s}s"
+}
+
+bridge_isolation_v2_migrate_wait_daemon_present() {
+  local timeout_s="${1:-10}"
+  local interval_s=0.2
+  local max_attempts=$(( timeout_s * 5 ))
+  local attempt
+  for (( attempt = 0; attempt < max_attempts; attempt++ )); do
+    if [[ -n "$(bridge_daemon_all_pids 2>/dev/null || true)" ]]; then
+      return 0
+    fi
+    sleep "$interval_s"
+  done
+  bridge_die "daemon failed to come up within ${timeout_s}s after restart"
+}
+
+# ---------------------------------------------------------------------------
+# 8. orchestrate stop / restart
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_orchestrate_stop() {
+  local snapshot_path="$1"
+
+  # Per-agent stop.
+  local agent
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-agent.sh" stop "$agent" >/dev/null 2>&1 \
+      || bridge_warn "stop failed for agent '$agent' — continuing; will be skipped at restart"
+  done < "$snapshot_path"
+
+  # Verify zero active.
+  local remaining
+  remaining="$(bridge_active_agent_ids | wc -l | tr -d ' ')"
+  if [[ "$remaining" =~ ^[0-9]+$ ]] && (( remaining > 0 )); then
+    bridge_die "agents still active after per-agent stop loop: $remaining"
+  fi
+
+  # Plain daemon stop (active=0 now → no --force needed).
+  "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-daemon.sh" stop >/dev/null 2>&1 \
+    || bridge_die "daemon stop returned non-zero"
+  bridge_isolation_v2_migrate_wait_daemon_gone 10
+}
+
+bridge_isolation_v2_migrate_orchestrate_restart() {
+  local snapshot_path="$1"
+
+  "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-daemon.sh" start >/dev/null 2>&1 \
+    || bridge_die "daemon restart failed"
+  bridge_isolation_v2_migrate_wait_daemon_present 10
+
+  local agent
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-agent.sh" start "$agent" >/dev/null 2>&1 \
+      || bridge_warn "restart failed for agent '$agent' — operator will need to start manually"
+  done < "$snapshot_path"
+}
+
+# ---------------------------------------------------------------------------
+# 9. marker write (atomic, validated content)
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_marker_write() {
+  local data_root="$1"
+  local marker_path
+  marker_path="$(bridge_isolation_v2_marker_path)"
+
+  bridge_isolation_v2_migrate_mkstate
+  install -d -m 0750 "$(dirname "$marker_path")" 2>/dev/null \
+    || mkdir -p "$(dirname "$marker_path")"
+
+  local tmp="${marker_path}.tmp.$$"
+  {
+    printf 'BRIDGE_LAYOUT=%s\n' "$(printf %q "v2")"
+    printf 'BRIDGE_DATA_ROOT=%s\n' "$(printf %q "$data_root")"
+  } > "$tmp"
+
+  chmod 0640 "$tmp" || { rm -f "$tmp"; bridge_die "marker chmod failed"; }
+  # Owner: leave as caller (controller). Group bit 0 prevents group write
+  # already; ownership is inherited from caller process which is the
+  # controller running the migration.
+  mv -f "$tmp" "$marker_path" || bridge_die "marker mv failed"
+
+  if ! bridge_isolation_v2_marker_validate "$marker_path"; then
+    rm -f "$marker_path"
+    bridge_die "marker validation failed after write — refusing to leave half-formed marker on disk"
+  fi
+}
+
+bridge_isolation_v2_migrate_marker_remove() {
+  local marker_path
+  marker_path="$(bridge_isolation_v2_marker_path)"
+  rm -f "$marker_path"
+}
+
+# ---------------------------------------------------------------------------
+# 10. legacy data path enumeration (commit candidate filter)
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_legacy_data_paths() {
+  local manifest_path
+  manifest_path="$(bridge_isolation_v2_migrate_manifest_path)"
+  [[ -f "$manifest_path" ]] || return 0
+  awk -F'\t' '$8 == "ok" && $9 == "1" { print $3 }' "$manifest_path"
+}
+
+# ---------------------------------------------------------------------------
+# 11. entrypoints
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_dry_run() {
+  local data_root="$1"
+  bridge_isolation_v2_migrate_acquire_lock
+  bridge_isolation_v2_migrate_capture_active_snapshot
+  local snapshot
+  snapshot="$(bridge_isolation_v2_migrate_active_snapshot_path)"
+
+  printf '== isolation-v2 migrate dry-run ==\n'
+  printf 'data_root: %s\n' "$data_root"
+  printf 'active agents: %s\n' "$(wc -l < "$snapshot" | tr -d ' ')"
+  printf '\n-- mirror plan (mapping_id  src  dst  delete_eligible) --\n'
+  bridge_isolation_v2_migrate_emit_plan "$data_root" "$snapshot"
+
+  printf '\n-- profile_home overrides --\n'
+  if bridge_isolation_v2_migrate_check_profile_home_overrides "$snapshot" "$data_root"; then
+    printf '(none misaligned)\n'
+  else
+    printf '(see warnings above; --apply will refuse until roster is aligned)\n'
+  fi
+}
+
+bridge_isolation_v2_migrate_apply() {
+  local data_root="$1"
+  [[ -n "$data_root" && "${data_root:0:1}" == "/" ]] \
+    || bridge_die "--apply requires --data-root <absolute-path>"
+  if bridge_isolation_v2_active; then
+    bridge_warn "v2 already active — apply is idempotent only when --data-root matches; proceeding will re-mirror."
+  fi
+
+  bridge_isolation_v2_migrate_acquire_lock
+  bridge_isolation_v2_migrate_capture_active_snapshot
+  local snapshot
+  snapshot="$(bridge_isolation_v2_migrate_active_snapshot_path)"
+
+  bridge_isolation_v2_migrate_self_stop_guard "$snapshot"
+
+  if ! bridge_isolation_v2_migrate_check_profile_home_overrides "$snapshot" "$data_root"; then
+    bridge_die "explicit BRIDGE_AGENT_PROFILE_HOME override(s) misaligned; see warnings above; align roster and retry"
+  fi
+
+  install -d -m 0755 "$data_root" 2>/dev/null || mkdir -p "$data_root"
+
+  bridge_isolation_v2_migrate_orchestrate_stop "$snapshot"
+
+  bridge_isolation_v2_migrate_ensure_groups "$snapshot" \
+    || bridge_die "group ensure failed"
+
+  local manifest
+  manifest="$(bridge_isolation_v2_migrate_manifest_path)"
+  if ! bridge_isolation_v2_migrate_mirror_all "$data_root" "$snapshot" "$manifest"; then
+    bridge_warn "mirror reported failures — marker NOT written; legacy tree intact; restarting agents on legacy"
+    bridge_isolation_v2_migrate_orchestrate_restart "$snapshot"
+    bridge_die "apply aborted at mirror step (manifest=$manifest)"
+  fi
+
+  bridge_isolation_v2_migrate_marker_write "$data_root"
+
+  bridge_isolation_v2_migrate_orchestrate_restart "$snapshot"
+
+  if ! bridge_isolation_v2_migrate_postflight_groups "$snapshot"; then
+    bridge_warn "post-flight group probe reported issues — investigate before --commit"
+  fi
+
+  printf 'apply ok: marker=%s manifest=%s\n' \
+    "$(bridge_isolation_v2_marker_path)" "$manifest"
+}
+
+bridge_isolation_v2_migrate_rollback() {
+  bridge_isolation_v2_migrate_acquire_lock
+  bridge_isolation_v2_migrate_capture_active_snapshot
+  local snapshot
+  snapshot="$(bridge_isolation_v2_migrate_active_snapshot_path)"
+
+  bridge_isolation_v2_migrate_self_stop_guard "$snapshot"
+
+  bridge_isolation_v2_migrate_orchestrate_stop "$snapshot"
+  bridge_isolation_v2_migrate_marker_remove
+  bridge_isolation_v2_migrate_orchestrate_restart "$snapshot"
+
+  printf 'rollback ok: marker removed; legacy tree intact\n'
+}
+
+bridge_isolation_v2_migrate_commit() {
+  bridge_isolation_v2_migrate_acquire_lock
+
+  if ! bridge_isolation_v2_active; then
+    bridge_die "commit requires v2 active (marker present + valid)"
+  fi
+
+  local manifest
+  manifest="$(bridge_isolation_v2_migrate_manifest_path)"
+  [[ -f "$manifest" ]] || bridge_die "no manifest at $manifest — apply must have run first"
+
+  local stamp tarball candidate
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  tarball="$(bridge_isolation_v2_migrate_backup_tarball_path "$stamp")"
+
+  local -a candidates=()
+  while IFS= read -r candidate; do
+    [[ -n "$candidate" && -e "$candidate" ]] || continue
+    candidates+=("$candidate")
+  done < <(bridge_isolation_v2_migrate_legacy_data_paths)
+
+  if (( ${#candidates[@]} == 0 )); then
+    printf 'commit: nothing to delete (no manifest rows with verify_status=ok && delete_eligible=1)\n'
+    return 0
+  fi
+
+  printf 'commit candidates (%d):\n' "${#candidates[@]}"
+  printf '  %s\n' "${candidates[@]}"
+
+  if [[ "${BRIDGE_ISOLATION_V2_MIGRATE_YES:-0}" != "1" ]]; then
+    bridge_die "refusing to delete without --yes"
+  fi
+
+  # Backup tarball first.
+  if command -v zstd >/dev/null 2>&1; then
+    tar --zstd -cf "$tarball" "${candidates[@]}" 2>/dev/null \
+      || bridge_die "backup tarball creation failed"
+  else
+    tarball="${tarball%.zst}"
+    tar -cf "$tarball" "${candidates[@]}" 2>/dev/null \
+      || bridge_die "backup tarball creation failed"
+  fi
+  chmod 0640 "$tarball" || true
+
+  # Delete.
+  local cand
+  for cand in "${candidates[@]}"; do
+    rm -rf -- "$cand" || bridge_warn "delete failed: $cand"
+  done
+
+  printf 'commit ok: deleted %d path(s); backup at %s\n' "${#candidates[@]}" "$tarball"
+}
+
+bridge_isolation_v2_migrate_status() {
+  local marker_path
+  marker_path="$(bridge_isolation_v2_marker_path)"
+  printf 'marker: %s\n' "$marker_path"
+  if [[ -f "$marker_path" ]]; then
+    if bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
+      printf 'marker_valid: yes\n'
+    else
+      printf 'marker_valid: no\n'
+    fi
+    printf '---\n'
+    cat "$marker_path"
+    printf '---\n'
+  else
+    printf 'marker_valid: absent\n'
+  fi
+  printf 'isolation_v2_active: %s\n' \
+    "$(bridge_isolation_v2_active && echo yes || echo no)"
+
+  local manifest
+  manifest="$(bridge_isolation_v2_migrate_manifest_path)"
+  if [[ -f "$manifest" ]]; then
+    local total ok delete_elig
+    total="$(wc -l < "$manifest" | tr -d ' ')"
+    ok="$(awk -F'\t' '$8 == "ok"' "$manifest" | wc -l | tr -d ' ')"
+    delete_elig="$(awk -F'\t' '$8 == "ok" && $9 == "1"' "$manifest" | wc -l | tr -d ' ')"
+    printf 'manifest: %s  total=%s  ok=%s  delete_eligible=%s\n' \
+      "$manifest" "$total" "$ok" "$delete_elig"
+  else
+    printf 'manifest: (none)\n'
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# 12. CLI dispatch
+# ---------------------------------------------------------------------------
+
+bridge_isolation_v2_migrate_cli() {
+  local sub="${1:-}"
+  shift || true
+
+  case "$sub" in
+    dry-run)
+      local data_root=""
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --data-root) data_root="$2"; shift 2 ;;
+          *) bridge_die "unknown dry-run option: $1" ;;
+        esac
+      done
+      [[ -n "$data_root" ]] || bridge_die "Usage: agent-bridge migrate isolation-v2 dry-run --data-root <path>"
+      bridge_isolation_v2_migrate_dry_run "$data_root"
+      ;;
+    apply)
+      local data_root=""
+      local yes=0
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --data-root) data_root="$2"; shift 2 ;;
+          --yes) yes=1; shift ;;
+          *) bridge_die "unknown apply option: $1" ;;
+        esac
+      done
+      (( yes == 1 )) || bridge_die "Usage: agent-bridge migrate isolation-v2 apply --data-root <path> --yes"
+      bridge_isolation_v2_migrate_apply "$data_root"
+      ;;
+    rollback)
+      local yes=0
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --yes) yes=1; shift ;;
+          *) bridge_die "unknown rollback option: $1" ;;
+        esac
+      done
+      (( yes == 1 )) || bridge_die "Usage: agent-bridge migrate isolation-v2 rollback --yes"
+      bridge_isolation_v2_migrate_rollback
+      ;;
+    commit)
+      local yes=0
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --yes) yes=1; shift ;;
+          *) bridge_die "unknown commit option: $1" ;;
+        esac
+      done
+      (( yes == 1 )) || bridge_die "Usage: agent-bridge migrate isolation-v2 commit --yes"
+      BRIDGE_ISOLATION_V2_MIGRATE_YES=1 bridge_isolation_v2_migrate_commit
+      ;;
+    status)
+      bridge_isolation_v2_migrate_status
+      ;;
+    ""|-h|--help|help)
+      cat <<'USAGE'
+Usage: agent-bridge migrate isolation-v2 <subcommand> [options]
+Subcommands:
+  dry-run --data-root <path>       Print the legacy→v2 mirror plan + profile_home preflight (no mutation).
+  apply   --data-root <path> --yes Stop active agents+daemon, mirror, ensure groups, write marker, restart.
+  rollback --yes                   Stop, remove marker, restart on legacy. Idempotent on absent marker.
+  commit  --yes                    Tar-zst backup + delete legacy paths recorded in manifest as
+                                   verify_status=ok && delete_eligible=1.
+  status                           Print marker + manifest summary.
+
+Notes:
+  - apply/rollback refuse when invoked from inside an Agent Bridge agent
+    session whose own id is in the active snapshot (self-stop guard).
+  - Run from an out-of-band controller shell with sudo available.
+USAGE
+      ;;
+    *)
+      bridge_die "unknown isolation-v2 subcommand: $sub"
+      ;;
+  esac
+}

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -440,21 +440,38 @@ bridge_isolation_v2_migrate_normalize_layout() {
       || { bridge_warn "normalize_layout: state/ chgrp_setgid_recursive failed"; return 1; }
   fi
 
-  local agent agent_grp
+  # Per-agent root must be 2750 (isolated UID enters via group r-x but
+  # MUST NOT have group write at the root, otherwise it could rename or
+  # delete credentials/ even though credentials/ itself is 2750). r3
+  # review caught the broad recursive 2770 pass making the root
+  # writable. Spec: lib/bridge-isolation-v2.sh:45-59 +
+  # lib/bridge-agents.sh:2116-2152 (`# 2750 — isolated UID r-x at root`).
+  local agent agent_grp agent_root sub
+  local writable_subs=(home workdir runtime logs requests responses)
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
     agent_grp="$(bridge_isolation_v2_agent_group_name "$agent")"
-    if [[ -d "$data_root/agents/$agent" ]]; then
-      # Whole agent root: dir 2770 (group rwx + setgid), file 0660.
+    agent_root="$data_root/agents/$agent"
+    [[ -d "$agent_root" ]] || continue
+
+    # Per-agent root: SINGLE-DIR normalize at 2750. No recursion.
+    bridge_isolation_v2_chgrp_setgid_dir "$agent_grp" 2750 "$agent_root" \
+      || { bridge_warn "normalize_layout: agents/$agent root chgrp_setgid_dir failed"; return 1; }
+
+    # Writable children: 2770/0660 recursive (group rwx + setgid +
+    # files group-rw so the isolated UID can write its runtime state).
+    for sub in "${writable_subs[@]}"; do
+      [[ -d "$agent_root/$sub" ]] || continue
       bridge_isolation_v2_chgrp_setgid_recursive \
-        "$agent_grp" 2770 0660 "$data_root/agents/$agent" \
-        || { bridge_warn "normalize_layout: agents/$agent chgrp_setgid_recursive failed"; return 1; }
-    fi
-    # credentials/ holds controller-private secrets — tighter modes
-    # (dir 2750, file 0640). Re-run after the broad pass so it overrides.
-    if [[ -d "$data_root/agents/$agent/credentials" ]]; then
+        "$agent_grp" 2770 0660 "$agent_root/$sub" \
+        || { bridge_warn "normalize_layout: agents/$agent/$sub chgrp_setgid_recursive failed"; return 1; }
+    done
+
+    # credentials/: tighter modes — controller writes, isolated UID
+    # gets group r-x dir + group r files only.
+    if [[ -d "$agent_root/credentials" ]]; then
       bridge_isolation_v2_chgrp_setgid_recursive \
-        "$agent_grp" 2750 0640 "$data_root/agents/$agent/credentials" \
+        "$agent_grp" 2750 0640 "$agent_root/credentials" \
         || { bridge_warn "normalize_layout: agents/$agent/credentials chgrp_setgid_recursive failed"; return 1; }
     fi
   done < "$snapshot_path"

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -378,12 +378,14 @@ bridge_isolation_v2_migrate_mirror_all() {
 # ---------------------------------------------------------------------------
 
 bridge_isolation_v2_migrate_ensure_groups_and_memberships() {
-  # Group creation + user membership additions + path ownership
-  # normalization, all in one operation. Uses BRIDGE_SHARED_GROUP /
-  # BRIDGE_CONTROLLER_GROUP / BRIDGE_AGENT_GROUP_PREFIX overrides if
-  # the marker provided them; defaults match lib/bridge-isolation-v2.sh.
+  # Group creation + user membership additions only. Honors
+  # BRIDGE_SHARED_GROUP / BRIDGE_CONTROLLER_GROUP / BRIDGE_AGENT_GROUP_PREFIX
+  # overrides; defaults match lib/bridge-isolation-v2.sh.
+  # Path ownership/mode normalization is a SEPARATE step
+  # (`bridge_isolation_v2_migrate_normalize_layout`) run AFTER mirror_all
+  # creates the destination tree — calling it here would no-op because
+  # the dirs do not exist yet. r2 review (P1 #1).
   local snapshot_path="$1"
-  local data_root="$2"
   local controller_user="${SUDO_USER:-${USER:-}}"
   local shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
   local ctrl_grp="${BRIDGE_CONTROLLER_GROUP:-ab-controller}"
@@ -411,38 +413,78 @@ bridge_isolation_v2_migrate_ensure_groups_and_memberships() {
     fi
   done < "$snapshot_path"
 
-  # Normalize ownership/mode on the migrated trees per the v2 layout
-  # spec (lib/bridge-isolation-v2.sh:36-65). Without this step the
-  # share-plugin-catalog / per-agent traverse paths cannot reach the
-  # files even with correct group memberships.
+  return 0
+}
+
+bridge_isolation_v2_migrate_normalize_layout() {
+  # chgrp + setgid + mode normalization on migrated trees. Called AFTER
+  # mirror_all so the destination paths actually exist. Each
+  # bridge_isolation_v2_chgrp_setgid_recursive call uses the helper's
+  # actual signature: (group, dir_mode, file_mode, root).
+  # Failures propagate so apply dies with a clear error — silent
+  # `2>/dev/null || true` was the r2 P1 #1 root cause.
+  local snapshot_path="$1"
+  local data_root="$2"
+  local shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+  local ctrl_grp="${BRIDGE_CONTROLLER_GROUP:-ab-controller}"
+
   if [[ -d "$data_root/shared" ]]; then
-    bridge_isolation_v2_chgrp_setgid_recursive "$data_root/shared" "$shared_grp" 2>/dev/null || true
+    bridge_isolation_v2_chgrp_setgid_recursive \
+      "$shared_grp" 2750 0640 "$data_root/shared" \
+      || { bridge_warn "normalize_layout: shared/ chgrp_setgid_recursive failed"; return 1; }
   fi
+
   if [[ -d "$data_root/state" ]]; then
-    bridge_isolation_v2_chgrp_setgid_recursive "$data_root/state" "$ctrl_grp" 2>/dev/null || true
+    bridge_isolation_v2_chgrp_setgid_recursive \
+      "$ctrl_grp" 2750 0640 "$data_root/state" \
+      || { bridge_warn "normalize_layout: state/ chgrp_setgid_recursive failed"; return 1; }
   fi
+
+  local agent agent_grp
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
     agent_grp="$(bridge_isolation_v2_agent_group_name "$agent")"
     if [[ -d "$data_root/agents/$agent" ]]; then
-      bridge_isolation_v2_chgrp_setgid_recursive "$data_root/agents/$agent" "$agent_grp" 2>/dev/null || true
+      # Whole agent root: dir 2770 (group rwx + setgid), file 0660.
+      bridge_isolation_v2_chgrp_setgid_recursive \
+        "$agent_grp" 2770 0660 "$data_root/agents/$agent" \
+        || { bridge_warn "normalize_layout: agents/$agent chgrp_setgid_recursive failed"; return 1; }
+    fi
+    # credentials/ holds controller-private secrets — tighter modes
+    # (dir 2750, file 0640). Re-run after the broad pass so it overrides.
+    if [[ -d "$data_root/agents/$agent/credentials" ]]; then
+      bridge_isolation_v2_chgrp_setgid_recursive \
+        "$agent_grp" 2750 0640 "$data_root/agents/$agent/credentials" \
+        || { bridge_warn "normalize_layout: agents/$agent/credentials chgrp_setgid_recursive failed"; return 1; }
     fi
   done < "$snapshot_path"
+
   return 0
 }
 
 bridge_isolation_v2_migrate_postflight_groups() {
   local snapshot_path="$1"
   local controller_user="${SUDO_USER:-${USER:-}}"
+  local shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+  local ctrl_grp="${BRIDGE_CONTROLLER_GROUP:-ab-controller}"
   local agent groups os_user
   local mismatch=0
 
-  # Controller fresh probe.
+  # Controller fresh probe — must be in shared+controller groups.
   if [[ -n "$controller_user" ]]; then
     groups="$(sudo -n -u "$controller_user" id -nG 2>/dev/null || true)"
     if [[ -z "$groups" ]]; then
       bridge_warn "postflight: cannot fresh-probe controller groups for $controller_user"
       mismatch=1
+    else
+      if ! grep -qw "$shared_grp" <<<"$groups"; then
+        bridge_warn "postflight: controller $controller_user missing group $shared_grp; got: $groups"
+        mismatch=1
+      fi
+      if ! grep -qw "$ctrl_grp" <<<"$groups"; then
+        bridge_warn "postflight: controller $controller_user missing group $ctrl_grp; got: $groups"
+        mismatch=1
+      fi
     fi
   fi
 
@@ -462,8 +504,8 @@ bridge_isolation_v2_migrate_postflight_groups() {
       bridge_warn "postflight: $os_user (agent $agent) missing group $agent_group; got: $groups"
       mismatch=1
     fi
-    if ! grep -qw "ab-shared" <<<"$groups"; then
-      bridge_warn "postflight: $os_user (agent $agent) missing group ab-shared; got: $groups"
+    if ! grep -qw "$shared_grp" <<<"$groups"; then
+      bridge_warn "postflight: $os_user (agent $agent) missing group $shared_grp; got: $groups"
       mismatch=1
     fi
   done < "$snapshot_path"
@@ -642,8 +684,8 @@ bridge_isolation_v2_migrate_apply() {
 
   bridge_isolation_v2_migrate_orchestrate_stop "$snapshot"
 
-  bridge_isolation_v2_migrate_ensure_groups_and_memberships "$snapshot" "$data_root" \
-    || bridge_die "group ensure / membership / normalize failed"
+  bridge_isolation_v2_migrate_ensure_groups_and_memberships "$snapshot" \
+    || bridge_die "group ensure / membership failed"
 
   local manifest
   manifest="$(bridge_isolation_v2_migrate_manifest_path)"
@@ -651,6 +693,12 @@ bridge_isolation_v2_migrate_apply() {
     bridge_warn "mirror reported failures — marker NOT written; legacy tree intact; restarting agents on legacy"
     bridge_isolation_v2_migrate_orchestrate_restart "$snapshot"
     bridge_die "apply aborted at mirror step (manifest=$manifest)"
+  fi
+
+  if ! bridge_isolation_v2_migrate_normalize_layout "$snapshot" "$data_root"; then
+    bridge_warn "layout normalize failed — marker NOT written; legacy tree intact; restarting agents on legacy"
+    bridge_isolation_v2_migrate_orchestrate_restart "$snapshot"
+    bridge_die "apply aborted at normalize step (manifest=$manifest)"
   fi
 
   bridge_isolation_v2_migrate_marker_write "$data_root"

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -664,9 +664,17 @@ bridge_isolation_v2_migrate_dry_run() {
   local snapshot
   snapshot="$(bridge_isolation_v2_migrate_active_snapshot_path)"
 
+  local active_count
+  active_count="$(wc -l < "$snapshot" | tr -d ' ')"
+
   printf '== isolation-v2 migrate dry-run ==\n'
   printf 'data_root: %s\n' "$data_root"
-  printf 'active agents: %s\n' "$(wc -l < "$snapshot" | tr -d ' ')"
+  printf 'BRIDGE_LAYOUT: %s\n' "${BRIDGE_LAYOUT:-legacy}"
+  printf 'active agents: %s\n' "$active_count"
+  if [[ "${BRIDGE_LAYOUT:-legacy}" != "v2" ]]; then
+    printf '(BRIDGE_LAYOUT currently %s — would migrate %s agents; set BRIDGE_LAYOUT=v2 + BRIDGE_DATA_ROOT=<path> before --apply)\n' \
+      "${BRIDGE_LAYOUT:-legacy}" "$active_count"
+  fi
   printf '\n-- mirror plan (mapping_id  src  dst  delete_eligible) --\n'
   bridge_isolation_v2_migrate_emit_plan "$data_root" "$snapshot"
 
@@ -682,6 +690,14 @@ bridge_isolation_v2_migrate_apply() {
   local data_root="$1"
   [[ -n "$data_root" && "${data_root:0:1}" == "/" ]] \
     || bridge_die "--apply requires --data-root <absolute-path>"
+
+  # Fail-fast on legacy installs. Operators must opt in to v2 before
+  # running the mutation paths; otherwise the marker flip lands on an
+  # install whose runtime is still wired to legacy paths.
+  if [[ "${BRIDGE_LAYOUT:-legacy}" != "v2" ]]; then
+    bridge_die "migrate apply requires BRIDGE_LAYOUT=v2 (currently: ${BRIDGE_LAYOUT:-legacy}). Set BRIDGE_LAYOUT=v2 + BRIDGE_DATA_ROOT=<path> in the controller environment before running the migration tool."
+  fi
+
   if bridge_isolation_v2_active; then
     bridge_warn "v2 already active — apply is idempotent only when --data-root matches; proceeding will re-mirror."
   fi
@@ -690,6 +706,14 @@ bridge_isolation_v2_migrate_apply() {
   bridge_isolation_v2_migrate_capture_active_snapshot
   local snapshot
   snapshot="$(bridge_isolation_v2_migrate_active_snapshot_path)"
+
+  # Empty active snapshot — no-op cleanly rather than silently mirroring
+  # zero rows. Operators expect a clear signal when there are no active
+  # claude agents to migrate.
+  if [[ ! -s "$snapshot" ]]; then
+    printf '[migrate] no active claude agents to migrate; nothing to do.\n'
+    return 0
+  fi
 
   bridge_isolation_v2_migrate_self_stop_guard "$snapshot"
 
@@ -731,6 +755,14 @@ bridge_isolation_v2_migrate_apply() {
 }
 
 bridge_isolation_v2_migrate_rollback() {
+  # Fail-fast on legacy installs. Rollback removes the v2 marker; if the
+  # install was never v2 there is nothing to roll back, and silent
+  # daemon stop/restart cycles on a legacy install would surprise the
+  # operator.
+  if [[ "${BRIDGE_LAYOUT:-legacy}" != "v2" ]]; then
+    bridge_die "migrate rollback requires BRIDGE_LAYOUT=v2 (currently: ${BRIDGE_LAYOUT:-legacy}). Rollback only makes sense on a v2-active install."
+  fi
+
   bridge_isolation_v2_migrate_acquire_lock
   bridge_isolation_v2_migrate_capture_active_snapshot
   local snapshot
@@ -746,6 +778,14 @@ bridge_isolation_v2_migrate_rollback() {
 }
 
 bridge_isolation_v2_migrate_commit() {
+  # Fail-fast on legacy installs. Commit deletes legacy paths recorded in
+  # the manifest; running on a legacy install would either no-op
+  # confusingly or — worse, if a stale manifest is around — delete data
+  # the runtime is still reading.
+  if [[ "${BRIDGE_LAYOUT:-legacy}" != "v2" ]]; then
+    bridge_die "migrate commit requires BRIDGE_LAYOUT=v2 (currently: ${BRIDGE_LAYOUT:-legacy}). Commit deletes legacy data and is only safe after apply has succeeded and the marker is active."
+  fi
+
   bridge_isolation_v2_migrate_acquire_lock
 
   if ! bridge_isolation_v2_active; then
@@ -887,6 +927,12 @@ bridge_isolation_v2_migrate_cli() {
       BRIDGE_ISOLATION_V2_MIGRATE_YES=1 bridge_isolation_v2_migrate_commit
       ;;
     status)
+      # status is read-only and works on any layout; reject extra
+      # positional args so typos like `status --json` (unsupported) don't
+      # silently succeed.
+      if (( $# > 0 )); then
+        bridge_die "migrate isolation-v2 status: unexpected extra args: $*"
+      fi
       bridge_isolation_v2_migrate_status
       ;;
     ""|-h|--help|help)

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -251,20 +251,35 @@ bridge_isolation_v2_migrate_emit_row() {
 # ---------------------------------------------------------------------------
 
 bridge_isolation_v2_migrate_sha256_of() {
-  # Print sha256 of a path. For files, hash the bytes. For dirs, hash
-  # the sorted concatenation of (relpath, sha256) lines so two trees
-  # with identical content compare equal regardless of inode/atime.
+  # Print sha256 of a path. For regular files, hash the bytes. For
+  # symlinks, hash the link kind + readlink target. For directories,
+  # walk every regular file AND symlink so a tree containing symlinks
+  # is verified — the previous `-type f` filter let symlink drops
+  # under `rsync -a` slip through as verify_status=ok.
   local target="$1"
-  if [[ -f "$target" && ! -L "$target" ]]; then
+  if [[ -L "$target" ]]; then
+    printf 'symlink:%s' "$(readlink "$target" 2>/dev/null || printf 'unreadable')" \
+      | sha256sum | awk '{print $1}'
+    return
+  fi
+  if [[ -f "$target" ]]; then
     sha256sum "$target" 2>/dev/null | awk '{print $1}'
     return
   fi
   if [[ -d "$target" ]]; then
     (
       cd "$target" 2>/dev/null || exit 0
-      find . -type f -print0 2>/dev/null \
+      find . \( -type f -o -type l \) -print0 2>/dev/null \
         | sort -z \
-        | xargs -0 sha256sum 2>/dev/null
+        | while IFS= read -r -d '' p; do
+            if [[ -L "$p" ]]; then
+              printf 'symlink:%s\t%s\n' "$p" \
+                "$(readlink "$p" 2>/dev/null || printf 'unreadable')"
+            elif [[ -f "$p" ]]; then
+              printf 'file:%s\t%s\n' "$p" \
+                "$(sha256sum "$p" 2>/dev/null | awk '{print $1}')"
+            fi
+          done
     ) | sha256sum | awk '{print $1}'
     return
   fi
@@ -302,16 +317,18 @@ bridge_isolation_v2_migrate_mirror_one() {
     mkdir -p "$dst_parent" 2>/dev/null
   fi
 
-  # Real copy. -a preserves perm/owner/time. -X xattrs. --numeric-ids
-  # avoids name lookups on the destination side. --no-links so symlinks
-  # are followed (rare in the layouts we mirror; if a symlink is later
-  # discovered we treat it as runtime).
+  # Real copy. -a preserves perm/owner/time AND symlinks (-l is part of
+  # -a). -H preserves hardlinks. -X preserves xattrs. --numeric-ids
+  # skips name lookups on the destination side. NOTE: do not use
+  # --no-links — it disables symlink copying entirely, which previously
+  # let symlink-bearing trees pass verify_status=ok with the symlinks
+  # silently dropped (caught by the dev-codex r1 review).
   local rc=0
   if [[ -d "$legacy_src" ]]; then
-    rsync -aHX --numeric-ids --no-links --delete-excluded \
+    rsync -aHX --numeric-ids --delete-excluded \
       "$legacy_src/" "$v2_dst/" >/dev/null 2>&1 || rc=$?
   else
-    rsync -aHX --numeric-ids --no-links \
+    rsync -aHX --numeric-ids \
       "$legacy_src" "$v2_dst" >/dev/null 2>&1 || rc=$?
   fi
   if (( rc != 0 )); then
@@ -360,17 +377,56 @@ bridge_isolation_v2_migrate_mirror_all() {
 # 6. group ensure + post-flight probe
 # ---------------------------------------------------------------------------
 
-bridge_isolation_v2_migrate_ensure_groups() {
+bridge_isolation_v2_migrate_ensure_groups_and_memberships() {
+  # Group creation + user membership additions + path ownership
+  # normalization, all in one operation. Uses BRIDGE_SHARED_GROUP /
+  # BRIDGE_CONTROLLER_GROUP / BRIDGE_AGENT_GROUP_PREFIX overrides if
+  # the marker provided them; defaults match lib/bridge-isolation-v2.sh.
   local snapshot_path="$1"
-  local _g
-  for _g in "ab-shared" "ab-controller"; do
-    bridge_isolation_v2_ensure_group "$_g" || return 1
-  done
-  local agent
+  local data_root="$2"
+  local controller_user="${SUDO_USER:-${USER:-}}"
+  local shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+  local ctrl_grp="${BRIDGE_CONTROLLER_GROUP:-ab-controller}"
+
+  bridge_isolation_v2_ensure_group "$shared_grp" || return 1
+  bridge_isolation_v2_ensure_group "$ctrl_grp" || return 1
+
+  if [[ -n "$controller_user" ]]; then
+    bridge_isolation_v2_ensure_user_in_group "$controller_user" "$shared_grp" || return 1
+    bridge_isolation_v2_ensure_user_in_group "$controller_user" "$ctrl_grp" || return 1
+  fi
+
+  local agent agent_grp os_user
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
-    bridge_isolation_v2_ensure_group "$(bridge_isolation_v2_agent_group_name "$agent")" \
-      || return 1
+    agent_grp="$(bridge_isolation_v2_agent_group_name "$agent")"
+    bridge_isolation_v2_ensure_group "$agent_grp" || return 1
+    os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || true)"
+    if [[ -n "$os_user" ]]; then
+      bridge_isolation_v2_ensure_user_in_group "$os_user" "$shared_grp" || return 1
+      bridge_isolation_v2_ensure_user_in_group "$os_user" "$agent_grp" || return 1
+    fi
+    if [[ -n "$controller_user" ]]; then
+      bridge_isolation_v2_ensure_user_in_group "$controller_user" "$agent_grp" || return 1
+    fi
+  done < "$snapshot_path"
+
+  # Normalize ownership/mode on the migrated trees per the v2 layout
+  # spec (lib/bridge-isolation-v2.sh:36-65). Without this step the
+  # share-plugin-catalog / per-agent traverse paths cannot reach the
+  # files even with correct group memberships.
+  if [[ -d "$data_root/shared" ]]; then
+    bridge_isolation_v2_chgrp_setgid_recursive "$data_root/shared" "$shared_grp" 2>/dev/null || true
+  fi
+  if [[ -d "$data_root/state" ]]; then
+    bridge_isolation_v2_chgrp_setgid_recursive "$data_root/state" "$ctrl_grp" 2>/dev/null || true
+  fi
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    agent_grp="$(bridge_isolation_v2_agent_group_name "$agent")"
+    if [[ -d "$data_root/agents/$agent" ]]; then
+      bridge_isolation_v2_chgrp_setgid_recursive "$data_root/agents/$agent" "$agent_grp" 2>/dev/null || true
+    fi
   done < "$snapshot_path"
   return 0
 }
@@ -586,8 +642,8 @@ bridge_isolation_v2_migrate_apply() {
 
   bridge_isolation_v2_migrate_orchestrate_stop "$snapshot"
 
-  bridge_isolation_v2_migrate_ensure_groups "$snapshot" \
-    || bridge_die "group ensure failed"
+  bridge_isolation_v2_migrate_ensure_groups_and_memberships "$snapshot" "$data_root" \
+    || bridge_die "group ensure / membership / normalize failed"
 
   local manifest
   manifest="$(bridge_isolation_v2_migrate_manifest_path)"
@@ -602,7 +658,7 @@ bridge_isolation_v2_migrate_apply() {
   bridge_isolation_v2_migrate_orchestrate_restart "$snapshot"
 
   if ! bridge_isolation_v2_migrate_postflight_groups "$snapshot"; then
-    bridge_warn "post-flight group probe reported issues — investigate before --commit"
+    bridge_die "post-flight group probe reported missing memberships — v2 plugin/share path will be broken; rollback before retrying"
   fi
 
   printf 'apply ok: marker=%s manifest=%s\n' \

--- a/lib/bridge-marker-bootstrap.sh
+++ b/lib/bridge-marker-bootstrap.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# bridge-marker-bootstrap.sh — Read v2 layout marker
+# (BRIDGE_LAYOUT/BRIDGE_DATA_ROOT) from $BRIDGE_STATE_DIR/layout-marker.sh
+# with strict validation, before bridge-isolation-v2.sh snapshots those env
+# vars. Sourced from bridge-lib.sh after bridge-core.sh (so bridge_warn is
+# available) and before bridge-isolation-v2.sh.
+#
+# Validation:
+#   - regular file, not symlink
+#   - owner is root (UID 0) or current controller (caller's UID)
+#   - mode has no group/world write bits
+#   - content lines match an allowlist of KEY=value assignments
+#   - when BRIDGE_LAYOUT=v2, BRIDGE_DATA_ROOT must be absolute non-empty
+#
+# Failures fall back silently to legacy (BRIDGE_LAYOUT defaults to "legacy"
+# in bridge-isolation-v2.sh). bridge_warn surfaces the reason once per
+# process so operators can investigate.
+# shellcheck shell=bash disable=SC2034
+
+bridge_isolation_v2_marker_path() {
+  printf '%s/layout-marker.sh' \
+    "${BRIDGE_STATE_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/state}"
+}
+
+bridge_isolation_v2_marker_validate() {
+  local path="${1:-}"
+  [[ -n "$path" ]] || return 1
+  [[ -f "$path" && ! -L "$path" ]] || return 1
+
+  local owner_uid mode_oct mode_int
+  owner_uid="$(stat -c '%u' "$path" 2>/dev/null)"
+  if [[ -z "$owner_uid" ]]; then
+    return 1
+  fi
+  if (( owner_uid != 0 )); then
+    local controller_uid
+    controller_uid="$(id -u 2>/dev/null || true)"
+    if [[ -z "$controller_uid" || "$owner_uid" != "$controller_uid" ]]; then
+      bridge_warn "layout-marker.sh ignored: owner UID $owner_uid is neither root nor current controller"
+      return 1
+    fi
+  fi
+
+  mode_oct="$(stat -c '%a' "$path" 2>/dev/null)"
+  if [[ -z "$mode_oct" ]]; then
+    return 1
+  fi
+  mode_int=$(( 8#$mode_oct ))
+  if (( mode_int & 0022 )); then
+    bridge_warn "layout-marker.sh ignored: mode $mode_oct has group or world write bit"
+    return 1
+  fi
+
+  local allowed_re='^(BRIDGE_LAYOUT|BRIDGE_DATA_ROOT|BRIDGE_SHARED_GROUP|BRIDGE_CONTROLLER_GROUP|BRIDGE_AGENT_GROUP_PREFIX)=.+$'
+  local line saw_layout=0 layout_value="" data_root_value=""
+  while IFS= read -r line; do
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    if ! [[ "$line" =~ $allowed_re ]]; then
+      bridge_warn "layout-marker.sh ignored: disallowed line '$line'"
+      return 1
+    fi
+    case "$line" in
+      BRIDGE_LAYOUT=*)
+        saw_layout=1
+        layout_value="${line#BRIDGE_LAYOUT=}"
+        ;;
+      BRIDGE_DATA_ROOT=*)
+        data_root_value="${line#BRIDGE_DATA_ROOT=}"
+        ;;
+    esac
+  done < "$path"
+
+  if (( saw_layout == 1 )); then
+    local _lv="$layout_value"
+    _lv="${_lv#\'}"; _lv="${_lv%\'}"
+    _lv="${_lv#\"}"; _lv="${_lv%\"}"
+    if [[ "$_lv" == "v2" ]]; then
+      local _dr="$data_root_value"
+      _dr="${_dr#\'}"; _dr="${_dr%\'}"
+      _dr="${_dr#\"}"; _dr="${_dr%\"}"
+      if [[ -z "$_dr" || "${_dr:0:1}" != "/" ]]; then
+        bridge_warn "layout-marker.sh ignored: BRIDGE_DATA_ROOT must be absolute, got '$data_root_value'"
+        return 1
+      fi
+    fi
+  fi
+
+  return 0
+}
+
+bridge_isolation_v2_marker_load() {
+  local path
+  path="$(bridge_isolation_v2_marker_path)"
+  [[ -f "$path" ]] || return 0
+  if bridge_isolation_v2_marker_validate "$path"; then
+    # shellcheck source=/dev/null
+    . "$path"
+  fi
+}
+
+# Auto-load: bridge-lib.sh sources this module after bridge-core.sh and
+# before bridge-isolation-v2.sh, so v2 helpers see the marker values when
+# they snapshot BRIDGE_LAYOUT/BRIDGE_DATA_ROOT.
+bridge_isolation_v2_marker_load

--- a/lib/bridge-marker-bootstrap.sh
+++ b/lib/bridge-marker-bootstrap.sh
@@ -51,8 +51,8 @@ bridge_isolation_v2_marker_validate() {
     return 1
   fi
 
-  local allowed_re='^(BRIDGE_LAYOUT|BRIDGE_DATA_ROOT|BRIDGE_SHARED_GROUP|BRIDGE_CONTROLLER_GROUP|BRIDGE_AGENT_GROUP_PREFIX)=.+$'
-  local line saw_layout=0 layout_value="" data_root_value=""
+  local allowed_re='^(BRIDGE_LAYOUT|BRIDGE_DATA_ROOT|BRIDGE_SHARED_GROUP|BRIDGE_CONTROLLER_GROUP|BRIDGE_AGENT_GROUP_PREFIX)=.*$'
+  local line key raw value saw_layout=0 layout_value="" data_root_value=""
   while IFS= read -r line; do
     [[ -z "${line//[[:space:]]/}" ]] && continue
     [[ "$line" =~ ^[[:space:]]*# ]] && continue
@@ -60,43 +60,89 @@ bridge_isolation_v2_marker_validate() {
       bridge_warn "layout-marker.sh ignored: disallowed line '$line'"
       return 1
     fi
-    case "$line" in
-      BRIDGE_LAYOUT=*)
-        saw_layout=1
-        layout_value="${line#BRIDGE_LAYOUT=}"
-        ;;
-      BRIDGE_DATA_ROOT=*)
-        data_root_value="${line#BRIDGE_DATA_ROOT=}"
-        ;;
+    key="${line%%=*}"
+    raw="${line#*=}"
+    if ! bridge_isolation_v2_marker_value_safe "$raw"; then
+      bridge_warn "layout-marker.sh ignored: unsafe value for $key"
+      return 1
+    fi
+    value="$(bridge_isolation_v2_marker_value_unquote "$raw")"
+    case "$key" in
+      BRIDGE_LAYOUT) saw_layout=1; layout_value="$value" ;;
+      BRIDGE_DATA_ROOT) data_root_value="$value" ;;
     esac
   done < "$path"
 
-  if (( saw_layout == 1 )); then
-    local _lv="$layout_value"
-    _lv="${_lv#\'}"; _lv="${_lv%\'}"
-    _lv="${_lv#\"}"; _lv="${_lv%\"}"
-    if [[ "$_lv" == "v2" ]]; then
-      local _dr="$data_root_value"
-      _dr="${_dr#\'}"; _dr="${_dr%\'}"
-      _dr="${_dr#\"}"; _dr="${_dr%\"}"
-      if [[ -z "$_dr" || "${_dr:0:1}" != "/" ]]; then
-        bridge_warn "layout-marker.sh ignored: BRIDGE_DATA_ROOT must be absolute, got '$data_root_value'"
-        return 1
-      fi
+  if (( saw_layout == 1 )) && [[ "$layout_value" == "v2" ]]; then
+    if [[ -z "$data_root_value" || "${data_root_value:0:1}" != "/" ]]; then
+      bridge_warn "layout-marker.sh ignored: BRIDGE_DATA_ROOT must be absolute, got '$data_root_value'"
+      return 1
     fi
   fi
 
   return 0
 }
 
+bridge_isolation_v2_marker_value_safe() {
+  # Strict value grammar. Reject any value that could trigger shell
+  # expansion (command/process/arithmetic substitution, backticks,
+  # redirect/pipe metacharacters, escapes, newlines, or globs) so the
+  # marker can never run code via the eventual export. Allowed forms:
+  #   - bare token: [A-Za-z0-9_./@:+-]+
+  #   - single-quoted token: '<bare token>' or empty ''
+  #   - double-quoted token: same content set
+  # Anything else is rejected.
+  local v="$1"
+  case "$v" in
+    *'$('*|*'$<'*|*'$>'*|*'$['*|*'$\\'*|*'`'*|*';'*|*'&'*|*'|'* \
+      |*'>'*|*'<'*|*'\\'*|*$'\n'*|*$'\r'*|*'*'*|*'?'*|*'~'* )
+      return 1
+      ;;
+  esac
+  if [[ "$v" =~ ^\'[A-Za-z0-9_./@:+-]*\'$ ]]; then
+    return 0
+  fi
+  if [[ "$v" =~ ^\"[A-Za-z0-9_./@:+-]*\"$ ]]; then
+    return 0
+  fi
+  if [[ "$v" =~ ^[A-Za-z0-9_./@:+-]+$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
+bridge_isolation_v2_marker_value_unquote() {
+  local v="$1"
+  v="${v#\'}"; v="${v%\'}"
+  v="${v#\"}"; v="${v%\"}"
+  printf '%s' "$v"
+}
+
 bridge_isolation_v2_marker_load() {
+  # Parse-and-export, do NOT source the marker. Sourcing would let any
+  # validated KEY=value line execute its value (e.g. command substitution),
+  # which the validator above explicitly cannot detect on shell-quoted
+  # bytes alone.
   local path
   path="$(bridge_isolation_v2_marker_path)"
   [[ -f "$path" ]] || return 0
-  if bridge_isolation_v2_marker_validate "$path"; then
-    # shellcheck source=/dev/null
-    . "$path"
-  fi
+  bridge_isolation_v2_marker_validate "$path" || return 0
+
+  local line key raw value
+  while IFS= read -r line; do
+    [[ -z "${line//[[:space:]]/}" ]] && continue
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    key="${line%%=*}"
+    raw="${line#*=}"
+    value="$(bridge_isolation_v2_marker_value_unquote "$raw")"
+    case "$key" in
+      BRIDGE_LAYOUT) export BRIDGE_LAYOUT="$value" ;;
+      BRIDGE_DATA_ROOT) export BRIDGE_DATA_ROOT="$value" ;;
+      BRIDGE_SHARED_GROUP) export BRIDGE_SHARED_GROUP="$value" ;;
+      BRIDGE_CONTROLLER_GROUP) export BRIDGE_CONTROLLER_GROUP="$value" ;;
+      BRIDGE_AGENT_GROUP_PREFIX) export BRIDGE_AGENT_GROUP_PREFIX="$value" ;;
+    esac
+  done < "$path"
 }
 
 # Auto-load: bridge-lib.sh sources this module after bridge-core.sh and

--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -142,16 +142,104 @@ PYEOF
 )
 
 # -------------------------------------------------------------------------
-# Lane B — non-daily captures for librarian ingest
+# Lane B — non-daily captures for librarian ingest.
+# Workdir-aware strict enumeration (PR-D / isolation v2 compatibility).
+# Does NOT source _common.sh — runs an inline strict probe so other callers
+# of list_active_claude_agents are unaffected by PR-D's stricter contract.
+# v2 활성 후 install-root memory 는 frozen snapshot 이라 새 file 안 들어옴;
+# `agb agent list --json` 의 workdir field 가 single source of truth.
+#
+# fail-closed semantics:
+#   - BRIDGE_AGB 미실행/비실행파일      → exit 2
+#   - `agent list --json` 호출 실패      → exit 2 + stderr
+#   - JSON parse 실패 또는 list 아님     → exit 2 + stderr
+#   - 정상 + 진짜 0 active claude agent  → silent OK, Lane B 0 카운트
+# 모든 fail 경로는 `_lane_b_stderr` 임시파일을 명시적으로 rm 한 뒤 exit
+# (기존 line ~101 의 COPY_JSON EXIT trap 을 손상하지 않기 위해 별도 trap 미사용).
 # -------------------------------------------------------------------------
 
-# Research files touched in last 24h.
-touched_research=$(find "$AGENTS_ROOT"/*/memory/research -type f -name '*.md' -mtime -1 2>/dev/null | sort)
+: "${BRIDGE_AGB:=$BRIDGE_HOME/agent-bridge}"
+: "${BRIDGE_PYTHON:=python3}"
+
+if [[ ! -x "$BRIDGE_AGB" ]]; then
+  printf '[wiki-daily-ingest] BRIDGE_AGB not executable: %s\n' "$BRIDGE_AGB" >&2
+  exit 2
+fi
+
+_lane_b_stderr="$(mktemp -t wiki-daily-ingest.agb-stderr.XXXXXX)"
+
+agent_list_json="$("$BRIDGE_AGB" agent list --json 2>"$_lane_b_stderr")"
+agb_exit=$?
+if (( agb_exit != 0 )); then
+  printf '[wiki-daily-ingest] agb agent list --json failed (exit=%d): %s\n' \
+    "$agb_exit" "$(cat "$_lane_b_stderr")" >&2
+  rm -f "$_lane_b_stderr"
+  exit 2
+fi
+
+agents_tsv="$("$BRIDGE_PYTHON" - "$agent_list_json" <<'PY' 2>"$_lane_b_stderr"
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+except Exception as e:
+    print(f"malformed JSON: {e}", file=sys.stderr)
+    sys.exit(2)
+if not isinstance(data, list):
+    print(f"expected JSON list, got {type(data).__name__}", file=sys.stderr)
+    sys.exit(2)
+for a in data:
+    if not isinstance(a, dict):
+        continue
+    if a.get("engine") != "claude" or not a.get("active"):
+        continue
+    name = a.get("agent") or ""
+    wd = a.get("workdir") or ""
+    if not name or not wd:
+        continue
+    print(f"{name}\t{wd}")
+PY
+)"
+parse_exit=$?
+if (( parse_exit != 0 )); then
+  printf '[wiki-daily-ingest] agent list JSON parse failed (exit=%d): %s\n' \
+    "$parse_exit" "$(cat "$_lane_b_stderr")" >&2
+  rm -f "$_lane_b_stderr"
+  exit 2
+fi
+rm -f "$_lane_b_stderr"
+
+declare -a AGENT_MEMORY_ROOTS=()
+if [[ -n "$agents_tsv" ]]; then
+  while IFS=$'\t' read -r _agent _workdir; do
+    [[ -n "$_agent" && -n "$_workdir" ]] || continue
+    [[ -d "$_workdir/memory" ]] || continue
+    AGENT_MEMORY_ROOTS+=("$_workdir/memory")
+  done <<< "$agents_tsv"
+fi
+
+# Research files touched in last 24h (across all active agent workdirs).
+touched_research=""
+for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
+  [[ -d "$_root/research" ]] || continue
+  while IFS= read -r _f; do
+    [[ -n "$_f" ]] && touched_research+="$_f"$'\n'
+  done < <(find "$_root/research" -type f -name '*.md' -mtime -1 2>/dev/null)
+done
+touched_research=$(printf '%s' "$touched_research" | sed '/^$/d' | sort -u)
 research_count=$(printf '%s\n' "$touched_research" | grep -c '[^[:space:]]' || true)
 research_count=${research_count:-0}
 
 # projects/shared/decisions files touched in last 24h.
-touched_other=$(find "$AGENTS_ROOT"/*/memory/projects "$AGENTS_ROOT"/*/memory/shared "$AGENTS_ROOT"/*/memory/decisions -type f -name '*.md' -mtime -1 2>/dev/null | sort)
+touched_other=""
+for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
+  for _sub in projects shared decisions; do
+    [[ -d "$_root/$_sub" ]] || continue
+    while IFS= read -r _f; do
+      [[ -n "$_f" ]] && touched_other+="$_f"$'\n'
+    done < <(find "$_root/$_sub" -type f -name '*.md' -mtime -1 2>/dev/null)
+  done
+done
+touched_other=$(printf '%s' "$touched_other" | sed '/^$/d' | sort -u)
 other_count=$(printf '%s\n' "$touched_other" | grep -c '[^[:space:]]' || true)
 other_count=${other_count:-0}
 

--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -143,13 +143,16 @@ PYEOF
 
 # -------------------------------------------------------------------------
 # Lane B — non-daily captures for librarian ingest.
-# Workdir-aware strict enumeration (PR-D / isolation v2 compatibility).
-# Does NOT source _common.sh — runs an inline strict probe so other callers
-# of list_active_claude_agents are unaffected by PR-D's stricter contract.
-# v2 활성 후 install-root memory 는 frozen snapshot 이라 새 file 안 들어옴;
-# `agb agent list --json` 의 workdir field 가 single source of truth.
 #
-# fail-closed semantics:
+# v2-gated dual-mode enumeration. Default-off invariant: legacy installs
+# (BRIDGE_LAYOUT unset or "legacy") use the original find-based enumeration
+# over $AGENTS_ROOT/*/memory/... so unrelated installs are unaffected by
+# PR-D's stricter contract. Only when BRIDGE_LAYOUT=v2 do we switch to the
+# workdir-aware strict probe via `agb agent list --json` — install-root
+# memory is a frozen snapshot under v2, so the workdir field becomes the
+# single source of truth.
+#
+# Strict (v2) fail-closed semantics:
 #   - BRIDGE_AGB 미실행/비실행파일      → exit 2
 #   - `agent list --json` 호출 실패      → exit 2 + stderr
 #   - JSON parse 실패 또는 list 아님     → exit 2 + stderr
@@ -161,23 +164,27 @@ PYEOF
 : "${BRIDGE_AGB:=$BRIDGE_HOME/agent-bridge}"
 : "${BRIDGE_PYTHON:=python3}"
 
-if [[ ! -x "$BRIDGE_AGB" ]]; then
-  printf '[wiki-daily-ingest] BRIDGE_AGB not executable: %s\n' "$BRIDGE_AGB" >&2
-  exit 2
-fi
+declare -a AGENT_MEMORY_ROOTS=()
 
-_lane_b_stderr="$(mktemp -t wiki-daily-ingest.agb-stderr.XXXXXX)"
+if [[ "${BRIDGE_LAYOUT:-legacy}" == "v2" ]]; then
+  # v2: strict workdir-aware enumeration via `agb agent list --json`.
+  if [[ ! -x "$BRIDGE_AGB" ]]; then
+    printf '[wiki-daily-ingest] BRIDGE_AGB not executable: %s\n' "$BRIDGE_AGB" >&2
+    exit 2
+  fi
 
-agent_list_json="$("$BRIDGE_AGB" agent list --json 2>"$_lane_b_stderr")"
-agb_exit=$?
-if (( agb_exit != 0 )); then
-  printf '[wiki-daily-ingest] agb agent list --json failed (exit=%d): %s\n' \
-    "$agb_exit" "$(cat "$_lane_b_stderr")" >&2
-  rm -f "$_lane_b_stderr"
-  exit 2
-fi
+  _lane_b_stderr="$(mktemp -t wiki-daily-ingest.agb-stderr.XXXXXX)"
 
-agents_tsv="$("$BRIDGE_PYTHON" - "$agent_list_json" <<'PY' 2>"$_lane_b_stderr"
+  agent_list_json="$("$BRIDGE_AGB" agent list --json 2>"$_lane_b_stderr")"
+  agb_exit=$?
+  if (( agb_exit != 0 )); then
+    printf '[wiki-daily-ingest] agb agent list --json failed (exit=%d): %s\n' \
+      "$agb_exit" "$(cat "$_lane_b_stderr")" >&2
+    rm -f "$_lane_b_stderr"
+    exit 2
+  fi
+
+  agents_tsv="$("$BRIDGE_PYTHON" - "$agent_list_json" <<'PY' 2>"$_lane_b_stderr"
 import json, sys
 try:
     data = json.loads(sys.argv[1])
@@ -199,25 +206,34 @@ for a in data:
     print(f"{name}\t{wd}")
 PY
 )"
-parse_exit=$?
-if (( parse_exit != 0 )); then
-  printf '[wiki-daily-ingest] agent list JSON parse failed (exit=%d): %s\n' \
-    "$parse_exit" "$(cat "$_lane_b_stderr")" >&2
+  parse_exit=$?
+  if (( parse_exit != 0 )); then
+    printf '[wiki-daily-ingest] agent list JSON parse failed (exit=%d): %s\n' \
+      "$parse_exit" "$(cat "$_lane_b_stderr")" >&2
+    rm -f "$_lane_b_stderr"
+    exit 2
+  fi
   rm -f "$_lane_b_stderr"
-  exit 2
-fi
-rm -f "$_lane_b_stderr"
 
-declare -a AGENT_MEMORY_ROOTS=()
-if [[ -n "$agents_tsv" ]]; then
-  while IFS=$'\t' read -r _agent _workdir; do
-    [[ -n "$_agent" && -n "$_workdir" ]] || continue
-    [[ -d "$_workdir/memory" ]] || continue
-    AGENT_MEMORY_ROOTS+=("$_workdir/memory")
-  done <<< "$agents_tsv"
+  if [[ -n "$agents_tsv" ]]; then
+    while IFS=$'\t' read -r _agent _workdir; do
+      [[ -n "$_agent" && -n "$_workdir" ]] || continue
+      [[ -d "$_workdir/memory" ]] || continue
+      AGENT_MEMORY_ROOTS+=("$_workdir/memory")
+    done <<< "$agents_tsv"
+  fi
+else
+  # Legacy: original find-based enumeration over $AGENTS_ROOT/*/memory.
+  # Each install-root agent dir with a memory/ subtree contributes a root.
+  if [[ -d "$AGENTS_ROOT" ]]; then
+    for _legacy_dir in "$AGENTS_ROOT"/*/memory; do
+      [[ -d "$_legacy_dir" ]] || continue
+      AGENT_MEMORY_ROOTS+=("$_legacy_dir")
+    done
+  fi
 fi
 
-# Research files touched in last 24h (across all active agent workdirs).
+# Research files touched in last 24h (across all active agent memory roots).
 touched_research=""
 for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
   [[ -d "$_root/research" ]] || continue

--- a/tests/isolation-v2-pr-d/smoke.sh
+++ b/tests/isolation-v2-pr-d/smoke.sh
@@ -349,6 +349,62 @@ else
   fail "ensure_groups_and_memberships does NOT add user memberships"
 fi
 
+# ---------------------------------------------------------------------------
+# Case 11: normalize_layout exists, called with correct helper signature,
+#          and runs AFTER mirror (separate from membership setup)
+# ---------------------------------------------------------------------------
+
+if declare -f bridge_isolation_v2_migrate_normalize_layout >/dev/null; then
+  ok "normalize_layout function defined"
+else
+  fail "normalize_layout function missing"
+fi
+
+# Helper signature is (group, dir_mode, file_mode, root). Verify all
+# calls in normalize_layout use 4 positional args, with the second/third
+# being octal mode tokens (2750/2770/0640/0660), and the FIRST arg is
+# the group var (not a path — that was the r2 P1 #1 bug).
+norm_body="$(declare -f bridge_isolation_v2_migrate_normalize_layout)"
+if grep -qE 'chgrp_setgid_recursive[[:space:]]+\\?\s*"\$(shared_grp|ctrl_grp|agent_grp)"\s+27[57]0\s+0[64]60\s+"\$data_root' <<<"$norm_body"; then
+  ok "normalize_layout calls helper with (group, dir_mode, file_mode, root)"
+else
+  # Fallback regex without strict line breaks.
+  if grep -E 'chgrp_setgid_recursive' <<<"$norm_body" \
+     | grep -qE '"\$(shared_grp|ctrl_grp|agent_grp)"[[:space:]]+27[57]0[[:space:]]+0[64]60'; then
+    ok "normalize_layout calls helper with (group, dir_mode, file_mode, root)"
+  else
+    fail "normalize_layout call signature looks wrong (expected group dir_mode file_mode root)"
+  fi
+fi
+
+# Apply path must call normalize_layout AFTER mirror_all.
+apply_body="$(declare -f bridge_isolation_v2_migrate_apply)"
+mirror_pos=$(grep -n 'mirror_all' <<<"$apply_body" | head -1 | cut -d: -f1)
+norm_pos=$(grep -n 'normalize_layout' <<<"$apply_body" | head -1 | cut -d: -f1)
+if [[ -n "$mirror_pos" && -n "$norm_pos" ]] && (( norm_pos > mirror_pos )); then
+  ok "apply runs normalize_layout AFTER mirror_all"
+else
+  fail "apply order wrong: normalize must come after mirror (mirror_pos=$mirror_pos norm_pos=$norm_pos)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 12: postflight honors BRIDGE_SHARED_GROUP / BRIDGE_CONTROLLER_GROUP
+# ---------------------------------------------------------------------------
+
+postflight_body="$(declare -f bridge_isolation_v2_migrate_postflight_groups)"
+if grep -q 'BRIDGE_SHARED_GROUP' <<<"$postflight_body" \
+   && grep -q 'BRIDGE_CONTROLLER_GROUP' <<<"$postflight_body"; then
+  ok "postflight honors BRIDGE_SHARED_GROUP + BRIDGE_CONTROLLER_GROUP overrides"
+else
+  fail "postflight does NOT reference both env overrides"
+fi
+
+if grep -q '"ab-shared"' <<<"$postflight_body"; then
+  fail "postflight still hardcodes 'ab-shared' as a literal"
+else
+  ok "postflight no longer hardcodes 'ab-shared'"
+fi
+
 printf '\n[summary] pass=%d fail=%d\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then
   exit 1

--- a/tests/isolation-v2-pr-d/smoke.sh
+++ b/tests/isolation-v2-pr-d/smoke.sh
@@ -168,6 +168,10 @@ bridge_isolation_v2_ensure_group() { return 0; }
 bridge_isolation_v2_agent_group_name() { printf 'ab-agent-%s' "$1"; }
 bridge_agent_os_user() { printf 'agent-bridge-%s' "$1"; }
 
+# Source the real isolation-v2 helpers (chgrp_setgid_{dir,recursive},
+# ensure_group, ensure_user_in_group, etc.) so the migrate module's
+# helper calls resolve to actual implementations rather than 127.
+source "$REPO_ROOT/lib/bridge-isolation-v2.sh"
 source "$REPO_ROOT/lib/bridge-isolation-v2-migrate.sh"
 
 # Case 5: emit_plan output contains profile rows with delete_eligible=0.
@@ -403,6 +407,107 @@ if grep -q '"ab-shared"' <<<"$postflight_body"; then
   fail "postflight still hardcodes 'ab-shared' as a literal"
 else
   ok "postflight no longer hardcodes 'ab-shared'"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 13: normalize_layout sets per-agent root to 2750, NOT 2770
+#          (r3 finding: 2770 root would let isolated UID rename credentials)
+# ---------------------------------------------------------------------------
+
+norm_body="$(declare -f bridge_isolation_v2_migrate_normalize_layout)"
+
+# Per-agent root call uses chgrp_setgid_dir (single, not recursive) at 2750.
+if grep -E 'chgrp_setgid_dir[[:space:]]+\\?\s*"\$agent_grp"\s+2750\s+"\$agent_root"' <<<"$norm_body" >/dev/null \
+   || grep -E 'chgrp_setgid_dir[[:space:]]' <<<"$norm_body" \
+        | grep -qE '"\$agent_grp"[[:space:]]+2750[[:space:]]+"\$agent_root"'; then
+  ok "normalize_layout sets per-agent root to 2750 via single-dir helper"
+else
+  fail "normalize_layout per-agent root call missing or wrong (expected chgrp_setgid_dir agent_grp 2750 root)"
+fi
+
+# Writable children iterated as a list, all 2770/0660.
+if grep -q 'writable_subs=(home workdir runtime logs requests responses)' <<<"$norm_body"; then
+  ok "normalize_layout enumerates writable subs explicitly"
+else
+  fail "normalize_layout writable_subs list missing or wrong"
+fi
+
+if grep -E 'chgrp_setgid_recursive[[:space:]]' <<<"$norm_body" \
+     | grep -qE '"\$agent_grp"[[:space:]]+2770[[:space:]]+0660'; then
+  ok "normalize_layout writable children use 2770/0660"
+else
+  fail "normalize_layout writable child call missing 2770/0660"
+fi
+
+# credentials/ override 2750/0640 still present.
+if grep -E 'chgrp_setgid_recursive[[:space:]]' <<<"$norm_body" \
+     | grep -qE '"\$agent_grp"[[:space:]]+2750[[:space:]]+0640'; then
+  ok "normalize_layout credentials/ uses 2750/0640"
+else
+  fail "normalize_layout credentials/ mode wrong"
+fi
+
+# Functional check: rootless run with a primary-group agent dir tree.
+PRIMARY_GRP="$(id -gn 2>/dev/null)"
+if [[ -n "$PRIMARY_GRP" ]]; then
+  norm_root="$SMOKE_ROOT/norm-test"
+  mkdir -p "$norm_root/agents/probe-agent/home" \
+           "$norm_root/agents/probe-agent/workdir" \
+           "$norm_root/agents/probe-agent/credentials"
+  echo 'irrelevant' > "$norm_root/agents/probe-agent/credentials/launch.env"
+
+  # Stub group-name resolver to use caller's primary group so
+  # chgrp/chmod succeed without sudo (helper falls through to direct
+  # path because mode/chgrp succeed for the owning user).
+  bridge_isolation_v2_agent_group_name() { printf '%s' "$PRIMARY_GRP"; }
+
+  # Build a one-line snapshot for the probe agent.
+  SNAP_NORM="$norm_root/snap"
+  printf 'probe-agent\n' > "$SNAP_NORM"
+
+  # Run the normalize step (BRIDGE_SHARED_GROUP/ctrl_grp left default —
+  # shared/ and state/ dirs do not exist in this fixture so those
+  # branches no-op).
+  set +e
+  ( bridge_isolation_v2_migrate_normalize_layout "$SNAP_NORM" "$norm_root" 2>/dev/null )
+  rc=$?
+  set -e
+
+  if (( rc == 0 )); then
+    root_mode="$(stat -c '%a' "$norm_root/agents/probe-agent" 2>/dev/null)"
+    workdir_mode="$(stat -c '%a' "$norm_root/agents/probe-agent/workdir" 2>/dev/null)"
+    home_mode="$(stat -c '%a' "$norm_root/agents/probe-agent/home" 2>/dev/null)"
+    cred_mode="$(stat -c '%a' "$norm_root/agents/probe-agent/credentials" 2>/dev/null)"
+    cred_file_mode="$(stat -c '%a' "$norm_root/agents/probe-agent/credentials/launch.env" 2>/dev/null)"
+
+    if [[ "$root_mode" == "2750" ]]; then
+      ok "post-normalize: per-agent root mode = 2750"
+    else
+      fail "post-normalize: per-agent root mode = $root_mode (expected 2750)"
+    fi
+    if [[ "$workdir_mode" == "2770" ]]; then
+      ok "post-normalize: workdir mode = 2770"
+    else
+      fail "post-normalize: workdir mode = $workdir_mode (expected 2770)"
+    fi
+    if [[ "$home_mode" == "2770" ]]; then
+      ok "post-normalize: home mode = 2770"
+    else
+      fail "post-normalize: home mode = $home_mode (expected 2770)"
+    fi
+    if [[ "$cred_mode" == "2750" ]]; then
+      ok "post-normalize: credentials/ mode = 2750"
+    else
+      fail "post-normalize: credentials/ mode = $cred_mode (expected 2750)"
+    fi
+    if [[ "$cred_file_mode" == "640" ]]; then
+      ok "post-normalize: credentials file mode = 0640"
+    else
+      fail "post-normalize: credentials file mode = $cred_file_mode (expected 640)"
+    fi
+  else
+    fail "normalize_layout returned rc=$rc on rootless fixture"
+  fi
 fi
 
 printf '\n[summary] pass=%d fail=%d\n' "$PASS" "$FAIL"

--- a/tests/isolation-v2-pr-d/smoke.sh
+++ b/tests/isolation-v2-pr-d/smoke.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# tests/isolation-v2-pr-d/smoke.sh — rootless smoke for PR-D migration tool.
+#
+# Covers (within rootless reach — root-required cases X-flagged at top):
+#   1. dry-run prints plan + does not create marker
+#   2. marker validation rejects unsafe owner/mode/content
+#   3. marker validation accepts valid v2 marker
+#   4. bridge_agent_default_profile_home returns v2 workdir when v2 active
+#   5. mirror map contains profile rows with delete_eligible=0
+#   6. commit candidate awk filter ($8==ok && $9==1) excludes delete_eligible=0
+#   7. self-stop guard refuses when BRIDGE_AGENT_ID is in snapshot
+#   8. daemon poll attempt counter exits within bounded time on mocked PIDs
+#
+# Skipped (root-required, X-flagged): real apply/rollback/commit, postflight
+# `sudo -u <agent> id -nG`, group ensure (groupadd), and full daemon stop.
+# Those are exercised by the live operator playbook in OPERATIONS.md.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+SMOKE_ROOT="$(mktemp -d -t isolation-v2-pr-d.XXXXXX)"
+trap 'rm -rf "$SMOKE_ROOT"' EXIT
+
+BRIDGE_HOME="$SMOKE_ROOT/bridge-home"
+BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
+BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+BRIDGE_RUNTIME_ROOT="$BRIDGE_HOME/runtime"
+BRIDGE_RUNTIME_SHARED_DIR="$BRIDGE_RUNTIME_ROOT/shared"
+BRIDGE_WORKTREE_ROOT="$BRIDGE_HOME/worktrees"
+BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+DATA_ROOT="$SMOKE_ROOT/data-v2"
+mkdir -p "$BRIDGE_STATE_DIR" "$BRIDGE_AGENT_HOME_ROOT" \
+         "$BRIDGE_RUNTIME_ROOT" "$BRIDGE_RUNTIME_SHARED_DIR" \
+         "$BRIDGE_WORKTREE_ROOT" "$BRIDGE_SHARED_DIR"
+export BRIDGE_HOME BRIDGE_STATE_DIR BRIDGE_AGENT_HOME_ROOT \
+       BRIDGE_RUNTIME_ROOT BRIDGE_RUNTIME_SHARED_DIR \
+       BRIDGE_WORKTREE_ROOT BRIDGE_SHARED_DIR
+
+PASS=0
+FAIL=0
+
+ok() {
+  PASS=$(( PASS + 1 ))
+  printf '[ok] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$(( FAIL + 1 ))
+  printf '[fail] %s\n' "$1" >&2
+}
+
+# Source the v2-migrate library directly (bridge-lib.sh expects a full
+# install; we shim the minimum for unit-style probing).
+source "$REPO_ROOT/lib/bridge-marker-bootstrap.sh" 2>/dev/null || true
+
+# Minimal shim for bridge_warn / bridge_die so the marker validator runs.
+bridge_warn() { printf '[warn] %s\n' "$*" >&2; }
+bridge_die()  { printf '[die] %s\n'  "$*" >&2; exit 9; }
+
+# ---------------------------------------------------------------------------
+# Case 2: marker validation rejects unsafe owner/mode/content
+# ---------------------------------------------------------------------------
+
+marker_path="$BRIDGE_STATE_DIR/layout-marker.sh"
+
+# 2a. group write bit
+printf 'BRIDGE_LAYOUT=v2\nBRIDGE_DATA_ROOT=/tmp/v2\n' > "$marker_path"
+chmod 0660 "$marker_path"
+if bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
+  fail "marker_validate accepted group-writable file"
+else
+  ok "marker_validate rejects group-writable mode"
+fi
+
+# 2b. disallowed line
+printf 'BRIDGE_LAYOUT=v2\nNASTY=$(rm -rf /)\n' > "$marker_path"
+chmod 0640 "$marker_path"
+if bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
+  fail "marker_validate accepted disallowed line"
+else
+  ok "marker_validate rejects disallowed key"
+fi
+
+# 2c. relative BRIDGE_DATA_ROOT
+printf 'BRIDGE_LAYOUT=v2\nBRIDGE_DATA_ROOT=relative/path\n' > "$marker_path"
+chmod 0640 "$marker_path"
+if bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
+  fail "marker_validate accepted relative DATA_ROOT"
+else
+  ok "marker_validate rejects relative BRIDGE_DATA_ROOT"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 3: marker validation accepts valid v2 marker
+# ---------------------------------------------------------------------------
+
+printf 'BRIDGE_LAYOUT=%s\nBRIDGE_DATA_ROOT=%s\n' \
+  "$(printf %q v2)" "$(printf %q "$DATA_ROOT")" > "$marker_path"
+chmod 0640 "$marker_path"
+if bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
+  ok "marker_validate accepts valid v2 marker"
+else
+  fail "marker_validate rejected valid v2 marker"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 5/6: mirror plan emit + commit awk filter (unit-style)
+# ---------------------------------------------------------------------------
+
+# Build the migration module surface enough to call emit_plan + the awk
+# commit filter against a fake manifest.
+
+# Fake snapshot — single agent.
+SNAP="$BRIDGE_STATE_DIR/migration/active-agents.snapshot"
+mkdir -p "$BRIDGE_STATE_DIR/migration"
+printf 'agent-x\n' > "$SNAP"
+
+# Fake legacy tree for agent-x.
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/agent-x/.claude/sessions"
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/agent-x/.teams"
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/agent-x/credentials"
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/agent-x/.agents/skills"
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/agent-x/memory"
+echo '{}' > "$BRIDGE_AGENT_HOME_ROOT/agent-x/.claude/sessions/abc.json"
+echo 'token=x' > "$BRIDGE_AGENT_HOME_ROOT/agent-x/.teams/access.json"
+echo 'sec' > "$BRIDGE_AGENT_HOME_ROOT/agent-x/credentials/launch-secrets.env"
+echo 'role: test' > "$BRIDGE_AGENT_HOME_ROOT/agent-x/CLAUDE.md"
+echo 'memory entry' > "$BRIDGE_AGENT_HOME_ROOT/agent-x/MEMORY.md"
+echo 'skill foo' > "$BRIDGE_AGENT_HOME_ROOT/agent-x/.agents/skills/foo.md"
+echo 'session: complete' > "$BRIDGE_AGENT_HOME_ROOT/agent-x/SESSION-TYPE.md"
+
+# Source the migration module. It requires a few helpers; provide stubs.
+bridge_expand_user_path() { printf '%s' "$1"; }
+bridge_linux_resolve_user_home() { getent passwd "$1" 2>/dev/null | cut -d: -f6 || printf '%s' "$HOME"; }
+bridge_active_agent_ids() { cat "$SNAP"; }
+bridge_daemon_all_pids() { :; }
+bridge_isolation_v2_active() { return 1; }   # no marker for plan-emit unit test
+bridge_isolation_v2_ensure_group() { return 0; }
+bridge_isolation_v2_agent_group_name() { printf 'ab-agent-%s' "$1"; }
+bridge_agent_os_user() { printf 'agent-bridge-%s' "$1"; }
+
+source "$REPO_ROOT/lib/bridge-isolation-v2-migrate.sh"
+
+# Case 5: emit_plan output contains profile rows with delete_eligible=0.
+plan_out="$(bridge_isolation_v2_migrate_emit_plan "$DATA_ROOT" "$SNAP")"
+if grep -qP '^agent_profile_CLAUDE\.md:agent-x\t.*\t0$' <<<"$plan_out"; then
+  ok "emit_plan includes CLAUDE.md row with delete_eligible=0"
+else
+  fail "emit_plan missing CLAUDE.md row with delete_eligible=0"
+fi
+if grep -qP '^agent_subtree_\.agents:agent-x\t.*\t0$' <<<"$plan_out"; then
+  ok "emit_plan includes .agents subtree with delete_eligible=0"
+else
+  fail "emit_plan missing .agents subtree row"
+fi
+if grep -qP '^agent_session_type:agent-x\t.*\t0$' <<<"$plan_out"; then
+  ok "emit_plan includes SESSION-TYPE.md with delete_eligible=0"
+else
+  fail "emit_plan missing SESSION-TYPE.md dual-read row"
+fi
+if grep -qP '^agent_claude:agent-x\t.*\t1$' <<<"$plan_out"; then
+  ok "emit_plan includes .claude with delete_eligible=1"
+else
+  fail "emit_plan missing .claude row"
+fi
+if grep -qP '^agent_teams:agent-x\t.*workdir/\.teams\t1$' <<<"$plan_out"; then
+  ok "emit_plan maps .teams to v2 workdir/ (not home/)"
+else
+  fail "emit_plan .teams destination wrong"
+fi
+
+# Case 6: commit awk filter excludes delete_eligible=0 rows.
+manifest="$BRIDGE_STATE_DIR/migration/manifest.tsv"
+{
+  printf '2026-01-01T00:00:00Z\trow_runtime\t/legacy/a\t/v2/a\t10\tx\tx\tok\t1\n'
+  printf '2026-01-01T00:00:00Z\trow_dual\t/legacy/b\t/v2/b\t20\ty\ty\tok\t0\n'
+  printf '2026-01-01T00:00:00Z\trow_failed\t/legacy/c\t/v2/c\t30\tz\tz\tchecksum_mismatch\t1\n'
+  printf '2026-01-01T00:00:00Z\trow_profile\t/legacy/d\t/v2/d\t40\tw\tw\tok\t0\n'
+} > "$manifest"
+
+candidates="$(bridge_isolation_v2_migrate_legacy_data_paths)"
+if [[ "$candidates" == "/legacy/a" ]]; then
+  ok "commit candidate filter returns only delete_eligible=1 verify=ok"
+else
+  fail "commit candidate filter wrong: '$candidates'"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 7: self-stop guard refuses when BRIDGE_AGENT_ID is in snapshot
+# ---------------------------------------------------------------------------
+
+set +e
+(
+  export BRIDGE_AGENT_ID="agent-x"
+  bridge_isolation_v2_migrate_self_stop_guard "$SNAP" 2>/dev/null
+)
+rc=$?
+if (( rc == 9 )); then
+  ok "self_stop_guard die when BRIDGE_AGENT_ID is in snapshot"
+else
+  fail "self_stop_guard returned rc=$rc (expected 9 = bridge_die)"
+fi
+unset BRIDGE_AGENT_ID
+
+bridge_isolation_v2_migrate_self_stop_guard "$SNAP" 2>/dev/null
+rc=$?
+if (( rc == 0 )); then
+  ok "self_stop_guard pass when BRIDGE_AGENT_ID is unset"
+else
+  fail "self_stop_guard rc=$rc when BRIDGE_AGENT_ID unset (expected 0)"
+fi
+set -e
+
+# ---------------------------------------------------------------------------
+# Case 8: daemon poll attempt counter is bounded (not 50s for 10s spec)
+# ---------------------------------------------------------------------------
+
+# Mock bridge_daemon_all_pids to always print a PID — wait_daemon_gone
+# should die after ~10s, NOT ~50s (the previous brief had a precedence bug).
+bridge_daemon_all_pids() { printf '12345'; }
+
+start_ts="$(date +%s)"
+set +e
+( bridge_isolation_v2_migrate_wait_daemon_gone 2 2>/dev/null )
+rc=$?
+set -e
+end_ts="$(date +%s)"
+elapsed=$(( end_ts - start_ts ))
+# Expect ~2s (timeout_s=2), not 10s. Tolerate up to 5s for slow CI.
+if (( rc == 9 )) && (( elapsed >= 1 )) && (( elapsed <= 5 )); then
+  ok "wait_daemon_gone bounded by attempt counter (~${elapsed}s for 2s spec)"
+else
+  fail "wait_daemon_gone rc=$rc elapsed=${elapsed}s (expected die ~2s)"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 1: dry-run does not create marker
+# ---------------------------------------------------------------------------
+
+# Reset state.
+rm -f "$marker_path"
+rm -rf "$BRIDGE_STATE_DIR/migration"
+mkdir -p "$BRIDGE_STATE_DIR/migration"
+printf 'agent-x\n' > "$SNAP"
+
+# Mock daemon helpers so dry-run unit doesn't hang.
+bridge_daemon_all_pids() { :; }
+
+# dry-run should not create marker.
+set +e
+bridge_isolation_v2_migrate_dry_run "$DATA_ROOT" >/tmp/dr.out.$$ 2>&1
+rc=$?
+set -e
+if [[ ! -f "$marker_path" ]]; then
+  ok "dry-run does not create marker file"
+else
+  fail "dry-run created marker file"
+fi
+rm -f /tmp/dr.out.$$
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+printf '\n[summary] pass=%d fail=%d\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0

--- a/tests/isolation-v2-pr-d/smoke.sh
+++ b/tests/isolation-v2-pr-d/smoke.sh
@@ -92,6 +92,33 @@ else
   ok "marker_validate rejects relative BRIDGE_DATA_ROOT"
 fi
 
+# 2d. command substitution in allowed-key value
+printf 'BRIDGE_LAYOUT=v2\nBRIDGE_DATA_ROOT=/tmp/v2\nBRIDGE_SHARED_GROUP=$(touch /tmp/agb-pwn-canary.%d)\n' "$$" > "$marker_path"
+chmod 0640 "$marker_path"
+rm -f "/tmp/agb-pwn-canary.$$"
+if bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
+  fail "marker_validate accepted command substitution in value"
+else
+  ok "marker_validate rejects command substitution in value"
+fi
+# Also confirm load does NOT execute it.
+( bridge_isolation_v2_marker_load 2>/dev/null )
+if [[ -e "/tmp/agb-pwn-canary.$$" ]]; then
+  fail "marker_load executed command substitution (canary file created)"
+  rm -f "/tmp/agb-pwn-canary.$$"
+else
+  ok "marker_load did not execute command substitution"
+fi
+
+# 2e. backtick injection
+printf 'BRIDGE_LAYOUT=v2\nBRIDGE_DATA_ROOT=`/bin/echo /tmp`\n' > "$marker_path"
+chmod 0640 "$marker_path"
+if bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
+  fail "marker_validate accepted backtick value"
+else
+  ok "marker_validate rejects backtick value"
+fi
+
 # ---------------------------------------------------------------------------
 # Case 3: marker validation accepts valid v2 marker
 # ---------------------------------------------------------------------------
@@ -263,6 +290,64 @@ rm -f /tmp/dr.out.$$
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Case 9: symlink-aware sha256_of (regression for r1 finding 3)
+# ---------------------------------------------------------------------------
+
+sym_root="$SMOKE_ROOT/symtest"
+mkdir -p "$sym_root/sub"
+echo 'real' > "$sym_root/sub/real.txt"
+ln -s "$sym_root/sub/real.txt" "$sym_root/link.txt"
+
+sha_with_link="$(bridge_isolation_v2_migrate_sha256_of "$sym_root")"
+
+# Drop just the symlink and recompute — hashes must differ. With the
+# old `-type f` filter the two hashes were identical because the
+# symlink was ignored.
+rm "$sym_root/link.txt"
+sha_without_link="$(bridge_isolation_v2_migrate_sha256_of "$sym_root")"
+
+if [[ "$sha_with_link" != "$sha_without_link" ]]; then
+  ok "sha256_of distinguishes presence of symlink"
+else
+  fail "sha256_of same hash with/without symlink — symlinks ignored"
+fi
+
+# Symlink standalone hash differs from absent.
+ln -s /nonexistent "$sym_root/danglink"
+sha_dangling="$(bridge_isolation_v2_migrate_sha256_of "$sym_root/danglink")"
+if [[ "$sha_dangling" != "absent" && "$sha_dangling" != "" ]]; then
+  ok "sha256_of dangling symlink hashes link target string"
+else
+  fail "sha256_of dangling symlink returned absent"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 10: ensure_groups_and_memberships exists and references env-overridable group names
+# ---------------------------------------------------------------------------
+
+# Cannot exercise group creation rootlessly, but verify the function
+# was renamed/updated and reads BRIDGE_SHARED_GROUP / BRIDGE_CONTROLLER_GROUP.
+if declare -f bridge_isolation_v2_migrate_ensure_groups_and_memberships >/dev/null; then
+  ok "ensure_groups_and_memberships function defined"
+else
+  fail "ensure_groups_and_memberships function missing"
+fi
+
+if declare -f bridge_isolation_v2_migrate_ensure_groups_and_memberships \
+   | grep -q 'BRIDGE_SHARED_GROUP'; then
+  ok "ensure_groups_and_memberships honors BRIDGE_SHARED_GROUP override"
+else
+  fail "ensure_groups_and_memberships does not reference BRIDGE_SHARED_GROUP override"
+fi
+
+if declare -f bridge_isolation_v2_migrate_ensure_groups_and_memberships \
+   | grep -q 'bridge_isolation_v2_ensure_user_in_group'; then
+  ok "ensure_groups_and_memberships adds user memberships"
+else
+  fail "ensure_groups_and_memberships does NOT add user memberships"
+fi
 
 printf '\n[summary] pass=%d fail=%d\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then

--- a/tests/wiki-daily-ingest/agb-mock.sh
+++ b/tests/wiki-daily-ingest/agb-mock.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # Hermetic mock of `agent-bridge` for the wiki-daily-ingest smoke.
-# Returns valid empty JSON for `agent list --json` (so PR-D's strict Lane B
-# parser sees zero active agents but parses cleanly), exits non-zero for
-# `agent show librarian` (so the librarian-watchdog branch short-circuits),
-# and no-ops for `task create` if ever reached. Any other subcommand exits
-# non-zero so unexpected calls surface in test failures.
+# Returns valid JSON for `agent list --json` (default empty list so PR-D's
+# strict Lane B parser sees zero active agents but parses cleanly).
+# When AGB_MOCK_AGENT_LIST_JSON is set, that exact JSON string is returned
+# instead — used by the v2 strict Lane B case to inject a populated agent
+# roster pointing at a fixture workdir.
+# Exits non-zero for `agent show librarian` (so the librarian-watchdog
+# branch short-circuits), and no-ops for `task create` if ever reached.
+# Any other subcommand exits non-zero so unexpected calls surface in test
+# failures.
 
 set -euo pipefail
 
@@ -13,7 +17,11 @@ case "${1:-}" in
     case "${2:-}" in
       list)
         if [[ "${3:-}" == "--json" ]]; then
-          printf '[]'
+          if [[ -n "${AGB_MOCK_AGENT_LIST_JSON:-}" ]]; then
+            printf '%s' "$AGB_MOCK_AGENT_LIST_JSON"
+          else
+            printf '[]'
+          fi
           exit 0
         fi
         exit 1

--- a/tests/wiki-daily-ingest/agb-mock.sh
+++ b/tests/wiki-daily-ingest/agb-mock.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Hermetic mock of `agent-bridge` for the wiki-daily-ingest smoke.
+# Returns valid empty JSON for `agent list --json` (so PR-D's strict Lane B
+# parser sees zero active agents but parses cleanly), exits non-zero for
+# `agent show librarian` (so the librarian-watchdog branch short-circuits),
+# and no-ops for `task create` if ever reached. Any other subcommand exits
+# non-zero so unexpected calls surface in test failures.
+
+set -euo pipefail
+
+case "${1:-}" in
+  agent)
+    case "${2:-}" in
+      list)
+        if [[ "${3:-}" == "--json" ]]; then
+          printf '[]'
+          exit 0
+        fi
+        exit 1
+        ;;
+      show)
+        # No librarian fixture in this smoke — let the watchdog probe fail.
+        exit 1
+        ;;
+      *)
+        exit 1
+        ;;
+    esac
+    ;;
+  task)
+    if [[ "${2:-}" == "create" ]]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac

--- a/tests/wiki-daily-ingest/smoke.sh
+++ b/tests/wiki-daily-ingest/smoke.sh
@@ -26,11 +26,19 @@
 #      a non-zero error count the previous watermark stays, so the next
 #      run retries the same window.
 #
-# Lane B (librarian-ingest task creation) is intentionally not exercised
-# here — it requires a real $BRIDGE_AGB binary. We populate only daily
-# notes under memory/, so the find(1) over research/projects/shared/
-# decisions returns zero and Lane B is a no-op. That matches the issue
-# scope (Lane A is the watermark consumer).
+# Lane B (librarian-ingest task creation) full task-create is intentionally
+# not exercised — that requires a real $BRIDGE_AGB binary. Scenarios 1-5
+# populate only daily notes under memory/, so the find(1) over
+# research/projects/shared/decisions returns zero and Lane B is a no-op.
+# That matches the watermark scope (Lane A is the watermark consumer).
+#
+# Scenarios 6 and 7 exercise the Lane B v2-gate added in PR-D r2:
+#   6. BRIDGE_LAYOUT unset/legacy → falls through to find-based
+#      enumeration over $AGENTS_ROOT/*/memory/research, picks up the
+#      research file under the legacy install-root memory path.
+#   7. BRIDGE_LAYOUT=v2 + populated `agb agent list --json` (via
+#      AGB_MOCK_AGENT_LIST_JSON) → strict enumeration picks up the
+#      research file under the v2 workdir's memory tree.
 #
 # Usage:   ./tests/wiki-daily-ingest/smoke.sh
 # Exit 0 if every scenario PASSes; exit 1 otherwise.
@@ -301,6 +309,86 @@ fi
 
 # Cleanup the deliberate collision so EXIT trap removes things cleanly.
 rm -f "$dest_parent" 2>/dev/null || true
+
+# =============================================================================
+# Scenario 6 — Lane B legacy fallback enumeration.
+# When BRIDGE_LAYOUT is unset/legacy, Lane B must fall through to the
+# original $AGENTS_ROOT/*/memory/<sub> find-based enumeration. We populate
+# a research/*.md file under the install-root agent path and assert the
+# audit log records it. The v2 strict path would never look at install-root
+# memory (frozen snapshot under v2), so this case proves the gate.
+# =============================================================================
+banner "6 — Lane B legacy fallback enumeration via install-root memory"
+reset_runtime
+unset BRIDGE_LAYOUT 2>/dev/null || true
+write_note "$TODAY" "# $TODAY note"
+
+# Drop a fresh research file under the install-root memory path.
+mkdir -p "$AGENT_HOME/memory/research"
+echo "# probe research note" >"$AGENT_HOME/memory/research/probe.md"
+# Ensure the file's mtime is within last-24h (BSD vs GNU touch differ; the
+# default mtime is "now" so this is just a belt-and-suspenders).
+touch "$AGENT_HOME/memory/research/probe.md"
+
+out_file="$(run_ingest s6 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+if [[ ! -f "$audit_file" ]]; then
+  fail "6" "audit log missing: $audit_file"
+elif ! grep -q "research/probe.md" "$audit_file"; then
+  fail "6" "legacy fallback did NOT enumerate $AGENT_HOME/memory/research/probe.md; audit body: $(head -c 400 "$audit_file")"
+elif ! grep -q "Research files (1)" "$audit_file"; then
+  fail "6" "expected 'Research files (1)' in audit; got: $(head -c 400 "$audit_file")"
+else
+  pass "6"
+fi
+
+# =============================================================================
+# Scenario 7 — Lane B v2 strict enumeration via populated agent list.
+# BRIDGE_LAYOUT=v2 + AGB_MOCK_AGENT_LIST_JSON pointing at a fixture v2
+# workdir: the audit log must reference the v2 workdir's memory tree, not
+# the install-root path.
+# =============================================================================
+banner "7 — Lane B v2 strict enumeration uses agb agent list workdir"
+reset_runtime
+write_note "$TODAY" "# $TODAY note"
+
+# Build a v2-style workdir for the smoke agent and put a research file
+# under its memory subtree. The legacy install-root memory must NOT
+# contain a matching file in this case so we can prove the v2 path is
+# what populated the audit log.
+V2_WORKDIR="$SMOKE_ROOT/data-v2/agents/$AGENT/workdir"
+mkdir -p "$V2_WORKDIR/memory/research"
+echo "# v2 probe research" >"$V2_WORKDIR/memory/research/v2probe.md"
+touch "$V2_WORKDIR/memory/research/v2probe.md"
+
+# Mock returns a single active claude agent with workdir pointing at the
+# fixture v2 workdir. Use python to emit valid JSON without escaping pain.
+AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
+import json, sys
+print(json.dumps([{
+    'agent': '$AGENT',
+    'engine': 'claude',
+    'active': True,
+    'workdir': '$V2_WORKDIR',
+}]))
+")"
+export AGB_MOCK_AGENT_LIST_JSON
+export BRIDGE_LAYOUT=v2
+
+out_file="$(run_ingest s7 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+if [[ ! -f "$audit_file" ]]; then
+  fail "7" "audit log missing: $audit_file"
+elif ! grep -q "v2probe.md" "$audit_file"; then
+  fail "7" "v2 strict enumeration did NOT pick up $V2_WORKDIR/memory/research/v2probe.md; audit body: $(head -c 400 "$audit_file")"
+elif ! grep -q "$V2_WORKDIR" "$audit_file"; then
+  fail "7" "audit log path is not the v2 workdir: $(head -c 400 "$audit_file")"
+else
+  pass "7"
+fi
+
+# Restore env for any later scenarios.
+unset AGB_MOCK_AGENT_LIST_JSON BRIDGE_LAYOUT 2>/dev/null || true
 
 # -----------------------------------------------------------------------------
 # Summary

--- a/tests/wiki-daily-ingest/smoke.sh
+++ b/tests/wiki-daily-ingest/smoke.sh
@@ -71,11 +71,13 @@ BRIDGE_AGENTS_ROOT="$BRIDGE_HOME/agents"
 BRIDGE_SHARED_ROOT="$BRIDGE_HOME/shared"
 BRIDGE_WIKI_ROOT="$BRIDGE_SHARED_ROOT/wiki"
 BRIDGE_SCRIPTS_ROOT="$REPO_ROOT/scripts"
-# Stub $BRIDGE_AGB to /bin/true so Lane B's "agent show librarian" probe
-# returns non-zero (no librarian) and the task-create call short-circuits
-# under `|| true`. With zero non-daily files we never reach that branch
-# anyway, but defense-in-depth keeps the test hermetic.
-BRIDGE_AGB="/bin/true"
+# PR-D made wiki-daily-ingest.sh Lane B strict: it now calls
+# `BRIDGE_AGB agent list --json` and refuses malformed JSON. /bin/true
+# returns empty stdout which the strict parser rejects, so the smoke
+# uses a tiny hermetic mock that returns a valid empty list and
+# fails non-zero for unrelated subcommands.
+BRIDGE_AGB="$REPO_ROOT/tests/wiki-daily-ingest/agb-mock.sh"
+chmod +x "$BRIDGE_AGB" 2>/dev/null || true
 WIKI_WATERMARK_FILE="$BRIDGE_STATE_DIR/wiki/last-ingest.txt"
 mkdir -p "$BRIDGE_STATE_DIR" "$BRIDGE_AGENTS_ROOT" "$BRIDGE_WIKI_ROOT/_audit"
 


### PR DESCRIPTION
## Summary

- Adds `agent-bridge migrate isolation-v2` operator tooling (dry-run / apply / rollback / commit / status) to migrate a legacy install onto the v2 layout shipped in PR-A/B/C (#370 / #371 / #381).
- Closes a contract gap PR-A/B/C left open: `bridge_agent_default_profile_home` is now v2-aware (returns workdir, matching every read site).
- Hardens `scripts/wiki-daily-ingest.sh` Lane B to a fail-closed workdir-aware enumeration so v2 memory updates are visible to the librarian ingest pipeline.

## Plan + reviews

Plan agreed with `agb-dev-codex-2` across 9 plan-review rounds (`r1`..`r9` briefs in `/tmp/agb-plan-pr-d-r*.md`). Final `plan-ok` came on r9.

## Test plan

- [x] `bash -n` on every changed shell file
- [x] `bash tests/isolation-v2-pr-d/smoke.sh` (14/14)
- [x] `bash tests/wiki-daily-ingest/smoke.sh` (5/5)
- [ ] `env -u BRIDGE_HOME TMPDIR=/tmp bash ./scripts/smoke-test.sh` (must run from a non-tmux shell — agent session inherits TMUX socket and blocks the smoke from creating new sessions)
- [ ] live apply + rollback in an isolated \`BRIDGE_HOME\` with one fake static agent (operator step before merge)
- [ ] live \`agent-bridge profile deploy <agent>\` after marker activation lands in v2 workdir (operator step before merge)

## Notes

- Self-stop guard refuses \`--apply\`/\`--rollback\` if \`BRIDGE_AGENT_ID\` is in the active snapshot — must be run from an out-of-band controller shell.
- \`--commit\` only deletes manifest rows with \`verify_status=ok && delete_eligible=1\`. Profile / skills / memory files (\`delete_eligible=0\`) are kept in the install root as a frozen snapshot through PR-G (see KNOWN_ISSUES.md entry 14).
- \`_common.sh\` \`list_active_claude_agents\` left silent-success-on-malformed-JSON for non-PR-D callers (KNOWN_ISSUES.md entry 15) — PR-D ships an inline strict block in wiki-daily-ingest.sh only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)