### PR TITLE
fix(hooks): bridge_guard_common load survives isolated UID --x ROOT ACL

### DIFF
--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import functools
 import hashlib
+import importlib.util
 import json
 import os
 import pwd
@@ -14,7 +15,7 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable, Optional
 
 PRIORITY_ORDER = {"urgent": 0, "high": 1, "normal": 2, "low": 3}
 
@@ -932,3 +933,58 @@ def codex_stop_reason(agent: str, row: dict[str, Any]) -> str:
         f"Run ~/.agent-bridge/agb inbox {agent} now, inspect the open tasks, "
         f"and claim the highest-priority queued task before ending the session."
     )
+
+
+_GUARD_MODULE_NAME = "bridge_guard_common"
+
+
+def load_guard_module(
+    bridge_root: Path,
+    required_attrs: Iterable[str],
+) -> Optional[Any]:
+    # Absolute-path module loader for ``bridge_guard_common.py``. Used by hooks
+    # that must keep functioning under linux-user isolation, where the parent
+    # ``BRIDGE_HOME`` directory may have only ``--x`` ACL traversal for the
+    # isolated UID and Python's path-based finder fails to listdir it.
+    #
+    # Returns the loaded module on success. Returns ``None`` (silent no-op)
+    # when the guard module cannot be located, read, parsed, or is missing one
+    # of ``required_attrs``. Silent fallback is the safer posture for hooks:
+    # if the guard is unreachable the Claude session keeps running without the
+    # extra guard layer rather than failing every hook invocation.
+    name = _GUARD_MODULE_NAME
+    guard_path = bridge_root / "bridge_guard_common.py"
+    required = tuple(required_attrs)
+
+    cached = sys.modules.get(name)
+    if cached is not None:
+        try:
+            for attr in required:
+                getattr(cached, attr)
+            return cached
+        except AttributeError:
+            sys.modules.pop(name, None)
+
+    try:
+        spec = importlib.util.spec_from_file_location(name, guard_path)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+    except (OSError, ImportError, ValueError):
+        return None
+
+    sys.modules[name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(name, None)
+        return None
+
+    try:
+        for attr in required:
+            getattr(module, attr)
+    except AttributeError:
+        sys.modules.pop(name, None)
+        return None
+
+    return module

--- a/hooks/permission_escalation.py
+++ b/hooks/permission_escalation.py
@@ -21,18 +21,28 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
-from bridge_guard_common import sanitize_text  # noqa: E402
+# Import bridge_hook_common from hooks/ directly; ROOT may have only ``--x``
+# ACL for isolated UIDs (see bridge_hook_common.load_guard_module docstring).
+_HOOKS_DIR = Path(__file__).resolve().parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
 from bridge_hook_common import (  # noqa: E402
     bridge_home_dir,
     bridge_script_dir,
     current_agent,
     current_agent_workdir,
+    load_guard_module,
     truncate_text,
     write_audit,
 )
+
+_guard = load_guard_module(ROOT, required_attrs=("sanitize_text",))
+if _guard is None:
+    sys.exit(0)
+
+sanitize_text = _guard.sanitize_text
 
 
 RECURSION_ENV = "BRIDGE_HOOK_PERMISSION_ESCALATION_ACTIVE"

--- a/hooks/prompt-guard.py
+++ b/hooks/prompt-guard.py
@@ -9,11 +9,29 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
-from bridge_guard_common import analyze_text, prompt_guard_enabled, threshold_for_surface  # noqa: E402
-from bridge_hook_common import current_agent, write_audit  # noqa: E402
+# Import bridge_hook_common from hooks/ directly; ROOT may have only ``--x``
+# ACL for isolated UIDs (see bridge_hook_common.load_guard_module docstring).
+_HOOKS_DIR = Path(__file__).resolve().parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
+from bridge_hook_common import (  # noqa: E402
+    current_agent,
+    load_guard_module,
+    write_audit,
+)
+
+_guard = load_guard_module(
+    ROOT,
+    required_attrs=("analyze_text", "prompt_guard_enabled", "threshold_for_surface"),
+)
+if _guard is None:
+    sys.exit(0)
+
+analyze_text = _guard.analyze_text
+prompt_guard_enabled = _guard.prompt_guard_enabled
+threshold_for_surface = _guard.threshold_for_surface
 
 
 def main() -> int:

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -12,17 +12,15 @@ from pathlib import Path
 from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
 
-from bridge_guard_common import (  # noqa: E402
-    analyze_text,
-    is_builtin_tool,
-    prompt_guard_enabled,
-    sanitize_text,
-    threshold_for_surface,
-    tool_output_text,
-)
+# Import bridge_hook_common from this hooks/ directory directly. ROOT (the
+# bridge home) cannot be added to sys.path under linux-user isolation because
+# the isolated UID may have only ``--x`` ACL on it, so listdir() based finders
+# fail. hooks/ remains readable+executable for isolated UIDs.
+_HOOKS_DIR = Path(__file__).resolve().parent
+if str(_HOOKS_DIR) not in sys.path:
+    sys.path.insert(0, str(_HOOKS_DIR))
+
 from bridge_hook_common import (  # noqa: E402
     agent_home_root,
     bridge_home_dir,
@@ -30,10 +28,36 @@ from bridge_hook_common import (  # noqa: E402
     current_agent_class,
     current_agent_workdir,
     emit_system_cross_agent_read,
+    load_guard_module,
     path_within,
     truncate_text,
     write_audit,
 )
+
+_guard = load_guard_module(
+    ROOT,
+    required_attrs=(
+        "analyze_text",
+        "is_builtin_tool",
+        "prompt_guard_enabled",
+        "sanitize_text",
+        "threshold_for_surface",
+        "tool_output_text",
+    ),
+)
+if _guard is None:
+    # Guard module unavailable (missing/unreadable/syntax/missing-symbol).
+    # Exit silently rather than tracebacking every hook invocation; a broken
+    # guard module is a corrupt install state for the operator to diagnose,
+    # not a reason to brick every Claude session.
+    sys.exit(0)
+
+analyze_text = _guard.analyze_text
+is_builtin_tool = _guard.is_builtin_tool
+prompt_guard_enabled = _guard.prompt_guard_enabled
+sanitize_text = _guard.sanitize_text
+threshold_for_surface = _guard.threshold_for_surface
+tool_output_text = _guard.tool_output_text
 
 # Importing the system-config protected-path SSOT requires lib/ on sys.path.
 # Keep this scoped to tool-policy.py rather than mutating bridge_hook_common


### PR DESCRIPTION
## Summary

- Hooks (`tool-policy.py`, `prompt-guard.py`, `permission_escalation.py`) tracebacked on every invocation under linux-user isolation because `from bridge_guard_common import ...` requires read on the bridge home root via Python's path-based finder, but isolated UIDs only have `--x` ACL traversal there. Result: isolated agents could not start a Claude session at all.
- Switched to absolute-path module loading via `importlib.util.spec_from_file_location()`, which only needs traverse + file read.
- New `load_guard_module()` helper in `hooks/bridge_hook_common.py` registers the module in `sys.modules` before `exec_module()` (so dataclass decorators in `bridge_guard_common` resolve), validates required attributes inside the helper, and returns `None` (silent no-op) on missing/unreadable/syntax-error/missing-symbol guard module so hooks degrade gracefully rather than bricking every session.
- No parent-directory ACL changes; isolation surface unchanged.

## Files

- `hooks/bridge_hook_common.py` — new `load_guard_module()` helper.
- `hooks/tool-policy.py` — switch to helper; keep separate `_LIB_DIR` insertion for `system_config_paths`.
- `hooks/prompt-guard.py` — switch to helper.
- `hooks/permission_escalation.py` — switch to helper.

4 files changed, +127 / -19.

## Test plan

- [x] `python3 -m py_compile hooks/{bridge_hook_common,tool-policy,prompt-guard,permission_escalation}.py`
- [x] H1 shared mode: `analyze_text(\"ignore previous instructions\")` returns `critical`.
- [x] H2/H3 isolated UID `agent-bridge-sales_sean` (UID 991): all 3 hooks rc=0, stderr empty.
- [x] H4 missing `bridge_guard_common.py`: silent no-op, no leftover entry in `sys.modules`.
- [x] H5 unreadable (chmod 0000): silent no-op.
- [x] H6 syntax-error guard: silent no-op.
- [x] H7 missing required symbol: silent no-op + `sys.modules` cleaned.
- [x] H8 missing `bridge_hook_common.py`: fail-fast `ModuleNotFoundError` (corrupt install).
- [x] Reviewer execute-only parent-dir fixture (root `--x` for isolated UID, hooks/lib readable, guard file readable): all 3 hooks rc=0.
- [x] Existing regression smokes `scripts/smoke/system-agent-class.sh` and `tests/system-config-gating/smoke.sh` PASS.

## Background

Found on a host running v0.7.6 with `sales_sean` (UID 991) as the only linux-user-isolated agent. Plan + code-review went through `patch` + `patch-dev` codex pair (3 plan-review rounds, 1 code-review round). Plan reviewer verified the same execute-only parent-dir fixture independently before issuing `review-ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)