### PR TITLE
upgrade: add OPERATOR_ACTIONS_PENDING.md release-action mechanism

### DIFF
--- a/OPERATOR_ACTIONS_PENDING.md
+++ b/OPERATOR_ACTIONS_PENDING.md
@@ -1,0 +1,95 @@
+# Operator Actions Pending
+
+Per-release admin checklist that the bridge-upgrade post-task references. Each
+section below is a single release. After running `agent-bridge upgrade --apply`
+on this host, the admin should:
+
+1. Read every section whose `applies_when_upgrading_from <= installed_version`.
+2. Execute the listed actions or close them with a one-line `not applicable
+   here because <reason>` note.
+3. Skip sections that ship with no operator action (the section's body says
+   "no operator action required" — most release bumps fall here).
+
+The latest release's section is always at the top. When opening a new release
+PR, prepend a new section; do not edit older sections in place.
+
+---
+
+## v0.6.37 — telegram-relay opt-in
+
+- applies_when_upgrading_from: any version `<= 0.6.36`
+- urgency: **high** if this host has any agent currently using
+  `plugin:telegram@claude-plugins-official` (mid-session disconnect symptom);
+  low otherwise.
+
+### Background
+
+`v0.6.34` already shipped the cron-cascade fix (#474), so
+`agent-bridge upgrade --apply` alone stops the 30-min cron-driven Telegram
+poller SIGTERM cycle on every host. **No operator action required for that
+fix — it activates automatically on upgrade.**
+
+`v0.6.37` adds the architectural fix for the remaining cascade triggers
+(operator opening a second attached session, `/mcp` reconnect, sibling plugin
+spawn): a single-token-owner relay daemon (`lib/telegram-relay.py`) plus a
+plugin client adapter (`plugins/telegram-relay/server.ts`) plus the
+`bridge-setup.py telegram --use-relay` lifecycle wiring. Activating it is
+**operator opt-in** because it changes the channel registration from
+`plugin:telegram@claude-plugins-official` to `plugin:telegram-relay@agent-bridge`.
+
+### Action — for each agent that uses the Telegram channel on this host
+
+1. Set `BRIDGE_TELEGRAM_RELAY_ENABLED=1` permanently in the bridge daemon's
+   environment file (typically `~/.agent-bridge/.env`; check
+   `lib/bridge-daemon.sh` env loading if unsure).
+
+2. Re-key each Telegram-using agent through the relay-aware setup path:
+   ```
+   ~/.agent-bridge/agent-bridge setup telegram <agent> \
+     --token "<bot-token>" \
+     --allow-from "<user-id>" \
+     --default-chat "<chat-id>" \
+     --use-relay --yes
+   ```
+   The token / allow-from / default-chat values can be recovered from the
+   agent's existing `~/.agent-bridge/agents/<agent>/.telegram/.env` and
+   `access.json` before re-running setup.
+
+3. Trigger one bridge-daemon sync:
+   ```
+   ~/.agent-bridge/agent-bridge daemon sync
+   ```
+
+4. Confirm the relay is connected:
+   ```
+   ~/.agent-bridge/agent-bridge status --json | python3 -c \
+     "import json,sys; d=json.load(sys.stdin); \
+      [print(a['agent'], [p for p in a.get('plugins', []) if p.get('name')=='telegram-relay']) \
+       for a in d.get('agents', [])]"
+   ```
+   Each Telegram agent's `telegram-relay` plugin should report
+   `"status": "connected"`.
+
+### Skip if
+
+- This host has no Telegram-using agents.
+- This host runs telegram via a non-bridge plugin (Slack/Mattermost/Discord
+  share none of the "one polling consumer per token" constraint and are
+  unaffected).
+- The operator already opted into the relay before upgrading (the existing
+  registration in `tokens.list` survives the upgrade).
+
+### Verification target
+
+- `agent-bridge status --json` shows each Telegram agent's `telegram-relay`
+  plugin in `connected` state within 60 s of `daemon sync` returning.
+- `BRIDGE_TELEGRAM_RELAY_ENABLED=1` is set in the daemon-loaded environment
+  (so it survives daemon restarts).
+
+### References
+
+- Issue #475 — full architectural review.
+- Phase 1 (daemon): #481 / v0.6.36.
+- Phase 2 (plugin client): #483 / v0.6.37.
+- Phase 3 (lifecycle + status): #484 / v0.6.37.
+- Short-term cron mitigation already applied automatically: #474 / v0.6.34.

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1377,10 +1377,21 @@ on.
 - Librarian CLAUDE.md template propagation
 - PreCompact hook registration on active claude agents (from bootstrap)
 
+## Operator actions pending (per-release admin checklist)
+
+Read \`$TARGET_ROOT/OPERATOR_ACTIONS_PENDING.md\` and execute every section
+whose \`applies_when_upgrading_from\` covers the previous installed version
+(${INSTALLED_VERSION:-unknown} → $SOURCE_VERSION). Each section is either a
+concrete action to run on this host or a clearly-marked skip rule. Close
+this task only after each applicable section is either executed or noted as
+"not applicable here because <reason>" in the done note. Sections that ship
+with no operator action (most release bumps) need no follow-up.
+
 ## Done note format
 
-When you finish the three steps above, close this task with:
-\`agb done <task_id> --note "bootstrap OK; first-scan <N> files / <M> entities; distribution report at <path>"\`
+When you finish the three steps above and processed every applicable section
+of OPERATOR_ACTIONS_PENDING.md, close this task with:
+\`agb done <task_id> --note "bootstrap OK; first-scan <N> files / <M> entities; distribution report at <path>; operator-actions: <summary>"\`
 POST_EOF
     # Persist the task body in state/ so the recovery command the
     # WARN block prints is actually rerunnable. Tempfiles vanish on

--- a/docs/agent-runtime/admin-protocol.md
+++ b/docs/agent-runtime/admin-protocol.md
@@ -169,6 +169,19 @@ Close the original `[upgrade-complete]` task with:
 agb done <task_id> --note "bootstrap OK; first scan <N> files / <E> entities; <C> hub candidates queued"
 ```
 
+## Post-Upgrade Operator Actions Pending
+
+업그레이드 후 admin이 가장 먼저 처리하는 자료는 source root의 [`OPERATOR_ACTIONS_PENDING.md`](../../OPERATOR_ACTIONS_PENDING.md)다. 이 파일은 release-specific 운영 checklist 모음이며, `[upgrade-complete]` 자동 task body가 이 파일의 위치를 명시한다.
+
+규칙:
+
+1. 각 release 섹션의 `applies_when_upgrading_from` 범위가 직전 설치 버전을 포함하면 그 섹션을 처리한다 (옛 install이 v0.6.33이고 새 install이 v0.6.37이면, `<= 0.6.36`이라고 적힌 모든 섹션이 적용된다).
+2. 섹션 본문이 명시한 "operator action"을 실제로 실행하거나, "Skip if" 조건과 일치하면 done note에 `not applicable here because <이유>` 한 줄로 닫는다.
+3. 섹션 본문이 "no operator action required"라고 명시하면 추가 행동 없이 통과한다 (대부분의 minor release가 여기에 해당).
+4. 처리 결과는 `[upgrade-complete]` task의 done note에 한 줄 summary로 남긴다 (예: `operator-actions: v0.6.37 telegram-relay → opted in for patch + jjujju, skipped sales_sean`).
+
+이 파일이 source에 없거나 비어 있으면 추가 행동이 필요 없다는 뜻이다 — 다음 release까지 정적이다.
+
 ## Post-Upgrade Issue Triage
 
 업그레이드·bootstrap 과정에서 발견된 문제는 로컬에서 조용히 우회하지 않고 upstream issue로 기록한다. "Upstream Issue Policy"(common-instructions.md §Upstream Issue Policy) 경로를 그대로 따르되, 트리거는 업그레이드 세션이다.


### PR DESCRIPTION
## Summary

Releases occasionally ship operator-side actions that don't activate automatically — most recently v0.6.37's telegram-relay opt-in, which needs the operator to re-key each Telegram-using agent through `setup --use-relay`. Today the bridge-upgrade `[upgrade-complete]` task body has the v0.4.0 wiki bootstrap checklist hardcoded into `bridge-upgrade.sh`, which couples release-specific content to the upgrade script.

This PR adds a per-release checklist file at the source root and makes the upgrader reference it unconditionally:

- **New `OPERATOR_ACTIONS_PENDING.md`** at source root. Section per release, newest at top. Each section names the version range it applies to, the action to take, the skip rule, and a verification target. v0.6.37 ships the first entry (telegram-relay opt-in).
- **`bridge-upgrade.sh`** post-task body appends a one-line reference to the file. Existing v0.4.0 bootstrap content stays — this is additive, not a replacement.
- **`docs/agent-runtime/admin-protocol.md`** adds a "Post-Upgrade Operator Actions Pending" section that defines the per-section processing rule (`applies_when_upgrading_from` filter, skip rule, done-note summary).

After this lands, every install that runs `agent-bridge upgrade --apply` receives an `[upgrade-complete]` task pointing at the checklist; the admin processes each applicable section and reports back. Future release PRs update `OPERATOR_ACTIONS_PENDING.md` only — the upgrade machinery itself doesn't need touching again.

## Why now

Sean's local install is on v0.6.33 and the v0.6.37 telegram-relay opt-in won't activate until the operator runs the 2-step manual sequence. Without this mechanism, every other host that upgrades to v0.6.37 has the same gap and would have to re-discover the action from the changelog. The `[upgrade-complete]` task already pings the admin on every successful upgrade — it should also surface release-specific actions automatically.

## Test plan

- [x] `bash -n bridge-upgrade.sh` — clean
- [x] `OPERATOR_ACTIONS_PENDING.md` ships v0.6.37 telegram-relay opt-in section
- [x] `admin-protocol.md` Post-Upgrade Operator Actions Pending section added before existing Post-Upgrade Issue Triage
- [x] `[upgrade-complete]` task body references the file (verified via diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)