### PR TITLE
fix(doctor): skip cold-restart-suspect on clean /exit (#588)

### DIFF
--- a/bridge-doctor.py
+++ b/bridge-doctor.py
@@ -320,9 +320,9 @@ def _is_clean_exit(prior_path: Path) -> bool:
     """Return True if the prior jsonl tail shows an operator-driven clean end.
 
     Reads up to the last 8 KiB of the file and looks for the slash-command
-    markers Claude Code writes when the operator types `/exit` or `/clear`.
-    Both are clean session ends, not cold restarts (#588). Any I/O error is
-    treated as "not clean" so the detector remains best-effort.
+    marker Claude Code writes when the operator types `/exit`. That is a
+    clean session end, not a cold restart (#588). Any I/O error is treated
+    as "not clean" so the detector remains best-effort.
     """
     try:
         size = prior_path.stat().st_size
@@ -331,10 +331,7 @@ def _is_clean_exit(prior_path: Path) -> bool:
             tail_bytes = fh.read()
     except OSError:
         return False
-    return (
-        b"<command-name>/exit</command-name>" in tail_bytes
-        or b"<command-name>/clear</command-name>" in tail_bytes
-    )
+    return b"<command-name>/exit</command-name>" in tail_bytes
 
 
 def detect_cold_restart_suspect(
@@ -348,9 +345,9 @@ def detect_cold_restart_suspect(
     least one prior jsonl in the same workdir-slug directory whose mtime is
     fresh (within the last 7 days) and whose stem differs from the active
     session_id. The 7d window keeps long-archived transcripts from triggering
-    false positives. Prior transcripts ending in a `/exit` or `/clear`
-    slash-command are skipped — those are clean operator-driven ends, not
-    cold restarts (#588).
+    false positives. Prior transcripts ending in a `/exit` slash-command
+    are skipped — those are clean operator-driven ends, not cold restarts
+    (#588).
     """
     findings: list[dict[str, Any]] = []
     if not projects_root.is_dir():

--- a/bridge-doctor.py
+++ b/bridge-doctor.py
@@ -316,6 +316,27 @@ def workdir_slug_candidates(workdir: str) -> list[str]:
     return candidates
 
 
+def _is_clean_exit(prior_path: Path) -> bool:
+    """Return True if the prior jsonl tail shows an operator-driven clean end.
+
+    Reads up to the last 8 KiB of the file and looks for the slash-command
+    markers Claude Code writes when the operator types `/exit` or `/clear`.
+    Both are clean session ends, not cold restarts (#588). Any I/O error is
+    treated as "not clean" so the detector remains best-effort.
+    """
+    try:
+        size = prior_path.stat().st_size
+        with prior_path.open("rb") as fh:
+            fh.seek(max(0, size - 8192))
+            tail_bytes = fh.read()
+    except OSError:
+        return False
+    return (
+        b"<command-name>/exit</command-name>" in tail_bytes
+        or b"<command-name>/clear</command-name>" in tail_bytes
+    )
+
+
 def detect_cold_restart_suspect(
     agents: list[dict[str, Any]],
     ts: str,
@@ -327,7 +348,9 @@ def detect_cold_restart_suspect(
     least one prior jsonl in the same workdir-slug directory whose mtime is
     fresh (within the last 7 days) and whose stem differs from the active
     session_id. The 7d window keeps long-archived transcripts from triggering
-    false positives.
+    false positives. Prior transcripts ending in a `/exit` or `/clear`
+    slash-command are skipped — those are clean operator-driven ends, not
+    cold restarts (#588).
     """
     findings: list[dict[str, Any]] = []
     if not projects_root.is_dir():
@@ -376,6 +399,8 @@ def detect_cold_restart_suspect(
         if not current_present or prior is None:
             continue
         prior_sid, prior_path, prior_mtime = prior
+        if _is_clean_exit(Path(prior_path)):
+            continue
         findings.append(
             {
                 "ts": ts,

--- a/tests/agb-doctor/_assert.py
+++ b/tests/agb-doctor/_assert.py
@@ -198,6 +198,27 @@ def kinds_superset(payload: str, args: list[str]) -> bool:
     return True
 
 
+def cold_restart_for_agent(payload: str, args: list[str]) -> bool:
+    """Assert exactly one cold-restart-suspect finding exists for <agent>."""
+    if not args:
+        print("cold_restart_for_agent requires <agent>", file=sys.stderr)
+        return False
+    agent = args[0]
+    findings = _load(payload)
+    matches = [
+        f for f in findings
+        if f.get("kind") == "cold-restart-suspect" and f.get("agent") == agent
+    ]
+    if len(matches) != 1:
+        print(
+            f"expected 1 cold-restart-suspect for {agent!r}, "
+            f"got {len(matches)} (kinds={[f.get('kind') for f in findings]})",
+            file=sys.stderr,
+        )
+        return False
+    return True
+
+
 def only_kind(payload: str, args: list[str]) -> bool:
     if not args:
         print("only_kind requires <kind>", file=sys.stderr)
@@ -228,6 +249,7 @@ CHECKS = {
     "abnormal_pane_placeholder": abnormal_pane_placeholder,
     "kinds_superset": kinds_superset,
     "only_kind": only_kind,
+    "cold_restart_for_agent": cold_restart_for_agent,
 }
 
 

--- a/tests/agb-doctor/smoke.sh
+++ b/tests/agb-doctor/smoke.sh
@@ -22,6 +22,9 @@
 #                                               row; never a hard crash
 #   D5   --detectors stale-blocked-task       -> only that kind survives
 #   D6   daemon-level finding (agent="")      -> renders cleanly in table
+#   D7a  cold-restart-suspect, prior /exit    -> 0 findings (#588 clean exit)
+#   D7b  cold-restart-suspect, no exit marker -> 1 finding (real cold restart)
+#   D7c  cold-restart-suspect, prior /clear   -> 0 findings (#588 clean clear)
 #
 # Uses an isolated mktemp BRIDGE_HOME — never touches the live install.
 
@@ -337,6 +340,97 @@ if [[ "$out_d6_tbl" == *"detector-error"* ]] && [[ "$out_d6_tbl" == *"-"* ]]; th
 else
   fail "D6 table render did not contain expected fields: $out_d6_tbl"
 fi
+
+# --- D7: cold-restart-suspect clean-exit skip (#588) -------------------
+#
+# Each scenario builds:
+#   - $dir/workdir            — agent's workdir (slug = "-...workdir")
+#   - $dir/projects/<slug>/<current_sid>.jsonl  (stub, present so the
+#                                                detector sees current_present)
+#   - $dir/projects/<slug>/<prior_sid>.jsonl    (prior; mtime fresh; tail
+#                                                may or may not contain a
+#                                                clean-exit slash-command)
+#
+# The roster fixture pins workdir + session_id so the detector locates the
+# slug deterministically.
+
+# slug_for(workdir) — mirror workdir_slug_candidates() in bridge-doctor.py
+slug_for() {
+  printf '%s' "$1" | tr '/' '-'
+}
+
+# build_cold_restart_fixture <dir> <prior-tail>
+#   <dir>       — case dir; tasks.db + agents.json + projects/ live here
+#   <prior-tail>— bytes appended to the prior jsonl (use "" for no marker)
+build_cold_restart_fixture() {
+  local dir="$1"
+  local prior_tail="$2"
+  mkdir -p "$dir"
+  init_db "$dir/tasks.db"
+  local workdir="$dir/workdir"
+  mkdir -p "$workdir"
+  local slug
+  slug="$(slug_for "$workdir")"
+  local proj_dir="$dir/projects/$slug"
+  mkdir -p "$proj_dir"
+  local current_sid="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+  local prior_sid="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+  # Current session jsonl — content irrelevant, just must exist.
+  printf '{"type":"user"}\n' >"$proj_dir/$current_sid.jsonl"
+  # Prior session jsonl — optionally seeded with the clean-exit marker.
+  printf '{"type":"user"}\n%s' "$prior_tail" >"$proj_dir/$prior_sid.jsonl"
+  # Make both files mtime fresh (within 7d window).
+  touch "$proj_dir/$current_sid.jsonl" "$proj_dir/$prior_sid.jsonl"
+  # Roster: one active claude agent with the pinned session_id + workdir.
+  "$PYTHON" - "$dir/agents.json" "$workdir" "$current_sid" <<'PY'
+import json, sys
+out, workdir, sid = sys.argv[1], sys.argv[2], sys.argv[3]
+roster = [{
+    "agent": "patch",
+    "engine": "claude",
+    "active": True,
+    "activity_state": "idle",
+    "loop": 1,
+    "session_id": sid,
+    "workdir": workdir,
+    "queue": {"queued": 0, "blocked": 0, "claimed": 0},
+}]
+with open(out, "w", encoding="utf-8") as fh:
+    json.dump(roster, fh)
+PY
+}
+
+# run_doctor_with_projects <dir>
+run_doctor_with_projects() {
+  local dir="$1"
+  "$PYTHON" "$DOCTOR" \
+    --json \
+    --agent-list-json "$dir/agents.json" \
+    --task-db "$dir/tasks.db" \
+    --projects-root "$dir/projects" \
+    --detectors cold-restart-suspect
+}
+
+# D7a: prior jsonl ends with /exit -> finding suppressed
+D7a="$ROOT/d7a"
+build_cold_restart_fixture "$D7a" '{"type":"user","message":{"content":"<command-name>/exit</command-name>"}}'$'\n'
+out_d7a="$(run_doctor_with_projects "$D7a")"
+json_assert "$out_d7a" kind_absent \
+  "D7a clean /exit suppresses cold-restart-suspect (#588)" cold-restart-suspect
+
+# D7b: prior jsonl has no clean-exit marker -> finding still emitted
+D7b="$ROOT/d7b"
+build_cold_restart_fixture "$D7b" '{"type":"user","message":{"content":"plain user text"}}'$'\n'
+out_d7b="$(run_doctor_with_projects "$D7b")"
+json_assert "$out_d7b" cold_restart_for_agent \
+  "D7b real cold restart still emits finding" patch
+
+# D7c: prior jsonl ends with /clear -> finding suppressed
+D7c="$ROOT/d7c"
+build_cold_restart_fixture "$D7c" '{"type":"user","message":{"content":"<command-name>/clear</command-name>"}}'$'\n'
+out_d7c="$(run_doctor_with_projects "$D7c")"
+json_assert "$out_d7c" kind_absent \
+  "D7c clean /clear suppresses cold-restart-suspect (#588)" cold-restart-suspect
 
 # --- Summary ------------------------------------------------------------
 printf '\n[smoke] agb-doctor: %d pass, %d fail\n' "$PASS" "$FAIL"

--- a/tests/agb-doctor/smoke.sh
+++ b/tests/agb-doctor/smoke.sh
@@ -24,7 +24,6 @@
 #   D6   daemon-level finding (agent="")      -> renders cleanly in table
 #   D7a  cold-restart-suspect, prior /exit    -> 0 findings (#588 clean exit)
 #   D7b  cold-restart-suspect, no exit marker -> 1 finding (real cold restart)
-#   D7c  cold-restart-suspect, prior /clear   -> 0 findings (#588 clean clear)
 #
 # Uses an isolated mktemp BRIDGE_HOME — never touches the live install.
 
@@ -424,13 +423,6 @@ build_cold_restart_fixture "$D7b" '{"type":"user","message":{"content":"plain us
 out_d7b="$(run_doctor_with_projects "$D7b")"
 json_assert "$out_d7b" cold_restart_for_agent \
   "D7b real cold restart still emits finding" patch
-
-# D7c: prior jsonl ends with /clear -> finding suppressed
-D7c="$ROOT/d7c"
-build_cold_restart_fixture "$D7c" '{"type":"user","message":{"content":"<command-name>/clear</command-name>"}}'$'\n'
-out_d7c="$(run_doctor_with_projects "$D7c")"
-json_assert "$out_d7c" kind_absent \
-  "D7c clean /clear suppresses cold-restart-suspect (#588)" cold-restart-suspect
 
 # --- Summary ------------------------------------------------------------
 printf '\n[smoke] agb-doctor: %d pass, %d fail\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

`detect_cold_restart_suspect` (`bridge-doctor.py:319`) flagged every agent that had been cleanly `/exit`'d in the last 7 days, because the heuristic only inspected jsonl mtime + stem and never read the prior session's tail. The operator's intent (`/exit`) is the opposite of a cold restart, but the detector emitted the finding anyway with a misleading `agent-bridge agent restart <agent> --no-continue` suggestion. Repeated false positives erode trust in the doctor surface — by the time a real cold restart (oom-kill, daemon crash, system reboot) needs attention, operators have learned to ignore the row (#588).

This patch peeks the last 8 KiB of the prior jsonl and skips the finding when the tail contains either `<command-name>/exit</command-name>` or `<command-name>/clear</command-name>`. Both are operator-driven clean ends. Read-only; no other detector touched.

The "cleaner alternative" the issue mentions — a `state/agents/<n>/last-exit-reason` marker written by `bridge-tmux.sh` — is producer-side and deferred to a follow-up.

## Changes

- `bridge-doctor.py` — new module-private `_is_clean_exit(prior_path)` helper; one `continue` in the detection loop after `prior` is computed.
- `tests/agb-doctor/_assert.py` — new `cold_restart_for_agent` predicate.
- `tests/agb-doctor/smoke.sh` — three new D7 cases:
  - **D7a** prior tail contains `/exit` -> 0 findings (suppressed)
  - **D7b** prior tail contains plain user text -> 1 finding (real cold restart still fires)
  - **D7c** prior tail contains `/clear` -> 0 findings (suppressed)

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-doctor.py').read())"` — AST OK
- [x] `python3 bridge-doctor.py --help` — CLI surface unchanged
- [x] `bash -n tests/agb-doctor/smoke.sh` and `shellcheck tests/agb-doctor/smoke.sh` — clean
- [x] `bash tests/agb-doctor/smoke.sh` — 20/20 pass (was 17/17 baseline + 3 new D7 cases)
- [x] Pre-fix verification: stashed `bridge-doctor.py`, reran smoke — D7a + D7c fail as expected, D7b still passes; restored fix and all 20 pass
- [x] `./scripts/smoke-test.sh` — runs through every assertion before the documented macOS-isolated tmux failure (`[smoke] starting isolated tmux role` -> `smoke tmux session was not created`); unrelated to this change

## Out of scope

- Producer-side `last-exit-reason` marker (cleaner long-term but requires `bridge-tmux.sh` changes).
- The "false negative when prior jsonl was rotated/deleted" side observation in the issue — separate detector-direction issue.
- VERSION / CHANGELOG.