### PR TITLE
Fix static agent restart regressions

### DIFF
--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -17,6 +17,109 @@ fi
 umask 077
 
 BRIDGE_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+bridge_early_ephemeral_tmp_root() {
+  local path="${1:-}"
+  local tmpdir="${TMPDIR:-}"
+  local rest=""
+  [[ -n "$path" ]] || return 1
+  case "$path" in
+    /tmp/tmp.*|/tmp/tmp.*/*)
+      rest="${path#/tmp/}"
+      printf '/tmp/%s' "${rest%%/*}"
+      ;;
+    /var/tmp/tmp.*|/var/tmp/tmp.*/*)
+      rest="${path#/var/tmp/}"
+      printf '/var/tmp/%s' "${rest%%/*}"
+      ;;
+    /private/tmp/tmp.*|/private/tmp/tmp.*/*)
+      rest="${path#/private/tmp/}"
+      printf '/private/tmp/%s' "${rest%%/*}"
+      ;;
+    *)
+      if [[ -n "$tmpdir" ]]; then
+        tmpdir="${tmpdir%/}"
+        case "$path" in
+          "$tmpdir"/tmp.*|"$tmpdir"/tmp.*/*)
+            rest="${path#"$tmpdir"/}"
+            printf '%s/%s' "$tmpdir" "${rest%%/*}"
+            ;;
+          *)
+            return 1
+            ;;
+        esac
+      else
+        return 1
+      fi
+      ;;
+  esac
+}
+
+bridge_sanitize_stale_ephemeral_controller_env() {
+  local name=""
+  local value=""
+  local root=""
+  local -a path_vars=(
+    BRIDGE_HOME
+    BRIDGE_ROSTER_FILE
+    BRIDGE_ROSTER_LOCAL_FILE
+    BRIDGE_STATE_DIR
+    BRIDGE_LAYOUT_MARKER_DIR
+    BRIDGE_ACTIVE_AGENT_DIR
+    BRIDGE_HISTORY_DIR
+    BRIDGE_WORKTREE_META_DIR
+    BRIDGE_ACTIVE_ROSTER_TSV
+    BRIDGE_ACTIVE_ROSTER_MD
+    BRIDGE_DAEMON_PID_FILE
+    BRIDGE_DAEMON_LOG
+    BRIDGE_DAEMON_CRASH_LOG
+    BRIDGE_TASK_DB
+    BRIDGE_PROFILE_STATE_DIR
+    BRIDGE_CRON_STATE_DIR
+    BRIDGE_CRON_HOME_DIR
+    BRIDGE_NATIVE_CRON_JOBS_FILE
+    BRIDGE_CRON_DISPATCH_WORKER_DIR
+    BRIDGE_WORKTREE_ROOT
+    BRIDGE_AGENT_HOME_ROOT
+    BRIDGE_RUNTIME_ROOT
+    BRIDGE_RUNTIME_SCRIPTS_DIR
+    BRIDGE_RUNTIME_SKILLS_DIR
+    BRIDGE_RUNTIME_SHARED_DIR
+    BRIDGE_RUNTIME_SHARED_TOOLS_DIR
+    BRIDGE_RUNTIME_SHARED_REFERENCES_DIR
+    BRIDGE_RUNTIME_MEMORY_DIR
+    BRIDGE_RUNTIME_CREDENTIALS_DIR
+    BRIDGE_RUNTIME_SECRETS_DIR
+    BRIDGE_RUNTIME_CONFIG_FILE
+    BRIDGE_HOOKS_DIR
+    BRIDGE_SHARED_DIR
+    BRIDGE_TASK_NOTE_DIR
+    BRIDGE_LOG_DIR
+    BRIDGE_DATA_ROOT
+    BRIDGE_SHARED_ROOT
+    BRIDGE_AGENT_ROOT_V2
+    BRIDGE_CONTROLLER_STATE_ROOT
+    BRIDGE_CLAUDE_CHANNELS_HOME
+    BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT
+    BRIDGE_CLAUDE_INSTALLED_PLUGINS_FILE
+  )
+
+  [[ "${BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV:-0}" == "1" ]] && return 0
+
+  for name in "${path_vars[@]}"; do
+    value="${!name:-}"
+    [[ -n "$value" ]] || continue
+    root="$(bridge_early_ephemeral_tmp_root "$value" 2>/dev/null || true)"
+    [[ -n "$root" ]] || continue
+    [[ -d "$root" ]] && continue
+    printf '[bridge-lib] [warn] unsetting stale ephemeral controller env %s=%s (missing root %s)\n' \
+      "$name" "$value" "$root" >&2
+    unset "$name"
+  done
+}
+
+bridge_sanitize_stale_ephemeral_controller_env
+
 if [[ -z "${BRIDGE_HOME:-}" ]]; then
   BRIDGE_HOME="$HOME/.agent-bridge"
 fi

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -291,8 +291,8 @@ bridge_run_reconcile_next_session_state() {
   age_seconds="$(bridge_agent_maybe_expire_next_session "$AGENT" "$ttl_seconds" || true)"
   if [[ "$age_seconds" =~ ^[0-9]+$ ]]; then
     marker_file="$(bridge_agent_next_session_marker_file "$AGENT")"
-    log_line "[info] auto-cleared stale NEXT-SESSION.md after ${age_seconds}s (previous handoff digest was already delivered)"
-    bridge_audit_log daemon next_session_autocleared "$AGENT" \
+    log_line "[info] auto-archived stale NEXT-SESSION.md after ${age_seconds}s (previous handoff digest was already delivered)"
+    bridge_audit_log daemon next_session_autoarchived "$AGENT" \
       --detail age_seconds="$age_seconds" \
       --detail ttl_seconds="$ttl_seconds" \
       --detail next_session_file="$next_file" \
@@ -308,6 +308,7 @@ bridge_run_reconcile_next_session_state() {
 bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
   local next_file="$WORK_DIR/NEXT-SESSION.md"
   local marker_file=""
+  local previous_session_id="${1:-}"
 
   [[ "$ENGINE" == "claude" ]] || return 0
   [[ $SAFE_MODE -eq 0 ]] || return 0
@@ -321,9 +322,12 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
       agent="$3"
       marker_file="$4"
       next_file="$5"
+      previous_session_id="$6"
       source "$script_dir/bridge-lib.sh"
       if bridge_tmux_wait_for_prompt "$session" claude 30; then
-        if [[ -z "$(bridge_agent_session_id "$agent")" ]]; then
+        if [[ -f "$next_file" && -n "$previous_session_id" ]]; then
+          bridge_refresh_agent_session_id "$agent" 24 0.5 "$previous_session_id" >/dev/null 2>&1 || true
+        elif [[ -z "$(bridge_agent_session_id "$agent")" ]]; then
           # Claude session metadata can appear after tmux startup. Refresh once
           # more at prompt-ready time so static resume state is persisted before
           # the agent later goes inactive.
@@ -344,7 +348,7 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
           printf "%s\n" "$(date +%s)" >"$marker_file"
         fi
       fi
-    ' -- "$SCRIPT_DIR" "$SESSION" "$AGENT" "$marker_file" "$next_file"
+    ' -- "$SCRIPT_DIR" "$SESSION" "$AGENT" "$marker_file" "$next_file" "$previous_session_id"
   ) >/dev/null 2>&1 &
 }
 
