### PR TITLE
fix(hooks): surface-reply-enforce matches plugin:<x>:<y> source tags

### DIFF
--- a/hooks/surface-reply-enforce.py
+++ b/hooks/surface-reply-enforce.py
@@ -3,7 +3,7 @@
 
 Runs once at Stop. If the latest user turn carries
 `<channel source="<surface>" chat_id="<id>" message_id="<id>" ...>` tags,
-the assistant turn must invoke `mcp__plugin_<surface>__reply` with a
+the assistant turn must invoke `mcp__plugin_<namespace>__reply` with a
 matching chat_id, OR the assistant text must include an explicit
 `<no-reply-needed source="<surface>" chat_id="<id>" reason="..." />`
 marker. Otherwise emit `{"decision": "block", "reason": "..."}` so
@@ -13,6 +13,14 @@ the reply.
 Issue #415 — textual rule from #342 kept regressing within 24h on the
 originating agent. Stop hook is the runtime boundary that doesn't rely
 on the LLM remembering the rule.
+
+Issue #20739 (2026-05-05) — production channel tags arrive as
+`source="plugin:<plugin_name>:<server_name>"` (e.g. "plugin:discord:discord")
+and reply tools are exposed as `mcp__plugin_<plugin>_<server>__reply`
+(e.g. `mcp__plugin_discord_discord__reply`). The previous
+`SUPPORTED_SURFACES = ("discord", ...)` membership check rejected the
+prefixed form, so the hook silent-passed every channel-sourced turn for
+roughly 30 days. `_parse_source` now normalizes both shapes.
 """
 from __future__ import annotations
 
@@ -22,11 +30,10 @@ import re
 import sys
 
 
-# Channel-source surfaces we enforce. Each maps to the mcp tool name
-# the agent must invoke to send the reply. Keep this list aligned with
-# the plugins that ship a `*__reply` tool (discord/telegram/teams).
-# ms365 plugin uses a different reply shape (email-send) and is not
-# enforced here.
+# Surface short-names we enforce. Each maps to the mcp reply tool name.
+# Keep this list aligned with the plugins that ship a `*__reply` tool
+# (discord/telegram/teams). ms365 plugin uses a different reply shape
+# (email-send) and is not enforced here.
 SUPPORTED_SURFACES = ("discord", "telegram", "teams")
 
 CHANNEL_TAG_RE = re.compile(
@@ -37,6 +44,33 @@ NO_REPLY_MARKER_RE = re.compile(
     r'<no-reply-needed\s+source="([^"]+)"\s+chat_id="([^"]+)"',
     re.IGNORECASE,
 )
+
+
+def _parse_source(raw: str):
+    """Parse a channel-tag source string → (surface, mcp_namespace).
+
+    Accepts both the legacy short form and the current MCP plugin form:
+
+    - "discord"                 → ("discord", "discord")
+    - "plugin:discord:discord"  → ("discord", "discord_discord")
+    - "plugin:telegram:telegram"→ ("telegram", "telegram_telegram")
+    - "plugin:foo"   (2 segs)   → ("foo", "foo")
+    - any other shape           → None
+
+    `surface` is the membership key for SUPPORTED_SURFACES; `mcp_namespace`
+    is the segment that goes into f"mcp__plugin_{namespace}__reply".
+    """
+    if not raw:
+        return None
+    s = raw.lower()
+    if s.startswith("plugin:"):
+        parts = s.split(":")
+        if len(parts) == 3:
+            return parts[1], f"{parts[1]}_{parts[2]}"
+        if len(parts) == 2:
+            return parts[1], parts[1]
+        return None
+    return s, s
 
 
 def load_event() -> dict:
@@ -82,10 +116,12 @@ def _extract_text(message_content) -> str:
 
 
 def _latest_pending_channel_input(entries: list[dict]):
-    """Walk entries in reverse and return the most recent user turn's
-    (source, chat_id, message_id, index) tuple where `index` is the
-    position of that user turn inside `entries`. Returns None if no
-    channel-source user turn is found in the trailing block."""
+    """Walk entries in reverse and return
+    (raw_source, surface, namespace, chat_id, message_id, index) for the
+    most recent user turn carrying a supported channel tag. Returns None
+    if the latest user turn isn't channel-sourced (matches existing
+    contract: enforcement applies only when the most recent user turn is
+    channel-bound)."""
     for idx in range(len(entries) - 1, -1, -1):
         entry = entries[idx]
         if entry.get("type") != "user":
@@ -93,29 +129,48 @@ def _latest_pending_channel_input(entries: list[dict]):
         text = _extract_text((entry.get("message") or {}).get("content"))
         match = CHANNEL_TAG_RE.search(text)
         if match:
-            source = match.group(1).lower()
-            if source in SUPPORTED_SURFACES:
-                return (source, match.group(2), match.group(3), idx)
-        # No supported channel tag on this user turn -> stop walking; we only
-        # enforce when the latest user turn was channel-sourced.
+            raw_source = match.group(1)
+            parsed = _parse_source(raw_source)
+            if parsed is not None:
+                surface, namespace = parsed
+                if surface in SUPPORTED_SURFACES:
+                    return (
+                        raw_source.lower(),
+                        surface,
+                        namespace,
+                        match.group(2),
+                        match.group(3),
+                        idx,
+                    )
+        # No supported channel tag on this user turn -> stop walking; we
+        # only enforce when the latest user turn was channel-sourced.
         return None
     return None
 
 
 def _assistant_replies_for_surface(
     entries: list[dict],
-    source: str,
+    raw_source: str,
+    surface: str,
+    namespace: str,
     chat_id: str,
     user_idx: int,
 ) -> bool:
     """Walk forward from the latest channel-source user turn (anchored at
     `user_idx`); return True when an assistant tool_use of
