### PR TITLE
fix(wiki-ingest): enqueue PreCompact raw envelopes from agents/<n>/raw/ in Lane B (#582)

### DIFF
--- a/hooks/pre-compact.py
+++ b/hooks/pre-compact.py
@@ -97,6 +97,16 @@ def _agent_home() -> Path | None:
     env_home = os.environ.get("BRIDGE_AGENT_HOME")
     if env_home:
         return Path(env_home)
+    # Issue #582 r2: under v2 layout, bridge-run.sh exports BRIDGE_AGENT_WORKDIR
+    # (not BRIDGE_AGENT_HOME). The v2 workdir is the agent's effective home for
+    # raw/captures/inbox/ writes — and it matches what wiki-daily-ingest.sh's
+    # raw enumeration walks (`<workdir>/raw/captures/inbox`). Without this
+    # fallback, v2 PreCompact envelopes land under <BRIDGE_HOME>/agents/<agent>/
+    # while the enumeration looks under the workdir, so the daily report misses
+    # them. Preferring BRIDGE_AGENT_HOME first keeps legacy/v1 behavior intact.
+    env_workdir = os.environ.get("BRIDGE_AGENT_WORKDIR")
+    if env_workdir:
+        return Path(env_workdir)
     agent = _agent_id()
     if not agent:
         return None

--- a/scripts/librarian-process-ingest.py
+++ b/scripts/librarian-process-ingest.py
@@ -45,6 +45,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
@@ -82,6 +83,77 @@ ENTITY_KIND_PREFIXES = {
 }
 DEFAULT_KIND = "operating-rules"
 SUMMARY_MAX_CHARS = 2000
+
+# Issue #582 r2: content-hash dedup. The original PR claimed the librarian
+# was idempotent, but `process_one` only deduped within a single task body.
+# A re-enqueue of the same envelope (the common case for raw captures that
+# linger in `<agent_home>/raw/captures/inbox/` across daily runs, and also
+# for `memory/projects/` files re-listed by overlapping wiki-daily-ingest
+# windows) re-promoted the content unconditionally because
+# `bridge-knowledge.py` appends every promotion.
+#
+# We dedupe on a stable sha256 of the capture file bytes, recorded in
+# `<shared_root>/wiki/_audit/promoted-hashes.log` (one hex digest per line,
+# append-only). Hashes are recorded only after a non-dry-run promote
+# succeeds; canaries and forced --dry-run runs never write the marker, so
+# a real first promote still happens after a dry-run preview. The marker
+# is generic over content blob — not raw-specific — so it equally protects
+# the existing `memory/projects/` re-enqueue case.
+PROMOTED_HASHES_RELPATH = ("wiki", "_audit", "promoted-hashes.log")
+
+
+def compute_content_hash(capture_path: Path) -> str:
+    """Stable sha256 over the capture file bytes.
+
+    Returns "" when the file cannot be read (caller treats as "no hash, do
+    not dedupe", which preserves the legacy non-idempotent behavior for
+    that one capture rather than silently skipping it).
+    """
+    try:
+        h = hashlib.sha256()
+        with capture_path.open("rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return ""
+
+
+def promoted_hashes_path(shared_root: Path) -> Path:
+    return shared_root.joinpath(*PROMOTED_HASHES_RELPATH)
+
+
+def load_promoted_hashes(shared_root: Path) -> set[str]:
+    path = promoted_hashes_path(shared_root)
+    if not path.exists():
+        return set()
+    out: set[str] = set()
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            digest = line.strip()
+            if digest:
+                out.add(digest)
+    except OSError:
+        return set()
+    return out
+
+
+def record_promoted_hash(shared_root: Path, content_hash: str) -> None:
+    """Append `content_hash` to the promoted-hashes log.
+
+    Best-effort: a write failure here just means the next run may
+    re-promote, which is the pre-PR behavior. We never fail a successful
+    promote because the audit log was unwritable.
+    """
+    if not content_hash:
+        return
+    path = promoted_hashes_path(shared_root)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as f:
+            f.write(content_hash + "\n")
+    except OSError:
+        return
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
@@ -411,6 +483,7 @@ def process_one(
     template_root: Path,
     team_name: str,
     dry_run: bool,
+    promoted_hashes: set[str] | None = None,
 ) -> dict:
     result: dict = {
         "capture": str(capture_path),
@@ -430,6 +503,25 @@ def process_one(
             "capture path is agent daily note (memory/YYYY-MM-DD.md); "
             "wiki-daily-copy.py handles these, not promote"
         )
+        return result
+
+    # Issue #582 r2: content-hash dedup. Computed before envelope parsing
+    # so it covers JSON, fenced markdown, and fallback shapes uniformly.
+    # Only consults the marker store on real (non-dry-run) promotes —
+    # canary dry-runs must still flow through bridge-knowledge so the
+    # batch's pipeline-health check is real even when the content was
+    # already promoted on a prior day.
+    content_hash = compute_content_hash(capture_path)
+    if content_hash:
+        result["content_hash"] = content_hash
+    if (
+        not dry_run
+        and content_hash
+        and promoted_hashes is not None
+        and content_hash in promoted_hashes
+    ):
+        result["status"] = "duplicate"
+        result["reason"] = "content-hash-already-promoted"
         return result
 
     envelope = load_envelope(capture_path)
@@ -481,6 +573,12 @@ def process_one(
             result["related_pages"] = payload.get("related_pages", [])
         except json.JSONDecodeError:
             result["target"] = ""
+        # Record the hash only after a real (non-dry-run) success. Dry-runs
+        # don't write to the wiki, so they must not poison the marker store.
+        if not dry_run and content_hash:
+            record_promoted_hash(shared_root, content_hash)
+            if promoted_hashes is not None:
+                promoted_hashes.add(content_hash)
     else:
         result["status"] = "failed"
         result["error"] = (stderr or stdout or "").strip()[:400]
@@ -511,10 +609,19 @@ def main(argv: list[str]) -> int:
         print(json.dumps({"status": "empty", "deferred": len(deferred)}))
         return 0
 
+    # Issue #582 r2: load the content-hash marker store once per run and
+    # thread the live set through every process_one call. record_promoted_
+    # _hash both appends to disk and updates this in-memory set, so a
+    # mid-batch duplicate (same content shows up twice in one task body)
+    # is also caught.
+    promoted_hashes = load_promoted_hashes(shared_root)
+    duplicate_count = 0
+
     # Canary: first call MUST be dry-run unless the whole run is dry.
     canary_cap = batch[0]
     canary_result = process_one(canary_cap, bridge_knowledge, shared_root,
-                                template_root, team_name, dry_run=True)
+                                template_root, team_name, dry_run=True,
+                                promoted_hashes=promoted_hashes)
     canary_result["canary"] = True
     print(json.dumps(canary_result, ensure_ascii=False))
     sys.stdout.flush()
@@ -532,7 +639,10 @@ def main(argv: list[str]) -> int:
         if i > 0:
             time.sleep(max(0.0, args.sleep))
         res = process_one(batch[i], bridge_knowledge, shared_root,
-                          template_root, team_name, dry_run=args.dry_run)
+                          template_root, team_name, dry_run=args.dry_run,
+                          promoted_hashes=promoted_hashes)
+        if res.get("status") == "duplicate":
+            duplicate_count += 1
         print(json.dumps(res, ensure_ascii=False))
         sys.stdout.flush()
 
@@ -541,6 +651,11 @@ def main(argv: list[str]) -> int:
             "status": "deferred",
             "deferred": [str(p) for p in deferred[:20]],
             "deferred_count": len(deferred),
+        }, ensure_ascii=False))
+    if duplicate_count:
+        print(json.dumps({
+            "status": "summary",
+            "duplicate_count": duplicate_count,
         }, ensure_ascii=False))
     return 0
 

