### PR TITLE
fix(hooks): manage full Claude Stop hook suite in shared base (refs #541)

### DIFF
--- a/agents/.claude/settings.json
+++ b/agents/.claude/settings.json
@@ -12,6 +12,24 @@
             "additionalContext": true
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 ~/.agent-bridge/hooks/surface-reply-enforce.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 ~/.agent-bridge/hooks/session-stop.py",
+            "timeout": 35
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -75,6 +75,24 @@ def stop_hook_command(bridge_home: Path, bash_bin: str) -> str:
     return shell_command(bash_bin, shell_path(hook_path))
 
 
+# Issue #541 PR-B: the Claude Stop event must fire three independent hooks —
+# mark-idle.sh (idle wake), surface-reply-enforce.py (assistant reply
+# guarantee), and session-stop.py (drain + transcript→daily-note reconcile).
+# Source agents/_template/.claude/settings.json already lists all three; the
+# shared base agents/.claude/settings.json carried only mark-idle.sh, so the
+# rerender path propagated the incomplete suite to every live always-on
+# Claude agent. Helpers below let the ensure path register the missing pair
+# in addition to mark-idle.sh.
+def surface_reply_enforce_hook_command(bridge_home: Path, python_bin: str) -> str:
+    hook_path = bridge_home / "hooks" / "surface-reply-enforce.py"
+    return shell_command(python_bin, shell_path(hook_path))
+
+
+def session_stop_hook_command(bridge_home: Path, python_bin: str) -> str:
+    hook_path = bridge_home / "hooks" / "session-stop.py"
+    return shell_command(python_bin, shell_path(hook_path))
+
+
 def session_start_hook_command(bridge_home: Path, python_bin: str, fmt: str = "text") -> str:
     hook_path = bridge_home / "hooks" / "session-start.py"
     if fmt != "text":
@@ -152,6 +170,14 @@ def hooks_list(settings: dict[str, Any], event_name: str) -> list[dict[str, Any]
 
 def is_mark_idle_hook(command: str) -> bool:
     return "mark-idle.sh" in str(command)
+
+
+def is_surface_reply_enforce_hook(command: str) -> bool:
+    return "surface-reply-enforce.py" in str(command)
+
+
+def is_session_stop_hook(command: str) -> bool:
+    return "session-stop.py" in str(command)
 
 
 def is_session_start_hook(command: str) -> bool:
@@ -237,18 +263,34 @@ def cmd_status_stop_hook(args: argparse.Namespace) -> int:
     settings_path = resolve_settings_path(args)
     settings = ensure_settings_root(settings_path)
     stop_hooks = hooks_list(settings, "Stop")
-    _group, hook = find_command_hook(stop_hooks, is_mark_idle_hook)
-    command = str(hook.get("command") or "") if hook else ""
+    _idle_group, idle_hook = find_command_hook(stop_hooks, is_mark_idle_hook)
+    _surface_group, surface_hook = find_command_hook(stop_hooks, is_surface_reply_enforce_hook)
+    _session_stop_group, session_stop_hook = find_command_hook(stop_hooks, is_session_stop_hook)
+    # mark-idle.sh keeps the legacy HOOK_STOP_HOOK / HOOK_COMMAND fields so
+    # existing operators / scripts that grep for them stay green. The
+    # HOOK_STOP_HOOK_SUITE field (#541 PR-B) reports the aggregate state so
+    # the upgrade and smoke paths can detect partial drops of the new pair.
+    command = str(idle_hook.get("command") or "") if idle_hook else ""
+    suite_present = bool(idle_hook and surface_hook and session_stop_hook)
     payload = {
         "HOOK_SETTINGS_FILE": str(settings_path),
-        "HOOK_STATUS": "present" if hook else "missing",
-        "HOOK_STOP_HOOK": "present" if hook else "missing",
+        "HOOK_STATUS": "present" if suite_present else "missing",
+        "HOOK_STOP_HOOK": "present" if idle_hook else "missing",
+        "HOOK_STOP_HOOK_SUITE": "present" if suite_present else "missing",
+        "HOOK_STOP_HOOK_MARK_IDLE": "present" if idle_hook else "missing",
+        "HOOK_STOP_HOOK_SURFACE_REPLY_ENFORCE": "present" if surface_hook else "missing",
+        "HOOK_STOP_HOOK_SESSION_STOP": "present" if session_stop_hook else "missing",
         "HOOK_PROMPT_HOOK": "",
         "HOOK_COMMAND": command,
-        "HOOK_ADDITIONAL_CONTEXT": "true" if hook and bool(hook.get("additionalContext")) else "false",
+        "HOOK_ADDITIONAL_CONTEXT": "true" if idle_hook and bool(idle_hook.get("additionalContext")) else "false",
     }
     print_payload(payload, args.format)
-    return 0 if hook else 1
+    if args.format != "shell":
+        print(f"stop_hook_suite: {'present' if suite_present else 'missing'}")
+        print(f"stop_hook_mark_idle: {'present' if idle_hook else 'missing'}")
+        print(f"stop_hook_surface_reply_enforce: {'present' if surface_hook else 'missing'}")
+        print(f"stop_hook_session_stop: {'present' if session_stop_hook else 'missing'}")
+    return 0 if suite_present else 1
 
 
 def cmd_status_session_start_hook(args: argparse.Namespace) -> int:
@@ -334,25 +376,60 @@ def ensure_command_hook(
 def cmd_ensure_stop_hook(args: argparse.Namespace) -> int:
     bridge_home = Path(args.bridge_home).expanduser()
     settings_path = resolve_settings_path(args)
-    desired_command = stop_hook_command(bridge_home, args.bash_bin)
+    # Resolve the python interpreter once. --bash-bin is the only required
+    # CLI flag historically (mark-idle.sh runs under bash), so we keep that
+    # contract and discover a python3 via PATH for the new pair. The render
+    # path that consumes this file later (bridge_link_claude_settings_to_shared)
+    # does the same dance.
+    python_bin = getattr(args, "python_bin", None) or shutil.which("python3") or "/usr/bin/python3"
+    mark_idle_command = stop_hook_command(bridge_home, args.bash_bin)
+    surface_command = surface_reply_enforce_hook_command(bridge_home, python_bin)
+    session_stop_command = session_stop_hook_command(bridge_home, python_bin)
+
+    # Issue #541 PR-B: ensure the full Stop hook suite. mark-idle.sh keeps
+    # additionalContext=true (idle-wake context); surface-reply-enforce.py
+    # and session-stop.py mirror agents/_template/.claude/settings.json
+    # (no additionalContext, timeout 5 / 35 respectively).
     changed = ensure_command_hook(
         settings_path,
         "Stop",
-        desired_command,
+        mark_idle_command,
         is_mark_idle_hook,
         timeout=3,
         additional_context=True,
     )
+    changed = ensure_command_hook(
+        settings_path,
+        "Stop",
+        surface_command,
+        is_surface_reply_enforce_hook,
+        timeout=5,
+    ) or changed
+    changed = ensure_command_hook(
+        settings_path,
+        "Stop",
+        session_stop_command,
+        is_session_stop_hook,
+        timeout=35,
+    ) or changed
 
     payload = {
         "HOOK_SETTINGS_FILE": str(settings_path),
         "HOOK_STATUS": "updated" if changed else "unchanged",
         "HOOK_STOP_HOOK": "present",
+        "HOOK_STOP_HOOK_SUITE": "present",
+        "HOOK_STOP_HOOK_MARK_IDLE": "present",
+        "HOOK_STOP_HOOK_SURFACE_REPLY_ENFORCE": "present",
+        "HOOK_STOP_HOOK_SESSION_STOP": "present",
         "HOOK_PROMPT_HOOK": "",
-        "HOOK_COMMAND": desired_command,
+        "HOOK_COMMAND": mark_idle_command,
         "HOOK_ADDITIONAL_CONTEXT": "true",
     }
     print_payload(payload, args.format)
+    if args.format != "shell":
+        print("stop_hook_suite: present")
+        print(f"surface_reply_enforce_command: {surface_command}")
+        print(f"session_stop_command: {session_stop_command}")
     return 0
 
 
@@ -874,6 +951,11 @@ def build_parser() -> argparse.ArgumentParser:
     ensure_parser.add_argument("--settings-file")
     ensure_parser.add_argument("--bridge-home", required=True)
     ensure_parser.add_argument("--bash-bin", required=True)
+    # --python-bin is optional for backward compatibility (existing callers
+    # in lib/bridge-hooks.sh only pass --bash-bin); when omitted the helper
+    # falls back to PATH-discovered python3. Required for the surface-reply
+    # and session-stop entries added by issue #541 PR-B.
+    ensure_parser.add_argument("--python-bin")
     ensure_parser.add_argument("--format", choices=("text", "shell"), default="text")
     ensure_parser.set_defaults(handler=cmd_ensure_stop_hook)
 

--- a/scripts/smoke/upgrade-shared-settings-propagate.sh
+++ b/scripts/smoke/upgrade-shared-settings-propagate.sh
@@ -139,6 +139,99 @@ assert_operator_overlay_wins() {
   smoke_assert_eq "600000" "$(settings_value "$agent_home/.claude/settings.json" autoCompactWindow)" "operator overlay overrides managed default"
 }
 
+assert_stop_hook_suite_propagates() {
+  # Issue #541 PR-B: ensure-stop-hook on the shared base must register the
+  # full suite (mark-idle.sh + surface-reply-enforce.py + session-stop.py),
+  # and the rendered effective settings (consumed by every per-agent symlink
+  # via bridge_link_claude_settings_to_shared) must carry all three.
+  local base effective stop_count
+  local has_mark_idle has_surface has_session_stop
+
+  base="$BRIDGE_AGENT_HOME_ROOT/.claude/settings.json"
+  effective="$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
+
+  # Reset the shared base and overlay to a "pre-fix" shape: only
+  # mark-idle.sh registered, mirroring v0.7.3 reference install state.
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/.claude"
+  rm -f "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.local.json" "$effective"
+  printf '%s\n' '{"hooks":{"Stop":[{"hooks":[{"type":"command","command":"bash ~/.agent-bridge/hooks/mark-idle.sh","timeout":3,"additionalContext":true}]}]}}' >"$base"
+
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" ensure-stop-hook \
+    --settings-file "$base" \
+    --bridge-home "$BRIDGE_HOME" \
+    --bash-bin bash >/dev/null
+
+  stop_count="$(python3 - "$base" <<'PY'
+import json, sys
+from pathlib import Path
+data = json.loads(Path(sys.argv[1]).read_text())
+stop = data.get("hooks", {}).get("Stop", [])
+flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
+print(len(flat))
+PY
+)"
+  smoke_assert_eq "3" "$stop_count" "shared base Stop array has 3 entries after ensure-stop-hook"
+
+  has_mark_idle="$(python3 - "$base" mark-idle.sh <<'PY'
+import json, sys
+from pathlib import Path
+needle = sys.argv[2]
+data = json.loads(Path(sys.argv[1]).read_text())
+stop = data.get("hooks", {}).get("Stop", [])
+flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
+print("yes" if any(needle in c for c in flat) else "no")
+PY
+)"
+  has_surface="$(python3 - "$base" surface-reply-enforce.py <<'PY'
+import json, sys
+from pathlib import Path
+needle = sys.argv[2]
+data = json.loads(Path(sys.argv[1]).read_text())
+stop = data.get("hooks", {}).get("Stop", [])
+flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
+print("yes" if any(needle in c for c in flat) else "no")
+PY
+)"
+  has_session_stop="$(python3 - "$base" session-stop.py <<'PY'
+import json, sys
+from pathlib import Path
+needle = sys.argv[2]
+data = json.loads(Path(sys.argv[1]).read_text())
+stop = data.get("hooks", {}).get("Stop", [])
+flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
+print("yes" if any(needle in c for c in flat) else "no")
+PY
+)"
+  smoke_assert_eq "yes" "$has_mark_idle" "shared base Stop suite includes mark-idle.sh"
+  smoke_assert_eq "yes" "$has_surface" "shared base Stop suite includes surface-reply-enforce.py"
+  smoke_assert_eq "yes" "$has_session_stop" "shared base Stop suite includes session-stop.py"
+
+  # status-stop-hook must agree (suite present, exit 0)
+  local status_out
+  status_out="$(python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" status-stop-hook --settings-file "$base" --bridge-home "$BRIDGE_HOME" --bash-bin bash --format shell)"
+  smoke_assert_contains "$status_out" "HOOK_STOP_HOOK_SUITE=present" "status-stop-hook reports suite present"
+  smoke_assert_contains "$status_out" "HOOK_STOP_HOOK_SURFACE_REPLY_ENFORCE=present" "status-stop-hook reports surface-reply-enforce.py present"
+  smoke_assert_contains "$status_out" "HOOK_STOP_HOOK_SESSION_STOP=present" "status-stop-hook reports session-stop.py present"
+
+  # render-shared-settings must propagate the suite into the effective file
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-shared-settings \
+    --base-settings-file "$base" \
+    --overlay-settings-file "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.local.json" \
+    --effective-settings-file "$effective" >/dev/null
+
+  local effective_count
+  effective_count="$(python3 - "$effective" <<'PY'
+import json, sys
+from pathlib import Path
+data = json.loads(Path(sys.argv[1]).read_text())
+stop = data.get("hooks", {}).get("Stop", [])
+flat = [h.get("command","") for grp in stop for h in grp.get("hooks", [])]
+print(len(flat))
+PY
+)"
+  smoke_assert_eq "3" "$effective_count" "effective settings carries 3-entry Stop suite (rerender-consumed)"
+}
+
 main() {
   smoke_require_cmd python3
   smoke_setup_bridge_home "upgrade-settings"
@@ -148,6 +241,7 @@ main() {
   smoke_run "rerender apply links shared settings and audits" assert_apply_rerenders_and_preserves_overlay
   smoke_run "upgrade apply rerenders shared Claude settings" assert_upgrade_runs_rerender
   smoke_run "operator overlay wins over managed default" assert_operator_overlay_wins
+  smoke_run "Stop hook suite propagates from shared base (#541 PR-B)" assert_stop_hook_suite_propagates
   smoke_log "passed"
 }
 


### PR DESCRIPTION
## Summary
- `agents/.claude/settings.json` now carries the full Claude Stop hook suite (`mark-idle.sh` + `surface-reply-enforce.py` + `session-stop.py`).
- `bridge-hooks.py` ensure/status helpers extended to manage all three. `mark-idle.sh` semantics unchanged (idle-wake); the new pair registers drain + transcript→daily-note reconcile so always-on agents pick them up via the existing per-agent rerender path on next `agb upgrade`.
- New regression smoke `scripts/smoke/upgrade-shared-settings-propagate.sh` asserts all three Stop hooks land in the shared base.

## Why this isn't a regression of mark-idle behavior
`mark-idle.sh` stays as the first Stop hook entry. The two added entries are independent hooks (different commands, different timeouts).

## Out of scope (deferred per issue #541)
- `cron/jobs.json` memory-daily payload jsonl-aware migration — issue #541 PR-A (separate brief; in dispatch).
- e2e-memory-system-test scenario for "yesterday's daily note matches jsonl turn count" — issue #541 PR-C.
- PreCompact threshold default — issue #541 PR-D (P2).
- No VERSION/CHANGELOG bump.

## Test plan
- [x] JSON parse + 3-hook count assertion on `agents/.claude/settings.json`.
- [x] `bridge-hooks.py status-stop-hook` reports the suite (HOOK_STOP_HOOK_SUITE=present).
- [x] `bash scripts/smoke/upgrade-shared-settings-propagate.sh` PASS (all 5 sub-tests).
- [x] `bash scripts/smoke/hooks.sh` PASS in isolation.
- [x] `./scripts/smoke-test.sh` blocked by pre-existing host tmux env limitation (reproduces on clean HEAD `6434a76` without these edits).
- [ ] Maintainer: live `agb upgrade` on a v0.7.5 install — confirm shared settings.effective.json Stop array contains all 3 entries.

Refs #541
