### PR TITLE
Fix isolated Claude memory-daily read lens

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -734,6 +734,43 @@ bridge_linux_traverse_stop_for() {
   return 0
 }
 
+# Restore the controller read lens on an isolated Claude home. The memory-daily
+# harvester runs in the controller context and scans the isolated UID's
+# ~/.claude/projects tree through this lens.
+bridge_linux_repair_isolated_claude_read_lens() {
+  local os_user="$1"
+  local user_home="$2"
+  local controller_user="$3"
+  local isolated_claude_dir=""
+  local isolated_projects_dir=""
+
+  [[ -n "$os_user" && -n "$user_home" && -n "$controller_user" ]] || return 0
+  if bridge_isolation_v2_active; then
+    return 0
+  fi
+
+  isolated_claude_dir="$user_home/.claude"
+  isolated_projects_dir="$isolated_claude_dir/projects"
+
+  bridge_linux_sudo_root test -d "$isolated_claude_dir" || return 0
+  bridge_linux_sudo_root setfacl \
+    -m "u:${controller_user}:r-x" \
+    -m "m::r-x" \
+    "$isolated_claude_dir" >/dev/null 2>&1 || true
+  bridge_linux_sudo_root setfacl \
+    -d -m "u:${controller_user}:r-X" \
+    -d -m "m::r-X" \
+    "$isolated_claude_dir" >/dev/null 2>&1 || true
+
+  bridge_linux_sudo_root test -d "$isolated_projects_dir" || return 0
+  bridge_linux_sudo_root find "$isolated_projects_dir" -type d \
+    -exec setfacl -m "u:${controller_user}:r-X" -m "m::r-X" {} + >/dev/null 2>&1 || true
+  bridge_linux_sudo_root find "$isolated_projects_dir" -type d \
+    -exec setfacl -d -m "u:${controller_user}:r-X" -d -m "m::r-X" {} + >/dev/null 2>&1 || true
+  bridge_linux_sudo_root find "$isolated_projects_dir" -type f \
+    -exec setfacl -m "u:${controller_user}:r--" -m "m::r--" {} + >/dev/null 2>&1 || true
+}
+
 # Claude Code reads its auth from $CLAUDE_CONFIG_DIR/.credentials.json
 # (default $HOME/.claude/.credentials.json). Under linux-user isolation
 # the agent runs as a dedicated UID whose $HOME is /home/<os_user>/,
