### PR TITLE
fix: gate dev-channel accept on claude foreground

### DIFF
--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -50,6 +50,48 @@ bridge_tmux_session_pane_pid() {
   tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_pid}' 2>/dev/null || true
 }
 
+bridge_tmux_command_name_is_claude() {
+  local command_name="${1:-}"
+  local base=""
+
+  [[ -n "$command_name" ]] || return 1
+  base="${command_name##*/}"
+  case "$base" in
+    claude|claude-*|claude.*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+bridge_tmux_pane_foreground_is_claude() {
+  local session="$1"
+  local pane_pid=""
+  local tpgid=""
+  local pgid=""
+  local comm=""
+  local pane_cmd=""
+
+  pane_pid="$(bridge_tmux_session_pane_pid "$session")"
+  if [[ "$pane_pid" =~ ^[0-9]+$ ]]; then
+    tpgid="$(ps -o tpgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$tpgid" =~ ^[0-9]+$ ]] && (( tpgid > 0 )); then
+      while read -r pgid comm; do
+        [[ "$pgid" == "$tpgid" ]] || continue
+        if bridge_tmux_command_name_is_claude "$comm"; then
+          return 0
+        fi
+      done < <(ps -eo pgid=,comm= 2>/dev/null || true)
+      return 1
+    fi
+  fi
+
+  pane_cmd="$(tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_current_command}' 2>/dev/null || true)"
+  bridge_tmux_command_name_is_claude "$pane_cmd"
+}
+
 bridge_tmux_kill_session() {
   local session="$1"
   tmux kill-session -t "$(bridge_tmux_session_target "$session")"
@@ -410,6 +452,7 @@ bridge_tmux_claude_advance_blocker() {
   local allow_devchannels="${2:-0}"
   local expected_state="${3:-}"
   local state=""
+  local settle_seconds="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_SETTLE_SECONDS:-0.2}"
 
   state="$(bridge_tmux_claude_blocker_state "$session")"
   # If the caller specified an expected state and the live state has
@@ -429,6 +472,11 @@ bridge_tmux_claude_advance_blocker() {
       ;;
     devchannels)
       if [[ "$allow_devchannels" == "1" ]]; then
+        if [[ "${BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND:-1}" != "0" ]]; then
+          bridge_tmux_pane_foreground_is_claude "$session" || return 1
+          [[ "$settle_seconds" =~ ^[0-9]+([.][0-9]+)?$ ]] || settle_seconds="0.2"
+          sleep "$settle_seconds"
+        fi
         bridge_tmux_send_keys_with_timeout tmux_send_advance_blocker_devchannels \
           -t "$(bridge_tmux_pane_target "$session")" C-m
         sleep 0.3
@@ -530,6 +578,11 @@ bridge_tmux_wait_for_prompt() {
     fi
     elapsed=$(( $(date +%s) - start_ts ))
     if (( elapsed >= timeout )); then
+      if [[ "$engine" == "claude" && "$state" == "devchannels" && "$allow_devchannels" == "1" \
+          && "${BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND:-1}" != "0" \
+          && $devchannels_actions -eq 0 ]]; then
+        bridge_warn "wait_for_prompt: devchannels picker present but pane foreground never became claude on session=${session}"
+      fi
       return 1
     fi
   done

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5543,12 +5543,34 @@ sleep 2
 EOF
 chmod +x "$DEV_CHANNELS_PROMPT_SCRIPT"
 tmux new-session -d -s "$DEV_CHANNELS_PROMPT_SESSION" "$DEV_CHANNELS_PROMPT_SCRIPT"
-"$BASH4_BIN" -c '
+BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND=0 "$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_tmux_wait_for_prompt "'"$DEV_CHANNELS_PROMPT_SESSION"'" claude 5 1
 ' >/dev/null
 assert_contains "$(cat "$DEV_CHANNELS_PROMPT_ACK")" "<enter>"
 tmux kill-session -t "=$DEV_CHANNELS_PROMPT_SESSION" >/dev/null 2>&1 || true
+
+log "gating dev-channel auto-accept on Claude foreground readiness (#429)"
+DEV_CHANNELS_CLAUDE_BIN="$TMP_ROOT/claude"
+DEV_CHANNELS_CLAUDE_SESSION="dev-channels-claude-fg-$SESSION_NAME"
+DEV_CHANNELS_SLEEP_SESSION="dev-channels-sleep-fg-$SESSION_NAME"
+ln -sf "$(command -v sleep)" "$DEV_CHANNELS_CLAUDE_BIN"
+tmux new-session -d -s "$DEV_CHANNELS_CLAUDE_SESSION" "$DEV_CHANNELS_CLAUDE_BIN 2"
+tmux new-session -d -s "$DEV_CHANNELS_SLEEP_SESSION" "$(command -v sleep) 2"
+wait_for_tmux_session "$DEV_CHANNELS_CLAUDE_SESSION" up 10 0.1
+wait_for_tmux_session "$DEV_CHANNELS_SLEEP_SESSION" up 10 0.1
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_CLAUDE_SESSION"'"
+' >/dev/null || die "expected symlinked claude foreground to be detected"
+if "$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_SLEEP_SESSION"'"
+' >/dev/null; then
+  die "sleep foreground must not be classified as claude"
+fi
+tmux kill-session -t "=$DEV_CHANNELS_CLAUDE_SESSION" >/dev/null 2>&1 || true
+tmux kill-session -t "=$DEV_CHANNELS_SLEEP_SESSION" >/dev/null 2>&1 || true
 
 log "classifying admin foreground exit by onboarding state"
 ONBOARDING_ADMIN_WORKDIR="$TMP_ROOT/onboarding-admin"


### PR DESCRIPTION
## Summary

- Add a tmux foreground-process check that resolves the pane foreground process group and recognizes `claude` before dev-channel picker auto-accept sends Enter.
- Gate only the dev-channels blocker path; trust/summary prompt advancement keeps the existing behavior.
- Preserve the existing bounded retry loop and timeout, with a warning when the picker is present but the pane never reaches Claude foreground.
- Add smoke coverage for the foreground detector and keep the existing synthetic picker fixture via an explicit opt-out.

Fixes #429

## Security / reliability self-check

- Retry behavior remains bounded by `bridge_tmux_wait_for_prompt` timeout and `BRIDGE_TMUX_DEV_CHANNELS_MAX_ADVANCE`; no infinite loop is introduced.
- Foreground polling uses local `tmux` + `ps` reads only; failed/unavailable process-group resolution falls back to tmux `pane_current_command`.
- Scope is limited to `allow_devchannels=1`, so trust/summary/login-style prompt handling is not widened.
- Synthetic/non-Claude tests can opt out with `BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND=0`; production defaults to requiring Claude foreground.

## Validation

- `bash -n lib/bridge-tmux.sh scripts/smoke-test.sh bridge-run.sh`
- `git diff --check`
- Focused foreground detector check: symlinked `claude` process returns true, plain `sleep` process returns false.
- Focused synthetic dev-channel picker check with explicit foreground-gate opt-out still sends Enter and reaches prompt.

