### PR TITLE
fix: redact secret env values in launch logs

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2036,7 +2036,9 @@ bridge_write_crash_report_body() {
   local stderr_file="$6"
   local tail_file="$7"
   local launch_cmd="$8"
+  local launch_cmd_display=""
 
+  launch_cmd_display="$(bridge_redact_inline_env_secrets "$launch_cmd")"
   mkdir -p "$(dirname "$body_file")"
   {
     echo "# Crash Loop Report"
@@ -2052,7 +2054,7 @@ bridge_write_crash_report_body() {
     echo "## Launch Command"
     echo
     echo '```bash'
-    printf '%s\n' "$launch_cmd"
+    printf '%s\n' "$launch_cmd_display"
     echo '```'
     echo
     echo "## Stderr Tail"

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -166,7 +166,7 @@ if [[ $DRY_RUN -eq 1 ]]; then
   echo "safe_mode=$SAFE_MODE"
   echo "channels=$(bridge_agent_channels_csv "$AGENT")"
   echo "channel_status=$(bridge_agent_channel_status "$AGENT")"
-  echo "launch=$LAUNCH_CMD"
+  echo "launch=$(bridge_redact_inline_env_secrets "$LAUNCH_CMD")"
   exit 0
 fi
 
@@ -437,7 +437,7 @@ bridge_run_safe_mode_resume_hint() {
   mode="$(bridge_safe_mode_resume_mode "$AGENT")"
   admin_agent="$(bridge_require_admin_agent 2>/dev/null || true)"
   log_line "[safe-mode] booting ${AGENT} with minimal launch"
-  log_line "[safe-mode] ignored roster launch_cmd: $(bridge_agent_launch_cmd_raw "$AGENT")"
+  log_line "[safe-mode] ignored roster launch_cmd: $(bridge_redact_inline_env_secrets "$(bridge_agent_launch_cmd_raw "$AGENT")")"
   if [[ -n "$(bridge_agent_channels_csv "$AGENT")" ]]; then
     log_line "[safe-mode] suppressed channels: $(bridge_agent_channels_csv "$AGENT")"
   fi
@@ -487,6 +487,7 @@ RAPID_FAIL_WINDOW="${BRIDGE_RUN_RAPID_FAIL_WINDOW_SECONDS:-10}"
 MAX_RAPID_FAILS="${BRIDGE_RUN_MAX_RAPID_FAILS:-5}"
 HEALTHY_RUN_RESET_SECONDS="${BRIDGE_RUN_HEALTHY_RESET_SECONDS:-60}"
 while true; do
+  local_launch_cmd_display=""
   local_err_size_before=0
   local_err_size_after=0
   run_started_at=0
@@ -503,6 +504,7 @@ while true; do
     LAUNCH_CMD="$(bridge_agent_launch_cmd "$AGENT")"
   fi
   [[ -n "$LAUNCH_CMD" ]] || bridge_die "'$AGENT'의 launch command가 비어 있습니다."
+  local_launch_cmd_display="$(bridge_redact_inline_env_secrets "$LAUNCH_CMD")"
 
   if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
     bridge_run_sync_dev_plugin_cache
@@ -511,15 +513,14 @@ while true; do
     bridge_run_schedule_idle_marker_and_inbox_bootstrap
   fi
 
-  log_line "실행: ${LAUNCH_CMD}"
+  log_line "실행: ${local_launch_cmd_display}"
   if [[ -f "$ERRFILE" ]]; then
     local_err_size_before="$(wc -c <"$ERRFILE" 2>/dev/null || echo 0)"
   fi
   # v2 isolation: load per-agent launch secrets from credentials/launch-secrets.env
   # into the child shell so the child inherits them via export, NEVER via
   # composing into LAUNCH_CMD. Composing tokens into LAUNCH_CMD leaks via
-  # process listings, the `log_line` above, dry-run output, the crash-report
-  # path (bridge_agent_write_crash_report writes LAUNCH_CMD verbatim), and
+  # process listings, raw display output, crash-report paths, and
   # any tee'd stderr. Loading inside the launch subshell (not the parent)
   # also prevents stale secrets from persisting across restart-loop
   # iterations after the credentials file is rotated, emptied, or removed.
@@ -597,7 +598,7 @@ while true; do
       RAPID_FAIL_COUNT=0
     fi
     if [[ $FAIL_COUNT -eq 5 || $(( FAIL_COUNT % 10 )) -eq 0 ]]; then
-      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$LAUNCH_CMD"
+      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$local_launch_cmd_display"
       bridge_audit_log daemon crash_loop_detected "$AGENT" \
         --detail engine="$ENGINE" \
         --detail fail_count="$FAIL_COUNT" \
@@ -605,8 +606,8 @@ while true; do
         --detail stderr_file="$ERRFILE"
     fi
     if [[ $rapid_failure -eq 1 && "$RAPID_FAIL_COUNT" =~ ^[0-9]+$ && "$MAX_RAPID_FAILS" =~ ^[0-9]+$ && $RAPID_FAIL_COUNT -ge $MAX_RAPID_FAILS ]]; then
-      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$LAUNCH_CMD"
-      bridge_agent_write_broken_launch_state "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$LAUNCH_CMD" "$local_err_size_before"
+      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$local_launch_cmd_display"
+      bridge_agent_write_broken_launch_state "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$local_launch_cmd_display" "$local_err_size_before"
       bridge_audit_log daemon crash_loop_broken "$AGENT" \
         --detail engine="$ENGINE" \
         --detail fail_count="$FAIL_COUNT" \

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -401,6 +401,72 @@ print(hashlib.sha1(sys.argv[1].encode("utf-8")).hexdigest())
 PY
 }
 
+bridge_redact_inline_env_secrets() {
+  local text="${1-}"
+  local redacted=""
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s' "[redacted launch command: python3 unavailable]"
+    return 0
+  fi
+
+  if redacted="$(printf '%s' "$text" | python3 -c '
+import re
+import sys
+
+text = sys.stdin.read()
+
+
+def sensitive(name):
+    upper = name.upper()
+    if any(
+        marker in upper
+        for marker in (
+            "SECRET",
+            "TOKEN",
+            "PASSWORD",
+            "PASSWD",
+            "CREDENTIAL",
+            "AUTH",
+            "BEARER",
+            "PRIVATE",
+            "COOKIE",
+            "JWT",
+        )
+    ):
+        return True
+    if re.search(r"(^|_)KEY($|_)", upper):
+        return True
+    if re.search(r"(^|_)PWD($|_)", upper):
+        return True
+    return False
+
+
+assignment = re.compile(
+    r"(^|\s)"
+    r"([A-Za-z_][A-Za-z0-9_]*)"
+    r"(=)"
+    r"(\$'\''(?:[^'\''\\]|\\.)*'\''|\$\"(?:[^\"\\]|\\.)*\"|'\''(?:[^'\''\\]|\\.)*'\''|\"(?:[^\"\\]|\\.)*\"|(?:\\.|[^\s])*)",
+    re.MULTILINE,
+)
+
+
+def replace(match):
+    prefix, name, equals, _value = match.groups()
+    if sensitive(name):
+        return f"{prefix}{name}{equals}***redacted***"
+    return match.group(0)
+
+
+sys.stdout.write(assignment.sub(replace, text))
+' 2>/dev/null)"; then
+    printf '%s' "$redacted"
+    return 0
+  fi
+
+  printf '%s' "[redacted launch command: redaction failed]"
+}
+
 bridge_queue_cli() {
   local agent=""
 

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -419,6 +419,12 @@ text = sys.stdin.read()
 
 def sensitive(name):
     upper = name.upper()
+    # Substring markers cover the common secret families. Note that
+    # ``AUTH``/``PRIVATE``/``SECRET`` already cover their ``*_KEY``
+    # variants by substring match; ``API_KEY``/``CLIENT_KEY``/``ACCESS_KEY``
+    # are listed explicitly so non-secret env names that merely happen to
+    # end in ``_KEY`` (e.g. ``BRIDGE_LAYOUT_MARKER_KEY``, ``CACHE_KEY``,
+    # ``STATE_KEY``) are no longer false-positive redacted (#428 r2).
     if any(
         marker in upper
         for marker in (
@@ -432,10 +438,14 @@ def sensitive(name):
             "PRIVATE",
             "COOKIE",
             "JWT",
+            "API_KEY",
+            "AUTH_KEY",
+            "PRIVATE_KEY",
+            "CLIENT_KEY",
+            "ACCESS_KEY",
+            "SECRET_KEY",
         )
     ):
-        return True
-    if re.search(r"(^|_)KEY($|_)", upper):
         return True
     if re.search(r"(^|_)PWD($|_)", upper):
         return True

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1863,11 +1863,13 @@ bridge_agent_write_crash_report() {
   local exit_code="$4"
   local stderr_file="$5"
   local launch_cmd="$6"
+  local launch_cmd_display=""
   local report_file=""
   local tail_file=""
   local error_hash=""
   local stderr_tail=""
 
+  launch_cmd_display="$(bridge_redact_inline_env_secrets "$launch_cmd")"
   report_file="$(bridge_agent_crash_report_file "$agent")"
   tail_file="$(bridge_agent_crash_tail_file "$agent")"
   mkdir -p "$(dirname "$report_file")"
@@ -1885,7 +1887,7 @@ CRASH_FAIL_COUNT=$(printf '%q' "$fail_count")
 CRASH_EXIT_CODE=$(printf '%q' "$exit_code")
 CRASH_STDERR_FILE=$(printf '%q' "$stderr_file")
 CRASH_TAIL_FILE=$(printf '%q' "$tail_file")
-CRASH_LAUNCH_CMD=$(printf '%q' "$launch_cmd")
+CRASH_LAUNCH_CMD=$(printf '%q' "$launch_cmd_display")
 CRASH_ERROR_HASH=$(printf '%q' "$error_hash")
 CRASH_REPORTED_AT=$(printf '%q' "$(bridge_now_iso)")
 EOF
@@ -1917,11 +1919,13 @@ bridge_agent_write_broken_launch_state() {
   local launch_cmd="${6:-}"
   local err_size_before="${7:-0}"
   local file=""
+  local launch_cmd_display=""
 
+  launch_cmd_display="$(bridge_redact_inline_env_secrets "$launch_cmd")"
   file="$(bridge_agent_broken_launch_file "$agent")"
   mkdir -p "$(dirname "$file")"
   bridge_require_python
-  python3 - "$file" "$agent" "$engine" "$fail_count" "$exit_code" "$stderr_file" "$launch_cmd" "$err_size_before" <<'PY'
+  python3 - "$file" "$agent" "$engine" "$fail_count" "$exit_code" "$stderr_file" "$launch_cmd_display" "$err_size_before" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -215,18 +215,24 @@ LAUNCH_REDACTION_OUTPUT="$("$BASH4_BIN" -s "$REPO_ROOT" <<'BASH_REDACTION'
 set -euo pipefail
 repo="$1"
 source "$repo/lib/bridge-core.sh"
-bridge_redact_inline_env_secrets "MS365_CLIENT_SECRET=s3cr3t SAFE_FLAG=1 API_KEY=abc BEARER_TOKEN=zzz SERVICE_PWD=pwd DB_PASSWORD='with space' OPTIONAL_KEY=\"quoted secret\" OAUTH_TOKEN=hello\\ world ANSI_SECRET=\$'line space' claude --ok"
+bridge_redact_inline_env_secrets "MS365_CLIENT_SECRET=s3cr3t SAFE_FLAG=1 MY_API_KEY=abc BEARER_TOKEN=zzz SERVICE_PWD=pwd DB_PASSWORD='with space' MY_PRIVATE_KEY=\"quoted secret\" OAUTH_TOKEN=hello\\ world ANSI_SECRET=\$'line space' BRIDGE_LAYOUT_MARKER_KEY=layout-marker CACHE_KEY=cache-val claude --ok"
 BASH_REDACTION
 )"
 assert_contains "$LAUNCH_REDACTION_OUTPUT" "MS365_CLIENT_SECRET=***redacted***"
-assert_contains "$LAUNCH_REDACTION_OUTPUT" "API_KEY=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "MY_API_KEY=***redacted***"
 assert_contains "$LAUNCH_REDACTION_OUTPUT" "BEARER_TOKEN=***redacted***"
 assert_contains "$LAUNCH_REDACTION_OUTPUT" "SERVICE_PWD=***redacted***"
 assert_contains "$LAUNCH_REDACTION_OUTPUT" "DB_PASSWORD=***redacted***"
-assert_contains "$LAUNCH_REDACTION_OUTPUT" "OPTIONAL_KEY=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "MY_PRIVATE_KEY=***redacted***"
 assert_contains "$LAUNCH_REDACTION_OUTPUT" "OAUTH_TOKEN=***redacted***"
 assert_contains "$LAUNCH_REDACTION_OUTPUT" "ANSI_SECRET=***redacted***"
 assert_contains "$LAUNCH_REDACTION_OUTPUT" "SAFE_FLAG=1"
+# #428 r2: bare ``_KEY`` no longer triggers redaction — only ``API_KEY`` /
+# ``AUTH_KEY`` / ``PRIVATE_KEY`` / ``CLIENT_KEY`` / ``ACCESS_KEY`` /
+# ``SECRET_KEY`` (and the existing substring families). Non-secret env
+# names that merely end in ``_KEY`` must round-trip unchanged.
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "BRIDGE_LAYOUT_MARKER_KEY=layout-marker"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "CACHE_KEY=cache-val"
 assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "s3cr3t"
 assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "abc"
 assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "zzz"
@@ -234,6 +240,45 @@ assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "with space"
 assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "quoted secret"
 assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "hello"
 assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "line space"
+
+# #428 r2 item 2: end-to-end dry-run smoke. The focused helper test above
+# only proves bridge_redact_inline_env_secrets does the right thing in
+# isolation. This case proves bridge-run.sh's --dry-run path actually
+# routes the launch_cmd through that helper before printing
+# `launch=...`, so a future refactor cannot silently drop the redaction
+# call and reintroduce the #428 leak.
+log "bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor (#428 r2)"
+LAUNCH_DRYRUN_HOME="$(mktemp -d)"
+LAUNCH_DRYRUN_WORKDIR="$LAUNCH_DRYRUN_HOME/work"
+mkdir -p "$LAUNCH_DRYRUN_WORKDIR"
+cat >"$LAUNCH_DRYRUN_HOME/agent-roster.local.sh" <<EOF
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+bridge_add_agent_id_if_missing "dryrun-redact-smoke"
+BRIDGE_AGENT_DESC["dryrun-redact-smoke"]="Dry-run redaction smoke role"
+BRIDGE_AGENT_ENGINE["dryrun-redact-smoke"]="claude"
+BRIDGE_AGENT_SESSION["dryrun-redact-smoke"]="dryrun-redact-smoke"
+BRIDGE_AGENT_WORKDIR["dryrun-redact-smoke"]="$LAUNCH_DRYRUN_WORKDIR"
+BRIDGE_AGENT_LAUNCH_CMD["dryrun-redact-smoke"]='MS365_CLIENT_SECRET=fake-secret-XYZ MY_API_TOKEN=fake-token-ABC BRIDGE_LAYOUT_MARKER_KEY=preserve-me claude --ok'
+EOF
+# Unset any inherited BRIDGE_ROSTER_* / BRIDGE_*_DIR overrides so the
+# isolated BRIDGE_HOME defaults bind to LAUNCH_DRYRUN_HOME. Without this,
+# operator-shell defaults would silently steer bridge-run.sh at the live
+# roster and the test would be a no-op (or worse, an env-pollution false
+# pass against unrelated agents).
+LAUNCH_DRYRUN_OUTPUT="$(env -u BRIDGE_ROSTER_FILE -u BRIDGE_ROSTER_LOCAL_FILE \
+  -u BRIDGE_STATE_DIR -u BRIDGE_ACTIVE_AGENT_DIR -u BRIDGE_LOG_DIR \
+  -u BRIDGE_SHARED_DIR -u BRIDGE_TASK_DB \
+  BRIDGE_HOME="$LAUNCH_DRYRUN_HOME" \
+  "$BASH4_BIN" "$REPO_ROOT/bridge-run.sh" "dryrun-redact-smoke" --dry-run 2>&1)"
+assert_contains "$LAUNCH_DRYRUN_OUTPUT" "launch=MS365_CLIENT_SECRET=***redacted***"
+assert_contains "$LAUNCH_DRYRUN_OUTPUT" "MY_API_TOKEN=***redacted***"
+# Non-secret BRIDGE_LAYOUT_MARKER_KEY must round-trip with its real value
+# (control assertion — proves the dry-run path didn't blanket-redact).
+assert_contains "$LAUNCH_DRYRUN_OUTPUT" "BRIDGE_LAYOUT_MARKER_KEY=preserve-me"
+assert_not_contains "$LAUNCH_DRYRUN_OUTPUT" "fake-secret-XYZ"
+assert_not_contains "$LAUNCH_DRYRUN_OUTPUT" "fake-token-ABC"
+rm -rf "$LAUNCH_DRYRUN_HOME"
 
 log "bridge_cron_sync_enabled reducer: any-0-disables semantics (issue #192)"
 # Regression matrix for the `BRIDGE_CRON_SYNC_ENABLED` reducer introduced

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -210,6 +210,31 @@ else
   log "shellcheck not installed; skipping"
 fi
 
+log "redacting sensitive inline env vars from launch display paths (#428)"
+LAUNCH_REDACTION_OUTPUT="$("$BASH4_BIN" -s "$REPO_ROOT" <<'BASH_REDACTION'
+set -euo pipefail
+repo="$1"
+source "$repo/lib/bridge-core.sh"
+bridge_redact_inline_env_secrets "MS365_CLIENT_SECRET=s3cr3t SAFE_FLAG=1 API_KEY=abc BEARER_TOKEN=zzz SERVICE_PWD=pwd DB_PASSWORD='with space' OPTIONAL_KEY=\"quoted secret\" OAUTH_TOKEN=hello\\ world ANSI_SECRET=\$'line space' claude --ok"
+BASH_REDACTION
+)"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "MS365_CLIENT_SECRET=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "API_KEY=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "BEARER_TOKEN=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "SERVICE_PWD=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "DB_PASSWORD=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "OPTIONAL_KEY=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "OAUTH_TOKEN=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "ANSI_SECRET=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "SAFE_FLAG=1"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "s3cr3t"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "abc"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "zzz"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "with space"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "quoted secret"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "hello"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "line space"
+
 log "bridge_cron_sync_enabled reducer: any-0-disables semantics (issue #192)"
 # Regression matrix for the `BRIDGE_CRON_SYNC_ENABLED` reducer introduced
 # in #213 after the original precedence chain silently let an outer =1
@@ -1836,7 +1861,7 @@ BRIDGE_STATE_DIR="$BROKEN_LAUNCH_HOME/state" "$BASH4_BIN" -lc '
   # `bridge_load_roster` would error without a roster file; skip it — the two
   # helpers we are exercising only touch $BRIDGE_STATE_DIR.
   source "'"$REPO_ROOT"'/bridge-lib.sh"
-  bridge_agent_write_broken_launch_state "'"$BROKEN_LAUNCH_AGENT"'" "claude" 5 1 "/tmp/err.log" "bash bridge-run.sh broken-smoke" 0
+  bridge_agent_write_broken_launch_state "'"$BROKEN_LAUNCH_AGENT"'" "claude" 5 1 "/tmp/err.log" "MS365_CLIENT_SECRET=broken-secret API_KEY=broken-key bash bridge-run.sh broken-smoke" 0
 '
 BROKEN_FILE="$BROKEN_LAUNCH_HOME/state/agents/$BROKEN_LAUNCH_AGENT/broken-launch"
 [[ -s "$BROKEN_FILE" ]] || die "bridge_agent_write_broken_launch_state did not create the quarantine file"
@@ -1851,6 +1876,10 @@ assert payload.get("fail_count") == 5, payload
 assert payload.get("exit_code") == 1, payload
 assert payload.get("engine") == "claude", payload
 assert payload.get("launch_cmd"), payload
+assert "broken-secret" not in payload.get("launch_cmd", ""), payload
+assert "broken-key" not in payload.get("launch_cmd", ""), payload
+assert "MS365_CLIENT_SECRET=***redacted***" in payload.get("launch_cmd", ""), payload
+assert "API_KEY=***redacted***" in payload.get("launch_cmd", ""), payload
 assert payload.get("stderr_file") == "/tmp/err.log", payload
 assert payload.get("quarantined_at"), payload
 PY
@@ -8495,10 +8524,15 @@ cat >"$CRASH_ERRFILE" <<'EOF'
 fatal: token expired
 unable to open runtime config
 EOF
-"$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_write_crash_report \"$BROKEN_CHANNEL_AGENT\" \"claude\" \"5\" \"1\" \"$CRASH_ERRFILE\" 'claude --dangerously-skip-permissions'"
+"$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_write_crash_report \"$BROKEN_CHANNEL_AGENT\" \"claude\" \"5\" \"1\" \"$CRASH_ERRFILE\" 'MS365_CLIENT_SECRET=crash-secret API_KEY=crash-key claude --dangerously-skip-permissions'"
 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 CRASH_OPEN_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[crash-loop] $BROKEN_CHANNEL_AGENT " 2>/dev/null || true)"
 [[ "$CRASH_OPEN_ID" =~ ^[0-9]+$ ]] || die "expected crash-loop task for $BROKEN_CHANNEL_AGENT"
+CRASH_BODY_FILE="$("$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_crash_report_body_file \"$BROKEN_CHANNEL_AGENT\"")"
+assert_contains "$(cat "$CRASH_BODY_FILE")" "MS365_CLIENT_SECRET=***redacted***"
+assert_contains "$(cat "$CRASH_BODY_FILE")" "API_KEY=***redacted***"
+assert_not_contains "$(cat "$CRASH_BODY_FILE")" "crash-secret"
+assert_not_contains "$(cat "$CRASH_BODY_FILE")" "crash-key"
 bash "$REPO_ROOT/bridge-task.sh" done "$CRASH_OPEN_ID" --agent "$SMOKE_AGENT" --note "crash report handled" >/dev/null
 CRASH_STATE_FILE="$("$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_crash_state_file \"$BROKEN_CHANNEL_AGENT\"")"
 [[ -f "$CRASH_STATE_FILE" ]] || die "expected crash state file for $BROKEN_CHANNEL_AGENT"
@@ -8507,7 +8541,6 @@ BRIDGE_CRASH_REPORT_COOLDOWN_SECONDS=0 bash "$REPO_ROOT/bridge-daemon.sh" sync >
 CRASH_OPEN_ID_AGAIN="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[crash-loop] $BROKEN_CHANNEL_AGENT " 2>/dev/null || true)"
 [[ -z "$CRASH_OPEN_ID_AGAIN" ]] || die "crash-loop report should stay acked while error hash is unchanged"
 "$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_clear_crash_report \"$BROKEN_CHANNEL_AGENT\""
-CRASH_BODY_FILE="$("$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_crash_report_body_file \"$BROKEN_CHANNEL_AGENT\"")"
 [[ ! -f "$CRASH_BODY_FILE" ]] || die "expected crash report body file to be removed on clear"
 
 log "directly alerting on admin crash loops"


