### PR TITLE
test: isolate legacy mark-idle inbox fixture

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6226,12 +6226,13 @@ CODEX_PROMPT_READY="$("$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; if 
 assert_contains "$CODEX_PROMPT_READY" "ok"
 
 log "ensuring mark-idle hook emits inbox summary context"
-HOOK_QUEUE_CREATE_OUTPUT="$(python3 "$REPO_ROOT/bridge-queue.py" create --to claude-static --title "Follow-up task" --from smoke --priority high --body "check inbox")"
+HOOK_INBOX_AGENT="mark-idle-inbox-$RUN_SUFFIX"
+HOOK_QUEUE_CREATE_OUTPUT="$(python3 "$REPO_ROOT/bridge-queue.py" create --to "$HOOK_INBOX_AGENT" --title "Follow-up task" --from smoke --priority high --body "check inbox")"
 assert_contains "$HOOK_QUEUE_CREATE_OUTPUT" "created task #"
-HOOK_CONTEXT_OUTPUT="$(BRIDGE_HOME="$REPO_ROOT" BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_ACTIVE_AGENT_DIR" BRIDGE_HISTORY_DIR="$BRIDGE_HISTORY_DIR" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" BRIDGE_ROSTER_FILE="$REPO_ROOT/agent-roster.sh" BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" BRIDGE_AGENT_ID="claude-static" "$BASH4_BIN" "$REPO_ROOT/hooks/mark-idle.sh")"
-assert_contains "$HOOK_CONTEXT_OUTPUT" "[Agent Bridge] 1 pending task(s) for claude-static."
+HOOK_CONTEXT_OUTPUT="$(BRIDGE_HOME="$REPO_ROOT" BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_ACTIVE_AGENT_DIR" BRIDGE_HISTORY_DIR="$BRIDGE_HISTORY_DIR" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" BRIDGE_ROSTER_FILE="$REPO_ROOT/agent-roster.sh" BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" BRIDGE_AGENT_ID="$HOOK_INBOX_AGENT" "$BASH4_BIN" "$REPO_ROOT/hooks/mark-idle.sh")"
+assert_contains "$HOOK_CONTEXT_OUTPUT" "[Agent Bridge] 1 pending task(s) for $HOOK_INBOX_AGENT."
 assert_contains "$HOOK_CONTEXT_OUTPUT" "ACTION REQUIRED: Use your Bash tool now."
-assert_contains "$HOOK_CONTEXT_OUTPUT" "Run exactly: ~/.agent-bridge/agb inbox claude-static"
+assert_contains "$HOOK_CONTEXT_OUTPUT" "Run exactly: ~/.agent-bridge/agb inbox $HOOK_INBOX_AGENT"
 assert_contains "$HOOK_CONTEXT_OUTPUT" "Highest priority: Task #"
 assert_contains "$HOOK_CONTEXT_OUTPUT" "Should the result of this task be shared with a human teammate?"
 


### PR DESCRIPTION
## Summary

Fixes the latest legacy-full-smoke failure by isolating the mark-idle inbox hook fixture from the shared `claude-static` smoke agent.

The legacy monolith can leave other open tasks for `claude-static` before this assertion, so expecting exactly one pending task for that shared agent is brittle. This switches the assertion to a dedicated `mark-idle-inbox-<suffix>` agent and keeps the exact pending-count assertion.

## Verification

- `/opt/homebrew/bin/bash -n scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh`
- `shellcheck --severity=warning scripts/smoke-test.sh scripts/smoke/legacy-full-smoke.sh`
- `git diff --check`
- local minimal mark-idle hook reproduction with an isolated `BRIDGE_TASK_DB`

## Failing run fixed

Latest manual full run failed only `legacy-full-smoke` at:
`mark-idle hook emits inbox summary context`
https://github.com/SYRS-AI/agent-bridge-public/actions/runs/25086532377
