### PR TITLE
fix(cron): memory-daily jsonl-aware payload migration + canonical constant (refs #541)

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -650,10 +650,20 @@ step_memory_daily_cron_one() {
   # $CRON_REQUEST_DIR/authoritative-memory-daily.json and the runner reads that
   # file directly. The subagent's structured_output is a secondary relay and
   # MUST NOT re-interpret status / summary / actions_taken.
+  #
+  # Issue #541 PR-A — this body must stay byte-identical to the canonical
+  # MEMORY_DAILY_JSONL_AWARE_PROMPT_TEMPLATE in bridge-cron.py (with `{agent}`
+  # substituted) so `agb cron migrate-payloads --jsonl-aware` treats freshly
+  # bootstrapped jobs as `unchanged`. If you edit one, edit the other and
+  # docs/agent-runtime/memory-daily-harvest.md §2 in the same change.
   local payload
   payload="bash \"\$BRIDGE_HOME/scripts/memory-daily-harvest.sh\" --agent $agent
 
-# The harvester writes the authoritative RESULT_SCHEMA JSON to
+# This harvester reconciles the agent's most recent jsonl session
+# transcript (resolved via session_id under ~/.claude/projects/) into the
+# agent's daily note at memory/daily/<YYYY-MM-DD>.md by invoking
+# scripts/daily-note-reconcile.py before the harvest pass. The harvester
+# then writes the authoritative RESULT_SCHEMA JSON to
 # \$CRON_REQUEST_DIR/authoritative-memory-daily.json. The runner reads that
 # file directly. Your structured_output is a secondary relay.
 # Do NOT re-interpret status / summary / actions_taken — the harvester is authoritative."

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -1965,15 +1965,13 @@ def run_migrate_payloads(args):
         "skipped_non_memory_daily": skipped_non_memory_daily,
         "backup_file": backup_file,
         "dry_run": bool(args.dry_run),
-        "jobs_file": str(jobs_path),
-        "migrated_jobs": migrated,
     }
 
     if args.json:
         print(json.dumps(payload_out, ensure_ascii=False, indent=2))
         return 0
 
-    print(f"jobs_file: {payload_out['jobs_file']}")
+    print(f"jobs_file: {jobs_path}")
     print(f"migrated: {payload_out['migrated']}")
     print(f"unchanged: {payload_out['unchanged']}")
     print(f"skipped_non_memory_daily: {payload_out['skipped_non_memory_daily']}")

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -55,6 +55,59 @@ _RUN_STATUS_FAILED_STATES = {"error"}
 _QUEUE_TERMINAL_STATUSES = {"done", "cancelled"}
 
 
+# Canonical memory-daily prompt body template (issue #541 PR-A).
+#
+# Both `agb cron create --family memory-daily` (via title-detection) and
+# `agb cron migrate-payloads --jsonl-aware` write this exact text, with
+# `{agent}` substituted, into the memory-daily job payloads. Keep this in
+# sync with bootstrap-memory-system.sh:step_memory_daily_cron_one and
+# docs/agent-runtime/memory-daily-harvest.md §2.
+#
+# The first line is load-bearing: the cron runner forwards the payload text
+# to a Claude subagent as the prompt body, and the subagent invokes the
+# harvester via Bash (see docs/agent-runtime/memory-daily-harvest.md §3).
+# The harvester itself runs scripts/daily-note-reconcile.py against the
+# agent's most recent jsonl session before the harvest pass; the comment
+# block exists so the subagent's pattern-matching surfaces the right
+# context (jsonl / session_id / daily-note-reconcile keywords) and so
+# operator-readers can audit jsonl-awareness from the cron payload alone.
+# The "Do NOT re-interpret" pragma is also load-bearing — without it the
+# subagent could paraphrase actions_taken and break the daemon
+# refresh-gating contract documented in §7 of the same doc.
+MEMORY_DAILY_JSONL_AWARE_PROMPT_TEMPLATE = (
+    'bash "$BRIDGE_HOME/scripts/memory-daily-harvest.sh" --agent {agent}\n'
+    "\n"
+    "# This harvester reconciles the agent's most recent jsonl session\n"
+    "# transcript (resolved via session_id under ~/.claude/projects/) into the\n"
+    "# agent's daily note at memory/daily/<YYYY-MM-DD>.md by invoking\n"
+    "# scripts/daily-note-reconcile.py before the harvest pass. The harvester\n"
+    "# then writes the authoritative RESULT_SCHEMA JSON to\n"
+    "# $CRON_REQUEST_DIR/authoritative-memory-daily.json. The runner reads that\n"
+    "# file directly. Your structured_output is a secondary relay.\n"
+    "# Do NOT re-interpret status / summary / actions_taken — the harvester is authoritative."
+)
+
+
+def render_memory_daily_jsonl_aware_prompt(agent):
+    """Materialize MEMORY_DAILY_JSONL_AWARE_PROMPT_TEMPLATE for one agent."""
+    return MEMORY_DAILY_JSONL_AWARE_PROMPT_TEMPLATE.format(agent=agent)
+
+
+# Tokens that together prove a memory-daily payload is jsonl-aware. The
+# canonical body above contains all three; hand-edited operator overrides
+# that lack any of them are flagged for migration.
+_MEMORY_DAILY_JSONL_AWARE_TOKENS = ("jsonl", "session_id", "daily-note-reconcile")
+
+
+def memory_daily_payload_is_jsonl_aware(text):
+    """True iff the payload text references jsonl + session_id + the
+    canonical reconciler (daily-note-reconcile.py) — see issue #541 PR-A."""
+    if not text:
+        return False
+    lowered = text.lower()
+    return all(token in lowered for token in _MEMORY_DAILY_JSONL_AWARE_TOKENS)
+
+
 def load_jobs_payload(path):
     raw = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
     jobs = raw.get("jobs") if isinstance(raw, dict) else raw
@@ -1631,6 +1684,16 @@ def run_native_create(args):
     actor = args.actor or os.environ.get("USER", "unknown")
     title = args.title.strip()
     payload_text = read_payload_argument(args.payload, args.payload_file)
+    # Issue #541 PR-A — default memory-daily payloads to the canonical
+    # jsonl-aware body when the operator did not supply one explicitly.
+    # Operator-provided payloads (--payload / --payload-file) pass through
+    # unchanged so existing override workflows keep working.
+    if (
+        args.payload is None
+        and args.payload_file is None
+        and classify_family(title) == "memory-daily"
+    ):
+        payload_text = render_memory_daily_jsonl_aware_prompt(args.agent)
     base_slug = slugify_title(title)
     job_id = f"{base_slug}-{secrets.token_hex(4)}"
 
@@ -1831,6 +1894,96 @@ def run_native_rebalance_memory_daily(args):
                     new_tz=tz_name,
                 )
             )
