### PR TITLE
feat(agent): refuse test-artifact names without --test-fixture (Track 4 of #598)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -395,6 +395,36 @@ mkdir -p ~/.agent-bridge/state ~/.agent-bridge/logs ~/.agent-bridge/shared
 Do not delete `agent-roster.local.sh` unless you intentionally want to remove
 local static roles.
 
+### Test-artifact name policy (issue #598 Track 4)
+
+Agent names matching test-artifact patterns are refused at create time and
+on dynamic spawn unless the operator explicitly opts in with
+`--test-fixture`. The blocked patterns are:
+
+- prefix `smoke-`
+- prefix `test-`
+- prefix `bootstrap-`
+- prefix `created-agent-`
+- prefix `pref-`
+- suffix `-repro-<N>` (digits)
+
+```bash
+# refused (no flag, looks like a leftover smoke fixture)
+agent-bridge agent create smoke-foo
+
+# accepted (explicit opt-in; cleanup tooling may reap this agent)
+agent-bridge agent create smoke-foo --test-fixture
+
+# same policy on dynamic spawn
+agent-bridge --codex --name smoke-x --test-fixture
+```
+
+When `--test-fixture` is used, an `agent_test_fixture_created` audit row
+records the opt-in so cleanup tooling can identify which agents were
+created intentionally as test fixtures. Existing agents already in the
+roster are grandfathered — the policy only fires at the create / new-spawn
+entry point.
+
 ## Platform Scope
 
 Agent Bridge runs on both macOS and Linux, but the two hosts have

--- a/agent-bridge
+++ b/agent-bridge
@@ -161,7 +161,7 @@ Usage:
   $CLI_NAME migrate workspace plan <agent>
   $CLI_NAME migrate workspace copy <agent> [--dry-run]
   $CLI_NAME migrate workspace cutover <agent> --dry-run
-  $CLI_NAME --codex|--claude --name <agent> [--loop] [--no-continue] [--workdir <dir>] [--replace] [--no-attach] [--no-project-skill] [--prefer wake|new|shared]
+  $CLI_NAME --codex|--claude --name <agent> [--loop] [--no-continue] [--workdir <dir>] [--replace] [--no-attach] [--no-project-skill] [--prefer wake|new|shared] [--test-fixture]
 
 Examples:
   $CLI_NAME status
@@ -796,6 +796,8 @@ ATTACH_MODE=1
 REPLACE_MODE=0
 INSTALL_PROJECT_SKILL=1
 SPAWN_PREFERENCE=""
+# Issue #598 Track 4: opt-in for test-artifact name patterns.
+TEST_FIXTURE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -849,6 +851,11 @@ while [[ $# -gt 0 ]]; do
       SPAWN_PREFERENCE="$2"
       shift 2
       ;;
+    --test-fixture)
+      # Issue #598 Track 4: opt into test-artifact-prefix policy.
+      TEST_FIXTURE=1
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -889,6 +896,28 @@ if ! bridge_agent_exists "$NAME"; then
   if RESOLVED_AGENT="$(bridge_agent_id_for_session "$NAME")"; then
     echo "[info] 세션 '$NAME'은(는) 역할 '$RESOLVED_AGENT'에 연결됩니다."
     NAME="$RESOLVED_AGENT"
+  fi
+fi
+
+# Issue #598 Track 4: refuse names that match a test-artifact pattern
+# (smoke-, test-, bootstrap-, created-agent-, pref-, *-repro-<N>) on
+# truly-new dynamic spawns unless the operator opted in with
+# --test-fixture. Existing static/dynamic agents are grandfathered:
+# the check only fires when the name does not already resolve to a
+# known agent. Cleanup tooling (Track 2 orphan-agent-dir detector)
+# treats test-fixture agents as reapable.
+if ! bridge_agent_exists "$NAME"; then
+  if bridge_validate_agent_name_test_artifact "$NAME"; then
+    if [[ $TEST_FIXTURE -eq 0 ]]; then
+      bridge_die "agent-bridge --name '$NAME' refused: name matches test-artifact pattern.
+Use \`--test-fixture\` if this is intentional test setup; cleanup tooling may
+report and reap test-fixture agents per their pattern."
+    else
+      bridge_audit_log agent agent_test_fixture_created "$NAME" \
+        --detail reason=test-fixture-flag \
+        --detail entrypoint=spawn \
+        2>/dev/null || true
+    fi
   fi
 fi
 

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -69,6 +69,9 @@ Options:
   --continue|--no-continue     explicit continue mode (default: continue)
   --dry-run                    print the planned role block without writing
   --json                       emit JSON instead of human text
+  --test-fixture               opt into test-artifact name patterns
+                               (smoke-/test-/bootstrap-/created-agent-/pref-,
+                               *-repro-<N>); cleanup tooling may reap these
 
 Examples:
   $(basename "$0") create reviewer --engine claude
@@ -1741,6 +1744,8 @@ run_create() {
   local users_json=""
   local default_home=""
   local start_dry_run=""
+  # Issue #598 Track 4: opt-in for test-artifact-prefix names.
+  local test_fixture=0
 
   shift || true
 
@@ -1884,11 +1889,36 @@ run_create() {
         json_mode=1
         shift
         ;;
+      --test-fixture)
+        # Issue #598 Track 4: opt into test-artifact-prefix policy.
+        test_fixture=1
+        shift
+        ;;
       *)
         bridge_die "지원하지 않는 agent create 옵션입니다: $1"
         ;;
     esac
   done
+
+  # Issue #598 Track 4: refuse names that match a test-artifact pattern
+  # (smoke-, test-, bootstrap-, created-agent-, pref-, *-repro-<N>) unless
+  # the operator opted in with --test-fixture. Cleanup tooling (Track 2
+  # orphan-agent-dir detector) treats these as test fixtures and may
+  # report/reap them.
+  if bridge_validate_agent_name_test_artifact "$agent"; then
+    if [[ $test_fixture -eq 0 ]]; then
+      bridge_die "agent-bridge agent create '$agent' refused: name matches test-artifact pattern.
+Use \`--test-fixture\` if this is intentional test setup; cleanup tooling may
+report and reap test-fixture agents per their pattern."
+    else
+      # Audit row so operators (and the future orphan-agent-dir detector)
+      # can identify which test-fixture agents to reap.
+      bridge_audit_log agent agent_test_fixture_created "$agent" \
+        --detail reason=test-fixture-flag \
+        --detail entrypoint=create \
+        2>/dev/null || true
+    fi
+  fi
 
   case "$engine" in
     claude|codex) ;;

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -648,6 +648,39 @@ bridge_validate_agent_name() {
   return 0
 }
 
+# Issue #598 Track 4: test-artifact name patterns. Cleanup detectors and
+# operator hygiene depend on this list staying canonical between `agent
+# create` / dynamic-spawn refusal and the future `orphan-agent-dir`
+# detector (Track 2). Keep BRIDGE_TEST_ARTIFACT_PREFIXES + the trailing
+# `-repro-<digits>` regex in lockstep with `bridge-doctor.py` if/when
+# Track 2 lands.
+BRIDGE_TEST_ARTIFACT_PREFIXES=(
+  "smoke-"
+  "test-"
+  "bootstrap-"
+  "created-agent-"
+  "pref-"
+)
+
+# bridge_validate_agent_name_test_artifact <name>
+#   Returns 0 when the name matches a known test-artifact pattern (a
+#   leading prefix from BRIDGE_TEST_ARTIFACT_PREFIXES OR a trailing
+#   `-repro-<digits>` suffix). Returns 1 otherwise. Callers use this to
+#   refuse `create` / dynamic-spawn unless `--test-fixture` is passed.
+bridge_validate_agent_name_test_artifact() {
+  local name="$1"
+  local prefix
+  for prefix in "${BRIDGE_TEST_ARTIFACT_PREFIXES[@]}"; do
+    if [[ "$name" == "$prefix"* ]]; then
+      return 0
+    fi
+  done
+  if [[ "$name" =~ -repro-[0-9]+$ ]]; then
+    return 0
+  fi
+  return 1
+}
+
 bridge_join_quoted() {
   local out=""
   local arg

--- a/scripts/smoke/agent-name-validation.sh
+++ b/scripts/smoke/agent-name-validation.sh
@@ -146,10 +146,15 @@ resolve_bash4() {
 }
 
 assert_helper_plumbing() {
-  # Source the helper directly to verify the prefix/suffix matcher is
-  # canonical and that the spawn-side --test-fixture flag plumbs into
-  # TEST_FIXTURE=1 without invoking tmux. This is the boundary this
-  # fixture owns; driving the full spawn path would require live tmux.
+  # Two-part assertion (codex r1 of #604 caught the original T8 only
+  # exercising the helper directly):
+  #   1. Helper-level: positive + negative prefix coverage via direct
+  #      sourcing of lib/bridge-core.sh.
+  #   2. End-to-end: drive `agent-bridge --codex --name smoke-x
+  #      --test-fixture --no-attach` so the dynamic-spawn entrypoint's
+  #      policy check passes and the audit row lands. The --no-attach
+  #      flag stops short of an interactive tmux attach, but the policy
+  #      check + audit emission run before the tmux step regardless.
   local bash4
   if ! bash4="$(resolve_bash4)"; then
     smoke_skip "helper plumbing" "no Bash 4+ binary on PATH (lib/bridge-core.sh uses declare -g)"
@@ -187,13 +192,32 @@ HELPER
     smoke_fail "helper plumbing: $out"
   smoke_assert_contains "$out" "OK" "helper matcher canonical (positive + negative)"
 
-  # Argparse plumbing: scan the agent-bridge entry point to confirm
-  # --test-fixture is wired (cheap textual contract — keeps T8 honest
-  # without booting tmux).
-  smoke_assert_contains \
-    "$(cat "$SMOKE_REPO_ROOT/agent-bridge")" \
-    "TEST_FIXTURE=1" \
-    "agent-bridge wires --test-fixture into TEST_FIXTURE=1"
+  # End-to-end spawn-with-fixture: drive the actual `agent-bridge` entry
+  # point so we exercise the same argparse + policy + audit path the
+  # operator hits. We don't assert an exit code — downstream tmux setup
+  # is allowed to fail in a smoke environment without a live tmux server
+  # — but we DO assert that:
+  #   (a) the test-artifact-pattern refusal NEVER appears (proving the
+  #       policy passed), and
+  #   (b) the audit log records `agent_test_fixture_created` with
+  #       entrypoint=spawn.
+  reset_runtime
+  local spawn_out
+  spawn_out="$(run_agent_bridge --codex --name smoke-x --test-fixture --no-attach 2>&1)" || true
+  smoke_assert_not_contains "$spawn_out" "test-artifact pattern" \
+    "spawn smoke-x --test-fixture: policy did NOT refuse"
+  smoke_assert_file_exists "$BRIDGE_AUDIT_LOG" \
+    "spawn --test-fixture: audit log file exists"
+  local spawn_audit
+  spawn_audit="$(cat "$BRIDGE_AUDIT_LOG")"
+  smoke_assert_contains "$spawn_audit" "agent_test_fixture_created" \
+    "spawn --test-fixture writes agent_test_fixture_created audit row"
+  smoke_assert_contains "$spawn_audit" "smoke-x" \
+    "spawn audit row carries the agent name"
+  smoke_assert_contains "$spawn_audit" "test-fixture-flag" \
+    "spawn audit row carries reason=test-fixture-flag"
+  smoke_assert_contains "$spawn_audit" "spawn" \
+    "spawn audit row carries entrypoint=spawn"
 }
 
 main() {

--- a/scripts/smoke/agent-name-validation.sh
+++ b/scripts/smoke/agent-name-validation.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# scripts/smoke/agent-name-validation.sh — Issue #598 Track 4 smoke.
+#
+# Validates the test-artifact name policy: `agent create` and dynamic
+# `agent-bridge --name <agent>` refuse names matching a test-artifact
+# pattern (smoke-/test-/bootstrap-/created-agent-/pref- prefix or a
+# trailing -repro-<N>) unless the operator opts in with --test-fixture.
+# When the flag is used, an `agent_test_fixture_created` audit row is
+# written so cleanup tooling can identify reapable test fixtures.
+#
+# Eight assertions:
+# T1: `agent create smoke-foo` (no flag) — refused, no scaffold
+# T2: `agent create smoke-foo --test-fixture --dry-run` — succeeds, audit
+#     row recorded
+# T3: `agent create test-bar` (no flag) — refused
+# T4: `agent create created-agent-baz` (no flag) — refused
+# T5: `agent create my-agent-repro-42` (no flag) — refused
+# T6: `agent create my-agent --dry-run` (no flag) — succeeds (not a test
+#     pattern; positive control)
+# T7: `agent-bridge --codex --name smoke-x` (no flag) — refused
+# T8: helper-level: with --test-fixture, the policy passes and the flag
+#     plumbing lands TEST_FIXTURE=1 (driving the spawn path end-to-end
+#     would require live tmux; the helper + plumbing are the boundary
+#     this fixture owns).
+
+set -euo pipefail
+
+SMOKE_NAME="agent-name-validation"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+run_create() {
+  # Capture stdout+stderr together; never let a non-zero exit kill the
+  # test before we assert on the captured text.
+  bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
+}
+
+run_agent_bridge() {
+  bash "$SMOKE_REPO_ROOT/agent-bridge" "$@" 2>&1 || true
+}
+
+assert_no_scaffold() {
+  local label="$1"
+  local bad_name="$2"
+  smoke_assert_eq "" "$(ls "$BRIDGE_AGENT_HOME_ROOT" 2>/dev/null || true)" \
+    "$label: agents/ root stays empty (no '$bad_name' dir scaffolded)"
+  if [[ -s "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
+    smoke_assert_not_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" \
+      "MANAGED ROLE: $bad_name" \
+      "$label: local roster has no MANAGED ROLE block for '$bad_name'"
+  fi
+}
+
+reset_runtime() {
+  rm -rf "$BRIDGE_AGENT_HOME_ROOT"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT"
+  : >"$BRIDGE_ROSTER_LOCAL_FILE"
+  : >"$BRIDGE_AUDIT_LOG"
+}
+
+assert_refused_create() {
+  local name="$1"
+  reset_runtime
+  local out
+  out="$(run_create "$name")"
+  smoke_assert_contains "$out" "test-artifact pattern" \
+    "create $name refused with test-artifact-pattern message"
+  smoke_assert_contains "$out" "--test-fixture" \
+    "create $name refusal hints at --test-fixture opt-in"
+  assert_no_scaffold "create $name" "$name"
+}
+
+assert_test_fixture_create() {
+  reset_runtime
+  local out
+  out="$(run_create smoke-foo --engine claude --test-fixture --dry-run)"
+  smoke_assert_contains "$out" "agent: smoke-foo" \
+    "create smoke-foo --test-fixture --dry-run accepted"
+  smoke_assert_contains "$out" "dry_run: yes" \
+    "create smoke-foo --test-fixture --dry-run flags itself as a plan"
+  # Audit row lands even on --dry-run (the policy/audit step runs before
+  # the dry-run gating, so cleanup tooling can see the opt-in regardless
+  # of whether the role was actually written).
+  smoke_assert_file_exists "$BRIDGE_AUDIT_LOG" \
+    "create --test-fixture: audit log file exists"
+  local audit_text
+  audit_text="$(cat "$BRIDGE_AUDIT_LOG")"
+  smoke_assert_contains "$audit_text" "agent_test_fixture_created" \
+    "create --test-fixture writes agent_test_fixture_created audit row"
+  smoke_assert_contains "$audit_text" "smoke-foo" \
+    "audit row carries the agent name"
+  smoke_assert_contains "$audit_text" "test-fixture-flag" \
+    "audit row carries reason=test-fixture-flag"
+  smoke_assert_contains "$audit_text" "create" \
+    "audit row carries entrypoint=create"
+}
+
+assert_positive_control_dry_run() {
+  reset_runtime
+  local out
+  out="$(run_create my-agent --engine claude --dry-run)"
+  smoke_assert_contains "$out" "agent: my-agent" \
+    "create my-agent --dry-run accepted (not a test pattern)"
+  smoke_assert_contains "$out" "dry_run: yes" \
+    "create my-agent --dry-run flags itself as a plan"
+  # No audit row from the test-fixture path on a non-matching name.
+  if [[ -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_assert_not_contains "$(cat "$BRIDGE_AUDIT_LOG")" \
+      "agent_test_fixture_created" \
+      "non-test-pattern create does not emit agent_test_fixture_created"
+  fi
+}
+
+assert_refused_spawn() {
+  reset_runtime
+  local out
+  # `--no-attach` keeps us out of an interactive tmux attach if the
+  # validation were to ever pass; the test-artifact policy fails the
+  # call long before the tmux step.
+  out="$(run_agent_bridge --codex --name smoke-x --no-attach)"
+  smoke_assert_contains "$out" "test-artifact pattern" \
+    "spawn smoke-x refused with test-artifact-pattern message"
+  smoke_assert_contains "$out" "--test-fixture" \
+    "spawn smoke-x refusal hints at --test-fixture opt-in"
+}
+
+resolve_bash4() {
+  # Mirror the bridge-lib.sh re-exec list: pick a Bash 4+ binary so the
+  # `declare -g` in lib/bridge-core.sh works when we source it for the
+  # helper-level assertions.
+  local cand
+  for cand in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+    [[ -n "$cand" && -x "$cand" ]] || continue
+    if "$cand" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      printf '%s\n' "$cand"
+      return 0
+    fi
+  done
+  return 1
+}
+
+assert_helper_plumbing() {
+  # Source the helper directly to verify the prefix/suffix matcher is
+  # canonical and that the spawn-side --test-fixture flag plumbs into
+  # TEST_FIXTURE=1 without invoking tmux. This is the boundary this
+  # fixture owns; driving the full spawn path would require live tmux.
+  local bash4
+  if ! bash4="$(resolve_bash4)"; then
+    smoke_skip "helper plumbing" "no Bash 4+ binary on PATH (lib/bridge-core.sh uses declare -g)"
+    return 0
+  fi
+
+  local helper_script
+  helper_script="$SMOKE_TMP_ROOT/helper-check.sh"
+  cat >"$helper_script" <<'HELPER'
+#!/usr/bin/env bash
+set -euo pipefail
+SMOKE_REPO_ROOT="$1"
+# shellcheck source=lib/bridge-core.sh
+source "$SMOKE_REPO_ROOT/lib/bridge-core.sh"
+
+for name in smoke-foo test-bar bootstrap-x created-agent-y pref-z my-agent-repro-42; do
+  if ! bridge_validate_agent_name_test_artifact "$name"; then
+    printf 'FAIL: expected %s to match test-artifact pattern\n' "$name" >&2
+    exit 1
+  fi
+done
+
+for name in my-agent reviewer codex-main agent-prefix repro-without-suffix; do
+  if bridge_validate_agent_name_test_artifact "$name"; then
+    printf 'FAIL: expected %s NOT to match test-artifact pattern\n' "$name" >&2
+    exit 1
+  fi
+done
+
+printf 'OK\n'
+HELPER
+
+  local out
+  out="$("$bash4" "$helper_script" "$SMOKE_REPO_ROOT" 2>&1)" || \
+    smoke_fail "helper plumbing: $out"
+  smoke_assert_contains "$out" "OK" "helper matcher canonical (positive + negative)"
+
+  # Argparse plumbing: scan the agent-bridge entry point to confirm
+  # --test-fixture is wired (cheap textual contract — keeps T8 honest
+  # without booting tmux).
+  smoke_assert_contains \
+    "$(cat "$SMOKE_REPO_ROOT/agent-bridge")" \
+    "TEST_FIXTURE=1" \
+    "agent-bridge wires --test-fixture into TEST_FIXTURE=1"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  smoke_run "T1: create smoke-foo refused"            assert_refused_create smoke-foo
+  smoke_run "T2: create smoke-foo --test-fixture ok"  assert_test_fixture_create
+  smoke_run "T3: create test-bar refused"             assert_refused_create test-bar
+  smoke_run "T4: create created-agent-baz refused"    assert_refused_create created-agent-baz
+  smoke_run "T5: create my-agent-repro-42 refused"    assert_refused_create my-agent-repro-42
+  smoke_run "T6: create my-agent (positive control)"  assert_positive_control_dry_run
+  smoke_run "T7: spawn smoke-x refused"               assert_refused_spawn
+  smoke_run "T8: --test-fixture helper + plumbing"    assert_helper_plumbing
+
+  smoke_log "PASS"
+}
+
+main "$@"

--- a/scripts/smoke/agent-name-validation.sh
+++ b/scripts/smoke/agent-name-validation.sh
@@ -97,8 +97,8 @@ assert_test_fixture_create() {
     "audit row carries the agent name"
   smoke_assert_contains "$audit_text" "test-fixture-flag" \
     "audit row carries reason=test-fixture-flag"
-  smoke_assert_contains "$audit_text" "create" \
-    "audit row carries entrypoint=create"
+  smoke_assert_contains "$audit_text" '"entrypoint": "create"' \
+    "audit row carries entrypoint=create (JSON detail field)"
 }
 
 assert_positive_control_dry_run() {
@@ -216,8 +216,8 @@ HELPER
     "spawn audit row carries the agent name"
   smoke_assert_contains "$spawn_audit" "test-fixture-flag" \
     "spawn audit row carries reason=test-fixture-flag"
-  smoke_assert_contains "$spawn_audit" "spawn" \
-    "spawn audit row carries entrypoint=spawn"
+  smoke_assert_contains "$spawn_audit" '"entrypoint": "spawn"' \
+    "spawn audit row carries entrypoint=spawn (JSON detail field)"
 }
 
 main() {


### PR DESCRIPTION
## Summary

Track 4 of issue #598 (runtime housekeeping): refuse names matching well-known test-artifact patterns at the `agent create` and dynamic `agent-bridge --name <agent>` entry points unless the operator explicitly opts in with `--test-fixture`. Stops the slow accumulation of leaked smoke / bootstrap / repro agent homes that issue #598 catalogued, without breaking existing roster-loaded agents (grandfathered: the policy only fires on truly-new names).

## What changed

- `lib/bridge-core.sh` — adds canonical `BRIDGE_TEST_ARTIFACT_PREFIXES` array and `bridge_validate_agent_name_test_artifact` helper. Track 2's future orphan-agent-dir detector can consume the same constants.
- `bridge-agent.sh` — `agent create` now honors `--test-fixture` and refuses test-pattern names without it. When the flag is used, an `agent_test_fixture_created` audit row is emitted (`reason=test-fixture-flag`, `entrypoint=create`).
- `agent-bridge` — dynamic spawn (`--name <agent>`) gains the same `--test-fixture` flag and policy, gated behind `bridge_agent_exists` so existing static/dynamic agents are grandfathered.
- `OPERATIONS.md` — brief operator-facing note on the policy + opt-in flag.
- `scripts/smoke/agent-name-validation.sh` — new standalone fixture covering T1-T8.

## Patterns blocked

`smoke-`, `test-`, `bootstrap-`, `created-agent-`, `pref-` (prefix), or trailing `-repro-<N>` (digits).

## Out of scope (per Track 4 brief)

- Tracks 1/2/3 (registry exposure, orphan-agent-dir detector, retire primitive)
- Roster-loaded agents are NOT re-validated (grandfathered)
- No VERSION/CHANGELOG bump

## Test plan

- [x] `bash -n` clean on `bridge-agent.sh`, `agent-bridge`, `lib/bridge-core.sh`, `scripts/smoke/agent-name-validation.sh`
- [x] `shellcheck` clean on the same set
- [x] New smoke `bash scripts/smoke/agent-name-validation.sh` — 8/8 PASS (T1 refused / T2 audit row / T3-T5 refused / T6 positive control / T7 spawn refused / T8 helper + plumbing)
- [x] Existing `scripts/smoke/agent-create-name-validation.sh` — 7/7 PASS (the new policy runs after the existing validator, only triggers on the test-pattern subset)
- [ ] Live operator: confirm `agb agent create smoke-x` is refused on a real install; confirm `--test-fixture` produces an `agent_test_fixture_created` row in `~/.agent-bridge/logs/audit.jsonl`

## Notes for reviewer

- Audit row write uses the `--detail key=value` form per `bridge-audit.py` parser; `2>/dev/null || true` so an audit failure cannot block the create/spawn path.
- The dynamic-spawn check is wrapped in `if ! bridge_agent_exists "$NAME"` so waking an existing static/dynamic agent that happens to have a test-pattern name (grandfathered) is unaffected.
- `scripts/smoke-test.sh` has a pre-existing failure on `main` at the `expected output to contain: smoke-agent-<PID>` assertion (verified by stashing this branch's changes and re-running — same error). That failure is unrelated to Track 4 and predates this branch.

refs #598

Generated with Claude Opus 4.7 (1M context).