### PR TITLE
feat(doctor): read-only stuck-state detector CLI (#511)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -238,6 +238,7 @@ agb status
 agb status --watch
 agb summary
 agb list
+agb doctor [--json]                # surface stuck-state signals (read-only) for admin self-healing recipes (#511)
 agb cron inventory --limit 20
 agb cron inventory --mode one-shot --limit 20
 agb cron list --agent <agent>

--- a/agent-bridge
+++ b/agent-bridge
@@ -54,6 +54,7 @@ Usage:
   $CLI_NAME user <set|show> ...
   $CLI_NAME guard <status|scan|sanitize> ...
   $CLI_NAME diagnose <acl> [--json]
+  $CLI_NAME doctor [--json] [--detectors <kind[,kind...]>] [--state-dir <path>] [--task-db <path>]
   $CLI_NAME knowledge <init|operator|capture|promote|search|lint> ...
   $CLI_NAME skills <list> [--agent <name>] [--json]
   $CLI_NAME config <set|get|list-protected> ...
@@ -599,6 +600,11 @@ PY
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-diagnose.sh" "$@"
       ;;
+    doctor)
+      shift
+      bridge_require_python
+      exec python3 "$SCRIPT_DIR/bridge-doctor.py" "$@"
+      ;;
     knowledge)
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-knowledge.sh" "$@"
@@ -770,7 +776,7 @@ PY
   # sqlite3 fallback path. Reject with an intent-recovery suggestion
   # before the spawn parser sees it.
   if [[ -n "${1:-}" && "${1:0:1}" != "-" ]]; then
-    _top_valid="admin bootstrap init version upgrade escalate upstream review user guard diagnose knowledge config bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
+    _top_valid="admin bootstrap init version upgrade escalate upstream review user guard diagnose doctor knowledge config bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
     _hint="$(bridge_suggest_subcommand "$1" "$_top_valid")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 명령입니다: $1"

