### PR TITLE
feat(channels): teams+mattermost managed-send (Track C of #597)

### DIFF
--- a/plugins/mattermost/server.ts
+++ b/plugins/mattermost/server.ts
@@ -901,10 +901,34 @@ async function runSendManagedCli(): Promise<number> {
   if (agent && !process.env.BRIDGE_AGENT_ID) {
     process.env.BRIDGE_AGENT_ID = agent
   }
-  if (!MM_TOKEN) {
+
+  // Resolve the per-agent route token so managed sends preserve bot identity
+  // in multi-bot deployments. MATTERMOST_BOT_ROUTES maps each route to a
+  // distinct bot account (token + username); send-managed should post as the
+  // bot configured for `--agent` rather than the global MM_TOKEN. Falls back
+  // to MM_TOKEN when no route matches (preserves behavior for installs that
+  // haven't set up multi-agent routing). See codex r1 review of #610.
+  let routeToken = ''
+  if (agent) {
+    try {
+      const routes = loadBotRoutes()
+      for (const r of routes) {
+        const routeAgent = r.agent ?? r.username.replace(/-bot$/, '').replace(/-/g, '_')
+        if (routeAgent === agent && r.token) {
+          routeToken = r.token
+          break
+        }
+      }
+    } catch (err) {
+      process.stderr.write(`mattermost send-managed: bot-routes lookup failed: ${err}\n`)
+    }
+  }
+  const sendToken = routeToken || MM_TOKEN
+  if (!sendToken) {
     process.stderr.write(
-      'mattermost send-managed: MATTERMOST_BOT_TOKEN required for managed sends; ' +
-        `set it in ${ENV_FILE}\n`,
+      'mattermost send-managed: no token available for agent ' +
+        (agent || '(unspecified)') +
+        '; set MATTERMOST_BOT_TOKEN or MATTERMOST_BOT_ROUTES in ' + ENV_FILE + '\n',
     )
     return 2
   }
@@ -924,7 +948,7 @@ async function runSendManagedCli(): Promise<number> {
   // shape, Mattermost resolves equivalently.
   let posted: unknown
   try {
-    posted = await mmCreatePost(channelId, sanitizedBody, undefined, replyToMessageId || undefined)
+    posted = await mmCreatePost(channelId, sanitizedBody, sendToken, replyToMessageId || undefined)
   } catch (err) {
     process.stderr.write(`mattermost send-managed: send failed: ${err}\n`)
     return 1

--- a/plugins/mattermost/server.ts
+++ b/plugins/mattermost/server.ts
@@ -61,6 +61,7 @@ type StoredMessage = {
 
 const STATE_DIR = process.env.MATTERMOST_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'mattermost')
 const BRIDGE_HOME = process.env.BRIDGE_HOME ?? join(homedir(), '.agent-bridge')
+const BRIDGE_STATE_DIR = process.env.BRIDGE_STATE_DIR ?? join(BRIDGE_HOME, 'state')
 const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const ENV_FILE = join(STATE_DIR, '.env')
 const MESSAGES_FILE = join(STATE_DIR, 'messages.jsonl')
@@ -245,6 +246,112 @@ function appendMessage(message: StoredMessage): void {
   appendFileSync(MESSAGES_FILE, JSON.stringify(message) + '\n', { mode: 0o600 })
 }
 
+// PreCompact channel auto-notify activity index — issue #597 Track C.
+//
+// Writes $BRIDGE_STATE_DIR/channels/mattermost/<agent>.json so the daemon's
+// route-precompact-target lookup can pick the most recent inbound channel
+// to notify on context compaction. Best-effort: any failure is logged and
+// swallowed so a state-dir glitch never breaks live message delivery.
+
+type MattermostActivityChannelEntry = {
+  channel_id: string
+  reply_kind: string
+  last_seen_id?: string
+  last_seen_ts?: number
+  last_user_inbound_ts: number
+  last_user_inbound_ts_ms: number
+  last_user_inbound_message_id: string
+  last_user_inbound_user_id: string
+  last_user_inbound_recorded_ns: number
+  thread_id?: string
+}
+
+type MattermostActivityIndex = {
+  schema_version: number
+  agent: string
+  plugin: 'mattermost'
+  updated_ts: number
+  channels: Record<string, MattermostActivityChannelEntry>
+}
+
+function sanitizeAgentForPath(raw: string): string {
+  if (!raw || typeof raw !== 'string') return ''
+  if (raw.length > 64) return ''
+  if (!/^[a-zA-Z0-9_-]+$/.test(raw)) return ''
+  return raw
+}
+
+function mattermostActivityIndexPath(agent: string): string {
+  return join(BRIDGE_STATE_DIR, 'channels', 'mattermost', `${agent}.json`)
+}
+
+function loadMattermostActivityIndex(path: string, agent: string): MattermostActivityIndex {
+  try {
+    const raw = readFileSync(path, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && parsed.channels && typeof parsed.channels === 'object') {
+      return parsed as MattermostActivityIndex
+    }
+  } catch {}
+  return {
+    schema_version: 1,
+    agent,
+    plugin: 'mattermost',
+    updated_ts: 0,
+    channels: {},
+  }
+}
+
+let mattermostRecordedTail = 0
+
+function writeMattermostActivityIndex(
+  agent: string,
+  channelId: string,
+  postId: string,
+  userId: string,
+  inboundDate: Date,
+  rootId: string,
+): void {
+  const safeAgent = sanitizeAgentForPath(agent)
+  if (!safeAgent || !channelId || !postId) return
+  try {
+    const path = mattermostActivityIndexPath(safeAgent)
+    const dir = join(BRIDGE_STATE_DIR, 'channels', 'mattermost')
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+    const index = loadMattermostActivityIndex(path, safeAgent)
+    const tsMs = inboundDate.getTime()
+    const tsSec = Math.floor(tsMs / 1000)
+    // recorded_ns: see writeTeamsActivityIndex — ms-precision packed into the
+    // upper digits, per-process counter into the lower three digits, kept
+    // under Number.MAX_SAFE_INTEGER. Used only for tie-break ordering.
+    const nowNs = tsMs * 1_000 + (mattermostRecordedTail++ % 1_000)
+    index.schema_version = 1
+    index.agent = safeAgent
+    index.plugin = 'mattermost'
+    index.updated_ts = tsSec
+    const entry: MattermostActivityChannelEntry = {
+      channel_id: channelId,
+      reply_kind: rootId ? 'thread' : 'root',
+      last_seen_id: postId,
+      last_seen_ts: tsSec,
+      last_user_inbound_ts: tsSec,
+      last_user_inbound_ts_ms: tsMs,
+      last_user_inbound_message_id: postId,
+      last_user_inbound_user_id: userId,
+      last_user_inbound_recorded_ns: nowNs,
+    }
+    if (rootId) {
+      entry.thread_id = rootId
+    }
+    index.channels[channelId] = entry
+    const tmp = `${path}.tmp`
+    writeFileSync(tmp, JSON.stringify(index, null, 2) + '\n', { mode: 0o600 })
+    renameSync(tmp, path)
+  } catch (err) {
+    process.stderr.write(`mattermost channel: activity-index write failed: ${err}\n`)
+  }
+}
+
 function runPromptGuard(command: 'scan' | 'sanitize', text: string): Record<string, unknown> | null {
   const script = join(BRIDGE_HOME, 'bridge-guard.py')
   const result = spawnSync(
@@ -296,7 +403,22 @@ async function mmApiRequest(
   return text ? JSON.parse(text) : null
 }
 
-async function mmCreatePost(channelId: string, message: string, tokenOverride?: string): Promise<unknown> {
+async function mmCreatePost(
+  channelId: string,
+  message: string,
+  tokenOverride?: string,
+  rootId?: string,
+): Promise<unknown> {
+  // root_id: when set, this post becomes a thread reply rooted at the given
+  // post id. Mattermost's threading model is "post inside the same channel
+  // with root_id == the original post id"; if the original was already
+  // inside a thread, callers should pass that thread's root id (the same
+  // root_id that lives on the inbound post.root_id), not the inbound's own
+  // post id. Issue #597 Track C uses this for managed PreCompact replies.
+  const body: Record<string, string> = { channel_id: channelId, message }
+  if (rootId && typeof rootId === 'string' && rootId.length > 0) {
+    body.root_id = rootId
+  }
   if (tokenOverride) {
     const url = `${MM_URL}/api/v4/posts`
     const response = await fetch(url, {
@@ -306,7 +428,7 @@ async function mmCreatePost(channelId: string, message: string, tokenOverride?: 
         'Content-Type': 'application/json',
         'User-Agent': 'agent-bridge-mattermost/0.1',
       },
-      body: JSON.stringify({ channel_id: channelId, message }),
+      body: JSON.stringify(body),
     })
     if (!response.ok) {
       const detail = await response.text()
@@ -314,7 +436,7 @@ async function mmCreatePost(channelId: string, message: string, tokenOverride?: 
     }
     return response.text().then(t => t ? JSON.parse(t) : null)
   }
-  return mmApiRequest('POST', '/posts', { channel_id: channelId, message })
+  return mmApiRequest('POST', '/posts', body)
 }
 
 async function bridgeSend(agent: string, message: string, userName: string, channelId: string, route?: BotRoute | null): Promise<void> {
@@ -562,6 +684,19 @@ async function handlePosted(
   }
   appendMessage(stored)
 
+  // PreCompact channel auto-notify activity-index write — issue #597 Track C.
+  // Best-effort; failures are logged inside the helper and never bubble up.
+  // root_id: thread continuation. If the inbound post is already inside a
+  // thread (post.root_id set), a reply uses that root; otherwise replying
+  // with root_id=post.id starts a thread under the inbound post.
+  const agentForIndex = route.agent || process.env.BRIDGE_AGENT_ID || ''
+  if (agentForIndex) {
+    const inboundDate =
+      post.create_at && post.create_at > 0 ? new Date(post.create_at) : new Date()
+    const rootForIndex = String(post.root_id ?? '').trim() || post.id
+    writeMattermostActivityIndex(agentForIndex, channelId, post.id, userId, inboundDate, rootForIndex)
+  }
+
   if (BRIDGE_MODE) {
     void bridgeSend(route.agent, text, userName, channelId, null)
   } else {
@@ -738,6 +873,85 @@ async function start(): Promise<void> {
   // (Architect finding #3, single-bot half) and multi-bot keeps running
   // until the watchdog or signal handler aborts.
   await Promise.all([mcp.connect(new StdioServerTransport()), ...wsLoops])
+}
+
+// CLI mode: `node server.js send-managed --agent ... --channel-id ...`.
+// Used by the daemon's send-managed-message wrapper for PreCompact notify
+// (issue #597). Short-circuits the daemon WS startup so a one-shot outbound
+// reply never spins up the inbound listener path.
+async function runSendManagedCli(): Promise<number> {
+  const argv = process.argv.slice(3)
+  const flags: Record<string, string> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2)
+    const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : ''
+    if (value) i++
+    flags[key] = value
+  }
+  const channelId = String(flags['channel-id'] ?? '').trim()
+  const replyToMessageId = String(flags['reply-to-message-id'] ?? '').trim()
+  const body = String(flags['body'] ?? '')
+  const agent = String(flags['agent'] ?? '').trim()
+  if (!channelId || !body) {
+    process.stderr.write('mattermost send-managed: --channel-id and --body are required\n')
+    return 2
+  }
+  if (agent && !process.env.BRIDGE_AGENT_ID) {
+    process.env.BRIDGE_AGENT_ID = agent
+  }
+  if (!MM_TOKEN) {
+    process.stderr.write(
+      'mattermost send-managed: MATTERMOST_BOT_TOKEN required for managed sends; ' +
+        `set it in ${ENV_FILE}\n`,
+    )
+    return 2
+  }
+
+  let sanitizedBody = body
+  const guarded = runPromptGuard('sanitize', body)
+  if (guarded?.blocked) {
+    sanitizedBody = '[Agent Bridge] outbound reply blocked by prompt guard.'
+  } else if (guarded?.was_modified && typeof guarded.sanitized_text === 'string') {
+    sanitizedBody = guarded.sanitized_text
+  }
+
+  // Mattermost threading: pass the inbound post id as root_id so the reply
+  // surfaces in the same thread. The daemon's --reply-to-message-id is the
+  // inbound post id from the activity index. If the original post was
+  // already a thread reply, callers may pass its root_id instead — same
+  // shape, Mattermost resolves equivalently.
+  let posted: unknown
+  try {
+    posted = await mmCreatePost(channelId, sanitizedBody, undefined, replyToMessageId || undefined)
+  } catch (err) {
+    process.stderr.write(`mattermost send-managed: send failed: ${err}\n`)
+    return 1
+  }
+
+  const postedRow = posted as { id?: string; root_id?: string } | null
+  const sentId = String(postedRow?.id ?? '').trim()
+  const threadId = String(postedRow?.root_id ?? '').trim() || replyToMessageId || ''
+  // best_effort_threading=false — Mattermost natively supports message-
+  // granular threading via root_id, which we used.
+  const out = {
+    status: 'sent',
+    plugin: 'mattermost',
+    channel_id: channelId,
+    message_id: sentId,
+    thread_id: threadId || null,
+    best_effort_threading: false,
+  }
+  process.stdout.write(JSON.stringify(out) + '\n')
+  return 0
+}
+
+const CLI_SUBCOMMAND = (process.argv[2] ?? '').trim()
+
+if (CLI_SUBCOMMAND === 'send-managed') {
+  const code = await runSendManagedCli()
+  process.exit(code)
 }
 
 await start()

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -431,7 +431,7 @@ function loadTeamsActivityIndex(path: string, agent: string): TeamsActivityIndex
 
 let teamsRecordedTail = 0
 
-function writeTeamsActivityIndex(
+export function writeTeamsActivityIndex(
   agent: string,
   channelId: string,
   messageId: string,
@@ -869,11 +869,45 @@ async function handleActivity(context: TurnContext): Promise<void> {
 
   // PreCompact channel auto-notify activity-index write — issue #597 Track C.
   // Best-effort; failures are logged inside the helper and never bubble up.
+  //
+  // Bot-self exclusion: only record inbound activity from a real user. Teams'
+  // Bot Framework can echo bot-authored messages back through the inbound
+  // pipeline (proactive sends from continueConversation, multi-bot crosstalk
+  // in shared channels). Recording those would point the daemon's
+  // route-precompact-target at the bot's own posts, breaking the "reply to
+  // the user who last spoke" contract. The most reliable Bot Framework signal
+  // is `from.role === 'bot'`; we also defense-in-depth against self-echo where
+  // `from.id` matches the bot's recipient id. See codex r1 review of #610.
   const agentForIndex = process.env.BRIDGE_AGENT_ID ?? ''
-  if (agentForIndex) {
+  if (agentForIndex && !isInboundFromBotOrSelf(activity)) {
     const inboundDate = activity.timestamp instanceof Date ? activity.timestamp : new Date()
     writeTeamsActivityIndex(agentForIndex, chatId, messageId, stored.user_id, inboundDate)
   }
+}
+
+/**
+ * True when an inbound activity is from a bot or a self-echo of the bot's own
+ * outbound message. Used to skip activity-index updates that would otherwise
+ * point the PreCompact route lookup at bot posts instead of the last user
+ * inbound.
+ *
+ * Signals (in order of reliability):
+ *   1. `from.role === 'bot'` — Bot Framework convention; emitted by Teams for
+ *      proactive sends and bot-to-bot messages.
+ *   2. `from.id === recipient.id` — self-echo: the bot is identified as both
+ *      the sender and the recipient on the same activity.
+ *   3. `from.id === APP_ID` — the bot's app id appears as the sender.
+ *
+ * Exported for the precompact-notify smoke harness.
+ */
+export function isInboundFromBotOrSelf(activity: Partial<Activity> & { from?: { id?: string; role?: string }; recipient?: { id?: string } }): boolean {
+  const from = activity.from
+  if (!from) return false
+  if (from.role === 'bot') return true
+  const recipientId = activity.recipient?.id ?? ''
+  if (from.id && recipientId && from.id === recipientId) return true
+  if (APP_ID && from.id && from.id === APP_ID) return true
+  return false
 }
 
 const httpServer = createServer((req, res) => {
@@ -991,6 +1025,49 @@ const CLI_SUBCOMMAND = (process.argv[2] ?? '').trim()
 if (CLI_SUBCOMMAND === 'send-managed') {
   const code = await runSendManagedCli()
   process.exit(code)
+}
+
+// Internal smoke harness — exercised only by tests/precompact-notify/teams-mattermost-adapter.sh.
+// `_smoke-record-activity` invokes writeTeamsActivityIndex directly so the
+// smoke can validate the activity-index file schema without spinning up a
+// full Bot Framework adapter. `_smoke-should-record` reports whether a
+// synthesized activity would be skipped by the bot-self filter. Both
+// short-circuit before httpServer.listen.
+if (CLI_SUBCOMMAND === '_smoke-record-activity' || CLI_SUBCOMMAND === '_smoke-should-record') {
+  const argv = process.argv.slice(3)
+  const flags: Record<string, string> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2)
+    const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : ''
+    if (value) i++
+    flags[key] = value
+  }
+  if (CLI_SUBCOMMAND === '_smoke-record-activity') {
+    const agent = String(flags['agent'] ?? '').trim()
+    const channelId = String(flags['channel-id'] ?? '').trim()
+    const messageId = String(flags['message-id'] ?? '').trim()
+    const userId = String(flags['user-id'] ?? '').trim()
+    const tsMs = Number(flags['ts-ms'] ?? Date.now())
+    if (!agent || !channelId || !messageId) {
+      process.stderr.write('teams _smoke-record-activity: --agent, --channel-id, --message-id required\n')
+      process.exit(2)
+    }
+    writeTeamsActivityIndex(agent, channelId, messageId, userId, new Date(tsMs))
+    process.exit(0)
+  }
+  // _smoke-should-record
+  const fromId = String(flags['from-id'] ?? '').trim()
+  const fromRole = String(flags['from-role'] ?? '').trim()
+  const recipientId = String(flags['recipient-id'] ?? '').trim()
+  const fakeActivity: any = {
+    from: { id: fromId, role: fromRole || undefined },
+    recipient: { id: recipientId },
+  }
+  const isBotOrSelf = isInboundFromBotOrSelf(fakeActivity)
+  process.stdout.write(JSON.stringify({ should_skip: isBotOrSelf }) + '\n')
+  process.exit(0)
 }
 
 httpServer.listen(PORT, HOST, () => {

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -83,6 +83,7 @@ type Ms365CallbackPayload = {
 
 const STATE_DIR = process.env.TEAMS_STATE_DIR ?? join(homedir(), '.claude', 'channels', 'teams')
 const BRIDGE_HOME = process.env.BRIDGE_HOME ?? join(homedir(), '.agent-bridge')
+const BRIDGE_STATE_DIR = process.env.BRIDGE_STATE_DIR ?? join(BRIDGE_HOME, 'state')
 const ACCESS_FILE = join(STATE_DIR, 'access.json')
 const ENV_FILE = join(STATE_DIR, '.env')
 const REFERENCES_FILE = join(STATE_DIR, 'conversations.json')
@@ -367,6 +368,113 @@ function storeReference(activity: Activity): void {
 function appendMessage(message: StoredMessage): void {
   ensureStateDir()
   appendFileSync(MESSAGES_FILE, JSON.stringify(message) + '\n', { mode: 0o600 })
+}
+
+// PreCompact channel auto-notify activity index — issue #597 Track C.
+//
+// Writes $BRIDGE_STATE_DIR/channels/teams/<agent>.json so the daemon's
+// route-precompact-target lookup can pick the most recent inbound chat
+// to notify on context compaction. Best-effort: any failure is logged and
+// swallowed so a state-dir glitch never breaks live message delivery.
+
+type TeamsActivityChannelEntry = {
+  channel_id: string
+  reply_kind: string
+  last_seen_id?: string
+  last_seen_ts?: number
+  last_user_inbound_ts: number
+  last_user_inbound_ts_ms: number
+  last_user_inbound_message_id: string
+  last_user_inbound_user_id: string
+  last_user_inbound_recorded_ns: number
+  thread_id?: string
+}
+
+type TeamsActivityIndex = {
+  schema_version: number
+  agent: string
+  plugin: 'teams'
+  updated_ts: number
+  channels: Record<string, TeamsActivityChannelEntry>
+}
+
+function sanitizeAgentForPath(raw: string): string {
+  // Activity-index files live at $BRIDGE_STATE_DIR/channels/teams/<agent>.json.
+  // The agent name comes from BRIDGE_AGENT_ID, but we still defense-in-depth
+  // against path traversal — same allowlist as bridge-agents.sh agent ids.
+  if (!raw || typeof raw !== 'string') return ''
+  if (raw.length > 64) return ''
+  if (!/^[a-zA-Z0-9_-]+$/.test(raw)) return ''
+  return raw
+}
+
+function teamsActivityIndexPath(agent: string): string {
+  return join(BRIDGE_STATE_DIR, 'channels', 'teams', `${agent}.json`)
+}
+
+function loadTeamsActivityIndex(path: string, agent: string): TeamsActivityIndex {
+  try {
+    const raw = readFileSync(path, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (parsed && typeof parsed === 'object' && parsed.channels && typeof parsed.channels === 'object') {
+      return parsed as TeamsActivityIndex
+    }
+  } catch {}
+  return {
+    schema_version: 1,
+    agent,
+    plugin: 'teams',
+    updated_ts: 0,
+    channels: {},
+  }
+}
+
+let teamsRecordedTail = 0
+
+function writeTeamsActivityIndex(
+  agent: string,
+  channelId: string,
+  messageId: string,
+  userId: string,
+  inboundDate: Date,
+): void {
+  const safeAgent = sanitizeAgentForPath(agent)
+  if (!safeAgent || !channelId || !messageId) return
+  try {
+    const path = teamsActivityIndexPath(safeAgent)
+    const dir = join(BRIDGE_STATE_DIR, 'channels', 'teams')
+    mkdirSync(dir, { recursive: true, mode: 0o700 })
+    const index = loadTeamsActivityIndex(path, safeAgent)
+    const tsMs = inboundDate.getTime()
+    const tsSec = Math.floor(tsMs / 1000)
+    // recorded_ns must be a JSON number (the route primitive int-coerces it).
+    // Real epoch nanoseconds (~1.7e18) exceed Number.MAX_SAFE_INTEGER, so we
+    // pack ms-precision into the upper digits and a per-process monotonic
+    // tail into the lower digits. The route primitive only consults this for
+    // tie-break ordering inside a 1-second window, so monotonicity within a
+    // process is the only invariant that matters.
+    const nowNs = tsMs * 1_000 + (teamsRecordedTail++ % 1_000)
+    index.schema_version = 1
+    index.agent = safeAgent
+    index.plugin = 'teams'
+    index.updated_ts = tsSec
+    index.channels[channelId] = {
+      channel_id: channelId,
+      reply_kind: 'conversation',
+      last_seen_id: messageId,
+      last_seen_ts: tsSec,
+      last_user_inbound_ts: tsSec,
+      last_user_inbound_ts_ms: tsMs,
+      last_user_inbound_message_id: messageId,
+      last_user_inbound_user_id: userId,
+      last_user_inbound_recorded_ns: nowNs,
+    }
+    const tmp = `${path}.tmp`
+    writeFileSync(tmp, JSON.stringify(index, null, 2) + '\n', { mode: 0o600 })
+    renameSync(tmp, path)
+  } catch (err) {
+    process.stderr.write(`teams channel: activity-index write failed: ${err}\n`)
+  }
 }
 
 function deliveredMessageSeen(chatId: string, messageId: string, revision: string): boolean {
@@ -758,6 +866,14 @@ async function handleActivity(context: TurnContext): Promise<void> {
   } catch (err) {
     process.stderr.write(`teams channel: failed to append local log message_id=${messageId} (delivery already succeeded): ${err}\n`)
   }
+
+  // PreCompact channel auto-notify activity-index write — issue #597 Track C.
+  // Best-effort; failures are logged inside the helper and never bubble up.
+  const agentForIndex = process.env.BRIDGE_AGENT_ID ?? ''
+  if (agentForIndex) {
+    const inboundDate = activity.timestamp instanceof Date ? activity.timestamp : new Date()
+    writeTeamsActivityIndex(agentForIndex, chatId, messageId, stored.user_id, inboundDate)
+  }
 }
 
 const httpServer = createServer((req, res) => {
@@ -792,6 +908,90 @@ httpServer.on('error', err => {
   process.stderr.write(`teams channel: http listen failed on ${HOST}:${PORT}: ${err}\n`)
   process.exit(1)
 })
+
+// CLI mode: `node server.js send-managed --agent ... --channel-id ...`.
+// Used by the daemon's send-managed-message wrapper for PreCompact notify
+// (issue #597). Short-circuits the daemon HTTP/WS startup so a one-shot
+// outbound reply never spins up the inbound listener path.
+async function runSendManagedCli(): Promise<number> {
+  const argv = process.argv.slice(3)
+  const flags: Record<string, string> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2)
+    const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : ''
+    if (value) i++
+    flags[key] = value
+  }
+  const channelId = String(flags['channel-id'] ?? '').trim()
+  const replyToMessageId = String(flags['reply-to-message-id'] ?? '').trim()
+  const body = String(flags['body'] ?? '')
+  const agent = String(flags['agent'] ?? '').trim()
+  if (!channelId || !body) {
+    process.stderr.write('teams send-managed: --channel-id and --body are required\n')
+    return 2
+  }
+  // Surface the agent id to runPromptGuard via env so the guard line uses
+  // the same agent the daemon claims to be sending on behalf of.
+  if (agent && !process.env.BRIDGE_AGENT_ID) {
+    process.env.BRIDGE_AGENT_ID = agent
+  }
+
+  let sanitizedBody = body
+  const guarded = runPromptGuard('sanitize', body)
+  if (guarded?.blocked) {
+    sanitizedBody = '[Agent Bridge] outbound reply blocked by prompt guard.'
+  } else if (guarded?.was_modified && typeof guarded.sanitized_text === 'string') {
+    sanitizedBody = guarded.sanitized_text
+  }
+
+  const refs = loadJson<Record<string, ConversationReference>>(REFERENCES_FILE, {})
+  const ref = refs[channelId]
+  if (!ref) {
+    process.stderr.write(
+      `teams send-managed: conversation reference not found for ${channelId}; ` +
+      `wait for an inbound Teams message first\n`,
+    )
+    return 3
+  }
+
+  let sentId = ''
+  try {
+    await adapter.continueConversation(ref, async context => {
+      const sent = await context.sendActivity(sanitizedBody)
+      if (sent && typeof sent === 'object' && 'id' in sent && typeof sent.id === 'string') {
+        sentId = sent.id
+      }
+    })
+  } catch (err) {
+    process.stderr.write(`teams send-managed: send failed: ${err}\n`)
+    return 1
+  }
+
+  // Q3: Teams' continueConversation posts into the same conversation, but
+  // Bot Framework does not surface true per-message threading at this API
+  // level — there is no replyToId parameter on sendActivity that maps to a
+  // user message id. The output marks best_effort_threading=true so the
+  // daemon can audit the limitation per the orchestrator's Track C spec.
+  const out = {
+    status: 'sent',
+    plugin: 'teams',
+    channel_id: channelId,
+    message_id: sentId || '',
+    thread_id: replyToMessageId || null,
+    best_effort_threading: true,
+  }
+  process.stdout.write(JSON.stringify(out) + '\n')
+  return 0
+}
+
+const CLI_SUBCOMMAND = (process.argv[2] ?? '').trim()
+
+if (CLI_SUBCOMMAND === 'send-managed') {
+  const code = await runSendManagedCli()
+  process.exit(code)
+}
 
 httpServer.listen(PORT, HOST, () => {
   process.stderr.write(`teams channel: listening on http://${HOST}:${PORT} (/api/messages, /auth/callback)\n`)

--- a/tests/precompact-notify/teams-mattermost-adapter.sh
+++ b/tests/precompact-notify/teams-mattermost-adapter.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# precompact-notify Teams + Mattermost adapter smoke — issue #597 Track C.
+#
+# Exercises the new managed-send CLI mode and the activity-index writer
+# wiring added to plugins/teams/server.ts and plugins/mattermost/server.ts.
+#
+# Cases:
+#
+#   T1  bun build of plugins/teams/server.ts succeeds with the new code
+#       -> compile gate; ensures activity-index helpers + send-managed CLI
+#          parse and bundle.
+#   T2  bun build of plugins/mattermost/server.ts succeeds with the new code.
+#   T3  Teams `send-managed --channel-id ... --body ...` short-circuits
+#       before HTTP listen; emits the contracted error path when the
+#       conversation reference for the requested channel is missing.
+#       (Real network sends require Azure Bot Service credentials and an
+#        inbound conversation reference — out of scope for CI smoke.)
+#   T4  Teams `send-managed` rejects empty --channel-id with exit 2 and
+#       stderr message; no JSON on stdout.
+#   T5  Mattermost `send-managed` exit 2 + stderr when MATTERMOST_BOT_TOKEN
+#       is unset; the CLI dispatcher must require credentials before any
+#       outbound API call.
+#   T6  Mattermost `send-managed` rejects empty --channel-id with exit 2.
+#
+# What this smoke does NOT cover (limitations):
+#
+#   - End-to-end inbound → activity-index write. The Teams + Mattermost
+#     inbound paths require real Bot Framework / WebSocket payloads that
+#     the standalone smoke cannot synthesize without spinning up an
+#     authenticated bot session. Track A's route-primitive smoke covers
+#     the consumer side; the writer-on-inbound path is verified by the
+#     daemon-level integration smoke that Track D is wiring in once the
+#     Track B observer lands.
+#   - Real network sends from send-managed. We assert exit codes + stderr
+#     contracts the daemon depends on, but we do NOT exercise
+#     adapter.continueConversation or POST /api/v4/posts against real
+#     endpoints — those require credentials and live tenants.
+#
+# This fixture is standalone; Track D registers it in scripts/smoke-test.sh
+# alongside the other PreCompact notify smokes once all writer/observer
+# pieces are in place.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+TEAMS_DIR="$REPO_ROOT/plugins/teams"
+MATTERMOST_DIR="$REPO_ROOT/plugins/mattermost"
+
+if ! command -v bun >/dev/null 2>&1; then
+  printf '[smoke][skip] bun not found on PATH; install bun to run this smoke\n' >&2
+  exit 0
+fi
+
+ROOT="$(mktemp -d -t precompact-tm-adapter.XXXXXX)"
+trap 'rm -rf "$ROOT"' EXIT
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+  if [[ -n "${2:-}" ]]; then
+    printf '%s\n' "$2" >&2
+  fi
+}
+
+ensure_teams_deps() {
+  if [[ ! -d "$TEAMS_DIR/node_modules/@modelcontextprotocol/sdk" ]]; then
+    (cd "$TEAMS_DIR" && bun install --frozen-lockfile >/dev/null 2>&1) || return 1
+  fi
+  return 0
+}
+
+ensure_mattermost_deps() {
+  if [[ ! -d "$MATTERMOST_DIR/node_modules/@modelcontextprotocol/sdk" ]]; then
+    (cd "$MATTERMOST_DIR" && bun install --frozen-lockfile >/dev/null 2>&1) || return 1
+  fi
+  return 0
+}
+
+# ---------- T1: teams plugin builds ---------------------------------------
+t1_teams_build() {
+  local case="T1 teams plugin builds with activity-index + send-managed CLI"
+  if ! ensure_teams_deps; then
+    fail "$case" "bun install failed for plugins/teams"
+    return
+  fi
+  local outfile="$ROOT/teams.bundle.js"
+  local errfile="$ROOT/teams.bundle.err"
+  if ! (cd "$TEAMS_DIR" && bun build server.ts --target=bun --outfile "$outfile" >/dev/null 2>"$errfile"); then
+    fail "$case" "bun build failed: $(cat "$errfile")"
+    return
+  fi
+  if [[ ! -s "$outfile" ]]; then
+    fail "$case" "bun build produced empty bundle"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T2: mattermost plugin builds -----------------------------------
+t2_mattermost_build() {
+  local case="T2 mattermost plugin builds with activity-index + send-managed CLI"
+  if ! ensure_mattermost_deps; then
+    fail "$case" "bun install failed for plugins/mattermost"
+    return
+  fi
+  local outfile="$ROOT/mattermost.bundle.js"
+  local errfile="$ROOT/mattermost.bundle.err"
+  if ! (cd "$MATTERMOST_DIR" && bun build server.ts --target=bun --outfile "$outfile" >/dev/null 2>"$errfile"); then
+    fail "$case" "bun build failed: $(cat "$errfile")"
+    return
+  fi
+  if [[ ! -s "$outfile" ]]; then
+    fail "$case" "bun build produced empty bundle"
+    return
+  fi
+  pass "$case"
+}
+
+setup_teams_env() {
+  # Populate the minimum env the Teams plugin requires before it parses the
+  # CLI subcommand. APP_ID/APP_PASSWORD are validated at module top — without
+  # them the plugin process.exit(1)'s before our CLI dispatcher runs.
+  local fake_state="$1"
+  mkdir -p "$fake_state"
+  printf 'TEAMS_APP_ID=smoke-fake-id\nTEAMS_APP_PASSWORD=smoke-fake-pw\n' >"$fake_state/.env"
+}
+
+# ---------- T3: Teams send-managed without conversation reference ----------
+t3_teams_send_no_reference() {
+  local case="T3 teams send-managed exits 3 + stderr when no conversation reference"
+  ensure_teams_deps || { fail "$case" "bun install failed"; return; }
+  local fake_state="$ROOT/t3-teams"
+  setup_teams_env "$fake_state"
+  local outfile="$ROOT/t3.out"
+  local errfile="$ROOT/t3.err"
+  set +e
+  TEAMS_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$ROOT/t3-bridge-home" \
+    BRIDGE_STATE_DIR="$ROOT/t3-bridge-home/state" \
+    bun "$TEAMS_DIR/server.ts" send-managed \
+      --agent smoke-agent \
+      --channel-id 'C-FAKE-1' \
+      --reply-to-message-id 'M-FAKE-1' \
+      --body 'precompact heads-up smoke' \
+      --kind notice \
+      >"$outfile" 2>"$errfile"
+  local exit=$?
+  set -e
+  if [[ "$exit" -ne 3 ]]; then
+    fail "$case" "expected exit 3 (no reference); got $exit; stderr: $(cat "$errfile")"
+    return
+  fi
+  if ! grep -qF 'conversation reference not found' "$errfile"; then
+    fail "$case" "expected stderr about missing conversation reference; got: $(cat "$errfile")"
+    return
+  fi
+  if [[ -s "$outfile" ]]; then
+    fail "$case" "expected empty stdout on send failure; got: $(cat "$outfile")"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T4: Teams send-managed missing args ----------------------------
+t4_teams_send_missing_args() {
+  local case="T4 teams send-managed rejects missing --channel-id with exit 2"
+  ensure_teams_deps || { fail "$case" "bun install failed"; return; }
+  local fake_state="$ROOT/t4-teams"
+  setup_teams_env "$fake_state"
+  local outfile="$ROOT/t4.out"
+  local errfile="$ROOT/t4.err"
+  set +e
+  TEAMS_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$ROOT/t4-bridge-home" \
+    BRIDGE_STATE_DIR="$ROOT/t4-bridge-home/state" \
+    bun "$TEAMS_DIR/server.ts" send-managed \
+      --agent smoke-agent \
+      --body 'oops no channel id' \
+      >"$outfile" 2>"$errfile"
+  local exit=$?
+  set -e
+  if [[ "$exit" -ne 2 ]]; then
+    fail "$case" "expected exit 2 (missing args); got $exit"
+    return
+  fi
+  if ! grep -qF -- '--channel-id and --body are required' "$errfile"; then
+    fail "$case" "expected stderr about required args; got: $(cat "$errfile")"
+    return
+  fi
+  pass "$case"
+}
+
+setup_mattermost_env() {
+  local fake_state="$1"
+  local with_token="${2:-1}"
+  mkdir -p "$fake_state"
+  if [[ "$with_token" == "1" ]]; then
+    printf 'MATTERMOST_BOT_TOKEN=smoke-fake-token\nMATTERMOST_URL=http://127.0.0.1:18065\n' \
+      >"$fake_state/.env"
+  else
+    : >"$fake_state/.env"
+  fi
+}
+
+# ---------- T5: Mattermost send-managed without bot token ------------------
+t5_mattermost_send_no_token() {
+  local case="T5 mattermost send-managed exits 2 when MATTERMOST_BOT_TOKEN unset"
+  ensure_mattermost_deps || { fail "$case" "bun install failed"; return; }
+  local fake_state="$ROOT/t5-mm"
+  # The bare module top-level requires MATTERMOST_BOT_TOKEN OR
+  # MATTERMOST_BOT_ROUTES — without either, server.ts process.exit(1)'s
+  # before our CLI dispatcher runs. Smoke covers the case where the env
+  # provides a token at top-level but the daemon-level send still fails to
+  # acquire it (defense-in-depth check inside runSendManagedCli).
+  setup_mattermost_env "$fake_state" 1
+  local outfile="$ROOT/t5.out"
+  local errfile="$ROOT/t5.err"
+  set +e
+  # Explicitly clear MATTERMOST_BOT_TOKEN so the in-process dispatcher
+  # check fires (the `.env` file still loads MM_URL but skips token).
+  rm -f "$fake_state/.env"
+  printf 'MATTERMOST_URL=http://127.0.0.1:18065\n' >"$fake_state/.env"
+  MATTERMOST_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$ROOT/t5-bridge-home" \
+    BRIDGE_STATE_DIR="$ROOT/t5-bridge-home/state" \
+    bun "$MATTERMOST_DIR/server.ts" send-managed \
+      --agent smoke-agent \
+      --channel-id 'C-MM-1' \
+      --reply-to-message-id 'P-MM-1' \
+      --body 'precompact heads-up smoke' \
+      --kind notice \
+      >"$outfile" 2>"$errfile"
+  local exit=$?
+  set -e
+  # The module-level "MATTERMOST_BOT_TOKEN or MATTERMOST_BOT_ROUTES required"
+  # check fires first (exit 1) — that's also a valid contract, since either
+  # path means the daemon cannot send without operator setup. Accept either
+  # exit 1 (module-level) or exit 2 (CLI-dispatcher-level) and assert the
+  # stderr surfaces the "token required" message rather than crashing.
+  if [[ "$exit" -ne 1 && "$exit" -ne 2 ]]; then
+    fail "$case" "expected exit 1 or 2; got $exit; stderr: $(cat "$errfile")"
+    return
+  fi
+  if ! grep -qE 'BOT_TOKEN|BOT_ROUTES' "$errfile"; then
+    fail "$case" "expected stderr about missing token; got: $(cat "$errfile")"
+    return
+  fi
+  if [[ -s "$outfile" ]]; then
+    fail "$case" "expected empty stdout on credential failure; got: $(cat "$outfile")"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T6: Mattermost send-managed missing args -----------------------
+t6_mattermost_send_missing_args() {
+  local case="T6 mattermost send-managed rejects missing --channel-id with exit 2"
+  ensure_mattermost_deps || { fail "$case" "bun install failed"; return; }
+  local fake_state="$ROOT/t6-mm"
+  setup_mattermost_env "$fake_state" 1
+  local outfile="$ROOT/t6.out"
+  local errfile="$ROOT/t6.err"
+  set +e
+  MATTERMOST_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$ROOT/t6-bridge-home" \
+    BRIDGE_STATE_DIR="$ROOT/t6-bridge-home/state" \
+    bun "$MATTERMOST_DIR/server.ts" send-managed \
+      --agent smoke-agent \
+      --body 'oops no channel id' \
+      >"$outfile" 2>"$errfile"
+  local exit=$?
+  set -e
+  if [[ "$exit" -ne 2 ]]; then
+    fail "$case" "expected exit 2 (missing args); got $exit; stderr: $(cat "$errfile")"
+    return
+  fi
+  if ! grep -qF -- '--channel-id and --body are required' "$errfile"; then
+    fail "$case" "expected stderr about required args; got: $(cat "$errfile")"
+    return
+  fi
+  pass "$case"
+}
+
+t1_teams_build
+t2_mattermost_build
+t3_teams_send_no_reference
+t4_teams_send_missing_args
+t5_mattermost_send_no_token
+t6_mattermost_send_missing_args
+
+printf '\n[smoke] result: pass=%d fail=%d\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+  for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f" >&2; done
+  exit 1
+fi
+exit 0

--- a/tests/precompact-notify/teams-mattermost-adapter.sh
+++ b/tests/precompact-notify/teams-mattermost-adapter.sh
@@ -21,20 +21,35 @@
 #       is unset; the CLI dispatcher must require credentials before any
 #       outbound API call.
 #   T6  Mattermost `send-managed` rejects empty --channel-id with exit 2.
+#   T7  Teams successful send-managed JSON shape — SKIPPED with documented
+#       reason; see t7_teams_send_success below.
+#   T8  Mattermost successful send-managed JSON shape against a mocked
+#       Mattermost API (Bun fetch listener stands in for /api/v4/posts).
+#       Asserts the contracted CLI JSON output and that the per-agent
+#       route token (MATTERMOST_BOT_ROUTES) overrides MM_TOKEN when an
+#       agent has a configured route — codex r1 PR #610 finding.
+#   T9  Activity-index writer schema — invokes the internal
+#       `_smoke-record-activity` subcommand and validates the produced
+#       state/channels/teams/<agent>.json shape (schema_version=1, plugin,
+#       channels.<id>.last_user_inbound_*, recorded_ns int).
+#   T10 Bot-self echo skipped — invokes `_smoke-should-record` with a
+#       synthesized activity where from.role='bot' and verifies the
+#       isInboundFromBotOrSelf gate reports should_skip=true so the
+#       activity-index writer would not be called. Mirrors the inbound-
+#       handler check added in handleActivity for codex r1 PR #610.
 #
 # What this smoke does NOT cover (limitations):
 #
-#   - End-to-end inbound → activity-index write. The Teams + Mattermost
-#     inbound paths require real Bot Framework / WebSocket payloads that
-#     the standalone smoke cannot synthesize without spinning up an
-#     authenticated bot session. Track A's route-primitive smoke covers
-#     the consumer side; the writer-on-inbound path is verified by the
-#     daemon-level integration smoke that Track D is wiring in once the
-#     Track B observer lands.
-#   - Real network sends from send-managed. We assert exit codes + stderr
-#     contracts the daemon depends on, but we do NOT exercise
-#     adapter.continueConversation or POST /api/v4/posts against real
-#     endpoints — those require credentials and live tenants.
+#   - End-to-end inbound → activity-index write through the full Bot
+#     Framework / Mattermost WebSocket pipeline. The inbound paths require
+#     real Bot Framework / WS payloads that the standalone smoke cannot
+#     synthesize without spinning up an authenticated bot session. T9/T10
+#     directly exercise the writer + bot-self filter as unit-style checks;
+#     end-to-end coverage is delegated to the daemon-level integration
+#     smoke once Track B observer + Track D writer are both in place.
+#   - Real network sends from Teams send-managed. T7 documents why; the
+#     Bot Framework adapter requires an MS auth round-trip that cannot be
+#     mocked at this layer without forking botbuilder.
 #
 # This fixture is standalone; Track D registers it in scripts/smoke-test.sh
 # alongside the other PreCompact notify smokes once all writer/observer
@@ -291,12 +306,307 @@ t6_mattermost_send_missing_args() {
   pass "$case"
 }
 
+# ---------- T7: Teams successful send-managed JSON shape (skipped) --------
+t7_teams_send_success() {
+  local case="T7 teams send-managed successful JSON shape (skipped)"
+  # The Bot Framework adapter's continueConversation path requires a real
+  # MS authentication round-trip (token endpoint + JWT issuance) before any
+  # outbound Activity is dispatched, and the SDK does not expose a seam for
+  # mocking the auth provider without forking botbuilder. T3 already covers
+  # the contract that send-managed exits cleanly when the conversation
+  # reference is missing; the success-path JSON shape is identical to
+  # Mattermost's, asserted by T8 below, modulo plugin name and
+  # best_effort_threading=true. Documented per codex r1 PR #610 review.
+  printf '[smoke][skip] %s — see comment for rationale\n' "$case"
+}
+
+# ---------- T8: Mattermost successful send-managed JSON shape (mocked) ----
+t8_mattermost_send_success() {
+  local case="T8 mattermost send-managed successful JSON shape against mocked API"
+  ensure_mattermost_deps || { fail "$case" "bun install failed"; return; }
+  local fake_state="$ROOT/t8-mm"
+  local fake_state_local="$ROOT/t8-mm/state"
+  local mock_log="$ROOT/t8-mock.log"
+  local mock_port_file="$ROOT/t8-mock.port"
+  local mock_pid_file="$ROOT/t8-mock.pid"
+  local mock_script="$ROOT/t8-mock.ts"
+  local routes_file="$ROOT/t8-routes.json"
+  local outfile="$ROOT/t8.out"
+  local errfile="$ROOT/t8.err"
+  mkdir -p "$fake_state_local"
+  cat >"$mock_script" <<'EOF_MOCK'
+import { serve } from 'bun'
+const fs = require('fs')
+const logFile = process.env.MOCK_LOG_FILE
+const server = serve({
+  port: 0,
+  async fetch(req: Request) {
+    const url = new URL(req.url)
+    if (req.method === 'POST' && url.pathname === '/api/v4/posts') {
+      const body = await req.json() as any
+      const auth = req.headers.get('authorization') ?? ''
+      if (logFile) fs.appendFileSync(logFile, JSON.stringify({ auth, body }) + '\n')
+      const fakePost = {
+        id: 'post-fake-001',
+        create_at: Date.now(),
+        channel_id: body.channel_id,
+        message: body.message,
+        root_id: body.root_id ?? '',
+      }
+      return new Response(JSON.stringify(fakePost), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return new Response('not found', { status: 404 })
+  },
+})
+console.log(server.port)
+EOF_MOCK
+  : >"$mock_log"
+  MOCK_LOG_FILE="$mock_log" bun "$mock_script" >"$mock_port_file" 2>"$errfile" &
+  local pid=$!
+  echo "$pid" >"$mock_pid_file"
+  # Give Bun a moment to bind the random port.
+  local tries=0
+  local mock_port=""
+  while [[ $tries -lt 20 ]]; do
+    if [[ -s "$mock_port_file" ]]; then
+      mock_port="$(tr -d '\n\r ' <"$mock_port_file" | tail -c 16)"
+      [[ -n "$mock_port" ]] && break
+    fi
+    sleep 0.1
+    tries=$((tries + 1))
+  done
+  if [[ -z "$mock_port" ]]; then
+    kill "$pid" 2>/dev/null || true
+    fail "$case" "mock server failed to bind a port; stderr: $(cat "$errfile" 2>/dev/null)"
+    return
+  fi
+
+  # Per-agent route token: send as agent_b → expect Bearer route-token-BBB,
+  # not the global MM_TOKEN.
+  cat >"$routes_file" <<EOF_ROUTES
+[
+  {"username":"agent-b-bot","token":"route-token-BBB","agent":"agent_b","system_prompt":""}
+]
+EOF_ROUTES
+  cat >"$fake_state/.env" <<EOF_ENV
+MATTERMOST_BOT_TOKEN=smoke-token-global
+MATTERMOST_URL=http://127.0.0.1:$mock_port
+EOF_ENV
+
+  set +e
+  MATTERMOST_BOT_ROUTES="$routes_file" \
+    MATTERMOST_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$ROOT/t8-bridge-home" \
+    BRIDGE_STATE_DIR="$ROOT/t8-bridge-home/state" \
+    bun "$MATTERMOST_DIR/server.ts" send-managed \
+      --agent agent_b \
+      --channel-id 'C-MM-1' \
+      --reply-to-message-id 'P-ROOT-1' \
+      --body 'precompact heads-up smoke' \
+      --kind notice \
+      >"$outfile" 2>"$errfile"
+  local exit=$?
+  set -e
+  kill "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+
+  if [[ "$exit" -ne 0 ]]; then
+    fail "$case" "expected exit 0; got $exit; stderr: $(cat "$errfile" 2>/dev/null)"
+    return
+  fi
+  # Validate JSON shape.
+  if ! grep -qF '"status":"sent"' "$outfile"; then
+    fail "$case" "expected status=sent; got: $(cat "$outfile")"
+    return
+  fi
+  if ! grep -qF '"plugin":"mattermost"' "$outfile"; then
+    fail "$case" "expected plugin=mattermost; got: $(cat "$outfile")"
+    return
+  fi
+  if ! grep -qF '"channel_id":"C-MM-1"' "$outfile"; then
+    fail "$case" "expected channel_id=C-MM-1; got: $(cat "$outfile")"
+    return
+  fi
+  if ! grep -qF '"message_id":"post-fake-001"' "$outfile"; then
+    fail "$case" "expected message_id=post-fake-001; got: $(cat "$outfile")"
+    return
+  fi
+  if ! grep -qF '"thread_id":"P-ROOT-1"' "$outfile"; then
+    fail "$case" "expected thread_id=P-ROOT-1; got: $(cat "$outfile")"
+    return
+  fi
+  if ! grep -qF '"best_effort_threading":false' "$outfile"; then
+    fail "$case" "expected best_effort_threading=false; got: $(cat "$outfile")"
+    return
+  fi
+  # Verify the per-agent route token won (codex r1 PR #610 finding r2.2).
+  if ! grep -qF '"auth":"Bearer route-token-BBB"' "$mock_log"; then
+    fail "$case" "expected per-agent route token in auth header; mock log: $(cat "$mock_log")"
+    return
+  fi
+  if grep -qF 'smoke-token-global' "$mock_log"; then
+    fail "$case" "global MM_TOKEN leaked into auth header instead of route token; mock log: $(cat "$mock_log")"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T9: Activity-index writer schema (mocked inbound) -------------
+t9_teams_writer_schema() {
+  local case="T9 teams activity-index writer schema (record-activity harness)"
+  ensure_teams_deps || { fail "$case" "bun install failed"; return; }
+  local fake_state="$ROOT/t9-teams"
+  local bridge_home="$ROOT/t9-bridge-home"
+  setup_teams_env "$fake_state"
+  local outfile="$ROOT/t9.out"
+  local errfile="$ROOT/t9.err"
+  set +e
+  TEAMS_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$bridge_home" \
+    BRIDGE_STATE_DIR="$bridge_home/state" \
+    bun "$TEAMS_DIR/server.ts" _smoke-record-activity \
+      --agent t9-agent \
+      --channel-id 'CHAN-T9' \
+      --message-id 'MSG-T9' \
+      --user-id 'USER-T9' \
+      --ts-ms 1700000000000 \
+      >"$outfile" 2>"$errfile"
+  local exit=$?
+  set -e
+  if [[ "$exit" -ne 0 ]]; then
+    fail "$case" "expected exit 0; got $exit; stderr: $(cat "$errfile")"
+    return
+  fi
+  local index_path="$bridge_home/state/channels/teams/t9-agent.json"
+  if [[ ! -s "$index_path" ]]; then
+    fail "$case" "expected activity-index file at $index_path; not found"
+    return
+  fi
+  # Top-level schema fields.
+  if ! grep -qF '"schema_version": 1' "$index_path"; then
+    fail "$case" "expected schema_version=1; got: $(cat "$index_path")"
+    return
+  fi
+  if ! grep -qF '"plugin": "teams"' "$index_path"; then
+    fail "$case" "expected plugin=teams; got: $(cat "$index_path")"
+    return
+  fi
+  if ! grep -qF '"agent": "t9-agent"' "$index_path"; then
+    fail "$case" "expected agent=t9-agent; got: $(cat "$index_path")"
+    return
+  fi
+  if ! grep -qF '"updated_ts": 1700000000' "$index_path"; then
+    fail "$case" "expected updated_ts=1700000000; got: $(cat "$index_path")"
+    return
+  fi
+  # Per-channel writer fields (the route primitive consumes these).
+  if ! grep -qF '"last_user_inbound_message_id": "MSG-T9"' "$index_path"; then
+    fail "$case" "expected last_user_inbound_message_id=MSG-T9; got: $(cat "$index_path")"
+    return
+  fi
+  if ! grep -qF '"last_user_inbound_user_id": "USER-T9"' "$index_path"; then
+    fail "$case" "expected last_user_inbound_user_id=USER-T9; got: $(cat "$index_path")"
+    return
+  fi
+  if ! grep -qF '"last_user_inbound_ts": 1700000000' "$index_path"; then
+    fail "$case" "expected last_user_inbound_ts=1700000000; got: $(cat "$index_path")"
+    return
+  fi
+  if ! grep -qF '"last_user_inbound_ts_ms": 1700000000000' "$index_path"; then
+    fail "$case" "expected last_user_inbound_ts_ms=1700000000000; got: $(cat "$index_path")"
+    return
+  fi
+  if ! grep -qE '"last_user_inbound_recorded_ns": [0-9]+' "$index_path"; then
+    fail "$case" "expected last_user_inbound_recorded_ns numeric; got: $(cat "$index_path")"
+    return
+  fi
+  pass "$case"
+}
+
+# ---------- T10: Bot-self echo skipped (mocked inbound from bot) ----------
+t10_teams_bot_self_skipped() {
+  local case="T10 teams bot-self filter — should-record returns skip=true for from.role=bot"
+  ensure_teams_deps || { fail "$case" "bun install failed"; return; }
+  local fake_state="$ROOT/t10-teams"
+  local bridge_home="$ROOT/t10-bridge-home"
+  setup_teams_env "$fake_state"
+  local outfile="$ROOT/t10.out"
+  local errfile="$ROOT/t10.err"
+  # Case A: from.role='bot' → should_skip=true.
+  set +e
+  TEAMS_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$bridge_home" \
+    BRIDGE_STATE_DIR="$bridge_home/state" \
+    bun "$TEAMS_DIR/server.ts" _smoke-should-record \
+      --from-id '28:bot-id' \
+      --from-role bot \
+      --recipient-id '29:user-id' \
+      >"$outfile" 2>"$errfile"
+  local exit=$?
+  set -e
+  if [[ "$exit" -ne 0 ]]; then
+    fail "$case" "expected exit 0; got $exit; stderr: $(cat "$errfile")"
+    return
+  fi
+  if ! grep -qF '"should_skip":true' "$outfile"; then
+    fail "$case" "expected should_skip=true for role=bot; got: $(cat "$outfile")"
+    return
+  fi
+  # Case B: from.role='user' → should_skip=false (user inbound is recorded).
+  set +e
+  TEAMS_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$bridge_home" \
+    BRIDGE_STATE_DIR="$bridge_home/state" \
+    bun "$TEAMS_DIR/server.ts" _smoke-should-record \
+      --from-id '29:user-id' \
+      --from-role user \
+      --recipient-id '28:bot-id' \
+      >"$outfile" 2>"$errfile"
+  exit=$?
+  if [[ "$exit" -ne 0 ]]; then
+    fail "$case" "expected exit 0 (user case); got $exit; stderr: $(cat "$errfile")"
+    return
+  fi
+  set -e
+  if ! grep -qF '"should_skip":false' "$outfile"; then
+    fail "$case" "expected should_skip=false for role=user; got: $(cat "$outfile")"
+    return
+  fi
+  # Case C: from.id == recipient.id self-echo → should_skip=true.
+  set +e
+  TEAMS_STATE_DIR="$fake_state" \
+    BRIDGE_HOME="$bridge_home" \
+    BRIDGE_STATE_DIR="$bridge_home/state" \
+    bun "$TEAMS_DIR/server.ts" _smoke-should-record \
+      --from-id '28:bot-id' \
+      --recipient-id '28:bot-id' \
+      >"$outfile" 2>"$errfile"
+  exit=$?
+  set -e
+  if [[ "$exit" -ne 0 ]]; then
+    fail "$case" "expected exit 0 (self-echo case); got $exit; stderr: $(cat "$errfile")"
+    return
+  fi
+  if ! grep -qF '"should_skip":true' "$outfile"; then
+    fail "$case" "expected should_skip=true for self-echo; got: $(cat "$outfile")"
+    return
+  fi
+  pass "$case"
+}
+
 t1_teams_build
 t2_mattermost_build
 t3_teams_send_no_reference
 t4_teams_send_missing_args
 t5_mattermost_send_no_token
 t6_mattermost_send_missing_args
+t7_teams_send_success
+t8_mattermost_send_success
+t9_teams_writer_schema
+t10_teams_bot_self_skipped
 
 printf '\n[smoke] result: pass=%d fail=%d\n' "$PASS" "$FAIL"
 if [[ "$FAIL" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Track C of issue #597 (PreCompact channel auto-notify). Wires the activity-index writer + `send-managed` CLI subcommand into `plugins/teams/server.ts` and `plugins/mattermost/server.ts`.

- Each plugin writes a normalized activity index at `\$BRIDGE_STATE_DIR/channels/<plugin>/<agent>.json` on every accepted inbound message — same schema Track A's `route-precompact-target` consumer reads (#601 / 86282e4).
- New CLI subcommand `bun server.ts send-managed --agent ... --channel-id ... --reply-to-message-id ... --body ... --kind notice|followup` short-circuits the daemon HTTP/WS startup so a one-shot outbound reply never spins up the inbound listener path. Track B's `bridge-channels.py send-managed-message` will shell out here.
- Mattermost threading: `mmCreatePost` gains an optional `rootId` parameter so managed sends thread under the original inbound post via Mattermost's native `root_id` API.
- Q3 commitment honored: Teams threading is **best-effort** — Bot Framework's `continueConversation` has no per-message threading hook at this API level. The CLI returns `best_effort_threading=true` and the reply lands in the conversation; the orchestrator audits the limitation rather than failing the send.

CLI output JSON shape (per spec):

\`\`\`json
{"status":"sent","plugin":"teams|mattermost","channel_id":"...","message_id":"...","thread_id":"...|null","best_effort_threading":bool}
\`\`\`

`refs #597`

## Out of scope (Track C)

- Daemon observer (Track B)
- Send primitive shell wrapper / template rendering (Track B)
- Discord/Telegram relay activity-index writer (Track D)
- Top-level smoke registration (Track D)

## Test plan

- [x] `bun build plugins/teams/server.ts --target=bun` — bundles cleanly (4.16 MB)
- [x] `bun build plugins/mattermost/server.ts --target=bun` — bundles cleanly (0.51 MB)
- [x] `bash tests/precompact-notify/teams-mattermost-adapter.sh` — 6/6 pass
  - T1: teams plugin builds with new CLI + writer
  - T2: mattermost plugin builds with new CLI + writer
  - T3: `teams send-managed` exits 3 + stderr when no conversation reference (the CLI does not blow past the reference check into a network call)
  - T4: `teams send-managed` rejects missing `--channel-id` with exit 2
  - T5: `mattermost send-managed` exits with token-required stderr when credentials are missing
  - T6: `mattermost send-managed` rejects missing `--channel-id` with exit 2
- [x] Track A `tests/precompact-notify/route-primitive.sh` — 6/6 pass (no regression in the consumer-side primitive)
- [x] Existing `scripts/smoke/mattermost-plugin.sh` — pass (build + setup unchanged)
- [x] Existing `scripts/smoke/channel-plugins.sh` — pass

## Limitations documented in the smoke

- End-to-end inbound → activity-index write requires synthesizing real Bot Framework / Mattermost WebSocket payloads with bot credentials; out of scope for the standalone smoke. The daemon-level integration smoke that Track D registers once Track B's observer lands will exercise this end-to-end.
- Real network sends from `send-managed` are not exercised (they need live tenants); the smoke asserts the exit-code + stderr contracts the daemon depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)