### PR TITLE
feat(cron): inbox-only reporting contract + dedupe semantics fix (PR1/3)

### DIFF
--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -566,9 +566,18 @@ def emit_legacy_key_audit(request: dict[str, Any], run_id: str, *, target_agent:
     """PR1.3 + PR1.4 + PR1.10 — one-line audit when a job still wires the
     deprecated `allow_channel_delivery`, `disposable_needs_channels`, or
     `payload_kind=agentTurn`. The runner honors none of these for behavior;
-    the audit gives operators a way to find and remove them."""
+    the audit gives operators a way to find and remove them.
+
+    Codex r1 P2 — `lib/bridge-cron.sh` writes both `allow_channel_delivery`
+    and `allow_structured_relay` for every request as a false-default
+    alias, so flagging on key-presence alone fires for normal no-relay
+    jobs. We now flag only the legacy enable-asymmetry: legacy key truthy
+    AND new key falsy (i.e., a request that opted into the deprecated
+    behavior without the new equivalent). Same logic for the other two:
+    only flag when the value is genuinely truthy / agentTurn-shaped.
+    """
     flagged: list[str] = []
-    if "allow_channel_delivery" in request and not request.get("allow_structured_relay"):
+    if bool_flag(request.get("allow_channel_delivery")) and not bool_flag(request.get("allow_structured_relay")):
         flagged.append("allow_channel_delivery")
     if bool_flag(request.get("disposable_needs_channels")):
         flagged.append("disposable_needs_channels")

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -16,6 +16,36 @@ from pathlib import Path
 from typing import Any
 
 
+# PR1 (cron inbox-only reporting) — RESULT_SCHEMA carries the structured
+# reporting contract. The cron child must NOT send to external channels;
+# instead it declares its `delivery_intent` and the runner relays the result
+# to the parent agent's inbox. `channel_relay` remains as a deprecated alias
+# (audit-warn on use) for one minor; replaced by `delivery_intent` +
+# `forward_target` + `summary_short`.
+DELIVERY_INTENT_VALUES = ("silent", "main_session_only", "forward_to_user")
+FORWARD_CHANNEL_VALUES = ("telegram", "discord", "mattermost")
+FORWARD_FORMAT_VALUES = ("markdown", "text")
+SUMMARY_SHORT_MAX = 200
+
+# PR1.5 — direct-send marker substrings the LLM should never emit at action
+# position (forward_target / summary_short). v1 behaviour: emit a one-line
+# `cron_audit` event with up to 80 chars of the offending substring; do NOT
+# reject (Sean Q-C 2026-05-02). Hard reject deferred to v2 once we measure
+# whether LLMs actually try this.
+DIRECT_SEND_MARKERS = (
+    "tg_send",
+    "telegram_send",
+    "discord_send",
+    "webhook_url",
+    "https://api.telegram.org",
+    "https://discord.com/api/webhooks",
+    "agb urgent",
+    "agb task create",
+    "agb task done",
+    "agb handoff",
+)
+MARKER_EXCERPT_LIMIT = 80
+
 RESULT_SCHEMA = {
     "type": "object",
     "properties": {
@@ -27,6 +57,21 @@ RESULT_SCHEMA = {
         "recommended_next_steps": {"type": "array", "items": {"type": "string"}},
         "artifacts": {"type": "array", "items": {"type": "string"}},
         "confidence": {"type": "string"},
+        "delivery_intent": {
+            "type": "string",
+            "enum": list(DELIVERY_INTENT_VALUES),
+        },
+        "forward_target": {
+            "type": "object",
+            "properties": {
+                "channel": {"type": "string", "enum": list(FORWARD_CHANNEL_VALUES)},
+                "target_ref": {"type": "string"},
+                "format": {"type": "string", "enum": list(FORWARD_FORMAT_VALUES)},
+            },
+            "required": ["channel", "target_ref", "format"],
+            "additionalProperties": False,
+        },
+        "summary_short": {"type": "string", "maxLength": SUMMARY_SHORT_MAX},
         "channel_relay": {
             "type": "object",
             "properties": {
@@ -49,6 +94,7 @@ RESULT_SCHEMA = {
         "recommended_next_steps",
         "artifacts",
         "confidence",
+        "delivery_intent",
     ],
     "additionalProperties": False,
 }
@@ -135,6 +181,61 @@ def normalize_channel_relay(value: Any) -> dict[str, str] | None:
     return relay
 
 
+def normalize_forward_target(value: Any) -> dict[str, str] | None:
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise ValueError("forward_target must be an object when present")
+    allowed = {"channel", "target_ref", "format"}
+    extras = sorted(set(value.keys()) - allowed)
+    if extras:
+        raise ValueError(f"forward_target contains unsupported fields: {', '.join(extras)}")
+    channel = str(value.get("channel", "")).strip().lower()
+    if channel not in FORWARD_CHANNEL_VALUES:
+        raise ValueError(
+            f"forward_target.channel must be one of {', '.join(FORWARD_CHANNEL_VALUES)}; got {channel!r}"
+        )
+    target_ref = str(value.get("target_ref", "")).strip()
+    if not target_ref:
+        raise ValueError("forward_target.target_ref must be a non-empty string")
+    fmt = str(value.get("format", "")).strip().lower()
+    if fmt not in FORWARD_FORMAT_VALUES:
+        raise ValueError(
+            f"forward_target.format must be one of {', '.join(FORWARD_FORMAT_VALUES)}; got {fmt!r}"
+        )
+    return {"channel": channel, "target_ref": target_ref, "format": fmt}
+
+
+def detect_direct_send_markers(result: dict[str, Any]) -> list[dict[str, str]]:
+    """Return one entry per detected direct-send marker at action position.
+
+    PR1.5 (Sean Q-C 2026-05-02): v1 logs only — no rejection. We sample only
+    `forward_target.target_ref` and `summary_short` because legitimate cron
+    bodies frequently quote URLs/IDs in narrative text. Markers found in
+    `summary` or `findings` would create false-positives.
+    """
+    detections: list[dict[str, str]] = []
+    sources: list[tuple[str, str]] = []
+    forward_target = result.get("forward_target") or {}
+    if isinstance(forward_target, dict):
+        ref = str(forward_target.get("target_ref") or "")
+        if ref:
+            sources.append(("forward_target.target_ref", ref))
+    summary_short = str(result.get("summary_short") or "")
+    if summary_short:
+        sources.append(("summary_short", summary_short))
+    for field, text in sources:
+        lowered = text.lower()
+        for marker in DIRECT_SEND_MARKERS:
+            idx = lowered.find(marker)
+            if idx < 0:
+                continue
+            start = max(0, idx - 8)
+            excerpt = text[start : start + MARKER_EXCERPT_LIMIT]
+            detections.append({"field": field, "marker": marker, "excerpt": excerpt})
+    return detections
+
+
 def validate_result(payload: dict[str, Any]) -> dict[str, Any]:
     result = normalize_result(payload)
     missing = [key for key in RESULT_SCHEMA["required"] if key not in result]
@@ -142,6 +243,45 @@ def validate_result(payload: dict[str, Any]) -> dict[str, Any]:
         raise ValueError(f"result missing required fields: {', '.join(missing)}")
     if not isinstance(result["summary"], str) or not result["summary"].strip():
         raise ValueError("result summary must be a non-empty string")
+
+    intent = str(result.get("delivery_intent") or "").strip()
+    if intent not in DELIVERY_INTENT_VALUES:
+        raise ValueError(
+            f"delivery_intent must be one of {', '.join(DELIVERY_INTENT_VALUES)}; got {intent!r}"
+        )
+    result["delivery_intent"] = intent
+
+    forward_target = normalize_forward_target(result.get("forward_target"))
+    if intent == "forward_to_user":
+        if forward_target is None:
+            raise ValueError("forward_target is required when delivery_intent=forward_to_user")
+        result["forward_target"] = forward_target
+    else:
+        # Drop forward_target on silent / main_session_only — it's meaningless
+        # and would otherwise confuse the parent's routing.
+        result.pop("forward_target", None)
+
+    summary_short_raw = result.get("summary_short")
+    if intent == "silent":
+        # Empty / unset is fine. Anything non-empty is silently dropped so a
+        # cron child can fill it without breaking the silent contract.
+        result.pop("summary_short", None)
+    else:
+        if summary_short_raw is None:
+            raise ValueError(
+                f"summary_short is required when delivery_intent={intent}"
+            )
+        text = str(summary_short_raw).strip()
+        if not text:
+            raise ValueError(
+                f"summary_short must be a non-empty string when delivery_intent={intent}"
+            )
+        if len(text) > SUMMARY_SHORT_MAX:
+            raise ValueError(
+                f"summary_short exceeds {SUMMARY_SHORT_MAX} chars (was {len(text)})"
+            )
+        result["summary_short"] = text
+
     relay = normalize_channel_relay(result.get("channel_relay"))
     if relay is not None:
         result["channel_relay"] = relay
@@ -370,6 +510,29 @@ def check_memory_pressure() -> dict[str, Any] | None:
 
 def emit_pressure_audit(run_id: str, target_agent: str, probe: dict[str, Any]) -> None:
     """Best-effort audit row for a deferred dispatch. Failure is non-fatal."""
+    emit_audit_row(
+        action="cron_dispatch_deferred",
+        actor="daemon",
+        target_agent=target_agent or "daemon",
+        run_id=run_id,
+        details=probe,
+    )
+
+
+def emit_audit_row(
+    *,
+    action: str,
+    actor: str,
+    target_agent: str,
+    run_id: str,
+    details: dict[str, Any],
+) -> None:
+    """Best-effort one-line audit emission via bridge-audit.py.
+
+    Failure is non-fatal: if BRIDGE_AUDIT_LOG is unset or the helper script
+    is missing, we silently skip. The cron run itself must not be blocked
+    on audit plumbing.
+    """
     audit_log = os.environ.get("BRIDGE_AUDIT_LOG")
     if not audit_log:
         return
@@ -383,15 +546,15 @@ def emit_pressure_audit(run_id: str, target_agent: str, probe: dict[str, Any]) -
         "--file",
         audit_log,
         "--actor",
-        "daemon",
+        actor,
         "--action",
-        "cron_dispatch_deferred",
+        action,
         "--target",
         target_agent or "daemon",
         "--detail",
         f"run_id={run_id}",
     ]
-    for key, value in probe.items():
+    for key, value in details.items():
         cmd.extend(["--detail", f"{key}={value}"])
     try:
         subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
@@ -399,109 +562,460 @@ def emit_pressure_audit(run_id: str, target_agent: str, probe: dict[str, Any]) -
         pass
 
 
-def disable_mcp_for_request(request: dict[str, Any]) -> bool:
-    """#263 + #468: decide whether the disposable child should launch with MCP disabled.
+def emit_legacy_key_audit(request: dict[str, Any], run_id: str, *, target_agent: str) -> None:
+    """PR1.3 + PR1.4 + PR1.10 — one-line audit when a job still wires the
+    deprecated `allow_channel_delivery`, `disposable_needs_channels`, or
+    `payload_kind=agentTurn`. The runner honors none of these for behavior;
+    the audit gives operators a way to find and remove them."""
+    flagged: list[str] = []
+    if "allow_channel_delivery" in request and not request.get("allow_structured_relay"):
+        flagged.append("allow_channel_delivery")
+    if bool_flag(request.get("disposable_needs_channels")):
+        flagged.append("disposable_needs_channels")
+    if str(request.get("payload_kind") or "").strip().lower() == "agentturn":
+        flagged.append("payload_kind=agentTurn")
+    if not flagged:
+        return
+    emit_audit_row(
+        action="cron_legacy_key_used",
+        actor="cron-runner",
+        target_agent=target_agent,
+        run_id=run_id,
+        details={"keys": ",".join(flagged)},
+    )
 
-    Order of precedence:
-      1. ``request['disposable_needs_channels']`` — channel relays need MCP
-         servers loaded to deliver, so we never disable in that case. Safety
-         override; nothing below can flip it back.
-      2. ``BRIDGE_CRON_DISPOSABLE_DISABLE_MCP`` env override (ops A/B switch).
-         Set to ``1``/``true`` to force-disable MCP for every cron child;
-         ``0``/``false`` to force-enable. Unset to defer to per-job config.
-      3. ``request['disable_mcp']`` from the job's ``metadata.disableMcp``
-         (or aliases) wired through ``bridge_cron_write_request``. When
-         explicitly set (``True``/``False``) the per-job choice wins.
-      4. **Default: True.** Non-channel cron disposables disable MCP unless
-         opted in. Disabling MCP cuts cold-start cost (~22K tokens / run on
-         the SYRS reference install) and prevents a cwd
-         ``settings.local.json`` ``enabledPlugins`` entry (e.g. telegram)
-         from auto-attaching in the disposable child and stealing the
-         parent agent's MCP poller via plugin singleton-lock (issue #468).
-         If a specific cron payload genuinely needs MCP tools, set
-         ``metadata.disableMcp = False`` on that job.
+
+def apply_reporting_policy(result: dict[str, Any], policy: str) -> tuple[dict[str, Any], str | None]:
+    """PR1.2 — Per-job override on delivery_intent.
+
+    Returns (possibly-mutated result, override_note). override_note is None
+    when the policy did not change the intent, otherwise a short string
+    describing the demotion ("forced_silent", "demoted_forward_to_main", …)
+    suitable for cron_audit details.
     """
-    if disposable_needs_channels(request):
+    if policy == "default":
+        return result, None
+    intent = str(result.get("delivery_intent") or "").strip()
+    if policy == "always_silent" and intent != "silent":
+        result = dict(result)
+        result["delivery_intent"] = "silent"
+        result.pop("forward_target", None)
+        result.pop("summary_short", None)
+        return result, f"forced_silent_from_{intent}"
+    if policy == "always_main_session" and intent != "main_session_only":
+        result = dict(result)
+        result["delivery_intent"] = "main_session_only"
+        result.pop("forward_target", None)
+        # Preserve summary_short if the child set one — still useful as a
+        # main-session digest. The main_session_only path requires it; if
+        # missing, fall back to the long summary truncated.
+        if not str(result.get("summary_short") or "").strip():
+            short = str(result.get("summary") or "")[:SUMMARY_SHORT_MAX].strip()
+            if short:
+                result["summary_short"] = short
+        return result, f"forced_main_session_from_{intent}"
+    return result, None
+
+
+def cron_followup_title(job_name: str, intent: str, run_id: str) -> str:
+    """PR1.6 dedupe-friendly title.
+
+    `main_session_only` collapses to `[cron-followup] <job> [main_session_only]`
+    so refresh-by-job dedupe (PR1.7) works on a stable prefix.
+    `forward_to_user` carries the run_id so each distinct alert is unique
+    and the per-run lookup mode never collapses two alerts.
+    """
+    safe_job = job_name or "cron"
+    if intent == "forward_to_user":
+        return f"[cron-followup] {safe_job} (run={run_id})"
+    return f"[cron-followup] {safe_job} [{intent}]"
+
+
+def write_followup_body(
+    body_path: Path,
+    *,
+    schema_version: int,
+    run_id: str,
+    job_id: str,
+    job_name: str,
+    family: str,
+    target_agent: str,
+    delivery_intent: str,
+    forward_target: dict[str, str] | None,
+    summary_short: str,
+    summary: str,
+    findings: list[str],
+    actions_taken: list[str],
+    recommended_next_steps: list[str],
+    artifacts: list[str],
+    reporting_policy_value: str,
+    structured_relay_legacy: bool,
+) -> None:
+    """PR1.6 — strict JSON-frontmatter body (parsed without PyYAML).
+
+    Frontmatter shape is part of the contract; PR2 will add a parser helper
+    in `lib/bridge_cron_followup.py` that consumes it.
+    """
+    frontmatter = {
+        "schema_version": schema_version,
+        "kind": "cron-followup",
+        "delivery_intent": delivery_intent,
+        "run_id": run_id,
+        "job_id": job_id,
+        "job_name": job_name,
+        "family": family,
+        "target_agent": target_agent,
+        "reporting_policy": reporting_policy_value,
+    }
+    if forward_target:
+        frontmatter["forward_target"] = forward_target
+    if summary_short:
+        frontmatter["summary_short"] = summary_short
+    if structured_relay_legacy:
+        frontmatter["legacy_structured_relay"] = True
+
+    lines = [
+        "---",
+        json.dumps(frontmatter, ensure_ascii=False, indent=2),
+        "---",
+        "",
+        f"# [cron-followup] {job_name or run_id}",
+        "",
+        f"- run_id: {run_id}",
+        f"- job: {job_name}",
+        f"- family: {family}",
+        f"- delivery_intent: {delivery_intent}",
+    ]
+    if summary_short:
+        lines.append(f"- summary_short: {summary_short}")
+    if forward_target:
+        lines.extend(
+            [
+                f"- forward_target.channel: {forward_target.get('channel', '')}",
+                f"- forward_target.target_ref: {forward_target.get('target_ref', '')}",
+                f"- forward_target.format: {forward_target.get('format', '')}",
+            ]
+        )
+
+    if summary.strip():
+        lines.extend(["", "## Summary", "", summary.rstrip()])
+
+    for label, items in (
+        ("Findings", findings),
+        ("Actions Taken", actions_taken),
+        ("Recommended Next Steps", recommended_next_steps),
+        ("Artifacts", artifacts),
+    ):
+        if items:
+            lines.extend(["", f"## {label}", ""])
+            for item in items:
+                lines.append(f"- {item}")
+
+    if delivery_intent == "main_session_only":
+        lines.extend(
+            [
+                "",
+                "## Action Required (main session)",
+                "",
+                "Absorb the above into your context. Update your mental model of this monitor.",
+                "Close this task with `agb done <id> --note 'absorbed'` or equivalent.",
+                "Do NOT forward to a user-facing channel — this run did not opt into user delivery.",
+            ]
+        )
+    elif delivery_intent == "forward_to_user":
+        lines.extend(
+            [
+                "",
+                "## Action Required (forward to user)",
+                "",
+                "Forward the summary above through your own channel plugin (telegram/discord/mattermost).",
+                "Resolve `forward_target.target_ref` against your routing config.",
+                "Close this task with `agb done <id> --note 'forwarded ts=...'`.",
+            ]
+        )
+
+    body_path.parent.mkdir(parents=True, exist_ok=True)
+    body_path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def queue_cli_path() -> Path:
+    return Path(__file__).resolve().parent / "bridge-queue.py"
+
+
+def find_open_followup_task(
+    *, target_agent: str, title_prefix: str, mode: str
+) -> int | None:
+    """Invoke bridge-queue.py find-open. Returns task_id or None.
+
+    `mode` is `refresh-by-job` (existing prefix lookup) or `per-run`
+    (always returns None — the caller will create a fresh task). PR1.7
+    extends bridge-queue.py with a `--mode` selector that returns nothing
+    for `per-run`, so this wrapper stays consistent with that contract.
+    """
+    if mode == "per-run":
+        return None
+    cmd = [
+        sys.executable,
+        str(queue_cli_path()),
+        "find-open",
+        "--agent",
+        target_agent,
+        "--title-prefix",
+        title_prefix,
+        "--mode",
+        mode,
+        "--format",
+        "id",
+    ]
+    try:
+        completed = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=15, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    text = completed.stdout.strip()
+    if not text:
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def queue_create_task(
+    *,
+    target_agent: str,
+    actor: str,
+    title: str,
+    body_path: Path,
+    priority: str,
+) -> int | None:
+    cmd = [
+        sys.executable,
+        str(queue_cli_path()),
+        "create",
+        "--to",
+        target_agent,
+        "--from",
+        actor,
+        "--title",
+        title,
+        "--priority",
+        priority,
+        "--body-file",
+        str(body_path),
+        "--format",
+        "shell",
+    ]
+    try:
+        completed = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=20, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    for line in completed.stdout.splitlines():
+        if line.startswith("TASK_ID="):
+            try:
+                return int(line.split("=", 1)[1].strip().strip("'\""))
+            except ValueError:
+                return None
+    return None
+
+
+def queue_update_task(
+    *,
+    task_id: int,
+    actor: str,
+    title: str,
+    body_path: Path,
+    priority: str,
+    note: str,
+) -> bool:
+    cmd = [
+        sys.executable,
+        str(queue_cli_path()),
+        "update",
+        str(task_id),
+        "--actor",
+        actor,
+        "--title",
+        title,
+        "--priority",
+        priority,
+        "--body-file",
+        str(body_path),
+        "--note",
+        note,
+    ]
+    try:
+        completed = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=20, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
         return False
-    override = os.environ.get("BRIDGE_CRON_DISPOSABLE_DISABLE_MCP")
-    if override is not None and override.strip():
-        return bool_flag(override)
-    raw = request.get("disable_mcp")
-    if raw is None or (isinstance(raw, str) and not raw.strip()):
-        return True
-    return bool_flag(raw)
+    return completed.returncode == 0
+
+
+def upsert_inbox_task(
+    *,
+    target_agent: str,
+    actor: str,
+    title: str,
+    body_path: Path,
+    priority: str,
+    intent: str,
+    job_name: str,
+) -> tuple[int | None, str]:
+    """Create or refresh the inbox task per PR1.7 dedupe semantics.
+
+    Returns (task_id_or_none, action) where action is one of
+    `created | refreshed | failed`.
+    """
+    if intent == "main_session_only":
+        prefix = f"[cron-followup] {job_name or 'cron'} [main_session_only]"
+        existing = find_open_followup_task(
+            target_agent=target_agent,
+            title_prefix=prefix,
+            mode="refresh-by-job",
+        )
+        if existing is not None:
+            ok = queue_update_task(
+                task_id=existing,
+                actor=actor,
+                title=title,
+                body_path=body_path,
+                priority=priority,
+                note=f"refreshed by cron-runner (intent={intent})",
+            )
+            return (existing if ok else None, "refreshed" if ok else "failed")
+    task_id = queue_create_task(
+        target_agent=target_agent,
+        actor=actor,
+        title=title,
+        body_path=body_path,
+        priority=priority,
+    )
+    return (task_id, "created" if task_id is not None else "failed")
+
+
+def disable_mcp_for_request(request: dict[str, Any]) -> bool:
+    """PR1.3 — cron child runs in `--strict-mcp-config` mode unconditionally.
+
+    Pre-PR1 logic gated MCP loading on `disposable_needs_channels` /
+    `BRIDGE_CRON_DISPOSABLE_DISABLE_MCP` / `metadata.disableMcp`. Post-PR1
+    that gating is gone: the cron child can no longer reach external
+    channels, so there is nothing for MCP plugins to do here, and loading
+    them risks the singleton-lock collisions that #468 worked around.
+    The legacy keys are still honored as audit-only signals — see
+    `cmd_run` for the audit-warn emit when a job sets them.
+    """
+    del request  # signature retained for callers / future per-job opt-in
+    return True
+
+
+def read_structured_relay_flag(request: dict[str, Any]) -> bool:
+    """PR1.4 — `allow_structured_relay` is the new name. The old key
+    `allow_channel_delivery` is honored for one minor as an alias; callers
+    that still emit it get an audit-warn path in cmd_run.
+    """
+    if "allow_structured_relay" in request:
+        return bool_flag(request.get("allow_structured_relay"))
+    return bool_flag(request.get("allow_channel_delivery"))
+
+
+def reporting_policy(request: dict[str, Any]) -> str:
+    """PR1.2 — per-job override on the default-silent policy. Allowed:
+    `default | always_main_session | always_silent` (Sean Q-B). Anything
+    else falls back to `default` and is audit-warned upstream.
+    """
+    raw = str(request.get("cron_reporting_policy") or request.get("reporting_policy") or "default").strip().lower()
+    if raw not in {"default", "always_main_session", "always_silent"}:
+        return "default"
+    return raw
 
 
 def build_prompt(request: dict[str, Any], payload_text: str) -> str:
-    allow_channel_delivery = bool_flag(request.get("allow_channel_delivery"))
-    child_channels_enabled = disposable_needs_channels(request)
-    target_channels = csv_items(request.get("target_channels", ""))
-    channel_name = str(request.get("job_delivery_channel") or "").strip()
-    channel_target = str(request.get("job_delivery_target") or "").strip()
-    lines = [
+    parent_agent = request.get("target_agent", "")
+    parent_engine = request.get("target_engine", "")
+    policy = reporting_policy(request)
+    structured_relay = read_structured_relay_flag(request)
+
+    # PR1.2 — Policy preamble. The cron child cannot reach external channels
+    # (PR1.3 strips MCP plugins; the runner rejects results that lack a
+    # delivery_intent). The child decides intent here; the runner relays it
+    # to the parent's inbox.
+    lines: list[str] = [
         "You are a disposable cron execution worker for Agent Bridge.",
         "",
-        "Act on behalf of the parent agent below.",
-        "Do the heavy cron work in this disposable run, then return JSON only.",
+        "## Reporting policy (binding — overrides any legacy operator prompt below)",
         "",
-        "Hard rules:",
+        "- This run has NO access to Discord, Telegram, Mattermost, email, or any human channel.",
+        "- Do NOT call agb urgent / agb task create / agb task done / agb handoff for delivery.",
+        "- Do NOT call message/reply/send tools or post to webhook URLs.",
+        "- Decide a `delivery_intent` and return it in the JSON result. Allowed values:",
+        "    - `silent` — default. The work was done; the parent does not need to be told. No inbox task is created.",
+        "    - `main_session_only` — the parent agent must absorb this into context. No user-facing send. The parent updates its mental model and closes the inbox task.",
+        "    - `forward_to_user` — the run produced a human-facing alert. The parent will forward it through its own first-party channel plugin.",
+        f"- Pick `silent` when routine monitoring has no material change. Pick `main_session_only` only when the parent must know something. Pick `forward_to_user` only when a human must see it.",
+        f"- Parent agent (= main session): `{parent_agent}` ({parent_engine}).",
+        "",
+        "## Required JSON fields (in addition to the schema's existing keys)",
+        "",
+        "- `delivery_intent`: one of `silent | main_session_only | forward_to_user`. Required.",
+        "- `summary_short`: ≤ 200 chars, operator-facing summary. Required when `delivery_intent != silent`.",
+        "- `forward_target`: required when `delivery_intent = forward_to_user`. Object with:",
+        "    - `channel`: one of `telegram | discord | mattermost`.",
+        "    - `target_ref`: a logical target name (NOT a chat id, NOT a webhook URL). The parent resolves it against its own routing config.",
+        "    - `format`: `markdown` or `text`.",
+        "- For `silent`, leave `summary_short` empty/unset and do not set `forward_target`.",
     ]
-    if allow_channel_delivery:
+
+    if policy == "always_silent":
         lines.extend(
             [
-                "- Do not send user-facing messages directly from this disposable run.",
-                "- If the cron needs a human-facing message, return it as a structured channel_relay object in the JSON result.",
-                "- channel_relay must include a non-empty body field.",
-                "- channel_relay transport/target are optional hints; request metadata remains the routing authority.",
-                "- When channel_relay is present, treat needs_human_followup as true.",
+                "",
+                "## Per-job override",
+                "",
+                "- This job's reporting_policy is `always_silent`. Choose `delivery_intent = silent` regardless of what you find unless the run itself errored.",
             ]
         )
-        if child_channels_enabled:
-            lines.extend(
-                [
-                    "- Even if channel tools are available in this run, do not use them for human delivery.",
-                    f"- Preferred relay transport: {channel_name or 'configured target agent channels'}",
-                    f"- Preferred relay target: {channel_target or '(not specified)'}",
-                    "- Do not use message/reply/send tools, direct webhook helpers, or agent-bridge urgent/task create/task done/handoff for delivery.",
-                    "- The parent agent will review the relay payload and send it from the parent session.",
-                    "- Keep the summary concise and operator-facing.",
-                ]
-            )
-        else:
-            lines.extend(
-                [
-                    "- Target agent channels are informational routing metadata in this disposable run.",
-                    "- If delivery is needed, return channel_relay instead of describing a direct send in prose only.",
-                    "- Do not use agent-bridge urgent/task create/task done/handoff for delivery.",
-                    "- Keep the summary concise and operator-facing.",
-                ]
-            )
-    else:
+    elif policy == "always_main_session":
         lines.extend(
             [
-                "- Do not send user-facing messages directly.",
-                "- Do not post to Discord, Telegram, email, or any human channel.",
-                "- Do not call agent-bridge urgent/task create/task done/handoff for delivery.",
-                "- If the legacy cron would normally notify someone, record that in recommended_next_steps instead.",
-                "- Set needs_human_followup=true only when the parent agent must review, decide, or act after this run, or when the run fails.",
-                "- Routine monitoring with no material change should set needs_human_followup=false.",
-                "- If you already completed the work and no parent follow-up is required, leave recommended_next_steps empty and set needs_human_followup=false.",
-                "- Keep the summary concise and operator-facing.",
+                "",
+                "## Per-job override",
+                "",
+                "- This job's reporting_policy is `always_main_session`. Choose `delivery_intent = main_session_only` so the parent always receives a heartbeat-style update.",
             ]
         )
-    if target_channels:
-        lines.extend(["", f"Target channels: {', '.join(target_channels)}"])
+
+    if structured_relay:
+        lines.extend(
+            [
+                "",
+                "## Legacy structured relay (deprecated)",
+                "",
+                "- This job opted into the legacy `channel_relay` field. You MAY still populate it, but `delivery_intent` + `forward_target` is the authoritative contract going forward.",
+                "- If you set `channel_relay`, also set `delivery_intent = forward_to_user` and a matching `forward_target` so the parent can route consistently.",
+            ]
+        )
+
     lines.extend(
         [
             "",
-            f"Parent agent: {request['target_agent']} ({request['target_engine']})",
-            f"Job: {request['job_name']}",
-            f"Family: {request['family']}",
-            f"Slot: {request['slot']}",
-            f"Run ID: {request['run_id']}",
-            f"Payload file: {request['payload_file']}",
+            "## Run metadata",
             "",
-            "Legacy cron payload follows:",
+            f"- Job: {request.get('job_name', '')}",
+            f"- Family: {request.get('family', '')}",
+            f"- Slot: {request.get('slot', '')}",
+            f"- Run ID: {request.get('run_id', '')}",
+            f"- Payload file: {request.get('payload_file', '')}",
+            "",
+            "## Operator prompt (scoped task — runs under the policy above)",
             "",
             payload_text.rstrip(),
             "",
@@ -534,35 +1048,12 @@ def runner_env() -> dict[str, str]:
     return env
 
 
-def apply_channel_runtime_env(request: dict[str, Any], env: dict[str, str]) -> dict[str, str]:
-    channels = csv_items(request.get("target_channels", ""))
-    updated = dict(env)
-    if channel_enabled(channels, "plugin:discord"):
-        discord_dir = str(request.get("target_discord_state_dir") or "").strip()
-        if discord_dir:
-            updated["DISCORD_STATE_DIR"] = discord_dir
-    if channel_enabled(channels, "plugin:telegram"):
-        telegram_dir = str(request.get("target_telegram_state_dir") or "").strip()
-        if telegram_dir:
-            updated["TELEGRAM_STATE_DIR"] = telegram_dir
-    return updated
-
-
-def validate_channel_delivery_request(request: dict[str, Any]) -> None:
-    if not bool_flag(request.get("allow_channel_delivery")):
-        return
-
-    channels = csv_items(request.get("target_channels", ""))
-    if not channels:
-        raise RuntimeError("channel delivery is allowed for this run, but target agent has no configured channels")
-
-    preferred = str(request.get("job_delivery_channel") or "").strip().lower()
-    if preferred:
-        expected = f"plugin:{preferred}"
-        if not channel_enabled(channels, expected):
-            raise RuntimeError(
-                f"channel delivery requested for {preferred}, but target agent channels are {', '.join(channels)}"
-            )
+# PR1.3 — `apply_channel_runtime_env` and `validate_channel_delivery_request`
+# are removed: the cron child no longer ever loads channel plugins, so
+# wiring DISCORD_STATE_DIR / TELEGRAM_STATE_DIR into its env, or validating
+# that a target's channels match `job_delivery_channel`, is meaningless.
+# The legacy `allow_channel_delivery` / `disposable_needs_channels` keys
+# are honored only for audit-warn (see `cmd_run`).
 
 
 def resolve_binary(name: str, override_env: str) -> str:
@@ -615,11 +1106,14 @@ def run_codex(request: dict[str, Any], prompt: str, schema_path: Path, timeout: 
 def run_claude(request: dict[str, Any], prompt: str, timeout: int, request_file: Path | None = None) -> tuple[list[str], subprocess.CompletedProcess[str]]:
     workdir = request["target_workdir"]
     claude_bin = resolve_binary("claude", "BRIDGE_CLAUDE_BIN")
-    channels = csv_items(request.get("target_channels", ""))
+    # PR1.3 — cron child never loads channel plugins or MCP servers. The
+    # `--channels` injection and `apply_channel_runtime_env` paths are gone.
+    # `--strict-mcp-config` is unconditional (see disable_mcp_for_request).
     command = [
         claude_bin,
         "-p",
         "--no-session-persistence",
+        "--strict-mcp-config",
         "--output-format",
         "json",
         "--json-schema",
@@ -628,14 +1122,7 @@ def run_claude(request: dict[str, Any], prompt: str, timeout: int, request_file:
         "bypassPermissions",
         prompt,
     ]
-    if channels and disposable_needs_channels(request):
-        command[2:2] = ["--channels", ",".join(channels)]
-    # #263: when MCP is opt-disabled, pass --strict-mcp-config without any
-    # --mcp-config so the child loads zero MCP servers. Cuts cold-start cost
-    # for cron payloads that do not use MCP tools (the common case).
-    if disable_mcp_for_request(request):
-        command[2:2] = ["--strict-mcp-config"]
-    env = apply_channel_runtime_env(request, runner_env())
+    env = runner_env()
     if request_file is not None:
         env["CRON_REQUEST_DIR"] = str(request_file.parent)
     completed = subprocess.run(
@@ -733,6 +1220,9 @@ def write_status(
     completed_at: str | None = None,
     exit_code: int | None = None,
     error: str | None = None,
+    delivery_intent: str | None = None,
+    reporting_decision: str | None = None,
+    inbox_task_id: int | None = None,
 ) -> None:
     payload: dict[str, Any] = {
         "run_id": run_id,
@@ -750,6 +1240,14 @@ def write_status(
         payload["exit_code"] = exit_code
     if error:
         payload["error"] = error
+    # PR1.8 — silent-exit audit fields. Emitted even when the cron is
+    # silent so operators can see "we ran, decided silent, no inbox task".
+    if delivery_intent is not None:
+        payload["delivery_intent"] = delivery_intent
+    if reporting_decision is not None:
+        payload["reporting_decision"] = reporting_decision
+    if inbox_task_id is not None:
+        payload["inbox_task_id"] = inbox_task_id
     write_json(status_file, payload)
 
 
@@ -825,7 +1323,10 @@ def cmd_run(args: argparse.Namespace) -> int:
     prompt = build_prompt(request, payload_text)
     write_text(prompt_file, prompt)
     write_json(schema_file, RESULT_SCHEMA)
-    validate_channel_delivery_request(request)
+    # PR1 — emit audit-warn for legacy keys before the child runs so that
+    # operators see exactly which deprecated knobs are still wired in
+    # production cron jobs.
+    emit_legacy_key_audit(request, run_id, target_agent=str(request.get("target_agent") or ""))
 
     timeout = int(os.environ.get("BRIDGE_CRON_SUBAGENT_TIMEOUT_SECONDS", "900"))
     started_at = now_iso()
@@ -928,7 +1429,114 @@ def cmd_run(args: argparse.Namespace) -> int:
             "recommended_next_steps": ["Inspect stdout.log and stderr.log"],
             "artifacts": [],
             "confidence": "low",
+            # PR1 — invalid result drops to silent so we don't accidentally
+            # spam the parent's inbox with malformed alerts. The audit log
+            # records the failure separately via reporting_decision=invalid.
+            "delivery_intent": "silent",
         }
+
+    # PR1.2 — apply per-job reporting_policy override (always_silent /
+    # always_main_session) and capture any demotion for the audit log.
+    policy_value = reporting_policy(request)
+    child_result, policy_override_note = apply_reporting_policy(child_result, policy_value)
+
+    delivery_intent = str(child_result.get("delivery_intent") or "silent").strip()
+    if delivery_intent not in DELIVERY_INTENT_VALUES:
+        delivery_intent = "silent"
+
+    # PR1.5 — direct-send marker detection (audit-only per Sean Q-C).
+    markers = detect_direct_send_markers(child_result)
+
+    # PR1.4 — record whether the legacy `allow_channel_delivery` key was
+    # used (vs the new `allow_structured_relay`) so the audit can quantify
+    # remaining migration work.
+    structured_relay_legacy = (
+        "allow_channel_delivery" in request and "allow_structured_relay" not in request
+    )
+
+    forward_target = child_result.get("forward_target") if delivery_intent == "forward_to_user" else None
+    summary_short = str(child_result.get("summary_short") or "") if delivery_intent != "silent" else ""
+
+    # PR1.6 — write the inbox-task body to the cron run's followup file
+    # and create / refresh the queue task. Failure is non-fatal here; the
+    # cron run itself succeeded. We mark reporting_decision accordingly.
+    inbox_task_id: int | None = None
+    inbox_action = "skipped"
+    target_agent = str(request.get("target_agent") or "")
+    cron_urgency = str(request.get("cron_urgency") or "").strip().lower()
+    if cron_urgency not in {"normal", "high", "urgent"}:
+        cron_urgency = "normal"
+    followup_body_path = run_dir / "cron-followup.md"
+
+    if final_state in {"success", "error", "timed_out"} and delivery_intent != "silent" and not error_message:
+        write_followup_body(
+            followup_body_path,
+            schema_version=1,
+            run_id=run_id,
+            job_id=str(request.get("job_id") or ""),
+            job_name=str(request.get("job_name") or ""),
+            family=family,
+            target_agent=target_agent,
+            delivery_intent=delivery_intent,
+            forward_target=forward_target if isinstance(forward_target, dict) else None,
+            summary_short=summary_short,
+            summary=str(child_result.get("summary") or ""),
+            findings=list(child_result.get("findings") or []),
+            actions_taken=list(child_result.get("actions_taken") or []),
+            recommended_next_steps=list(child_result.get("recommended_next_steps") or []),
+            artifacts=list(child_result.get("artifacts") or []),
+            reporting_policy_value=policy_value,
+            structured_relay_legacy=structured_relay_legacy,
+        )
+        title = cron_followup_title(
+            str(request.get("job_name") or ""), delivery_intent, run_id
+        )
+        inbox_task_id, inbox_action = upsert_inbox_task(
+            target_agent=target_agent,
+            actor=f"cron:{request.get('source_agent', 'cron')}",
+            title=title,
+            body_path=followup_body_path,
+            priority=cron_urgency,
+            intent=delivery_intent,
+            job_name=str(request.get("job_name") or ""),
+        )
+
+    if error_message or final_state not in {"success", "error", "timed_out"}:
+        reporting_decision = "invalid"
+    elif delivery_intent == "silent":
+        reporting_decision = "silent"
+    elif inbox_action == "failed" or inbox_task_id is None:
+        reporting_decision = "invalid"
+    else:
+        reporting_decision = "reported"
+
+    # PR1.5 — emit one cron_audit line per run summarizing the reporting
+    # decision and any direct-send markers detected. Disk-volume rule
+    # (Sean 2026-05-02): keep it to a single line, ≤80-char marker excerpt.
+    audit_details: dict[str, Any] = {
+        "intent": delivery_intent,
+        "decision": reporting_decision,
+        "task": inbox_task_id if inbox_task_id is not None else "null",
+        "markers": len(markers),
+        "policy": policy_value,
+        "inbox_action": inbox_action,
+    }
+    if policy_override_note:
+        audit_details["policy_override"] = policy_override_note
+    if markers:
+        first = markers[0]
+        excerpt = first["excerpt"][:MARKER_EXCERPT_LIMIT]
+        audit_details["marker_field"] = first["field"]
+        audit_details["marker_excerpt"] = excerpt
+    if structured_relay_legacy:
+        audit_details["legacy_relay_key"] = "allow_channel_delivery"
+    emit_audit_row(
+        action="cron_audit",
+        actor="cron-runner",
+        target_agent=target_agent or "daemon",
+        run_id=run_id,
+        details=audit_details,
+    )
 
     result_payload = {
         "run_id": run_id,
@@ -953,7 +1561,20 @@ def cmd_run(args: argparse.Namespace) -> int:
         "command": command,
         "command_pretty": " ".join(shlex.quote(part) for part in command),
         "child_exit_code": completed.returncode,
+        # PR1.8 — silent-exit audit fields (always emitted, even on silent).
+        "delivery_intent": delivery_intent,
+        "reporting_decision": reporting_decision,
+        "inbox_task_id": inbox_task_id,
+        "reporting_policy": policy_value,
     }
+    if forward_target:
+        result_payload["forward_target"] = forward_target
+    if summary_short:
+        result_payload["summary_short"] = summary_short
+    if structured_relay_legacy:
+        result_payload["legacy_structured_relay_key_used"] = True
+    if markers:
+        result_payload["direct_send_markers_count"] = len(markers)
     if sidecar_error_note:
         result_payload["sidecar_error_note"] = sidecar_error_note
     if error_message:
@@ -971,6 +1592,9 @@ def cmd_run(args: argparse.Namespace) -> int:
         completed_at=completed_at,
         exit_code=completed.returncode,
         error=error_message,
+        delivery_intent=delivery_intent,
+        reporting_decision=reporting_decision,
+        inbox_task_id=inbox_task_id,
     )
 
     print(f"status: {final_state}")
@@ -979,6 +1603,18 @@ def cmd_run(args: argparse.Namespace) -> int:
     print(f"result_file: {rel_for_output(str(result_file))}")
     print(f"status_file: {rel_for_output(str(status_file))}")
     print(f"summary: {child_result['summary']}")
+    print(f"reporting_decision: {reporting_decision}")
+    print(f"delivery_intent: {delivery_intent}")
+    if inbox_task_id is not None:
+        print(f"inbox_task_id: {inbox_task_id}")
+    # PR1.5 — schema-required reject (e.g., bad delivery_intent payload)
+    # surfaces here as reporting_decision=invalid AND error_message set;
+    # exit non-zero so the daemon's existing health path picks it up.
+    if reporting_decision == "invalid" and not error_message:
+        # We landed in "invalid" because inbox writeback failed. The cron
+        # body itself ran fine, so we still return 1 to ensure the dispatch
+        # task gets retried/raised by the daemon.
+        return 1
     return 0 if final_state == "success" else 1
 
 

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -1510,7 +1510,22 @@ def cmd_run(args: argparse.Namespace) -> int:
             job_name=str(request.get("job_name") or ""),
         )
 
-    if error_message or final_state not in {"success", "error", "timed_out"}:
+    # Codex r2 P1 — `silent` must mean "the cron ran, decided nothing was
+    # worth telling the parent, and exited cleanly". Anything else (engine
+    # error, timed-out, structured `status: error`, runner exception,
+    # subagent non-zero exit) MUST surface as `invalid` so the daemon's
+    # existing failure followup path picks it up. Without this guard, a
+    # cron that returns `{"status":"error","delivery_intent":"silent"}`
+    # — or one whose intent is forced to silent by `always_silent` while
+    # the underlying status is error — would be silently dropped by the
+    # daemon's silent/reported gate.
+    child_status_error = str(child_result.get("status", "")).strip().lower() == "error"
+    run_failed = (
+        bool(error_message)
+        or final_state != "success"
+        or child_status_error
+    )
+    if run_failed:
         reporting_decision = "invalid"
     elif delivery_intent == "silent":
         reporting_decision = "silent"

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -1477,7 +1477,21 @@ def cmd_run(args: argparse.Namespace) -> int:
         cron_urgency = "normal"
     followup_body_path = run_dir / "cron-followup.md"
 
-    if final_state in {"success", "error", "timed_out"} and delivery_intent != "silent" and not error_message:
+    # Codex r2 P1 / r3 P1 — compute the failure predicate BEFORE the inbox
+    # upsert so a structurally-valid child result with `status:"error"`
+    # (or any other non-success final state) cannot create a runner-owned
+    # inbox task that the daemon then duplicates via its failure-followup
+    # path. `silent` is reserved exclusively for clean-success-no-signal;
+    # everything else surfaces as `invalid` and is left to the existing
+    # daemon-side failure-followup path.
+    child_status_error = str(child_result.get("status", "")).strip().lower() == "error"
+    run_failed = (
+        bool(error_message)
+        or final_state != "success"
+        or child_status_error
+    )
+
+    if not run_failed and delivery_intent != "silent":
         write_followup_body(
             followup_body_path,
             schema_version=1,
@@ -1510,21 +1524,6 @@ def cmd_run(args: argparse.Namespace) -> int:
             job_name=str(request.get("job_name") or ""),
         )
 
-    # Codex r2 P1 — `silent` must mean "the cron ran, decided nothing was
-    # worth telling the parent, and exited cleanly". Anything else (engine
-    # error, timed-out, structured `status: error`, runner exception,
-    # subagent non-zero exit) MUST surface as `invalid` so the daemon's
-    # existing failure followup path picks it up. Without this guard, a
-    # cron that returns `{"status":"error","delivery_intent":"silent"}`
-    # — or one whose intent is forced to silent by `always_silent` while
-    # the underlying status is error — would be silently dropped by the
-    # daemon's silent/reported gate.
-    child_status_error = str(child_result.get("status", "")).strip().lower() == "error"
-    run_failed = (
-        bool(error_message)
-        or final_state != "success"
-        or child_status_error
-    )
     if run_failed:
         reporting_decision = "invalid"
     elif delivery_intent == "silent":

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -304,6 +304,25 @@ def build_job_record(job):
             or metadata.get("disposableDisableMcp")
             or metadata.get("disposable_disable_mcp")
         ),
+        # PR1.2 — per-job override on the default-silent cron reporting
+        # policy. Allowed values per Sean Q-B 2026-05-02:
+        #   default | always_main_session | always_silent
+        # Anything else falls back to `default` at the runner side.
+        "cron_reporting_policy": str(
+            metadata.get("cronReportingPolicy")
+            or metadata.get("cron_reporting_policy")
+            or metadata.get("reportingPolicy")
+            or metadata.get("reporting_policy")
+            or ""
+        ).strip(),
+        # PR1.6 — priority hint for the cron-runner-created inbox task.
+        # Allowed: normal | high | urgent. Default `normal` at runner side.
+        "cron_urgency": str(
+            metadata.get("cronUrgency")
+            or metadata.get("cron_urgency")
+            or metadata.get("urgency")
+            or ""
+        ).strip(),
         "payload_text": payload_text,
         "payload_preview": preview_text(payload_text),
         "raw": job,
@@ -419,6 +438,11 @@ def serialize_record(record, include_payload=False):
         "allow_channel_delivery": record["allow_channel_delivery"],
         "disposable_needs_channels": record["disposable_needs_channels"],
         "disable_mcp": record["disable_mcp"],
+        # PR1.2 / PR1.6 — surface per-job reporting policy + urgency hints
+        # so the dispatch path (`bridge-cron.sh`) can ferry them into the
+        # request JSON consumed by the runner.
+        "cron_reporting_policy": record.get("cron_reporting_policy", ""),
+        "cron_urgency": record.get("cron_urgency", ""),
         "payload_preview": record["payload_preview"],
     }
     if include_payload:

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -500,6 +500,12 @@ run_enqueue() {
   allow_channel_delivery="${CRON_JOB_ALLOW_CHANNEL_DELIVERY:-0}"
   disposable_needs_channels="${CRON_JOB_DISPOSABLE_NEEDS_CHANNELS:-0}"
   disable_mcp="${CRON_JOB_DISABLE_MCP:-0}"
+  # PR1.2 / PR1.6 — per-job cron reporting policy override (Sean Q-B
+  # 2026-05-02: default | always_main_session | always_silent) and the
+  # urgency hint that maps to the inbox task priority. Empty string
+  # = use runner-side defaults (default policy, normal priority).
+  cron_reporting_policy="${CRON_JOB_CRON_REPORTING_POLICY:-}"
+  cron_urgency="${CRON_JOB_CRON_URGENCY:-}"
   request_rel="${request_file#$BRIDGE_HOME/}"
   result_rel="${result_file#$BRIDGE_HOME/}"
   status_rel="${status_file#$BRIDGE_HOME/}"
@@ -571,9 +577,9 @@ except Exception:
   # task_id=0 is a sentinel placeholder; real queue id is patched in below
   # via bridge_cron_update_*_task_id once the queue record exists.
   created_at="$(bridge_now_iso)"
-  bridge_cron_write_request "$request_file" "$run_id" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$jobs_file" "$CRON_JOB_PAYLOAD_KIND" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels" "$disable_mcp"
+  bridge_cron_write_request "$request_file" "$run_id" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$jobs_file" "$CRON_JOB_PAYLOAD_KIND" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels" "$disable_mcp" "$cron_reporting_policy" "$cron_urgency"
   bridge_cron_write_status "$status_file" "$run_id" "queued" "$target_engine" "$request_file" "$result_file" "$created_at"
-  bridge_cron_write_manifest "$manifest_file" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$jobs_file" "$run_id" "$request_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels"
+  bridge_cron_write_manifest "$manifest_file" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$jobs_file" "$run_id" "$request_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels" "$cron_reporting_policy" "$cron_urgency"
   # Per-run ACL grant is best-effort under v1.3 (#219): the memory-daily
   # harvester now runs as the controller UID, so it does not need the
   # isolated os_user to own/rwX the per-run dir. Other families that do

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3086,6 +3086,21 @@ cmd_run_cron_worker() {
     fi
   fi
 
+  # PR1.6 — when the cron-runner has already created an inbox task itself
+  # (delivery_intent in {main_session_only, forward_to_user}), skip the
+  # daemon-side followup creation so we don't double-task the parent. The
+  # `silent` decision is also honored — the cron decided not to bother the
+  # parent at all. Legacy cron jobs without a reporting_decision (PR1
+  # rollout, downgrade, manual shim) still flow through the original path.
+  if [[ -n "${CRON_REPORTING_DECISION:-}" ]]; then
+    if [[ "${CRON_INBOX_TASK_ID:-}" =~ ^[0-9]+$ ]]; then
+      daemon_info "cron-runner already wrote inbox task #${CRON_INBOX_TASK_ID} for ${CRON_JOB_NAME:-$run_id} (decision=${CRON_REPORTING_DECISION}); skipping daemon followup"
+    else
+      daemon_info "cron-runner reported decision=${CRON_REPORTING_DECISION} for ${CRON_JOB_NAME:-$run_id}; skipping daemon followup"
+    fi
+    CRON_NEEDS_HUMAN_FOLLOWUP=""
+  fi
+
   if [[ "$CRON_NEEDS_HUMAN_FOLLOWUP" == "1" ]]; then
     followup_body_file="$(bridge_cron_dispatch_followup_file_by_id "$run_id")"
     bridge_cron_write_followup_body "$run_id" "$followup_body_file"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3086,20 +3086,32 @@ cmd_run_cron_worker() {
     fi
   fi
 
-  # PR1.6 — when the cron-runner has already created an inbox task itself
-  # (delivery_intent in {main_session_only, forward_to_user}), skip the
-  # daemon-side followup creation so we don't double-task the parent. The
-  # `silent` decision is also honored — the cron decided not to bother the
-  # parent at all. Legacy cron jobs without a reporting_decision (PR1
-  # rollout, downgrade, manual shim) still flow through the original path.
-  if [[ -n "${CRON_REPORTING_DECISION:-}" ]]; then
-    if [[ "${CRON_INBOX_TASK_ID:-}" =~ ^[0-9]+$ ]]; then
-      daemon_info "cron-runner already wrote inbox task #${CRON_INBOX_TASK_ID} for ${CRON_JOB_NAME:-$run_id} (decision=${CRON_REPORTING_DECISION}); skipping daemon followup"
-    else
-      daemon_info "cron-runner reported decision=${CRON_REPORTING_DECISION} for ${CRON_JOB_NAME:-$run_id}; skipping daemon followup"
-    fi
-    CRON_NEEDS_HUMAN_FOLLOWUP=""
-  fi
+  # PR1.6 — gate the daemon-side followup task only when the cron-runner
+  # legitimately handled reporting itself: `silent` (intentional no-op) or
+  # `reported` (cron-runner created an inbox task and recorded its id).
+  # `invalid` and any unknown decision must continue to the failure path
+  # below so a broken result, schema/validation reject, or inbox writeback
+  # failure still wakes the existing daemon-side health surfaces (Codex
+  # r1 P1 — without this, a non-zero cron run with reporting_decision=
+  # invalid was silently dropped). Legacy cron jobs without a
+  # reporting_decision (PR1 rollout, downgrade, manual shim) also flow
+  # through the original path unchanged.
+  case "${CRON_REPORTING_DECISION:-}" in
+    silent|reported)
+      if [[ "${CRON_INBOX_TASK_ID:-}" =~ ^[0-9]+$ ]]; then
+        daemon_info "cron-runner already wrote inbox task #${CRON_INBOX_TASK_ID} for ${CRON_JOB_NAME:-$run_id} (decision=${CRON_REPORTING_DECISION}); skipping daemon followup"
+      else
+        daemon_info "cron-runner reported decision=${CRON_REPORTING_DECISION} for ${CRON_JOB_NAME:-$run_id}; skipping daemon followup"
+      fi
+      CRON_NEEDS_HUMAN_FOLLOWUP=""
+      ;;
+    invalid)
+      daemon_info "cron-runner reported decision=invalid for ${CRON_JOB_NAME:-$run_id}; daemon followup path remains active so the failure surfaces"
+      ;;
+    "" | *)
+      : # empty / unknown → legacy / forward-compatible path, no gate change
+      ;;
+  esac
 
   if [[ "$CRON_NEEDS_HUMAN_FOLLOWUP" == "1" ]]; then
     followup_body_file="$(bridge_cron_dispatch_followup_file_by_id "$run_id")"

--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -3294,6 +3294,15 @@ def _build_result_payload(
         "recommended_next_steps": recommended_next_steps,
         "artifacts": artifacts,
         "confidence": confidence,
+        # PR1.1 — `delivery_intent` is schema-required by the cron-runner
+        # (`bridge-cron-runner.py:RESULT_SCHEMA`). The memory-daily harvester
+        # writes its authoritative sidecar before the disposable child
+        # returns; without this field the runner's `validate_result` would
+        # reject the sidecar (Codex r1 P1) and the daemon's session-refresh
+        # gate could miss the queue-backfill action. memory-daily reporting
+        # is intentionally silent — the daemon already owns the parent
+        # session-refresh path.
+        "delivery_intent": "silent",
     }
 
 

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -737,6 +737,19 @@ def cmd_show(args: argparse.Namespace) -> int:
 
 
 def cmd_find_open(args: argparse.Namespace) -> int:
+    # PR1.7 — `--mode` selector for the cron-followup dedupe contract.
+    #   refresh-by-job (default): the existing prefix-match behavior. Used
+    #     by `delivery_intent=main_session_only` so consecutive runs
+    #     refresh a single open task ("current state of this monitor").
+    #   per-run: always returns nothing. Used by
+    #     `delivery_intent=forward_to_user` so each distinct human-facing
+    #     alert gets its own task and never overwrites an unread one.
+    mode = getattr(args, "mode", "refresh-by-job") or "refresh-by-job"
+    if mode == "per-run":
+        if getattr(args, "all", False):
+            print(json.dumps([], ensure_ascii=False))
+        return 1
+
     params: list[object] = [args.agent]
     sql = """
         SELECT *
@@ -2012,6 +2025,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--all",
         action="store_true",
         help="return all matching open tasks as a JSON array (forces JSON output with created_ts/updated_ts)",
+    )
+    find_open_parser.add_argument(
+        "--mode",
+        choices=("refresh-by-job", "per-run"),
+        default="refresh-by-job",
+        help=(
+            "PR1.7 cron-followup dedupe selector. refresh-by-job (default) "
+            "matches prior open task by title prefix; per-run always "
+            "returns nothing so each distinct alert lands as a new task."
+        ),
     )
     find_open_parser.set_defaults(handler=cmd_find_open)
 

--- a/docs/proposals/cron-inbox-only-reporting.md
+++ b/docs/proposals/cron-inbox-only-reporting.md
@@ -1,0 +1,205 @@
+# Plan — cron → main-session inbox-only reporting + telegram-relay 폐기
+
+**Status**: DRAFT, awaiting operator review
+**Author**: agb-dev-claude (with Codex design-ok #2819, 2026-05-02)
+**Operator brief**: Sean, 2026-05-02 11:20 KST
+**Related issues / PRs**: #468 (race cascade), #475 (relay daemon — to be reversed), #496 (this PR family's preceding hotfix)
+
+## Goal
+
+Eliminate three intertwined problems in cron behavior:
+
+1. **Context pollution** — recurring "no problem" reports flooding the main session.
+2. **Race condition** — cron child and main session both writing to the same external channel (Telegram, Discord) over a singleton resource.
+3. **Visibility gap** — main session can't reason about its own crons because their output never lands in its conversation.
+
+End state:
+
+- **Outbound external channels (Telegram/Discord/etc.) are the main session's sole responsibility.** Main session uses Claude Code's official channel plugins. No daemon, no relay, no cron child ever opens an outbound socket on those channels.
+- **Cron behaviour:**
+  - `silent`: log to existing `state/cron/runs/<run_id>/` artifacts, exit. Don't create an inbox task.
+  - `main_session_only`: queue an inbox task to the parent agent with structured frontmatter; main absorbs the info into context, no user-facing send.
+  - `forward_to_user`: queue an inbox task with `forward_target` (channel + logical target ref + format). Main resolves the target against its own routing config and sends through its official plugin.
+- **Cron children physically cannot reach external channels.** No channel plugins loaded, no MCP tools available, no `agb urgent/task/handoff` shortcuts for delivery. Enforced by removed flags + result validation, not just prompt guidance.
+- **`disposable_needs_channels` and the telegram-relay daemon are deleted.**
+
+## Why now
+
+`v0.6.37`–`v0.6.39` shipped a relay-daemon architecture (#475 phase 2/3) that mutated from "fix the race" to "replace the official Telegram plugin." That direction is wrong; it duplicates Claude Code's first-party transport for a problem that is solved more cleanly by making the cron a producer instead of a sender. This plan reverses that direction and puts cron output behind a structured inbox contract.
+
+## Architecture
+
+```
+                     ┌──────────────────────────────────────────────┐
+                     │          main session (jjujju, etc.)         │
+                     │                                              │
+   external channels │   ↑ Telegram (in/out via official plugin)   │
+   ◀────────────────►│   ↑ Discord  (in/out via official plugin)   │
+                     │   ↑ Mattermost (in/out via plugin)          │
+                     │                                              │
+                     │   ── reads inbox tasks (from cron) ──        │
+                     │   ── routes to channel based on frontmatter ─│
+                     └──────────────────────────────────────────────┘
+                                          ▲
+                                          │ agent-bridge inbox task
+                                          │ (one per non-silent run)
+                                          │ frontmatter: delivery_intent, forward_target, …
+                                          │
+                     ┌──────────────────────────────────────────────┐
+                     │   cron child (claude -p / codex exec)        │
+                     │   - no channel plugins                       │
+                     │   - no `agb urgent/task/handoff` for delivery│
+                     │   - if no signal → log + exit (silent)       │
+                     │   - if signal → write inbox task + exit      │
+                     └──────────────────────────────────────────────┘
+                                          ▲
+                                          │ cron schedule fires
+                                          │ bridge-cron-runner.py
+```
+
+## Implementation choice (decision)
+
+**Option C — runtime injection + per-job override.** Selected over Option A (creation-time prompt template) and pure Option B (runtime injection only) because:
+
+- **Centralized** — one preamble in `bridge-cron-runner.build_prompt()` covers every existing cron the moment the PR lands. No per-job migration needed.
+- **Hard to bypass** — the policy preamble is at the top of every cron prompt; subsequent operator prompt content is positioned as a scoped task within the policy's frame.
+- **Per-job opt-out** — `metadata.cron_reporting_policy` (allowed values to be enumerated in PR1) lets specific jobs override default silent-on-no-signal (e.g., heartbeat that needs to confirm liveness every tick).
+- **Defense in depth** — runtime injection alone is not enforcement; PR1 also (a) physically removes channel plugins from the cron child and (b) validates the result JSON contains a `delivery_intent` and no legacy direct-send markers.
+
+This matches Codex's correction in #2819 "Runtime prompt injection is necessary but not sufficient. … enforce with disabled channel tools and result validation."
+
+## PR series (Codex-recommended order)
+
+### PR1 — cron reporting contract
+
+Single-file dominant change in `bridge-cron-runner.py` plus minor surface in `lib/bridge-cron.sh`, `bridge-queue.py`, smoke tests.
+
+Scope:
+
+1. **Result schema additions** — extend `RESULT_SCHEMA` (Claude `--json-schema` and Codex `--output-schema`) with:
+   - `delivery_intent`: enum `silent | main_session_only | forward_to_user`. Required.
+   - `forward_target` (object, required when `delivery_intent = forward_to_user`): `{ channel, target_ref, format }`. Channel is enum `telegram | discord | mattermost | …`. `target_ref` is a logical name (not a chat ID or webhook URL). `format` is `markdown | text`.
+   - `summary_short`: required when `delivery_intent != silent`, ≤ 200 chars.
+   - Existing `channel_relay` is renamed to a deprecated alias of the structured fields and removed in PR2 cleanup.
+2. **Policy preamble in `build_prompt()`** — prepended to every cron prompt:
+   - Cron child must NOT call any external channel directly (no telegram/discord MCP tools, no shell-outs for delivery, no `agb urgent/task create/handoff` for delivery).
+   - Decide `delivery_intent`. Default `silent`. Pick `main_session_only` only when the parent must know. Pick `forward_to_user` only when the run produced a human-facing alert.
+   - For `silent`, set summary fields to empty; the runner will skip the inbox task.
+   - For non-silent, set `summary_short` and `body` (markdown).
+   - Parent identity is `<target_agent>`; main session = parent.
+3. **`disposable_needs_channels` deprecation** — flag is read-only honored (audit-log warn) but no longer adds `--channels` or loads MCP plugins. The cron child runs in `--strict-mcp-config` mode unconditionally.
+4. **`allow_channel_delivery` rename → `allow_structured_relay`** — old name kept as alias for one minor version, audit-log warn on use. Updated docs/help text.
+5. **Result validation in runner** — on `claude -p` / `codex exec` return:
+   - Reject results with no `delivery_intent` (schema-required).
+   - Reject results with `delivery_intent = forward_to_user` but no `forward_target` (schema-required).
+   - **Direct-send markers (`tg_send`, webhook URLs, raw chat IDs, etc.)**: per Sean 2026-05-02 — **defer hard reject to v2.** v1 only emits a one-line `cron_audit` event when a marker is detected so we can quantify whether LLMs actually try this in practice. If observed → add reject in follow-up PR. v1 keeps the door open without false-positive blocking (e.g., a body that legitimately quotes a webhook URL in summary text).
+   - On schema-required reject: write `result.json` with `reporting_decision = invalid`, log to stderr, exit non-zero (cron run is marked failed; daemon picks up via existing health path).
+   - **Log volume rule (Sean 2026-05-02)**: cron audit entries are one line per run. Format: `cron_audit job=<name> run=<id> intent=<intent> task=<id|null> markers=<n>`. **Do not dump full LLM output to logs.** If markers > 0, attach offending substring (≤ 80 chars) for diagnosis, no more.
+6. **Inbox task creation** — for `delivery_intent != silent`:
+   - Use existing `bridge_queue_cli create --to <parent_agent> --from cron --title "[cron-followup] <job_name> (<delivery_intent>)" --body-file <frontmatter+body>` path.
+   - Body file is markdown with strict JSON-frontmatter (parsed without PyYAML), schema_version=1.
+   - Priority maps from new `metadata.cron_urgency` field (`normal | high | urgent`); default `normal`.
+7. **Dedupe semantics fix** (Codex caught this) — replace existing prefix-only dedupe `[cron-followup] <job> (` with:
+   - `main_session_only`: refresh-by-job (prior open task with matching `job_id` is updated in place — context is "current state of this monitor").
+   - `forward_to_user`: dedupe by `run_id` only — every distinct human-facing alert gets its own task. NEVER overwrite an unread `forward_to_user` task.
+   - Implementation: extend `bridge_queue_cli find-open` selector with `--mode refresh-by-job` and `--mode per-run`.
+8. **Silent-exit audit** — extend `result.json` and `status.json` with:
+   - `reporting_decision`: `silent | reported | invalid`
+   - `delivery_intent`: copy of the field
+   - `inbox_task_id`: null if silent, otherwise the created queue task id
+9. **Smoke test (Codex caught this)** — current smoke only tests synthetic result file, not runner→result→followup end-to-end. Add integration test in `scripts/smoke-test.sh` that:
+   - Invokes a fake cron with each of the three `delivery_intent` values
+   - Verifies inbox state (silent → no task; main_only → refresh-by-job; forward → per-run)
+   - Verifies `result.json`/`status.json` audit fields
+   - Verifies dedupe semantics (two consecutive `main_only` runs → 1 open task; two consecutive `forward_to_user` runs → 2 open tasks)
+10. **Schema migration**: none required (no new task columns; frontmatter inside `body_text`).
+
+PR1 verification:
+- `bash -n` + `shellcheck` for `*.sh` files
+- `python3 -m py_compile` for `*.py` files
+- New smoke integration test passes
+- Existing smoke (queue/static-role/daemon) passes
+- Pair-review with Codex per CLAUDE.md
+
+### PR2 — main session handling helpers + parent-side docs
+
+Smaller, doc-and-helper-heavy.
+
+Scope:
+
+1. **Frontmatter parser helper** — Python helper at `lib/bridge_cron_followup.py` exposing `parse_followup(body_text) -> dict | None`. Strict JSON frontmatter, no eval, schema_version check. Used by parent-session helpers, future status views, and potential daemon-level routing diagnostics.
+2. **Main-session prompt instructions** — extend the admin/parent agent template's session-start instructions to:
+   - Recognize `[cron-followup]` titled tasks
+   - Parse frontmatter via the helper
+   - For `main_session_only`: read body, update internal model, close task with `decision: absorbed`.
+   - For `forward_to_user`: resolve `forward_target.channel` against the agent's routing config (parent agent owns this — telegram/discord plugin enabled in agent settings), deliver, close task with `decision: forwarded ts=<ts>`.
+3. **`agb cron status` update** — extend status output to show last-run `reporting_decision`, `delivery_intent`, and (if reported) `inbox_task_id` so operators can trace cron→inbox→main flow without grep.
+4. **OPERATOR_ACTIONS_PENDING.md entry** — informational: "v0.6.x cron behavior change; existing crons now silent-on-no-signal automatically. No action required, but `agb cron list` may show fewer follow-up tasks against admin agents — this is expected."
+5. **Docs** — update `ARCHITECTURE.md` (new "Cron reporting contract" section), `docs/developer-handover.md` (new "Adding a cron with reporting" walkthrough), `docs/agent-runtime/admin-protocol.md` (parent's responsibilities for cron followups).
+
+PR2 verification:
+- Doc lint (markdown links)
+- Helper unit test (frontmatter parse edge cases — missing field, schema_version mismatch, unknown intent, malformed JSON)
+- Pair-review with Codex
+
+### PR3 — telegram-relay reversal/removal
+
+Big, mostly deletion + setup-default rollback.
+
+Scope:
+
+1. **Setup defaults** — `bridge-setup.sh` / `bridge-setup.py telegram` no longer defaults to `--use-relay`. Default flips back to the official `plugin:telegram@claude-plugins-official` path. `--use-relay`/`--no-relay` flags removed (or kept as no-op with deprecation warning for one minor — TBD, Codex prefers full removal).
+2. **Daemon supervision** — remove `bridge_telegram_relay_supervise` from `bridge-daemon.sh`. Stop supervising the relay process.
+3. **CLI / plugin / state** — delete `agent-bridge telegram-relay`, `bridge-telegram-relay.sh`, `lib/telegram-relay.py`, `plugins/telegram-relay/`. Drop `BRIDGE_TELEGRAM_RELAY_*` env vars from documented surface (keep recognition for one minor with warning, then remove).
+4. **`bridge-status.py`** — drop relay status fields.
+5. **Smokes** — delete `scripts/smoke/telegram-relay*`.
+6. **Operator migration note** — `OPERATOR_ACTIONS_PENDING.md` entry:
+   - Existing relay registrations (e.g., on jjujju host): re-run `agent-bridge setup telegram <agent>` (now defaults to official plugin) to migrate.
+   - Stop the relay daemon manually if it was supervised by something other than `bridge-daemon.sh` (e.g., a systemd unit installed by an early v0.6.37 setup).
+   - Remove `BRIDGE_TELEGRAM_RELAY_*` env vars from `~/.agent-bridge/agent-roster.local.sh` if present.
+7. **CHANGELOG** — explicitly call out that #475's relay daemon (Phase 2/3) is reverted, with rationale referencing this design.
+
+PR3 verification:
+- Full smoke (`./scripts/smoke-test.sh`) passes (excluding the pre-existing `TMP_ROOT` failure)
+- `oss-preflight.sh` passes
+- jjujju host migration walkthrough (operator action) — out-of-band manual verification by Sean before merge
+- Pair-review with Codex
+
+### Recommended release shape
+
+- PR1 + PR2 → v0.6.40+ minor or patch series. Behavior change is operator-invisible (no flag flips) so a patch is acceptable.
+- PR3 → v0.7.0 minor (the relay reversal is a documented removal of a v0.6.x feature; semver-clean to bump minor).
+
+## Operator decisions (Sean 2026-05-02)
+
+- **Q-A** (forward routing config): reuse existing — `settings.local.json` `enabledPlugins` + `agent-roster.local.sh`. **Confirmed.**
+- **Q-B** (reporting policy override values): `default | always_main_session | always_silent` only. No `force_forward_to_user`. **Confirmed.**
+- **Q-C** (legacy direct-send marker enforcement): **deferred** — v1 only logs detections (one-line `cron_audit`) so we can measure whether LLMs actually try direct send. Hard reject ships only if it becomes a real problem. Log volume kept tight (one line, ≤ 80 char marker excerpt, no full LLM output dump).
+- **Q-D** (agentTurn deprecation): deprecate, treat as text. **Confirmed.**
+- **Q-E** (PR3 timing): PR1+PR2 first; PR3 (relay removal) batched separately for a later release once PR1+PR2 stabilize the race. **Confirmed.**
+- **Q-F** (jjujju host migration): manual operator action on the jjujju host post-PR3. Sean asked for a self-contained migration prompt that can be sent verbatim to the jjujju agent (not auto-scripted into `agent-bridge upgrade --apply`). See `docs/proposals/jjujju-migration-prompt.md` (delivered alongside this plan).
+
+## Open questions for Sean
+
+(All Q-A through Q-F resolved 2026-05-02 — see Operator decisions section above.)
+
+## Risks
+
+- **Existing crons relying on direct-send instructions in their prompt** — PR1 makes those instructions a no-op (no channel tools). The cron will run, the direct-send will silently not happen. Audit-log warns the operator on the next run. Mitigation: PR1 also rewrites the prompt preamble to explicitly tell the child not to attempt direct send, so the LLM doesn't waste tokens trying.
+- **Main session falls behind on inbox** — If the parent agent is stopped (jjujju case), `forward_to_user` tasks pile up unread. They are not dropped, and once the parent reattaches it sees them. Acceptable v1 behavior. Daemon-level fanout on extreme delay is out of scope.
+- **PR3 reversal anger** — Anyone who wrote tooling against `BRIDGE_TELEGRAM_RELAY_ENABLED` after v0.6.37 will see breakage. Since the relay was only ever shipped against the SYRS reference install, blast radius is small.
+- **Schema validation false-positive** — The legacy-marker reject list might trip on legitimate body content (e.g., a cron summarizing a Slack incident that contains a webhook URL in its description). Mitigation: require markers in *intent* fields (forward_target / summary_short / direct-send fragments at action position), not anywhere in body.
+
+## Verification gates per PR
+
+- All three PRs follow the existing CLAUDE.md pair-review contract (Codex r1 → up to r3 max → squash merge after `implement-ok`).
+- PR3 additionally requires operator-side manual verification on the jjujju host (Sean confirms migration works) before merge.
+- After all three land, post-deploy verification: a real cron tick on the SYRS reference install runs end-to-end → main session sees inbox task → parent forwards correctly via official plugin → cron child shows `--strict-mcp-config` in audit log.
+
+## What this plan does NOT change
+
+- Stall watchdog logic (covered by v0.6.40 #496).
+- Live-session tmux `send-keys` urgent-send paths.
+- The agent-bridge inbox/queue mechanics themselves.
+- Any other channel plugin (Discord, Mattermost) — those don't have the relay daemon issue.
+- Memory-pipeline / always-on-cost concerns (#389, #390).

--- a/docs/proposals/jjujju-migration-prompt.md
+++ b/docs/proposals/jjujju-migration-prompt.md
@@ -1,0 +1,82 @@
+# 쭈쭈(jjujju) 호스트 마이그레이션 프롬프트
+
+**용도**: PR3(telegram-relay 폐기) 머지 후 쭈쭈 호스트에서 텔레그램 셋업을 공식 Claude Code 플러그인으로 되돌리기 위한 1회성 마이그레이션. Sean이 쭈쭈 admin/세션에 그대로 보내면 됩니다.
+
+**전제 조건**: 쭈쭈 호스트에서 `agent-bridge upgrade --apply`를 먼저 실행해서 PR3가 포함된 버전(예상: v0.7.0+)으로 올라간 상태여야 합니다.
+
+---
+
+## 쭈쭈에게 보낼 프롬프트 (이 아래부터 그대로 복붙해서 보내면 됨)
+
+```
+[운영자 지시] 텔레그램 마이그레이션 — 자체 릴레이 폐기, Claude Code 공식 플러그인으로 복귀
+
+배경:
+agent-bridge가 v0.6.37 이후로 자체 telegram-relay 데몬을 띄워서 텔레그램 long-polling을 가로채는 구조였는데, 설계가 잘못됐다는 결론으로 폐기됐어. 너(쭈쭈) 호스트도 이 데몬을 사용 중이었고, 이번 업그레이드(PR3) 이후로는 Claude Code 공식 텔레그램 채널 플러그인을 직접 사용해야 해.
+
+작업 절차 (순서대로 실행하고 각 단계 결과를 보고해줘):
+
+1. 업그레이드 확인
+   $ agent-bridge --version
+   v0.7.0 이상이어야 함. 아니면 멈추고 운영자(Sean)에게 보고.
+
+2. 현재 텔레그램 등록 상태 확인
+   $ agent-bridge status | grep -i telegram
+   $ ls ~/.agent-bridge/state/channels/telegram/ 2>/dev/null
+   기존 relay 관련 socket/state 파일이 남아있는지 확인. 있으면 그대로 두고 다음 단계 진행 (4단계에서 정리됨).
+
+3. 텔레그램 셋업 재실행 (공식 플러그인 모드로)
+   $ agent-bridge setup telegram jjujju
+   - 기존 봇 토큰 그대로 사용할지 물어보면 yes
+   - --use-relay/--no-relay 같은 플래그는 PR3에서 제거됐으므로 안 쓰면 됨
+   - 셋업 끝나면 너의 ~/.agent-bridge/agents/jjujju/.claude/settings.local.json의 enabledPlugins에 plugin:telegram@claude-plugins-official이 들어있어야 함
+
+4. 환경변수/로스터 정리
+   $ grep BRIDGE_TELEGRAM_RELAY ~/.agent-bridge/agent-roster.local.sh
+   - 매치 있으면 해당 줄 삭제 (BRIDGE_TELEGRAM_RELAY_ENABLED, BRIDGE_TELEGRAM_RELAY_TOKEN 등 전부)
+   - agent-roster.local.sh는 직접 편집 가능. 편집 후 다음 명령으로 검증:
+     $ bash -n ~/.agent-bridge/agent-roster.local.sh
+
+5. 데몬 재시작 + 상태 확인
+   $ bash ~/.agent-bridge-source/bridge-daemon.sh restart
+     # 또는 시스템에 따라: bash bridge-daemon.sh restart
+   $ agent-bridge status
+   - 텔레그램 라인이 "official plugin" 또는 비슷한 표시여야 함
+   - "relay daemon" 같은 표현은 이제 안 보여야 정상
+
+6. 본인이 너 자신한테 텔레그램으로 테스트 메시지 보내고 수신되는지 확인
+   너의 일반 텔레그램 채널로 "마이그레이션 테스트" 보내고 정상 수신되는지 확인.
+   안 되면 멈추고 보고.
+
+7. 운영자에게 결과 보고
+   각 단계의 출력 요약 + 마이그레이션 성공/실패 한 줄로 요약해서 운영자(Sean)에게 인박스 task로 회신.
+   제목: [migration-done] jjujju telegram official plugin
+   본문: 단계별 결과, 발견한 이상치(있으면), 현재 상태 (정상 송수신 가능 / 추가 조치 필요).
+
+주의사항:
+- 이 작업 중에는 어떤 cron 잡도 텔레그램으로 알림 보내려고 하면 안 됨 (하지만 PR1+PR2가 이미 머지된 시점이라 cron들은 이제 인박스로만 보고하므로 충돌 가능성 없음)
+- 이전에 사용하던 systemd 유닛(있다면) 멈추기:
+  $ systemctl --user status bridge-telegram-relay 2>/dev/null
+  - 활성이면 stop + disable
+  - 없으면 무시
+- 마이그레이션 실패 시 롤백: 업그레이드 전 버전으로 돌리지 말고, 우선 운영자(Sean)에게 보고. 문제 진단 후 후속 결정.
+
+질문 있으면 작업 멈추고 운영자한테 escalate.
+```
+
+---
+
+## Sean이 직접 점검할 사항 (프롬프트 보내기 전)
+
+- 쭈쭈 호스트에서 `agent-bridge --version`이 PR3 포함된 버전인지 확인
+- 쭈쭈 봇 토큰이 환경변수든 어디든 살아있는지 확인 (안 그러면 step 3에서 막힘)
+- 쭈쭈 세션이 실제로 살아있는지 (`agent-bridge status` 또는 `tmux ls`로) — stopped 상태라면 먼저 복구
+
+## 구조
+
+- Sean: 위 프롬프트를 쭈쭈 admin 세션에 보냄 (인박스 task 또는 직접 send)
+- 쭈쭈: 단계별 실행, 각 단계 결과 자체 audit
+- 쭈쭈: 끝나면 `[migration-done] jjujju telegram official plugin` 제목으로 인박스 회신
+- Sean: 회신 확인하고 끝
+
+문제 있으면 쭈쭈가 escalate, Sean이 직접 개입. 자동화 없음.

--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -335,6 +335,12 @@ fields = {
         or request.get("failure_class")
         or "admin-resolvable"
     ).strip().lower() or "admin-resolvable",
+    # PR1.8 — surface the cron-runner reporting decision so the daemon can
+    # gate its own followup-task path. Empty string when the cron-runner
+    # didn't populate the field (legacy / pre-PR1 result.json).
+    "CRON_REPORTING_DECISION": str(result.get("reporting_decision") or status.get("reporting_decision") or "").strip(),
+    "CRON_DELIVERY_INTENT": str(result.get("delivery_intent") or status.get("delivery_intent") or "").strip(),
+    "CRON_INBOX_TASK_ID": str(result.get("inbox_task_id") if result.get("inbox_task_id") is not None else (status.get("inbox_task_id") if status.get("inbox_task_id") is not None else "")),
 }
 
 for key, value in fields.items():
@@ -636,7 +642,12 @@ payload = {
     "job_delivery_mode": job_delivery_mode,
     "job_delivery_channel": job_delivery_channel,
     "job_delivery_target": job_delivery_target,
+    # PR1.4 — `allow_channel_delivery` is the legacy key name. Wire the
+    # new `allow_structured_relay` alongside it so the cron-runner can
+    # read the new name preferentially while existing operator surfaces
+    # (manifest readers, audit consumers) keep seeing the old key.
     "allow_channel_delivery": allow_channel_delivery == "1",
+    "allow_structured_relay": allow_channel_delivery == "1",
     "disposable_needs_channels": disposable_needs_channels == "1",
     "slot": slot,
     "task_id": int(task_id),
@@ -714,7 +725,10 @@ payload = {
     "job_delivery_mode": job_delivery_mode,
     "job_delivery_channel": job_delivery_channel,
     "job_delivery_target": job_delivery_target,
+    # PR1.4 — wire both keys; cron-runner reads `allow_structured_relay`
+    # first and falls back to the legacy name.
     "allow_channel_delivery": allow_channel_delivery == "1",
+    "allow_structured_relay": allow_channel_delivery == "1",
     "disposable_needs_channels": disposable_needs_channels == "1",
     "disable_mcp": disable_mcp == "1",
     "slot": slot,

--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -621,16 +621,20 @@ bridge_cron_write_manifest() {
   local allow_channel_delivery="${22:-0}"
   local routing_mode="${23:-}"
   local disposable_needs_channels="${24:-0}"
+  # PR1.2 / PR1.6 — per-job reporting policy override + urgency hint.
+  # Empty string means "use runner default" (silent / normal).
+  local cron_reporting_policy="${25:-}"
+  local cron_urgency="${26:-}"
 
   mkdir -p "$(dirname "$manifest_file")"
 
   bridge_require_python
-  python3 - "$manifest_file" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$source_file" "$run_id" "$request_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" <<'PY'
+  python3 - "$manifest_file" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$source_file" "$run_id" "$request_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" "$cron_reporting_policy" "$cron_urgency" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-(manifest_file, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, source_file, run_id, request_file, payload_file, result_file, status_file, stdout_log, stderr_log, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels) = sys.argv[1:]
+(manifest_file, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, source_file, run_id, request_file, payload_file, result_file, status_file, stdout_log, stderr_log, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels, cron_reporting_policy, cron_urgency) = sys.argv[1:]
 
 payload = {
     "job_id": job_id,
@@ -649,6 +653,8 @@ payload = {
     "allow_channel_delivery": allow_channel_delivery == "1",
     "allow_structured_relay": allow_channel_delivery == "1",
     "disposable_needs_channels": disposable_needs_channels == "1",
+    "cron_reporting_policy": cron_reporting_policy,
+    "cron_urgency": cron_urgency,
     "slot": slot,
     "task_id": int(task_id),
     "created_at": created_at,
@@ -698,16 +704,21 @@ bridge_cron_write_request() {
   local routing_mode="${28:-}"
   local disposable_needs_channels="${29:-0}"
   local disable_mcp="${30:-0}"
+  # PR1.2 / PR1.6 — per-job reporting policy + urgency hint surfaced
+  # to the runner so policy overrides actually reach build_prompt and
+  # the inbox-task creation path.
+  local cron_reporting_policy="${31:-}"
+  local cron_urgency="${32:-}"
 
   mkdir -p "$(dirname "$request_file")"
 
   bridge_require_python
-  python3 - "$request_file" "$run_id" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$source_file" "$payload_kind" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" "$disable_mcp" <<'PY'
+  python3 - "$request_file" "$run_id" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$source_file" "$payload_kind" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" "$disable_mcp" "$cron_reporting_policy" "$cron_urgency" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-(request_file, run_id, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, payload_file, result_file, status_file, stdout_log, stderr_log, source_file, payload_kind, target_engine, target_workdir, target_channels, target_discord_state_dir, target_telegram_state_dir, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels, disable_mcp) = sys.argv[1:]
+(request_file, run_id, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, payload_file, result_file, status_file, stdout_log, stderr_log, source_file, payload_kind, target_engine, target_workdir, target_channels, target_discord_state_dir, target_telegram_state_dir, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels, disable_mcp, cron_reporting_policy, cron_urgency) = sys.argv[1:]
 
 payload = {
     "run_id": run_id,
@@ -731,6 +742,8 @@ payload = {
     "allow_structured_relay": allow_channel_delivery == "1",
     "disposable_needs_channels": disposable_needs_channels == "1",
     "disable_mcp": disable_mcp == "1",
+    "cron_reporting_policy": cron_reporting_policy,
+    "cron_urgency": cron_urgency,
     "slot": slot,
     "dispatch_task_id": int(task_id),
     "created_at": created_at,

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7352,6 +7352,10 @@ assert_contains "$CHANNEL_SHELL_OUTPUT" "CRON_JOB_ALLOW_CHANNEL_DELIVERY=1"
 assert_contains "$CHANNEL_SHELL_OUTPUT" "CRON_JOB_DISPOSABLE_NEEDS_CHANNELS=0"
 
 python3 - <<'PY'
+# PR1 (cron inbox-only reporting) — the cron child no longer ever sends
+# to external channels itself, so the prompt preamble talks about
+# `delivery_intent` rather than `channel_relay`, and `--channels` /
+# `apply_channel_runtime_env` paths are gone. Tests reflect that contract.
 import importlib.util
 import subprocess
 from pathlib import Path
@@ -7373,20 +7377,128 @@ request = {
     "target_workdir": str(Path(".").resolve()),
     "target_channels": "plugin:telegram",
     "target_telegram_state_dir": "/tmp/telegram-state",
-    "allow_channel_delivery": True,
+    "allow_structured_relay": True,
     "disposable_needs_channels": False,
     "job_delivery_channel": "telegram",
     "job_delivery_target": "telegram:123",
 }
 prompt = module.build_prompt(request, "send a telegram update")
-assert "Do not send user-facing messages directly from this disposable run." in prompt
-assert "return it as a structured channel_relay object" in prompt
-assert "Target channels: plugin:telegram" in prompt
-assert "Target agent channels are informational routing metadata in this disposable run." in prompt
-env = module.apply_channel_runtime_env(request, {"PATH": "/usr/bin"})
-assert env["TELEGRAM_STATE_DIR"] == "/tmp/telegram-state"
+# PR1.2 — the policy preamble must carry the inbox-only reporting contract.
+assert "Reporting policy" in prompt
+assert "delivery_intent" in prompt
+assert "main_session_only" in prompt
+assert "forward_to_user" in prompt
+# PR1.3 — the cron child has no path to external channels at all, so the
+# prompt does not negotiate about `--channels` or relay tools. The `tester`
+# parent identity must still be surfaced (`<{parent}>`).
+assert "tester" in prompt
+# PR1.4 — when the legacy `allow_structured_relay` flag is on we still
+# acknowledge `channel_relay` as a deprecated fallback.
+assert "Legacy structured relay" in prompt or "channel_relay" in prompt
 
-normalized = module.validate_result(
+# PR1.5 — validate_result rejects results that omit delivery_intent.
+try:
+    module.validate_result(
+        {
+            "status": "completed",
+            "summary": "missing intent",
+            "findings": [],
+            "actions_taken": [],
+            "needs_human_followup": False,
+            "recommended_next_steps": [],
+            "artifacts": [],
+            "confidence": "high",
+        }
+    )
+except ValueError as exc:
+    assert "delivery_intent" in str(exc)
+else:
+    raise AssertionError("expected missing delivery_intent to fail")
+
+# silent-intent results don't need summary_short or forward_target.
+silent = module.validate_result(
+    {
+        "status": "completed",
+        "summary": "routine ok",
+        "findings": [],
+        "actions_taken": [],
+        "needs_human_followup": False,
+        "recommended_next_steps": [],
+        "artifacts": [],
+        "confidence": "high",
+        "delivery_intent": "silent",
+    }
+)
+assert silent["delivery_intent"] == "silent"
+assert "summary_short" not in silent
+assert "forward_target" not in silent
+
+# main_session_only requires summary_short.
+try:
+    module.validate_result(
+        {
+            "status": "completed",
+            "summary": "long summary",
+            "findings": [],
+            "actions_taken": [],
+            "needs_human_followup": True,
+            "recommended_next_steps": [],
+            "artifacts": [],
+            "confidence": "high",
+            "delivery_intent": "main_session_only",
+        }
+    )
+except ValueError as exc:
+    assert "summary_short" in str(exc)
+else:
+    raise AssertionError("expected missing summary_short to fail")
+
+# forward_to_user requires both summary_short and forward_target.
+try:
+    module.validate_result(
+        {
+            "status": "completed",
+            "summary": "alert",
+            "findings": [],
+            "actions_taken": [],
+            "needs_human_followup": True,
+            "recommended_next_steps": [],
+            "artifacts": [],
+            "confidence": "high",
+            "delivery_intent": "forward_to_user",
+            "summary_short": "alert!",
+        }
+    )
+except ValueError as exc:
+    assert "forward_target" in str(exc)
+else:
+    raise AssertionError("expected missing forward_target to fail")
+
+# Happy path: forward_to_user with a complete forward_target.
+forward = module.validate_result(
+    {
+        "status": "completed",
+        "summary": "Disk usage 95% on host A",
+        "findings": ["disk_full"],
+        "actions_taken": [],
+        "needs_human_followup": True,
+        "recommended_next_steps": [],
+        "artifacts": [],
+        "confidence": "high",
+        "delivery_intent": "forward_to_user",
+        "summary_short": "Disk usage 95% on host A",
+        "forward_target": {
+            "channel": "telegram",
+            "target_ref": "ops",
+            "format": "markdown",
+        },
+    }
+)
+assert forward["forward_target"]["channel"] == "telegram"
+assert forward["forward_target"]["target_ref"] == "ops"
+
+# legacy channel_relay is still honored as a deprecated alias.
+legacy = module.validate_result(
     {
         "status": "completed",
         "summary": "relay prepared",
@@ -7396,6 +7508,8 @@ normalized = module.validate_result(
         "recommended_next_steps": [],
         "artifacts": [],
         "confidence": "high",
+        "delivery_intent": "main_session_only",
+        "summary_short": "relay prepared",
         "channel_relay": {
             "body": "hello from relay",
             "transport": "telegram",
@@ -7404,9 +7518,10 @@ normalized = module.validate_result(
         },
     }
 )
-assert normalized["needs_human_followup"] is True
-assert normalized["channel_relay"]["body"] == "hello from relay"
+assert legacy["needs_human_followup"] is True
+assert legacy["channel_relay"]["body"] == "hello from relay"
 
+# PR1.5 — empty relay body is still rejected (legacy semantics preserved).
 try:
     module.validate_result(
         {
@@ -7418,6 +7533,8 @@ try:
             "recommended_next_steps": [],
             "artifacts": [],
             "confidence": "high",
+            "delivery_intent": "main_session_only",
+            "summary_short": "bad relay",
             "channel_relay": {"body": "   "},
         }
     )
@@ -7425,6 +7542,34 @@ except ValueError as exc:
     assert "channel_relay.body" in str(exc)
 else:
     raise AssertionError("expected invalid empty relay body to fail")
+
+# PR1.5 — direct-send markers in forward_target.target_ref or summary_short
+# are detected (audit-only; never raise per Sean Q-C 2026-05-02).
+markers = module.detect_direct_send_markers(
+    {
+        "delivery_intent": "forward_to_user",
+        "summary_short": "alert",
+        "forward_target": {
+            "channel": "telegram",
+            "target_ref": "tg_send chat_id=123",
+            "format": "text",
+        },
+    }
+)
+assert markers, "expected direct-send marker detection on forward_target.target_ref"
+assert markers[0]["field"] == "forward_target.target_ref"
+assert markers[0]["marker"] == "tg_send"
+
+# Markers in `summary` (free-form narrative) are deliberately NOT flagged
+# to avoid false-positives when a body legitimately quotes a webhook URL.
+no_markers = module.detect_direct_send_markers(
+    {
+        "delivery_intent": "main_session_only",
+        "summary_short": "all good",
+        "summary": "I considered tg_send but did not invoke it.",
+    }
+)
+assert not no_markers, "narrative summary should not trip marker detection"
 
 
 def fake_run(command, **kwargs):
@@ -7439,15 +7584,18 @@ def fake_run(command, **kwargs):
 module.resolve_binary = lambda name, env_var: f"/fake/{name}"
 module.subprocess.run = fake_run
 
+# PR1.3 — `--channels` is never injected and `--strict-mcp-config` is
+# always present, regardless of legacy `disposable_needs_channels` /
+# `target_channels` content in the request.
 command, _ = module.run_claude(request, prompt, 30)
-assert "--channels" not in command
+assert "--channels" not in command, command
+assert "--strict-mcp-config" in command, command
 
 opt_in_request = dict(request)
 opt_in_request["disposable_needs_channels"] = True
-opt_in_prompt = module.build_prompt(opt_in_request, "send a telegram update")
-assert "Even if channel tools are available in this run, do not use them for human delivery." in opt_in_prompt
-command, _ = module.run_claude(opt_in_request, opt_in_prompt, 30)
-assert command[2:4] == ["--channels", "plugin:telegram"]
+command, _ = module.run_claude(opt_in_request, prompt, 30)
+assert "--channels" not in command, command
+assert "--strict-mcp-config" in command, command
 PY
 
 log "honouring metadata.disableMcp on disposable cron child (#263)"
@@ -7514,6 +7662,12 @@ DEFAULT_SHELL="$(python3 "$REPO_ROOT/bridge-cron.py" show --jobs-file "$CRON_NOM
 assert_contains "$DEFAULT_SHELL" "CRON_JOB_DISABLE_MCP=0"
 
 python3 - <<'PY'
+# PR1.3 — `disable_mcp_for_request` is unconditionally True now and
+# `run_claude` always passes `--strict-mcp-config`. The legacy env override
+# (`BRIDGE_CRON_DISPOSABLE_DISABLE_MCP`) and `disposable_needs_channels`
+# safety override are intentionally dead so an existing telegram cron
+# config can never re-attach the parent's MCP poller from the disposable
+# child (#468).
 import importlib.util
 import os
 import subprocess
@@ -7539,23 +7693,21 @@ base = {
     "disposable_needs_channels": False,
 }
 
-# Default: no flag.
-assert module.disable_mcp_for_request(dict(base)) is False
-# Per-request opt-in.
-on = dict(base, disable_mcp=True)
-assert module.disable_mcp_for_request(on) is True
-# Env override forces ON.
-os.environ["BRIDGE_CRON_DISPOSABLE_DISABLE_MCP"] = "1"
 assert module.disable_mcp_for_request(dict(base)) is True
-# Env override forces OFF.
+# Legacy env override has no effect any more.
 os.environ["BRIDGE_CRON_DISPOSABLE_DISABLE_MCP"] = "0"
-assert module.disable_mcp_for_request(on) is False
-del os.environ["BRIDGE_CRON_DISPOSABLE_DISABLE_MCP"]
-# Channel relays must always keep MCP enabled, regardless of the flag.
-relay = dict(base, disable_mcp=True, disposable_needs_channels=True, target_channels="plugin:telegram")
-assert module.disable_mcp_for_request(relay) is False
+try:
+    assert module.disable_mcp_for_request(dict(base)) is True
+finally:
+    del os.environ["BRIDGE_CRON_DISPOSABLE_DISABLE_MCP"]
+# disposable_needs_channels no longer flips the gate.
+relay = dict(base, disable_mcp=False, disposable_needs_channels=True, target_channels="plugin:telegram")
+assert module.disable_mcp_for_request(relay) is True
+# Per-request opt-out is now a no-op.
+opt_out = dict(base, disable_mcp=False)
+assert module.disable_mcp_for_request(opt_out) is True
 
-# Wire-through: --strict-mcp-config flag in the spawned claude command.
+# Wire-through: --strict-mcp-config flag is always present.
 captured = {}
 real_run = subprocess.run
 
@@ -7567,13 +7719,22 @@ subprocess.run = fake_run
 try:
     module.resolve_binary = lambda name, env_var: f"/fake/{name}"
     module.run_claude(dict(base), "prompt", 30)
-    assert "--strict-mcp-config" not in captured["cmd"]
-    module.run_claude(on, "prompt", 30)
     assert "--strict-mcp-config" in captured["cmd"]
+    assert "--channels" not in captured["cmd"]
+    # Even when the legacy disposable_needs_channels + target_channels are
+    # set, --channels stays out and --strict-mcp-config stays in.
+    relay_request = dict(
+        base,
+        disposable_needs_channels=True,
+        target_channels="plugin:telegram",
+    )
+    module.run_claude(relay_request, "prompt", 30)
+    assert "--strict-mcp-config" in captured["cmd"]
+    assert "--channels" not in captured["cmd"]
 finally:
     subprocess.run = real_run
 
-print("disable_mcp wire-through OK")
+print("PR1.3 strict-mcp + no-channels wire-through OK")
 PY
 
 log "pre-flight memory guard defers cron dispatch on pressured hosts (#263 Track B)"
@@ -7705,6 +7866,10 @@ healthy_completed_payload = json.dumps(
             "recommended_next_steps": [],
             "artifacts": [],
             "confidence": "high",
+            # PR1 — delivery_intent is now schema-required. The healthy
+            # smoke path returns silent so cmd_run takes the no-inbox-task
+            # branch and we don't need to mock bridge-queue.py here.
+            "delivery_intent": "silent",
         }
     },
     ensure_ascii=True,
@@ -7747,6 +7912,204 @@ del os.environ["BRIDGE_CRON_MIN_AVAIL_MB"]
 assert module._min_avail_mb() == module.DEFAULT_MIN_AVAIL_MB
 
 print("pre-flight memory guard OK")
+PY
+
+log "PR1.9 — cron-runner end-to-end delivery_intent matrix + dedupe semantics"
+PR1_RUN_ROOT="$TMP_ROOT/pr1-cron-runs"
+PR1_TARGET_AGENT="smoke-pr1-target"
+mkdir -p "$PR1_RUN_ROOT"
+PR1_RUN_ROOT="$PR1_RUN_ROOT" \
+PR1_TARGET_AGENT="$PR1_TARGET_AGENT" \
+PR1_REPO_ROOT="$REPO_ROOT" \
+python3 - <<'PY'
+# Drive cmd_run for each delivery_intent (silent / main_session_only /
+# forward_to_user) against an isolated BRIDGE_TASK_DB, mocking the Claude
+# binary spawn but letting real bridge-queue.py + audit subprocess calls
+# go through. Verifies plan §PR1.9:
+#   - silent → no inbox task, reporting_decision=silent
+#   - main_session_only → 1 inbox task; second run with same job refreshes (refresh-by-job)
+#   - forward_to_user → fresh task per run (per-run)
+import argparse
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+run_root = Path(os.environ["PR1_RUN_ROOT"])
+target_agent = os.environ["PR1_TARGET_AGENT"]
+repo_root = Path(os.environ["PR1_REPO_ROOT"])
+
+path = repo_root / "bridge-cron-runner.py"
+spec = importlib.util.spec_from_file_location("bridge_cron_runner", path)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+
+def make_request(run_id: str, job_name: str) -> Path:
+    run_dir = run_root / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    request_path = run_dir / "request.json"
+    request_path.write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "job_id": "pr1-test-job",
+                "job_name": job_name,
+                "family": job_name,
+                "slot": run_id,
+                "source_agent": "smoke",
+                "target_agent": target_agent,
+                "target_engine": "claude",
+                "target_workdir": str(run_dir),
+                "target_channels": "",
+                "allow_structured_relay": False,
+                "disposable_needs_channels": False,
+                "payload_file": str(run_dir / "payload.txt"),
+                "result_file": str(run_dir / "result.json"),
+                "status_file": str(run_dir / "status.json"),
+                "stdout_log": str(run_dir / "stdout.log"),
+                "stderr_log": str(run_dir / "stderr.log"),
+                "cron_urgency": "normal",
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (run_dir / "payload.txt").write_text("ping\n", encoding="utf-8")
+    return request_path
+
+
+def fake_claude_payload(intent: str) -> str:
+    output_dict = {
+        "status": "completed",
+        "summary": "smoke test result",
+        "findings": [],
+        "actions_taken": [],
+        "needs_human_followup": False,
+        "recommended_next_steps": [],
+        "artifacts": [],
+        "confidence": "high",
+        "delivery_intent": intent,
+    }
+    if intent != "silent":
+        output_dict["summary_short"] = f"alert ({intent})"
+    if intent == "forward_to_user":
+        output_dict["forward_target"] = {
+            "channel": "telegram",
+            "target_ref": "ops-channel",
+            "format": "markdown",
+        }
+    return json.dumps({"structured_output": output_dict})
+
+
+REAL_RUN = subprocess.run
+
+
+def make_fake_run(intent: str):
+    payload = fake_claude_payload(intent)
+
+    def fake(cmd, **kwargs):
+        if cmd and "claude" in os.path.basename(cmd[0]) and "bridge-queue" not in os.path.basename(cmd[0]):
+            return subprocess.CompletedProcess(cmd, 0, payload, "")
+        return REAL_RUN(cmd, **kwargs)
+
+    return fake
+
+
+def run_cron(run_id: str, job_name: str, intent: str) -> dict:
+    request = make_request(run_id, job_name)
+    module.resolve_binary = lambda name, env_var: "/fake/claude" if name == "claude" else f"/fake/{name}"
+    module.subprocess.run = make_fake_run(intent)
+    try:
+        rc = module.cmd_run(argparse.Namespace(request_file=str(request), dry_run=False))
+    finally:
+        module.subprocess.run = REAL_RUN
+    result_path = request.parent / "result.json"
+    return {
+        "rc": rc,
+        "result": json.loads(result_path.read_text(encoding="utf-8")),
+    }
+
+
+def open_tasks() -> list[dict]:
+    out = REAL_RUN(
+        [
+            sys.executable,
+            str(repo_root / "bridge-queue.py"),
+            "find-open",
+            "--agent",
+            target_agent,
+            "--all",
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if out.returncode not in (0, 1):
+        raise AssertionError(f"find-open --all failed rc={out.returncode}: {out.stderr}")
+    return json.loads(out.stdout or "[]")
+
+
+# 1) silent — no inbox task created, reporting_decision=silent
+silent_a = run_cron("silent-A", "pr1-silent-job", "silent")
+assert silent_a["rc"] == 0, silent_a
+assert silent_a["result"]["delivery_intent"] == "silent", silent_a["result"]
+assert silent_a["result"]["reporting_decision"] == "silent", silent_a["result"]
+assert silent_a["result"].get("inbox_task_id") in (None, ""), silent_a["result"]
+silent_tasks = [t for t in open_tasks() if t["title"].startswith("[cron-followup] pr1-silent-job")]
+assert not silent_tasks, f"silent run should not create a task: {silent_tasks}"
+
+# 2) main_session_only — refresh-by-job dedupe (one task across runs)
+main1 = run_cron("main-A", "pr1-main-job", "main_session_only")
+assert main1["rc"] == 0, main1
+assert main1["result"]["delivery_intent"] == "main_session_only", main1["result"]
+assert main1["result"]["reporting_decision"] == "reported", main1["result"]
+main_id_1 = main1["result"]["inbox_task_id"]
+assert isinstance(main_id_1, int) and main_id_1 > 0, main1["result"]
+
+main2 = run_cron("main-B", "pr1-main-job", "main_session_only")
+assert main2["rc"] == 0, main2
+main_id_2 = main2["result"]["inbox_task_id"]
+assert main_id_2 == main_id_1, (
+    f"main_session_only should refresh-by-job: first={main_id_1} second={main_id_2}"
+)
+
+main_open = [t for t in open_tasks() if t["title"].startswith("[cron-followup] pr1-main-job")]
+assert len(main_open) == 1, f"expected 1 open main task, got {main_open}"
+
+# 3) forward_to_user — per-run dedupe (each run lands as a fresh task)
+fwd1 = run_cron("fwd-A", "pr1-fwd-job", "forward_to_user")
+assert fwd1["rc"] == 0, fwd1
+assert fwd1["result"]["delivery_intent"] == "forward_to_user", fwd1["result"]
+fwd_id_1 = fwd1["result"]["inbox_task_id"]
+assert isinstance(fwd_id_1, int) and fwd_id_1 > 0, fwd1["result"]
+
+fwd2 = run_cron("fwd-B", "pr1-fwd-job", "forward_to_user")
+assert fwd2["rc"] == 0, fwd2
+fwd_id_2 = fwd2["result"]["inbox_task_id"]
+assert fwd_id_2 != fwd_id_1, (
+    f"forward_to_user should produce per-run tasks: first={fwd_id_1} second={fwd_id_2}"
+)
+
+fwd_open = [t for t in open_tasks() if t["title"].startswith("[cron-followup] pr1-fwd-job")]
+assert len(fwd_open) == 2, f"expected 2 open forward tasks, got {fwd_open}"
+
+# Audit fields: each result.json carries delivery_intent + reporting_decision.
+for run_id in ("silent-A", "main-A", "main-B", "fwd-A", "fwd-B"):
+    result = json.loads((run_root / run_id / "result.json").read_text(encoding="utf-8"))
+    assert "delivery_intent" in result, (run_id, result)
+    assert "reporting_decision" in result, (run_id, result)
+    status = json.loads((run_root / run_id / "status.json").read_text(encoding="utf-8"))
+    assert "delivery_intent" in status, (run_id, status)
+    assert "reporting_decision" in status, (run_id, status)
+
+print("PR1.9 cron-runner end-to-end OK")
 PY
 
 log "bridge_check_memory_pressure bash helper handles probe failure as healthy"

--- a/tests/memory-daily-harvest/smoke.sh
+++ b/tests/memory-daily-harvest/smoke.sh
@@ -315,7 +315,8 @@ cat >"$sidecar" <<'EOF'
   "needs_human_followup": false,
   "recommended_next_steps": [],
   "artifacts": ["state/memory-daily/test/2026-04-22.json"],
-  "confidence": "medium"
+  "confidence": "medium",
+  "delivery_intent": "silent"
 }
 EOF
 


### PR DESCRIPTION
## Summary

PR1 of the [cron → main-session inbox-only reporting](../blob/feat/cron-inbox-only-reporting/docs/proposals/cron-inbox-only-reporting.md) plan (Sean operator-approved 2026-05-02).

Cron disposable children stop sending to external channels (Telegram / Discord / Mattermost) directly. Instead, they declare a structured `delivery_intent` and the runner relays the result to the parent (main) session as an inbox task with strict JSON-frontmatter. The parent absorbs (`main_session_only`) or forwards (`forward_to_user`) via its own first-party channel plugin.

This eliminates:
- The relay-daemon race the v0.6.37–v0.6.39 series tried to paper over (#475 Phase 2/3 — being reversed in PR3).
- The "no problem" cron reports flooding admin context.
- Cron / parent collisions on the singleton Telegram channel.

## What changed

**`bridge-cron-runner.py`**
- `RESULT_SCHEMA` extended with `delivery_intent` (silent | main_session_only | forward_to_user), `forward_target { channel, target_ref, format }`, `summary_short` (≤200 chars).
- `build_prompt()` prepends a binding policy preamble (no channel calls; decide intent; default silent).
- `disable_mcp_for_request` is now unconditional True; `run_claude` always passes `--strict-mcp-config` and never `--channels` (PR1.3).
- `validate_result` enforces the new fields per intent; missing `delivery_intent` raises (schema-required).
- `detect_direct_send_markers` looks for legacy direct-send patterns at action position only and emits a one-line `cron_audit` row (≤80-char excerpt). Per Sean Q-C 2026-05-02, hard reject is deferred to v2.
- New helpers `cron_followup_title`, `write_followup_body` (frontmatter+body), `upsert_inbox_task` wire `cmd_run` to `bridge-queue.py` directly.
- `cmd_run` records `delivery_intent`, `reporting_decision` (silent | reported | invalid), `inbox_task_id` in both `result.json` and `status.json` (PR1.8).
- `apply_reporting_policy` enforces `metadata.cron_reporting_policy` overrides (`default | always_main_session | always_silent` per Sean Q-B).
- Legacy-key audit-warn for `allow_channel_delivery`, `disposable_needs_channels`, `payload_kind=agentTurn` (PR1.4 / PR1.3 / PR1.10).

**`bridge-queue.py`**
- `find-open` learns a `--mode {refresh-by-job | per-run}` selector. `per-run` always returns nothing so the caller creates a fresh task (PR1.7).

**`lib/bridge-cron.sh`**
- `bridge_cron_load_run_shell` now exports `CRON_REPORTING_DECISION`, `CRON_DELIVERY_INTENT`, `CRON_INBOX_TASK_ID` so the daemon can gate its own followup creation.
- Manifest + request payloads carry `allow_structured_relay` alongside `allow_channel_delivery` (PR1.4 alias).

**`bridge-daemon.sh`**
- When the cron-runner has already populated `reporting_decision` (PR1+), the daemon-side followup-task path is skipped to avoid double-tasking the parent. Pre-PR1 result.json files (legacy) still flow through the original path.

**`scripts/smoke-test.sh`**
- Existing cron-channel relay tests rewritten to the PR1 contract (delivery_intent matrix, no `--channels`, always `--strict-mcp-config`, marker detection, validation rejects, legacy alias still honored).
- New end-to-end integration test (PR1.9) drives `cmd_run` for each `delivery_intent` against an isolated `BRIDGE_TASK_DB` and verifies the inbox state, audit fields, and dedupe contract (2 main_only → 1 task; 2 forward → 2 tasks).

## Operator decisions baked in

| | Decision (Sean 2026-05-02) |
|---|---|
| Q-A forward routing config | reuse existing `settings.local.json` `enabledPlugins` + `agent-roster.local.sh` |
| Q-B reporting_policy values | `default | always_main_session | always_silent` only |
| Q-C marker enforcement | v1 logs detections (one-line audit, ≤80-char excerpt); hard reject deferred to v2 |
| Q-D agentTurn deprecation | audit-warn + treat as text |
| Q-E PR3 timing | batched separately for a later release |
| Q-F jjujju host migration | manual operator action via `docs/proposals/jjujju-migration-prompt.md` after PR3 |

## Test plan

- [x] `bash -n` on every touched `.sh` file
- [x] `python3 -m py_compile` on every touched `.py` file
- [x] `shellcheck` on `bridge-daemon.sh`, `lib/bridge-cron.sh`, `scripts/smoke-test.sh` (clean)
- [x] PR1.9 end-to-end matrix verified ad-hoc against an isolated `BRIDGE_HOME` (silent → no task; main 2× → 1 refreshed task; forward 2× → 2 distinct tasks)
- [x] Ad-hoc unit checks: schema enum, prompt preamble text, `disable_mcp_for_request` always-True, `--strict-mcp-config` always present, `validate_result` rejects missing intent, marker detection at action position only, `apply_reporting_policy` demotion
- [ ] `./scripts/smoke-test.sh` — halts at the pre-existing line-447 `TMP_ROOT`-unbound bug (CLAUDE.md notes this as unrelated). PR1.9 portion was validated ad-hoc.
- [ ] Live SYRS-install verification (post-merge): real cron tick → main-session inbox task → parent forwards via official plugin → cron child shows `--strict-mcp-config` in audit log

## Out of scope (separate PRs)

- **PR2** — main-session helpers + parent-side docs (`lib/bridge_cron_followup.py` frontmatter parser, `agb cron status` extension, ARCHITECTURE.md / dev-handover updates)
- **PR3** — telegram-relay reversal (setup defaults rollback, daemon supervision removal, CLI/plugin/state deletion). Batched separately per Sean Q-E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)