### PR TITLE
upgrade: preserve static admin agent source

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -58,7 +58,7 @@ Usage:
   $CLI_NAME bundle <create|show> ...
   $CLI_NAME intake <triage|show> ...
   $CLI_NAME wave <dispatch|list|show|templates|close-issue> ...
-  $CLI_NAME agent <create|list|show|start|safe-mode|stop|restart|attach|compact|handoff> ...
+  $CLI_NAME agent <create|list|show|reclassify|start|safe-mode|stop|restart|attach|compact|handoff> ...
   $CLI_NAME kill <number|all>
   $CLI_NAME attach [number|name]
   $CLI_NAME urgent <agent> "<message>" [--wait <seconds>]
@@ -115,6 +115,7 @@ Usage:
   $CLI_NAME agent create <agent> [--engine claude|codex] [--session <name>] [--workdir <path>] [--always-on] [--dry-run] [--json]
   $CLI_NAME agent list [--json]
   $CLI_NAME agent show <agent> [--json]
+  $CLI_NAME agent reclassify [--agent <agent>] [--apply] [--json]
   $CLI_NAME agent start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $CLI_NAME agent safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $CLI_NAME agent stop <agent>
@@ -194,6 +195,7 @@ Examples:
   $CLI_NAME agent create reviewer --engine claude
   $CLI_NAME agent list --json
   $CLI_NAME agent show reviewer --json
+  $CLI_NAME agent reclassify --apply
   $CLI_NAME agent start reviewer --dry-run
   $CLI_NAME agent restart reviewer --attach
   $CLI_NAME agent compact static-discord-bot

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -14,6 +14,7 @@ Usage:
   $(basename "$0") create <agent> [options]
   $(basename "$0") list [--json]
   $(basename "$0") show <agent> [--json]
+  $(basename "$0") reclassify [--agent <agent>] [--apply] [--json]
   $(basename "$0") start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $(basename "$0") safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $(basename "$0") stop <agent>
@@ -54,6 +55,7 @@ Examples:
   $(basename "$0") create ops --engine claude --channels plugin:discord@claude-plugins-official --discord-channel 123456789012345678 --json
   $(basename "$0") list --json
   $(basename "$0") show reviewer --json
+  $(basename "$0") reclassify --apply
   $(basename "$0") start reviewer --dry-run
   $(basename "$0") restart reviewer --attach
   $(basename "$0") safe-mode reviewer --attach