@@ -495,8 +499,10 @@ while true; do
   run_duration=0
   rapid_failure=0
   sleep_seconds=5
+  previous_session_id=""
   bridge_run_refresh_roster_if_changed
   export BRIDGE_AGENT_LOOP_RESTART_COUNT="$RESTART_COUNT"
+  previous_session_id="$(bridge_agent_session_id "$AGENT")"
   bridge_run_reconcile_next_session_state
   if [[ $SAFE_MODE -eq 1 ]]; then
     LAUNCH_CMD="$(bridge_build_safe_launch_cmd "$AGENT")"
@@ -510,7 +516,7 @@ while true; do
     bridge_run_sync_dev_plugin_cache
     bridge_ensure_claude_launch_channel_plugins "$AGENT"
     bridge_run_schedule_dev_channels_accept "$LAUNCH_CMD"
-    bridge_run_schedule_idle_marker_and_inbox_bootstrap
+    bridge_run_schedule_idle_marker_and_inbox_bootstrap "$previous_session_id"
   fi
 
   log_line "실행: ${local_launch_cmd_display}"

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -255,7 +255,7 @@ def _stamp_next_session_delivered(agent: str, next_session: Path) -> str | None:
 
     The bash-side `bridge_agent_maybe_expire_next_session` gates on
     `bridge_agent_next_session_is_delivered` (marker file equals the current
-    file digest). Without this writer the auto-clear path is dead code — a
+    file digest). Without this writer the auto-archive path is dead code — a
     regression introduced when `bridge_run_schedule_next_session_prompt` was
     removed in b38e584 in favour of the SessionStart hook. We restore the
     marker here so `bridge-run.sh`'s reconcile step can age out a stale
