### PR TITLE
upgrade: rerender shared Claude settings

### DIFF
--- a/OPERATOR_ACTIONS_PENDING.md
+++ b/OPERATOR_ACTIONS_PENDING.md
@@ -15,6 +15,31 @@ PR, prepend a new section; do not edit older sections in place.
 
 ---
 
+## v0.6.39 — settings rerender for hosts that upgraded before this fix
+
+- applies_when_upgrading_from: any version `0.6.33 .. 0.6.38`
+- urgency: medium.
+
+### Action
+
+Run on the upgraded host to backfill managed Claude settings defaults that may
+not have propagated during prior upgrades:
+
+```bash
+agent-bridge agent rerender-settings --apply
+```
+
+Confirm `autoCompactWindow: 400000` is present in each managed Claude agent's
+effective settings.
+
+### Skip if
+
+- This host has no managed Claude agents.
+- `agent-bridge agent rerender-settings --dry-run` reports every target as
+  `unchanged`.
+
+---
+
 ## v0.6.37 — telegram-relay opt-in
 
 - applies_when_upgrading_from: any version `<= 0.6.36`

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -15,6 +15,7 @@ Usage:
   $(basename "$0") list [--json]
   $(basename "$0") show <agent> [--json]
   $(basename "$0") reclassify [--agent <agent>] [--apply] [--json]
+  $(basename "$0") rerender-settings [<agent>...] [--apply|--dry-run] [--json]
   $(basename "$0") start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $(basename "$0") safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $(basename "$0") stop <agent>
@@ -56,6 +57,7 @@ Examples:
   $(basename "$0") list --json
   $(basename "$0") show reviewer --json
   $(basename "$0") reclassify --apply
+  $(basename "$0") rerender-settings --apply
   $(basename "$0") start reviewer --dry-run
   $(basename "$0") restart reviewer --attach
   $(basename "$0") safe-mode reviewer --attach
@@ -1321,6 +1323,334 @@ PY
   done <<<"$rows"
 }
 
