### PR TITLE
fix(plugin-liveness): probeable/unprobeable split + restart kill-switch (refs #542)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2513,6 +2513,15 @@ run_restart() {
   [[ "$verify_max_attempts" =~ ^[0-9]+$ ]] || verify_max_attempts=5
   (( verify_max_attempts >= 1 )) || verify_max_attempts=1
 
+  # Emergency operator kill-switch for the restart-internal verifier.
+  # Independent of the daemon-only BRIDGE_SKIP_PLUGIN_LIVENESS knob so
+  # operators can leave daemon liveness on while bypassing this loop
+  # during incident triage (issue #542).
+  if [[ "${BRIDGE_SKIP_RESTART_PLUGIN_LIVENESS:-0}" == "1" ]]; then
+    bridge_warn "BRIDGE_SKIP_RESTART_PLUGIN_LIVENESS=1; skipping restart-internal plugin MCP liveness verifier for '$agent'."
+    return 0
+  fi
+
   verify_attempts=1
   # Verify via descendant process probe (issue #143). The banner-based
   # verifier read only the last 80 tmux lines, so busy sessions (`--resume`

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4616,6 +4616,26 @@ bridge_plugin_mcp_identity_for_item() {
   esac
 }
 
+# Returns 0 if the channel item has a probeable plugin MCP identity
+# (currently the 4 chat providers we ship a `ps`-descendant probe for).
+# Returns 1 for plugins we ship without a probe (HTTP MCPs, marketplace
+# plugins, ms365 / generic command-MCPs, etc.) — these are reported as
+# unknown/skipped rather than missing so they cannot drive restart loops.
+# See issue #542; per-plugin-class probes (command-MCP, HTTP MCP) are
+# tracked as follow-ups and will extend this classifier.
+bridge_plugin_mcp_is_probeable_item() {
+  local item="$1"
+  local identity=""
+
+  identity="$(bridge_plugin_mcp_identity_for_item "$item")"
+  [[ -n "$identity" ]]
+}
+
+# NOTE: an empty identity from bridge_plugin_mcp_identity_for_item means
+# the plugin is *unprobeable* (we have no descendant probe for it), not
+# that it is missing. Callers should gate on bridge_plugin_mcp_is_probeable_item
+# *before* invoking this probe so unprobeable plugins do not get flagged
+# as missing and trigger restart loops (issue #542).
 bridge_plugin_mcp_descendant_ready_for_item() {
   local root_pid="$1"
   local item="$2"
@@ -4719,6 +4739,10 @@ bridge_agent_missing_plugin_mcp_channels_csv() {
   for item in "${items[@]}"; do
     item="$(bridge_trim_whitespace "$item")"
     [[ -n "$item" ]] || continue
+    # Skip plugins we cannot probe (HTTP MCPs, marketplace plugins, ms365,
+    # etc.). They are reported as unknown/skipped — not missing — so they
+    # cannot drive restart loops. See issue #542.
+    bridge_plugin_mcp_is_probeable_item "$item" || continue
     if ! bridge_agent_plugin_mcp_alive_for_item "$agent" "$item"; then
       missing="$(bridge_merge_channels_csv "$missing" "$item")"
     fi


### PR DESCRIPTION
## Summary
- Stops false-positive `Claude plugin MCP liveness missing` retry loop for any non-{discord,telegram,teams,mattermost} plugin (ms365, HTTP MCPs, marketplace plugins).
- New `bridge_plugin_mcp_is_probeable_item` classifier; `bridge_agent_missing_plugin_mcp_channels_csv` skips unprobeable items so unknown/skipped plugins cannot drive restart triggers.
- New `BRIDGE_SKIP_RESTART_PLUGIN_LIVENESS=1` knob disables the restart-internal verifier independently of the existing daemon-only `BRIDGE_SKIP_PLUGIN_LIVENESS=1`.

## Out of scope (deferred per issue)
- Per-plugin-class probes (`ms365` command-MCP probe, HTTP MCP probe) — separate design.
- `agent show` `unknown/skipped` diagnostic surface — small follow-up.
- No changes to identity-mapping (the 4 chat providers stay as-is).
- No VERSION/CHANGELOG bump.

## Test plan
- [x] `bash -n` on touched files.
- [x] `shellcheck lib/bridge-agents.sh bridge-agent.sh`.
- [x] `./scripts/smoke-test.sh` (pre-existing failure on `[smoke] guarding isolated agent-env writes from stale tmp controller env (#365 follow-up)` reproduces on `main` HEAD `7207057` without these edits — unrelated to this change).
- [x] Live function smoke: `bridge_plugin_mcp_is_probeable_item` returns 0 for `plugin:teams@*` and 1 for `plugin:ms365@*` / `plugin:cosmax-crm@*`.
- [ ] Maintainer: Live `agent restart <isolated-agent>` with at least one ms365/HTTP/marketplace plugin declared — confirm no retry loop.

Refs #542