### PR TITLE
feat(isolation): v0.8.0 T1 — layout resolver hard-cut, v2-only runtime

### DIFF
--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -79,9 +79,18 @@
 # 1. opt-in flag and path variables
 # ---------------------------------------------------------------------------
 
-# Layout selector. Legacy installs leave this empty/unset. New installs and
-# migrated installs set BRIDGE_LAYOUT=v2. Tests may set it to "v2" via env.
-BRIDGE_LAYOUT="${BRIDGE_LAYOUT:-legacy}"
+# Layout selector. v0.8.0 hard-cut: the only accepted value is `v2`. The
+# resolver in lib/bridge-layout-resolver.sh fail-fasts on anything else
+# (including unset / legacy / v1 / arbitrary strings) BEFORE this module
+# is sourced, so by the time we read BRIDGE_LAYOUT here it is either
+# `v2` or the process has already exited via bridge_die. We deliberately
+# do NOT default to `legacy` anymore — the legacy-fallback default was
+# the v1 ACL-isolation entry point and v0.8.0 removed v1.
+#
+# Tests that source this file standalone (without going through
+# bridge-lib.sh + the resolver) must export BRIDGE_LAYOUT=v2 themselves;
+# leaving it unset is no longer a valid runtime state.
+BRIDGE_LAYOUT="${BRIDGE_LAYOUT:-}"
 
 # Data root for v2 layout. When unset, v2 helpers no-op (legacy mode).
 # Default suggestion when an operator opts in: /srv/agent-bridge.
@@ -103,7 +112,15 @@ BRIDGE_AGENT_GROUP_PREFIX="${BRIDGE_AGENT_GROUP_PREFIX:-ab-agent-}"
 
 bridge_isolation_v2_active() {
   # Returns 0 (active) when BRIDGE_LAYOUT=v2 and BRIDGE_DATA_ROOT is set.
-  # All v2 helpers should gate on this so they no-op for legacy installs.
+  #
+  # v0.8.0 hard-cut: this is now an invariant/status helper, not a
+  # runtime branching primitive. The layout resolver fail-fasts at
+  # startup if v2 is not active, so any code path that reaches a
+  # v2-helper call site is already guaranteed to be running under v2.
+  # Callers should treat a `false` return here as a programmer error
+  # surface (e.g. status reporting, smoke tests sourcing the module
+  # standalone), not a signal to fall back to v1/ACL behavior — the
+  # v1/ACL code paths were removed.
   [[ "$BRIDGE_LAYOUT" == "v2" ]] || return 1
   [[ -n "$BRIDGE_DATA_ROOT" ]] || return 1
   return 0

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -114,15 +114,6 @@ bridge_layout_resolver_validate_env() {
       # No env override at all — let marker / evidence flow handle it.
       return 1
       ;;
-    legacy)
-      # legacy override — clear any stale v2-derived roots so they don't
-      # leak into child env.
-      if [[ -n "$data_root" ]]; then
-        unset BRIDGE_DATA_ROOT
-      fi
-      BRIDGE_LAYOUT_SOURCE="env"
-      return 0
-      ;;
     v2)
       if [[ -z "$data_root" ]]; then
         # Partial — ignore the v2 hint, fall through.
