### PR TITLE
Deprecate context-pressure admin queue pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,11 +115,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install integration dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y tmux
-
       - name: Show selected integration smoke
         run: bash ./scripts/ci-select-smoke.sh --suite integration --base "$BASE_SHA" --head "$HEAD_SHA"
 

--- a/README.md
+++ b/README.md
@@ -509,9 +509,9 @@ agb status
 
 ### 복원력 마커
 
-데몬은 에이전트가 살아 있는지와 별개로 여러 복원력 상태를 marker로 추적합니다. stall, crash-loop, 채널 health, context pressure는 서로 다른 상태로 기록되고, 필요한 경우 admin 큐나 외부 채널로 에스컬레이션됩니다.
+데몬은 에이전트가 살아 있는지와 별개로 여러 복원력 상태를 marker로 추적합니다. stall, crash-loop, 채널 health, context pressure는 서로 다른 상태로 기록됩니다. stall/crash-loop/channel health는 정책에 따라 admin 큐나 외부 채널로 에스컬레이션될 수 있지만, context pressure는 감사 로그와 상태 파일만 남깁니다.
 
-특히 context pressure는 프로세스 장애가 아닙니다. 세션이 정상 실행 중이어도 대화가 길어져 compaction, `NEXT-SESSION.md` handoff, 또는 재시작이 필요한 상태를 별도로 표시합니다.
+특히 context pressure는 프로세스 장애가 아닙니다. 세션이 정상 실행 중이어도 대화가 길어져 compaction이 가까워진 상태를 별도로 표시합니다. 자동 대응은 setup-time Claude Code native auto-compact 설정(#473) 쪽에서 처리하고, daemon은 `[context-pressure]` admin task나 `[admin-compact]` queue chain을 만들지 않습니다.
 
 ### MCP 고아 프로세스 정리
 

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -399,46 +399,6 @@ def emit_pressure_audit(run_id: str, target_agent: str, probe: dict[str, Any]) -
         pass
 
 
-def notify_admin_pressure_defer(run_id: str, job_name: str, probe: dict[str, Any]) -> None:
-    """Best-effort admin task creation. Failure is non-fatal — the deferred
-    status file is the durable record; this is the surfacing layer."""
-    admin_agent = os.environ.get("BRIDGE_ADMIN_AGENT_ID", "").strip()
-    if not admin_agent:
-        return
-    task_script = Path(__file__).resolve().parent / "bridge-task.sh"
-    if not task_script.is_file():
-        return
-    bash_bin = os.environ.get("BRIDGE_BASH_BIN") or os.environ.get("BASH") or "bash"
-    title = f"[cron-deferred] {job_name or run_id} memory pressure"
-    detail_lines = [f"- {key}: {value}" for key, value in probe.items()]
-    body = (
-        f"Cron dispatch deferred +{PRESSURE_DEFER_SECONDS // 60} min by pre-flight memory guard.\n\n"
-        f"- run_id: {run_id}\n"
-        f"- job_name: {job_name}\n"
-        + "\n".join(detail_lines)
-        + "\n\nThe disposable child was not spawned. The next scheduler tick will re-fire the slot.\n"
-    )
-    cmd = [
-        bash_bin,
-        str(task_script),
-        "create",
-        "--to",
-        admin_agent,
-        "--from",
-        "daemon",
-        "--priority",
-        "normal",
-        "--title",
-        title,
-        "--body",
-        body,
-    ]
-    try:
-        subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
-    except (OSError, subprocess.SubprocessError):
-        pass
-
-
 def disable_mcp_for_request(request: dict[str, Any]) -> bool:
     """#263 + #468: decide whether the disposable child should launch with MCP disabled.
 
@@ -829,13 +789,13 @@ def cmd_run(args: argparse.Namespace) -> int:
     # Probe BEFORE materialising prompt artifacts or spawning the child. On a
     # pressured host the child cold-load is what tips the disposable run past
     # its timeout (see issue body for the event-reminder-30min stall). We skip
-    # the spawn, mark the run deferred, audit the decision, and ping admin.
-    # The next scheduler tick re-fires the slot once memory recovers.
+    # the spawn, mark the run deferred, and audit the decision. The next
+    # scheduler tick re-fires the slot once memory recovers; no admin queue
+    # nudge is emitted (issue #472).
     pressure = check_memory_pressure()
     if pressure is not None:
         deferred_at = now_iso()
         target_agent = str(request.get("target_agent") or "")
-        job_name = str(request.get("job_name") or "")
         deferred_payload: dict[str, Any] = {
             "run_id": run_id,
             "state": "deferred",
@@ -850,7 +810,6 @@ def cmd_run(args: argparse.Namespace) -> int:
         }
         write_json(status_file, deferred_payload)
         emit_pressure_audit(run_id, target_agent, pressure)
-        notify_admin_pressure_defer(run_id, job_name, pressure)
         print(f"status: deferred")
         print(f"run_id: {run_id}")
         print(f"engine: {engine}")

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1492,103 +1492,6 @@ PY
   return "$changed"
 }
 
-bridge_context_pressure_decode_excerpt() {
-  local encoded="${1:-}"
-  python3 - "$encoded" <<'PY'
-import base64, sys
-payload = sys.argv[1]
-if not payload:
-    raise SystemExit(0)
-print(base64.b64decode(payload.encode("ascii")).decode("utf-8", errors="ignore"), end="")
-PY
-}
-
-bridge_context_pressure_title_prefix() {
-  local agent="$1"
-  printf '[context-pressure] %s ' "$agent"
-}
-
-bridge_context_pressure_title() {
-  local agent="$1"
-  local severity="$2"
-  printf '[context-pressure] %s (%s)' "$agent" "$severity"
-}
-
-bridge_context_pressure_priority() {
-  local severity="$1"
-  case "$severity" in
-    critical)
-      printf '%s' "urgent"
-      ;;
-    *)
-      printf '%s' "high"
-      ;;
-  esac
-}
-
-bridge_write_context_pressure_report_body() {
-  local agent="$1"
-  local session="$2"
-  local severity="$3"
-  local idle="$4"
-  local first_detected_ts="$5"
-  local matched_pattern="$6"
-  local excerpt="$7"
-  local body_file="$8"
-  local first_detected_iso=""
-
-  first_detected_iso="$(python3 - "$first_detected_ts" <<'PY'
-from datetime import datetime, timezone
-import sys
-try:
-    ts = int(sys.argv[1])
-except Exception:
-    ts = 0
-if ts > 0:
-    print(datetime.fromtimestamp(ts, timezone.utc).astimezone().isoformat())
-PY
-)"
-  local source_kind=""
-  source_kind="$(bridge_agent_source "$agent")"
-  mkdir -p "$(dirname "$body_file")"
-  {
-    echo "# Context Pressure Report"
-    echo
-    echo "- agent: $agent"
-    echo "- session: ${session:--}"
-    echo "- severity: $severity"
-    echo "- idle_seconds: $idle"
-    echo "- agent_source: ${source_kind:-static}"
-    echo "- first_detected_at: ${first_detected_iso:-$(bridge_now_iso)}"
-    echo "- detected_at: $(bridge_now_iso)"
-    if [[ -n "$matched_pattern" ]]; then
-      echo "- matched_pattern: $matched_pattern"
-    fi
-    echo
-    echo "## Recommended Next Action"
-    echo
-    if [[ "$source_kind" == "dynamic" ]]; then
-      echo "**Operator-managed.** This is a dynamic agent — the operator manages it directly in the TUI. Close this task with a one-line note \`dynamic agent — operator-managed\` and take no further action. See CLAUDE.md \`## Admin Static vs Dynamic Agent Boundary\` for the rule."
-    else
-      echo "**Resolve autonomously.** This is a static agent (end-user is on Discord/Telegram/Teams; cannot run any Claude Code command). Do not nudge the agent or its end-user."
-      echo
-      echo "Severity: $severity"
-      echo "Target agent: $agent"
-      echo "Target source: $source_kind"
-      echo
-      echo "If target_source == dynamic: close this task with note \`context-pressure: dynamic agent — operator-managed\`. Do NOT create follow-up tasks."
-      echo
-      echo "If target_source == static (this case): invoke \`agent-bridge agent compact $agent\` for warning-class pressure, or \`agent-bridge agent handoff $agent\` if the session is at critical and a fresh-session restart is the safer path. Both primitives reject dynamic agents (defense in depth) and write an \`admin_compact_invoked\` / \`admin_handoff_invoked\` audit row on the static path. Close this task with the action you took. See CLAUDE.md \`## Admin Static vs Dynamic Agent Boundary\` for the rule."
-    fi
-    echo
-    echo "## Recent Output"
-    echo
-    echo '```text'
-    printf '%s\n' "$excerpt"
-    echo '```'
-  } >"$body_file"
-}
-
 bridge_clear_context_pressure_state() {
   local agent="$1"
   rm -f "$(bridge_agent_context_pressure_state_file "$agent")"
@@ -1602,8 +1505,7 @@ bridge_note_context_pressure_state() {
   local last_detected_ts="$5"
   local last_scan_ts="$6"
   local last_report_ts="$7"
-  local task_id="$8"
-  local matched_pattern="${9:-}"
+  local matched_pattern="${8:-}"
   local state_file=""
 
   state_file="$(bridge_agent_context_pressure_state_file "$agent")"
@@ -1615,15 +1517,12 @@ CONTEXT_PRESSURE_FIRST_DETECTED_TS=$(printf '%q' "$first_detected_ts")
 CONTEXT_PRESSURE_LAST_DETECTED_TS=$(printf '%q' "$last_detected_ts")
 CONTEXT_PRESSURE_LAST_SCAN_TS=$(printf '%q' "$last_scan_ts")
 CONTEXT_PRESSURE_LAST_REPORT_TS=$(printf '%q' "$last_report_ts")
-CONTEXT_PRESSURE_TASK_ID=$(printf '%q' "$task_id")
 CONTEXT_PRESSURE_MATCHED_PATTERN=$(printf '%q' "$matched_pattern")
 EOF
 }
 
 process_context_pressure_reports() {
   local summary_output="${1:-}"
-  local admin_agent="${BRIDGE_ADMIN_AGENT_ID:-}"
-  local admin_available=0
   local changed=1
   local now_ts=0
   local agent=""
@@ -1645,34 +1544,16 @@ process_context_pressure_reports() {
   local last_detected_ts=0
   local last_scan_ts=0
   local last_report_ts=0
-  local task_id=""
   local matched_pattern=""
   local scan_interval="${BRIDGE_CONTEXT_PRESSURE_SCAN_INTERVAL_SECONDS:-60}"
-  # Cooldown between fresh report emissions for the same (agent, severity).
-  # BRIDGE_CONTEXT_PRESSURE_COOLDOWN_SEC is the documented knob (issue #184);
-  # BRIDGE_CONTEXT_PRESSURE_REPORT_COOLDOWN_SECONDS is accepted for backward
-  # compatibility with deployments that set the original name.
-  local report_cooldown="${BRIDGE_CONTEXT_PRESSURE_COOLDOWN_SEC:-${BRIDGE_CONTEXT_PRESSURE_REPORT_COOLDOWN_SECONDS:-1800}}"
   local capture=""
   local analysis_shell=""
   local severity=""
   local excerpt_hash=""
-  local excerpt_b64=""
-  local excerpt=""
-  local body_file=""
-  local title=""
-  local title_prefix=""
-  local priority=""
-  local existing_id=""
-  local create_output=""
   local inactive=0
 
   [[ "${BRIDGE_CONTEXT_PRESSURE_SCAN_ENABLED:-1}" == "1" ]] || return 1
-  if [[ -n "$admin_agent" ]] && bridge_agent_exists "$admin_agent"; then
-    admin_available=1
-  fi
   [[ "$scan_interval" =~ ^[0-9]+$ ]] || scan_interval=60
-  [[ "$report_cooldown" =~ ^[0-9]+$ ]] || report_cooldown=1800
   now_ts="$(date +%s)"
 
   while IFS=$'\t' read -r agent queued claimed blocked active idle last_seen last_nudge session engine workdir; do
@@ -1685,7 +1566,6 @@ process_context_pressure_reports() {
     last_detected_ts=0
     last_scan_ts=0
     last_report_ts=0
-    task_id=""
     matched_pattern=""
 
     if [[ -f "$state_file" ]]; then
@@ -1698,7 +1578,6 @@ process_context_pressure_reports() {
       last_detected_ts="${CONTEXT_PRESSURE_LAST_DETECTED_TS:-0}"
       last_scan_ts="${CONTEXT_PRESSURE_LAST_SCAN_TS:-0}"
       last_report_ts="${CONTEXT_PRESSURE_LAST_REPORT_TS:-0}"
-      task_id="${CONTEXT_PRESSURE_TASK_ID:-}"
       matched_pattern="${CONTEXT_PRESSURE_MATCHED_PATTERN:-}"
     fi
     [[ "$first_detected_ts" =~ ^[0-9]+$ ]] || first_detected_ts=0
@@ -1737,8 +1616,6 @@ process_context_pressure_reports() {
     severity=""
     matched_pattern=""
     excerpt_hash=""
-    excerpt_b64=""
-    excerpt=""
     if [[ -n "$capture" ]]; then
       # Issue #265 proposal A: same risk profile as the stall analyzer above
       # (per-agent per-cycle); cap subprocess time to keep the loop moving.
@@ -1747,14 +1624,11 @@ process_context_pressure_reports() {
         CONTEXT_PRESSURE_SEVERITY=""
         CONTEXT_PRESSURE_MATCHED_PATTERN=""
         CONTEXT_PRESSURE_EXCERPT_HASH=""
-        CONTEXT_PRESSURE_EXCERPT_B64=""
         # shellcheck disable=SC1091
         source /dev/stdin <<<"$analysis_shell"
         severity="${CONTEXT_PRESSURE_SEVERITY:-}"
         matched_pattern="${CONTEXT_PRESSURE_MATCHED_PATTERN:-}"
         excerpt_hash="${CONTEXT_PRESSURE_EXCERPT_HASH:-}"
-        excerpt_b64="${CONTEXT_PRESSURE_EXCERPT_B64:-}"
-        excerpt="$(bridge_context_pressure_decode_excerpt "$excerpt_b64")"
       fi
     fi
 
@@ -1769,21 +1643,13 @@ process_context_pressure_reports() {
       continue
     fi
 
-    # Severity change is a real edge: bump first_detected_ts, clear the last
-    # emit timestamp so the cooldown/find-open path can emit an escalated or
-    # freshly-downgraded report, and drop the stale task_id so a stale link
-    # doesn't shadow a new find-open result.
-    #
-    # Excerpt-hash change alone (same severity, captured text shifted by a
-    # cursor blink or HUD percent drift) is NOT an edge: resetting
-    # last_report_ts here used to bypass the cooldown every scan and — when
-    # the admin had since closed the existing task — caused a new
-    # [context-pressure] task to be created on every daemon sync cycle
-    # (issue #184).
+    # Severity change is a real edge for telemetry: bump first_detected_ts and
+    # write a fresh audit row. The daemon no longer emits [context-pressure]
+    # tasks or direct admin notifications; setup-time native auto-compact is
+    # the remediation path (issue #472/#473).
     if [[ "$previous_severity" != "$severity" ]]; then
       first_detected_ts="$now_ts"
       last_report_ts=0
-      task_id=""
       bridge_audit_log daemon context_pressure_detected "$agent" \
         --detail severity="$severity" \
         --detail excerpt_hash="$excerpt_hash" \
@@ -1797,12 +1663,8 @@ process_context_pressure_reports() {
       changed=0
     fi
 
-    # Issue #419: dynamic agents are operator-managed — admin doesn't act on
-    # context-pressure for them (the static-target task body itself instructs
-    # admin to close such tasks as no-ops). Skip task creation entirely
-    # instead of letting admin process and immediately close, same anti-pattern
-    # the v0.6.22 fix #393 closed for cron-followup memory_pressure deferrals.
-    # State is cleared so first_detected_ts doesn't accumulate indefinitely.
+    # Issue #419: dynamic agents are operator-managed. Keep the suppression
+    # audit and clear state so first_detected_ts doesn't accumulate forever.
     local source_kind=""
     source_kind="$(bridge_agent_source "$agent")"
     if [[ "$source_kind" == "dynamic" ]]; then
@@ -1817,60 +1679,7 @@ process_context_pressure_reports() {
     fi
 
     last_detected_ts="$now_ts"
-    title="$(bridge_context_pressure_title "$agent" "$severity")"
-    title_prefix="$(bridge_context_pressure_title_prefix "$agent")"
-    priority="$(bridge_context_pressure_priority "$severity")"
-    body_file="$(bridge_agent_context_pressure_report_file "$agent" "$severity")"
-    bridge_write_context_pressure_report_body "$agent" "$session" "$severity" "$idle" "$first_detected_ts" "$matched_pattern" "$excerpt" "$body_file"
-
-    # Issue #230-A: in the default policy, silent re-broadcast every
-    # `report_cooldown` for an agent that simply stayed in the same
-    # severity bucket is pure inbox noise — the admin already saw the
-    # first alert. Only `critical` keeps the legacy cooldown rebroadcast
-    # (that is an ongoing emergency, operators want the recurring ping).
-    # info/warning get a single alert per bucket entry; a severity change
-    # already zeroes last_report_ts above so an escalation still fires.
-    local should_emit=0
-    if (( last_report_ts == 0 )); then
-      should_emit=1
-    elif [[ "$severity" == "critical" ]] && (( now_ts - last_report_ts >= report_cooldown )); then
-      should_emit=1
-    fi
-
-    if [[ "$agent" == "$admin_agent" ]] && bridge_agent_has_notify_transport "$admin_agent"; then
-      if (( should_emit == 1 )); then
-        bridge_notify_send "$admin_agent" "$title" "Context pressure detected for ${agent}; compact or restart with handoff before quality degrades." "" "$priority" "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
-        last_report_ts="$now_ts"
-        bridge_audit_log daemon context_pressure_report "$admin_agent" \
-          --detail agent="$agent" \
-          --detail severity="$severity" \
-          --detail mode=direct_notify
-        changed=0
-      fi
-    elif (( admin_available == 1 )); then
-      existing_id="$(bridge_queue_cli find-open --agent "$admin_agent" --title-prefix "$title_prefix" 2>/dev/null || true)"
-      if [[ "$existing_id" =~ ^[0-9]+$ ]]; then
-        bridge_queue_cli update "$existing_id" --actor daemon --title "$title" --priority "$priority" --body-file "$body_file" >/dev/null 2>&1 || true
-        task_id="$existing_id"
-        last_report_ts="$now_ts"
-        changed=0
-      elif (( should_emit == 1 )); then
-        create_output="$(bridge_queue_cli create --to "$admin_agent" --from daemon --priority "$priority" --title "$title" --body-file "$body_file" 2>/dev/null || true)"
-        if [[ "$create_output" =~ created\ task\ \#([0-9]+) ]]; then
-          task_id="${BASH_REMATCH[1]}"
-          last_report_ts="$now_ts"
-          changed=0
-        fi
-      fi
-      if [[ -n "$task_id" ]]; then
-        bridge_audit_log daemon context_pressure_report "$admin_agent" \
-          --detail agent="$agent" \
-          --detail severity="$severity" \
-          --detail task_id="$task_id"
-      fi
-    fi
-
-    bridge_note_context_pressure_state "$agent" "$severity" "$excerpt_hash" "$first_detected_ts" "$last_detected_ts" "$now_ts" "$last_report_ts" "$task_id" "$matched_pattern"
+    bridge_note_context_pressure_state "$agent" "$severity" "$excerpt_hash" "$first_detected_ts" "$last_detected_ts" "$now_ts" "$last_report_ts" "$matched_pattern"
   done <<<"$summary_output"
 
   return "$changed"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -443,6 +443,123 @@ run_cp_case "338 B1: Welcome banner above a fresh 36% HUD -> warning silenced (b
   "" "hud:context_pct=36" \
   $'Welcome to Claude Code!\n\n> hi\n\nContext ███░░░░░░░ 36%\n'
 
+log "context-pressure daemon function: audit-only state transitions (issue #472)"
+CONTEXT_PRESSURE_UNIT_ROOT="$(mktemp -d "$TMP_ROOT/context-pressure-unit.XXXXXX")"
+CONTEXT_PRESSURE_UNIT_AUDIT="$CONTEXT_PRESSURE_UNIT_ROOT/audit.log"
+CONTEXT_PRESSURE_UNIT_STATE_DIR="$CONTEXT_PRESSURE_UNIT_ROOT/state"
+CONTEXT_PRESSURE_UNIT_HELPER="$CONTEXT_PRESSURE_UNIT_ROOT/context-pressure-functions.sh"
+mkdir -p "$CONTEXT_PRESSURE_UNIT_STATE_DIR"
+: >"$CONTEXT_PRESSURE_UNIT_AUDIT"
+awk '
+  /^bridge_clear_context_pressure_state\(\) \{/ { capture=1 }
+  capture { print }
+  capture && /^}[[:space:]]*$/ {
+    done += 1
+    if (done == 3) {
+      capture=0
+    }
+  }
+' "$REPO_ROOT/bridge-daemon.sh" >"$CONTEXT_PRESSURE_UNIT_HELPER"
+[[ -s "$CONTEXT_PRESSURE_UNIT_HELPER" ]] || die "could not extract context-pressure daemon functions"
+set +e
+CONTEXT_PRESSURE_UNIT_OUTPUT="$("$BASH4_BIN" -lc '
+set -euo pipefail
+state_dir="$1"
+audit_file="$2"
+helper="$3"
+SCRIPT_DIR="$PWD"
+export BRIDGE_CONTEXT_PRESSURE_SCAN_ENABLED=1
+export BRIDGE_CONTEXT_PRESSURE_SCAN_INTERVAL_SECONDS=0
+mkdir -p "$state_dir"
+
+analysis_severity=""
+analysis_hash=""
+analysis_pattern=""
+agent_source_mode="static"
+capture_empty=0
+
+bridge_agent_context_pressure_state_file() {
+  printf "%s/%s.env" "$state_dir" "$1"
+}
+
+bridge_audit_log() {
+  local actor="$1"
+  local action="$2"
+  local target="$3"
+  shift 3
+  {
+    printf "%s|%s|%s" "$actor" "$action" "$target"
+    for item in "$@"; do
+      printf "|%s" "$item"
+    done
+    printf "\n"
+  } >>"$audit_file"
+}
+
+bridge_tmux_session_exists() { return 0; }
+bridge_capture_recent() {
+  (( capture_empty == 1 )) && return 0
+  printf "Context remaining 8%%. Please compact soon."
+}
+bridge_with_timeout() {
+  cat >/dev/null || true
+  [[ -n "$analysis_severity" ]] || return 0
+  printf "CONTEXT_PRESSURE_SEVERITY=%q\n" "$analysis_severity"
+  printf "CONTEXT_PRESSURE_MATCHED_PATTERN=%q\n" "$analysis_pattern"
+  printf "CONTEXT_PRESSURE_EXCERPT_HASH=%q\n" "$analysis_hash"
+}
+bridge_agent_source() { printf "%s" "$agent_source_mode"; }
+bridge_queue_cli() { echo "bridge_queue_cli should not be called"; exit 99; }
+bridge_notify_send() { echo "bridge_notify_send should not be called"; exit 99; }
+daemon_info() { :; }
+
+# shellcheck disable=SC1090
+source "$helper"
+
+summary_static=$'"'"'static-agent\t0\t0\t0\t1\t0\t0\t0\tstatic-session\tclaude\t/tmp'"'"'
+summary_dynamic=$'"'"'dynamic-agent\t0\t0\t0\t1\t0\t0\t0\tdynamic-session\tclaude\t/tmp'"'"'
+
+analysis_severity=warning
+analysis_hash=hash-static
+analysis_pattern=hud:context_pct=72
+agent_source_mode=static
+process_context_pressure_reports "$summary_static" >/dev/null
+static_state="$(cat "$state_dir/static-agent.env")"
+[[ "$static_state" == *"CONTEXT_PRESSURE_SEVERITY=warning"* ]] || { echo "static severity missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_EXCERPT_HASH=hash-static"* ]] || { echo "static hash missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_FIRST_DETECTED_TS="* ]] || { echo "static first ts missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_LAST_DETECTED_TS="* ]] || { echo "static last detected ts missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_LAST_SCAN_TS="* ]] || { echo "static scan ts missing"; exit 1; }
+[[ "$static_state" != *"CONTEXT_PRESSURE_TASK_ID"* ]] || { echo "static task id persisted"; exit 1; }
+grep -q "daemon|context_pressure_detected|static-agent|--detail|severity=warning" "$audit_file" || { echo "static detected audit missing"; exit 1; }
+[[ ! -e "$state_dir/context-pressure/static-agent-warning.md" ]] || { echo "static report body created"; exit 1; }
+
+analysis_hash=hash-static-2
+process_context_pressure_reports "$summary_static" >/dev/null
+grep -q "daemon|context_pressure_detected|static-agent|--detail|severity=warning|--detail|excerpt_hash=hash-static-2|--detail|mode=hash_drift" "$audit_file" || { echo "hash drift audit missing"; exit 1; }
+
+analysis_hash=hash-dynamic
+agent_source_mode=dynamic
+bridge_note_context_pressure_state "dynamic-agent" "warning" "hash-dynamic" "10" "11" "12" "0" "hud:context_pct=72"
+process_context_pressure_reports "$summary_dynamic" >/dev/null
+[[ ! -e "$state_dir/dynamic-agent.env" ]] || { echo "dynamic state not cleared"; exit 1; }
+grep -q "daemon|context_pressure_suppressed|dynamic-agent|--detail|severity=warning|--detail|reason=dynamic_agent_operator_managed" "$audit_file" || { echo "dynamic suppressed audit missing"; exit 1; }
+! grep -q "daemon|context_pressure_detected|dynamic-agent" "$audit_file" || { echo "dynamic same-severity edge should not emit detected audit"; exit 1; }
+
+capture_empty=1
+analysis_severity=""
+agent_source_mode=static
+process_context_pressure_reports "$summary_static" >/dev/null
+[[ ! -e "$state_dir/static-agent.env" ]] || { echo "recovered state not cleared"; exit 1; }
+grep -q "daemon|context_pressure_recovered|static-agent|--detail|severity=warning|--detail|reason=no_pattern" "$audit_file" || { echo "recovered audit missing"; exit 1; }
+
+echo ok
+' _ "$CONTEXT_PRESSURE_UNIT_STATE_DIR" "$CONTEXT_PRESSURE_UNIT_AUDIT" "$CONTEXT_PRESSURE_UNIT_HELPER")"
+CONTEXT_PRESSURE_UNIT_RC=$?
+set -e
+[[ "$CONTEXT_PRESSURE_UNIT_RC" -eq 0 && "$CONTEXT_PRESSURE_UNIT_OUTPUT" == "ok" ]] || die "context-pressure daemon function unit failed: $CONTEXT_PRESSURE_UNIT_OUTPUT"
+log "  [ok] context-pressure daemon function audit/state transitions"
+
 log "stall-detector rate_limit/auth regex narrowing (#329 Track A)"
 # Self-contained classifier checks for the bare `\b429\b` / `\bunauthorized\b`
 # narrowing. Mirrors the #161 timeout fix: bare numerics/keywords now require

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7540,9 +7540,7 @@ pressure_probe = {
 }
 module.check_memory_pressure = lambda: dict(pressure_probe)
 audit_calls = []
-notify_calls = []
 module.emit_pressure_audit = lambda run_id, target, probe: audit_calls.append((run_id, target, dict(probe)))
-module.notify_admin_pressure_defer = lambda run_id, job, probe: notify_calls.append((run_id, job, dict(probe)))
 subprocess.run = fake_run
 try:
     args = argparse.Namespace(request_file=request_file, dry_run=False)
@@ -7567,7 +7565,6 @@ assert not any("codex" in os.path.basename(b) for b in spawn_bins), (
 )
 assert audit_calls, "expected emit_pressure_audit to be called"
 assert audit_calls[0][2]["reason"] == "memory_pressure"
-assert notify_calls, "expected notify_admin_pressure_defer to be called"
 
 # Reset for the healthy-path probe.
 status_file.unlink(missing_ok=True)
@@ -9183,19 +9180,26 @@ BRIDGE_CONTEXT_PRESSURE_SCAN_ENABLED=1 \
 BRIDGE_CONTEXT_PRESSURE_SCAN_INTERVAL_SECONDS=0 \
 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 CONTEXT_PRESSURE_TASK_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[context-pressure] $CONTEXT_PRESSURE_AGENT " 2>/dev/null || true)"
-[[ "$CONTEXT_PRESSURE_TASK_ID" =~ ^[0-9]+$ ]] || die "expected context-pressure report task"
+[[ ! "$CONTEXT_PRESSURE_TASK_ID" =~ ^[0-9]+$ ]] || die "context-pressure scanner should not create report task"
 CONTEXT_PRESSURE_BODY_FILE="$BRIDGE_SHARED_DIR/context-pressure/$CONTEXT_PRESSURE_AGENT-warning.md"
-[[ -f "$CONTEXT_PRESSURE_BODY_FILE" ]] || die "expected context-pressure report body"
-CONTEXT_PRESSURE_BODY="$(cat "$CONTEXT_PRESSURE_BODY_FILE")"
-assert_contains "$CONTEXT_PRESSURE_BODY" "# Context Pressure Report"
-assert_contains "$CONTEXT_PRESSURE_BODY" "severity: warning"
-assert_contains "$CONTEXT_PRESSURE_BODY" "Context remaining 8%"
+[[ ! -e "$CONTEXT_PRESSURE_BODY_FILE" ]] || die "context-pressure scanner should not write report body"
+CONTEXT_PRESSURE_STATE_FILE="$BRIDGE_ACTIVE_AGENT_DIR/$CONTEXT_PRESSURE_AGENT/context-pressure.env"
+[[ -f "$CONTEXT_PRESSURE_STATE_FILE" ]] || die "expected context-pressure telemetry state"
+CONTEXT_PRESSURE_STATE="$(cat "$CONTEXT_PRESSURE_STATE_FILE")"
+assert_contains "$CONTEXT_PRESSURE_STATE" "CONTEXT_PRESSURE_SEVERITY=warning"
+assert_not_contains "$CONTEXT_PRESSURE_STATE" "CONTEXT_PRESSURE_TASK_ID"
+CONTEXT_DETECTED_JSON="$("$REPO_ROOT/agent-bridge" audit --action context_pressure_detected --limit 20 --json)"
+python3 - "$CONTEXT_DETECTED_JSON" "$CONTEXT_PRESSURE_AGENT" <<'PY'
+import json, sys
+rows = json.loads(sys.argv[1])
+assert any(row.get("target") == sys.argv[2] for row in rows), rows
+PY
 [[ ! -s "$CONTEXT_PRESSURE_INPUT_LOG" ]] || die "context pressure scanner must not inject messages into the active session"
 BRIDGE_CONTEXT_PRESSURE_SCAN_ENABLED=1 \
 BRIDGE_CONTEXT_PRESSURE_SCAN_INTERVAL_SECONDS=0 \
 bash "$REPO_ROOT/bridge-daemon.sh" sync >/dev/null
 CONTEXT_PRESSURE_TASK_ID_AGAIN="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$SMOKE_AGENT" --title-prefix "[context-pressure] $CONTEXT_PRESSURE_AGENT " 2>/dev/null || true)"
-[[ "$CONTEXT_PRESSURE_TASK_ID_AGAIN" == "$CONTEXT_PRESSURE_TASK_ID" ]] || die "expected deduped context-pressure report"
+[[ ! "$CONTEXT_PRESSURE_TASK_ID_AGAIN" =~ ^[0-9]+$ ]] || die "context-pressure scanner should remain audit-only on repeated scan"
 tmux_kill_session_exact "$CONTEXT_PRESSURE_AGENT" || true
 "$BASH4_BIN" -lc "source \"$REPO_ROOT/bridge-lib.sh\"; bridge_load_roster; bridge_agent_mark_manual_stop \"$CONTEXT_PRESSURE_AGENT\""
 BRIDGE_CONTEXT_PRESSURE_SCAN_ENABLED=1 \
@@ -9209,12 +9213,12 @@ assert any(row.get("target") == sys.argv[2] for row in rows), rows
 PY
 
 log "context-pressure FP-rate counter (#338 Track C)"
-# Fixture: emit a fake [context-pressure] critical task body (the daemon's
-# own format), seed a context_pressure_report audit row so the dashboard
-# denominator picks it up, then close the task with a "false-positive"
-# operator note via bridge-task.sh and assert (a) the audit row was
-# written by bridge-task.sh and (b) `agent-bridge status` renders the
-# 1/1 (100%) line.
+# Fixture: emit a legacy [context-pressure] critical task body and seed a
+# context_pressure_report audit row so the dashboard denominator still covers
+# historical reports. The daemon no longer emits these rows itself (#472).
+# Then close the task with a "false-positive" operator note via bridge-task.sh
+# and assert (a) the audit row was written by bridge-task.sh and (b)
+# `agent-bridge status` renders the 1/1 (100%) line.
 FP_AGENT="fp-counter-$SESSION_NAME"
 FP_BODY_DIR="$BRIDGE_SHARED_DIR/context-pressure"
 FP_BODY_FILE="$FP_BODY_DIR/$FP_AGENT-critical.md"
@@ -9244,7 +9248,7 @@ EOF
 FP_TASK_CREATE_OUTPUT="$(BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 "$REPO_ROOT/bridge-queue.py" create --to "$SMOKE_AGENT" --from daemon --priority urgent --title "[context-pressure] $FP_AGENT (critical)" --body-file "$FP_BODY_FILE" --format shell)"
 FP_TASK_ID="$(printf '%s\n' "$FP_TASK_CREATE_OUTPUT" | sed -n "s/^TASK_ID=//p" | tr -d "'\"" | head -n1)"
 [[ "$FP_TASK_ID" =~ ^[0-9]+$ ]] || die "expected fp-counter task id, got: $FP_TASK_ID"
-# Seed the denominator row exactly as the daemon would (process_context_pressure_reports).
+# Seed the legacy denominator row that older daemon versions emitted.
 python3 "$REPO_ROOT/bridge-audit.py" write --file "$BRIDGE_AUDIT_LOG" \
   --actor daemon --action context_pressure_report --target "$SMOKE_AGENT" \
   --detail agent="$FP_AGENT" \

--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -44,6 +44,132 @@ EOF
   smoke_assert_eq $'blocked\nallowed-after-clear' "$output" "daemon autostart broken-launch gate"
 }
 
+daemon_context_pressure_audit_state_transitions() {
+  local root audit_file state_dir helper output rc bash_bin
+
+  root="$(mktemp -d "$SMOKE_TMP_ROOT/context-pressure-unit.XXXXXX")"
+  audit_file="$root/audit.log"
+  state_dir="$root/state"
+  helper="$root/context-pressure-functions.sh"
+  mkdir -p "$state_dir"
+  : >"$audit_file"
+
+  awk '
+    /^bridge_clear_context_pressure_state\(\) \{/ { capture=1 }
+    capture { print }
+    capture && /^}[[:space:]]*$/ {
+      done += 1
+      if (done == 3) {
+        capture=0
+      }
+    }
+  ' "$SMOKE_REPO_ROOT/bridge-daemon.sh" >"$helper"
+  [[ -s "$helper" ]] || smoke_fail "context pressure: could not extract daemon functions"
+
+  bash_bin="${BASH4_BIN:-}"
+  if [[ -z "$bash_bin" || ! -x "$bash_bin" ]]; then
+    bash_bin="$(command -v bash)"
+  fi
+
+  set +e
+  output="$("$bash_bin" -lc '
+set -euo pipefail
+state_dir="$1"
+audit_file="$2"
+helper="$3"
+SCRIPT_DIR="$PWD"
+export BRIDGE_CONTEXT_PRESSURE_SCAN_ENABLED=1
+export BRIDGE_CONTEXT_PRESSURE_SCAN_INTERVAL_SECONDS=0
+mkdir -p "$state_dir"
+
+analysis_severity=""
+analysis_hash=""
+analysis_pattern=""
+agent_source_mode="static"
+capture_empty=0
+
+bridge_agent_context_pressure_state_file() {
+  printf "%s/%s.env" "$state_dir" "$1"
+}
+
+bridge_audit_log() {
+  local actor="$1"
+  local action="$2"
+  local target="$3"
+  shift 3
+  {
+    printf "%s|%s|%s" "$actor" "$action" "$target"
+    for item in "$@"; do
+      printf "|%s" "$item"
+    done
+    printf "\n"
+  } >>"$audit_file"
+}
+
+bridge_tmux_session_exists() { return 0; }
+bridge_capture_recent() {
+  (( capture_empty == 1 )) && return 0
+  printf "Context remaining 8%%. Please compact soon."
+}
+bridge_with_timeout() {
+  cat >/dev/null || true
+  [[ -n "$analysis_severity" ]] || return 0
+  printf "CONTEXT_PRESSURE_SEVERITY=%q\n" "$analysis_severity"
+  printf "CONTEXT_PRESSURE_MATCHED_PATTERN=%q\n" "$analysis_pattern"
+  printf "CONTEXT_PRESSURE_EXCERPT_HASH=%q\n" "$analysis_hash"
+}
+bridge_agent_source() { printf "%s" "$agent_source_mode"; }
+bridge_queue_cli() { echo "bridge_queue_cli should not be called"; exit 99; }
+bridge_notify_send() { echo "bridge_notify_send should not be called"; exit 99; }
+daemon_info() { :; }
+
+# shellcheck disable=SC1090
+source "$helper"
+
+summary_static=$'"'"'static-agent\t0\t0\t0\t1\t0\t0\t0\tstatic-session\tclaude\t/tmp'"'"'
+summary_dynamic=$'"'"'dynamic-agent\t0\t0\t0\t1\t0\t0\t0\tdynamic-session\tclaude\t/tmp'"'"'
+
+analysis_severity=warning
+analysis_hash=hash-static
+analysis_pattern=hud:context_pct=72
+agent_source_mode=static
+process_context_pressure_reports "$summary_static" >/dev/null
+static_state="$(cat "$state_dir/static-agent.env")"
+[[ "$static_state" == *"CONTEXT_PRESSURE_SEVERITY=warning"* ]] || { echo "static severity missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_EXCERPT_HASH=hash-static"* ]] || { echo "static hash missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_FIRST_DETECTED_TS="* ]] || { echo "static first ts missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_LAST_DETECTED_TS="* ]] || { echo "static last detected ts missing"; exit 1; }
+[[ "$static_state" == *"CONTEXT_PRESSURE_LAST_SCAN_TS="* ]] || { echo "static scan ts missing"; exit 1; }
+[[ "$static_state" != *"CONTEXT_PRESSURE_TASK_ID"* ]] || { echo "static task id persisted"; exit 1; }
+grep -q "daemon|context_pressure_detected|static-agent|--detail|severity=warning" "$audit_file" || { echo "static detected audit missing"; exit 1; }
+[[ ! -e "$state_dir/context-pressure/static-agent-warning.md" ]] || { echo "static report body created"; exit 1; }
+
+analysis_hash=hash-static-2
+process_context_pressure_reports "$summary_static" >/dev/null
+grep -q "daemon|context_pressure_detected|static-agent|--detail|severity=warning|--detail|excerpt_hash=hash-static-2|--detail|mode=hash_drift" "$audit_file" || { echo "hash drift audit missing"; exit 1; }
+
+analysis_hash=hash-dynamic
+agent_source_mode=dynamic
+bridge_note_context_pressure_state "dynamic-agent" "warning" "hash-dynamic" "10" "11" "12" "0" "hud:context_pct=72"
+process_context_pressure_reports "$summary_dynamic" >/dev/null
+[[ ! -e "$state_dir/dynamic-agent.env" ]] || { echo "dynamic state not cleared"; exit 1; }
+grep -q "daemon|context_pressure_suppressed|dynamic-agent|--detail|severity=warning|--detail|reason=dynamic_agent_operator_managed" "$audit_file" || { echo "dynamic suppressed audit missing"; exit 1; }
+! grep -q "daemon|context_pressure_detected|dynamic-agent" "$audit_file" || { echo "dynamic same-severity edge should not emit detected audit"; exit 1; }
+
+capture_empty=1
+analysis_severity=""
+agent_source_mode=static
+process_context_pressure_reports "$summary_static" >/dev/null
+[[ ! -e "$state_dir/static-agent.env" ]] || { echo "recovered state not cleared"; exit 1; }
+grep -q "daemon|context_pressure_recovered|static-agent|--detail|severity=warning|--detail|reason=no_pattern" "$audit_file" || { echo "recovered audit missing"; exit 1; }
+
+echo ok
+' _ "$state_dir" "$audit_file" "$helper")"
+  rc=$?
+  set -e
+  [[ "$rc" -eq 0 && "$output" == "ok" ]] || smoke_fail "context pressure audit/state transitions failed: $output"
+}
+
 daemon_stale_claim_requeue() {
   local create_out task_id snapshot now_ts old_ts show_out
 
@@ -134,6 +260,7 @@ main() {
   smoke_setup_bridge_home "daemon"
   python3 "$SMOKE_REPO_ROOT/bridge-queue.py" init >/dev/null
   smoke_run "autostart quarantine gate" daemon_autostart_gate
+  smoke_run "context pressure audit/state transitions" daemon_context_pressure_audit_state_transitions
   smoke_run "stale claimed tasks requeue deterministically" daemon_stale_claim_requeue
   smoke_run "blocked task reminder/escalation aging" daemon_blocked_aging
   smoke_log "passed"

--- a/tests/admin-static-dynamic-boundary/smoke.sh
+++ b/tests/admin-static-dynamic-boundary/smoke.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # tests/admin-static-dynamic-boundary/smoke.sh
 #
-# Regression test for issue #304 — admin static/dynamic boundary
-# (Tracks B + C). Verifies (portable, runs on macOS with bash 4+):
+# Regression test for issue #304 — admin static/dynamic boundary.
+# Verifies (portable, runs on macOS with bash 4+):
 #
 #   1. `agent-bridge agent compact <static>` enqueues a synthetic
 #      [admin-compact] task to the static agent and writes an
@@ -14,11 +14,6 @@
 #      [admin-handoff] task. Body references the bridge-spec
 #      <agent-home>/NEXT-SESSION.md filename so the receiving agent
 #      writes the handoff at the path SessionStart hook auto-consumes.
-#   4. The Track C daemon body builder emits the role-aware conditional
-#      block — both the `if target_source == dynamic` close path and
-#      the `agent-bridge agent compact <agent>` / `agent-bridge agent
-#      handoff <agent>` invocation are present in the static-agent
-#      body.
 #
 # This test stands up an isolated BRIDGE_HOME under mktemp, never
 # touches the live bridge state, and does not require a running tmux
@@ -211,69 +206,5 @@ no_dyn_handoff_task="$(sqlite3 "$BRIDGE_TASK_DB" \
   "SELECT COUNT(*) FROM tasks WHERE assigned_to='$DYNAMIC_AGENT' AND title LIKE '[admin-handoff]%'")"
 [[ "$no_dyn_handoff_task" == "0" ]] \
   || die "agent handoff <dynamic> created a queue task ($no_dyn_handoff_task) — must NOT enqueue when rejected"
-
-# ---------------------------------------------------------------------------
-# Step 4: Track C — daemon body builder emits role-aware conditional block
-# ---------------------------------------------------------------------------
-
-log "step 4 — Track C daemon body for static target"
-# bridge_write_context_pressure_report_body is a daemon helper; we sourcestate
-# the daemon script in a subshell so the function definition is available
-# without starting the daemon proper. The function depends on bridge_now_iso
-# + bridge_agent_source, both of which are in lib/bridge-state.sh and
-# lib/bridge-agents.sh and are loaded via bridge-lib.sh.
-body_file="$TMP_ROOT/static-body.md"
-(
-  set +u
-  # shellcheck source=../../bridge-lib.sh
-  source "$REPO_ROOT/bridge-lib.sh"
-  bridge_load_roster
-  # bridge-daemon.sh defines the body builder near the top; sourcing the
-  # whole script triggers its own startup work, so we extract just the
-  # function body via awk.
-  helper_src="$TMP_ROOT/body-builder.sh"
-  awk '
-    /^bridge_write_context_pressure_report_body\(\) \{/ { capture=1 }
-    capture { print }
-    capture && /^}$/ { capture=0 }
-  ' "$REPO_ROOT/bridge-daemon.sh" > "$helper_src"
-  [[ -s "$helper_src" ]] || die "could not extract body builder from bridge-daemon.sh"
-  # shellcheck disable=SC1090
-  source "$helper_src"
-  bridge_write_context_pressure_report_body \
-    "$STATIC_AGENT" "$STATIC_AGENT" warning 0 0 hud:context_pct=85 "demo excerpt" "$body_file"
-)
-[[ -s "$body_file" ]] || die "static body file empty: $body_file"
-grep -q "Target source: static" "$body_file" \
-  || die "static body missing 'Target source: static'"
-grep -q "If target_source == dynamic" "$body_file" \
-  || die "static body missing dynamic-branch close instruction"
-grep -q "agent-bridge agent compact $STATIC_AGENT" "$body_file" \
-  || die "static body missing 'agent-bridge agent compact <agent>' invocation"
-grep -q "agent-bridge agent handoff $STATIC_AGENT" "$body_file" \
-  || die "static body missing 'agent-bridge agent handoff <agent>' invocation"
-
-log "step 4 — Track C daemon body for dynamic target uses the close path"
-dyn_body_file="$TMP_ROOT/dynamic-body.md"
-(
-  set +u
-  # shellcheck source=../../bridge-lib.sh
-  source "$REPO_ROOT/bridge-lib.sh"
-  bridge_load_roster
-  helper_src="$TMP_ROOT/body-builder.sh"
-  # shellcheck disable=SC1090
-  source "$helper_src"
-  bridge_write_context_pressure_report_body \
-    "$DYNAMIC_AGENT" "$DYNAMIC_AGENT" warning 0 0 hud:context_pct=85 "demo excerpt" "$dyn_body_file"
-)
-[[ -s "$dyn_body_file" ]] || die "dynamic body file empty: $dyn_body_file"
-grep -q "Operator-managed" "$dyn_body_file" \
-  || die "dynamic body missing 'Operator-managed' close instruction"
-# Defense-in-depth: the dynamic-branch body must NOT recommend invoking
-# the new primitives (those reject dynamic anyway, but the body should
-# not even suggest them and make admin try).
-if grep -q "agent-bridge agent compact $DYNAMIC_AGENT" "$dyn_body_file"; then
-  die "dynamic body must not recommend 'agent compact'; admin should close as operator-managed"
-fi
 
 log "all steps passed"


### PR DESCRIPTION
## Summary
- Remove daemon-driven `[context-pressure]` queue task/direct admin notification emission while preserving detection, audit, suppression, recovery, and telemetry state.
- Remove cron-runner `notify_admin_pressure_defer`; pressured cron dispatches now defer + audit only, with no admin queue nudge.
- Update smoke expectations so context-pressure scan is audit/state-only, and keep manual `agent compact` / `agent handoff` primitives covered.
- Update README resilience marker docs to point context-pressure remediation at setup-time native auto-compact (#473).

## What intentionally stays
- `bridge-context-pressure.py` analyzer remains unchanged.
- `agent-bridge agent compact <agent>` and `agent-bridge agent handoff <agent>` manual primitives remain unchanged.
- `NEXT-SESSION.md` SessionStart handling remains untouched.
- Textual role-spec edits in `_template/CLAUDE.md` / `docs/agent-runtime/admin-protocol.md` are intentionally deferred because PR #476/#471 owns the doc-slim movement.

## Verification
- `python3 -m py_compile bridge-cron-runner.py bridge-context-pressure.py`
- `for f in bridge-daemon.sh scripts/smoke-test.sh tests/admin-static-dynamic-boundary/smoke.sh agent-bridge agb; do bash -n "$f" || exit 1; done`
- `shellcheck bridge-daemon.sh scripts/smoke-test.sh tests/admin-static-dynamic-boundary/smoke.sh`
- `bash scripts/ci-select-smoke.sh --suite required --changed-file bridge-daemon.sh --changed-file bridge-cron-runner.py --changed-file scripts/smoke-test.sh --changed-file tests/admin-static-dynamic-boundary/smoke.sh --run`
- `bash scripts/ci-select-smoke.sh --suite integration --changed-file bridge-daemon.sh --changed-file bridge-cron-runner.py --changed-file scripts/smoke-test.sh --changed-file tests/admin-static-dynamic-boundary/smoke.sh --run`
- `/opt/homebrew/bin/bash tests/admin-static-dynamic-boundary/smoke.sh`
- context-pressure function unit: stubs `process_context_pressure_reports`, asserts `context_pressure_detected` audit + state file and no `CONTEXT_PRESSURE_TASK_ID`
- `grep -nE 'context.pressure.*create|admin-compact' bridge-daemon.sh` -> no output
- `grep -nE 'notify_admin_pressure_defer|admin-pressure' bridge-cron-runner.py bridge-cron.py lib/bridge-cron.sh scripts/` -> no output

References #472, #473, #184, #419
