### PR TITLE
fix(bridge-start): channel-env ACL preflight on restart path (refs #543)

### DIFF
--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -295,6 +295,9 @@ fi
 if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]] \
     && bridge_agent_linux_user_isolation_effective "$AGENT"; then
   bridge_linux_repair_claude_credentials_access "$AGENT" >/dev/null 2>&1 || true
+  # Issue #543: mirror daemon channel-health preflight (bridge-daemon.sh) so a
+  # transient ACL drift on .<channel>/.env does not bridge_die the restart path.
+  bridge_linux_acl_repair_channel_env_files "$AGENT" >/dev/null 2>&1 || true
 fi
 
 if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- bridge-start.sh now calls `bridge_linux_acl_repair_channel_env_files` immediately after `bridge_linux_repair_claude_credentials_access`, before `bridge_agent_channel_status_reason` reads the channel `.env` files.
- Mirrors the existing daemon channel-health preflight at bridge-daemon.sh:2903.
- Recovers from transient ACL drift on isolated agent restart, eliminating the false-negative "missing TEAMS_APP_ID" `bridge_die` path.

## Out of scope (deferred per issue)
- Soft-launch on `unreadable:` reasons (item 2 in #543) — separate thread.
- No changes to `lib/bridge-agents.sh`, `bridge-daemon.sh`, or VERSION/CHANGELOG.

## Test plan
- [x] `bash -n bridge-start.sh`
- [x] `shellcheck bridge-start.sh`
- [x] `./scripts/smoke-test.sh`
- [ ] Maintainer: live linux-user isolated agent restart with intentional ACL drift on `<workdir>/.<channel>/.env`.

Refs #543