### PR TITLE
fix(setup): default `setup telegram` to --use-relay; add --no-relay opt-out (#2293)

### DIFF
--- a/OPERATOR_ACTIONS_PENDING.md
+++ b/OPERATOR_ACTIONS_PENDING.md
@@ -15,6 +15,25 @@ PR, prepend a new section; do not edit older sections in place.
 
 ---
 
+## v0.6.39 — `setup telegram` defaults to relay (no operator action required)
+
+- applies_when_upgrading_from: any version `<= 0.6.38`.
+- urgency: **none** (informational).
+
+### Background
+
+`agent-bridge setup telegram <agent>` now defaults to `--use-relay` (the architectural fix from #475 phase 2/3). The legacy `plugin:telegram@claude-plugins-official` path is still reachable via `--no-relay` as a transitional escape hatch.
+
+### Action
+
+**No operator action required.** Existing agents on the legacy plugin path keep working until the operator explicitly re-runs `setup telegram`. Hosts that already have the v0.6.37 telegram-relay opt-in section processed are already on the relay path.
+
+### Skip if
+
+- Always skip — this is informational. The flag flip only affects new `setup telegram` invocations; existing registrations are untouched.
+
+---
+
 ## v0.6.37 — telegram-relay opt-in
 
 - applies_when_upgrading_from: any version `<= 0.6.36`

--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -23,11 +23,17 @@ class SetupError(Exception):
     """Raised when setup validation fails with a user-facing message."""
 
 
-TELEGRAM_RELAY_LEGACY_WARN_AFTER = "2026-06-01"
 
 
-def env_flag(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+def env_flag(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if not raw:
+        return default
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return default
 
 
 def plugin_port_range() -> tuple[int, int]:
@@ -886,7 +892,11 @@ def cmd_telegram(args: argparse.Namespace) -> int:
     access_payload = inspected["access_payload"]
     warnings: list[str] = []
     interactive = sys.stdin.isatty() and sys.stdout.isatty() and not args.yes
-    use_relay = bool(args.use_relay or env_flag("BRIDGE_TELEGRAM_USE_RELAY"))
+    if args.use_relay is None:
+        env_use_relay = env_flag("BRIDGE_TELEGRAM_USE_RELAY", default=True)
+        use_relay = bool(env_use_relay)
+    else:
+        use_relay = bool(args.use_relay)
 
     result: dict[str, Any] = {
         "agent": args.agent,
@@ -967,9 +977,9 @@ def cmd_telegram(args: argparse.Namespace) -> int:
             warnings.append(
                 f"No default Telegram chat id configured for {args.agent}. Set --default-chat if you want a stable notify/test target."
             )
-        if not use_relay and datetime.now(timezone.utc).date().isoformat() >= TELEGRAM_RELAY_LEGACY_WARN_AFTER:
+        if not use_relay:
             warnings.append(
-                "Telegram relay setup is now recommended. Re-run with --use-relay to avoid Telegram getUpdates polling slot contention."
+                "Telegram relay is now the default; --no-relay opts into the legacy plugin:telegram path. Use only as a transitional escape hatch."
             )
 
         result["token_source"] = token_source or "existing:.telegram/.env"
@@ -1302,7 +1312,20 @@ def build_parser() -> argparse.ArgumentParser:
     telegram_parser.add_argument("--allow-from", action="append", default=[])
     telegram_parser.add_argument("--default-chat", default="")
     telegram_parser.add_argument("--test-chat", default="")
-    telegram_parser.add_argument("--use-relay", action="store_true")
+    relay_group = telegram_parser.add_mutually_exclusive_group()
+    relay_group.add_argument(
+        "--use-relay",
+        dest="use_relay",
+        action="store_true",
+        default=None,
+        help="Use plugin:telegram-relay@agent-bridge (architectural fix from #475 phase 2/3). Default since v0.6.39.",
+    )
+    relay_group.add_argument(
+        "--no-relay",
+        dest="use_relay",
+        action="store_false",
+        help="Use legacy plugin:telegram@claude-plugins-official. Transitional escape hatch only.",
+    )
     telegram_parser.add_argument("--bridge-state-dir", default="")
     telegram_parser.add_argument("--yes", action="store_true")
     telegram_parser.add_argument("--skip-validate", action="store_true")

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -12,7 +12,7 @@ usage() {
   cat <<EOF
 Usage:
   $(basename "$0") discord <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--channel <id>]... [--allow-from <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
-  $(basename "$0") telegram <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--allow-from <id>]... [--default-chat <id>] [--test-chat <id>] [--use-relay] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
+  $(basename "$0") telegram <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--allow-from <id>]... [--default-chat <id>] [--test-chat <id>] [--use-relay (default) | --no-relay] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
   $(basename "$0") teams <agent> [--app-id <id>] [--app-password <secret>] [--tenant-id <id>] [--channel-account <account>] [--runtime-config <path>] [--messaging-endpoint <url>] [--webhook-host <host>] [--webhook-port <port>] [--ingress-port <port>] [--allow-from <id>]... [--conversation <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
   $(basename "$0") agent <agent> [--skip-discord] [--skip-telegram] [--skip-teams] [--test-start] [setup options...]
   $(basename "$0") admin <agent>
@@ -40,7 +40,7 @@ EOF
     telegram)
       cat <<EOF
 Usage:
-  $(basename "$0") telegram <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--allow-from <id>]... [--default-chat <id>] [--test-chat <id>] [--use-relay] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
+  $(basename "$0") telegram <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--allow-from <id>]... [--default-chat <id>] [--test-chat <id>] [--use-relay (default) | --no-relay] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
 EOF
       ;;
     teams)
@@ -521,7 +521,7 @@ run_telegram() {
   local compat_config=""
   local channel_account=""
   local dry_run=0
-  local use_relay=0
+  local use_relay=1
   local py_args=()
   local base_args=()
 
@@ -536,6 +536,9 @@ run_telegram() {
   runtime_config="$(bridge_compat_config_file)"
   compat_config="$(bridge_compat_config_file)"
   case "${BRIDGE_TELEGRAM_USE_RELAY:-}" in
+    0|false|FALSE|no|NO|off|OFF)
+      use_relay=0
+      ;;
     1|true|TRUE|yes|YES|on|ON)
       use_relay=1
       ;;
@@ -561,6 +564,11 @@ run_telegram() {
         ;;
       --use-relay)
         use_relay=1
+        py_args+=("$1")
+        shift
+        ;;
+      --no-relay)
+        use_relay=0
         py_args+=("$1")
         shift
         ;;
