### PR TITLE
fix(daemon): gate stall trigger on inbox/refresh state

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1205,16 +1205,20 @@ process_stall_reports() {
           fi
           if [[ -n "$classification" ]]; then
             # Issue #496: even after a positive classification, suppress the
-            # trigger when the agent has no real inbox work AND no pending
-            # daily memory refresh. A loop-mode admin agent reached this point
-            # via the `loop_mode=1` clause above, but with a fully drained inbox
-            # (queued=0 claimed=0) the classifier is only matching benign
-            # Claude UI text in the detached pane (transcript wraps, system-
-            # reminder echoes, tool-call results) and fires `[Agent Bridge]:
-            # stall detected` every ~30 min indefinitely. blocked rows are
-            # intentionally excluded -- they are stuck-with-a-reason and the
-            # nudge wording ("continue if work can proceed") does not apply.
-            if (( idle >= explicit_idle )) && (( queued > 0 || claimed > 0 || refresh_pending == 1 )); then
+            # trigger when the agent has no real inbox work. A loop-mode admin
+            # agent reached this point via the `loop_mode=1` clause above, but
+            # with a fully drained inbox (queued=0 claimed=0) the classifier is
+            # only matching benign Claude UI text in the detached pane
+            # (transcript wraps, system-reminder echoes, tool-call results) and
+            # fires `[Agent Bridge]: stall detected` every ~30 min indefinitely.
+            # blocked rows are intentionally excluded -- they are
+            # stuck-with-a-reason and the nudge wording ("continue if work can
+            # proceed") does not apply. refresh_pending is also excluded: it
+            # can stay true for hours on an idle detached agent and would
+            # otherwise re-introduce the same false-positive cycle in a
+            # different shape; daily memory refresh has its own nudge surface
+            # and is not the stall watchdog's responsibility.
+            if (( idle >= explicit_idle )) && (( queued > 0 || claimed > 0 )); then
               trigger_stall=1
             fi
           elif (( claimed > 0 )) && (( idle >= unknown_idle )) && [[ -n "$excerpt_hash" ]]; then

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1203,26 +1203,23 @@ process_stall_reports() {
               excerpt="$(bridge_stall_decode_excerpt "$excerpt_b64")"
             fi
           fi
-          if [[ -n "$classification" ]]; then
-            # Issue #496: even after a positive classification, suppress the
-            # trigger when the agent has no real inbox work. A loop-mode admin
-            # agent reached this point via the `loop_mode=1` clause above, but
-            # with a fully drained inbox (queued=0 claimed=0) the classifier is
-            # only matching benign Claude UI text in the detached pane
-            # (transcript wraps, system-reminder echoes, tool-call results) and
-            # fires `[Agent Bridge]: stall detected` every ~30 min indefinitely.
-            # blocked rows are intentionally excluded -- they are
-            # stuck-with-a-reason and the nudge wording ("continue if work can
-            # proceed") does not apply. refresh_pending is also excluded: it
-            # can stay true for hours on an idle detached agent and would
-            # otherwise re-introduce the same false-positive cycle in a
-            # different shape; daily memory refresh has its own nudge surface
-            # and is not the stall watchdog's responsibility.
-            if (( idle >= explicit_idle )) && (( queued > 0 || claimed > 0 )); then
-              trigger_stall=1
-            fi
-          elif (( claimed > 0 )) && (( idle >= unknown_idle )) && [[ -n "$excerpt_hash" ]]; then
-            classification="unknown"
+          # Issue #496: trust the classifier. The previous `unknown`-fallback
+          # branch fired whenever (claimed > 0 && idle >= unknown_idle &&
+          # excerpt_hash != "") even though the classifier had explicitly
+          # returned an empty classification -- meaning no rate_limit, auth,
+          # network, or interactive_picker pattern matched the captured pane.
+          # Audit-log evidence on the affected host showed 29 spurious fires
+          # across 2026-04-29..2026-04-30 against an attached `patch` admin,
+          # all with classification=unknown, matched_line_hash="", and a
+          # short-lived claimed=1 produced by per-10-min cron ticks
+          # (librarian-watchdog, wiki-mention-scan, etc.) that briefly held
+          # a queue task. The classifier patterns are deliberately narrow
+          # (Issues #161, #264, #329 Track A) so an empty result should be
+          # honored as a hard "not stalled" rather than overridden by a
+          # heuristic that does not actually correlate with being stuck.
+          # Real stalls (rate_limit, auth, network, interactive_picker)
+          # still fire because the classifier still matches them.
+          if [[ -n "$classification" ]] && (( idle >= explicit_idle )); then
             trigger_stall=1
           fi
         fi

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1143,6 +1143,7 @@ process_stall_reports() {
       continue
     fi
 
+    [[ "$queued" =~ ^[0-9]+$ ]] || queued=0
     [[ "$claimed" =~ ^[0-9]+$ ]] || claimed=0
     [[ "$active" =~ ^[0-9]+$ ]] || active=0
     [[ "$idle" =~ ^[0-9]+$ ]] || idle=0
@@ -1203,7 +1204,19 @@ process_stall_reports() {
             fi
           fi
           if [[ -n "$classification" ]]; then
-            (( idle >= explicit_idle )) && trigger_stall=1
+            # Issue #496: even after a positive classification, suppress the
+            # trigger when the agent has no real inbox work AND no pending
+            # daily memory refresh. A loop-mode admin agent reached this point
+            # via the `loop_mode=1` clause above, but with a fully drained inbox
+            # (queued=0 claimed=0) the classifier is only matching benign
+            # Claude UI text in the detached pane (transcript wraps, system-
+            # reminder echoes, tool-call results) and fires `[Agent Bridge]:
+            # stall detected` every ~30 min indefinitely. blocked rows are
+            # intentionally excluded -- they are stuck-with-a-reason and the
+            # nudge wording ("continue if work can proceed") does not apply.
+            if (( idle >= explicit_idle )) && (( queued > 0 || claimed > 0 || refresh_pending == 1 )); then
+              trigger_stall=1
+            fi
           elif (( claimed > 0 )) && (( idle >= unknown_idle )) && [[ -n "$excerpt_hash" ]]; then
             classification="unknown"
             trigger_stall=1
@@ -1249,6 +1262,7 @@ process_stall_reports() {
       bridge_audit_log daemon stall_detected "$agent" \
         --detail classification="$classification" \
         --detail idle_seconds="$idle" \
+        --detail queued="$queued" \
         --detail claimed="$claimed" \
         --detail excerpt_hash="$excerpt_hash" \
         --detail matched_line_hash="$matched_line_hash"


### PR DESCRIPTION
## Summary

- **Root cause** (per the issue author's audit-log RCA in the comment thread): the `unknown`-classification fallback at the elif branch in `process_stall_reports()` fired whenever (`claimed > 0 && idle >= unknown_idle && excerpt_hash != ""`) even when `bridge-stall.py classify()` had explicitly returned an empty classification — i.e. no `rate_limit` / `auth` / `network` / `interactive_picker` pattern actually matched the captured pane. On the affected host, 29 spurious fires across 2026-04-29..2026-04-30 hit an attached `patch` admin with `classification=unknown matched_line_hash=""` and a short-lived `claimed=1` produced by per-10-min cron ticks (librarian-watchdog, wiki-mention-scan, etc.) that briefly held a queue task. The pane captures were normal Claude UI text (system-reminder echoes, transcript scrollback). No actual stall.
- **Fix**: trust the classifier. Remove the heuristic `unknown`-fallback so an empty classification result is honored as a hard "not stalled" rather than overridden. The classifier patterns are deliberately narrow (Issues #161, #264, #329 Track A). Real stalls (`rate_limit`, `auth`, `network`, `interactive_picker`) still fire because the classifier still matches them.
- **Scope**: single-file change in `bridge-daemon.sh` (+19/-4). The inbox-count gate explored in r1/r2 is dropped — with the fallback gone, the classifier's negative result already covers the empty-inbox case, and gating *positive* classifications on inbox state would suppress legitimate picker/auth/network stalls on idle agents (exactly when those need to fire).
- **Defense-in-depth**: `queued` numeric normalization (mirrors existing `claimed`/`active`/`idle` pattern) and `--detail queued="$queued"` in the `stall_detected` audit log are kept as low-cost diagnostics for any future regression in this area.
- Issue #374's pre-classifier guard at line 1174 is intentionally untouched.

## Review history (Codex pair-review per CLAUDE.md)

- **r1** `eb5fa64`: gate `(queued > 0 || claimed > 0 || refresh_pending == 1)` post-classifier.
- **r2** `c081bf0`: drop `refresh_pending` from the gate (Codex caught that a refresh-pending idle agent would still fire on benign UI text).
- **r3** `a1e5642`: remove the `unknown`-fallback elif entirely. Issue author posted an audit-log RCA showing the documented production fires were via the unknown-fallback path with cron-transient `claimed=1`, not via the post-classifier path the inbox gate covered. The cleaner fix is to trust the classifier; the inbox gate becomes unnecessary.

## Test plan

- [x] `bash -n bridge-daemon.sh` — passes
- [x] `shellcheck bridge-daemon.sh` — clean
- [x] `./scripts/smoke-test.sh` — passes through the entire stall/queue/cron-reducer/context-pressure-detector sections; trips the **pre-existing** `TMP_ROOT: unbound variable` at `scripts/smoke-test.sh:447` (issue-#472 context-pressure unit block) which is unrelated to this fix and reproduces on `main` without the patch
- [x] Trigger-table walkthrough for the patched code path:

| case | classification | claimed | idle | r3 trigger |
|---|---|---|---|---|
| documented #496 (cron-transient claim, benign pane) | `""` | 1 | 1500 | `0` ← bug fixed |
| empty-inbox idle (loop=1 admin, benign pane) | `""` | 0 | 300 | `0` |
| genuine rate_limit stall | `rate_limit` | * | 300 | `1` |
| genuine auth stall | `auth` | * | 300 | `1` |
| genuine picker stall (idle agent) | `interactive_picker` | 0 | 300 | `1` ← preserved |
| genuine network stall on claimed work | `network` | 1 | 300 | `1` |
| classifier returns empty, idle below threshold | `""` | * | 10 | `0` |

The dropped fallback's only legitimate use case was "agent has a claimed task and pane has been silent for 15+ min" — but with the classifier already returning empty, there is no concrete stall signal to act on, and the audit data shows this case was empirically a false-positive driver in production. If a defensive fallback is wanted later it should require a stronger signal than the previous heuristic (e.g. provider-PID hung, queue-task lease near expiry) — tracked separately.

Fixes #496