### PR TITLE
fix(wiki-ingest): explicit skip of isolated-private-root agents in Lane B (#583 Track C)

### DIFF
--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -159,12 +159,32 @@ PYEOF
 #   - 정상 + 진짜 0 active claude agent  → silent OK, Lane B 0 카운트
 # 모든 fail 경로는 `_lane_b_stderr` 임시파일을 명시적으로 rm 한 뒤 exit
 # (기존 line ~101 의 COPY_JSON EXIT trap 을 손상하지 않기 위해 별도 trap 미사용).
+#
+# Isolated-agent skip (issue #583 Track C):
+#   Agents created with `--isolation linux-user` own their `memory/` subtree
+#   under a per-UID 0700 root. The librarian (running as the operator UID)
+#   cannot read those paths, so any [librarian-ingest] task pointed at them
+#   completes with "cross-agent access blocked" and the same files re-queue
+#   the next day forever. We classify isolation up-front from operator-UID-
+#   readable metadata only (`agb agent list --json` reads the roster, never
+#   the agent's private root) and skip such agents from Lane B entirely
+#   before any `find`/`ls` touches their tree. Skipped agents are recorded
+#   in the audit log AND the stdout summary with the stable reason string
+#   `isolated_private_root_unreadable_by_design` so log consumers can grep
+#   on it. Track A (ACL grant on the private root) is rejected by operator
+#   policy after isolate-v2; Track B (push-to-staging) is the long-term
+#   fix and ships separately.
 # -------------------------------------------------------------------------
 
 : "${BRIDGE_AGB:=$BRIDGE_HOME/agent-bridge}"
 : "${BRIDGE_PYTHON:=python3}"
 
+# Stable identifier for the skip reason. Keep this literal in sync with
+# any downstream log consumers / dashboards that grep on it.
+readonly LANE_B_ISOLATED_SKIP_REASON="isolated_private_root_unreadable_by_design"
+
 declare -a AGENT_MEMORY_ROOTS=()
+declare -a SKIPPED_ISOLATED_AGENTS=()
 
 # Active-contract gate: v2 path requires BRIDGE_LAYOUT=v2 AND a populated
 # BRIDGE_DATA_ROOT directory. A child env that propagates only LAYOUT=v2
@@ -191,6 +211,10 @@ if [[ "${BRIDGE_LAYOUT:-legacy}" == "v2" \
     exit 2
   fi
 
+  # Emit "<agent>\t<workdir>\t<isolation_mode>" per active claude agent.
+  # isolation_mode is read from the JSON only — the roster is the source of
+  # truth and the operator UID can read it; we never touch the agent's
+  # private root to determine isolation status (issue #583 Track C).
   agents_tsv="$("$BRIDGE_PYTHON" - "$agent_list_json" <<'PY' 2>"$_lane_b_stderr"
 import json, sys
 try:
@@ -210,7 +234,9 @@ for a in data:
     wd = a.get("workdir") or ""
     if not name or not wd:
         continue
-    print(f"{name}\t{wd}")
+    isolation = a.get("isolation") or {}
+    mode = (isolation.get("mode") if isinstance(isolation, dict) else "") or "shared"
+    print(f"{name}\t{wd}\t{mode}")
 PY
 )"
   parse_exit=$?
@@ -223,8 +249,15 @@ PY
   rm -f "$_lane_b_stderr"
 
   if [[ -n "$agents_tsv" ]]; then
-    while IFS=$'\t' read -r _agent _workdir; do
+    while IFS=$'\t' read -r _agent _workdir _isolation; do
       [[ -n "$_agent" && -n "$_workdir" ]] || continue
+      # Issue #583 Track C: skip linux-user-isolated agents BEFORE any
+      # filesystem read. The classifier above used only operator-UID-
+      # readable metadata so this branch never opens the private root.
+      if [[ "$_isolation" == "linux-user" ]]; then
+        SKIPPED_ISOLATED_AGENTS+=("$_agent")
+        continue
+      fi
       [[ -d "$_workdir/memory" ]] || continue
       AGENT_MEMORY_ROOTS+=("$_workdir/memory")
     done <<< "$agents_tsv"
@@ -232,36 +265,119 @@ PY
 else
   # Legacy: original find-based enumeration over $AGENTS_ROOT/*/memory.
   # Each install-root agent dir with a memory/ subtree contributes a root.
+  #
+  # Issue #583 Track C: ask `agb agent list --json` (operator-UID-readable
+  # roster only — does not touch any agent's private root) for the
+  # isolation mode of each agent and skip linux-user agents before the
+  # find walk reaches their tree. Best-effort: if BRIDGE_AGB is missing
+  # or the call fails / returns malformed JSON, the deny-list stays
+  # empty and the legacy path runs exactly as before. This preserves the
+  # legacy default-off invariant while giving the skip path a chance to
+  # work on every install where the CLI is healthy.
+  #
+  # Bash 3.2 compatibility: macOS system bash lacks associative arrays,
+  # so the deny-list is held as a newline-delimited string with leading
+  # and trailing delimiters and tested via `[[ ... == *NL$name$NL* ]]`.
+  # bridge_validate_agent_name already restricts agent names to
+  # alphanumerics/dash/underscore so a name cannot contain a literal
+  # newline that would defeat the membership test.
+  _legacy_iso_deny_list=$'\n'
+  if [[ -x "$BRIDGE_AGB" ]]; then
+    _legacy_iso_json="$("$BRIDGE_AGB" agent list --json 2>/dev/null || true)"
+    if [[ -n "$_legacy_iso_json" ]]; then
+      _legacy_iso_tsv="$("$BRIDGE_PYTHON" - "$_legacy_iso_json" <<'PY' 2>/dev/null || true
+import json, sys
+try:
+    data = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)
+if not isinstance(data, list):
+    sys.exit(0)
+for a in data:
+    if not isinstance(a, dict):
+        continue
+    name = a.get("agent") or ""
+    if not name:
+        continue
+    isolation = a.get("isolation") or {}
+    mode = (isolation.get("mode") if isinstance(isolation, dict) else "") or "shared"
+    if mode == "linux-user":
+        print(name)
+PY
+)"
+      while IFS= read -r _iso_name; do
+        [[ -n "$_iso_name" ]] || continue
+        _legacy_iso_deny_list+="$_iso_name"$'\n'
+      done <<< "$_legacy_iso_tsv"
+    fi
+  fi
+
   if [[ -d "$AGENTS_ROOT" ]]; then