@@ -769,7 +777,7 @@ run_agent() {
         teams_args+=("$1")
         shift
         ;;
-      --use-relay)
+      --use-relay|--no-relay)
         telegram_args+=("$1")
         shift
         ;;

--- a/plugins/telegram-relay/README.md
+++ b/plugins/telegram-relay/README.md
@@ -36,23 +36,21 @@ writes a protected `relay-token` file next to `.env`, registers that path in
 `~/.agent-bridge/state/channels/telegram/tokens.list`, and enables daemon
 supervision. The token value is never placed on argv.
 
-## Opt-In Steps
+## Setup Steps
 
-1. Configure the Telegram state and opt into relay supervision:
+Since v0.6.39 the relay path is the default for `agent-bridge setup telegram`. The minimum sequence:
+
+1. Configure the Telegram state. `--use-relay` is the default; pass `--no-relay` only as a transitional escape hatch when a long-running legacy `plugin:telegram@claude-plugins-official` session must be preserved.
 
    ```bash
    agent-bridge setup telegram patch \
      --token "<telegram-bot-token>" \
      --allow-from "<telegram-user-id>" \
      --default-chat "<telegram-chat-id>" \
-     --use-relay \
      --yes
    ```
 
-2. Restart or sync the bridge daemon. Setup already writes `.env`,
-   `access.json`, `.telegram/relay-token`, `tokens.list`, the
-   `plugin:telegram-relay@agent-bridge` channel registration, and
-   `BRIDGE_TELEGRAM_RELAY_ENABLED=1`.
+2. Restart or sync the bridge daemon. Setup already writes `.env`, `access.json`, `.telegram/relay-token`, `tokens.list`, the `plugin:telegram-relay@agent-bridge` channel registration, and `BRIDGE_TELEGRAM_RELAY_ENABLED=1`.
 
    ```bash
    bash bridge-daemon.sh sync

--- a/scripts/smoke/telegram-relay-setup.sh
+++ b/scripts/smoke/telegram-relay-setup.sh
@@ -172,17 +172,17 @@ telegram_relay_setup_flow() {
   local api_base setup_output telegram_dir env_file access_file relay_token tokens_file socket_path roster_text
 
   api_base="$(start_fake_telegram)"
+  # Default flip (since v0.6.39): no --use-relay flag should still land on relay path.
   "$SMOKE_REPO_ROOT/agent-bridge" setup telegram test-agent \
     --token "123456:fake-token" \
     --allow-from "111111" \
     --default-chat "222222" \
-    --use-relay \
     --skip-validate \
     --skip-send-test \
     --yes \
     --api-base-url "$api_base" >"$SMOKE_TMP_ROOT/setup.out"
   setup_output="$(cat "$SMOKE_TMP_ROOT/setup.out")"
-  smoke_assert_contains "$setup_output" "relay_enabled: yes" "setup reports relay opt-in"
+  smoke_assert_contains "$setup_output" "relay_enabled: yes" "setup defaults to relay (no flag)"
 
   telegram_dir="$BRIDGE_AGENT_HOME_ROOT/test-agent/.telegram"
   env_file="$telegram_dir/.env"
@@ -228,7 +228,7 @@ main() {
   TMPDIR=/tmp smoke_setup_bridge_home "tgsetup"
   write_roster
   write_plugin_registry
-  smoke_run "Telegram relay setup lifecycle/status smoke" telegram_relay_setup_flow
+  smoke_run "Telegram relay setup lifecycle/status smoke (default flip)" telegram_relay_setup_flow
   smoke_log "passed"
 }
 


### PR DESCRIPTION
## Summary

Since v0.6.37 (#475 phase 2/3) the relay path is the architecturally-safe Telegram channel. But `setup telegram` defaulted to `plugin:telegram@claude-plugins-official` unless the operator passed `--use-relay`. For new setups there's no reason to land on the legacy path — it's the path that needed the relay fix in the first place.

Closes queue task #2293.

## Behavior matrix

| invocation | result |
|---|---|
| `setup telegram` (no flag) | `plugin:telegram-relay@agent-bridge` (**NEW DEFAULT**) |
| `setup telegram --use-relay` | `plugin:telegram-relay@agent-bridge` (idempotent) |
| `setup telegram --no-relay` | `plugin:telegram@claude-plugins-official` (escape hatch) |
| `BRIDGE_TELEGRAM_USE_RELAY=0` + no flag | legacy |
| `--use-relay --no-relay` | argparse error (mutually exclusive) |

## Changes

- `bridge-setup.sh:524`: `use_relay=0` → `use_relay=1`; new `--no-relay` flag handling. Usage strings updated to `[--use-relay (default) | --no-relay]`. The `agent` umbrella subcommand now accepts `--no-relay` too (line ~780).
- `bridge-setup.py`: `--use-relay` / `--no-relay` in a mutually-exclusive argparse group. `cmd_telegram` uses tri-state default (`None` = inherit env or default True).
- `env_flag(name, default=...)` helper extended to honor explicit false values (`"0"`/`"false"`/`"no"`/`"off"`) so `BRIDGE_TELEGRAM_USE_RELAY=0` still opts out at the shell level.
- Removed the dated `TELEGRAM_RELAY_LEGACY_WARN_AFTER` constant — the warning now fires on `--no-relay` regardless of date.
- `plugins/telegram-relay/README.md` "Opt-In Steps" → "Setup Steps" (no longer opt-in since default).
- `OPERATOR_ACTIONS_PENDING.md`: v0.6.39 informational entry. **No operator action required** — existing legacy registrations are untouched until the operator explicitly re-runs setup.
- `scripts/smoke/telegram-relay-setup.sh`: existing fixture now exercises the no-flag default path and asserts `relay_enabled: yes` without `--use-relay`.

## What's NOT touched

Existing operator overlays / channel registrations are untouched. The flip only affects new `setup telegram` invocations. Hosts on legacy `plugin:telegram@claude-plugins-official` keep working until the operator runs setup again.

## Test plan

- [x] `bash -n bridge-setup.sh scripts/smoke/telegram-relay-setup.sh` clean
- [x] `python3 -m py_compile bridge-setup.py` clean
- [x] `shellcheck bridge-setup.sh scripts/smoke/telegram-relay-setup.sh` clean
- [x] env_flag tri-state verified manually (`env_flag("NONEXISTENT", default=True)` → True)
- [x] smoke fixture asserts no-flag default lands on relay path

🤖 Generated with [Claude Code](https://claude.com/claude-code)