### PR TITLE
fix(cron): disable MCP by default for non-channel disposable children (#468)

### DIFF
--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -440,24 +440,36 @@ def notify_admin_pressure_defer(run_id: str, job_name: str, probe: dict[str, Any
 
 
 def disable_mcp_for_request(request: dict[str, Any]) -> bool:
-    """#263: decide whether the disposable child should launch with MCP disabled.
+    """#263 + #468: decide whether the disposable child should launch with MCP disabled.
 
     Order of precedence:
-      1. ``BRIDGE_CRON_DISPOSABLE_DISABLE_MCP`` env override (ops A/B switch).
+      1. ``request['disposable_needs_channels']`` — channel relays need MCP
+         servers loaded to deliver, so we never disable in that case. Safety
+         override; nothing below can flip it back.
+      2. ``BRIDGE_CRON_DISPOSABLE_DISABLE_MCP`` env override (ops A/B switch).
          Set to ``1``/``true`` to force-disable MCP for every cron child;
          ``0``/``false`` to force-enable. Unset to defer to per-job config.
-      2. ``request['disable_mcp']`` from the job's ``metadata.disableMcp``
-         (or aliases) wired through ``bridge_cron_write_request``.
-      3. ``request['disposable_needs_channels']`` — channel relays need MCP
-         servers loaded to deliver, so we never disable in that case even if
-         the per-job flag says so. This is a safety override.
+      3. ``request['disable_mcp']`` from the job's ``metadata.disableMcp``
+         (or aliases) wired through ``bridge_cron_write_request``. When
+         explicitly set (``True``/``False``) the per-job choice wins.
+      4. **Default: True.** Non-channel cron disposables disable MCP unless
+         opted in. Disabling MCP cuts cold-start cost (~22K tokens / run on
+         the SYRS reference install) and prevents a cwd
+         ``settings.local.json`` ``enabledPlugins`` entry (e.g. telegram)
+         from auto-attaching in the disposable child and stealing the
+         parent agent's MCP poller via plugin singleton-lock (issue #468).
+         If a specific cron payload genuinely needs MCP tools, set
+         ``metadata.disableMcp = False`` on that job.
     """
     if disposable_needs_channels(request):
         return False
     override = os.environ.get("BRIDGE_CRON_DISPOSABLE_DISABLE_MCP")
     if override is not None and override.strip():
         return bool_flag(override)
-    return bool_flag(request.get("disable_mcp"))
+    raw = request.get("disable_mcp")
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        return True
+    return bool_flag(raw)
 
 
 def build_prompt(request: dict[str, Any], payload_text: str) -> str:


### PR DESCRIPTION
## Summary

- Flip `disable_mcp_for_request()` default from `False` to `True` for non-channel cron disposable children. Closes #468.
- Cuts cron cold-start cost ~49% (~22K input tokens / run on SYRS reference install) by passing `--strict-mcp-config` to `claude -p` so cwd `settings.local.json` `enabledPlugins` no longer auto-attach.
- Stops the plugin singleton-lock cascade behind #468: a cron disposable spawned in an agent home with `enabledPlugins.telegram@claude-plugins-official=true` was loading the telegram MCP server, and the plugin's stale-pid logic then SIGTERMed the parent Claude session's live poller every 15 min.

## Why this is a 1-line semantic flip, not a new mechanism

PR #263 already wired `--strict-mcp-config` into `run_claude()` (`bridge-cron-runner.py:664-665`). That code only fires when `disable_mcp_for_request()` returns `True`. Today the function returns `True` only when `metadata.disableMcp` is set on the job — i.e. opt-in. None of the existing recurring cron jobs (`event-reminder-30min`, `librarian-watchdog`, `picker-sweep`, etc.) carry that flag, so MCP loaded by default and #468 reproduced reliably.

This PR keeps the same mechanism, same env override, same per-job override — just flips the unset-metadata default to `True`. Channel-relay paths (`disposable_needs_channels=True`) are unchanged; the safety override at line 455 still wins above everything.

## Test plan

- [x] `python3 -m py_compile bridge-cron-runner.py` — OK
- [x] 8-case unit harness covering precedence chain:
  - safety override (`disposable_needs_channels=True` → False even when default would be True)
  - env override (`BRIDGE_CRON_DISPOSABLE_DISABLE_MCP=0` → False; `=1` → True)
  - per-job opt-out (`disable_mcp=False` and `'false'` → False)
  - per-job opt-in (`disable_mcp=True` → True)
  - default flip (missing key, `None`, `''` → True)
- [x] Live `claude -p` reproduction in `/tmp/agb-468-test/` with telegram plugin enabled, 4 flag variants:
  | flags | MCP cache dir | input cache_create tokens |
  |---|---|---|
  | (baseline) | created (10 plugins attach) | 45,482 |
  | `--strict-mcp-config --mcp-config /tmp/empty.json` | not created | 23,010 |
  | `--bare` | **FAIL — Not logged in** | — |
  | `--strict-mcp-config` (alone) | not created | 23,010 |

  → confirms `--strict-mcp-config` alone (no separate `--mcp-config <path>`) is sufficient and `--bare` is unsuitable for cron because it skips auth.
- [ ] Operator post-merge verification: pick a recurring cron with no `metadata.disableMcp` set, observe one slot, confirm `~/Library/Caches/claude-cli-nodejs/<workdir-slug>/mcp-logs-plugin-*/` does **not** gain a fresh jsonl in that window. Fix scope is intentionally narrow — only this default flip; observability is the operator's window.

## Regression matrix

| cron type | `disposable_needs_channels` | `metadata.disableMcp` | post-PR behavior | changed? |
|---|---|---|---|---|
| `event-reminder-30min` (jjujju) | False | unset | `--strict-mcp-config` applied | **fixed** |
| `librarian-watchdog`, `picker-sweep`, etc. | False | unset | `--strict-mcp-config` applied | side benefit (cold-start saving) |
| `cron-dispatch` (channel relay) | **True** | any | MCP loaded (safety override) | unchanged |
| MCP-dependent cron payloads | False | **`False`** explicit | MCP loaded (per-job opt-out) | unchanged |
| `BRIDGE_CRON_DISPOSABLE_DISABLE_MCP=0` install-wide | False | any | MCP loaded (env override) | unchanged |

## Out of scope

- Plugin-side fix (`claude-plugins-official/telegram@0.0.6/server.ts:54-69` singleton-lock that SIGTERMs sibling pollers without coordination). That's an upstream `claude-plugins-official` concern. flock-based pid file would generalize cleanly there since OS releases the lock on process exit, eliminating stale-pid handling entirely.
- Auto-detection of cron jobs that genuinely need MCP. Today operators flip `metadata.disableMcp=False` per-job on the few that do; a scan/migration helper can ship later if the opt-out list grows.

## References

- Issue: #468
- Verification comment with reproduction data: https://github.com/SYRS-AI/agent-bridge-public/issues/468#issuecomment-4340861717
- Prior wiring (mechanism already shipped): #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)
