### PR TITLE
memory-daily: apply-time migration cleanup + static-only docs (#376 B+D)

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -666,6 +666,46 @@ step_memory_daily_cron_one() {
     existing_tz="$(printf '%s' "$found" | awk -F'\t' '{print $3}')"
   fi
 
+  # Issue #376 Track B: apply-time migration. Track A (v0.6.18) gates the
+  # registration loop on STATIC_AGENT_SET so a fresh bootstrap no longer
+  # creates memory-daily-<agent> crons for dynamic agents. But pre-v0.6.18
+  # installs already have those crons sitting on the cron board — Track C
+  # makes the harvester silently no-op for them, but the entries remain
+  # dead weight until removed. Detect and clean them up here, mirroring
+  # the 3-mode pattern used for the #320 Track A migration in step_cron_one.
+  #
+  # Dynamic = "active claude agent NOT in STATIC_AGENT_SET". This avoids an
+  # extra `agb agent show --json` subprocess per agent — the static set is
+  # already loaded at script start from list_active_static_claude_agents.
+  if [[ -z "${STATIC_AGENT_SET[$agent]:-}" ]]; then
+    if [[ -n "$found" ]]; then
+      case "$MODE" in
+        apply)
+          if "$BRIDGE_AGB" cron delete "$existing_id" >/dev/null 2>&1; then
+            record "$agent" "cron:$title" "migrated-removed" \
+              "id=$existing_id reason=dynamic-agent-not-memory-daily-target"
+          else
+            record "$agent" "cron:$title" "migrate-failed" \
+              "id=$existing_id reason=dynamic-agent-not-memory-daily-target"
+            note_drift
+          fi
+          ;;
+        dry-run)
+          record "$agent" "cron:$title" "would-remove" \
+            "id=$existing_id reason=dynamic-agent-not-memory-daily-target"
+          ;;
+        check|*)
+          record "$agent" "cron:$title" "drift-migration-pending" \
+            "id=$existing_id reason=dynamic-agent-not-memory-daily-target"
+          note_drift
+          ;;
+      esac
+    else
+      record "$agent" "cron:$title" "skip-dynamic-agent" ""
+    fi
+    return 0
+  fi
+
   if ! memory_daily_gate_on "$agent"; then
     # Gate off. If a cron exists, schedule a cleanup in apply mode; else skip.
     if [[ -n "$found" ]]; then
@@ -990,12 +1030,13 @@ while IFS=$'\t' read -r agent home; do
   [[ -z "$agent" || -z "$home" ]] && continue
   step_hook_one "$agent" "$home"
   step_rebuild_one "$agent" "$home"
-  # Issue #376: only register memory-daily-<agent> crons for static agents.
-  # Dynamic agents have no stable per-agent home; the harvester would fail
-  # every morning with exit 2 and spam admin's queue with cron-followup tasks.
-  if [[ -n "${STATIC_AGENT_SET[$agent]:-}" ]]; then
-    step_memory_daily_cron_one "$agent"
-  fi
+  # Issue #376: memory-daily-<agent> registration is gated on static-class
+  # membership *inside* step_memory_daily_cron_one. The function returns
+  # early for dynamic agents — either deleting a stale pre-v0.6.18 cron
+  # (Track B apply-time migration) or recording skip-dynamic-agent when no
+  # cron exists. Always invoke; the static/dynamic split is the function's
+  # responsibility, not the loop's.
+  step_memory_daily_cron_one "$agent"
 done < "$AGENT_LIST_TMP"
 
 for spec in "${CRON_SPECS[@]}"; do

--- a/docs/agent-runtime/memory-daily-harvest.md
+++ b/docs/agent-runtime/memory-daily-harvest.md
@@ -26,7 +26,8 @@ No LLM is invoked. The harvester is pure detection.
 
 ## 2. Cron registration
 
