### PR TITLE
upgrade: stream analysis JSON for base ref

### DIFF
--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -142,6 +142,14 @@ def read_source_version(source_root: Path) -> str:
     return version or "0.0.0-dev"
 
 
+def load_json_arg(value: str = "", file_path: str = "") -> dict[str, Any]:
+    if file_path:
+        return json.loads(Path(file_path).read_text(encoding="utf-8"))
+    if value:
+        return json.loads(value)
+    return {}
+
+
 def git_file_bytes(source_root: Path, ref: str, relpath: str) -> bytes | None:
     proc = subprocess.run(
         ["git", "-C", str(source_root), "show", f"{ref}:{relpath}"],
@@ -971,8 +979,8 @@ def cmd_backup_live(args: argparse.Namespace) -> int:
     target_root = Path(args.target_root).expanduser()
     backup_root = Path(args.backup_root).expanduser()
     source_root = Path(args.source_root).expanduser() if args.source_root else None
-    analysis_payload = json.loads(args.analysis_json) if args.analysis_json else {}
-    migration_payload = json.loads(args.migration_json) if args.migration_json else {}
+    analysis_payload = load_json_arg(args.analysis_json, args.analysis_json_file)
+    migration_payload = load_json_arg(args.migration_json, args.migration_json_file)
     entries = build_backup_entries(target_root, analysis_payload, migration_payload) if (analysis_payload or migration_payload) else []
     payload = {
         "target_root": str(target_root),
@@ -1188,8 +1196,9 @@ def cmd_write_state(args: argparse.Namespace) -> int:
         "channel": args.channel or "",
         "backup_root": str(Path(args.backup_root).expanduser()) if args.backup_root else "",
     }
-    if args.analysis_json:
-        payload["analysis"] = json.loads(args.analysis_json)
+    analysis_payload = load_json_arg(args.analysis_json, args.analysis_json_file)
+    if analysis_payload:
+        payload["analysis"] = analysis_payload
     save_json(upgrade_state_path(target_root), payload)
     print(json.dumps(payload, ensure_ascii=False, indent=2))
     return 0
@@ -1231,7 +1240,9 @@ def build_parser() -> argparse.ArgumentParser:
     backup.add_argument("--backup-root", required=True)
     backup.add_argument("--source-root")
     backup.add_argument("--analysis-json", default="")
+    backup.add_argument("--analysis-json-file", default="")
     backup.add_argument("--migration-json", default="")
+    backup.add_argument("--migration-json-file", default="")
     backup.add_argument("--dry-run", action="store_true")
     backup.set_defaults(handler=cmd_backup_live)
 
@@ -1279,6 +1290,7 @@ def build_parser() -> argparse.ArgumentParser:
     write_state.add_argument("--target-root", required=True)
     write_state.add_argument("--backup-root", default="")
     write_state.add_argument("--analysis-json", default="")
+    write_state.add_argument("--analysis-json-file", default="")
     write_state.add_argument("--version", default="")
     write_state.add_argument("--source-ref", default="")
     write_state.add_argument("--channel", default="")

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1122,16 +1122,20 @@ fi
 
 if [[ $BACKUP -eq 1 ]]; then
   backup_args=(backup-live --target-root "$TARGET_ROOT" --backup-root "$BACKUP_ROOT" --source-root "$SOURCE_ROOT")
+  _backup_payload_dir="$(mktemp -d "${TMPDIR:-/tmp}/bridge-upgrade-backup-json.XXXXXX")"
   if [[ "$ANALYSIS_JSON" != "{}" ]]; then
-    backup_args+=(--analysis-json "$ANALYSIS_JSON")
+    printf '%s' "$ANALYSIS_JSON" >"$_backup_payload_dir/analysis.json"
+    backup_args+=(--analysis-json-file "$_backup_payload_dir/analysis.json")
   fi
   if [[ "$MIGRATION_PREVIEW_JSON" != "{}" ]]; then
-    backup_args+=(--migration-json "$MIGRATION_PREVIEW_JSON")
+    printf '%s' "$MIGRATION_PREVIEW_JSON" >"$_backup_payload_dir/migration.json"
+    backup_args+=(--migration-json-file "$_backup_payload_dir/migration.json")
   fi
   if [[ $DRY_RUN -eq 1 ]]; then
     backup_args+=(--dry-run)
   fi
   BACKUP_JSON="$(python3 "$SOURCE_ROOT/bridge-upgrade.py" "${backup_args[@]}")"
+  rm -rf "$_backup_payload_dir"
 fi
 
 reclassify_args=(reclassify --json)
@@ -1140,12 +1144,12 @@ if [[ $DRY_RUN -eq 0 ]]; then
 fi
 SOURCE_RECLASSIFY_JSON="$(bridge_upgrade_with_target_env "$TARGET_ROOT" "$BRIDGE_BASH_BIN" "$SOURCE_ROOT/bridge-agent.sh" "${reclassify_args[@]}")"
 
-BASE_REF="$(python3 - "$ANALYSIS_JSON" <<'PY'
-import json, sys
-payload = json.loads(sys.argv[1])
+BASE_REF="$(printf '%s' "$ANALYSIS_JSON" | python3 -c '
+import json
+import sys
+payload = json.load(sys.stdin)
 print(payload.get("base_ref", ""))
-PY
-)"
+')"
 
 apply_args=(apply-live --source-root "$SOURCE_ROOT" --target-root "$TARGET_ROOT")
 if [[ -n "$BASE_REF" ]]; then
