### PR TITLE
fix(isolate): move plugin-grant ledger out of runtime state dir

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1315,13 +1315,27 @@ print("present:other")
 PY
 }
 
+bridge_isolated_plugin_grants_state_dir() {
+  # Controller-owned ledger root for plugin-share ACL grants. Keep this out
+  # of $BRIDGE_ACTIVE_AGENT_DIR/<agent>: in legacy mode that path is also the
+  # runtime state directory, which needs the normal isolated/controller write
+  # ACL contract for agent-env.sh and session state.
+  printf '%s/isolated-plugin-grants' "$BRIDGE_STATE_DIR"
+}
+
 bridge_isolated_plugin_grants_state_file() {
-  # State file recording the channel set last granted plugin-share ACLs to
-  # an isolated agent. Lives under $BRIDGE_ACTIVE_AGENT_DIR/<agent>/ — the
-  # same per-agent state pattern used by other isolation helpers. Used by
-  # bridge_linux_share_plugin_catalog (to compute added/removed channels
-  # across reapply) and by bridge_migration_unisolate (to revoke channels
-  # the live roster may already have dropped).
+  # State file recording the channel set last granted plugin-share ACLs to an
+  # isolated agent. Used by bridge_linux_share_plugin_catalog (to compute
+  # added/removed channels across reapply) and by bridge_migration_unisolate
+  # (to revoke channels the live roster may already have dropped).
+  local agent="$1"
+  printf '%s/%s.json' "$(bridge_isolated_plugin_grants_state_dir)" "$agent"
+}
+
+bridge_isolated_plugin_grants_legacy_state_file() {
+  # v0.6.28 wrote the grant ledger under the agent runtime state directory.
+  # Keep a fallback reader/remover so upgrades can revoke stale grants and
+  # migrate the ledger without leaving the old file behind.
   local agent="$1"
   printf '%s/%s/isolated-plugin-grants.json' "$BRIDGE_ACTIVE_AGENT_DIR" "$agent"
 }
