### PR TITLE
feat(isolated-cli-policy): subcommand allowlist + audit for isolated agb invocations (refs #544 PR4, supersedes #563)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -437,10 +437,33 @@ agent-bridge isolate <agent> --reapply
 ownership) followed by an agent restart so `bridge-start.sh`
 regenerates the agent's `agent-env.sh` with the new PATH.
 
-Out of scope: the broader `agent-bridge` subcommand surface for
-isolated UIDs remains explicit default-deny per issue
-[#544](https://github.com/SYRS-AI/agent-bridge-public/issues/544) PR4
-design review.
+### Isolated `agb` subcommand allowlist + audit
+
+When `bin/agb` is invoked from an isolated UID context (env carries
+`BRIDGE_GATEWAY_PROXY=1` AND the running UID differs from
+`BRIDGE_CONTROLLER_UID`, both emitted by
+`bridge_write_linux_agent_env_file`), the shim enforces a curated
+allowlist:
+
+- Allowed: `inbox`, `show`, `claim`, `done`, `summary`, `create`.
+- Anything else (including `admin`, `upgrade`, `daemon`, `urgent`,
+  `kill`, `attach`, `agent start|stop|restart|create|update`,
+  `cron *`, `config set`, `setup`, `isolate`, `unisolate`, `worktree`,
+  `audit`, `wave dispatch`) returns exit `64` with a clean message
+  pointing the operator at the queue route
+  (`agb create --to admin --title "..."`).
+
+Every isolated invocation (allow or deny) appends a JSONL row to
+`${BRIDGE_HOME}/logs/agents/<agent>/audit.jsonl` carrying
+`{ts, agent, uid, subcommand, arg_count, decision, reason}`. Argument
+**values** are intentionally not captured — task IDs and note text may
+be sensitive — so audit reviewers see the call shape, not the
+operator's text. Operators who need to invoke administrative
+subcommands run `agb` from the controller shell, not from inside an
+isolated agent's tmux pane. Existing isolated agents pick up the
+controller-UID env-file emission by re-running the same
+`agent-bridge isolate <agent> --reapply` + restart sequence from the
+PR1 section above.
 
 ### Bridge-native skills under the isolated HOME
 

--- a/bin/agb
+++ b/bin/agb
@@ -3,12 +3,15 @@
 #
 # - PR1: env-file sourcing + BRIDGE_HOME fallback + exec delegation.
 # - PR4: subcommand allowlist + audit when invoked from an isolated UID.
-#   Detection requires both BRIDGE_GATEWAY_PROXY=1 (set in the agent's
-#   agent-env.sh by bridge_write_linux_agent_env_file for linux-user
-#   isolation) AND a UID mismatch against BRIDGE_CONTROLLER_UID. Either
-#   gate alone is insufficient: the env flag could be exported manually
-#   in a controller shell, and the UID hint may be missing on installs
-#   that haven't refreshed the env file yet.
+#   Detection is STRICT: requires BRIDGE_GATEWAY_PROXY=1 (set in the
+#   agent's agent-env.sh by bridge_write_linux_agent_env_file for
+#   linux-user isolation) AND a non-empty BRIDGE_CONTROLLER_UID that
+#   differs from the running UID. Both halves must hold; there is no
+#   fallback to proxy-flag-only when the UID hint is missing. A
+#   controller shell with BRIDGE_GATEWAY_PROXY=1 exported (operator
+#   debugging gateway routing) would otherwise be incorrectly treated
+#   as isolated and have admin commands denied. Installs missing the
+#   UID hint should re-run isolated env regeneration.
 #
 # Out of scope here: arg-value capture (privacy), audit-log rotation,
 # verbose-audit env. Tracked as PR4 follow-ups.
@@ -45,24 +48,42 @@ if [[ -z "${BRIDGE_HOME:-}" ]]; then
   unset _shim_self _shim_link _shim_max_hops _shim_dir
 fi
 
+# JSON-escape helper for audit-row string fields. The audit row is a
+# pure-bash printf so values containing `"`, `\`, or whitespace control
+# chars would otherwise produce invalid JSONL and break log readers.
+# Keep this minimal: escape the chars JSON requires (RFC 8259 §7) for
+# the field surface we actually emit (subcommand, agent id, ts, reason,
+# decision). Order matters: backslash MUST come first so we don't
+# double-escape escapes we just inserted.
+_json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  printf '%s' "$s"
+}
+
 # === PR4: isolated subcommand allowlist + audit ===
 # Apply policy only when invoked from an isolated UID context. Both gates
