### PR TITLE
feat(precompact): daemon observer + send primitive (Track B of #597)

### DIFF
--- a/agent-roster.local.example.sh
+++ b/agent-roster.local.example.sh
@@ -142,6 +142,30 @@ BRIDGE_AGENT_ACTION["developer:clear"]="/clear"
 # BRIDGE_HEALTH_WARN_SECONDS=3600
 # BRIDGE_HEALTH_CRITICAL_SECONDS=14400
 
+# Issue #597 Track B: PreCompact channel auto-notify (Claude /compact only).
+#
+# When Claude Code starts an auto-compact on a static, channel-bound agent,
+# the daemon can post a "I'm compacting now, back in ~Ns" message in the
+# most recently active bound channel and a "back online" follow-up once the
+# session returns. Default is OFF for every agent — opt in here.
+#
+# Eligibility requires ALL of:
+#   - BRIDGE_AGENT_PRECOMPACT_NOTIFY[<agent>]="1"
+#   - agent is engine=claude AND source=static (declared in this file)
+#   - BRIDGE_AGENT_CHANNELS[<agent>] resolves to >=1 plugin channel
+#   - the trigger is "auto" (operator /compact is intentionally silent)
+#   - the most recent inbound user message is within
+#     BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS (default 1800s).
+#
+# BRIDGE_AGENT_PRECOMPACT_NOTIFY["developer"]="1"
+# BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG["developer"]="ko"
+#
+# Global controls (env or roster):
+#   BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1        # kill switch (overrides per-agent)
+#   BRIDGE_PRECOMPACT_NOTIFY_LANG="ko"         # fleet default language (en|ko)
+#   BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS=1800
+#   BRIDGE_PRECOMPACT_NOTICE_DEDUP_SECONDS=300
+
 # Optional: agent class — privilege boundary consumed by hooks/tool-policy.py
 # (issue #539). The closed value space is { user, system }; an unknown class
 # is a hard error at roster load.

--- a/bridge-channels.py
+++ b/bridge-channels.py
@@ -4,7 +4,19 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
+import math
+import os
+import socket
+import ssl
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -439,6 +451,828 @@ def cmd_route_precompact_target(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# PreCompact send-managed-message + templates + EMA stats (issue #597 Track B).
+#
+# This block adds:
+#   1. Localized notice / followup template rendering with override envs.
+#   2. EMA-backed stats file at $BRIDGE_STATE_DIR/precompact-stats.json with
+#      fcntl.flock + atomic replace; mirrors bridge-memory.py's pattern.
+#   3. Per-plugin send adapters for Discord and Telegram (operator-side
+#      credentials/access state). Teams + Mattermost return a structured
+#      `track-c-pending` error so the daemon's audit row records the gap
+#      until Track C ships the TS-side CLI mode.
+#
+# Track D (the relay activity-index writers) and Track C (TS plugin server
+# changes) are intentionally out of scope here.
+# ---------------------------------------------------------------------------
+
+
+_PRECOMPACT_STATS_SCHEMA_VERSION = 1
+_EMA_ALPHA_DEFAULT = 0.30
+_EMA_ALPHA_MIN = 0.01
+_EMA_ALPHA_MAX = 1.00
+_EXPECTED_SECONDS_FALLBACK = 45
+_EXPECTED_SECONDS_MIN = 5
+_EXPECTED_SECONDS_MAX = 900
+_PLUGINS_TRACK_C_PENDING = ("teams", "mattermost")
+_HTTP_TIMEOUT_SECONDS = 10.0
+
+
+_DEFAULT_TEMPLATES = {
+    "notice": {
+        "en": "Heads up: {agent} is compacting its context now. I should be back in about {expected_seconds}s.",
+        "ko": "{agent} 컨텍스트 압축이 시작됐습니다. 약 {expected_seconds}초 뒤에 다시 응답할 수 있습니다.",
+    },
+    "followup": {
+        "en": "{agent} is back online after compaction. Thanks for waiting.",
+        "ko": "{agent} 컨텍스트 압축이 끝났습니다. 이제 다시 응답할 수 있습니다.",
+    },
+}
+
+_TEMPLATE_ENV_KEYS = {
+    "notice": {
+        "en": "BRIDGE_PRECOMPACT_NOTIFY_TEMPLATE_EN",
+        "ko": "BRIDGE_PRECOMPACT_NOTIFY_TEMPLATE_KO",
+    },
+    "followup": {
+        "en": "BRIDGE_PRECOMPACT_FOLLOWUP_TEMPLATE_EN",
+        "ko": "BRIDGE_PRECOMPACT_FOLLOWUP_TEMPLATE_KO",
+    },
+}
+
+
+def _normalize_lang(raw: str | None) -> str:
+    """Normalize a language hint to one of the supported codes ("en"|"ko")."""
+    if not raw:
+        return "en"
+    code = str(raw).strip().lower()
+    if code in ("en", "ko"):
+        return code
+    return "en"
+
+
+def _resolve_template(kind: str, lang: str) -> str:
+    """Pick the active template for `kind` ∈ {notice, followup} and `lang`.
+
+    Resolution: env override (BRIDGE_PRECOMPACT_*_TEMPLATE_EN/KO) → default.
+    The override env is ignored when empty/whitespace.
+    """
+    env_key = _TEMPLATE_ENV_KEYS.get(kind, {}).get(lang)
+    if env_key:
+        override = os.environ.get(env_key, "")
+        if override and override.strip():
+            return override
+    return _DEFAULT_TEMPLATES.get(kind, {}).get(lang) or _DEFAULT_TEMPLATES["notice"]["en"]
+
+
+def _format_template(template: str, fields: dict[str, Any]) -> str:
+    """Substitute `{name}` placeholders with `fields`; missing keys render empty.
+
+    Using a custom dict-of-strings rather than `str.format(**fields)` so a
+    template that references a field we did not compute does not raise KeyError
+    — that would surface as a send failure instead of a degraded but
+    deliverable message.
+    """
+    class _SafeDict(dict):
+        def __missing__(self, key: str) -> str:  # type: ignore[override]
+            return ""
+
+    try:
+        return template.format_map(_SafeDict(fields))
+    except (IndexError, ValueError):
+        # Malformed template: fall back to the raw template so the operator
+        # at least gets a delivered notice that points at their own typo.
+        return template
+
+
+def _coerce_alpha(raw: str | float | int | None) -> float:
+    """Clamp the EMA alpha from env to [0.01, 1.00]; default 0.30."""
+    if raw is None or raw == "":
+        return _EMA_ALPHA_DEFAULT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return _EMA_ALPHA_DEFAULT
+    if math.isnan(value) or math.isinf(value):
+        return _EMA_ALPHA_DEFAULT
+    return max(_EMA_ALPHA_MIN, min(_EMA_ALPHA_MAX, value))
+
+
+def _ema_update(prior: float | None, sample: float, alpha: float) -> float:
+    """Exponential moving average — first sample seeds the EMA at the sample."""
+    if prior is None or prior <= 0:
+        return float(sample)
+    return float(alpha) * float(sample) + (1.0 - float(alpha)) * float(prior)
+
+
+def _stats_path(state_dir: Path) -> Path:
+    return state_dir / "precompact-stats.json"
+
+
+def _stats_lock_path(state_dir: Path) -> Path:
+    return state_dir / "precompact-stats.json.lock"
+
+
+def _load_stats(state_dir: Path) -> dict[str, Any]:
+    """Read precompact-stats.json or return a freshly seeded skeleton.
+
+    Caller MUST hold the sibling .lock flock. On parse failure, the corrupt
+    file is renamed aside and a fresh skeleton is returned so the writer
+    starts from a clean slate (mirrors the spec's risk-mitigation guidance).
+    """
+    path = _stats_path(state_dir)
+    if not path.exists():
+        return _empty_stats()
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        try:
+            corrupt = path.with_suffix(path.suffix + f".corrupt-{int(time.time())}")
+            path.replace(corrupt)
+        except OSError:
+            pass
+        return _empty_stats()
+    if not isinstance(payload, dict):
+        return _empty_stats()
+    if "schema_version" not in payload:
+        payload["schema_version"] = _PRECOMPACT_STATS_SCHEMA_VERSION
+    if not isinstance(payload.get("agents"), dict):
+        payload["agents"] = {}
+    if not isinstance(payload.get("global"), dict):
+        payload["global"] = _empty_global_stats()
+    return payload
+
+
+def _empty_global_stats() -> dict[str, Any]:
+    return {
+        "count": 0,
+        "ema_seconds": 0.0,
+        "last_duration_seconds": 0,
+        "last_started_ts": 0,
+        "last_completed_ts": 0,
+    }
+
+
+def _empty_agent_stats() -> dict[str, Any]:
+    return {
+        "count": 0,
+        "auto_count": 0,
+        "manual_count": 0,
+        "ema_seconds": 0.0,
+        "auto_ema_seconds": 0.0,
+        "manual_ema_seconds": 0.0,
+        "last_duration_seconds": 0,
+        "last_trigger": "",
+        "last_started_ts": 0,
+        "last_completed_ts": 0,
+    }
+
+
+def _empty_stats() -> dict[str, Any]:
+    return {
+        "schema_version": _PRECOMPACT_STATS_SCHEMA_VERSION,
+        "host": socket.gethostname(),
+        "updated_ts": 0,
+        "alpha": _EMA_ALPHA_DEFAULT,
+        "global": _empty_global_stats(),
+        "agents": {},
+    }
+
+
+def _save_stats(state_dir: Path, payload: dict[str, Any]) -> None:
+    """Atomic temp-then-replace write of precompact-stats.json.
+
+    Caller MUST hold the sibling .lock flock.
+    """
+    path = _stats_path(state_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=str(path.parent),
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    try:
+        json.dump(payload, tmp, ensure_ascii=False, indent=2)
+        tmp.write("\n")
+        tmp.flush()
+        try:
+            os.fsync(tmp.fileno())
+        except OSError:
+            pass
+    finally:
+        tmp.close()
+    os.replace(tmp.name, path)
+
+
+def _expected_seconds(stats: dict[str, Any], agent: str) -> int:
+    """Resolve `expected_seconds` for the notice template.
+
+    Order: agent.auto_ema_seconds → agent.ema_seconds → global.ema_seconds →
+    BRIDGE_PRECOMPACT_NOTIFY_DEFAULT_EXPECTED_SECONDS env → 45. Result is
+    rounded up to a whole second and clamped to [5, 900] for display.
+    """
+    agent_stats = stats.get("agents", {}).get(agent, {}) if isinstance(stats, dict) else {}
+    candidate = 0.0
+    for key in ("auto_ema_seconds", "ema_seconds"):
+        val = agent_stats.get(key) if isinstance(agent_stats, dict) else None
+        if isinstance(val, (int, float)) and val > 0:
+            candidate = float(val)
+            break
+    if candidate <= 0:
+        global_stats = stats.get("global", {}) if isinstance(stats, dict) else {}
+        gval = global_stats.get("ema_seconds") if isinstance(global_stats, dict) else None
+        if isinstance(gval, (int, float)) and gval > 0:
+            candidate = float(gval)
+    if candidate <= 0:
+        env_default = os.environ.get("BRIDGE_PRECOMPACT_NOTIFY_DEFAULT_EXPECTED_SECONDS", "")
+        try:
+            ev = float(env_default) if env_default else 0.0
+        except (TypeError, ValueError):
+            ev = 0.0
+        if ev > 0:
+            candidate = ev
+    if candidate <= 0:
+        candidate = float(_EXPECTED_SECONDS_FALLBACK)
+    rounded = int(math.ceil(candidate))
+    return max(_EXPECTED_SECONDS_MIN, min(_EXPECTED_SECONDS_MAX, rounded))
+
+
+def _read_stats_for_render(state_dir: Path) -> dict[str, Any]:
+    """Read stats under a shared flock. Returns an empty skeleton on any IO error."""
+    path = _stats_path(state_dir)
+    if not path.exists():
+        return _empty_stats()
+    lock_path = _stats_lock_path(state_dir)
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return _empty_stats()
+    try:
+        with lock_path.open("a") as lock_handle:
+            try:
+                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_SH)
+            except OSError:
+                pass
+            try:
+                return _load_stats(state_dir)
+            finally:
+                try:
+                    fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+                except OSError:
+                    pass
+    except OSError:
+        return _empty_stats()
+
+
+def _record_completion_stats(
+    state_dir: Path,
+    agent: str,
+    trigger: str,
+    started_ts: int,
+    completed_ts: int,
+    alpha: float,
+) -> dict[str, Any]:
+    """Append a started/completed pair to precompact-stats.json under flock.
+
+    Returns the post-update stats payload (including the agent and global
+    ema_seconds the daemon can echo into the audit row).
+    """
+    duration = max(0, int(completed_ts) - int(started_ts))
+    lock_path = _stats_lock_path(state_dir)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a") as lock_handle:
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        except OSError:
+            # Without flock we still proceed; concurrent writers are rare and
+            # we'd rather miss a sample than block the daemon loop.
+            pass
+        try:
+            payload = _load_stats(state_dir)
+            payload["alpha"] = float(alpha)
+            payload["host"] = socket.gethostname()
+            payload["updated_ts"] = int(time.time())
+
+            agents = payload.setdefault("agents", {})
+            agent_stats = agents.get(agent)
+            if not isinstance(agent_stats, dict):
+                agent_stats = _empty_agent_stats()
+                agents[agent] = agent_stats
+
+            agent_stats["count"] = int(agent_stats.get("count", 0)) + 1
+            trigger_norm = (trigger or "").strip().lower()
+            if trigger_norm == "auto":
+                agent_stats["auto_count"] = int(agent_stats.get("auto_count", 0)) + 1
+                agent_stats["auto_ema_seconds"] = _ema_update(
+                    agent_stats.get("auto_ema_seconds"), duration, alpha
+                )
+            elif trigger_norm == "manual":
+                agent_stats["manual_count"] = int(agent_stats.get("manual_count", 0)) + 1
+                agent_stats["manual_ema_seconds"] = _ema_update(
+                    agent_stats.get("manual_ema_seconds"), duration, alpha
+                )
+            agent_stats["ema_seconds"] = _ema_update(
+                agent_stats.get("ema_seconds"), duration, alpha
+            )
+            agent_stats["last_duration_seconds"] = duration
+            agent_stats["last_trigger"] = trigger_norm
+            agent_stats["last_started_ts"] = int(started_ts)
+            agent_stats["last_completed_ts"] = int(completed_ts)
+
+            global_stats = payload.setdefault("global", _empty_global_stats())
+            global_stats["count"] = int(global_stats.get("count", 0)) + 1
+            global_stats["ema_seconds"] = _ema_update(
+                global_stats.get("ema_seconds"), duration, alpha
+            )
+            global_stats["last_duration_seconds"] = duration
+            global_stats["last_started_ts"] = int(started_ts)
+            global_stats["last_completed_ts"] = int(completed_ts)
+
+            _save_stats(state_dir, payload)
+            return payload
+        finally:
+            try:
+                fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+
+
+def _format_started_time(ts: int | str | None) -> str:
+    """Best-effort ISO-second formatter for template fields."""
+    try:
+        epoch = int(ts) if ts not in (None, "") else 0
+    except (TypeError, ValueError):
+        return ""
+    if epoch <= 0:
+        return ""
+    try:
+        return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat(timespec="seconds")
+    except (OverflowError, OSError, ValueError):
+        return ""
+
+
+def _render_managed_message(
+    kind: str,
+    lang: str,
+    agent: str,
+    expected_seconds: int,
+    duration_seconds: int,
+    started_ts: int,
+    completed_ts: int,
+    plugin: str,
+    channel_id: str,
+    trigger: str,
+) -> str:
+    """Render the notice or followup body for the requested language."""
+    lang_norm = _normalize_lang(lang)
+    template = _resolve_template(kind, lang_norm)
+    fields = {
+        "agent": agent,
+        "expected_seconds": expected_seconds,
+        "expected_minutes": max(1, math.ceil(expected_seconds / 60)),
+        "duration_seconds": duration_seconds,
+        "duration_minutes": max(1, math.ceil(duration_seconds / 60)) if duration_seconds else 0,
+        "started_time": _format_started_time(started_ts),
+        "completed_time": _format_started_time(completed_ts),
+        "channel": channel_id,
+        "host": socket.gethostname(),
+        "trigger": trigger or "",
+    }
+    return _format_template(template, fields)
+
+
+# ---------------------------------------------------------------------------
+# Per-plugin send adapters.
+#
+# These are operator-side senders that read per-agent plugin state under
+# <BRIDGE_HOME>/agents/<agent>/.<plugin>/. They are intentionally minimal —
+# they only do what the daemon's PreCompact notice needs (post a short message
+# in reply to a known channel/message id) and do not attempt to mirror the
+# full plugin surface.
+#
+# Each adapter returns a tuple `(message_id, thread_id)` on success and
+# raises a SendAdapterError on failure. Discord + Telegram are implemented
+# in Track B; Teams + Mattermost return a structured `track-c-pending`
+# error so the daemon's audit row records the gap until Track C lands.
+# ---------------------------------------------------------------------------
+
+
+class SendAdapterError(Exception):
+    """Structured failure wrapper for managed-message adapter calls."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def _agent_plugin_dir(bridge_home: Path, agent: str, plugin: str) -> Path:
+    return bridge_home / "agents" / agent / f".{plugin}"
+
+
+def _read_dotenv(path: Path) -> dict[str, str]:
+    """Parse a `KEY=value` style .env file. Tolerates missing/unreadable files."""
+    out: dict[str, str] = {}
+    if not path.exists():
+        return out
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return out
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if (value.startswith("\"") and value.endswith("\"")) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            value = value[1:-1]
+        if key:
+            out[key] = value
+    return out
+
+
+def _http_post_json(url: str, payload: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
+    """POST a JSON body and decode the JSON response.
+
+    Raises SendAdapterError on transport failure or non-2xx response. The
+    raw response body is included in the error message (truncated) so the
+    daemon's audit row can surface the platform-side reason.
+    """
+    body = json.dumps(payload).encode("utf-8")
+    base_headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    base_headers.update(headers)
+    request = urllib.request.Request(url, data=body, headers=base_headers, method="POST")
+    try:
+        ctx = ssl.create_default_context()
+        with urllib.request.urlopen(request, timeout=_HTTP_TIMEOUT_SECONDS, context=ctx) as response:
+            raw = response.read()
+            if response.status < 200 or response.status >= 300:
+                raise SendAdapterError(
+                    "http_error",
+                    f"HTTP {response.status}: {raw[:200]!r}",
+                )
+            try:
+                return json.loads(raw.decode("utf-8") or "{}")
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                return {}
+    except urllib.error.HTTPError as exc:
+        try:
+            raw = exc.read()[:200]
+        except Exception:
+            raw = b""
+        raise SendAdapterError("http_error", f"HTTP {exc.code}: {raw!r}") from exc
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        raise SendAdapterError("network_error", str(exc)) from exc
+
+
+def _adapter_discord(
+    bridge_home: Path,
+    agent: str,
+    channel_id: str,
+    reply_to_message_id: str,
+    body: str,
+) -> tuple[str, str]:
+    """Discord adapter — POST /channels/{id}/messages with message_reference.
+
+    Reads the bot token from the per-agent .discord/.env (DISCORD_BOT_TOKEN
+    or BRIDGE_DISCORD_BOT_TOKEN); the access.json sidecar can override the
+    token, mirroring how bridge-setup.py persists Discord credentials.
+    """
+    plugin_dir = _agent_plugin_dir(bridge_home, agent, "discord")
+    env = _read_dotenv(plugin_dir / ".env")
+    token = (
+        env.get("DISCORD_BOT_TOKEN")
+        or env.get("BRIDGE_DISCORD_BOT_TOKEN")
+        or env.get("DISCORD_TOKEN")
+    )
+    access_path = plugin_dir / "access.json"
+    if access_path.exists():
+        try:
+            access = json.loads(access_path.read_text(encoding="utf-8"))
+            if isinstance(access, dict):
+                token = access.get("bot_token") or access.get("token") or token
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            pass
+    if not token:
+        raise SendAdapterError("missing_credentials", "discord bot token not configured")
+
+    payload: dict[str, Any] = {"content": body[:2000]}
+    if reply_to_message_id:
+        payload["message_reference"] = {
+            "channel_id": channel_id,
+            "message_id": reply_to_message_id,
+            # fail_if_not_exists=False: if the original was deleted, still
+            # post in the channel rather than rejecting the send.
+            "fail_if_not_exists": False,
+        }
+        # Suppress the "@<user>" ping inherited from the reply chain.
+        payload["allowed_mentions"] = {"replied_user": False, "parse": []}
+
+    url = f"https://discord.com/api/v10/channels/{urllib.parse.quote(channel_id)}/messages"
+    response = _http_post_json(
+        url,
+        payload,
+        {"Authorization": f"Bot {token}", "User-Agent": "agent-bridge/0 (+precompact-notify)"},
+    )
+    message_id = str(response.get("id") or "")
+    thread_id = ""
+    if not message_id:
+        raise SendAdapterError("malformed_response", "discord response missing message id")
+    return message_id, thread_id
+
+
+def _adapter_telegram(
+    bridge_home: Path,
+    agent: str,
+    channel_id: str,
+    reply_to_message_id: str,
+    body: str,
+) -> tuple[str, str]:
+    """Telegram adapter — POST /bot{token}/sendMessage with reply_parameters.
+
+    Reads the bot token from the per-agent .telegram/.env; access.json may
+    override. Uses the modern `reply_parameters` envelope when a reply id is
+    provided so quote-replies survive forum topics and supergroup retargets.
+    """
+    plugin_dir = _agent_plugin_dir(bridge_home, agent, "telegram")
+    env = _read_dotenv(plugin_dir / ".env")
+    token = (
+        env.get("TELEGRAM_BOT_TOKEN")
+        or env.get("BRIDGE_TELEGRAM_BOT_TOKEN")
+        or env.get("TELEGRAM_TOKEN")
+    )
+    access_path = plugin_dir / "access.json"
+    if access_path.exists():
+        try:
+            access = json.loads(access_path.read_text(encoding="utf-8"))
+            if isinstance(access, dict):
+                token = access.get("bot_token") or access.get("token") or token
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            pass
+    if not token:
+        raise SendAdapterError("missing_credentials", "telegram bot token not configured")
+
+    # Telegram caps message bodies around 4096 chars; truncate well below.
+    payload: dict[str, Any] = {"chat_id": channel_id, "text": body[:4000]}
+    if reply_to_message_id:
+        try:
+            mid = int(reply_to_message_id)
+            payload["reply_parameters"] = {
+                "message_id": mid,
+                "allow_sending_without_reply": True,
+            }
+        except (TypeError, ValueError):
+            # If the message id is non-numeric (shouldn't happen for Telegram),
+            # send without a reply anchor rather than failing the whole send.
+            pass
+
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    response = _http_post_json(url, payload, {})
+    if not response.get("ok"):
+        raise SendAdapterError(
+            "platform_error",
+            f"telegram error: {response.get('description') or response}",
+        )
+    result = response.get("result") if isinstance(response.get("result"), dict) else {}
+    message_id = str(result.get("message_id") or "")
+    thread_id = str(result.get("message_thread_id") or "")
+    if not message_id:
+        raise SendAdapterError("malformed_response", "telegram response missing message_id")
+    return message_id, thread_id
+
+
+def _dispatch_send(
+    plugin: str,
+    bridge_home: Path,
+    agent: str,
+    channel_id: str,
+    reply_to_message_id: str,
+    body: str,
+) -> tuple[str, str]:
+    """Route the send call to the correct adapter, raising SendAdapterError."""
+    if plugin == "discord":
+        return _adapter_discord(bridge_home, agent, channel_id, reply_to_message_id, body)
+    if plugin == "telegram":
+        return _adapter_telegram(bridge_home, agent, channel_id, reply_to_message_id, body)
+    if plugin in _PLUGINS_TRACK_C_PENDING:
+        # Teams / Mattermost true managed-send needs the TS plugin server's
+        # CLI extension (Track C). Returning a structured error here lets the
+        # daemon's audit row name the gap precisely without the operator
+        # having to grep the code to find out why nothing went out.
+        raise SendAdapterError(
+            "track_c_pending",
+            f"managed-message send for plugin={plugin} requires Track C TS plugin extension",
+        )
+    raise SendAdapterError("unsupported_plugin", f"unsupported plugin: {plugin}")
+
+
+def _emit_send_payload(payload: dict[str, str], fmt: str) -> None:
+    """Print the result either as `KEY="value"` shell pairs or single-line JSON."""
+    if fmt == "json":
+        print(json.dumps(payload, ensure_ascii=False))
+        return
+    for key, value in payload.items():
+        print(f"{key}={json.dumps(str(value))}")
+
+
+def cmd_send_managed_message(args: argparse.Namespace) -> int:
+    """Send a managed PreCompact notice or followup via the resolved plugin.
+
+    Honors `--dry-run` for CI/smoke; in dry-run mode the adapter is bypassed
+    entirely and a deterministic synthetic message id is emitted so the
+    daemon's pending-state writer can still close the loop.
+    """
+    bridge_home = Path(args.bridge_home).expanduser()
+    state_dir = Path(args.bridge_state_dir).expanduser()
+    plugin = (args.plugin or "").strip().lower()
+    agent = (args.agent or "").strip()
+    channel_id = (args.channel_id or "").strip()
+    body = args.body or ""
+    kind = (args.kind or "notice").strip().lower()
+    if kind not in ("notice", "followup"):
+        kind = "notice"
+    reply_to = (args.reply_to_message_id or "").strip()
+    correlation_id = (args.correlation_id or "").strip()
+
+    if not plugin or not agent or not channel_id or not body:
+        return 2
+
+    if args.dry_run:
+        synthetic_id = f"dryrun-{int(time.time() * 1000)}"
+        _emit_send_payload(
+            {
+                "CHANNEL_SEND_STATUS": "ok",
+                "CHANNEL_SEND_PLUGIN": plugin,
+                "CHANNEL_SEND_CHANNEL_ID": channel_id,
+                "CHANNEL_SEND_REPLY_TO_MESSAGE_ID": reply_to,
+                "CHANNEL_SEND_MESSAGE_ID": synthetic_id,
+                "CHANNEL_SEND_THREAD_ID": "",
+                "CHANNEL_SEND_DRY_RUN": "1",
+                "CHANNEL_SEND_KIND": kind,
+                "CHANNEL_SEND_CORRELATION_ID": correlation_id,
+            },
+            args.format,
+        )
+        return 0
+
+    # Daemon log channel — the daemon redirects stdout to a captured pipe and
+    # parses CHANNEL_SEND_* assignments, so structured error context belongs
+    # on stderr where bridge-daemon.sh forwards it to the audit row reason.
+    try:
+        message_id, thread_id = _dispatch_send(
+            plugin, bridge_home, agent, channel_id, reply_to, body
+        )
+    except SendAdapterError as exc:
+        print(f"send-managed-message error: {exc.code}: {exc.message}", file=sys.stderr)
+        return 1
+
+    # Stats access here is read-only — record_completion_stats happens in the
+    # follow-up dispatch when the daemon pairs the started/completed markers.
+    _ = state_dir
+
+    _emit_send_payload(
+        {
+            "CHANNEL_SEND_STATUS": "ok",
+            "CHANNEL_SEND_PLUGIN": plugin,
+            "CHANNEL_SEND_CHANNEL_ID": channel_id,
+            "CHANNEL_SEND_REPLY_TO_MESSAGE_ID": reply_to,
+            "CHANNEL_SEND_MESSAGE_ID": message_id,
+            "CHANNEL_SEND_THREAD_ID": thread_id,
+            "CHANNEL_SEND_DRY_RUN": "0",
+            "CHANNEL_SEND_KIND": kind,
+            "CHANNEL_SEND_CORRELATION_ID": correlation_id,
+        },
+        args.format,
+    )
+    return 0
+
+
+def cmd_render_precompact_message(args: argparse.Namespace) -> int:
+    """Stand-alone renderer used by the daemon to produce notice/followup body.
+
+    Accepts most of the per-event context as flags so the daemon can call
+    it once per send without round-tripping through stats again. When
+    `--read-stats` is set, the renderer pulls `expected_seconds` from
+    precompact-stats.json (under shared flock); otherwise it uses the
+    explicit `--expected-seconds` value.
+    """
+    state_dir = Path(args.bridge_state_dir).expanduser()
+    expected_seconds = 0
+    try:
+        if args.expected_seconds not in (None, ""):
+            expected_seconds = int(args.expected_seconds)
+    except (TypeError, ValueError):
+        expected_seconds = 0
+    if expected_seconds <= 0 and args.read_stats:
+        stats = _read_stats_for_render(state_dir)
+        expected_seconds = _expected_seconds(stats, args.agent)
+    if expected_seconds <= 0:
+        expected_seconds = _EXPECTED_SECONDS_FALLBACK
+
+    duration_seconds = 0
+    try:
+        if args.duration_seconds not in (None, ""):
+            duration_seconds = max(0, int(args.duration_seconds))
+    except (TypeError, ValueError):
+        duration_seconds = 0
+
+    started_ts = 0
+    try:
+        started_ts = int(args.started_ts) if args.started_ts not in (None, "") else 0
+    except (TypeError, ValueError):
+        started_ts = 0
+    completed_ts = 0
+    try:
+        completed_ts = int(args.completed_ts) if args.completed_ts not in (None, "") else 0
+    except (TypeError, ValueError):
+        completed_ts = 0
+
+    body = _render_managed_message(
+        kind=args.kind,
+        lang=args.lang,
+        agent=args.agent,
+        expected_seconds=expected_seconds,
+        duration_seconds=duration_seconds,
+        started_ts=started_ts,
+        completed_ts=completed_ts,
+        plugin=args.plugin,
+        channel_id=args.channel_id,
+        trigger=args.trigger,
+    )
+
+    if args.format == "json":
+        print(json.dumps({
+            "BODY": body,
+            "EXPECTED_SECONDS": expected_seconds,
+            "DURATION_SECONDS": duration_seconds,
+            "LANG": _normalize_lang(args.lang),
+            "KIND": args.kind,
+        }, ensure_ascii=False))
+        return 0
+    # Shell format: BODY uses base64 to keep newlines/quotes intact when the
+    # daemon eval's the output. Daemon decodes via `base64 -d`.
+    import base64
+    encoded = base64.b64encode(body.encode("utf-8")).decode("ascii")
+    print(f"PRECOMPACT_BODY_B64={json.dumps(encoded)}")
+    print(f"PRECOMPACT_EXPECTED_SECONDS={json.dumps(str(expected_seconds))}")
+    print(f"PRECOMPACT_DURATION_SECONDS={json.dumps(str(duration_seconds))}")
+    print(f"PRECOMPACT_LANG={json.dumps(_normalize_lang(args.lang))}")
+    print(f"PRECOMPACT_KIND={json.dumps(args.kind)}")
+    return 0
+
+
+def cmd_record_precompact_completion(args: argparse.Namespace) -> int:
+    """Record a started/completed pair into precompact-stats.json.
+
+    Called by the daemon after pairing markers. Emits the post-update
+    `expected_seconds` so the daemon can include it in the followup audit
+    row without re-reading the stats file.
+    """
+    state_dir = Path(args.bridge_state_dir).expanduser()
+    try:
+        started_ts = int(args.started_ts)
+        completed_ts = int(args.completed_ts)
+    except (TypeError, ValueError):
+        return 2
+    if completed_ts < started_ts:
+        completed_ts = started_ts
+    alpha = _coerce_alpha(args.alpha if args.alpha not in (None, "") else os.environ.get("BRIDGE_PRECOMPACT_EMA_ALPHA"))
+    payload = _record_completion_stats(
+        state_dir=state_dir,
+        agent=args.agent,
+        trigger=args.trigger or "",
+        started_ts=started_ts,
+        completed_ts=completed_ts,
+        alpha=alpha,
+    )
+    expected = _expected_seconds(payload, args.agent)
+    duration = max(0, completed_ts - started_ts)
+    if args.format == "json":
+        print(json.dumps({
+            "DURATION_SECONDS": duration,
+            "EXPECTED_SECONDS": expected,
+            "ALPHA": alpha,
+        }, ensure_ascii=False))
+        return 0
+    print(f"PRECOMPACT_STATS_DURATION_SECONDS={json.dumps(str(duration))}")
+    print(f"PRECOMPACT_STATS_EXPECTED_SECONDS={json.dumps(str(expected))}")
+    print(f"PRECOMPACT_STATS_ALPHA={json.dumps(str(alpha))}")
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="bridge-channels.py")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -463,6 +1297,47 @@ def build_parser() -> argparse.ArgumentParser:
     route_parser.add_argument("--now-ts", default="")
     route_parser.add_argument("--format", choices=("shell", "json"), default="shell")
     route_parser.set_defaults(handler=cmd_route_precompact_target)
+
+    # Issue #597 Track B: managed-message send + render + completion-stats subcommands.
+    send_parser = subparsers.add_parser("send-managed-message")
+    send_parser.add_argument("--plugin", required=True)
+    send_parser.add_argument("--agent", required=True)
+    send_parser.add_argument("--channel-id", required=True)
+    send_parser.add_argument("--reply-to-message-id", default="")
+    send_parser.add_argument("--body", required=True)
+    send_parser.add_argument("--kind", default="notice", choices=("notice", "followup"))
+    send_parser.add_argument("--bridge-home", required=True)
+    send_parser.add_argument("--bridge-state-dir", required=True)
+    send_parser.add_argument("--correlation-id", default="")
+    send_parser.add_argument("--format", choices=("shell", "json"), default="shell")
+    send_parser.add_argument("--dry-run", action="store_true")
+    send_parser.set_defaults(handler=cmd_send_managed_message)
+
+    render_parser = subparsers.add_parser("render-precompact-message")
+    render_parser.add_argument("--agent", required=True)
+    render_parser.add_argument("--kind", required=True, choices=("notice", "followup"))
+    render_parser.add_argument("--lang", default="en")
+    render_parser.add_argument("--plugin", default="")
+    render_parser.add_argument("--channel-id", default="")
+    render_parser.add_argument("--trigger", default="")
+    render_parser.add_argument("--expected-seconds", default="")
+    render_parser.add_argument("--duration-seconds", default="")
+    render_parser.add_argument("--started-ts", default="")
+    render_parser.add_argument("--completed-ts", default="")
+    render_parser.add_argument("--bridge-state-dir", required=True)
+    render_parser.add_argument("--read-stats", action="store_true")
+    render_parser.add_argument("--format", choices=("shell", "json"), default="shell")
+    render_parser.set_defaults(handler=cmd_render_precompact_message)
+
+    record_parser = subparsers.add_parser("record-precompact-completion")
+    record_parser.add_argument("--agent", required=True)
+    record_parser.add_argument("--trigger", default="auto")
+    record_parser.add_argument("--started-ts", required=True)
+    record_parser.add_argument("--completed-ts", required=True)
+    record_parser.add_argument("--alpha", default="")
+    record_parser.add_argument("--bridge-state-dir", required=True)
+    record_parser.add_argument("--format", choices=("shell", "json"), default="shell")
+    record_parser.set_defaults(handler=cmd_record_precompact_completion)
 
     return parser
 

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3374,6 +3374,33 @@ process_precompact_events() {
   shopt -u nullglob
 }
 
+# Parse error_class out of bridge-channels.py send-managed-message stderr.
+# The send primitive emits "send-managed-message error: <code>: <message>"
+# (see bridge-channels.py SendAdapterError handler). Codes include
+# track_c_pending (Teams/Mattermost), missing_credentials, platform_error,
+# network_error, http_error, malformed_response, unsupported_plugin.
+# Falls back to "send_failed" when the stderr is empty or unparseable so the
+# audit row always carries a non-empty error_class.
+_bridge_precompact_parse_error_class() {
+  local stderr_text="${1:-}"
+  local fallback="send_failed"
+  if [[ -z "$stderr_text" ]]; then
+    printf '%s' "$fallback"
+    return 0
+  fi
+  local parsed=""
+  parsed="$(printf '%s' "$stderr_text" \
+    | grep -E 'send-managed-message error:' \
+    | head -1 \
+    | sed -E 's/^.*send-managed-message error: *([A-Za-z0-9_-]+).*/\1/' \
+    || true)"
+  if [[ -n "$parsed" && "$parsed" =~ ^[A-Za-z0-9_-]+$ ]]; then
+    printf '%s' "$parsed"
+  else
+    printf '%s' "$fallback"
+  fi
+}
+
 # Internal: process every started marker for one agent. Each marker either
 # becomes a sent notice (with pending state) or is skipped; in both cases the
 # marker moves to processed/ so the daemon does not reconsider it. Malformed
@@ -3580,7 +3607,14 @@ print("raw_trigger\t" + str(data.get("raw_trigger") or ""))
   fi
   local send_output=""
   local send_rc=0
-  send_output="$(bridge_with_timeout 30 precompact_send python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" "${send_args[@]}" 2>/dev/null)" || send_rc=$?
+  local send_stderr_file
+  send_stderr_file="$(mktemp 2>/dev/null || printf '%s/precompact-notice-stderr.%s' "${TMPDIR:-/tmp}" "$$")"
+  send_output="$(bridge_with_timeout 30 precompact_send python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" "${send_args[@]}" 2>"$send_stderr_file")" || send_rc=$?
+  local send_stderr=""
+  if [[ -f "$send_stderr_file" ]]; then
+    send_stderr="$(cat "$send_stderr_file" 2>/dev/null || true)"
+    rm -f "$send_stderr_file" 2>/dev/null || true
+  fi
 
   local CHANNEL_SEND_STATUS="" CHANNEL_SEND_PLUGIN="" CHANNEL_SEND_CHANNEL_ID=""
   local CHANNEL_SEND_REPLY_TO_MESSAGE_ID="" CHANNEL_SEND_MESSAGE_ID=""
@@ -3591,6 +3625,8 @@ print("raw_trigger\t" + str(data.get("raw_trigger") or ""))
   fi
 
   if (( send_rc != 0 )) || [[ "$CHANNEL_SEND_STATUS" != "ok" ]]; then
+    local error_class
+    error_class="$(_bridge_precompact_parse_error_class "$send_stderr")"
     bridge_audit_log daemon precompact_notice_failed "$agent" \
       --detail event_id="$event_id" \
       --detail plugin="$CHANNEL_ROUTE_PLUGIN" \
@@ -3600,7 +3636,7 @@ print("raw_trigger\t" + str(data.get("raw_trigger") or ""))
       --detail trigger="$trigger" \
       --detail started_ts="$started_ts" \
       --detail send_rc="$send_rc" \
-      --detail error_class="send_failed" 2>/dev/null || true
+      --detail error_class="$error_class" 2>/dev/null || true
     mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
     return 0
   fi
@@ -3775,27 +3811,43 @@ for k in keys:
     return 0
   fi
 
-  # Update EMA stats and resolve duration / expected_seconds for the followup.
-  local stats_output=""
-  stats_output="$(bridge_with_timeout 10 precompact_stats_record python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
-    record-precompact-completion \
-    --agent "$agent" \
-    --trigger "$pending_trigger" \
-    --started-ts "$pending_started_ts" \
-    --completed-ts "$completed_ts" \
-    --bridge-state-dir "$BRIDGE_STATE_DIR" \
-    --format shell 2>/dev/null)" || stats_output=""
+  # Update EMA stats once per event_id. The completion-recorded flag prevents
+  # follow-up retries from re-incrementing the counter / re-blending the EMA
+  # when the send fails repeatedly (see r2 of #611). Compute duration locally
+  # so a skipped record-call still produces the right value for rendering.
+  local recorded_flag_dir="$agent_state_dir/precompact-completion-recorded"
+  local recorded_flag="$recorded_flag_dir/$pending_event_id.flag"
+  local duration_secs=$(( completed_ts - pending_started_ts ))
+  (( duration_secs >= 0 )) || duration_secs=0
 
-  local PRECOMPACT_STATS_DURATION_SECONDS=""
-  local PRECOMPACT_STATS_EXPECTED_SECONDS=""
-  local PRECOMPACT_STATS_ALPHA=""
-  if [[ -n "$stats_output" ]]; then
-    # shellcheck disable=SC1090
-    source /dev/stdin <<<"$stats_output"
+  if [[ ! -f "$recorded_flag" ]]; then
+    local stats_output=""
+    stats_output="$(bridge_with_timeout 10 precompact_stats_record python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
+      record-precompact-completion \
+      --agent "$agent" \
+      --trigger "$pending_trigger" \
+      --started-ts "$pending_started_ts" \
+      --completed-ts "$completed_ts" \
+      --bridge-state-dir "$BRIDGE_STATE_DIR" \
+      --format shell 2>/dev/null)" || stats_output=""
+
+    local PRECOMPACT_STATS_DURATION_SECONDS=""
+    local PRECOMPACT_STATS_EXPECTED_SECONDS=""
+    local PRECOMPACT_STATS_ALPHA=""
+    if [[ -n "$stats_output" ]]; then
+      # shellcheck disable=SC1090
+      source /dev/stdin <<<"$stats_output"
+    fi
+
+    if [[ "${PRECOMPACT_STATS_DURATION_SECONDS:-}" =~ ^[0-9]+$ ]]; then
+      duration_secs="$PRECOMPACT_STATS_DURATION_SECONDS"
+    fi
+
+    # Mark EMA as recorded for this event regardless of send outcome below;
+    # the stats file has already been mutated and a retry must not re-blend.
+    mkdir -p "$recorded_flag_dir" 2>/dev/null || true
+    : >"$recorded_flag" 2>/dev/null || true
   fi
-
-  local duration_secs="${PRECOMPACT_STATS_DURATION_SECONDS:-0}"
-  [[ "$duration_secs" =~ ^[0-9]+$ ]] || duration_secs=0
 
   # Render the follow-up body.
   local render_output=""
@@ -3837,6 +3889,7 @@ for k in keys:
 
   local send_rc=0
   local send_output=""
+  local send_stderr=""
   if [[ -z "$body" ]]; then
     send_rc=1
   else
@@ -3858,7 +3911,13 @@ for k in keys:
     if [[ "${BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN:-0}" == "1" ]]; then
       fu_send_args+=(--dry-run)
     fi
-    send_output="$(bridge_with_timeout 30 precompact_send_followup python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" "${fu_send_args[@]}" 2>/dev/null)" || send_rc=$?
+    local fu_stderr_file
+    fu_stderr_file="$(mktemp 2>/dev/null || printf '%s/precompact-followup-stderr.%s' "${TMPDIR:-/tmp}" "$$")"
+    send_output="$(bridge_with_timeout 30 precompact_send_followup python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" "${fu_send_args[@]}" 2>"$fu_stderr_file")" || send_rc=$?
+    if [[ -f "$fu_stderr_file" ]]; then
+      send_stderr="$(cat "$fu_stderr_file" 2>/dev/null || true)"
+      rm -f "$fu_stderr_file" 2>/dev/null || true
+    fi
   fi
 
   if [[ "$pending_dry_run" == "1" ]]; then
@@ -3879,13 +3938,15 @@ for k in keys:
     # BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS; otherwise archive and give up.
     local retry_window="${BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS:-600}"
     [[ "$retry_window" =~ ^[0-9]+$ ]] || retry_window=600
+    local fu_error_class
+    fu_error_class="$(_bridge_precompact_parse_error_class "$send_stderr")"
     bridge_audit_log daemon precompact_followup_failed "$agent" \
       --detail event_id="$pending_event_id" \
       --detail plugin="$pending_plugin" \
       --detail channel_id="$pending_channel_id" \
       --detail duration_seconds="$duration_secs" \
       --detail send_rc="$send_rc" \
-      --detail error_class="send_failed" 2>/dev/null || true
+      --detail error_class="$fu_error_class" 2>/dev/null || true
 
     # Update pending followup_attempt_ts and decide whether to expire.
     local notice_sent_ts=0

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3811,42 +3811,26 @@ for k in keys:
     return 0
   fi
 
-  # Update EMA stats once per event_id. The completion-recorded flag prevents
-  # follow-up retries from re-incrementing the counter / re-blending the EMA
-  # when the send fails repeatedly (see r2 of #611). Compute duration locally
-  # so a skipped record-call still produces the right value for rendering.
+  # Stats mutation + per-event dedup flag are deferred until AFTER a successful
+  # follow-up send (see r3 of #611). Rationale: writing the flag and mutating
+  # precompact-stats.json before the send means a retry-loop on send failure
+  # would either re-blend the EMA (no flag yet) or skip stats entirely while
+  # the marker stays pending (flag already present). Both outcomes are wrong.
+  # The correct invariant is "stats + flag move iff send succeeded once",
+  # implemented by short-circuiting on the flag here and writing it inside
+  # the success branch below. Duration is computed locally so the followup
+  # body renders correctly even when stats have not yet been recorded.
   local recorded_flag_dir="$agent_state_dir/precompact-completion-recorded"
   local recorded_flag="$recorded_flag_dir/$pending_event_id.flag"
   local duration_secs=$(( completed_ts - pending_started_ts ))
   (( duration_secs >= 0 )) || duration_secs=0
 
-  if [[ ! -f "$recorded_flag" ]]; then
-    local stats_output=""
-    stats_output="$(bridge_with_timeout 10 precompact_stats_record python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
-      record-precompact-completion \
-      --agent "$agent" \
-      --trigger "$pending_trigger" \
-      --started-ts "$pending_started_ts" \
-      --completed-ts "$completed_ts" \
-      --bridge-state-dir "$BRIDGE_STATE_DIR" \
-      --format shell 2>/dev/null)" || stats_output=""
-
-    local PRECOMPACT_STATS_DURATION_SECONDS=""
-    local PRECOMPACT_STATS_EXPECTED_SECONDS=""
-    local PRECOMPACT_STATS_ALPHA=""
-    if [[ -n "$stats_output" ]]; then
-      # shellcheck disable=SC1090
-      source /dev/stdin <<<"$stats_output"
-    fi
-
-    if [[ "${PRECOMPACT_STATS_DURATION_SECONDS:-}" =~ ^[0-9]+$ ]]; then
-      duration_secs="$PRECOMPACT_STATS_DURATION_SECONDS"
-    fi
-
-    # Mark EMA as recorded for this event regardless of send outcome below;
-    # the stats file has already been mutated and a retry must not re-blend.
-    mkdir -p "$recorded_flag_dir" 2>/dev/null || true
-    : >"$recorded_flag" 2>/dev/null || true
+  if [[ -f "$recorded_flag" ]]; then
+    # Already processed this event_id (flag survives across retries). Tidy up
+    # any stale completed-marker copy and exit; pending JSON was archived to
+    # history at the time of the original successful send.
+    mv -f "$marker" "$processed_dir/$marker_basename" 2>/dev/null || true
+    return 0
   fi
 
   # Render the follow-up body.
@@ -3985,6 +3969,27 @@ if isinstance(data, dict):
   fi
 
   # Followup succeeded — finalize pending and archive history.
+  #
+  # Order matters for crash-restart correctness (see r3 of #611):
+  #   1. Write the per-event flag FIRST so a crash between flag and stats
+  #      leaves the flag present; the next sync short-circuits at the entry
+  #      block and never re-blends the EMA. Stats are slightly under-counted
+  #      by one sample in that narrow window, which is acceptable; double
+  #      counting is not.
+  #   2. Run record-precompact-completion to mutate precompact-stats.json.
+  #   3. Update the pending JSON in place, then archive + move the marker.
+  mkdir -p "$recorded_flag_dir" 2>/dev/null || true
+  : >"$recorded_flag" 2>/dev/null || true
+
+  bridge_with_timeout 10 precompact_stats_record python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
+    record-precompact-completion \
+    --agent "$agent" \
+    --trigger "$pending_trigger" \
+    --started-ts "$pending_started_ts" \
+    --completed-ts "$completed_ts" \
+    --bridge-state-dir "$BRIDGE_STATE_DIR" \
+    --format shell >/dev/null 2>&1 || true
+
   python3 -c '
 import json, sys
 path = sys.argv[1]

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3333,6 +3333,632 @@ process_channel_health() {
   done
 }
 
+# Issue #597 Track B: PreCompact channel auto-notify observer.
+#
+# Each daemon sync cycle:
+#   1. Walk every started marker under
+#      $BRIDGE_STATE_DIR/precompact-events/<agent>/started/.
+#      For each eligible agent (opt-in, static source, claude engine, auto
+#      trigger, declared channels, dedup window respected) resolve a route
+#      via bridge_channel_precompact_target, render a notice template, and
+#      send via bridge_channel_send_managed_message wrapped in
+#      bridge_with_timeout.
+#   2. Walk every completed marker under
+#      $BRIDGE_STATE_DIR/precompact-events/<agent>/completed/. If a pending
+#      notice exists for that agent (and follow-up has not already been
+#      sent), update the EMA stats and send a "back online" follow-up
+#      threaded against the original notice when possible.
+#   3. Move processed markers to the agent's processed/ subdirectory; move
+#      malformed markers to invalid/ silently.
+#
+# Network sends are wrapped in bridge_with_timeout so a stuck Discord/
+# Telegram POST cannot block the daemon's main loop. The kill switch
+# BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1 short-circuits the entire helper.
+process_precompact_events() {
+  if [[ "${BRIDGE_PRECOMPACT_NOTIFY_DISABLED:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  local events_root="$BRIDGE_STATE_DIR/precompact-events"
+  [[ -d "$events_root" ]] || return 0
+
+  local agent_dir agent
+  shopt -s nullglob
+  for agent_dir in "$events_root"/*; do
+    [[ -d "$agent_dir" ]] || continue
+    agent="$(basename "$agent_dir")"
+    [[ -n "$agent" ]] || continue
+    _bridge_precompact_process_started_markers "$agent" "$agent_dir" || true
+    _bridge_precompact_process_completed_markers "$agent" "$agent_dir" || true
+  done
+  shopt -u nullglob
+}
+
+# Internal: process every started marker for one agent. Each marker either
+# becomes a sent notice (with pending state) or is skipped; in both cases the
+# marker moves to processed/ so the daemon does not reconsider it. Malformed
+# JSON files move to invalid/.
+_bridge_precompact_process_started_markers() {
+  local agent="$1"
+  local agent_dir="$2"
+  local started_dir="$agent_dir/started"
+  [[ -d "$started_dir" ]] || return 0
+
+  local marker
+  shopt -s nullglob
+  for marker in "$started_dir"/*.json; do
+    _bridge_precompact_handle_started "$agent" "$agent_dir" "$marker" || true
+  done
+  shopt -u nullglob
+}
+
+_bridge_precompact_handle_started() {
+  local agent="$1"
+  local agent_dir="$2"
+  local marker="$3"
+
+  local processed_dir="$agent_dir/processed"
+  local invalid_dir="$agent_dir/invalid"
+  mkdir -p "$processed_dir" "$invalid_dir"
+
+  local marker_basename
+  marker_basename="$(basename "$marker")"
+
+  # Parse the marker JSON via python so we never have to grep raw JSON.
+  local parsed
+  parsed="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(2)
+if not isinstance(data, dict):
+    sys.exit(2)
+print("event_id\t" + str(data.get("event_id") or ""))
+print("trigger\t" + str(data.get("trigger") or ""))
+print("started_ts\t" + str(data.get("started_ts") or 0))
+print("raw_trigger\t" + str(data.get("raw_trigger") or ""))
+' "$marker" 2>/dev/null)" || {
+    mv -f "$marker" "$invalid_dir/$marker_basename" 2>/dev/null || true
+    return 0
+  }
+
+  local event_id="" trigger="" started_ts="" raw_trigger=""
+  local key="" val=""
+  while IFS=$'\t' read -r key val; do
+    case "$key" in
+      event_id) event_id="$val" ;;
+      trigger) trigger="$val" ;;
+      started_ts) started_ts="$val" ;;
+      raw_trigger) raw_trigger="$val" ;;
+    esac
+  done <<<"$parsed"
+
+  if [[ -z "$event_id" ]]; then
+    mv -f "$marker" "$invalid_dir/$marker_basename" 2>/dev/null || true
+    return 0
+  fi
+
+  # Eligibility checks. Any silent skip moves the marker to processed/ so we
+  # don't reconsider it on every cycle.
+  if ! _bridge_precompact_is_agent_eligible "$agent"; then
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  fi
+  if [[ "$trigger" != "auto" ]]; then
+    # Manual /compact never gets an auto-notice (operator typed the command).
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  fi
+
+  local agent_state_dir="$BRIDGE_STATE_DIR/agents/$agent"
+  mkdir -p "$agent_state_dir"
+
+  # Dedup: skip when the same event_id was already processed.
+  local last_event_file="$agent_state_dir/precompact-notice-last-event-id"
+  if [[ -f "$last_event_file" ]]; then
+    local last_event=""
+    last_event="$(<"$last_event_file")" 2>/dev/null || last_event=""
+    if [[ "$last_event" == "$event_id" ]]; then
+      mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+      return 0
+    fi
+  fi
+
+  # Dedup: skip when the previous notice was sent within the dedup window.
+  local last_ts_file="$agent_state_dir/precompact-notice-last-ts"
+  local now_ts
+  now_ts="$(date +%s 2>/dev/null || echo 0)"
+  local dedup_window="${BRIDGE_PRECOMPACT_NOTICE_DEDUP_SECONDS:-300}"
+  [[ "$dedup_window" =~ ^[0-9]+$ ]] || dedup_window=300
+  if [[ -f "$last_ts_file" ]]; then
+    local last_ts=""
+    last_ts="$(<"$last_ts_file")" 2>/dev/null || last_ts=""
+    if [[ "$last_ts" =~ ^[0-9]+$ ]] && (( now_ts - last_ts < dedup_window )); then
+      mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+      return 0
+    fi
+  fi
+
+  local channels_csv=""
+  channels_csv="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+  if [[ -z "$channels_csv" ]]; then
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  fi
+
+  # Resolve the channel route. Non-zero exit = no recent inbound = silent skip.
+  # Invoke python3 directly (bridge_with_timeout wraps timeout(1), which can
+  # only wrap external commands — not the bash function bridge_channel_precompact_target).
+  local route_output=""
+  local route_rc=0
+  route_output="$(bridge_with_timeout 15 precompact_route python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
+    route-precompact-target \
+    --agent "$agent" \
+    --channels-csv "$channels_csv" \
+    --bridge-state-dir "$BRIDGE_STATE_DIR" \
+    --recency-seconds "${BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS:-1800}" \
+    --now-ts "$now_ts" \
+    --format shell 2>/dev/null)" || route_rc=$?
+  if (( route_rc != 0 )) || [[ -z "$route_output" ]]; then
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  fi
+
+  local CHANNEL_ROUTE_PLUGIN="" CHANNEL_ROUTE_CHANNEL_ID=""
+  local CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID="" CHANNEL_ROUTE_LAST_USER_INBOUND_TS=""
+  local CHANNEL_ROUTE_THREAD_ID=""
+  # shellcheck disable=SC1090
+  source /dev/stdin <<<"$route_output"
+
+  if [[ -z "$CHANNEL_ROUTE_PLUGIN" || -z "$CHANNEL_ROUTE_CHANNEL_ID" ]]; then
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  fi
+
+  # Render the notice body.
+  local lang
+  lang="$(bridge_agent_precompact_notify_lang "$agent")"
+  local render_output=""
+  render_output="$(bridge_with_timeout 10 precompact_render python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
+    render-precompact-message \
+    --agent "$agent" \
+    --kind notice \
+    --lang "$lang" \
+    --plugin "$CHANNEL_ROUTE_PLUGIN" \
+    --channel-id "$CHANNEL_ROUTE_CHANNEL_ID" \
+    --trigger "$trigger" \
+    --started-ts "$started_ts" \
+    --bridge-state-dir "$BRIDGE_STATE_DIR" \
+    --read-stats \
+    --format shell 2>/dev/null)" || {
+    bridge_audit_log daemon precompact_notice_failed "$agent" \
+      --detail event_id="$event_id" \
+      --detail plugin="$CHANNEL_ROUTE_PLUGIN" \
+      --detail channel_id="$CHANNEL_ROUTE_CHANNEL_ID" \
+      --detail error_class="render_failed" 2>/dev/null || true
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  }
+
+  local PRECOMPACT_BODY_B64="" PRECOMPACT_EXPECTED_SECONDS=""
+  local PRECOMPACT_LANG="" PRECOMPACT_KIND="" PRECOMPACT_DURATION_SECONDS=""
+  # shellcheck disable=SC1090
+  source /dev/stdin <<<"$render_output"
+  local body=""
+  if [[ -n "$PRECOMPACT_BODY_B64" ]]; then
+    body="$(printf '%s' "$PRECOMPACT_BODY_B64" | base64 -d 2>/dev/null || true)"
+  fi
+  if [[ -z "$body" ]]; then
+    bridge_audit_log daemon precompact_notice_failed "$agent" \
+      --detail event_id="$event_id" \
+      --detail error_class="empty_body" 2>/dev/null || true
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  fi
+
+  # Send the notice. Invoke python3 directly (bridge_with_timeout wraps
+  # timeout(1), which can only wrap external commands).
+  local -a send_args=(
+    send-managed-message
+    --plugin "$CHANNEL_ROUTE_PLUGIN"
+    --agent "$agent"
+    --channel-id "$CHANNEL_ROUTE_CHANNEL_ID"
+    --body "$body"
+    --kind notice
+    --bridge-home "$BRIDGE_HOME"
+    --bridge-state-dir "$BRIDGE_STATE_DIR"
+    --correlation-id "$event_id"
+    --format shell
+  )
+  if [[ -n "$CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID" ]]; then
+    send_args+=(--reply-to-message-id "$CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID")
+  fi
+  if [[ "${BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN:-0}" == "1" ]]; then
+    send_args+=(--dry-run)
+  fi
+  local send_output=""
+  local send_rc=0
+  send_output="$(bridge_with_timeout 30 precompact_send python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" "${send_args[@]}" 2>/dev/null)" || send_rc=$?
+
+  local CHANNEL_SEND_STATUS="" CHANNEL_SEND_PLUGIN="" CHANNEL_SEND_CHANNEL_ID=""
+  local CHANNEL_SEND_REPLY_TO_MESSAGE_ID="" CHANNEL_SEND_MESSAGE_ID=""
+  local CHANNEL_SEND_THREAD_ID="" CHANNEL_SEND_DRY_RUN=""
+  if [[ -n "$send_output" ]]; then
+    # shellcheck disable=SC1090
+    source /dev/stdin <<<"$send_output"
+  fi
+
+  if (( send_rc != 0 )) || [[ "$CHANNEL_SEND_STATUS" != "ok" ]]; then
+    bridge_audit_log daemon precompact_notice_failed "$agent" \
+      --detail event_id="$event_id" \
+      --detail plugin="$CHANNEL_ROUTE_PLUGIN" \
+      --detail channel_id="$CHANNEL_ROUTE_CHANNEL_ID" \
+      --detail reply_to_message_id="$CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID" \
+      --detail expected_seconds="$PRECOMPACT_EXPECTED_SECONDS" \
+      --detail trigger="$trigger" \
+      --detail started_ts="$started_ts" \
+      --detail send_rc="$send_rc" \
+      --detail error_class="send_failed" 2>/dev/null || true
+    mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+    return 0
+  fi
+
+  # Persist dedup state and pending-notice JSON for the follow-up handler.
+  printf '%s\n' "$now_ts" >"$last_ts_file" 2>/dev/null || true
+  printf '%s\n' "$event_id" >"$last_event_file" 2>/dev/null || true
+
+  local pending_path="$agent_state_dir/precompact-notice-pending.json"
+  python3 -c '
+import json, sys
+data = {
+    "event_id": sys.argv[1],
+    "agent": sys.argv[2],
+    "plugin": sys.argv[3],
+    "channel_id": sys.argv[4],
+    "reply_to_message_id": sys.argv[5],
+    "notice_message_id": sys.argv[6],
+    "thread_id": sys.argv[7],
+    "trigger": sys.argv[8],
+    "started_ts": int(sys.argv[9] or 0),
+    "notice_sent_ts": int(sys.argv[10] or 0),
+    "expected_seconds": int(sys.argv[11] or 0),
+    "lang": sys.argv[12],
+    "dry_run": sys.argv[13] == "1",
+}
+with open(sys.argv[14], "w", encoding="utf-8") as fh:
+    json.dump(data, fh, ensure_ascii=False, indent=2)
+    fh.write("\n")
+' \
+    "$event_id" \
+    "$agent" \
+    "$CHANNEL_ROUTE_PLUGIN" \
+    "$CHANNEL_ROUTE_CHANNEL_ID" \
+    "$CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID" \
+    "$CHANNEL_SEND_MESSAGE_ID" \
+    "$CHANNEL_SEND_THREAD_ID" \
+    "$trigger" \
+    "$started_ts" \
+    "$now_ts" \
+    "$PRECOMPACT_EXPECTED_SECONDS" \
+    "$PRECOMPACT_LANG" \
+    "${CHANNEL_SEND_DRY_RUN:-0}" \
+    "$pending_path" 2>/dev/null || true
+
+  bridge_audit_log daemon precompact_notice_sent "$agent" \
+    --detail event_id="$event_id" \
+    --detail plugin="$CHANNEL_ROUTE_PLUGIN" \
+    --detail channel_id="$CHANNEL_ROUTE_CHANNEL_ID" \
+    --detail reply_to_message_id="$CHANNEL_ROUTE_REPLY_TO_MESSAGE_ID" \
+    --detail notice_message_id="$CHANNEL_SEND_MESSAGE_ID" \
+    --detail expected_seconds="$PRECOMPACT_EXPECTED_SECONDS" \
+    --detail trigger="$trigger" \
+    --detail started_ts="$started_ts" \
+    --detail dry_run="${CHANNEL_SEND_DRY_RUN:-0}" 2>/dev/null || true
+
+  mv -f "$marker" "$processed_dir/$event_id.json" 2>/dev/null || true
+  : "$raw_trigger"  # silence unused warning under set -u
+  return 0
+}
+
+_bridge_precompact_is_agent_eligible() {
+  local agent="$1"
+
+  bridge_agent_precompact_notify_enabled "$agent" || return 1
+  [[ "$(bridge_agent_source "$agent" 2>/dev/null)" == "static" ]] || return 1
+  [[ "$(bridge_agent_engine "$agent" 2>/dev/null)" == "claude" ]] || return 1
+  return 0
+}
+
+_bridge_precompact_process_completed_markers() {
+  local agent="$1"
+  local agent_dir="$2"
+  local completed_dir="$agent_dir/completed"
+  [[ -d "$completed_dir" ]] || return 0
+
+  local marker
+  shopt -s nullglob
+  for marker in "$completed_dir"/*.json; do
+    _bridge_precompact_handle_completed "$agent" "$agent_dir" "$marker" || true
+  done
+  shopt -u nullglob
+}
+
+_bridge_precompact_handle_completed() {
+  local agent="$1"
+  local agent_dir="$2"
+  local marker="$3"
+
+  local processed_dir="$agent_dir/processed"
+  local invalid_dir="$agent_dir/invalid"
+  mkdir -p "$processed_dir" "$invalid_dir"
+
+  local marker_basename
+  marker_basename="$(basename "$marker")"
+
+  local completed_ts=""
+  completed_ts="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    print(int(data.get("completed_ts") or 0))
+except Exception:
+    sys.exit(2)
+' "$marker" 2>/dev/null)" || {
+    mv -f "$marker" "$invalid_dir/$marker_basename" 2>/dev/null || true
+    return 0
+  }
+
+  local agent_state_dir="$BRIDGE_STATE_DIR/agents/$agent"
+  local pending_path="$agent_state_dir/precompact-notice-pending.json"
+  if [[ ! -f "$pending_path" ]]; then
+    # No pending notice => nothing to follow up. Move on silently.
+    mv -f "$marker" "$processed_dir/$marker_basename" 2>/dev/null || true
+    return 0
+  fi
+
+  # Load pending state.
+  local pending_parsed
+  pending_parsed="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(2)
+if not isinstance(data, dict):
+    sys.exit(2)
+keys = ("event_id", "plugin", "channel_id", "reply_to_message_id",
+        "notice_message_id", "trigger", "started_ts", "lang", "dry_run",
+        "followup_sent_ts")
+for k in keys:
+    v = data.get(k, "")
+    if isinstance(v, bool):
+        v = "1" if v else "0"
+    print(f"{k}\t{v}")
+' "$pending_path" 2>/dev/null)" || {
+    mv -f "$marker" "$invalid_dir/$marker_basename" 2>/dev/null || true
+    return 0
+  }
+
+  local pending_event_id="" pending_plugin="" pending_channel_id=""
+  local pending_reply_to="" pending_notice_msg_id="" pending_trigger=""
+  local pending_started_ts="0" pending_lang="" pending_dry_run="0"
+  local pending_followup_sent_ts=""
+  local pkey="" pval=""
+  while IFS=$'\t' read -r pkey pval; do
+    case "$pkey" in
+      event_id) pending_event_id="$pval" ;;
+      plugin) pending_plugin="$pval" ;;
+      channel_id) pending_channel_id="$pval" ;;
+      reply_to_message_id) pending_reply_to="$pval" ;;
+      notice_message_id) pending_notice_msg_id="$pval" ;;
+      trigger) pending_trigger="$pval" ;;
+      started_ts) pending_started_ts="$pval" ;;
+      lang) pending_lang="$pval" ;;
+      dry_run) pending_dry_run="$pval" ;;
+      followup_sent_ts) pending_followup_sent_ts="$pval" ;;
+    esac
+  done <<<"$pending_parsed"
+
+  if [[ -n "$pending_followup_sent_ts" && "$pending_followup_sent_ts" != "0" ]]; then
+    # Already sent followup for this pending notice — completion marker is
+    # for a later compaction; archive it.
+    mv -f "$marker" "$processed_dir/$marker_basename" 2>/dev/null || true
+    return 0
+  fi
+
+  if [[ -z "$pending_event_id" || -z "$pending_plugin" || -z "$pending_channel_id" ]]; then
+    mv -f "$marker" "$processed_dir/$marker_basename" 2>/dev/null || true
+    return 0
+  fi
+
+  # Update EMA stats and resolve duration / expected_seconds for the followup.
+  local stats_output=""
+  stats_output="$(bridge_with_timeout 10 precompact_stats_record python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
+    record-precompact-completion \
+    --agent "$agent" \
+    --trigger "$pending_trigger" \
+    --started-ts "$pending_started_ts" \
+    --completed-ts "$completed_ts" \
+    --bridge-state-dir "$BRIDGE_STATE_DIR" \
+    --format shell 2>/dev/null)" || stats_output=""
+
+  local PRECOMPACT_STATS_DURATION_SECONDS=""
+  local PRECOMPACT_STATS_EXPECTED_SECONDS=""
+  local PRECOMPACT_STATS_ALPHA=""
+  if [[ -n "$stats_output" ]]; then
+    # shellcheck disable=SC1090
+    source /dev/stdin <<<"$stats_output"
+  fi
+
+  local duration_secs="${PRECOMPACT_STATS_DURATION_SECONDS:-0}"
+  [[ "$duration_secs" =~ ^[0-9]+$ ]] || duration_secs=0
+
+  # Render the follow-up body.
+  local render_output=""
+  render_output="$(bridge_with_timeout 10 precompact_render_followup python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
+    render-precompact-message \
+    --agent "$agent" \
+    --kind followup \
+    --lang "${pending_lang:-en}" \
+    --plugin "$pending_plugin" \
+    --channel-id "$pending_channel_id" \
+    --trigger "$pending_trigger" \
+    --duration-seconds "$duration_secs" \
+    --started-ts "$pending_started_ts" \
+    --completed-ts "$completed_ts" \
+    --bridge-state-dir "$BRIDGE_STATE_DIR" \
+    --format shell 2>/dev/null)" || render_output=""
+
+  local PRECOMPACT_BODY_B64="" PRECOMPACT_EXPECTED_SECONDS=""
+  local PRECOMPACT_LANG="" PRECOMPACT_KIND="" PRECOMPACT_DURATION_SECONDS=""
+  if [[ -n "$render_output" ]]; then
+    # shellcheck disable=SC1090
+    source /dev/stdin <<<"$render_output"
+  fi
+  local body=""
+  if [[ -n "$PRECOMPACT_BODY_B64" ]]; then
+    body="$(printf '%s' "$PRECOMPACT_BODY_B64" | base64 -d 2>/dev/null || true)"
+  fi
+
+  local followup_thread_anchor="$pending_notice_msg_id"
+  if [[ -z "$followup_thread_anchor" ]]; then
+    followup_thread_anchor="$pending_reply_to"
+  fi
+
+  # Honor pending dry-run state to keep notice + followup symmetric in CI.
+  local saved_dry_run="${BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN:-0}"
+  if [[ "$pending_dry_run" == "1" ]]; then
+    export BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN=1
+  fi
+
+  local send_rc=0
+  local send_output=""
+  if [[ -z "$body" ]]; then
+    send_rc=1
+  else
+    local -a fu_send_args=(
+      send-managed-message
+      --plugin "$pending_plugin"
+      --agent "$agent"
+      --channel-id "$pending_channel_id"
+      --body "$body"
+      --kind followup
+      --bridge-home "$BRIDGE_HOME"
+      --bridge-state-dir "$BRIDGE_STATE_DIR"
+      --correlation-id "$pending_event_id"
+      --format shell
+    )
+    if [[ -n "$followup_thread_anchor" ]]; then
+      fu_send_args+=(--reply-to-message-id "$followup_thread_anchor")
+    fi
+    if [[ "${BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN:-0}" == "1" ]]; then
+      fu_send_args+=(--dry-run)
+    fi
+    send_output="$(bridge_with_timeout 30 precompact_send_followup python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" "${fu_send_args[@]}" 2>/dev/null)" || send_rc=$?
+  fi
+
+  if [[ "$pending_dry_run" == "1" ]]; then
+    export BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN="$saved_dry_run"
+  fi
+
+  local CHANNEL_SEND_STATUS="" CHANNEL_SEND_MESSAGE_ID="" CHANNEL_SEND_DRY_RUN=""
+  if [[ -n "$send_output" ]]; then
+    # shellcheck disable=SC1090
+    source /dev/stdin <<<"$send_output"
+  fi
+
+  local now_ts
+  now_ts="$(date +%s 2>/dev/null || echo 0)"
+
+  if (( send_rc != 0 )) || [[ "$CHANNEL_SEND_STATUS" != "ok" ]]; then
+    # Honor the retry window: keep pending in place if we're still inside
+    # BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS; otherwise archive and give up.
+    local retry_window="${BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS:-600}"
+    [[ "$retry_window" =~ ^[0-9]+$ ]] || retry_window=600
+    bridge_audit_log daemon precompact_followup_failed "$agent" \
+      --detail event_id="$pending_event_id" \
+      --detail plugin="$pending_plugin" \
+      --detail channel_id="$pending_channel_id" \
+      --detail duration_seconds="$duration_secs" \
+      --detail send_rc="$send_rc" \
+      --detail error_class="send_failed" 2>/dev/null || true
+
+    # Update pending followup_attempt_ts and decide whether to expire.
+    local notice_sent_ts=0
+    notice_sent_ts="$(python3 -c '
+import json, sys
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    print(int(data.get("notice_sent_ts") or 0))
+except Exception:
+    sys.exit(2)
+' "$pending_path" 2>/dev/null || echo 0)"
+
+    if [[ "$notice_sent_ts" =~ ^[0-9]+$ ]] && (( now_ts - notice_sent_ts > retry_window )); then
+      mkdir -p "$agent_state_dir/precompact-notice-history"
+      mv -f "$pending_path" "$agent_state_dir/precompact-notice-history/$pending_event_id.json" 2>/dev/null || true
+      mv -f "$marker" "$processed_dir/$marker_basename" 2>/dev/null || true
+    else
+      python3 -c '
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(0)
+if isinstance(data, dict):
+    data["followup_attempt_ts"] = int(sys.argv[2])
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+' "$pending_path" "$now_ts" 2>/dev/null || true
+      # Leave the completed marker in place for the next sync cycle to retry.
+    fi
+    return 0
+  fi
+
+  # Followup succeeded — finalize pending and archive history.
+  python3 -c '
+import json, sys
+path = sys.argv[1]
+try:
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception:
+    sys.exit(0)
+if isinstance(data, dict):
+    data["completed_ts"] = int(sys.argv[2])
+    data["duration_seconds"] = int(sys.argv[3])
+    data["followup_sent_ts"] = int(sys.argv[4])
+    data["followup_message_id"] = sys.argv[5]
+    data["stats_updated"] = 1
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+        fh.write("\n")
+' "$pending_path" "$completed_ts" "$duration_secs" "$now_ts" "$CHANNEL_SEND_MESSAGE_ID" 2>/dev/null || true
+
+  bridge_audit_log daemon precompact_followup_sent "$agent" \
+    --detail event_id="$pending_event_id" \
+    --detail plugin="$pending_plugin" \
+    --detail channel_id="$pending_channel_id" \
+    --detail reply_to_message_id="$pending_reply_to" \
+    --detail notice_message_id="$pending_notice_msg_id" \
+    --detail followup_message_id="$CHANNEL_SEND_MESSAGE_ID" \
+    --detail duration_seconds="$duration_secs" \
+    --detail dry_run="${CHANNEL_SEND_DRY_RUN:-0}" 2>/dev/null || true
+
+  mkdir -p "$agent_state_dir/precompact-notice-history"
+  mv -f "$pending_path" "$agent_state_dir/precompact-notice-history/$pending_event_id.json" 2>/dev/null || true
+  mv -f "$marker" "$processed_dir/$marker_basename" 2>/dev/null || true
+  return 0
+}
+
 cron_worker_running_count() {
   local worker_dir
   local pid_file
@@ -4488,6 +5114,13 @@ cmd_sync_cycle() {
   # Discord relay runs FIRST — lowest-latency path for DM wake
   BRIDGE_DAEMON_LAST_STEP="discord_relay"
   bridge_discord_relay_step || true
+
+  # Issue #597 Track B: PreCompact channel auto-notify observer. Runs after
+  # the Discord relay (so any inbound user activity is already mirrored into
+  # the activity index when the route lookup runs) and before bridge-sync,
+  # which is the cheap "I/O is mostly done for this cycle" boundary.
+  BRIDGE_DAEMON_LAST_STEP="precompact_events"
+  process_precompact_events || true
 
   BRIDGE_DAEMON_LAST_STEP="bridge_sync"
   "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-sync.sh" >/dev/null 2>&1 || true

--- a/hooks/pre-compact.py
+++ b/hooks/pre-compact.py
@@ -53,14 +53,21 @@ from __future__ import annotations
 import json
 import os
 import re
+import secrets
 import subprocess
 import sys
 import tempfile
-from datetime import datetime
+import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 SCHEMA_VERSION = "1"
 CUSTOM_EXCERPT_LIMIT = 500
+# Issue #597 Track B: schema for the precompact-events/started/<event_id>.json
+# marker the daemon observer consumes. Bumped only when the marker layout
+# changes in a way the observer needs to branch on; readers must tolerate a
+# missing/older schema_version by treating it as 1.
+MARKER_SCHEMA_VERSION = "1"
 
 # Allow `from bridge_hook_common import …` even when this hook is invoked
 # from `~/.agent-bridge/hooks/pre-compact.py` (the live-runtime layout
@@ -143,6 +150,83 @@ def _read_session_type(home: Path) -> str:
         return ""
     raw = match.group(1).strip().strip("`")
     return raw.split()[0] if raw else ""
+
+
+def _state_dir() -> Path:
+    """Resolve $BRIDGE_STATE_DIR; defaults to <bridge-home>/state.
+
+    The daemon observer reads markers from the same location, so the hook
+    and daemon agree on the path even when BRIDGE_STATE_DIR is unset.
+    """
+    env_state = os.environ.get("BRIDGE_STATE_DIR")
+    if env_state:
+        return Path(env_state)
+    return _bridge_home() / "state"
+
+
+def _new_event_id() -> str:
+    """Generate a sortable event id: <epoch-ms>-<8-hex>.
+
+    Sortable prefix lets the daemon observer process markers in
+    started-time order without parsing the JSON; the random suffix
+    keeps two near-simultaneous compactions on the same agent
+    (vanishingly unlikely but plausible during reproduction tests)
+    from colliding on the same path.
+    """
+    return f"{int(time.time() * 1000):013d}-{secrets.token_hex(4)}"
+
+
+def _write_started_marker(agent: str, payload: dict, trigger: str) -> None:
+    """Write a best-effort started marker for the daemon observer.
+
+    Issue #597 Track B. The marker tells `process_precompact_events` (in
+    bridge-daemon.sh) that a compaction has just begun on this agent so
+    the daemon can resolve a channel route and send the user a "back in
+    ~Ns" notice. The hook stays exit-0 / non-blocking — every error here
+    is swallowed and compaction proceeds exactly as before.
+    """
+    try:
+        event_id = _new_event_id()
+        started_ts = int(time.time())
+        started_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        marker = {
+            "schema_version": MARKER_SCHEMA_VERSION,
+            "event_id": event_id,
+            "agent": agent,
+            "trigger": trigger,
+            "raw_trigger": str(payload.get("trigger") or payload.get("reason") or ""),
+            "started_ts": started_ts,
+            "started_iso": started_iso,
+            "hook_pid": os.getpid(),
+        }
+        if isinstance(payload, dict) and payload:
+            marker["payload_keys"] = sorted(k for k in payload.keys() if isinstance(k, str))
+
+        target_dir = _state_dir() / "precompact-events" / agent / "started"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / f"{event_id}.json"
+        # Atomic temp-then-replace so a half-written marker can never be
+        # read by the daemon mid-write.
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(target_dir),
+            prefix=f".{event_id}.",
+            suffix=".tmp",
+            delete=False,
+        ) as fh:
+            json.dump(marker, fh, ensure_ascii=False)
+            fh.write("\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass
+            tmp_path = fh.name
+        os.replace(tmp_path, target)
+    except Exception:
+        # Hook stays exit-0; missing marker just means no notice gets sent.
+        pass
 
 
 def _normalize_trigger(payload: dict) -> str:
@@ -273,6 +357,14 @@ def main() -> int:
         if not agent or home is None:
             return 0
         payload = _stdin_payload()
+
+        # Issue #597 Track B: write the daemon-observer marker BEFORE the
+        # synchronous capture path. The capture flow is best-effort and may
+        # block briefly on bridge-memory; writing the marker first keeps
+        # notice latency bounded by daemon interval rather than capture
+        # duration. The marker write is itself best-effort/exit-0.
+        _write_started_marker(agent, payload, _normalize_trigger(payload))
+
         snapshot_path = _capture_canonical_snapshot(agent)
         envelope = _build_envelope(agent, home, payload, snapshot_path)
 

--- a/hooks/session_start.py
+++ b/hooks/session_start.py
@@ -21,7 +21,9 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 
 from bridge_hook_common import (
@@ -30,6 +32,11 @@ from bridge_hook_common import (
     remember_session_start,
     session_start_context,
 )
+
+# Issue #597 Track B: schema for the completed-marker the daemon observer
+# pairs with the started marker emitted by hooks/pre-compact.py. Bumped
+# only when the layout changes in a way the observer needs to branch on.
+_COMPLETED_MARKER_SCHEMA_VERSION = "1"
 
 
 _KNOWN_MATCHERS = {"startup", "resume", "clear", "compact"}
@@ -95,6 +102,59 @@ def _compact_note_should_emit(agent: str, now_epoch: int | None = None) -> bool:
     return True
 
 
+def _write_compact_completed_marker(agent: str, matcher: str) -> None:
+    """Write a best-effort completion marker for the daemon observer.
+
+    Issue #597 Track B. The daemon's `process_precompact_events` pairs this
+    completion marker with the `started` marker that `hooks/pre-compact.py`
+    wrote when compaction began so it can (a) send the operator a
+    "back online" follow-up message and (b) update the per-agent EMA of
+    compaction duration used to render the "I'll be back in ~Ns" notice.
+
+    The hook stays exit-0 / non-blocking — every error is swallowed and the
+    SessionStart contract is preserved.
+    """
+    try:
+        completed_ts = int(time.time())
+        completed_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        hook_pid = os.getpid()
+        # Marker filename uses <completed_ts>-<pid>.json so the observer can
+        # process completions in chronological order without parsing JSON;
+        # pid breaks ties on the unlikely same-second double-fire.
+        target_dir = bridge_state_dir() / "precompact-events" / agent / "completed"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        marker_name = f"{completed_ts}-{hook_pid}.json"
+        target = target_dir / marker_name
+        marker = {
+            "schema_version": _COMPLETED_MARKER_SCHEMA_VERSION,
+            "agent": agent,
+            "completed_ts": completed_ts,
+            "completed_iso": completed_iso,
+            "hook_pid": hook_pid,
+            "matcher": matcher,
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=str(target_dir),
+            prefix=f".{marker_name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as fh:
+            json.dump(marker, fh, ensure_ascii=False)
+            fh.write("\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass
+            tmp_path = fh.name
+        os.replace(tmp_path, target)
+    except Exception:
+        # Hook stays exit-0; missing marker just means no follow-up gets sent.
+        pass
+
+
 def _forget_session_on_clear(agent: str) -> None:
     """Auto-forget the persisted resume id when /clear forks the session.
 
@@ -154,6 +214,13 @@ def main(argv: list[str] | None = None) -> int:
         _forget_session_on_clear(agent)
     context = session_start_context(agent)
     if matcher == "compact" and _compact_note_should_emit(agent):
+        # Issue #597 Track B: leave a completion marker for the daemon
+        # observer BEFORE doing the (synchronous) canonical recovery work
+        # below. The marker write is best-effort — if the state dir is not
+        # writable, the daemon simply won't send a follow-up and compaction
+        # behavior is unchanged.
+        _write_compact_completed_marker(agent, matcher)
+
         # #509 P3 (C3): re-inject canonical identity files BEFORE the queue
         # context so the model reads SOUL/MEMORY/etc before acting on any
         # post-compact queue prompt. The trailing `_compact_note()` is kept

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -397,6 +397,30 @@ bridge_agent_provenance() {
   printf '%s' "${BRIDGE_AGENT_PROVENANCE[$agent]-static-roster}"
 }
 
+# Issue #597 Track B: PreCompact channel auto-notify opt-in.
+#
+# Returns 0 (success) when the agent is opted in, 1 otherwise. The daemon
+# observer should consult this rather than reading BRIDGE_AGENT_PRECOMPACT_NOTIFY
+# directly so any future normalization (e.g. yes/on/true acceptance) lands in
+# one place. Default is OFF — only the literal value "1" enables the notice.
+bridge_agent_precompact_notify_enabled() {
+  local agent="$1"
+  local val="${BRIDGE_AGENT_PRECOMPACT_NOTIFY[$agent]-0}"
+  [[ "$val" == "1" ]]
+}
+
+# Issue #597 Track B: PreCompact notice language (en|ko).
+#
+# Resolution order: per-agent map → global BRIDGE_PRECOMPACT_NOTIFY_LANG env
+# → "en" fallback. Unknown values pass through; the Python template renderer
+# normalizes anything outside {en, ko} back to "en".
+bridge_agent_precompact_notify_lang() {
+  local agent="$1"
+  local lang="${BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG[$agent]-${BRIDGE_PRECOMPACT_NOTIFY_LANG:-en}}"
+  [[ -n "$lang" ]] || lang="en"
+  printf '%s' "$lang"
+}
+
 # Issue #539: agent class is the privilege boundary consumed by
 # hooks/tool-policy.py. The closed value space is {user, system}; any
 # unknown value (including the empty string written by older roster

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -28,6 +28,68 @@ bridge_channel_precompact_target() {
     --format shell
 }
 
+# Send a managed channel message (PreCompact notice or follow-up) — Track B
+# of issue #597. The daemon observer calls this after `bridge_channel_precompact_target`
+# resolves a route and the Python adapter renders the localized template.
+#
+# Args (positional):
+#   plugin              - "discord" | "telegram" | "teams" | "mattermost"
+#   agent               - bridge agent id (used to locate per-agent plugin
+#                         credentials under <BRIDGE_HOME>/agents/<agent>/.<plugin>/)
+#   channel_id          - platform channel/conversation id from the route
+#   reply_to_message_id - platform message id to thread the reply against
+#                         (may be empty when the route lacks a per-message
+#                         anchor; the Python adapter then sends a plain reply
+#                         in the channel and returns no thread id)
+#   body                - rendered notice/followup text
+#   kind                - "notice" (default) | "followup"; lets adapters
+#                         distinguish the two for telemetry only
+#   correlation_id      - opaque id propagated into adapter logs (optional)
+#
+# On success: emits CHANNEL_SEND_* shell assignments on stdout, exit 0.
+# On failure: returns non-zero with no partial-success output. The daemon
+# catches the non-zero exit and emits a precompact_notice_failed audit row.
+#
+# BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN=1 routes the call through the Python
+# adapter's --dry-run path so CI/smoke can exercise the shell wrapper
+# without performing real network sends.
+bridge_channel_send_managed_message() {
+  local plugin="${1:-}"
+  local agent="${2:-}"
+  local channel_id="${3:-}"
+  local reply_to_message_id="${4:-}"
+  local body="${5:-}"
+  local kind="${6:-notice}"
+  local correlation_id="${7:-}"
+
+  if [[ -z "$plugin" || -z "$agent" || -z "$channel_id" || -z "$body" ]]; then
+    return 2
+  fi
+
+  local -a args=(
+    send-managed-message
+    --plugin "$plugin"
+    --agent "$agent"
+    --channel-id "$channel_id"
+    --body "$body"
+    --kind "$kind"
+    --bridge-home "$BRIDGE_HOME"
+    --bridge-state-dir "$BRIDGE_STATE_DIR"
+    --format shell
+  )
+  if [[ -n "$reply_to_message_id" ]]; then
+    args+=(--reply-to-message-id "$reply_to_message_id")
+  fi
+  if [[ -n "$correlation_id" ]]; then
+    args+=(--correlation-id "$correlation_id")
+  fi
+  if [[ "${BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN:-0}" == "1" ]]; then
+    args+=(--dry-run)
+  fi
+
+  bridge_channels_python "${args[@]}"
+}
+
 bridge_channel_server_script_path() {
   local live_path="$BRIDGE_HOME/bridge-channel-server.py"
 

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -575,6 +575,8 @@ bridge_reset_roster_maps() {
   unset BRIDGE_AGENT_ISOLATION_MODE BRIDGE_AGENT_OS_USER
   unset BRIDGE_AGENT_CLASS
   unset BRIDGE_AGENT_PROVENANCE
+  # Issue #597 Track B: PreCompact channel auto-notify opt-in maps.
+  unset BRIDGE_AGENT_PRECOMPACT_NOTIFY BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG
 
   declare -g -a BRIDGE_AGENT_IDS=()
   declare -g -A BRIDGE_AGENT_DESC=()
@@ -624,7 +626,32 @@ bridge_reset_roster_maps() {
   # implicit behavior of any id present in BRIDGE_AGENT_IDS without a
   # dynamic loader having claimed it.
   declare -g -A BRIDGE_AGENT_PROVENANCE=()
+  # Issue #597 Track B: per-agent opt-in for PreCompact channel auto-notify.
+  # Default OFF (any unset entry is treated as 0). Opt in per-agent in
+  # agent-roster.local.sh: BRIDGE_AGENT_PRECOMPACT_NOTIFY[<agent>]="1".
+  declare -g -A BRIDGE_AGENT_PRECOMPACT_NOTIFY=()
+  # Issue #597 Track B: per-agent language override for PreCompact notice
+  # template. Falls back to BRIDGE_PRECOMPACT_NOTIFY_LANG (env, default "en").
+  declare -g -A BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG=()
   declare -g -a BRIDGE_CRON_ENQUEUE_FAMILIES=()
+
+  # Issue #597 Track B: scalar envs for the auto-notify pipeline. Each is
+  # honored at daemon-cycle time; the kill switch lets operators disable
+  # all sends without redeploy.
+  : "${BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS:=1800}"
+  : "${BRIDGE_PRECOMPACT_NOTICE_DEDUP_SECONDS:=300}"
+  : "${BRIDGE_PRECOMPACT_EMA_ALPHA:=0.30}"
+  : "${BRIDGE_PRECOMPACT_NOTIFY_DISABLED:=0}"
+  : "${BRIDGE_PRECOMPACT_NOTIFY_LANG:=en}"
+  : "${BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN:=0}"
+  : "${BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS:=600}"
+  export BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS \
+    BRIDGE_PRECOMPACT_NOTICE_DEDUP_SECONDS \
+    BRIDGE_PRECOMPACT_EMA_ALPHA \
+    BRIDGE_PRECOMPACT_NOTIFY_DISABLED \
+    BRIDGE_PRECOMPACT_NOTIFY_LANG \
+    BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN \
+    BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS
 }
 
 bridge_add_agent_id_if_missing() {

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1384,6 +1384,11 @@ bridge_load_roster() {
     BRIDGE_AGENT_CONTINUE["$agent"]="${BRIDGE_AGENT_CONTINUE[$agent]-1}"
     BRIDGE_AGENT_HISTORY_KEY["$agent"]="${BRIDGE_AGENT_HISTORY_KEY[$agent]-$(bridge_history_key_for "$(bridge_agent_engine "$agent")" "$agent" "$(bridge_agent_workdir "$agent")")}"
     BRIDGE_AGENT_IDLE_TIMEOUT["$agent"]="${BRIDGE_AGENT_IDLE_TIMEOUT[$agent]-$BRIDGE_ON_DEMAND_IDLE_SECONDS}"
+    # Issue #597 Track B: default OFF for PreCompact auto-notify. Per-agent
+    # opt-in lives in agent-roster.local.sh; the language map falls back to
+    # the global BRIDGE_PRECOMPACT_NOTIFY_LANG env (default "en").
+    BRIDGE_AGENT_PRECOMPACT_NOTIFY["$agent"]="${BRIDGE_AGENT_PRECOMPACT_NOTIFY[$agent]-0}"
+    BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG["$agent"]="${BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG[$agent]-${BRIDGE_PRECOMPACT_NOTIFY_LANG:-en}}"
   done
 
   bridge_load_dynamic_agents

--- a/tests/precompact-notify/observer-smoke.sh
+++ b/tests/precompact-notify/observer-smoke.sh
@@ -1,0 +1,552 @@
+#!/usr/bin/env bash
+# precompact-notify observer + send primitive smoke — issue #597 Track B.
+#
+# Exercises:
+#   - hooks/pre-compact.py marker write under an isolated BRIDGE_HOME.
+#   - hooks/session_start.py compact-matcher completion marker.
+#   - bridge-channels.py render-precompact-message (en + ko, notice + followup).
+#   - bridge-channels.py send-managed-message --dry-run (Discord + Telegram).
+#   - bridge-channels.py record-precompact-completion (EMA stats schema).
+#   - bridge-daemon.sh process_precompact_events end-to-end with a mocked
+#     activity index + dry-run sender, verifying:
+#       * pending-state JSON is written
+#       * precompact-notice-last-ts / -last-event-id dedup files appear
+#       * processed/<event_id>.json marker is moved
+#       * precompact_notice_sent audit row lands
+#       * a completed marker triggers a precompact_followup_sent audit + EMA update
+#
+# Track B does NOT register this in scripts/smoke-test.sh — Track D wires
+# the full precompact-notify suite once the writers + TS plugin extensions
+# are in place.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+DAEMON="$REPO_ROOT/bridge-daemon.sh"
+CHANNELS_PY="$REPO_ROOT/bridge-channels.py"
+PRECOMPACT_HOOK="$REPO_ROOT/hooks/pre-compact.py"
+SESSION_START_HOOK="$REPO_ROOT/hooks/session_start.py"
+
+if [[ ! -x "$PYTHON" && ! -r "$PYTHON" ]]; then
+  printf '[smoke][error] python3 not found at %s\n' "$PYTHON" >&2
+  exit 2
+fi
+for f in "$DAEMON" "$CHANNELS_PY" "$PRECOMPACT_HOOK" "$SESSION_START_HOOK"; do
+  if [[ ! -f "$f" ]]; then
+    printf '[smoke][error] required file missing: %s\n' "$f" >&2
+    exit 2
+  fi
+done
+
+ROOT="$(mktemp -d -t precompact-observer.XXXXXX)"
+trap 'rm -rf "$ROOT"' EXIT
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+  if [[ -n "${2:-}" ]]; then
+    printf '%s\n' "$2" | sed 's/^/[smoke][fail][detail]   /' >&2
+  fi
+}
+
+# -- T1: hooks/pre-compact.py writes a started marker -------------------------
+
+t1_started_marker() {
+  local home="$ROOT/t1-home"
+  local state_dir="$home/state"
+  mkdir -p "$home/agents/dev"
+
+  # Empty stdin payload — hook should still write a marker with trigger=unknown
+  # (we then test trigger=auto explicitly below). bridge-memory.py absent =>
+  # the existing capture path is a no-op, but the marker write should still happen.
+  local payload='{"trigger": "auto"}'
+  local out
+  out="$(BRIDGE_HOME="$home" BRIDGE_STATE_DIR="$state_dir" BRIDGE_AGENT_ID=dev \
+    BRIDGE_AGENT_HOME="$home/agents/dev" \
+    "$PYTHON" "$PRECOMPACT_HOOK" 2>&1 <<<"$payload")"
+  local rc=$?
+  if (( rc != 0 )); then
+    fail "T1 pre-compact hook should exit 0" "rc=$rc out=$out"
+    return
+  fi
+
+  local started_count
+  started_count="$(find "$state_dir/precompact-events/dev/started" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "$started_count" != "1" ]]; then
+    fail "T1 expected exactly 1 started marker; got $started_count" \
+         "$(ls -la "$state_dir/precompact-events/dev/started" 2>/dev/null || true)"
+    return
+  fi
+
+  local marker
+  marker="$(find "$state_dir/precompact-events/dev/started" -name '*.json')"
+  local trigger
+  trigger="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+print(data.get("trigger") or "")
+' "$marker")"
+  if [[ "$trigger" != "auto" ]]; then
+    fail "T1 marker trigger should be 'auto'; got '$trigger'"
+    return
+  fi
+  pass "T1 hooks/pre-compact.py writes started marker (trigger=auto)"
+}
+
+# -- T2: hooks/session_start.py writes a completed marker on compact -----------
+
+t2_completed_marker() {
+  local home="$ROOT/t2-home"
+  local state_dir="$home/state"
+  mkdir -p "$home/agents/dev" "$state_dir"
+
+  local payload='{"matcher": "compact"}'
+  local out
+  out="$(BRIDGE_HOME="$home" BRIDGE_STATE_DIR="$state_dir" BRIDGE_AGENT_ID=dev \
+    "$PYTHON" "$SESSION_START_HOOK" 2>&1 <<<"$payload")"
+  local rc=$?
+  if (( rc != 0 )); then
+    fail "T2 session_start hook should exit 0" "rc=$rc out=$out"
+    return
+  fi
+
+  local count
+  count="$(find "$state_dir/precompact-events/dev/completed" -name '*.json' 2>/dev/null | wc -l | tr -d ' ')"
+  if [[ "$count" != "1" ]]; then
+    fail "T2 expected exactly 1 completed marker; got $count"
+    return
+  fi
+  pass "T2 hooks/session_start.py writes completed marker on compact matcher"
+}
+
+# -- T3: bridge-channels.py render-precompact-message (en + ko) ---------------
+
+t3_render_templates() {
+  local state_dir="$ROOT/t3-state"
+  mkdir -p "$state_dir"
+
+  local out
+  out="$("$PYTHON" "$CHANNELS_PY" render-precompact-message \
+    --agent dev --kind notice --lang en \
+    --plugin discord --channel-id ch1 --trigger auto \
+    --expected-seconds 60 \
+    --bridge-state-dir "$state_dir" \
+    --format json)"
+  if ! grep -q '"BODY"' <<<"$out"; then
+    fail "T3 render notice/en should emit BODY field" "$out"
+    return
+  fi
+  if ! grep -q 'compacting' <<<"$out"; then
+    fail "T3 render notice/en should include 'compacting'" "$out"
+    return
+  fi
+
+  local out_ko
+  out_ko="$("$PYTHON" "$CHANNELS_PY" render-precompact-message \
+    --agent dev --kind notice --lang ko \
+    --plugin telegram --channel-id ch2 --trigger auto \
+    --expected-seconds 45 \
+    --bridge-state-dir "$state_dir" \
+    --format json)"
+  # Korean template includes "압축" (compaction). Match via python in case grep
+  # locale acts up on macOS.
+  local has_ko
+  has_ko="$("$PYTHON" -c '
+import json, sys
+data = json.loads(sys.argv[1])
+print("ok" if "압축" in data.get("BODY", "") else "no")
+' "$out_ko")"
+  if [[ "$has_ko" != "ok" ]]; then
+    fail "T3 render notice/ko should include 압축" "$out_ko"
+    return
+  fi
+
+  local out_followup
+  out_followup="$("$PYTHON" "$CHANNELS_PY" render-precompact-message \
+    --agent dev --kind followup --lang en \
+    --plugin discord --channel-id ch1 \
+    --duration-seconds 30 \
+    --bridge-state-dir "$state_dir" \
+    --format json)"
+  if ! grep -q 'back online' <<<"$out_followup"; then
+    fail "T3 render followup/en should include 'back online'" "$out_followup"
+    return
+  fi
+  pass "T3 render-precompact-message renders en + ko notice + followup"
+}
+
+# -- T4: bridge-channels.py send-managed-message --dry-run --------------------
+
+t4_send_dry_run() {
+  local home="$ROOT/t4-home"
+  local state_dir="$home/state"
+  mkdir -p "$home" "$state_dir"
+
+  local out
+  out="$("$PYTHON" "$CHANNELS_PY" send-managed-message \
+    --plugin discord --agent dev --channel-id 1234 \
+    --reply-to-message-id 9999 \
+    --body 'hello' --kind notice \
+    --bridge-home "$home" --bridge-state-dir "$state_dir" \
+    --format shell --dry-run)"
+  if ! grep -q '^CHANNEL_SEND_STATUS="ok"' <<<"$out"; then
+    fail "T4 send --dry-run should emit CHANNEL_SEND_STATUS=ok" "$out"
+    return
+  fi
+  if ! grep -q '^CHANNEL_SEND_DRY_RUN="1"' <<<"$out"; then
+    fail "T4 send --dry-run should emit CHANNEL_SEND_DRY_RUN=1" "$out"
+    return
+  fi
+  if ! grep -q '^CHANNEL_SEND_MESSAGE_ID="dryrun-' <<<"$out"; then
+    fail "T4 send --dry-run should emit a dryrun-* synthetic message id" "$out"
+    return
+  fi
+  pass "T4 send-managed-message --dry-run emits CHANNEL_SEND_* envelope"
+}
+
+# -- T5: record-precompact-completion seeds EMA stats -------------------------
+
+t5_record_ema() {
+  local state_dir="$ROOT/t5-state"
+  mkdir -p "$state_dir"
+
+  # First sample: duration 60s with alpha=0.5 should set ema_seconds == 60.
+  "$PYTHON" "$CHANNELS_PY" record-precompact-completion \
+    --agent dev --trigger auto \
+    --started-ts 1000 --completed-ts 1060 \
+    --alpha 0.5 \
+    --bridge-state-dir "$state_dir" \
+    --format json >/dev/null
+
+  # Second sample: duration 30s with alpha=0.5 should produce ema = 0.5*30 + 0.5*60 = 45.
+  local out
+  out="$("$PYTHON" "$CHANNELS_PY" record-precompact-completion \
+    --agent dev --trigger auto \
+    --started-ts 2000 --completed-ts 2030 \
+    --alpha 0.5 \
+    --bridge-state-dir "$state_dir" \
+    --format json)"
+  local expected
+  expected="$("$PYTHON" -c '
+import json, sys
+data = json.loads(sys.argv[1])
+print(data["EXPECTED_SECONDS"])
+' "$out")"
+  if [[ "$expected" != "45" ]]; then
+    fail "T5 EMA expected_seconds should be 45 after two samples; got $expected" "$out"
+    return
+  fi
+
+  # Verify schema version + agent block on disk.
+  local schema_ok
+  schema_ok="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+ok = (
+    data.get("schema_version") == 1
+    and isinstance(data.get("agents"), dict)
+    and "dev" in data["agents"]
+    and data["agents"]["dev"].get("auto_count") == 2
+)
+print("ok" if ok else "fail")
+' "$state_dir/precompact-stats.json")"
+  if [[ "$schema_ok" != "ok" ]]; then
+    fail "T5 stats file schema/agent count mismatch"
+    return
+  fi
+  pass "T5 record-precompact-completion seeds EMA stats with alpha=0.5"
+}
+
+# -- T6: end-to-end daemon observer with mocked activity index + dry-run send -
+
+t6_observer_e2e() {
+  local home="$ROOT/t6-home"
+  local state_dir="$home/state"
+  local agent="dev"
+  local plugin="discord"
+  local channel_id="111111"
+  local message_id="222222"
+
+  mkdir -p "$home" "$state_dir/agents/$agent"
+  mkdir -p "$state_dir/channels/$plugin"
+
+  # Mock the activity index Track A's primitive consumes.
+  local now_ts
+  now_ts="$(date +%s)"
+  "$PYTHON" -c '
+import json, sys
+now = int(sys.argv[1])
+data = {
+    "schema_version": 1,
+    "agent": "dev",
+    "plugin": "discord",
+    "updated_ts": now,
+    "channels": {
+        sys.argv[2]: {
+            "channel_id": sys.argv[2],
+            "reply_kind": "thread",
+            "last_seen_id": sys.argv[3],
+            "last_seen_ts": now,
+            "last_user_inbound_ts": now,
+            "last_user_inbound_ts_ms": now * 1000,
+            "last_user_inbound_message_id": sys.argv[3],
+            "last_user_inbound_user_id": "user1",
+            "last_user_inbound_recorded_ns": now * 1_000_000_000,
+        }
+    },
+}
+with open(sys.argv[4], "w") as fh:
+    json.dump(data, fh)
+' "$now_ts" "$channel_id" "$message_id" "$state_dir/channels/$plugin/$agent.json"
+
+  # Build a minimal roster snapshot the daemon can source. We bypass
+  # bridge_load_roster by supplying BRIDGE_AGENT_ENV_FILE so the scoped path
+  # bridge-state.sh:1260+ uses fires; that loads the env file directly and
+  # skips reading the public roster.
+  cat >"$home/agent-env.sh" <<EOF
+declare -ga BRIDGE_AGENT_IDS=("$agent")
+declare -gA BRIDGE_AGENT_ENGINE=([${agent}]="claude")
+declare -gA BRIDGE_AGENT_SOURCE=([${agent}]="static")
+declare -gA BRIDGE_AGENT_CHANNELS=([${agent}]="plugin:${plugin}")
+declare -gA BRIDGE_AGENT_DESC=([${agent}]="t6 fixture")
+declare -gA BRIDGE_AGENT_SESSION=([${agent}]="$agent")
+declare -gA BRIDGE_AGENT_PRECOMPACT_NOTIFY=([${agent}]="1")
+declare -gA BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG=([${agent}]="en")
+EOF
+
+  # Drop a started marker as if hooks/pre-compact.py just ran.
+  mkdir -p "$state_dir/precompact-events/$agent/started"
+  local event_id
+  event_id="$(date +%s%N | head -c 18)-deadbeef"
+  cat >"$state_dir/precompact-events/$agent/started/$event_id.json" <<EOF
+{
+  "schema_version": "1",
+  "event_id": "$event_id",
+  "agent": "$agent",
+  "trigger": "auto",
+  "raw_trigger": "auto",
+  "started_ts": $now_ts,
+  "started_iso": "1970-01-01T00:00:00+00:00",
+  "hook_pid": 1
+}
+EOF
+
+  # Run the daemon's sync cycle once with the dry-run sender enabled.
+  # `env -i` scrubs the parent's leaked BRIDGE_* exports (the test harness
+  # runs inside a live agent-bridge session where BRIDGE_HOME/STATE_DIR/etc.
+  # point at the real runtime — without -i those leak into the daemon and
+  # writes land under the live install instead of the test BRIDGE_HOME).
+  local daemon_out
+  daemon_out="$(env -i \
+    PATH="$PATH" HOME="$HOME" \
+    BRIDGE_HOME="$home" \
+    BRIDGE_STATE_DIR="$state_dir" \
+    BRIDGE_AGENT_ENV_FILE="$home/agent-env.sh" \
+    BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN=1 \
+    BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS=3600 \
+    BRIDGE_DAEMON_NOTIFY_DRY_RUN=1 \
+    BRIDGE_DISCORD_RELAY_ENABLED=0 \
+    BRIDGE_CRON_SYNC_ENABLED=0 \
+    bash "$DAEMON" sync 2>&1)" || true
+
+  # Pending file should exist and reference our event_id.
+  local pending="$state_dir/agents/$agent/precompact-notice-pending.json"
+  if [[ ! -f "$pending" ]]; then
+    fail "T6 expected precompact-notice-pending.json after notice send" \
+         "daemon_out=$daemon_out"
+    return
+  fi
+
+  local stored_event_id
+  stored_event_id="$("$PYTHON" -c '
+import json, sys
+print(json.load(open(sys.argv[1])).get("event_id") or "")
+' "$pending")"
+  if [[ "$stored_event_id" != "$event_id" ]]; then
+    fail "T6 pending event_id mismatch (expected $event_id; got $stored_event_id)"
+    return
+  fi
+
+  # Dedup state should be present.
+  if [[ ! -f "$state_dir/agents/$agent/precompact-notice-last-ts" ]]; then
+    fail "T6 expected precompact-notice-last-ts dedup file"
+    return
+  fi
+  if [[ ! -f "$state_dir/agents/$agent/precompact-notice-last-event-id" ]]; then
+    fail "T6 expected precompact-notice-last-event-id dedup file"
+    return
+  fi
+
+  # Started marker should have moved to processed/.
+  local processed_marker="$state_dir/precompact-events/$agent/processed/$event_id.json"
+  if [[ ! -f "$processed_marker" ]]; then
+    fail "T6 expected started marker to move to processed/"
+    return
+  fi
+
+  # Audit row: precompact_notice_sent.
+  local audit_log="$home/logs/audit.jsonl"
+  if [[ ! -f "$audit_log" ]]; then
+    fail "T6 expected audit log at $audit_log"
+    return
+  fi
+  if ! grep -q precompact_notice_sent "$audit_log"; then
+    fail "T6 expected precompact_notice_sent audit row" "$(cat "$audit_log")"
+    return
+  fi
+
+  # Drop a completed marker; second daemon cycle should send the followup.
+  mkdir -p "$state_dir/precompact-events/$agent/completed"
+  local completed_ts=$((now_ts + 25))
+  cat >"$state_dir/precompact-events/$agent/completed/${completed_ts}-1.json" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$agent",
+  "completed_ts": $completed_ts,
+  "completed_iso": "1970-01-01T00:00:00+00:00",
+  "hook_pid": 1,
+  "matcher": "compact"
+}
+EOF
+
+  env -i \
+    PATH="$PATH" HOME="$HOME" \
+    BRIDGE_HOME="$home" \
+    BRIDGE_STATE_DIR="$state_dir" \
+    BRIDGE_AGENT_ENV_FILE="$home/agent-env.sh" \
+    BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN=1 \
+    BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS=3600 \
+    BRIDGE_DAEMON_NOTIFY_DRY_RUN=1 \
+    BRIDGE_DISCORD_RELAY_ENABLED=0 \
+    BRIDGE_CRON_SYNC_ENABLED=0 \
+    bash "$DAEMON" sync >/dev/null 2>&1 || true
+
+  if ! grep -q precompact_followup_sent "$audit_log"; then
+    fail "T6 expected precompact_followup_sent audit row" "$(cat "$audit_log")"
+    return
+  fi
+
+  # Pending should now be archived under precompact-notice-history/.
+  local history="$state_dir/agents/$agent/precompact-notice-history/$event_id.json"
+  if [[ ! -f "$history" ]]; then
+    fail "T6 expected pending state to be archived to history/"
+    return
+  fi
+  if [[ -f "$pending" ]]; then
+    fail "T6 expected pending file to be removed after followup"
+    return
+  fi
+
+  # Stats file should reflect the recorded duration.
+  local duration_ok
+  duration_ok="$("$PYTHON" -c '
+import json, sys
+data = json.load(open(sys.argv[1]))
+agent = data.get("agents", {}).get("dev", {})
+print("ok" if agent.get("count", 0) >= 1 else "fail")
+' "$state_dir/precompact-stats.json" 2>/dev/null || echo fail)"
+  if [[ "$duration_ok" != "ok" ]]; then
+    fail "T6 precompact-stats.json should reflect at least one sample"
+    return
+  fi
+  pass "T6 daemon observer: notice -> pending -> followup -> history (dry-run)"
+}
+
+# -- T7: kill switch suppresses sends -----------------------------------------
+
+t7_kill_switch() {
+  local home="$ROOT/t7-home"
+  local state_dir="$home/state"
+  local agent="dev"
+  local plugin="discord"
+  local channel_id="333"
+
+  mkdir -p "$home" "$state_dir/agents/$agent" "$state_dir/channels/$plugin"
+
+  local now_ts
+  now_ts="$(date +%s)"
+  "$PYTHON" -c '
+import json, sys
+now = int(sys.argv[1])
+data = {
+    "schema_version": 1, "agent": "dev", "plugin": "discord", "updated_ts": now,
+    "channels": {sys.argv[2]: {
+        "channel_id": sys.argv[2], "reply_kind": "thread",
+        "last_user_inbound_ts": now, "last_user_inbound_ts_ms": now * 1000,
+        "last_user_inbound_message_id": "msg1",
+        "last_user_inbound_recorded_ns": now * 1_000_000_000,
+    }}
+}
+json.dump(data, open(sys.argv[3], "w"))
+' "$now_ts" "$channel_id" "$state_dir/channels/$plugin/$agent.json"
+
+  cat >"$home/agent-env.sh" <<EOF
+declare -ga BRIDGE_AGENT_IDS=("$agent")
+declare -gA BRIDGE_AGENT_ENGINE=([${agent}]="claude")
+declare -gA BRIDGE_AGENT_SOURCE=([${agent}]="static")
+declare -gA BRIDGE_AGENT_CHANNELS=([${agent}]="plugin:${plugin}")
+declare -gA BRIDGE_AGENT_DESC=([${agent}]="t7 fixture")
+declare -gA BRIDGE_AGENT_SESSION=([${agent}]="$agent")
+declare -gA BRIDGE_AGENT_PRECOMPACT_NOTIFY=([${agent}]="1")
+EOF
+
+  mkdir -p "$state_dir/precompact-events/$agent/started"
+  cat >"$state_dir/precompact-events/$agent/started/evt1.json" <<EOF
+{"schema_version":"1","event_id":"evt1","agent":"$agent","trigger":"auto","raw_trigger":"auto","started_ts":$now_ts,"started_iso":"1970","hook_pid":1}
+EOF
+
+  env -i \
+    PATH="$PATH" HOME="$HOME" \
+    BRIDGE_HOME="$home" \
+    BRIDGE_STATE_DIR="$state_dir" \
+    BRIDGE_AGENT_ENV_FILE="$home/agent-env.sh" \
+    BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1 \
+    BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN=1 \
+    BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS=3600 \
+    BRIDGE_DAEMON_NOTIFY_DRY_RUN=1 \
+    BRIDGE_DISCORD_RELAY_ENABLED=0 \
+    BRIDGE_CRON_SYNC_ENABLED=0 \
+    bash "$DAEMON" sync >/dev/null 2>&1 || true
+
+  if [[ -f "$state_dir/agents/$agent/precompact-notice-pending.json" ]]; then
+    fail "T7 kill switch should prevent pending state being written"
+    return
+  fi
+  # Marker should still be in started/ — kill switch returns before processing.
+  if [[ ! -f "$state_dir/precompact-events/$agent/started/evt1.json" ]]; then
+    fail "T7 kill switch should leave started marker untouched"
+    return
+  fi
+  pass "T7 BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1 short-circuits the helper"
+}
+
+# -- run all ------------------------------------------------------------------
+
+t1_started_marker
+t2_completed_marker
+t3_render_templates
+t4_send_dry_run
+t5_record_ema
+t6_observer_e2e
+t7_kill_switch
+
+printf '\n[smoke][summary] passes=%d fails=%d\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf '[smoke][summary] failures:\n'
+  for failure in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$failure"
+  done
+  exit 1
+fi
+exit 0

--- a/tests/precompact-notify/observer-smoke.sh
+++ b/tests/precompact-notify/observer-smoke.sh
@@ -531,50 +531,52 @@ EOF
   pass "T7 BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1 short-circuits the helper"
 }
 
-# -- T8: follow-up send failure does NOT inflate EMA across retries -----------
+# -- T8: stats + flag mutate iff follow-up send succeeds ----------------------
 #
-# Regression for r2 of #611: the original Track B observer recorded the EMA
-# sample BEFORE attempting the follow-up send and left the completed marker in
-# place on failure, so each retry sync re-entered record-precompact-completion
-# and re-blended the agent's EMA. The fix gates the EMA call behind a per
-# event_id flag under precompact-completion-recorded/. This test exercises the
-# repeated-failure case end-to-end by routing follow-up through the teams
-# adapter (which structurally returns track_c_pending) and asserts the agent's
-# stats sample count stays at exactly 1 across three retry cycles.
+# Regression for r3 of #611: the original Track B observer recorded the EMA
+# sample BEFORE attempting the follow-up send. r2 moved only the flag write,
+# leaving record-precompact-completion in place on every retry. The correct
+# invariant is "stats + flag advance iff the send succeeded once, ever".
+# This test drives that invariant by running:
+#   * 3 failure cycles (teams adapter → track_c_pending) — flag absent,
+#     EMA count stays at 0, marker stays in completed/.
+#   * 1 success cycle (discord adapter + dry-run) — flag written, EMA count
+#     becomes exactly 1, marker moves to processed/.
+#   * 1 sanity sync after success — nothing further happens; flag still
+#     present, stats unchanged, marker stays in processed/.
 
-t8_followup_failure_no_ema_inflation() {
+t8_followup_stats_iff_success() {
   local home="$ROOT/t8-home"
   local state_dir="$home/state"
   local agent="dev"
-  local plugin="teams"
   local channel_id="t8-channel"
 
   mkdir -p "$home" "$state_dir/agents/$agent"
   mkdir -p "$state_dir/precompact-events/$agent/completed"
 
+  # Roster fixture; same shape works for both adapters since the daemon picks
+  # plugin from the pending JSON, not from BRIDGE_AGENT_CHANNELS.
   cat >"$home/agent-env.sh" <<EOF
 declare -ga BRIDGE_AGENT_IDS=("$agent")
 declare -gA BRIDGE_AGENT_ENGINE=([${agent}]="claude")
 declare -gA BRIDGE_AGENT_SOURCE=([${agent}]="static")
-declare -gA BRIDGE_AGENT_CHANNELS=([${agent}]="plugin:${plugin}")
+declare -gA BRIDGE_AGENT_CHANNELS=([${agent}]="plugin:teams")
 declare -gA BRIDGE_AGENT_DESC=([${agent}]="t8 fixture")
 declare -gA BRIDGE_AGENT_SESSION=([${agent}]="$agent")
 declare -gA BRIDGE_AGENT_PRECOMPACT_NOTIFY=([${agent}]="1")
 EOF
 
-  # Synthesize a pending notice that points at the teams adapter (track_c_pending).
-  # We bypass the notice-send path so the failure scenario is purely the
-  # follow-up branch; dry_run is intentionally 0 so the followup hits the
-  # real adapter dispatcher and fails with a structured error.
+  # Pending notice using the teams adapter for cycles 1-3 (structural failure).
   local now_ts
   now_ts="$(date +%s)"
   local started_ts=$((now_ts - 60))
   local event_id="t8-event-1"
-  cat >"$state_dir/agents/$agent/precompact-notice-pending.json" <<EOF
+  local pending="$state_dir/agents/$agent/precompact-notice-pending.json"
+  cat >"$pending" <<EOF
 {
   "event_id": "$event_id",
   "agent": "$agent",
-  "plugin": "$plugin",
+  "plugin": "teams",
   "channel_id": "$channel_id",
   "reply_to_message_id": "",
   "notice_message_id": "notice-1",
@@ -588,9 +590,12 @@ EOF
 }
 EOF
 
-  # Drop a completed marker the daemon will pair with the pending notice.
+  # Single completed marker — the daemon should keep this in place across the
+  # failure cycles and only move it to processed/ on the success cycle.
   local completed_ts=$((started_ts + 30))
-  cat >"$state_dir/precompact-events/$agent/completed/${completed_ts}-1.json" <<EOF
+  local marker_basename="${completed_ts}-1.json"
+  local marker_path="$state_dir/precompact-events/$agent/completed/$marker_basename"
+  cat >"$marker_path" <<EOF
 {
   "schema_version": "1",
   "agent": "$agent",
@@ -601,7 +606,11 @@ EOF
 }
 EOF
 
-  # Helper: run one daemon sync cycle in an isolated env.
+  # Helper: run one daemon sync cycle in an isolated env. We deliberately do
+  # NOT set BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN here — pending JSON's dry_run
+  # field drives the dry-run flag instead, so cycles 1-3 hit the real teams
+  # adapter (track_c_pending → failure) and cycle 4 flips dry_run=true to
+  # force a clean dry-run success.
   local daemon_run='
     env -i \
       PATH="$PATH" HOME="$HOME" \
@@ -616,34 +625,78 @@ EOF
       bash "'"$DAEMON"'" sync >/dev/null 2>&1 || true
   '
 
-  # Run three sync cycles; the followup should fail every time.
+  local audit_log="$home/logs/audit.jsonl"
+  local flag="$state_dir/agents/$agent/precompact-completion-recorded/$event_id.flag"
+  local stats_file="$state_dir/precompact-stats.json"
+  local processed_marker="$state_dir/precompact-events/$agent/processed/$marker_basename"
+
+  # --- Cycles 1-3: failures (teams adapter, dry_run=false in JSON) -----------
   local i
   for i in 1 2 3; do
     eval "$daemon_run"
   done
 
-  # Pending must still be in place (within retry window).
-  if [[ ! -f "$state_dir/agents/$agent/precompact-notice-pending.json" ]]; then
-    fail "T8 expected pending notice to remain across retry cycles"
+  if [[ ! -f "$pending" ]]; then
+    fail "T8 expected pending notice to remain across failure cycles"
+    return
+  fi
+  if [[ ! -f "$marker_path" ]]; then
+    fail "T8 expected completed marker to stay in place across failure cycles"
+    return
+  fi
+  if [[ -f "$flag" ]]; then
+    fail "T8 flag must NOT exist after failure-only cycles" \
+         "$(ls -la "$state_dir/agents/$agent/precompact-completion-recorded" 2>/dev/null || true)"
+    return
+  fi
+  if [[ -f "$audit_log" ]] && ! grep -q precompact_followup_failed "$audit_log"; then
+    fail "T8 expected at least one precompact_followup_failed row after failures" \
+         "$(cat "$audit_log")"
+    return
+  fi
+  local count_before
+  count_before="$("$PYTHON" -c '
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    print(0); sys.exit(0)
+agent = data.get("agents", {}).get("dev", {})
+print(agent.get("count", 0))
+' "$stats_file" 2>/dev/null || echo 0)"
+  if [[ "$count_before" != "0" ]]; then
+    fail "T8 EMA count must be 0 after failure-only cycles; got $count_before" \
+         "$(cat "$stats_file" 2>/dev/null || echo no-stats)"
     return
   fi
 
-  # Audit log must contain at least one followup_failed row with a structured
-  # (non-send_failed) error_class.
-  local audit_log="$home/logs/audit.jsonl"
-  if [[ ! -f "$audit_log" ]]; then
-    fail "T8 expected audit log at $audit_log"
-    return
-  fi
-  if ! grep -q precompact_followup_failed "$audit_log"; then
-    fail "T8 expected at least one precompact_followup_failed row" "$(cat "$audit_log")"
-    return
-  fi
+  # --- Cycle 4: success (flip pending plugin to discord + dry-run) -----------
+  "$PYTHON" -c '
+import json, sys
+path = sys.argv[1]
+with open(path, "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+data["plugin"] = "discord"
+data["dry_run"] = True
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, ensure_ascii=False, indent=2)
+    fh.write("\n")
+' "$pending"
 
-  # Critical assertion: the EMA sample counter must be exactly 1, not 3.
-  # If it's >1 the EMA is double-counting on retry.
-  local count
-  count="$("$PYTHON" -c '
+  eval "$daemon_run"
+
+  if ! grep -q precompact_followup_sent "$audit_log"; then
+    fail "T8 expected precompact_followup_sent audit row after success cycle" \
+         "$(cat "$audit_log")"
+    return
+  fi
+  if [[ ! -f "$flag" ]]; then
+    fail "T8 flag must be present after success cycle" \
+         "$(ls -la "$state_dir/agents/$agent/precompact-completion-recorded" 2>/dev/null || true)"
+    return
+  fi
+  local count_after
+  count_after="$("$PYTHON" -c '
 import json, sys
 try:
     data = json.load(open(sys.argv[1]))
@@ -651,22 +704,62 @@ except Exception:
     print("missing"); sys.exit(0)
 agent = data.get("agents", {}).get("dev", {})
 print(agent.get("count", 0))
-' "$state_dir/precompact-stats.json" 2>/dev/null || echo missing)"
-  if [[ "$count" != "1" ]]; then
-    fail "T8 EMA count should be 1 across 3 retries; got $count" \
-         "$(cat "$state_dir/precompact-stats.json" 2>/dev/null || echo no-stats)"
+' "$stats_file" 2>/dev/null || echo missing)"
+  if [[ "$count_after" != "1" ]]; then
+    fail "T8 EMA count must be exactly 1 after success cycle; got $count_after" \
+         "$(cat "$stats_file" 2>/dev/null || echo no-stats)"
+    return
+  fi
+  if [[ -f "$marker_path" ]]; then
+    fail "T8 completed marker must move to processed/ after success cycle"
+    return
+  fi
+  if [[ ! -f "$processed_marker" ]]; then
+    fail "T8 expected processed marker at $processed_marker"
     return
   fi
 
-  # And the per-event flag should be present so subsequent retries skip the
-  # record-precompact-completion call.
-  local flag="$state_dir/agents/$agent/precompact-completion-recorded/$event_id.flag"
+  # --- Cycle 5: sanity (drop a duplicate completed marker; flag must short
+  # circuit and the stats must not be re-mutated) ----------------------------
+  local stray_marker="$state_dir/precompact-events/$agent/completed/${completed_ts}-stray.json"
+  cat >"$stray_marker" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$agent",
+  "completed_ts": $completed_ts,
+  "completed_iso": "1970-01-01T00:00:00+00:00",
+  "hook_pid": 1,
+  "matcher": "compact"
+}
+EOF
+
+  eval "$daemon_run"
+
   if [[ ! -f "$flag" ]]; then
-    fail "T8 expected precompact-completion-recorded flag at $flag" \
-         "$(ls -la "$state_dir/agents/$agent/precompact-completion-recorded" 2>/dev/null || true)"
+    fail "T8 flag should still be present on sanity sync"
     return
   fi
-  pass "T8 follow-up retries do not inflate EMA (count stays at 1, flag present)"
+  if [[ -f "$stray_marker" ]]; then
+    fail "T8 stray marker should be archived to processed/ via flag short-circuit"
+    return
+  fi
+  local count_sanity
+  count_sanity="$("$PYTHON" -c '
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    print("missing"); sys.exit(0)
+agent = data.get("agents", {}).get("dev", {})
+print(agent.get("count", 0))
+' "$stats_file" 2>/dev/null || echo missing)"
+  if [[ "$count_sanity" != "1" ]]; then
+    fail "T8 EMA count must remain 1 after sanity sync; got $count_sanity" \
+         "$(cat "$stats_file" 2>/dev/null || echo no-stats)"
+    return
+  fi
+
+  pass "T8 stats + flag advance iff follow-up send succeeded (count=1 once, flag set on success only)"
 }
 
 # -- T9: structured error class preserved in audit ----------------------------
@@ -785,7 +878,7 @@ t4_send_dry_run
 t5_record_ema
 t6_observer_e2e
 t7_kill_switch
-t8_followup_failure_no_ema_inflation
+t8_followup_stats_iff_success
 t9_followup_error_class_preserved
 
 printf '\n[smoke][summary] passes=%d fails=%d\n' "$PASS" "$FAIL"

--- a/tests/precompact-notify/observer-smoke.sh
+++ b/tests/precompact-notify/observer-smoke.sh
@@ -531,6 +531,251 @@ EOF
   pass "T7 BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1 short-circuits the helper"
 }
 