-    mcp__plugin_<source>__reply with matching chat_id is found, OR when an
-    explicit <no-reply-needed source=.. chat_id=..> marker appears in the
-    assistant text. Codex r1 fix #415: anchoring on user_idx (not the first
-    same-chat user turn from the start of transcript) prevents an older
-    reply from satisfying a newer unanswered message in the same chat."""
-    expected_tool = f"mcp__plugin_{source}__reply"
+    mcp__plugin_<namespace>__reply with matching chat_id is found, OR when
+    an explicit <no-reply-needed source=.. chat_id=..> marker appears in
+    the assistant text.
+
+    Marker matching accepts two `source` forms:
+      1. exact `raw_source` (e.g. "plugin:discord:discord") — preferred
+      2. legacy short surface ("discord", "telegram", "teams") for
+         backward compatibility.
+
+    Anything else in the marker source field is rejected to avoid
+    accepting unrelated `plugin:<x>:<y>` variants.
+    """
+    expected_tool = f"mcp__plugin_{namespace}__reply"
     for entry in entries[user_idx + 1:]:
         if entry.get("type") != "assistant":
             continue
@@ -136,7 +191,11 @@ def _assistant_replies_for_surface(
             if ptype == "text":
                 text = str(part.get("text") or "")
                 for nm in NO_REPLY_MARKER_RE.finditer(text):
-                    if nm.group(1).lower() == source and nm.group(2) == chat_id:
+                    nm_source = nm.group(1).lower()
+                    nm_chat = nm.group(2)
+                    if nm_chat != chat_id:
+                        continue
+                    if nm_source == raw_source or nm_source == surface:
                         return True
     return False
 
@@ -165,16 +224,19 @@ def main() -> int:
     if pending is None:
         return 0
 
-    source, chat_id, message_id, user_idx = pending
-    if _assistant_replies_for_surface(entries, source, chat_id, user_idx):
+    raw_source, surface, namespace, chat_id, message_id, user_idx = pending
+    if _assistant_replies_for_surface(
+        entries, raw_source, surface, namespace, chat_id, user_idx,
+    ):
         return 0
 
+    expected_tool = f"mcp__plugin_{namespace}__reply"
     reason = (
-        f"{source} chat_id={chat_id} message_id={message_id} "
-        f"입력에 대한 답변이 mcp__plugin_{source}__reply 호출로 전송되지 않았습니다. "
+        f"{raw_source} chat_id={chat_id} message_id={message_id} "
+        f"입력에 대한 답변이 {expected_tool} 호출로 전송되지 않았습니다. "
         f"답변 본문 작성 후 reply tool 호출 후 다시 종료하세요. "
         f"(답변이 불필요하면 assistant text에 "
-        f'<no-reply-needed source="{source}" chat_id="{chat_id}" reason="..." /> 마커 추가)'
+        f'<no-reply-needed source="{raw_source}" chat_id="{chat_id}" reason="..." /> 마커 추가)'
     )
     response = {"decision": "block", "reason": reason}
     sys.stdout.write(json.dumps(response, ensure_ascii=False))

--- a/tests/surface-reply-enforce/smoke.sh
+++ b/tests/surface-reply-enforce/smoke.sh
@@ -122,6 +122,41 @@ write_transcript_unsupported_plugin() {
 JSONL
 }
 
+# ──────────────────────────────────────────────────────────────────────
+# Multi-surface coverage (issue #20739 codex r2): SUPPORTED_SURFACES is
+# {discord, telegram, teams}; _parse_source handles all three via the
+# same plugin:<x>:<y> shape. Add telegram + teams production-format
+# fixtures so the membership gate is exercised beyond discord.
+# ──────────────────────────────────────────────────────────────────────
+
+write_transcript_telegram_with_reply() {
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:telegram:telegram\" chat_id=\"T123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"sending"},{"type":"tool_use","name":"mcp__plugin_telegram_telegram__reply","input":{"chat_id":"T123","content":"hi back"}}]}}
+JSONL
+}
+
+write_transcript_telegram_missing_reply() {
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:telegram:telegram\" chat_id=\"T123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"prose only, no reply tool"}]}}
+JSONL
+}
+
+write_transcript_teams_with_reply() {
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:teams:teams\" chat_id=\"TM123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"sending"},{"type":"tool_use","name":"mcp__plugin_teams_teams__reply","input":{"chat_id":"TM123","content":"hi back"}}]}}
+JSONL
+}
+
+write_transcript_teams_missing_reply() {
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:teams:teams\" chat_id=\"TM123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"prose only, no reply tool"}]}}
+JSONL
+}
+
 write_transcript_unparseable_prefix() {
   # 4 segments — _parse_source returns None.
   cat >"$1" <<'JSONL'
@@ -249,5 +284,51 @@ write_transcript_unparseable_prefix "$T"
 out="$(run_hook "$T" "agent-foo")"
 [[ -z "$out" ]] || die "case (j) expected no output (unparseable 4-segment prefix), got: $out"
 pass "(j) plugin:a:b:c (4-segment) -> silent"
+
+# ---- Case (k) telegram production format + matching reply -> silent -----
+T="$TMP/k.jsonl"
+write_transcript_telegram_with_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (k) expected no output, got: $out"
+pass "(k) plugin:telegram:telegram input + matching reply -> silent"
+
+# ---- Case (k2) telegram production format + missing reply -> block ------
+T="$TMP/k2.jsonl"
+write_transcript_telegram_missing_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -n "$out" ]] || die "case (k2) expected block JSON, got empty"
+echo "$out" | python3 -c '
+import json, sys
+data = json.loads(sys.stdin.read())
+assert data.get("decision") == "block", data
+reason = data.get("reason", "")
+assert "plugin:telegram:telegram" in reason.lower(), "reason missing raw_source: " + reason
+assert "T123" in reason, "reason missing chat_id: " + reason
+assert "mcp__plugin_telegram_telegram__reply" in reason, "reason missing tool: " + reason
+' || die "case (k2) JSON shape mismatch"
+pass "(k2) plugin:telegram:telegram input + missing reply -> block (with telegram_telegram tool name)"
+
+# ---- Case (l) teams production format + matching reply -> silent --------
+T="$TMP/l.jsonl"
+write_transcript_teams_with_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (l) expected no output, got: $out"
+pass "(l) plugin:teams:teams input + matching reply -> silent"
+
+# ---- Case (l2) teams production format + missing reply -> block ---------
+T="$TMP/l2.jsonl"
+write_transcript_teams_missing_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -n "$out" ]] || die "case (l2) expected block JSON, got empty"
+echo "$out" | python3 -c '
+import json, sys
+data = json.loads(sys.stdin.read())
+assert data.get("decision") == "block", data
+reason = data.get("reason", "")
+assert "plugin:teams:teams" in reason.lower(), "reason missing raw_source: " + reason
+assert "TM123" in reason, "reason missing chat_id: " + reason
+assert "mcp__plugin_teams_teams__reply" in reason, "reason missing tool: " + reason
+' || die "case (l2) JSON shape mismatch"
+pass "(l2) plugin:teams:teams input + missing reply -> block (with teams_teams tool name)"
 
 log "all cases passed"

