### PR TITLE
fix(teams): deliver inbound via Claude channels

### DIFF
--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -82,6 +82,12 @@ Filenames and message ids are sanitized (strict allowlist) before they're joined
 
 Outbound attachments (sending files from the bot to Teams) are not yet implemented; track that work separately.
 
+## Delivery Mode
+
+By default, inbound Teams messages are delivered to Claude Code with `notifications/claude/channel`, and the server waits for the MCP stdio write before acknowledging the Teams webhook. If the MCP write fails, the webhook returns an error so Teams can retry.
+
+Legacy `TEAMS_BRIDGE_MODE` / `TEAMS_BRIDGE_AGENT` settings are ignored. Teams inbound delivery must not create Agent Bridge queue tasks; it should enter the active Claude Code session as a channel message. Accepted messages are written to the local log only after Claude Code accepts the channel notification, so Teams webhook retries can still recover from delivery failures without duplicating already delivered messages.
+
 ## Current Scope
 
 This is the Phase 1 channel implementation: webhook receive, access gate, Claude channel notification, reply, local message fetch, and a lightweight `/auth/callback` endpoint used by the `ms365` plugin authorization-code pairing flow. Multi-tenant user-to-agent routing is intentionally left to the Agent Bridge relay layer so one Teams bot can map many users to many timeout agents without mixing conversation state.

--- a/plugins/teams/dedupe.ts
+++ b/plugins/teams/dedupe.ts
@@ -13,6 +13,24 @@ export type RecentMessageDeduper = {
   forget(messageId: string): void
 }
 
+// Matches a stored messages.jsonl row against an incoming activity. Two
+// match shapes:
+//   1. exact 3-tuple (chat_id + message_id + revision) — same edit replay
+//      or same-revision retransmit.
+//   2. legacy fallback (stored.revision === undefined) — pre-revision rows
+//      written by older versions had no revision field; without this clause
+//      a fresh-revision arrival for the same (chat_id, message_id) would
+//      slip past the dedupe and double-deliver. Conservative: any row that
+//      lacks revision matches regardless of incoming revision.
+// The caller filters rows by chat_id+message_id before calling this.
+export function storedRowMatchesIncoming(
+  storedRevision: string | undefined,
+  incomingRevision: string,
+): boolean {
+  if (storedRevision === undefined) return true
+  return (storedRevision ?? '') === (incomingRevision ?? '')
+}
+
 export function createRecentMessageDeduper(limit = 256): RecentMessageDeduper {
   const queue: string[] = []
   const seenIds = new Set<string>()

--- a/plugins/teams/dedupe.ts
+++ b/plugins/teams/dedupe.ts
@@ -1,5 +1,6 @@
 export type RecentMessageDeduper = {
   seen(messageId: string): boolean
+  forget(messageId: string): void
 }
 
 export function createRecentMessageDeduper(limit = 256): RecentMessageDeduper {
@@ -19,6 +20,12 @@ export function createRecentMessageDeduper(limit = 256): RecentMessageDeduper {
         if (removed) seenIds.delete(removed)
       }
       return false
+    },
+    forget(messageId: string): void {
+      const id = String(messageId || '').trim()
+      if (!id || !seenIds.delete(id)) return
+      const idx = queue.indexOf(id)
+      if (idx >= 0) queue.splice(idx, 1)
     },
   }
 }

