### PR TITLE
fix(watchdog): refuse cross-home BRIDGE_DAEMON_PID_FILE configurations (#591)

### DIFF
--- a/bridge-watchdog-silence.py
+++ b/bridge-watchdog-silence.py
@@ -16,6 +16,16 @@ vector slips past the timeout layer, audit silence is the durable signal
 and an automated restart contains the blast radius without operator
 intervention.
 
+Trust model (issue #591):
+    `BRIDGE_DAEMON_PID_FILE` MUST resolve to a path under `BRIDGE_HOME`.
+    The watchdog supervises only the daemon launched from the same
+    `BRIDGE_HOME` tree; a cross-home configuration (e.g. a dev shell that
+    leaked the live host's pid file path while pointing `BRIDGE_HOME` at
+    a temp dir) lets a stale watchdog SIGTERM the live daemon. The
+    validator at startup (`_validate_cross_home`) refuses to run in that
+    shape and exits with code 2, distinct from the normal "no daemon
+    running" path.
+
 Usage:
     python3 bridge-watchdog-silence.py run [--once]
     python3 bridge-watchdog-silence.py status
@@ -24,7 +34,7 @@ Environment:
     BRIDGE_HOME                                       runtime root
     BRIDGE_AUDIT_LOG                                  audit JSONL path
     BRIDGE_STATE_DIR                                  state dir for cooldown file
-    BRIDGE_DAEMON_PID_FILE                            daemon pid file
+    BRIDGE_DAEMON_PID_FILE                            daemon pid file (must be under BRIDGE_HOME)
     BRIDGE_DAEMON_HEARTBEAT_SECONDS                   if 0, watchdog disables itself
     BRIDGE_DAEMON_SILENCE_THRESHOLD_SECONDS           default 600
     BRIDGE_DAEMON_SILENCE_POLL_INTERVAL_SECONDS       default 60
@@ -63,6 +73,34 @@ COOLDOWN_FILE = Path(
 DAEMON_SCRIPT = Path(
     os.environ.get("BRIDGE_DAEMON_SCRIPT", SCRIPT_DIR / "bridge-daemon.sh")
 )
+
+
+def _validate_cross_home() -> None:
+    """Refuse to run if `BRIDGE_DAEMON_PID_FILE` is outside `BRIDGE_HOME`.
+
+    Issue #591 / #592: a watchdog inheriting `BRIDGE_DAEMON_PID_FILE` from a
+    parent shell while `BRIDGE_HOME` points at a temp dir will read its own
+    (empty) audit log, conclude the live daemon is silent, and SIGTERM the
+    live PID. The legitimate use case (a test bridge-home shutting down its
+    own daemon) is preserved because that test's pid file lives under its
+    own BRIDGE_HOME — only the *cross-home* shape is unsafe.
+
+    `.resolve()` is called on both paths so symlinked BRIDGE_HOME layouts
+    (e.g. `~/.agent-bridge` -> `~/.agent-bridge-home`) compare correctly.
+    """
+    pid_file = BRIDGE_DAEMON_PID_FILE.resolve()
+    home = BRIDGE_HOME.resolve()
+    try:
+        pid_file.relative_to(home)
+    except ValueError:
+        log.error(
+            "refusing to run: BRIDGE_DAEMON_PID_FILE=%s is outside BRIDGE_HOME=%s "
+            "(cross-home configuration is unsafe; the watchdog can only supervise "
+            "a daemon whose pid file lives under its own BRIDGE_HOME). "
+            "Unset BRIDGE_DAEMON_PID_FILE or set BRIDGE_HOME to match.",
+            pid_file, home,
+        )
+        sys.exit(2)  # exit code distinct from normal "no daemon running" paths
 
 
 def _env_int(name: str, default: int) -> int:
@@ -427,6 +465,10 @@ def main() -> int:
     status_p.set_defaults(handler=cmd_status)
 
     args = parser.parse_args()
+    # Issue #591: refuse to run with a cross-home pid file before any state
+    # read or audit peek so a leaked-env orphan terminates itself instead of
+    # cross-home killing the live daemon.
+    _validate_cross_home()
     return int(args.handler(args))
 
 

--- a/tests/watchdog-silence-cross-home/smoke.sh
+++ b/tests/watchdog-silence-cross-home/smoke.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# watchdog-silence cross-home smoke — issue #591.
+#
+# Verifies that bridge-watchdog-silence.py refuses to run when
+# BRIDGE_DAEMON_PID_FILE resolves outside BRIDGE_HOME, while still accepting
+# same-home, default, and symlinked-home configurations.
+#
+# Each case runs in an isolated mktemp BRIDGE_HOME — never touches the live
+# install. The actual assertions live in test_cross_home.py alongside this
+# wrapper so the Python validator can be exercised directly.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+TEST_PY="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/test_cross_home.py"
+
+if [[ ! -x "$PYTHON" && ! -r "$PYTHON" ]]; then
+  printf '[smoke][error] python3 not found at %s\n' "$PYTHON" >&2
+  exit 2
+fi
+if [[ ! -f "$TEST_PY" ]]; then
+  printf '[smoke][error] test_cross_home.py missing alongside smoke.sh\n' >&2
+  exit 2
+fi
+if [[ ! -f "$REPO_ROOT/bridge-watchdog-silence.py" ]]; then
+  printf '[smoke][error] bridge-watchdog-silence.py not found at repo root\n' >&2
+  exit 2
+fi
+
+# Scrub any inherited env so the "defaults accepted" case actually tests
+# defaults rather than the operator's live install paths.
+unset BRIDGE_HOME BRIDGE_DAEMON_PID_FILE BRIDGE_STATE_DIR BRIDGE_LOG_DIR BRIDGE_AUDIT_LOG
+
+exec "$PYTHON" "$TEST_PY"

--- a/tests/watchdog-silence-cross-home/test_cross_home.py
+++ b/tests/watchdog-silence-cross-home/test_cross_home.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Regression test for issue #591 — bridge-watchdog-silence.py must refuse
+to run when `BRIDGE_DAEMON_PID_FILE` resolves outside `BRIDGE_HOME`.
+
+The bug: a watchdog inheriting `BRIDGE_DAEMON_PID_FILE` from a parent shell
+while pointing `BRIDGE_HOME` at a temp dir reads its own (empty) audit log,
+concludes the live daemon is silent, and SIGTERMs the live PID at ~0.4
+events/min until launchd KeepAlive gives up.
+
+This test exercises `_validate_cross_home()` in four shapes:
+  1. cross-home  -> SystemExit(2) and an error log
+  2. same-home   -> no exit
+  3. defaults    -> no exit (default pid file lives under default home)
+  4. symlinked   -> no exit when BRIDGE_HOME is a symlink to the pid file's
+                    real parent (`.resolve()` follows the symlink)
+
+The validator function is loaded fresh per case via importlib so each case
+gets the env it actually wants — module-level `Path(os.environ.get(...))`
+would otherwise cache the first case's values across the whole test run.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WATCHDOG_PATH = REPO_ROOT / "bridge-watchdog-silence.py"
+
+
+def _load_watchdog_module() -> Any:
+    """Re-import the watchdog module so module-level env reads pick up the
+    current test's `BRIDGE_HOME` / `BRIDGE_DAEMON_PID_FILE`."""
+    # Use a unique module name each call so importlib doesn't return a
+    # cached module with stale env-derived globals.
+    mod_name = f"bridge_watchdog_silence_under_test_{len(sys.modules)}"
+    spec = importlib.util.spec_from_file_location(mod_name, WATCHDOG_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not build import spec for {WATCHDOG_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _set_env(home: str | None, pid_file: str | None) -> None:
+    """Set or unset the two env vars the watchdog reads at import time."""
+    for key, value in (("BRIDGE_HOME", home), ("BRIDGE_DAEMON_PID_FILE", pid_file)):
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+
+
+def _capture_validate(module: Any) -> tuple[int | None, str]:
+    """Run `_validate_cross_home()` with a captured logger and return
+    `(exit_code, error_log_text)`. `exit_code` is None on the no-exit path."""
+    handler_records: list[logging.LogRecord] = []
+
+    class ListHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            handler_records.append(record)
+
+    handler = ListHandler(level=logging.ERROR)
+    module.log.addHandler(handler)
+    try:
+        try:
+            module._validate_cross_home()
+        except SystemExit as exc:
+            code = exc.code if isinstance(exc.code, int) else 1
+            text = "\n".join(r.getMessage() for r in handler_records if r.levelno >= logging.ERROR)
+            return code, text
+        return None, ""
+    finally:
+        module.log.removeHandler(handler)
+
+
+def case_cross_home_refused() -> None:
+    """(1) BRIDGE_HOME=/tmp/<a>, pid file under /tmp/<b> -> SystemExit(2)."""
+    with tempfile.TemporaryDirectory(prefix="agb-test-home-") as home, \
+         tempfile.TemporaryDirectory(prefix="agb-test-state-") as elsewhere:
+        pid_file = Path(elsewhere) / "daemon.pid"
+        pid_file.write_text("99999\n", encoding="utf-8")
+        _set_env(home=home, pid_file=str(pid_file))
+        module = _load_watchdog_module()
+        code, log_text = _capture_validate(module)
+    assert code == 2, f"expected SystemExit(2), got {code!r}"
+    assert "refusing to run" in log_text, f"missing error log; got: {log_text!r}"
+    assert "BRIDGE_DAEMON_PID_FILE" in log_text, f"log missing var name: {log_text!r}"
+
+
+def case_same_home_accepted() -> None:
+    """(2) pid file under BRIDGE_HOME -> no exit."""
+    with tempfile.TemporaryDirectory(prefix="agb-test-home-") as home:
+        state_dir = Path(home) / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = state_dir / "daemon.pid"
+        pid_file.write_text("99999\n", encoding="utf-8")
+        _set_env(home=home, pid_file=str(pid_file))
+        module = _load_watchdog_module()
+        code, _ = _capture_validate(module)
+    assert code is None, f"unexpected exit on same-home config: code={code!r}"
+
+
+def case_defaults_accepted() -> None:
+    """(3) Both vars unset -> defaults resolve consistently. The watchdog's
+    default `BRIDGE_DAEMON_PID_FILE` is `BRIDGE_STATE_DIR/daemon.pid` which is
+    `BRIDGE_HOME/state/daemon.pid` — always under home by construction."""
+    _set_env(home=None, pid_file=None)
+    # Do NOT touch the live ~/.agent-bridge tree; the validator only does a
+    # path-prefix check via `.resolve()`. Default `Path.home() / ".agent-bridge"`
+    # may or may not exist on the test host; `.resolve()` returns the absolute
+    # path either way.
+    module = _load_watchdog_module()
+    code, _ = _capture_validate(module)
+    assert code is None, f"unexpected exit on default config: code={code!r}"
+
+
+def case_symlink_followed() -> None:
+    """(4) BRIDGE_HOME is a symlink to a tmp dir; pid file lives under the
+    symlink target. `.resolve()` on both sides should make them equal. We
+    point BRIDGE_HOME at the symlink and the pid file at the underlying
+    real-path so the naive (non-resolving) comparison would fail. With
+    `.resolve()` it succeeds."""
+    with tempfile.TemporaryDirectory(prefix="agb-test-real-") as real_home_str, \
+         tempfile.TemporaryDirectory(prefix="agb-test-link-parent-") as link_parent_str:
+        real_home = Path(real_home_str)
+        link_parent = Path(link_parent_str)
+        symlink_home = link_parent / "home-symlink"
+        os.symlink(real_home, symlink_home)
+        state_dir = real_home / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        pid_file = state_dir / "daemon.pid"
+        pid_file.write_text("99999\n", encoding="utf-8")
+        # BRIDGE_HOME points at the symlink path; pid file at the real path.
+        _set_env(home=str(symlink_home), pid_file=str(pid_file))
+        module = _load_watchdog_module()
+        code, log_text = _capture_validate(module)
+    assert code is None, (
+        f"symlinked BRIDGE_HOME should be accepted after .resolve(); "
+        f"got code={code!r} log={log_text!r}"
+    )
+
+
+def main() -> int:
+    cases = [
+        ("cross-home refused", case_cross_home_refused),
+        ("same-home accepted", case_same_home_accepted),
+        ("defaults accepted", case_defaults_accepted),
+        ("symlink followed", case_symlink_followed),
+    ]
+    failures = 0
+    for label, fn in cases:
+        try:
+            fn()
+        except AssertionError as exc:
+            failures += 1
+            print(f"[smoke][fail] {label}: {exc}", file=sys.stderr)
+        except Exception as exc:  # noqa: BLE001 — surface unexpected errors as failures
+            failures += 1
+            print(f"[smoke][fail] {label}: unexpected {type(exc).__name__}: {exc}", file=sys.stderr)
+        else:
+            print(f"[smoke][pass] {label}")
+    total = len(cases)
+    print(f"\n[smoke] watchdog-silence cross-home: {total - failures} pass, {failures} fail")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`bridge-watchdog-silence.py` reads `BRIDGE_HOME` and `BRIDGE_DAEMON_PID_FILE` independently with no constraint that the pid file lives under home. A dev/test/upgrade shell that exports `BRIDGE_HOME=$(mktemp -d)` while `BRIDGE_DAEMON_PID_FILE` is already set from a parent shell creates a watchdog that:

1. polls its own (empty) `BRIDGE_HOME/logs/audit.jsonl`,
2. finds no `daemon_tick`,
3. concludes the live daemon is silent,
4. calls `bridge-daemon.sh stop --force` against the live PID.

`launchd` `KeepAlive` respawns; the next tick re-detects silence; the cycle settles at ~N/300 SIGTERMs per second per rogue.

This is the issue surfaced in #591 (active on a SYRS MacBook with 17 rogues) and the duplicate report #592 from a sibling host.

### What changed

- Add `_validate_cross_home()` to `bridge-watchdog-silence.py`. Resolves both `BRIDGE_HOME` and `BRIDGE_DAEMON_PID_FILE` via `.resolve()` so symlink layouts compare correctly, then `pid_file.relative_to(home)` — `ValueError` -> `log.error` + `sys.exit(2)`. Exit code 2 is distinct from `skip:daemon_not_running`.
- Call from `main()` before any handler runs. `--help` still works (argparse exits before this), and the `status` subcommand validates too (cross-home `status` would still misrepresent state).
- Add `tests/watchdog-silence-cross-home/` exercising four shapes: cross-home refused, same-home accepted, defaults accepted, symlink-followed accepted.

### What didn't change

- `bridge-daemon.sh` — out of scope per brief.
- `VERSION` / `CHANGELOG.md` — release PRs handle bumps.
- Peer-PID identity check before SIGTERM (#591 suggestion (b)) — separate, defense-in-depth follow-up.
- Audit row when a cross-home attempt is blocked (#591 suggestion (c)) — separate.
- Spawn-side guard from `bridge_start_silence_watchdog` (#592 suggestion (4)) — separate.
- Cleaning up rogue watchdogs already running on a host — operators handle with `pkill -f bridge-watchdog-silence.py` filtered by env. The fix prevents new rogues from starting useful work.

### Reproduction (from issue #591)

Pre-fix:

```bash
BRIDGE_HOME=/tmp/scratch \
BRIDGE_DAEMON_PID_FILE=$HOME/.agent-bridge/state/daemon.pid \
python3 ~/.agent-bridge/bridge-watchdog-silence.py run &
# process keeps running; eventually SIGTERMs the live daemon.
```

Post-fix:

```
ERROR refusing to run: BRIDGE_DAEMON_PID_FILE=/Users/.../.agent-bridge/state/daemon.pid is outside BRIDGE_HOME=/private/tmp/scratch (cross-home configuration is unsafe; the watchdog can only supervise a daemon whose pid file lives under its own BRIDGE_HOME). Unset BRIDGE_DAEMON_PID_FILE or set BRIDGE_HOME to match.
exit=2
```

Verified locally on macOS 15.x ARM64. The `status` subcommand under the same env also exits 2 with the same error line, so the validator gate doesn't depend on which subcommand was invoked.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-watchdog-silence.py').read())"` passes.
- [x] `python3 bridge-watchdog-silence.py --help >/dev/null` still works.
- [x] `bash tests/watchdog-silence-cross-home/smoke.sh` -> `4 pass, 0 fail`.
  - cross-home -> `SystemExit(2)` with error log containing `refusing to run` and `BRIDGE_DAEMON_PID_FILE`.
  - same-home -> no exit.
  - defaults -> no exit (default pid file resolves under default home).
  - symlinked BRIDGE_HOME -> no exit (verifies `.resolve()` follows symlinks; naive prefix comparison would fail).
- [x] `shellcheck tests/watchdog-silence-cross-home/smoke.sh` clean.
- [x] `./scripts/smoke-test.sh` runs to completion. The intermediate `[smoke][error]` line on this host (`smoke tmux session was not created`) reproduces on a fresh `git clone` of `origin/main` without any edits, confirming it's pre-existing and unrelated to this change.
- [x] Live reproduction of the bug shape post-fix: `BRIDGE_HOME=/tmp/agb-fake-home BRIDGE_DAEMON_PID_FILE=$HOME/.agent-bridge/state/daemon.pid python3 bridge-watchdog-silence.py status` -> exit 2 with the loud error log.

Refs #591 — duplicate report tracked at #592.

🤖 Generated with [Claude Code](https://claude.com/claude-code)