### PR TITLE
Guard daemon state files under isolation

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -35,6 +35,14 @@ daemon_source_state_file() {
   local file="$1"
   local label="${2:-state}"
   local clear_on_error="${3:-0}"
+  # Optional 4th positional: whitespace-separated names of variables that MUST
+  # be non-empty after sourcing. Empty/truncated env files (e.g. a partially
+  # flushed write from an isolated UID) pass `bash -n` + `source` silently
+  # and would otherwise leave callers operating on stale or zero-valued vars.
+  # Callsites that genuinely tolerate "missing fields" (e.g. first-run
+  # daily-backup state) omit this argument.
+  local required_vars="${4:-}"
+  local var
 
   [[ -f "$file" ]] || return 1
   if [[ ! -r "$file" ]]; then
@@ -61,6 +69,18 @@ daemon_source_state_file() {
     fi
     return 1
   }
+
+  if [[ -n "$required_vars" ]]; then
+    for var in $required_vars; do
+      if [[ -z "${!var:-}" ]]; then
+        daemon_warn "${label} state file missing required var ${var}; ignoring: $file"
+        if [[ "$clear_on_error" == "1" ]]; then
+          rm -f "$file" >/dev/null 2>&1 || true
+        fi
+        return 1
+      fi
+    done
+  fi
 }
 
 # --- Daemon exit observability (issue #193) ----------------------------------
@@ -180,7 +200,7 @@ bridge_agent_heartbeat_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_agent_heartbeat_state_file "$agent")"
   [[ -f "$file" ]] || return 0