+# -- T8: follow-up send failure does NOT inflate EMA across retries -----------
+#
+# Regression for r2 of #611: the original Track B observer recorded the EMA
+# sample BEFORE attempting the follow-up send and left the completed marker in
+# place on failure, so each retry sync re-entered record-precompact-completion
+# and re-blended the agent's EMA. The fix gates the EMA call behind a per
+# event_id flag under precompact-completion-recorded/. This test exercises the
+# repeated-failure case end-to-end by routing follow-up through the teams
+# adapter (which structurally returns track_c_pending) and asserts the agent's
+# stats sample count stays at exactly 1 across three retry cycles.
+
+t8_followup_failure_no_ema_inflation() {
+  local home="$ROOT/t8-home"
+  local state_dir="$home/state"
+  local agent="dev"
+  local plugin="teams"
+  local channel_id="t8-channel"
+
+  mkdir -p "$home" "$state_dir/agents/$agent"
+  mkdir -p "$state_dir/precompact-events/$agent/completed"
+
+  cat >"$home/agent-env.sh" <<EOF
+declare -ga BRIDGE_AGENT_IDS=("$agent")
+declare -gA BRIDGE_AGENT_ENGINE=([${agent}]="claude")
+declare -gA BRIDGE_AGENT_SOURCE=([${agent}]="static")
+declare -gA BRIDGE_AGENT_CHANNELS=([${agent}]="plugin:${plugin}")
+declare -gA BRIDGE_AGENT_DESC=([${agent}]="t8 fixture")
+declare -gA BRIDGE_AGENT_SESSION=([${agent}]="$agent")
+declare -gA BRIDGE_AGENT_PRECOMPACT_NOTIFY=([${agent}]="1")
+EOF
+
+  # Synthesize a pending notice that points at the teams adapter (track_c_pending).
+  # We bypass the notice-send path so the failure scenario is purely the
+  # follow-up branch; dry_run is intentionally 0 so the followup hits the
+  # real adapter dispatcher and fails with a structured error.
+  local now_ts
+  now_ts="$(date +%s)"
+  local started_ts=$((now_ts - 60))
+  local event_id="t8-event-1"
+  cat >"$state_dir/agents/$agent/precompact-notice-pending.json" <<EOF
+{
+  "event_id": "$event_id",
+  "agent": "$agent",
+  "plugin": "$plugin",
+  "channel_id": "$channel_id",
+  "reply_to_message_id": "",
+  "notice_message_id": "notice-1",
+  "thread_id": "",
+  "trigger": "auto",
+  "started_ts": $started_ts,
+  "notice_sent_ts": $now_ts,
+  "expected_seconds": 60,
+  "lang": "en",
+  "dry_run": false
+}
+EOF
+
+  # Drop a completed marker the daemon will pair with the pending notice.
+  local completed_ts=$((started_ts + 30))
+  cat >"$state_dir/precompact-events/$agent/completed/${completed_ts}-1.json" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$agent",
+  "completed_ts": $completed_ts,
+  "completed_iso": "1970-01-01T00:00:00+00:00",
+  "hook_pid": 1,
+  "matcher": "compact"
+}
+EOF
+
+  # Helper: run one daemon sync cycle in an isolated env.
+  local daemon_run='
+    env -i \
+      PATH="$PATH" HOME="$HOME" \
+      BRIDGE_HOME="'"$home"'" \
+      BRIDGE_STATE_DIR="'"$state_dir"'" \
+      BRIDGE_AGENT_ENV_FILE="'"$home"'/agent-env.sh" \
+      BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS=3600 \
+      BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS=3600 \
+      BRIDGE_DAEMON_NOTIFY_DRY_RUN=1 \
+      BRIDGE_DISCORD_RELAY_ENABLED=0 \
+      BRIDGE_CRON_SYNC_ENABLED=0 \
+      bash "'"$DAEMON"'" sync >/dev/null 2>&1 || true
+  '
+
+  # Run three sync cycles; the followup should fail every time.
+  local i
+  for i in 1 2 3; do
+    eval "$daemon_run"
+  done
+
+  # Pending must still be in place (within retry window).
+  if [[ ! -f "$state_dir/agents/$agent/precompact-notice-pending.json" ]]; then
+    fail "T8 expected pending notice to remain across retry cycles"
+    return
+  fi
+
+  # Audit log must contain at least one followup_failed row with a structured
+  # (non-send_failed) error_class.
+  local audit_log="$home/logs/audit.jsonl"
+  if [[ ! -f "$audit_log" ]]; then
+    fail "T8 expected audit log at $audit_log"
+    return
+  fi
+  if ! grep -q precompact_followup_failed "$audit_log"; then
+    fail "T8 expected at least one precompact_followup_failed row" "$(cat "$audit_log")"
+    return
+  fi
+
+  # Critical assertion: the EMA sample counter must be exactly 1, not 3.
+  # If it's >1 the EMA is double-counting on retry.
+  local count
+  count="$("$PYTHON" -c '
+import json, sys
+try:
+    data = json.load(open(sys.argv[1]))
+except Exception:
+    print("missing"); sys.exit(0)
+agent = data.get("agents", {}).get("dev", {})
+print(agent.get("count", 0))
+' "$state_dir/precompact-stats.json" 2>/dev/null || echo missing)"
+  if [[ "$count" != "1" ]]; then
+    fail "T8 EMA count should be 1 across 3 retries; got $count" \
+         "$(cat "$state_dir/precompact-stats.json" 2>/dev/null || echo no-stats)"
+    return
+  fi
+
+  # And the per-event flag should be present so subsequent retries skip the
+  # record-precompact-completion call.
+  local flag="$state_dir/agents/$agent/precompact-completion-recorded/$event_id.flag"
+  if [[ ! -f "$flag" ]]; then
+    fail "T8 expected precompact-completion-recorded flag at $flag" \
+         "$(ls -la "$state_dir/agents/$agent/precompact-completion-recorded" 2>/dev/null || true)"
+    return
+  fi
+  pass "T8 follow-up retries do not inflate EMA (count stays at 1, flag present)"
+}
+
+# -- T9: structured error class preserved in audit ----------------------------
+#
+# Regression for r2 of #611: the daemon used to redirect send-primitive stderr
+# to /dev/null and hardcode error_class="send_failed", swallowing the
+# track_c_pending signal that bridge-channels.py emits for Teams/Mattermost.
+# This test verifies the parser captures the structured code from stderr and
+# stamps it onto the audit detail.
+
+t9_followup_error_class_preserved() {
+  local home="$ROOT/t9-home"
+  local state_dir="$home/state"
+  local agent="dev"
+  local plugin="teams"
+  local channel_id="t9-channel"
+
+  mkdir -p "$home" "$state_dir/agents/$agent"
+  mkdir -p "$state_dir/precompact-events/$agent/completed"
+
+  cat >"$home/agent-env.sh" <<EOF
+declare -ga BRIDGE_AGENT_IDS=("$agent")
+declare -gA BRIDGE_AGENT_ENGINE=([${agent}]="claude")
+declare -gA BRIDGE_AGENT_SOURCE=([${agent}]="static")
+declare -gA BRIDGE_AGENT_CHANNELS=([${agent}]="plugin:${plugin}")
+declare -gA BRIDGE_AGENT_DESC=([${agent}]="t9 fixture")
+declare -gA BRIDGE_AGENT_SESSION=([${agent}]="$agent")
+declare -gA BRIDGE_AGENT_PRECOMPACT_NOTIFY=([${agent}]="1")
+EOF
+
+  local now_ts
+  now_ts="$(date +%s)"
+  local started_ts=$((now_ts - 60))
+  local event_id="t9-event-1"
+  cat >"$state_dir/agents/$agent/precompact-notice-pending.json" <<EOF
+{
+  "event_id": "$event_id",
+  "agent": "$agent",
+  "plugin": "$plugin",
+  "channel_id": "$channel_id",
+  "reply_to_message_id": "",
+  "notice_message_id": "notice-1",
+  "thread_id": "",
+  "trigger": "auto",
+  "started_ts": $started_ts,
+  "notice_sent_ts": $now_ts,
+  "expected_seconds": 60,
+  "lang": "en",
+  "dry_run": false
+}
+EOF
+
+  local completed_ts=$((started_ts + 30))
+  cat >"$state_dir/precompact-events/$agent/completed/${completed_ts}-1.json" <<EOF
+{
+  "schema_version": "1",
+  "agent": "$agent",
+  "completed_ts": $completed_ts,
+  "completed_iso": "1970-01-01T00:00:00+00:00",
+  "hook_pid": 1,
+  "matcher": "compact"
+}
+EOF
+
+  env -i \
+    PATH="$PATH" HOME="$HOME" \
+    BRIDGE_HOME="$home" \
+    BRIDGE_STATE_DIR="$state_dir" \
+    BRIDGE_AGENT_ENV_FILE="$home/agent-env.sh" \
+    BRIDGE_PRECOMPACT_NOTIFY_RECENCY_SECONDS=3600 \
+    BRIDGE_PRECOMPACT_FOLLOWUP_RETRY_SECONDS=3600 \
+    BRIDGE_DAEMON_NOTIFY_DRY_RUN=1 \
+    BRIDGE_DISCORD_RELAY_ENABLED=0 \
+    BRIDGE_CRON_SYNC_ENABLED=0 \
+    bash "$DAEMON" sync >/dev/null 2>&1 || true
+
+  local audit_log="$home/logs/audit.jsonl"
+  if [[ ! -f "$audit_log" ]]; then
+    fail "T9 expected audit log at $audit_log"
+    return
+  fi
+
+  local error_class
+  error_class="$("$PYTHON" -c '
+import json, sys
+target = ""
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except Exception:
+            continue
+        if row.get("action") == "precompact_followup_failed":
+            detail = row.get("detail") or {}
+            target = str(detail.get("error_class") or "")
+print(target)
+' "$audit_log")"
+
+  if [[ "$error_class" != "track_c_pending" ]]; then
+    fail "T9 expected error_class=track_c_pending; got '$error_class'" \
+         "$(grep precompact_followup_failed "$audit_log" 2>/dev/null || true)"
+    return
+  fi
+  pass "T9 structured error_class=track_c_pending preserved in audit detail"
+}
+
 # -- run all ------------------------------------------------------------------
 
 t1_started_marker