+    return 0
+
+
+def run_migrate_payloads(args):
+    """Rewrite memory-daily job payloads to the canonical jsonl-aware body.
+
+    Issue #541 PR-A. Idempotent: jobs whose payload already passes
+    memory_daily_payload_is_jsonl_aware() are counted as `unchanged` and
+    are not modified. Non-memory-daily jobs are left strictly untouched
+    (counted as `skipped_non_memory_daily`). On any mutation a
+    jobs.json.bak-<timestamp> backup is written first, mirroring the
+    cleanup-prune convention.
+    """
+    raw_payload, jobs = load_jobs_payload(args.jobs_file)
+    jobs_path = Path(args.jobs_file).expanduser()
+
+    migrated = []
+    unchanged = []
+    skipped_non_memory_daily = 0
+    updated_jobs = []
+
+    for job in jobs:
+        name = str(job.get("name") or "")
+        if classify_family(name) != "memory-daily":
+            skipped_non_memory_daily += 1
+            updated_jobs.append(job)
+            continue
+
+        payload = job.get("payload") or {}
+        text = payload.get("text") or payload.get("message") or ""
+        if memory_daily_payload_is_jsonl_aware(text):
+            unchanged.append({"id": job.get("id"), "name": name})
+            updated_jobs.append(job)
+            continue
+
+        agent = job.get("agentId") or job.get("agent") or ""
+        canonical = render_memory_daily_jsonl_aware_prompt(agent)
+        updated = dict(job)
+        updated_payload = dict(payload)
+        updated_payload["text"] = canonical
+        # Preserve the original payload kind ("text") if it was set, else
+        # default to "text" — the runner reads .text either way (see
+        # native_job_payload()), but write the kind explicitly for parity
+        # with build_native_job().
+        if not updated_payload.get("kind"):
+            updated_payload["kind"] = "text"
+        updated["payload"] = updated_payload
+        updated_jobs.append(updated)
+        migrated.append({"id": updated.get("id"), "name": name, "agent": agent})
+
+    backup_file = None
+    will_write = bool(migrated) and not args.dry_run
+
+    if will_write:
+        backup_path = backup_path_for(jobs_path)
+        backup_path.write_text(jobs_path.read_text(encoding="utf-8"), encoding="utf-8")
+        backup_file = str(backup_path)
+        if isinstance(raw_payload, dict):
+            next_payload = dict(raw_payload)
+            next_payload["jobs"] = updated_jobs
+            next_payload["updatedAt"] = datetime.now().astimezone().isoformat()
+        else:
+            next_payload = updated_jobs
+        atomic_write_jobs(jobs_path, next_payload)
+
+    payload_out = {
+        "migrated": len(migrated),
+        "unchanged": len(unchanged),
+        "skipped_non_memory_daily": skipped_non_memory_daily,
+        "backup_file": backup_file,
+        "dry_run": bool(args.dry_run),
+        "jobs_file": str(jobs_path),
+        "migrated_jobs": migrated,
+    }
+
+    if args.json:
+        print(json.dumps(payload_out, ensure_ascii=False, indent=2))
+        return 0
+
+    print(f"jobs_file: {payload_out['jobs_file']}")
+    print(f"migrated: {payload_out['migrated']}")
+    print(f"unchanged: {payload_out['unchanged']}")
+    print(f"skipped_non_memory_daily: {payload_out['skipped_non_memory_daily']}")
+    print(f"dry_run: {'yes' if payload_out['dry_run'] else 'no'}")
+    if backup_file:
+        print(f"backup_file: {backup_file}")
+    if migrated:
+        print("migrated_jobs:")
+        for item in migrated:
+            print(f"  - {item['id']} {item['name']} ({item['agent']})")
     return 0
 
 
