### PR TITLE
feat(hooks): compact-recovery — re-inject canonical agent files (#509 C3+C4)

### DIFF
--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -361,6 +361,159 @@ def _enqueue_handoff_pending(agent: str, next_session: Path, digest: str) -> Non
         return
 
 
+DEFAULT_COMPACT_RECOVERY_FILES: tuple[str, ...] = (
+    "SOUL.md",
+    "SESSION-TYPE.md",
+    "COMMON-INSTRUCTIONS.md",
+    "TOOLS.md",
+    "MEMORY.md",
+)
+_COMPACT_RECOVERY_DEFAULT_CAP = 5120
+_COMPACT_RECOVERY_MIN_CAP = 256
+
+
+def compact_recovery_enabled() -> bool:
+    raw = os.environ.get("BRIDGE_COMPACT_RECOVERY", "").strip().lower()
+    if not raw:
+        return True
+    return raw not in {"0", "false", "no", "off"}
+
+
+def compact_recovery_files() -> tuple[str, ...]:
+    raw = os.environ.get("BRIDGE_COMPACT_RECOVERY_FILES", "").strip()
+    if not raw:
+        return DEFAULT_COMPACT_RECOVERY_FILES
+    parts = [piece.strip() for piece in raw.split(",") if piece.strip()]
+    return tuple(parts) if parts else DEFAULT_COMPACT_RECOVERY_FILES
+
+
+def compact_recovery_per_file_cap() -> int:
+    raw = os.environ.get("BRIDGE_COMPACT_RECOVERY_MAX_BYTES", "").strip()
+    if not raw:
+        return _COMPACT_RECOVERY_DEFAULT_CAP
+    try:
+        value = int(raw)
+    except ValueError:
+        return _COMPACT_RECOVERY_DEFAULT_CAP
+    return max(value, _COMPACT_RECOVERY_MIN_CAP)
+
+
+def compact_snapshot_path(agent: str) -> Path:
+    return bridge_state_dir() / "agents" / agent / "compact-snapshot.json"
+
+
+def _read_canonical_file(home: Path, name: str, cap: int) -> str:
+    candidate = home / name
+    try:
+        # read_text follows symlinks, so SHARED-symlinked files resolve
+        # transparently (TOOLS.md → shared/TOOLS.md, etc.).
+        if not candidate.exists():
+            return ""
+        text = candidate.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+    text = text.strip("\n")
+    if len(text) > cap:
+        text = text[:cap].rstrip() + "\n[…truncated by compact-recovery cap…]"
+    return text
+
+
+def gather_canonical_files(agent: str) -> dict[str, str]:
+    """Return ordered mapping of canonical filename → text content.
+
+    Reads from the agent workdir first, then falls back to the agent
+    default home for installations where the two diverge. Missing or
+    unreadable files yield empty strings — the caller decides whether to
+    skip or substitute a snapshot.
+    """
+    files = compact_recovery_files()
+    cap = compact_recovery_per_file_cap()
+    workdir = agent_workdir(agent)
+    default_home = agent_default_home(agent)
+    out: dict[str, str] = {}
+    for name in files:
+        text = _read_canonical_file(workdir, name, cap)
+        if not text and workdir != default_home:
+            text = _read_canonical_file(default_home, name, cap)
+        out[name] = text
+    return out
+
+
+def write_compact_snapshot(agent: str, payload: dict[str, str]) -> Path | None:
+    """Atomically persist canonical-file contents next to the agent state.
+
+    The session-start hook reads this file as a fallback when the live
+    canonical files have been moved/cleared between pre-compact and the
+    post-compact session resume. Best-effort — IO failures are swallowed
+    because pre-compact must never block compaction.
+    """
+    path = compact_snapshot_path(agent)
+    envelope = {
+        "agent": agent,
+        "captured_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "files": payload,
+    }
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(envelope, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(tmp, 0o600)
+        tmp.replace(path)
+        os.chmod(path, 0o600)
+        return path
+    except OSError:
+        return None
+
+
+def load_compact_snapshot(agent: str) -> dict[str, str]:
+    path = compact_snapshot_path(agent)
+    if not path.exists():
+        return {}
+    try:
+        envelope = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(envelope, dict):
+        return {}
+    files = envelope.get("files")
+    if not isinstance(files, dict):
+        return {}
+    return {str(k): str(v) for k, v in files.items() if isinstance(v, str)}
+
+
+def compact_recovery_context(agent: str) -> str:
+    """Return the `## Restored Context` block for compaction recovery.
+
+    Reads canonical files live (resolves symlinks). When a file is missing
+    or empty, falls back to the most recent pre-compact snapshot. Returns
+    an empty string when the feature is disabled or no content survived.
+    """
+    if not compact_recovery_enabled():
+        return ""
+    live = gather_canonical_files(agent)
+    snapshot = load_compact_snapshot(agent) if any(not v for v in live.values()) else {}
+    sections: list[str] = []
+    for name, text in live.items():
+        if not text and snapshot.get(name):
+            text = snapshot[name].rstrip() + "\n[restored from pre-compact snapshot]"
+        if not text:
+            continue
+        sections.append(f"### {name}\n{text}")
+    if not sections:
+        return ""
+    body = "\n\n".join(sections)
+    return (
+        "## Restored Context (post-compact)\n"
+        "These canonical agent files were re-injected because the previous\n"
+        "conversation was compacted. Treat them as the load-bearing identity\n"
+        "anchors for this turn before reading queue/handoff state below.\n\n"
+        + body
+    )
+
+
 def bootstrap_artifact_context(agent: str) -> str:
     workdir = agent_workdir(agent)
     default_home = agent_default_home(agent)

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -413,9 +413,18 @@ def _read_canonical_file(home: Path, name: str, cap: int) -> str:
     except OSError:
         return ""
     text = text.strip("\n")
-    if len(text) > cap:
-        text = text[:cap].rstrip() + "\n[…truncated by compact-recovery cap…]"
-    return text
+    encoded = text.encode("utf-8")
+    if len(encoded) <= cap:
+        return text
+    # Cap is named/documented as a UTF-8 BYTE cap, so truncate on a byte
+    # window. `errors="ignore"` drops a partial trailing byte sequence so
+    # we never emit a half-character; the suffix marker tells the reader
+    # the section was clipped. This matters for non-ASCII (Korean,
+    # Japanese, etc.) where 1 character = 2–4 bytes — a character-count
+    # cap would let the payload silently grow several times past the
+    # documented budget. (Codex r1 / PR #510.)
+    truncated = encoded[:cap].decode("utf-8", errors="ignore").rstrip()
+    return truncated + "\n[…truncated by compact-recovery cap…]"
 
 
 def gather_canonical_files(agent: str) -> dict[str, str]:

--- a/hooks/pre-compact.py
+++ b/hooks/pre-compact.py
@@ -30,6 +30,24 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+# Allow `from bridge_hook_common import …` even when this hook is invoked
+# from `~/.agent-bridge/hooks/pre-compact.py` (the live-runtime layout
+# Claude Code wires through settings.json). bridge_hook_common.py sits
+# next to this file in both the source tree and the deployed runtime.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+try:
+    from bridge_hook_common import (
+        compact_recovery_enabled,
+        gather_canonical_files,
+        write_compact_snapshot,
+    )
+except ImportError:  # pragma: no cover — keep pre-compact resilient if
+    # bridge_hook_common is missing (e.g. hooks/ is partially deployed).
+    compact_recovery_enabled = None  # type: ignore[assignment]
+    gather_canonical_files = None  # type: ignore[assignment]
+    write_compact_snapshot = None  # type: ignore[assignment]
+
 
 def _bridge_home() -> Path:
     env_home = os.environ.get("BRIDGE_HOME")
@@ -67,6 +85,29 @@ def _stdin_payload() -> dict:
         return {}
 
 
+def _capture_canonical_snapshot(agent: str) -> str:
+    """Persist a pre-compact snapshot of the canonical agent files.
+
+    Returns the snapshot path as a string for inclusion in the bridge-memory
+    capture text (so an operator running `bridge-memory search` can locate
+    the sidecar later). Empty string when the feature is disabled or the
+    helpers from bridge_hook_common are unavailable.
+    """
+    if compact_recovery_enabled is None or gather_canonical_files is None or write_compact_snapshot is None:
+        return ""
+    try:
+        if not compact_recovery_enabled():
+            return ""
+        files = gather_canonical_files(agent)
+        if not any(files.values()):
+            return ""
+        path = write_compact_snapshot(agent, files)
+        return str(path) if path is not None else ""
+    except Exception:
+        # Snapshot failure must never block compaction.
+        return ""
+
+
 def main() -> int:
     try:
         agent = _agent_id()
@@ -76,11 +117,14 @@ def main() -> int:
         payload = _stdin_payload()
         trigger = str(payload.get("trigger") or payload.get("reason") or "").strip() or "unknown"
         custom = str(payload.get("custom_instructions") or "").strip()
+        snapshot_path = _capture_canonical_snapshot(agent)
         capture_text_parts = [
             f"trigger={trigger}",
             f"agent={agent}",
             f"ts={datetime.now().astimezone().isoformat(timespec='seconds')}",
         ]
+        if snapshot_path:
+            capture_text_parts.append(f"canonical_snapshot={snapshot_path}")
         if custom:
             # Keep the custom-instructions excerpt short; the full prompt
             # is in the session transcript which Claude Code handles on its

--- a/hooks/session_start.py
+++ b/hooks/session_start.py
@@ -26,6 +26,7 @@ from pathlib import Path
 
 from bridge_hook_common import (
     bridge_state_dir,
+    compact_recovery_context,
     remember_session_start,
     session_start_context,
 )
@@ -153,7 +154,17 @@ def main(argv: list[str] | None = None) -> int:
         _forget_session_on_clear(agent)
     context = session_start_context(agent)
     if matcher == "compact" and _compact_note_should_emit(agent):
-        context = context + _compact_note()
+        # #509 P3 (C3): re-inject canonical identity files BEFORE the queue
+        # context so the model reads SOUL/MEMORY/etc before acting on any
+        # post-compact queue prompt. The trailing `_compact_note()` is kept
+        # as a debug marker pointing at the raw capture store.
+        restored = compact_recovery_context(agent)
+        parts: list[str] = []
+        if restored:
+            parts.append(restored)
+        parts.append(context)
+        parts.append(_compact_note().strip())
+        context = "\n\n".join(parts)
 
     if args.format == "codex":
         json.dump(

--- a/tests/compact-recovery/smoke.sh
+++ b/tests/compact-recovery/smoke.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# compact-recovery smoke — end-to-end check for issue #509 P3 (C3+C4).
+#
+#   1  pre-compact writes <state>/agents/<agent>/compact-snapshot.json
+#      with SOUL/MEMORY content
+#   2  session_start matcher=compact emits a `## Restored Context` block
+#      with live SOUL/MEMORY content, BEFORE the queue context
+#   3  matcher=compact dedup: a second invocation within the dedup window
+#      does NOT re-emit the restored block
+#   4  fallback: when a canonical file is missing post-compact, the
+#      session_start hook substitutes the snapshot content with the
+#      `[restored from pre-compact snapshot]` marker
+#   5  feature flag: BRIDGE_COMPACT_RECOVERY=off suppresses the block
+#      entirely (note: dedup state is shared with #3, so we use a fresh
+#      home with no prior dedup)
+#   6  matcher=startup (non-compact): no restored block
+#
+# Each case runs in its own ephemeral BRIDGE_HOME.
+
+set -u
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PRE_COMPACT="$REPO_ROOT/hooks/pre-compact.py"
+SESSION_START="$REPO_ROOT/hooks/session_start.py"
+COMMON="$REPO_ROOT/hooks/bridge_hook_common.py"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+PASS=0
+FAIL=0
+FAIL_IDS=()
+
+pass() { PASS=$((PASS + 1)); printf '  [PASS] %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); FAIL_IDS+=("$1"); printf '  [FAIL] %s — %s\n' "$1" "$2"; }
+banner() { printf '\n=== case %s — %s ===\n' "$1" "$2"; }
+
+SMOKE_ROOT="$(mktemp -d -t compact-recovery.XXXXXX)"
+trap 'rm -rf "$SMOKE_ROOT" 2>/dev/null || true' EXIT
+
+# Build a minimal mock BRIDGE_HOME with hooks/ and a tester agent home.
+make_bridge_home() {
+  local root="$1" agent="$2"
+  mkdir -p "$root/hooks" "$root/agents/$agent"
+  cp "$COMMON" "$root/hooks/bridge_hook_common.py"
+  cp "$PRE_COMPACT" "$root/hooks/pre-compact.py"
+  cp "$SESSION_START" "$root/hooks/session_start.py"
+  chmod +x "$root/hooks/pre-compact.py" "$root/hooks/session_start.py"
+  # Provide a stub bridge-memory.py that exits 0 silently — pre-compact
+  # invokes it for capture; we don't care about the memory pipeline here.
+  cat > "$root/bridge-memory.py" <<'PYSTUB'
+#!/usr/bin/env python3
+import sys
+sys.exit(0)
+PYSTUB
+  chmod +x "$root/bridge-memory.py"
+  # Default canonical files for the agent.
+  cat > "$root/agents/$agent/SOUL.md" <<EOF
+# SOUL — $agent
+identity = compact-recovery-tester
+EOF
+  cat > "$root/agents/$agent/MEMORY.md" <<EOF
+# MEMORY — $agent
+recent_anchor = anchor-row-1
+EOF
+}
+
+run_pre_compact() {
+  local bhome="$1" agent="$2" payload="$3"
+  env -u BRIDGE_AGENT_WORKDIR -u BRIDGE_AGENT_HOME -u BRIDGE_AGENT_HOME_ROOT \
+      -u BRIDGE_STATE_DIR -u BRIDGE_ACTIVE_AGENT_DIR \
+      BRIDGE_HOME="$bhome" BRIDGE_AGENT_ID="$agent" \
+      "$PYTHON" "$bhome/hooks/pre-compact.py" <<<"$payload"
+}
+
+run_session_start() {
+  # $1 = bhome, $2 = agent, $3 = matcher, [$4 = extra env, e.g. "BRIDGE_COMPACT_RECOVERY=off"]
+  local bhome="$1" agent="$2" matcher="$3" extra="${4:-}"
+  if [[ -n "$extra" ]]; then
+    # `extra` is intentionally word-split into KEY=value pairs that env
+    # consumes — quoting it would break that.
+    # shellcheck disable=SC2086
+    env -u BRIDGE_AGENT_WORKDIR -u BRIDGE_AGENT_HOME -u BRIDGE_AGENT_HOME_ROOT \
+        -u BRIDGE_STATE_DIR -u BRIDGE_ACTIVE_AGENT_DIR \
+        BRIDGE_HOME="$bhome" BRIDGE_AGENT_ID="$agent" $extra \
+        "$PYTHON" "$bhome/hooks/session_start.py" --matcher "$matcher"
+  else
+    env -u BRIDGE_AGENT_WORKDIR -u BRIDGE_AGENT_HOME -u BRIDGE_AGENT_HOME_ROOT \
+        -u BRIDGE_STATE_DIR -u BRIDGE_ACTIVE_AGENT_DIR \
+        BRIDGE_HOME="$bhome" BRIDGE_AGENT_ID="$agent" \
+        "$PYTHON" "$bhome/hooks/session_start.py" --matcher "$matcher"
+  fi
+}
+
+# ---------- case 1: pre-compact writes snapshot ----------
+banner 1 "pre-compact writes compact-snapshot.json"
+C1_HOME="$SMOKE_ROOT/c1"
+make_bridge_home "$C1_HOME" "tester"
+if run_pre_compact "$C1_HOME" "tester" '{"trigger":"manual"}' >/dev/null 2>&1; then
+  SNAPSHOT="$C1_HOME/state/agents/tester/compact-snapshot.json"
+  if [[ ! -f "$SNAPSHOT" ]]; then
+    fail 1 "expected snapshot at $SNAPSHOT (state dir contents: $(find "$C1_HOME/state" -type f 2>/dev/null || echo '<none>'))"
+  elif ! "$PYTHON" -c "
+import json, sys
+data = json.load(open('$SNAPSHOT', encoding='utf-8'))
+files = data.get('files') or {}
+if 'identity = compact-recovery-tester' not in files.get('SOUL.md', ''):
+    sys.exit(f'SOUL.md content missing: {files.get(\"SOUL.md\", \"<empty>\")[:80]}')
+if 'recent_anchor' not in files.get('MEMORY.md', ''):
+    sys.exit(f'MEMORY.md content missing: {files.get(\"MEMORY.md\", \"<empty>\")[:80]}')
+"; then
+    fail 1 "snapshot validation failed"
+  else
+    pass 1
+  fi
+else
+  rc=$?
+  fail 1 "pre-compact rc=$rc"
+fi
+
+# ---------- case 2: session_start matcher=compact emits restored block ----------
+banner 2 "session_start matcher=compact emits Restored Context block"
+C2_HOME="$SMOKE_ROOT/c2"
+make_bridge_home "$C2_HOME" "tester"
+C2_OUT="$SMOKE_ROOT/c2.out"
+if run_session_start "$C2_HOME" "tester" "compact" >"$C2_OUT" 2>&1; then
+  if ! grep -q "## Restored Context (post-compact)" "$C2_OUT"; then
+    fail 2 "missing '## Restored Context' header. output:\n$(cat "$C2_OUT")"
+  elif ! grep -q "identity = compact-recovery-tester" "$C2_OUT"; then
+    fail 2 "SOUL.md content missing"
+  elif ! grep -q "recent_anchor" "$C2_OUT"; then
+    fail 2 "MEMORY.md content missing"
+  else
+    # Ordering: restored block must come BEFORE queue protocol line.
+    RESTORED_LINE=$(grep -n "## Restored Context" "$C2_OUT" | head -1 | cut -d: -f1)
+    QUEUE_LINE=$(grep -n "Agent Bridge queue protocol" "$C2_OUT" | head -1 | cut -d: -f1)
+    if [[ -z "$RESTORED_LINE" || -z "$QUEUE_LINE" ]]; then
+      fail 2 "could not find both markers for ordering check"
+    elif (( RESTORED_LINE >= QUEUE_LINE )); then
+      fail 2 "restored block (line $RESTORED_LINE) not before queue context (line $QUEUE_LINE)"
+    else
+      pass 2
+    fi
+  fi
+else
+  rc=$?
+  fail 2 "session_start rc=$rc; output:\n$(cat "$C2_OUT")"
+fi
+
+# ---------- case 3: dedup on second compact within window ----------
+banner 3 "second compact within dedup window does NOT re-emit restored block"
+C3_OUT="$SMOKE_ROOT/c3.out"
+# Reuse C2_HOME — first run already stamped the dedup marker.
+if run_session_start "$C2_HOME" "tester" "compact" >"$C3_OUT" 2>&1; then
+  if grep -q "## Restored Context" "$C3_OUT"; then
+    fail 3 "restored block re-emitted on second compact within dedup window"
+  else
+    pass 3
+  fi
+else
+  rc=$?
+  fail 3 "session_start (second compact) rc=$rc; output:\n$(cat "$C3_OUT")"
+fi
+
+# ---------- case 4: snapshot fallback when live file vanished ----------
+banner 4 "snapshot fallback when live SOUL.md missing post-compact"
+C4_HOME="$SMOKE_ROOT/c4"
+make_bridge_home "$C4_HOME" "tester"
+# 4a — pre-compact captures live state
+run_pre_compact "$C4_HOME" "tester" '{"trigger":"manual"}' >/dev/null 2>&1 || true
+# 4b — simulate worst case: SOUL.md vanishes between pre-compact and resume
+rm -f "$C4_HOME/agents/tester/SOUL.md"
+C4_OUT="$SMOKE_ROOT/c4.out"
+if run_session_start "$C4_HOME" "tester" "compact" >"$C4_OUT" 2>&1; then
+  if ! grep -q "identity = compact-recovery-tester" "$C4_OUT"; then
+    fail 4 "snapshot SOUL.md content not restored. output:\n$(cat "$C4_OUT")"
+  elif ! grep -q "restored from pre-compact snapshot" "$C4_OUT"; then
+    fail 4 "snapshot fallback marker missing"
+  else
+    pass 4
+  fi
+else
+  rc=$?
+  fail 4 "session_start rc=$rc"
+fi
+
+# ---------- case 5: BRIDGE_COMPACT_RECOVERY=off suppresses the block ----------
+banner 5 "BRIDGE_COMPACT_RECOVERY=off suppresses Restored Context entirely"
+C5_HOME="$SMOKE_ROOT/c5"
+make_bridge_home "$C5_HOME" "tester"
+C5_OUT="$SMOKE_ROOT/c5.out"
+if run_session_start "$C5_HOME" "tester" "compact" "BRIDGE_COMPACT_RECOVERY=off" >"$C5_OUT" 2>&1; then
+  if grep -q "## Restored Context" "$C5_OUT"; then
+    fail 5 "restored block emitted despite BRIDGE_COMPACT_RECOVERY=off"
+  elif ! grep -q "Agent Bridge queue protocol" "$C5_OUT"; then
+    fail 5 "queue context missing — hook should still emit baseline output"
+  else
+    pass 5
+  fi
+else
+  rc=$?
+  fail 5 "session_start rc=$rc"
+fi
+
+# ---------- case 6: matcher=startup never emits restored block ----------
+banner 6 "matcher=startup omits Restored Context block"
+C6_HOME="$SMOKE_ROOT/c6"
+make_bridge_home "$C6_HOME" "tester"
+C6_OUT="$SMOKE_ROOT/c6.out"
+if run_session_start "$C6_HOME" "tester" "startup" >"$C6_OUT" 2>&1; then
+  if grep -q "## Restored Context" "$C6_OUT"; then
+    fail 6 "restored block emitted on matcher=startup"
+  else
+    pass 6
+  fi
+else
+  rc=$?
+  fail 6 "session_start rc=$rc"
+fi
+
+# ---------- summary ----------
+printf '\n=== summary: %d PASS, %d FAIL ===\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf 'FAILED: %s\n' "${FAIL_IDS[*]}"
+  exit 1
+fi
+exit 0

--- a/tests/compact-recovery/smoke.sh
+++ b/tests/compact-recovery/smoke.sh
@@ -216,6 +216,46 @@ else
   fail 6 "session_start rc=$rc"
 fi
 
+# ---------- case 7: BRIDGE_COMPACT_RECOVERY_MAX_BYTES is a UTF-8 byte cap ----------
+banner 7 "MAX_BYTES enforced as UTF-8 bytes, not Python char count (codex r1)"
+C7_HOME="$SMOKE_ROOT/c7"
+make_bridge_home "$C7_HOME" "tester"
+# Korean text: each char is 3 bytes in UTF-8. 300 chars = 900 bytes, well
+# above a 256-byte cap. The pre-fix code (len(text) <= cap on chars) would
+# emit the full 900 bytes; the fix must keep the raw section under cap.
+"$PYTHON" -c "
+from pathlib import Path
+Path('$C7_HOME/agents/tester/SOUL.md').write_text('안녕' * 150, encoding='utf-8')
+"
+C7_OUT="$SMOKE_ROOT/c7.out"
+if env -u BRIDGE_AGENT_WORKDIR -u BRIDGE_AGENT_HOME -u BRIDGE_AGENT_HOME_ROOT \
+    -u BRIDGE_STATE_DIR -u BRIDGE_ACTIVE_AGENT_DIR \
+    BRIDGE_HOME="$C7_HOME" BRIDGE_AGENT_ID="tester" \
+    BRIDGE_COMPACT_RECOVERY_MAX_BYTES=256 \
+    "$PYTHON" "$C7_HOME/hooks/session_start.py" --matcher compact >"$C7_OUT" 2>&1; then
+  # Extract bytes between '### SOUL.md\n' and the truncation marker.
+  RAW_BYTES=$("$PYTHON" - "$C7_OUT" <<'PY'
+import sys, pathlib, re
+text = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+m = re.search(r"### SOUL\.md\n(.*?)\n\[…truncated by compact-recovery cap…\]", text, re.S)
+if not m:
+    print("NO_TRUNC_MARKER")
+    sys.exit(0)
+print(len(m.group(1).encode("utf-8")))
+PY
+)
+  if [[ "$RAW_BYTES" == "NO_TRUNC_MARKER" ]]; then
+    fail 7 "expected '[…truncated by compact-recovery cap…]' marker — pre-fix bug would skip truncation entirely. output:\n$(cat "$C7_OUT")"
+  elif (( RAW_BYTES > 256 )); then
+    fail 7 "raw SOUL section bytes=$RAW_BYTES exceed cap=256 (regression — char vs byte cap)"
+  else
+    pass 7
+  fi
+else
+  rc=$?
+  fail 7 "session_start rc=$rc; output:\n$(cat "$C7_OUT")"
+fi
+
 # ---------- summary ----------
 printf '\n=== summary: %d PASS, %d FAIL ===\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary

Closes the **lifecycle** half of #509 (P3 / C3+C4 only):

- `hooks/pre-compact.py` snapshots SOUL/SESSION-TYPE/COMMON-INSTRUCTIONS/TOOLS/MEMORY into `state/agents/<agent>/compact-snapshot.json` before compaction starts. Best-effort; never blocks compaction.
- `hooks/session_start.py`, on `matcher=compact`, prepends a `## Restored Context` block ahead of the queue context. Reads canonical files live (resolves symlinks); falls back to the pre-compact snapshot when a live file is missing.
- `hooks/bridge_hook_common.py` grows the helpers + three env knobs: `BRIDGE_COMPACT_RECOVERY` (on|off, default on), `BRIDGE_COMPACT_RECOVERY_FILES` (csv basenames), `BRIDGE_COMPACT_RECOVERY_MAX_BYTES` (per-file cap, default 5120).

The **skill-discovery** half of #509 (C1/C2/C5 — retire `SKILLS.md`, drop the template boot dependency, add `agb skills list`) is intentionally **out of scope** for this PR and will land separately. Splitting the surface keeps each review tractable.

### Why this PR first

C3+C4 has the largest user-visible benefit (Sean reported the "agent slowly stops sounding like itself after the third or fourth compaction" symptom directly), is independent of the skill-discovery work, and needs no backwards-compat flag scaffolding. C1/C2/C5 are gated behind a new `BRIDGE_SKILLS_DOC_MODE` and touch templates + a new CLI — different review concerns, different blast radius.

### Design notes

- Snapshot lives in a sidecar JSON next to other per-agent state files (`state/agents/<agent>/compact-snapshot.json`), not in the `bridge-memory` capture envelope. The capture envelope `--text` field would have to absorb 25+ KB of canonical content on a single line — the sidecar keeps `bridge-memory` payloads at their current size and gives operators a stable on-disk artifact to inspect.
- Live file is preferred over the snapshot. Snapshot only kicks in when the live file is empty/missing — annotated with `[restored from pre-compact snapshot]` so the operator knows the source.
- Per-file cap (5120 bytes default) bounds the worst-case payload to ~25 KB / ~10k tokens regardless of how big the agent's MEMORY.md grew. Configurable.
- Dedup window (`_COMPACT_NOTE_DEDUP_SECONDS = 300`, pre-existing) is reused — restored block is emitted at most once per logical compact event.
- Ordering moved: restored block lives at the *front* of the session_start payload, ahead of `Agent Bridge queue protocol applies to …`. Without this the model reads queue context first and acts on it before re-reading SOUL/MEMORY (this is the issue #509 P3 footgun).

### Verification

- `tests/compact-recovery/smoke.sh` — 6 cases, all PASS:
  1. `pre-compact` writes `compact-snapshot.json` with SOUL/MEMORY content
  2. `session_start --matcher compact` emits `## Restored Context` block ordered **before** the queue context
  3. Dedup: second compact within 300 s window does NOT re-emit the block
  4. Snapshot fallback: when live SOUL.md vanishes, restored block uses the snapshot copy + emits the `[restored from pre-compact snapshot]` marker
  5. `BRIDGE_COMPACT_RECOVERY=off` suppresses the block (queue context still emitted)
  6. `--matcher startup` (non-compact) never emits the block
- `bash -n` + `shellcheck` clean across the project (one intentional `SC2086 disable` for env KEY=value word-splitting in the test runner)
- `python3 -m py_compile hooks/{session_start,pre-compact,bridge_hook_common}.py` clean
- `scripts/smoke-test.sh` ran in isolated env; surfaced one pre-existing worktree-replace race ("worktree spawn reused stale session") that is unrelated to hooks/ — no new failures introduced.

### Test plan

- [ ] CI lane: `bash tests/compact-recovery/smoke.sh` returns 0
- [ ] Manual repro: spin a tmux Claude session in an isolated `BRIDGE_HOME`, force `/compact`, verify the next user-turn context contains the `## Restored Context` block with SOUL/MEMORY content above the queue protocol line
- [ ] Backwards-compat: with `BRIDGE_COMPACT_RECOVERY=off` set in `agent-roster.local.sh`, the hook behaves exactly as today (queue context only + the existing one-line capture-store hint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)