### PR TITLE
test: read roster reload smoke log from agent log dir

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5728,7 +5728,7 @@ text, count = pattern.subn(replacement, text, count=1)
 assert count == 1, (agent, path)
 path.write_text(text, encoding="utf-8")
 PY
-ROSTER_RELOAD_RUN_LOG="$BRIDGE_LOG_DIR/${ROSTER_RELOAD_AGENT}-$(date '+%Y%m%d').log"
+ROSTER_RELOAD_RUN_LOG="$BRIDGE_LOG_DIR/agents/$ROSTER_RELOAD_AGENT/$(date '+%Y%m%d').log"
 "$BASH4_BIN" "$REPO_ROOT/bridge-run.sh" "$ROSTER_RELOAD_AGENT" >/dev/null 2>&1 &
 ROSTER_RELOAD_PID=$!
 for _ in {1..40}; do


### PR DESCRIPTION
## Summary
- update legacy roster-reload smoke to read bridge-run logs from the current per-agent log directory

## Verification
- bash -n scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh
- shellcheck --severity=warning scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh
- git diff --check

This addresses manual full CI run 25082217050, where legacy-full-smoke reached the roster reload scenario and failed because it grepped the old logs/<agent>-YYYYMMDD.log path instead of logs/agents/<agent>/YYYYMMDD.log.