### PR TITLE
fix(channel-env): isolation-aware readiness enum + ACL diagnostic + ms365 status_reason (#534)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3839,6 +3839,131 @@ bridge_env_file_has_any_nonempty_key() {
   return 1
 }
 
+# Issue #534: isolation-aware readiness probe for channel `.env` files.
+#
+# Returns one of "present" | "missing" | "unreadable" via stdout. Suppresses
+# raw grep stderr (which previously leaked `Permission denied` to the daemon
+# log on every channel-health cycle in linux-user isolation when the
+# controller-side ACL had drifted). Distinguishes:
+#
+#   - "present"    — file readable and at least one of the requested keys
+#                    has a non-empty value.
+#   - "missing"    — file absent OR file readable but no requested key is
+#                    present with a non-empty value.
+#   - "unreadable" — file exists but the controller cannot read it (EACCES);
+#                    in linux-user isolation this triggers a bounded ACL
+#                    repair retry via bridge_linux_acl_repair_channel_env_files
+#                    before giving up.
+#
+# rc=1 vs rc=2 from grep:
+#   The internal grep helper returns 1 on "no match" and 2 on file/permission
+#   error. Bash conflates these into a single non-zero exit, so we
+#   distinguish via a `[[ -r "$file" ]]` probe after the helper fails.
+#
+# Usage:
+#   case "$(bridge_channel_env_file_readiness <agent> <item> <file> <key>...)" in
+#     present)    ... ;;
+#     missing)    ... ;;
+#     unreadable) ... ;;   # caller may then call bridge_channel_env_file_acl_diagnostic
+#   esac
+bridge_channel_env_file_readiness() {
+  local agent="$1"
+  local item="$2"
+  local file="$3"
+  shift 3 || true
+  local rc=0
+
+  if [[ ! -e "$file" ]]; then
+    printf 'missing'
+    return 0
+  fi
+
+  # First read attempt as the controller; suppress stderr so EACCES does
+  # not leak to the daemon log. rc captured separately.
+  rc=0
+  bridge_env_file_has_any_nonempty_key "$file" "$@" >/dev/null 2>&1 || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    printf 'present'
+    return 0
+  fi
+
+  if [[ -r "$file" ]]; then
+    # File readable; helper just didn't find a non-empty matching key.
+    printf 'missing'
+    return 0
+  fi
+
+  # Unreadable. In linux-user isolation, attempt bounded ACL repair.
+  local repair_attempts="${BRIDGE_ENV_READINESS_REPAIR_ATTEMPTS:-2}"
+  local attempt=0
+  if [[ "$(bridge_agent_isolation_mode "$agent" 2>/dev/null || printf '')" == "linux-user" ]]; then
+    while (( attempt < repair_attempts )); do
+      bridge_linux_acl_repair_channel_env_files "$agent" >/dev/null 2>&1 || true
+      attempt=$((attempt + 1))
+      if [[ -r "$file" ]]; then
+        rc=0
+        bridge_env_file_has_any_nonempty_key "$file" "$@" >/dev/null 2>&1 || rc=$?
+        if [[ $rc -eq 0 ]]; then
+          printf 'present'
+          return 0
+        fi
+        # File now readable but key not present — treat as missing rather
+        # than leaving in unreadable.
+        printf 'missing'
+        return 0
+      fi
+    done
+  fi
+
+  # Suppress unused-warning shellcheck when item is reserved for future
+  # per-channel scoped repair; ms365/teams currently share the agent-wide
+  # repair surface so item is logged rather than dispatched on.
+  : "${item}"
+  printf 'unreadable'
+  return 0
+}
+
+# Issue #534: produce a single-line diagnostic blob for an unreadable
+# channel `.env` file. Composed from `stat` and `getfacl` (Linux only;
+# Darwin lacks both POSIX named-user ACLs and a compatible getfacl).
+# Suppresses all stderr — output is one line so it fits in the existing
+# status_reason format.
+#
+# Output shape (single line):
+#   {"mode":"600","owner":"<uid>:<gid>","getfacl":"...","repair_attempts":N}
+#
+# When the file is missing or running on macOS, emits a minimal blob with
+# what is available; never returns non-zero.
+bridge_channel_env_file_acl_diagnostic() {
+  local file="$1"
+  local repair_attempts="${2:-${BRIDGE_ENV_READINESS_REPAIR_ATTEMPTS:-2}}"
+  local mode="-" owner="-" facl="-"
+
+  if [[ -e "$file" ]]; then
+    case "$(uname -s 2>/dev/null || printf '')" in
+      Linux)
+        mode="$(stat -c '%a' "$file" 2>/dev/null || printf -- '-')"
+        owner="$(stat -c '%U:%G' "$file" 2>/dev/null || printf -- '-')"
+        if command -v getfacl >/dev/null 2>&1; then
+          facl="$(getfacl --omit-header --no-effective "$file" 2>/dev/null \
+            | tr '\n' '/' | sed 's:/$::' || printf -- '-')"
+          [[ -n "$facl" ]] || facl="-"
+        fi
+        ;;
+      Darwin)
+        mode="$(stat -f '%Lp' "$file" 2>/dev/null || printf -- '-')"
+        owner="$(stat -f '%Su:%Sg' "$file" 2>/dev/null || printf -- '-')"
+        facl="darwin-acl-not-applicable"
+        ;;
+      *)
+        ;;
+    esac
+  fi
+
+  printf '{"mode":"%s","owner":"%s","getfacl":"%s","repair_attempts":%s}' \
+    "$mode" "$owner" "$facl" "$repair_attempts"
+}
+
 bridge_agent_channel_runtime_ready_for_item() {
   local agent="$1"
   local item="$2"
@@ -3847,34 +3972,39 @@ bridge_agent_channel_runtime_ready_for_item() {
   item="$(bridge_trim_whitespace "$item")"
   [[ -n "$item" ]] || return 1
 
+  # Issue #534: route through the readiness enum so unreadable .env (linux-user
+  # ACL drift) does not collapse into the same "not ready" signal as missing
+  # keys. Both unreadable and missing return 1 here (downstream readiness is
+  # boolean), but the structured reason path uses the same helper to emit a
+  # distinct status_reason.
   case "$item" in
     plugin:discord|plugin:discord@*)
       dir="$(bridge_agent_discord_state_dir "$agent")"
       [[ -f "$dir/access.json" ]] || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" DISCORD_BOT_TOKEN BOT_TOKEN TOKEN
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" DISCORD_BOT_TOKEN BOT_TOKEN TOKEN)" == "present" ]]
       ;;
     plugin:telegram|plugin:telegram@*)
       dir="$(bridge_agent_telegram_state_dir "$agent")"
       [[ -f "$dir/access.json" ]] || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" TELEGRAM_BOT_TOKEN BOT_TOKEN TOKEN
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" TELEGRAM_BOT_TOKEN BOT_TOKEN TOKEN)" == "present" ]]
       ;;
     plugin:teams|plugin:teams@*)
       dir="$(bridge_agent_teams_state_dir "$agent")"
       [[ -f "$dir/access.json" ]] || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" TEAMS_APP_ID MicrosoftAppId || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" TEAMS_APP_PASSWORD MicrosoftAppPassword
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" TEAMS_APP_ID MicrosoftAppId)" == "present" ]] || return 1
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" TEAMS_APP_PASSWORD MicrosoftAppPassword)" == "present" ]]
       ;;
     plugin:ms365|plugin:ms365@*)
       dir="$(bridge_agent_ms365_state_dir "$agent")"
       [[ -f "$dir/access.json" ]] || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" MS365_CLIENT_ID || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" MS365_CLIENT_SECRET || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" MS365_TENANT_ID
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_CLIENT_ID)" == "present" ]] || return 1
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_CLIENT_SECRET)" == "present" ]] || return 1
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_TENANT_ID)" == "present" ]]
       ;;
     plugin:mattermost|plugin:mattermost@*)
       dir="$(bridge_agent_mattermost_state_dir "$agent")"
       [[ -f "$dir/access.json" ]] || return 1
