### PR TITLE
daemon: skip context-pressure task for dynamic agents (#419)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1796,6 +1796,26 @@ process_context_pressure_reports() {
         --detail mode=hash_drift
       changed=0
     fi
+
+    # Issue #419: dynamic agents are operator-managed — admin doesn't act on
+    # context-pressure for them (the static-target task body itself instructs
+    # admin to close such tasks as no-ops). Skip task creation entirely
+    # instead of letting admin process and immediately close, same anti-pattern
+    # the v0.6.22 fix #393 closed for cron-followup memory_pressure deferrals.
+    # State is cleared so first_detected_ts doesn't accumulate indefinitely.
+    local source_kind=""
+    source_kind="$(bridge_agent_source "$agent")"
+    if [[ "$source_kind" == "dynamic" ]]; then
+      bridge_audit_log daemon context_pressure_suppressed "$agent" \
+        --detail severity="$severity" \
+        --detail reason=dynamic_agent_operator_managed \
+        --detail excerpt_hash="$excerpt_hash"
+      daemon_info "skipped context-pressure task for dynamic agent $agent (operator-managed)"
+      bridge_clear_context_pressure_state "$agent"
+      changed=0
+      continue
+    fi
+
     last_detected_ts="$now_ts"
     title="$(bridge_context_pressure_title "$agent" "$severity")"
     title_prefix="$(bridge_context_pressure_title_prefix "$agent")"


### PR DESCRIPTION
## Summary

Reference: #419.

`bridge-daemon.sh::process_context_pressure_reports` was creating high-priority `[context-pressure] <agent>` tasks for admin even when the target was a dynamic agent — and the task body itself documented that admin should close it as a no-op (`bridge-daemon.sh:1571`: "Operator-managed. ... Close this task with a one-line note `dynamic agent — operator-managed`."). Same anti-pattern as #393 (memory_pressure deferral cron-followup spam), fixed in v0.6.22 with a daemon-side skip.

## Change

After the severity / excerpt-hash classification and the existing `context_pressure_detected` edge audit row have fired, gate on `bridge_agent_source`:

- `source == "dynamic"` → audit `context_pressure_suppressed reason=dynamic_agent_operator_managed`, log `daemon_info`, clear the per-agent context-pressure state file (so `first_detected_ts` doesn't accumulate indefinitely), `continue`. No task created.
- `source == "static"` → unchanged: existing find-open / update / create path runs as today, including direct-notify for the admin self-case.

The dynamic-agent reference inside the static task's cross-target body text (`bridge-daemon.sh:1571,1579` in `bridge_write_context_pressure_report_body`) is unchanged — that's a different code path.

## Verification

- `bash -n bridge-daemon.sh` → PASS
- `shellcheck bridge-daemon.sh` → PASS
- Trace verification documented in commit body covers static (unchanged), dynamic (new skip with audit + state clear + no task), no-pressure (unchanged early-out) cases.
- `scripts/smoke-test.sh` context-pressure block uses a static-shaped roster entry, so the new gate is not entered and the existing assertions on report task creation / dedupe / recovery are preserved by inspection. The smoke run on this branch fails on a pre-existing assertion at `daemon stop --force` (unrelated to context-pressure code path) that also reproduces on `main` without these changes.

Reference: #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)