### PR TITLE
hooks(session-start): self-enqueue handoff-pending task so queue contract enforces NEXT-SESSION.md priority (#409 Track A)

### DIFF
--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -324,14 +324,18 @@ def _enqueue_handoff_pending(agent: str, next_session: Path, digest: str) -> Non
         f"\n"
         f"Auto-enqueued by bridge_hook_common._enqueue_handoff_pending.\n"
     )
-    # find-open guard: skip if a same-titled task is already open for the agent.
-    # bridge-queue.py find-open --title-prefix uses SQL LIKE; with --format json
-    # and no --all, returns a single dict (or returncode 1 with empty stdout).
+    # find-open guard: skip if a same-digest handoff task is already open.
+    # bridge-queue.py find-open --title-prefix uses SQL LIKE; passing the FULL
+    # digest-bearing title as the prefix is the exact-match form (no other
+    # title starts with this exact string since digest8 + ")" is terminal).
+    # Codex r1 flagged the LIMIT 1 trap: a generic prefix like
+    # "[bridge:handoff-pending]" matches an older different-digest row first
+    # and suppresses the new enqueue, missing the current handoff.
     try:
         existing = queue_cli([
             "find-open",
             "--agent", agent,
-            "--title-prefix", "[bridge:handoff-pending]",
+            "--title-prefix", title,
             "--format", "json",
         ])
         if existing.returncode == 0 and existing.stdout.strip():

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -250,7 +250,7 @@ def onboarding_state_from_file(path: Path | None) -> str:
     return match.group(1)
 
 
-def _stamp_next_session_delivered(agent: str, next_session: Path) -> None:
+def _stamp_next_session_delivered(agent: str, next_session: Path) -> str | None:
     """Persist the SHA-1 digest of NEXT-SESSION.md into the per-agent marker.
 
     The bash-side `bridge_agent_maybe_expire_next_session` gates on
@@ -261,13 +261,17 @@ def _stamp_next_session_delivered(agent: str, next_session: Path) -> None:
     marker here so `bridge-run.sh`'s reconcile step can age out a stale
     handoff file the next time a Claude agent restarts.
 
+    Returns the digest string on success so callers (e.g. the queue-route
+    handoff path in #409 Track A) can use it as an idempotency key. Returns
+    None when the file cannot be read or the marker cannot be written.
+
     Best-effort: any IO failure is swallowed so the hook never blocks agent
     startup over marker bookkeeping.
     """
     try:
         content = next_session.read_bytes()
     except OSError:
-        return
+        return None
     # bridge_agent_next_session_digest (bash) pipes the file through
     # `bridge_sha1 "$(cat $file)"`. Command substitution strips trailing
     # newlines before the argument reaches Python's hashlib, so hashing
@@ -286,6 +290,70 @@ def _stamp_next_session_delivered(agent: str, next_session: Path) -> None:
         marker_file.parent.mkdir(parents=True, exist_ok=True)
         marker_file.write_text(digest, encoding="utf-8")
     except OSError:
+        return None
+    return digest
+
+
+def _enqueue_handoff_pending(agent: str, next_session: Path, digest: str) -> None:
+    """Self-enqueue an urgent task so the queue contract enforces handoff priority.
+
+    The hook's stdout-as-context surface (current behaviour) puts the handoff
+    instruction on equal footing with whatever the operator types as the first
+    user message. Empirically the operator's intent wins and the handoff is
+    silently skipped. By creating a queued task on the agent's own inbox at
+    the same time, the existing "claim highest-priority queued task first"
+    contract turns the handoff into a hard precondition for any other work.
+
+    Idempotency: title carries the digest so re-running for the same handoff
+    file produces a duplicate-title task that bridge-task.sh's find-open path
+    refuses to re-create. A new digest (handoff content changed) yields a new
+    task; an unchanged digest is a no-op.
+
+    Best-effort: any IO/subprocess failure is swallowed so the hook never
+    blocks agent startup over enqueue bookkeeping. The stdout-as-context path
+    still runs as a fallback regardless.
+    """
+    title = f"[bridge:handoff-pending] {next_session.name} ({digest[:8]})"
+    body = (
+        f"NEXT-SESSION.md handoff detected at {next_session}.\n"
+        f"\n"
+        f"Read this file in full and execute its checklist before any other work. "
+        f"Reply briefly to the operator (\"handoff 처리부터 하겠습니다\") if a user "
+        f"message is also pending; resume normal flow only after the file is "
+        f"deleted by the agent.\n"
+        f"\n"
+        f"Auto-enqueued by bridge_hook_common._enqueue_handoff_pending.\n"
+    )
+    # find-open guard: skip if a same-titled task is already open for the agent.
+    # bridge-queue.py find-open --title-prefix uses SQL LIKE; with --format json
+    # and no --all, returns a single dict (or returncode 1 with empty stdout).
+    try:
+        existing = queue_cli([
+            "find-open",
+            "--agent", agent,
+            "--title-prefix", "[bridge:handoff-pending]",
+            "--format", "json",
+        ])
+        if existing.returncode == 0 and existing.stdout.strip():
+            try:
+                row = json.loads(existing.stdout)
+            except (json.JSONDecodeError, ValueError):
+                row = None
+            if isinstance(row, dict) and row.get("title", "") == title:
+                return  # already enqueued for this exact digest
+    except Exception:
+        pass
+    try:
+        queue_cli([
+            "create",
+            "--to", agent,
+            "--from", agent,
+            "--priority", "urgent",
+            "--title", title,
+            "--body", body,
+        ])
+    except Exception:
+        # Hook must not block agent startup on enqueue failure.
         return
 
 