@@ -582,6 +584,7 @@ bridge_write_role_block() {
   local always_on="${15}"
   local isolation_mode="${16:-}"
   local os_user="${17:-}"
+  local replace_existing="${18:-0}"
 
   bridge_agent_manage_python \
     "$BRIDGE_ROSTER_LOCAL_FILE" \
@@ -601,10 +604,12 @@ bridge_write_role_block() {
     "$continue_mode" \
     "$always_on" \
     "$isolation_mode" \
-    "$os_user" <<'PY'
+    "$os_user" \
+    "$replace_existing" <<'PY'
 from pathlib import Path
 import shlex
 import sys
+import re
 
 (
     path_str,
@@ -625,6 +630,7 @@ import sys
     always_on,
     isolation_mode,
     os_user,
+    replace_existing,
 ) = sys.argv[1:]
 
 path = Path(path_str)
@@ -635,7 +641,7 @@ else:
 
 begin = f"# BEGIN AGENT BRIDGE MANAGED ROLE: {agent}"
 end = f"# END AGENT BRIDGE MANAGED ROLE: {agent}"
-if begin in text or end in text:
+if replace_existing != "1" and (begin in text or end in text):
     raise SystemExit(f"managed block already exists for {agent}: {path}")
 
 def sq(value: str) -> str:
@@ -648,6 +654,7 @@ lines = [
     f'BRIDGE_AGENT_ENGINE["{agent}"]={sq(engine)}',
     f'BRIDGE_AGENT_SESSION["{agent}"]={sq(session)}',
     f'BRIDGE_AGENT_WORKDIR["{agent}"]={sq(workdir)}',
+    f'BRIDGE_AGENT_SOURCE["{agent}"]="static"',
     f'BRIDGE_AGENT_LAUNCH_CMD["{agent}"]={sq(launch_cmd)}',
 ]
 if profile_home:
@@ -680,16 +687,181 @@ if os_user:
 lines.append(end)
 
 block = "\n".join(lines) + "\n"
-if text and not text.endswith("\n"):
-    text += "\n"
-if text and not text.endswith("\n\n"):
-    text += "\n"
-text += block
+if begin in text or end in text:
+    pattern = re.compile(
+        rf"^# BEGIN AGENT BRIDGE MANAGED ROLE: {re.escape(agent)}\n.*?^# END AGENT BRIDGE MANAGED ROLE: {re.escape(agent)}\n?",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if not pattern.search(text):
+        raise SystemExit(f"managed block is malformed for {agent}: {path}")
+    text = pattern.sub(block, text)
+else:
+    if text and not text.endswith("\n"):
+        text += "\n"
+    if text and not text.endswith("\n\n"):
+        text += "\n"
+    text += block
 
 path.parent.mkdir(parents=True, exist_ok=True)
 path.write_text(text, encoding="utf-8")
 print(path)
 PY
+}
+
+bridge_agent_session_type_from_home() {
+  local agent="$1"
+  local path=""
+  local line=""
+
+  for path in \
+      "$(bridge_agent_workdir "$agent")/SESSION-TYPE.md" \
+      "$(bridge_agent_default_home "$agent")/SESSION-TYPE.md" \
+      "$BRIDGE_AGENT_HOME_ROOT/$agent/SESSION-TYPE.md"; do
+    [[ -f "$path" ]] || continue
+    line="$(grep -E 'Session Type:[[:space:]]*[A-Za-z0-9._-]+' "$path" 2>/dev/null | head -n 1 || true)"
+    if [[ "$line" =~ Session[[:space:]]+Type:[[:space:]]*([A-Za-z0-9._-]+) ]]; then
+      printf '%s' "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+bridge_agent_canonical_dir() {
+  local path="$1"
+  if [[ -d "$path" ]]; then
+    (cd -P "$path" && pwd -P)
+  else
+    printf '%s' "$path"
+  fi
+}
+
+bridge_agent_has_static_admin_shape() {
+  local agent="$1"
+  local workdir=""
+  local default_home=""
+  local legacy_home=""
+  local session_type=""
+
+  [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || return 1
+  session_type="$(bridge_agent_session_type_from_home "$agent" 2>/dev/null || true)"
+  [[ "$session_type" == "admin" ]] || return 1
+
+  workdir="$(bridge_agent_canonical_dir "$(bridge_expand_user_path "$(bridge_agent_workdir "$agent")")")"
+  default_home="$(bridge_agent_canonical_dir "$(bridge_expand_user_path "$(bridge_agent_default_home "$agent")")")"
+  legacy_home="$(bridge_agent_canonical_dir "$(bridge_expand_user_path "$BRIDGE_AGENT_HOME_ROOT/$agent")")"
+  [[ -n "$workdir" && ( "$workdir" == "$default_home" || "$workdir" == "$legacy_home" ) ]] || return 1
+
+  [[ -f "$workdir/SOUL.md" || -f "$default_home/SOUL.md" || -f "$legacy_home/SOUL.md" ]] || return 1
+  return 0
+}
+
+bridge_roster_local_mentions_agent() {
+  local agent="$1"
+  local file="$BRIDGE_ROSTER_LOCAL_FILE"
+
+  bridge_agent_manage_python "$file" "$agent" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+path = Path(sys.argv[1])
+agent = sys.argv[2]
+text = path.read_text(encoding="utf-8", errors="ignore") if path.exists() else ""
+patterns = [
+    rf"^# BEGIN AGENT BRIDGE MANAGED ROLE: {re.escape(agent)}$",
+    rf"^BRIDGE_AGENT_[A-Z_]+\[[\"']{re.escape(agent)}[\"']\]=",
+]
+raise SystemExit(0 if any(re.search(pattern, text, re.M) for pattern in patterns) else 1)
+PY
+}
+
+bridge_roster_local_upsert_scalar() {
+  local key="$1"
+  local value="$2"
+  local file="$BRIDGE_ROSTER_LOCAL_FILE"
+
+  bridge_agent_manage_python "$file" "$key" "$value" <<'PY'
+from pathlib import Path
+import re
+import shlex
+import sys
+
+path = Path(sys.argv[1])
+key = sys.argv[2]
+value = sys.argv[3]
+text = path.read_text(encoding="utf-8") if path.exists() else "#!/usr/bin/env bash\n# shellcheck shell=bash disable=SC2034\n"
+rendered = f"{key}={shlex.quote(value)}"
+pattern = re.compile(rf"^{re.escape(key)}=.*$", flags=re.MULTILINE)
+if pattern.search(text):
+    text = pattern.sub(rendered, text)
+else:
+    if text and not text.endswith("\n"):
+        text += "\n"
+    text += rendered + "\n"
+path.parent.mkdir(parents=True, exist_ok=True)
+path.write_text(text, encoding="utf-8")
+PY
+}
+
+bridge_agent_reclassify_static_admin() {
+  local agent="$1"
+  local old_source="$2"
+  local reason="$3"
+  local description engine session workdir profile_home launch_cmd channels discord_channel
+  local notify_kind notify_target notify_account loop_mode continue_mode always_on isolation_mode os_user
+
+  description="$(bridge_agent_desc "$agent")"
+  [[ -n "$description" ]] || description="$agent static admin role"
+  engine="$(bridge_agent_engine "$agent")"
+  session="$(bridge_agent_session "$agent")"
+  [[ -n "$session" ]] || session="$agent"
+  workdir="$(bridge_expand_user_path "$(bridge_agent_workdir "$agent")")"
+  profile_home="$(bridge_expand_user_path "$(bridge_agent_profile_home "$agent")")"
+  launch_cmd="$(bridge_agent_launch_cmd_raw "$agent")"
+  [[ -n "$launch_cmd" ]] || launch_cmd="$(bridge_agent_default_launch_cmd "$engine")"
+  channels="$(bridge_agent_channels_csv "$agent")"
+  discord_channel="$(bridge_agent_discord_channel_id "$agent")"
+  notify_kind="$(bridge_agent_notify_kind "$agent")"
+  notify_target="$(bridge_agent_notify_target "$agent")"
+  notify_account="$(bridge_agent_notify_account "$agent")"
+  loop_mode="$(bridge_agent_loop "$agent")"
+  continue_mode="$(bridge_agent_continue "$agent")"
+  always_on=0
+  [[ "$(bridge_agent_idle_timeout "$agent")" == "0" ]] && always_on=1
+  isolation_mode="$(bridge_agent_isolation_mode "$agent")"
+  os_user="$(bridge_agent_os_user "$agent")"
+
+  bridge_write_role_block \
+    "$agent" \
+    "$description" \
+    "$engine" \
+    "$session" \
+    "$workdir" \
+    "$profile_home" \
+    "$launch_cmd" \
+    "$channels" \
+    "$discord_channel" \
+    "$notify_kind" \
+    "$notify_target" \
+    "$notify_account" \
+    "$loop_mode" \
+    "$continue_mode" \
+    "$always_on" \
+    "$isolation_mode" \
+    "$os_user" \
+    1 >/dev/null
+
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  if [[ -z "${BRIDGE_ADMIN_AGENT_ID:-}" ]]; then
+    bridge_roster_local_upsert_scalar "BRIDGE_ADMIN_AGENT_ID" "$agent"
+    BRIDGE_ADMIN_AGENT_ID="$agent"
+  fi
+  bridge_audit_log "$(bridge_admin_agent_id 2>/dev/null || printf bridge-upgrade)" "agent_source_reclassified" "$agent" \
+    --detail old_source="$old_source" \
+    --detail new_source=static \
+    --detail reason="$reason" >/dev/null 2>&1 || true
 }
 
 emit_create_json() {
@@ -1048,6 +1220,105 @@ PY
     printf 'session_health:\n'
     bridge_agent_session_guidance_text "$agent" | sed 's/^/  /'
   done <<<"$output"
+}
+
+run_reclassify() {
+  local selected_agent=""
+  local apply=0
+  local json_mode=0
+  local agent=""
+  local old_source=""
+  local action=""
+  local reason=""
+  local workdir=""
+  local rows=$'agent\told_source\tnew_source\taction\treason\tworkdir\n'
+  local count=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)
+        [[ $# -ge 2 ]] || bridge_die "--agent 뒤에 값을 지정하세요."
+        selected_agent="$2"
+        shift 2
+        ;;
+      --apply)
+        apply=1
+        shift
+        ;;
+      --dry-run)
+        apply=0
+        shift
+        ;;
+      --json)
+        json_mode=1
+        shift
+        ;;
+      -h|--help)
+        printf 'Usage: %s reclassify [--agent <agent>] [--apply] [--json]\n' "$(basename "$0")"
+        return 0
+        ;;
+      *)
+        bridge_die "지원하지 않는 agent reclassify 옵션입니다: $1"
+        ;;
+    esac
+  done
+
+  if [[ -n "$selected_agent" ]]; then
+    bridge_require_agent "$selected_agent"
+  fi
+
+  for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+    if [[ -n "$selected_agent" && "$agent" != "$selected_agent" ]]; then
+      continue
+    fi
+
+    bridge_agent_has_static_admin_shape "$agent" || continue
+    old_source="$(bridge_agent_source "$agent")"
+    action=""
+    reason=""
+    if [[ "$old_source" == "dynamic" ]]; then
+      action="reclassify"
+      reason="static-admin-shape"
+    elif [[ "$old_source" == "static" ]] && ! bridge_roster_local_mentions_agent "$agent"; then
+      action="persist"
+      reason="static-admin-local-preserve"
+    fi
+    [[ -n "$action" ]] || continue
+
+    workdir="$(bridge_agent_workdir "$agent")"
+    rows+="${agent}"$'\t'"${old_source}"$'\t'"static"$'\t'"${action}"$'\t'"${reason}"$'\t'"${workdir}"$'\n'
+    count=$((count + 1))
+
+    if [[ $apply -eq 1 ]]; then
+      bridge_agent_reclassify_static_admin "$agent" "$old_source" "$reason"
+    fi
+  done
+
+  if [[ $json_mode -eq 1 ]]; then
+    bridge_agent_manage_python "$apply" "$rows" <<'PY'
+import csv
+import io
+import json
+import sys
+
+apply = sys.argv[1] == "1"
+rows = list(csv.DictReader(io.StringIO(sys.argv[2]), delimiter="\t"))
+print(json.dumps({"mode": "apply" if apply else "dry-run", "count": len(rows), "candidates": rows}, ensure_ascii=False, indent=2))
+PY
+    return 0
+  fi
+
+  printf 'mode: %s\n' "$([[ $apply -eq 1 ]] && printf apply || printf dry-run)"
+  if [[ $count -eq 0 ]]; then
+    echo "reclassify: no candidates"
+    return 0
+  fi
+
+  while IFS=$'\t' read -r row_agent row_old row_new row_action row_reason row_workdir; do
+    [[ "$row_agent" == "agent" || -z "$row_agent" ]] && continue
+    printf '%s: %s old_source=%s new_source=%s reason=%s workdir=%s\n' \
+      "$row_action" "$row_agent" "$row_old" "$row_new" "$row_reason" "$row_workdir"
+  done <<<"$rows"
 }
 
 run_create() {
@@ -1815,6 +2086,9 @@ case "$subcommand" in
   show)
     run_show "$@"
     ;;