--- a/tests/surface-reply-enforce/smoke.sh
+++ b/tests/surface-reply-enforce/smoke.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # tests/surface-reply-enforce/smoke.sh
 #
-# Regression test for issue #415 — Stop hook input-source ↔ output-reply
-# enforcement.
+# Regression test for issues #415 (anchored reply scan) and #20739
+# (channel-source prefix matching) — Stop hook input-source ↔
+# output-reply enforcement.
 #
 # The hook reads a Claude Code Stop event from stdin (JSON with
 # `transcript_path` and optional `stop_hook_active`), inspects the JSONL
@@ -12,21 +13,18 @@
 #   1. BRIDGE_AGENT_ID is non-empty (i.e. real agent session, not TUI-only)
 #   2. The latest user turn carries a <channel source="<surface>"
 #      chat_id="<id>" message_id="<id>"> tag for a supported surface
-#      (discord/telegram/teams)
+#      (discord/telegram/teams). Both legacy short form ("discord") and
+#      current MCP plugin form ("plugin:discord:discord") are accepted.
 #   3. No subsequent assistant turn invoked
-#      mcp__plugin_<surface>__reply with matching chat_id
+#      mcp__plugin_<namespace>__reply with matching chat_id, where
+#      <namespace> is "discord" for the legacy form and "discord_discord"
+#      for the plugin form.
 #   4. No subsequent assistant text emitted
