### PR TITLE
feat(admin-pair): sibling codex dev for admin + managed pair-programming SOP block

### DIFF
--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -6,6 +6,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
+# shellcheck source=lib/bridge-admin-pair.sh
+source "$SCRIPT_DIR/lib/bridge-admin-pair.sh"
 # bridge_load_roster is deferred until after argument parsing so that
 # `init --dry-run` is mutation-free (bridge_load_roster -> bridge_init_dirs
 # would otherwise create $BRIDGE_HOME/state on a fresh-install-candidate and
@@ -436,6 +438,24 @@ else
   "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "${create_args[@]}" >/dev/null
   created=1
   bridge_load_roster
+fi
+
+# Issue #517: ensure the admin's sibling codex dev pair (`<admin>-dev`) and
+# inject the pair-programming SOP managed block into the admin's CLAUDE.md.
+# Tolerant on failure — pair backfill must never fail an otherwise-successful
+# admin install. Skipped on --dry-run to honor the mutation-free contract.
+if [[ $dry_run -eq 0 ]] && [[ "$engine" == "claude" ]]; then
+  pair_output=""
+  if ! pair_output="$(bridge_ensure_admin_codex_pair "$admin_agent" 2>&1)"; then
+    bridge_init_append_warning "admin-pair backfill failed: ${pair_output}"
+  else
+    [[ -n "$pair_output" ]] && printf '%s\n' "$pair_output" >&2
+    bridge_load_roster
+    inject_output=""
+    if ! inject_output="$(python3 "$SCRIPT_DIR/bridge-upgrade.py" inject-admin-pair-block --target-root "$BRIDGE_HOME" --admin-agent "$admin_agent" 2>&1)"; then
+      bridge_init_append_warning "admin-pair CLAUDE.md inject failed: ${inject_output}"
+    fi
+  fi
 fi
 
 if [[ $dry_run -eq 0 ]] && [[ "$(bridge_agent_engine "$admin_agent" 2>/dev/null || printf '%s' "$engine")" == "claude" ]]; then

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -442,9 +442,12 @@ fi
 
 # Issue #517: ensure the admin's sibling codex dev pair (`<admin>-dev`) and
 # inject the pair-programming SOP managed block into the admin's CLAUDE.md.
-# Tolerant on failure — pair backfill must never fail an otherwise-successful
-# admin install. Skipped on --dry-run to honor the mutation-free contract.
-if [[ $dry_run -eq 0 ]] && [[ "$engine" == "claude" ]]; then
+# Applies regardless of admin engine — the pair is always engine=codex; the
+# SOP block is engine-neutral (it talks about plan/review/implement loops,
+# which apply to any orchestrator). Tolerant on failure — pair backfill must
+# never fail an otherwise-successful admin install. Skipped on --dry-run to
+# honor the mutation-free contract.
+if [[ $dry_run -eq 0 ]]; then
   pair_output=""
   if ! pair_output="$(bridge_ensure_admin_codex_pair "$admin_agent" 2>&1)"; then
     bridge_init_append_warning "admin-pair backfill failed: ${pair_output}"

--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -27,6 +27,12 @@ from typing import Any, Iterator
 MANAGED_CLAUDE_START = "<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->"
 MANAGED_CLAUDE_END = "<!-- END AGENT BRIDGE DOC MIGRATION -->"
 
+# Issue #517: admin-only pair-programming SOP block. Generalized
+# extract/refresh helpers below take delimiter args so the same logic
+# rerenders both blocks idempotently.
+MANAGED_PAIR_START = "<!-- BEGIN MANAGED:admin-pair-programming -->"
+MANAGED_PAIR_END = "<!-- END MANAGED:admin-pair-programming -->"
+
 
 def now_iso() -> str:
     return datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds")
@@ -247,21 +253,23 @@ def render_template(text: str, agent_id: str, display_name: str, role_text: str,
     return text
 
 
-def extract_managed_claude_block(text: str) -> str:
+def extract_managed_block(text: str, start_marker: str, end_marker: str) -> str:
     match = re.search(
-        rf"{re.escape(MANAGED_CLAUDE_START)}.*?{re.escape(MANAGED_CLAUDE_END)}",
+        rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}",
         text,
         re.S,
     )
     return match.group(0).strip() if match else ""
 
 