@@ -419,6 +419,35 @@ def bootstrap_artifact_context(agent: str) -> str:
 
     if not lines:
         return ""
+    return "\n".join(lines)
+
+
+def next_session_required_prompt_context(agent: str) -> str:
+    workdir = agent_workdir(agent)
+    default_home = agent_default_home(agent)
+    next_session = first_existing_path(
+        [
+            workdir / "NEXT-SESSION.md",
+            default_home / "NEXT-SESSION.md",
+        ]
+    )
+    if next_session is None:
+        return ""
+
+    lines = [
+        "<agent_bridge_next_session_required>",
+        f"NEXT-SESSION.md is still present at {next_session}.",
+        "Before answering the current user prompt or doing any other work, read this file in full and execute its checklist.",
+        "If the current user prompt conflicts with the handoff, acknowledge that the handoff is being processed first.",
+    ]
+    excerpt = short_file_excerpt(next_session)
+    if excerpt:
+        lines.append("Handoff excerpt:")
+        lines.append(excerpt)
+    digest = _stamp_next_session_delivered(agent, next_session)
+    if digest is not None:
+        _enqueue_handoff_pending(agent, next_session, digest)
+    lines.append("</agent_bridge_next_session_required>")
     return "\n".join(lines)
 
 

--- a/hooks/prompt_timestamp.py
+++ b/hooks/prompt_timestamp.py
@@ -8,7 +8,11 @@ import json
 import os
 import sys
 
