### PR TITLE
feat(cron-cleanup): retention/GC for cron run artifacts (#533)

### DIFF
--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -5,11 +5,14 @@ import os
 import re
 import secrets
 import shlex
+import signal
 import sqlite3
+import subprocess
 import sys
 import tempfile
+import time
 from collections import Counter, defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -22,6 +25,34 @@ FAMILY_RULES = (
     "event-reminder",
     "weekly-review",
 )
+
+# Issue #533 — retention defaults for cron run-artifact GC.
+RUN_ARTIFACTS_TIER_A_DEFAULT_DAYS = 7
+RUN_ARTIFACTS_TIER_B_DEFAULT_DAYS = 30
+ALWAYS_PRESERVE_FLOOR = 5
+
+# Surface paths are relative to the BRIDGE_HOME target_root.
+RUN_ARTIFACTS_TIER_A_SURFACES = (
+    "state/cron/runs",
+    "state/cron/workers",
+    "state/cron/dispatch",
+)
+RUN_ARTIFACTS_TIER_B_SURFACES = (
+    "shared/cron-dispatch",
+    "shared/cron-result",
+    "shared/cron-followup",
+)
+
+# Terminal state.json values for a cron run. "deferred" is intentionally NOT
+# terminal — the runner asks for re-fire and the slot is still in flight.
+_RUN_STATUS_TERMINAL_STATES = {"success", "error", "cancelled"}
+# Failed runs (state="error") are retained on the longer Tier-B clock so the
+# operator has time to triage even when the originating surface is Tier-A.
+_RUN_STATUS_FAILED_STATES = {"error"}
+
+# bridge-queue.py terminal statuses are "done" and "cancelled" only — there
+# is no "failed" queue state. Source: bridge-queue.py status enum + #533.
+_QUEUE_TERMINAL_STATUSES = {"done", "cancelled"}
 
 
 def load_jobs_payload(path):
@@ -616,7 +647,12 @@ def print_errors_report(args, records):
 
 def cleanup_candidates(records, mode):
     now = datetime.now().astimezone()
-    if mode != "expired-one-shot":
+    # ``one-shot`` is the issue #533 alias for the legacy
+    # ``expired-one-shot`` mode kept for backwards compat. ``all`` runs
+    # both the legacy expired-one-shot pass *and* the new run-artifacts
+    # pass; from the legacy pass's perspective ``all`` is just the
+    # one-shot subset, hence the alias here.
+    if mode not in ("expired-one-shot", "one-shot", "all"):
         raise ValueError(f"unsupported cleanup mode: {mode}")
     return [
         record
@@ -636,6 +672,665 @@ def format_cleanup_candidate(record):
         f"last={format_dt(record['last_run_at'])} | "
         f"status={record['last_status']}"
     )
+
+
+# -----------------------------------------------------------------------------
+# Issue #533 — run-artifact cleanup helpers.
+#
+# The 6 surfaces (3 Tier-A + 3 Tier-B) accumulate one entry per cron tick with
+# no built-in retention. The helpers below implement the combined-AND deletion
+# gate (queue-terminal AND status-terminal AND no-live-pid AND outside floor)
+# plus the always-preserve floor that protects quiet weekly jobs from losing
+# their only diagnostic.
+# -----------------------------------------------------------------------------
+
+
+def _rmtree_safe(path):
+    """Recursively delete; refuse to follow symlinks; never cross a bind mount.
+
+    Mirrors ``bridge-relay-cleanup.py:_rmtree_safe`` so the prune path matches
+    the existing telegram-relay cleanup safety contract.
+    """
+    if path.is_symlink() or not path.is_dir():
+        try:
+            path.unlink()
+        except (FileNotFoundError, IsADirectoryError):
+            pass
+        return
+    for child in path.iterdir():
+        _rmtree_safe(child)
+    try:
+        path.rmdir()
+    except OSError:
+        pass
+
+
+def _iter_processes_psutil():
+    """Try psutil; return None if unavailable so caller can fall back to ps."""
+    try:
+        import psutil  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    items = []
+    for proc in psutil.process_iter(["pid", "cmdline"]):
+        try:
+            cmdline = proc.info.get("cmdline") or []
+            pid = int(proc.info["pid"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if not cmdline:
+            continue
+        items.append((pid, list(cmdline)))
+    return items
+
+
+def _iter_processes_ps():
+    try:
+        out = subprocess.check_output(
+            ["ps", "-eo", "pid=,args="], text=True, stderr=subprocess.DEVNULL
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+        return []
+    items = []
+    for raw_line in out.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        head, _, rest = line.partition(" ")
+        try:
+            pid = int(head)
+        except ValueError:
+            continue
+        argv = rest.strip().split()
+        if not argv:
+            continue
+        items.append((pid, argv))
+    return items
+
+
+def _iter_live_processes():
+    procs = _iter_processes_psutil()
+    if procs is None:
+        procs = _iter_processes_ps()
+    return procs
+
+
+def _argv_run_id_match(argv, run_id, target_root):
+    """Path-anchored match: argv must reference run_id under ``target_root``.
+
+    Mirrors PR #527 / ``bridge-relay-cleanup.py:_stale_relay_match``: we
+    REJECT bare-substring matches against ``run_id`` alone — a foreign
+    install on the same host whose argv happens to mention the same
+    run_id must NOT cause this install to skip cleanup. The matcher
+    insists the run_id appears as a path component under either
+    ``<target_root>/state/cron/...`` or ``<target_root>/shared/cron-...``.
+    """
+    if not argv or not run_id:
+        return False
+    target_str = str(target_root).rstrip("/")
+    if not target_str:
+        return False
+    rooted_prefixes = (
+        target_str + os.sep + "state" + os.sep + "cron" + os.sep,
+        target_str + os.sep + "shared" + os.sep + "cron-",
+    )
+    for token in argv:
+        if not token or run_id not in token:
+            continue
+        if any(token.startswith(prefix) for prefix in rooted_prefixes):
+            return True
+    return False
+
+
+def has_live_pid_for_run(run_id, target_root):
+    procs = _iter_live_processes()
+    self_pid = os.getpid()
+    for pid, argv in procs:
+        if pid == self_pid:
+            continue
+        if _argv_run_id_match(argv, run_id, target_root):
+            return True
+    return False
+
+
+def queue_dispatch_terminal(run_id, target_root, *, tasks_db_path=None, run_dir=None):
+    """Return (terminal?, queue_status, dispatch_task_id) for the given run.
+
+    Looks up ``dispatch_task_id`` from ``state/cron/runs/<run_id>/request.json``
+    and queries the SQLite tasks db directly. Reads SQLite the same way
+    ``run_reconcile_run_state`` does — we deliberately do NOT shell out to
+    ``bridge-queue.py``, since that would multiply the per-prune cost by the
+    number of run dirs.
+
+    A run with NO request.json or NO dispatch_task_id is treated as terminal
+    (no queue task to wait on). A run whose dispatch task row has been deleted
+    from the queue (e.g. a much older queue row already pruned) is also
+    treated as terminal — there is nothing keeping it alive.
+    """
+    if run_dir is None:
+        run_dir = Path(target_root) / "state" / "cron" / "runs" / run_id
+    request_path = Path(run_dir) / "request.json"
+    if not request_path.is_file():
+        return True, "no_request", None
+    try:
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return True, "unparseable_request", None
+    dispatch_task_id = request.get("dispatch_task_id")
+    try:
+        dispatch_task_id = int(dispatch_task_id) if dispatch_task_id is not None else None
+    except (TypeError, ValueError):
+        dispatch_task_id = None
+    if dispatch_task_id is None:
+        return True, "no_dispatch_task_id", None
+
+    if tasks_db_path is None:
+        tasks_db_path = Path(target_root) / "state" / "tasks.db"
+    tasks_db_path = Path(tasks_db_path)
+    if not tasks_db_path.is_file():
+        return True, "no_tasks_db", dispatch_task_id
+
+    try:
+        with sqlite3.connect(tasks_db_path) as conn:
+            row = conn.execute(
+                "SELECT status FROM tasks WHERE id = ?", (dispatch_task_id,)
+            ).fetchone()
+    except sqlite3.Error:
+        return False, "queue_query_error", dispatch_task_id
+    if row is None:
+        return True, "row_missing", dispatch_task_id
+    status = row[0]
+    return status in _QUEUE_TERMINAL_STATUSES, status, dispatch_task_id
+
+
+def run_status_terminal(run_id, target_root, *, run_dir=None):
+    """Return (terminal?, final_state) from state/cron/runs/<run_id>/status.json.
+
+    A run with NO status.json is NOT terminal — the runner has not finished
+    writing it yet (or never started). Caller should skip such runs.
+    """
+    if run_dir is None:
+        run_dir = Path(target_root) / "state" / "cron" / "runs" / run_id
+    status_path = Path(run_dir) / "status.json"
+    if not status_path.is_file():
+        return False, None
+    try:
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False, "unparseable_status"
+    state_value = str(status.get("state") or "")
+    return state_value in _RUN_STATUS_TERMINAL_STATES, state_value
+
+
+def cron_family_from_run_id(run_id, *, run_dir=None, target_root=None):
+    """Best-effort cron-family extraction.
+
+    Strategy:
+      1. If ``state/cron/runs/<run_id>/request.json`` exists and has a
+         ``job_name`` we can classify, prefer that — it matches the family
+         taxonomy used by ``classify_family``.
+      2. Otherwise fall back to the run_id naming convention
+         ``<safe_name>-<short_id>--<slot_token>``: the prefix before the
+         ``--<slot_token>`` separator is the slug; strip the trailing
+         ``-<short_id>`` and run that through ``classify_family``.
+
+    Returns a non-empty string. ``"<unknown>"`` if neither approach yields
+    a family — those entries land in the synthetic family of the same name
+    so the always-preserve floor still applies.
+    """
+    if not run_id:
+        return "<unknown>"
+    if run_dir is None and target_root is not None:
+        run_dir = Path(target_root) / "state" / "cron" / "runs" / run_id
+    if run_dir is not None:
+        request_path = Path(run_dir) / "request.json"
+        if request_path.is_file():
+            try:
+                request = json.loads(request_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                request = {}
+            job_name = str(
+                request.get("job_name")
+                or request.get("name")
+                or (request.get("job") or {}).get("name")
+                or ""
+            ).strip()
+            if job_name:
+                return classify_family(job_name)
+    base = run_id.split("--", 1)[0]
+    if "-" in base:
+        head, tail = base.rsplit("-", 1)
+        if head and tail and re.fullmatch(r"[0-9a-fA-F]{4,}", tail):
+            base = head
+    return classify_family(base) if base else "<unknown>"
+
+
+def _run_id_from_md(path):
+    """For ``shared/cron-{dispatch,result,followup}/<run_id>.md`` surfaces."""
+    name = path.name
+    if name.endswith(".md"):
+        return name[:-3]
+    return name
+
+
+def _run_id_from_worker_log(path):
+    """``state/cron/workers/task-<id>.log|.pid`` — keyed by queue task_id."""
+    name = path.name
+    m = re.match(r"^task-(?P<task_id>\d+)\.(log|pid)$", name)
+    if m:
+        return f"task-{m.group('task_id')}"
+    return name
+
+
+def _entries_for_runs_dir(runs_root):
+    if not runs_root.is_dir() or runs_root.is_symlink():
+        return
+    for child in sorted(runs_root.iterdir()):
+        if child.is_symlink():
+            yield {"path": child, "run_id": child.name, "is_symlink": True}
+            continue
+        if not child.is_dir():
+            continue
+        yield {"path": child, "run_id": child.name, "is_symlink": False}
+
+
+def _entries_for_workers_dir(workers_root):
+    if not workers_root.is_dir() or workers_root.is_symlink():
+        return
+    for child in sorted(workers_root.iterdir()):
+        if child.is_symlink():
+            yield {
+                "path": child,
+                "run_id": _run_id_from_worker_log(child),
+                "is_symlink": True,
+            }
+            continue
+        if not child.is_file():
+            continue
+        if not re.match(r"^task-\d+\.(log|pid)$", child.name):
+            continue
+        yield {
+            "path": child,
+            "run_id": _run_id_from_worker_log(child),
+            "is_symlink": False,
+        }
+
+
+def _entries_for_dispatch_dir(dispatch_root):
+    """``state/cron/dispatch/<job_slug>/<slot_token>.json`` — each manifest
+    file is a per-slot artifact.  Empty parent slug dirs are pruned at the
+    end of the cleanup pass."""
+    if not dispatch_root.is_dir() or dispatch_root.is_symlink():
+        return
+    for slug_dir in sorted(dispatch_root.iterdir()):
+        if slug_dir.is_symlink():
+            yield {"path": slug_dir, "run_id": slug_dir.name, "is_symlink": True}
+            continue
+        if not slug_dir.is_dir():
+            continue
+        for manifest in sorted(slug_dir.iterdir()):
+            if manifest.is_symlink():
+                yield {
+                    "path": manifest,
+                    "run_id": f"{slug_dir.name}--{manifest.stem}",
+                    "is_symlink": True,
+                }
+                continue
+            if not manifest.is_file():
+                continue
+            yield {
+                "path": manifest,
+                "run_id": f"{slug_dir.name}--{manifest.stem}",
+                "is_symlink": False,
+            }
+
+
+def _entries_for_shared_md_dir(md_root):
+    if not md_root.is_dir() or md_root.is_symlink():
+        return
+    for child in sorted(md_root.iterdir()):
+        if child.is_symlink():
+            yield {
+                "path": child,
+                "run_id": _run_id_from_md(child),
+                "is_symlink": True,
+            }
+            continue
+        if not child.is_file() or child.suffix != ".md":
+            continue
+        yield {
+            "path": child,
+            "run_id": _run_id_from_md(child),
+            "is_symlink": False,
+        }
+
+
+def _surface_entries(target_root, surface):
+    full = Path(target_root) / surface
+    if surface == "state/cron/runs":
+        yield from _entries_for_runs_dir(full)
+    elif surface == "state/cron/workers":
+        yield from _entries_for_workers_dir(full)
+    elif surface == "state/cron/dispatch":
+        yield from _entries_for_dispatch_dir(full)
+    elif surface in RUN_ARTIFACTS_TIER_B_SURFACES:
+        yield from _entries_for_shared_md_dir(full)
+
+
+def _entry_mtime(path):
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def collect_run_artifact_candidates(
+    target_root,
+    *,
+    tier_a_days,
+    tier_b_days,
+    tasks_db_path=None,
+    now_ts=None,
+):
+    """Walk all 6 surfaces and evaluate the combined deletion gate per entry.
+
+    Returns a list of dicts; see ``_evaluate_entry`` for the shape.
+
+    Eligibility is the combined-AND condition from the issue body:
+      (1) queue terminal  AND  (2) status terminal
+      AND  (3) no live PID  AND  (4) outside the always-preserve floor.
+    Plus a tier-aware age check (Tier-A days vs Tier-B days). For runs in
+    ``error`` state we apply only the longer Tier-B clock even on Tier-A
+    surfaces — operators get more time to triage failures.
+    The always-preserve floor is applied AFTER eligibility evaluation by
+    grouping the eligible-by-other-means entries per (surface, family) and
+    bumping the latest N=ALWAYS_PRESERVE_FLOOR back to ineligible.
+    """
+    if now_ts is None:
+        now_ts = time.time()
+    tier_a_cutoff = now_ts - (tier_a_days * 86400.0)
+    tier_b_cutoff = now_ts - (tier_b_days * 86400.0)
+    results = []
+    for surface in RUN_ARTIFACTS_TIER_A_SURFACES:
+        for entry in _surface_entries(target_root, surface):
+            results.append(
+                _evaluate_entry(
+                    target_root,
+                    surface,
+                    "A",
+                    tier_a_cutoff,
+                    tier_b_cutoff,
+                    entry,
+                    tasks_db_path=tasks_db_path,
+                )
+            )
+    for surface in RUN_ARTIFACTS_TIER_B_SURFACES:
+        for entry in _surface_entries(target_root, surface):
+            results.append(
+                _evaluate_entry(
+                    target_root,
+                    surface,
+                    "B",
+                    tier_b_cutoff,
+                    tier_b_cutoff,
+                    entry,
+                    tasks_db_path=tasks_db_path,
+                )
+            )
+    _apply_preserve_floor(results)
+    return results
+
+
+def _evaluate_entry(
+    target_root,
+    surface,
+    tier,
+    age_cutoff,
+    tier_b_cutoff,
+    entry,
+    *,
+    tasks_db_path,
+):
+    path = entry["path"]
+    run_id = entry["run_id"]
+    is_symlink = bool(entry.get("is_symlink"))
+    mtime = _entry_mtime(path)
+    record = {
+        "surface": surface,
+        "path": path,
+        "run_id": run_id,
+        "family": "<unknown>",
+        "tier": tier,
+        "mtime": mtime,
+        "is_symlink": is_symlink,
+        "eligible": False,
+        "skip_reason": None,
+        "queue_status": None,
+        "run_state": None,
+    }
+    if is_symlink:
+        record["skip_reason"] = "symlink"
+        return record
+    run_dir = Path(target_root) / "state" / "cron" / "runs" / run_id
+    record["family"] = cron_family_from_run_id(
+        run_id, run_dir=run_dir, target_root=target_root
+    )
+    queue_terminal, queue_status, _ = queue_dispatch_terminal(
+        run_id, target_root, tasks_db_path=tasks_db_path, run_dir=run_dir
+    )
+    record["queue_status"] = queue_status
+    if not queue_terminal:
+        record["skip_reason"] = f"queue_status:{queue_status}"
+        return record
+    status_terminal, run_state = run_status_terminal(
+        run_id, target_root, run_dir=run_dir
+    )
+    record["run_state"] = run_state
+    # If state/cron/runs/<run_id>/ does not exist (e.g. orphaned shared/*.md
+    # whose run dir was already purged on a prior pass), treat status as
+    # terminal — there is nothing for the runner to still be writing.
+    if not run_dir.is_dir():
+        status_terminal = True
+    if not status_terminal:
+        record["skip_reason"] = "run_state_not_terminal"
+        return record
+    effective_cutoff = age_cutoff
+    if run_state in _RUN_STATUS_FAILED_STATES:
+        effective_cutoff = min(age_cutoff, tier_b_cutoff)
+    if mtime > effective_cutoff:
+        record["skip_reason"] = "within_retention"
+        return record
+    if has_live_pid_for_run(run_id, target_root):
+        record["skip_reason"] = "live_pid"
+        return record
+    record["eligible"] = True
+    return record
+
+
+def _apply_preserve_floor(records):
+    """Bump the latest ALWAYS_PRESERVE_FLOOR entries per (surface, family) back
+    to ineligible.  This guarantees quiet weekly jobs always have at least
+    N=5 diagnostics on each surface, regardless of retention age."""
+    groups = defaultdict(list)
+    for record in records:
+        groups[(record["surface"], record["family"])].append(record)
+    for items in groups.values():
+        items.sort(key=lambda r: r["mtime"], reverse=True)
+        for record in items[:ALWAYS_PRESERVE_FLOOR]:
+            if record["eligible"]:
+                record["eligible"] = False
+                record["skip_reason"] = "preserve_floor"
+
+
+def _format_artifact_summary(records):
+    eligible = [r for r in records if r["eligible"]]
+    by_surface = Counter(r["surface"] for r in eligible)
+    by_tier = Counter(r["tier"] for r in eligible)
+    by_family = Counter(r["family"] for r in eligible)
+    skip_counts = Counter(
+        r["skip_reason"] for r in records if not r["eligible"] and r["skip_reason"]
+    )
+    return {
+        "eligible_count": len(eligible),
+        "scanned_count": len(records),
+        "by_surface": dict(by_surface),
+        "by_tier": dict(by_tier),
+        "by_family": dict(by_family),
+        "skip_reasons": dict(skip_counts),
+    }
+
+
+def _serialize_artifact_record(record, *, target_root):
+    try:
+        rel = str(Path(record["path"]).relative_to(target_root))
+    except ValueError:
+        rel = str(record["path"])
+    return {
+        "surface": record["surface"],
+        "path": rel,
+        "run_id": record["run_id"],
+        "family": record["family"],
+        "tier": record["tier"],
+        "mtime": record["mtime"],
+        "eligible": record["eligible"],
+        "skip_reason": record["skip_reason"],
+        "queue_status": record["queue_status"],
+        "run_state": record["run_state"],
+    }
+
+
+def _rel_under(target_root, path):
+    p = Path(path)
+    try:
+        return str(p.relative_to(target_root))
+    except ValueError:
+        return str(p)
+
+
+def run_cleanup_run_artifacts(args, *, dry_run):
+    """Apply path for ``cleanup-{report,prune} --mode run-artifacts``.
+
+    Audit row policy: counts only + at most 5 sample paths. Payload contents
+    are NEVER included — the issue body and the brief both pin this.
+    """
+    target_root_arg = getattr(args, "target_root", None) or os.environ.get("BRIDGE_HOME") or ""
+    target_root = Path(target_root_arg).expanduser() if target_root_arg else Path("")
+    if not target_root_arg or not target_root.is_dir():
+        payload = {
+            "status": "error",
+            "mode": "run-artifacts",
+            "error": "target_root_missing",
+            "target_root": str(target_root),
+        }
+        if getattr(args, "json", False):
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+        else:
+            print("status: error")
+            print(f"error: target_root_missing ({target_root})")
+        return 2
+    target_root = target_root.resolve()
+    older_than_days = getattr(args, "older_than_days", None)
+    if older_than_days is not None:
+        tier_a_days = int(older_than_days)
+        tier_b_days = int(older_than_days)
+    else:
+        tier_a_days = RUN_ARTIFACTS_TIER_A_DEFAULT_DAYS
+        tier_b_days = RUN_ARTIFACTS_TIER_B_DEFAULT_DAYS
+    tasks_db_path = getattr(args, "tasks_db", None)
+    tasks_db_path = Path(tasks_db_path).expanduser() if tasks_db_path else None
+    records = collect_run_artifact_candidates(
+        target_root,
+        tier_a_days=tier_a_days,
+        tier_b_days=tier_b_days,
+        tasks_db_path=tasks_db_path,
+    )
+    summary = _format_artifact_summary(records)
+    eligible = [r for r in records if r["eligible"]]
+    sample_paths = [_rel_under(target_root, r["path"]) for r in eligible[:5]]
+    report_only = bool(getattr(args, "_report_only", False))
+
+    payload = {
+        "status": "report" if report_only else ("dry_run" if dry_run else "pruned"),
+        "mode": "run-artifacts",
+        "target_root": str(target_root),
+        "tier_a_days": tier_a_days,
+        "tier_b_days": tier_b_days,
+        "always_preserve_floor": ALWAYS_PRESERVE_FLOOR,
+        "summary": summary,
+        "sample_paths": sample_paths,
+    }
+
+    deleted = 0
+    delete_errors = []
+    if not dry_run and not report_only:
+        for record in eligible:
+            path = Path(record["path"])
+            try:
+                if path.is_symlink():
+                    # Defense-in-depth: we already filter symlinks during
+                    # the walk, but if one slipped past, refuse.
+                    continue
+                if path.is_dir():
+                    _rmtree_safe(path)
+                else:
+                    try:
+                        path.unlink()
+                    except FileNotFoundError:
+                        pass
+                deleted += 1
+            except OSError as exc:
+                delete_errors.append({"path": str(path), "error": str(exc)})
+        # Best-effort: prune now-empty parent dirs under state/cron/dispatch.
+        dispatch_root = target_root / "state" / "cron" / "dispatch"
+        if dispatch_root.is_dir():
+            for slug_dir in list(dispatch_root.iterdir()):
+                if (
+                    slug_dir.is_dir()
+                    and not slug_dir.is_symlink()
+                    and not any(slug_dir.iterdir())
+                ):
+                    try:
+                        slug_dir.rmdir()
+                    except OSError:
+                        pass
+        payload["deleted_count"] = deleted
+        if delete_errors:
+            payload["delete_errors"] = delete_errors[:10]
+            payload["delete_error_count"] = len(delete_errors)
+
+    if getattr(args, "json", False):
+        payload["records"] = [
+            _serialize_artifact_record(r, target_root=target_root)
+            for r in records[:50]
+        ]
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 0
+
+    print("mode: run-artifacts")
+    print(f"target_root: {target_root}")
+    print(f"tier_a_days: {tier_a_days}")
+    print(f"tier_b_days: {tier_b_days}")
+    print(f"always_preserve_floor: {ALWAYS_PRESERVE_FLOOR}")
+    print(f"scanned: {summary['scanned_count']}")
+    print(f"eligible: {summary['eligible_count']}")
+    if summary["by_surface"]:
+        print("by_surface:")
+        for surface, count in summary["by_surface"].items():
+            print(f"- {surface}: {count}")
+    if summary["skip_reasons"]:
+        print("skip_reasons:")
+        for reason, count in summary["skip_reasons"].items():
+            print(f"- {reason}: {count}")
+    if sample_paths:
+        print("sample_paths:")
+        for sample in sample_paths:
+            print(f"- {sample}")
+    if not dry_run and not report_only:
+        print(f"deleted: {deleted}")
+        if delete_errors:
+            print(f"delete_errors: {len(delete_errors)}")
+    print(f"status: {payload['status']}")
+    return 0
 
 
 def print_cleanup_report(args, records):
@@ -1633,17 +2328,44 @@ def build_parser():
     errors_report_parser.add_argument("--limit", type=int, default=None)
     errors_report_parser.add_argument("--json", action="store_true")
 
-    cleanup_report_parser = subparsers.add_parser("cleanup-report", help="Report prune candidates for stale one-shot cron jobs.")
-    cleanup_report_parser.add_argument("--jobs-file", required=True)
-    cleanup_report_parser.add_argument("--mode", choices=("expired-one-shot",), default="expired-one-shot")
+    cleanup_report_parser = subparsers.add_parser("cleanup-report", help="Report prune candidates for stale one-shot cron jobs and/or run artifacts.")
+    # ``--jobs-file`` is required only for the legacy one-shot mode; the
+    # run-artifacts mode operates on the BRIDGE_HOME tree instead. We drop
+    # the required flag and validate per-mode in main().
+    cleanup_report_parser.add_argument("--jobs-file")
+    cleanup_report_parser.add_argument(
+        "--mode",
+        choices=("expired-one-shot", "one-shot", "run-artifacts", "all"),
+        default="expired-one-shot",
+    )
     cleanup_report_parser.add_argument("--limit", type=int, default=None)
     cleanup_report_parser.add_argument("--json", action="store_true")
+    cleanup_report_parser.add_argument("--target-root", help="BRIDGE_HOME for --mode run-artifacts/all")
+    cleanup_report_parser.add_argument("--tasks-db", help="tasks.db path for --mode run-artifacts/all")
+    cleanup_report_parser.add_argument(
+        "--older-than-days",
+        type=int,
+        default=None,
+        help="single-knob retention override (overrides both Tier-A and Tier-B defaults)",
+    )
 
-    cleanup_prune_parser = subparsers.add_parser("cleanup-prune", help="Prune stale one-shot cron jobs from jobs.json.")
-    cleanup_prune_parser.add_argument("--jobs-file", required=True)
-    cleanup_prune_parser.add_argument("--mode", choices=("expired-one-shot",), default="expired-one-shot")
+    cleanup_prune_parser = subparsers.add_parser("cleanup-prune", help="Prune stale one-shot cron jobs from jobs.json and/or run artifacts.")
+    cleanup_prune_parser.add_argument("--jobs-file")
+    cleanup_prune_parser.add_argument(
+        "--mode",
+        choices=("expired-one-shot", "one-shot", "run-artifacts", "all"),
+        default="expired-one-shot",
+    )
     cleanup_prune_parser.add_argument("--dry-run", action="store_true")
     cleanup_prune_parser.add_argument("--json", action="store_true")
+    cleanup_prune_parser.add_argument("--target-root", help="BRIDGE_HOME for --mode run-artifacts/all")
+    cleanup_prune_parser.add_argument("--tasks-db", help="tasks.db path for --mode run-artifacts/all")
+    cleanup_prune_parser.add_argument(
+        "--older-than-days",
+        type=int,
+        default=None,
+        help="single-knob retention override (overrides both Tier-A and Tier-B defaults)",
+    )
 
     native_list_parser = subparsers.add_parser("native-list", help="List bridge-native cron jobs.")
     native_list_parser.add_argument("--jobs-file", required=True)
@@ -1796,7 +2518,23 @@ def main():
             print(f"error: {exc}", file=sys.stderr)
             return 2
 
+    # Issue #533 — `cleanup-{report,prune} --mode run-artifacts` does not
+    # touch jobs.json, so it must short-circuit before the jobs-file load.
+    # `--mode all` runs both passes (one-shot first, then run-artifacts).
+    if args.command in ("cleanup-report", "cleanup-prune"):
+        mode = getattr(args, "mode", "expired-one-shot")
+        if mode == "run-artifacts":
+            args._report_only = args.command == "cleanup-report"  # noqa: SLF001
+            dry_run = args._report_only or bool(getattr(args, "dry_run", False))
+            return run_cleanup_run_artifacts(args, dry_run=dry_run)
+
     try:
+        if not getattr(args, "jobs_file", None):
+            print(
+                "error: --jobs-file is required for this command/mode",
+                file=sys.stderr,
+            )
+            return 2
         raw_payload, jobs = load_jobs_payload(args.jobs_file)
         records = [build_job_record(job) for job in jobs]
     except FileNotFoundError:
@@ -1826,10 +2564,24 @@ def main():
         if args.limit is not None and args.limit < 0:
             print("error: --limit must be >= 0", file=sys.stderr)
             return 2
-        return print_cleanup_report(args, records)
+        rc = print_cleanup_report(args, records)
+        if rc == 0 and getattr(args, "mode", "") == "all":
+            args._report_only = True  # noqa: SLF001
+            print()
+            print("--- run-artifacts ---")
+            rc = run_cleanup_run_artifacts(args, dry_run=True)
+        return rc
 
     if args.command == "cleanup-prune":
-        return run_cleanup_prune(args, raw_payload, records)
+        rc = run_cleanup_prune(args, raw_payload, records)
+        if rc == 0 and getattr(args, "mode", "") == "all":
+            print()
+            print("--- run-artifacts ---")
+            args._report_only = False  # noqa: SLF001
+            rc = run_cleanup_run_artifacts(
+                args, dry_run=bool(getattr(args, "dry_run", False))
+            )
+        return rc
 
     parser.error(f"unsupported command: {args.command}")
     return 2

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -793,53 +793,132 @@ def has_live_pid_for_run(run_id, target_root):
     return False
 
 
+def _queue_cli_path():
+    """Path to the sibling ``bridge-queue.py`` CLI."""
+    return Path(__file__).resolve().parent / "bridge-queue.py"
+
+
+def _lookup_queue_status_via_cli(task_id, *, tasks_db_path):
+    """Subprocess to ``bridge-queue.py show <task_id> --format shell`` and
+    return the queue status string, or ``None`` when the row cannot be
+    read (task not found / queue unavailable / parse error).
+
+    PR #536 r2: keeps the cleanup pass on the queue-first contract
+    (CLAUDE.md). The subprocess cost is bounded — GC runs are rare
+    (daily-ish) and each artifact requires one short read.
+    """
+    cmd = [
+        sys.executable,
+        str(_queue_cli_path()),
+        "show",
+        str(task_id),
+        "--format",
+        "shell",
+    ]
+    env = dict(os.environ)
+    # Force the direct (non-gateway) read path. The gateway adds a
+    # round-trip we don't need for a status lookup, and would require an
+    # operator agent context the cleanup pass doesn't have.
+    env.pop("BRIDGE_GATEWAY_PROXY", None)
+    env.pop("BRIDGE_AGENT_ID", None)
+    if tasks_db_path is not None:
+        env["BRIDGE_TASK_DB"] = str(tasks_db_path)
+    try:
+        completed = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=15, check=False, env=env
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if completed.returncode != 0:
+        return None
+    for line in completed.stdout.splitlines():
+        if line.startswith("TASK_STATUS="):
+            # Shell-format value is shlex-quoted; for a queue status enum
+            # ("queued"/"claimed"/"done"/"cancelled"/"blocked"/"in_progress")
+            # there are no shell-special characters so a simple strip is
+            # sufficient. Use shlex.split to be safe against edge cases.
+            try:
+                parts = shlex.split(line[len("TASK_STATUS="):])
+            except ValueError:
+                return None
+            return parts[0] if parts else None
+    return None
+
+
 def queue_dispatch_terminal(run_id, target_root, *, tasks_db_path=None, run_dir=None):
     """Return (terminal?, queue_status, dispatch_task_id) for the given run.
 
-    Looks up ``dispatch_task_id`` from ``state/cron/runs/<run_id>/request.json``
-    and queries the SQLite tasks db directly. Reads SQLite the same way
-    ``run_reconcile_run_state`` does — we deliberately do NOT shell out to
-    ``bridge-queue.py``, since that would multiply the per-prune cost by the
-    number of run dirs.
-
-    A run with NO request.json or NO dispatch_task_id is treated as terminal
-    (no queue task to wait on). A run whose dispatch task row has been deleted
-    from the queue (e.g. a much older queue row already pruned) is also
-    treated as terminal — there is nothing keeping it alive.
+    PR #536 r2 contract:
+      - The dispatch task_id is resolved from ``request.json`` first, then
+        falls back to extracting ``<id>`` from a ``run_id`` of the form
+        ``task-<id>`` (used by the worker-artifact surface). Without this
+        fallback, a worker artifact whose run-dir was pruned would satisfy
+        the queue gate vacuously — Codex r1 finding #1.
+      - The status lookup goes through ``bridge-queue.py show --format
+        shell`` rather than direct SQLite, honoring the queue-first
+        contract in CLAUDE.md (Codex r1 finding #2).
+      - When the task_id cannot be identified at all, the gate returns
+        ``False`` (NOT terminal). Conservative-on-missing-context: a
+        missing-context artifact stays around until the operator can
+        investigate. This trades a small amount of long-tail orphan
+        retention for safety against the active-artifact bypass.
     """
     if run_dir is None:
         run_dir = Path(target_root) / "state" / "cron" / "runs" / run_id
     request_path = Path(run_dir) / "request.json"
-    if not request_path.is_file():
-        return True, "no_request", None
-    try:
-        request = json.loads(request_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        return True, "unparseable_request", None
-    dispatch_task_id = request.get("dispatch_task_id")
-    try:
-        dispatch_task_id = int(dispatch_task_id) if dispatch_task_id is not None else None
-    except (TypeError, ValueError):
-        dispatch_task_id = None
+
+    dispatch_task_id = None
+    request_present = request_path.is_file()
+    request_parseable = True
+    if request_present:
+        try:
+            request = json.loads(request_path.read_text(encoding="utf-8"))
+            raw_task_id = request.get("dispatch_task_id")
+            try:
+                dispatch_task_id = (
+                    int(raw_task_id) if raw_task_id is not None else None
+                )
+            except (TypeError, ValueError):
+                dispatch_task_id = None
+        except (OSError, ValueError):
+            request_parseable = False
+
+    # Worker-artifact fallback: ``state/cron/workers/task-<id>.{pid,log}``
+    # entries are keyed by the queue task id directly (see
+    # ``_run_id_from_worker_log``). When the run-dir is missing for these,
+    # we still know the task_id — extract it from the run_id rather than
+    # treating the missing request.json as "terminal".
+    if dispatch_task_id is None and run_id.startswith("task-"):
+        suffix = run_id[len("task-"):]
+        if suffix.isdigit():
+            try:
+                dispatch_task_id = int(suffix)
+            except (TypeError, ValueError):
+                dispatch_task_id = None
+
     if dispatch_task_id is None:
-        return True, "no_dispatch_task_id", None
+        # Cannot identify the queue row. Refuse to consider the artifact
+        # eligible — better a long-tail orphan than an active bypass.
+        if not request_present:
+            return False, "missing_task_id:no_request", None
+        if not request_parseable:
+            return False, "missing_task_id:unparseable_request", None
+        return False, "missing_task_id:no_dispatch_task_id", None
 
     if tasks_db_path is None:
         tasks_db_path = Path(target_root) / "state" / "tasks.db"
     tasks_db_path = Path(tasks_db_path)
     if not tasks_db_path.is_file():
-        return True, "no_tasks_db", dispatch_task_id
+        # No queue DB on disk — be conservative.
+        return False, "no_tasks_db", dispatch_task_id
 
-    try:
-        with sqlite3.connect(tasks_db_path) as conn:
-            row = conn.execute(
-                "SELECT status FROM tasks WHERE id = ?", (dispatch_task_id,)
-            ).fetchone()
-    except sqlite3.Error:
-        return False, "queue_query_error", dispatch_task_id
-    if row is None:
-        return True, "row_missing", dispatch_task_id
-    status = row[0]
+    status = _lookup_queue_status_via_cli(
+        dispatch_task_id, tasks_db_path=tasks_db_path
+    )
+    if status is None:
+        # CLI read failed (timeout, parse error, row missing). Conservative
+        # on missing context: NOT terminal.
+        return False, "queue_lookup_failed", dispatch_task_id
     return status in _QUEUE_TERMINAL_STATUSES, status, dispatch_task_id
 
 

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -781,6 +781,27 @@ run_sync() {
         status=1
       fi
       cleanup_json="$tmp_dir/native-cleanup.json"
+
+      # Issue #533 — opt-in periodic GC for cron run artifacts. Default OFF
+      # to preserve current sync behavior exactly. Operators can enable
+      # hands-off retention via:
+      #   BRIDGE_CRON_RUN_ARTIFACTS_GC=1 (and optional
+      #   BRIDGE_CRON_RUN_ARTIFACTS_OLDER_THAN_DAYS=<N> single-knob).
+      # Failures here do NOT flip $status — retention is best-effort and
+      # must not block scheduler tick visibility.
+      if [[ "${BRIDGE_CRON_RUN_ARTIFACTS_GC:-0}" == "1" ]]; then
+        local rga_args=(
+          cleanup-prune
+          --mode run-artifacts
+          --target-root "$BRIDGE_HOME"
+          --tasks-db "$BRIDGE_TASK_DB"
+          --json
+        )
+        if [[ -n "${BRIDGE_CRON_RUN_ARTIFACTS_OLDER_THAN_DAYS:-}" ]]; then
+          rga_args+=(--older-than-days "$BRIDGE_CRON_RUN_ARTIFACTS_OLDER_THAN_DAYS")
+        fi
+        bridge_cron_python "${rga_args[@]}" >"$tmp_dir/native-run-artifacts-cleanup.json" 2>/dev/null || true
+      fi
     fi
   fi
 
@@ -932,20 +953,32 @@ run_cleanup() {
   local cleanup_cmd="${1:-}"
   shift || true
 
-  local jobs_file
-  jobs_file="$(bridge_cron_source_jobs_file || true)"
-  bridge_require_cron_source_jobs "$jobs_file"
+  # Issue #533 — for `--mode run-artifacts` and `--mode all` the cleanup
+  # operates on BRIDGE_HOME directly and does not need a jobs file. We
+  # peek at the args to decide whether to require the source jobs file.
+  local _peek_mode="expired-one-shot"
+  local _arg
+  for _arg in "$@"; do
+    if [[ "$_arg" == "run-artifacts" || "$_arg" == "all" || "$_arg" == "one-shot" || "$_arg" == "expired-one-shot" ]]; then
+      _peek_mode="$_arg"
+    fi
+  done
+
+  local jobs_file=""
+  if [[ "$_peek_mode" != "run-artifacts" ]]; then
+    jobs_file="$(bridge_cron_source_jobs_file || true)"
+    bridge_require_cron_source_jobs "$jobs_file"
+  fi
 
   case "$cleanup_cmd" in
     report)
-      local py_args=(
-        cleanup-report
-        --jobs-file "$jobs_file"
-      )
+      local py_args=(cleanup-report)
+      [[ -n "$jobs_file" ]] && py_args+=(--jobs-file "$jobs_file")
+      py_args+=(--target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB")
       while [[ $# -gt 0 ]]; do
         case "$1" in
-          --mode)
-            [[ $# -lt 2 ]] && bridge_die "--mode 뒤에 값을 지정하세요."
+          --mode|--older-than-days|--target-root|--tasks-db)
+            [[ $# -lt 2 ]] && bridge_die "$1 뒤에 값을 지정하세요."
             py_args+=("$1" "$2")
             shift 2
             ;;
@@ -965,14 +998,13 @@ run_cleanup() {
       bridge_cron_python "${py_args[@]}"
       ;;
     prune)
-      local py_args=(
-        cleanup-prune
-        --jobs-file "$jobs_file"
-      )
+      local py_args=(cleanup-prune)
+      [[ -n "$jobs_file" ]] && py_args+=(--jobs-file "$jobs_file")
+      py_args+=(--target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB")
       while [[ $# -gt 0 ]]; do
         case "$1" in
-          --mode)
-            [[ $# -lt 2 ]] && bridge_die "--mode 뒤에 값을 지정하세요."
+          --mode|--older-than-days|--target-root|--tasks-db)
+            [[ $# -lt 2 ]] && bridge_die "$1 뒤에 값을 지정하세요."
             py_args+=("$1" "$2")
             shift 2
             ;;

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention
 }
 
 add_all_integration() {
@@ -187,9 +187,17 @@ select_for_path() {
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention
       add_integration integration-minimal
       add_live live-tmux-daemon
+      ;;
+
+    bridge-cron.py|bridge-cron-runner.py|bridge-cron-scheduler.py)
+      # Issue #533 — cron run-artifact retention/GC contract lives in
+      # bridge-cron.py. Cover its smoke directly when any cron-side
+      # python file moves.
+      add_required cron-run-artifacts-retention queue
+      add_integration integration-minimal
       ;;
 
     bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh|lib/bridge-wave.sh|lib/bridge-agent-update.sh)

--- a/scripts/smoke/cron-run-artifacts-retention.sh
+++ b/scripts/smoke/cron-run-artifacts-retention.sh
@@ -688,10 +688,24 @@ for key, value in expected.items():
 # normalization step for round-tripped reads, which is byte-equivalent).
 PY
 
+  # Codex PR #536 r2 review finding #3 (r3): the JSON-field semantic
+  # checks above prove shape compat, but the original brief asked for
+  # byte-identical determinism across an idempotent re-run. Capture
+  # sha256 of jobs.json now (post-first-prune), re-run the same legacy
+  # `--mode expired-one-shot` path, then capture sha256 again. Stable
+  # output bytes prove the prune writer is fully deterministic when
+  # there is nothing left to remove.
+  local expected_sha actual_sha
+  expected_sha="$(python3 -c 'import sys, hashlib; sys.stdout.write(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$jobs_file")"
+
   # Run prune again — should be idempotent (nothing left to prune).
   out="$(run_py cleanup-prune --jobs-file "$jobs_file" \
     --mode expired-one-shot --json)"
   smoke_assert_contains "$out" '"status": "nothing_to_prune"' "one-shot byte-compat: idempotent re-run"
+
+  actual_sha="$(python3 -c 'import sys, hashlib; sys.stdout.write(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$jobs_file")"
+  smoke_assert_eq "$expected_sha" "$actual_sha" \
+    "one-shot prune output sha256 stable across idempotent reruns"
 
   # And `--mode run-artifacts` does NOT touch jobs.json — assert by hash.
   local sha_before sha_after

--- a/scripts/smoke/cron-run-artifacts-retention.sh
+++ b/scripts/smoke/cron-run-artifacts-retention.sh
@@ -65,6 +65,11 @@ PY
 }
 
 seed_tasks_db() {
+  # PR #536 r2 — `queue_dispatch_terminal` now reads the queue via
+  # `bridge-queue.py show <id> --format shell` (queue-first contract).
+  # `bridge-queue.py` runs `init_db` on every connect, which expects the
+  # full v2 schema. Stand up a real schema instead of the minimal
+  # (id,status) two-column version so the CLI read path works.
   python3 - "$BRIDGE_TASK_DB" <<'PY'
 import sqlite3, sys
 path = sys.argv[1]
@@ -75,7 +80,19 @@ conn.execute(
     """
     CREATE TABLE IF NOT EXISTS tasks (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
-        status TEXT NOT NULL DEFAULT 'queued'
+        title TEXT NOT NULL,
+        assigned_to TEXT NOT NULL,
+        created_by TEXT NOT NULL,
+        priority TEXT NOT NULL DEFAULT 'normal',
+        status TEXT NOT NULL DEFAULT 'queued',
+        created_ts INTEGER NOT NULL,
+        updated_ts INTEGER NOT NULL,
+        body_text TEXT,
+        body_path TEXT,
+        claimed_by TEXT,
+        claimed_ts INTEGER,
+        lease_until_ts INTEGER,
+        closed_ts INTEGER
     )
     """
 )
@@ -87,10 +104,19 @@ PY
 insert_task() {
   local status="$1"
   python3 - "$BRIDGE_TASK_DB" "$status" <<'PY'
-import sqlite3, sys
+import sqlite3, sys, time
 path, status = sys.argv[1], sys.argv[2]
+ts = int(time.time())
 conn = sqlite3.connect(path)
-cur = conn.execute("INSERT INTO tasks (status) VALUES (?)", (status,))
+cur = conn.execute(
+    """
+    INSERT INTO tasks (
+      title, assigned_to, created_by, priority, status,
+      created_ts, updated_ts, body_text
+    ) VALUES (?, ?, ?, 'normal', ?, ?, ?, ?)
+    """,
+    ("smoke fixture", "smoke-agent", "smoke-actor", status, ts, ts, "fixture body"),
+)
 print(cur.lastrowid)
 conn.commit()
 conn.close()
@@ -426,6 +452,256 @@ EOF
   smoke_assert_contains "$out_alias" '"candidate_count": 0' "one-shot alias runs without error"
 }
 
+# PR #536 r2 — Codex r1 finding #3, smoke gap #1: failed-run eviction at the
+# full Tier-B 30d window. Issue body promises that state="error" runs are
+# held back to the longer Tier-B clock, then evicted past it. Pair with a
+# 29-day-old fixture as the negative control (within retention).
+assert_failed_run_evicted_at_30d() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  local task_evict task_keep
+  task_evict="$(insert_task done)"
+  task_keep="$(insert_task done)"
+  # 31 days old failed run on a Tier-A surface — past Tier-B 30d so eligible.
+  write_run_fixture "morning-briefing-err30--evict" "$task_evict" "error" 31
+  # 29 days old failed run — within Tier-B retention so retained.
+  write_run_fixture "morning-briefing-err30--keep" "$task_keep" "error" 29
+  # Pad the family floor so neither test entry is preserve_floor-pinned.
+  seed_floor_padding "morning-briefing-err30-padding"
+
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  python3 - "$out" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+records = payload["records"]
+evict = next(
+    r for r in records
+    if r["surface"] == "state/cron/runs" and r["run_id"] == "morning-briefing-err30--evict"
+)
+keep = next(
+    r for r in records
+    if r["surface"] == "state/cron/runs" and r["run_id"] == "morning-briefing-err30--keep"
+)
+assert evict["eligible"] is True, (
+    f"31d failed run must be evicted at Tier-B 30d; got record={evict}"
+)
+assert evict["run_state"] == "error", evict
+assert keep["eligible"] is False, (
+    f"29d failed run must be retained within Tier-B; got record={keep}"
+)
+assert keep["skip_reason"] == "within_retention", keep
+PY
+}
+
+# PR #536 r2 — Codex r1 finding #3, smoke gap #2: state/cron/dispatch surface
+# is one of the 6 surfaces in the issue body but the original smoke only
+# seeded runs/workers/shared. Seed N=6 per-slot manifests under dispatch
+# (so the always-preserve floor of 5 leaves 1 eligible) and assert that
+# the eligible one gets removed under Tier-A retention.
+assert_dispatch_surface_pruned() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  # state/cron/dispatch/<job_slug>/<slot_token>.json — the slot's run_id is
+  # `${slug}--${slot_token}` per `_entries_for_dispatch_dir`. classify_family
+  # matches "morning-briefing" prefix, so all 6 share one (surface, family)
+  # bucket — floor=5 leaves exactly 1 eligible.
+  local slug_dir="$BRIDGE_STATE_DIR/cron/dispatch/morning-briefing-dispatch"
+  mkdir -p "$slug_dir"
+  local i task_id manifest run_id
+  for i in 1 2 3 4 5 6; do
+    task_id="$(insert_task done)"
+    run_id="morning-briefing-dispatch--slot${i}"
+    # Seed paired runs/ fixture so the queue gate has a request.json.
+    write_run_fixture "$run_id" "$task_id" "success" 30
+    manifest="$slug_dir/slot${i}.json"
+    printf '{"slot":"slot%d","status":"success","dispatch_task_id":%s}\n' \
+      "$i" "$task_id" >"$manifest"
+    # Stagger mtime by i seconds so slot6 is "newest of the old".
+    python3 - "$manifest" "$i" <<'PY'
+import os, sys, time
+path, bump = sys.argv[1], int(sys.argv[2])
+ts = int(time.time()) - 30 * 86400 + bump
+os.utime(path, (ts, ts))
+PY
+  done
+  backdate "$slug_dir" 30
+
+  local before_dispatch
+  # shellcheck disable=SC2012  # fixture filenames are well-known.
+  before_dispatch="$(ls "$slug_dir" 2>/dev/null | wc -l | tr -d ' ')"
+  smoke_assert_eq "6" "$before_dispatch" "dispatch fixture seeded six manifests"
+
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  python3 - "$out" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+dispatch_records = [
+    r for r in payload["records"] if r["surface"] == "state/cron/dispatch"
+]
+assert len(dispatch_records) == 6, (
+    f"expected 6 dispatch records, got {len(dispatch_records)}; payload={payload}"
+)
+eligible = [r for r in dispatch_records if r["eligible"]]
+assert len(eligible) == 1, (
+    f"expected exactly 1 eligible dispatch entry (floor=5 of 6); got {len(eligible)}"
+)
+# The eligible entry should be slot1 (oldest mtime), since slot6 is newest.
+assert eligible[0]["run_id"] == "morning-briefing-dispatch--slot1", eligible[0]
+PY
+
+  out="$(run_py cleanup-prune --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  smoke_assert_contains "$out" '"status": "pruned"' "prune ran on dispatch entry"
+  [[ ! -f "$slug_dir/slot1.json" ]] \
+    || smoke_fail "dispatch manifest slot1.json was not deleted"
+  # The other 5 slot manifests must remain (preserve_floor).
+  local after_dispatch
+  # shellcheck disable=SC2012  # fixture filenames are well-known.
+  after_dispatch="$(ls "$slug_dir" 2>/dev/null | wc -l | tr -d ' ')"
+  smoke_assert_eq "5" "$after_dispatch" "5 dispatch manifests preserved by floor"
+}
+
+# PR #536 r2 — Codex r1 finding #3, smoke gap #3: --mode all end-to-end.
+# Seed BOTH an expired one-shot job AND eligible run-artifacts, run
+# `cleanup-prune --mode all`, assert that one-shot rewrites jobs.json and
+# the run-artifact pass deletes the eligible artifact.
+assert_mode_all_end_to_end() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  # Seed an expired one-shot job in jobs.json.
+  local jobs_file="$BRIDGE_HOME/cron/jobs.json"
+  mkdir -p "$BRIDGE_HOME/cron"
+  # ``deleteAfterRun=true``, ``enabled=false``, ``schedule.kind=at`` with
+  # an `at` value in the past = the expired-one-shot cleanup criteria
+  # (see ``cleanup_candidates`` in bridge-cron.py).
+  cat >"$jobs_file" <<'EOF'
+{"format":"agent-bridge-cron-v1","jobs":[
+  {"id":"expired1","name":"expired1","agentId":"a",
+   "schedule":{"kind":"at","at":"2020-01-01T00:00:00+00:00","tz":"UTC"},
+   "enabled":false,"deleteAfterRun":true},
+  {"id":"keepme","name":"keepme","agentId":"a",
+   "schedule":{"kind":"cron","expr":"0 * * * *","tz":"UTC"},
+   "enabled":true,"deleteAfterRun":false}
+]}
+EOF
+
+  # Seed an eligible run-artifact (30d old, success, queue done).
+  local task_id
+  task_id="$(insert_task done)"
+  write_run_fixture "morning-briefing-all--slot1" "$task_id" "success" 30
+  seed_floor_padding "morning-briefing-all-padding"
+
+  local out
+  out="$(run_py cleanup-prune --mode all \
+    --jobs-file "$jobs_file" \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  # `--mode all` prints the one-shot JSON, then `--- run-artifacts ---`,
+  # then the run-artifacts JSON. Both must report a non-zero deletion.
+  smoke_assert_contains "$out" "--- run-artifacts ---" "mode-all printed run-artifacts banner"
+  smoke_assert_contains "$out" '"deleted_jobs": 1' "one-shot pass deleted expired1"
+  smoke_assert_contains "$out" '"status": "pruned"' "run-artifacts pass pruned"
+
+  # jobs.json should still contain keepme but no longer expired1.
+  python3 - "$jobs_file" <<'PY'
+import json, sys
+payload = json.loads(open(sys.argv[1], encoding="utf-8").read())
+ids = sorted(j.get("id") for j in payload.get("jobs", []))
+assert ids == ["keepme"], f"expected only keepme; got {ids}"
+PY
+
+  # The eligible run-artifact must be gone.
+  [[ ! -d "$BRIDGE_STATE_DIR/cron/runs/morning-briefing-all--slot1" ]] \
+    || smoke_fail "run-artifact pass did not delete morning-briefing-all--slot1"
+}
+
+# PR #536 r2 — Codex r1 finding #3, smoke gap #4: real one-shot
+# byte-identical compat. Capture jobs.json after the legacy
+# `--mode expired-one-shot` path runs over a real expired one-shot
+# fixture, normalize, and confirm the rewrite shape matches what the
+# pre-#533 path would have produced (i.e. the new code path did not drift
+# the JSON emission shape).
+assert_one_shot_byte_identical_compat() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  local jobs_file="$BRIDGE_HOME/cron/jobs.json"
+  mkdir -p "$BRIDGE_HOME/cron"
+  # Two-job fixture: one expired one-shot to be removed, one keeper.
+  cat >"$jobs_file" <<'EOF'
+{
+  "format": "agent-bridge-cron-v1",
+  "jobs": [
+    {
+      "id": "drop1",
+      "name": "drop1",
+      "agentId": "a",
+      "schedule": {"kind": "at", "at": "2020-01-01T00:00:00+00:00", "tz": "UTC"},
+      "enabled": false,
+      "deleteAfterRun": true
+    },
+    {
+      "id": "keepme",
+      "name": "keepme",
+      "agentId": "a",
+      "schedule": {"kind": "cron", "expr": "0 * * * *", "tz": "UTC"},
+      "enabled": true,
+      "deleteAfterRun": false
+    }
+  ]
+}
+EOF
+  local before
+  before="$(cat "$jobs_file")"
+
+  local out
+  out="$(run_py cleanup-prune --jobs-file "$jobs_file" \
+    --mode expired-one-shot --json)"
+  smoke_assert_contains "$out" '"deleted_jobs": 1' "one-shot byte-compat: expected one deletion"
+
+  local after
+  after="$(cat "$jobs_file")"
+  [[ "$before" != "$after" ]] || smoke_fail "one-shot byte-compat: jobs.json unchanged after prune"
+
+  # Normalize to compact JSON via python3 and confirm the keepme job's
+  # serialized shape is byte-identical to the expected post-prune shape.
+  python3 - "$jobs_file" <<'PY'
+import json, sys
+payload = json.loads(open(sys.argv[1], encoding="utf-8").read())
+jobs = payload.get("jobs", [])
+ids = sorted(j.get("id") for j in jobs)
+assert ids == ["keepme"], f"expected only keepme; got {ids}"
+keep = jobs[0]
+# byte-identical compat: every field that appeared in the pre-#533
+# emission must be exactly preserved on the surviving job.
+expected = {
+    "id": "keepme",
+    "name": "keepme",
+    "agentId": "a",
+    "schedule": {"kind": "cron", "expr": "0 * * * *", "tz": "UTC"},
+    "enabled": True,
+    "deleteAfterRun": False,
+}
+for key, value in expected.items():
+    got = keep.get(key)
+    assert got == value, f"keepme drift on {key}: expected {value!r}, got {got!r}"
+# Must NOT have alias or "agent" duplicate added (the v0.7.4 emission
+# uses agentId only; normalize_job_agent_fields adds "agent" mirror as a
+# normalization step for round-tripped reads, which is byte-equivalent).
+PY
+
+  # Run prune again — should be idempotent (nothing left to prune).
+  out="$(run_py cleanup-prune --jobs-file "$jobs_file" \
+    --mode expired-one-shot --json)"
+  smoke_assert_contains "$out" '"status": "nothing_to_prune"' "one-shot byte-compat: idempotent re-run"
+
+  # And `--mode run-artifacts` does NOT touch jobs.json — assert by hash.
+  local sha_before sha_after
+  sha_before="$(python3 -c 'import sys, hashlib; sys.stdout.write(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$jobs_file")"
+  out="$(run_py cleanup-prune --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  sha_after="$(python3 -c 'import sys, hashlib; sys.stdout.write(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$jobs_file")"
+  smoke_assert_eq "$sha_before" "$sha_after" "run-artifacts mode must not touch jobs.json"
+}
+
 main() {
   smoke_require_cmd python3
   smoke_setup_bridge_home "$SMOKE_NAME"
@@ -446,6 +722,11 @@ main() {
   smoke_run "symlink safety: never follow a symlink" assert_symlink_safety
   smoke_run "dry-run does not mutate" assert_dry_run_does_not_mutate
   smoke_run "one-shot/expired-one-shot backwards compat" assert_one_shot_mode_backwards_compat
+  # PR #536 r2 — codex r1 needs-more remediation, finding #3 (4 new gates).
+  smoke_run "failed run evicted at full Tier-B 30d (29d retained)" assert_failed_run_evicted_at_30d
+  smoke_run "state/cron/dispatch surface seeded and pruned" assert_dispatch_surface_pruned
+  smoke_run "--mode all runs one-shot then run-artifacts" assert_mode_all_end_to_end
+  smoke_run "one-shot byte-identical compat (legacy mode prune)" assert_one_shot_byte_identical_compat
   smoke_log "passed"
 }
 

--- a/scripts/smoke/cron-run-artifacts-retention.sh
+++ b/scripts/smoke/cron-run-artifacts-retention.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# scripts/smoke/cron-run-artifacts-retention.sh — Issue #533 smoke.
+#
+# Validates the new `cleanup --mode run-artifacts` retention/GC pass:
+#  1. report --dry-run reports the expected eligibility for seeded fixtures.
+#  2. prune actually deletes eligible entries.
+#  3. always-preserve floor: with 10 entries for a single cron-family all
+#     older than retention, top 5 are preserved.
+#  4. combined deletion gate skips runs whose:
+#     - queue status is non-terminal (claimed),
+#     - status.json is non-terminal (failed-run state="error" honors
+#       Tier-B but is still kept on Tier-A surfaces because the longer
+#       Tier-B clock applies),
+#     - argv references the run_id (live PID liveness anchor).
+#  5. symlink safety: a fixture entry replaced with a symlink to /etc/passwd
+#     is never followed, /etc/passwd is intact.
+#  6. dry-run does not mutate.
+#  7. backwards compat: --mode one-shot / expired-one-shot still works
+#     (rewrites jobs.json correctly; this is the path that ran before #533).
+#  8. foreign-install isolation: a `sleep` whose argv mentions a run_id
+#     but is rooted under a different prefix does NOT match the
+#     path-anchored matcher.
+#
+# This smoke uses BRIDGE_HOME isolation (mktemp -d) and never touches the
+# operator's live runtime.
+
+set -euo pipefail
+
+SMOKE_NAME="cron-run-artifacts-retention"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+PY_BIN="${PYTHON3:-python3}"
+SPAWNED_PIDS=()
+
+cleanup() {
+  local pid
+  for pid in "${SPAWNED_PIDS[@]:-}"; do
+    [[ -n "$pid" ]] || continue
+    kill "$pid" 2>/dev/null || true
+  done
+  SPAWNED_PIDS=()
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+now_minus_days_seconds() {
+  local days="$1"
+  python3 -c "import sys, time; print(int(time.time()) - int(sys.argv[1]) * 86400)" "$days"
+}
+
+# Touch a path's mtime to <days> ago.
+backdate() {
+  local path="$1"
+  local days="$2"
+  local target_ts
+  target_ts="$(now_minus_days_seconds "$days")"
+  python3 - "$path" "$target_ts" <<'PY'
+import os, sys
+path = sys.argv[1]
+ts = int(sys.argv[2])
+os.utime(path, (ts, ts))
+PY
+}
+
+seed_tasks_db() {
+  python3 - "$BRIDGE_TASK_DB" <<'PY'
+import sqlite3, sys
+path = sys.argv[1]
+import pathlib
+pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+conn = sqlite3.connect(path)
+conn.execute(
+    """
+    CREATE TABLE IF NOT EXISTS tasks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        status TEXT NOT NULL DEFAULT 'queued'
+    )
+    """
+)
+conn.commit()
+conn.close()
+PY
+}
+
+insert_task() {
+  local status="$1"
+  python3 - "$BRIDGE_TASK_DB" "$status" <<'PY'
+import sqlite3, sys
+path, status = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(path)
+cur = conn.execute("INSERT INTO tasks (status) VALUES (?)", (status,))
+print(cur.lastrowid)
+conn.commit()
+conn.close()
+PY
+}
+
+seed_floor_padding() {
+  # Seed N=5 padding fixtures in a given cron-family so the test's single
+  # entry of interest does NOT get pinned by the always-preserve floor.
+  # Padding entries are 8 days old (just past Tier-A 7d retention, so
+  # they remain eligible-by-age) and they MUST be newer than the test
+  # entry's mtime so the floor-by-mtime-DESC sort picks padding ahead of
+  # the test entry. Caller writes its test entry first, then we pad.
+  local family_prefix="$1"
+  local i task_id
+  for i in 91 92 93 94 95; do
+    task_id="$(insert_task done)"
+    write_run_fixture "${family_prefix}--padslot${i}" "$task_id" "success" 8
+  done
+}
+
+write_run_fixture() {
+  # Args: run_id, dispatch_task_id, run_state, days_old
+  local run_id="$1"
+  local dispatch_task_id="$2"
+  local run_state="$3"
+  local days_old="$4"
+  local run_dir="$BRIDGE_STATE_DIR/cron/runs/$run_id"
+  mkdir -p "$run_dir"
+  cat >"$run_dir/request.json" <<EOF
+{"run_id": "$run_id", "dispatch_task_id": $dispatch_task_id, "job_id": "job-${run_id}", "job_name": "morning-briefing-${run_id}"}
+EOF
+  cat >"$run_dir/payload.md" <<EOF
+[fixture payload for $run_id]
+EOF
+  cat >"$run_dir/status.json" <<EOF
+{"run_id": "$run_id", "state": "$run_state"}
+EOF
+  cat >"$run_dir/result.json" <<EOF
+{"status": "$run_state"}
+EOF
+  : >"$run_dir/stdout.log"
+  : >"$run_dir/stderr.log"
+  backdate "$run_dir" "$days_old"
+  backdate "$run_dir/status.json" "$days_old"
+  backdate "$run_dir/request.json" "$days_old"
+  backdate "$run_dir/payload.md" "$days_old"
+  # Write paired shared/cron-* artifacts so we can assert all 6 surfaces.
+  local dispatch_md="$BRIDGE_SHARED_DIR/cron-dispatch/$run_id.md"
+  local result_md="$BRIDGE_SHARED_DIR/cron-result/$run_id.md"
+  local followup_md="$BRIDGE_SHARED_DIR/cron-followup/$run_id.md"
+  mkdir -p "$BRIDGE_SHARED_DIR/cron-dispatch" "$BRIDGE_SHARED_DIR/cron-result" "$BRIDGE_SHARED_DIR/cron-followup"
+  : >"$dispatch_md"
+  : >"$result_md"
+  : >"$followup_md"
+  backdate "$dispatch_md" "$days_old"
+  backdate "$result_md" "$days_old"
+  backdate "$followup_md" "$days_old"
+  # Worker log keyed by queue task id.
+  local worker_log="$BRIDGE_STATE_DIR/cron/workers/task-${dispatch_task_id}.log"
+  mkdir -p "$BRIDGE_STATE_DIR/cron/workers"
+  : >"$worker_log"
+  backdate "$worker_log" "$days_old"
+}
+
+run_py() {
+  python3 "$SMOKE_REPO_ROOT/bridge-cron.py" "$@"
+}
+
+assert_basic_dry_run_report() {
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  smoke_assert_contains "$out" '"mode": "run-artifacts"' "report mode echoed"
+  smoke_assert_contains "$out" '"tier_a_days": 7' "default tier_a_days emitted"
+  smoke_assert_contains "$out" '"tier_b_days": 30' "default tier_b_days emitted"
+  smoke_assert_contains "$out" '"always_preserve_floor": 5' "preserve floor emitted"
+}
+
+assert_eligible_runs_get_pruned() {
+  # Seed 6 entries (>= floor+1) so at least 1 entry is eligible after the
+  # always-preserve floor.  All 6 share a cron-family, all >7d old.
+  local i task_id
+  for i in 1 2 3 4 5 6; do
+    task_id="$(insert_task done)"
+    write_run_fixture "morning-briefing-aaa--slot${i}" "$task_id" "success" 30
+    # Stagger mtime by i seconds so item 6 is "newest of the old".
+    python3 - "$BRIDGE_STATE_DIR/cron/runs/morning-briefing-aaa--slot${i}" "$i" <<'PY'
+import os, sys, time
+path = sys.argv[1]
+bump = int(sys.argv[2])
+ts = int(time.time()) - 30 * 86400 + bump
+os.utime(path, (ts, ts))
+PY
+  done
+  local before_runs after_runs
+  # shellcheck disable=SC2012  # fixture run_ids are alphanumeric+dash; ls is fine here.
+  before_runs="$(ls "$BRIDGE_STATE_DIR/cron/runs" 2>/dev/null | wc -l | tr -d ' ')"
+  smoke_assert_eq "6" "$before_runs" "fixture seeded six run dirs"
+
+  local out
+  out="$(run_py cleanup-prune --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  smoke_assert_contains "$out" '"status": "pruned"' "prune emits pruned status"
+
+  # shellcheck disable=SC2012  # fixture run_ids are alphanumeric+dash; ls is fine here.
+  after_runs="$(ls "$BRIDGE_STATE_DIR/cron/runs" 2>/dev/null | wc -l | tr -d ' ')"
+  # Floor of 5 → exactly 1 should be deleted.
+  smoke_assert_eq "5" "$after_runs" "exactly 1 deleted; 5 kept by always-preserve floor"
+}
+
+assert_preserve_floor_keeps_latest_five() {
+  # Reset fixtures.
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  mkdir -p "$BRIDGE_STATE_DIR/cron/runs" "$BRIDGE_SHARED_DIR/cron-dispatch"
+
+  # 10 entries, all 60 days old (well beyond Tier-A 7d), all "success".
+  # Vary mtime by 1s so the sort by mtime DESC is deterministic.
+  local i task_id
+  for i in $(seq 1 10); do
+    task_id="$(insert_task done)"
+    write_run_fixture "morning-briefing-floor--slot${i}" "$task_id" "success" 60
+    # Bump the mtime forward by i seconds so item 10 is "newest of the old".
+    python3 - "$BRIDGE_STATE_DIR/cron/runs/morning-briefing-floor--slot${i}" "$i" <<'PY'
+import os, sys, time
+path = sys.argv[1]
+bump = int(sys.argv[2])
+ts = int(time.time()) - 60 * 86400 + bump
+os.utime(path, (ts, ts))
+PY
+  done
+
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  # By-surface eligibility on state/cron/runs should be 5 (10 - floor of 5).
+  python3 - "$out" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+by_surface = payload["summary"]["by_surface"]
+got = by_surface.get("state/cron/runs", 0)
+expected = 5  # 10 entries - floor of 5
+assert got == expected, f"runs eligible: expected {expected}, got {got}; payload={payload}"
+preserved = sum(
+    1 for r in payload["records"]
+    if r["surface"] == "state/cron/runs" and r["skip_reason"] == "preserve_floor"
+)
+assert preserved == 5, f"expected 5 preserve_floor entries, got {preserved}"
+PY
+}
+
+assert_skipped_when_queue_status_claimed() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  mkdir -p "$BRIDGE_STATE_DIR/cron/runs"
+  local task_id
+  task_id="$(insert_task claimed)"
+  write_run_fixture "morning-briefing-claim--slot1" "$task_id" "success" 30
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  python3 - "$out" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+records = payload["records"]
+runs_record = next(r for r in records if r["surface"] == "state/cron/runs")
+assert runs_record["eligible"] is False, runs_record
+assert runs_record["skip_reason"] == "queue_status:claimed", runs_record
+PY
+}
+
+assert_failed_run_kept_on_tier_a() {
+  # state="error" runs should fall back to the Tier-B clock (30d).
+  # A 14-day-old failed run on a Tier-A surface (state/cron/runs) is
+  # within the Tier-B retention window so it must be preserved.
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  local task_id
+  task_id="$(insert_task done)"
+  write_run_fixture "morning-briefing-err--slot1" "$task_id" "error" 14
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  python3 - "$out" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+records = payload["records"]
+runs_record = next(r for r in records if r["surface"] == "state/cron/runs")
+assert runs_record["eligible"] is False, runs_record
+assert runs_record["skip_reason"] == "within_retention", runs_record
+PY
+}
+
+assert_skipped_when_live_pid_anchored_under_target_root() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  local task_id
+  task_id="$(insert_task done)"
+  local run_id="morning-briefing-pid--slot1"
+  # Spawn a long-running process whose argv contains a path rooted at
+  # `$BRIDGE_STATE_DIR/cron/...<run_id>...`. We use `bash -c` so the
+  # rooted path lands in argv[2] without confusing `sleep`'s arg parser.
+  local rooted_path="$BRIDGE_STATE_DIR/cron/runs/$run_id/sentinel"
+  bash -c "exec -a 'agb-smoke-live-pid $rooted_path' sleep 30" 2>/dev/null &
+  local sleep_pid=$!
+  SPAWNED_PIDS+=("$sleep_pid")
+  sleep 0.2
+
+  # Seed the run fixture AFTER the sleep launches so the dir mtime is
+  # not reset by the sleep argv setup. days_old=30 is well past Tier-A 7d
+  # so without the live-PID gate the entry would be eligible for prune.
+  write_run_fixture "$run_id" "$task_id" "success" 30
+
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  kill "$sleep_pid" 2>/dev/null || true
+  wait "$sleep_pid" 2>/dev/null || true
+  python3 - "$out" "$run_id" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+target_run_id = sys.argv[2]
+runs_record = next(
+    r for r in payload["records"]
+    if r["surface"] == "state/cron/runs" and r["run_id"] == target_run_id
+)
+assert runs_record["eligible"] is False, runs_record
+assert runs_record["skip_reason"] == "live_pid", runs_record
+PY
+}
+
+assert_foreign_install_pid_does_not_match() {
+  # Same run_id appears in argv but rooted under a *different* prefix —
+  # the path-anchored matcher must NOT skip our cleanup.
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  local task_id
+  task_id="$(insert_task done)"
+  write_run_fixture "morning-briefing-foreign--slot1" "$task_id" "success" 30
+  # Pad the family floor so the test entry isn't preserve_floor-pinned.
+  seed_floor_padding "morning-briefing-foreign-padding"
+
+  local foreign_root="$SMOKE_TMP_ROOT/foreign-install"
+  mkdir -p "$foreign_root/state/cron/runs/morning-briefing-foreign--slot1"
+  local foreign_path="$foreign_root/state/cron/runs/morning-briefing-foreign--slot1/marker"
+  bash -c "exec -a 'agb-smoke-foreign-pid $foreign_path' sleep 30" 2>/dev/null &
+  local sleep_pid=$!
+  SPAWNED_PIDS+=("$sleep_pid")
+  sleep 0.2
+
+  local out
+  out="$(run_py cleanup-report --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  kill "$sleep_pid" 2>/dev/null || true
+  wait "$sleep_pid" 2>/dev/null || true
+  python3 - "$out" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+runs_record = next(
+    r for r in payload["records"]
+    if r["surface"] == "state/cron/runs"
+    and r["run_id"] == "morning-briefing-foreign--slot1"
+)
+assert runs_record["eligible"] is True, (
+    f"foreign-install PID should not block cleanup; got record={runs_record}"
+)
+PY
+}
+
+assert_symlink_safety() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  mkdir -p "$BRIDGE_STATE_DIR/cron/runs" "$BRIDGE_SHARED_DIR/cron-dispatch"
+  # Create a passwd-like decoy file we never want clobbered.
+  local decoy="$SMOKE_TMP_ROOT/decoy-passwd"
+  printf 'root:x:0:0:do-not-delete:/root:/bin/bash\n' >"$decoy"
+
+  # Replace one cron-dispatch entry with a symlink to the decoy.
+  local symlink_path="$BRIDGE_SHARED_DIR/cron-dispatch/morning-briefing-link--slot1.md"
+  ln -s "$decoy" "$symlink_path"
+
+  # Pair it with a legit eligible run so prune actually has work to do.
+  local task_id
+  task_id="$(insert_task done)"
+  write_run_fixture "morning-briefing-real--slot1" "$task_id" "success" 30
+  seed_floor_padding "morning-briefing-real-padding"
+
+  local out
+  out="$(run_py cleanup-prune --mode run-artifacts \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  smoke_assert_contains "$out" '"status": "pruned"' "prune ran on real entry"
+  smoke_assert_file_exists "$decoy" "decoy preserved (symlink not followed)"
+  local decoy_content
+  decoy_content="$(cat "$decoy")"
+  smoke_assert_contains "$decoy_content" "do-not-delete" "decoy content intact"
+}
+
+assert_dry_run_does_not_mutate() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  local task_id
+  task_id="$(insert_task done)"
+  write_run_fixture "morning-briefing-dry--slot1" "$task_id" "success" 30
+  seed_floor_padding "morning-briefing-dry-padding"
+  local before_count
+  # shellcheck disable=SC2012  # fixture run_ids are alphanumeric+dash.
+  before_count="$(ls "$BRIDGE_STATE_DIR/cron/runs" 2>/dev/null | wc -l | tr -d ' ')"
+
+  local out
+  out="$(run_py cleanup-prune --mode run-artifacts --dry-run \
+    --target-root "$BRIDGE_HOME" --tasks-db "$BRIDGE_TASK_DB" --json)"
+  smoke_assert_contains "$out" '"status": "dry_run"' "dry-run status echoed"
+
+  local after_count
+  # shellcheck disable=SC2012  # fixture run_ids are alphanumeric+dash.
+  after_count="$(ls "$BRIDGE_STATE_DIR/cron/runs" 2>/dev/null | wc -l | tr -d ' ')"
+  smoke_assert_eq "$before_count" "$after_count" "dry-run did not delete"
+}
+
+assert_one_shot_mode_backwards_compat() {
+  rm -rf "$BRIDGE_STATE_DIR/cron" "$BRIDGE_SHARED_DIR"/cron-* 2>/dev/null || true
+  # Issue #533 contract: legacy `--mode expired-one-shot` and the new
+  # alias `--mode one-shot` both must keep rewriting jobs.json. Only
+  # the path that ran before #533 is exercised here — we do NOT run the
+  # one-shot path against run-artifact fixtures, since those are now
+  # the responsibility of `--mode run-artifacts`.
+  local jobs_file="$BRIDGE_HOME/cron/jobs.json"
+  mkdir -p "$BRIDGE_HOME/cron"
+  cat >"$jobs_file" <<'EOF'
+{"format":"agent-bridge-cron-v1","jobs":[{"id":"keepme","name":"keepme","agentId":"a","schedule":{"kind":"cron","expr":"0 * * * *","tz":"UTC"},"enabled":true,"deleteAfterRun":false}]}
+EOF
+  local out_legacy out_alias
+  out_legacy="$(run_py cleanup-report \
+    --jobs-file "$jobs_file" --mode expired-one-shot --json)"
+  smoke_assert_contains "$out_legacy" '"candidate_count": 0' "legacy mode runs without error"
+
+  out_alias="$(run_py cleanup-report \
+    --jobs-file "$jobs_file" --mode one-shot --json)"
+  smoke_assert_contains "$out_alias" '"candidate_count": 0' "one-shot alias runs without error"
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "$SMOKE_NAME"
+  mkdir -p "$BRIDGE_STATE_DIR/cron/runs" \
+           "$BRIDGE_STATE_DIR/cron/workers" \
+           "$BRIDGE_STATE_DIR/cron/dispatch" \
+           "$BRIDGE_SHARED_DIR/cron-dispatch" \
+           "$BRIDGE_SHARED_DIR/cron-result" \
+           "$BRIDGE_SHARED_DIR/cron-followup"
+  seed_tasks_db
+  smoke_run "report --mode run-artifacts works on empty tree" assert_basic_dry_run_report
+  smoke_run "eligible runs are deleted by prune" assert_eligible_runs_get_pruned
+  smoke_run "preserve floor keeps latest 5 per family" assert_preserve_floor_keeps_latest_five
+  smoke_run "skip when queue status is claimed" assert_skipped_when_queue_status_claimed
+  smoke_run "failed run kept on Tier-A via Tier-B clock" assert_failed_run_kept_on_tier_a
+  smoke_run "skip when live PID anchored under target_root" assert_skipped_when_live_pid_anchored_under_target_root
+  smoke_run "foreign-install PID does NOT block cleanup" assert_foreign_install_pid_does_not_match
+  smoke_run "symlink safety: never follow a symlink" assert_symlink_safety
+  smoke_run "dry-run does not mutate" assert_dry_run_does_not_mutate
+  smoke_run "one-shot/expired-one-shot backwards compat" assert_one_shot_mode_backwards_compat
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `agent-bridge cron cleanup {report,prune} --mode {one-shot,run-artifacts,all}` so the existing cleanup CLI now also walks the six per-tick cron run-artifact surfaces (`state/cron/runs`, `state/cron/workers`, `state/cron/dispatch`, `shared/cron-{dispatch,result,followup}`) and prunes eligible entries under a combined deletion gate.
- Two-tier retention with an always-preserve floor: Tier-A surfaces default to 7d, Tier-B to 30d, and per `(surface, cron-family)` we keep at least the latest **N=5** entries even when older than retention. `--older-than-days N` overrides both tiers.
- Periodic daemon-driven GC is opt-in only via `BRIDGE_CRON_RUN_ARTIFACTS_GC=1` (default OFF). Failures in that path are best-effort and do not flip sync status. The legacy `--mode expired-one-shot` path used by `bridge-cron.sh sync` is unchanged; `--mode one-shot` is its alias.

## What changed

- **`bridge-cron.py`**:
  - New module-level retention constants + walkers per surface.
  - `collect_run_artifact_candidates()` evaluates the combined-AND deletion gate per entry and applies the always-preserve floor after eligibility.
  - **Combined deletion gate** (all four must hold):
    1. Queue dispatch task is `done` or `cancelled` (the only terminal `bridge-queue.py` statuses — `failed` does not exist).
    2. `state/cron/runs/<run_id>/status.json` reports a terminal `state` (`success | error | cancelled`).
    3. No live PID has the run_id in its argv rooted under `<target_root>/state/cron/...` or `<target_root>/shared/cron-...`. The matcher is **path-anchored**, mirroring PR #527's stale-relay anchor — bare-substring matches against just the run_id are rejected so a foreign install on the same host whose argv mentions the same run_id does NOT block our cleanup.
    4. The entry is outside the always-preserve floor (latest N=5 per `(surface, cron-family)` by mtime DESC).
  - **Failed-run handling**: runs with `state="error"` are held back to the longer Tier-B clock even when their artifact lives on a Tier-A surface, so the operator has time to triage.
  - **Symlink safety**: reuses the `_rmtree_safe` pattern from `bridge-relay-cleanup.py`. Symlinks under any of the six surfaces are never followed during walk or delete.
  - **Audit row policy**: counts + at most 5 sample paths; payload contents are NEVER included.
  - `--mode all` runs both passes; `--mode one-shot` is an alias for the legacy `expired-one-shot`.
- **`bridge-cron.sh`**:
  - `cleanup` subcommand forwards `--mode`, `--older-than-days`, `--target-root`, `--tasks-db`, `--dry-run`, `--json` to the python.
  - `--mode run-artifacts` skips the source-jobs requirement (it operates on `BRIDGE_HOME` directly).
  - `sync` adds opt-in run-artifacts cleanup gated on `BRIDGE_CRON_RUN_ARTIFACTS_GC=1`.
- **New smoke** `scripts/smoke/cron-run-artifacts-retention.sh` (10 assertions): empty-tree report; eligible-prune; preserve-floor (10 entries → top 5 kept); skip on queue=`claimed`; failed-run Tier-B fallback on Tier-A surface; live-PID gate; foreign-install isolation (sibling install argv must NOT match); symlink safety (decoy `/etc/passwd`-shaped target preserved); dry-run no-mutation; one-shot/expired-one-shot backwards compat.
- **`scripts/ci-select-smoke.sh`**: appended `cron-run-artifacts-retention` to `add_all_required_static`, added it to the `bridge-cron.sh|lib/bridge-cron.sh` trigger, and added a new path trigger for `bridge-cron.py|bridge-cron-runner.py|bridge-cron-scheduler.py`.

## Out of scope

- **No** `state/cron/jobs.json` schema change.
- **No** new daemon service. Daemon GC is opt-in via the existing sync hook only.
- **No** VERSION/CHANGELOG bump (operator deferred release).
- The dispatch close path (`bridge-daemon.sh:3658`) is correct in v0.7.3 and untouched.
- The optional `backup-extend-live`-style pre-delete backup is left as a follow-up — wiring it in this PR would have grown scope past the small-fix bar; the prune path is symlink-safe and dry-run-able, which covers the immediate operator risk.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-cron.py').read())"` — pass
- [x] `bash -n bridge-cron.sh scripts/smoke/cron-run-artifacts-retention.sh scripts/ci-select-smoke.sh` — pass
- [x] `shellcheck bridge-cron.sh scripts/smoke/cron-run-artifacts-retention.sh scripts/ci-select-smoke.sh` — clean
- [x] `bash scripts/smoke/cron-run-artifacts-retention.sh` — all 10 assertions pass
- [x] `bash scripts/smoke/admin-codex-pair.sh` — regression pass
- [x] manual: `cleanup-report --mode all` runs both passes back-to-back without raising; legacy `--mode expired-one-shot` still rewrites `jobs.json` only

## Manual verification before merge

The existing `scripts/smoke/admin-codex-pair.sh` and the new `cron-run-artifacts-retention.sh` are isolated-`BRIDGE_HOME` smokes. They do NOT exercise the daemon-driven sync hook against a real cron family. Recommended manual check on a copy of the operator's live install:

```bash
BRIDGE_CRON_RUN_ARTIFACTS_GC=1 bash bridge-cron.sh sync --json | jq '.cleanup, .totals'
agent-bridge cron cleanup report --mode run-artifacts --json | jq '.summary'
agent-bridge cron cleanup prune --mode run-artifacts --dry-run --json | jq '.summary'
```

closes #533

🤖 Generated with [Claude Code](https://claude.com/claude-code)