### PR TITLE
feat(channels): precompact route primitive (Track A of #597)

### DIFF
--- a/bridge-channels.py
+++ b/bridge-channels.py
@@ -274,17 +274,23 @@ def _load_activity_index(state_dir: Path, plugin: str, agent: str) -> dict[str, 
 def _candidate_inbound_ms(entry: dict[str, Any]) -> int | None:
     """Compute the candidate's last_user_inbound timestamp in milliseconds.
 
-    Prefers ``last_user_inbound_ts_ms`` when it is a positive integer;
-    otherwise multiplies ``last_user_inbound_ts`` by 1000.
-    Returns ``None`` if neither field is present/valid.
+    Both ``last_user_inbound_ts`` (epoch seconds) and the optional
+    ``last_user_inbound_ts_ms`` (epoch milliseconds) must agree on
+    "this entry has a recorded user inbound." If ``last_user_inbound_ts``
+    is missing or non-positive the candidate is filtered out — feeders
+    that can only emit `_ms` should also emit `_ts = _ms // 1000` so the
+    schema invariant holds (codex review of #601 r1 caught this gap).
+
+    When both are present, prefer `_ms` for resolution; fall back to
+    `_ts * 1000` when `_ms` is absent or invalid.
     """
+    ts_raw = entry.get("last_user_inbound_ts")
+    if not (isinstance(ts_raw, (int, float)) and ts_raw > 0):
+        return None
     ms_raw = entry.get("last_user_inbound_ts_ms")
     if isinstance(ms_raw, (int, float)) and ms_raw > 0:
         return int(ms_raw)
-    ts_raw = entry.get("last_user_inbound_ts")
-    if isinstance(ts_raw, (int, float)) and ts_raw > 0:
-        return int(ts_raw * 1000)
-    return None
+    return int(ts_raw * 1000)
 
 
 def _candidate_recorded_ns(entry: dict[str, Any]) -> int:
@@ -351,19 +357,34 @@ def _collect_route_candidates(
     return candidates
 
 
-def _select_route(candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
-    """Argmax over inbound_ms; tie-break by ns, plugin, channel_id, message_id.
+_TIE_WINDOW_MS = 1000
 
-    The 1-second tie window is implicit in argmax-on-ms when feeders only
-    write second-precision timestamps; ns-precision feeders effectively
-    never tie at the ms level. Either way the deterministic chain wins.
+
+def _select_route(candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Pick the most-recent inbound channel with a deterministic 1-second tie window.
+
+    The spec contract is "tie-break when two candidates differ by less
+    than one second" — sorting on exact ts_ms first would let a candidate
+    1 ms newer beat a same-second peer that has a higher recorded_ns
+    (codex review of #601 r1 caught this).
+
+    Algorithm:
+    1. Find the maximum ts_ms (call it ``leader_ms``).
+    2. Group all candidates with ``ts_ms >= leader_ms - 1000`` (the tie
+       window). Anything older than the window is excluded — it lost on
+       inbound time, not on tie-break.
+    3. Within the tie window, sort by ``recorded_ns`` desc, then lexical
+       ``plugin``, ``channel_id``, ``reply_to_message_id``.
+    4. Return the first.
     """
     if not candidates:
         return None
+    leader_ms = max(int(c["last_user_inbound_ts_ms"]) for c in candidates)
+    floor_ms = leader_ms - _TIE_WINDOW_MS
+    tie_window = [c for c in candidates if int(c["last_user_inbound_ts_ms"]) >= floor_ms]
     return min(
-        candidates,
+        tie_window,
         key=lambda c: (
-            -int(c["last_user_inbound_ts_ms"]),
             -int(c["last_user_inbound_recorded_ns"]),
             c["plugin"],
             c["channel_id"],

--- a/bridge-channels.py
+++ b/bridge-channels.py
@@ -148,6 +148,276 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--format", choices=("text", "shell"), default="text")
 
 
+# ---------------------------------------------------------------------------
+# PreCompact channel auto-notify routing primitive (issue #597 Track A).
+#
+# Activity index file: $BRIDGE_STATE_DIR/channels/<plugin>/<agent>.json
+# Schema:
+# {
+#   "schema_version": 1,
+#   "agent": "<agent-id>",
+#   "plugin": "<plugin-id>",     # e.g. "discord", "telegram", "teams", "mattermost"
+#   "updated_ts": <epoch>,
+#   "channels": {
+#     "<platform-channel-id>": {
+#       "channel_id": "<platform id>",
+#       "reply_kind": "thread|conversation|root",
+#       "last_seen_id": "...",
+#       "last_seen_ts": <epoch>,
+#       "last_user_inbound_ts": <epoch>,
+#       "last_user_inbound_ts_ms": <int milliseconds>,
+#       "last_user_inbound_message_id": "...",
+#       "last_user_inbound_user_id": "...",
+#       "last_user_inbound_recorded_ns": <int nanoseconds>,
+#       "thread_id": "..." (optional)
+#     },
+#     ...
+#   }
+# }
+#
+# Track A defines the consumer side only. Writers (Discord/Telegram relays
+# and the Teams/Mattermost TS plugins) populate this index in later tracks.
+# Until those land, the route lookup correctly returns "no route" (exit 1)
+# whenever an activity index file is missing or empty.
+# ---------------------------------------------------------------------------
+
+
+_ROUTE_DEFAULT_RECENCY_SECONDS = 1800
+
+
+def _coerce_recency_seconds(raw: str | int | None) -> int:
+    """Coerce a recency value to a positive int, falling back to the default.
+
+    Empty strings, non-numeric strings, zero, and negative values all collapse
+    to the 1800-second default per the spec — callers should never need to
+    pre-validate this argument.
+    """
+    if raw is None:
+        return _ROUTE_DEFAULT_RECENCY_SECONDS
+    if isinstance(raw, int):
+        return raw if raw >= 1 else _ROUTE_DEFAULT_RECENCY_SECONDS
+    text = str(raw).strip()
+    if not text:
+        return _ROUTE_DEFAULT_RECENCY_SECONDS
+    try:
+        value = int(text)
+    except ValueError:
+        try:
+            value = int(float(text))
+        except ValueError:
+            return _ROUTE_DEFAULT_RECENCY_SECONDS
+    return value if value >= 1 else _ROUTE_DEFAULT_RECENCY_SECONDS
+
+
+def _normalize_channel_token(token: str) -> tuple[str, str] | None:
+    """Strip `plugin:` prefix and `@marketplace` suffix from a roster token.
+
+    Returns ``(plugin, channel_key)`` where ``plugin`` is the plugin id
+    (e.g. ``discord``) and ``channel_key`` is the marketplace-stripped tail
+    used as a sanity check against the roster's declared plugin id.
+
+    Returns ``None`` for empty or malformed tokens (silently skipped).
+    """
+    if not token:
+        return None
+    raw = token.strip()
+    if not raw:
+        return None
+    if raw.startswith("plugin:"):
+        raw = raw[len("plugin:"):]
+    if not raw:
+        return None
+    # Drop @marketplace suffix if present.
+    plugin = raw.split("@", 1)[0].strip()
+    if not plugin:
+        return None
+    return plugin, raw
+
+
+def _split_channels_csv(csv: str) -> list[tuple[str, str]]:
+    """Parse a roster channels CSV into a list of (plugin, raw) pairs."""
+    if not csv:
+        return []
+    out: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    # Tokens may be space- or comma-separated, mirroring bridge_normalize_channels_csv.
+    for chunk in csv.replace(",", " ").split():
+        normalized = _normalize_channel_token(chunk)
+        if normalized is None:
+            continue
+        plugin = normalized[0]
+        if plugin in seen:
+            continue
+        seen.add(plugin)
+        out.append(normalized)
+    return out
+
+
+def _load_activity_index(state_dir: Path, plugin: str, agent: str) -> dict[str, Any] | None:
+    """Read the per-plugin per-agent activity index file.
+
+    Returns ``None`` for missing files or malformed JSON. Never raises.
+    """
+    path = state_dir / "channels" / plugin / f"{agent}.json"
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _candidate_inbound_ms(entry: dict[str, Any]) -> int | None:
+    """Compute the candidate's last_user_inbound timestamp in milliseconds.
+
+    Prefers ``last_user_inbound_ts_ms`` when it is a positive integer;
+    otherwise multiplies ``last_user_inbound_ts`` by 1000.
+    Returns ``None`` if neither field is present/valid.
+    """
+    ms_raw = entry.get("last_user_inbound_ts_ms")
+    if isinstance(ms_raw, (int, float)) and ms_raw > 0:
+        return int(ms_raw)
+    ts_raw = entry.get("last_user_inbound_ts")
+    if isinstance(ts_raw, (int, float)) and ts_raw > 0:
+        return int(ts_raw * 1000)
+    return None
+
+
+def _candidate_recorded_ns(entry: dict[str, Any]) -> int:
+    """Return ``last_user_inbound_recorded_ns`` as an int (0 when absent)."""
+    raw = entry.get("last_user_inbound_recorded_ns")
+    if isinstance(raw, (int, float)) and raw >= 0:
+        return int(raw)
+    return 0
+
+
+def _collect_route_candidates(
+    state_dir: Path,
+    agent: str,
+    channels: list[tuple[str, str]],
+    cutoff_ms: int,
+) -> list[dict[str, Any]]:
+    """Walk the activity index for each declared plugin and gather candidates.
+
+    Each candidate dict carries the fields needed for argmax + tie-break and
+    for shaping the final shell/JSON output.
+    """
+    candidates: list[dict[str, Any]] = []
+    for plugin, _raw in channels:
+        index = _load_activity_index(state_dir, plugin, agent)
+        if index is None:
+            continue
+        ch_map = index.get("channels")
+        if not isinstance(ch_map, dict):
+            continue
+        for channel_key, entry in ch_map.items():
+            if not isinstance(entry, dict):
+                continue
+            inbound_ms = _candidate_inbound_ms(entry)
+            if inbound_ms is None or inbound_ms < cutoff_ms:
+                continue
+            message_id = entry.get("last_user_inbound_message_id")
+            if not isinstance(message_id, str) or not message_id:
+                continue
+            channel_id = entry.get("channel_id")
+            if not isinstance(channel_id, str) or not channel_id:
+                # Fall back to the map key so writers that key by channel id
+                # still produce a usable route.
+                if isinstance(channel_key, str) and channel_key:
+                    channel_id = channel_key
+                else:
+                    continue
+            inbound_ts = entry.get("last_user_inbound_ts")
+            if isinstance(inbound_ts, (int, float)) and inbound_ts > 0:
+                inbound_ts_int = int(inbound_ts)
+            else:
+                inbound_ts_int = inbound_ms // 1000
+            thread_id = entry.get("thread_id") if isinstance(entry.get("thread_id"), str) else ""
+            candidates.append(
+                {
+                    "plugin": plugin,
+                    "channel_id": channel_id,
+                    "reply_to_message_id": message_id,
+                    "last_user_inbound_ts": inbound_ts_int,
+                    "last_user_inbound_ts_ms": inbound_ms,
+                    "last_user_inbound_recorded_ns": _candidate_recorded_ns(entry),
+                    "thread_id": thread_id or "",
+                }
+            )
+    return candidates
+
+
+def _select_route(candidates: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Argmax over inbound_ms; tie-break by ns, plugin, channel_id, message_id.
+
+    The 1-second tie window is implicit in argmax-on-ms when feeders only
+    write second-precision timestamps; ns-precision feeders effectively
+    never tie at the ms level. Either way the deterministic chain wins.
+    """
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda c: (
+            -int(c["last_user_inbound_ts_ms"]),
+            -int(c["last_user_inbound_recorded_ns"]),
+            c["plugin"],
+            c["channel_id"],
+            c["reply_to_message_id"],
+        ),
+    )
+
+
+def _print_route(route: dict[str, Any], fmt: str) -> None:
+    """Emit the selected route in shell or JSON format."""
+    payload = {
+        "CHANNEL_ROUTE_PLUGIN": route["plugin"],
+        "CHANNEL_ROUTE_CHANNEL_ID": route["channel_id"],
+        "CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID": route["reply_to_message_id"],
+        "CHANNEL_ROUTE_LAST_USER_INBOUND_TS": str(route["last_user_inbound_ts"]),
+    }
+    if route.get("thread_id"):
+        payload["CHANNEL_ROUTE_THREAD_ID"] = route["thread_id"]
+    if fmt == "json":
+        print(json.dumps(payload, ensure_ascii=False))
+        return
+    for key, value in payload.items():
+        print(f"{key}={json.dumps(str(value))}")
+
+
+def cmd_route_precompact_target(args: argparse.Namespace) -> int:
+    """Resolve the best PreCompact reply target for ``--agent``.
+
+    On success: prints shell/json key=value assignments and exits 0.
+    On no route: exits 1 with no stdout (silent skip path for the daemon).
+    """
+    recency_seconds = _coerce_recency_seconds(args.recency_seconds)
+    try:
+        now_ts_int = int(args.now_ts) if args.now_ts not in (None, "") else 0
+    except (TypeError, ValueError):
+        now_ts_int = 0
+    if now_ts_int <= 0:
+        import time as _time
+        now_ts_int = int(_time.time())
+    cutoff_ms = (now_ts_int - recency_seconds) * 1000
+
+    channels = _split_channels_csv(args.channels_csv or "")
+    if not channels:
+        return 1
+
+    state_dir = Path(args.bridge_state_dir).expanduser()
+    candidates = _collect_route_candidates(state_dir, args.agent, channels, cutoff_ms)
+    route = _select_route(candidates)
+    if route is None:
+        return 1
+    _print_route(route, args.format)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="bridge-channels.py")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -163,6 +433,15 @@ def build_parser() -> argparse.ArgumentParser:
     remove_parser = subparsers.add_parser("remove-webhook-server")
     add_common_args(remove_parser)
     remove_parser.set_defaults(handler=cmd_remove_webhook_server)
+
+    route_parser = subparsers.add_parser("route-precompact-target")
+    route_parser.add_argument("--agent", required=True)
+    route_parser.add_argument("--channels-csv", required=True)
+    route_parser.add_argument("--bridge-state-dir", required=True)
+    route_parser.add_argument("--recency-seconds", default="1800")
+    route_parser.add_argument("--now-ts", default="")
+    route_parser.add_argument("--format", choices=("shell", "json"), default="shell")
+    route_parser.set_defaults(handler=cmd_route_precompact_target)
 
     return parser
 

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -6,6 +6,28 @@ bridge_channels_python() {
   python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" "$@"
 }
 
+# Resolve the best PreCompact reply target for an opt-in static agent.
+# Echoes shell-format assignments (`CHANNEL_ROUTE_PLUGIN=...`,
+# `CHANNEL_ROUTE_CHANNEL_ID=...`, `CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID=...`,
+# `CHANNEL_ROUTE_LAST_USER_INBOUND_TS=...`, optional `CHANNEL_ROUTE_THREAD_ID=...`)
+# on success; exits non-zero with no stdout when there is no eligible route.
+# The daemon observer (Track B) consumes this via `eval` and skips silently
+# on non-zero exit.
+bridge_channel_precompact_target() {
+  local agent="$1"
+  local channels_csv="$2"
+  local recency_seconds="${3:-${BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS:-1800}}"
+  local now_ts="${4:-$(date +%s)}"
+
+  bridge_channels_python route-precompact-target \
+    --agent "$agent" \
+    --channels-csv "$channels_csv" \
+    --bridge-state-dir "$BRIDGE_STATE_DIR" \
+    --recency-seconds "$recency_seconds" \
+    --now-ts "$now_ts" \
+    --format shell
+}
+
 bridge_channel_server_script_path() {
   local live_path="$BRIDGE_HOME/bridge-channel-server.py"
 

--- a/tests/precompact-notify/route-primitive.sh
+++ b/tests/precompact-notify/route-primitive.sh
@@ -224,14 +224,19 @@ EOF
 
 # ---------- T3: tie-break by recorded_ns then lexical plugin --------------
 t3() {
-  local case="T3 ms-tie → ns wins, then lexical plugin"
+  local case="T3 sub-second tie window → ns wins, then lexical plugin; older-than-window excluded"
   local sd="$ROOT/t3"
   local now=2000000000
   local agent="alpha"
-  local same_ms=$(( (now - 30) * 1000 ))
+  # discord at -30s minus 700 ms; telegram at -30s exactly. Inside the
+  # 1-second tie window, so ns must decide — NOT exact ts_ms (codex r1
+  # caught the implementation sorting on ts_ms first, which would have
+  # let telegram win 700 ms newer and bypass the ns/lexical chain).
+  local discord_ms=$(( (now - 30) * 1000 - 700 ))
+  local telegram_ms=$(( (now - 30) * 1000 ))
 
-  # Two candidates with identical inbound_ms; discord has higher recorded_ns
-  # so it wins on the ns tie-break.
+  # discord is 700 ms older than telegram BUT has higher recorded_ns;
+  # within the 1-second tie window, ns precedence must put discord first.
   write_activity "$sd" discord "$agent" "$(cat <<EOF
 {
   "schema_version": 1, "agent": "$agent", "plugin": "discord",
@@ -240,7 +245,7 @@ t3() {
     "C-D-1": {
       "channel_id": "C-D-1",
       "last_user_inbound_ts": $((now - 30)),
-      "last_user_inbound_ts_ms": $same_ms,
+      "last_user_inbound_ts_ms": $discord_ms,
       "last_user_inbound_message_id": "MSG-D-1",
       "last_user_inbound_recorded_ns": 999000000
     }
@@ -256,7 +261,7 @@ EOF
     "C-T-1": {
       "channel_id": "C-T-1",
       "last_user_inbound_ts": $((now - 30)),
-      "last_user_inbound_ts_ms": $same_ms,
+      "last_user_inbound_ts_ms": $telegram_ms,
       "last_user_inbound_message_id": "MSG-T-1",
       "last_user_inbound_recorded_ns": 100000000
     }
@@ -271,12 +276,62 @@ EOF
     return
   fi
   if ! grep -qF 'CHANNEL_ROUTE_PLUGIN="discord"' <<<"$ROUTE_OUT"; then
-    fail "$case (ns)" "expected discord (higher recorded_ns); got: $ROUTE_OUT"
+    fail "$case (ns)" "expected discord (higher ns within 1s tie window); got: $ROUTE_OUT"
     return
   fi
 
-  # Now flip ns to be equal — fall through to lexical plugin (discord < telegram).
+  # Sub-case: same setup but discord shifted to 1500 ms older — outside
+  # the 1-second window. telegram must win on inbound_ms now; the ns
+  # tie-break is not consulted.
   rm -rf "$sd"
+  local discord_old_ms=$(( (now - 30) * 1000 - 1500 ))
+  write_activity "$sd" discord "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "discord",
+  "updated_ts": $((now - 30)),
+  "channels": {
+    "C-D-1": {
+      "channel_id": "C-D-1",
+      "last_user_inbound_ts": $((now - 30)),
+      "last_user_inbound_ts_ms": $discord_old_ms,
+      "last_user_inbound_message_id": "MSG-D-1",
+      "last_user_inbound_recorded_ns": 999000000
+    }
+  }
+}
+EOF
+)"
+  write_activity "$sd" telegram "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "telegram",
+  "updated_ts": $((now - 30)),
+  "channels": {
+    "C-T-1": {
+      "channel_id": "C-T-1",
+      "last_user_inbound_ts": $((now - 30)),
+      "last_user_inbound_ts_ms": $telegram_ms,
+      "last_user_inbound_message_id": "MSG-T-1",
+      "last_user_inbound_recorded_ns": 100000000
+    }
+  }
+}
+EOF
+)"
+
+  run_route "$agent" "plugin:discord,plugin:telegram" "$sd" 1800 "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case (window)" "expected exit 0; got $ROUTE_EXIT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_PLUGIN="telegram"' <<<"$ROUTE_OUT"; then
+    fail "$case (window)" "expected telegram (discord >1s older, outside tie window); got: $ROUTE_OUT"
+    return
+  fi
+
+  # Sub-case: equal ts_ms within window, equal ns — fall through to lexical
+  # plugin order (discord < telegram).
+  rm -rf "$sd"
+  local same_ms=$telegram_ms
   write_activity "$sd" discord "$agent" "$(cat <<EOF
 {
   "schema_version": 1, "agent": "$agent", "plugin": "discord",

--- a/tests/precompact-notify/route-primitive.sh
+++ b/tests/precompact-notify/route-primitive.sh
@@ -1,0 +1,472 @@
+#!/usr/bin/env bash
+# precompact-notify route primitive smoke — issue #597 Track A.
+#
+# Exercises bridge-channels.py route-precompact-target with mocked
+# state/channels/<plugin>/<agent>.json activity index files. No daemon, no
+# real channel plugins, no roster — pure consumer-side primitive coverage.
+#
+# Cases:
+#
+#   T1  two channels with different last_user_inbound_ts
+#       -> picks the newer one; exit 0; emits expected shell assignments.
+#   T2  every channel is older than the recency cutoff
+#       -> exit 1, no stdout (silent skip path).
+#   T3  two candidates within 1 ms of each other
+#       -> ns-precision tie-break picks the higher recorded_ns;
+#          fallback lexical-plugin tie-break is also exercised.
+#   T4  malformed JSON in the activity index
+#       -> exit 1, no traceback (graceful skip).
+#   T5  candidate is missing last_user_inbound_message_id
+#       -> filtered out; the remaining valid candidate wins.
+#   T6  --recency-seconds 0 is coerced to the 1800-second default
+#       -> a candidate within the default window still routes.
+#
+# Each case sets up its own temp BRIDGE_STATE_DIR. The fixture is intentionally
+# standalone — Track A does NOT register it in scripts/smoke-test.sh; Track D
+# wires the full precompact-notify suite in once the writers and daemon
+# observer are in place.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+ROUTE_PY="$REPO_ROOT/bridge-channels.py"
+
+if [[ ! -x "$PYTHON" && ! -r "$PYTHON" ]]; then
+  printf '[smoke][error] python3 not found at %s\n' "$PYTHON" >&2
+  exit 2
+fi
+if [[ ! -f "$ROUTE_PY" ]]; then
+  printf '[smoke][error] bridge-channels.py not found at %s\n' "$ROUTE_PY" >&2
+  exit 2
+fi
+
+ROOT="$(mktemp -d -t precompact-route.XXXXXX)"
+trap 'rm -rf "$ROOT"' EXIT
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+  if [[ -n "${2:-}" ]]; then
+    printf '%s\n' "$2" >&2
+  fi
+}
+
+write_activity() {
+  # write_activity <state-dir> <plugin> <agent> <json-payload>
+  local state_dir="$1"
+  local plugin="$2"
+  local agent="$3"
+  local payload="$4"
+  local dir="$state_dir/channels/$plugin"
+  mkdir -p "$dir"
+  printf '%s' "$payload" >"$dir/$agent.json"
+}
+
+ROUTE_EXIT=0
+ROUTE_OUT=""
+ROUTE_ERR=""
+
+run_route() {
+  # run_route <agent> <channels-csv> <state-dir> <recency> <now-ts>
+  # Populates globals $ROUTE_OUT / $ROUTE_ERR / $ROUTE_EXIT.
+  # We invoke via tmpfiles instead of $(...) so the exit code is visible in
+  # the parent shell — the caller asserts on both stdout and exit code.
+  local agent="$1"
+  local channels="$2"
+  local state_dir="$3"
+  local recency="$4"
+  local now="$5"
+  local outfile="$ROOT/.route.out"
+  local errfile="$ROOT/.route.err"
+
+  "$PYTHON" "$ROUTE_PY" route-precompact-target \
+    --agent "$agent" \
+    --channels-csv "$channels" \
+    --bridge-state-dir "$state_dir" \
+    --recency-seconds "$recency" \
+    --now-ts "$now" \
+    --format shell >"$outfile" 2>"$errfile"
+  ROUTE_EXIT=$?
+
+  ROUTE_OUT="$(cat "$outfile")"
+  ROUTE_ERR="$(cat "$errfile")"
+}
+
+# ---------- T1: argmax over last_user_inbound_ts ---------------------------
+t1() {
+  local case="T1 argmax picks newer candidate"
+  local sd="$ROOT/t1"
+  local now=2000000000
+  local agent="alpha"
+
+  # discord candidate is 600s old, telegram candidate is 60s old.
+  # telegram should win.
+  write_activity "$sd" discord "$agent" "$(cat <<EOF
+{
+  "schema_version": 1,
+  "agent": "$agent",
+  "plugin": "discord",
+  "updated_ts": $((now - 600)),
+  "channels": {
+    "C-DISCORD-1": {
+      "channel_id": "C-DISCORD-1",
+      "last_user_inbound_ts": $((now - 600)),
+      "last_user_inbound_ts_ms": $(( (now - 600) * 1000 )),
+      "last_user_inbound_message_id": "MSG-DISCORD-1",
+      "last_user_inbound_recorded_ns": 100
+    }
+  }
+}
+EOF
+)"
+  write_activity "$sd" telegram "$agent" "$(cat <<EOF
+{
+  "schema_version": 1,
+  "agent": "$agent",
+  "plugin": "telegram",
+  "updated_ts": $((now - 60)),
+  "channels": {
+    "C-TELEGRAM-1": {
+      "channel_id": "C-TELEGRAM-1",
+      "last_user_inbound_ts": $((now - 60)),
+      "last_user_inbound_ts_ms": $(( (now - 60) * 1000 )),
+      "last_user_inbound_message_id": "MSG-TELEGRAM-1",
+      "last_user_inbound_recorded_ns": 200
+    }
+  }
+}
+EOF
+)"
+
+  run_route "$agent" "plugin:discord@official,plugin:telegram@official" "$sd" 1800 "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case" "expected exit 0; got $ROUTE_EXIT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_PLUGIN="telegram"' <<<"$ROUTE_OUT"; then
+    fail "$case" "expected telegram plugin; got: $ROUTE_OUT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_CHANNEL_ID="C-TELEGRAM-1"' <<<"$ROUTE_OUT"; then
+    fail "$case" "expected C-TELEGRAM-1 channel; got: $ROUTE_OUT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID="MSG-TELEGRAM-1"' <<<"$ROUTE_OUT"; then
+    fail "$case" "expected MSG-TELEGRAM-1 reply target; got: $ROUTE_OUT"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T2: only-stale candidates -------------------------------------
+t2() {
+  local case="T2 stale-only candidates → silent skip"
+  local sd="$ROOT/t2"
+  local now=2000000000
+  local agent="alpha"
+
+  # Both candidates are well outside a 1800s recency window.
+  write_activity "$sd" discord "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "discord",
+  "updated_ts": $((now - 5000)),
+  "channels": {
+    "C-A": {
+      "channel_id": "C-A",
+      "last_user_inbound_ts": $((now - 5000)),
+      "last_user_inbound_ts_ms": $(( (now - 5000) * 1000 )),
+      "last_user_inbound_message_id": "MSG-A",
+      "last_user_inbound_recorded_ns": 1
+    }
+  }
+}
+EOF
+)"
+  write_activity "$sd" telegram "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "telegram",
+  "updated_ts": $((now - 4000)),
+  "channels": {
+    "C-B": {
+      "channel_id": "C-B",
+      "last_user_inbound_ts": $((now - 4000)),
+      "last_user_inbound_ts_ms": $(( (now - 4000) * 1000 )),
+      "last_user_inbound_message_id": "MSG-B",
+      "last_user_inbound_recorded_ns": 2
+    }
+  }
+}
+EOF
+)"
+
+  run_route "$agent" "plugin:discord,plugin:telegram" "$sd" 1800 "$now"
+  if [[ "$ROUTE_EXIT" -eq 0 ]]; then
+    fail "$case" "expected non-zero exit; got 0 with stdout: $ROUTE_OUT"
+    return
+  fi
+  if [[ -n "$ROUTE_OUT" ]]; then
+    fail "$case" "expected empty stdout on no-route; got: $ROUTE_OUT"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T3: tie-break by recorded_ns then lexical plugin --------------
+t3() {
+  local case="T3 ms-tie → ns wins, then lexical plugin"
+  local sd="$ROOT/t3"
+  local now=2000000000
+  local agent="alpha"
+  local same_ms=$(( (now - 30) * 1000 ))
+
+  # Two candidates with identical inbound_ms; discord has higher recorded_ns
+  # so it wins on the ns tie-break.
+  write_activity "$sd" discord "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "discord",
+  "updated_ts": $((now - 30)),
+  "channels": {
+    "C-D-1": {
+      "channel_id": "C-D-1",
+      "last_user_inbound_ts": $((now - 30)),
+      "last_user_inbound_ts_ms": $same_ms,
+      "last_user_inbound_message_id": "MSG-D-1",
+      "last_user_inbound_recorded_ns": 999000000
+    }
+  }
+}
+EOF
+)"
+  write_activity "$sd" telegram "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "telegram",
+  "updated_ts": $((now - 30)),
+  "channels": {
+    "C-T-1": {
+      "channel_id": "C-T-1",
+      "last_user_inbound_ts": $((now - 30)),
+      "last_user_inbound_ts_ms": $same_ms,
+      "last_user_inbound_message_id": "MSG-T-1",
+      "last_user_inbound_recorded_ns": 100000000
+    }
+  }
+}
+EOF
+)"
+
+  run_route "$agent" "plugin:discord,plugin:telegram" "$sd" 1800 "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case" "expected exit 0; got $ROUTE_EXIT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_PLUGIN="discord"' <<<"$ROUTE_OUT"; then
+    fail "$case (ns)" "expected discord (higher recorded_ns); got: $ROUTE_OUT"
+    return
+  fi
+
+  # Now flip ns to be equal — fall through to lexical plugin (discord < telegram).
+  rm -rf "$sd"
+  write_activity "$sd" discord "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "discord",
+  "updated_ts": $((now - 30)),
+  "channels": {
+    "C-D-1": {
+      "channel_id": "C-D-1",
+      "last_user_inbound_ts": $((now - 30)),
+      "last_user_inbound_ts_ms": $same_ms,
+      "last_user_inbound_message_id": "MSG-D-1",
+      "last_user_inbound_recorded_ns": 500
+    }
+  }
+}
+EOF
+)"
+  write_activity "$sd" telegram "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "telegram",
+  "updated_ts": $((now - 30)),
+  "channels": {
+    "C-T-1": {
+      "channel_id": "C-T-1",
+      "last_user_inbound_ts": $((now - 30)),
+      "last_user_inbound_ts_ms": $same_ms,
+      "last_user_inbound_message_id": "MSG-T-1",
+      "last_user_inbound_recorded_ns": 500
+    }
+  }
+}
+EOF
+)"
+
+  run_route "$agent" "plugin:discord,plugin:telegram" "$sd" 1800 "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case (lex)" "expected exit 0; got $ROUTE_EXIT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_PLUGIN="discord"' <<<"$ROUTE_OUT"; then
+    fail "$case (lex)" "expected discord (lexical < telegram); got: $ROUTE_OUT"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T4: malformed JSON → graceful skip ----------------------------
+t4() {
+  local case="T4 malformed JSON → silent skip"
+  local sd="$ROOT/t4"
+  local now=2000000000
+  local agent="alpha"
+
+  mkdir -p "$sd/channels/discord"
+  printf '%s' '{not valid json' >"$sd/channels/discord/$agent.json"
+
+  run_route "$agent" "plugin:discord" "$sd" 1800 "$now"
+
+  if [[ "$ROUTE_EXIT" -eq 0 ]]; then
+    fail "$case" "expected non-zero exit; got 0 stdout=$ROUTE_OUT"
+    return
+  fi
+  if [[ -n "$ROUTE_OUT" ]]; then
+    fail "$case" "expected empty stdout; got: $ROUTE_OUT"
+    return
+  fi
+  if grep -qE 'Traceback|JSONDecodeError' <<<"$ROUTE_ERR"; then
+    fail "$case" "expected no traceback on stderr; saw: $ROUTE_ERR"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T5: missing last_user_inbound_message_id ----------------------
+t5() {
+  local case="T5 missing message_id filters out the candidate"
+  local sd="$ROOT/t5"
+  local now=2000000000
+  local agent="alpha"
+
+  # discord newer but missing message_id; telegram older but valid → telegram wins.
+  write_activity "$sd" discord "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "discord",
+  "updated_ts": $((now - 10)),
+  "channels": {
+    "C-D-1": {
+      "channel_id": "C-D-1",
+      "last_user_inbound_ts": $((now - 10)),
+      "last_user_inbound_ts_ms": $(( (now - 10) * 1000 )),
+      "last_user_inbound_recorded_ns": 1
+    }
+  }
+}
+EOF
+)"
+  write_activity "$sd" telegram "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "telegram",
+  "updated_ts": $((now - 100)),
+  "channels": {
+    "C-T-1": {
+      "channel_id": "C-T-1",
+      "last_user_inbound_ts": $((now - 100)),
+      "last_user_inbound_ts_ms": $(( (now - 100) * 1000 )),
+      "last_user_inbound_message_id": "MSG-T-1",
+      "last_user_inbound_recorded_ns": 2
+    }
+  }
+}
+EOF
+)"
+
+  run_route "$agent" "plugin:discord,plugin:telegram" "$sd" 1800 "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case" "expected exit 0 (telegram should win); got $ROUTE_EXIT, stdout=$ROUTE_OUT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_PLUGIN="telegram"' <<<"$ROUTE_OUT"; then
+    fail "$case" "expected telegram (discord filtered out); got: $ROUTE_OUT"
+    return
+  fi
+  if grep -qF 'CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID="MSG-T-1"' <<<"$ROUTE_OUT"; then
+    pass "$case"
+    return
+  fi
+  fail "$case" "expected MSG-T-1; got: $ROUTE_OUT"
+}
+
+# ---------- T6: --recency-seconds 0 coerced to 1800 default ---------------
+t6() {
+  local case="T6 recency=0 is coerced to default 1800"
+  local sd="$ROOT/t6"
+  local now=2000000000
+  local agent="alpha"
+
+  # Candidate is 1000s old: outside any tiny window but well inside 1800s default.
+  write_activity "$sd" discord "$agent" "$(cat <<EOF
+{
+  "schema_version": 1, "agent": "$agent", "plugin": "discord",
+  "updated_ts": $((now - 1000)),
+  "channels": {
+    "C-D-1": {
+      "channel_id": "C-D-1",
+      "last_user_inbound_ts": $((now - 1000)),
+      "last_user_inbound_ts_ms": $(( (now - 1000) * 1000 )),
+      "last_user_inbound_message_id": "MSG-D-1",
+      "last_user_inbound_recorded_ns": 1
+    }
+  }
+}
+EOF
+)"
+
+  run_route "$agent" "plugin:discord" "$sd" 0 "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case" "expected exit 0 (1000s within 1800s default); got $ROUTE_EXIT"
+    return
+  fi
+  if ! grep -qF 'CHANNEL_ROUTE_PLUGIN="discord"' <<<"$ROUTE_OUT"; then
+    fail "$case" "expected discord route; got: $ROUTE_OUT"
+    return
+  fi
+
+  # Sanity: empty string and non-numeric also coerce.
+  run_route "$agent" "plugin:discord" "$sd" "" "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case (empty)" "expected exit 0 with empty recency; got $ROUTE_EXIT"
+    return
+  fi
+  run_route "$agent" "plugin:discord" "$sd" "abc" "$now"
+  if [[ "$ROUTE_EXIT" -ne 0 ]]; then
+    fail "$case (non-numeric)" "expected exit 0 with non-numeric recency; got $ROUTE_EXIT"
+    return
+  fi
+  pass "$case"
+}
+
+t1
+t2
+t3
+t4
+t5
+t6
+
+printf '\n[smoke] %d passed, %d failed\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf '[smoke] failures:\n'
+  for entry in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$entry"
+  done
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Track A of multi-track issue #597 (PreCompact channel auto-notify). Implements the **consumer side**: route primitive + activity index schema. Daemon observer (Track B), TS plugin extensions (Track C), and Discord/Telegram relay activity-index writers (Track D) are future tracks.

## Files touched

- `bridge-channels.py` (+279) — new `route-precompact-target` subcommand
- `lib/bridge-channels.sh` (+22) — `bridge_channel_precompact_target` shell wrapper
- `tests/precompact-notify/route-primitive.sh` (+472) — 6-case standalone smoke fixture

## Routing logic

1. Parse channels-csv (normalize `plugin:`/`@marketplace`)
2. For each (plugin, channel) pair, read `state/channels/<plugin>/<agent>.json` activity index
3. Filter on `last_user_inbound_ts` present + `last_user_inbound_message_id` present + within recency window (default 1800s)
4. Argmax over `last_user_inbound_ts_ms` (or `last_user_inbound_ts * 1000`)
5. Tie-break: `last_user_inbound_recorded_ns` → lexical plugin → lexical channel_id → lexical message_id
6. Output shell or JSON; exit 1 silently when no route

## Open-question commitments (from codex spec)

- Q2: agent class == static maps to `bridge_agent_source` (provenance), NOT `bridge_agent_class` (privilege). Track B uses this.
- Q4: Agent Bridge maintains its own normalized activity index. Plugin-internal state not consulted directly.

## Verification

\`\`\`
bash -n lib/bridge-channels.sh                                                # PASS
shellcheck lib/bridge-channels.sh tests/precompact-notify/route-primitive.sh  # PASS
python3 -c "import ast; ast.parse(open('bridge-channels.py').read())"         # PASS

bash tests/precompact-notify/route-primitive.sh
[smoke][pass] T1 argmax picks newer candidate
[smoke][pass] T2 stale-only candidates → silent skip
[smoke][pass] T3 ms-tie → ns wins, then lexical plugin
[smoke][pass] T4 malformed JSON → silent skip
[smoke][pass] T5 missing message_id filters out the candidate
[smoke][pass] T6 recency=0 is coerced to default 1800
[smoke] 6 passed, 0 failed
\`\`\`

## Out of scope (later tracks)

- Daemon observer / hook marker writer / opt-in roster array (Track B)
- Send primitive `bridge_channel_send_managed_message` (Track B/C)
- Templates + EMA stats (Track B)
- Discord/Telegram relay activity-index writers (Track C/D)
- Teams/Mattermost TS plugin extensions (Track C)
- Smoke fixture registration in `scripts/smoke-test.sh` (Track D)

refs #597

🤖 Generated with [Claude Code](https://claude.com/claude-code)