+  reclassify)
+    run_reclassify "$@"
+    ;;
   start)
     run_start "$@"
     ;;
@@ -1848,7 +2122,7 @@ case "$subcommand" in
   *)
     # Issue #163 Phase 2: surface an intent-recovery hint before dying.
     _hint="$(bridge_suggest_subcommand "$subcommand" \
-      "create list show start safe-mode stop restart ack-crash forget-session attach compact handoff")"
+      "create list show reclassify start safe-mode stop restart ack-crash forget-session attach compact handoff")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 agent 명령입니다: $subcommand"
     ;;

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -37,6 +37,7 @@ TARGET_HEAD=""
 SOURCE_VERSION=""
 SOURCE_REF=""
 SOURCE_HEAD=""
+SOURCE_RECLASSIFY_JSON='{}'
 
 usage() {
   cat <<EOF
@@ -1133,6 +1134,12 @@ if [[ $BACKUP -eq 1 ]]; then
   BACKUP_JSON="$(python3 "$SOURCE_ROOT/bridge-upgrade.py" "${backup_args[@]}")"
 fi
 
+reclassify_args=(reclassify --json)
+if [[ $DRY_RUN -eq 0 ]]; then
+  reclassify_args+=(--apply)
+fi
+SOURCE_RECLASSIFY_JSON="$(bridge_upgrade_with_target_env "$TARGET_ROOT" "$BRIDGE_BASH_BIN" "$SOURCE_ROOT/bridge-agent.sh" "${reclassify_args[@]}")"
+
 BASE_REF="$(python3 - "$ANALYSIS_JSON" <<'PY'
 import json, sys
 payload = json.loads(sys.argv[1])
@@ -1447,10 +1454,11 @@ if [[ $JSON -eq 1 ]]; then
   printf '%s' "$ANALYSIS_JSON" >"$_json_payload_dir/analysis.json"
   printf '%s' "$AGENT_RESTART_JSON" >"$_json_payload_dir/agent-restart.json"
   printf '%s' "$CHANNEL_GUARD_JSON" >"$_json_payload_dir/channel-guard.json"
+  printf '%s' "$SOURCE_RECLASSIFY_JSON" >"$_json_payload_dir/source-reclassify.json"
   set +e
-  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" <<'PY'
+  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" "$_json_payload_dir/source-reclassify.json" <<'PY'
 import json, sys
-source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file = sys.argv[1:]
+source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file, source_reclassify_json_file = sys.argv[1:]
 
 def load_json(path):
     with open(path, encoding="utf-8") as fh:
@@ -1462,6 +1470,7 @@ apply_payload = load_json(apply_json_file)
 analysis_payload = load_json(analysis_json_file)
 agent_restart_payload = load_json(agent_restart_json_file)
 channel_guard_payload = load_json(channel_guard_json_file)
+source_reclassify_payload = load_json(source_reclassify_json_file)
 payload = {
     "mode": "upgrade",
     "version": source_version,
@@ -1496,6 +1505,7 @@ payload = {
     "channel_guard": channel_guard_payload,
     "agent_restart": agent_restart_payload,
     "agent_migration": migration_payload,
+    "source_reclassify": source_reclassify_payload,
   }
 print(json.dumps(payload, ensure_ascii=False, indent=2))
 PY
@@ -1536,6 +1546,15 @@ print(f"analysis_merge_required: {counts.get('merge_required', 0)}")
 print(f"analysis_unknown_base_live_diff: {counts.get('unknown_base_live_diff', 0)}")
 PY
 bridge_upgrade_print_channel_guard_summary "$CHANNEL_GUARD_JSON"
+python3 - "$SOURCE_RECLASSIFY_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+count = int(payload.get("count") or 0)
+mode = payload.get("mode") or "dry-run"
+print(f"source_reclassify: {count} candidate(s) ({mode})")
+for item in payload.get("candidates") or []:
+    print(f"  - {item.get('action')}: {item.get('agent')} old_source={item.get('old_source')} new_source={item.get('new_source')} reason={item.get('reason')}")
+PY
 python3 - "$APPLY_JSON" <<'PY'
 import json, sys
 payload = json.loads(sys.argv[1])

--- a/lib/bridge-marker-bootstrap.sh
+++ b/lib/bridge-marker-bootstrap.sh
@@ -118,9 +118,10 @@ bridge_isolation_v2_marker_value_safe() {
   #   - double-quoted token: same content set
   # Anything else is rejected.
   local v="$1"
+  [[ "$v" == *\\* ]] && return 1
   case "$v" in
-    *'$('*|*'$<'*|*'$>'*|*'$['*|*'$\\'*|*'`'*|*';'*|*'&'*|*'|'* \
-      |*'>'*|*'<'*|*'\\'*|*$'\n'*|*$'\r'*|*'*'*|*'?'*|*'~'* )
+    *'$('*|*'$<'*|*'$>'*|*'$['*|*'`'*|*';'*|*'&'*|*'|'* \
+      |*'>'*|*'<'*|*$'\n'*|*$'\r'*|*'*'*|*'?'*|*'~'* )
       return 1
       ;;
   esac

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade telegram-relay telegram-relay-plugin telegram-relay-setup
+  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation telegram-relay telegram-relay-plugin telegram-relay-setup
 }
 
 add_all_integration() {
@@ -193,7 +193,7 @@ select_for_path() {
       ;;
 
     bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh)
-      add_required launch tmux-injection
+      add_required launch tmux-injection upgrade-source-preservation
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -225,7 +225,7 @@ select_for_path() {
       ;;
 
     bridge-upgrade.sh|bridge-upgrade.py|scripts/export-public-snapshot.sh|VERSION)
-      add_required upgrade
+      add_required upgrade upgrade-source-preservation
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/upgrade-source-preservation.sh
+++ b/scripts/smoke/upgrade-source-preservation.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SMOKE_NAME="upgrade-source-preservation"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+json_field() {
+  local json="$1"
+  local expr="$2"
+  python3 - "$json" "$expr" <<'PY'
+import json
+import sys
+
+payload = json.loads(sys.argv[1])
+expr = sys.argv[2]
+print(eval(expr, {"payload": payload}))
+PY
+}
+
+agent_source() {
+  local agent="$1"
+  BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" agent show "$agent" --json \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["source"])'
+}
+
+agent_admin_flag() {
+  local agent="$1"
+  BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" agent show "$agent" --json \
+    | python3 -c 'import json,sys; print("yes" if json.load(sys.stdin)["admin"] else "no")'
+}
+
+write_fixture() {
+  local patch_home="$BRIDGE_AGENT_HOME_ROOT/patch"
+  local worker_home="$SMOKE_TMP_ROOT/dynamic-worker"
+
+  mkdir -p "$patch_home" "$worker_home" "$BRIDGE_ACTIVE_AGENT_DIR"
+  printf '# patch soul\n' >"$patch_home/SOUL.md"
+  printf '# Session Type\n\n- Session Type: admin\n- Onboarding State: complete\n' >"$patch_home/SESSION-TYPE.md"
+  printf '# worker\n' >"$worker_home/README.md"
+
+  cat >"$BRIDGE_ACTIVE_AGENT_DIR/patch.env" <<EOF
+AGENT_ID=patch
+AGENT_DESC=patch\ admin\ role
+AGENT_ENGINE=claude
+AGENT_SESSION=patch
+AGENT_WORKDIR=$patch_home
+AGENT_LOOP=1
+AGENT_CONTINUE=1
+EOF
+
+  cat >"$BRIDGE_ACTIVE_AGENT_DIR/dynamic-worker.env" <<EOF
+AGENT_ID=dynamic-worker
+AGENT_DESC=dynamic\ worker
+AGENT_ENGINE=claude
+AGENT_SESSION=dynamic-worker
+AGENT_WORKDIR=$worker_home
+AGENT_LOOP=1
+AGENT_CONTINUE=1
+EOF
+}
+
+assert_reclassify_dry_run() {
+  local output count agent old_source action
+
+  output="$(BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" agent reclassify --json)"
+  count="$(json_field "$output" 'payload["count"]')"
+  agent="$(json_field "$output" 'payload["candidates"][0]["agent"]')"
+  old_source="$(json_field "$output" 'payload["candidates"][0]["old_source"]')"
+  action="$(json_field "$output" 'payload["candidates"][0]["action"]')"
+
+  smoke_assert_eq "1" "$count" "reclassify dry-run candidate count"
+  smoke_assert_eq "patch" "$agent" "reclassify dry-run candidate agent"
+  smoke_assert_eq "dynamic" "$old_source" "reclassify dry-run preserves observed old source"
+  smoke_assert_eq "reclassify" "$action" "reclassify dry-run action"
+  smoke_assert_eq "dynamic" "$(agent_source patch)" "dry-run leaves patch source unchanged"
+}
+
+assert_reclassify_apply() {
+  local output count action audit
+
+  output="$(BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" agent reclassify --apply --json)"
+  count="$(json_field "$output" 'payload["count"]')"
+  action="$(json_field "$output" 'payload["candidates"][0]["action"]')"
+  audit="$(cat "$BRIDGE_AUDIT_LOG")"
+
+  smoke_assert_eq "1" "$count" "reclassify apply candidate count"
+  smoke_assert_eq "reclassify" "$action" "reclassify apply action"
+  smoke_assert_eq "static" "$(agent_source patch)" "apply restores admin source to static"
+  smoke_assert_eq "yes" "$(agent_admin_flag patch)" "apply restores admin identity when roster scalar is missing"
+  smoke_assert_eq "dynamic" "$(agent_source dynamic-worker)" "apply preserves unrelated dynamic agent source"
+  smoke_assert_contains "$audit" "agent_source_reclassified" "apply emits audit row"
+  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" 'BRIDGE_AGENT_SOURCE["patch"]="static"' "apply persists static source"
+  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" "BRIDGE_ADMIN_AGENT_ID=patch" "apply persists admin scalar"
+}
+
+assert_upgrade_runs_fixup() {
+  local upgrade_json count
+
+  rm -f "$BRIDGE_ROSTER_LOCAL_FILE"
+  : >"$BRIDGE_ROSTER_LOCAL_FILE"
+  smoke_assert_eq "dynamic" "$(agent_source patch)" "fixture reset exposes patch as dynamic"
+
+  upgrade_json="$(
+    env BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" upgrade \
+      --source "$SMOKE_REPO_ROOT" \
+      --target "$BRIDGE_HOME" \
+      --channel current \
+      --no-pull \
+      --no-backup \
+      --no-migrate-agents \
+      --no-restart-daemon \
+      --no-restart-agents \
+      --allow-dirty \
+      --allow-dirty-source \
+      --json
+  )"
+  count="$(json_field "$upgrade_json" 'payload["source_reclassify"]["count"]')"
+  smoke_assert_eq "1" "$count" "upgrade apply reports source reclassify candidate"
+  smoke_assert_eq "static" "$(agent_source patch)" "upgrade apply restores admin source to static"
+  smoke_assert_eq "yes" "$(agent_admin_flag patch)" "upgrade apply restores admin identity"
+  smoke_assert_eq "dynamic" "$(agent_source dynamic-worker)" "upgrade apply preserves dynamic worker"
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "upgrade-source"
+  write_fixture
+  smoke_run "reclassify dry-run detects static-admin misclassification" assert_reclassify_dry_run
+  smoke_run "reclassify apply restores static source and audits" assert_reclassify_apply
+  smoke_run "upgrade apply runs source reclassify fixup" assert_upgrade_runs_fixup
+  smoke_log "passed"
+}
+
+main "$@"

