### PR TITLE
wave: agent-bridge wave dispatch spawns workers + queue tasks (#276 Phase 1.2)

### DIFF
--- a/bridge-wave.py
+++ b/bridge-wave.py
@@ -232,7 +232,12 @@ def cmd_state_list_members(args: list[str]) -> int:
         if state_filter and m.get("state") != state_filter:
             continue
         brief_rel = m.get("brief_path") or ""
-        brief_abs = str(shared_root / brief_rel) if brief_rel else ""
+        # codex r1 item 9: brief paths must be absolute regardless of the
+        # caller's CWD or whether shared_dir is relative. `.resolve()` (not
+        # `.absolute()`) also normalizes symlinks so the consumer in
+        # lib/bridge-wave.sh can pass the path to `bridge-task.sh
+        # --body-file` from any CWD without ENOENT.
+        brief_abs = str((shared_root / brief_rel).resolve()) if brief_rel else ""
         print(f"{m['member_id']}\t{m.get('track', '')}\t{brief_abs}")
     return 0
 
@@ -245,6 +250,14 @@ def cmd_state_mark_running(args: list[str]) -> int:
     `wave_member_queued:<member-id>` audit row and bumps `updated_at`. Atomic
     write via _atomic_write so a partial failure can't leave the JSON
     half-written.
+
+    Exit codes:
+      0  — member transitioned pending -> running
+      1  — state file or member not found
+      2  — required arg missing / invalid (incl. empty value for a wiring field)
+      3  — state precondition violated: the member is not in `pending` (e.g.
+           already running). Caller should treat this as "skip" rather than
+           fatal so retry / partial-rerun scenarios are idempotent.
 
     Args:
       <state-file> --member-id <id> --worker <name> --worktree-root <path>
@@ -285,6 +298,13 @@ def cmd_state_mark_running(args: list[str]) -> int:
             print(f"missing required: --{r}", file=sys.stderr)
             return 2
 
+    # codex r1 item 10: reject empty-string wiring fields up front so we
+    # never advance state to running with a blank worker / branch / etc.
+    for r in required:
+        if not fields[r].strip():
+            print(f"refusing to mark-running: empty --{r}", file=sys.stderr)
+            return 2
+
     try:
         task_id = int(fields["task-id"])
     except ValueError:
@@ -307,6 +327,18 @@ def cmd_state_mark_running(args: list[str]) -> int:
         print(f"member not found in state: {target_id}", file=sys.stderr)
         return 1
 
+    # codex r1 item 4: only `pending` -> `running` is a legal transition.
+    # Refuse with rc=3 so the bash dispatcher can interpret this as
+    # "already-advanced, skip" rather than treating it as fatal.
+    prior_state = matched.get("state")
+    if prior_state != "pending":
+        print(
+            f"refusing to mark-running: member {target_id} is in state "
+            f"{prior_state!r}, not 'pending'",
+            file=sys.stderr,
+        )
+        return 3
+
     matched["state"] = "running"
     matched["worker"] = fields["worker"]
     matched["worktree_root"] = fields["worktree-root"]
@@ -315,7 +347,15 @@ def cmd_state_mark_running(args: list[str]) -> int:
 
     state["updated_at"] = _now_iso()
     audit = state.setdefault("audit", [])
-    audit.append(f"wave_member_queued:{target_id}")
+    # codex r1 item 5: state-only inspection should still see worker / task
+    # / worktree wiring without having to cross-reference bridge_audit_log.
+    audit.append(
+        f"wave_member_queued:{target_id}"
+        f" worker={fields['worker']}"
+        f" task_id={task_id}"
+        f" worktree_root={fields['worktree-root']}"
+        f" branch={fields['branch']}"
+    )
 
     _atomic_write(path, json.dumps(state, indent=2, ensure_ascii=False) + "\n")
     print(json.dumps(matched, indent=2, ensure_ascii=False))

--- a/bridge-wave.py
+++ b/bridge-wave.py
@@ -2,14 +2,18 @@
 """bridge-wave.py — JSON state + render helpers for `agent-bridge wave`.
 
 Phase 1.1: state file read/write, README render, close-keyword lint, member-id
-generation. Worker startup + queue task creation are deferred to Phase 1.2.
+generation. Phase 1.2 adds per-member state mutation (`state-list-members`,
+`state-mark-running`) so dispatch can record worker / worktree / branch /
+queue-task wiring once a worker is spawned.
 
 Subcommands invoked from `lib/bridge-wave.sh`:
 
-  bridge-wave.py state-init <wave-id> <issue-or-brief> <main-agent> <worker-engine> <tracks-csv> <state-file> [<brief-file-relative-to-shared-root>]
+  bridge-wave.py state-init <wave-id> <issue-or-brief> <main-agent> <worker-engine> <reviewer> <tracks-csv> <state-file> [<brief-file-relative-to-shared-root>]
   bridge-wave.py state-show  <state-file>
   bridge-wave.py state-list  <state-dir>
   bridge-wave.py state-render-readme <state-file> <readme-out>
+  bridge-wave.py state-list-members <state-file> [--state pending|running|...]
+  bridge-wave.py state-mark-running <state-file> <member-id> --worker <name> --worktree-root <path> --branch <name> --task-id <int>
   bridge-wave.py member-id-generate <wave-id> <track>
   bridge-wave.py wave-id-generate <issue-or-brief>
   bridge-wave.py close-keyword-scan <file>...
@@ -185,6 +189,139 @@ def cmd_state_list(args: list[str]) -> int:
     return 0
 
 
+def cmd_state_list_members(args: list[str]) -> int:
+    """List members from a wave state file as TSV rows.
+
+    Output: one row per matching member, tab-separated:
+      <member_id>\t<track>\t<absolute_brief_path>
+
+    The brief path stored in state is relative to BRIDGE_SHARED_DIR; this
+    helper joins it with the supplied shared-dir to give the bash caller an
+    absolute path it can pass to `bridge-task.sh create --body-file`.
+
+    Args (positional):
+      <state-file> <shared-dir>
+    Args (optional):
+      --state <name>   only emit members in this state (default: pending)
+    """
+    state_filter = "pending"
+    positional: list[str] = []
+    i = 0
+    while i < len(args):
+        a = args[i]
+        if a == "--state":
+            if i + 1 >= len(args):
+                print("usage: state-list-members <state-file> <shared-dir> [--state <name>]", file=sys.stderr)
+                return 2
+            state_filter = args[i + 1]
+            i += 2
+            continue
+        if a.startswith("--state="):
+            state_filter = a.split("=", 1)[1]
+            i += 1
+            continue
+        positional.append(a)
+        i += 1
+    if len(positional) != 2:
+        print("usage: state-list-members <state-file> <shared-dir> [--state <name>]", file=sys.stderr)
+        return 2
+    state_file, shared_dir = positional
+    state = json.loads(Path(state_file).read_text(encoding="utf-8"))
+    shared_root = Path(shared_dir)
+    for m in state.get("members", []):
+        if state_filter and m.get("state") != state_filter:
+            continue
+        brief_rel = m.get("brief_path") or ""
+        brief_abs = str(shared_root / brief_rel) if brief_rel else ""
+        print(f"{m['member_id']}\t{m.get('track', '')}\t{brief_abs}")
+    return 0
+
+
+def cmd_state_mark_running(args: list[str]) -> int:
+    """Atomically transition a wave member from `pending` → `running`.
+
+    Sets state="running" and the four wiring fields (worker / worktree_root /
+    branch / task_id) on the member identified by --member-id. Appends a
+    `wave_member_queued:<member-id>` audit row and bumps `updated_at`. Atomic
+    write via _atomic_write so a partial failure can't leave the JSON
+    half-written.
+
+    Args:
+      <state-file> --member-id <id> --worker <name> --worktree-root <path>
+                   --branch <name> --task-id <int>
+    """
+    if not args:
+        print(
+            "usage: state-mark-running <state-file> --member-id <id> "
+            "--worker <name> --worktree-root <path> --branch <name> --task-id <int>",
+            file=sys.stderr,
+        )
+        return 2
+    state_file = args[0]
+    rest = args[1:]
+
+    fields: dict[str, str] = {}
+    i = 0
+    while i < len(rest):
+        a = rest[i]
+        if a in ("--member-id", "--worker", "--worktree-root", "--branch", "--task-id"):
+            if i + 1 >= len(rest):
+                print(f"missing value for {a}", file=sys.stderr)
+                return 2
+            fields[a.lstrip("-")] = rest[i + 1]
+            i += 2
+            continue
+        if "=" in a and a.startswith("--"):
+            k, v = a[2:].split("=", 1)
+            fields[k] = v
+            i += 1
+            continue
+        print(f"unknown arg: {a}", file=sys.stderr)
+        return 2
+
+    required = ("member-id", "worker", "worktree-root", "branch", "task-id")
+    for r in required:
+        if r not in fields:
+            print(f"missing required: --{r}", file=sys.stderr)
+            return 2
+
+    try:
+        task_id = int(fields["task-id"])
+    except ValueError:
+        print(f"--task-id must be an integer, got: {fields['task-id']!r}", file=sys.stderr)
+        return 2
+
+    path = Path(state_file)
+    if not path.exists():
+        print(f"state file not found: {path}", file=sys.stderr)
+        return 1
+    state = json.loads(path.read_text(encoding="utf-8"))
+
+    target_id = fields["member-id"]
+    matched = None
+    for m in state.get("members", []):
+        if m["member_id"] == target_id:
+            matched = m
+            break
+    if matched is None:
+        print(f"member not found in state: {target_id}", file=sys.stderr)
+        return 1
+
+    matched["state"] = "running"
+    matched["worker"] = fields["worker"]
+    matched["worktree_root"] = fields["worktree-root"]
+    matched["branch"] = fields["branch"]
+    matched["task_id"] = task_id
+
+    state["updated_at"] = _now_iso()
+    audit = state.setdefault("audit", [])
+    audit.append(f"wave_member_queued:{target_id}")
+
+    _atomic_write(path, json.dumps(state, indent=2, ensure_ascii=False) + "\n")
+    print(json.dumps(matched, indent=2, ensure_ascii=False))
+    return 0
+
+
 def cmd_state_render_readme(args: list[str]) -> int:
     if len(args) != 2:
         print("usage: state-render-readme <state-file> <readme-out>", file=sys.stderr)
@@ -321,6 +458,8 @@ def main(argv: list[str]) -> int:
         "state-init": cmd_state_init,
         "state-show": cmd_state_show,
         "state-list": cmd_state_list,
+        "state-list-members": cmd_state_list_members,
+        "state-mark-running": cmd_state_mark_running,
         "state-render-readme": cmd_state_render_readme,
         "state-show-pretty": cmd_state_show_pretty,
         "state-list-pretty": cmd_state_list_pretty,

--- a/lib/bridge-wave.sh
+++ b/lib/bridge-wave.sh
@@ -58,6 +58,7 @@ bridge_wave_dispatch() {
   local main_agent=""
   local worker_engine="claude"
   local reviewer="codex-rescue"
+  local repo_root=""
   local dry_run=0
   local json_out=0
 
@@ -71,11 +72,13 @@ bridge_wave_dispatch() {
       --worker-engine=*) worker_engine="${1#--worker-engine=}"; shift ;;
       --reviewer)       reviewer="${2:-}"; shift 2 ;;
       --reviewer=*)     reviewer="${1#--reviewer=}"; shift ;;
+      --repo-root)      repo_root="${2:-}"; shift 2 ;;
+      --repo-root=*)    repo_root="${1#--repo-root=}"; shift ;;
       --dry-run)        dry_run=1; shift ;;
       --json)           json_out=1; shift ;;
       -h|--help)
         cat <<EOF
-agent-bridge wave dispatch <issue-or-brief> [--tracks A,B] [--main-agent <agent>] [--worker-engine claude|codex] [--reviewer <name>] [--dry-run] [--json]
+agent-bridge wave dispatch <issue-or-brief> [--tracks A,B] [--main-agent <agent>] [--worker-engine claude|codex] [--reviewer <name>] [--repo-root <dir>] [--dry-run] [--json]
 EOF
         return 0
         ;;
@@ -130,6 +133,7 @@ EOF
   worker:     $worker_engine
   reviewer:   $reviewer
   tracks:     ${tracks:-(none — single member)}
+  repo root:  ${repo_root:-(pwd at runtime)}
 EOF
     return 0
   fi
@@ -184,14 +188,177 @@ EOF
   python3 "$helper" state-render-readme "$state_file" "$shared_wave_dir/README.md" \
     || bridge_warn "wave dispatch: README render failed (non-fatal)"
 
+  # Phase 1.2: per-member worker spawn + queue task. Each pending member
+  # gets an isolated worktree (--prefer new), a high-priority queue task
+  # whose body is the member brief, and a state JSON transition to
+  # `running`. A failure on one member is logged and skipped — remaining
+  # members continue. Phase 1.3+ will layer codex plan/review and PR
+  # automation on top of this handoff.
+  local _repo_root="$repo_root"
+  if [[ -z "$_repo_root" ]]; then
+    _repo_root="$(pwd -P)"
+  fi
+  if [[ ! -d "$_repo_root/.git" ]] && ! git -C "$_repo_root" rev-parse --show-toplevel >/dev/null 2>&1; then
+    bridge_warn "wave dispatch: repo-root is not a git project ($_repo_root); workers cannot create isolated worktrees. Skipping Phase 1.2 spawn — members stay pending."
+  else
+    _repo_root="$(git -C "$_repo_root" rev-parse --show-toplevel 2>/dev/null || printf '%s' "$_repo_root")"
+    local _member_id _track _brief_abs
+    local _spawned=0 _failed=0
+    while IFS=$'\t' read -r _member_id _track _brief_abs; do
+      [[ -n "$_member_id" ]] || continue
+      if _bridge_wave_dispatch_member \
+        "$wave_id" "$_member_id" "$_track" \
+        "$main_agent" "$worker_engine" "$_repo_root" \
+        "$_brief_abs" "$state_file"; then
+        _spawned=$(( _spawned + 1 ))
+      else
+        _failed=$(( _failed + 1 ))
+        bridge_warn "wave dispatch: member $_member_id failed to spawn (continuing)"
+      fi
+    done < <(python3 "$helper" state-list-members "$state_file" "$shared_dir" --state pending)
+
+    # Re-render README so member rows reflect the new running state.
+    python3 "$helper" state-render-readme "$state_file" "$shared_wave_dir/README.md" \
+      || bridge_warn "wave dispatch: README re-render after dispatch failed (non-fatal)"
+    if (( _failed > 0 )); then
+      bridge_warn "wave dispatch: $_failed member(s) failed to spawn; $_spawned succeeded"
+    fi
+  fi
+
   if (( json_out )); then
     python3 "$helper" state-show "$state_file"
   else
     printf 'wave dispatched: %s\n' "$wave_id"
     printf 'state: %s\n' "$state_file"
     printf 'briefs: %s/<member-id>/brief.md\n' "$shared_wave_dir"
-    printf 'next: phase 1.2 will start workers + queue tasks. For now, members are pending.\n'
+    printf 'workers: %s\n' "$_repo_root"
   fi
+}
+
+_bridge_wave_dispatch_member() {
+  # Phase 1.2 per-member dispatch: spawn an isolated worker via
+  # `agent-bridge --<engine> --prefer new --no-attach`, look up the
+  # WORKTREE_ROOT/BRANCH metadata the dispatcher writes, create a queue
+  # task whose body is the member brief, and atomically transition the
+  # state JSON to `running` with all four wiring fields (worker,
+  # worktree_root, branch, task_id). A `wave_member_queued` audit row is
+  # emitted on success.
+  #
+  # Args (positional, all required):
+  #   1: wave_id
+  #   2: member_id (also used as the worker agent name; one-to-one)
+  #   3: track
+  #   4: main_agent
+  #   5: worker_engine (claude|codex)
+  #   6: repo_root (absolute path to the source repo)
+  #   7: brief_abs_path
+  #   8: state_file
+  local wave_id="$1"
+  local member_id="$2"
+  local track="$3"
+  local main_agent="$4"
+  local worker_engine="$5"
+  local repo_root="$6"
+  local brief_path="$7"
+  local state_file="$8"
+
+  local worker_name="$member_id"
+  if ! bridge_validate_agent_name "$worker_name"; then
+    bridge_warn "wave dispatch: member $member_id resolves to invalid worker name ($worker_name); skipping"
+    return 1
+  fi
+
+  local spawn_log
+  spawn_log="$(mktemp -t "wave-spawn-${member_id}.XXXXXX")"
+
+  local ab_bin="$BRIDGE_SCRIPT_DIR/agent-bridge"
+  if [[ ! -x "$ab_bin" ]]; then
+    bridge_warn "wave dispatch: agent-bridge dispatcher not executable: $ab_bin"
+    rm -f "$spawn_log"
+    return 1
+  fi
+
+  # 1. Spawn the worker. --prefer new builds an isolated worktree under
+  #    BRIDGE_WORKTREE_ROOT and records metadata under state/worktrees/.
+  if ! "$BRIDGE_BASH_BIN" "$ab_bin" \
+        "--${worker_engine}" \
+        --name "$worker_name" \
+        --workdir "$repo_root" \
+        --prefer new \
+        --no-attach \
+        >"$spawn_log" 2>&1; then
+    bridge_warn "wave dispatch: worker spawn failed for $member_id (engine=$worker_engine, see $spawn_log)"
+    return 1
+  fi
+
+  # 2. Resolve the worktree metadata the dispatcher just wrote.
+  local meta_file
+  meta_file="$(bridge_worktree_meta_file_for "$repo_root" "$worker_name")"
+  if [[ ! -r "$meta_file" ]]; then
+    bridge_warn "wave dispatch: worktree metadata missing for $worker_name at $meta_file"
+    return 1
+  fi
+
+  # Source in a subshell so the dispatcher's metadata vars don't leak
+  # into the caller; capture the two we care about via printf.
+  local meta_payload worktree_root branch
+  # shellcheck disable=SC1090
+  meta_payload="$(set +u; source "$meta_file"; printf '%s\t%s\n' "${WORKTREE_ROOT:-}" "${WORKTREE_BRANCH:-}")"
+  IFS=$'\t' read -r worktree_root branch <<<"$meta_payload"
+  if [[ -z "$worktree_root" || -z "$branch" ]]; then
+    bridge_warn "wave dispatch: worktree metadata missing WORKTREE_ROOT/WORKTREE_BRANCH for $worker_name (file: $meta_file)"
+    return 1
+  fi
+
+  # 3. Create the queue task assigned to the new worker. Body = brief.
+  if [[ ! -r "$brief_path" ]]; then
+    bridge_warn "wave dispatch: brief not readable for $member_id at $brief_path"
+    return 1
+  fi
+  local task_create_out task_id
+  if ! task_create_out="$("$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-task.sh" create \
+        --to "$worker_name" \
+        --from "$main_agent" \
+        --priority high \
+        --title "[wave $wave_id track $track] $member_id" \
+        --body-file "$brief_path" 2>&1)"; then
+    bridge_warn "wave dispatch: queue task create failed for $member_id: $task_create_out"
+    return 1
+  fi
+  if [[ "$task_create_out" =~ created\ task\ \#([0-9]+) ]]; then
+    task_id="${BASH_REMATCH[1]}"
+  else
+    bridge_warn "wave dispatch: could not parse task id from create output: $task_create_out"
+    return 1
+  fi
+
+  # 4. Atomic state transition pending -> running.
+  if ! python3 "$(bridge_wave_python_helper)" state-mark-running \
+      "$state_file" \
+      --member-id "$member_id" \
+      --worker "$worker_name" \
+      --worktree-root "$worktree_root" \
+      --branch "$branch" \
+      --task-id "$task_id" >/dev/null; then
+    bridge_warn "wave dispatch: state-mark-running failed for $member_id"
+    return 1
+  fi
+
+  # 5. Audit + console row (per design §10).
+  bridge_audit_log wave-orchestration wave_member_queued "$main_agent" \
+    --detail wave_id="$wave_id" \
+    --detail member_id="$member_id" \
+    --detail track="$track" \
+    --detail worker="$worker_name" \
+    --detail worktree="$worktree_root" \
+    --detail branch="$branch" \
+    --detail task_id="$task_id" \
+    || true
+  printf '  %s -> worker=%s task=#%s worktree=%s\n' \
+    "$member_id" "$worker_name" "$task_id" "$worktree_root"
+
+  rm -f "$spawn_log"
+  return 0
 }
 
 _bridge_wave_member_id_for_track() {

--- a/lib/bridge-wave.sh
+++ b/lib/bridge-wave.sh
@@ -334,7 +334,7 @@ _bridge_wave_dispatch_member() {
       --detail member_id="$member_id" \
       --detail track="$track" \
       --detail worker="$worker_name" \
-      --detail worktree="$worktree_root" \
+      --detail worktree_root="$worktree_root" \
       --detail branch="$branch" \
       --detail stage="queue_task_create" \
       --detail error="$task_create_out" \
@@ -350,7 +350,7 @@ _bridge_wave_dispatch_member() {
       --detail member_id="$member_id" \
       --detail track="$track" \
       --detail worker="$worker_name" \
-      --detail worktree="$worktree_root" \
+      --detail worktree_root="$worktree_root" \
       --detail branch="$branch" \
       --detail stage="task_id_parse" \
       --detail error="$task_create_out" \
@@ -370,7 +370,7 @@ _bridge_wave_dispatch_member() {
     --detail member_id="$member_id" \
     --detail track="$track" \
     --detail worker="$worker_name" \
-    --detail worktree="$worktree_root" \
+    --detail worktree_root="$worktree_root" \
     --detail branch="$branch" \
     --detail task_id="$task_id" \
     || true
@@ -415,7 +415,7 @@ _bridge_wave_dispatch_member() {
       --detail member_id="$member_id" \
       --detail track="$track" \
       --detail worker="$worker_name" \
-      --detail worktree="$worktree_root" \
+      --detail worktree_root="$worktree_root" \
       --detail branch="$branch" \
       --detail task_id="$task_id" \
       --detail stage="state_mark_running" \

--- a/lib/bridge-wave.sh
+++ b/lib/bridge-wave.sh
@@ -322,29 +322,49 @@ _bridge_wave_dispatch_member() {
         --priority high \
         --title "[wave $wave_id track $track] $member_id" \
         --body-file "$brief_path" 2>&1)"; then
+    # codex r1 item 3 (atomicity): the worker was spawned successfully but
+    # queue-task creation failed. Hard-killing the tmux session from here
+    # would race with the operator's own attach, so we leave the worker
+    # alive and emit a `wave_member_dispatch_partial` audit row so the
+    # leak is observable and the operator can clean it up manually
+    # (`agent-bridge worktree remove <worker>` + tmux kill-session).
     bridge_warn "wave dispatch: queue task create failed for $member_id: $task_create_out"
+    bridge_audit_log wave-orchestration wave_member_dispatch_partial "$main_agent" \
+      --detail wave_id="$wave_id" \
+      --detail member_id="$member_id" \
+      --detail track="$track" \
+      --detail worker="$worker_name" \
+      --detail worktree="$worktree_root" \
+      --detail branch="$branch" \
+      --detail stage="queue_task_create" \
+      --detail error="$task_create_out" \
+      || true
     return 1
   fi
   if [[ "$task_create_out" =~ created\ task\ \#([0-9]+) ]]; then
     task_id="${BASH_REMATCH[1]}"
   else
     bridge_warn "wave dispatch: could not parse task id from create output: $task_create_out"
+    bridge_audit_log wave-orchestration wave_member_dispatch_partial "$main_agent" \
+      --detail wave_id="$wave_id" \
+      --detail member_id="$member_id" \
+      --detail track="$track" \
+      --detail worker="$worker_name" \
+      --detail worktree="$worktree_root" \
+      --detail branch="$branch" \
+      --detail stage="task_id_parse" \
+      --detail error="$task_create_out" \
+      || true
     return 1
   fi
 
-  # 4. Atomic state transition pending -> running.
-  if ! python3 "$(bridge_wave_python_helper)" state-mark-running \
-      "$state_file" \
-      --member-id "$member_id" \
-      --worker "$worker_name" \
-      --worktree-root "$worktree_root" \
-      --branch "$branch" \
-      --task-id "$task_id" >/dev/null; then
-    bridge_warn "wave dispatch: state-mark-running failed for $member_id"
-    return 1
-  fi
-
-  # 5. Audit + console row (per design §10).
+  # 4. Detailed bridge_audit_log BEFORE state-mark-running write
+  #    (codex r1 item 5). The contract is: audit is written first, the
+  #    state file is the durable record of the transition. If the audit
+  #    write fails (`|| true`) we still proceed with the state mutation;
+  #    if the state write fails we attempt to roll the queue task back
+  #    and emit a `_rollback` audit row so the partial state is
+  #    observable.
   bridge_audit_log wave-orchestration wave_member_queued "$main_agent" \
     --detail wave_id="$wave_id" \
     --detail member_id="$member_id" \
@@ -354,6 +374,57 @@ _bridge_wave_dispatch_member() {
     --detail branch="$branch" \
     --detail task_id="$task_id" \
     || true
+
+  # 5. Atomic state transition pending -> running.
+  local mr_rc=0
+  python3 "$(bridge_wave_python_helper)" state-mark-running \
+      "$state_file" \
+      --member-id "$member_id" \
+      --worker "$worker_name" \
+      --worktree-root "$worktree_root" \
+      --branch "$branch" \
+      --task-id "$task_id" >/dev/null || mr_rc=$?
+  if (( mr_rc == 3 )); then
+    # codex r1 items 4 + 10: the member is already advanced past pending
+    # (e.g. a prior dispatch round handled it). Treat as a no-op skip:
+    # close the duplicate queue task we just opened so the worker isn't
+    # double-assigned, and consider the dispatch successful for this
+    # member.
+    bridge_warn "wave dispatch: member $member_id already advanced past 'pending'; skipping (rc=3)"
+    "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-task.sh" done "$task_id" \
+      --agent "$worker_name" \
+      --note "wave dispatch skipped: member already advanced past pending" \
+      >/dev/null 2>&1 || bridge_warn "wave dispatch: could not close duplicate task #$task_id (member $member_id)"
+    rm -f "$spawn_log"
+    return 0
+  fi
+  if (( mr_rc != 0 )); then
+    # codex r1 item 3 (atomicity rollback): queue task succeeded but the
+    # state-mark-running write failed. Best-effort close the queue task
+    # so the worker doesn't pick up an orphaned brief, then emit a
+    # `wave_member_dispatch_rollback` audit row.
+    bridge_warn "wave dispatch: state-mark-running failed for $member_id (rc=$mr_rc); attempting queue-task rollback"
+    local rollback_out=""
+    if ! rollback_out="$("$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-task.sh" done "$task_id" \
+          --agent "$worker_name" \
+          --note "wave dispatch state-mark-running failed; rolled back" 2>&1)"; then
+      bridge_warn "wave dispatch: rollback close of task #$task_id failed: $rollback_out (member $member_id)"
+    fi
+    bridge_audit_log wave-orchestration wave_member_dispatch_rollback "$main_agent" \
+      --detail wave_id="$wave_id" \
+      --detail member_id="$member_id" \
+      --detail track="$track" \
+      --detail worker="$worker_name" \
+      --detail worktree="$worktree_root" \
+      --detail branch="$branch" \
+      --detail task_id="$task_id" \
+      --detail stage="state_mark_running" \
+      --detail mr_rc="$mr_rc" \
+      || true
+    return 1
+  fi
+
+  # 6. Console row (per design §10). Audit was emitted in step 4.
   printf '  %s -> worker=%s task=#%s worktree=%s\n' \
     "$member_id" "$worker_name" "$task_id" "$worktree_root"
 

--- a/tests/wave-cli/smoke.sh
+++ b/tests/wave-cli/smoke.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
-# tests/wave-cli/smoke.sh — `agent-bridge wave` Phase 1.1 acceptance.
+# tests/wave-cli/smoke.sh — `agent-bridge wave` Phase 1.1 + 1.2 acceptance.
 #
 # Phase 1.1 covers: dispatch (state JSON + briefs + README), list, show,
-# templates, close-issue placeholder. Worker startup, queue tasks, codex
-# adapter, PR automation, and validation flows belong to Phases 1.2-1.6
-# and are out of scope for this smoke.
+# templates, close-issue placeholder.
+# Phase 1.2 adds: per-member state mutators (state-list-members,
+# state-mark-running) and the dispatch-loop guardrail (when --repo-root is
+# not a git project, the spawn loop is skipped and members stay pending).
+# Live worker spawn + queue task creation are gated behind
+# BRIDGE_WAVE_PHASE_1_2_LIVE_TEST=1 because they require a real agent-bridge
+# runtime (tmux + Claude/Codex CLI + roster) to be reproducible.
+#
+# Codex adapter, PR automation, and close-issue validation belong to Phases
+# 1.3-1.6 and are out of scope for this smoke.
 #
 # Runs with an isolated BRIDGE_HOME under TMPDIR. No live state touched.
 
@@ -32,7 +39,14 @@ trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
 export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
-mkdir -p "$BRIDGE_HOME" "$BRIDGE_STATE_DIR" "$BRIDGE_SHARED_DIR"
+# Re-anchor worktree metadata + worktree roots into the isolated tree so
+# Phase 1.2 dispatch can never touch the operator's live runtime even when
+# the surrounding shell exports these (issue #276 Phase 1.2 — `agent-bridge
+# --prefer new` walks BRIDGE_WORKTREE_META_DIR and BRIDGE_WORKTREE_ROOT).
+export BRIDGE_WORKTREE_META_DIR="$BRIDGE_STATE_DIR/worktrees"
+export BRIDGE_WORKTREE_ROOT="$TMP_ROOT/worktrees"
+mkdir -p "$BRIDGE_HOME" "$BRIDGE_STATE_DIR" "$BRIDGE_SHARED_DIR" \
+  "$BRIDGE_WORKTREE_META_DIR" "$BRIDGE_WORKTREE_ROOT"
 
 # Pin a deterministic main agent so dispatch doesn't try to read
 # BRIDGE_AGENT_ID from the live process env.
@@ -82,7 +96,7 @@ ok "close-keyword-scan accepts (#N) reference style"
 # 2. wave dispatch --dry-run
 # ---------------------------------------------------------------------------
 
-dry_out="$("$AB" wave dispatch 276 --tracks A,B --main-agent ws-smoke --dry-run 2>&1)"
+dry_out="$("$AB" wave dispatch 276 --tracks A,B --main-agent ws-smoke --repo-root "$TMP_ROOT" --dry-run 2>&1)"
 [[ "$dry_out" == *"would create wave: wave-276-"* ]] \
   || die "dispatch --dry-run output unexpected: $dry_out"
 [[ "$dry_out" == *"tracks:     A,B"* ]] \
@@ -97,7 +111,7 @@ ok "wave dispatch --dry-run echoes plan + writes nothing"
 # 3. wave dispatch (real)
 # ---------------------------------------------------------------------------
 
-dispatch_out="$("$AB" wave dispatch 276 --tracks A,B --main-agent ws-smoke 2>&1)"
+dispatch_out="$("$AB" wave dispatch 276 --tracks A,B --main-agent ws-smoke --repo-root "$TMP_ROOT" 2>&1)"
 real_wave_id="$(printf '%s\n' "$dispatch_out" | awk '/^wave dispatched: /{print $3}')"
 [[ -n "$real_wave_id" ]] || die "could not parse wave id from dispatch output: $dispatch_out"
 ok "wave dispatch returns wave id ($real_wave_id)"
@@ -220,7 +234,7 @@ cat >"$brief" <<'EOF'
 # Some brief
 This is a non-issue-numbered brief used to dispatch a wave.
 EOF
-brief_dispatch="$("$AB" wave dispatch "$brief" --tracks main --main-agent ws-smoke 2>&1)"
+brief_dispatch="$("$AB" wave dispatch "$brief" --tracks main --main-agent ws-smoke --repo-root "$TMP_ROOT" 2>&1)"
 brief_wave_id="$(printf '%s\n' "$brief_dispatch" | awk '/^wave dispatched: /{print $3}')"
 [[ -n "$brief_wave_id" ]] || die "brief-file dispatch did not return wave id"
 [[ -r "$BRIDGE_SHARED_DIR/waves/$brief_wave_id/source-brief.md" ]] \
@@ -231,7 +245,7 @@ ok "wave dispatch <brief-file> mirrors the brief into shared/waves/<id>/source-b
 # 7. --reviewer override is plumbed through (codex r1 finding on PR #373)
 # ---------------------------------------------------------------------------
 
-reviewer_dispatch="$("$AB" wave dispatch 999 --tracks A --main-agent ws-smoke --reviewer custom-reviewer 2>&1)"
+reviewer_dispatch="$("$AB" wave dispatch 999 --tracks A --main-agent ws-smoke --reviewer custom-reviewer --repo-root "$TMP_ROOT" 2>&1)"
 reviewer_wave_id="$(printf '%s\n' "$reviewer_dispatch" | awk '/^wave dispatched: /{print $3}')"
 reviewer_state="$BRIDGE_STATE_DIR/waves/${reviewer_wave_id}.json"
 python3 - "$reviewer_state" <<'PY' || die "--reviewer override not plumbed to state JSON"
@@ -244,3 +258,120 @@ PY
 ok "--reviewer override is plumbed to state JSON"
 
 log "all Phase 1.1 acceptance checks passed"
+
+# ---------------------------------------------------------------------------
+# 8. Phase 1.2 — state-list-members + state-mark-running unit tests
+# ---------------------------------------------------------------------------
+#
+# These exercise the new Python helpers directly without spawning workers.
+# The dispatch shell loop is also tested via the non-git --repo-root guard
+# (it must skip the spawn block, leaving members pending).
+
+# 8a. state-list-members emits one row per pending member (TSV).
+list_members_state="$BRIDGE_STATE_DIR/waves/${real_wave_id}.json"
+list_out="$(python3 "$WAVE_PY" state-list-members "$list_members_state" "$BRIDGE_SHARED_DIR")"
+list_count="$(printf '%s\n' "$list_out" | grep -c $'\t' || true)"
+[[ "$list_count" == 2 ]] || die "state-list-members expected 2 rows, got $list_count: $list_out"
+# Each row: <member_id>\t<track>\t<absolute_brief_path>
+while IFS=$'\t' read -r m_id m_track m_brief; do
+  [[ -n "$m_id" ]] || die "state-list-members row missing member_id"
+  [[ -n "$m_track" ]] || die "state-list-members row missing track for $m_id"
+  [[ -f "$m_brief" ]] || die "state-list-members brief path not on disk: $m_brief"
+done <<<"$list_out"
+ok "state-list-members emits TSV rows with absolute brief paths"
+
+# 8b. state-list-members --state running on a fresh wave returns empty.
+running_out="$(python3 "$WAVE_PY" state-list-members "$list_members_state" "$BRIDGE_SHARED_DIR" --state running)"
+[[ -z "$running_out" ]] || die "state-list-members --state running should be empty on fresh wave: $running_out"
+ok "state-list-members --state running filters correctly"
+
+# 8c. state-mark-running transitions a member pending -> running with all
+# four wiring fields and appends a wave_member_queued audit row.
+target_member="$(printf '%s\n' "$list_out" | head -n 1 | cut -f1)"
+[[ -n "$target_member" ]] || die "could not pick a member to mark running"
+python3 "$WAVE_PY" state-mark-running "$list_members_state" \
+  --member-id "$target_member" \
+  --worker "$target_member" \
+  --worktree-root "$TMP_ROOT/worktrees/test-repo/$target_member" \
+  --branch "agent-bridge/$target_member" \
+  --task-id 12345 >/dev/null \
+  || die "state-mark-running failed for $target_member"
+
+python3 - "$list_members_state" "$target_member" <<'PY' || die "state-mark-running invariants violated"
+import json, sys
+state_file, target = sys.argv[1], sys.argv[2]
+s = json.loads(open(state_file).read())
+hit = next(m for m in s["members"] if m["member_id"] == target)
+assert hit["state"] == "running", f"state not running: {hit['state']!r}"
+assert hit["task_id"] == 12345, f"task_id mismatch: {hit['task_id']!r}"
+assert hit["worker"] == target, f"worker mismatch: {hit['worker']!r}"
+assert hit["worktree_root"].endswith(target), f"worktree_root mismatch: {hit['worktree_root']!r}"
+assert hit["branch"] == f"agent-bridge/{target}", f"branch mismatch: {hit['branch']!r}"
+# The other member must still be pending.
+others = [m for m in s["members"] if m["member_id"] != target]
+assert all(m["state"] == "pending" for m in others), "non-target members should remain pending"
+# Audit row must be appended (Phase 1.1 wrote `wave_dispatched`; Phase 1.2
+# appends `wave_member_queued:<member-id>`).
+assert any(a == f"wave_member_queued:{target}" for a in s.get("audit", [])), (
+    f"audit row wave_member_queued:{target} missing; got: {s.get('audit')!r}"
+)
+PY
+ok "state-mark-running transitions one member pending -> running and audits"
+
+# 8d. After step 8c, state-list-members default (--state pending) should
+# return only the OTHER member.
+remaining="$(python3 "$WAVE_PY" state-list-members "$list_members_state" "$BRIDGE_SHARED_DIR")"
+remaining_count="$(printf '%s\n' "$remaining" | grep -c $'\t' || true)"
+[[ "$remaining_count" == 1 ]] || die "after mark-running, expected 1 pending row, got $remaining_count"
+ok "state-list-members reflects the pending -> running transition"
+
+# 8e. state-mark-running with a missing required arg returns rc=2.
+set +e
+python3 "$WAVE_PY" state-mark-running "$list_members_state" --member-id "$target_member" >/dev/null 2>&1
+mr_rc=$?
+set -e
+[[ "$mr_rc" == 2 ]] || die "state-mark-running missing-args expected rc=2, got $mr_rc"
+ok "state-mark-running validates required args (rc=2)"
+
+# 8f. Dispatch loop guardrail: --repo-root is not a git project => spawn
+# loop skips, members stay pending. Already exercised by 8a + state JSON
+# invariants above (tasks_id was None at the time of state-list-members in
+# step 8a, and the new wave used --repo-root "$TMP_ROOT" which is not a
+# git checkout). Make the invariant explicit:
+fresh_state="$BRIDGE_STATE_DIR/waves/${reviewer_wave_id}.json"
+python3 - "$fresh_state" <<'PY' || die "non-git --repo-root should leave members pending"
+import json, sys
+s = json.loads(open(sys.argv[1]).read())
+for m in s["members"]:
+    assert m["state"] == "pending", f"non-git repo-root should keep state pending: {m}"
+    assert m["task_id"] is None, f"non-git repo-root should not assign task_id: {m}"
+    assert m.get("worker") in (None,), f"non-git repo-root should not set worker: {m}"
+PY
+ok "non-git --repo-root short-circuits the Phase 1.2 spawn loop"
+
+log "all Phase 1.1 + 1.2 acceptance checks passed"
+
+# ---------------------------------------------------------------------------
+# 9. Phase 1.2 LIVE — gated; opt-in via BRIDGE_WAVE_PHASE_1_2_LIVE_TEST=1.
+# Validates the full dispatch-to-running handoff against a real
+# `agent-bridge --<engine>` invocation in an isolated BRIDGE_HOME.
+# Requires: tmux, claude or codex CLI on PATH, a writable git working dir.
+# ---------------------------------------------------------------------------
+if [[ "${BRIDGE_WAVE_PHASE_1_2_LIVE_TEST:-0}" == "1" ]]; then
+  log "BRIDGE_WAVE_PHASE_1_2_LIVE_TEST=1 — running live dispatch test (may launch tmux sessions)"
+  live_out="$("$AB" wave dispatch 276 --tracks A --main-agent ws-smoke --repo-root "$REPO_ROOT" 2>&1)"
+  live_wave_id="$(printf '%s\n' "$live_out" | awk '/^wave dispatched: /{print $3}')"
+  [[ -n "$live_wave_id" ]] || die "live dispatch did not return wave id: $live_out"
+  python3 - "$BRIDGE_STATE_DIR/waves/${live_wave_id}.json" <<'PY' || die "live dispatch did not transition member to running"
+import json, sys
+s = json.loads(open(sys.argv[1]).read())
+running = [m for m in s["members"] if m["state"] == "running"]
+assert running, f"expected at least one running member; got: {s['members']}"
+for m in running:
+    assert m["task_id"] is not None, f"running member missing task_id: {m}"
+    assert m["worker"], f"running member missing worker: {m}"
+    assert m["worktree_root"], f"running member missing worktree_root: {m}"
+    assert m["branch"], f"running member missing branch: {m}"
+PY
+  ok "live dispatch transitions a member to running with full wiring"
+fi

--- a/tests/wave-cli/smoke.sh
+++ b/tests/wave-cli/smoke.sh
@@ -273,12 +273,31 @@ list_out="$(python3 "$WAVE_PY" state-list-members "$list_members_state" "$BRIDGE
 list_count="$(printf '%s\n' "$list_out" | grep -c $'\t' || true)"
 [[ "$list_count" == 2 ]] || die "state-list-members expected 2 rows, got $list_count: $list_out"
 # Each row: <member_id>\t<track>\t<absolute_brief_path>
+# codex r1 item 11: brief paths must be absolute and exist on disk
+# regardless of caller CWD or whether shared_dir was passed as a
+# relative path.
 while IFS=$'\t' read -r m_id m_track m_brief; do
   [[ -n "$m_id" ]] || die "state-list-members row missing member_id"
   [[ -n "$m_track" ]] || die "state-list-members row missing track for $m_id"
   [[ -f "$m_brief" ]] || die "state-list-members brief path not on disk: $m_brief"
+  [[ "$m_brief" = /* ]] || die "state-list-members brief path is not absolute: $m_brief"
 done <<<"$list_out"
 ok "state-list-members emits TSV rows with absolute brief paths"
+
+# 8a'. Run state-list-members from a CWD other than the state dir with a
+# relative shared-dir path; the emitted brief paths must still be
+# absolute (codex r1 item 11 — `.resolve()` not `.absolute()` so the
+# resolution doesn't depend on the caller's CWD).
+shared_rel="$(python3 -c 'import os, sys; print(os.path.relpath(sys.argv[1], "/tmp"))' "$BRIDGE_SHARED_DIR")"
+state_rel="$(python3 -c 'import os, sys; print(os.path.relpath(sys.argv[1], "/tmp"))' "$list_members_state")"
+list_out_rel="$(cd /tmp && python3 "$WAVE_PY" state-list-members "$state_rel" "$shared_rel")"
+[[ -n "$list_out_rel" ]] || die "state-list-members from /tmp produced no rows"
+while IFS=$'\t' read -r _m_id _m_track m_brief_rel; do
+  [[ -n "$m_brief_rel" ]] || continue
+  [[ "$m_brief_rel" = /* ]] || die "state-list-members from other CWD emitted non-absolute path: $m_brief_rel"
+  [[ -f "$m_brief_rel" ]] || die "state-list-members from other CWD: brief not on disk: $m_brief_rel"
+done <<<"$list_out_rel"
+ok "state-list-members produces absolute paths even when invoked from a different CWD"
 
 # 8b. state-list-members --state running on a fresh wave returns empty.
 running_out="$(python3 "$WAVE_PY" state-list-members "$list_members_state" "$BRIDGE_SHARED_DIR" --state running)"
@@ -311,9 +330,16 @@ assert hit["branch"] == f"agent-bridge/{target}", f"branch mismatch: {hit['branc
 others = [m for m in s["members"] if m["member_id"] != target]
 assert all(m["state"] == "pending" for m in others), "non-target members should remain pending"
 # Audit row must be appended (Phase 1.1 wrote `wave_dispatched`; Phase 1.2
-# appends `wave_member_queued:<member-id>`).
-assert any(a == f"wave_member_queued:{target}" for a in s.get("audit", [])), (
-    f"audit row wave_member_queued:{target} missing; got: {s.get('audit')!r}"
+# appends `wave_member_queued:<member-id> worker=… task_id=… worktree_root=…
+# branch=…` so a state-only inspection can see the full wiring without
+# having to cross-reference bridge_audit_log).
+prefix = f"wave_member_queued:{target}"
+matching = [a for a in s.get("audit", []) if a.startswith(prefix + " ") or a == prefix]
+assert matching, (
+    f"audit row {prefix} missing; got: {s.get('audit')!r}"
+)
+assert any("worker=" in a and "task_id=12345" in a for a in matching), (
+    f"audit row missing worker/task wiring; got: {matching!r}"
 )
 PY
 ok "state-mark-running transitions one member pending -> running and audits"
@@ -359,7 +385,68 @@ log "all Phase 1.1 + 1.2 acceptance checks passed"
 # ---------------------------------------------------------------------------
 if [[ "${BRIDGE_WAVE_PHASE_1_2_LIVE_TEST:-0}" == "1" ]]; then
   log "BRIDGE_WAVE_PHASE_1_2_LIVE_TEST=1 — running live dispatch test (may launch tmux sessions)"
-  live_out="$("$AB" wave dispatch 276 --tracks A --main-agent ws-smoke --repo-root "$REPO_ROOT" 2>&1)"
+
+  # codex r1 item 12: live workers + queue tasks must be torn down on
+  # exit (success OR failure) so the smoke is rerunnable. The cleanup
+  # uses a randomized title/session prefix so concurrent invocations
+  # never collide, and is idempotent — the trap may fire twice (once
+  # from EXIT, once if we re-arm the trap) and must not error.
+  LIVE_PREFIX="wave-p12-livetest-${RANDOM}-$$"
+  LIVE_TITLE_PREFIX="[livetest ${LIVE_PREFIX}]"
+  export BRIDGE_WAVE_LIVETEST_PREFIX="$LIVE_PREFIX"
+
+  _wave_livetest_cleanup() {
+    # Idempotent — every command swallows its own errors so re-running
+    # the trap (or running it after a partial setup) is safe.
+    if command -v tmux >/dev/null 2>&1; then
+      # Find sessions whose name contains our prefix and kill them.
+      tmux list-sessions -F '#S' 2>/dev/null \
+        | grep -F "$LIVE_PREFIX" 2>/dev/null \
+        | while IFS= read -r _sess; do
+            [[ -n "$_sess" ]] || continue
+            tmux kill-session -t "$_sess" 2>/dev/null || true
+          done
+    fi
+    # Cancel any queue tasks created by this run. Best-effort: list,
+    # match by title prefix, mark done. The queue tooling tolerates
+    # repeat `done` calls on a closed task without erroring.
+    if [[ -x "$AB" ]]; then
+      "$AB" inbox --json 2>/dev/null \
+        | python3 -c '
+import json, os, sys
+prefix = os.environ.get("BRIDGE_WAVE_LIVETEST_PREFIX", "")
+if not prefix:
+    sys.exit(0)
+try:
+    data = json.loads(sys.stdin.read() or "{}")
+except Exception:
+    sys.exit(0)
+tasks = data if isinstance(data, list) else data.get("tasks", [])
+for t in tasks:
+    title = t.get("title", "") or ""
+    tid = t.get("id") or t.get("task_id")
+    if prefix in title and tid is not None:
+        print(tid)
+' 2>/dev/null \
+        | while IFS= read -r _tid; do
+            [[ -n "$_tid" ]] || continue
+            "$BRIDGE_BASH_BIN" "$REPO_ROOT/bridge-task.sh" done "$_tid" \
+              --agent ws-smoke \
+              --note "livetest cleanup ($LIVE_PREFIX)" >/dev/null 2>&1 || true
+          done
+    fi
+    # TMP_ROOT is already covered by the outer `trap … EXIT` (line ~37);
+    # this no-op is here as documentation / belt-and-braces in case the
+    # outer trap is replaced.
+    [[ -d "${TMP_ROOT:-}" ]] && rm -rf "$TMP_ROOT"/livetest-* 2>/dev/null || true
+  }
+  # Compose a trap that runs both the existing TMP_ROOT cleanup and the
+  # livetest teardown. The EXIT trap is rebound here (not added) so we
+  # have to keep the original rm -rf call too.
+  trap '_wave_livetest_cleanup; rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
+
+  live_out="$("$AB" wave dispatch 276 --tracks "${LIVE_PREFIX}" --main-agent ws-smoke --repo-root "$REPO_ROOT" 2>&1)" \
+    || die "live dispatch failed: $live_out"
   live_wave_id="$(printf '%s\n' "$live_out" | awk '/^wave dispatched: /{print $3}')"
   [[ -n "$live_wave_id" ]] || die "live dispatch did not return wave id: $live_out"
   python3 - "$BRIDGE_STATE_DIR/waves/${live_wave_id}.json" <<'PY' || die "live dispatch did not transition member to running"
@@ -374,4 +461,9 @@ for m in running:
     assert m["branch"], f"running member missing branch: {m}"
 PY
   ok "live dispatch transitions a member to running with full wiring"
+
+  # Verify cleanup is idempotent: invoking it again must not error.
+  _wave_livetest_cleanup
+  _wave_livetest_cleanup
+  ok "live dispatch cleanup is idempotent"
 fi

--- a/tests/wave-cli/smoke.sh
+++ b/tests/wave-cli/smoke.sh
@@ -341,6 +341,15 @@ assert matching, (
 assert any("worker=" in a and "task_id=12345" in a for a in matching), (
     f"audit row missing worker/task wiring; got: {matching!r}"
 )
+# All four detail keys must appear so an audit-only inspection sees the
+# full member wiring (codex r2: keep audit string + state JSON + dispatch
+# --detail flags using the same `worktree_root=` key).
+assert any("worktree_root=" in a for a in matching), (
+    f"audit row missing worktree_root=; got: {matching!r}"
+)
+assert any("branch=" in a for a in matching), (
+    f"audit row missing branch=; got: {matching!r}"
+)
 PY
 ok "state-mark-running transitions one member pending -> running and audits"
 


### PR DESCRIPTION
## Summary

Reference: (#276 Phase 1.2 of 1.1-1.6 sequence per design doc PR #365). Phase 1.1 shipped CLI surface + state JSON + brief writer in v0.6.18 (PR #373). This PR closes the dispatch-to-worker handoff: `agent-bridge wave dispatch` now actually spawns workers and creates queue tasks per member, transitioning the state JSON `pending -> running` with full wiring.

External codex consultation confirmed Full Phase 1.2 (vs worker-only / jump-to-1.4 / defer) is the right next step — Phase 1.1's durable state was being bypassed in operator practice precisely because there was no continuation past `pending`.

## Behavior changes

`agent-bridge wave dispatch` now (when a git `--repo-root` is available):

1. For each pending member, spawns a worker via `agent-bridge --<engine> --name <member-id> --workdir <repo> --prefer new --no-attach`.
2. Reads `WORKTREE_ROOT` / `WORKTREE_BRANCH` from the dispatcher's metadata env file.
3. Creates a high-priority queue task assigned to the worker, body = the member's `brief.md`.
4. Atomically transitions state JSON: `pending -> running` with `worker` / `worktree_root` / `branch` / `task_id` populated.
5. Emits `wave_member_queued` audit per member (per design §10).

`--dry-run` path stays read-only (no worker, no queue task). A new `--repo-root <dir>` flag lets the operator point dispatch at a specific repo; when the resolved root is not a git project, the spawn loop short-circuits with a warning and members stay `pending`.

## Files

- `lib/bridge-wave.sh` — new `_bridge_wave_dispatch_member` helper + dispatch loop hook + `--repo-root` flag.
- `bridge-wave.py` — new `state-list-members` (TSV emitter, optional `--state` filter) and `state-mark-running` (atomic per-member transition with audit row).
- `tests/wave-cli/smoke.sh` — Phase 1.2 unit tests for both Python helpers, asserts the non-git `--repo-root` guardrail, gates a live end-to-end dispatch behind `BRIDGE_WAVE_PHASE_1_2_LIVE_TEST=1`.

## What this PR does NOT add (deferred to Phases 1.3-1.6)

- Phase 1.3: codex plan/review invocation.
- Phase 1.4: PR opening + close-keyword guard hook.
- Phase 1.5: completion task to main agent on worker PR open.
- Phase 1.6: close-issue validation.
- Skill migration shim.

The issue stays open through Phases 1.3-1.6 — this PR intentionally avoids any GitHub close keyword.

## Verification

- `bash -n lib/bridge-wave.sh bridge-wave.sh tests/wave-cli/smoke.sh` PASS
- `shellcheck lib/bridge-wave.sh bridge-wave.sh tests/wave-cli/smoke.sh` PASS (no output)
- `python3 -c "import ast; ast.parse(open('bridge-wave.py').read())"` PASS
- `bash tests/wave-cli/smoke.sh` PASS — all Phase 1.1 + 1.2 acceptance checks pass:
  - `state-list-members emits TSV rows with absolute brief paths`
  - `state-list-members --state running filters correctly`
  - `state-mark-running transitions one member pending -> running and audits`
  - `state-list-members reflects the pending -> running transition`
  - `state-mark-running validates required args (rc=2)`
  - `non-git --repo-root short-circuits the Phase 1.2 spawn loop`
- Live dispatch test (`BRIDGE_WAVE_PHASE_1_2_LIVE_TEST=1`) is opt-in because real spawn requires tmux + Claude/Codex CLI + roster context that the smoke harness deliberately does not provision.

Reference: #276