### PR TITLE
fix: link dev plugin source dependencies

### DIFF
--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -64,6 +64,59 @@ def remove_tree(path: Path) -> None:
         shutil.rmtree(path)
 
 
+NODE_MODULES_NAME = "node_modules"
+
+
+def _copy_file_if_changed(src: Path, dst: Path) -> bool:
+    """Copy file from src to dst when missing or content differs. Returns True if written."""
+    try:
+        if dst.is_symlink() or dst.is_file():
+            if dst.is_file() and not dst.is_symlink():
+                if dst.stat().st_size == src.stat().st_size and dst.read_bytes() == src.read_bytes():
+                    return False
+            dst.unlink(missing_ok=True)
+        elif dst.exists():
+            remove_tree(dst)
+    except OSError:
+        remove_tree(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    return True
+
+
+def _overlay_dir(src: Path, dst: Path) -> bool:
+    """Recursively overlay src onto dst. Returns True if anything was written."""
+    changed = False
+    if dst.exists() and not dst.is_dir():
+        remove_tree(dst)
+    dst.mkdir(parents=True, exist_ok=True)
+    for entry in src.iterdir():
+        target = dst / entry.name
+        if entry.is_symlink() or entry.is_file():
+            if _copy_file_if_changed(entry, target):
+                changed = True
+        elif entry.is_dir():
+            if _overlay_dir(entry, target):
+                changed = True
+    return changed
+
+
+def overlay_source_to_cache(source_path: Path, cache_version_path: Path) -> bool:
+    """Mirror source files (except node_modules) onto cache. Returns True if changed."""
+    changed = False
+    for entry in source_path.iterdir():
+        if entry.name == NODE_MODULES_NAME:
+            continue
+        target = cache_version_path / entry.name
+        if entry.is_symlink() or entry.is_file():
+            if _copy_file_if_changed(entry, target):
+                changed = True
+        elif entry.is_dir():
+            if _overlay_dir(entry, target):
+                changed = True
+    return changed
+
+
 def link_source_node_modules(source_path: Path, cache_version_path: Path) -> tuple[str, str]:
     source_node_modules = source_path / "node_modules"
     cache_node_modules = cache_version_path / "node_modules"
@@ -136,9 +189,12 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
         cache_type = "symlink"
     else:
         if cache_version_path.is_dir():
-            # Real cache directories carry installed dependencies. Keep them and
-            # link only node_modules into the dev source root below.
-            status = "unchanged"
+            # Real cache directories carry installed dependencies. Overlay source
+            # files (everything except node_modules) so operator edits reach the
+            # cache, while preserving the cache's installed node_modules dir. The
+            # source root's node_modules is then linked back to the cache below.
+            changed = overlay_source_to_cache(source_path, cache_version_path)
+            status = "updated" if changed else "unchanged"
             cache_type = "directory"
         elif cache_version_path.exists():
             remove_tree(cache_version_path)

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Sync Claude dev-loaded plugin cache entries to live marketplace sources."""
+"""Prepare Claude dev-loaded plugin cache/source links for live marketplace sources."""
 
 from __future__ import annotations
 
@@ -64,6 +64,31 @@ def remove_tree(path: Path) -> None:
         shutil.rmtree(path)
 
 
+def link_source_node_modules(source_path: Path, cache_version_path: Path) -> tuple[str, str]:
+    source_node_modules = source_path / "node_modules"
+    cache_node_modules = cache_version_path / "node_modules"
+
+    if cache_version_path.is_symlink() and cache_version_path.resolve() == source_path:
+        return "cache-is-source", ""
+    if not cache_node_modules.exists():
+        return "missing", ""
+    if not cache_node_modules.is_dir():
+        return "not-directory", str(cache_node_modules)
+
+    if source_node_modules.is_symlink():
+        if source_node_modules.resolve() == cache_node_modules.resolve():
+            return "unchanged", str(cache_node_modules)
+        source_node_modules.unlink()
+        source_node_modules.symlink_to(cache_node_modules, target_is_directory=True)
+        return "updated", str(cache_node_modules)
+
+    if source_node_modules.exists():
+        return "present", str(source_node_modules)
+
+    source_node_modules.symlink_to(cache_node_modules, target_is_directory=True)
+    return "linked", str(cache_node_modules)
+
+
 def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
     marketplace_name, plugins = load_marketplace(root)
 
@@ -98,6 +123,7 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
     plugin_cache_root = cache_root() / marketplace_name / plugin_name
     cache_version_path = plugin_cache_root / version
     orphan_removed = 0
+    cache_type = "missing"
 
     if cache_version_path.is_symlink():
         current_target = cache_version_path.resolve()
@@ -107,19 +133,31 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             cache_version_path.unlink(missing_ok=True)
             cache_version_path.symlink_to(source_path, target_is_directory=True)
             status = "updated"
+        cache_type = "symlink"
     else:
-        if cache_version_path.exists():
+        if cache_version_path.is_dir():
+            # Real cache directories carry installed dependencies. Keep them and
+            # link only node_modules into the dev source root below.
+            status = "unchanged"
+            cache_type = "directory"
+        elif cache_version_path.exists():
             remove_tree(cache_version_path)
             status = "updated"
+            cache_type = "symlink"
+            plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            cache_version_path.symlink_to(source_path, target_is_directory=True)
         else:
             status = "linked"
-        plugin_cache_root.mkdir(parents=True, exist_ok=True)
-        cache_version_path.symlink_to(source_path, target_is_directory=True)
+            cache_type = "symlink"
+            plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            cache_version_path.symlink_to(source_path, target_is_directory=True)
 
     if plugin_cache_root.exists():
         for marker in plugin_cache_root.rglob(".orphaned_at"):
             marker.unlink(missing_ok=True)
             orphan_removed += 1
+
+    node_modules_status, node_modules_target = link_source_node_modules(source_path, cache_version_path)
 
     return {
         "channel": channel,
@@ -128,7 +166,10 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
         "version": version,
         "source": str(source_path),
         "cache": str(cache_version_path),
+        "cache_type": cache_type,
         "status": status,
+        "node_modules_status": node_modules_status,
+        "node_modules_target": node_modules_target,
         "orphan_removed": str(orphan_removed),
     }
 
@@ -159,6 +200,8 @@ def main(argv: list[str] | None = None) -> int:
         if status in {"linked", "updated", "unchanged"}:
             print(
                 f"{plugin}: {status} cache={item.get('cache','-')} source={item.get('source','-')} "
+                f"node_modules={item.get('node_modules_status','-')} "
+                f"node_modules_target={item.get('node_modules_target','-') or '-'} "
                 f"orphan_removed={item.get('orphan_removed','0')}"
             )
         else:

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5294,7 +5294,7 @@ assert row["status"] in {"linked", "updated", "unchanged"}, row
 assert row["cache_type"] == "directory", row
 assert row["node_modules_status"] == "linked", row
 assert cache_version.is_dir() and not cache_version.is_symlink(), cache_version
-assert (cache_version / "server.ts").read_text(encoding="utf-8") == "stale cache\n"
+assert (cache_version / "server.ts").read_text(encoding="utf-8") == "source server\n"
 assert not (cache_version / ".orphaned_at").exists()
 source_node_modules = source / "node_modules"
 cache_node_modules = cache_version / "node_modules"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5262,12 +5262,23 @@ else
 fi
 
 log "syncing dev-loaded plugin cache to live marketplace sources"
+DEV_PLUGIN_MARKETPLACE_ROOT="$TMP_ROOT/dev-plugin-marketplace"
+mkdir -p "$DEV_PLUGIN_MARKETPLACE_ROOT/.claude-plugin" \
+  "$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/teams" \
+  "$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/ms365"
+cp "$REPO_ROOT/.claude-plugin/marketplace.json" "$DEV_PLUGIN_MARKETPLACE_ROOT/.claude-plugin/marketplace.json"
+cp "$REPO_ROOT/plugins/teams/.mcp.json" "$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/teams/.mcp.json"
+cp "$REPO_ROOT/plugins/ms365/.mcp.json" "$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/ms365/.mcp.json"
+printf 'source server\n' >"$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/teams/server.ts"
+printf 'source server\n' >"$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/ms365/server.ts"
 TEAMS_CACHE_VERSION_DIR="$BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT/agent-bridge/teams/0.1.0"
-mkdir -p "$TEAMS_CACHE_VERSION_DIR"
+rm -rf "$BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT/agent-bridge/teams"
+mkdir -p "$TEAMS_CACHE_VERSION_DIR/node_modules/@smoke-dep"
 printf 'stale cache\n' >"$TEAMS_CACHE_VERSION_DIR/server.ts"
+printf '{"name":"@smoke-dep"}\n' >"$TEAMS_CACHE_VERSION_DIR/node_modules/@smoke-dep/package.json"
 printf 'orphaned\n' >"$TEAMS_CACHE_VERSION_DIR/.orphaned_at"
-DEV_PLUGIN_CACHE_JSON="$(python3 "$REPO_ROOT/bridge-dev-plugin-cache.py" sync --channels "plugin:teams@agent-bridge" --json)"
-python3 - "$DEV_PLUGIN_CACHE_JSON" "$REPO_ROOT/plugins/teams" "$TEAMS_CACHE_VERSION_DIR" <<'PY'
+DEV_PLUGIN_CACHE_JSON="$(python3 "$REPO_ROOT/bridge-dev-plugin-cache.py" sync --channels "plugin:teams@agent-bridge" --root "$DEV_PLUGIN_MARKETPLACE_ROOT" --json)"
+python3 - "$DEV_PLUGIN_CACHE_JSON" "$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/teams" "$TEAMS_CACHE_VERSION_DIR" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -5280,15 +5291,22 @@ assert len(results) == 1, results
 row = results[0]
 assert row["plugin"] == "teams", row
 assert row["status"] in {"linked", "updated", "unchanged"}, row
-assert cache_version.is_symlink(), cache_version
-assert cache_version.resolve() == source, (cache_version, source)
+assert row["cache_type"] == "directory", row
+assert row["node_modules_status"] == "linked", row
+assert cache_version.is_dir() and not cache_version.is_symlink(), cache_version
+assert (cache_version / "server.ts").read_text(encoding="utf-8") == "stale cache\n"
 assert not (cache_version / ".orphaned_at").exists()
+source_node_modules = source / "node_modules"
+cache_node_modules = cache_version / "node_modules"
+assert source_node_modules.is_symlink(), source_node_modules
+assert source_node_modules.resolve() == cache_node_modules.resolve(), (source_node_modules, cache_node_modules)
+assert (source_node_modules / "@smoke-dep" / "package.json").exists()
 mcp = json.loads((source / ".mcp.json").read_text(encoding="utf-8"))
 args = mcp["mcpServers"]["teams"]["args"]
 assert args[:2] == ["--cwd", "${CLAUDE_PLUGIN_ROOT}"], args
 assert args[2:] == ["--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"], args
 PY
-python3 - "$REPO_ROOT/plugins/ms365/.mcp.json" <<'PY'
+python3 - "$DEV_PLUGIN_MARKETPLACE_ROOT/plugins/ms365/.mcp.json" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -5298,13 +5316,14 @@ args = mcp["mcpServers"]["ms365"]["args"]
 assert args[:2] == ["--cwd", "${CLAUDE_PLUGIN_ROOT}"], args
 assert args[2:] == ["--no-install", "${CLAUDE_PLUGIN_ROOT}/server.ts"], args
 PY
-DEV_PLUGIN_CACHE_JSON_AGAIN="$(python3 "$REPO_ROOT/bridge-dev-plugin-cache.py" sync --channels "plugin:teams@agent-bridge" --json)"
+DEV_PLUGIN_CACHE_JSON_AGAIN="$(python3 "$REPO_ROOT/bridge-dev-plugin-cache.py" sync --channels "plugin:teams@agent-bridge" --root "$DEV_PLUGIN_MARKETPLACE_ROOT" --json)"
 python3 - "$DEV_PLUGIN_CACHE_JSON_AGAIN" <<'PY'
 import json
 import sys
 
 payload = json.loads(sys.argv[1])
 assert payload["results"][0]["status"] == "unchanged", payload
+assert payload["results"][0]["node_modules_status"] == "unchanged", payload
 PY
 
 BOOTSTRAP_FAIL_HOME="$TMP_ROOT/bootstrap-fail-home"


### PR DESCRIPTION
## Summary
- preserve real Claude plugin cache version directories so installed dependencies remain available
- link dev plugin source `node_modules` to the cache `node_modules` when present, without replacing a real source dependency directory
- update smoke coverage to assert cache preservation, source symlink creation, orphan marker cleanup, and idempotence

## Security self-check
- The symlink is created by the controller in the plugin source dir and points only at the existing Claude cache dependency tree. It does not add write permission for isolated UIDs.
- Isolated agents still need normal r-x traversal/read permission on the cache path; the symlink does not bypass POSIX/ACL checks.
- The shared cache `node_modules` tree is dependency code, not per-agent state. Runtime secrets/state remain in per-agent/private plugin state dirs, so sharing the read-only dependency tree is safe for multi-isolated agents.

## Tests
- `python3 -m py_compile bridge-dev-plugin-cache.py`
- `bash -n scripts/smoke-test.sh`
- `git diff --check`
- focused temp-fixture sync test: real cache dir with `node_modules` is preserved, source `node_modules` is linked, orphan marker removed, second sync is unchanged

Agent Bridge task #391