### PR TITLE
hooks(stop): enforce input-source -> mcp reply matching at runtime (#415)

### DIFF
--- a/agents/_template/.claude/settings.json
+++ b/agents/_template/.claude/settings.json
@@ -12,6 +12,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 ~/.agent-bridge/hooks/surface-reply-enforce.py",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/surface-reply-enforce.py
+++ b/hooks/surface-reply-enforce.py
@@ -83,9 +83,11 @@ def _extract_text(message_content) -> str:
 
 def _latest_pending_channel_input(entries: list[dict]):
     """Walk entries in reverse and return the most recent user turn's
-    (source, chat_id, message_id) tuple. Returns None if no channel-source
-    user turn is found in the trailing block."""
-    for entry in reversed(entries):
+    (source, chat_id, message_id, index) tuple where `index` is the
+    position of that user turn inside `entries`. Returns None if no
+    channel-source user turn is found in the trailing block."""
+    for idx in range(len(entries) - 1, -1, -1):
+        entry = entries[idx]
         if entry.get("type") != "user":
             continue
         text = _extract_text((entry.get("message") or {}).get("content"))
@@ -93,7 +95,7 @@ def _latest_pending_channel_input(entries: list[dict]):
         if match:
             source = match.group(1).lower()
             if source in SUPPORTED_SURFACES:
-                return (source, match.group(2), match.group(3))
+                return (source, match.group(2), match.group(3), idx)
         # No supported channel tag on this user turn -> stop walking; we only
         # enforce when the latest user turn was channel-sourced.
         return None
@@ -104,23 +106,17 @@ def _assistant_replies_for_surface(
     entries: list[dict],
     source: str,
     chat_id: str,
+    user_idx: int,
 ) -> bool:
-    """Walk forward from the latest channel-source user turn; return True
-    when an assistant tool_use of mcp__plugin_<source>__reply with matching
-    chat_id is found, OR when an explicit <no-reply-needed source=..
-    chat_id=..> marker appears in the assistant text."""
+    """Walk forward from the latest channel-source user turn (anchored at
+    `user_idx`); return True when an assistant tool_use of
+    mcp__plugin_<source>__reply with matching chat_id is found, OR when an
+    explicit <no-reply-needed source=.. chat_id=..> marker appears in the
+    assistant text. Codex r1 fix #415: anchoring on user_idx (not the first
+    same-chat user turn from the start of transcript) prevents an older
+    reply from satisfying a newer unanswered message in the same chat."""
     expected_tool = f"mcp__plugin_{source}__reply"
-    found_user = False
-    for entry in entries:
-        if not found_user:
-            if entry.get("type") == "user":
-                text = _extract_text((entry.get("message") or {}).get("content"))
-                m = CHANNEL_TAG_RE.search(text)
-                if m and m.group(1).lower() == source and m.group(2) == chat_id:
-                    found_user = True
-            continue
-
-        # Past the latest channel-source user turn; check assistant replies.
+    for entry in entries[user_idx + 1:]:
         if entry.get("type") != "assistant":
             continue
         content = (entry.get("message") or {}).get("content")
@@ -169,8 +165,8 @@ def main() -> int:
     if pending is None:
         return 0
 
-    source, chat_id, message_id = pending
-    if _assistant_replies_for_surface(entries, source, chat_id):
+    source, chat_id, message_id, user_idx = pending
+    if _assistant_replies_for_surface(entries, source, chat_id, user_idx):
         return 0
 
     reason = (

--- a/hooks/surface-reply-enforce.py
+++ b/hooks/surface-reply-enforce.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Stop hook: enforce that channel-sourced user turns get a matching mcp reply.
+
+Runs once at Stop. If the latest user turn carries
+`<channel source="<surface>" chat_id="<id>" message_id="<id>" ...>` tags,
+the assistant turn must invoke `mcp__plugin_<surface>__reply` with a
+matching chat_id, OR the assistant text must include an explicit
+`<no-reply-needed source="<surface>" chat_id="<id>" reason="..." />`
+marker. Otherwise emit `{"decision": "block", "reason": "..."}` so
+Claude Code re-enters the turn and gives the agent a chance to send
+the reply.
+
+Issue #415 — textual rule from #342 kept regressing within 24h on the
+originating agent. Stop hook is the runtime boundary that doesn't rely
+on the LLM remembering the rule.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+
+# Channel-source surfaces we enforce. Each maps to the mcp tool name
+# the agent must invoke to send the reply. Keep this list aligned with
+# the plugins that ship a `*__reply` tool (discord/telegram/teams).
+# ms365 plugin uses a different reply shape (email-send) and is not
+# enforced here.
+SUPPORTED_SURFACES = ("discord", "telegram", "teams")
+
+CHANNEL_TAG_RE = re.compile(
+    r'<channel\s+source="([^"]+)"\s+chat_id="([^"]+)"\s+message_id="([^"]+)"',
+    re.IGNORECASE,
+)
+NO_REPLY_MARKER_RE = re.compile(
+    r'<no-reply-needed\s+source="([^"]+)"\s+chat_id="([^"]+)"',
+    re.IGNORECASE,
+)
+
+
+def load_event() -> dict:
+    raw = sys.stdin.read().strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _read_transcript(path: str) -> list[dict]:
+    if not path:
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            entries: list[dict] = []
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entries.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+            return entries
+    except OSError:
+        return []
+
+
+def _extract_text(message_content) -> str:
+    if isinstance(message_content, str):
+        return message_content
+    if isinstance(message_content, list):
+        text = ""
+        for part in message_content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                text += str(part.get("text") or "")
+        return text
+    return ""
+
+
+def _latest_pending_channel_input(entries: list[dict]):
+    """Walk entries in reverse and return the most recent user turn's
+    (source, chat_id, message_id) tuple. Returns None if no channel-source
+    user turn is found in the trailing block."""
+    for entry in reversed(entries):
+        if entry.get("type") != "user":
+            continue
+        text = _extract_text((entry.get("message") or {}).get("content"))
+        match = CHANNEL_TAG_RE.search(text)
+        if match:
+            source = match.group(1).lower()
+            if source in SUPPORTED_SURFACES:
+                return (source, match.group(2), match.group(3))
+        # No supported channel tag on this user turn -> stop walking; we only
+        # enforce when the latest user turn was channel-sourced.
+        return None
+    return None
+
+
+def _assistant_replies_for_surface(
+    entries: list[dict],
+    source: str,
+    chat_id: str,
+) -> bool:
+    """Walk forward from the latest channel-source user turn; return True
+    when an assistant tool_use of mcp__plugin_<source>__reply with matching
+    chat_id is found, OR when an explicit <no-reply-needed source=..
+    chat_id=..> marker appears in the assistant text."""
+    expected_tool = f"mcp__plugin_{source}__reply"
+    found_user = False
+    for entry in entries:
+        if not found_user:
+            if entry.get("type") == "user":
+                text = _extract_text((entry.get("message") or {}).get("content"))
+                m = CHANNEL_TAG_RE.search(text)
+                if m and m.group(1).lower() == source and m.group(2) == chat_id:
+                    found_user = True
+            continue
+
+        # Past the latest channel-source user turn; check assistant replies.
+        if entry.get("type") != "assistant":
+            continue
+        content = (entry.get("message") or {}).get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            ptype = part.get("type")
+            if ptype == "tool_use" and part.get("name") == expected_tool:
+                tool_input = part.get("input") or {}
+                cand = tool_input.get("chat_id")
+                if cand is None:
+                    cand = tool_input.get("chatId")
+                if str(cand or "") == str(chat_id):
+                    return True
+            if ptype == "text":
+                text = str(part.get("text") or "")
+                for nm in NO_REPLY_MARKER_RE.finditer(text):
+                    if nm.group(1).lower() == source and nm.group(2) == chat_id:
+                        return True
+    return False
+
+
+def main() -> int:
+    event = load_event()
+    if not event:
+        return 0
+
+    # Re-entry guard: if Stop hook is already active for this turn,
+    # don't re-block (mirrors the existing check_inbox.py pattern).
+    if event.get("stop_hook_active"):
+        return 0
+
+    # TUI-only / admin sessions: no BRIDGE_AGENT_ID -> not enforced.
+    agent_id = os.environ.get("BRIDGE_AGENT_ID", "").strip()
+    if not agent_id:
+        return 0
+
+    transcript_path = str(event.get("transcript_path") or "")
+    entries = _read_transcript(transcript_path)
+    if not entries:
+        return 0
+
+    pending = _latest_pending_channel_input(entries)
+    if pending is None:
+        return 0
+
+    source, chat_id, message_id = pending
+    if _assistant_replies_for_surface(entries, source, chat_id):
+        return 0
+
+    reason = (
+        f"{source} chat_id={chat_id} message_id={message_id} "
+        f"입력에 대한 답변이 mcp__plugin_{source}__reply 호출로 전송되지 않았습니다. "
+        f"답변 본문 작성 후 reply tool 호출 후 다시 종료하세요. "
+        f"(답변이 불필요하면 assistant text에 "
+        f'<no-reply-needed source="{source}" chat_id="{chat_id}" reason="..." /> 마커 추가)'
+    )
+    response = {"decision": "block", "reason": reason}
+    sys.stdout.write(json.dumps(response, ensure_ascii=False))
+    sys.stdout.flush()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/surface-reply-enforce/smoke.sh
+++ b/tests/surface-reply-enforce/smoke.sh
@@ -76,6 +76,20 @@ write_transcript_tui_only() {
 JSONL
 }
 
+write_transcript_old_reply_new_unanswered() {
+  # codex r1 fix: an OLD reply to chat_id=C123 must NOT satisfy a NEW
+  # unanswered user turn from the SAME chat_id. The reply scanner used
+  # to walk forward from the start of the transcript and matched the
+  # first reply for that chat_id, leaking past a newer unanswered
+  # message in the same chat.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M111\" />\nfirst question"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"answering"},{"type":"tool_use","name":"mcp__plugin_discord__reply","input":{"chat_id":"C123","content":"old reply"}}]}}
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M222\" />\nsecond question — needs a fresh reply"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"thinking out loud, no reply tool"}]}}
+JSONL
+}
+
 run_hook() {
   # $1: transcript path
   # $2: BRIDGE_AGENT_ID value (use empty string to unset)
@@ -140,5 +154,22 @@ write_transcript_missing_reply "$T"
 out="$(run_hook "$T" "agent-foo" ',"stop_hook_active":true')"
 [[ -z "$out" ]] || die "case (f) expected no output (stop_hook_active=true), got: $out"
 pass "(f) stop_hook_active re-entry -> silent"
+
+# ---- Case (g) old reply for same chat_id must NOT satisfy newer unanswered ----
+# codex r1 regression: reply scanner anchored at index of the LATEST
+# channel-source user turn, not the first same-chat user turn from the
+# start of the transcript.
+T="$TMP/g.jsonl"
+write_transcript_old_reply_new_unanswered "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -n "$out" ]] || die "case (g) expected block JSON for new unanswered turn, got empty (old reply leaked through)"
+echo "$out" | python3 -c '
+import json, sys
+data = json.loads(sys.stdin.read())
+assert data.get("decision") == "block"
+reason = data.get("reason", "")
+assert "M222" in reason, "reason should reference NEW message_id, got: " + reason
+' || die "case (g) JSON shape mismatch (old reply may be satisfying new unanswered)"
+pass "(g) old reply for same chat_id does not satisfy newer unanswered turn"
 
 log "all cases passed"

--- a/tests/surface-reply-enforce/smoke.sh
+++ b/tests/surface-reply-enforce/smoke.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# tests/surface-reply-enforce/smoke.sh
+#
+# Regression test for issue #415 — Stop hook input-source ↔ output-reply
+# enforcement.
+#
+# The hook reads a Claude Code Stop event from stdin (JSON with
+# `transcript_path` and optional `stop_hook_active`), inspects the JSONL
+# transcript at `transcript_path`, and emits
+# `{"decision":"block","reason":"..."}` on stdout iff:
+#
+#   1. BRIDGE_AGENT_ID is non-empty (i.e. real agent session, not TUI-only)
+#   2. The latest user turn carries a <channel source="<surface>"
+#      chat_id="<id>" message_id="<id>"> tag for a supported surface
+#      (discord/telegram/teams)
+#   3. No subsequent assistant turn invoked
+#      mcp__plugin_<surface>__reply with matching chat_id
+#   4. No subsequent assistant text emitted
+#      <no-reply-needed source="<surface>" chat_id="<id>" ...>
+#
+# Otherwise it is silent and exits 0 (Stop proceeds).
+#
+# We exercise five cases:
+#   (a) channel input + matching mcp reply  -> exit 0, no output
+#   (b) channel input + missing reply       -> exit 0, JSON block on stdout
+#   (c) channel input + <no-reply-needed/>  -> exit 0, no output
+#   (d) TUI-source input (no channel tag)   -> exit 0, no output
+#   (e) BRIDGE_AGENT_ID empty               -> exit 0, no output
+#   (f) stop_hook_active=true re-entry      -> exit 0, no output
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+HOOK="$REPO_ROOT/hooks/surface-reply-enforce.py"
+
+log() { printf '[surface-reply-enforce] %s\n' "$*"; }
+die() { printf '[surface-reply-enforce][error] %s\n' "$*" >&2; exit 1; }
+pass() { printf '[surface-reply-enforce][pass] %s\n' "$*"; }
+
+[[ -f "$HOOK" ]] || die "hook missing: $HOOK"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+write_transcript_with_reply() {
+  # User turn (Discord-source) followed by assistant tool_use of
+  # mcp__plugin_discord__reply with matching chat_id.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"sending"},{"type":"tool_use","name":"mcp__plugin_discord__reply","input":{"chat_id":"C123","content":"hi back"}}]}}
+JSONL
+}
+
+write_transcript_missing_reply() {
+  # User turn (Discord-source) followed by an assistant turn that ONLY
+  # writes prose — no reply tool, no marker. This is the bug.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Here are three options: A/B/C."}]}}
+JSONL
+}
+
+write_transcript_no_reply_marker() {
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"bot noise; no reply needed.\n<no-reply-needed source=\"discord\" chat_id=\"C123\" reason=\"bot ack\" />"}]}}
+JSONL
+}
+
+write_transcript_tui_only() {
+  # No <channel ...> tag on the latest user turn.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"please show me the queue"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"sure"}]}}
+JSONL
+}
+
+run_hook() {
+  # $1: transcript path
+  # $2: BRIDGE_AGENT_ID value (use empty string to unset)
+  # $3: extra event JSON keys (e.g. ',"stop_hook_active":true'); may be empty
+  local transcript="$1" agent_id="$2" extra="${3:-}"
+  local event="{\"transcript_path\":\"$transcript\"$extra}"
+  if [[ -z "$agent_id" ]]; then
+    BRIDGE_AGENT_ID="" python3 "$HOOK" <<<"$event"
+  else
+    BRIDGE_AGENT_ID="$agent_id" python3 "$HOOK" <<<"$event"
+  fi
+}
+
+# ---- Case (a) channel input + matching mcp reply -> silent --------------
+T="$TMP/a.jsonl"
+write_transcript_with_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (a) expected no output, got: $out"
+pass "(a) channel input + matching reply -> silent"
+
+# ---- Case (b) channel input + missing reply -> block --------------------
+T="$TMP/b.jsonl"
+write_transcript_missing_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -n "$out" ]] || die "case (b) expected block JSON, got empty"
+echo "$out" | python3 -c '
+import json, sys
+data = json.loads(sys.stdin.read())
+decision = data.get("decision")
+assert decision == "block", "decision=" + repr(decision)
+reason = data.get("reason", "")
+assert "discord" in reason.lower(), "reason missing surface: " + reason
+assert "C123" in reason, "reason missing chat_id: " + reason
+assert "mcp__plugin_discord__reply" in reason, "reason missing tool: " + reason
+' || die "case (b) JSON shape mismatch"
+pass "(b) channel input + missing reply -> block"
+
+# ---- Case (c) channel input + <no-reply-needed/> -> silent --------------
+T="$TMP/c.jsonl"
+write_transcript_no_reply_marker "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (c) expected no output, got: $out"
+pass "(c) channel input + no-reply marker -> silent"
+
+# ---- Case (d) TUI-source input (no channel tag) -> silent ---------------
+T="$TMP/d.jsonl"
+write_transcript_tui_only "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (d) expected no output, got: $out"
+pass "(d) TUI-source input -> silent"
+
+# ---- Case (e) BRIDGE_AGENT_ID empty -> silent (even on a missing-reply transcript) ----
+T="$TMP/e.jsonl"
+write_transcript_missing_reply "$T"
+out="$(run_hook "$T" "")"
+[[ -z "$out" ]] || die "case (e) expected no output (BRIDGE_AGENT_ID empty), got: $out"
+pass "(e) BRIDGE_AGENT_ID empty -> silent"
+
+# ---- Case (f) stop_hook_active=true re-entry -> silent ------------------
+T="$TMP/f.jsonl"
+write_transcript_missing_reply "$T"
+out="$(run_hook "$T" "agent-foo" ',"stop_hook_active":true')"
+[[ -z "$out" ]] || die "case (f) expected no output (stop_hook_active=true), got: $out"
+pass "(f) stop_hook_active re-entry -> silent"
+
+log "all cases passed"


### PR DESCRIPTION
## Summary

Reference: #415.

Issue #342 closed with a textual fix only (plugin tool descriptions + `_template/CLAUDE.md` rule). Within 24h the same defect resurfaced twice on the reporter's host — once on `syrs-satomi` (skipped Discord reply for ~1h36m), once on `patch` (the agent that filed #342, replied to a TUI question via Discord). Same-day re-occurrence on the originator is the strongest signal that text-only enforcement is insufficient.

This PR adds a Stop hook that enforces the rule at the runtime boundary.

## Changes

- `hooks/surface-reply-enforce.py` (new) — Stop hook. Reads transcript, finds the latest user turn with `<channel source=... chat_id=... message_id=...>` tags, checks whether the assistant turn invoked the matching `mcp__plugin_<source>__reply` OR emitted a `<no-reply-needed source="..." chat_id="..." />` marker. Blocks Stop with a corrective `reason` if mismatch. Re-entry guard via `stop_hook_active`. Bypassed when `BRIDGE_AGENT_ID` is empty (TUI-only / admin sessions). `load_event()` mirrors `check_inbox.py` (the existing common module does not export one).
- `agents/_template/.claude/settings.json` — registers the hook in a new `Stop` array. `agb upgrade` propagates to channel-paired agents.
- `tests/surface-reply-enforce/smoke.sh` (new) — 6-case fixture exercising every code path; runs with `bash tests/surface-reply-enforce/smoke.sh`.

Surfaces enforced: discord / telegram / teams (i.e., the plugins that ship a `*__reply` tool). ms365 uses a different reply shape and is not enforced.

## Smoke matrix (all PASS locally)

| # | Setup | Expected | Result |
|---|---|---|---|
| a | channel input + matching `mcp__plugin_discord__reply` (chat_id match) | exit 0, no output | PASS |
| b | channel input + assistant prose only (no reply, no marker) | `{"decision":"block","reason":"…"}` on stdout | PASS |
| c | channel input + `<no-reply-needed source="discord" chat_id="C123" />` marker | exit 0, no output | PASS |
| d | TUI-source input (no channel tag on latest user turn) | exit 0, no output | PASS |
| e | `BRIDGE_AGENT_ID` empty (admin / TUI-only) | exit 0, no output | PASS |
| f | `stop_hook_active=true` re-entry | exit 0, no output | PASS |

## Out of scope (separate concerns)

- Fabricated `message_id` sent-log (issue's "Incident A step 5"): tracked separately.
- Subagent dispatch detection beyond the `BRIDGE_AGENT_ID` empty gate.
- Plugin tool description text update telling the agent how to emit `<no-reply-needed/>`: operator can land that as a follow-up; the block reason already documents the marker shape inline.

## Verification

- `python3 -c "import ast; ast.parse(open('hooks/surface-reply-enforce.py').read())"` — PASS
- `python3 -c "import json; json.load(open('agents/_template/.claude/settings.json'))"` — PASS
- `bash -n tests/surface-reply-enforce/smoke.sh` — PASS
- `shellcheck tests/surface-reply-enforce/smoke.sh` — clean
- `bash tests/surface-reply-enforce/smoke.sh` — 6/6 cases PASS

Reference: #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)