### PR TITLE
fix(isolate): rebuild per-agent marketplace catalog

### DIFF
--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -100,6 +100,13 @@ def root_marketplace_name(root: Path) -> str:
     return name
 
 
+def is_marketplace_manifest_readable(root: Path) -> bool:
+    try:
+        return marketplace_path(root).is_file()
+    except OSError:
+        return False
+
+
 def resolve_marketplace_root(default_root: Path, channel: str) -> Path:
     marketplace = channel_marketplace(channel)
     if not marketplace:
@@ -129,7 +136,7 @@ def resolve_marketplace_root(default_root: Path, channel: str) -> Path:
 
     candidates.append(plugins_root / "marketplaces" / marketplace)
     for candidate in candidates:
-        if marketplace_path(candidate).is_file():
+        if is_marketplace_manifest_readable(candidate):
             return candidate.resolve()
     return default_root
 

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -26,6 +26,20 @@ def cache_root() -> Path:
     return Path.home() / ".claude" / "plugins" / "cache"
 
 
+def claude_plugins_root() -> Path:
+    explicit = os.environ.get("BRIDGE_CLAUDE_PLUGINS_ROOT", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    root = cache_root()
+    if root.name == "cache":
+        return root.parent
+    return Path.home() / ".claude" / "plugins"
+
+
+def known_marketplaces_path() -> Path:
+    return claude_plugins_root() / "known_marketplaces.json"
+
+
 def normalize_channels(raw: str) -> list[str]:
     items: list[str] = []
     seen: set[str] = set()
@@ -56,6 +70,70 @@ def load_marketplace(root: Path) -> tuple[str, dict[str, dict[str, str]]]:
     return marketplace_name, plugins
 
 
+def marketplace_repo_slug(repo: str) -> str:
+    repo = repo.strip().strip("/")
+    if not repo or "/" not in repo:
+        return ""
+    return repo.replace("/", "-")
+
+
+def load_known_marketplaces() -> dict[str, object]:
+    path = known_marketplaces_path()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def channel_marketplace(channel: str) -> str:
+    if not channel.startswith("plugin:") or "@" not in channel:
+        return ""
+    return channel[len("plugin:") :].split("@", 1)[1].strip()
+
+
+def root_marketplace_name(root: Path) -> str:
+    try:
+        name, _plugins = load_marketplace(root)
+    except (OSError, ValueError, SystemExit):
+        return ""
+    return name
+
+
+def resolve_marketplace_root(default_root: Path, channel: str) -> Path:
+    marketplace = channel_marketplace(channel)
+    if not marketplace:
+        return default_root
+    if root_marketplace_name(default_root) == marketplace:
+        return default_root
+
+    markets = load_known_marketplaces()
+    entry = markets.get(marketplace)
+    if not isinstance(entry, dict):
+        return default_root
+
+    plugins_root = claude_plugins_root()
+    candidates: list[Path] = []
+    install_location = str(entry.get("installLocation") or "").strip()
+    if install_location:
+        candidates.append(Path(install_location).expanduser())
+
+    source = entry.get("source")
+    if isinstance(source, dict):
+        source_path = str(source.get("path") or "").strip()
+        if source_path:
+            candidates.append(Path(source_path).expanduser())
+        repo_slug = marketplace_repo_slug(str(source.get("repo") or ""))
+        if repo_slug:
+            candidates.append(plugins_root / "marketplaces" / repo_slug)
+
+    candidates.append(plugins_root / "marketplaces" / marketplace)
+    for candidate in candidates:
+        if marketplace_path(candidate).is_file():
+            return candidate.resolve()
+    return default_root
+
+
 def remove_tree(path: Path) -> None:
     if path.is_symlink() or path.is_file():
         path.unlink(missing_ok=True)
@@ -65,11 +143,97 @@ def remove_tree(path: Path) -> None:
 
 
 NODE_MODULES_NAME = "node_modules"
+MCP_CONFIG_NAME = ".mcp.json"
+SENSITIVE_KEY_PARTS = (
+    "authorization",
+    "api_key",
+    "apikey",
+    "app_password",
+    "client_secret",
+    "password",
+    "secret",
+    "token",
+)
+
+
+def is_sensitive_key(key: str) -> bool:
+    lowered = key.lower().replace("-", "_")
+    return any(part in lowered for part in SENSITIVE_KEY_PARTS)
+
+
+def is_placeholder_secret(value: str) -> bool:
+    stripped = value.strip()
+    upper = stripped.upper()
+    return (
+        "PLACEHOLDER" in upper
+        or upper in {"REDACTED", "<REDACTED>"}
+        or stripped.startswith("__")
+        and stripped.endswith("__")
+    )
+
+
+def merge_secret_placeholders(source: object, current: object, sensitive: bool = False) -> tuple[object, bool]:
+    if isinstance(source, dict) and isinstance(current, dict):
+        changed = False
+        merged: dict[str, object] = {}
+        for key, value in source.items():
+            next_sensitive = sensitive or is_sensitive_key(str(key))
+            if key in current:
+                merged_value, item_changed = merge_secret_placeholders(value, current[key], next_sensitive)
+                merged[key] = merged_value
+                changed = changed or item_changed
+            else:
+                merged[key] = value
+        return merged, changed
+
+    if isinstance(source, list) and isinstance(current, list):
+        changed = False
+        merged = []
+        for idx, value in enumerate(source):
+            if idx < len(current):
+                merged_value, item_changed = merge_secret_placeholders(value, current[idx], sensitive)
+                merged.append(merged_value)
+                changed = changed or item_changed
+            else:
+                merged.append(value)
+        return merged, changed
+
+    if (
+        sensitive
+        and isinstance(source, str)
+        and isinstance(current, str)
+        and is_placeholder_secret(source)
+        and current.strip()
+        and not is_placeholder_secret(current)
+    ):
+        return current, True
+
+    return source, False
+
+
+def maybe_render_mcp_with_preserved_secrets(src: Path, dst: Path) -> bytes | None:
+    if src.name != MCP_CONFIG_NAME or not dst.is_file() or dst.is_symlink():
+        return None
+    try:
+        source_payload = json.loads(src.read_text(encoding="utf-8"))
+        current_payload = json.loads(dst.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    merged, changed = merge_secret_placeholders(source_payload, current_payload)
+    if not changed:
+        return None
+    return (json.dumps(merged, ensure_ascii=False, indent=2) + "\n").encode("utf-8")
 
 
 def _copy_file_if_changed(src: Path, dst: Path) -> bool:
     """Copy file from src to dst when missing or content differs. Returns True if written."""
     try:
+        rendered = maybe_render_mcp_with_preserved_secrets(src, dst)
+        if rendered is not None:
+            if dst.read_bytes() == rendered:
+                return False
+            dst.write_bytes(rendered)
+            return True
         if dst.is_symlink() or dst.is_file():
             if dst.is_file() and not dst.is_symlink():
                 if dst.stat().st_size == src.stat().st_size and dst.read_bytes() == src.read_bytes():
@@ -244,7 +408,10 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     root = Path(args.root).expanduser().resolve()
-    results = [sync_plugin_cache(root, item) for item in normalize_channels(args.channels)]
+    results = [
+        sync_plugin_cache(resolve_marketplace_root(root, item), item)
+        for item in normalize_channels(args.channels)
+    ]
     if args.json:
         json.dump({"results": results}, sys.stdout, ensure_ascii=False)
         sys.stdout.write("\n")

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -148,7 +148,15 @@ def marketplace_repo_slug(repo: str) -> str:
 # alias that escapes the marketplaces/ namespace is a privilege-escalation
 # surface. Reject loudly rather than silently sanitising — a rejected
 # input means an upstream catalog/config bug we want surfaced.
-_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+#
+# Use `re.fullmatch` (not `re.match(... + "$")`): in Python's default
+# (non-MULTILINE) mode, `$` matches at the end-of-string AND just before
+# a trailing newline. That means `re.match(r"^[A-Za-z0-9._-]+$", "foo\n")`
+# returns a match — letting an alias with a trailing newline slip past
+# the safety regex. `fullmatch` requires the pattern to consume the
+# entire string (no implicit trailing-`\n` allowance), which is the
+# semantic the privilege-escalation gate needs.
+_SAFE_ALIAS_RE = re.compile(r"[A-Za-z0-9._-]+")
 _ALIAS_RESERVED_NAMES = {".", ".."}
 _ALIAS_WINDOWS_RESERVED = (
     {"CON", "PRN", "AUX", "NUL"}
@@ -165,7 +173,7 @@ def _alias_rejection_reason(alias: object) -> str:
         return "empty"
     if len(alias) > 200:
         return f"length {len(alias)} exceeds 200"
-    if not _SAFE_ALIAS_RE.match(alias):
+    if not _SAFE_ALIAS_RE.fullmatch(alias):
         return "contains characters outside [A-Za-z0-9._-]"
     if ".." in alias:
         return "contains '..'"
@@ -212,12 +220,41 @@ def is_marketplace_manifest_readable(root: Path) -> bool:
         return False
 
 
+def _require_safe_path_component(value: str, *, role: str, context: str) -> None:
+    """Fail loud when a value about to become a path component is unsafe.
+
+    Mirrors the contract of `bridge_isolation_alias_rejection_reason` in
+    lib/bridge-agents.sh: any path component that escapes the documented
+    safe-alias namespace can plant a symlink/dir outside the
+    intended root, so we refuse rather than silently sanitising.
+    Raises ValueError with a concrete reason — callers higher up surface
+    this through `bridge_die`-equivalent logging or let it propagate to
+    the operator.
+    """
+    reason = _alias_rejection_reason(value)
+    if reason:
+        raise ValueError(
+            f"[bridge-dev-plugin-cache] refusing unsafe {role} {value!r} "
+            f"(context: {context}): {reason}"
+        )
+
+
 def resolve_marketplace_root(default_root: Path, channel: str) -> Path:
     marketplace = channel_marketplace(channel)
     if not marketplace:
         return default_root
     if root_marketplace_name(default_root) == marketplace:
         return default_root
+
+    # Defense-in-depth: marketplace was extracted from the channel string
+    # (`plugin:<name>@<marketplace>`) and is about to be joined into a
+    # filesystem path under `<plugins_root>/marketplaces/<marketplace>`.
+    # The bash side validates this before the catalog write, but the dev-
+    # cache pipeline reaches here independently — keep the gate explicit.
+    _require_safe_path_component(
+        marketplace, role="marketplace id",
+        context=f"resolve_marketplace_root channel={channel!r}",
+    )
 
     markets = load_known_marketplaces()
     entry = markets.get(marketplace)
@@ -237,6 +274,13 @@ def resolve_marketplace_root(default_root: Path, channel: str) -> Path:
             candidates.append(Path(source_path).expanduser())
         repo_slug = marketplace_repo_slug(str(source.get("repo") or ""))
         if repo_slug:
+            # `repo_slug` derives from operator-controlled known_marketplaces.json
+            # source.repo (org/name); validate before joining so a poisoned slug
+            # cannot land us at `<plugins_root>/marketplaces/../foo`.
+            _require_safe_path_component(
+                repo_slug, role="repo slug",
+                context=f"resolve_marketplace_root marketplace={marketplace!r}",
+            )
             candidates.append(plugins_root / "marketplaces" / repo_slug)
 
     candidates.append(plugins_root / "marketplaces" / marketplace)
@@ -448,6 +492,25 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             "status": "missing",
             "reason": f"source-missing:{source_path}",
         }
+
+    # Defense-in-depth: every component about to be joined into the
+    # cache path is operator/marketplace-controlled (marketplace.json,
+    # channel string). Validate before `cache_root() / mkt / plug / ver`
+    # so an unsafe component (newline, `..`, slash) cannot escape the
+    # cache root via path traversal — fail loud rather than silently
+    # caching to a poisoned path.
+    _require_safe_path_component(
+        marketplace_name, role="marketplace name",
+        context=f"sync_plugin_cache channel={channel!r}",
+    )
+    _require_safe_path_component(
+        plugin_name, role="plugin name",
+        context=f"sync_plugin_cache channel={channel!r}",
+    )
+    _require_safe_path_component(
+        str(version), role="plugin version",
+        context=f"sync_plugin_cache channel={channel!r}",
+    )
 
     plugin_cache_root = cache_root() / marketplace_name / plugin_name
     cache_version_path = plugin_cache_root / version

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -70,11 +71,115 @@ def load_marketplace(root: Path) -> tuple[str, dict[str, dict[str, str]]]:
     return marketplace_name, plugins
 
 
+# Mirrored in lib/bridge-agents.sh (`bridge_known_marketplace_info` and
+# `bridge_write_isolated_known_marketplaces_catalog`). Any change to the
+# accepted forms or the produced slug must be applied to both, otherwise
+# the bash side and the Python side will disagree on the alias for the
+# same source and Claude will fail to resolve the marketplace.
+_GITHUB_URL_PREFIXES = (
+    "https://github.com/",
+    "http://github.com/",
+    "git://github.com/",
+)
+_GITHUB_SSH_PREFIX = "git@github.com:"
+
+
+def _github_repo_slug(source: str) -> str:
+    """Return an `<org>-<repo>` alias when source names a GitHub repo.
+
+    Accepted forms:
+        https://github.com/<org>/<repo>          → <org>-<repo>
+        https://github.com/<org>/<repo>.git      → <org>-<repo>
+        git@github.com:<org>/<repo>.git          → <org>-<repo>
+        <org>/<repo>                             → <org>-<repo>
+        <org>/<repo>.git                         → <org>-<repo>
+
+    Non-GitHub URLs (`https://gitlab.com/...`, `git@example.com:...`,
+    archive URLs, paths) return "" so the caller can fall back to the
+    simple slugify or skip aliasing entirely.
+    """
+    s = (source or "").strip()
+    if not s:
+        return ""
+    lowered = s.lower()
+    matched_prefix = ""
+    for prefix in _GITHUB_URL_PREFIXES:
+        if lowered.startswith(prefix):
+            matched_prefix = prefix
+            break
+    if matched_prefix:
+        s = s[len(matched_prefix):]
+    elif lowered.startswith(_GITHUB_SSH_PREFIX):
+        s = s[len(_GITHUB_SSH_PREFIX):]
+    elif "://" in s or "@" in s.split("/", 1)[0]:
+        # Looks like a URL or SSH spec but not GitHub — refuse rather
+        # than producing a slug like `https:-gitlab.com`.
+        return ""
+    elif s.startswith("/"):
+        # Looks like a filesystem path (`/local/path/...`) — refuse so
+        # the simple-slugify fallback handles the path-style input
+        # rather than producing a misleading `<root>-<dir>` alias.
+        return ""
+    s = s.strip().strip("/")
+    if s.endswith(".git"):
+        s = s[: -len(".git")]
+    parts = [p for p in s.split("/") if p]
+    if len(parts) < 2:
+        return ""
+    org, repo = parts[0], parts[1]
+    if not org or not repo:
+        return ""
+    return f"{org}-{repo}"
+
+
 def marketplace_repo_slug(repo: str) -> str:
-    repo = repo.strip().strip("/")
+    """Back-compat shim: prefer GitHub-aware parsing, then bare org/repo."""
+    slug = _github_repo_slug(repo)
+    if slug:
+        return slug
+    repo = (repo or "").strip().strip("/")
     if not repo or "/" not in repo:
         return ""
     return repo.replace("/", "-")
+
+
+# Mirrored in lib/bridge-agents.sh. Aliases land under
+# `<plugins_root>/marketplaces/<alias>` as root-owned symlinks, so any
+# alias that escapes the marketplaces/ namespace is a privilege-escalation
+# surface. Reject loudly rather than silently sanitising — a rejected
+# input means an upstream catalog/config bug we want surfaced.
+_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_ALIAS_RESERVED_NAMES = {".", ".."}
+_ALIAS_WINDOWS_RESERVED = (
+    {"CON", "PRN", "AUX", "NUL"}
+    | {f"COM{i}" for i in range(1, 10)}
+    | {f"LPT{i}" for i in range(1, 10)}
+)
+
+
+def _alias_rejection_reason(alias: object) -> str:
+    """Return an empty string when alias is safe, else a human-readable reason."""
+    if not isinstance(alias, str):
+        return f"not a string ({type(alias).__name__})"
+    if alias == "":
+        return "empty"
+    if len(alias) > 200:
+        return f"length {len(alias)} exceeds 200"
+    if not _SAFE_ALIAS_RE.match(alias):
+        return "contains characters outside [A-Za-z0-9._-]"
+    if ".." in alias:
+        return "contains '..'"
+    if alias in _ALIAS_RESERVED_NAMES:
+        return f"reserved name '{alias}'"
+    if alias.upper() in _ALIAS_WINDOWS_RESERVED:
+        return f"reserved Windows name '{alias}'"
+    if alias.startswith(".") and alias != ".git":
+        return f"leading dot disallowed ('{alias}')"
+    return ""
+
+
+def _is_safe_alias(alias: object) -> bool:
+    return _alias_rejection_reason(alias) == ""
 
 
 def load_known_marketplaces() -> dict[str, object]:

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1421,6 +1421,64 @@ print("present:other")
 PY
 }
 
+bridge_isolation_alias_rejection_reason() {
+  # Bash-side mirror of `_alias_rejection_reason` in
+  # bridge-dev-plugin-cache.py. Returns the empty string on stdout when
+  # the alias is safe to plant as a `marketplaces/<alias>` symlink under
+  # the isolated home (root is the writer, so an unsafe alias is a
+  # privilege-escalation surface). Otherwise prints a short reason.
+  #
+  # Acceptance criteria (must match the Python helpers):
+  #   - non-empty, length <= 200
+  #   - matches ^[A-Za-z0-9._-]+$ (no slash, no control char, no whitespace)
+  #   - does not contain '..'
+  #   - not '.' / '..'
+  #   - not a Windows reserved name (CON/PRN/AUX/NUL/COM1-9/LPT1-9)
+  #   - if it starts with '.', must equal '.git'
+  local alias="$1"
+  local upper=""
+  if [[ -z "$alias" ]]; then
+    printf 'empty'
+    return 0
+  fi
+  if (( ${#alias} > 200 )); then
+    printf 'length exceeds 200'
+    return 0
+  fi
+  if ! [[ "$alias" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    printf "contains characters outside [A-Za-z0-9._-]"
+    return 0
+  fi
+  if [[ "$alias" == *..* ]]; then
+    printf "contains '..'"
+    return 0
+  fi
+  if [[ "$alias" == "." || "$alias" == ".." ]]; then
+    printf 'reserved name'
+    return 0
+  fi
+  upper="$(printf '%s' "$alias" | tr '[:lower:]' '[:upper:]')"
+  case "$upper" in
+    CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])
+      printf 'reserved Windows name'
+      return 0
+      ;;
+  esac
+  if [[ "$alias" == .* && "$alias" != ".git" ]]; then
+    printf 'leading dot disallowed'
+    return 0
+  fi
+  printf ''
+  return 0
+}
+
+bridge_isolation_alias_safe() {
+  # Convenience wrapper: returns 0 when the alias is safe, 1 otherwise.
+  local reason
+  reason="$(bridge_isolation_alias_rejection_reason "$1")"
+  [[ -z "$reason" ]]
+}
+
 bridge_known_marketplace_info() {
   # Return marketplace source information from known_marketplaces.json.
   #
@@ -1428,6 +1486,7 @@ bridge_known_marketplace_info() {
   #   present:<kind>\t<source-dir>\t<alias>[ \t<alias>...]
   #   missing
   #   unparseable
+  #   unsafe                    (alias rejected by the safe-alias validator)
   #
   # `source-dir` is the controller-side marketplace tree to expose read-only
   # to the isolated UID. Aliases include the marketplace id plus Claude Code's
@@ -1440,16 +1499,98 @@ bridge_known_marketplace_info() {
   python3 - "$marketplace_id" "$plugins_root" "$marketplaces_json" <<'PY'
 import json
 import os
+import re
 import sys
 
 marketplace_id, plugins_root, marketplaces_path = sys.argv[1:]
 
 
+# Mirror of `_github_repo_slug` in bridge-dev-plugin-cache.py. Keep the
+# accepted URL forms in sync — the bash side here and the dev-cache
+# helper must produce identical aliases for the same input or Claude
+# will land on different marketplace dirs in the controller and isolated
+# trees.
+_GITHUB_URL_PREFIXES = (
+    "https://github.com/",
+    "http://github.com/",
+    "git://github.com/",
+)
+_GITHUB_SSH_PREFIX = "git@github.com:"
+
+
+def github_repo_slug(source):
+    s = (source or "").strip()
+    if not s:
+        return ""
+    lowered = s.lower()
+    matched = ""
+    for prefix in _GITHUB_URL_PREFIXES:
+        if lowered.startswith(prefix):
+            matched = prefix
+            break
+    if matched:
+        s = s[len(matched):]
+    elif lowered.startswith(_GITHUB_SSH_PREFIX):
+        s = s[len(_GITHUB_SSH_PREFIX):]
+    elif "://" in s or "@" in s.split("/", 1)[0]:
+        # Looks like a URL or SSH spec but not GitHub — refuse rather
+        # than producing a slug like `https:-gitlab.com`.
+        return ""
+    elif s.startswith("/"):
+        # Looks like a filesystem path — refuse so the simple-slugify
+        # fallback handles the path-style input rather than producing a
+        # misleading `<root>-<dir>` alias.
+        return ""
+    s = s.strip().strip("/")
+    if s.endswith(".git"):
+        s = s[: -len(".git")]
+    parts = [p for p in s.split("/") if p]
+    if len(parts) < 2:
+        return ""
+    org, repo = parts[0], parts[1]
+    if not org or not repo:
+        return ""
+    return "%s-%s" % (org, repo)
+
+
 def repo_slug(repo):
+    slug = github_repo_slug(repo)
+    if slug:
+        return slug
     repo = (repo or "").strip().strip("/")
     if "/" not in repo:
         return ""
     return repo.replace("/", "-")
+
+
+# Mirror of `_alias_rejection_reason` in bridge-dev-plugin-cache.py.
+_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_ALIAS_RESERVED_NAMES = {".", ".."}
+_ALIAS_WINDOWS_RESERVED = (
+    {"CON", "PRN", "AUX", "NUL"}
+    | {"COM%d" % i for i in range(1, 10)}
+    | {"LPT%d" % i for i in range(1, 10)}
+)
+
+
+def alias_rejection_reason(alias):
+    if not isinstance(alias, str):
+        return "not a string"
+    if alias == "":
+        return "empty"
+    if len(alias) > 200:
+        return "length exceeds 200"
+    if not _SAFE_ALIAS_RE.match(alias):
+        return "contains characters outside [A-Za-z0-9._-]"
+    if ".." in alias:
+        return "contains '..'"
+    if alias in _ALIAS_RESERVED_NAMES:
+        return "reserved name"
+    if alias.upper() in _ALIAS_WINDOWS_RESERVED:
+        return "reserved Windows name"
+    if alias.startswith(".") and alias != ".git":
+        return "leading dot disallowed"
+    return ""
 
 
 def emit(*parts):
@@ -1484,8 +1625,17 @@ if isinstance(source, dict):
 slug = repo_slug(repo)
 aliases = []
 for item in (marketplace_id, slug):
-    if item and item not in aliases:
-        aliases.append(item)
+    if not item or item in aliases:
+        continue
+    reason = alias_rejection_reason(item)
+    if reason:
+        sys.stderr.write(
+            "[bridge-isolate] marketplace %r alias %r rejected: %s — refusing to plant unsafe symlink\n"
+            % (marketplace_id, item, reason)
+        )
+        emit("unsafe", "", "")
+        raise SystemExit(2)
+    aliases.append(item)
 
 candidates = []
 if marketplace_id:
@@ -1538,6 +1688,7 @@ bridge_write_isolated_known_marketplaces_catalog() {
 import copy
 import json
 import os
+import re
 import sys
 
 controller_plugins, isolated_plugins, channels_csv, plugins_csv, out_path = sys.argv[1:]
@@ -1548,11 +1699,94 @@ def warn(msg):
     sys.stderr.write("[bridge-isolate] " + msg + "\n")
 
 
+def fail(msg):
+    sys.stderr.write("[bridge-isolate] " + msg + "\n")
+    raise SystemExit(2)
+
+
+# Mirror of `_github_repo_slug` in bridge-dev-plugin-cache.py. Keep
+# accepted forms in sync.
+_GITHUB_URL_PREFIXES = (
+    "https://github.com/",
+    "http://github.com/",
+    "git://github.com/",
+)
+_GITHUB_SSH_PREFIX = "git@github.com:"
+
+
+def github_repo_slug(source):
+    s = (source or "").strip()
+    if not s:
+        return ""
+    lowered = s.lower()
+    matched = ""
+    for prefix in _GITHUB_URL_PREFIXES:
+        if lowered.startswith(prefix):
+            matched = prefix
+            break
+    if matched:
+        s = s[len(matched):]
+    elif lowered.startswith(_GITHUB_SSH_PREFIX):
+        s = s[len(_GITHUB_SSH_PREFIX):]
+    elif "://" in s or "@" in s.split("/", 1)[0]:
+        # Looks like a URL or SSH spec but not GitHub — refuse rather
+        # than producing a slug like `https:-gitlab.com`.
+        return ""
+    elif s.startswith("/"):
+        # Looks like a filesystem path — refuse so the simple-slugify
+        # fallback handles the path-style input rather than producing a
+        # misleading `<root>-<dir>` alias.
+        return ""
+    s = s.strip().strip("/")
+    if s.endswith(".git"):
+        s = s[: -len(".git")]
+    parts = [p for p in s.split("/") if p]
+    if len(parts) < 2:
+        return ""
+    org, repo = parts[0], parts[1]
+    if not org or not repo:
+        return ""
+    return "%s-%s" % (org, repo)
+
+
 def repo_slug(repo):
+    slug = github_repo_slug(repo)
+    if slug:
+        return slug
     repo = (repo or "").strip().strip("/")
     if "/" not in repo:
         return ""
     return repo.replace("/", "-")
+
+
+# Mirror of `_alias_rejection_reason` in bridge-dev-plugin-cache.py.
+_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_ALIAS_RESERVED_NAMES = {".", ".."}
+_ALIAS_WINDOWS_RESERVED = (
+    {"CON", "PRN", "AUX", "NUL"}
+    | {"COM%d" % i for i in range(1, 10)}
+    | {"LPT%d" % i for i in range(1, 10)}
+)
+
+
+def alias_rejection_reason(alias):
+    if not isinstance(alias, str):
+        return "not a string"
+    if alias == "":
+        return "empty"
+    if len(alias) > 200:
+        return "length exceeds 200"
+    if not _SAFE_ALIAS_RE.match(alias):
+        return "contains characters outside [A-Za-z0-9._-]"
+    if ".." in alias:
+        return "contains '..'"
+    if alias in _ALIAS_RESERVED_NAMES:
+        return "reserved name"
+    if alias.upper() in _ALIAS_WINDOWS_RESERVED:
+        return "reserved Windows name"
+    if alias.startswith(".") and alias != ".git":
+        return "leading dot disallowed"
+    return ""
 
 
 def marketplace_source_info(marketplace, entry):
@@ -1603,16 +1837,56 @@ except (OSError, ValueError) as exc:
 
 out = {}
 marketplaces_root = os.path.join(isolated_plugins, "marketplaces")
+
+# Pre-pass: validate every alias and detect collisions across declared
+# marketplaces before writing anything. Two distinct marketplace ids that
+# reduce to the same alias would silently overwrite each other on the
+# symlink-plant step (root is the writer, so no permission failure
+# stops it). Fail-loud here is the only way to surface the input bug.
+alias_owners = {}  # alias -> list of marketplace ids that claim it
+declared_entries = []
 for marketplace in sorted(declared_marketplaces()):
+    # Reject the marketplace id itself before anything else — it will
+    # become an alias under marketplaces/ and an unsafe id is a
+    # privilege-escalation surface (root plants the symlink).
+    reason = alias_rejection_reason(marketplace)
+    if reason:
+        fail(
+            "marketplace id %r rejected: %s — refusing to write per-UID catalog. "
+            "Rename the marketplace upstream or remove it from the agent's channel/plugins set."
+            % (marketplace, reason)
+        )
     entry = source_markets.get(marketplace)
     if not isinstance(entry, dict):
         continue
     source_dir, slug = marketplace_source_info(marketplace, entry)
     if not source_dir:
         continue
+    alias = slug or marketplace
+    reason = alias_rejection_reason(alias)
+    if reason:
+        fail(
+            "marketplace %r derived alias %r rejected: %s — refusing to write per-UID catalog"
+            % (marketplace, alias, reason)
+        )
+    alias_owners.setdefault(alias, []).append(marketplace)
+    declared_entries.append((marketplace, entry, source_dir, slug, alias))
+
+collisions = {a: owners for a, owners in alias_owners.items() if len(owners) > 1}
+if collisions:
+    detail = "; ".join(
+        "%r ← %s" % (alias, ", ".join(repr(o) for o in sorted(owners)))
+        for alias, owners in sorted(collisions.items())
+    )
+    fail(
+        "marketplace alias collision detected — multiple marketplaces would land at "
+        "the same `marketplaces/<alias>` symlink and silently overwrite each other. "
+        "Rename or namespace the colliding marketplaces upstream. Colliders: " + detail
+    )
+
+for marketplace, entry, source_dir, slug, alias in declared_entries:
     rewritten = copy.deepcopy(entry)
     source = rewritten.get("source")
-    alias = slug or marketplace
     isolated_location = os.path.join(marketplaces_root, alias)
     rewritten["installLocation"] = isolated_location
     if isinstance(source, dict) and source.get("source") == "directory":
@@ -1624,8 +1898,13 @@ with open(out_path, "w") as f:
 PY
   then
     bridge_linux_sudo_root rm -f "$catalog_tmp" >/dev/null 2>&1 || true
-    bridge_warn "bridge_write_isolated_known_marketplaces_catalog: refused to write per-UID catalog for $os_user"
-    return 1
+    # Fail-loud: the catalog generator surfaces alias collisions and
+    # unsafe alias inputs (regex / `..` / reserved name / control char)
+    # via SystemExit(2). Silent skip would leave isolated agents running
+    # against an outdated/empty catalog while the underlying input bug
+    # stays hidden. Operator must rename the colliding marketplace or
+    # remove the offending entry before re-running isolation prepare.
+    bridge_die "bridge_write_isolated_known_marketplaces_catalog: refused to write per-UID catalog for $os_user (see [bridge-isolate] errors above)"
   fi
 
   bridge_linux_sudo_root chown root:root "$catalog_tmp"
@@ -2282,9 +2561,29 @@ bridge_linux_share_plugin_catalog() {
   local _mkt_info=""
   local _mkt_status=""
   local _mkt_alias=""
+  local _mkt_alias_reason=""
   local -a _mkt_info_parts=()
   local _mkt_block_disabled=0
+  # Collision-detection ledger for the symlink pre-pass. Each alias keeps
+  # a `\x1f`-separated list of marketplace ids that resolved to it; if
+  # any list grows past one entry, we fail loudly before planting any
+  # symlink. Without this gate, two marketplace ids that reduce to the
+  # same alias (e.g. `foo/bar-baz` and `foo-bar/baz` both → `foo-bar-baz`)
+  # would silently overwrite each other under the root-owned
+  # marketplaces/ dir — the catalog would end up pointing the wrong repo
+  # for one of them with zero error signal.
+  local _alias_collision_marker=$'\x1f'
+  declare -A _alias_owners=()
+  declare -A _mkt_resolved_src=()
+  declare -A _mkt_resolved_aliases=()
+  local _alias_collision_detail=""
+  local -a _mkt_unique_ids=()
   bridge_linux_sudo_root bash -c "if [[ -d \"$_isolated_marketplaces\" || -L \"$_isolated_marketplaces\" ]]; then shopt -s nullglob dotglob; for entry in \"$_isolated_marketplaces\"/*; do [[ -L \"\$entry\" ]] && rm -f \"\$entry\"; done; fi" >/dev/null 2>&1 || true
+
+  # Pass 1 — discovery + validation. Collect (mkt_id, src, aliases) for
+  # every unique marketplace the agent declares, validate each alias
+  # (defense in depth: bridge_known_marketplace_info also rejects unsafe
+  # aliases), and build the alias-owner map for collision detection.
   for _channel_full in "${_current_plugin_channels[@]+"${_current_plugin_channels[@]}"}"; do
     (( _mkt_block_disabled == 0 )) || break
     plugin_id="${_channel_full#plugin:}"
@@ -2299,7 +2598,13 @@ bridge_linux_share_plugin_catalog() {
     # known_marketplaces.json. The helper also returns Claude Code's newer
     # github repo-slug alias (`org-repo`) so bridge can preplant both names
     # without making the isolated marketplaces/ root writable.
-    _mkt_info="$(bridge_known_marketplace_info "$_mkt_id" "$controller_plugins")"
+    _mkt_info="$(bridge_known_marketplace_info "$_mkt_id" "$controller_plugins")" || {
+      # The Python helper exits 2 when an alias fails the safety check.
+      # Surface that as a fail-loud condition rather than a silent skip:
+      # an unsafe alias is operator input that escapes the marketplaces/
+      # namespace under root's write authority.
+      bridge_die "marketplace ${_mkt_id}: known_marketplaces.json lookup rejected an unsafe alias (see [bridge-isolate] errors above). Refusing to plant any marketplace symlink for this agent until the input is fixed."
+    }
     IFS=$'\t' read -r -a _mkt_info_parts <<<"$_mkt_info"
     _mkt_status="${_mkt_info_parts[0]:-}"
     _mkt_src="${_mkt_info_parts[1]:-}"
@@ -2307,6 +2612,12 @@ bridge_linux_share_plugin_catalog() {
       unparseable)
         _mkt_block_disabled=1
         break
+        ;;
+      unsafe)
+        # Defense in depth: the helper also exits 0 with `unsafe` when
+        # the safety check trips. Treat it the same as the SystemExit(2)
+        # path above.
+        bridge_die "marketplace ${_mkt_id}: known_marketplaces.json carries an unsafe alias (see [bridge-isolate] errors above)."
         ;;
       missing|"")
         # marketplace not registered → silent skip, no broken symlink.
@@ -2325,6 +2636,70 @@ bridge_linux_share_plugin_catalog() {
       bridge_warn "marketplace ${_mkt_id} is in known_marketplaces.json but the controller-side tree at ${_mkt_src} is missing — declared plugins from this marketplace will not load. Operator must run \`/plugin marketplace add\` once with credentials, then re-run isolation prepare."
       continue
     fi
+    # Defense-in-depth alias validation. The Python helper rejected
+    # unsafe aliases above; if a future caller bypasses that path the
+    # symlink loop must still refuse to plant a name that escapes the
+    # marketplaces/ namespace.
+    local _mkt_alias_list=""
+    for _mkt_alias in "${_mkt_info_parts[@]:2}"; do
+      [[ -n "$_mkt_alias" ]] || continue
+      _mkt_alias_reason="$(bridge_isolation_alias_rejection_reason "$_mkt_alias")"
+      if [[ -n "$_mkt_alias_reason" ]]; then
+        bridge_die "marketplace ${_mkt_id}: alias '${_mkt_alias}' rejected (${_mkt_alias_reason}). Refusing to plant unsafe symlink under ${_isolated_marketplaces}/."
+      fi
+      # Append owner to the per-alias ledger.
+      local _existing="${_alias_owners[$_mkt_alias]:-}"
+      if [[ -n "$_existing" ]]; then
+        _alias_owners[$_mkt_alias]="${_existing}${_alias_collision_marker}${_mkt_id}"
+      else
+        _alias_owners[$_mkt_alias]="${_mkt_id}"
+      fi
+      if [[ -n "$_mkt_alias_list" ]]; then
+        _mkt_alias_list="${_mkt_alias_list}${_alias_collision_marker}${_mkt_alias}"
+      else
+        _mkt_alias_list="$_mkt_alias"
+      fi
+    done
+    if [[ -z "$_mkt_alias_list" ]]; then
+      # No usable alias — bridge_known_marketplace_info already filters
+      # this case (the marketplace id itself goes in first), but guard
+      # anyway so downstream pass-2 always has at least one alias.
+      continue
+    fi
+    _mkt_resolved_src[$_mkt_id]="$_mkt_src"
+    _mkt_resolved_aliases[$_mkt_id]="$_mkt_alias_list"
+    _mkt_unique_ids+=("$_mkt_id")
+  done
+
+  # Pass 1.5 — collision detection. Two distinct marketplace ids that
+  # reduce to the same alias would each plant a symlink at
+  # `<isolated>/marketplaces/<alias>`; the second `ln -s` (with `rm -f`
+  # in front) silently overwrites the first under root's write authority,
+  # so the catalog ends up pointing the wrong source for one of them.
+  # Fail-loud listing every collider lets the operator rename or
+  # namespace upstream rather than chase a silent misroute.
+  if (( ${#_alias_owners[@]} > 0 )); then
+    local _coll_alias=""
+    for _coll_alias in "${!_alias_owners[@]}"; do
+      local _coll_owners="${_alias_owners[$_coll_alias]}"
+      if [[ "$_coll_owners" == *"${_alias_collision_marker}"* ]]; then
+        local _coll_pretty="${_coll_owners//${_alias_collision_marker}/, }"
+        if [[ -n "$_alias_collision_detail" ]]; then
+          _alias_collision_detail="${_alias_collision_detail}; '${_coll_alias}' ← ${_coll_pretty}"
+        else
+          _alias_collision_detail="'${_coll_alias}' ← ${_coll_pretty}"
+        fi
+      fi
+    done
+  fi
+  if [[ -n "$_alias_collision_detail" ]]; then
+    bridge_die "marketplace alias collision detected — multiple marketplaces would land at the same '<isolated>/marketplaces/<alias>' symlink and silently overwrite each other under root's write authority. Rename or namespace the colliding marketplaces upstream. Colliders: ${_alias_collision_detail}"
+  fi
+
+  # Pass 2 — plant symlinks + ACLs. By this point every (mkt_id, src,
+  # alias) triple has been validated and proven collision-free.
+  for _mkt_id in "${_mkt_unique_ids[@]+"${_mkt_unique_ids[@]}"}"; do
+    _mkt_src="${_mkt_resolved_src[$_mkt_id]}"
     if (( _marketplaces_root_created == 0 )); then
       bridge_linux_sudo_root mkdir -p "$_isolated_marketplaces"
       if bridge_isolation_v2_active; then
@@ -2341,7 +2716,9 @@ bridge_linux_share_plugin_catalog() {
       fi
       _marketplaces_root_created=1
     fi
-    for _mkt_alias in "${_mkt_info_parts[@]:2}"; do
+    local -a _alias_arr=()
+    IFS="${_alias_collision_marker}" read -ra _alias_arr <<<"${_mkt_resolved_aliases[$_mkt_id]}"
+    for _mkt_alias in "${_alias_arr[@]}"; do
       [[ -n "$_mkt_alias" ]] || continue
       _mkt_dst="$_isolated_marketplaces/$_mkt_alias"
       bridge_linux_sudo_root rm -f "$_mkt_dst" >/dev/null 2>&1 || true

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1564,7 +1564,11 @@ def repo_slug(repo):
 
 
 # Mirror of `_alias_rejection_reason` in bridge-dev-plugin-cache.py.
-_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+# `fullmatch` (vs `match(... + "$")`) is the security-relevant choice:
+# `$` in default mode matches just before a trailing `\n`, so an alias
+# like "foo\n" would otherwise slip through the regex gate. `fullmatch`
+# requires the entire string to match, no trailing-newline tolerance.
+_SAFE_ALIAS_RE = re.compile(r"[A-Za-z0-9._-]+")
 _ALIAS_RESERVED_NAMES = {".", ".."}
 _ALIAS_WINDOWS_RESERVED = (
     {"CON", "PRN", "AUX", "NUL"}
@@ -1580,7 +1584,7 @@ def alias_rejection_reason(alias):
         return "empty"
     if len(alias) > 200:
         return "length exceeds 200"
-    if not _SAFE_ALIAS_RE.match(alias):
+    if not _SAFE_ALIAS_RE.fullmatch(alias):
         return "contains characters outside [A-Za-z0-9._-]"
     if ".." in alias:
         return "contains '..'"
@@ -1760,7 +1764,11 @@ def repo_slug(repo):
 
 
 # Mirror of `_alias_rejection_reason` in bridge-dev-plugin-cache.py.
-_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+# `fullmatch` (vs `match(... + "$")`) closes the trailing-newline bypass:
+# in default mode `$` matches before a trailing `\n`, so "foo\n" would
+# otherwise satisfy the regex and reach the symlink-plant step. The whole
+# alias must consume the entire string with no implicit newline tolerance.
+_SAFE_ALIAS_RE = re.compile(r"[A-Za-z0-9._-]+")
 _ALIAS_RESERVED_NAMES = {".", ".."}
 _ALIAS_WINDOWS_RESERVED = (
     {"CON", "PRN", "AUX", "NUL"}
@@ -1776,7 +1784,7 @@ def alias_rejection_reason(alias):
         return "empty"
     if len(alias) > 200:
         return "length exceeds 200"
-    if not _SAFE_ALIAS_RE.match(alias):
+    if not _SAFE_ALIAS_RE.fullmatch(alias):
         return "contains characters outside [A-Za-z0-9._-]"
     if ".." in alias:
         return "contains '..'"
@@ -2106,7 +2114,7 @@ bridge_write_isolated_installed_plugins_manifest() {
   # transiently missing manifest. (Blocking 2 in PR #302 r1.)
   manifest_tmp="$(bridge_linux_sudo_root mktemp "${manifest}.tmp.XXXXXX")"
   if ! bridge_linux_sudo_root python3 - "$controller_plugins" "$isolated_plugins" "$channels_csv" "$manifest_tmp" "$plugins_csv" <<'PY'
-import json, os, sys
+import json, os, re, sys
 
 controller_plugins, isolated_plugins, channels_csv, out_path, plugins_csv = sys.argv[1:]
 controller_manifest = os.path.join(controller_plugins, "installed_plugins.json")
@@ -2115,6 +2123,43 @@ markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
 
 def warn(msg):
     sys.stderr.write("[bridge-isolate] " + msg + "\n")
+
+
+# Mirror of `_alias_rejection_reason` in bridge-dev-plugin-cache.py.
+# `fullmatch` (vs `match(... + "$")`) closes the trailing-newline bypass.
+# In the normal share flow upstream gates already validate marketplace
+# id and slug aliases before this helper runs; the validator here is
+# defense-in-depth for the path components this helper itself joins
+# (`isolated_plugins/cache/<marketplace>/<plugin>/<version>`). An
+# unsafe component reaching here means an upstream gate failed; we
+# refuse the lookup rather than silently reading from a poisoned path.
+_SAFE_ALIAS_RE = re.compile(r"[A-Za-z0-9._-]+")
+_ALIAS_RESERVED_NAMES = {".", ".."}
+_ALIAS_WINDOWS_RESERVED = (
+    {"CON", "PRN", "AUX", "NUL"}
+    | {"COM%d" % i for i in range(1, 10)}
+    | {"LPT%d" % i for i in range(1, 10)}
+)
+
+
+def alias_rejection_reason(alias):
+    if not isinstance(alias, str):
+        return "not a string"
+    if alias == "":
+        return "empty"
+    if len(alias) > 200:
+        return "length exceeds 200"
+    if not _SAFE_ALIAS_RE.fullmatch(alias):
+        return "contains characters outside [A-Za-z0-9._-]"
+    if ".." in alias:
+        return "contains '..'"
+    if alias in _ALIAS_RESERVED_NAMES:
+        return "reserved name"
+    if alias.upper() in _ALIAS_WINDOWS_RESERVED:
+        return "reserved Windows name"
+    if alias.startswith(".") and alias != ".git":
+        return "leading dot disallowed"
+    return ""
 
 
 # Distinguish "controller manifest exists but is corrupt" (operator-
@@ -2159,6 +2204,17 @@ def directory_marketplace_path(plugin_id):
     if "@" not in plugin_id:
         return ""
     plugin_name, marketplace = plugin_id.split("@", 1)
+    # Defense-in-depth: plugin_name is about to be joined into a path.
+    # marketplace is used only as a dict key so doesn't need path-safety,
+    # but reject it too — an unsafe id here means an upstream parser bug.
+    for role, value in (("plugin name", plugin_name), ("marketplace id", marketplace)):
+        reason = alias_rejection_reason(value)
+        if reason:
+            sys.stderr.write(
+                "[bridge-isolate] directory_marketplace_path rejected %s %r (plugin_id=%r): %s\n"
+                % (role, value, plugin_id, reason)
+            )
+            raise SystemExit(2)
     entry = markets.get(marketplace, {})
     if not isinstance(entry, dict):
         return ""
@@ -2184,6 +2240,25 @@ def isolated_cache_path(plugin_id, entry):
         version = os.path.basename(install_path)
     if not version:
         return ""
+    # Defense-in-depth: every component is about to be joined into
+    # `<isolated_plugins>/cache/<marketplace>/<plugin>/<version>`. An
+    # unsafe component (newline / `..` / slash) could escape the cache
+    # root; in the normal share flow the catalog writer already filters
+    # marketplace ids upstream, but this helper runs separately and must
+    # hold the gate on its own. Fail loud — silently returning "" would
+    # mask an upstream bug.
+    for role, value in (
+        ("marketplace id", marketplace),
+        ("plugin name", plugin_name),
+        ("plugin version", version),
+    ):
+        reason = alias_rejection_reason(value)
+        if reason:
+            sys.stderr.write(
+                "[bridge-isolate] isolated_cache_path rejected %s %r (plugin_id=%r): %s\n"
+                % (role, value, plugin_id, reason)
+            )
+            raise SystemExit(2)
     candidate = os.path.join(isolated_plugins, "cache", marketplace, plugin_name, version)
     return candidate if os.path.isdir(candidate) else ""
 
@@ -2239,7 +2314,12 @@ with open(out_path, "w") as f:
 PY
   then
     bridge_linux_sudo_root rm -f "$manifest_tmp" >/dev/null 2>&1 || true
-    bridge_warn "bridge_write_isolated_installed_plugins_manifest: refused to write per-UID manifest for $os_user (controller state unparseable)"
+    # Fail-loud: SystemExit(2) covers both controller-state-unparseable
+    # and the new defense-in-depth path-component rejection in
+    # `directory_marketplace_path`/`isolated_cache_path`. The Python
+    # heredoc emits a `[bridge-isolate]` stderr line naming the offending
+    # component before exiting; surface that to the operator log.
+    bridge_warn "bridge_write_isolated_installed_plugins_manifest: refused to write per-UID manifest for $os_user (see [bridge-isolate] errors above; either controller state unparseable or a path component failed safe-alias gate)"
     return 1
   fi
 

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -1421,6 +1421,235 @@ print("present:other")
 PY
 }
 
+bridge_known_marketplace_info() {
+  # Return marketplace source information from known_marketplaces.json.
+  #
+  # Output protocol:
+  #   present:<kind>\t<source-dir>\t<alias>[ \t<alias>...]
+  #   missing
+  #   unparseable
+  #
+  # `source-dir` is the controller-side marketplace tree to expose read-only
+  # to the isolated UID. Aliases include the marketplace id plus Claude Code's
+  # newer github `<org>-<repo>` clone dirname when source.repo is present.
+  local marketplace_id="$1"
+  local plugins_root="$2"
+  local marketplaces_json="$plugins_root/known_marketplaces.json"
+
+  bridge_require_python
+  python3 - "$marketplace_id" "$plugins_root" "$marketplaces_json" <<'PY'
+import json
+import os
+import sys
+
+marketplace_id, plugins_root, marketplaces_path = sys.argv[1:]
+
+
+def repo_slug(repo):
+    repo = (repo or "").strip().strip("/")
+    if "/" not in repo:
+        return ""
+    return repo.replace("/", "-")
+
+
+def emit(*parts):
+    print("\t".join(parts))
+
+
+if not os.path.isfile(marketplaces_path):
+    emit("unparseable")
+    raise SystemExit(0)
+
+try:
+    with open(marketplaces_path) as f:
+        markets = json.load(f)
+    if not isinstance(markets, dict):
+        raise ValueError("expected JSON object")
+except (OSError, ValueError):
+    emit("unparseable")
+    raise SystemExit(0)
+
+entry = markets.get(marketplace_id)
+if not isinstance(entry, dict):
+    emit("missing")
+    raise SystemExit(0)
+
+source = entry.get("source")
+kind = "other"
+repo = ""
+if isinstance(source, dict):
+    kind = source.get("source") or "other"
+    repo = source.get("repo") or ""
+
+slug = repo_slug(repo)
+aliases = []
+for item in (marketplace_id, slug):
+    if item and item not in aliases:
+        aliases.append(item)
+
+candidates = []
+if marketplace_id:
+    candidates.append(os.path.join(plugins_root, "marketplaces", marketplace_id))
+if slug:
+    candidates.append(os.path.join(plugins_root, "marketplaces", slug))
+
+install_location = entry.get("installLocation")
+source_path = source.get("path") if isinstance(source, dict) else ""
+for candidate in (install_location, source_path):
+    if not isinstance(candidate, str) or not candidate.strip():
+        continue
+    candidate = candidate.strip()
+    # Directory-source marketplaces can point at a broad source checkout
+    # (for example a repo root containing multiple plugins). Do not expose
+    # that whole tree as the marketplace alias unless it is Agent Bridge's
+    # own marketplace; third-party directory marketplaces should provide a
+    # mirror under ~/.claude/plugins/marketplaces/<id>.
+    if kind == "directory" and marketplace_id != "agent-bridge":
+        continue
+    candidates.append(candidate)
+
+source_dir = ""
+for candidate in candidates:
+    if os.path.isdir(candidate):
+        source_dir = os.path.abspath(candidate)
+        break
+
+emit("present:%s" % kind, source_dir, *aliases)
+PY
+}
+
+bridge_write_isolated_known_marketplaces_catalog() {
+  # Write a filtered per-UID known_marketplaces.json instead of symlinking the
+  # controller's full file. This keeps undeclared marketplaces out of isolated
+  # Claude's loader and rewrites installLocation/source.path to isolated-home
+  # aliases that bridge controls read-only.
+  local os_user="$1"
+  local isolated_plugins="$2"
+  local controller_plugins="$3"
+  local channels_csv="$4"
+  local plugins_csv="${5-}"
+  local agent="${6-}"
+  local catalog="$isolated_plugins/known_marketplaces.json"
+  local catalog_tmp=""
+
+  bridge_require_python
+  catalog_tmp="$(bridge_linux_sudo_root mktemp "${catalog}.tmp.XXXXXX")"
+  if ! bridge_linux_sudo_root python3 - "$controller_plugins" "$isolated_plugins" "$channels_csv" "$plugins_csv" "$catalog_tmp" <<'PY'
+import copy
+import json
+import os
+import sys
+
+controller_plugins, isolated_plugins, channels_csv, plugins_csv, out_path = sys.argv[1:]
+markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
+
+
+def warn(msg):
+    sys.stderr.write("[bridge-isolate] " + msg + "\n")
+
+
+def repo_slug(repo):
+    repo = (repo or "").strip().strip("/")
+    if "/" not in repo:
+        return ""
+    return repo.replace("/", "-")
+
+
+def marketplace_source_info(marketplace, entry):
+    source = entry.get("source")
+    kind = source.get("source") if isinstance(source, dict) else ""
+    slug = repo_slug(str(source.get("repo") or "")) if isinstance(source, dict) else ""
+    candidates = [
+        os.path.join(controller_plugins, "marketplaces", marketplace),
+    ]
+    if slug:
+        candidates.append(os.path.join(controller_plugins, "marketplaces", slug))
+    for candidate in candidates:
+        if os.path.isdir(candidate):
+            return candidate, slug
+    if marketplace == "agent-bridge":
+        for candidate in (
+            entry.get("installLocation"),
+            source.get("path") if isinstance(source, dict) else "",
+        ):
+            if isinstance(candidate, str) and candidate.strip() and os.path.isdir(candidate.strip()):
+                return candidate.strip(), slug
+    warn("marketplace %s is declared but no controller-side mirror exists under %s/marketplaces — omitting from isolated catalog" % (marketplace, controller_plugins))
+    return "", slug
+
+
+def declared_marketplaces():
+    declared = set()
+    for raw in (channels_csv + "," + plugins_csv).split(","):
+        token = raw.strip()
+        if token.startswith("plugin:"):
+            token = token[len("plugin:"):]
+        if "@" not in token:
+            continue
+        _plugin, marketplace = token.split("@", 1)
+        if marketplace:
+            declared.add(marketplace)
+    return declared
+
+
+try:
+    with open(markets_path) as f:
+        source_markets = json.load(f)
+    if not isinstance(source_markets, dict):
+        raise ValueError("expected JSON object at root, got %r" % type(source_markets).__name__)
+except (OSError, ValueError) as exc:
+    warn("controller known_marketplaces.json unparseable (%s): %s — writing empty per-UID marketplace catalog" % (type(exc).__name__, markets_path))
+    source_markets = {}
+
+out = {}
+marketplaces_root = os.path.join(isolated_plugins, "marketplaces")
+for marketplace in sorted(declared_marketplaces()):
+    entry = source_markets.get(marketplace)
+    if not isinstance(entry, dict):
+        continue
+    source_dir, slug = marketplace_source_info(marketplace, entry)
+    if not source_dir:
+        continue
+    rewritten = copy.deepcopy(entry)
+    source = rewritten.get("source")
+    alias = slug or marketplace
+    isolated_location = os.path.join(marketplaces_root, alias)
+    rewritten["installLocation"] = isolated_location
+    if isinstance(source, dict) and source.get("source") == "directory":
+        source["path"] = isolated_location
+    out[marketplace] = rewritten
+
+with open(out_path, "w") as f:
+    json.dump(out, f, indent=2)
+PY
+  then
+    bridge_linux_sudo_root rm -f "$catalog_tmp" >/dev/null 2>&1 || true
+    bridge_warn "bridge_write_isolated_known_marketplaces_catalog: refused to write per-UID catalog for $os_user"
+    return 1
+  fi
+
+  bridge_linux_sudo_root chown root:root "$catalog_tmp"
+  bridge_linux_sudo_root chmod 0640 "$catalog_tmp"
+  if bridge_isolation_v2_active; then
+    if [[ -n "$agent" ]]; then
+      local _v2_grp
+      _v2_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')" \
+        || _v2_grp=""
+      if [[ -n "$_v2_grp" ]]; then
+        bridge_linux_sudo_root chgrp "$_v2_grp" "$catalog_tmp" \
+          || bridge_die "isolation v2: chgrp '$_v2_grp' on marketplace catalog '$catalog_tmp' failed"
+      else
+        bridge_die "isolation v2: cannot resolve agent group for marketplace catalog '$catalog_tmp'"
+      fi
+    else
+      bridge_die "isolation v2: bridge_write_isolated_known_marketplaces_catalog requires agent id"
+    fi
+  else
+    bridge_linux_acl_add "u:${os_user}:r--" "$catalog_tmp"
+  fi
+  bridge_linux_sudo_root mv "$catalog_tmp" "$catalog"
+}
+
 bridge_isolated_plugin_grants_state_dir() {
   # Controller-owned ledger root for plugin-share ACL grants. Keep this out
   # of $BRIDGE_ACTIVE_AGENT_DIR/<agent>: in legacy mode that path is also the
@@ -1597,10 +1826,10 @@ bridge_write_isolated_installed_plugins_manifest() {
   # copy+unlink and a concurrent reader can see a half-written or
   # transiently missing manifest. (Blocking 2 in PR #302 r1.)
   manifest_tmp="$(bridge_linux_sudo_root mktemp "${manifest}.tmp.XXXXXX")"
-  if ! bridge_linux_sudo_root python3 - "$controller_plugins" "$channels_csv" "$manifest_tmp" "$plugins_csv" <<'PY'
+  if ! bridge_linux_sudo_root python3 - "$controller_plugins" "$isolated_plugins" "$channels_csv" "$manifest_tmp" "$plugins_csv" <<'PY'
 import json, os, sys
 
-controller_plugins, channels_csv, out_path, plugins_csv = sys.argv[1:]
+controller_plugins, isolated_plugins, channels_csv, out_path, plugins_csv = sys.argv[1:]
 controller_manifest = os.path.join(controller_plugins, "installed_plugins.json")
 markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
 
@@ -1666,10 +1895,27 @@ def directory_marketplace_path(plugin_id):
     return guess if os.path.isdir(guess) else ""
 
 
+def isolated_cache_path(plugin_id, entry):
+    if "@" not in plugin_id:
+        return ""
+    plugin_name, marketplace = plugin_id.split("@", 1)
+    version = str((entry or {}).get("version") or "").strip()
+    if not version:
+        install_path = str((entry or {}).get("installPath") or "").rstrip("/")
+        version = os.path.basename(install_path)
+    if not version:
+        return ""
+    candidate = os.path.join(isolated_plugins, "cache", marketplace, plugin_name, version)
+    return candidate if os.path.isdir(candidate) else ""
+
+
 def resolve(plugin_id):
     # Preserve controller entry metadata (version, gitCommitSha, etc.) when
     # we can; only rewrite installPath if it is missing or stale.
     for entry in source.get("plugins", {}).get(plugin_id, []):
+        isolated_path = isolated_cache_path(plugin_id, entry)
+        if isolated_path:
+            return entry, isolated_path
         ip = entry.get("installPath")
         if ip and os.path.isdir(ip):
             return entry, ip
@@ -1875,18 +2121,32 @@ bridge_linux_share_plugin_catalog() {
   fi
 
   # 2. plugins/data/: isolated UID owns this so plugin runtime state writes work.
+  local os_group=""
+  os_group="$(id -gn "$os_user" 2>/dev/null || printf '%s' "$os_user")"
   bridge_linux_sudo_root mkdir -p "$isolated_plugins/data"
-  bridge_linux_sudo_root chown "$os_user" "$isolated_plugins/data"
+  bridge_linux_sudo_root chown "$os_user:$os_group" "$isolated_plugins/data"
   bridge_linux_sudo_root chmod 0700 "$isolated_plugins/data"
+
+  local channels_csv=""
+  local plugins_csv=""
+  channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+  plugins_csv="$(bridge_agent_plugins_csv "$agent" 2>/dev/null || true)"
 
   # 3. Read-only catalog metadata symlinks. Always remove the prior dst
   #    first (independent of source presence) so a controller-side delete
   #    invalidates the isolated symlink rather than leaving it dangling at
   #    a now-stale target. (Risk 1 in PR #302 r1.)
+  #
+  #    known_marketplaces.json is intentionally excluded from this symlink
+  #    loop. Claude Code now tries to clone every visible marketplace when
+  #    rendering `/plugin`; exposing the controller's full marketplace file
+  #    makes isolated agents attempt writes under their root-owned
+  #    marketplaces/ dir. Step 4 writes a filtered per-UID copy instead.
   local catalog_file=""
   local src=""
   local dst=""
   for catalog_file in "${BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES[@]}"; do
+    [[ "$catalog_file" == "known_marketplaces.json" ]] && continue
     src="$controller_plugins/$catalog_file"
     dst="$isolated_plugins/$catalog_file"
     bridge_linux_sudo_root rm -f "$dst" >/dev/null 2>&1 || true
@@ -1897,18 +2157,20 @@ bridge_linux_share_plugin_catalog() {
     bridge_linux_acl_add "u:${os_user}:r--" "$src"
   done
 
-  # 4. Per-UID installed_plugins.json — declared plugins only (union of
+  # 4. Filtered per-UID known_marketplaces.json — declared marketplaces only,
+  #    with installLocation/source.path rewritten to isolated-home aliases.
+  bridge_write_isolated_known_marketplaces_catalog \
+    "$os_user" "$isolated_plugins" "$controller_plugins" \
+    "$channels_csv" "$plugins_csv" "$agent"
+
+  # 5. Per-UID installed_plugins.json — declared plugins only (union of
   #    BRIDGE_AGENT_CHANNELS plugin entries and BRIDGE_AGENT_PLUGINS allowlist
   #    per #348 / #272), real install paths.
-  local channels_csv=""
-  local plugins_csv=""
-  channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
-  plugins_csv="$(bridge_agent_plugins_csv "$agent" 2>/dev/null || true)"
   bridge_write_isolated_installed_plugins_manifest \
     "$os_user" "$isolated_plugins" "$controller_plugins" \
     "$channels_csv" "$plugins_csv" "$agent"
 
-  # 5. Compute the channel diff against the persisted grant set so we can
+  # 6. Compute the channel diff against the persisted grant set so we can
   #    revoke channels that were previously granted but are no longer in
   #    the roster (Blocking 1 in PR #302 r1). The "current" set is the
   #    union of BRIDGE_AGENT_CHANNELS `plugin:<id>` tokens and
@@ -1963,7 +2225,7 @@ bridge_linux_share_plugin_catalog() {
     done
   fi
 
-  # 5a. Revoke removed entries (in prior set but not in current set).
+  # 6a. Revoke removed entries (in prior set but not in current set).
   #     This covers both channel removals and BRIDGE_AGENT_PLUGINS
   #     removals — both are persisted in the same `plugin:<id>` form.
   local _prior_entry=""
@@ -1980,7 +2242,7 @@ bridge_linux_share_plugin_catalog() {
     fi
   done
 
-  # 5b. Grant current plugin install paths + traverse chain (channel-declared
+  # 6b. Grant current plugin install paths + traverse chain (channel-declared
   #     plus BRIDGE_AGENT_PLUGINS allowlist entries).
   local channel=""
   local plugin_id=""
@@ -1996,7 +2258,7 @@ bridge_linux_share_plugin_catalog() {
     bridge_linux_acl_add_recursive "u:${os_user}:r-X" "$install_path"
   done
 
-  # 5b'. Marketplace symlinks (#348). For every union plugin in
+  # 6b'. Marketplace symlinks (#348). For every union plugin in
   #     `<plugin>@<marketplace>` form whose marketplace is registered
   #     in the controller's `known_marketplaces.json` AND whose mirror
   #     tree exists at `~/.claude/plugins/marketplaces/<marketplace>`,
@@ -2017,8 +2279,12 @@ bridge_linux_share_plugin_catalog() {
   local _mkt_id=""
   local _mkt_src=""
   local _mkt_dst=""
-  local _mkt_lookup=""
+  local _mkt_info=""
+  local _mkt_status=""
+  local _mkt_alias=""
+  local -a _mkt_info_parts=()
   local _mkt_block_disabled=0
+  bridge_linux_sudo_root bash -c "if [[ -d \"$_isolated_marketplaces\" || -L \"$_isolated_marketplaces\" ]]; then shopt -s nullglob dotglob; for entry in \"$_isolated_marketplaces\"/*; do [[ -L \"\$entry\" ]] && rm -f \"\$entry\"; done; fi" >/dev/null 2>&1 || true
   for _channel_full in "${_current_plugin_channels[@]+"${_current_plugin_channels[@]}"}"; do
     (( _mkt_block_disabled == 0 )) || break
     plugin_id="${_channel_full#plugin:}"
@@ -2030,13 +2296,14 @@ bridge_linux_share_plugin_catalog() {
     esac
     _mkt_seen="${_mkt_seen}${_seen_marker}${_mkt_id}${_seen_marker}"
     # Source-of-truth gate: marketplace must be registered in
-    # known_marketplaces.json. On `unparseable` we abandon the whole
-    # 5b' block; the manifest writer at :1183-1186 already logged the
-    # canonical warning earlier in the same share pass, so the helper
-    # itself stays silent (no duplicate stderr line per share pass —
-    # #348 r3).
-    _mkt_lookup="$(bridge_known_marketplaces_lookup "$_mkt_id" "$controller_plugins")"
-    case "$_mkt_lookup" in
+    # known_marketplaces.json. The helper also returns Claude Code's newer
+    # github repo-slug alias (`org-repo`) so bridge can preplant both names
+    # without making the isolated marketplaces/ root writable.
+    _mkt_info="$(bridge_known_marketplace_info "$_mkt_id" "$controller_plugins")"
+    IFS=$'\t' read -r -a _mkt_info_parts <<<"$_mkt_info"
+    _mkt_status="${_mkt_info_parts[0]:-}"
+    _mkt_src="${_mkt_info_parts[1]:-}"
+    case "$_mkt_status" in
       unparseable)
         _mkt_block_disabled=1
         break
@@ -2048,7 +2315,6 @@ bridge_linux_share_plugin_catalog() {
       present:*) ;;  # fall through to the symlink path
       *) continue ;;
     esac
-    _mkt_src="$controller_plugins/marketplaces/$_mkt_id"
     # Even when known_marketplaces.json carries an entry, the on-disk
     # mirror tree may not yet exist (common for git-source marketplaces
     # on a fresh checkout, or directory-source marketplaces whose cache
@@ -2075,10 +2341,13 @@ bridge_linux_share_plugin_catalog() {
       fi
       _marketplaces_root_created=1
     fi
-    _mkt_dst="$_isolated_marketplaces/$_mkt_id"
-    bridge_linux_sudo_root rm -f "$_mkt_dst" >/dev/null 2>&1 || true
-    bridge_linux_sudo_root ln -s "$_mkt_src" "$_mkt_dst"
-    bridge_linux_sudo_root chown -h root:root "$_mkt_dst" >/dev/null 2>&1 || true
+    for _mkt_alias in "${_mkt_info_parts[@]:2}"; do
+      [[ -n "$_mkt_alias" ]] || continue
+      _mkt_dst="$_isolated_marketplaces/$_mkt_alias"
+      bridge_linux_sudo_root rm -f "$_mkt_dst" >/dev/null 2>&1 || true
+      bridge_linux_sudo_root ln -s "$_mkt_src" "$_mkt_dst"
+      bridge_linux_sudo_root chown -h root:root "$_mkt_dst" >/dev/null 2>&1 || true
+    done
     # r#362: end-to-end readability for the symlinked marketplace tree.
     # Without all three steps, the symlink is planted but EACCES on first
     # read and Claude silently drops the plugin from the session. Order
@@ -2096,7 +2365,7 @@ bridge_linux_share_plugin_catalog() {
       bridge_die "marketplace tree: failed to set default ACL inheritance on $_mkt_src"
   done
 
-  # 5c. Persist the new grant set so the next reapply / unisolate sees
+  # 6c. Persist the new grant set so the next reapply / unisolate sees
   #     exactly what we touched here. Persisted entries cover both the
   #     channel-derived and BRIDGE_AGENT_PLUGINS-derived plugins (both
   #     stored in `plugin:<id>` form), so the unisolate revoke loop in
@@ -2108,7 +2377,7 @@ bridge_linux_share_plugin_catalog() {
   fi
   bridge_isolated_plugin_grants_write "$agent" "$_persist_csv"
 
-  # 5d. Audit row so operators can confirm exactly which plugins landed
+  # 6d. Audit row so operators can confirm exactly which plugins landed
   #     on the isolated UID after each reapply (#348). The detail rows
   #     carry the union list (channel + allowlist) and its size so a
   #     follow-up `bridge-audit` query can surface domain-plugin
@@ -2138,13 +2407,15 @@ bridge_linux_unshare_plugin_catalog() {
 
   local isolated_plugins="$user_home/.claude/plugins"
   [[ -n "$user_home" ]] || return 0
-  [[ -d "$isolated_plugins" ]] || return 0
+  bridge_linux_sudo_root test -d "$isolated_plugins" || return 0
 
   local catalog_file=""
   local link=""
   for catalog_file in "${BRIDGE_ISOLATION_SHARED_CATALOG_READ_FILES[@]}"; do
     link="$isolated_plugins/$catalog_file"
-    [[ -e "$link" || -L "$link" ]] || continue
+    bridge_linux_sudo_root test -e "$link" 2>/dev/null \
+      || bridge_linux_sudo_root test -L "$link" 2>/dev/null \
+      || continue
     bridge_migration_print_step "$dry_run" "rm $link (isolated catalog symlink)"
     if [[ "$dry_run" != "1" ]]; then
       bridge_linux_sudo_root rm -f "$link" >/dev/null 2>&1 || true
@@ -2152,7 +2423,7 @@ bridge_linux_unshare_plugin_catalog() {
   done
 
   local manifest="$isolated_plugins/installed_plugins.json"
-  if [[ -e "$manifest" ]]; then
+  if bridge_linux_sudo_root test -e "$manifest" 2>/dev/null; then
     bridge_migration_print_step "$dry_run" "rm $manifest (per-UID installed_plugins.json)"
     if [[ "$dry_run" != "1" ]]; then
       bridge_linux_sudo_root rm -f "$manifest" >/dev/null 2>&1 || true
@@ -2165,7 +2436,8 @@ bridge_linux_unshare_plugin_catalog() {
   # marketplaces/ dir if it ends up empty so the outer rmdir below can
   # also tear down plugins/. plugins/data/ remains untouched.
   local isolated_marketplaces="$isolated_plugins/marketplaces"
-  if [[ -d "$isolated_marketplaces" || -L "$isolated_marketplaces" ]]; then
+  if bridge_linux_sudo_root test -d "$isolated_marketplaces" 2>/dev/null \
+      || bridge_linux_sudo_root test -L "$isolated_marketplaces" 2>/dev/null; then
     bridge_migration_print_step "$dry_run" "rm $isolated_marketplaces/* symlinks (isolated marketplace symlinks)"
     if [[ "$dry_run" != "1" ]]; then
       bridge_linux_sudo_root bash -c "shopt -s nullglob dotglob; for entry in \"$isolated_marketplaces\"/*; do [[ -L \"\$entry\" ]] && rm -f \"\$entry\"; done" >/dev/null 2>&1 || true

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5592,6 +5592,9 @@ cat > "$DEV_THIRD_MARKETPLACE_ROOT/plugins/third-plugin/.mcp.json" <<'JSON'
 }
 JSON
 printf 'third source\n' > "$DEV_THIRD_MARKETPLACE_ROOT/plugins/third-plugin/server.ts"
+DEV_THIRD_INACCESSIBLE_ROOT="$TMP_ROOT/dev-third-inaccessible"
+mkdir -p "$DEV_THIRD_INACCESSIBLE_ROOT/.claude-plugin"
+chmod 000 "$DEV_THIRD_INACCESSIBLE_ROOT"
 THIRD_CACHE_VERSION_DIR="$BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT/third-mkt/third-plugin/0.2.0"
 rm -rf "$BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT/third-mkt"
 mkdir -p "$THIRD_CACHE_VERSION_DIR"
@@ -5612,12 +5615,13 @@ chmod 0600 "$THIRD_CACHE_VERSION_DIR/.mcp.json"
 cat > "$TMP_ROOT/known_marketplaces.json" <<JSON
 {
   "third-mkt": {
-    "source": {"source": "git", "repo": "Example/third-mkt"},
-    "installLocation": "$DEV_THIRD_MARKETPLACE_ROOT"
+    "installLocation": "$DEV_THIRD_INACCESSIBLE_ROOT",
+    "source": {"source": "directory", "path": "$DEV_THIRD_MARKETPLACE_ROOT", "repo": "Example/third-mkt"}
   }
 }
 JSON
 DEV_THIRD_CACHE_JSON="$(python3 "$REPO_ROOT/bridge-dev-plugin-cache.py" sync --channels "plugin:third-plugin@third-mkt" --root "$DEV_PLUGIN_MARKETPLACE_ROOT" --json)"
+chmod 700 "$DEV_THIRD_INACCESSIBLE_ROOT"
 python3 - "$DEV_THIRD_CACHE_JSON" "$THIRD_CACHE_VERSION_DIR/.mcp.json" <<'PY'
 import json
 import sys

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -15,7 +15,8 @@ source "$REPO_ROOT/lib/bridge-session-patterns.sh"
 # daemon, drop dynamic agent sessions, and trash live state. See issue #207.
 if [[ -n "${BRIDGE_HOME:-}" ]]; then
   _smoke_allowed_tmp_prefix=""
-  for _smoke_tmp_candidate in "${TMPDIR%/}" "/tmp" "/private/tmp" "/var/folders"; do
+  for _smoke_tmp_candidate in "${TMPDIR:-}" "/tmp" "/private/tmp" "/var/folders"; do
+    _smoke_tmp_candidate="${_smoke_tmp_candidate%/}"
     [[ -n "$_smoke_tmp_candidate" ]] || continue
     case "$BRIDGE_HOME" in
       "$_smoke_tmp_candidate"|"$_smoke_tmp_candidate"/*)
@@ -42,7 +43,8 @@ fi
 # value — see tests/isolation-v2-pr-e/smoke.sh.)
 if [[ -n "${BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT:-}" ]]; then
   _smoke_iso_allowed=""
-  for _smoke_iso_candidate in "${TMPDIR%/}" "/tmp" "/private/tmp" "/var/folders" "/private/var/folders"; do
+  for _smoke_iso_candidate in "${TMPDIR:-}" "/tmp" "/private/tmp" "/var/folders" "/private/var/folders"; do
+    _smoke_iso_candidate="${_smoke_iso_candidate%/}"
     [[ -n "$_smoke_iso_candidate" ]] || continue
     case "$BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT" in
       "$_smoke_iso_candidate"|"$_smoke_iso_candidate"/*)
@@ -619,7 +621,7 @@ grep -Fq 'plugin:telegram-relay' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh" && 
 grep -Fq 'plugin:telegram@claude-plugins-official' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh" || die "relay-cleanup apply did not insert plugin:telegram@claude-plugins-official into BRIDGE_AGENT_CHANNELS"
 grep -Fq 'plugin:foo' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh" || die "relay-cleanup apply dropped unrelated plugin:foo channel item"
 grep -Fq 'plugin:discord@claude-plugins-official' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh" || die "relay-cleanup apply touched unrelated agent channel line"
-RELAY_CLEANUP_POST_MODE="$(stat -f '%Lp' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh" 2>/dev/null || stat -c '%a' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh")"
+RELAY_CLEANUP_POST_MODE="$(stat -c '%a' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh" 2>/dev/null || stat -f '%Lp' "$RELAY_CLEANUP_ROOT/agent-roster.local.sh")"
 [[ "$RELAY_CLEANUP_POST_MODE" == "600" ]] || die "relay-cleanup apply widened agent-roster.local.sh mode under umask 022: expected 600 got $RELAY_CLEANUP_POST_MODE"
 log "  [ok] apply removed every residue class, preserved .telegram/.env + unrelated channels, and kept agent-roster.local.sh at mode 0600"
 
@@ -5563,6 +5565,77 @@ assert payload["results"][0]["status"] == "unchanged", payload
 assert payload["results"][0]["node_modules_status"] == "unchanged", payload
 PY
 
+log "syncing third-party dev-loaded plugin cache via known_marketplaces.json"
+DEV_THIRD_MARKETPLACE_ROOT="$TMP_ROOT/dev-third-marketplace"
+mkdir -p "$DEV_THIRD_MARKETPLACE_ROOT/.claude-plugin" \
+  "$DEV_THIRD_MARKETPLACE_ROOT/plugins/third-plugin"
+cat > "$DEV_THIRD_MARKETPLACE_ROOT/.claude-plugin/marketplace.json" <<'JSON'
+{
+  "name": "third-mkt",
+  "metadata": {"version": "0.2.0"},
+  "plugins": [
+    {"name": "third-plugin", "source": "./plugins/third-plugin", "version": "0.2.0"}
+  ]
+}
+JSON
+cat > "$DEV_THIRD_MARKETPLACE_ROOT/plugins/third-plugin/.mcp.json" <<'JSON'
+{
+  "mcpServers": {
+    "third-plugin": {
+      "type": "http",
+      "url": "https://updated.example.invalid/mcp",
+      "headers": {
+        "Authorization": "Bearer __TOKEN_PLACEHOLDER__"
+      }
+    }
+  }
+}
+JSON
+printf 'third source\n' > "$DEV_THIRD_MARKETPLACE_ROOT/plugins/third-plugin/server.ts"
+THIRD_CACHE_VERSION_DIR="$BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT/third-mkt/third-plugin/0.2.0"
+rm -rf "$BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT/third-mkt"
+mkdir -p "$THIRD_CACHE_VERSION_DIR"
+cat > "$THIRD_CACHE_VERSION_DIR/.mcp.json" <<'JSON'
+{
+  "mcpServers": {
+    "third-plugin": {
+      "type": "http",
+      "url": "https://old.example.invalid/mcp",
+      "headers": {
+        "Authorization": "Bearer live-secret"
+      }
+    }
+  }
+}
+JSON
+chmod 0600 "$THIRD_CACHE_VERSION_DIR/.mcp.json"
+cat > "$TMP_ROOT/known_marketplaces.json" <<JSON
+{
+  "third-mkt": {
+    "source": {"source": "git", "repo": "Example/third-mkt"},
+    "installLocation": "$DEV_THIRD_MARKETPLACE_ROOT"
+  }
+}
+JSON
+DEV_THIRD_CACHE_JSON="$(python3 "$REPO_ROOT/bridge-dev-plugin-cache.py" sync --channels "plugin:third-plugin@third-mkt" --root "$DEV_PLUGIN_MARKETPLACE_ROOT" --json)"
+python3 - "$DEV_THIRD_CACHE_JSON" "$THIRD_CACHE_VERSION_DIR/.mcp.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+payload = json.loads(sys.argv[1])
+row = payload["results"][0]
+assert row["plugin"] == "third-plugin", row
+assert row["marketplace"] == "third-mkt", row
+assert row["status"] in {"linked", "updated", "unchanged"}, row
+mcp = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+server = mcp["mcpServers"]["third-plugin"]
+assert server["url"] == "https://updated.example.invalid/mcp", server
+assert server["headers"]["Authorization"] == "Bearer live-secret", server
+PY
+THIRD_CACHE_MCP_MODE="$(stat -c '%a' "$THIRD_CACHE_VERSION_DIR/.mcp.json" 2>/dev/null || stat -f '%Lp' "$THIRD_CACHE_VERSION_DIR/.mcp.json")"
+[[ "$THIRD_CACHE_MCP_MODE" == "600" ]] || die "third-party dev cache .mcp.json mode widened during secret-preserving overlay: got $THIRD_CACHE_MCP_MODE"
+
 BOOTSTRAP_FAIL_HOME="$TMP_ROOT/bootstrap-fail-home"
 mkdir -p "$BOOTSTRAP_FAIL_HOME"
 BOOTSTRAP_FAIL_OUTPUT="$(HOME="$BOOTSTRAP_FAIL_HOME" BRIDGE_CLAUDE_CHANNELS_HOME="$TMP_ROOT/empty-claude-channels" "$REPO_ROOT/agent-bridge" bootstrap --admin bootstrap-fail --engine claude --session bootstrap-fail --channels plugin:telegram --allow-from 123456789 --default-chat 123456789 --rcfile "$TMP_ROOT/bootstrap-fail.rc" --skip-daemon --skip-launchagent 2>&1 || true)"
@@ -6849,10 +6922,10 @@ DAEMON_DAILY_OUTPUT="$(
     process_daily_backup >/dev/null
     archive="$(find "'"$DAEMON_BACKUP_HOME"'/backups/daily" -maxdepth 1 -name "agent-bridge-*.tgz" | head -n 1)"
     [[ -n "$archive" && -f "$archive" ]] || exit 1
-    before="$(stat -f "%m" "$archive" 2>/dev/null || stat -c "%Y" "$archive")"
+    before="$(stat -c "%Y" "$archive" 2>/dev/null || stat -f "%m" "$archive")"
     sleep 1
     process_daily_backup >/dev/null || true
-    after="$(stat -f "%m" "$archive" 2>/dev/null || stat -c "%Y" "$archive")"
+    after="$(stat -c "%Y" "$archive" 2>/dev/null || stat -f "%m" "$archive")"
     printf "ARCHIVE=%s\nBEFORE=%s\nAFTER=%s\n" "$archive" "$before" "$after"
   '
 )"
@@ -7107,7 +7180,7 @@ APPLY_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "$
 assert_contains "$APPLY_JSON" "\"files_mode_synced\": 1"
 assert_contains "$APPLY_JSON" "\"applied\": true"
 # apply-live stamps the source's exec bits onto the live file.
-mode_after="$(stat -f '%Lp' "$MODE_ROOT/tool.sh" 2>/dev/null || stat -c '%a' "$MODE_ROOT/tool.sh")"
+mode_after="$(stat -c '%a' "$MODE_ROOT/tool.sh" 2>/dev/null || stat -f '%Lp' "$MODE_ROOT/tool.sh")"
 [[ "$mode_after" == "755" ]] || die "expected tool.sh to be 755 after mode sync, got $mode_after"
 # A second pass is idempotent (no drift, no rewrites).
 SECOND_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "$MODE_REPO" --target-root "$MODE_ROOT" --base-ref "$MODE_BASE")"
@@ -7136,7 +7209,7 @@ cp "$MISMATCH_REPO/tool.sh" "$MISMATCH_ROOT/tool.sh"
 chmod 0644 "$MISMATCH_ROOT/tool.sh"
 MISMATCH_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "$MISMATCH_REPO" --target-root "$MISMATCH_ROOT" --base-ref "$MISMATCH_BASE")"
 assert_contains "$MISMATCH_JSON" "\"files_mode_synced\": 1"
-mode_mismatch="$(stat -f '%Lp' "$MISMATCH_ROOT/tool.sh" 2>/dev/null || stat -c '%a' "$MISMATCH_ROOT/tool.sh")"
+mode_mismatch="$(stat -c '%a' "$MISMATCH_ROOT/tool.sh" 2>/dev/null || stat -f '%Lp' "$MISMATCH_ROOT/tool.sh")"
 [[ "$mode_mismatch" == "755" ]] || die "expected tool.sh to be 755 from git index (100755), got $mode_mismatch (worktree drift must not leak)"
 
 log "smart upgrade propagates exec-bit removal from source"
@@ -7158,7 +7231,7 @@ git -C "$REMOVE_REPO" commit -qm "tool script without exec bit"
 REMOVE_BASE="$(git -C "$REMOVE_REPO" rev-parse HEAD)"
 REMOVE_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "$REMOVE_REPO" --target-root "$REMOVE_ROOT" --base-ref "$REMOVE_BASE")"
 assert_contains "$REMOVE_JSON" "\"files_mode_synced\": 1"
-mode_removed="$(stat -f '%Lp' "$REMOVE_ROOT/tool.sh" 2>/dev/null || stat -c '%a' "$REMOVE_ROOT/tool.sh")"
+mode_removed="$(stat -c '%a' "$REMOVE_ROOT/tool.sh" 2>/dev/null || stat -f '%Lp' "$REMOVE_ROOT/tool.sh")"
 [[ "$mode_removed" == "644" ]] || die "expected tool.sh to be 644 after exec-bit removal, got $mode_removed"
 
 log "strict merge aborts on conflict without touching live file"

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -1136,113 +1136,152 @@ adv_run_unsafe_id "dotdot-mid"        "foo..bar"
 adv_run_unsafe_id "leading-slash"     "/foo"
 adv_run_unsafe_id "trailing-slash"    "foo/"
 
-# Subgroup B — control-char and empty cases. `bridge_agent_plugins_csv`
-# tokenises on `[ \t\n,]` so a literal newline/tab in BRIDGE_AGENT_PLUGINS
-# would be consumed as a separator before reaching the validator. Drive
-# the catalog-generator's validator directly with a synthesised
-# known_marketplaces.json so the bash CSV path doesn't shield us from
-# the assertion.
-adv_run_unsafe_id_via_catalog_gen() {
-  local label="$1" mkt_id="$2" alias_id="${3:-}"
-  local adv_dir="$TMP_ROOT/adv-cg-${label}"
-  rm -rf "$adv_dir" >/dev/null 2>&1 || true
-  mkdir -p "$adv_dir/isolated/plugins" "$adv_dir/controller-plugins"
-  python3 - "$adv_dir/controller-plugins/known_marketplaces.json" "$mkt_id" <<'PY'
+# Subgroup B — adversarial inputs that *cannot* enter via BRIDGE_AGENT_PLUGINS
+# (the bash tokenizer in `bridge_agent_plugins_csv` splits on `[ \t\n,]`)
+# but CAN enter via `known_marketplaces.json` keys/values, which is
+# operator-controlled JSON. The end-to-end gate is:
+#   BRIDGE_AGENT_PLUGINS  → tokenize  → catalog write  → validator
+# so the security boundary that codex r2 finding 4b challenged is whether
+# adversarial JSON content reaches the validator and is rejected.
+#
+# These cases drive `bridge_linux_share_plugin_catalog` end-to-end (the
+# real production attack surface) rather than re-implementing the
+# validator in inline Python — which was the bypass r2 flagged.
+adv_run_unsafe_known_marketplaces_key() {
+  # Stage a controller `known_marketplaces.json` whose KEY contains an
+  # adversarial sequence (newline, tab, etc.) and a clean plugin ref to
+  # ensure the catalog generator iterates the entry. Assert the share
+  # helper fails loud.
+  #
+  # Mechanism:
+  #   - The agent declares a *clean* marketplace id via
+  #     BRIDGE_AGENT_PLUGINS, but we ALSO inject an unsafe key into the
+  #     controller's known_marketplaces.json. The catalog generator
+  #     iterates `declared_marketplaces()` (filtered to declared) and
+  #     would only validate the clean id — so we additionally seed
+  #     installed_plugins.json with a `<plugin>@<unsafe_key>` entry
+  #     that the agent declares verbatim. The bash tokenizer's literal-
+  #     character split keeps `..` / `foo..bar` / `/foo` intact (these
+  #     pass the tokenizer untouched, see Subgroup A), and we use those
+  #     same shapes here against the END-to-end catalog writer.
+  #
+  # NOTE: literal `\n`/`\t` cannot enter via BRIDGE_AGENT_PLUGINS at all
+  # because the bash tokenizer eats them. The matching coverage is in
+  # the unit assertion at the bottom of this section, which targets the
+  # validator's regex/length/empty branches the way an operator would
+  # see them in a `bridge_isolate` failure log.
+  local label="$1" mkt_id="$2"
+  cp "$ADV_SNAP_INSTALLED" "$CONTROLLER_PLUGINS/installed_plugins.json"
+  cp "$ADV_SNAP_KNOWN" "$CONTROLLER_PLUGINS/known_marketplaces.json"
+  python3 - "$CONTROLLER_PLUGINS/known_marketplaces.json" "$mkt_id" <<'PY'
 import json, sys
 path, mkt_id = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data[mkt_id] = {
+    "source": {"source": "git", "repo": "Example-Org/unsafe-mkt"},
+    "installLocation": "/nonexistent/unsafe",
+}
 with open(path, "w") as f:
-    json.dump({
-        mkt_id: {
-            "source": {"source": "git", "repo": "Example-Org/unsafe-mkt"},
-            "installLocation": "/nonexistent/unsafe",
-        }
-    }, f)
+    json.dump(data, f, indent=2)
 PY
-  # Run the catalog-generator's Python heredoc body directly so we
-  # bypass the bash CSV tokenizer entirely. The body lives inline in
-  # bridge_write_isolated_known_marketplaces_catalog; we mirror its
-  # interface here via the SAME validator code paths.
+  python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$mkt_id" <<'PY'
+import json, sys
+manifest_path, mkt_id = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["unsafe-plugin@" + mkt_id] = [
+    {"scope": "user", "version": "0.1.0", "installPath": "/nonexistent/unsafe"}
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+  BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]="unsafe-plugin@${mkt_id}"
   set +e
   local out=""
-  out="$(python3 - "$adv_dir/controller-plugins" "$adv_dir/isolated/plugins" \
-        "" "unsafe-plugin@${mkt_id}" "$adv_dir/out.json" 2>&1 <<'PY'
-import json
-import os
-import re
-import sys
-
-controller_plugins, isolated_plugins, channels_csv, plugins_csv, out_path = sys.argv[1:]
-markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
-
-_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
-_RES = {".", ".."}
-_WIN = ({"CON","PRN","AUX","NUL"}
-        | {"COM%d"%i for i in range(1,10)}
-        | {"LPT%d"%i for i in range(1,10)})
-def reason(a):
-    if not isinstance(a, str): return "not a string"
-    if a == "": return "empty"
-    if len(a) > 200: return "length exceeds 200"
-    if not _SAFE_ALIAS_RE.match(a): return "regex"
-    if ".." in a: return "contains '..'"
-    if a in _RES: return "reserved name"
-    if a.upper() in _WIN: return "reserved Windows name"
-    if a.startswith(".") and a != ".git": return "leading dot disallowed"
-    return ""
-
-def declared(channels_csv, plugins_csv):
-    out = set()
-    for raw in (channels_csv + "," + plugins_csv).split(","):
-        token = raw.strip()
-        if token.startswith("plugin:"):
-            token = token[len("plugin:"):]
-        if "@" not in token:
-            continue
-        _p, m = token.split("@", 1)
-        if m:
-            out.add(m)
-    return out
-
-# `BRIDGE_AGENT_PLUGINS["agent"]="unsafe-plugin@<mkt_id>"` is what the
-# operator typed; the bash CSV tokenizer would mangle whitespace, so
-# inject the marketplace id directly via declared().
-mkt_ids = declared(channels_csv, plugins_csv)
-for m in mkt_ids:
-    r = reason(m)
-    if r:
-        print("[bridge-isolate] marketplace id %r rejected: %s" % (m, r), file=sys.stderr)
-        raise SystemExit(2)
-print("[bridge-isolate] all marketplace ids passed validation: %r" % sorted(mkt_ids))
-PY
-)"
+  out="$(BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+    bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT" 2>&1)"
   local rc=$?
   set -e
   if [[ "$rc" -eq 0 ]]; then
-    die "Adv-3[$label]: catalog-generator validator did NOT reject mkt_id $(printf '%q' "$mkt_id"); output: $out"
+    die "Adv-3[$label]: bridge_linux_share_plugin_catalog should have failed loud on adversarial known_marketplaces.json key $(printf '%q' "$mkt_id"); rc=0, output: $out"
   fi
   case "$out" in
-    *rejected*) : ;;
-    *) die "Adv-3[$label]: expected 'rejected' in stderr, got: $out" ;;
+    *rejected*|*unsafe*|*"alias collision"*) : ;;
+    *)
+      die "Adv-3[$label]: expected 'rejected' or 'unsafe' in error for known_marketplaces.json key $(printf '%q' "$mkt_id"), got: $out"
+      ;;
   esac
 }
 
-adv_run_unsafe_id_via_catalog_gen "embedded-newline" "$(printf 'foo\nbar')"
-adv_run_unsafe_id_via_catalog_gen "embedded-tab"     "$(printf 'foo\tbar')"
-adv_run_unsafe_id_via_catalog_gen "dot-only"         "."
-adv_run_unsafe_id_via_catalog_gen "double-dot-only"  ".."
+# Adversarial JSON-key forms that the bash tokenizer DOES preserve
+# verbatim (so the production end-to-end pipeline carries them to the
+# validator inside `bridge_write_isolated_known_marketplaces_catalog`).
+adv_run_unsafe_known_marketplaces_key "key-dot-only"        "."
+adv_run_unsafe_known_marketplaces_key "key-double-dot-only" ".."
 
-# The empty-id case never reaches the validator from any production
-# path (the `@` parser short-circuits when marketplace is empty after
-# split). Pin the validator's empty-string branch with a direct unit
-# assertion so a future refactor can't silently relax it.
+# Tokenizer coverage: confirm `bridge_agent_plugins_csv` strips
+# `\n`/`\t`/space from BRIDGE_AGENT_PLUGINS values BEFORE the catalog
+# generator sees them. This pins the upstream gate that prevents
+# whitespace-bearing entries from reaching the validator end-to-end —
+# the design contract that r2 finding 4b asked us to make explicit.
+# Implementation: `read -ra` with IFS=$' \t\n,' tokenizes the raw value;
+# `<<<` herestring + `read`'s default line-bounded behavior means a
+# `\n` truncates the input at the first newline (the rest is dropped),
+# while `\t` and ` ` are treated as token separators. Either way: NO
+# whitespace byte reaches the emitted CSV. Test runs in a subshell so
+# adversarial assignments don't leak into the rest of the suite.
+log "Adv-3 tokenizer-rejection: BRIDGE_AGENT_PLUGINS whitespace-bearing entries are stripped by bridge_agent_plugins_csv"
+(
+  declare -A BRIDGE_AGENT_PLUGINS=()
+  # Newline-bearing input: read truncates at the first `\n`; rest dropped.
+  BRIDGE_AGENT_PLUGINS["adv_tok"]=$'plugin-a@safe-mkt\nplugin-b@bad-mkt'
+  csv="$(bridge_agent_plugins_csv adv_tok)"
+  case "$csv" in
+    *$'\n'*) printf '[adv-tok] FAIL: tokenizer leaked literal newline: %q\n' "$csv" >&2; exit 1 ;;
+  esac
+  # Tab-bearing input: tab is treated as a token separator; both halves
+  # land in the CSV but each is whitespace-free.
+  BRIDGE_AGENT_PLUGINS["adv_tok"]=$'plugin-a@safe-mkt\tplugin-b@bad-mkt'
+  csv="$(bridge_agent_plugins_csv adv_tok)"
+  case "$csv" in
+    *$'\n'*|*$'\t'*) printf '[adv-tok] FAIL: tokenizer leaked tab: %q\n' "$csv" >&2; exit 1 ;;
+  esac
+  # Space-bearing input: same — space is a separator.
+  BRIDGE_AGENT_PLUGINS["adv_tok"]='plugin-a@safe-mkt plugin-b@bad-mkt'
+  csv="$(bridge_agent_plugins_csv adv_tok)"
+  case "$csv" in
+    *' '*) printf '[adv-tok] FAIL: tokenizer leaked space: %q\n' "$csv" >&2; exit 1 ;;
+  esac
+  # Pathological: trailing newline alone — first token must still be
+  # whitespace-free in the emitted CSV (regression for r3 #3a where the
+  # *validator* tolerated trailing newline; the tokenizer's strip is
+  # the upstream gate that makes this unreachable through this path).
+  BRIDGE_AGENT_PLUGINS["adv_tok"]=$'plugin-a@safe-mkt\n'
+  csv="$(bridge_agent_plugins_csv adv_tok)"
+  case "$csv" in
+    *$'\n'*) printf '[adv-tok] FAIL: tokenizer kept trailing newline: %q\n' "$csv" >&2; exit 1 ;;
+  esac
+  [[ "$csv" == "plugin-a@safe-mkt" ]] \
+    || { printf '[adv-tok] FAIL: trailing-newline csv unexpected: %q\n' "$csv" >&2; exit 1; }
+  exit 0
+) || die "Adv-3 tokenizer rejection: BRIDGE_AGENT_PLUGINS whitespace leaked through bridge_agent_plugins_csv (security gate broken)"
+
+# Validator unit pin: empty/whitespace/length/trailing-newline branches.
+# The trailing-newline assertion is the r3 finding 3a regression: the
+# old `re.match(... + "$")` form let `foo\n` pass (in default mode, `$`
+# matches before a trailing `\n`). `re.fullmatch` rejects it. Both
+# Python validators (lib/bridge-agents.sh inline + bridge-dev-plugin-
+# cache.py module-level) must agree.
 python3 - <<'PY'
 import re
-_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+# Mirror the production validator. Use `fullmatch`, not `match(... + "$")`.
+_SAFE_ALIAS_RE = re.compile(r"[A-Za-z0-9._-]+")
 def reason(a):
     if not isinstance(a, str): return "not a string"
     if a == "": return "empty"
     if len(a) > 200: return "length exceeds 200"
-    if not _SAFE_ALIAS_RE.match(a): return "regex"
+    if not _SAFE_ALIAS_RE.fullmatch(a): return "regex"
     if ".." in a: return "contains '..'"
     if a in {".", ".."}: return "reserved name"
     if a.startswith(".") and a != ".git": return "leading dot disallowed"
@@ -1251,6 +1290,35 @@ assert reason("") == "empty", "empty alias must be rejected"
 assert reason(".git") == "", "'.git' is the documented escape hatch and must remain accepted"
 assert reason("foo bar") != "", "whitespace must be rejected"
 assert reason("a" * 201) != "", "length>200 must be rejected"
+# r3 finding 3a regressions: trailing newline / carriage-return must be
+# rejected. With the OLD `re.match(... + "$")` form these passed; with
+# `re.fullmatch` they're rejected.
+assert reason("foo\n") != "", "alias with trailing newline must be rejected (r3 #3a)"
+assert reason("bar\n") != "", "alias 'bar\\n' must be rejected (r3 #3a)"
+assert reason("baz\r") != "", "alias 'baz\\r' must be rejected (r3 #3a)"
+# Sanity: the same prefix without the control char remains accepted.
+assert reason("foo") == "", "clean alias 'foo' must remain accepted"
+assert reason("baz") == "", "clean alias 'baz' must remain accepted"
+PY
+
+# Cross-validator parity check: import BOTH production validators and
+# confirm they agree on the trailing-newline regression. This is the
+# regression bridge between bridge-dev-plugin-cache.py (where #3a was
+# discovered) and the lib/bridge-agents.sh inline mirror — drift here
+# would let one path block while the other passes adversarial input.
+python3 - "$REPO_ROOT" <<'PY'
+import importlib.util, pathlib, sys
+repo_root = pathlib.Path(sys.argv[1])
+dev_cache_path = repo_root / "bridge-dev-plugin-cache.py"
+spec = importlib.util.spec_from_file_location("bridge_dev_plugin_cache", dev_cache_path)
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+fn = mod._alias_rejection_reason
+for sample in ("foo\n", "bar\n", "baz\r", "alias\x00null", "alias\x1fctrl"):
+    r = fn(sample)
+    assert r, "bridge-dev-plugin-cache.py must reject %r (got %r)" % (sample, r)
+assert fn("foo") == "", "clean alias must pass dev-cache validator"
+assert fn(".git") == "", "documented escape hatch must pass dev-cache validator"
 PY
 log "Adv-3 PASS"
 
@@ -1325,11 +1393,44 @@ ADV_AB_SRC="$(printf '%s\n' "$ADV_AB_OUT" | awk -F'\t' '{print $2}')"
   || die "Adv-5: expected installLocation ($ADV_INSTALL_LOC) to win over source.path ($ADV_SRC_PATH); helper resolved $ADV_AB_SRC (raw: $ADV_AB_OUT)"
 log "Adv-5 PASS"
 
-# Note: v2 group enforcement (non-group-member UID cannot read catalog)
-# is exercised by tests/isolation-v2-primitives/smoke.sh. Adding a v2
-# group setup to this fixture would require system-group provisioning
-# that overlaps significantly with that suite; keeping it out of scope
-# avoids a duplicated and harder-to-maintain v2 sandbox here.
+# Adv-6: v2 group-membership-based read denial. The PR-E security claim
+# is that under BRIDGE_LAYOUT=v2 the per-UID known_marketplaces.json is
+# group-readable by `ab-agent-<agent>` (via chgrp + 0640) and a UID NOT
+# in that group cannot read it. The Adv-4 path above exercises the v1
+# named-user ACL boundary; this section pins the v2 group boundary.
+#
+# Capability gate: this needs a SECOND non-root UID that is provably
+# NOT a member of the agent group. Provisioning a second system user
+# from inside this test is a meaningful CI burden (groupdel timing,
+# uid collisions) so we gate behind BRIDGE_TEST_PR_C_NONMEMBER_UID and
+# explicit-skip otherwise. Silent skip is rejected — that was the gap
+# that prompted r3 review finding 4a.
+log "Adv-6: v2 group-membership-based read denial (non-member UID cannot read catalog)"
+ADV6_NONMEMBER_UID="${BRIDGE_TEST_PR_C_NONMEMBER_UID:-}"
+if [[ -z "$ADV6_NONMEMBER_UID" ]]; then
+  log "Adv-6 SKIP: requires non-group-member non-root UID via BRIDGE_TEST_PR_C_NONMEMBER_UID=<username>"
+  log "Adv-6 SKIP rationale: the v1 named-user ACL path is exercised by Adv-4 above; the v2 group boundary requires a second system UID that is not a member of ab-agent-<agent> — provisioning that here would duplicate v2-pr-c smoke fixture setup."
+  log "Adv-6 SKIP NOTE: this is an explicit capability gap, NOT silent coverage. Operator running on a Linux CI lane with two test UIDs MUST set BRIDGE_TEST_PR_C_NONMEMBER_UID to exercise the gate end-to-end before claiming v2 group denial passes."
+elif ! bridge_isolation_v2_active 2>/dev/null; then
+  log "Adv-6 SKIP: BRIDGE_LAYOUT!=v2 — group ACL contract is v2-only, v1 ACL path covered by Adv-4."
+elif ! id "$ADV6_NONMEMBER_UID" >/dev/null 2>&1; then
+  die "Adv-6: BRIDGE_TEST_PR_C_NONMEMBER_UID=$ADV6_NONMEMBER_UID does not exist as a system user"
+else
+  ADV6_GROUP="$(bridge_isolation_v2_agent_group_name "$TEST_AGENT" 2>/dev/null || printf '')"
+  [[ -n "$ADV6_GROUP" ]] || die "Adv-6: bridge_isolation_v2_agent_group_name returned empty for $TEST_AGENT"
+  if id -nG "$ADV6_NONMEMBER_UID" 2>/dev/null | tr ' ' '\n' | grep -Fxq "$ADV6_GROUP"; then
+    die "Adv-6: BRIDGE_TEST_PR_C_NONMEMBER_UID=$ADV6_NONMEMBER_UID is a member of $ADV6_GROUP — must be a non-member to exercise the denial path"
+  fi
+  ADV6_CATALOG="$ISOLATED_PLUGINS/known_marketplaces.json"
+  # Group member (TEST_OS_USER) must be able to read.
+  sudo -n -u "$TEST_OS_USER" cat "$ADV6_CATALOG" >/dev/null \
+    || die "Adv-6: group-member UID $TEST_OS_USER could not read $ADV6_CATALOG (v2 group ACL broken)"
+  # Non-member must NOT be able to read.
+  if sudo -n -u "$ADV6_NONMEMBER_UID" cat "$ADV6_CATALOG" >/dev/null 2>&1; then
+    die "Adv-6: non-group-member UID $ADV6_NONMEMBER_UID was able to read $ADV6_CATALOG — v2 group boundary broken"
+  fi
+  log "Adv-6 PASS: non-member UID $ADV6_NONMEMBER_UID denied, group member $TEST_OS_USER allowed"
+fi
 
 # Restore baseline state and re-run a normal share so the linear
 # unisolate flow below operates against the expected snapshot.

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -1476,10 +1476,12 @@ parity_inputs = [
     "foo",                  # both accept
     ".git",                 # both accept (documented escape hatch)
     "valid_alias-1.0",      # both accept
+    "foo.git",              # both accept (".git" escape only applies when alias == ".git", not as a suffix)
     "",                     # both reject (empty)
     ".",                    # both reject (reserved)
     "..",                   # both reject (contains '..' / reserved)
     "../etc",               # both reject (contains '..')
+    "foo..bar",             # both reject (contains '..' mid-string, no slash)
     ".secret",              # both reject (leading dot, not .git)
     "CON",                  # both reject (Windows reserved)
     "com1",                 # both reject (Windows reserved, case-folded)
@@ -1490,6 +1492,8 @@ parity_inputs = [
     "foo\n",                # both reject (trailing newline — r3 #3a)
     "bar\n",                # both reject (trailing newline)
     "baz\r",                # both reject (trailing CR)
+    "foo\r",                # both reject (trailing CR — codex r4 sample)
+    "foo\t",                # both reject (trailing TAB — codex r4 sample)
     "alias\x00null",        # both reject (NUL byte)
     "alias\x1fctrl",        # both reject (control byte)
     "a" * 201,              # both reject (length > 200)

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -1220,6 +1220,87 @@ PY
 adv_run_unsafe_known_marketplaces_key "key-dot-only"        "."
 adv_run_unsafe_known_marketplaces_key "key-double-dot-only" ".."
 
+# Whitespace-embedded JSON keys (r3 finding 4b end-to-end gap): the bash
+# tokenizer in `bridge_agent_plugins_csv` / `bridge_normalize_channels_csv`
+# strips space/tab/newline/CR from agent declarations BEFORE the catalog
+# generator sees them, so `adv_run_unsafe_known_marketplaces_key` cannot
+# carry these shapes through BRIDGE_AGENT_PLUGINS. To exercise the
+# validator's whitespace-rejection branch end-to-end against the actual
+# JSON-key surface, we invoke `bridge_write_isolated_known_marketplaces_catalog`
+# directly with a hand-crafted channels_csv that bypasses the bash
+# tokenizer. The catalog writer's inline `declared_marketplaces()` does
+# call `token.strip()` on each split element, so leading/trailing
+# whitespace (e.g. `\tfoo`, `foo\n`) is collapsed before the validator
+# sees the key — those shapes are covered separately by the
+# cross-validator parity sweep below (which calls the inline lib
+# validator directly with no tokenizer/strip in the way). The cases
+# here are the embedded-whitespace shapes that survive `.strip()` and
+# reach the validator with their whitespace intact.
+adv_run_unsafe_known_marketplaces_key_bypass_tokenizer() {
+  # Stage a controller `known_marketplaces.json` whose KEY contains a
+  # whitespace-bearing sequence and pass that key verbatim to the
+  # catalog writer via channels_csv (no bash-level tokenization). Assert
+  # non-zero exit and an error message that names the offending key.
+  local label="$1" mkt_id="$2"
+  cp "$ADV_SNAP_INSTALLED" "$CONTROLLER_PLUGINS/installed_plugins.json"
+  cp "$ADV_SNAP_KNOWN" "$CONTROLLER_PLUGINS/known_marketplaces.json"
+  python3 - "$CONTROLLER_PLUGINS/known_marketplaces.json" "$mkt_id" <<'PY'
+import json, sys
+path, mkt_id = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data[mkt_id] = {
+    "source": {"source": "git", "repo": "Example-Org/unsafe-mkt"},
+    "installLocation": "/nonexistent/unsafe",
+}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+  # Hand-crafted channels_csv: the catalog writer's `declared_marketplaces()`
+  # splits on `,`, calls `token.strip()` on each element (so we MUST use
+  # embedded-whitespace shapes — leading/trailing whitespace is stripped
+  # off before the `@`-split), then takes everything after `@` as the
+  # marketplace id. We deliberately bypass `bridge_agent_channels_csv`
+  # (which would also strip embedded whitespace via its tokenizer) so
+  # the bad key reaches the validator unmodified.
+  local channels_csv="plugin:unsafe-plugin@${mkt_id}"
+  set +e
+  local out=""
+  out="$(BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+    bridge_write_isolated_known_marketplaces_catalog \
+      "$TEST_OS_USER" "$ISOLATED_PLUGINS" "$CONTROLLER_PLUGINS" \
+      "$channels_csv" "" "$TEST_AGENT" 2>&1)"
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    die "Adv-3[$label]: bridge_write_isolated_known_marketplaces_catalog should have failed loud on whitespace-bearing known_marketplaces.json key $(printf '%q' "$mkt_id"); rc=0, output: $out"
+  fi
+  case "$out" in
+    *rejected*|*unsafe*|*"alias collision"*) : ;;
+    *)
+      die "Adv-3[$label]: expected 'rejected' or 'unsafe' in error for whitespace-bearing known_marketplaces.json key $(printf '%q' "$mkt_id"), got: $out"
+      ;;
+  esac
+}
+
+# Whitespace shapes that survive `.strip()` in `declared_marketplaces()`
+# and reach `alias_rejection_reason` with their whitespace bytes intact:
+#   - embedded space/tab/newline/CR (whitespace BETWEEN non-whitespace
+#     chars is preserved by `.strip()`)
+#   - leading whitespace AFTER an `@` (the strip happens before the
+#     `@`-split, so a tab between `@` and the rest of the marketplace
+#     id stays attached to the marketplace half)
+# The trailing-whitespace shape `foo\n` is collapsed to `foo` by
+# `token.strip()` (the entire token's trailing newline is stripped
+# before the `@`-split), so that case doesn't reach the validator on
+# this end-to-end path. It's covered by the cross-validator parity
+# sweep below, which calls the inline lib validator directly.
+adv_run_unsafe_known_marketplaces_key_bypass_tokenizer "key-embedded-space"   'foo bar'
+adv_run_unsafe_known_marketplaces_key_bypass_tokenizer "key-embedded-tab"     $'foo\tbar'
+adv_run_unsafe_known_marketplaces_key_bypass_tokenizer "key-embedded-newline" $'foo\nbar'
+adv_run_unsafe_known_marketplaces_key_bypass_tokenizer "key-embedded-cr"      $'foo\rbar'
+adv_run_unsafe_known_marketplaces_key_bypass_tokenizer "key-leading-tab"      $'\tfoo'
+
 # Tokenizer coverage: confirm `bridge_agent_plugins_csv` strips
 # `\n`/`\t`/space from BRIDGE_AGENT_PLUGINS values BEFORE the catalog
 # generator sees them. This pins the upstream gate that prevents
@@ -1306,19 +1387,143 @@ PY
 # regression bridge between bridge-dev-plugin-cache.py (where #3a was
 # discovered) and the lib/bridge-agents.sh inline mirror — drift here
 # would let one path block while the other passes adversarial input.
+#
+# r3 finding 4b second gap: the previous version of this block only
+# imported bridge-dev-plugin-cache.py and never exercised the inline
+# `lib/bridge-agents.sh` validator. The inline mirror is text-extracted
+# from the .sh file (the canonical block inside
+# `bridge_write_isolated_known_marketplaces_catalog`), loaded into a
+# fresh module via importlib, and compared accept/reject with the
+# dev-cache validator on a fixed input set. Reason strings differ
+# between the two (the dev-cache validator interpolates the offending
+# alias), so parity is asserted on boolean accept/reject, which is what
+# the symlink-plant gate actually keys on.
 python3 - "$REPO_ROOT" <<'PY'
-import importlib.util, pathlib, sys
+import importlib.util, pathlib, sys, tempfile
+
 repo_root = pathlib.Path(sys.argv[1])
 dev_cache_path = repo_root / "bridge-dev-plugin-cache.py"
+agents_lib_path = repo_root / "lib" / "bridge-agents.sh"
+
+# 1. Standalone validator from bridge-dev-plugin-cache.py.
 spec = importlib.util.spec_from_file_location("bridge_dev_plugin_cache", dev_cache_path)
 mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
-fn = mod._alias_rejection_reason
+dev_cache_fn = mod._alias_rejection_reason
+
+# 2. Extract the inline-lib validator body from lib/bridge-agents.sh by
+#    line-based slicing (regex-with-DOTALL across multiple `(...)` paren
+#    blocks risks catastrophic backtracking, so we walk lines instead).
+#    The .sh file embeds the validator as part of a python heredoc inside
+#    `bridge_known_marketplace_info` /
+#    `bridge_write_isolated_known_marketplaces_catalog` /
+#    `bridge_write_isolated_installed_plugins_manifest`. All three
+#    mirrors are kept in sync; we take the first match. Anchor on the
+#    `_SAFE_ALIAS_RE` declaration line (canonical), then walk forward
+#    through the `def alias_rejection_reason(alias):` header to the
+#    first `return ""` line that closes the function body. The block is
+#    written to a temp .py file and importlib-loaded so
+#    `alias_rejection_reason` becomes a directly-callable Python
+#    function in this process.
+agents_lib_lines = agents_lib_path.read_text().split("\n")
+_safe_alias_marker = '_SAFE_ALIAS_RE = re.compile(r"[A-Za-z0-9._-]+")'
+start_idx = None
+for i, ln in enumerate(agents_lib_lines):
+    if ln.strip() == _safe_alias_marker:
+        start_idx = i
+        break
+assert start_idx is not None, (
+    "could not locate `_SAFE_ALIAS_RE` declaration in lib/bridge-agents.sh; "
+    "the parity test slices the inline validator from that anchor — if you "
+    "renamed the constant, update the marker here."
+)
+def_idx = None
+for i in range(start_idx, len(agents_lib_lines)):
+    if agents_lib_lines[i].strip() == "def alias_rejection_reason(alias):":
+        def_idx = i
+        break
+assert def_idx is not None, (
+    "found `_SAFE_ALIAS_RE` in lib/bridge-agents.sh but no following "
+    "`def alias_rejection_reason(alias):` — the inline validator shape "
+    "changed; update the parity-test slice anchors here."
+)
+end_idx = None
+for i in range(def_idx + 1, len(agents_lib_lines)):
+    if agents_lib_lines[i].strip() == 'return ""':
+        end_idx = i
+        break
+assert end_idx is not None, (
+    "found `def alias_rejection_reason` in lib/bridge-agents.sh but no "
+    "`return \"\"` line that closes the function — update parity-test "
+    "slice here."
+)
+inline_lib_src = "import re\n" + "\n".join(agents_lib_lines[start_idx:end_idx + 1]) + "\n"
+with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as tf:
+    tf.write(inline_lib_src)
+    inline_lib_tmp = tf.name
+inline_spec = importlib.util.spec_from_file_location("bridge_agents_inline_validator", inline_lib_tmp)
+inline_mod = importlib.util.module_from_spec(inline_spec)
+inline_spec.loader.exec_module(inline_mod)
+inline_lib_fn = inline_mod.alias_rejection_reason
+
+# Sanity: both validators must be live callables.
+assert callable(dev_cache_fn) and callable(inline_lib_fn)
+
+# 3. Boolean accept/reject parity sweep. Reason strings differ
+#    intentionally (the dev-cache validator interpolates the offending
+#    alias for operator legibility), so we compare `bool(reason)` only.
+parity_inputs = [
+    "foo",                  # both accept
+    ".git",                 # both accept (documented escape hatch)
+    "valid_alias-1.0",      # both accept
+    "",                     # both reject (empty)
+    ".",                    # both reject (reserved)
+    "..",                   # both reject (contains '..' / reserved)
+    "../etc",               # both reject (contains '..')
+    ".secret",              # both reject (leading dot, not .git)
+    "CON",                  # both reject (Windows reserved)
+    "com1",                 # both reject (Windows reserved, case-folded)
+    "foo bar",              # both reject (whitespace)
+    "foo\tbar",             # both reject (whitespace)
+    "foo\nbar",             # both reject (whitespace)
+    "foo\rbar",             # both reject (whitespace)
+    "foo\n",                # both reject (trailing newline — r3 #3a)
+    "bar\n",                # both reject (trailing newline)
+    "baz\r",                # both reject (trailing CR)
+    "alias\x00null",        # both reject (NUL byte)
+    "alias\x1fctrl",        # both reject (control byte)
+    "a" * 201,              # both reject (length > 200)
+    "/etc/passwd",          # both reject (slash outside charset)
+    "../../../root",        # both reject (slash + ..)
+]
+for sample in parity_inputs:
+    dev_reason = dev_cache_fn(sample)
+    lib_reason = inline_lib_fn(sample)
+    dev_rejected = bool(dev_reason)
+    lib_rejected = bool(lib_reason)
+    assert dev_rejected == lib_rejected, (
+        "validator parity drift on %r: dev-cache=%r (rejected=%s), "
+        "inline-lib=%r (rejected=%s)"
+        % (sample, dev_reason, dev_rejected, lib_reason, lib_rejected)
+    )
+
+# 4. Pin known accept set against both validators (regression bridge).
+for accept_input in ("foo", ".git", "valid_alias-1.0"):
+    assert dev_cache_fn(accept_input) == "", (
+        "dev-cache validator unexpectedly rejected %r" % accept_input
+    )
+    assert inline_lib_fn(accept_input) == "", (
+        "inline-lib validator unexpectedly rejected %r" % accept_input
+    )
+
+# 5. Pin known reject set with the same trailing-newline / control-byte
+#    samples that the original parity block used. Both validators must
+#    reject these — that's the security regression bridge for r3 #3a.
 for sample in ("foo\n", "bar\n", "baz\r", "alias\x00null", "alias\x1fctrl"):
-    r = fn(sample)
-    assert r, "bridge-dev-plugin-cache.py must reject %r (got %r)" % (sample, r)
-assert fn("foo") == "", "clean alias must pass dev-cache validator"
-assert fn(".git") == "", "documented escape hatch must pass dev-cache validator"
+    dev_reason = dev_cache_fn(sample)
+    lib_reason = inline_lib_fn(sample)
+    assert dev_reason, "bridge-dev-plugin-cache.py must reject %r (got %r)" % (sample, dev_reason)
+    assert lib_reason, "lib/bridge-agents.sh inline validator must reject %r (got %r)" % (sample, lib_reason)
 PY
 log "Adv-3 PASS"
 

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -51,7 +51,8 @@ command -v userdel >/dev/null 2>&1 || skip "userdel required"
 
 TMP_ROOT="$(mktemp -d -t isolate-plugin-test.XXXXXX)"
 SAFE_TMP_PREFIX=""
-for _candidate in "${TMPDIR%/}" "/tmp" "/var/tmp"; do
+for _candidate in "${TMPDIR:-}" "/tmp" "/var/tmp"; do
+  _candidate="${_candidate%/}"
   [[ -n "$_candidate" ]] || continue
   case "$TMP_ROOT" in
     "$_candidate"|"$_candidate"/*) SAFE_TMP_PREFIX="$_candidate"; break ;;
@@ -86,9 +87,11 @@ CONTROLLER_PLUGINS="$CONTROLLER_HOME_FAKE/.claude/plugins"
 mkdir -p "$CONTROLLER_PLUGINS/cache/td-mkt/declared-plugin/0.1.0" \
          "$CONTROLLER_PLUGINS/cache/td-mkt/undeclared-plugin/0.1.0" \
          "$CONTROLLER_PLUGINS/data" \
-         "$CONTROLLER_PLUGINS/marketplaces"
+         "$CONTROLLER_PLUGINS/marketplaces/td-mkt"
 echo 'declared plugin source' > "$CONTROLLER_PLUGINS/cache/td-mkt/declared-plugin/0.1.0/index.js"
 echo 'undeclared plugin source' > "$CONTROLLER_PLUGINS/cache/td-mkt/undeclared-plugin/0.1.0/index.js"
+echo '{"name":"td-mkt","plugins":["declared-plugin","undeclared-plugin"]}' \
+  > "$CONTROLLER_PLUGINS/marketplaces/td-mkt/marketplace.json"
 cat > "$CONTROLLER_PLUGINS/installed_plugins.json" <<JSON
 {
   "version": 2,
@@ -122,11 +125,13 @@ mkdir -p "$BRIDGE_HOME/plugins/declared-plugin" "$BRIDGE_HOME/plugins/undeclared
 echo 'declared plugin (dir-marketplace)' > "$BRIDGE_HOME/plugins/declared-plugin/server.ts"
 echo 'undeclared plugin (dir-marketplace)' > "$BRIDGE_HOME/plugins/undeclared-plugin/server.ts"
 
-# Make the controller-side plugin tree readable by everyone so the
-# isolated UID can actually traverse it once we grant the per-UID ACLs.
-# (The traverse chain stamps `--x` on parents up to controller_home;
-#  base mode bits also need to allow read on files we explicitly grant.)
-chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
+# Make controller-side catalog fixtures readable while keeping the synthetic
+# plugin install tree private. The isolated UID gets parent traverse via a
+# named ACL after the temp user exists; per-plugin read comes only from the
+# bridge helper under test.
+chmod o+x "$TMP_ROOT" "$BRIDGE_HOME"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE"
+chmod -R go-rwx "$BRIDGE_HOME/plugins"
 
 TEST_AGENT="qpa-test"
 TEST_OS_USER="agent-bridge-${TEST_AGENT}"
@@ -169,6 +174,11 @@ fi
 sudo -n mkdir -p "$TEST_OS_HOME"
 sudo -n chown "$TEST_OS_USER:$TEST_OS_USER" "$TEST_OS_HOME"
 sudo -n chmod 0700 "$TEST_OS_HOME"
+sudo -n mkdir -p "$TEST_OS_HOME/.claude"
+sudo -n chown "$TEST_OS_USER:$TEST_OS_USER" "$TEST_OS_HOME/.claude"
+sudo -n chmod 0700 "$TEST_OS_HOME/.claude"
+sudo -n setfacl -m "u:${TEST_OS_USER}:--x" "$TMP_ROOT" "$BRIDGE_HOME" "$BRIDGE_HOME/plugins" \
+  || die "failed to grant temp plugin parent traverse ACL to $TEST_OS_USER"
 
 TEST_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$TEST_AGENT"
 mkdir -p "$TEST_WORKDIR"
@@ -246,10 +256,25 @@ entry = m["plugins"]["declared-plugin@td-mkt"][0]
 assert "installPath" in entry and entry["installPath"], "missing installPath"
 ' || die "per-UID manifest contents do not match the channel boundary"
 
-log "verifying catalog symlinks resolve to controller copies"
-for catalog in known_marketplaces.json install-counts-cache.json blocklist.json; do
+log "verifying generated known_marketplaces.json is per-UID filtered"
+sudo -n python3 - "$ISOLATED_PLUGINS/known_marketplaces.json" "$ISOLATED_PLUGINS" <<'PY'
+import json
+import sys
+
+path, isolated_plugins = sys.argv[1:]
+with open(path) as f:
+    data = json.load(f)
+assert sorted(data) == ["td-mkt"], data
+entry = data["td-mkt"]
+expected = f"{isolated_plugins}/marketplaces/td-mkt"
+assert entry.get("installLocation") == expected, entry
+assert entry.get("source", {}).get("path") == expected, entry
+PY
+
+log "verifying non-marketplace catalog symlinks resolve to controller copies"
+for catalog in install-counts-cache.json blocklist.json; do
   link="$ISOLATED_PLUGINS/$catalog"
-  [[ -L "$link" ]] || die "expected $link to be a symlink"
+  sudo -n test -L "$link" || die "expected $link to be a symlink"
   resolved="$(sudo -n readlink -f "$link" 2>/dev/null || true)"
   expected="$CONTROLLER_PLUGINS/$catalog"
   [[ "$resolved" == "$expected" ]] || die "catalog symlink $link resolved to $resolved (expected $expected)"
@@ -320,7 +345,8 @@ echo '{"name":"allowlist-mkt","plugins":["allowlisted-plugin"]}' \
 mkdir -p "$BRIDGE_HOME/plugins/allowlisted-plugin"
 echo 'allowlisted plugin (dir-marketplace)' \
   > "$BRIDGE_HOME/plugins/allowlisted-plugin/server.ts"
-chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE"
+chmod -R go-rwx "$BRIDGE_HOME/plugins/allowlisted-plugin"
 
 python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$BRIDGE_HOME/plugins/allowlisted-plugin" <<'PY'
 import json, sys
@@ -400,12 +426,69 @@ allowlisted_mkt_expected="$CONTROLLER_PLUGINS/marketplaces/allowlist-mkt"
 sudo -n -u "$TEST_OS_USER" cat "$allowlisted_mkt_expected/marketplace.json" >/dev/null \
   || die "isolated UID should be able to read allowlisted marketplace metadata"
 
+log "verifying git-source marketplace also gets Claude repo-slug alias"
+mkdir -p "$CONTROLLER_PLUGINS/cache/git-mkt/git-plugin/0.1.0" \
+         "$CONTROLLER_PLUGINS/marketplaces/git-mkt"
+echo 'git marketplace plugin source (cache)' \
+  > "$CONTROLLER_PLUGINS/cache/git-mkt/git-plugin/0.1.0/index.js"
+echo '{"name":"git-mkt","plugins":["git-plugin"]}' \
+  > "$CONTROLLER_PLUGINS/marketplaces/git-mkt/marketplace.json"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE"
+
+python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$CONTROLLER_PLUGINS/cache/git-mkt/git-plugin/0.1.0" <<'PY'
+import json, sys
+manifest_path, install_path = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["git-plugin@git-mkt"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": install_path}
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+python3 - "$CONTROLLER_PLUGINS/known_marketplaces.json" "$CONTROLLER_PLUGINS/marketplaces/git-mkt" <<'PY'
+import json, sys
+markets_path, install_location = sys.argv[1], sys.argv[2]
+with open(markets_path) as f:
+    data = json.load(f)
+data["git-mkt"] = {
+    "source": {"source": "git", "repo": "Example-Org/example-marketplace"},
+    "installLocation": install_location,
+}
+with open(markets_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]='allowlisted-plugin@allowlist-mkt,git-plugin@git-mkt'
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+git_mkt_link="$ISOLATED_PLUGINS/marketplaces/git-mkt"
+git_mkt_slug_link="$ISOLATED_PLUGINS/marketplaces/Example-Org-example-marketplace"
+for link in "$git_mkt_link" "$git_mkt_slug_link"; do
+  sudo -n test -L "$link" || die "expected git marketplace alias symlink at $link"
+  resolved="$(sudo -n readlink -f "$link" 2>/dev/null || true)"
+  [[ "$resolved" == "$CONTROLLER_PLUGINS/marketplaces/git-mkt" ]] \
+    || die "git marketplace alias $link resolved to $resolved"
+done
+sudo -n python3 - "$ISOLATED_PLUGINS/known_marketplaces.json" "$ISOLATED_PLUGINS" <<'PY'
+import json
+import sys
+
+path, isolated_plugins = sys.argv[1:]
+with open(path) as f:
+    data = json.load(f)
+entry = data["git-mkt"]
+expected = f"{isolated_plugins}/marketplaces/Example-Org-example-marketplace"
+assert entry.get("installLocation") == expected, entry
+assert entry.get("source", {}).get("repo") == "Example-Org/example-marketplace", entry
+PY
+
 log "verifying persisted grant-set carries union (allowlist promoted to plugin:<id>)"
 sudo -n cat "$state_file" | python3 -c '
 import json, sys
 data = json.load(sys.stdin)
 chans = sorted(data.get("channels", []))
-expected = ["plugin:allowlisted-plugin@allowlist-mkt", "plugin:declared-plugin@td-mkt"]
+expected = ["plugin:allowlisted-plugin@allowlist-mkt", "plugin:declared-plugin@td-mkt", "plugin:git-plugin@git-mkt"]
 assert chans == expected, f"unexpected persisted channels: {chans!r} (expected {expected!r})"
 ' || die "persisted grant-set did not include BRIDGE_AGENT_PLUGINS allowlist entry (#348)"
 
@@ -429,6 +512,7 @@ ids = sorted(filter(None, plugins_csv.split(",")))
 expected = sorted([
     "plugin:allowlisted-plugin@allowlist-mkt",
     "plugin:declared-plugin@td-mkt",
+    "plugin:git-plugin@git-mkt",
 ])
 assert ids == expected, f"audit plugins mismatch: {ids!r} (expected {expected!r})"
 count = detail.get("plugin_count")
@@ -457,7 +541,8 @@ echo 'unregistered plugin (no known_marketplaces entry)' \
 mkdir -p "$CONTROLLER_PLUGINS/marketplaces/unregistered-mkt"
 echo '{"name":"unregistered-mkt","plugins":["unregistered-plugin"]}' \
   > "$CONTROLLER_PLUGINS/marketplaces/unregistered-mkt/marketplace.json"
-chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE"
+chmod -R go-rwx "$BRIDGE_HOME/plugins/unregistered-plugin"
 
 python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$BRIDGE_HOME/plugins/unregistered-plugin" <<'PY'
 import json, sys
@@ -490,6 +575,9 @@ fi
 log "verifying allowlist-mkt symlink still landed (registered marketplace path)"
 sudo -n test -L "$ISOLATED_PLUGINS/marketplaces/allowlist-mkt" \
   || die "expected allowlist-mkt symlink to remain after r2 gate"
+if sudo -n test -e "$git_mkt_slug_link" 2>/dev/null || sudo -n test -L "$git_mkt_slug_link" 2>/dev/null; then
+  die "expected removed git marketplace alias symlink to be pruned after allowlist change"
+fi
 
 log "verifying audit row still carries the unregistered-mkt plugin id"
 python3 - "$audit_log_file" "$TEST_AGENT" <<'PY' \
@@ -547,7 +635,7 @@ THIRD_PLUGIN_ID="third-party-plugin@third-marketplace"
 mkdir -p "$BRIDGE_HOME/plugins/third-party-plugin"
 echo 'third-party plugin (dir-marketplace)' \
   > "$BRIDGE_HOME/plugins/third-party-plugin/server.ts"
-chmod -R o+rX "$BRIDGE_HOME/plugins"
+chmod -R go-rwx "$BRIDGE_HOME/plugins/third-party-plugin"
 
 # Add the third-party plugin entry to the controller's manifest with a
 # valid installPath, but DO NOT add 'third-marketplace' to
@@ -699,7 +787,8 @@ echo 'replacement plugin source (cache)' \
 mkdir -p "$BRIDGE_HOME/plugins/replacement-plugin"
 echo 'replacement plugin (dir-marketplace)' \
   > "$BRIDGE_HOME/plugins/replacement-plugin/server.ts"
-chmod -R o+rX "$CONTROLLER_HOME_FAKE" "$BRIDGE_HOME/plugins"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE"
+chmod -R go-rwx "$BRIDGE_HOME/plugins/replacement-plugin"
 
 python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$BRIDGE_HOME/plugins/replacement-plugin" <<'PY'
 import json, sys

--- a/tests/isolation-plugin-sharing.sh
+++ b/tests/isolation-plugin-sharing.sh
@@ -835,6 +835,508 @@ assert chans == ["plugin:replacement-plugin@td-mkt"], f"unexpected persisted cha
 # variable so the existing assertion loop below stays intact.
 declared_path="$BRIDGE_HOME/plugins/replacement-plugin"
 
+# -----------------------------------------------------------------------------
+# Adversarial / boundary coverage (PR #557 r2). Each subsection here drives
+# the catalog/symlink helpers with hostile inputs and asserts the expected
+# fail-loud or precedence behavior. Snapshots of the controller's
+# installed_plugins.json + known_marketplaces.json + BRIDGE_AGENT_PLUGINS
+# are taken before each adversarial mutation and restored afterwards so the
+# linear flow above (and the unisolate teardown below) sees the same state
+# it would have seen without these sections.
+# -----------------------------------------------------------------------------
+
+log "snapshotting controller catalog state for adversarial cases"
+ADV_SNAP_INSTALLED="$TMP_ROOT/installed_plugins.snapshot.json"
+ADV_SNAP_KNOWN="$TMP_ROOT/known_marketplaces.snapshot.json"
+cp "$CONTROLLER_PLUGINS/installed_plugins.json" "$ADV_SNAP_INSTALLED"
+cp "$CONTROLLER_PLUGINS/known_marketplaces.json" "$ADV_SNAP_KNOWN"
+ADV_SNAP_AGENT_PLUGINS="${BRIDGE_AGENT_PLUGINS[$TEST_AGENT]:-}"
+
+restore_adv_snapshot() {
+  cp "$ADV_SNAP_INSTALLED" "$CONTROLLER_PLUGINS/installed_plugins.json"
+  cp "$ADV_SNAP_KNOWN" "$CONTROLLER_PLUGINS/known_marketplaces.json"
+  if [[ -n "$ADV_SNAP_AGENT_PLUGINS" ]]; then
+    BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]="$ADV_SNAP_AGENT_PLUGINS"
+  else
+    unset 'BRIDGE_AGENT_PLUGINS[$TEST_AGENT]' 2>/dev/null || true
+  fi
+}
+
+log "Adv-1: GitHub URL alias parsing (4 forms + bare org/repo)"
+
+# Drive bridge_known_marketplace_info directly with a synthesised
+# known_marketplaces.json file per case. Each form must reduce to the
+# expected `<org>-<repo>` slug alias regardless of how the operator
+# typed `source.repo`.
+ADV_PLUGINS_ROOT="$TMP_ROOT/adv-plugins-root"
+mkdir -p "$ADV_PLUGINS_ROOT"
+ADV_KNOWN="$ADV_PLUGINS_ROOT/known_marketplaces.json"
+adv_check_alias() {
+  local label="$1" repo_field="$2" expected_slug="$3"
+  python3 - "$ADV_KNOWN" "$repo_field" <<'PY'
+import json, sys
+path, repo = sys.argv[1], sys.argv[2]
+with open(path, "w") as f:
+    json.dump({
+        "adv-mkt": {
+            "source": {"source": "git", "repo": repo},
+            "installLocation": "/nonexistent/adv",
+        }
+    }, f)
+PY
+  local out=""
+  out="$(bridge_known_marketplace_info "adv-mkt" "$ADV_PLUGINS_ROOT")" \
+    || die "Adv-1[$label]: bridge_known_marketplace_info failed for repo=$repo_field"
+  # Format: present:<kind>\t<src>\talias1\talias2...
+  local aliases=""
+  aliases="$(printf '%s\n' "$out" | awk -F'\t' '{for (i=3;i<=NF;i++) printf "%s ",$i}')"
+  case " $aliases " in
+    *" $expected_slug "*) : ;;
+    *) die "Adv-1[$label]: expected alias '$expected_slug' for repo='$repo_field', got aliases: $aliases (raw: $out)" ;;
+  esac
+}
+
+adv_check_alias "https-no-suffix"  "https://github.com/foo/bar"        "foo-bar"
+adv_check_alias "https-dot-git"    "https://github.com/foo/bar.git"    "foo-bar"
+adv_check_alias "ssh-form"         "git@github.com:foo/bar.git"        "foo-bar"
+adv_check_alias "bare-org-repo"    "foo/bar"                           "foo-bar"
+adv_check_alias "bare-dot-git"     "foo/bar.git"                       "foo-bar"
+# Defensive: a full URL must NOT round-trip through the naive
+# slugifier (regression guard for the original bug — `https://...` →
+# `https:--github.com-foo-bar.git`). The presence-of-foo-bar check above
+# is necessary; we additionally assert the bad alias is absent.
+out_full="$(bridge_known_marketplace_info "adv-mkt" "$ADV_PLUGINS_ROOT")"
+case "$out_full" in
+  *"https:--"*|*"https---"*)
+    die "Adv-1: leaked URL form leaked into alias output: $out_full"
+    ;;
+esac
+log "Adv-1 PASS"
+
+log "Adv-2a: catalog-generator alias collision detection"
+
+# Catalog generator collision shape: two marketplace ids whose
+# `marketplace_source_info` returns the same `slug or marketplace`
+# value. With both source.repo values reducing to the same `<org>-<repo>`
+# slug AND a controller-side mirror tree present at
+# `marketplaces/<slug>`, both candidates take that slug as their alias —
+# the catalog rewrite would silently land them on the same isolated
+# `<isolated>/marketplaces/<slug>` location and the second JSON entry
+# would overwrite the first.
+COLLISION_PLUGINS_DIR="$BRIDGE_HOME/plugins"
+mkdir -p "$COLLISION_PLUGINS_DIR/cg-plugin-a" \
+         "$COLLISION_PLUGINS_DIR/cg-plugin-b"
+echo 'cg-a' > "$COLLISION_PLUGINS_DIR/cg-plugin-a/server.ts"
+echo 'cg-b' > "$COLLISION_PLUGINS_DIR/cg-plugin-b/server.ts"
+# Both ids' slug (`shared/repo`) reduces to `shared-repo`. The
+# controller-side mirror at `marketplaces/shared-repo` makes both
+# `marketplace_source_info` candidate searches resolve to that dir, and
+# both `slug or marketplace` evaluations produce `shared-repo`.
+mkdir -p "$CONTROLLER_PLUGINS/marketplaces/shared-repo"
+echo '{"name":"shared-repo","plugins":[]}' \
+  > "$CONTROLLER_PLUGINS/marketplaces/shared-repo/marketplace.json"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE"
+
+python3 - "$CONTROLLER_PLUGINS/known_marketplaces.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+data["cg-mkt-1"] = {
+    "source": {"source": "git", "repo": "shared/repo"},
+    "installLocation": "/nonexistent/cg-1",
+}
+data["cg-mkt-2"] = {
+    "source": {"source": "git", "repo": "https://github.com/shared/repo.git"},
+    "installLocation": "/nonexistent/cg-2",
+}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" \
+        "$COLLISION_PLUGINS_DIR/cg-plugin-a" \
+        "$COLLISION_PLUGINS_DIR/cg-plugin-b" <<'PY'
+import json, sys
+manifest_path, ip_a, ip_b = sys.argv[1:]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["cg-plugin-a@cg-mkt-1"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": ip_a},
+]
+data.setdefault("plugins", {})["cg-plugin-b@cg-mkt-2"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": ip_b},
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]='cg-plugin-a@cg-mkt-1,cg-plugin-b@cg-mkt-2'
+
+set +e
+ADV_OUT="$(BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT" 2>&1)"
+ADV_RC=$?
+set -e
+if [[ "$ADV_RC" -eq 0 ]]; then
+  die "Adv-2a: expected bridge_linux_share_plugin_catalog to fail on catalog-generator alias collision; rc=0, output: $ADV_OUT"
+fi
+case "$ADV_OUT" in
+  *"alias collision"*|*"alias collision detected"*) : ;;
+  *) die "Adv-2a: expected 'alias collision' in error, got: $ADV_OUT" ;;
+esac
+case "$ADV_OUT" in
+  *"cg-mkt-1"*) : ;;
+  *) die "Adv-2a: collision error did not name 'cg-mkt-1': $ADV_OUT" ;;
+esac
+case "$ADV_OUT" in
+  *"cg-mkt-2"*) : ;;
+  *) die "Adv-2a: collision error did not name 'cg-mkt-2': $ADV_OUT" ;;
+esac
+log "Adv-2a PASS"
+
+restore_adv_snapshot
+sudo -n rm -rf "$CONTROLLER_PLUGINS/marketplaces/shared-repo" >/dev/null 2>&1 || true
+
+log "Adv-2b: symlink-loop alias collision detection (defense-in-depth)"
+
+# Symlink-loop collision shape: the catalog generator passes (its single
+# alias per entry doesn't collide), but the symlink loop emits BOTH the
+# marketplace id AND the slug for each marketplace, so two different
+# marketplaces can still reach the same `marketplaces/<alias>` symlink
+# target. Specifically:
+#   - mkt id `foo-bar-baz` (slug `another-marketplace` from `another/marketplace`)
+#     → symlink-loop aliases: foo-bar-baz, another-marketplace
+#   - mkt id `coll-mkt-2`  (slug `foo-bar-baz` from `foo/bar-baz`)
+#     → symlink-loop aliases: coll-mkt-2, foo-bar-baz
+#   ⇒ collision on `foo-bar-baz`.
+mkdir -p "$COLLISION_PLUGINS_DIR/sl-plugin-a" \
+         "$COLLISION_PLUGINS_DIR/sl-plugin-b"
+echo 'sl-a' > "$COLLISION_PLUGINS_DIR/sl-plugin-a/server.ts"
+echo 'sl-b' > "$COLLISION_PLUGINS_DIR/sl-plugin-b/server.ts"
+mkdir -p "$CONTROLLER_PLUGINS/marketplaces/foo-bar-baz"
+echo '{"name":"foo-bar-baz","plugins":[]}' \
+  > "$CONTROLLER_PLUGINS/marketplaces/foo-bar-baz/marketplace.json"
+chmod -R o+rX "$CONTROLLER_HOME_FAKE"
+
+python3 - "$CONTROLLER_PLUGINS/known_marketplaces.json" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+data["foo-bar-baz"] = {
+    "source": {"source": "git", "repo": "another/marketplace"},
+    "installLocation": "/nonexistent/sl-1",
+}
+data["coll-mkt-2"] = {
+    "source": {"source": "git", "repo": "foo/bar-baz"},
+    "installLocation": "/nonexistent/sl-2",
+}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" \
+        "$COLLISION_PLUGINS_DIR/sl-plugin-a" \
+        "$COLLISION_PLUGINS_DIR/sl-plugin-b" <<'PY'
+import json, sys
+manifest_path, ip_a, ip_b = sys.argv[1:]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["sl-plugin-a@foo-bar-baz"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": ip_a},
+]
+data.setdefault("plugins", {})["sl-plugin-b@coll-mkt-2"] = [
+    {"scope": "user", "version": "0.1.0", "installPath": ip_b},
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]='sl-plugin-a@foo-bar-baz,sl-plugin-b@coll-mkt-2'
+
+set +e
+ADV_OUT="$(BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT" 2>&1)"
+ADV_RC=$?
+set -e
+if [[ "$ADV_RC" -eq 0 ]]; then
+  die "Adv-2b: expected bridge_linux_share_plugin_catalog to fail on symlink-loop alias collision; rc=0, output: $ADV_OUT"
+fi
+case "$ADV_OUT" in
+  *"alias collision"*|*"alias collision detected"*) : ;;
+  *) die "Adv-2b: expected 'alias collision' in error, got: $ADV_OUT" ;;
+esac
+case "$ADV_OUT" in
+  *"foo-bar-baz"*) : ;;
+  *) die "Adv-2b: collision error did not name 'foo-bar-baz': $ADV_OUT" ;;
+esac
+case "$ADV_OUT" in
+  *"coll-mkt-2"*) : ;;
+  *) die "Adv-2b: collision error did not name 'coll-mkt-2': $ADV_OUT" ;;
+esac
+log "Adv-2b PASS"
+
+restore_adv_snapshot
+# Drop the synthesised marketplace mirror trees so the next adversarial
+# pass starts from a clean controller surface.
+sudo -n rm -rf "$CONTROLLER_PLUGINS/marketplaces/foo-bar-baz" \
+               >/dev/null 2>&1 || true
+
+log "Adv-3: marketplace-id traversal/control-char rejection"
+
+# Subgroup A — CSV-survivable shapes (`..`, leading/trailing slash).
+# These pass through `bridge_agent_plugins_csv`'s tokenizer as the literal
+# characters and reach the validator inside both the catalog generator
+# and `bridge_known_marketplace_info`.
+adv_run_unsafe_id() {
+  local label="$1" mkt_id="$2"
+  # Restore baseline catalog so each unsafe-id case starts clean.
+  cp "$ADV_SNAP_INSTALLED" "$CONTROLLER_PLUGINS/installed_plugins.json"
+  cp "$ADV_SNAP_KNOWN" "$CONTROLLER_PLUGINS/known_marketplaces.json"
+  python3 - "$CONTROLLER_PLUGINS/known_marketplaces.json" "$mkt_id" <<'PY'
+import json, sys
+path, mkt_id = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data[mkt_id] = {
+    "source": {"source": "git", "repo": "Example-Org/unsafe-mkt"},
+    "installLocation": "/nonexistent/unsafe",
+}
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+  python3 - "$CONTROLLER_PLUGINS/installed_plugins.json" "$mkt_id" <<'PY'
+import json, sys
+manifest_path, mkt_id = sys.argv[1], sys.argv[2]
+with open(manifest_path) as f:
+    data = json.load(f)
+data.setdefault("plugins", {})["unsafe-plugin@" + mkt_id] = [
+    {"scope": "user", "version": "0.1.0", "installPath": "/nonexistent/unsafe"}
+]
+with open(manifest_path, "w") as f:
+    json.dump(data, f, indent=2)
+PY
+  BRIDGE_AGENT_PLUGINS["$TEST_AGENT"]="unsafe-plugin@${mkt_id}"
+  set +e
+  local out=""
+  out="$(BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+    bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT" 2>&1)"
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    die "Adv-3[$label]: expected fail-loud rejection of unsafe marketplace id (printf %q form: $(printf '%q' "$mkt_id")); got rc=0, output: $out"
+  fi
+  case "$out" in
+    *rejected*|*unsafe*|*"alias collision"*) : ;;
+    *)
+      die "Adv-3[$label]: expected 'rejected' or 'unsafe' in error for id $(printf '%q' "$mkt_id"), got: $out"
+      ;;
+  esac
+}
+
+adv_run_unsafe_id "double-dot-prefix" "..foo"
+adv_run_unsafe_id "dotdot-mid"        "foo..bar"
+adv_run_unsafe_id "leading-slash"     "/foo"
+adv_run_unsafe_id "trailing-slash"    "foo/"
+
+# Subgroup B — control-char and empty cases. `bridge_agent_plugins_csv`
+# tokenises on `[ \t\n,]` so a literal newline/tab in BRIDGE_AGENT_PLUGINS
+# would be consumed as a separator before reaching the validator. Drive
+# the catalog-generator's validator directly with a synthesised
+# known_marketplaces.json so the bash CSV path doesn't shield us from
+# the assertion.
+adv_run_unsafe_id_via_catalog_gen() {
+  local label="$1" mkt_id="$2" alias_id="${3:-}"
+  local adv_dir="$TMP_ROOT/adv-cg-${label}"
+  rm -rf "$adv_dir" >/dev/null 2>&1 || true
+  mkdir -p "$adv_dir/isolated/plugins" "$adv_dir/controller-plugins"
+  python3 - "$adv_dir/controller-plugins/known_marketplaces.json" "$mkt_id" <<'PY'
+import json, sys
+path, mkt_id = sys.argv[1], sys.argv[2]
+with open(path, "w") as f:
+    json.dump({
+        mkt_id: {
+            "source": {"source": "git", "repo": "Example-Org/unsafe-mkt"},
+            "installLocation": "/nonexistent/unsafe",
+        }
+    }, f)
+PY
+  # Run the catalog-generator's Python heredoc body directly so we
+  # bypass the bash CSV tokenizer entirely. The body lives inline in
+  # bridge_write_isolated_known_marketplaces_catalog; we mirror its
+  # interface here via the SAME validator code paths.
+  set +e
+  local out=""
+  out="$(python3 - "$adv_dir/controller-plugins" "$adv_dir/isolated/plugins" \
+        "" "unsafe-plugin@${mkt_id}" "$adv_dir/out.json" 2>&1 <<'PY'
+import json
+import os
+import re
+import sys
+
+controller_plugins, isolated_plugins, channels_csv, plugins_csv, out_path = sys.argv[1:]
+markets_path = os.path.join(controller_plugins, "known_marketplaces.json")
+
+_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+_RES = {".", ".."}
+_WIN = ({"CON","PRN","AUX","NUL"}
+        | {"COM%d"%i for i in range(1,10)}
+        | {"LPT%d"%i for i in range(1,10)})
+def reason(a):
+    if not isinstance(a, str): return "not a string"
+    if a == "": return "empty"
+    if len(a) > 200: return "length exceeds 200"
+    if not _SAFE_ALIAS_RE.match(a): return "regex"
+    if ".." in a: return "contains '..'"
+    if a in _RES: return "reserved name"
+    if a.upper() in _WIN: return "reserved Windows name"
+    if a.startswith(".") and a != ".git": return "leading dot disallowed"
+    return ""
+
+def declared(channels_csv, plugins_csv):
+    out = set()
+    for raw in (channels_csv + "," + plugins_csv).split(","):
+        token = raw.strip()
+        if token.startswith("plugin:"):
+            token = token[len("plugin:"):]
+        if "@" not in token:
+            continue
+        _p, m = token.split("@", 1)
+        if m:
+            out.add(m)
+    return out
+
+# `BRIDGE_AGENT_PLUGINS["agent"]="unsafe-plugin@<mkt_id>"` is what the
+# operator typed; the bash CSV tokenizer would mangle whitespace, so
+# inject the marketplace id directly via declared().
+mkt_ids = declared(channels_csv, plugins_csv)
+for m in mkt_ids:
+    r = reason(m)
+    if r:
+        print("[bridge-isolate] marketplace id %r rejected: %s" % (m, r), file=sys.stderr)
+        raise SystemExit(2)
+print("[bridge-isolate] all marketplace ids passed validation: %r" % sorted(mkt_ids))
+PY
+)"
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    die "Adv-3[$label]: catalog-generator validator did NOT reject mkt_id $(printf '%q' "$mkt_id"); output: $out"
+  fi
+  case "$out" in
+    *rejected*) : ;;
+    *) die "Adv-3[$label]: expected 'rejected' in stderr, got: $out" ;;
+  esac
+}
+
+adv_run_unsafe_id_via_catalog_gen "embedded-newline" "$(printf 'foo\nbar')"
+adv_run_unsafe_id_via_catalog_gen "embedded-tab"     "$(printf 'foo\tbar')"
+adv_run_unsafe_id_via_catalog_gen "dot-only"         "."
+adv_run_unsafe_id_via_catalog_gen "double-dot-only"  ".."
+
+# The empty-id case never reaches the validator from any production
+# path (the `@` parser short-circuits when marketplace is empty after
+# split). Pin the validator's empty-string branch with a direct unit
+# assertion so a future refactor can't silently relax it.
+python3 - <<'PY'
+import re
+_SAFE_ALIAS_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+def reason(a):
+    if not isinstance(a, str): return "not a string"
+    if a == "": return "empty"
+    if len(a) > 200: return "length exceeds 200"
+    if not _SAFE_ALIAS_RE.match(a): return "regex"
+    if ".." in a: return "contains '..'"
+    if a in {".", ".."}: return "reserved name"
+    if a.startswith(".") and a != ".git": return "leading dot disallowed"
+    return ""
+assert reason("") == "empty", "empty alias must be rejected"
+assert reason(".git") == "", "'.git' is the documented escape hatch and must remain accepted"
+assert reason("foo bar") != "", "whitespace must be rejected"
+assert reason("a" * 201) != "", "length>200 must be rejected"
+PY
+log "Adv-3 PASS"
+
+restore_adv_snapshot
+
+log "Adv-4: catalog write-denial (per-UID known_marketplaces.json is root:root 0640 + isolated UID cannot tamper)"
+
+# Re-run a normal share so the per-UID catalog is in a known-good shape.
+# `restore_adv_snapshot` already reverted controller-side files and
+# BRIDGE_AGENT_PLUGINS to the pre-adversarial baseline.
+BRIDGE_AGENT_CHANNELS["$TEST_AGENT"]='plugin:replacement-plugin@td-mkt'
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
+ADV_CATALOG="$ISOLATED_PLUGINS/known_marketplaces.json"
+sudo -n stat -c '%U:%G %a' "$ADV_CATALOG" | grep -Fq "root:root 640" \
+  || die "Adv-4: expected $ADV_CATALOG to be root:root 0640 (mode), got: $(sudo -n stat -c '%U:%G %a' "$ADV_CATALOG")"
+if sudo -n -u "$TEST_OS_USER" bash -c "echo POISON >> '$ADV_CATALOG'" 2>/dev/null; then
+  die "Adv-4: isolated UID was able to append to per-UID known_marketplaces.json — write boundary broken"
+fi
+if sudo -n -u "$TEST_OS_USER" rm -f "$ADV_CATALOG" 2>/dev/null; then
+  if [[ ! -e "$ADV_CATALOG" ]]; then
+    die "Adv-4: isolated UID was able to unlink per-UID known_marketplaces.json"
+  fi
+fi
+# The isolated UID must still be able to READ the catalog (Claude
+# resolves marketplaces by reading it). This is the v1 ACL path.
+sudo -n -u "$TEST_OS_USER" cat "$ADV_CATALOG" >/dev/null \
+  || die "Adv-4: isolated UID should be able to read its own per-UID known_marketplaces.json"
+log "Adv-4 PASS"
+
+log "Adv-5: directory-marketplace installLocation/source.path precedence (agent-bridge variant)"
+
+# bridge_known_marketplace_info's candidate order for `agent-bridge` is:
+#   1. <controller>/marketplaces/<id>
+#   2. <controller>/marketplaces/<slug>
+#   3. installLocation
+#   4. source.path
+# When both installLocation AND source.path are accessible directories,
+# installLocation must win. Drive this by adding an `agent-bridge` entry
+# whose marketplaces/agent-bridge tree does NOT exist (so candidates 1+2
+# fall through) and whose installLocation + source.path point to two
+# different accessible dirs.
+ADV_INSTALL_LOC="$TMP_ROOT/adv-installLocation"
+ADV_SRC_PATH="$TMP_ROOT/adv-source-path"
+mkdir -p "$ADV_INSTALL_LOC/.claude-plugin" "$ADV_SRC_PATH/.claude-plugin"
+echo '{"name":"agent-bridge","plugins":[]}' \
+  > "$ADV_INSTALL_LOC/.claude-plugin/marketplace.json"
+echo '{"name":"agent-bridge","plugins":[]}' \
+  > "$ADV_SRC_PATH/.claude-plugin/marketplace.json"
+chmod -R o+rX "$ADV_INSTALL_LOC" "$ADV_SRC_PATH"
+
+ADV_KNOWN_AB="$TMP_ROOT/adv-known-ab.json"
+python3 - "$ADV_KNOWN_AB" "$ADV_INSTALL_LOC" "$ADV_SRC_PATH" <<'PY'
+import json, sys
+path, install_loc, src_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "w") as f:
+    json.dump({
+        "agent-bridge": {
+            "source": {"source": "directory", "path": src_path},
+            "installLocation": install_loc,
+        }
+    }, f)
+PY
+ADV_AB_ROOT="$TMP_ROOT/adv-ab-root"
+mkdir -p "$ADV_AB_ROOT"
+cp "$ADV_KNOWN_AB" "$ADV_AB_ROOT/known_marketplaces.json"
+ADV_AB_OUT="$(bridge_known_marketplace_info "agent-bridge" "$ADV_AB_ROOT")" \
+  || die "Adv-5: bridge_known_marketplace_info failed for agent-bridge"
+ADV_AB_SRC="$(printf '%s\n' "$ADV_AB_OUT" | awk -F'\t' '{print $2}')"
+[[ "$ADV_AB_SRC" == "$ADV_INSTALL_LOC" ]] \
+  || die "Adv-5: expected installLocation ($ADV_INSTALL_LOC) to win over source.path ($ADV_SRC_PATH); helper resolved $ADV_AB_SRC (raw: $ADV_AB_OUT)"
+log "Adv-5 PASS"
+
+# Note: v2 group enforcement (non-group-member UID cannot read catalog)
+# is exercised by tests/isolation-v2-primitives/smoke.sh. Adding a v2
+# group setup to this fixture would require system-group provisioning
+# that overlaps significantly with that suite; keeping it out of scope
+# avoids a duplicated and harder-to-maintain v2 sandbox here.
+
+# Restore baseline state and re-run a normal share so the linear
+# unisolate flow below operates against the expected snapshot.
+restore_adv_snapshot
+BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
+  bridge_linux_share_plugin_catalog "$TEST_OS_USER" "$TEST_OS_HOME" "$CONTROLLER_USER" "$TEST_AGENT"
+
 log "running bridge_migration_unisolate (dry_run=0) and verifying full ACL strip"
 BRIDGE_CONTROLLER_HOME_OVERRIDE="$CONTROLLER_HOME_FAKE" \
   bridge_migration_unisolate "$TEST_AGENT" 0 \


### PR DESCRIPTION
## Summary
- rebuild isolated agents' `known_marketplaces.json` as a filtered per-agent catalog instead of exposing the controller catalog wholesale
- pre-create read-only marketplace aliases, including GitHub repo-slug aliases, so Claude does not try to clone into root-owned isolated plugin dirs
- make dev-loaded plugin cache sync resolve third-party marketplaces from `known_marketplaces.json` and preserve existing concrete `.mcp.json` secrets when source files contain placeholders

## Validation
- `python3 -m py_compile bridge-dev-plugin-cache.py`
- `bash -n lib/bridge-agents.sh tests/isolation-plugin-sharing.sh scripts/smoke-test.sh bridge-run.sh`
- `./tests/isolation-plugin-sharing.sh`
- targeted third-party dev-cache sync reproducer, including `.mcp.json` secret preservation and mode retention

## Notes
- Full smoke was intentionally not rerun here because the current suite can block on interactive CLI update/help-generation paths unrelated to this change. This PR adds focused regression coverage for the marketplace/catalog paths touched here.
