### PR TITLE
feat(doctor): orphan-agent-dir detector (Track 2 of #598)

### DIFF
--- a/bridge-doctor.py
+++ b/bridge-doctor.py
@@ -14,6 +14,10 @@ Detectors:
 - abnormal-session-pane    : tmux pane scrollback matches login/trust/blocker UI patterns
                              (placeholder — emits detector-error until pattern reuse from
                              bridge-stall.py is factored cleanly; see PR notes)
+- daemon-log-split         : BRIDGE_DAEMON_LOG frozen while launchagent.log is active (#590)
+- orphan-agent-dir         : directories under $BRIDGE_AGENT_HOME_ROOT that are not in
+                             `agent registry --json` (#598 Track 2). Report-only;
+                             emits a manual quarantine recipe in suggested_action.
 
 Read-only contract: the CLI never mutates queue/state/tmux. `suggested_action`
 is a string the admin agent LLM parses and decides whether to execute.
@@ -42,7 +46,27 @@ DETECTOR_KINDS = (
     "cold-restart-suspect",
     "abnormal-session-pane",
     "daemon-log-split",
+    "orphan-agent-dir",
 )
+
+
+# Issue #598 Track 2: directories under $BRIDGE_AGENT_HOME_ROOT whose
+# basename starts with one of these prefixes (or ends with `-repro-<digits>`)
+# are flagged `is_test_artifact: true` so the operator can triage in one
+# pass. Mirrors lib/bridge-core.sh:BRIDGE_TEST_ARTIFACT_PREFIXES (Track 4)
+# — keep the two lists in lockstep.
+ORPHAN_TEST_ARTIFACT_PREFIXES = (
+    "smoke-",
+    "test-",
+    "bootstrap-",
+    "created-agent-",
+    "pref-",
+)
+ORPHAN_TEST_ARTIFACT_REPRO_REGEX = re.compile(r"-repro-\d+$")
+
+# Directory basenames under $BRIDGE_AGENT_HOME_ROOT that are bridge-managed
+# infrastructure rather than per-agent homes; the detector skips them.
+ORPHAN_SKIP_NAMES = frozenset({"_template", "shared"})
 
 
 def iso_now() -> str:
@@ -62,6 +86,24 @@ def resolve_state_dir(arg_value: str | None) -> Path:
     home = os.environ.get("BRIDGE_HOME", "").strip()
     base = Path(home).expanduser() if home else (Path.home() / ".agent-bridge")
     return base / "state"
+
+
+def resolve_agent_home_root(arg_value: str | None) -> Path:
+    """Resolve `BRIDGE_AGENT_HOME_ROOT` for the orphan-agent-dir detector.
+
+    Mirrors `lib/bridge-agents.sh`: arg > $BRIDGE_AGENT_HOME_ROOT >
+    $BRIDGE_HOME/agents > ~/.agent-bridge/agents. Does not require the
+    directory to exist; the detector itself handles the missing-dir case
+    (graceful skip, no findings).
+    """
+    if arg_value:
+        return Path(arg_value).expanduser()
+    explicit = os.environ.get("BRIDGE_AGENT_HOME_ROOT", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    home = os.environ.get("BRIDGE_HOME", "").strip()
+    base = Path(home).expanduser() if home else (Path.home() / ".agent-bridge")
+    return base / "agents"
 
 
 def resolve_task_db(arg_value: str | None, state_dir: Path) -> Path:
@@ -133,6 +175,63 @@ def load_agent_list(args: argparse.Namespace) -> list[dict[str, Any]]:
         raise SystemExit(f"agent-bridge agent list --json: invalid JSON ({exc})") from exc
     if not isinstance(data, list):
         raise SystemExit("agent-bridge agent list --json: expected JSON array")
+    return data
+
+
+def load_agent_registry(args: argparse.Namespace) -> list[dict[str, Any]]:
+    """Load the agent registry snapshot via `agent-bridge agent registry --json`.
+
+    Issue #598 Track 1 (PR #603) added the registry endpoint that exposes
+    static + dynamic + system ids together with provenance. The orphan
+    detector subtracts this set from the `BRIDGE_AGENT_HOME_ROOT` listing to
+    decide what is unowned.
+
+    Tests inject `--agent-registry-json <file>` to skip the subprocess.
+    """
+    if args.agent_registry_json:
+        path = Path(args.agent_registry_json).expanduser()
+        if not path.is_file():
+            raise SystemExit(f"--agent-registry-json file not found: {path}")
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if not isinstance(data, list):
+            raise SystemExit("--agent-registry-json must contain a JSON array")
+        return data
+
+    binary = args.agent_bridge or os.environ.get("BRIDGE_AGENT_BRIDGE_BIN", "").strip()
+    if not binary:
+        sibling = Path(__file__).resolve().parent / "agent-bridge"
+        if sibling.is_file():
+            binary = str(sibling)
+        else:
+            located = shutil.which("agent-bridge")
+            if not located:
+                raise SystemExit(
+                    "agent-bridge binary not found; pass --agent-bridge or "
+                    "--agent-registry-json"
+                )
+            binary = located
+
+    try:
+        proc = subprocess.run(
+            [binary, "agent", "registry", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        raise SystemExit(
+            f"agent-bridge agent registry --json failed (rc={exc.returncode}): "
+            f"{(exc.stderr or '').strip()}"
+        ) from exc
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(
+            f"agent-bridge agent registry --json: invalid JSON ({exc})"
+        ) from exc
+    if not isinstance(data, list):
+        raise SystemExit("agent-bridge agent registry --json: expected JSON array")
     return data
 
 
@@ -564,6 +663,205 @@ def detect_daemon_log_split(
     return findings
 
 
+def _is_test_artifact_name(name: str) -> bool:
+    for prefix in ORPHAN_TEST_ARTIFACT_PREFIXES:
+        if name.startswith(prefix):
+            return True
+    return bool(ORPHAN_TEST_ARTIFACT_REPRO_REGEX.search(name))
+
+
+def _best_effort_dir_size(path: Path) -> int | None:
+    """Walk `path` and sum file sizes. Returns None if the walk cannot start.
+
+    Best-effort: errors on individual entries (permission denied on a single
+    subdir) are swallowed so the detector still reports the orphan rather
+    than crashing. A None return signals the operator that size_bytes could
+    not be computed at all (top-level directory is unreadable).
+    """
+    total = 0
+    try:
+        iterator = os.walk(path, onerror=lambda _e: None)
+    except OSError:
+        return None
+    saw_anything = False
+    for root, _dirs, files in iterator:
+        saw_anything = True
+        for fname in files:
+            fpath = os.path.join(root, fname)
+            try:
+                total += os.path.getsize(fpath)
+            except OSError:
+                continue
+    if not saw_anything:
+        # os.walk yielded nothing — either the path is unreadable or empty.
+        # Distinguish: if path is a readable directory we report 0; otherwise
+        # signal failure with None.
+        try:
+            if not os.access(path, os.R_OK | os.X_OK):
+                return None
+        except OSError:
+            return None
+        return 0
+    return total
+
+
+def _best_effort_last_active(path: Path) -> float | None:
+    """Latest mtime under `path/{raw,memory,state}` recursively, fallback to
+    the dir mtime. Returns None if even the dir mtime cannot be read."""
+    candidates: list[float] = []
+    for sub in ("raw", "memory", "state"):
+        sub_path = path / sub
+        if not sub_path.is_dir():
+            continue
+        try:
+            for root, _dirs, files in os.walk(sub_path, onerror=lambda _e: None):
+                for fname in files:
+                    fpath = os.path.join(root, fname)
+                    try:
+                        candidates.append(os.path.getmtime(fpath))
+                    except OSError:
+                        continue
+                # Also consider the dir mtime so empty subtrees still count.
+                try:
+                    candidates.append(os.path.getmtime(root))
+                except OSError:
+                    continue
+        except OSError:
+            continue
+    if candidates:
+        return max(candidates)
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def _format_size(size_bytes: int) -> str:
+    if size_bytes < 1024:
+        return f"{size_bytes}B"
+    for unit in ("KB", "MB", "GB", "TB"):
+        size_bytes /= 1024  # type: ignore[assignment]
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f}{unit}"
+    return f"{size_bytes:.1f}PB"
+
+
+def _iso_from_epoch(epoch: float | None) -> str:
+    if epoch is None:
+        return ""
+    try:
+        return (
+            datetime.fromtimestamp(int(epoch), tz=timezone.utc)
+            .astimezone()
+            .isoformat(timespec="seconds")
+        )
+    except (OSError, ValueError, OverflowError):
+        return ""
+
+
+def detect_orphan_agent_dir(
+    registry: list[dict[str, Any]],
+    home_root: Path,
+    ts: str,
+) -> list[dict[str, Any]]:
+    """Issue #598 Track 2: surface directories under $BRIDGE_AGENT_HOME_ROOT
+    that are not registered in `agent registry --json`.
+
+    Report-only. Each finding includes a manual quarantine recipe in
+    `suggested_action` (the eventual `agent retire` primitive — Track 3 —
+    will replace the recipe when it lands). Test-artifact prefixes get
+    `evidence.is_test_artifact = true` so an operator can triage in one
+    pass.
+    """
+    findings: list[dict[str, Any]] = []
+    if not home_root.is_dir():
+        return findings
+
+    known: set[str] = set()
+    for row in registry:
+        if not isinstance(row, dict):
+            continue
+        agent_id = str(row.get("id") or "").strip()
+        if agent_id:
+            known.add(agent_id)
+
+    try:
+        entries = sorted(home_root.iterdir(), key=lambda p: p.name)
+    except OSError:
+        return findings
+
+    for entry in entries:
+        name = entry.name
+        if name in ORPHAN_SKIP_NAMES:
+            continue
+        if name.startswith(".claude") or name.startswith("."):
+            continue
+        # Per spec: match by basename, not by `home` equality (dynamic agents
+        # can place their workdir anywhere). The registry `id` IS the
+        # directory basename for any home-root-resident agent.
+        if name in known:
+            continue
+        if not entry.is_dir():
+            continue
+        # Skip symlinks that don't point at an actual agent home (live
+        # `shared/` link, stale convenience symlinks). A dir-shaped symlink
+        # whose target is a real directory is still walked — that's the
+        # `--prefer new` worktree case where the agent home is a real dir.
+        try:
+            if entry.is_symlink():
+                resolved = entry.resolve(strict=False)
+                if not resolved.is_dir():
+                    continue
+        except OSError:
+            continue
+
+        try:
+            dir_mtime = os.path.getmtime(entry)
+        except OSError:
+            dir_mtime = None
+        size_bytes = _best_effort_dir_size(entry)
+        last_active = _best_effort_last_active(entry)
+        is_test_artifact = _is_test_artifact_name(name)
+
+        evidence: dict[str, Any] = {
+            "dir": str(entry),
+            "mtime": _iso_from_epoch(dir_mtime),
+            "last_active_at": _iso_from_epoch(last_active),
+            "is_test_artifact": is_test_artifact,
+            "registry_checked": "agent registry --json",
+        }
+        if size_bytes is not None:
+            evidence["size_bytes"] = int(size_bytes)
+        size_human = _format_size(size_bytes) if size_bytes is not None else "unknown"
+        mtime_iso = evidence["mtime"] or "unknown"
+        # NOTE: Track 3's `agent retire <name> [--purge-home]` will replace
+        # the manual recipe below. Until then, recommend a quarantine move
+        # so the operator preserves the dir for postmortem and the orphan
+        # set drops out of the next doctor run.
+        suggested = (
+            f"Orphan agent dir at {entry} (size {size_human}, mtime {mtime_iso}). "
+            "Not registered in `agent registry --json`. Manual quarantine: "
+            f'mv "{entry}" '
+            f'"$BRIDGE_HOME/archive/orphans-$(date +%Y%m%d-%H%M%S)-{name}". '
+            "If this is a test artifact (smoke-/test-/bootstrap-/"
+            "created-agent-/pref-/*-repro-N), confirm via "
+            "`--detectors orphan-agent-dir --json | jq` and quarantine in "
+            "batch. `agent retire` (issue #598 Track 3) will replace this "
+            "manual recipe when it lands."
+        )
+
+        findings.append(
+            {
+                "ts": ts,
+                "kind": "orphan-agent-dir",
+                "agent": name,
+                "evidence": evidence,
+                "suggested_action": suggested,
+            }
+        )
+    return findings
+
+
 # --- rendering -------------------------------------------------------------
 
 
@@ -636,6 +934,23 @@ def main() -> int:
         help=(
             "Override the Claude transcripts root for cold-restart-suspect "
             "(default: ~/.claude/projects)."
+        ),
+    )
+    parser.add_argument(
+        "--agent-registry-json",
+        default=None,
+        help=(
+            "Path to a JSON file with `agent-bridge agent registry --json` "
+            "output. Used by tests to skip the subprocess (Issue #598 Track 2)."
+        ),
+    )
+    parser.add_argument(
+        "--agent-home-root",
+        default=None,
+        help=(
+            "Override BRIDGE_AGENT_HOME_ROOT (default: env / "
+            "$BRIDGE_HOME/agents / ~/.agent-bridge/agents). Used by the "
+            "orphan-agent-dir detector."
         ),
     )
     args = parser.parse_args()
@@ -738,6 +1053,32 @@ def main() -> int:
     if conn is not None:
         conn.close()
 
+    # Issue #598 Track 2: lazy-load `agent registry --json` only when the
+    # orphan-agent-dir detector is enabled. The detector closure captures
+    # the deferred loader so a registry failure surfaces as a per-detector
+    # detector-error rather than failing the whole doctor run.
+    enabled_set_pre = set(enabled)
+    home_root = resolve_agent_home_root(args.agent_home_root)
+    if "orphan-agent-dir" in enabled_set_pre:
+        try:
+            registry = load_agent_registry(args)
+        except SystemExit as exc:
+            registry = []
+            findings.append(
+                {
+                    "ts": ts,
+                    "kind": "detector-error",
+                    "agent": "",
+                    "evidence": {
+                        "detector": "orphan-agent-dir",
+                        "error": str(exc),
+                    },
+                    "suggested_action": "",
+                }
+            )
+    else:
+        registry = []
+
     abnormal_explicit = bool(args.detectors)
     detector_runs: list[tuple[str, Any]] = [
         (
@@ -759,6 +1100,10 @@ def main() -> int:
         (
             "daemon-log-split",
             lambda: detect_daemon_log_split(state_dir, ts),
+        ),
+        (
+            "orphan-agent-dir",
+            lambda: detect_orphan_agent_dir(registry, home_root, ts),
         ),
     ]
 

--- a/bridge-doctor.py
+++ b/bridge-doctor.py
@@ -1059,11 +1059,13 @@ def main() -> int:
     # detector-error rather than failing the whole doctor run.
     enabled_set_pre = set(enabled)
     home_root = resolve_agent_home_root(args.agent_home_root)
+    registry_load_failed = False
     if "orphan-agent-dir" in enabled_set_pre:
         try:
             registry = load_agent_registry(args)
         except SystemExit as exc:
             registry = []
+            registry_load_failed = True
             findings.append(
                 {
                     "ts": ts,
@@ -1103,7 +1105,12 @@ def main() -> int:
         ),
         (
             "orphan-agent-dir",
-            lambda: detect_orphan_agent_dir(registry, home_root, ts),
+            # Short-circuit when registry-load failed so we don't flood the
+            # operator with every-dir-is-orphan false positives. The
+            # detector-error row was already emitted above; the empty
+            # known-set otherwise treats every dir under BRIDGE_AGENT_HOME_ROOT
+            # as orphan.
+            lambda: [] if registry_load_failed else detect_orphan_agent_dir(registry, home_root, ts),
         ),
     ]
 

--- a/scripts/smoke/orphan-agent-dir.sh
+++ b/scripts/smoke/orphan-agent-dir.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# scripts/smoke/orphan-agent-dir.sh — Issue #598 Track 2 smoke.
+#
+# Validates the new `orphan-agent-dir` detector in bridge-doctor.py.
+# The detector enumerates BRIDGE_AGENT_HOME_ROOT direct children,
+# subtracts the `agent registry --json` set (Track 1), and emits one
+# finding per remainder with an `is_test_artifact` heuristic flag.
+#
+# Test cases:
+#   T1. Empty BRIDGE_AGENT_HOME_ROOT → no findings.
+#   T2. Dir not in registry, name matches no test prefix → 1 finding,
+#       is_test_artifact=false.
+#   T3. Dir matching `smoke-*` prefix → finding with
+#       is_test_artifact=true. Same prefix list as Track 4
+#       (lib/bridge-core.sh:BRIDGE_TEST_ARTIFACT_PREFIXES).
+#   T4. Dir whose basename matches an `agent registry --json` `id` →
+#       not flagged (positive control: live dynamic agent must not
+#       be reaped).
+#   T5. `_template` and `shared` skipped silently.
+#   T6. Dir with an unreadable subdir → finding still emitted; no
+#       Python traceback (best-effort size_bytes / last_active_at).
+#   T7. `*-repro-<digits>` suffix recognized as test artifact.
+#
+# Uses an isolated BRIDGE_HOME via smoke_setup_bridge_home — never
+# touches the operator's live runtime. Registry is supplied via
+# `--agent-registry-json` so this fixture does NOT depend on
+# bridge-agent.sh registry being runnable in the test scope.
+
+set -euo pipefail
+
+SMOKE_NAME="orphan-agent-dir"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  # Restore any chmod we did so rm -rf can clear the temp root.
+  if [[ -n "${ORPHAN_LOCKED_DIR:-}" && -d "$ORPHAN_LOCKED_DIR" ]]; then
+    chmod -R u+rwX "$ORPHAN_LOCKED_DIR" 2>/dev/null || true
+  fi
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "orphan-agent-dir"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+DOCTOR="$REPO_ROOT/bridge-doctor.py"
+smoke_assert_file_exists "$DOCTOR" "doctor script present"
+
+# Empty agent-list payload — the doctor's other detectors need a roster
+# but that's out of scope here. Reuse for every run.
+EMPTY_AGENT_LIST="$SMOKE_TMP_ROOT/agent-list.empty.json"
+printf '%s\n' '[]' >"$EMPTY_AGENT_LIST"
+
+# ---------------------------------------------------------------------------
+# Helpers.
+# ---------------------------------------------------------------------------
+
+reset_home_root() {
+  # Reset agent-home-root to a clean dir between tests so each test
+  # starts from a known state.
+  if [[ -n "${ORPHAN_LOCKED_DIR:-}" && -d "$ORPHAN_LOCKED_DIR" ]]; then
+    chmod -R u+rwX "$ORPHAN_LOCKED_DIR" 2>/dev/null || true
+    ORPHAN_LOCKED_DIR=""
+  fi
+  rm -rf "$BRIDGE_AGENT_HOME_ROOT"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT"
+}
+
+write_registry() {
+  # write_registry <output-file> <id1> [<id2> ...]
+  # Emits a minimal `agent registry --json`-shaped JSON array.
+  local out="$1"
+  shift
+  local ids=("$@")
+  if (( ${#ids[@]} == 0 )); then
+    printf '%s\n' '[]' >"$out"
+    return
+  fi
+  {
+    printf '['
+    local first=1
+    local id
+    for id in "${ids[@]}"; do
+      if (( first )); then
+        first=0
+      else
+        printf ','
+      fi
+      printf '{"id":"%s","class":"dynamic","agent_source":"dynamic","privilege_class":"user","home":"%s/%s","engine":"claude","is_alive":true,"source":"dynamic-active-env"}' \
+        "$id" "$BRIDGE_AGENT_HOME_ROOT" "$id"
+    done
+    printf ']\n'
+  } >"$out"
+}
+
+run_doctor_orphan() {
+  # run_doctor_orphan <registry-json>
+  local registry="$1"
+  "$PY_BIN" "$DOCTOR" --json \
+    --detectors orphan-agent-dir \
+    --agent-registry-json "$registry" \
+    --agent-list-json "$EMPTY_AGENT_LIST" \
+    --agent-home-root "$BRIDGE_AGENT_HOME_ROOT"
+}
+
+# Return number of findings (after filtering for orphan-agent-dir kind
+# only, so an unrelated detector-error from a fragile subdetector does
+# not contaminate the count).
+findings_count() {
+  local payload="$1"
+  "$PY_BIN" -c '
+import json, sys
+data = json.loads(sys.stdin.read() or "[]")
+print(sum(1 for r in data if r.get("kind") == "orphan-agent-dir"))
+' <<<"$payload"
+}
+
+# Return JSON list of orphan-agent-dir findings only (drops detector-error
+# noise so per-test JSON inspection stays simple).
+findings_only() {
+  local payload="$1"
+  "$PY_BIN" -c '
+import json, sys
+data = json.loads(sys.stdin.read() or "[]")
+print(json.dumps([r for r in data if r.get("kind") == "orphan-agent-dir"]))
+' <<<"$payload"
+}
+
+# Pull a JSON field from the first finding matching `agent`.
+finding_field() {
+  local payload="$1"
+  local agent="$2"
+  local field="$3"
+  "$PY_BIN" -c '
+import json, sys
+agent, field = sys.argv[1], sys.argv[2]
+data = json.loads(sys.stdin.read() or "[]")
+matches = [r for r in data if r.get("kind") == "orphan-agent-dir" and r.get("agent") == agent]
+if not matches:
+    print("__MISSING__")
+    sys.exit(0)
+ev = matches[0].get("evidence") or {}
+val = ev.get(field, matches[0].get(field, "__MISSING__"))
+if isinstance(val, bool):
+    print("true" if val else "false")
+else:
+    print(val)
+' "$agent" "$field" <<<"$payload"
+}
+
+# ---------------------------------------------------------------------------
+# T1 — empty agent-home-root → no findings.
+# ---------------------------------------------------------------------------
+test_empty_home_root() {
+  reset_home_root
+  local registry="$SMOKE_TMP_ROOT/registry.t1.json"
+  write_registry "$registry"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+  local count
+  count="$(findings_count "$out")"
+  smoke_assert_eq "0" "$count" "T1 empty home root → no orphan findings"
+}
+
+# ---------------------------------------------------------------------------
+# T2 — orphan dir with non-test name → 1 finding, is_test_artifact=false.
+# ---------------------------------------------------------------------------
+test_plain_orphan() {
+  reset_home_root
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/shopicode"
+  printf 'placeholder\n' >"$BRIDGE_AGENT_HOME_ROOT/shopicode/notes.md"
+  local registry="$SMOKE_TMP_ROOT/registry.t2.json"
+  write_registry "$registry"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+  local count
+  count="$(findings_count "$out")"
+  smoke_assert_eq "1" "$count" "T2 one orphan finding"
+
+  local agent_field
+  agent_field="$(finding_field "$out" "shopicode" "dir")"
+  smoke_assert_contains "$agent_field" "shopicode" "T2 evidence.dir"
+
+  local is_test
+  is_test="$(finding_field "$out" "shopicode" "is_test_artifact")"
+  smoke_assert_eq "false" "$is_test" "T2 is_test_artifact false for plain name"
+
+  local registry_checked
+  registry_checked="$(finding_field "$out" "shopicode" "registry_checked")"
+  smoke_assert_eq "agent registry --json" "$registry_checked" \
+    "T2 evidence.registry_checked label"
+}
+
+# ---------------------------------------------------------------------------
+# T3 — `smoke-*` orphan flagged is_test_artifact=true.
+# ---------------------------------------------------------------------------
+test_smoke_prefix_orphan() {
+  reset_home_root
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/smoke-foo"
+  local registry="$SMOKE_TMP_ROOT/registry.t3.json"
+  write_registry "$registry"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+  local is_test
+  is_test="$(finding_field "$out" "smoke-foo" "is_test_artifact")"
+  smoke_assert_eq "true" "$is_test" "T3 smoke- prefix flagged is_test_artifact"
+}
+
+# ---------------------------------------------------------------------------
+# T4 — registry-matching dir is NOT flagged (live dynamic agent control).
+# ---------------------------------------------------------------------------
+test_registered_agent_not_flagged() {
+  reset_home_root
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/agb-dev-claude"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/orphan-leftover"
+  local registry="$SMOKE_TMP_ROOT/registry.t4.json"
+  write_registry "$registry" "agb-dev-claude"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+  local count
+  count="$(findings_count "$out")"
+  smoke_assert_eq "1" "$count" "T4 only the unregistered dir is flagged"
+
+  local agb_field
+  agb_field="$(finding_field "$out" "agb-dev-claude" "dir")"
+  smoke_assert_eq "__MISSING__" "$agb_field" \
+    "T4 registered live agent dir is NOT flagged"
+
+  local orphan_dir
+  orphan_dir="$(finding_field "$out" "orphan-leftover" "dir")"
+  smoke_assert_contains "$orphan_dir" "orphan-leftover" \
+    "T4 unregistered dir is flagged"
+}
+
+# ---------------------------------------------------------------------------
+# T5 — `_template` and `shared` skipped silently.
+# ---------------------------------------------------------------------------
+test_template_and_shared_skipped() {
+  reset_home_root
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/_template"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/shared"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/.claude-projects"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/real-orphan"
+  local registry="$SMOKE_TMP_ROOT/registry.t5.json"
+  write_registry "$registry"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+  local count
+  count="$(findings_count "$out")"
+  smoke_assert_eq "1" "$count" \
+    "T5 _template / shared / .claude-projects are skipped silently"
+
+  local real_dir
+  real_dir="$(finding_field "$out" "real-orphan" "dir")"
+  smoke_assert_contains "$real_dir" "real-orphan" \
+    "T5 the actual orphan is still flagged"
+}
+
+# ---------------------------------------------------------------------------
+# T6 — dir with an unreadable subdir still surfaces a finding.
+# ---------------------------------------------------------------------------
+test_unreadable_subdir_partial_finding() {
+  reset_home_root
+  local target="$BRIDGE_AGENT_HOME_ROOT/locked-orphan"
+  mkdir -p "$target/raw"
+  printf 'data\n' >"$target/raw/note.md"
+  chmod 000 "$target/raw"
+  ORPHAN_LOCKED_DIR="$target"
+  local registry="$SMOKE_TMP_ROOT/registry.t6.json"
+  write_registry "$registry"
+
+  local out rc=0
+  out="$(run_doctor_orphan "$registry")" || rc=$?
+  smoke_assert_eq "0" "$rc" "T6 doctor exits 0 even with unreadable subdir"
+
+  local count
+  count="$(findings_count "$out")"
+  smoke_assert_eq "1" "$count" \
+    "T6 unreadable subdir still produces an orphan finding"
+
+  # Restore perms before any further test runs.
+  chmod -R u+rwX "$target"
+  ORPHAN_LOCKED_DIR=""
+
+  if grep -q 'Traceback' <<<"$out"; then
+    smoke_fail "T6 doctor output contains a Python traceback: $out"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# T7 — `*-repro-<digits>` suffix recognised as test artifact.
+# ---------------------------------------------------------------------------
+test_repro_suffix_artifact() {
+  reset_home_root
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/created-agent-repro-44925"
+  local registry="$SMOKE_TMP_ROOT/registry.t7.json"
+  write_registry "$registry"
+
+  local out
+  out="$(run_doctor_orphan "$registry")"
+  local is_test
+  is_test="$(finding_field "$out" "created-agent-repro-44925" "is_test_artifact")"
+  smoke_assert_eq "true" "$is_test" \
+    "T7 *-repro-<digits> suffix flagged is_test_artifact"
+}
+
+# ---------------------------------------------------------------------------
+# Drive cases.
+# ---------------------------------------------------------------------------
+ORPHAN_LOCKED_DIR=""
+smoke_run "T1 empty home root" test_empty_home_root
+smoke_run "T2 plain orphan" test_plain_orphan
+smoke_run "T3 smoke- prefix orphan" test_smoke_prefix_orphan
+smoke_run "T4 registered agent not flagged" test_registered_agent_not_flagged
+smoke_run "T5 _template/shared skipped" test_template_and_shared_skipped
+smoke_run "T6 unreadable subdir partial finding" test_unreadable_subdir_partial_finding
+smoke_run "T7 *-repro-<digits> suffix" test_repro_suffix_artifact
+
+smoke_log "all orphan-agent-dir cases passed"

--- a/scripts/smoke/orphan-agent-dir.sh
+++ b/scripts/smoke/orphan-agent-dir.sh
@@ -303,7 +303,12 @@ test_unreadable_subdir_partial_finding() {
 # ---------------------------------------------------------------------------
 test_repro_suffix_artifact() {
   reset_home_root
+  # codex r1 noted that `created-agent-repro-44925` matches the
+  # `created-agent-` prefix branch first, so the regex path is never
+  # reached. Add a pure-regex name (no matching prefix) to isolate the
+  # ORPHAN_TEST_ARTIFACT_REPRO_REGEX branch.
   mkdir -p "$BRIDGE_AGENT_HOME_ROOT/created-agent-repro-44925"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/worker-repro-42"
   local registry="$SMOKE_TMP_ROOT/registry.t7.json"
   write_registry "$registry"
 
@@ -312,7 +317,10 @@ test_repro_suffix_artifact() {
   local is_test
   is_test="$(finding_field "$out" "created-agent-repro-44925" "is_test_artifact")"
   smoke_assert_eq "true" "$is_test" \
-    "T7 *-repro-<digits> suffix flagged is_test_artifact"
+    "T7 (a) *-repro-<digits> suffix flagged is_test_artifact (prefix branch)"
+  is_test="$(finding_field "$out" "worker-repro-42" "is_test_artifact")"
+  smoke_assert_eq "true" "$is_test" \
+    "T7 (b) regex-only -repro-<digits> match (no prefix overlap)"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds a report-only `orphan-agent-dir` detector to `bridge-doctor.py` (Issue #598 Track 2).
- Enumerates direct children of `$BRIDGE_AGENT_HOME_ROOT`, subtracts the union of ids from `agent registry --json` (Track 1 / PR #603), and emits one finding per remainder.
- Each finding includes `evidence.is_test_artifact` (mirrors `lib/bridge-core.sh:BRIDGE_TEST_ARTIFACT_PREFIXES` from Track 4 / PR #604 plus the `-repro-<digits>` suffix), best-effort `size_bytes` / `last_active_at` / `mtime`, and a manual quarantine recipe in `suggested_action`. The recipe will be superseded by `agent retire` once Track 3 lands.
- Skips `_template`, `shared`, dot-prefixed names, and any basename already in the registry — so live dynamic agents are not mis-classified as orphans (the failure mode the issue body documents on the MacBook Pro install where 3 of 5 "candidates" were live `agb-dev-claude` / `crm-dev` / `crm-test`).
- Adds `scripts/smoke/orphan-agent-dir.sh` with T1-T7. Standalone fixture (not registered in `scripts/smoke-test.sh` per Track-2 brief).

`refs #598`. Multi-track issue — orchestrator handles cross-track integration.

## Implementation notes

- `--agent-registry-json` and `--agent-home-root` flags expose test injection points without requiring a runnable `agent-bridge` in scope. `--agent-registry-json` mirrors the existing `--agent-list-json` test escape hatch.
- Registry load is lazy: only invoked when `orphan-agent-dir` is in the enabled detector set. A registry load failure surfaces as a per-detector `detector-error` row (allow-listed through the existing `--detectors` filter), not a fatal exit — the other detectors continue to run.
- `_best_effort_dir_size` and `_best_effort_last_active` swallow per-entry I/O errors so a single permission-denied subdir cannot crash the detector. T6 confirms a chmod-000 subtree still produces a finding with no traceback.
- The `BRIDGE_AGENT_HOME_ROOT` resolver mirrors the bash-side precedence (env var > `$BRIDGE_HOME/agents` > `~/.agent-bridge/agents`).

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-doctor.py').read())"` — passes.
- [x] `python3 -c "import py_compile; py_compile.compile('bridge-doctor.py', doraise=True)"` — passes.
- [x] `shellcheck scripts/smoke/orphan-agent-dir.sh` — clean.
- [x] `bash scripts/smoke/orphan-agent-dir.sh` — T1-T7 all pass in isolated `BRIDGE_HOME`.
- [x] `./scripts/smoke-test.sh` — same pre-existing failure on `main` (`refusing to write isolated agent-env.sh from ephemeral controller path`); not introduced by this change. Re-verified by `git stash && ./scripts/smoke-test.sh`.
- [x] `python3 bridge-doctor.py --help` — new flags surface correctly.
- [x] Manual verification: with the operator's live runtime, `python3 bridge-doctor.py --json --detectors orphan-agent-dir` runs end-to-end against `agent registry --json` (lazy load triggers).

## Out of scope

- `agent retire <name> [--purge-home]` primitive — Track 3, separate PR.
- Modifying `lib/bridge-core.sh` prefix list — already shipped via PR #604; this detector mirrors the list rather than importing from bash.
- VERSION / CHANGELOG bumps — multi-track issue, single release at the end.