### PR TITLE
feat(bootstrap): migrate stale [cron-dispatch] cron payloads to canonical bash $script

### DIFF
--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -400,7 +400,11 @@ EXISTING_CRONS_JSON="$(mktemp -t bootstrap-crons.XXXXXX.json)"
 "$BRIDGE_AGB" cron list --agent "$BRIDGE_ADMIN_AGENT" --json >"$EXISTING_CRONS_JSON" 2>/dev/null || echo '[]' > "$EXISTING_CRONS_JSON"
 
 cron_lookup() {
-  # cron_lookup <title> — prints "id<TAB>schedule<TAB>tz" or empty.
+  # cron_lookup <title> — prints "id<TAB>schedule<TAB>tz<TAB>payload_preview"
+  # or empty. payload_preview is the truncated payload string surfaced by
+  # `agent-bridge cron list --json`; sufficient for the legacy
+  # `[cron-dispatch]` prefix check used by the payload-migration branch in
+  # step_cron_one.
   local title="$1"
   "$BRIDGE_PYTHON" - "$EXISTING_CRONS_JSON" "$title" <<'PY'
 import json, sys
@@ -438,7 +442,13 @@ for j in jobs:
         sched = j.get("schedule") or j.get("schedule_text") or ""
         tz = j.get("tz") or j.get("timezone") or j.get("schedule_tz") or ""
         jid = j.get("id") or j.get("job_id") or ""
-        print(f"{jid}\t{sched}\t{tz}")
+        # payload_preview is a ~100-char truncation; we only need the
+        # leading prefix to gate the `[cron-dispatch]` migration branch.
+        preview = j.get("payload_preview") or ""
+        # Strip tab/newline so awk -F'\t' parsing in bash doesn't split
+        # a multiline payload across columns.
+        preview = preview.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+        print(f"{jid}\t{sched}\t{tz}\t{preview}")
         break
 PY
 }