--- a/plugins/teams/dedupe.ts
+++ b/plugins/teams/dedupe.ts
@@ -1,3 +1,13 @@
+// Bounded in-memory deduper for inbound channel webhooks. The caller is
+// responsible for choosing the key shape; the Teams server passes
+// `${chat_id}::${message_id}::${revision}` so:
+//   - chat_id scopes the id (Teams reuses message ids across conversations
+//     for thread replies, so a bare message id can collide).
+//   - message_id is the activity's stable id, the primary dedupe field.
+//   - revision (Bot Framework localTimestamp / timestamp) lets Teams edits
+//     through — edits keep the same message_id but bump localTimestamp.
+// `forget` is exposed so the caller can roll back the dedupe entry when
+// channel delivery fails and the message must be allowed to retry.
 export type RecentMessageDeduper = {
   seen(messageId: string): boolean
   forget(messageId: string): void

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -32,7 +32,7 @@ import {
 } from 'fs'
 import { homedir } from 'os'
 import { isAbsolute as pathIsAbsolute, join, resolve as pathResolve } from 'path'
-import { createRecentMessageDeduper } from './dedupe.ts'
+import { createRecentMessageDeduper, storedRowMatchesIncoming } from './dedupe.ts'
 
 type GroupPolicy = {
   requireMention?: boolean
@@ -377,10 +377,7 @@ function deliveredMessageSeen(chatId: string, messageId: string, revision: strin
       try {
         const row = JSON.parse(lines[i]) as Partial<StoredMessage>
         if (row.chat_id !== chatId || row.message_id !== messageId) continue
-        // Edits arrive with the same chat_id+message_id but a bumped revision.
-        // Treat a row as a "duplicate" only if the revision matches (or both
-        // sides lack one — pre-revision rows or non-edit-aware activities).
-        if ((row.revision ?? '') === (revision ?? '')) return true
+        if (storedRowMatchesIncoming(row.revision, revision)) return true
       } catch {}
     }
   } catch {}
@@ -658,7 +655,17 @@ mcp.setRequestHandler(CallToolRequestSchema, async req => {
 
 async function handleActivity(context: TurnContext): Promise<void> {
   const activity = context.activity
-  if (activity.type !== ActivityTypes.Message) return
+  // Supported activity types:
+  //   - Message       — new chat message from a Teams user.
+  //   - MessageUpdate — Teams edit of an existing message; reuses the
+  //                     original activity.id but bumps localTimestamp /
+  //                     timestamp. The revision-aware dedupe (below) lets
+  //                     edits flow through while still dropping retransmits.
+  // Intentionally not handled: MessageDelete (out of scope — Teams does
+  // emit these, but we don't currently propagate redactions back to the
+  // Claude session). All other activity types (typing, conversationUpdate,
+  // membersAdded, …) are ignored.
+  if (activity.type !== ActivityTypes.Message && activity.type !== ActivityTypes.MessageUpdate) return
   if (!gate(activity)) return
 
   const chatId = referenceKey(activity)

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -66,6 +66,10 @@ type StoredMessage = {
   aad_object_id: string
   text: string
   ts: string
+  // Edit indicator: Teams reuses message_id on edits but bumps
+  // localTimestamp/timestamp. Stored so deliveredMessageSeen can let edits
+  // through while still dropping pure retransmits.
+  revision?: string
   attachments?: StoredAttachment[]
 }
 
@@ -365,14 +369,18 @@ function appendMessage(message: StoredMessage): void {
   appendFileSync(MESSAGES_FILE, JSON.stringify(message) + '\n', { mode: 0o600 })
 }
 
-function deliveredMessageSeen(chatId: string, messageId: string): boolean {
+function deliveredMessageSeen(chatId: string, messageId: string, revision: string): boolean {
   if (!chatId || !messageId || !existsSync(MESSAGES_FILE)) return false
   try {
     const lines = readFileSync(MESSAGES_FILE, 'utf8').split('\n').filter(Boolean)
     for (let i = lines.length - 1; i >= 0; i -= 1) {
       try {
         const row = JSON.parse(lines[i]) as Partial<StoredMessage>
-        if (row.chat_id === chatId && row.message_id === messageId) return true
+        if (row.chat_id !== chatId || row.message_id !== messageId) continue
+        // Edits arrive with the same chat_id+message_id but a bumped revision.
+        // Treat a row as a "duplicate" only if the revision matches (or both
+        // sides lack one — pre-revision rows or non-edit-aware activities).
+        if ((row.revision ?? '') === (revision ?? '')) return true
       } catch {}
     }
   } catch {}
@@ -553,8 +561,13 @@ const adapter = new BotFrameworkAdapter({
 const recentMessageIds = createRecentMessageDeduper(256)
 let duplicateDropLogs = 0
 
-function dedupeKey(chatId: string, messageId: string): string {
-  return `${chatId}::${messageId}`
+// dedupeKey: chat scopes the id (Teams reuses message ids across conversations
+// for thread replies); revision distinguishes edits — Teams keeps the same
+// activity.id when a user edits a message but bumps localTimestamp/timestamp,
+// so including the revision lets edits through while still dropping pure
+// retransmits of the original payload.
+function dedupeKey(chatId: string, messageId: string, revision: string): string {
+  return revision ? `${chatId}::${messageId}::${revision}` : `${chatId}::${messageId}`
 }
 
 function logDuplicateDrop(chatId: string, messageId: string): void {
@@ -650,11 +663,18 @@ async function handleActivity(context: TurnContext): Promise<void> {
 
   const chatId = referenceKey(activity)
   const messageId = String(activity.id ?? randomUUID())
-  if (recentMessageIds.seen(dedupeKey(chatId, messageId))) {
+  // Bot Framework bumps localTimestamp on edited messages (and timestamp
+  // tracks server-side receive time). Either is a stable enough edit
+  // indicator to keep edits from being dropped as duplicates.
+  const revision = String(
+    (activity as any).localTimestamp ??
+      (activity.timestamp instanceof Date ? activity.timestamp.toISOString() : activity.timestamp ?? ''),
+  )
+  if (recentMessageIds.seen(dedupeKey(chatId, messageId, revision))) {
     logDuplicateDrop(chatId, messageId)
     return
   }
-  if (deliveredMessageSeen(chatId, messageId)) {
+  if (deliveredMessageSeen(chatId, messageId, revision)) {
     logDuplicateDrop(chatId, messageId)
     return
   }
@@ -679,8 +699,15 @@ async function handleActivity(context: TurnContext): Promise<void> {
     aad_object_id: aad,
     text,
     ts,
+    ...(revision ? { revision } : {}),
     ...(attachments.length > 0 ? { attachments } : {}),
   }
+  // Channel delivery and local log append are split: a delivery failure must
+  // surface as a non-2xx so Teams retries, but a successful delivery followed
+  // by a failed log append (disk full, EACCES, …) should NOT cause Teams to
+  // retry — the message is already in the active Claude session. The only
+  // observable consequence of a log-append failure is that fetch_messages
+  // can't replay this entry from the local audit log.
   try {
     await mcp.notification({
       method: 'notifications/claude/channel',
@@ -697,6 +724,7 @@ async function handleActivity(context: TurnContext): Promise<void> {
           tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
           service_url: String(activity.serviceUrl ?? ''),
           ts,
+          ...(revision ? { revision } : {}),
           ...(attachments.length > 0
             ? {
                 attachment_count: String(attachments.length),
@@ -713,11 +741,15 @@ async function handleActivity(context: TurnContext): Promise<void> {
         },
       },
     })
-    appendMessage(stored)
   } catch (err) {
-    recentMessageIds.forget(dedupeKey(chatId, messageId))
+    recentMessageIds.forget(dedupeKey(chatId, messageId, revision))
     process.stderr.write(`teams channel: failed to deliver inbound message_id=${messageId}: ${err}\n`)
     throw err
+  }
+  try {
+    appendMessage(stored)
+  } catch (err) {
+    process.stderr.write(`teams channel: failed to append local log message_id=${messageId} (delivery already succeeded): ${err}\n`)
   }
 }
 

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -152,6 +152,17 @@ const HOST = process.env.TEAMS_WEBHOOK_HOST ?? '127.0.0.1'
 const PORT = Number(process.env.TEAMS_WEBHOOK_PORT ?? '3978')
 const STATIC = process.env.TEAMS_ACCESS_MODE === 'static'
 
+if (process.env.TEAMS_BRIDGE_MODE === '1' || process.env.TEAMS_BRIDGE_AGENT) {
+  process.stderr.write(
+    'teams channel: ignoring deprecated TEAMS_BRIDGE_MODE/TEAMS_BRIDGE_AGENT; inbound messages use notifications/claude/channel\n',
+  )
+}
+if (process.env.TEAMS_DELIVERY_MODE && process.env.TEAMS_DELIVERY_MODE !== 'channel') {
+  process.stderr.write(
+    `teams channel: unsupported TEAMS_DELIVERY_MODE=${process.env.TEAMS_DELIVERY_MODE}; using channel delivery\n`,
+  )
+}
+
 const APP_ID = process.env.TEAMS_APP_ID ?? process.env.MicrosoftAppId
 const APP_PASSWORD = process.env.TEAMS_APP_PASSWORD ?? process.env.MicrosoftAppPassword
 const TENANT_ID = process.env.TEAMS_TENANT_ID ?? process.env.MicrosoftAppTenantId ?? ''
@@ -354,6 +365,20 @@ function appendMessage(message: StoredMessage): void {
   appendFileSync(MESSAGES_FILE, JSON.stringify(message) + '\n', { mode: 0o600 })
 }
 
+function deliveredMessageSeen(chatId: string, messageId: string): boolean {
+  if (!chatId || !messageId || !existsSync(MESSAGES_FILE)) return false
+  try {
+    const lines = readFileSync(MESSAGES_FILE, 'utf8').split('\n').filter(Boolean)
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+      try {
+        const row = JSON.parse(lines[i]) as Partial<StoredMessage>
+        if (row.chat_id === chatId && row.message_id === messageId) return true
+      } catch {}
+    }
+  } catch {}
+  return false
+}
+
 function sanitizeMessageId(raw: string): string {
   // Teams message ids are typically guid-like, numeric, or "<guid>:<num>".
   // Strict allowlist prevents path-traversal via attacker-controlled activity.id.
@@ -528,6 +553,16 @@ const adapter = new BotFrameworkAdapter({
 const recentMessageIds = createRecentMessageDeduper(256)
 let duplicateDropLogs = 0
 
+function dedupeKey(chatId: string, messageId: string): string {
+  return `${chatId}::${messageId}`
+}
+
+function logDuplicateDrop(chatId: string, messageId: string): void {
+  if (duplicateDropLogs >= 10) return
+  process.stderr.write(`teams channel: dropped duplicate chat_id=${chatId} message_id=${messageId}\n`)
+  duplicateDropLogs += 1
+}
+
 const mcp = new Server(
   { name: 'teams', version: '0.1.0' },
   {
@@ -615,11 +650,12 @@ async function handleActivity(context: TurnContext): Promise<void> {
 
   const chatId = referenceKey(activity)
   const messageId = String(activity.id ?? randomUUID())
-  if (recentMessageIds.seen(messageId)) {
-    if (duplicateDropLogs < 10) {
-      process.stderr.write(`teams channel: dropped duplicate message_id=${messageId}\n`)
-      duplicateDropLogs += 1
-    }
+  if (recentMessageIds.seen(dedupeKey(chatId, messageId))) {
+    logDuplicateDrop(chatId, messageId)
+    return
+  }
+  if (deliveredMessageSeen(chatId, messageId)) {
+    logDuplicateDrop(chatId, messageId)
     return
   }
 
@@ -645,38 +681,44 @@ async function handleActivity(context: TurnContext): Promise<void> {
     ts,
     ...(attachments.length > 0 ? { attachments } : {}),
   }
-  appendMessage(stored)
-
-  void mcp.notification({
-    method: 'notifications/claude/channel',
-    params: {
-      content: text,
-      meta: {
-        source: 'teams',
-        chat_id: chatId,
-        conversation_id: chatId,
-        message_id: messageId,
-        user: userName,
-        user_id: stored.user_id,
-        aad_object_id: aad,
-        tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
-        service_url: String(activity.serviceUrl ?? ''),
-        ts,
-        ...(attachments.length > 0
-          ? {
-              attachments: attachments.map(att => ({
-                name: att.name,
-                content_type: att.content_type,
-                download_status: att.download_status,
-                ...(att.local_path ? { local_path: att.local_path } : {}),
-                ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
-                ...(att.download_error ? { download_error: att.download_error } : {}),
-              })),
-            }
-          : {}),
+  try {
+    await mcp.notification({
+      method: 'notifications/claude/channel',
+      params: {
+        content: text || (attachments.length > 0 ? '(attachment)' : ''),
+        meta: {
+          source: 'teams',
+          chat_id: chatId,
+          conversation_id: chatId,
+          message_id: messageId,
+          user: userName,
+          user_id: stored.user_id,
+          aad_object_id: aad,
+          tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
+          service_url: String(activity.serviceUrl ?? ''),
+          ts,
+          ...(attachments.length > 0
+            ? {
+                attachment_count: String(attachments.length),
+                attachments: attachments.map(att => ({
+                  name: att.name,
+                  content_type: att.content_type,
+                  download_status: att.download_status,
+                  ...(att.local_path ? { local_path: att.local_path } : {}),
+                  ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
+                  ...(att.download_error ? { download_error: att.download_error } : {}),
+                })),
+              }
+            : {}),
+        },
       },
-    },
-  })
+    })
+    appendMessage(stored)
+  } catch (err) {
+    recentMessageIds.forget(dedupeKey(chatId, messageId))
+    process.stderr.write(`teams channel: failed to deliver inbound message_id=${messageId}: ${err}\n`)
+    throw err
+  }
 }
 
 const httpServer = createServer((req, res) => {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5483,6 +5483,24 @@ PY
   assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "ignoring deprecated TEAMS_BRIDGE_MODE"
   TEAMS_DEDUPE_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { createRecentMessageDeduper } from "./dedupe.ts"; const dedupe = createRecentMessageDeduper(2); console.log(JSON.stringify([dedupe.seen("1775901127484"), dedupe.seen("1775901127484"), dedupe.seen("1775901127485"), dedupe.seen("1775901127486"), dedupe.seen("1775901127484")]))')"
   assert_contains "$TEAMS_DEDUPE_OUTPUT" "[false,true,false,false,false]"
+  # Round-2: channel-failure path — forget() must roll back the dedupe entry
+  # so a Teams retry of the same activity is allowed through after a delivery
+  # error. Without forget() the retry would be silently dropped.
+  TEAMS_DEDUPE_FORGET_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { createRecentMessageDeduper } from "./dedupe.ts"; const dedupe = createRecentMessageDeduper(8); const a = dedupe.seen("chat-1::msg-1::rev-1"); const b = dedupe.seen("chat-1::msg-1::rev-1"); dedupe.forget("chat-1::msg-1::rev-1"); const c = dedupe.seen("chat-1::msg-1::rev-1"); console.log(JSON.stringify([a, b, c]))')"
+  assert_contains "$TEAMS_DEDUPE_FORGET_OUTPUT" "[false,true,false]"
+  # Round-2: edit-aware key — same chat_id+message_id with a bumped revision
+  # must not collide. Teams edits keep the activity id but bump
+  # localTimestamp/timestamp.
+  TEAMS_DEDUPE_EDIT_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { createRecentMessageDeduper } from "./dedupe.ts"; const dedupe = createRecentMessageDeduper(8); const original = dedupe.seen("chat-1::msg-1::2026-01-01T00:00:00Z"); const edit = dedupe.seen("chat-1::msg-1::2026-01-01T00:05:00Z"); const replay = dedupe.seen("chat-1::msg-1::2026-01-01T00:00:00Z"); console.log(JSON.stringify([original, edit, replay]))')"
+  assert_contains "$TEAMS_DEDUPE_EDIT_OUTPUT" "[false,false,true]"
+  # Round-2: catch-block scope — channel delivery and local log append must
+  # use separate try blocks so a successful delivery followed by an
+  # appendMessage failure does NOT cause Teams to retry an already-delivered
+  # message.
+  assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "failed to append local log"
+  assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "delivery already succeeded"
+  # Round-2: dedupe key must include a revision so Teams edits flow through.
+  assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "dedupeKey(chatId, messageId, revision)"
   log "exercising ms365 human-profile disclosure helper"
   MS365_DISCLOSURE_OUTPUT="$(cd "$REPO_ROOT/plugins/ms365" && bun -e 'import { mkdtempSync } from "fs"; import { join } from "path"; import { tmpdir } from "os"; import { hasChatDisclaimerBeenSent, markChatDisclaimerSent, prependHumanOutboundDisclaimer } from "./disclosure.ts"; const root = mkdtempSync(join(tmpdir(), "ms365-disclosure-")); const statePath = join(root, "human-outbound-disclosures.json"); const text = prependHumanOutboundDisclaimer("hello", "text", "notice"); const html = prependHumanOutboundDisclaimer("<p>hello</p>", "html", "notice"); const before = hasChatDisclaimerBeenSent(statePath, "owner@example.com", "chat-1"); markChatDisclaimerSent(statePath, "owner@example.com", "chat-1", "msg-1"); const after = hasChatDisclaimerBeenSent(statePath, "owner@example.com", "chat-1"); const other = hasChatDisclaimerBeenSent(statePath, "owner@example.com", "chat-2"); console.log(JSON.stringify({ text, html, before, after, other }));')"
   python3 - "$MS365_DISCLOSURE_OUTPUT" <<'PY'

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5376,6 +5376,8 @@ assert_contains "$SETUP_TEAMS_OUTPUT" "--dangerously-load-development-channels p
 assert_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams/.env")" "TEAMS_APP_ID=smoke-teams-app-id"
 assert_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams/.env")" "TEAMS_WEBHOOK_HOST=0.0.0.0"
 assert_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams/.env")" "TEAMS_WEBHOOK_PORT=3978"
+assert_not_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams/.env")" "TEAMS_BRIDGE_MODE"
+assert_not_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams/.env")" "TEAMS_BRIDGE_AGENT"
 assert_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams/access.json")" "19:smoke@thread.v2"
 assert_contains "$(cat "$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams/state.json")" "\"status\": \"ok\""
 CREATED_TEAMS_LAUNCH="$("$BASH4_BIN" -c '
@@ -5476,6 +5478,9 @@ PY
     die "Teams plugin unexpectedly stayed alive on duplicate port bind"
   fi
   assert_contains "$(cat "$TEAMS_PLUGIN_CONFLICT_LOG")" "teams channel: http listen failed on 0.0.0.0:$TEAMS_SMOKE_PORT"
+  assert_not_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "agent-bridge urgent"
+  assert_not_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "spawnSync(agb, ['urgent'"
+  assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "ignoring deprecated TEAMS_BRIDGE_MODE"
   TEAMS_DEDUPE_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { createRecentMessageDeduper } from "./dedupe.ts"; const dedupe = createRecentMessageDeduper(2); console.log(JSON.stringify([dedupe.seen("1775901127484"), dedupe.seen("1775901127484"), dedupe.seen("1775901127485"), dedupe.seen("1775901127486"), dedupe.seen("1775901127484")]))')"
   assert_contains "$TEAMS_DEDUPE_OUTPUT" "[false,true,false,false,false]"
   log "exercising ms365 human-profile disclosure helper"
@@ -7113,6 +7118,25 @@ mode_after="$(stat -f '%Lp' "$MODE_ROOT/tool.sh" 2>/dev/null || stat -c '%a' "$M
 SECOND_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "$MODE_REPO" --target-root "$MODE_ROOT" --base-ref "$MODE_BASE")"
 assert_contains "$SECOND_JSON" "\"files_mode_synced\": 0"
 assert_contains "$SECOND_JSON" "\"files_skipped_noop\": 1"
+
+log "smart upgrade repairs non-executable tracked file mode when content already matches"
+READ_ROOT="$TMP_ROOT/upgrade-mode-read-root"
+READ_REPO="$TMP_ROOT/upgrade-mode-read-repo"
+mkdir -p "$READ_ROOT" "$READ_REPO"
+git -C "$READ_REPO" init -q
+git -C "$READ_REPO" config user.email smoke-test
+git -C "$READ_REPO" config user.name "Bridge Smoke"
+printf 'library helper\n' >"$READ_REPO/helper.txt"
+chmod 0644 "$READ_REPO/helper.txt"
+git -C "$READ_REPO" add helper.txt
+git -C "$READ_REPO" commit -qm "helper tracked 100644"
+READ_BASE="$(git -C "$READ_REPO" rev-parse HEAD)"
+cp "$READ_REPO/helper.txt" "$READ_ROOT/helper.txt"
+chmod 0600 "$READ_ROOT/helper.txt"
+READ_JSON="$(python3 "$REPO_ROOT/bridge-upgrade.py" apply-live --source-root "$READ_REPO" --target-root "$READ_ROOT" --base-ref "$READ_BASE")"
+assert_contains "$READ_JSON" "\"files_mode_synced\": 1"
+mode_read="$(stat -f '%Lp' "$READ_ROOT/helper.txt" 2>/dev/null || stat -c '%a' "$READ_ROOT/helper.txt")"
+[[ "$mode_read" == "644" ]] || die "expected helper.txt to be 644 after read-mode sync, got $mode_read"
 
 log "smart upgrade trusts git index mode over working-tree stat"
 MISMATCH_REPO="$TMP_ROOT/upgrade-mode-mismatch-repo"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5501,6 +5501,18 @@ PY
   assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "delivery already succeeded"
   # Round-2: dedupe key must include a revision so Teams edits flow through.
   assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "dedupeKey(chatId, messageId, revision)"
+  # Round-3 Finding A: handleActivity must route Teams edits
+  # (ActivityTypes.MessageUpdate) through the same delivery path as new
+  # messages. Without this gate change the revision-aware dedupe is dead
+  # code — edits never reach it.
+  assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "ActivityTypes.MessageUpdate"
+  # Round-3 Finding B: legacy messages.jsonl rows (written before r2 added
+  # the `revision` field) have no revision. New arrivals always derive a
+  # non-empty revision. The delivered-seen predicate must treat a stored
+  # row with revision === undefined as a match regardless of incoming
+  # revision; otherwise Teams retries replay legacy messages.
+  TEAMS_LEGACY_MATCH_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { storedRowMatchesIncoming } from "./dedupe.ts"; const legacyVsFresh = storedRowMatchesIncoming(undefined, "2026-01-01T00:05:00Z"); const legacyVsEmpty = storedRowMatchesIncoming(undefined, ""); const exactMatch = storedRowMatchesIncoming("2026-01-01T00:05:00Z", "2026-01-01T00:05:00Z"); const exactMismatch = storedRowMatchesIncoming("2026-01-01T00:00:00Z", "2026-01-01T00:05:00Z"); console.log(JSON.stringify([legacyVsFresh, legacyVsEmpty, exactMatch, exactMismatch]))')"
+  assert_contains "$TEAMS_LEGACY_MATCH_OUTPUT" "[true,true,true,false]"
   log "exercising ms365 human-profile disclosure helper"
   MS365_DISCLOSURE_OUTPUT="$(cd "$REPO_ROOT/plugins/ms365" && bun -e 'import { mkdtempSync } from "fs"; import { join } from "path"; import { tmpdir } from "os"; import { hasChatDisclaimerBeenSent, markChatDisclaimerSent, prependHumanOutboundDisclaimer } from "./disclosure.ts"; const root = mkdtempSync(join(tmpdir(), "ms365-disclosure-")); const statePath = join(root, "human-outbound-disclosures.json"); const text = prependHumanOutboundDisclaimer("hello", "text", "notice"); const html = prependHumanOutboundDisclaimer("<p>hello</p>", "html", "notice"); const before = hasChatDisclaimerBeenSent(statePath, "owner@example.com", "chat-1"); markChatDisclaimerSent(statePath, "owner@example.com", "chat-1", "msg-1"); const after = hasChatDisclaimerBeenSent(statePath, "owner@example.com", "chat-1"); const other = hasChatDisclaimerBeenSent(statePath, "owner@example.com", "chat-2"); console.log(JSON.stringify({ text, html, before, after, other }));')"
   python3 - "$MS365_DISCLOSURE_OUTPUT" <<'PY'


### PR DESCRIPTION
## Summary
- remove the Teams inbound queue sender path (`agent-bridge urgent`) and always deliver inbound Teams messages through `notifications/claude/channel`
- ignore stale `TEAMS_BRIDGE_MODE` / `TEAMS_BRIDGE_AGENT` settings so existing env files cannot silently route Teams messages into tasks
- await channel delivery before acknowledging the Teams webhook, then append the local message log so Teams retries can recover without duplicate delivered messages
- use a chat/message composite dedupe key and keep smoke coverage for no bridge-mode env or queue sender regression

## Validation
- `bash -n scripts/smoke-test.sh`
- `git diff --check`
- `bun build server.ts --target=bun --outfile /tmp/teams-server-pr-check.js` using the live Teams plugin dependency tree
- local sales_sean hotfix applied and restarted; Teams health endpoint is responding on port 3980; loaded Teams plugin source has no `bridgeSend` / `agent-bridge urgent` path

## Notes
- Claude Code Channels API expects inbound external-service messages through `notifications/claude/channel`; queue tasks are not the channel delivery protocol.
- The existing PR #558 durable queue direction is superseded by this direct-channel fix.