-    for _legacy_dir in "$AGENTS_ROOT"/*/memory; do
-      [[ -d "$_legacy_dir" ]] || continue
-      AGENT_MEMORY_ROOTS+=("$_legacy_dir")
+    # Issue #583 Track C r2: glob $AGENTS_ROOT/* (the operator-UID-readable
+    # parent), derive the agent name from the path, run the deny-list check
+    # FIRST, and only then `[[ -d "$_legacy_agent_dir/memory" ]]`. The
+    # previous shape stat'd the agent's memory subdir before the deny-list
+    # check, which could trip permissions on installs where the agent home
+    # itself is per-UID owned. The "skip BEFORE any read attempt into a
+    # possibly-private path" contract requires the deny-list to gate even
+    # the directory-existence test on $_legacy_agent_dir/memory.
+    for _legacy_agent_dir in "$AGENTS_ROOT"/*; do
+      # Stat the parent (operator-UID-readable in v1 layout). Skip non-dir
+      # entries like stray files or broken symlinks.
+      [[ -d "$_legacy_agent_dir" ]] || continue
+      _legacy_agent="${_legacy_agent_dir##*/}"
+      if [[ "$_legacy_iso_deny_list" == *$'\n'"$_legacy_agent"$'\n'* ]]; then
+        SKIPPED_ISOLATED_AGENTS+=("$_legacy_agent")
+        continue
+      fi
+      _legacy_memory_dir="$_legacy_agent_dir/memory"
+      [[ -d "$_legacy_memory_dir" ]] || continue
+      AGENT_MEMORY_ROOTS+=("$_legacy_memory_dir")
     done
   fi
 fi
 
