### PR TITLE
fix(cron-scheduler): anchor sync cursor to minute boundary so weekly firings are not skipped (#581)

### DIFF
--- a/bridge-cron-scheduler.py
+++ b/bridge-cron-scheduler.py
@@ -144,8 +144,10 @@ def load_state(path: Path) -> dict[str, Any]:
 def select_cursor(state: dict[str, Any], now_dt: datetime, bootstrap_seconds: int) -> datetime:
     cursor = parse_iso(state.get("last_sync_at"))
     if cursor is not None:
-        if isinstance(state.get("last_sync_key"), dict):
-            cursor -= timedelta(milliseconds=1)
+        # Issue #581: anchor cursor to start-of-minute - 1ms so the firing
+        # minute that lands on last_sync_at is not skipped by the strict
+        # `current > start_local` check in enumerate_cron_occurrences.
+        cursor = cursor.replace(second=0, microsecond=0) - timedelta(milliseconds=1)
         if cursor > now_dt:
             return now_dt
         return cursor
@@ -660,5 +662,38 @@ def main(argv: list[str] | None = None) -> int:
     return args.func(args)
 
 
+def _self_test_581() -> int:
+    """Issue #581 regression: cursor on a firing-minute boundary must not skip the firing."""
+    tz = timezone(timedelta(hours=9))
+    iso = lambda dt: dt.isoformat(timespec="milliseconds")  # noqa: E731
+    job = {"id": "j", "name": "wiki-hub-audit", "agentId": "a", "enabled": True,
+           "schedule": {"kind": "cron", "expr": "0 23 * * 4", "tz": "Asia/Seoul"}}
+    # (a) Boundary minute: prev sync at 23:00:00 with key=None must still find the 23:00 firing.
+    state_a = {"last_sync_at": iso(datetime(2026, 4, 30, 23, 0, 0, tzinfo=tz))}
+    now_a = datetime(2026, 4, 30, 23, 0, 30, tzinfo=tz)
+    occ_a = enumerate_cron_occurrences(job, select_cursor(state_a, now_a, 3600), now_a)
+    assert len(occ_a) == 1, f"(a) expected boundary firing, got {occ_a}"
+    # (b) Dedup: with last_sync_key set for the just-fired slot, must NOT re-enqueue.
+    fired = occ_a[0]
+    family = classify_family(job["name"])
+    state_b = {"last_sync_at": iso(fired),
+               "last_sync_key": {"agent": "a", "job_name": "wiki-hub-audit",
+                                 "slot": derive_slot(family, fired, job), "job_id": "j"}}
+    now_b = datetime(2026, 4, 30, 23, 1, 0, tzinfo=tz)
+    occ_b = enumerate_cron_occurrences(job, select_cursor(state_b, now_b, 3600), now_b)
+    runs_b = [DueRun("j", "wiki-hub-audit", family, "a", "cron", o, derive_slot(family, o, job)) for o in occ_b]
+    assert filter_due_runs_from_state(runs_b, state_b) == [], "(b) duplicate slipped through dedup"
+    # (c) Sub-minute cursor for high-frequency spec still catches the boundary firing.
+    job_c = {**job, "schedule": {"kind": "cron", "expr": "*/10 * * * *", "tz": "Asia/Seoul"}}
+    state_c = {"last_sync_at": iso(datetime(2026, 4, 30, 14, 0, 15, tzinfo=tz))}
+    now_c = datetime(2026, 4, 30, 14, 0, 30, tzinfo=tz)
+    occ_c = enumerate_cron_occurrences(job_c, select_cursor(state_c, now_c, 3600), now_c)
+    assert any(o.astimezone(tz).minute == 0 for o in occ_c), f"(c) missed 14:00 firing: {occ_c}"
+    print("self-test #581: OK")
+    return 0
+
+
 if __name__ == "__main__":
+    if len(sys.argv) == 2 and sys.argv[1] == "--self-test":
+        raise SystemExit(_self_test_581())
     raise SystemExit(main())

--- a/bridge-cron-scheduler.py
+++ b/bridge-cron-scheduler.py
@@ -408,6 +408,19 @@ def state_key_for_run(run: DueRun) -> dict[str, str]:
     }
 
 
