### PR TITLE
fix(agent-create): reject CLI-flag and reserved names; add new smoke (#526)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -861,7 +861,16 @@ done
 [[ -z "$NAME" ]] && bridge_die "--name은 필수입니다."
 
 if ! bridge_validate_agent_name "$NAME"; then
-  bridge_die "이름은 영문/숫자/점/밑줄/하이픈만 허용합니다: $NAME"
+  # Issue #526: same leading-dash / reserved-name rejection as `agent
+  # create`. Helps users who accidentally typed `--name --help`.
+  case "$NAME" in
+    -*)
+      bridge_die "이름이 CLI 플래그처럼 보입니다: '$NAME'. 도움말은 '$CLI_NAME --help' 를 실행하세요."
+      ;;
+    *)
+      bridge_die "이름은 영문/숫자/점/밑줄/하이픈만 허용하고 영문/숫자로 시작해야 하며 'help'/'version' 은 예약어입니다: $NAME"
+      ;;
+  esac
 fi
 
 case "$SPAWN_PREFERENCE" in

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1680,8 +1680,28 @@ run_create() {
   local start_dry_run=""
 
   shift || true
+
+  # Issue #526: short-circuit help BEFORE the positional <agent> binding
+  # so `bridge-agent.sh create --help` (or via `agent-bridge agent create
+  # --help`) prints usage instead of scaffolding an agent named `--help`.
+  case "$agent" in
+    -h|--help|help)
+      usage
+      return 0
+      ;;
+  esac
+
   [[ -n "$agent" ]] || bridge_die "Usage: $(basename "$0") create <agent> [...]"