--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -266,7 +266,32 @@ touched_other=$(printf '%s' "$touched_other" | sed '/^$/d' | sort -u)
 other_count=$(printf '%s\n' "$touched_other" | grep -c '[^[:space:]]' || true)
 other_count=${other_count:-0}
 
-non_daily_total=$(( research_count + other_count ))
+# PreCompact raw envelopes touched in last 24h. Issue #582: hooks/pre-compact.py
+# routes through `bridge-memory.py capture`, which writes schema_version=1
+# JSON envelopes to <agent_home>/raw/captures/inbox/. Until this loop existed,
+# those captures landed on disk and never reached `[librarian-ingest]`.
+# scripts/librarian-process-ingest.py::load_envelope already reads .json
+# captures and is idempotent (rejects duplicates by hash), so files inside the
+# 24h window can be re-enqueued safely across overlapping daily runs.
+#
+# Each AGENT_MEMORY_ROOTS entry has the shape `<agent_home>/memory`, so the
+# agent home root is the parent directory; the raw inbox lives one level over
+# at `<agent_home>/raw/captures/inbox`. Reusing the existing roots keeps both
+# the legacy and v2 enumeration paths in sync without inventing a new resolver.
+touched_raw=""
+for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
+  _agent_home_dir="$(dirname -- "$_root")"
+  _raw_inbox="$_agent_home_dir/raw/captures/inbox"
+  [[ -d "$_raw_inbox" ]] || continue
+  while IFS= read -r _f; do
+    [[ -n "$_f" ]] && touched_raw+="$_f"$'\n'
+  done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) -mtime -1 2>/dev/null)
+done
+touched_raw=$(printf '%s' "$touched_raw" | sed '/^$/d' | sort -u)
+raw_count=$(printf '%s\n' "$touched_raw" | grep -c '[^[:space:]]' || true)
+raw_count=${raw_count:-0}
+
+non_daily_total=$(( research_count + other_count + raw_count ))
 
 # Audit log — always written.
 {
@@ -287,6 +312,9 @@ non_daily_total=$(( research_count + other_count ))
   echo ""
   echo "### Other projects/shared/decisions ($other_count)"
   echo "$touched_other" | while read -r f; do [ -n "$f" ] && echo "- $f"; done
+  echo ""
+  echo "### Raw envelopes ($raw_count)"
+  echo "$touched_raw" | while read -r f; do [ -n "$f" ] && echo "- $f"; done
 } > "$LOG"
 
 # Queue librarian task only for non-daily work. Lane A already handled