@@ -800,7 +837,10 @@ bridge_linux_grant_claude_credentials_access() {
 
   bridge_linux_sudo_root mkdir -p "$isolated_claude_dir"
   bridge_linux_sudo_root chown "$os_user" "$isolated_claude_dir"
-  bridge_linux_sudo_root chmod 0700 "$isolated_claude_dir"
+  if ! bridge_isolation_v2_active; then
+    bridge_linux_sudo_root chmod 0700 "$isolated_claude_dir"
+    bridge_linux_repair_isolated_claude_read_lens "$os_user" "$user_home" "$controller_user"
+  fi
 
   if bridge_isolation_v2_active; then
     # C1 exception: bypass the v2-noop public traverse chain and apply
@@ -2950,7 +2990,7 @@ bridge_linux_prepare_agent_isolation() {
   # isolated user's home and its .claude subdirectory. `/home` and `/`
   # stay untouched — the controller reaches them via base perms.
   bridge_linux_acl_add "u:${controller_user}:--x" "$user_home" >/dev/null 2>&1 || true
-  bridge_linux_acl_add "u:${controller_user}:r-x" "$isolated_claude_dir" >/dev/null 2>&1 || true
+  bridge_linux_repair_isolated_claude_read_lens "$os_user" "$user_home" "$controller_user" >/dev/null 2>&1 || true
   # Default ACL on .claude/ so any subdirectory (projects/, sessions/, ...)
   # created later by the isolated UID inherits controller read access.
   # PR-E: in v2 mode the per-agent group + setgid contract covers

--- a/scripts/smoke/isolation.sh
+++ b/scripts/smoke/isolation.sh
@@ -15,6 +15,7 @@ trap cleanup EXIT
 main() {
   smoke_make_temp_root "isolation"
   smoke_run "v2 isolation rootless primitives" bash "$SMOKE_REPO_ROOT/tests/isolation-v2-primitives/smoke.sh"
+  smoke_run "isolated Claude read lens mask repair" bash "$SMOKE_REPO_ROOT/tests/isolation-claude-read-lens/smoke.sh"
   smoke_log "passed"
 }
 

--- a/tests/isolation-claude-read-lens/smoke.sh
+++ b/tests/isolation-claude-read-lens/smoke.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+TARGET="$REPO_ROOT/lib/bridge-agents.sh"
+
+python3 - "$TARGET" <<'PY'
+from pathlib import Path
+import sys
+
+text = Path(sys.argv[1]).read_text(encoding="utf-8")
+
+
+def body(name: str) -> str:
+    marker = f"{name}() {{"
+    start = text.find(marker)
+    if start < 0:
+        raise SystemExit(f"missing function: {name}")
+    pos = start + len(marker)
+    depth = 1
+    while pos < len(text):
+        ch = text[pos]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:pos]
+        pos += 1
+    raise SystemExit(f"unterminated function: {name}")
+
+
+helper = body("bridge_linux_repair_isolated_claude_read_lens")
+required_helper_fragments = [
+    'm::r-x',
+    'd -m "m::r-X"',
+    'find "$isolated_projects_dir" -type d',
+    'find "$isolated_projects_dir" -type f',
+    'm::r--',
+]
+missing = [fragment for fragment in required_helper_fragments if fragment not in helper]
+if missing:
+    raise SystemExit(f"read-lens helper missing fragments: {missing}")
+
+cred = body("bridge_linux_grant_claude_credentials_access")
+repair_call = (
+    'bridge_linux_repair_isolated_claude_read_lens '
+    '"$os_user" "$user_home" "$controller_user"'
+)
+repair_pos = cred.find(repair_call)
+early_return_pos = cred.find('if [[ "$current_target" == "$controller_cred_file" ]]; then')
+if repair_pos < 0:
+    raise SystemExit("credential repair path does not restore isolated Claude read lens")
+if early_return_pos < 0:
+    raise SystemExit("credential symlink early-return guard not found")
+if repair_pos > early_return_pos:
+    raise SystemExit("read lens repair must run before credential symlink early return")
+
+prepare = body("bridge_linux_prepare_agent_isolation")
+if repair_call not in prepare:
+    raise SystemExit("isolation prepare path does not use read-lens helper")
+
+print("isolation Claude read-lens smoke passed")
+PY


### PR DESCRIPTION
## Summary

Fixes a legacy linux-user isolation regression where the daemon's Claude credential repair path repeatedly reset the isolated UID's `~/.claude` ACL mask to `---`, nullifying the controller user's read lens on `~/.claude/projects`.

That read lens is required by the memory-daily harvester, which runs in controller context and scans the isolated agent's Claude transcripts with `--transcripts-home`.

## What changed

- Added `bridge_linux_repair_isolated_claude_read_lens` to restore:
  - controller `r-x` on isolated `~/.claude`
  - ACL mask `r-x` on the same directory
  - default controller `r-X` + default mask on `~/.claude`
  - controller read/traverse ACLs and masks under `~/.claude/projects`
- Call the read-lens repair immediately after the legacy credential helper's `chmod 0700 ~/.claude`, before the symlink early-return can exit.
- Reuse the helper from the isolation prepare path.
- Added a static smoke regression under `tests/isolation-claude-read-lens/smoke.sh`, wired into the required isolation smoke suite.

## Live verification

On the affected host, `sales_sean` was failing `memory-daily-sales_sean-memory--2026-04-29` with `skipped-permission` / `PermissionError` because:

- `state/memory-daily/sales_sean/` lacked write permission for `agent-bridge-sales_sean`.
- After fixing that, controller read access to `/home/agent-bridge-sales_sean/.claude/projects` kept being revoked because `~/.claude` mask returned to `---` every daemon tick.

After applying this patch to the live install and restarting the daemon:

- controller access remained stable after daemon ticks: `access_rc=0`
- rerun succeeded and produced an authoritative sidecar:
  - `summary: sales_sean/2026-04-28 queued queue-backfill`
  - `child_result_source: authoritative-sidecar`
- sales_sean received backfill task `#558`.

## Verification

- `bash -n lib/bridge-agents.sh scripts/smoke/isolation.sh tests/isolation-claude-read-lens/smoke.sh`
- `bash tests/isolation-claude-read-lens/smoke.sh`
- `bash scripts/smoke/isolation.sh`
- `scripts/ci-select-smoke.sh --suite required --changed-file lib/bridge-agents.sh --run`

Local note: `shellcheck` is not installed on this host; GitHub CI will run it.