+def final_cursor_key_for_run(last_safe_run: DueRun | None) -> dict[str, str] | None:
+    """Issue #581 (r2): preserve the per-run dedup key on the all-success final
+    write when a due run was processed this sync. The next sync's rolled-back
+    cursor (``select_cursor`` minute-boundary anchor) re-enumerates the just-
+    fired minute, but ``filter_due_runs_from_state`` uses this key to drop the
+    duplicate. Returns ``None`` for a genuinely empty window, where re-enumerating
+    nothing is harmless and matches the legacy state shape.
+    """
+    if last_safe_run is None:
+        return None
+    return state_key_for_run(last_safe_run)
+
+
 def summarize_results(results: list[dict[str, Any]], counters: dict[str, int]) -> dict[str, int]:
     return {
         "due_occurrences": counters.get("due_occurrences", 0),
@@ -613,7 +626,7 @@ def cmd_sync(args: argparse.Namespace) -> int:
             state_file,
             build_state_payload(
                 cursor_dt=now_dt,
-                cursor_key=None,
+                cursor_key=final_cursor_key_for_run(last_safe_run),
                 bootstrap_lookback=args.bootstrap_lookback,
                 max_occurrences_per_job=args.max_occurrences_per_job,
                 counters=counters,
@@ -689,6 +702,37 @@ def _self_test_581() -> int:
     now_c = datetime(2026, 4, 30, 14, 0, 30, tzinfo=tz)
     occ_c = enumerate_cron_occurrences(job_c, select_cursor(state_c, now_c, 3600), now_c)
     assert any(o.astimezone(tz).minute == 0 for o in occ_c), f"(c) missed 14:00 firing: {occ_c}"
+    # (d) r2 regression: post-cmd_sync all-success state shape must preserve the
+    #     dedup key when a due run was processed. Reproduces the live final-write
+    #     payload via final_cursor_key_for_run + build_state_payload (i.e. exactly
+    #     what cmd_sync persists at lines ~611-622), then re-runs the next-sync
+    #     enumerate + filter pipeline. Pre-r2 always wrote cursor_key=None on the
+    #     all-success path, so the next sync's rolled-back cursor would re-enqueue
+    #     the just-fired minute as a duplicate; the assertion below detects that.
+    fired_d = occ_a[0]
+    last_safe_d = DueRun("j", "wiki-hub-audit", family, "a", "cron",
+                         fired_d, derive_slot(family, fired_d, job))
+    final_key_d = final_cursor_key_for_run(last_safe_d)
+    assert final_key_d is not None, "(d) final-write key dropped on all-success path with due_runs"
+    payload_d = build_state_payload(
+        cursor_dt=now_a,
+        cursor_key=final_key_d,
+        bootstrap_lookback=3600,
+        max_occurrences_per_job=10,
+        counters={},
+        results=[],
+    )
+    assert payload_d.get("last_sync_key") is not None, "(d) state payload must carry last_sync_key"
+    # Empty-window path keeps cursor_key=None so re-enumeration of nothing stays harmless.
+    assert final_cursor_key_for_run(None) is None, "(d) empty-window cursor_key must remain None"
+    # Next sync at 23:01:00 with the fixed final-write state must NOT re-enqueue 23:00.
+    state_d = dict(payload_d)
+    now_d = datetime(2026, 4, 30, 23, 1, 0, tzinfo=tz)
+    occ_d = enumerate_cron_occurrences(job, select_cursor(state_d, now_d, 3600), now_d)
+    runs_d = [DueRun("j", "wiki-hub-audit", family, "a", "cron", o, derive_slot(family, o, job))
+              for o in occ_d]
+    assert filter_due_runs_from_state(runs_d, state_d) == [], \
+        "(d) post-cmd_sync state failed to dedup the just-fired boundary minute"
     print("self-test #581: OK")
     return 0
 


### PR DESCRIPTION
## Summary

Fixes the scheduler bug where `last_sync_at` advancing past a firing minute (with `last_sync_key=None`) caused the next sync to skip that minute entirely. Most visible for weekly weekday-restricted crons (`0 7 * * 0`, `0 23 * * 4`) because losing one slot means waiting a full week for the next.

## Root cause (one-liner)

`enumerate_cron_occurrences` uses strict `current > start_local`, and `select_cursor`'s 1 ms rollback was conditional on `last_sync_key` being a dict. When the previous sync had no due_runs (`cmd_sync` line 614 sets `cursor_key=None`), the next sync's `start_local` could equal a firing minute boundary, and `current > start_local` evaluated False for that minute.

## Fix

`select_cursor` now anchors the cursor to start-of-minute minus 1 ms unconditionally. This guarantees `enumerate_cron_occurrences` re-considers the cursor's minute on every sync. The existing `filter_due_runs_from_state` checkpoint continues to dedupe re-discovered slots when `last_sync_key` is a dict; for the no-due-runs branch the dedup is off but the re-enumeration is the desired behavior (a firing was MISSED on that branch by definition, otherwise it would have taken the line 580 branch).

## Verification

Inline `--self-test` (`python3 bridge-cron-scheduler.py --self-test`) covers:
- (a) Boundary minute: cursor at exactly Thu 23:00 with `last_sync_key=None` → next sync MUST find the 23:00 firing.
- (b) No duplicate: cursor at Thu 23:00 with `last_sync_key={…23:00 slot…}` → re-discovered firing is dedup'd by `filter_due_runs_from_state`.
- (c) Sub-minute cursor: `*/10 * * * *` with cursor at 14:00:15 → the 14:00 firing is still enqueued (rollback anchors to 13:59:59.999).

Pre-fix, (a) and (c) reproduce the bug (occurrences=0). Post-fix all three pass.

```
$ python3 -c "import ast; ast.parse(open('bridge-cron-scheduler.py').read())"  # OK
$ python3 bridge-cron-scheduler.py --self-test                                  # self-test #581: OK
$ bash scripts/smoke/cron-migrate-payloads.sh                                   # PASS
$ bash scripts/smoke/cron-run-artifacts-retention.sh                            # PASS
```

`scripts/smoke-test.sh` runs to a pre-existing macOS-host failure at the `starting isolated tmux role` lane on `main` as well (unrelated). Targeted CI cron smokes (auto-selected by `scripts/ci-select-smoke.sh` for any `bridge-cron-scheduler.py` change) both pass.

## Recovery for already-stuck installs

Operators run `agent-bridge cron update <id> --schedule "<same-expr>"` to force re-resolution (per the issue's workaround section). This PR does not touch existing `cron/jobs.json` state.

## Scope

- Single file (`bridge-cron-scheduler.py`).
- Track 4 (`cron doctor` surface) deferred to a follow-up — issue stays open after merge.
- No `VERSION` / `CHANGELOG` bump.