@@ -309,7 +377,9 @@ def bootstrap_artifact_context(agent: str) -> str:
         if excerpt:
             lines.append("Handoff excerpt:")
             lines.append(excerpt)
-        _stamp_next_session_delivered(agent, next_session)
+        digest = _stamp_next_session_delivered(agent, next_session)
+        if digest is not None:
+            _enqueue_handoff_pending(agent, next_session, digest)
 
     session_type = first_existing_path(
         [


### PR DESCRIPTION
## Summary

`NEXT-SESSION.md` handoff was advisory only — the SessionStart hook injected a stdout context line, which empirically got out-prioritized by whatever the operator typed as the first user message and was silently skipped.

This change also self-enqueues an urgent task on the agent's own inbox when a handoff is detected. The existing queue contract ("claim highest-priority queued task first") then turns the handoff into a hard precondition for any other work.

## What changed

- `hooks/bridge_hook_common.py` only.
  - New helper `_enqueue_handoff_pending(agent, next_session, digest)` — idempotent enqueue via the existing `queue_cli` path, using a digest-suffixed title and a `find-open --title-prefix` guard.
  - `_stamp_next_session_delivered` return type widened from `None` to `str | None` (returns the SHA-1 digest, or `None` on IO failure) so the new helper can use it as the idempotency key.
  - `bootstrap_artifact_context` calls the new helper after the existing stamp call, only when stamping succeeded.
  - Existing "Handoff present:" stdout-as-context surface is unchanged.

## Verification

All 5 checks from the brief passed locally:

1. **`ast.parse`** — `python3 -c "import ast; ast.parse(open('hooks/bridge_hook_common.py').read())"` → OK.
2. **stamp callers grep** — `grep -nE "_stamp_next_session_delivered" hooks/` returns the def site (line 253) and the single caller (line 380, in `bootstrap_artifact_context`). No other callers broke.
3. **No-NEXT-SESSION smoke** — `BRIDGE_AGENT_ID=foo python3 hooks/session_start.py --matcher startup` against an empty isolated `BRIDGE_HOME` → exit 0, only the queue-protocol message is emitted, no enqueue, no error.
4. **Idempotency smoke** — running the hook twice against the same `NEXT-SESSION.md` produced exactly 1 `[bridge:handoff-pending]` urgent task (digest `ed6c9200…`). Changing the file's content and running a third time produced a new task with a fresh digest while leaving the original queued — confirming "same digest = no-op, new digest = fresh enqueue."
5. **`queue_cli`-unavailable smoke** — running the hook with `PATH=/usr/bin` and from a copy of `hooks/` whose script-dir parent has no `bridge-queue.py` → exit 0, no traceback, the existing "Handoff present:" stdout context still emits.

Smoke recipe (env-scrubbed to bypass the operator's live `BRIDGE_*` exports):

```bash
TMP=/tmp/handoff-test-$$
mkdir -p "$TMP/agents/foo" "$TMP/state/agents/foo"
echo "test handoff line" > "$TMP/agents/foo/NEXT-SESSION.md"
env -i HOME="$HOME" PATH="$PATH" \
  BRIDGE_HOME="$TMP" BRIDGE_STATE_DIR="$TMP/state" BRIDGE_TASK_DB="$TMP/state/tasks.db" \
  BRIDGE_AGENT_HOME_ROOT="$TMP/agents" BRIDGE_ACTIVE_AGENT_DIR="$TMP/state/agents" \
  BRIDGE_AGENT_ID=foo python3 hooks/session_start.py --matcher resume
# … run twice, then inspect $TMP/state/tasks.db
```

## Idempotency

- Title format: `[bridge:handoff-pending] <basename> (<digest8>)` — the digest substring is the SHA-1 prefix of the trailing-newline-stripped handoff bytes (matches the bash side's `bridge_agent_next_session_digest`).
- `bridge-queue.py find-open --agent <a> --title-prefix "[bridge:handoff-pending]" --format json` returns the existing open task (if any) for the same agent. The helper compares its `title` field against the new title — equal → skip; unequal → enqueue.
- This guard holds across hook re-deliveries (`startup`, `resume`, `compact`) because the digest is content-derived, not invocation-derived.
- A handoff content change yields a new digest, hence a new urgent task. The operator can `done` the old one once the new handoff is processed.

## Backwards compatibility

- The existing stdout-as-context "Handoff present:" lines are still emitted unchanged — operators reading the transcript still see them.
- `_stamp_next_session_delivered` return type changed from `-> None` to `-> str | None`. The single caller in `bootstrap_artifact_context` now uses the return value; no other module references the helper (verified via `grep -rn _stamp_next_session_delivered hooks/`).

## CI

Pre-existing CI failures on `main` are not addressed here — out of scope for a Track A fix. Not blocking.

## Scope discipline

- No `VERSION` bump, no `CHANGELOG.md` entry.
- Only `hooks/bridge_hook_common.py` touched (1 file, +73 / -3).
- Single commit.

Addresses Track A of #409. Tracks B (settings.json schema cleanup) / C (role contract strengthening) / D (audit row for unacted handoff) stay open.