+# Deduplicate the skipped-agent list and sort for deterministic output.
+# Bash 3.2 compatibility: avoid mapfile (bash 4) by using a portable read
+# loop into a temporary array, then reassigning.
+if (( ${#SKIPPED_ISOLATED_AGENTS[@]} > 0 )); then
+  _skipped_sorted=()
+  while IFS= read -r _name; do
+    [[ -n "$_name" ]] && _skipped_sorted+=("$_name")
+  done < <(printf '%s\n' "${SKIPPED_ISOLATED_AGENTS[@]}" | sort -u)
+  SKIPPED_ISOLATED_AGENTS=("${_skipped_sorted[@]}")
+fi
+skipped_isolated_count=${#SKIPPED_ISOLATED_AGENTS[@]}
+
 # Research files touched in last 24h (across all active agent memory roots).
+# Issue #583 Track C: AGENT_MEMORY_ROOTS may legitimately be empty when every
+# active agent is linux-user-isolated (and therefore skipped). Use the
+# defined-fallback expansion so `set -u` does not trip on the empty array.
 touched_research=""
-for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
-  [[ -d "$_root/research" ]] || continue
-  while IFS= read -r _f; do
-    [[ -n "$_f" ]] && touched_research+="$_f"$'\n'
-  done < <(find "$_root/research" -type f -name '*.md' -mtime -1 2>/dev/null)
-done
+if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
+  for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
+    [[ -d "$_root/research" ]] || continue
+    while IFS= read -r _f; do
+      [[ -n "$_f" ]] && touched_research+="$_f"$'\n'
+    done < <(find "$_root/research" -type f -name '*.md' -mtime -1 2>/dev/null)
+  done
+fi
 touched_research=$(printf '%s' "$touched_research" | sed '/^$/d' | sort -u)
 research_count=$(printf '%s\n' "$touched_research" | grep -c '[^[:space:]]' || true)
 research_count=${research_count:-0}
 
 # projects/shared/decisions files touched in last 24h.
 touched_other=""
-for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
-  for _sub in projects shared decisions; do
-    [[ -d "$_root/$_sub" ]] || continue
-    while IFS= read -r _f; do
-      [[ -n "$_f" ]] && touched_other+="$_f"$'\n'
-    done < <(find "$_root/$_sub" -type f -name '*.md' -mtime -1 2>/dev/null)
+if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
+  for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
+    for _sub in projects shared decisions; do
+      [[ -d "$_root/$_sub" ]] || continue
+      while IFS= read -r _f; do
+        [[ -n "$_f" ]] && touched_other+="$_f"$'\n'
+      done < <(find "$_root/$_sub" -type f -name '*.md' -mtime -1 2>/dev/null)
+    done
   done
-done
+fi
 touched_other=$(printf '%s' "$touched_other" | sed '/^$/d' | sort -u)
 other_count=$(printf '%s\n' "$touched_other" | grep -c '[^[:space:]]' || true)
 other_count=${other_count:-0}
@@ -278,15 +394,28 @@ other_count=${other_count:-0}
 # agent home root is the parent directory; the raw inbox lives one level over
 # at `<agent_home>/raw/captures/inbox`. Reusing the existing roots keeps both
 # the legacy and v2 enumeration paths in sync without inventing a new resolver.
+#
+# Issue #583 Track C: AGENT_MEMORY_ROOTS is already filtered to exclude
+# linux-user-isolated agents (the deny-list runs during root construction
+# above), so this loop transparently inherits the skip. The raw inbox under
+# an isolated agent's `<agent_home>/raw/captures/inbox` is never stat'd for
+# the same reason its `<agent_home>/memory/...` is never stat'd: the deny-
+# list short-circuits before either path is reached. A skipped agent
+# therefore contributes ONE skip line to the audit log (not two — memory
+# and raw are deduped through the shared roots array).
+# Same empty-array guard as the research/other walks: every active agent
+# may legitimately be linux-user-isolated, leaving AGENT_MEMORY_ROOTS empty.
 touched_raw=""
-for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
-  _agent_home_dir="$(dirname -- "$_root")"
-  _raw_inbox="$_agent_home_dir/raw/captures/inbox"
-  [[ -d "$_raw_inbox" ]] || continue
-  while IFS= read -r _f; do
-    [[ -n "$_f" ]] && touched_raw+="$_f"$'\n'
-  done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) -mtime -1 2>/dev/null)
-done
+if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
+  for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
+    _agent_home_dir="$(dirname -- "$_root")"
+    _raw_inbox="$_agent_home_dir/raw/captures/inbox"
+    [[ -d "$_raw_inbox" ]] || continue
+    while IFS= read -r _f; do
+      [[ -n "$_f" ]] && touched_raw+="$_f"$'\n'
+    done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) -mtime -1 2>/dev/null)
+  done
+fi
 touched_raw=$(printf '%s' "$touched_raw" | sed '/^$/d' | sort -u)
 raw_count=$(printf '%s\n' "$touched_raw" | grep -c '[^[:space:]]' || true)
 raw_count=${raw_count:-0}
@@ -315,6 +444,18 @@ non_daily_total=$(( research_count + other_count + raw_count ))
   echo ""
   echo "### Raw envelopes ($raw_count)"
   echo "$touched_raw" | while read -r f; do [ -n "$f" ] && echo "- $f"; done
+  echo ""
+  # Issue #583 Track C: explicit listing of agents whose private root was
+  # not enumerated. Stable reason string — keep in sync with
+  # $LANE_B_ISOLATED_SKIP_REASON above. A skipped agent is recorded once
+  # here regardless of whether the gate fired against the memory walk or
+  # the raw envelope walk; both share AGENT_MEMORY_ROOTS as their input.
+  echo "### Skipped (isolated private root) ($skipped_isolated_count)"
+  if (( skipped_isolated_count > 0 )); then
+    for _skipped in "${SKIPPED_ISOLATED_AGENTS[@]}"; do
+      echo "- $_skipped — reason: $LANE_B_ISOLATED_SKIP_REASON"
+    done
+  fi
 } > "$LOG"
 
 # Queue librarian task only for non-daily work. Lane A already handled
@@ -339,4 +480,14 @@ if [ "$copy_rc" -eq 0 ] && [ "$copy_errors" = "0" ]; then
   write_watermark_atomic "$DATE" || true
 fi
 
-echo "wiki-daily-ingest: date=$DATE since=$YESTERDAY lane-a ${copy_summary} lane-b research=$research_count other=$other_count raw=$raw_count total=$non_daily_total log=$LOG"
+# Stdout summary. The skipped-isolated counter is always present so log
+# consumers can grep on it without conditional lookups; the agent list
+# uses the LANE_B_ISOLATED_SKIP_REASON literal so the grep contract is
+# stable across both surfaces (audit log + stdout). The raw=$raw_count
+# field is the #585 raw envelope counter and stays adjacent to the other
+# Lane B lane counters.
+skipped_isolated_csv=""
+if (( skipped_isolated_count > 0 )); then
+  skipped_isolated_csv="$(IFS=,; echo "${SKIPPED_ISOLATED_AGENTS[*]}")"
+fi
+echo "wiki-daily-ingest: date=$DATE since=$YESTERDAY lane-a ${copy_summary} lane-b research=$research_count other=$other_count raw=$raw_count total=$non_daily_total skipped-isolated=$skipped_isolated_count skipped-isolated-reason=$LANE_B_ISOLATED_SKIP_REASON skipped-isolated-agents=${skipped_isolated_csv:-none} log=$LOG"