--- a/scripts/test-stale-resume.sh
+++ b/scripts/test-stale-resume.sh
@@ -174,15 +174,18 @@ source "$INTEG_EXTRACT"
 
 # Stubs for the static-collision branch's roster lookups. The test fixture
 # treats "test-static" as a pre-existing static agent and nothing else.
-declare -gA BRIDGE_AGENT_IDS_MAP=([test-static]=1)
-declare -gA BRIDGE_AGENT_SOURCE=([test-static]=static)
-declare -gA BRIDGE_AGENT_SESSION_ID=([test-static]="")
+declare -gA BRIDGE_AGENT_IDS_MAP=(["test-static"]=1)
+declare -gA BRIDGE_AGENT_SOURCE=(["test-static"]=static)
+declare -gA BRIDGE_AGENT_SESSION_ID=(["test-static"]="")
 declare -gA BRIDGE_AGENT_HISTORY_KEY=()
 declare -gA BRIDGE_AGENT_CREATED_AT=()
 declare -gA BRIDGE_AGENT_UPDATED_AT=()
 
+# shellcheck disable=SC2329
 bridge_agent_exists() { [[ -n "${BRIDGE_AGENT_IDS_MAP[$1]+x}" ]]; }
+# shellcheck disable=SC2329
 bridge_agent_source() { printf '%s' "${BRIDGE_AGENT_SOURCE[$1]:-}"; }