-  daemon_source_state_file "$file" "heartbeat" 1 || return 0
+  daemon_source_state_file "$file" "heartbeat" 1 "HEARTBEAT_NEXT_TS" || return 0
   [[ "${HEARTBEAT_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   next_ts="${HEARTBEAT_NEXT_TS:-0}"
   now="$(date +%s)"
@@ -314,7 +334,7 @@ bridge_usage_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_usage_poll_state_file)"
   [[ -f "$file" ]] || return 0
-  daemon_source_state_file "$file" "usage" 1 || return 0
+  daemon_source_state_file "$file" "usage" 1 "USAGE_NEXT_TS" || return 0
   [[ "${USAGE_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   now="$(date +%s)"
   next_ts="${USAGE_NEXT_TS:-0}"
@@ -379,7 +399,7 @@ bridge_release_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_release_poll_state_file)"
   [[ -f "$file" ]] || return 0
-  daemon_source_state_file "$file" "release" 1 || return 0
+  daemon_source_state_file "$file" "release" 1 "RELEASE_NEXT_TS" || return 0
   [[ "${RELEASE_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   now="$(date +%s)"
   next_ts="${RELEASE_NEXT_TS:-0}"
@@ -1586,7 +1606,7 @@ process_stall_reports() {
     matched_pattern=""
 
     if [[ -f "$state_file" ]]; then
-      if daemon_source_state_file "$state_file" "stall/$agent" 1; then
+      if daemon_source_state_file "$state_file" "stall/$agent" 1 "STALL_LAST_SCAN_TS"; then
         had_state=1
       fi
       active_classification="${STALL_ACTIVE_CLASSIFICATION:-}"
@@ -2053,7 +2073,7 @@ process_context_pressure_reports() {
     matched_pattern=""
 
     if [[ -f "$state_file" ]]; then
-      if daemon_source_state_file "$state_file" "context-pressure/$agent" 1; then
+      if daemon_source_state_file "$state_file" "context-pressure/$agent" 1 "CONTEXT_PRESSURE_LAST_SCAN_TS"; then
         had_state=1
       fi
       previous_severity="${CONTEXT_PRESSURE_SEVERITY:-}"
@@ -2208,7 +2228,7 @@ bridge_watchdog_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_watchdog_state_file)"
   [[ -f "$file" ]] || return 0
-  daemon_source_state_file "$file" "watchdog" 1 || return 0
+  daemon_source_state_file "$file" "watchdog" 1 "WATCHDOG_NEXT_TS" || return 0
   [[ "${WATCHDOG_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   now="$(date +%s)"
   next_ts="${WATCHDOG_NEXT_TS:-0}"
@@ -2280,7 +2300,7 @@ PY
   [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=86400
   now_ts="$(date +%s)"
   if [[ -f "$(bridge_watchdog_state_file)" ]]; then
-    daemon_source_state_file "$(bridge_watchdog_state_file)" "watchdog" 1 || true
+    daemon_source_state_file "$(bridge_watchdog_state_file)" "watchdog" 1 "WATCHDOG_LAST_REPORT_TS" || true
     last_key="${WATCHDOG_LAST_KEY:-}"
     last_report_ts="${WATCHDOG_LAST_REPORT_TS:-0}"
   fi
@@ -2402,7 +2422,7 @@ process_crash_reports() {
     launch_cmd=""
     error_hash=""
     reported_at=""
-    daemon_source_state_file "$report_file" "crash-report/$agent" 1 || continue
+    daemon_source_state_file "$report_file" "crash-report/$agent" 1 "CRASH_AGENT" || continue
     agent="${CRASH_AGENT:-$agent}"
     [[ -n "$agent" ]] || continue
     if ! bridge_agent_exists "$agent"; then
@@ -2425,7 +2445,7 @@ process_crash_reports() {
     ack_hash=""
     ack_ts=0
     if [[ -f "$state_file" ]]; then
-      daemon_source_state_file "$state_file" "crash-state/$agent" 1 || true
+      daemon_source_state_file "$state_file" "crash-state/$agent" 1 "CRASH_LAST_REPORT_TS" || true
       last_hash="${CRASH_LAST_HASH:-}"
       last_report_ts="${CRASH_LAST_REPORT_TS:-0}"
       ack_hash="${CRASH_ACK_HASH:-}"
@@ -2572,7 +2592,7 @@ bridge_daemon_autostart_allowed() {
 
   file="$(bridge_daemon_autostart_state_file "$agent")"
   [[ -f "$file" ]] || return 0
-  daemon_source_state_file "$file" "autostart/$agent" 1 || return 0
+  daemon_source_state_file "$file" "autostart/$agent" 1 "AUTO_START_NEXT_RETRY_TS" || return 0
   [[ "${AUTO_START_NEXT_RETRY_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   next_retry_ts="${AUTO_START_NEXT_RETRY_TS:-0}"
   now="$(date +%s)"
@@ -2591,7 +2611,7 @@ bridge_daemon_note_autostart_failure() {
   file="$(bridge_daemon_autostart_state_file "$agent")"
   mkdir -p "$(dirname "$file")"
   if [[ -f "$file" ]]; then
-    daemon_source_state_file "$file" "autostart/$agent" 1 || true
+    daemon_source_state_file "$file" "autostart/$agent" 1 "AUTO_START_NEXT_RETRY_TS" || true
   fi
   AUTO_START_FAIL_COUNT="${AUTO_START_FAIL_COUNT:-0}"
   [[ "$AUTO_START_FAIL_COUNT" =~ ^[0-9]+$ ]] || AUTO_START_FAIL_COUNT=0
@@ -2939,7 +2959,7 @@ bridge_report_channel_health_miss() {
   body_file="$(bridge_channel_health_body_file "$agent")"
 
   if [[ -f "$state_file" ]]; then
-    daemon_source_state_file "$state_file" "channel-health/$agent" 1 || true
+    daemon_source_state_file "$state_file" "channel-health/$agent" 1 "LAST_REPORT_TS" || true
     last_key="${LAST_KEY:-}"
     last_report_ts="${LAST_REPORT_TS:-0}"
   fi
@@ -3061,7 +3081,7 @@ bridge_report_plugin_liveness_miss() {
   [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=60
   state_file="$(bridge_plugin_liveness_state_file "$agent")"
   if [[ -f "$state_file" ]]; then
-    daemon_source_state_file "$state_file" "plugin-liveness/$agent" 1 || true
+    daemon_source_state_file "$state_file" "plugin-liveness/$agent" 1 "LAST_DETECTED_TS" || true
     last_key="${LAST_KEY:-}"
     last_detected_ts="${LAST_DETECTED_TS:-0}"
     last_restart_ts="${LAST_RESTART_TS:-0}"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -31,6 +31,38 @@ daemon_warn() {
   printf '[%s] [warn] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$message" >&2
 }
 
+daemon_source_state_file() {
+  local file="$1"
+  local label="${2:-state}"
+  local clear_on_error="${3:-0}"
+
+  [[ -f "$file" ]] || return 1
+  if [[ ! -r "$file" ]]; then
+    daemon_warn "${label} state file is unreadable; ignoring: $file"
+    if [[ "$clear_on_error" == "1" ]]; then
+      rm -f "$file" >/dev/null 2>&1 || true
+    fi
+    return 1
+  fi
+
+  if ! "${BASH:-bash}" -n "$file" >/dev/null 2>&1; then
+    daemon_warn "${label} state file has invalid shell syntax; ignoring: $file"
+    if [[ "$clear_on_error" == "1" ]]; then
+      rm -f "$file" >/dev/null 2>&1 || true
+    fi
+    return 1
+  fi
+
+  # shellcheck source=/dev/null
+  source "$file" 2>/dev/null || {
+    daemon_warn "${label} state file could not be sourced; ignoring: $file"
+    if [[ "$clear_on_error" == "1" ]]; then
+      rm -f "$file" >/dev/null 2>&1 || true
+    fi
+    return 1
+  }
+}
+
 # --- Daemon exit observability (issue #193) ----------------------------------
 # These traps guarantee every daemon exit path leaves a trail in both
 # $BRIDGE_LAUNCHAGENT_LOG and the audit log. Without this, silent exits
@@ -148,8 +180,7 @@ bridge_agent_heartbeat_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_agent_heartbeat_state_file "$agent")"
   [[ -f "$file" ]] || return 0
-  # shellcheck source=/dev/null
-  source "$file"
+  daemon_source_state_file "$file" "heartbeat" 1 || return 0
   [[ "${HEARTBEAT_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   next_ts="${HEARTBEAT_NEXT_TS:-0}"
   now="$(date +%s)"
@@ -283,8 +314,7 @@ bridge_usage_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_usage_poll_state_file)"
   [[ -f "$file" ]] || return 0
-  # shellcheck source=/dev/null
-  source "$file"
+  daemon_source_state_file "$file" "usage" 1 || return 0
   [[ "${USAGE_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   now="$(date +%s)"
   next_ts="${USAGE_NEXT_TS:-0}"
@@ -349,8 +379,7 @@ bridge_release_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_release_poll_state_file)"
   [[ -f "$file" ]] || return 0
-  # shellcheck source=/dev/null
-  source "$file"
+  daemon_source_state_file "$file" "release" 1 || return 0
   [[ "${RELEASE_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   now="$(date +%s)"
   next_ts="${RELEASE_NEXT_TS:-0}"
@@ -456,8 +485,7 @@ bridge_daily_backup_due() {
   DAILY_BACKUP_LAST_FAILURE_REASON=""
   DAILY_BACKUP_LAST_WARN_TS=""
   if [[ -f "$file" ]]; then
-    # shellcheck source=/dev/null
-    source "$file"
+    daemon_source_state_file "$file" "daily-backup" 0 || true
   fi
   if [[ "${DAILY_BACKUP_LAST_SUCCESS_DATE:-}" == "$today" ]]; then
     return 1
@@ -586,8 +614,7 @@ bridge_note_daily_backup_failure() {
   DAILY_BACKUP_LAST_ARCHIVE=""
   DAILY_BACKUP_LAST_PRUNED_COUNT=""
   if [[ -f "$file" ]]; then
-    # shellcheck source=/dev/null
-    source "$file"
+    daemon_source_state_file "$file" "daily-backup" 0 || true
   fi
   body="$(bridge_daily_backup_compose_state \
     --success-ts "${DAILY_BACKUP_LAST_SUCCESS_TS:-}" \
@@ -1559,9 +1586,9 @@ process_stall_reports() {
     matched_pattern=""
 
     if [[ -f "$state_file" ]]; then
-      had_state=1
-      # shellcheck source=/dev/null
-      source "$state_file"
+      if daemon_source_state_file "$state_file" "stall/$agent" 1; then
+        had_state=1
+      fi
       active_classification="${STALL_ACTIVE_CLASSIFICATION:-}"
       active_hash="${STALL_ACTIVE_EXCERPT_HASH:-}"
       active_matched_line_hash="${STALL_ACTIVE_MATCHED_LINE_HASH:-}"
@@ -2026,9 +2053,9 @@ process_context_pressure_reports() {
     matched_pattern=""
 
     if [[ -f "$state_file" ]]; then
-      had_state=1
-      # shellcheck source=/dev/null
-      source "$state_file"
+      if daemon_source_state_file "$state_file" "context-pressure/$agent" 1; then
+        had_state=1
+      fi
       previous_severity="${CONTEXT_PRESSURE_SEVERITY:-}"
       previous_hash="${CONTEXT_PRESSURE_EXCERPT_HASH:-}"
       first_detected_ts="${CONTEXT_PRESSURE_FIRST_DETECTED_TS:-0}"
@@ -2181,8 +2208,7 @@ bridge_watchdog_due() {
   (( interval > 0 )) || return 0
   file="$(bridge_watchdog_state_file)"
   [[ -f "$file" ]] || return 0
-  # shellcheck source=/dev/null
-  source "$file"
+  daemon_source_state_file "$file" "watchdog" 1 || return 0
   [[ "${WATCHDOG_NEXT_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   now="$(date +%s)"
   next_ts="${WATCHDOG_NEXT_TS:-0}"
@@ -2254,8 +2280,7 @@ PY
   [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=86400
   now_ts="$(date +%s)"
   if [[ -f "$(bridge_watchdog_state_file)" ]]; then
-    # shellcheck source=/dev/null
-    source "$(bridge_watchdog_state_file)"
+    daemon_source_state_file "$(bridge_watchdog_state_file)" "watchdog" 1 || true
     last_key="${WATCHDOG_LAST_KEY:-}"
     last_report_ts="${WATCHDOG_LAST_REPORT_TS:-0}"
   fi
@@ -2377,8 +2402,7 @@ process_crash_reports() {
     launch_cmd=""
     error_hash=""
     reported_at=""
-    # shellcheck source=/dev/null
-    source "$report_file"
+    daemon_source_state_file "$report_file" "crash-report/$agent" 1 || continue
     agent="${CRASH_AGENT:-$agent}"
     [[ -n "$agent" ]] || continue
     if ! bridge_agent_exists "$agent"; then
@@ -2401,8 +2425,7 @@ process_crash_reports() {
     ack_hash=""
     ack_ts=0
     if [[ -f "$state_file" ]]; then
-      # shellcheck source=/dev/null
-      source "$state_file"
+      daemon_source_state_file "$state_file" "crash-state/$agent" 1 || true
       last_hash="${CRASH_LAST_HASH:-}"
       last_report_ts="${CRASH_LAST_REPORT_TS:-0}"
       ack_hash="${CRASH_ACK_HASH:-}"
@@ -2549,8 +2572,7 @@ bridge_daemon_autostart_allowed() {
 
   file="$(bridge_daemon_autostart_state_file "$agent")"
   [[ -f "$file" ]] || return 0
-  # shellcheck source=/dev/null
-  source "$file"
+  daemon_source_state_file "$file" "autostart/$agent" 1 || return 0
   [[ "${AUTO_START_NEXT_RETRY_TS:-0}" =~ ^[0-9]+$ ]] || return 0
   next_retry_ts="${AUTO_START_NEXT_RETRY_TS:-0}"
   now="$(date +%s)"
@@ -2569,8 +2591,7 @@ bridge_daemon_note_autostart_failure() {
   file="$(bridge_daemon_autostart_state_file "$agent")"
   mkdir -p "$(dirname "$file")"
   if [[ -f "$file" ]]; then
-    # shellcheck source=/dev/null
-    source "$file"
+    daemon_source_state_file "$file" "autostart/$agent" 1 || true
   fi
   AUTO_START_FAIL_COUNT="${AUTO_START_FAIL_COUNT:-0}"
   [[ "$AUTO_START_FAIL_COUNT" =~ ^[0-9]+$ ]] || AUTO_START_FAIL_COUNT=0
@@ -2918,8 +2939,7 @@ bridge_report_channel_health_miss() {
   body_file="$(bridge_channel_health_body_file "$agent")"
 
   if [[ -f "$state_file" ]]; then
-    # shellcheck source=/dev/null
-    source "$state_file"
+    daemon_source_state_file "$state_file" "channel-health/$agent" 1 || true
     last_key="${LAST_KEY:-}"
     last_report_ts="${LAST_REPORT_TS:-0}"
   fi
@@ -3041,8 +3061,7 @@ bridge_report_plugin_liveness_miss() {
   [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=60
   state_file="$(bridge_plugin_liveness_state_file "$agent")"
   if [[ -f "$state_file" ]]; then
-    # shellcheck source=/dev/null
-    source "$state_file"
+    daemon_source_state_file "$state_file" "plugin-liveness/$agent" 1 || true
     last_key="${LAST_KEY:-}"
     last_detected_ts="${LAST_DETECTED_TS:-0}"
     last_restart_ts="${LAST_RESTART_TS:-0}"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -42,7 +42,22 @@ daemon_source_state_file() {
   # Callsites that genuinely tolerate "missing fields" (e.g. first-run
   # daily-backup state) omit this argument.
   local required_vars="${4:-}"
+  # Optional 5th positional: whitespace-separated names of every variable
+  # the file is expected to define. These are unset BEFORE sourcing so a
+  # failed source (unreadable, invalid syntax, missing required var, or
+  # missing field) cannot leak previously-sourced values from an earlier
+  # caller (e.g. a different agent in the same per-loop-iteration scan)
+  # into the post-call read. The required_vars list is implicitly part of
+  # this set; callers may list it in either argument. (#576 r3 Finding 1)
+  local sanitize_vars="${5:-}"
   local var
+
+  # Sanitize required + caller-declared family BEFORE any of the early-return
+  # paths below: an unreadable / syntactically invalid file must not leave
+  # stale values from a prior successful source still in scope.
+  for var in $required_vars $sanitize_vars; do
+    unset "$var"
+  done
 
   [[ -f "$file" ]] || return 1
   if [[ ! -r "$file" ]]; then
@@ -1606,7 +1621,8 @@ process_stall_reports() {
     matched_pattern=""
 
     if [[ -f "$state_file" ]]; then
-      if daemon_source_state_file "$state_file" "stall/$agent" 1 "STALL_LAST_SCAN_TS"; then
+      if daemon_source_state_file "$state_file" "stall/$agent" 1 "STALL_LAST_SCAN_TS" \
+          "STALL_ACTIVE_CLASSIFICATION STALL_ACTIVE_EXCERPT_HASH STALL_ACTIVE_MATCHED_LINE_HASH STALL_FIRST_DETECTED_TS STALL_LAST_DETECTED_TS STALL_NUDGE_COUNT STALL_LAST_NUDGE_TS STALL_ESCALATED_TS STALL_TASK_ID STALL_MATCHED_PATTERN"; then
         had_state=1
       fi
       active_classification="${STALL_ACTIVE_CLASSIFICATION:-}"
@@ -2073,7 +2089,8 @@ process_context_pressure_reports() {
     matched_pattern=""
 
     if [[ -f "$state_file" ]]; then
-      if daemon_source_state_file "$state_file" "context-pressure/$agent" 1 "CONTEXT_PRESSURE_LAST_SCAN_TS"; then
+      if daemon_source_state_file "$state_file" "context-pressure/$agent" 1 "CONTEXT_PRESSURE_LAST_SCAN_TS" \
+          "CONTEXT_PRESSURE_SEVERITY CONTEXT_PRESSURE_EXCERPT_HASH CONTEXT_PRESSURE_FIRST_DETECTED_TS CONTEXT_PRESSURE_LAST_DETECTED_TS CONTEXT_PRESSURE_LAST_REPORT_TS CONTEXT_PRESSURE_MATCHED_PATTERN"; then
         had_state=1
       fi
       previous_severity="${CONTEXT_PRESSURE_SEVERITY:-}"
@@ -2445,7 +2462,9 @@ process_crash_reports() {
     ack_hash=""
     ack_ts=0
     if [[ -f "$state_file" ]]; then
-      daemon_source_state_file "$state_file" "crash-state/$agent" 1 "CRASH_LAST_REPORT_TS" || true
+      daemon_source_state_file "$state_file" "crash-state/$agent" 1 "CRASH_LAST_REPORT_TS" \
+          "CRASH_LAST_HASH CRASH_ACK_HASH CRASH_ACK_TS" \
+        || true
       last_hash="${CRASH_LAST_HASH:-}"
       last_report_ts="${CRASH_LAST_REPORT_TS:-0}"
       ack_hash="${CRASH_ACK_HASH:-}"
@@ -2611,7 +2630,14 @@ bridge_daemon_note_autostart_failure() {
   file="$(bridge_daemon_autostart_state_file "$agent")"
   mkdir -p "$(dirname "$file")"
   if [[ -f "$file" ]]; then
-    daemon_source_state_file "$file" "autostart/$agent" 1 "AUTO_START_NEXT_RETRY_TS" || true
+    daemon_source_state_file "$file" "autostart/$agent" 1 "AUTO_START_NEXT_RETRY_TS" \
+        "AUTO_START_FAIL_COUNT AUTO_START_LAST_REASON" \
+      || true
+  else
+    # No state file means a fresh agent or a cleared backoff — wipe any
+    # AUTO_START_* values left over from a different agent in this same
+    # daemon process so the new fail_count counter starts at 0. (#576 r3)
+    unset AUTO_START_FAIL_COUNT AUTO_START_NEXT_RETRY_TS AUTO_START_LAST_REASON
   fi
   AUTO_START_FAIL_COUNT="${AUTO_START_FAIL_COUNT:-0}"
   [[ "$AUTO_START_FAIL_COUNT" =~ ^[0-9]+$ ]] || AUTO_START_FAIL_COUNT=0
@@ -2959,7 +2985,9 @@ bridge_report_channel_health_miss() {
   body_file="$(bridge_channel_health_body_file "$agent")"
 
   if [[ -f "$state_file" ]]; then
-    daemon_source_state_file "$state_file" "channel-health/$agent" 1 "LAST_REPORT_TS" || true
+    daemon_source_state_file "$state_file" "channel-health/$agent" 1 "LAST_REPORT_TS" \
+        "LAST_KEY" \
+      || true
     last_key="${LAST_KEY:-}"
     last_report_ts="${LAST_REPORT_TS:-0}"
   fi
@@ -3081,7 +3109,9 @@ bridge_report_plugin_liveness_miss() {
   [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=60
   state_file="$(bridge_plugin_liveness_state_file "$agent")"
   if [[ -f "$state_file" ]]; then
-    daemon_source_state_file "$state_file" "plugin-liveness/$agent" 1 "LAST_DETECTED_TS" || true
+    daemon_source_state_file "$state_file" "plugin-liveness/$agent" 1 "LAST_DETECTED_TS" \
+        "LAST_KEY LAST_RESTART_TS" \
+      || true
     last_key="${LAST_KEY:-}"
     last_detected_ts="${LAST_DETECTED_TS:-0}"
     last_restart_ts="${LAST_RESTART_TS:-0}"

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -2,14 +2,23 @@
 # shellcheck shell=bash disable=SC2034
 
 if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
-  for bridge_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
-    [[ -n "$bridge_candidate_bash" && -x "$bridge_candidate_bash" ]] || continue
-    if "$bridge_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
-      exec "$bridge_candidate_bash" "$0" "$@"
-    fi
-  done
+  # Re-exec into a Bash 4+ candidate, but ONLY when $0 names a regular file
+  # we can hand back to the new shell. When bridge-lib.sh is sourced from a
+  # `bash -lc '...' _ args` invocation (e.g. inside scripts/smoke/daemon.sh
+  # subshells), $0 is `_`, which isn't a script — exec'ing it produces the
+  # cryptic `_: No such file or directory` from the candidate shell instead
+  # of the real "requires Bash 4+" message. Fail loud in that path. (#576 r3
+  # Finding 3)
+  if [[ -f "$0" ]]; then
+    for bridge_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+      [[ -n "$bridge_candidate_bash" && -x "$bridge_candidate_bash" ]] || continue
+      if "$bridge_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$bridge_candidate_bash" "$0" "$@"
+      fi
+    done
+  fi
 
-  echo "[bridge-lib] Agent Bridge requires Bash 4+ (current: ${BASH_VERSION:-unknown})." >&2
+  echo "[bridge-lib] Agent Bridge requires Bash 4+ (current: ${BASH_VERSION:-unknown}). Re-run with a Bash 4+ shell on PATH (e.g. \`/opt/homebrew/bin/bash <script>\`)." >&2
   exit 1
 fi
 

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash disable=SC2034
 
+# Resolve the re-exec target before any guard logic, since $0 is unreliable
+# under macOS /bin/bash invocations like `bash -lc '...' _ args` (where $0
+# is the placeholder `_`). Prefer the caller script that sourced us
+# (BASH_SOURCE[1] — e.g. bridge-daemon.sh / agent-bridge), fall back to
+# bridge-lib.sh itself if invoked directly. (#576 r4 Finding 3)
+_BRIDGE_LIB_REEXEC_TARGET="${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}"
+
 if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
-  # Re-exec into a Bash 4+ candidate, but ONLY when $0 names a regular file
-  # we can hand back to the new shell. When bridge-lib.sh is sourced from a
-  # `bash -lc '...' _ args` invocation (e.g. inside scripts/smoke/daemon.sh
-  # subshells), $0 is `_`, which isn't a script — exec'ing it produces the
-  # cryptic `_: No such file or directory` from the candidate shell instead
-  # of the real "requires Bash 4+" message. Fail loud in that path. (#576 r3
-  # Finding 3)
-  if [[ -f "$0" ]]; then
+  # Re-exec into a Bash 4+ candidate, but ONLY when the resolved target
+  # names a regular file we can hand back to the new shell. If the target
+  # cannot be resolved (e.g. sourced from `bash -c` with no caller script),
+  # fall through to the "requires Bash 4+" message rather than handing the
+  # candidate shell a path it cannot open.
+  if [[ -f "$_BRIDGE_LIB_REEXEC_TARGET" ]]; then
     for bridge_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
       [[ -n "$bridge_candidate_bash" && -x "$bridge_candidate_bash" ]] || continue
       if "$bridge_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
-        exec "$bridge_candidate_bash" "$0" "$@"
+        exec "$bridge_candidate_bash" "$_BRIDGE_LIB_REEXEC_TARGET" "$@"
       fi
     done
   fi

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2982,7 +2982,7 @@ bridge_linux_prepare_agent_isolation() {
     bridge_linux_sudo_root setfacl -d -m "u:${controller_user}:r-X" "$queue_gateway_root" >/dev/null 2>&1 || true
   fi
   bridge_linux_acl_add_recursive "u:${controller_user}:rwX" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
-  bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:rwX" "$queue_gateway_agent_dir" "$request_dir" "$response_dir"
+  bridge_linux_acl_add_default_dirs_recursive "u:${controller_user}:rwX" "$runtime_state_dir" "$log_dir" "$queue_gateway_agent_dir" "$request_dir" "$response_dir" "$memory_daily_agent_dir" "$memory_daily_shared_aggregate_dir"
 
   # memory-daily transcripts read-access (issue #219 v1.3): grant the
   # controller user r-X on the isolated user's ~/.claude/projects/ so the

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2172,8 +2172,15 @@ bridge_agent_ack_crash_report() {
 
   report_file="$(bridge_agent_crash_report_file "$agent")"
   if [[ -f "$report_file" ]]; then
+    if ! "${BASH:-bash}" -n "$report_file" >/dev/null 2>&1; then
+      bridge_agent_clear_crash_report "$agent" >/dev/null 2>&1 || true
+      return 1
+    fi
     # shellcheck source=/dev/null
-    source "$report_file"
+    source "$report_file" 2>/dev/null || {
+      bridge_agent_clear_crash_report "$agent" >/dev/null 2>&1 || true
+      return 1
+    }
     if [[ -n "${CRASH_AGENT:-}" && "$CRASH_AGENT" != "$agent" ]]; then
       return 1
     fi
@@ -2181,8 +2188,14 @@ bridge_agent_ack_crash_report() {
 
   state_file="$(bridge_agent_crash_state_file "$agent")"
   if [[ -f "$state_file" ]]; then
-    # shellcheck source=/dev/null
-    source "$state_file"
+    if ! "${BASH:-bash}" -n "$state_file" >/dev/null 2>&1; then
+      rm -f "$state_file" >/dev/null 2>&1 || true
+    else
+      # shellcheck source=/dev/null
+      source "$state_file" 2>/dev/null || {
+        rm -f "$state_file" >/dev/null 2>&1 || true
+      }
+    fi
   fi
 
   # Fall back to whatever hash state.env last recorded when report.env
@@ -2235,7 +2248,10 @@ bridge_agent_idle_since_epoch() {
 
   file="$(bridge_agent_idle_since_file "$agent")"
   [[ -f "$file" ]] || return 1
-  value="$(<"$file")"
+  value="$(cat "$file" 2>/dev/null)" || {
+    bridge_agent_clear_idle_marker "$agent" >/dev/null 2>&1 || true
+    return 1
+  }
   [[ "$value" =~ ^[0-9]+$ ]] || return 1
   printf '%s' "$value"
 }
@@ -2252,7 +2268,10 @@ bridge_agent_manual_stop_active() {
 
   file="$(bridge_agent_manual_stop_file "$agent")"
   [[ -f "$file" ]] || return 1
-  value="$(<"$file")"
+  value="$(cat "$file" 2>/dev/null)" || {
+    bridge_agent_clear_manual_stop "$agent" >/dev/null 2>&1 || true
+    return 1
+  }
   [[ "$value" =~ ^[0-9]+$ ]]
 }
 
@@ -2314,7 +2333,10 @@ bridge_reconcile_idle_markers() {
       continue
     fi
 
-    value="$(<"$file")"
+    value="$(cat "$file" 2>/dev/null)" || {
+      bridge_agent_clear_idle_marker "$agent" >/dev/null 2>&1 || true
+      continue
+    }
     if ! [[ "$value" =~ ^[0-9]+$ ]]; then
       bridge_agent_clear_idle_marker "$agent"
     fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -515,6 +515,10 @@ bridge_agent_source() { printf "%s" "$agent_source_mode"; }
 bridge_queue_cli() { echo "bridge_queue_cli should not be called"; exit 99; }
 bridge_notify_send() { echo "bridge_notify_send should not be called"; exit 99; }
 daemon_info() { :; }
+daemon_source_state_file() {
+  # shellcheck source=/dev/null
+  source "$1" 2>/dev/null
+}
 
 # shellcheck disable=SC1090
 source "$helper"

--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -377,11 +377,134 @@ fi
   exit 1
 }
 
+# required-vars guard: empty file passes bash -n + source but must be
+# rejected when caller declares a required variable. This is the
+# isolated-UID partial-flush case the round-1 review flagged.
+: >"$state_file"
+unset STATE_NEXT_TS
+if daemon_source_state_file "$state_file" "unit" 1 "STATE_NEXT_TS"; then
+  echo "empty state with required var unexpectedly sourced"
+  exit 1
+fi
+[[ ! -e "$state_file" ]] || {
+  echo "empty state with required var was not cleared"
+  exit 1
+}
+
+# required-vars guard: a file populated only with unrelated vars must be
+# rejected when the caller declares a different required var.
+printf "OTHER_VAR=1\n" >"$state_file"
+unset STATE_NEXT_TS
+if daemon_source_state_file "$state_file" "unit" 1 "STATE_NEXT_TS"; then
+  echo "missing required var unexpectedly sourced"
+  exit 1
+fi
+[[ ! -e "$state_file" ]] || {
+  echo "state with missing required var was not cleared"
+  exit 1
+}
+
+# required-vars guard: when the required var is present, the source
+# call must succeed and the var must be exported into the caller scope.
+printf "STATE_NEXT_TS=999\n" >"$state_file"
+unset STATE_NEXT_TS
+daemon_source_state_file "$state_file" "unit" 1 "STATE_NEXT_TS"
+[[ "${STATE_NEXT_TS:-}" == "999" ]] || {
+  echo "required var present did not source"
+  exit 1
+}
+
 echo ok
 ' _ "$root" "$helper" 2>/dev/null)"
   rc=$?
   set -e
   [[ "$rc" -eq 0 && "$output" == "ok" ]] || smoke_fail "source state file guard failed: $output"
+}
+
+daemon_acl_default_inheritance() {
+  # Verifies the core correctness claim of this PR: when the controller
+  # installs a default ACL on a runtime_state_dir / log_dir-style
+  # directory, files subsequently created inside that directory by an
+  # isolated UID inherit the default ACL and remain controller-readable.
+  # Without the default ACL, controller reads return EACCES (the bug
+  # this PR is meant to prevent).
+  #
+  # Two-UID + setfacl is required, and elevated privileges (root or a
+  # configured sudoers entry) to switch UIDs. Skip cleanly otherwise so
+  # the test runs on platforms that support it (linux server install)
+  # without breaking dev-box smoke runs (macOS, unprivileged CI).
+  local isolated_user="" controller_user="" root="" target_dir=""
+  local positive_file="" negative_dir="" negative_file=""
+  local rc
+
+  if ! command -v setfacl >/dev/null 2>&1; then
+    smoke_log "skipped acl default inheritance: setfacl not available (requires Linux + acl pkg)"
+    return 0
+  fi
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    smoke_log "skipped acl default inheritance: requires root to switch UIDs"
+    return 0
+  fi
+  controller_user="$(id -un)"
+  for candidate in nobody daemon bin; do
+    if id -u "$candidate" >/dev/null 2>&1; then
+      isolated_user="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$isolated_user" ]]; then
+    smoke_log "skipped acl default inheritance: no isolated user candidate (nobody/daemon/bin) on this host"
+    return 0
+  fi
+  if [[ "$isolated_user" == "$controller_user" ]]; then
+    smoke_log "skipped acl default inheritance: controller user matches isolated user"
+    return 0
+  fi
+
+  root="$(mktemp -d "$SMOKE_TMP_ROOT/acl-default.XXXXXX")"
+  target_dir="$root/with-default-acl"
+  negative_dir="$root/without-default-acl"
+  mkdir -p "$target_dir" "$negative_dir"
+  # Mimic isolated-UID-only ownership: the isolated agent owns the
+  # directory and group/other have no access. Default ACLs are the only
+  # path by which the controller can ever read the contents.
+  chown "$isolated_user":"$isolated_user" "$target_dir" "$negative_dir"
+  chmod 700 "$target_dir" "$negative_dir"
+
+  # Install the default ACL on the positive-case directory. This is the
+  # exact shape lib/bridge-agents.sh::bridge_linux_acl_add_default_dirs_recursive
+  # applies (setfacl -d -m u:<controller>:rwX), narrowed to one dir.
+  setfacl -d -m "u:${controller_user}:rwX" "$target_dir" \
+    || smoke_fail "acl default inheritance: setfacl -d failed on $target_dir"
+
+  # Simulated isolated-UID write into both directories.
+  positive_file="$target_dir/idle-since"
+  negative_file="$negative_dir/idle-since"
+  sudo -n -u "$isolated_user" /bin/sh -c "printf '%s' \"123\" >'$positive_file'" \
+    || smoke_fail "acl default inheritance: isolated UID could not write positive file"
+  sudo -n -u "$isolated_user" /bin/sh -c "printf '%s' \"123\" >'$negative_file'" \
+    || smoke_fail "acl default inheritance: isolated UID could not write negative file"
+
+  # Positive case: controller (test driver) must be able to read the
+  # file the isolated UID just created. This is the inheritance guarantee.
+  set +e
+  cat "$positive_file" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" -eq 0 ]] \
+    || smoke_fail "acl default inheritance: controller could not read isolated-UID file under default ACL (rc=$rc)"
+
+  # Negative case: same setup without the default ACL must reject the
+  # controller. If this passes silently, the positive case is not
+  # actually exercising the ACL — it's just chmod 755 by accident.
+  set +e
+  cat "$negative_file" >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" -ne 0 ]] \
+    || smoke_fail "acl default inheritance: controller unexpectedly read file without default ACL (test setup is not exercising ACL)"
+
+  smoke_log "ok: acl default inheritance positive+negative confirmed (controller=$controller_user, isolated=$isolated_user)"
 }
 
 main() {
@@ -395,6 +518,7 @@ main() {
   smoke_run "blocked task reminder/escalation aging" daemon_blocked_aging
   smoke_run "idle marker permission guard" daemon_idle_marker_permission_guard
   smoke_run "source state file guard" daemon_source_state_file_guard
+  smoke_run "acl default inheritance" daemon_acl_default_inheritance
   smoke_log "passed"
 }
 

--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -122,6 +122,10 @@ bridge_agent_source() { printf "%s" "$agent_source_mode"; }
 bridge_queue_cli() { echo "bridge_queue_cli should not be called"; exit 99; }
 bridge_notify_send() { echo "bridge_notify_send should not be called"; exit 99; }
 daemon_info() { :; }
+daemon_source_state_file() {
+  # shellcheck source=/dev/null
+  source "$1" 2>/dev/null
+}
 
 # shellcheck disable=SC1090
 source "$helper"
@@ -254,6 +258,132 @@ EOF
   smoke_assert_match "$reminder_id" '^[0-9]+$' "daemon blocked-aging escalation task"
 }
 
+daemon_idle_marker_permission_guard() {
+  local agent dir idle_file manual_file output rc
+
+  agent="idle-acl-agent"
+  dir="$BRIDGE_ACTIVE_AGENT_DIR/$agent"
+  idle_file="$dir/idle-since"
+  manual_file="$dir/manual-stop"
+  mkdir -p "$dir"
+
+  set +e
+  output="$("$BASH" -lc '
+set -euo pipefail
+repo_root="$1"
+agent="$2"
+idle_file="$3"
+manual_file="$4"
+# shellcheck disable=SC1090
+source "$repo_root/bridge-lib.sh"
+
+BRIDGE_AGENT_IDS=("$agent")
+bridge_agent_is_active() { return 0; }
+
+printf "123\n" >"$idle_file"
+chmod 000 "$idle_file"
+if bridge_agent_idle_since_epoch "$agent"; then
+  echo "idle epoch unexpectedly succeeded"
+  exit 1
+fi
+[[ ! -e "$idle_file" ]] || {
+  echo "unreadable idle marker was not cleared"
+  exit 1
+}
+
+mkdir -p "$(dirname "$manual_file")"
+printf "123\n" >"$manual_file"
+chmod 000 "$manual_file"
+if bridge_agent_manual_stop_active "$agent"; then
+  echo "manual-stop unexpectedly succeeded"
+  exit 1
+fi
+[[ ! -e "$manual_file" ]] || {
+  echo "unreadable manual-stop marker was not cleared"
+  exit 1
+}
+
+mkdir -p "$(dirname "$idle_file")"
+printf "123\n" >"$idle_file"
+chmod 000 "$idle_file"
+bridge_reconcile_idle_markers
+[[ ! -e "$idle_file" ]] || {
+  echo "unreadable idle marker survived reconcile"
+  exit 1
+}
+
+echo ok
+' _ "$SMOKE_REPO_ROOT" "$agent" "$idle_file" "$manual_file" 2>&1)"
+  rc=$?
+  set -e
+  chmod 600 "$idle_file" "$manual_file" >/dev/null 2>&1 || true
+  rm -f "$idle_file" "$manual_file" >/dev/null 2>&1 || true
+  [[ "$rc" -eq 0 && "$output" == "ok" ]] || smoke_fail "idle marker permission guard failed: $output"
+}
+
+daemon_source_state_file_guard() {
+  local root helper output rc bash_bin
+
+  root="$(mktemp -d "$SMOKE_TMP_ROOT/source-state-unit.XXXXXX")"
+  helper="$root/daemon-source-state-file.sh"
+  awk '
+    /^daemon_source_state_file\(\) \{/ { capture=1 }
+    capture { print }
+    capture && /^}[[:space:]]*$/ { exit }
+  ' "$SMOKE_REPO_ROOT/bridge-daemon.sh" >"$helper"
+  [[ -s "$helper" ]] || smoke_fail "source-state: could not extract daemon_source_state_file"
+
+  bash_bin="${BASH4_BIN:-}"
+  if [[ -z "$bash_bin" || ! -x "$bash_bin" ]]; then
+    bash_bin="$(command -v bash)"
+  fi
+
+  set +e
+  output="$("$bash_bin" -lc '
+set -euo pipefail
+root="$1"
+helper="$2"
+daemon_warn() { printf "warn:%s\n" "$1" >&2; }
+# shellcheck disable=SC1090
+source "$helper"
+
+state_file="$root/state.env"
+printf "STATE_NEXT_TS=123\n" >"$state_file"
+STATE_NEXT_TS=0
+daemon_source_state_file "$state_file" "unit" 1
+[[ "${STATE_NEXT_TS:-}" == "123" ]] || {
+  echo "readable state did not source"
+  exit 1
+}
+
+printf "STATE_NEXT_TS=456\n" >"$state_file"
+chmod 000 "$state_file"
+if daemon_source_state_file "$state_file" "unit" 1; then
+  echo "unreadable state unexpectedly sourced"
+  exit 1
+fi
+[[ ! -e "$state_file" ]] || {
+  echo "unreadable state was not cleared"
+  exit 1
+}
+
+printf "STATE_NEXT_TS=\$(\n" >"$state_file"
+if daemon_source_state_file "$state_file" "unit" 1; then
+  echo "invalid state unexpectedly sourced"
+  exit 1
+fi
+[[ ! -e "$state_file" ]] || {
+  echo "invalid state was not cleared"
+  exit 1
+}
+
+echo ok
+' _ "$root" "$helper" 2>/dev/null)"
+  rc=$?
+  set -e
+  [[ "$rc" -eq 0 && "$output" == "ok" ]] || smoke_fail "source state file guard failed: $output"
+}
+
 main() {
   smoke_require_cmd awk
   smoke_require_cmd python3
@@ -263,6 +393,8 @@ main() {
   smoke_run "context pressure audit/state transitions" daemon_context_pressure_audit_state_transitions
   smoke_run "stale claimed tasks requeue deterministically" daemon_stale_claim_requeue
   smoke_run "blocked task reminder/escalation aging" daemon_blocked_aging
+  smoke_run "idle marker permission guard" daemon_idle_marker_permission_guard
+  smoke_run "source state file guard" daemon_source_state_file_guard
   smoke_log "passed"
 }
 

--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -5,14 +5,20 @@
 # `./scripts/smoke/daemon.sh` direct invocation through `/usr/bin/env bash`
 # may resolve to /bin/bash. Re-exec into a Bash 4+ candidate when needed
 # so the resulting subshells (and the bridge-lib.sh re-exec guard, which
-# sees $0 as the smoke script path) all run on Bash 4+. (#576 r3 Finding 3)
+# sees $0 as the smoke script path) all run on Bash 4+. Capture
+# BASH_SOURCE[0] before any re-exec — $0 is unreliable under macOS
+# /bin/bash invocations like `bash -lc '...' _` where it expands to `_`.
+# (#576 r4 Finding 3)
+_SMOKE_DAEMON_REEXEC_TARGET="${BASH_SOURCE[0]}"
 if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
-  for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
-    [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
-    if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
-      exec "$smoke_candidate_bash" "$0" "$@"
-    fi
-  done
+  if [[ -f "$_SMOKE_DAEMON_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_DAEMON_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
   echo "[smoke:daemon] requires Bash 4+; install homebrew bash or set BASH4_BIN to a Bash 4+ binary." >&2
   exit 1
 fi

--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
 
+# This smoke depends on Bash 4+ behavior in bridge-lib.sh and in helpers
+# extracted from bridge-daemon.sh. macOS ships Bash 3.2 by default, so
+# `./scripts/smoke/daemon.sh` direct invocation through `/usr/bin/env bash`
+# may resolve to /bin/bash. Re-exec into a Bash 4+ candidate when needed
+# so the resulting subshells (and the bridge-lib.sh re-exec guard, which
+# sees $0 as the smoke script path) all run on Bash 4+. (#576 r3 Finding 3)
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+    [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+    if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$smoke_candidate_bash" "$0" "$@"
+    fi
+  done
+  echo "[smoke:daemon] requires Bash 4+; install homebrew bash or set BASH4_BIN to a Bash 4+ binary." >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 SMOKE_NAME="daemon"
@@ -414,6 +431,47 @@ daemon_source_state_file "$state_file" "unit" 1 "STATE_NEXT_TS"
   exit 1
 }
 
+# Finding 1 (#576 r3) regression: a successful source from agent A must
+# not leak vars into agent B when agent B'\''s file fails to source.
+# Mirrors the per-loop scan pattern in bridge_scan_stall_state /
+# bridge_scan_context_pressure where the post-call read happens
+# unconditionally regardless of source rc.
+agent_a="$root/agent-a.env"
+agent_b="$root/agent-b.env"
+printf "STALL_LAST_SCAN_TS=111\nSTALL_ACTIVE_CLASSIFICATION=foo\n" >"$agent_a"
+unset STALL_LAST_SCAN_TS STALL_ACTIVE_CLASSIFICATION
+daemon_source_state_file "$agent_a" "stall/A" 1 "STALL_LAST_SCAN_TS" "STALL_ACTIVE_CLASSIFICATION"
+[[ "${STALL_LAST_SCAN_TS:-}" == "111" ]] || { echo "agent-A scan-ts did not source"; exit 1; }
+[[ "${STALL_ACTIVE_CLASSIFICATION:-}" == "foo" ]] || { echo "agent-A classification did not source"; exit 1; }
+
+# Agent B does not exist. The helper must fail AND clear all sanitize_vars
+# so the post-call read does not see agent A'\''s "foo".
+if daemon_source_state_file "$agent_b" "stall/B" 0 "STALL_LAST_SCAN_TS" "STALL_ACTIVE_CLASSIFICATION"; then
+  echo "missing state file unexpectedly sourced"
+  exit 1
+fi
+[[ -z "${STALL_LAST_SCAN_TS:-}" ]] || { echo "STALL_LAST_SCAN_TS leaked from agent-A: ${STALL_LAST_SCAN_TS}"; exit 1; }
+[[ -z "${STALL_ACTIVE_CLASSIFICATION:-}" ]] || { echo "STALL_ACTIVE_CLASSIFICATION leaked from agent-A: ${STALL_ACTIVE_CLASSIFICATION}"; exit 1; }
+
+# Same pattern but with an unreadable file (the actual reproduction of
+# the live bug — isolated UID writes a 0600 file, controller cannot read).
+printf "STALL_LAST_SCAN_TS=111\nSTALL_ACTIVE_CLASSIFICATION=bar\n" >"$agent_a"
+chmod 600 "$agent_a"
+unset STALL_LAST_SCAN_TS STALL_ACTIVE_CLASSIFICATION
+daemon_source_state_file "$agent_a" "stall/A" 0 "STALL_LAST_SCAN_TS" "STALL_ACTIVE_CLASSIFICATION"
+[[ "${STALL_ACTIVE_CLASSIFICATION:-}" == "bar" ]] || { echo "agent-A re-source did not pick up bar"; exit 1; }
+
+agent_c="$root/agent-c.env"
+: >"$agent_c"
+chmod 000 "$agent_c"
+if daemon_source_state_file "$agent_c" "stall/C" 0 "STALL_LAST_SCAN_TS" "STALL_ACTIVE_CLASSIFICATION"; then
+  echo "unreadable state unexpectedly sourced (cross-agent leak case)"
+  exit 1
+fi
+[[ -z "${STALL_LAST_SCAN_TS:-}" ]] || { echo "STALL_LAST_SCAN_TS leaked across unreadable boundary: ${STALL_LAST_SCAN_TS}"; exit 1; }
+[[ -z "${STALL_ACTIVE_CLASSIFICATION:-}" ]] || { echo "STALL_ACTIVE_CLASSIFICATION leaked across unreadable boundary: ${STALL_ACTIVE_CLASSIFICATION}"; exit 1; }
+chmod 600 "$agent_c" 2>/dev/null || true
+
 echo ok
 ' _ "$root" "$helper" 2>/dev/null)"
   rc=$?
@@ -429,35 +487,82 @@ daemon_acl_default_inheritance() {
   # Without the default ACL, controller reads return EACCES (the bug
   # this PR is meant to prevent).
   #
-  # Two-UID + setfacl is required, and elevated privileges (root or a
-  # configured sudoers entry) to switch UIDs. Skip cleanly otherwise so
-  # the test runs on platforms that support it (linux server install)
-  # without breaking dev-box smoke runs (macOS, unprivileged CI).
+  # The boundary this test must demonstrate is:
+  #   non-root controller UID  --read-->  isolated-UID-owned 0700 file
+  # Root MUST NOT play either role: root bypasses POSIX ACLs entirely,
+  # which makes any negative-case `cat` succeed regardless of the ACL
+  # state and renders the positive case vacuous. Two distinct non-root
+  # UIDs are therefore required, and we need privilege (root or a
+  # passwordless sudo grant) to switch into both. Skip cleanly otherwise
+  # so the test runs on platforms that support it (linux server install)
+  # without breaking dev-box smoke runs (macOS, unprivileged CI). (#576 r3
+  # Finding 2)
   local isolated_user="" controller_user="" root="" target_dir=""
   local positive_file="" negative_dir="" negative_file=""
-  local rc
+  local rc cleanup_users=()
 
   if ! command -v setfacl >/dev/null 2>&1; then
     smoke_log "skipped acl default inheritance: setfacl not available (requires Linux + acl pkg)"
     return 0
   fi
   if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
-    smoke_log "skipped acl default inheritance: requires root to switch UIDs"
+    smoke_log "skipped acl default inheritance: requires root (or equivalent) to switch into two non-root UIDs"
     return 0
   fi
-  controller_user="$(id -un)"
-  for candidate in nobody daemon bin; do
-    if id -u "$candidate" >/dev/null 2>&1; then
-      isolated_user="$candidate"
+  if ! command -v sudo >/dev/null 2>&1; then
+    smoke_log "skipped acl default inheritance: sudo not available — cannot switch UIDs without bypassing the ACL"
+    return 0
+  fi
+
+  # Allow the operator to pin specific test UIDs via env (e.g. on hosts
+  # where `nobody`/`daemon` are unusable). Both must be non-root, distinct,
+  # and `sudo -n -u` must be able to switch into them.
+  local controller_candidate isolated_candidate
+  controller_candidate="${BRIDGE_ACL_SMOKE_CONTROLLER:-}"
+  isolated_candidate="${BRIDGE_ACL_SMOKE_ISOLATED:-}"
+
+  # Auto-discover from a small whitelist of unprivileged accounts that
+  # exist on most Linux distros. Avoid creating users implicitly — the
+  # round-3 brief permits creation but it's a side effect a smoke run
+  # should not leave on the host.
+  local user_candidate
+  for user_candidate in "$isolated_candidate" nobody daemon bin _unknown nfsnobody mail; do
+    [[ -n "$user_candidate" ]] || continue
+    [[ "$user_candidate" == root ]] && continue
+    id -u "$user_candidate" >/dev/null 2>&1 || continue
+    if [[ -z "$isolated_user" ]]; then
+      isolated_user="$user_candidate"
+      continue
+    fi
+    if [[ -z "$controller_user" && "$user_candidate" != "$isolated_user" ]]; then
+      controller_user="$user_candidate"
       break
     fi
   done
-  if [[ -z "$isolated_user" ]]; then
-    smoke_log "skipped acl default inheritance: no isolated user candidate (nobody/daemon/bin) on this host"
+
+  # Operator override for the controller role takes precedence over the
+  # auto-discovered choice (lets a host pin its actual bridge admin UID).
+  if [[ -n "$controller_candidate" ]] && id -u "$controller_candidate" >/dev/null 2>&1; then
+    controller_user="$controller_candidate"
+  fi
+
+  if [[ -z "$isolated_user" || -z "$controller_user" || "$isolated_user" == "$controller_user" ]]; then
+    smoke_log "skipped acl default inheritance: need two distinct non-root UIDs (set BRIDGE_ACL_SMOKE_ISOLATED + BRIDGE_ACL_SMOKE_CONTROLLER, or ensure two of nobody/daemon/bin/_unknown exist)"
     return 0
   fi
-  if [[ "$isolated_user" == "$controller_user" ]]; then
-    smoke_log "skipped acl default inheritance: controller user matches isolated user"
+  if [[ "$isolated_user" == root || "$controller_user" == root ]]; then
+    smoke_log "skipped acl default inheritance: refusing to use root as either role (root bypasses POSIX ACLs)"
+    return 0
+  fi
+
+  # Verify both UIDs are reachable via passwordless sudo. Without this
+  # the rest of the test would prompt or hang.
+  if ! sudo -n -u "$isolated_user" /bin/true >/dev/null 2>&1; then
+    smoke_log "skipped acl default inheritance: sudo -n -u $isolated_user failed (no passwordless grant)"
+    return 0
+  fi
+  if ! sudo -n -u "$controller_user" /bin/true >/dev/null 2>&1; then
+    smoke_log "skipped acl default inheritance: sudo -n -u $controller_user failed (no passwordless grant)"
     return 0
   fi
 
@@ -470,6 +575,12 @@ daemon_acl_default_inheritance() {
   # path by which the controller can ever read the contents.
   chown "$isolated_user":"$isolated_user" "$target_dir" "$negative_dir"
   chmod 700 "$target_dir" "$negative_dir"
+  # The controller UID must be able to traverse $root to reach
+  # $target_dir; mktemp -d defaults to 0700 owned by the smoke runner
+  # (root here). Add an ACL grant so traversal works without flipping
+  # the parent dir to 0755.
+  setfacl -m "u:${controller_user}:x" "$root" "$target_dir" "$negative_dir" \
+    || smoke_fail "acl default inheritance: setfacl traversal grant failed on $root"
 
   # Install the default ACL on the positive-case directory. This is the
   # exact shape lib/bridge-agents.sh::bridge_linux_acl_add_default_dirs_recursive
@@ -485,25 +596,30 @@ daemon_acl_default_inheritance() {
   sudo -n -u "$isolated_user" /bin/sh -c "printf '%s' \"123\" >'$negative_file'" \
     || smoke_fail "acl default inheritance: isolated UID could not write negative file"
 
-  # Positive case: controller (test driver) must be able to read the
-  # file the isolated UID just created. This is the inheritance guarantee.
+  # Positive case: controller (NON-root) must be able to read the file
+  # the isolated UID just created. This is the inheritance guarantee. We
+  # MUST run the read as $controller_user — running as root would bypass
+  # the ACL and make this assertion vacuous.
   set +e
-  cat "$positive_file" >/dev/null 2>&1
+  sudo -n -u "$controller_user" /bin/sh -c "cat '$positive_file' >/dev/null 2>&1"
   rc=$?
   set -e
   [[ "$rc" -eq 0 ]] \
-    || smoke_fail "acl default inheritance: controller could not read isolated-UID file under default ACL (rc=$rc)"
+    || smoke_fail "acl default inheritance: controller (${controller_user}) could not read isolated-UID file under default ACL (rc=$rc)"
 
-  # Negative case: same setup without the default ACL must reject the
-  # controller. If this passes silently, the positive case is not
-  # actually exercising the ACL — it's just chmod 755 by accident.
+  # Negative case: same setup WITHOUT the default ACL must reject the
+  # non-root controller. If this passes silently, the positive case is
+  # not actually exercising the ACL. (Running as root here would always
+  # succeed — this is exactly the vacuous-test class the round-3 review
+  # called out.)
   set +e
-  cat "$negative_file" >/dev/null 2>&1
+  sudo -n -u "$controller_user" /bin/sh -c "cat '$negative_file' >/dev/null 2>&1"
   rc=$?
   set -e
   [[ "$rc" -ne 0 ]] \
-    || smoke_fail "acl default inheritance: controller unexpectedly read file without default ACL (test setup is not exercising ACL)"
+    || smoke_fail "acl default inheritance: controller (${controller_user}) unexpectedly read file without default ACL (test setup is not exercising the ACL boundary)"
 
+  : "${cleanup_users[@]:-}"  # silence unused-var warning when cleanup empty
   smoke_log "ok: acl default inheritance positive+negative confirmed (controller=$controller_user, isolated=$isolated_user)"
 }
 


### PR DESCRIPTION
## Summary
- prevent unreadable or malformed daemon state env files from aborting the daemon under set -e
- clear unreadable idle/manual-stop markers instead of crashing during idle reconciliation
- grant controller default ACLs on isolated runtime/log/memory state dirs so files created later by the isolated UID remain controller-readable
- add daemon smoke coverage for unreadable idle markers and unreadable/malformed state env files

## Live diagnosis
The daemon restart at 2026-05-04T15:47:17Z was caused by an unguarded read of /home/ec2-user/.agent-bridge/state/agents/sales_sean/idle-since. That marker was created by the isolated runtime user without an effective controller read grant, and bridge_reconcile_idle_markers aborted the daemon under set -e.

Adjacent risks found in the same audit:
- legacy isolation granted controller rwX recursively on runtime_state_dir/log_dir but did not install matching default ACLs there
- daemon sourced several generated state env files directly, so unreadable or syntactically corrupt generated state could also terminate the daemon

## Validation
- bash -n bridge-daemon.sh lib/bridge-state.sh lib/bridge-agents.sh scripts/smoke/daemon.sh
- bash scripts/smoke/daemon.sh
- git diff --check

ShellCheck was not available on the live host used for this patch.