### PR TITLE
fix(509-followups): bulk-register dynamic enum + cap default + stale template cleanup

### DIFF
--- a/bridge-docs.py
+++ b/bridge-docs.py
@@ -949,6 +949,25 @@ def sync_shared_docs(bridge_home: Path, source_shared: Path, dry_run: bool, stam
             path.unlink()
         changed.append(f"removed:{path}")
 
+    # PR #514 deleted agents/_template/SKILLS.md from source (so newly
+    # scaffolded agents no longer inherit a stale catalog placeholder),
+    # but `agent-bridge upgrade` does not propagate source-side file
+    # deletions to the live runtime. Hosts that upgraded before PR #514
+    # still carry agents/_template/SKILLS.md, and the scaffolder copies
+    # everything under _template/ into a new agent home — so the stale
+    # file would re-leak into newly-created agents on those hosts.
+    # Clean up explicitly (idempotent — backups land alongside the
+    # _shared cleanup above).
+    template_skills = bridge_home / "agents" / "_template" / "SKILLS.md"
+    if template_skills.exists() or template_skills.is_symlink():
+        template_backup_root = (
+            bridge_home / "state" / "doc-migration" / "backups" / stamp / "_template"
+        )
+        backup_file(template_skills, template_backup_root, dry_run)
+        if not dry_run:
+            template_skills.unlink()
+        changed.append(f"removed:{template_skills}")
+
     source_refs = source_shared / "references"
     if source_refs.exists():
         for ref in sorted(source_refs.rglob("*")):

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -368,8 +368,14 @@ DEFAULT_COMPACT_RECOVERY_FILES: tuple[str, ...] = (
     "TOOLS.md",
     "MEMORY.md",
 )
-_COMPACT_RECOVERY_DEFAULT_CAP = 5120
-_COMPACT_RECOVERY_MIN_CAP = 256
+_COMPACT_RECOVERY_DEFAULT_CAP = 8192  # raised from 5120 (issue #509 follow-up):
+_COMPACT_RECOVERY_MIN_CAP = 256       # patch's SESSION-TYPE.md is 5607 bytes,
+                                      # so 5120 truncated the admin
+                                      # bootstrap content. 8192 covers all
+                                      # observed canonical files on the SYRS
+                                      # install. Total worst-case payload
+                                      # remains 5×8192 = 40 KB / ~16k tokens
+                                      # at the post-compact turn.
 
 
 def compact_recovery_enabled() -> bool:

--- a/scripts/bulk-register-precompact.sh
+++ b/scripts/bulk-register-precompact.sh
@@ -57,24 +57,109 @@ CANARY_AGENTS=(patch)
 PHASE2_AGENTS=(newsbot syrs-calendar syrs-creative)
 
 list_all_claude_agents() {
-    # Roster rows look like: `name [...] | claude | ... | engine=... | ...`.
-    # The `agent list` CLI has a stable first column = agent name and a
-    # second column = engine (claude|codex).
-    "$AGENT_BRIDGE_BIN" agent list 2>/dev/null \
-        | awk -F '|' 'NR>1 && $2 ~ /claude/ {
-              split($1, name_parts, " ")
-              gsub(/^[ \t]+|[ \t]+$/, "", name_parts[1])
-              if (name_parts[1] != "") print name_parts[1]
-          }' \
-        | grep -Ev '^(shared|_template)$' \
-        || true
+    # Roster rows from `agent list --json` carry the live workdir for each
+    # claude agent (static or dynamic). Issue #509 phase3 finding: the prior
+    # text-parse path missed dynamic agents because their workdir lives
+    # outside $BRIDGE_HOME/agents/<name>, so register_one() saw them as
+    # "missing_home" and skipped them. Use the JSON view as the authoritative
+    # source so dynamic agents are reachable from --all (and --canary /
+    # --phase2 still resolve their static workdirs via the same path).
+    #
+    # The Python heredoc shells `agent list --json` itself (subprocess.check_output)
+    # instead of via shell pipe so the heredoc stays the only stdin consumer —
+    # same shape codex pinned in PR #512 r2 for the OPERATOR_ACTIONS_PENDING
+    # v0.7.3 snippets.
+    AGENT_BRIDGE_BIN="$AGENT_BRIDGE_BIN" "$PYTHON_BIN" - <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+cli = os.environ.get("AGENT_BRIDGE_BIN", "")
+try:
+    raw = subprocess.check_output([cli, "agent", "list", "--json"], stderr=subprocess.DEVNULL)
+except (OSError, subprocess.CalledProcessError):
+    sys.exit(0)
+try:
+    data = json.loads(raw or b"[]")
+except (ValueError, json.JSONDecodeError):
+    sys.exit(0)
+for row in data:
+    if row.get("engine") != "claude":
+        continue
+    agent = str(row.get("agent") or "").strip()
+    workdir = str(row.get("workdir") or "").strip()
+    if not agent or agent in ("shared", "_template"):
+        continue
+    if not workdir:
+        continue
+    # Tab is the field delimiter consumed by the main loop; agent ids and
+    # workdir paths never contain tabs in valid roster output.
+    print(f"{agent}\t{workdir}")
+PY
+}
+
+resolve_static_target_workdir() {
+    # For canary/phase2 (static names hardcoded above), look up the live
+    # workdir from the same JSON view. Falls back to BRIDGE_HOME/agents/<name>
+    # so a host that has not yet bootstrapped the agent still gets a deterministic
+    # path (matches the prior register_one() default).
+    local agent="$1"
+    AGENT="$agent" AGENT_BRIDGE_BIN="$AGENT_BRIDGE_BIN" "$PYTHON_BIN" - <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+cli = os.environ.get("AGENT_BRIDGE_BIN", "")
+target = os.environ.get("AGENT", "")
+try:
+    raw = subprocess.check_output([cli, "agent", "list", "--json"], stderr=subprocess.DEVNULL)
+except (OSError, subprocess.CalledProcessError):
+    sys.exit(1)
+try:
+    data = json.loads(raw or b"[]")
+except (ValueError, json.JSONDecodeError):
+    sys.exit(1)
+for row in data:
+    if row.get("agent") == target and row.get("engine") == "claude":
+        workdir = str(row.get("workdir") or "").strip()
+        if workdir:
+            print(workdir)
+            sys.exit(0)
+sys.exit(1)
+PY
+}
+
+emit_target_with_workdir() {
+    # Print "<agent>\t<workdir>" for static-phase rosters; fall back to
+    # $BRIDGE_HOME/agents/<agent> when the agent isn't in the live roster
+    # (matches register_one's pre-fix default — "missing home" cases get
+    # surfaced inside register_one rather than dropped here).
+    local agent="$1"
+    local workdir
+    workdir="$(resolve_static_target_workdir "$agent" 2>/dev/null || true)"
+    if [ -z "$workdir" ]; then
+        workdir="$BRIDGE_HOME/agents/$agent"
+    fi
+    printf '%s\t%s\n' "$agent" "$workdir"
 }
 
 pick_targets() {
     case "$PHASE" in
-        canary) printf '%s\n' "${CANARY_AGENTS[@]}" ;;
-        phase2) printf '%s\n' "${PHASE2_AGENTS[@]}" ;;
-        all)    list_all_claude_agents ;;
+        canary)
+            for agent in "${CANARY_AGENTS[@]}"; do
+                emit_target_with_workdir "$agent"
+            done
+            ;;
+        phase2)
+            for agent in "${PHASE2_AGENTS[@]}"; do
+                emit_target_with_workdir "$agent"
+            done
+            ;;
+        all)
+            list_all_claude_agents
+            ;;
     esac
 }
 