@@ -540,6 +785,8 @@ t4_send_dry_run
 t5_record_ema
 t6_observer_e2e
 t7_kill_switch
+t8_followup_failure_no_ema_inflation
+t9_followup_error_class_preserved
 
 printf '\n[smoke][summary] passes=%d fails=%d\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary

Track B of issue #597 (PreCompact channel auto-notify). Track A landed the route primitive in #601. This PR is the bridge between Track A's route consumer and Tracks C/D's writers — daemon observer + send primitive + EMA stats + templates + opt-in mechanics + kill switch.

## What this implements

- **`hooks/pre-compact.py`**: writes a best-effort started marker to `$BRIDGE_STATE_DIR/precompact-events/<agent>/started/<event_id>.json`. Hook stays exit-0; missing marker just suppresses the notice.
- **`hooks/session_start.py`**: writes a completion marker in the `compact` matcher branch so the daemon can pair started + completed.
- **`bridge-daemon.sh`**: `process_precompact_events` helper attached to the sync cycle right after `bridge_discord_relay_step` and before `bridge-sync.sh`. Walks markers, runs eligibility checks (opt-in + `source=static` + `engine=claude` + `trigger=auto` + channels declared + dedup window respected), resolves a route via Track A's primitive, renders a localized template, sends via `bridge_with_timeout`-wrapped `python3`, persists pending state, and audits notice/followup events.
- **`lib/bridge-channels.sh`**: `bridge_channel_send_managed_message` wrapper that honors `BRIDGE_PRECOMPACT_NOTIFY_DRY_RUN=1` for CI.
- **`bridge-channels.py`**: `send-managed-message` + `render-precompact-message` + `record-precompact-completion` subcommands. Discord and Telegram adapters are implemented; Teams + Mattermost return a structured `track-c-pending` error so the audit row records the gap until Track C ships the TS plugin extension. Stats file uses `fcntl.flock` + atomic replace mirroring `bridge-memory.py`.
- **`lib/bridge-core.sh` / `lib/bridge-state.sh` / `lib/bridge-agents.sh`**: declare and normalize `BRIDGE_AGENT_PRECOMPACT_NOTIFY[]` and `BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG[]` roster maps; expose getters; default per-agent OFF.
- **`agent-roster.local.example.sh`**: opt-in docs (kill switch, language, recency, default-OFF posture).

