### PR TITLE
fix(hooks,daemon): system-class Bash carve-out + idle-since marker self-heal

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -789,7 +789,10 @@ def _peer_alias_list(agent: str) -> list[str]:
 def _shared_forbidden_aliases() -> list[str]:
     """Return the substring-deny list for ``shared/private/`` and
     ``shared/secrets/``. Includes absolute, ``~``, and ``$HOME``
-    variants so substitution rendering doesn't slip past the gate.
+    variants — both with and without a trailing slash — so a bare
+    directory reference (``ls $BRIDGE_HOME/shared/private``) cannot
+    bypass the gate. patch-dev review of 94711d3 caught the
+    no-slash variant gap.
     """
     bridge_home = bridge_home_dir()
     aliases: list[str] = []
@@ -798,8 +801,11 @@ def _shared_forbidden_aliases() -> list[str]:
         aliases.extend(
             (
                 f"{bridge_home}/shared/{rel}/",
+                f"{bridge_home}/shared/{rel}",
                 f"~/.agent-bridge/shared/{rel}/",
+                f"~/.agent-bridge/shared/{rel}",
                 f"$HOME/.agent-bridge/shared/{rel}/",
+                f"$HOME/.agent-bridge/shared/{rel}",
             )
         )
     return aliases

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -732,6 +732,245 @@ def _token_matches_protected(token: str, protected: Path) -> bool:
     return False
 
 
