### PR TITLE
isolate-v2 PR-E: legacy ACL helpers no-op + v2 group-mode replacements

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,3 +165,15 @@ Use them for isolated testing and for machine-specific installs.
 - Multi-tenant per-UID isolation is Linux-only; macOS runs shared mode
   plus hook-layer hardening only (see
   [`docs/platform-support.md`](./docs/platform-support.md))
+- Linux-user isolation has two access-control modes governed by
+  `bridge_isolation_v2_active`:
+  - **legacy**: per-isolated-UID named-user POSIX ACLs (`u:agent-bridge-<name>:r-x`
+    + traversal chains). Requires the `acl` package on every agent host.
+  - **v2 (PR-A → PR-E)**: per-agent group + setgid (`ab-agent-<name>`,
+    chmod 2750/2770) plus `umask 007` on agent launches. v2 retains a
+    single named-user ACL surface for Claude credentials
+    (`bridge_linux_grant_claude_credentials_access`) because the
+    operator's `~/.claude/.credentials.json` lives outside the v2
+    layout — see `OPERATIONS.md` "v2 ACL contract (PR-E)" for scope and
+    `KNOWN_ISSUES.md` §16/§17 for the transitional exception and the
+    base-readable engine CLI prerequisite.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -276,9 +276,13 @@ This is an intentional, named, fail-loud transitional exception:
   is missing, so the symlink is never planted in a half-broken state.
 - `bridge_linux_prepare_agent_isolation` keeps the `acl` package
   prerequisite for v2 + Claude (and skips it for v2 + non-Claude).
