### PR TITLE
feat(isolated): curated bin/agb shim + isolated PATH grant (refs #544 PR1)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -380,6 +380,27 @@ emits when `BRIDGE_AGENT_ISOLATION_MODE=linux-user`. See issue
 > A2A queue tasks from those sessions stop routing through the gateway
 > until they pick up the new env.
 
+### Picking up the curated `bin/` after upgrade
+
+After v0.7.6+, isolated agents can call `agb` bare from their Bash tool
+because the launcher prepends `${BRIDGE_HOME}/bin` to the agent's PATH
+and the curated `bin/agb` shim auto-sources `BRIDGE_AGENT_ENV_FILE`
+before delegating to the underlying `${BRIDGE_HOME}/agb`. Existing
+isolated agents pick this up by re-running:
+
+```bash
+agent-bridge isolate <agent> --reapply
+```
+
+(idempotent; only re-installs the ACL contract, doesn't mutate
+ownership) followed by an agent restart so `bridge-start.sh`
+regenerates the agent's `agent-env.sh` with the new PATH.
+
+Out of scope: the broader `agent-bridge` subcommand surface for
+isolated UIDs remains explicit default-deny per issue
+[#544](https://github.com/SYRS-AI/agent-bridge-public/issues/544) PR4
+design review.
+
 ## Migrating to layout v2
 
 The v2 layout (PR-A/B/C, shipped in v0.6.19) replaces named-ACL access on

--- a/bin/agb
+++ b/bin/agb
@@ -18,12 +18,28 @@ if [[ -n "${BRIDGE_AGENT_ENV_FILE:-}" && -r "$BRIDGE_AGENT_ENV_FILE" ]]; then
 fi
 
 # Resolve BRIDGE_HOME with two fallbacks: explicit env (preferred) > derived
-# from this shim's own location (bin/agb -> ../agb).
+# from this shim's REAL location (resolves symlinks; bin/agb -> ../agb).
+# Operators may symlink the shim from a non-standard PATH location
+# (e.g. /usr/local/bin/agb -> ${BRIDGE_HOME}/bin/agb). Without symlink
+# resolution the fallback would point at the symlink's parent and
+# `exec "$BRIDGE_HOME/agb"` would target the wrong root.
 if [[ -z "${BRIDGE_HOME:-}" ]]; then
-  _shim_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-  BRIDGE_HOME="$(cd -P "$_shim_dir/.." && pwd -P)"
+  _shim_self="${BASH_SOURCE[0]}"
+  # Walk symlinks until we hit the real file. Bounded loop guards against
+  # cycles. Portable across macOS bash 3.2 (no `readlink -f`) and Linux.
+  _shim_max_hops=16
+  while [[ -L "$_shim_self" && "$_shim_max_hops" -gt 0 ]]; do
+    _shim_link="$(readlink "$_shim_self")"
+    case "$_shim_link" in
+      /*) _shim_self="$_shim_link" ;;
+      *)  _shim_self="$(cd -P "$(dirname "$_shim_self")" 2>/dev/null && pwd -P)/$_shim_link" ;;
+    esac
+    _shim_max_hops=$(( _shim_max_hops - 1 ))
+  done
+  _shim_dir="$(cd -P "$(dirname "$_shim_self")" 2>/dev/null && pwd -P)"
+  BRIDGE_HOME="$(cd -P "$_shim_dir/.." 2>/dev/null && pwd -P)"
   export BRIDGE_HOME
-  unset _shim_dir
+  unset _shim_self _shim_link _shim_max_hops _shim_dir
 fi
 
 exec "$BRIDGE_HOME/agb" "$@"

--- a/bin/agb
+++ b/bin/agb
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Curated agb shim for isolated agents (issue #544 PR1).
+#
+# - When invoked from an isolated agent's UID with BRIDGE_AGENT_ENV_FILE in
+#   env, source it first so BRIDGE_GATEWAY_PROXY=1 / BRIDGE_HOME / sentineled
+#   BRIDGE_TASK_DB are present even in fresh non-login subshells (Bash tool
+#   subprocess re-evaluating PATH, etc.).
+# - Then exec the underlying $BRIDGE_HOME/agb script.
+#
+# Out of scope here: subcommand allowlist / denylist enforcement (issue #544
+# PR4 design). This shim is a discovery/delivery wrapper, not a policy gate.
+
+set -euo pipefail
+
+if [[ -n "${BRIDGE_AGENT_ENV_FILE:-}" && -r "$BRIDGE_AGENT_ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$BRIDGE_AGENT_ENV_FILE"
+fi
+
+# Resolve BRIDGE_HOME with two fallbacks: explicit env (preferred) > derived
+# from this shim's own location (bin/agb -> ../agb).
+if [[ -z "${BRIDGE_HOME:-}" ]]; then
+  _shim_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  BRIDGE_HOME="$(cd -P "$_shim_dir/.." && pwd -P)"
+  export BRIDGE_HOME
+  unset _shim_dir
+fi
+
+exec "$BRIDGE_HOME/agb" "$@"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -714,6 +714,24 @@ bridge_linux_grant_engine_cli_access() {
   fi
 }
 
+# Grant the isolated UID r-x on the curated $BRIDGE_HOME/bin directory and
+# the agb shim inside it (issue #544 PR1). Mirrors the engine-cli grant:
+# best-effort, idempotent, and re-applied via `agent-bridge isolate <agent>
+# --reapply`. PATH injection happens in bridge_write_linux_agent_env_file.
+#
+# Out of scope: broader subcommand allowlist/denylist enforcement (issue
+# #544 PR4 design). This helper is a discovery/delivery grant only.
+bridge_linux_grant_bin_dir_access() {
+  local os_user="$1"
+  local bin_dir="$BRIDGE_HOME/bin"
+  [[ -n "$os_user" ]] || return 0
+  [[ -d "$bin_dir" ]] || return 0
+  bridge_linux_acl_add "u:${os_user}:r-x" "$bin_dir" >/dev/null 2>&1 || true
+  if [[ -e "$bin_dir/agb" ]]; then
+    bridge_linux_acl_add "u:${os_user}:r-x" "$bin_dir/agb" >/dev/null 2>&1 || true
+  fi
+}
+
 bridge_linux_traverse_stop_for() {
   # Return a safe stop_path for traversing ancestors of $target. Prefers
   # the operator's home when $target sits under it (that's the case that
@@ -2504,14 +2522,24 @@ EOF
   # would die with "command not found". Resolving on every start picks up
   # CLI upgrades automatically; the matching ACL grant lives in
   # bridge_linux_grant_engine_cli_access (one-shot at isolate time).
-  if [[ "$isolation_mode" == "linux-user" && -n "$engine" ]]; then
-    local _engine_cli _engine_dir
-    _engine_cli="$(bridge_resolve_engine_cli "$engine" 2>/dev/null || printf '')"
-    if [[ -n "$_engine_cli" ]]; then
-      _engine_dir="$(dirname "$_engine_cli")"
-      printf '\nexport PATH=%s:"${PATH:-/usr/local/bin:/usr/bin:/bin}"\n' \
-        "$(printf '%q' "$_engine_dir")" >>"$file"
+  if [[ "$isolation_mode" == "linux-user" ]]; then
+    if [[ -n "$engine" ]]; then
+      local _engine_cli _engine_dir
+      _engine_cli="$(bridge_resolve_engine_cli "$engine" 2>/dev/null || printf '')"
+      if [[ -n "$_engine_cli" ]]; then
+        _engine_dir="$(dirname "$_engine_cli")"
+        printf '\nexport PATH=%s:"${PATH:-/usr/local/bin:/usr/bin:/bin}"\n' \
+          "$(printf '%q' "$_engine_dir")" >>"$file"
+      fi
     fi
+    # Curated bridge bin dir (issue #544 PR1). Lets the isolated UID call
+    # `agb` bare from a Bash tool subprocess. Only the curated shim at
+    # ${BRIDGE_HOME}/bin/agb is exposed here — broader agent-bridge
+    # subcommand surface stays gated behind PR4's default-deny design.
+    # Matching ACL grant lives in bridge_linux_grant_bin_dir_access
+    # (one-shot at isolate time).
+    printf '\nexport PATH=%s:"${PATH:-/usr/local/bin:/usr/bin:/bin}"\n' \
+      "$(printf '%q' "$BRIDGE_HOME/bin")" >>"$file"
   fi
   chmod 600 "$file"
   # PR-E: in v2 mode, replace the named-user ACL grant pair with a
@@ -2854,6 +2882,7 @@ bridge_linux_prepare_agent_isolation() {
   done
   shopt -u nullglob
   bridge_linux_grant_engine_cli_access "$os_user" "$(bridge_agent_engine "$agent")"
+  bridge_linux_grant_bin_dir_access "$os_user"
   bridge_linux_grant_claude_credentials_access "$os_user" "$user_home" "$controller_user" "$(bridge_agent_engine "$agent")"
   bridge_linux_acl_add_recursive "u:${os_user}:r-X" "${recursive_read_paths[@]}"
   bridge_linux_acl_add_recursive "u:${os_user}:rwX" "${recursive_write_paths[@]}"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle
 }
 
 add_all_integration() {
@@ -217,9 +217,15 @@ select_for_path() {
       ;;
 
     lib/bridge-isolation*.sh|lib/bridge-migration.sh|bridge-migrate.sh|tests/isolation*)
-      add_required isolation launch
+      add_required isolation isolated-bin-agb launch
       add_integration integration-minimal
       add_live live-tmux-daemon
+      ;;
+
+    bin/agb|bin/*)
+      # Issue #544 PR1 — curated bin/ shim for isolated agents.
+      add_required isolated-bin-agb isolation launch
+      add_integration integration-minimal
       ;;
 
     scripts/apply-channel-policy.sh|lib/bridge-channels.sh|lib/bridge-discord.sh|bridge-discord-relay.sh|bridge-notify.sh|runtime-templates/*)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10198,6 +10198,7 @@ bash "$REPO_ROOT/scripts/smoke/cron-migrate-payloads.sh"
 
 # Issue #544 PR1 — curated bin/agb shim for isolated agents.
 log "running isolated-bin-agb smoke (issue #544 PR1)"
+log "isolated-bin-agb covers shim env-source/delegation/fallback only — live PATH injection requires isolate+restart"
 bash "$REPO_ROOT/scripts/smoke/isolated-bin-agb.sh"
 
 log "smoke test passed"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -203,9 +203,9 @@ done
 [[ -n "$BASH4_BIN" ]] || die "missing bash 4+ interpreter"
 
 log "linting shell entry points"
-"$BASH4_BIN" -n "$REPO_ROOT"/*.sh "$REPO_ROOT"/agent-bridge "$REPO_ROOT"/agb "$REPO_ROOT"/scripts/smoke-test.sh
+"$BASH4_BIN" -n "$REPO_ROOT"/*.sh "$REPO_ROOT"/agent-bridge "$REPO_ROOT"/agb "$REPO_ROOT"/bin/agb "$REPO_ROOT"/scripts/smoke-test.sh
 if command -v shellcheck >/dev/null 2>&1; then
-  shellcheck "$REPO_ROOT"/*.sh "$REPO_ROOT"/agent-bridge "$REPO_ROOT"/agb "$REPO_ROOT"/scripts/smoke-test.sh "$REPO_ROOT"/agent-roster.local.example.sh
+  shellcheck "$REPO_ROOT"/*.sh "$REPO_ROOT"/agent-bridge "$REPO_ROOT"/agb "$REPO_ROOT"/bin/agb "$REPO_ROOT"/scripts/smoke-test.sh "$REPO_ROOT"/agent-roster.local.example.sh
 else
   log "shellcheck not installed; skipping"
 fi
@@ -10195,5 +10195,9 @@ bash "$REPO_ROOT/scripts/test-stale-resume.sh"
 # Issue #541 PR-A — memory-daily payload jsonl-aware migration regression.
 log "running cron-migrate-payloads smoke (issue #541 PR-A)"
 bash "$REPO_ROOT/scripts/smoke/cron-migrate-payloads.sh"
+
+# Issue #544 PR1 — curated bin/agb shim for isolated agents.
+log "running isolated-bin-agb smoke (issue #544 PR1)"
+bash "$REPO_ROOT/scripts/smoke/isolated-bin-agb.sh"
 
 log "smoke test passed"

--- a/scripts/smoke/isolated-bin-agb.sh
+++ b/scripts/smoke/isolated-bin-agb.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# scripts/smoke/isolated-bin-agb.sh — Issue #544 PR1 smoke.
+#
+# Validates the curated bin/agb shim that lets isolated agents call `agb`
+# bare from a Bash tool subprocess. Three assertions:
+#
+# 1. The shim auto-sources BRIDGE_AGENT_ENV_FILE before delegating, so
+#    flags emitted into the env file (BRIDGE_GATEWAY_PROXY=1, custom
+#    BRIDGE_TASK_DB, peer-id arrays, etc.) reach the resulting agb
+#    invocation even from a fresh non-login subshell.
+# 2. The shim exec's the underlying ${BRIDGE_HOME}/agb script, not some
+#    other agb on PATH.
+# 3. The shim exits non-zero (bubbled from the underlying agb) when the
+#    delegate fails — i.e. it doesn't swallow the exit code.
+
+set -euo pipefail
+
+SMOKE_NAME="isolated-bin-agb"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+build_fixture() {
+  smoke_make_temp_root "$SMOKE_NAME"
+  FIXTURE_HOME="$SMOKE_TMP_ROOT/bridge-home"
+  mkdir -p "$FIXTURE_HOME/bin"
+  # Copy the real shim from the source tree we're testing.
+  cp "$SMOKE_REPO_ROOT/bin/agb" "$FIXTURE_HOME/bin/agb"
+  chmod +x "$FIXTURE_HOME/bin/agb"
+
+  # Stand in a stub root agb that just records its env + argv to a file
+  # so we can introspect what the shim handed it. The real
+  # ${BRIDGE_HOME}/agb just exec's agent-bridge; for this smoke we only
+  # care that the shim delegates to *this* path with the env preserved.
+  STUB_LOG="$SMOKE_TMP_ROOT/stub-agb.log"
+  cat >"$FIXTURE_HOME/agb" <<EOF
+#!/usr/bin/env bash
+{
+  printf 'argv:%s\n' "\$*"
+  printf 'BRIDGE_HOME=%s\n' "\${BRIDGE_HOME:-<unset>}"
+  printf 'BRIDGE_GATEWAY_PROXY=%s\n' "\${BRIDGE_GATEWAY_PROXY:-<unset>}"
+  printf 'TEST_ENV_MARKER=%s\n' "\${TEST_ENV_MARKER:-<unset>}"
+  printf 'STUB_AGB_PATH=%s\n' "\$0"
+} >>"$STUB_LOG"
+exit "\${STUB_EXIT_CODE:-0}"
+EOF
+  chmod +x "$FIXTURE_HOME/agb"
+
+  # Fixture env file the shim must auto-source. Mirrors the shape
+  # bridge_write_linux_agent_env_file emits for isolated agents.
+  AGENT_ENV_FILE="$FIXTURE_HOME/agent-env.sh"
+  cat >"$AGENT_ENV_FILE" <<EOF
+export BRIDGE_HOME="$FIXTURE_HOME"
+export BRIDGE_GATEWAY_PROXY=1
+export TEST_ENV_MARKER=isolated-bin-agb-smoke
+EOF
+  chmod 600 "$AGENT_ENV_FILE"
+}
+
+assert_shim_sources_env_and_delegates() {
+  : >"$STUB_LOG"
+  # Run the shim from a fresh subshell that has BRIDGE_AGENT_ENV_FILE set
+  # but no BRIDGE_HOME / BRIDGE_GATEWAY_PROXY / TEST_ENV_MARKER — the shim
+  # must source the env file to get them.
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    BRIDGE_AGENT_ENV_FILE="$AGENT_ENV_FILE" \
+    bash "$FIXTURE_HOME/bin/agb" smoke-arg-1 smoke-arg-2
+
+  smoke_assert_file_exists "$STUB_LOG" "stub agb invocation log written"
+  local out
+  out="$(cat "$STUB_LOG")"
+  smoke_assert_contains "$out" "argv:smoke-arg-1 smoke-arg-2" \
+    "shim forwards positional arguments verbatim"
+  smoke_assert_contains "$out" "BRIDGE_HOME=$FIXTURE_HOME" \
+    "shim exports BRIDGE_HOME from the sourced env file"
+  smoke_assert_contains "$out" "BRIDGE_GATEWAY_PROXY=1" \
+    "shim propagates BRIDGE_GATEWAY_PROXY=1 from the env file"
+  smoke_assert_contains "$out" "TEST_ENV_MARKER=isolated-bin-agb-smoke" \
+    "shim sources arbitrary env-file exports"
+  smoke_assert_contains "$out" "STUB_AGB_PATH=$FIXTURE_HOME/agb" \
+    "shim exec's the underlying \${BRIDGE_HOME}/agb (not some PATH lookup)"
+}
+
+assert_shim_works_without_env_file() {
+  : >"$STUB_LOG"
+  # When BRIDGE_AGENT_ENV_FILE is unset (operator-side invocation, no
+  # isolation), the shim must still exec the underlying agb. BRIDGE_HOME
+  # falls back to the shim's own ../ directory.
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    bash "$FIXTURE_HOME/bin/agb" plain-arg
+
+  smoke_assert_file_exists "$STUB_LOG" "stub agb log written for env-less invocation"
+  local out
+  out="$(cat "$STUB_LOG")"
+  smoke_assert_contains "$out" "argv:plain-arg" \
+    "shim forwards args even with no env file present"
+  smoke_assert_contains "$out" "BRIDGE_HOME=$FIXTURE_HOME" \
+    "shim derives BRIDGE_HOME from its own location when env unset"
+  smoke_assert_contains "$out" "STUB_AGB_PATH=$FIXTURE_HOME/agb" \
+    "shim still delegates to the sibling agb when env unset"
+}
+
+assert_shim_propagates_exit_code() {
+  : >"$STUB_LOG"
+  local rc=0
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    BRIDGE_AGENT_ENV_FILE="$AGENT_ENV_FILE" \
+    STUB_EXIT_CODE=42 \
+    bash "$FIXTURE_HOME/bin/agb" failing-call \
+    || rc=$?
+  smoke_assert_eq "42" "$rc" \
+    "shim propagates underlying agb exit code (no swallow)"
+}
+
+main() {
+  build_fixture
+
+  smoke_run "shim sources env file and delegates" \
+    assert_shim_sources_env_and_delegates
+  smoke_run "shim works without env file" \
+    assert_shim_works_without_env_file
+  smoke_run "shim propagates exit code" \
+    assert_shim_propagates_exit_code
+
+  smoke_log "PASS"
+}
+
+main "$@"

--- a/scripts/smoke/isolated-bin-agb.sh
+++ b/scripts/smoke/isolated-bin-agb.sh
@@ -12,6 +12,15 @@
 #    other agb on PATH.
 # 3. The shim exits non-zero (bubbled from the underlying agb) when the
 #    delegate fails — i.e. it doesn't swallow the exit code.
+#
+# Coverage: shim env-source ordering, exec delegation, BRIDGE_HOME fallback
+# derivation (including symlinked invocation). Does NOT exercise:
+#   - live `bridge_write_linux_agent_env_file` PATH injection (requires
+#     `agent-bridge isolate <agent>` against a real linux-user UID).
+#   - live ACL access from the isolated UID to ${BRIDGE_HOME}/bin
+#     (requires sudo + named-user ACL on a Linux host).
+# End-to-end coverage is operator-side via OPERATIONS.md migration step
+# (`agent-bridge isolate <agent> --reapply` + agent restart).
 
 set -euo pipefail
 

--- a/scripts/smoke/isolated-bin-agb.sh
+++ b/scripts/smoke/isolated-bin-agb.sh
@@ -132,6 +132,40 @@ assert_shim_propagates_exit_code() {
     "shim propagates underlying agb exit code (no swallow)"
 }
 
+assert_shim_resolves_symlinked_invocation() {
+  : >"$STUB_LOG"
+  # Operators may symlink the shim from a non-standard PATH location
+  # (e.g. /usr/local/bin/agb -> ${BRIDGE_HOME}/bin/agb). When invoked via
+  # such a symlink with BRIDGE_HOME unset, the shim must walk the symlink
+  # back to its real parent and derive the underlying $BRIDGE_HOME/agb
+  # from there — not from the symlink's directory.
+  #
+  # macOS TMPDIR is itself a /var -> /private/var symlink, so the
+  # fixture path must be canonicalized via `cd -P && pwd -P` before
+  # comparing against what the shim's own resolution emits.
+  local fixture_real
+  fixture_real="$(cd -P "$FIXTURE_HOME" && pwd -P)"
+  mkdir -p "$FIXTURE_HOME/symlink"
+  ln -sf "$FIXTURE_HOME/bin/agb" "$FIXTURE_HOME/symlink/agb"
+
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    bash "$FIXTURE_HOME/symlink/agb" symlink-arg
+
+  smoke_assert_file_exists "$STUB_LOG" "stub agb log written for symlinked invocation"
+  local out
+  out="$(cat "$STUB_LOG")"
+  smoke_assert_contains "$out" "argv:symlink-arg" \
+    "shim forwards args when invoked via symlink"
+  smoke_assert_contains "$out" "BRIDGE_HOME=$fixture_real" \
+    "shim resolves BRIDGE_HOME through the symlink to the real parent"
+  smoke_assert_contains "$out" "STUB_AGB_PATH=$FIXTURE_HOME/agb" \
+    "shim delegates to the real sibling agb (not symlink-dir/agb)"
+  smoke_assert_not_contains "$out" "BRIDGE_HOME=$FIXTURE_HOME/symlink" \
+    "shim does NOT use the symlink directory as BRIDGE_HOME"
+}
+
 main() {
   build_fixture
 
@@ -141,6 +175,8 @@ main() {
     assert_shim_works_without_env_file
   smoke_run "shim propagates exit code" \
     assert_shim_propagates_exit_code
+  smoke_run "shim resolves symlinked invocation to real BRIDGE_HOME" \
+    assert_shim_resolves_symlinked_invocation
 
   smoke_log "PASS"
 }


### PR DESCRIPTION
## Summary
- New `bin/agb` shim: sources `BRIDGE_AGENT_ENV_FILE` (when present) and exec's `${BRIDGE_HOME}/agb`. Lets isolated agents call `agb` bare from any Bash tool subprocess, including fresh non-login shells where rcfiles aren't reliably read.
- `lib/bridge-agents.sh` env-file generator now prepends `${BRIDGE_HOME}/bin` to PATH for `isolation_mode=linux-user` agents, alongside the existing engine CLI dir.
- ACL grant: isolated UID gets r-x on `bin/` and `bin/agb` (best-effort, mirrors `bridge_linux_grant_engine_cli_access` pattern; idempotent under `agent-bridge isolate <agent> --reapply`).
- `OPERATIONS.md` documents the post-upgrade `--reapply` migration step for existing isolated agents.
- New smoke `scripts/smoke/isolated-bin-agb.sh` asserts the shim env-sourcing, `${BRIDGE_HOME}/agb` delegation, and exit-code propagation. Wired into both `scripts/smoke-test.sh` (canonical local CI) and `scripts/ci-select-smoke.sh` (selected on isolation/agents/bin path changes).

## Why option B (curated bin/) over option A (full BRIDGE_HOME on PATH)
Option A would expose every `bridge-*.sh` / `bridge-*.py` root script to direct invocation by an isolated UID's Bash tool. Issue #544 PR4 explicitly defers the broader subcommand surface to a separate design review with default-deny semantics. Option B preserves that boundary: only the curated `agb` shim is reachable via PATH discovery.

## Out of scope (deferred)
- PR2 (settings.json hooks rendering for isolated home) — separate brief.
- PR3 (skills sync + path normalization) — separate brief.
- PR4 (subcommand allowlist/denylist + audit) — separate design review.
- No VERSION/CHANGELOG bump.

## Test plan
- [x] `bash -n` + `shellcheck` on touched files (bin/agb, lib/bridge-agents.sh, scripts/smoke/isolated-bin-agb.sh, scripts/ci-select-smoke.sh, scripts/smoke-test.sh) — clean.
- [x] `bin/agb` executable, correct shebang, delegates to `$BRIDGE_HOME/agb`.
- [x] `bash scripts/smoke/isolated-bin-agb.sh` PASS (3 assertions: env-source + delegation + exit-code propagation).
- [ ] Maintainer: live `agent-bridge isolate <agent> --reapply` then `agent-bridge agent restart <agent>` -> confirm isolated Bash subprocess can run `agb inbox <self>` bare.

Refs #544