### PR TITLE
stall: skip cron-followup for memory_pressure deferrals (#393)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3074,6 +3074,7 @@ cmd_run_cron_worker() {
   local CRON_SLOT=""
   local CRON_TARGET_AGENT=""
   local CRON_TARGET_ENGINE=""
+  local CRON_DEFERRED_REASON=""
   local CRON_RESULT_STATUS=""
   local CRON_RESULT_SUMMARY=""
   local CRON_RUN_STATE=""
@@ -3138,6 +3139,27 @@ cmd_run_cron_worker() {
     CRON_NEEDS_HUMAN_FOLLOWUP="1"
     followup_priority="high"
     is_failure_followup=1
+  fi
+
+  # Issue #393: memory_pressure deferrals auto-retry on the next cron
+  # slot — emitting a high-priority cron-followup task per deferred slot
+  # only wakes the parent agent (e.g. patch), consumes tokens that
+  # materialize as more memory, and deepens the pressure that triggered
+  # the deferral in the first place. Reset the followup flags after
+  # the failure-path set above so the existing burst-counter + creation
+  # block silently skips. Real failed/timeout/crash runs still emit a
+  # high-priority followup as today; only the memory_pressure deferral
+  # path is suppressed.
+  if [[ "$CRON_RUN_STATE" == "deferred" && "$CRON_DEFERRED_REASON" == "memory_pressure" ]]; then
+    CRON_NEEDS_HUMAN_FOLLOWUP=""
+    is_failure_followup=0
+    bridge_audit_log daemon cron_followup_suppressed "$TASK_ASSIGNED_TO" \
+      --detail run_id="$run_id" \
+      --detail job_name="${CRON_JOB_NAME:-$run_id}" \
+      --detail family="${CRON_FAMILY:-}" \
+      --detail slot="${CRON_SLOT:-}" \
+      --detail reason=memory_pressure_deferral
+    daemon_info "skipped cron-followup for memory_pressure deferral of ${CRON_FAMILY:-${CRON_JOB_NAME:-$run_id}}"
   fi
 
   # Trust the subagent's needs_human_followup decision.

--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -314,6 +314,10 @@ fields = {
     "CRON_RESULT_STATUS": result.get("status", ""),
     "CRON_RESULT_SUMMARY": result.get("summary", ""),
     "CRON_RUN_STATE": status.get("state", ""),
+    # Issue #393: surface deferred_reason so the daemon can suppress
+    # cron-followup tasks for memory_pressure deferrals. Empty string
+    # for non-deferred runs (legacy callers see the same value).
+    "CRON_DEFERRED_REASON": str(status.get("deferred_reason") or "").strip(),
     "CRON_RESULT_FILE": str(result_file),
     "CRON_STATUS_FILE": str(status_file),
     "CRON_STDOUT_LOG": request.get("stdout_log", ""),


### PR DESCRIPTION
## Summary

Reference: #393.

\`v0.6.21\` pre-flight memory guard (#263 Track B) defers cron dispatch when host swap > 80%, but the daemon still emits a high-priority \`[cron-followup]\` task to the parent agent for every deferred slot — even though the next slot retries automatically. Parent agents (e.g. \`patch\` on memory-pressured hosts) must claim/done these no-op followups, which keeps a claude session warm and consumes more memory, deepening the pressure that triggered the deferrals: a self-feeding loop.

Observed pattern on a memory-pressured macOS host: 6 \`memory_pressure\` deferrals in 1 hour, each emitting a high-priority cron-followup that \`patch\` had to manually close.

## Change

Two-part fix:

### \`lib/bridge-cron.sh::bridge_cron_load_run_shell\`

Surfaces \`CRON_DEFERRED_REASON\` from \`status.json\` so the daemon can branch on the deferral reason. Empty string for non-deferred runs (legacy callers see no behavior change).

### \`bridge-daemon.sh::process_stall_reports\`

Resets \`CRON_NEEDS_HUMAN_FOLLOWUP\` and \`is_failure_followup\` to \`""\` / \`0\` after the failure-path set when \`CRON_RUN_STATE == \"deferred\" && CRON_DEFERRED_REASON == \"memory_pressure\"\`. The existing burst-counter + creation block then silently skips, an audit row records the suppression with \`reason=memory_pressure_deferral\`, and a \`daemon_info\` line reports the skip.

## What this PR does NOT change

- Real \`failed\` / \`timeout\` / \`crash\` cron outcomes still emit a high-priority cron-followup as today.
- The transient-failure burst protection from #230-B is preserved unchanged.
- The success+needs_human_followup path from #385 is preserved unchanged.
- Other deferral reasons (if any added later) continue to flow through the existing failure path.

## Verification

- \`bash -n bridge-daemon.sh lib/bridge-cron.sh\` PASS
- \`shellcheck bridge-daemon.sh lib/bridge-cron.sh\` PASS

Reference: #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)