-#      <no-reply-needed source="<surface>" chat_id="<id>" ...>
+#      <no-reply-needed source="<source>" chat_id="<id>" ...>
+#      with `source` matching either the raw input source or the short
+#      surface ("discord"/"telegram"/"teams").
 #
 # Otherwise it is silent and exits 0 (Stop proceeds).
-#
-# We exercise five cases:
-#   (a) channel input + matching mcp reply  -> exit 0, no output
-#   (b) channel input + missing reply       -> exit 0, JSON block on stdout
-#   (c) channel input + <no-reply-needed/>  -> exit 0, no output
-#   (d) TUI-source input (no channel tag)   -> exit 0, no output
-#   (e) BRIDGE_AGENT_ID empty               -> exit 0, no output
-#   (f) stop_hook_active=true re-entry      -> exit 0, no output
 
 set -euo pipefail
 
@@ -43,50 +41,92 @@ pass() { printf '[surface-reply-enforce][pass] %s\n' "$*"; }
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+# ──────────────────────────────────────────────────────────────────────
+# Production format fixtures (issue #20739): source="plugin:discord:discord",
+# reply tool "mcp__plugin_discord_discord__reply".
+# ──────────────────────────────────────────────────────────────────────
+
 write_transcript_with_reply() {
-  # User turn (Discord-source) followed by assistant tool_use of
-  # mcp__plugin_discord__reply with matching chat_id.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:discord:discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"sending"},{"type":"tool_use","name":"mcp__plugin_discord_discord__reply","input":{"chat_id":"C123","content":"hi back"}}]}}
+JSONL
+}
+
+write_transcript_missing_reply() {
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:discord:discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Here are three options: A/B/C."}]}}
+JSONL
+}
+
+write_transcript_no_reply_marker_raw() {
+  # Marker uses the raw production source verbatim.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:discord:discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"bot noise; no reply needed.\n<no-reply-needed source=\"plugin:discord:discord\" chat_id=\"C123\" reason=\"bot ack\" />"}]}}
+JSONL
+}
+
+write_transcript_no_reply_marker_short() {
+  # Marker uses the short surface form even though channel input is in
+  # plugin form. Backward-compat: still satisfies the gate.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:discord:discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"bot noise; no reply needed.\n<no-reply-needed source=\"discord\" chat_id=\"C123\" reason=\"bot ack\" />"}]}}
+JSONL
+}
+
+write_transcript_old_reply_new_unanswered() {
+  # codex r1 #415 regression: an old reply must not satisfy a newer
+  # unanswered turn from the same chat_id.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:discord:discord\" chat_id=\"C123\" message_id=\"M111\" />\nfirst question"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"answering"},{"type":"tool_use","name":"mcp__plugin_discord_discord__reply","input":{"chat_id":"C123","content":"old reply"}}]}}
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:discord:discord\" chat_id=\"C123\" message_id=\"M222\" />\nsecond question — needs a fresh reply"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"thinking out loud, no reply tool"}]}}
+JSONL
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Legacy short-form fixtures (pre-#20739). Kept as regression coverage
+# in case a future bridge revision emits the bare surface form.
+# ──────────────────────────────────────────────────────────────────────
+
+write_transcript_legacy_with_reply() {
   cat >"$1" <<'JSONL'
 {"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"sending"},{"type":"tool_use","name":"mcp__plugin_discord__reply","input":{"chat_id":"C123","content":"hi back"}}]}}
 JSONL
 }
 
-write_transcript_missing_reply() {
-  # User turn (Discord-source) followed by an assistant turn that ONLY
-  # writes prose — no reply tool, no marker. This is the bug.
+write_transcript_legacy_missing_reply() {
   cat >"$1" <<'JSONL'
 {"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
-{"type":"assistant","message":{"content":[{"type":"text","text":"Here are three options: A/B/C."}]}}
-JSONL
-}
-
-write_transcript_no_reply_marker() {
-  cat >"$1" <<'JSONL'
-{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M999\" />\nhello"}]}}
-{"type":"assistant","message":{"content":[{"type":"text","text":"bot noise; no reply needed.\n<no-reply-needed source=\"discord\" chat_id=\"C123\" reason=\"bot ack\" />"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"prose only"}]}}
 JSONL
 }
 
 write_transcript_tui_only() {
-  # No <channel ...> tag on the latest user turn.
   cat >"$1" <<'JSONL'
 {"type":"user","message":{"content":[{"type":"text","text":"please show me the queue"}]}}
 {"type":"assistant","message":{"content":[{"type":"text","text":"sure"}]}}
 JSONL
 }
 
-write_transcript_old_reply_new_unanswered() {
-  # codex r1 fix: an OLD reply to chat_id=C123 must NOT satisfy a NEW
-  # unanswered user turn from the SAME chat_id. The reply scanner used
-  # to walk forward from the start of the transcript and matched the
-  # first reply for that chat_id, leaking past a newer unanswered
-  # message in the same chat.
+write_transcript_unsupported_plugin() {
+  # Parseable plugin shape but surface not in SUPPORTED_SURFACES.
   cat >"$1" <<'JSONL'
-{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M111\" />\nfirst question"}]}}
-{"type":"assistant","message":{"content":[{"type":"text","text":"answering"},{"type":"tool_use","name":"mcp__plugin_discord__reply","input":{"chat_id":"C123","content":"old reply"}}]}}
-{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"discord\" chat_id=\"C123\" message_id=\"M222\" />\nsecond question — needs a fresh reply"}]}}
-{"type":"assistant","message":{"content":[{"type":"text","text":"thinking out loud, no reply tool"}]}}
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:foobar:foobar\" chat_id=\"C999\" message_id=\"M000\" />\nhi"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"prose only"}]}}
+JSONL
+}
+
+write_transcript_unparseable_prefix() {
+  # 4 segments — _parse_source returns None.
+  cat >"$1" <<'JSONL'
+{"type":"user","message":{"content":[{"type":"text","text":"<channel source=\"plugin:a:b:c\" chat_id=\"C999\" message_id=\"M000\" />\nhi"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"prose only"}]}}
 JSONL
 }
 