-  bridge_validate_agent_name "$agent" || bridge_die "에이전트 이름은 영문/숫자/._- 만 사용할 수 있습니다: $agent"
+  if ! bridge_validate_agent_name "$agent"; then
+    case "$agent" in
+      -*)
+        bridge_die "에이전트 이름이 CLI 플래그처럼 보입니다: '$agent'. 도움말을 보려면 '$(basename "$0") create --help' 를 실행하세요."
+        ;;
+      *)
+        bridge_die "에이전트 이름은 영문/숫자/._- 만 사용할 수 있고 영문/숫자로 시작해야 하며 'help'/'version' 은 예약어입니다: $agent"
+        ;;
+    esac
+  fi
   if bridge_agent_exists "$agent"; then
     bridge_die "이미 등록된 에이전트입니다: $agent"
   fi

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -567,7 +567,19 @@ bridge_add_agent_id_if_missing() {
 
 bridge_validate_agent_name() {
   local name="$1"
-  [[ "$name" =~ ^[A-Za-z0-9._-]+$ ]]
+
+  # Issue #526: a leading hyphen lets `--help` / `-h` / future flag names
+  # slip through as positional <name> arguments and silently scaffold a real
+  # agent named `--help`. Require the first character to be alphanumeric so
+  # CLI flags can never bind here.
+  [[ "$name" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || return 1
+
+  # Reserved-name list: bare words that look like CLI verbs.
+  case "$name" in
+    help|version) return 1 ;;
+  esac
+
+  return 0
 }
 
 bridge_join_quoted() {

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup
+  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation
 }
 
 add_all_integration() {
@@ -193,7 +193,7 @@ select_for_path() {
       ;;
 
     bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh)
-      add_required launch tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate
+      add_required launch tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -192,7 +192,7 @@ select_for_path() {
       add_live live-tmux-daemon
       ;;
 
-    bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh)
+    bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh|lib/bridge-wave.sh)
       add_required launch tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation
       add_integration integration-minimal
       add_live live-tmux-daemon

--- a/scripts/smoke/agent-create-name-validation.sh
+++ b/scripts/smoke/agent-create-name-validation.sh
@@ -3,14 +3,19 @@
 #
 # Validates that `bridge-agent.sh create <name>` rejects names that look
 # like CLI flags or reserved verbs before any roster mutation, and that
-# `--help` short-circuits to the create usage banner. Six assertions:
+# `--help` short-circuits to the create usage banner. Seven assertions:
 #
 # 1. `create --help` exits 0, prints usage, does NOT scaffold an agent.
 # 2. `create -h` is treated the same way.
-# 3. `create help` is rejected as a reserved name (and no scaffold).
+# 3. `create version` is rejected as a reserved name (and no scaffold).
+#    `version` is on the reserved list but — unlike `help` — is NOT
+#    intercepted by the help-first short-circuit, so it actually exercises
+#    the reserved-name branch in bridge_validate_agent_name.
 # 4. `create ""` is rejected (Usage hint, no scaffold).
 # 5. `create 'evil"name'` is rejected by the char-class regex (no scaffold).
-# 6. Negative control: `create valid-worker --dry-run` succeeds and emits a
+# 6. Positive control: `create 9worker --dry-run` succeeds, locking in the
+#    intentional regex loosening that allows numeric-start names.
+# 7. Negative control: `create valid-worker --dry-run` succeeds and emits a
 #    role block on stdout without mutating the local roster file.
 
 set -euo pipefail
@@ -58,14 +63,15 @@ assert_help_short_circuit() {
   assert_no_scaffold "create $flag" "$flag"
 }
 
-assert_reserved_help_word() {
+assert_reserved_version_word() {
   reset_runtime
   local out
-  out="$(run_create "help")"
-  # `help` is a reserved bare verb, AND is also intercepted by the
-  # help-first short-circuit in run_create — either way no scaffold.
-  smoke_assert_contains "$out" "create <agent>" "create help short-circuits to usage"
-  assert_no_scaffold "create help" "help"
+  out="$(run_create "version")"
+  # `version` is on the reserved-name list but is NOT intercepted by the
+  # help-first short-circuit (which only handles -h/--help/help), so this
+  # actually exercises the reserved-name branch of the validator.
+  smoke_assert_contains "$out" "예약어" "create version rejected by reserved-name validator"
+  assert_no_scaffold "create version" "version"
 }
 
 assert_empty_name() {
@@ -82,6 +88,23 @@ assert_metachar_name() {
   out="$(run_create 'evil"name')"
   smoke_assert_contains "$out" "에이전트 이름" "create 'evil\"name' rejected by validator"
   assert_no_scaffold "create metachar" 'evil"name'
+}
+
+assert_numeric_start_dry_run() {
+  reset_runtime
+  local out
+  out="$(run_create 9worker --engine claude --dry-run)"
+  smoke_assert_contains "$out" "agent: 9worker" \
+    "create 9worker --dry-run accepted (numeric-start regex loosening)"
+  smoke_assert_contains "$out" "dry_run: yes" \
+    "create 9worker --dry-run flags itself as a plan, not a mutation"
+  if [[ -s "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
+    smoke_assert_not_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" \
+      "MANAGED ROLE: 9worker" \
+      "create 9worker --dry-run does not mutate local roster"
+  fi
+  [[ ! -d "$BRIDGE_AGENT_HOME_ROOT/9worker" ]] || \
+    smoke_fail "create 9worker --dry-run unexpectedly created agents/9worker/"
 }
 
 assert_valid_dry_run() {
@@ -110,9 +133,10 @@ main() {
 
   smoke_run "create --help short-circuits"  assert_help_short_circuit --help
   smoke_run "create -h short-circuits"      assert_help_short_circuit -h
-  smoke_run "create help reserved-word"     assert_reserved_help_word
+  smoke_run "create version reserved-word"  assert_reserved_version_word
   smoke_run "create '' rejected"            assert_empty_name
   smoke_run "create 'evil\"name' rejected"  assert_metachar_name
+  smoke_run "create 9worker --dry-run"      assert_numeric_start_dry_run
   smoke_run "create valid-worker --dry-run" assert_valid_dry_run
 
   smoke_log "PASS"

--- a/scripts/smoke/agent-create-name-validation.sh
+++ b/scripts/smoke/agent-create-name-validation.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# scripts/smoke/agent-create-name-validation.sh — Issue #526 smoke.
+#
+# Validates that `bridge-agent.sh create <name>` rejects names that look
+# like CLI flags or reserved verbs before any roster mutation, and that
+# `--help` short-circuits to the create usage banner. Six assertions:
+#
+# 1. `create --help` exits 0, prints usage, does NOT scaffold an agent.
+# 2. `create -h` is treated the same way.
+# 3. `create help` is rejected as a reserved name (and no scaffold).
+# 4. `create ""` is rejected (Usage hint, no scaffold).
+# 5. `create 'evil"name'` is rejected by the char-class regex (no scaffold).
+# 6. Negative control: `create valid-worker --dry-run` succeeds and emits a
+#    role block on stdout without mutating the local roster file.
+
+set -euo pipefail
+
+SMOKE_NAME="agent-create-name-validation"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+run_create() {
+  # Capture stdout+stderr together; never let a non-zero exit kill the test
+  # before we assert on the captured text.
+  bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
+}
+
+assert_no_scaffold() {
+  local label="$1"
+  local bad_name="$2"
+  smoke_assert_eq "" "$(ls "$BRIDGE_AGENT_HOME_ROOT" 2>/dev/null || true)" \
+    "$label: agents/ root stays empty (no '$bad_name' dir scaffolded)"
+  if [[ -s "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
+    smoke_assert_not_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" \
+      "MANAGED ROLE: $bad_name" \
+      "$label: local roster has no MANAGED ROLE block for '$bad_name'"
+  fi
+}
+
+reset_runtime() {
+  rm -rf "$BRIDGE_AGENT_HOME_ROOT"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT"
+  : >"$BRIDGE_ROSTER_LOCAL_FILE"
+}
+
+assert_help_short_circuit() {
+  local flag="$1"
+  reset_runtime
+  local out
+  out="$(run_create "$flag")"
+  smoke_assert_contains "$out" "create <agent>" "create $flag prints usage banner"
+  assert_no_scaffold "create $flag" "$flag"
+}
+
+assert_reserved_help_word() {
+  reset_runtime
+  local out
+  out="$(run_create "help")"
+  # `help` is a reserved bare verb, AND is also intercepted by the
+  # help-first short-circuit in run_create — either way no scaffold.
+  smoke_assert_contains "$out" "create <agent>" "create help short-circuits to usage"
+  assert_no_scaffold "create help" "help"
+}
+
+assert_empty_name() {
+  reset_runtime
+  local out
+  out="$(run_create "")"
+  smoke_assert_contains "$out" "Usage:" "create '' surfaces Usage hint"
+  assert_no_scaffold "create empty" ""
+}
+
+assert_metachar_name() {
+  reset_runtime
+  local out
+  out="$(run_create 'evil"name')"
+  smoke_assert_contains "$out" "에이전트 이름" "create 'evil\"name' rejected by validator"
+  assert_no_scaffold "create metachar" 'evil"name'
+}
+
+assert_valid_dry_run() {
+  reset_runtime
+  local out
+  out="$(run_create valid-worker --engine claude --dry-run)"
+  smoke_assert_contains "$out" "agent: valid-worker" \
+    "create valid-worker --dry-run echoes agent line"
+  smoke_assert_contains "$out" "engine: claude" \
+    "create valid-worker --dry-run echoes engine line"
+  smoke_assert_contains "$out" "dry_run: yes" \
+    "create valid-worker --dry-run flags itself as a plan, not a mutation"
+  # --dry-run must not actually mutate the roster.
+  if [[ -s "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
+    smoke_assert_not_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" \
+      "MANAGED ROLE: valid-worker" \
+      "create valid-worker --dry-run does not mutate local roster"
+  fi
+  # And it must not have created a runtime home for the agent.
+  [[ ! -d "$BRIDGE_AGENT_HOME_ROOT/valid-worker" ]] || \
+    smoke_fail "create valid-worker --dry-run unexpectedly created agents/valid-worker/"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  smoke_run "create --help short-circuits"  assert_help_short_circuit --help
+  smoke_run "create -h short-circuits"      assert_help_short_circuit -h
+  smoke_run "create help reserved-word"     assert_reserved_help_word
+  smoke_run "create '' rejected"            assert_empty_name
+  smoke_run "create 'evil\"name' rejected"  assert_metachar_name
+  smoke_run "create valid-worker --dry-run" assert_valid_dry_run
+
+  smoke_log "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Issue #526. `agent-bridge agent create --help` no longer creates an agent literally named `--help`. The `bridge_validate_agent_name` helper now requires an alphanumeric first character (so any leading-dash CLI flag — `--help`, `-h`, `--version`, `--debug`, future flags — can never bind to the positional `<name>`) and the bare reserved words `help` / `version` are also rejected. The empty string and shell metacharacters were already rejected by the existing char-class regex; the strengthened regex preserves that.

The `run_create` handler in `bridge-agent.sh` now short-circuits `-h` / `--help` / `help` BEFORE positional binding, so `bridge-agent.sh create --help` (or `agent-bridge agent create --help`) prints the create usage banner instead of failing the validator. Both callers (the create subcommand and the top-level `agent-bridge --codex/--claude --name <NAME>` dynamic spawn) emit a friendlier "looks like a CLI flag" error pointing at the right help command when a flag-shaped name slips in.

## What changed

- `lib/bridge-core.sh` — `bridge_validate_agent_name` regex now `^[A-Za-z0-9][A-Za-z0-9._-]*$`; reserved-name guard for `help` / `version`. All three callers (`bridge-agent.sh` create, `agent-bridge` dynamic spawn, `lib/bridge-wave.sh` worker dispatch) inherit the strengthening.
- `bridge-agent.sh` — help-first short-circuit at the top of `run_create`; error message now distinguishes "looks like a CLI flag" from "violates char rules".
- `agent-bridge` — same dual error message in the dynamic-spawn validator branch.
- `scripts/smoke/agent-create-name-validation.sh` (new, +97 LOC) — six assertions: rejects `--help` / `-h` / `help` / empty / `evil"name` (each with no agents scaffold AND no roster mutation), allows `valid-worker --dry-run` (negative control: stdout has agent/engine/dry_run lines, roster untouched, no agents/valid-worker dir).
- `scripts/ci-select-smoke.sh` — added to `add_all_required_static` and to the `bridge-agent.sh|agent-bridge|...` path-trigger map.

## Verification

- `bash -n` clean on all 4 touched shell files + new smoke.
- `shellcheck` clean on all 5 files.
- `bash scripts/smoke/agent-create-name-validation.sh` → 6/6 PASS.
- `bash scripts/smoke/launch.sh` → PASS (regression).
- `bash scripts/smoke/admin-codex-pair.sh` → PASS (regression).
- `scripts/smoke-test.sh` has a pre-existing failure on `[smoke] guarding isolated agent-env writes from stale tmp controller env (#365 follow-up)` that reproduces on `main` at the same SHA without any of these edits — unrelated.

## Out of scope

- No CHANGELOG/VERSION bump; release ships when operator OKs.
- No tool-policy or roster-format changes; that is #528 territory.
- Sibling subcommands (`agent show`, `agent start`, etc.) that take a positional `<name>` already die safely via `bridge_require_agent` (no destructive scaffolding) and were intentionally not refactored — per issue brief: out of scope to retrofit help-first parsing on every subcommand.

Closes #526.