### PR TITLE
fix(launch): inject BRIDGE_AGENT_CHANNELS dev-channels into static Claude argv (#529)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4053,8 +4053,12 @@ bridge_agent_channel_launch_allowlisted_for_item() {
   }
 
   item="$(bridge_qualify_channel_item "$item")"
+  # Mirror the real launch-builder path: bridge_agent_launch_cmd() applies
+  # bridge_claude_launch_with_channels then bridge_claude_launch_with_development_channels
+  # using bridge_agent_required_dev_channels_csv. Use the same arg here so the
+  # diagnostic surface (launch_allowlisted) matches what `claude` actually receives.
   generated="$(bridge_claude_launch_with_channels "$agent" "$(bridge_agent_launch_cmd_raw "$agent")")"
-  generated="$(bridge_claude_launch_with_development_channels "$generated" "$(bridge_agent_dev_channels_csv "$agent")")"
+  generated="$(bridge_claude_launch_with_development_channels "$generated" "$(bridge_agent_required_dev_channels_csv "$agent")")"
   effective="$(bridge_extract_channels_from_command "$generated")"
   effective_dev="$(bridge_extract_development_channels_from_command "$generated")"
   if bridge_channel_item_is_development "$item"; then

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -803,6 +803,7 @@ bridge_agent_launch_cmd() {
         launch_cmd="$(bridge_codex_launch_with_hooks "$launch_cmd")"
       elif [[ "$engine" == "claude" ]]; then
         launch_cmd="$(bridge_claude_launch_with_channels "$agent" "$launch_cmd")"
+        launch_cmd="$(bridge_claude_launch_with_development_channels "$launch_cmd" "$(bridge_agent_required_dev_channels_csv "$agent")")"
         launch_cmd="$(bridge_claude_launch_with_channel_state_dirs "$agent" "$launch_cmd")"
       fi
       launch_cmd="$(bridge_claude_launch_with_webhook "$agent" "$launch_cmd")"
@@ -814,6 +815,7 @@ bridge_agent_launch_cmd() {
       launch_cmd="$(bridge_codex_launch_with_hooks "$launch_cmd")"
     elif [[ "$engine" == "claude" ]]; then
       launch_cmd="$(bridge_claude_launch_with_channels "$agent" "$launch_cmd")"
+      launch_cmd="$(bridge_claude_launch_with_development_channels "$launch_cmd" "$(bridge_agent_required_dev_channels_csv "$agent")")"
       launch_cmd="$(bridge_claude_launch_with_channel_state_dirs "$agent" "$launch_cmd")"
     fi
     launch_cmd="$(bridge_claude_launch_with_webhook "$agent" "$launch_cmd")"
@@ -824,6 +826,7 @@ bridge_agent_launch_cmd() {
   fallback="${BRIDGE_AGENT_LAUNCH_CMD[$agent]-}"
   if [[ "$engine" == "claude" ]] && launch_cmd="$(bridge_build_static_claude_launch_cmd "$agent")"; then
     launch_cmd="$(bridge_claude_launch_with_channels "$agent" "$launch_cmd")"
+    launch_cmd="$(bridge_claude_launch_with_development_channels "$launch_cmd" "$(bridge_agent_required_dev_channels_csv "$agent")")"
     launch_cmd="$(bridge_claude_launch_with_channel_state_dirs "$agent" "$launch_cmd")"
     launch_cmd="$(bridge_claude_launch_with_webhook "$agent" "$launch_cmd")"
     printf '%s' "$launch_cmd"
@@ -834,6 +837,7 @@ bridge_agent_launch_cmd() {
       launch_cmd="$(bridge_codex_launch_with_hooks "$launch_cmd")"
     elif [[ "$(bridge_agent_engine "$agent")" == "claude" ]]; then
       launch_cmd="$(bridge_claude_launch_with_channels "$agent" "$launch_cmd")"
+      launch_cmd="$(bridge_claude_launch_with_development_channels "$launch_cmd" "$(bridge_agent_required_dev_channels_csv "$agent")")"
       launch_cmd="$(bridge_claude_launch_with_channel_state_dirs "$agent" "$launch_cmd")"
     fi
     launch_cmd="$(bridge_claude_launch_with_webhook "$agent" "$launch_cmd")"
@@ -845,6 +849,7 @@ bridge_agent_launch_cmd() {
     fallback="$(bridge_codex_launch_with_hooks "$fallback")"
   elif [[ "$(bridge_agent_engine "$agent")" == "claude" ]]; then
     fallback="$(bridge_claude_launch_with_channels "$agent" "$fallback")"
+    fallback="$(bridge_claude_launch_with_development_channels "$fallback" "$(bridge_agent_required_dev_channels_csv "$agent")")"
     fallback="$(bridge_claude_launch_with_channel_state_dirs "$agent" "$fallback")"
   fi
   launch_cmd="$(bridge_claude_launch_with_webhook "$agent" "$fallback")"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation
 }
 
 add_all_integration() {
@@ -187,13 +187,13 @@ select_for_path() {
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)
-      add_required daemon queue
+      add_required daemon queue launch-dev-channels-injection
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
 
     bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh|lib/bridge-wave.sh)
-      add_required launch tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke/launch-dev-channels-injection.sh
+++ b/scripts/smoke/launch-dev-channels-injection.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+
+# Issue #529: BRIDGE_AGENT_CHANNELS development-channel plugins must reach
+# the actual `claude` argv. The launch builder previously called
+# bridge_claude_launch_with_channels but never bridge_claude_launch_with_development_channels,
+# while channel diagnostics simulated the missing call and reported
+# launch_allowlisted=yes. This smoke locks the contract so the simulate-vs-real
+# drift cannot return:
+#
+# 1. injection: BRIDGE_AGENT_CHANNELS dev-channel reaches the built launch_cmd.
+# 2. dedup: a hand-pasted token in raw BRIDGE_AGENT_LAUNCH_CMD is not duplicated.
+# 3. multi-channel order: declaration order is preserved for multiple dev channels.
+# 4. diagnostic alignment: launch_allowlisted matches whether the real builder
+#    actually injects the token (positive and negative cases).
+# 5. non-dev untouched: an official-marketplace plugin does NOT acquire a
+#    --dangerously-load-development-channels token, while a co-declared dev
+#    channel does.
+
+set -euo pipefail
+
+SMOKE_NAME="launch-dev-channels-injection"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+source_bridge_lib() {
+  # shellcheck source=bridge-lib.sh
+  source "$SMOKE_REPO_ROOT/bridge-lib.sh"
+  # Initialize the roster associative arrays (bridge_reset_roster_maps runs
+  # inside bridge_load_roster). Without this the per-agent map slots are
+  # unbound and assignments below trigger `set -u` errors.
+  bridge_load_roster
+}
+
+register_worker_static_claude() {
+  local workdir="$BRIDGE_AGENT_HOME_ROOT/worker"
+  mkdir -p "$workdir"
+  bridge_add_agent_id_if_missing "worker"
+  BRIDGE_AGENT_ENGINE["worker"]="claude"
+  BRIDGE_AGENT_SOURCE["worker"]="static"
+  BRIDGE_AGENT_SESSION["worker"]="worker-session"
+  BRIDGE_AGENT_WORKDIR["worker"]="$workdir"
+  BRIDGE_AGENT_LOOP["worker"]=0
+  BRIDGE_AGENT_CONTINUE["worker"]=0
+}
+
+count_substring() {
+  local haystack="$1"
+  local needle="$2"
+  local trimmed="${haystack//$needle/}"
+  local removed=$(( ${#haystack} - ${#trimmed} ))
+  if (( ${#needle} == 0 )); then
+    printf '0'
+    return 0
+  fi
+  printf '%d' $(( removed / ${#needle} ))
+}
+
+assert_injection() {
+  local launch_cmd
+  BRIDGE_AGENT_CHANNELS["worker"]="plugin:foo@m"
+  BRIDGE_AGENT_LAUNCH_CMD["worker"]="claude --dangerously-skip-permissions"
+
+  launch_cmd="$(bridge_agent_launch_cmd worker)"
+  smoke_assert_contains "$launch_cmd" "--dangerously-load-development-channels plugin:foo@m" \
+    "real launch builder injects BRIDGE_AGENT_CHANNELS dev plugin into argv"
+}
+
+assert_dedup_against_raw_paste() {
+  local launch_cmd count
+  BRIDGE_AGENT_CHANNELS["worker"]="plugin:foo@m"
+  BRIDGE_AGENT_LAUNCH_CMD["worker"]="claude --dangerously-load-development-channels plugin:foo@m --dangerously-skip-permissions"
+
+  launch_cmd="$(bridge_agent_launch_cmd worker)"
+  count="$(count_substring "$launch_cmd" "plugin:foo@m")"
+  smoke_assert_eq "1" "$count" \
+    "dev-channel injection dedups against operator-pasted raw LAUNCH_CMD token"
+}
+
+assert_multi_channel_order_stable() {
+  local launch_cmd a_pos b_pos
+  BRIDGE_AGENT_CHANNELS["worker"]="plugin:a@m,plugin:b@m"
+  BRIDGE_AGENT_LAUNCH_CMD["worker"]="claude --dangerously-skip-permissions"
+
+  launch_cmd="$(bridge_agent_launch_cmd worker)"
+  smoke_assert_contains "$launch_cmd" "--dangerously-load-development-channels plugin:a@m" \
+    "first declared dev channel reaches argv"
+  smoke_assert_contains "$launch_cmd" "--dangerously-load-development-channels plugin:b@m" \
+    "second declared dev channel reaches argv"
+
+  # Order: plugin:a@m must appear before plugin:b@m in the rebuilt command.
+  a_pos="$(awk -v s="$launch_cmd" -v t="plugin:a@m" 'BEGIN { print index(s, t) }')"
+  b_pos="$(awk -v s="$launch_cmd" -v t="plugin:b@m" 'BEGIN { print index(s, t) }')"
+  if (( a_pos == 0 || b_pos == 0 || a_pos >= b_pos )); then
+    smoke_fail "multi-channel order: expected plugin:a@m before plugin:b@m in: $launch_cmd"
+  fi
+}
+
+assert_diagnostic_alignment() {
+  local launch_cmd allowlisted
+
+  # Positive case: declared dev channel must be allowlisted AND injected.
+  BRIDGE_AGENT_CHANNELS["worker"]="plugin:foo@m"
+  BRIDGE_AGENT_LAUNCH_CMD["worker"]="claude --dangerously-skip-permissions"
+
+  launch_cmd="$(bridge_agent_launch_cmd worker)"
+  smoke_assert_contains "$launch_cmd" "--dangerously-load-development-channels plugin:foo@m" \
+    "diagnostic alignment positive: real builder injects token"
+
+  allowlisted="$(bridge_agent_channel_launch_allowlisted_for_item worker plugin:foo@m)"
+  smoke_assert_eq "yes" "$allowlisted" \
+    "diagnostic alignment positive: launch_allowlisted reports yes when real builder injects"
+
+  # Negative case: remove the channel; both surfaces must agree it's not loaded.
+  BRIDGE_AGENT_CHANNELS["worker"]=""
+  launch_cmd="$(bridge_agent_launch_cmd worker)"
+  smoke_assert_not_contains "$launch_cmd" "--dangerously-load-development-channels plugin:foo@m" \
+    "diagnostic alignment negative: removed channel not in real builder argv"
+
+  allowlisted="$(bridge_agent_channel_launch_allowlisted_for_item worker plugin:foo@m)"
+  smoke_assert_eq "no" "$allowlisted" \
+    "diagnostic alignment negative: launch_allowlisted reports no when real builder skips"
+}
+
+assert_non_dev_channel_untouched() {
+  local launch_cmd dev_count
+  # plugin:telegram@claude-plugins-official is the canonical non-dev (official
+  # marketplace) plugin per bridge_channel_item_is_development. plugin:foo@m
+  # is dev (marketplace != claude-plugins-official).
+  BRIDGE_AGENT_CHANNELS["worker"]="plugin:telegram@claude-plugins-official,plugin:foo@m"
+  BRIDGE_AGENT_LAUNCH_CMD["worker"]="claude --dangerously-skip-permissions"
+
+  launch_cmd="$(bridge_agent_launch_cmd worker)"
+
+  smoke_assert_contains "$launch_cmd" "--dangerously-load-development-channels plugin:foo@m" \
+    "co-declared dev channel still injected when alongside non-dev"
+  smoke_assert_not_contains "$launch_cmd" "--dangerously-load-development-channels plugin:telegram@claude-plugins-official" \
+    "official-marketplace plugin must not get a --dangerously-load-development-channels token"
+
+  # Sanity: only one --dangerously-load-development-channels occurrence overall
+  # (for plugin:foo@m), proving the official channel did not produce a second.
+  dev_count="$(count_substring "$launch_cmd" "--dangerously-load-development-channels")"
+  smoke_assert_eq "1" "$dev_count" \
+    "exactly one dev-channel token emitted when one dev + one non-dev channel are declared"
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "launch-dev-channels-injection"
+  source_bridge_lib
+  register_worker_static_claude
+  smoke_run "BRIDGE_AGENT_CHANNELS dev plugin reaches argv"           assert_injection
+  smoke_run "dedup against operator-pasted raw LAUNCH_CMD token"      assert_dedup_against_raw_paste
+  smoke_run "multi-channel injection preserves declaration order"    assert_multi_channel_order_stable
+  smoke_run "diagnostic launch_allowlisted matches real builder"     assert_diagnostic_alignment
+  smoke_run "non-dev (official) channel does not get dev-load token" assert_non_dev_channel_untouched
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Issue #529. `bridge_agent_launch_cmd()` now calls
`bridge_claude_launch_with_development_channels()` in every Claude branch
(dynamic / resume / static / fallback), so dev-channel plugins declared in
`BRIDGE_AGENT_CHANNELS` (any `plugin:<name>@<marketplace>` whose marketplace
is not `claude-plugins-official`) actually reach the launched `claude` argv.
The diagnostic surface (`agent-bridge agent show X` / `launch_allowlisted`)
now feeds the same `bridge_agent_required_dev_channels_csv` input the real
builder uses, closing the simulate-vs-real drift that allowed this
regression to be silent.

## What changed

- `lib/bridge-state.sh` — inserted
  `bridge_claude_launch_with_development_channels` between
  `bridge_claude_launch_with_channels` and
  `bridge_claude_launch_with_channel_state_dirs` in all 4 Claude branches of
  `bridge_agent_launch_cmd()`. The helper already dedups against raw
  `BRIDGE_AGENT_LAUNCH_CMD` tokens, so operators who hand-pasted a
  `--dangerously-load-development-channels plugin:foo@spec` token are not
  affected (assertion #2 below).

- `lib/bridge-agents.sh` — diagnostic alignment via the **same-args helper
  call** strategy. `bridge_agent_channel_launch_allowlisted_for_item` now
  passes `bridge_agent_required_dev_channels_csv "$agent"` (Claude-plugin
  filtered) into the simulation, matching the real builder's input. Chosen
  over "invoke `bridge_agent_launch_cmd` from diagnostics" because that
  function calls `bridge_normalize_agent_session_id`, which mutates state
  (`BRIDGE_AGENT_SESSION_ID[…]` and persisted state) — diagnostics must
  stay read-only. The launch status-reason path at line 4720 already used
  the right helper.

- `scripts/smoke/launch-dev-channels-injection.sh` (new) — 5 assertions:
  1. Real `bridge_agent_launch_cmd` argv contains
     `--dangerously-load-development-channels plugin:foo@m`
     when only `BRIDGE_AGENT_CHANNELS["worker"]="plugin:foo@m"` is set.
  2. Operator-pasted raw token is not duplicated (helper dedup).
  3. Multi-channel declaration order is preserved.
  4. `launch_allowlisted` matches the real argv in both positive and
     negative cases (channel removed → both flip to `no`).
  5. Co-declared `plugin:telegram@claude-plugins-official` (official
     marketplace = non-dev per `bridge_channel_item_is_development`)
     does NOT receive a `--dangerously-load-development-channels` token.

- `scripts/ci-select-smoke.sh` — wired into `add_all_required_static` and
  added to the path-trigger entries for `lib/bridge-state.sh` and the
  `bridge-start.sh|bridge-run.sh|…|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh`
  family. Edits to `lib/bridge-agents.sh` already fall into the
  `add_all_required_static` selector.

## Verification

```
bash -n lib/bridge-state.sh lib/bridge-agents.sh scripts/smoke/launch-dev-channels-injection.sh   # ok
shellcheck lib/bridge-state.sh lib/bridge-agents.sh scripts/smoke/launch-dev-channels-injection.sh # ok (exit 0)
shellcheck *.sh agent-bridge agb lib/*.sh scripts/*.sh agent-roster.local.example.sh              # ok (exit 0)
bash scripts/smoke/launch-dev-channels-injection.sh   # passed (5/5)
bash scripts/smoke/launch.sh                          # passed (regression)
bash scripts/smoke/tmux-injection.sh                  # passed (regression)
```

`./scripts/smoke-test.sh` reproduces a pre-existing `expected output to
contain: smoke-agent-35155` failure on `main` at the static-role roster-sync
step — unrelated to this change (no edits touch roster sync).

## Out of scope

- No fix for the typed-updater path (#528 is a separate PR).
- No VERSION/CHANGELOG bump.
- No roster-format / parse changes; only the launch-builder consumption of
  `BRIDGE_AGENT_CHANNELS`.

## Reproducibility (for the reviewer)

- Path: `~/Projects/agent-bridge-public/.claude/worktrees/<wt>` →
  `cd "$(git rev-parse --show-toplevel)"` after checking out the branch.
- Env: clean shell, `unset BRIDGE_HOME BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT`.
- The new smoke is self-contained: it calls `smoke_setup_bridge_home`
  (mktemp BRIDGE_HOME), sources `bridge-lib.sh`, runs
  `bridge_load_roster` to initialise the associative arrays, then mutates
  `BRIDGE_AGENT_CHANNELS`/`BRIDGE_AGENT_LAUNCH_CMD` in-process and asserts
  `bridge_agent_launch_cmd worker` and
  `bridge_agent_channel_launch_allowlisted_for_item worker plugin:foo@m`.

Refs #529.