### PR TITLE
fix(autocompact): model-aware autoCompactWindow default — 1M for [1m] launches (refs #547)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -94,7 +94,7 @@ agb upgrade --dry-run
 agb upgrade --apply
 ```
 
-`--apply` 는 atomic — daemon stop/start, agent restart, shared settings rerender (`autoCompactWindow:400000` 등 managed default propagate), shared hooks 재등록, `_template/CLAUDE.md` sync, `[upgrade-complete]` admin task 등록 모두 포함.
+`--apply` 는 atomic — daemon stop/start, agent restart, shared settings rerender (model-aware `autoCompactWindow` 등 managed default propagate; `[1m]`-variant launches → `1_000_000`, 그 외 → `400_000` 유지, 자세한 내용은 [autoCompactWindow per model](#autocompactwindow-per-model-v076-issue-547) 참고), shared hooks 재등록, `_template/CLAUDE.md` sync, `[upgrade-complete]` admin task 등록 모두 포함.
 
 The upgrader preserves local runtime data by default:
 
@@ -148,6 +148,33 @@ cd ~/.agent-bridge-source
 ./scripts/deploy-live-install.sh --dry-run --target ~/.agent-bridge
 ./scripts/deploy-live-install.sh --target ~/.agent-bridge --restart-daemon
 ```
+
+### autoCompactWindow per model (v0.7.6+, issue #547)
+
+`bridge-hooks.py render-shared-settings` resolves the managed
+`autoCompactWindow` default per agent based on `BRIDGE_AGENT_LAUNCH_CMD`:
+
+- launch_cmd contains `[1m]` (Opus 4.7 1M-context line) → `1_000_000`
+- everything else (Opus 4.6 / pre-1M Sonnet / Haiku) → `400_000` (preserved compromise)
+
+Threading is per-agent: every `bridge-agent.sh rerender-settings`,
+`agent-bridge upgrade --apply`, and `agent-bridge create` invocation forwards
+the resolved launch_cmd to the renderer. Operator overlays
+(`~/.agent-bridge/.claude/settings.local.json` and per-agent base
+`settings.json`) still win over the managed default.
+
+This means `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is now computed against the
+model's actual native context window for `[1m]` launches, not the
+previously-capped `400_000`. Operators who want to opt back into the legacy
+400K cap on a 1M-context agent set:
+
+```sh
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000
+```
+
+in `agent-roster.local.sh` (env wins over settings per Claude Code's
+resolution order, so this overrides the new model-aware default and
+survives `agent-bridge upgrade --apply`).
 
 ## Recommended Collaboration Pattern
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -176,6 +176,20 @@ in `agent-roster.local.sh` (env wins over settings per Claude Code's
 resolution order, so this overrides the new model-aware default and
 survives `agent-bridge upgrade --apply`).
 
+**Mixed-model installs (caveat).** The shared settings effective file
+under `$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json` is
+**install-wide** — one file symlinked from each managed agent's workdir.
+On installs where some agents launch `[1m]` and others launch pre-1M
+models, the file inherits the `autoCompactWindow` of whichever agent
+ran the last `agb upgrade --apply` / restart-rerender. Until per-agent
+effective settings lands (tracked separately), operators on mixed-model
+installs should either:
+
+- keep models homogeneous within an install, or
+- override per-agent via `CLAUDE_CODE_AUTO_COMPACT_WINDOW=<value>`
+  in the env-precedence layer (env wins over settings per Claude
+  Code's resolution order).
+
 ## Recommended Collaboration Pattern
 
 1. Start agents

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1345,6 +1345,8 @@ PY
 bridge_agent_shared_settings_plan_json() {
   local agent="$1"
   local workdir="$2"
+  local launch_cmd
+  launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
 
   bridge_agent_manage_python \
     "$SCRIPT_DIR/bridge-hooks.py" \
@@ -1352,14 +1354,15 @@ bridge_agent_shared_settings_plan_json() {
     "$workdir" \
     "$(bridge_hook_shared_settings_base_file)" \
     "$(bridge_hook_shared_settings_overlay_file)" \
-    "$(bridge_hook_shared_settings_effective_file)" <<'PY'
+    "$(bridge_hook_shared_settings_effective_file)" \
+    "$launch_cmd" <<'PY'
 import importlib.util
 import json
 import os
 import sys
 from pathlib import Path
 
-hooks_py, agent, workdir, base_file, overlay_file, effective_file = sys.argv[1:]
+hooks_py, agent, workdir, base_file, overlay_file, effective_file, launch_cmd = sys.argv[1:]
 spec = importlib.util.spec_from_file_location("bridge_hooks", hooks_py)
 if spec is None or spec.loader is None:
     raise SystemExit(f"could not load {hooks_py}")
@@ -1390,7 +1393,8 @@ def load_object(path: Path, label: str, *, absent_ok: bool = True) -> dict:
 
 base_payload = load_object(base_path, "base")
 overlay_payload = load_object(overlay_path, "overlay")
-expected = hooks.merge_settings(hooks.BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS, base_payload)
+managed_defaults = hooks.managed_claude_settings_defaults(launch_cmd or None)
+expected = hooks.merge_settings(managed_defaults, base_payload)
 expected = hooks.merge_settings(expected, overlay_payload)
 
 current_error = ""
@@ -1405,7 +1409,7 @@ effective_exists = effective_path.exists()
 effective_matches = effective_exists and effective_payload == expected
 
 changes = []
-for key in hooks.BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS:
+for key in managed_defaults:
     expected_value = expected.get(key)
     if key not in current_payload:
         changes.append({"key": key, "from": None, "to": expected_value, "reason": "missing"})
@@ -1556,6 +1560,7 @@ run_rerender_settings() {
   local error=""
   local rows_file=""
   local failed_count=0
+  local target_launch_cmd=""
   local -a selected_agents=()
   local -a targets=()
   local -A seen_workdirs=()
@@ -1645,7 +1650,10 @@ run_rerender_settings() {
     before_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir")"
     error=""
     if [[ $apply -eq 1 ]]; then
-      if apply_output="$(bridge_link_claude_settings_to_shared "$workdir" 2>&1)"; then
+      # Issue #547: forward launch_cmd so the rerender picks the right
+      # autoCompactWindow default (1_000_000 for [1m] launches, else 400_000).
+      target_launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
+      if apply_output="$(bridge_link_claude_settings_to_shared "$workdir" "$target_launch_cmd" 2>&1)"; then
         after_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir")"
         bridge_audit_log "$(bridge_admin_agent_id 2>/dev/null || printf bridge-upgrade)" "shared_settings_rerendered" "$agent" \
           --detail workdir="$workdir" >/dev/null 2>&1 || true
@@ -1951,7 +1959,9 @@ run_create() {
       "$os_user" >/dev/null
     bridge_load_roster
     if [[ "$engine" == "claude" ]]; then
-      bridge_ensure_claude_shared_settings_for_managed_workdir "$workdir" >/dev/null 2>&1 || true
+      # Issue #547: forward launch_cmd so the freshly-created agent gets
+      # the right autoCompactWindow default for its model variant.
+      bridge_ensure_claude_shared_settings_for_managed_workdir "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
     fi
     bridge_sync_skill_docs "$agent" >/dev/null 2>&1 || true
     if [[ "$isolation_mode" == "linux-user" ]]; then

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -17,9 +17,27 @@ from typing import Any
 # setting CLAUDE_CODE_AUTO_COMPACT_WINDOW here because that env var takes
 # precedence over settings and would make operator overlays harder to reason
 # about.
-BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS: dict[str, Any] = {
-    "autoCompactWindow": 400000,
-}
+#
+# The default is launch_cmd-aware (issue #547): on 1M-context Opus 4.7 [1m]
+# the legacy 400_000 cap silently rescaled CLAUDE_AUTOCOMPACT_PCT_OVERRIDE
+# (operator setting pct=45 expecting compact at ~450K of 1M was getting
+# compact at 180K). Sub-string match on `[1m]` is sufficient for the
+# dominant case; a roster-level BRIDGE_AGENT_MODEL field is deferred per
+# issue #547 recommendation 2.
+BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW_LEGACY = 400_000
+BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW_1M = 1_000_000
+
+
+def resolve_managed_autocompact_window(launch_cmd: str | None) -> int:
+    if launch_cmd and "[1m]" in launch_cmd:
+        return BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW_1M
+    return BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW_LEGACY
+
+
+def managed_claude_settings_defaults(launch_cmd: str | None) -> dict[str, Any]:
+    return {
+        "autoCompactWindow": resolve_managed_autocompact_window(launch_cmd),
+    }
 
 
 def load_json(path: Path) -> Any:
@@ -809,7 +827,9 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
     if not isinstance(overlay_payload, dict):
         raise SystemExit(f"shared settings overlay must be a JSON object: {overlay_path}")
 
-    merged = merge_settings(BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS, base_payload)
+    launch_cmd = (getattr(args, "launch_cmd", "") or "") or None
+    managed_defaults = managed_claude_settings_defaults(launch_cmd)
+    merged = merge_settings(managed_defaults, base_payload)
     merged = merge_settings(merged, overlay_payload)
     save_json(effective_path, merged)
 
@@ -1070,6 +1090,11 @@ def build_parser() -> argparse.ArgumentParser:
     render_shared_parser.add_argument("--base-settings-file", required=True)
     render_shared_parser.add_argument("--overlay-settings-file", required=True)
     render_shared_parser.add_argument("--effective-settings-file", required=True)
+    render_shared_parser.add_argument(
+        "--launch-cmd",
+        default="",
+        help="Agent launch_cmd; substring '[1m]' raises autoCompactWindow default to 1_000_000 (issue #547).",
+    )
     render_shared_parser.add_argument("--format", choices=("text", "shell"), default="text")
     render_shared_parser.set_defaults(handler=cmd_render_shared_settings)
 

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -464,7 +464,8 @@ fi
 if [[ $dry_run -eq 0 ]] && [[ "$(bridge_agent_engine "$admin_agent" 2>/dev/null || printf '%s' "$engine")" == "claude" ]]; then
   admin_workdir="$(bridge_agent_workdir "$admin_agent" 2>/dev/null || true)"
   if [[ -n "$admin_workdir" ]]; then
-    bridge_ensure_claude_shared_settings_for_managed_workdir "$admin_workdir" >/dev/null 2>&1 || true
+    admin_launch_cmd="$(bridge_agent_launch_cmd_raw "$admin_agent" 2>/dev/null || true)"
+    bridge_ensure_claude_shared_settings_for_managed_workdir "$admin_workdir" "$admin_launch_cmd" >/dev/null 2>&1 || true
   fi
 fi
 

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -192,21 +192,26 @@ bridge_upgrade_propagate_claude_hooks() {
     bridge_load_roster
     BRIDGE_AGENT_HOME_ROOT="$1/agents"
     workdir=""
+    launch_cmd=""
     for agent in "${BRIDGE_AGENT_IDS[@]}"; do
       [[ "$(bridge_agent_engine "$agent" 2>/dev/null || true)" == "claude" ]] || continue
       workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
       [[ -n "$workdir" ]] || continue
-      bridge_ensure_claude_stop_hook "$workdir" >/dev/null 2>&1 || true
-      bridge_ensure_claude_session_start_hook "$workdir" >/dev/null 2>&1 || true
-      bridge_ensure_claude_prompt_hook "$workdir" >/dev/null 2>&1 || true
-      bridge_ensure_claude_prompt_guard_hook "$workdir" >/dev/null 2>&1 || true
-      bridge_ensure_claude_tool_policy_hooks "$workdir" >/dev/null 2>&1 || true
+      # Issue #547: forward each agent launch_cmd so the rerendered
+      # shared settings pick the right autoCompactWindow default per
+      # model variant ([1m] → 1_000_000, otherwise → 400_000).
+      launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
+      bridge_ensure_claude_stop_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
+      bridge_ensure_claude_session_start_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
+      bridge_ensure_claude_prompt_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
+      bridge_ensure_claude_prompt_guard_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
+      bridge_ensure_claude_tool_policy_hooks "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
       # Issue #509 / PR #510 deployment gap: PreCompact was the one event
       # the propagation loop never re-registered, so hosts that upgraded
       # without restarting agents shipped hooks/pre-compact.py code with
       # no settings.json wire. Adding it here closes that gap on every
       # subsequent upgrade.
-      bridge_ensure_claude_pre_compact_hook "$workdir" >/dev/null 2>&1 || true
+      bridge_ensure_claude_pre_compact_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
     done
   ' -- "$target_root"
 }

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -115,8 +115,9 @@ bridge_claude_settings_mode() {
 
 bridge_ensure_claude_shared_settings_for_managed_workdir() {
   local workdir="$1"
+  local launch_cmd="${2-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
-    bridge_link_claude_settings_to_shared "$workdir"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
   else
     return 0
   fi
@@ -124,10 +125,17 @@ bridge_ensure_claude_shared_settings_for_managed_workdir() {
 
 bridge_link_claude_settings_to_shared() {
   local workdir="$1"
+  # Issue #547: launch_cmd substring '[1m]' raises the managed
+  # autoCompactWindow default from 400_000 to 1_000_000. The shared
+  # settings file is install-wide; on a mixed-model install the last
+  # rerender for an agent decides the value. The dominant case is
+  # all-Opus-4.7-[1m] (or all-pre-1M), where every rerender agrees.
+  local launch_cmd="${2-}"
   bridge_hooks_python render-shared-settings \
     --base-settings-file "$(bridge_hook_shared_settings_base_file)" \
     --overlay-settings-file "$(bridge_hook_shared_settings_overlay_file)" \
-    --effective-settings-file "$(bridge_hook_shared_settings_effective_file)" >/dev/null
+    --effective-settings-file "$(bridge_hook_shared_settings_effective_file)" \
+    --launch-cmd "$launch_cmd" >/dev/null
   bridge_hooks_python link-shared-settings --workdir "$workdir" --shared-settings-file "$(bridge_hook_shared_settings_effective_file)"
 }
 
@@ -183,9 +191,10 @@ bridge_claude_tool_policy_hooks_status() {
 
 bridge_ensure_claude_stop_hook() {
   local workdir="$1"
+  local launch_cmd="${2-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-stop-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --bash-bin bash >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
   else
     bridge_hooks_python ensure-stop-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --bash-bin "$BRIDGE_BASH_BIN"
   fi
@@ -193,9 +202,10 @@ bridge_ensure_claude_stop_hook() {
 
 bridge_ensure_claude_session_start_hook() {
   local workdir="$1"
+  local launch_cmd="${2-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-session-start-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
   else
     bridge_hooks_python ensure-session-start-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi
@@ -203,9 +213,10 @@ bridge_ensure_claude_session_start_hook() {
 
 bridge_ensure_claude_prompt_hook() {
   local workdir="$1"
+  local launch_cmd="${2-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-prompt-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --bash-bin bash --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
   else
     bridge_hooks_python ensure-prompt-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --bash-bin "$BRIDGE_BASH_BIN" --python-bin "$(command -v python3)"
   fi
@@ -213,9 +224,10 @@ bridge_ensure_claude_prompt_hook() {
 
 bridge_ensure_claude_prompt_guard_hook() {
   local workdir="$1"
+  local launch_cmd="${2-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-prompt-guard-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
   else
     bridge_hooks_python ensure-prompt-guard-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi
@@ -223,9 +235,10 @@ bridge_ensure_claude_prompt_guard_hook() {
 
 bridge_ensure_claude_tool_policy_hooks() {
   local workdir="$1"
+  local launch_cmd="${2-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-tool-policy-hooks --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
   else
     bridge_hooks_python ensure-tool-policy-hooks --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi
@@ -241,9 +254,10 @@ bridge_ensure_claude_tool_policy_hooks() {
 # snapshot — the disaster-recovery fallback — never gets written.
 bridge_ensure_claude_pre_compact_hook() {
   local workdir="$1"
+  local launch_cmd="${2-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-pre-compact-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
   else
     bridge_hooks_python ensure-pre-compact-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -201,7 +201,7 @@ select_for_path() {
       ;;
 
     bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh|lib/bridge-wave.sh|lib/bridge-agent-update.sh)
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update upgrade-conflicts-lifecycle
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update upgrade-conflicts-lifecycle managed-autocompact-window
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -246,7 +246,7 @@ select_for_path() {
       ;;
 
     bridge-upgrade.sh|bridge-upgrade.py|scripts/export-public-snapshot.sh|VERSION)
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window
       add_integration integration-minimal
       ;;
 
@@ -256,7 +256,7 @@ select_for_path() {
       ;;
 
     bridge-init.sh|lib/bridge-admin-pair.sh)
-      add_required admin-codex-pair upgrade-shared-settings-propagate
+      add_required admin-codex-pair upgrade-shared-settings-propagate managed-autocompact-window
       add_integration integration-minimal
       ;;
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention upgrade-conflicts-lifecycle
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention upgrade-conflicts-lifecycle managed-autocompact-window
 }
 
 add_all_integration() {
@@ -241,7 +241,7 @@ select_for_path() {
       ;;
 
     hooks/*|bridge-hooks.py|lib/bridge-hooks.sh)
-      add_required hooks upgrade-shared-settings-propagate
+      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/managed-autocompact-window.sh
+++ b/scripts/smoke/managed-autocompact-window.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# scripts/smoke/managed-autocompact-window.sh — Issue #547 regression smoke.
+#
+# Covers `bridge-hooks.py render-shared-settings` resolution of the managed
+# autoCompactWindow default:
+#   - launch_cmd contains '[1m]' → 1_000_000 (Opus 4.7 1M-context line)
+#   - launch_cmd lacks '[1m]'    → 400_000  (legacy / Opus 4.6 era)
+#   - --launch-cmd omitted        → 400_000  (back-compat with pre-#547 callers)
+
+set -euo pipefail
+
+SMOKE_NAME="managed-autocompact-window"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+assert_window() {
+  local effective_file="$1"
+  local expected="$2"
+  local context="$3"
+
+  python3 - "$effective_file" "$expected" "$context" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+effective_file, expected, context = sys.argv[1:]
+payload = json.loads(Path(effective_file).read_text(encoding="utf-8"))
+actual = payload.get("autoCompactWindow")
+if actual != int(expected):
+    raise SystemExit(f"{context}: autoCompactWindow expected {expected}, got {actual!r}")
+PY
+}
+
+run_render() {
+  local base="$1"
+  local overlay="$2"
+  local effective="$3"
+  shift 3
+  rm -f "$effective"
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-shared-settings \
+    --base-settings-file "$base" \
+    --overlay-settings-file "$overlay" \
+    --effective-settings-file "$effective" \
+    "$@" >/dev/null
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  local case_dir base overlay effective
+  case_dir="$SMOKE_TMP_ROOT/render-cases"
+  mkdir -p "$case_dir"
+  base="$case_dir/settings.json"
+  overlay="$case_dir/settings.local.json"
+  effective="$case_dir/settings.effective.json"
+
+  rm -f "$base" "$overlay"
+
+  smoke_log "case: launch_cmd contains '[1m]' → 1_000_000"
+  run_render "$base" "$overlay" "$effective" \
+    --launch-cmd "claude --model claude-opus-4-7[1m]"
+  assert_window "$effective" "1000000" "1m launch_cmd raises managed default"
+
+  smoke_log "case: launch_cmd lacks '[1m]' → 400_000"
+  run_render "$base" "$overlay" "$effective" \
+    --launch-cmd "claude --model claude-opus-4-7"
+  assert_window "$effective" "400000" "non-1m launch_cmd preserves legacy default"
+
+  smoke_log "case: empty --launch-cmd → 400_000 (back-compat for unspecified)"
+  run_render "$base" "$overlay" "$effective" --launch-cmd ""
+  assert_window "$effective" "400000" "empty launch_cmd falls through to legacy default"
+
+  smoke_log "case: --launch-cmd omitted entirely → 400_000 (back-compat for pre-#547 callers)"
+  run_render "$base" "$overlay" "$effective"
+  assert_window "$effective" "400000" "omitted launch_cmd flag preserves legacy default"
+
+  smoke_log "case: base autoCompactWindow wins over managed default even on [1m]"
+  printf '%s\n' '{"autoCompactWindow":650000}' >"$base"
+  run_render "$base" "$overlay" "$effective" \
+    --launch-cmd "claude [1m]"
+  assert_window "$effective" "650000" "explicit base value overrides managed default"
+  rm -f "$base"
+
+  smoke_log "case: overlay autoCompactWindow wins over managed default on [1m]"
+  printf '%s\n' '{"autoCompactWindow":475000}' >"$overlay"
+  run_render "$base" "$overlay" "$effective" \
+    --launch-cmd "claude [1m]"
+  assert_window "$effective" "475000" "explicit overlay value overrides managed default"
+
+  smoke_log "PASS: managed autoCompactWindow resolver matrix (#547)"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- `bridge-hooks.py` replaces the static `BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS["autoCompactWindow"] = 400_000` with a launch_cmd-aware resolver. `[1m]` substring → `1_000_000`; everything else → `400_000` (preserved).
- New optional `--launch-cmd` flag on `bridge-hooks.py render-shared-settings` (back-compat: omitting the flag preserves the legacy default).
- `lib/bridge-hooks.sh` threads an optional `launch_cmd` arg through `bridge_link_claude_settings_to_shared`, `bridge_ensure_claude_shared_settings_for_managed_workdir`, and the six `bridge_ensure_claude_*_hook` helpers.
- Three call-site updates (`bridge-agent.sh` `run_create` + `run_rerender_settings` + `bridge_agent_shared_settings_plan_json`, `bridge-init.sh` admin-wire, `bridge-upgrade.sh` per-agent propagation loop) resolve the agent's `launch_cmd` via `bridge_agent_launch_cmd_raw` and forward it.
- New regression smoke `scripts/smoke/managed-autocompact-window.sh` covers the full resolution matrix ([1m] / non-[1m] / empty / omitted, plus base & overlay precedence over the managed default). Wired into `scripts/ci-select-smoke.sh` required suite (added to `add_all_required_static` and to the `hooks/*|bridge-hooks.py|lib/bridge-hooks.sh` change-detection block).
- `OPERATIONS.md` documents the new behavior + the opt-back-in escape hatch (env var).

## Why heuristic on launch_cmd, not the existing `BRIDGE_AGENT_MODEL` roster field
`BRIDGE_AGENT_MODEL` exists today but is optional and defaults to `claude-opus-4-7` (no `[1m]` suffix), so it does not encode the 1M-context variant on its own. The launch_cmd is the universal source of truth on current installs (operators who run the 1M variant always include `[1m]` in their roster `BRIDGE_AGENT_LAUNCH_CMD`). Substring match on `[1m]` is precise enough for the dominant case and zero-config — when more model variants need distinct handling (e.g., a future `[2m]`), the resolver becomes the natural extension point. Adding a model-id parser or a new model-suffix roster field is deferred per issue #547 recommendation 2.

## Operator escape hatch (preserved)
Operators who want to opt back into the legacy 400K cap on a 1M-context agent set:
```sh
export CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000
```
in `agent-roster.local.sh`. Env wins over settings per Claude Code's resolution order, so this overrides the new model-aware default and survives `agent-bridge upgrade --apply`.

## Out of scope (deferred)
- Option B (rescaling pct against model native capacity) — explicitly rejected in issue body; it would remove the sub-model-window operator lever.
- Option C (session-start advisory when `window < model_capacity`) — useful, separate follow-up.
- New `BRIDGE_AGENT_MODEL`-derived model suffix field — heuristic on launch_cmd is sufficient for current dominant models.
- No VERSION/CHANGELOG bump.

## Test plan
- [x] `python3 -c "import ast; ast.parse(open('bridge-hooks.py').read())"`.
- [x] `bash -n` + `shellcheck` clean on every touched bash file.
- [x] Resolver matrix: `[1m]` → `1_000_000`; non-`[1m]` → `400_000`; `None` / empty → `400_000`.
- [x] `--launch-cmd` flag exposed in `bridge-hooks.py render-shared-settings --help`.
- [x] Old `BRIDGE_MANAGED_CLAUDE_SETTINGS_DEFAULTS` constant fully removed from code (only historical references remain in `CHANGELOG.md` and `docs/agent-runtime/admin-protocol.md`).
- [x] `bash scripts/smoke/managed-autocompact-window.sh` PASS — six cases (1m, non-1m, empty, omitted, base override, overlay override).
- [x] `bash scripts/smoke/hooks.sh` PASS — confirms back-compat; the existing `claude_shared_settings_context_defaults` test (which calls `render-shared-settings` without `--launch-cmd`) still asserts `autoCompactWindow=400000`.
- [x] `bash scripts/smoke/upgrade-shared-settings-propagate.sh` PASS — confirms the rerender plan / dry-run / apply path picks up `managed_claude_settings_defaults(launch_cmd)` correctly.
- [x] Manual end-to-end: `python3 bridge-hooks.py render-shared-settings --launch-cmd "claude --model claude-opus-4-7[1m]" ...` writes `autoCompactWindow: 1000000`; same call without `[1m]` writes `400000`.
- [ ] Maintainer: live `agb upgrade --apply` on an install with both pre-1M and Opus 4.7 [1m] agents → confirm `<live-home>/agents/<agent>/.claude/settings.effective.json` `autoCompactWindow` is correct for the agent the rerender ran for last (shared file is install-wide; on uniform-model installs every per-agent rerender agrees).

Refs #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)