### PR TITLE
bridge-run: schedule dev-channels accept for non-isolated agents too (#410)

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -350,28 +350,23 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
 
 bridge_run_should_auto_accept_dev_channels() {
   local launch_cmd="$1"
-  local allowed=""
   local effective=""
-  local item=""
-  local -a items=()
 
   [[ "$ENGINE" == "claude" ]] || return 1
   [[ $SAFE_MODE -eq 0 ]] || return 1
+  # Presence of --dangerously-load-development-channels in the launch cmd
+  # is itself the operator's explicit opt-in; the warning picker is a
+  # confirmation of that same decision. Auto-accept whenever any dev
+  # channel is extracted from the cmd, regardless of the per-agent
+  # allowlist or isolation mode. PR #364 r2 originally gated this on the
+  # bridge_agent_auto_accept_dev_channels_csv allowlist, which silently
+  # excluded non-isolated agents whose roster had a non-default override
+  # (issue #410: sales_sean stalled indefinitely on the picker on cold
+  # start because the per-agent allowlist did not intersect the loaded
+  # dev channels).
   effective="$(bridge_extract_development_channels_from_command "$launch_cmd")"
   [[ -n "$effective" ]] || return 1
-  allowed="$(bridge_agent_auto_accept_dev_channels_csv "$AGENT")"
-  [[ -n "$allowed" ]] || return 1
-
-  IFS=',' read -r -a items <<<"$allowed"
-  for item in "${items[@]}"; do
-    item="$(bridge_trim_whitespace "$item")"
-    [[ -n "$item" ]] || continue
-    if bridge_channel_csv_contains "$effective" "$item"; then
-      return 0
-    fi
-  done
-
-  return 1
+  return 0
 }
 
 bridge_run_schedule_dev_channels_accept() {


### PR DESCRIPTION
## Summary

Reference: #410.

PR #364 hardened the dev-channels picker auto-accept for isolated agents in v0.6.18. The same WARNING picker fires on **non-isolated** agents whose launch command contains `--dangerously-load-development-channels`, but `bridge_run_should_auto_accept_dev_channels` required the per-agent allowlist (`bridge_agent_auto_accept_dev_channels_csv`) to intersect the launch cmd's effective dev channels. Non-isolated agents whose roster set a non-default `BRIDGE_AGENT_AUTO_ACCEPT_DEV_CHANNELS` override — or whose loaded dev channels did not include the default `plugin:teams@agent-bridge` — fell out of that intersection. The predicate returned 1, the schedule helper short-circuited, and the picker stalled indefinitely on cold start.

## Change

`bridge-run.sh` `bridge_run_should_auto_accept_dev_channels`: drop the allowlist intersection step. Presence of `--dangerously-load-development-channels` in the launch cmd is itself the operator's explicit opt-in to dev mode, and the warning picker is a confirmation of that same decision. The engine=claude, !safe-mode, and dev-channels-extracted guards are unchanged.

The schedule helper itself (`bridge_run_schedule_dev_channels_accept`) is engine-agnostic and tmux-driven, so the same logic applies to both isolated and non-isolated paths.

## What this PR does NOT change

- `bridge_run_schedule_dev_channels_accept` body unchanged (PR #364 r2 picker advance + log redirect).
- `bridge_tmux_wait_for_prompt` state-machine unchanged.
- No new env-overridable knobs.
- `bridge_agent_auto_accept_dev_channels_csv` left in place (out of scope to remove the now-vestigial helper).

## Verification

- `bash -n bridge-run.sh` PASS
- `shellcheck bridge-run.sh` PASS
- Unit-level shell test (5 cases) PASS:
  - dev-channels in cmd → returns 0 (auto-accept)
  - no dev-channels in cmd → returns 1 (skip)
  - codex engine → returns 1 (skip)
  - safe mode → returns 1 (skip)
  - non-default dev channel only (e.g. `plugin:ms365@agent-bridge`) → returns 0 (this case previously broke and stalled the picker; #410 root cause)

## Operator manual verification

Operator should observe the dev-channels picker auto-clear on a non-isolated static Claude agent with `--dangerously-load-development-channels` in its launch cmd, within `BRIDGE_RUN_DEV_CHANNELS_ACCEPT_TIMEOUT_SECONDS` (default 60s) on next cold start.

Reference: #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)