### PR TITLE
feat(memory-pipeline): daily-note-reconcile.py — jsonl to daily note merger (#390 PR-1)

### DIFF
--- a/scripts/daily-note-reconcile.py
+++ b/scripts/daily-note-reconcile.py
@@ -58,13 +58,53 @@ Caller contract
 * rc=2 on jsonl missing/unreadable, bad CLI args, or write failure.
 * JSON summary on stdout when ``--json`` is set.
 * ``--dry-run`` prints unified diff (or "no changes") and never writes.
+
+JSON output schema (when ``--json`` is set, stdout is one parseable JSON document)
+---------------------------------------------------------------------------------
+``{
+    "outcome": "merged" | "noop" | "dry-run" | "error",
+    "agent": "<id>",
+    "date": "YYYY-MM-DD",
+    "session_id": "<id or empty string>",
+    "jsonl": "<path>",
+    "memory_dir": "<path>",
+    "note_path": "<path>",
+    "turns_total": <int>,           # turns extracted from jsonl matching --date
+    "turns_filtered": <int>,        # turns dropped to dedupe / type-guard
+    "turns_new": <int>,             # turns actually appended to the daily note
+    "manifest_size_before": <int>,  # total fingerprints across all sessions
+    "manifest_size_after": <int>,
+    "sessions": [<per-session summary>],
+    "applied": "noop" | "updated" | "created",
+    "dry_run": <bool>,
+    "diff": "<unified diff text or empty>",  # only populated for --dry-run
+    "human_summary": "<one-line human-readable summary>",
+    "warnings": ["..."],            # quarantine / type-guard / recovery breadcrumbs
+    "error": "<message or null>"
+}``
+
+Concurrency safety
+------------------
+The read/parse/render/write cycle is wrapped in an ``fcntl.flock`` against
+a sentinel file (``<memory-dir>/.daily-note-reconcile.lock``). Concurrent
+invocations (cron + Stop hook + ad-hoc operator) serialise on this lock.
+
+Path safety
+-----------
+``--agent`` is allowlisted to ``[A-Za-z0-9_-]{1,64}``. ``--memory-dir``
+defaults to ``<BRIDGE_HOME>/agents/<agent>/memory``; if an explicit
+override is provided, the resolved path MUST be inside the resolved
+``BRIDGE_HOME`` (or the operator's ``--bridge-root``-equivalent default
+home), otherwise the script exits with rc=2.
 """
 
 from __future__ import annotations
 
 import argparse
+import contextlib
 import datetime as _dt
 import difflib
+import fcntl
 import hashlib
 import json
 import os
@@ -85,6 +125,25 @@ DAILY_SECTION_HEADER_RE = re.compile(
     r"^## Session (?P<session>[A-Za-z0-9_-]+)(?P<tail>.*)$",
     re.MULTILINE,
 )
+# Matches "### turn N · <role> · <iso-ts>" block headers used inside
+# session sections. Captures role + timestamp so we can re-fingerprint
+# body turns when the manifest is missing/corrupt (Item 1c+3b recovery).
+DAILY_TURN_HEADER_RE = re.compile(
+    r"^### turn (?P<idx>\d+)\s+·\s+(?P<role>[^·\n]+?)\s+·\s+(?P<ts>[^\n]*?)\s*$",
+    re.MULTILINE,
+)
+# Quarantine block markers used when meta parsing fails or finds stray
+# meta-region lines (Item 2b).
+QUARANTINE_OPEN = "<!-- daily-note-reconcile-quarantine -->"
+QUARANTINE_CLOSE = "<!-- /daily-note-reconcile-quarantine -->"
+QUARANTINE_RE = re.compile(
+    r"\n?<!-- daily-note-reconcile-quarantine -->\n(?P<body>.*?)\n<!-- /daily-note-reconcile-quarantine -->\n?",
+    re.DOTALL,
+)
+# Allowlist for --agent (Item 6). Matches the bridge runtime's existing
+# agent id convention; rejects "..", "/", whitespace, etc.
+AGENT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+AGENT_ID_MAX_LEN = 64
 
 # Wrappers Claude emits for non-conversation scaffolding. These appear
 # inside string user content but are not what the operator typed.
@@ -113,6 +172,29 @@ TRUNCATION_MARKER = "\n\n[... truncated, see jsonl ...]\n\n"
 def _eprint(verbose: bool, *parts: Any) -> None:
     if verbose:
         sys.stderr.write("[daily-note-reconcile] " + " ".join(str(p) for p in parts) + "\n")
+
+
+def _warn(*parts: Any) -> None:
+    """Always-on stderr warning (independent of --verbose)."""
+    sys.stderr.write("[daily-note-reconcile] warn: " + " ".join(str(p) for p in parts) + "\n")
+
+
+def _safe_str(value: Any, label: str, warnings: list[str] | None = None) -> str | None:
+    """Coerce ``value`` to a string only if it is already one (Item 5a/c).
+
+    Non-string values trigger a stderr warning and return ``None`` so the
+    caller can skip the affected turn instead of crashing inside
+    ``.lstrip()`` / ``.encode()``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    msg = f"{label} not a string ({type(value).__name__}); skipping turn"
+    _warn(msg)
+    if warnings is not None:
+        warnings.append(msg)
+    return None
 
 
 def _today_utc() -> str:
@@ -144,7 +226,9 @@ def _date_of(ts: _dt.datetime | None) -> str | None:
     return ts.strftime("%Y-%m-%d")
 
 
-def _is_scaffolding(text: str) -> bool:
+def _is_scaffolding(text: Any) -> bool:
+    if not isinstance(text, str):
+        return False
     s = text.lstrip()
     return any(s.startswith(p) for p in SCAFFOLDING_PREFIXES)
 
@@ -159,11 +243,11 @@ def _truncate(text: str) -> str:
 
 def _fingerprint(role: str, text: str, ts_raw: str) -> str:
     h = hashlib.sha1()
-    h.update(role.encode("utf-8"))
+    h.update((role if isinstance(role, str) else "").encode("utf-8"))
     h.update(b"\x1f")
-    h.update(text.encode("utf-8"))
+    h.update((text if isinstance(text, str) else "").encode("utf-8"))
     h.update(b"\x1f")
-    h.update((ts_raw or "").encode("utf-8"))
+    h.update((ts_raw if isinstance(ts_raw, str) else "").encode("utf-8"))
     return h.hexdigest()[:16]  # 16 hex chars is plenty; keeps manifest small
 
 
@@ -176,18 +260,23 @@ def extract_turns(
     jsonl_path: Path,
     target_date: str,
     verbose: bool = False,
-) -> tuple[list[dict[str, Any]], list[str]]:
-    """Return (turns, session_ids_seen).
+    warnings: list[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[str], int]:
+    """Return (turns, session_ids_seen, dropped_count).
 
     Each turn is a dict with: ``session_id``, ``role``, ``text``,
     ``timestamp`` (raw string), ``timestamp_iso`` (parsed UTC ISO),
     ``fingerprint``.
 
-    Malformed lines are skipped (with a warning when verbose).
+    ``dropped_count`` counts turns rejected by the type-guard (Item 5a/c)
+    or by within-batch dedupe (Item 3c). Malformed jsonl lines are
+    skipped (with a verbose-only breadcrumb).
     """
     turns: list[dict[str, Any]] = []
     session_ids: list[str] = []
     seen_sids: set[str] = set()
+    seen_in_batch: set[str] = set()
+    dropped = 0
 
     with jsonl_path.open("r", encoding="utf-8", errors="replace") as fh:
         for lineno, raw_line in enumerate(fh, start=1):
@@ -206,13 +295,15 @@ def extract_turns(
             if rec_type not in ("user", "assistant"):
                 continue
 
-            ts_raw = rec.get("timestamp") or ""
+            ts_raw_value = rec.get("timestamp")
+            ts_raw = ts_raw_value if isinstance(ts_raw_value, str) else ""
             ts = _parse_iso_ts(ts_raw)
             day = _date_of(ts)
             if day != target_date:
                 continue
 
-            sid = rec.get("sessionId") or ""
+            sid_value = rec.get("sessionId")
+            sid = sid_value if isinstance(sid_value, str) else ""
             if not sid:
                 continue
             if sid not in seen_sids:
@@ -222,7 +313,17 @@ def extract_turns(
             msg = rec.get("message")
             if not isinstance(msg, dict):
                 continue
-            role = msg.get("role") or rec_type
+
+            # Item 5a/c — guard role: must be a string. If non-string,
+            # warn and skip the turn instead of crashing later.
+            raw_role = msg.get("role")
+            if raw_role is None:
+                raw_role = rec_type
+            role = _safe_str(raw_role, "role", warnings)
+            if role is None:
+                dropped += 1
+                continue
+
             content = msg.get("content")
 
             text_chunks: list[str] = []
@@ -235,7 +336,11 @@ def extract_turns(
                         continue
                     btype = blk.get("type")
                     if btype == "text":
-                        t = blk.get("text") or ""
+                        # Item 5a/c — guard text: must be a string.
+                        t = _safe_str(blk.get("text"), "text", warnings)
+                        if t is None:
+                            dropped += 1
+                            continue
                         if t and not _is_scaffolding(t):
                             text_chunks.append(t)
                     # thinking, tool_use, tool_result intentionally skipped.
@@ -247,7 +352,23 @@ def extract_turns(
                 continue
             text = _truncate(text)
 
-            fp = _fingerprint(role, text, ts_raw)
+            # Fingerprint against the SAME timestamp string the
+            # renderer writes (timestamp_iso when parseable, else the
+            # raw value). This keeps the manifest-recovery path
+            # (Item 1c+3b) byte-stable: re-fingerprinting a rendered
+            # body produces the same hash the extractor produced.
+            ts_for_fp = ts.isoformat() if ts else ts_raw
+            fp = _fingerprint(role, text, ts_for_fp)
+
+            # Item 3c — dedupe within the input batch. Two records with
+            # identical (role, text, ts) collapse to a single appended
+            # entry; without this, a stuttered cron emit could duplicate
+            # the turn N times within the same run.
+            if fp in seen_in_batch:
+                dropped += 1
+                continue
+            seen_in_batch.add(fp)
+
             turns.append({
                 "session_id": sid,
                 "role": role,
@@ -257,7 +378,7 @@ def extract_turns(
                 "fingerprint": fp,
             })
 
-    return turns, session_ids
+    return turns, session_ids, dropped
 
 
 # ----------------------------------------------------------------------
@@ -265,19 +386,79 @@ def extract_turns(
 # ----------------------------------------------------------------------
 
 
-def _read_meta_block(text: str) -> tuple[dict[str, Any], str]:
+def _read_meta_block(text: str) -> tuple[dict[str, Any], str, list[str], bool]:
+    """Parse the meta envelope.
+
+    Returns ``(meta, remainder, quarantined_lines, meta_was_corrupt)``.
+
+    ``quarantined_lines`` collects meta-region content that was NOT a
+    parseable bridge-daily-meta envelope but appeared above the title
+    (Item 2b). These are surfaced to the operator via the quarantine
+    block instead of leaking into the rendered body.
+
+    ``meta_was_corrupt`` is True when a marker was present but the JSON
+    failed to parse (or wasn't a dict). The caller treats this as a
+    signal that manifest recovery from the body should be attempted
+    (Item 1c).
+    """
     match = DAILY_META_RE.search(text)
-    if not match:
-        return {}, text
-    try:
-        meta = json.loads(match.group("json"))
-    except json.JSONDecodeError:
-        return {}, text
-    if not isinstance(meta, dict):
-        return {}, text
-    start, end = match.span(0)
-    remainder = text[:start] + text[end:].lstrip("\n")
-    return meta, remainder
+    if match:
+        raw_json = match.group("json")
+        try:
+            meta = json.loads(raw_json)
+            meta_corrupt = False
+        except json.JSONDecodeError:
+            meta = None
+            meta_corrupt = True
+        if not isinstance(meta, dict):
+            meta = None
+            meta_corrupt = True
+
+        start, end = match.span(0)
+        pre = text[:start]
+        post = text[end:].lstrip("\n")
+
+        # Item 2b — anything before the (first) meta marker that isn't
+        # blank is "stray meta-region content". Quarantine those lines
+        # so they don't bleed into the rendered body.
+        quarantined: list[str] = []
+        if pre.strip():
+            for line in pre.splitlines():
+                if line.strip():
+                    quarantined.append(line)
+
+        if meta_corrupt:
+            # Quarantine the corrupt meta marker itself so the operator
+            # can recover whatever was in there if needed.
+            quarantined.append(match.group(0))
+            meta = {}
+
+        return meta, post, quarantined, meta_corrupt
+
+    # No structured match. Item 2b — fall back to a line-level scan: if
+    # any line resembles a meta marker (``<!-- bridge-daily-meta:`` or
+    # the closing ``-->`` after one) it failed to parse cleanly, so we
+    # quarantine those lines and rebuild the envelope from scratch.
+    quarantined = []
+    cleaned_lines: list[str] = []
+    in_meta_remnant = False
+    for line in text.splitlines(keepends=True):
+        bare = line.rstrip("\n")
+        if bare.lstrip().startswith(DAILY_META_MARKER):
+            quarantined.append(bare)
+            # Track whether this line already closes the marker; if not,
+            # we'll keep collecting until we find ``-->``.
+            in_meta_remnant = " -->" not in bare
+            continue
+        if in_meta_remnant:
+            quarantined.append(bare)
+            if "-->" in bare:
+                in_meta_remnant = False
+            continue
+        cleaned_lines.append(line)
+    if quarantined:
+        return {}, "".join(cleaned_lines), quarantined, True
+    return {}, text, [], False
 
 
 def _render_meta_block(meta: dict[str, Any]) -> str:
@@ -297,8 +478,32 @@ def _split_sections(body: str) -> list[tuple[str | None, str]]:
     return parts
 
 
-def _parse_daily_note(text: str, date: str, agent: str) -> tuple[dict[str, Any], str, list[tuple[str | None, str]]]:
-    meta, body = _read_meta_block(text)
+def _strip_quarantine_block(body: str) -> tuple[str, list[str]]:
+    """Detach an existing quarantine block from ``body`` (if any).
+
+    Returns ``(body_without_quarantine, prior_quarantine_lines)``.
+    Idempotency: re-running on a previously quarantined note keeps the
+    quarantined content stable rather than re-wrapping it each pass.
+    """
+    match = QUARANTINE_RE.search(body)
+    if not match:
+        return body, []
+    inner = match.group("body").rstrip("\n").splitlines()
+    cleaned = body[: match.start()] + body[match.end():]
+    return cleaned, inner
+
+
+def _parse_daily_note(
+    text: str,
+    date: str,
+    agent: str,
+) -> tuple[dict[str, Any], str, list[tuple[str | None, str]], list[str], bool]:
+    meta, body, quarantined_lines, meta_corrupt = _read_meta_block(text)
+    # Detach any existing quarantine block from the bottom so we don't
+    # parse it as a body section / re-double-wrap it.
+    body, prior_quarantine = _strip_quarantine_block(body)
+    if prior_quarantine:
+        quarantined_lines = list(quarantined_lines) + list(prior_quarantine)
     title_match = re.match(r"^\s*(#\s[^\n]+)\n?", body)
     if title_match:
         title = title_match.group(1)
@@ -314,10 +519,15 @@ def _parse_daily_note(text: str, date: str, agent: str) -> tuple[dict[str, Any],
             "last_reconciled_at": _now_iso_utc(),
         }
     sections = _split_sections(body.lstrip("\n"))
-    return meta, title, sections
+    return meta, title, sections, quarantined_lines, meta_corrupt
 
 
-def _assemble_daily_note(title: str, meta: dict[str, Any], sections: list[tuple[str | None, str]]) -> str:
+def _assemble_daily_note(
+    title: str,
+    meta: dict[str, Any],
+    sections: list[tuple[str | None, str]],
+    quarantined_lines: list[str] | None = None,
+) -> str:
     chunks: list[str] = [_render_meta_block(meta), "", title.rstrip(), ""]
     rendered_preamble = False
     for session_id, text in sections:
@@ -331,7 +541,15 @@ def _assemble_daily_note(title: str, meta: dict[str, Any], sections: list[tuple[
         elif session_id is not None:
             chunks.append(text)
             chunks.append("")
-    return "\n".join(chunks).rstrip() + "\n"
+    body = "\n".join(chunks).rstrip() + "\n"
+    if quarantined_lines:
+        # Item 2b — append a clearly-delimited quarantine block at the
+        # very bottom so operators can recover hand-edits or malformed
+        # meta-region content the parser refused.
+        body += "\n" + QUARANTINE_OPEN + "\n"
+        body += "\n".join(quarantined_lines).rstrip("\n") + "\n"
+        body += QUARANTINE_CLOSE + "\n"
+    return body
 
 
 def _render_turn_block(idx: int, turn: dict[str, Any]) -> str:
@@ -378,8 +596,120 @@ def _atomic_write(path: Path, text: str) -> None:
 
 
 # ----------------------------------------------------------------------
+# concurrency lock (Item 2a + 7c)
+# ----------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def daily_note_lock(memory_dir: Path):
+    """Hold an exclusive ``fcntl.flock`` on a sentinel file in
+    ``memory_dir`` while the read/parse/render/write cycle runs.
+
+    Concurrent invocations (cron + Stop hook + ad-hoc operator firing in
+    the same second) serialise on this lock instead of clobbering each
+    other's updates with the atomic-rename pattern. The sentinel is a
+    sibling of the daily note — never the note itself, since the atomic
+    rename would invalidate any lock held on the note's inode.
+    """
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(memory_dir, 0o700)
+    except OSError:
+        pass
+    lock_path = memory_dir / ".daily-note-reconcile.lock"
+    fp = open(lock_path, "w")
+    try:
+        fcntl.flock(fp.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(fp.fileno(), fcntl.LOCK_UN)
+    finally:
+        fp.close()
+
+
+# ----------------------------------------------------------------------
+# manifest recovery (Item 1c + 3b)
+# ----------------------------------------------------------------------
+
+
+def recover_manifest_from_body(
+    sections: list[tuple[str | None, str]],
+    target_session: str,
+) -> list[str]:
+    """Re-fingerprint already-rendered turn blocks for ``target_session``
+    so a missing/corrupt manifest doesn't cause duplicate-on-first-run.
+
+    The renderer writes ``### turn N · <role> · <iso-ts>\\n\\n<text>\\n``
+    blocks. We walk the body of the matching session section, extract
+    each block's ``role`` + ``text`` + ``ts``, and recompute the same
+    fingerprint the extractor would emit.
+
+    Best-effort: if a block doesn't parse cleanly we skip it and keep
+    going. The caller should treat the returned list as a *floor*, not
+    a guarantee — first re-run after recovery may still append a turn
+    that the extractor parses slightly differently than the body
+    rendering. That's a one-time event; subsequent runs stabilise.
+    """
+    fingerprints: list[str] = []
+    for sid, body in sections:
+        if sid != target_session:
+            continue
+        # Find every "### turn N · role · ts" header inside this section.
+        matches = list(DAILY_TURN_HEADER_RE.finditer(body))
+        for i, m in enumerate(matches):
+            role = m.group("role").strip()
+            ts = m.group("ts").strip()
+            block_start = m.end()
+            block_end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+            text = body[block_start:block_end].strip("\n").rstrip()
+            # Strip the leading blank line emitted by _render_turn_block.
+            text = text.lstrip("\n")
+            fingerprints.append(_fingerprint(role, text, ts))
+    return fingerprints
+
+
+# ----------------------------------------------------------------------
 # core reconcile
 # ----------------------------------------------------------------------
+
+
+def _manifest_total(manifest: dict[str, list[str]]) -> int:
+    return sum(len(v) for v in manifest.values())
+
+
+def _empty_result(
+    agent: str,
+    date: str,
+    note_path: Path,
+    jsonl_path: Path,
+    memory_dir: Path,
+    dry_run: bool,
+    warnings: list[str],
+) -> dict[str, Any]:
+    return {
+        "status": "ok",
+        "outcome": "noop",
+        "agent": agent,
+        "date": date,
+        "session_id": "",
+        "jsonl": str(jsonl_path),
+        "memory_dir": str(memory_dir),
+        "note_path": str(note_path),
+        "turns_total": 0,
+        "turns_filtered": 0,
+        "turns_new": 0,
+        "manifest_size_before": 0,
+        "manifest_size_after": 0,
+        "sessions": [],
+        "applied": "noop",
+        "dry_run": dry_run,
+        "no_turns": True,
+        "diff": "",
+        "human_summary": f"noop agent={agent} date={date} turns_new=0 note={note_path}",
+        "warnings": warnings,
+        "error": None,
+    }
 
 
 def reconcile(
@@ -391,170 +721,261 @@ def reconcile(
     verbose: bool,
 ) -> dict[str, Any]:
     note_path = memory_dir / f"{date}.md"
+    warnings: list[str] = []
 
-    turns, sessions_in_jsonl = extract_turns(jsonl_path, date, verbose=verbose)
+    turns, sessions_in_jsonl, dropped = extract_turns(
+        jsonl_path, date, verbose=verbose, warnings=warnings,
+    )
 
     if not turns:
         sys.stderr.write(f"no turns for {date} in {jsonl_path}\n")
-        return {
-            "status": "ok",
-            "agent": agent,
-            "date": date,
-            "note_path": str(note_path),
-            "turns_total": 0,
-            "turns_new": 0,
-            "sessions": [],
-            "applied": "noop",
-            "dry_run": dry_run,
-            "no_turns": True,
-        }
+        result = _empty_result(agent, date, note_path, jsonl_path, memory_dir, dry_run, warnings)
+        result["turns_filtered"] = dropped
+        return result
 
-    # Read existing daily note (may not exist).
-    if note_path.exists():
-        existing_text = note_path.read_text(encoding="utf-8")
-    else:
-        existing_text = ""
+    # Item 2a + 7c — hold an exclusive flock on a memory_dir-local
+    # sentinel so concurrent reconciles don't lose each others' updates.
+    with daily_note_lock(memory_dir):
+        # Read existing daily note (may not exist).
+        if note_path.exists():
+            existing_text = note_path.read_text(encoding="utf-8")
+        else:
+            existing_text = ""
 
-    if existing_text:
-        meta, title, sections = _parse_daily_note(existing_text, date, agent)
-    else:
-        meta = {
-            "schema_version": 1,
-            "session_ids": [],
-            "writer_mix": {},
-            "reconciled_fingerprints": {},
-            "last_reconciled_at": _now_iso_utc(),
-        }
-        title = f"# {date} — {agent}"
-        sections = []
+        quarantined_lines: list[str] = []
+        meta_corrupt = False
+        if existing_text:
+            meta, title, sections, quarantined_lines, meta_corrupt = _parse_daily_note(
+                existing_text, date, agent,
+            )
+        else:
+            meta = {
+                "schema_version": 1,
+                "session_ids": [],
+                "writer_mix": {},
+                "reconciled_fingerprints": {},
+                "last_reconciled_at": _now_iso_utc(),
+            }
+            title = f"# {date} — {agent}"
+            sections = []
 
-    # Tolerate corrupt manifest fields.
-    raw_manifest = meta.get("reconciled_fingerprints")
-    if not isinstance(raw_manifest, dict):
-        _eprint(verbose, "manifest malformed — treating as empty")
-        raw_manifest = {}
-    manifest: dict[str, list[str]] = {}
-    for k, v in raw_manifest.items():
-        if isinstance(k, str) and isinstance(v, list):
-            manifest[k] = [str(x) for x in v if isinstance(x, (str, int))]
+        if meta_corrupt:
+            msg = "meta envelope corrupt — rebuilding from manifest recovery"
+            _warn(msg)
+            warnings.append(msg)
 
-    session_ids = list(meta.get("session_ids") or [])
-    writer_mix = dict(meta.get("writer_mix") or {})
+        # Tolerate corrupt manifest fields.
+        raw_manifest = meta.get("reconciled_fingerprints")
+        manifest_was_invalid = not isinstance(raw_manifest, dict)
+        if manifest_was_invalid:
+            _eprint(verbose, "manifest malformed — treating as empty")
+            raw_manifest = {}
+        manifest: dict[str, list[str]] = {}
+        for k, v in raw_manifest.items():
+            if isinstance(k, str) and isinstance(v, list):
+                manifest[k] = [str(x) for x in v if isinstance(x, (str, int))]
 
-    # Group turns by session_id, in jsonl order.
-    by_session: dict[str, list[dict[str, Any]]] = {}
-    for t in turns:
-        by_session.setdefault(t["session_id"], []).append(t)
+        manifest_size_before = _manifest_total(manifest)
 
-    # Determine new turns per session.
-    new_turn_count = 0
-    sessions_summary: list[dict[str, Any]] = []
-    for sid in sessions_in_jsonl:
-        existing_fps = set(manifest.get(sid, []))
-        session_turns = by_session.get(sid, [])
-        new_turns = [t for t in session_turns if t["fingerprint"] not in existing_fps]
+        session_ids = list(meta.get("session_ids") or [])
+        writer_mix = dict(meta.get("writer_mix") or {})
 
-        if not new_turns:
+        # Group turns by session_id, in jsonl order.
+        by_session: dict[str, list[dict[str, Any]]] = {}
+        for t in turns:
+            by_session.setdefault(t["session_id"], []).append(t)
+
+        # Determine new turns per session.
+        new_turn_count = 0
+        recovered_any = False
+        sessions_summary: list[dict[str, Any]] = []
+        for sid in sessions_in_jsonl:
+            # Item 1c + 3b — if the manifest is missing/corrupt for this
+            # session BUT the body already has rendered turn blocks,
+            # rebuild the manifest from the body before treating any
+            # turn as "new". Without this, the first run after a manifest
+            # loss duplicates every turn.
+            session_manifest = manifest.get(sid)
+            if (not session_manifest) and existing_text and sections:
+                recovered = recover_manifest_from_body(sections, sid)
+                if recovered:
+                    msg = (
+                        f"recovered {len(recovered)} fingerprint(s) from body "
+                        f"for session {sid}"
+                    )
+                    _warn(msg)
+                    warnings.append(msg)
+                    manifest[sid] = list(recovered)
+                    recovered_any = True
+
+            existing_fps = set(manifest.get(sid, []))
+            session_turns = by_session.get(sid, [])
+            new_turns = [t for t in session_turns if t["fingerprint"] not in existing_fps]
+
+            if not new_turns:
+                sessions_summary.append({
+                    "session_id": sid,
+                    "turns_in_jsonl": len(session_turns),
+                    "turns_new": 0,
+                })
+                continue
+
+            # Find existing section for this session (if any) and append new
+            # turn blocks. Otherwise create a new section.
+            existing_section_idx: int | None = None
+            for idx, (existing_sid, _text) in enumerate(sections):
+                if existing_sid == sid:
+                    existing_section_idx = idx
+                    break
+
+            if existing_section_idx is None:
+                # Build full section from scratch — number turns from 1.
+                section_text = _build_section_text(sid, new_turns)
+                sections.append((sid, section_text))
+                if sid not in session_ids:
+                    session_ids.append(sid)
+                writer_mix[WRITER_LABEL] = writer_mix.get(WRITER_LABEL, 0) + 1
+            else:
+                # Count existing ### turn blocks under this section to keep
+                # numbering monotonic across re-runs.
+                _existing_sid, existing_section_text = sections[existing_section_idx]
+                existing_turn_count = len(re.findall(
+                    r"^### turn \d+\s+·", existing_section_text, re.MULTILINE,
+                ))
+                appended_blocks = []
+                for offset, turn in enumerate(new_turns, start=1):
+                    appended_blocks.append(_render_turn_block(existing_turn_count + offset, turn))
+                updated_text = (
+                    existing_section_text.rstrip("\n")
+                    + "\n\n"
+                    + "\n".join(appended_blocks).rstrip()
+                    + "\n"
+                )
+                sections[existing_section_idx] = (sid, updated_text)
+
+            # Extend the manifest.
+            manifest.setdefault(sid, []).extend(t["fingerprint"] for t in new_turns)
+            new_turn_count += len(new_turns)
             sessions_summary.append({
                 "session_id": sid,
                 "turns_in_jsonl": len(session_turns),
-                "turns_new": 0,
+                "turns_new": len(new_turns),
             })
-            continue
 
-        # Find existing section for this session (if any) and append new
-        # turn blocks. Otherwise create a new section.
-        existing_section_idx: int | None = None
-        for idx, (existing_sid, _text) in enumerate(sections):
-            if existing_sid == sid:
-                existing_section_idx = idx
-                break
+        # Update meta.
+        meta["schema_version"] = meta.get("schema_version", 1)
+        meta["session_ids"] = session_ids
+        meta["writer_mix"] = writer_mix
+        meta["reconciled_fingerprints"] = manifest
+        meta["last_reconciled_at"] = _now_iso_utc()
 
-        if existing_section_idx is None:
-            # Build full section from scratch — number turns from 1.
-            section_text = _build_section_text(sid, new_turns)
-            sections.append((sid, section_text))
-            if sid not in session_ids:
-                session_ids.append(sid)
-            writer_mix[WRITER_LABEL] = writer_mix.get(WRITER_LABEL, 0) + 1
-        else:
-            # Count existing ### turn blocks under this section to keep
-            # numbering monotonic across re-runs.
-            _existing_sid, existing_text = sections[existing_section_idx]
-            existing_turn_count = len(re.findall(r"^### turn \d+\s+·", existing_text, re.MULTILINE))
-            appended_blocks = []
-            for offset, turn in enumerate(new_turns, start=1):
-                appended_blocks.append(_render_turn_block(existing_turn_count + offset, turn))
-            updated_text = existing_text.rstrip("\n") + "\n\n" + "\n".join(appended_blocks).rstrip() + "\n"
-            sections[existing_section_idx] = (sid, updated_text)
+        new_text = _assemble_daily_note(title, meta, sections, quarantined_lines)
 
-        # Extend the manifest.
-        manifest.setdefault(sid, []).extend(t["fingerprint"] for t in new_turns)
-        new_turn_count += len(new_turns)
-        sessions_summary.append({
-            "session_id": sid,
-            "turns_in_jsonl": len(session_turns),
-            "turns_new": len(new_turns),
-        })
-
-    # Update meta.
-    meta["schema_version"] = meta.get("schema_version", 1)
-    meta["session_ids"] = session_ids
-    meta["writer_mix"] = writer_mix
-    meta["reconciled_fingerprints"] = manifest
-    meta["last_reconciled_at"] = _now_iso_utc()
-
-    new_text = _assemble_daily_note(title, meta, sections)
-
-    # Decide outcome.
-    if new_turn_count == 0:
-        applied = "noop"
-    elif existing_text:
-        applied = "updated"
-    else:
-        applied = "created"
-
-    if dry_run:
-        if existing_text == new_text:
-            sys.stdout.write("no changes\n")
-        else:
-            diff = difflib.unified_diff(
-                existing_text.splitlines(keepends=True),
-                new_text.splitlines(keepends=True),
-                fromfile=str(note_path) + ".old",
-                tofile=str(note_path) + ".new",
-                lineterm="",
+        if quarantined_lines:
+            msg = (
+                f"quarantined {len(quarantined_lines)} stray meta-region line(s); "
+                f"see <!-- daily-note-reconcile-quarantine --> block in {note_path}"
             )
-            sys.stdout.write("".join(diff))
-            if not new_text.endswith("\n"):
-                sys.stdout.write("\n")
+            _warn(msg)
+            warnings.append(msg)
+
+        manifest_size_after = _manifest_total(manifest)
+
+        # Decide outcome.
+        if new_turn_count == 0:
+            applied = "noop"
+        elif existing_text:
+            applied = "updated"
+        else:
+            applied = "created"
+
+        # If we touched the file purely to add a quarantine block, fix
+        # a corrupt meta envelope, or persist a recovered manifest, treat
+        # that as "updated" so the operator can see the change AND so we
+        # don't skip the write below (which would leave the recovery
+        # in-memory only and re-trigger on the next run).
+        if applied == "noop" and existing_text and (
+            quarantined_lines or meta_corrupt or recovered_any
+        ):
+            if existing_text != new_text or recovered_any:
+                applied = "updated"
+
+        primary_session = sessions_in_jsonl[0] if sessions_in_jsonl else ""
+
+        if dry_run:
+            diff_text = ""
+            if existing_text == new_text:
+                # Note: human prose moved to human_summary / stderr in the
+                # JSON path. Keep the legacy text path for human callers.
+                pass
+            else:
+                diff_text = "".join(difflib.unified_diff(
+                    existing_text.splitlines(keepends=True),
+                    new_text.splitlines(keepends=True),
+                    fromfile=str(note_path) + ".old",
+                    tofile=str(note_path) + ".new",
+                    lineterm="",
+                ))
+                if diff_text and not diff_text.endswith("\n"):
+                    diff_text += "\n"
+            human_summary = (
+                f"dry-run agent={agent} date={date} "
+                f"turns_new={new_turn_count} note={note_path}"
+            )
+            return {
+                "status": "ok",
+                "outcome": "dry-run",
+                "agent": agent,
+                "date": date,
+                "session_id": primary_session,
+                "jsonl": str(jsonl_path),
+                "memory_dir": str(memory_dir),
+                "note_path": str(note_path),
+                "turns_total": len(turns),
+                "turns_filtered": dropped,
+                "turns_new": new_turn_count,
+                "manifest_size_before": manifest_size_before,
+                "manifest_size_after": manifest_size_after,
+                "sessions": sessions_summary,
+                "applied": applied,
+                "dry_run": True,
+                "diff": diff_text,
+                "human_summary": human_summary,
+                "warnings": warnings,
+                "error": None,
+            }
+
+        if applied != "noop":
+            _ensure_memory_dir(memory_dir)
+            _atomic_write(note_path, new_text)
+
+        outcome = "merged" if applied != "noop" else "noop"
+        human_summary = (
+            f"{applied} agent={agent} date={date} "
+            f"turns_new={new_turn_count} note={note_path}"
+        )
         return {
             "status": "ok",
+            "outcome": outcome,
             "agent": agent,
             "date": date,
+            "session_id": primary_session,
+            "jsonl": str(jsonl_path),
+            "memory_dir": str(memory_dir),
             "note_path": str(note_path),
             "turns_total": len(turns),
+            "turns_filtered": dropped,
             "turns_new": new_turn_count,
+            "manifest_size_before": manifest_size_before,
+            "manifest_size_after": manifest_size_after,
             "sessions": sessions_summary,
             "applied": applied,
-            "dry_run": True,
+            "dry_run": False,
+            "diff": "",
+            "human_summary": human_summary,
+            "warnings": warnings,
+            "error": None,
         }
-
-    if applied != "noop":
-        _ensure_memory_dir(memory_dir)
-        _atomic_write(note_path, new_text)
-
-    return {
-        "status": "ok",
-        "agent": agent,
-        "date": date,
-        "note_path": str(note_path),
-        "turns_total": len(turns),
-        "turns_new": new_turn_count,
-        "sessions": sessions_summary,
-        "applied": applied,
-        "dry_run": False,
-    }
 
 
 # ----------------------------------------------------------------------
@@ -562,18 +983,95 @@ def reconcile(
 # ----------------------------------------------------------------------
 
 
-def _resolve_memory_dir(args: argparse.Namespace) -> Path:
-    if args.memory_dir:
-        return Path(args.memory_dir).expanduser()
-    # Default: agents/<agent>/memory/ relative to bridge home.
-    bridge_home = os.environ.get("BRIDGE_HOME") or str(Path.home() / ".agent-bridge")
+def _sanitize_agent_id(raw: str) -> str:
+    """Allowlist ``[A-Za-z0-9_-]{1,64}`` for --agent (Item 6).
+
+    Rejects path traversal payloads (``..``), separators (``/``, ``\\``),
+    whitespace, and unicode lookalikes. Raised ``ValueError`` is caught
+    in ``main`` and surfaced as a non-zero exit + stderr message
+    (matching the existing CLI failure shape).
+    """
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("agent id required")
+    if len(raw) > AGENT_ID_MAX_LEN:
+        raise ValueError(f"agent id too long (>{AGENT_ID_MAX_LEN} chars)")
+    if not AGENT_ID_RE.match(raw):
+        # Truncate echoed value to keep error logs bounded.
+        raise ValueError(
+            f"agent id invalid (must match [A-Za-z0-9_-]+): {raw[:50]!r}"
+        )
+    return raw
+
+
+def _bridge_home(args: argparse.Namespace) -> Path:
+    """Resolve the bridge runtime root used as the path-traversal anchor.
+
+    Honours ``--transcripts-home`` (PR #426 Track C parity), then
+    ``BRIDGE_HOME``, then ``~/.agent-bridge``. The returned path is
+    always ``Path.resolve()``'d so the relative-to check below is
+    symlink-stable.
+    """
     if args.transcripts_home:
-        # PR #426 Track C parity: when an isolated agent's transcripts
-        # live under a different home, the daily note typically lives
-        # under that same home's bridge tree. Caller can override
-        # explicitly via --memory-dir; this is a soft default.
-        bridge_home = str(Path(args.transcripts_home).expanduser() / ".agent-bridge")
-    return Path(bridge_home) / "agents" / args.agent / "memory"
+        return (Path(args.transcripts_home).expanduser() / ".agent-bridge").resolve()
+    raw = os.environ.get("BRIDGE_HOME")
+    if raw:
+        return Path(raw).expanduser().resolve()
+    return (Path.home() / ".agent-bridge").resolve()
+
+
+def _resolve_memory_dir(args: argparse.Namespace, agent: str) -> Path:
+    """Resolve the daily-note directory.
+
+    Default: ``<BRIDGE_HOME>/agents/<agent>/memory``. If ``--memory-dir``
+    is provided, the resolved path MUST live inside the resolved bridge
+    home (Item 6 — closes ``--memory-dir /etc/passwd``-style escapes).
+    Raises ``ValueError`` on a containment violation.
+    """
+    bridge_root = _bridge_home(args)
+    if not args.memory_dir:
+        return bridge_root / "agents" / agent / "memory"
+    candidate = Path(args.memory_dir).expanduser().resolve()
+    try:
+        candidate.relative_to(bridge_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"--memory-dir must resolve within BRIDGE_HOME ({bridge_root}); "
+            f"got {candidate}"
+        ) from exc
+    return candidate
+
+
+def _emit_json_error(jsonl_path: str, agent: str, date: str, message: str) -> None:
+    """Print a stable JSON error envelope to stdout (Item 9c).
+
+    Used when ``--json`` is set and a CLI / argument validation failure
+    would otherwise emit prose to stderr only. We still mirror the
+    message to stderr for human callers.
+    """
+    payload = {
+        "status": "error",
+        "outcome": "error",
+        "agent": agent,
+        "date": date,
+        "session_id": "",
+        "jsonl": jsonl_path,
+        "memory_dir": "",
+        "note_path": "",
+        "turns_total": 0,
+        "turns_filtered": 0,
+        "turns_new": 0,
+        "manifest_size_before": 0,
+        "manifest_size_after": 0,
+        "sessions": [],
+        "applied": "noop",
+        "dry_run": False,
+        "diff": "",
+        "human_summary": message,
+        "warnings": [],
+        "error": message,
+    }
+    sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+    sys.stderr.write(message + "\n")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -607,36 +1105,67 @@ def main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    if not args.agent.strip():
-        sys.stderr.write("agent name is empty\n")
+    # Item 6 — sanitize agent id BEFORE we use it in any path. We pass
+    # ``args.agent`` (raw) into the JSON error envelope so the operator
+    # can correlate, then bail.
+    try:
+        agent = _sanitize_agent_id(args.agent)
+    except ValueError as exc:
+        if args.json:
+            _emit_json_error(args.jsonl, args.agent or "", args.date or "", str(exc))
+        else:
+            sys.stderr.write(str(exc) + "\n")
         return 2
 
     date = args.date or _today_utc()
     if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
-        sys.stderr.write(f"invalid --date {date!r} (expected YYYY-MM-DD)\n")
+        msg = f"invalid --date {date!r} (expected YYYY-MM-DD)"
+        if args.json:
+            _emit_json_error(args.jsonl, agent, args.date or "", msg)
+        else:
+            sys.stderr.write(msg + "\n")
         return 2
 
     jsonl_path = Path(args.jsonl).expanduser()
     if not jsonl_path.exists():
-        sys.stderr.write(f"jsonl not found: {jsonl_path}\n")
+        msg = f"jsonl not found: {jsonl_path}"
+        if args.json:
+            _emit_json_error(str(jsonl_path), agent, date, msg)
+        else:
+            sys.stderr.write(msg + "\n")
         return 2
     if not jsonl_path.is_file():
-        sys.stderr.write(f"jsonl is not a file: {jsonl_path}\n")
+        msg = f"jsonl is not a file: {jsonl_path}"
+        if args.json:
+            _emit_json_error(str(jsonl_path), agent, date, msg)
+        else:
+            sys.stderr.write(msg + "\n")
         return 2
     try:
         # Touch readability without slurping the whole file.
         with jsonl_path.open("rb") as _probe:
             _probe.read(1)
     except OSError:
-        # Do NOT echo the path beyond this — minimal info leak.
-        sys.stderr.write("jsonl unreadable\n")
+        msg = "jsonl unreadable"
+        if args.json:
+            _emit_json_error(str(jsonl_path), agent, date, msg)
+        else:
+            # Do NOT echo the path beyond this — minimal info leak.
+            sys.stderr.write(msg + "\n")
         return 2
 
-    memory_dir = _resolve_memory_dir(args)
+    try:
+        memory_dir = _resolve_memory_dir(args, agent)
+    except ValueError as exc:
+        if args.json:
+            _emit_json_error(str(jsonl_path), agent, date, str(exc))
+        else:
+            sys.stderr.write(str(exc) + "\n")
+        return 2
 
     try:
         result = reconcile(
-            agent=args.agent,
+            agent=agent,
             jsonl_path=jsonl_path,
             date=date,
             memory_dir=memory_dir,
@@ -644,16 +1173,35 @@ def main(argv: list[str] | None = None) -> int:
             verbose=args.verbose,
         )
     except OSError as exc:
-        sys.stderr.write(f"reconcile write failed: {exc}\n")
+        msg = f"reconcile write failed: {exc}"
+        if args.json:
+            _emit_json_error(str(jsonl_path), agent, date, msg)
+        else:
+            sys.stderr.write(msg + "\n")
         return 2
 
+    # Item 9c — when --json is set, stdout is one parseable JSON document.
+    # Human-readable summary / diff goes into the JSON body
+    # (``human_summary`` + ``diff``). Diffs in the legacy ``--dry-run``
+    # (no --json) path still print to stdout for human callers.
     if args.json:
         sys.stdout.write(json.dumps(result, ensure_ascii=False) + "\n")
-    else:
-        sys.stdout.write(
-            f"{result['applied']} agent={result['agent']} date={result['date']} "
-            f"turns_new={result['turns_new']} note={result['note_path']}\n"
-        )
+        return 0
+
+    if args.dry_run:
+        diff_text = result.get("diff") or ""
+        if diff_text:
+            sys.stdout.write(diff_text)
+            if not diff_text.endswith("\n"):
+                sys.stdout.write("\n")
+        else:
+            sys.stdout.write("no changes\n")
+        return 0
+
+    sys.stdout.write(
+        f"{result['applied']} agent={result['agent']} date={result['date']} "
+        f"turns_new={result['turns_new']} note={result['note_path']}\n"
+    )
 
     return 0
 

--- a/scripts/daily-note-reconcile.py
+++ b/scripts/daily-note-reconcile.py
@@ -1,0 +1,662 @@
+#!/usr/bin/env python3
+"""daily-note-reconcile.py — idempotent jsonl→daily-note merger.
+
+PR-1 of 4 in the issue #390 memory-pipeline rewiring sequence.
+
+Reads a single Claude session jsonl transcript, extracts the meaningful
+conversation turns for a target date, and merges them into the agent's
+daily note at ``<memory-dir>/<YYYY-MM-DD>.md`` idempotently.
+
+The script is a thin entrypoint: callers (Stop hook in PR-2, cron payload
+rewrite in PR-3, ad-hoc operator invocation) pass the jsonl path
+explicitly. PR-1 does NOT discover sessions on its own.
+
+Daily note format
+-----------------
+We re-use the section convention already established by
+``bridge-memory.py daily-append``:
+
+* A ``<!-- bridge-daily-meta: {...} -->`` block on line 1 (JSON meta).
+* A ``# YYYY-MM-DD — <agent>`` H1 title.
+* One ``## Session <session_id> — <writer>`` H2 per session.
+* Below each H2 we render ``### turn <N> · <role> · <iso-ts>`` H3
+  blocks holding the turn text.
+
+Idempotency contract
+--------------------
+The meta block carries a ``reconciled_fingerprints`` map keyed by
+session_id whose value is a list of per-turn sha1 fingerprints already
+merged. On each run we recompute fingerprints from the jsonl, diff
+against the manifest, and emit ONLY the new turns. Re-running with the
+same (agent, jsonl, date) is a no-op (mtime may bump; content is byte
+stable). A hand-edit that corrupts the manifest is tolerated — we treat
+the corrupt entry as ``no fingerprints known`` and proceed; the next run
+will re-stabilise.
+
+Date interpretation
+-------------------
+``--date YYYY-MM-DD`` is interpreted in **UTC**. Claude session jsonl
+timestamps are emitted in ISO-8601 with a ``Z`` suffix (UTC), and we
+match against UTC day boundaries. Operators who want local-day boundary
+behaviour pass the local day explicitly.
+
+Turn extraction filters
+-----------------------
+* Include: assistant ``text`` blocks; user ``text``/``str`` content that
+  is NOT one of Claude's scaffolding wrappers
+  (``<local-command-…>``, ``<system-reminder>``, ``<command-name>``…).
+* Exclude: assistant ``thinking`` (internal reasoning, not
+  operator-visible); ``tool_use`` blocks (the operator can read the
+  jsonl for tool transcripts); ``tool_result`` blocks (often huge,
+  low-signal).
+* Long turns are truncated to 2000 head + 500 tail with a
+  ``[... truncated, see jsonl ...]`` marker.
+
+Caller contract
+---------------
+* rc=0 on success (including "no turns for date" — informational).
+* rc=2 on jsonl missing/unreadable, bad CLI args, or write failure.
+* JSON summary on stdout when ``--json`` is set.
+* ``--dry-run`` prints unified diff (or "no changes") and never writes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import difflib
+import hashlib
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+DAILY_META_MARKER = "<!-- bridge-daily-meta: "
+DAILY_META_END = " -->"
+DAILY_META_RE = re.compile(
+    r"^<!-- bridge-daily-meta: (?P<json>\{.*\}) -->\s*$",
+    re.MULTILINE,
+)
+DAILY_SECTION_HEADER_RE = re.compile(
+    r"^## Session (?P<session>[A-Za-z0-9_-]+)(?P<tail>.*)$",
+    re.MULTILINE,
+)
+
+# Wrappers Claude emits for non-conversation scaffolding. These appear
+# inside string user content but are not what the operator typed.
+SCAFFOLDING_PREFIXES = (
+    "<local-command-",
+    "<system-reminder>",
+    "<command-name>",
+    "<command-message>",
+    "<command-args>",
+    "<bash-input>",
+    "<bash-stdout>",
+    "<bash-stderr>",
+)
+
+WRITER_LABEL = "reconcile"
+TURN_HEAD_LIMIT = 2000
+TURN_TAIL_LIMIT = 500
+TRUNCATION_MARKER = "\n\n[... truncated, see jsonl ...]\n\n"
+
+
+# ----------------------------------------------------------------------
+# helpers
+# ----------------------------------------------------------------------
+
+
+def _eprint(verbose: bool, *parts: Any) -> None:
+    if verbose:
+        sys.stderr.write("[daily-note-reconcile] " + " ".join(str(p) for p in parts) + "\n")
+
+
+def _today_utc() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+
+
+def _now_iso_utc() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso_ts(raw: str) -> _dt.datetime | None:
+    """Parse ISO-8601 with trailing ``Z`` (Claude jsonl convention)."""
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        # ``fromisoformat`` accepts ``+00:00`` but not ``Z`` until 3.11.
+        norm = raw.replace("Z", "+00:00")
+        ts = _dt.datetime.fromisoformat(norm)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=_dt.timezone.utc)
+        return ts.astimezone(_dt.timezone.utc)
+    except ValueError:
+        return None
+
+
+def _date_of(ts: _dt.datetime | None) -> str | None:
+    if ts is None:
+        return None
+    return ts.strftime("%Y-%m-%d")
+
+
+def _is_scaffolding(text: str) -> bool:
+    s = text.lstrip()
+    return any(s.startswith(p) for p in SCAFFOLDING_PREFIXES)
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= TURN_HEAD_LIMIT + TURN_TAIL_LIMIT + len(TRUNCATION_MARKER):
+        return text
+    head = text[:TURN_HEAD_LIMIT].rstrip()
+    tail = text[-TURN_TAIL_LIMIT:].lstrip()
+    return f"{head}{TRUNCATION_MARKER}{tail}"
+
+
+def _fingerprint(role: str, text: str, ts_raw: str) -> str:
+    h = hashlib.sha1()
+    h.update(role.encode("utf-8"))
+    h.update(b"\x1f")
+    h.update(text.encode("utf-8"))
+    h.update(b"\x1f")
+    h.update((ts_raw or "").encode("utf-8"))
+    return h.hexdigest()[:16]  # 16 hex chars is plenty; keeps manifest small
+
+
+# ----------------------------------------------------------------------
+# jsonl extraction
+# ----------------------------------------------------------------------
+
+
+def extract_turns(
+    jsonl_path: Path,
+    target_date: str,
+    verbose: bool = False,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Return (turns, session_ids_seen).
+
+    Each turn is a dict with: ``session_id``, ``role``, ``text``,
+    ``timestamp`` (raw string), ``timestamp_iso`` (parsed UTC ISO),
+    ``fingerprint``.
+
+    Malformed lines are skipped (with a warning when verbose).
+    """
+    turns: list[dict[str, Any]] = []
+    session_ids: list[str] = []
+    seen_sids: set[str] = set()
+
+    with jsonl_path.open("r", encoding="utf-8", errors="replace") as fh:
+        for lineno, raw_line in enumerate(fh, start=1):
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+            try:
+                rec = json.loads(raw_line)
+            except json.JSONDecodeError as exc:
+                _eprint(verbose, f"skip line {lineno}: {exc}")
+                continue
+            if not isinstance(rec, dict):
+                continue
+
+            rec_type = rec.get("type")
+            if rec_type not in ("user", "assistant"):
+                continue
+
+            ts_raw = rec.get("timestamp") or ""
+            ts = _parse_iso_ts(ts_raw)
+            day = _date_of(ts)
+            if day != target_date:
+                continue
+
+            sid = rec.get("sessionId") or ""
+            if not sid:
+                continue
+            if sid not in seen_sids:
+                seen_sids.add(sid)
+                session_ids.append(sid)
+
+            msg = rec.get("message")
+            if not isinstance(msg, dict):
+                continue
+            role = msg.get("role") or rec_type
+            content = msg.get("content")
+
+            text_chunks: list[str] = []
+            if isinstance(content, str):
+                if not _is_scaffolding(content):
+                    text_chunks.append(content)
+            elif isinstance(content, list):
+                for blk in content:
+                    if not isinstance(blk, dict):
+                        continue
+                    btype = blk.get("type")
+                    if btype == "text":
+                        t = blk.get("text") or ""
+                        if t and not _is_scaffolding(t):
+                            text_chunks.append(t)
+                    # thinking, tool_use, tool_result intentionally skipped.
+            if not text_chunks:
+                continue
+
+            text = "\n\n".join(c.strip() for c in text_chunks if c.strip())
+            if not text:
+                continue
+            text = _truncate(text)
+
+            fp = _fingerprint(role, text, ts_raw)
+            turns.append({
+                "session_id": sid,
+                "role": role,
+                "text": text,
+                "timestamp": ts_raw,
+                "timestamp_iso": ts.isoformat() if ts else "",
+                "fingerprint": fp,
+            })
+
+    return turns, session_ids
+
+
+# ----------------------------------------------------------------------
+# daily note read / parse / assemble
+# ----------------------------------------------------------------------
+
+
+def _read_meta_block(text: str) -> tuple[dict[str, Any], str]:
+    match = DAILY_META_RE.search(text)
+    if not match:
+        return {}, text
+    try:
+        meta = json.loads(match.group("json"))
+    except json.JSONDecodeError:
+        return {}, text
+    if not isinstance(meta, dict):
+        return {}, text
+    start, end = match.span(0)
+    remainder = text[:start] + text[end:].lstrip("\n")
+    return meta, remainder
+
+
+def _render_meta_block(meta: dict[str, Any]) -> str:
+    return DAILY_META_MARKER + json.dumps(meta, ensure_ascii=False) + DAILY_META_END
+
+
+def _split_sections(body: str) -> list[tuple[str | None, str]]:
+    parts: list[tuple[str | None, str]] = []
+    last_idx = 0
+    last_session: str | None = None
+    for match in DAILY_SECTION_HEADER_RE.finditer(body):
+        if match.start() > last_idx:
+            parts.append((last_session, body[last_idx:match.start()]))
+        last_session = match.group("session")
+        last_idx = match.start()
+    parts.append((last_session, body[last_idx:]))
+    return parts
+
+
+def _parse_daily_note(text: str, date: str, agent: str) -> tuple[dict[str, Any], str, list[tuple[str | None, str]]]:
+    meta, body = _read_meta_block(text)
+    title_match = re.match(r"^\s*(#\s[^\n]+)\n?", body)
+    if title_match:
+        title = title_match.group(1)
+        body = body[title_match.end():]
+    else:
+        title = f"# {date} — {agent}"
+    if not meta:
+        meta = {
+            "schema_version": 1,
+            "session_ids": [],
+            "writer_mix": {},
+            "reconciled_fingerprints": {},
+            "last_reconciled_at": _now_iso_utc(),
+        }
+    sections = _split_sections(body.lstrip("\n"))
+    return meta, title, sections
+
+
+def _assemble_daily_note(title: str, meta: dict[str, Any], sections: list[tuple[str | None, str]]) -> str:
+    chunks: list[str] = [_render_meta_block(meta), "", title.rstrip(), ""]
+    rendered_preamble = False
+    for session_id, text in sections:
+        text = text.rstrip("\n")
+        if not text.strip():
+            continue
+        if session_id is None and not rendered_preamble:
+            chunks.append(text)
+            chunks.append("")
+            rendered_preamble = True
+        elif session_id is not None:
+            chunks.append(text)
+            chunks.append("")
+    return "\n".join(chunks).rstrip() + "\n"
+
+
+def _render_turn_block(idx: int, turn: dict[str, Any]) -> str:
+    role = turn["role"]
+    ts = turn.get("timestamp_iso") or turn.get("timestamp") or ""
+    body = turn["text"].rstrip()
+    return f"### turn {idx} · {role} · {ts}\n\n{body}\n"
+
+
+def _build_section_text(session_id: str, ordered_turns: list[dict[str, Any]]) -> str:
+    header = f"## Session {session_id} — {WRITER_LABEL}"
+    if not ordered_turns:
+        return header + "\n"
+    parts = [header, ""]
+    for idx, turn in enumerate(ordered_turns, start=1):
+        parts.append(_render_turn_block(idx, turn))
+    return "\n".join(parts).rstrip() + "\n"
+
+
+def _ensure_memory_dir(memory_dir: Path) -> None:
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(memory_dir, 0o700)
+    except OSError:
+        # Non-fatal — operator may have a stricter umask or readonly fs
+        # in tests; the dir already exists, the reconcile can proceed.
+        pass
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8",
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp",
+        delete=False,
+    )
+    try:
+        tmp.write(text)
+        tmp.flush()
+        os.fsync(tmp.fileno())
+    finally:
+        tmp.close()
+    os.replace(tmp.name, path)
+
+
+# ----------------------------------------------------------------------
+# core reconcile
+# ----------------------------------------------------------------------
+
+
+def reconcile(
+    agent: str,
+    jsonl_path: Path,
+    date: str,
+    memory_dir: Path,
+    dry_run: bool,
+    verbose: bool,
+) -> dict[str, Any]:
+    note_path = memory_dir / f"{date}.md"
+
+    turns, sessions_in_jsonl = extract_turns(jsonl_path, date, verbose=verbose)
+
+    if not turns:
+        sys.stderr.write(f"no turns for {date} in {jsonl_path}\n")
+        return {
+            "status": "ok",
+            "agent": agent,
+            "date": date,
+            "note_path": str(note_path),
+            "turns_total": 0,
+            "turns_new": 0,
+            "sessions": [],
+            "applied": "noop",
+            "dry_run": dry_run,
+            "no_turns": True,
+        }
+
+    # Read existing daily note (may not exist).
+    if note_path.exists():
+        existing_text = note_path.read_text(encoding="utf-8")
+    else:
+        existing_text = ""
+
+    if existing_text:
+        meta, title, sections = _parse_daily_note(existing_text, date, agent)
+    else:
+        meta = {
+            "schema_version": 1,
+            "session_ids": [],
+            "writer_mix": {},
+            "reconciled_fingerprints": {},
+            "last_reconciled_at": _now_iso_utc(),
+        }
+        title = f"# {date} — {agent}"
+        sections = []
+
+    # Tolerate corrupt manifest fields.
+    raw_manifest = meta.get("reconciled_fingerprints")
+    if not isinstance(raw_manifest, dict):
+        _eprint(verbose, "manifest malformed — treating as empty")
+        raw_manifest = {}
+    manifest: dict[str, list[str]] = {}
+    for k, v in raw_manifest.items():
+        if isinstance(k, str) and isinstance(v, list):
+            manifest[k] = [str(x) for x in v if isinstance(x, (str, int))]
+
+    session_ids = list(meta.get("session_ids") or [])
+    writer_mix = dict(meta.get("writer_mix") or {})
+
+    # Group turns by session_id, in jsonl order.
+    by_session: dict[str, list[dict[str, Any]]] = {}
+    for t in turns:
+        by_session.setdefault(t["session_id"], []).append(t)
+
+    # Determine new turns per session.
+    new_turn_count = 0
+    sessions_summary: list[dict[str, Any]] = []
+    for sid in sessions_in_jsonl:
+        existing_fps = set(manifest.get(sid, []))
+        session_turns = by_session.get(sid, [])
+        new_turns = [t for t in session_turns if t["fingerprint"] not in existing_fps]
+
+        if not new_turns:
+            sessions_summary.append({
+                "session_id": sid,
+                "turns_in_jsonl": len(session_turns),
+                "turns_new": 0,
+            })
+            continue
+
+        # Find existing section for this session (if any) and append new
+        # turn blocks. Otherwise create a new section.
+        existing_section_idx: int | None = None
+        for idx, (existing_sid, _text) in enumerate(sections):
+            if existing_sid == sid:
+                existing_section_idx = idx
+                break
+
+        if existing_section_idx is None:
+            # Build full section from scratch — number turns from 1.
+            section_text = _build_section_text(sid, new_turns)
+            sections.append((sid, section_text))
+            if sid not in session_ids:
+                session_ids.append(sid)
+            writer_mix[WRITER_LABEL] = writer_mix.get(WRITER_LABEL, 0) + 1
+        else:
+            # Count existing ### turn blocks under this section to keep
+            # numbering monotonic across re-runs.
+            _existing_sid, existing_text = sections[existing_section_idx]
+            existing_turn_count = len(re.findall(r"^### turn \d+\s+·", existing_text, re.MULTILINE))
+            appended_blocks = []
+            for offset, turn in enumerate(new_turns, start=1):
+                appended_blocks.append(_render_turn_block(existing_turn_count + offset, turn))
+            updated_text = existing_text.rstrip("\n") + "\n\n" + "\n".join(appended_blocks).rstrip() + "\n"
+            sections[existing_section_idx] = (sid, updated_text)
+
+        # Extend the manifest.
+        manifest.setdefault(sid, []).extend(t["fingerprint"] for t in new_turns)
+        new_turn_count += len(new_turns)
+        sessions_summary.append({
+            "session_id": sid,
+            "turns_in_jsonl": len(session_turns),
+            "turns_new": len(new_turns),
+        })
+
+    # Update meta.
+    meta["schema_version"] = meta.get("schema_version", 1)
+    meta["session_ids"] = session_ids
+    meta["writer_mix"] = writer_mix
+    meta["reconciled_fingerprints"] = manifest
+    meta["last_reconciled_at"] = _now_iso_utc()
+
+    new_text = _assemble_daily_note(title, meta, sections)
+
+    # Decide outcome.
+    if new_turn_count == 0:
+        applied = "noop"
+    elif existing_text:
+        applied = "updated"
+    else:
+        applied = "created"
+
+    if dry_run:
+        if existing_text == new_text:
+            sys.stdout.write("no changes\n")
+        else:
+            diff = difflib.unified_diff(
+                existing_text.splitlines(keepends=True),
+                new_text.splitlines(keepends=True),
+                fromfile=str(note_path) + ".old",
+                tofile=str(note_path) + ".new",
+                lineterm="",
+            )
+            sys.stdout.write("".join(diff))
+            if not new_text.endswith("\n"):
+                sys.stdout.write("\n")
+        return {
+            "status": "ok",
+            "agent": agent,
+            "date": date,
+            "note_path": str(note_path),
+            "turns_total": len(turns),
+            "turns_new": new_turn_count,
+            "sessions": sessions_summary,
+            "applied": applied,
+            "dry_run": True,
+        }
+
+    if applied != "noop":
+        _ensure_memory_dir(memory_dir)
+        _atomic_write(note_path, new_text)
+
+    return {
+        "status": "ok",
+        "agent": agent,
+        "date": date,
+        "note_path": str(note_path),
+        "turns_total": len(turns),
+        "turns_new": new_turn_count,
+        "sessions": sessions_summary,
+        "applied": applied,
+        "dry_run": False,
+    }
+
+
+# ----------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------
+
+
+def _resolve_memory_dir(args: argparse.Namespace) -> Path:
+    if args.memory_dir:
+        return Path(args.memory_dir).expanduser()
+    # Default: agents/<agent>/memory/ relative to bridge home.
+    bridge_home = os.environ.get("BRIDGE_HOME") or str(Path.home() / ".agent-bridge")
+    if args.transcripts_home:
+        # PR #426 Track C parity: when an isolated agent's transcripts
+        # live under a different home, the daily note typically lives
+        # under that same home's bridge tree. Caller can override
+        # explicitly via --memory-dir; this is a soft default.
+        bridge_home = str(Path(args.transcripts_home).expanduser() / ".agent-bridge")
+    return Path(bridge_home) / "agents" / args.agent / "memory"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="daily-note-reconcile.py",
+        description=(
+            "Idempotent jsonl→daily-note merger. "
+            "PR-1 of 4 in the issue #390 memory-pipeline rewiring."
+        ),
+    )
+    parser.add_argument("--agent", required=True, help="Agent id (matches bridge runtime).")
+    parser.add_argument("--jsonl", required=True, help="Path to a Claude session jsonl.")
+    parser.add_argument(
+        "--date",
+        default=None,
+        help="Target date YYYY-MM-DD (UTC). Default: today (UTC).",
+    )
+    parser.add_argument(
+        "--memory-dir",
+        default=None,
+        help="Daily-note directory. Default: <BRIDGE_HOME>/agents/<agent>/memory/.",
+    )
+    parser.add_argument(
+        "--transcripts-home",
+        default=None,
+        help="Optional isolated home root (PR #426 Track C). Used to derive a default memory dir; ignored if --memory-dir is set.",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print diff/no-changes instead of writing.")
+    parser.add_argument("--verbose", action="store_true", help="Debug breadcrumbs to stderr.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON summary on stdout.")
+
+    args = parser.parse_args(argv)
+
+    if not args.agent.strip():
+        sys.stderr.write("agent name is empty\n")
+        return 2
+
+    date = args.date or _today_utc()
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
+        sys.stderr.write(f"invalid --date {date!r} (expected YYYY-MM-DD)\n")
+        return 2
+
+    jsonl_path = Path(args.jsonl).expanduser()
+    if not jsonl_path.exists():
+        sys.stderr.write(f"jsonl not found: {jsonl_path}\n")
+        return 2
+    if not jsonl_path.is_file():
+        sys.stderr.write(f"jsonl is not a file: {jsonl_path}\n")
+        return 2
+    try:
+        # Touch readability without slurping the whole file.
+        with jsonl_path.open("rb") as _probe:
+            _probe.read(1)
+    except OSError:
+        # Do NOT echo the path beyond this — minimal info leak.
+        sys.stderr.write("jsonl unreadable\n")
+        return 2
+
+    memory_dir = _resolve_memory_dir(args)
+
+    try:
+        result = reconcile(
+            agent=args.agent,
+            jsonl_path=jsonl_path,
+            date=date,
+            memory_dir=memory_dir,
+            dry_run=args.dry_run,
+            verbose=args.verbose,
+        )
+    except OSError as exc:
+        sys.stderr.write(f"reconcile write failed: {exc}\n")
+        return 2
+
+    if args.json:
+        sys.stdout.write(json.dumps(result, ensure_ascii=False) + "\n")
+    else:
+        sys.stdout.write(
+            f"{result['applied']} agent={result['agent']} date={result['date']} "
+            f"turns_new={result['turns_new']} note={result['note_path']}\n"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/daily-note-reconcile/fixtures/sample.jsonl
+++ b/tests/daily-note-reconcile/fixtures/sample.jsonl
@@ -1,0 +1,10 @@
+{"type":"worktree-state","sessionId":"sess-fixture-A","worktreeSession":"x"}
+{"type":"user","sessionId":"sess-fixture-A","timestamp":"2026-04-01T01:00:00.000Z","message":{"role":"user","content":"<local-command-stdout>noise</local-command-stdout>"}}
+{"type":"user","sessionId":"sess-fixture-A","timestamp":"2026-04-01T01:01:00.000Z","message":{"role":"user","content":"안녕, 오늘 작업 시작합시다."}}
+{"type":"assistant","sessionId":"sess-fixture-A","timestamp":"2026-04-01T01:02:00.000Z","message":{"role":"assistant","content":[{"type":"thinking","text":"hidden chain of thought"},{"type":"text","text":"네, Phase 0 부터 시작하겠습니다."}]}}
+{"type":"assistant","sessionId":"sess-fixture-A","timestamp":"2026-04-01T01:03:00.000Z","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}
+{"type":"user","sessionId":"sess-fixture-A","timestamp":"2026-04-01T01:03:30.000Z","message":{"role":"user","content":[{"type":"tool_result","content":"file1\nfile2\n"}]}}
+{"type":"user","sessionId":"sess-fixture-A","timestamp":"2026-03-31T23:50:00.000Z","message":{"role":"user","content":"이건 어제 메시지"}}
+{"type":"user","sessionId":"sess-fixture-A","timestamp":"2026-04-01T02:00:00.000Z","message":{"role":"user","content":"<system-reminder>scaffolding wrapper</system-reminder>"}}
+not a json line at all
+{"type":"assistant","sessionId":"sess-fixture-A","timestamp":"2026-04-01T02:30:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"완료. 결과 요약은 다음과 같습니다."}]}}

--- a/tests/daily-note-reconcile/smoke.sh
+++ b/tests/daily-note-reconcile/smoke.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# daily-note-reconcile smoke — covers the 8 acceptance cases from the
+# issue #390 PR-1 brief.
+#
+#   1 empty jsonl → no daily note created (or empty manifest)
+#   2 single-turn jsonl → daily note created with 1 turn + manifest entry
+#   3 re-run with same jsonl → no change (idempotency)
+#   4 re-run after appending a new turn → 2 turns + 2 manifest entries
+#   5 --dry-run returns diff without writing
+#   6 malformed jsonl line → script tolerates (skips), continues
+#   7 long turn truncation → respects 2000 head + 500 tail
+#   8 --date filter → only that day's turns extracted
+#
+# Usage:   bash tests/daily-note-reconcile/smoke.sh
+# Exit 0 if all 8 cases PASS, 1 otherwise.
+
+set -u
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+SCRIPT="$REPO_ROOT/scripts/daily-note-reconcile.py"
+FIXTURE="$REPO_ROOT/tests/daily-note-reconcile/fixtures/sample.jsonl"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+PASS=0
+FAIL=0
+FAIL_IDS=()
+
+pass() { PASS=$((PASS + 1)); printf '  [PASS] %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); FAIL_IDS+=("$1"); printf '  [FAIL] %s — %s\n' "$1" "$2"; }
+banner() { printf '\n=== case %s — %s ===\n' "$1" "$2"; }
+
+SMOKE_ROOT="$(mktemp -d -t daily-note-reconcile.XXXXXX)"
+trap 'rm -rf "$SMOKE_ROOT" 2>/dev/null || true' EXIT
+
+AGENT="smoke-agent"
+MEMDIR="$SMOKE_ROOT/memory"
+mkdir -p "$MEMDIR"
+
+# ---------- case 1: empty jsonl ----------
+banner 1 "empty jsonl → noop"
+EMPTY_JSONL="$SMOKE_ROOT/empty.jsonl"
+: > "$EMPTY_JSONL"
+out_json="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$EMPTY_JSONL" \
+    --date 2026-04-01 --memory-dir "$MEMDIR" --json 2>/dev/null)"
+rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail 1 "non-zero rc=$rc"
+elif ! printf '%s' "$out_json" | "$PYTHON" -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+sys.exit(0 if d.get("turns_new") == 0 and d.get("applied") == "noop" else 1)
+'; then
+  fail 1 "expected noop+turns_new=0 in JSON: $out_json"
+elif [[ -e "$MEMDIR/2026-04-01.md" ]]; then
+  fail 1 "daily note created from empty jsonl"
+else
+  pass 1
+fi
+
+# ---------- case 2: single-turn jsonl ----------
+banner 2 "single-turn jsonl → 1 turn + manifest"
+SINGLE="$SMOKE_ROOT/single.jsonl"
+cat > "$SINGLE" <<'EOF'
+{"type":"user","sessionId":"sess-A","timestamp":"2026-04-02T10:00:00.000Z","message":{"role":"user","content":"hello world"}}
+EOF
+out_json="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$SINGLE" \
+    --date 2026-04-02 --memory-dir "$MEMDIR" --json)"
+rc=$?
+note="$MEMDIR/2026-04-02.md"
+if [[ $rc -ne 0 ]]; then
+  fail 2 "non-zero rc=$rc"
+elif [[ ! -f "$note" ]]; then
+  fail 2 "daily note not created at $note"
+elif ! grep -q "## Session sess-A — reconcile" "$note"; then
+  fail 2 "section header missing"
+elif ! grep -q "hello world" "$note"; then
+  fail 2 "turn text missing"
+elif ! head -1 "$note" | grep -q "bridge-daily-meta:"; then
+  fail 2 "meta block missing on line 1"
+elif ! "$PYTHON" -c '
+import json, re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"<!-- bridge-daily-meta: (\{.*\}) -->", text)
+meta = json.loads(m.group(1))
+fps = meta.get("reconciled_fingerprints", {}).get("sess-A", [])
+sys.exit(0 if len(fps) == 1 else 1)
+' "$note"; then
+  fail 2 "manifest does not have exactly 1 fingerprint"
+else
+  pass 2
+fi
+
+# ---------- case 3: re-run same jsonl → idempotent ----------
+banner 3 "re-run same jsonl → byte-identical (modulo last_reconciled_at)"
+before_hash="$("$PYTHON" -c '
+import re, sys, hashlib
+t = open(sys.argv[1], encoding="utf-8").read()
+# strip last_reconciled_at — that field is allowed to update
+t = re.sub(r"\"last_reconciled_at\":\s*\"[^\"]+\"", "\"last_reconciled_at\":\"X\"", t)
+print(hashlib.sha256(t.encode("utf-8")).hexdigest())
+' "$note")"
+out_json2="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$SINGLE" \
+    --date 2026-04-02 --memory-dir "$MEMDIR" --json)"
+after_hash="$("$PYTHON" -c '
+import re, sys, hashlib
+t = open(sys.argv[1], encoding="utf-8").read()
+t = re.sub(r"\"last_reconciled_at\":\s*\"[^\"]+\"", "\"last_reconciled_at\":\"X\"", t)
+print(hashlib.sha256(t.encode("utf-8")).hexdigest())
+' "$note")"
+applied2="$(printf '%s' "$out_json2" | "$PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read())["applied"])')"
+if [[ "$before_hash" != "$after_hash" ]]; then
+  fail 3 "content-hash changed on idempotent re-run"
+elif [[ "$applied2" != "noop" ]]; then
+  fail 3 "applied should be noop on re-run, got $applied2"
+else
+  pass 3
+fi
+
+# ---------- case 4: append new turn → 2 turns ----------
+banner 4 "append new turn → 2 turns + 2 manifest entries"
+cat >> "$SINGLE" <<'EOF'
+{"type":"assistant","sessionId":"sess-A","timestamp":"2026-04-02T10:30:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"second turn arrived"}]}}
+EOF
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$SINGLE" \
+    --date 2026-04-02 --memory-dir "$MEMDIR" --json > "$SMOKE_ROOT/out4.json"
+rc=$?
+turn_blocks="$(grep -c '^### turn ' "$note" || true)"
+fp_count="$("$PYTHON" -c '
+import json, re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"<!-- bridge-daily-meta: (\{.*\}) -->", text)
+meta = json.loads(m.group(1))
+print(len(meta.get("reconciled_fingerprints", {}).get("sess-A", [])))
+' "$note")"
+if [[ $rc -ne 0 ]]; then
+  fail 4 "non-zero rc=$rc"
+elif [[ "$turn_blocks" != "2" ]]; then
+  fail 4 "expected 2 turn blocks, got $turn_blocks"
+elif [[ "$fp_count" != "2" ]]; then
+  fail 4 "expected 2 manifest fingerprints, got $fp_count"
+elif ! grep -q "second turn arrived" "$note"; then
+  fail 4 "second turn text missing"
+else
+  pass 4
+fi
+
+# ---------- case 5: --dry-run shows diff, no write ----------
+banner 5 "--dry-run shows diff and does not write"
+DRY_JSONL="$SMOKE_ROOT/dry.jsonl"
+cat > "$DRY_JSONL" <<'EOF'
+{"type":"user","sessionId":"sess-DRY","timestamp":"2026-04-03T09:00:00.000Z","message":{"role":"user","content":"dry-run probe"}}
+EOF
+dry_note="$MEMDIR/2026-04-03.md"
+[[ -e "$dry_note" ]] && rm "$dry_note"
+diff_out="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$DRY_JSONL" \
+    --date 2026-04-03 --memory-dir "$MEMDIR" --dry-run 2>/dev/null)"
+rc=$?
+if [[ $rc -ne 0 ]]; then
+  fail 5 "dry-run rc=$rc"
+elif [[ -e "$dry_note" ]]; then
+  fail 5 "dry-run created note file"
+elif ! printf '%s' "$diff_out" | grep -q "dry-run probe"; then
+  fail 5 "dry-run output missing turn text"
+else
+  pass 5
+fi
+
+# ---------- case 6: malformed jsonl line ----------
+banner 6 "malformed line tolerated (uses fixture sample.jsonl)"
+fix_note="$MEMDIR/2026-04-01.md"
+[[ -e "$fix_note" ]] && rm "$fix_note"
+out_json6="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$FIXTURE" \
+    --date 2026-04-01 --memory-dir "$MEMDIR" --json --verbose 2>"$SMOKE_ROOT/err6.log")"
+rc=$?
+turns_new6="$(printf '%s' "$out_json6" | "$PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read())["turns_new"])')"
+if [[ $rc -ne 0 ]]; then
+  fail 6 "rc=$rc with malformed line in fixture"
+elif [[ ! -f "$fix_note" ]]; then
+  fail 6 "daily note not created"
+elif ! grep -q "Phase 0 부터 시작" "$fix_note"; then
+  fail 6 "expected real assistant text missing"
+elif grep -q "hidden chain of thought" "$fix_note"; then
+  fail 6 "thinking block leaked into daily note"
+elif grep -q "scaffolding wrapper" "$fix_note"; then
+  fail 6 "system-reminder scaffolding leaked"
+elif grep -q "tool_result" "$fix_note"; then
+  fail 6 "tool_result leaked"
+elif grep -q "어제 메시지" "$fix_note"; then
+  fail 6 "out-of-date turn leaked into 2026-04-01 note"
+elif [[ "$turns_new6" -lt 2 ]]; then
+  fail 6 "expected at least 2 new turns, got $turns_new6"
+else
+  pass 6
+fi
+
+# ---------- case 7: long turn truncation ----------
+banner 7 "long turn truncated to 2000 head + 500 tail"
+LONG_JSONL="$SMOKE_ROOT/long.jsonl"
+"$PYTHON" - "$LONG_JSONL" <<'PY'
+import json, sys
+path = sys.argv[1]
+big = "A" * 2000 + "M" * 5000 + "Z" * 500
+rec = {
+    "type": "user",
+    "sessionId": "sess-LONG",
+    "timestamp": "2026-04-04T05:00:00.000Z",
+    "message": {"role": "user", "content": big},
+}
+with open(path, "w", encoding="utf-8") as fh:
+    fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+PY
+long_note="$MEMDIR/2026-04-04.md"
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$LONG_JSONL" \
+    --date 2026-04-04 --memory-dir "$MEMDIR" >/dev/null
+if ! grep -q "truncated, see jsonl" "$long_note"; then
+  fail 7 "truncation marker missing"
+elif grep -q "MMMMMMMMMMMMMMMMMMMM" "$long_note"; then
+  # The middle "M" run should NOT survive truncation — head is "A...A",
+  # tail is "Z...Z", marker in between.
+  fail 7 "middle of long turn was not truncated"
+else
+  pass 7
+fi
+
+# ---------- case 8: --date filter ----------
+banner 8 "--date filter selects only target day"
+filt_note_1="$MEMDIR/2026-04-01.md"
+# We already wrote 2026-04-01 in case 6. Now run for 2026-04-02 against
+# the same fixture; nothing in the fixture is on 2026-04-02, so we
+# should get noop and no new daily note for that date.
+d2_note="$MEMDIR/_d2_only.md"
+mkdir -p "$SMOKE_ROOT/d2"
+out_json8="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$FIXTURE" \
+    --date 2026-04-05 --memory-dir "$SMOKE_ROOT/d2" --json 2>/dev/null)"
+rc=$?
+turns8="$(printf '%s' "$out_json8" | "$PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read())["turns_new"])')"
+if [[ $rc -ne 0 ]]; then
+  fail 8 "rc=$rc on date with no turns"
+elif [[ "$turns8" != "0" ]]; then
+  fail 8 "expected 0 turns_new for 2026-04-05, got $turns8"
+elif [[ -e "$SMOKE_ROOT/d2/2026-04-05.md" ]]; then
+  fail 8 "daily note created for date with no turns"
+else
+  pass 8
+fi
+
+# ---------- summary ----------
+printf '\n=== summary: %d PASS, %d FAIL ===\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf 'FAILED: %s\n' "${FAIL_IDS[*]}"
+  exit 1
+fi
+exit 0

--- a/tests/daily-note-reconcile/smoke.sh
+++ b/tests/daily-note-reconcile/smoke.sh
@@ -1,18 +1,27 @@
 #!/usr/bin/env bash
 # daily-note-reconcile smoke — covers the 8 acceptance cases from the
-# issue #390 PR-1 brief.
+# issue #390 PR-1 brief plus the 7 r2 codex-review cases.
 #
-#   1 empty jsonl → no daily note created (or empty manifest)
-#   2 single-turn jsonl → daily note created with 1 turn + manifest entry
-#   3 re-run with same jsonl → no change (idempotency)
-#   4 re-run after appending a new turn → 2 turns + 2 manifest entries
-#   5 --dry-run returns diff without writing
-#   6 malformed jsonl line → script tolerates (skips), continues
-#   7 long turn truncation → respects 2000 head + 500 tail
-#   8 --date filter → only that day's turns extracted
+#   1  empty jsonl → no daily note created (or empty manifest)
+#   2  single-turn jsonl → daily note created with 1 turn + manifest entry
+#   3  re-run with same jsonl → no change (idempotency)
+#   4  re-run after appending a new turn → 2 turns + 2 manifest entries
+#   5  --dry-run returns diff without writing
+#   6  malformed jsonl line → script tolerates (skips), continues
+#   7  long turn truncation → respects 2000 head + 500 tail
+#   8  --date filter → only that day's turns extracted
+#  --- r2 (codex r1 review) -----------------------------------------
+#   9  manifest recovery: corrupted manifest + non-empty body → no dup
+#  10  concurrent reconciles (flock) → both inputs land in the note
+#  11  malformed meta lines → quarantine block at bottom, body intact
+#  12  input batch dedupe → identical fingerprints collapse to 1 entry
+#  13  path traversal: --agent ../../etc → non-zero exit
+#       and --memory-dir /etc/passwd → non-zero exit
+#  14  defensive type guards: non-string role → skipped, no crash
+#  15  --json + --dry-run → stdout is parseable JSON only
 #
 # Usage:   bash tests/daily-note-reconcile/smoke.sh
-# Exit 0 if all 8 cases PASS, 1 otherwise.
+# Exit 0 if all 15 cases PASS, 1 otherwise.
 
 set -u
 
@@ -31,6 +40,11 @@ banner() { printf '\n=== case %s — %s ===\n' "$1" "$2"; }
 
 SMOKE_ROOT="$(mktemp -d -t daily-note-reconcile.XXXXXX)"
 trap 'rm -rf "$SMOKE_ROOT" 2>/dev/null || true' EXIT
+
+# r2 — Item 6 path-traversal sanitisation requires --memory-dir to live
+# under BRIDGE_HOME. Anchor the smoke's BRIDGE_HOME at SMOKE_ROOT so the
+# operator-override path stays inside the allowed root.
+export BRIDGE_HOME="$SMOKE_ROOT"
 
 AGENT="smoke-agent"
 MEMDIR="$SMOKE_ROOT/memory"
@@ -242,6 +256,264 @@ elif [[ -e "$SMOKE_ROOT/d2/2026-04-05.md" ]]; then
   fail 8 "daily note created for date with no turns"
 else
   pass 8
+fi
+
+# ---------- case 9: manifest recovery — corrupt manifest + non-empty body ----------
+banner 9 "corrupt manifest + non-empty body → no duplicate-on-first-run"
+R9_DIR="$SMOKE_ROOT/r9"
+mkdir -p "$R9_DIR"
+R9_JSONL="$SMOKE_ROOT/r9.jsonl"
+cat > "$R9_JSONL" <<'EOF'
+{"type":"user","sessionId":"sess-R9","timestamp":"2026-04-09T10:00:00.000Z","message":{"role":"user","content":"recovery turn 1"}}
+{"type":"assistant","sessionId":"sess-R9","timestamp":"2026-04-09T10:30:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"recovery turn 2"}]}}
+EOF
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R9_JSONL" \
+    --date 2026-04-09 --memory-dir "$R9_DIR" >/dev/null
+r9_note="$R9_DIR/2026-04-09.md"
+turns_before="$(grep -c '^### turn ' "$r9_note" || true)"
+# Wipe the manifest entry by replacing the JSON value of
+# reconciled_fingerprints with {} (simulates operator hand-edit).
+"$PYTHON" - "$r9_note" <<'PY'
+import json, re, sys
+p = sys.argv[1]
+text = open(p, encoding="utf-8").read()
+m = re.search(r"<!-- bridge-daily-meta: (\{.*\}) -->", text)
+meta = json.loads(m.group(1))
+meta["reconciled_fingerprints"] = {}
+new_meta_line = "<!-- bridge-daily-meta: " + json.dumps(meta, ensure_ascii=False) + " -->"
+text = text[:m.start()] + new_meta_line + text[m.end():]
+open(p, "w", encoding="utf-8").write(text)
+PY
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R9_JSONL" \
+    --date 2026-04-09 --memory-dir "$R9_DIR" >/dev/null 2>"$SMOKE_ROOT/err9.log"
+rc9=$?
+turns_after="$(grep -c '^### turn ' "$r9_note" || true)"
+fps9="$("$PYTHON" -c '
+import json, re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"<!-- bridge-daily-meta: (\{.*\}) -->", text)
+meta = json.loads(m.group(1))
+print(len(meta.get("reconciled_fingerprints", {}).get("sess-R9", [])))
+' "$r9_note")"
+if [[ $rc9 -ne 0 ]]; then
+  fail 9 "rc=$rc9 after manifest wipe"
+elif [[ "$turns_before" != "2" ]]; then
+  fail 9 "expected 2 turn blocks before wipe, got $turns_before"
+elif [[ "$turns_after" != "2" ]]; then
+  fail 9 "expected still-2 turn blocks after recovery, got $turns_after (duplicate appended?)"
+elif [[ "$fps9" != "2" ]]; then
+  fail 9 "expected 2 recovered fingerprints, got $fps9"
+else
+  pass 9
+fi
+
+# ---------- case 10: concurrent reconciles → both land ----------
+banner 10 "two concurrent reconciles with disjoint jsonls → no lost update"
+R10_DIR="$SMOKE_ROOT/r10"
+mkdir -p "$R10_DIR"
+R10_JSONL_A="$SMOKE_ROOT/r10a.jsonl"
+R10_JSONL_B="$SMOKE_ROOT/r10b.jsonl"
+cat > "$R10_JSONL_A" <<'EOF'
+{"type":"user","sessionId":"sess-CA","timestamp":"2026-04-10T10:00:00.000Z","message":{"role":"user","content":"concurrent input A"}}
+EOF
+cat > "$R10_JSONL_B" <<'EOF'
+{"type":"user","sessionId":"sess-CB","timestamp":"2026-04-10T10:00:01.000Z","message":{"role":"user","content":"concurrent input B"}}
+EOF
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R10_JSONL_A" \
+    --date 2026-04-10 --memory-dir "$R10_DIR" >/dev/null 2>>"$SMOKE_ROOT/err10.log" &
+pid_a=$!
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R10_JSONL_B" \
+    --date 2026-04-10 --memory-dir "$R10_DIR" >/dev/null 2>>"$SMOKE_ROOT/err10.log" &
+pid_b=$!
+wait "$pid_a"; rc_a=$?
+wait "$pid_b"; rc_b=$?
+r10_note="$R10_DIR/2026-04-10.md"
+if [[ $rc_a -ne 0 || $rc_b -ne 0 ]]; then
+  fail 10 "concurrent rc: A=$rc_a B=$rc_b"
+elif [[ ! -f "$r10_note" ]]; then
+  fail 10 "concurrent note not created"
+elif ! grep -q "concurrent input A" "$r10_note"; then
+  fail 10 "input A lost"
+elif ! grep -q "concurrent input B" "$r10_note"; then
+  fail 10 "input B lost (lost update)"
+else
+  pass 10
+fi
+
+# ---------- case 11: malformed meta → quarantine block ----------
+banner 11 "corrupt meta lines → quarantine block at bottom, body intact"
+R11_DIR="$SMOKE_ROOT/r11"
+mkdir -p "$R11_DIR"
+R11_JSONL="$SMOKE_ROOT/r11.jsonl"
+cat > "$R11_JSONL" <<'EOF'
+{"type":"user","sessionId":"sess-Q","timestamp":"2026-04-11T10:00:00.000Z","message":{"role":"user","content":"body should survive"}}
+EOF
+r11_note="$R11_DIR/2026-04-11.md"
+# Pre-seed a daily note whose meta envelope is malformed (broken JSON).
+cat > "$r11_note" <<'EOF'
+<!-- bridge-daily-meta: {"schema_version": 1, "session_ids": [BROKEN -->
+some operator stray line above title
+# 2026-04-11 — smoke-agent
+
+## Session sess-Q — reconcile
+
+### turn 1 · user · 2026-04-11T10:00:00+00:00
+
+body should survive
+EOF
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R11_JSONL" \
+    --date 2026-04-11 --memory-dir "$R11_DIR" >/dev/null 2>"$SMOKE_ROOT/err11.log"
+rc11=$?
+if [[ $rc11 -ne 0 ]]; then
+  fail 11 "rc=$rc11"
+elif ! grep -q "<!-- daily-note-reconcile-quarantine -->" "$r11_note"; then
+  fail 11 "quarantine open marker missing"
+elif ! grep -q "<!-- /daily-note-reconcile-quarantine -->" "$r11_note"; then
+  fail 11 "quarantine close marker missing"
+elif ! grep -q "body should survive" "$r11_note"; then
+  fail 11 "body content lost"
+elif ! grep -q "BROKEN" "$r11_note"; then
+  fail 11 "corrupt meta line not preserved in quarantine"
+elif ! "$PYTHON" -c '
+import re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+# Quarantine block must come AFTER the title, not before.
+title_idx = text.find("# 2026-04-11")
+quar_idx = text.find("<!-- daily-note-reconcile-quarantine -->")
+sys.exit(0 if title_idx > -1 and quar_idx > title_idx else 1)
+' "$r11_note"; then
+  fail 11 "quarantine block not at bottom"
+elif ! head -1 "$r11_note" | grep -q '"reconciled_fingerprints"'; then
+  fail 11 "clean meta envelope not on line 1"
+else
+  pass 11
+fi
+
+# ---------- case 12: input batch dedupe ----------
+banner 12 "duplicate fingerprints within input → collapsed to 1 entry"
+R12_DIR="$SMOKE_ROOT/r12"
+mkdir -p "$R12_DIR"
+R12_JSONL="$SMOKE_ROOT/r12.jsonl"
+cat > "$R12_JSONL" <<'EOF'
+{"type":"user","sessionId":"sess-D","timestamp":"2026-04-12T10:00:00.000Z","message":{"role":"user","content":"dup probe"}}
+{"type":"user","sessionId":"sess-D","timestamp":"2026-04-12T10:00:00.000Z","message":{"role":"user","content":"dup probe"}}
+{"type":"user","sessionId":"sess-D","timestamp":"2026-04-12T10:01:00.000Z","message":{"role":"user","content":"distinct probe"}}
+EOF
+out_json12="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R12_JSONL" \
+    --date 2026-04-12 --memory-dir "$R12_DIR" --json)"
+rc12=$?
+r12_note="$R12_DIR/2026-04-12.md"
+turns12="$(grep -c '^### turn ' "$r12_note" || true)"
+fps12="$("$PYTHON" -c '
+import json, re, sys
+text = open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"<!-- bridge-daily-meta: (\{.*\}) -->", text)
+meta = json.loads(m.group(1))
+print(len(meta.get("reconciled_fingerprints", {}).get("sess-D", [])))
+' "$r12_note")"
+filtered12="$(printf '%s' "$out_json12" | "$PYTHON" -c 'import json,sys; print(json.loads(sys.stdin.read()).get("turns_filtered", -1))')"
+if [[ $rc12 -ne 0 ]]; then
+  fail 12 "rc=$rc12"
+elif [[ "$turns12" != "2" ]]; then
+  fail 12 "expected 2 turn blocks (dup collapsed), got $turns12"
+elif [[ "$fps12" != "2" ]]; then
+  fail 12 "expected 2 fingerprints, got $fps12"
+elif [[ "$filtered12" != "1" ]]; then
+  fail 12 "expected 1 turn filtered as dup, got $filtered12"
+else
+  pass 12
+fi
+
+# ---------- case 13: path traversal sanitisation ----------
+banner 13 "--agent traversal + --memory-dir escape → non-zero exit"
+R13_JSONL="$SMOKE_ROOT/r13.jsonl"
+cat > "$R13_JSONL" <<'EOF'
+{"type":"user","sessionId":"sess-T","timestamp":"2026-04-13T10:00:00.000Z","message":{"role":"user","content":"trav probe"}}
+EOF
+"$PYTHON" "$SCRIPT" --agent "../../etc" --jsonl "$R13_JSONL" \
+    --date 2026-04-13 --memory-dir "$SMOKE_ROOT/r13" >/dev/null 2>"$SMOKE_ROOT/err13a.log"
+rc13a=$?
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R13_JSONL" \
+    --date 2026-04-13 --memory-dir "/etc/passwd" >/dev/null 2>"$SMOKE_ROOT/err13b.log"
+rc13b=$?
+if [[ $rc13a -eq 0 ]]; then
+  fail 13 "--agent ../../etc unexpectedly succeeded"
+elif ! grep -q "agent id invalid" "$SMOKE_ROOT/err13a.log"; then
+  fail 13 "expected agent-id rejection message"
+elif [[ $rc13b -eq 0 ]]; then
+  fail 13 "--memory-dir /etc/passwd unexpectedly succeeded"
+elif ! grep -q "BRIDGE_HOME" "$SMOKE_ROOT/err13b.log"; then
+  fail 13 "expected BRIDGE_HOME containment error"
+else
+  pass 13
+fi
+
+# ---------- case 14: defensive type guard on role ----------
+banner 14 "non-string role → skipped with warning, no crash"
+R14_DIR="$SMOKE_ROOT/r14"
+mkdir -p "$R14_DIR"
+R14_JSONL="$SMOKE_ROOT/r14.jsonl"
+"$PYTHON" - "$R14_JSONL" <<'PY'
+import json, sys
+path = sys.argv[1]
+records = [
+    # Non-string role: list. Should be skipped with a warning.
+    {"type": "user", "sessionId": "sess-G",
+     "timestamp": "2026-04-14T09:00:00.000Z",
+     "message": {"role": ["unexpected", "list"], "content": "should be skipped"}},
+    # Healthy turn — should land.
+    {"type": "user", "sessionId": "sess-G",
+     "timestamp": "2026-04-14T09:01:00.000Z",
+     "message": {"role": "user", "content": "healthy turn"}},
+]
+with open(path, "w", encoding="utf-8") as fh:
+    for r in records:
+        fh.write(json.dumps(r) + "\n")
+PY
+"$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R14_JSONL" \
+    --date 2026-04-14 --memory-dir "$R14_DIR" >"$SMOKE_ROOT/out14.log" 2>"$SMOKE_ROOT/err14.log"
+rc14=$?
+r14_note="$R14_DIR/2026-04-14.md"
+if [[ $rc14 -ne 0 ]]; then
+  fail 14 "rc=$rc14 — script crashed on non-string role"
+elif [[ ! -f "$r14_note" ]]; then
+  fail 14 "healthy turn was not written"
+elif grep -q "should be skipped" "$r14_note"; then
+  fail 14 "non-string role turn leaked into note"
+elif ! grep -q "healthy turn" "$r14_note"; then
+  fail 14 "healthy turn missing"
+elif ! grep -q "role not a string" "$SMOKE_ROOT/err14.log"; then
+  fail 14 "no stderr warning for non-string role"
+else
+  pass 14
+fi
+
+# ---------- case 15: --dry-run --json → parseable JSON only ----------
+banner 15 "--dry-run --json on non-empty input → stdout is JSON"
+R15_DIR="$SMOKE_ROOT/r15"
+mkdir -p "$R15_DIR"
+R15_JSONL="$SMOKE_ROOT/r15.jsonl"
+cat > "$R15_JSONL" <<'EOF'
+{"type":"user","sessionId":"sess-J","timestamp":"2026-04-15T10:00:00.000Z","message":{"role":"user","content":"json probe"}}
+EOF
+out15="$("$PYTHON" "$SCRIPT" --agent "$AGENT" --jsonl "$R15_JSONL" \
+    --date 2026-04-15 --memory-dir "$R15_DIR" --dry-run --json 2>/dev/null)"
+rc15=$?
+parse15_outcome="$(printf '%s' "$out15" | "$PYTHON" -c '
+import json, sys
+d = json.loads(sys.stdin.read())
+print(d.get("outcome", ""))
+' 2>"$SMOKE_ROOT/err15.log" || true)"
+if [[ $rc15 -ne 0 ]]; then
+  fail 15 "rc=$rc15"
+elif [[ "$parse15_outcome" != "dry-run" ]]; then
+  fail 15 "stdout not parseable as JSON or wrong outcome (got '$parse15_outcome'): $out15"
+elif printf '%s' "$out15" | grep -q "^no changes$"; then
+  fail 15 "human prose 'no changes' leaked into JSON stdout"
+elif [[ -e "$R15_DIR/2026-04-15.md" ]]; then
+  fail 15 "dry-run created note file"
+else
+  pass 15
 fi
 
 # ---------- summary ----------


### PR DESCRIPTION
## Summary

PR-1 of 4 from #390 split proposal. Ships the dependency for the rest of the
memory-pipeline rewiring sequence — a thin idempotent script that merges a
Claude session jsonl into the agent's daily note.

## Behavior

- `python3 scripts/daily-note-reconcile.py --agent <id> --jsonl <path> [--date YYYY-MM-DD]`
- Extracts meaningful turns (filters out thinking / tool_use / tool_result and Claude scaffolding wrappers like `<local-command-…>`, `<system-reminder>`, `<command-name>`).
- Truncates long turns to 2000 head + 500 tail with a `[... truncated, see jsonl ...]` marker.
- Merges into `agents/<agent>/memory/<YYYY-MM-DD>.md` idempotently via per-turn sha1 manifest.
- Manifest is stored inside the existing `bridge-daily-meta` JSON envelope as a new `reconciled_fingerprints` map keyed by `session_id` — re-using the meta block already established by `bridge-memory.py daily-append` keeps the daily-note format stable for `wiki-daily-copy.py` and avoids inventing a parallel HTML-comment manifest at the bottom of the file.
- `--date YYYY-MM-DD` is interpreted in UTC (Claude jsonl timestamps are UTC).
- Caller passes the jsonl path explicitly (no session discovery in PR-1 — that's the Stop hook / cron payload's job).

## What this PR does NOT do

- Stop hook implementation: PR-2.
- Cron payload rewrite (memory-daily-* jobs that are currently jsonl-blind): PR-3.
- PreCompact threshold tuning: PR-4.

Issue #390 stays open through PR-4.

## Verification

- `python3 -c "import ast; ast.parse(open('scripts/daily-note-reconcile.py').read())"` — pass.
- `python3 -m py_compile scripts/daily-note-reconcile.py` — pass.
- `bash -n tests/daily-note-reconcile/smoke.sh` — pass.
- `shellcheck tests/daily-note-reconcile/smoke.sh` — clean.
- `bash tests/daily-note-reconcile/smoke.sh` — 8/8 PASS (empty jsonl / single turn / idempotent re-run / append-then-re-run / dry-run diff / malformed line / long-turn truncation / `--date` filter).
- Idempotency verified end-to-end: re-running with the same (agent, jsonl, date) leaves the daily note byte-stable modulo `last_reconciled_at`.
- Spot-check against a real production jsonl (~1100 records) extracted 17 user/assistant text turns; thinking/tool_use/tool_result correctly stripped.

## Design notes

- Section format re-used from `bridge-memory.py daily-append`: `## Session <session_id> — reconcile` with `### turn <N> · <role> · <iso-ts>` H3 blocks underneath. New writer label `reconcile` distinguishes this writer from `session` and `cron`; same `writer_mix` semantics so the existing meta envelope stays valid.
- Manifest as an extension of the existing meta block (rather than a separate HTML-comment block at the bottom of the file as the brief floated) is more elegant: there is already exactly one structured envelope per daily note, parsing it twice is cheaper, and `wiki-daily-copy.py` does not need to learn a second hidden region.
- 16-hex-char sha1 (truncated) per fingerprint keeps the manifest small even for long days; collision risk on ~hundreds of turns/day is negligible for the dedup contract.
- Memory dir is created with mode 0700 to match the per-agent operator-readable convention.

Reference: #390 (PR-1 of 4)