@@ -478,6 +488,61 @@ step_cron_one() {
     local effective_existing_tz="${existing_tz:-$trailing_tz}"
     norm_expected="$sched"
     if [[ "$norm_existing" == "$norm_expected" && "$effective_existing_tz" == "$tz" ]]; then
+      # schedule + tz match. The payload may still be stale: older
+      # bootstraps registered these jobs as `[cron-dispatch] ...`
+      # natural-language briefs aimed at the admin agent, while the
+      # canonical payload (line ~549 below) is `bash $installed_script`.
+      # That mismatch wakes the admin's 1M-context Opus session every
+      # firing just to invoke a deterministic shell script.
+      #
+      # Migrate stale managed payloads to match the canonical bootstrap
+      # payload. Only fires when the existing payload starts with the
+      # `[cron-dispatch]` prefix (operator-customized payloads keep their
+      # text). Same 3-mode pattern as the wiki-daily-ingest schedule
+      # migration block below.
+      local existing_id existing_payload canonical_payload
+      existing_id="$(printf '%s' "$found" | awk -F'\t' '{print $1}')"
+      existing_payload="$(printf '%s' "$found" | awk -F'\t' '{print $4}')"
+      canonical_payload="bash $installed_script"
+      if [[ "$existing_payload" == "[cron-dispatch]"* ]]; then
+        if [[ "$MODE" == "check" ]]; then
+          record "$BRIDGE_ADMIN_AGENT" "cron:$title" "drift-payload-pending" \
+            "id=$existing_id existing-prefix=[cron-dispatch] want=bash"
+          note_drift
+          return 0
+        fi
+        if [[ "$MODE" == "dry-run" ]]; then
+          record "$BRIDGE_ADMIN_AGENT" "cron:$title" "would-migrate-payload" \
+            "id=$existing_id [cron-dispatch] → bash $installed_script"
+          return 0
+        fi
+        if [[ -z "$existing_id" ]]; then
+          record "$BRIDGE_ADMIN_AGENT" "cron:$title" "migrate-payload-failed" \
+            "no id from cron_lookup; existing-prefix=[cron-dispatch]"
+          note_drift
+          return 0
+        fi
+        if [[ ! -x "$installed_script" ]]; then
+          # Script not yet installed (apply-step bootstrap_install_scripts
+          # may run after this). Defer: leave the stale payload, emit
+          # drift so the next run picks it up.
+          record "$BRIDGE_ADMIN_AGENT" "cron:$title" "migrate-payload-deferred" \
+            "id=$existing_id installed_script=$installed_script not-yet-executable"
+          note_drift
+          return 0
+        fi
+        if "$BRIDGE_AGB" cron update "$existing_id" \
+              --payload "$canonical_payload" \
+              >/dev/null 2>&1; then
+          record "$BRIDGE_ADMIN_AGENT" "cron:$title" "migrated-payload" \
+            "id=$existing_id [cron-dispatch] → bash"
+        else
+          record "$BRIDGE_ADMIN_AGENT" "cron:$title" "migrate-payload-failed" \
+            "id=$existing_id"
+          note_drift
+        fi
+        return 0
+      fi
       record "$BRIDGE_ADMIN_AGENT" "cron:$title" "already-registered" "$existing_sched tz=$effective_existing_tz"
       return 0
     fi


### PR DESCRIPTION
# [review] cron-payload-migration — Track A implementation

## Branch + commit

- Branch: `feat/cron-payload-migration` (off `origin/main` @ `2407af8` v0.7.6)
- Commit: `d02ee0e feat(bootstrap): migrate stale [cron-dispatch] cron payloads to canonical bash $script`
- Source tree: `~/agent-bridge-public`
- Files changed: `bootstrap-memory-system.sh` (+67 / -2)

## Scope (per your plan-ok @ task #19476)

Track A only. B and C are out per your veto. Five managed wiki/librarian crons migrate when payload starts with `[cron-dispatch]`:
wiki-mention-scan, wiki-daily-ingest, wiki-copy-full-backfill, librarian-watchdog, wiki-hub-audit.

## Two changes

### 1. `cron_lookup` extended — 3 cols → 4 cols

Was: `id<TAB>schedule<TAB>tz`. Now: `id<TAB>schedule<TAB>tz<TAB>payload_preview`. Verified `agent-bridge cron list --json` exposes `payload_preview` (~100-char truncation) on the live runtime and that's enough to gate on the `[cron-dispatch]` prefix without a second JSON round-trip. Tabs/newlines stripped from preview before printing so awk `-F'\t'` parsing in step_cron_one stays single-row.

### 2. `step_cron_one` — payload-migration block in the schedule+tz-match branch

Inserted *before* the existing `already-registered` line. Same 3-mode contract as the wiki-daily-ingest schedule-migration block right below it:
- `check` → records `drift-payload-pending` + `note_drift`
- `dry-run` → records `would-migrate-payload`
- `apply` → calls `agb cron update <id> --payload "bash $installed_script"`, records `migrated-payload`

Defensive guards:
- `existing_id` empty → `migrate-payload-failed` + drift
- `installed_script` not yet executable → `migrate-payload-deferred` + drift (handles ordering with bootstrap_install_scripts; payload migration retries on next bootstrap pass once the script is installed)

Operator-customized payloads (anything not starting with literal `[cron-dispatch]`) untouched — falls through to the existing `already-registered` path.

## Focus checklist

1. **Prefix exactness.** Does `[[ "$existing_payload" == "[cron-dispatch]"* ]]` correctly gate only on managed legacy payloads? I deliberately used the literal-string prefix (no `*` between `[` and `]`, no regex). Confirm this won't false-positive on operator payloads that *contain* the substring later in the body.
2. **payload_preview truncation.** Worst case: legacy payload starts with leading whitespace (e.g. `  [cron-dispatch] ...`). Should the prefix check be `lstrip()`-tolerant? Current code does not strip leading whitespace from preview before comparison. My read: bridge-cron emits payload verbatim and the legacy block always begins at column 0, so no strip needed. Confirm or veto.
3. **Ordering vs bootstrap_install_scripts.** I added `installed_script` executability guard so payload-migration is deferred when the script copy hasn't happened yet. Concretely: if step_cron_one runs *before* bootstrap_install_scripts on a fresh apply, deferral kicks in; on the next bootstrap pass the script is in place and migration proceeds. Is this ordering the actual layering at line 1054, or does step_cron_one always run after script copy? If the latter, the deferral branch is dead code — happy to drop it.
4. **note_drift call sites.** I emit `note_drift` for failure/deferred branches but NOT for the successful `migrated-payload` branch (consistent with the wiki-daily-ingest precedent at line 515-516). Confirm that's the convention you want.
5. **Wording.** Per your earlier nit, framed as "migrate stale managed payloads" not "shell-direct / no-LLM". Commit message and inline comments use that framing. Recheck.
6. **No new payload field break in `agent-bridge cron list --json`.** The 4th column is appended; existing callers reading 3 columns are unaffected by the bash awk parser. Confirm no other call site grabs `cron_lookup` output.

## Validation done

- `bash -n bootstrap-memory-system.sh` → OK
- `shellcheck -S warning bootstrap-memory-system.sh` → 0 warnings
- `./scripts/smoke-test.sh` → ran in isolated `BRIDGE_HOME` + `BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT`, passed every section through tmux pending-attention spool, then died at "updating shell integration managed block when repo path changes" — looks like a pre-existing isolated-environment expectation issue, **not** my diff. Worth a separate flag if you've seen it before.
- No new smoke test added for the migration scenario itself. Discuss: should I add `scripts/smoke/cron-payload-migration.sh` that stages a fake `[cron-dispatch]` payload and runs the bootstrap apply, asserting the audit emits `migrated-payload`? My lean: yes, but only after `implement-ok` to keep the diff focused. Veto if you want it in this PR.

## Validation NOT done

- Real-install rehearsal: I haven't run a clean install with a deliberately-staged `[cron-dispatch]` payload through `bootstrap-memory-system.sh --apply` to confirm the live update works. Plan to do this as the operator-side manual verification step before the PR merges. Flag if you want it before review.

## Expected response shape

- `implement-ok` — I'll push the branch, open the PR with this brief as the description, and run the manual verification rehearsal.
- `needs-more: <bullets>` — I'll address and resubmit as `[review] (r2)` with a fresh brief.

## Branch + push timing

Branch is committed locally only; not pushed yet. Will push after `implement-ok` so the GH PR matches the reviewed diff.

## Local install state for context

- Sean's install (this machine): I already manually migrated `wiki-mention-scan-180b0970` payload + reverted ownership librarian→patch + deleted the now-redundant `wiki-mention-scan-guard-c3bd9721` cron (per your veto on Track B/C). Bridge-daemon's existing consecutive-failure followup path takes over.
- Out of scope: Sean's other 4 managed wiki crons (wiki-daily-ingest, wiki-copy-full-backfill, librarian-watchdog, wiki-hub-audit) — I have not surveyed their payload state. Once this PR ships and the operator runs `agb upgrade`, the migration block will sweep them on the next bootstrap pass.