+# === Issue #539 follow-up: Bash carve-out for system-class read-intent ===
+
+# Shell-language constructs that can hide text from shlex argv
+# decomposition. When *any* of these is present we refuse to apply the
+# system-class peer/shared read carve-out, because a visible allowed
+# peer path could mask a smuggled forbidden read inside a `$(...)` body
+# or here-string. patch-dev review of plan r3/r4 (2026-05-06) — see PR
+# body for the detailed `cat <<< "$(cat .../private/secret.md)"` vector.
+#
+# Pipes / `&&` / `||` / `;` are deliberately NOT considered embeddings:
+# each shell stage stays individually visible to shlex (and to
+# `_is_read_intent_bash`, which already classifies stage-by-stage).
+_SHELL_EMBEDDING_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\$\("),       # command substitution `$(...)`
+    re.compile(r"`"),          # backticks
+    re.compile(r"<\("),        # process substitution (read)
+    re.compile(r">\("),        # process substitution (write)
+    re.compile(r"<<"),         # heredoc / here-string (covers <<-, <<<)
+)
+
+
+def _command_has_shell_embedding(text: str) -> bool:
+    """True iff *text* contains shell-language constructs that can hide
+    text from shlex argv decomposition.
+
+    The check runs against the raw text — the embedding tokens (``<<``,
+    ``<<<``, ``<(``, ``>(``) are themselves the signals we want to
+    catch, so we deliberately do NOT pre-strip safe redirect noise.
+    """
+    return any(pat.search(text) for pat in _SHELL_EMBEDDING_PATTERNS)
+
+
+def _peer_alias_list(agent: str) -> list[str]:
+    """Return the substring-deny needle list for cross-agent home
+    references. Each peer agent contributes six variants (with/without
+    trailing slash, expanded vs ``~`` vs ``$HOME``). Stable order so
+    deny messages are deterministic.
+    """
+    home_root = agent_home_root()
+    aliases: list[str] = []
+    for other in other_agent_homes(agent):
+        aliases.extend(
+            (
+                f"{home_root}/{other.name}/",
+                f"{home_root}/{other.name}",
+                f"~/.agent-bridge/agents/{other.name}/",
+                f"~/.agent-bridge/agents/{other.name}",
+                f"$HOME/.agent-bridge/agents/{other.name}/",
+                f"$HOME/.agent-bridge/agents/{other.name}",
+            )
+        )
+    return aliases
+
+
+def _shared_forbidden_aliases() -> list[str]:
+    """Return the substring-deny list for ``shared/private/`` and
+    ``shared/secrets/``. Includes absolute, ``~``, and ``$HOME``
+    variants so substitution rendering doesn't slip past the gate.
+    """
+    bridge_home = bridge_home_dir()
+    aliases: list[str] = []
+    for forbidden in _SHARED_FORBIDDEN_PREFIXES:
+        rel = forbidden.rstrip("/")
+        aliases.extend(
+            (
+                f"{bridge_home}/shared/{rel}/",
+                f"~/.agent-bridge/shared/{rel}/",
+                f"$HOME/.agent-bridge/shared/{rel}/",
+            )
+        )
+    return aliases
+
+
+def _bash_token_resolved_paths(token: str) -> list[Path]:
+    """Return resolved Paths for the path-shaped fragments of *token*.
+
+    Mirrors `_token_matches_protected`'s expansion logic but yields
+    Path objects instead of running an equality check, so the caller
+    can run any decision against them.
+    """
+    out: list[Path] = []
+    for fragment in _alias_path_fragments(token):
+        expanded = os.path.expandvars(os.path.expanduser(fragment))
+        if not expanded:
+            continue
+        try:
+            out.append(Path(expanded))
+        except Exception:
+            continue
+    return out
+
+
+def _bash_argv_protected_decisions(
+    text: str,
+    agent: str,
+) -> tuple[list[tuple[Path, str, str]], bool] | None:
+    """Walk shlex tokens in *text* with the same skip / treat-as-value
+    rules as `_bash_argv_references_path`. For every non-skipped token,
+    resolve to one or more Paths. For Paths that land in another
+    agent's home, run `_system_class_cross_agent_read_allowed` and
+    record the decision.
+
+    Returns ``None`` when shlex.split() raises (caller falls through to
+    the substring deny). Otherwise returns ``(decisions, all_allowed)``:
+
+    - ``decisions`` is a list of ``(path, audit_target, peer_key)``
+      triples for every peer-agent token the carve-out admits.
+      ``peer_key`` is the peer agent name — a stable string used by the
+      text-occurrence proof step to compare counts without depending on
+      symlink-resolved absolute paths (e.g. macOS ``/var`` →
+      ``/private/var``).
+    - ``all_allowed`` is False as soon as one resolved peer token sits
+      outside the carve-out (peer outside ``memory/{projects,decisions,
+      shared}/``).
+
+    Shared/* tokens are deliberately NOT collected: shared/non-forbidden
+    is broadly readable across classes (the file-tool carve-out emits
+    audits for system-class shared reads — Bash-side shared audits are
+    follow-up scope). Shared/private|shared/secrets are caught earlier
+    by the unconditional Stage A substring deny.
+    """
+    home_root = agent_home_root()
+
+    try:
+        tokens = shlex.split(text, posix=True, comments=False)
+    except ValueError:
+        return None
+
+    decisions: list[tuple[Path, str, str]] = []
+    all_allowed = True
+
+    def _classify_peer(path: Path) -> tuple[bool, str, str] | None:
+        """Return (allowed, audit_target, peer_key) for cross-agent peer
+        paths; None for paths outside the cross-agent territory."""
+        rel_agent = _resolve_under(path, home_root)
+        if rel_agent is None:
+            return None
+        parts = rel_agent.parts
+        if not parts:
+            return None
+        peer = parts[0]
+        if peer == agent:
+            return None  # self-home, not a cross-agent reference
+        allowed, audit_target = _system_class_cross_agent_read_allowed(
+            path, agent
+        )
+        return allowed, audit_target, peer
+
+    def _process_value(value: str) -> None:
+        nonlocal all_allowed
+        for path in _bash_token_resolved_paths(value):
+            verdict = _classify_peer(path)
+            if verdict is None:
+                continue
+            allowed, audit_target, peer_key = verdict
+            if not allowed:
+                all_allowed = False
+                continue
+            decisions.append((path, audit_target, peer_key))
+
+    skip_next_payload = False
+    treat_next_as_value = False
+    for tok in tokens:
+        if skip_next_payload:
+            skip_next_payload = False
+            continue
+        if treat_next_as_value:
+            treat_next_as_value = False
+            _process_value(tok)
+            continue
+        if tok in _STRING_PAYLOAD_FLAGS:
+            skip_next_payload = True
+            continue
+        if tok in _FILE_VALUED_FLAGS:
+            treat_next_as_value = True
+            continue
+        if tok.startswith("--") and "=" in tok:
+            flag, _, value = tok.partition("=")
+            if flag in _STRING_PAYLOAD_FLAGS:
+                continue
+            _process_value(value)
+            continue
+        _process_value(tok)
+
+    return decisions, all_allowed
+
+
+def _argv_occurrences_explain_text(
+    text: str,
+    peer_aliases: list[str],
+    decisions: list[tuple[Path, str, str]],
+) -> bool:
+    """Return True iff every peer-alias substring occurrence in *text*
+    is exactly accounted for by a decision in *decisions*.
+
+    Both sides key on the peer agent name (the last segment of the
+    alias, also `decisions[*][2]`). Multiple alias variants pointing at
+    the same peer collapse to the same key. Counts must match — if
+    text mentions peer X twice but only one argv token resolved to
+    peer X, a smuggle (e.g. second occurrence inside a quoted blob the
+    argv parser cannot surface) is suspected.
+
+    Variants overlap (the no-trailing-slash form is a prefix of the
+    trailing-slash form). We sort by length descending and "consume"
+    matched ranges with NUL so the shorter form doesn't double-count.
+    """
+    sorted_aliases = sorted(peer_aliases, key=len, reverse=True)
+
+    def _peer_for_alias(alias: str) -> str:
+        return alias.rstrip("/").rsplit("/", 1)[-1]
+
+    consumed = list(text)
+    text_count: dict[str, int] = {}
+    for alias in sorted_aliases:
+        peer = _peer_for_alias(alias)
+        if not peer:
+            continue
+        n = len(alias)
+        i = 0
+        while True:
+            joined = "".join(consumed)
+            idx = joined.find(alias, i)
+            if idx < 0:
+                break
+            for k in range(idx, idx + n):
+                consumed[k] = "\0"
+            text_count[peer] = text_count.get(peer, 0) + 1
+            i = idx + n
+
+    decision_count: dict[str, int] = {}
+    for _path, _audit, peer_key in decisions:
+        decision_count[peer_key] = decision_count.get(peer_key, 0) + 1
+
+    for peer in set(text_count) | set(decision_count):
+        if text_count.get(peer, 0) != decision_count.get(peer, 0):
+            return False
+    return True
+
+
 def _bash_argv_references_path(command: str, protected: Path) -> bool:
     """Return True if *command*, interpreted as shell argv, names
     *protected* as a filesystem argument — either positionally or as the
@@ -931,43 +1170,53 @@ def protected_alias_reason(text: str, agent: str) -> str | None:
         return SYSTEM_CONFIG_DENY_REASON
     if admin:
         return None
-    aliases = [
-        f"{home_root}/{other.name}/"
-        for other in other_agent_homes(agent)
-    ]
-    aliases.extend(
-        [
-            f"{home_root}/{other.name}"
-            for other in other_agent_homes(agent)
-        ]
-    )
-    aliases.extend(
-        [
-            f"~/.agent-bridge/agents/{other.name}/"
-            for other in other_agent_homes(agent)
-        ]
-    )
-    aliases.extend(
-        [
-            f"~/.agent-bridge/agents/{other.name}"
-            for other in other_agent_homes(agent)
-        ]
-    )
-    aliases.extend(
-        [
-            f"$HOME/.agent-bridge/agents/{other.name}/"
-            for other in other_agent_homes(agent)
-        ]
-    )
-    aliases.extend(
-        [
-            f"$HOME/.agent-bridge/agents/{other.name}"
-            for other in other_agent_homes(agent)
-        ]
-    )
-    for alias in aliases:
-        if alias in text:
-            return f"cross-agent access is blocked: {alias}"
+
+    # Issue #539 follow-up — Stage A: shared/private/ and shared/secrets/
+    # are off-limits for every non-admin agent regardless of class.
+    # Substring deny because the path can ride inside a heredoc body or
+    # a quoted blob the argv parser cannot surface as a clean token.
+    for forbidden_alias in _shared_forbidden_aliases():
+        if forbidden_alias in text:
+            return (
+                "cross-agent access is blocked: shared/private and "
+                "shared/secrets are off-limits"
+            )
+
+    # Stage B: peer-agent-home substring deny with a system-class
+    # read-intent exception path. The default stance is deny: a system-
+    # class agent earns the carve-out only when (1) the command is
+    # smuggle-free and (2) every alias substring in raw text is
+    # explained by a clean argv token whose resolved Path satisfies
+    # `_system_class_cross_agent_read_allowed`.
+    peer_aliases = _peer_alias_list(agent)
+    matched_alias = next((a for a in peer_aliases if a in text), None)
+    if matched_alias is None:
+        return None
+
+    if not (read_intent and current_agent_class() == "system"):
+        return f"cross-agent access is blocked: {matched_alias}"
+
+    if _command_has_shell_embedding(text):
+        return f"cross-agent access is blocked: {matched_alias}"
+
+    decisions_and_flag = _bash_argv_protected_decisions(text, agent)
+    if decisions_and_flag is None:
+        return f"cross-agent access is blocked: {matched_alias}"
+
+    decisions, all_allowed = decisions_and_flag
+    if not all_allowed:
+        return f"cross-agent access is blocked: {matched_alias}"
+
+    if not _argv_occurrences_explain_text(text, peer_aliases, decisions):
+        return f"cross-agent access is blocked: {matched_alias}"
+
+    for path, audit_target, _peer_key in decisions:
+        emit_system_cross_agent_read(
+            agent=agent,
+            target_path=str(path),
+            target_agent=audit_target,
+            tool="Bash",
+        )
     return None
 
 

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -298,7 +298,14 @@ bridge_write_idle_ready_agents() {
 
     case "$engine" in
       claude)
-        bridge_agent_idle_marker_exists "$agent" || continue
+        if ! bridge_agent_idle_marker_exists "$agent"; then
+          # A missing marker most often means a turn aborted before the
+          # Stop hook fired (Anthropic 429 quota cap, network drop, etc.).
+          # Reuse the visual-prompt probe that bridge_dispatch_notification
+          # already calls at dispatch time so the agent rejoins the ready
+          # list as soon as its tmux pane is back at a Claude prompt.
+          bridge_claude_session_try_mark_prompt_ready "$agent" "$session" || continue
+        fi
         ;;
       codex)
         bridge_tmux_session_has_prompt "$session" "$engine" || continue

--- a/tests/tool-policy-bash-system-class/smoke.sh
+++ b/tests/tool-policy-bash-system-class/smoke.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# tool-policy-bash-system-class smoke — verify the issue #539 follow-up
+# carve-out for class=system Bash read-intent peer/shared access.
+#
+# Background. PR #539/#562 added a Read-tool carve-out so class=system
+# agents (e.g. librarian) can read peer memory/{projects,decisions,
+# shared}/ and shared/* (excluding shared/private + shared/secrets).
+# The Bash code path missed the same carve-out — `if alias in text`
+# at the tail of `protected_alias_reason` denied every Bash command
+# that named a peer path, even read-intent `ls`/`cat` calls. librarian
+# #18510 wedged on this for four days.
+#
+# This test pins the new behaviour:
+#
+#   1.  system + read-intent + peer/memory/projects → ALLOW + audit
+#   2.  system + read-intent + peer/memory/decisions → ALLOW + audit
+#   3.  system + read-intent + shared/notes (non-forbidden) → ALLOW + audit
+#   4.  system + read-intent + peer/memory/secrets (outside allowlist)
+#       → DENY (allowlist rejects, all_allowed=False)
+#   5.  system + read-intent + shared/private/x → DENY (Stage A absolute)
+#   6.  system + read-intent + shared/secrets/x → DENY (Stage A absolute)
+#   7.  user-class + read-intent + peer/memory/projects → DENY (no carve)
+#   8.  system + write-intent (cp) + peer/memory/projects → DENY
+#   9.  system + read-intent + here-string smuggle case
+#       (`cat .../projects/x <<< "$(cat .../private/secret)"`) → DENY
+#  10.  system + read-intent + backtick smuggle → DENY
+#  11.  system + read-intent + process-substitution smuggle → DENY
+#  12.  system + read-intent + heredoc → DENY (smuggling vector)
+#  13.  system + read-intent + multi-stage simple read
+#       (`cat .../projects/a && ls .../projects/`) → ALLOW (2 audits)
+#  14.  system + read-intent + `--body` skipped path → DENY
+#       (text-occurrence proof rejects the unaccounted alias)
+#  15.  Track E sanity: idle-marker self-heal (deferred to bash unit
+#       below) — just confirms the helper exists with the new
+#       fallback path.
+#
+# Every ALLOW path must produce a `system_cross_agent_read` audit row
+# with `tool="Bash"`. Every DENY path must NOT produce that row for
+# the request being denied.
+#
+# Uses an isolated mktemp BRIDGE_HOME — never touches the live install.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd -P)"
+PYTHON="${BRIDGE_PYTHON:-$(command -v python3 || echo /usr/bin/python3)}"
+
+if [[ ! -x "$PYTHON" && ! -r "$PYTHON" ]]; then
+  printf '[smoke][error] python3 not found at %s\n' "$PYTHON" >&2
+  exit 2
+fi
+
+BRIDGE_HOME="$(mktemp -d -t agb-bash-syscls.XXXXXX)"
+export BRIDGE_HOME
+# bridge-run.sh exports BRIDGE_AGENT_HOME_ROOT in live agent shells, so
+# `agent_home_root()` will ignore BRIDGE_HOME if we leave that var
+# dangling. Pin it to the fixture once so every spawned hook sees it.
+BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"
+export BRIDGE_AGENT_HOME_ROOT
+trap 'rm -rf "$BRIDGE_HOME"' EXIT
+
+ADMIN_AGENT="patch"
+SYSTEM_AGENT="librarian"
+USER_AGENT="huchu"
+PEER_AGENT="syrs-derm"
+
+mkdir -p "$BRIDGE_HOME/agents/$ADMIN_AGENT"
+mkdir -p "$BRIDGE_HOME/agents/$SYSTEM_AGENT"
+mkdir -p "$BRIDGE_HOME/agents/$USER_AGENT"
+mkdir -p "$BRIDGE_HOME/agents/$PEER_AGENT/memory/projects"
+mkdir -p "$BRIDGE_HOME/agents/$PEER_AGENT/memory/decisions"
+mkdir -p "$BRIDGE_HOME/agents/$PEER_AGENT/memory/secrets"
+mkdir -p "$BRIDGE_HOME/shared/notes"
+mkdir -p "$BRIDGE_HOME/shared/private"
+mkdir -p "$BRIDGE_HOME/shared/secrets"
+mkdir -p "$BRIDGE_HOME/logs"
+
+PROJECTS_FILE="$BRIDGE_HOME/agents/$PEER_AGENT/memory/projects/x.md"
+DECISIONS_FILE="$BRIDGE_HOME/agents/$PEER_AGENT/memory/decisions/y.md"
+SECRETS_FILE="$BRIDGE_HOME/agents/$PEER_AGENT/memory/secrets/z.md"
+SHARED_NOTES_FILE="$BRIDGE_HOME/shared/notes/foo.md"
+SHARED_PRIVATE_FILE="$BRIDGE_HOME/shared/private/p.md"
+SHARED_SECRETS_FILE="$BRIDGE_HOME/shared/secrets/s.md"
+
+printf 'projects body\n' >"$PROJECTS_FILE"
+printf 'decisions body\n' >"$DECISIONS_FILE"
+printf 'secrets body\n' >"$SECRETS_FILE"
+printf 'shared notes\n' >"$SHARED_NOTES_FILE"
+printf 'shared private\n' >"$SHARED_PRIVATE_FILE"
+printf 'shared secrets\n' >"$SHARED_SECRETS_FILE"
+
+AUDIT_LOG="$BRIDGE_HOME/logs/audit.jsonl"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+pass() {
+  PASS=$((PASS + 1))
+  printf '[smoke][pass] %s\n' "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  FAILURES+=("$1")
+  printf '[smoke][fail] %s\n' "$1" >&2
+}
+
+run_hook() {
+  # run_hook <agent> <class user|system> <bash command>
+  local agent="$1"
+  local cls="$2"
+  local cmd="$3"
+  local payload
+  payload=$("$PYTHON" - "$cmd" <<'PY'
+import json, sys
+print(json.dumps({
+  "hook_event_name": "PreToolUse",
+  "tool_name": "Bash",
+  "tool_use_id": "test",
+  "session_id": "test-session",
+  "tool_input": {"command": sys.argv[1]},
+}))
+PY
+)
+  BRIDGE_AGENT_ID="$agent" \
+    BRIDGE_AGENT_CLASS_FOR_HOOK="$cls" \
+    BRIDGE_AUDIT_LOG="$AUDIT_LOG" \
+    BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT" \
+    "$PYTHON" "$REPO_ROOT/hooks/tool-policy.py" <<<"$payload"
+}
+
+assert_allow() {
+  local name="$1"
+  local out="$2"
+  if [[ -z "$out" ]]; then
+    pass "$name: allow (no deny output)"
+    return 0
+  fi
+  # Some allow paths may emit JSON without permissionDecision=deny.
+  if [[ "$out" != *'"permissionDecision":"deny"'* ]] && [[ "$out" != *'"permissionDecision": "deny"'* ]]; then
+    pass "$name: allow"
+    return 0
+  fi
+  fail "$name: expected allow but got deny — $out"
+  return 1
+}
+
+assert_deny() {
+  local name="$1"
+  local out="$2"
+  local expect_substr="${3:-cross-agent}"
+  if [[ "$out" == *"$expect_substr"* ]]; then
+    pass "$name: deny matched '$expect_substr'"
+    return 0
+  fi
+  fail "$name: expected deny containing '$expect_substr' — got: $out"
+  return 1
+}
+
+audit_has_row() {
+  # audit_has_row <action> <expected_target_path_substring> <expected_target_agent>
+  local action="$1"
+  local path_sub="$2"
+  local target_agent="$3"
+  [[ -f "$AUDIT_LOG" ]] || return 1
+  "$PYTHON" - "$AUDIT_LOG" "$action" "$path_sub" "$target_agent" <<'PY'
+import json, sys
+log_path, action, path_sub, target_agent = sys.argv[1:5]
+with open(log_path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if row.get("action") != action:
+            continue
+        detail = row.get("detail") or {}
+        if path_sub and path_sub not in str(detail.get("target_path", "")):
+            continue
+        if detail.get("target_agent") != target_agent:
+            continue
+        if detail.get("tool") != "Bash":
+            continue
+        sys.exit(0)
+sys.exit(1)
+PY
+}
+
+audit_count() {
+  # audit_count <action> <tool>
+  local action="$1"
+  local tool="$2"
+  [[ -f "$AUDIT_LOG" ]] || { echo 0; return; }
+  "$PYTHON" - "$AUDIT_LOG" "$action" "$tool" <<'PY'
+import json, sys
+log_path, action, tool = sys.argv[1:4]
+n = 0
+with open(log_path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if row.get("action") != action:
+            continue
+        detail = row.get("detail") or {}
+        if detail.get("tool") != tool:
+            continue
+        n += 1
+print(n)
+PY
+}
+
+# --- Scenario 1: system + read + peer/memory/projects -> ALLOW + audit
+out="$(run_hook "$SYSTEM_AGENT" system "ls $PROJECTS_FILE" 2>/dev/null)"
+assert_allow "scenario 1 (system read peer projects)" "$out"
+if audit_has_row "system_cross_agent_read" "$PROJECTS_FILE" "$PEER_AGENT"; then
+  pass "scenario 1: audit row present (target_agent=$PEER_AGENT, tool=Bash)"
+else
+  fail "scenario 1: expected system_cross_agent_read audit row"
+fi
+
+# --- Scenario 2: system + read + peer/memory/decisions
+out="$(run_hook "$SYSTEM_AGENT" system "cat $DECISIONS_FILE" 2>/dev/null)"
+assert_allow "scenario 2 (system read peer decisions)" "$out"
+if audit_has_row "system_cross_agent_read" "$DECISIONS_FILE" "$PEER_AGENT"; then
+  pass "scenario 2: audit row present"
+else
+  fail "scenario 2: expected audit row for $DECISIONS_FILE"
+fi
+
+# --- Scenario 3: system + read + shared/notes (non-forbidden)
+# shared/non-forbidden is broadly readable across classes today; the
+# file-tool path emits the system-class audit row when librarian Reads
+# the same path. Bash-side audit emission for shared/* reads is
+# documented follow-up scope (PR body) — this test pins the no-deny
+# behavior but does not assert the audit row.
+out="$(run_hook "$SYSTEM_AGENT" system "ls $SHARED_NOTES_FILE" 2>/dev/null)"
+assert_allow "scenario 3 (system read shared/notes)" "$out"
+
+# --- Scenario 4: system + read + peer/memory/secrets (not in allowlist)
+out="$(run_hook "$SYSTEM_AGENT" system "cat $SECRETS_FILE" 2>/dev/null)"
+assert_deny "scenario 4 (system read peer/memory/secrets)" "$out" "cross-agent"
+
+# --- Scenario 5: system + read + shared/private/x (Stage A absolute deny)
+out="$(run_hook "$SYSTEM_AGENT" system "cat $SHARED_PRIVATE_FILE" 2>/dev/null)"
+assert_deny "scenario 5 (system read shared/private)" "$out" "shared/private"
+
+# --- Scenario 6: system + read + shared/secrets/x (Stage A)
+out="$(run_hook "$SYSTEM_AGENT" system "cat $SHARED_SECRETS_FILE" 2>/dev/null)"
+assert_deny "scenario 6 (system read shared/secrets)" "$out" "shared/secrets"
+
+# --- Scenario 7: user-class read on peer/projects -> DENY
+out="$(run_hook "$USER_AGENT" user "cat $PROJECTS_FILE" 2>/dev/null)"
+assert_deny "scenario 7 (user-class peer read)" "$out" "cross-agent"
+
+# --- Scenario 8: system + write (cp) on peer projects -> DENY
+out="$(run_hook "$SYSTEM_AGENT" system "cp $PROJECTS_FILE /tmp/x.md" 2>/dev/null)"
+assert_deny "scenario 8 (system write to peer)" "$out" "cross-agent"
+
+# --- Scenario 9: here-string smuggle case (the patch-dev r3 vector)
+out="$(run_hook "$SYSTEM_AGENT" system "cat $PROJECTS_FILE <<< \"\$(cat $SHARED_PRIVATE_FILE)\"" 2>/dev/null)"
+assert_deny "scenario 9 (heredoc-string + command substitution smuggle)" "$out"
+
+# --- Scenario 10: backtick smuggle
+out="$(run_hook "$SYSTEM_AGENT" system 'cat '"$PROJECTS_FILE"' `cat '"$SHARED_PRIVATE_FILE"'`' 2>/dev/null)"
+assert_deny "scenario 10 (backtick smuggle)" "$out"
+
+# --- Scenario 11: process substitution smuggle
+out="$(run_hook "$SYSTEM_AGENT" system "diff $PROJECTS_FILE <(cat $SHARED_PRIVATE_FILE)" 2>/dev/null)"
+assert_deny "scenario 11 (process substitution smuggle)" "$out"
+
+# --- Scenario 12: heredoc — the "<<EOF" embedding gates carve-out
+out="$(run_hook "$SYSTEM_AGENT" system "cat $PROJECTS_FILE <<EOF
+$SHARED_PRIVATE_FILE
+EOF" 2>/dev/null)"
+assert_deny "scenario 12 (heredoc smuggle)" "$out"
+
+# --- Scenario 13: multi-stage simple read (no smuggle markers)
+before_count="$(audit_count "system_cross_agent_read" "Bash")"
+out="$(run_hook "$SYSTEM_AGENT" system "cat $PROJECTS_FILE && ls $DECISIONS_FILE" 2>/dev/null)"
+assert_allow "scenario 13 (multi-stage simple peer read)" "$out"
+after_count="$(audit_count "system_cross_agent_read" "Bash")"
+delta=$((after_count - before_count))
+if [[ "$delta" -ge 2 ]]; then
+  pass "scenario 13: at least 2 audit rows emitted (delta=$delta)"
+else
+  fail "scenario 13: expected >=2 audit rows, got delta=$delta"
+fi
+
+# --- Scenario 14: --body skipped + alias still in text -> DENY
+# `cat --body $peer/projects` skips --body's value via _STRING_PAYLOAD_FLAGS.
+# The alias is still in raw text but argv-resolved decision is empty;
+# occurrence proof should reject.
+out="$(run_hook "$SYSTEM_AGENT" system "cat --body $PROJECTS_FILE" 2>/dev/null)"
+assert_deny "scenario 14 (--body skipped value)" "$out" "cross-agent"
+
+# --- Scenario 15: Track E sanity — confirm the helper is wired
+if grep -q "bridge_claude_session_try_mark_prompt_ready" \
+     "$REPO_ROOT/lib/bridge-channels.sh"; then
+  pass "scenario 15: bridge_write_idle_ready_agents falls back to try_mark_prompt_ready"
+else
+  fail "scenario 15: Track E helper call missing from bridge_write_idle_ready_agents"
+fi
+
+# --- Summary
+printf '\n[smoke] PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
+if (( FAIL > 0 )); then
+  printf '[smoke] failures:\n' >&2
+  for f in "${FAILURES[@]}"; do
+    printf '  - %s\n' "$f" >&2
+  done
+  exit 1
+fi
+exit 0

--- a/tests/tool-policy-bash-system-class/smoke.sh
+++ b/tests/tool-policy-bash-system-class/smoke.sh
@@ -257,6 +257,17 @@ assert_deny "scenario 5 (system read shared/private)" "$out" "shared/private"
 out="$(run_hook "$SYSTEM_AGENT" system "cat $SHARED_SECRETS_FILE" 2>/dev/null)"
 assert_deny "scenario 6 (system read shared/secrets)" "$out" "shared/secrets"
 
+# --- Scenario 6a: bare directory `ls .../shared/private` (no trailing slash)
+# patch-dev review of 94711d3 caught that the slash-only alias variants in
+# `_shared_forbidden_aliases()` let `ls $BRIDGE_HOME/shared/private` slip
+# past Stage A. Pin the no-trailing-slash form here.
+out="$(run_hook "$SYSTEM_AGENT" system "ls $BRIDGE_HOME/shared/private" 2>/dev/null)"
+assert_deny "scenario 6a (bare directory shared/private no trailing slash)" "$out" "shared/private"
+
+# --- Scenario 6b: same regression, secrets root, no trailing slash
+out="$(run_hook "$SYSTEM_AGENT" system "ls $BRIDGE_HOME/shared/secrets" 2>/dev/null)"
+assert_deny "scenario 6b (bare directory shared/secrets no trailing slash)" "$out" "shared/secrets"
+
 # --- Scenario 7: user-class read on peer/projects -> DENY
 out="$(run_hook "$USER_AGENT" user "cat $PROJECTS_FILE" 2>/dev/null)"
 assert_deny "scenario 7 (user-class peer read)" "$out" "cross-agent"


### PR DESCRIPTION
## Summary

- **`hooks/tool-policy.py`** — system-class agents (e.g. `librarian`) can now run read-intent Bash commands (`ls`, `cat`, `find`, `wc`, `grep`) against peer `memory/{projects,decisions,shared}/` paths. Previously the Read-tool carve-out from #539/#562 was missing on the Bash side, leaving librarian's audit pipeline wedged for four days even after `class=system` was opted in. Each allow emits a `system_cross_agent_read` audit row with `tool="Bash"`.
- **`lib/bridge-channels.sh`** — `bridge_write_idle_ready_agents` reuses the existing `bridge_claude_session_try_mark_prompt_ready` helper to self-heal stale `idle-since` markers caused by abnormal turn termination (Anthropic 429 quota cap was the live trigger today; same symptom for SIGKILL / disk-full / network drop). No semantic change to the marker.

Surfaced together during the 2026-05-06 KST quota-cap incident: five running claude agents stayed stale for 4-6h after midnight because their Stop hooks never fired, while librarian (#18510) stayed blocked for four days against syrs-derm's `memory/projects/` ingest. Both root causes share the same v0.7.x doctrine — partial coverage of the system-class isolation surface — so closing them together preserves design coherence.

## Bash carve-out flow

After the existing roster / queue-DB / system-config gates and the admin bypass, `protected_alias_reason` now does:

1. **Stage A — absolute substring deny.** `_shared_forbidden_aliases()` returns six variants per forbidden prefix (private/, secrets/) covering absolute, `~`, `$HOME` × with/without trailing slash. Any substring hit denies even for system class.
2. **Stage B — peer alias substring deny with system-class read-intent exception.** Default stance is deny. The carve-out fires only when *all four* of the following hold:
   - `read_intent and current_agent_class() == "system"`.
   - `_command_has_shell_embedding(text)` is False — no `$(`, backtick, `<(`, `>(`, `<<` in raw text. These are the only smuggling vectors; pipes / `&&` / `||` / `;` stay individually visible to shlex and pass.
   - `_bash_argv_protected_decisions(text, agent)` returns `(decisions, all_allowed=True)` with every peer-resolving argv token admitted by `_system_class_cross_agent_read_allowed`.
   - `_argv_occurrences_explain_text(text, peer_aliases, decisions)` confirms every peer-alias substring count in raw text equals the argv-resolved decision count for that peer. Mismatch (extra hit hidden in a quoted blob, `--body` skipped value, etc.) rejects.

Emits `emit_system_cross_agent_read` per allowed decision.

The vulnerability `cat $peer/memory/projects/x <<< "$(cat $peer/private/secret)"` (raised during plan review) trips the embedding gate and stays denied. Each smuggling variant has a pinned regression case.

## Idle-marker fix

`bridge_dispatch_notification` already calls `bridge_claude_session_try_mark_prompt_ready` at delivery time as a fallback when `bridge_claude_session_can_wake` says "no marker". The probe is cheap (one `tmux capture-pane`) and guards against false positives (only marks idle if the pane currently shows a Claude prompt). The fix simply runs the same probe one stage earlier, in `bridge_write_idle_ready_agents`, so a marker-missing agent re-enters the ready list as soon as its tmux pane is back at the prompt — rather than being filtered out before the dispatch fallback can ever run.

## Tests

- New: `tests/tool-policy-bash-system-class/smoke.sh` — 20 scenarios covering the allow path, the four smuggling vectors, both Stage A bare-directory regressions, multi-stage allow, the `--body` skipped-value mismatch, and the Track E helper wiring.
- Existing: `tests/system-config-gating/smoke.sh` — 37 PASS, 0 fail (no regression).

## Test plan

- [ ] CI on the PR.
- [ ] After merge: bump VERSION on a release branch and tag.
- [ ] After upgrade locally: librarian #18510 blocked-aging chain should clear once `agent-bridge knowledge` Bash read pipeline is allowed; existing peer Read-tool path is unchanged.

## Known follow-up scope (intentionally deferred)

- **Bash-side audit emission for system-class shared/* (non-forbidden) reads.** The Read-tool path already emits these audit rows; Bash parity is a separate, smaller change.
- **`--body` / `--message` payload false-positive on the substring deny.** A peer-alias substring inside a message body string (which `_bash_argv_references_path` already skips for argv purposes) still trips the substring deny. Pre-existing behavior; not regressed by this change.

## Pair-review

Plan reviewed in 4 rounds with `patch-dev`; implementation reviewed in 2 rounds with `patch-dev` (`needs-more` on the bare-directory bypass → fixed in d33aa30 → `implement-ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)