### PR TITLE
fix(relay-cleanup): rewrite BRIDGE_AGENT_LAUNCH_CMD + prune source-deleted relay tree (#523)

### DIFF
--- a/bridge-relay-cleanup.py
+++ b/bridge-relay-cleanup.py
@@ -15,8 +15,27 @@ Touched surface:
   - ``BRIDGE_AGENT_CHANNELS["X"]`` containing ``plugin:telegram-relay@*``
     is rewritten to drop the relay item and ensure
     ``plugin:telegram@claude-plugins-official`` is present
+  - ``BRIDGE_AGENT_LAUNCH_CMD["X"]`` containing the development-channel
+    relay loader (``--dangerously-load-development-channels
+    plugin:telegram-relay@<spec>`` in either whitespace or ``=`` form,
+    plus dangling bare ``plugin:telegram-relay@<spec>`` tokens) is
+    rewritten to drop the relay loader. Quote style and unrelated args
+    (other dev channels, env assignments, flags) are preserved.
   - ``BRIDGE_TELEGRAM_RELAY_ENABLED`` and ``BRIDGE_TELEGRAM_USE_RELAY``
     scalar lines are deleted (matches both bare and ``export`` form)
+- Source-deleted relay files left over from v0.6.37+ installs upgraded
+  to v0.7.0+ (live-runtime is additive-only, so the upgrader cannot
+  delete them as a side effect of the source diff). Versioned manifest:
+  ``lib/telegram-relay.py``, ``bridge-telegram-relay.sh``,
+  ``plugins/telegram-relay/``. Symlinks at any of these paths are
+  refused (logged as ``prune_skipped``) — the operator likely retargeted
+  them deliberately.
+- Stale relay processes whose ``argv`` is rooted under the configured
+  ``--target-root`` (``<target_root>/lib/telegram-relay.py`` or
+  ``<target_root>/plugins/telegram-relay/...``). SIGTERM, then SIGKILL
+  on the holdouts after ``--term-timeout`` seconds. The path-prefix
+  anchor is required so a different install on the same host is not
+  affected.
 
 Preserved:
 
@@ -25,7 +44,10 @@ Preserved:
 - Anything else under ``state/channels/telegram/`` that does not match
   the deletion patterns (none should exist post-PR3, but defensive).
 
-Stdlib only. Returns JSON summary on stdout when ``--json`` is set.
+Stdlib only (``psutil`` is used opportunistically for stale-process
+discovery; the tool falls back to parsing ``ps -eo pid,args`` when
+``psutil`` is not importable). Returns JSON summary on stdout when
+``--json`` is set.
 
 Exit code:
   0 — success or no-op
@@ -37,9 +59,14 @@ import argparse
 import json
 import os
 import re
+import shutil
+import signal
 import stat
+import subprocess
 import sys
 import tempfile
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 ENV_KEYS_TO_REMOVE = (
@@ -50,6 +77,47 @@ ENV_KEYS_TO_REMOVE = (
 CHANNEL_LINE_RE = re.compile(
     r'^([ \t]*BRIDGE_AGENT_CHANNELS\["([^"]+)"\]=)"([^"]*)"(.*)$'
 )
+
+# v0.7.0 (#501) deleted these from source. Live-runtime upgrade is
+# additive-only, so a versioned removal manifest is the safe path —
+# generic mtime/size diffs would also nuke node_modules and other
+# legitimately-present runtime trees.
+TELEGRAM_RELAY_LIVE_FILES = (
+    "lib/telegram-relay.py",
+    "bridge-telegram-relay.sh",
+)
+TELEGRAM_RELAY_LIVE_DIRS = (
+    "plugins/telegram-relay",
+)
+
+# Launch-cmd assignment forms. Two patterns instead of a single backref
+# group because Bash treats the two quote styles as distinct tokens at
+# parse time and the operator's existing quote choice must round-trip.
+LAUNCH_CMD_LINE_DOUBLE_RE = re.compile(
+    r'^(?P<prefix>[ \t]*BRIDGE_AGENT_LAUNCH_CMD\["(?P<agent>[^"]+)"\]=)'
+    r'"(?P<value>[^"]*)"(?P<suffix>.*)$'
+)
+LAUNCH_CMD_LINE_SINGLE_RE = re.compile(
+    r"^(?P<prefix>[ \t]*BRIDGE_AGENT_LAUNCH_CMD\[\"(?P<agent>[^\"]+)\"\]=)"
+    r"'(?P<value>[^']*)'(?P<suffix>.*)$"
+)
+# Anything that starts with the assignment but neither close-quote form
+# matched (escapes, multi-line continuations, eval-style values). The
+# operator gets a heads-up via ``unparsed_launch_cmd_lines`` rather than
+# a silent partial rewrite.
+LAUNCH_CMD_LINE_ANY_PREFIX_RE = re.compile(
+    r'^[ \t]*BRIDGE_AGENT_LAUNCH_CMD\[(?:"(?P<agent>[^"]+)"|\S+)\]='
+)
+
+# Removes the ``--dangerously-load-development-channels`` option in
+# either whitespace-separated or ``=``-separated form when paired with
+# a ``plugin:telegram-relay@<spec>`` argument.
+RELAY_DEV_CHANNEL_RE = re.compile(
+    r"--dangerously-load-development-channels[= ]plugin:telegram-relay@\S+"
+)
+# Dangling bare token left over after the option was stripped, or after
+# operator hand-edits removed only the option half of the pair.
+RELAY_BARE_TOKEN_RE = re.compile(r"\bplugin:telegram-relay@\S+")
 
 
 def _load_text(path: Path) -> str | None:
@@ -274,6 +342,312 @@ def remove_per_agent_relay_tokens(agents_root: Path, *, dry_run: bool) -> list[s
     return removed
 
 
+def _strip_relay_tokens(value: str) -> str:
+    """Remove relay dev-channel option + dangling bare tokens from a launch cmd."""
+    cleaned = RELAY_DEV_CHANNEL_RE.sub("", value)
+    cleaned = RELAY_BARE_TOKEN_RE.sub("", cleaned)
+    # Collapse runs of whitespace inside the captured value only — the
+    # surrounding line (prefix/suffix) is preserved verbatim, so leading
+    # indentation and trailing comments survive intact.
+    cleaned = re.sub(r"[ \t]{2,}", " ", cleaned)
+    return cleaned.strip()
+
+
+def rewrite_launch_cmds(
+    roster_path: Path, *, dry_run: bool
+) -> tuple[list[str], list[str]]:
+    """Rewrite ``BRIDGE_AGENT_LAUNCH_CMD["X"]=...`` lines that load the relay.
+
+    Returns ``(rewritten_agents, unparsed_lines)``. Lines whose quoting
+    matches neither the double- nor single-quoted form (escapes,
+    multi-line continuations, ``eval``-style expansions) are recorded
+    in ``unparsed_lines`` and left untouched — the operator should
+    inspect them by hand. The agent name comes from the assignment
+    bracket if parseable, else the (1-indexed) line number.
+
+    Quote style is preserved on rewrite. Other dev channels (e.g.
+    ``plugin:teams@agent-bridge``), env assignments before ``claude``,
+    and unrelated flags are not touched.
+    """
+    text = _load_text(roster_path)
+    if text is None:
+        return [], []
+    new_lines: list[str] = []
+    rewritten_agents: list[str] = []
+    unparsed: list[str] = []
+    any_change = False
+    for idx, line in enumerate(text.splitlines(keepends=True), start=1):
+        stripped = line.rstrip("\n")
+        m_double = LAUNCH_CMD_LINE_DOUBLE_RE.match(stripped)
+        m_single = LAUNCH_CMD_LINE_SINGLE_RE.match(stripped)
+        if m_double is not None:
+            quote = '"'
+            m = m_double
+        elif m_single is not None:
+            quote = "'"
+            m = m_single
+        else:
+            prefix_only = LAUNCH_CMD_LINE_ANY_PREFIX_RE.match(stripped)
+            if prefix_only is not None:
+                agent = prefix_only.group("agent") or f"line-{idx}"
+                if RELAY_DEV_CHANNEL_RE.search(stripped) or RELAY_BARE_TOKEN_RE.search(
+                    stripped
+                ):
+                    unparsed.append(agent)
+            new_lines.append(line)
+            continue
+        agent = m.group("agent")
+        value = m.group("value")
+        suffix = m.group("suffix")
+        # If the relay tokens live *outside* the captured value (i.e.
+        # in the suffix after the matched closing quote), the value is
+        # almost certainly an escaped-quote / multi-token expansion the
+        # regex closed prematurely. Touching it would corrupt the
+        # operator's intent — surface as unparsed instead.
+        if RELAY_DEV_CHANNEL_RE.search(suffix) or RELAY_BARE_TOKEN_RE.search(suffix):
+            unparsed.append(agent)
+            new_lines.append(line)
+            continue
+        if not (
+            RELAY_DEV_CHANNEL_RE.search(value) or RELAY_BARE_TOKEN_RE.search(value)
+        ):
+            new_lines.append(line)
+            continue
+        new_value = _strip_relay_tokens(value)
+        if new_value == value:
+            new_lines.append(line)
+            continue
+        rewritten = (
+            f"{m.group('prefix')}{quote}{new_value}{quote}{m.group('suffix')}"
+        )
+        if line.endswith("\n") and not rewritten.endswith("\n"):
+            rewritten += "\n"
+        new_lines.append(rewritten)
+        rewritten_agents.append(agent)
+        any_change = True
+    if any_change and not dry_run:
+        _atomic_write(roster_path, "".join(new_lines))
+    return rewritten_agents, unparsed
+
+
+def _iter_processes_psutil():
+    try:
+        import psutil  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    items: list[tuple[int, list[str]]] = []
+    for proc in psutil.process_iter(["pid", "cmdline"]):
+        try:
+            cmdline = proc.info.get("cmdline") or []
+            pid = int(proc.info["pid"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if not cmdline:
+            continue
+        items.append((pid, list(cmdline)))
+    return items
+
+
+def _iter_processes_ps() -> list[tuple[int, list[str]]]:
+    try:
+        out = subprocess.check_output(
+            ["ps", "-eo", "pid=,args="], text=True, stderr=subprocess.DEVNULL
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+        return []
+    items: list[tuple[int, list[str]]] = []
+    for raw_line in out.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        head, _, rest = line.partition(" ")
+        try:
+            pid = int(head)
+        except ValueError:
+            continue
+        # ps -o args= already coalesces argv into a single space-joined
+        # string. Split on whitespace for prefix-anchor matching; this is
+        # lossy but the matcher only needs argv[0..1] for the path check.
+        argv = rest.strip().split()
+        if not argv:
+            continue
+        items.append((pid, argv))
+    return items
+
+
+def _stale_relay_match(argv: list[str], target_root: Path) -> str | None:
+    """Return the matched absolute path if argv runs telegram-relay under target_root.
+
+    Two argv shapes are accepted:
+      1. ``<target_root>/lib/telegram-relay.py ...``
+         (when the script is invoked directly via shebang).
+      2. ``python3 <target_root>/lib/telegram-relay.py ...``
+         (or any python interpreter; checks argv[1] when argv[0] is a
+         python binary).
+
+    A path under ``<target_root>/plugins/telegram-relay/...`` is also
+    matched (Node child processes spawned out of the relay plugin tree).
+
+    Substring/glob matches against the bare name ``lib/telegram-relay.py``
+    are intentionally rejected — a different install on the same host
+    must not be affected.
+    """
+    if not argv:
+        return None
+    target_str = str(target_root)
+    rel_file = str(target_root / "lib" / "telegram-relay.py")
+    rel_plugin_prefix = str(target_root / "plugins" / "telegram-relay") + os.sep
+    rel_plugin_exact = str(target_root / "plugins" / "telegram-relay")
+
+    # The interpreter case: argv[0] looks like python (case-insensitive
+    # matches the macOS Python.framework `Python` binary too), argv[1]
+    # is the path.
+    candidates: list[str] = []
+    head = argv[0]
+    head_base = os.path.basename(head).lower()
+    if head_base.startswith("python") and len(argv) >= 2:
+        candidates.append(argv[1])
+    candidates.append(head)
+
+    for cand in candidates:
+        if not cand:
+            continue
+        if cand == rel_file:
+            return cand
+        if cand == rel_plugin_exact or cand.startswith(rel_plugin_prefix):
+            return cand
+        # Defensive: reject anything that does not literally start with
+        # the absolute target_root path. This is the path-prefix anchor
+        # the issue body calls out.
+        if not cand.startswith(target_str + os.sep):
+            continue
+    return None
+
+
+def stop_stale_relay_processes(
+    target_root: Path, *, dry_run: bool, term_timeout: float = 8.0
+) -> list[str]:
+    """SIGTERM (then SIGKILL) relay processes rooted under ``target_root``.
+
+    Returns a list of redacted descriptors ``"<pid>:<matched-path>"`` —
+    intentionally **does not** include raw argv because the relay's argv
+    can carry ``--token-file`` paths under credential directories. Each
+    matched-path is one we already constructed from ``target_root``, so
+    it is known-safe to log.
+    """
+    procs = _iter_processes_psutil()
+    if procs is None:
+        procs = _iter_processes_ps()
+    matches: list[tuple[int, str]] = []
+    self_pid = os.getpid()
+    for pid, argv in procs:
+        if pid == self_pid:
+            continue
+        matched = _stale_relay_match(argv, target_root)
+        if matched is not None:
+            matches.append((pid, matched))
+    redacted = [f"{pid}:{path}" for pid, path in matches]
+    if dry_run or not matches:
+        return redacted
+
+    # SIGTERM phase.
+    for pid, _ in matches:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            continue
+
+    deadline = time.monotonic() + max(0.5, term_timeout)
+    survivors = list(matches)
+    while survivors and time.monotonic() < deadline:
+        time.sleep(0.25)
+        still_alive: list[tuple[int, str]] = []
+        for pid, path in survivors:
+            try:
+                # Signal 0 = "still there?" probe.
+                os.kill(pid, 0)
+                still_alive.append((pid, path))
+            except (ProcessLookupError, OSError):
+                continue
+        survivors = still_alive
+
+    # SIGKILL holdouts.
+    for pid, _ in survivors:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            continue
+    return redacted
+
+
+def prune_live_files(
+    target_root: Path, *, dry_run: bool
+) -> tuple[list[str], list[str]]:
+    """Delete v0.7.0-deleted relay files left in the live runtime.
+
+    Returns ``(pruned_relpaths, skipped_relpaths)``. ``skipped`` covers
+    paths that exist but are symlinks (refused on safety grounds — the
+    operator likely retargeted them deliberately, and following could
+    delete an unrelated tree). Missing paths are silently ignored.
+    """
+    pruned: list[str] = []
+    skipped: list[str] = []
+    for relpath in TELEGRAM_RELAY_LIVE_FILES:
+        path = target_root / relpath
+        if path.is_symlink():
+            skipped.append(relpath)
+            continue
+        if not path.exists():
+            continue
+        if not dry_run:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                continue
+        pruned.append(relpath)
+    for relpath in TELEGRAM_RELAY_LIVE_DIRS:
+        path = target_root / relpath
+        if path.is_symlink():
+            skipped.append(relpath)
+            continue
+        if not path.exists():
+            continue
+        if not dry_run:
+            _rmtree_safe(path)
+        pruned.append(relpath)
+    return pruned, skipped
+
+
+def _backup_live_paths(
+    target_root: Path,
+    relpaths: list[str],
+    *,
+    backup_root: Path,
+) -> None:
+    """Copy each relpath under ``backup_root/live/`` before prune.
+
+    Used when the cleanup runs **outside** ``agent-bridge upgrade --apply``
+    (no upgrader-managed backup to extend). Mirrors the layout that
+    ``bridge-upgrade.py backup-extend-live`` produces so an operator who
+    needs to recover can re-use the same restore tooling. Symlinks are
+    not followed (matches ``_rmtree_safe`` semantics).
+    """
+    backup_live = backup_root / "live"
+    for relpath in relpaths:
+        src = target_root / relpath
+        dst = backup_live / relpath
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if src.is_symlink():
+            # Should not happen — prune_live_files refuses symlinks —
+            # but defensive in case the caller passes a list it did
+            # not derive from prune_live_files.
+            continue
+        if src.is_dir():
+            shutil.copytree(src, dst, symlinks=True, dirs_exist_ok=True)
+        elif src.is_file():
+            shutil.copy2(src, dst, follow_symlinks=False)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -295,6 +669,30 @@ def main() -> int:
         action="store_true",
         help="Emit JSON summary on stdout (default: human key: value lines).",
     )
+    parser.add_argument(
+        "--term-timeout",
+        type=float,
+        default=8.0,
+        help="Seconds to wait between SIGTERM and SIGKILL for stale relay procs.",
+    )
+    parser.add_argument(
+        "--backup-root",
+        help=(
+            "Override the standalone-run backup directory. Default: "
+            "<target-root>/backups/relay-cleanup-<UTC-stamp>/. "
+            "Ignored when run from `agent-bridge upgrade --apply` (the "
+            "upgrader provides its own backup via `backup-extend-live`)."
+        ),
+    )
+    parser.add_argument(
+        "--no-backup",
+        action="store_true",
+        help=(
+            "Skip the standalone-run backup before pruning live files. "
+            "Use only when the upgrader is calling this tool (it has "
+            "already extended the upgrade backup manifest)."
+        ),
+    )
     args = parser.parse_args()
 
     target_root = Path(args.target_root).expanduser()
@@ -302,8 +700,45 @@ def main() -> int:
     state_root = target_root / "state" / "channels" / "telegram"
     agents_root = target_root / "agents"
 
+    backup_root: Path | None = None
+
     try:
+        # 1. Rewrite launch commands first. Future sessions stop loading
+        #    the relay plugin tree; live processes are not yet affected.
+        launch_cmds_rewritten, unparsed_launch_cmd_lines = rewrite_launch_cmds(
+            roster_file, dry_run=args.dry_run
+        )
+        # 2. Existing channel rewrite (also touches agent-roster.local.sh).
         agents_migrated = rewrite_channels(roster_file, dry_run=args.dry_run)
+        # 3. Stop stale relay processes — must happen *before* live-file
+        #    prune (mmap'd binaries on Linux can hold the inode open).
+        stale_processes_terminated = stop_stale_relay_processes(
+            target_root,
+            dry_run=args.dry_run,
+            term_timeout=max(0.0, float(args.term_timeout)),
+        )
+        # 4. Live-file prune (Gap B). Compute first so we can backup
+        #    pre-deletion when running standalone.
+        if args.dry_run:
+            live_files_pruned, prune_skipped = prune_live_files(
+                target_root, dry_run=True
+            )
+        else:
+            # Plan first (still on disk), backup, then apply.
+            planned, prune_skipped = prune_live_files(target_root, dry_run=True)
+            if planned and not args.no_backup:
+                stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                backup_root = (
+                    Path(args.backup_root).expanduser()
+                    if args.backup_root
+                    else target_root / "backups" / f"relay-cleanup-{stamp}"
+                )
+                backup_root.mkdir(parents=True, exist_ok=True)
+                _backup_live_paths(target_root, planned, backup_root=backup_root)
+            live_files_pruned, _ = prune_live_files(target_root, dry_run=False)
+        # 5. Existing state cleanup — must run *after* the live-file
+        #    prune. If a surviving relay process recreated state between
+        #    step 3 and now, this is the catch-up sweep.
         env_keys_removed = remove_env_lines(roster_file, dry_run=args.dry_run)
         state_files_removed = remove_state_files(state_root, dry_run=args.dry_run)
         agent_tokens_removed = remove_per_agent_relay_tokens(
@@ -319,6 +754,13 @@ def main() -> int:
         "env_keys_removed": env_keys_removed,
         "state_files_removed": state_files_removed,
         "agent_tokens_removed": agent_tokens_removed,
+        "launch_cmds_rewritten": launch_cmds_rewritten,
+        "unparsed_launch_cmd_lines": unparsed_launch_cmd_lines,
+        "live_files_pruned": live_files_pruned,
+        "prune_skipped": prune_skipped,
+        "stale_processes_terminated": stale_processes_terminated,
+        "agent_restart_required": list(launch_cmds_rewritten),
+        "backup_root": str(backup_root) if backup_root else "",
     }
     summary["any_changes"] = any(
         bool(summary[key])
@@ -327,6 +769,9 @@ def main() -> int:
             "env_keys_removed",
             "state_files_removed",
             "agent_tokens_removed",
+            "launch_cmds_rewritten",
+            "live_files_pruned",
+            "stale_processes_terminated",
         )
     )
 
@@ -334,14 +779,18 @@ def main() -> int:
     # consumption. The `removed:` prefix matches the convention of the
     # existing backup-extend-live API (paths that will be deleted are
     # recorded so rollback can restore them, identical handling to
-    # files that will be modified-in-place).
+    # files that will be modified-in-place). Live-file prunes are
+    # emitted as absolute paths so the upgrader's relpath-vs-target-root
+    # check resolves correctly.
     changed: list[str] = []
-    if agents_migrated or env_keys_removed:
+    if agents_migrated or env_keys_removed or launch_cmds_rewritten:
         changed.append(str(roster_file))
     for path_str in state_files_removed:
         changed.append(f"removed:{path_str}")
     for path_str in agent_tokens_removed:
         changed.append(f"removed:{path_str}")
+    for relpath in live_files_pruned:
+        changed.append(f"removed:{target_root / relpath}")
     summary["changed_paths"] = changed
 
     if args.json:

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1256,8 +1256,16 @@ PY
           --paths-json "$RELAY_CLEANUP_PREVIEW_JSON" >/dev/null 2>&1 || true
       fi
       set +e
+      # `--no-backup`: the upgrader already extended the upgrade backup
+      # manifest with `changed_paths` from the preview JSON above
+      # (including the new `removed:<abs>/lib/telegram-relay.py` etc.
+      # entries). A second standalone backup under
+      # `<target>/backups/relay-cleanup-*/` would be redundant noise on
+      # every upgrade. Standalone (non-upgrade) invocations of
+      # `bridge-relay-cleanup.py` still produce their own backup by
+      # default; only this in-upgrade caller opts out.
       RELAY_CLEANUP_JSON="$(python3 "$SOURCE_ROOT/bridge-relay-cleanup.py" \
-        --target-root "$TARGET_ROOT" --json 2>/dev/null)"
+        --target-root "$TARGET_ROOT" --no-backup --json 2>/dev/null)"
       _relay_cleanup_rc=$?
       set -e
       if [[ $_relay_cleanup_rc -ne 0 ]]; then

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip
+  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup
 }
 
 add_all_integration() {
@@ -230,7 +230,12 @@ select_for_path() {
       ;;
 
     bridge-upgrade.sh|bridge-upgrade.py|scripts/export-public-snapshot.sh|VERSION)
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup
+      add_integration integration-minimal
+      ;;
+
+    bridge-relay-cleanup.py)
+      add_required upgrade upgrade-shared-settings-propagate telegram-relay-residue-cleanup
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/telegram-relay-residue-cleanup.sh
+++ b/scripts/smoke/telegram-relay-residue-cleanup.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+
+# Issue #523: telegram-relay residue survives v0.7 cleanup via launch
+# cmd and stale live files. Locks the contract for both Gap A
+# (BRIDGE_AGENT_LAUNCH_CMD rewrite) and Gap B (versioned live-file
+# prune) plus the cleanup execution order, idempotency, symlink
+# safety, and absolute-path-anchored stale-process matching.
+
+set -euo pipefail
+
+SMOKE_NAME="telegram-relay-residue-cleanup"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  # Belt-and-suspenders: any sleeper process the smoke spawned should
+  # be cleaned up even if an assertion failed mid-run. The trap fires
+  # before smoke_cleanup_temp_root removes BRIDGE_HOME.
+  if [[ -n "${SMOKE_RELAY_INTREE_PID:-}" ]]; then
+    kill -KILL "$SMOKE_RELAY_INTREE_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${SMOKE_RELAY_FOREIGN_PID:-}" ]]; then
+    kill -KILL "$SMOKE_RELAY_FOREIGN_PID" >/dev/null 2>&1 || true
+  fi
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+CLEANUP_PY="$SMOKE_REPO_ROOT/bridge-relay-cleanup.py"
+
+# json_field follows the established `scripts/smoke/upgrade-*.sh`
+# pattern: a Python one-liner reads JSON from stdin, then prints the
+# result of the expression argument. The expression is smoke-author
+# code (not user input), so the inline `eval` mirrors the existing
+# convention here. New smokes outside this file should keep using it
+# for consistency.
+json_field() {
+  local json="$1"
+  local expr="$2"
+  printf '%s' "$json" | python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+print(eval(sys.argv[1], {"payload": payload}))
+' "$expr"
+}
+
+write_fixture_roster() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<'EOF'
+# Smoke fixture: agent X carries the relay residue (Gap A target).
+BRIDGE_AGENT_CHANNELS["X"]="plugin:telegram@claude-plugins-official"
+BRIDGE_AGENT_LAUNCH_CMD["X"]="claude --dangerously-load-development-channels plugin:telegram-relay@agent-bridge --dangerously-load-development-channels plugin:teams@agent-bridge --some-flag"
+# Agent Y is clean; cleanup must not touch it.
+BRIDGE_AGENT_CHANNELS["Y"]="plugin:telegram@claude-plugins-official"
+BRIDGE_AGENT_LAUNCH_CMD["Y"]='claude --dangerously-load-development-channels plugin:teams@agent-bridge'
+# Agent Z has a deliberately malformed (escaped-quote) value that the
+# regex-based rewriter cannot safely touch — must surface in
+# unparsed_launch_cmd_lines and be left untouched.
+BRIDGE_AGENT_LAUNCH_CMD["Z"]="claude --foo \"plugin:telegram-relay@agent-bridge\""
+EOF
+}
+
+write_fixture_live_files() {
+  mkdir -p "$BRIDGE_HOME/lib" "$BRIDGE_HOME/plugins/telegram-relay"
+  printf 'fixture: lib/telegram-relay.py\n' >"$BRIDGE_HOME/lib/telegram-relay.py"
+  printf 'fixture: bridge-telegram-relay.sh\n' >"$BRIDGE_HOME/bridge-telegram-relay.sh"
+  printf 'fixture: plugins/telegram-relay/server.ts\n' >"$BRIDGE_HOME/plugins/telegram-relay/server.ts"
+}
+
+assert_dry_run_reports_residue() {
+  local json rewritten pruned migrated launch_x
+
+  json="$(python3 "$CLEANUP_PY" --target-root "$BRIDGE_HOME" --dry-run --json)"
+  rewritten="$(json_field "$json" 'payload["launch_cmds_rewritten"]')"
+  pruned="$(json_field "$json" 'payload["live_files_pruned"]')"
+  migrated="$(json_field "$json" 'payload["agents_migrated"]')"
+  smoke_assert_eq "['X']" "$rewritten" "dry-run reports launch-cmd rewrite for agent X"
+  smoke_assert_contains "$pruned" "lib/telegram-relay.py" "dry-run plans lib prune"
+  smoke_assert_contains "$pruned" "bridge-telegram-relay.sh" "dry-run plans bridge-telegram-relay.sh prune"
+  smoke_assert_contains "$pruned" "plugins/telegram-relay" "dry-run plans plugin tree prune"
+  smoke_assert_eq "[]" "$migrated" "channel rewrite is no-op for already-clean fixture"
+
+  # Dry-run must not mutate the roster.
+  launch_x="$(grep '^BRIDGE_AGENT_LAUNCH_CMD\["X"\]=' "$BRIDGE_ROSTER_LOCAL_FILE")"
+  smoke_assert_contains "$launch_x" "telegram-relay" "dry-run leaves roster untouched"
+
+  # Dry-run must not delete fixture files.
+  smoke_assert_file_exists "$BRIDGE_HOME/lib/telegram-relay.py" "dry-run preserves lib fixture"
+  smoke_assert_file_exists "$BRIDGE_HOME/bridge-telegram-relay.sh" "dry-run preserves bridge-telegram-relay.sh fixture"
+  smoke_assert_file_exists "$BRIDGE_HOME/plugins/telegram-relay/server.ts" "dry-run preserves plugin tree fixture"
+}
+
+assert_apply_rewrites_and_prunes() {
+  local json launch_x launch_y launch_z restart_required backup_root pruned
+
+  json="$(python3 "$CLEANUP_PY" --target-root "$BRIDGE_HOME" --json)"
+  pruned="$(json_field "$json" 'payload["live_files_pruned"]')"
+  smoke_assert_contains "$pruned" "lib/telegram-relay.py" "apply prunes lib"
+  restart_required="$(json_field "$json" 'payload["agent_restart_required"]')"
+  smoke_assert_eq "['X']" "$restart_required" "apply emits restart hint for X"
+
+  launch_x="$(grep '^BRIDGE_AGENT_LAUNCH_CMD\["X"\]=' "$BRIDGE_ROSTER_LOCAL_FILE")"
+  smoke_assert_not_contains "$launch_x" "telegram-relay" "agent X relay loader removed"
+  smoke_assert_contains "$launch_x" "plugin:teams@agent-bridge" "agent X teams dev channel preserved"
+  smoke_assert_contains "$launch_x" "--some-flag" "agent X --some-flag preserved"
+  # Quote style must be preserved (X started double-quoted).
+  smoke_assert_match "$launch_x" '^BRIDGE_AGENT_LAUNCH_CMD\["X"\]="' "agent X double-quote style preserved"
+
+  launch_y="$(grep '^BRIDGE_AGENT_LAUNCH_CMD\["Y"\]=' "$BRIDGE_ROSTER_LOCAL_FILE")"
+  smoke_assert_match "$launch_y" "^BRIDGE_AGENT_LAUNCH_CMD\\[\"Y\"\\]='" "agent Y single-quote style preserved (no rewrite)"
+  smoke_assert_contains "$launch_y" "plugin:teams@agent-bridge" "agent Y line untouched"
+
+  launch_z="$(grep '^BRIDGE_AGENT_LAUNCH_CMD\["Z"\]=' "$BRIDGE_ROSTER_LOCAL_FILE")"
+  smoke_assert_contains "$launch_z" "telegram-relay" "agent Z malformed line left untouched"
+
+  [[ ! -e "$BRIDGE_HOME/lib/telegram-relay.py" ]] || smoke_fail "apply did not delete lib/telegram-relay.py"
+  [[ ! -e "$BRIDGE_HOME/bridge-telegram-relay.sh" ]] || smoke_fail "apply did not delete bridge-telegram-relay.sh"
+  [[ ! -e "$BRIDGE_HOME/plugins/telegram-relay" ]] || smoke_fail "apply did not delete plugin tree"
+
+  backup_root="$(json_field "$json" 'payload["backup_root"]')"
+  [[ -n "$backup_root" && -d "$backup_root" ]] || smoke_fail "apply must create backup root, got: $backup_root"
+  smoke_assert_file_exists "$backup_root/live/lib/telegram-relay.py" "backup captures lib"
+  smoke_assert_file_exists "$backup_root/live/bridge-telegram-relay.sh" "backup captures bridge-telegram-relay.sh"
+  smoke_assert_file_exists "$backup_root/live/plugins/telegram-relay/server.ts" "backup captures plugin tree"
+}
+
+assert_unparsed_reported() {
+  local json unparsed
+  # `assert_apply_rewrites_and_prunes` already mutated the roster. Z's
+  # malformed line is the only relay-token line left after that pass —
+  # re-run dry-run to capture it explicitly.
+  json="$(python3 "$CLEANUP_PY" --target-root "$BRIDGE_HOME" --dry-run --json)"
+  unparsed="$(json_field "$json" 'payload["unparsed_launch_cmd_lines"]')"
+  smoke_assert_eq "['Z']" "$unparsed" "agent Z surfaces in unparsed_launch_cmd_lines"
+}
+
+assert_idempotent() {
+  local json any_changes rewritten pruned
+
+  # Drop agent Z so the second run is genuinely clean.
+  python3 - "$BRIDGE_ROSTER_LOCAL_FILE" <<'PY'
+import sys
+from pathlib import Path
+path = Path(sys.argv[1])
+text = path.read_text(encoding="utf-8")
+keep = [line for line in text.splitlines(keepends=True) if 'BRIDGE_AGENT_LAUNCH_CMD["Z"]' not in line]
+path.write_text("".join(keep), encoding="utf-8")
+PY
+
+  json="$(python3 "$CLEANUP_PY" --target-root "$BRIDGE_HOME" --json)"
+  any_changes="$(json_field "$json" 'payload["any_changes"]')"
+  rewritten="$(json_field "$json" 'payload["launch_cmds_rewritten"]')"
+  pruned="$(json_field "$json" 'payload["live_files_pruned"]')"
+  smoke_assert_eq "False" "$any_changes" "second run is no-op"
+  smoke_assert_eq "[]" "$rewritten" "second run does not re-rewrite"
+  smoke_assert_eq "[]" "$pruned" "second run does not re-prune"
+}
+
+assert_symlink_safety() {
+  local json skipped target_passwd
+
+  # Reseed only the lib path as a symlink to a sensitive system file.
+  rm -f "$BRIDGE_HOME/lib/telegram-relay.py"
+  ln -s /etc/passwd "$BRIDGE_HOME/lib/telegram-relay.py"
+  # Snapshot inode so we can prove /etc/passwd was not deleted/replaced.
+  target_passwd="$(stat -f '%i' /etc/passwd 2>/dev/null || stat -c '%i' /etc/passwd)"
+
+  json="$(python3 "$CLEANUP_PY" --target-root "$BRIDGE_HOME" --json)"
+  skipped="$(json_field "$json" 'payload["prune_skipped"]')"
+  smoke_assert_contains "$skipped" "lib/telegram-relay.py" "symlink prune is refused"
+
+  [[ -L "$BRIDGE_HOME/lib/telegram-relay.py" ]] || smoke_fail "symlink must still exist (refused, not deleted)"
+  [[ -r /etc/passwd ]] || smoke_fail "/etc/passwd must remain readable"
+  local now_inode
+  now_inode="$(stat -f '%i' /etc/passwd 2>/dev/null || stat -c '%i' /etc/passwd)"
+  smoke_assert_eq "$target_passwd" "$now_inode" "/etc/passwd inode unchanged"
+
+  # Cleanup the symlink so subsequent assertions start from a known shape.
+  rm -f "$BRIDGE_HOME/lib/telegram-relay.py"
+}
+
+assert_stale_process_path_anchor() {
+  local foreign_root sleeper_py json terminated intree_pid foreign_pid
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    smoke_log "skipping stale-process assertion: python3 missing"
+    return 0
+  fi
+
+  # Build an in-tree relay sleeper so the path-prefix matcher fires.
+  mkdir -p "$BRIDGE_HOME/lib"
+  sleeper_py="$BRIDGE_HOME/lib/telegram-relay.py"
+  cat >"$sleeper_py" <<'PY'
+import sys, time
+# Distinct argv tail makes manual triage easier if the smoke ever
+# leaks a sleeper into the operator's process table.
+sys.argv = sys.argv + ["--smoke-fixture-tag=residue-cleanup"]
+time.sleep(120)
+PY
+
+  # Foreign sleeper (different root → must not be killed).
+  foreign_root="$SMOKE_TMP_ROOT/foreign-bridge"
+  mkdir -p "$foreign_root/lib"
+  cp "$sleeper_py" "$foreign_root/lib/telegram-relay.py"
+
+  python3 "$sleeper_py" >/dev/null 2>&1 &
+  intree_pid=$!
+  SMOKE_RELAY_INTREE_PID="$intree_pid"
+  python3 "$foreign_root/lib/telegram-relay.py" >/dev/null 2>&1 &
+  foreign_pid=$!
+  SMOKE_RELAY_FOREIGN_PID="$foreign_pid"
+
+  # Give both sleepers a moment to enter ps.
+  sleep 1
+
+  json="$(python3 "$CLEANUP_PY" --target-root "$BRIDGE_HOME" --term-timeout 4 --json)"
+  terminated="$(json_field "$json" 'payload["stale_processes_terminated"]')"
+  smoke_assert_contains "$terminated" "$intree_pid:" "in-tree relay PID matched and reported"
+  smoke_assert_not_contains "$terminated" "$foreign_pid:" "foreign-install relay PID NOT matched"
+
+  # Foreign sleeper must still be alive.
+  if ! kill -0 "$foreign_pid" 2>/dev/null; then
+    smoke_fail "foreign-install relay process was killed (path-prefix anchor leak)"
+  fi
+  # In-tree sleeper should be gone.
+  if kill -0 "$intree_pid" 2>/dev/null; then
+    smoke_fail "in-tree relay process survived SIGTERM/SIGKILL"
+  fi
+  SMOKE_RELAY_INTREE_PID=""
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "telegram-relay-residue"
+  write_fixture_roster
+  write_fixture_live_files
+  smoke_run "dry-run reports residue without mutating" assert_dry_run_reports_residue
+  smoke_run "apply rewrites launch cmd, prunes live tree, backs up" assert_apply_rewrites_and_prunes
+  smoke_run "malformed launch-cmd line surfaces as unparsed" assert_unparsed_reported
+  smoke_run "idempotent on a clean install" assert_idempotent
+  smoke_run "symlink at residue path refused" assert_symlink_safety
+  smoke_run "stale-process matcher anchored to absolute target_root" assert_stale_process_path_anchor
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Issue #523. Fixes the v0.7.0–v0.7.3 telegram-relay residue causal loop.
\`bridge-relay-cleanup.py\` did not rewrite \`BRIDGE_AGENT_LAUNCH_CMD\` lines
(Gap A), so agents kept loading the relay plugin every session, and the
upgrader's additive-only contract left the source-deleted relay tree on
disk (Gap B), feeding the loop. After this PR, cleanup reorders to:
rewrite launch cmds → SIGTERM/SIGKILL stale relay processes (path-rooted
match only) → prune \`lib/telegram-relay.py\` / \`bridge-telegram-relay.sh\`
/ \`plugins/telegram-relay/\` from the live runtime via versioned manifest
→ existing state/token cleanup. Backup goes through \`backup-extend-live\`
when invoked via \`agent-bridge upgrade --apply\`, otherwise to
\`<BRIDGE_HOME>/backups/relay-cleanup-<UTC-stamp>/\`.

## What changed

- **\`bridge-relay-cleanup.py\`** — added \`rewrite_launch_cmds\`,
  \`prune_live_files\`, \`stop_stale_relay_processes\`. Reordered \`main()\`
  per issue spec section C. New JSON output keys:
  \`launch_cmds_rewritten\`, \`unparsed_launch_cmd_lines\`,
  \`live_files_pruned\`, \`prune_skipped\`, \`stale_processes_terminated\`,
  \`agent_restart_required\`, \`backup_root\`. Both double- and
  single-quoted launch-cmd assignment forms supported; quoting style
  preserved on rewrite. Lines with escaped inner quotes (regex closes
  prematurely) surface as \`unparsed_launch_cmd_lines\` and are left
  untouched.
- **\`bridge-upgrade.sh\`** — pass \`--no-backup\` to the apply-mode
  cleanup call. The upgrader already extends the upgrade backup
  manifest from the dry-run preview's \`changed_paths\`; a second
  standalone backup under \`<target>/backups/relay-cleanup-*/\` would be
  redundant. Standalone (non-upgrade) invocations still produce a
  backup by default.
- **\`bridge-upgrade.py:cmd_backup_extend_live\`** — verified existing
  flow already handles directory entries via \`shutil.copytree\` (line
  ~1759). The new \`removed:<abs>/plugins/telegram-relay\` entries flow
  through unchanged.
- **\`scripts/smoke/telegram-relay-residue-cleanup.sh\`** (new, 246 LOC)
  — 6 contract assertions in an isolated \`BRIDGE_HOME=$(mktemp -d)\`:
  dry-run no-mutation, apply quoting/quote-style/dev-channel
  preservation, unparsed line reporting, idempotency, symlink safety
  (\`/etc/passwd\` inode unchanged across the cleanup),
  foreign-install process isolation (path-prefix anchor only — verified
  by spawning two relay sleepers under different prefixes and asserting
  only the in-tree one is killed).
- **\`scripts/ci-select-smoke.sh\`** — wired the new smoke into
  \`add_all_required_static\`, the \`bridge-upgrade.{sh,py}\` trigger,
  and a new \`bridge-relay-cleanup.py\` trigger.

## Out of scope (deliberate)

- No \`psutil\` hard dep — falls back to \`ps -eo pid,args\` with
  absolute-path-rooted matching. Substring-match against the bare name
  is rejected; foreign-install processes on a multi-install host are
  not affected.
- No auto-restart — operator runs \`agent-bridge agent restart <agent>\`
  per the new \`agent_restart_required\` summary field.
- No VERSION/CHANGELOG bump — release ships in a separate v0.7.5 PR
  after this and #522 land.
- No \`OPERATIONS.md\` / \`KNOWN_ISSUES.md\` doc edits — per brief, this
  PR is the work-around-removal, not the documentation-of-work-around;
  v0.7.5 release notes will summarize.

## Verification

- \`bash -n bridge-upgrade.sh scripts/smoke/telegram-relay-residue-cleanup.sh scripts/ci-select-smoke.sh\` — clean.
- \`shellcheck\` on the same set — clean.
- \`python3 -c "import ast; ast.parse(...)"\` on \`bridge-relay-cleanup.py\` and \`bridge-upgrade.py\` — clean.
- \`bash scripts/smoke/telegram-relay-residue-cleanup.sh\` — all 6 assertions pass.
- \`./scripts/smoke-test.sh\` — passes through the same point as
  \`main @ 24bce90\`. The two failures observed
  (\`refusing to write isolated agent-env.sh from ephemeral controller path\`
  and \`auto-start role did not start with timeout=0\`) reproduce on a
  fresh checkout of \`main\` without any of these changes; they are
  pre-existing and unrelated to this PR.

## Manual verification (recommended for reviewer)

The upgrader integration cannot be exercised by the smoke script because
\`./scripts/smoke/upgrade.sh\` does not run the cleanup helper end-to-end.
Suggested manual check:

\`\`\`bash
export BRIDGE_HOME=$(mktemp -d -t relay-residue-XXXX)/bridge-home
mkdir -p "\$BRIDGE_HOME/lib" "\$BRIDGE_HOME/plugins/telegram-relay"
echo 'fixture' > "\$BRIDGE_HOME/lib/telegram-relay.py"
echo 'fixture' > "\$BRIDGE_HOME/bridge-telegram-relay.sh"
echo 'fixture' > "\$BRIDGE_HOME/plugins/telegram-relay/server.ts"
cat > "\$BRIDGE_HOME/agent-roster.local.sh" <<'ROSTER'
BRIDGE_AGENT_CHANNELS["smoke"]="plugin:telegram@claude-plugins-official"
BRIDGE_AGENT_LAUNCH_CMD["smoke"]="claude --dangerously-load-development-channels plugin:telegram-relay@agent-bridge"
ROSTER

python3 bridge-relay-cleanup.py --target-root "\$BRIDGE_HOME" --json | jq
ls "\$BRIDGE_HOME/lib" "\$BRIDGE_HOME/plugins" 2>&1   # tree gone
grep telegram-relay "\$BRIDGE_HOME/agent-roster.local.sh" || echo "rewrite ok"
ls -la "\$BRIDGE_HOME/backups/"     # backup directory exists
\`\`\`

Closes #523.