### PR DESCRIPTION
## Summary

- Add a shared launch-command redactor for sensitive inline `KEY=value` env assignments.
- Redact launch command copies before they reach `bridge-run.sh --dry-run`, tmux-visible runner logs, safe-mode hints, crash reports, broken-launch state, and daemon crash-report bodies.
- Keep the raw launch command unchanged for execution and dev-channel picker parsing.

Fixes #428

## Security self-check

- Redaction is broad by variable name: `SECRET`, `TOKEN`, `PASSWORD`, `PASSWD`, `CREDENTIAL`, `AUTH`, `BEARER`, `PRIVATE`, `COOKIE`, `JWT`, `_KEY`, and `_PWD` patterns render as `<NAME>=***redacted***`.
- No temporary env-file path was added in this hotfix; no new ACL/mode surface is introduced.
- Operator debugging still sees the command shape and non-secret env assignments, but not credential values.
- Crash body rendering also sanitizes stale/raw report input created before this patch.

## Validation

- `bash -n bridge-daemon.sh bridge-run.sh lib/bridge-core.sh lib/bridge-state.sh scripts/smoke-test.sh`
- `git diff --check`
- Focused redaction helper check for quoted, escaped-space, `_TOKEN`, `_KEY`, `_PWD`, and `SECRET` names.
- Focused `bridge-run.sh --dry-run` fixture confirmed secret values are absent and safe launch context remains.
- Focused crash-report, broken-launch, and daemon crash-body checks confirmed persisted/formatted launch commands are redacted.

