### PR TITLE
test: derive legacy roster reload log path

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5728,7 +5728,11 @@ text, count = pattern.subn(replacement, text, count=1)
 assert count == 1, (agent, path)
 path.write_text(text, encoding="utf-8")
 PY
-ROSTER_RELOAD_RUN_LOG="$BRIDGE_LOG_DIR/agents/$ROSTER_RELOAD_AGENT/$(date '+%Y%m%d').log"
+ROSTER_RELOAD_RUN_LOG="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  printf "%s/%s.log" "$(bridge_agent_log_dir "$1")" "$(date "+%Y%m%d")"
+' -- "$ROSTER_RELOAD_AGENT")"
 "$BASH4_BIN" "$REPO_ROOT/bridge-run.sh" "$ROSTER_RELOAD_AGENT" >/dev/null 2>&1 &
 ROSTER_RELOAD_PID=$!
 for _ in {1..40}; do


### PR DESCRIPTION
## Summary
- Use bridge_agent_log_dir in the legacy roster reload fixture instead of hard-coding BRIDGE_LOG_DIR/agents.
- Fixes the v2 isolation log-path mismatch exposed by manual legacy-full-smoke.

## Verification
- /opt/homebrew/bin/bash -n scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh
- shellcheck --severity=warning scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh
- git diff --check

Manual full CI failure this addresses: https://github.com/SYRS-AI/agent-bridge-public/actions/runs/25083774537/job/73494759014