--- a/bridge-doctor.py
+++ b/bridge-doctor.py
@@ -1,0 +1,669 @@
+#!/usr/bin/env python3
+"""bridge-doctor.py — read-only stuck-state detectors for admin self-healing (#511).
+
+Surfaces cross-cutting "agent stuck" signals so an admin agent (e.g. `patch`)
+can call existing primitives (agent restart, task update) to self-heal. Does
+NOT execute any action; `suggested_action` is a string hint only.
+
+Detectors:
+
+- stale-stopped-with-queue : state=stopped AND loop_enabled AND (queued>0 OR blocked>0)
+- stale-blocked-task       : task.status=blocked AND task.claimed_by.activity_state=idle
+                             AND lease_age > BRIDGE_DOCTOR_BLOCKED_THRESHOLD_SECONDS (default 24h)
+- cold-restart-suspect     : agent has fresh session_id but prior jsonl still on disk (#167)
+- abnormal-session-pane    : tmux pane scrollback matches login/trust/blocker UI patterns
+                             (placeholder — emits detector-error until pattern reuse from
+                             bridge-stall.py is factored cleanly; see PR notes)
+
+Read-only contract: the CLI never mutates queue/state/tmux. `suggested_action`
+is a string the admin agent LLM parses and decides whether to execute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import signal
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DETECTOR_KINDS = (
+    "stale-stopped-with-queue",
+    "stale-blocked-task",
+    "cold-restart-suspect",
+    "abnormal-session-pane",
+)
+
+
+def iso_now() -> str:
+    return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
+
+
+def now_ts() -> int:
+    return int(datetime.now(timezone.utc).timestamp())
+
+
+def resolve_state_dir(arg_value: str | None) -> Path:
+    if arg_value:
+        return Path(arg_value).expanduser()
+    explicit = os.environ.get("BRIDGE_STATE_DIR", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    home = os.environ.get("BRIDGE_HOME", "").strip()
+    base = Path(home).expanduser() if home else (Path.home() / ".agent-bridge")
+    return base / "state"
+
+
+def resolve_task_db(arg_value: str | None, state_dir: Path) -> Path:
+    if arg_value:
+        return Path(arg_value).expanduser()
+    explicit = os.environ.get("BRIDGE_TASK_DB", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    return state_dir / "tasks.db"
+
+
+def parse_detectors(value: str) -> list[str]:
+    if not value:
+        return list(DETECTOR_KINDS)
+    requested = [item.strip() for item in value.split(",") if item.strip()]
+    invalid = [k for k in requested if k not in DETECTOR_KINDS]
+    if invalid:
+        raise SystemExit(f"unknown detector kind(s): {', '.join(invalid)}")
+    return requested
+
+
+def load_agent_list(args: argparse.Namespace) -> list[dict[str, Any]]:
+    """Load the roster snapshot via `agent-bridge agent list --json`.
+
+    Tests inject `--agent-list-json <file>` to skip the subprocess. Live
+    invocations reuse the existing CLI so the doctor never duplicates the
+    bash-side roster loader.
+    """
+    if args.agent_list_json:
+        path = Path(args.agent_list_json).expanduser()
+        if not path.is_file():
+            raise SystemExit(f"--agent-list-json file not found: {path}")
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, list):
+            raise SystemExit("--agent-list-json must contain a JSON array")
+        return data
+
+    binary = args.agent_bridge or os.environ.get("BRIDGE_AGENT_BRIDGE_BIN", "").strip()
+    if not binary:
+        # Default: sibling to this script.
+        sibling = Path(__file__).resolve().parent / "agent-bridge"
+        if sibling.is_file():
+            binary = str(sibling)
+        else:
+            located = shutil.which("agent-bridge")
+            if not located:
+                raise SystemExit(
+                    "agent-bridge binary not found; pass --agent-bridge or "
+                    "--agent-list-json"
+                )
+            binary = located
+
+    try:
+        proc = subprocess.run(
+            [binary, "agent", "list", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"agent-bridge agent list --json failed (rc={exc.returncode}): "
+            f"{(exc.stderr or '').strip()}"
+        ) from exc
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"agent-bridge agent list --json: invalid JSON ({exc})") from exc
+    if not isinstance(data, list):
+        raise SystemExit("agent-bridge agent list --json: expected JSON array")
+    return data
+
+
+def db_connect_readonly(path: Path) -> sqlite3.Connection | None:
+    if not path.is_file():
+        return None
+    # Open in read-only URI mode so a buggy doctor can never mutate state.
+    uri = f"file:{path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def fetch_agent_state(conn: sqlite3.Connection | None) -> dict[str, dict[str, Any]]:
+    if conn is None:
+        return {}
+    rows: dict[str, dict[str, Any]] = {}
+    try:
+        for row in conn.execute(
+            "SELECT agent, session_activity_ts, last_seen_ts, last_heartbeat_ts, "
+            "session, engine, workdir FROM agent_state"
+        ):
+            rows[str(row["agent"])] = {
+                "session_activity_ts": row["session_activity_ts"],
+                "last_seen_ts": row["last_seen_ts"],
+                "last_heartbeat_ts": row["last_heartbeat_ts"],
+                "session": row["session"] or "",
+                "engine": row["engine"] or "",
+                "workdir": row["workdir"] or "",
+            }
+    except sqlite3.OperationalError:
+        return {}
+    return rows
+
+
+def fetch_blocked_tasks(conn: sqlite3.Connection | None) -> list[dict[str, Any]]:
+    if conn is None:
+        return []
+    out: list[dict[str, Any]] = []
+    try:
+        for row in conn.execute(
+            "SELECT id, claimed_by, assigned_to, status, updated_ts, claimed_ts, title "
+            "FROM tasks WHERE status='blocked'"
+        ):
+            out.append(
+                {
+                    "id": int(row["id"]),
+                    "claimed_by": str(row["claimed_by"] or ""),
+                    "assigned_to": str(row["assigned_to"] or ""),
+                    "updated_ts": int(row["updated_ts"] or 0),
+                    "claimed_ts": int(row["claimed_ts"] or 0),
+                    "title": str(row["title"] or ""),
+                }
+            )
+    except sqlite3.OperationalError:
+        return []
+    return out
+
+
+# --- detectors -------------------------------------------------------------
+
+
+def detect_stale_stopped_with_queue(
+    agents: list[dict[str, Any]],
+    agent_state: dict[str, dict[str, Any]],
+    ts: str,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    now = now_ts()
+    for agent in agents:
+        name = str(agent.get("agent") or "")
+        if not name:
+            continue
+        active = bool(agent.get("active"))
+        activity_state = str(agent.get("activity_state") or "")
+        loop_value = agent.get("loop")
+        try:
+            loop_enabled = int(loop_value) == 1
+        except (TypeError, ValueError):
+            loop_enabled = str(loop_value).strip() == "1"
+        # `state=stopped` per the issue spec means the dashboard's stopped
+        # state, which corresponds to active=False (no live tmux session).
+        # `activity_state` is "stopped" in the same case for the snapshot
+        # writer, but `agent list --json` only emits one of idle/working
+        # for active agents — the dashboard derives "stopped" from active=0
+        # (lib/bridge-state.sh:2872). Treat either signal as authoritative.
+        is_stopped = (not active) or activity_state == "stopped"
+        if not is_stopped or not loop_enabled:
+            continue
+        queue = agent.get("queue") or {}
+        queued = int(queue.get("queued") or 0)
+        blocked = int(queue.get("blocked") or 0)
+        if queued <= 0 and blocked <= 0:
+            continue
+        state_row = agent_state.get(name, {})
+        activity_ts = state_row.get("session_activity_ts") or state_row.get("last_seen_ts") or 0
+        wake_stale = max(0, now - int(activity_ts)) if activity_ts else 0
+        # tmux_alive is best-effort; if the source CLI says active=False the
+        # tmux session is gone. Mirror that signal — admin agent can re-check.
+        tmux_alive = bool(active)
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "stale-stopped-with-queue",
+                "agent": name,
+                "evidence": {
+                    "loop_enabled": loop_enabled,
+                    "tmux_alive": tmux_alive,
+                    "queued": queued,
+                    "blocked": blocked,
+                    "wake_stale_seconds": int(wake_stale),
+                },
+                "suggested_action": f"agent-bridge agent restart {name}",
+            }
+        )
+    return findings
+
+
+def detect_stale_blocked_task(
+    agents: list[dict[str, Any]],
+    blocked_tasks: list[dict[str, Any]],
+    threshold_seconds: int,
+    ts: str,
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    now = now_ts()
+    by_name: dict[str, dict[str, Any]] = {
+        str(agent.get("agent") or ""): agent for agent in agents if agent.get("agent")
+    }
+    for task in blocked_tasks:
+        claimed_by = task["claimed_by"]
+        if not claimed_by:
+            continue
+        owner = by_name.get(claimed_by) or {}
+        owner_state = str(owner.get("activity_state") or "")
+        # Spec: only emit when the claimer is `idle`. `stopped` agents are a
+        # different recovery path (covered by stale-stopped-with-queue or by
+        # admin escalation). `working` means the claimer is actively making
+        # progress; the blocked task may legitimately be parked while the
+        # claimer works on something else.
+        if owner_state != "idle":
+            continue
+        updated_ts = int(task["updated_ts"] or 0)
+        blocked_age = max(0, now - updated_ts) if updated_ts else 0
+        if blocked_age < threshold_seconds:
+            continue
+        last_update = blocked_age  # `updated_ts` is the last status change
+        suggested = f"agent-bridge update {task['id']} --status queued"
+        if blocked_age > 7 * 86400:
+            suggested = (
+                f"agent-bridge update {task['id']} --status queued "
+                "(escalate to operator — blocked >7d)"
+            )
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "stale-blocked-task",
+                "agent": claimed_by,
+                "evidence": {
+                    "task_id": int(task["id"]),
+                    "claimed_by": claimed_by,
+                    "claimed_by_activity_state": owner_state,
+                    "blocked_age_seconds": int(blocked_age),
+                    "last_update_seconds": int(last_update),
+                },
+                "suggested_action": suggested,
+            }
+        )
+    return findings
+
+
+def workdir_slug_candidates(workdir: str) -> list[str]:
+    """Mirror lib/bridge-state.sh workdir_slug_candidates() — the slug
+    transformer Claude Code itself uses to pick `~/.claude/projects/<slug>/`.
+    """
+    if not workdir:
+        return []
+    slash_only = workdir.replace("/", "-")
+    slash_and_dot = re.sub(r"[/.]", "-", workdir)
+    candidates = [slash_only]
+    if slash_and_dot != slash_only:
+        candidates.append(slash_and_dot)
+    return candidates
+
+
+def detect_cold_restart_suspect(
+    agents: list[dict[str, Any]],
+    ts: str,
+    projects_root: Path,
+) -> list[dict[str, Any]]:
+    """Best-effort: emit only when we are confident.
+
+    Heuristic: the agent's current session has its own jsonl AND there is at
+    least one prior jsonl in the same workdir-slug directory whose mtime is
+    fresh (within the last 7 days) and whose stem differs from the active
+    session_id. The 7d window keeps long-archived transcripts from triggering
+    false positives.
+    """
+    findings: list[dict[str, Any]] = []
+    if not projects_root.is_dir():
+        return findings
+    now = now_ts()
+    fresh_window = 7 * 86400
+    for agent in agents:
+        if str(agent.get("engine") or "") != "claude":
+            continue
+        if not agent.get("active"):
+            continue
+        name = str(agent.get("agent") or "")
+        current_sid = str(agent.get("session_id") or "")
+        workdir = str(agent.get("workdir") or "")
+        if not name or not current_sid or not workdir:
+            continue
+        candidates = workdir_slug_candidates(workdir)
+        prior: tuple[str, str, int] | None = None
+        current_present = False
+        for slug in candidates:
+            slug_dir = projects_root / slug
+            if not slug_dir.is_dir():
+                continue
+            try:
+                entries = list(slug_dir.iterdir())
+            except OSError:
+                continue
+            for entry in entries:
+                if entry.suffix != ".jsonl":
+                    continue
+                stem = entry.stem
+                if not stem:
+                    continue
+                try:
+                    mtime = int(entry.stat().st_mtime)
+                except OSError:
+                    continue
+                if stem == current_sid:
+                    current_present = True
+                    continue
+                age = now - mtime
+                if age < 0 or age > fresh_window:
+                    continue
+                if prior is None or mtime > prior[2]:
+                    prior = (stem, str(entry), mtime)
+        if not current_present or prior is None:
+            continue
+        prior_sid, prior_path, prior_mtime = prior
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "cold-restart-suspect",
+                "agent": name,
+                "evidence": {
+                    "current_session_id": current_sid,
+                    "previous_session_id": prior_sid,
+                    "prior_jsonl_path": prior_path,
+                    "prior_jsonl_age_seconds": int(max(0, now - prior_mtime)),
+                },
+                "suggested_action": (
+                    f"agent-bridge agent restart {name} --no-continue"
+                ),
+            }
+        )
+    return findings
+
+
+def detect_abnormal_session_pane(ts: str, explicit: bool) -> list[dict[str, Any]]:
+    """Placeholder — best-effort detector that is not yet implemented.
+
+    The pane-pattern set lives in bridge-stall.py and is tuned for the
+    daemon's stall classifier. Reusing those patterns for an admin-facing
+    detector would require either importing from a non-package script or
+    extracting them into a shared module — both are larger than the spec's
+    "smallest read-only CLI" scope. The brief explicitly authorizes shipping
+    this detector as a placeholder so the other three deliver primary value
+    now; a follow-up can lift the patterns when an operator hits the case.
+
+    When the default detector set runs, this returns []: a healthy host
+    should see an empty findings list, not a detector-error row that the
+    admin agent must learn to ignore. When the operator explicitly opts in
+    via `--detectors abnormal-session-pane`, we surface the
+    not-yet-implemented gap as a detector-error so the request is not
+    silently swallowed.
+    """
+    if not explicit:
+        return []
+    return [
+        {
+            "ts": ts,
+            "kind": "detector-error",
+            "agent": "",
+            "evidence": {
+                "detector": "abnormal-session-pane",
+                "error": "abnormal-session-pane detector not implemented",
+            },
+            "suggested_action": "",
+        }
+    ]
+
+
+# --- rendering -------------------------------------------------------------
+
+
+def render_table(findings: list[dict[str, Any]]) -> str:
+    if not findings:
+        return "No stuck-state signals detected."
+    lines: list[str] = []
+    lines.append("kind                       agent           evidence")
+    for finding in findings:
+        kind = str(finding.get("kind") or "")
+        agent = str(finding.get("agent") or "") or "-"
+        evidence = finding.get("evidence") or {}
+        if isinstance(evidence, dict):
+            ev_str = " ".join(f"{k}={v}" for k, v in evidence.items())
+        else:
+            ev_str = str(evidence)
+        lines.append(f"{kind:<26} {agent:<15} {ev_str}")
+        suggested = str(finding.get("suggested_action") or "")
+        if suggested:
+            lines.append(f"  suggested: {suggested}")
+    return "\n".join(lines)
+
+
+# --- main ------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="bridge-doctor.py",
+        description=(
+            "Read-only stuck-state detectors for admin self-healing. "
+            "Findings are hints; daemon does not act on them."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON list of findings.")
+    parser.add_argument(
+        "--state-dir",
+        default=None,
+        help="Override BRIDGE_STATE_DIR (default: env / $BRIDGE_HOME/state / ~/.agent-bridge/state).",
+    )
+    parser.add_argument(
+        "--task-db",
+        default=None,
+        help="Override BRIDGE_TASK_DB (default: env / <state-dir>/tasks.db).",
+    )
+    parser.add_argument(
+        "--detectors",
+        default="",
+        help=(
+            "Comma-separated allow-list of detector kinds. Default: all four. "
+            f"Valid: {','.join(DETECTOR_KINDS)}."
+        ),
+    )
+    parser.add_argument(
+        "--agent-list-json",
+        default=None,
+        help=(
+            "Path to a JSON file with `agent-bridge agent list --json` output. "
+            "Used by tests to skip the subprocess."
+        ),
+    )
+    parser.add_argument(
+        "--agent-bridge",
+        default=None,
+        help="Path to the agent-bridge binary (default: sibling to this script).",
+    )
+    parser.add_argument(
+        "--projects-root",
+        default=None,
+        help=(
+            "Override the Claude transcripts root for cold-restart-suspect "
+            "(default: ~/.claude/projects)."
+        ),
+    )
+    args = parser.parse_args()
+
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    enabled = parse_detectors(args.detectors)
+    state_dir = resolve_state_dir(args.state_dir)
+    task_db = resolve_task_db(args.task_db, state_dir)
+    projects_root = (
+        Path(args.projects_root).expanduser()
+        if args.projects_root
+        else (Path.home() / ".claude" / "projects")
+    )
+
+    threshold_env = os.environ.get("BRIDGE_DOCTOR_BLOCKED_THRESHOLD_SECONDS", "").strip()
+    try:
+        blocked_threshold = int(threshold_env) if threshold_env else 86400
+    except ValueError:
+        blocked_threshold = 86400
+    if blocked_threshold < 0:
+        blocked_threshold = 86400
+
+    ts = iso_now()
+    findings: list[dict[str, Any]] = []
+
+    # Each detector runs inside its own try/except so an internal exception
+    # in one does not crash the whole CLI.
+    try:
+        agents = load_agent_list(args)
+    except SystemExit:
+        # Roster load failure is fatal — no detector can run without it.
+        # Emit a single detector-error and exit 0 so the admin agent still
+        # gets a parseable response.
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "detector-error",
+                "agent": "",
+                "evidence": {
+                    "detector": "roster",
+                    "error": "agent list unavailable",
+                },
+                "suggested_action": "",
+            }
+        )
+        agents = []
+
+    conn = None
+    try:
+        conn = db_connect_readonly(task_db)
+    except sqlite3.OperationalError as exc:
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "detector-error",
+                "agent": "",
+                "evidence": {
+                    "detector": "task-db",
+                    "error": f"sqlite open failed: {exc}",
+                },
+                "suggested_action": "",
+            }
+        )
+
+    try:
+        agent_state = fetch_agent_state(conn)
+    except Exception as exc:  # noqa: BLE001 — detector boundary
+        agent_state = {}
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "detector-error",
+                "agent": "",
+                "evidence": {
+                    "detector": "agent_state",
+                    "error": str(exc),
+                },
+                "suggested_action": "",
+            }
+        )
+
+    try:
+        blocked_tasks = fetch_blocked_tasks(conn)
+    except Exception as exc:  # noqa: BLE001 — detector boundary
+        blocked_tasks = []
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "detector-error",
+                "agent": "",
+                "evidence": {
+                    "detector": "tasks",
+                    "error": str(exc),
+                },
+                "suggested_action": "",
+            }
+        )
+
+    if conn is not None:
+        conn.close()
+
+    abnormal_explicit = bool(args.detectors)
+    detector_runs: list[tuple[str, Any]] = [
+        (
+            "stale-stopped-with-queue",
+            lambda: detect_stale_stopped_with_queue(agents, agent_state, ts),
+        ),
+        (
+            "stale-blocked-task",
+            lambda: detect_stale_blocked_task(agents, blocked_tasks, blocked_threshold, ts),
+        ),
+        (
+            "cold-restart-suspect",
+            lambda: detect_cold_restart_suspect(agents, ts, projects_root),
+        ),
+        (
+            "abnormal-session-pane",
+            lambda: detect_abnormal_session_pane(ts, abnormal_explicit),
+        ),
+    ]
+
+    enabled_set = set(enabled)
+    for kind, runner in detector_runs:
+        if kind not in enabled_set:
+            continue
+        try:
+            findings.extend(runner())
+        except Exception as exc:  # noqa: BLE001 — detector boundary, spec-mandated
+            findings.append(
+                {
+                    "ts": ts,
+                    "kind": "detector-error",
+                    "agent": "",
+                    "evidence": {
+                        "detector": kind,
+                        "error": str(exc),
+                    },
+                    "suggested_action": "",
+                }
+            )
+
+    # `--detectors` is also an allow-list against detector-error rows so the
+    # admin agent can isolate one detector cleanly (D5 in the smoke matrix).
+    if args.detectors:
+        kept: list[dict[str, Any]] = []
+        for finding in findings:
+            kind = finding.get("kind")
+            if kind in enabled_set:
+                kept.append(finding)
+                continue
+            if kind == "detector-error":
+                evidence = finding.get("evidence") or {}
+                if isinstance(evidence, dict) and evidence.get("detector") in enabled_set:
+                    kept.append(finding)
+        findings = kept
+
+    if args.json:
+        print(json.dumps(findings, ensure_ascii=False, indent=2))
+    else:
+        print(render_table(findings))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agb-doctor/_assert.py
+++ b/tests/agb-doctor/_assert.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Named JSON predicates for tests/agb-doctor/smoke.sh.
+
+Each subcommand reads the doctor's `--json` payload from argv[2] and exits 0
+on pass / non-zero on fail. Smoke uses bash `if`-tests against the exit code
+and prints its own pass/fail line, so this helper deliberately stays silent
+on success and writes a one-line reason to stderr on failure.
+
+Predicates are kept as tiny named functions so the smoke harness never has
+to expand a test-controlled string into Python code. Each predicate has a
+fixed argv schema documented in its docstring.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+REQUIRED_STALE_STOPPED_EVIDENCE = {
+    "loop_enabled",
+    "tmux_alive",
+    "queued",
+    "blocked",
+    "wake_stale_seconds",
+}
+
+
+def _load(payload: str) -> list[dict[str, Any]]:
+    return json.loads(payload)
+
+
+def empty(payload: str, _args: list[str]) -> bool:
+    findings = _load(payload)
+    if findings != []:
+        print(f"expected [], got {len(findings)} findings", file=sys.stderr)
+        return False
+    return True
+
+
+def stale_stopped_emitted(payload: str, args: list[str]) -> bool:
+    if not args:
+        print("stale_stopped_emitted requires <agent-name>", file=sys.stderr)
+        return False
+    agent = args[0]
+    findings = _load(payload)
+    matches = [
+        f for f in findings
+        if f.get("kind") == "stale-stopped-with-queue" and f.get("agent") == agent
+    ]
+    if len(matches) != 1:
+        print(
+            f"expected exactly 1 stale-stopped-with-queue for {agent!r}, "
+            f"got {len(matches)} (kinds={[f.get('kind') for f in findings]})",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def stale_stopped_evidence_shape(payload: str, _args: list[str]) -> bool:
+    findings = _load(payload)
+    target = next(
+        (f for f in findings if f.get("kind") == "stale-stopped-with-queue"),
+        None,
+    )
+    if target is None:
+        print("no stale-stopped-with-queue finding present", file=sys.stderr)
+        return False
+    evidence = target.get("evidence") or {}
+    keys = set(evidence.keys()) if isinstance(evidence, dict) else set()
+    if keys != REQUIRED_STALE_STOPPED_EVIDENCE:
+        print(
+            f"evidence keys {sorted(keys)} != spec {sorted(REQUIRED_STALE_STOPPED_EVIDENCE)}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def suggested_action_equals(payload: str, args: list[str]) -> bool:
+    if len(args) < 2:
+        print("suggested_action_equals requires <kind> <expected>", file=sys.stderr)
+        return False
+    kind, expected = args[0], args[1]
+    findings = _load(payload)
+    target = next((f for f in findings if f.get("kind") == kind), None)
+    if target is None:
+        print(f"no finding of kind {kind!r}", file=sys.stderr)
+        return False
+    if target.get("suggested_action") != expected:
+        print(
+            f"suggested_action {target.get('suggested_action')!r} != {expected!r}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def kind_absent(payload: str, args: list[str]) -> bool:
+    if not args:
+        print("kind_absent requires <kind>", file=sys.stderr)
+        return False
+    kind = args[0]
+    findings = _load(payload)
+    leaks = [f for f in findings if f.get("kind") == kind]
+    if leaks:
+        print(f"unexpected {kind!r} findings present: {len(leaks)}", file=sys.stderr)
+        return False
+    return True
+
+
+def stale_blocked_task_id(payload: str, args: list[str]) -> bool:
+    if not args:
+        print("stale_blocked_task_id requires <task-id>", file=sys.stderr)
+        return False
+    try:
+        task_id = int(args[0])
+    except ValueError:
+        print(f"task-id {args[0]!r} is not an int", file=sys.stderr)
+        return False
+    findings = _load(payload)
+    matches = [
+        f for f in findings
+        if f.get("kind") == "stale-blocked-task"
+        and isinstance(f.get("evidence"), dict)
+        and f["evidence"].get("task_id") == task_id
+    ]
+    if not matches:
+        print(
+            f"no stale-blocked-task finding for task_id={task_id}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def stale_blocked_suggested_prefix(payload: str, args: list[str]) -> bool:
+    if not args:
+        print("stale_blocked_suggested_prefix requires <prefix>", file=sys.stderr)
+        return False
+    prefix = args[0]
+    findings = _load(payload)
+    target = next(
+        (f for f in findings if f.get("kind") == "stale-blocked-task"),
+        None,
+    )
+    if target is None:
+        print("no stale-blocked-task finding present", file=sys.stderr)
+        return False
+    if not str(target.get("suggested_action") or "").startswith(prefix):
+        print(
+            f"suggested_action {target.get('suggested_action')!r} "
+            f"does not start with {prefix!r}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def abnormal_pane_placeholder(payload: str, _args: list[str]) -> bool:
+    findings = _load(payload)
+    if len(findings) != 1:
+        print(f"expected exactly 1 finding, got {len(findings)}", file=sys.stderr)
+        return False
+    target = findings[0]
+    if target.get("kind") != "detector-error":
+        print(f"expected kind=detector-error, got {target.get('kind')}", file=sys.stderr)
+        return False
+    evidence = target.get("evidence") or {}
+    if not isinstance(evidence, dict):
+        print("evidence missing/not-dict", file=sys.stderr)
+        return False
+    if evidence.get("detector") != "abnormal-session-pane":
+        print(
+            f"expected detector=abnormal-session-pane, got {evidence.get('detector')}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def kinds_superset(payload: str, args: list[str]) -> bool:
+    expected = set(args)
+    if not expected:
+        print("kinds_superset requires at least one kind arg", file=sys.stderr)
+        return False
+    findings = _load(payload)
+    actual = {f.get("kind") for f in findings}
+    missing = expected - actual
+    if missing:
+        print(
+            f"missing kinds: {sorted(missing)} (got {sorted(actual)})",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+def only_kind(payload: str, args: list[str]) -> bool:
+    if not args:
+        print("only_kind requires <kind>", file=sys.stderr)
+        return False
+    kind = args[0]
+    findings = _load(payload)
+    if not findings:
+        print("no findings — expected at least one", file=sys.stderr)
+        return False
+    bad = [f for f in findings if f.get("kind") != kind]
+    if bad:
+        print(
+            f"unexpected non-{kind} findings: {[f.get('kind') for f in bad]}",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
+CHECKS = {
+    "empty": empty,
+    "stale_stopped_emitted": stale_stopped_emitted,
+    "stale_stopped_evidence_shape": stale_stopped_evidence_shape,
+    "suggested_action_equals": suggested_action_equals,
+    "kind_absent": kind_absent,
+    "stale_blocked_task_id": stale_blocked_task_id,
+    "stale_blocked_suggested_prefix": stale_blocked_suggested_prefix,
+    "abnormal_pane_placeholder": abnormal_pane_placeholder,
+    "kinds_superset": kinds_superset,
+    "only_kind": only_kind,
+}
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: _assert.py <check> <payload-json> [args...]", file=sys.stderr)
+        return 2
+    check = sys.argv[1]
+    payload = sys.argv[2]
+    args = sys.argv[3:]
+    fn = CHECKS.get(check)
+    if fn is None:
+        print(f"unknown check: {check!r} (valid: {sorted(CHECKS)})", file=sys.stderr)
+        return 2
+    return 0 if fn(payload, args) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agb-doctor/smoke.sh
+++ b/tests/agb-doctor/smoke.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# agb-doctor smoke — issue #511 read-only stuck-state detector CLI.
+#
+# Exercises the four detectors via fixture roster JSON (so the test does not
+# depend on a live agent-bridge binary or roster) plus a hand-built sqlite
+# tasks.db. Every case is independent: each scenario builds its own fixture
+# directory, invokes `bridge-doctor.py --json`, and asserts the resulting
+# finding list shape against the issue spec.
+#
+# Cases (mirroring the brief's test plan):
+#
+#   D1a  empty state                          -> []
+#   D1b  one stale-stopped-with-queue agent   -> 1 finding, evidence shape
+#   D1c  loop=0 (disabled)                    -> 0 findings (loop required)
+#   D1d  queued=0 AND blocked=0               -> 0 findings (backlog required)
+#   D2a  blocked task aged 25h, owner idle    -> stale-blocked-task finding
+#   D2b  blocked task aged 1h                 -> 0 findings
+#   D2c  blocked task aged 25h, owner working -> 0 findings (only idle)
+#   D2d  threshold env override (3600s) +     -> stale-blocked-task finding
+#        90-min-old blocked task
+#   D4   abnormal-session-pane (placeholder)  -> exactly one detector-error
+#                                               row; never a hard crash
+#   D5   --detectors stale-blocked-task       -> only that kind survives
+#   D6   daemon-level finding (agent="")      -> renders cleanly in table
+#
+# Uses an isolated mktemp BRIDGE_HOME — never touches the live install.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+DOCTOR="$REPO_ROOT/bridge-doctor.py"
+ASSERT_HELPER="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/_assert.py"
+
+if [[ ! -x "$PYTHON" && ! -r "$PYTHON" ]]; then
+  printf '[smoke][error] python3 not found at %s\n' "$PYTHON" >&2
+  exit 2
+fi
+if [[ ! -f "$DOCTOR" ]]; then
+  printf '[smoke][error] bridge-doctor.py not found at %s\n' "$DOCTOR" >&2
+  exit 2
+fi
+if [[ ! -f "$ASSERT_HELPER" ]]; then
+  printf '[smoke][error] _assert.py helper missing alongside smoke.sh\n' >&2
+  exit 2
+fi
+
+ROOT="$(mktemp -d -t agb-doctor-smoke.XXXXXX)"
+trap 'rm -rf "$ROOT"' EXIT
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+}
+
+# init_db <path>
+# Build an empty queue DB matching bridge-queue.py init_db().
+init_db() {
+  local db="$1"
+  "$PYTHON" - "$db" <<'PY'
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+conn.executescript("""
+CREATE TABLE tasks (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  title TEXT NOT NULL,
+  assigned_to TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  priority TEXT NOT NULL DEFAULT 'normal',
+  status TEXT NOT NULL DEFAULT 'queued',
+  created_ts INTEGER NOT NULL,
+  updated_ts INTEGER NOT NULL,
+  body_text TEXT,
+  body_path TEXT,
+  claimed_by TEXT,
+  claimed_ts INTEGER,
+  lease_until_ts INTEGER,
+  closed_ts INTEGER
+);
+CREATE TABLE agent_state (
+  agent TEXT PRIMARY KEY,
+  engine TEXT,
+  session TEXT,
+  workdir TEXT,
+  active INTEGER NOT NULL DEFAULT 0,
+  last_seen_ts INTEGER,
+  last_heartbeat_ts INTEGER,
+  session_activity_ts INTEGER,
+  last_nudge_ts INTEGER,
+  last_nudge_key TEXT,
+  nudge_fail_count INTEGER NOT NULL DEFAULT 0,
+  zombie INTEGER NOT NULL DEFAULT 0
+);
+""")
+conn.commit()
+conn.close()
+PY
+}
+
+# write_roster <path> <json>
+write_roster() {
+  printf '%s\n' "$2" >"$1"
+}
+
+# insert_task <db> <id> <assigned_to> <claimed_by> <status> <updated_ts>
+insert_task() {
+  local db="$1" tid="$2" assigned="$3" owner="$4" status="$5" updated="$6"
+  "$PYTHON" - "$db" "$tid" "$assigned" "$owner" "$status" "$updated" <<'PY'
+import sqlite3, sys
+db, tid, assigned, owner, status, updated = sys.argv[1:7]
+conn = sqlite3.connect(db)
+conn.execute(
+    "INSERT INTO tasks (id, title, assigned_to, created_by, status, "
+    "created_ts, updated_ts, claimed_by, claimed_ts) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    (
+        int(tid),
+        f"smoke task {tid}",
+        assigned,
+        "smoke",
+        status,
+        int(updated),
+        int(updated),
+        owner or None,
+        int(updated) if owner else None,
+    ),
+)
+conn.commit()
+conn.close()
+PY
+}
+
+# run_doctor <case-dir> <extra args...>
+run_doctor() {
+  local dir="$1"
+  shift
+  local roster="$dir/agents.json"
+  local db="$dir/tasks.db"
+  "$PYTHON" "$DOCTOR" \
+    --json \
+    --agent-list-json "$roster" \
+    --task-db "$db" \
+    --projects-root "$dir/no-such-claude-projects" \
+    "$@"
+}
+
+# json_assert <payload-string> <check-name> <case-label> [extra args]
+# `check-name` is one of the named predicates in tests/agb-doctor/_assert.py.
+# Extra args after the label are forwarded to the helper.
+json_assert() {
+  local payload="$1"
+  local check="$2"
+  local label="$3"
+  shift 3
+  if "$PYTHON" "$ASSERT_HELPER" "$check" "$payload" "$@" >/dev/null 2>&1; then
+    pass "$label"
+  else
+    fail "$label — payload=$payload check=$check args=$*"
+  fi
+}
+
+NOW="$("$PYTHON" -c 'import time; print(int(time.time()))')"
+
+# --- D1a: empty state ---------------------------------------------------
+D1a="$ROOT/d1a"
+mkdir -p "$D1a"
+init_db "$D1a/tasks.db"
+write_roster "$D1a/agents.json" "[]"
+out_d1a="$(run_doctor "$D1a")"
+json_assert "$out_d1a" empty "D1a empty state -> []"
+
+# Table mode: assert the empty-state human string.
+out_d1a_tbl="$("$PYTHON" "$DOCTOR" \
+  --agent-list-json "$D1a/agents.json" \
+  --task-db "$D1a/tasks.db" \
+  --projects-root "$D1a/no-such-claude-projects" 2>&1)"
+if [[ "$out_d1a_tbl" == *"No stuck-state signals detected."* ]]; then
+  pass "D1a table mode -> 'No stuck-state signals detected.'"
+else
+  fail "D1a table mode wrong output: $out_d1a_tbl"
+fi
+
+# --- D1b: one stale-stopped-with-queue ---------------------------------
+D1b="$ROOT/d1b"
+mkdir -p "$D1b"
+init_db "$D1b/tasks.db"
+"$PYTHON" - "$D1b/tasks.db" "$NOW" <<'PY'
+import sqlite3, sys
+db, now = sys.argv[1], int(sys.argv[2])
+conn = sqlite3.connect(db)
+conn.execute(
+    "INSERT INTO agent_state (agent, engine, session, active, last_seen_ts, "
+    "session_activity_ts) VALUES (?, ?, ?, ?, ?, ?)",
+    ("syrs-calendar", "claude", "syrs-calendar", 0, now - 600000, now - 600000),
+)
+conn.commit()
+conn.close()
+PY
+write_roster "$D1b/agents.json" '[{"agent":"syrs-calendar","engine":"claude","active":false,"activity_state":"stopped","loop":1,"queue":{"queued":4,"blocked":0,"claimed":0}}]'
+out_d1b="$(run_doctor "$D1b")"
+json_assert "$out_d1b" stale_stopped_emitted \
+  "D1b stale-stopped-with-queue emitted" syrs-calendar
+json_assert "$out_d1b" stale_stopped_evidence_shape \
+  "D1b evidence shape matches spec"
+json_assert "$out_d1b" suggested_action_equals \
+  "D1b suggested_action is the restart hint" \
+  stale-stopped-with-queue "agent-bridge agent restart syrs-calendar"
+
+# --- D1c: stopped + loop=0 -> NO finding -------------------------------
+D1c="$ROOT/d1c"
+mkdir -p "$D1c"
+init_db "$D1c/tasks.db"
+write_roster "$D1c/agents.json" '[{"agent":"loopless","engine":"claude","active":false,"activity_state":"stopped","loop":0,"queue":{"queued":4,"blocked":2,"claimed":0}}]'
+out_d1c="$(run_doctor "$D1c")"
+json_assert "$out_d1c" kind_absent \
+  "D1c loop=0 produces no stale-stopped-with-queue" stale-stopped-with-queue
+
+# --- D1d: stopped, loop=1, queued=0, blocked=0 -> NO finding -----------
+D1d="$ROOT/d1d"
+mkdir -p "$D1d"
+init_db "$D1d/tasks.db"
+write_roster "$D1d/agents.json" '[{"agent":"empty-bag","engine":"claude","active":false,"activity_state":"stopped","loop":1,"queue":{"queued":0,"blocked":0,"claimed":0}}]'
+out_d1d="$(run_doctor "$D1d")"
+json_assert "$out_d1d" kind_absent \
+  "D1d empty backlog produces no stale-stopped-with-queue" stale-stopped-with-queue
+
+# --- D2a: blocked aged 25h, owner idle ---------------------------------
+D2a="$ROOT/d2a"
+mkdir -p "$D2a"
+init_db "$D2a/tasks.db"
+old="$((NOW - 90000))"  # 25h ago
+insert_task "$D2a/tasks.db" 11 "librarian" "librarian" "blocked" "$old"
+write_roster "$D2a/agents.json" '[{"agent":"librarian","engine":"claude","active":true,"activity_state":"idle","loop":1,"queue":{"queued":0,"blocked":1,"claimed":0}}]'
+out_d2a="$(run_doctor "$D2a")"
+json_assert "$out_d2a" stale_blocked_task_id \
+  "D2a stale-blocked-task emitted" 11
+json_assert "$out_d2a" stale_blocked_suggested_prefix \
+  "D2a suggested_action targets task 11" \
+  "agent-bridge update 11 --status queued"
+
+# --- D2b: blocked aged 1h -> NO finding --------------------------------
+D2b="$ROOT/d2b"
+mkdir -p "$D2b"
+init_db "$D2b/tasks.db"
+recent="$((NOW - 3600))"  # 1h ago
+insert_task "$D2b/tasks.db" 12 "librarian" "librarian" "blocked" "$recent"
+write_roster "$D2b/agents.json" '[{"agent":"librarian","engine":"claude","active":true,"activity_state":"idle","loop":1,"queue":{"queued":0,"blocked":1,"claimed":0}}]'
+out_d2b="$(run_doctor "$D2b")"
+json_assert "$out_d2b" kind_absent \
+  "D2b 1h-old blocked task does not trip default 24h threshold" stale-blocked-task
+
+# --- D2c: blocked aged 25h but owner working -> NO finding -------------
+D2c="$ROOT/d2c"
+mkdir -p "$D2c"
+init_db "$D2c/tasks.db"
+old="$((NOW - 90000))"
+insert_task "$D2c/tasks.db" 13 "worker-bee" "worker-bee" "blocked" "$old"
+write_roster "$D2c/agents.json" '[{"agent":"worker-bee","engine":"claude","active":true,"activity_state":"working","loop":1,"queue":{"queued":0,"blocked":1,"claimed":0}}]'
+out_d2c="$(run_doctor "$D2c")"
+json_assert "$out_d2c" kind_absent \
+  "D2c working owner blocks the stale-blocked-task signal" stale-blocked-task
+
+# --- D2d: threshold env override --------------------------------------
+D2d="$ROOT/d2d"
+mkdir -p "$D2d"
+init_db "$D2d/tasks.db"
+ninety_min="$((NOW - 5400))"  # 90 min ago
+insert_task "$D2d/tasks.db" 14 "librarian" "librarian" "blocked" "$ninety_min"
+write_roster "$D2d/agents.json" '[{"agent":"librarian","engine":"claude","active":true,"activity_state":"idle","loop":1,"queue":{"queued":0,"blocked":1,"claimed":0}}]'
+out_d2d="$(BRIDGE_DOCTOR_BLOCKED_THRESHOLD_SECONDS=3600 \
+  "$PYTHON" "$DOCTOR" \
+  --json \
+  --agent-list-json "$D2d/agents.json" \
+  --task-db "$D2d/tasks.db" \
+  --projects-root "$D2d/no-such-claude-projects")"
+json_assert "$out_d2d" stale_blocked_task_id \
+  "D2d threshold env override triggers stale-blocked-task at 90min" 14
+
+# --- D4: abnormal-session-pane placeholder ----------------------------
+D4="$ROOT/d4"
+mkdir -p "$D4"
+init_db "$D4/tasks.db"
+write_roster "$D4/agents.json" "[]"
+out_d4="$(run_doctor "$D4" --detectors abnormal-session-pane)"
+json_assert "$out_d4" abnormal_pane_placeholder \
+  "D4 abnormal-session-pane emits a single detector-error placeholder"
+# pipefail above guards crash detection; if the CLI had segfaulted run_doctor
+# would have failed and we would not have reached this line.
+pass "D4 abnormal-session-pane CLI exits cleanly (no hard crash)"
+
+# --- D5: --detectors filter --------------------------------------------
+D5="$ROOT/d5"
+mkdir -p "$D5"
+init_db "$D5/tasks.db"
+old="$((NOW - 90000))"
+insert_task "$D5/tasks.db" 21 "librarian" "librarian" "blocked" "$old"
+write_roster "$D5/agents.json" '[
+  {"agent":"librarian","engine":"claude","active":true,"activity_state":"idle","loop":1,"queue":{"queued":0,"blocked":1,"claimed":0}},
+  {"agent":"sleeper","engine":"claude","active":false,"activity_state":"stopped","loop":1,"queue":{"queued":3,"blocked":0,"claimed":0}}
+]'
+# Without filter: 2 kinds expected (stale-blocked-task + stale-stopped-with-queue).
+out_d5_all="$(run_doctor "$D5")"
+json_assert "$out_d5_all" kinds_superset \
+  "D5 baseline emits both detector kinds" \
+  stale-blocked-task stale-stopped-with-queue
+# With filter: only stale-blocked-task survives, no detector-error rows leak.
+out_d5_filter="$(run_doctor "$D5" --detectors stale-blocked-task)"
+json_assert "$out_d5_filter" only_kind \
+  "D5 --detectors stale-blocked-task isolates the kind" \
+  stale-blocked-task
+
+# --- D6: daemon-level finding renders cleanly --------------------------
+# The placeholder abnormal-session-pane detector emits a detector-error
+# row with agent="". Use it as the daemon-level finding and assert the
+# table renderer prints "-" for the agent column without crashing.
+D6="$ROOT/d6"
+mkdir -p "$D6"
+init_db "$D6/tasks.db"
+write_roster "$D6/agents.json" "[]"
+out_d6_tbl="$("$PYTHON" "$DOCTOR" \
+  --agent-list-json "$D6/agents.json" \
+  --task-db "$D6/tasks.db" \
+  --projects-root "$D6/no-such-claude-projects" \
+  --detectors abnormal-session-pane 2>&1)"
+if [[ "$out_d6_tbl" == *"detector-error"* ]] && [[ "$out_d6_tbl" == *"-"* ]]; then
+  pass "D6 daemon-level finding renders cleanly in table"
+else
+  fail "D6 table render did not contain expected fields: $out_d6_tbl"
+fi
+
+# --- Summary ------------------------------------------------------------
+printf '\n[smoke] agb-doctor: %d pass, %d fail\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf '[smoke] failing scenarios:\n' >&2
+  for failure in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$failure" >&2
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `agent-bridge doctor [--json]` — a read-only CLI that surfaces stuck-state cross-cutting signals so the admin agent can self-heal infra via existing primitives (`agent-bridge agent restart`, `agent-bridge update`). Per the issue spec: zero new policy, zero new schema columns, zero daemon hooks. The admin agent LLM does the classification and decides whether to act.

Detectors:

- `stale-stopped-with-queue` — `state=stopped AND loop_enabled AND (queued>0 OR blocked>0)`
- `stale-blocked-task` — `task.blocked AND task.claimed_by.state=idle AND lease_age > 24h` (threshold env-overridable via `BRIDGE_DOCTOR_BLOCKED_THRESHOLD_SECONDS`)
- `cold-restart-suspect` — fresh `session_id` with a prior jsonl still on disk for the same workdir slug within the last 7 days (#167)
- `abnormal-session-pane` — **shipped as a placeholder** (per the brief's explicit authorization). The pane-pattern reuse from `bridge-stall.py` is larger than the "smallest read-only CLI" scope, so this detector returns `[]` by default and emits a single `detector-error` row only when the operator opts in via `--detectors abnormal-session-pane`. Follow-up can lift the patterns into a shared helper when an operator hits the case.

`suggested_action` is a string hint. The daemon does not execute it.

### Read-only contract

- The sqlite DB is opened in read-only URI mode so a buggy doctor cannot mutate state.
- Each detector runs in its own try/except boundary — a failing detector emits a `kind: "detector-error"` row instead of crashing the whole CLI.
- `--detectors KIND[,KIND...]` is also an allow-list against `detector-error` rows so the admin agent can isolate one detector cleanly.

### Files

- `bridge-doctor.py` (new) — the CLI.
- `agent-bridge` — one-line dispatcher arm + help-block entry.
- `OPERATIONS.md` — one-line bullet under `Status And Debugging`.
- `tests/agb-doctor/smoke.sh` (new) — 17 isolated cases covering every scenario in the brief's test plan (D1a/b/c/d, D2a/b/c/d, D4, D5, D6).
- `tests/agb-doctor/_assert.py` (new) — named JSON predicates so the smoke harness never expands a test-controlled string into Python code.

## Test plan

- [x] `bash -n bridge-*.sh agent-bridge agb lib/*.sh scripts/*.sh` — clean.
- [x] `shellcheck bridge-*.sh agent-bridge agb lib/*.sh scripts/*.sh` — clean (including new `tests/agb-doctor/smoke.sh`).
- [x] `python3 -c "import ast; ast.parse(open('bridge-doctor.py').read())"` — clean.
- [x] `bash tests/agb-doctor/smoke.sh` — **17/17 pass**.
- [x] Live invocation in isolated `BRIDGE_HOME` — empty-state and seeded-fixture output both render correctly in `--json` and table modes.
- [ ] `./scripts/smoke-test.sh` — could not complete in this session (the run hangs at `starting isolated tmux role` while spawning a real claude/codex tmux session, which is unrelated to this PR's surface). Reviewer should re-run on a fresh shell. The new file lives outside any `bridge-*.sh` / `lib/` / `hooks/` path that smoke-test.sh exercises.

## Out of scope

- Auto-execution of `suggested_action` (read-only is the contract).
- New queue/task/state schema columns.
- Daemon push channel integration.
- `doctor apply` subcommand (issue body explicitly excludes this).
- Admin-CLAUDE.md SOP changes (issue #517's scope).
- VERSION / CHANGELOG (deferred to release PR).

## Notes for the reviewer

- The `abnormal-session-pane` detector intentionally stays empty in default invocations so a healthy host produces `[]` (D1a). The brief explicitly authorizes shipping it as a placeholder; a follow-up can lift the pattern set out of `bridge-stall.py` when needed.
- Roster data comes from `agent-bridge agent list --json` as a subprocess. Tests inject `--agent-list-json <file>` to skip the subprocess; live `agent-bridge doctor` invocations resolve the binary as a sibling of `bridge-doctor.py`.

Closes #511.