-# must fire:
+# must fire STRICTLY — there is no fallback when the controller UID hint
+# is missing:
 #   1. BRIDGE_GATEWAY_PROXY=1 — set in the agent's agent-env.sh when
 #      isolation_mode == linux-user (lib/bridge-agents.sh).
-#   2. running UID != BRIDGE_CONTROLLER_UID (also emitted into the same
-#      env file). Guards against an operator who manually exports
-#      BRIDGE_GATEWAY_PROXY=1 in their controller shell.
-# When BRIDGE_CONTROLLER_UID is missing (env file from <0.7.6+ that
-# hasn't been rewritten yet), fall back to the proxy flag alone — that's
-# the behaviour the existing gateway-routing code already trusts.
+#   2. BRIDGE_CONTROLLER_UID is non-empty AND != running UID. Both halves
+#      matter. Falling back to the proxy flag alone would be unsafe: a
+#      controller shell with BRIDGE_GATEWAY_PROXY=1 exported (e.g. an
+#      operator debugging gateway routing) would otherwise be treated as
+#      isolated and have admin commands denied. Installs without the UID
+#      hint emitted should re-run isolated env regeneration rather than
+#      have the shim guess.
 _isolated_invocation=0
 _self_uid="$(id -u)"
+_controller_uid=""
 if [[ "${BRIDGE_GATEWAY_PROXY:-0}" == "1" ]]; then
   _controller_uid="${BRIDGE_CONTROLLER_UID:-}"
   if [[ -n "$_controller_uid" && "$_self_uid" != "$_controller_uid" ]]; then
-    _isolated_invocation=1
-  elif [[ -z "$_controller_uid" ]]; then
     _isolated_invocation=1
   fi
 fi
@@ -95,7 +116,13 @@ if (( _isolated_invocation == 1 )); then
     _arg_count=0
   fi
   _audit_row="$(printf '{"ts":"%s","agent":"%s","uid":%s,"subcommand":"%s","arg_count":%d,"decision":"%s","reason":"%s","source":"isolated_cli_policy"}' \
-    "$_ts" "$_agent_id" "$_self_uid" "$_subcommand" "$_arg_count" "$_decision" "$_reason")"
+    "$(_json_escape "$_ts")" \
+    "$(_json_escape "$_agent_id")" \
+    "$_self_uid" \
+    "$(_json_escape "$_subcommand")" \
+    "$_arg_count" \
+    "$(_json_escape "$_decision")" \
+    "$(_json_escape "$_reason")")"
   if mkdir -p "$_audit_dir" 2>/dev/null && [[ -w "$_audit_dir" ]]; then
     printf '%s\n' "$_audit_row" >>"$_audit_log" 2>/dev/null || true
   fi

--- a/bin/agb
+++ b/bin/agb
@@ -1,14 +1,17 @@
 #!/usr/bin/env bash
-# Curated agb shim for isolated agents (issue #544 PR1).
+# Curated agb shim for isolated agents (issue #544 PR1 + PR4).
 #
-# - When invoked from an isolated agent's UID with BRIDGE_AGENT_ENV_FILE in
-#   env, source it first so BRIDGE_GATEWAY_PROXY=1 / BRIDGE_HOME / sentineled
-#   BRIDGE_TASK_DB are present even in fresh non-login subshells (Bash tool
-#   subprocess re-evaluating PATH, etc.).
-# - Then exec the underlying $BRIDGE_HOME/agb script.
+# - PR1: env-file sourcing + BRIDGE_HOME fallback + exec delegation.
+# - PR4: subcommand allowlist + audit when invoked from an isolated UID.
+#   Detection requires both BRIDGE_GATEWAY_PROXY=1 (set in the agent's
+#   agent-env.sh by bridge_write_linux_agent_env_file for linux-user
+#   isolation) AND a UID mismatch against BRIDGE_CONTROLLER_UID. Either
+#   gate alone is insufficient: the env flag could be exported manually
+#   in a controller shell, and the UID hint may be missing on installs
+#   that haven't refreshed the env file yet.
 #
-# Out of scope here: subcommand allowlist / denylist enforcement (issue #544
-# PR4 design). This shim is a discovery/delivery wrapper, not a policy gate.
+# Out of scope here: arg-value capture (privacy), audit-log rotation,
+# verbose-audit env. Tracked as PR4 follow-ups.
 
 set -euo pipefail
 
@@ -41,5 +44,71 @@ if [[ -z "${BRIDGE_HOME:-}" ]]; then
   export BRIDGE_HOME
   unset _shim_self _shim_link _shim_max_hops _shim_dir
 fi
