### PR TITLE
feat(teams): capture and download inbound attachments

### DIFF
--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -74,9 +74,11 @@ When a Teams user attaches a file or image, the plugin downloads each attachment
 Override the location and size cap via:
 
 ```dotenv
-TEAMS_ATTACHMENTS_DIR=<absolute path>
-TEAMS_ATTACHMENT_MAX_BYTES=52428800   # default: 50 MB
+TEAMS_ATTACHMENTS_DIR=<absolute path>     # must be absolute and writable; otherwise default is used
+TEAMS_ATTACHMENT_MAX_BYTES=52428800       # default: 50 MB; clamped to 1 GB; non-numeric falls back to default
 ```
+
+Filenames and message ids are sanitized (strict allowlist) before they're joined into the on-disk path; downloads stream to disk with an in-flight byte counter so a server lying about `Content-Length` cannot bypass the cap.
 
 Outbound attachments (sending files from the bot to Teams) are not yet implemented; track that work separately.
 

--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -61,6 +61,25 @@ Agent Bridge writes this file through:
 agb setup teams <agent> --app-id ... --app-password ... --tenant-id ... --allow-from ... --messaging-endpoint https://bot.example.com/api/messages --webhook-host 0.0.0.0
 ```
 
+## Inbound Attachments
+
+When a Teams user attaches a file or image, the plugin downloads each attachment to:
+
+```
+<TEAMS_STATE_DIR>/attachments/<message_id>/<filename>
+```
+
+(directory mode 0700, file mode 0600). The Claude channel notification meta gains an `attachments` array with `name`, `content_type`, `download_status` (`ok` / `skipped_non_file` / `failed`), and — on success — `local_path` and `size_bytes`. Cards and other non-file attachment kinds are recorded with `skipped_non_file` so the agent still sees the metadata.
+
+Override the location and size cap via:
+
+```dotenv
+TEAMS_ATTACHMENTS_DIR=<absolute path>
+TEAMS_ATTACHMENT_MAX_BYTES=52428800   # default: 50 MB
+```
+
+Outbound attachments (sending files from the bot to Teams) are not yet implemented; track that work separately.
+
 ## Current Scope
 
 This is the Phase 1 channel implementation: webhook receive, access gate, Claude channel notification, reply, local message fetch, and a lightweight `/auth/callback` endpoint used by the `ms365` plugin authorization-code pairing flow. Multi-tenant user-to-agent routing is intentionally left to the Agent Bridge relay layer so one Teams bot can map many users to many timeout agents without mixing conversation state.

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -44,6 +44,17 @@ type Access = {
   routes?: Record<string, unknown>
 }
 
+type StoredAttachment = {
+  attachment_id: string
+  name: string
+  content_type: string
+  size_bytes?: number
+  download_url?: string
+  local_path?: string
+  download_status: 'ok' | 'skipped_non_file' | 'failed'
+  download_error?: string
+}
+
 type StoredMessage = {
   chat_id: string
   message_id: string
@@ -52,6 +63,7 @@ type StoredMessage = {
   aad_object_id: string
   text: string
   ts: string
+  attachments?: StoredAttachment[]
 }
 
 type Ms365CallbackPayload = {
@@ -68,6 +80,9 @@ const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const ENV_FILE = join(STATE_DIR, '.env')
 const REFERENCES_FILE = join(STATE_DIR, 'conversations.json')
 const MESSAGES_FILE = join(STATE_DIR, 'messages.jsonl')
+const ATTACHMENTS_DIR = process.env.TEAMS_ATTACHMENTS_DIR ?? join(STATE_DIR, 'attachments')
+const ATTACHMENT_MAX_BYTES = Number(process.env.TEAMS_ATTACHMENT_MAX_BYTES ?? '52428800')
+const TEAMS_FILE_DOWNLOAD_TYPE = 'application/vnd.microsoft.teams.file.download.info'
 const MS365_CALLBACK_DIR =
   process.env.MS365_CALLBACK_SHARED_DIR ?? join(BRIDGE_HOME, 'shared', 'ms365-callbacks')
 
@@ -292,6 +307,72 @@ function appendMessage(message: StoredMessage): void {
   appendFileSync(MESSAGES_FILE, JSON.stringify(message) + '\n', { mode: 0o600 })
 }
 
+function sanitizeFilename(name: string): string {
+  const trimmed = name.replace(/[\/\\\0]/g, '_').trim()
+  return (trimmed || 'attachment').slice(0, 200)
+}
+
+async function fetchAttachmentBytes(url: string, maxBytes: number): Promise<Buffer> {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+  const declared = Number(res.headers.get('content-length') ?? '0')
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new Error('size_limit')
+  }
+  const buf = Buffer.from(await res.arrayBuffer())
+  if (buf.length > maxBytes) throw new Error('size_limit')
+  return buf
+}
+
+async function downloadAttachments(
+  activity: Activity,
+  messageId: string,
+): Promise<StoredAttachment[]> {
+  const items = Array.isArray(activity.attachments) ? activity.attachments : []
+  if (items.length === 0) return []
+  const results: StoredAttachment[] = []
+  for (let i = 0; i < items.length; i++) {
+    const att = items[i]
+    const rawId = String((att as any).id ?? (att as any).contentUrl ?? '').trim()
+    const attachmentId = rawId || `${messageId}-${i}`
+    const name = String(att.name ?? '').trim() || `attachment-${i}`
+    const contentType = String(att.contentType ?? '').trim()
+    const stored: StoredAttachment = {
+      attachment_id: attachmentId,
+      name,
+      content_type: contentType,
+      download_status: 'skipped_non_file',
+    }
+    let downloadUrl = ''
+    if (contentType === TEAMS_FILE_DOWNLOAD_TYPE) {
+      const content = ((att as any).content ?? {}) as { downloadUrl?: string }
+      downloadUrl = String(content.downloadUrl ?? '').trim() || String((att as any).contentUrl ?? '').trim()
+    } else if (contentType.startsWith('image/')) {
+      downloadUrl = String((att as any).contentUrl ?? '').trim()
+    }
+    if (!downloadUrl) {
+      results.push(stored)
+      continue
+    }
+    stored.download_url = downloadUrl
+    try {
+      const bytes = await fetchAttachmentBytes(downloadUrl, ATTACHMENT_MAX_BYTES)
+      const dir = join(ATTACHMENTS_DIR, messageId)
+      mkdirSync(dir, { recursive: true, mode: 0o700 })
+      const localPath = join(dir, sanitizeFilename(name))
+      writeFileSync(localPath, bytes, { mode: 0o600 })
+      stored.local_path = localPath
+      stored.size_bytes = bytes.length
+      stored.download_status = 'ok'
+    } catch (err) {
+      stored.download_status = 'failed'
+      stored.download_error = String((err as Error)?.message ?? err).slice(0, 200)
+    }
+    results.push(stored)
+  }
+  return results
+}
+
 function runPromptGuard(command: 'scan' | 'sanitize', text: string): Record<string, unknown> | null {
   const script = join(BRIDGE_HOME, 'bridge-guard.py')
   const result = spawnSync(
@@ -432,6 +513,8 @@ async function handleActivity(context: TurnContext): Promise<void> {
   if (guarded?.blocked) return
   const ts = activity.timestamp instanceof Date ? activity.timestamp.toISOString() : new Date().toISOString()
 
+  const attachments = await downloadAttachments(activity, messageId)
+
   const stored: StoredMessage = {
     chat_id: chatId,
     message_id: messageId,
@@ -440,6 +523,7 @@ async function handleActivity(context: TurnContext): Promise<void> {
     aad_object_id: aad,
     text,
     ts,
+    ...(attachments.length > 0 ? { attachments } : {}),
   }
   appendMessage(stored)
 
@@ -458,6 +542,18 @@ async function handleActivity(context: TurnContext): Promise<void> {
         tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
         service_url: String(activity.serviceUrl ?? ''),
         ts,
+        ...(attachments.length > 0
+          ? {
+              attachments: attachments.map(att => ({
+                name: att.name,
+                content_type: att.content_type,
+                download_status: att.download_status,
+                ...(att.local_path ? { local_path: att.local_path } : {}),
+                ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
+                ...(att.download_error ? { download_error: att.download_error } : {}),
+              })),
+            }
+          : {}),
       },
     },
   })

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -19,16 +19,19 @@ import { createServer } from 'http'
 import { randomUUID } from 'crypto'
 import { spawnSync } from 'child_process'
 import {
+  accessSync,
   appendFileSync,
   chmodSync,
+  constants as fsConstants,
   existsSync,
   mkdirSync,
   readFileSync,
   renameSync,
+  unlinkSync,
   writeFileSync,
 } from 'fs'
 import { homedir } from 'os'
-import { join } from 'path'
+import { isAbsolute as pathIsAbsolute, join, resolve as pathResolve } from 'path'
 import { createRecentMessageDeduper } from './dedupe.ts'
 
 type GroupPolicy = {
@@ -80,8 +83,52 @@ const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const ENV_FILE = join(STATE_DIR, '.env')
 const REFERENCES_FILE = join(STATE_DIR, 'conversations.json')
 const MESSAGES_FILE = join(STATE_DIR, 'messages.jsonl')
-const ATTACHMENTS_DIR = process.env.TEAMS_ATTACHMENTS_DIR ?? join(STATE_DIR, 'attachments')
-const ATTACHMENT_MAX_BYTES = Number(process.env.TEAMS_ATTACHMENT_MAX_BYTES ?? '52428800')
+function resolveAttachmentsDir(): string {
+  const override = process.env.TEAMS_ATTACHMENTS_DIR
+  if (override) {
+    if (!pathIsAbsolute(override)) {
+      process.stderr.write(
+        `teams channel: TEAMS_ATTACHMENTS_DIR not absolute, falling back to default\n`,
+      )
+    } else {
+      try {
+        accessSync(override, fsConstants.W_OK)
+        return override
+      } catch {
+        // Don't echo override path on failure to avoid leaking attacker-supplied
+        // env bytes into logs.
+        process.stderr.write(
+          `teams channel: TEAMS_ATTACHMENTS_DIR not writable, falling back to default\n`,
+        )
+      }
+    }
+  }
+  return pathResolve(STATE_DIR, 'attachments')
+}
+
+function resolveAttachmentMaxBytes(): number {
+  const DEFAULT_MAX = 50 * 1024 * 1024 // 50 MB
+  const CEILING = 1024 * 1024 * 1024 // 1 GB sanity ceiling
+  const raw = process.env.TEAMS_ATTACHMENT_MAX_BYTES
+  if (!raw) return DEFAULT_MAX
+  const n = Number(raw)
+  if (!Number.isFinite(n) || n <= 0) {
+    process.stderr.write(
+      `teams channel: TEAMS_ATTACHMENT_MAX_BYTES invalid, using default ${DEFAULT_MAX}\n`,
+    )
+    return DEFAULT_MAX
+  }
+  if (n > CEILING) {
+    process.stderr.write(
+      `teams channel: TEAMS_ATTACHMENT_MAX_BYTES exceeds ceiling ${CEILING}, using ceiling\n`,
+    )
+    return CEILING
+  }
+  return Math.floor(n)
+}
+
+const ATTACHMENTS_DIR = resolveAttachmentsDir()
+const ATTACHMENT_MAX_BYTES = resolveAttachmentMaxBytes()
 const TEAMS_FILE_DOWNLOAD_TYPE = 'application/vnd.microsoft.teams.file.download.info'
 const MS365_CALLBACK_DIR =
   process.env.MS365_CALLBACK_SHARED_DIR ?? join(BRIDGE_HOME, 'shared', 'ms365-callbacks')
@@ -307,21 +354,73 @@ function appendMessage(message: StoredMessage): void {
   appendFileSync(MESSAGES_FILE, JSON.stringify(message) + '\n', { mode: 0o600 })
 }
 
-function sanitizeFilename(name: string): string {
-  const trimmed = name.replace(/[\/\\\0]/g, '_').trim()
-  return (trimmed || 'attachment').slice(0, 200)
+function sanitizeMessageId(raw: string): string {
+  // Teams message ids are typically guid-like, numeric, or "<guid>:<num>".
+  // Strict allowlist prevents path-traversal via attacker-controlled activity.id.
+  if (!raw || typeof raw !== 'string') return ''
+  if (raw.length > 256) return ''
+  if (!/^[A-Za-z0-9_:.\-]+$/.test(raw)) return ''
+  // Defensive: any literal ".." segment is rejected even if the regex matches.
+  if (raw.includes('..')) return ''
+  return raw
 }
 
-async function fetchAttachmentBytes(url: string, maxBytes: number): Promise<Buffer> {
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`HTTP ${res.status}`)
-  const declared = Number(res.headers.get('content-length') ?? '0')
-  if (Number.isFinite(declared) && declared > maxBytes) {
-    throw new Error('size_limit')
+function sanitizeFilename(name: string): string {
+  if (!name || typeof name !== 'string') return ''
+  // Strip path-traversal segments and separators first.
+  let clean = name.replace(/\.\./g, '_').replace(/[\\/]/g, '_')
+  // Strip control chars + DEL + null bytes.
+  // eslint-disable-next-line no-control-regex
+  clean = clean.replace(/[\x00-\x1f\x7f]/g, '')
+  // Strip leading/trailing dots and whitespace.
+  clean = clean.replace(/^[.\s]+|[.\s]+$/g, '')
+  // Allowlist: alphanumerics, dot, dash, underscore, space.
+  clean = clean.replace(/[^A-Za-z0-9._\- ]/g, '_')
+  if (clean.length === 0 || clean.length > 255) return ''
+  return clean
+}
+
+async function streamDownload(
+  url: string,
+  destPath: string,
+  maxBytes: number,
+): Promise<{ ok: true; size: number } | { ok: false; error: string }> {
+  const resp = await fetch(url)
+  if (!resp.ok) return { ok: false, error: `HTTP ${resp.status}` }
+  const cl = resp.headers.get('content-length')
+  if (cl !== null) {
+    const declared = Number(cl)
+    if (Number.isFinite(declared) && declared > maxBytes) {
+      return { ok: false, error: 'size_limit' }
+    }
   }
-  const buf = Buffer.from(await res.arrayBuffer())
-  if (buf.length > maxBytes) throw new Error('size_limit')
-  return buf
+  if (!resp.body) return { ok: false, error: 'no response body' }
+
+  let total = 0
+  // Pre-create the file with restrictive mode so the writer inherits 0600.
+  writeFileSync(destPath, '', { mode: 0o600 })
+  const writer = Bun.file(destPath).writer()
+  const reader = resp.body.getReader()
+  try {
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      if (!value) continue
+      total += value.byteLength
+      if (total > maxBytes) {
+        try { await writer.end() } catch {}
+        try { unlinkSync(destPath) } catch {}
+        return { ok: false, error: 'size_limit' }
+      }
+      writer.write(value)
+    }
+    await writer.end()
+    return { ok: true, size: total }
+  } catch (err) {
+    try { await writer.end() } catch {}
+    try { unlinkSync(destPath) } catch {}
+    return { ok: false, error: String((err as Error)?.message ?? err) }
+  }
 }
 
 async function downloadAttachments(
@@ -330,6 +429,7 @@ async function downloadAttachments(
 ): Promise<StoredAttachment[]> {
   const items = Array.isArray(activity.attachments) ? activity.attachments : []
   if (items.length === 0) return []
+  const safeMessageId = sanitizeMessageId(messageId)
   const results: StoredAttachment[] = []
   for (let i = 0; i < items.length; i++) {
     const att = items[i]
@@ -355,15 +455,32 @@ async function downloadAttachments(
       continue
     }
     stored.download_url = downloadUrl
+    if (!safeMessageId) {
+      stored.download_status = 'failed'
+      stored.download_error = 'rejected message id'
+      results.push(stored)
+      continue
+    }
+    const safeName = sanitizeFilename(name)
+    if (!safeName) {
+      stored.download_status = 'failed'
+      stored.download_error = 'rejected filename'
+      results.push(stored)
+      continue
+    }
     try {
-      const bytes = await fetchAttachmentBytes(downloadUrl, ATTACHMENT_MAX_BYTES)
-      const dir = join(ATTACHMENTS_DIR, messageId)
+      const dir = join(ATTACHMENTS_DIR, safeMessageId)
       mkdirSync(dir, { recursive: true, mode: 0o700 })
-      const localPath = join(dir, sanitizeFilename(name))
-      writeFileSync(localPath, bytes, { mode: 0o600 })
-      stored.local_path = localPath
-      stored.size_bytes = bytes.length
-      stored.download_status = 'ok'
+      const localPath = join(dir, safeName)
+      const dl = await streamDownload(downloadUrl, localPath, ATTACHMENT_MAX_BYTES)
+      if (dl.ok) {
+        stored.local_path = localPath
+        stored.size_bytes = dl.size
+        stored.download_status = 'ok'
+      } else {
+        stored.download_status = 'failed'
+        stored.download_error = dl.error.slice(0, 200)
+      }
     } catch (err) {
       stored.download_status = 'failed'
       stored.download_error = String((err as Error)?.message ?? err).slice(0, 200)

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -357,11 +357,14 @@ function appendMessage(message: StoredMessage): void {
 function sanitizeMessageId(raw: string): string {
   // Teams message ids are typically guid-like, numeric, or "<guid>:<num>".
   // Strict allowlist prevents path-traversal via attacker-controlled activity.id.
+  // Dot is intentionally NOT allowed — even with the literal ".." check below,
+  // single dots could let an attacker craft segments that the filesystem
+  // resolves into traversal under some path normalization (codex r2 PR #443).
+  // Real Teams message ids in the wild are alphanumeric/colon/dash/underscore;
+  // the rare dotted format would safely fail-closed (download_status=failed).
   if (!raw || typeof raw !== 'string') return ''
   if (raw.length > 256) return ''
-  if (!/^[A-Za-z0-9_:.\-]+$/.test(raw)) return ''
-  // Defensive: any literal ".." segment is rejected even if the regex matches.
-  if (raw.includes('..')) return ''
+  if (!/^[A-Za-z0-9_:\-]+$/.test(raw)) return ''
   return raw
 }
 

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -357,11 +357,11 @@ function appendMessage(message: StoredMessage): void {
 function sanitizeMessageId(raw: string): string {
   // Teams message ids are typically guid-like, numeric, or "<guid>:<num>".
   // Strict allowlist prevents path-traversal via attacker-controlled activity.id.
-  // Dot is intentionally NOT allowed — even with the literal ".." check below,
-  // single dots could let an attacker craft segments that the filesystem
-  // resolves into traversal under some path normalization (codex r2 PR #443).
-  // Real Teams message ids in the wild are alphanumeric/colon/dash/underscore;
-  // the rare dotted format would safely fail-closed (download_status=failed).
+  // Dot is intentionally NOT in the allowlist — single dots could let an
+  // attacker craft segments that the filesystem resolves into traversal
+  // under some path normalization (codex r2 PR #443). Real Teams message
+  // ids in the wild are alphanumeric/colon/dash/underscore; the rare
+  // dotted format safely fail-closes (download_status=failed).
   if (!raw || typeof raw !== 'string') return ''
   if (raw.length > 256) return ''
   if (!/^[A-Za-z0-9_:\-]+$/.test(raw)) return ''


### PR DESCRIPTION
## Summary

- Teams plugin (`plugins/teams/server.ts`) was dropping `activity.attachments` and only forwarding the text body. Inbound PDFs/Excels/images never reached the agent.
- Adds `StoredAttachment` typing and a `downloadAttachments()` helper. Inbound file-consent attachments and inline images are downloaded via anonymous GET to `<TEAMS_STATE_DIR>/attachments/<message_id>/<filename>` (dir 0700, file 0600), capped at `TEAMS_ATTACHMENT_MAX_BYTES` (default 50 MB).
- Persists per-attachment `name`, `content_type`, `download_status` (`ok` / `skipped_non_file` / `failed`), `local_path`, `size_bytes`, `download_error` on both the `StoredMessage` log and the `notifications/claude/channel` meta. Cards and other non-file attachment kinds record `skipped_non_file` so the agent still observes their metadata.
- README updated with the new behaviour and the two env knobs (`TEAMS_ATTACHMENTS_DIR`, `TEAMS_ATTACHMENT_MAX_BYTES`).
- Outbound attachments and bot-token fallback for download URLs that require auth are intentionally **not** in this change — see "Out of scope" below for the follow-up plan.

Plan document: [`agents/dev_mun/references/teams-plugin-inbound-attachment-plan.md`](https://github.com/SYRS-AI/agent-bridge-public/) (lives in the dev_mun runtime home, not the source tree).

## Behaviour

Before this change a Teams DM with a PDF attachment arrived as a text-only `<channel source="teams" ...>` block; the agent had no way to know a file was sent.

After this change the same message arrives with `meta.attachments` populated:

```json
"attachments": [
  {
    "name": "조선미녀 견적.xlsx",
    "content_type": "application/vnd.microsoft.teams.file.download.info",
    "download_status": "ok",
    "local_path": "/home/ec2-user/.agent-bridge/agents/<agent>/.teams/attachments/<message_id>/조선미녀 견적.xlsx",
    "size_bytes": 24576
  }
]
```

The agent can then call `Read` on `local_path`. Failed downloads expose `download_status="failed"` plus a short `download_error` string and never block the underlying text notification.

## Out of scope (separate work)

1. **Outbound attachments** — Teams' standard path is the File Consent Card (or OneDrive upload + link). Tracked in the plan doc; expected to land as a follow-up PR.
2. **Bot-token fallback for protected downloadUrl** — current implementation only does anonymous GET, which works for Teams-issued signed URLs in observed cases. If a tenant's policy requires the bot token to fetch the attachment, that fallback is small but needs a real reproduction first.
3. **Attachment retention / cleanup cron** — files persist under `attachments/<message_id>/` with no automated pruning yet.
4. **Prompt-guard scope on attachment filenames** — currently only the text body is scanned. Filenames in attachment metadata are not.

## Test plan

- [x] `bun build plugins/teams/server.ts --target=bun --outfile=/tmp/teams-build.out` — bundle succeeded, no syntax/import errors (984 modules)
- [x] `bash -n` on root shell scripts — clean
- [x] `BRIDGE_HOME=/tmp/agb-smoke-pr ./scripts/smoke-test.sh` — isolated smoke test exercises daemon/queue/static-role paths; this change touches plugin TS only, so the suite is for regression coverage rather than direct verification.
- [ ] **Manual live verification** (recommended before merge): in an isolated `BRIDGE_HOME`, send a Teams DM with one PDF + one image + one text-only message to a dev_mun-style agent, confirm the channel block exposes `attachments` with `download_status="ok"` and that `Read <local_path>` returns the original bytes.
- [ ] Negative path: send an attachment >50 MB, confirm `download_status="failed"` with `download_error="size_limit"`, text body still delivered.

## Validation notes

- Plugin pulled into `BotFrameworkAdapter` runtime; the surface is limited to `handleActivity` and the `StoredMessage` shape. No changes to MCP tool definitions, no port binding changes, no `access.json` schema changes.
- Live deployment requires a teams plugin restart per agent that consumes the upgrade, which falls under the patch (admin) operating contract — see `OPERATIONS.md` and the project `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
