### PR TITLE
fix(hooks): class-aware autoCompactWindow default (refs #593)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1347,7 +1347,18 @@ bridge_agent_shared_settings_plan_json() {
   local agent="$1"
   local workdir="$2"
   local launch_cmd
+  local agent_class=""
   launch_cmd="$(bridge_agent_launch_cmd_raw "$agent" 2>/dev/null || true)"
+  # Issue #593: pass the agent's source class through to the resolver so
+  # the plan/diff helper computes the same managed default the renderer
+  # will (static→400_000, dynamic→1_000_000). Without this the doctor
+  # path would always evaluate the unknown-class fallback (1_000_000) and
+  # report `needs-rerender` for every static agent on every run. Gate
+  # the lookup so the helper still works when callers haven't loaded
+  # the roster (the inline plan-json subprocess treats empty as unknown).
+  if declare -p BRIDGE_AGENT_SOURCE >/dev/null 2>&1; then
+    agent_class="$(bridge_agent_source "$agent" 2>/dev/null || true)"
+  fi
 
   # Issue #555: the rerender now writes the effective file at the
   # per-agent path ($BRIDGE_AGENT_HOME_ROOT/<agent>/.claude/
@@ -1362,14 +1373,15 @@ bridge_agent_shared_settings_plan_json() {
     "$(bridge_hook_shared_settings_base_file)" \
     "$(bridge_hook_shared_settings_overlay_file)" \
     "$(bridge_hook_per_agent_settings_effective_file "$agent")" \
-    "$launch_cmd" <<'PY'
+    "$launch_cmd" \
+    "$agent_class" <<'PY'
 import importlib.util
 import json
 import os
 import sys
 from pathlib import Path
 
-hooks_py, agent, workdir, base_file, overlay_file, effective_file, launch_cmd = sys.argv[1:]
+hooks_py, agent, workdir, base_file, overlay_file, effective_file, launch_cmd, agent_class = sys.argv[1:]
 spec = importlib.util.spec_from_file_location("bridge_hooks", hooks_py)
 if spec is None or spec.loader is None:
     raise SystemExit(f"could not load {hooks_py}")
@@ -1400,7 +1412,7 @@ def load_object(path: Path, label: str, *, absent_ok: bool = True) -> dict:
 
 base_payload = load_object(base_path, "base")
 overlay_payload = load_object(overlay_path, "overlay")
-managed_defaults = hooks.managed_claude_settings_defaults(launch_cmd or None)
+managed_defaults = hooks.managed_claude_settings_defaults(launch_cmd or None, agent_class or None)
 expected = hooks.merge_settings(managed_defaults, base_payload)
 expected = hooks.merge_settings(expected, overlay_payload)
 

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -18,26 +18,48 @@ from typing import Any
 # precedence over settings and would make operator overlays harder to reason
 # about.
 #
-# Default to the 1M-context window (issue #570): the previous launch_cmd
-# `[1m]` substring heuristic (issue #547) never fired in practice because
-# `[1m]` is a model-id suffix the runtime prints (`claude-opus-4-7[1m]`),
-# not a CLI argument — agents always launched with the 400_000 legacy cap,
-# making `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=45` compact at ~180K instead of
-# the intended ~450K. Setting 1_000_000 is a no-regret upper bound: any
-# model with smaller native context will compact earlier on its own.
-BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW = 1_000_000
+# Token budgets are class-aware (issue #593):
+# - static-class agents (long-lived, registered in agent-roster.local.sh)
+#   compact at 400_000 tokens — the legacy default that protects 8GB-RAM
+#   hosts from the worst-case 1M-context restore.
+# - dynamic agents (--prefer new, ad hoc, --codex --name … spawns)
+#   compact at 1_000_000 tokens — they're disposable and benefit from
+#   the full window.
+# Unknown / missing class falls back to 1_000_000 (safer per issue #570:
+# the prior launch_cmd `[1m]` substring heuristic from #547 never fired in
+# practice — `[1m]` is a model-id suffix the runtime prints, not a CLI
+# argument — and 1_000_000 is a no-regret upper bound because models with
+# smaller native context will compact earlier on their own).
+BRIDGE_AUTOCOMPACT_WINDOW_STATIC = 400_000
+BRIDGE_AUTOCOMPACT_WINDOW_DYNAMIC = 1_000_000
+BRIDGE_AUTOCOMPACT_WINDOW_DEFAULT = BRIDGE_AUTOCOMPACT_WINDOW_DYNAMIC
+# Back-compat alias for any external caller that imported the pre-#593
+# constant name; same value as the unknown-class fallback.
+BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW = BRIDGE_AUTOCOMPACT_WINDOW_DEFAULT
 
 
-def resolve_managed_autocompact_window(launch_cmd: str | None) -> int:
-    # launch_cmd is accepted for backwards compatibility with callers but is
-    # no longer consulted; see issue #570.
+def resolve_managed_autocompact_window(
+    launch_cmd: str | None,
+    agent_class: str | None = None,
+) -> int:
+    # launch_cmd is retained for ABI compatibility with callers that still
+    # pass it positionally; the substring heuristic was removed in #570 and
+    # the resolver now keys off agent_class instead (issue #593).
     del launch_cmd
-    return BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW
+    cls = (agent_class or "").strip().lower()
+    if cls == "static":
+        return BRIDGE_AUTOCOMPACT_WINDOW_STATIC
+    if cls == "dynamic":
+        return BRIDGE_AUTOCOMPACT_WINDOW_DYNAMIC
+    return BRIDGE_AUTOCOMPACT_WINDOW_DEFAULT
 
 
-def managed_claude_settings_defaults(launch_cmd: str | None) -> dict[str, Any]:
+def managed_claude_settings_defaults(
+    launch_cmd: str | None,
+    agent_class: str | None = None,
+) -> dict[str, Any]:
     return {
-        "autoCompactWindow": resolve_managed_autocompact_window(launch_cmd),
+        "autoCompactWindow": resolve_managed_autocompact_window(launch_cmd, agent_class),
     }
 
 
@@ -829,7 +851,8 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
         raise SystemExit(f"shared settings overlay must be a JSON object: {overlay_path}")
 
     launch_cmd = (getattr(args, "launch_cmd", "") or "") or None
-    managed_defaults = managed_claude_settings_defaults(launch_cmd)
+    agent_class = (getattr(args, "agent_class", "") or "") or None
+    managed_defaults = managed_claude_settings_defaults(launch_cmd, agent_class)
     merged = merge_settings(managed_defaults, base_payload)
     merged = merge_settings(merged, overlay_payload)
     save_json(effective_path, merged)
@@ -879,6 +902,7 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     base_path = Path(args.base_settings_file).expanduser()
     overlay_path = Path(args.overlay_settings_file).expanduser()
     launch_cmd = (getattr(args, "launch_cmd", "") or "") or None
+    agent_class = (getattr(args, "agent_class", "") or "") or None
 
     target_dir = isolated_home / ".claude"
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -926,7 +950,7 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     if not isinstance(overlay_payload, dict):
         raise SystemExit(f"isolated overlay must be a JSON object: {overlay_path}")
 
-    managed_defaults = managed_claude_settings_defaults(launch_cmd)
+    managed_defaults = managed_claude_settings_defaults(launch_cmd, agent_class)
     merged = merge_settings(managed_defaults, base_payload)
     merged = merge_settings(merged, overlay_payload)
     if preserved:
@@ -1211,7 +1235,12 @@ def build_parser() -> argparse.ArgumentParser:
     render_shared_parser.add_argument(
         "--launch-cmd",
         default="",
-        help="Accepted for backwards compatibility; no longer consulted (issue #570 — managed autoCompactWindow default is unconditionally 1_000_000).",
+        help="Accepted for backwards compatibility; no longer consulted (issue #570 — managed autoCompactWindow default keys off --agent-class instead).",
+    )
+    render_shared_parser.add_argument(
+        "--agent-class",
+        default="",
+        help="static|dynamic — drives the autoCompactWindow default (issue #593: static=400_000, dynamic=1_000_000, unknown=1_000_000).",
     )
     render_shared_parser.add_argument("--format", choices=("text", "shell"), default="text")
     render_shared_parser.set_defaults(handler=cmd_render_shared_settings)
@@ -1228,7 +1257,12 @@ def build_parser() -> argparse.ArgumentParser:
     render_isolated_parser.add_argument(
         "--launch-cmd",
         default="",
-        help="Accepted for backwards compatibility; no longer consulted (issue #570 — managed autoCompactWindow default is unconditionally 1_000_000).",
+        help="Accepted for backwards compatibility; no longer consulted (issue #570 — managed autoCompactWindow default keys off --agent-class instead).",
+    )
+    render_isolated_parser.add_argument(
+        "--agent-class",
+        default="",
+        help="static|dynamic — drives the autoCompactWindow default (issue #593: static=400_000, dynamic=1_000_000, unknown=1_000_000).",
     )
     render_isolated_parser.add_argument("--format", choices=("text", "shell"), default="text")
     render_isolated_parser.set_defaults(handler=cmd_render_isolated_home_settings)

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -149,8 +149,8 @@ bridge_ensure_claude_shared_settings_for_managed_workdir() {
 bridge_link_claude_settings_to_shared() {
   local workdir="$1"
   # Issue #570: launch_cmd is accepted for backwards compatibility but the
-  # managed autoCompactWindow default is unconditionally 1_000_000; the
-  # renderer no longer inspects this value.
+  # managed autoCompactWindow default is no longer derived from it; the
+  # renderer keys off --agent-class instead (issue #593).
   local launch_cmd="${2-}"
   # Issue #555: when the caller passes the agent id (3rd arg), render the
   # effective file at the per-agent path so mixed-model installs get
@@ -159,8 +159,19 @@ bridge_link_claude_settings_to_shared() {
   # install-wide render so the helper remains backwards-compatible.
   local agent="${3-}"
   local effective_file
+  local agent_class=""
   if [[ -n "$agent" ]]; then
     effective_file="$(bridge_hook_per_agent_settings_effective_file "$agent")"
+    # Issue #593: source class drives the managed autoCompactWindow default
+    # (static→400_000, dynamic→1_000_000). Gate the lookup behind a
+    # declare-check on BRIDGE_AGENT_SOURCE so callers that haven't sourced
+    # the roster (smoke fixtures, back-compat callers) keep working — when
+    # the array is missing, agent_class stays empty and the renderer falls
+    # back to the unknown-class default (1_000_000). Mirrors the same
+    # gating bridge_claude_settings_mode uses for BRIDGE_AGENT_IDS above.
+    if declare -p BRIDGE_AGENT_SOURCE >/dev/null 2>&1; then
+      agent_class="$(bridge_agent_source "$agent" 2>/dev/null || true)"
+    fi
   else
     effective_file="$(bridge_hook_shared_settings_effective_file)"
   fi
@@ -168,7 +179,8 @@ bridge_link_claude_settings_to_shared() {
     --base-settings-file "$(bridge_hook_shared_settings_base_file)" \
     --overlay-settings-file "$(bridge_hook_shared_settings_overlay_file)" \
     --effective-settings-file "$effective_file" \
-    --launch-cmd "$launch_cmd" >/dev/null
+    --launch-cmd "$launch_cmd" \
+    --agent-class "$agent_class" >/dev/null
   bridge_hooks_python link-shared-settings --workdir "$workdir" --shared-settings-file "$effective_file"
 }
 
@@ -343,6 +355,15 @@ bridge_install_isolated_home_settings() {
   local stage_dir=""
   local stage_settings=""
   local stage_effective=""
+  # Issue #593: pass the agent's source class through to the renderer so
+  # the isolated-home effective file matches the per-agent shared render.
+  # Gate the lookup so the helper still works when called from contexts
+  # that haven't loaded the roster (BRIDGE_AGENT_SOURCE absent → empty
+  # agent_class → renderer falls back to the unknown-class default).
+  local agent_class=""
+  if declare -p BRIDGE_AGENT_SOURCE >/dev/null 2>&1; then
+    agent_class="$(bridge_agent_source "$agent" 2>/dev/null || true)"
+  fi
 
   [[ -n "$agent" ]] || return 0
 
@@ -431,7 +452,8 @@ bridge_install_isolated_home_settings() {
         --isolated-home "$stage_home" \
         --base-settings-file "$(bridge_hook_shared_settings_base_file)" \
         --overlay-settings-file "$(bridge_hook_shared_settings_overlay_file)" \
-        --launch-cmd "$launch_cmd" >"$stage_root/render.out" 2>&1; then
+        --launch-cmd "$launch_cmd" \
+        --agent-class "$agent_class" >"$stage_root/render.out" 2>&1; then
     bridge_warn "isolated home settings install: render failed for $agent ($(head -n1 "$stage_root/render.out" 2>/dev/null || true))"
     rm -rf "$stage_root"
     return 0

--- a/scripts/smoke/managed-autocompact-window.sh
+++ b/scripts/smoke/managed-autocompact-window.sh
@@ -1,19 +1,22 @@
 #!/usr/bin/env bash
-# scripts/smoke/managed-autocompact-window.sh — Issue #570 regression smoke.
+# scripts/smoke/managed-autocompact-window.sh — Issue #570 / #593 regression smoke.
 #
 # Covers `bridge-hooks.py render-shared-settings` resolution of the managed
-# autoCompactWindow default. As of issue #570 the default is unconditionally
-# 1_000_000 — the `--launch-cmd` flag is accepted for backwards compatibility
-# but is no longer consulted by the renderer.
+# autoCompactWindow default. Issue #593 made the resolver class-aware:
+# static→400_000, dynamic→1_000_000, unknown/missing→1_000_000 (back-compat).
+# The `--launch-cmd` flag is still accepted for backwards compatibility but
+# is no longer consulted; the new `--agent-class` flag drives the decision.
 #
 # Cases covered:
-#   - launch_cmd containing '[1m]'    → 1_000_000 (was the only 1M case pre-#570)
-#   - launch_cmd lacking '[1m]'        → 1_000_000 (was 400_000 pre-#570)
-#   - --launch-cmd empty / omitted     → 1_000_000 (was 400_000 pre-#570)
-#   - explicit base / overlay value    → wins over the managed default
-#   - CLAUDE_CODE_AUTO_COMPACT_WINDOW   → operator escape hatch (env wins via
-#     Claude Code's resolution order; verified at the runtime layer, not in
-#     this renderer-only smoke).
+#   - launch_cmd containing '[1m]', no --agent-class → 1_000_000 (unknown→1M)
+#   - launch_cmd lacking '[1m]', no --agent-class    → 1_000_000 (unknown→1M)
+#   - --launch-cmd empty / omitted                   → 1_000_000 (unknown→1M)
+#   - --agent-class static                            → 400_000 (#593)
+#   - --agent-class dynamic                           → 1_000_000 (#593)
+#   - explicit base / overlay value                  → wins over managed default
+#   - CLAUDE_CODE_AUTO_COMPACT_WINDOW                 → operator escape hatch (env
+#     wins via Claude Code's resolution order; verified at the runtime layer,
+#     not in this renderer-only smoke).
 
 set -euo pipefail
 
@@ -88,6 +91,16 @@ main() {
   run_render "$base" "$overlay" "$effective"
   assert_window "$effective" "1000000" "omitted launch_cmd flag lands on managed 1M default"
 
+  smoke_log "case: --agent-class static → 400_000 (#593 class-aware default)"
+  run_render "$base" "$overlay" "$effective" \
+    --launch-cmd "" --agent-class "static"
+  assert_window "$effective" "400000" "static class lands on 400_000 (#593)"
+
+  smoke_log "case: --agent-class dynamic → 1_000_000 (#593 class-aware default)"
+  run_render "$base" "$overlay" "$effective" \
+    --launch-cmd "" --agent-class "dynamic"
+  assert_window "$effective" "1000000" "dynamic class lands on 1_000_000 (#593)"
+
   smoke_log "case: base autoCompactWindow wins over managed default"
   printf '%s\n' '{"autoCompactWindow":650000}' >"$base"
   run_render "$base" "$overlay" "$effective" \
@@ -101,7 +114,7 @@ main() {
     --launch-cmd "claude [1m]"
   assert_window "$effective" "475000" "explicit overlay value overrides managed default"
 
-  smoke_log "PASS: managed autoCompactWindow resolver matrix (#570)"
+  smoke_log "PASS: managed autoCompactWindow resolver matrix (#570 / #593)"
 }
 
 main "$@"

--- a/scripts/smoke/per-agent-settings-rendering.sh
+++ b/scripts/smoke/per-agent-settings-rendering.sh
@@ -8,14 +8,17 @@
 # overlay overrides for one agent are not last-rerender-wins clobbered by
 # a sibling rerender.
 #
-# Note (issue #570): the managed `autoCompactWindow` default is now
-# unconditionally 1_000_000 — the previous launch_cmd `[1m]` substring
-# heuristic was retired. These sub-tests assert the per-agent *path*
-# routing, not a per-launch_cmd value split.
+# Note (issue #593): the managed `autoCompactWindow` default is now
+# class-aware (static→400_000, dynamic→1_000_000). This fixture drives
+# `bridge_link_claude_settings_to_shared` directly without sourcing the
+# roster, so `BRIDGE_AGENT_SOURCE` is unset and the renderer falls back
+# to the unknown-class default (1_000_000) — the back-compat path. The
+# assertions here therefore stay at 1_000_000 and validate per-agent
+# *path* routing, not the class-aware value split.
 #
 # Sub-tests:
 #   1. agent-A renders its per-agent effective file with the managed
-#      autoCompactWindow=1_000_000 default.
+#      autoCompactWindow=1_000_000 default (unknown-class fallback).
 #   2. agent-B renders its own per-agent effective file (separate path
 #      from agent-A) with the same managed default.
 #   3. Each agent's workdir settings.json is a symlink to its own per-agent
@@ -98,11 +101,12 @@ invoke_setup_ensure_helpers_for_agent() {
   # Issue #555 r2: simulates bridge-setup.sh:run_agent's post-channel
   # ensure block. Drives the same two helpers (`bridge_ensure_claude_stop_hook`
   # and `bridge_ensure_claude_prompt_hook`) the way the FIXED run_agent
-  # does, forwarding the resolved launch_cmd through. Issue #570: the
-  # managed autoCompactWindow default is unconditionally 1_000_000, so
-  # this assertion is now about per-agent *path* routing — the setup
-  # ensure must still write to the per-agent effective file, not clobber
-  # a sibling.
+  # does, forwarding the resolved launch_cmd through. Issue #593: the
+  # renderer is class-aware, but this fixture leaves BRIDGE_AGENT_SOURCE
+  # unset, so the resolver falls back to the unknown-class default
+  # (1_000_000). The assertion is therefore about per-agent *path*
+  # routing — the setup ensure must still write to the per-agent
+  # effective file, not clobber a sibling.
   local agent="$1"
   local workdir="$2"
   local launch_cmd="$3"
@@ -135,17 +139,20 @@ main() {
   printf '%s\n' '{}' >"$install_wide_dir/settings.json"
   printf '%s\n' '{}' >"$install_wide_dir/settings.local.json"
 
-  smoke_log "case 1: agent-A renders per-agent file with managed autoCompactWindow=1_000_000 default (#570)"
+  # BRIDGE_AGENT_SOURCE is unset in this fixture (the helper is invoked
+  # without sourcing the roster), so the renderer falls back to the
+  # unknown-class default (1_000_000) per issue #593 back-compat.
+  smoke_log "case 1: agent-A renders per-agent file with managed autoCompactWindow=1_000_000 default (#593 back-compat)"
   invoke_link_for_agent agent-a "$agent_a_workdir" "claude --model claude-opus-4-7[1m]"
   local agent_a_effective="$agent_a_workdir/.claude/settings.effective.json"
   smoke_assert_file_exists "$agent_a_effective" "agent-A per-agent effective file rendered"
-  smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A autoCompactWindow=1_000_000 (managed default)"
+  smoke_assert_eq "1000000" "$(settings_value "$agent_a_effective" autoCompactWindow)" "agent-A autoCompactWindow=1_000_000 (unknown class → 1M fallback, #593)"
 
   smoke_log "case 2: agent-B renders its OWN per-agent file (separate path from agent-A) with managed default"
   invoke_link_for_agent agent-b "$agent_b_workdir" "claude --model claude-opus-4-6"
   local agent_b_effective="$agent_b_workdir/.claude/settings.effective.json"
   smoke_assert_file_exists "$agent_b_effective" "agent-B per-agent effective file rendered"
-  smoke_assert_eq "1000000" "$(settings_value "$agent_b_effective" autoCompactWindow)" "agent-B autoCompactWindow=1_000_000 (managed default)"
+  smoke_assert_eq "1000000" "$(settings_value "$agent_b_effective" autoCompactWindow)" "agent-B autoCompactWindow=1_000_000 (unknown class → 1M fallback, #593)"
 
   smoke_log "case 3: each agent's workdir settings.json is a symlink to its own per-agent effective file"
   local agent_a_link="$agent_a_workdir/.claude/settings.json"

--- a/scripts/smoke/upgrade-shared-settings-propagate.sh
+++ b/scripts/smoke/upgrade-shared-settings-propagate.sh
@@ -88,15 +88,16 @@ assert_apply_rerenders_and_preserves_overlay() {
   # points to that per-agent file.
   effective_file="$BRIDGE_AGENT_HOME_ROOT/patch/.claude/settings.effective.json"
   [[ -L "$settings_file" ]] || smoke_fail "rerender apply should link agent settings to per-agent effective settings"
-  # Issue #570: managed autoCompactWindow default is unconditionally 1_000_000.
-  smoke_assert_eq "1000000" "$(settings_value "$settings_file" autoCompactWindow)" "rerender apply backfills autoCompactWindow"
+  # Issue #593: class-aware managed default — patch is static (see write_fixture
+  # roster), so the renderer resolves autoCompactWindow to 400_000.
+  smoke_assert_eq "400000" "$(settings_value "$settings_file" autoCompactWindow)" "rerender apply backfills autoCompactWindow"
   smoke_assert_eq "yes" "$(python3 - "$settings_file" <<'PY'
 import json, sys
 from pathlib import Path
 print(json.loads(Path(sys.argv[1]).read_text()).get("env", {}).get("OVERLAY_ONLY"))
 PY
 )" "rerender apply preserves operator overlay"
-  smoke_assert_eq "1000000" "$(settings_value "$effective_file" autoCompactWindow)" "per-agent effective has managed default"
+  smoke_assert_eq "400000" "$(settings_value "$effective_file" autoCompactWindow)" "per-agent effective has managed default"
 
   audit="$(cat "$BRIDGE_AUDIT_LOG")"
   smoke_assert_contains "$audit" "shared_settings_rerendered" "rerender apply emits audit row"
@@ -127,8 +128,9 @@ assert_upgrade_runs_rerender() {
   has_patch="$(json_field "$upgrade_json" 'any(item["agent"] == "patch" for item in payload["shared_settings_rerender"]["candidates"])')"
   smoke_assert_eq "True" "$has_patch" "upgrade reports patch shared settings rerender target"
   [[ -L "$agent_home/.claude/settings.json" ]] || smoke_fail "upgrade should relink managed Claude settings"
-  # Issue #570: managed autoCompactWindow default is unconditionally 1_000_000.
-  smoke_assert_eq "1000000" "$(settings_value "$agent_home/.claude/settings.json" autoCompactWindow)" "upgrade backfills autoCompactWindow"
+  # Issue #593: class-aware managed default — patch is static, so the
+  # backfill resolves to 400_000 (legacy 8GB-RAM-host budget).
+  smoke_assert_eq "400000" "$(settings_value "$agent_home/.claude/settings.json" autoCompactWindow)" "upgrade backfills autoCompactWindow"
 }
 
 assert_operator_overlay_wins() {


### PR DESCRIPTION
## Summary

`bridge-hooks.py:resolve_managed_autocompact_window` previously returned the same `1_000_000`-token managed default for every agent (issue #570 retired the launch_cmd `[1m]` heuristic). Issue #593 reports the practical regression: dynamic agents on 1M-context models compact at the right budget, but every static agent in the live install — including 8GB-RAM hosts where the legacy 400_000 budget protected against worst-case 1M-context restores — picks up the same 1M default and chews memory it doesn't have.

Per operator policy decided on the issue:

| class    | autoCompactWindow |
| -------- | ----------------- |
| static   | 400_000           |
| dynamic  | 1_000_000         |
| unknown  | 1_000_000         |

`unknown → 1_000_000` is the no-regret fallback from #570: smaller-context models compact earlier on their own, and back-compat callers (smoke fixtures, unsourced contexts) silently take this branch without a behavior change.

## Changes

- **`bridge-hooks.py`** — split the constant into `BRIDGE_AUTOCOMPACT_WINDOW_STATIC`, `…_DYNAMIC`, `…_DEFAULT`, kept `BRIDGE_DEFAULT_AUTOCOMPACT_WINDOW` as a back-compat alias. `resolve_managed_autocompact_window` and `managed_claude_settings_defaults` now accept an optional keyword `agent_class` (case-insensitive `"static"` / `"dynamic"`); existing positional callers keep working. Added `--agent-class` to `render-shared-settings` and `render-isolated-home-settings` subparsers next to the existing `--launch-cmd`.
- **`lib/bridge-hooks.sh`** — `bridge_link_claude_settings_to_shared` and `bridge_install_isolated_home_settings` look up the agent class via `bridge_agent_source` and forward it as `--agent-class`. Lookup is gated behind `declare -p BRIDGE_AGENT_SOURCE >/dev/null 2>&1` so callers that haven't loaded the roster (smoke, back-compat) continue to render the unknown-class default.
- **`bridge-agent.sh`** — `bridge_agent_shared_settings_plan_json` (the `agent doctor` plan-json subprocess) passes the same agent class through the heredoc to `hooks.managed_claude_settings_defaults`, so doctor stops reporting `needs-rerender` for every static agent on every run.

## Out of scope (deferred per brief)

- `BRIDGE_AGENT_MODEL` roster field (#593 future-work item).
- `agent create --autocompact-window=N` per-agent override.
- VERSION / CHANGELOG bumps — release will document.
- `CLAUDE_CODE_AUTO_COMPACT_WINDOW` env handling (already wins over settings upstream).

## Verification

- `bash -n bridge-agent.sh lib/bridge-hooks.sh` → PASS
- `shellcheck bridge-agent.sh lib/bridge-hooks.sh` → PASS
- `python3 -c "import ast; ast.parse(open('bridge-hooks.py').read())"` → PASS
- Resolver matrix:

  ```
  $ python3 - <<'PY'
  import importlib.util
  spec = importlib.util.spec_from_file_location("bridge_hooks", "bridge-hooks.py")
  m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
  assert m.resolve_managed_autocompact_window(None, "static") == 400_000
  assert m.resolve_managed_autocompact_window(None, "dynamic") == 1_000_000
  assert m.resolve_managed_autocompact_window(None, None) == 1_000_000
  assert m.resolve_managed_autocompact_window(None, "") == 1_000_000
  assert m.resolve_managed_autocompact_window(None, "Static") == 400_000
  print("ok")
  PY
  ok
  ```

- `scripts/smoke/managed-autocompact-window.sh` → PASS (existing 1M-default cases still hold via the unknown-class fallback)
- `scripts/smoke/isolated-settings-rendering.sh` → PASS
- `scripts/smoke/hooks.sh` → PASS

### Pre-existing smoke notes (not introduced by this PR)

- `scripts/smoke/per-agent-settings-rendering.sh` and the `[smoke] starting isolated tmux role` step inside `scripts/smoke-test.sh` fail on pristine `main` in this macOS env (the `bash -lc 'source bridge-lib.sh; …'` re-exec from `/bin/bash` 3.2 inside `env -i` drops the calling smoke command). Verified against `git stash` of the working tree — same failures with no edits.

Refs #593