-`bootstrap-memory-system.sh` registers one cron per active Claude agent:
+`bootstrap-memory-system.sh` registers one cron per active **static** Claude
+agent (see [§12 — Static-only contract](#12-static-only-contract)):
 
 - Title: `memory-daily-<agent>`
 - Schedule: `0 3 * * *` (Asia/Seoul)
@@ -402,3 +403,67 @@ invocation.
   not write notes — only queues backfill tasks.
 - Cron rebalancing via `agb cron rebalance-memory-daily` is a separate
   operational surface and not invoked by bootstrap.
+
+## 12. Static-only contract
+
+Per [issue #376](https://github.com/SYRS-AI/agent-bridge-public/issues/376),
+the `memory-daily-<agent>` cron + `memory-daily-harvest.sh` harvester pipeline
+is intentionally scoped to **static** agents only.
+
+### Why
+
+Static agents are managed-from-outside: operators interact via
+Discord/Telegram/Teams, agents run unattended, and the daily note at
+`<agent-home>/memory/<date>.md` is the operational record.
+
+Dynamic agents are managed-from-inside: the operator is at the agent's TUI,
+the conversation IS the operational record, and the transcript is already on
+disk at `~/.claude/projects/<slug>/<sessionId>.jsonl`. There is no separate
+daily note the bridge needs to harvest — the operator already saw everything.
+
+### Enforcement points (defense in depth)
+
+The contract is enforced at three layers so a single forgotten filter at any
+one layer cannot reintroduce the daily exit-2 / `[cron-followup]` storm that
+issue #376 documents:
+
+| Layer | Source | Behavior |
+|---|---|---|
+| Registration filter (Track A, v0.6.18) | `scripts/_common.sh::list_active_static_claude_agents` | Filters `agent list --json` on `engine=="claude" && active && source=="static"`. `bootstrap-memory-system.sh` builds `STATIC_AGENT_SET` from this helper. |
+| Apply-time migration (Track B) | `bootstrap-memory-system.sh::step_memory_daily_cron_one` | When `agent ∉ STATIC_AGENT_SET`, the function detects an existing dynamic-agent cron and removes it via the existing 3-mode pattern (`check` records `drift-migration-pending`; `dry-run` records `would-remove`; `apply` calls `agb cron delete <id>` and records `migrated-removed`). When no cron exists for the dynamic agent, it records `skip-dynamic-agent`. |
+| Harvester refusal (Track C, v0.6.18) | `scripts/memory-daily-harvest.sh` | Re-checks `agent show --json | .source` and exits `0` (success / no-op) — *not* `2` — when source is dynamic. Exit 0 keeps the cron's run-state at success so the daemon does not generate a `[cron-followup]` task. |
+
+Track A prevents new dynamic-agent crons from being registered. Track B
+removes any pre-v0.6.18 dynamic-agent crons on the next
+`bootstrap-memory-system.sh apply` and reports them under `check` / `dry-run`.
+Track C is the last-resort guard that catches manually-created crons or
+future helpers that forget to filter.
+
+### Future helpers
+
+If you add a new per-agent pipeline that depends on `<agent-home>/` existing
+on disk, filter on `source == "static"`. The dynamic-agent case is easy to
+forget because the broader `list_active_claude_agents` helper still emits
+both classes — that helper is preserved for status reporting and watchdog
+scans that genuinely apply to both. For static-only registration, use
+`list_active_static_claude_agents`.
+
+The strict source-class block lives in `bootstrap-memory-system.sh` and
+`scripts/wiki-daily-ingest.sh` per `KNOWN_ISSUES` entry 15 — do not lift
+it into a new `_common.sh` helper without re-reviewing that contract.
+
+### Operator-side cleanup of pre-fix installs
+
+Operators with installs bootstrapped before v0.6.18 already have
+`memory-daily-<agent>` crons registered for dynamic agents. After v0.6.18,
+the harvester silently no-ops via Track C, so the dead crons are harmless —
+but they remain dead weight on the cron board until removed. To clean them
+up automatically:
+
+```bash
+bash bootstrap-memory-system.sh --apply
+```
+
+The Track B branch in `step_memory_daily_cron_one` detects the existing
+dynamic-agent crons and removes them with a `migrated-removed` audit row.
+Re-runs are no-ops (the lookup returns nothing on the second pass).


### PR DESCRIPTION
## Summary

Reference: (#376 Tracks B+D). Cleanup follow-up to v0.6.18 PR #378 (Tracks A+C). All four tracks of #376 are now in tree.

## Track B — apply-time migration

`bootstrap-memory-system.sh::step_memory_daily_cron_one` detects existing `memory-daily-<agent>` crons whose agent is dynamic and removes them via the existing 3-mode pattern:

- **check**: records `drift-migration-pending` and notes drift.
- **dry-run**: records `would-remove`.
- **apply**: `agb cron delete <id>` + records `migrated-removed`. Delete failure records `migrate-failed` and notes drift.

Implementation notes:

- Dynamic-class check uses membership in `STATIC_AGENT_SET` (already loaded at script start from `list_active_static_claude_agents`), so no extra per-agent `agb agent show --json` subprocess is paid.
- Call-site loop is updated to always invoke `step_memory_daily_cron_one`; the static/dynamic split is the function's responsibility now, not the loop's. Static-agent paths through the function are unchanged.
- When a dynamic agent has no existing cron (the post-v0.6.18 fresh-install case), the function records `skip-dynamic-agent` and returns 0 — no `note_drift`.

Operators with installs bootstrapped before v0.6.18 had dynamic-agent crons registered; v0.6.18 Track C made the harvester silently no-op for them, but the cron entries remained on the cron board until removed by hand. Track B closes that loop on the next `bash bootstrap-memory-system.sh --apply`.

## Track D — docs

`docs/agent-runtime/memory-daily-harvest.md` gets a new section 12 ("Static-only contract") documenting the three layers that enforce the static-only memory-daily contract — Track A registration filter (`scripts/_common.sh::list_active_static_claude_agents`), Track B apply-time migration (this PR), and Track C harvester refusal (`scripts/memory-daily-harvest.sh`). Section 2 ("Cron registration") gets a cross-link to the new section so future readers land on the contract before assuming `every active claude agent`.

The doc also points future per-agent pipeline authors at the strict source-class block in `bootstrap-memory-system.sh` / `wiki-daily-ingest.sh` per `KNOWN_ISSUES` entry 15, so a new per-agent flow that depends on `<agent-home>/` won't duplicate the omission that #376 documented.

## Verification

- `bash -n bootstrap-memory-system.sh` — PASS
- `shellcheck bootstrap-memory-system.sh` — PASS
- 3-mode branch present: `grep -nB1 -A2 "dynamic-agent-not-memory-daily-target" bootstrap-memory-system.sh` shows all four record() lines (apply migrated-removed, apply migrate-failed, dry-run would-remove, check drift-migration-pending) with the same reason string.
- Track D doc lands at `docs/agent-runtime/memory-daily-harvest.md` §12 with the cross-link from §2.

Reference: (#376 B+D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)