### PR TITLE
test: fix legacy queue cancel cleanup

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3514,7 +3514,7 @@ print(last)
 PY
 )"
 [[ "$NUDGE_DROP_ACTION" == "session_nudge_dropped" ]] || die "expected session_nudge_dropped audit row, got '$NUDGE_DROP_ACTION'"
-python3 "$REPO_ROOT/bridge-queue.py" cancel "$NUDGE_DROP_TASK_ID" --agent "$REQUESTER_AGENT" --note "verify drop cleanup" >/dev/null
+python3 "$REPO_ROOT/bridge-queue.py" cancel "$NUDGE_DROP_TASK_ID" --actor "$REQUESTER_AGENT" --note "verify drop cleanup" >/dev/null
 
 log "Issue #331: marking session_nudge_sent when the task moves out of queued before the grace expires"
 NUDGE_SENT_OUTPUT="$(python3 "$REPO_ROOT/bridge-queue.py" create --to "$CODEX_CLI_AGENT" --title "verify sent oracle" --body "pickup" --from "$REQUESTER_AGENT")"


### PR DESCRIPTION
## Summary
- update legacy smoke cleanup to call `bridge-queue.py cancel` with `--actor` instead of the removed/invalid `--agent` option

## Verification
- `bash -n scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh`
- `shellcheck --severity=warning scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh`
- `python3 bridge-queue.py cancel --help`

This addresses the workflow_dispatch legacy-full-smoke failure in run 25077866489.