@@ -103,14 +143,14 @@ run_hook() {
   fi
 }
 
-# ---- Case (a) channel input + matching mcp reply -> silent --------------
+# ---- Case (a) production format + matching mcp reply -> silent ----------
 T="$TMP/a.jsonl"
 write_transcript_with_reply "$T"
 out="$(run_hook "$T" "agent-foo")"
 [[ -z "$out" ]] || die "case (a) expected no output, got: $out"
-pass "(a) channel input + matching reply -> silent"
+pass "(a) plugin:discord:discord input + matching reply -> silent"
 
-# ---- Case (b) channel input + missing reply -> block --------------------
+# ---- Case (b) production format + missing reply -> block ----------------
 T="$TMP/b.jsonl"
 write_transcript_missing_reply "$T"
 out="$(run_hook "$T" "agent-foo")"
@@ -118,21 +158,27 @@ out="$(run_hook "$T" "agent-foo")"
 echo "$out" | python3 -c '
 import json, sys
 data = json.loads(sys.stdin.read())
-decision = data.get("decision")
-assert decision == "block", "decision=" + repr(decision)
+assert data.get("decision") == "block", data
 reason = data.get("reason", "")
-assert "discord" in reason.lower(), "reason missing surface: " + reason
+assert "plugin:discord:discord" in reason.lower(), "reason missing raw_source: " + reason
 assert "C123" in reason, "reason missing chat_id: " + reason