--- a/tests/wiki-daily-ingest/agb-mock.sh
+++ b/tests/wiki-daily-ingest/agb-mock.sh
@@ -37,6 +37,16 @@ case "${1:-}" in
     ;;
   task)
     if [[ "${2:-}" == "create" ]]; then
+      # Issue #583 Track C r2: record `task create` argv so smoke scenarios
+      # can prove the librarian-ingest task creation/non-creation contract
+      # (scenario 11 asserts no [librarian-ingest] line for skipped isolated
+      # agents; scenario 12 asserts one for the shared-agent passthrough;
+      # scenarios 13 and 14 assert the same negative for legacy-path and
+      # raw-walk skips respectively). When AGB_MOCK_TASK_LOG is unset the
+      # mock stays a no-op so unrelated callers/tests are not perturbed.
+      if [[ -n "${AGB_MOCK_TASK_LOG:-}" ]]; then
+        printf '%s\n' "$*" >>"$AGB_MOCK_TASK_LOG"
+      fi
       exit 0
     fi
     exit 1

--- a/tests/wiki-daily-ingest/smoke.sh
+++ b/tests/wiki-daily-ingest/smoke.sh
@@ -123,6 +123,17 @@ reset_runtime() {
   rm -rf "$BRIDGE_WIKI_ROOT/_audit" 2>/dev/null || true
   rm -f "$WIKI_WATERMARK_FILE" 2>/dev/null || true
   rm -rf "$AGENT_HOME/memory" 2>/dev/null || true
+  # Issue #582 / #583 Track C: scenarios that seed `$AGENT_HOME/raw/` (raw
+  # PreCompact envelopes) must not bleed across into later scenarios — the
+  # legacy walk iterates `$AGENTS_ROOT/*` and picks up any leftover envelope.
+  # Clean both the raw/ subtree and any stray data-v2/ fixtures the v2
+  # scenarios create under SMOKE_ROOT, so each `reset_runtime` returns a
+  # genuinely empty AGENT_HOME and a clean v2 root.
+  rm -rf "$AGENT_HOME/raw" 2>/dev/null || true
+  if [[ -n "${SMOKE_ROOT:-}" && -d "$SMOKE_ROOT/data-v2" ]]; then
+    chmod -R u+rwX "$SMOKE_ROOT/data-v2" 2>/dev/null || true
+    rm -rf "$SMOKE_ROOT/data-v2" 2>/dev/null || true
+  fi
   mkdir -p "$BRIDGE_WIKI_ROOT/_audit" "$AGENT_HOME/memory"
 }
 
@@ -671,6 +682,345 @@ else
     pass "10"
   fi
 fi