@@ -2500,6 +2653,22 @@ def build_parser():
     native_rebalance_parser.add_argument("--dry-run", action="store_true")
     native_rebalance_parser.add_argument("--json", action="store_true")
 
+    # Issue #541 PR-A — rewrite memory-daily payloads to the canonical
+    # jsonl-aware body. Idempotent; backs up jobs.json before any mutation.
+    migrate_payloads_parser = subparsers.add_parser(
+        "migrate-payloads",
+        help="Migrate cron job payloads. Currently supports --jsonl-aware for memory-daily.",
+    )
+    migrate_payloads_parser.add_argument("--jobs-file", required=True)
+    migrate_payloads_parser.add_argument(
+        "--jsonl-aware",
+        action="store_true",
+        required=True,
+        help="Rewrite memory-daily job payloads to the canonical jsonl-aware body.",
+    )
+    migrate_payloads_parser.add_argument("--dry-run", action="store_true")
+    migrate_payloads_parser.add_argument("--json", action="store_true")
+
     native_import_parser = subparsers.add_parser("native-import", help="Import cron jobs into the bridge-native store.")
     native_import_parser.add_argument("--jobs-file", required=True)
     native_import_parser.add_argument("--source-jobs-file", required=True)
@@ -2567,6 +2736,16 @@ def main():
             print(f"error: {exc}", file=sys.stderr)
             return 2
         except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+
+    if args.command == "migrate-payloads":
+        try:
+            return run_migrate_payloads(args)
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        except (ValueError, json.JSONDecodeError) as exc:
             print(f"error: {exc}", file=sys.stderr)
             return 2
 

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -18,6 +18,7 @@ Usage:
   $(basename "$0") update <job-id> [--agent <bridge-agent>] [--schedule "<cron-expr>" | --at "<iso-datetime>"] [--title "<title>"] [--payload "<text>" | --payload-file <path>] [--tz <iana-tz>] [--enable|--disable] [--delete-after-run|--keep-after-run]
   $(basename "$0") delete <job-id>
   $(basename "$0") rebalance-memory-daily [--jobs-file <path>] [--schedule "<cron-expr>"] [--tz <iana-tz>] [--dry-run] [--json]
+  $(basename "$0") migrate-payloads --jsonl-aware [--jobs-file <path>] [--dry-run] [--json]
   $(basename "$0") enqueue <job-name-or-id> [--slot <slot-key>] [--target <bridge-agent>] [--from <actor>] [--priority normal|high] [--dry-run]
   $(basename "$0") sync [--dry-run] [--json] [--since <iso-datetime>] [--now <iso-datetime>]
   $(basename "$0") run-subagent <run-id> [--dry-run]
@@ -261,6 +262,38 @@ run_rebalance_memory_daily() {
         ;;
       *)
         bridge_die "지원하지 않는 rebalance-memory-daily 옵션입니다: $1"
+        ;;
+    esac
+  done
+
+  py_args+=(--jobs-file "$jobs_file")
+  bridge_cron_python "${py_args[@]}"
+}
+
+# Issue #541 PR-A — operator-driven migration of memory-daily payloads to
+# the canonical jsonl-aware body. Mirrors the cleanup-prune surface
+# (jobs.json.bak-<timestamp> backup, --dry-run, --json).
+run_migrate_payloads() {
+  local jobs_file="$BRIDGE_NATIVE_CRON_JOBS_FILE"
+  local py_args=(migrate-payloads)
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --jobs-file)
+        [[ $# -lt 2 ]] && bridge_die "$1 뒤에 값을 지정하세요."
+        jobs_file="$2"
+        shift 2
+        ;;
+      --jsonl-aware|--dry-run|--json)
+        py_args+=("$1")
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        bridge_die "지원하지 않는 migrate-payloads 옵션입니다: $1"
         ;;
     esac
   done
@@ -1057,6 +1090,9 @@ case "$subcommand" in
   rebalance-memory-daily)
     run_rebalance_memory_daily "$@"
     ;;