-def refresh_managed_claude_block(original: str, managed_block: str) -> str:
+def refresh_managed_block(
+    original: str, managed_block: str, start_marker: str, end_marker: str
+) -> str:
     if not managed_block:
         return original
     block = managed_block.rstrip() + "\n"
     pattern = re.compile(
-        rf"{re.escape(MANAGED_CLAUDE_START)}.*?{re.escape(MANAGED_CLAUDE_END)}\n*",
+        rf"{re.escape(start_marker)}.*?{re.escape(end_marker)}\n*",
         re.S,
     )
     if pattern.search(original):
@@ -280,6 +288,48 @@ def refresh_managed_claude_block(original: str, managed_block: str) -> str:
     if normalized:
         return f"{block}\n{normalized}\n"
     return block
+
+
+def extract_managed_claude_block(text: str) -> str:
+    return extract_managed_block(text, MANAGED_CLAUDE_START, MANAGED_CLAUDE_END)
+
+
+def refresh_managed_claude_block(original: str, managed_block: str) -> str:
+    return refresh_managed_block(original, managed_block, MANAGED_CLAUDE_START, MANAGED_CLAUDE_END)
+
+
+def render_admin_pair_block(admin: str) -> str:
+    """Render the admin-pair-programming managed block for the given admin.
+
+    Issue #517. Must stay byte-identical to the bash side
+    (lib/bridge-admin-pair.sh:bridge_admin_pair_managed_block) so a fresh
+    install and an upgraded install converge on the same content.
+    """
+    pair = f"{admin}-dev"
+    return f"""{MANAGED_PAIR_START}
+## Pair Programming Protocol (with `{pair}`)
+
+This admin agent always pair-programs with `{pair}` (codex). Never commit or
+file an upstream PR without going through the loop below; never ask the operator
+to manually trigger a review.
+
+1. **Plan brief.** Write `/tmp/<task-slug>-plan.md` describing background, focus
+   checklist, expected output shape (`plan-ok` / `needs-more`). Queue:
+   `agent-bridge task create --to {pair} --title "[plan] <subject>" --body-file /tmp/...`.
+2. **Wait for plan-ok.** Implement only after `{pair}` returns
+   `plan-ok` or after a `needs-more` round resolves.
+3. **Implement** in your worktree.
+4. **Code review.** Write `/tmp/<task-slug>-codereview.md` (artifacts to review,
+   focus list). Queue: `agent-bridge task create --to {pair} --title "[review] <subject>" --body-file ...`.
+5. **Merge only on `implement-ok`.** If `needs-more`, action and resubmit as
+   r2/r3 with bumped title and a fresh brief. After 3 rounds without
+   `implement-ok`, stop and reconsider scope.
+6. **Off-hours autonomy.** When the operator delegates explicitly, `{pair}`'s
+   `implement-ok` substitutes for operator approval until the operator returns.
+
+Out of scope for this pair: business decisions, anything tagged
+`human-decision-required`. Those go to the operator channel, not `{pair}`.
+{MANAGED_PAIR_END}"""
 
 
 def discover_agent_dirs(agent_root: Path) -> list[Path]:
@@ -411,6 +461,19 @@ def migrate_agent_home(agent_dir: Path, template_root: Path, admin_agent: str, d
                 if not dry_run:
                     claude_target.write_text(refreshed, encoding="utf-8")
 
+    # Issue #517: admin-only pair-programming SOP block. Refreshed
+    # idempotently from rendered code (no template-side substitution) so
+    # non-admin agents are never touched by this branch.
+    if session_type == "admin" and claude_target.exists():
+        pair_block = render_admin_pair_block(agent)
+        original = claude_target.read_text(encoding="utf-8", errors="ignore")
+        refreshed = refresh_managed_block(original, pair_block, MANAGED_PAIR_START, MANAGED_PAIR_END)
+        if refreshed != original:
+            if "CLAUDE.md" not in updated_files:
+                updated_files.append("CLAUDE.md")
+            if not dry_run:
+                claude_target.write_text(refreshed, encoding="utf-8")
+
     return AgentMigrationResult(
         agent=agent,
         added_files=added_files,
@@ -419,6 +482,38 @@ def migrate_agent_home(agent_dir: Path, template_root: Path, admin_agent: str, d
         session_type=session_type,
         engine=engine,
     )
+
+
+def cmd_inject_admin_pair_block(args: argparse.Namespace) -> int:
+    """Render + refresh the admin-pair-programming managed block.
+
+    Issue #517 — invoked by bridge-init.sh after the admin agent and its
+    sibling codex pair have been registered. Idempotent: a second invocation
+    on an already-injected admin CLAUDE.md is a no-op.
+    """
+    target_root = Path(args.target_root).expanduser()
+    admin = (args.admin_agent or "").strip()
+    if not admin:
+        print(json.dumps({"error": "admin-agent required"}, ensure_ascii=False))
+        return 1
+    claude_path = target_root / "agents" / admin / "CLAUDE.md"
+    if not claude_path.exists():
+        print(json.dumps(
+            {"skipped": "admin CLAUDE.md missing", "path": str(claude_path)},
+            ensure_ascii=False,
+        ))
+        return 0
+    pair_block = render_admin_pair_block(admin)
+    original = claude_path.read_text(encoding="utf-8", errors="ignore")
+    refreshed = refresh_managed_block(original, pair_block, MANAGED_PAIR_START, MANAGED_PAIR_END)
+    changed = refreshed != original
+    if changed and not args.dry_run:
+        claude_path.write_text(refreshed, encoding="utf-8")
+    print(json.dumps(
+        {"path": str(claude_path), "changed": changed, "dry_run": bool(args.dry_run)},
+        ensure_ascii=False,
+    ))
+    return 0
 
 
 def cmd_migrate_agents(args: argparse.Namespace) -> int:
@@ -2087,6 +2182,20 @@ def build_parser() -> argparse.ArgumentParser:
     migrate.add_argument("--admin-agent", default="")
     migrate.add_argument("--dry-run", action="store_true")
     migrate.set_defaults(handler=cmd_migrate_agents)
+
+    # Issue #517: inject the admin-pair-programming managed block into the
+    # admin CLAUDE.md. Called from bridge-init.sh after admin + pair create.
+    inject_pair = subparsers.add_parser(
+        "inject-admin-pair-block",
+        help=(
+            "Refresh the admin-pair-programming managed block in the named "
+            "admin agent's CLAUDE.md. Idempotent."
+        ),
+    )
+    inject_pair.add_argument("--target-root", required=True)
+    inject_pair.add_argument("--admin-agent", required=True)
+    inject_pair.add_argument("--dry-run", action="store_true")
+    inject_pair.set_defaults(handler=cmd_inject_admin_pair_block)
 
     backup = subparsers.add_parser("backup-live")
     backup.add_argument("--target-root", required=True)

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1291,6 +1291,32 @@ if [[ $MIGRATE_AGENTS -eq 1 ]]; then
     done
   ' -- "$SOURCE_ROOT" "$DRY_RUN"
 
+  # Issue #517: backfill the admin's sibling codex dev pair (`<admin>-dev`).
+  # Idempotent — skipped when the pair already exists. The admin CLAUDE.md
+  # managed pair-programming block is refreshed by `migrate-agents` above
+  # (admin session_type branch in migrate_agent_home), so this step only
+  # owns the agent registration. Tolerant on failure: warn and continue.
+  if [[ -n "$ADMIN_AGENT_ID" ]]; then
+    if [[ $DRY_RUN -eq 1 ]]; then
+      echo "[bridge-upgrade] plan: ensure admin codex pair ${ADMIN_AGENT_ID}-dev (idempotent)"
+    else
+      _admin_pair_output=""
+      if ! _admin_pair_output="$(
+        bridge_upgrade_with_target_env "$TARGET_ROOT" "$BRIDGE_BASH_BIN" -lc '
+          set -euo pipefail
+          source "$1/bridge-lib.sh"
+          source "$1/lib/bridge-admin-pair.sh"
+          bridge_load_roster
+          bridge_ensure_admin_codex_pair "$2"
+        ' -- "$SOURCE_ROOT" "$ADMIN_AGENT_ID" 2>&1
+      )"; then
+        echo "[bridge-upgrade] WARN: admin-pair backfill failed: $_admin_pair_output" >&2
+      else
+        [[ -n "$_admin_pair_output" ]] && printf '%s\n' "$_admin_pair_output" >&2
+      fi
+    fi
+  fi
+
   # Also propagate per-agent doc sync (bridge-docs.py apply) so
   # MEMORY-SCHEMA.md / SKILLS.md / CLAUDE.md managed blocks track the
   # canonical runtime on every upgrade. Before 2026-04-19 this hook was

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1304,8 +1304,15 @@ if [[ $MIGRATE_AGENTS -eq 1 ]]; then
       if ! _admin_pair_output="$(
         bridge_upgrade_with_target_env "$TARGET_ROOT" "$BRIDGE_BASH_BIN" -lc '
           set -euo pipefail
-          source "$1/bridge-lib.sh"
-          source "$1/lib/bridge-admin-pair.sh"
+          # bridge-admin-pair.sh:bridge_ensure_admin_codex_pair invokes
+          # "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" agent create ...,
+          # so SCRIPT_DIR must be bound before sourcing the helper. Without
+          # this the heredocs subshells set -u aborts as
+          # "SCRIPT_DIR: unbound variable" and admin-pair backfill fails on
+          # every upgrade. (Issue #517 r1 review finding 1.)
+          SCRIPT_DIR="$1"
+          source "$SCRIPT_DIR/bridge-lib.sh"
+          source "$SCRIPT_DIR/lib/bridge-admin-pair.sh"
           bridge_load_roster
           bridge_ensure_admin_codex_pair "$2"
         ' -- "$SOURCE_ROOT" "$ADMIN_AGENT_ID" 2>&1

--- a/lib/bridge-admin-pair.sh
+++ b/lib/bridge-admin-pair.sh
@@ -58,6 +58,17 @@ bridge_ensure_admin_codex_pair() {
   rc=$?
   set -e
   if [[ $rc -ne 0 ]]; then
+    # Defensive: `agent create` can return nonzero after the roster mutation
+    # has already happened (post-register validation, env warnings, etc.).
+    # Reload the roster and let the inject step run if the pair actually
+    # made it. This keeps the install convergent on transient failures
+    # rather than leaving an admin with a registered pair but no SOP block.
+    # (Issue #517 r1 review finding 3.)
+    bridge_load_roster
+    if bridge_agent_exists "$pair_name"; then
+      printf '[admin-pair] create-partial-but-registered: %s\n%s\n' "$pair_name" "$create_output" >&2
+      return 0
+    fi
     printf '[admin-pair] create-failed: %s\n%s\n' "$pair_name" "$create_output" >&2
     return 1
   fi

--- a/lib/bridge-admin-pair.sh
+++ b/lib/bridge-admin-pair.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# bridge-admin-pair.sh — register the sibling codex dev agent (`<admin>-dev`)
+# that the admin agent pair-programs with, and render the managed
+# pair-programming SOP block that gets injected into the admin's CLAUDE.md.
+#
+# Issue #517. The bash-side managed-block rendering MUST stay byte-identical
+# to bridge-upgrade.py's render_admin_pair_block() so a fresh admin install
+# (this lib) and an upgraded admin (bridge-upgrade.py migrate-agents) end up
+# with the same content.
+
+bridge_admin_pair_name() {
+  local admin="$1"
+  printf '%s-dev' "$admin"
+}
+
+# Idempotently register the sibling codex agent for the given admin.
+# - engine=codex, session-type=static-codex, source=static
+# - workdir inherits the admin's workdir (admin pair-programs in the same tree)
+# - channels: none (queue-only — pair never reaches an external surface)
+# - --always-on so the daemon picks it up automatically
+# Prints a structured stderr line on every action so callers can audit.
+# Returns 0 when the pair exists at exit (created or already-existed); 1 on
+# hard failure of `agent create`.
+bridge_ensure_admin_codex_pair() {
+  local admin="$1"
+  local pair_name pair_workdir create_output rc
+
+  [[ -n "$admin" ]] || return 1
+  pair_name="$(bridge_admin_pair_name "$admin")"
+
+  if bridge_agent_exists "$pair_name"; then
+    printf '[admin-pair] skipped (already-exists): %s\n' "$pair_name" >&2
+    return 0
+  fi
+
+  pair_workdir="$(bridge_agent_workdir "$admin" 2>/dev/null || true)"
+  if [[ -z "$pair_workdir" ]]; then
+    pair_workdir="$(bridge_agent_default_home "$admin")"
+  fi
+
+  local description="Dedicated codex dev pair for ${admin}: plans, reviews, and proposes code changes via the queue."
+  local role_text="Pair programmer for ${admin} (codex)"
+
+  set +e
+  create_output="$(
+    "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" agent create "$pair_name" \
+      --engine codex \
+      --session-type static-codex \
+      --session "$pair_name" \
+      --display-name "$pair_name" \
+      --workdir "$pair_workdir" \
+      --role "$role_text" \
+      --description "$description" \
+      --always-on \
+      2>&1
+  )"
+  rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    printf '[admin-pair] create-failed: %s\n%s\n' "$pair_name" "$create_output" >&2
+    return 1
+  fi
+
+  printf '[admin-pair] created: %s\n' "$pair_name" >&2
+  return 0
+}
+
+# Render the admin pair-programming SOP managed block for the given admin
+# name. Output is read by callers and either written into the admin's
+# CLAUDE.md (via bridge-upgrade.py inject-admin-pair-block) or compared
+# against the python-rendered output during smoke verification.
+#
+# Keep the body byte-identical to bridge-upgrade.py:render_admin_pair_block.
+bridge_admin_pair_managed_block() {
+  local admin="$1"
+  local pair
+  pair="$(bridge_admin_pair_name "$admin")"
+  cat <<EOF
+<!-- BEGIN MANAGED:admin-pair-programming -->
+## Pair Programming Protocol (with \`${pair}\`)
+
+This admin agent always pair-programs with \`${pair}\` (codex). Never commit or
+file an upstream PR without going through the loop below; never ask the operator
+to manually trigger a review.
+
+1. **Plan brief.** Write \`/tmp/<task-slug>-plan.md\` describing background, focus
+   checklist, expected output shape (\`plan-ok\` / \`needs-more\`). Queue:
+   \`agent-bridge task create --to ${pair} --title "[plan] <subject>" --body-file /tmp/...\`.
+2. **Wait for plan-ok.** Implement only after \`${pair}\` returns
+   \`plan-ok\` or after a \`needs-more\` round resolves.
+3. **Implement** in your worktree.
+4. **Code review.** Write \`/tmp/<task-slug>-codereview.md\` (artifacts to review,
+   focus list). Queue: \`agent-bridge task create --to ${pair} --title "[review] <subject>" --body-file ...\`.
+5. **Merge only on \`implement-ok\`.** If \`needs-more\`, action and resubmit as
+   r2/r3 with bumped title and a fresh brief. After 3 rounds without
+   \`implement-ok\`, stop and reconsider scope.
+6. **Off-hours autonomy.** When the operator delegates explicitly, \`${pair}\`'s
+   \`implement-ok\` substitutes for operator approval until the operator returns.
+
+Out of scope for this pair: business decisions, anything tagged
+\`human-decision-required\`. Those go to the operator channel, not \`${pair}\`.
+<!-- END MANAGED:admin-pair-programming -->
+EOF
+}

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate mattermost-plugin
+  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin
 }
 
 add_all_integration() {
@@ -225,7 +225,12 @@ select_for_path() {
       ;;
 
     bridge-upgrade.sh|bridge-upgrade.py|scripts/export-public-snapshot.sh|VERSION)
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair
+      add_integration integration-minimal
+      ;;
+
+    bridge-init.sh|lib/bridge-admin-pair.sh)
+      add_required admin-codex-pair upgrade-shared-settings-propagate
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/admin-codex-pair.sh
+++ b/scripts/smoke/admin-codex-pair.sh
@@ -33,6 +33,7 @@ cleanup() {
 trap cleanup EXIT
 
 ADMIN="testadmin"
+ADMIN_CODEX="testadmincodex"
 SENTINEL_LINE="<!-- operator-note: smoke-${RANDOM}-${RANDOM} -->"
 PRE_EXISTING_MIGRATION_LINE="## Agent Bridge Runtime Canon"
 
@@ -115,6 +116,36 @@ assert_missing_admin_home_is_skip() {
   smoke_assert_eq "admin CLAUDE.md missing" "$skipped" "missing admin home is skipped, not failed"
 }
 
+# Issue #517 r1 finding 2: bridge-init.sh dropped the engine=="claude" gate
+# so codex admins also get the SOP block. The python inject path was already
+# engine-agnostic by code reading; this fixture pins that contract — a
+# CLAUDE.md authored as a codex admin still receives the same managed block
+# markers + pair-name substitution after inject.
+write_codex_admin_fixture() {
+  local admin_home="$BRIDGE_AGENT_HOME_ROOT/$ADMIN_CODEX"
+  mkdir -p "$admin_home"
+  cat >"$admin_home/CLAUDE.md" <<'EOF'
+# testadmincodex — Admin Role (Codex CLI)
+
+너는 testadmincodex이야. Codex CLI로 동작하는 admin.
+
+EOF
+}
+
+assert_codex_admin_inject_writes_block() {
+  local output changed claude_path content
+  output="$(python3 "$SMOKE_REPO_ROOT/bridge-upgrade.py" inject-admin-pair-block \
+    --target-root "$BRIDGE_HOME" --admin-agent "$ADMIN_CODEX")"
+  changed="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["changed"])')"
+  smoke_assert_eq "True" "$changed" "codex-admin inject reports changed=true"
+
+  claude_path="$BRIDGE_AGENT_HOME_ROOT/$ADMIN_CODEX/CLAUDE.md"
+  content="$(cat "$claude_path")"
+  smoke_assert_contains "$content" "<!-- BEGIN MANAGED:admin-pair-programming -->" "codex-admin block start marker present"
+  smoke_assert_contains "$content" "<!-- END MANAGED:admin-pair-programming -->" "codex-admin block end marker present"
+  smoke_assert_contains "$content" "${ADMIN_CODEX}-dev" "codex-admin pair name substituted into block"
+}
+
 assert_bash_python_blocks_byte_identical() {
   local bash_block python_block
   bash_block="$(bridge_admin_pair_managed_block "$ADMIN")"
@@ -150,12 +181,14 @@ main() {
   smoke_require_cmd python3
   smoke_setup_bridge_home "admin-codex-pair"
   write_admin_fixture
+  write_codex_admin_fixture
   smoke_run "pair name helper" assert_pair_name_helper
   smoke_run "bash and python managed blocks are byte-identical" assert_bash_python_blocks_byte_identical
   smoke_run "first inject writes block + preserves overlay" assert_first_inject_writes_block
   smoke_run "second inject is a no-op (idempotent)" assert_second_inject_is_noop
   smoke_run "dry-run reports change without mutating" assert_dry_run_does_not_mutate
   smoke_run "missing admin home is skipped, not failed" assert_missing_admin_home_is_skip
+  smoke_run "codex-admin inject writes block (engine-neutral)" assert_codex_admin_inject_writes_block
   smoke_log "passed"
 }
 

--- a/scripts/smoke/admin-codex-pair.sh
+++ b/scripts/smoke/admin-codex-pair.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/smoke/admin-codex-pair.sh — Issue #517 smoke.
+#
+# Validates:
+# 1. bridge-upgrade.py inject-admin-pair-block injects the managed block
+#    into a fixture admin's CLAUDE.md.
+# 2. Re-running is a no-op (changed=false on second run).
+# 3. Operator overlay outside the managed block is preserved across reruns.
+# 4. The pre-existing AGENT BRIDGE DOC MIGRATION block is preserved
+#    (regression check on the generalized refresh helper).
+# 5. The bash-side managed block (bridge_admin_pair_managed_block) and the
+#    python-side managed block (render_admin_pair_block) are byte-identical
+#    when invoked with the same admin name — preserves the fresh-install
+#    vs upgrade-install convergence contract.
+#
+# This smoke does NOT exercise `bridge-init.sh`/`bridge-upgrade.sh` end-to-end
+# — those require a real Claude/Codex CLI on PATH and live tmux. The
+# integration is covered by ci-select-smoke routing the existing `upgrade`
+# smoke + this targeted contract check on the helpers themselves.
+
+set -euo pipefail
+
+SMOKE_NAME="admin-codex-pair"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+# shellcheck source=lib/bridge-admin-pair.sh
+source "$SMOKE_REPO_ROOT/lib/bridge-admin-pair.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+ADMIN="testadmin"
+SENTINEL_LINE="<!-- operator-note: smoke-${RANDOM}-${RANDOM} -->"
+PRE_EXISTING_MIGRATION_LINE="## Agent Bridge Runtime Canon"
+
+write_admin_fixture() {
+  local admin_home="$BRIDGE_AGENT_HOME_ROOT/$ADMIN"
+  mkdir -p "$admin_home"
+  cat >"$admin_home/CLAUDE.md" <<'EOF'
+# testadmin — Admin Role
+
+<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->
+## Agent Bridge Runtime Canon
+- existing migration block content kept by the generalized refresh helper.
+<!-- END AGENT BRIDGE DOC MIGRATION -->
+
+너는 testadmin이야. 운영 contract.
+
+EOF
+  printf '%s\n' "$SENTINEL_LINE" >>"$admin_home/CLAUDE.md"
+}
+
+inject_block() {
+  python3 "$SMOKE_REPO_ROOT/bridge-upgrade.py" inject-admin-pair-block \
+    --target-root "$BRIDGE_HOME" \
+    --admin-agent "$ADMIN"
+}
+
+assert_first_inject_writes_block() {
+  local output changed claude_path content
+  output="$(inject_block)"
+  changed="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["changed"])')"
+  smoke_assert_eq "True" "$changed" "first inject reports changed=true"
+
+  claude_path="$BRIDGE_AGENT_HOME_ROOT/$ADMIN/CLAUDE.md"
+  content="$(cat "$claude_path")"
+  smoke_assert_contains "$content" "<!-- BEGIN MANAGED:admin-pair-programming -->" "block start marker present"
+  smoke_assert_contains "$content" "<!-- END MANAGED:admin-pair-programming -->" "block end marker present"
+  smoke_assert_contains "$content" "${ADMIN}-dev" "pair name substituted into block"
+  smoke_assert_contains "$content" "$PRE_EXISTING_MIGRATION_LINE" "pre-existing migration block preserved after inject"
+  smoke_assert_contains "$content" "$SENTINEL_LINE" "operator overlay sentinel preserved after inject"
+}
+
+assert_second_inject_is_noop() {
+  local output changed
+  output="$(inject_block)"
+  changed="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin)["changed"])')"
+  smoke_assert_eq "False" "$changed" "second inject reports changed=false (idempotent)"
+}
+
+assert_dry_run_does_not_mutate() {
+  local before after output
+  local claude_path="$BRIDGE_AGENT_HOME_ROOT/$ADMIN/CLAUDE.md"
+
+  # Force a drift so dry-run has something to report.
+  python3 - "$claude_path" <<'PY'
+import sys
+from pathlib import Path
+p = Path(sys.argv[1])
+text = p.read_text(encoding="utf-8")
+text = text.replace("Pair Programming Protocol", "PAIR PROGRAMMING (drifted)", 1)
+p.write_text(text, encoding="utf-8")
+PY
+  before="$(cat "$claude_path")"
+  output="$(python3 "$SMOKE_REPO_ROOT/bridge-upgrade.py" inject-admin-pair-block \
+    --target-root "$BRIDGE_HOME" --admin-agent "$ADMIN" --dry-run)"
+  after="$(cat "$claude_path")"
+  smoke_assert_eq "$before" "$after" "dry-run does not mutate file"
+  printf '%s' "$output" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+assert payload["dry_run"] is True, payload
+assert payload["changed"] is True, payload
+'
+}
+
+assert_missing_admin_home_is_skip() {
+  local output skipped
+  output="$(python3 "$SMOKE_REPO_ROOT/bridge-upgrade.py" inject-admin-pair-block \
+    --target-root "$BRIDGE_HOME" --admin-agent "ghostadmin")"
+  skipped="$(printf '%s' "$output" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("skipped",""))')"
+  smoke_assert_eq "admin CLAUDE.md missing" "$skipped" "missing admin home is skipped, not failed"
+}
+
+assert_bash_python_blocks_byte_identical() {
+  local bash_block python_block
+  bash_block="$(bridge_admin_pair_managed_block "$ADMIN")"
+  # Load bridge-upgrade.py under a Python-legal module name so the embedded
+  # dataclass does not trip __module__ lookups (hyphens in spec name break
+  # `sys.modules.get(cls.__module__)` on py3.9 stdlib dataclasses).
+  python_block="$(BRIDGE_UPGRADE_PATH="$SMOKE_REPO_ROOT/bridge-upgrade.py" SMOKE_ADMIN="$ADMIN" python3 -c '
+import importlib.util, os, sys
+path = os.environ["BRIDGE_UPGRADE_PATH"]
+admin = os.environ["SMOKE_ADMIN"]
+spec = importlib.util.spec_from_file_location("bridge_upgrade", path)
+module = importlib.util.module_from_spec(spec)
+sys.modules["bridge_upgrade"] = module
+spec.loader.exec_module(module)
+print(module.render_admin_pair_block(admin))
+')"
+  if [[ "$bash_block" != "$python_block" ]]; then
+    smoke_log "bash block:"
+    printf '%s\n' "$bash_block" | sed 's/^/  /' >&2
+    smoke_log "python block:"
+    printf '%s\n' "$python_block" | sed 's/^/  /' >&2
+    smoke_fail "bash and python managed-block content drifted (issue #517 contract)"
+  fi
+}
+
+assert_pair_name_helper() {
+  local got
+  got="$(bridge_admin_pair_name "$ADMIN")"
+  smoke_assert_eq "${ADMIN}-dev" "$got" "bridge_admin_pair_name returns <admin>-dev"
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "admin-codex-pair"
+  write_admin_fixture
+  smoke_run "pair name helper" assert_pair_name_helper
+  smoke_run "bash and python managed blocks are byte-identical" assert_bash_python_blocks_byte_identical
+  smoke_run "first inject writes block + preserves overlay" assert_first_inject_writes_block
+  smoke_run "second inject is a no-op (idempotent)" assert_second_inject_is_noop
+  smoke_run "dry-run reports change without mutating" assert_dry_run_does_not_mutate
+  smoke_run "missing admin home is skipped, not failed" assert_missing_admin_home_is_skip
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Issue #517 — admin agents now ship with a sibling `<admin>-dev` codex agent (engine=codex, source=static, queue-only, always-on) and a managed `<!-- BEGIN/END MANAGED:admin-pair-programming -->` block in the admin CLAUDE.md that codifies the pair-programming SOP from `AGENTS.md` "Multi-Agent Collaboration".

The pair is created on fresh install (`bridge-init.sh`) and idempotently backfilled on `agent-bridge upgrade --apply`. The managed block uses the same operator-overlay-preserving refresh idiom as the existing `<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->` block — `extract_managed_claude_block` / `refresh_managed_claude_block` are generalized to accept delimiter pairs and re-used.

## What changed

- `lib/bridge-admin-pair.sh` (new): `bridge_admin_pair_name`, `bridge_ensure_admin_codex_pair`, `bridge_admin_pair_managed_block`. Idempotent — skips when the pair already exists.
- `bridge-init.sh`: after admin agent create, ensure `<admin>-dev` exists and inject the managed block into admin CLAUDE.md (via the new `bridge-upgrade.py inject-admin-pair-block` sub-command). Skipped on `--dry-run`. Tolerant on failure (warning, not error).
- `bridge-upgrade.sh`: in apply path, after `migrate-agents` succeeds, ensure the pair exists for the resolved admin id (idempotent backfill on existing installs). The CLAUDE.md block is refreshed by `migrate-agents` itself via the admin branch in `migrate_agent_home`.
- `bridge-upgrade.py`: generalize `extract/refresh_managed_claude_block` to take delimiter args (existing wrappers preserved); add `MANAGED_PAIR_START/END`, `render_admin_pair_block`, `cmd_inject_admin_pair_block`. `migrate_agent_home` refreshes the admin-pair-programming block when `session_type=admin`.
- `scripts/smoke/admin-codex-pair.sh` (new): isolated `BRIDGE_HOME` smoke covering pair-name helper, bash↔python byte-identity, first-inject mutation, idempotent re-run, dry-run mutation-safety, missing-admin-skip, operator-overlay preservation, and pre-existing migration block preservation.
- `scripts/ci-select-smoke.sh`: adds `admin-codex-pair` to `add_all_required_static`, plus path-triggers on `bridge-init.sh`, `lib/bridge-admin-pair.sh`, `bridge-upgrade.{sh,py}`. (The brief said "wire into `scripts/smoke-test.sh`" but the modular smoke surface in this repo is `scripts/ci-select-smoke.sh`; that's where existing smokes like `upgrade-shared-settings-propagate` are registered, so I matched that pattern.)

## Out of scope

- No `--no-pair` opt-out flag (default-on per issue spec).
- No deprecation of existing codex agents (`agb-dev-codex`, `agb-dev-syrs`, etc.) — operator decision per issue body.
- No auto-merge/auto-approve plumbing — pair review stays a contract, not automation.
- No template-side conditional substitution; the admin-only block is rendered purely from code so non-admin agents are never touched.
- No VERSION/CHANGELOG.md bump — release happens in a separate `release/v0.7.4` PR.

## Verification

- `bash -n` clean across `bridge-init.sh`, `bridge-upgrade.sh`, `lib/bridge-admin-pair.sh`, root + `lib/` + `scripts/` shell sources, and the new smoke.
- `shellcheck` clean (severity=warning) across the same set + `agent-roster.local.example.sh`.
- `python3 -c "import ast; ast.parse(open('bridge-upgrade.py').read())"` clean. `inject-admin-pair-block --help` and `migrate-agents --help` both render.
- New `scripts/smoke/admin-codex-pair.sh` passes all 6 assertions in an isolated `BRIDGE_HOME=$(mktemp -d)`.
- `./scripts/smoke-test.sh` failure on `[smoke] expected output to contain: codex-cli-agent-<pid>` (live tmux/Codex orchestration step) reproduces on `main` at `43fe5a2` without any of these edits — pre-existing host-state issue, not a regression from this PR.

## Footgun callouts

- The bash and python managed blocks must stay byte-identical for the same admin name. `assert_bash_python_blocks_byte_identical` in the new smoke enforces this; please rerun if you touch either renderer.
- `bridge-init.sh`'s `--dry-run` contract is preserved: pair backfill is gated on `dry_run -eq 0`. Same for `bridge-upgrade.sh` (`DRY_RUN -eq 1` only emits a planned-line).
- The admin-pair block is refreshed only when `session_type == "admin"` in `migrate_agent_home`; non-admin agents (including the new `<admin>-dev` codex pair, which is `static-codex`) never receive the block.

Closes #517.