-assert "mcp__plugin_discord__reply" in reason, "reason missing tool: " + reason
+assert "mcp__plugin_discord_discord__reply" in reason, "reason missing tool: " + reason
 ' || die "case (b) JSON shape mismatch"
-pass "(b) channel input + missing reply -> block"
+pass "(b) plugin:discord:discord input + missing reply -> block (with discord_discord tool name)"
 
-# ---- Case (c) channel input + <no-reply-needed/> -> silent --------------
+# ---- Case (c) production format + raw-source no-reply marker -> silent --
 T="$TMP/c.jsonl"
-write_transcript_no_reply_marker "$T"
+write_transcript_no_reply_marker_raw "$T"
 out="$(run_hook "$T" "agent-foo")"
 [[ -z "$out" ]] || die "case (c) expected no output, got: $out"
-pass "(c) channel input + no-reply marker -> silent"
+pass "(c) plugin:discord:discord input + raw-source no-reply marker -> silent"
+
+# ---- Case (c2) production format + short-surface no-reply marker -> silent ----
+T="$TMP/c2.jsonl"
+write_transcript_no_reply_marker_short "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (c2) expected no output, got: $out"
+pass "(c2) plugin:discord:discord input + short-surface no-reply marker -> silent"
 
 # ---- Case (d) TUI-source input (no channel tag) -> silent ---------------
 T="$TMP/d.jsonl"
@@ -141,7 +187,7 @@ out="$(run_hook "$T" "agent-foo")"
 [[ -z "$out" ]] || die "case (d) expected no output, got: $out"
 pass "(d) TUI-source input -> silent"
 
-# ---- Case (e) BRIDGE_AGENT_ID empty -> silent (even on a missing-reply transcript) ----
+# ---- Case (e) BRIDGE_AGENT_ID empty -> silent ---------------------------
 T="$TMP/e.jsonl"
 write_transcript_missing_reply "$T"
 out="$(run_hook "$T" "")"
@@ -155,10 +201,7 @@ out="$(run_hook "$T" "agent-foo" ',"stop_hook_active":true')"
 [[ -z "$out" ]] || die "case (f) expected no output (stop_hook_active=true), got: $out"
 pass "(f) stop_hook_active re-entry -> silent"
 
-# ---- Case (g) old reply for same chat_id must NOT satisfy newer unanswered ----
-# codex r1 regression: reply scanner anchored at index of the LATEST
-# channel-source user turn, not the first same-chat user turn from the
-# start of the transcript.
+# ---- Case (g) old reply for same chat_id does NOT satisfy newer unanswered ----
 T="$TMP/g.jsonl"
 write_transcript_old_reply_new_unanswered "$T"
 out="$(run_hook "$T" "agent-foo")"
@@ -171,5 +214,40 @@ reason = data.get("reason", "")
 assert "M222" in reason, "reason should reference NEW message_id, got: " + reason
 ' || die "case (g) JSON shape mismatch (old reply may be satisfying new unanswered)"
 pass "(g) old reply for same chat_id does not satisfy newer unanswered turn"
+
+# ---- Case (h) legacy short form input + matching legacy reply -> silent ----
+T="$TMP/h.jsonl"
+write_transcript_legacy_with_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (h) expected no output, got: $out"
+pass "(h) legacy 'discord' source + mcp__plugin_discord__reply -> silent"
+
+# ---- Case (h2) legacy short form input + missing reply -> block (with short tool name) ----
+T="$TMP/h2.jsonl"
+write_transcript_legacy_missing_reply "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -n "$out" ]] || die "case (h2) expected block JSON, got empty"
+echo "$out" | python3 -c '
+import json, sys
+data = json.loads(sys.stdin.read())
+assert data.get("decision") == "block", data
+reason = data.get("reason", "")
+assert "mcp__plugin_discord__reply" in reason, "legacy expected tool: " + reason
+' || die "case (h2) JSON shape mismatch (legacy expected tool)"
+pass "(h2) legacy 'discord' source + missing reply -> block with short tool name"
+
+# ---- Case (i) parseable plugin shape but unsupported surface -> silent ----
+T="$TMP/i.jsonl"
+write_transcript_unsupported_plugin "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (i) expected no output (surface=foobar not supported), got: $out"
+pass "(i) plugin:foobar:foobar (unsupported surface) -> silent"
+
+# ---- Case (j) unparseable plugin prefix -> silent -----------------------
+T="$TMP/j.jsonl"
+write_transcript_unparseable_prefix "$T"
+out="$(run_hook "$T" "agent-foo")"
+[[ -z "$out" ]] || die "case (j) expected no output (unparseable 4-segment prefix), got: $out"
+pass "(j) plugin:a:b:c (4-segment) -> silent"
 
 log "all cases passed"


