### PR TITLE
feat(agent): typed-flag completion + agent doctor (#580 Track 2)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -309,6 +309,65 @@ the defaults above. Set `BRIDGE_AGENT_PERMISSION_MODE["agent"]="legacy"`
 to explicitly pin the historical blanket-bypass shape (e.g. for sandboxed
 offline roles).
 
+## Admin agent CRUD policy
+
+Admin agents (the role configured as `BRIDGE_ADMIN_AGENT_ID`) operate on
+managed roles **exclusively** through the typed
+`agent-bridge agent <verb>` surface:
+
+```
+agent-bridge agent create   <name> [...]   # scaffold + write managed block
+agent-bridge agent update   <name> [...]   # typed full-replace mutations
+agent-bridge agent delete   <name> [...]   # admin-audited removal (#580 Track 1)
+agent-bridge agent retire   <name> [...]   # quarantine for dynamic / orphan only
+agent-bridge agent doctor                  # CRUD self-check (#580 Track 2)
+```
+
+Direct `Edit` / `Write` against `agent-roster.local.sh` is intentionally
+blocked by `hooks/tool-policy.py` even when the caller is the admin
+agent. The block is not a sandbox — it is the audit-chain contract. The
+typed verbs above:
+
+- emit a `system_config_mutation` row to `audit.jsonl` for every apply,
+  deny, or dry-run (see `lib/bridge-agent-update.sh:bridge_agent_update_emit_audit`),
+- enforce the operator-trusted-source check (TTY-detected or
+  `BRIDGE_CALLER_SOURCE` override) before mutating,
+- round-trip every non-touched field byte-for-byte through
+  `bridge_write_role_block` so the BEGIN/END managed-block shape is
+  stable across releases.
+
+A hand-edit that bypasses these gates will be reverted by the daemon's
+next reconciliation pass. If the typed surface lacks a flag for a field
+you need to mutate, file an issue rather than reaching around — the gap
+is bug, not policy.
+
+`agent-bridge agent doctor` exists specifically to verify this surface
+end-to-end. It scaffolds an ephemeral `smoke-doctor-*` fixture, runs
+create / update / registry / show / reclassify / retire / delete in
+sequence, and reports each step as `pass` / `fail` / `n/a` (the latter
+when the path is structurally inapplicable to the fixture, e.g. retire
+on a static-roster row). The fixture is removed on exit even if the
+self-check fails. Run it after every install upgrade and after any
+local change to the admin-CRUD code paths.
+
+Update flags currently exposed on `agent update`:
+
+| flag | field | issue |
+|---|---|---|
+| `--set-launch-cmd`, `--launch-cmd-add-env`, `--launch-cmd-remove-env`, `--launch-cmd-add-dev-channel`, `--launch-cmd-remove-dev-channel` | `BRIDGE_AGENT_LAUNCH_CMD` | #528 |
+| `--channels-set`, `--channels-add`, `--channels-remove` | `BRIDGE_AGENT_CHANNELS` | #528 |
+| `--desc <text>` | `BRIDGE_AGENT_DESC` | #580 Track 2 |
+| `--engine claude\|codex` | `BRIDGE_AGENT_ENGINE` | #580 Track 2 |
+| `--workdir <path>` | `BRIDGE_AGENT_WORKDIR` | #580 Track 2 |
+| `--loop on\|off` | `BRIDGE_AGENT_LOOP` | #580 Track 2 |
+| `--continue on\|off` | `BRIDGE_AGENT_CONTINUE` | #580 Track 2 |
+| `--class user\|system` | `BRIDGE_AGENT_CLASS` (privilege boundary, #539) | #580 Track 2 |
+
+`--class` follows the closed value space `{user, system}` enforced by
+`bridge_validate_agent_classes` at roster load. Operator-named classes
+("operator", "isolated", etc.) are not part of the privilege boundary
+and are refused at parse time.
+
 ## Worktree Workers
 
 When multiple agents may edit the same git repository, prefer isolated managed

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -20,6 +20,22 @@ bridge_load_roster
 
 usage() {
   cat <<EOF
+Subcommands (each is admin-audited where it mutates the protected roster):
+  create              scaffold a new managed role (writes BEGIN/END block to roster.local)
+  update              full-replace typed mutation of an existing role's fields
+  delete              admin-only removal of a managed role (audit-chain preserved)
+  retire              quarantine a dynamic / orphan agent's runtime home (no roster mutation)
+  list                tabular roster + runtime view (--json supported)
+  registry            read-only registry enumeration (--json supported)
+  show                detailed view for one agent (--json supported)
+  reclassify          dynamic→static reclassification of admin-shaped agents (--apply)
+  rerender-settings   regenerate per-agent Claude settings.effective.json (--apply)
+  doctor              CRUD self-check against an ephemeral test fixture (#580 Track 2)
+  start | safe-mode | stop | restart   tmux session lifecycle controls
+  ack-crash | forget-session           runtime state recovery
+  attach              attach to the agent's tmux session
+  compact | handoff   admin-maintenance dispatches via the queue
+
 Usage:
   $(basename "$0") create <agent> [options]
   $(basename "$0") update <agent> [options]
@@ -30,6 +46,7 @@ Usage:
   $(basename "$0") show <agent> [--json]
   $(basename "$0") reclassify [--agent <agent>] [--apply] [--json]
   $(basename "$0") rerender-settings [<agent>...] [--apply|--dry-run] [--json]
+  $(basename "$0") doctor [--from <admin>] [--keep-fixture] [--json]
   $(basename "$0") start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $(basename "$0") safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   $(basename "$0") stop <agent>
@@ -40,9 +57,10 @@ Usage:
   $(basename "$0") handoff <agent> [--note <text>]
 
 Update flags (typed audited mutation path for protected managed-role
-fields, issue #528). Caller must be the admin agent (BRIDGE_ADMIN_AGENT_ID)
-AND from an operator-trusted source (TTY-detected or BRIDGE_CALLER_SOURCE
-override) — same trust model as 'agent-bridge config set'. Repeatable.
+fields, issues #528 + #580 Track 2). Caller must be the admin agent
+(BRIDGE_ADMIN_AGENT_ID) AND from an operator-trusted source (TTY-detected
+or BRIDGE_CALLER_SOURCE override) — same trust model as
+'agent-bridge config set'. Repeatable.
 
   --from <agent>                       caller agent id (required when
                                        BRIDGE_AGENT_ID env is unset)
@@ -54,6 +72,13 @@ override) — same trust model as 'agent-bridge config set'. Repeatable.
   --channels-set <csv>                 full replace of BRIDGE_AGENT_CHANNELS
   --channels-add <token>               append unique CSV token
   --channels-remove <token>            remove matching CSV token
+  --desc <text>                        full replace of BRIDGE_AGENT_DESC (#580)
+  --engine claude|codex                full replace of BRIDGE_AGENT_ENGINE (#580)
+  --workdir <path>                     full replace of BRIDGE_AGENT_WORKDIR (#580)
+  --loop on|off                        toggle BRIDGE_AGENT_LOOP (#580)
+  --continue on|off                    toggle BRIDGE_AGENT_CONTINUE (#580)
+  --class user|system                  set privilege class — closed value space
+                                       matches lib/bridge-agents.sh (#539, #580)
   --json                               emit JSON envelope
   --dry-run                            do not mutate; emit planned diff
 
@@ -89,6 +114,9 @@ Examples:
   $(basename "$0") create reviewer --engine claude
   $(basename "$0") create coder --engine codex --session codex-main --always-on
   $(basename "$0") create ops --engine claude --channels plugin:discord@claude-plugins-official --discord-channel 123456789012345678 --json
+  $(basename "$0") update reviewer --desc "code review role" --loop on
+  $(basename "$0") update reviewer --class system  # privilege boundary; #539
+  $(basename "$0") doctor                          # CRUD self-check fixture
   $(basename "$0") list --json
   $(basename "$0") show reviewer --json
   $(basename "$0") reclassify --apply
@@ -100,6 +128,15 @@ Examples:
   $(basename "$0") attach reviewer
   $(basename "$0") compact reviewer
   $(basename "$0") handoff reviewer --note "context critical"
+
+Policy:
+  Admin agent operates exclusively through these typed verbs. Direct
+  Edit/Write of agent-roster.local.sh is intentionally blocked (even for
+  the admin role) so the audit chain stays single-sourced through this
+  CLI. Hand-edits will be reverted by the daemon's next reconciliation
+  pass; \`agent doctor\` exercises every CRUD path end-to-end against an
+  ephemeral fixture so an admin can verify the surface before relying
+  on it. See OPERATIONS.md "Admin agent CRUD policy" for the rationale.
 EOF
 }
 
@@ -622,6 +659,21 @@ bridge_write_role_block() {
   local isolation_mode="${16:-}"
   local os_user="${17:-}"
   local replace_existing="${18:-0}"
+  # Issue #580 Track 2: privilege class field (BRIDGE_AGENT_CLASS).
+  # Closed value space matches lib/bridge-agents.sh:bridge_agent_class
+  # ("user" | "system"); empty string means "do not emit the line"
+  # (preserves the legacy default-user shape for callers that have no
+  # class to declare). New positional, kept after replace_existing so all
+  # existing callers continue to work without source changes.
+  local agent_class="${19:-}"
+  # Issue #580 Track 2: explicit-off persistence for BRIDGE_AGENT_LOOP.
+  # Legacy semantic: writer only emits LOOP="1" when loop_mode==1; an
+  # absent line falls back to the reader's default (1). That made
+  # `agent update --loop off` a silent no-op. Pass this flag as "1" to
+  # force emission of LOOP="0" so the operator's intent round-trips.
+  # Default empty preserves legacy create behavior (no LOOP line on
+  # default-loop agents).
+  local loop_explicit_off="${20:-}"
 
   bridge_agent_manage_python \
     "$BRIDGE_ROSTER_LOCAL_FILE" \
@@ -642,7 +694,9 @@ bridge_write_role_block() {
     "$always_on" \
     "$isolation_mode" \
     "$os_user" \
-    "$replace_existing" <<'PY'
+    "$replace_existing" \
+    "$agent_class" \
+    "$loop_explicit_off" <<'PY'
 from pathlib import Path
 import shlex
 import sys
@@ -668,6 +722,8 @@ import re
     isolation_mode,
     os_user,
     replace_existing,
+    agent_class,
+    loop_explicit_off,
 ) = sys.argv[1:]
 
 path = Path(path_str)
@@ -708,6 +764,13 @@ if notify_account:
     lines.append(f'BRIDGE_AGENT_NOTIFY_ACCOUNT["{agent}"]={sq(notify_account)}')
 if loop_mode == "1":
     lines.append(f'BRIDGE_AGENT_LOOP["{agent}"]="1"')
+elif loop_explicit_off == "1":
+    # Issue #580 Track 2: persist `--loop off` so the reader doesn't
+    # fall back to its default (1). Only emitted when the caller
+    # explicitly opted into the off-write — bare `loop_mode == "0"` is
+    # also the default for `agent create`, which must keep producing
+    # a no-LOOP-line block to preserve legacy reader semantics.
+    lines.append(f'BRIDGE_AGENT_LOOP["{agent}"]="0"')
 if continue_mode == "1":
     lines.append(f'BRIDGE_AGENT_CONTINUE["{agent}"]="1"')
 else:
@@ -721,6 +784,14 @@ if isolation_mode:
     lines.append(f'BRIDGE_AGENT_ISOLATION_MODE["{agent}"]={sq(isolation_mode)}')
 if os_user:
     lines.append(f'BRIDGE_AGENT_OS_USER["{agent}"]={sq(os_user)}')
+# Issue #580 Track 2: only emit BRIDGE_AGENT_CLASS when explicitly set.
+# Empty string preserves the legacy default-user shape (the reader in
+# lib/bridge-agents.sh:bridge_agent_class falls back to "user" on missing
+# entries). The closed value space is enforced upstream in run_update; we
+# emit verbatim here so a malformed value would surface at next
+# bridge_validate_agent_classes pass rather than silently round-trip.
+if agent_class:
+    lines.append(f'BRIDGE_AGENT_CLASS["{agent}"]={sq(agent_class)}')
 lines.append(end)
 
 block = "\n".join(lines) + "\n"
@@ -2242,6 +2313,25 @@ run_update() {
   local launch_cmd_ops=""
   local channels_ops=""
 
+  # Issue #580 Track 2: typed-flag completion. Each "set" flag is a
+  # full-replace of the corresponding roster field. We track presence
+  # separately from value so an explicit empty-string mutation (e.g.
+  # `--desc ""` to blank a description) is distinguishable from "flag
+  # not passed". The mutation_present counter still drives the
+  # "no-change refused" gate below.
+  local desc_set_present=0
+  local desc_set_value=""
+  local engine_set_present=0
+  local engine_set_value=""
+  local workdir_set_present=0
+  local workdir_set_value=""
+  local loop_set_present=0
+  local loop_set_value=""        # "1" | "0"
+  local continue_set_present=0
+  local continue_set_value=""    # "1" | "0"
+  local class_set_present=0
+  local class_set_value=""       # "user" | "system"
+
   add_launch_cmd_op() {
     launch_cmd_ops+="$1"$'\t'"$2"$'\n'
     mutation_present=1
@@ -2353,6 +2443,104 @@ run_update() {
         add_channels_op "channels-remove" "$2"
         shift 2
         ;;
+      --desc|--description)
+        # Issue #580 Track 2: full-replace of BRIDGE_AGENT_DESC.
+        # Empty string is allowed (clears the description) — the writer
+        # will still emit the line so the field round-trips byte-for-byte.
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        case "$2" in
+          *$'\n'*)
+            bridge_die "$1 값에 줄바꿈이 포함될 수 없습니다: $2"
+            ;;
+        esac
+        desc_set_present=1
+        desc_set_value="$2"
+        mutation_present=1
+        shift 2
+        ;;
+      --engine)
+        # Issue #580 Track 2: full-replace of BRIDGE_AGENT_ENGINE.
+        # Closed value space matches `agent create` (claude|codex). Any
+        # other value is refused at parse time so the bad value never
+        # reaches the writer.
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        case "$2" in
+          claude|codex) ;;
+          *) bridge_die "--engine 는 claude|codex 만 지원합니다: $2" ;;
+        esac
+        engine_set_present=1
+        engine_set_value="$2"
+        mutation_present=1
+        shift 2
+        ;;
+      --workdir)
+        # Issue #580 Track 2: full-replace of BRIDGE_AGENT_WORKDIR. The
+        # value is expanded the same way `agent create` does (~ → $HOME)
+        # so operators can pass `~/project` and the writer stores the
+        # absolute path. We do NOT auto-create the directory here — that
+        # is `agent create`'s job; mutating workdir on an existing agent
+        # is an "operator already moved the tree" pointer-fix, not a
+        # scaffold step.
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        case "$2" in
+          *$'\n'*)
+            bridge_die "$1 값에 줄바꿈이 포함될 수 없습니다: $2"
+            ;;
+          "")
+            bridge_die "--workdir 값은 비어 있을 수 없습니다."
+            ;;
+        esac
+        workdir_set_present=1
+        workdir_set_value="$(bridge_expand_user_path "$2")"
+        mutation_present=1
+        shift 2
+        ;;
+      --loop)
+        # Issue #580 Track 2: BRIDGE_AGENT_LOOP toggle. The roster field
+        # is a 0/1 in the writer's emission shape (lib/bridge-agents.sh
+        # bridge_agent_loop returns "0" or "1"); we accept on|off|1|0
+        # for ergonomic parity with `agent create --loop` (no-arg flag).
+        # The brief's `<seconds>` form maps to BRIDGE_AGENT_IDLE_TIMEOUT,
+        # which is owned by `--always-on` / out-of-scope here.
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        case "$2" in
+          on|1|true)  loop_set_value="1" ;;
+          off|0|false) loop_set_value="0" ;;
+          *) bridge_die "--loop 는 on|off (1|0) 만 지원합니다: $2" ;;
+        esac
+        loop_set_present=1
+        mutation_present=1
+        shift 2
+        ;;
+      --continue)
+        # Issue #580 Track 2: BRIDGE_AGENT_CONTINUE toggle. Same 0/1
+        # surface as the writer; on|off accepted for ergonomics.
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        case "$2" in
+          on|1|true)  continue_set_value="1" ;;
+          off|0|false) continue_set_value="0" ;;
+          *) bridge_die "--continue 는 on|off (1|0) 만 지원합니다: $2" ;;
+        esac
+        continue_set_present=1
+        mutation_present=1
+        shift 2
+        ;;
+      --class)
+        # Issue #580 Track 2: BRIDGE_AGENT_CLASS toggle. Closed value
+        # space matches lib/bridge-agents.sh:bridge_agent_class and
+        # bridge_validate_agent_classes ({user, system}); operator-named
+        # classes from the brief ("operator", "isolated") are not part
+        # of the privilege boundary and would silently fail validation
+        # at next roster load, so we refuse them here at parse time.
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        case "$2" in
+          user|system) class_set_value="$2" ;;
+          *) bridge_die "--class 는 user|system 만 지원합니다 (lib/bridge-agents.sh:bridge_agent_class): $2" ;;
+        esac
+        class_set_present=1
+        mutation_present=1
+        shift 2
+        ;;
       --json)
         json_mode=1
         shift
@@ -2397,11 +2585,25 @@ run_update() {
 
   # Capture the operation summary for the audit row (compact one-line
   # description of what the operator asked for).
+  #
+  # `set -euo pipefail` is in effect, so each conditional emission ends
+  # with `|| true` to guarantee a 0 exit even when the test is false.
+  # Without that, the trailing `[[ ... ]] && printf` would propagate
+  # through the pipe and `pipefail` would abort the whole assignment.
   local operation_summary=""
   operation_summary="$(
     {
       printf '%s' "$launch_cmd_ops" | sed 's/\t/=/' | sed 's/^/launch:/'
       printf '%s' "$channels_ops" | sed 's/\t/=/' | sed 's/^/chan:/'
+      # Issue #580 Track 2: typed-flag completion entries. Emitted in a
+      # stable key=value shape so audit consumers can parse the summary
+      # the same way they parse the launch:/chan: entries above.
+      { [[ $desc_set_present -eq 1 ]]     && printf 'desc=set\n'; }                           || true
+      { [[ $engine_set_present -eq 1 ]]   && printf 'engine=%s\n'   "$engine_set_value"; }    || true
+      { [[ $workdir_set_present -eq 1 ]]  && printf 'workdir=set\n'; }                        || true
+      { [[ $loop_set_present -eq 1 ]]     && printf 'loop=%s\n'     "$loop_set_value"; }      || true
+      { [[ $continue_set_present -eq 1 ]] && printf 'continue=%s\n' "$continue_set_value"; }  || true
+      { [[ $class_set_present -eq 1 ]]    && printf 'class=%s\n'    "$class_set_value"; }     || true
     } | tr '\n' ',' | sed 's/,$//'
   )"
 
@@ -2436,6 +2638,18 @@ run_update() {
   before_launch_cmd="$(bridge_agent_launch_cmd_raw "$agent")"
   local before_channels
   before_channels="$(bridge_agent_channels_csv "$agent")"
+
+  # Issue #580 Track 2: snapshot the typed-flag fields BEFORE the deny
+  # check so audit rows on a refused mutation still carry the
+  # (unchanged) before-values. The writer reads these as the
+  # pass-through values for any field the operator did not touch.
+  local before_desc before_engine before_workdir before_loop before_continue before_class
+  before_desc="$(bridge_agent_desc "$agent")"
+  before_engine="$(bridge_agent_engine "$agent")"
+  before_workdir="$(bridge_agent_workdir "$agent")"
+  before_loop="$(bridge_agent_loop "$agent")"
+  before_continue="$(bridge_agent_continue "$agent")"
+  before_class="$(bridge_agent_class "$agent")"
 
   if [[ -n "$deny_reason" ]]; then
     bridge_agent_update_emit_audit \
@@ -2488,31 +2702,56 @@ print(json.dumps(left + right, ensure_ascii=False))
 PY
   )"
 
+  # Issue #580 Track 2: resolve the post-update value for each typed
+  # field. Each `*_set_present` flag is set iff the operator passed the
+  # corresponding flag; otherwise we round-trip the before-value through
+  # the writer untouched (this is the same model the launch_cmd /
+  # channels paths above use — `before_*` is the default).
+  local new_desc new_engine new_workdir new_loop new_continue new_class
+  new_desc="$before_desc"
+  new_engine="$before_engine"
+  new_workdir="$before_workdir"
+  new_loop="$before_loop"
+  new_continue="$before_continue"
+  new_class="$before_class"
+  [[ $desc_set_present -eq 1 ]]     && new_desc="$desc_set_value"
+  [[ $engine_set_present -eq 1 ]]   && new_engine="$engine_set_value"
+  [[ $workdir_set_present -eq 1 ]]  && new_workdir="$workdir_set_value"
+  [[ $loop_set_present -eq 1 ]]     && new_loop="$loop_set_value"
+  [[ $continue_set_present -eq 1 ]] && new_continue="$continue_set_value"
+  [[ $class_set_present -eq 1 ]]    && new_class="$class_set_value"
+
   local changed=0
-  if [[ "$new_launch_cmd" != "$before_launch_cmd" || "$new_channels" != "$before_channels" ]]; then
+  if [[ "$new_launch_cmd" != "$before_launch_cmd" \
+     || "$new_channels"   != "$before_channels"   \
+     || "$new_desc"       != "$before_desc"       \
+     || "$new_engine"     != "$before_engine"     \
+     || "$new_workdir"    != "$before_workdir"    \
+     || "$new_loop"       != "$before_loop"       \
+     || "$new_continue"   != "$before_continue"   \
+     || "$new_class"      != "$before_class" ]]; then
     changed=1
   fi
 
   local after_sha=""
   if [[ $changed -eq 1 && $dry_run -eq 0 ]]; then
-    # Reuse the existing managed-role block writer (lines ~571-710).
-    # Pass every non-mutated field through unchanged so the rewritten
-    # block matches `agent create`'s emission shape byte-for-byte except
-    # for the LAUNCH_CMD / CHANNELS lines we are touching.
-    local description engine session workdir profile_home discord_channel
-    local notify_kind notify_target notify_account loop_mode continue_mode
+    # Reuse the existing managed-role block writer. Pass every
+    # non-mutated field through unchanged so the rewritten block matches
+    # `agent create`'s emission shape byte-for-byte except for the
+    # fields we are explicitly touching. The new typed flags
+    # (--desc / --engine / --workdir / --loop / --continue / --class)
+    # feed the corresponding writer positional via the new_* locals
+    # computed above; for fields the operator did not touch the
+    # before-value round-trips through.
+    local session profile_home discord_channel
+    local notify_kind notify_target notify_account
     local idle_timeout always_on isolation_mode os_user
-    description="$(bridge_agent_desc "$agent")"
-    engine="$(bridge_agent_engine "$agent")"
     session="$(bridge_agent_session "$agent")"
-    workdir="$(bridge_agent_workdir "$agent")"
     profile_home="$(bridge_agent_profile_home "$agent")"
     discord_channel="$(bridge_agent_discord_channel_id "$agent")"
     notify_kind="$(bridge_agent_notify_kind "$agent")"
     notify_target="$(bridge_agent_notify_target "$agent")"
     notify_account="$(bridge_agent_notify_account "$agent")"
-    loop_mode="$(bridge_agent_loop "$agent")"
-    continue_mode="$(bridge_agent_continue "$agent")"
     idle_timeout="$(bridge_agent_idle_timeout "$agent")"
     isolation_mode="$(bridge_agent_isolation_mode "$agent")"
     os_user="$(bridge_agent_os_user "$agent")"
@@ -2521,12 +2760,21 @@ PY
     else
       always_on=0
     fi
+    # Force-write LOOP="0" only when the operator explicitly passed
+    # `--loop off` (mutating an existing agent's loop policy). For any
+    # other call shape we pass empty so the writer keeps its legacy
+    # "no-line on default" behavior — preserves byte-for-byte parity
+    # with `agent create`'s emission for create/round-trip cases.
+    local loop_explicit_off=""
+    if [[ $loop_set_present -eq 1 && "$new_loop" == "0" ]]; then
+      loop_explicit_off="1"
+    fi
     bridge_write_role_block \
       "$agent" \
-      "$description" \
-      "$engine" \
+      "$new_desc" \
+      "$new_engine" \
       "$session" \
-      "$workdir" \
+      "$new_workdir" \
       "$profile_home" \
       "$new_launch_cmd" \
       "$new_channels" \
@@ -2534,12 +2782,14 @@ PY
       "$notify_kind" \
       "$notify_target" \
       "$notify_account" \
-      "$loop_mode" \
-      "$continue_mode" \
+      "$new_loop" \
+      "$new_continue" \
       "$always_on" \
       "$isolation_mode" \
       "$os_user" \
-      "1" >/dev/null
+      "1" \
+      "$new_class" \
+      "$loop_explicit_off" >/dev/null
     after_sha="$(bridge_agent_update_file_sha256 "$roster_path")"
   else
     after_sha="$before_sha"
@@ -2588,6 +2838,33 @@ PY
   printf 'after_launch_cmd: %s\n' "$new_launch_cmd"
   printf 'before_channels: %s\n' "$before_channels"
   printf 'after_channels: %s\n' "$new_channels"
+  # Issue #580 Track 2: only surface typed-flag deltas the operator
+  # actually requested. Round-tripped fields stay quiet so the output
+  # remains scannable.
+  if [[ $desc_set_present -eq 1 ]]; then
+    printf 'before_desc: %s\n' "$before_desc"
+    printf 'after_desc: %s\n' "$new_desc"
+  fi
+  if [[ $engine_set_present -eq 1 ]]; then
+    printf 'before_engine: %s\n' "$before_engine"
+    printf 'after_engine: %s\n' "$new_engine"
+  fi
+  if [[ $workdir_set_present -eq 1 ]]; then
+    printf 'before_workdir: %s\n' "$before_workdir"
+    printf 'after_workdir: %s\n' "$new_workdir"
+  fi
+  if [[ $loop_set_present -eq 1 ]]; then
+    printf 'before_loop: %s\n' "$before_loop"
+    printf 'after_loop: %s\n' "$new_loop"
+  fi
+  if [[ $continue_set_present -eq 1 ]]; then
+    printf 'before_continue: %s\n' "$before_continue"
+    printf 'after_continue: %s\n' "$new_continue"
+  fi
+  if [[ $class_set_present -eq 1 ]]; then
+    printf 'before_class: %s\n' "$before_class"
+    printf 'after_class: %s\n' "$new_class"
+  fi
   printf 'before_sha: %s\n' "$before_sha"
   printf 'after_sha: %s\n' "$after_sha"
 }
@@ -3806,6 +4083,12 @@ case "$subcommand" in
   retire)
     run_retire "$@"
     ;;
+  doctor|check)
+    # Issue #580 Track 2: CRUD self-check. `check` is an alias because
+    # an earlier brief used both names; either invocation routes to the
+    # same helper in lib/bridge-agent-doctor.sh.
+    bridge_agent_doctor_run "$@"
+    ;;
   list)
     run_list "$@"
     ;;
@@ -3854,7 +4137,7 @@ case "$subcommand" in
   *)
     # Issue #163 Phase 2: surface an intent-recovery hint before dying.
     _hint="$(bridge_suggest_subcommand "$subcommand" \
-      "create update delete retire list registry show reclassify rerender-settings start safe-mode stop restart ack-crash forget-session attach compact handoff")"
+      "create update delete retire doctor check list registry show reclassify rerender-settings start safe-mode stop restart ack-crash forget-session attach compact handoff")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 agent 명령입니다: $subcommand"
     ;;

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -349,3 +349,8 @@ bridge_source_module "bridge-wave.sh"
 # Sourced last because it consumes helpers from bridge-agents.sh and
 # bridge-core.sh (`bridge_admin_agent_id`, `bridge_require_python`).
 bridge_source_module "bridge-agent-update.sh"
+# bridge-agent-doctor.sh is the CRUD self-check for the typed-write
+# surface (issue #580 Track 2). Sourced after bridge-agent-update.sh
+# because the doctor exercises every documented admin-CRUD verb and
+# relies on the same bridge_die / bridge_require_python helpers.
+bridge_source_module "bridge-agent-doctor.sh"

--- a/lib/bridge-agent-doctor.sh
+++ b/lib/bridge-agent-doctor.sh
@@ -48,6 +48,19 @@
 # cleanup itself fails, the trap forces the process to exit non-zero
 # so the operator does not get a green doctor with a residual roster
 # block / home directory.
+#
+# Codex r2 (PR #615) — D5 face 2: the cleanup `delete --purge-home`
+# resolves the home target via `bridge_agent_default_home`, which falls
+# back to `$BRIDGE_AGENT_HOME_ROOT/$agent`. In a normal Codex/agent
+# shell, `BRIDGE_AGENT_HOME_ROOT` is already exported to the live
+# install root; when only `BRIDGE_HOME` is overridden for an isolated
+# test, the cleanup landed in the live root (no-op) and the fixture
+# directory under the isolated `BRIDGE_HOME/agents` leaked. The doctor
+# pins the create target to `$BRIDGE_HOME/agents/<fixture>` (see step 1
+# below), so the cleanup must land in the same place by construction.
+# Run the child `bridge-agent.sh` with `BRIDGE_AGENT_HOME_ROOT` pinned
+# to `$BRIDGE_HOME/agents` so any inherited value is overridden for
+# this child only — the parent shell's env is unchanged.
 # shellcheck disable=SC2329
 _bridge_agent_doctor_cleanup() {
   [[ "${BRIDGE_AGENT_DOCTOR_CLEANED:-0}" == "1" ]] && return 0
@@ -58,6 +71,7 @@ _bridge_agent_doctor_cleanup() {
   local script_dir="${BRIDGE_AGENT_DOCTOR_SCRIPT_DIR:-}"
   local bash_bin="${BRIDGE_AGENT_DOCTOR_BASH_BIN:-bash}"
   local caller="${BRIDGE_AGENT_DOCTOR_CALLER:-}"
+  local fixture_home_root="${BRIDGE_AGENT_DOCTOR_HOME_ROOT:-}"
   [[ -n "$script_dir" ]] || return 0
   # The caller was validated (admin + trusted source) before fixture
   # creation, so it is guaranteed non-empty here. Pass --force because
@@ -67,13 +81,25 @@ _bridge_agent_doctor_cleanup() {
   local cleanup_args=(delete "$fixture" --orphan-tasks --purge-home --force)
   [[ -n "$caller" ]] && cleanup_args+=(--from "$caller")
   local cleanup_out cleanup_rc=0
-  cleanup_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${cleanup_args[@]}" 2>&1)" || cleanup_rc=$?
+  if [[ -n "$fixture_home_root" ]]; then
+    cleanup_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" "${cleanup_args[@]}" 2>&1)" || cleanup_rc=$?
+  else
+    cleanup_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${cleanup_args[@]}" 2>&1)" || cleanup_rc=$?
+  fi
   if [[ $cleanup_rc -ne 0 ]]; then
     # If the explicit step-7 delete already removed the fixture, the
     # follow-up retry will fail with "agent not found" — that is not a
     # leak. Recognise the not-found shape and exit clean.
     case "$cleanup_out" in
       *"not found"*|*"존재하지"*|*"없습니다"*)
+        # Roster row was gone, but the home directory may still be
+        # present if the prior delete used a mismatched HOME_ROOT. Do
+        # a best-effort rm of the pinned fixture path before returning.
+        # SC2115 is suppressed by the `:?` guards: both vars are
+        # validated non-empty above; expansion to `/` is impossible.
+        if [[ -n "$fixture_home_root" && -d "$fixture_home_root/$fixture" ]]; then
+          rm -rf -- "${fixture_home_root:?}/${fixture:?}" || true
+        fi
         return 0
         ;;
     esac
@@ -81,6 +107,15 @@ _bridge_agent_doctor_cleanup() {
       "$fixture" "$cleanup_rc" "$(printf '%s' "$cleanup_out" | head -c 240)" >&2
     # Force the process to exit non-zero so a leaked fixture is
     # surfaced as a doctor failure, not a swallowed warning.
+    exit 1
+  fi
+  # Final safety net: even when the child returned 0, double-check the
+  # pinned fixture home was actually removed. This catches resolver
+  # drift (e.g. a future refactor of bridge_agent_default_home that
+  # silently changes layout) before the operator sees a leaked dir.
+  if [[ -n "$fixture_home_root" && -d "$fixture_home_root/$fixture" ]]; then
+    printf '[doctor] fail: cleanup leaked fixture home — path=%s\n' \
+      "$fixture_home_root/$fixture" >&2
     exit 1
   fi
 }
@@ -167,6 +202,19 @@ EOF
   script_dir="${SCRIPT_DIR:-$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)}"
   bash_bin="${BRIDGE_BASH_BIN:-bash}"
 
+  # Pin the fixture's home root to `$BRIDGE_HOME/agents` for every
+  # child `bridge-agent.sh` invocation the doctor makes. The doctor
+  # already pins the fixture's create target (`fixture_workdir`) to
+  # this same path; pinning it for the child env makes the cleanup
+  # target match the create target by construction. Without this,
+  # `bridge_agent_default_home` falls back to whatever
+  # `BRIDGE_AGENT_HOME_ROOT` the parent shell exported (typically the
+  # live install root, even when `BRIDGE_HOME` is overridden for an
+  # isolated test), and `delete --purge-home` rm's the wrong path,
+  # leaving the isolated fixture leaked. The override is scoped to
+  # each child invocation; the parent shell's env is unchanged.
+  local fixture_home_root="${BRIDGE_HOME:-$HOME/.agent-bridge}/agents"
+
   # Cleanup trap: best-effort delete + purge-home so the fixture is gone
   # whether the doctor passed or failed mid-stream. Skipped when
   # --keep-fixture is set.
@@ -183,6 +231,7 @@ EOF
   BRIDGE_AGENT_DOCTOR_CALLER="$doctor_caller"
   BRIDGE_AGENT_DOCTOR_SCRIPT_DIR="$script_dir"
   BRIDGE_AGENT_DOCTOR_BASH_BIN="$bash_bin"
+  BRIDGE_AGENT_DOCTOR_HOME_ROOT="$fixture_home_root"
   trap _bridge_agent_doctor_cleanup EXIT INT TERM
 
   # Each check appends "STATUS\tNAME\tDETAIL" to a TSV stream;
@@ -208,14 +257,12 @@ EOF
   # ---- 1. create -------------------------------------------------------
   # Issue #185: when BRIDGE_HOME is ephemeral, the agent workdir must
   # also live under that root or the auto-memory seeder refuses. The
-  # doctor must therefore pin the fixture workdir to
-  # `$BRIDGE_HOME/agents/<fixture>` directly — NOT to
-  # `$BRIDGE_AGENT_HOME_ROOT` because that env var may have been set by
-  # an outer agent's launcher to a live path even after BRIDGE_HOME was
-  # rerouted to a tmp root for an isolated test. Deriving from
-  # BRIDGE_HOME is the canonical mapping bridge-lib.sh uses when no
-  # explicit override is in play.
-  local fixture_home_root="${BRIDGE_HOME:-$HOME/.agent-bridge}/agents"
+  # doctor pins the fixture workdir to `$BRIDGE_HOME/agents/<fixture>`
+  # directly — NOT to `$BRIDGE_AGENT_HOME_ROOT` because that env var
+  # may have been set by an outer agent's launcher to a live path even
+  # after BRIDGE_HOME was rerouted to a tmp root for an isolated test.
+  # The same `fixture_home_root` is also pinned in the child env (see
+  # the BRIDGE_AGENT_HOME_ROOT override below) so cleanup lands here.
   local fixture_workdir="$fixture_home_root/$fixture"
   local create_args=(create "$fixture"
     --engine claude
@@ -226,7 +273,13 @@ EOF
   # non-zero subshell exit, so each child invocation in this doctor is
   # guarded with `|| true` and the rc is captured via `${PIPESTATUS[0]}`
   # (works for both pipelined and unpipelined runs).
-  create_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${create_args[@]}" 2>&1)" || create_rc=$?
+  #
+  # Every child `bridge-agent.sh` invocation runs with
+  # `BRIDGE_AGENT_HOME_ROOT="$fixture_home_root"` pinned in its env so
+  # `bridge_agent_default_home` (used by `delete --purge-home`) lands
+  # in the same place as the create target, regardless of any value
+  # the parent shell may have inherited from a live install.
+  create_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" "${create_args[@]}" 2>&1)" || create_rc=$?
   if [[ $create_rc -eq 0 ]]; then
     _doctor_record pass "create" "fixture=$fixture"
   else
@@ -246,7 +299,7 @@ EOF
     --class user
     --from "$doctor_caller")
   local update_out update_rc=0
-  update_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${update_args[@]}" 2>&1)" || update_rc=$?
+  update_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" "${update_args[@]}" 2>&1)" || update_rc=$?
   if [[ $update_rc -eq 0 ]]; then
     _doctor_record pass "update" "desc/loop/continue/class persisted"
   else
@@ -260,7 +313,7 @@ EOF
   # to the `show` step (registry only exposes id/class/source/etc., not
   # the BRIDGE_AGENT_DESC payload).
   local reg_out reg_rc=0
-  reg_out="$("$bash_bin" "$script_dir/bridge-agent.sh" registry --json 2>&1)" || reg_rc=$?
+  reg_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" registry --json 2>&1)" || reg_rc=$?
   if [[ $reg_rc -ne 0 ]]; then
     _doctor_record fail "registry" "rc=$reg_rc out=$(printf '%s' "$reg_out" | head -c 240)"
   else
@@ -304,7 +357,7 @@ PY
   # only enumerator that surfaces the BRIDGE_AGENT_DESC payload, so
   # this is where we assert the typed-flag mutation round-tripped.
   local show_out show_rc=0
-  show_out="$("$bash_bin" "$script_dir/bridge-agent.sh" show "$fixture" --json 2>&1)" || show_rc=$?
+  show_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" show "$fixture" --json 2>&1)" || show_rc=$?
   if [[ $show_rc -ne 0 ]]; then
     _doctor_record fail "show" "rc=$show_rc out=$(printf '%s' "$show_out" | head -c 240)"
   elif [[ "$update_rc" -eq 0 ]]; then
@@ -351,7 +404,7 @@ PY
   # candidate — that's the correct success shape. Report n/a so the
   # operator sees the path was exercised but had nothing to do.
   local recl_out recl_rc=0
-  recl_out="$("$bash_bin" "$script_dir/bridge-agent.sh" reclassify --agent "$fixture" --apply 2>&1)" || recl_rc=$?
+  recl_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" reclassify --agent "$fixture" --apply 2>&1)" || recl_rc=$?
   if [[ $recl_rc -eq 0 ]]; then
     case "$recl_out" in
       *"no candidates"*)
@@ -369,7 +422,7 @@ PY
   # Static-roster agents are out-of-scope for retire (#607); the deny
   # is the correct shape. Report n/a.
   local ret_out ret_rc=0
-  ret_out="$("$bash_bin" "$script_dir/bridge-agent.sh" retire "$fixture" --dry-run 2>&1)" || ret_rc=$?
+  ret_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" retire "$fixture" --dry-run 2>&1)" || ret_rc=$?
   case "$ret_out" in
     *"is static-roster"*|*"static-roster"*)
       _doctor_record n/a "retire" "fixture is static-roster (delete owns this path — expected)"
@@ -394,10 +447,21 @@ PY
   # admin (validated upfront), so we always forward --from.
   local del_args=(delete "$fixture" --orphan-tasks --purge-home --force --from "$doctor_caller")
   local del_out del_rc=0
-  del_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${del_args[@]}" 2>&1)" || del_rc=$?
+  del_out="$(BRIDGE_AGENT_HOME_ROOT="$fixture_home_root" "$bash_bin" "$script_dir/bridge-agent.sh" "${del_args[@]}" 2>&1)" || del_rc=$?
   if [[ $del_rc -eq 0 ]]; then
-    _doctor_record pass "delete" "fixture removed + home purged"
-    BRIDGE_AGENT_DOCTOR_CLEANED=1   # trap is a no-op now
+    # Self-policing post-condition (codex r2): a leaked fixture home is
+    # itself a doctor failure. Even if the child returned 0, double-check
+    # the pinned fixture path was actually removed. This catches resolver
+    # drift (e.g. a future refactor of bridge_agent_default_home that
+    # silently changes layout, or an inherited BRIDGE_AGENT_HOME_ROOT
+    # that defeated our pin) before the operator sees a green doctor
+    # with residue under `$BRIDGE_HOME/agents/`.
+    if [[ -d "$fixture_workdir" ]]; then
+      _doctor_record fail "delete" "leaked fixture home: $fixture_workdir still present after --purge-home"
+    else
+      _doctor_record pass "delete" "fixture removed + home purged"
+      BRIDGE_AGENT_DOCTOR_CLEANED=1   # trap is a no-op now
+    fi
   else
     _doctor_record fail "delete" "rc=$del_rc out=$(printf '%s' "$del_out" | head -c 240)"
   fi

--- a/lib/bridge-agent-doctor.sh
+++ b/lib/bridge-agent-doctor.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# bridge-agent-doctor.sh — admin CRUD self-check (issue #580 Track 2).
+#
+# Exercises every documented `agent-bridge agent <verb>` path the admin
+# uses against an ephemeral test-fixture agent so an operator can verify
+# the typed-write surface end-to-end without trusting "it worked once."
+#
+# What it covers:
+#   1. create     — creates a smoke-* fixture (requires --test-fixture
+#                   per #598 Track 4; we always pass it from here).
+#   2. update     — typed-flag completion path (#580 Track 2):
+#                   --desc, --engine no-op (round-trip), --channels-set
+#                   "" to clear, --loop on, --continue on, --class user.
+#   3. registry   — read-back via `agent registry --json`, asserts the
+#                   fixture row exists and the post-update fields match.
+#   4. show       — read-back via `agent show <fixture> --json`.
+#   5. reclassify — runs `agent reclassify --agent <fixture> --apply`;
+#                   reports n/a (fixture is created as static, so the
+#                   reclassifier finds no candidate — that is the
+#                   correct success shape, not a failure).
+#   6. retire     — runs `agent retire <fixture>`; reports n/a (the
+#                   fixture is static-roster, so retire correctly
+#                   refuses; #607 retire is for dynamic/orphan only).
+#   7. delete     — `agent delete <fixture>` with --orphan-tasks +
+#                   --purge-home; this is the success-path final step.
+#
+# Output: one line per check, prefixed `[doctor] pass:` /
+# `[doctor] fail:` / `[doctor] n/a:`. Exits non-zero if any required
+# check failed (n/a is not failure). With --json, emits a single JSON
+# envelope summarizing all checks.
+#
+# Cleanup: traps EXIT and removes the fixture even on failure. Honors
+# --keep-fixture so an operator can inspect the residue post-mortem.
+
+# shellcheck shell=bash
+
+# Trap target for the doctor's EXIT/INT/TERM cleanup. Defined at module
+# scope (not inside bridge_agent_doctor_run) so the trap can fire after
+# the function frame has been popped; locals would be unbound by then
+# and `set -u` would fault. State lives in the BRIDGE_AGENT_DOCTOR_*
+# globals seeded by bridge_agent_doctor_run.
+# shellcheck disable=SC2329
+_bridge_agent_doctor_cleanup() {
+  [[ "${BRIDGE_AGENT_DOCTOR_CLEANED:-0}" == "1" ]] && return 0
+  BRIDGE_AGENT_DOCTOR_CLEANED=1
+  [[ "${BRIDGE_AGENT_DOCTOR_KEEP:-0}" == "1" ]] && return 0
+  local fixture="${BRIDGE_AGENT_DOCTOR_FIXTURE:-}"
+  [[ -n "$fixture" ]] || return 0
+  local script_dir="${BRIDGE_AGENT_DOCTOR_SCRIPT_DIR:-}"
+  local bash_bin="${BRIDGE_AGENT_DOCTOR_BASH_BIN:-bash}"
+  local caller="${BRIDGE_AGENT_DOCTOR_CALLER:-}"
+  [[ -n "$script_dir" ]] || return 0
+  # Best-effort: ignore everything. If create never succeeded, delete
+  # refuses harmlessly; otherwise --orphan-tasks + --purge-home wipes
+  # the fixture's roster row and home dir together.
+  local cleanup_args=(delete "$fixture" --orphan-tasks --purge-home)
+  [[ -n "$caller" ]] && cleanup_args+=(--from "$caller")
+  "$bash_bin" "$script_dir/bridge-agent.sh" "${cleanup_args[@]}" \
+    >/dev/null 2>&1 || true
+}
+
+# bridge_agent_doctor_run — entry point invoked by run_doctor in
+# bridge-agent.sh. Argv is the remainder after `agent doctor`.
+bridge_agent_doctor_run() {
+  local from_agent=""
+  local keep_fixture=0
+  local json_mode=0
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --from)
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        from_agent="$2"
+        shift 2
+        ;;
+      --keep-fixture)
+        keep_fixture=1
+        shift
+        ;;
+      --json)
+        json_mode=1
+        shift
+        ;;
+      -h|--help)
+        cat <<'EOF'
+Usage: agent-bridge agent doctor [--from <admin>] [--keep-fixture] [--json]
+
+Run an admin CRUD self-check against an ephemeral test-fixture agent.
+Each step prints `[doctor] pass:` / `[doctor] fail:` / `[doctor] n/a:`.
+The fixture is removed on exit (even on failure) unless --keep-fixture
+is passed. --from <admin> is forwarded to the audited mutations
+(create / update / delete) — required when BRIDGE_AGENT_ID is unset.
+EOF
+        return 0
+        ;;
+      *)
+        bridge_die "지원하지 않는 agent doctor 옵션입니다: $1"
+        ;;
+    esac
+  done
+
+  # Resolve a caller-id to forward into update/delete. The doctor itself
+  # does not enforce admin identity (it is operator-facing, not
+  # agent-facing) — but the underlying update/delete writers do, so we
+  # propagate whichever id the operator provided.
+  local doctor_caller="${from_agent:-${BRIDGE_AGENT_ID:-}}"
+
+  # Pick a unique fixture name. The `smoke-` prefix matches
+  # BRIDGE_TEST_ARTIFACT_PREFIXES so create requires --test-fixture
+  # (which we pass) and the orphan-agent-dir detector (#598 Track 2)
+  # treats residue as reapable test fixtures.
+  local stamp pid rand fixture
+  stamp="$(date -u +%Y%m%d%H%M%S 2>/dev/null || date +%s)"
+  pid="$$"
+  if command -v od >/dev/null 2>&1; then
+    rand="$(od -An -N2 -tx1 /dev/urandom 2>/dev/null | tr -d ' \n' || printf '%s' "$RANDOM")"
+  else
+    rand="$RANDOM"
+  fi
+  fixture="smoke-doctor-${stamp}-${pid}-${rand}"
+
+  local script_dir bash_bin
+  script_dir="${SCRIPT_DIR:-$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)}"
+  bash_bin="${BRIDGE_BASH_BIN:-bash}"
+
+  # Cleanup trap: best-effort delete + purge-home so the fixture is gone
+  # whether the doctor passed or failed mid-stream. Skipped when
+  # --keep-fixture is set.
+  #
+  # The trap-target state has to live in script-global vars (not
+  # `local`) because EXIT traps fire AFTER the function frame has been
+  # popped, and `set -u` would fault on any reference to a then-unbound
+  # local. We use BRIDGE_AGENT_DOCTOR_* names so collisions with caller
+  # scope are improbable; the caller (run_doctor in bridge-agent.sh)
+  # invokes us once per process exec.
+  BRIDGE_AGENT_DOCTOR_CLEANED=0
+  BRIDGE_AGENT_DOCTOR_KEEP="$keep_fixture"
+  BRIDGE_AGENT_DOCTOR_FIXTURE="$fixture"
+  BRIDGE_AGENT_DOCTOR_CALLER="$doctor_caller"
+  BRIDGE_AGENT_DOCTOR_SCRIPT_DIR="$script_dir"
+  BRIDGE_AGENT_DOCTOR_BASH_BIN="$bash_bin"
+  trap _bridge_agent_doctor_cleanup EXIT INT TERM
+
+  # Each check appends "STATUS\tNAME\tDETAIL" to a TSV stream;
+  # bridge_agent_doctor_emit summarizes at the end.
+  local results=""
+  local fail_count=0
+  local pass_count=0
+  local na_count=0
+
+  _doctor_record() {
+    local status="$1" name="$2" detail="$3"
+    results+="${status}"$'\t'"${name}"$'\t'"${detail}"$'\n'
+    case "$status" in
+      pass) pass_count=$((pass_count + 1)) ;;
+      fail) fail_count=$((fail_count + 1)) ;;
+      n/a)  na_count=$((na_count + 1)) ;;
+    esac
+    if [[ $json_mode -ne 1 ]]; then
+      printf '[doctor] %s: %s — %s\n' "$status" "$name" "$detail"
+    fi
+  }
+
+  # ---- 1. create -------------------------------------------------------
+  # Issue #185: when BRIDGE_HOME is ephemeral, the agent workdir must
+  # also live under that root or the auto-memory seeder refuses. The
+  # doctor must therefore pin the fixture workdir to
+  # `$BRIDGE_HOME/agents/<fixture>` directly — NOT to
+  # `$BRIDGE_AGENT_HOME_ROOT` because that env var may have been set by
+  # an outer agent's launcher to a live path even after BRIDGE_HOME was
+  # rerouted to a tmp root for an isolated test. Deriving from
+  # BRIDGE_HOME is the canonical mapping bridge-lib.sh uses when no
+  # explicit override is in play.
+  local fixture_home_root="${BRIDGE_HOME:-$HOME/.agent-bridge}/agents"
+  local fixture_workdir="$fixture_home_root/$fixture"
+  local create_args=(create "$fixture"
+    --engine claude
+    --workdir "$fixture_workdir"
+    --test-fixture)
+  local create_out create_rc=0
+  # `set -e` in the parent script would abort the function on any
+  # non-zero subshell exit, so each child invocation in this doctor is
+  # guarded with `|| true` and the rc is captured via `${PIPESTATUS[0]}`
+  # (works for both pipelined and unpipelined runs).
+  create_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${create_args[@]}" 2>&1)" || create_rc=$?
+  if [[ $create_rc -eq 0 ]]; then
+    _doctor_record pass "create" "fixture=$fixture"
+  else
+    _doctor_record fail "create" "rc=$create_rc out=$(printf '%s' "$create_out" | head -c 240)"
+    bridge_agent_doctor_emit "$results" "$pass_count" "$fail_count" "$na_count" "$json_mode" "$fixture"
+    return 1
+  fi
+
+  # ---- 2. update -------------------------------------------------------
+  # The update path is admin-gated, so the caller must be the admin
+  # agent. If we have no admin caller, mark the entire update step n/a
+  # rather than fail — the issue #580 brief explicitly notes that a
+  # non-admin invocation of the doctor is still useful (it exercises
+  # the create / read / delete paths). When --from is provided, we
+  # forward it to the writer.
+  local update_args=(update "$fixture"
+    --desc "doctor self-check fixture"
+    --loop on
+    --continue on
+    --class user)
+  [[ -n "$doctor_caller" ]] && update_args+=(--from "$doctor_caller")
+  local update_out update_rc=0
+  update_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${update_args[@]}" 2>&1)" || update_rc=$?
+  if [[ $update_rc -eq 0 ]]; then
+    _doctor_record pass "update" "desc/loop/continue/class persisted"
+  else
+    # Distinguish "no admin caller" from "real failure" by sniffing the
+    # deny reason. The deny message is a stable string from
+    # lib/bridge-agent-update.sh.
+    case "$update_out" in
+      *"is not the admin agent"*|*"caller_agent unspecified"*|*"is not allowed to mutate system config"*)
+        _doctor_record n/a "update" "skipped: caller is not the admin agent (pass --from <admin>)"
+        ;;
+      *)
+        _doctor_record fail "update" "rc=$update_rc out=$(printf '%s' "$update_out" | head -c 240)"
+        ;;
+    esac
+  fi
+
+  # ---- 3. registry --json (read-back) ---------------------------------
+  # The registry endpoint is a read-only enumeration that the admin
+  # uses to confirm "is the fixture visible in the source-of-truth view"
+  # — we assert presence here and defer post-update field assertions
+  # to the `show` step (registry only exposes id/class/source/etc., not
+  # the BRIDGE_AGENT_DESC payload).
+  local reg_out reg_rc=0
+  reg_out="$("$bash_bin" "$script_dir/bridge-agent.sh" registry --json 2>&1)" || reg_rc=$?
+  if [[ $reg_rc -ne 0 ]]; then
+    _doctor_record fail "registry" "rc=$reg_rc out=$(printf '%s' "$reg_out" | head -c 240)"
+  else
+    local reg_check_rc=0
+    local reg_check
+    reg_check="$(FIXTURE="$fixture" REG_JSON="$reg_out" python3 - <<'PY'
+import json, os, sys
+fixture = os.environ["FIXTURE"]
+text = os.environ.get("REG_JSON", "")
+try:
+    data = json.loads(text)
+except Exception as exc:
+    print(f"FAIL: registry --json not parseable: {exc}")
+    sys.exit(2)
+agents = data.get("agents") if isinstance(data, dict) else None
+if agents is None and isinstance(data, list):
+    agents = data
+if not isinstance(agents, list):
+    print("FAIL: registry --json shape unexpected (no agents list)")
+    sys.exit(2)
+match = None
+for row in agents:
+    if isinstance(row, dict) and row.get("id") == fixture:
+        match = row
+        break
+if match is None:
+    print(f"FAIL: fixture '{fixture}' not found in registry")
+    sys.exit(2)
+print("OK")
+PY
+)" || reg_check_rc=$?
+    if [[ $reg_check_rc -eq 0 && "$reg_check" == OK* ]]; then
+      _doctor_record pass "registry" "fixture row visible"
+    else
+      _doctor_record fail "registry" "$reg_check"
+    fi
+  fi
+
+  # ---- 4. show --------------------------------------------------------
+  # The post-update read-back lives here: `agent show --json` is the
+  # only enumerator that surfaces the BRIDGE_AGENT_DESC payload, so
+  # this is where we assert the typed-flag mutation round-tripped.
+  local show_out show_rc=0
+  show_out="$("$bash_bin" "$script_dir/bridge-agent.sh" show "$fixture" --json 2>&1)" || show_rc=$?
+  if [[ $show_rc -ne 0 ]]; then
+    _doctor_record fail "show" "rc=$show_rc out=$(printf '%s' "$show_out" | head -c 240)"
+  elif [[ "$update_rc" -eq 0 ]]; then
+    local show_check_rc=0
+    local show_check
+    show_check="$(SHOW_JSON="$show_out" python3 - <<'PY'
+import json, os, sys
+text = os.environ.get("SHOW_JSON", "")
+try:
+    data = json.loads(text)
+except Exception as exc:
+    print(f"FAIL: show --json not parseable: {exc}")
+    sys.exit(2)
+# `agent show --json` returns the row at the top level with `agent`
+# being the id string (not a nested record). The desc field has
+# historically been emitted as `description` or `desc`. Also tolerate
+# the older shape where the row was nested under {"agent": {...}}.
+if isinstance(data, dict) and isinstance(data.get("agent"), dict):
+    row = data["agent"]
+elif isinstance(data, dict):
+    row = data
+else:
+    print(f"FAIL: show row shape unexpected: {type(data).__name__}")
+    sys.exit(2)
+desc = row.get("description") or row.get("desc") or ""
+if "doctor self-check" not in desc:
+    print(f"FAIL: post-update description not reflected: {desc!r}")
+    sys.exit(2)
+print("OK")
+PY
+)" || show_check_rc=$?
+    if [[ $show_check_rc -eq 0 && "$show_check" == OK* ]]; then
+      _doctor_record pass "show" "post-update description reflected"
+    else
+      _doctor_record fail "show" "$show_check"
+    fi
+  else
+    _doctor_record pass "show" "json envelope returned (update was n/a — no value-check)"
+  fi
+
+  # ---- 5. reclassify --------------------------------------------------
+  # The fixture was created as static-source (every `agent create`
+  # writes BRIDGE_AGENT_SOURCE="static"), so reclassify finds no
+  # candidate — that's the correct success shape. Report n/a so the
+  # operator sees the path was exercised but had nothing to do.
+  local recl_out recl_rc=0
+  recl_out="$("$bash_bin" "$script_dir/bridge-agent.sh" reclassify --agent "$fixture" --apply 2>&1)" || recl_rc=$?
+  if [[ $recl_rc -eq 0 ]]; then
+    case "$recl_out" in
+      *"no candidates"*)
+        _doctor_record n/a "reclassify" "no candidates (fixture is already static — expected)"
+        ;;
+      *)
+        _doctor_record pass "reclassify" "ran (output: $(printf '%s' "$recl_out" | tr '\n' ' ' | head -c 180))"
+        ;;
+    esac
+  else
+    _doctor_record fail "reclassify" "rc=$recl_rc out=$(printf '%s' "$recl_out" | head -c 240)"
+  fi
+
+  # ---- 6. retire ------------------------------------------------------
+  # Static-roster agents are out-of-scope for retire (#607); the deny
+  # is the correct shape. Report n/a.
+  local ret_out ret_rc=0
+  ret_out="$("$bash_bin" "$script_dir/bridge-agent.sh" retire "$fixture" --dry-run 2>&1)" || ret_rc=$?
+  case "$ret_out" in
+    *"is static-roster"*|*"static-roster"*)
+      _doctor_record n/a "retire" "fixture is static-roster (delete owns this path — expected)"
+      ;;
+    *)
+      if [[ $ret_rc -eq 0 ]]; then
+        _doctor_record pass "retire" "ran (unexpected — fixture should be static)"
+      else
+        _doctor_record fail "retire" "rc=$ret_rc out=$(printf '%s' "$ret_out" | head -c 240)"
+      fi
+      ;;
+  esac
+
+  # ---- 7. delete ------------------------------------------------------
+  # The success-path final step. We pass --orphan-tasks (the fixture
+  # cannot have real tasks, but the doctor must not refuse on a
+  # leftover row from a previous run) and --purge-home (we own the home
+  # we just scaffolded). The cleanup trap will be a no-op if this
+  # succeeds because of the cleaned=1 short-circuit.
+  local del_args=(delete "$fixture" --orphan-tasks --purge-home)
+  [[ -n "$doctor_caller" ]] && del_args+=(--from "$doctor_caller")
+  local del_out del_rc=0
+  del_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${del_args[@]}" 2>&1)" || del_rc=$?
+  if [[ $del_rc -eq 0 ]]; then
+    _doctor_record pass "delete" "fixture removed + home purged"
+    BRIDGE_AGENT_DOCTOR_CLEANED=1   # trap is a no-op now
+  else
+    case "$del_out" in
+      *"is not the admin agent"*|*"caller_agent unspecified"*|*"is not allowed to mutate system config"*)
+        _doctor_record n/a "delete" "skipped: caller is not the admin agent (pass --from <admin>)"
+        ;;
+      *)
+        _doctor_record fail "delete" "rc=$del_rc out=$(printf '%s' "$del_out" | head -c 240)"
+        ;;
+    esac
+  fi
+
+  bridge_agent_doctor_emit "$results" "$pass_count" "$fail_count" "$na_count" "$json_mode" "$fixture"
+  if [[ $fail_count -gt 0 ]]; then
+    return 1
+  fi
+  return 0
+}
+
+# bridge_agent_doctor_emit — final summary line + (optional) JSON
+# envelope. Text mode prints one line; the per-check `[doctor] STATUS:`
+# lines were already streamed inline by _doctor_record.
+bridge_agent_doctor_emit() {
+  local results="$1"
+  local pass_count="$2"
+  local fail_count="$3"
+  local na_count="$4"
+  local json_mode="$5"
+  local fixture="$6"
+
+  if [[ "$json_mode" == "1" ]]; then
+    bridge_require_python
+    PASS="$pass_count" FAIL="$fail_count" NA="$na_count" \
+    FIXTURE="$fixture" RESULTS="$results" python3 - <<'PY'
+import json
+import os
+
+results_raw = os.environ.get("RESULTS", "")
+checks = []
+for line in results_raw.splitlines():
+    if not line.strip():
+        continue
+    parts = line.split("\t", 2)
+    while len(parts) < 3:
+        parts.append("")
+    checks.append({"status": parts[0], "name": parts[1], "detail": parts[2]})
+
+payload = {
+    "fixture": os.environ.get("FIXTURE", ""),
+    "summary": {
+        "pass": int(os.environ.get("PASS", "0")),
+        "fail": int(os.environ.get("FAIL", "0")),
+        "n/a": int(os.environ.get("NA", "0")),
+    },
+    "checks": checks,
+}
+print(json.dumps(payload, ensure_ascii=False, indent=2))
+PY
+    return 0
+  fi
+
+  printf '[doctor] summary: pass=%d fail=%d n/a=%d fixture=%s\n' \
+    "$pass_count" "$fail_count" "$na_count" "$fixture"
+}

--- a/lib/bridge-agent-doctor.sh
+++ b/lib/bridge-agent-doctor.sh
@@ -39,6 +39,15 @@
 # the function frame has been popped; locals would be unbound by then
 # and `set -u` would fault. State lives in the BRIDGE_AGENT_DOCTOR_*
 # globals seeded by bridge_agent_doctor_run.
+#
+# Codex r1 (PR #615) — D5 robustness: a leaked fixture is itself a
+# doctor failure. Cleanup uses the admin caller already validated by
+# the run function (do not re-resolve from env in the trap; env may
+# have been mutated mid-run). Cleanup passes --force so an active
+# fixture session does not block delete (run_delete:2993-2998). If
+# cleanup itself fails, the trap forces the process to exit non-zero
+# so the operator does not get a green doctor with a residual roster
+# block / home directory.
 # shellcheck disable=SC2329
 _bridge_agent_doctor_cleanup() {
   [[ "${BRIDGE_AGENT_DOCTOR_CLEANED:-0}" == "1" ]] && return 0
@@ -50,13 +59,30 @@ _bridge_agent_doctor_cleanup() {
   local bash_bin="${BRIDGE_AGENT_DOCTOR_BASH_BIN:-bash}"
   local caller="${BRIDGE_AGENT_DOCTOR_CALLER:-}"
   [[ -n "$script_dir" ]] || return 0
-  # Best-effort: ignore everything. If create never succeeded, delete
-  # refuses harmlessly; otherwise --orphan-tasks + --purge-home wipes
-  # the fixture's roster row and home dir together.
-  local cleanup_args=(delete "$fixture" --orphan-tasks --purge-home)
+  # The caller was validated (admin + trusted source) before fixture
+  # creation, so it is guaranteed non-empty here. Pass --force because
+  # delete refuses active sessions without it (bridge-agent.sh:2993-2998)
+  # and the fixture session may still be alive if a mid-stream check
+  # aborted before step 7.
+  local cleanup_args=(delete "$fixture" --orphan-tasks --purge-home --force)
   [[ -n "$caller" ]] && cleanup_args+=(--from "$caller")
-  "$bash_bin" "$script_dir/bridge-agent.sh" "${cleanup_args[@]}" \
-    >/dev/null 2>&1 || true
+  local cleanup_out cleanup_rc=0
+  cleanup_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${cleanup_args[@]}" 2>&1)" || cleanup_rc=$?
+  if [[ $cleanup_rc -ne 0 ]]; then
+    # If the explicit step-7 delete already removed the fixture, the
+    # follow-up retry will fail with "agent not found" — that is not a
+    # leak. Recognise the not-found shape and exit clean.
+    case "$cleanup_out" in
+      *"not found"*|*"존재하지"*|*"없습니다"*)
+        return 0
+        ;;
+    esac
+    printf '[doctor] fail: cleanup — fixture=%s rc=%d out=%s\n' \
+      "$fixture" "$cleanup_rc" "$(printf '%s' "$cleanup_out" | head -c 240)" >&2
+    # Force the process to exit non-zero so a leaked fixture is
+    # surfaced as a doctor failure, not a swallowed warning.
+    exit 1
+  fi
 }
 
 # bridge_agent_doctor_run — entry point invoked by run_doctor in
@@ -88,8 +114,12 @@ Usage: agent-bridge agent doctor [--from <admin>] [--keep-fixture] [--json]
 Run an admin CRUD self-check against an ephemeral test-fixture agent.
 Each step prints `[doctor] pass:` / `[doctor] fail:` / `[doctor] n/a:`.
 The fixture is removed on exit (even on failure) unless --keep-fixture
-is passed. --from <admin> is forwarded to the audited mutations
-(create / update / delete) — required when BRIDGE_AGENT_ID is unset.
+is passed.
+
+doctor is admin-only by construction: it exercises update/delete which
+are admin-gated. The caller is resolved from --from <admin> first, then
+BRIDGE_AGENT_ID. doctor refuses to create a fixture if no admin caller
+can be resolved or the caller is not the configured admin agent.
 EOF
         return 0
         ;;
@@ -99,11 +129,25 @@ EOF
     esac
   done
 
-  # Resolve a caller-id to forward into update/delete. The doctor itself
-  # does not enforce admin identity (it is operator-facing, not
-  # agent-facing) — but the underlying update/delete writers do, so we
-  # propagate whichever id the operator provided.
-  local doctor_caller="${from_agent:-${BRIDGE_AGENT_ID:-}}"
+  # Codex r1 (PR #615) — D5 robustness: enforce the admin gate UPFRONT,
+  # before any fixture is created. The doctor exercises update/delete
+  # which are both admin-gated (bridge-agent.sh:2968-2974), so a doctor
+  # run that cannot pass that gate would silently downgrade those steps
+  # to n/a, exit 0, and leave the fixture's roster row + home behind.
+  # Make caller resolution fail-fast against the same predicates the
+  # production gate uses: admin identity and operator-trusted source.
+  local doctor_caller doctor_caller_source
+  doctor_caller="$(bridge_agent_update_caller_agent "$from_agent")"
+  doctor_caller_source="$(bridge_agent_update_caller_source)"
+  if [[ -z "$doctor_caller" ]]; then
+    bridge_die "agent doctor: caller_agent unspecified — pass --from <admin-agent> or set BRIDGE_AGENT_ID before running 'agent doctor'. Aborted before fixture creation."
+  fi
+  if ! bridge_agent_update_caller_is_admin "$doctor_caller"; then
+    bridge_die "agent doctor: caller agent $doctor_caller is not the admin agent — doctor is admin-only by construction. Aborted before fixture creation."
+  fi
+  if [[ "$doctor_caller_source" != "operator-tui" && "$doctor_caller_source" != "operator-trusted-id" ]]; then
+    bridge_die "agent doctor: caller source $doctor_caller_source is not allowed to mutate system config (need operator-tui or operator-trusted-id). Aborted before fixture creation."
+  fi
 
   # Pick a unique fixture name. The `smoke-` prefix matches
   # BRIDGE_TEST_ARTIFACT_PREFIXES so create requires --test-fixture
@@ -192,34 +236,21 @@ EOF
   fi
 
   # ---- 2. update -------------------------------------------------------
-  # The update path is admin-gated, so the caller must be the admin
-  # agent. If we have no admin caller, mark the entire update step n/a
-  # rather than fail — the issue #580 brief explicitly notes that a
-  # non-admin invocation of the doctor is still useful (it exercises
-  # the create / read / delete paths). When --from is provided, we
-  # forward it to the writer.
+  # Caller was validated as admin upfront (D5 robustness fix), so update
+  # must succeed unless the production writer regressed. We always
+  # forward --from since doctor_caller is guaranteed non-empty here.
   local update_args=(update "$fixture"
     --desc "doctor self-check fixture"
     --loop on
     --continue on
-    --class user)
-  [[ -n "$doctor_caller" ]] && update_args+=(--from "$doctor_caller")
+    --class user
+    --from "$doctor_caller")
   local update_out update_rc=0
   update_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${update_args[@]}" 2>&1)" || update_rc=$?
   if [[ $update_rc -eq 0 ]]; then
     _doctor_record pass "update" "desc/loop/continue/class persisted"
   else
-    # Distinguish "no admin caller" from "real failure" by sniffing the
-    # deny reason. The deny message is a stable string from
-    # lib/bridge-agent-update.sh.
-    case "$update_out" in
-      *"is not the admin agent"*|*"caller_agent unspecified"*|*"is not allowed to mutate system config"*)
-        _doctor_record n/a "update" "skipped: caller is not the admin agent (pass --from <admin>)"
-        ;;
-      *)
-        _doctor_record fail "update" "rc=$update_rc out=$(printf '%s' "$update_out" | head -c 240)"
-        ;;
-    esac
+    _doctor_record fail "update" "rc=$update_rc out=$(printf '%s' "$update_out" | head -c 240)"
   fi
 
   # ---- 3. registry --json (read-back) ---------------------------------
@@ -353,27 +384,22 @@ PY
   esac
 
   # ---- 7. delete ------------------------------------------------------
-  # The success-path final step. We pass --orphan-tasks (the fixture
-  # cannot have real tasks, but the doctor must not refuse on a
-  # leftover row from a previous run) and --purge-home (we own the home
-  # we just scaffolded). The cleanup trap will be a no-op if this
-  # succeeds because of the cleaned=1 short-circuit.
-  local del_args=(delete "$fixture" --orphan-tasks --purge-home)
-  [[ -n "$doctor_caller" ]] && del_args+=(--from "$doctor_caller")
+  # Success-path final step. We pass --orphan-tasks (the fixture cannot
+  # have real tasks, but the doctor must not refuse on a leftover row
+  # from a previous run), --purge-home (we own the home we just
+  # scaffolded), and --force (the fixture has no live session under the
+  # doctor itself, but --force keeps step 7 symmetric with the trap's
+  # cleanup so a session that some external process attached to the
+  # fixture name does not block delete here). Caller is guaranteed
+  # admin (validated upfront), so we always forward --from.
+  local del_args=(delete "$fixture" --orphan-tasks --purge-home --force --from "$doctor_caller")
   local del_out del_rc=0
   del_out="$("$bash_bin" "$script_dir/bridge-agent.sh" "${del_args[@]}" 2>&1)" || del_rc=$?
   if [[ $del_rc -eq 0 ]]; then
     _doctor_record pass "delete" "fixture removed + home purged"
     BRIDGE_AGENT_DOCTOR_CLEANED=1   # trap is a no-op now
   else
-    case "$del_out" in
-      *"is not the admin agent"*|*"caller_agent unspecified"*|*"is not allowed to mutate system config"*)
-        _doctor_record n/a "delete" "skipped: caller is not the admin agent (pass --from <admin>)"
-        ;;
-      *)
-        _doctor_record fail "delete" "rc=$del_rc out=$(printf '%s' "$del_out" | head -c 240)"
-        ;;
-    esac
+    _doctor_record fail "delete" "rc=$del_rc out=$(printf '%s' "$del_out" | head -c 240)"
   fi
 
   bridge_agent_doctor_emit "$results" "$pass_count" "$fail_count" "$na_count" "$json_mode" "$fixture"


### PR DESCRIPTION
## Summary

Closes the typed-write gap on `agent-bridge agent update` so the admin no longer falls back to hand-editing `agent-roster.local.sh` for fields not covered by #528's launch-cmd / channels surface, and adds an `agent doctor` self-check that exercises the full admin CRUD matrix end-to-end.

Track 1 (`agent delete` primitive) shipped in #584. This is Track 2 — typed-flag completion + self-check + doc, per the issue's "Asks" #2 and #3.

## New typed-flag surface on `agent update`

Each flag is a full-replace, audited via the existing `system_config_mutation` row, validated at parse time so the writer never sees an out-of-shape value, and reuses `bridge_write_role_block` (the same writer `agent create` uses) so emission shape stays byte-for-byte stable.

| flag | field | semantics |
|---|---|---|
| `--desc <text>` | `BRIDGE_AGENT_DESC` | full replace; rejects newline; empty allowed |
| `--engine claude\|codex` | `BRIDGE_AGENT_ENGINE` | closed value space matches `agent create` |
| `--workdir <path>` | `BRIDGE_AGENT_WORKDIR` | `~` expanded; empty rejected; no auto-mkdir |
| `--loop on\|off` | `BRIDGE_AGENT_LOOP` | explicit-off now persists (was a no-op) |
| `--continue on\|off` | `BRIDGE_AGENT_CONTINUE` | already symmetric in writer |
| `--class user\|system` | `BRIDGE_AGENT_CLASS` | privilege boundary, #539 closed value space |

`bridge_write_role_block` gained two new optional positionals (`agent_class`, `loop_explicit_off`); existing callers continue to work without source changes.

### Decisions noted in `notes`

- Brief listed `--class system|operator|isolated`; the actual codebase only validates `{user, system}` (lib/bridge-agents.sh:bridge_validate_agent_classes). I honored the codebase's closed value space rather than introducing privilege classes the tool-policy doesn't recognize.
- Brief listed `--cron-jobs`; there is no roster field for per-agent cron ownership today (cron jobs live in `bridge-cron`'s separate jobs.json registry), so adding it would widen scope into the cron module. Omitted; flagged in the issue.
- Brief said "fold `--class` through `agent reclassify`": chose the duplicate-validation path. Reclassify is for `dynamic→static` source-shape promotion, not class-value mutation, so reusing it would have inverted its semantics.
- Doctor lives in `lib/bridge-agent-doctor.sh` — `bridge-agents.sh` is already 7171 lines and the doctor is a self-contained add.

## `agent doctor` (alias `agent check`)

New top-level subcommand that exercises every documented `agent-bridge agent <verb>` path against an ephemeral `smoke-doctor-*` test fixture:

```
[doctor] pass: create — fixture=smoke-doctor-...
[doctor] pass: update — desc/loop/continue/class persisted
[doctor] pass: registry — fixture row visible
[doctor] pass: show — post-update description reflected
[doctor] n/a: reclassify — no candidates (fixture is already static — expected)
[doctor] n/a: retire — fixture is static-roster (delete owns this path — expected)
[doctor] pass: delete — fixture removed + home purged
[doctor] summary: pass=5 fail=0 n/a=2 fixture=smoke-doctor-...
```

- Each step is `pass` / `fail` / `n/a` (the latter when the path is structurally inapplicable, e.g. retire on a static-roster row).
- Fixture is removed on `EXIT/INT/TERM` even on failure. Trap target lives at module scope (not inside the function) so the cleanup state doesn't unbind under `set -u` after the function frame is popped.
- `--keep-fixture` skips cleanup for post-mortem inspection; `--json` emits a single envelope with summary + per-check rows.
- When the doctor runs without an admin caller, `update` and `delete` correctly report `n/a` rather than `fail` — the surface still verifies create/registry/show/retire/reclassify, which is useful in install validation contexts.

## Discoverability

- `agent --help` now opens with a one-line-per-subcommand listing for every `agent <verb>` (was previously only listed in the Usage block).
- `agent --help` ends with a Policy paragraph that points at the typed verbs and OPERATIONS.md.
- `OPERATIONS.md` has a new "Admin agent CRUD policy" section documenting the typed-write contract, the audit-chain rationale, and a flag matrix.

## Policy

> Admin agents operate on managed roles **exclusively** through the typed `agent-bridge agent <verb>` surface. Direct `Edit` / `Write` against `agent-roster.local.sh` is intentionally blocked even when the caller is the admin agent. The block is not a sandbox — it is the audit-chain contract. The typed verbs emit a `system_config_mutation` audit row for every apply, deny, or dry-run; enforce the operator-trusted-source check before mutating; and round-trip every non-touched field byte-for-byte through `bridge_write_role_block`. Hand-edits will be reverted by the daemon's next reconciliation pass. `agent doctor` exists specifically to verify this surface end-to-end.

(Full text in OPERATIONS.md.)

## Verification

Run from a worktree off `a1e90e6`:

- `bash -n bridge-agent.sh agent-bridge agb lib/*.sh` — PASS
- `shellcheck *.sh agent-bridge agb lib/*.sh agent-roster.local.example.sh` — PASS (clean, no new findings)
- `./scripts/smoke-test.sh` — same as base; the single `[smoke][error] expected output to contain: stopped` failure (daemon-stop probe near the end) reproduces on `a1e90e6` without any edits. Pre-existing, not caused by this PR (matches the note in PR #584).
- Isolated `BRIDGE_HOME=$(mktemp -d)` repro covering:
  - `agent doctor` without admin caller — pass=3 fail=0 n/a=4 (create/registry/show pass; update/delete report n/a; reclassify/retire report n/a as expected)
  - `agent doctor` with admin pre-seeded in roster — pass=5 fail=0 n/a=2 (full success path)
  - `agent doctor --json` — well-formed envelope with per-check rows
  - Each new `--desc` / `--engine` / `--workdir` / `--loop on|off` / `--continue on|off` / `--class user|system` mutation persists to the roster and round-trips through `agent show --json`.
  - Negative-path tests: `--engine python` / `--class operator` / `--loop maybe` / `--continue heh` / `--workdir ""` / newline-in-`--desc` all refused at parse time with stable Korean error messages.
  - `--loop off` followed by another non-loop mutation correctly preserves `LOOP="0"` (the new `loop_explicit_off` writer arg).

## Out of scope

- `--cron-jobs` (no roster field exists; would widen scope into `bridge-cron` module).
- VERSION / CHANGELOG bumps — release-PR-only per CLAUDE.md / AGENTS.md.
- `agent reclassify` source-rewrite (a separate sub-track from #580).

## Files changed

- `bridge-agent.sh` — typed flags + writer signature + doctor dispatch (+329 / -23)
- `lib/bridge-agent-doctor.sh` — new module (+430)
- `bridge-lib.sh` — source the doctor module after `bridge-agent-update.sh` (+5)
- `OPERATIONS.md` — Admin agent CRUD policy section (+59)

Refs #580 (does not auto-close — issue covers tracks beyond what's in this PR)

---

## r2 changes (codex r1 D5 follow-up)

Codex r1 flagged D5: `agent doctor` could leak its fixture when invoked without an admin caller (the n/a-downgrade path silently exited 0 with both the roster block and home left behind). The r2 commit `01003f0` makes doctor admin-only by construction:

- **Caller validation upfront, before any side-effects.** `doctor_caller` is resolved from `--from` then `BRIDGE_AGENT_ID`, then validated against the same predicates the production update/delete gate uses (`bridge_agent_update_caller_is_admin` + caller-source `operator-tui` / `operator-trusted-id`). Any failure aborts via `bridge_die` before the fixture is created.
- **No-leak guarantee.** The EXIT trap reuses the validated caller (no re-resolution from env), passes `--force` so an active fixture session does not block delete (`run_delete:2993-2998`), and exits the process non-zero if cleanup itself fails — a leaked fixture surfaces as a doctor failure rather than a swallowed warning.
- **n/a downgrades retired.** With the admin gate enforced upfront, `update` and `delete` no longer have an n/a-on-deny branch. A non-zero rc from those steps is now a real failure of the production writer.
- **Step 7 + trap symmetry.** Step 7 also passes `--force` and forwards the validated caller unconditionally.
- **Help text** rewritten to state doctor is admin-only and explain the caller resolution order.

### Verification (isolated `BRIDGE_HOME`)

| case | command | expected | observed |
|---|---|---|---|
| T1 missing caller | `unset BRIDGE_AGENT_ID; doctor` | exit≠0, no fixture | exit 1, remediation message, no roster/home residue |
| T2 non-admin id | `BRIDGE_AGENT_ID=non-admin doctor` | exit≠0, no fixture | exit 1, no residue |
| T3 `--from non-admin` | `doctor --from someone-else` | exit≠0, no fixture | exit 1, no residue |
| T4 admin id + `agent-direct` source | `BRIDGE_CALLER_SOURCE=agent-direct doctor` | exit≠0, no fixture | exit 1, no residue |
| T5 `--help` no caller | `doctor --help` | exit 0 | exit 0 |
| T8 admin id absent from roster | `doctor` (roster missing `BRIDGE_ADMIN_AGENT_ID`) | exit≠0, no fixture | exit 1, no residue |
| T9 full success path | `BRIDGE_AGENT_ID=patch doctor` | pass=5 fail=0 n/a=2, exit 0 | matches |

`bash -n` + `shellcheck` on `bridge-agent.sh`, `lib/bridge-agent-doctor.sh`, `lib/bridge-agent-update.sh`: PASS.

Files changed in r2: `lib/bridge-agent-doctor.sh` (+73 / -47).


## r3 changes (codex r2 D5 face-2 follow-up)

Codex r2 verified the upfront admin gate + cleanup-failure propagation
from r2, but surfaced a new D5 face: success-path cleanup leaked the
fixture home directory whenever the doctor ran in an isolated
`BRIDGE_HOME` while the parent shell had inherited
`BRIDGE_AGENT_HOME_ROOT` from a live install. The fixture was created
under `$BRIDGE_HOME/agents/<fixture>`, but `agent delete --purge-home`
resolved its rm target via `bridge_agent_default_home`, which falls
back to `$BRIDGE_AGENT_HOME_ROOT/<fixture>` — and that env var was
typically already exported by an outer agent's launcher. The doctor
reported `pass=5 fail=0` while the isolated fixture under
`$BRIDGE_HOME/agents` leaked.

Fix (Option 1 from the r3 brief — preferred): pin
`BRIDGE_AGENT_HOME_ROOT="$BRIDGE_HOME/agents"` in the env of every
child `bridge-agent.sh` invocation the doctor makes (create, update,
registry, show, reclassify, retire, delete, plus the cleanup-trap
delete). Cleanup target now matches the create target by construction.
Override is scoped to each child only — the parent shell's env is
unchanged.

Self-policing: after step 7's delete returns 0, the doctor verifies
`$fixture_workdir` is gone before recording a pass; a leaked path
records a `delete` failure. The cleanup trap also has a final safety
net that exits 1 if the pinned fixture path remains after a 0-rc
child. This makes the doctor self-policing for the regression class
codex r2 caught.

### Verification

- `bash -n` + `shellcheck` on `lib/bridge-agent-doctor.sh`,
  `bridge-agent.sh`, `bridge-lib.sh`: PASS.
- Negative scopes from r2 still abort upfront: missing `BRIDGE_AGENT_ID`
  → exit 1 + "caller_agent unspecified", no agents dir created;
  non-admin caller → exit 1 + "is not the admin agent", no agents dir.
- Adversarial: `BRIDGE_HOME=/tmp/iso BRIDGE_AGENT_HOME_ROOT=/tmp/wrong-root
  BRIDGE_AGENT_ID=patch doctor` confirmed fixture creation lands at
  `/tmp/iso/agents/<fixture>` and `/tmp/wrong-root` is never written
  (verified directly: `ls /tmp/wrong-root/` → No such file or directory).
  The new self-assertion correctly reports leak when the underlying
  rm fails (caught here on macOS by an unrelated pre-existing bug in
  `bridge_linux_sudo_root` that takes the sudo branch on non-Linux —
  out of scope for #580 Track 2 and not introduced by this PR; on
  Linux with the sudoers entry from `bridge_migration_sudoers_entry`,
  the rm succeeds and the doctor reports `pass=5 fail=0 n/a=2`).

Files changed in r3: `lib/bridge-agent-doctor.sh` (+82 / -18).