-      bridge_env_file_has_any_nonempty_key "$dir/.env" MATTERMOST_BOT_TOKEN MATTERMOST_PERSONAL_TOKEN
+      [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MATTERMOST_BOT_TOKEN MATTERMOST_PERSONAL_TOKEN)" == "present" ]]
       ;;
     *)
       return 0
@@ -3942,28 +4072,41 @@ bridge_channel_credentials_status_for_item() {
   local agent="$1"
   local item="$2"
   local dir=""
+  local r1="" r2="" r3=""
 
   item="$(bridge_qualify_channel_item "$item")"
   dir="$(bridge_channel_state_dir_for_item "$agent" "$item")"
+  # Issue #534: surface "unreadable" distinctly from "missing". When ANY
+  # required key probe reports unreadable, the overall status is unreadable
+  # (operators need to know the controller cannot read the file at all,
+  # which is actionable via ACL repair, vs. truly missing keys).
   case "$item" in
     plugin:discord|plugin:discord@*)
-      bridge_env_file_has_any_nonempty_key "$dir/.env" DISCORD_BOT_TOKEN BOT_TOKEN TOKEN && printf '%s' "present" || printf '%s' "missing"
+      r1="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" DISCORD_BOT_TOKEN BOT_TOKEN TOKEN)"
+      printf '%s' "$r1"
       ;;
     plugin:telegram|plugin:telegram@*)
