### PR TITLE
fix(509-followups): dynamic handoff path + queue nudge + tool-policy + shared-settings gating (#516)

### DIFF
--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -771,7 +771,12 @@ def queue_summary(agent: str) -> tuple[int, dict[str, Any] | None]:
     row = rows[0] if isinstance(rows[0], dict) else None
     if not row:
         return 0, None
-    pending = int(row.get("queued_count", 0)) + int(row.get("blocked_count", 0)) + int(row.get("claimed_count", 0))
+    # `blocked` tasks intentionally excluded — they wait on external unblock,
+    # not on the agent acting now. Admin agents still see blocked-task counts
+    # via `admin_blocked_self_cleanup_context` above. Without this exclusion,
+    # every `bridge-task update --status blocked` re-fires the SessionStart
+    # `[Agent Bridge] N pending task(s) … ACTION REQUIRED` nudge.
+    pending = int(row.get("queued_count", 0)) + int(row.get("claimed_count", 0))
     if pending <= 0:
         return 0, None
 

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 import os
@@ -82,11 +83,73 @@ def agent_default_home(agent: str) -> Path:
     return agent_home_root() / agent
 
 
+@functools.lru_cache(maxsize=None)
+def _resolve_workdir_via_roster(agent: str) -> Path | None:
+    """Best-effort lookup of an agent's live workdir via the roster CLI.
+
+    Used by :func:`agent_workdir` when neither the explicit env var nor
+    the static-home directory is available — i.e. for dynamic claude
+    agents whose workdir lives outside ``$BRIDGE_HOME/agents/<name>/``.
+    Hooks invoked from cron / external surfaces lack the env that
+    ``bridge-run.sh`` would export, so without this fallback the
+    candidate list in :func:`bootstrap_artifact_context` misses the
+    real ``<project-workdir>/NEXT-SESSION.md`` and the handoff is
+    silently dropped.
+
+    Any subprocess / parse / lookup failure returns ``None`` so the
+    caller can fall back to the prior default-home behaviour. The
+    result is memoised for the duration of the hook process.
+    """
+    cli = bridge_script_dir() / "agent-bridge"
+    try:
+        proc = subprocess.run(
+            [str(cli), "agent", "list", "--json"],
+            cwd=str(bridge_script_dir()),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+    rows: list[dict[str, Any]]
+    if isinstance(payload, list):
+        rows = [row for row in payload if isinstance(row, dict)]
+    elif isinstance(payload, dict):
+        candidates = payload.get("agents") or payload.get("rows") or []
+        rows = [row for row in candidates if isinstance(row, dict)]
+    else:
+        return None
+    for row in rows:
+        if row.get("agent") != agent:
+            continue
+        workdir = row.get("workdir")
+        if isinstance(workdir, str) and workdir.strip():
+            return Path(workdir).expanduser()
+    return None
+
+
 def agent_workdir(agent: str) -> Path:
     explicit = os.environ.get("BRIDGE_AGENT_WORKDIR", "").strip()
     if explicit:
         return Path(explicit).expanduser()
-    return agent_default_home(agent)
+    default = agent_default_home(agent)
+    if default.is_dir():
+        return default
+    # Dynamic-agent fallback (issue #509 D wave): the env that
+    # bridge-run.sh exports may not be available on cron / external
+    # invocations, and the static default home does not exist for
+    # agents whose workdir is a project directory.
+    roster_workdir = _resolve_workdir_via_roster(agent)
+    if roster_workdir is not None:
+        return roster_workdir
+    return default
 
 
 def current_agent() -> str:

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -468,6 +468,51 @@ def _alias_path_fragments(token: str):
             yield fragment
 
 
+# Length below which a substring-fallback needle is considered too generic
+# to fire on its own — e.g. `hooks/` and `state/cron/` are short enough
+# that any heredoc body documenting the hook chain or cron layout will
+# trigger them. For such needles we require the character immediately
+# preceding the match to be a strict filesystem-prefix character (`/`,
+# `~`, `$`) so the match must look like an actual path argument
+# (``/abs/.../hooks/foo``, ``~/state/cron/``, ``$BRIDGE_HOME/hooks/x``)
+# and not prose like ``See hooks/post.sh for details`` that follows a
+# space. Longer needles (``.discord/access.json``,
+# ``agent-roster.local.sh``, etc.) are specific enough that a plain
+# substring hit is acceptable. Issue #509 D2 follow-up.
+_SHORT_NEEDLE_THRESHOLD = 12
+_PATH_PREFIX_CHARS = frozenset({"/", "~", "$"})
+
+
+def _command_substring_hits_protected_needle(command: str) -> bool:
+    """Return True iff *command* contains any protected literal suffix in
+    a plausible path-argument position.
+
+    Long needles (>= :data:`_SHORT_NEEDLE_THRESHOLD` chars) match on a
+    plain substring scan. Short needles only fire when preceded by a
+    strict filesystem-prefix character (`/`, `~`, `$`), which keeps the
+    fallback no weaker than the structural-argv check for real path
+    arguments while letting heredoc prose like ``It's hooks/post.sh``
+    pass — that prose is what triggered the regression operator-side
+    on 2026-05-03 (issue #509 D2 follow-up).
+    """
+    for needle in protected_literal_suffixes():
+        if not needle:
+            continue
+        if len(needle) >= _SHORT_NEEDLE_THRESHOLD:
+            if needle in command:
+                return True
+            continue
+        start = 0
+        while True:
+            idx = command.find(needle, start)
+            if idx < 0:
+                break
+            if idx > 0 and command[idx - 1] in _PATH_PREFIX_CHARS:
+                return True
+            start = idx + 1
+    return False
+
+
 def _token_matches_protected(token: str, protected: Path) -> bool:
     for fragment in _alias_path_fragments(token):
         expanded = os.path.expandvars(os.path.expanduser(fragment))
@@ -580,10 +625,18 @@ def _bash_argv_references_system_config(command: str) -> bool:
     try:
         tokens = shlex.split(command, posix=True, comments=False)
     except ValueError:
-        for needle in protected_literal_suffixes():
-            if needle and needle in command:
-                return True
-        return False
+        # Substring fallback: shlex rejected the command (commonly an
+        # unbalanced apostrophe inside a heredoc body — `It's foo` etc.).
+        # The shorter needles in protected_literal_suffixes (`hooks/`,
+        # `state/cron/`) match too eagerly when prose mentions them
+        # mid-sentence (e.g. a handoff body that documents the hook
+        # chain). Require each needle to sit at a path-boundary:
+        # start-of-string or preceded by a character that plausibly opens
+        # a filesystem token (`/`, `~`, `$`, whitespace, quote, paren, or
+        # one of the redirection prefixes). This keeps the fallback no
+        # weaker than the structural-argv check for real path arguments
+        # while letting heredoc prose pass.
+        return _command_substring_hits_protected_needle(command)
 
     def _check_value(value: str) -> bool:
         for fragment in _alias_path_fragments(value):

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -472,15 +472,37 @@ def _alias_path_fragments(token: str):
 # to fire on its own — e.g. `hooks/` and `state/cron/` are short enough
 # that any heredoc body documenting the hook chain or cron layout will
 # trigger them. For such needles we require the character immediately
-# preceding the match to be a strict filesystem-prefix character (`/`,
-# `~`, `$`) so the match must look like an actual path argument
-# (``/abs/.../hooks/foo``, ``~/state/cron/``, ``$BRIDGE_HOME/hooks/x``)
-# and not prose like ``See hooks/post.sh for details`` that follows a
-# space. Longer needles (``.discord/access.json``,
-# ``agent-roster.local.sh``, etc.) are specific enough that a plain
-# substring hit is acceptable. Issue #509 D2 follow-up.
+# preceding the match to be a path-boundary / token-boundary character
+# so the match looks like an actual argv-shaped path (``>hooks/foo``,
+# ``"hooks/post.sh"``, ``FOO=hooks/x``, ``$(hooks/y)``, ``cmd|hooks/z``,
+# or start-of-string) and not prose like ``See hooks/post.sh for
+# details`` that follows whitespace. Whitespace is **deliberately
+# excluded** from the prefix set: heredoc bodies are the dominant
+# source of false-positive shlex failures, and prose mentions inside
+# them are always preceded by a space. Real argv writes always have a
+# non-whitespace boundary character (redirection ``>``, assignment
+# ``=``, quote, parenthesis, separator). Longer needles
+# (``.discord/access.json``, ``agent-roster.local.sh``, etc.) are
+# specific enough that a plain substring hit is acceptable. Issue #509
+# D2 follow-up; tightened for r2 after codex flagged
+# ``cat >hooks/foo 'unterminated`` bypassing the original three-char
+# prefix set.
 _SHORT_NEEDLE_THRESHOLD = 12
-_PATH_PREFIX_CHARS = frozenset({"/", "~", "$"})
+_PATH_PREFIX_CHARS = frozenset({
+    "/",        # absolute / relative path
+    "~",        # home expansion
+    "$",        # var expansion
+    ">",        # output redirection target (`>hooks/foo`, `&>hooks/foo`)
+    "<",        # input redirection target
+    "'",        # single-quoted token boundary
+    '"',        # double-quoted token boundary
+    "(",        # subshell / `$(...)` inner
+    "=",        # assignment value (`FOO=hooks/...`)
+    "&",        # background / fd redirect prefix (`&>hooks/...`)
+    "|",        # pipe boundary
+    ";",        # statement separator
+    ",",        # comma separator in some shell idioms
+})
 
 
 def _command_substring_hits_protected_needle(command: str) -> bool:
@@ -488,12 +510,14 @@ def _command_substring_hits_protected_needle(command: str) -> bool:
     a plausible path-argument position.
 
     Long needles (>= :data:`_SHORT_NEEDLE_THRESHOLD` chars) match on a
-    plain substring scan. Short needles only fire when preceded by a
-    strict filesystem-prefix character (`/`, `~`, `$`), which keeps the
-    fallback no weaker than the structural-argv check for real path
-    arguments while letting heredoc prose like ``It's hooks/post.sh``
-    pass — that prose is what triggered the regression operator-side
-    on 2026-05-03 (issue #509 D2 follow-up).
+    plain substring scan. Short needles fire when the needle sits at
+    start-of-string OR is preceded by a token/path-boundary character
+    (see :data:`_PATH_PREFIX_CHARS`). Whitespace is intentionally NOT a
+    boundary character so heredoc prose like ``It's hooks/post.sh``
+    pass — that prose is what triggered the regression operator-side on
+    2026-05-03 (issue #509 D2). Real argv writes such as
+    ``cat >hooks/foo 'unterminated`` still deny because ``>`` is in the
+    prefix set (#509 D2 r2 codex follow-up).
     """
     for needle in protected_literal_suffixes():
         if not needle:
@@ -507,7 +531,10 @@ def _command_substring_hits_protected_needle(command: str) -> bool:
             idx = command.find(needle, start)
             if idx < 0:
                 break
-            if idx > 0 and command[idx - 1] in _PATH_PREFIX_CHARS:
+            if idx == 0:
+                # Needle at start-of-string is path-shaped by construction.
+                return True
+            if command[idx - 1] in _PATH_PREFIX_CHARS:
                 return True
             start = idx + 1
     return False
@@ -631,11 +658,11 @@ def _bash_argv_references_system_config(command: str) -> bool:
         # `state/cron/`) match too eagerly when prose mentions them
         # mid-sentence (e.g. a handoff body that documents the hook
         # chain). Require each needle to sit at a path-boundary:
-        # start-of-string or preceded by a character that plausibly opens
-        # a filesystem token (`/`, `~`, `$`, whitespace, quote, paren, or
-        # one of the redirection prefixes). This keeps the fallback no
-        # weaker than the structural-argv check for real path arguments
-        # while letting heredoc prose pass.
+        # start-of-string or preceded by a token-boundary character
+        # (redirection `>`/`<`, quote, paren, assignment `=`, fd `&`,
+        # pipe `|`, separator `;`/`,`, plus the original `/`, `~`, `$`).
+        # Whitespace is deliberately excluded so heredoc prose preceded
+        # by a space still passes — see _PATH_PREFIX_CHARS for rationale.
         return _command_substring_hits_protected_needle(command)
 
     def _check_value(value: str) -> bool:

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -59,6 +59,33 @@ bridge_claude_settings_mode() {
   local agent=""
   local agent_workdir=""
 
+  # Issue #516 r2 (codex needs-more on PR #518): the
+  # "inside BRIDGE_AGENT_HOME_ROOT means shared" fast-path is NOT
+  # static-by-construction. Dynamic spawn defaults to the current
+  # directory and accepts arbitrary --workdir, then records
+  # source=dynamic with that workdir. If an operator passes
+  # --workdir into the home root, the dynamic agent would inherit
+  # the static autoCompactWindow=400000 default — exactly what the
+  # original Issue #516 fix tried to prevent.
+  #
+  # Short-circuit registered dynamic claude agents to `local` BEFORE
+  # the HOME_ROOT branch. Static agents under HOME_ROOT keep the
+  # existing fast path; static agents whose workdir is registered
+  # outside HOME_ROOT keep their existing handling in the second
+  # loop below.
+  if declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1; then
+    for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+      [[ "$(bridge_agent_engine "$agent" 2>/dev/null || true)" == "claude" ]] || continue
+      [[ "$(bridge_agent_source "$agent" 2>/dev/null || true)" == "dynamic" ]] || continue
+      agent_workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
+      [[ -n "$agent_workdir" ]] || continue
+      if [[ "$(bridge_hook_paths_equal "$workdir" "$agent_workdir")" == "1" ]]; then
+        printf 'local'
+        return 0
+      fi
+    done
+  fi
+
   if [[ "$(bridge_path_is_within_root "$workdir" "$BRIDGE_AGENT_HOME_ROOT")" == "1" ]]; then
     printf 'shared'
     return 0

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -67,6 +67,13 @@ bridge_claude_settings_mode() {
   if declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1; then
     for agent in "${BRIDGE_AGENT_IDS[@]}"; do
       [[ "$(bridge_agent_engine "$agent" 2>/dev/null || true)" == "claude" ]] || continue
+      # Issue #516: only static claude agents inherit the shared
+      # `autoCompactWindow=400000` defaults. Dynamic agents register their
+      # workdir in BRIDGE_AGENT_IDS too (see bridge_register_dynamic_agent
+      # in agent-bridge), so without a source gate the second branch matched
+      # any registered workdir and inflated dynamic-agent context budget
+      # against operator intent.
+      [[ "$(bridge_agent_source "$agent" 2>/dev/null || true)" == "static" ]] || continue
       agent_workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
       [[ -n "$agent_workdir" ]] || continue
       if [[ "$(bridge_hook_paths_equal "$workdir" "$agent_workdir")" == "1" ]]; then

--- a/scripts/smoke/hooks.sh
+++ b/scripts/smoke/hooks.sh
@@ -198,15 +198,44 @@ claude_settings_mode_source_gate() {
   # "shared" — inflating dynamic agents' context budget by inheriting the
   # static-only autoCompactWindow=400000 default.
   local case_root static_workdir dynamic_workdir within_root_workdir bash4_bin
-  local mode_dynamic mode_static mode_within_root
+  local dynamic_under_root_workdir
+  local mode_dynamic mode_static mode_within_root mode_dynamic_under_root
 
   case_root="$SMOKE_TMP_ROOT/settings-mode-gate"
   mkdir -p "$case_root"
   static_workdir="$case_root/static-agent-workdir"
   dynamic_workdir="$case_root/dynamic-agent-workdir"
   within_root_workdir="$BRIDGE_AGENT_HOME_ROOT/within-root-agent"
-  mkdir -p "$static_workdir" "$dynamic_workdir" "$within_root_workdir"
+  dynamic_under_root_workdir="$BRIDGE_AGENT_HOME_ROOT/dynamic-agent"
+  mkdir -p "$static_workdir" "$dynamic_workdir" "$within_root_workdir" \
+    "$dynamic_under_root_workdir"
 
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "static-agent"
+BRIDGE_AGENT_ENGINE["static-agent"]="claude"
+BRIDGE_AGENT_SOURCE["static-agent"]="static"
+BRIDGE_AGENT_SESSION["static-agent"]="static-agent"
+BRIDGE_AGENT_WORKDIR["static-agent"]="$static_workdir"
+
+bridge_add_agent_id_if_missing "dynamic-agent"
+BRIDGE_AGENT_ENGINE["dynamic-agent"]="claude"
+BRIDGE_AGENT_SOURCE["dynamic-agent"]="dynamic"
+BRIDGE_AGENT_SESSION["dynamic-agent"]="dynamic-agent"
+BRIDGE_AGENT_WORKDIR["dynamic-agent"]="$dynamic_under_root_workdir"
+EOF
+
+  bash4_bin="$BASH"
+  if (( BASH_VERSINFO[0] < 4 )); then
+    if [[ -x /opt/homebrew/bin/bash ]]; then
+      bash4_bin="/opt/homebrew/bin/bash"
+    elif [[ -x /usr/local/bin/bash ]]; then
+      bash4_bin="/usr/local/bin/bash"
+    fi
+  fi
+
+  # E1 — dynamic claude agent's registered workdir (outside HOME_ROOT) must
+  # NOT classify as `shared`. Re-register the dynamic agent with the
+  # outside-HOME_ROOT workdir for this case.
   cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
 bridge_add_agent_id_if_missing "static-agent"
 BRIDGE_AGENT_ENGINE["static-agent"]="claude"
@@ -220,17 +249,6 @@ BRIDGE_AGENT_SOURCE["dynamic-agent"]="dynamic"
 BRIDGE_AGENT_SESSION["dynamic-agent"]="dynamic-agent"
 BRIDGE_AGENT_WORKDIR["dynamic-agent"]="$dynamic_workdir"
 EOF
-
-  bash4_bin="$BASH"
-  if (( BASH_VERSINFO[0] < 4 )); then
-    if [[ -x /opt/homebrew/bin/bash ]]; then
-      bash4_bin="/opt/homebrew/bin/bash"
-    elif [[ -x /usr/local/bin/bash ]]; then
-      bash4_bin="/usr/local/bin/bash"
-    fi
-  fi
-
-  # E1 — dynamic claude agent's registered workdir must NOT classify as `shared`.
   mode_dynamic="$(
     "$bash4_bin" -c 'repo="$1"; workdir="$2"; source "$repo/bridge-lib.sh"; bridge_load_roster; bridge_claude_settings_mode "$workdir"' \
       _ "$SMOKE_REPO_ROOT" "$dynamic_workdir"
@@ -244,14 +262,41 @@ EOF
   )"
   smoke_assert_eq "shared" "$mode_static" "E2: static claude agent workdir resolves as shared"
 
-  # E3 — first branch (workdir within BRIDGE_AGENT_HOME_ROOT) still resolves as
-  # `shared` regardless of source — anything inside the agent home root is
-  # static-by-construction and the source gate is intentionally skipped there.
+  # E3 — workdir within BRIDGE_AGENT_HOME_ROOT and NOT registered as a
+  # dynamic agent still resolves as `shared`. The dynamic short-circuit
+  # only fires on exact-match registered workdirs, so unregistered paths
+  # under the home root keep their static-by-construction default.
   mode_within_root="$(
     "$bash4_bin" -c 'repo="$1"; workdir="$2"; source "$repo/bridge-lib.sh"; bridge_load_roster; bridge_claude_settings_mode "$workdir"' \
       _ "$SMOKE_REPO_ROOT" "$within_root_workdir"
   )"
-  smoke_assert_eq "shared" "$mode_within_root" "E3: workdir inside BRIDGE_AGENT_HOME_ROOT remains shared"
+  smoke_assert_eq "shared" "$mode_within_root" "E3: workdir inside BRIDGE_AGENT_HOME_ROOT (unregistered) remains shared"
+
+  # E4 — Issue #516 r2 (codex needs-more on PR #518): a dynamic claude
+  # agent registered with a workdir that LIVES UNDER
+  # BRIDGE_AGENT_HOME_ROOT must short-circuit to `local` BEFORE the
+  # HOME_ROOT fast-path fires. Operator passes --workdir under the home
+  # root via the dynamic spawn path; without the registered-dynamic
+  # short-circuit, the HOME_ROOT fast-path would silently inflate that
+  # agent's autoCompactWindow against operator intent.
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "static-agent"
+BRIDGE_AGENT_ENGINE["static-agent"]="claude"
+BRIDGE_AGENT_SOURCE["static-agent"]="static"
+BRIDGE_AGENT_SESSION["static-agent"]="static-agent"
+BRIDGE_AGENT_WORKDIR["static-agent"]="$static_workdir"
+
+bridge_add_agent_id_if_missing "dynamic-agent"
+BRIDGE_AGENT_ENGINE["dynamic-agent"]="claude"
+BRIDGE_AGENT_SOURCE["dynamic-agent"]="dynamic"
+BRIDGE_AGENT_SESSION["dynamic-agent"]="dynamic-agent"
+BRIDGE_AGENT_WORKDIR["dynamic-agent"]="$dynamic_under_root_workdir"
+EOF
+  mode_dynamic_under_root="$(
+    "$bash4_bin" -c 'repo="$1"; workdir="$2"; source "$repo/bridge-lib.sh"; bridge_load_roster; bridge_claude_settings_mode "$workdir"' \
+      _ "$SMOKE_REPO_ROOT" "$dynamic_under_root_workdir"
+  )"
+  smoke_assert_eq "local" "$mode_dynamic_under_root" "E4: dynamic claude agent registered with workdir under HOME_ROOT resolves as local (not shared)"
 }
 
 hook_runtime_helpers() {

--- a/scripts/smoke/hooks.sh
+++ b/scripts/smoke/hooks.sh
@@ -190,6 +190,70 @@ EOF
   assert_claude_auto_compact_window "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json" "400000" "custom managed shared settings"
 }
 
+claude_settings_mode_source_gate() {
+  # Issue #516: bridge_claude_settings_mode must gate the registered-workdir
+  # branch on source=static. Dynamic claude agents register a workdir in
+  # BRIDGE_AGENT_IDS too (bulk-register, dynamic spawn), and without the
+  # source check the second branch would treat any registered workdir as
+  # "shared" — inflating dynamic agents' context budget by inheriting the
+  # static-only autoCompactWindow=400000 default.
+  local case_root static_workdir dynamic_workdir within_root_workdir bash4_bin
+  local mode_dynamic mode_static mode_within_root
+
+  case_root="$SMOKE_TMP_ROOT/settings-mode-gate"
+  mkdir -p "$case_root"
+  static_workdir="$case_root/static-agent-workdir"
+  dynamic_workdir="$case_root/dynamic-agent-workdir"
+  within_root_workdir="$BRIDGE_AGENT_HOME_ROOT/within-root-agent"
+  mkdir -p "$static_workdir" "$dynamic_workdir" "$within_root_workdir"
+
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "static-agent"
+BRIDGE_AGENT_ENGINE["static-agent"]="claude"
+BRIDGE_AGENT_SOURCE["static-agent"]="static"
+BRIDGE_AGENT_SESSION["static-agent"]="static-agent"
+BRIDGE_AGENT_WORKDIR["static-agent"]="$static_workdir"
+
+bridge_add_agent_id_if_missing "dynamic-agent"
+BRIDGE_AGENT_ENGINE["dynamic-agent"]="claude"
+BRIDGE_AGENT_SOURCE["dynamic-agent"]="dynamic"
+BRIDGE_AGENT_SESSION["dynamic-agent"]="dynamic-agent"
+BRIDGE_AGENT_WORKDIR["dynamic-agent"]="$dynamic_workdir"
+EOF
+
+  bash4_bin="$BASH"
+  if (( BASH_VERSINFO[0] < 4 )); then
+    if [[ -x /opt/homebrew/bin/bash ]]; then
+      bash4_bin="/opt/homebrew/bin/bash"
+    elif [[ -x /usr/local/bin/bash ]]; then
+      bash4_bin="/usr/local/bin/bash"
+    fi
+  fi
+
+  # E1 — dynamic claude agent's registered workdir must NOT classify as `shared`.
+  mode_dynamic="$(
+    "$bash4_bin" -c 'repo="$1"; workdir="$2"; source "$repo/bridge-lib.sh"; bridge_load_roster; bridge_claude_settings_mode "$workdir"' \
+      _ "$SMOKE_REPO_ROOT" "$dynamic_workdir"
+  )"
+  smoke_assert_eq "local" "$mode_dynamic" "E1: dynamic claude agent workdir resolves as local (not shared)"
+
+  # E2 — static claude agent's registered workdir continues to classify as `shared`.
+  mode_static="$(
+    "$bash4_bin" -c 'repo="$1"; workdir="$2"; source "$repo/bridge-lib.sh"; bridge_load_roster; bridge_claude_settings_mode "$workdir"' \
+      _ "$SMOKE_REPO_ROOT" "$static_workdir"
+  )"
+  smoke_assert_eq "shared" "$mode_static" "E2: static claude agent workdir resolves as shared"
+
+  # E3 — first branch (workdir within BRIDGE_AGENT_HOME_ROOT) still resolves as
+  # `shared` regardless of source — anything inside the agent home root is
+  # static-by-construction and the source gate is intentionally skipped there.
+  mode_within_root="$(
+    "$bash4_bin" -c 'repo="$1"; workdir="$2"; source "$repo/bridge-lib.sh"; bridge_load_roster; bridge_claude_settings_mode "$workdir"' \
+      _ "$SMOKE_REPO_ROOT" "$within_root_workdir"
+  )"
+  smoke_assert_eq "shared" "$mode_within_root" "E3: workdir inside BRIDGE_AGENT_HOME_ROOT remains shared"
+}
+
 hook_runtime_helpers() {
   local hook_workdir prompt_output session_output
 
@@ -215,6 +279,7 @@ main() {
   smoke_run "Claude hooks ensure/status" claude_hooks_contract
   smoke_run "Claude shared settings context defaults" claude_shared_settings_context_defaults
   smoke_run "managed custom workdir shared settings" managed_custom_workdir_shared_settings
+  smoke_run "claude settings mode source=static gate (#516)" claude_settings_mode_source_gate
   smoke_run "hook runtime helper output" hook_runtime_helpers
   smoke_log "passed"
 }

--- a/tests/dynamic-agent-handoff/smoke.sh
+++ b/tests/dynamic-agent-handoff/smoke.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# dynamic-agent-handoff smoke — issue #509 wave Track C follow-up.
+#
+# Asserts the SessionStart bootstrap_artifact_context hook surfaces
+# `Handoff present: …` for dynamic claude agents whose workdir lives
+# outside `$BRIDGE_HOME/agents/<name>/`. Three cases:
+#
+#   C1 — `BRIDGE_AGENT_WORKDIR` env explicitly points at the dynamic
+#        agent's project workdir + NEXT-SESSION.md is there.
+#   C2 — env unset, dynamic agent registered via a stubbed
+#        `agent-bridge agent list --json` whose row carries the
+#        workdir. Hook must consult the roster CLI fallback.
+#   C3 — env unset, roster CLI fails (returns rc=1 / empty). Hook
+#        must NOT crash; must return empty (graceful fallback to the
+#        prior default-home behaviour).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+}
+
+# Each case sets up a fresh BRIDGE_HOME under /tmp so the live install
+# is never touched. The dynamic agent's project workdir lives at the
+# same level (sibling to BRIDGE_HOME), mimicking the operator's
+# `--workdir /Users/sean/Projects/repo` shape.
+
+# ----- C1: explicit env --------------------------------------------------
+sce1_root="$(mktemp -d -t agb-c1.XXXXXX)"
+sce1_home="$sce1_root/bridge-home"
+sce1_workdir="$sce1_root/project-workdir"
+mkdir -p "$sce1_home/agents" "$sce1_workdir"
+cat >"$sce1_workdir/NEXT-SESSION.md" <<'MD'
+# Handoff
+Read this first.
+MD
+
+sce1_out="$(
+  BRIDGE_HOME="$sce1_home" \
+    BRIDGE_AGENT_WORKDIR="$sce1_workdir" \
+    BRIDGE_AGENT_ID=dyn-test \
+    "$PYTHON" -c "
+import sys
+sys.path.insert(0, '$REPO_ROOT/hooks')
+import bridge_hook_common as bhc
+print(bhc.bootstrap_artifact_context('dyn-test'))
+" 2>&1 || true
+)"
+if [[ "$sce1_out" == *"Handoff present:"* ]]; then
+  pass "C1: explicit BRIDGE_AGENT_WORKDIR surfaces Handoff present"
+else
+  fail "C1: did not surface Handoff present — output: $sce1_out"
+fi
+rm -rf "$sce1_root"
+
+# ----- C2: env unset, roster CLI returns workdir -------------------------
+# Stubs `agent-bridge` via a PATH-prepended script that prints a JSON
+# roster row. The hook discovers the CLI via bridge_script_dir() —
+# which is the parent of the hooks/ dir — so we need to overlay our
+# fake `agent-bridge` next to a copy of bridge_hook_common.py.
+sce2_root="$(mktemp -d -t agb-c2.XXXXXX)"
+sce2_home="$sce2_root/bridge-home"
+sce2_workdir="$sce2_root/project-workdir"
+sce2_overlay="$sce2_root/overlay-source"
+mkdir -p "$sce2_home/agents" "$sce2_workdir" "$sce2_overlay/hooks"
+
+cp "$REPO_ROOT/hooks/bridge_hook_common.py" "$sce2_overlay/hooks/bridge_hook_common.py"
+
+cat >"$sce2_overlay/agent-bridge" <<EOF
+#!/usr/bin/env bash
+# fake agent-bridge for C2 smoke
+if [[ "\$1" == "agent" && "\$2" == "list" && "\$3" == "--json" ]]; then
+  cat <<JSON
+[
+  {"agent":"dyn-c2","engine":"claude","source":"dynamic","workdir":"$sce2_workdir"}
+]
+JSON
+  exit 0
+fi
+echo "fake agent-bridge: unsupported invocation: \$*" >&2
+exit 1
+EOF
+chmod +x "$sce2_overlay/agent-bridge"
+
+cat >"$sce2_workdir/NEXT-SESSION.md" <<'MD'
+# Handoff (C2)
+Read this first.
+MD
+
+sce2_out="$(
+  BRIDGE_HOME="$sce2_home" \
+    BRIDGE_AGENT_ID=dyn-c2 \
+    "$PYTHON" -c "
+import sys
+sys.path.insert(0, '$sce2_overlay/hooks')
+import bridge_hook_common as bhc
+print(bhc.bootstrap_artifact_context('dyn-c2'))
+" 2>&1 || true
+)"
+if [[ "$sce2_out" == *"Handoff present:"* ]]; then
+  pass "C2: env unset, roster CLI fallback surfaces Handoff present"
+else
+  fail "C2: roster CLI fallback did not surface Handoff present — output: $sce2_out"
+fi
+rm -rf "$sce2_root"
+
+# ----- C3: env unset, roster CLI fails (no crash, empty output) ---------
+sce3_root="$(mktemp -d -t agb-c3.XXXXXX)"
+sce3_home="$sce3_root/bridge-home"
+sce3_overlay="$sce3_root/overlay-source"
+mkdir -p "$sce3_home/agents" "$sce3_overlay/hooks"
+
+cp "$REPO_ROOT/hooks/bridge_hook_common.py" "$sce3_overlay/hooks/bridge_hook_common.py"
+
+cat >"$sce3_overlay/agent-bridge" <<'EOF'
+#!/usr/bin/env bash
+# fake agent-bridge that always fails (simulates roster unreachable)
+echo "fake agent-bridge: roster unavailable" >&2
+exit 1
+EOF
+chmod +x "$sce3_overlay/agent-bridge"
+
+# We expect bootstrap_artifact_context to return an empty string (no
+# NEXT-SESSION.md found anywhere) without raising or printing a stack
+# trace. Capture both stdout and stderr; assert no Python traceback.
+sce3_combined="$(
+  BRIDGE_HOME="$sce3_home" \
+    BRIDGE_AGENT_ID=dyn-c3 \
+    "$PYTHON" -c "
+import sys
+sys.path.insert(0, '$sce3_overlay/hooks')
+import bridge_hook_common as bhc
+out = bhc.bootstrap_artifact_context('dyn-c3')
+print(f'OUT={out!r}')
+" 2>&1 || true
+)"
+if [[ "$sce3_combined" == *"OUT=''"* ]] && [[ "$sce3_combined" != *"Traceback"* ]]; then
+  pass "C3: roster CLI failure → empty output, no crash"
+else
+  fail "C3: graceful-fallback contract broken — output: $sce3_combined"
+fi
+rm -rf "$sce3_root"
+
+# ----- Summary -----------------------------------------------------------
+printf '\n[smoke] dynamic-agent-handoff: %d pass, %d fail\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf '[smoke] failing scenarios:\n' >&2
+  for failure in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$failure" >&2
+  done
+  exit 1
+fi
+exit 0

--- a/tests/queue-pending-summary/smoke.sh
+++ b/tests/queue-pending-summary/smoke.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# queue-pending-summary smoke — issue #509 D1 follow-up.
+#
+# Asserts that hooks/bridge_hook_common.queue_summary excludes blocked-state
+# tasks from the `pending` count. The SessionStart hook only nudges with
+# `[Agent Bridge] N pending task(s) … ACTION REQUIRED` when at least one
+# queued or claimed task exists — operator-set blocked-with-reason tasks
+# are waiting on external unblock and must not re-fire the nudge after
+# every `bridge-task update --status blocked`.
+#
+# Cases:
+#   D1a — 1 queued + 1 blocked + 0 claimed → pending=1 (NOT 2)
+#   D1b — 0 queued + 2 blocked + 0 claimed → pending=0 (no nudge, row None)
+#   D1c — 0 queued + 1 blocked + 1 claimed → pending=1
+#
+# Stubs queue_cli via a monkeypatched function in-process so the test does
+# not need a real SQLite queue.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+}
+
+# run_case <queued> <blocked> <claimed> <expected_pending> <expected_row_none: 0|1>
+run_case() {
+  local queued="$1" blocked="$2" claimed="$3" expected_pending="$4" expect_row_none="$5"
+  "$PYTHON" - "$REPO_ROOT" "$queued" "$blocked" "$claimed" "$expected_pending" "$expect_row_none" <<'PY'
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+repo_root, queued, blocked, claimed, expected_pending, expect_row_none = sys.argv[1:7]
+sys.path.insert(0, str(Path(repo_root) / "hooks"))
+
+import bridge_hook_common as bhc
+
+# Stub queue_cli to return canned summary + find-open responses.
+calls = []
+
+class FakeProc:
+    def __init__(self, stdout, returncode=0):
+        self.stdout = stdout
+        self.returncode = returncode
+
+def fake_queue_cli(args):
+    calls.append(list(args))
+    if args[:1] == ["summary"]:
+        row = {
+            "queued_count": int(queued),
+            "blocked_count": int(blocked),
+            "claimed_count": int(claimed),
+        }
+        return FakeProc(json.dumps([row]))
+    if args[:1] == ["find-open"]:
+        # Return a top-priority queued task only when queued > 0; for
+        # claimed-only setups the daemon would still surface a row, so
+        # mirror that.
+        if int(queued) + int(claimed) > 0:
+            return FakeProc(json.dumps({"id": 42, "priority": "normal", "title": "x"}))
+        return FakeProc("")
+    return FakeProc("", returncode=1)
+
+bhc.queue_cli = fake_queue_cli
+
+pending, row = bhc.queue_summary("tester")
+errors = []
+if pending != int(expected_pending):
+    errors.append(f"pending={pending} (expected {expected_pending})")
+if expect_row_none == "1" and row is not None:
+    errors.append(f"row should be None, got {row}")
+if expect_row_none == "0" and pending > 0 and row is None:
+    errors.append("row should be a dict when pending > 0")
+if errors:
+    print("\n".join(errors), file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# D1a — 1 queued + 1 blocked + 0 claimed → pending=1 (blocked excluded)
+if run_case 1 1 0 1 0 2>err.tmp; then
+  pass "D1a: queued=1 blocked=1 claimed=0 → pending=1"
+else
+  fail "D1a: $(cat err.tmp)"
+fi
+
+# D1b — 0 queued + 2 blocked + 0 claimed → pending=0, row None (no nudge)
+if run_case 0 2 0 0 1 2>err.tmp; then
+  pass "D1b: queued=0 blocked=2 claimed=0 → pending=0, no nudge"
+else
+  fail "D1b: $(cat err.tmp)"
+fi
+
+# D1c — 0 queued + 1 blocked + 1 claimed → pending=1 (claimed counts)
+if run_case 0 1 1 1 0 2>err.tmp; then
+  pass "D1c: queued=0 blocked=1 claimed=1 → pending=1"
+else
+  fail "D1c: $(cat err.tmp)"
+fi
+
+rm -f err.tmp
+
+printf '\n[smoke] queue-pending-summary: %d pass, %d fail\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf '[smoke] failing scenarios:\n' >&2
+  for failure in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$failure" >&2
+  done
+  exit 1
+fi
+exit 0

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -452,6 +452,101 @@ else
   fail "scenario 7 (D2d): substring fallback regression — real protected path no longer denied: $sce7d_out"
 fi
 
+# D2e — Bash redirect into hooks/ with unbalanced quote MUST deny.
+# Issue #509 D2 r2 (codex needs-more): the original three-char prefix
+# set `{/,~,$}` missed the `>hooks/` form, so a malformed real write
+# slipped through the fallback. `>` is now in _PATH_PREFIX_CHARS.
+sce7e_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7e",
+  "session_id": "test-session-7e",
+  "tool_input": {
+    "command": "cat >hooks/foo 'unterminated",
+    "description": "redirect into hooks/ with unbalanced quote"
+  }
+}
+JSON
+)
+sce7e_out="$(run_hook_pretool_payload "$sce7e_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7e_out" == *'"deny"'* ]] && [[ "$sce7e_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2e): \`cat >hooks/foo 'unterminated\` denied via expanded prefix set"
+else
+  fail "scenario 7 (D2e): \`>hooks/foo\` not denied — output: $sce7e_out"
+fi
+
+# D2f — Bash redirect into state/cron/ with unbalanced quote MUST deny.
+# Reviewer's second explicit bypass for the original narrow prefix set.
+sce7f_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7f",
+  "session_id": "test-session-7f",
+  "tool_input": {
+    "command": "cat >state/cron/job.json 'unterminated",
+    "description": "redirect into state/cron/ with unbalanced quote"
+  }
+}
+JSON
+)
+sce7f_out="$(run_hook_pretool_payload "$sce7f_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7f_out" == *'"deny"'* ]] && [[ "$sce7f_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2f): \`cat >state/cron/job.json 'unterminated\` denied via expanded prefix set"
+else
+  fail "scenario 7 (D2f): \`>state/cron/job.json\` not denied — output: $sce7f_out"
+fi
+
+# D2g — short needle at start-of-string (idx==0) MUST deny.
+# Without the explicit `idx == 0` short-circuit, `hooks/post.sh ...` at
+# the very start of a malformed command would slip through because the
+# original loop required `idx > 0` and a prefix char before the needle.
+sce7g_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7g",
+  "session_id": "test-session-7g",
+  "tool_input": {
+    "command": "hooks/post.sh some-arg-with-quote'",
+    "description": "short needle at start-of-string with unbalanced quote"
+  }
+}
+JSON
+)
+sce7g_out="$(run_hook_pretool_payload "$sce7g_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7g_out" == *'"deny"'* ]] && [[ "$sce7g_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2g): short needle at start-of-string denied via idx==0 short-circuit"
+else
+  fail "scenario 7 (D2g): start-of-string needle not denied — output: $sce7g_out"
+fi
+
+# D2h — Regression-preserve: heredoc prose with `hooks/post.sh` preceded
+# by a SPACE must still NOT deny. Whitespace is deliberately excluded
+# from the expanded _PATH_PREFIX_CHARS so prose mentions inside heredoc
+# bodies keep passing. Mirrors the existing D2a case but written as an
+# explicit r2 regression-preserve check.
+sce7h_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7h",
+  "session_id": "test-session-7h",
+  "tool_input": {
+    "command": "cat >> .agents/X.md <<'EOF'\nThe chain at hooks/post.sh writes to /tmp.\nEOF",
+    "description": "heredoc prose preserve"
+  }
+}
+JSON
+)
+sce7h_out="$(run_hook_pretool_payload "$sce7h_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7h_out" == *'"deny"'* ]]; then
+  fail "scenario 7 (D2h): heredoc prose `the chain at hooks/post.sh` falsely denied — output: $sce7h_out"
+else
+  pass "scenario 7 (D2h): heredoc prose preceded by whitespace still passes (regression-preserve)"
+fi
+
 # --- Summary -------------------------------------------------------------
 printf '\n[smoke] system-config-gating: %d pass, %d fail\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -350,6 +350,108 @@ else
   fail "scenario 6: roster file was mutated despite deny"
 fi
 
+# --- Scenario 7: tool-policy false positive on .agents/ runtime dir ------
+# Issue #509 D2 follow-up. A heredoc body whose prose contains a generic
+# directory mention like `hooks/post.sh` or `state/cron/` and an
+# unbalanced apostrophe (e.g. "the agent's hook chain at hooks/post.sh")
+# used to trip the substring fallback in `_bash_argv_references_system_config`
+# when shlex.split rejected the unbalanced quote — denying every write
+# to a project-level `.agents/` working directory. The fallback now
+# requires short needles to sit at a strict filesystem-prefix boundary
+# (`/`, `~`, `$`), so prose mentions pass while real path arguments
+# (`/abs/.../hooks/foo`) keep firing.
+
+# D2a — Bash heredoc append to .agents/foo.md MUST NOT be denied.
+sce7_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7a",
+  "session_id": "test-session-7a",
+  "tool_input": {
+    "command": "cat >> .agents/foo.md <<'EOF'\nThe agent's hook chain at hooks/post.sh writes to /tmp.\nEOF",
+    "description": "append handoff"
+  }
+}
+JSON
+)
+sce7_out="$(run_hook_pretool_payload "$sce7_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7_out" == *'"deny"'* ]]; then
+  fail "scenario 7 (D2a): heredoc append to .agents/foo.md falsely denied — output: $sce7_out"
+else
+  pass "scenario 7 (D2a): Bash heredoc append to .agents/foo.md not denied"
+fi
+
+# D2b — Bash echo redirect to .agents/handoff.md MUST NOT be denied.
+sce7b_payload=$(cat <<'JSON'
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7b",
+  "session_id": "test-session-7b",
+  "tool_input": {
+    "command": "echo hi > .agents/handoff.md",
+    "description": "write handoff"
+  }
+}
+JSON
+)
+sce7b_out="$(run_hook_pretool_payload "$sce7b_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7b_out" == *'"deny"'* ]]; then
+  fail "scenario 7 (D2b): echo redirect to .agents/handoff.md falsely denied — output: $sce7b_out"
+else
+  pass "scenario 7 (D2b): Bash echo to .agents/handoff.md not denied"
+fi
+
+# D2c — Edit tool to <workdir>/.agents/handoff.md MUST NOT be denied.
+TMP_WORKDIR="$(mktemp -d -t agb-d2-workdir.XXXXXX)"
+mkdir -p "$TMP_WORKDIR/.agents"
+printf 'placeholder\n' >"$TMP_WORKDIR/.agents/handoff.md"
+sce7c_payload=$(cat <<JSON
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Edit",
+  "tool_use_id": "test-7c",
+  "session_id": "test-session-7c",
+  "tool_input": {
+    "file_path": "$TMP_WORKDIR/.agents/handoff.md",
+    "old_string": "placeholder",
+    "new_string": "updated"
+  }
+}
+JSON
+)
+sce7c_out="$(run_hook_pretool_payload "$sce7c_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7c_out" == *'"deny"'* ]]; then
+  fail "scenario 7 (D2c): Edit on <workdir>/.agents/handoff.md falsely denied — output: $sce7c_out"
+else
+  pass "scenario 7 (D2c): Edit on .agents/handoff.md not denied"
+fi
+rm -rf "$TMP_WORKDIR"
+
+# D2d — Regression: real protected path with unbalanced quote MUST still
+# fire via the substring fallback. The needle here (`.discord/access.json`)
+# is long enough to bypass the path-prefix-boundary requirement.
+sce7d_payload=$(cat <<JSON
+{
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test-7d",
+  "session_id": "test-session-7d",
+  "tool_input": {
+    "command": "sqlite3 $BRIDGE_HOME/agents/$ADMIN_AGENT/.discord/access.json 'SELECT *",
+    "description": "unbalanced quote with real protected path"
+  }
+}
+JSON
+)
+sce7d_out="$(run_hook_pretool_payload "$sce7d_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+if [[ "$sce7d_out" == *'"deny"'* ]] && [[ "$sce7d_out" == *"system config path"* ]]; then
+  pass "scenario 7 (D2d): unbalanced-quote substring fallback still fires on real protected path"
+else
+  fail "scenario 7 (D2d): substring fallback regression — real protected path no longer denied: $sce7d_out"
+fi
+
 # --- Summary -------------------------------------------------------------
 printf '\n[smoke] system-config-gating: %d pass, %d fail\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -542,7 +542,7 @@ JSON
 )
 sce7h_out="$(run_hook_pretool_payload "$sce7h_payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
 if [[ "$sce7h_out" == *'"deny"'* ]]; then
-  fail "scenario 7 (D2h): heredoc prose `the chain at hooks/post.sh` falsely denied — output: $sce7h_out"
+  fail "scenario 7 (D2h): heredoc prose 'the chain at hooks/post.sh' falsely denied — output: $sce7h_out"
 else
   pass "scenario 7 (D2h): heredoc prose preceded by whitespace still passes (regression-preserve)"
 fi


### PR DESCRIPTION
## Summary

Bundles four small follow-up fixes that surfaced from the issue #509 wave handoff:

- **Track C** — `hooks/bridge_hook_common.py:agent_workdir` now falls through to a memoised roster-CLI lookup (`agent-bridge agent list --json`) when neither `BRIDGE_AGENT_WORKDIR` nor the static default home is available. Dynamic claude agents whose workdir is a project directory outside the agent home root no longer drop SessionStart `Handoff present:` emits when the hook is invoked from cron / external surfaces. The runtime-side leg (tmux pane env propagation across re-execs) is intentionally out of scope — `bridge-run.sh` already exports the env on every supervisor restart, so the visible managed-agent regression is closed by the hook-side safety net.
- **Track D1** — `queue_summary` no longer counts `blocked` tasks as `pending`. `blocked` means "waiting on external unblock", not "operator must act now"; admin agents still see blocked-task counts via the existing `admin_blocked_self_cleanup_context` path.
- **Track D2** — the `_bash_argv_references_system_config` substring fallback (used when `shlex.split` fails on an unbalanced quote) now anchors short needles (`hooks/`, `state/cron/`) at a strict filesystem-prefix character (`/`, `~`, `$`). Heredoc bodies that mention these directories in prose with an apostrophe (`the agent's hook chain at hooks/post.sh`) no longer false-positive into a system-config deny on writes to project-level `.agents/` working directories. Longer needles (`.discord/access.json`, `agent-roster.local.sh`, etc.) keep the plain-substring behaviour.
- **Track E** (Fixes #516) — `bridge_claude_settings_mode` now gates the registered-workdir loop on `source=static`. Dynamic claude agents no longer inherit the static-only `autoCompactWindow=400000` shared default. The first branch (workdir within `BRIDGE_AGENT_HOME_ROOT`) is unchanged: anything inside the agent home root is static by construction.

Each track is its own commit so the reviewer can read the diff one fix at a time.

## Test plan

- [x] `bash -n bridge-*.sh agent-bridge agb lib/*.sh scripts/*.sh tests/*/smoke.sh` — clean
- [x] `shellcheck` — clean on every touched .sh file
- [x] `python3 -c "import ast; ast.parse(open(<file>).read())"` — clean on `hooks/bridge_hook_common.py`, `hooks/tool-policy.py`
- [x] `tests/queue-pending-summary/smoke.sh` (D1, 3 cases) — pass
- [x] `tests/dynamic-agent-handoff/smoke.sh` (C, 3 cases) — pass
- [x] `tests/system-config-gating/smoke.sh` (D2 extension + regression, 19 cases total) — pass
- [x] `scripts/smoke/hooks.sh` (E gate + existing 5 cases) — pass
- [x] `scripts/smoke/upgrade-shared-settings-propagate.sh` — pass
- [x] `./scripts/smoke-test.sh` — same pre-existing failure on `c245bfc` baseline (`refusing to write isolated agent-env.sh from ephemeral controller path`); unrelated to this PR

## Out of scope

VERSION bump and CHANGELOG entry are deferred to the v0.7.3 release bundle PR. Track C runtime-side leg (manual-relaunch / external-invocation env propagation audit) deferred — the hook-side safety net closes the visible regression and the runtime audit needs broader review surface than fits this small-fix bundle.

Fixes #516.