### PR TITLE
fix(hooks): preserve per-agent user keys in cmd_render_shared_settings (#613)

### DIFF
--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -838,6 +838,44 @@ def next_backup_path(path: Path) -> Path:
     return candidate
 
 
+# User-owned keys that bridge renderers must preserve across rerenders.
+# Rationale: the shared and isolated renderers both compose
+# `managed defaults < base < overlay` and overwrite the effective settings
+# file on every call (`agent restart`, `agent rerender-settings --apply`,
+# `bridge-init.sh` install, `agb upgrade propagate`). Without explicit
+# preservation, per-agent user state — plugin enable/disable, marketplace
+# pins, danger-prompt skip — is silently wiped on the next render even
+# though it lives in the same JSON file Claude itself reads.
+#
+# (Issue #544 PR2 originally introduced this for the isolated renderer to
+# survive the `settings.json` → `settings.effective.json` symlink
+# transition. Issue #613 generalized it to the shared renderer after
+# operators hit the same silent-clobber on every `--apply`.)
+PRESERVED_USER_KEYS = (
+    "enabledPlugins",
+    "extraKnownMarketplaces",
+    "skipDangerousModePermissionPrompt",
+)
+
+
+def _load_preserved_user_keys(effective_path: Path) -> dict[str, Any]:
+    """Read the user-owned subset of an existing effective settings file.
+
+    Returns an empty dict if the file is missing, unreadable, malformed,
+    or not a JSON object. Callers merge the result *last* so user keys
+    win over base/overlay/managed defaults.
+    """
+    if not effective_path.exists():
+        return {}
+    try:
+        existing = load_json(effective_path)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(existing, dict):
+        return {}
+    return {k: existing[k] for k in PRESERVED_USER_KEYS if k in existing}
+
+
 def cmd_render_shared_settings(args: argparse.Namespace) -> int:
     base_path = Path(args.base_settings_file).expanduser()
     overlay_path = Path(args.overlay_settings_file).expanduser()
@@ -853,8 +891,15 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
     launch_cmd = (getattr(args, "launch_cmd", "") or "") or None
     agent_class = (getattr(args, "agent_class", "") or "") or None
     managed_defaults = managed_claude_settings_defaults(launch_cmd, agent_class)
+    # Compose: managed defaults < base < overlay < preserved user keys.
+    # Preserved keys merge last so per-agent edits to the effective file
+    # (e.g. operator-disabled plugins) survive every rerender. See
+    # `PRESERVED_USER_KEYS` rationale above.
+    preserved = _load_preserved_user_keys(effective_path)
     merged = merge_settings(managed_defaults, base_payload)
     merged = merge_settings(merged, overlay_payload)
+    if preserved:
+        merged = merge_settings(merged, preserved)
     save_json(effective_path, merged)
 
     payload = {
@@ -862,6 +907,7 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
         "overlay_settings_file": str(overlay_path),
         "effective_settings_file": str(effective_path),
         "overlay_present": "true" if overlay_path.exists() else "false",
+        "preserved_keys": ",".join(sorted(preserved.keys())),
     }
     if args.format == "shell":
         for key, value in payload.items():
@@ -872,6 +918,7 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
     print(f"overlay_settings_file: {payload['overlay_settings_file']}")
     print(f"effective_settings_file: {payload['effective_settings_file']}")
     print(f"overlay_present: {payload['overlay_present']}")
+    print(f"preserved_keys: [{payload['preserved_keys']}]")
     return 0
 
 
@@ -885,18 +932,10 @@ def cmd_render_shared_settings(args: argparse.Namespace) -> int:
 # inside controller/root ownership while still letting the isolated UID
 # read it. Hooks themselves run as the isolated UID — that is intended.
 #
-# Pre-existing isolated-UID user keys (`enabledPlugins`,
-# `extraKnownMarketplaces`, `skipDangerousModePermissionPrompt`) are
+# Pre-existing isolated-UID user keys (see `PRESERVED_USER_KEYS`) are
 # extracted from any prior regular `settings.json` at that path and merged
 # into the rendered effective file so first-run user state survives the
 # transition to symlink-managed.
-ISOLATED_HOME_PRESERVED_USER_KEYS = (
-    "enabledPlugins",
-    "extraKnownMarketplaces",
-    "skipDangerousModePermissionPrompt",
-)
-
-
 def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     isolated_home = Path(args.isolated_home).expanduser()
     base_path = Path(args.base_settings_file).expanduser()
@@ -921,20 +960,10 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     #     breaking idempotency and erasing the operator's user state
     #     on every subsequent rerender (e.g. agent restart).
     preserved: dict[str, Any] = {}
-    preserve_source: Path | None = None
     if settings_link.exists() and not settings_link.is_symlink():
-        preserve_source = settings_link
-    elif settings_link.is_symlink() and effective_path.exists():
-        preserve_source = effective_path
-    if preserve_source is not None:
-        try:
-            existing = load_json(preserve_source)
-        except (OSError, json.JSONDecodeError):
-            existing = {}
-        if isinstance(existing, dict):
-            for key in ISOLATED_HOME_PRESERVED_USER_KEYS:
-                if key in existing:
-                    preserved[key] = existing[key]
+        preserved = _load_preserved_user_keys(settings_link)
+    elif settings_link.is_symlink():
+        preserved = _load_preserved_user_keys(effective_path)
 
     # 2. Compose: managed defaults < base < overlay < preserved user keys.
     base_payload = ensure_settings_root(base_path)

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys
 }
 
 add_all_integration() {
@@ -265,7 +265,9 @@ select_for_path() {
       # Issue #555 — `bridge_link_claude_settings_to_shared` /
       # `bridge_ensure_claude_*_hook` now take an optional 3rd `agent`
       # arg that switches to per-agent rendering; cover the regression.
-      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering
+      # Issue #613 — shared renderer now preserves operator-edited user
+      # keys symmetrically with the isolated renderer.
+      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10390,6 +10390,12 @@ bash "$REPO_ROOT/scripts/smoke/system-agent-class.sh"
 log "running per-agent-settings-rendering smoke (issue #555)"
 bash "$REPO_ROOT/scripts/smoke/per-agent-settings-rendering.sh"
 
+# Issue #613 — shared renderer must preserve operator-edited user keys
+# (enabledPlugins, extraKnownMarketplaces, skipDangerousModePermissionPrompt)
+# on every rerender, matching the long-standing isolated-renderer contract.
+log "running shared-settings-preserve-user-keys smoke (issue #613)"
+bash "$REPO_ROOT/scripts/smoke/shared-settings-preserve-user-keys.sh"
+
 # Issue #597 Track D — precompact-notify suite. Exercises the Discord
 # relay activity-index writer, the Track A route-primitive end-to-end
 # with the writer-populated index, and the pre-compact.py hook

--- a/scripts/smoke/shared-settings-preserve-user-keys.sh
+++ b/scripts/smoke/shared-settings-preserve-user-keys.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# scripts/smoke/shared-settings-preserve-user-keys.sh — Issue #613 regression smoke.
+#
+# Validates that `bridge-hooks.py render-shared-settings` preserves
+# user-owned keys on rerender, matching the long-standing behavior of
+# `render-isolated-home-settings`.
+#
+# Background (issue #613): the shared renderer used to overwrite the
+# effective file from `managed defaults < base < overlay` on every call
+# and silently dropped per-agent edits to `enabledPlugins`,
+# `extraKnownMarketplaces`, `skipDangerousModePermissionPrompt`. Operators
+# who disabled heavy plugins per-agent saw their edits reverted on the
+# next `agent restart`, `agent rerender-settings --apply`, `bridge-init.sh`
+# run, or `agb upgrade propagate`. The fix extracted a shared
+# `_load_preserved_user_keys()` helper used by both renderers; this smoke
+# guards the shared-renderer path so the asymmetry can't silently return.
+#
+# Sub-tests:
+#   1. Fresh render produces an effective file with no user keys
+#      (preservation is a no-op when there's nothing to preserve).
+#   2. After an operator edits the effective file with the three preserved
+#      keys, the next render keeps them verbatim.
+#   3. Rerender is idempotent — same SHA256 across two consecutive runs.
+#   4. Non-allowlisted operator keys do NOT round-trip — only the
+#      documented allowlist is preserved.
+
+set -euo pipefail
+
+SMOKE_NAME="shared-settings-preserve-user-keys"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+build_fixture() {
+  smoke_make_temp_root "$SMOKE_NAME"
+
+  FIXTURE_BRIDGE_HOME="$SMOKE_TMP_ROOT/bridge-home"
+  mkdir -p "$FIXTURE_BRIDGE_HOME/agents/.claude"
+
+  # Use the real shared base so the smoke catches base-side regressions
+  # at the same time it validates the preserve contract.
+  cp "$SMOKE_REPO_ROOT/agents/.claude/settings.json" \
+    "$FIXTURE_BRIDGE_HOME/agents/.claude/settings.json"
+  # The shared renderer's `load_json` raises on a zero-byte file, so seed
+  # the overlay with an explicit empty JSON object — matches the operator
+  # contract that an absent / empty-object overlay is a no-op.
+  echo '{}' >"$FIXTURE_BRIDGE_HOME/agents/.claude/settings.local.json"
+
+  BASE="$FIXTURE_BRIDGE_HOME/agents/.claude/settings.json"
+  OVERLAY="$FIXTURE_BRIDGE_HOME/agents/.claude/settings.local.json"
+  EFFECTIVE="$FIXTURE_BRIDGE_HOME/agents/.claude/settings.effective.json"
+}
+
+invoke_renderer() {
+  python3 "$SMOKE_REPO_ROOT/bridge-hooks.py" render-shared-settings \
+    --base-settings-file "$BASE" \
+    --overlay-settings-file "$OVERLAY" \
+    --effective-settings-file "$EFFECTIVE" \
+    --launch-cmd ""
+}
+
+assert_fresh_render_has_no_user_keys() {
+  invoke_renderer >/dev/null
+
+  smoke_assert_file_exists "$EFFECTIVE" \
+    "settings.effective.json rendered by shared renderer"
+
+  local content
+  content="$(cat "$EFFECTIVE")"
+  smoke_assert_not_contains "$content" '"enabledPlugins"' \
+    "fresh render: no enabledPlugins preserved (nothing to preserve yet)"
+  smoke_assert_not_contains "$content" '"extraKnownMarketplaces"' \
+    "fresh render: no extraKnownMarketplaces preserved"
+  smoke_assert_not_contains "$content" '"skipDangerousModePermissionPrompt"' \
+    "fresh render: no skipDangerousModePermissionPrompt preserved"
+}
+
+assert_user_keys_preserved_on_rerender() {
+  # Operator edits the effective file in place — the documented per-agent
+  # override pattern this smoke is regressing against.
+  python3 - "$EFFECTIVE" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+payload = json.loads(path.read_text(encoding="utf-8"))
+payload["enabledPlugins"] = {"context7@claude-plugins-official": False}
+payload["extraKnownMarketplaces"] = {
+    "acme": {"source": {"type": "github", "repo": "acme/marketplace"}}
+}
+payload["skipDangerousModePermissionPrompt"] = True
+payload["unrelatedSetting"] = "should-not-leak-into-effective"
+path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+PY
+
+  invoke_renderer >/dev/null
+
+  local content
+  content="$(cat "$EFFECTIVE")"
+  smoke_assert_contains "$content" '"context7@claude-plugins-official": false' \
+    "enabledPlugins preserved with operator-disabled value"
+  smoke_assert_contains "$content" '"acme"' \
+    "extraKnownMarketplaces preserved with operator value"
+  smoke_assert_contains "$content" '"skipDangerousModePermissionPrompt": true' \
+    "skipDangerousModePermissionPrompt preserved"
+  smoke_assert_not_contains "$content" "unrelatedSetting" \
+    "non-allowlisted operator key dropped (allowlist is tight)"
+}
+
+assert_idempotent() {
+  local before after
+  before="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$EFFECTIVE")"
+  invoke_renderer >/dev/null
+  after="$(python3 -c "import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],'rb').read()).hexdigest())" "$EFFECTIVE")"
+  smoke_assert_eq "$before" "$after" \
+    "shared renderer is idempotent across consecutive renders"
+}
+
+main() {
+  build_fixture
+
+  smoke_run "fresh render: no preserved keys" \
+    assert_fresh_render_has_no_user_keys
+  smoke_run "operator-edited keys preserved across rerender" \
+    assert_user_keys_preserved_on_rerender
+  smoke_run "rerender is idempotent" \
+    assert_idempotent
+
+  smoke_log "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
Closes #613.

## Summary

`cmd_render_shared_settings` and `cmd_render_isolated_home_settings` in `bridge-hooks.py` were asymmetric. The isolated renderer preserved a small allowlist of operator-owned keys (`enabledPlugins`, `extraKnownMarketplaces`, `skipDangerousModePermissionPrompt`) from the prior effective file before re-merging; the shared renderer overwrote them on every call. That meant per-agent edits to `settings.effective.json` (e.g. `enabledPlugins.<plugin>=false` to disable a heavy MCP per-agent) silently reverted on every `agent restart`, `agent rerender-settings --apply`, `bridge-init.sh` install, or `agb upgrade propagate`. The operator measured 19/19 agents reverted after a single `--apply` cycle.

This PR extracts a shared `_load_preserved_user_keys(effective_path)` helper and a module-level `PRESERVED_USER_KEYS` tuple, then routes both renderers through it. Preserved keys merge **last** so user state wins over managed defaults / base / overlay. The isolated renderer keeps its two-source selection (regular `settings.json` pre-symlink-transition vs post-transition `settings.effective.json`) — only the dict-extraction is refactored. Isolated-path behavior is unchanged.

The internal `ISOLATED_HOME_PRESERVED_USER_KEYS` constant is renamed to `PRESERVED_USER_KEYS` outright (no alias kept) — it had only two references inside `bridge-hooks.py`.

## Preserved keys

- `enabledPlugins`
- `extraKnownMarketplaces`
- `skipDangerousModePermissionPrompt`

(Same allowlist the isolated renderer has been preserving since #544 PR2; deliberately tight — keys outside the allowlist are not promised to round-trip.)

## What is NOT changed

- The isolated renderer's behavior. The refactor routes the existing inline preserve block through the new helper; both source-of-truth modes (regular file pre-symlink, symlink to effective post-symlink) and the broken-symlink edge case continue to work.
- The renderer arg surface, exit codes, or any caller (`lib/bridge-hooks.sh`, `bridge-agent.sh`, `bridge-init.sh`, `bridge-upgrade.sh`).
- `settings.local.json` semantics — that file is still untouched by either renderer; the existing operator workaround (per-agent `<workdir>/.claude/settings.local.json`) remains valid.

The shared renderer also now reports `preserved_keys: [...]` in its text/shell output, mirroring the isolated renderer's diagnostic field.

## Verification

Reproducible from a fresh `BRIDGE_HOME`:

```bash
# 1. py_compile
python3 -m py_compile bridge-hooks.py

# 2. New regression smoke (added by this PR)
bash scripts/smoke/shared-settings-preserve-user-keys.sh

# 3. Existing isolated smoke must still pass (no regression)
bash scripts/smoke/isolated-settings-rendering.sh

# 4. Existing per-agent smoke (#555) still passes
bash scripts/smoke/per-agent-settings-rendering.sh
```

Manual fixture (mirrors the issue's repro section):

```bash
TMP=$(mktemp -d)
cp agents/.claude/settings.json $TMP/base.json
echo '{}' > $TMP/overlay.json

python3 bridge-hooks.py render-shared-settings \
  --base-settings-file $TMP/base.json \
  --overlay-settings-file $TMP/overlay.json \
  --effective-settings-file $TMP/effective.json \
  --launch-cmd ""

# Operator edit
python3 -c "
import json, sys
p = '$TMP/effective.json'
d = json.load(open(p))
d['enabledPlugins'] = {'context7@claude-plugins-official': False}
json.dump(d, open(p,'w'), indent=2)
"

# Rerender — operator edit must survive
python3 bridge-hooks.py render-shared-settings \
  --base-settings-file $TMP/base.json \
  --overlay-settings-file $TMP/overlay.json \
  --effective-settings-file $TMP/effective.json \
  --launch-cmd ""

# Confirm
python3 -c "import json; print(json.load(open('$TMP/effective.json'))['enabledPlugins'])"
# Expected: {'context7@claude-plugins-official': False}
```

## Test plan

- [x] py_compile bridge-hooks.py
- [x] shellcheck on touched shell files (smoke-test.sh, ci-select-smoke.sh, new smoke fixture)
- [x] isolated-settings-rendering.sh — PASS (regression check; isolated path unchanged)
- [x] per-agent-settings-rendering.sh — PASS
- [x] shared-settings-preserve-user-keys.sh (new) — PASS
- [x] Manual Python fixture covering both renderers under `tempfile.TemporaryDirectory` — PASS

## CI smoke wiring

The new fixture is added to:
- `scripts/smoke-test.sh` (after `per-agent-settings-rendering`)
- `scripts/ci-select-smoke.sh` `add_all_required_static` set
- `scripts/ci-select-smoke.sh` `bridge-hooks.py | hooks/* | lib/bridge-hooks.sh` selector

So any future regression on the shared-renderer preserve contract is caught alongside the existing isolated-renderer guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)