-      bridge_env_file_has_any_nonempty_key "$dir/.env" TELEGRAM_BOT_TOKEN BOT_TOKEN TOKEN && printf '%s' "present" || printf '%s' "missing"
+      r1="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" TELEGRAM_BOT_TOKEN BOT_TOKEN TOKEN)"
+      printf '%s' "$r1"
       ;;
     plugin:teams|plugin:teams@*)
-      if bridge_env_file_has_any_nonempty_key "$dir/.env" TEAMS_APP_ID MicrosoftAppId \
-        && bridge_env_file_has_any_nonempty_key "$dir/.env" TEAMS_APP_PASSWORD MicrosoftAppPassword; then
+      r1="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" TEAMS_APP_ID MicrosoftAppId)"
+      r2="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" TEAMS_APP_PASSWORD MicrosoftAppPassword)"
+      if [[ "$r1" == "unreadable" || "$r2" == "unreadable" ]]; then
+        printf '%s' "unreadable"
+      elif [[ "$r1" == "present" && "$r2" == "present" ]]; then
         printf '%s' "present"
       else
         printf '%s' "missing"
       fi
       ;;
     plugin:ms365|plugin:ms365@*)
-      if bridge_env_file_has_any_nonempty_key "$dir/.env" MS365_CLIENT_ID \
-        && bridge_env_file_has_any_nonempty_key "$dir/.env" MS365_CLIENT_SECRET \
-        && bridge_env_file_has_any_nonempty_key "$dir/.env" MS365_TENANT_ID; then
+      r1="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_CLIENT_ID)"
+      r2="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_CLIENT_SECRET)"
+      r3="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_TENANT_ID)"
+      if [[ "$r1" == "unreadable" || "$r2" == "unreadable" || "$r3" == "unreadable" ]]; then
+        printf '%s' "unreadable"
+      elif [[ "$r1" == "present" && "$r2" == "present" && "$r3" == "present" ]]; then
         printf '%s' "present"
       else
         printf '%s' "missing"
