### PR TITLE
fix(isolation): bridge_linux_sudo_root only sudo on Linux (#620)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -573,6 +573,18 @@ bridge_agent_linux_env_file() {
 }
 
 bridge_linux_sudo_root() {
+  # Linux-user isolation only escalates via sudo on Linux. On other
+  # platforms (notably macOS), the helper falls through to a direct
+  # invocation as the controller user. Without this guard `sudo -n` runs
+  # under the calling user's policy and silently fails non-interactively
+  # on hosts with no passwordless sudoers entry — which is the macOS
+  # default — so callers like `agent delete --purge-home` would log
+  # `best-effort rm failed` and leak paths. Issue #620.
+  if [[ "$(uname -s)" != "Linux" ]]; then
+    "$@"
+    return $?
+  fi
+
   if [[ "$(id -u)" == "0" ]]; then
     "$@"
     return $?


### PR DESCRIPTION
Closes #620.

## Problem

`bridge_linux_sudo_root` unconditionally took the `sudo -n "$@"` branch on every non-root host, regardless of platform. The original guard relied on callers probing `command -v bridge_linux_sudo_root`, which **always** matches once the function is loaded — so on macOS the helper still drove `sudo -n` even though the default macOS sudoers policy has no passwordless entry, and the call fails non-interactively.

Operator-visible symptom: `agent delete --purge-home` returns rc=0 but leaves the agent home directory on disk, with `best-effort rm failed` warning in logs. Surfaced during PR #615 r3 verification when the new doctor self-assertion caught the leak.

Linux review hosts didn't see the bug because their migration sudoers entry whitelists the relevant commands; macOS hosts have no such entry by default.

## Fix

Add a runtime `uname -s` short-circuit at the top of `bridge_linux_sudo_root` so non-Linux platforms fall through to direct invocation as the controller user. Linux semantics are preserved verbatim:

- Linux + root → direct invocation (unchanged)
- Linux + non-root + passwordless sudo → `sudo -n "$@"` (unchanged)
- Linux + non-root + no sudo → `bridge_die "linux-user isolation requires sudo"` (unchanged)
- **non-Linux (macOS, etc.) → direct invocation** (NEW; previously took sudo branch and failed)

This is the minimum decisive change. Caller logic at `bridge-agent.sh:2987` (`agent delete --purge-home`) and `bridge-agent.sh:3277/3286` (`agent retire`) was audited and is correct under the new semantics — the explicit `if command -v bridge_linux_sudo_root …` guards still hold (function is always defined now), but the function itself now no-ops the sudo branch on macOS.

## Verification

### macOS reproduction — before/after

```bash
# Setup
rm -rf /tmp/bh-620 && mkdir -p /tmp/bh-620/agents/test-fixture/home

# BEFORE (mimicking pre-fix function):
bridge_linux_sudo_root rm -rf -- /tmp/bh-620/agents/test-fixture
# → "sudo: a password is required", rc=1, directory remains.

# AFTER (with this PR sourced):
bridge_linux_sudo_root rm -rf -- /tmp/bh-620/agents/test-fixture
# → rc=0, directory removed.
```

Full call-site replay (`bridge-agent.sh:2987` shape) on macOS:
```
[before] exists=yes
[after] exists=no
```
No `best-effort rm failed` warning emitted.

### Static analysis

- `bash -n lib/bridge-agents.sh` (Homebrew bash 4) — pass
- `shellcheck lib/bridge-agents.sh agent-bridge agb` — pass (no new findings)
- `./scripts/smoke-test.sh` — same pass set as `main`; the pre-existing `agent-env.sh from ephemeral controller path` failure reproduces unchanged on the base branch and is unrelated to this fix.

### Linux behavior

Unchanged by inspection: the new short-circuit only fires when `uname -s != Linux`. The existing Linux branches (root passthrough, non-root sudo, no-sudo `bridge_die`) are untouched.

## Notes

- v0.7.8 will pick this up via Track 6; no `VERSION`/`CHANGELOG.md` bump in this PR.
- macOS operators who previously saw `agent delete --purge-home` exit 0 with the home dir still present should now see the directory actually removed.