@@ -1334,8 +1348,17 @@ bridge_isolated_plugin_grants_read() {
   # write so callers can rely on stable ordering.
   local agent="$1"
   local state_file=""
+  local legacy_state_file=""
   state_file="$(bridge_isolated_plugin_grants_state_file "$agent")"
-  [[ -e "$state_file" ]] || { printf ''; return 0; }
+  legacy_state_file="$(bridge_isolated_plugin_grants_legacy_state_file "$agent")"
+  if bridge_linux_sudo_root test -e "$state_file"; then
+    :
+  elif bridge_linux_sudo_root test -e "$legacy_state_file"; then
+    state_file="$legacy_state_file"
+  else
+    printf ''
+    return 0
+  fi
   bridge_require_python
   bridge_linux_sudo_root python3 - "$state_file" <<'PY'
 import json, os, sys
@@ -1362,9 +1385,11 @@ bridge_isolated_plugin_grants_write() {
   local channels_csv="$2"
   local state_file=""
   local state_dir=""
+  local legacy_state_file=""
   local tmp_file=""
   state_file="$(bridge_isolated_plugin_grants_state_file "$agent")"
   state_dir="$(dirname "$state_file")"
+  legacy_state_file="$(bridge_isolated_plugin_grants_legacy_state_file "$agent")"
   bridge_linux_sudo_root mkdir -p "$state_dir"
   # Place the temp file in the destination dir so the mv is always within
   # one filesystem (atomic rename); see Blocking 2 in PR #302 r1.
@@ -1382,6 +1407,9 @@ PY
   bridge_linux_sudo_root chmod 0640 "$state_file"
   bridge_linux_sudo_root chown root:root "$state_dir" >/dev/null 2>&1 || true
   bridge_linux_sudo_root chmod 0750 "$state_dir" >/dev/null 2>&1 || true
+  if [[ "$legacy_state_file" != "$state_file" ]]; then
+    bridge_linux_sudo_root rm -f "$legacy_state_file" >/dev/null 2>&1 || true
+  fi
 }
 
 bridge_isolated_plugin_grants_remove() {
@@ -1389,9 +1417,16 @@ bridge_isolated_plugin_grants_remove() {
   # ACL strip completes successfully).
   local agent="$1"
   local state_file=""
+  local legacy_state_file=""
   state_file="$(bridge_isolated_plugin_grants_state_file "$agent")"
-  [[ -e "$state_file" ]] || return 0
-  bridge_linux_sudo_root rm -f "$state_file" >/dev/null 2>&1 || true
+  legacy_state_file="$(bridge_isolated_plugin_grants_legacy_state_file "$agent")"
+  if bridge_linux_sudo_root test -e "$state_file"; then
+    bridge_linux_sudo_root rm -f "$state_file" >/dev/null 2>&1 || true
+  fi
+  if [[ "$legacy_state_file" != "$state_file" ]] \
+      && bridge_linux_sudo_root test -e "$legacy_state_file"; then
+    bridge_linux_sudo_root rm -f "$legacy_state_file" >/dev/null 2>&1 || true
+  fi
 }
 
 bridge_linux_revoke_plugin_channel_grants() {
@@ -1622,7 +1657,7 @@ bridge_linux_share_plugin_catalog() {
   #
   # Reapply contract: the helper is rerun on every isolate refresh. To
   # keep the isolation boundary tight, the previously-granted channel
-  # set is persisted under $BRIDGE_ACTIVE_AGENT_DIR/<agent>/ and diffed
+  # set is persisted under a root-owned controller ledger and diffed
   # against the current channels — channels removed from the roster
   # have their ACLs and catalog symlinks revoked here, not just at
   # unisolate. (Blocking 1 in PR #302 r1.)

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -285,8 +285,12 @@ if sudo -n -u "$TEST_OS_USER" cat "$undeclared_path/server.ts" >/dev/null 2>&1; 
 fi
 
 log "verifying persisted grant-set state file recorded the channel"
-state_file="$BRIDGE_ACTIVE_AGENT_DIR/$TEST_AGENT/isolated-plugin-grants.json"
+state_file="$(bridge_isolated_plugin_grants_state_file "$TEST_AGENT")"
+legacy_state_file="$(bridge_isolated_plugin_grants_legacy_state_file "$TEST_AGENT")"
 sudo -n test -e "$state_file" || die "expected persisted grant-set at $state_file"
+if sudo -n test -e "$legacy_state_file" 2>/dev/null; then
+  die "legacy grant-set path still exists at $legacy_state_file; grant ledger must not harden runtime state dir"
+fi
 sudo -n cat "$state_file" | python3 -c '
 import json, sys
 data = json.load(sys.stdin)


### PR DESCRIPTION
## Summary

On v0.6.28, `agent-bridge isolate <agent>` can partially fail on Linux with `Permission denied` while writing `<bridge-home>/state/agents/<agent>/agent-env.sh`.

The failure happens after plugin-sharing setup narrows the POSIX ACL mask on the same directory that later needs to receive `agent-env.sh`.

## Reproduction

Run isolate from a clean environment on a Linux host with a linux-user isolated agent:

```bash
env -i HOME="$HOME" PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
  BRIDGE_HOME="$HOME/.agent-bridge" bash -lc \
  '"$HOME/.agent-bridge/agent-bridge" isolate <agent>'
```

Observed tail:

```text
[apply]   install per-agent ACLs + queue-gateway dirs + hidden-path strips
.../lib/bridge-agents.sh: line <line>: .../state/agents/<agent>/agent-env.sh: Permission denied
chmod: cannot access '.../state/agents/<agent>/agent-env.sh': No such file or directory
[warning] bridge_linux_prepare_agent_isolation returned non-zero for <agent>
[done] isolation applied for <agent>
```

The resulting directory shape is:

```text
state/agents/<agent>:
  owner root:root, mode 0750
  user:<isolated>:rwx #effective:r-x
  user:<controller>:rwx #effective:r-x
  mask::r-x
```

## Root Cause

`bridge_linux_prepare_agent_isolation` expects the legacy runtime state directory `$BRIDGE_ACTIVE_AGENT_DIR/<agent>` to remain writable by the controller so it can emit `agent-env.sh`.

During the same prepare pass, `bridge_linux_share_plugin_catalog` calls `bridge_isolated_plugin_grants_write`.

In v0.6.28 the persisted grant-set path is:

```text
$BRIDGE_ACTIVE_AGENT_DIR/<agent>/isolated-plugin-grants.json
```

The writer then hardens `dirname "$state_file"` with:

```text
chown root:root "$state_dir"
chmod 0750 "$state_dir"
```

In legacy mode, `state_dir` is the runtime state directory. The `chmod 0750` resets the ACL mask to `r-x`, capping the controller's named `rwx` entry to effective read/execute. The subsequent `cat > agent-env.sh` therefore fails.

## Proposed Fix

Move the plugin grant ledger out of the runtime state directory:

```text
$BRIDGE_STATE_DIR/isolated-plugin-grants/<agent>.json
```

Keep the new ledger root-owned (`0750`) and the file root-owned (`0640`). Add a fallback reader/remover for the v0.6.28 path so upgrade/reapply can still revoke grants and migrate away from the old file.

This avoids broadening runtime directory ACL masks and keeps the grant ledger tamper-resistant.

## Security Notes

Setting `mask::rwx` on the runtime directory would restore writes but would also make all named `rwx` entries effective on that directory. Writing `agent-env.sh` through root would bypass the symptom but leave the ledger hardening the wrong directory. Moving the ledger preserves both contracts: runtime state keeps its normal ACLs, and the grant ledger stays root-owned outside the isolated UID's writable runtime tree.

## Verification

- `bash -n lib/bridge-agents.sh tests/isolation-plugin-sharing.sh tests/isolation-queue-gateway-acl.sh`
- `git diff --check origin/main..HEAD`
- Targeted ledger smoke: new ledger path, runtime dir unchanged.
- Targeted legacy migration smoke: read old path, write new path, remove old path.

Verified locally on Linux EC2 production host (Cosmax intranet, isolated agent + cosmax-marketplace plugins) — verify report follows in a comment after #346 + #362 acceptance reruns.