+
+# =============================================================================
+# Scenario 11 — Issue #583 Track C: linux-user-isolated agent is skipped from
+# Lane B before any filesystem read AND recorded in the audit log + stdout
+# under the stable reason `isolated_private_root_unreadable_by_design`.
+#
+# We populate a 0700-mode private memory root for an "isolated" agent (the
+# operator UID still owns it in this hermetic smoke, but the test asserts
+# the SKIP path triggers regardless of whether the operator could actually
+# read it — the Track C contract is "don't even try"). The mock returns
+# isolation.mode=linux-user for this agent in `agb agent list --json`. The
+# audit log must show "Skipped (isolated private root) (1)" with the
+# stable reason string and must NOT enumerate the projects file. The
+# stdout summary must include `skipped-isolated=1` and the literal reason.
+#
+# Renumbered from scenario 8 to 11 to avoid colliding with PR #585's
+# scenarios 8/9/10 (raw envelope enumeration + dedup) on `main`.
+# =============================================================================
+banner "11 — Track C: linux-user agent is skipped explicitly with stable reason"
+reset_runtime
+write_note "$TODAY" "# $TODAY note"
+
+ISO_AGENT="iso-agent"
+ISO_WORKDIR="$SMOKE_ROOT/data-v2/agents/$ISO_AGENT/workdir"
+mkdir -p "$ISO_WORKDIR/memory/projects"
+echo "# would-be-promote" >"$ISO_WORKDIR/memory/projects/foo.md"
+touch "$ISO_WORKDIR/memory/projects/foo.md"
+chmod 0700 "$ISO_WORKDIR/memory/projects" 2>/dev/null || true
+chmod 0700 "$ISO_WORKDIR/memory" 2>/dev/null || true
+
+# Mock returns one active claude agent flagged isolation.mode=linux-user.
+AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
+import json, sys
+print(json.dumps([{
+    'agent': '$ISO_AGENT',
+    'engine': 'claude',
+    'active': True,
+    'workdir': '$ISO_WORKDIR',
+    'isolation': {'mode': 'linux-user'},
+}]))
+")"
+export AGB_MOCK_AGENT_LIST_JSON
+
+export BRIDGE_LAYOUT=v2
+BRIDGE_DATA_ROOT_FIXTURE="$SMOKE_ROOT/data-v2"
+mkdir -p "$BRIDGE_DATA_ROOT_FIXTURE"
+export BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT_FIXTURE"
+
+# Issue #583 Track C r2: capture every `task create` invocation the mock
+# observes during this scenario. The Track C contract requires that NO
+# [librarian-ingest] task is created when every active agent is
+# linux-user-isolated (Lane B has nothing to enumerate, so the librarian
+# call site is short-circuited).
+S11_TASK_LOG="$SMOKE_ROOT/s11.task-log"
+: >"$S11_TASK_LOG"
+export AGB_MOCK_TASK_LOG="$S11_TASK_LOG"
+
+out_file="$(run_ingest s11 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+err_file="$SMOKE_ROOT/s11.err"
+if [[ ! -f "$audit_file" ]]; then
+  fail "11" "audit log missing: $audit_file"
+elif grep -qiE "permission denied|EACCES" "$err_file" "$out_file"; then
+  fail "11" "EACCES leaked into ingest output (stderr or stdout); err=$(head -c 200 "$err_file") out=$(head -c 200 "$out_file")"
+elif ! grep -q "Skipped (isolated private root) (1)" "$audit_file"; then
+  fail "11" "audit log missing 'Skipped (isolated private root) (1)' header; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "$ISO_AGENT — reason: isolated_private_root_unreadable_by_design" "$audit_file"; then
+  fail "11" "audit log missing skipped agent + reason line; body: $(head -c 400 "$audit_file")"
+elif grep -q "projects/foo.md" "$audit_file"; then
+  fail "11" "private root was enumerated despite linux-user isolation; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "skipped-isolated=1" "$out_file"; then
+  fail "11" "stdout missing skipped-isolated=1 counter; got: $(head -c 200 "$out_file")"
+elif ! grep -q "skipped-isolated-reason=isolated_private_root_unreadable_by_design" "$out_file"; then
+  fail "11" "stdout missing stable reason literal; got: $(head -c 200 "$out_file")"
+elif ! grep -q "skipped-isolated-agents=$ISO_AGENT" "$out_file"; then
+  fail "11" "stdout missing isolated agent name; got: $(head -c 200 "$out_file")"
+elif grep -q '\[librarian-ingest\]' "$S11_TASK_LOG"; then
+  fail "11" "[librarian-ingest] task was created for skipped isolated agent; task-log: $(head -c 200 "$S11_TASK_LOG")"
+else
+  pass "11"
+fi
+
+# Restore mode so the EXIT trap can rm -rf without permission errors.
+chmod -R u+rwX "$ISO_WORKDIR" 2>/dev/null || true
+unset AGB_MOCK_AGENT_LIST_JSON BRIDGE_LAYOUT BRIDGE_DATA_ROOT AGB_MOCK_TASK_LOG 2>/dev/null || true
+
+# =============================================================================
+# Scenario 12 — Issue #583 Track C: non-isolated (shared) agent is unaffected.
+# Same shape as scenario 7, but explicitly assert that an agent without
+# isolation.mode=linux-user is enumerated as before AND that the audit log's
+# Track C section reports zero skips. This proves the filter is gated on the
+# isolation field and does not regress the existing path.
+#
+# Renumbered from scenario 9 to 12 to avoid colliding with PR #585's
+# scenarios 8/9/10 on `main`.
+# =============================================================================
+banner "12 — Track C: shared (non-isolated) agent is enumerated as before"
+reset_runtime
+write_note "$TODAY" "# $TODAY note"
+
+SHARED_WORKDIR="$SMOKE_ROOT/data-v2/agents/$AGENT/workdir"
+mkdir -p "$SHARED_WORKDIR/memory/projects"
+echo "# shared probe" >"$SHARED_WORKDIR/memory/projects/bar.md"
+touch "$SHARED_WORKDIR/memory/projects/bar.md"
+
+AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
+import json, sys
+print(json.dumps([{
+    'agent': '$AGENT',
+    'engine': 'claude',
+    'active': True,
+    'workdir': '$SHARED_WORKDIR',
+    'isolation': {'mode': 'shared'},
+}]))
+")"
+export AGB_MOCK_AGENT_LIST_JSON
+export BRIDGE_LAYOUT=v2
+mkdir -p "$BRIDGE_DATA_ROOT_FIXTURE"
+export BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT_FIXTURE"
+
+# Issue #583 Track C r2: companion to scenario 11. The shared-agent
+# passthrough must still produce exactly one [librarian-ingest] task — this
+# is the regression sentinel that proves the Track C filter does not
+# accidentally suppress task creation for non-isolated agents.
+S12_TASK_LOG="$SMOKE_ROOT/s12.task-log"
+: >"$S12_TASK_LOG"
+export AGB_MOCK_TASK_LOG="$S12_TASK_LOG"
+
+out_file="$(run_ingest s12 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+if [[ ! -f "$audit_file" ]]; then
+  fail "12" "audit log missing: $audit_file"
+elif ! grep -q "projects/bar.md" "$audit_file"; then
+  fail "12" "shared agent's projects/bar.md was NOT enumerated; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "Skipped (isolated private root) (0)" "$audit_file"; then
+  fail "12" "audit log expected 'Skipped (isolated private root) (0)' header; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "skipped-isolated=0" "$out_file"; then
+  fail "12" "stdout missing skipped-isolated=0 counter; got: $(head -c 200 "$out_file")"
+elif ! grep -q "skipped-isolated-agents=none" "$out_file"; then
+  fail "12" "stdout expected skipped-isolated-agents=none; got: $(head -c 200 "$out_file")"
+elif ! grep -q '\[librarian-ingest\]' "$S12_TASK_LOG"; then
+  fail "12" "shared-agent passthrough did NOT create a [librarian-ingest] task; task-log: $(head -c 200 "$S12_TASK_LOG")"
+else
+  pass "12"
+fi
+
+unset AGB_MOCK_AGENT_LIST_JSON BRIDGE_LAYOUT BRIDGE_DATA_ROOT AGB_MOCK_TASK_LOG 2>/dev/null || true
+
+# =============================================================================
+# Scenario 13 — Issue #583 Track C r2: legacy-path isolated agent is skipped
+# BEFORE any stat into its memory subdir.
+#
+# This is the Finding-1 load-bearing case. The legacy iteration must:
+#   - record the isolated agent under SKIPPED_ISOLATED_AGENTS via deny-list
+#   - NOT enumerate $AGENTS_ROOT/<iso>/memory at all
+#
+# We deliberately give the isolated agent a memory subtree containing a
+# research file. With the correct r2 ordering (deny-list BEFORE memory
+# `[[ -d ]]`) the file is not enumerated and the agent is recorded as
+# skipped. The pre-r2 ordering (memory `[[ -d ]]` first, then deny-list)
+# would also avoid enumerating because the deny-list still runs before
+# AGENT_MEMORY_ROOTS+=, but the stat into the private memory subdir would
+# already have happened — which is exactly the contract violation Finding 1
+# called out. To observe the difference *behaviorally* in this hermetic
+# smoke, we exercise the case where the isolated agent has NO memory
+# subdir: r2 still records the skip via deny-list, while r1 (which gates on
+# `[[ -d "$_legacy_dir" ]]` first) silently drops the agent before the
+# deny-list runs and reports zero skips.
+#
+# Renumbered from scenario 10 to 13 to avoid colliding with PR #585's
+# scenarios 8/9/10 on `main`.
+# =============================================================================
+banner "13 — Track C r2: legacy-path isolated agent skip is recorded even without memory/"
+reset_runtime
+unset BRIDGE_LAYOUT 2>/dev/null || true
+write_note "$TODAY" "# $TODAY note"
+
+ISO_LEGACY_AGENT="iso-legacy-agent"
+# Create the agent home but intentionally NO memory subdir. Under r2 the
+# deny-list short-circuits before the memory `[[ -d ]]` test, so the skip
+# is still recorded. Under r1 the missing memory subdir caused the iter
+# body to `continue` before the deny-list ran, so the skip went unrecorded.
+mkdir -p "$BRIDGE_AGENTS_ROOT/$ISO_LEGACY_AGENT"
+
+# Mock declares this agent linux-user-isolated.
+AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
+import json, sys
+print(json.dumps([{
+    'agent': '$ISO_LEGACY_AGENT',
+    'engine': 'claude',
+    'active': True,
+    'isolation': {'mode': 'linux-user'},
+}]))
+")"
+export AGB_MOCK_AGENT_LIST_JSON
+
+S13_TASK_LOG="$SMOKE_ROOT/s13.task-log"
+: >"$S13_TASK_LOG"
+export AGB_MOCK_TASK_LOG="$S13_TASK_LOG"
+
+out_file="$(run_ingest s13 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+if [[ ! -f "$audit_file" ]]; then
+  fail "13" "audit log missing: $audit_file"
+elif ! grep -q "Skipped (isolated private root) (1)" "$audit_file"; then
+  fail "13" "audit log missing 'Skipped (isolated private root) (1)' for legacy iso agent; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "$ISO_LEGACY_AGENT — reason: isolated_private_root_unreadable_by_design" "$audit_file"; then
+  fail "13" "audit log missing skipped legacy agent + reason line; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "skipped-isolated=1" "$out_file"; then
+  fail "13" "stdout missing skipped-isolated=1 for legacy iso agent; got: $(head -c 200 "$out_file")"
+elif ! grep -q "skipped-isolated-agents=$ISO_LEGACY_AGENT" "$out_file"; then
+  fail "13" "stdout missing legacy isolated agent name; got: $(head -c 200 "$out_file")"
+elif grep -q '\[librarian-ingest\]' "$S13_TASK_LOG"; then
+  fail "13" "[librarian-ingest] task created for legacy-path isolated agent; task-log: $(head -c 200 "$S13_TASK_LOG")"
+else
+  pass "13"
+fi
+
+unset AGB_MOCK_AGENT_LIST_JSON AGB_MOCK_TASK_LOG 2>/dev/null || true
+
+# =============================================================================
+# Scenario 14 — Issue #583 Track C ∩ Issue #582: an isolated agent with a
+# raw PreCompact envelope under `<workdir>/raw/captures/inbox/` is skipped
+# from BOTH Lane B walks (memory + raw envelope) without an EACCES leak.
+#
+# This is the load-bearing assertion for the Track C extension to PR #585's
+# raw envelope walk. We seed:
+#   - a 0700/2750 isolated workdir for an agent flagged
+#     `isolation.mode=linux-user` in `agb agent list --json`,
+#   - a schema_version=1 raw envelope at
+#     `<workdir>/raw/captures/inbox/precompact-isolated.json`.
+#
+# Track C requires that AGENT_MEMORY_ROOTS exclude this agent before either
+# the memory walk or the new raw envelope walk runs. The audit log must
+# therefore:
+#   - report `Raw envelopes (0)` (the raw inbox is NEVER stat'd),
+#   - NOT mention `precompact-isolated.json`,
+#   - record `Skipped (isolated private root) (1)` with the stable reason,
+#   - mention the isolated agent ONCE (no double-count for memory + raw).
+# Stdout: `raw=0`, `skipped-isolated=1`. No EACCES on either stream.
+# No `[librarian-ingest]` task is created for the isolated agent.
+#
+# Pre-extension verification: with the raw-walk loop unguarded by the
+# AGENT_MEMORY_ROOTS filter (e.g., walking the install-root or workdir
+# directly), the envelope would be enumerated and `Raw envelopes (1)` /
+# `raw=1` would appear — making this scenario fail. With the extension in
+# place (the raw walk reuses the already-filtered AGENT_MEMORY_ROOTS), the
+# envelope is invisible to Lane B.
+# =============================================================================
+banner "14 — Track C: isolated agent's raw envelope inbox is skipped without EACCES"
+reset_runtime
+write_note "$TODAY" "# $TODAY note"
+
+ISO_RAW_AGENT="iso-raw-agent"
+ISO_RAW_WORKDIR="$SMOKE_ROOT/data-v2/agents/$ISO_RAW_AGENT/workdir"
+mkdir -p "$ISO_RAW_WORKDIR/memory/projects"
+mkdir -p "$ISO_RAW_WORKDIR/raw/captures/inbox"
+echo "# would-be-promote" >"$ISO_RAW_WORKDIR/memory/projects/foo.md"
+touch "$ISO_RAW_WORKDIR/memory/projects/foo.md"
+
+# Seed a raw PreCompact envelope under the isolated workdir. If the Track C
+# raw-walk skip is missing, this file would be picked up.
+cat >"$ISO_RAW_WORKDIR/raw/captures/inbox/precompact-isolated.json" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$ISO_RAW_AGENT",
+  "captured_at": "${TODAY}T00:00:00Z",
+  "session_type": "default",
+  "trigger": "manual",
+  "source": "pre-compact-hook",
+  "custom_instructions_excerpt": "",
+  "suggested_entities": ["projects/iso-raw-smoke"],
+  "suggested_concepts": [],
+  "suggested_slug": "iso-raw-smoke",
+  "suggested_title": "iso raw smoke",
+  "excerpt": "pre-compact trigger=manual agent=$ISO_RAW_AGENT iso-raw smoke",
+  "transcript_available": false
+}
+EOF
+touch "$ISO_RAW_WORKDIR/raw/captures/inbox/precompact-isolated.json"
+# 2750 mirrors the production isolated layout (sgid + group-traverse, owner-
+# only read). `chmod 0700` on memory + raw mirrors the per-UID lockdown.
+chmod 0700 "$ISO_RAW_WORKDIR/memory" 2>/dev/null || true
+chmod 0700 "$ISO_RAW_WORKDIR/raw" 2>/dev/null || true
+chmod 0700 "$ISO_RAW_WORKDIR/raw/captures" 2>/dev/null || true
+chmod 0700 "$ISO_RAW_WORKDIR/raw/captures/inbox" 2>/dev/null || true
+
+AGB_MOCK_AGENT_LIST_JSON="$("$PYTHON" -c "
+import json
+print(json.dumps([{
+    'agent': '$ISO_RAW_AGENT',
+    'engine': 'claude',
+    'active': True,
+    'workdir': '$ISO_RAW_WORKDIR',
+    'isolation': {'mode': 'linux-user'},
+}]))
+")"
+export AGB_MOCK_AGENT_LIST_JSON
+export BRIDGE_LAYOUT=v2
+BRIDGE_DATA_ROOT_FIXTURE="$SMOKE_ROOT/data-v2"
+mkdir -p "$BRIDGE_DATA_ROOT_FIXTURE"
+export BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT_FIXTURE"
+
+S14_TASK_LOG="$SMOKE_ROOT/s14.task-log"
+: >"$S14_TASK_LOG"
+export AGB_MOCK_TASK_LOG="$S14_TASK_LOG"
+
+out_file="$(run_ingest s14 || true)"
+audit_file="$BRIDGE_WIKI_ROOT/_audit/ingest-$TODAY.md"
+err_file="$SMOKE_ROOT/s14.err"
+if [[ ! -f "$audit_file" ]]; then
+  fail "14" "audit log missing: $audit_file"
+elif grep -qiE "permission denied|EACCES" "$err_file" "$out_file"; then
+  fail "14" "EACCES leaked into ingest output (stderr or stdout); err=$(head -c 200 "$err_file") out=$(head -c 200 "$out_file")"
+elif grep -q "precompact-isolated.json" "$audit_file"; then
+  fail "14" "isolated agent's raw envelope was enumerated despite linux-user isolation; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "Raw envelopes (0)" "$audit_file"; then
+  fail "14" "audit log expected 'Raw envelopes (0)' for skipped isolated agent; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "Skipped (isolated private root) (1)" "$audit_file"; then
+  fail "14" "audit log missing 'Skipped (isolated private root) (1)' header; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "$ISO_RAW_AGENT — reason: isolated_private_root_unreadable_by_design" "$audit_file"; then
+  fail "14" "audit log missing skipped agent + reason line; body: $(head -c 400 "$audit_file")"
+elif ! grep -q "raw=0" "$out_file"; then
+  fail "14" "stdout expected raw=0 for skipped isolated agent; got: $(head -c 200 "$out_file")"
+elif ! grep -q "skipped-isolated=1" "$out_file"; then
+  fail "14" "stdout missing skipped-isolated=1 counter; got: $(head -c 200 "$out_file")"
+elif ! grep -q "skipped-isolated-agents=$ISO_RAW_AGENT" "$out_file"; then
+  fail "14" "stdout missing isolated agent name; got: $(head -c 200 "$out_file")"
+elif grep -q '\[librarian-ingest\]' "$S14_TASK_LOG"; then
+  fail "14" "[librarian-ingest] task was created for skipped isolated raw-walk agent; task-log: $(head -c 200 "$S14_TASK_LOG")"
+elif [[ "$(grep -c "$ISO_RAW_AGENT — reason:" "$audit_file" || true)" -ne 1 ]]; then
+  fail "14" "skipped isolated agent listed more than once in audit log (memory + raw should dedup); body: $(head -c 400 "$audit_file")"
+else
+  pass "14"
+fi
+
+# Restore mode so the EXIT trap can rm -rf without permission errors.
+chmod -R u+rwX "$ISO_RAW_WORKDIR" 2>/dev/null || true
+unset AGB_MOCK_AGENT_LIST_JSON BRIDGE_LAYOUT BRIDGE_DATA_ROOT AGB_MOCK_TASK_LOG 2>/dev/null || true
 
 # -----------------------------------------------------------------------------
 # Summary


