### PR TITLE
feat(roster): system agent class with read-only cross-agent scope (refs #539)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,6 +232,35 @@ The daemon's followup gate (`bridge-daemon.sh` `case "$CRON_REPORTING_DECISION"`
 - `silent` / `reported` → daemon clears `CRON_NEEDS_HUMAN_FOLLOWUP` (runner already handled or intentionally silent).
 - `invalid` / empty → daemon's existing failure-followup path runs (so a malformed result or missing field is never lost).
 
+## Hooks / Tool Policy
+
+`hooks/tool-policy.py` is the per-tool-call gate that enforces per-agent
+isolation, audited mutation of protected paths, and prompt-guard
+sanitization. Together with `hooks/bridge_hook_common.py` it is the
+containment/audit layer (not a sandbox — see CLAUDE.md "High-Risk
+Areas" item 5).
+
+### Agent class
+
+Each agent has a class (`user` by default; `system` opt-in via roster).
+
+- `user` — per-agent isolation; cross-agent reads denied.
+- `system` — read-only access to other agents' `memory/{projects,
+  decisions,shared}/` subtrees and to `shared/*` (excluding
+  `shared/private/` and `shared/secrets/`). `Bash`, `Edit`, and `Write`
+  outside the agent's own home stay denied even for `system`. Every
+  cross-agent read emits a `system_cross_agent_read` row to
+  `audit.jsonl` so the operator retains a full ledger.
+
+Class is declared in the roster (`BRIDGE_AGENT_CLASS["<agent>"]="system"`
+in `agent-roster.local.sh`) — runtime cannot change it. Unknown class
+values hard-fail at roster load. The shipped public roster declares
+no system-class agents; operators add `BRIDGE_AGENT_CLASS["…"]="system"`
+to their librarian / patch agents locally. The bash side exposes the
+value via `bridge_agent_class`; the calling agent's class is exported
+to hook subprocesses as the `BRIDGE_AGENT_CLASS_FOR_HOOK` scalar
+(distinct name to avoid colliding with the bash associative array).
+
 ## Configuration Surface
 
 Important environment variables:

--- a/agent-roster.local.example.sh
+++ b/agent-roster.local.example.sh
@@ -142,6 +142,26 @@ BRIDGE_AGENT_ACTION["developer:clear"]="/clear"
 # BRIDGE_HEALTH_WARN_SECONDS=3600
 # BRIDGE_HEALTH_CRITICAL_SECONDS=14400
 
+# Optional: agent class — privilege boundary consumed by hooks/tool-policy.py
+# (issue #539). The closed value space is { user, system }; an unknown class
+# is a hard error at roster load.
+#
+#   user   - default. Per-agent isolation; cross-agent reads denied.
+#   system - read-only access to other agents' memory/{projects,decisions,
+#            shared}/ trees plus shared/* (excluding shared/private/ and
+#            shared/secrets/). Bash/Edit/Write outside the agent's own
+#            home stay denied even for class=system. Every cross-agent
+#            read emits a `system_cross_agent_read` row to audit.jsonl.
+#
+# Class is intended for ingestion/supervisory roles (e.g., a librarian
+# that harvests every agent's memory tree into a shared wiki, or a
+# patch/doctor that diagnoses other agents). The shipped public roster
+# declares no system-class agents — operators opt in locally.
+#
+# Example (uncomment and replace the agent name with your local role):
+# BRIDGE_AGENT_CLASS["librarian"]="system"
+# BRIDGE_AGENT_CLASS["patch"]="system"
+
 # Example: add another long-lived role.
 # bridge_add_agent_id_if_missing "reviewer"
 # BRIDGE_AGENT_DESC["reviewer"]="Code review role (Claude Code)"

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -176,6 +176,13 @@ export BRIDGE_ADMIN_AGENT_ID="$(bridge_admin_agent_id)"
 export BRIDGE_AGENT_WORKDIR="$WORK_DIR"
 export BRIDGE_AGENT_ISOLATION_MODE="$(bridge_agent_isolation_mode "$AGENT")"
 export BRIDGE_AGENT_OS_USER="$(bridge_agent_os_user "$AGENT")"
+# Issue #539: privilege class consumed by hooks/tool-policy.py to gate
+# cross-agent reads. Default "user"; "system" opts in to read-only access
+# of peer memory/{projects,decisions,shared}/ trees. Exported as a
+# distinctly-named scalar (BRIDGE_AGENT_CLASS in bash is the associative
+# array of every agent's class; the hook only needs the calling agent's
+# value, so we surface a scalar alias here).
+export BRIDGE_AGENT_CLASS_FOR_HOOK="$(bridge_agent_class "$AGENT")"
 export BRIDGE_AGENT_INJECT_TIMESTAMP="$(bridge_agent_inject_timestamp "$AGENT")"
 export BRIDGE_AGENT_PROMPT_GUARD_POLICY="$(bridge_guard_policy_raw "$AGENT")"
 export BRIDGE_PROMPT_GUARD_CANARY_TOKENS="$(bridge_agent_prompt_guard_canary "$AGENT")"

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -156,6 +156,52 @@ def current_agent() -> str:
     return os.environ.get("BRIDGE_AGENT_ID", "").strip()
 
 
+# Issue #539: the calling agent's privilege class. The closed value space
+# is {"user", "system"}; missing or unknown values normalize to "user" so
+# the default-deny posture for cross-agent reads is preserved. The bash
+# roster loader (lib/bridge-state.sh::bridge_load_roster) hard-fails on
+# unknown class values, so seeing one here means an out-of-band shell
+# corrupted the env file — fall back conservatively rather than escalate.
+#
+# The exported env var is BRIDGE_AGENT_CLASS_FOR_HOOK (a scalar alias);
+# the bare name BRIDGE_AGENT_CLASS in bash is the associative array of
+# every agent's class, which would collide with a scalar export.
+# bridge-run.sh:178-184 sets the alias for the calling agent.
+@functools.lru_cache(maxsize=1)
+def current_agent_class() -> str:
+    raw = os.environ.get("BRIDGE_AGENT_CLASS_FOR_HOOK", "").strip().lower()
+    if raw in {"user", "system"}:
+        return raw
+    return "user"
+
+
+# Issue #539: standardized audit event for every cross-agent file read by
+# a class=system agent. Mirrors the write_audit envelope (ts/host/uid/etc.)
+# but exposes a stable detail shape — `target_path` (the absolute or
+# bridge-relative path the agent attempted to read), `target_agent` (the
+# peer whose home contains the path, or "" for shared/* reads), and
+# `tool` (the Claude tool name that drove the access). Operators audit
+# every system-class read by grepping audit.jsonl for
+# `"action":"system_cross_agent_read"`.
+def emit_system_cross_agent_read(
+    *,
+    agent: str,
+    target_path: str,
+    target_agent: str,
+    tool: str,
+) -> None:
+    write_audit(
+        "system_cross_agent_read",
+        agent or "unknown",
+        {
+            "agent": agent or "unknown",
+            "target_path": target_path,
+            "target_agent": target_agent,
+            "tool": tool,
+        },
+    )
+
+
 def current_isolated_agent() -> str | None:
     agent = current_agent()
     if not agent:

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -492,11 +492,41 @@ def protected_path_reason(
         return SYSTEM_CONFIG_DENY_REASON
     if admin:
         return None
+    # Issue #539 r2: shared/* is NOT a peer-agent path, so
+    # target_agent_for_path() returns None for it and the original
+    # `if target:` block below never fired for shared reads. Evaluate
+    # the system-class shared/* gate first, before peer-agent
+    # resolution, so:
+    #   - shared/private/*, shared/secrets/* → DENY for system class
+    #     (operators may put credentials/secrets here that even
+    #     ingestion agents must not see).
+    #   - shared/<anything else> → ALLOW + audit for system class.
+    # User class shared/* behavior is unchanged: target stays None,
+    # the function returns None below, and the read passes without
+    # audit (matches pre-#539 behavior — out of #539 scope).
+    if read_intent and current_agent_class() == "system":
+        rel_shared = _resolve_under(path, bridge_home_dir() / "shared")
+        if rel_shared is not None:
+            rel_str = rel_shared.as_posix()
+            if rel_str != "." and any(
+                rel_str == forbidden.rstrip("/") or rel_str.startswith(forbidden)
+                for forbidden in _SHARED_FORBIDDEN_PREFIXES
+            ):
+                return (
+                    "cross-agent access is blocked: shared/private and "
+                    "shared/secrets are off-limits even for system-class agents"
+                )
+            emit_system_cross_agent_read(
+                agent=agent,
+                target_path=str(path),
+                target_agent="",
+                tool="Read",
+            )
+            return None
     target = target_agent_for_path(path, agent)
     if target:
         # Issue #539: class=system agents are allowed read-only access to
-        # peer memory/{projects,decisions,shared}/ subtrees and to
-        # shared/* (excluding shared/private/, shared/secrets/). The
+        # peer memory/{projects,decisions,shared}/ subtrees. The
         # carve-out fires only for read-intent tools (Read / Glob /
         # Grep / NotebookRead) — Bash/Edit/Write reach this branch with
         # read_intent=False and stay denied. Every allowed read emits a

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -27,7 +27,9 @@ from bridge_hook_common import (  # noqa: E402
     agent_home_root,
     bridge_home_dir,
     current_agent,
+    current_agent_class,
     current_agent_workdir,
+    emit_system_cross_agent_read,
     path_within,
     truncate_text,
     write_audit,
@@ -351,6 +353,100 @@ def _is_read_intent_tool(tool_name: str, tool_input: dict[str, Any]) -> bool:
     return False
 
 
+# Issue #539: subpath allowlist that a class=system agent may read out of
+# another agent's home. Only the operator-curated, ingestion-friendly
+# memory subtrees are exposed; raw `state/`, `logs/`, `private/`,
+# credentials, etc. stay denied even for system-class agents. Add a new
+# subpath here ONLY when the bridge has a clear ingestion contract for
+# it — every entry expands the cross-agent privilege surface.
+_SYSTEM_CLASS_READABLE_AGENT_SUBPATHS: tuple[str, ...] = (
+    "memory/projects/",
+    "memory/decisions/",
+    "memory/shared/",
+)
+
+# Issue #539: shared/* is broadly readable by class=system agents, with
+# narrow exceptions for any operator-side curated secret/private prefix.
+# Anything operators want to keep private even from system-class agents
+# goes under one of these prefixes.
+_SHARED_FORBIDDEN_PREFIXES: tuple[str, ...] = (
+    "private/",
+    "secrets/",
+)
+
+
+def _resolve_under(path: Path, root: Path) -> Path | None:
+    """Return *path* expressed relative to *root*, or None if outside.
+
+    Resolves both sides through ``Path.resolve()`` so symlinked aliases
+    (e.g., the ``shared`` symlink under ``$BRIDGE_HOME/agents/``) and
+    ``..`` traversal are normalized before the prefix check. Returning
+    None signals "not under this root" to the caller — never an error.
+    """
+    try:
+        rel = path.resolve().relative_to(root.resolve())
+    except (ValueError, OSError):
+        return None
+    return rel
+
+
+def _system_class_cross_agent_read_allowed(
+    path: Path,
+    self_agent: str,
+) -> tuple[bool, str]:
+    """Decide whether *path* is in the class=system Read allowlist.
+
+    Returns ``(allowed, target_agent)``. ``target_agent`` is the peer
+    whose home contains *path*, or ``""`` for shared/* matches; the
+    caller uses it for the audit row. ``allowed=False`` means the path
+    sits outside both the per-agent subpath allowlist and the shared
+    allowlist, so the cross-agent gate must continue to deny — even for
+    a system-class actor.
+
+    The check is read-only by construction: the caller (the ``Read`` /
+    ``Glob`` / ``Grep`` cross-agent gate) only invokes this for
+    read-intent tools. Bash/Edit/Write paths never reach here, so a
+    system-class agent cannot escalate to cross-agent writes through
+    this carve-out.
+    """
+    bridge_home = bridge_home_dir()
+    home_root = agent_home_root()
+
+    # shared/* allowlist (with private/ and secrets/ explicitly excluded).
+    shared_root = bridge_home / "shared"
+    rel_shared = _resolve_under(path, shared_root)
+    if rel_shared is not None:
+        rel_str = rel_shared.as_posix()
+        # Bare `shared/` (rel == ".") is allowed for directory-level reads.
+        if rel_str == ".":
+            return True, ""
+        for forbidden in _SHARED_FORBIDDEN_PREFIXES:
+            if rel_str == forbidden.rstrip("/") or rel_str.startswith(forbidden):
+                return False, ""
+        return True, ""
+
+    # agents/<other>/memory/{projects,decisions,shared}/ allowlist.
+    rel_agent = _resolve_under(path, home_root)
+    if rel_agent is not None:
+        parts = rel_agent.parts
+        if len(parts) < 2:
+            # `agents/` itself or `agents/<name>` — not enough structure
+            # to be inside the memory allowlist.
+            return False, ""
+        other_agent = parts[0]
+        # Self-home reads are allowed by the existing per-agent isolation;
+        # this carve-out is specifically for *cross*-agent Read.
+        if other_agent == self_agent:
+            return False, ""
+        rest = "/".join(parts[1:]) + "/"
+        for sub in _SYSTEM_CLASS_READABLE_AGENT_SUBPATHS:
+            if rest.startswith(sub):
+                return True, other_agent
+        return False, other_agent
+
+    return False, ""
+
+
 def protected_path_reason(
     path: Path,
     agent: str,
@@ -398,6 +494,24 @@ def protected_path_reason(
         return None
     target = target_agent_for_path(path, agent)
     if target:
+        # Issue #539: class=system agents are allowed read-only access to
+        # peer memory/{projects,decisions,shared}/ subtrees and to
+        # shared/* (excluding shared/private/, shared/secrets/). The
+        # carve-out fires only for read-intent tools (Read / Glob /
+        # Grep / NotebookRead) — Bash/Edit/Write reach this branch with
+        # read_intent=False and stay denied. Every allowed read emits a
+        # `system_cross_agent_read` audit row so the operator retains a
+        # full ledger of cross-agent access.
+        if read_intent and current_agent_class() == "system":
+            allowed, audit_target = _system_class_cross_agent_read_allowed(path, agent)
+            if allowed:
+                emit_system_cross_agent_read(
+                    agent=agent,
+                    target_path=str(path),
+                    target_agent=audit_target or target,
+                    tool="Read",
+                )
+                return None
         return f"cross-agent access is blocked: {target}"
     return None
 

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -386,6 +386,43 @@ bridge_agent_source() {
   printf '%s' "${BRIDGE_AGENT_SOURCE[$agent]-static}"
 }
 
+# Issue #539: agent class is the privilege boundary consumed by
+# hooks/tool-policy.py. The closed value space is {user, system}; any
+# unknown value (including the empty string written by older roster
+# snapshots) is normalized to "user" so the default-deny posture for
+# cross-agent reads is preserved on rosters that predate this field.
+# Validation of operator-supplied class= values happens at roster-load
+# time via bridge_validate_agent_class — this getter is the read-side
+# fallback.
+bridge_agent_class() {
+  local agent="$1"
+  local cls="${BRIDGE_AGENT_CLASS[$agent]-user}"
+  case "$cls" in
+    user|system) ;;
+    *) cls="user" ;;
+  esac
+  printf '%s' "$cls"
+}
+
+# Validate every BRIDGE_AGENT_CLASS entry currently present in the roster
+# maps. Called from bridge_load_roster after sourcing the roster files so
+# typos like `class=admin` or `class=System` surface as a hard error
+# rather than silently falling back to user-class. The closed value space
+# matches bridge_agent_class above; future classes must extend both the
+# value list AND the tool-policy gate.
+bridge_validate_agent_classes() {
+  declare -p BRIDGE_AGENT_CLASS >/dev/null 2>&1 || return 0
+  local agent cls
+  for agent in "${!BRIDGE_AGENT_CLASS[@]}"; do
+    cls="${BRIDGE_AGENT_CLASS[$agent]}"
+    [[ -n "$cls" ]] || continue
+    case "$cls" in
+      user|system) ;;
+      *) bridge_die "unknown agent class '$cls' for agent '$agent'; valid: user, system" ;;
+    esac
+  done
+}
+
 bridge_agent_session() {
   local agent="$1"
   printf '%s' "${BRIDGE_AGENT_SESSION[$agent]-}"
@@ -2443,6 +2480,7 @@ declare -g -A BRIDGE_AGENT_MODEL=()
 declare -g -A BRIDGE_AGENT_EFFORT=()
 declare -g -A BRIDGE_AGENT_PERMISSION_MODE=()
 declare -g -A BRIDGE_AGENT_PROMPT_GUARD=()
+declare -g -A BRIDGE_AGENT_CLASS=()
 EOF
   # Self entry first: full record including LAUNCH_CMD (the calling agent's
   # own launch command may legitimately carry tokens; ACLs already restrict
@@ -2471,6 +2509,7 @@ BRIDGE_AGENT_CHANNELS[$(printf '%q' "$agent")]=$(printf '%q' "$channels")
 BRIDGE_AGENT_ISOLATION_MODE[$(printf '%q' "$agent")]=$(printf '%q' "$isolation_mode")
 BRIDGE_AGENT_OS_USER[$(printf '%q' "$agent")]=$(printf '%q' "$os_user")
 BRIDGE_AGENT_PROMPT_GUARD[$(printf '%q' "$agent")]=$(printf '%q' "${BRIDGE_AGENT_PROMPT_GUARD[$agent]-}")
+BRIDGE_AGENT_CLASS[$(printf '%q' "$agent")]=$(printf '%q' "$(bridge_agent_class "$agent")")
 EOF
   # Peer entries: id + non-secret metadata. NEVER emit a peer's LAUNCH_CMD
   # (token-bearing) or PROMPT_GUARD policy (canary tokens at

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -513,6 +513,7 @@ bridge_reset_roster_maps() {
   unset BRIDGE_AGENT_WEBHOOK_PORT BRIDGE_LEGACY_AGENT_TARGET BRIDGE_OPENCLAW_AGENT_TARGET BRIDGE_CRON_AGENT_TARGET BRIDGE_CRON_FALLBACK_AGENT BRIDGE_AGENT_DISCORD_CHANNEL_ID BRIDGE_AGENT_CHANNELS BRIDGE_AGENT_PLUGINS BRIDGE_AGENT_AUTO_ACCEPT_DEV_CHANNELS BRIDGE_AGENT_MEMORY_DAILY_REFRESH BRIDGE_AGENT_INJECT_TIMESTAMP BRIDGE_AGENT_PROMPT_GUARD BRIDGE_CRON_ENQUEUE_FAMILIES
   unset BRIDGE_AGENT_SKILLS
   unset BRIDGE_AGENT_ISOLATION_MODE BRIDGE_AGENT_OS_USER
+  unset BRIDGE_AGENT_CLASS
 
   declare -g -a BRIDGE_AGENT_IDS=()
   declare -g -A BRIDGE_AGENT_DESC=()
@@ -549,6 +550,11 @@ bridge_reset_roster_maps() {
   declare -g -A BRIDGE_AGENT_SKILLS=()
   declare -g -A BRIDGE_AGENT_ISOLATION_MODE=()
   declare -g -A BRIDGE_AGENT_OS_USER=()
+  # Issue #539: per-agent privilege class consumed by hooks/tool-policy.py.
+  # Default-empty; bridge_agent_class normalizes missing/unknown to "user".
+  # Operators opt agents into class=system in agent-roster.local.sh; the
+  # public roster declares no system-class agents.
+  declare -g -A BRIDGE_AGENT_CLASS=()
   declare -g -a BRIDGE_CRON_ENQUEUE_FAMILIES=()
 }
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1255,6 +1255,14 @@ bridge_load_roster() {
     fi
   fi
 
+  # Issue #539: validate BRIDGE_AGENT_CLASS values once the roster files
+  # have been sourced. The closed value space is {user, system}; a typo
+  # like `class=admin` must surface as a hard load error rather than
+  # silently degrading to user-class privileges.
+  if declare -F bridge_validate_agent_classes >/dev/null 2>&1; then
+    bridge_validate_agent_classes
+  fi
+
   : "${BRIDGE_LOG_DIR:=$BRIDGE_HOME/logs}"
   : "${BRIDGE_AUDIT_LOG:=$BRIDGE_LOG_DIR/audit.jsonl}"
   : "${BRIDGE_SHARED_DIR:=$BRIDGE_HOME/shared}"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10201,4 +10201,8 @@ log "running isolated-bin-agb smoke (issue #544 PR1)"
 log "isolated-bin-agb covers shim env-source/delegation/fallback only — live PATH injection requires isolate+restart"
 bash "$REPO_ROOT/scripts/smoke/isolated-bin-agb.sh"
 
+# Issue #539 — system agent class roundtrip + tool-policy gate scenarios.
+log "running system-agent-class smoke (issue #539)"
+bash "$REPO_ROOT/scripts/smoke/system-agent-class.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/system-agent-class.sh
+++ b/scripts/smoke/system-agent-class.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# scripts/smoke/system-agent-class.sh — Issue #539 smoke.
+#
+# Validates the first-class `system` agent class introduced in #539:
+#   1. Roster loader recognizes BRIDGE_AGENT_CLASS and exposes the value
+#      via bridge_agent_class (defaulting unknown/missing entries to
+#      "user").
+#   2. bridge_validate_agent_classes hard-fails on an unknown class.
+#   3. hooks/tool-policy.py allows a class=system agent to Read another
+#      agent's memory/projects/ tree, audits the access, and continues
+#      to deny:
+#        - cross-agent Read into a forbidden subpath (state/),
+#        - cross-agent Write of any kind (system class is read-only),
+#        - cross-agent Read by a default class=user agent.
+#
+# This smoke uses an isolated BRIDGE_HOME via smoke_setup_bridge_home and
+# never touches the operator's live runtime.
+
+set -euo pipefail
+
+SMOKE_NAME="system-agent-class"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "system-agent-class"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+
+BASH4_BIN="${BASH:-bash}"
+if (( BASH_VERSINFO[0] < 4 )); then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BASH4_BIN="/opt/homebrew/bin/bash"
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BASH4_BIN="/usr/local/bin/bash"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1 — class roundtrip + default-to-user behavior.
+# ---------------------------------------------------------------------------
+class_getter_roundtrip() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "alpha"
+BRIDGE_AGENT_ENGINE["alpha"]="claude"
+BRIDGE_AGENT_SESSION["alpha"]="alpha"
+BRIDGE_AGENT_WORKDIR["alpha"]="$BRIDGE_AGENT_HOME_ROOT/alpha"
+
+bridge_add_agent_id_if_missing "beta"
+BRIDGE_AGENT_ENGINE["beta"]="claude"
+BRIDGE_AGENT_SESSION["beta"]="beta"
+BRIDGE_AGENT_WORKDIR["beta"]="$BRIDGE_AGENT_HOME_ROOT/beta"
+BRIDGE_AGENT_CLASS["beta"]="system"
+EOF
+
+  local out
+  out="$(
+    "$BASH4_BIN" -c 'repo="$1"; source "$repo/bridge-lib.sh"; bridge_load_roster
+      printf "alpha=%s\n" "$(bridge_agent_class alpha)"
+      printf "beta=%s\n"  "$(bridge_agent_class beta)"
+      printf "missing=%s\n" "$(bridge_agent_class ghost)"
+    ' _ "$REPO_ROOT"
+  )"
+
+  smoke_assert_contains "$out" "alpha=user"   "alpha defaults to user class"
+  smoke_assert_contains "$out" "beta=system"  "beta resolves system class"
+  smoke_assert_contains "$out" "missing=user" "unknown agent defaults to user"
+}
+
+# ---------------------------------------------------------------------------
+# Step 2 — unknown class value is rejected at roster load.
+# ---------------------------------------------------------------------------
+unknown_class_rejected() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "gamma"
+BRIDGE_AGENT_ENGINE["gamma"]="claude"
+BRIDGE_AGENT_SESSION["gamma"]="gamma"
+BRIDGE_AGENT_WORKDIR["gamma"]="$BRIDGE_AGENT_HOME_ROOT/gamma"
+BRIDGE_AGENT_CLASS["gamma"]="admin"
+EOF
+
+  local rc=0
+  local out
+  out="$(
+    "$BASH4_BIN" -c 'repo="$1"; source "$repo/bridge-lib.sh"; bridge_load_roster' \
+      _ "$REPO_ROOT" 2>&1
+  )" || rc=$?
+
+  if (( rc == 0 )); then
+    smoke_fail "unknown class 'admin' should have been rejected at roster load"
+  fi
+  smoke_assert_contains "$out" "unknown agent class 'admin'" "unknown class error message"
+  smoke_assert_contains "$out" "gamma" "error names the offending agent"
+}
+
+# ---------------------------------------------------------------------------
+# Step 3 — tool-policy.py gate scenarios.
+#
+# We set up two static agents (alpha/user, beta/system) and replay the
+# four canonical Pretool payloads through hooks/tool-policy.py. Each
+# invocation runs under a BRIDGE_AGENT_ID + BRIDGE_AGENT_CLASS_FOR_HOOK
+# env that mirrors the prod export shape from bridge-run.sh. The hook
+# emits a one-line JSON deny payload on block; an empty stdout means the
+# tool call was allowed.
+# ---------------------------------------------------------------------------
+
+# Reset roster maps for the gate scenarios — drop the lingering "admin"
+# entry from the rejection test before we re-seed the alpha/beta pair.
+reset_roster_for_gate() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "alpha"
+BRIDGE_AGENT_ENGINE["alpha"]="claude"
+BRIDGE_AGENT_SESSION["alpha"]="alpha"
+BRIDGE_AGENT_WORKDIR["alpha"]="$BRIDGE_AGENT_HOME_ROOT/alpha"
+
+bridge_add_agent_id_if_missing "beta"
+BRIDGE_AGENT_ENGINE["beta"]="claude"
+BRIDGE_AGENT_SESSION["beta"]="beta"
+BRIDGE_AGENT_WORKDIR["beta"]="$BRIDGE_AGENT_HOME_ROOT/beta"
+BRIDGE_AGENT_CLASS["beta"]="system"
+EOF
+
+  # Materialize the agent home dirs so other_agent_homes() (which uses
+  # `iterdir()` on $BRIDGE_HOME/agents) sees both peers.
+  mkdir -p \
+    "$BRIDGE_AGENT_HOME_ROOT/alpha/memory/projects" \
+    "$BRIDGE_AGENT_HOME_ROOT/alpha/state" \
+    "$BRIDGE_AGENT_HOME_ROOT/beta/memory/projects"
+  : >"$BRIDGE_AGENT_HOME_ROOT/alpha/memory/projects/foo.md"
+  : >"$BRIDGE_AGENT_HOME_ROOT/alpha/state/foo.db"
+}
+
+# Run hooks/tool-policy.py once with the supplied actor class + tool
+# payload. Echoes the hook's stdout (empty string when the call was
+# allowed; a JSON deny payload when blocked).
+run_policy_hook() {
+  local actor="$1"
+  local actor_class="$2"
+  local tool_name="$3"
+  local file_path="$4"
+
+  local payload
+  payload="$(
+    "$PY_BIN" - "$tool_name" "$file_path" <<'PY'
+import json
+import sys
+
+tool_name, file_path = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "hook_event_name": "PreToolUse",
+    "tool_name": tool_name,
+    "tool_input": {"file_path": file_path},
+    "tool_use_id": "smoke-539",
+    "session_id": "smoke-session",
+}))
+PY
+  )"
+
+  BRIDGE_AGENT_ID="$actor" \
+  BRIDGE_AGENT_CLASS_FOR_HOOK="$actor_class" \
+  BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+  BRIDGE_AGENT_HOME_ROOT="$BRIDGE_AGENT_HOME_ROOT" \
+  BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+    "$PY_BIN" "$REPO_ROOT/hooks/tool-policy.py" <<<"$payload"
+}
+
+assert_policy_allowed() {
+  local context="$1"
+  local out="$2"
+  if [[ -n "${out//[[:space:]]/}" ]]; then
+    smoke_fail "$context: expected ALLOW (empty stdout) but got: $out"
+  fi
+}
+
+assert_policy_denied() {
+  local context="$1"
+  local out="$2"
+  if [[ -z "${out//[[:space:]]/}" ]]; then
+    smoke_fail "$context: expected DENY (deny payload on stdout) but got empty"
+  fi
+  if [[ "$out" != *"\"permissionDecision\": \"deny\""* ]]; then
+    smoke_fail "$context: expected deny permissionDecision; got: $out"
+  fi
+  if [[ "$out" != *"cross-agent access is blocked"* ]]; then
+    smoke_fail "$context: expected cross-agent block reason; got: $out"
+  fi
+}
+
+count_audit_events() {
+  local action="$1"
+  if [[ ! -f "$BRIDGE_AUDIT_LOG" ]]; then
+    printf '0'
+    return 0
+  fi
+  "$PY_BIN" - "$BRIDGE_AUDIT_LOG" "$action" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path, action = Path(sys.argv[1]), sys.argv[2]
+n = 0
+for line in path.read_text(encoding="utf-8").splitlines():
+    if not line.strip():
+        continue
+    try:
+        row = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if row.get("action") == action:
+        n += 1
+print(n)
+PY
+}
+
+tool_policy_gate_scenarios() {
+  reset_roster_for_gate
+
+  # Truncate the audit log so we can count system_cross_agent_read
+  # events from this scenario alone.
+  : >"$BRIDGE_AUDIT_LOG"
+
+  local out
+
+  # Scenario A — beta (system) Read of alpha's memory/projects/foo.md → ALLOW.
+  out="$(run_policy_hook "beta" "system" "Read" "$BRIDGE_AGENT_HOME_ROOT/alpha/memory/projects/foo.md")"
+  assert_policy_allowed "beta system Read of alpha memory/projects/foo.md" "$out"
+
+  # Scenario B — beta (system) Read of alpha's state/foo.db → DENY.
+  out="$(run_policy_hook "beta" "system" "Read" "$BRIDGE_AGENT_HOME_ROOT/alpha/state/foo.db")"
+  assert_policy_denied "beta system Read of forbidden alpha state/foo.db" "$out"
+
+  # Scenario C — beta (system) Write to alpha's memory/projects/foo.md → DENY.
+  # Even though the path is in the system-class read allowlist, Write is
+  # not read-intent, so the carve-out must not fire.
+  out="$(run_policy_hook "beta" "system" "Write" "$BRIDGE_AGENT_HOME_ROOT/alpha/memory/projects/foo.md")"
+  assert_policy_denied "beta system Write to alpha memory/projects/foo.md" "$out"
+
+  # Scenario D — alpha (default user) Read of beta's memory/projects/foo.md → DENY.
+  : >"$BRIDGE_AGENT_HOME_ROOT/beta/memory/projects/foo.md"
+  out="$(run_policy_hook "alpha" "user" "Read" "$BRIDGE_AGENT_HOME_ROOT/beta/memory/projects/foo.md")"
+  assert_policy_denied "alpha user Read of beta memory/projects/foo.md" "$out"
+
+  # Audit ledger — only Scenario A should have emitted the
+  # system_cross_agent_read event.
+  local count
+  count="$(count_audit_events "system_cross_agent_read")"
+  smoke_assert_eq "1" "$count" "system_cross_agent_read audit event count"
+}
+
+main() {
+  smoke_require_cmd "$PY_BIN"
+  smoke_run "class getter roundtrip" class_getter_roundtrip
+  smoke_run "unknown class rejected at roster load" unknown_class_rejected
+  smoke_run "tool-policy.py gate scenarios (#539)" tool_policy_gate_scenarios
+  smoke_log "passed"
+}
+
+main "$@"

--- a/scripts/smoke/system-agent-class.sh
+++ b/scripts/smoke/system-agent-class.sh
@@ -134,6 +134,18 @@ EOF
     "$BRIDGE_AGENT_HOME_ROOT/beta/memory/projects"
   : >"$BRIDGE_AGENT_HOME_ROOT/alpha/memory/projects/foo.md"
   : >"$BRIDGE_AGENT_HOME_ROOT/alpha/state/foo.db"
+
+  # Issue #539 r2: shared/* fixtures so the new shared-path sub-tests
+  # have a real on-disk target. The hook resolves shared paths via
+  # `bridge_home_dir() / "shared"` and runs them through Path.resolve(),
+  # which requires the file to exist for the prefix comparison to work.
+  mkdir -p \
+    "$BRIDGE_HOME/shared/wiki" \
+    "$BRIDGE_HOME/shared/private" \
+    "$BRIDGE_HOME/shared/secrets"
+  : >"$BRIDGE_HOME/shared/wiki/foo.md"
+  : >"$BRIDGE_HOME/shared/private/secret.md"
+  : >"$BRIDGE_HOME/shared/secrets/key.txt"
 }
 
 # Run hooks/tool-policy.py once with the supplied actor class + tool
@@ -247,11 +259,33 @@ tool_policy_gate_scenarios() {
   out="$(run_policy_hook "alpha" "user" "Read" "$BRIDGE_AGENT_HOME_ROOT/beta/memory/projects/foo.md")"
   assert_policy_denied "alpha user Read of beta memory/projects/foo.md" "$out"
 
-  # Audit ledger — only Scenario A should have emitted the
-  # system_cross_agent_read event.
+  # Issue #539 r2 — shared/* sub-tests. Codex r2 caught that shared/*
+  # paths bypassed both the system-class allowlist and the audit row
+  # because they sat inside the `if target:` peer-agent block (which
+  # only fires when target_agent_for_path() resolves the path to a
+  # peer home — shared/* never does). The fix lifts shared/* eval
+  # above the peer-agent block.
+
+  # Scenario E — beta (system) Read of shared/wiki/foo.md → ALLOW + audit.
+  out="$(run_policy_hook "beta" "system" "Read" "$BRIDGE_HOME/shared/wiki/foo.md")"
+  assert_policy_allowed "beta system Read of shared/wiki/foo.md" "$out"
+
+  # Scenario F — beta (system) Read of shared/private/secret.md → DENY.
+  out="$(run_policy_hook "beta" "system" "Read" "$BRIDGE_HOME/shared/private/secret.md")"
+  assert_policy_denied "beta system Read of shared/private/secret.md" "$out"
+
+  # Scenario G — beta (system) Read of shared/secrets/key.txt → DENY.
+  out="$(run_policy_hook "beta" "system" "Read" "$BRIDGE_HOME/shared/secrets/key.txt")"
+  assert_policy_denied "beta system Read of shared/secrets/key.txt" "$out"
+
+  # Audit ledger — Scenario A (peer-agent ALLOW) and Scenario E
+  # (shared/* ALLOW) should both have emitted system_cross_agent_read.
+  # The two DENY scenarios for shared/private and shared/secrets do
+  # not emit this row (they emit agent_tool_denied via the standard
+  # block path).
   local count
   count="$(count_audit_events "system_cross_agent_read")"
-  smoke_assert_eq "1" "$count" "system_cross_agent_read audit event count"
+  smoke_assert_eq "2" "$count" "system_cross_agent_read audit event count"
 }
 
 main() {


### PR DESCRIPTION
## Summary
- New first-class agent `class=` field in roster (default `user`, opt-in `system`). Validated against the closed `{user, system}` set; unknown class is a hard error at roster load (`bridge_validate_agent_classes`).
- `system` class opens read-only cross-agent access to `agents/<other>/memory/{projects,decisions,shared}/` and `shared/*` (excluding `shared/private/`, `shared/secrets/`). Bash/Edit/Write outside own home stay denied even for `system` (the carve-out is gated on read-intent so write tools never reach it).
- Every cross-agent read by a `system`-class agent emits `system_cross_agent_read` to `audit.jsonl` (existing audit sink).
- Public roster ships zero default `class=system` agents — operators opt in locally for librarian / patch / similar ingestion roles by setting `BRIDGE_AGENT_CLASS["<agent>"]="system"` in their own `agent-roster.local.sh`.
- New regression smoke `scripts/smoke/system-agent-class.sh` covers class roundtrip + unknown-class hard-fail + 4 gate scenarios (system allow on memory/projects, system deny on state/, system deny on Write, user deny on cross-agent Read) plus audit-event count assertion. Wired into `scripts/smoke-test.sh`.
- `ARCHITECTURE.md` adds a new "Hooks / Tool Policy" section documenting the class boundary.

## Why full class field over a hardcoded librarian/patch allowlist
The codex R2 design consult on #539 chose the full mechanism over a minimal name-based allowlist: name-based hardcoded allowlists scatter across call sites and don't compose; a roster class field is policy-driven, auditable in one place, and makes the privilege model legible to future maintainers. The class is also the cleanest place to grow future privilege boundaries should they be needed.

## Out of scope (deferred per codex R2 consult)
- No `admin` class (system + admin split rejected; `system` alone is sufficient for the librarian/patch use case).
- No librarian / patch agent definitions in this PR — they're local-install constructs that operators add to `agent-roster.local.sh`.
- No extension of cross-agent Bash/Edit/Write for `system` class — read-only by design.
- No VERSION/CHANGELOG bump.

## Implementation notes
- The bash `BRIDGE_AGENT_CLASS` associative array would collide with a scalar export of the same name, so the calling agent's class is exported to hook subprocesses as `BRIDGE_AGENT_CLASS_FOR_HOOK`. `current_agent_class()` in `hooks/bridge_hook_common.py` reads it and normalizes unknown values to `"user"` (defense-in-depth — the bash loader already hard-fails on unknown values).
- The Read carve-out in `protected_path_reason` is gated on `read_intent and current_agent_class() == "system"`. The existing per-tool `_is_read_intent_tool()` classifier (`Read`/`Glob`/`Grep`/`NotebookRead` are read-intent; `Edit`/`Write`/`MultiEdit` are not) means write tools never reach the carve-out, even when their `file_path` falls inside the system-class allowlist.

## Test plan
- [x] `bash -n` + `shellcheck` + `python3 -c ast.parse` on touched files.
- [x] `bridge_agent_class` returns correct value for user/system/missing/empty.
- [x] `bash scripts/smoke/system-agent-class.sh` PASS — 3 steps: class getter roundtrip, unknown-class hard-fail at roster load, tool-policy gate scenarios (4 sub-scenarios + audit event count).
- [x] `./scripts/smoke-test.sh` — pre-existing dynamic-agent / mcp-restart failures reproduce on `main` HEAD without these edits (orchestrator-confirmed).
- [ ] Maintainer: live install — set `BRIDGE_AGENT_CLASS["<agent>"]="system"` on a test agent, attempt cross-agent Read of `agents/other/memory/projects/foo.md` (expect ALLOW + `system_cross_agent_read` row in `audit.jsonl`), then attempt of `agents/other/state/foo.db` (expect DENY).

Refs #539
