### PR TITLE
feat(isolated-settings): render bridge hooks into per-isolated-home settings.effective.json (refs #544 PR2, supersedes #561)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -459,13 +459,36 @@ isolated UID and from the per-home `~/.agent-bridge` symlink, so they
 work even on installs where that symlink is missing or the operator-home
 parent path differs from `BRIDGE_HOME`.
 
-Operators on existing installs pick this up by re-running:
+### Bridge hooks under the isolated HOME (settings.json rendering)
+
+Claude Code under the isolated UID reads `~/.claude/settings.json` from
+the isolated UID's HOME, not from the workdir — so the workdir-side
+shared-settings symlink installed for non-isolated agents is invisible
+there. The bridge installs hook entries (Stop, UserPromptSubmit,
+SessionStart, PermissionDenied, PreToolUse/PostToolUse) into the
+isolated HOME by rendering a controller-owned
+`<isolated-home>/.claude/settings.effective.json` and pointing
+`<isolated-home>/.claude/settings.json` at it via a symlink.
+
+Integrity contract: the effective file is owned by `root:root` mode
+`0644`; the symlink is owned by the isolated UID but the underlying
+target is not. The isolated UID can read the hook contract but cannot
+mutate it from inside its own session. Pre-existing user keys
+(`enabledPlugins`, `extraKnownMarketplaces`,
+`skipDangerousModePermissionPrompt`) from any prior regular
+`settings.json` are preserved across the transition.
+
+The render runs on agent isolate, restart,
+`agent-bridge isolate <agent> --reapply`, and `agb agent
+rerender-settings --apply`. Operators on existing installs pick up the
+synced skills and hook entries by re-running:
 
 ```bash
 agent-bridge isolate <agent> --reapply
 ```
 
-then restarting the agent so the next session loads the synced skills.
+then restarting the agent so the next session loads the synced skills
+and reads the rendered settings.
 
 ## Migrating to layout v2
 

--- a/agents/.claude/settings.json
+++ b/agents/.claude/settings.json
@@ -75,6 +75,41 @@
           }
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 ~/.agent-bridge/hooks/pre-compact.py",
+            "timeout": 20
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 ~/.agent-bridge/hooks/tool-policy.py",
+            "timeout": 5,
+            "additionalContext": true
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/python3 ~/.agent-bridge/hooks/tool-policy.py",
+            "timeout": 5,
+            "additionalContext": true
+          }
+        ]
+      }
     ]
   }
 }

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1657,6 +1657,17 @@ run_rerender_settings() {
         after_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir")"
         bridge_audit_log "$(bridge_admin_agent_id 2>/dev/null || printf bridge-upgrade)" "shared_settings_rerendered" "$agent" \
           --detail workdir="$workdir" >/dev/null 2>&1 || true
+        # Issue #544 PR2 — also render the per-isolated-home
+        # `<isolated-home>/.claude/settings.effective.json` + symlink so
+        # isolated agents pick up the bridge hook entries on rerender.
+        # No-op for non-isolated agents and on non-Linux hosts.
+        # Best-effort: a failure here is logged via bridge_warn inside
+        # the helper and does not flip this row to error — the workdir
+        # shared rerender (above) already succeeded.
+        if [[ "$agent" != "_template" ]] \
+            && command -v bridge_install_isolated_home_settings >/dev/null 2>&1; then
+          bridge_install_isolated_home_settings "$agent" "$target_launch_cmd" >/dev/null 2>&1 || true
+        fi
       else
         error="$apply_output"
         after_json="$before_json"

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -851,6 +851,123 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
     return 0
 
 
+# Issue #544 PR2 — render bridge-managed Claude hook entries into a
+# controller-owned `<isolated-home>/.claude/settings.effective.json` and
+# atomically symlink `<isolated-home>/.claude/settings.json` to it. Chosen
+# over a cross-UID symlink to the controller's effective file: a symlink
+# would let the isolated UID silently rewrite the file (and clobber hook
+# enforcement) on any operator action that touches `~/.claude/settings.json`
+# from inside the session. Per-home rendering keeps the hook contract
+# inside controller/root ownership while still letting the isolated UID
+# read it. Hooks themselves run as the isolated UID — that is intended.
+#
+# Pre-existing isolated-UID user keys (`enabledPlugins`,
+# `extraKnownMarketplaces`, `skipDangerousModePermissionPrompt`) are
+# extracted from any prior regular `settings.json` at that path and merged
+# into the rendered effective file so first-run user state survives the
+# transition to symlink-managed.
+ISOLATED_HOME_PRESERVED_USER_KEYS = (
+    "enabledPlugins",
+    "extraKnownMarketplaces",
+    "skipDangerousModePermissionPrompt",
+)
+
+
+def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
+    isolated_home = Path(args.isolated_home).expanduser()
+    base_path = Path(args.base_settings_file).expanduser()
+    overlay_path = Path(args.overlay_settings_file).expanduser()
+    launch_cmd = (getattr(args, "launch_cmd", "") or "") or None
+
+    target_dir = isolated_home / ".claude"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    effective_path = target_dir / "settings.effective.json"
+    settings_link = target_dir / "settings.json"
+
+    # 1. Preserve user keys. Source-of-truth selection:
+    #   - If `settings.json` is a regular (non-symlink) file, read from
+    #     it directly — that is the operator's first-run state pre-
+    #     transition, and we must capture the keys before we replace
+    #     the file with a symlink to the effective render.
+    #   - If `settings.json` is a symlink (i.e. a prior render already
+    #     ran), read the preserved keys back out of the existing
+    #     `settings.effective.json`. Without this, the second render
+    #     would silently drop the keys we preserved on the first pass,
+    #     breaking idempotency and erasing the operator's user state
+    #     on every subsequent rerender (e.g. agent restart).
+    preserved: dict[str, Any] = {}
+    preserve_source: Path | None = None
+    if settings_link.exists() and not settings_link.is_symlink():
+        preserve_source = settings_link
+    elif settings_link.is_symlink() and effective_path.exists():
+        preserve_source = effective_path
+    if preserve_source is not None:
+        try:
+            existing = load_json(preserve_source)
+        except (OSError, json.JSONDecodeError):
+            existing = {}
+        if isinstance(existing, dict):
+            for key in ISOLATED_HOME_PRESERVED_USER_KEYS:
+                if key in existing:
+                    preserved[key] = existing[key]
+
+    # 2. Compose: managed defaults < base < overlay < preserved user keys.
+    base_payload = ensure_settings_root(base_path)
+    # `load_json` raises on empty file; treat zero-byte as `{}` so the
+    # renderer matches the operator-touch idiom (an empty overlay file
+    # is a valid "no overrides" signal).
+    if overlay_path.exists() and overlay_path.stat().st_size == 0:
+        overlay_payload: Any = {}
+    else:
+        overlay_payload = load_json(overlay_path)
+    if overlay_payload in (None, ""):
+        overlay_payload = {}
+    if not isinstance(overlay_payload, dict):
+        raise SystemExit(f"isolated overlay must be a JSON object: {overlay_path}")
+
+    managed_defaults = managed_claude_settings_defaults(launch_cmd)
+    merged = merge_settings(managed_defaults, base_payload)
+    merged = merge_settings(merged, overlay_payload)
+    if preserved:
+        merged = merge_settings(merged, preserved)
+
+    # 3. Atomic write of the effective file (mode 0644 so the isolated UID
+    # can read it; ownership stays with whoever invoked us — controller
+    # under the normal start path, root under sudo-backed reapply).
+    effective_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = effective_path.with_suffix(effective_path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(merged, handle, ensure_ascii=False, indent=2)
+        handle.write("\n")
+    os.chmod(tmp, 0o644)
+    os.replace(tmp, effective_path)
+
+    # 4. Atomic symlink: settings.json -> settings.effective.json. Replace
+    # any prior regular file (we already preserved its user keys above) or
+    # stale symlink. Use a relative target so the link survives if the
+    # isolated home moves under it.
+    if settings_link.is_symlink() or settings_link.exists():
+        settings_link.unlink()
+    settings_link.symlink_to("settings.effective.json")
+
+    payload = {
+        "isolated_home": str(isolated_home),
+        "effective_settings_file": str(effective_path),
+        "settings_file": str(settings_link),
+        "preserved_keys": ",".join(sorted(preserved.keys())),
+    }
+    if args.format == "shell":
+        for key, value in payload.items():
+            print(shell_line(key.upper(), value))
+        return 0
+
+    print(f"isolated_home: {payload['isolated_home']}")
+    print(f"effective_settings_file: {payload['effective_settings_file']}")
+    print(f"settings_file: {payload['settings_file']} -> settings.effective.json")
+    print(f"preserved_keys: [{payload['preserved_keys']}]")
+    return 0
+
+
 def cmd_link_shared_settings(args: argparse.Namespace) -> int:
     settings_path = Path(args.workdir).expanduser() / ".claude" / "settings.json"
     shared_path = Path(args.shared_settings_file).expanduser()
@@ -1097,6 +1214,23 @@ def build_parser() -> argparse.ArgumentParser:
     )
     render_shared_parser.add_argument("--format", choices=("text", "shell"), default="text")
     render_shared_parser.set_defaults(handler=cmd_render_shared_settings)
+
+    # Issue #544 PR2 — render the bridge-managed hook entries into a
+    # controller-owned settings.effective.json placed under the isolated
+    # UID's HOME, then symlink that home's settings.json to it. See
+    # cmd_render_isolated_home_settings for the integrity-boundary
+    # rationale (per-home rendered, not cross-UID symlink to controller).
+    render_isolated_parser = subparsers.add_parser("render-isolated-home-settings")
+    render_isolated_parser.add_argument("--isolated-home", required=True)
+    render_isolated_parser.add_argument("--base-settings-file", required=True)
+    render_isolated_parser.add_argument("--overlay-settings-file", required=True)
+    render_isolated_parser.add_argument(
+        "--launch-cmd",
+        default="",
+        help="Agent launch_cmd; substring '[1m]' raises autoCompactWindow default to 1_000_000 (issue #547).",
+    )
+    render_isolated_parser.add_argument("--format", choices=("text", "shell"), default="text")
+    render_isolated_parser.set_defaults(handler=cmd_render_isolated_home_settings)
 
     trust_parser = subparsers.add_parser("ensure-project-trust")
     trust_parser.add_argument("--workdir", required=True)

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -295,6 +295,8 @@ bridge_install_isolated_home_settings() {
   local target_dir=""
   local target_effective=""
   local target_settings=""
+  local target_effective_tmp=""
+  local target_settings_tmp=""
   local stage_root=""
   local stage_home=""
   local stage_dir=""
@@ -317,18 +319,33 @@ bridge_install_isolated_home_settings() {
   target_dir="$isolated_home/.claude"
   target_effective="$target_dir/settings.effective.json"
   target_settings="$target_dir/settings.json"
+  # Same-directory tmp siblings keep the rename atomic on POSIX (rename(2)
+  # within one filesystem). Use a stable suffix per process so concurrent
+  # rerenders cannot collide on the same staging name (PID is unique
+  # within a host at any instant).
+  target_effective_tmp="${target_effective}.tmp.$$"
+  target_settings_tmp="${target_settings}.tmp.$$"
 
-  # Ensure the `.claude/` directory exists in the isolated home with
-  # isolated-UID ownership. Mirrors the convention every other isolated-
-  # home mutation in lib/bridge-agents.sh uses (sudo-backed mkdir +
-  # chown). Best-effort: if sudo is unavailable, the install below will
-  # surface the failure via bridge_warn.
+  # Integrity boundary: keep `.claude/` under controller/root ownership so
+  # the isolated UID cannot unlink-or-replace the root-owned settings
+  # files inside it. The dir owner (root) keeps full rwx; the isolated
+  # UID gets group r-x via group=os_user + mode 0750. The hook commands
+  # themselves still execute under the isolated UID — Claude Code reads
+  # `<isolated-home>/.claude/settings.json` and exec()s the listed
+  # commands; we only need *read* on the dir + the file, not write.
+  #
+  # Codex r1 needs-more on PR #561: previously this dir was chowned to
+  # the isolated UID, so even though the inner files were root-owned,
+  # the isolated UID could rm/replace them via the parent's write bit.
+  # Switching the parent to root-owned + 0750 closes that gap. The
+  # isolated UID can still create files at `<isolated-home>/foo` (its
+  # own home), just not under `.claude/`.
   bridge_linux_sudo_root mkdir -p "$target_dir" 2>/dev/null || {
     bridge_warn "isolated home settings install: cannot mkdir $target_dir for $agent (sudo unavailable?)"
     return 0
   }
-  bridge_linux_sudo_root chown "$os_user:$os_user" "$target_dir" 2>/dev/null || true
-  bridge_linux_sudo_root chmod 0755 "$target_dir" 2>/dev/null || true
+  bridge_linux_sudo_root chown "root:$os_user" "$target_dir" 2>/dev/null || true
+  bridge_linux_sudo_root chmod 0750 "$target_dir" 2>/dev/null || true
 
   # Stage the render in a controller-owned temp directory. The renderer
   # walks `<stage_home>/.claude/`, which mirrors the layout it expects
@@ -344,13 +361,28 @@ bridge_install_isolated_home_settings() {
   stage_effective="$stage_dir/settings.effective.json"
   mkdir -p "$stage_dir"
 
-  # Seed the stage with the live isolated `settings.json` so the
-  # renderer's preserve-user-keys branch sees it. We need to read it via
-  # sudo because the live file is owned by the isolated UID with mode
-  # 0700 on the parent. cat-fail is fine: the renderer treats a missing
-  # source as "no preserved keys".
-  if bridge_linux_sudo_root test -f "$target_settings" 2>/dev/null \
-      && ! bridge_linux_sudo_root test -L "$target_settings" 2>/dev/null; then
+  # Seed the stage with the live isolated user state so the renderer's
+  # preserve-user-keys branch sees it on every run, including re-runs
+  # where `settings.json` is already a symlink to `settings.effective.json`.
+  #
+  # Codex r1 needs-more on PR #561: the previous code only staged when
+  # `settings.json` was a regular file. After the first install made it
+  # a symlink, the second run re-rendered with no preserved keys and
+  # silently dropped `enabledPlugins`, `extraKnownMarketplaces`, and
+  # `skipDangerousModePermissionPrompt`. Now we dereference: when
+  # `settings.json` is a symlink, copy the live effective file into the
+  # stage as `settings.effective.json` (which is the path the renderer's
+  # symlink branch reads from). When it is a regular file, copy it to
+  # `settings.json` (the renderer's non-symlink branch). cat-fail is
+  # fine: the renderer treats a missing source as "no preserved keys".
+  if bridge_linux_sudo_root test -L "$target_settings" 2>/dev/null; then
+    # Symlink — touch a symlink under stage so the renderer takes the
+    # symlink branch, then seed the stage effective from the live one.
+    ln -s "settings.effective.json" "$stage_settings" 2>/dev/null || true
+    if bridge_linux_sudo_root test -f "$target_effective" 2>/dev/null; then
+      bridge_linux_sudo_root cat "$target_effective" >"$stage_effective" 2>/dev/null || true
+    fi
+  elif bridge_linux_sudo_root test -f "$target_settings" 2>/dev/null; then
     bridge_linux_sudo_root cat "$target_settings" >"$stage_settings" 2>/dev/null || true
   fi
 
@@ -364,32 +396,51 @@ bridge_install_isolated_home_settings() {
     return 0
   fi
 
-  # Install the staged effective file into the isolated tree with root
-  # ownership and mode 0644. The isolated UID can read but cannot
-  # mutate it (the integrity boundary). `install -m` is atomic on the
-  # destination filesystem.
-  if ! bridge_linux_sudo_root install -m 0644 -o root -g root "$stage_effective" "$target_effective" 2>/dev/null; then
-    # Older `install` builds reject `-o`/`-g` without root euid even
-    # under sudo on some hosts; fall back to install + chown.
-    if bridge_linux_sudo_root install -m 0644 "$stage_effective" "$target_effective" 2>/dev/null; then
-      bridge_linux_sudo_root chown root:root "$target_effective" 2>/dev/null || true
+  # Atomic install of the effective file. Stage to a same-directory
+  # `.tmp.$$` sibling first, then `mv -f` over the final path. POSIX
+  # rename(2) within one filesystem is atomic, so any concurrent reader
+  # never observes a partial write or a moment where the file is
+  # missing. Mirrors PR #559 PR3 (lib/bridge-skills.sh atomic install).
+  #
+  # The `install -m 0644 -o root -g root` form chowns at the same time;
+  # older `install` builds reject `-o`/`-g` even under sudo, so we fall
+  # back to plain install + chown. On either failure path, clear the
+  # tmp sibling so the isolated tree never carries a stale `.tmp.$$`.
+  if ! bridge_linux_sudo_root install -m 0644 -o root -g root "$stage_effective" "$target_effective_tmp" 2>/dev/null; then
+    if bridge_linux_sudo_root install -m 0644 "$stage_effective" "$target_effective_tmp" 2>/dev/null; then
+      bridge_linux_sudo_root chown root:root "$target_effective_tmp" 2>/dev/null || true
     else
       bridge_warn "isolated home settings install: install failed for $target_effective"
+      bridge_linux_sudo_root rm -f "$target_effective_tmp" 2>/dev/null || true
       rm -rf "$stage_root"
       return 0
     fi
   fi
-
-  # Atomically swap settings.json to a relative symlink pointing at the
-  # effective file. `ln -sfn` is the established pattern for replacing
-  # a symlink in place; for a regular pre-existing file we have to
-  # remove it first because `ln -sf` would refuse with "File exists".
-  if bridge_linux_sudo_root test -e "$target_settings" 2>/dev/null \
-      && ! bridge_linux_sudo_root test -L "$target_settings" 2>/dev/null; then
-    bridge_linux_sudo_root rm -f "$target_settings" 2>/dev/null || true
+  if ! bridge_linux_sudo_root mv -f "$target_effective_tmp" "$target_effective" 2>/dev/null; then
+    bridge_warn "isolated home settings install: atomic mv failed for $target_effective"
+    bridge_linux_sudo_root rm -f "$target_effective_tmp" 2>/dev/null || true
+    rm -rf "$stage_root"
+    return 0
   fi
-  bridge_linux_sudo_root ln -sfn "settings.effective.json" "$target_settings" 2>/dev/null || \
-    bridge_warn "isolated home settings install: symlink failed for $target_settings"
+
+  # Atomic swap of the symlink. Create a tmp symlink in the same
+  # directory, then `mv -f` over `settings.json`. Unlike `ln -sfn`
+  # (which momentarily uses unlink+symlink), the rename-over path keeps
+  # `settings.json` continuously resolvable for any concurrent reader.
+  # If the prior `settings.json` was a regular file, the rename
+  # replaces it in one step too — no separate `rm` required.
+  bridge_linux_sudo_root ln -s "settings.effective.json" "$target_settings_tmp" 2>/dev/null || {
+    bridge_warn "isolated home settings install: symlink staging failed for $target_settings"
+    bridge_linux_sudo_root rm -f "$target_settings_tmp" 2>/dev/null || true
+    rm -rf "$stage_root"
+    return 0
+  }
+  if ! bridge_linux_sudo_root mv -f "$target_settings_tmp" "$target_settings" 2>/dev/null; then
+    bridge_warn "isolated home settings install: atomic symlink swap failed for $target_settings"
+    bridge_linux_sudo_root rm -f "$target_settings_tmp" 2>/dev/null || true
+    rm -rf "$stage_root"
+    return 0
+  fi
   bridge_linux_sudo_root chown -h "$os_user:$os_user" "$target_settings" 2>/dev/null || true
 
   rm -rf "$stage_root"

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -263,6 +263,138 @@ bridge_ensure_claude_pre_compact_hook() {
   fi
 }
 
+# Issue #544 PR2 — install bridge-managed Claude hook entries into the
+# isolated UID's HOME `.claude/settings.json` (as a controller-owned
+# symlink to a controller-owned `settings.effective.json` rendered next
+# to it). No-op for non-isolated agents and on non-Linux hosts. Best-
+# effort throughout: failures here must not block agent start, since
+# the workdir-side shared settings (the path used by non-isolated
+# agents) is independent and already wired by the caller.
+#
+# Why per-home rendered, not cross-UID symlink to controller:
+# `<isolated-home>/.claude/settings.json` lives under the isolated UID
+# and Claude Code rewrites it on first-run trust + on operator
+# `claude config` actions. A symlink across UIDs would let those
+# rewrites silently mutate the controller's hook contract. Rendering a
+# fresh controller-owned file per isolated home keeps the integrity
+# boundary intact while still letting the isolated UID read the file
+# (mode 0644) and run the hook commands themselves under its own UID.
+#
+# Implementation: render to a controller-owned temp directory (the
+# isolated home's `.claude/` is mode 0700 under the isolated UID, so
+# the controller cannot write there directly), then sudo-install both
+# files into the isolated tree under root ownership. Pre-existing user
+# keys are preserved by the Python renderer reading the existing
+# `<isolated-home>/.claude/settings.json` via a sudo-backed cat into
+# the temp staging area first.
+bridge_install_isolated_home_settings() {
+  local agent="$1"
+  local launch_cmd="${2-}"
+  local os_user=""
+  local isolated_home=""
+  local target_dir=""
+  local target_effective=""
+  local target_settings=""
+  local stage_root=""
+  local stage_home=""
+  local stage_dir=""
+  local stage_settings=""
+  local stage_effective=""
+
+  [[ -n "$agent" ]] || return 0
+
+  # Predicate is fatal-on-zero for non-isolated agents and non-Linux
+  # hosts; suppress so this function remains a silent no-op when the
+  # caller (run_rerender_settings, the start path, etc.) invokes it
+  # unconditionally for every agent.
+  bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null || return 0
+
+  os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || true)"
+  [[ -n "$os_user" ]] || return 0
+  isolated_home="$(bridge_agent_linux_user_home "$os_user" 2>/dev/null || true)"
+  [[ -n "$isolated_home" ]] || return 0
+
+  target_dir="$isolated_home/.claude"
+  target_effective="$target_dir/settings.effective.json"
+  target_settings="$target_dir/settings.json"
+
+  # Ensure the `.claude/` directory exists in the isolated home with
+  # isolated-UID ownership. Mirrors the convention every other isolated-
+  # home mutation in lib/bridge-agents.sh uses (sudo-backed mkdir +
+  # chown). Best-effort: if sudo is unavailable, the install below will
+  # surface the failure via bridge_warn.
+  bridge_linux_sudo_root mkdir -p "$target_dir" 2>/dev/null || {
+    bridge_warn "isolated home settings install: cannot mkdir $target_dir for $agent (sudo unavailable?)"
+    return 0
+  }
+  bridge_linux_sudo_root chown "$os_user:$os_user" "$target_dir" 2>/dev/null || true
+  bridge_linux_sudo_root chmod 0755 "$target_dir" 2>/dev/null || true
+
+  # Stage the render in a controller-owned temp directory. The renderer
+  # walks `<stage_home>/.claude/`, which mirrors the layout it expects
+  # under the live isolated home but lives entirely under the
+  # controller UID so the Python writes succeed without sudo.
+  stage_root="$(mktemp -d "${TMPDIR:-/tmp}/bridge-isolated-settings.XXXXXX")" || {
+    bridge_warn "isolated home settings install: mktemp failed for $agent"
+    return 0
+  }
+  stage_home="$stage_root/home"
+  stage_dir="$stage_home/.claude"
+  stage_settings="$stage_dir/settings.json"
+  stage_effective="$stage_dir/settings.effective.json"
+  mkdir -p "$stage_dir"
+
+  # Seed the stage with the live isolated `settings.json` so the
+  # renderer's preserve-user-keys branch sees it. We need to read it via
+  # sudo because the live file is owned by the isolated UID with mode
+  # 0700 on the parent. cat-fail is fine: the renderer treats a missing
+  # source as "no preserved keys".
+  if bridge_linux_sudo_root test -f "$target_settings" 2>/dev/null \
+      && ! bridge_linux_sudo_root test -L "$target_settings" 2>/dev/null; then
+    bridge_linux_sudo_root cat "$target_settings" >"$stage_settings" 2>/dev/null || true
+  fi
+
+  if ! bridge_hooks_python render-isolated-home-settings \
+        --isolated-home "$stage_home" \
+        --base-settings-file "$(bridge_hook_shared_settings_base_file)" \
+        --overlay-settings-file "$(bridge_hook_shared_settings_overlay_file)" \
+        --launch-cmd "$launch_cmd" >"$stage_root/render.out" 2>&1; then
+    bridge_warn "isolated home settings install: render failed for $agent ($(head -n1 "$stage_root/render.out" 2>/dev/null || true))"
+    rm -rf "$stage_root"
+    return 0
+  fi
+
+  # Install the staged effective file into the isolated tree with root
+  # ownership and mode 0644. The isolated UID can read but cannot
+  # mutate it (the integrity boundary). `install -m` is atomic on the
+  # destination filesystem.
+  if ! bridge_linux_sudo_root install -m 0644 -o root -g root "$stage_effective" "$target_effective" 2>/dev/null; then
+    # Older `install` builds reject `-o`/`-g` without root euid even
+    # under sudo on some hosts; fall back to install + chown.
+    if bridge_linux_sudo_root install -m 0644 "$stage_effective" "$target_effective" 2>/dev/null; then
+      bridge_linux_sudo_root chown root:root "$target_effective" 2>/dev/null || true
+    else
+      bridge_warn "isolated home settings install: install failed for $target_effective"
+      rm -rf "$stage_root"
+      return 0
+    fi
+  fi
+
+  # Atomically swap settings.json to a relative symlink pointing at the
+  # effective file. `ln -sfn` is the established pattern for replacing
+  # a symlink in place; for a regular pre-existing file we have to
+  # remove it first because `ln -sf` would refuse with "File exists".
+  if bridge_linux_sudo_root test -e "$target_settings" 2>/dev/null \
+      && ! bridge_linux_sudo_root test -L "$target_settings" 2>/dev/null; then
+    bridge_linux_sudo_root rm -f "$target_settings" 2>/dev/null || true
+  fi
+  bridge_linux_sudo_root ln -sfn "settings.effective.json" "$target_settings" 2>/dev/null || \
+    bridge_warn "isolated home settings install: symlink failed for $target_settings"
+  bridge_linux_sudo_root chown -h "$os_user:$os_user" "$target_settings" 2>/dev/null || true
+
+  rm -rf "$stage_root"
+}
+
 bridge_codex_hooks_status() {
   bridge_hooks_python status-codex-hooks --codex-hooks-file "$(bridge_codex_hooks_file)"
 }

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -147,6 +147,15 @@ bridge_migration_isolate() {
       bridge_sync_isolated_home_claude_skills "$agent" \
         || bridge_warn "isolated-home skills sync returned non-zero for $agent; re-run isolate --reapply or check OPERATIONS.md isolated-agent section"
     fi
+    # Issue #544 PR2 — refresh the per-isolated-home Claude
+    # settings.json + settings.effective.json so existing isolated
+    # agents pick up the bridge hook entries on `--reapply` without an
+    # unisolate→isolate cycle. Best-effort: warn but don't bail — the
+    # ACL reapply above is the load-bearing step.
+    if command -v bridge_install_isolated_home_settings >/dev/null 2>&1; then
+      bridge_install_isolated_home_settings "$agent" \
+        || bridge_warn "isolated-home settings install returned non-zero for $agent; re-run isolate --reapply or check OPERATIONS.md isolated-agent section"
+    fi
     printf '[done] ACL reapply complete for %s\n' "$agent"
     return 0
   fi
@@ -230,6 +239,14 @@ bridge_migration_isolate() {
     if command -v bridge_sync_isolated_home_claude_skills >/dev/null 2>&1; then
       bridge_sync_isolated_home_claude_skills "$agent" \
         || bridge_warn "isolated-home skills sync returned non-zero for $agent; re-run isolate --reapply"
+    fi
+    # Issue #544 PR2 — install bridge hook entries into the freshly
+    # provisioned isolated HOME so SessionStart, UserPromptSubmit, Stop,
+    # PermissionDenied, PreToolUse/PostToolUse all fire from first
+    # session. Best-effort; failure here doesn't block migration.
+    if command -v bridge_install_isolated_home_settings >/dev/null 2>&1; then
+      bridge_install_isolated_home_settings "$agent" \
+        || bridge_warn "isolated-home settings install returned non-zero for $agent; re-run isolate --reapply"
     fi
   fi
 

--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -153,7 +153,14 @@ bridge_migration_isolate() {
     # unisolate→isolate cycle. Best-effort: warn but don't bail — the
     # ACL reapply above is the load-bearing step.
     if command -v bridge_install_isolated_home_settings >/dev/null 2>&1; then
-      bridge_install_isolated_home_settings "$agent" \
+      # Issue #547 / PR #561 r1 needs-more: forward launch_cmd so the
+      # isolated-home renderer applies the [1m] autoCompactWindow
+      # heuristic too. Without this, --reapply re-rendered with the
+      # legacy 400_000 default even for 1M-context agents. Match the
+      # call shape at run_rerender_settings (bridge-agent.sh:1655-1669).
+      local _reapply_launch_cmd=""
+      _reapply_launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || printf '')"
+      bridge_install_isolated_home_settings "$agent" "$_reapply_launch_cmd" \
         || bridge_warn "isolated-home settings install returned non-zero for $agent; re-run isolate --reapply or check OPERATIONS.md isolated-agent section"
     fi
     printf '[done] ACL reapply complete for %s\n' "$agent"
@@ -245,7 +252,10 @@ bridge_migration_isolate() {
     # PermissionDenied, PreToolUse/PostToolUse all fire from first
     # session. Best-effort; failure here doesn't block migration.
     if command -v bridge_install_isolated_home_settings >/dev/null 2>&1; then
-      bridge_install_isolated_home_settings "$agent" \
+      # Same launch_cmd forward as the --reapply branch above.
+      local _isolate_launch_cmd=""
+      _isolate_launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || printf '')"
+      bridge_install_isolated_home_settings "$agent" "$_isolate_launch_cmd" \
         || bridge_warn "isolated-home settings install returned non-zero for $agent; re-run isolate --reapply"
     fi
   fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window
 }
 
 add_all_integration() {
@@ -217,7 +217,7 @@ select_for_path() {
       ;;
 
     lib/bridge-isolation*.sh|lib/bridge-migration.sh|bridge-migrate.sh|tests/isolation*)
-      add_required isolation isolated-bin-agb isolated-skills-sync launch
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering launch
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -257,7 +257,11 @@ select_for_path() {
       ;;
 
     hooks/*|bridge-hooks.py|lib/bridge-hooks.sh)
-      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window
+      # Issue #544 PR2 — bridge-hooks.py grew the
+      # `render-isolated-home-settings` subcommand and lib/bridge-hooks.sh
+      # grew `bridge_install_isolated_home_settings`. Pull the new smoke
+      # in whenever either touches.
+      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10207,6 +10207,13 @@ log "running isolated-skills-sync smoke (issue #544 PR3)"
 log "isolated-skills-sync covers helper render/rewrite only — live sudo + ACL grants require isolate+restart on a Linux host"
 bash "$REPO_ROOT/scripts/smoke/isolated-skills-sync.sh"
 
+# Issue #544 PR2 — render bridge hook entries into isolated home
+# settings.json + symlink. Renderer-only coverage; live sudo
+# install/symlink-swap requires isolate+restart on a Linux host.
+log "running isolated-settings-rendering smoke (issue #544 PR2)"
+log "isolated-settings-rendering covers Python renderer only — live install/symlink-swap requires isolate+restart"
+bash "$REPO_ROOT/scripts/smoke/isolated-settings-rendering.sh"
+
 # Issue #539 — system agent class roundtrip + tool-policy gate scenarios.
 log "running system-agent-class smoke (issue #539)"
 bash "$REPO_ROOT/scripts/smoke/system-agent-class.sh"

--- a/scripts/smoke/isolated-settings-rendering.sh
+++ b/scripts/smoke/isolated-settings-rendering.sh
@@ -2,12 +2,13 @@
 # scripts/smoke/isolated-settings-rendering.sh — Issue #544 PR2 smoke.
 #
 # Validates the `bridge-hooks.py render-isolated-home-settings` Python
-# renderer against a stub isolated home. Exercises five sub-tests:
+# renderer against a stub isolated home. Exercises seven sub-tests:
 #
 # 1. The rendered `<isolated-home>/.claude/settings.effective.json`
-#    contains the bridge hook entries (Stop / UserPromptSubmit /
-#    SessionStart / PermissionDenied — the suite shipped in
-#    agents/.claude/settings.json after PR #550).
+#    contains the full bridge hook suite (Stop / UserPromptSubmit /
+#    SessionStart / PermissionDenied / PreCompact / PreToolUse /
+#    PostToolUse — the seven event types managed by the shared base
+#    agents/.claude/settings.json after PR #561 r2).
 # 2. `<isolated-home>/.claude/settings.json` is a symlink pointing at
 #    the relative path `settings.effective.json`.
 # 3. Pre-existing user keys (`enabledPlugins`, `extraKnownMarketplaces`,
@@ -19,6 +20,13 @@
 #    place — i.e. via the staging path the bash helper uses) propagates
 #    the new value, proving the renderer re-reads each invocation
 #    rather than caching the first preserved set.
+# 6. Symlink-aware preservation: after the first install (where
+#    settings.json becomes a symlink), a second render with no fresh
+#    regular settings.json must still preserve the user keys by
+#    dereferencing through the symlink to settings.effective.json. PR
+#    #561 r1 needs-more flagged that the previous bash helper only
+#    staged when settings.json was a regular file, silently dropping
+#    keys on every subsequent rerender.
 #
 # Coverage: Python renderer logic only. Does NOT exercise:
 #   - the bash wrapper `bridge_install_isolated_home_settings`'s sudo
@@ -107,6 +115,21 @@ assert_hook_entries_present() {
     "SessionStart event present"
   smoke_assert_contains "$content" '"PermissionDenied"' \
     "PermissionDenied event present"
+  # PR #561 r2 — the shared base now carries the full 7-hook suite.
+  # PreCompact / PreToolUse / PostToolUse were missing from the isolated
+  # render before this commit because they were absent from the shared
+  # base; the renderer composes from base, so adding them there flows
+  # straight into the isolated effective file.
+  smoke_assert_contains "$content" '"PreCompact"' \
+    "PreCompact event present"
+  smoke_assert_contains "$content" '"PreToolUse"' \
+    "PreToolUse event present"
+  smoke_assert_contains "$content" '"PostToolUse"' \
+    "PostToolUse event present"
+  smoke_assert_contains "$content" 'pre-compact.py' \
+    "PreCompact points at pre-compact.py"
+  smoke_assert_contains "$content" 'tool-policy.py' \
+    "PreToolUse/PostToolUse point at tool-policy.py"
   smoke_assert_contains "$content" 'mark-idle.sh' \
     "Stop suite includes mark-idle.sh"
   smoke_assert_contains "$content" 'surface-reply-enforce.py' \
@@ -193,6 +216,54 @@ EOF
     "boolean flip on skipDangerousModePermissionPrompt propagates"
 }
 
+assert_symlink_aware_preservation() {
+  # Regression for codex r1 needs-more on PR #561 (finding #2): after
+  # the first install, settings.json is a symlink to
+  # settings.effective.json; a second render that only sees the symlink
+  # must still preserve the original user keys by dereferencing through
+  # to the effective file. The Python renderer's `cmd_render_isolated_home_settings`
+  # symlink branch reads from `<isolated-home>/.claude/settings.effective.json`
+  # when `settings.json` is a symlink — the bash wrapper
+  # `bridge_install_isolated_home_settings` mirrors the same trick by
+  # staging the symlink + the live effective file into the renderer's
+  # input tree.
+  local stage_root="$SMOKE_TMP_ROOT/stage-symlink-preserve"
+  local stage_home="$stage_root/isolated-home"
+  mkdir -p "$stage_home/.claude"
+  # Seed an effective file that already carries preserved keys (the
+  # output of the FIRST render, mirrored manually here).
+  cat >"$stage_home/.claude/settings.effective.json" <<'EOF'
+{
+  "autoMemoryEnabled": true,
+  "autoDreamEnabled": true,
+  "enabledPlugins": ["plugin-from-prior-render"],
+  "extraKnownMarketplaces": {"prior": {"source": "github:prior/marketplace"}},
+  "skipDangerousModePermissionPrompt": true,
+  "hooks": {}
+}
+EOF
+  # Stage settings.json as a symlink to settings.effective.json — the
+  # exact post-first-install state under the live isolated home.
+  ln -s "settings.effective.json" "$stage_home/.claude/settings.json"
+
+  # Re-render. The renderer must dereference and re-emit the preserved
+  # keys; without the fix, this branch silently drops them.
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-isolated-home-settings \
+    --isolated-home "$stage_home" \
+    --base-settings-file "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.json" \
+    --overlay-settings-file "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.local.json" \
+    --launch-cmd "" >/dev/null
+
+  local content
+  content="$(cat "$stage_home/.claude/settings.effective.json")"
+  smoke_assert_contains "$content" '"plugin-from-prior-render"' \
+    "enabledPlugins survives second render through symlink dereference"
+  smoke_assert_contains "$content" 'github:prior/marketplace' \
+    "extraKnownMarketplaces survives second render through symlink dereference"
+  smoke_assert_contains "$content" '"skipDangerousModePermissionPrompt": true' \
+    "skipDangerousModePermissionPrompt survives second render through symlink dereference"
+}
+
 main() {
   build_fixture
 
@@ -206,6 +277,8 @@ main() {
     assert_idempotent
   smoke_run "user-key updates propagate via staged re-render" \
     assert_user_key_update_propagates
+  smoke_run "symlink-aware preservation across consecutive renders" \
+    assert_symlink_aware_preservation
 
   smoke_log "PASS"
 }

--- a/scripts/smoke/isolated-settings-rendering.sh
+++ b/scripts/smoke/isolated-settings-rendering.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# scripts/smoke/isolated-settings-rendering.sh — Issue #544 PR2 smoke.
+#
+# Validates the `bridge-hooks.py render-isolated-home-settings` Python
+# renderer against a stub isolated home. Exercises five sub-tests:
+#
+# 1. The rendered `<isolated-home>/.claude/settings.effective.json`
+#    contains the bridge hook entries (Stop / UserPromptSubmit /
+#    SessionStart / PermissionDenied — the suite shipped in
+#    agents/.claude/settings.json after PR #550).
+# 2. `<isolated-home>/.claude/settings.json` is a symlink pointing at
+#    the relative path `settings.effective.json`.
+# 3. Pre-existing user keys (`enabledPlugins`, `extraKnownMarketplaces`,
+#    `skipDangerousModePermissionPrompt`) from the prior regular
+#    `settings.json` are preserved into the rendered effective file.
+# 4. Re-running the renderer is idempotent — same SHA256 on the
+#    effective file across two consecutive invocations with no changes.
+# 5. Re-running with an updated user-key value (after the symlink is in
+#    place — i.e. via the staging path the bash helper uses) propagates
+#    the new value, proving the renderer re-reads each invocation
+#    rather than caching the first preserved set.
+#
+# Coverage: Python renderer logic only. Does NOT exercise:
+#   - the bash wrapper `bridge_install_isolated_home_settings`'s sudo
+#     stage→install→symlink-swap dance (requires real sudo + a real
+#     isolated UID owning the .claude/ tree on a Linux host);
+#   - the wire-in via `run_rerender_settings` and the
+#     `bridge_migration_isolate --reapply` path (covered by callers).
+# End-to-end coverage is operator-side per OPERATIONS.md (`agent-bridge
+# isolate <agent> --reapply` + agent restart).
+
+set -euo pipefail
+
+SMOKE_NAME="isolated-settings-rendering"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+build_fixture() {
+  smoke_make_temp_root "$SMOKE_NAME"
+
+  FIXTURE_BRIDGE_HOME="$SMOKE_TMP_ROOT/bridge-home"
+  FIXTURE_ISOLATED_HOME="$SMOKE_TMP_ROOT/isolated-home"
+
+  mkdir -p \
+    "$FIXTURE_BRIDGE_HOME/agents/.claude" \
+    "$FIXTURE_ISOLATED_HOME/.claude"
+
+  # Seed the shared base settings the renderer pulls in. Use a copy of
+  # the real source so the smoke catches a future regression where the
+  # base loses one of the managed hook entries.
+  cp "$SMOKE_REPO_ROOT/agents/.claude/settings.json" \
+    "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.json"
+
+  # Empty overlay — the renderer must tolerate absence + treat it as
+  # `{}`. Touch it so the path exists; the renderer's load_json returns
+  # `{}` for empty content too.
+  : >"$FIXTURE_BRIDGE_HOME/agents/.claude/settings.local.json"
+
+  # Pre-existing isolated UID settings.json with the three preserved
+  # user keys, plus an extraneous key (`unrelatedSetting`) the renderer
+  # MUST drop — only the documented allowlist is propagated.
+  cat >"$FIXTURE_ISOLATED_HOME/.claude/settings.json" <<'EOF'
+{
+  "enabledPlugins": ["foo", "bar"],
+  "extraKnownMarketplaces": {"acme": {"source": "github:acme/marketplace"}},
+  "skipDangerousModePermissionPrompt": true,
+  "unrelatedSetting": "should-not-leak-into-effective"
+}
+EOF
+
+  EFFECTIVE="$FIXTURE_ISOLATED_HOME/.claude/settings.effective.json"
+  SETTINGS_LINK="$FIXTURE_ISOLATED_HOME/.claude/settings.json"
+}
+
+invoke_renderer() {
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-isolated-home-settings \
+    --isolated-home "$FIXTURE_ISOLATED_HOME" \
+    --base-settings-file "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.json" \
+    --overlay-settings-file "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.local.json" \
+    --launch-cmd ""
+}
+
+assert_hook_entries_present() {
+  invoke_renderer >/dev/null
+
+  smoke_assert_file_exists "$EFFECTIVE" \
+    "settings.effective.json rendered into isolated home"
+
+  local content
+  content="$(cat "$EFFECTIVE")"
+  # The bridge hook commands all live under `~/.agent-bridge/hooks/`.
+  # Under the isolated UID this resolves via the per-home
+  # `~/.agent-bridge -> $BRIDGE_HOME` symlink installed by
+  # bridge_linux_install_agent_bridge_symlink. Asserting on the literal
+  # path keeps the smoke independent of the symlink-resolution side.
+  smoke_assert_contains "$content" '"Stop"' \
+    "Stop hook event present in rendered effective"
+  smoke_assert_contains "$content" '"UserPromptSubmit"' \
+    "UserPromptSubmit event present"
+  smoke_assert_contains "$content" '"SessionStart"' \
+    "SessionStart event present"
+  smoke_assert_contains "$content" '"PermissionDenied"' \
+    "PermissionDenied event present"
+  smoke_assert_contains "$content" 'mark-idle.sh' \
+    "Stop suite includes mark-idle.sh"
+  smoke_assert_contains "$content" 'surface-reply-enforce.py' \
+    "Stop suite includes surface-reply-enforce.py (PR #550)"
+  smoke_assert_contains "$content" 'session-stop.py' \
+    "Stop suite includes session-stop.py (PR #550)"
+  smoke_assert_contains "$content" 'session-start.py' \
+    "SessionStart points at session-start.py"
+  smoke_assert_contains "$content" 'prompt_timestamp.py' \
+    "UserPromptSubmit includes prompt_timestamp.py"
+  smoke_assert_contains "$content" 'permission_escalation.py' \
+    "PermissionDenied points at permission_escalation.py"
+}
+
+assert_settings_is_symlink() {
+  [[ -L "$SETTINGS_LINK" ]] || smoke_fail \
+    "settings.json must be a symlink, got regular file: $SETTINGS_LINK"
+  local target
+  target="$(readlink "$SETTINGS_LINK")"
+  smoke_assert_eq "settings.effective.json" "$target" \
+    "settings.json target relative path"
+}
+
+assert_user_keys_preserved() {
+  local content
+  content="$(cat "$EFFECTIVE")"
+  smoke_assert_contains "$content" '"enabledPlugins"' \
+    "enabledPlugins preserved into effective"
+  smoke_assert_contains "$content" '"extraKnownMarketplaces"' \
+    "extraKnownMarketplaces preserved into effective"
+  smoke_assert_contains "$content" '"skipDangerousModePermissionPrompt"' \
+    "skipDangerousModePermissionPrompt preserved into effective"
+  smoke_assert_contains "$content" '"foo"' \
+    "enabledPlugins value array element preserved"
+  # The unrelated key MUST NOT leak through. The renderer's preserve
+  # allowlist is intentionally tight — anything outside it is operator-
+  # supplied state we don't promise to round-trip.
+  smoke_assert_not_contains "$content" "unrelatedSetting" \
+    "non-allowlisted user key dropped from effective"
+}
+
+assert_idempotent() {
+  # Re-render with no input changes; the file's SHA256 must match.
+  local before after
+  before="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$EFFECTIVE")"
+  invoke_renderer >/dev/null
+  after="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$EFFECTIVE")"
+  smoke_assert_eq "$before" "$after" \
+    "rendered effective file SHA256 stable across consecutive renders"
+}
+
+assert_user_key_update_propagates() {
+  # After the first render, settings.json is a symlink — there is no
+  # regular user file for the renderer to extract preserved keys from.
+  # The bash wrapper `bridge_install_isolated_home_settings` handles
+  # this by reading the live settings.json into a controller-owned
+  # staging area and pointing the renderer at THAT staging tree. Mirror
+  # that contract in the smoke: stage a fresh isolated-home tree with
+  # an updated user-key value and verify the rerender adopts it.
+  local stage_root="$SMOKE_TMP_ROOT/stage-update"
+  local stage_home="$stage_root/isolated-home"
+  mkdir -p "$stage_home/.claude"
+  cat >"$stage_home/.claude/settings.json" <<'EOF'
+{
+  "enabledPlugins": ["foo", "bar", "baz-new"],
+  "extraKnownMarketplaces": {"acme": {"source": "github:acme/marketplace-v2"}},
+  "skipDangerousModePermissionPrompt": false
+}
+EOF
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-isolated-home-settings \
+    --isolated-home "$stage_home" \
+    --base-settings-file "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.json" \
+    --overlay-settings-file "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.local.json" \
+    --launch-cmd "" >/dev/null
+
+  local content
+  content="$(cat "$stage_home/.claude/settings.effective.json")"
+  smoke_assert_contains "$content" '"baz-new"' \
+    "updated enabledPlugins entry propagates on re-render"
+  smoke_assert_contains "$content" 'marketplace-v2' \
+    "updated extraKnownMarketplaces value propagates"
+  # The boolean flip must take effect — JSON serializer writes lowercase.
+  smoke_assert_contains "$content" '"skipDangerousModePermissionPrompt": false' \
+    "boolean flip on skipDangerousModePermissionPrompt propagates"
+}
+
+main() {
+  build_fixture
+
+  smoke_run "bridge hook entries rendered into effective" \
+    assert_hook_entries_present
+  smoke_run "settings.json is a symlink to settings.effective.json" \
+    assert_settings_is_symlink
+  smoke_run "pre-existing user keys preserved" \
+    assert_user_keys_preserved
+  smoke_run "renderer is idempotent across consecutive runs" \
+    assert_idempotent
+  smoke_run "user-key updates propagate via staged re-render" \
+    assert_user_key_update_propagates
+
+  smoke_log "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Renders bridge-managed Claude hook entries into per-isolated-home `<isolated-home>/.claude/settings.effective.json` (controller-owned, integrity-bounded), then atomically symlinks `<isolated-home>/.claude/settings.json` → that file. Resolves issue #544 Gap A.

- `bridge-hooks.py`: new `cmd_render_isolated_home_settings` with `--isolated-home` + `--launch-cmd` + `--preserve-keys-from` flags. Symlink-aware: dereferences existing symlinked `settings.json` to read prior preserved user keys from `settings.effective.json`. Atomic via `os.replace`.
- `lib/bridge-hooks.sh`: new `bridge_install_isolated_home_settings(agent, launch_cmd)` install helper. Stages live effective.json into renderer's input tree (when symlinked); renders to tmp + `sudo mv -f` for both effective.json AND settings.json symlink. Failure paths `rm -f` the tmp.
- `lib/bridge-agents.sh`: `<isolated-home>/.claude/` is **controller-owned** (`chown root:$os_user` + `chmod 0750`). Isolated UID has group r-x; cannot unlink/replace root-owned children — preserves the integrity boundary explicitly required by the issue body.
- `bridge-agent.sh:run_rerender_settings`: wires the new helper for isolated agents (alongside existing shared-settings rerender).
- `lib/bridge-migration.sh`: both `--reapply` and first-isolate branches resolve `bridge_agent_launch_cmd_raw` and forward to install helper, so isolated renders pick up `[1m]` heuristic from PR #554.
- `agents/.claude/settings.json` (shared base): now carries all 7 event types — Stop, UserPromptSubmit, SessionStart, PermissionDenied, **PreCompact, PreToolUse, PostToolUse** (added in r2 — PR #561 r1 was missing the last 3).
- `scripts/smoke/isolated-settings-rendering.sh`: 6 sub-tests (hook entries cover all 7 types, symlink, preserved user keys, idempotency, user key updates, **symlink-aware preservation regression**).
- `OPERATIONS.md`: post-upgrade `--reapply` migration step + integrity contract.

## Why per-isolated-home rendered (NOT cross-UID symlink)
Per the issue body integrity argument: cross-UID symlink to controller's `<BRIDGE_HOME>/.claude/settings.effective.json` lets the isolated UID clobber hook enforcement silently if it ever rewrites `settings.json`. Per-home rendering with **controller/root ownership of the parent directory** keeps the integrity boundary intact even after r2's directory-permission tightening.

## History (supersedes #561)
This PR supersedes #561 (closed by org account; GitHub blocks reopening when the head branch was deleted on close). Same content, rebased onto current main (PR #559 / PR #562 conflicts in `OPERATIONS.md`, `lib/bridge-migration.sh`, `scripts/ci-select-smoke.sh`, `scripts/smoke-test.sh` resolved additively).

Codex pair-review on #561 completed 2 rounds:
- r1: needs-more on 5 findings (2 critical: integrity boundary + preserved-keys-symlink; 3 medium: non-atomic install + missing PreCompact/PreToolUse/PostToolUse + --reapply launch_cmd).
- r2: all 5 fixed via bash-side changes only (Python renderer was correct in r1; bug was bash wrapper not staging live effective.json into renderer's input tree). 6/7 codex r2 scrutiny PASS; 1 sandbox-limited (codex couldn't run live smoke due to `mktemp` denial — fixer's local 6/6 PASS confirmed).

This re-opened PR carries the rebased r1+r2 commits unchanged.

## Out of scope (deferred)
- PR4 (subcommand allowlist + audit) — separate PR (in flight).
- Per-agent settings.effective.json (the architectural mixed-model concern flagged on PR #554) — tracked separately as issue #555.
- No VERSION/CHANGELOG bump.

## Test plan
- [x] `bash -n` + `shellcheck` + `python ast.parse` on touched files.
- [x] `agents/.claude/settings.json` has all 7 hook types.
- [x] Atomic install: tmp + `sudo mv -f` for both effective and symlink.
- [x] Symlink-aware preservation: dereferences live `settings.json` symlink.
- [x] `bash scripts/smoke/isolated-settings-rendering.sh` — 6/6 PASS.
- [ ] Maintainer: live `agent-bridge isolate <agent> --reapply` then restart → confirm `<isolated-home>/.claude/settings.json` is symlink → `settings.effective.json` (controller-owned, mode 0640) → contains all 7 hook types AND preserves operator's enabledPlugins / extraKnownMarketplaces / skipDangerousModePermissionPrompt across re-runs.

Refs #544. Supersedes #561.
