### PR TITLE
feat(per-agent-settings): per-agent settings.effective.json for managed agents (refs #555)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -176,19 +176,27 @@ in `agent-roster.local.sh` (env wins over settings per Claude Code's
 resolution order, so this overrides the new model-aware default and
 survives `agent-bridge upgrade --apply`).
 
-**Mixed-model installs (caveat).** The shared settings effective file
-under `$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json` is
-**install-wide** — one file symlinked from each managed agent's workdir.
-On installs where some agents launch `[1m]` and others launch pre-1M
-models, the file inherits the `autoCompactWindow` of whichever agent
-ran the last `agb upgrade --apply` / restart-rerender. Until per-agent
-effective settings lands (tracked separately), operators on mixed-model
-installs should either:
+**Per-agent settings.effective.json (issue #555).** As of v0.7.x+, every
+managed agent has its own `settings.effective.json` rendered at
+`$BRIDGE_AGENT_HOME_ROOT/<agent>/.claude/settings.effective.json` and the
+agent's workdir `settings.json` symlinks to it. Per-agent values like
+`autoCompactWindow` are independent — a 1M-context Opus 4.7 `[1m]` agent
+and a pre-1M Opus 4.6 agent on the same install each see their own
+resolved value, regardless of which one ran the last
+`agb upgrade --apply` / restart-rerender.
 
-- keep models homogeneous within an install, or
-- override per-agent via `CLAUDE_CODE_AUTO_COMPACT_WINDOW=<value>`
-  in the env-precedence layer (env wins over settings per Claude
-  Code's resolution order).
+The shared base (`$BRIDGE_AGENT_HOME_ROOT/.claude/settings.json`) and
+overlay (`settings.local.json`) remain install-wide and are still
+authoritative for hook wiring and operator overrides; only the *effective*
+output (managed defaults + base + overlay) is split per agent.
+
+Existing installs migrate automatically on the next `agb upgrade --apply`:
+the per-agent loop renders each agent's per-agent effective file and
+re-points its workdir symlink. The old install-wide
+`$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json` becomes
+orphaned but harmless after migration (no symlink references it);
+operators may delete it manually after verifying the per-agent files
+exist and contain the expected `autoCompactWindow` value.
 
 ## Recommended Collaboration Pattern
 

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1348,13 +1348,19 @@ bridge_agent_shared_settings_plan_json() {
   local launch_cmd
   launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
 
+  # Issue #555: the rerender now writes the effective file at the
+  # per-agent path ($BRIDGE_AGENT_HOME_ROOT/<agent>/.claude/
+  # settings.effective.json). The plan/diff helper must compare the
+  # workdir symlink against the same per-agent target it will be
+  # relinked to — comparing against the install-wide path would
+  # forever report `needs-rerender` after a successful apply.
   bridge_agent_manage_python \
     "$SCRIPT_DIR/bridge-hooks.py" \
     "$agent" \
     "$workdir" \
     "$(bridge_hook_shared_settings_base_file)" \
     "$(bridge_hook_shared_settings_overlay_file)" \
-    "$(bridge_hook_shared_settings_effective_file)" \
+    "$(bridge_hook_per_agent_settings_effective_file "$agent")" \
     "$launch_cmd" <<'PY'
 import importlib.util
 import json
@@ -1653,7 +1659,12 @@ run_rerender_settings() {
       # Issue #547: forward launch_cmd so the rerender picks the right
       # autoCompactWindow default (1_000_000 for [1m] launches, else 400_000).
       target_launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
-      if apply_output="$(bridge_link_claude_settings_to_shared "$workdir" "$target_launch_cmd" 2>&1)"; then
+      # Issue #555: forward agent id so the rerender writes to the
+      # per-agent effective file ($BRIDGE_AGENT_HOME_ROOT/<agent>/.claude/
+      # settings.effective.json). Mixed-model installs no longer fight
+      # over a single install-wide file; each agent's autoCompactWindow
+      # (and any future per-agent managed default) is independent.
+      if apply_output="$(bridge_link_claude_settings_to_shared "$workdir" "$target_launch_cmd" "$agent" 2>&1)"; then
         after_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir")"
         bridge_audit_log "$(bridge_admin_agent_id 2>/dev/null || printf bridge-upgrade)" "shared_settings_rerendered" "$agent" \
           --detail workdir="$workdir" >/dev/null 2>&1 || true
@@ -1972,7 +1983,9 @@ run_create() {
     if [[ "$engine" == "claude" ]]; then
       # Issue #547: forward launch_cmd so the freshly-created agent gets
       # the right autoCompactWindow default for its model variant.
-      bridge_ensure_claude_shared_settings_for_managed_workdir "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
+      # Issue #555: pass agent id so the freshly-created agent gets its
+      # own per-agent settings.effective.json (not the install-wide one).
+      bridge_ensure_claude_shared_settings_for_managed_workdir "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
     fi
     bridge_sync_skill_docs "$agent" >/dev/null 2>&1 || true
     if [[ "$isolation_mode" == "linux-user" ]]; then

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -465,7 +465,11 @@ if [[ $dry_run -eq 0 ]] && [[ "$(bridge_agent_engine "$admin_agent" 2>/dev/null 
   admin_workdir="$(bridge_agent_workdir "$admin_agent" 2>/dev/null || true)"
   if [[ -n "$admin_workdir" ]]; then
     admin_launch_cmd="$(bridge_agent_launch_cmd_raw "$admin_agent" 2>/dev/null || true)"
-    bridge_ensure_claude_shared_settings_for_managed_workdir "$admin_workdir" "$admin_launch_cmd" >/dev/null 2>&1 || true
+    # Issue #555: pass admin agent id so the rendered effective file
+    # lives at $BRIDGE_AGENT_HOME_ROOT/<admin>/.claude/settings.effective.json
+    # (per-agent), not the install-wide path that would later be overwritten
+    # by other managed agents' rerenders.
+    bridge_ensure_claude_shared_settings_for_managed_workdir "$admin_workdir" "$admin_launch_cmd" "$admin_agent" >/dev/null 2>&1 || true
   fi
 fi
 

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -672,6 +672,7 @@ run_agent() {
   local claude_path=""
   local hook_output=""
   local prompt_hook_output=""
+  local launch_cmd=""
   local webhook_cleanup_output=""
   local wake_status=""
   local settings_mode=""
@@ -873,17 +874,22 @@ run_agent() {
       printf 'shared_settings_base_file: %s\n' "$(bridge_hook_shared_settings_base_file)"
       printf 'shared_settings_effective_file: %s\n' "$(bridge_hook_shared_settings_effective_file)"
     fi
-    # Issue #555: forward agent id (3rd arg) so the post-ensure relink
-    # writes the per-agent effective file. launch_cmd left empty — setup
-    # only verifies hook wiring; actual managed-default values come from
-    # the rerender path which has the full launch_cmd context.
-    if hook_output="$(bridge_ensure_claude_stop_hook "$workdir" "" "$agent" 2>&1)"; then
+    # Issue #555 r2: resolve launch_cmd from the roster so the post-ensure
+    # relink renders the per-agent effective file with the agent's correct
+    # managed-default values (e.g. autoCompactWindow=1_000_000 for [1m]
+    # variants vs the legacy 400_000). Mirrors the pattern in
+    # bridge-start.sh:240, bridge-agent.sh:1661, and bridge-upgrade.sh:203.
+    # Without this, `agent-bridge setup agent <1m-agent>` would clobber the
+    # per-agent file to the empty-launch_cmd legacy default and regress
+    # PR #554's [1m] heuristic.
+    launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
+    if hook_output="$(bridge_ensure_claude_stop_hook "$workdir" "$launch_cmd" "$agent" 2>&1)"; then
       echo "$hook_output"
     else
       echo "$hook_output"
       failures=$((failures + 1))
     fi
-    if prompt_hook_output="$(bridge_ensure_claude_prompt_hook "$workdir" "" "$agent" 2>&1)"; then
+    if prompt_hook_output="$(bridge_ensure_claude_prompt_hook "$workdir" "$launch_cmd" "$agent" 2>&1)"; then
       echo "$prompt_hook_output"
     else
       echo "$prompt_hook_output"

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -873,13 +873,17 @@ run_agent() {
       printf 'shared_settings_base_file: %s\n' "$(bridge_hook_shared_settings_base_file)"
       printf 'shared_settings_effective_file: %s\n' "$(bridge_hook_shared_settings_effective_file)"
     fi
-    if hook_output="$(bridge_ensure_claude_stop_hook "$workdir" 2>&1)"; then
+    # Issue #555: forward agent id (3rd arg) so the post-ensure relink
+    # writes the per-agent effective file. launch_cmd left empty — setup
+    # only verifies hook wiring; actual managed-default values come from
+    # the rerender path which has the full launch_cmd context.
+    if hook_output="$(bridge_ensure_claude_stop_hook "$workdir" "" "$agent" 2>&1)"; then
       echo "$hook_output"
     else
       echo "$hook_output"
       failures=$((failures + 1))
     fi
-    if prompt_hook_output="$(bridge_ensure_claude_prompt_hook "$workdir" 2>&1)"; then
+    if prompt_hook_output="$(bridge_ensure_claude_prompt_hook "$workdir" "" "$agent" 2>&1)"; then
       echo "$prompt_hook_output"
     else
       echo "$prompt_hook_output"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -232,19 +232,25 @@ if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
   if ! bridge_ensure_claude_project_trust "$WORK_DIR" >/dev/null 2>&1; then
     bridge_warn "Claude project trust seed failed: $WORK_DIR"
   fi
-  if ! bridge_ensure_claude_stop_hook "$WORK_DIR" >/dev/null; then
+  # Issue #555: forward agent id (3rd arg) so each ensure-*-hook helper
+  # relinks the per-agent effective file at $BRIDGE_AGENT_HOME_ROOT/<agent>/
+  # .claude/settings.effective.json. Resolve launch_cmd from the roster so
+  # the rerender picks the right autoCompactWindow default for this agent's
+  # model variant ([1m] → 1_000_000, otherwise → 400_000).
+  AGENT_LAUNCH_CMD="$(bridge_agent_launch_cmd_raw "$AGENT" 2>/dev/null || true)"
+  if ! bridge_ensure_claude_stop_hook "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null; then
     bridge_die "Claude Stop hook 설정에 실패했습니다: $WORK_DIR"
   fi
-  if ! bridge_ensure_claude_session_start_hook "$WORK_DIR" >/dev/null; then
+  if ! bridge_ensure_claude_session_start_hook "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null; then
     bridge_die "Claude SessionStart hook 설정에 실패했습니다: $WORK_DIR"
   fi
-  if ! bridge_ensure_claude_prompt_hook "$WORK_DIR" >/dev/null; then
+  if ! bridge_ensure_claude_prompt_hook "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null; then
     bridge_die "Claude UserPromptSubmit hook 설정에 실패했습니다: $WORK_DIR"
   fi
-  if ! bridge_ensure_claude_prompt_guard_hook "$WORK_DIR" >/dev/null; then
+  if ! bridge_ensure_claude_prompt_guard_hook "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null; then
     bridge_die "Claude prompt guard hook 설정에 실패했습니다: $WORK_DIR"
   fi
-  if ! bridge_ensure_claude_tool_policy_hooks "$WORK_DIR" >/dev/null; then
+  if ! bridge_ensure_claude_tool_policy_hooks "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null; then
     bridge_die "Claude tool policy hook 설정에 실패했습니다: $WORK_DIR"
   fi
   if ! bridge_disable_claude_webhook_channel "$AGENT" "$WORK_DIR" >/dev/null 2>&1; then

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -201,17 +201,21 @@ bridge_upgrade_propagate_claude_hooks() {
       # shared settings pick the right autoCompactWindow default per
       # model variant ([1m] → 1_000_000, otherwise → 400_000).
       launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
-      bridge_ensure_claude_stop_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
-      bridge_ensure_claude_session_start_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
-      bridge_ensure_claude_prompt_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
-      bridge_ensure_claude_prompt_guard_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
-      bridge_ensure_claude_tool_policy_hooks "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
+      # Issue #555: forward agent id so each ensure-*-hook helper relinks
+      # the per-agent effective file (not the install-wide one). Mixed-
+      # model installs no longer last-rerender-wins on per-agent managed
+      # defaults like `autoCompactWindow`.
+      bridge_ensure_claude_stop_hook "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
+      bridge_ensure_claude_session_start_hook "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
+      bridge_ensure_claude_prompt_hook "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
+      bridge_ensure_claude_prompt_guard_hook "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
+      bridge_ensure_claude_tool_policy_hooks "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
       # Issue #509 / PR #510 deployment gap: PreCompact was the one event
       # the propagation loop never re-registered, so hosts that upgraded
       # without restarting agents shipped hooks/pre-compact.py code with
       # no settings.json wire. Adding it here closes that gap on every
       # subsequent upgrade.
-      bridge_ensure_claude_pre_compact_hook "$workdir" "$launch_cmd" >/dev/null 2>&1 || true
+      bridge_ensure_claude_pre_compact_hook "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
     done
   ' -- "$target_root"
 }

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -39,6 +39,22 @@ bridge_hook_shared_settings_effective_file() {
   printf '%s/.claude/settings.effective.json' "$BRIDGE_AGENT_HOME_ROOT"
 }
 
+# Issue #555: per-agent rendering target for managed (non-isolated) agents.
+# `bridge_link_claude_settings_to_shared` writes to this path when the caller
+# passes the agent id, eliminating the "last rerender wins" mixed-model
+# behavior on per-agent managed defaults like `autoCompactWindow`. The base
+# (.claude/settings.json) and overlay (.claude/settings.local.json) under
+# $BRIDGE_AGENT_HOME_ROOT remain install-wide; only the *effective* output
+# is per-agent and lives inside that agent's managed workdir
+# ($BRIDGE_AGENT_HOME_ROOT/<agent>/.claude/), next to the symlinked
+# settings.json. After migration, the install-wide
+# `$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json` becomes orphaned
+# but harmless — operators may delete it manually after verifying.
+bridge_hook_per_agent_settings_effective_file() {
+  local agent="$1"
+  printf '%s/%s/.claude/settings.effective.json' "$BRIDGE_AGENT_HOME_ROOT" "$agent"
+}
+
 bridge_hook_paths_equal() {
   local left="$1"
   local right="$2"
@@ -116,8 +132,14 @@ bridge_claude_settings_mode() {
 bridge_ensure_claude_shared_settings_for_managed_workdir() {
   local workdir="$1"
   local launch_cmd="${2-}"
+  # Issue #555: optional 3rd arg switches to per-agent rendering. Forward
+  # it through so callers that already know the agent id (start path,
+  # rerender loop, upgrade propagate, admin-pair init) get independent
+  # `settings.effective.json` files; callers that don't (back-compat) keep
+  # the legacy install-wide render.
+  local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
-    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
     return 0
   fi
@@ -126,17 +148,26 @@ bridge_ensure_claude_shared_settings_for_managed_workdir() {
 bridge_link_claude_settings_to_shared() {
   local workdir="$1"
   # Issue #547: launch_cmd substring '[1m]' raises the managed
-  # autoCompactWindow default from 400_000 to 1_000_000. The shared
-  # settings file is install-wide; on a mixed-model install the last
-  # rerender for an agent decides the value. The dominant case is
-  # all-Opus-4.7-[1m] (or all-pre-1M), where every rerender agrees.
+  # autoCompactWindow default from 400_000 to 1_000_000.
   local launch_cmd="${2-}"
+  # Issue #555: when the caller passes the agent id (3rd arg), render the
+  # effective file at the per-agent path so mixed-model installs get
+  # independent values for `autoCompactWindow` (and any future per-agent
+  # managed default). When omitted (legacy callers), fall back to the
+  # install-wide render so the helper remains backwards-compatible.
+  local agent="${3-}"
+  local effective_file
+  if [[ -n "$agent" ]]; then
+    effective_file="$(bridge_hook_per_agent_settings_effective_file "$agent")"
+  else
+    effective_file="$(bridge_hook_shared_settings_effective_file)"
+  fi
   bridge_hooks_python render-shared-settings \
     --base-settings-file "$(bridge_hook_shared_settings_base_file)" \
     --overlay-settings-file "$(bridge_hook_shared_settings_overlay_file)" \
-    --effective-settings-file "$(bridge_hook_shared_settings_effective_file)" \
+    --effective-settings-file "$effective_file" \
     --launch-cmd "$launch_cmd" >/dev/null
-  bridge_hooks_python link-shared-settings --workdir "$workdir" --shared-settings-file "$(bridge_hook_shared_settings_effective_file)"
+  bridge_hooks_python link-shared-settings --workdir "$workdir" --shared-settings-file "$effective_file"
 }
 
 bridge_ensure_claude_project_trust() {
@@ -192,9 +223,12 @@ bridge_claude_tool_policy_hooks_status() {
 bridge_ensure_claude_stop_hook() {
   local workdir="$1"
   local launch_cmd="${2-}"
+  # Issue #555: optional 3rd arg routes the post-ensure relink to the
+  # per-agent effective file when the caller knows the agent id.
+  local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-stop-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --bash-bin bash >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
     bridge_hooks_python ensure-stop-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --bash-bin "$BRIDGE_BASH_BIN"
   fi
@@ -203,9 +237,10 @@ bridge_ensure_claude_stop_hook() {
 bridge_ensure_claude_session_start_hook() {
   local workdir="$1"
   local launch_cmd="${2-}"
+  local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-session-start-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
     bridge_hooks_python ensure-session-start-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi
@@ -214,9 +249,10 @@ bridge_ensure_claude_session_start_hook() {
 bridge_ensure_claude_prompt_hook() {
   local workdir="$1"
   local launch_cmd="${2-}"
+  local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-prompt-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --bash-bin bash --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
     bridge_hooks_python ensure-prompt-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --bash-bin "$BRIDGE_BASH_BIN" --python-bin "$(command -v python3)"
   fi
@@ -225,9 +261,10 @@ bridge_ensure_claude_prompt_hook() {
 bridge_ensure_claude_prompt_guard_hook() {
   local workdir="$1"
   local launch_cmd="${2-}"
+  local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-prompt-guard-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
     bridge_hooks_python ensure-prompt-guard-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi
@@ -236,9 +273,10 @@ bridge_ensure_claude_prompt_guard_hook() {
 bridge_ensure_claude_tool_policy_hooks() {
   local workdir="$1"
   local launch_cmd="${2-}"
+  local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-tool-policy-hooks --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
     bridge_hooks_python ensure-tool-policy-hooks --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi
@@ -255,9 +293,10 @@ bridge_ensure_claude_tool_policy_hooks() {
 bridge_ensure_claude_pre_compact_hook() {
   local workdir="$1"
   local launch_cmd="${2-}"
+  local agent="${3-}"
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-pre-compact-hook --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
-    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd"
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
   else
     bridge_hooks_python ensure-pre-compact-hook --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering
 }
 
 add_all_integration() {
@@ -203,7 +203,7 @@ select_for_path() {
       ;;
 
     bridge-start.sh|bridge-run.sh|bridge-send.sh|bridge-action.sh|bridge-agent.sh|agent-bridge|agb|lib/bridge-tmux.sh|lib/bridge-session-patterns.sh|lib/bridge-wave.sh|lib/bridge-agent-update.sh)
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update upgrade-conflicts-lifecycle managed-autocompact-window
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -262,12 +262,15 @@ select_for_path() {
       # `render-isolated-home-settings` subcommand and lib/bridge-hooks.sh
       # grew `bridge_install_isolated_home_settings`. Pull the new smoke
       # in whenever either touches.
-      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering
+      # Issue #555 — `bridge_link_claude_settings_to_shared` /
+      # `bridge_ensure_claude_*_hook` now take an optional 3rd `agent`
+      # arg that switches to per-agent rendering; cover the regression.
+      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering
       add_integration integration-minimal
       ;;
 
     bridge-upgrade.sh|bridge-upgrade.py|scripts/export-public-snapshot.sh|VERSION)
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering
       add_integration integration-minimal
       ;;
 
@@ -277,7 +280,7 @@ select_for_path() {
       ;;
 
     bridge-init.sh|lib/bridge-admin-pair.sh)
-      add_required admin-codex-pair upgrade-shared-settings-propagate managed-autocompact-window
+      add_required admin-codex-pair upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10223,4 +10223,10 @@ bash "$REPO_ROOT/scripts/smoke/isolated-cli-policy.sh"
 log "running system-agent-class smoke (issue #539)"
 bash "$REPO_ROOT/scripts/smoke/system-agent-class.sh"
 
+# Issue #555 — per-agent settings.effective.json rendering for managed
+# (non-isolated) agents. Mixed-model installs no longer last-rerender-wins
+# on `autoCompactWindow` (or any future per-agent managed default).
+log "running per-agent-settings-rendering smoke (issue #555)"
+bash "$REPO_ROOT/scripts/smoke/per-agent-settings-rendering.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/per-agent-settings-rendering.sh
+++ b/scripts/smoke/per-agent-settings-rendering.sh
@@ -19,6 +19,12 @@
 #      file (independence proven — the original mixed-model bug).
 #   5. Back-compat: when agent id is omitted, rendering still writes the
 #      install-wide file at the legacy path.
+#   6. Setup path (#555 r2): bridge-setup.sh's run_agent invokes
+#      `bridge_ensure_claude_stop_hook` / `bridge_ensure_claude_prompt_hook`
+#      after channel setup. Pre-fix it passed empty launch_cmd, clobbering
+#      the per-agent effective file back to the legacy 400_000 default.
+#      Post-fix it must resolve launch_cmd and preserve 1_000_000 for [1m]
+#      agents.
 
 set -euo pipefail
 
@@ -84,6 +90,24 @@ invoke_link_install_wide() {
   ' -- "$SMOKE_REPO_ROOT" "$workdir" "$launch_cmd" >/dev/null
 }
 
+invoke_setup_ensure_helpers_for_agent() {
+  # Issue #555 r2: simulates bridge-setup.sh:run_agent's post-channel
+  # ensure block. Drives the same two helpers (`bridge_ensure_claude_stop_hook`
+  # and `bridge_ensure_claude_prompt_hook`) the way the FIXED run_agent
+  # does — with the resolved launch_cmd, so the post-ensure relink hits
+  # the renderer with the right managed-default context. Pre-fix this
+  # passed empty launch_cmd and clobbered [1m] agents back to 400_000.
+  local agent="$1"
+  local workdir="$2"
+  local launch_cmd="$3"
+  "$BRIDGE_BASH_BIN_OR_DEFAULT" -lc '
+    set -euo pipefail
+    source "$1/bridge-lib.sh"
+    bridge_ensure_claude_stop_hook "$2" "$3" "$4" >/dev/null
+    bridge_ensure_claude_prompt_hook "$2" "$3" "$4" >/dev/null
+  ' -- "$SMOKE_REPO_ROOT" "$workdir" "$launch_cmd" "$agent" >/dev/null
+}
+
 main() {
   smoke_require_cmd python3
   smoke_setup_bridge_home "$SMOKE_NAME"
@@ -147,6 +171,19 @@ main() {
   # Per-agent files for agent-A/agent-B remain untouched by the back-compat call.
   smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A per-agent file unaffected by install-wide back-compat render"
   smoke_assert_eq "400000" "$(settings_value "$agent_b_effective" autoCompactWindow)" "agent-B per-agent file unaffected by install-wide back-compat render"
+
+  smoke_log "case 6: setup path preserves [1m] launch_cmd through ensure helpers (#555 r2)"
+  # Pre-state: agent-A's per-agent file is already at 1_000_000 (from cases 1/4).
+  smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A pre-setup baseline still 1_000_000"
+  # Act: simulate bridge-setup.sh:run_agent invoking the ensure helpers
+  # the way the FIX does — passing the resolved [1m] launch_cmd through.
+  invoke_setup_ensure_helpers_for_agent agent-a "$agent_a_workdir" "claude --model claude-opus-4-7[1m]"
+  # Assert: per-agent effective file STILL holds the [1m] managed default,
+  # not the empty-launch_cmd legacy 400_000 fallback the renderer would
+  # otherwise have written.
+  smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A per-agent file STILL 1_000_000 after setup-style ensure (no clobber to 400_000)"
+  # And agent-B (the non-[1m] sibling) remains untouched — no cross-agent leak.
+  smoke_assert_eq "400000" "$(settings_value "$agent_b_effective" autoCompactWindow)" "agent-B per-agent file unaffected by agent-A setup-style ensure"
 
   smoke_log "PASS: per-agent settings.effective.json rendering (#555)"
 }

--- a/scripts/smoke/per-agent-settings-rendering.sh
+++ b/scripts/smoke/per-agent-settings-rendering.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# scripts/smoke/per-agent-settings-rendering.sh — Issue #555 regression smoke.
+#
+# Validates that `bridge_link_claude_settings_to_shared`, when invoked
+# with an agent id (3rd arg), writes the rendered effective file at the
+# per-agent path `$BRIDGE_AGENT_HOME_ROOT/<agent>/.claude/settings.effective.json`
+# rather than the install-wide path. Mixed-model installs no longer
+# last-rerender-wins on `autoCompactWindow` (or any future per-agent
+# managed default).
+#
+# Sub-tests:
+#   1. agent-A (launch_cmd contains '[1m]') gets autoCompactWindow=1_000_000
+#      in its per-agent file.
+#   2. agent-B (launch_cmd lacks '[1m]') gets autoCompactWindow=400_000 in
+#      its per-agent file.
+#   3. Each agent's workdir settings.json is a symlink to its own per-agent
+#      effective file (NOT to the install-wide one).
+#   4. Re-rendering agent-A AFTER agent-B does not touch agent-B's per-agent
+#      file (independence proven — the original mixed-model bug).
+#   5. Back-compat: when agent id is omitted, rendering still writes the
+#      install-wide file at the legacy path.
+
+set -euo pipefail
+
+SMOKE_NAME="per-agent-settings-rendering"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+settings_value() {
+  local settings_file="$1"
+  local key="$2"
+  python3 - "$settings_file" "$key" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+settings_file, key = sys.argv[1:]
+payload = json.loads(Path(settings_file).read_text(encoding="utf-8"))
+print(payload.get(key))
+PY
+}
+
+file_sha256() {
+  local path="$1"
+  python3 - "$path" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+}
+
+invoke_link_for_agent() {
+  # Drives `bridge_link_claude_settings_to_shared` from a child bash that
+  # sources the helper library exactly the way the live callers do
+  # (rerender loop, run_create, propagate-claude-hooks). This is the unit
+  # under test — going through the real helper catches a regression in the
+  # bash plumbing as well as the underlying Python renderer call.
+  local agent="$1"
+  local workdir="$2"
+  local launch_cmd="$3"
+  "$BRIDGE_BASH_BIN_OR_DEFAULT" -lc '
+    set -euo pipefail
+    source "$1/bridge-lib.sh"
+    bridge_link_claude_settings_to_shared "$2" "$3" "$4"
+  ' -- "$SMOKE_REPO_ROOT" "$workdir" "$launch_cmd" "$agent" >/dev/null
+}
+
+invoke_link_install_wide() {
+  # Back-compat path: omit the agent id, expect the install-wide file.
+  local workdir="$1"
+  local launch_cmd="$2"
+  "$BRIDGE_BASH_BIN_OR_DEFAULT" -lc '
+    set -euo pipefail
+    source "$1/bridge-lib.sh"
+    bridge_link_claude_settings_to_shared "$2" "$3"
+  ' -- "$SMOKE_REPO_ROOT" "$workdir" "$launch_cmd" >/dev/null
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  BRIDGE_BASH_BIN_OR_DEFAULT="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+
+  local install_wide_dir agent_a_workdir agent_b_workdir
+  install_wide_dir="$BRIDGE_AGENT_HOME_ROOT/.claude"
+  agent_a_workdir="$BRIDGE_AGENT_HOME_ROOT/agent-a"
+  agent_b_workdir="$BRIDGE_AGENT_HOME_ROOT/agent-b"
+  mkdir -p "$install_wide_dir" "$agent_a_workdir/.claude" "$agent_b_workdir/.claude"
+
+  # Minimal valid install-wide base + overlay so managed defaults
+  # dominate the rendered effective file. Real installs carry hook wiring
+  # in the base; we only assert on autoCompactWindow here, which the
+  # managed-defaults layer always supplies. The renderer requires base to
+  # be a valid JSON object (see ensure_settings_root in bridge-hooks.py);
+  # an empty file would raise JSONDecodeError.
+  printf '%s\n' '{}' >"$install_wide_dir/settings.json"
+  printf '%s\n' '{}' >"$install_wide_dir/settings.local.json"
+
+  smoke_log "case 1: agent-A ([1m] launch_cmd) renders per-agent file with autoCompactWindow=1_000_000"
+  invoke_link_for_agent agent-a "$agent_a_workdir" "claude --model claude-opus-4-7[1m]"
+  local agent_a_effective="$agent_a_workdir/.claude/settings.effective.json"
+  smoke_assert_file_exists "$agent_a_effective" "agent-A per-agent effective file rendered"
+  smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A autoCompactWindow=1_000_000 ([1m])"
+
+  smoke_log "case 2: agent-B (non-[1m] launch_cmd) renders per-agent file with autoCompactWindow=400_000"
+  invoke_link_for_agent agent-b "$agent_b_workdir" "claude --model claude-opus-4-6"
+  local agent_b_effective="$agent_b_workdir/.claude/settings.effective.json"
+  smoke_assert_file_exists "$agent_b_effective" "agent-B per-agent effective file rendered"
+  smoke_assert_eq "400000" "$(settings_value "$agent_b_effective" autoCompactWindow)" "agent-B autoCompactWindow=400_000 (pre-1M)"
+
+  smoke_log "case 3: each agent's workdir settings.json is a symlink to its own per-agent effective file"
+  local agent_a_link="$agent_a_workdir/.claude/settings.json"
+  local agent_b_link="$agent_b_workdir/.claude/settings.json"
+  [[ -L "$agent_a_link" ]] || smoke_fail "agent-A workdir settings.json should be a symlink"
+  [[ -L "$agent_b_link" ]] || smoke_fail "agent-B workdir settings.json should be a symlink"
+  local agent_a_target agent_b_target
+  agent_a_target="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$agent_a_link")"
+  agent_b_target="$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$agent_b_link")"
+  smoke_assert_eq "$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$agent_a_effective")" "$agent_a_target" "agent-A symlink resolves to agent-A's per-agent effective file"
+  smoke_assert_eq "$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$agent_b_effective")" "$agent_b_target" "agent-B symlink resolves to agent-B's per-agent effective file"
+
+  smoke_log "case 4: re-rendering agent-A does NOT touch agent-B's per-agent file (mixed-model independence)"
+  local agent_b_sha_before
+  agent_b_sha_before="$(file_sha256 "$agent_b_effective")"
+  invoke_link_for_agent agent-a "$agent_a_workdir" "claude --model claude-opus-4-7[1m]"
+  smoke_assert_eq "$agent_b_sha_before" "$(file_sha256 "$agent_b_effective")" "agent-B per-agent file unchanged after agent-A rerender"
+  smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A still 1_000_000 after rerender"
+  smoke_assert_eq "400000" "$(settings_value "$agent_b_effective" autoCompactWindow)" "agent-B still 400_000 after agent-A rerender"
+
+  smoke_log "case 5: back-compat — omitting agent id renders install-wide file"
+  local install_wide_effective="$install_wide_dir/settings.effective.json"
+  rm -f "$install_wide_effective"
+  local back_compat_workdir="$BRIDGE_AGENT_HOME_ROOT/legacy-back-compat"
+  mkdir -p "$back_compat_workdir/.claude"
+  invoke_link_install_wide "$back_compat_workdir" "claude --model claude-opus-4-7[1m]"
+  smoke_assert_file_exists "$install_wide_effective" "back-compat (no agent id) renders install-wide effective file"
+  smoke_assert_eq "1000000" "$(settings_value "$install_wide_effective" autoCompactWindow)" "install-wide file picks up [1m] launch_cmd"
+  # Per-agent files for agent-A/agent-B remain untouched by the back-compat call.
+  smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A per-agent file unaffected by install-wide back-compat render"
+  smoke_assert_eq "400000" "$(settings_value "$agent_b_effective" autoCompactWindow)" "agent-B per-agent file unaffected by install-wide back-compat render"
+
+  smoke_log "PASS: per-agent settings.effective.json rendering (#555)"
+}
+
+main "$@"

--- a/scripts/smoke/upgrade-shared-settings-propagate.sh
+++ b/scripts/smoke/upgrade-shared-settings-propagate.sh
@@ -83,8 +83,11 @@ assert_apply_rerenders_and_preserves_overlay() {
   smoke_assert_eq "rerendered" "$status" "rerender apply status"
 
   settings_file="$BRIDGE_AGENT_HOME_ROOT/patch/.claude/settings.json"
-  effective_file="$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
-  [[ -L "$settings_file" ]] || smoke_fail "rerender apply should link agent settings to shared effective settings"
+  # Issue #555: rerender writes per-agent effective file under each
+  # agent's workdir, not the install-wide path; the workdir symlink
+  # points to that per-agent file.
+  effective_file="$BRIDGE_AGENT_HOME_ROOT/patch/.claude/settings.effective.json"
+  [[ -L "$settings_file" ]] || smoke_fail "rerender apply should link agent settings to per-agent effective settings"
   smoke_assert_eq "400000" "$(settings_value "$settings_file" autoCompactWindow)" "rerender apply backfills autoCompactWindow"
   smoke_assert_eq "yes" "$(python3 - "$settings_file" <<'PY'
 import json, sys
@@ -92,7 +95,7 @@ from pathlib import Path
 print(json.loads(Path(sys.argv[1]).read_text()).get("env", {}).get("OVERLAY_ONLY"))
 PY
 )" "rerender apply preserves operator overlay"
-  smoke_assert_eq "400000" "$(settings_value "$effective_file" autoCompactWindow)" "shared effective has managed default"
+  smoke_assert_eq "400000" "$(settings_value "$effective_file" autoCompactWindow)" "per-agent effective has managed default"
 
   audit="$(cat "$BRIDGE_AUDIT_LOG")"
   smoke_assert_contains "$audit" "shared_settings_rerendered" "rerender apply emits audit row"
@@ -102,7 +105,8 @@ assert_upgrade_runs_rerender() {
   local agent_home upgrade_json has_patch
 
   agent_home="$BRIDGE_AGENT_HOME_ROOT/patch"
-  rm -f "$agent_home/.claude/settings.json" "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
+  # Issue #555: per-agent effective file lives under <agent>/.claude/.
+  rm -f "$agent_home/.claude/settings.json" "$agent_home/.claude/settings.effective.json"
   printf '%s\n' '{"env":{"BASE_ONLY":"yes-again"}}' >"$agent_home/.claude/settings.json"
 
   upgrade_json="$(
@@ -129,7 +133,8 @@ assert_operator_overlay_wins() {
   local agent_home output status
 
   agent_home="$BRIDGE_AGENT_HOME_ROOT/patch"
-  rm -f "$agent_home/.claude/settings.json" "$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json"
+  # Issue #555: per-agent effective file lives under <agent>/.claude/.
+  rm -f "$agent_home/.claude/settings.json" "$agent_home/.claude/settings.effective.json"
   printf '%s\n' '{"autoCompactWindow":600000,"env":{"OVERLAY_ONLY":"yes"}}' >"$BRIDGE_AGENT_HOME_ROOT/.claude/settings.local.json"
   printf '%s\n' '{"env":{"STALE_AGENT":"yes"}}' >"$agent_home/.claude/settings.json"
 


### PR DESCRIPTION
## Summary

Closes the "last rerender wins" mixed-model behavior on per-agent managed defaults like `autoCompactWindow` (the architectural follow-up tracked by #555 after PR #554's model-aware resolver landed with an install-wide caveat).

Each managed (non-isolated) Claude agent now has its own
`settings.effective.json` rendered at
`$BRIDGE_AGENT_HOME_ROOT/<agent>/.claude/settings.effective.json`, with the
agent's workdir `settings.json` symlinked to it. A 1M-context Opus 4.7
`[1m]` agent and a pre-1M Opus 4.6 agent on the same install now keep
their own resolved values regardless of which one ran the last
`agb upgrade --apply` / restart-rerender.

## Design

- The shared base (`$BRIDGE_AGENT_HOME_ROOT/.claude/settings.json`) and
  overlay (`settings.local.json`) stay install-wide and authoritative for
  hook wiring + operator overrides — only the *effective* output
  (managed defaults + base + overlay) is split per agent.
- All ensure/link helpers gain an optional 3rd `agent` arg. When passed,
  the helper renders to the per-agent path; when omitted, it falls back
  to the install-wide path so legacy callers stay backwards-compatible.
- Existing installs migrate automatically on the next `agb upgrade --apply`
  per-agent loop. The old install-wide
  `$BRIDGE_AGENT_HOME_ROOT/.claude/settings.effective.json` becomes
  orphaned but harmless after migration; operator-driven cleanup is
  documented in `OPERATIONS.md` (no auto-delete, per #555 spec).

## Files changed

- `lib/bridge-hooks.sh` — new `bridge_hook_per_agent_settings_effective_file`
  helper; `bridge_link_claude_settings_to_shared`, the 6 `ensure-*-hook`
  helpers, and `bridge_ensure_claude_shared_settings_for_managed_workdir`
  gain optional `agent` arg.
- `bridge-agent.sh` — `run_rerender_settings` and `run_create` forward
  agent id; `bridge_agent_shared_settings_plan_json` compares against the
  per-agent target so post-apply status is `unchanged`.
- `bridge-init.sh` — admin-pair init forwards admin agent id.
- `bridge-upgrade.sh` — `bridge_upgrade_propagate_claude_hooks` per-agent
  loop forwards agent id through every hook ensure call.
- `bridge-start.sh` — agent-start re-registration forwards `$AGENT` and
  also resolves the agent's `launch_cmd` (previously empty, which would
  have re-rendered with the wrong managed default at every restart).
- `bridge-setup.sh` — `setup` command forwards agent id.
- `OPERATIONS.md` — replaces the PR #554 r2 mixed-model caveat with the
  per-agent contract + migration note.
- `scripts/smoke/per-agent-settings-rendering.sh` — new dedicated smoke.
- `scripts/smoke/upgrade-shared-settings-propagate.sh` — fixture updated
  to assert the per-agent path under each agent's workdir.
- `scripts/smoke-test.sh`, `scripts/ci-select-smoke.sh` — wire the new
  smoke into the all-required-static list and the file-trigger groups
  for `bridge-hooks`, `bridge-agent`, `bridge-init`, and `bridge-upgrade`.

## Test plan

- [x] `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh` — pass
- [x] `shellcheck *.sh agent-bridge agb lib/*.sh scripts/*.sh agent-roster.local.example.sh` — pass
- [x] `python3 -c "import ast; ast.parse(open('bridge-hooks.py').read())"` — pass
- [x] `bash scripts/smoke/per-agent-settings-rendering.sh` — pass (5/5
  cases: `[1m]` → 1_000_000, non-`[1m]` → 400_000, per-agent symlink
  targeting, agent-A rerender independence, install-wide back-compat)
- [x] `bash scripts/smoke/managed-autocompact-window.sh` — pass (no
  regression on the #547 resolver matrix)
- [x] `bash scripts/smoke/upgrade-shared-settings-propagate.sh` — pass
  (rerender / upgrade / overlay / Stop-suite assertions all green
  against the per-agent path)
- [x] `bash scripts/smoke/hooks.sh`, `launch.sh`, `admin-codex-pair.sh`,
  `agent-create-name-validation.sh` — pass
- [x] `./scripts/smoke-test.sh` — pass (full integration suite)

## Out of scope

- Did NOT modify `cmd_render_isolated_home_settings` (PR #564 PR2
  territory — already per-isolated-home).
- Did NOT modify the renderer's managed-defaults logic (PR #554
  territory — `[1m]` heuristic unchanged).
- Did NOT auto-delete the orphan install-wide file — operator-driven
  cleanup per the #555 spec; documented in `OPERATIONS.md`.
- No `VERSION` / `CHANGELOG` bump.

Refs #555