+# shellcheck disable=SC2329
 bridge_add_agent_id_if_missing() { :; }
 
 mk_env_file() {
@@ -282,7 +285,7 @@ rm -rf "$HOME/.claude/projects/$SLUG"
 assert_function_calls_resolver() {
   local file="$1" function_name="$2"
   step "S/${function_name}: function body contains bridge_resolve_resume_session_id (#430 item 2)"
-  python3 - "$file" "$function_name" <<'PY'
+  if python3 - "$file" "$function_name" <<'PY'
 import re
 import sys
 from pathlib import Path
@@ -306,7 +309,11 @@ if "bridge_resolve_resume_session_id" not in body:
     )
     sys.exit(1)
 PY
-  if [[ $? -eq 0 ]]; then ok; else err "missing resolver call in $function_name (see stderr)"; fi
+  then
+    ok
+  else
+    err "missing resolver call in $function_name (see stderr)"
+  fi
 }
 
 assert_function_calls_resolver "$ROOT_DIR/lib/bridge-state.sh" "bridge_load_dynamic_agent_file"


### PR DESCRIPTION
## Summary
- emit `BRIDGE_AGENT_SOURCE[agent]=static` in generated static role blocks so future roster reloads cannot fall back to dynamic
- add `agent-bridge agent reclassify` dry-run/apply to recover admin-shaped Claude homes that are currently loaded from dynamic active metadata
- run the source reclassify fixup during `upgrade --apply` after backup and before live apply, and expose it in upgrade JSON/text output
- add focused `upgrade-source-preservation` smoke and wire it into CI selection for agent/upgrade changes
- clean existing ShellCheck findings in `lib/bridge-marker-bootstrap.sh` and `scripts/test-stale-resume.sh` so shellcheck remains actionable