### PR DESCRIPTION
## Summary

`hooks/surface-reply-enforce.py` was silent-passing every channel-sourced
turn for ~30 days because production channel tags now arrive in the form
`source="plugin:<plugin_name>:<server_name>"` (e.g.
`plugin:discord:discord`) and reply tools as
`mcp__plugin_<plugin>_<server>__reply` (e.g.
`mcp__plugin_discord_discord__reply`), while the hook still expected the
legacy short form `"discord"` for `SUPPORTED_SURFACES` membership.
Membership check failed → hook returned None → no enforcement → an
agent could legitimately respond to a Discord-bound user with a TUI-only
text turn and the Stop hook would not block.

A real instance triggered today: a Discord-bound agent answered an
operator question with prose only; the operator never saw the answer.
Investigation found this hook was wired in `settings.effective.json`
but had been failing the membership check since 2026-04-04 (the
earliest channel tag with the prefixed form found in transcripts).

## What changes

- New `_parse_source(raw)` helper normalizes both the legacy short form
  and the current MCP plugin form:
  - `"discord"` → `("discord", "discord")`
  - `"plugin:discord:discord"` → `("discord", "discord_discord")`
  - `"plugin:telegram:telegram"` → `("telegram", "telegram_telegram")`
  - `"plugin:foo"` (2 segs) → `("foo", "foo")`
  - 4+ segments / empty → `None`
- `_latest_pending_channel_input` now returns
  `(raw_source, surface, namespace, chat_id, message_id, idx)` so the
  raw source survives for marker matching.
- `_assistant_replies_for_surface` checks
  `mcp__plugin_<namespace>__reply` (which becomes
  `mcp__plugin_discord_discord__reply` for the prefixed form, and
  remains `mcp__plugin_discord__reply` for the legacy form).
- The `<no-reply-needed source="…" chat_id="…"/>` escape hatch accepts
  two source forms only (raw exact match, or short surface) so unrelated
  `plugin:<x>:<y>` variants cannot satisfy the gate.
- Block-reason text now exposes `raw_source` and the actual
  `expected_tool`, so operators see the production form and write
  matching markers.

## Tests

`tests/surface-reply-enforce/smoke.sh` rewritten so the *primary* cases
exercise the production format. Six new cases plus the pre-existing
five (now in production format):

| Case | Description | Expected |
|---|---|---|
| (a) | `plugin:discord:discord` + matching reply | silent |
| (b) | `plugin:discord:discord` + missing reply | block, reason names `mcp__plugin_discord_discord__reply` |
| (c) | `plugin:discord:discord` + raw-source no-reply marker | silent |
| (c2) | `plugin:discord:discord` + short-surface no-reply marker | silent |
| (d) | TUI-source input | silent |
| (e) | `BRIDGE_AGENT_ID` empty | silent |
| (f) | `stop_hook_active` re-entry | silent |
| (g) | old reply for same chat_id, then newer unanswered | block (anchored scan, regression coverage for #415) |
| (h) | legacy `"discord"` source + legacy reply tool | silent |
| (h2) | legacy `"discord"` source + missing reply | block, reason names `mcp__plugin_discord__reply` |
| (i) | `plugin:foobar:foobar` (parseable, unsupported surface) | silent |
| (j) | `plugin:a:b:c` (unparseable 4-segment) | silent |

12/12 pass.

## Test plan

- [x] `python3 -m py_compile hooks/surface-reply-enforce.py`
- [x] `bash tests/surface-reply-enforce/smoke.sh` (12/12)
- [x] Replayed the real production incident transcript (`source="plugin:discord:discord"`, prose-only assistant) — patched hook returns `{"decision":"block", … mcp__plugin_discord_discord__reply …}`.

## Notes

- The hook honors `BRIDGE_AGENT_ID` empty (TUI-only) and
  `stop_hook_active` re-entry guards as before.
- Behavior fix only; settings/wiring are unchanged.
- Issue #415 anchored-reply-scan regression case (g) preserved.
- ms365 plugin reply path is intentionally not enforced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)