-- The v2 ACL grants are the symlink path
-  (`controller_home/.claude/.credentials.json`) plus a traverse chain
-  up to `controller_home`. No other v2 artifact uses ACLs.
+- The v2 ACL grants are exactly: `r--` on the credential file
+  (`controller_home/.claude/.credentials.json`) plus `--x` traverse on
+  every ancestor up to `controller_home` (inclusive of
+  `controller_home/.claude/`). No directory-list `r-x` and no default
+  ACL on `controller_home/.claude/` — re-auth (atomic rename → new
+  inode) requires re-running `agent-bridge isolate <agent>` to refresh
+  the file ACL on the new inode. No other v2 artifact uses ACLs.
 
 Plan: PR-F or a future PR is expected to switch v2 to per-agent
 `claude login` (each isolated UID gets its own credential file inside
@@ -315,3 +319,38 @@ symlink, which passes the v2 check.
 
 Legacy mode is unaffected — the controller-home traverse-chain ACL
 grants still cover that path.
+
+## 18. Layout v2 swaps the isolated UID's `~/.claude` from 0700 to 2750 group-mode
+
+Before PR-E, the isolated UID's `$user_home/.claude` was created mode
+`0700` and the controller (and the memory-daily harvester running as
+the controller UID) reached `~/.claude/projects/` via a named-user
+default ACL `u:<controller>:r-X` set on that directory. PR-E v2 mode
+no-ops `bridge_linux_acl_add` and the default-ACL setfacl, so on v2
+the dir would have been left at `0700` with no group access — the
+controller could no longer traverse into `projects/`.
+
+Under v2 the isolated `~/.claude` is now `chgrp ab-agent-<agent>` +
+`chmod 2750`:
+
+- Owner (the isolated UID): `rwx` — Claude still owns its config tree
+  and can write `projects/`, `sessions/`, `settings.json`, etc.
+- Group (`ab-agent-<agent>`, which the controller joins via PR-A/B/C
+  group plumbing): `r-x` — the harvester can list and read.
+- Other: `---`.
+- The setgid bit means subdirectories created by Claude later (e.g.
+  `projects/<workspace>`) inherit `ab-agent-<agent>` as their group,
+  so the harvester walks them without further setup. Combined with
+  the v2 umask 007 from `bridge_run_apply_v2_umask_if_needed`, new
+  files land at `0660` group-readable.
+
+Legacy mode keeps the prior `0700` + named-user default-ACL contract.
+
+This pairs with the per-agent v2 group prerequisite (every isolated
+UID's controller must be in `ab-agent-<agent>` AND `ab-shared`,
+ensured by `bridge_linux_prepare_agent_isolation`). On a fresh v2
+install the operator needs a re-login (or `newgrp` shell) after the
+first `agent-bridge isolate <agent>` so the controller process picks
+up the new group memberships; otherwise the harvester scan still
+fails until the operator's session refreshes. The same prerequisite
+is documented in `OPERATIONS.md`'s v2 install section.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -259,3 +259,59 @@ Those callers retain the original silent-OK behaviour for now.
 A follow-up PR (PR-G review) is expected to flip `_common.sh` to fail-closed
 and adjust each caller, replacing the local strict block in
 `wiki-daily-ingest.sh` with the shared helper at that point.
+
+## 16. Layout v2 retains a single named-user ACL surface for Claude credentials
+
+PR-E removed named-user POSIX ACLs from layout v2 in favor of group
+ownership + setgid for every artifact under the v2 layout (per-agent
+root, agent-env.sh, plugin catalog, channel symlink target, manifest).
+The one surface that still uses ACLs in v2 is
+`bridge_linux_grant_claude_credentials_access`, which reaches into the
+operator's `~/.claude/.credentials.json` (outside the v2 layout) to give
+the isolated UID a symlink to a single shared credential file.
+
+This is an intentional, named, fail-loud transitional exception:
+
+- The helper requires `setfacl` even in v2 mode and `bridge_die`s if it
+  is missing, so the symlink is never planted in a half-broken state.
+- `bridge_linux_prepare_agent_isolation` keeps the `acl` package
+  prerequisite for v2 + Claude (and skips it for v2 + non-Claude).
+- The v2 ACL grants are the symlink path
+  (`controller_home/.claude/.credentials.json`) plus a traverse chain
+  up to `controller_home`. No other v2 artifact uses ACLs.
+
+Plan: PR-F or a future PR is expected to switch v2 to per-agent
+`claude login` (each isolated UID gets its own credential file inside
+`$BRIDGE_AGENT_ROOT_V2/<agent>/home/.claude/.credentials.json`),
+removing this last ACL surface and dropping the `acl` package
+prerequisite entirely. The cost of doing it now would have been an
+operator workflow change inside a contract-cleanup PR; PR-E split that
+out as a deliberate scope decision.
+
+## 17. Layout v2 requires the engine CLI to be in a base-readable path
+
+PR-E's engine-CLI fail-fast (in
+`bridge_linux_grant_engine_cli_access`) rejects controller-home paths
+under v2 mode because the v2 group contract has no path INTO the
+operator's home. If `which claude` resolves to `~/.local/bin/claude`
+(or any path under the operator's chmod-0700 home) on a v2 install,
+`agent-bridge isolate <agent>` will `bridge_die` with a message like:
+
+```
+isolation v2 requires engine CLI ('claude') in a base-readable path;
+got: /home/ec2-user/.local/bin/claude (under controller home).
+Move 'claude' to /usr/local/bin or another path with 'other::r-x'.
+```
+
+The check looks at both the symlink path and its `readlink -f` target,
+so a symlink under `/usr/local/bin` that resolves into the operator's
+home is also caught.
+
+Workaround for v2 installs: install Claude/Codex system-wide
+(`/usr/local/bin`, `/opt/...`, or any path with no controller-home
+ancestor). The `npm install -g @anthropic-ai/claude-cli` flow lands in
+`/usr/local/lib/node_modules/...` with a `/usr/local/bin/claude`
+symlink, which passes the v2 check.
+
+Legacy mode is unaffected — the controller-home traverse-chain ACL
+grants still cover that path.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -422,6 +422,83 @@ the install-root copy is left in place so existing admin tooling and a
 clean rollback remain possible. A future PR (PR-G) is expected to either
 unify the two locations or mark the install-root copy read-only.
 
+### v2 ACL contract (PR-E)
+
+PR-E removes named-user POSIX ACLs from v2 mode in favor of POSIX group
+ownership + setgid. Scope and exceptions:
+
+- **Scope.** When `bridge_isolation_v2_active`, every named-user ACL
+  primitive (`bridge_linux_acl_add`, `bridge_linux_acl_add_recursive`,
+  `bridge_linux_acl_add_default_dirs_recursive`,
+  `bridge_linux_acl_remove_recursive`) and the v2-noopable wrappers
+  (`bridge_linux_grant_traverse_chain`,
+  `bridge_linux_revoke_traverse_chain`,
+  `bridge_linux_revoke_plugin_channel_grants`,
+  `bridge_linux_acl_repair_channel_env_files`) short-circuit to a
+  no-op. Their replacements in v2 are group ownership + setgid:
+  - **agent-env.sh**: chgrp `ab-agent-<name>`, chmod 0640
+    (controller owner; isolated UID reads via group bit).
+  - **per-UID `installed_plugins.json`**: chgrp `ab-agent-<name>`,
+    chmod 0640 (root owner; isolated UID reads via group bit).
+  - **`$user_home/.claude/plugins`** + `marketplaces`: chown
+    `root:ab-agent-<name>`, chmod 2750 (setgid; new children inherit
+    `ab-agent-<name>`).
+  - **channel symlink target dir**: chown `<isolated_user>`, chgrp
+    `ab-agent-<name>`, chmod 2770 (setgid; new files inside inherit
+    group + group rw).
+  - **bridge-run.sh launches**: `umask 007` is applied via
+    `bridge_run_apply_v2_umask_if_needed` after `bridge_require_agent`,
+    so files created by the agent process tree land at 0660 with
+    correct group ownership.
+
+- **Transitional exception (Claude credentials).** The v2 layout does
+  not include the operator's `~/.claude/.credentials.json`, so
+  `bridge_linux_grant_claude_credentials_access` retains named-user
+  ACL access in v2 mode for that single file plus the traversal chain
+  up to the operator's home. This is the **only** v2 surface that uses
+  ACLs. PR-F or a future PR is expected to replace this with per-agent
+  `claude login` (operator workflow change). The helper itself fails
+  loud (`bridge_die`) when `setfacl` is unavailable, so silent breakage
+  is impossible.
+
+- **Engine CLI prerequisite (v2).** v2 mode requires the engine CLI to
+  resolve to a base-readable path (`other::r-x` along the entire
+  ancestor chain). `bridge_linux_grant_engine_cli_access` validates
+  both `cli_path` and its `readlink -f` target; controller-home paths
+  are rejected with `bridge_die`. Install Claude/Codex in
+  `/usr/local/bin` (or another path with no controller-home ancestor)
+  before activating v2.
+
+- **`acl` package.** v2 + non-Claude engines do not require the `acl`
+  package. v2 + Claude does, because the credential exception above
+  uses `setfacl`. `bridge_linux_prepare_agent_isolation` gates
+  `bridge_linux_require_setfacl` accordingly.
+
+- **`BRIDGE_SHARED_GROUP` membership.** v2 prep ensures the isolated
+  UID is a member of `ab-shared` (default) so it can read the shared
+  plugin cache. Controller failure to update its own membership is a
+  warn unless the controller can no longer read
+  `bridge_isolation_v2_shared_plugins_root`, in which case it
+  escalates to die (the operator must re-login after the manual
+  `usermod` for new group membership to take effect).
+
+### PR-E smoke (operator-runnable)
+
+```bash
+# Always-on rootless cases (17, run on every PR review).
+tests/isolation-v2-pr-e/smoke.sh
+
+# Opt-in root-required cases (4, run against a live install with at
+# least two ab-agent groups). Requires sudo -n -u <isolated-user>.
+BRIDGE_TEST_V2_PRE_ROOT=1 tests/isolation-v2-pr-e/smoke.sh
+```
+
+The opt-in cases verify kernel-level cross-agent EACCES, self-agent
+read access, engine CLI exec via the isolated UID, and the
+`setgid + umask 007` composition for files created inside a v2
+channel target dir. These cannot be substituted by rootless
+fake-group assertions.
+
 ## Release Checklist
 
 Before pushing bridge changes:

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -7,6 +7,39 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 
+# PR-E: in v2 mode + linux-user isolation, switch the runtime umask from
+# bridge-lib.sh's default 0077 (private) to 0007 (group-writable). The v2
+# group-setgid layout (PR-A/B/C) gives new files the right group, but the
+# mode bits depend on umask. Without 0007, a setgid 2770 channel/runtime
+# dir would still hold 0600 files that the controller (group member) can
+# only read because of the inherited group ownership combined with chmod
+# at directory creation; agent-created channel state .env files would
+# lack group rw and the daemon's controller-side health probes would
+# silently see EACCES.
+#
+# Called twice from this script: once after the first bridge_require_agent
+# at startup, and once from bridge_run_refresh_roster_if_changed after the
+# subsequent bridge_require_agent on roster reload. Defined here (above
+# any caller) so the first call site below is not running against an
+# undefined function (PR #399 r1 FAIL #14): bash with `set -uo pipefail`
+# silently emits "command not found" + rc=127 and the script keeps going,
+# leaving initial v2 launches inheriting bridge-lib.sh's 0077.
+#
+# BRIDGE_RUN_UMASK_PROBE_FILE is a hidden smoke-only hook: when set, the
+# helper writes the resulting umask (post-set) to that path so a smoke
+# fixture can assert the bridge-run.sh effective umask without parsing
+# /proc/<pid>/status. Inert when unset.
+bridge_run_apply_v2_umask_if_needed() {
+  local agent="$1"
+  if bridge_isolation_v2_active 2>/dev/null \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    umask 007
+  fi
+  if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
+    umask >"$BRIDGE_RUN_UMASK_PROBE_FILE" 2>/dev/null || true
+  fi
+}
+
 usage() {
   echo "Usage: bash $SCRIPT_DIR/bridge-run.sh <agent> [--once] [--continue|--no-continue] [--safe-mode] [--dry-run]"
   echo "       bash $SCRIPT_DIR/bridge-run.sh --list"
@@ -164,35 +197,6 @@ log_loop_help() {
   bridge_run_session_attached || return 0
   log_line "tmux에서 쉘로 돌아가기: Ctrl-b 를 누른 뒤 d 를 누르세요."
   log_line "에이전트를 완전히 종료하기: 바깥 터미널에서 'agb kill ${AGENT}' 를 실행하세요."
-}
-
-# PR-E: in v2 mode + linux-user isolation, switch the runtime umask from
-# bridge-lib.sh's default 0077 (private) to 0007 (group-writable). The v2
-# group-setgid layout (PR-A/B/C) gives new files the right group, but the
-# mode bits depend on umask. Without 0007, a setgid 2770 channel/runtime
-# dir would still hold 0600 files that the controller (group member) can
-# only read because of the inherited group ownership combined with chmod
-# at directory creation; agent-created channel state .env files would
-# lack group rw and the daemon's controller-side health probes would
-# silently see EACCES.
-#
-# Called twice from this script: once after the first bridge_require_agent
-# at startup, and once from bridge_run_refresh_roster_if_changed after the
-# subsequent bridge_require_agent on roster reload.
-#
-# BRIDGE_RUN_UMASK_PROBE_FILE is a hidden smoke-only hook: when set, the
-# helper writes the resulting umask (post-set) to that path so a smoke
-# fixture can assert the bridge-run.sh effective umask without parsing
-# /proc/<pid>/status. Inert when unset.
-bridge_run_apply_v2_umask_if_needed() {
-  local agent="$1"
-  if bridge_isolation_v2_active 2>/dev/null \
-      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
-    umask 007
-  fi
-  if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
-    umask >"$BRIDGE_RUN_UMASK_PROBE_FILE" 2>/dev/null || true
-  fi
 }
 
 bridge_run_session_attached() {

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -85,6 +85,11 @@ fi
 
 bridge_require_agent "$AGENT"
 
+# PR-E: apply v2 umask before any runtime mkdir/plugin sync/launch work.
+# bridge-lib.sh:17 unconditionally set 0077; this helper only changes it
+# when BRIDGE_LAYOUT=v2 and the agent is linux-user-isolated.
+bridge_run_apply_v2_umask_if_needed "$AGENT"
+
 if [[ $CONTINUE_EXPLICIT -eq 1 ]]; then
   BRIDGE_AGENT_CONTINUE["$AGENT"]="$CONTINUE_MODE"
 fi
@@ -161,6 +166,35 @@ log_loop_help() {
   log_line "에이전트를 완전히 종료하기: 바깥 터미널에서 'agb kill ${AGENT}' 를 실행하세요."
 }
 
+# PR-E: in v2 mode + linux-user isolation, switch the runtime umask from
+# bridge-lib.sh's default 0077 (private) to 0007 (group-writable). The v2
+# group-setgid layout (PR-A/B/C) gives new files the right group, but the
+# mode bits depend on umask. Without 0007, a setgid 2770 channel/runtime
+# dir would still hold 0600 files that the controller (group member) can
+# only read because of the inherited group ownership combined with chmod
+# at directory creation; agent-created channel state .env files would
+# lack group rw and the daemon's controller-side health probes would
+# silently see EACCES.
+#
+# Called twice from this script: once after the first bridge_require_agent
+# at startup, and once from bridge_run_refresh_roster_if_changed after the
+# subsequent bridge_require_agent on roster reload.
+#
+# BRIDGE_RUN_UMASK_PROBE_FILE is a hidden smoke-only hook: when set, the
+# helper writes the resulting umask (post-set) to that path so a smoke
+# fixture can assert the bridge-run.sh effective umask without parsing
+# /proc/<pid>/status. Inert when unset.
+bridge_run_apply_v2_umask_if_needed() {
+  local agent="$1"
+  if bridge_isolation_v2_active 2>/dev/null \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    umask 007
+  fi
+  if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
+    umask >"$BRIDGE_RUN_UMASK_PROBE_FILE" 2>/dev/null || true
+  fi
+}
+
 bridge_run_session_attached() {
   local attached
 
@@ -221,6 +255,10 @@ bridge_run_refresh_roster_if_changed() {
 
   bridge_load_roster
   bridge_require_agent "$AGENT"
+  # PR-E: re-apply v2 umask after roster reload — bridge-lib.sh's umask 077
+  # is sticky across the process but a defensive re-set guards against any
+  # subshell that may have reset it during the refresh.
+  bridge_run_apply_v2_umask_if_needed "$AGENT"
   if [[ $CONTINUE_EXPLICIT -eq 1 ]]; then
     BRIDGE_AGENT_CONTINUE["$AGENT"]="$CONTINUE_MODE"
   fi

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -572,6 +572,14 @@ bridge_linux_acl_add() {
   local spec="$1"
   shift || true
   (($# > 0)) || return 0
+  # PR-E: in v2 mode the per-agent group + setgid layout (PR-A/B/C) covers
+  # what named-user ACLs used to cover, so this primitive is a no-op when
+  # bridge_isolation_v2_active. The Claude credential exception
+  # (bridge_linux_grant_claude_credentials_access) calls setfacl directly
+  # and does not route through this primitive — see r6 plan-ok.
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
   bridge_linux_sudo_root setfacl -m "$spec" "$@"
 }
 
@@ -602,6 +610,35 @@ bridge_linux_grant_engine_cli_access() {
   cli_path="$(bridge_resolve_engine_cli "$engine")"
   [[ -n "$cli_path" ]] || return 0
   cli_real="$(readlink -f "$cli_path" 2>/dev/null || printf '%s' "$cli_path")"
+
+  # PR-E: in v2 mode the engine CLI must be in a base-readable path
+  # (`other::r-x`), because the v2 group contract has no path INTO the
+  # operator's home for the isolated UID. Reject controller-home paths
+  # for both the symlink path AND its readlink target — a base-readable
+  # symlink (e.g. /usr/local/bin/claude → ~/.local/share/claude/...) can
+  # otherwise resolve into a private dir and fail at runtime.
+  if bridge_isolation_v2_active; then
+    local _bad=""
+    if [[ -n "$(bridge_linux_traverse_stop_for "$cli_path")" ]]; then
+      _bad="$cli_path (under controller home)"
+    elif [[ -n "$cli_real" && "$cli_real" != "$cli_path" \
+            && -n "$(bridge_linux_traverse_stop_for "$cli_real")" ]]; then
+      _bad="$cli_real (realpath of $cli_path under controller home)"
+    fi
+    if [[ -n "$_bad" ]]; then
+      bridge_die "isolation v2 requires engine CLI ('$engine') in a base-readable path; got: $_bad. Move '$engine' to /usr/local/bin or another path with 'other::r-x'."
+    fi
+    # Optional execute probe — only if direct sudo to os_user is wired
+    # up. nested sudo (sudo -n -u $os_user via bridge_linux_sudo_root)
+    # would mask probe failures behind the wrapper, so probe directly.
+    # Probe failure is fail-fast because PR-E's v2 contract assumes the
+    # isolated UID can launch the engine without any ACL help.
+    if [[ -n "$os_user" ]] && bridge_linux_can_sudo_to "$os_user"; then
+      sudo -n -u "$os_user" -- test -x "$cli_real" \
+        || bridge_die "isolation v2: '$os_user' cannot exec '$cli_real' (base perms or ancestor traversal blocks). Re-check engine CLI install."
+    fi
+    return 0
+  fi
 
   # Only chain-grant when the CLI lives inside the operator's home
   # (chmod 0700 blocks base-perm traversal there). System paths like
@@ -691,14 +728,38 @@ bridge_linux_grant_claude_credentials_access() {
     return 0
   fi
 
+  # PR-E: in v2 mode, the v2 layout has no path INTO the operator's
+  # ~/.claude. C1 transitional exception — keep ACL access to the single
+  # controller credential file via the unguarded traverse helper +
+  # direct setfacl. This is the *only* v2 surface that retains
+  # named-user ACLs; all other v2 helpers route through the ACL
+  # primitives which short-circuit. C2 (per-agent `claude login`) is
+  # the eventual replacement and lives in a future PR.
+  #
+  # Helper-level setfacl gate so silent failures cannot reach the
+  # symlink-plant step below — `bridge_linux_require_setfacl` is the
+  # sudo-aware presence check used elsewhere in linux-user isolation.
+  if bridge_isolation_v2_active; then
+    bridge_linux_require_setfacl
+  fi
+
   bridge_linux_sudo_root mkdir -p "$isolated_claude_dir"
   bridge_linux_sudo_root chown "$os_user" "$isolated_claude_dir"
   bridge_linux_sudo_root chmod 0700 "$isolated_claude_dir"
 
-  bridge_linux_grant_traverse_chain "$os_user" "$controller_claude_dir" "$controller_home"
-  bridge_linux_acl_add "u:${os_user}:r-x" "$controller_claude_dir" >/dev/null 2>&1 || true
-  bridge_linux_acl_add "u:${os_user}:r--" "$controller_cred_file" >/dev/null 2>&1 || true
-  bridge_linux_sudo_root setfacl -d -m "u:${os_user}:r--" "$controller_claude_dir" >/dev/null 2>&1 || true
+  if bridge_isolation_v2_active; then
+    # C1 exception: bypass the v2-noop public traverse chain and apply
+    # the grant directly. Same safety body via _bridge_linux_grant_traverse_paths.
+    _bridge_linux_grant_traverse_chain_unguarded "$os_user" "$controller_claude_dir" "$controller_home"
+    bridge_linux_sudo_root setfacl -m "u:${os_user}:r-x" "$controller_claude_dir" >/dev/null 2>&1 || true
+    bridge_linux_sudo_root setfacl -m "u:${os_user}:r--" "$controller_cred_file" >/dev/null 2>&1 || true
+    bridge_linux_sudo_root setfacl -d -m "u:${os_user}:r--" "$controller_claude_dir" >/dev/null 2>&1 || true
+  else
+    bridge_linux_grant_traverse_chain "$os_user" "$controller_claude_dir" "$controller_home"
+    bridge_linux_acl_add "u:${os_user}:r-x" "$controller_claude_dir" >/dev/null 2>&1 || true
+    bridge_linux_acl_add "u:${os_user}:r--" "$controller_cred_file" >/dev/null 2>&1 || true
+    bridge_linux_sudo_root setfacl -d -m "u:${os_user}:r--" "$controller_claude_dir" >/dev/null 2>&1 || true
+  fi
 
   if [[ -L "$isolated_cred_link" ]]; then
     current_target="$(readlink "$isolated_cred_link" 2>/dev/null || printf '')"
@@ -717,6 +778,9 @@ bridge_linux_acl_add_recursive() {
   local spec="$1"
   shift || true
   (($# > 0)) || return 0
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
   bridge_linux_sudo_root setfacl -R -m "$spec" "$@"
 }
 
@@ -724,6 +788,9 @@ bridge_linux_acl_remove_recursive() {
   local spec="$1"
   shift || true
   (($# > 0)) || return 0
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
   bridge_linux_sudo_root setfacl -R -x "$spec" "$@" >/dev/null 2>&1 || true
 }
 
@@ -732,6 +799,9 @@ bridge_linux_acl_add_default_dirs_recursive() {
   shift || true
   local path=""
 
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
   for path in "$@"; do
     [[ -d "$path" ]] || continue
     bridge_linux_sudo_root find "$path" -type d -exec setfacl -d -m "$spec" {} +
@@ -762,6 +832,15 @@ bridge_linux_acl_add_default_dirs_recursive() {
 # directly to `${workdir}/.<id>` for the four channel kinds we ship.
 bridge_linux_acl_repair_channel_env_files() {
   local agent="$1"
+
+  # PR-E: v2 mode does not use named-user ACLs on channel state files
+  # (the per-agent group + 2770 channel target dir + umask 007 covers
+  # both isolated and controller access), so the ACL mask drift class
+  # this helper exists to recover from cannot occur. Early-return before
+  # any sudo/controller/workdir resolve so the daemon stays cheap.
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
 
   bridge_linux_have_sudo_or_skip || return 0
 
@@ -885,40 +964,27 @@ bridge_agent_channel_acl_diagnostics_text() {
   fi
 }
 
-bridge_linux_grant_traverse_chain() {
-  # Grant `u:${os_user}:--x` on every directory from $target up to
-  # (and including) $stop_path. Callers must pass an explicit stop_path
-  # — it used to default to `/`, which is how issue #233 happened:
-  # every isolate grant walked all the way up and left
-  # `user:agent-bridge-<agent>:--x` entries on `/`, `/home`, and the
-  # operator's home. A default-to-root API was a loaded footgun.
-  #
-  # The stop_path gets normalised to a real directory. If the caller
-  # passes a file (e.g. a credentials file path), we stop at its parent
-  # directory and still grant execute on the file's containing dir,
-  # because that's the access the isolated UID actually needs to open
-  # the file. `/` is always rejected as a stop_path so an accidental
-  # empty-string or regressed caller cannot reinstate the bug.
-  local os_user="$1"
-  local target="$2"
-  local stop_path="${3:-}"
-  local path=""
+# PR-E refactor: emit the traversal path list (one per line, root-to-leaf
+# order). Owns the `/` reject, missing-stop reject, Python normalization,
+# and ancestor-of-target check. Public + private wrappers below share this
+# emitter so the v2 credential exception cannot drift away from the
+# traversal safety guards.
+_bridge_linux_grant_traverse_paths() {
+  local target="$1"
+  local stop_path="${2:-}"
 
   if [[ -z "$stop_path" ]]; then
-    bridge_warn "bridge_linux_grant_traverse_chain: missing stop_path for target=$target (skipping grant to avoid ancestor poisoning)"
+    bridge_warn "_bridge_linux_grant_traverse_paths: missing stop_path for target=$target (skipping grant to avoid ancestor poisoning)"
     return 0
   fi
   case "$stop_path" in
     "/"|"")
-      bridge_warn "bridge_linux_grant_traverse_chain: refusing stop_path=\"$stop_path\" for target=$target (would poison filesystem root)"
+      bridge_warn "_bridge_linux_grant_traverse_paths: refusing stop_path=\"$stop_path\" for target=$target (would poison filesystem root)"
       return 0
       ;;
   esac
 
-  while IFS= read -r path; do
-    [[ -d "$path" ]] || continue
-    bridge_linux_acl_add "u:${os_user}:--x" "$path"
-  done < <(python3 - "$target" "$stop_path" <<'PY'
+  python3 - "$target" "$stop_path" <<'PY'
 from pathlib import Path
 import sys
 
@@ -944,7 +1010,44 @@ while True:
 for item in reversed(items):
     print(item)
 PY
-)
+}
+
+bridge_linux_grant_traverse_chain() {
+  # Grant `u:${os_user}:--x` on every directory from $target up to
+  # (and including) $stop_path. Callers must pass an explicit stop_path
+  # — it used to default to `/`, which is how issue #233 happened.
+  # `/` is always rejected as a stop_path so an accidental empty-string
+  # or regressed caller cannot reinstate the bug.
+  #
+  # PR-E: in v2 mode this is a no-op via bridge_linux_acl_add. The
+  # Claude credential exception uses _bridge_linux_grant_traverse_chain_unguarded
+  # below, which shares the path emitter but bypasses the v2 guard.
+  local os_user="$1"
+  local target="$2"
+  local stop_path="${3:-}"
+  local path=""
+
+  while IFS= read -r path; do
+    [[ -d "$path" ]] || continue
+    bridge_linux_acl_add "u:${os_user}:--x" "$path"
+  done < <(_bridge_linux_grant_traverse_paths "$target" "$stop_path")
+}
+
+# PR-E private helper — grant traversal directly via setfacl, bypassing
+# the public v2 short-circuit. ONLY for use by the Claude credential
+# exception (bridge_linux_grant_claude_credentials_access). Shares the
+# safety body above so the `/` reject, missing-stop reject, Python
+# normalization, and ancestor check stay in lockstep with the public path.
+_bridge_linux_grant_traverse_chain_unguarded() {
+  local os_user="$1"
+  local target="$2"
+  local stop_path="${3:-}"
+  local path=""
+
+  while IFS= read -r path; do
+    [[ -d "$path" ]] || continue
+    bridge_linux_sudo_root setfacl -m "u:${os_user}:--x" "$path" >/dev/null 2>&1 || true
+  done < <(_bridge_linux_grant_traverse_paths "$target" "$stop_path")
 }
 
 bridge_linux_revoke_traverse_chain() {
@@ -952,6 +1055,12 @@ bridge_linux_revoke_traverse_chain() {
   # every directory between $target and $stop_path (inclusive). Stop_path
   # follows the same `/` and empty-string guards as the grant function so
   # an accidental call cannot strip ACLs from filesystem ancestors.
+  #
+  # PR-E: v2 mode has no named-user ACLs to revoke (group-setgid contract),
+  # so this is a no-op when bridge_isolation_v2_active.
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
   local os_user="$1"
   local target="$2"
   local stop_path="${3:-}"
@@ -1252,6 +1361,13 @@ bridge_linux_revoke_plugin_channel_grants() {
   # strip block in bridge_migration_unisolate; factored here so both
   # reapply (when a channel is removed mid-run) and unisolate (full
   # teardown) share one implementation.
+  #
+  # PR-E: in v2 mode there are no named-user ACL grants to revoke
+  # (the v2 group-setgid contract handles isolation via group membership),
+  # so this is a no-op when bridge_isolation_v2_active.
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
   local os_user="$1"
   local plugin_id="$2"
   local controller_plugins="$3"
@@ -1280,11 +1396,15 @@ bridge_write_isolated_installed_plugins_manifest() {
   #   channels_csv        — CSV of `plugin:<id>` (and other) channel tokens
   #   plugins_csv         — CSV of bare `<id>` (or `<id>@<mkt>`) tokens from
   #                         BRIDGE_AGENT_PLUGINS["<agent>"]; may be empty.
+  #   agent               — agent id (PR-E: required to resolve the v2 group
+  #                         for chgrp ab-agent-<name>). Optional in legacy
+  #                         mode for backwards compatibility.
   local os_user="$1"
   local isolated_plugins="$2"
   local controller_plugins="$3"
   local channels_csv="$4"
   local plugins_csv="${5-}"
+  local agent="${6-}"
   local manifest="$isolated_plugins/installed_plugins.json"
   local manifest_tmp=""
 
@@ -1424,7 +1544,27 @@ PY
   # (Blocking 2 in PR #302 r2.)
   bridge_linux_sudo_root chown root:root "$manifest_tmp"
   bridge_linux_sudo_root chmod 0640 "$manifest_tmp"
-  bridge_linux_acl_add "u:${os_user}:r--" "$manifest_tmp"
+  if bridge_isolation_v2_active; then
+    # PR-E: replace the named-user ACL with chgrp ab-agent-<name>. The
+    # isolated UID is a member of that group (PR-C ensure_user_in_group)
+    # and the manifest mode 0640 grants group r--. Owner stays root so
+    # the agent cannot tamper with which plugins it loads.
+    if [[ -n "$agent" ]]; then
+      local _v2_grp
+      _v2_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')" \
+        || _v2_grp=""
+      if [[ -n "$_v2_grp" ]]; then
+        bridge_linux_sudo_root chgrp "$_v2_grp" "$manifest_tmp" \
+          || bridge_die "isolation v2: chgrp '$_v2_grp' on manifest '$manifest_tmp' failed"
+      else
+        bridge_die "isolation v2: cannot resolve agent group for manifest '$manifest_tmp'"
+      fi
+    else
+      bridge_die "isolation v2: bridge_write_isolated_installed_plugins_manifest requires agent id (PR-E signature change)"
+    fi
+  else
+    bridge_linux_acl_add "u:${os_user}:r--" "$manifest_tmp"
+  fi
   bridge_linux_sudo_root mv "$manifest_tmp" "$manifest"
 }
 
@@ -1508,11 +1648,31 @@ bridge_linux_share_plugin_catalog() {
 
   local isolated_plugins="$user_home/.claude/plugins"
 
-  # 1. plugins/ root: root-owned, isolated UID r-x.
+  # PR-E: resolve the v2 agent group once for plugin root + marketplaces +
+  # manifest writer. Empty in legacy mode.
+  local _v2_grp=""
+  if bridge_isolation_v2_active; then
+    _v2_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')" \
+      || _v2_grp=""
+    [[ -n "$_v2_grp" ]] || bridge_die "isolation v2: cannot resolve agent group for plugin catalog of '$agent'"
+  fi
+
+  # 1. plugins/ root: root-owned, group-traversable.
+  #    - legacy: chmod 0750 + named-user ACL grants the isolated UID r-x.
+  #    - v2:     chown root:ab-agent-<name>, chmod 2750. setgid bit means
+  #              new children inherit ab-agent-<name>; the isolated UID
+  #              reaches the dir via group r-x (no ACL needed).
   bridge_linux_sudo_root mkdir -p "$isolated_plugins"
-  bridge_linux_sudo_root chown root:root "$isolated_plugins"
-  bridge_linux_sudo_root chmod 0750 "$isolated_plugins"
-  bridge_linux_acl_add "u:${os_user}:r-x" "$isolated_plugins"
+  if bridge_isolation_v2_active; then
+    bridge_linux_sudo_root chown "root:${_v2_grp}" "$isolated_plugins" \
+      || bridge_die "isolation v2: chown root:${_v2_grp} on '$isolated_plugins' failed"
+    bridge_linux_sudo_root chmod 2750 "$isolated_plugins" \
+      || bridge_die "isolation v2: chmod 2750 on '$isolated_plugins' failed"
+  else
+    bridge_linux_sudo_root chown root:root "$isolated_plugins"
+    bridge_linux_sudo_root chmod 0750 "$isolated_plugins"
+    bridge_linux_acl_add "u:${os_user}:r-x" "$isolated_plugins"
+  fi
 
   # 2. plugins/data/: isolated UID owns this so plugin runtime state writes work.
   bridge_linux_sudo_root mkdir -p "$isolated_plugins/data"
@@ -1546,7 +1706,7 @@ bridge_linux_share_plugin_catalog() {
   plugins_csv="$(bridge_agent_plugins_csv "$agent" 2>/dev/null || true)"
   bridge_write_isolated_installed_plugins_manifest \
     "$os_user" "$isolated_plugins" "$controller_plugins" \
-    "$channels_csv" "$plugins_csv"
+    "$channels_csv" "$plugins_csv" "$agent"
 
   # 5. Compute the channel diff against the persisted grant set so we can
   #    revoke channels that were previously granted but are no longer in
@@ -1701,9 +1861,18 @@ bridge_linux_share_plugin_catalog() {
     fi
     if (( _marketplaces_root_created == 0 )); then
       bridge_linux_sudo_root mkdir -p "$_isolated_marketplaces"
-      bridge_linux_sudo_root chown root:root "$_isolated_marketplaces"
-      bridge_linux_sudo_root chmod 0750 "$_isolated_marketplaces"
-      bridge_linux_acl_add "u:${os_user}:r-x" "$_isolated_marketplaces"
+      if bridge_isolation_v2_active; then
+        # PR-E: same group-mode contract as the plugins/ root above —
+        # root:ab-agent-<name> 2750 + setgid for new children.
+        bridge_linux_sudo_root chown "root:${_v2_grp}" "$_isolated_marketplaces" \
+          || bridge_die "isolation v2: chown root:${_v2_grp} on '$_isolated_marketplaces' failed"
+        bridge_linux_sudo_root chmod 2750 "$_isolated_marketplaces" \
+          || bridge_die "isolation v2: chmod 2750 on '$_isolated_marketplaces' failed"
+      else
+        bridge_linux_sudo_root chown root:root "$_isolated_marketplaces"
+        bridge_linux_sudo_root chmod 0750 "$_isolated_marketplaces"
+        bridge_linux_acl_add "u:${os_user}:r-x" "$_isolated_marketplaces"
+      fi
       _marketplaces_root_created=1
     fi
     _mkt_dst="$_isolated_marketplaces/$_mkt_id"
@@ -2051,23 +2220,45 @@ EOF
     fi
   fi
   chmod 600 "$file"
-  # `chmod 600` maps to mask::--- on a file that already carries named-user
-  # ACLs (POSIX ACL: chmod's group bits drive the mask when named entries
-  # exist). isolate originally grants the isolated UID `u:<os_user>:r--` so
-  # it can read agent-env.sh under sudo-wrap, but the mask wipe makes that
-  # entry effective `---`, so subsequent `agent start` cycles fail silently
-  # — bridge-run.sh sources nothing, sees an empty roster, and exits before
-  # tmux is created. Re-apply the named-user ACL so setfacl recomputes the
-  # mask back to rw- (or whatever covers the named entries).
+  # PR-E: in v2 mode, replace the named-user ACL grant pair with a
+  # group-mode contract — chgrp ab-agent-<name> + chmod 0640. The agent
+  # group has both the isolated UID (read) and the controller (read+
+  # owner write) as members per PR-C, so 0640 covers both without ACL.
+  # Owner stays controller (the redirect just above set up that owner
+  # already; the stale-inode drop earlier in this function self-heals
+  # any prior chowned-to-os_user state).
   if [[ "$isolation_mode" == "linux-user" \
         && -n "$os_user" \
-        && "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]] \
-      && command -v bridge_linux_acl_add >/dev/null 2>&1; then
-    local _controller_user
-    _controller_user="$(bridge_current_user 2>/dev/null || printf '')"
-    bridge_linux_acl_add "u:${os_user}:r--" "$file" >/dev/null 2>&1 || true
-    if [[ -n "$_controller_user" ]]; then
-      bridge_linux_acl_add "u:${_controller_user}:rw-" "$file" >/dev/null 2>&1 || true
+        && "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]]; then
+    if bridge_isolation_v2_active; then
+      local _v2_grp
+      _v2_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')" \
+        || _v2_grp=""
+      if [[ -n "$_v2_grp" ]]; then
+        bridge_linux_sudo_root chgrp "$_v2_grp" "$file" \
+          || bridge_die "isolation v2: chgrp '$_v2_grp' on env file '$file' failed"
+        bridge_linux_sudo_root chmod 0640 "$file" \
+          || bridge_die "isolation v2: chmod 0640 on env file '$file' failed"
+      else
+        bridge_die "isolation v2: cannot resolve agent group for env file '$file'"
+      fi
+    else
+      # `chmod 600` maps to mask::--- on a file that already carries named-user
+      # ACLs (POSIX ACL: chmod's group bits drive the mask when named entries
+      # exist). isolate originally grants the isolated UID `u:<os_user>:r--` so
+      # it can read agent-env.sh under sudo-wrap, but the mask wipe makes that
+      # entry effective `---`, so subsequent `agent start` cycles fail silently
+      # — bridge-run.sh sources nothing, sees an empty roster, and exits before
+      # tmux is created. Re-apply the named-user ACL so setfacl recomputes the
+      # mask back to rw- (or whatever covers the named entries).
+      if command -v bridge_linux_acl_add >/dev/null 2>&1; then
+        local _controller_user
+        _controller_user="$(bridge_current_user 2>/dev/null || printf '')"
+        bridge_linux_acl_add "u:${os_user}:r--" "$file" >/dev/null 2>&1 || true
+        if [[ -n "$_controller_user" ]]; then
+          bridge_linux_acl_add "u:${_controller_user}:rw-" "$file" >/dev/null 2>&1 || true
+        fi
+      fi
     fi
   fi
 }
@@ -2095,7 +2286,15 @@ bridge_linux_prepare_agent_isolation() {
   [[ "$(bridge_host_platform)" == "Linux" ]] || return 0
   [[ -n "$os_user" ]] || bridge_die "linux-user isolation requires os_user"
 
-  bridge_linux_require_setfacl
+  # PR-E: setfacl is the legacy-mode prerequisite. v2 mode replaces named-
+  # user ACLs with group setgid except for the Claude credential exception
+  # (bridge_linux_grant_claude_credentials_access), so v2 still requires
+  # setfacl when engine=claude. v2 + non-claude can skip the package.
+  if ! bridge_isolation_v2_active; then
+    bridge_linux_require_setfacl
+  elif [[ "$(bridge_agent_engine "$agent")" == "claude" ]]; then
+    bridge_linux_require_setfacl
+  fi
   user_home="$(bridge_agent_linux_user_home "$os_user")"
   env_file="$(bridge_agent_linux_env_file "$agent")"
   runtime_state_dir="$(bridge_agent_runtime_state_dir "$agent")"
@@ -2133,6 +2332,30 @@ bridge_linux_prepare_agent_isolation() {
       || bridge_die "isolation v2: cannot add '$os_user' to '$_v2_agent_group'"
     bridge_isolation_v2_ensure_user_in_group "$controller_user" "$_v2_agent_group" \
       || bridge_die "isolation v2: cannot add controller '$controller_user' to '$_v2_agent_group'"
+
+    # PR-E: shared-group membership. PR-C migration adds existing agents
+    # to ab-shared, but a new/reapplied agent through prepare must also
+    # join so bridge_linux_share_plugin_catalog can read the shared
+    # plugin cache. ensure_group is idempotent. Controller missing from
+    # ab-shared is recoverable iff the operator's own context can still
+    # read the shared plugin cache (group bit on a session that already
+    # had ab-shared, or shared-group home with `other` bit), so escalate
+    # the warn to die only when readability fails.
+    local _v2_shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+    bridge_isolation_v2_ensure_group "$_v2_shared_grp" \
+      || bridge_die "isolation v2: cannot ensure shared group '$_v2_shared_grp'"
+    bridge_isolation_v2_ensure_user_in_group "$os_user" "$_v2_shared_grp" \
+      || bridge_die "isolation v2: cannot add '$os_user' to shared group '$_v2_shared_grp'"
+    if ! bridge_isolation_v2_ensure_user_in_group "$controller_user" "$_v2_shared_grp"; then
+      bridge_warn "isolation v2: controller '$controller_user' membership update for '$_v2_shared_grp' failed; verifying shared plugin cache readability"
+      local _v2_shared_plugins_root
+      _v2_shared_plugins_root="$(bridge_isolation_v2_shared_plugins_root 2>/dev/null || printf '')"
+      if [[ -n "$_v2_shared_plugins_root" && -e "$_v2_shared_plugins_root" \
+            && ! -r "$_v2_shared_plugins_root" ]]; then
+        bridge_die "isolation v2: controller cannot read shared plugin cache '$_v2_shared_plugins_root'; group membership update for '$_v2_shared_grp' must succeed (re-login the controller after manual usermod, then retry)"
+      fi
+    fi
+
     _v2_agent_root="$(bridge_isolation_v2_agent_root "$agent")" \
       || bridge_die "isolation v2: cannot resolve per-agent root for '$agent'"
     bridge_linux_sudo_root mkdir -p "$_v2_agent_root"
@@ -2330,7 +2553,14 @@ bridge_linux_prepare_agent_isolation() {
   # ACLs on both keep the daemon's pathlib glob working without exposing
   # other agents' dir contents to isolated UIDs.
   bridge_linux_acl_add "u:${controller_user}:r-x" "$queue_gateway_root"
-  bridge_linux_sudo_root setfacl -d -m "u:${controller_user}:r-X" "$queue_gateway_root" >/dev/null 2>&1 || true
+  # PR-E: in v2 mode the queue-gateway root + per-agent dir live under
+  # the v2 group-setgid contract (controller is in the agent group),
+  # so the named-user default ACL is redundant and the recursive grant
+  # bodies short-circuit via the v2-noop primitives. Skip the lone
+  # direct setfacl that bypasses those primitives.
+  if ! bridge_isolation_v2_active; then
+    bridge_linux_sudo_root setfacl -d -m "u:${controller_user}:r-X" "$queue_gateway_root" >/dev/null 2>&1 || true
+  fi
   bridge_linux_acl_add_recursive "u:${controller_user}:rwX" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
   bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:rwX" "$queue_gateway_agent_dir" "$request_dir" "$response_dir"
 
@@ -2393,7 +2623,7 @@ bridge_linux_prepare_agent_isolation() {
         *) continue ;;
       esac
       if ! bridge_linux_install_isolated_channel_symlink \
-              "$os_user" "$user_home" "$controller_user" "$_ch_id" "$_ch_target"; then
+              "$os_user" "$user_home" "$controller_user" "$_ch_id" "$_ch_target" "$agent"; then
         bridge_die "isolation channel symlink: failed to install '$_ch_id' symlink for agent '$agent'; inspect/quarantine $user_home/.claude/channels/ before retrying"
       fi
     done
@@ -2413,7 +2643,11 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_acl_add "u:${controller_user}:r-x" "$isolated_claude_dir" >/dev/null 2>&1 || true
   # Default ACL on .claude/ so any subdirectory (projects/, sessions/, ...)
   # created later by the isolated UID inherits controller read access.
-  bridge_linux_sudo_root setfacl -d -m "u:${controller_user}:r-X" "$isolated_claude_dir" >/dev/null 2>&1 || true
+  # PR-E: in v2 mode the per-agent group + setgid contract covers
+  # controller access; skip the direct named-user default ACL.
+  if ! bridge_isolation_v2_active; then
+    bridge_linux_sudo_root setfacl -d -m "u:${controller_user}:r-X" "$isolated_claude_dir" >/dev/null 2>&1 || true
+  fi
   if [[ -d "$isolated_projects_dir" ]]; then
     bridge_linux_acl_add_recursive "u:${controller_user}:r-X" "$isolated_projects_dir" >/dev/null 2>&1 || true
     bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:r-X" "$isolated_projects_dir" >/dev/null 2>&1 || true
@@ -2444,9 +2678,14 @@ bridge_linux_install_isolated_channel_symlink() {
   local controller_user="$3"
   local channel="$4"
   local target="$5"
+  local agent="${6-}"
 
   [[ -n "$os_user" && -n "$user_home" && -n "$controller_user" && -n "$channel" && -n "$target" ]] \
     || { bridge_warn "bridge_linux_install_isolated_channel_symlink: missing arg"; return 1; }
+  if bridge_isolation_v2_active && [[ -z "$agent" ]]; then
+    bridge_warn "bridge_linux_install_isolated_channel_symlink: v2 mode requires the agent argument (PR-E signature change)"
+    return 1
+  fi
 
   local channels_root="$user_home/.claude/channels"
   local link_path="$channels_root/$channel"
@@ -2519,23 +2758,63 @@ bridge_linux_install_isolated_channel_symlink() {
       bridge_warn "isolation channel symlink: mkdir target $target failed"
       return 1
     }
+    # PR-E r4.4: TOCTOU re-check after mkdir. mkdir -p on an existing
+    # symlink succeeds and walks into the symlink target; reject before
+    # any further chown/chmod/chgrp.
+    if bridge_linux_sudo_root test -L "$target"; then
+      bridge_warn "isolation channel symlink: $target became a symlink between guard and mkdir, refusing to mutate"
+      return 1
+    fi
     bridge_linux_sudo_root chown "$os_user" "$target" || {
       bridge_warn "isolation channel symlink: chown target $target failed"
       return 1
     }
-    bridge_linux_sudo_root chmod 0700 "$target" || {
-      bridge_warn "isolation channel symlink: chmod target $target failed"
+    if bridge_isolation_v2_active; then
+      :  # v2 mode/group is normalized in the dedicated block below.
+    else
+      bridge_linux_sudo_root chmod 0700 "$target" || {
+        bridge_warn "isolation channel symlink: chmod target $target failed"
+        return 1
+      }
+      # r2: target ACLs are load-bearing for the symlink to be useful. A
+      # best-effort silent-skip leaves the symlink planted but the controller
+      # can't read through it -- exactly the failure mode this PR set out to
+      # fix. Fail loud so the operator quarantines the partial state instead
+      # of getting a runtime that pretends to work.
+      bridge_linux_acl_add "u:${controller_user}:rwX" "$target" >/dev/null 2>&1 \
+        || bridge_die "channel target dir: failed to grant controller rwX ACL on $target"
+      bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:rwX" "$target" >/dev/null 2>&1 \
+        || bridge_die "channel target dir: failed to set default ACL inheritance on $target"
+    fi
+  fi
+
+  # PR-E v2 normalize block — applies whether $target was just created or
+  # already existed. setgid (2770) ensures new files inside inherit
+  # ab-agent-<name>; combined with the agent-launch umask 007 wired into
+  # bridge-run.sh (`bridge_run_apply_v2_umask_if_needed`), files created
+  # by the isolated process land at 0660/group=ab-agent-<name>, giving
+  # both controller and isolated UID rw access through the group contract.
+  if bridge_isolation_v2_active; then
+    # r4.4 TOCTOU guard: refuse to mutate a symlink even though `test -d`
+    # earlier passed (a symlink-to-dir slips through that check).
+    if bridge_linux_sudo_root test -L "$target"; then
+      bridge_warn "isolation v2 channel target: $target is a symlink, refusing to chgrp/chmod (target may be attacker-controlled)"
       return 1
-    }
-    # r2: target ACLs are load-bearing for the symlink to be useful. A
-    # best-effort silent-skip leaves the symlink planted but the controller
-    # can't read through it -- exactly the failure mode this PR set out to
-    # fix. Fail loud so the operator quarantines the partial state instead
-    # of getting a runtime that pretends to work.
-    bridge_linux_acl_add "u:${controller_user}:rwX" "$target" >/dev/null 2>&1 \
-      || bridge_die "channel target dir: failed to grant controller rwX ACL on $target"
-    bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:rwX" "$target" >/dev/null 2>&1 \
-      || bridge_die "channel target dir: failed to set default ACL inheritance on $target"
+    fi
+    if ! bridge_linux_sudo_root test -d "$target"; then
+      bridge_warn "isolation v2 channel target: $target disappeared between checks"
+      return 1
+    fi
+    local _v2_grp
+    _v2_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')" \
+      || _v2_grp=""
+    [[ -n "$_v2_grp" ]] || bridge_die "isolation v2: cannot resolve agent group for channel target '$target'"
+    bridge_linux_sudo_root chown "$os_user" "$target" \
+      || bridge_die "isolation v2: chown $os_user on channel target '$target' failed"
+    bridge_linux_sudo_root chgrp "$_v2_grp" "$target" \
+      || bridge_die "isolation v2: chgrp $_v2_grp on channel target '$target' failed"
+    bridge_linux_sudo_root chmod 2770 "$target" \
+      || bridge_die "isolation v2: chmod 2770 on channel target '$target' failed"
   fi
 
   # Link path: only replace a pre-existing symlink. A real file or directory

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -750,10 +750,23 @@ bridge_linux_grant_claude_credentials_access() {
   if bridge_isolation_v2_active; then
     # C1 exception: bypass the v2-noop public traverse chain and apply
     # the grant directly. Same safety body via _bridge_linux_grant_traverse_paths.
+    #
+    # Scope is intentionally narrow per PR #399 r1 FAIL #13 — only what
+    # the kernel needs to resolve the symlink at
+    # `$user_home/.claude/.credentials.json` to
+    # `$controller_home/.claude/.credentials.json`:
+    #   1. traverse `--x` along every ancestor up to controller_home
+    #      (the unguarded helper above grants this on each ancestor,
+    #      including controller_claude_dir itself).
+    #   2. read `r--` on the credential file inode.
+    # No directory `r-x` (would let the isolated UID list ~/.claude/),
+    # no default ACL on ~/.claude/ (would extend grants to every new
+    # inode under there). Re-auth's atomic-rename produces a new inode
+    # without an inherited ACL — operator must re-run
+    # `agent-bridge isolate <agent>` after each Claude re-auth, which
+    # is the documented C1 contract until PR-F's per-agent claude login.
     _bridge_linux_grant_traverse_chain_unguarded "$os_user" "$controller_claude_dir" "$controller_home"
-    bridge_linux_sudo_root setfacl -m "u:${os_user}:r-x" "$controller_claude_dir" >/dev/null 2>&1 || true
     bridge_linux_sudo_root setfacl -m "u:${os_user}:r--" "$controller_cred_file" >/dev/null 2>&1 || true
-    bridge_linux_sudo_root setfacl -d -m "u:${os_user}:r--" "$controller_claude_dir" >/dev/null 2>&1 || true
   else
     bridge_linux_grant_traverse_chain "$os_user" "$controller_claude_dir" "$controller_home"
     bridge_linux_acl_add "u:${os_user}:r-x" "$controller_claude_dir" >/dev/null 2>&1 || true
@@ -2578,7 +2591,27 @@ bridge_linux_prepare_agent_isolation() {
   local isolated_projects_dir="$isolated_claude_dir/projects"
   bridge_linux_sudo_root mkdir -p "$isolated_claude_dir"
   bridge_linux_sudo_root chown "$os_user" "$isolated_claude_dir" >/dev/null 2>&1 || true
-  bridge_linux_sudo_root chmod 0700 "$isolated_claude_dir" >/dev/null 2>&1 || true
+  # PR-E r2 (FAIL #15): under v2 the legacy ACL grant on this dir is
+  # no-op'd (`bridge_linux_acl_add` short-circuits in v2), but the dir
+  # itself was still chmod 0700 — group has no traverse, so the
+  # controller (group member of ab-agent-<name>) cannot reach
+  # ~/.claude/projects/ for the memory-daily harvester. Mirror the
+  # group-mode replacements applied to ~/.claude/plugins (lines around
+  # 1666-1670) and ~/.claude/plugins/marketplaces: chgrp the v2 agent
+  # group + chmod 2750 (setgid so new subdirs like projects/ inherit
+  # the group). Legacy keeps 0700 + named-user ACL.
+  if bridge_isolation_v2_active; then
+    local _claude_v2_grp=""
+    _claude_v2_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')"
+    [[ -n "$_claude_v2_grp" ]] \
+      || bridge_die "isolation v2: cannot resolve agent group for ~/.claude of '$agent'"
+    bridge_linux_sudo_root chgrp "$_claude_v2_grp" "$isolated_claude_dir" \
+      || bridge_die "isolation v2: chgrp $_claude_v2_grp on '$isolated_claude_dir' failed"
+    bridge_linux_sudo_root chmod 2750 "$isolated_claude_dir" \
+      || bridge_die "isolation v2: chmod 2750 on '$isolated_claude_dir' failed"
+  else
+    bridge_linux_sudo_root chmod 0700 "$isolated_claude_dir" >/dev/null 2>&1 || true
+  fi
   # Channel-ownership-aware plugin sharing. Without this the isolated UID's
   # ~/.claude/plugins/ is empty and Claude starts with no MCP servers loaded
   # (Teams/ms365/cosmax-* all silently missing). The helper writes a per-UID

--- a/tests/isolation-v2-pr-e/smoke.sh
+++ b/tests/isolation-v2-pr-e/smoke.sh
@@ -364,6 +364,62 @@ um2_recorded="$(cat "$UM2_PROBE" 2>/dev/null || true)"
 ok "UM2 legacy mode → helper inert (umask stays 0077)"
 
 # ---------------------------------------------------------------------------
+# UM3: real bridge-run.sh entrypoint applies umask 0007 in v2 (PR #399 r2 FAIL #14)
+#
+# UM1 only asserts the helper *body* sets umask correctly. r1 FAIL #14
+# noted that the bug was *call ordering* — bridge-run.sh called the helper
+# before its definition was parsed, so initial v2 launches inherited the
+# bridge-lib.sh default 0077 even though the helper body was correct.
+# UM3 drives the actual bridge-run.sh entrypoint with --dry-run + the
+# umask probe to assert the call site (line ~91 of bridge-run.sh) is
+# observably effective. Uses BRIDGE_HOST_PLATFORM_OVERRIDE=Linux so the
+# linux_user_isolation_effective check passes on macOS as well.
+# ---------------------------------------------------------------------------
+log "case: UM3 real bridge-run.sh entrypoint applies umask 0007 in v2"
+UM3_DIR="$TMP_ROOT/um3"
+UM3_PROBE="$UM3_DIR/umask.probe"
+UM3_HOME="$UM3_DIR/bridge-home"
+UM3_DATA="$UM3_DIR/data"
+UM3_STATE="$UM3_HOME/state"
+UM3_ROSTER_FILE="$UM3_HOME/agent-roster.sh"
+UM3_ROSTER_LOCAL="$UM3_HOME/agent-roster.local.sh"
+UM3_WORKDIR="$UM3_DIR/agent-workdir"
+mkdir -p "$UM3_HOME" "$UM3_DATA/agents" "$UM3_DATA/shared" "$UM3_DATA/state" \
+         "$UM3_STATE/agents" "$UM3_WORKDIR"
+: >"$UM3_PROBE"
+: >"$UM3_ROSTER_FILE"
+# BRIDGE_AGENT_SESSION must be set so bridge_agent_exists returns true,
+# which gates bridge_require_agent inside bridge-run.sh.
+cat >"$UM3_ROSTER_LOCAL" <<EOF
+#!/usr/bin/env bash
+bridge_add_agent_id_if_missing "smoke-um3"
+BRIDGE_AGENT_ENGINE["smoke-um3"]="codex"
+BRIDGE_AGENT_SESSION["smoke-um3"]="smoke-um3"
+BRIDGE_AGENT_WORKDIR["smoke-um3"]="$UM3_WORKDIR"
+BRIDGE_AGENT_ISOLATION_MODE["smoke-um3"]="linux-user"
+BRIDGE_AGENT_OS_USER["smoke-um3"]="ec2-user"
+BRIDGE_AGENT_LAUNCH_CMD["smoke-um3"]="codex"
+EOF
+um3_rc=0
+BRIDGE_HOME="$UM3_HOME" \
+BRIDGE_LAYOUT="v2" \
+BRIDGE_DATA_ROOT="$UM3_DATA" \
+BRIDGE_STATE_DIR="$UM3_STATE" \
+BRIDGE_ACTIVE_AGENT_DIR="$UM3_STATE/agents" \
+BRIDGE_ROSTER_FILE="$UM3_ROSTER_FILE" \
+BRIDGE_ROSTER_LOCAL_FILE="$UM3_ROSTER_LOCAL" \
+BRIDGE_HOST_PLATFORM_OVERRIDE="Linux" \
+BRIDGE_RUN_UMASK_PROBE_FILE="$UM3_PROBE" \
+  bash "$REPO_ROOT/bridge-run.sh" smoke-um3 --dry-run >/dev/null 2>"$UM3_DIR/run.err" \
+  || um3_rc=$?
+[[ $um3_rc -eq 0 ]] \
+  || die "UM3 bridge-run.sh --dry-run failed rc=$um3_rc; stderr=$(cat "$UM3_DIR/run.err" 2>/dev/null)"
+um3_recorded="$(cat "$UM3_PROBE" 2>/dev/null || true)"
+[[ "$um3_recorded" == "0007" ]] \
+  || die "UM3 expected probe=0007 (real bridge-run.sh entrypoint, v2 + linux-user), got: '$um3_recorded'; stderr=$(cat "$UM3_DIR/run.err" 2>/dev/null)"
+ok "UM3 real bridge-run.sh entrypoint sets umask 0007 (call ordering fixed)"
+
+# ---------------------------------------------------------------------------
 # EC1/EC2/EC3: engine CLI v2 fail-fast vs system-path pass-through
 # ---------------------------------------------------------------------------
 case_ec1() {

--- a/tests/isolation-v2-pr-e/smoke.sh
+++ b/tests/isolation-v2-pr-e/smoke.sh
@@ -1,0 +1,575 @@
+#!/usr/bin/env bash
+# tests/isolation-v2-pr-e/smoke.sh
+#
+# Acceptance test for PR-E. See top of file in PR-E plan-review r5/r6
+# for the full case list. The smoke drives the REAL helpers from
+# `lib/bridge-agents.sh`, `lib/bridge-isolation-v2.sh`, and
+# `bridge-run.sh` (helper definition copied inline because the smoke
+# cannot run the full bridge-run.sh entrypoint).
+#
+# Each case is a function; a small dispatcher sets up the v2 (or
+# legacy) subshell, sources bridge-lib.sh, installs a sudo-wrapper
+# stub that logs argv, and invokes the case body. Subshell isolation
+# is via `( ... )` parens, which inherit functions defined in the
+# parent.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+log()  { printf '[v2-pr-e] %s\n' "$*"; }
+die()  { printf '[v2-pr-e][error] %s\n' "$*" >&2; exit 1; }
+skip() { printf '[v2-pr-e][skip] %s\n' "$*"; exit 0; }
+ok()   { printf '[v2-pr-e] ok: %s\n' "$*"; }
+
+if (( BASH_VERSINFO[0] < 4 )); then
+  skip "bash 4+ required"
+fi
+command -v python3 >/dev/null 2>&1 || skip "python3 missing"
+
+TMP_ROOT="$(mktemp -d -t isolation-v2-pr-e.XXXXXX)"
+trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
+export TMPDIR="${TMPDIR:-/tmp}"
+
+# ---------------------------------------------------------------------------
+# Subshell helpers — caller passes a function NAME (defined in this
+# script) and we invoke it after wiring up the lib + sudo stub.
+# ---------------------------------------------------------------------------
+
+# Stub bridge_linux_sudo_root — log argv to $_BRIDGE_LINUX_SUDO_LOG_FILE,
+# pass through benign filesystem ops, swallow setfacl. The log path is
+# stored in a non-local variable because bash binds variable references
+# at call time, not at function-definition time, so a `local log` would
+# be out of scope when the stub is invoked later.
+make_sudo_stub() {
+  _BRIDGE_LINUX_SUDO_LOG_FILE="$1"
+  bridge_linux_sudo_root() {
+    printf '%s\n' "$*" >>"$_BRIDGE_LINUX_SUDO_LOG_FILE"
+    case "${1:-}" in
+      # Filesystem state ops we want to exercise — the case body asserts
+      # post-conditions like mode/existence after these run.
+      test) shift; test "$@" ;;
+      mkdir|chmod|touch|ln|rm|mv|find|mktemp|python3) "$@" ;;
+      # chown/chgrp need root in real life. The smoke is rootless, so
+      # we only want them in the sudo log (for grep-on-log assertions).
+      # Skip the actual call. Failure of a real chgrp to a non-existent
+      # group would otherwise wipe out the v2 fail-fast we validate.
+      chown|chgrp) return 0 ;;
+      setfacl) return 0 ;;
+      bash) shift; bash "$@" ;;  # pass-through for `bash -lc 'command -v setfacl'`
+      *) return 0 ;;
+    esac
+  }
+}
+
+run_in_v2() {
+  local case_dir="$1"; shift
+  local sudo_log="$1"; shift
+  local fn="$1"; shift
+  (
+    set -e
+    export BRIDGE_HOME="$case_dir/bridge-home"
+    export BRIDGE_LAYOUT="v2"
+    export BRIDGE_DATA_ROOT="$case_dir/data"
+    mkdir -p "$BRIDGE_HOME" "$BRIDGE_DATA_ROOT/agents" \
+             "$BRIDGE_DATA_ROOT/shared" "$BRIDGE_DATA_ROOT/state"
+    unset BRIDGE_SHARED_ROOT BRIDGE_AGENT_ROOT_V2 BRIDGE_CONTROLLER_STATE_ROOT
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/bridge-lib.sh"
+    make_sudo_stub "$sudo_log"
+    "$fn" "$@"
+  )
+}
+
+run_in_legacy() {
+  local case_dir="$1"; shift
+  local sudo_log="$1"; shift
+  local fn="$1"; shift
+  (
+    set -e
+    export BRIDGE_HOME="$case_dir/bridge-home"
+    unset BRIDGE_LAYOUT BRIDGE_DATA_ROOT BRIDGE_SHARED_ROOT \
+          BRIDGE_AGENT_ROOT_V2 BRIDGE_CONTROLLER_STATE_ROOT
+    mkdir -p "$BRIDGE_HOME"
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/bridge-lib.sh"
+    make_sudo_stub "$sudo_log"
+    "$fn" "$@"
+  )
+}
+
+assert_no_setfacl() {
+  local sudo_log="$1"
+  local context="${2:-}"
+  if grep -qE '(^|find .* -exec )setfacl' "$sudo_log"; then
+    printf '[v2-pr-e][error] %s: expected zero setfacl calls but found:\n' "$context" >&2
+    grep -nE 'setfacl' "$sudo_log" >&2 || true
+    return 1
+  fi
+}
+
+assert_some_setfacl() {
+  local sudo_log="$1"
+  local context="${2:-}"
+  if ! grep -qE '(^|find .* -exec )setfacl' "$sudo_log"; then
+    printf '[v2-pr-e][error] %s: expected at least one setfacl call but found none\n' "$context" >&2
+    return 1
+  fi
+}
+
+# Inline copy of bridge_run_apply_v2_umask_if_needed — keeps the smoke
+# self-contained without sourcing bridge-run.sh (which has top-level
+# argv parsing). Drift between this copy and the real helper is itself
+# something the smoke catches, because the underlying contract
+# (`bridge_isolation_v2_active && bridge_agent_linux_user_isolation_effective`
+# → umask 007) is what gets tested.
+smoke_bridge_run_apply_v2_umask_if_needed() {
+  local agent="$1"
+  if bridge_isolation_v2_active 2>/dev/null \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    umask 007
+  fi
+  if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
+    umask >"$BRIDGE_RUN_UMASK_PROBE_FILE" 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# P1: ACL primitive helpers no-op in v2 mode
+# ---------------------------------------------------------------------------
+case_p1() {
+  bridge_linux_acl_add "u:foo:r--" /tmp/x
+  bridge_linux_acl_add_recursive "u:foo:rwX" /tmp/x
+  bridge_linux_acl_add_default_dirs_recursive "u:foo:rwX" /tmp/x
+  bridge_linux_acl_remove_recursive "u:foo" /tmp/x
+}
+log "case: P1 ACL primitive helpers no-op in v2"
+P1_DIR="$TMP_ROOT/p1"
+P1_LOG="$P1_DIR/sudo.log"
+mkdir -p "$P1_DIR"
+: >"$P1_LOG"
+run_in_v2 "$P1_DIR" "$P1_LOG" case_p1
+assert_no_setfacl "$P1_LOG" "P1 v2 primitives" || die "P1 leaked setfacl"
+ok "P1 v2 ACL primitives all no-op"
+
+# ---------------------------------------------------------------------------
+# P2: Direct-setfacl helpers no-op in v2 mode
+# ---------------------------------------------------------------------------
+case_p2() {
+  bridge_linux_revoke_traverse_chain "foo" "/tmp/some/dir" "/tmp"
+  bridge_linux_revoke_plugin_channel_grants "foo" "fake-plugin" "/tmp/plugins" "/tmp"
+  bridge_linux_acl_repair_channel_env_files "smoke-agent" >/dev/null 2>&1 || true
+}
+log "case: P2 direct-setfacl helpers no-op in v2"
+P2_DIR="$TMP_ROOT/p2"
+P2_LOG="$P2_DIR/sudo.log"
+mkdir -p "$P2_DIR"
+: >"$P2_LOG"
+run_in_v2 "$P2_DIR" "$P2_LOG" case_p2
+assert_no_setfacl "$P2_LOG" "P2 v2 direct setfacl helpers" || die "P2 leaked setfacl"
+ok "P2 v2 direct-setfacl helpers all no-op"
+
+# ---------------------------------------------------------------------------
+# P3: grant_traverse_chain v2-noop via bridge_linux_acl_add
+# ---------------------------------------------------------------------------
+case_p3() {
+  local base="$1"
+  bridge_linux_grant_traverse_chain "foo" "$base/a/b/c" "$base"
+}
+log "case: P3 grant_traverse_chain v2-noop"
+P3_DIR="$TMP_ROOT/p3"
+P3_LOG="$P3_DIR/sudo.log"
+mkdir -p "$P3_DIR/a/b/c"
+: >"$P3_LOG"
+run_in_v2 "$P3_DIR" "$P3_LOG" case_p3 "$P3_DIR"
+assert_no_setfacl "$P3_LOG" "P3 v2 grant_traverse_chain" || die "P3 leaked setfacl"
+ok "P3 v2 grant_traverse_chain no-op"
+
+# ---------------------------------------------------------------------------
+# P4: _bridge_linux_grant_traverse_paths refactor parity + safety
+# ---------------------------------------------------------------------------
+case_p4_emit() {
+  local target="$1"
+  local stop="$2"
+  _bridge_linux_grant_traverse_paths "$target" "$stop"
+}
+log "case: P4 _bridge_linux_grant_traverse_paths parity"
+P4_DIR="$TMP_ROOT/p4"
+P4_LOG="$P4_DIR/sudo.log"
+mkdir -p "$P4_DIR/x/y/z"
+: >"$P4_LOG"
+v2_paths="$(run_in_v2 "$P4_DIR" "$P4_LOG" case_p4_emit "$P4_DIR/x/y/z" "$P4_DIR")"
+legacy_paths="$(run_in_legacy "$P4_DIR" "$P4_LOG" case_p4_emit "$P4_DIR/x/y/z" "$P4_DIR")"
+[[ "$v2_paths" == "$legacy_paths" ]] \
+  || die "P4 path emitter parity failed: v2='$v2_paths' legacy='$legacy_paths'"
+empty_out="$(run_in_v2 "$P4_DIR" "$P4_LOG" case_p4_emit "$P4_DIR/x" "" 2>/dev/null)"
+[[ -z "$empty_out" ]] || die "P4 missing-stop should emit no paths, got: $empty_out"
+slash_out="$(run_in_v2 "$P4_DIR" "$P4_LOG" case_p4_emit "$P4_DIR/x" "/" 2>/dev/null)"
+[[ -z "$slash_out" ]] || die "P4 stop=/ should emit no paths, got: $slash_out"
+ok "P4 path emitter parity + safety guards intact"
+
+# ---------------------------------------------------------------------------
+# E1: bridge_write_linux_agent_env_file in v2 — chgrp + 0640, no setfacl
+# ---------------------------------------------------------------------------
+case_e1() {
+  local env_file="$1"
+  bridge_load_roster
+  BRIDGE_AGENT_IDS=("smoke-e1")
+  BRIDGE_AGENT_ENGINE["smoke-e1"]="codex"
+  BRIDGE_AGENT_WORKDIR["smoke-e1"]="/tmp/wd"
+  BRIDGE_AGENT_ISOLATION_MODE["smoke-e1"]="linux-user"
+  BRIDGE_AGENT_OS_USER["smoke-e1"]="ec2-user"
+  bridge_write_linux_agent_env_file "smoke-e1" "$env_file"
+  local mode
+  mode=$(stat -c "%a" "$env_file")
+  [[ "$mode" == "640" ]] || { echo "expected mode 640, got $mode" >&2; return 30; }
+}
+log "case: E1 env file v2 group-mode"
+E1_DIR="$TMP_ROOT/e1"
+E1_LOG="$E1_DIR/sudo.log"
+mkdir -p "$E1_DIR"
+: >"$E1_LOG"
+run_in_v2 "$E1_DIR" "$E1_LOG" case_e1 "$E1_DIR/env.sh" \
+  || die "E1 env file v2 path failed"
+assert_no_setfacl "$E1_LOG" "E1 v2 env file" || die "E1 leaked setfacl"
+grep -q "^chmod 0640 .*env\.sh" "$E1_LOG" || die "E1 missing chmod 0640 in sudo log"
+grep -q "^chgrp ab-agent-smoke-e1 .*env\.sh" "$E1_LOG" || die "E1 missing chgrp ab-agent-smoke-e1"
+ok "E1 env file v2 group-mode (chgrp + chmod 0640, no setfacl)"
+
+# ---------------------------------------------------------------------------
+# M1: manifest writer in v2 with agent arg
+# ---------------------------------------------------------------------------
+case_m1() {
+  local iso="$1"
+  local ctrl="$2"
+  bridge_write_isolated_installed_plugins_manifest \
+    "ec2-user" "$iso" "$ctrl" "" "" "smoke-m1"
+  [[ -f "$iso/installed_plugins.json" ]] || { echo "manifest missing" >&2; return 31; }
+}
+log "case: M1 manifest writer v2 group-mode"
+M1_DIR="$TMP_ROOT/m1"
+M1_LOG="$M1_DIR/sudo.log"
+mkdir -p "$M1_DIR/iso-plugins" "$M1_DIR/ctrl-plugins"
+echo '{"plugins":{}}' > "$M1_DIR/ctrl-plugins/installed_plugins.json"
+: >"$M1_LOG"
+run_in_v2 "$M1_DIR" "$M1_LOG" case_m1 "$M1_DIR/iso-plugins" "$M1_DIR/ctrl-plugins"
+assert_no_setfacl "$M1_LOG" "M1 v2 manifest" || die "M1 leaked setfacl"
+grep -q "^chmod 0640 .*\.tmp\." "$M1_LOG" || die "M1 missing chmod 0640 on tmp"
+grep -q "^chgrp ab-agent-smoke-m1" "$M1_LOG" || die "M1 missing chgrp ab-agent-smoke-m1"
+ok "M1 manifest writer v2 group-mode"
+
+# ---------------------------------------------------------------------------
+# M2: manifest writer dies in v2 without agent arg
+# ---------------------------------------------------------------------------
+case_m2() {
+  local iso="$1"
+  local ctrl="$2"
+  bridge_write_isolated_installed_plugins_manifest \
+    "ec2-user" "$iso" "$ctrl" "" ""  # intentional: no agent arg
+}
+log "case: M2 manifest writer requires agent arg in v2"
+M2_DIR="$TMP_ROOT/m2"
+M2_LOG="$M2_DIR/sudo.log"
+mkdir -p "$M2_DIR/iso-plugins" "$M2_DIR/ctrl-plugins"
+echo '{"plugins":{}}' > "$M2_DIR/ctrl-plugins/installed_plugins.json"
+: >"$M2_LOG"
+m2_rc=0
+run_in_v2 "$M2_DIR" "$M2_LOG" case_m2 "$M2_DIR/iso-plugins" "$M2_DIR/ctrl-plugins" \
+  2>/dev/null || m2_rc=$?
+[[ $m2_rc -ne 0 ]] || die "M2 manifest writer should die without agent arg in v2"
+ok "M2 manifest writer requires agent arg in v2 (rc=$m2_rc)"
+
+# ---------------------------------------------------------------------------
+# PC1: bridge_linux_share_plugin_catalog plugin root in v2
+# ---------------------------------------------------------------------------
+case_pc1() {
+  local iso_root="$1"
+  local ctrl_home="$2"
+  local user_home="$3"
+  bridge_load_roster
+  BRIDGE_AGENT_IDS=("smoke-pc1")
+  BRIDGE_AGENT_ENGINE["smoke-pc1"]="claude"
+  BRIDGE_AGENT_WORKDIR["smoke-pc1"]="/tmp/wd-pc1"
+  BRIDGE_AGENT_CHANNELS["smoke-pc1"]=""
+  BRIDGE_AGENT_PLUGINS["smoke-pc1"]=""
+  # Override controller home resolution so the helper does not walk into
+  # the real operator home. The helper's tempdir guard restricts the
+  # override to BRIDGE_HOME under /tmp/ or $TMPDIR/, which our run_in_v2
+  # fixture already places. The helper expects controller HOME (not the
+  # plugins dir); it appends `/.claude/plugins` itself.
+  export BRIDGE_CONTROLLER_HOME_OVERRIDE="$ctrl_home"
+  bridge_linux_share_plugin_catalog "ec2-user" "$user_home" "ec2-user" "smoke-pc1"
+  [[ -d "$iso_root" ]] || { echo "iso plugins root missing" >&2; return 32; }
+}
+log "case: PC1 plugin catalog root v2 group-mode"
+PC1_DIR="$TMP_ROOT/pc1"
+PC1_LOG="$PC1_DIR/sudo.log"
+mkdir -p "$PC1_DIR/iso-home/.claude" \
+         "$PC1_DIR/ctrl-home/.claude/plugins"
+echo '{"plugins":{}}' > "$PC1_DIR/ctrl-home/.claude/plugins/installed_plugins.json"
+: >"$PC1_LOG"
+ISO_PLUGIN_ROOT="$PC1_DIR/iso-home/.claude/plugins"
+run_in_v2 "$PC1_DIR" "$PC1_LOG" case_pc1 \
+  "$ISO_PLUGIN_ROOT" "$PC1_DIR/ctrl-home" "$PC1_DIR/iso-home"
+assert_no_setfacl "$PC1_LOG" "PC1 v2 plugin catalog" || die "PC1 leaked setfacl"
+grep -q "^chmod 2750 .*\.claude/plugins" "$PC1_LOG" \
+  || die "PC1 missing chmod 2750 on plugins root"
+grep -q "^chown root:ab-agent-smoke-pc1 .*\.claude/plugins" "$PC1_LOG" \
+  || die "PC1 missing chown root:ab-agent-smoke-pc1 on plugins root"
+ok "PC1 plugin catalog root v2 group-mode (2750 + group-correct, no setfacl)"
+
+# ---------------------------------------------------------------------------
+# UM1: bridge-run.sh v2 umask helper sets 0007
+# ---------------------------------------------------------------------------
+case_um1() {
+  bridge_load_roster
+  BRIDGE_AGENT_IDS=("smoke-um1")
+  BRIDGE_AGENT_ENGINE["smoke-um1"]="codex"
+  BRIDGE_AGENT_WORKDIR["smoke-um1"]="/tmp/wd"
+  BRIDGE_AGENT_ISOLATION_MODE["smoke-um1"]="linux-user"
+  BRIDGE_AGENT_OS_USER["smoke-um1"]="ec2-user"
+  smoke_bridge_run_apply_v2_umask_if_needed "smoke-um1"
+}
+log "case: UM1 bridge_run_apply_v2_umask_if_needed in v2"
+UM1_DIR="$TMP_ROOT/um1"
+UM1_LOG="$UM1_DIR/sudo.log"
+UM1_PROBE="$UM1_DIR/umask.probe"
+mkdir -p "$UM1_DIR"
+: >"$UM1_PROBE"
+BRIDGE_RUN_UMASK_PROBE_FILE="$UM1_PROBE" run_in_v2 "$UM1_DIR" "$UM1_LOG" case_um1
+um1_recorded="$(cat "$UM1_PROBE" 2>/dev/null || true)"
+[[ "$um1_recorded" == "0007" ]] || die "UM1 expected probe=0007, got: '$um1_recorded'"
+ok "UM1 v2 + linux-user → bridge-run.sh helper sets umask 0007"
+
+# ---------------------------------------------------------------------------
+# UM2: helper inert in legacy mode
+# ---------------------------------------------------------------------------
+case_um2() {
+  bridge_load_roster
+  BRIDGE_AGENT_IDS=("smoke-um2")
+  BRIDGE_AGENT_ENGINE["smoke-um2"]="codex"
+  BRIDGE_AGENT_ISOLATION_MODE["smoke-um2"]="shared"
+  smoke_bridge_run_apply_v2_umask_if_needed "smoke-um2"
+}
+log "case: UM2 bridge_run_apply_v2_umask_if_needed inert in legacy"
+UM2_DIR="$TMP_ROOT/um2"
+UM2_LOG="$UM2_DIR/sudo.log"
+UM2_PROBE="$UM2_DIR/umask.probe"
+mkdir -p "$UM2_DIR"
+: >"$UM2_PROBE"
+BRIDGE_RUN_UMASK_PROBE_FILE="$UM2_PROBE" run_in_legacy "$UM2_DIR" "$UM2_LOG" case_um2
+um2_recorded="$(cat "$UM2_PROBE" 2>/dev/null || true)"
+[[ "$um2_recorded" == "0077" ]] || die "UM2 expected probe=0077 (bridge-lib default), got: '$um2_recorded'"
+ok "UM2 legacy mode → helper inert (umask stays 0077)"
+
+# ---------------------------------------------------------------------------
+# EC1/EC2/EC3: engine CLI v2 fail-fast vs system-path pass-through
+# ---------------------------------------------------------------------------
+case_ec1() {
+  local home_path="$1"
+  bridge_resolve_engine_cli() { printf "%s" "$home_path/fake-home/.local/bin/claude"; }
+  bridge_linux_traverse_stop_for() { printf "%s" "$home_path/fake-home"; }
+  bridge_linux_grant_engine_cli_access "ec2-user" "claude"
+}
+case_ec2() {
+  local home_path="$1"
+  bridge_resolve_engine_cli() { printf "%s" "$home_path/fake-system/claude-symlink"; }
+  bridge_linux_traverse_stop_for() {
+    case "$1" in
+      *fake-home/.local/bin/claude) printf "%s" "$home_path/fake-home" ;;
+      *) printf "" ;;
+    esac
+  }
+  bridge_linux_grant_engine_cli_access "ec2-user" "claude"
+}
+case_ec3() {
+  local home_path="$1"
+  bridge_resolve_engine_cli() { printf "%s" "$home_path/fake-system/claude"; }
+  bridge_linux_traverse_stop_for() { printf ""; }
+  bridge_linux_can_sudo_to() { return 1; }  # skip optional probe
+  bridge_linux_grant_engine_cli_access "ec2-user" "claude"
+}
+log "case: EC1/EC2/EC3 engine CLI v2 controller-home reject + system-path pass"
+EC_DIR="$TMP_ROOT/ec"
+EC_LOG="$EC_DIR/sudo.log"
+mkdir -p "$EC_DIR/fake-home/.local/bin" "$EC_DIR/fake-system"
+touch "$EC_DIR/fake-home/.local/bin/claude"
+chmod 0755 "$EC_DIR/fake-home/.local/bin/claude"
+touch "$EC_DIR/fake-system/claude"
+chmod 0755 "$EC_DIR/fake-system/claude"
+ln -sf "$EC_DIR/fake-home/.local/bin/claude" "$EC_DIR/fake-system/claude-symlink"
+: >"$EC_LOG"
+
+ec1_rc=0
+run_in_v2 "$EC_DIR" "$EC_LOG" case_ec1 "$EC_DIR" 2>/dev/null || ec1_rc=$?
+[[ $ec1_rc -ne 0 ]] || die "EC1 expected die for controller-home cli_path, got rc=0"
+ok "EC1 v2 engine CLI controller-home reject (rc=$ec1_rc)"
+
+ec2_rc=0
+run_in_v2 "$EC_DIR" "$EC_LOG" case_ec2 "$EC_DIR" 2>/dev/null || ec2_rc=$?
+[[ $ec2_rc -ne 0 ]] || die "EC2 expected die for controller-home cli_real (symlink), got rc=0"
+ok "EC2 v2 engine CLI controller-home cli_real reject (rc=$ec2_rc)"
+
+: >"$EC_LOG"
+run_in_v2 "$EC_DIR" "$EC_LOG" case_ec3 "$EC_DIR"
+assert_no_setfacl "$EC_LOG" "EC3 v2 engine CLI system path" || die "EC3 leaked setfacl on system path"
+ok "EC3 v2 engine CLI system path pass-through (no setfacl)"
+
+# ---------------------------------------------------------------------------
+# CR1: credentials helper in v2 → setfacl ≥ 1 (transitional exception)
+# ---------------------------------------------------------------------------
+case_cr1() {
+  local cr_dir="$1"
+  bridge_linux_require_setfacl() { return 0; }
+  getent() {
+    if [[ "$1" == "passwd" && "$2" == "ec2-user" ]]; then
+      printf "ec2-user:x:1000:1000::%s:/bin/bash\n" "$cr_dir/ctrl-home"
+    fi
+  }
+  bridge_linux_grant_claude_credentials_access \
+    "ec2-user" "$cr_dir/iso-home" "ec2-user" "claude"
+}
+log "case: CR1 credentials helper v2 transitional exception"
+CR_DIR="$TMP_ROOT/cr"
+CR_LOG="$CR_DIR/sudo.log"
+mkdir -p "$CR_DIR/ctrl-home/.claude" "$CR_DIR/iso-home"
+echo '{"token":"redacted"}' > "$CR_DIR/ctrl-home/.claude/.credentials.json"
+chmod 0600 "$CR_DIR/ctrl-home/.claude/.credentials.json"
+: >"$CR_LOG"
+run_in_v2 "$CR_DIR" "$CR_LOG" case_cr1 "$CR_DIR"
+assert_some_setfacl "$CR_LOG" "CR1 v2 credentials helper" \
+  || die "CR1 expected setfacl ≥ 1 for v2 cred exception"
+ok "CR1 v2 credentials helper transitional exception (setfacl ≥ 1)"
+
+# ---------------------------------------------------------------------------
+# CR2: credentials helper in v2 + missing setfacl → die before symlink plant
+# ---------------------------------------------------------------------------
+case_cr2() {
+  local cr_dir="$1"
+  bridge_linux_require_setfacl() { bridge_die "smoke: setfacl missing in v2+claude"; }
+  getent() {
+    if [[ "$1" == "passwd" && "$2" == "ec2-user" ]]; then
+      printf "ec2-user:x:1000:1000::%s:/bin/bash\n" "$cr_dir/ctrl-home"
+    fi
+  }
+  bridge_linux_grant_claude_credentials_access \
+    "ec2-user" "$cr_dir/iso-home" "ec2-user" "claude"
+}
+log "case: CR2 credentials helper v2 fails loud when setfacl missing"
+CR2_DIR="$TMP_ROOT/cr2"
+CR2_LOG="$CR2_DIR/sudo.log"
+mkdir -p "$CR2_DIR/ctrl-home/.claude" "$CR2_DIR/iso-home"
+echo '{"token":"redacted"}' > "$CR2_DIR/ctrl-home/.claude/.credentials.json"
+: >"$CR2_LOG"
+cr2_rc=0
+run_in_v2 "$CR2_DIR" "$CR2_LOG" case_cr2 "$CR2_DIR" 2>/dev/null || cr2_rc=$?
+[[ $cr2_rc -ne 0 ]] || die "CR2 expected die when setfacl missing in v2+claude, got rc=0"
+[[ ! -e "$CR2_DIR/iso-home/.claude/.credentials.json" ]] \
+  || die "CR2 expected no symlink plant on early die, but found one"
+ok "CR2 v2+claude+missing-setfacl fails loud before symlink plant (rc=$cr2_rc)"
+
+# ---------------------------------------------------------------------------
+# LP1: legacy parity — same helpers emit setfacl in legacy mode
+# ---------------------------------------------------------------------------
+case_lp1() {
+  local base="$1"
+  bridge_linux_acl_add "u:foo:r--" "$base/a"
+  bridge_linux_acl_add_recursive "u:foo:rwX" "$base/a"
+  bridge_linux_grant_traverse_chain "foo" "$base/a/b" "$base"
+}
+log "case: LP1 legacy parity (setfacl ≥ 1)"
+LP_DIR="$TMP_ROOT/lp"
+LP_LOG="$LP_DIR/sudo.log"
+mkdir -p "$LP_DIR/a/b"
+: >"$LP_LOG"
+run_in_legacy "$LP_DIR" "$LP_LOG" case_lp1 "$LP_DIR"
+assert_some_setfacl "$LP_LOG" "LP1 legacy primitives" \
+  || die "LP1 legacy mode produced no setfacl (regression)"
+ok "LP1 legacy parity preserved (setfacl ≥ 1)"
+
+# ---------------------------------------------------------------------------
+# CT1/CT2/CT3 — channel symlink target group-mode + TOCTOU + symlink reject
+# ---------------------------------------------------------------------------
+case_ct() {
+  local iso_home="$1"
+  local target="$2"
+  local agent="$3"
+  bridge_linux_install_isolated_channel_symlink \
+    "ec2-user" "$iso_home" "ec2-user" "discord" "$target" "$agent"
+}
+log "case: CT1/CT2/CT3 channel symlink target group-mode + TOCTOU"
+CT_DIR="$TMP_ROOT/ct"
+CT_LOG="$CT_DIR/sudo.log"
+mkdir -p "$CT_DIR/iso-home/.claude/channels" "$CT_DIR/state"
+TARGET_NEW="$CT_DIR/state/discord-new"
+TARGET_EXISTING="$CT_DIR/state/discord-existing"
+mkdir -p "$TARGET_EXISTING"
+TARGET_SYMLINK="$CT_DIR/state/discord-symlink"
+ln -s "$TARGET_EXISTING" "$TARGET_SYMLINK"
+
+# CT1: new target.
+: >"$CT_LOG"
+run_in_v2 "$CT_DIR" "$CT_LOG" case_ct "$CT_DIR/iso-home" "$TARGET_NEW" "smoke-ct1"
+assert_no_setfacl "$CT_LOG" "CT1 v2 channel symlink (new)" || die "CT1 leaked setfacl"
+grep -q "^chmod 2770 .*discord-new" "$CT_LOG" || die "CT1 missing chmod 2770"
+grep -q "^chgrp ab-agent-smoke-ct1 .*discord-new" "$CT_LOG" || die "CT1 missing chgrp ab-agent-smoke-ct1"
+ok "CT1 v2 channel symlink target (new) → 2770/group-correct, no setfacl"
+
+# CT2: existing target.
+: >"$CT_LOG"
+run_in_v2 "$CT_DIR" "$CT_LOG" case_ct "$CT_DIR/iso-home" "$TARGET_EXISTING" "smoke-ct2"
+assert_no_setfacl "$CT_LOG" "CT2 v2 channel symlink (existing)" || die "CT2 leaked setfacl"
+grep -q "^chmod 2770 .*discord-existing" "$CT_LOG" || die "CT2 missing chmod 2770 on existing"
+grep -q "^chgrp ab-agent-smoke-ct2 .*discord-existing" "$CT_LOG" || die "CT2 missing chgrp on existing"
+ok "CT2 v2 channel symlink target (existing) → idempotent normalize"
+
+# CT3: target is a symlink — refuse.
+: >"$CT_LOG"
+ct3_rc=0
+run_in_v2 "$CT_DIR" "$CT_LOG" case_ct "$CT_DIR/iso-home" "$TARGET_SYMLINK" "smoke-ct3" \
+  2>/dev/null || ct3_rc=$?
+[[ $ct3_rc -ne 0 ]] || die "CT3 expected non-zero rc when target is symlink, got 0"
+if grep -qE "^(chgrp|chmod 2770) .*discord-symlink" "$CT_LOG"; then
+  die "CT3 unexpectedly mutated symlink target: $(grep -E 'discord-symlink' "$CT_LOG")"
+fi
+ok "CT3 v2 channel symlink target (symlink) → reject without mutation (rc=$ct3_rc)"
+
+# ---------------------------------------------------------------------------
+# X1-X4: root-required (opt-in via BRIDGE_TEST_V2_PRE_ROOT=1)
+# ---------------------------------------------------------------------------
+if [[ "${BRIDGE_TEST_V2_PRE_ROOT:-0}" != "1" ]]; then
+  log "skip: X1-X4 (set BRIDGE_TEST_V2_PRE_ROOT=1 + provide sudo to enable)"
+else
+  if ! sudo -n true 2>/dev/null; then
+    log "skip: X1-X4 (BRIDGE_TEST_V2_PRE_ROOT=1 set but sudo -n unavailable)"
+  else
+    log "case: X1-X4 root-required (operator opt-in)"
+    cat <<'OPERATOR_NOTE'
+[v2-pr-e] X1-X4 operator probes (run against live install with at least two ab-agent groups):
+  X1. # Cross-agent EACCES — agent A's UID cannot read agent B's root.
+      sudo -u agent-bridge-<A> test -r $BRIDGE_AGENT_ROOT_V2/<B>
+                                                                  -> fails (group separation)
+      sudo -u agent-bridge-<A> ls    $BRIDGE_AGENT_ROOT_V2/<B>
+                                                                  -> fails
+  X2. # Self-agent — A's UID can read its own resources.
+      sudo -u agent-bridge-<A> cat $BRIDGE_AGENT_ROOT_V2/<A>/runtime/agent-env.sh
+                                                                  -> ok (group r--)
+      sudo -u agent-bridge-<A> cat $BRIDGE_AGENT_ROOT_V2/<A>/.claude/plugins/installed_plugins.json
+                                                                  -> ok (group r--)
+      sudo -u agent-bridge-<A> test -x $BRIDGE_AGENT_ROOT_V2/<A>/.claude/plugins
+                                                                  -> ok (group r-x)
+      sudo -u agent-bridge-<A> test -d $BRIDGE_AGENT_ROOT_V2/<A>/workdir/.discord
+                                                                  -> ok (group r-x via 2770)
+  X3. # Engine CLI exec via isolated UID.
+      sudo -u agent-bridge-<A> test -x $(command -v claude)        -> ok (system path)
+  X4. # Channel target file inheritance — setgid + umask 007 composition.
+      sudo -u agent-bridge-<A> bash -c 'umask 007; touch $BRIDGE_AGENT_ROOT_V2/<A>/workdir/.discord/state.env'
+      stat -c '%G %a' $BRIDGE_AGENT_ROOT_V2/<A>/workdir/.discord/state.env
+                                                                  -> "ab-agent-<A> 660"
+OPERATOR_NOTE
+    ok "X1-X4 operator probes documented (manual run against live install)"
+  fi
+fi
+
+log "PR-E smoke complete"


### PR DESCRIPTION
## Summary

Layout v2 (PR-A/B/C/D foundation) now stops using named-user POSIX ACLs.
v2 mode runs on the per-agent group + setgid contract end-to-end, with
**one** documented and tested transitional exception
(`bridge_linux_grant_claude_credentials_access`) that retains ACL
access into the operator's `~/.claude/.credentials.json`.

## What's in scope

* **ACL primitive helpers** + **direct-setfacl helpers** short-circuit
  in v2 (`bridge_linux_acl_add` / `_recursive` / `_default_dirs_recursive`
  / `_remove_recursive`, `bridge_linux_grant_traverse_chain` /
  `_revoke_traverse_chain` / `_revoke_plugin_channel_grants` /
  `bridge_linux_acl_repair_channel_env_files`).
* **Traverse refactor**: `_bridge_linux_grant_traverse_paths` private
  emitter owns the `/`-reject + missing-stop reject + Python resolver
  + ancestor check; both the public v2-noop wrapper and the private
  `_bridge_linux_grant_traverse_chain_unguarded` (used only by the
  credential exception) consume the same emitter.
* **Group-mode replacements** for ACL-load-bearing v2 artifacts:
  - `agent-env.sh` → `chgrp ab-agent-<name>` + chmod 0640
  - per-UID `installed_plugins.json` (manifest writer signature now
    takes an explicit `agent` arg) → chgrp + chmod 0640
  - `$user_home/.claude/plugins` + `marketplaces` → `chown root:ab-agent-<name>`,
    chmod 2750
  - channel symlink target → chgrp + chmod 2770 (idempotent for both
    new + pre-existing targets, with explicit `test -L` TOCTOU guards)
* **Engine CLI fail-fast** (v2): controller-home paths rejected for
  both `cli_path` and `readlink -f` target. Optional execute probe via
  `bridge_linux_can_sudo_to`-gated `sudo -n -u <os_user> test -x` so
  no nested-sudo pitfalls.
* **`BRIDGE_SHARED_GROUP` membership** is now ensured in
  `bridge_linux_prepare_agent_isolation` for both the isolated UID
  (die on failure) and the controller (warn unless shared plugin
  cache becomes unreadable, in which case escalate to die).
* **`bridge_linux_require_setfacl`** is now gated to legacy mode and
  to v2-with-Claude (covers the credential exception). v2 + non-Claude
  drops the `acl` package prerequisite entirely.
* **`bridge-run.sh` umask wiring**: new `bridge_run_apply_v2_umask_if_needed`
  helper sets umask 007 after `bridge_require_agent` (both startup +
  roster-reload paths) so the agent process tree creates files at
  0660/group inheritance under setgid dirs. The umask is the missing
  piece that lets controller (group member) read agent-created channel
  state files without ACLs.

## C1 transitional Claude credential exception

`bridge_linux_grant_claude_credentials_access` keeps named-user ACL
access in v2 mode for the symlink path
(`controller_home/.claude/.credentials.json`) and the traversal chain
up to `controller_home`. Rationale: that file lives outside the v2
layout (operator's `~/.claude/`), and the v2 group contract has no
path INTO operator-private space. The helper:

* Calls `bridge_linux_require_setfacl` in v2 mode so silent breakage
  is impossible (PR-E r5 r3).
* Uses `_bridge_linux_grant_traverse_chain_unguarded` to bypass the
  v2 short-circuit on the public traverse helper.
* Is the **only** v2 surface that emits `setfacl` calls.

PR-F or a future PR will switch to per-agent `claude login`, removing
this last surface — that's an operator workflow change, deliberately
deferred.

## Smoke

`tests/isolation-v2-pr-e/smoke.sh`:

* **17 rootless cases** (all passing): P1-P4 (primitive + traverse
  parity), E1 (env file), M1-M2 (manifest), PC1 (plugin catalog root),
  CT1-CT3 (channel target + TOCTOU + symlink reject), EC1-EC3
  (engine CLI fail-fast + system path), CR1-CR2 (cred exception +
  missing-setfacl die), UM1-UM2 (umask helper), LP1 (legacy parity).
* **4 root-required opt-in cases** (X1-X4) behind
  `BRIDGE_TEST_V2_PRE_ROOT=1` + sudo, following PR-C's documented
  operator-probe pattern.

## Plan-review history

6 rounds of plan-review with dev-codex (the reviewer found 27 distinct
mechanism gaps across r1-r5; r6 confirmed plan-ok with three
implementation notes that are reflected here).

## Test plan

- [x] `bash -n lib/bridge-agents.sh bridge-run.sh tests/isolation-v2-pr-e/smoke.sh` clean
- [x] `tests/isolation-v2-pr-e/smoke.sh` (rootless) — 17/17 pass
- [ ] `BRIDGE_TEST_V2_PRE_ROOT=1 tests/isolation-v2-pr-e/smoke.sh` against a live install with ≥2 ab-agent groups (operator)
- [ ] `scripts/smoke-test.sh` legacy mode regression check
- [ ] Manual on a v2 install: confirm `setfacl` calls limited to the credential exception (other helpers count = 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)