### PR DESCRIPTION
## Summary

`wiki-daily-ingest.sh` Lane B was enumerating every agent's `memory/projects/`, `memory/shared/`, `memory/decisions/` and creating `[librarian-ingest]` tasks for the librarian. For agents under `--isolation linux-user`, the librarian's operator-UID can't read those files (private root is `0700` per-UID owned), the librarian closes each task with "cross-agent access blocked", and the daily scan re-detects the same files tomorrow — identical tasks accumulate forever.

This PR ships **Track C** from the issue: classify each agent's isolation mode from operator-UID-readable metadata only, and explicitly skip isolated-private-root agents from Lane B enumeration before any read attempt. No ACL grants. No producer-side changes. Track B (push-to-staging) is the long-term fix and is a separate future PR — Track C and Track B are orthogonal and B can land on top of C without conflict.

## Why explicit skip, not silent skip

A silent skip would just hide the problem; the operator and any downstream log consumer would have no signal that data is being dropped. This PR records every skipped agent with the stable reason `isolated_private_root_unreadable_by_design` in:

- the daily report's new "Skipped (isolated private root) (N)" section (human-readable markdown), and
- the structured stdout summary (`skipped-isolated=N`, `skipped-isolated-reason=…`, `skipped-isolated-agents=…` so log consumers can grep on the literal).