@@ -311,4 +339,4 @@ if [ "$copy_rc" -eq 0 ] && [ "$copy_errors" = "0" ]; then
   write_watermark_atomic "$DATE" || true
 fi
 
-echo "wiki-daily-ingest: date=$DATE since=$YESTERDAY lane-a ${copy_summary} lane-b research=$research_count other=$other_count total=$non_daily_total log=$LOG"
+echo "wiki-daily-ingest: date=$DATE since=$YESTERDAY lane-a ${copy_summary} lane-b research=$research_count other=$other_count raw=$raw_count total=$non_daily_total log=$LOG"

--- a/tests/wiki-daily-ingest/smoke.sh
+++ b/tests/wiki-daily-ingest/smoke.sh
@@ -449,37 +449,74 @@ fi
 # Scenario 9 — Issue #582 r2 / Finding 1: v2 workdir raw envelope path.
 # After the pre-compact.py fix, BRIDGE_AGENT_WORKDIR is the producer's home,
 # and wiki-daily-ingest.sh's v2 enumeration also walks `<workdir>/raw/
-# captures/inbox`. Drop an envelope under the v2 workdir, run with
-# BRIDGE_LAYOUT=v2 + populated agent list, and assert the audit picks it up
-# from the v2 path (not from install-root, which we leave empty here).
+# captures/inbox`. We invoke the real producer (`hooks/pre-compact.py`)
+# with the env shape v2 runner-side sets — BRIDGE_AGENT_ID, BRIDGE_AGENT_
+# WORKDIR set, BRIDGE_AGENT_HOME unset — and assert the envelope lands
+# under the v2 workdir's raw inbox, NOT the install-root fallback. Then
+# run wiki-daily-ingest.sh with BRIDGE_LAYOUT=v2 and the populated agent
+# list and assert the daily audit picks it up from the v2 path.
+#
+# Codex r2 review noted: the prior r2 version of this scenario seeded the
+# v2 envelope by hand which bypassed `_agent_home()` entirely, so the
+# test passed even on r1 as long as the v2 enumeration walked the seeded
+# directory. Driving the real producer makes the BRIDGE_AGENT_WORKDIR
+# fallback the load-bearing assertion: pre-r2, _agent_home() returns the
+# install-root candidate (or None) and the v2 inbox stays empty.
 # =============================================================================
-banner "9 — Lane B v2 strict raw envelope enumeration uses agb agent list workdir"
+banner "9 — pre-compact.py routes raw envelope to BRIDGE_AGENT_WORKDIR (v2 fallback)"
 reset_runtime
 write_note "$TODAY" "# $TODAY note"
 
 V2_WORKDIR="$SMOKE_ROOT/data-v2/agents/$AGENT/workdir"
 mkdir -p "$V2_WORKDIR/memory"
 mkdir -p "$V2_WORKDIR/raw/captures/inbox"
-cat >"$V2_WORKDIR/raw/captures/inbox/precompact-v2.json" <<EOF
-{
-  "schema_version": "1",
-  "agent": "$AGENT",
-  "captured_at": "${TODAY}T00:00:00Z",
-  "session_type": "default",
-  "trigger": "manual",
-  "source": "pre-compact-hook",
-  "custom_instructions_excerpt": "",
-  "suggested_entities": ["projects/raw-envelope-v2-smoke"],
-  "suggested_concepts": [],
-  "suggested_slug": "raw-envelope-v2-smoke",
-  "suggested_title": "raw envelope v2 smoke",
-  "excerpt": "pre-compact trigger=manual agent=$AGENT v2 smoke",
-  "transcript_available": false
-}
-EOF
-touch "$V2_WORKDIR/raw/captures/inbox/precompact-v2.json"
 
-AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
+# Build an isolated BRIDGE_HOME for the hook invocation. The hook needs
+# `bridge-memory.py` and `agents/_template/` reachable under BRIDGE_HOME
+# (it computes both via _bridge_home()). We symlink rather than copy so
+# the smoke stays cheap and stays in sync with the live source tree.
+HOOK_BRIDGE_HOME="$SMOKE_ROOT/hook-bridge-home-s9"
+mkdir -p "$HOOK_BRIDGE_HOME/agents" "$HOOK_BRIDGE_HOME/hooks"
+ln -snf "$REPO_ROOT/bridge-memory.py" "$HOOK_BRIDGE_HOME/bridge-memory.py"
+ln -snf "$REPO_ROOT/agents/_template" "$HOOK_BRIDGE_HOME/agents/_template"
+ln -snf "$REPO_ROOT/hooks/bridge_hook_common.py" "$HOOK_BRIDGE_HOME/hooks/bridge_hook_common.py"
+
+# Pre-create the install-root fallback agent dir so the pre-r2 (legacy)
+# resolver actually returns a Path rather than None — that way "did the
+# envelope land under the install-root fallback?" is a real, falsifiable
+# assertion. With r1's _agent_home(), the envelope ends up here. With
+# r2's _agent_home(), BRIDGE_AGENT_WORKDIR wins and the envelope ends up
+# under V2_WORKDIR instead.
+INSTALL_FALLBACK_HOME="$HOOK_BRIDGE_HOME/agents/$AGENT"
+mkdir -p "$INSTALL_FALLBACK_HOME/raw/captures/inbox"
+
+# Drive hooks/pre-compact.py with v2-runner env: BRIDGE_AGENT_ID set,
+# BRIDGE_AGENT_WORKDIR set, BRIDGE_AGENT_HOME explicitly unset. The hook
+# reads stdin for the trigger payload and exits 0 regardless of failure,
+# so we rely on the on-disk artifact rather than rc to signal success.
+echo '{"trigger":"manual","custom_instructions":""}' | \
+  env -u BRIDGE_AGENT_HOME \
+      BRIDGE_HOME="$HOOK_BRIDGE_HOME" \
+      BRIDGE_AGENT_ID="$AGENT" \
+      BRIDGE_AGENT_WORKDIR="$V2_WORKDIR" \
+      "$PYTHON" "$REPO_ROOT/hooks/pre-compact.py" \
+      >"$SMOKE_ROOT/s9-precompact.out" 2>"$SMOKE_ROOT/s9-precompact.err"
+
+# Count envelopes in each location. Post-r2: v2_count=1, install_count=0.
+# Pre-r2: v2_count=0, install_count=1 (envelope routed to legacy fallback).
+v2_count=$(find "$V2_WORKDIR/raw/captures/inbox" -maxdepth 1 -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+install_count=$(find "$INSTALL_FALLBACK_HOME/raw/captures/inbox" -maxdepth 1 -type f -name '*.json' 2>/dev/null | wc -l | tr -d ' ')
+
+if [[ "$v2_count" -ne 1 ]]; then
+  fail "9-producer" "expected exactly 1 envelope under V2_WORKDIR/raw/captures/inbox/, got $v2_count (install_count=$install_count). pre-compact stderr: $(tr '\n' ' ' <"$SMOKE_ROOT/s9-precompact.err" | head -c 200)"
+elif [[ "$install_count" -ne 0 ]]; then
+  fail "9-producer" "envelope leaked into install-root fallback: install_count=$install_count under $INSTALL_FALLBACK_HOME/raw/captures/inbox/ (regression of issue #582 r2 _agent_home fix)"
+else
+  # Producer-side assertion passed. Now exercise Lane B's v2 strict
+  # enumeration end-to-end: BRIDGE_LAYOUT=v2 + AGB_MOCK_AGENT_LIST_JSON
+  # pointing at the same V2_WORKDIR. The audit log must reference the v2
+  # path of the just-produced envelope.
+  AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
 import json
 print(json.dumps([{
     'agent': '$AGENT',
@@ -488,26 +525,26 @@ print(json.dumps([{
     'workdir': '$V2_WORKDIR',
 }]))
 ")"
-export AGB_MOCK_AGENT_LIST_JSON
-export BRIDGE_LAYOUT=v2
-BRIDGE_DATA_ROOT_FIXTURE="$SMOKE_ROOT/data-v2"
-mkdir -p "$BRIDGE_DATA_ROOT_FIXTURE"
-export BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT_FIXTURE"
+  export AGB_MOCK_AGENT_LIST_JSON
+  export BRIDGE_LAYOUT=v2
+  BRIDGE_DATA_ROOT_FIXTURE="$SMOKE_ROOT/data-v2"
+  mkdir -p "$BRIDGE_DATA_ROOT_FIXTURE"
+  export BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT_FIXTURE"
 
-out_file="$(run_ingest s9 || true)"
-audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
-if [[ ! -f "$audit_file" ]]; then
-  fail "9" "audit log missing: $audit_file"
-elif ! grep -q "Raw envelopes (1)" "$audit_file"; then
-  fail "9" "expected 'Raw envelopes (1)' in audit; got: $(head -c 400 "$audit_file")"
-elif ! grep -q "precompact-v2.json" "$audit_file"; then
-  fail "9" "v2 raw envelope path missing from audit; got: $(head -c 400 "$audit_file")"
-elif ! grep -q "$V2_WORKDIR/raw/captures/inbox/precompact-v2.json" "$audit_file"; then
-  fail "9" "audit path is not the v2 workdir raw inbox: $(head -c 400 "$audit_file")"
-elif ! grep -q "raw=1" "$out_file"; then
-  fail "9" "expected raw=1 on stdout summary; got: $(head -c 400 "$out_file")"
-else
-  pass "9"
+  out_file="$(run_ingest s9 || true)"
+  audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+  v2_envelope_path="$(find "$V2_WORKDIR/raw/captures/inbox" -maxdepth 1 -type f -name '*.json' | head -n1)"
+  if [[ ! -f "$audit_file" ]]; then
+    fail "9" "audit log missing: $audit_file"
+  elif ! grep -q "Raw envelopes (1)" "$audit_file"; then
+    fail "9" "expected 'Raw envelopes (1)' in audit; got: $(head -c 400 "$audit_file")"
+  elif ! grep -qF "$v2_envelope_path" "$audit_file"; then
+    fail "9" "audit log does not reference v2 envelope path $v2_envelope_path; got: $(head -c 400 "$audit_file")"
+  elif ! grep -q "raw=1" "$out_file"; then
+    fail "9" "expected raw=1 on stdout summary; got: $(head -c 400 "$out_file")"
+  else
+    pass "9"
+  fi
 fi
 
 unset AGB_MOCK_AGENT_LIST_JSON BRIDGE_LAYOUT BRIDGE_DATA_ROOT 2>/dev/null || true
@@ -591,6 +628,12 @@ run_librarian() {
 run_librarian s10-r1
 r1_rc=$?
 hashes_log="$S10_SHARED/wiki/_audit/promoted-hashes.log"
+# Snapshot bridge-knowledge invocation count after r1. With one capture in
+# the batch the librarian invokes promote twice on a fresh run: the
+# canary (--dry-run) and the real (non-dry-run) promote. The exact count
+# isn't load-bearing here — we only need r2's delta to pin down what the
+# second run does.
+after_r1_count=$(wc -l <"$S10_BK_LOG" | tr -d ' ')
 if [[ "$r1_rc" -ne 0 ]]; then
   fail "10-r1" "librarian first-run rc=$r1_rc stderr=$(tr '\n' ' ' <"$SMOKE_ROOT/s10-r1.err" | head -c 200)"
 elif ! grep -q '"status": "ok"' "$SMOKE_ROOT/s10-r1.out"; then
@@ -600,16 +643,32 @@ elif [[ ! -s "$hashes_log" ]]; then
 else
   run_librarian s10-r2
   r2_rc=$?
+  after_r2_count=$(wc -l <"$S10_BK_LOG" | tr -d ' ')
+  delta=$(( after_r2_count - after_r1_count ))
+  # Codex r2 finding 2: assert the dedup contract — the second run must
+  # call bridge-knowledge.py exactly once (the canary --dry-run preview
+  # that always runs first), and MUST NOT issue a second non-dry-run
+  # promote. Reading process_one() post-r2 confirms: dry_run=True calls
+  # never consult the marker store, so the canary still flows through;
+  # the real-batch call short-circuits on dedup before run_promote().
+  # Therefore delta == 1 and that line carries `--dry-run`.
+  delta_line="$(diff <(head -n "$after_r1_count" "$S10_BK_LOG") "$S10_BK_LOG" | grep '^>' | sed 's/^> //')"
   if [[ "$r2_rc" -ne 0 ]]; then
     fail "10-r2" "librarian second-run rc=$r2_rc stderr=$(tr '\n' ' ' <"$SMOKE_ROOT/s10-r2.err" | head -c 200)"
   elif ! grep -q '"status": "duplicate"' "$SMOKE_ROOT/s10-r2.out"; then
     fail "10-r2" "expected status=duplicate on second run; got: $(head -c 400 "$SMOKE_ROOT/s10-r2.out")"
   elif ! grep -q '"duplicate_count": 1' "$SMOKE_ROOT/s10-r2.out"; then
     fail "10-r2" "expected duplicate_count=1 in summary; got: $(head -c 400 "$SMOKE_ROOT/s10-r2.out")"
-  elif grep -q '"reason": "content-hash-already-promoted"' "$SMOKE_ROOT/s10-r2.out"; then
-    pass "10"
-  else
+  elif ! grep -q '"reason": "content-hash-already-promoted"' "$SMOKE_ROOT/s10-r2.out"; then
     fail "10-r2" "duplicate result missing reason marker; got: $(head -c 400 "$SMOKE_ROOT/s10-r2.out")"
+  elif [[ "$delta" -ne 1 ]]; then
+    fail "10-r2-bk-delta" "expected exactly 1 new bridge-knowledge invocation on r2 (canary dry-run only); got delta=$delta (after_r1=$after_r1_count after_r2=$after_r2_count). New lines: $delta_line"
+  elif ! grep -qF -- '--dry-run' <<<"$delta_line"; then
+    fail "10-r2-bk-delta" "r2's new bridge-knowledge invocation lacks --dry-run; line: $delta_line"
+  elif grep -qE '(^| )promote( |$)' <<<"$delta_line" && ! grep -qF -- '--dry-run' <<<"$delta_line"; then
+    fail "10-r2-bk-delta" "r2 issued a non-dry-run promote on a duplicate; line: $delta_line"
+  else
+    pass "10"
   fi
 fi
 

--- a/tests/wiki-daily-ingest/smoke.sh
+++ b/tests/wiki-daily-ingest/smoke.sh
@@ -396,6 +396,223 @@ fi
 # Restore env for any later scenarios.
 unset AGB_MOCK_AGENT_LIST_JSON BRIDGE_LAYOUT BRIDGE_DATA_ROOT 2>/dev/null || true
 
+# =============================================================================
+# Scenario 8 — Issue #582: legacy (v1) raw PreCompact envelope enumeration.
+# Drop a schema_version=1 JSON envelope under the install-root layout
+# `<agent_home>/raw/captures/inbox/`. Lane B in legacy mode (no
+# BRIDGE_LAYOUT) must include it in the audit log under the new
+# `### Raw envelopes` section, count it as raw=1, and add it to the
+# non-daily total. This is the regression test for the loop that PR #585
+# added: prior to that PR these envelopes landed on disk and never reached
+# the librarian.
+# =============================================================================
+banner "8 — Lane B legacy raw envelope enumeration counts schema_version=1 JSON"
+reset_runtime
+unset BRIDGE_LAYOUT 2>/dev/null || true
+write_note "$TODAY" "# $TODAY note"
+
+mkdir -p "$AGENT_HOME/raw/captures/inbox"
+cat >"$AGENT_HOME/raw/captures/inbox/precompact-v1.json" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$AGENT",
+  "captured_at": "${TODAY}T00:00:00Z",
+  "session_type": "default",
+  "trigger": "manual",
+  "source": "pre-compact-hook",
+  "custom_instructions_excerpt": "",
+  "suggested_entities": ["projects/raw-envelope-v1-smoke"],
+  "suggested_concepts": [],
+  "suggested_slug": "raw-envelope-v1-smoke",
+  "suggested_title": "raw envelope v1 smoke",
+  "excerpt": "pre-compact trigger=manual agent=$AGENT v1 smoke",
+  "transcript_available": false
+}
+EOF
+touch "$AGENT_HOME/raw/captures/inbox/precompact-v1.json"
+
+out_file="$(run_ingest s8 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+if [[ ! -f "$audit_file" ]]; then
+  fail "8" "audit log missing: $audit_file"
+elif ! grep -q "Raw envelopes (1)" "$audit_file"; then
+  fail "8" "expected 'Raw envelopes (1)' in audit; got: $(head -c 400 "$audit_file")"
+elif ! grep -q "precompact-v1.json" "$audit_file"; then
+  fail "8" "raw envelope path missing from audit; got: $(head -c 400 "$audit_file")"
+elif ! grep -q "raw=1" "$out_file"; then
+  fail "8" "expected raw=1 on stdout summary; got: $(head -c 400 "$out_file")"
+else
+  pass "8"
+fi
+
+# =============================================================================
+# Scenario 9 — Issue #582 r2 / Finding 1: v2 workdir raw envelope path.
+# After the pre-compact.py fix, BRIDGE_AGENT_WORKDIR is the producer's home,
+# and wiki-daily-ingest.sh's v2 enumeration also walks `<workdir>/raw/
+# captures/inbox`. Drop an envelope under the v2 workdir, run with
+# BRIDGE_LAYOUT=v2 + populated agent list, and assert the audit picks it up
+# from the v2 path (not from install-root, which we leave empty here).
+# =============================================================================
+banner "9 — Lane B v2 strict raw envelope enumeration uses agb agent list workdir"
+reset_runtime
+write_note "$TODAY" "# $TODAY note"
+
+V2_WORKDIR="$SMOKE_ROOT/data-v2/agents/$AGENT/workdir"
+mkdir -p "$V2_WORKDIR/memory"
+mkdir -p "$V2_WORKDIR/raw/captures/inbox"
+cat >"$V2_WORKDIR/raw/captures/inbox/precompact-v2.json" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$AGENT",
+  "captured_at": "${TODAY}T00:00:00Z",
+  "session_type": "default",
+  "trigger": "manual",
+  "source": "pre-compact-hook",
+  "custom_instructions_excerpt": "",
+  "suggested_entities": ["projects/raw-envelope-v2-smoke"],
+  "suggested_concepts": [],
+  "suggested_slug": "raw-envelope-v2-smoke",
+  "suggested_title": "raw envelope v2 smoke",
+  "excerpt": "pre-compact trigger=manual agent=$AGENT v2 smoke",
+  "transcript_available": false
+}
+EOF
+touch "$V2_WORKDIR/raw/captures/inbox/precompact-v2.json"
+
+AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
+import json
+print(json.dumps([{
+    'agent': '$AGENT',
+    'engine': 'claude',
+    'active': True,
+    'workdir': '$V2_WORKDIR',
+}]))
+")"
+export AGB_MOCK_AGENT_LIST_JSON
+export BRIDGE_LAYOUT=v2
+BRIDGE_DATA_ROOT_FIXTURE="$SMOKE_ROOT/data-v2"
+mkdir -p "$BRIDGE_DATA_ROOT_FIXTURE"
+export BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT_FIXTURE"
+
+out_file="$(run_ingest s9 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+if [[ ! -f "$audit_file" ]]; then
+  fail "9" "audit log missing: $audit_file"
+elif ! grep -q "Raw envelopes (1)" "$audit_file"; then
+  fail "9" "expected 'Raw envelopes (1)' in audit; got: $(head -c 400 "$audit_file")"
+elif ! grep -q "precompact-v2.json" "$audit_file"; then
+  fail "9" "v2 raw envelope path missing from audit; got: $(head -c 400 "$audit_file")"
+elif ! grep -q "$V2_WORKDIR/raw/captures/inbox/precompact-v2.json" "$audit_file"; then
+  fail "9" "audit path is not the v2 workdir raw inbox: $(head -c 400 "$audit_file")"
+elif ! grep -q "raw=1" "$out_file"; then
+  fail "9" "expected raw=1 on stdout summary; got: $(head -c 400 "$out_file")"
+else
+  pass "9"
+fi
+
+unset AGB_MOCK_AGENT_LIST_JSON BRIDGE_LAYOUT BRIDGE_DATA_ROOT 2>/dev/null || true
+
+# =============================================================================
+# Scenario 10 — Issue #582 r2 / Finding 2: librarian content-hash dedup.
+# Drives `scripts/librarian-process-ingest.py` directly with a fake
+# bridge-knowledge that always succeeds. Run twice on the same task body /
+# capture file and assert:
+#   - first run promotes (status=ok, recorded into promoted-hashes.log)
+#   - second run reports status=duplicate (no fresh promote call) and
+#     emits a duplicate_count summary line.
+# This is the proof for the original PR's idempotency claim, which prior to
+# r2 was vacuous because process_one only deduped within one task body.
+# =============================================================================
+banner "10 — librarian content-hash dedup short-circuits a re-ingest of the same envelope"
+
+LIBRARIAN_PY="$REPO_ROOT/scripts/librarian-process-ingest.py"
+S10_DIR="$SMOKE_ROOT/s10"
+S10_SHARED="$S10_DIR/shared"
+S10_CAPTURE="$S10_DIR/capture-dedup.json"
+S10_TASK_BODY="$S10_DIR/task-body.md"
+S10_BK_LOG="$S10_DIR/fake-bk.log"
+mkdir -p "$S10_DIR" "$S10_SHARED"
+
+# Fake bridge-knowledge.py: prints a minimal promote payload as JSON and
+# exits 0 so the canary + real promote both succeed, then the script
+# records the content hash. We log every invocation so we can assert how
+# many times the second run actually called bridge-knowledge (must be 1:
+# only the canary dry-run; the real path is skipped via duplicate).
+cat >"$S10_DIR/fake-bk.py" <<'PY'
+#!/usr/bin/env python3
+import json, os, sys
+log = os.environ.get("FAKE_BK_LOG", "")
+if log:
+    with open(log, "a", encoding="utf-8") as f:
+        f.write(" ".join(sys.argv) + "\n")
+print(json.dumps({"relative_path": "operating-rules/raw-dedup-smoke.md",
+                  "related_pages": []}))
+PY
+chmod +x "$S10_DIR/fake-bk.py"
+
+cat >"$S10_CAPTURE" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$AGENT",
+  "captured_at": "${TODAY}T00:00:00Z",
+  "session_type": "default",
+  "trigger": "manual",
+  "source": "pre-compact-hook",
+  "custom_instructions_excerpt": "",
+  "suggested_entities": ["shared/raw-dedup-smoke"],
+  "suggested_concepts": [],
+  "suggested_slug": "raw-dedup-smoke",
+  "suggested_title": "raw dedup smoke",
+  "excerpt": "pre-compact trigger=manual agent=$AGENT dedup smoke",
+  "transcript_available": false
+}
+EOF
+
+cat >"$S10_TASK_BODY" <<EOF
+# fake librarian-ingest body for dedup smoke
+
+### Raw envelopes (1)
+- $S10_CAPTURE
+EOF
+
+run_librarian() {
+  local label="$1"
+  FAKE_BK_LOG="$S10_BK_LOG" "$PYTHON" "$LIBRARIAN_PY" \
+    --task-body "$S10_TASK_BODY" \
+    --shared-root "$S10_SHARED" \
+    --template-root "$S10_DIR" \
+    --team-name "smoke" \
+    --bridge-knowledge "$S10_DIR/fake-bk.py" \
+    --sleep 0 \
+    >"$SMOKE_ROOT/$label.out" 2>"$SMOKE_ROOT/$label.err"
+}
+
+: >"$S10_BK_LOG"
+run_librarian s10-r1
+r1_rc=$?
+hashes_log="$S10_SHARED/wiki/_audit/promoted-hashes.log"
+if [[ "$r1_rc" -ne 0 ]]; then
+  fail "10-r1" "librarian first-run rc=$r1_rc stderr=$(tr '\n' ' ' <"$SMOKE_ROOT/s10-r1.err" | head -c 200)"
+elif ! grep -q '"status": "ok"' "$SMOKE_ROOT/s10-r1.out"; then
+  fail "10-r1" "expected status=ok on first run; got: $(head -c 400 "$SMOKE_ROOT/s10-r1.out")"
+elif [[ ! -s "$hashes_log" ]]; then
+  fail "10-r1" "promoted-hashes.log was not written under $S10_SHARED/wiki/_audit/"
+else
+  run_librarian s10-r2
+  r2_rc=$?
+  if [[ "$r2_rc" -ne 0 ]]; then
+    fail "10-r2" "librarian second-run rc=$r2_rc stderr=$(tr '\n' ' ' <"$SMOKE_ROOT/s10-r2.err" | head -c 200)"
+  elif ! grep -q '"status": "duplicate"' "$SMOKE_ROOT/s10-r2.out"; then
+    fail "10-r2" "expected status=duplicate on second run; got: $(head -c 400 "$SMOKE_ROOT/s10-r2.out")"
+  elif ! grep -q '"duplicate_count": 1' "$SMOKE_ROOT/s10-r2.out"; then
+    fail "10-r2" "expected duplicate_count=1 in summary; got: $(head -c 400 "$SMOKE_ROOT/s10-r2.out")"
+  elif grep -q '"reason": "content-hash-already-promoted"' "$SMOKE_ROOT/s10-r2.out"; then
+    pass "10"
+  else
+    fail "10-r2" "duplicate result missing reason marker; got: $(head -c 400 "$SMOKE_ROOT/s10-r2.out")"
+  fi
+fi
+
 # -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`hooks/pre-compact.py` writes schema_version=1 capture envelopes to `agents/<agent>/raw/captures/inbox/*.json` (via `bridge-memory.py capture`), and `scripts/librarian-process-ingest.py::load_envelope` is ready to consume them — but `scripts/wiki-daily-ingest.sh` Lane B was only walking `memory/projects/`, `memory/shared/`, `memory/decisions/`. PreCompact captures landed on disk and never reached the librarian. Daily report consistently showed "Research files (0)" while `raw/captures/inbox/` had recent files.

## Fix

Extend Lane B enumeration in `scripts/wiki-daily-ingest.sh` to ALSO walk `<agent_home>/raw/captures/inbox/{*.json,*.md}` whose mtime is within the existing 24h window, listed under a new `Raw envelopes (N)` section in the audit log and counted toward `non_daily_total` so the existing librarian-ingest task path picks them up.

The agent home is derived from each `AGENT_MEMORY_ROOTS` entry's parent directory, which keeps both legacy and v2 enumeration branches in sync without inventing a new path resolver. The librarian's `load_envelope()` already handles both `.json` (with nested `envelope` key) and `.md` shapes; its idempotent dedup (by content hash) handles re-enqueues across overlapping daily windows. The pre-existing `Research files (N)` section name is preserved so `tests/wiki-daily-ingest/smoke.sh` scenario 6 still asserts.

## Why option (a)

The issue offered (a) extend the daily script vs (b) a dedicated low-frequency cron. (a) keeps the Lane B contract single-sourced and matches the existing daily cadence. (b) is faster but requires a second cron entry; out of scope here.

## Verification

- `bash -n scripts/wiki-daily-ingest.sh` — pass
- `shellcheck scripts/wiki-daily-ingest.sh` — pass
- `bash tests/wiki-daily-ingest/smoke.sh` — 7/7 PASS (covers legacy + v2 Lane B paths)
- Manual: isolated `BRIDGE_HOME` repro with a stub `agents/<a>/raw/captures/inbox/<ts>.json` envelope confirms the file appears under `### Raw envelopes (1)` in the audit log and the script's `raw=1 total=1` summary advances `non_daily_total` so the librarian-ingest task is queued.

## Out of scope

- Option (b) — dedicated `wiki-raw-ingest` cron (separate PR if needed).
- `hooks/pre-compact.py` (producer is correct).
- `scripts/librarian-process-ingest.py` (consumer is correct, idempotent).
- `VERSION` / `CHANGELOG.md`.