### PR TITLE
fix(bridge-run): apply linux-user isolation umask regardless of layout

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -7,15 +7,13 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 
-# PR-E: in v2 mode + linux-user isolation, switch the runtime umask from
-# bridge-lib.sh's default 0077 (private) to 0007 (group-writable). The v2
-# group-setgid layout (PR-A/B/C) gives new files the right group, but the
-# mode bits depend on umask. Without 0007, a setgid 2770 channel/runtime
-# dir would still hold 0600 files that the controller (group member) can
-# only read because of the inherited group ownership combined with chmod
-# at directory creation; agent-created channel state .env files would
-# lack group rw and the daemon's controller-side health probes would
-# silently see EACCES.
+# PR-E (revised): linux-user isolation requires umask 0007 in both
+# legacy ACL-backed isolation and v2 group/setgid isolation. Without
+# 0007, umask-governed creates land with group bits=0, which can collapse
+# the POSIX ACL mask to `---` and mask named-user entries such as the
+# controller's rwX grant. This caused 2026-05-04/05 daily-backup EACCES
+# regressions on isolated agent homes. Scope is the umask-governed create
+# path only; application-level chmod 0600 remains out of scope.
 #
 # Called twice from this script: once after the first bridge_require_agent
 # at startup, and once from bridge_run_refresh_roster_if_changed after the
