### PR TITLE
bridge: pin Claude auto-compact window

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1310,6 +1310,9 @@ run_create() {
       "$isolation_mode" \
       "$os_user" >/dev/null
     bridge_load_roster
+    if [[ "$engine" == "claude" ]]; then
+      bridge_ensure_claude_shared_settings_for_managed_workdir "$workdir" >/dev/null 2>&1 || true
+    fi
     bridge_sync_skill_docs "$agent" >/dev/null 2>&1 || true
     if [[ "$isolation_mode" == "linux-user" ]]; then
       bridge_linux_prepare_agent_isolation "$agent" "$os_user" "$workdir"

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -13,6 +13,15 @@ from pathlib import Path
 from typing import Any
 
 
+# Claude Code 2.1.123 exposes autoCompactWindow in user settings. Avoid
+# setting CLAUDE_CODE_AUTO_COMPACT_WINDOW here because that env var takes
+# precedence over settings and would make operator overlays harder to reason
+# about.
+BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS: dict[str, Any] = {
+    "autoCompactWindow": 400000,
+}
+
+
 def load_json(path: Path) -> Any:
     if not path.exists():
         return {}
@@ -723,7 +732,8 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
     if not isinstance(overlay_payload, dict):
         raise SystemExit(f"shared settings overlay must be a JSON object: {overlay_path}")
 
-    merged = merge_settings(base_payload, overlay_payload)
+    merged = merge_settings(BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS, base_payload)
+    merged = merge_settings(merged, overlay_payload)
     save_json(effective_path, merged)
 
     payload = {

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -438,6 +438,13 @@ else
   bridge_load_roster
 fi
 
+if [[ $dry_run -eq 0 ]] && [[ "$(bridge_agent_engine "$admin_agent" 2>/dev/null || printf '%s' "$engine")" == "claude" ]]; then
+  admin_workdir="$(bridge_agent_workdir "$admin_agent" 2>/dev/null || true)"
+  if [[ -n "$admin_workdir" ]]; then
+    bridge_ensure_claude_shared_settings_for_managed_workdir "$admin_workdir" >/dev/null 2>&1 || true
+  fi
+fi
+
 if [[ $skip_channel_setup -eq 0 ]] && [[ $dry_run -eq 0 ]]; then
   channel_setup_status="ok"
   if bridge_channel_csv_contains "$channels" "plugin:discord"; then

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -167,6 +167,24 @@ bridge_upgrade_with_target_env() {
     "$@"
 }
 
+bridge_upgrade_propagate_claude_shared_settings() {
+  local target_root="$1"
+
+  bridge_upgrade_with_target_env "$target_root" "$BRIDGE_BASH_BIN" -lc '
+    set -euo pipefail
+    source "$1/bridge-lib.sh"
+    bridge_load_roster
+    agent=""
+    workdir=""
+    for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+      [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || continue
+      workdir="$(bridge_agent_workdir "$agent")"
+      [[ -n "$workdir" ]] || continue
+      bridge_ensure_claude_shared_settings_for_managed_workdir "$workdir" >/dev/null 2>&1 || true
+    done
+  ' -- "$target_root"
+}
+
 bridge_upgrade_collect_agent_restart_report() {
   local target_root="$1"
   local dry_run="${2:-0}"
@@ -1134,6 +1152,10 @@ if [[ $STRICT_MERGE -eq 1 ]]; then
 fi
 APPLY_JSON="$(python3 "$SOURCE_ROOT/bridge-upgrade.py" "${apply_args[@]}")"
 AGENT_RESTART_JSON="$(bridge_upgrade_agent_restart_json "" 0 "$DRY_RUN")"
+
+if [[ $DRY_RUN -eq 0 ]]; then
+  bridge_upgrade_propagate_claude_shared_settings "$TARGET_ROOT" >/dev/null 2>&1 || true
+fi
 
 if [[ $MIGRATE_AGENTS -eq 1 ]]; then
   if [[ $DRY_RUN -eq 1 ]]; then

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -39,12 +39,52 @@ bridge_hook_shared_settings_effective_file() {
   printf '%s/.claude/settings.effective.json' "$BRIDGE_AGENT_HOME_ROOT"
 }
 
+bridge_hook_paths_equal() {
+  local left="$1"
+  local right="$2"
+
+  bridge_require_python
+  python3 - "$left" "$right" <<'PY'
+import os
+import sys
+
+left = os.path.realpath(sys.argv[1])
+right = os.path.realpath(sys.argv[2])
+print("1" if left == right else "0")
+PY
+}
+
 bridge_claude_settings_mode() {
   local workdir="$1"
+  local agent=""
+  local agent_workdir=""
+
   if [[ "$(bridge_path_is_within_root "$workdir" "$BRIDGE_AGENT_HOME_ROOT")" == "1" ]]; then
     printf 'shared'
+    return 0
+  fi
+
+  if declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1; then
+    for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+      [[ "$(bridge_agent_engine "$agent" 2>/dev/null || true)" == "claude" ]] || continue
+      agent_workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
+      [[ -n "$agent_workdir" ]] || continue
+      if [[ "$(bridge_hook_paths_equal "$workdir" "$agent_workdir")" == "1" ]]; then
+        printf 'shared'
+        return 0
+      fi
+    done
+  fi
+
+  printf 'local'
+}
+
+bridge_ensure_claude_shared_settings_for_managed_workdir() {
+  local workdir="$1"
+  if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
+    bridge_link_claude_settings_to_shared "$workdir"
   else
-    printf 'local'
+    return 0
   fi
 }
 

--- a/scripts/smoke/hooks.sh
+++ b/scripts/smoke/hooks.sh
@@ -67,6 +67,129 @@ claude_hooks_contract() {
   smoke_assert_contains "$status_out" "ok" "Claude prompt hook status"
 }
 
+assert_claude_auto_compact_window() {
+  local settings_file="$1"
+  local expected="$2"
+  local context="$3"
+
+  python3 - "$settings_file" "$expected" "$context" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_file, expected, context = sys.argv[1:]
+payload = json.loads(Path(settings_file).read_text(encoding="utf-8"))
+actual = payload.get("autoCompactWindow")
+if actual != int(expected):
+    raise SystemExit(f"{context}: autoCompactWindow expected {expected}, got {actual!r}")
+PY
+}
+
+assert_json_env_key() {
+  local settings_file="$1"
+  local key="$2"
+  local expected="$3"
+  local context="$4"
+
+  python3 - "$settings_file" "$key" "$expected" "$context" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_file, key, expected, context = sys.argv[1:]
+payload = json.loads(Path(settings_file).read_text(encoding="utf-8"))
+actual = payload.get("env", {}).get(key)
+if actual != expected:
+    raise SystemExit(f"{context}: env.{key} expected {expected!r}, got {actual!r}")
+PY
+}
+
+claude_shared_settings_context_defaults() {
+  local case_dir base overlay effective isolated_root isolated_workdir link_output target
+
+  case_dir="$SMOKE_TMP_ROOT/shared-settings"
+  mkdir -p "$case_dir"
+  base="$case_dir/settings.json"
+  overlay="$case_dir/settings.local.json"
+  effective="$case_dir/settings.effective.json"
+
+  rm -f "$base" "$overlay" "$effective"
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-shared-settings \
+    --base-settings-file "$base" \
+    --overlay-settings-file "$overlay" \
+    --effective-settings-file "$effective" >/dev/null
+  assert_claude_auto_compact_window "$effective" "400000" "bridge defaults"
+
+  printf '%s\n' '{"autoCompactWindow":650000,"env":{"BASE_ONLY":"yes"}}' >"$base"
+  rm -f "$overlay" "$effective"
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-shared-settings \
+    --base-settings-file "$base" \
+    --overlay-settings-file "$overlay" \
+    --effective-settings-file "$effective" >/dev/null
+  assert_claude_auto_compact_window "$effective" "650000" "base overrides bridge defaults"
+  assert_json_env_key "$effective" "BASE_ONLY" "yes" "base env key preserved"
+
+  printf '%s\n' '{"autoCompactWindow":475000,"env":{"OVERLAY_ONLY":"yes"}}' >"$overlay"
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-shared-settings \
+    --base-settings-file "$base" \
+    --overlay-settings-file "$overlay" \
+    --effective-settings-file "$effective" >/dev/null
+  assert_claude_auto_compact_window "$effective" "475000" "overlay overrides base and bridge defaults"
+  assert_json_env_key "$effective" "BASE_ONLY" "yes" "base env key survives overlay merge"
+  assert_json_env_key "$effective" "OVERLAY_ONLY" "yes" "overlay env key preserved"
+
+  isolated_root="$SMOKE_TMP_ROOT/isolated-agent-root"
+  isolated_workdir="$isolated_root/iso-agent"
+  mkdir -p "$isolated_root/.claude" "$isolated_workdir"
+  printf '%s\n' '{"autoCompactWindow":425000}' >"$isolated_root/.claude/settings.local.json"
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-shared-settings \
+    --base-settings-file "$isolated_root/.claude/settings.json" \
+    --overlay-settings-file "$isolated_root/.claude/settings.local.json" \
+    --effective-settings-file "$isolated_root/.claude/settings.effective.json" >/dev/null
+  link_output="$(
+    python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" link-shared-settings \
+      --workdir "$isolated_workdir" \
+      --shared-settings-file "$isolated_root/.claude/settings.effective.json"
+  )"
+  smoke_assert_contains "$link_output" "settings_file: $isolated_workdir/.claude/settings.json" "isolated settings link output"
+  [[ -L "$isolated_workdir/.claude/settings.json" ]] || smoke_fail "isolated settings should be a symlink"
+  target="$(readlink "$isolated_workdir/.claude/settings.json")"
+  smoke_assert_contains "$target" "../../.claude/settings.effective.json" "isolated settings symlink target"
+  assert_claude_auto_compact_window "$isolated_root/.claude/settings.effective.json" "425000" "isolated overlay preserves operator override"
+}
+
+managed_custom_workdir_shared_settings() {
+  local custom_workdir output target bash4_bin
+
+  custom_workdir="$SMOKE_TMP_ROOT/custom-managed-workdir"
+  mkdir -p "$custom_workdir"
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "custom-agent"
+BRIDGE_AGENT_ENGINE["custom-agent"]="claude"
+BRIDGE_AGENT_SESSION["custom-agent"]="custom-agent"
+BRIDGE_AGENT_WORKDIR["custom-agent"]="$custom_workdir"
+EOF
+
+  bash4_bin="$BASH"
+  if (( BASH_VERSINFO[0] < 4 )); then
+    if [[ -x /opt/homebrew/bin/bash ]]; then
+      bash4_bin="/opt/homebrew/bin/bash"
+    elif [[ -x /usr/local/bin/bash ]]; then
+      bash4_bin="/usr/local/bin/bash"
+    fi
+  fi
+
+  output="$(
+    "$bash4_bin" -c 'repo="$1"; workdir="$2"; source "$repo/bridge-lib.sh"; bridge_load_roster; bridge_ensure_claude_stop_hook "$workdir"' \
+      _ "$SMOKE_REPO_ROOT" "$custom_workdir"
+  )"
+  smoke_assert_contains "$output" "settings_file: $custom_workdir/.claude/settings.json" "custom managed settings link output"
+  [[ -L "$custom_workdir/.claude/settings.json" ]] || smoke_fail "custom managed workdir should use shared settings symlink"
+  target="$(readlink "$custom_workdir/.claude/settings.json")"
+  smoke_assert_contains "$target" "../bridge-home/agents/.claude/settings.effective.json" "custom managed settings symlink target"
+  assert_claude_auto_compact_window "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json" "400000" "custom managed shared settings"
+}
+
 hook_runtime_helpers() {
   local hook_workdir prompt_output session_output
 
@@ -90,6 +213,8 @@ main() {
   smoke_setup_bridge_home "hooks"
   smoke_run "Codex hooks ensure/status" codex_hooks_contract
   smoke_run "Claude hooks ensure/status" claude_hooks_contract
+  smoke_run "Claude shared settings context defaults" claude_shared_settings_context_defaults
+  smoke_run "managed custom workdir shared settings" managed_custom_workdir_shared_settings
   smoke_run "hook runtime helper output" hook_runtime_helpers
   smoke_log "passed"
 }


### PR DESCRIPTION
## Summary

- add bridge-managed Claude settings defaults so shared `settings.effective.json` gets `autoCompactWindow: 400000`
- keep merge order as bridge defaults -> shared base -> shared overlay, so `agents/.claude/settings.local.json` still wins
- apply shared settings during `agent create`, `init`/bootstrap, and `upgrade --apply`; roster-managed custom workdirs now resolve to the shared settings layer too
- add focused hook smoke coverage for default/base/overlay layering, isolated-root rendering, and managed custom workdir symlinking

## Claude Code key rationale

Official Claude Code settings docs describe the user/project/local settings model, but I did not find a documented hard context-window cap key. The current installed Claude Code source/binary (`claude 2.1.123`) exposes `autoCompactWindow` in the user settings schema as an integer from 100k to 1M tokens and describes it as the auto-compact window size. It also exposes `CLAUDE_CODE_AUTO_COMPACT_WINDOW`, but the runtime says that env var takes precedence over settings. For that reason this PR uses only the settings key:

```json
{
  "autoCompactWindow": 400000
}
```

That pins native auto-compact to the operator target without making operator overlays fight a higher-priority env var. If Anthropic later documents a separate hard context cap, it can be added as another bridge-managed default below the overlay layer.

Docs checked:
- https://docs.anthropic.com/en/docs/claude-code/settings
- https://docs.anthropic.com/en/docs/claude-code/settings#settings-precedence

## Lifecycle propagation

| Path | Behavior |
| --- | --- |
| `agent-bridge agent create` | after roster write/reload, Claude agents call `bridge_ensure_claude_shared_settings_for_managed_workdir` before first `bridge-start --dry-run` |
| bootstrap / `agent-bridge init` | created admins inherit the create path; existing admin workdirs are linked after init loads the roster |
| `agent-bridge upgrade --apply` | re-renders shared settings for each roster-managed Claude agent after files are applied |
| isolated agents | uses `BRIDGE_AGENT_HOME_ROOT`, so effective settings remain under that isolated agent root; smoke covers isolated overlay preservation |

## Merge layering tests

| Case | Expected | Covered by |
| --- | --- | --- |
| no base/overlay | `autoCompactWindow: 400000` | `scripts/smoke/hooks.sh` |
| base overrides bridge default | base value wins | `scripts/smoke/hooks.sh` |
| overlay overrides base/default | overlay value wins | `scripts/smoke/hooks.sh` |
| env/object keys merge | unrelated `env` keys survive | `scripts/smoke/hooks.sh` |
| isolated root | isolated overlay wins and symlink stays under isolated root | `scripts/smoke/hooks.sh` |
| custom managed workdir | roster-managed Claude custom workdir uses shared effective settings symlink | `scripts/smoke/hooks.sh` |

## Verification

```bash
bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh
python3 -m py_compile bridge-hooks.py
shellcheck bridge-agent.sh bridge-init.sh bridge-upgrade.sh lib/bridge-hooks.sh scripts/smoke/hooks.sh
bash scripts/smoke/hooks.sh
bash scripts/ci-select-smoke.sh --suite required --changed-file bridge-hooks.py --changed-file lib/bridge-hooks.sh --changed-file bridge-agent.sh --changed-file bridge-init.sh --changed-file bridge-upgrade.sh --run
bash scripts/ci-select-smoke.sh --suite integration --changed-file bridge-hooks.py --changed-file lib/bridge-hooks.sh --changed-file bridge-agent.sh --changed-file bridge-init.sh --changed-file bridge-upgrade.sh --run
```

Operator create smoke was also run in an `env -i` isolated `BRIDGE_HOME`; it produced a managed `settings.json` symlink to `bridge-home/agents/.claude/settings.effective.json` containing `autoCompactWindow: 400000`.

Closes #473.
Refs #472.