## Root Cause / Fix Surface
`bridge_write_role_block` in `bridge-agent.sh` now emits `BRIDGE_AGENT_SOURCE["<agent>"]="static"` at lines 650-658 and can replace an existing managed block during recovery. The post-upgrade recovery path is `run_reclassify` in `bridge-agent.sh`, which detects Claude admin homes by `SESSION-TYPE.md`, canonical workdir, and `SOUL.md`, then writes a local static role block plus `BRIDGE_ADMIN_AGENT_ID` when missing.

`bridge-upgrade.sh` invokes `bridge-agent.sh reclassify --json [--apply]` after backup and before apply at lines 1137-1141. JSON output now includes `source_reclassify`; text output prints an actionable candidate summary.

## Reproduction
Live dev host dry-run before applying this PR detects the baked-in regression:

```json
{
  "mode": "dry-run",
  "count": 1,
  "candidates": [
    {
      "agent": "patch",
      "old_source": "dynamic",
      "new_source": "static",
      "action": "reclassify",
      "reason": "static-admin-shape",
      "workdir": "/Users/sean/.agent-bridge/agents/patch"
    }
  ]
}
```

The new smoke provisions the same shape in an isolated `BRIDGE_HOME`: admin home + active dynamic env. Dry-run leaves it dynamic, apply restores `patch` to static, preserves a separate dynamic worker, persists the local role block, and verifies upgrade apply runs the fixup.

## Verification
- `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh scripts/smoke/*.sh`
- `shellcheck *.sh agent-bridge agb lib/*.sh scripts/*.sh scripts/smoke/*.sh`
- `python3 -m py_compile bridge-upgrade.py bridge-queue.py bridge-setup.py bridge-docs.py bridge-hooks.py bridge-audit.py bridge-status.py`
- `bash scripts/smoke/upgrade-source-preservation.sh`
- `bash scripts/smoke/upgrade.sh`
- `bash scripts/ci-select-smoke.sh --suite required --changed-file bridge-agent.sh --run`
- `bash scripts/ci-select-smoke.sh --suite required --changed-file bridge-upgrade.sh --run`

Note: `scripts/test-stale-resume.sh` remains Ubuntu/Bash-4-oriented; macOS Bash 3.2 cannot execute its associative-array fixture, but ShellCheck is clean.

Refs queue task #2294 / issue #2292; related #420 #304 #345 #376.