@@ -140,12 +131,22 @@ bridge_layout_resolver_validate_env() {
       BRIDGE_LAYOUT_SOURCE="env"
       return 0
       ;;
+    legacy|v1)
+      # v0.8.0 hard-cut: ACL-based isolation (v1) was removed. The only
+      # accepted BRIDGE_LAYOUT value is now `v2`. Fail-fast so operators
+      # who scripted `BRIDGE_LAYOUT=legacy` (or `=v1`) discover the
+      # required migration immediately instead of silently running on a
+      # half-removed code path.
+      bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
+  current_layout=${layout}
+  remediation: run \`agent-bridge upgrade --apply\` to migrate, or roll back to v0.7.x.
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
+      ;;
     *)
-      bridge_warn "BRIDGE_LAYOUT='$layout' is invalid (expected 'legacy' or 'v2') — ignoring env override"
-      BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV="BRIDGE_LAYOUT"
-      unset BRIDGE_LAYOUT
-      [[ -z "$data_root" ]] || unset BRIDGE_DATA_ROOT
-      return 1
+      bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
+  current_layout=${layout}
+  remediation: unset BRIDGE_LAYOUT or set BRIDGE_LAYOUT=v2 (only accepted value).
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
       ;;
   esac
 }
@@ -187,9 +188,17 @@ bridge_resolve_layout() {
         BRIDGE_LAYOUT_SOURCE="marker"
         return 0
       fi
-      if [[ "${BRIDGE_LAYOUT:-}" == "legacy" ]]; then
-        BRIDGE_LAYOUT_SOURCE="marker"
-        return 0
+      if [[ "${BRIDGE_LAYOUT:-}" == "legacy" || "${BRIDGE_LAYOUT:-}" == "v1" ]]; then
+        # v0.8.0 hard-cut: a marker pinning the install to the legacy/v1
+        # layout is no longer a valid runtime state. The migration tool
+        # (T3) rewrites the marker to v2; surface the same remediation as
+        # the env-override path so operators don't silently run on a
+        # half-removed code path.
+        bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
+  current_layout=${BRIDGE_LAYOUT}
+  marker=${marker_path}
+  remediation: run \`agent-bridge upgrade --apply\` to migrate, or roll back to v0.7.x.
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
       fi
     fi
     # Marker is on disk but failed validation — bridge_warn already fired
@@ -201,24 +210,34 @@ bridge_resolve_layout() {
   # Step 3/4 — no env, no valid marker. Evidence-based classification.
   if bridge_layout_resolver_has_existing_evidence; then
     [[ -n "${BRIDGE_LAYOUT_SOURCE:-}" ]] || BRIDGE_LAYOUT_SOURCE="missing-marker(existing)"
-    # Existing markerless install is legacy by invariant.
-    BRIDGE_LAYOUT="legacy"
-    return 0
+    # v0.8.0 hard-cut: existing markerless installs were previously pinned
+    # to the legacy layout. With v1 removed, there is no longer a runtime
+    # path that can serve them — the operator must run the migration tool
+    # exactly once. Operators upgrading from v0.7.x will hit this on the
+    # first invocation after the upgrade, and the migration tool (T3)
+    # writes the v2 marker so subsequent boots take the marker branch.
+    bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
+  current_layout=markerless(existing-install)
+  remediation: run \`agent-bridge upgrade --apply\` to migrate this install to v2, or roll back to v0.7.x.
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
   fi
 
-  # Fresh install candidate. BRIDGE_LAYOUT is intentionally NOT set to v2 —
-  # bridge_isolation_v2_active must remain false until `agent-bridge init`
-  # writes the marker. If we already classified the prior marker as
-  # invalid-marker(fallback), preserve that source so status output
-  # honestly reports the bad marker instead of pretending the install is
-  # fresh; the v2-active state is the same either way.
+  # Fresh install candidate. Pre-v0.8.0 this branch left BRIDGE_LAYOUT
+  # unset until `agent-bridge init` wrote the marker; with v1 removed,
+  # the only honest behavior is to refuse and point the operator at the
+  # migration / init tool. We still set BRIDGE_DEFAULT_DATA_ROOT so the
+  # init helper can compute its default before bridge_die fires —
+  # callers that legitimately need to inspect the unwritten layout
+  # (e.g. `agent-bridge init` itself) gate on BRIDGE_LAYOUT_SOURCE
+  # before invoking the resolver in fail-fast mode.
   if [[ "${BRIDGE_LAYOUT_SOURCE:-}" != "invalid-marker(fallback)" ]]; then
     BRIDGE_LAYOUT_SOURCE="fresh-install-candidate"
   fi
   BRIDGE_DEFAULT_DATA_ROOT="${BRIDGE_HOME:-$HOME/.agent-bridge}/data"
-  # BRIDGE_LAYOUT stays whatever bridge-isolation-v2.sh defaults it to
-  # (legacy). Do not export v2 here.
-  return 0
+  bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
+  current_layout=markerless(${BRIDGE_LAYOUT_SOURCE})
+  remediation: run \`agent-bridge upgrade --apply\` to migrate this install to v2, or roll back to v0.7.x.
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Track 1 of 7 for the v0.8.0 isolation-v2 migration release. v0.8.0 removes ACL-based isolation (v1) entirely and standardizes on POSIX group + setgid isolation (v2). T1 establishes the v2-only invariant in the layout resolver so subsequent tracks (T2 v1 helper delete, T3 migration tool, T4 #583 smoke, T5 rollback hatch, T7 docs+release) can rely on every reachable runtime path already being under v2.

Spec context: see the synthesized v0.8.0 plan (`v080-spec-synthesis.md`) — Q1 ("Flag handling: (c) major boundary — `BRIDGE_LAYOUT=v1`/`legacy` fail-fast at start; `bridge_isolation_v2_active` retained as invariant/status helper only").

## What changes

### `lib/bridge-layout-resolver.sh`

Five paths flipped from "accept and pin to legacy" to "fail-fast with migration remediation":

1. Env override `BRIDGE_LAYOUT=legacy` (and `=v1`).
2. Env override `BRIDGE_LAYOUT=<arbitrary>`.
3. Marker file declaring `BRIDGE_LAYOUT=legacy` / `v1`.
4. Existing markerless install (resolver detects evidence: `tasks.db`, `agent-roster.local.sh`, populated `agents/`, etc.).
5. Fresh-install-candidate (no env, no marker, no evidence).

All five paths now call `bridge_die` with a uniform remediation message pointing at `agent-bridge upgrade --apply` (which T3 will wire up) or `roll back to v0.7.x`.

### `lib/bridge-isolation-v2.sh`

- Removed the `BRIDGE_LAYOUT="${BRIDGE_LAYOUT:-legacy}"` default. The legacy default was the v1 ACL fallback entry point; with v1 gone, the module no longer auto-defaults. The resolver fail-fasts upstream so by the time this module is sourced via `bridge-lib.sh`, `BRIDGE_LAYOUT` is either `v2` or the process has already exited.
- Updated `bridge_isolation_v2_active` doc-comment to reflect its new role as invariant/status helper, not runtime branching primitive. Function body unchanged so sibling tracks (status reporting, standalone-test invariant probes) keep their existing semantics.

## Remediation message format

Identical wording across all five fail paths:

```
error: Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
  current_layout=<v1|legacy|markerless(existing-install)|markerless(fresh-install-candidate)|garbage>
  [marker=…  when applicable]
  remediation: run `agent-bridge upgrade --apply` to migrate, or roll back to v0.7.x.
  background: ACL-based isolation (v1) was removed in v0.8.0. See
    https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md
    for details.
