### PR TITLE
feat(isolated-skills): sync bridge-native skills into isolated HOME with absolute path text (refs #544 PR3)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -442,6 +442,31 @@ isolated UIDs remains explicit default-deny per issue
 [#544](https://github.com/SYRS-AI/agent-bridge-public/issues/544) PR4
 design review.
 
+### Bridge-native skills under the isolated HOME
+
+Bridge-native Claude skills (`agent-bridge-runtime`, `cron-manager`,
+`memory-wiki`, `patch-permission-approval`) are synced into
+`<isolated-home>/.claude/skills/<skill>/` on agent isolate, restart,
+`agent-bridge isolate <agent> --reapply`, and `agb upgrade`. Claude Code
+running under the isolated UID reads `~/.claude/skills/` from that home,
+so the workdir-side symlinks used by shared agents are not visible
+there — the bridge installs a parallel rendered copy into the isolated
+home instead. Skill body text is normalized at sync time so every
+`~/.agent-bridge/agb` and `~/.agent-bridge/agent-bridge` reference
+becomes the absolute `${BRIDGE_HOME}/agb` (resp. `${BRIDGE_HOME}/agent-bridge`)
+path. This decouples skill commands from `~` resolution under the
+isolated UID and from the per-home `~/.agent-bridge` symlink, so they
+work even on installs where that symlink is missing or the operator-home
+parent path differs from `BRIDGE_HOME`.
+
+Operators on existing installs pick this up by re-running:
+
+```bash
+agent-bridge isolate <agent> --reapply
+```
+
+then restarting the agent so the next session loads the synced skills.
+
 ## Migrating to layout v2
 
 The v2 layout (PR-A/B/C, shipped in v0.6.19) replaces named-ACL access on

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1273,6 +1273,13 @@ if [[ $MIGRATE_AGENTS -eq 1 ]]; then
     for agent in "${BRIDGE_AGENT_IDS[@]}"; do
       [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || continue
       bridge_sync_claude_runtime_skills "$agent" "$(bridge_agent_workdir "$agent")" "$dry_run" >/dev/null 2>&1 || true
+      # Issue #544 PR3 — refresh bridge-native skills under each
+      # isolated agent HOME on upgrade. No-op for non-isolated agents.
+      # Honors --dry-run: only run the live sync when dry_run != 1.
+      if [[ "$dry_run" != "1" ]] \
+          && command -v bridge_sync_isolated_home_claude_skills >/dev/null 2>&1; then
+        bridge_sync_isolated_home_claude_skills "$agent" >/dev/null 2>&1 || true
+      fi
     done
   ' -- "$SOURCE_ROOT" "$DRY_RUN"
 

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -138,6 +138,15 @@ bridge_migration_isolate() {
     fi
     bridge_linux_prepare_agent_isolation "$agent" "$os_user" "$workdir" "$(bridge_current_user)" || \
       bridge_warn "bridge_linux_prepare_agent_isolation returned non-zero for $agent; re-run isolate or check acceptance runbook §2"
+    # Issue #544 PR3 — refresh the bridge-native skills under the
+    # isolated HOME (.claude/skills/) so existing isolated agents pick
+    # up new/changed skills on `--reapply` without unisolate→isolate.
+    # Best-effort: warn but don't bail out — the ACL reapply above is
+    # the load-bearing step.
+    if command -v bridge_sync_isolated_home_claude_skills >/dev/null 2>&1; then
+      bridge_sync_isolated_home_claude_skills "$agent" \
+        || bridge_warn "isolated-home skills sync returned non-zero for $agent; re-run isolate --reapply or check OPERATIONS.md isolated-agent section"
+    fi
     printf '[done] ACL reapply complete for %s\n' "$agent"
     return 0
   fi
@@ -212,6 +221,16 @@ bridge_migration_isolate() {
   if [[ "$dry_run" != "1" ]]; then
     bridge_linux_prepare_agent_isolation "$agent" "$os_user" "$workdir" "$(bridge_current_user)" || \
       bridge_warn "bridge_linux_prepare_agent_isolation returned non-zero for $agent; re-run isolate or check acceptance runbook §2"
+    # Issue #544 PR3 — install bridge-native skills into the freshly
+    # provisioned isolated HOME so SessionStart/UserPromptSubmit hooks
+    # (PR2 surface) and the agent itself can discover the
+    # agent-bridge-runtime / cron-manager / memory-wiki /
+    # patch-permission-approval skills under the isolated UID.
+    # Best-effort: failure here doesn't block migration.
+    if command -v bridge_sync_isolated_home_claude_skills >/dev/null 2>&1; then
+      bridge_sync_isolated_home_claude_skills "$agent" \
+        || bridge_warn "isolated-home skills sync returned non-zero for $agent; re-run isolate --reapply"
+    fi
   fi
 
   if [[ "$install_sudoers" == "1" ]]; then

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -223,8 +223,14 @@ import sys
 src, dst, home = sys.argv[1], sys.argv[2], sys.argv[3]
 with open(src, "r", encoding="utf-8") as fh:
     content = fh.read()
-# Normalize trailing slash on the home path so substitution is exact.
-home_norm = home.rstrip("/") + "/"
+# Canonicalize BRIDGE_HOME so that trailing-slash, doubled-slash, and
+# symlinked variants of the same logical path all produce identical
+# rendered output. realpath resolves symlinks (so a fixture pointing
+# BRIDGE_HOME at a symlink renders the underlying real path), normpath
+# collapses double slashes, and the trailing-slash strip + re-append
+# produces an exact `<canonical>/` substitution string.
+home_canonical = os.path.realpath(os.path.normpath(home))
+home_norm = home_canonical.rstrip("/") + "/"
 content = content.replace("~/.agent-bridge/", home_norm)
 tmp = dst + ".tmp"
 os.makedirs(os.path.dirname(dst), exist_ok=True)
@@ -324,22 +330,46 @@ bridge_sync_isolated_home_claude_skills() {
       rel="${source_file#"$source_dir/"}"
       target_file="$target_dir/$rel"
       bridge_linux_sudo_root mkdir -p "$(dirname "$target_file")" 2>/dev/null || continue
+      # Atomic install via tmp + mv -f inside the isolated tree so any
+      # concurrent reader (e.g. an isolated agent already mid-launch)
+      # never observes a truncated file. The renderer / source-copy
+      # writes a controller-owned temp file, which is sudo-installed to
+      # `${target_file}.tmp.$$` (same directory as the final target so
+      # the rename stays within one filesystem), and only then renamed
+      # over `$target_file`. `mv -f` on POSIX is an atomic rename within
+      # a filesystem; if it fails the tmp sibling is removed so the
+      # isolated tree never carries a stale `.tmp.$$` artifact. Mirrors
+      # the controller-side os.replace pattern used by
+      # bridge_render_skill_file_for_isolated.
+      local _tmp_target="${target_file}.tmp.$$"
       if bridge_skill_file_is_text "$source_file" 2>/dev/null; then
-        # Render to a controller-owned temp file, then sudo-move into
-        # the isolated tree. Two-step is required because the renderer
-        # writes as the controller UID.
+        # Render to a controller-owned temp file, then sudo-stage into
+        # the isolated tree's tmp sibling. Two-step is required because
+        # the renderer writes as the controller UID.
         local _tmp_rendered=""
         _tmp_rendered="$(mktemp)" || continue
         if bridge_render_skill_file_for_isolated "$source_file" "$_tmp_rendered" "$BRIDGE_HOME"; then
-          bridge_linux_sudo_root install -m 0644 "$_tmp_rendered" "$target_file" 2>/dev/null \
-            || bridge_warn "isolated skills sync: install failed for $target_file"
+          if bridge_linux_sudo_root install -m 0644 "$_tmp_rendered" "$_tmp_target" 2>/dev/null; then
+            bridge_linux_sudo_root mv -f "$_tmp_target" "$target_file" 2>/dev/null || {
+              bridge_linux_sudo_root rm -f "$_tmp_target" 2>/dev/null || true
+              bridge_warn "isolated skills sync: atomic mv failed for $target_file"
+            }
+          else
+            bridge_warn "isolated skills sync: install failed for $target_file"
+          fi
         else
           bridge_warn "isolated skills sync: render failed for $source_file"
         fi
         rm -f "$_tmp_rendered"
       else
-        bridge_linux_sudo_root install -m 0644 "$source_file" "$target_file" 2>/dev/null \
-          || bridge_warn "isolated skills sync: copy failed for $target_file"
+        if bridge_linux_sudo_root install -m 0644 "$source_file" "$_tmp_target" 2>/dev/null; then
+          bridge_linux_sudo_root mv -f "$_tmp_target" "$target_file" 2>/dev/null || {
+            bridge_linux_sudo_root rm -f "$_tmp_target" 2>/dev/null || true
+            bridge_warn "isolated skills sync: atomic mv failed for $target_file"
+          }
+        else
+          bridge_warn "isolated skills sync: copy failed for $target_file"
+        fi
       fi
     done < <(find "$source_dir" -type f -print0 2>/dev/null)
 

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -181,7 +181,170 @@ bridge_bootstrap_claude_shared_skills() {
 
   if [[ -n "$agent" ]]; then
     bridge_sync_claude_runtime_skills "$agent" "$workdir"
+    # Issue #544 PR3 — isolated agents read ~/.claude/skills/ from the
+    # isolated UID's HOME, not from $workdir. The workdir symlinks above
+    # serve shared agents only; isolated agents need a parallel rendered
+    # copy under the isolated HOME with `~/.agent-bridge/` rewritten to
+    # the absolute BRIDGE_HOME path so skill commands resolve regardless
+    # of how `~` resolves under the isolated UID. Best-effort: silently
+    # skips non-isolated agents and never blocks the start path.
+    bridge_sync_isolated_home_claude_skills "$agent" >/dev/null 2>&1 || true
   fi
+}
+
+# Issue #544 PR3 — list of bridge-native skills that must be present in an
+# isolated agent's HOME `.claude/skills/` directory. This is the parallel
+# of the workdir symlink set installed by `bridge_bootstrap_claude_shared_skills`,
+# extended with `patch-permission-approval` so admin agents under isolation
+# also get the escalation runbook. New shared skills should be added here.
+bridge_isolated_home_shared_skill_names() {
+  printf '%s\n' \
+    "agent-bridge-runtime" \
+    "cron-manager" \
+    "memory-wiki" \
+    "patch-permission-approval"
+}
+
+# Render one skill text file from the controller-side source into the
+# isolated home copy, substituting `~/.agent-bridge/` with the absolute
+# BRIDGE_HOME path so the skill body's `agb` / `agent-bridge` commands
+# resolve under the isolated UID regardless of how `~` resolves there.
+# Atomic install via temp file + replace.
+bridge_render_skill_file_for_isolated() {
+  local source_file="$1"
+  local target_file="$2"
+  local bridge_home_resolved="$3"
+
+  bridge_require_python
+  python3 - "$source_file" "$target_file" "$bridge_home_resolved" <<'PY'
+import os
+import sys
+
+src, dst, home = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(src, "r", encoding="utf-8") as fh:
+    content = fh.read()
+# Normalize trailing slash on the home path so substitution is exact.
+home_norm = home.rstrip("/") + "/"
+content = content.replace("~/.agent-bridge/", home_norm)
+tmp = dst + ".tmp"
+os.makedirs(os.path.dirname(dst), exist_ok=True)
+with open(tmp, "w", encoding="utf-8") as fh:
+    fh.write(content)
+os.replace(tmp, dst)
+PY
+}
+
+# Decide whether a file under a skill directory is a UTF-8 text file the
+# renderer should rewrite, or an opaque binary that should be copied
+# verbatim. Heuristic: try to decode as UTF-8; on failure treat as binary.
+# Returns 0 (text) or 1 (binary).
+bridge_skill_file_is_text() {
+  local path="$1"
+  bridge_require_python
+  python3 - "$path" <<'PY'
+import sys
+try:
+    with open(sys.argv[1], "rb") as fh:
+        chunk = fh.read(8192)
+    if b"\x00" in chunk:
+        sys.exit(1)
+    chunk.decode("utf-8")
+    sys.exit(0)
+except (OSError, UnicodeDecodeError):
+    sys.exit(1)
+PY
+}
+
+# Sync the bridge-native skill set into the isolated UID's HOME
+# `.claude/skills/<skill>/` so Claude Code can discover them under the
+# isolated UID. No-op for non-isolated agents.
+#
+# Path text in SKILL.md (and other UTF-8 text files) is normalized:
+# `~/.agent-bridge/` → `${BRIDGE_HOME}/` (absolute) so the skill body's
+# `agb` / `agent-bridge` references resolve correctly under the isolated
+# UID regardless of `~` semantics or per-home symlink presence.
+#
+# Best-effort: returns 0 silently when the agent is not isolated, when
+# the controller cannot sudo to root, when sources are missing, or when
+# any individual skill fails to render. Failures inside the loop emit a
+# warning but do not abort sibling skills or block the caller.
+bridge_sync_isolated_home_claude_skills() {
+  local agent="$1"
+  local os_user=""
+  local isolated_home=""
+  local skills_root=""
+  local skill_name=""
+  local source_dir=""
+  local target_dir=""
+  local source_file=""
+  local rel=""
+  local target_file=""
+
+  [[ -n "$agent" ]] || return 0
+
+  # Predicate is fatal-on-zero for non-isolated agents; suppress so this
+  # remains a silent no-op when called unconditionally from the start path.
+  bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null || return 0
+
+  os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || true)"
+  [[ -n "$os_user" ]] || return 0
+  isolated_home="$(bridge_agent_linux_user_home "$os_user" 2>/dev/null || true)"
+  [[ -n "$isolated_home" ]] || return 0
+
+  skills_root="$isolated_home/.claude/skills"
+
+  # Ensure the skills root exists with isolated-UID ownership. The parent
+  # `.claude` may already be owned by the isolated UID; mkdir -p as root
+  # is the safe primitive (sudo wrap matches every other isolated-home
+  # mutation in lib/bridge-agents.sh).
+  bridge_linux_sudo_root mkdir -p "$skills_root" 2>/dev/null || {
+    bridge_warn "isolated skills sync: cannot mkdir $skills_root for $agent (sudo unavailable?)"
+    return 0
+  }
+  bridge_linux_sudo_root chown "$os_user:$os_user" "$skills_root" 2>/dev/null || true
+  bridge_linux_sudo_root chmod 0755 "$skills_root" 2>/dev/null || true
+
+  while IFS= read -r skill_name; do
+    [[ -n "$skill_name" ]] || continue
+    source_dir="$(bridge_shared_claude_skill_source_dir "$skill_name")"
+    if [[ ! -d "$source_dir" ]]; then
+      bridge_warn "isolated skills sync: source missing for skill '$skill_name' (looked under $source_dir)"
+      continue
+    fi
+    target_dir="$skills_root/$skill_name"
+    bridge_linux_sudo_root mkdir -p "$target_dir" 2>/dev/null || {
+      bridge_warn "isolated skills sync: cannot mkdir $target_dir"
+      continue
+    }
+
+    # Walk every regular file under the source skill dir and either
+    # render (text) or copy verbatim (binary). Preserve subdirectory
+    # structure under references/ etc.
+    while IFS= read -r -d '' source_file; do
+      rel="${source_file#"$source_dir/"}"
+      target_file="$target_dir/$rel"
+      bridge_linux_sudo_root mkdir -p "$(dirname "$target_file")" 2>/dev/null || continue
+      if bridge_skill_file_is_text "$source_file" 2>/dev/null; then
+        # Render to a controller-owned temp file, then sudo-move into
+        # the isolated tree. Two-step is required because the renderer
+        # writes as the controller UID.
+        local _tmp_rendered=""
+        _tmp_rendered="$(mktemp)" || continue
+        if bridge_render_skill_file_for_isolated "$source_file" "$_tmp_rendered" "$BRIDGE_HOME"; then
+          bridge_linux_sudo_root install -m 0644 "$_tmp_rendered" "$target_file" 2>/dev/null \
+            || bridge_warn "isolated skills sync: install failed for $target_file"
+        else
+          bridge_warn "isolated skills sync: render failed for $source_file"
+        fi
+        rm -f "$_tmp_rendered"
+      else
+        bridge_linux_sudo_root install -m 0644 "$source_file" "$target_file" 2>/dev/null \
+          || bridge_warn "isolated skills sync: copy failed for $target_file"
+      fi
+    done < <(find "$source_dir" -type f -print0 2>/dev/null)
+
+    bridge_linux_sudo_root chown -R "$os_user:$os_user" "$target_dir" 2>/dev/null || true
+  done < <(bridge_isolated_home_shared_skill_names)
 }
 
 bridge_agent_skills_registry_json() {

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -355,6 +355,7 @@ bridge_sync_isolated_home_claude_skills() {
               bridge_warn "isolated skills sync: atomic mv failed for $target_file"
             }
           else
+            bridge_linux_sudo_root rm -f "$_tmp_target" 2>/dev/null || true
             bridge_warn "isolated skills sync: install failed for $target_file"
           fi
         else
@@ -368,6 +369,7 @@ bridge_sync_isolated_home_claude_skills() {
             bridge_warn "isolated skills sync: atomic mv failed for $target_file"
           }
         else
+          bridge_linux_sudo_root rm -f "$_tmp_target" 2>/dev/null || true
           bridge_warn "isolated skills sync: copy failed for $target_file"
         fi
       fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window
 }
 
 add_all_integration() {
@@ -217,7 +217,7 @@ select_for_path() {
       ;;
 
     lib/bridge-isolation*.sh|lib/bridge-migration.sh|bridge-migrate.sh|tests/isolation*)
-      add_required isolation isolated-bin-agb launch
+      add_required isolation isolated-bin-agb isolated-skills-sync launch
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -225,6 +225,14 @@ select_for_path() {
     bin/agb|bin/*)
       # Issue #544 PR1 — curated bin/ shim for isolated agents.
       add_required isolated-bin-agb isolation launch
+      add_integration integration-minimal
+      ;;
+
+    lib/bridge-skills.sh|.claude/skills/*)
+      # Issue #544 PR3 — bridge-native skill sync into isolated HOME.
+      # Path text rewrite + tree walk live in lib/bridge-skills.sh and
+      # the source skill bodies are the rewrite input.
+      add_required isolated-skills-sync isolation launch
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10201,4 +10201,10 @@ log "running isolated-bin-agb smoke (issue #544 PR1)"
 log "isolated-bin-agb covers shim env-source/delegation/fallback only — live PATH injection requires isolate+restart"
 bash "$REPO_ROOT/scripts/smoke/isolated-bin-agb.sh"
 
+# Issue #544 PR3 — bridge-native skills sync into isolated HOME with
+# `~/.agent-bridge/` → absolute BRIDGE_HOME path normalization.
+log "running isolated-skills-sync smoke (issue #544 PR3)"
+log "isolated-skills-sync covers helper render/rewrite only — live sudo + ACL grants require isolate+restart on a Linux host"
+bash "$REPO_ROOT/scripts/smoke/isolated-skills-sync.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/isolated-skills-sync.sh
+++ b/scripts/smoke/isolated-skills-sync.sh
@@ -176,6 +176,121 @@ assert_subdir_preserved() {
     "subdir SKILL reference rewrites bridge path to absolute BRIDGE_HOME"
 }
 
+# Render a single skill with `BRIDGE_HOME=$1`, into an isolated home
+# unique to that run. The variant tests run after the main sync and
+# therefore re-use the seeded source tree under $FIXTURE_BRIDGE_HOME
+# (a real path with no quirks). The non-canonical input is what the
+# variant feeds to the helper as BRIDGE_HOME — the renderer must
+# canonicalize it to the same `$FIXTURE_BRIDGE_HOME` text in the
+# rendered SKILL.md.
+invoke_sync_with_bridge_home() {
+  local bridge_home_input="$1"
+  local isolated_home_root="$2"
+  local os_user="$3"
+
+  local repo_root="$SMOKE_REPO_ROOT"
+  local bash_bin="${BRIDGE_BASH_BIN:-bash}"
+
+  BRIDGE_HOME="$bridge_home_input" \
+  BRIDGE_HOST_PLATFORM_OVERRIDE=Linux \
+  BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT="$isolated_home_root" \
+  "$bash_bin" -c "
+    set -uo pipefail
+    source '$repo_root/bridge-lib.sh'
+
+    bridge_reset_roster_maps
+
+    BRIDGE_AGENT_IDS+=($FIXTURE_AGENT)
+    BRIDGE_AGENT_ENGINE[$FIXTURE_AGENT]=claude
+    BRIDGE_AGENT_ISOLATION_MODE[$FIXTURE_AGENT]=linux-user
+    BRIDGE_AGENT_OS_USER[$FIXTURE_AGENT]=$os_user
+
+    bridge_linux_sudo_root() {
+      \"\$@\"
+    }
+
+    bridge_sync_isolated_home_claude_skills '$FIXTURE_AGENT'
+  "
+}
+
+# Render with BRIDGE_HOME ending in a trailing slash. Canonicalization
+# must produce the same absolute path as the canonical fixture, with no
+# `//` doubled separator in the rewritten text.
+assert_canonicalize_trailing_slash() {
+  local home_trailing="$FIXTURE_BRIDGE_HOME/"
+  local iso_root="$SMOKE_TMP_ROOT/home-trailing"
+  local iso_user="agent-bridge-smoke-trailing"
+  local iso_home="$iso_root/$iso_user"
+
+  mkdir -p "$iso_home"
+  invoke_sync_with_bridge_home "$home_trailing" "$iso_root" "$iso_user"
+
+  local target="$iso_home/.claude/skills/agent-bridge-runtime/SKILL.md"
+  smoke_assert_file_exists "$target" \
+    "trailing-slash variant: rendered SKILL.md exists"
+  smoke_assert_contains \
+    "$(cat "$target")" \
+    "$FIXTURE_BRIDGE_HOME/agb inbox" \
+    "trailing-slash variant: rewrite produces canonical BRIDGE_HOME path"
+  smoke_assert_not_contains \
+    "$(cat "$target")" \
+    "$FIXTURE_BRIDGE_HOME//" \
+    "trailing-slash variant: no doubled '//' separator in rendered output"
+}
+
+# Render with BRIDGE_HOME containing an embedded doubled slash. normpath
+# collapses the duplicate; the rewritten text must match the canonical
+# single-slash absolute form.
+assert_canonicalize_doubled_slash() {
+  local home_double
+  home_double="$(dirname "$FIXTURE_BRIDGE_HOME")//$(basename "$FIXTURE_BRIDGE_HOME")"
+  local iso_root="$SMOKE_TMP_ROOT/home-double"
+  local iso_user="agent-bridge-smoke-double"
+  local iso_home="$iso_root/$iso_user"
+
+  mkdir -p "$iso_home"
+  invoke_sync_with_bridge_home "$home_double" "$iso_root" "$iso_user"
+
+  local target="$iso_home/.claude/skills/agent-bridge-runtime/SKILL.md"
+  smoke_assert_file_exists "$target" \
+    "doubled-slash variant: rendered SKILL.md exists"
+  smoke_assert_contains \
+    "$(cat "$target")" \
+    "$FIXTURE_BRIDGE_HOME/agb inbox" \
+    "doubled-slash variant: rewrite produces canonical BRIDGE_HOME path"
+  smoke_assert_not_contains \
+    "$(cat "$target")" \
+    "$FIXTURE_BRIDGE_HOME//" \
+    "doubled-slash variant: doubled '//' collapsed to single '/'"
+}
+
+# Render with BRIDGE_HOME pointing at a symlink to the real bridge home.
+# realpath must resolve the symlink so the rewritten text reflects the
+# underlying real path, not the symlink string.
+assert_canonicalize_symlink() {
+  local link_path="$SMOKE_TMP_ROOT/bridge-home-symlink"
+  ln -s "$FIXTURE_BRIDGE_HOME" "$link_path"
+
+  local iso_root="$SMOKE_TMP_ROOT/home-symlink"
+  local iso_user="agent-bridge-smoke-symlink"
+  local iso_home="$iso_root/$iso_user"
+
+  mkdir -p "$iso_home"
+  invoke_sync_with_bridge_home "$link_path" "$iso_root" "$iso_user"
+
+  local target="$iso_home/.claude/skills/agent-bridge-runtime/SKILL.md"
+  smoke_assert_file_exists "$target" \
+    "symlink variant: rendered SKILL.md exists"
+  smoke_assert_contains \
+    "$(cat "$target")" \
+    "$FIXTURE_BRIDGE_HOME/agb inbox" \
+    "symlink variant: rewrite resolves to real BRIDGE_HOME path"
+  smoke_assert_not_contains \
+    "$(cat "$target")" \
+    "$link_path/agb" \
+    "symlink variant: symlink string does not appear in rendered output"
+}
+
 main() {
   build_fixture
   invoke_sync
@@ -186,6 +301,17 @@ main() {
     assert_path_normalization
   smoke_run "skill subdirectory structure preserved" \
     assert_subdir_preserved
+
+  # Canonicalization sub-tests (issue #544 PR3 r2). Each variant feeds
+  # the helper a non-canonical BRIDGE_HOME spelling and asserts the
+  # rendered SKILL.md contains the same canonical absolute path the
+  # main fixture produces. Without realpath+normpath these diverge.
+  smoke_run "trailing-slash BRIDGE_HOME canonicalizes to bare path" \
+    assert_canonicalize_trailing_slash
+  smoke_run "doubled-slash BRIDGE_HOME canonicalizes to single slash" \
+    assert_canonicalize_doubled_slash
+  smoke_run "symlinked BRIDGE_HOME canonicalizes to real path" \
+    assert_canonicalize_symlink
 
   smoke_log "PASS"
 }

--- a/scripts/smoke/isolated-skills-sync.sh
+++ b/scripts/smoke/isolated-skills-sync.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# scripts/smoke/isolated-skills-sync.sh — Issue #544 PR3 smoke.
+#
+# Validates `bridge_sync_isolated_home_claude_skills` against a fixture
+# bridge home and a stand-in isolated UID home. Three groups of assertions:
+#
+# 1. All four bridge-native skills (agent-bridge-runtime, cron-manager,
+#    memory-wiki, patch-permission-approval) land in the isolated home's
+#    .claude/skills/<skill>/SKILL.md.
+# 2. Path text in rendered SKILL.md is normalized: every occurrence of
+#    `~/.agent-bridge/` becomes the absolute BRIDGE_HOME path, so the
+#    skill body's `agb` / `agent-bridge` commands resolve under the
+#    isolated UID without depending on `~` semantics or per-home symlinks.
+# 3. Subdirectory structure (e.g. references/) is preserved when the
+#    source skill carries one.
+#
+# Coverage: helper logic only. Does NOT exercise:
+#   - real Linux sudo (we stub bridge_linux_sudo_root to drop sudo since
+#     the fixture isolated home is owned by the test user under TMPDIR);
+#   - real `agent-bridge isolate <agent> --reapply` against a live UID;
+#   - the wire-in via bridge_bootstrap_claude_shared_skills (covered by
+#     existing isolation smoke).
+# End-to-end coverage is operator-side per OPERATIONS.md (`agent-bridge
+# isolate <agent> --reapply` + agent restart).
+
+set -euo pipefail
+
+SMOKE_NAME="isolated-skills-sync"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+SKILL_NAMES=(agent-bridge-runtime cron-manager memory-wiki patch-permission-approval)
+
+build_fixture() {
+  smoke_make_temp_root "$SMOKE_NAME"
+
+  FIXTURE_BRIDGE_HOME="$SMOKE_TMP_ROOT/bridge-home"
+  FIXTURE_ISOLATED_HOME_ROOT="$SMOKE_TMP_ROOT/home"
+  FIXTURE_OS_USER="agent-bridge-smoke"
+  FIXTURE_ISOLATED_HOME="$FIXTURE_ISOLATED_HOME_ROOT/$FIXTURE_OS_USER"
+  FIXTURE_AGENT="smoke"
+
+  mkdir -p \
+    "$FIXTURE_BRIDGE_HOME/.claude/skills" \
+    "$FIXTURE_ISOLATED_HOME"
+
+  # Seed each shared skill with a minimal SKILL.md whose body contains
+  # the `~/.agent-bridge/` literal that the renderer must rewrite. The
+  # extra plain-text line ensures rewrite happens both inline and in
+  # fenced code blocks. patch-permission-approval also gets a
+  # references/ subdir so the smoke verifies subdir preservation.
+  local skill
+  for skill in "${SKILL_NAMES[@]}"; do
+    mkdir -p "$FIXTURE_BRIDGE_HOME/.claude/skills/$skill"
+    cat >"$FIXTURE_BRIDGE_HOME/.claude/skills/$skill/SKILL.md" <<EOF
+---
+name: $skill
+description: Smoke fixture for $skill — exercises path rewrite.
+---
+
+# $skill
+
+Run \`~/.agent-bridge/agb inbox \$BRIDGE_AGENT_ID\` to drain the queue.
+
+\`\`\`bash
+~/.agent-bridge/agent-bridge memory query --agent "\$BRIDGE_AGENT_ID"
+\`\`\`
+EOF
+  done
+
+  # Subdirectory in patch-permission-approval — verify the renderer
+  # walks the tree and preserves structure.
+  mkdir -p "$FIXTURE_BRIDGE_HOME/.claude/skills/patch-permission-approval/references"
+  cat >"$FIXTURE_BRIDGE_HOME/.claude/skills/patch-permission-approval/references/notes.md" <<'EOF'
+# Reference notes
+
+See `~/.agent-bridge/agb show <id>` for task detail.
+EOF
+}
+
+invoke_sync() {
+  # Run the helper inside a fresh bash that sources bridge-lib.sh, with
+  # BRIDGE_HOST_PLATFORM_OVERRIDE=Linux so the predicate succeeds on
+  # macOS dev hosts, and BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT pointed at
+  # the fixture so the helper writes into TMPDIR. We override
+  # bridge_linux_sudo_root to drop the sudo wrap (the fixture isolated
+  # home is already owned by the test user) — the helper's behavior is
+  # otherwise identical.
+  local repo_root="$SMOKE_REPO_ROOT"
+  local bash_bin="${BRIDGE_BASH_BIN:-bash}"
+
+  BRIDGE_HOME="$FIXTURE_BRIDGE_HOME" \
+  BRIDGE_HOST_PLATFORM_OVERRIDE=Linux \
+  BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT="$FIXTURE_ISOLATED_HOME_ROOT" \
+  "$bash_bin" -c "
+    set -uo pipefail
+    source '$repo_root/bridge-lib.sh'
+
+    # Initialize empty roster maps without loading on-disk rosters.
+    # bridge_reset_roster_maps declares every BRIDGE_AGENT_* assoc
+    # array, which lets us inject the fixture agent's metadata directly.
+    bridge_reset_roster_maps
+
+    # Inject the fixture agent. Keys are unquoted on purpose: bash
+    # under \`set -u\` evaluates quoted single-token keys as variable
+    # references inside an assoc-array index.
+    BRIDGE_AGENT_IDS+=($FIXTURE_AGENT)
+    BRIDGE_AGENT_ENGINE[$FIXTURE_AGENT]=claude
+    BRIDGE_AGENT_ISOLATION_MODE[$FIXTURE_AGENT]=linux-user
+    BRIDGE_AGENT_OS_USER[$FIXTURE_AGENT]=$FIXTURE_OS_USER
+
+    # Drop sudo: the fixture isolated home is owned by the controlling
+    # test user under TMPDIR, so sudo is unnecessary and unavailable in
+    # CI. The helper calls this primitive uniformly for every mutation.
+    bridge_linux_sudo_root() {
+      \"\$@\"
+    }
+
+    bridge_sync_isolated_home_claude_skills '$FIXTURE_AGENT'
+  "
+}
+
+assert_all_skills_present() {
+  local skill
+  for skill in "${SKILL_NAMES[@]}"; do
+    smoke_assert_file_exists \
+      "$FIXTURE_ISOLATED_HOME/.claude/skills/$skill/SKILL.md" \
+      "skill '$skill' rendered into isolated home"
+  done
+}
+
+assert_path_normalization() {
+  local skill
+  local target
+  for skill in "${SKILL_NAMES[@]}"; do
+    target="$FIXTURE_ISOLATED_HOME/.claude/skills/$skill/SKILL.md"
+    # Every `~/.agent-bridge/` literal in the source must be gone. The
+    # tilde here is intentional — we are searching for the literal text
+    # the renderer is supposed to have rewritten away, not a path.
+    # shellcheck disable=SC2088
+    if grep -F '~/.agent-bridge/' "$target" >/dev/null 2>&1; then
+      smoke_fail "skill '$skill' still contains '~/.agent-bridge/' after rewrite (target=$target)"
+    fi
+    # Absolute BRIDGE_HOME path must be present in its place. The
+    # fixture body inserts both `agb` and `agent-bridge memory` calls,
+    # so the rewrite must produce the absolute form for both.
+    smoke_assert_contains \
+      "$(cat "$target")" \
+      "$FIXTURE_BRIDGE_HOME/agb inbox" \
+      "skill '$skill' rewrites '~/.agent-bridge/agb' to absolute BRIDGE_HOME"
+    smoke_assert_contains \
+      "$(cat "$target")" \
+      "$FIXTURE_BRIDGE_HOME/agent-bridge memory" \
+      "skill '$skill' rewrites '~/.agent-bridge/agent-bridge' to absolute BRIDGE_HOME"
+  done
+}
+
+assert_subdir_preserved() {
+  local subdir_target="$FIXTURE_ISOLATED_HOME/.claude/skills/patch-permission-approval/references/notes.md"
+  smoke_assert_file_exists "$subdir_target" \
+    "subdirectory file under references/ preserved during sync"
+  # Same intentional-tilde rationale as assert_path_normalization above.
+  # shellcheck disable=SC2088
+  if grep -F '~/.agent-bridge/' "$subdir_target" >/dev/null 2>&1; then
+    smoke_fail "subdir file still contains '~/.agent-bridge/' after rewrite (target=$subdir_target)"
+  fi
+  smoke_assert_contains \
+    "$(cat "$subdir_target")" \
+    "$FIXTURE_BRIDGE_HOME/agb show" \
+    "subdir SKILL reference rewrites bridge path to absolute BRIDGE_HOME"
+}
+
+main() {
+  build_fixture
+  invoke_sync
+
+  smoke_run "all bridge-native skills present in isolated home" \
+    assert_all_skills_present
+  smoke_run "path text normalized to absolute BRIDGE_HOME" \
+    assert_path_normalization
+  smoke_run "skill subdirectory structure preserved" \
+    assert_subdir_preserved
+
+  smoke_log "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Issue #544 PR3 (Gap B + Gap C). Sync the four bridge-native Claude skills (`agent-bridge-runtime`, `cron-manager`, `memory-wiki`, `patch-permission-approval`) into the isolated UID's HOME `/home/agent-bridge-<agent>/.claude/skills/`, with skill body text normalized so every `~/.agent-bridge/agb` and `~/.agent-bridge/agent-bridge` reference is rewritten to the absolute `${BRIDGE_HOME}/...` path at sync time.

Why this is needed (from the issue):

- Claude Code under the isolated UID reads `~/.claude/skills/` from the isolated home, not from the workdir. The existing workdir-side symlinks installed by `bridge_link_shared_claude_skill` serve shared (non-isolated) agents only — they are not visible to isolated agents.
- The skill bodies hard-code `~/.agent-bridge/agb`, which under the isolated UID resolves via the per-isolated-home `~/.agent-bridge → $BRIDGE_HOME` symlink. That symlink is fragile across install variants and silently breaks the agent's documented commands when missing or pointing elsewhere.

Path normalization choice (option C from the issue): rewrite to absolute `${BRIDGE_HOME}/agb`, not bare `agb`. Bare `agb` would rely on PR1's PATH injection — a future change to PR1's PATH ordering would silently break skill commands. Absolute is unambiguous and works regardless of PATH state.

## Changes

- `lib/bridge-skills.sh` — new helpers:
  - `bridge_isolated_home_shared_skill_names` (canonical list of the 4 skills)
  - `bridge_render_skill_file_for_isolated` (Python heredoc; `~/.agent-bridge/` → absolute `${BRIDGE_HOME}/`)
  - `bridge_skill_file_is_text` (UTF-8 vs binary heuristic so binary blobs are copied verbatim)
  - `bridge_sync_isolated_home_claude_skills` (main sync; no-op for non-isolated agents; sudo-backed for isolated home ownership; preserves subdirectory structure)
  - `bridge_bootstrap_claude_shared_skills` now calls the new sync as a sibling of the workdir symlink path. Best-effort; never blocks the start path.
- `lib/bridge-migration.sh` — wire the sync into both branches of `bridge_migration_isolate`:
  - first-time isolate (after `bridge_linux_prepare_agent_isolation`)
  - `--reapply` (after the ACL reapply)
- `bridge-upgrade.sh` — sync isolated-home skills on `agb upgrade` so existing isolated agents pick up new/changed skills automatically (honors `--dry-run`).
- `scripts/smoke/isolated-skills-sync.sh` — new smoke. Builds a fixture `BRIDGE_HOME` with the 4 skills (one carrying a `references/` subdir), invokes the helper with `BRIDGE_HOST_PLATFORM_OVERRIDE=Linux` against a TMPDIR-rooted isolated home, and asserts: all 4 skills present, no `~/.agent-bridge/` literal remains in any rendered SKILL.md, the absolute `${BRIDGE_HOME}/agb`/`${BRIDGE_HOME}/agent-bridge` paths appear, and subdirectory structure is preserved.
- `scripts/smoke-test.sh` — invokes the new smoke after the existing `isolated-bin-agb`.
- `scripts/ci-select-smoke.sh` — add `isolated-skills-sync` to the static required list, and add a per-path trigger for `lib/bridge-skills.sh` and `.claude/skills/*` so the sync is exercised whenever the source skill bodies move.
- `OPERATIONS.md` — operator note in the isolated-agent section: the sync runs on isolate / restart / `--reapply` / upgrade; existing installs adopt by `agent-bridge isolate <agent> --reapply` followed by an agent restart.

## Out of scope

- Issue #544 PR2 (settings.json hooks rendering for isolated HOME — Gap A).
- Issue #544 PR4 (broader `agent-bridge` subcommand allowlist + audit — Gap D, beyond what PR1 already shipped).
- The source `.claude/skills/<skill>/SKILL.md` files are intentionally NOT modified — they remain canonical for shared (non-isolated) agents. Only the rendered copy under the isolated home is path-normalized.
- `bridge_link_shared_claude_skill` (workdir symlink) is intentionally NOT touched — it serves shared agents and the new isolated-HOME path is parallel.

## Test plan

- [x] `bash -n lib/bridge-skills.sh lib/bridge-migration.sh bridge-upgrade.sh scripts/smoke/isolated-skills-sync.sh scripts/smoke-test.sh scripts/ci-select-smoke.sh` — pass
- [x] `shellcheck` on the same set — pass (intentional-tilde greps in the smoke carry SC2088 disables with the rationale inline)
- [x] `bash scripts/smoke/isolated-skills-sync.sh` — pass (3 assertion groups: presence, path normalization, subdir preserved)
- [x] `./scripts/smoke-test.sh` — pass on the new smoke; pre-existing failures unchanged
- [ ] Operator-side end-to-end on a Linux host: `agent-bridge isolate <agent> --reapply` then restart; verify `<isolated-home>/.claude/skills/agent-bridge-runtime/SKILL.md` exists, contains `${BRIDGE_HOME}/agb`, and contains no `~/.agent-bridge/` literal. (Not exercised by smoke — fixture stubs `bridge_linux_sudo_root` to a no-op since the TMPDIR target is owned by the test user.)

Refs #544
