### PR TITLE
Treat ms365 channel readiness as env-only

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4074,7 +4074,6 @@ bridge_agent_channel_runtime_ready_for_item() {
       ;;
     plugin:ms365|plugin:ms365@*)
       dir="$(bridge_agent_ms365_state_dir "$agent")"
-      [[ -f "$dir/access.json" ]] || return 1
       [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_CLIENT_ID)" == "present" ]] || return 1
       [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_CLIENT_SECRET)" == "present" ]] || return 1
       [[ "$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_TENANT_ID)" == "present" ]]
@@ -4204,6 +4203,12 @@ bridge_channel_access_status_for_item() {
   local access_file=""
 
   item="$(bridge_qualify_channel_item "$item")"
+  case "$item" in
+    plugin:ms365|plugin:ms365@*)
+      printf '%s' "n/a"
+      return 0
+      ;;
+  esac
   provider="$(bridge_channel_provider_for_item "$item")"
   dir="$(bridge_channel_state_dir_for_item "$agent" "$item")"
   [[ -n "$dir" ]] || {
@@ -5077,10 +5082,6 @@ bridge_agent_runtime_channel_status_reason() {
   if bridge_channel_csv_contains "$required" "plugin:ms365"; then
     local ms365_dir=""
     ms365_dir="$(bridge_agent_ms365_state_dir "$agent")"
-    if [[ ! -f "$ms365_dir/access.json" ]]; then
-      printf 'missing MS365 access file under %s (access.json required)' "$ms365_dir"
-      return 0
-    fi
     readiness="$(bridge_channel_env_file_readiness "$agent" "plugin:ms365" "$ms365_dir/.env" MS365_CLIENT_ID)"
     if [[ "$readiness" == "unreadable" ]]; then
       printf 'unreadable: MS365 .env under %s (ACL repair failed %s times; %s)' \

--- a/scripts/smoke/channel-env-readiness.sh
+++ b/scripts/smoke/channel-env-readiness.sh
@@ -280,11 +280,11 @@ assert_status_reason_unreadable_with_diagnostic() {
 
 assert_ms365_branch_covered() {
   # Set up: only ms365 required, .env present with valid keys. The new
-  # ms365 branch must process this without leaking through to the
-  # post-loop empty-string return — which historically meant ms365
-  # readiness was silently skipped.
+  # ms365 branch must process this without requiring access.json. Unlike
+  # Teams/Discord/Mattermost, ms365 is token/env based and has no allowlist
+  # access file in its runtime contract.
   mkdir -p "$MS365_DIR"
-  : >"$MS365_DIR/access.json"
+  rm -f "$MS365_DIR/access.json"
   write_present_ms365_env
   reset_repair_mock none
 
@@ -293,16 +293,19 @@ assert_ms365_branch_covered() {
 
   local reason
   reason="$(bridge_agent_runtime_channel_status_reason "$WORKER")"
-  smoke_assert_eq "" "$reason" "ms365 with all keys present produces empty status_reason (ok)"
+  smoke_assert_eq "" "$reason" "ms365 with all keys present and no access.json produces empty status_reason (ok)"
+  smoke_assert_eq "n/a" "$(bridge_channel_access_status_for_item "$WORKER" "plugin:ms365")" \
+    "ms365 reports access_status n/a because it has no access.json contract"
 
-  # Now break ms365 access.json — the new branch must surface that.
-  rm -f "$MS365_DIR/access.json"
+  # Now break the ms365 .env — the branch must surface that, proving it
+  # is not silently falling through after the access.json check was removed.
+  : >"$MS365_ENV"
   reason="$(bridge_agent_runtime_channel_status_reason "$WORKER")"
-  smoke_assert_contains "$reason" "missing MS365 access file" \
-    "ms365 branch surfaces missing access.json (proves branch is reached)"
+  smoke_assert_contains "$reason" "missing MS365 client id" \
+    "ms365 branch surfaces missing .env keys (proves branch is reached)"
 
   # Restore for unreadable-detection sub-check.
-  : >"$MS365_DIR/access.json"
+  write_present_ms365_env
   chmod 000 "$MS365_ENV"
   reset_repair_mock nop
   reason="$(bridge_agent_runtime_channel_status_reason "$WORKER")"


### PR DESCRIPTION
## Summary
- stop requiring `.ms365/access.json` for `plugin:ms365` readiness
- report ms365 access status as `n/a`, matching its token/env runtime contract
- update channel readiness smoke to cover ms365 without access.json while preserving missing/unreadable `.env` diagnostics

## Verification
- `bash -n lib/bridge-agents.sh scripts/smoke/channel-env-readiness.sh`
- `bash scripts/smoke/channel-env-readiness.sh`
- `git diff --check`

## Live validation
Applied as a live hotfix on the operator host: `sales_sean` channel readiness changed from ms365 `access_status=missing` to `access_status=n/a`, all required plugins became ready, and the Claude session started with teams/ms365/cosmax plugins listening.