### PR TITLE
fix(teams): add durable bridge delivery mode

### DIFF
--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -1355,24 +1355,22 @@ def analyze_live(source_root: Path, target_root: Path, base_ref: str) -> dict[st
             classification = "missing_live"
             strategy = "deploy_upstream"
         elif upstream == live:
-            # Content matches. Check whether the exec bit also matches
-            # source — a mode-only drift (live 0644 vs upstream 0755 or
-            # vice versa) is still a drift worth repairing, even though
-            # the bytes agree. Without this the previous content-only
-            # classifier skipped the file entirely, leaving the live
-            # install with the wrong permission. Source-of-truth is the
-            # git index, not source_path.stat() — a dev checkout may
-            # have drifted filesystem perms (0744 / 0700) while git
-            # still tracks 100755, and using stat would propagate the
-            # bad worktree mode to every downstream install.
-            source_exec = git_tracked_exec_bits(source_root, relpath)
-            live_exec = 0
+            # Content matches. Check whether the installed file mode also
+            # matches the git-tracked mode we deploy below. A mode-only drift
+            # is still operationally significant: 0600 bridge modules are
+            # unreadable to linux-user isolated agents even when bytes match.
+            # Source-of-truth is the git index, not source_path.stat() — a dev
+            # checkout may have drifted filesystem perms (0744 / 0700) while
+            # git still tracks 100755, and using stat would propagate the bad
+            # worktree mode to every downstream install.
+            target_mode = 0o644 | git_tracked_exec_bits(source_root, relpath)
+            live_mode = target_mode
             if not live_path.is_symlink():
                 try:
-                    live_exec = live_path.stat().st_mode & 0o111
+                    live_mode = live_path.stat().st_mode & 0o777
                 except OSError:
-                    live_exec = 0
-            if source_exec != live_exec:
+                    live_mode = 0
+            if target_mode != live_mode:
                 classification = "mode_drift"
                 strategy = "sync_mode"
             else:

--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -82,6 +82,19 @@ Filenames and message ids are sanitized (strict allowlist) before they're joined
 
 Outbound attachments (sending files from the bot to Teams) are not yet implemented; track that work separately.
 
+## Delivery Mode
+
+By default, inbound Teams messages are delivered to Claude Code with `notifications/claude/channel`, and the server waits for the MCP stdio write before acknowledging the Teams webhook. If the MCP write fails, the webhook returns an error so Teams can retry.
+
+For production agents that need durable delivery while Claude Code channel notifications are unreliable, enable Agent Bridge queue delivery:
+
+```dotenv
+TEAMS_BRIDGE_MODE=1
+TEAMS_BRIDGE_AGENT=<agent-id>
+```
+
+In bridge mode, accepted Teams messages are written to the local log and then submitted through `agent-bridge urgent <agent-id> ...`. The agent should reply with the `teams` MCP `reply` tool using the included `chat_id`.
+
 ## Current Scope
 
 This is the Phase 1 channel implementation: webhook receive, access gate, Claude channel notification, reply, local message fetch, and a lightweight `/auth/callback` endpoint used by the `ms365` plugin authorization-code pairing flow. Multi-tenant user-to-agent routing is intentionally left to the Agent Bridge relay layer so one Teams bot can map many users to many timeout agents without mixing conversation state.

--- a/plugins/teams/dedupe.ts
+++ b/plugins/teams/dedupe.ts
@@ -1,5 +1,6 @@
 export type RecentMessageDeduper = {
   seen(messageId: string): boolean
+  forget(messageId: string): void
 }
 
 export function createRecentMessageDeduper(limit = 256): RecentMessageDeduper {
@@ -19,6 +20,12 @@ export function createRecentMessageDeduper(limit = 256): RecentMessageDeduper {
         if (removed) seenIds.delete(removed)
       }
       return false
+    },
+    forget(messageId: string): void {
+      const id = String(messageId || '').trim()
+      if (!id || !seenIds.delete(id)) return
+      const idx = queue.indexOf(id)
+      if (idx >= 0) queue.splice(idx, 1)
     },
   }
 }

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -151,6 +151,8 @@ try {
 const HOST = process.env.TEAMS_WEBHOOK_HOST ?? '127.0.0.1'
 const PORT = Number(process.env.TEAMS_WEBHOOK_PORT ?? '3978')
 const STATIC = process.env.TEAMS_ACCESS_MODE === 'static'
+const BRIDGE_MODE = process.env.TEAMS_BRIDGE_MODE === '1'
+const BRIDGE_AGENT = process.env.TEAMS_BRIDGE_AGENT ?? process.env.BRIDGE_AGENT_ID ?? ''
 
 const APP_ID = process.env.TEAMS_APP_ID ?? process.env.MicrosoftAppId
 const APP_PASSWORD = process.env.TEAMS_APP_PASSWORD ?? process.env.MicrosoftAppPassword
@@ -520,6 +522,38 @@ function recentMessages(chatId: string, limit: number): StoredMessage[] {
   return rows.slice(-Math.max(1, Math.min(limit, 100)))
 }
 
+function bridgeSend(agent: string, stored: StoredMessage): void {
+  const targetAgent = agent.trim()
+  if (!targetAgent) {
+    throw new Error('TEAMS_BRIDGE_MODE=1 requires TEAMS_BRIDGE_AGENT or BRIDGE_AGENT_ID')
+  }
+  const attachmentHint = stored.attachments?.length
+    ? `\nattachments=${JSON.stringify(stored.attachments.map(att => ({
+        name: att.name,
+        content_type: att.content_type,
+        download_status: att.download_status,
+        ...(att.local_path ? { local_path: att.local_path } : {}),
+        ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
+      })))}`
+    : ''
+  const sendMessage =
+    `[Teams] chat_id=${stored.chat_id} message_id=${stored.message_id} user=${stored.user}${attachmentHint}\n\n` +
+    `${stored.text}\n\n` +
+    `Reply via the teams MCP tool (mcp__teams__reply) using the chat_id above.`
+  const agb = join(BRIDGE_HOME, 'agent-bridge')
+  const result = spawnSync(agb, ['urgent', targetAgent, sendMessage], {
+    encoding: 'utf8',
+    timeout: 10000,
+  })
+  if (result.error) {
+    throw new Error(`bridge-send spawn failed: ${result.error}`)
+  }
+  if (result.status !== 0) {
+    throw new Error(`bridge-send exit ${result.status}: ${result.stderr ?? ''}`)
+  }
+  process.stderr.write(`teams channel: bridge-send to ${targetAgent} for chat ${stored.chat_id}\n`)
+}
+
 const adapter = new BotFrameworkAdapter({
   appId: APP_ID,
   appPassword: APP_PASSWORD,
@@ -647,36 +681,46 @@ async function handleActivity(context: TurnContext): Promise<void> {
   }
   appendMessage(stored)
 
-  void mcp.notification({
-    method: 'notifications/claude/channel',
-    params: {
-      content: text,
-      meta: {
-        source: 'teams',
-        chat_id: chatId,
-        conversation_id: chatId,
-        message_id: messageId,
-        user: userName,
-        user_id: stored.user_id,
-        aad_object_id: aad,
-        tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
-        service_url: String(activity.serviceUrl ?? ''),
-        ts,
-        ...(attachments.length > 0
-          ? {
-              attachments: attachments.map(att => ({
-                name: att.name,
-                content_type: att.content_type,
-                download_status: att.download_status,
-                ...(att.local_path ? { local_path: att.local_path } : {}),
-                ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
-                ...(att.download_error ? { download_error: att.download_error } : {}),
-              })),
-            }
-          : {}),
-      },
-    },
-  })
+  try {
+    if (BRIDGE_MODE) {
+      bridgeSend(BRIDGE_AGENT, stored)
+    } else {
+      await mcp.notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: text,
+          meta: {
+            source: 'teams',
+            chat_id: chatId,
+            conversation_id: chatId,
+            message_id: messageId,
+            user: userName,
+            user_id: stored.user_id,
+            aad_object_id: aad,
+            tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
+            service_url: String(activity.serviceUrl ?? ''),
+            ts,
+            ...(attachments.length > 0
+              ? {
+                  attachments: attachments.map(att => ({
+                    name: att.name,
+                    content_type: att.content_type,
+                    download_status: att.download_status,
+                    ...(att.local_path ? { local_path: att.local_path } : {}),
+                    ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
+                    ...(att.download_error ? { download_error: att.download_error } : {}),
+                  })),
+                }
+              : {}),
+          },
+        },
+      })
+    }
+  } catch (err) {
+    recentMessageIds.forget(messageId)
+    process.stderr.write(`teams channel: failed to deliver inbound message_id=${messageId}: ${err}\n`)
+    throw err
+  }
 }
 
 const httpServer = createServer((req, res) => {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7114,6 +7114,25 @@ SECOND_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "
 assert_contains "$SECOND_JSON" "\"files_mode_synced\": 0"
 assert_contains "$SECOND_JSON" "\"files_skipped_noop\": 1"
 
+log "smart upgrade repairs non-executable tracked file mode when content already matches"
+READ_ROOT="$TMP_ROOT/upgrade-mode-read-root"
+READ_REPO="$TMP_ROOT/upgrade-mode-read-repo"
+mkdir -p "$READ_ROOT" "$READ_REPO"
+git -C "$READ_REPO" init -q
+git -C "$READ_REPO" config user.email smoke-test
+git -C "$READ_REPO" config user.name "Bridge Smoke"
+printf 'library helper\n' >"$READ_REPO/helper.txt"
+chmod 0644 "$READ_REPO/helper.txt"
+git -C "$READ_REPO" add helper.txt
+git -C "$READ_REPO" commit -qm "helper tracked 100644"
+READ_BASE="$(git -C "$READ_REPO" rev-parse HEAD)"
+cp "$READ_REPO/helper.txt" "$READ_ROOT/helper.txt"
+chmod 0600 "$READ_ROOT/helper.txt"
+READ_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "$READ_REPO" --target-root "$READ_ROOT" --base-ref "$READ_BASE")"
+assert_contains "$READ_JSON" "\"files_mode_synced\": 1"
+mode_read="$(stat -f '%Lp' "$READ_ROOT/helper.txt" 2>/dev/null || stat -c '%a' "$READ_ROOT/helper.txt")"
+[[ "$mode_read" == "644" ]] || die "expected helper.txt to be 644 after read-mode sync, got $mode_read"
+
 log "smart upgrade trusts git index mode over working-tree stat"
 MISMATCH_REPO="$TMP_ROOT/upgrade-mode-mismatch-repo"
 MISMATCH_ROOT="$TMP_ROOT/upgrade-mode-mismatch-root"


### PR DESCRIPTION
## Summary
- await Teams `notifications/claude/channel` delivery instead of fire-and-forget
- add opt-in `TEAMS_BRIDGE_MODE=1` delivery through `agent-bridge urgent <agent>` for durable local queue injection
- let the Teams deduper forget a message id when delivery fails so upstream webhook retries are not suppressed
- repair smart-upgrade mode drift for 100644 files, so 0600 live bridge modules are restored to readable 0644 for linux-user isolated runtimes

## Why
Claude Code channel notifications currently have no delivered acknowledgement and can silently drop inbound Teams messages in busy sessions. The default path now at least waits for the MCP stdio write and surfaces write failures to the webhook. Operators that need durable delivery can opt in to Agent Bridge queue delivery without waiting on Claude channel notification semantics.

The mode-drift repair is included because the live incident also exposed a restart blocker: upgraded bridge modules could retain 0600 modes despite matching source bytes, which made isolated linux-user agents unable to source bridge runtime modules.

## Validation
- `python3 -m py_compile bridge-upgrade.py`
- `bash -n scripts/smoke-test.sh`
- `git diff --check`
- focused `bridge-upgrade.py apply-live` check: 0600 tracked-100644 file repaired to 0644
- `bun build plugins/teams/server.ts --target=bun --outfile=/tmp/teams-server-check.js`
- focused Teams dedupe retry check with `forget()`