## Why no ACL

Operator policy after isolate-v2: ACL grants on private roots are not added. The repository's history (#233, #441, #543, #534, plus the v0.7.7 release line "isolation hardening") shows ACL drift / repair is a recurring failure mode. Track C honors that policy by not reading the private root at all — no `setfacl` / `getfacl` calls anywhere in this PR.

## Implementation notes

Both the v2 strict path and the legacy fallback now ask `agb agent list --json` for the isolation mode. In v2 the existing TSV (already piped through `BRIDGE_PYTHON`) is extended with a third `mode` column and the loop checks `mode == linux-user` before recording the workdir. In the legacy path the same JSON is parsed into a newline-delimited deny-list (Bash 3.2 compatible — no associative array) and the install-root `agents/*/memory` glob skips matching dirs. Empty-array iteration under `set -u` is guarded with explicit `(( ${#…[@]} > 0 ))` checks so an all-isolated install doesn't blow up.

## Verification

- `bash -n scripts/wiki-daily-ingest.sh tests/wiki-daily-ingest/smoke.sh` — PASS
- `shellcheck scripts/wiki-daily-ingest.sh tests/wiki-daily-ingest/smoke.sh` — PASS
- `bash tests/wiki-daily-ingest/smoke.sh` — 9/9 PASS
- Pre-fix regression check: scenarios 8 and 9 (this PR's new regression coverage) FAIL when run against `origin/main`'s `scripts/wiki-daily-ingest.sh`; PASS on this branch — confirming Track C closes the gap.
- `./scripts/smoke-test.sh` halts on the same pre-existing `#365 follow-up isolated agent-env` failure on both `origin/main` and this branch — not introduced by this change.

### New regression scenarios

- **Scenario 8** — `linux-user`-isolated agent with `0700` per-UID memory root is skipped without EACCES, the audit log records "Skipped (isolated private root) (1)" with the stable reason, the stdout summary reports `skipped-isolated=1` with the agent name, and no `projects/foo.md` line is enumerated.
- **Scenario 9** — `shared` (non-isolated) agent is unaffected — its `projects/bar.md` is enumerated as before and the audit log reports `Skipped (isolated private root) (0)`.

## Closes / references

References #583. Track A (ACL grant) is explicitly out of scope per operator policy. Track B (push-to-staging) is deferred to a separate PR — Track B can land on top of this without conflict.