+bridge_agent_shared_settings_plan_json() {
+  local agent="$1"
+  local workdir="$2"
+
+  bridge_agent_manage_python \
+    "$SCRIPT_DIR/bridge-hooks.py" \
+    "$agent" \
+    "$workdir" \
+    "$(bridge_hook_shared_settings_base_file)" \
+    "$(bridge_hook_shared_settings_overlay_file)" \
+    "$(bridge_hook_shared_settings_effective_file)" <<'PY'
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+hooks_py, agent, workdir, base_file, overlay_file, effective_file = sys.argv[1:]
+spec = importlib.util.spec_from_file_location("bridge_hooks", hooks_py)
+if spec is None or spec.loader is None:
+    raise SystemExit(f"could not load {hooks_py}")
+hooks = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hooks)
+
+settings_path = Path(workdir).expanduser() / ".claude" / "settings.json"
+base_path = Path(base_file).expanduser()
+overlay_path = Path(overlay_file).expanduser()
+effective_path = Path(effective_file).expanduser()
+
+errors: list[str] = []
+
+def load_object(path: Path, label: str, *, absent_ok: bool = True) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        errors.append(f"{label} invalid JSON: {path}: {exc}")
+        return {}
+    if payload in (None, ""):
+        return {}
+    if not isinstance(payload, dict):
+        errors.append(f"{label} must be a JSON object: {path}")
+        return {}
+    return payload
+
+base_payload = load_object(base_path, "base")
+overlay_payload = load_object(overlay_path, "overlay")
+expected = hooks.merge_settings(hooks.BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS, base_payload)
+expected = hooks.merge_settings(expected, overlay_payload)
+
+current_error = ""
+try:
+    current_payload = load_object(settings_path, "current")
+except OSError as exc:
+    current_error = str(exc)
+    current_payload = {}
+
+effective_payload = load_object(effective_path, "effective")
+effective_exists = effective_path.exists()
+effective_matches = effective_exists and effective_payload == expected
+
+changes = []
+for key in hooks.BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS:
+    expected_value = expected.get(key)
+    if key not in current_payload:
+        changes.append({"key": key, "from": None, "to": expected_value, "reason": "missing"})
+    elif current_payload.get(key) != expected_value:
+        changes.append({
+            "key": key,
+            "from": current_payload.get(key),
+            "to": expected_value,
+            "reason": "differs",
+        })
+
+is_symlink = settings_path.is_symlink()
+link_target = os.readlink(settings_path) if is_symlink else ""
+link_ok = is_symlink and os.path.realpath(settings_path) == os.path.realpath(effective_path)
+needs_rerender = bool(changes) or not link_ok or not effective_matches or bool(errors) or bool(current_error)
+
+payload = {
+    "agent": agent,
+    "workdir": str(Path(workdir).expanduser()),
+    "settings_file": str(settings_path),
+    "base_settings_file": str(base_path),
+    "overlay_settings_file": str(overlay_path),
+    "effective_settings_file": str(effective_path),
+    "status": "needs-rerender" if needs_rerender else "unchanged",
+    "changes": changes,
+    "link": {
+        "ok": link_ok,
+        "is_symlink": is_symlink,
+        "target": link_target,
+    },
+    "effective": {
+        "exists": effective_exists,
+        "matches_expected": effective_matches,
+    },
+    "errors": errors,
+    "current_error": current_error,
+}
+print(json.dumps(payload, ensure_ascii=False, sort_keys=True))
+PY
+}
+
+bridge_agent_rerender_row_json() {
+  local mode="$1"
+  local before_json="$2"
+  local after_json="$3"
+  local error="$4"
+
+  bridge_agent_manage_python "$mode" "$before_json" "$after_json" "$error" <<'PY'
+import json
+import sys
+
+mode, before_raw, after_raw, error = sys.argv[1:]
+before = json.loads(before_raw)
+after = json.loads(after_raw) if after_raw else before
+row = dict(after)
+row["mode"] = mode
+row["before"] = before
+if error:
+    row["status"] = "failed"
+    row["error"] = error
+elif mode == "apply" and before.get("status") == "needs-rerender":
+    row["status"] = "rerendered" if after.get("status") == "unchanged" else after.get("status", "rerendered")
+else:
+    row["status"] = after.get("status", "unchanged")
+print(json.dumps(row, ensure_ascii=False, sort_keys=True))
+PY
+}
+
+bridge_agent_print_rerender_json() {
+  local mode="$1"
+  local rows_file="$2"
+  local failed_count="$3"
+
+  bridge_agent_manage_python "$mode" "$rows_file" "$failed_count" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+mode, rows_file, failed_count = sys.argv[1:]
+rows = []
+path = Path(rows_file)
+if path.exists():
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            rows.append(json.loads(line))
+print(json.dumps({
+    "mode": mode,
+    "count": len(rows),
+    "failed_count": int(failed_count),
+    "candidates": rows,
+}, ensure_ascii=False, indent=2))
+PY
+}
+
+bridge_agent_print_rerender_text() {
+  local mode="$1"
+  local rows_file="$2"
+  local failed_count="$3"
+
+  bridge_agent_manage_python "$mode" "$rows_file" "$failed_count" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+mode, rows_file, failed_count = sys.argv[1:]
+rows = []
+path = Path(rows_file)
+if path.exists():
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+print(f"mode: {mode}")
+if not rows:
+    print("rerender-settings: no managed Claude settings targets")
+    raise SystemExit(0)
+for row in rows:
+    changes = row.get("before", row).get("changes") or row.get("changes") or []
+    change_text = ", ".join(
+        f"{item.get('key')}: {item.get('from')!r} -> {item.get('to')!r}"
+        for item in changes
+    ) or "-"
+    link = row.get("link") or {}
+    effective = row.get("effective") or {}
+    print(
+        f"{row.get('status')}: {row.get('agent')} "
+        f"changes={change_text} "
+        f"link_ok={str(bool(link.get('ok'))).lower()} "
+        f"effective_ok={str(bool(effective.get('matches_expected'))).lower()} "
+        f"workdir={row.get('workdir')}"
+    )
+    if row.get("error"):
+        print(f"  error: {row.get('error')}")
+    for error in row.get("errors") or []:
+        print(f"  error: {error}")
+if int(failed_count):
+    print(f"failed_count: {failed_count}")
+PY
+}
+
+run_rerender_settings() {
+  local apply=0
+  local json_mode=0
+  local agent=""
+  local workdir=""
+  local canonical=""
+  local before_json=""
+  local after_json=""
+  local row_json=""
+  local apply_output=""
+  local error=""
+  local rows_file=""
+  local failed_count=0
+  local -a selected_agents=()
+  local -a targets=()
+  local -A seen_workdirs=()
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --apply)
+        apply=1
+        shift
+        ;;
+      --dry-run)
+        apply=0
+        shift
+        ;;
+      --json)
+        json_mode=1
+        shift
+        ;;
+      -h|--help)
+        printf 'Usage: %s rerender-settings [<agent>...] [--apply|--dry-run] [--json]\n' "$(basename "$0")"
+        return 0
+        ;;
+      --*)
+        bridge_die "지원하지 않는 agent rerender-settings 옵션입니다: $1"
+        ;;
+      *)
+        selected_agents+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  add_target() {
+    local target_agent="$1"
+    local target_workdir="$2"
+    [[ -n "$target_agent" && -n "$target_workdir" ]] || return 0
+    [[ -d "$target_workdir" ]] || return 0
+    canonical="$(bridge_agent_canonical_dir "$target_workdir")"
+    [[ -n "$canonical" ]] || return 0
+    if [[ -n "${seen_workdirs[$canonical]:-}" ]]; then
+      return 0
+    fi
+    seen_workdirs["$canonical"]=1
+    targets+=("${target_agent}"$'\t'"${target_workdir}")
+  }
+
+  if [[ ${#selected_agents[@]} -gt 0 ]]; then
+    for agent in "${selected_agents[@]}"; do
+      if [[ "$agent" == "_template" ]]; then
+        add_target "$agent" "$BRIDGE_AGENT_HOME_ROOT/_template"
+        continue
+      fi
+      bridge_require_agent "$agent"
+      [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || bridge_die "Claude agent가 아닙니다: $agent"
+      add_target "$agent" "$(bridge_expand_user_path "$(bridge_agent_workdir "$agent")")"
+    done
+  else
+    for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+      [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || continue
+      add_target "$agent" "$(bridge_expand_user_path "$(bridge_agent_workdir "$agent")")"
+    done
+
+    if [[ -d "$BRIDGE_AGENT_HOME_ROOT/_template" ]]; then
+      add_target "_template" "$BRIDGE_AGENT_HOME_ROOT/_template"
+    fi
+
+    if [[ -d "$BRIDGE_AGENT_HOME_ROOT" ]]; then
+      for workdir in "$BRIDGE_AGENT_HOME_ROOT"/*; do
+        [[ -d "$workdir" ]] || continue
+        agent="$(basename "$workdir")"
+        [[ "$agent" == ".claude" || "$agent" == "_template" ]] && continue
+        if [[ -f "$workdir/SESSION-TYPE.md" ]]; then
+          if grep -Eq 'Session Type:[[:space:]]*(admin|static-claude)' "$workdir/SESSION-TYPE.md"; then
+            add_target "$agent" "$workdir"
+          fi
+        elif [[ -e "$workdir/.claude/settings.json" ]]; then
+          add_target "$agent" "$workdir"
+        fi
+      done
+    fi
+  fi
+
+  rows_file="$(mktemp "${TMPDIR:-/tmp}/bridge-rerender-settings.XXXXXX")"
+  for target in "${targets[@]}"; do
+    agent="${target%%$'\t'*}"
+    workdir="${target#*$'\t'}"
+    before_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir")"
+    error=""
+    if [[ $apply -eq 1 ]]; then
+      if apply_output="$(bridge_link_claude_settings_to_shared "$workdir" 2>&1)"; then
+        after_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir")"
+        bridge_audit_log "$(bridge_admin_agent_id 2>/dev/null || printf bridge-upgrade)" "shared_settings_rerendered" "$agent" \
+          --detail workdir="$workdir" >/dev/null 2>&1 || true
+      else
+        error="$apply_output"
+        after_json="$before_json"
+        failed_count=$((failed_count + 1))
+      fi
+      row_json="$(bridge_agent_rerender_row_json apply "$before_json" "$after_json" "$error")"
+    else
+      row_json="$(bridge_agent_rerender_row_json dry-run "$before_json" "" "")"
+    fi
+    printf '%s\n' "$row_json" >>"$rows_file"
+  done
+
+  if [[ $json_mode -eq 1 ]]; then
+    bridge_agent_print_rerender_json "$([[ $apply -eq 1 ]] && printf apply || printf dry-run)" "$rows_file" "$failed_count"
+  else
+    bridge_agent_print_rerender_text "$([[ $apply -eq 1 ]] && printf apply || printf dry-run)" "$rows_file" "$failed_count"
+  fi
+  rm -f "$rows_file"
+  [[ $failed_count -eq 0 ]]
+}
+
 run_create() {
   local agent="${1:-}"
   local engine="claude"
@@ -2089,6 +2419,9 @@ case "$subcommand" in
   reclassify)
     run_reclassify "$@"
     ;;
+  rerender-settings)
+    run_rerender_settings "$@"
+    ;;
   start)
     run_start "$@"
     ;;
@@ -2122,7 +2455,7 @@ case "$subcommand" in
   *)
     # Issue #163 Phase 2: surface an intent-recovery hint before dying.
     _hint="$(bridge_suggest_subcommand "$subcommand" \
-      "create list show reclassify start safe-mode stop restart ack-crash forget-session attach compact handoff")"
+      "create list show reclassify rerender-settings start safe-mode stop restart ack-crash forget-session attach compact handoff")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 agent 명령입니다: $subcommand"
     ;;

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -38,6 +38,7 @@ SOURCE_VERSION=""
 SOURCE_REF=""
 SOURCE_HEAD=""
 SOURCE_RECLASSIFY_JSON='{}'
+SHARED_SETTINGS_RERENDER_JSON='{"mode":"skipped","count":0,"failed_count":0,"candidates":[]}'
 
 usage() {
   cat <<EOF
@@ -171,19 +172,8 @@ bridge_upgrade_with_target_env() {
 bridge_upgrade_propagate_claude_shared_settings() {
   local target_root="$1"
 
-  bridge_upgrade_with_target_env "$target_root" "$BRIDGE_BASH_BIN" -lc '
-    set -euo pipefail
-    source "$1/bridge-lib.sh"
-    bridge_load_roster
-    agent=""
-    workdir=""
-    for agent in "${BRIDGE_AGENT_IDS[@]}"; do
-      [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || continue
-      workdir="$(bridge_agent_workdir "$agent")"
-      [[ -n "$workdir" ]] || continue
-      bridge_ensure_claude_shared_settings_for_managed_workdir "$workdir" >/dev/null 2>&1 || true
-    done
-  ' -- "$target_root"
+  bridge_upgrade_with_target_env "$target_root" \
+    "$BRIDGE_BASH_BIN" "$target_root/bridge-agent.sh" rerender-settings --apply --json
 }
 
 bridge_upgrade_collect_agent_restart_report() {
@@ -1165,7 +1155,16 @@ APPLY_JSON="$(python3 "$SOURCE_ROOT/bridge-upgrade.py" "${apply_args[@]}")"
 AGENT_RESTART_JSON="$(bridge_upgrade_agent_restart_json "" 0 "$DRY_RUN")"
 
 if [[ $DRY_RUN -eq 0 ]]; then
-  bridge_upgrade_propagate_claude_shared_settings "$TARGET_ROOT" >/dev/null 2>&1 || true
+  SHARED_SETTINGS_RERENDER_JSON="$(bridge_upgrade_propagate_claude_shared_settings "$TARGET_ROOT")"
+  if ! python3 - "$SHARED_SETTINGS_RERENDER_JSON" <<'PY'
+import json
+import sys
+payload = json.loads(sys.argv[1])
+raise SystemExit(0 if int(payload.get("failed_count") or 0) == 0 else 1)
+PY
+  then
+    echo "[bridge-upgrade] WARN: shared Claude settings rerender failed for one or more agents" >&2
+  fi
 fi
 
 if [[ $MIGRATE_AGENTS -eq 1 ]]; then
@@ -1462,10 +1461,11 @@ if [[ $JSON -eq 1 ]]; then
   printf '%s' "$AGENT_RESTART_JSON" >"$_json_payload_dir/agent-restart.json"
   printf '%s' "$CHANNEL_GUARD_JSON" >"$_json_payload_dir/channel-guard.json"
   printf '%s' "$SOURCE_RECLASSIFY_JSON" >"$_json_payload_dir/source-reclassify.json"
+  printf '%s' "$SHARED_SETTINGS_RERENDER_JSON" >"$_json_payload_dir/shared-settings-rerender.json"
   set +e
-  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" "$_json_payload_dir/source-reclassify.json" <<'PY'
+  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" "$_json_payload_dir/source-reclassify.json" "$_json_payload_dir/shared-settings-rerender.json" <<'PY'
 import json, sys
-source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file, source_reclassify_json_file = sys.argv[1:]
+source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file, source_reclassify_json_file, shared_settings_rerender_json_file = sys.argv[1:]
 
 def load_json(path):
     with open(path, encoding="utf-8") as fh:
@@ -1478,6 +1478,7 @@ analysis_payload = load_json(analysis_json_file)
 agent_restart_payload = load_json(agent_restart_json_file)
 channel_guard_payload = load_json(channel_guard_json_file)
 source_reclassify_payload = load_json(source_reclassify_json_file)
+shared_settings_rerender_payload = load_json(shared_settings_rerender_json_file)
 payload = {
     "mode": "upgrade",
     "version": source_version,
@@ -1513,6 +1514,7 @@ payload = {
     "agent_restart": agent_restart_payload,
     "agent_migration": migration_payload,
     "source_reclassify": source_reclassify_payload,
+    "shared_settings_rerender": shared_settings_rerender_payload,
   }
 print(json.dumps(payload, ensure_ascii=False, indent=2))
 PY
@@ -1561,6 +1563,20 @@ mode = payload.get("mode") or "dry-run"
 print(f"source_reclassify: {count} candidate(s) ({mode})")
 for item in payload.get("candidates") or []:
     print(f"  - {item.get('action')}: {item.get('agent')} old_source={item.get('old_source')} new_source={item.get('new_source')} reason={item.get('reason')}")
+PY
+python3 - "$SHARED_SETTINGS_RERENDER_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+count = int(payload.get("count") or 0)
+failed = int(payload.get("failed_count") or 0)
+mode = payload.get("mode") or "skipped"
+print(f"shared_settings_rerender: {count} target(s) ({mode}), failed={failed}")
+for item in payload.get("candidates") or []:
+    status = item.get("status") or "unknown"
+    agent = item.get("agent") or "-"
+    changes = item.get("before", item).get("changes") or item.get("changes") or []
+    change_keys = ",".join(str(change.get("key")) for change in changes) or "-"
+    print(f"  - {status}: {agent} changes={change_keys}")
 PY
 python3 - "$APPLY_JSON" <<'PY'
 import json, sys

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation telegram-relay telegram-relay-plugin telegram-relay-setup
+  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate telegram-relay telegram-relay-plugin telegram-relay-setup
 }
 
 add_all_integration() {
@@ -193,7 +193,7 @@ select_for_path() {
       ;;
 
     bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh)
-      add_required launch tmux-injection upgrade-source-preservation
+      add_required launch tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -220,12 +220,12 @@ select_for_path() {
       ;;
 
     hooks/*|bridge-hooks.py|lib/bridge-hooks.sh)
-      add_required hooks
+      add_required hooks upgrade-shared-settings-propagate
       add_integration integration-minimal
       ;;
 
     bridge-upgrade.sh|bridge-upgrade.py|scripts/export-public-snapshot.sh|VERSION)
-      add_required upgrade upgrade-source-preservation
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/upgrade-shared-settings-propagate.sh
+++ b/scripts/smoke/upgrade-shared-settings-propagate.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SMOKE_NAME="upgrade-shared-settings-propagate"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+json_field() {
+  local json="$1"
+  local expr="$2"
+  printf '%s' "$json" | python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+expr = sys.argv[1]
+print(eval(expr, {"payload": payload}))
+' "$expr"
+}
+
+settings_value() {
+  local settings_file="$1"
+  local key="$2"
+  python3 - "$settings_file" "$key" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_file, key = sys.argv[1:]
+payload = json.loads(Path(settings_file).read_text(encoding="utf-8"))
+print(payload.get(key))
+PY
+}
+
+write_fixture() {
+  local agent_home="$BRIDGE_AGENT_HOME_ROOT/patch"
+
+  mkdir -p "$agent_home/.claude" "$BRIDGE_ACTIVE_AGENT_DIR"
+  printf '# patch soul\n' >"$agent_home/SOUL.md"
+  printf '# Session Type\n\n- Session Type: admin\n' >"$agent_home/SESSION-TYPE.md"
+  printf '%s\n' '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"old"}]}]},"env":{"BASE_ONLY":"yes"}}' >"$agent_home/.claude/settings.json"
+  printf '%s\n' '{"env":{"OVERLAY_ONLY":"yes"}}' >"$BRIDGE_AGENT_HOME_ROOT/.claude/settings.local.json"
+
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+BRIDGE_ADMIN_AGENT_ID=patch
+bridge_add_agent_id_if_missing "patch"
+BRIDGE_AGENT_DESC["patch"]="patch admin role"
+BRIDGE_AGENT_ENGINE["patch"]="claude"
+BRIDGE_AGENT_SOURCE["patch"]="static"
+BRIDGE_AGENT_SESSION["patch"]="patch"
+BRIDGE_AGENT_WORKDIR["patch"]="$agent_home"
+BRIDGE_AGENT_LOOP["patch"]="1"
+BRIDGE_AGENT_CONTINUE["patch"]="1"
+EOF
+}
+
+assert_dry_run_reports_missing_default() {
+  local output count status key
+
+  output="$(BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" agent rerender-settings --json)"
+  count="$(json_field "$output" 'payload["count"]')"
+  status="$(json_field "$output" 'payload["candidates"][0]["status"]')"
+  key="$(json_field "$output" 'payload["candidates"][0]["changes"][0]["key"]')"
+
+  smoke_assert_eq "1" "$count" "rerender dry-run target count"
+  smoke_assert_eq "needs-rerender" "$status" "rerender dry-run status"
+  smoke_assert_eq "autoCompactWindow" "$key" "rerender dry-run missing managed default"
+  [[ ! -L "$BRIDGE_AGENT_HOME_ROOT/patch/.claude/settings.json" ]] || smoke_fail "dry-run should not relink settings"
+}
+
+assert_apply_rerenders_and_preserves_overlay() {
+  local output status audit settings_file effective_file
+
+  output="$(BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" agent rerender-settings --apply --json)"
+  status="$(json_field "$output" 'payload["candidates"][0]["status"]')"
+  smoke_assert_eq "rerendered" "$status" "rerender apply status"
+
+  settings_file="$BRIDGE_AGENT_HOME_ROOT/patch/.claude/settings.json"
+  effective_file="$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
+  [[ -L "$settings_file" ]] || smoke_fail "rerender apply should link agent settings to shared effective settings"
+  smoke_assert_eq "400000" "$(settings_value "$settings_file" autoCompactWindow)" "rerender apply backfills autoCompactWindow"
+  smoke_assert_eq "yes" "$(python3 - "$settings_file" <<'PY'
+import json, sys
+from pathlib import Path
+print(json.loads(Path(sys.argv[1]).read_text()).get("env", {}).get("OVERLAY_ONLY"))
+PY
+)" "rerender apply preserves operator overlay"
+  smoke_assert_eq "400000" "$(settings_value "$effective_file" autoCompactWindow)" "shared effective has managed default"
+
+  audit="$(cat "$BRIDGE_AUDIT_LOG")"
+  smoke_assert_contains "$audit" "shared_settings_rerendered" "rerender apply emits audit row"
+}
+
+assert_upgrade_runs_rerender() {
+  local agent_home upgrade_json has_patch
+
+  agent_home="$BRIDGE_AGENT_HOME_ROOT/patch"
+  rm -f "$agent_home/.claude/settings.json" "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
+  printf '%s\n' '{"env":{"BASE_ONLY":"yes-again"}}' >"$agent_home/.claude/settings.json"
+
+  upgrade_json="$(
+    env BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" upgrade \
+      --source "$SMOKE_REPO_ROOT" \
+      --target "$BRIDGE_HOME" \
+      --channel current \
+      --no-pull \
+      --no-backup \
+      --no-migrate-agents \
+      --no-restart-daemon \
+      --no-restart-agents \
+      --allow-dirty \
+      --allow-dirty-source \
+      --json
+  )"
+  has_patch="$(json_field "$upgrade_json" 'any(item["agent"] == "patch" for item in payload["shared_settings_rerender"]["candidates"])')"
+  smoke_assert_eq "True" "$has_patch" "upgrade reports patch shared settings rerender target"
+  [[ -L "$agent_home/.claude/settings.json" ]] || smoke_fail "upgrade should relink managed Claude settings"
+  smoke_assert_eq "400000" "$(settings_value "$agent_home/.claude/settings.json" autoCompactWindow)" "upgrade backfills autoCompactWindow"
+}
+
+assert_operator_overlay_wins() {
+  local agent_home output status
+
+  agent_home="$BRIDGE_AGENT_HOME_ROOT/patch"
+  rm -f "$agent_home/.claude/settings.json" "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
+  printf '%s\n' '{"autoCompactWindow":600000,"env":{"OVERLAY_ONLY":"yes"}}' >"$BRIDGE_AGENT_HOME_ROOT/.claude/settings.local.json"
+  printf '%s\n' '{"env":{"STALE_AGENT":"yes"}}' >"$agent_home/.claude/settings.json"
+
+  output="$(BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" agent rerender-settings --apply --json)"
+  status="$(json_field "$output" 'payload["candidates"][0]["status"]')"
+  smoke_assert_eq "rerendered" "$status" "rerender overlay apply status"
+  smoke_assert_eq "600000" "$(settings_value "$agent_home/.claude/settings.json" autoCompactWindow)" "operator overlay overrides managed default"
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "upgrade-settings"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/.claude"
+  write_fixture
+  smoke_run "rerender dry-run reports missing managed default" assert_dry_run_reports_missing_default
+  smoke_run "rerender apply links shared settings and audits" assert_apply_rerenders_and_preserves_overlay
+  smoke_run "upgrade apply rerenders shared Claude settings" assert_upgrade_runs_rerender
+  smoke_run "operator overlay wins over managed default" assert_operator_overlay_wins
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `agent rerender-settings` dry-run/apply recovery for managed Claude shared settings
- make upgrade run the rerender path and report `shared_settings_rerender` in JSON/text output
- add focused smoke coverage for v0.6.33-0.6.38 missing `autoCompactWindow` propagation and operator overlay precedence
- add OPERATOR_ACTIONS_PENDING.md recovery guidance

## Verification
- `bash -n bridge-agent.sh bridge-upgrade.sh scripts/smoke/upgrade-shared-settings-propagate.sh scripts/ci-select-smoke.sh`
- `shellcheck bridge-agent.sh bridge-upgrade.sh scripts/smoke/upgrade-shared-settings-propagate.sh scripts/ci-select-smoke.sh`
- `python3 -m py_compile bridge-hooks.py bridge-upgrade.py`
- `bash scripts/smoke/upgrade-shared-settings-propagate.sh`
- `bash scripts/smoke/upgrade.sh`
- `bash scripts/smoke/hooks.sh`
- `bash scripts/ci-select-smoke.sh --suite required --changed-file bridge-agent.sh --changed-file bridge-upgrade.sh --changed-file lib/bridge-hooks.sh --changed-file scripts/ci-select-smoke.sh --changed-file scripts/smoke/upgrade-shared-settings-propagate.sh --run`

Refs queue task #2300 / issue #2299.