### PR TITLE
fix: retry dev-channel picker foreground readiness

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2036,7 +2036,9 @@ bridge_write_crash_report_body() {
   local stderr_file="$6"
   local tail_file="$7"
   local launch_cmd="$8"
+  local launch_cmd_display=""
 
+  launch_cmd_display="$(bridge_redact_inline_env_secrets "$launch_cmd")"
   mkdir -p "$(dirname "$body_file")"
   {
     echo "# Crash Loop Report"
@@ -2052,7 +2054,7 @@ bridge_write_crash_report_body() {
     echo "## Launch Command"
     echo
     echo '```bash'
-    printf '%s\n' "$launch_cmd"
+    printf '%s\n' "$launch_cmd_display"
     echo '```'
     echo
     echo "## Stderr Tail"

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -166,7 +166,7 @@ if [[ $DRY_RUN -eq 1 ]]; then
   echo "safe_mode=$SAFE_MODE"
   echo "channels=$(bridge_agent_channels_csv "$AGENT")"
   echo "channel_status=$(bridge_agent_channel_status "$AGENT")"
-  echo "launch=$LAUNCH_CMD"
+  echo "launch=$(bridge_redact_inline_env_secrets "$LAUNCH_CMD")"
   exit 0
 fi
 
@@ -437,7 +437,7 @@ bridge_run_safe_mode_resume_hint() {
   mode="$(bridge_safe_mode_resume_mode "$AGENT")"
   admin_agent="$(bridge_require_admin_agent 2>/dev/null || true)"
   log_line "[safe-mode] booting ${AGENT} with minimal launch"
-  log_line "[safe-mode] ignored roster launch_cmd: $(bridge_agent_launch_cmd_raw "$AGENT")"
+  log_line "[safe-mode] ignored roster launch_cmd: $(bridge_redact_inline_env_secrets "$(bridge_agent_launch_cmd_raw "$AGENT")")"
   if [[ -n "$(bridge_agent_channels_csv "$AGENT")" ]]; then
     log_line "[safe-mode] suppressed channels: $(bridge_agent_channels_csv "$AGENT")"
   fi
@@ -487,6 +487,7 @@ RAPID_FAIL_WINDOW="${BRIDGE_RUN_RAPID_FAIL_WINDOW_SECONDS:-10}"
 MAX_RAPID_FAILS="${BRIDGE_RUN_MAX_RAPID_FAILS:-5}"
 HEALTHY_RUN_RESET_SECONDS="${BRIDGE_RUN_HEALTHY_RESET_SECONDS:-60}"
 while true; do
+  local_launch_cmd_display=""
   local_err_size_before=0
   local_err_size_after=0
   run_started_at=0
@@ -503,6 +504,7 @@ while true; do
     LAUNCH_CMD="$(bridge_agent_launch_cmd "$AGENT")"
   fi
   [[ -n "$LAUNCH_CMD" ]] || bridge_die "'$AGENT'의 launch command가 비어 있습니다."
+  local_launch_cmd_display="$(bridge_redact_inline_env_secrets "$LAUNCH_CMD")"
 
   if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
     bridge_run_sync_dev_plugin_cache
@@ -511,15 +513,14 @@ while true; do
     bridge_run_schedule_idle_marker_and_inbox_bootstrap
   fi
 
-  log_line "실행: ${LAUNCH_CMD}"
+  log_line "실행: ${local_launch_cmd_display}"
   if [[ -f "$ERRFILE" ]]; then
     local_err_size_before="$(wc -c <"$ERRFILE" 2>/dev/null || echo 0)"
   fi
   # v2 isolation: load per-agent launch secrets from credentials/launch-secrets.env
   # into the child shell so the child inherits them via export, NEVER via
   # composing into LAUNCH_CMD. Composing tokens into LAUNCH_CMD leaks via
-  # process listings, the `log_line` above, dry-run output, the crash-report
-  # path (bridge_agent_write_crash_report writes LAUNCH_CMD verbatim), and
+  # process listings, raw display output, crash-report paths, and
   # any tee'd stderr. Loading inside the launch subshell (not the parent)
   # also prevents stale secrets from persisting across restart-loop
   # iterations after the credentials file is rotated, emptied, or removed.
@@ -597,7 +598,7 @@ while true; do
       RAPID_FAIL_COUNT=0
     fi
     if [[ $FAIL_COUNT -eq 5 || $(( FAIL_COUNT % 10 )) -eq 0 ]]; then
-      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$LAUNCH_CMD"
+      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$local_launch_cmd_display"
       bridge_audit_log daemon crash_loop_detected "$AGENT" \
         --detail engine="$ENGINE" \
         --detail fail_count="$FAIL_COUNT" \
@@ -605,8 +606,8 @@ while true; do
         --detail stderr_file="$ERRFILE"
     fi
     if [[ $rapid_failure -eq 1 && "$RAPID_FAIL_COUNT" =~ ^[0-9]+$ && "$MAX_RAPID_FAILS" =~ ^[0-9]+$ && $RAPID_FAIL_COUNT -ge $MAX_RAPID_FAILS ]]; then
-      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$LAUNCH_CMD"
-      bridge_agent_write_broken_launch_state "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$LAUNCH_CMD" "$local_err_size_before"
+      bridge_agent_write_crash_report "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$local_launch_cmd_display"
+      bridge_agent_write_broken_launch_state "$AGENT" "$ENGINE" "$FAIL_COUNT" "$EXIT_CODE" "$ERRFILE" "$local_launch_cmd_display" "$local_err_size_before"
       bridge_audit_log daemon crash_loop_broken "$AGENT" \
         --detail engine="$ENGINE" \
         --detail fail_count="$FAIL_COUNT" \

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -167,6 +167,38 @@ bridge_upgrade_with_target_env() {
     "$@"
 }
 
+bridge_upgrade_should_emit_post_task() {
+  local channel="$1"
+  local apply_json="$2"
+
+  case "$channel" in
+    current|dev|ref)
+      return 1
+      ;;
+  esac
+
+  python3 - "$apply_json" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.loads(sys.argv[1])
+except Exception:
+    # Fail open: a malformed apply payload should not hide an upgrade signal.
+    raise SystemExit(0)
+
+counts = payload.get("counts") or {}
+changed = 0
+for key in ("files_copied", "files_merged_clean", "files_merged_conflict", "files_mode_synced"):
+    try:
+        changed += int(counts.get(key, 0) or 0)
+    except (TypeError, ValueError):
+        raise SystemExit(0)
+
+raise SystemExit(0 if changed > 0 else 1)
+PY
+}
+
 bridge_upgrade_collect_agent_restart_report() {
   local target_root="$1"
   local dry_run="${2:-0}"
@@ -1215,9 +1247,9 @@ fi
 # Post-upgrade admin signal: file a [upgrade-complete] task with a
 # ready-to-execute checklist. Without this the admin has to know to
 # go read docs/agent-runtime/wiki-onboarding.md; the task makes the
-# first run self-announcing. Skipped on dry-runs and when no admin
-# agent is configured.
-if [[ $DRY_RUN -eq 0 ]]; then
+# first run self-announcing. Skipped on dry-runs, dev/ref/current channel
+# upgrades, no-op applies, and when no admin agent is configured.
+if [[ $DRY_RUN -eq 0 ]] && bridge_upgrade_should_emit_post_task "$CHANNEL" "$APPLY_JSON"; then
   # Resolve admin id: explicit upgrade override → grep the target roster → skip.
   # We grep instead of sourcing because the roster files reference
   # bridge-lib arrays/functions that are not loaded in this scope;

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -401,6 +401,72 @@ print(hashlib.sha1(sys.argv[1].encode("utf-8")).hexdigest())
 PY
 }
 
+bridge_redact_inline_env_secrets() {
+  local text="${1-}"
+  local redacted=""
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    printf '%s' "[redacted launch command: python3 unavailable]"
+    return 0
+  fi
+
+  if redacted="$(printf '%s' "$text" | python3 -c '
+import re
+import sys
+
+text = sys.stdin.read()
+
+
+def sensitive(name):
+    upper = name.upper()
+    if any(
+        marker in upper
+        for marker in (
+            "SECRET",
+            "TOKEN",
+            "PASSWORD",
+            "PASSWD",
+            "CREDENTIAL",
+            "AUTH",
+            "BEARER",
+            "PRIVATE",
+            "COOKIE",
+            "JWT",
+        )
+    ):
+        return True
+    if re.search(r"(^|_)KEY($|_)", upper):
+        return True
+    if re.search(r"(^|_)PWD($|_)", upper):
+        return True
+    return False
+
+
+assignment = re.compile(
+    r"(^|\s)"
+    r"([A-Za-z_][A-Za-z0-9_]*)"
+    r"(=)"
+    r"(\$'\''(?:[^'\''\\]|\\.)*'\''|\$\"(?:[^\"\\]|\\.)*\"|'\''(?:[^'\''\\]|\\.)*'\''|\"(?:[^\"\\]|\\.)*\"|(?:\\.|[^\s])*)",
+    re.MULTILINE,
+)
+
+
+def replace(match):
+    prefix, name, equals, _value = match.groups()
+    if sensitive(name):
+        return f"{prefix}{name}{equals}***redacted***"
+    return match.group(0)
+
+
+sys.stdout.write(assignment.sub(replace, text))
+' 2>/dev/null)"; then
+    printf '%s' "$redacted"
+    return 0
+  fi
+
+  printf '%s' "[redacted launch command: redaction failed]"
+}
+
 bridge_queue_cli() {
   local agent=""
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1863,11 +1863,13 @@ bridge_agent_write_crash_report() {
   local exit_code="$4"
   local stderr_file="$5"
   local launch_cmd="$6"
+  local launch_cmd_display=""
   local report_file=""
   local tail_file=""
   local error_hash=""
   local stderr_tail=""
 
+  launch_cmd_display="$(bridge_redact_inline_env_secrets "$launch_cmd")"
   report_file="$(bridge_agent_crash_report_file "$agent")"
   tail_file="$(bridge_agent_crash_tail_file "$agent")"
   mkdir -p "$(dirname "$report_file")"
@@ -1885,7 +1887,7 @@ CRASH_FAIL_COUNT=$(printf '%q' "$fail_count")
 CRASH_EXIT_CODE=$(printf '%q' "$exit_code")
 CRASH_STDERR_FILE=$(printf '%q' "$stderr_file")
 CRASH_TAIL_FILE=$(printf '%q' "$tail_file")
-CRASH_LAUNCH_CMD=$(printf '%q' "$launch_cmd")
+CRASH_LAUNCH_CMD=$(printf '%q' "$launch_cmd_display")
 CRASH_ERROR_HASH=$(printf '%q' "$error_hash")
 CRASH_REPORTED_AT=$(printf '%q' "$(bridge_now_iso)")
 EOF
@@ -1917,11 +1919,13 @@ bridge_agent_write_broken_launch_state() {
   local launch_cmd="${6:-}"
   local err_size_before="${7:-0}"
   local file=""
+  local launch_cmd_display=""
 
+  launch_cmd_display="$(bridge_redact_inline_env_secrets "$launch_cmd")"
   file="$(bridge_agent_broken_launch_file "$agent")"
   mkdir -p "$(dirname "$file")"
   bridge_require_python
-  python3 - "$file" "$agent" "$engine" "$fail_count" "$exit_code" "$stderr_file" "$launch_cmd" "$err_size_before" <<'PY'
+  python3 - "$file" "$agent" "$engine" "$fail_count" "$exit_code" "$stderr_file" "$launch_cmd_display" "$err_size_before" <<'PY'
 import json
 import sys
 from datetime import datetime, timezone

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -50,6 +50,48 @@ bridge_tmux_session_pane_pid() {
   tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_pid}' 2>/dev/null || true
 }
 
+bridge_tmux_command_name_is_claude() {
+  local command_name="${1:-}"
+  local base=""
+
+  [[ -n "$command_name" ]] || return 1
+  base="${command_name##*/}"
+  case "$base" in
+    claude|claude-*|claude.*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+bridge_tmux_pane_foreground_is_claude() {
+  local session="$1"
+  local pane_pid=""
+  local tpgid=""
+  local pgid=""
+  local comm=""
+  local pane_cmd=""
+
+  pane_pid="$(bridge_tmux_session_pane_pid "$session")"
+  if [[ "$pane_pid" =~ ^[0-9]+$ ]]; then
+    tpgid="$(ps -o tpgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    if [[ "$tpgid" =~ ^[0-9]+$ ]] && (( tpgid > 0 )); then
+      while read -r pgid comm; do
+        [[ "$pgid" == "$tpgid" ]] || continue
+        if bridge_tmux_command_name_is_claude "$comm"; then
+          return 0
+        fi
+      done < <(ps -eo pgid=,comm= 2>/dev/null || true)
+      return 1
+    fi
+  fi
+
+  pane_cmd="$(tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_current_command}' 2>/dev/null || true)"
+  bridge_tmux_command_name_is_claude "$pane_cmd"
+}
+
 bridge_tmux_kill_session() {
   local session="$1"
   tmux kill-session -t "$(bridge_tmux_session_target "$session")"
@@ -410,6 +452,7 @@ bridge_tmux_claude_advance_blocker() {
   local allow_devchannels="${2:-0}"
   local expected_state="${3:-}"
   local state=""
+  local settle_seconds="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_SETTLE_SECONDS:-0.2}"
 
   state="$(bridge_tmux_claude_blocker_state "$session")"
   # If the caller specified an expected state and the live state has
@@ -429,6 +472,11 @@ bridge_tmux_claude_advance_blocker() {
       ;;
     devchannels)
       if [[ "$allow_devchannels" == "1" ]]; then
+        if [[ "${BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND:-1}" != "0" ]]; then
+          bridge_tmux_pane_foreground_is_claude "$session" || return 1
+          [[ "$settle_seconds" =~ ^[0-9]+([.][0-9]+)?$ ]] || settle_seconds="0.2"
+          sleep "$settle_seconds"
+        fi
         bridge_tmux_send_keys_with_timeout tmux_send_advance_blocker_devchannels \
           -t "$(bridge_tmux_pane_target "$session")" C-m
         sleep 0.3
@@ -530,6 +578,11 @@ bridge_tmux_wait_for_prompt() {
     fi
     elapsed=$(( $(date +%s) - start_ts ))
     if (( elapsed >= timeout )); then
+      if [[ "$engine" == "claude" && "$state" == "devchannels" && "$allow_devchannels" == "1" \
+          && "${BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND:-1}" != "0" \
+          && $devchannels_actions -eq 0 ]]; then
+        bridge_warn "wait_for_prompt: devchannels picker present but pane foreground never became claude on session=${session}"
+      fi
       return 1
     fi
   done

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -121,6 +121,35 @@ bridge_tmux_pane_foreground_is_claude() {
   bridge_tmux_command_name_is_claude "$pane_cmd"
 }
 
+bridge_tmux_wait_for_claude_foreground() {
+  local session="$1"
+  local timeout="${2:-60}"
+  local poll="${3:-2}"
+  local max_checks="${4:-30}"
+  local start_ts=""
+  local elapsed=0
+  local checks=0
+
+  [[ "$timeout" =~ ^[0-9]+$ ]] || timeout=60
+  (( timeout > 0 )) || timeout=60
+  [[ "$poll" =~ ^[0-9]+([.][0-9]+)?$ ]] || poll=2
+  [[ "$max_checks" =~ ^[0-9]+$ ]] || max_checks=30
+  (( max_checks > 0 )) || max_checks=30
+
+  start_ts="$(date +%s)"
+  while (( checks < max_checks )); do
+    if bridge_tmux_pane_foreground_is_claude "$session"; then
+      return 0
+    fi
+    checks=$((checks + 1))
+    elapsed=$(( $(date +%s) - start_ts ))
+    (( elapsed >= timeout )) && break
+    sleep "$poll"
+  done
+
+  return 1
+}
+
 bridge_tmux_kill_session() {
   local session="$1"
   tmux kill-session -t "$(bridge_tmux_session_target "$session")"
@@ -481,6 +510,9 @@ bridge_tmux_claude_advance_blocker() {
   local allow_devchannels="${2:-0}"
   local expected_state="${3:-}"
   local state=""
+  local foreground_wait="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_WAIT_SECONDS:-60}"
+  local foreground_poll="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_POLL_SECONDS:-2}"
+  local foreground_max="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_MAX_CHECKS:-30}"
   local settle_seconds="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_SETTLE_SECONDS:-0.2}"
 
   state="$(bridge_tmux_claude_blocker_state "$session")"
@@ -502,7 +534,7 @@ bridge_tmux_claude_advance_blocker() {
     devchannels)
       if [[ "$allow_devchannels" == "1" ]]; then
         if [[ "${BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND:-1}" != "0" ]]; then
-          bridge_tmux_pane_foreground_is_claude "$session" || return 1
+          bridge_tmux_wait_for_claude_foreground "$session" "$foreground_wait" "$foreground_poll" "$foreground_max" || return 1
           [[ "$settle_seconds" =~ ^[0-9]+([.][0-9]+)?$ ]] || settle_seconds="0.2"
           sleep "$settle_seconds"
         fi

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -66,26 +66,55 @@ bridge_tmux_command_name_is_claude() {
   esac
 }
 
+bridge_tmux_process_tree_has_claude() {
+  local root_pid="$1"
+  local max_procs="${BRIDGE_TMUX_PROCESS_TREE_MAX_PROCS:-128}"
+  local -a queue=()
+  local seen=" "
+  local pid=""
+  local child=""
+  local comm=""
+  local count=0
+
+  [[ "$root_pid" =~ ^[0-9]+$ ]] || return 1
+  [[ "$max_procs" =~ ^[0-9]+$ ]] || max_procs=128
+  (( max_procs > 0 )) || max_procs=128
+
+  queue=("$root_pid")
+  while ((${#queue[@]} > 0)) && (( count < max_procs )); do
+    pid="${queue[0]}"
+    queue=("${queue[@]:1}")
+    case "$seen" in
+      *" $pid "*) continue ;;
+    esac
+    seen+="$pid "
+    count=$((count + 1))
+
+    comm="$(ps -o comm= -p "$pid" 2>/dev/null | awk '{$1=$1; print}' || true)"
+    if bridge_tmux_command_name_is_claude "$comm"; then
+      return 0
+    fi
+
+    while IFS= read -r child; do
+      [[ "$child" =~ ^[0-9]+$ ]] || continue
+      case "$seen" in
+        *" $child "*) continue ;;
+      esac
+      queue+=("$child")
+    done < <(pgrep -P "$pid" 2>/dev/null || true)
+  done
+
+  return 1
+}
+
 bridge_tmux_pane_foreground_is_claude() {
   local session="$1"
   local pane_pid=""
-  local tpgid=""
-  local pgid=""
-  local comm=""
   local pane_cmd=""
 
   pane_pid="$(bridge_tmux_session_pane_pid "$session")"
-  if [[ "$pane_pid" =~ ^[0-9]+$ ]]; then
-    tpgid="$(ps -o tpgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]' || true)"
-    if [[ "$tpgid" =~ ^[0-9]+$ ]] && (( tpgid > 0 )); then
-      while read -r pgid comm; do
-        [[ "$pgid" == "$tpgid" ]] || continue
-        if bridge_tmux_command_name_is_claude "$comm"; then
-          return 0
-        fi
-      done < <(ps -eo pgid=,comm= 2>/dev/null || true)
-      return 1
-    fi
+  if [[ "$pane_pid" =~ ^[0-9]+$ ]] && bridge_tmux_process_tree_has_claude "$pane_pid"; then
+    return 0
   fi
 
   pane_cmd="$(tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_current_command}' 2>/dev/null || true)"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5572,12 +5572,34 @@ sleep 2
 EOF
 chmod +x "$DEV_CHANNELS_PROMPT_SCRIPT"
 tmux new-session -d -s "$DEV_CHANNELS_PROMPT_SESSION" "$DEV_CHANNELS_PROMPT_SCRIPT"
-"$BASH4_BIN" -c '
+BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND=0 "$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_tmux_wait_for_prompt "'"$DEV_CHANNELS_PROMPT_SESSION"'" claude 5 1
 ' >/dev/null
 assert_contains "$(cat "$DEV_CHANNELS_PROMPT_ACK")" "<enter>"
 tmux kill-session -t "=$DEV_CHANNELS_PROMPT_SESSION" >/dev/null 2>&1 || true
+
+log "gating dev-channel auto-accept on Claude foreground readiness (#429)"
+DEV_CHANNELS_CLAUDE_BIN="$TMP_ROOT/claude"
+DEV_CHANNELS_CLAUDE_SESSION="dev-channels-claude-fg-$SESSION_NAME"
+DEV_CHANNELS_SLEEP_SESSION="dev-channels-sleep-fg-$SESSION_NAME"
+ln -sf "$(command -v sleep)" "$DEV_CHANNELS_CLAUDE_BIN"
+tmux new-session -d -s "$DEV_CHANNELS_CLAUDE_SESSION" "$DEV_CHANNELS_CLAUDE_BIN 2"
+tmux new-session -d -s "$DEV_CHANNELS_SLEEP_SESSION" "$(command -v sleep) 2"
+wait_for_tmux_session "$DEV_CHANNELS_CLAUDE_SESSION" up 10 0.1
+wait_for_tmux_session "$DEV_CHANNELS_SLEEP_SESSION" up 10 0.1
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_CLAUDE_SESSION"'"
+' >/dev/null || die "expected symlinked claude foreground to be detected"
+if "$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_SLEEP_SESSION"'"
+' >/dev/null; then
+  die "sleep foreground must not be classified as claude"
+fi
+tmux kill-session -t "=$DEV_CHANNELS_CLAUDE_SESSION" >/dev/null 2>&1 || true
+tmux kill-session -t "=$DEV_CHANNELS_SLEEP_SESSION" >/dev/null 2>&1 || true
 
 log "classifying admin foreground exit by onboarding state"
 ONBOARDING_ADMIN_WORKDIR="$TMP_ROOT/onboarding-admin"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -210,6 +210,31 @@ else
   log "shellcheck not installed; skipping"
 fi
 
+log "redacting sensitive inline env vars from launch display paths (#428)"
+LAUNCH_REDACTION_OUTPUT="$("$BASH4_BIN" -s "$REPO_ROOT" <<'BASH_REDACTION'
+set -euo pipefail
+repo="$1"
+source "$repo/lib/bridge-core.sh"
+bridge_redact_inline_env_secrets "MS365_CLIENT_SECRET=s3cr3t SAFE_FLAG=1 API_KEY=abc BEARER_TOKEN=zzz SERVICE_PWD=pwd DB_PASSWORD='with space' OPTIONAL_KEY=\"quoted secret\" OAUTH_TOKEN=hello\\ world ANSI_SECRET=\$'line space' claude --ok"
+BASH_REDACTION
+)"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "MS365_CLIENT_SECRET=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "API_KEY=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "BEARER_TOKEN=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "SERVICE_PWD=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "DB_PASSWORD=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "OPTIONAL_KEY=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "OAUTH_TOKEN=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "ANSI_SECRET=***redacted***"
+assert_contains "$LAUNCH_REDACTION_OUTPUT" "SAFE_FLAG=1"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "s3cr3t"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "abc"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "zzz"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "with space"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "quoted secret"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "hello"
+assert_not_contains "$LAUNCH_REDACTION_OUTPUT" "line space"
+
 log "bridge_cron_sync_enabled reducer: any-0-disables semantics (issue #192)"
 # Regression matrix for the `BRIDGE_CRON_SYNC_ENABLED` reducer introduced
 # in #213 after the original precedence chain silently let an outer =1
@@ -1836,7 +1861,7 @@ BRIDGE_STATE_DIR="$BROKEN_LAUNCH_HOME/state" "$BASH4_BIN" -lc '
   # `bridge_load_roster` would error without a roster file; skip it — the two
   # helpers we are exercising only touch $BRIDGE_STATE_DIR.
   source "'"$REPO_ROOT"'/bridge-lib.sh"
-  bridge_agent_write_broken_launch_state "'"$BROKEN_LAUNCH_AGENT"'" "claude" 5 1 "/tmp/err.log" "bash bridge-run.sh broken-smoke" 0
+  bridge_agent_write_broken_launch_state "'"$BROKEN_LAUNCH_AGENT"'" "claude" 5 1 "/tmp/err.log" "MS365_CLIENT_SECRET=broken-secret API_KEY=broken-key bash bridge-run.sh broken-smoke" 0
 '
 BROKEN_FILE="$BROKEN_LAUNCH_HOME/state/agents/$BROKEN_LAUNCH_AGENT/broken-launch"
 [[ -s "$BROKEN_FILE" ]] || die "bridge_agent_write_broken_launch_state did not create the quarantine file"
@@ -1851,6 +1876,10 @@ assert payload.get("fail_count") == 5, payload
 assert payload.get("exit_code") == 1, payload
 assert payload.get("engine") == "claude", payload
 assert payload.get("launch_cmd"), payload
+assert "broken-secret" not in payload.get("launch_cmd", ""), payload
+assert "broken-key" not in payload.get("launch_cmd", ""), payload
+assert "MS365_CLIENT_SECRET=***redacted***" in payload.get("launch_cmd", ""), payload
+assert "API_KEY=***redacted***" in payload.get("launch_cmd", ""), payload
 assert payload.get("stderr_file") == "/tmp/err.log", payload
 assert payload.get("quarantined_at"), payload
 PY
@@ -8495,10 +8524,15 @@ cat >"$CRASH_ERRFILE" <<'EOF'
 fatal: token expired
 unable to open runtime config
 EOF
-"$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_write_crash_report \"$BROKEN_CHANNEL_AGENT\" \"claude\" \"5\" \"1\" \"$CRASH_ERRFILE\" 'claude --dangerously-skip-permissions'"
+"$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_write_crash_report \"$BROKEN_CHANNEL_AGENT\" \"claude\" \"5\" \"1\" \"$CRASH_ERRFILE\" 'MS365_CLIENT_SECRET=crash-secret API_KEY=crash-key claude --dangerously-skip-permissions'"
 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 CRASH_OPEN_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[crash-loop] $BROKEN_CHANNEL_AGENT " 2>/dev/null || true)"
 [[ "$CRASH_OPEN_ID" =~ ^[0-9]+$ ]] || die "expected crash-loop task for $BROKEN_CHANNEL_AGENT"
+CRASH_BODY_FILE="$("$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_crash_report_body_file \"$BROKEN_CHANNEL_AGENT\"")"
+assert_contains "$(cat "$CRASH_BODY_FILE")" "MS365_CLIENT_SECRET=***redacted***"
+assert_contains "$(cat "$CRASH_BODY_FILE")" "API_KEY=***redacted***"
+assert_not_contains "$(cat "$CRASH_BODY_FILE")" "crash-secret"
+assert_not_contains "$(cat "$CRASH_BODY_FILE")" "crash-key"
 bash "$REPO_ROOT/bridge-task.sh" done "$CRASH_OPEN_ID" --agent "$SMOKE_AGENT" --note "crash report handled" >/dev/null
 CRASH_STATE_FILE="$("$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_crash_state_file \"$BROKEN_CHANNEL_AGENT\"")"
 [[ -f "$CRASH_STATE_FILE" ]] || die "expected crash state file for $BROKEN_CHANNEL_AGENT"
@@ -8507,7 +8541,6 @@ BRIDGE_CRASH_REPORT_COOLDOWN_SECONDS=0 bash "$REPO_ROOT/bridge-daemon.sh" sync >
 CRASH_OPEN_ID_AGAIN="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[crash-loop] $BROKEN_CHANNEL_AGENT " 2>/dev/null || true)"
 [[ -z "$CRASH_OPEN_ID_AGAIN" ]] || die "crash-loop report should stay acked while error hash is unchanged"
 "$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_clear_crash_report \"$BROKEN_CHANNEL_AGENT\""
-CRASH_BODY_FILE="$("$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_crash_report_body_file \"$BROKEN_CHANNEL_AGENT\"")"
 [[ ! -f "$CRASH_BODY_FILE" ]] || die "expected crash report body file to be removed on clear"
 
 log "directly alerting on admin crash loops"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3390,7 +3390,7 @@ print(last)
 PY
 )"
 [[ "$NUDGE_DROP_ACTION" == "session_nudge_dropped" ]] || die "expected session_nudge_dropped audit row, got '$NUDGE_DROP_ACTION'"
-python3 "$REPO_ROOT/bridge-queue.py" cancel "$NUDGE_DROP_TASK_ID" --agent "$REQUESTER_AGENT" --note "verify drop cleanup" >/dev/null
+python3 "$REPO_ROOT/bridge-queue.py" cancel "$NUDGE_DROP_TASK_ID" --actor "$REQUESTER_AGENT" --note "verify drop cleanup" >/dev/null
 
 log "Issue #331: marking session_nudge_sent when the task moves out of queued before the grace expires"
 NUDGE_SENT_OUTPUT="$(python3 "$REPO_ROOT/bridge-queue.py" create --to "$CODEX_CLI_AGENT" --title "verify sent oracle" --body "pickup" --from "$REQUESTER_AGENT")"
@@ -5583,23 +5583,52 @@ log "gating dev-channel auto-accept on Claude foreground readiness (#429)"
 DEV_CHANNELS_CLAUDE_BIN="$TMP_ROOT/claude"
 DEV_CHANNELS_CLAUDE_SESSION="dev-channels-claude-fg-$SESSION_NAME"
 DEV_CHANNELS_SLEEP_SESSION="dev-channels-sleep-fg-$SESSION_NAME"
+DEV_CHANNELS_WRAPPED_CLAUDE_SESSION="dev-channels-wrapped-claude-fg-$SESSION_NAME"
+DEV_CHANNELS_WRAPPED_SLEEP_SESSION="dev-channels-wrapped-sleep-fg-$SESSION_NAME"
+DEV_CHANNELS_WRAPPED_CLAUDE_SCRIPT="$TMP_ROOT/dev-channels-wrapped-claude.sh"
+DEV_CHANNELS_WRAPPED_SLEEP_SCRIPT="$TMP_ROOT/dev-channels-wrapped-sleep.sh"
 ln -sf "$(command -v sleep)" "$DEV_CHANNELS_CLAUDE_BIN"
+cat >"$DEV_CHANNELS_WRAPPED_CLAUDE_SCRIPT" <<EOF
+#!/usr/bin/env bash
+"$DEV_CHANNELS_CLAUDE_BIN" 2
+EOF
+cat >"$DEV_CHANNELS_WRAPPED_SLEEP_SCRIPT" <<EOF
+#!/usr/bin/env bash
+"$(command -v sleep)" 2
+EOF
+chmod +x "$DEV_CHANNELS_WRAPPED_CLAUDE_SCRIPT" "$DEV_CHANNELS_WRAPPED_SLEEP_SCRIPT"
 tmux new-session -d -s "$DEV_CHANNELS_CLAUDE_SESSION" "$DEV_CHANNELS_CLAUDE_BIN 2"
 tmux new-session -d -s "$DEV_CHANNELS_SLEEP_SESSION" "$(command -v sleep) 2"
+tmux new-session -d -s "$DEV_CHANNELS_WRAPPED_CLAUDE_SESSION" "$DEV_CHANNELS_WRAPPED_CLAUDE_SCRIPT"
+tmux new-session -d -s "$DEV_CHANNELS_WRAPPED_SLEEP_SESSION" "$DEV_CHANNELS_WRAPPED_SLEEP_SCRIPT"
 wait_for_tmux_session "$DEV_CHANNELS_CLAUDE_SESSION" up 10 0.1
 wait_for_tmux_session "$DEV_CHANNELS_SLEEP_SESSION" up 10 0.1
+wait_for_tmux_session "$DEV_CHANNELS_WRAPPED_CLAUDE_SESSION" up 10 0.1
+wait_for_tmux_session "$DEV_CHANNELS_WRAPPED_SLEEP_SESSION" up 10 0.1
 "$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_CLAUDE_SESSION"'"
 ' >/dev/null || die "expected symlinked claude foreground to be detected"
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_WRAPPED_CLAUDE_SESSION"'"
+' >/dev/null || die "expected wrapped claude descendant to be detected"
 if "$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_SLEEP_SESSION"'"
 ' >/dev/null; then
   die "sleep foreground must not be classified as claude"
 fi
+if "$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_WRAPPED_SLEEP_SESSION"'"
+' >/dev/null; then
+  die "wrapped sleep descendant must not be classified as claude"
+fi
 tmux kill-session -t "=$DEV_CHANNELS_CLAUDE_SESSION" >/dev/null 2>&1 || true
 tmux kill-session -t "=$DEV_CHANNELS_SLEEP_SESSION" >/dev/null 2>&1 || true
+tmux kill-session -t "=$DEV_CHANNELS_WRAPPED_CLAUDE_SESSION" >/dev/null 2>&1 || true
+tmux kill-session -t "=$DEV_CHANNELS_WRAPPED_SLEEP_SESSION" >/dev/null 2>&1 || true
 
 log "classifying admin foreground exit by onboarding state"
 ONBOARDING_ADMIN_WORKDIR="$TMP_ROOT/onboarding-admin"
@@ -6469,6 +6498,33 @@ assert restart["considered"] == 0, restart
 assert "live-leak-agent" not in restart.get("restart_eligible_agents", []), restart
 assert "live-leak-agent" not in restart.get("restart_attempted_ok_agents", []), restart
 PY
+
+log "upgrade post-task signal only emits for stable upgrades with live drift (#331)"
+POST_TASK_GATE_BODY="$TMP_ROOT/upgrade-post-task-gate.sh"
+python3 - "$REPO_ROOT/bridge-upgrade.sh" "$POST_TASK_GATE_BODY" <<'PY'
+import pathlib
+import re
+import sys
+
+src = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+match = re.search(r"^bridge_upgrade_should_emit_post_task\(\) \{\n.*?^}\n", src, re.M | re.S)
+if not match:
+    raise SystemExit("bridge_upgrade_should_emit_post_task not found")
+pathlib.Path(sys.argv[2]).write_text(match.group(0), encoding="utf-8")
+PY
+POST_TASK_CHANGED='{"counts":{"files_copied":1,"files_merged_clean":0,"files_merged_conflict":0,"files_mode_synced":0}}'
+POST_TASK_NOOP='{"counts":{"files_copied":0,"files_merged_clean":0,"files_merged_conflict":0,"files_mode_synced":0,"files_skipped_noop":4}}'
+"$BASH4_BIN" -c 'source "$1"; bridge_upgrade_should_emit_post_task stable "$2"' -- "$POST_TASK_GATE_BODY" "$POST_TASK_CHANGED" \
+  || die "stable upgrade with copied files should emit post task"
+if "$BASH4_BIN" -c 'source "$1"; bridge_upgrade_should_emit_post_task stable "$2"' -- "$POST_TASK_GATE_BODY" "$POST_TASK_NOOP"; then
+  die "stable no-op upgrade must not emit post task"
+fi
+for _post_channel in current dev ref; do
+  if "$BASH4_BIN" -c 'source "$1"; bridge_upgrade_should_emit_post_task "$2" "$3"' -- "$POST_TASK_GATE_BODY" "$_post_channel" "$POST_TASK_CHANGED"; then
+    die "$_post_channel upgrade must not emit post task"
+  fi
+done
+rm -f "$POST_TASK_GATE_BODY"
 
 log "rolling back from an upgrade backup snapshot"
 ROLLBACK_ROOT="$TMP_ROOT/rollback-root"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5630,6 +5630,38 @@ tmux kill-session -t "=$DEV_CHANNELS_SLEEP_SESSION" >/dev/null 2>&1 || true
 tmux kill-session -t "=$DEV_CHANNELS_WRAPPED_CLAUDE_SESSION" >/dev/null 2>&1 || true
 tmux kill-session -t "=$DEV_CHANNELS_WRAPPED_SLEEP_SESSION" >/dev/null 2>&1 || true
 
+log "retrying dev-channel foreground readiness until wrapped Claude appears (#429)"
+DEV_CHANNELS_RACE_SESSION="dev-channels-race-fg-$SESSION_NAME"
+DEV_CHANNELS_RACE_ACK="$TMP_ROOT/dev-channels-race-ack.txt"
+DEV_CHANNELS_RACE_SCRIPT="$TMP_ROOT/dev-channels-race.sh"
+cat >"$DEV_CHANNELS_RACE_SCRIPT" <<EOF
+#!/usr/bin/env bash
+delayed_claude() {
+  sleep 1
+  exec "$DEV_CHANNELS_CLAUDE_BIN" 2
+}
+printf 'WARNING: Loading development channels\n'
+printf 'I am using this for local development\n'
+printf 'Enter to confirm · Esc to cancel\n'
+delayed_claude &
+IFS= read -r line
+printf '%s\n' "\${line:-<enter>}" >"$DEV_CHANNELS_RACE_ACK"
+printf '❯ \n'
+sleep 1
+EOF
+chmod +x "$DEV_CHANNELS_RACE_SCRIPT"
+tmux new-session -d -s "$DEV_CHANNELS_RACE_SESSION" "$DEV_CHANNELS_RACE_SCRIPT"
+wait_for_tmux_session "$DEV_CHANNELS_RACE_SESSION" up 10 0.1
+BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_WAIT_SECONDS=5 \
+BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_POLL_SECONDS=0.2 \
+BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_MAX_CHECKS=30 \
+  "$BASH4_BIN" -c '
+    source "'"$REPO_ROOT"'/bridge-lib.sh"
+    bridge_tmux_wait_for_prompt "'"$DEV_CHANNELS_RACE_SESSION"'" claude 6 1
+  ' >/dev/null || die "expected dev-channel auto-accept to wait for delayed claude foreground"
+assert_contains "$(cat "$DEV_CHANNELS_RACE_ACK")" "<enter>"
+tmux kill-session -t "=$DEV_CHANNELS_RACE_SESSION" >/dev/null 2>&1 || true
+
 log "classifying admin foreground exit by onboarding state"
 ONBOARDING_ADMIN_WORKDIR="$TMP_ROOT/onboarding-admin"
 mkdir -p "$ONBOARDING_ADMIN_WORKDIR"


### PR DESCRIPTION
## Summary
- follow-up to #434 for the isolated UID picker race seen on `sales_sean`
- keep the default Claude foreground safety gate enabled, but poll for Claude under the tmux pane process tree before auto-accepting the dev-channel picker
- add a smoke case where the picker appears before the wrapped Claude child exists

This reinforces the #429 fix path; it does not disable the existing `BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND=1` default.

Related: #434
Fixes #429

## Verification
- `bash -n lib/bridge-tmux.sh scripts/smoke-test.sh bridge-run.sh`
- `git diff --check`
- focused delayed-Claude dev-channel picker race check
- focused direct/wrapped/sleep foreground detector check
- focused no-Claude foreground timeout check