## Out of scope

- TS plugin server changes (Track C wires Teams + Mattermost true managed-send).
- Discord/Telegram relay activity-index writers (Track D wires the writer side that Track A's consumer reads).
- Top-level smoke-test.sh registration (Track D wires the full suite).
- VERSION / CHANGELOG bump (release PR territory).

## Verification

- `bash -n` and `shellcheck` clean on every touched `.sh`.
- `python3 -c 'import ast; ast.parse(...)'` clean on every touched `.py`.
- `tests/precompact-notify/observer-smoke.sh`: 7/7 pass — covers
  - hook started + completed markers
  - en/ko notice + followup template rendering
  - `send-managed-message --dry-run` envelope
  - EMA stats with `alpha=0.5` (60s + 30s -> 45s expected)
  - end-to-end daemon observer: notice -> pending -> followup -> history
  - `BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1` kill switch
- Existing `tests/precompact-notify/route-primitive.sh` (Track A): 6/6 still pass.
- `scripts/smoke-test.sh` reaches the same pre-existing assertion failure on `main` (expected output to contain: refusing to write isolated agent-env.sh from ephemeral controller path BRIDGE_HOME=) — unrelated to this PR.

## Test plan

- [ ] `bash -n` + `shellcheck` clean on touched `.sh` files
- [ ] `python3 ast` clean on touched `.py` files
- [ ] `bash tests/precompact-notify/observer-smoke.sh` — 7/7 pass
- [ ] `bash tests/precompact-notify/route-primitive.sh` — 6/6 still pass (Track A guarantee preserved)
- [ ] Manual smoke under isolated `BRIDGE_HOME` with mocked activity index, dry-run sender enabled, single `bash bridge-daemon.sh sync` — verify pending JSON, dedup files, processed marker, `precompact_notice_sent` audit row; drop a completion marker, run sync again, verify `precompact_followup_sent` audit + history archive + EMA stats updated

## Open-question commitments (orchestrator-decided)

- **Q1** gh-only constraints: none beyond brief.
- **Q2** "agent class == static" maps to `bridge_agent_source` (provenance), not `bridge_agent_class`.
- **Q3** Teams/Mattermost true thread reply is best-effort. Send primitive does not fail on missing thread support — Track B returns `track-c-pending` for those plugins; Track C wires native thread reply.
- **Q4** AB maintains its own normalized activity index at `state/channels/<plugin>/<agent>.json` (Track A schema).
- **Q5** Default language: `BRIDGE_AGENT_PRECOMPACT_NOTIFY_LANG[agent]` -> env `BRIDGE_PRECOMPACT_NOTIFY_LANG` -> `'en'` fallback. Operator sets `'ko'` per-install via roster.

## Risk + rollback

- Worst plausible failure: an auto-compact loop produces duplicate notices. Mitigated by `precompact-notice-last-ts` + `precompact-notice-last-event-id` + `BRIDGE_PRECOMPACT_NOTICE_DEDUP_SECONDS=300`.
- Network-blocking risk on the daemon loop: every send/render/stats call is wrapped in `bridge_with_timeout`.
- Per-install rollback: `BRIDGE_PRECOMPACT_NOTIFY_DISABLED=1` short-circuits the entire helper.
- Per-agent rollback: `BRIDGE_AGENT_PRECOMPACT_NOTIFY[<agent>]="0"` (or remove the entry) and rerun `bash bridge-daemon.sh sync`.

refs #597 (multi-track issue stays open until Track C and D land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)