+  migrate-payloads)
+    run_migrate_payloads "$@"
+    ;;
   enqueue)
     run_enqueue "$@"
     ;;
@@ -1082,7 +1118,7 @@ case "$subcommand" in
     # Issue #163: attach an intent-recovery suggestion before dying so the
     # caller sees "혹시 X?" instead of just the bare rejection.
     _hint="$(bridge_suggest_subcommand "cron $subcommand" \
-      "inventory show import list create update delete rebalance-memory-daily enqueue sync run-subagent finalize-run errors cleanup")"
+      "inventory show import list create update delete rebalance-memory-daily migrate-payloads enqueue sync run-subagent finalize-run errors cleanup")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 cron 명령입니다: $subcommand"
     ;;

--- a/docs/agent-runtime/memory-daily-harvest.md
+++ b/docs/agent-runtime/memory-daily-harvest.md
@@ -36,13 +36,24 @@ agent (see [§12 — Static-only contract](#12-static-only-contract)):
   ```
   bash "$BRIDGE_HOME/scripts/memory-daily-harvest.sh" --agent <agent>
 
-  # The harvester writes the authoritative RESULT_SCHEMA JSON to
+  # This harvester reconciles the agent's most recent jsonl session
+  # transcript (resolved via session_id under ~/.claude/projects/) into the
+  # agent's daily note at memory/daily/<YYYY-MM-DD>.md by invoking
+  # scripts/daily-note-reconcile.py before the harvest pass. The harvester
+  # then writes the authoritative RESULT_SCHEMA JSON to
   # $CRON_REQUEST_DIR/authoritative-memory-daily.json. The runner reads that
   # file directly. Your structured_output is a secondary relay.
   # Do NOT re-interpret status / summary / actions_taken — the harvester is authoritative.
   ```
 
-The inline `Do NOT re-interpret` comment is load-bearing. The cron runner
+This body is the canonical source; `bridge-cron.py`
+`MEMORY_DAILY_JSONL_AWARE_PROMPT_TEMPLATE` and the embedded literal in
+`bootstrap-memory-system.sh:step_memory_daily_cron_one` mirror it. The
+`jsonl` / `session_id` / `daily-note-reconcile` keywords are load-bearing:
+`agb cron migrate-payloads --jsonl-aware` (issue #541 PR-A) uses them as
+the predicate for whether an existing payload needs rewriting.
+
+The inline `Do NOT re-interpret` pragma is load-bearing. The cron runner
 forwards payload text to a Claude subagent as the prompt body; without the
 override the subagent could paraphrase `actions_taken`, which would defeat the
 daemon refresh-gating contract in §7.

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention upgrade-conflicts-lifecycle
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle
 }
 
 add_all_integration() {
@@ -196,7 +196,9 @@ select_for_path() {
       # Issue #533 — cron run-artifact retention/GC contract lives in
       # bridge-cron.py. Cover its smoke directly when any cron-side
       # python file moves.
-      add_required cron-run-artifacts-retention queue
+      # Issue #541 PR-A — memory-daily payload migration also lives in
+      # bridge-cron.py; pull its smoke in for the same trigger set.
+      add_required cron-run-artifacts-retention cron-migrate-payloads queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10192,4 +10192,8 @@ assert_contains "$FP_STATUS_OUTPUT" "context-pressure FP rate (7d): 1/1 (100%)"
 log "running stale-resume regression suite"
 bash "$REPO_ROOT/scripts/test-stale-resume.sh"
 
+# Issue #541 PR-A — memory-daily payload jsonl-aware migration regression.
+log "running cron-migrate-payloads smoke (issue #541 PR-A)"
+bash "$REPO_ROOT/scripts/smoke/cron-migrate-payloads.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/cron-migrate-payloads.sh
+++ b/scripts/smoke/cron-migrate-payloads.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# scripts/smoke/cron-migrate-payloads.sh — Issue #541 PR-A smoke.
+#
+# Validates `agb cron migrate-payloads --jsonl-aware`:
+#   1. --dry-run on a mixed fixture reports migrated=2, unchanged=1,
+#      skipped_non_memory_daily=1 and does NOT mutate the file.
+#   2. apply pass writes a jobs.json.bak-<timestamp> backup (matching the
+#      cleanup-prune naming convention), rewrites the two stale memory-daily
+#      payloads to a body that passes the jsonl-aware predicate, and leaves
+#      the non-memory-daily job byte-identical.
+#   3. re-running --dry-run after the apply pass reports migrated=0,
+#      unchanged=3 (idempotency).
+#   4. `agb cron create --title memory-daily-<agent> --agent <agent>` with
+#      no explicit --payload defaults to the canonical jsonl-aware body
+#      (acceptance criterion 2 of the issue).
+#
+# This smoke uses isolated fixtures under SMOKE_TMP_ROOT and never touches
+# the operator's live runtime jobs.json.
+
+set -euo pipefail
+
+SMOKE_NAME="cron-migrate-payloads"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root
+FIXTURE="$SMOKE_TMP_ROOT/jobs.json"
+
+write_fixture() {
+  cat >"$FIXTURE" <<'JSON'
+{
+  "format": "agent-bridge-cron-v1",
+  "updatedAt": "2026-05-04T00:00:00+00:00",
+  "jobs": [
+    {
+      "id": "memory-daily-already-aware-aaaaaaaa",
+      "name": "memory-daily-already",
+      "agentId": "already",
+      "enabled": true,
+      "schedule": {"kind": "cron", "expr": "0 3 * * *", "tz": "Asia/Seoul"},
+      "payload": {
+        "kind": "text",
+        "text": "bash \"$BRIDGE_HOME/scripts/memory-daily-harvest.sh\" --agent already\n# Reconciles jsonl via session_id and daily-note-reconcile.py before harvest."
+      },
+      "metadata": {"source": "fixture"}
+    },
+    {
+      "id": "memory-daily-stale-one-bbbbbbbb",
+      "name": "memory-daily-stale-one",
+      "agentId": "stale-one",
+      "enabled": true,
+      "schedule": {"kind": "cron", "expr": "0 3 * * *", "tz": "Asia/Seoul"},
+      "payload": {
+        "kind": "text",
+        "text": "bash \"$BRIDGE_HOME/scripts/memory-daily-harvest.sh\" --agent stale-one\n# Pre-#390 body: no jsonl/session_id/reconcile keywords."
+      },
+      "metadata": {"source": "fixture"}
+    },
+    {
+      "id": "memory-daily-stale-two-cccccccc",
+      "name": "memory-daily-stale-two",
+      "agentId": "stale-two",
+      "enabled": true,
+      "schedule": {"kind": "cron", "expr": "0 3 * * *", "tz": "Asia/Seoul"},
+      "payload": {
+        "kind": "text",
+        "text": "bash \"$BRIDGE_HOME/scripts/memory-daily-harvest.sh\" --agent stale-two\n# Authoritative RESULT_SCHEMA JSON; do not re-interpret actions_taken."
+      },
+      "metadata": {"source": "fixture"}
+    },
+    {
+      "id": "morning-briefing-other-dddddddd",
+      "name": "morning-briefing-other",
+      "agentId": "other",
+      "enabled": true,
+      "schedule": {"kind": "cron", "expr": "30 8 * * *", "tz": "Asia/Seoul"},
+      "payload": {
+        "kind": "text",
+        "text": "morning briefing — should be left alone by --jsonl-aware migration"
+      },
+      "metadata": {"source": "fixture"}
+    }
+  ]
+}
+JSON
+}
+
+# 1. Dry-run on a fresh fixture.
+write_fixture
+ORIGINAL_HASH="$("$PY_BIN" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$FIXTURE")"
+
+DRY_JSON="$("$PY_BIN" "$REPO_ROOT/bridge-cron.py" migrate-payloads --jsonl-aware --dry-run --jobs-file "$FIXTURE" --json)"
+"$PY_BIN" - "$DRY_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["migrated"] == 2, payload
+assert payload["unchanged"] == 1, payload
+assert payload["skipped_non_memory_daily"] == 1, payload
+assert payload["dry_run"] is True, payload
+assert payload["backup_file"] is None, payload
+PY
+
+DRY_HASH="$("$PY_BIN" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$FIXTURE")"
+smoke_assert_eq "$ORIGINAL_HASH" "$DRY_HASH" "dry-run must not mutate fixture"
+smoke_log "ok: dry-run counters correct, fixture unchanged"
+
+# Capture the non-memory-daily job's bytes AFTER load+normalize so the
+# byte-identity check below targets whether migrate-payloads itself
+# mutates the job — independent of the on-load normalize_job_agent_fields
+# pass shared by every jobs.json writer (cleanup-prune, rebalance, etc.).
+NON_MD_BEFORE="$("$PY_BIN" - "$FIXTURE" "$REPO_ROOT" <<'PY'
+import json, sys, importlib.util, os
+fixture_path, repo_root = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("bridge_cron", os.path.join(repo_root, "bridge-cron.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+_, jobs = mod.load_jobs_payload(fixture_path)
+for job in jobs:
+    if job.get("name") == "morning-briefing-other":
+        print(json.dumps(job, sort_keys=True, ensure_ascii=False))
+        break
+PY
+)"
+
+# 2. Apply pass.
+APPLY_JSON="$("$PY_BIN" "$REPO_ROOT/bridge-cron.py" migrate-payloads --jsonl-aware --jobs-file "$FIXTURE" --json)"
+BACKUP_FILE="$("$PY_BIN" - "$APPLY_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["migrated"] == 2, payload
+assert payload["unchanged"] == 1, payload
+assert payload["skipped_non_memory_daily"] == 1, payload
+assert payload["dry_run"] is False, payload
+assert payload["backup_file"], payload
+print(payload["backup_file"])
+PY
+)"
+smoke_assert_file_exists "$BACKUP_FILE" "backup file should exist after apply"
+
+# Backup name must match cleanup-prune convention: jobs.json.bak-<timestamp>.
+case "$(basename "$BACKUP_FILE")" in
+  jobs.json.bak-*) ;;
+  *) smoke_fail "backup file naming must mirror cleanup-prune (jobs.json.bak-<ts>); got $(basename "$BACKUP_FILE")" ;;
+esac
+
+# Backup must be byte-identical to the pre-apply fixture.
+BACKUP_HASH="$("$PY_BIN" -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$BACKUP_FILE")"
+smoke_assert_eq "$ORIGINAL_HASH" "$BACKUP_HASH" "backup file must equal pre-apply fixture bytes"
+
+# All three memory-daily jobs must now pass the jsonl-aware predicate, and
+# the non-memory-daily job must be byte-identical to its pre-apply form.
+"$PY_BIN" - "$FIXTURE" "$REPO_ROOT" "$NON_MD_BEFORE" <<'PY'
+import json, sys, importlib.util, os
+
+fixture_path, repo_root, non_md_before_json = sys.argv[1], sys.argv[2], sys.argv[3]
+
+spec = importlib.util.spec_from_file_location("bridge_cron", os.path.join(repo_root, "bridge-cron.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+data = json.load(open(fixture_path))
+md_count = 0
+non_md_after = None
+for job in data["jobs"]:
+    name = job.get("name", "")
+    if name.startswith("memory-daily"):
+        text = (job.get("payload") or {}).get("text") or ""
+        assert mod.memory_daily_payload_is_jsonl_aware(text), f"job {name} payload not jsonl-aware after migration: {text!r}"
+        md_count += 1
+    elif name == "morning-briefing-other":
+        non_md_after = json.dumps(job, sort_keys=True, ensure_ascii=False)
+
+assert md_count == 3, f"expected 3 memory-daily jobs, got {md_count}"
+assert non_md_after == non_md_before_json, "non-memory-daily job mutated by --jsonl-aware migration"
+print("ok: 3/3 memory-daily payloads jsonl-aware; non-memory-daily byte-identical")
+PY
+smoke_log "ok: apply pass migrates payloads, backup written, non-memory-daily preserved"
+
+# 3. Idempotency — second apply pass should report all unchanged.
+IDEMPOTENT_JSON="$("$PY_BIN" "$REPO_ROOT/bridge-cron.py" migrate-payloads --jsonl-aware --jobs-file "$FIXTURE" --json)"
+"$PY_BIN" - "$IDEMPOTENT_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["migrated"] == 0, payload
+assert payload["unchanged"] == 3, payload
+assert payload["skipped_non_memory_daily"] == 1, payload
+assert payload["backup_file"] is None, payload
+PY
+smoke_log "ok: idempotent re-run reports migrated=0 unchanged=3"
+
+# 4. cron create --family memory-daily acceptance: no explicit --payload
+#    must default to the canonical jsonl-aware body.
+FRESH_JOBS="$SMOKE_TMP_ROOT/fresh-jobs.json"
+"$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-create \
+  --jobs-file "$FRESH_JOBS" \
+  --agent acceptance-agent \
+  --schedule "0 3 * * *" \
+  --tz "Asia/Seoul" \
+  --title "memory-daily-acceptance-agent" >/dev/null
+
+"$PY_BIN" - "$FRESH_JOBS" "$REPO_ROOT" <<'PY'
+import json, sys, importlib.util, os
+fresh_path, repo_root = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("bridge_cron", os.path.join(repo_root, "bridge-cron.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+data = json.load(open(fresh_path))
+assert len(data["jobs"]) == 1, data
+text = data["jobs"][0]["payload"]["text"]
+assert mod.memory_daily_payload_is_jsonl_aware(text), f"fresh memory-daily create did not default to jsonl-aware body: {text!r}"
+assert "acceptance-agent" in text, text
+PY
+smoke_log "ok: cron create --title memory-daily-* defaults to canonical jsonl-aware body"
+
+smoke_log "smoke test passed"

--- a/scripts/smoke/cron-migrate-payloads.sh
+++ b/scripts/smoke/cron-migrate-payloads.sh
@@ -221,4 +221,134 @@ assert "acceptance-agent" in text, text
 PY
 smoke_log "ok: cron create --title memory-daily-* defaults to canonical jsonl-aware body"
 
+# 5. cron create --title memory-daily-* WITH explicit --payload must
+#    preserve the operator-supplied body (no canonical default substitution).
+OVERRIDE_JOBS="$SMOKE_TMP_ROOT/override-jobs.json"
+OVERRIDE_MARKER="operator-override-test-marker-$$"
+"$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-create \
+  --jobs-file "$OVERRIDE_JOBS" \
+  --agent override-agent \
+  --schedule "0 3 * * *" \
+  --tz "Asia/Seoul" \
+  --title "memory-daily-override-agent" \
+  --payload "$OVERRIDE_MARKER" >/dev/null
+
+"$PY_BIN" - "$OVERRIDE_JOBS" "$REPO_ROOT" "$OVERRIDE_MARKER" <<'PY'
+import json, sys, importlib.util, os
+override_path, repo_root, marker = sys.argv[1], sys.argv[2], sys.argv[3]
+spec = importlib.util.spec_from_file_location("bridge_cron", os.path.join(repo_root, "bridge-cron.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+data = json.load(open(override_path))
+assert len(data["jobs"]) == 1, data
+text = data["jobs"][0]["payload"]["text"]
+assert text == marker, f"explicit --payload not preserved verbatim: {text!r} != {marker!r}"
+canonical = mod.render_memory_daily_jsonl_aware_prompt("override-agent")
+assert text != canonical, "explicit --payload was overwritten by canonical jsonl-aware body"
+PY
+smoke_log "PASS: create with explicit --payload preserves operator override"
+
+# 6. Top-level-list jobs.json shape must round-trip: handler accepts a
+#    top-level JSON array (no {jobs: [...]} wrapper), rewrites memory-daily
+#    payloads in place, leaves non-memory-daily byte-identical, writes
+#    jobs.json.bak-<ts>, and the resulting file is still a top-level list.
+LIST_FIXTURE="$SMOKE_TMP_ROOT/list-jobs.json"
+cat >"$LIST_FIXTURE" <<'JSON'
+[
+  {
+    "id": "memory-daily-list-a-aaaaaaaa",
+    "name": "memory-daily-list-a",
+    "agentId": "list-a",
+    "enabled": true,
+    "schedule": {"kind": "cron", "expr": "0 3 * * *", "tz": "Asia/Seoul"},
+    "payload": {
+      "kind": "text",
+      "text": "bash \"$BRIDGE_HOME/scripts/memory-daily-harvest.sh\" --agent list-a\n# Pre-#390 body."
+    },
+    "metadata": {"source": "fixture"}
+  },
+  {
+    "id": "memory-daily-list-b-bbbbbbbb",
+    "name": "memory-daily-list-b",
+    "agentId": "list-b",
+    "enabled": true,
+    "schedule": {"kind": "cron", "expr": "0 3 * * *", "tz": "Asia/Seoul"},
+    "payload": {
+      "kind": "text",
+      "text": "bash \"$BRIDGE_HOME/scripts/memory-daily-harvest.sh\" --agent list-b\n# Stale, no jsonl-aware tokens."
+    },
+    "metadata": {"source": "fixture"}
+  },
+  {
+    "id": "morning-briefing-list-c-cccccccc",
+    "name": "morning-briefing-list-c",
+    "agentId": "list-c",
+    "enabled": true,
+    "schedule": {"kind": "cron", "expr": "30 8 * * *", "tz": "Asia/Seoul"},
+    "payload": {
+      "kind": "text",
+      "text": "morning briefing — top-level-list non-memory-daily; must be left alone"
+    },
+    "metadata": {"source": "fixture"}
+  }
+]
+JSON
+
+# Capture pre-apply normalized bytes of the non-memory-daily job for the
+# byte-identity check (parity with the object-shape sub-test above).
+LIST_NON_MD_BEFORE="$("$PY_BIN" - "$LIST_FIXTURE" "$REPO_ROOT" <<'PY'
+import json, sys, importlib.util, os
+fixture_path, repo_root = sys.argv[1], sys.argv[2]
+spec = importlib.util.spec_from_file_location("bridge_cron", os.path.join(repo_root, "bridge-cron.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+_, jobs = mod.load_jobs_payload(fixture_path)
+for job in jobs:
+    if job.get("name") == "morning-briefing-list-c":
+        print(json.dumps(job, sort_keys=True, ensure_ascii=False))
+        break
+PY
+)"
+
+LIST_APPLY_JSON="$("$PY_BIN" "$REPO_ROOT/bridge-cron.py" migrate-payloads --jsonl-aware --jobs-file "$LIST_FIXTURE" --json)"
+LIST_BACKUP_FILE="$("$PY_BIN" - "$LIST_APPLY_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["migrated"] == 2, payload
+assert payload["unchanged"] == 0, payload
+assert payload["skipped_non_memory_daily"] == 1, payload
+assert payload["dry_run"] is False, payload
+assert payload["backup_file"], payload
+print(payload["backup_file"])
+PY
+)"
+smoke_assert_file_exists "$LIST_BACKUP_FILE" "top-level-list backup file should exist after apply"
+case "$(basename "$LIST_BACKUP_FILE")" in
+  jobs.json.bak-*|list-jobs.json.bak-*) ;;
+  *) smoke_fail "top-level-list backup naming must mirror cleanup-prune (<name>.bak-<ts>); got $(basename "$LIST_BACKUP_FILE")" ;;
+esac
+
+"$PY_BIN" - "$LIST_FIXTURE" "$REPO_ROOT" "$LIST_NON_MD_BEFORE" <<'PY'
+import json, sys, importlib.util, os
+fixture_path, repo_root, non_md_before_json = sys.argv[1], sys.argv[2], sys.argv[3]
+spec = importlib.util.spec_from_file_location("bridge_cron", os.path.join(repo_root, "bridge-cron.py"))
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+data = json.load(open(fixture_path))
+assert isinstance(data, list), f"top-level-list jobs.json must round-trip as a list, got {type(data).__name__}"
+md_count = 0
+non_md_after = None
+for job in data:
+    name = job.get("name", "")
+    if name.startswith("memory-daily"):
+        text = (job.get("payload") or {}).get("text") or ""
+        assert mod.memory_daily_payload_is_jsonl_aware(text), f"job {name} payload not jsonl-aware after migration: {text!r}"
+        md_count += 1
+    elif name == "morning-briefing-list-c":
+        non_md_after = json.dumps(job, sort_keys=True, ensure_ascii=False)
+assert md_count == 2, f"expected 2 migrated memory-daily jobs in list shape, got {md_count}"
+assert non_md_after == non_md_before_json, "non-memory-daily job mutated by --jsonl-aware migration in list shape"
+PY
+smoke_log "PASS: top-level-list jobs.json shape round-trips correctly"
+
 smoke_log "smoke test passed"


### PR DESCRIPTION
## Summary
- New canonical `MEMORY_DAILY_JSONL_AWARE_PROMPT_TEMPLATE` constant + `render_memory_daily_jsonl_aware_prompt()` helper in `bridge-cron.py`. `agb cron create --title memory-daily-*` uses it by default and the new `agb cron migrate-payloads --jsonl-aware` rewrites existing live-runtime payloads to it.
- `bridge-cron.py` predicate `memory_daily_payload_is_jsonl_aware()` (jsonl + session_id + daily-note-reconcile token triple) enables idempotent re-runs — already-jsonl-aware jobs are no-ops.
- Migration emits `jobs.json.bak-<timestamp>` before any mutation (mirrors `cleanup-prune` convention exactly). Non-memory-daily jobs are strictly untouched.
- `bootstrap-memory-system.sh` + `docs/agent-runtime/memory-daily-harvest.md` updated to mirror the canonical body byte-for-byte, with cross-ref pointer so the three sources stay in sync.
- New smoke `scripts/smoke/cron-migrate-payloads.sh` covers dry-run counters, idempotent re-run, backup creation + naming convention, non-memory-daily job byte preservation, and the `cron create` default acceptance path. Wired into `scripts/smoke-test.sh` and the `ci-select-smoke.sh` trigger set for `bridge-cron.py`.

## Operator usage on existing installs
```
agb cron migrate-payloads --jsonl-aware --dry-run --json   # preview
agb cron migrate-payloads --jsonl-aware                    # apply (writes .bak)
```

## Out of scope (deferred)
- Stop hook propagation — issue #541 PR-B (separate brief).
- e2e-memory-system-test scenario for "yesterday's daily note matches jsonl turn count" — issue #541 PR-C.
- PreCompact threshold default — issue #541 PR-D (P2).
- No VERSION/CHANGELOG bump.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('bridge-cron.py').read())"`.
- [x] `bash -n` + `shellcheck` clean on `bridge-cron.sh`, `bootstrap-memory-system.sh`, `scripts/smoke/cron-migrate-payloads.sh`, `scripts/ci-select-smoke.sh`.
- [x] Constant + render + predicate self-consistency: `render_memory_daily_jsonl_aware_prompt('admin')` round-trips through `memory_daily_payload_is_jsonl_aware`; pre-#390 body fails the predicate (negative case).
- [x] `python3 bridge-cron.py migrate-payloads --help` shows the new subcommand; `bash bridge-cron.sh --help` exposes `migrate-payloads --jsonl-aware`.
- [x] `bash scripts/smoke/cron-migrate-payloads.sh` PASS — dry-run (migrated=2, unchanged=1, skipped_non_memory_daily=1, no mutation), apply (backup written, predicate passes for all 3 memory-daily jobs after, non-memory-daily byte-identical), idempotent re-run (migrated=0, unchanged=3), `cron create` default acceptance.
- [x] `./scripts/smoke-test.sh` reaches the pre-existing `#365 follow-up` failure verbatim on this branch and on `main` `7207057` (`expected output to contain: running pid=` at `daemon stop refuses while active agents are present`); not introduced by this PR.
- [ ] Maintainer: live `agb cron migrate-payloads --jsonl-aware --dry-run --json` on reference install → confirm 22 migrated.

Refs #541