### PR TITLE
fix(cron): scheduler honors deferred-retry nextRunAtMs (#614)

### DIFF
--- a/bridge-cron-scheduler.py
+++ b/bridge-cron-scheduler.py
@@ -368,6 +368,96 @@ def enumerate_due_runs(
     return due_runs, dict(counters)
 
 
+# Issue #614: marker prefix on retry slot strings so audit / dashboards can
+# tell a deferred-retry occurrence apart from a natural cron occurrence
+# without having to dig into job state. Format: "<prefix><iso-of-retry-time>".
+RETRY_SLOT_PREFIX = "deferred-retry-"
+
+
+def derive_retry_slot(occurrence_at: datetime) -> str:
+    return f"{RETRY_SLOT_PREFIX}{occurrence_at.isoformat(timespec='minutes')}"
+
+
+def enumerate_pending_retries(
+    jobs: list[dict[str, Any]],
+    now_dt: datetime,
+) -> tuple[list[DueRun], dict[str, int]]:
+    """Issue #614 — second-pass enumerator for deferred-retry slots.
+
+    `enumerate_due_runs` only walks the cron / every / at expression. When
+    `bridge-cron-runner.py` defers a slot (e.g. memory-pressure pre-flight),
+    `bridge-cron.py` writes `state.nextRunAtMs` forward by `deferred_seconds`
+    and tags `state.lastStatus = deferred`. Nothing else reads that state.
+    For high-frequency jobs the next natural occurrence catches up; for
+    daily / weekly / monthly cron and one-shot `at`, the deferred slot is
+    silently lost.
+
+    This helper synthesises a `DueRun` at `parse_epoch_ms(nextRunAtMs)` so
+    the existing enqueue path can re-fire the slot. The retry carries:
+
+    - `occurrence_at = retry fire time` (NOT the original slot time). That
+      keeps `due_run_sort_key` strictly monotonic against the cursor, so
+      `filter_due_runs_from_state` accepts it without a special bypass.
+    - `slot = derive_retry_slot(occurrence_at)` — a unique transport slot
+      that does not collide with the original (whose request/manifest may
+      still be on disk and would otherwise return `already_enqueued`).
+    - `family / source_agent / job_id / job_name` from the job, so audit
+      and delivery routing match the original.
+
+    The original slot / occurrence is preserved in `job_state` (written by
+    `bridge-cron.py` on the deferred-finalize path) under
+    `deferredRetryOfSlot` / `deferredRetryOfOccurrenceAt`. Operators reading
+    the dashboard can correlate the retry back to its origin without the
+    scheduler having to encode the original slot inside the retry's slot
+    string.
+    """
+    counters: Counter = Counter()
+    retries: list[DueRun] = []
+
+    for job in jobs:
+        if not job_enabled(job):
+            counters["disabled"] += 1
+            continue
+
+        state = job.get("state") or {}
+        last_status = str(state.get("lastStatus") or state.get("lastRunStatus") or "")
+        if last_status != "deferred":
+            counters["not_deferred"] += 1
+            continue
+
+        retry_dt = parse_epoch_ms(state.get("nextRunAtMs"))
+        if retry_dt is None:
+            counters["no_next_run"] += 1
+            continue
+        if retry_dt > now_dt:
+            counters["retry_in_future"] += 1
+            continue
+
+        schedule = job.get("schedule") or {}
+        kind = str(schedule.get("kind") or "")
+        if kind not in ("cron", "every", "at"):
+            counters["unsupported_kind"] += 1
+            continue
+
+        slot = derive_retry_slot(retry_dt)
+        family = classify_family(job.get("name", ""))
+        retries.append(
+            DueRun(
+                job_id=job.get("id", ""),
+                job_name=job.get("name", "<unnamed>"),
+                family=family,
+                source_agent=job.get("agentId") or job.get("agent") or "<unknown>",
+                schedule_kind=kind,
+                occurrence_at=retry_dt,
+                slot=slot,
+            )
+        )
+        counters["retry_due"] += 1
+
+    retries.sort(key=lambda item: (item.occurrence_at, item.source_agent, item.job_name, item.slot))
+    return retries, dict(counters)
+
+
 def due_run_sort_key(run: DueRun) -> tuple[datetime, str, str, str, str]:
     return (
         run.occurrence_at,
@@ -571,6 +661,23 @@ def cmd_sync(args: argparse.Namespace) -> int:
     jobs = load_jobs(jobs_file)
     due_runs, counters = enumerate_due_runs(jobs, start_dt, now_dt, args.max_occurrences_per_job)
     due_runs = filter_due_runs_from_state(due_runs, state)
+    # Issue #614: synthesise deferred-retry slots whose `nextRunAtMs` has
+    # arrived. These are appended *after* the cursor filter — their
+    # occurrence_at is strictly later than the original deferred slot
+    # (= original_slot_time + deferred_seconds), so the cursor naturally
+    # accepts them. Dedup against the same job's natural occurrence is by
+    # (occurrence_at, slot, job_id) tuple uniqueness; the retry slot uses
+    # `derive_retry_slot()` which never collides with cron expression slots.
+    pending_retries, retry_counters = enumerate_pending_retries(jobs, now_dt)
+    if pending_retries:
+        existing_keys = {due_run_sort_key(run) for run in due_runs}
+        for retry in pending_retries:
+            if due_run_sort_key(retry) in existing_keys:
+                continue
+            due_runs.append(retry)
+            existing_keys.add(due_run_sort_key(retry))
+        due_runs.sort(key=lambda item: (item.occurrence_at, item.source_agent, item.job_name, item.slot))
+    counters["pending_retries"] = retry_counters.get("retry_due", 0)
     counters["due_occurrences"] = len(due_runs)
 
     results: list[dict[str, Any]] = []

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -2109,6 +2109,12 @@ def run_native_finalize(args):
         job_state["consecutiveErrors"] = 0
         job_state.pop("lastErrorAtMs", None)
         job_state.pop("lastError", None)
+        # Issue #614: clear deferred-retry provenance so the next deferral
+        # captures a fresh original slot.
+        job_state.pop("deferredRetryOfSlot", None)
+        job_state.pop("deferredRetryOfOccurrenceAt", None)
+        job_state.pop("deferredRetryAttempt", None)
+        job_state.pop("deferredFirstAt", None)
     elif final_status == "deferred":
         # #263 Track B: the runner asked us to defer this slot for
         # `deferred_seconds`. Push nextRunAtMs forward by that window so
@@ -2125,8 +2131,34 @@ def run_native_finalize(args):
         deferred_reason = str(status.get("deferred_reason") or "").strip()
         if deferred_reason:
             job_state["lastDeferredReason"] = deferred_reason
+
+        # Issue #614: persist deferred-retry provenance so the scheduler can
+        # re-fire the slot with a new transport identity (slot/run_id).
+        # Reusing the original slot is unsafe — `bridge-cron.sh:516-575` keys
+        # run_id, request.json, and the dispatch manifest off slot, and an
+        # existing manifest with `dispatch_task_id` returns
+        # `status: already_enqueued`. So the retry needs a *new* slot, but
+        # the original slot/occurrence must be preserved as provenance for
+        # audit and so the scheduler can clear nextRunAtMs cleanly on success.
+        request_slot = str(request.get("slot") or "").strip()
+        if request_slot and "deferredRetryOfSlot" not in job_state:
+            job_state["deferredRetryOfSlot"] = request_slot
+            job_state["deferredRetryOfOccurrenceAt"] = request_slot
+        try:
+            previous_attempt = int(job_state.get("deferredRetryAttempt") or 0)
+        except (TypeError, ValueError):
+            previous_attempt = 0
+        job_state["deferredRetryAttempt"] = previous_attempt + 1
+        if "deferredFirstAt" not in job_state:
+            job_state["deferredFirstAt"] = datetime.now().astimezone().isoformat(timespec="seconds")
     else:
         job_state["nextRunAtMs"] = 0
+        # Issue #614: clear deferred-retry provenance so a future deferral
+        # captures a fresh original slot.
+        job_state.pop("deferredRetryOfSlot", None)
+        job_state.pop("deferredRetryOfOccurrenceAt", None)
+        job_state.pop("deferredRetryAttempt", None)
+        job_state.pop("deferredFirstAt", None)
         try:
             previous_errors = int(job_state.get("consecutiveErrors") or 0)
         except (TypeError, ValueError):

--- a/tests/cron-deferred-retry/smoke.sh
+++ b/tests/cron-deferred-retry/smoke.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Issue #614 — scheduler deferred-retry regression smoke.
+#
+# Runs the Python unit tests in test_pending_retries.py against the
+# repo's bridge-cron-scheduler.py. Three scenarios assert the new
+# enumerate_pending_retries + cmd_sync dedup logic:
+#
+#   1. daily cron deferred at 06:00 with nextRunAtMs=06:15 → retry at 06:15
+#   2. deferred `at` job → same retry behaviour
+#   3. retry + next natural occurrence both due → both enqueue exactly once
+#
+# Usage: ./tests/cron-deferred-retry/smoke.sh
+# Exit 0 = pass, exit 1 = fail.
+
+set -uo pipefail
+
+THIS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+python3 "$THIS_DIR/test_pending_retries.py"

--- a/tests/cron-deferred-retry/test_pending_retries.py
+++ b/tests/cron-deferred-retry/test_pending_retries.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Issue #614 — regression coverage for scheduler deferred-retry enumerator.
+
+Three scenarios:
+
+1. ``daily_cron_deferred`` — daily 06:00 cron deferred at fire time with
+   ``nextRunAtMs = 06:15``. Retry must show up exactly once with
+   ``occurrence_at == 06:15``, original 06:00 slot stays past the cursor,
+   and the synthetic retry's slot uses the deferred-retry marker.
+
+2. ``deferred_at_job`` — one-shot ``schedule.kind=at`` job that deferred.
+   Same retry behaviour as the daily cron; the bug existed there too
+   despite the comment in ``bridge-cron.py:2145-2148``.
+
+3. ``retry_collides_with_natural_occurrence`` — same scheduler tick yields
+   both a deferred retry AND the next natural occurrence. Both must be
+   emitted exactly once each, no collapse.
+
+These exercise the new ``enumerate_pending_retries`` plus the dedup logic
+in ``cmd_sync``. They run the scheduler module by import, not by
+subprocess, so the assertions stay focused on the scheduling decision
+without spinning up a real queue / runner / worker.
+
+Usage:  python3 tests/cron-deferred-retry/test_pending_retries.py
+        Exit 0 = pass, exit 1 = fail.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEDULER_PATH = REPO_ROOT / "bridge-cron-scheduler.py"
+
+
+def load_scheduler():
+    spec = importlib.util.spec_from_file_location("bridge_cron_scheduler", SCHEDULER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load scheduler module at {SCHEDULER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec — dataclass field type resolution
+    # walks `sys.modules.get(cls.__module__)` and crashes if the module is
+    # absent (Python 3.9 dataclasses internals).
+    sys.modules["bridge_cron_scheduler"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def epoch_ms(dt: datetime) -> int:
+    return int(dt.timestamp() * 1000)
+
+
+def make_daily_cron_job(now_dt: datetime) -> dict:
+    occurrence_at = now_dt.replace(hour=6, minute=0, second=0, microsecond=0)
+    next_retry_at = occurrence_at + timedelta(minutes=15)
+    return {
+        "id": "daily-job-id",
+        "name": "morning-briefing-test",
+        "agentId": "patch",
+        "enabled": True,
+        "schedule": {
+            "kind": "cron",
+            "expr": "0 6 * * *",
+            "tz": "Asia/Seoul",
+        },
+        "state": {
+            "lastStatus": "deferred",
+            "lastRunStatus": "deferred",
+            "nextRunAtMs": epoch_ms(next_retry_at),
+            "deferredRetryOfSlot": occurrence_at.isoformat(timespec="minutes"),
+            "deferredRetryOfOccurrenceAt": occurrence_at.isoformat(timespec="minutes"),
+            "deferredRetryAttempt": 1,
+        },
+    }
+
+
+def make_at_job(now_dt: datetime) -> dict:
+    occurrence_at = now_dt.replace(hour=8, minute=0, second=0, microsecond=0)
+    next_retry_at = occurrence_at + timedelta(minutes=15)
+    return {
+        "id": "at-job-id",
+        "name": "event-reminder-test",
+        "agentId": "jjujju",
+        "enabled": True,
+        "schedule": {
+            "kind": "at",
+            "at": occurrence_at.isoformat(),
+            "tz": "Asia/Seoul",
+        },
+        "state": {
+            "lastStatus": "deferred",
+            "nextRunAtMs": epoch_ms(next_retry_at),
+            "deferredRetryOfSlot": occurrence_at.isoformat(timespec="minutes"),
+            "deferredRetryOfOccurrenceAt": occurrence_at.isoformat(timespec="minutes"),
+            "deferredRetryAttempt": 1,
+        },
+    }
+
+
+def make_high_freq_cron_job(now_dt: datetime) -> dict:
+    """Every-15min job that deferred at :00, retry at :15. By :15 the next
+    natural cron occurrence ALSO fires. Both must come through."""
+    deferred_slot = now_dt.replace(minute=0, second=0, microsecond=0)
+    retry_at = deferred_slot + timedelta(minutes=15)
+    return {
+        "id": "freq-job-id",
+        "name": "every15-test",
+        "agentId": "patch",
+        "enabled": True,
+        "schedule": {
+            "kind": "cron",
+            "expr": "*/15 * * * *",
+            "tz": "Asia/Seoul",
+        },
+        "state": {
+            "lastStatus": "deferred",
+            "nextRunAtMs": epoch_ms(retry_at),
+            "deferredRetryOfSlot": deferred_slot.isoformat(timespec="minutes"),
+            "deferredRetryOfOccurrenceAt": deferred_slot.isoformat(timespec="minutes"),
+            "deferredRetryAttempt": 1,
+        },
+    }
+
+
+def assert_eq(actual, expected, label):
+    if actual != expected:
+        print(f"FAIL: {label}: expected {expected!r}, got {actual!r}")
+        return False
+    print(f"PASS: {label}")
+    return True
+
+
+def assert_true(value, label):
+    if not value:
+        print(f"FAIL: {label}: expected truthy, got {value!r}")
+        return False
+    print(f"PASS: {label}")
+    return True
+
+
+def test_daily_cron_deferred(scheduler):
+    now_dt = datetime(2026, 5, 6, 6, 20, 0, tzinfo=scheduler.LOCAL_TZ)
+    job = make_daily_cron_job(now_dt)
+    retries, counters = scheduler.enumerate_pending_retries([job], now_dt)
+    ok = True
+    ok &= assert_eq(len(retries), 1, "daily_cron: one pending retry")
+    if retries:
+        retry = retries[0]
+        ok &= assert_eq(retry.job_id, "daily-job-id", "daily_cron: retry.job_id")
+        ok &= assert_eq(retry.schedule_kind, "cron", "daily_cron: schedule_kind preserved")
+        # Retry occurrence_at == nextRunAtMs (06:15), NOT the original 06:00.
+        ok &= assert_eq(
+            retry.occurrence_at.replace(microsecond=0),
+            now_dt.replace(hour=6, minute=15, second=0, microsecond=0),
+            "daily_cron: retry occurrence_at = nextRunAtMs",
+        )
+        ok &= assert_true(
+            retry.slot.startswith(scheduler.RETRY_SLOT_PREFIX),
+            "daily_cron: retry slot uses deferred-retry- prefix",
+        )
+    ok &= assert_eq(counters.get("retry_due"), 1, "daily_cron: counter retry_due=1")
+    return ok
+
+
+def test_deferred_at_job(scheduler):
+    now_dt = datetime(2026, 5, 6, 8, 20, 0, tzinfo=scheduler.LOCAL_TZ)
+    job = make_at_job(now_dt)
+    retries, counters = scheduler.enumerate_pending_retries([job], now_dt)
+    ok = True
+    ok &= assert_eq(len(retries), 1, "at_job: one pending retry")
+    if retries:
+        retry = retries[0]
+        ok &= assert_eq(retry.schedule_kind, "at", "at_job: schedule_kind=at")
+        ok &= assert_eq(retry.job_id, "at-job-id", "at_job: retry.job_id")
+        ok &= assert_eq(
+            retry.occurrence_at.replace(microsecond=0),
+            now_dt.replace(hour=8, minute=15, second=0, microsecond=0),
+            "at_job: retry occurrence_at = nextRunAtMs",
+        )
+    ok &= assert_eq(counters.get("retry_due"), 1, "at_job: counter retry_due=1")
+    return ok
+
+
+def test_retry_and_natural_occurrence_collide(scheduler):
+    # Tick at 12:18. Job deferred at 12:00, retry due at 12:15.
+    # Next natural occurrence (every-15min) is 12:15. Both must be present
+    # exactly once each — no collapse.
+    now_dt = datetime(2026, 5, 6, 12, 18, 0, tzinfo=scheduler.LOCAL_TZ)
+    start_dt = datetime(2026, 5, 6, 12, 5, 0, tzinfo=scheduler.LOCAL_TZ)
+    job = make_high_freq_cron_job(now_dt)
+
+    natural_due, natural_counters = scheduler.enumerate_due_runs(
+        [job], start_dt, now_dt, per_job_limit=0
+    )
+    pending_retries, retry_counters = scheduler.enumerate_pending_retries([job], now_dt)
+
+    # Replicate dedup: combine, drop duplicate keys, sort.
+    existing_keys = {scheduler.due_run_sort_key(r) for r in natural_due}
+    merged = list(natural_due)
+    for retry in pending_retries:
+        if scheduler.due_run_sort_key(retry) in existing_keys:
+            continue
+        merged.append(retry)
+        existing_keys.add(scheduler.due_run_sort_key(retry))
+
+    ok = True
+    # The natural occurrence at 12:15 must be present.
+    natural_at_1215 = [
+        r
+        for r in merged
+        if r.occurrence_at.replace(microsecond=0)
+        == now_dt.replace(minute=15, second=0, microsecond=0)
+        and not r.slot.startswith(scheduler.RETRY_SLOT_PREFIX)
+    ]
+    ok &= assert_eq(
+        len(natural_at_1215), 1, "collision: natural 12:15 cron occurrence present"
+    )
+    # The retry at 12:15 must also be present.
+    retries_at_1215 = [
+        r
+        for r in merged
+        if r.occurrence_at.replace(microsecond=0)
+        == now_dt.replace(minute=15, second=0, microsecond=0)
+        and r.slot.startswith(scheduler.RETRY_SLOT_PREFIX)
+    ]
+    ok &= assert_eq(
+        len(retries_at_1215), 1, "collision: deferred retry at 12:15 present"
+    )
+    # No duplicate keys.
+    keys = [scheduler.due_run_sort_key(r) for r in merged]
+    ok &= assert_eq(len(keys), len(set(keys)), "collision: no duplicate due_run keys")
+    return ok
+
+
+def main():
+    scheduler = load_scheduler()
+    results = [
+        ("daily_cron_deferred", test_daily_cron_deferred(scheduler)),
+        ("deferred_at_job", test_deferred_at_job(scheduler)),
+        ("retry_and_natural_occurrence_collide", test_retry_and_natural_occurrence_collide(scheduler)),
+    ]
+    print()
+    print("=== summary ===")
+    failed = [name for name, ok in results if not ok]
+    for name, ok in results:
+        print(f"  {name}: {'PASS' if ok else 'FAIL'}")
+    if failed:
+        print(f"\n{len(failed)} test(s) failed: {', '.join(failed)}")
+        sys.exit(1)
+    print("\nAll tests passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Closes #614. Scheduler's `enumerate_due_runs` only walked cron / every / at expressions; nothing read `state.nextRunAtMs` written by the deferred-finalize path. Daily / weekly / one-shot `at` jobs lost the deferred slot silently — high-frequency jobs were rescued by the next natural occurrence, low-frequency ones disappeared.
- Adds `enumerate_pending_retries` to synthesise a `DueRun` at `parse_epoch_ms(nextRunAtMs)` whose `slot` is unique (`deferred-retry-<iso>` prefix) so it does not collide with the original cron-expression slot's request/manifest.
- Persists deferred-retry provenance (`deferredRetryOfSlot`, `deferredRetryOfOccurrenceAt`, `deferredRetryAttempt`, `deferredFirstAt`) so audit/dashboards can correlate retries to origins. Cleared on success and error so future deferrals start clean.
- Cursor advance keeps working without a special bypass: retry occurrence_at is strictly later than the original deferred slot.

Reviewed by paired codex agent (`patch-dev`); plan-ok and implement-ok received before opening.

## Test plan

- [x] `bash tests/cron-deferred-retry/smoke.sh` — 3/3 scenarios pass: daily cron defer, one-shot `at` defer, retry+natural-occurrence collision in same scheduler tick.
- [x] `python3 -c 'import ast; ast.parse(...)'` clean on `bridge-cron-scheduler.py`, `bridge-cron.py`, and the new test module.
- [x] Direct fixture check of `bridge-cron.py native-finalize-run` writes the new provenance fields and advances `nextRunAtMs` (verified by reviewer).
- [ ] CI green on push.

## Out of scope

- Retry-budget cap / give-up policy. Cheap-to-record fields (`deferredRetryAttempt`, `deferredFirstAt`) are added so a future cap can use them; the cap itself is a separate PR.
- Memory-probe behaviour (#263).
- Dashboard surfacing of `deferredRetryAttempt` / `deferredFirstAt`.

## Non-blocking note carried forward (per reviewer)

`deferredRetryOfOccurrenceAt` currently stores the original slot string (timezone-tagged ISO), not a canonical occurrence timestamp; `deferredFirstAt` is recorded at finalize time, not the runner's `deferred_at`. Fine for this PR because the scheduler does not consume those fields. If surfaced later in dashboards/docs, describe as best-effort provenance rather than exact scheduling timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)