### PR TITLE
feat(agent): registry --json endpoint (Track 1 of #598)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -314,6 +314,23 @@ agb cron cleanup report
 status, activity age, and stale-session health. Stale health is based on local
 tmux activity and recorded bridge state, not on model calls.
 
+For tooling that needs the full agent enumeration plus provenance and
+privilege-class together (cleanup detectors, retirement scripts,
+third-party housekeeping helpers), use `agb agent registry --json`. It
+returns one JSON record per agent id known on this host (static +
+dynamic + system) with `class` (`system|dynamic|static` — system wins
+over the static/dynamic split for cleanup callers), `agent_source`
+(raw `static|dynamic`), `privilege_class` (raw `user|system`), `home`,
+`workdir`, `engine`, `session`, `is_alive` (tmux session present), and
+`source` (which loader path made the id known: `static-roster`,
+`dynamic-active-env`, `dynamic-history-live-session`,
+`dynamic-tmux-recovered`). Output is sorted by id for stable diffs.
+This is the recommended endpoint for any cleanup tool that needs to
+subtract the live dynamic-agent set before flagging directories as
+orphan — `agb agent list` does not surface dynamic agents, which is
+why naive cleanup rules historically false-positived live `--prefer
+new` workers.
+
 When changing cron behavior, inspect jobs before modifying them:
 
 ```bash

--- a/agent-bridge
+++ b/agent-bridge
@@ -61,7 +61,7 @@ Usage:
   $CLI_NAME bundle <create|show> ...
   $CLI_NAME intake <triage|show> ...
   $CLI_NAME wave <dispatch|list|show|templates|close-issue> ...
-  $CLI_NAME agent <create|update|list|show|reclassify|start|safe-mode|stop|restart|attach|compact|handoff> ...
+  $CLI_NAME agent <create|update|delete|list|registry|show|reclassify|start|safe-mode|stop|restart|attach|compact|handoff> ...
   $CLI_NAME kill <number|all>
   $CLI_NAME attach [number|name]
   $CLI_NAME urgent <agent> "<message>" [--wait <seconds>]
@@ -116,6 +116,7 @@ Usage:
   $CLI_NAME profile deploy <agent> [--dry-run] [--force]
   $CLI_NAME agent create <agent> [--engine claude|codex] [--session <name>] [--workdir <path>] [--always-on] [--dry-run] [--json]
   $CLI_NAME agent list [--json]
+  $CLI_NAME agent registry [--json]
   $CLI_NAME agent show <agent> [--json]
   $CLI_NAME agent reclassify [--agent <agent>] [--apply] [--json]
   $CLI_NAME agent start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
@@ -197,6 +198,7 @@ Examples:
   $CLI_NAME kill all
   $CLI_NAME agent create reviewer --engine claude
   $CLI_NAME agent list --json
+  $CLI_NAME agent registry --json
   $CLI_NAME agent show reviewer --json
   $CLI_NAME agent reclassify --apply
   $CLI_NAME agent start reviewer --dry-run

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -6,6 +6,16 @@ set -euo pipefail
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
+
+# Issue #598 Track 1 r2: the `agent registry` endpoint must be read-only,
+# but bridge_load_roster runs unconditionally at script load. Detect the
+# registry subcommand early and export BRIDGE_REGISTRY_READ_ONLY=1 so the
+# guards in lib/bridge-state.sh skip the dynamic active-env writes that
+# the recovery loaders would otherwise perform during registry enumeration.
+if [[ "${1:-}" == "registry" ]]; then
+  export BRIDGE_REGISTRY_READ_ONLY=1
+fi
+
 bridge_load_roster
 
 usage() {

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -15,6 +15,7 @@ Usage:
   $(basename "$0") update <agent> [options]
   $(basename "$0") delete <agent> [--from <admin>] [--force] [--orphan-tasks] [--purge-home] [--purge-crons] [--dry-run] [--json]
   $(basename "$0") list [--json]
+  $(basename "$0") registry [--json]
   $(basename "$0") show <agent> [--json]
   $(basename "$0") reclassify [--agent <agent>] [--apply] [--json]
   $(basename "$0") rerender-settings [<agent>...] [--apply|--dry-run] [--json]
@@ -1159,6 +1160,127 @@ for item in items:
         f"{item.get('session','')} | "
         f"{item.get('workdir','')}"
     )
+PY
+}
+
+# run_registry — issue #598 Track 1. Read-only enumeration of every
+# agent id known on this host (static + dynamic + system) with the
+# provenance tag for the loader that surfaced each id. Intended for
+# tooling that needs class + provenance together (cleanup detectors,
+# retirement scripts) without re-implementing roster parsing. Sibling
+# to `agent list` — does not modify state and does not replace
+# `agent list`'s human/JSON shape.
+#
+# Output schema (JSON array sorted by `id` for stable diffs):
+#   id              agent name
+#   class           cleanup-class: system > dynamic > static
+#                   (system wins so cleanup tools never reap a
+#                   privileged static agent purely on source=static)
+#   agent_source    raw bridge_agent_source: static | dynamic
+#   privilege_class raw bridge_agent_class: user | system
+#   home            bridge_agent_default_home (live agent home root)
+#   workdir         bridge_agent_workdir
+#   engine          bridge_agent_engine
+#   session         bridge_agent_session
+#   is_alive        bridge_agent_is_active (tmux session exists)
+#   source          provenance: static-roster | dynamic-active-env |
+#                   dynamic-history-live-session | dynamic-tmux-recovered
+run_registry() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json)
+        # Currently the only output mode. Accept the flag for
+        # symmetry with `agent list --json` so callers can keep a
+        # single argv shape across both endpoints.
+        shift
+        ;;
+      *)
+        bridge_die "지원하지 않는 agent registry 옵션입니다: $1"
+        ;;
+    esac
+  done
+
+  local agent
+  local agent_source
+  local privilege_class
+  local cleanup_class
+  local home
+  local workdir
+  local engine
+  local session
+  local provenance
+  local is_alive
+  local rows=""
+
+  if declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 && (( ${#BRIDGE_AGENT_IDS[@]} > 0 )); then
+    for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+      agent_source="$(bridge_agent_source "$agent")"
+      privilege_class="$(bridge_agent_class "$agent")"
+      # cleanup_class: system > dynamic > static. Operators consuming
+      # `class` to decide reap-or-keep see "system" for privileged
+      # agents regardless of how the roster surfaced them. The raw
+      # static/dynamic split stays available via agent_source.
+      if [[ "$privilege_class" == "system" ]]; then
+        cleanup_class="system"
+      elif [[ "$agent_source" == "dynamic" ]]; then
+        cleanup_class="dynamic"
+      else
+        cleanup_class="static"
+      fi
+      home="$(bridge_agent_default_home "$agent")"
+      workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || printf '')"
+      engine="$(bridge_agent_engine "$agent")"
+      session="$(bridge_agent_session "$agent")"
+      provenance="$(bridge_agent_provenance "$agent")"
+      if bridge_agent_is_active "$agent"; then
+        is_alive="1"
+      else
+        is_alive="0"
+      fi
+      rows+=$(printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$agent" \
+        "$cleanup_class" \
+        "$agent_source" \
+        "$privilege_class" \
+        "$home" \
+        "$workdir" \
+        "$engine" \
+        "$session" \
+        "$is_alive" \
+        "$provenance")
+      rows+=$'\n'
+    done
+  fi
+
+  bridge_agent_manage_python "$rows" <<'PY'
+import json
+import sys
+
+raw = sys.argv[1] if len(sys.argv) > 1 else ""
+records = []
+for line in raw.splitlines():
+    if not line.strip():
+        continue
+    parts = line.split("\t")
+    if len(parts) < 10:
+        continue
+    (id_, cls, agent_source, privilege_class, home, workdir,
+     engine, session, is_alive, source) = parts[:10]
+    records.append({
+        "id": id_,
+        "class": cls,
+        "agent_source": agent_source,
+        "privilege_class": privilege_class,
+        "home": home,
+        "workdir": workdir,
+        "engine": engine,
+        "session": session,
+        "is_alive": is_alive == "1",
+        "source": source,
+    })
+
+records.sort(key=lambda r: r["id"])
+print(json.dumps(records, ensure_ascii=False, indent=2))
 PY
 }
 
@@ -3360,6 +3482,9 @@ case "$subcommand" in
   list)
     run_list "$@"
     ;;
+  registry)
+    run_registry "$@"
+    ;;
   show)
     run_show "$@"
     ;;
@@ -3402,7 +3527,7 @@ case "$subcommand" in
   *)
     # Issue #163 Phase 2: surface an intent-recovery hint before dying.
     _hint="$(bridge_suggest_subcommand "$subcommand" \
-      "create update delete list show reclassify rerender-settings start safe-mode stop restart ack-crash forget-session attach compact handoff")"
+      "create update delete list registry show reclassify rerender-settings start safe-mode stop restart ack-crash forget-session attach compact handoff")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 agent 명령입니다: $subcommand"
     ;;

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -386,6 +386,17 @@ bridge_agent_source() {
   printf '%s' "${BRIDGE_AGENT_SOURCE[$agent]-static}"
 }
 
+# Issue #598 Track 1: which loader path made this agent id known.
+# Closed value space: {static-roster, dynamic-active-env,
+# dynamic-history-live-session, dynamic-tmux-recovered}. Falls back to
+# `static-roster` when the loader did not tag the agent — that matches
+# the historical implicit behavior of any id in BRIDGE_AGENT_IDS that
+# only has BRIDGE_AGENT_SOURCE=static.
+bridge_agent_provenance() {
+  local agent="$1"
+  printf '%s' "${BRIDGE_AGENT_PROVENANCE[$agent]-static-roster}"
+}
+
 # Issue #539: agent class is the privilege boundary consumed by
 # hooks/tool-policy.py. The closed value space is {user, system}; any
 # unknown value (including the empty string written by older roster

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -574,6 +574,7 @@ bridge_reset_roster_maps() {
   unset BRIDGE_AGENT_SKILLS
   unset BRIDGE_AGENT_ISOLATION_MODE BRIDGE_AGENT_OS_USER
   unset BRIDGE_AGENT_CLASS
+  unset BRIDGE_AGENT_PROVENANCE
 
   declare -g -a BRIDGE_AGENT_IDS=()
   declare -g -A BRIDGE_AGENT_DESC=()
@@ -615,6 +616,14 @@ bridge_reset_roster_maps() {
   # Operators opt agents into class=system in agent-roster.local.sh; the
   # public roster declares no system-class agents.
   declare -g -A BRIDGE_AGENT_CLASS=()
+  # Issue #598 Track 1: provenance tag set by each loader path so the
+  # registry endpoint can report which registry made the agent id known
+  # (`static-roster`, `dynamic-active-env`, `dynamic-history-live-session`,
+  # `dynamic-tmux-recovered`). Default-empty; consumers fall back to
+  # `static-roster` when the tag is missing — that matches the historical
+  # implicit behavior of any id present in BRIDGE_AGENT_IDS without a
+  # dynamic loader having claimed it.
+  declare -g -A BRIDGE_AGENT_PROVENANCE=()
   declare -g -a BRIDGE_CRON_ENQUEUE_FAMILIES=()
 }
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -914,6 +914,9 @@ bridge_load_dynamic_agent_file() {
   BRIDGE_AGENT_WORKDIR["$AGENT_ID"]="$AGENT_WORKDIR"
   BRIDGE_AGENT_SOURCE["$AGENT_ID"]="dynamic"
   BRIDGE_AGENT_META_FILE["$AGENT_ID"]="$file"
+  # Issue #598 Track 1: tag provenance so `agent registry --json` can
+  # report which loader made this id known.
+  BRIDGE_AGENT_PROVENANCE["$AGENT_ID"]="dynamic-active-env"
   BRIDGE_AGENT_LOOP["$AGENT_ID"]="${AGENT_LOOP:-1}"
   BRIDGE_AGENT_CONTINUE["$AGENT_ID"]="${AGENT_CONTINUE:-1}"
   # Hydration: gate the stored id through the freshness resolver. rc=0 keeps
@@ -988,6 +991,10 @@ bridge_restore_dynamic_agents_from_history() {
     BRIDGE_AGENT_SESSION["$AGENT_ID"]="$AGENT_SESSION"
     BRIDGE_AGENT_WORKDIR["$AGENT_ID"]="$AGENT_WORKDIR"
     BRIDGE_AGENT_SOURCE["$AGENT_ID"]="dynamic"
+    # Issue #598 Track 1: history-restored entries are gated above on
+    # bridge_tmux_session_exists, so this path only fires for agents
+    # whose tmux session is currently live.
+    BRIDGE_AGENT_PROVENANCE["$AGENT_ID"]="dynamic-history-live-session"
     BRIDGE_AGENT_LOOP["$AGENT_ID"]="${AGENT_LOOP:-1}"
     BRIDGE_AGENT_CONTINUE["$AGENT_ID"]="${AGENT_CONTINUE:-1}"
     # Hydration: gate stored id through resolver (see bridge_load_dynamic_agent_file).
@@ -1066,6 +1073,9 @@ bridge_reconcile_dynamic_agents_from_tmux() {
     BRIDGE_AGENT_SESSION["$session"]="$session"
     BRIDGE_AGENT_WORKDIR["$session"]="$pane_path"
     BRIDGE_AGENT_SOURCE["$session"]="dynamic"
+    # Issue #598 Track 1: pane-derived recovery — neither active env nor
+    # history file produced a registration, so the only signal is tmux.
+    BRIDGE_AGENT_PROVENANCE["$session"]="dynamic-tmux-recovered"
     BRIDGE_AGENT_LOOP["$session"]="1"
     BRIDGE_AGENT_CONTINUE["$session"]="1"
     BRIDGE_AGENT_SESSION_ID["$session"]=""
@@ -1130,6 +1140,10 @@ _bridge_register_dynamic_from_env_file() {
   BRIDGE_AGENT_SESSION["$AGENT_ID"]="$AGENT_SESSION"
   BRIDGE_AGENT_WORKDIR["$AGENT_ID"]="$AGENT_WORKDIR"
   BRIDGE_AGENT_SOURCE["$AGENT_ID"]="dynamic"
+  # Issue #598 Track 1: this helper is only called from
+  # bridge_reconcile_dynamic_agents_from_tmux (tmux session is the
+  # discovery signal; the history env file just supplies engine/workdir).
+  BRIDGE_AGENT_PROVENANCE["$AGENT_ID"]="dynamic-tmux-recovered"
   BRIDGE_AGENT_LOOP["$AGENT_ID"]="${AGENT_LOOP:-1}"
   BRIDGE_AGENT_CONTINUE["$AGENT_ID"]="${AGENT_CONTINUE:-1}"
   # Hydration: gate the stored id through the freshness resolver. rc=0 keeps
@@ -1341,6 +1355,13 @@ bridge_load_roster() {
 
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do
     BRIDGE_AGENT_SOURCE["$agent"]="${BRIDGE_AGENT_SOURCE[$agent]-static}"
+    # Issue #598 Track 1: any id surfaced by the roster files (without an
+    # explicit dynamic loader claiming it later) is static — tag default.
+    # The dynamic loaders below overwrite this with their own provenance
+    # tag when they recognise the id.
+    if [[ "${BRIDGE_AGENT_SOURCE[$agent]}" == "static" ]]; then
+      BRIDGE_AGENT_PROVENANCE["$agent"]="${BRIDGE_AGENT_PROVENANCE[$agent]-static-roster}"
+    fi
     BRIDGE_AGENT_LOOP["$agent"]="${BRIDGE_AGENT_LOOP[$agent]-1}"
     BRIDGE_AGENT_CONTINUE["$agent"]="${BRIDGE_AGENT_CONTINUE[$agent]-1}"
     BRIDGE_AGENT_HISTORY_KEY["$agent"]="${BRIDGE_AGENT_HISTORY_KEY[$agent]-$(bridge_history_key_for "$(bridge_agent_engine "$agent")" "$agent" "$(bridge_agent_workdir "$agent")")}"

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1010,7 +1010,13 @@ bridge_restore_dynamic_agents_from_history() {
 
     active_file="$(bridge_dynamic_agent_file_for "$AGENT_ID")"
     BRIDGE_AGENT_META_FILE["$AGENT_ID"]="$active_file"
-    bridge_write_dynamic_agent_file "$AGENT_ID" "$active_file"
+    # Issue #598 Track 1 r2: when BRIDGE_REGISTRY_READ_ONLY=1 is set by the
+    # registry endpoint, skip the persistence side-effect to keep the registry
+    # read truly read-only. The in-memory state (BRIDGE_AGENT_*) is still
+    # populated for the registry's enumeration.
+    if [[ "${BRIDGE_REGISTRY_READ_ONLY:-0}" != "1" ]]; then
+      bridge_write_dynamic_agent_file "$AGENT_ID" "$active_file"
+    fi
   done
   shopt -u nullglob
 }
@@ -1085,7 +1091,13 @@ bridge_reconcile_dynamic_agents_from_tmux() {
 
     active_file="$(bridge_dynamic_agent_file_for "$session")"
     BRIDGE_AGENT_META_FILE["$session"]="$active_file"
-    bridge_write_dynamic_agent_file "$session" "$active_file"
+    # Issue #598 Track 1 r2: when BRIDGE_REGISTRY_READ_ONLY=1 is set by the
+    # registry endpoint, skip the persistence side-effect to keep the registry
+    # read truly read-only. The in-memory state (BRIDGE_AGENT_*) is still
+    # populated for the registry's enumeration.
+    if [[ "${BRIDGE_REGISTRY_READ_ONLY:-0}" != "1" ]]; then
+      bridge_write_dynamic_agent_file "$session" "$active_file"
+    fi
   done < <(tmux list-sessions -F '#{session_name}' 2>/dev/null || true)
 }
 
@@ -1162,7 +1174,13 @@ _bridge_register_dynamic_from_env_file() {
 
   active_file="$(bridge_dynamic_agent_file_for "$AGENT_ID")"
   BRIDGE_AGENT_META_FILE["$AGENT_ID"]="$active_file"
-  bridge_write_dynamic_agent_file "$AGENT_ID" "$active_file"
+  # Issue #598 Track 1 r2: when BRIDGE_REGISTRY_READ_ONLY=1 is set by the
+  # registry endpoint, skip the persistence side-effect to keep the registry
+  # read truly read-only. The in-memory state (BRIDGE_AGENT_*) is still
+  # populated for the registry's enumeration.
+  if [[ "${BRIDGE_REGISTRY_READ_ONLY:-0}" != "1" ]]; then
+    bridge_write_dynamic_agent_file "$AGENT_ID" "$active_file"
+  fi
 }
 
 bridge_load_static_agent_history() {

--- a/scripts/smoke/agent-registry.sh
+++ b/scripts/smoke/agent-registry.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# scripts/smoke/agent-registry.sh — Issue #598 Track 1 smoke.
+#
+# Validates the new `agent registry --json` endpoint:
+#   T1. Static + dynamic-active-env mix → both rows surface with correct
+#       `class` (static vs dynamic) and `source` (static-roster vs
+#       dynamic-active-env) tags.
+#   T2. system-class agent → `class=system` in the public field while
+#       `agent_source` and `privilege_class` preserve the raw signals
+#       (system wins over static/dynamic for cleanup callers, but the
+#       provenance split stays available).
+#   T3. Empty roster → `[]` (well-formed JSON).
+#   T4. Stable sort: two consecutive calls produce byte-identical output.
+#   T5. Output is parseable by `jq` (well-formed JSON, not just
+#       text-shaped JSON).
+#
+# Uses an isolated BRIDGE_HOME via smoke_setup_bridge_home — never
+# touches the operator's live runtime.
+#
+# Not registered in scripts/smoke-test.sh yet — Track 2's detector smoke
+# will register both fixtures once the orphan-agent-dir detector lands.
+
+set -euo pipefail
+
+SMOKE_NAME="agent-registry"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "agent-registry"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BASH4_BIN="${BASH:-bash}"
+if (( BASH_VERSINFO[0] < 4 )); then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BASH4_BIN="/opt/homebrew/bin/bash"
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BASH4_BIN="/usr/local/bin/bash"
+  fi
+fi
+
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+# Helper — invoke `agent registry --json` against the isolated
+# BRIDGE_HOME. Re-exports every BRIDGE_* the lib injected so the
+# subshell sees the same scope.
+agent_registry_json() {
+  "$BASH4_BIN" "$REPO_ROOT/bridge-agent.sh" registry --json
+}
+
+# Helper — assert JSON output parses with jq when jq is available; fall
+# back to python json.loads otherwise so the smoke remains portable to
+# hosts without jq installed.
+assert_valid_json() {
+  local payload="$1"
+  local context="$2"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$payload" | jq -e . >/dev/null 2>&1 \
+      || smoke_fail "$context: jq rejected the payload (not valid JSON): $payload"
+  else
+    "$PY_BIN" -c 'import json,sys; json.loads(sys.stdin.read())' <<<"$payload" \
+      || smoke_fail "$context: python json.loads rejected the payload: $payload"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Roster fixture writers.
+# ---------------------------------------------------------------------------
+
+write_empty_roster() {
+  : >"$BRIDGE_ROSTER_LOCAL_FILE"
+  rm -rf "$BRIDGE_ACTIVE_AGENT_DIR"
+  mkdir -p "$BRIDGE_ACTIVE_AGENT_DIR"
+}
+
+write_static_one() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "alpha"
+BRIDGE_AGENT_ENGINE["alpha"]="claude"
+BRIDGE_AGENT_SESSION["alpha"]="alpha"
+BRIDGE_AGENT_WORKDIR["alpha"]="$BRIDGE_AGENT_HOME_ROOT/alpha"
+EOF
+  # Clear any dynamic-active-env files left behind by a prior test so
+  # tests that expect a static-only roster are not contaminated.
+  rm -rf "$BRIDGE_ACTIVE_AGENT_DIR"
+  mkdir -p "$BRIDGE_ACTIVE_AGENT_DIR"
+}
+
+# Dynamic active-env files live under $BRIDGE_ACTIVE_AGENT_DIR/*.env and
+# are sourced by bridge_load_dynamic_agents during bridge_load_roster.
+write_dynamic_active_env() {
+  local agent="$1"
+  local engine="$2"
+  local file="$BRIDGE_ACTIVE_AGENT_DIR/${agent}.env"
+  mkdir -p "$BRIDGE_ACTIVE_AGENT_DIR"
+  cat >"$file" <<EOF
+AGENT_ID="$agent"
+AGENT_DESC="dynamic test agent"
+AGENT_ENGINE="$engine"
+AGENT_SESSION="$agent"
+AGENT_WORKDIR="$BRIDGE_AGENT_HOME_ROOT/$agent"
+AGENT_LOOP=1
+AGENT_CONTINUE=1
+EOF
+}
+
+write_static_with_system() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "alpha"
+BRIDGE_AGENT_ENGINE["alpha"]="claude"
+BRIDGE_AGENT_SESSION["alpha"]="alpha"
+BRIDGE_AGENT_WORKDIR["alpha"]="$BRIDGE_AGENT_HOME_ROOT/alpha"
+
+bridge_add_agent_id_if_missing "patrol"
+BRIDGE_AGENT_ENGINE["patrol"]="claude"
+BRIDGE_AGENT_SESSION["patrol"]="patrol"
+BRIDGE_AGENT_WORKDIR["patrol"]="$BRIDGE_AGENT_HOME_ROOT/patrol"
+BRIDGE_AGENT_CLASS["patrol"]="system"
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# T1 — static + dynamic mix.
+# ---------------------------------------------------------------------------
+test_static_plus_dynamic() {
+  write_static_one
+  write_dynamic_active_env "delta" "codex"
+
+  local out
+  out="$(agent_registry_json)"
+  assert_valid_json "$out" "T1 valid JSON"
+
+  # Two records, sorted alphabetically (alpha before delta).
+  local count
+  count="$("$PY_BIN" -c 'import json,sys; print(len(json.loads(sys.stdin.read())))' <<<"$out")"
+  smoke_assert_eq "2" "$count" "T1 two records"
+
+  local first_id
+  first_id="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); print(d[0]["id"])' <<<"$out")"
+  smoke_assert_eq "alpha" "$first_id" "T1 sorted by id (alpha first)"
+
+  # Field-level assertions for the static row.
+  local alpha_class alpha_source alpha_provenance alpha_priv
+  alpha_class="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="alpha"][0]; print(a["class"])' <<<"$out")"
+  alpha_source="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="alpha"][0]; print(a["agent_source"])' <<<"$out")"
+  alpha_provenance="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="alpha"][0]; print(a["source"])' <<<"$out")"
+  alpha_priv="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="alpha"][0]; print(a["privilege_class"])' <<<"$out")"
+  smoke_assert_eq "static" "$alpha_class" "T1 alpha class"
+  smoke_assert_eq "static" "$alpha_source" "T1 alpha agent_source"
+  smoke_assert_eq "static-roster" "$alpha_provenance" "T1 alpha provenance"
+  smoke_assert_eq "user" "$alpha_priv" "T1 alpha privilege_class"
+
+  # Field-level assertions for the dynamic row.
+  local delta_class delta_source delta_provenance delta_engine
+  delta_class="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="delta"][0]; print(a["class"])' <<<"$out")"
+  delta_source="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="delta"][0]; print(a["agent_source"])' <<<"$out")"
+  delta_provenance="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="delta"][0]; print(a["source"])' <<<"$out")"
+  delta_engine="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="delta"][0]; print(a["engine"])' <<<"$out")"
+  smoke_assert_eq "dynamic" "$delta_class" "T1 delta class"
+  smoke_assert_eq "dynamic" "$delta_source" "T1 delta agent_source"
+  smoke_assert_eq "dynamic-active-env" "$delta_provenance" "T1 delta provenance"
+  smoke_assert_eq "codex" "$delta_engine" "T1 delta engine"
+}
+
+# ---------------------------------------------------------------------------
+# T2 — system-class agent (cleanup-class system wins, raw fields preserved).
+# ---------------------------------------------------------------------------
+test_system_class_precedence() {
+  write_static_with_system
+  rm -rf "$BRIDGE_ACTIVE_AGENT_DIR"
+  mkdir -p "$BRIDGE_ACTIVE_AGENT_DIR"
+
+  local out
+  out="$(agent_registry_json)"
+  assert_valid_json "$out" "T2 valid JSON"
+
+  local patrol_class patrol_source patrol_priv
+  patrol_class="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="patrol"][0]; print(a["class"])' <<<"$out")"
+  patrol_source="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="patrol"][0]; print(a["agent_source"])' <<<"$out")"
+  patrol_priv="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); a=[r for r in d if r["id"]=="patrol"][0]; print(a["privilege_class"])' <<<"$out")"
+  smoke_assert_eq "system" "$patrol_class" "T2 system wins over static in cleanup class"
+  smoke_assert_eq "static" "$patrol_source" "T2 raw agent_source preserved"
+  smoke_assert_eq "system" "$patrol_priv" "T2 raw privilege_class preserved"
+}
+
+# ---------------------------------------------------------------------------
+# T3 — empty roster → `[]`.
+# ---------------------------------------------------------------------------
+test_empty_roster() {
+  write_empty_roster
+
+  local out
+  out="$(agent_registry_json)"
+  assert_valid_json "$out" "T3 valid JSON"
+
+  local count
+  count="$("$PY_BIN" -c 'import json,sys; print(len(json.loads(sys.stdin.read())))' <<<"$out")"
+  smoke_assert_eq "0" "$count" "T3 empty roster yields zero records"
+}
+
+# ---------------------------------------------------------------------------
+# T4 — stable sort across calls.
+# ---------------------------------------------------------------------------
+test_stable_sort() {
+  write_static_one
+  write_dynamic_active_env "delta" "codex"
+  write_dynamic_active_env "bravo" "claude"
+  write_dynamic_active_env "charlie" "claude"
+
+  local first second
+  first="$(agent_registry_json)"
+  second="$(agent_registry_json)"
+  if [[ "$first" != "$second" ]]; then
+    smoke_fail "T4 two consecutive calls produced different output"
+  fi
+
+  # Also confirm the order is alphabetical: alpha, bravo, charlie, delta.
+  local ids
+  ids="$("$PY_BIN" -c 'import json,sys; d=json.loads(sys.stdin.read()); print(",".join(r["id"] for r in d))' <<<"$first")"
+  smoke_assert_eq "alpha,bravo,charlie,delta" "$ids" "T4 ids sorted alphabetically"
+}
+
+# ---------------------------------------------------------------------------
+# T5 — output is well-formed JSON parseable by jq.
+# T1/T2/T3/T4 already call assert_valid_json on every payload, but T5
+# adds an explicit jq-only check (skipped when jq is absent) so the
+# fixture documents the contract distinctly.
+# ---------------------------------------------------------------------------
+test_jq_parseable() {
+  write_static_one
+
+  local out
+  out="$(agent_registry_json)"
+
+  if command -v jq >/dev/null 2>&1; then
+    local jq_count
+    jq_count="$(printf '%s' "$out" | jq 'length')"
+    smoke_assert_eq "1" "$jq_count" "T5 jq length matches expected"
+    local jq_id
+    jq_id="$(printf '%s' "$out" | jq -r '.[0].id')"
+    smoke_assert_eq "alpha" "$jq_id" "T5 jq selects expected id"
+  else
+    smoke_skip "T5 jq parse" "jq not installed on host"
+  fi
+}
+
+smoke_run "T1 static + dynamic mix"           test_static_plus_dynamic
+smoke_run "T2 system-class precedence"        test_system_class_precedence
+smoke_run "T3 empty roster"                   test_empty_roster
+smoke_run "T4 stable sort"                    test_stable_sort
+smoke_run "T5 jq parseable"                   test_jq_parseable
+
+smoke_log "all checks passed"

--- a/scripts/smoke/agent-registry.sh
+++ b/scripts/smoke/agent-registry.sh
@@ -251,10 +251,88 @@ test_jq_parseable() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# T6 — registry endpoint is read-only (Issue #598 Track 1 r2).
+#
+# Codex r1 review flagged that `agent registry --json` inherits 3
+# bridge_write_dynamic_agent_file calls from the recovery code in
+# lib/bridge-state.sh (the dynamic-history, tmux-recovered, and
+# history-restored paths). The fix: gate those persistence sites behind
+# BRIDGE_REGISTRY_READ_ONLY=1, exported by bridge-agent.sh before
+# bridge_load_roster runs when the subcommand is `registry`.
+#
+# The 3 gated writes only fire when there is a live tmux session that
+# matches a history entry — out of reach in a portable smoke fixture.
+# So this T6 uses the env-var-flag-passthrough variant from the brief:
+#   - Override bridge_write_dynamic_agent_file inside the roster-local
+#     file so any call records the value of BRIDGE_REGISTRY_READ_ONLY
+#     and the call count to a probe file.
+#   - The override also hooks into a synthetic call from the roster
+#     itself, which runs inside bridge_load_roster (the same call window
+#     where the gated recovery loaders run). This proves the flag is in
+#     scope at the persistence-site call boundary for `agent registry`,
+#     and is NOT in scope for `agent list`.
+# ---------------------------------------------------------------------------
+test_registry_read_only_flag_in_scope() {
+  local probe="$SMOKE_TMP_ROOT/registry-readonly-probe.log"
+  : >"$probe"
+  rm -rf "$BRIDGE_ACTIVE_AGENT_DIR"
+  mkdir -p "$BRIDGE_ACTIVE_AGENT_DIR"
+
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "alpha"
+BRIDGE_AGENT_ENGINE["alpha"]="claude"
+BRIDGE_AGENT_SESSION["alpha"]="alpha"
+BRIDGE_AGENT_WORKDIR["alpha"]="$BRIDGE_AGENT_HOME_ROOT/alpha"
+
+# Override bridge_write_dynamic_agent_file so any call during this
+# bridge_load_roster invocation records the BRIDGE_REGISTRY_READ_ONLY
+# value visible at that moment. Re-defining inside the roster file is
+# safe — lib/bridge-state.sh has already been sourced by the time
+# bridge_load_roster runs the local roster, so this override is the one
+# the recovery loaders see.
+bridge_write_dynamic_agent_file() {
+  printf 'flag=%s call=%s\n' "\${BRIDGE_REGISTRY_READ_ONLY:-unset}" "\$1" >>"$probe"
+  return 0
+}
+
+# Synthetic call inside the roster-load window. This stands in for the
+# 3 recovery-path call sites (1013, 1088, 1165) that, in production,
+# are reached via live tmux + history files we cannot reproduce in a
+# smoke fixture. The flag must be visible here for the real gates to fire.
+bridge_write_dynamic_agent_file "synthetic" "$BRIDGE_ACTIVE_AGENT_DIR/synthetic.env"
+EOF
+
+  # Run via `agent registry --json` — flag MUST be set during roster load.
+  agent_registry_json >/dev/null
+  smoke_assert_file_exists "$probe" "T6 probe captured registry roster load"
+
+  local registry_line
+  registry_line="$(grep '^flag=' "$probe" | head -n 1)"
+  if [[ "$registry_line" != *"flag=1"* ]]; then
+    smoke_fail "T6 registry call did not export BRIDGE_REGISTRY_READ_ONLY=1; probe line: $registry_line"
+  fi
+
+  # Reset probe and run via `agent list` — flag MUST NOT be set, so the
+  # other callers continue persisting as today.
+  : >"$probe"
+  "$BASH4_BIN" "$REPO_ROOT/bridge-agent.sh" list --json >/dev/null
+
+  local list_line
+  list_line="$(grep '^flag=' "$probe" | head -n 1)"
+  if [[ "$list_line" == *"flag=1"* ]]; then
+    smoke_fail "T6 'agent list' leaked BRIDGE_REGISTRY_READ_ONLY=1; probe line: $list_line"
+  fi
+  if [[ "$list_line" != *"flag=unset"* && "$list_line" != *"flag=0"* ]]; then
+    smoke_fail "T6 'agent list' probe missing or unexpected; probe line: $list_line"
+  fi
+}
+
 smoke_run "T1 static + dynamic mix"           test_static_plus_dynamic
 smoke_run "T2 system-class precedence"        test_system_class_precedence
 smoke_run "T3 empty roster"                   test_empty_roster
 smoke_run "T4 stable sort"                    test_stable_sort
 smoke_run "T5 jq parseable"                   test_jq_parseable
+smoke_run "T6 registry read-only flag"        test_registry_read_only_flag_in_scope
 
 smoke_log "all checks passed"


### PR DESCRIPTION
## Summary

Track 1 of issue #598. Adds `agent registry --json` as a sibling to `agent list` — the load-bearing read-side endpoint that enumerates every agent id known on this host (static + dynamic + system) with provenance and class together. Tracks 2 (doctor `orphan-agent-dir` detector) and 3 (`agent retire` primitive) depend on this; Track 4 (test-prefix `agent create` refusal) ships in parallel.

The cross-host evidence in the issue body is the motivation: a Mac mini install accumulated a generic-skeleton orphan (`shopicode`) while a MacBook Pro install false-positived 3 of 5 "orphan candidates" because the static-roster-only rule had no way to recognise live dynamic agents (`agb-dev-claude`, `crm-dev`, `crm-test`). This endpoint fixes the gap by giving cleanup tools a single source of truth that subtracts the live dynamic-agent set before flagging anything.

### What changed

- **`bridge-agent.sh`**: new `run_registry` function and dispatcher case. Output schema:
  | field | meaning |
  | --- | --- |
  | `id` | agent name |
  | `class` | cleanup-class: `system` > `dynamic` > `static` (system wins so cleanup tools never reap a privileged static agent purely on `source=static`) |
  | `agent_source` | raw `bridge_agent_source`: `static\|dynamic` |
  | `privilege_class` | raw `bridge_agent_class`: `user\|system` |
  | `home`, `workdir`, `engine`, `session` | usual getters |
  | `is_alive` | tmux session exists |
  | `source` | provenance: `static-roster\|dynamic-active-env\|dynamic-history-live-session\|dynamic-tmux-recovered` |

  Output is sorted by `id` for stable diffs. No caching (per spec — fresh enumeration on each call).

- **`lib/bridge-state.sh`**: 4 loader sites now stamp `BRIDGE_AGENT_PROVENANCE`:
  - `bridge_load_dynamic_agent_file` → `dynamic-active-env`
  - `bridge_restore_dynamic_agents_from_history` → `dynamic-history-live-session`
  - `bridge_reconcile_dynamic_agents_from_tmux` (both pane-derived branch and `_bridge_register_dynamic_from_env_file` helper) → `dynamic-tmux-recovered`
  - `bridge_load_roster` static-default loop → `static-roster`

- **`lib/bridge-core.sh`**: declares `BRIDGE_AGENT_PROVENANCE` associative array and unsets it in `bridge_reset_roster_maps`.

- **`lib/bridge-agents.sh`**: new `bridge_agent_provenance` getter that defaults to `static-roster` when the loader did not tag the agent (matches historical implicit behavior).

- **`agent-bridge`**: usage banner enumerates the new subcommand. The dispatcher `agent)` case already passes through to `bridge-agent.sh` so no routing change is needed.

- **`scripts/smoke/agent-registry.sh`**: standalone smoke (T1-T5). Not registered in `scripts/smoke-test.sh` yet — Track 2's detector smoke will register both fixtures together.

- **`OPERATIONS.md`**: one-paragraph note in "Status And Debugging" pointing tooling that needs class + provenance together at the new endpoint and explaining why naive `agent list`-only cleanup historically false-positived dynamic agents.

### Out of scope

- Doctor `orphan-agent-dir` detector — Track 2.
- `agent retire` primitive — Track 3.
- `agent create` test-prefix refusal — Track 4 (in parallel).
- No caching (per spec).
- No changes to `agent list` output (sibling, not replacement).
- No `VERSION` / `CHANGELOG` bump.

## Test plan

- [x] `/opt/homebrew/bin/bash -n` on every touched .sh file
- [x] `shellcheck` on every touched .sh file (clean)
- [x] `bash scripts/smoke/agent-registry.sh` passes T1-T5:
  - T1 static + dynamic-active-env mix → both rows surface with correct `class` and `source`
  - T2 system-class agent → `class=system` while `agent_source=static` and `privilege_class=system` are preserved
  - T3 empty roster → `[]`
  - T4 stable sort across two consecutive calls (identical output)
  - T5 jq-parseable JSON
- [x] `./scripts/smoke-test.sh` reproduces only the pre-existing `[smoke] creating queue task` failure that exists on `main` without any edits (confirmed by checkout-and-rerun while my changes were stashed).

## Reviewer notes

- This is one of 4 parallel tracks for #598. Track 4 is running in parallel and may also touch `bridge-agent.sh` and `agent-bridge` (different functions / sections); the second-merging branch will rebase if needed.
- The new endpoint is intentionally read-only and stateless — no audit row, no mutations. Cleanup mutations are Track 2/3's job and they will reuse this enumeration.
- I considered extending `agent list --include dynamic` instead but chose the sibling endpoint per codex spec Part A: keeps `agent list`'s human/JSON shape stable for existing tooling, makes the new schema (with `provenance` + `cleanup-class`) discoverable as its own contract.

refs #598