@@ -31,8 +29,7 @@ source "$SCRIPT_DIR/bridge-lib.sh"
 # /proc/<pid>/status. Inert when unset.
 bridge_run_apply_v2_umask_if_needed() {
   local agent="$1"
-  if bridge_isolation_v2_active 2>/dev/null \
-      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+  if bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
     umask 007
   fi
   if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
@@ -118,9 +115,9 @@ fi
 
 bridge_require_agent "$AGENT"
 
-# PR-E: apply v2 umask before any runtime mkdir/plugin sync/launch work.
-# bridge-lib.sh:17 unconditionally set 0077; this helper only changes it
-# when BRIDGE_LAYOUT=v2 and the agent is linux-user-isolated.
+# PR-E: apply the isolation launch umask before any runtime mkdir/plugin
+# sync/launch work. bridge-lib.sh:17 unconditionally sets 0077; this
+# helper changes it only when the agent is linux-user-isolated.
 bridge_run_apply_v2_umask_if_needed "$AGENT"
 
 if [[ $CONTINUE_EXPLICIT -eq 1 ]]; then
@@ -266,9 +263,9 @@ bridge_run_refresh_roster_if_changed() {
 
   bridge_load_roster
   bridge_require_agent "$AGENT"
-  # PR-E: re-apply v2 umask after roster reload — bridge-lib.sh's umask 077
-  # is sticky across the process but a defensive re-set guards against any
-  # subshell that may have reset it during the refresh.
+  # PR-E: re-apply isolation umask after roster reload — bridge-lib.sh's
+  # umask 077 is sticky across the process but a defensive re-set guards
+  # against any subshell that may have reset it during the refresh.
   bridge_run_apply_v2_umask_if_needed "$AGENT"
   if [[ $CONTINUE_EXPLICIT -eq 1 ]]; then
     BRIDGE_AGENT_CONTINUE["$AGENT"]="$CONTINUE_MODE"

--- a/scripts/smoke/launch.sh
+++ b/scripts/smoke/launch.sh
@@ -14,7 +14,8 @@ trap cleanup EXIT
 
 write_launch_roster() {
   local workdir="$BRIDGE_AGENT_HOME_ROOT/launch-agent"
-  mkdir -p "$workdir"
+  local isolated_workdir="$BRIDGE_AGENT_HOME_ROOT/launch-isolated-agent"
+  mkdir -p "$workdir" "$isolated_workdir"
   cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
 bridge_add_agent_id_if_missing "launch-agent"
 BRIDGE_AGENT_DESC["launch-agent"]="Launch static smoke"
@@ -24,6 +25,17 @@ BRIDGE_AGENT_WORKDIR["launch-agent"]="$workdir"
 BRIDGE_AGENT_LAUNCH_CMD["launch-agent"]="bash -lc 'echo launch-agent'"
 BRIDGE_AGENT_LOOP["launch-agent"]=0
 BRIDGE_AGENT_CONTINUE["launch-agent"]=0
+
+bridge_add_agent_id_if_missing "launch-isolated-agent"
+BRIDGE_AGENT_DESC["launch-isolated-agent"]="Launch isolated umask smoke"
+BRIDGE_AGENT_ENGINE["launch-isolated-agent"]="shell"
+BRIDGE_AGENT_SESSION["launch-isolated-agent"]="launch-isolated-smoke-session"
+BRIDGE_AGENT_WORKDIR["launch-isolated-agent"]="$isolated_workdir"
+BRIDGE_AGENT_LAUNCH_CMD["launch-isolated-agent"]="bash -lc 'echo launch-isolated-agent'"
+BRIDGE_AGENT_LOOP["launch-isolated-agent"]=0
+BRIDGE_AGENT_CONTINUE["launch-isolated-agent"]=0
+BRIDGE_AGENT_ISOLATION_MODE["launch-isolated-agent"]="linux-user"
+BRIDGE_AGENT_OS_USER["launch-isolated-agent"]="agent-bridge-launch-smoke"
 EOF
 }
 
@@ -45,10 +57,47 @@ launch_dry_run_contract() {
   smoke_assert_contains "$run_out" "launch=bash -lc 'echo launch-agent'" "bridge-run dry-run launch command"
 }
 
+launch_umask_probe_contract() {
+  local shared_probe isolated_probe v2_probe
+  local shared_recorded isolated_recorded v2_recorded
+  local v2_data_root
+
+  shared_probe="$SMOKE_TMP_ROOT/launch-shared-umask.probe"
+  isolated_probe="$SMOKE_TMP_ROOT/launch-isolated-legacy-umask.probe"
+  v2_probe="$SMOKE_TMP_ROOT/launch-isolated-v2-umask.probe"
+  v2_data_root="$SMOKE_TMP_ROOT/v2-data"
+  mkdir -p "$v2_data_root/agents" "$v2_data_root/shared" "$v2_data_root/state"
+
+  BRIDGE_LAYOUT=legacy \
+  BRIDGE_DATA_ROOT= \
+  BRIDGE_HOST_PLATFORM_OVERRIDE=Linux \
+  BRIDGE_RUN_UMASK_PROBE_FILE="$shared_probe" \
+    bash "$SMOKE_REPO_ROOT/bridge-run.sh" launch-agent --dry-run >/dev/null
+  shared_recorded="$(cat "$shared_probe" 2>/dev/null || true)"
+  smoke_assert_eq "0077" "$shared_recorded" "legacy shared bridge-run umask remains private"
+
+  BRIDGE_LAYOUT=legacy \
+  BRIDGE_DATA_ROOT= \
+  BRIDGE_HOST_PLATFORM_OVERRIDE=Linux \
+  BRIDGE_RUN_UMASK_PROBE_FILE="$isolated_probe" \
+    bash "$SMOKE_REPO_ROOT/bridge-run.sh" launch-isolated-agent --dry-run >/dev/null
+  isolated_recorded="$(cat "$isolated_probe" 2>/dev/null || true)"
+  smoke_assert_eq "0007" "$isolated_recorded" "legacy linux-user bridge-run umask preserves ACL mask"
+
+  BRIDGE_LAYOUT=v2 \
+  BRIDGE_DATA_ROOT="$v2_data_root" \
+  BRIDGE_HOST_PLATFORM_OVERRIDE=Linux \
+  BRIDGE_RUN_UMASK_PROBE_FILE="$v2_probe" \
+    bash "$SMOKE_REPO_ROOT/bridge-run.sh" launch-isolated-agent --dry-run >/dev/null
+  v2_recorded="$(cat "$v2_probe" 2>/dev/null || true)"
+  smoke_assert_eq "0007" "$v2_recorded" "v2 linux-user bridge-run umask remains 0007"
+}
+
 main() {
   smoke_setup_bridge_home "launch"
   write_launch_roster
   smoke_run "bridge-start/bridge-run dry-run launch contract" launch_dry_run_contract
+  smoke_run "bridge-run linux-user umask probe contract" launch_umask_probe_contract
   smoke_log "passed"
 }
 

--- a/tests/isolation-v2-pr-e/smoke.sh
+++ b/tests/isolation-v2-pr-e/smoke.sh
@@ -221,12 +221,11 @@ assert_some_setfacl() {
 # self-contained without sourcing bridge-run.sh (which has top-level
 # argv parsing). Drift between this copy and the real helper is itself
 # something the smoke catches, because the underlying contract
-# (`bridge_isolation_v2_active && bridge_agent_linux_user_isolation_effective`
-# → umask 007) is what gets tested.
+# (`bridge_agent_linux_user_isolation_effective` → umask 007) is what
+# gets tested for both legacy ACL-backed and v2 group/setgid isolation.
 smoke_bridge_run_apply_v2_umask_if_needed() {
   local agent="$1"
-  if bridge_isolation_v2_active 2>/dev/null \
-      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+  if bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
     umask 007
   fi
   if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
@@ -452,7 +451,7 @@ um1_recorded="$(cat "$UM1_PROBE" 2>/dev/null || true)"
 ok "UM1 v2 + linux-user → bridge-run.sh helper sets umask 0007"
 
 # ---------------------------------------------------------------------------
-# UM2: helper inert in legacy mode
+# UM2: helper inert for legacy shared agents
 # ---------------------------------------------------------------------------
 case_um2() {
   bridge_load_roster
@@ -461,7 +460,7 @@ case_um2() {
   BRIDGE_AGENT_ISOLATION_MODE["smoke-um2"]="shared"
   smoke_bridge_run_apply_v2_umask_if_needed "smoke-um2"
 }
-log "case: UM2 bridge_run_apply_v2_umask_if_needed inert in legacy"
+log "case: UM2 bridge_run_apply_v2_umask_if_needed inert for legacy shared"
 UM2_DIR="$TMP_ROOT/um2"
 UM2_LOG="$UM2_DIR/sudo.log"
 UM2_PROBE="$UM2_DIR/umask.probe"
@@ -471,7 +470,31 @@ BRIDGE_RUN_UMASK_PROBE_FILE="$UM2_PROBE" run_in_legacy "$UM2_DIR" "$UM2_LOG" cas
   || die "UM2 case_um2 returned non-zero"
 um2_recorded="$(cat "$UM2_PROBE" 2>/dev/null || true)"
 [[ "$um2_recorded" == "0077" ]] || die "UM2 expected probe=0077 (bridge-lib default), got: '$um2_recorded'"
-ok "UM2 legacy mode → helper inert (umask stays 0077)"
+ok "UM2 legacy shared → helper inert (umask stays 0077)"
+
+# ---------------------------------------------------------------------------
+# UM4: helper sets 0007 for legacy linux-user isolation
+# ---------------------------------------------------------------------------
+case_um4() {
+  bridge_load_roster
+  BRIDGE_AGENT_IDS=("smoke-um4")
+  BRIDGE_AGENT_ENGINE["smoke-um4"]="codex"
+  BRIDGE_AGENT_WORKDIR["smoke-um4"]="/tmp/wd"
+  BRIDGE_AGENT_ISOLATION_MODE["smoke-um4"]="linux-user"
+  BRIDGE_AGENT_OS_USER["smoke-um4"]="ec2-user"
+  smoke_bridge_run_apply_v2_umask_if_needed "smoke-um4"
+}
+log "case: UM4 bridge_run_apply_v2_umask_if_needed in legacy linux-user"
+UM4_DIR="$TMP_ROOT/um4"
+UM4_LOG="$UM4_DIR/sudo.log"
+UM4_PROBE="$UM4_DIR/umask.probe"
+mkdir -p "$UM4_DIR"
+: >"$UM4_PROBE"
+BRIDGE_RUN_UMASK_PROBE_FILE="$UM4_PROBE" run_in_legacy "$UM4_DIR" "$UM4_LOG" case_um4 \
+  || die "UM4 case_um4 returned non-zero"
+um4_recorded="$(cat "$UM4_PROBE" 2>/dev/null || true)"
+[[ "$um4_recorded" == "0007" ]] || die "UM4 expected probe=0007 (legacy + linux-user), got: '$um4_recorded'"
+ok "UM4 legacy linux-user → bridge-run.sh helper sets umask 0007"
 
 # ---------------------------------------------------------------------------
 # UM3: real bridge-run.sh entrypoint applies umask 0007 in v2 (PR #399 r2 FAIL #14)

--- a/tests/isolation-v2-pr-e/smoke.sh
+++ b/tests/isolation-v2-pr-e/smoke.sh
@@ -474,6 +474,15 @@ ok "UM2 legacy shared → helper inert (umask stays 0077)"
 
 # ---------------------------------------------------------------------------
 # UM4: helper sets 0007 for legacy linux-user isolation
+#
+# Two assertions, both required:
+#   1. probe-text — `umask` reports 0007 (catches helper body regressions)
+#   2. real-file mode — a file created *after* the helper has mode 0660
+#      (catches regressions where the probe still says 0007 but something
+#      strips group bits or umask isn't actually applied to creates).
+# A future change could fool the probe alone (e.g. set then reset, or
+# print the right value without applying it); the create+stat closes
+# that gap and is the actual permission contract operators care about.
 # ---------------------------------------------------------------------------
 case_um4() {
   bridge_load_roster
@@ -483,6 +492,22 @@ case_um4() {
   BRIDGE_AGENT_ISOLATION_MODE["smoke-um4"]="linux-user"
   BRIDGE_AGENT_OS_USER["smoke-um4"]="ec2-user"
   smoke_bridge_run_apply_v2_umask_if_needed "smoke-um4"
+  # Real-file mode-bit assertion. Must run inside the same subshell as
+  # the helper so the umask actually applies to the create. Use the
+  # case-scoped fixture dir passed in via the first positional arg.
+  local fixture_dir="$1"
+  local probe_file="$fixture_dir/created-after-umask"
+  : >"$probe_file" || { echo "case_um4: failed to create probe file at $probe_file" >&2; return 31; }
+  local mode
+  if mode=$(stat -c '%a' "$probe_file" 2>/dev/null); then :;
+  elif mode=$(stat -f '%Lp' "$probe_file" 2>/dev/null); then :;
+  else
+    echo "case_um4: stat unsupported on this platform" >&2
+    return 32
+  fi
+  # Strip leading zeros so 0660 / 660 both match.
+  mode="${mode#0}"
+  [[ "$mode" == "660" ]] || { echo "case_um4: expected file mode 660, got $mode" >&2; return 33; }
 }
 log "case: UM4 bridge_run_apply_v2_umask_if_needed in legacy linux-user"
 UM4_DIR="$TMP_ROOT/um4"
@@ -490,11 +515,11 @@ UM4_LOG="$UM4_DIR/sudo.log"
 UM4_PROBE="$UM4_DIR/umask.probe"
 mkdir -p "$UM4_DIR"
 : >"$UM4_PROBE"
-BRIDGE_RUN_UMASK_PROBE_FILE="$UM4_PROBE" run_in_legacy "$UM4_DIR" "$UM4_LOG" case_um4 \
+BRIDGE_RUN_UMASK_PROBE_FILE="$UM4_PROBE" run_in_legacy "$UM4_DIR" "$UM4_LOG" case_um4 "$UM4_DIR" \
   || die "UM4 case_um4 returned non-zero"
 um4_recorded="$(cat "$UM4_PROBE" 2>/dev/null || true)"
 [[ "$um4_recorded" == "0007" ]] || die "UM4 expected probe=0007 (legacy + linux-user), got: '$um4_recorded'"
-ok "UM4 legacy linux-user → bridge-run.sh helper sets umask 0007"
+ok "UM4 legacy linux-user → bridge-run.sh helper sets umask 0007 + created file mode 0660"
 
 # ---------------------------------------------------------------------------
 # UM3: real bridge-run.sh entrypoint applies umask 0007 in v2 (PR #399 r2 FAIL #14)


### PR DESCRIPTION
## Summary

Fixes the isolated-agent umask regression where legacy linux-user isolated agents still inherited `bridge-lib.sh`'s private `0077` umask. New files could then land with group-class bits set to `0`, collapsing POSIX ACL masks to `---` and nullifying named-user controller grants.

This applies the PR-E launch umask contract to linux-user isolation regardless of layout:

- legacy ACL-backed isolation: `BRIDGE_LAYOUT=legacy` + `linux-user` -> `umask 0007`
- v2 group/setgid isolation: `BRIDGE_LAYOUT=v2` + `linux-user` -> `umask 0007`
- shared/non-isolated agents remain `0077`

## Context

Observed on 2026-05-04/05 daily-backup runs: newly-created files under an isolated agent home repeatedly drifted to ACL `mask::---`, causing controller-side EACCES. One-time `setfacl -R -m m::rwx` repairs helped existing files but did not prevent the next umask-governed create path from regressing.

## Security model

- Linux-user isolation is expected to use a dedicated OS user/private primary group, or a controller-owned worktree where group access is intentional.
- `other` remains closed under `umask 0007`.
- Existing ACL/default-ACL paths recover because group-class bits no longer collapse the ACL mask to `---`.
- This does not add new production ACL grants.
- Application-level explicit `chmod 0600` remains out of scope and should be handled by targeted repair if needed.

## Changes

- `bridge-run.sh`
  - removes the `bridge_isolation_v2_active` gate from `bridge_run_apply_v2_umask_if_needed`
  - updates comments to document legacy ACL-backed and v2 group/setgid isolation
- `scripts/smoke/launch.sh`
  - adds real `bridge-run.sh --dry-run` umask probe coverage for legacy shared, legacy linux-user, and v2 linux-user
- `tests/isolation-v2-pr-e/smoke.sh`
  - updates the inline helper contract
  - clarifies UM2 legacy shared behavior
  - adds UM4 legacy linux-user coverage

## Verification

- `bash -n bridge-run.sh scripts/smoke/launch.sh tests/isolation-v2-pr-e/smoke.sh`
- `scripts/smoke/launch.sh`
- `scripts/smoke/isolation.sh`
- `bash tests/isolation-v2-pr-e/smoke.sh`
- `git diff --check`

Note: local `shellcheck` was not installed on the host; GitHub CI lint is expected to cover it.

## r2 changes

Codex r1 closed D1/D2 but returned `needs-more` on D3: UM4 only inspected the helper's `umask` text via `BRIDGE_RUN_UMASK_PROBE_FILE`, never created a file or asserted resulting mode bits, leaving the regression class unguarded against changes that fool the probe but skip the actual permission contract.

- `tests/isolation-v2-pr-e/smoke.sh` (`case_um4`)
  - after `smoke_bridge_run_apply_v2_umask_if_needed`, creates a probe file inside the same subshell so the helper's umask actually applies, then asserts mode `0660` using a portable stat fallback (`-c '%a'` for GNU, `-f '%Lp'` for BSD)
  - keeps the existing umask-probe assertion at line ~495 so both checks must pass — probe-text catches helper-body regressions, file-mode catches anything that strips group bits or fails to apply umask to creates
  - UM2 and other cases untouched; `bridge-run.sh` and `bridge-lib.sh` not modified