```

## What is NOT in this PR

- v1 helper file delete (`lib/bridge-isolation.sh`) → **T2** (separate PR).
- ACL repair preflight in `bridge-start.sh:294-306` → **T2**.
- `agent-bridge upgrade --apply` migration tool implementation → **T3**.
- Resolver-bypass mechanism that lets `agent-bridge upgrade`/`init`/`migrate` be invokable on a markerless install → **T3**.
- Per-agent migration markers, Darwin group helpers, `dseditgroup` → **T3**.
- Smoke test fixture updates (every `mktemp -d` BRIDGE_HOME fixture now hits the new fail-fast and needs a v2 marker pre-write) → expected to land alongside T2/T3 since those tracks already touch the test surface.
- `BRIDGE_DISABLE_ISOLATION=1` rollback hatch → **T5**.
- VERSION bump + CHANGELOG entry + docs updates → **T7**.

This PR also intentionally does NOT auto-close any issue. v0.8.0 is a multi-track release; closure happens at T7 with the release commit.

## Test plan

- [x] `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh` clean
- [x] `shellcheck *.sh agent-bridge agb lib/*.sh` clean
- [x] Negative case `BRIDGE_LAYOUT=v1` against `bridge-start.sh --list` → exit 1 with `isolation-v2` + `agent-bridge upgrade --apply` in the error
- [x] Negative case `BRIDGE_LAYOUT=legacy` → same fail-fast
- [x] Negative case `BRIDGE_LAYOUT=garbage` → fail-fast with "set BRIDGE_LAYOUT=v2 (only accepted value)" remediation
- [x] Markerless install (no env, fresh `BRIDGE_HOME`/state) → fail-fast with `current_layout=markerless(fresh-install-candidate)` and `agent-bridge upgrade --apply` remediation
- [x] Markerless+roster install (existing-evidence path) → fail-fast with `current_layout=markerless(existing-install)`
- [x] `tests/isolation-v2-primitives/smoke.sh` (PR-A primitives test) — passes through the legacy-default and v2-active sections; the `chgrp_setgid_recursive: dir mode unexpected: 750` later assertion is a pre-existing macOS quirk unrelated to T1
- [ ] Positive case (marker-on-disk + `BRIDGE_LAYOUT=v2`): not exercisable on the local macOS workstation because the marker validator at `lib/bridge-marker-bootstrap.sh:39` uses GNU `stat -c '%u'` which BSD stat rejects. This is a pre-existing flake and unrelated to T1; should be exercised on the Linux smoke fleet during T4
- [ ] `./scripts/smoke-test.sh` regresses at every fixture that does `BRIDGE_HOME="$(mktemp -d)"` then invokes the runtime without pre-writing a v2 marker. This is the **expected** post-T1 behavior — the brief explicitly notes "Operators upgrading from v0.7.x will hit this exactly once" — but the fixtures need to be updated before smoke is green again. Surfacing this as a T1 follow-up to coordinate with T2/T3 test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)