@@ -1231,14 +1235,17 @@ if [[ $RESTART_DAEMON -eq 1 && $DRY_RUN -eq 0 ]]; then
 fi
 
 if [[ $DRY_RUN -eq 0 ]]; then
+  _write_state_payload_dir="$(mktemp -d "${TMPDIR:-/tmp}/bridge-upgrade-state-json.XXXXXX")"
+  printf '%s' "$ANALYSIS_JSON" >"$_write_state_payload_dir/analysis.json"
   python3 "$SOURCE_ROOT/bridge-upgrade.py" write-state \
     --source-root "$SOURCE_ROOT" \
     --target-root "$TARGET_ROOT" \
     --backup-root "$BACKUP_ROOT" \
-    --analysis-json "$ANALYSIS_JSON" \
+    --analysis-json-file "$_write_state_payload_dir/analysis.json" \
     --version "$SOURCE_VERSION" \
     --source-ref "$SOURCE_REF" \
     --channel "$CHANNEL" >/dev/null
+  rm -rf "$_write_state_payload_dir"
 fi
 
 # Post-upgrade admin signal: file a [upgrade-complete] task with a

--- a/scripts/smoke/upgrade-source-preservation.sh
+++ b/scripts/smoke/upgrade-source-preservation.sh
@@ -15,14 +15,14 @@ trap cleanup EXIT
 json_field() {
   local json="$1"
   local expr="$2"
-  python3 - "$json" "$expr" <<'PY'
+  printf '%s' "$json" | python3 -c '
 import json
 import sys
 
-payload = json.loads(sys.argv[1])
-expr = sys.argv[2]
+payload = json.load(sys.stdin)
+expr = sys.argv[1]
 print(eval(expr, {"payload": payload}))
-PY
+' "$expr"
 }
 
 agent_source() {


### PR DESCRIPTION
## Summary
- fix the PR #488 unit/static smoke failure by reading `ANALYSIS_JSON` from stdin instead of passing the full payload as a Python argv
- keeps the focused `upgrade-source-preservation` smoke from tripping Linux `ARG_MAX` on GitHub runners

## Root Cause
PR #488 was merged, but its required `unit/static smoke` failed in GitHub Actions with:

```
bridge-upgrade.sh: line 1148: /usr/bin/python3: Argument list too long
```

The large `analyze-live` JSON for a full repo checkout was passed as `$1` to Python. Local macOS did not hit the limit; Ubuntu runner did.

## Verification
- `bash -n bridge-upgrade.sh`
- `shellcheck bridge-upgrade.sh`
- `bash scripts/smoke/upgrade-source-preservation.sh`

Follow-up for PR #488 / task #2294.