### PR TITLE
fix(tool-policy): treat stderr suppression as read-intent (#574)

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -275,6 +275,13 @@ def _stage_first_token(stage: str) -> str:
     return ""
 
 
+# Stderr-suppression / fd-dup forms that *look* like write redirection
+# but cannot mutate the filesystem: `2>/dev/null` discards fd-2,
+# `2>&1` merges fd-2 into fd-1, `&>/dev/null` discards both. These must
+# not flip a read-intent classification (issue #574).
+_SAFE_REDIRECT_PATTERNS = ("2>/dev/null", "2>&1", "&>/dev/null")
+
+
 def _is_read_intent_bash(command: str) -> bool:
     """Return True iff *command* is purely read-intent.
 
@@ -289,6 +296,9 @@ def _is_read_intent_bash(command: str) -> bool:
       a token starting with that prefix and disqualifies the pipeline,
       even if the leading command is otherwise a read tool. ``cat >x``
       writes to *x* — the destination path could be the protected one.
+      Stderr-suppression / fd-dup tokens in
+      :data:`_SAFE_REDIRECT_PATTERNS` are exempt: they don't mutate the
+      filesystem (issue #574).
     - Input redirection (``<``) is fine; it only opens the file for
       reading.
     - A single write-intent or unknown leading command anywhere in the
@@ -297,13 +307,24 @@ def _is_read_intent_bash(command: str) -> bool:
     """
     if not command.strip():
         return False
-    for stage in _COMMAND_OPERATOR_RE.split(command):
+    # Strip stderr-suppression / fd-dup tokens before splitting on shell
+    # operators. `_COMMAND_OPERATOR_RE` would otherwise tear `2>&1` and
+    # `&>/dev/null` on the embedded `&`, hiding them from the per-token
+    # check below (issue #574).
+    sanitized = command
+    for safe in _SAFE_REDIRECT_PATTERNS:
+        sanitized = sanitized.replace(safe, " ")
+    for stage in _COMMAND_OPERATOR_RE.split(sanitized):
         stage_stripped = stage.strip()
         if not stage_stripped:
             continue
         # Reject output-redirection anywhere in the stage. Input redir
         # (`<file`) is fine; write redir (`>`, `>>`, `&>`, `2>`) is not.
+        # Stderr-suppression forms (`2>/dev/null`, `2>&1`, `&>/dev/null`)
+        # were stripped above and don't reach this loop (issue #574).
         for tok in stage_stripped.split():
+            if tok in _SAFE_REDIRECT_PATTERNS:
+                continue
             for prefix in ("&>", "2>", ">>", ">"):
                 if tok.startswith(prefix):
                     return False

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -281,6 +281,17 @@ def _stage_first_token(stage: str) -> str:
 # not flip a read-intent classification (issue #574).
 _SAFE_REDIRECT_PATTERNS = ("2>/dev/null", "2>&1", "&>/dev/null")
 
+# Token-boundary regex used to strip the safe-redirect forms before
+# operator splitting. Naive `str.replace` would also strip substrings
+# like `2>/dev/null/extra` (a real write to a path *under* /dev/null/),
+# turning a write into a fake read (issue #574 r2). The lookahead
+# requires end-of-string or a shell metacharacter / whitespace after
+# the match — i.e. the form must stand on its own as a redirection
+# token, not as a prefix of a longer pathname.
+_SAFE_REDIRECT_RE = re.compile(
+    r"(?:2>/dev/null|2>&1|&>/dev/null)(?=$|[\s;&|()<>`$])"
+)
+
 
 def _is_read_intent_bash(command: str) -> bool:
     """Return True iff *command* is purely read-intent.
@@ -310,10 +321,10 @@ def _is_read_intent_bash(command: str) -> bool:
     # Strip stderr-suppression / fd-dup tokens before splitting on shell
     # operators. `_COMMAND_OPERATOR_RE` would otherwise tear `2>&1` and
     # `&>/dev/null` on the embedded `&`, hiding them from the per-token
-    # check below (issue #574).
-    sanitized = command
-    for safe in _SAFE_REDIRECT_PATTERNS:
-        sanitized = sanitized.replace(safe, " ")
+    # check below (issue #574). Matches must be token-boundary aware:
+    # `2>/dev/null/extra` is a real write to a path under /dev/null/,
+    # not a stderr discard, and must NOT be stripped (issue #574 r2).
+    sanitized = _SAFE_REDIRECT_RE.sub(" ", command)
     for stage in _COMMAND_OPERATOR_RE.split(sanitized):
         stage_stripped = stage.strip()
         if not stage_stripped:

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -285,11 +285,13 @@ _SAFE_REDIRECT_PATTERNS = ("2>/dev/null", "2>&1", "&>/dev/null")
 # operator splitting. Naive `str.replace` would also strip substrings
 # like `2>/dev/null/extra` (a real write to a path *under* /dev/null/),
 # turning a write into a fake read (issue #574 r2). The lookahead
-# requires end-of-string or a shell metacharacter / whitespace after
-# the match — i.e. the form must stand on its own as a redirection
-# token, not as a prefix of a longer pathname.
+# requires end-of-string or a true shell token-separator after the
+# match — whitespace or one of `; & | ( ) < >`. `$` and backtick are
+# excluded because they begin variable / command substitution and are
+# not separators: `2>/dev/null$VAR` and ``2>/dev/null`cmd` `` are real
+# writes to a substituted path, not stderr discards (issue #574 r3).
 _SAFE_REDIRECT_RE = re.compile(
-    r"(?:2>/dev/null|2>&1|&>/dev/null)(?=$|[\s;&|()<>`$])"
+    r"(?:2>/dev/null|2>&1|&>/dev/null)(?=$|[\s;&|()<>])"
 )
 
 

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -605,10 +605,16 @@ done
 # `str.replace('2>/dev/null', '')` strips the substring out of
 # `2>/dev/null/extra`, hiding the real write to a path under /dev/null/.
 # The token-boundary regex (`_SAFE_REDIRECT_RE`) must keep these as write-
-# intent, so a hit on the protected path is denied.
+# intent, so a hit on the protected path is denied. r3: variable / command
+# substitution suffixes (`$VAR`, `` `cmd` ``) are also non-separators —
+# `2>/dev/null$SUFFIX` is a real write to a substituted path, not a
+# stderr discard, and must NOT be stripped by the safe-redirect regex.
 for trap_cmd in \
   "cat $ACCESS_PATH 2>/dev/null/extra" \
-  "cat $ACCESS_PATH 2>/dev/null.bak"; do
+  "cat $ACCESS_PATH 2>/dev/null.bak" \
+  "cat $ACCESS_PATH 2>/dev/null\$SUFFIX" \
+  "cat $ACCESS_PATH &>/dev/null\$SUFFIX" \
+  "cat $ACCESS_PATH 2>/dev/null\`cmd\`"; do
   payload="$(emit_bash_payload "test-8c" "$trap_cmd")"
   out="$(run_hook_pretool_payload "$payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
   if [[ "$out" == *'"deny"'* ]] && [[ "$out" == *"system config path"* ]]; then

--- a/tests/system-config-gating/smoke.sh
+++ b/tests/system-config-gating/smoke.sh
@@ -547,6 +547,93 @@ else
   pass "scenario 7 (D2h): heredoc prose preceded by whitespace still passes (regression-preserve)"
 fi
 
+# --- Scenario 8: stderr-suppression read-intent on protected path -------
+# Issue #574 + r2 follow-up. The three safe-redirect forms
+# (`2>/dev/null`, `2>&1`, `&>/dev/null`) must be classified as read-intent
+# so a `grep`/`cat`/`tail` on a protected file (allowed for any agent
+# under #383's read-bypass) is not falsely denied. Real writes — including
+# write redirects that *contain* a safe form, and substring-traps like
+# `2>/dev/null/extra` (a real write to a path under /dev/null/) — must
+# still deny. Each scenario reuses the protected access.json so the
+# system-config gate is the one actually tested.
+
+emit_bash_payload() {
+  # $1: tool_use_id, $2: command (single-quoted JSON-safe)
+  local id="$1" cmd="$2"
+  "$PYTHON" - "$id" "$cmd" <<'PY'
+import json, sys
+tool_use_id, command = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "hook_event_name": "PreToolUse",
+    "tool_name": "Bash",
+    "tool_use_id": tool_use_id,
+    "session_id": f"test-session-{tool_use_id}",
+    "tool_input": {"command": command, "description": "574 r2 smoke"},
+}))
+PY
+}
+
+# 8a — safe-redirect read on protected path MUST be allowed (any agent)
+for form in "2>/dev/null" "2>&1" "&>/dev/null"; do
+  cmd="grep -nE x $ACCESS_PATH $form"
+  payload="$(emit_bash_payload "test-8a-$form" "$cmd")"
+  out="$(run_hook_pretool_payload "$payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+  if [[ "$out" == *'"deny"'* ]]; then
+    fail "scenario 8a: safe-redirect read \`$form\` falsely denied — output: $out"
+  else
+    pass "scenario 8a: safe-redirect read \`$form\` on protected path allowed"
+  fi
+done
+
+# 8b — real writes on protected path MUST still deny, even adjacent to a
+# safe form. `> bar` and `2>err.log` are real file writes; `2>&1` next to
+# them must not launder the classification.
+for write_cmd in \
+  "cat $ACCESS_PATH > /tmp/agb-574-bar" \
+  "cat $ACCESS_PATH > /tmp/agb-574-bar 2>&1" \
+  "cat $ACCESS_PATH 2>/tmp/agb-574-err"; do
+  payload="$(emit_bash_payload "test-8b" "$write_cmd")"
+  out="$(run_hook_pretool_payload "$payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+  if [[ "$out" == *'"deny"'* ]] && [[ "$out" == *"system config path"* ]]; then
+    pass "scenario 8b: real write denied — \`${write_cmd##* }\`"
+  else
+    fail "scenario 8b: real write not denied — cmd: $write_cmd / output: $out"
+  fi
+done
+
+# 8c — path-collision regression (THE r1 substring trap). Naive
+# `str.replace('2>/dev/null', '')` strips the substring out of
+# `2>/dev/null/extra`, hiding the real write to a path under /dev/null/.
+# The token-boundary regex (`_SAFE_REDIRECT_RE`) must keep these as write-
+# intent, so a hit on the protected path is denied.
+for trap_cmd in \
+  "cat $ACCESS_PATH 2>/dev/null/extra" \
+  "cat $ACCESS_PATH 2>/dev/null.bak"; do
+  payload="$(emit_bash_payload "test-8c" "$trap_cmd")"
+  out="$(run_hook_pretool_payload "$payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+  if [[ "$out" == *'"deny"'* ]] && [[ "$out" == *"system config path"* ]]; then
+    pass "scenario 8c: path-collision write denied — \`${trap_cmd##* }\`"
+  else
+    fail "scenario 8c: path-collision write not denied — cmd: $trap_cmd / output: $out"
+  fi
+done
+
+# 8d — compound commands carrying safe forms MUST stay read-intent so the
+# protected-path read still passes. Mixes `&&`, `;`, and `|` with the
+# three safe-redirect tokens.
+for compound_cmd in \
+  "cat $ACCESS_PATH && grep x $ACCESS_PATH 2>&1" \
+  "cat $ACCESS_PATH; grep x $ACCESS_PATH 2>/dev/null" \
+  "cat $ACCESS_PATH 2>/dev/null | grep x 2>&1"; do
+  payload="$(emit_bash_payload "test-8d" "$compound_cmd")"
+  out="$(run_hook_pretool_payload "$payload" "$NON_ADMIN_AGENT" 2>/dev/null || true)"
+  if [[ "$out" == *'"deny"'* ]]; then
+    fail "scenario 8d: compound read falsely denied — cmd: $compound_cmd / output: $out"
+  else
+    pass "scenario 8d: compound read allowed — \`${compound_cmd}\`"
+  fi
+done
+
 # --- Summary -------------------------------------------------------------
 printf '\n[smoke] system-config-gating: %d pass, %d fail\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary

`hooks/tool-policy.py::_is_read_intent_bash` rejects any token that *starts with* a write-redirection prefix. That correctly catches real stderr writes (`2>err.log`), but also collaterally flips three forms that cannot mutate the filesystem:

- `2>/dev/null` — discards fd-2 to the always-empty device
- `2>&1` — fd-dup; merges fd-2 into fd-1
- `&>/dev/null` — discards both fd-1 and fd-2

The result: a clearly read-intent Bash command against a protected path is denied as soon as the operator suppresses stderr, even though admin holds protected-path read by #383.

## Reproduction (from #574)

Admin agent (`BRIDGE_ADMIN_AGENT=patch`), live install v0.7.6:

```
$ grep -n PreCompact ~/.agent-bridge/bridge-hooks.py 2>/dev/null
# blocked: "system config path requires `agent-bridge config set` ..."

$ grep -n PreCompact ~/.agent-bridge/bridge-hooks.py
# allowed
```

This contradicts #383's stated bar of *"this command provably does not mutate state at the protected path"* — neither stderr suppression nor fd-dup mutate anything. It also makes `hooks/*` (which is itself a protected path) partially uninspectable for debugging once the operator's `grep` emits stderr noise.

## Fix recipe applied

Per the issue's "Suggested fix":

```python
_SAFE_REDIRECT_PATTERNS = ("2>/dev/null", "2>&1", "&>/dev/null")
```

defined at module scope just above `_is_read_intent_bash`, with the per-token loop teaching to skip those tokens.

One implementation detail beyond the issue text: `_COMMAND_OPERATOR_RE` (used to split the command into pipeline stages) splits on `&` and `|`, so `2>&1` and `&>/dev/null` would be torn apart at the embedded `&` *before* the per-token check ever sees them. To handle that, the safe forms are also stripped from the command string before the operator-split. The per-token whitelist still runs (kept for clarity at the rejection site).

A real write that *also* contains `2>&1` (e.g. `cat foo > out 2>&1`) remains denied — only the `> out` half is reachable after sanitisation; the `>` token still fires.

## Test plan

- [x] `python3 -m py_compile hooks/tool-policy.py` — PASS
- [x] `python3 -c "import ast; ast.parse(open('hooks/tool-policy.py').read())"` — PASS
- [x] `bash tests/system-config-gating/smoke.sh` — 23 pass, 0 fail (including the existing #341 hook-deny scenarios and #509 `.agents/` false-positive regression cases)
- [x] Inline functional check on `_is_read_intent_bash` covering:
  - `grep foo file 2>/dev/null` → True (was False before fix)
  - `grep foo file 2>&1` → True (was False before fix)
  - `grep foo file &>/dev/null` → True (was False before fix)
  - `cat foo > bar` → False (regression check)
  - `cat foo >> bar` → False (regression check)
  - `cat foo 2>err.log` → False (regression check)
  - `cat foo &>both.log` → False (regression check)
  - `grep foo file > out 2>&1` → False (regression: real write next to safe redirect still blocks)
  - `cat a && grep b 2>&1` → True
  - `cat a; grep b 2>/dev/null` → True

## Related

- #383 — protected-path read allowance (sets the bar this fix restores)
- #341 — system config write-audit chain (untouched here; this only affects read-intent classification)

Fixes #574