### PR TITLE
fix(plugin): declare ms365 in agent-bridge marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -16,6 +16,14 @@
       "version": "0.1.0",
       "category": "messaging",
       "tags": ["teams", "messaging", "channel", "mcp"]
+    },
+    {
+      "name": "ms365",
+      "source": "./plugins/ms365",
+      "description": "Microsoft 365 / Graph API tools for Claude Code with Agent Bridge channel state and disclosure policy integration.",
+      "version": "0.1.0",
+      "category": "productivity",
+      "tags": ["microsoft", "m365", "graph", "mail", "calendar", "teams", "mcp"]
     }
   ]
 }

--- a/scripts/oss-preflight.sh
+++ b/scripts/oss-preflight.sh
@@ -38,7 +38,7 @@ check_email_patterns() {
 
   matches="$(rg -n --color never -e '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}' "${scan_files[@]}" || true)"
   # Public plugin manifests may use non-routable placeholder contacts.
-  matches="$(printf '%s\n' "$matches" | grep -Ev '@(agent-bridge\.local|local\.invalid|tenant\.com)([^A-Za-z0-9.-]|$)|@odata\.(bind|id|type)' || true)"
+  matches="$(printf '%s\n' "$matches" | grep -Ev '@(agent-bridge\.local|example\.com|example\.test|local\.invalid|tenant\.com)([^A-Za-z0-9.-]|$)|@odata\.(bind|id|type)' || true)"
   if [[ -n "$matches" ]]; then
     echo "[oss] fail: email addresses in tracked content"
     echo "$matches"
@@ -62,6 +62,48 @@ fi
 check_email_patterns
 check_pattern "discord webhook URLs in tracked content" 'discord\.com/api/webhooks/'
 check_pattern "discord mention IDs in tracked content" '<@[0-9]{6,}>'
+
+echo "[oss] checking Agent Bridge marketplace declarations"
+if ! python3 - "$repo_root" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+marketplace_path = repo / ".claude-plugin" / "marketplace.json"
+try:
+    marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"[oss] fail: cannot parse {marketplace_path.relative_to(repo)}: {exc}")
+    raise SystemExit(1)
+
+declared = {
+    plugin.get("name")
+    for plugin in marketplace.get("plugins", [])
+    if isinstance(plugin, dict) and isinstance(plugin.get("name"), str)
+}
+
+missing = []
+for plugin_json in sorted((repo / "plugins").glob("*/.claude-plugin/plugin.json")):
+    try:
+        payload = json.loads(plugin_json.read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(f"[oss] fail: cannot parse {plugin_json.relative_to(repo)}: {exc}")
+        raise SystemExit(1)
+    name = payload.get("name")
+    if not isinstance(name, str) or not name:
+        print(f"[oss] fail: {plugin_json.relative_to(repo)} missing non-empty name")
+        raise SystemExit(1)
+    if name not in declared:
+        missing.append(name)
+
+if missing:
+    print("[oss] fail: shipped plugins missing from .claude-plugin/marketplace.json: " + ", ".join(missing))
+    raise SystemExit(1)
+PY
+then
+  fail=1
+fi
 
 if [[ -f "$local_patterns_file" ]]; then
   while IFS= read -r pattern; do


### PR DESCRIPTION
## Summary

Fixes #425.

The repo ships a complete `plugins/ms365` Claude plugin, and Agent Bridge channel code treats `plugin:ms365@agent-bridge` as a live development-channel plugin. The Agent Bridge directory marketplace only declared `teams`, so Claude plugin preflight could refresh the marketplace and still reject `ms365@agent-bridge` as missing.

## Changes

- Declare `ms365` in `.claude-plugin/marketplace.json`.
- Add an OSS preflight check that every shipped `plugins/*/.claude-plugin/plugin.json` name is declared in the Agent Bridge marketplace.
- Allow reserved example email domains in the OSS preflight email scanner so the existing smoke fixtures do not mask the new marketplace check.

## Security Notes

- No MS365 secret handling changed. `MS365_CLIENT_SECRET`, delegated tokens, and per-agent state remain handled by the existing plugin/runtime paths.
- This only exposes a plugin source tree that is already shipped in the repository and already referenced by channel/isolation code.
- I did not add graceful-degrade behavior for missing plugins; hard-failing preflight remains intact, so a missing required channel cannot silently disable a reply surface.

## Validation

- `python3 -m json.tool .claude-plugin/marketplace.json`
- `bash -n scripts/oss-preflight.sh`
- `git diff --check origin/main..HEAD`
- `bash scripts/oss-preflight.sh`

Verified locally on Linux EC2 production host (Cosmax intranet, isolated agent + cosmax-marketplace plugins) — verify report follows in a comment after #346 + #362 acceptance reruns.
