### PR TITLE
Fix v0.6.30 isolated agent residuals

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2623,7 +2623,8 @@ bridge_report_channel_health_miss() {
   [[ "$admin_agent" != "$agent" ]] || return 0
 
   # Preflight: repair sticky POSIX ACL mask drift on channel state .env
-  # files for Linux-isolated agents BEFORE evaluating channel status.
+  # files and Claude credentials for Linux-isolated agents BEFORE evaluating
+  # channel status.
   # Without this preflight, an unrelated chmod elsewhere can leave
   # mask=--- on .teams/.env / .ms365/.env, the daemon's grep against
   # those files returns EACCES, the status reads "miss", and we enqueue
@@ -2634,6 +2635,7 @@ bridge_report_channel_health_miss() {
   if bridge_agent_linux_user_isolation_requested "$agent" 2>/dev/null \
       && [[ "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]]; then
     bridge_linux_acl_repair_channel_env_files "$agent" >/dev/null 2>&1 || true
+    bridge_linux_repair_claude_credentials_access "$agent" >/dev/null 2>&1 || true
   fi
 
   status="$(bridge_agent_channel_status "$agent")"

--- a/bridge-queue-gateway.py
+++ b/bridge-queue-gateway.py
@@ -133,12 +133,16 @@ def handle_request(path: Path, queue_script: Path) -> int:
         path.unlink(missing_ok=True)
         return 1
 
+    child_env = os.environ.copy()
+    child_env["BRIDGE_QUEUE_GATEWAY_SERVER"] = "1"
+    child_env.pop("BRIDGE_GATEWAY_PROXY", None)
+
     proc = subprocess.run(
         [sys.executable, str(queue_script), *argv],
         cwd=cwd,
         capture_output=True,
         text=True,
-        env=os.environ.copy(),
+        env=child_env,
         check=False,
     )
     response = {

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -10,6 +10,7 @@ import os
 import re
 import shlex
 import sqlite3
+import subprocess
 import sys
 import time
 from contextlib import closing
@@ -59,6 +60,67 @@ def get_db_path() -> Path:
     db_path = Path(os.environ.get("BRIDGE_TASK_DB", str(state_dir / "tasks.db")))
     db_path.parent.mkdir(parents=True, exist_ok=True)
     return db_path
+
+
+def get_queue_gateway_root() -> Path:
+    bridge_home = Path(os.environ.get("BRIDGE_HOME", str(Path.home() / ".agent-bridge")))
+    state_dir = Path(os.environ.get("BRIDGE_STATE_DIR", str(bridge_home / "state")))
+    layout = os.environ.get("BRIDGE_LAYOUT", "").strip()
+    agent_root_v2 = os.environ.get("BRIDGE_AGENT_ROOT_V2", "").strip()
+    if layout == "v2" and agent_root_v2:
+        return Path(agent_root_v2).expanduser()
+    return state_dir / "queue-gateway"
+
+
+def queue_gateway_proxy_agent() -> str:
+    if os.environ.get("BRIDGE_QUEUE_GATEWAY_SERVER", "") == "1":
+        return ""
+    if os.environ.get("BRIDGE_GATEWAY_PROXY", "") != "1":
+        return ""
+    return os.environ.get("BRIDGE_AGENT_ID", "").strip()
+
+
+def queue_gateway_float_env(name: str, default: str) -> str:
+    raw = os.environ.get(name, default).strip()
+    try:
+        value = float(raw)
+    except ValueError:
+        return default
+    if value <= 0:
+        return default
+    return raw
+
+
+def should_proxy_via_queue_gateway(argv: list[str]) -> bool:
+    if not argv:
+        return False
+    if argv[0] in {"-h", "--help"}:
+        return False
+    if len(argv) == 2 and argv[1] in {"-h", "--help"}:
+        return False
+    return bool(queue_gateway_proxy_agent())
+
+
+def proxy_via_queue_gateway(argv: list[str]) -> int:
+    agent = queue_gateway_proxy_agent()
+    if not agent:
+        return 1
+    gateway_script = Path(__file__).resolve().with_name("bridge-queue-gateway.py")
+    command = [
+        sys.executable,
+        str(gateway_script),
+        "client",
+        "--root",
+        str(get_queue_gateway_root()),
+        "--agent",
+        agent,
+        "--timeout",
+        queue_gateway_float_env("BRIDGE_QUEUE_GATEWAY_TIMEOUT_SECONDS", "45"),
+        "--poll",
+        queue_gateway_float_env("BRIDGE_QUEUE_GATEWAY_POLL_SECONDS", "0.2"),
+        *argv,
+    ]
+    return int(subprocess.run(command, check=False).returncode)
 
 
 def get_cron_state_dir() -> Path:
@@ -2068,9 +2130,13 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+    if should_proxy_via_queue_gateway(argv):
+        return proxy_via_queue_gateway(argv)
     parser = build_parser()
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
     if args.command == "init":
         with closing(connect()):
             pass

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -319,6 +319,13 @@ if [[ $DRY_RUN -eq 1 ]]; then
   exit 0
 fi
 
+if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]] \
+    && bridge_agent_linux_user_isolation_effective "$AGENT"; then
+  if ! bridge_linux_repair_claude_credentials_access "$AGENT"; then
+    bridge_warn "Claude credential ACL repair skipped or failed for isolated agent '$AGENT'"
+  fi
+fi
+
 if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
   if [[ $SUPPRESS_MISSING_CHANNELS -eq 1 ]]; then
     BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS=1 bridge_ensure_claude_launch_channel_plugins "$AGENT"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -218,6 +218,18 @@ if [[ $CONTINUE_EXPLICIT -eq 1 && "$CONTINUE_MODE" == "0" ]]; then
   unset _persisted_session_id
 fi
 
+# Item 10 (PR #442 r2): repair Claude credential ACL BEFORE the channel
+# health read. Without this, an unrelated chmod under ~/.claude can leave
+# mask=--- on credentials.json so bridge_agent_channel_status_reason gets
+# EACCES on first call after a Claude re-auth and the start path bails out
+# with a false-negative "Not logged in"/credential-unreadable diagnostic.
+# Helper is best-effort and silently skips on macOS / non-isolated /
+# non-claude / no-sudo cases (see bridge_linux_repair_claude_credentials_access).
+if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]] \
+    && bridge_agent_linux_user_isolation_effective "$AGENT"; then
+  bridge_linux_repair_claude_credentials_access "$AGENT" >/dev/null 2>&1 || true
+fi
+
 if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
   CHANNEL_REASON="$(bridge_agent_channel_status_reason "$AGENT")"
   if [[ -n "$CHANNEL_REASON" ]]; then
@@ -317,13 +329,6 @@ if [[ $DRY_RUN -eq 1 ]]; then
   fi
   echo "tmux_command=$SESSION_CMD"
   exit 0
-fi
-
-if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]] \
-    && bridge_agent_linux_user_isolation_effective "$AGENT"; then
-  if ! bridge_linux_repair_claude_credentials_access "$AGENT"; then
-    bridge_warn "Claude credential ACL repair skipped or failed for isolated agent '$AGENT'"
-  fi
 fi
 
 if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -817,9 +817,8 @@ bridge_linux_grant_claude_credentials_access() {
     # No directory `r-x` (would let the isolated UID list ~/.claude/),
     # no default ACL on ~/.claude/ (would extend grants to every new
     # inode under there). Re-auth's atomic-rename produces a new inode
-    # without an inherited ACL — operator must re-run
-    # `agent-bridge isolate <agent>` after each Claude re-auth, which
-    # is the documented C1 contract until PR-F's per-agent claude login.
+    # without an inherited ACL, so start/daemon preflights call this helper
+    # again and explicitly restore both the named-user grant and ACL mask.
     _bridge_linux_grant_traverse_chain_unguarded "$os_user" "$controller_claude_dir" "$controller_home"
     # PR-E r2 P1#3 fix: load-bearing setfacl call must fail-loud. The
     # `|| true` of the prior version masked filesystem-ACL-disabled
@@ -830,10 +829,13 @@ bridge_linux_grant_claude_credentials_access() {
     # that retains a named-user ACL (KNOWN_ISSUES.md §16).
     bridge_linux_sudo_root setfacl -m "u:${os_user}:r--" "$controller_cred_file" \
       || bridge_die "claude cred ACL: setfacl r-- on $controller_cred_file failed (v2+claude requires functional ACLs on this surface; see KNOWN_ISSUES.md §16)"
+    bridge_linux_sudo_root setfacl -m "m::r--" "$controller_cred_file" \
+      || bridge_die "claude cred ACL: setfacl mask r-- on $controller_cred_file failed (v2+claude requires the ACL mask to preserve the isolated UID read grant)"
   else
     bridge_linux_grant_traverse_chain "$os_user" "$controller_claude_dir" "$controller_home"
     bridge_linux_acl_add "u:${os_user}:r-x" "$controller_claude_dir" >/dev/null 2>&1 || true
     bridge_linux_acl_add "u:${os_user}:r--" "$controller_cred_file" >/dev/null 2>&1 || true
+    bridge_linux_sudo_root setfacl -m "m::r--" "$controller_cred_file" >/dev/null 2>&1 || true
     bridge_linux_sudo_root setfacl -d -m "u:${os_user}:r--" "$controller_claude_dir" >/dev/null 2>&1 || true
   fi
 
@@ -848,6 +850,28 @@ bridge_linux_grant_claude_credentials_access() {
   fi
   bridge_linux_sudo_root ln -s "$controller_cred_file" "$isolated_cred_link"
   bridge_linux_sudo_root chown -h "$os_user" "$isolated_cred_link" >/dev/null 2>&1 || true
+}
+
+bridge_linux_repair_claude_credentials_access() {
+  local agent="$1"
+  local os_user=""
+  local user_home=""
+  local controller_user=""
+  local engine=""
+
+  [[ "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]] || return 0
+  bridge_agent_linux_user_isolation_effective "$agent" || return 0
+  engine="$(bridge_agent_engine "$agent")"
+  [[ "$engine" == "claude" ]] || return 0
+
+  os_user="$(bridge_agent_os_user "$agent")"
+  [[ -n "$os_user" ]] || return 0
+  user_home="$(getent passwd "$os_user" 2>/dev/null | cut -d: -f6 || true)"
+  [[ -n "$user_home" ]] || return 0
+  controller_user="$(bridge_current_user)"
+  [[ -n "$controller_user" ]] || return 0
+
+  bridge_linux_grant_claude_credentials_access "$os_user" "$user_home" "$controller_user" "$engine"
 }
 
 bridge_linux_acl_add_recursive() {
@@ -2119,6 +2143,81 @@ bridge_linux_unshare_plugin_catalog() {
   fi
 }
 
+bridge_tmp_ephemeral_path_is() {
+  local path="${1:-}"
+  local tmpdir="${TMPDIR:-}"
+
+  [[ -n "$path" ]] || return 1
+  case "$path" in
+    /tmp/tmp.*|/tmp/tmp.*/*|/var/tmp/tmp.*|/var/tmp/tmp.*/*|/private/tmp/tmp.*|/private/tmp/tmp.*/*)
+      return 0
+      ;;
+  esac
+  if [[ -n "$tmpdir" ]]; then
+    tmpdir="${tmpdir%/}"
+    case "$path" in
+      "$tmpdir"/tmp.*|"$tmpdir"/tmp.*/*)
+        return 0
+        ;;
+    esac
+  fi
+  return 1
+}
+
+bridge_reject_ephemeral_controller_env_for_agent_env() {
+  local name=""
+  local value=""
+  local -a path_vars=(
+    BRIDGE_HOME
+    BRIDGE_ROSTER_FILE
+    BRIDGE_ROSTER_LOCAL_FILE
+    BRIDGE_STATE_DIR
+    BRIDGE_LAYOUT_MARKER_DIR
+    BRIDGE_ACTIVE_AGENT_DIR
+    BRIDGE_HISTORY_DIR
+    BRIDGE_WORKTREE_META_DIR
+    BRIDGE_ACTIVE_ROSTER_TSV
+    BRIDGE_ACTIVE_ROSTER_MD
+    BRIDGE_DAEMON_PID_FILE
+    BRIDGE_DAEMON_LOG
+    BRIDGE_DAEMON_CRASH_LOG
+    BRIDGE_TASK_DB
+    BRIDGE_PROFILE_STATE_DIR
+    BRIDGE_CRON_STATE_DIR
+    BRIDGE_CRON_HOME_DIR
+    BRIDGE_WORKTREE_ROOT
+    BRIDGE_AGENT_HOME_ROOT
+    BRIDGE_RUNTIME_ROOT
+    BRIDGE_RUNTIME_SCRIPTS_DIR
+    BRIDGE_RUNTIME_SKILLS_DIR
+    BRIDGE_RUNTIME_SHARED_DIR
+    BRIDGE_RUNTIME_SHARED_TOOLS_DIR
+    BRIDGE_RUNTIME_SHARED_REFERENCES_DIR
+    BRIDGE_RUNTIME_MEMORY_DIR
+    BRIDGE_RUNTIME_CREDENTIALS_DIR
+    BRIDGE_RUNTIME_SECRETS_DIR
+    BRIDGE_RUNTIME_CONFIG_FILE
+    BRIDGE_HOOKS_DIR
+    BRIDGE_SHARED_DIR
+    BRIDGE_TASK_NOTE_DIR
+    BRIDGE_LOG_DIR
+    BRIDGE_DATA_ROOT
+    BRIDGE_SHARED_ROOT
+    BRIDGE_AGENT_ROOT_V2
+    BRIDGE_CONTROLLER_STATE_ROOT
+  )
+
+  [[ "${BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV:-0}" == "1" ]] && return 0
+
+  for name in "${path_vars[@]}"; do
+    value="${!name:-}"
+    [[ -n "$value" ]] || continue
+    if bridge_tmp_ephemeral_path_is "$value"; then
+      bridge_die "refusing to write isolated agent-env.sh from ephemeral controller path ${name}=${value}; unset stale BRIDGE_* variables before running isolate/start, or set BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1 for a deliberate temp test install"
+    fi
+  done
+}
+
 bridge_write_linux_agent_env_file() {
   local agent="$1"
   local file="${2:-$(bridge_agent_linux_env_file "$agent")}"
@@ -2169,6 +2268,8 @@ bridge_write_linux_agent_env_file() {
   admin_agent="$(bridge_admin_agent_id)"
   agent_log_dir="$(bridge_agent_log_dir "$agent")"
   agent_audit_log="$(bridge_agent_audit_log_file "$agent")"
+
+  bridge_reject_ephemeral_controller_env_for_agent_env
 
   mkdir -p "$(dirname "$file")"
   # Self-heal ownership: when an earlier isolate cycle chowned the file to the
@@ -2237,6 +2338,8 @@ BRIDGE_AUDIT_LOG=$(printf '%q' "$agent_audit_log")
 BRIDGE_ROSTER_FILE=""
 BRIDGE_ROSTER_LOCAL_FILE=""
 BRIDGE_ADMIN_AGENT_ID=$(printf '%q' "$admin_agent")
+BRIDGE_AGENT_ID=$(printf '%q' "$agent")
+export BRIDGE_AGENT_ID
 BRIDGE_AGENT_IDS=()
 declare -g -A BRIDGE_AGENT_DESC=()
 declare -g -A BRIDGE_AGENT_ENGINE=()

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -864,6 +864,12 @@ bridge_linux_repair_claude_credentials_access() {
   engine="$(bridge_agent_engine "$agent")"
   [[ "$engine" == "claude" ]] || return 0
 
+  # Item 13 (PR #442 r2): repair is best-effort. Skip cleanly when sudo is
+  # unavailable (CI without sudo, dev shell without sudo) — without this
+  # guard, the inner bridge_linux_sudo_root would bridge_die on the start /
+  # daemon-health path even when the repair would otherwise be a no-op.
+  bridge_linux_have_sudo_or_skip || return 0
+
   os_user="$(bridge_agent_os_user "$agent")"
   [[ -n "$os_user" ]] || return 0
   user_home="$(getent passwd "$os_user" 2>/dev/null | cut -d: -f6 || true)"

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -66,30 +66,88 @@ bridge_tmux_command_name_is_claude() {
   esac
 }
 
+bridge_tmux_process_tree_has_claude() {
+  local root_pid="$1"
+  local max_procs="${BRIDGE_TMUX_PROCESS_TREE_MAX_PROCS:-128}"
+  local -a queue=()
+  local seen=" "
+  local pid=""
+  local child=""
+  local comm=""
+  local count=0
+
+  [[ "$root_pid" =~ ^[0-9]+$ ]] || return 1
+  [[ "$max_procs" =~ ^[0-9]+$ ]] || max_procs=128
+  (( max_procs > 0 )) || max_procs=128
+
+  queue=("$root_pid")
+  while ((${#queue[@]} > 0)) && (( count < max_procs )); do
+    pid="${queue[0]}"
+    queue=("${queue[@]:1}")
+    case "$seen" in
+      *" $pid "*) continue ;;
+    esac
+    seen+="$pid "
+    count=$((count + 1))
+
+    comm="$(ps -o comm= -p "$pid" 2>/dev/null | awk '{$1=$1; print}' || true)"
+    if bridge_tmux_command_name_is_claude "$comm"; then
+      return 0
+    fi
+
+    while IFS= read -r child; do
+      [[ "$child" =~ ^[0-9]+$ ]] || continue
+      case "$seen" in
+        *" $child "*) continue ;;
+      esac
+      queue+=("$child")
+    done < <(pgrep -P "$pid" 2>/dev/null || true)
+  done
+
+  return 1
+}
+
 bridge_tmux_pane_foreground_is_claude() {
   local session="$1"
   local pane_pid=""
-  local tpgid=""
-  local pgid=""
-  local comm=""
   local pane_cmd=""
 
   pane_pid="$(bridge_tmux_session_pane_pid "$session")"
-  if [[ "$pane_pid" =~ ^[0-9]+$ ]]; then
-    tpgid="$(ps -o tpgid= -p "$pane_pid" 2>/dev/null | tr -d '[:space:]' || true)"
-    if [[ "$tpgid" =~ ^[0-9]+$ ]] && (( tpgid > 0 )); then
-      while read -r pgid comm; do
-        [[ "$pgid" == "$tpgid" ]] || continue
-        if bridge_tmux_command_name_is_claude "$comm"; then
-          return 0
-        fi
-      done < <(ps -eo pgid=,comm= 2>/dev/null || true)
-      return 1
-    fi
+  if [[ "$pane_pid" =~ ^[0-9]+$ ]] && bridge_tmux_process_tree_has_claude "$pane_pid"; then
+    return 0
   fi
 
   pane_cmd="$(tmux display-message -p -t "$(bridge_tmux_pane_target "$session")" '#{pane_current_command}' 2>/dev/null || true)"
   bridge_tmux_command_name_is_claude "$pane_cmd"
+}
+
+bridge_tmux_wait_for_claude_foreground() {
+  local session="$1"
+  local timeout="${2:-60}"
+  local poll="${3:-2}"
+  local max_checks="${4:-30}"
+  local start_ts=""
+  local elapsed=0
+  local checks=0
+
+  [[ "$timeout" =~ ^[0-9]+$ ]] || timeout=60
+  (( timeout > 0 )) || timeout=60
+  [[ "$poll" =~ ^[0-9]+([.][0-9]+)?$ ]] || poll=2
+  [[ "$max_checks" =~ ^[0-9]+$ ]] || max_checks=30
+  (( max_checks > 0 )) || max_checks=30
+
+  start_ts="$(date +%s)"
+  while (( checks < max_checks )); do
+    if bridge_tmux_pane_foreground_is_claude "$session"; then
+      return 0
+    fi
+    checks=$((checks + 1))
+    elapsed=$(( $(date +%s) - start_ts ))
+    (( elapsed >= timeout )) && break
+    sleep "$poll"
+  done
+
+  return 1
 }
 
 bridge_tmux_kill_session() {
@@ -453,6 +511,9 @@ bridge_tmux_claude_advance_blocker() {
   local expected_state="${3:-}"
   local state=""
   local settle_seconds="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_SETTLE_SECONDS:-0.2}"
+  local foreground_wait="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_WAIT_SECONDS:-60}"
+  local foreground_poll="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_POLL_SECONDS:-2}"
+  local foreground_max="${BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_MAX_CHECKS:-30}"
 
   state="$(bridge_tmux_claude_blocker_state "$session")"
   # If the caller specified an expected state and the live state has
@@ -473,7 +534,7 @@ bridge_tmux_claude_advance_blocker() {
     devchannels)
       if [[ "$allow_devchannels" == "1" ]]; then
         if [[ "${BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND:-1}" != "0" ]]; then
-          bridge_tmux_pane_foreground_is_claude "$session" || return 1
+          bridge_tmux_wait_for_claude_foreground "$session" "$foreground_wait" "$foreground_poll" "$foreground_max" || return 1
           [[ "$settle_seconds" =~ ^[0-9]+([.][0-9]+)?$ ]] || settle_seconds="0.2"
           sleep "$settle_seconds"
         fi

--- a/plugins/ms365/.mcp.json
+++ b/plugins/ms365/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "ms365": {
       "command": "bun",
-      "args": ["--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"]
+      "args": ["--cwd", "${CLAUDE_PLUGIN_ROOT}", "--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"]
     }
   }
 }

--- a/plugins/teams/.mcp.json
+++ b/plugins/teams/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "teams": {
       "command": "bun",
-      "args": ["--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"]
+      "args": ["--cwd", "${CLAUDE_PLUGIN_ROOT}", "--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"]
     }
   }
 }

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1035,6 +1035,7 @@ SPOOL_UT
 
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
+export BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1
 # Issue #403 fix #4: pin the isolated-user home root under TMP_ROOT so any
 # inner test path that builds `<root>/<os_user>/.agent-bridge` cannot
 # escape into the operator's $HOME — even if a future test forgets to use
@@ -1405,6 +1406,16 @@ BRIDGE_AGENT_LAUNCH_CMD["claude-static"]='DISCORD_STATE_DIR=REPLACE_CLAUDE_DISCO
 BRIDGE_AGENT_LAUNCH_CMD["$ROSTER_RELOAD_AGENT"]='ROSTER_MARK=before claude --dangerously-skip-permissions --name roster-reload'
 BRIDGE_AGENT_IDLE_TIMEOUT["$ALWAYS_ON_AGENT"]="0"
 EOF
+
+log "guarding isolated agent-env writes from stale tmp controller env (#365 follow-up)"
+STALE_ENV_GUARD_FILE="$TMP_ROOT/stale-agent-env.sh"
+STALE_ENV_GUARD_OUTPUT="$(BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=0 "$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  bridge_write_linux_agent_env_file "$1" "$2"
+' -- "$SMOKE_AGENT" "$STALE_ENV_GUARD_FILE" 2>&1 || true)"
+assert_contains "$STALE_ENV_GUARD_OUTPUT" "refusing to write isolated agent-env.sh from ephemeral controller path BRIDGE_HOME="
+[[ ! -e "$STALE_ENV_GUARD_FILE" ]] || die "stale controller env guard wrote $STALE_ENV_GUARD_FILE despite refusing"
 
 python3 - "$BRIDGE_ROSTER_LOCAL_FILE" "$CLAUDE_STATIC_WORKDIR/.discord" <<'PY'
 from pathlib import Path
@@ -2608,6 +2619,51 @@ QUEUE_TASK_ID="$(printf '%s\n' "$CREATE_OUTPUT" | sed -n 's/^created task #\([0-
 [[ "$QUEUE_TASK_ID" =~ ^[0-9]+$ ]] || die "could not parse queue task id"
 QUEUE_TASK_SHELL="$(python3 "$REPO_ROOT/bridge-queue.py" show "$QUEUE_TASK_ID" --format shell)"
 assert_contains "$QUEUE_TASK_SHELL" "TASK_BODY_PATH=$BRIDGE_SHARED_DIR/note.md"
+
+log "routing direct isolated queue commands through queue gateway (#436)"
+run_queue_gateway_proxy_smoke() {
+  local agent="gateway-proxy-$SESSION_NAME"
+  local root="$BRIDGE_STATE_DIR/queue-gateway"
+  local stdout_file="$TMP_ROOT/queue-gateway-proxy.out"
+  local stderr_file="$TMP_ROOT/queue-gateway-proxy.err"
+  local pid=""
+  local served=""
+  rm -f "$stdout_file" "$stderr_file"
+  BRIDGE_GATEWAY_PROXY=1 \
+    BRIDGE_AGENT_ID="$agent" \
+    BRIDGE_TASK_DB=/dev/null \
+    BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+    BRIDGE_LAYOUT=legacy \
+    BRIDGE_AGENT_ROOT_V2= \
+    BRIDGE_QUEUE_GATEWAY_TIMEOUT_SECONDS=5 \
+    BRIDGE_QUEUE_GATEWAY_POLL_SECONDS=0.05 \
+    python3 "$REPO_ROOT/bridge-queue.py" "$@" >"$stdout_file" 2>"$stderr_file" &
+  pid=$!
+  for _ in {1..80}; do
+    if compgen -G "$root/$agent/requests/*.request.json" >/dev/null; then
+      break
+    fi
+    sleep 0.05
+  done
+  served="$(BRIDGE_TASK_DB="$BRIDGE_TASK_DB" BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" BRIDGE_LAYOUT=legacy BRIDGE_AGENT_ROOT_V2= \
+    python3 "$REPO_ROOT/bridge-queue-gateway.py" serve-once --root "$root" --queue-script "$REPO_ROOT/bridge-queue.py" --max-requests 1)"
+  [[ "$served" == "1" ]] || die "queue gateway proxy smoke did not process exactly one request for: $* (processed=$served)"
+  if ! wait "$pid"; then
+    cat "$stderr_file" >&2 || true
+    die "queue gateway proxy command failed: $*"
+  fi
+  cat "$stdout_file"
+}
+GATEWAY_PROXY_CREATE_OUTPUT="$(run_queue_gateway_proxy_smoke create --to "$SMOKE_AGENT" --title "gateway proxy smoke" --body "gateway body" --from "$REQUESTER_AGENT")"
+assert_contains "$GATEWAY_PROXY_CREATE_OUTPUT" "created task #"
+GATEWAY_PROXY_TASK_ID="$(printf '%s\n' "$GATEWAY_PROXY_CREATE_OUTPUT" | sed -n 's/^created task #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+[[ "$GATEWAY_PROXY_TASK_ID" =~ ^[0-9]+$ ]] || die "could not parse queue gateway proxy task id"
+GATEWAY_PROXY_SHOW_OUTPUT="$(run_queue_gateway_proxy_smoke show "$GATEWAY_PROXY_TASK_ID")"
+assert_contains "$GATEWAY_PROXY_SHOW_OUTPUT" "gateway proxy smoke"
+GATEWAY_PROXY_CLAIM_OUTPUT="$(run_queue_gateway_proxy_smoke claim "$GATEWAY_PROXY_TASK_ID" --agent "$SMOKE_AGENT" --lease-seconds 60)"
+assert_contains "$GATEWAY_PROXY_CLAIM_OUTPUT" "claimed task #$GATEWAY_PROXY_TASK_ID"
+GATEWAY_PROXY_DONE_OUTPUT="$(run_queue_gateway_proxy_smoke done "$GATEWAY_PROXY_TASK_ID" --agent "$SMOKE_AGENT" --note "gateway proxy smoke cleanup")"
+assert_contains "$GATEWAY_PROXY_DONE_OUTPUT" "completed task #$GATEWAY_PROXY_TASK_ID"
 
 log "stabilizing ephemeral body-file payloads inside the queue"
 EPHEMERAL_BODY_FILE="$(mktemp "$TMP_ROOT/queue-body.XXXXXX.md")"
@@ -5227,6 +5283,20 @@ assert row["status"] in {"linked", "updated", "unchanged"}, row
 assert cache_version.is_symlink(), cache_version
 assert cache_version.resolve() == source, (cache_version, source)
 assert not (cache_version / ".orphaned_at").exists()
+mcp = json.loads((source / ".mcp.json").read_text(encoding="utf-8"))
+args = mcp["mcpServers"]["teams"]["args"]
+assert args[:2] == ["--cwd", "${CLAUDE_PLUGIN_ROOT}"], args
+assert args[2:] == ["--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"], args
+PY
+python3 - "$REPO_ROOT/plugins/ms365/.mcp.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+mcp = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+args = mcp["mcpServers"]["ms365"]["args"]
+assert args[:2] == ["--cwd", "${CLAUDE_PLUGIN_ROOT}"], args
+assert args[2:] == ["--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"], args
 PY
 DEV_PLUGIN_CACHE_JSON_AGAIN="$(python3 "$REPO_ROOT/bridge-dev-plugin-cache.py" sync --channels "plugin:teams@agent-bridge" --json)"
 python3 - "$DEV_PLUGIN_CACHE_JSON_AGAIN" <<'PY'
@@ -5628,15 +5698,43 @@ log "gating dev-channel auto-accept on Claude foreground readiness (#429)"
 DEV_CHANNELS_CLAUDE_BIN="$TMP_ROOT/claude"
 DEV_CHANNELS_CLAUDE_SESSION="dev-channels-claude-fg-$SESSION_NAME"
 DEV_CHANNELS_SLEEP_SESSION="dev-channels-sleep-fg-$SESSION_NAME"
+DEV_CHANNELS_WRAPPED_SESSION="dev-channels-wrapped-fg-$SESSION_NAME"
+DEV_CHANNELS_DELAYED_SESSION="dev-channels-delayed-fg-$SESSION_NAME"
+DEV_CHANNELS_WRAPPED_SCRIPT="$TMP_ROOT/dev-channels-wrapped.sh"
+DEV_CHANNELS_DELAYED_SCRIPT="$TMP_ROOT/dev-channels-delayed.sh"
 ln -sf "$(command -v sleep)" "$DEV_CHANNELS_CLAUDE_BIN"
 tmux new-session -d -s "$DEV_CHANNELS_CLAUDE_SESSION" "$DEV_CHANNELS_CLAUDE_BIN 2"
 tmux new-session -d -s "$DEV_CHANNELS_SLEEP_SESSION" "$(command -v sleep) 2"
+cat >"$DEV_CHANNELS_WRAPPED_SCRIPT" <<EOF
+#!/usr/bin/env bash
+"$DEV_CHANNELS_CLAUDE_BIN" 2
+EOF
+cat >"$DEV_CHANNELS_DELAYED_SCRIPT" <<EOF
+#!/usr/bin/env bash
+sleep 1
+"$DEV_CHANNELS_CLAUDE_BIN" 2
+EOF
+chmod +x "$DEV_CHANNELS_WRAPPED_SCRIPT" "$DEV_CHANNELS_DELAYED_SCRIPT"
+tmux new-session -d -s "$DEV_CHANNELS_WRAPPED_SESSION" "$DEV_CHANNELS_WRAPPED_SCRIPT"
+tmux new-session -d -s "$DEV_CHANNELS_DELAYED_SESSION" "$DEV_CHANNELS_DELAYED_SCRIPT"
 wait_for_tmux_session "$DEV_CHANNELS_CLAUDE_SESSION" up 10 0.1
 wait_for_tmux_session "$DEV_CHANNELS_SLEEP_SESSION" up 10 0.1
+wait_for_tmux_session "$DEV_CHANNELS_WRAPPED_SESSION" up 10 0.1
+wait_for_tmux_session "$DEV_CHANNELS_DELAYED_SESSION" up 10 0.1
 "$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_CLAUDE_SESSION"'"
 ' >/dev/null || die "expected symlinked claude foreground to be detected"
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_WRAPPED_SESSION"'"
+' >/dev/null || die "expected wrapped claude child process to be detected"
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_POLL_SECONDS=0.1 \
+    BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_MAX_CHECKS=40 \
+    bridge_tmux_wait_for_claude_foreground "'"$DEV_CHANNELS_DELAYED_SESSION"'" 5 0.1 40
+' >/dev/null || die "expected delayed wrapped claude foreground wait to succeed"
 if "$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_tmux_pane_foreground_is_claude "'"$DEV_CHANNELS_SLEEP_SESSION"'"
@@ -5645,6 +5743,8 @@ if "$BASH4_BIN" -c '
 fi
 tmux kill-session -t "=$DEV_CHANNELS_CLAUDE_SESSION" >/dev/null 2>&1 || true
 tmux kill-session -t "=$DEV_CHANNELS_SLEEP_SESSION" >/dev/null 2>&1 || true
+tmux kill-session -t "=$DEV_CHANNELS_WRAPPED_SESSION" >/dev/null 2>&1 || true
+tmux kill-session -t "=$DEV_CHANNELS_DELAYED_SESSION" >/dev/null 2>&1 || true
 
 log "classifying admin foreground exit by onboarding state"
 ONBOARDING_ADMIN_WORKDIR="$TMP_ROOT/onboarding-admin"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5746,6 +5746,84 @@ tmux kill-session -t "=$DEV_CHANNELS_SLEEP_SESSION" >/dev/null 2>&1 || true
 tmux kill-session -t "=$DEV_CHANNELS_WRAPPED_SESSION" >/dev/null 2>&1 || true
 tmux kill-session -t "=$DEV_CHANNELS_DELAYED_SESSION" >/dev/null 2>&1 || true
 
+# Item 4 (PR #442 r2): exercise the *full* dispatch path end-to-end.
+# The previous case only validates the foreground detector + wait helper in
+# isolation. This case wires both into the picker dispatcher
+# (bridge_tmux_claude_advance_blocker) so a regression that re-orders the
+# wait + send-keys, drops the foreground gate, or short-circuits before
+# Enter is dispatched cannot pass without smoke-level fail.
+log "dispatching dev-channel auto-accept via advance_blocker (#442 item 4)"
+DEV_CHANNELS_DISPATCH_SESSION="dev-channels-dispatch-$SESSION_NAME"
+DEV_CHANNELS_DISPATCH_ACK="$TMP_ROOT/dev-channels-dispatch-ack.txt"
+DEV_CHANNELS_DISPATCH_BIN_DIR="$TMP_ROOT/dev-channels-dispatch-bin"
+# Synthetic claude binary lives in its own dir under exact name `claude`
+# so bridge_tmux_command_name_is_claude classifies the basename correctly
+# (the matcher accepts only `claude` / `claude-*` / `claude.*`, so a longer
+# path basename like `dev-channels-dispatch-claude` would NOT match).
+DEV_CHANNELS_DISPATCH_CLAUDE="$DEV_CHANNELS_DISPATCH_BIN_DIR/claude"
+DEV_CHANNELS_DISPATCH_PAYLOAD="$TMP_ROOT/dev-channels-dispatch-payload.sh"
+DEV_CHANNELS_DISPATCH_SCRIPT="$TMP_ROOT/dev-channels-dispatch.sh"
+rm -f "$DEV_CHANNELS_DISPATCH_ACK"
+mkdir -p "$DEV_CHANNELS_DISPATCH_BIN_DIR"
+# Synthetic claude binary: a "claude"-named symlink to bash, so when the
+# driver script execs it the pane PID's `ps -o comm=` reports "claude" and
+# bridge_tmux_pane_foreground_is_claude classifies the foreground correctly.
+ln -sf "$(command -v bash)" "$DEV_CHANNELS_DISPATCH_CLAUDE"
+# Payload script run as the bash arg under the claude symlink: reads one
+# line from its stdin and writes "<enter>" (or the literal line) to the ack
+# file. Lives long enough for the dispatcher's wait + capture + send + read.
+cat >"$DEV_CHANNELS_DISPATCH_PAYLOAD" <<EOF
+IFS= read -r line
+printf '%s\n' "\${line:-<enter>}" >"$DEV_CHANNELS_DISPATCH_ACK"
+sleep 2
+EOF
+chmod +x "$DEV_CHANNELS_DISPATCH_PAYLOAD"
+# Pane bootstrap: print the dev-channels banner so blocker_state classifies
+# as "devchannels", briefly run a non-claude foreground (sleep) so the
+# wait loop has to spin at least once, then exec the claude stub so the
+# detector sees a "claude" comm on the pane PID's process tree.
+cat >"$DEV_CHANNELS_DISPATCH_SCRIPT" <<EOF
+#!/usr/bin/env bash
+printf 'WARNING: Loading development channels\n'
+printf 'I am using this for local development\n'
+printf 'Enter to confirm · Esc to cancel\n'
+sleep 0.5
+exec "$DEV_CHANNELS_DISPATCH_CLAUDE" "$DEV_CHANNELS_DISPATCH_PAYLOAD"
+EOF
+chmod +x "$DEV_CHANNELS_DISPATCH_SCRIPT"
+tmux new-session -d -s "$DEV_CHANNELS_DISPATCH_SESSION" "$DEV_CHANNELS_DISPATCH_SCRIPT"
+wait_for_tmux_session "$DEV_CHANNELS_DISPATCH_SESSION" up 10 0.1
+# Wait until the driver has actually printed the dev-channels banner so
+# bridge_tmux_claude_blocker_state classifies the pane as "devchannels"
+# before we invoke the dispatcher. Without this wait, advance_blocker is
+# called while the pane PID is still `/usr/bin/env` and the expected_state
+# guard short-circuits with rc=1.
+DEV_CHANNELS_DISPATCH_READY=0
+for _ in {1..50}; do
+  if tmux capture-pane -p -t "=$DEV_CHANNELS_DISPATCH_SESSION:" 2>/dev/null \
+      | grep -Fq 'WARNING: Loading development channels'; then
+    DEV_CHANNELS_DISPATCH_READY=1
+    break
+  fi
+  sleep 0.1
+done
+[[ "$DEV_CHANNELS_DISPATCH_READY" == "1" ]] || die "dev-channels dispatch driver did not render banner"
+"$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_WAIT_SECONDS=5 \
+    BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_POLL_SECONDS=0.1 \
+    BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_MAX_CHECKS=50 \
+    BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_SETTLE_SECONDS=0.05 \
+    bridge_tmux_claude_advance_blocker "'"$DEV_CHANNELS_DISPATCH_SESSION"'" 1 devchannels
+' >/dev/null || die "advance_blocker dispatch did not succeed for delayed-claude pane"
+for _ in {1..40}; do
+  [[ -s "$DEV_CHANNELS_DISPATCH_ACK" ]] && break
+  sleep 0.1
+done
+[[ -s "$DEV_CHANNELS_DISPATCH_ACK" ]] || die "advance_blocker did not deliver Enter to dev-channels picker"
+assert_contains "$(cat "$DEV_CHANNELS_DISPATCH_ACK")" "<enter>"
+tmux kill-session -t "=$DEV_CHANNELS_DISPATCH_SESSION" >/dev/null 2>&1 || true
+
 log "classifying admin foreground exit by onboarding state"
 ONBOARDING_ADMIN_WORKDIR="$TMP_ROOT/onboarding-admin"
 mkdir -p "$ONBOARDING_ADMIN_WORKDIR"

--- a/tests/isolation-peer-routing.sh
+++ b/tests/isolation-peer-routing.sh
@@ -42,6 +42,7 @@ fi
 
 TMP_ROOT="$(mktemp -d -t peer-routing-test.XXXXXX)"
 trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
+export BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1
 
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 export BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"

--- a/tests/isolation-queue-gateway-acl.sh
+++ b/tests/isolation-queue-gateway-acl.sh
@@ -40,6 +40,7 @@ command -v userdel >/dev/null 2>&1 || skip "userdel required"
 
 # Sandbox under a temp BRIDGE_HOME so we never touch a live install.
 TMP_ROOT="$(mktemp -d -t isolate-acl-test.XXXXXX)"
+export BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1
 SAFE_TMP_PREFIX=""
 for _candidate in "${TMPDIR%/}" "/tmp" "/var/tmp"; do
   [[ -n "$_candidate" ]] || continue

--- a/tests/isolation-v2-pr-c/smoke.sh
+++ b/tests/isolation-v2-pr-c/smoke.sh
@@ -71,6 +71,7 @@ command -v python3 >/dev/null 2>&1 || skip "python3 missing"
 TMP_ROOT="$(mktemp -d -t isolation-v2-pr-c.XXXXXX)"
 trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
 export TMPDIR="${TMPDIR:-/tmp}"
+export BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1
 
 # ---------------------------------------------------------------------------
 # Fixture: build a minimal BRIDGE_HOME + v2 data root for the resolver

--- a/tests/isolation-v2-pr-e/smoke.sh
+++ b/tests/isolation-v2-pr-e/smoke.sh
@@ -31,6 +31,7 @@ command -v python3 >/dev/null 2>&1 || skip "python3 missing"
 TMP_ROOT="$(mktemp -d -t isolation-v2-pr-e.XXXXXX)"
 trap 'rm -rf "$TMP_ROOT" >/dev/null 2>&1 || true' EXIT
 export TMPDIR="${TMPDIR:-/tmp}"
+export BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1
 
 # Issue #403 (#406): redirect the isolated-user home root into the
 # TMP_ROOT so even if a test passes an os_user that collides with a
@@ -607,6 +608,8 @@ run_in_v2 "$CR_DIR" "$CR_LOG" case_cr1 "$CR_DIR" \
   || die "CR1 case_cr1 returned non-zero"
 assert_some_setfacl "$CR_LOG" "CR1 v2 credentials helper" \
   || die "CR1 expected setfacl ≥ 1 for v2 cred exception"
+grep -q "setfacl -m m::r-- .*\.credentials\.json" "$CR_LOG" \
+  || die "CR1 expected credential ACL mask repair (m::r--)"
 ok "CR1 v2 credentials helper transitional exception (setfacl ≥ 1)"
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- restore dev-channel auto-accept under linux-user isolation by detecting wrapped/delayed Claude process trees before pressing the picker
- route direct bridge-queue.py invocations through the queue gateway when BRIDGE_GATEWAY_PROXY=1, including show/claim/done under BRIDGE_TASK_DB=/dev/null, and prevent gateway recursion
- keep Claude credential sharing readable after OAuth rewrites by repairing the ACL mask before start/daemon health checks
- add Bun --cwd to agent-bridge Teams/MS365 MCP plugin definitions so dev-channel MCP servers start from their plugin cache root
- fail closed when isolated agent-env.sh generation sees stale /tmp/tmp.* controller BRIDGE_* paths

Fixes #437
Fixes #436
Fixes #441

## Security self-check

- queue gateway client still scopes requests under the calling agent id and the daemon remains the only direct DB writer
- credential repair only restores the existing isolated UID named-user read grant and mask on the single Claude credentials file
- stale-env guard refuses persistent env generation rather than silently substituting ambiguous controller paths

## Tests

- python3 -m py_compile bridge-queue.py bridge-queue-gateway.py
- bash -n lib/bridge-agents.sh scripts/smoke-test.sh tests/isolation-v2-pr-e/smoke.sh tests/isolation-v2-pr-c/smoke.sh tests/isolation-peer-routing.sh tests/isolation-queue-gateway-acl.sh lib/bridge-tmux.sh bridge-start.sh bridge-daemon.sh
- git diff --check
- focused queue gateway proxy smoke for show/claim/done with BRIDGE_TASK_DB=/dev/null
- focused Teams/MS365 .mcp.json Bun --cwd shape check
- focused tmux wrapped/delayed Claude foreground detection
- bash tests/isolation-peer-routing.sh
- bash tests/isolation-v2-pr-e/smoke.sh
- bash tests/isolation-v2-pr-c/smoke.sh

Note: full scripts/smoke-test.sh was started after unsetting live BRIDGE_HOME, but I stopped it before completion to incorporate task #370 follow-up; the focused coverage above exercises the modified surfaces.