+
+# === PR4: isolated subcommand allowlist + audit ===
+# Apply policy only when invoked from an isolated UID context. Both gates
+# must fire:
+#   1. BRIDGE_GATEWAY_PROXY=1 — set in the agent's agent-env.sh when
+#      isolation_mode == linux-user (lib/bridge-agents.sh).
+#   2. running UID != BRIDGE_CONTROLLER_UID (also emitted into the same
+#      env file). Guards against an operator who manually exports
+#      BRIDGE_GATEWAY_PROXY=1 in their controller shell.
+# When BRIDGE_CONTROLLER_UID is missing (env file from <0.7.6+ that
+# hasn't been rewritten yet), fall back to the proxy flag alone — that's
+# the behaviour the existing gateway-routing code already trusts.
+_isolated_invocation=0
+_self_uid="$(id -u)"
+if [[ "${BRIDGE_GATEWAY_PROXY:-0}" == "1" ]]; then
+  _controller_uid="${BRIDGE_CONTROLLER_UID:-}"
+  if [[ -n "$_controller_uid" && "$_self_uid" != "$_controller_uid" ]]; then
+    _isolated_invocation=1
+  elif [[ -z "$_controller_uid" ]]; then
+    _isolated_invocation=1
+  fi
+fi
+
+if (( _isolated_invocation == 1 )); then
+  _subcommand="${1:-}"
+  _agent_id="${BRIDGE_AGENT_ID:-unknown}"
+  case "$_subcommand" in
+    inbox|show|claim|done|summary|create)
+      _decision=allow
+      _reason=allowlist
+      ;;
+    *)
+      _decision=deny
+      _reason=not_on_isolated_allowlist
+      ;;
+  esac
+
+  # Audit row. Best-effort: a write failure (e.g. dir not writable) must
+  # not abort the policy decision. Schema:
+  #   ts, agent, uid, subcommand, arg_count, decision, reason
+  # NOTE: arg_count only — never arg values. Arg values may carry task
+  # IDs or note text the operator wouldn't want in plain audit.
+  _audit_dir="${BRIDGE_HOME}/logs/agents/${_agent_id}"
+  _audit_log="${_audit_dir}/audit.jsonl"
+  _ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if [[ "$#" -gt 0 ]]; then
+    _arg_count=$(( $# - 1 ))
+  else
+    _arg_count=0
+  fi
+  _audit_row="$(printf '{"ts":"%s","agent":"%s","uid":%s,"subcommand":"%s","arg_count":%d,"decision":"%s","reason":"%s","source":"isolated_cli_policy"}' \
+    "$_ts" "$_agent_id" "$_self_uid" "$_subcommand" "$_arg_count" "$_decision" "$_reason")"
+  if mkdir -p "$_audit_dir" 2>/dev/null && [[ -w "$_audit_dir" ]]; then
+    printf '%s\n' "$_audit_row" >>"$_audit_log" 2>/dev/null || true
+  fi
+
+  if [[ "$_decision" == "deny" ]]; then
+    printf 'agb: subcommand %q is not allowed for isolated agents.\n' "$_subcommand" >&2
+    printf '     Operator/admin actions must go through the queue: agb create --to admin --title "..."\n' >&2
+    printf '     (audit row written to %s)\n' "$_audit_log" >&2
+    exit 64
+  fi
+  unset _subcommand _agent_id _decision _reason _audit_dir _audit_log _ts _arg_count _audit_row
+fi
+unset _isolated_invocation _self_uid _controller_uid
+# === end PR4 ===
 
 exec "$BRIDGE_HOME/agb" "$@"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2548,10 +2548,20 @@ EOF
   # routing from `${#BRIDGE_AGENT_IDS[@]}` so the peer-id additions above do
   # not accidentally drop the agent off the gateway. See issue #294 +
   # bridge_queue_gateway_proxy_agent.
+  #
+  # BRIDGE_CONTROLLER_UID is the writer's UID (this function runs in the
+  # controller context). The bin/agb shim uses it to confirm a strict UID
+  # mismatch before applying the isolated-CLI allowlist (issue #544 PR4) —
+  # the gateway-proxy flag alone could be spoofed by an operator who
+  # manually exports it in their own shell.
   if [[ "$isolation_mode" == "linux-user" ]]; then
-    cat >>"$file" <<'EOF'
+    local _controller_uid
+    _controller_uid="$(id -u)"
+    cat >>"$file" <<EOF
 BRIDGE_GATEWAY_PROXY=1
 export BRIDGE_GATEWAY_PROXY
+BRIDGE_CONTROLLER_UID=$(printf '%q' "$_controller_uid")
+export BRIDGE_CONTROLLER_UID
 EOF
   fi
   # Inject engine CLI directory into PATH for sudo-wrapped launchers when

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window
 }
 
 add_all_integration() {
@@ -217,14 +217,15 @@ select_for_path() {
       ;;
 
     lib/bridge-isolation*.sh|lib/bridge-migration.sh|bridge-migrate.sh|tests/isolation*)
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering launch
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy launch
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
 
     bin/agb|bin/*)
       # Issue #544 PR1 — curated bin/ shim for isolated agents.
-      add_required isolated-bin-agb isolation launch
+      # Issue #544 PR4 — same shim carries the isolated-CLI policy gate.
+      add_required isolated-bin-agb isolated-cli-policy isolation launch
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10214,6 +10214,11 @@ log "running isolated-settings-rendering smoke (issue #544 PR2)"
 log "isolated-settings-rendering covers Python renderer only — live install/symlink-swap requires isolate+restart"
 bash "$REPO_ROOT/scripts/smoke/isolated-settings-rendering.sh"
 
+# Issue #544 PR4 — isolated subcommand allowlist + audit on bin/agb shim.
+log "running isolated-cli-policy smoke (issue #544 PR4)"
+log "isolated-cli-policy covers shim allowlist/denylist gate + audit redaction — live BRIDGE_CONTROLLER_UID emission requires isolate+restart on a Linux host"
+bash "$REPO_ROOT/scripts/smoke/isolated-cli-policy.sh"
+
 # Issue #539 — system agent class roundtrip + tool-policy gate scenarios.
 log "running system-agent-class smoke (issue #539)"
 bash "$REPO_ROOT/scripts/smoke/system-agent-class.sh"

--- a/scripts/smoke/isolated-bin-agb.sh
+++ b/scripts/smoke/isolated-bin-agb.sh
@@ -62,10 +62,16 @@ EOF
 
   # Fixture env file the shim must auto-source. Mirrors the shape
   # bridge_write_linux_agent_env_file emits for isolated agents.
+  # BRIDGE_CONTROLLER_UID matches our own UID on purpose: this smoke
+  # exercises the PR1 env-source + delegation contract only, not the
+  # PR4 isolated-CLI policy gate. Setting it equal to $(id -u) tells
+  # the shim "the writer == this UID, so don't apply policy" — which
+  # is what we want here (separate smoke covers the gate explicitly).
   AGENT_ENV_FILE="$FIXTURE_HOME/agent-env.sh"
   cat >"$AGENT_ENV_FILE" <<EOF
 export BRIDGE_HOME="$FIXTURE_HOME"
 export BRIDGE_GATEWAY_PROXY=1
+export BRIDGE_CONTROLLER_UID=$(id -u)
 export TEST_ENV_MARKER=isolated-bin-agb-smoke
 EOF
   chmod 600 "$AGENT_ENV_FILE"

--- a/scripts/smoke/isolated-cli-policy.sh
+++ b/scripts/smoke/isolated-cli-policy.sh
@@ -111,6 +111,18 @@ run_uid_match_shim() {
     bash "$FIXTURE_HOME/bin/agb" "$@"
 }
 
+run_proxy_no_controller_shim() {
+  # BRIDGE_GATEWAY_PROXY=1 but BRIDGE_CONTROLLER_UID is unset/empty →
+  # strict gate must NOT fire (no fallback to proxy-flag-only).
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    BRIDGE_HOME="$FIXTURE_HOME" \
+    BRIDGE_GATEWAY_PROXY=1 \
+    BRIDGE_AGENT_ID=test-agent \
+    bash "$FIXTURE_HOME/bin/agb" "$@"
+}
+
 last_audit_row() {
   [[ -f "$AUDIT_LOG" ]] || return 0
   tail -n 1 "$AUDIT_LOG"
@@ -221,6 +233,70 @@ assert_audit_redaction_drops_arg_values() {
     "audit redaction: flag names NOT emitted (only arg_count)"
 }
 
+assert_proxy_without_controller_uid_skips_gate() {
+  # Strict isolated detection: BRIDGE_GATEWAY_PROXY=1 alone (no
+  # BRIDGE_CONTROLLER_UID hint) must NOT trigger the gate. Falling back
+  # to proxy-flag-only would deny operator-class commands in a
+  # controller shell that happens to have the proxy flag exported (e.g.
+  # operator debugging gateway routing). admin is a denylist subcommand
+  # if the gate fires; if it pops through cleanly we've confirmed the
+  # gate stayed off.
+  : >"$STUB_LOG"
+  : >"$AUDIT_LOG"
+  run_proxy_no_controller_shim admin --some-arg
+  smoke_assert_contains "$(cat "$STUB_LOG")" "INVOKED:admin --some-arg" \
+    "BRIDGE_GATEWAY_PROXY=1 + BRIDGE_CONTROLLER_UID unset bypasses policy (strict gate)"
+  local audit_size
+  audit_size="$(wc -c <"$AUDIT_LOG" | tr -d ' ')"
+  smoke_assert_eq "0" "$audit_size" \
+    "BRIDGE_GATEWAY_PROXY=1 + BRIDGE_CONTROLLER_UID unset writes NO audit row"
+}
+
+assert_audit_row_is_valid_jsonl() {
+  # Subcommand carrying a literal `"` would break the audit row if the
+  # shim's printf didn't json-escape the value. Use a denylist
+  # subcommand (anything outside the allowlist) so the row goes through
+  # the deny branch — both branches share the same printf.
+  : >"$STUB_LOG"
+  : >"$AUDIT_LOG"
+  local rc=0
+  run_isolated_shim 'foo"bar' >/dev/null 2>&1 || rc=$?
+  smoke_assert_eq "64" "$rc" \
+    "JSONL escape: quote-bearing subcommand still hits deny branch (exit 64)"
+
+  # Validate every row in the audit log parses as JSON.
+  if ! python3 -c '
+import json, sys
+with open(sys.argv[1]) as fh:
+    for i, line in enumerate(fh, 1):
+        line = line.strip()
+        if not line:
+            continue
+        json.loads(line)
+' "$AUDIT_LOG" 2>/dev/null; then
+    smoke_fail "JSONL escape: audit row containing quote in subcommand is not valid JSONL"
+  else
+    smoke_log "JSONL escape: audit row with quote-bearing subcommand parses as valid JSONL"
+  fi
+
+  # And confirm the escaped subcommand round-trips correctly.
+  local extracted
+  extracted="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        row = json.loads(line)
+        if row.get("subcommand") == "foo\"bar":
+            print("MATCH")
+            break
+' "$AUDIT_LOG" 2>/dev/null)"
+  smoke_assert_eq "MATCH" "$extracted" \
+    "JSONL escape: subcommand value preserved through json.loads round-trip"
+}
+
 main() {
   build_fixture
 
@@ -234,6 +310,10 @@ main() {
     assert_uid_match_skips_gate
   smoke_run "audit row redacts arg values (arg_count only)" \
     assert_audit_redaction_drops_arg_values
+  smoke_run "strict gate: proxy flag + unset CONTROLLER_UID bypasses policy" \
+    assert_proxy_without_controller_uid_skips_gate
+  smoke_run "audit row remains valid JSONL when subcommand contains a quote" \
+    assert_audit_row_is_valid_jsonl
 
   smoke_log "PASS"
 }

--- a/scripts/smoke/isolated-cli-policy.sh
+++ b/scripts/smoke/isolated-cli-policy.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# scripts/smoke/isolated-cli-policy.sh — Issue #544 PR4 smoke.
+#
+# Validates the curated bin/agb shim's isolated-UID subcommand
+# allowlist + audit row writer (added by PR4). Coverage:
+#
+# 1. Allowlist subcommands (inbox, show, claim, done, summary, create)
+#    pass through to the underlying ${BRIDGE_HOME}/agb when invoked from
+#    an isolated UID context (BRIDGE_GATEWAY_PROXY=1 + UID mismatch),
+#    and an `decision: "allow"` audit row appears.
+# 2. Anything-not-allowed (admin, kill, agent restart, cron create,
+#    config set, wave dispatch — sample of the default-deny set) exits
+#    64 with a clean message and writes a `decision: "deny"` audit row.
+# 3. Non-isolated invocation (BRIDGE_GATEWAY_PROXY unset, OR UID matches
+#    BRIDGE_CONTROLLER_UID) skips the gate entirely — no audit row, all
+#    subcommands pass to the underlying agb.
+# 4. Audit redaction: arg VALUES never appear in the audit row, only
+#    arg_count. A subcommand carrying a fake task ID + private note must
+#    leave neither in the JSONL row.
+#
+# Does NOT exercise:
+#   - live `bridge_write_linux_agent_env_file` emission of
+#     BRIDGE_CONTROLLER_UID under sudo (requires `agent-bridge isolate`
+#     against a real linux-user UID).
+#   - real allowlisted `agb` subcommand semantics (queue, db, etc.).
+#     Those are covered by the queue / agent-update smokes.
+
+set -euo pipefail
+
+SMOKE_NAME="isolated-cli-policy"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+build_fixture() {
+  smoke_make_temp_root "$SMOKE_NAME"
+  FIXTURE_HOME="$SMOKE_TMP_ROOT/bridge-home"
+  mkdir -p "$FIXTURE_HOME/bin" "$FIXTURE_HOME/logs/agents/test-agent"
+  cp "$SMOKE_REPO_ROOT/bin/agb" "$FIXTURE_HOME/bin/agb"
+  chmod +x "$FIXTURE_HOME/bin/agb"
+
+  # Stub root agb that records its argv so we can assert the shim's
+  # gate let the call through.
+  STUB_LOG="$SMOKE_TMP_ROOT/stub-agb.log"
+  cat >"$FIXTURE_HOME/agb" <<EOF
+#!/usr/bin/env bash
+printf 'INVOKED:%s\n' "\$*" >>"$STUB_LOG"
+exit 0
+EOF
+  chmod +x "$FIXTURE_HOME/agb"
+
+  AUDIT_LOG="$FIXTURE_HOME/logs/agents/test-agent/audit.jsonl"
+}
+
+# Real UID at smoke run time. We pick a deliberately mismatched
+# BRIDGE_CONTROLLER_UID so the policy gate fires. Using a constant
+# (e.g. 99999) would collide on systems where the smoke happens to
+# run as that UID; instead derive a guaranteed-different value.
+mismatched_controller_uid() {
+  local self_uid
+  self_uid="$(id -u)"
+  if (( self_uid == 0 )); then
+    printf '%s' "12345"
+  else
+    printf '%s' "$(( self_uid + 1 ))"
+  fi
+}
+
+run_isolated_shim() {
+  # $@ becomes the shim's argv. Caller wraps with isolated env.
+  local controller_uid
+  controller_uid="$(mismatched_controller_uid)"
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    BRIDGE_HOME="$FIXTURE_HOME" \
+    BRIDGE_GATEWAY_PROXY=1 \
+    BRIDGE_CONTROLLER_UID="$controller_uid" \
+    BRIDGE_AGENT_ID=test-agent \
+    bash "$FIXTURE_HOME/bin/agb" "$@"
+}
+
+run_non_isolated_shim() {
+  # No BRIDGE_GATEWAY_PROXY → gate doesn't fire.
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    BRIDGE_HOME="$FIXTURE_HOME" \
+    BRIDGE_AGENT_ID=test-agent \
+    bash "$FIXTURE_HOME/bin/agb" "$@"
+}
+
+run_uid_match_shim() {
+  # BRIDGE_GATEWAY_PROXY=1 but BRIDGE_CONTROLLER_UID matches our UID →
+  # gate doesn't fire (operator forgot to drop the env from their own
+  # shell).
+  local self_uid
+  self_uid="$(id -u)"
+  env -i \
+    PATH="/usr/bin:/bin" \
+    HOME="$SMOKE_TMP_ROOT" \
+    BRIDGE_HOME="$FIXTURE_HOME" \
+    BRIDGE_GATEWAY_PROXY=1 \
+    BRIDGE_CONTROLLER_UID="$self_uid" \
+    BRIDGE_AGENT_ID=test-agent \
+    bash "$FIXTURE_HOME/bin/agb" "$@"
+}
+
+last_audit_row() {
+  [[ -f "$AUDIT_LOG" ]] || return 0
+  tail -n 1 "$AUDIT_LOG"
+}
+
+assert_allowlist_passes_through() {
+  local subcmd
+  for subcmd in inbox show claim done summary create; do
+    : >"$STUB_LOG"
+    : >"$AUDIT_LOG"
+    run_isolated_shim "$subcmd" "arg-1" "arg-2"
+    smoke_assert_contains "$(cat "$STUB_LOG")" "INVOKED:$subcmd arg-1 arg-2" \
+      "allowlist '$subcmd' delegates to underlying agb"
+    local row
+    row="$(last_audit_row)"
+    smoke_assert_contains "$row" "\"subcommand\":\"$subcmd\"" \
+      "allowlist '$subcmd' audit row carries subcommand name"
+    smoke_assert_contains "$row" '"decision":"allow"' \
+      "allowlist '$subcmd' audit row marks decision=allow"
+    smoke_assert_contains "$row" '"reason":"allowlist"' \
+      "allowlist '$subcmd' audit row reason=allowlist"
+    smoke_assert_contains "$row" '"arg_count":2' \
+      "allowlist '$subcmd' audit row reports arg_count without values"
+  done
+}
+
+assert_denylist_blocks_with_exit_64() {
+  # A representative slice of the default-deny set. The shim does not
+  # enumerate denied subcommands — anything not on the allowlist is
+  # denied. Pick across the operator-class surface to confirm.
+  local rc=0 stderr_capture
+  for subcmd in admin kill upgrade attach urgent setup isolate worktree audit; do
+    : >"$STUB_LOG"
+    : >"$AUDIT_LOG"
+    rc=0
+    stderr_capture="$(run_isolated_shim "$subcmd" 2>&1 1>/dev/null)" || rc=$?
+    smoke_assert_eq "64" "$rc" \
+      "denylist '$subcmd' exits 64"
+    smoke_assert_contains "$stderr_capture" "is not allowed for isolated agents" \
+      "denylist '$subcmd' surfaces clean deny message"
+    smoke_assert_contains "$stderr_capture" "agb create --to admin" \
+      "denylist '$subcmd' suggests queue route"
+    smoke_assert_eq "" "$(cat "$STUB_LOG")" \
+      "denylist '$subcmd' does NOT delegate to underlying agb"
+    local row
+    row="$(last_audit_row)"
+    smoke_assert_contains "$row" "\"subcommand\":\"$subcmd\"" \
+      "denylist '$subcmd' audit row carries subcommand name"
+    smoke_assert_contains "$row" '"decision":"deny"' \
+      "denylist '$subcmd' audit row marks decision=deny"
+    smoke_assert_contains "$row" '"reason":"not_on_isolated_allowlist"' \
+      "denylist '$subcmd' audit row reason=not_on_isolated_allowlist"
+  done
+}
+
+assert_non_isolated_skips_gate() {
+  # Without BRIDGE_GATEWAY_PROXY the policy gate is disabled, so even
+  # operator-class subcommands pass through and NO audit row is written.
+  local subcmd
+  for subcmd in inbox admin kill upgrade attach create; do
+    : >"$STUB_LOG"
+    : >"$AUDIT_LOG"
+    run_non_isolated_shim "$subcmd" "arg"
+    smoke_assert_contains "$(cat "$STUB_LOG")" "INVOKED:$subcmd arg" \
+      "non-isolated '$subcmd' delegates without policy"
+    local audit_size
+    audit_size="$(wc -c <"$AUDIT_LOG" | tr -d ' ')"
+    smoke_assert_eq "0" "$audit_size" \
+      "non-isolated '$subcmd' writes NO audit row"
+  done
+}
+
+assert_uid_match_skips_gate() {
+  # BRIDGE_GATEWAY_PROXY=1 but UID matches BRIDGE_CONTROLLER_UID — this
+  # is the "operator manually exported the proxy flag in their own
+  # shell" case. Gate must NOT fire.
+  : >"$STUB_LOG"
+  : >"$AUDIT_LOG"
+  run_uid_match_shim admin --some-arg
+  smoke_assert_contains "$(cat "$STUB_LOG")" "INVOKED:admin --some-arg" \
+    "UID-matching invocation bypasses policy even with BRIDGE_GATEWAY_PROXY=1"
+  local audit_size
+  audit_size="$(wc -c <"$AUDIT_LOG" | tr -d ' ')"
+  smoke_assert_eq "0" "$audit_size" \
+    "UID-matching invocation writes NO audit row"
+}
+
+assert_audit_redaction_drops_arg_values() {
+  # Args carrying a fake task ID + private note must NOT appear in the
+  # audit row. Only arg_count is captured.
+  : >"$STUB_LOG"
+  : >"$AUDIT_LOG"
+  local secret_token="task-secret-id-12345"
+  local private_note="private notes operator wouldnt want logged"
+  run_isolated_shim done "$secret_token" --agent self --note "$private_note"
+
+  local row
+  row="$(last_audit_row)"
+  smoke_assert_contains "$row" '"subcommand":"done"' \
+    "audit redaction: subcommand name preserved"
+  smoke_assert_contains "$row" '"arg_count":5' \
+    "audit redaction: arg_count reflects positional + flags (token + --agent + self + --note + note-text)"
+  smoke_assert_not_contains "$row" "$secret_token" \
+    "audit redaction: secret task-id NOT emitted"
+  smoke_assert_not_contains "$row" "private notes" \
+    "audit redaction: private note text NOT emitted"
+  smoke_assert_not_contains "$row" "--agent" \
+    "audit redaction: flag names NOT emitted (only arg_count)"
+}
+
+main() {
+  build_fixture
+
+  smoke_run "allowlist subcommands pass through with allow audit" \
+    assert_allowlist_passes_through
+  smoke_run "denylist subcommands exit 64 with deny audit" \
+    assert_denylist_blocks_with_exit_64
+  smoke_run "non-isolated invocation skips policy + audit" \
+    assert_non_isolated_skips_gate
+  smoke_run "UID-matching invocation skips policy even with proxy flag" \
+    assert_uid_match_skips_gate
+  smoke_run "audit row redacts arg values (arg_count only)" \
+    assert_audit_redaction_drops_arg_values
+
+  smoke_log "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Extends `bin/agb` (PR1 shim) with subcommand allowlist + audit when invoked from an isolated UID. Resolves issue #544 PR4 (broader agb subcommand surface design review).

- `bin/agb`: strict isolated-detection gate (`BRIDGE_GATEWAY_PROXY=1` + non-empty `BRIDGE_CONTROLLER_UID` + UID mismatch — all three required). Allowlist case-match (`inbox|show|claim|done|summary|create`). Default-deny exit 64 for everything else with clean message redirecting operators to queue task creation. Every invocation (allow + deny) appends a JSONL audit row with subcommand + arg_count (NOT arg values, for privacy). New `_json_escape` helper for safe JSON serialization.
- `lib/bridge-agents.sh`: `bridge_write_linux_agent_env_file` emits `BRIDGE_CONTROLLER_UID` so the shim's strict gate has the explicit hint it requires.
- `scripts/smoke/isolated-cli-policy.sh`: 7 sub-tests (allowlist allow + deny exit 64 + non-isolated bypass + UID-matching bypass + arg redaction + proxy-without-controller bypass + JSONL escape round-trip).
- `scripts/smoke/isolated-bin-agb.sh`: extended to confirm policy gate is no-op for non-isolated invocations.
- `scripts/ci-select-smoke.sh`: auto-select wiring.
- `OPERATIONS.md`: allowlist + denied UX + audit redaction contract.

## Allowlist rationale (per codex R2 design consult)
Only queue-routing primitives the agent uses for self-management: `inbox`, `show`, `claim`, `done`, `summary`, `create`. Everything else default-deny. `agb send-reply` was originally proposed in the codex R2 candidate list but is NOT a real subcommand on this codebase — excluded per codex R2 escalation note.

## Strict isolated detection
Both gates strictly required:
1. `BRIDGE_GATEWAY_PROXY=1` (set in isolated agents' agent-env.sh)
2. `BRIDGE_CONTROLLER_UID` non-empty
3. `$(id -u)` != `$BRIDGE_CONTROLLER_UID`

A controller shell with `BRIDGE_GATEWAY_PROXY=1` exported for debugging (no CONTROLLER_UID) bypasses the policy entirely — no audit row, no deny. This was tightened in r2 after codex review noted the original elif fallback would false-positive on operator debugging.

## Audit privacy
Records subcommand + arg COUNT only — arg values can carry sensitive data (task IDs, notes containing operator-private text). All string fields (ts, agent, subcommand, decision, reason) escaped via `_json_escape` (RFC 8259 §7 ordering: backslash → quote → control whitespace) so a subcommand containing `"` or `\` produces valid JSONL.

Schema:
```json
{"ts":"2026-05-04T...","agent":"librarian","uid":1001,"subcommand":"done","arg_count":4,"decision":"allow","reason":"allowlist"}
```

## History (supersedes #563)
This PR supersedes #563 (closed by org account; GitHub blocks reopening when the head branch was deleted on close). Same content, rebased onto current main (PR #564 / `scripts/smoke-test.sh` + `scripts/ci-select-smoke.sh` conflicts resolved additively).

Codex pair-review on #563 completed 2 rounds:
- r1: needs-more on detection fallback + JSONL escaping.
- r2: tightened gate (no fallback when CONTROLLER_UID empty) + `_json_escape` helper applied to all 5 string fields + 2 new smoke sub-tests; **implement-ok**.

This re-opened PR carries the rebased r1+r2 commits unchanged.

## Out of scope (deferred)
- `BRIDGE_ISOLATED_CLI_AUDIT_VERBOSE` env flag — separate follow-up.
- Audit log rotation — existing log rotation covers it.
- Audit-dir ACL grant for isolated UID — best-effort `printf >> ... || true`.
- No VERSION/CHANGELOG bump.

## Test plan
- [x] `bash -n` + `shellcheck` on touched files.
- [x] Strict gate: requires BRIDGE_GATEWAY_PROXY=1 + non-empty BRIDGE_CONTROLLER_UID + UID mismatch.
- [x] Allowlist exact set (`inbox|show|claim|done|summary|create`); no `send-reply`.
- [x] Audit row: subcommand + arg_count only; no arg-value leakage; valid JSONL even for quote-containing values.
- [x] `bash scripts/smoke/isolated-cli-policy.sh` — 7/7 PASS (allow, deny, non-isolated bypass, UID-matching bypass, arg redaction, proxy-without-controller bypass, JSONL escape round-trip).
- [ ] Maintainer: live `agent-bridge isolate <agent> --reapply` then restart → confirm isolated `agb admin` returns exit 64 + audit row written; `agb inbox <self>` works.

Refs #544. Supersedes #563. **Combined with PR #556 (PR1) + PR #564 (PR2) + PR #559 (PR3) — issue #544 fully addressed on merge.**
