### PR TITLE
chore(post-v0.7.0): drop dead telegram-relay marketplace entry + per-host verification prompt

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,14 +18,6 @@
       "tags": ["teams", "messaging", "channel", "mcp"]
     },
     {
-      "name": "telegram-relay",
-      "source": "./plugins/telegram-relay",
-      "description": "Telegram channel for Claude Code through the Agent Bridge polling relay daemon. Opt-in replacement for per-session Telegram polling.",
-      "version": "0.1.0",
-      "category": "messaging",
-      "tags": ["telegram", "relay", "messaging", "channel", "mcp"]
-    },
-    {
       "name": "ms365",
       "source": "./plugins/ms365",
       "description": "Microsoft 365 / Graph API tools for Claude Code with Agent Bridge channel state and disclosure policy integration.",

--- a/docs/proposals/v0.7.0-install-cleanup-verification-prompt.md
+++ b/docs/proposals/v0.7.0-install-cleanup-verification-prompt.md
@@ -1,0 +1,105 @@
+# v0.7.0 install-host cleanup 검증 프롬프트 (모든 호스트용)
+
+**용도**: agent-bridge v0.7.0 으로 업그레이드한 모든 install host 가 telegram-relay 잔존 코드/state 를 깨끗이 정리했는지 1회성으로 검증. Sean 이 각 host 의 admin/세션에 그대로 보낼 수 있도록 작성됨.
+
+**전제 조건**: 해당 host 에서 `agent-bridge upgrade --apply` 가 v0.7.0 이상으로 완료된 상태. (아니라면 1단계가 자동으로 catch.)
+
+**관련 prompt**: 이 host 가 v0.6.37+ telegram-relay 를 실제로 등록해서 쓰던 install (예: SYRS jjujju) 이라면 [`docs/proposals/jjujju-migration-prompt.md`](jjujju-migration-prompt.md) 의 마이그레이션을 먼저 또는 함께 수행해야 함. 이 검증 프롬프트는 마이그레이션 이후에 잔존물이 없는지 sanity check 하는 단계.
+
+---
+
+## 보낼 프롬프트 (이 아래부터 그대로 복붙해서 보내면 됨)
+
+```
+[운영자 지시] v0.7.0 telegram-relay 잔존물 검증
+
+배경:
+agent-bridge v0.7.0 (PR #501 머지) 부터 자체 telegram-relay 데몬이 완전히 제거됐어. live runtime (~/.agent-bridge/) 의 옛 relay 파일들은 `agent-bridge upgrade --apply` 가 자동으로 삭제했어야 해. 이 작업은 그게 실제로 깨끗이 됐는지 검증하는 1회성 점검이야.
+
+이 host 가 relay 를 실제로 등록한 적 있는지에 따라 결과가 달라:
+- 등록 안 했으면: 모든 단계가 즉시 통과해야 정상.
+- 등록했었으면: 먼저 jjujju 마이그레이션 prompt (운영자에게 받은) 를 끝낸 다음 이 검증을 돌려.
+
+작업 절차 (순서대로 실행하고 각 단계 결과를 보고해줘):
+
+1. 버전 확인
+   $ agent-bridge version 2>&1 | head -3
+   "Agent Bridge 0.7.0" 이상이어야 함. 0.6.x 로 나오면 멈추고 운영자에게 보고 (먼저 upgrade 해야 함).
+
+2. 옛 relay 코드 파일들이 live runtime 에서 사라졌는지 확인
+   $ ls ~/.agent-bridge/bridge-telegram-relay.sh 2>&1
+   $ ls ~/.agent-bridge/lib/telegram-relay.py 2>&1
+   $ ls ~/.agent-bridge/plugins/telegram-relay/ 2>&1
+   $ ls ~/.agent-bridge/scripts/smoke/telegram-relay*.sh 2>&1
+   네 줄 모두 "No such file" 또는 "No matches" 같은 에러로 떨어져야 정상. 하나라도 살아있으면:
+   - upgrade 가 실패했거나, 충돌 처리로 보존됨 → ~/.agent-bridge/.upgrade-conflicts/ 확인
+   - 멈추고 운영자(Sean) 에게 보고. 직접 rm 하지 말 것 (upgrader 버그 가능성)
+
+3. relay state 디렉토리 청결 확인
+   $ ls -la ~/.agent-bridge/state/channels/telegram/ 2>&1
+   - 디렉토리가 없거나 (정상), 있어도 .  ..  외 파일 없어야 함
+   - tokens.list / *.sock / <token-hash>/ 같은 게 있으면 → relay 등록 호스트였다는 뜻. jjujju prompt 받았는지 확인.
+
+4. 에이전트별 relay 토큰 잔존 확인
+   $ find ~/.agent-bridge/agents -maxdepth 4 -name 'relay-token' 2>/dev/null
+   $ find ~/.agent-bridge/agents -maxdepth 4 -name '.telegram' -type d 2>/dev/null
+   - 첫 명령은 출력 없어야 정상.
+   - 두 번째 명령: 출력 있으면 그 에이전트 디렉토리에 .env / access.json 만 남아있는지 확인. relay-token 또는 다른 잔존 파일 있으면 jjujju prompt 단계 확인.
+
+5. 환경변수 잔존 확인
+   $ grep -E 'BRIDGE_TELEGRAM_(RELAY|USE_RELAY)' ~/.agent-bridge/agent-roster.local.sh 2>&1
+   - 출력 없어야 정상. 매치 있으면 해당 줄 삭제 (BRIDGE_TELEGRAM_RELAY_ENABLED, BRIDGE_TELEGRAM_USE_RELAY).
+   - 편집 후 검증: bash -n ~/.agent-bridge/agent-roster.local.sh
+
+6. systemd 잔존 확인 (Linux 호스트만, macOS 는 무시)
+   $ systemctl --user status bridge-telegram-relay 2>/dev/null || true
+   - "Unit bridge-telegram-relay.service could not be found" 정상.
+   - 활성으로 나오면 운영자가 수동으로 만든 것: stop + disable + 보고.
+
+7. 데몬 health 확인
+   $ agent-bridge daemon status
+   $ agent-bridge status 2>&1 | grep -i 'telegram-relay\|relay daemon' | head -5
+   - daemon 은 running 이어야 함.
+   - grep 결과는 비어야 정상 (telegram-relay 관련 라인이 더 이상 없어야 함).
+
+8. 운영자에게 결과 보고
+   각 단계 결과를 한 줄씩 요약 + 전체 통과/실패 한 줄로 운영자(Sean)에게 인박스 task 로 회신.
+   제목: [migration-done] <host-id> v0.7.0 relay cleanup verification
+   본문: 단계별 통과/실패, 발견한 이상치 (있으면 정확한 경로/출력 포함).
+
+판단:
+- 모든 단계 통과 → 잔존물 없음, host 깨끗.
+- 2단계 실패 → upgrader 가 옛 파일 삭제 못함, 운영자가 issue/PR 조사.
+- 3/4단계 실패 → relay 등록 흔적, jjujju prompt 적용 필요. 이미 적용했으면 그 prompt 를 다시 확인.
+- 5단계만 매치 → 단순 환경변수 잔존. 직접 삭제 가능.
+
+질문 있으면 멈추고 운영자에게 escalate.
+```
+
+---
+
+## Sean 이 직접 점검할 사항 (프롬프트 보내기 전)
+
+- 대상 host 가 어느 install 인지 (이름/별명) — 회신 task 제목에 들어가도록 host-id 지정해서 보낼 것
+- 대상 host 가 v0.6.37 ~ v0.6.x 중 telegram-relay 를 실제 등록한 적 있는지 사전 추측 (jjujju prompt 도 같이 보내야 하는지 결정에 영향)
+- 회신 받을 인박스 (운영자 본인 inbox) 가 비어있는지 / 처리 가능한지
+
+## 구조
+
+- Sean: 위 프롬프트를 각 host 의 admin 세션에 보냄 (인박스 task 또는 직접 send)
+- host: 단계별 실행, 각 단계 결과 자체 audit
+- host: 끝나면 `[migration-done] <host-id> v0.7.0 relay cleanup verification` 제목으로 인박스 회신
+- Sean: 회신 확인 → 깨끗하면 끝, 이상 있으면 follow-up
+
+문제 있으면 host 가 escalate, Sean 이 직접 개입. 자동화 없음.
+
+## 이 프롬프트 vs jjujju 프롬프트 차이
+
+| 항목 | `jjujju-migration-prompt.md` | 이 파일 |
+|---|---|---|
+| 대상 | v0.6.37+ relay 를 등록한 호스트 (예: jjujju) | 모든 v0.7.0 install host |
+| 작업 | setup 재실행 + state cleanup + 데몬 재시작 (실제 마이그레이션) | 잔존물 검증만 (read-only 위주, 5단계만 환경변수 직접 삭제) |
+| 위험도 | 중간 — 데몬 재시작 + state 파일 삭제 | 낮음 — 거의 read-only |
+| 빈도 | host 당 1회 | host 당 1회 (마이그레이션 후) |
+
+두 프롬프트 모두 운영자(Sean) 가 manual 로 보내고 회신 확인. 자동 적용 (`agent-bridge upgrade --apply` hook) 으로 묶지 않음 (Sean Q-F 2026-05-02 결정).


### PR DESCRIPTION
## Summary

Two follow-ups noticed after v0.7.0 ship:

### 1. Drop dead `telegram-relay` marketplace entry

`.claude-plugin/marketplace.json` still listed `telegram-relay` pointing at `./plugins/telegram-relay/` — but PR3 (#501) deleted the entire directory. The marketplace entry was a dead link; any consumer resolving the marketplace JSON would 404 on the `source` path.

The 8-line block is removed. Remaining plugins: `teams`, `ms365`, `mattermost`. `oss-preflight.sh` passes (its marketplace declaration check is happy with the smaller list).

### 2. Per-install verification prompt (sibling to jjujju prompt)

`OPERATOR_ACTIONS_PENDING.md` v0.7.0 entry already references `docs/proposals/jjujju-migration-prompt.md` for hosts that **registered** the relay (heavy migration: setup re-run + state cleanup + daemon restart). There was no symmetric prompt for the all-host *post-upgrade verification* case.

Add `docs/proposals/v0.7.0-install-cleanup-verification-prompt.md` — verbatim, copy-pasteable, generic. 8 read-mostly steps that catch:

- live-runtime relay file leftovers from a partial `upgrade --apply`
- orphaned `state/channels/telegram/` files
- per-agent `.telegram/relay-token` / dir
- residual env vars (`BRIDGE_TELEGRAM_RELAY_ENABLED` / `BRIDGE_TELEGRAM_USE_RELAY`) in `agent-roster.local.sh`
- residual systemd units (Linux-only, defensive)
- daemon health post-upgrade

The new file ends with a side-by-side table differentiating it from the jjujju prompt so Sean can tell at a glance which one to send to which host.

Both prompts stay operator-driven (Sean Q-F 2026-05-02 standing decision) — no auto-run hook in `agent-bridge upgrade --apply`.

## Test plan

- [x] `oss-preflight.sh` clean
- [x] `python3 -c "json.load(open('.claude-plugin/marketplace.json'))"` parses, plugins list = `['teams', 'ms365', 'mattermost']`
- [x] Inventory grep against `plugin:telegram-relay\|plugins/telegram-relay\|telegram-relay`: no active code references; only past-tense docs (CHANGELOG / OPERATOR_ACTIONS_PENDING / README / admin-protocol / migration-guide / plan doc / two prompts)
- [ ] Codex pair-review per CLAUDE.md (queued separately)

## Versioning

This is a tiny cleanup. v0.7.0 was just tagged a few hours ago at `393b5a1`. Options:

- bundle into the next routine release as part of v0.7.1 (or wherever)
- ignore — the dead marketplace entry doesn't fail any current install since nobody installs it via marketplace JSON yet (only via source clone)

Either way the fix lands now and the release call is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)