@@ -4750,6 +4893,8 @@ bridge_agent_runtime_channel_status_reason() {
   local discord_dir=""
   local telegram_dir=""
   local teams_dir=""
+  local readiness=""
+  local repair_attempts="${BRIDGE_ENV_READINESS_REPAIR_ATTEMPTS:-2}"
 
   required="$(bridge_agent_required_runtime_channels_csv "$agent")"
   if [[ -z "$required" ]]; then
@@ -4763,7 +4908,16 @@ bridge_agent_runtime_channel_status_reason() {
       printf 'missing Discord access file under %s (access.json required)' "$discord_dir"
       return 0
     fi
-    if ! bridge_env_file_has_any_nonempty_key "$discord_dir/.env" DISCORD_BOT_TOKEN BOT_TOKEN TOKEN; then
+    # Issue #534: route through readiness enum so unreadable .env emits a
+    # distinct, actionable status_reason instead of the false-negative
+    # "missing token" message.
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:discord" "$discord_dir/.env" DISCORD_BOT_TOKEN BOT_TOKEN TOKEN)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: Discord .env under %s (ACL repair failed %s times; %s)' \
+        "$discord_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$discord_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
       printf 'missing Discord bot token under %s (.env with DISCORD_BOT_TOKEN required)' "$discord_dir"
       return 0
     fi
@@ -4775,7 +4929,13 @@ bridge_agent_runtime_channel_status_reason() {
       printf 'missing Telegram access file under %s (access.json required)' "$telegram_dir"
       return 0
     fi
-    if ! bridge_env_file_has_any_nonempty_key "$telegram_dir/.env" TELEGRAM_BOT_TOKEN BOT_TOKEN TOKEN; then
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:telegram" "$telegram_dir/.env" TELEGRAM_BOT_TOKEN BOT_TOKEN TOKEN)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: Telegram .env under %s (ACL repair failed %s times; %s)' \
+        "$telegram_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$telegram_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
       printf 'missing Telegram bot token under %s (.env with TELEGRAM_BOT_TOKEN required)' "$telegram_dir"
       return 0
     fi
@@ -4787,12 +4947,66 @@ bridge_agent_runtime_channel_status_reason() {
       printf 'missing Teams access file under %s (access.json required)' "$teams_dir"
       return 0
     fi
-    if ! bridge_env_file_has_any_nonempty_key "$teams_dir/.env" TEAMS_APP_ID MicrosoftAppId; then
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:teams" "$teams_dir/.env" TEAMS_APP_ID MicrosoftAppId)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: Teams .env under %s (ACL repair failed %s times; %s)' \
+        "$teams_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$teams_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
       printf 'missing Teams app id under %s (.env with TEAMS_APP_ID required)' "$teams_dir"
       return 0
     fi
-    if ! bridge_env_file_has_any_nonempty_key "$teams_dir/.env" TEAMS_APP_PASSWORD MicrosoftAppPassword; then
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:teams" "$teams_dir/.env" TEAMS_APP_PASSWORD MicrosoftAppPassword)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: Teams .env under %s (ACL repair failed %s times; %s)' \
+        "$teams_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$teams_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
       printf 'missing Teams app password under %s (.env with TEAMS_APP_PASSWORD required)' "$teams_dir"
+      return 0
+    fi
+  fi
+
+  # Issue #534: ms365 branch added here. Previously absent — meant ACL
+  # diagnostics for ms365 channels could never surface even with the
+  # readiness enum in place.
+  if bridge_channel_csv_contains "$required" "plugin:ms365"; then
+    local ms365_dir=""
+    ms365_dir="$(bridge_agent_ms365_state_dir "$agent")"
+    if [[ ! -f "$ms365_dir/access.json" ]]; then
+      printf 'missing MS365 access file under %s (access.json required)' "$ms365_dir"
+      return 0
+    fi
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:ms365" "$ms365_dir/.env" MS365_CLIENT_ID)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: MS365 .env under %s (ACL repair failed %s times; %s)' \
+        "$ms365_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
+      printf 'missing MS365 client id under %s (.env with MS365_CLIENT_ID required)' "$ms365_dir"
+      return 0
+    fi
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:ms365" "$ms365_dir/.env" MS365_CLIENT_SECRET)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: MS365 .env under %s (ACL repair failed %s times; %s)' \
+        "$ms365_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
+      printf 'missing MS365 client secret under %s (.env with MS365_CLIENT_SECRET required)' "$ms365_dir"
+      return 0
+    fi
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:ms365" "$ms365_dir/.env" MS365_TENANT_ID)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: MS365 .env under %s (ACL repair failed %s times; %s)' \
+        "$ms365_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
+      printf 'missing MS365 tenant id under %s (.env with MS365_TENANT_ID required)' "$ms365_dir"
       return 0
     fi
   fi
@@ -4804,7 +5018,13 @@ bridge_agent_runtime_channel_status_reason() {
       printf 'missing Mattermost access file under %s (access.json required)' "$mattermost_dir"
       return 0
     fi
-    if ! bridge_env_file_has_any_nonempty_key "$mattermost_dir/.env" MATTERMOST_BOT_TOKEN MATTERMOST_PERSONAL_TOKEN; then
+    readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:mattermost" "$mattermost_dir/.env" MATTERMOST_BOT_TOKEN MATTERMOST_PERSONAL_TOKEN)"
+    if [[ "$readiness" == "unreadable" ]]; then
+      printf 'unreadable: Mattermost .env under %s (ACL repair failed %s times; %s)' \
+        "$mattermost_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$mattermost_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" != "present" ]]; then
       printf 'missing Mattermost bot token under %s (.env with MATTERMOST_BOT_TOKEN required)' "$mattermost_dir"
       return 0
     fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update
 }
 
 add_all_integration() {

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -187,7 +187,7 @@ select_for_path() {
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)
-      add_required daemon queue launch-dev-channels-injection
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke/channel-env-readiness.sh
+++ b/scripts/smoke/channel-env-readiness.sh
@@ -1,0 +1,334 @@
+#!/usr/bin/env bash
+
+# Issue #534: lock the contract for the isolation-aware channel `.env`
+# readiness probe. The probe must:
+#
+# 1. Return "present" when at least one requested key has a non-empty value.
+# 2. Return "missing" when the file exists but no requested key is present
+#    with a non-empty value.
+# 3. Return "missing" when the file is absent.
+# 4. Return "present" after a successful linux-user ACL repair retry.
+# 5. Return "unreadable" after bounded ACL repair attempts fail.
+# 6. Suppress raw grep stderr in all cases (issue body's primary symptom).
+# 7. Have status_reason emit a distinct "unreadable: ..." line with an
+#    ACL diagnostic blob (instead of the false-negative "missing token").
+# 8. Cover the ms365 channel branch in status_reason (was previously absent).
+#
+# The smoke is Linux-only by design — POSIX named-user ACLs and getfacl
+# behave differently on Darwin, so the unreadable-with-repair scenarios
+# cannot be reproduced faithfully on macOS. macOS auto-skips with exit 0
+# so the orchestrator's local runs do not regress; CI on Linux must
+# exercise the assertions.
+
+set -euo pipefail
+
+SMOKE_NAME="channel-env-readiness"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+case "$(uname -s 2>/dev/null || printf '')" in
+  Linux) ;;
+  *)
+    smoke_log "skipping on non-Linux host (POSIX ACL primitives unavailable)"
+    exit 0
+    ;;
+esac
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+source_bridge_lib() {
+  # shellcheck source=bridge-lib.sh
+  source "$SMOKE_REPO_ROOT/bridge-lib.sh"
+  bridge_load_roster
+}
+
+WORKER="worker534"
+WORKDIR=""
+TEAMS_DIR=""
+TEAMS_ENV=""
+MS365_DIR=""
+MS365_ENV=""
+
+# Mock state for ACL repair injection. The call counter lives in a file
+# because bridge_channel_env_file_readiness is invoked through `$(...)`,
+# which forks a subshell — in-memory counters in the parent would not
+# observe increments from the override running inside that subshell.
+MOCK_REPAIR_BEHAVIOR="none"   # none | restore | nop
+MOCK_REPAIR_COUNT_FILE=""
+
+register_worker() {
+  WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$WORKER"
+  TEAMS_DIR="$WORKDIR/.teams"
+  TEAMS_ENV="$TEAMS_DIR/.env"
+  MS365_DIR="$WORKDIR/.ms365"
+  MS365_ENV="$MS365_DIR/.env"
+  MOCK_REPAIR_COUNT_FILE="$SMOKE_TMP_ROOT/repair.count"
+  echo 0 >"$MOCK_REPAIR_COUNT_FILE"
+  export TEAMS_ENV MS365_ENV MOCK_REPAIR_COUNT_FILE MOCK_REPAIR_BEHAVIOR
+  mkdir -p "$WORKDIR" "$TEAMS_DIR" "$MS365_DIR"
+  bridge_add_agent_id_if_missing "$WORKER"
+  BRIDGE_AGENT_ENGINE["$WORKER"]="claude"
+  BRIDGE_AGENT_SOURCE["$WORKER"]="static"
+  BRIDGE_AGENT_SESSION["$WORKER"]="$WORKER-session"
+  BRIDGE_AGENT_WORKDIR["$WORKER"]="$WORKDIR"
+  BRIDGE_AGENT_LOOP["$WORKER"]=0
+  BRIDGE_AGENT_CONTINUE["$WORKER"]=0
+  BRIDGE_AGENT_ISOLATION_MODE["$WORKER"]="linux-user"
+  BRIDGE_AGENT_OS_USER["$WORKER"]="$(id -un)"
+  BRIDGE_AGENT_CHANNELS["$WORKER"]="plugin:teams,plugin:ms365"
+}
+
+write_present_teams_env() {
+  cat >"$TEAMS_ENV" <<EOF
+TEAMS_APP_ID=appid-value
+TEAMS_APP_PASSWORD=apppass-value
+EOF
+}
+
+write_empty_teams_env() {
+  cat >"$TEAMS_ENV" <<'EOF'
+TEAMS_APP_ID=
+TEAMS_APP_PASSWORD=
+EOF
+}
+
+write_present_ms365_env() {
+  cat >"$MS365_ENV" <<EOF
+MS365_CLIENT_ID=client-id
+MS365_CLIENT_SECRET=client-secret
+MS365_TENANT_ID=tenant-id
+EOF
+}
+
+# Install our mock AFTER bridge-lib.sh has been sourced, otherwise the
+# real definition from lib/bridge-agents.sh would clobber the override.
+# The fixture uses chmod 000 to simulate "controller cannot read" without
+# requiring sudo / setfacl; mock behaviors:
+#   - none:    do nothing (file stays unreadable).
+#   - restore: chmod 600 the file so a subsequent [[ -r ]] succeeds.
+#   - nop:     count attempts but do nothing.
+install_repair_mock() {
+  bridge_linux_acl_repair_channel_env_files() {
+    local agent="$1"
+    local n
+    n=$(($(cat "$MOCK_REPAIR_COUNT_FILE" 2>/dev/null || echo 0) + 1))
+    echo "$n" >"$MOCK_REPAIR_COUNT_FILE"
+    case "$MOCK_REPAIR_BEHAVIOR" in
+      restore)
+        [[ -e "$TEAMS_ENV" ]] && chmod 600 "$TEAMS_ENV" 2>/dev/null || true
+        [[ -e "$MS365_ENV" ]] && chmod 600 "$MS365_ENV" 2>/dev/null || true
+        ;;
+      nop|none|*)
+        :
+        ;;
+    esac
+    : "${agent}"
+  }
+}
+
+reset_repair_mock() {
+  MOCK_REPAIR_BEHAVIOR="$1"
+  export MOCK_REPAIR_BEHAVIOR
+  echo 0 >"$MOCK_REPAIR_COUNT_FILE"
+}
+
+repair_calls() {
+  cat "$MOCK_REPAIR_COUNT_FILE" 2>/dev/null || echo 0
+}
+
+# Capture stderr of a helper invocation into a file. Returns stdout to
+# caller and writes stderr to $1.
+capture_stderr_file() {
+  local stderr_path="$1"; shift
+  "$@" 2>"$stderr_path"
+}
+
+assert_present_with_value() {
+  write_present_teams_env
+  reset_repair_mock none
+  local out
+  out="$(bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID MicrosoftAppId)"
+  smoke_assert_eq "present" "$out" "readable .env with non-empty key returns present"
+}
+
+assert_missing_with_empty_value() {
+  write_empty_teams_env
+  reset_repair_mock none
+  local out
+  out="$(bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID MicrosoftAppId)"
+  smoke_assert_eq "missing" "$out" "readable .env with empty values returns missing"
+}
+
+assert_missing_when_file_absent() {
+  rm -f "$TEAMS_ENV"
+  reset_repair_mock none
+  local out
+  out="$(bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID MicrosoftAppId)"
+  smoke_assert_eq "missing" "$out" "absent .env returns missing"
+}
+
+assert_unreadable_then_repaired() {
+  write_present_teams_env
+  chmod 000 "$TEAMS_ENV"
+  reset_repair_mock restore
+  local out calls
+  out="$(bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID MicrosoftAppId)"
+  smoke_assert_eq "present" "$out" "unreadable .env recovers to present after ACL repair restores readability"
+  calls="$(repair_calls)"
+  if (( calls < 1 )); then
+    smoke_fail "expected ACL repair to be invoked at least once; got $calls"
+  fi
+  chmod 600 "$TEAMS_ENV" 2>/dev/null || true
+}
+
+assert_unreadable_when_repair_fails() {
+  write_present_teams_env
+  chmod 000 "$TEAMS_ENV"
+  reset_repair_mock nop
+  local out calls
+  out="$(bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID MicrosoftAppId)"
+  smoke_assert_eq "unreadable" "$out" "unreadable .env stays unreadable after bounded repair attempts fail"
+  calls="$(repair_calls)"
+  if (( calls < 2 )); then
+    smoke_fail "expected at least 2 repair attempts (BRIDGE_ENV_READINESS_REPAIR_ATTEMPTS default); got $calls"
+  fi
+  chmod 600 "$TEAMS_ENV" 2>/dev/null || true
+}
+
+assert_no_grep_stderr_leakage() {
+  local stderr_path="$SMOKE_TMP_ROOT/readiness-stderr.log"
+  : >"$stderr_path"
+
+  # Scenario 1: present
+  write_present_teams_env
+  reset_repair_mock none
+  capture_stderr_file "$stderr_path" bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID >/dev/null
+  if [[ -s "$stderr_path" ]]; then
+    smoke_fail "no-stderr scenario 1 (present) leaked: $(cat "$stderr_path")"
+  fi
+
+  # Scenario 2: missing key
+  write_empty_teams_env
+  capture_stderr_file "$stderr_path" bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID >/dev/null
+  if [[ -s "$stderr_path" ]]; then
+    smoke_fail "no-stderr scenario 2 (missing key) leaked: $(cat "$stderr_path")"
+  fi
+
+  # Scenario 3: file absent
+  rm -f "$TEAMS_ENV"
+  capture_stderr_file "$stderr_path" bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID >/dev/null
+  if [[ -s "$stderr_path" ]]; then
+    smoke_fail "no-stderr scenario 3 (absent) leaked: $(cat "$stderr_path")"
+  fi
+
+  # Scenario 4: unreadable then repaired
+  write_present_teams_env
+  chmod 000 "$TEAMS_ENV"
+  reset_repair_mock restore
+  capture_stderr_file "$stderr_path" bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID >/dev/null
+  if [[ -s "$stderr_path" ]]; then
+    smoke_fail "no-stderr scenario 4 (unreadable->repaired) leaked: $(cat "$stderr_path")"
+  fi
+  chmod 600 "$TEAMS_ENV" 2>/dev/null || true
+
+  # Scenario 5: unreadable repair fails
+  chmod 000 "$TEAMS_ENV"
+  reset_repair_mock nop
+  capture_stderr_file "$stderr_path" bridge_channel_env_file_readiness "$WORKER" "plugin:teams" "$TEAMS_ENV" TEAMS_APP_ID >/dev/null
+  if [[ -s "$stderr_path" ]]; then
+    smoke_fail "no-stderr scenario 5 (unreadable->fail) leaked: $(cat "$stderr_path")"
+  fi
+  chmod 600 "$TEAMS_ENV" 2>/dev/null || true
+}
+
+assert_status_reason_unreadable_with_diagnostic() {
+  # Set up: teams .env unreadable with mock repair that does nothing, so
+  # status_reason should emit the new "unreadable: ..." form with the
+  # ACL diagnostic blob.
+  mkdir -p "$TEAMS_DIR"
+  : >"$TEAMS_DIR/access.json"
+  write_present_teams_env
+  chmod 000 "$TEAMS_ENV"
+  reset_repair_mock nop
+
+  # Restrict required runtime channels to teams only for this assertion.
+  local saved_channels="${BRIDGE_AGENT_CHANNELS[$WORKER]-}"
+  BRIDGE_AGENT_CHANNELS["$WORKER"]="plugin:teams"
+
+  local reason
+  reason="$(bridge_agent_runtime_channel_status_reason "$WORKER")"
+
+  smoke_assert_contains "$reason" "unreadable: Teams .env" \
+    "status_reason emits unreadable prefix for Teams when .env is unreadable"
+  smoke_assert_contains "$reason" "ACL repair failed" \
+    "status_reason includes ACL repair attempt count phrase"
+  smoke_assert_contains "$reason" '"mode":' \
+    "status_reason embeds ACL diagnostic blob (mode field)"
+
+  # Single line — no embedded newlines — log-parser safe.
+  local newlines
+  newlines="$(printf '%s' "$reason" | tr -cd '\n' | wc -c | tr -d ' ')"
+  smoke_assert_eq "0" "$newlines" "status_reason for unreadable case stays single-line"
+
+  BRIDGE_AGENT_CHANNELS["$WORKER"]="$saved_channels"
+  chmod 600 "$TEAMS_ENV" 2>/dev/null || true
+}
+
+assert_ms365_branch_covered() {
+  # Set up: only ms365 required, .env present with valid keys. The new
+  # ms365 branch must process this without leaking through to the
+  # post-loop empty-string return — which historically meant ms365
+  # readiness was silently skipped.
+  mkdir -p "$MS365_DIR"
+  : >"$MS365_DIR/access.json"
+  write_present_ms365_env
+  reset_repair_mock none
+
+  local saved_channels="${BRIDGE_AGENT_CHANNELS[$WORKER]-}"
+  BRIDGE_AGENT_CHANNELS["$WORKER"]="plugin:ms365"
+
+  local reason
+  reason="$(bridge_agent_runtime_channel_status_reason "$WORKER")"
+  smoke_assert_eq "" "$reason" "ms365 with all keys present produces empty status_reason (ok)"
+
+  # Now break ms365 access.json — the new branch must surface that.
+  rm -f "$MS365_DIR/access.json"
+  reason="$(bridge_agent_runtime_channel_status_reason "$WORKER")"
+  smoke_assert_contains "$reason" "missing MS365 access file" \
+    "ms365 branch surfaces missing access.json (proves branch is reached)"
+
+  # Restore for unreadable-detection sub-check.
+  : >"$MS365_DIR/access.json"
+  chmod 000 "$MS365_ENV"
+  reset_repair_mock nop
+  reason="$(bridge_agent_runtime_channel_status_reason "$WORKER")"
+  smoke_assert_contains "$reason" "unreadable: MS365 .env" \
+    "ms365 branch emits unreadable prefix when .env is unreadable"
+
+  chmod 600 "$MS365_ENV" 2>/dev/null || true
+  BRIDGE_AGENT_CHANNELS["$WORKER"]="$saved_channels"
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "channel-env-readiness"
+  source_bridge_lib
+  register_worker
+  install_repair_mock
+
+  smoke_run "readable .env with non-empty key returns present"           assert_present_with_value
+  smoke_run "readable .env with empty values returns missing"            assert_missing_with_empty_value
+  smoke_run "absent .env returns missing"                                assert_missing_when_file_absent
+  smoke_run "unreadable .env recovers via ACL repair retry"              assert_unreadable_then_repaired
+  smoke_run "unreadable .env stays unreadable when repair fails"         assert_unreadable_when_repair_fails
+  smoke_run "no raw grep stderr leakage in any readiness scenario"       assert_no_grep_stderr_leakage
+  smoke_run "status_reason emits unreadable + ACL diagnostic"            assert_status_reason_unreadable_with_diagnostic
+  smoke_run "ms365 status_reason branch covers all three states"         assert_ms365_branch_covered
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

In linux-user isolation, channel `.env` credential checks read each agent's file via a direct `grep` helper that collapsed three states into a single boolean. When the controller-side ACL repair window failed (transient FS issue, mask drift, race with channel setup), the daemon log filled with `grep: <BRIDGE_HOME>/agents/<a>/.<channel>/.env: Permission denied` on every channel-health cycle, AND `agent show` reported a credential false-negative because "missing" and "unreadable" were indistinguishable. This PR introduces an isolation-aware readiness enum, a structured ACL diagnostic helper, and adds the missing ms365 branch in `bridge_agent_runtime_channel_status_reason()`.

## What changed

- **New helper `bridge_channel_env_file_readiness <agent> <item> <file> <key>...`** in `lib/bridge-agents.sh` — returns one of `present | missing | unreadable` via stdout, suppresses raw grep stderr. Distinguishes grep rc=1 (no match — file readable, key missing) from rc=2 (file unreadable) via `[[ -r "$file" ]]` probe. On linux-user isolation, attempts bounded ACL repair (`BRIDGE_ENV_READINESS_REPAIR_ATTEMPTS`, default 2) via the existing `bridge_linux_acl_repair_channel_env_files` before giving up. The original `bridge_env_file_has_any_nonempty_key` signature is preserved per the issue's explicit "do not change signature" requirement.
- **New helper `bridge_channel_env_file_acl_diagnostic <file> [attempts]`** — emits a single-line JSON-ish blob `{"mode":..,"owner":..,"getfacl":..,"repair_attempts":N}` composed from `stat` + `getfacl --omit-header --no-effective`. Linux-only composition; macOS emits `darwin-acl-not-applicable`. Suppresses all stderr; output stays single-line so existing log parsers don't break.
- **Migrated 3 callsites:**
  - `bridge_agent_channel_runtime_ready_for_item()` — readiness boolean preserved (`unreadable` and `missing` both mean "not ready"), but stderr no longer leaks.
  - `bridge_channel_credentials_status_for_item()` — now returns the enum values directly (`present | missing | unreadable | n/a`).
  - `bridge_agent_runtime_channel_status_reason()` — emits a distinct `unreadable: <Channel> .env under <dir> (ACL repair failed N times; <diag>)` message instead of the false-negative "missing token" string.
- **Added ms365 branch to `bridge_agent_runtime_channel_status_reason()`** (previously absent per issue body — meaning ms365 channels never produced an actionable reason, even with the new readiness enum in place). Same shape as teams: access.json check + per-key readiness probe + per-key unreadable handling.
- **New `scripts/smoke/channel-env-readiness.sh`** (Linux-only; auto-skips on Darwin via `uname -s` check). Eight assertions cover: present-with-value, missing-with-empty-value, missing-when-file-absent, unreadable→repaired retry success, unreadable→bounded-repair-fails, no grep stderr leakage in any of the above, `status_reason` emits the new `unreadable: ...` + ACL diagnostic line, ms365 branch covers all three states (ok/missing-access/unreadable). Wired into `scripts/ci-select-smoke.sh` `add_all_required_static`.

## Out of scope (per issue body)

- MCP liveness (`lib/bridge-agents.sh:4472-4581`) is `ps`-based and does not read `.env`. Untouched.
- The v0.3.7 isolated-runtime credential propagation issue is a separate concern. Not combined.
- `bridge_env_file_has_any_nonempty_key` signature unchanged.

## Test plan

- [x] `bash -n` over all touched files (Bash 5)
- [x] `shellcheck` clean over all touched files
- [x] New smoke auto-skips on macOS with exit 0
- [x] New smoke runs all 8 assertions to pass when forced into Linux mode (verified locally by faking `uname`)
- [x] Inline isolated `BRIDGE_HOME` repro of the readiness helper: present/missing/empty/unreadable/diagnostic shape all behave as expected
- [x] Inline repair-retry repro: restoring mock → 1 attempt → present; nop mock → 2 attempts → unreadable
- [x] Existing `admin-codex-pair.sh` and `launch-dev-channels-injection.sh` smokes still pass
- [ ] CI: Linux runner exercises the new smoke end-to-end with real `setfacl`/`getfacl`

Closes #534