-from bridge_hook_common import agent_timestamp_enabled, prompt_timestamp_context
+from bridge_hook_common import (
+    agent_timestamp_enabled,
+    next_session_required_prompt_context,
+    prompt_timestamp_context,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -23,7 +27,9 @@ def main(argv: list[str] | None = None) -> int:
             sys.stdout.write("\n")
         return 0
 
-    context = prompt_timestamp_context(agent)
+    handoff_context = next_session_required_prompt_context(agent)
+    timestamp_context = prompt_timestamp_context(agent)
+    context = f"{handoff_context}\n{timestamp_context}" if handoff_context else timestamp_context
     if args.format == "codex":
         json.dump(
             {

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -526,6 +526,28 @@ import shlex
 import sys
 
 agent, continue_mode, session_id, continue_fallback, original = sys.argv[1:]
+
+
+def repair_false_command(value: str) -> str:
+    try:
+        tokens = shlex.split(value)
+    except ValueError:
+        return value
+    if not tokens:
+        return value
+    idx = 0
+    while idx < len(tokens):
+        key = tokens[idx].split("=", 1)[0]
+        if "=" not in tokens[idx] or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key) or tokens[idx].startswith("-"):
+            break
+        idx += 1
+    if idx < len(tokens) and tokens[idx] == "false":
+        tokens[idx] = "claude"
+        return " ".join(shlex.quote(token) for token in tokens)
+    return value
+
+
+original = repair_false_command(original)
 match = re.match(r"^(?P<prefix>.*?)(?P<command>claude(?:\s|$).*)$", original)
 if not match:
     print(original)
@@ -594,6 +616,28 @@ import shlex
 import sys
 
 agent, continue_mode, session_id, original = sys.argv[1:]
+
+
+def repair_false_command(value: str) -> str:
+    try:
+        tokens = shlex.split(value)
+    except ValueError:
+        return value
+    if not tokens:
+        return value
+    idx = 0
+    while idx < len(tokens):
+        key = tokens[idx].split("=", 1)[0]
+        if "=" not in tokens[idx] or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", key) or tokens[idx].startswith("-"):
+            break
+        idx += 1
+    if idx < len(tokens) and tokens[idx] == "false":
+        tokens[idx] = "claude"
+        return " ".join(shlex.quote(token) for token in tokens)
+    return value
+
+
+original = repair_false_command(original)
 match = re.match(r"^(?P<prefix>.*?)(?P<command>claude(?:\s|$).*)$", original)
 if not match:
     print(original)
@@ -1837,6 +1881,38 @@ bridge_agent_clear_next_session_state() {
   rm -f "$(bridge_agent_next_session_file "$agent")" "$(bridge_agent_next_session_marker_file "$agent")"
 }
 
+bridge_agent_archive_next_session_state() {
+  local agent="$1"
+  local next_file=""
+  local marker_file=""
+  local archive_dir=""
+  local archive_file=""
+  local digest=""
+  local digest_short=""
+  local stamp=""
+  local index=0
+
+  next_file="$(bridge_agent_next_session_file "$agent")"
+  marker_file="$(bridge_agent_next_session_marker_file "$agent")"
+  [[ -f "$next_file" ]] || return 1
+
+  digest="$(bridge_agent_next_session_digest "$agent" 2>/dev/null || true)"
+  digest_short="${digest:0:12}"
+  [[ -n "$digest_short" ]] || digest_short="unknown"
+  stamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+  archive_dir="$(dirname "$next_file")/archive"
+  archive_file="$archive_dir/NEXT-SESSION.${stamp}.${digest_short}.md"
+
+  mkdir -p "$archive_dir"
+  while [[ -e "$archive_file" ]]; do
+    index=$((index + 1))
+    archive_file="$archive_dir/NEXT-SESSION.${stamp}.${digest_short}.${index}.md"
+  done
+  mv "$next_file" "$archive_file"
+  rm -f "$marker_file"
+  printf '%s' "$archive_file"
+}
+
 bridge_agent_maybe_expire_next_session() {
   local agent="$1"
   local ttl_seconds="${2:-${BRIDGE_NEXT_SESSION_AUTO_CLEAR_SECONDS:-300}}"
@@ -1847,7 +1923,7 @@ bridge_agent_maybe_expire_next_session() {
   age_seconds="$(bridge_agent_next_session_age_seconds "$agent" || echo 0)"
   [[ "$age_seconds" =~ ^[0-9]+$ ]] || age_seconds=0
   (( age_seconds >= ttl_seconds )) || return 1
-  bridge_agent_clear_next_session_state "$agent"
+  bridge_agent_archive_next_session_state "$agent" >/dev/null || return 1
   printf '%s' "$age_seconds"
 }
 
@@ -2516,19 +2592,31 @@ bridge_refresh_agent_session_id() {
   local agent="$1"
   local attempts="${2:-8}"
   local sleep_seconds="${3:-0.25}"
+  local extra_exclude_csv="${4:-}"
   local since_hint sid detected exclude_csv
   local -a excluded=()
-  local other try_index
+  local -a extra_excluded=()
+  local other try_index extra
 
   sid="$(bridge_agent_session_id "$agent")"
   if [[ -n "$sid" ]]; then
-    printf '%s' "$sid"
-    return 0
+    if ! bridge_channel_csv_contains "$extra_exclude_csv" "$sid"; then
+      printf '%s' "$sid"
+      return 0
+    fi
+  fi
+  if [[ -n "$extra_exclude_csv" ]]; then
+    IFS=',' read -r -a extra_excluded <<<"$extra_exclude_csv"
   fi
 
   since_hint="${BRIDGE_AGENT_CREATED_AT[$agent]-$(date +%s)}"
   for ((try_index = 0; try_index < attempts; try_index += 1)); do
     excluded=()
+    for extra in "${extra_excluded[@]}"; do
+      extra="$(bridge_trim_whitespace "$extra")"
+      [[ -n "$extra" ]] || continue
+      excluded+=("$extra")
+    done
     for other in "${BRIDGE_AGENT_IDS[@]}"; do
       [[ "$other" == "$agent" ]] && continue
       sid="$(bridge_agent_session_id "$other")"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1111,6 +1111,24 @@ export BRIDGE_MCP_ORPHAN_CLEANUP_ENABLED=0
 export BRIDGE_WEBHOOK_PORT_RANGE_START=9301
 export BRIDGE_WEBHOOK_PORT_RANGE_END=9399
 
+STALE_CONTROLLER_ENV_ROOT="/tmp/tmp.agent-bridge-stale-env-$$"
+rm -rf "$STALE_CONTROLLER_ENV_ROOT"
+STALE_CONTROLLER_ENV_OUTPUT="$(
+  BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=0 \
+  BRIDGE_AGENT_HOME_ROOT="$STALE_CONTROLLER_ENV_ROOT/bridge-home/agents" \
+  BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT="$STALE_CONTROLLER_ENV_ROOT/claude-plugin-cache" \
+  "$BASH4_BIN" -c '
+    source "'"$REPO_ROOT"'/bridge-lib.sh"
+    printf "agent_home=%s\n" "$BRIDGE_AGENT_HOME_ROOT"
+    printf "plugin_cache=%s\n" "${BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT-unset}"
+  ' 2>&1
+)"
+assert_contains "$STALE_CONTROLLER_ENV_OUTPUT" "unsetting stale ephemeral controller env BRIDGE_AGENT_HOME_ROOT="
+assert_contains "$STALE_CONTROLLER_ENV_OUTPUT" "unsetting stale ephemeral controller env BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT="
+assert_contains "$STALE_CONTROLLER_ENV_OUTPUT" "agent_home=$BRIDGE_HOME/agents"
+assert_contains "$STALE_CONTROLLER_ENV_OUTPUT" "plugin_cache=unset"
+
 SESSION_NAME="bridge-smoke-$$"
 REQUESTER_SESSION="bridge-requester-$$"
 CLAUDE_STATIC_SESSION="claude-static-$SESSION_NAME"
@@ -3163,6 +3181,10 @@ assert_contains "$CLAUDE_SESSION_START_OUTPUT" "Handoff present: NEXT-SESSION.md
 assert_contains "$CLAUDE_SESSION_START_OUTPUT" "Resume Checklist"
 assert_contains "$CLAUDE_SESSION_START_OUTPUT" "Onboarding pending:"
 assert_contains "$CLAUDE_SESSION_START_OUTPUT" "agb inbox claude-static"
+CLAUDE_PROMPT_NEXT_SESSION_OUTPUT="$(BRIDGE_AGENT_ID="claude-static" BRIDGE_AGENT_WORKDIR="$CLAUDE_STATIC_WORKDIR" BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents" BRIDGE_HOME="$BRIDGE_HOME" python3 "$REPO_ROOT/hooks/prompt_timestamp.py")"
+assert_contains "$CLAUDE_PROMPT_NEXT_SESSION_OUTPUT" "<agent_bridge_next_session_required>"
+assert_contains "$CLAUDE_PROMPT_NEXT_SESSION_OUTPUT" "Before answering the current user prompt"
+assert_contains "$CLAUDE_PROMPT_NEXT_SESSION_OUTPUT" "Resume Checklist"
 # Issue #228: the SessionStart hook must also stamp the next-session
 # digest into the per-agent marker so bash-side
 # bridge_agent_maybe_expire_next_session can later age out the handoff.
@@ -5387,6 +5409,7 @@ cat >"$CLAUDE_STATIC_WORKDIR/NEXT-SESSION.md" <<'EOF'
 
 Already delivered in a previous restart.
 EOF
+rm -rf "$CLAUDE_STATIC_WORKDIR/archive"
 CLAUDE_STATIC_NEXT_DIGEST="$("$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_load_roster
@@ -5413,9 +5436,12 @@ CLAUDE_STALE_NEXT_CLEAR_AGE="$("$BASH4_BIN" -c '
   bridge_load_roster
   bridge_agent_maybe_expire_next_session "claude-static" 300 || true
 ')"
-[[ "$CLAUDE_STALE_NEXT_CLEAR_AGE" =~ ^[0-9]+$ ]] || die "expected stale NEXT-SESSION auto-clear age"
-[[ ! -f "$CLAUDE_STATIC_WORKDIR/NEXT-SESSION.md" ]] || die "expected stale NEXT-SESSION file to be cleared"
+[[ "$CLAUDE_STALE_NEXT_CLEAR_AGE" =~ ^[0-9]+$ ]] || die "expected stale NEXT-SESSION auto-archive age"
+[[ ! -f "$CLAUDE_STATIC_WORKDIR/NEXT-SESSION.md" ]] || die "expected stale NEXT-SESSION file to be archived away from active path"
 [[ ! -f "$CLAUDE_STATIC_NEXT_MARKER_FILE" ]] || die "expected stale NEXT-SESSION marker to be cleared"
+CLAUDE_STALE_NEXT_ARCHIVE="$(find "$CLAUDE_STATIC_WORKDIR/archive" -maxdepth 1 -name 'NEXT-SESSION.*.md' -print | head -n 1)"
+[[ -n "$CLAUDE_STALE_NEXT_ARCHIVE" && -f "$CLAUDE_STALE_NEXT_ARCHIVE" ]] || die "expected stale NEXT-SESSION archive file"
+assert_contains "$(cat "$CLAUDE_STALE_NEXT_ARCHIVE")" "Already delivered in a previous restart."
 
 FAKE_CLAUDE_HOME="$TMP_ROOT/fake-claude-home"
 mkdir -p "$FAKE_CLAUDE_HOME/.claude/sessions"
@@ -5443,6 +5469,16 @@ CLAUDE_SAFE_MODE_RESUME="$(HOME="$FAKE_CLAUDE_HOME" "$BASH4_BIN" -c '
 ')"
 assert_contains "$CLAUDE_SAFE_MODE_RESUME" "claude --resume static-existing-session-id --dangerously-skip-permissions --name claude-static"
 assert_not_contains "$CLAUDE_SAFE_MODE_RESUME" "--channels"
+CLAUDE_FALSE_LAUNCH_RECOVERY="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CHANNELS["claude-static"]="plugin:teams@agent-bridge"
+  BRIDGE_AGENT_LAUNCH_CMD["claude-static"]="false --dangerously-load-development-channels plugin:teams@agent-bridge --dangerously-skip-permissions"
+  bridge_agent_launch_cmd "claude-static"
+')"
+assert_not_contains "$CLAUDE_FALSE_LAUNCH_RECOVERY" "false --dangerously"
+assert_contains "$CLAUDE_FALSE_LAUNCH_RECOVERY" "claude --dangerously-skip-permissions --name claude-static"
+assert_contains "$CLAUDE_FALSE_LAUNCH_RECOVERY" "--dangerously-load-development-channels plugin:teams@agent-bridge"
 FAKE_CLAUDE_STALE_HOME="$TMP_ROOT/fake-claude-stale-home"
 mkdir -p "$FAKE_CLAUDE_STALE_HOME/.claude/sessions"
 cat >"$FAKE_CLAUDE_STALE_HOME/.claude/sessions/stale-existing.json" <<EOF
@@ -5507,6 +5543,32 @@ CLAUDE_REALPATH_REFRESH_OUTPUT="$(HOME="$FAKE_CLAUDE_REALPATH_HOME" "$BASH4_BIN"
   printf "SESSION_ID=%s" "${BRIDGE_AGENT_SESSION_ID["claude-static"]-}"
 ')"
 assert_contains "$CLAUDE_REALPATH_REFRESH_OUTPUT" "SESSION_ID=realpath-session-id"
+FAKE_CLAUDE_NEXT_REFRESH_HOME="$TMP_ROOT/fake-claude-next-refresh-home"
+CLAUDE_STATIC_WORKDIR_SLUG="${CLAUDE_STATIC_WORKDIR//\//-}"
+mkdir -p "$FAKE_CLAUDE_NEXT_REFRESH_HOME/.claude/sessions" \
+  "$FAKE_CLAUDE_NEXT_REFRESH_HOME/.claude/projects/$CLAUDE_STATIC_WORKDIR_SLUG"
+cat >"$FAKE_CLAUDE_NEXT_REFRESH_HOME/.claude/sessions/next-refresh.json" <<EOF
+{"sessionId":"next-session-new-id","cwd":"$CLAUDE_STATIC_WORKDIR","startedAt":1760000000300}
+EOF
+cat >"$FAKE_CLAUDE_NEXT_REFRESH_HOME/.claude/projects/$CLAUDE_STATIC_WORKDIR_SLUG/next-session-new-id.jsonl" <<'EOF'
+{"type":"custom-title","customTitle":"claude-static","sessionId":"next-session-new-id"}
+EOF
+cat >"$FAKE_CLAUDE_NEXT_REFRESH_HOME/.claude/projects/$CLAUDE_STATIC_WORKDIR_SLUG/next-session-old-id.jsonl" <<'EOF'
+{"type":"custom-title","customTitle":"claude-static","sessionId":"next-session-old-id"}
+EOF
+CLAUDE_NEXT_REFRESH_OUTPUT="$(HOME="$FAKE_CLAUDE_NEXT_REFRESH_HOME" "$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CONTINUE["claude-static"]="1"
+  BRIDGE_AGENT_CREATED_AT["claude-static"]="1760000000"
+  BRIDGE_AGENT_SESSION_ID["claude-static"]="next-session-old-id"
+  bridge_refresh_agent_session_id "claude-static" 2 0 "next-session-old-id"
+  printf "SESSION_ID=%s PERSISTED=%s" \
+    "${BRIDGE_AGENT_SESSION_ID["claude-static"]-}" \
+    "$(bridge_agent_persisted_session_id "claude-static")"
+')"
+assert_contains "$CLAUDE_NEXT_REFRESH_OUTPUT" "SESSION_ID=next-session-new-id"
+assert_contains "$CLAUDE_NEXT_REFRESH_OUTPUT" "PERSISTED=next-session-new-id"
 CLAUDE_REALPATH_LAUNCH_OUTPUT="$(HOME="$FAKE_CLAUDE_REALPATH_HOME" "$BASH4_BIN" -c '
   source "'"$REPO_ROOT"'/bridge-lib.sh"
   bridge_load_roster


### PR DESCRIPTION
## Summary

Code changes (in this PR's diff):
- scrub stale missing-root /tmp/tmp.* controller BRIDGE_* paths before bridge defaults resolve, with an opt-in escape hatch for temp smoke fixtures
- archive delivered stale NEXT-SESSION.md files instead of deleting them, and reinforce active handoffs through UserPromptSubmit context
- force fresh NEXT-SESSION Claude restarts to replace the previous session id in persisted state
- recover static Claude launch commands corrupted to start with false, while preserving env prefixes and channel/plugin arguments

Out of band (operator-host-side, NOT in this PR's diff):
- repair live mgt_ahn roster corruption and clear its broken-launch crash state on the host (one-time host repair done separately on the operator's reference install; included in summary for change-log completeness, not part of the source-tree diff)

Fixes #447

## Security self-check
- stale env scrubbing is limited to known bridge path variables whose temp root matches /tmp/tmp.*, /var/tmp/tmp.*, /private/tmp/tmp.*, or TMPDIR/tmp.* and no longer exists; BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1 keeps intentional temp fixtures working
- no ACL or permission grants are broadened; isolated and non-isolated paths continue through existing launch/state helpers
- false-token recovery only rewrites the first real command token after env assignments when it is exactly false; arbitrary non-Claude commands are left unchanged
- handoff prompt reinforcement is emitted only while NEXT-SESSION.md exists and uses the existing digest marker/idempotent handoff queue path

## Verification
- bash -n bridge-lib.sh bridge-run.sh lib/bridge-state.sh scripts/smoke-test.sh
- python3 -m py_compile hooks/bridge_hook_common.py hooks/prompt_timestamp.py hooks/session_start.py
- git diff --check
- focused stale controller env scrub check
- focused false static launch recovery check
- focused NEXT-SESSION archive preservation check
- focused UserPromptSubmit NEXT-SESSION context check
- focused forced session id refresh + persisted state check

## Codex pair-review notes

- r1 PASS: Fix 1 (env scrub), Fix 2 (NEXT-SESSION archive), Fix 4 (false-token recovery)
- r1 concern (deferred): Fix 3 session-id refresh persistence flows through existing `bridge_persist_agent_state` which uses direct redirection, not temp+rename atomic write. This is pre-existing infra, NOT introduced by this PR. Atomic write conversion is a separate broader-infrastructure scope.
- r1 originally flagged Fix 5 "blocking" because the diff doesn't include it — body now clarifies it is host-side ops (not code).