### PR TITLE
isolation: accept canonical temp paths

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2152,6 +2152,7 @@ bridge_linux_unshare_plugin_catalog() {
 bridge_tmp_ephemeral_path_is() {
   local path="${1:-}"
   local tmpdir="${TMPDIR:-}"
+  local tmpdir_real=""
 
   [[ -n "$path" ]] || return 1
   case "$path" in
@@ -2166,6 +2167,17 @@ bridge_tmp_ephemeral_path_is() {
         return 0
         ;;
     esac
+    if [[ -d "$tmpdir" ]]; then
+      tmpdir_real="$(cd -P "$tmpdir" 2>/dev/null && pwd -P || true)"
+      tmpdir_real="${tmpdir_real%/}"
+      if [[ -n "$tmpdir_real" && "$tmpdir_real" != "$tmpdir" ]]; then
+        case "$path" in
+          "$tmpdir_real"/tmp.*|"$tmpdir_real"/tmp.*/*)
+            return 0
+            ;;
+        esac
+      fi
+    fi
   fi
   return 1
 }

--- a/scripts/smoke/isolation.sh
+++ b/scripts/smoke/isolation.sh
@@ -12,8 +12,30 @@ cleanup() {
 }
 trap cleanup EXIT
 
+canonical_tmpdir_ephemeral_detector() {
+  local physical_tmp logical_tmp candidate result
+
+  physical_tmp="$SMOKE_TMP_ROOT/physical-tmp"
+  logical_tmp="$SMOKE_TMP_ROOT/logical-tmp"
+  candidate="$physical_tmp/tmp.bridge-home"
+
+  mkdir -p "$physical_tmp"
+  ln -s "$physical_tmp" "$logical_tmp"
+
+  result="$(TMPDIR="$logical_tmp" "$BASH" -c '
+    source "$1/bridge-lib.sh"
+    if bridge_tmp_ephemeral_path_is "$2"; then
+      printf yes
+    else
+      printf no
+    fi
+  ' -- "$SMOKE_REPO_ROOT" "$candidate")"
+  smoke_assert_eq "yes" "$result" "canonical TMPDIR path classified as ephemeral"
+}
+
 main() {
   smoke_make_temp_root "isolation"
+  smoke_run "ephemeral detector accepts physical TMPDIR paths" canonical_tmpdir_ephemeral_detector
   smoke_run "v2 isolation rootless primitives" bash "$SMOKE_REPO_ROOT/tests/isolation-v2-primitives/smoke.sh"
   smoke_log "passed"
 }


### PR DESCRIPTION
## Summary
- Treat TMPDIR physical paths as ephemeral when the logical TMPDIR resolves through a symlink.
- Add an isolation smoke regression for canonicalized temp roots.

## Verification
- /opt/homebrew/bin/bash -n lib/bridge-agents.sh scripts/smoke/isolation.sh scripts/smoke-test.sh
- shellcheck --severity=warning lib/bridge-agents.sh scripts/smoke/isolation.sh
- /opt/homebrew/bin/bash scripts/smoke/isolation.sh
- git diff --check

Note: full local required smoke on macOS still hits the pre-existing isolation-v2 primitive group-mode difference (`chgrp_setgid_recursive: dir mode unexpected: 750`); GitHub Linux runner is the source of truth for that suite.