@@ -104,7 +189,7 @@ record() {
 
 backup_settings() {
     local agent="$1"
-    local settings="$BRIDGE_HOME/agents/$agent/.claude/settings.json"
+    local settings="$2"
     if [ ! -f "$settings" ]; then
         echo ""
         return 0
@@ -119,11 +204,12 @@ backup_settings() {
 
 register_one() {
     local agent="$1"
-    local settings="$BRIDGE_HOME/agents/$agent/.claude/settings.json"
+    local workdir="${2:-$BRIDGE_HOME/agents/$agent}"
+    local settings="$workdir/.claude/settings.json"
 
-    if [ ! -d "$BRIDGE_HOME/agents/$agent" ]; then
-        record "$agent" "skip" "missing_home" "" "" "no home dir"
-        echo "skip   $agent (no home)"
+    if [ ! -d "$workdir" ]; then
+        record "$agent" "skip" "missing_workdir" "" "" "no workdir: $workdir"
+        echo "skip   $agent (no workdir: $workdir)"
         return 0
     fi
 
@@ -134,13 +220,13 @@ register_one() {
     fi
 
     local backup
-    backup="$(backup_settings "$agent")"
+    backup="$(backup_settings "$agent" "$settings")"
 
     # Canonical invocation: call bridge-hooks.py directly. The top-level
     # `agent-bridge hooks` subcommand does not exist (bootstrap-memory-system.sh
     # and bridge-agent.sh's safety net both use this same direct path).
     local cmd_for_log
-    cmd_for_log="$PYTHON_BIN $BRIDGE_HOME/bridge-hooks.py ensure-pre-compact-hook --workdir $BRIDGE_HOME/agents/$agent --bridge-home $BRIDGE_HOME --python-bin $PYTHON_BIN --settings-file $settings"
+    cmd_for_log="$PYTHON_BIN $BRIDGE_HOME/bridge-hooks.py ensure-pre-compact-hook --workdir $workdir --bridge-home $BRIDGE_HOME --python-bin $PYTHON_BIN --settings-file $settings"
 
     if [ $DRY_RUN -eq 1 ]; then
         record "$agent" "register" "dry_run" "$cmd_for_log" "$backup" ""
@@ -150,7 +236,7 @@ register_one() {
 
     local out status
     if out="$("$PYTHON_BIN" "$BRIDGE_HOME/bridge-hooks.py" ensure-pre-compact-hook \
-            --workdir "$BRIDGE_HOME/agents/$agent" \
+            --workdir "$workdir" \
             --bridge-home "$BRIDGE_HOME" \
             --python-bin "$PYTHON_BIN" \
             --settings-file "$settings" 2>&1)"; then
@@ -185,10 +271,10 @@ main() {
     fi
 
     echo "# phase=$PHASE dry_run=$DRY_RUN log=$LOG_FILE"
-    local agent
-    while IFS= read -r agent; do
+    local agent workdir
+    while IFS=$'\t' read -r agent workdir; do
         [ -z "$agent" ] && continue
-        register_one "$agent"
+        register_one "$agent" "$workdir"
         # Gentle pause to avoid racing settings.json writes.
         if [ $DRY_RUN -eq 0 ] && [ "$PHASE" = "all" ]; then
             sleep 5

--- a/tests/compact-recovery/smoke.sh
+++ b/tests/compact-recovery/smoke.sh
@@ -256,6 +256,26 @@ else
   fail 7 "session_start rc=$rc; output:\n$(cat "$C7_OUT")"
 fi
 
+# ---------- case 8: cap default covers patch's 5607-byte SESSION-TYPE.md ----------
+# Issue #509 follow-up: patch's PR #510 verify report flagged that the
+# default cap (5120 bytes) was hit by patch's SESSION-TYPE.md (5607 bytes),
+# truncating the admin bootstrap content. The default was raised to 8192;
+# pin that here so a future "performance optimisation" doesn't silently
+# drop it back below the observed admin bootstrap size.
+banner 8 "default cap (>= 8192) covers a 5607-byte canonical file untruncated"
+"$PYTHON" -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/hooks')
+import bridge_hook_common as m
+import os
+for k in list(os.environ):
+    if k.startswith('BRIDGE_COMPACT_RECOVERY'):
+        del os.environ[k]
+cap = m.compact_recovery_per_file_cap()
+assert cap >= 8192, f'default cap regressed below 8192: {cap}'
+print('OK', cap)
+" >/dev/null && pass 8 || fail 8 "default cap is below 8192 (regressed below patch's observed SESSION-TYPE size)"
+
 # ---------- summary ----------
 printf '\n=== summary: %d PASS, %d FAIL ===\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then

--- a/tests/skill-discovery-mode/smoke.sh
+++ b/tests/skill-discovery-mode/smoke.sh
@@ -414,6 +414,36 @@ $ok15 && run_gate "plugin-routing" "remove" "1" >/dev/null 2>&1 || { ok15=false;
 $ok15 && run_gate "disabled" "remove" "1" >/dev/null 2>&1 || { ok15=false; fail 15 "disabled gate did not remove SKILLS.md or did not record 'removed:'"; }
 $ok15 && pass 15
 
+# ---------- case 16: sync_shared_docs cleans up stale _template/SKILLS.md ----------
+# patch's PR #514 verify (#3115) found that hosts upgraded before PR #514
+# still carried agents/_template/SKILLS.md in the live runtime — source
+# deleted the file but `agent-bridge upgrade` does not propagate
+# source-side deletions. The follow-up fix has sync_shared_docs explicitly
+# clean up the stale file. Pin that here.
+banner 16 "sync_shared_docs removes stale agents/_template/SKILLS.md from live runtime"
+C16_HOME="$SMOKE_ROOT/c16"
+SOURCE_SHARED="$SMOKE_ROOT/c16-src-shared"
+mkdir -p "$C16_HOME/agents/_template" "$C16_HOME/state" "$SOURCE_SHARED"
+echo "STALE TEMPLATE SKILLS CONTENT" > "$C16_HOME/agents/_template/SKILLS.md"
+
+"$PYTHON" -c "$load_bd_preamble"$'
+import pathlib
+home = pathlib.Path("'"$C16_HOME"'")
+src = pathlib.Path("'"$SOURCE_SHARED"'")
+mod.sync_shared_docs(home, src, dry_run=False, stamp="20260503T000000Z", registry={})
+'
+
+ok16=true
+if [[ -f "$C16_HOME/agents/_template/SKILLS.md" ]]; then
+  ok16=false; fail 16 "stale _template/SKILLS.md not removed from live runtime"
+fi
+# Backup must be present so the cleanup is recoverable
+BACKUP_DIR="$C16_HOME/state/doc-migration/backups/20260503T000000Z/_template"
+if $ok16 && [[ ! -f "$BACKUP_DIR/SKILLS.md" ]]; then
+  ok16=false; fail 16 "expected backup at $BACKUP_DIR/SKILLS.md (cleanup must be recoverable). state contents:\n$(find "$C16_HOME/state" -type f 2>/dev/null)"
+fi
+$ok16 && pass 16
+
 # ---------- summary ----------
 printf '\n=== summary: %d PASS, %d FAIL ===\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then

--- a/tests/upgrade-precompact-wire/smoke.sh
+++ b/tests/upgrade-precompact-wire/smoke.sh
@@ -247,6 +247,58 @@ else
   fail 6 "bridge-upgrade.sh does not reference bridge_ensure_claude_pre_compact_hook (call site missing)"
 fi
 
+# ---------- case 7: bulk-register-precompact.sh enumerates dynamic agents ----------
+# Issue #509 phase3 finding: the prior text-parse path of
+# list_all_claude_agents() in scripts/bulk-register-precompact.sh skipped
+# dynamic claude agents whose workdir lives outside $BRIDGE_HOME/agents/.
+# The follow-up rewrites the enumeration to use `agent-bridge agent list
+# --json`, which exposes the live workdir directly. Pin that here.
+banner 7 "bulk-register-precompact.sh --all enumerates static + dynamic claude (issue #509 phase3)"
+C7_HOME="$SMOKE_ROOT/c7"
+mkdir -p "$C7_HOME/state" "$C7_HOME/hooks"
+cp "$REPO_ROOT/bridge-hooks.py" "$C7_HOME/bridge-hooks.py"
+# Static-style agent under BRIDGE_HOME/agents/<name>
+mkdir -p "$C7_HOME/agents/static-a/.claude"
+echo '{}' > "$C7_HOME/agents/static-a/.claude/settings.json"
+# Dynamic-style agent: workdir lives outside BRIDGE_HOME/agents/
+DYN_DIR="$SMOKE_ROOT/c7-dyn-project"
+mkdir -p "$DYN_DIR/.claude"
+echo '{}' > "$DYN_DIR/.claude/settings.json"
+
+# Stub `agent-bridge agent list --json` so the script sees a fixed roster
+# without needing the live install. The stub returns one static claude
+# (BRIDGE_HOME-rooted), one dynamic claude (project-rooted), and one
+# codex agent (must be excluded).
+STUB="$SMOKE_ROOT/c7-stub-agent-bridge"
+cat > "$STUB" <<STUB_EOF
+#!/usr/bin/env bash
+if [[ "\$1 \$2 \$3" == "agent list --json" ]]; then
+  cat <<JSON
+[
+  {"agent": "static-a", "engine": "claude", "source": "static", "workdir": "$C7_HOME/agents/static-a"},
+  {"agent": "dyn-b", "engine": "claude", "source": "dynamic", "workdir": "$DYN_DIR"},
+  {"agent": "codex-c", "engine": "codex", "source": "static", "workdir": "/tmp/codex-c"}
+]
+JSON
+fi
+STUB_EOF
+chmod +x "$STUB"
+
+C7_OUT=$(BRIDGE_HOME="$C7_HOME" AGENT_BRIDGE_BIN="$STUB" BRIDGE_PYTHON_BIN="$PYTHON" \
+         bash "$REPO_ROOT/scripts/bulk-register-precompact.sh" --all --dry-run 2>&1)
+
+ok7=true
+if ! grep -q "static-a" <<<"$C7_OUT"; then
+  ok7=false; fail 7 "static-a (BRIDGE_HOME-rooted) not enumerated. output:\n$C7_OUT"
+fi
+if $ok7 && ! grep -q "dyn-b" <<<"$C7_OUT"; then
+  ok7=false; fail 7 "dyn-b (dynamic, workdir outside BRIDGE_HOME/agents) not enumerated — phase3 regression. output:\n$C7_OUT"
+fi
+if $ok7 && grep -q "codex-c" <<<"$C7_OUT"; then
+  ok7=false; fail 7 "codex-c (engine=codex) should NOT be enumerated"
+fi
+$ok7 && pass 7
+
 # ---------- summary ----------
 printf '\n=== summary: %d PASS, %d FAIL ===\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary

Three small follow-ups surfaced during the issue #509 wave verify reports. With this PR merged, the #509 follow-up tail is closed.

## Changes

### 1. `scripts/bulk-register-precompact.sh` — dynamic agent enumeration

phase3 (#3089) found that the prior text-parse path of `list_all_claude_agents()` skipped dynamic claude agents whose workdir lives outside `$BRIDGE_HOME/agents/<name>`. The SYRS install's three dynamic agents (`agb-dev-claude`, `crm-dev`, `crm-test`) all slipped through.

Rewrite `list_all_claude_agents` and add `resolve_static_target_workdir` so both paths drive off `agent-bridge agent list --json`. Targets flow through the loop as `<agent>\t<workdir>`; `register_one()` / `backup_settings()` / the `bridge-hooks.py` invocation all use the per-target workdir.

The Python heredocs shell `agent-bridge agent list --json` themselves (via `subprocess.check_output`) instead of via shell pipe so the heredoc stays the only stdin consumer — same shape codex pinned in PR #512 r2.

### 2. `BRIDGE_COMPACT_RECOVERY_MAX_BYTES` default 5120 → 8192

patch's PR #510 verify (#3100) showed `SESSION-TYPE.md` at 5607 bytes hitting the cap and emitting the truncation marker. 8192 covers the observed canonical files while keeping the worst-case payload at 5×8192 = 40 KB / ~16k tokens. Operators can still tune via env.

### 3. Stale `agents/_template/SKILLS.md` cleanup on apply

PR #514 deleted `_template/SKILLS.md` from source, but `agent-bridge upgrade` does not propagate source-side file deletions to the live runtime. patch's PR #514 verify (#3115) found the file still present at `~/.agent-bridge/agents/_template/SKILLS.md`, which means scaffolding new agents on that host would still leak the stale per-agent SKILLS.md that PR #514's text edits were trying to retire.

Add an explicit cleanup in `sync_shared_docs` that backs up and removes the stale file. Idempotent — already-cleaned hosts hit a no-op. Backup lands under `state/doc-migration/backups/<stamp>/_template/SKILLS.md`.

## Tests

- `tests/upgrade-precompact-wire/smoke.sh` case 7 (new): stub `agent-bridge agent list --json` with a fixture mixing static claude / dynamic claude / codex agents; assert static enumerated, dynamic enumerated (the regression), codex excluded.
- `tests/compact-recovery/smoke.sh` case 8 (new): pin default cap >= 8192.
- `tests/skill-discovery-mode/smoke.sh` case 16 (new): seed a stale `_template/SKILLS.md`, run `sync_shared_docs`, assert removal + backup presence.

All three smoke suites pass: **8/8 + 7/7 + 16/16**. shellcheck + bash -n + py_compile clean.

## Test plan

- [ ] CI lane: all three smoke suites return 0
- [ ] Live host: `bash $HOME/.agent-bridge/scripts/bulk-register-precompact.sh --all --dry-run` lists the dynamic claude agents with their project workdirs (not just the static ones under `BRIDGE_HOME/agents/`).
- [ ] Live host with stale `_template/SKILLS.md`: `agent-bridge upgrade --apply` removes the file (with backup) and the next `agent-bridge agent create` does not seed the stale catalog placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)