### PR TITLE
feat(cron): add payload.kind=shell runner

### DIFF
--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -138,7 +138,7 @@ def rel_for_output(path_value: str) -> str:
     return str(path)
 
 
-def read_json(path: Path) -> dict[str, Any]:
+def read_json(path: Path) -> Any:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
@@ -1836,27 +1836,40 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("runner_error: request_artifact_tampered")
         return 1
 
-    request: dict[str, Any]
+    request: Any
     if route == "shell":
         try:
             request = read_json(request_file)
-        except json.JSONDecodeError as exc:
-            error_message = f"request_artifact_corrupted: {exc}"
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            error_message = f"request_artifact_corrupted: {type(exc).__name__}"
             write_shell_terminal_error(
                 request_file,
-                runner_error="request_artifact_corrupted",
+                runner_error=error_message,
+                summary=f"{error_message}: {exc}",
+                run_id=run_dir_id(request_file.parent),
+            )
+            print("status: error")
+            print(f"run_id: {run_dir_id(request_file.parent)}")
+            print("engine: shell")
+            print(f"runner_error: {error_message}")
+            return 1
+        if not isinstance(request, dict):
+            error_message = "request_artifact_corrupted: non_dict_top_level"
+            write_shell_terminal_error(
+                request_file,
+                runner_error=error_message,
                 summary=error_message,
                 run_id=run_dir_id(request_file.parent),
             )
             print("status: error")
             print(f"run_id: {run_dir_id(request_file.parent)}")
             print("engine: shell")
-            print("runner_error: request_artifact_corrupted")
+            print(f"runner_error: {error_message}")
             return 1
     else:
         request = read_json(request_file)
 
-    if is_shell_request_payload(request):
+    if isinstance(request, dict) and is_shell_request_payload(request):
         if route != "shell":
             error_message = "request_artifact_tampered: shell request artifacts are not controller-private"
             write_shell_terminal_error(

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -4,10 +4,14 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
+import pwd
 import shlex
 import shutil
+import signal
+import stat
 import subprocess
 import sys
 import time
@@ -106,6 +110,10 @@ COMMON_BIN_DIRS = [
     Path("/opt/homebrew/bin"),
     Path("/usr/local/bin"),
 ]
+SHELL_RESULT_STATUS_VALUES = {"success", "error"}
+SHELL_PAYLOAD_ENV_PREFIXES = ("POLL_", "SCRIPT_")
+SHELL_PROTECTED_ENV_EXACT = {"HOME", "PATH"}
+SHELL_PROTECTED_ENV_PREFIXES = ("BRIDGE_", "CRON_")
 
 
 def now_iso() -> str:
@@ -142,6 +150,231 @@ def write_json(path: Path, payload: dict[str, Any]) -> None:
 def write_text(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
+
+
+def run_dir_id(run_dir: Path) -> str:
+    return run_dir.name
+
+
+def mode_has_group_or_other_write(path: Path) -> bool:
+    try:
+        mode = path.stat().st_mode
+    except OSError:
+        return True
+    return bool(mode & (stat.S_IWGRP | stat.S_IWOTH))
+
+
+def path_acl_has_write_exposure(path: Path, *, include_default: bool = True) -> bool:
+    getfacl = shutil.which("getfacl")
+    if not getfacl:
+        return False
+    try:
+        completed = subprocess.run(
+            [getfacl, "-cp", str(path)],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except OSError:
+        return False
+    if completed.returncode != 0:
+        return False
+    for raw_line in completed.stdout.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        fields = line.split(":")
+        is_default = fields[0] == "default"
+        if is_default and not include_default:
+            continue
+        if is_default:
+            fields = fields[1:]
+        if len(fields) < 3:
+            continue
+        tag, qualifier, perms = fields[0], fields[1], fields[2]
+        effective = perms
+        if "#effective:" in line:
+            effective = line.rsplit("#effective:", 1)[1].strip()
+        if tag == "user" and qualifier == "":
+            continue
+        if tag in {"user", "group", "mask", "other"} and "w" in effective:
+            if tag == "mask":
+                continue
+            return True
+    return False
+
+
+def validate_shell_request_artifacts(request_file: Path) -> tuple[bool, str | None]:
+    run_dir = request_file.parent
+    controller_uid = os.getuid()
+    for path in (run_dir, request_file):
+        try:
+            st = path.stat()
+        except OSError as exc:
+            return False, f"request_artifact_tampered: stat failed for {path}: {exc}"
+        if st.st_uid != controller_uid:
+            return False, f"request_artifact_tampered: owner uid mismatch for {path}"
+        if mode_has_group_or_other_write(path):
+            return False, f"request_artifact_tampered: group/other writable mode on {path}"
+        if path_acl_has_write_exposure(path, include_default=path.is_dir()):
+            return False, f"request_artifact_tampered: ACL write exposure on {path}"
+    return True, None
+
+
+def truncate_output(data: bytes, cap: int) -> tuple[str, bool]:
+    if len(data) <= cap:
+        return data.decode("utf-8", errors="replace"), False
+    truncated = data[:cap].decode("utf-8", errors="replace")
+    return truncated + f"\n[agent-bridge] output truncated at {cap} bytes\n", True
+
+
+def cron_state_dir_from_env(run_dir: Path) -> Path:
+    value = os.environ.get("BRIDGE_CRON_STATE_DIR")
+    if value:
+        return Path(value).expanduser().resolve()
+    return run_dir.parent.parent
+
+
+def shell_payload_env(payload: dict[str, Any]) -> dict[str, str]:
+    env = payload.get("env") or {}
+    if not isinstance(env, dict):
+        raise ValueError("payload.env must be an object")
+    clean: dict[str, str] = {}
+    for raw_key, raw_value in env.items():
+        key = str(raw_key)
+        if key in SHELL_PROTECTED_ENV_EXACT or key.startswith(SHELL_PROTECTED_ENV_PREFIXES):
+            raise ValueError(f"protected env var cannot be set by shell cron payload: {key}")
+        if not key.startswith(SHELL_PAYLOAD_ENV_PREFIXES):
+            raise ValueError(f"shell cron env var must start with POLL_ or SCRIPT_: {key}")
+        clean[key] = str(raw_value)
+    return clean
+
+
+def shell_command_for_execution(execution: dict[str, Any], env: dict[str, str], script: str, args: list[str]) -> list[str]:
+    os_user = str(execution.get("os_user") or "")
+    uid = int(execution.get("uid"))
+    gid = int(execution.get("gid"))
+    env_parts = [f"{key}={value}" for key, value in sorted(env.items())]
+    current_uid = os.geteuid()
+    try:
+        current_name = pwd.getpwuid(current_uid).pw_name
+    except KeyError:
+        current_name = ""
+    if current_uid == uid and (not os_user or os_user == current_name):
+        return ["env", "-i", *env_parts, script, *args]
+    sudo = shutil.which("sudo")
+    if sudo and os_user:
+        return [sudo, "-n", "-H", "-u", os_user, "env", "-i", *env_parts, script, *args]
+    setpriv = shutil.which("setpriv")
+    if setpriv:
+        return [setpriv, "--reuid", str(uid), "--regid", str(gid), "--init-groups", "env", "-i", *env_parts, script, *args]
+    raise RuntimeError("no supported UID drop helper found (sudo or setpriv)")
+
+
+def redact_shell_command(command: list[str]) -> list[str]:
+    redacted: list[str] = []
+    for part in command:
+        if "=" in part and not part.startswith(("/", "./")):
+            key = part.split("=", 1)[0]
+            if key and all(ch.isalnum() or ch == "_" for ch in key):
+                redacted.append(f"{key}=<redacted>")
+                continue
+        redacted.append(part)
+    return redacted
+
+
+def write_shell_status(
+    status_file: Path,
+    *,
+    run_id: str,
+    state: str,
+    request_file: Path,
+    result_file: Path,
+    started_at: str | None = None,
+    completed_at: str | None = None,
+    duration_ms: int | None = None,
+    exit_code: int | None = None,
+    runner_error: str | None = None,
+) -> None:
+    payload: dict[str, Any] = {
+        "run_id": run_id,
+        "state": state,
+        "engine": "shell",
+        "updated_at": now_iso(),
+        "request_file": str(request_file),
+        "result_file": str(result_file),
+        "delivery_intent": "silent",
+        "reporting_decision": "silent",
+    }
+    if started_at:
+        payload["started_at"] = started_at
+    if completed_at:
+        payload["completed_at"] = completed_at
+    if duration_ms is not None:
+        payload["duration_ms"] = duration_ms
+    if exit_code is not None:
+        payload["exit_code"] = exit_code
+    if runner_error:
+        payload["runner_error"] = runner_error
+        payload["error"] = runner_error
+    write_json(status_file, payload)
+
+
+def write_shell_result(
+    result_file: Path,
+    *,
+    run_id: str,
+    status: str,
+    summary: str,
+    request_file: Path,
+    stdout_log: Path,
+    stderr_log: Path,
+    started_at: str | None = None,
+    completed_at: str | None = None,
+    duration_ms: int | None = None,
+    exit_code: int | None = None,
+    runner_error: str | None = None,
+    command: list[str] | None = None,
+    stdout_truncated: bool = False,
+    stderr_truncated: bool = False,
+) -> None:
+    if status not in SHELL_RESULT_STATUS_VALUES:
+        status = "error"
+    payload: dict[str, Any] = {
+        "run_id": run_id,
+        "engine": "shell",
+        "status": status,
+        "summary": summary,
+        "findings": [],
+        "actions_taken": [],
+        "needs_human_followup": False,
+        "recommended_next_steps": [],
+        "artifacts": [str(stdout_log), str(stderr_log)],
+        "confidence": "high" if status == "success" else "medium",
+        "delivery_intent": "silent",
+        "reporting_decision": "silent",
+        "request_file": str(request_file),
+        "stdout_log": str(stdout_log),
+        "stderr_log": str(stderr_log),
+        "stdout_truncated": stdout_truncated,
+        "stderr_truncated": stderr_truncated,
+    }
+    if started_at:
+        payload["started_at"] = started_at
+    if completed_at:
+        payload["completed_at"] = completed_at
+    if duration_ms is not None:
+        payload["duration_ms"] = duration_ms
+    if exit_code is not None:
+        payload["child_exit_code"] = exit_code
+    if runner_error:
+        payload["runner_error"] = runner_error
+    if command:
+        safe_command = redact_shell_command(command)
+        payload["command"] = safe_command
+        payload["command_pretty"] = " ".join(shlex.quote(part) for part in safe_command)
+    write_json(result_file, payload)
 
 
 def normalize_result(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1260,6 +1493,241 @@ def write_status(
     write_json(status_file, payload)
 
 
+def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Namespace) -> int:
+    run_dir = request_file.parent
+    run_id = str(request.get("run_id") or run_dir_id(run_dir))
+    result_file = (run_dir / "result.json").resolve()
+    status_file = (run_dir / "status.json").resolve()
+    stdout_log = (run_dir / "stdout.log").resolve()
+    stderr_log = (run_dir / "stderr.log").resolve()
+
+    if args.dry_run:
+        print("status: dry_run")
+        print(f"run_id: {run_id}")
+        print("engine: shell")
+        print(f"request_file: {rel_for_output(str(request_file))}")
+        print(f"result_file: {rel_for_output(str(result_file))}")
+        print(f"status_file: {rel_for_output(str(status_file))}")
+        return 0
+
+    trusted, trust_error = validate_shell_request_artifacts(request_file)
+    if not trusted:
+        error_message = trust_error or "request_artifact_tampered"
+        completed_at = now_iso()
+        write_text(stdout_log, "")
+        write_text(stderr_log, error_message + "\n")
+        write_shell_result(
+            result_file,
+            run_id=run_id,
+            status="error",
+            summary=error_message,
+            request_file=request_file,
+            stdout_log=stdout_log,
+            stderr_log=stderr_log,
+            completed_at=completed_at,
+            exit_code=1,
+            runner_error="request_artifact_tampered",
+        )
+        write_shell_status(
+            status_file,
+            run_id=run_id,
+            state="error",
+            request_file=request_file,
+            result_file=result_file,
+            completed_at=completed_at,
+            exit_code=1,
+            runner_error="request_artifact_tampered",
+        )
+        print("status: error")
+        print(f"run_id: {run_id}")
+        print("engine: shell")
+        print("runner_error: request_artifact_tampered")
+        return 1
+
+    payload = request.get("payload") or {}
+    if not isinstance(payload, dict):
+        raise RuntimeError("shell request payload must be an object")
+    execution = request.get("execution") or {}
+    if not isinstance(execution, dict):
+        raise RuntimeError("shell request execution block must be an object")
+    script = str(payload.get("script") or "")
+    if not script:
+        raise RuntimeError("shell request missing payload.script")
+    script_path = Path(script).expanduser().resolve()
+    if not script_path.is_file() or not os.access(script_path, os.X_OK):
+        raise RuntimeError(f"shell script is not executable: {script_path}")
+    run_uid = int(execution.get("uid"))
+    script_stat = script_path.stat()
+    if script_stat.st_uid not in {os.getuid(), run_uid}:
+        raise RuntimeError(f"shell script owner must be controller uid or run-as uid: {script_path}")
+    if script_stat.st_mode & 0o022:
+        raise RuntimeError(f"shell script must not be group/other writable: {script_path}")
+    script_args = payload.get("args") or []
+    if not isinstance(script_args, list):
+        raise RuntimeError("payload.args must be an array")
+    argv = [str(item) for item in script_args]
+    timeout_seconds = int(payload.get("timeoutSeconds") or 900)
+    output_cap_bytes = int(payload.get("outputCapBytes") or 65536)
+    if timeout_seconds <= 0:
+        raise RuntimeError("payload.timeoutSeconds must be positive")
+    if output_cap_bytes <= 0:
+        raise RuntimeError("payload.outputCapBytes must be positive")
+
+    env_snapshot = execution.get("env_snapshot") or {}
+    if not isinstance(env_snapshot, dict):
+        raise RuntimeError("execution.env_snapshot must be an object")
+    child_env = {str(key): str(value) for key, value in env_snapshot.items()}
+    child_env.update(shell_payload_env(payload))
+    child_env["HOME"] = str(execution.get("home") or child_env.get("HOME") or str(Path.home()))
+    child_env["CRON_RUN_ID"] = run_id
+    child_env["CRON_JOB_ID"] = str(request.get("job_id") or "")
+    child_env["CRON_JOB_NAME"] = str(request.get("job_name") or "")
+    child_env["CRON_SLOT"] = str(request.get("slot") or "")
+    child_env["CRON_REQUEST_FILE"] = str(request_file)
+    child_env["CRON_RUN_DIR"] = str(run_dir)
+
+    command = shell_command_for_execution(execution, child_env, str(script_path), argv)
+    lock_dir = cron_state_dir_from_env(run_dir) / "locks"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_dir / f"{str(request.get('job_id') or run_id)}.lock"
+
+    with lock_file.open("w", encoding="utf-8") as lock_handle:
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            completed_at = now_iso()
+            write_text(stdout_log, "")
+            write_text(stderr_log, "lock_held\n")
+            write_shell_result(
+                result_file,
+                run_id=run_id,
+                status="success",
+                summary="lock_held",
+                request_file=request_file,
+                stdout_log=stdout_log,
+                stderr_log=stderr_log,
+                completed_at=completed_at,
+                exit_code=0,
+                runner_error="lock_held",
+                command=command,
+            )
+            write_shell_status(
+                status_file,
+                run_id=run_id,
+                state="success",
+                request_file=request_file,
+                result_file=result_file,
+                completed_at=completed_at,
+                exit_code=0,
+                runner_error="lock_held",
+            )
+            print("status: success")
+            print(f"run_id: {run_id}")
+            print("engine: shell")
+            print("summary: lock_held")
+            return 0
+
+        started_at = now_iso()
+        start_monotonic = time.monotonic()
+        write_shell_status(
+            status_file,
+            run_id=run_id,
+            state="running",
+            request_file=request_file,
+            result_file=result_file,
+            started_at=started_at,
+        )
+
+        process = subprocess.Popen(
+            command,
+            cwd=str(run_dir),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        timed_out = False
+        try:
+            stdout_bytes, stderr_bytes = process.communicate(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except OSError:
+                pass
+            try:
+                stdout_bytes, stderr_bytes = process.communicate(timeout=5)
+            except subprocess.TimeoutExpired:
+                try:
+                    os.killpg(process.pid, signal.SIGKILL)
+                except OSError:
+                    pass
+                stdout_bytes, stderr_bytes = process.communicate()
+
+        completed_at = now_iso()
+        duration_ms = int((time.monotonic() - start_monotonic) * 1000)
+        stdout_text, stdout_truncated = truncate_output(stdout_bytes or b"", output_cap_bytes)
+        stderr_text, stderr_truncated = truncate_output(stderr_bytes or b"", output_cap_bytes)
+        if stdout_truncated or stderr_truncated:
+            stderr_text += "[agent-bridge] one or more streams were truncated\n"
+        write_text(stdout_log, stdout_text)
+        write_text(stderr_log, stderr_text)
+
+        if timed_out:
+            final_state = "timed_out"
+            result_status = "error"
+            error_message = f"timed out after {timeout_seconds}s"
+            exit_code = 124
+        else:
+            exit_code = int(process.returncode)
+            if exit_code == 0:
+                final_state = "success"
+                result_status = "success"
+                error_message = None
+            else:
+                final_state = "error"
+                result_status = "error"
+                error_message = f"script exited {exit_code}"
+
+        write_shell_result(
+            result_file,
+            run_id=run_id,
+            status=result_status,
+            summary="shell cron completed" if result_status == "success" else (error_message or "shell cron failed"),
+            request_file=request_file,
+            stdout_log=stdout_log,
+            stderr_log=stderr_log,
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_ms=duration_ms,
+            exit_code=exit_code,
+            runner_error=error_message,
+            command=command,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
+        )
+        write_shell_status(
+            status_file,
+            run_id=run_id,
+            state=final_state,
+            request_file=request_file,
+            result_file=result_file,
+            started_at=started_at,
+            completed_at=completed_at,
+            duration_ms=duration_ms,
+            exit_code=exit_code,
+            runner_error=error_message,
+        )
+
+    print(f"status: {final_state}")
+    print(f"run_id: {run_id}")
+    print("engine: shell")
+    print(f"result_file: {rel_for_output(str(result_file))}")
+    print(f"status_file: {rel_for_output(str(status_file))}")
+    if error_message:
+        print(f"runner_error: {error_message}")
+    return 0 if final_state == "success" else 1
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     request_file = Path(args.request_file).expanduser().resolve()
     if not request_file.is_file():
@@ -1267,6 +1735,10 @@ def cmd_run(args: argparse.Namespace) -> int:
         return 2
 
     request = read_json(request_file)
+    request_payload = request.get("payload") if isinstance(request.get("payload"), dict) else {}
+    if request.get("payload_kind") == "shell" or request_payload.get("kind") == "shell":
+        return cmd_run_shell(request, request_file, args)
+
     engine = request.get("target_engine", "")
     run_id = request.get("run_id", "")
     workdir = request.get("target_workdir", "")

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -222,6 +222,40 @@ def validate_shell_request_artifacts(request_file: Path) -> tuple[bool, str | No
     return True, None
 
 
+def shell_artifact_route(request_file: Path) -> tuple[str, str | None]:
+    """Classify request artifacts before reading untrusted request JSON.
+
+    Shell jobs are dispatched with controller-private artifacts
+    (run_dir=0700, request.json=0600, no named/default ACL write exposure).
+    Group/other writable artifacts are treated as tampered before JSON parse.
+    Named/default ACL write exposure disqualifies the shell convention but is
+    only terminal once the parsed request actually declares a shell payload,
+    preserving legacy text runs that intentionally carry per-run ACL grants.
+    """
+    run_dir = request_file.parent
+    controller_uid = os.getuid()
+    states: list[tuple[Path, os.stat_result]] = []
+    for path in (run_dir, request_file):
+        try:
+            states.append((path, path.stat()))
+        except OSError as exc:
+            return "tampered", f"request_artifact_tampered: stat failed for {path}: {exc}"
+    acl_write_exposed = False
+    for path, st in states:
+        if st.st_uid != controller_uid:
+            return "tampered", f"request_artifact_tampered: owner uid mismatch for {path}"
+        if mode_has_group_or_other_write(path):
+            return "tampered", f"request_artifact_tampered: group/other writable mode on {path}"
+        if path_acl_has_write_exposure(path, include_default=path.is_dir()):
+            acl_write_exposed = True
+
+    run_mode = stat.S_IMODE(states[0][1].st_mode)
+    request_mode = stat.S_IMODE(states[1][1].st_mode)
+    if run_mode == 0o700 and request_mode == 0o600 and not acl_write_exposed:
+        return "shell", None
+    return "text", None
+
+
 def truncate_output(data: bytes, cap: int) -> tuple[str, bool]:
     if len(data) <= cap:
         return data.decode("utf-8", errors="replace"), False
@@ -375,6 +409,62 @@ def write_shell_result(
         payload["command"] = safe_command
         payload["command_pretty"] = " ".join(shlex.quote(part) for part in safe_command)
     write_json(result_file, payload)
+
+
+def is_shell_request_payload(request: dict[str, Any]) -> bool:
+    request_payload = request.get("payload") if isinstance(request.get("payload"), dict) else {}
+    return request.get("payload_kind") == "shell" or request_payload.get("kind") == "shell"
+
+
+def write_shell_terminal_error(
+    request_file: Path,
+    *,
+    runner_error: str,
+    summary: str | None = None,
+    run_id: str | None = None,
+    started_at: str | None = None,
+    audit_target_agent: str = "daemon",
+) -> None:
+    run_dir = request_file.parent
+    resolved_run_id = run_id or run_dir_id(run_dir)
+    result_file = (run_dir / "result.json").resolve()
+    status_file = (run_dir / "status.json").resolve()
+    stdout_log = (run_dir / "stdout.log").resolve()
+    stderr_log = (run_dir / "stderr.log").resolve()
+    completed_at = now_iso()
+    write_text(stdout_log, "")
+    write_text(stderr_log, (summary or runner_error) + "\n")
+    write_shell_result(
+        result_file,
+        run_id=resolved_run_id,
+        status="error",
+        summary=summary or runner_error,
+        request_file=request_file,
+        stdout_log=stdout_log,
+        stderr_log=stderr_log,
+        started_at=started_at,
+        completed_at=completed_at,
+        exit_code=1,
+        runner_error=runner_error,
+    )
+    write_shell_status(
+        status_file,
+        run_id=resolved_run_id,
+        state="error",
+        request_file=request_file,
+        result_file=result_file,
+        started_at=started_at,
+        completed_at=completed_at,
+        exit_code=1,
+        runner_error=runner_error,
+    )
+    emit_audit_row(
+        action="cron_shell_runner_error",
+        actor="cron-runner",
+        target_agent=audit_target_agent or "daemon",
+        run_id=resolved_run_id,
+        details={"runner_error": runner_error},
+    )
 
 
 def normalize_result(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1513,30 +1603,12 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
     trusted, trust_error = validate_shell_request_artifacts(request_file)
     if not trusted:
         error_message = trust_error or "request_artifact_tampered"
-        completed_at = now_iso()
-        write_text(stdout_log, "")
-        write_text(stderr_log, error_message + "\n")
-        write_shell_result(
-            result_file,
-            run_id=run_id,
-            status="error",
+        write_shell_terminal_error(
+            request_file,
+            runner_error="request_artifact_tampered",
             summary=error_message,
-            request_file=request_file,
-            stdout_log=stdout_log,
-            stderr_log=stderr_log,
-            completed_at=completed_at,
-            exit_code=1,
-            runner_error="request_artifact_tampered",
-        )
-        write_shell_status(
-            status_file,
             run_id=run_id,
-            state="error",
-            request_file=request_file,
-            result_file=result_file,
-            completed_at=completed_at,
-            exit_code=1,
-            runner_error="request_artifact_tampered",
+            audit_target_agent=str(request.get("target_agent") or "daemon"),
         )
         print("status: error")
         print(f"run_id: {run_id}")
@@ -1544,52 +1616,67 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
         print("runner_error: request_artifact_tampered")
         return 1
 
-    payload = request.get("payload") or {}
-    if not isinstance(payload, dict):
-        raise RuntimeError("shell request payload must be an object")
-    execution = request.get("execution") or {}
-    if not isinstance(execution, dict):
-        raise RuntimeError("shell request execution block must be an object")
-    script = str(payload.get("script") or "")
-    if not script:
-        raise RuntimeError("shell request missing payload.script")
-    script_path = Path(script).expanduser().resolve()
-    if not script_path.is_file() or not os.access(script_path, os.X_OK):
-        raise RuntimeError(f"shell script is not executable: {script_path}")
-    run_uid = int(execution.get("uid"))
-    script_stat = script_path.stat()
-    if script_stat.st_uid not in {os.getuid(), run_uid}:
-        raise RuntimeError(f"shell script owner must be controller uid or run-as uid: {script_path}")
-    if script_stat.st_mode & 0o022:
-        raise RuntimeError(f"shell script must not be group/other writable: {script_path}")
-    script_args = payload.get("args") or []
-    if not isinstance(script_args, list):
-        raise RuntimeError("payload.args must be an array")
-    argv = [str(item) for item in script_args]
-    timeout_seconds = int(payload.get("timeoutSeconds") or 900)
-    output_cap_bytes = int(payload.get("outputCapBytes") or 65536)
-    if timeout_seconds <= 0:
-        raise RuntimeError("payload.timeoutSeconds must be positive")
-    if output_cap_bytes <= 0:
-        raise RuntimeError("payload.outputCapBytes must be positive")
+    try:
+        payload = request.get("payload") or {}
+        if not isinstance(payload, dict):
+            raise RuntimeError("shell request payload must be an object")
+        execution = request.get("execution") or {}
+        if not isinstance(execution, dict):
+            raise RuntimeError("shell request execution block must be an object")
+        script = str(payload.get("script") or "")
+        if not script:
+            raise RuntimeError("shell request missing payload.script")
+        script_path = Path(script).expanduser().resolve()
+        if not script_path.is_file() or not os.access(script_path, os.X_OK):
+            raise RuntimeError(f"not regular/executable file: {script_path}")
+        run_uid = int(execution.get("uid"))
+        script_stat = script_path.stat()
+        if script_stat.st_uid not in {os.getuid(), run_uid}:
+            raise RuntimeError(f"shell script owner must be controller uid or run-as uid: {script_path}")
+        if script_stat.st_mode & 0o022:
+            raise RuntimeError(f"shell script must not be group/other writable: {script_path}")
+        script_args = payload.get("args") or []
+        if not isinstance(script_args, list):
+            raise RuntimeError("payload.args must be an array")
+        argv = [str(item) for item in script_args]
+        timeout_seconds = int(payload.get("timeoutSeconds") or 900)
+        output_cap_bytes = int(payload.get("outputCapBytes") or 65536)
+        if timeout_seconds <= 0:
+            raise RuntimeError("payload.timeoutSeconds must be positive")
+        if output_cap_bytes <= 0:
+            raise RuntimeError("payload.outputCapBytes must be positive")
 
-    env_snapshot = execution.get("env_snapshot") or {}
-    if not isinstance(env_snapshot, dict):
-        raise RuntimeError("execution.env_snapshot must be an object")
-    child_env = {str(key): str(value) for key, value in env_snapshot.items()}
-    child_env.update(shell_payload_env(payload))
-    child_env["HOME"] = str(execution.get("home") or child_env.get("HOME") or str(Path.home()))
-    child_env["CRON_RUN_ID"] = run_id
-    child_env["CRON_JOB_ID"] = str(request.get("job_id") or "")
-    child_env["CRON_JOB_NAME"] = str(request.get("job_name") or "")
-    child_env["CRON_SLOT"] = str(request.get("slot") or "")
-    child_env["CRON_REQUEST_FILE"] = str(request_file)
-    child_env["CRON_RUN_DIR"] = str(run_dir)
+        env_snapshot = execution.get("env_snapshot") or {}
+        if not isinstance(env_snapshot, dict):
+            raise RuntimeError("execution.env_snapshot must be an object")
+        child_env = {str(key): str(value) for key, value in env_snapshot.items()}
+        child_env.update(shell_payload_env(payload))
+        child_env["HOME"] = str(execution.get("home") or child_env.get("HOME") or str(Path.home()))
+        child_env["CRON_RUN_ID"] = run_id
+        child_env["CRON_JOB_ID"] = str(request.get("job_id") or "")
+        child_env["CRON_JOB_NAME"] = str(request.get("job_name") or "")
+        child_env["CRON_SLOT"] = str(request.get("slot") or "")
+        child_env["CRON_REQUEST_FILE"] = str(request_file)
+        child_env["CRON_RUN_DIR"] = str(run_dir)
 
-    command = shell_command_for_execution(execution, child_env, str(script_path), argv)
-    lock_dir = cron_state_dir_from_env(run_dir) / "locks"
-    lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_file = lock_dir / f"{str(request.get('job_id') or run_id)}.lock"
+        command = shell_command_for_execution(execution, child_env, str(script_path), argv)
+        lock_dir = cron_state_dir_from_env(run_dir) / "locks"
+        lock_dir.mkdir(parents=True, exist_ok=True)
+        lock_file = lock_dir / f"{str(request.get('job_id') or run_id)}.lock"
+    except Exception as exc:  # noqa: BLE001
+        error_message = f"script_validation_failed: {exc}"
+        write_shell_terminal_error(
+            request_file,
+            runner_error=error_message,
+            summary=error_message,
+            run_id=run_id,
+            audit_target_agent=str(request.get("target_agent") or "daemon"),
+        )
+        print("status: error")
+        print(f"run_id: {run_id}")
+        print("engine: shell")
+        print(f"runner_error: {error_message}")
+        return 1
 
     with lock_file.open("w", encoding="utf-8") as lock_handle:
         try:
@@ -1734,9 +1821,56 @@ def cmd_run(args: argparse.Namespace) -> int:
         print(f"error: request file not found: {request_file}", file=sys.stderr)
         return 2
 
-    request = read_json(request_file)
-    request_payload = request.get("payload") if isinstance(request.get("payload"), dict) else {}
-    if request.get("payload_kind") == "shell" or request_payload.get("kind") == "shell":
+    route, route_error = shell_artifact_route(request_file)
+    if route == "tampered":
+        error_message = route_error or "request_artifact_tampered"
+        write_shell_terminal_error(
+            request_file,
+            runner_error="request_artifact_tampered",
+            summary=error_message,
+            run_id=run_dir_id(request_file.parent),
+        )
+        print("status: error")
+        print(f"run_id: {run_dir_id(request_file.parent)}")
+        print("engine: shell")
+        print("runner_error: request_artifact_tampered")
+        return 1
+
+    request: dict[str, Any]
+    if route == "shell":
+        try:
+            request = read_json(request_file)
+        except json.JSONDecodeError as exc:
+            error_message = f"request_artifact_corrupted: {exc}"
+            write_shell_terminal_error(
+                request_file,
+                runner_error="request_artifact_corrupted",
+                summary=error_message,
+                run_id=run_dir_id(request_file.parent),
+            )
+            print("status: error")
+            print(f"run_id: {run_dir_id(request_file.parent)}")
+            print("engine: shell")
+            print("runner_error: request_artifact_corrupted")
+            return 1
+    else:
+        request = read_json(request_file)
+
+    if is_shell_request_payload(request):
+        if route != "shell":
+            error_message = "request_artifact_tampered: shell request artifacts are not controller-private"
+            write_shell_terminal_error(
+                request_file,
+                runner_error="request_artifact_tampered",
+                summary=error_message,
+                run_id=str(request.get("run_id") or run_dir_id(request_file.parent)),
+                audit_target_agent=str(request.get("target_agent") or "daemon"),
+            )
+            print("status: error")
+            print(f"run_id: {str(request.get('run_id') or run_dir_id(request_file.parent))}")
+            print("engine: shell")
+            print("runner_error: request_artifact_tampered")
+            return 1
         return cmd_run_shell(request, request_file, args)
 
     engine = request.get("target_engine", "")

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -14,6 +14,7 @@ import signal
 import stat
 import subprocess
 import sys
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -261,6 +262,110 @@ def truncate_output(data: bytes, cap: int) -> tuple[str, bool]:
         return data.decode("utf-8", errors="replace"), False
     truncated = data[:cap].decode("utf-8", errors="replace")
     return truncated + f"\n[agent-bridge] output truncated at {cap} bytes\n", True
+
+
+class ShellStreamCollector:
+    """Stream a child process pipe to a file with a hard byte cap.
+
+    Streams bytes from `source` to `dest_path`, accumulates a byte counter,
+    and stops writing once `cap_bytes` is exceeded. When the cap trips,
+    `on_cap_exceeded` is invoked (best-effort, once) so the caller can kill
+    the child's process group. The remainder of the pipe is drained but
+    discarded so the child does not block on a full pipe buffer.
+
+    Drives finding 2 of PR #625 r2 review: replaces the unbounded
+    `process.communicate()` collector that allowed a noisy script to OOM
+    the controller before the cap fired.
+    """
+
+    _CHUNK = 65536
+
+    def __init__(
+        self,
+        source: Any,
+        dest_path: Path,
+        cap_bytes: int,
+        on_cap_exceeded: Any,
+        label: str,
+    ) -> None:
+        self._source = source
+        self._dest_path = dest_path
+        self._cap_bytes = cap_bytes
+        self._on_cap_exceeded = on_cap_exceeded
+        self._label = label
+        self.bytes_written = 0
+        self.truncated = False
+        self._notified = False
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"shell-{label}-collector",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        self._dest_path.parent.mkdir(parents=True, exist_ok=True)
+        self._thread.start()
+
+    def join(self, timeout: float | None = None) -> None:
+        self._thread.join(timeout=timeout)
+
+    @property
+    def alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def _notify_once(self) -> None:
+        if self._notified:
+            return
+        self._notified = True
+        try:
+            self._on_cap_exceeded(self._label)
+        except Exception:  # noqa: BLE001 — best-effort
+            pass
+
+    def _run(self) -> None:
+        try:
+            with self._dest_path.open("wb") as fh:
+                while True:
+                    chunk = self._source.read(self._CHUNK)
+                    if not chunk:
+                        return
+                    if self.truncated:
+                        # Drain remaining bytes so the child never blocks
+                        # on a full pipe; do not write them to disk.
+                        continue
+                    remaining = self._cap_bytes - self.bytes_written
+                    if remaining <= 0:
+                        # Defensive — should have been caught last iter.
+                        self.truncated = True
+                        self._notify_once()
+                        continue
+                    if len(chunk) > remaining:
+                        fh.write(chunk[:remaining])
+                        self.bytes_written += remaining
+                        self.truncated = True
+                        self._notify_once()
+                        continue
+                    fh.write(chunk)
+                    self.bytes_written += len(chunk)
+        except Exception:  # noqa: BLE001 — best-effort streaming
+            return
+        finally:
+            try:
+                self._source.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def append_truncation_marker(self) -> None:
+        if not self.truncated:
+            return
+        try:
+            with self._dest_path.open("ab") as fh:
+                marker = (
+                    f"\n[agent-bridge] output truncated at {self._cap_bytes} bytes\n"
+                ).encode("utf-8")
+                fh.write(marker)
+        except OSError:
+            pass
 
 
 def cron_state_dir_from_env(run_dir: Path) -> Path:
@@ -1583,6 +1688,26 @@ def write_status(
     write_json(status_file, payload)
 
 
+def _validate_shell_script(script_path: Path, run_uid: int) -> None:
+    """Re-runnable script validation. Used both pre- and post-flock.
+
+    Drives finding 1 of PR #625 r2 review: the same checks fire while the
+    flock is held immediately before exec, so an attacker swapping the
+    script after enqueue but before exec is caught.
+    """
+    if not script_path.is_file() or not os.access(script_path, os.X_OK):
+        raise RuntimeError(f"not regular/executable file: {script_path}")
+    script_stat = script_path.stat()
+    if script_stat.st_uid not in {os.getuid(), run_uid}:
+        raise RuntimeError(
+            f"shell script owner must be controller uid or run-as uid: {script_path}"
+        )
+    if script_stat.st_mode & 0o022:
+        raise RuntimeError(
+            f"shell script must not be group/other writable: {script_path}"
+        )
+
+
 def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Namespace) -> int:
     run_dir = request_file.parent
     run_id = str(request.get("run_id") or run_dir_id(run_dir))
@@ -1600,77 +1725,24 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
         print(f"status_file: {rel_for_output(str(status_file))}")
         return 0
 
-    trusted, trust_error = validate_shell_request_artifacts(request_file)
-    if not trusted:
-        error_message = trust_error or "request_artifact_tampered"
-        write_shell_terminal_error(
-            request_file,
-            runner_error="request_artifact_tampered",
-            summary=error_message,
-            run_id=run_id,
-            audit_target_agent=str(request.get("target_agent") or "daemon"),
-        )
-        print("status: error")
-        print(f"run_id: {run_id}")
-        print("engine: shell")
-        print("runner_error: request_artifact_tampered")
-        return 1
+    audit_target_agent = str(request.get("target_agent") or "daemon")
 
+    # Derive the per-job lock path from the parsed request BEFORE any
+    # artifact validation, so we can hold the flock across validation +
+    # exec (finding 1 of PR #625 r2 review — TOCTOU window between
+    # validate and exec when validation ran outside the flock).
     try:
-        payload = request.get("payload") or {}
-        if not isinstance(payload, dict):
-            raise RuntimeError("shell request payload must be an object")
-        execution = request.get("execution") or {}
-        if not isinstance(execution, dict):
-            raise RuntimeError("shell request execution block must be an object")
-        script = str(payload.get("script") or "")
-        if not script:
-            raise RuntimeError("shell request missing payload.script")
-        script_path = Path(script).expanduser().resolve()
-        if not script_path.is_file() or not os.access(script_path, os.X_OK):
-            raise RuntimeError(f"not regular/executable file: {script_path}")
-        run_uid = int(execution.get("uid"))
-        script_stat = script_path.stat()
-        if script_stat.st_uid not in {os.getuid(), run_uid}:
-            raise RuntimeError(f"shell script owner must be controller uid or run-as uid: {script_path}")
-        if script_stat.st_mode & 0o022:
-            raise RuntimeError(f"shell script must not be group/other writable: {script_path}")
-        script_args = payload.get("args") or []
-        if not isinstance(script_args, list):
-            raise RuntimeError("payload.args must be an array")
-        argv = [str(item) for item in script_args]
-        timeout_seconds = int(payload.get("timeoutSeconds") or 900)
-        output_cap_bytes = int(payload.get("outputCapBytes") or 65536)
-        if timeout_seconds <= 0:
-            raise RuntimeError("payload.timeoutSeconds must be positive")
-        if output_cap_bytes <= 0:
-            raise RuntimeError("payload.outputCapBytes must be positive")
-
-        env_snapshot = execution.get("env_snapshot") or {}
-        if not isinstance(env_snapshot, dict):
-            raise RuntimeError("execution.env_snapshot must be an object")
-        child_env = {str(key): str(value) for key, value in env_snapshot.items()}
-        child_env.update(shell_payload_env(payload))
-        child_env["HOME"] = str(execution.get("home") or child_env.get("HOME") or str(Path.home()))
-        child_env["CRON_RUN_ID"] = run_id
-        child_env["CRON_JOB_ID"] = str(request.get("job_id") or "")
-        child_env["CRON_JOB_NAME"] = str(request.get("job_name") or "")
-        child_env["CRON_SLOT"] = str(request.get("slot") or "")
-        child_env["CRON_REQUEST_FILE"] = str(request_file)
-        child_env["CRON_RUN_DIR"] = str(run_dir)
-
-        command = shell_command_for_execution(execution, child_env, str(script_path), argv)
         lock_dir = cron_state_dir_from_env(run_dir) / "locks"
         lock_dir.mkdir(parents=True, exist_ok=True)
         lock_file = lock_dir / f"{str(request.get('job_id') or run_id)}.lock"
     except Exception as exc:  # noqa: BLE001
-        error_message = f"script_validation_failed: {exc}"
+        error_message = f"lock_path_unavailable: {exc}"
         write_shell_terminal_error(
             request_file,
             runner_error=error_message,
             summary=error_message,
             run_id=run_id,
-            audit_target_agent=str(request.get("target_agent") or "daemon"),
+            audit_target_agent=audit_target_agent,
         )
         print("status: error")
         print(f"run_id: {run_id}")
@@ -1696,7 +1768,6 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
                 completed_at=completed_at,
                 exit_code=0,
                 runner_error="lock_held",
-                command=command,
             )
             write_shell_status(
                 status_file,
@@ -1713,6 +1784,84 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
             print("engine: shell")
             print("summary: lock_held")
             return 0
+
+        # Validate request artifacts UNDER the flock so a swap between
+        # validation and exec must contend with the same lock.
+        trusted, trust_error = validate_shell_request_artifacts(request_file)
+        if not trusted:
+            error_message = trust_error or "request_artifact_tampered"
+            write_shell_terminal_error(
+                request_file,
+                runner_error="request_artifact_tampered",
+                summary=error_message,
+                run_id=run_id,
+                audit_target_agent=audit_target_agent,
+            )
+            print("status: error")
+            print(f"run_id: {run_id}")
+            print("engine: shell")
+            print("runner_error: request_artifact_tampered")
+            return 1
+
+        try:
+            payload = request.get("payload") or {}
+            if not isinstance(payload, dict):
+                raise RuntimeError("shell request payload must be an object")
+            execution = request.get("execution") or {}
+            if not isinstance(execution, dict):
+                raise RuntimeError("shell request execution block must be an object")
+            script = str(payload.get("script") or "")
+            if not script:
+                raise RuntimeError("shell request missing payload.script")
+            script_path = Path(script).expanduser().resolve()
+            run_uid = int(execution.get("uid"))
+            _validate_shell_script(script_path, run_uid)
+            script_args = payload.get("args") or []
+            if not isinstance(script_args, list):
+                raise RuntimeError("payload.args must be an array")
+            argv = [str(item) for item in script_args]
+            timeout_seconds = int(payload.get("timeoutSeconds") or 900)
+            output_cap_bytes = int(payload.get("outputCapBytes") or 65536)
+            if timeout_seconds <= 0:
+                raise RuntimeError("payload.timeoutSeconds must be positive")
+            if output_cap_bytes <= 0:
+                raise RuntimeError("payload.outputCapBytes must be positive")
+
+            env_snapshot = execution.get("env_snapshot") or {}
+            if not isinstance(env_snapshot, dict):
+                raise RuntimeError("execution.env_snapshot must be an object")
+            child_env = {str(key): str(value) for key, value in env_snapshot.items()}
+            child_env.update(shell_payload_env(payload))
+            child_env["HOME"] = str(execution.get("home") or child_env.get("HOME") or str(Path.home()))
+            child_env["CRON_RUN_ID"] = run_id
+            child_env["CRON_JOB_ID"] = str(request.get("job_id") or "")
+            child_env["CRON_JOB_NAME"] = str(request.get("job_name") or "")
+            child_env["CRON_SLOT"] = str(request.get("slot") or "")
+            child_env["CRON_REQUEST_FILE"] = str(request_file)
+            child_env["CRON_RUN_DIR"] = str(run_dir)
+
+            command = shell_command_for_execution(execution, child_env, str(script_path), argv)
+
+            # Re-run the script owner/mode probe immediately before exec.
+            # We are still inside the flock; the controller-private lock
+            # serializes parallel runs, and re-validation here closes the
+            # window that previously sat between argv construction and
+            # subprocess.Popen (finding 1 of PR #625 r2 review).
+            _validate_shell_script(script_path, run_uid)
+        except Exception as exc:  # noqa: BLE001
+            error_message = f"script_validation_failed: {exc}"
+            write_shell_terminal_error(
+                request_file,
+                runner_error=error_message,
+                summary=error_message,
+                run_id=run_id,
+                audit_target_agent=audit_target_agent,
+            )
+            print("status: error")
+            print(f"run_id: {run_id}")
+            print("engine: shell")
+            print(f"runner_error: {error_message}")
+            return 1
 
         started_at = now_iso()
         start_monotonic = time.monotonic()
@@ -1733,53 +1882,137 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
             start_new_session=True,
         )
         timed_out = False
-        try:
-            stdout_bytes, stderr_bytes = process.communicate(timeout=timeout_seconds)
-        except subprocess.TimeoutExpired:
-            timed_out = True
+        cap_exceeded = False
+        kill_lock = threading.Lock()
+        kill_state = {"sigterm_sent": False, "sigkill_sent": False}
+
+        def killpg_signal(sig: int) -> None:
             try:
-                os.killpg(process.pid, signal.SIGTERM)
+                pgid = os.getpgid(process.pid)
+            except OSError:
+                return
+            try:
+                os.killpg(pgid, sig)
             except OSError:
                 pass
+
+        def trigger_kill(reason: str) -> None:
+            # `reason` is informational ("stdout"/"stderr"/"timeout") so a
+            # future log can attribute the SIGTERM. Today we only need
+            # to ensure SIGTERM fires once per kill request.
+            del reason
+            with kill_lock:
+                if kill_state["sigterm_sent"]:
+                    return
+                kill_state["sigterm_sent"] = True
+            killpg_signal(signal.SIGTERM)
+
+        def on_cap_exceeded(label: str) -> None:
+            nonlocal cap_exceeded
+            cap_exceeded = True
+            trigger_kill(label)
+
+        stdout_collector = ShellStreamCollector(
+            process.stdout,
+            stdout_log,
+            output_cap_bytes,
+            on_cap_exceeded,
+            "stdout",
+        )
+        stderr_collector = ShellStreamCollector(
+            process.stderr,
+            stderr_log,
+            output_cap_bytes,
+            on_cap_exceeded,
+            "stderr",
+        )
+        stdout_collector.start()
+        stderr_collector.start()
+
+        try:
+            process.wait(timeout=timeout_seconds)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            trigger_kill("timeout")
             try:
-                stdout_bytes, stderr_bytes = process.communicate(timeout=5)
+                process.wait(timeout=5)
             except subprocess.TimeoutExpired:
+                with kill_lock:
+                    kill_state["sigkill_sent"] = True
+                killpg_signal(signal.SIGKILL)
                 try:
-                    os.killpg(process.pid, signal.SIGKILL)
-                except OSError:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
                     pass
-                stdout_bytes, stderr_bytes = process.communicate()
+
+        # If a cap-trip already issued SIGTERM, escalate to SIGKILL on
+        # any process that ignored it before we close pipes.
+        if cap_exceeded and process.returncode is None:
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                with kill_lock:
+                    kill_state["sigkill_sent"] = True
+                killpg_signal(signal.SIGKILL)
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    pass
+
+        # Drain the collector threads so logs are fully flushed before we
+        # write result/status. The child has exited (or been SIGKILLed),
+        # so EOF on the pipes is imminent; bound the wait defensively.
+        stdout_collector.join(timeout=10)
+        stderr_collector.join(timeout=10)
+
+        stdout_truncated = stdout_collector.truncated
+        stderr_truncated = stderr_collector.truncated
+        stdout_collector.append_truncation_marker()
+        stderr_collector.append_truncation_marker()
+        if stdout_truncated or stderr_truncated:
+            try:
+                with stderr_log.open("ab") as fh:
+                    fh.write(b"[agent-bridge] one or more streams were truncated\n")
+            except OSError:
+                pass
 
         completed_at = now_iso()
         duration_ms = int((time.monotonic() - start_monotonic) * 1000)
-        stdout_text, stdout_truncated = truncate_output(stdout_bytes or b"", output_cap_bytes)
-        stderr_text, stderr_truncated = truncate_output(stderr_bytes or b"", output_cap_bytes)
-        if stdout_truncated or stderr_truncated:
-            stderr_text += "[agent-bridge] one or more streams were truncated\n"
-        write_text(stdout_log, stdout_text)
-        write_text(stderr_log, stderr_text)
 
-        if timed_out:
+        if cap_exceeded:
+            final_state = "error"
+            result_status = "error"
+            error_message = f"output_cap_exceeded: cap={output_cap_bytes} bytes"
+            exit_code = int(process.returncode) if process.returncode is not None else -1
+            runner_error_field = "output_cap_exceeded"
+            summary_text = error_message
+        elif timed_out:
             final_state = "timed_out"
             result_status = "error"
             error_message = f"timed out after {timeout_seconds}s"
             exit_code = 124
+            runner_error_field = error_message
+            summary_text = error_message
         else:
-            exit_code = int(process.returncode)
+            exit_code = int(process.returncode) if process.returncode is not None else -1
             if exit_code == 0:
                 final_state = "success"
                 result_status = "success"
                 error_message = None
+                runner_error_field = None
+                summary_text = "shell cron completed"
             else:
                 final_state = "error"
                 result_status = "error"
                 error_message = f"script exited {exit_code}"
+                runner_error_field = error_message
+                summary_text = error_message
 
         write_shell_result(
             result_file,
             run_id=run_id,
             status=result_status,
-            summary="shell cron completed" if result_status == "success" else (error_message or "shell cron failed"),
+            summary=summary_text,
             request_file=request_file,
             stdout_log=stdout_log,
             stderr_log=stderr_log,
@@ -1787,7 +2020,7 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
             completed_at=completed_at,
             duration_ms=duration_ms,
             exit_code=exit_code,
-            runner_error=error_message,
+            runner_error=runner_error_field,
             command=command,
             stdout_truncated=stdout_truncated,
             stderr_truncated=stderr_truncated,
@@ -1802,7 +2035,7 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
             completed_at=completed_at,
             duration_ms=duration_ms,
             exit_code=exit_code,
-            runner_error=error_message,
+            runner_error=runner_error_field,
         )
 
     print(f"status: {final_state}")

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -323,10 +323,22 @@ class ShellStreamCollector:
             pass
 
     def _run(self) -> None:
+        # Use `read1` so each iteration returns whatever bytes are
+        # currently available on the pipe rather than blocking until
+        # the buffer fills (`read(_CHUNK)` waits for either _CHUNK
+        # bytes OR EOF). With `read`, a child that prints a small
+        # burst then sleeps holds the cap-trip back until the child
+        # eventually closes stdout — which is exactly the
+        # SIGTERM-ignoring child case in finding 2 of PR #625 r2
+        # review. `read1` lets the cap fire as soon as the first
+        # over-cap chunk arrives.
+        reader = getattr(self._source, "read1", None)
+        if reader is None:
+            reader = self._source.read
         try:
             with self._dest_path.open("wb") as fh:
                 while True:
-                    chunk = self._source.read(self._CHUNK)
+                    chunk = reader(self._CHUNK)
                     if not chunk:
                         return
                     if self.truncated:
@@ -1708,13 +1720,56 @@ def _validate_shell_script(script_path: Path, run_uid: int) -> None:
         )
 
 
-def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Namespace) -> int:
+def _extract_shell_lock_key(request_file: Path) -> tuple[str, str, str | None]:
+    """Minimal parse to derive the per-job lock key + run_id.
+
+    Reads ONLY enough of the request body to know which lock to take —
+    no artifact-trust validation, no script validation, no env build.
+    The full re-parse + validation runs under the flock in
+    `cmd_run_shell`. This keeps the lock-acquired-before-validation
+    invariant intact (finding 1 of PR #625 r2 review).
+
+    Returns (lock_key, run_id, error). `error` is None on success.
+    """
+    fallback_run_id = run_dir_id(request_file.parent)
+    try:
+        data = json.loads(request_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return "", fallback_run_id, f"request_artifact_corrupted: {type(exc).__name__}: {exc}"
+    if not isinstance(data, dict):
+        return "", fallback_run_id, "request_artifact_corrupted: non_dict_top_level"
+    run_id = str(data.get("run_id") or fallback_run_id)
+    lock_key = str(data.get("job_id") or run_id)
+    return lock_key, run_id, None
+
+
+def cmd_run_shell(request_file: Path, args: argparse.Namespace) -> int:
     run_dir = request_file.parent
-    run_id = str(request.get("run_id") or run_dir_id(run_dir))
     result_file = (run_dir / "result.json").resolve()
     status_file = (run_dir / "status.json").resolve()
     stdout_log = (run_dir / "stdout.log").resolve()
     stderr_log = (run_dir / "stderr.log").resolve()
+
+    # Minimal pre-lock parse — lock key + run_id only. The full body
+    # is re-read under the flock below for validation + exec, so this
+    # parse intentionally inspects nothing else.
+    lock_key, run_id, lock_key_error = _extract_shell_lock_key(request_file)
+    if lock_key_error is not None:
+        # Match the existing terminal-error contract: status.runner_error
+        # carries the full classifier string (e.g. "request_artifact_corrupted:
+        # non_dict_top_level") so smoke assertions can grep for both halves.
+        write_shell_terminal_error(
+            request_file,
+            runner_error=lock_key_error,
+            summary=lock_key_error,
+            run_id=run_id,
+        )
+        print("status: error")
+        print(f"run_id: {run_id}")
+        print("engine: shell")
+        # Header line uses the short prefix so operators see a stable token.
+        print(f"runner_error: {lock_key_error.split(':', 1)[0]}")
+        return 1
 
     if args.dry_run:
         print("status: dry_run")
@@ -1725,16 +1780,14 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
         print(f"status_file: {rel_for_output(str(status_file))}")
         return 0
 
-    audit_target_agent = str(request.get("target_agent") or "daemon")
-
-    # Derive the per-job lock path from the parsed request BEFORE any
-    # artifact validation, so we can hold the flock across validation +
-    # exec (finding 1 of PR #625 r2 review — TOCTOU window between
-    # validate and exec when validation ran outside the flock).
+    # Derive the per-job lock path from the minimal pre-parse so we
+    # can hold the flock across the full re-parse + artifact/script
+    # validation + exec (finding 1 of PR #625 r2 review — body must
+    # not be parsed/validated outside the flock).
     try:
         lock_dir = cron_state_dir_from_env(run_dir) / "locks"
         lock_dir.mkdir(parents=True, exist_ok=True)
-        lock_file = lock_dir / f"{str(request.get('job_id') or run_id)}.lock"
+        lock_file = lock_dir / f"{lock_key}.lock"
     except Exception as exc:  # noqa: BLE001
         error_message = f"lock_path_unavailable: {exc}"
         write_shell_terminal_error(
@@ -1742,7 +1795,6 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
             runner_error=error_message,
             summary=error_message,
             run_id=run_id,
-            audit_target_agent=audit_target_agent,
         )
         print("status: error")
         print(f"run_id: {run_id}")
@@ -1784,6 +1836,85 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
             print("engine: shell")
             print("summary: lock_held")
             return 0
+
+        # Re-read the request body from disk UNDER the flock (finding 1
+        # of PR #625 r2 review). The pre-lock minimal parse only
+        # extracted the lock key; the full parse + artifact-trust +
+        # script validation must all run while we hold the per-job
+        # flock so an attacker cannot swap the body or script between
+        # validate and exec.
+        try:
+            request: dict[str, Any] = read_json(request_file)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            error_message = f"request_artifact_corrupted: {type(exc).__name__}"
+            write_shell_terminal_error(
+                request_file,
+                runner_error=error_message,
+                summary=f"{error_message}: {exc}",
+                run_id=run_id,
+            )
+            print("status: error")
+            print(f"run_id: {run_id}")
+            print("engine: shell")
+            print(f"runner_error: {error_message}")
+            return 1
+        if not isinstance(request, dict):
+            error_message = "request_artifact_corrupted: non_dict_top_level"
+            write_shell_terminal_error(
+                request_file,
+                runner_error=error_message,
+                summary=error_message,
+                run_id=run_id,
+            )
+            print("status: error")
+            print(f"run_id: {run_id}")
+            print("engine: shell")
+            print(f"runner_error: {error_message}")
+            return 1
+        if not is_shell_request_payload(request):
+            error_message = "request_artifact_tampered: payload_kind no longer shell after lock"
+            write_shell_terminal_error(
+                request_file,
+                runner_error="request_artifact_tampered",
+                summary=error_message,
+                run_id=run_id,
+                audit_target_agent=str(request.get("target_agent") or "daemon"),
+            )
+            print("status: error")
+            print(f"run_id: {run_id}")
+            print("engine: shell")
+            print("runner_error: request_artifact_tampered")
+            return 1
+
+        # Confirm the post-lock job_id matches the lock we acquired.
+        # If an attacker swapped the body's job_id between the pre-lock
+        # minimal parse and the post-lock re-read, we'd otherwise be
+        # holding the wrong lock — a different runner could legitimately
+        # be holding the now-correct lock and exec'ing the same job
+        # body in parallel. Treat the mismatch as tampering.
+        post_lock_run_id = str(request.get("run_id") or run_dir_id(run_dir))
+        post_lock_lock_key = str(request.get("job_id") or post_lock_run_id)
+        if post_lock_lock_key != lock_key:
+            error_message = (
+                "request_artifact_tampered: job_id changed between pre-lock parse and lock acquisition"
+            )
+            write_shell_terminal_error(
+                request_file,
+                runner_error="request_artifact_tampered",
+                summary=error_message,
+                run_id=run_id,
+                audit_target_agent=str(request.get("target_agent") or "daemon"),
+            )
+            print("status: error")
+            print(f"run_id: {run_id}")
+            print("engine: shell")
+            print("runner_error: request_artifact_tampered")
+            return 1
+
+        # `audit_target_agent` is derived from the freshly re-read
+        # body so audit attribution always reflects what is on disk
+        # under the lock — never the stale pre-lock dict.
+        audit_target_agent = str(request.get("target_agent") or "daemon")
 
         # Validate request artifacts UNDER the flock so a swap between
         # validation and exec must contend with the same lock.
@@ -1881,18 +2012,31 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
             stderr=subprocess.PIPE,
             start_new_session=True,
         )
+        # Capture the process group id at spawn-time. Looking it up
+        # later via `os.getpgid(process.pid)` fails on some platforms
+        # once the immediate Popen child has been reaped — but the
+        # pgid keeps living as long as descendants remain (e.g. a
+        # SIGTERM-ignoring Python grandchild). We need the pgid to
+        # SIGKILL those descendants in `escalate_after_grace`.
+        try:
+            process_pgid = os.getpgid(process.pid)
+        except OSError:
+            process_pgid = process.pid
         timed_out = False
         cap_exceeded = False
         kill_lock = threading.Lock()
         kill_state = {"sigterm_sent": False, "sigkill_sent": False}
+        # cap_event interlocks the cap-collector threads with the main
+        # waiter so a cap-trip starts the SIGKILL grace immediately
+        # (finding 2 of PR #625 r2 review). Pre-r3 the main thread sat
+        # in `process.wait(timeout=timeout_seconds)`, so a TERM-ignoring
+        # child kept running until the full cron timeout, then another
+        # 5s grace — instead of cap-fire + 5s.
+        cap_event = threading.Event()
 
         def killpg_signal(sig: int) -> None:
             try:
-                pgid = os.getpgid(process.pid)
-            except OSError:
-                return
-            try:
-                os.killpg(pgid, sig)
+                os.killpg(process_pgid, sig)
             except OSError:
                 pass
 
@@ -1910,6 +2054,7 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
         def on_cap_exceeded(label: str) -> None:
             nonlocal cap_exceeded
             cap_exceeded = True
+            cap_event.set()
             trigger_kill(label)
 
         stdout_collector = ShellStreamCollector(
@@ -1929,35 +2074,56 @@ def cmd_run_shell(request: dict[str, Any], request_file: Path, args: argparse.Na
         stdout_collector.start()
         stderr_collector.start()
 
-        try:
-            process.wait(timeout=timeout_seconds)
-        except subprocess.TimeoutExpired:
-            timed_out = True
-            trigger_kill("timeout")
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                with kill_lock:
-                    kill_state["sigkill_sent"] = True
-                killpg_signal(signal.SIGKILL)
+        # Single waiter loop — wake on cap_event, process exit, or the
+        # cron timeout deadline (finding 2 of PR #625 r2 review).
+        # Reuses kill_lock from r2 so SIGTERM/SIGKILL escalation
+        # remains serialized.
+        timeout_deadline = start_monotonic + float(timeout_seconds)
+
+        def escalate_after_grace(grace_seconds: float = 5.0) -> None:
+            # SIGTERM has already been issued via trigger_kill().
+            # Wait up to `grace_seconds` for the immediate child to
+            # exit, then SIGKILL the entire process group so any
+            # descendants that ignored SIGTERM (or were spawned in
+            # `start_new_session=True` and outlived the bash parent)
+            # are also reaped. Without the pgid SIGKILL, a Python
+            # child that traps SIGTERM survives the grace because
+            # `process.poll()` only reflects the immediate Popen
+            # child (typically bash) — descendants in the same
+            # pgid stay alive holding stdout open.
+            grace_deadline = time.monotonic() + grace_seconds
+            while time.monotonic() < grace_deadline:
+                if process.poll() is not None:
+                    break
+                time.sleep(0.1)
+            with kill_lock:
+                kill_state["sigkill_sent"] = True
+            killpg_signal(signal.SIGKILL)
+            if process.poll() is None:
                 try:
                     process.wait(timeout=5)
                 except subprocess.TimeoutExpired:
                     pass
 
-        # If a cap-trip already issued SIGTERM, escalate to SIGKILL on
-        # any process that ignored it before we close pipes.
-        if cap_exceeded and process.returncode is None:
-            try:
-                process.wait(timeout=5)
-            except subprocess.TimeoutExpired:
-                with kill_lock:
-                    kill_state["sigkill_sent"] = True
-                killpg_signal(signal.SIGKILL)
-                try:
-                    process.wait(timeout=5)
-                except subprocess.TimeoutExpired:
-                    pass
+        while True:
+            if process.poll() is not None:
+                break
+            if cap_event.is_set():
+                # Cap tripped — SIGTERM was already issued by
+                # on_cap_exceeded → trigger_kill. Start the SIGKILL
+                # grace from cap-fire, not from cron timeout.
+                escalate_after_grace(5.0)
+                break
+            now = time.monotonic()
+            if now >= timeout_deadline:
+                timed_out = True
+                trigger_kill("timeout")
+                escalate_after_grace(5.0)
+                break
+            # Sleep at most ~0.5s OR until cap_event fires OR until
+            # the timeout deadline, whichever comes first.
+            wait_slice = min(0.5, max(0.0, timeout_deadline - now))
+            cap_event.wait(timeout=wait_slice)
 
         # Drain the collector threads so logs are fully flushed before we
         # write result/status. The child has exited (or been SIGKILLed),
@@ -2069,55 +2235,34 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("runner_error: request_artifact_tampered")
         return 1
 
-    request: Any
     if route == "shell":
-        try:
-            request = read_json(request_file)
-        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-            error_message = f"request_artifact_corrupted: {type(exc).__name__}"
-            write_shell_terminal_error(
-                request_file,
-                runner_error=error_message,
-                summary=f"{error_message}: {exc}",
-                run_id=run_dir_id(request_file.parent),
-            )
-            print("status: error")
-            print(f"run_id: {run_dir_id(request_file.parent)}")
-            print("engine: shell")
-            print(f"runner_error: {error_message}")
-            return 1
-        if not isinstance(request, dict):
-            error_message = "request_artifact_corrupted: non_dict_top_level"
-            write_shell_terminal_error(
-                request_file,
-                runner_error=error_message,
-                summary=error_message,
-                run_id=run_dir_id(request_file.parent),
-            )
-            print("status: error")
-            print(f"run_id: {run_dir_id(request_file.parent)}")
-            print("engine: shell")
-            print(f"runner_error: {error_message}")
-            return 1
-    else:
-        request = read_json(request_file)
+        # Shell-route artifacts are controller-private. Hand off to
+        # `cmd_run_shell` which acquires the per-job flock BEFORE any
+        # body parse/validation (finding 1 of PR #625 r2 review).
+        # The corrupted-JSON / non-dict / payload_kind cross-check
+        # path now runs inside the flock so a body swap between
+        # validate and exec must contend with the lock.
+        return cmd_run_shell(request_file, args)
 
+    # Non-shell route: legacy text path. The artifacts are not
+    # controller-private here, so we treat the body as untrusted —
+    # parse it just enough to reject any cross-route shell payload
+    # (loose-mode dir holding a shell body is tampering).
+    request = read_json(request_file)
     if isinstance(request, dict) and is_shell_request_payload(request):
-        if route != "shell":
-            error_message = "request_artifact_tampered: shell request artifacts are not controller-private"
-            write_shell_terminal_error(
-                request_file,
-                runner_error="request_artifact_tampered",
-                summary=error_message,
-                run_id=str(request.get("run_id") or run_dir_id(request_file.parent)),
-                audit_target_agent=str(request.get("target_agent") or "daemon"),
-            )
-            print("status: error")
-            print(f"run_id: {str(request.get('run_id') or run_dir_id(request_file.parent))}")
-            print("engine: shell")
-            print("runner_error: request_artifact_tampered")
-            return 1
-        return cmd_run_shell(request, request_file, args)
+        error_message = "request_artifact_tampered: shell request artifacts are not controller-private"
+        write_shell_terminal_error(
+            request_file,
+            runner_error="request_artifact_tampered",
+            summary=error_message,
+            run_id=str(request.get("run_id") or run_dir_id(request_file.parent)),
+            audit_target_agent=str(request.get("target_agent") or "daemon"),
+        )
+        print("status: error")
+        print(f"run_id: {str(request.get('run_id') or run_dir_id(request_file.parent))}")
+        print("engine: shell")
+        print("runner_error: request_artifact_tampered")
+        return 1
 
     engine = request.get("target_engine", "")
     run_id = request.get("run_id", "")

--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -45,14 +45,19 @@ RUN_ARTIFACTS_TIER_B_SURFACES = (
 
 # Terminal state.json values for a cron run. "deferred" is intentionally NOT
 # terminal — the runner asks for re-fire and the slot is still in flight.
-_RUN_STATUS_TERMINAL_STATES = {"success", "error", "cancelled"}
+_RUN_STATUS_TERMINAL_STATES = {"success", "error", "timed_out", "cancelled"}
 # Failed runs (state="error") are retained on the longer Tier-B clock so the
 # operator has time to triage even when the originating surface is Tier-A.
-_RUN_STATUS_FAILED_STATES = {"error"}
+_RUN_STATUS_FAILED_STATES = {"error", "timed_out"}
 
 # bridge-queue.py terminal statuses are "done" and "cancelled" only — there
 # is no "failed" queue state. Source: bridge-queue.py status enum + #533.
 _QUEUE_TERMINAL_STATUSES = {"done", "cancelled"}
+
+SHELL_PAYLOAD_ENV_PREFIXES = ("POLL_", "SCRIPT_")
+SHELL_PROTECTED_ENV_EXACT = {"HOME", "PATH"}
+SHELL_PROTECTED_ENV_PREFIXES = ("BRIDGE_", "CRON_")
+SHELL_ARG_FORBIDDEN_RE = re.compile(r"[\x00\r\n;&|<>`]")
 
 
 # Canonical memory-daily prompt body template (issue #541 PR-A).
@@ -225,6 +230,13 @@ def preview_text(value, limit=120):
     return flattened[: limit - 3].rstrip() + "..."
 
 
+def preview_shell_payload(payload, limit=120):
+    script = str(payload.get("script") or "").strip()
+    args = payload.get("args") if isinstance(payload.get("args"), list) else []
+    flattened = " ".join([script, *[str(item) for item in args]]).strip()
+    return preview_text(flattened, limit=limit)
+
+
 def classify_family(name):
     for rule in FAMILY_RULES:
         if name.startswith(rule) or rule in name:
@@ -340,7 +352,13 @@ def build_job_record(job):
     name = job.get("name", "<unnamed>")
     last_status = state.get("lastStatus") or state.get("lastRunStatus") or "-"
     consecutive_errors = int(state.get("consecutiveErrors") or 0)
+    payload_kind = payload.get("kind", "-")
     payload_text = payload.get("text") or payload.get("message") or ""
+    if payload_kind == "shell":
+        payload_text = ""
+        payload_preview = preview_shell_payload(payload)
+    else:
+        payload_preview = preview_text(payload_text)
     last_error = parse_epoch_ms(state.get("lastErrorAtMs"))
     if last_error is None and (consecutive_errors > 0 or last_status not in ("-", "ok", "success")):
         last_error = last_run
@@ -374,7 +392,13 @@ def build_job_record(job):
         "last_inbox_task_id": state.get("lastInboxTaskId"),
         "session_target": job.get("sessionTarget", "-"),
         "wake_mode": job.get("wakeMode", "-"),
-        "payload_kind": payload.get("kind", "-"),
+        "payload_kind": payload_kind,
+        "payload_shell_script": payload.get("script", ""),
+        "payload_shell_args": payload.get("args") if isinstance(payload.get("args"), list) else [],
+        "payload_shell_env": payload.get("env") if isinstance(payload.get("env"), dict) else {},
+        "payload_shell_timeout_seconds": payload.get("timeoutSeconds", ""),
+        "payload_shell_output_cap_bytes": payload.get("outputCapBytes", ""),
+        "execution_run_as_agent": (job.get("execution") or {}).get("runAsAgent", ""),
         "job_delivery_mode": delivery.get("mode", ""),
         "job_delivery_channel": delivery.get("channel", ""),
         "job_delivery_target": delivery.get("to", ""),
@@ -419,7 +443,7 @@ def build_job_record(job):
             or ""
         ).strip(),
         "payload_text": payload_text,
-        "payload_preview": preview_text(payload_text),
+        "payload_preview": payload_preview,
         "raw": job,
     }
 
@@ -533,6 +557,12 @@ def serialize_record(record, include_payload=False):
         "session_target": record["session_target"],
         "wake_mode": record["wake_mode"],
         "payload_kind": record["payload_kind"],
+        "payload_shell_script": record.get("payload_shell_script", ""),
+        "payload_shell_args": record.get("payload_shell_args", []),
+        "payload_shell_env": record.get("payload_shell_env", {}),
+        "payload_shell_timeout_seconds": record.get("payload_shell_timeout_seconds", ""),
+        "payload_shell_output_cap_bytes": record.get("payload_shell_output_cap_bytes", ""),
+        "execution_run_as_agent": record.get("execution_run_as_agent", ""),
         "job_delivery_mode": record["job_delivery_mode"],
         "job_delivery_channel": record["job_delivery_channel"],
         "job_delivery_target": record["job_delivery_target"],
@@ -1652,6 +1682,93 @@ def read_payload_argument(payload_text, payload_file):
     return ""
 
 
+def parse_shell_env(values):
+    env = {}
+    for raw in values or []:
+        if "=" not in raw:
+            raise ValueError("--script-env must be KEY=VALUE")
+        key, value = raw.split("=", 1)
+        if not re.match(r"^[A-Z_][A-Z0-9_]*$", key):
+            raise ValueError(f"invalid --script-env key: {key}")
+        if key in SHELL_PROTECTED_ENV_EXACT or key.startswith(SHELL_PROTECTED_ENV_PREFIXES):
+            raise ValueError(f"protected env var cannot be set by shell cron payload: {key}")
+        if not key.startswith(SHELL_PAYLOAD_ENV_PREFIXES):
+            allowed = ", ".join(f"{prefix}*" for prefix in SHELL_PAYLOAD_ENV_PREFIXES)
+            raise ValueError(f"shell cron env var must use one of these prefixes: {allowed}: {key}")
+        env[key] = value
+    return env
+
+
+def resolve_shell_script(path_value):
+    raw = str(path_value or "").strip()
+    if not raw:
+        raise ValueError("--script is required for --kind shell")
+    bridge_home_value = os.environ.get("BRIDGE_HOME")
+    if raw == "$BRIDGE_HOME" or raw.startswith("$BRIDGE_HOME/"):
+        if not bridge_home_value:
+            raise ValueError("--script uses $BRIDGE_HOME but BRIDGE_HOME is not set")
+        raw = bridge_home_value + raw[len("$BRIDGE_HOME") :]
+    elif "$" in raw:
+        raise ValueError("--script contains an unresolved environment variable")
+    path = Path(raw).expanduser()
+    if not path.is_absolute():
+        raise ValueError("--script must resolve to an absolute path")
+    path = path.resolve()
+    try:
+        stat_result = path.stat()
+    except OSError as exc:
+        raise ValueError(f"--script is not accessible: {path}") from exc
+    if not path.is_file():
+        raise ValueError(f"--script must be a regular file: {path}")
+    if not os.access(path, os.X_OK):
+        raise ValueError(f"--script must be executable: {path}")
+    if stat_result.st_mode & 0o022:
+        raise ValueError(f"--script must not be group/other writable: {path}")
+    return str(path)
+
+
+def validate_shell_args(values):
+    args = []
+    for raw in values or []:
+        value = str(raw)
+        if SHELL_ARG_FORBIDDEN_RE.search(value):
+            raise ValueError(f"--script-arg contains shell metacharacters: {value!r}")
+        if "$(" in value or "${" in value:
+            raise ValueError(f"--script-arg contains shell expansion syntax: {value!r}")
+        args.append(value)
+    return args
+
+
+def build_native_job_shell_payload(args, existing_payload=None, existing_execution=None):
+    existing_payload = existing_payload or {}
+    existing_execution = existing_execution or {}
+    script = args.script if args.script is not None else existing_payload.get("script")
+    run_as_agent = args.run_as_agent or existing_execution.get("runAsAgent")
+    env_values = args.script_env or []
+    arg_values = args.script_arg if args.script_arg is not None else None
+    timeout = args.timeout if args.timeout is not None else existing_payload.get("timeoutSeconds", 900)
+    output_cap = args.output_cap if args.output_cap is not None else existing_payload.get("outputCapBytes", 65536)
+
+    if not run_as_agent:
+        raise ValueError("--run-as-agent is required for --kind shell")
+    if str(run_as_agent).isdigit():
+        raise ValueError("--run-as-agent must be an agent id, not a numeric UID/user")
+    if timeout is None or int(timeout) <= 0:
+        raise ValueError("--timeout must be a positive integer")
+    if output_cap is None or int(output_cap) <= 0:
+        raise ValueError("--output-cap must be a positive integer")
+
+    payload = {
+        "kind": "shell",
+        "script": resolve_shell_script(script),
+        "args": validate_shell_args(arg_values if arg_values is not None else existing_payload.get("args", [])),
+        "env": parse_shell_env(env_values) if env_values else dict(existing_payload.get("env") or {}),
+        "timeoutSeconds": int(timeout),
+        "outputCapBytes": int(output_cap),
+    }
+    return payload, {"runAsAgent": run_as_agent}
+
+
 def parse_at_datetime(value):
     parsed = parse_iso_datetime(value)
     if parsed is None:
@@ -1681,6 +1798,8 @@ def build_native_job(
     actor,
     delete_after_run,
     existing_job=None,
+    payload=None,
+    execution=None,
 ):
     now_ms_value = now_epoch_ms()
     if at_value is not None:
@@ -1695,6 +1814,13 @@ def build_native_job(
             "tz": tz_name or default_tz_name(),
         }
     job = dict(existing_job or {})
+    if payload is None:
+        payload = {
+            "kind": "text",
+            "text": payload_text,
+        }
+    if execution is None:
+        execution = dict(job.get("execution") or {})
     job.update(
         {
             "id": job_id,
@@ -1705,10 +1831,8 @@ def build_native_job(
             "updatedAtMs": now_ms_value,
             "schedule": schedule,
             "deleteAfterRun": bool(delete_after_run),
-            "payload": {
-                "kind": "text",
-                "text": payload_text,
-            },
+            "payload": payload,
+            "execution": execution,
             "sessionTarget": "agent-bridge",
             "wakeMode": "queue-dispatch",
             "state": dict(job.get("state") or {}),
@@ -1777,12 +1901,23 @@ def run_native_create(args):
     records = [build_job_record(job) for job in jobs]
     actor = args.actor or os.environ.get("USER", "unknown")
     title = args.title.strip()
-    payload_text = read_payload_argument(args.payload, args.payload_file)
+    payload_text = ""
+    payload = None
+    execution = None
+    payload_kind = args.kind or "text"
+    if payload_kind == "shell":
+        if args.payload is not None or args.payload_file is not None:
+            raise ValueError("--payload/--payload-file cannot be used with --kind shell")
+        payload, execution = build_native_job_shell_payload(args)
+    else:
+        payload_text = read_payload_argument(args.payload, args.payload_file)
     # Issue #541 PR-A — default memory-daily payloads to the canonical
     # jsonl-aware body when the operator did not supply one explicitly.
     # Operator-provided payloads (--payload / --payload-file) pass through
     # unchanged so existing override workflows keep working.
     if (
+        payload_kind == "text"
+        and
         args.payload is None
         and args.payload_file is None
         and classify_family(title) == "memory-daily"
@@ -1806,6 +1941,8 @@ def run_native_create(args):
         enabled=not args.disabled,
         actor=actor,
         delete_after_run=args.delete_after_run,
+        payload=payload,
+        execution=execution,
     )
     jobs.append(job)
     raw_payload["jobs"] = jobs
@@ -1848,6 +1985,8 @@ def run_native_update(args):
         return 2
 
     existing = dict(jobs[job_index])
+    existing_payload = dict(existing.get("payload") or {})
+    existing_payload_kind = existing_payload.get("kind") or "text"
     title = args.title.strip() if args.title is not None else existing.get("name", record["name"])
     agent = args.agent or existing.get("agentId") or existing.get("agent") or record["agent"]
     schedule = existing.get("schedule") or {}
@@ -1855,9 +1994,41 @@ def run_native_update(args):
     schedule_expr = args.schedule or (schedule.get("expr") if schedule_kind == "cron" else "") or ""
     at_value = args.at or (schedule.get("at") if schedule_kind == "at" else None)
     tz_name = args.tz or schedule.get("tz") or default_tz_name()
+    requested_kind = args.kind
+    shell_fields_present = any(
+        value is not None
+        for value in (args.script, args.run_as_agent, args.timeout, args.output_cap)
+    ) or bool(args.script_arg) or bool(args.script_env)
+    text_fields_present = args.payload is not None or args.payload_file is not None
+    if requested_kind is None:
+        if shell_fields_present:
+            requested_kind = "shell"
+        elif text_fields_present:
+            requested_kind = "text"
+        else:
+            requested_kind = existing_payload_kind
+    if requested_kind != existing_payload_kind and not args.allow_kind_transition:
+        raise ValueError(
+            f"payload kind transition {existing_payload_kind!r} -> {requested_kind!r} requires --allow-kind-transition"
+        )
+    if requested_kind == "shell" and text_fields_present:
+        raise ValueError("--payload/--payload-file cannot be used with --kind shell")
+    if requested_kind == "text" and shell_fields_present:
+        raise ValueError("shell payload options require --kind shell")
+
     payload_text = native_job_payload(existing)
-    if args.payload is not None or args.payload_file is not None:
-        payload_text = read_payload_argument(args.payload, args.payload_file)
+    payload = None
+    execution = None
+    if requested_kind == "shell":
+        payload, execution = build_native_job_shell_payload(
+            args,
+            existing_payload=existing_payload if existing_payload_kind == "shell" else None,
+            existing_execution=existing.get("execution") or {},
+        )
+    else:
+        execution = {}
+        if text_fields_present:
+            payload_text = read_payload_argument(args.payload, args.payload_file)
 
     enabled = existing.get("enabled", True)
     if args.enable:
@@ -1882,6 +2053,8 @@ def run_native_update(args):
         actor=actor,
         delete_after_run=delete_after_run,
         existing_job=existing,
+        payload=payload,
+        execution=execution,
     )
     jobs[job_index] = updated_job
     raw_payload["jobs"] = jobs
@@ -2865,6 +3038,13 @@ def build_parser():
     native_payload_group = native_create_parser.add_mutually_exclusive_group()
     native_payload_group.add_argument("--payload")
     native_payload_group.add_argument("--payload-file")
+    native_create_parser.add_argument("--kind", choices=("text", "shell"), default="text")
+    native_create_parser.add_argument("--script")
+    native_create_parser.add_argument("--script-arg", action="append", default=[])
+    native_create_parser.add_argument("--script-env", action="append", default=[])
+    native_create_parser.add_argument("--run-as-agent")
+    native_create_parser.add_argument("--timeout", type=int)
+    native_create_parser.add_argument("--output-cap", type=int)
     native_create_parser.add_argument("--tz", default=default_tz_name())
     native_create_parser.add_argument("--actor")
     native_create_parser.add_argument("--disabled", action="store_true")
@@ -2881,6 +3061,14 @@ def build_parser():
     native_update_payload_group = native_update_parser.add_mutually_exclusive_group()
     native_update_payload_group.add_argument("--payload")
     native_update_payload_group.add_argument("--payload-file")
+    native_update_parser.add_argument("--kind", choices=("text", "shell"))
+    native_update_parser.add_argument("--script")
+    native_update_parser.add_argument("--script-arg", action="append")
+    native_update_parser.add_argument("--script-env", action="append", default=[])
+    native_update_parser.add_argument("--run-as-agent")
+    native_update_parser.add_argument("--timeout", type=int)
+    native_update_parser.add_argument("--output-cap", type=int)
+    native_update_parser.add_argument("--allow-kind-transition", action="store_true")
     native_update_parser.add_argument("--tz")
     native_update_parser.add_argument("--actor")
     delete_after_run_group = native_update_parser.add_mutually_exclusive_group()

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -167,7 +167,6 @@ run_list() {
 bridge_cron_validate_shell_run_config() {
   local run_as_agent="$1"
   local script_path="${2:-}"
-  local mode="${3:-create}"
 
   [[ -n "$run_as_agent" ]] || bridge_die "--run-as-agent is required for --kind shell"
   bridge_load_roster
@@ -182,10 +181,7 @@ bridge_cron_validate_shell_run_config() {
     bridge_die "--run-as-agent must be an agent id, not a numeric UID/user"
   fi
 
-  if [[ -z "$script_path" && "$mode" == "update" ]]; then
-    return 0
-  fi
-
+  [[ -n "$script_path" ]] || bridge_die "--script is required for --kind shell"
   local resolved_script="$script_path"
   case "$resolved_script" in
     '$BRIDGE_HOME'|'$BRIDGE_HOME'/*)
@@ -260,8 +256,10 @@ run_update() {
     native-update
     --jobs-file "$BRIDGE_NATIVE_CRON_JOBS_FILE"
   )
+  local kind=""
   local run_as_agent=""
   local script_path=""
+  local shell_option_seen=0
 
   shift || true
   [[ -n "$job_ref" ]] || bridge_die "Usage: $(basename "$0") update <job-id> [--agent <bridge-agent>] [--schedule <cron-expr>|--at <iso-datetime>] [--title <title>] [--payload <text>|--payload-file <path>] [--tz <iana-tz>] [--enable|--disable] [--delete-after-run|--keep-after-run]"
@@ -272,8 +270,14 @@ run_update() {
       --agent|--schedule|--at|--title|--payload|--payload-file|--tz|--actor|--kind|--script|--script-arg|--script-env|--run-as-agent|--timeout|--output-cap)
         [[ $# -lt 2 ]] && bridge_die "$1 뒤에 값을 지정하세요."
         case "$1" in
+          --kind) kind="$2" ;;
           --run-as-agent) run_as_agent="$2" ;;
           --script) script_path="$2" ;;
+        esac
+        case "$1" in
+          --kind|--script|--script-arg|--script-env|--run-as-agent|--timeout|--output-cap)
+            shell_option_seen=1
+            ;;
         esac
         py_args+=("$1" "$2")
         shift 2
@@ -292,8 +296,24 @@ run_update() {
     esac
   done
 
-  if [[ -n "$run_as_agent" ]]; then
-    bridge_cron_validate_shell_run_config "$run_as_agent" "$script_path" "update"
+  local existing_shell_payload=""
+  local existing_payload_kind=""
+  local existing_script_path=""
+  local existing_run_as_agent=""
+  existing_shell_payload="$(bridge_cron_python show --jobs-file "$BRIDGE_NATIVE_CRON_JOBS_FILE" --format shell "$job_ref" 2>/dev/null || true)"
+  if [[ -n "$existing_shell_payload" ]]; then
+    local CRON_JOB_PAYLOAD_KIND=""
+    local CRON_JOB_PAYLOAD_SHELL_SCRIPT=""
+    local CRON_JOB_EXECUTION_RUN_AS_AGENT=""
+    # shellcheck disable=SC1090
+    source <(printf '%s\n' "$existing_shell_payload")
+    existing_payload_kind="$CRON_JOB_PAYLOAD_KIND"
+    existing_script_path="$CRON_JOB_PAYLOAD_SHELL_SCRIPT"
+    existing_run_as_agent="$CRON_JOB_EXECUTION_RUN_AS_AGENT"
+  fi
+
+  if [[ "$existing_payload_kind" == "shell" || "$kind" == "shell" || $shell_option_seen -eq 1 ]]; then
+    bridge_cron_validate_shell_run_config "${run_as_agent:-$existing_run_as_agent}" "${script_path:-$existing_script_path}" "update"
   fi
 
   bridge_cron_python "${py_args[@]}"

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -14,8 +14,8 @@ Usage:
   $(basename "$0") show <job-name-or-id> [--json]
   $(basename "$0") import [--source-jobs-file <path>] [--dry-run]
   $(basename "$0") list [--agent <bridge-agent>] [--enabled yes|no|all] [--limit <count>] [--json]
-  $(basename "$0") create --agent <bridge-agent> (--schedule "<cron-expr>" | --at "<iso-datetime>") --title "<title>" [--payload "<text>" | --payload-file <path>] [--tz <iana-tz>] [--delete-after-run]
-  $(basename "$0") update <job-id> [--agent <bridge-agent>] [--schedule "<cron-expr>" | --at "<iso-datetime>"] [--title "<title>"] [--payload "<text>" | --payload-file <path>] [--tz <iana-tz>] [--enable|--disable] [--delete-after-run|--keep-after-run]
+  $(basename "$0") create --agent <bridge-agent> (--schedule "<cron-expr>" | --at "<iso-datetime>") --title "<title>" [--payload "<text>" | --payload-file <path>] [--kind text|shell --script <path> --run-as-agent <agent> [--script-arg <arg>] [--script-env KEY=VALUE] [--timeout <seconds>] [--output-cap <bytes>]] [--tz <iana-tz>] [--delete-after-run]
+  $(basename "$0") update <job-id> [--agent <bridge-agent>] [--schedule "<cron-expr>" | --at "<iso-datetime>"] [--title "<title>"] [--payload "<text>" | --payload-file <path>] [--kind text|shell --script <path> --run-as-agent <agent> [--script-arg <arg>] [--script-env KEY=VALUE] [--timeout <seconds>] [--output-cap <bytes>] [--allow-kind-transition]] [--tz <iana-tz>] [--enable|--disable] [--delete-after-run|--keep-after-run]
   $(basename "$0") delete <job-id>
   $(basename "$0") rebalance-memory-daily [--jobs-file <path>] [--schedule "<cron-expr>"] [--tz <iana-tz>] [--dry-run] [--json]
   $(basename "$0") migrate-payloads --jsonl-aware [--jobs-file <path>] [--dry-run] [--json]
@@ -164,16 +164,72 @@ run_list() {
   bridge_cron_python "${py_args[@]}"
 }
 
+bridge_cron_validate_shell_run_config() {
+  local run_as_agent="$1"
+  local script_path="${2:-}"
+  local mode="${3:-create}"
+
+  [[ -n "$run_as_agent" ]] || bridge_die "--run-as-agent is required for --kind shell"
+  bridge_load_roster
+  bridge_require_agent "$run_as_agent"
+  bridge_agent_linux_user_isolation_effective "$run_as_agent" \
+    || bridge_die "--run-as-agent must name a linux-user isolated agent: $run_as_agent"
+
+  local os_user
+  os_user="$(bridge_agent_os_user "$run_as_agent")"
+  [[ -n "$os_user" ]] || bridge_die "--run-as-agent has no os_user: $run_as_agent"
+  if [[ "$run_as_agent" =~ ^[0-9]+$ || "$os_user" =~ ^[0-9]+$ ]]; then
+    bridge_die "--run-as-agent must be an agent id, not a numeric UID/user"
+  fi
+
+  if [[ -z "$script_path" && "$mode" == "update" ]]; then
+    return 0
+  fi
+
+  local resolved_script="$script_path"
+  case "$resolved_script" in
+    '$BRIDGE_HOME'|'$BRIDGE_HOME'/*)
+      resolved_script="${BRIDGE_HOME}${resolved_script#'$BRIDGE_HOME'}"
+      ;;
+    *'$'*)
+      bridge_die "--script contains an unresolved environment variable: $script_path"
+      ;;
+  esac
+  [[ "$resolved_script" = /* ]] || bridge_die "--script must resolve to an absolute path: $script_path"
+  [[ -f "$resolved_script" && -x "$resolved_script" ]] || bridge_die "--script must be an executable file: $resolved_script"
+
+  local owner_uid run_uid controller_uid mode_bits
+  owner_uid="$(stat -c '%u' "$resolved_script" 2>/dev/null || true)"
+  mode_bits="$(stat -c '%a' "$resolved_script" 2>/dev/null || true)"
+  run_uid="$(id -u "$os_user" 2>/dev/null || true)"
+  controller_uid="$(id -u)"
+  [[ -n "$owner_uid" && -n "$run_uid" ]] || bridge_die "could not resolve --script owner or --run-as-agent uid"
+  if [[ "$owner_uid" != "$controller_uid" && "$owner_uid" != "$run_uid" ]]; then
+    bridge_die "--script owner must be controller uid or run-as uid: $resolved_script"
+  fi
+  if (( (8#$mode_bits) & 0022 )); then
+    bridge_die "--script must not be group/other writable: $resolved_script"
+  fi
+}
+
 run_create() {
   local py_args=(
     native-create
     --jobs-file "$BRIDGE_NATIVE_CRON_JOBS_FILE"
   )
+  local kind="text"
+  local run_as_agent=""
+  local script_path=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --agent|--schedule|--at|--title|--payload|--payload-file|--tz|--actor)
+      --agent|--schedule|--at|--title|--payload|--payload-file|--tz|--actor|--kind|--script|--script-arg|--script-env|--run-as-agent|--timeout|--output-cap)
         [[ $# -lt 2 ]] && bridge_die "$1 뒤에 값을 지정하세요."
+        case "$1" in
+          --kind) kind="$2" ;;
+          --run-as-agent) run_as_agent="$2" ;;
+          --script) script_path="$2" ;;
+        esac
         py_args+=("$1" "$2")
         shift 2
         ;;
@@ -191,6 +247,10 @@ run_create() {
     esac
   done
 
+  if [[ "$kind" == "shell" ]]; then
+    bridge_cron_validate_shell_run_config "$run_as_agent" "$script_path"
+  fi
+
   bridge_cron_python "${py_args[@]}"
 }
 
@@ -200,6 +260,8 @@ run_update() {
     native-update
     --jobs-file "$BRIDGE_NATIVE_CRON_JOBS_FILE"
   )
+  local run_as_agent=""
+  local script_path=""
 
   shift || true
   [[ -n "$job_ref" ]] || bridge_die "Usage: $(basename "$0") update <job-id> [--agent <bridge-agent>] [--schedule <cron-expr>|--at <iso-datetime>] [--title <title>] [--payload <text>|--payload-file <path>] [--tz <iana-tz>] [--enable|--disable] [--delete-after-run|--keep-after-run]"
@@ -207,12 +269,16 @@ run_update() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --agent|--schedule|--at|--title|--payload|--payload-file|--tz|--actor)
+      --agent|--schedule|--at|--title|--payload|--payload-file|--tz|--actor|--kind|--script|--script-arg|--script-env|--run-as-agent|--timeout|--output-cap)
         [[ $# -lt 2 ]] && bridge_die "$1 뒤에 값을 지정하세요."
+        case "$1" in
+          --run-as-agent) run_as_agent="$2" ;;
+          --script) script_path="$2" ;;
+        esac
         py_args+=("$1" "$2")
         shift 2
         ;;
-      --enable|--disable|--delete-after-run|--keep-after-run)
+      --enable|--disable|--delete-after-run|--keep-after-run|--allow-kind-transition)
         py_args+=("$1")
         shift
         ;;
@@ -225,6 +291,10 @@ run_update() {
         ;;
     esac
   done
+
+  if [[ -n "$run_as_agent" ]]; then
+    bridge_cron_validate_shell_run_config "$run_as_agent" "$script_path" "update"
+  fi
 
   bridge_cron_python "${py_args[@]}"
 }
@@ -379,6 +449,44 @@ write_dispatch_body() {
   } >"$body_file"
 }
 
+build_shell_env_snapshot_json() {
+  local run_as_agent="$1"
+  local os_user="$2"
+  local run_home="$3"
+  local agent_env_file="$4"
+
+  (
+    set -a
+    if [[ -f "$agent_env_file" ]]; then
+      # shellcheck source=/dev/null
+      source "$agent_env_file"
+    fi
+    set +a
+    export HOME="$run_home"
+    export USER="$os_user"
+    export LOGNAME="$os_user"
+    export BRIDGE_AGENT_ID="$run_as_agent"
+    export BRIDGE_AGENT_NAME="$run_as_agent"
+    export BRIDGE_AGENT_ENV_FILE="$agent_env_file"
+    export BRIDGE_CONTROLLER_UID="${BRIDGE_CONTROLLER_UID:-$(id -u)}"
+    export BRIDGE_GATEWAY_PROXY=1
+    bridge_require_python
+    python3 - <<'PY'
+import json
+import os
+
+exact = {
+    "HOME", "PATH", "USER", "LOGNAME", "SHELL", "TERM", "LANG", "LC_ALL",
+}
+payload = {}
+for key, value in os.environ.items():
+    if key in exact or key.startswith("BRIDGE_"):
+        payload[key] = value
+print(json.dumps(payload, ensure_ascii=True, sort_keys=True))
+PY
+  )
+}
+
 run_enqueue() {
   local job_ref=""
   local jobs_file
@@ -421,6 +529,13 @@ run_enqueue() {
   local target_channels=""
   local target_discord_state_dir=""
   local target_telegram_state_dir=""
+  local shell_run_as_agent=""
+  local shell_os_user=""
+  local shell_uid=""
+  local shell_gid=""
+  local shell_home=""
+  local shell_agent_env_file=""
+  local shell_env_snapshot_json="{}"
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -477,6 +592,12 @@ run_enqueue() {
   local CRON_JOB_NEXT_RUN_AT=""
   local CRON_JOB_PAYLOAD_KIND=""
   local CRON_JOB_PAYLOAD_TEXT=""
+  local CRON_JOB_PAYLOAD_SHELL_SCRIPT=""
+  local CRON_JOB_PAYLOAD_SHELL_ARGS="[]"
+  local CRON_JOB_PAYLOAD_SHELL_ENV="{}"
+  local CRON_JOB_PAYLOAD_SHELL_TIMEOUT_SECONDS=""
+  local CRON_JOB_PAYLOAD_SHELL_OUTPUT_CAP_BYTES=""
+  local CRON_JOB_EXECUTION_RUN_AS_AGENT=""
 
   shell_payload="$(bridge_cron_python show --jobs-file "$jobs_file" --format shell "$job_ref")" || exit $?
   # shellcheck disable=SC1090
@@ -539,6 +660,33 @@ run_enqueue() {
   # = use runner-side defaults (default policy, normal priority).
   cron_reporting_policy="${CRON_JOB_CRON_REPORTING_POLICY:-}"
   cron_urgency="${CRON_JOB_CRON_URGENCY:-}"
+  shell_run_as_agent=""
+  shell_os_user=""
+  shell_uid=""
+  shell_gid=""
+  shell_home=""
+  shell_agent_env_file=""
+  shell_env_snapshot_json="{}"
+  if [[ "$CRON_JOB_PAYLOAD_KIND" == "shell" ]]; then
+    shell_run_as_agent="${CRON_JOB_EXECUTION_RUN_AS_AGENT:-}"
+    [[ -n "$shell_run_as_agent" ]] || bridge_die "shell cron job is missing execution.runAsAgent: $CRON_JOB_NAME"
+    bridge_require_agent "$shell_run_as_agent"
+    bridge_agent_linux_user_isolation_effective "$shell_run_as_agent" \
+      || bridge_die "shell cron run_as_agent must be linux-user isolated: $shell_run_as_agent"
+    shell_os_user="$(bridge_agent_os_user "$shell_run_as_agent")"
+    [[ -n "$shell_os_user" ]] || bridge_die "shell cron run_as_agent has no os_user: $shell_run_as_agent"
+    [[ ! "$shell_run_as_agent" =~ ^[0-9]+$ && ! "$shell_os_user" =~ ^[0-9]+$ ]] \
+      || bridge_die "shell cron run_as_agent must be an agent id, not numeric UID/user"
+    shell_uid="$(id -u "$shell_os_user")"
+    shell_gid="$(id -g "$shell_os_user")"
+    shell_home="$(getent passwd "$shell_os_user" | awk -F: '{print $6}' | head -n1)"
+    [[ -n "$shell_home" ]] || shell_home="$(bridge_agent_linux_user_home "$shell_os_user")"
+    shell_agent_env_file="$(bridge_agent_linux_env_file "$shell_run_as_agent")"
+    if [[ ! -f "$shell_agent_env_file" ]] && command -v bridge_write_linux_agent_env_file >/dev/null 2>&1; then
+      bridge_write_linux_agent_env_file "$shell_run_as_agent" "$shell_agent_env_file"
+    fi
+    shell_env_snapshot_json="$(build_shell_env_snapshot_json "$shell_run_as_agent" "$shell_os_user" "$shell_home" "$shell_agent_env_file")"
+  fi
   request_rel="${request_file#$BRIDGE_HOME/}"
   result_rel="${result_file#$BRIDGE_HOME/}"
   status_rel="${status_file#$BRIDGE_HOME/}"
@@ -610,16 +758,21 @@ except Exception:
   # task_id=0 is a sentinel placeholder; real queue id is patched in below
   # via bridge_cron_update_*_task_id once the queue record exists.
   created_at="$(bridge_now_iso)"
-  bridge_cron_write_request "$request_file" "$run_id" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$jobs_file" "$CRON_JOB_PAYLOAD_KIND" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels" "$disable_mcp" "$cron_reporting_policy" "$cron_urgency"
+  bridge_cron_write_request "$request_file" "$run_id" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$jobs_file" "$CRON_JOB_PAYLOAD_KIND" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels" "$disable_mcp" "$cron_reporting_policy" "$cron_urgency" "$CRON_JOB_PAYLOAD_SHELL_SCRIPT" "$CRON_JOB_PAYLOAD_SHELL_ARGS" "$CRON_JOB_PAYLOAD_SHELL_ENV" "$shell_run_as_agent" "$shell_os_user" "$shell_uid" "$shell_gid" "$shell_home" "$shell_agent_env_file" "$shell_env_snapshot_json" "$CRON_JOB_PAYLOAD_SHELL_TIMEOUT_SECONDS" "$CRON_JOB_PAYLOAD_SHELL_OUTPUT_CAP_BYTES"
   bridge_cron_write_status "$status_file" "$run_id" "queued" "$target_engine" "$request_file" "$result_file" "$created_at"
   bridge_cron_write_manifest "$manifest_file" "$CRON_JOB_ID" "$CRON_JOB_NAME" "$CRON_JOB_FAMILY" "$CRON_JOB_AGENT" "$target" "$slot" "0" "$created_at" "$body_file" "$jobs_file" "$run_id" "$request_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$delivery_mode" "$disposable_needs_channels" "$cron_reporting_policy" "$cron_urgency"
+  if [[ "$CRON_JOB_PAYLOAD_KIND" == "shell" ]]; then
+    bridge_cron_normalize_shell_run_artifacts "$(bridge_cron_run_dir_by_id "$run_id")" "$request_file" "$status_file" "$payload_file"
+  fi
   # Per-run ACL grant is best-effort under v1.3 (#219): the memory-daily
   # harvester now runs as the controller UID, so it does not need the
   # isolated os_user to own/rwX the per-run dir. Other families that do
   # spawn isolated subprocesses can still rely on the grant when sudo/acl
   # infrastructure is available; failure here is non-fatal and does NOT
   # remove the pre-queue artifacts.
-  bridge_cron_run_dir_grant_isolation "$(bridge_cron_run_dir_by_id "$run_id")" "$target" >/dev/null 2>&1 || true
+  if [[ "$CRON_JOB_PAYLOAD_KIND" != "shell" ]]; then
+    bridge_cron_run_dir_grant_isolation "$(bridge_cron_run_dir_by_id "$run_id")" "$target" >/dev/null 2>&1 || true
+  fi
 
   create_output="$(bridge_queue_cli create --to "$target" --title "$title" --from "$actor" --priority "$priority" --body-file "$body_file")"
   printf '%s\n' "$create_output"
@@ -632,6 +785,9 @@ except Exception:
 
   bridge_cron_update_request_task_id "$request_file" "$task_id"
   bridge_cron_update_manifest_task_id "$manifest_file" "$task_id"
+  if [[ "$CRON_JOB_PAYLOAD_KIND" == "shell" ]]; then
+    bridge_cron_normalize_shell_run_artifacts "$(bridge_cron_run_dir_by_id "$run_id")" "$request_file" "$status_file" "$payload_file"
+  fi
 
   printf 'run_id: %s\n' "$run_id"
   printf 'request_file: %s\n' "$request_rel"

--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -709,16 +709,35 @@ bridge_cron_write_request() {
   # the inbox-task creation path.
   local cron_reporting_policy="${31:-}"
   local cron_urgency="${32:-}"
+  local shell_script="${33:-}"
+  local shell_args_json="${34:-[]}"
+  local shell_env_json="${35:-{}}"
+  local shell_run_as_agent="${36:-}"
+  local shell_os_user="${37:-}"
+  local shell_uid="${38:-}"
+  local shell_gid="${39:-}"
+  local shell_home="${40:-}"
+  local shell_agent_env_file="${41:-}"
+  local shell_env_snapshot_json="${42:-{}}"
+  local shell_timeout_seconds="${43:-}"
+  local shell_output_cap_bytes="${44:-}"
 
   mkdir -p "$(dirname "$request_file")"
 
   bridge_require_python
-  python3 - "$request_file" "$run_id" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$source_file" "$payload_kind" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" "$disable_mcp" "$cron_reporting_policy" "$cron_urgency" <<'PY'
+  python3 - "$request_file" "$run_id" "$job_id" "$job_name" "$family" "$source_agent" "$target" "$slot" "$task_id" "$created_at" "$body_file" "$payload_file" "$result_file" "$status_file" "$stdout_log" "$stderr_log" "$source_file" "$payload_kind" "$target_engine" "$target_workdir" "$target_channels" "$target_discord_state_dir" "$target_telegram_state_dir" "$job_delivery_mode" "$job_delivery_channel" "$job_delivery_target" "$allow_channel_delivery" "$routing_mode" "$disposable_needs_channels" "$disable_mcp" "$cron_reporting_policy" "$cron_urgency" "$shell_script" "$shell_args_json" "$shell_env_json" "$shell_run_as_agent" "$shell_os_user" "$shell_uid" "$shell_gid" "$shell_home" "$shell_agent_env_file" "$shell_env_snapshot_json" "$shell_timeout_seconds" "$shell_output_cap_bytes" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-(request_file, run_id, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, payload_file, result_file, status_file, stdout_log, stderr_log, source_file, payload_kind, target_engine, target_workdir, target_channels, target_discord_state_dir, target_telegram_state_dir, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels, disable_mcp, cron_reporting_policy, cron_urgency) = sys.argv[1:]
+(request_file, run_id, job_id, job_name, family, source_agent, target, slot, task_id, created_at, body_file, payload_file, result_file, status_file, stdout_log, stderr_log, source_file, payload_kind, target_engine, target_workdir, target_channels, target_discord_state_dir, target_telegram_state_dir, job_delivery_mode, job_delivery_channel, job_delivery_target, allow_channel_delivery, routing_mode, disposable_needs_channels, disable_mcp, cron_reporting_policy, cron_urgency, shell_script, shell_args_json, shell_env_json, shell_run_as_agent, shell_os_user, shell_uid, shell_gid, shell_home, shell_agent_env_file, shell_env_snapshot_json, shell_timeout_seconds, shell_output_cap_bytes) = sys.argv[1:]
+
+def decode_json(value, fallback):
+    try:
+        decoded = json.loads(value)
+    except json.JSONDecodeError:
+        return fallback
+    return decoded
 
 payload = {
     "run_id": run_id,
@@ -756,6 +775,25 @@ payload = {
     "stderr_log": stderr_log,
     "source_file": source_file,
 }
+if payload_kind == "shell":
+    shell_payload = {
+        "kind": "shell",
+        "script": shell_script,
+        "args": decode_json(shell_args_json, []),
+        "env": decode_json(shell_env_json, {}),
+        "timeoutSeconds": int(shell_timeout_seconds or 900),
+        "outputCapBytes": int(shell_output_cap_bytes or 65536),
+    }
+    payload["payload"] = shell_payload
+    payload["execution"] = {
+        "run_as_agent": shell_run_as_agent,
+        "os_user": shell_os_user,
+        "uid": int(shell_uid),
+        "gid": int(shell_gid),
+        "home": shell_home,
+        "agent_env_file": shell_agent_env_file,
+        "env_snapshot": decode_json(shell_env_snapshot_json, {}),
+    }
 
 Path(request_file).write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 PY
@@ -794,6 +832,28 @@ if error_message:
 
 Path(status_file).write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
 PY
+}
+
+bridge_cron_normalize_shell_run_artifacts() {
+  local run_dir="$1"
+  shift || true
+  [[ -n "$run_dir" && -d "$run_dir" ]] || return 0
+
+  if command -v setfacl >/dev/null 2>&1; then
+    setfacl -b -k "$run_dir" >/dev/null 2>&1 || true
+    local artifact
+    for artifact in "$@"; do
+      [[ -n "$artifact" && -e "$artifact" ]] || continue
+      setfacl -b "$artifact" >/dev/null 2>&1 || true
+    done
+  fi
+
+  chmod 0700 "$run_dir" >/dev/null 2>&1 || true
+  local file
+  for file in "$@"; do
+    [[ -n "$file" && -e "$file" ]] || continue
+    chmod 0600 "$file" >/dev/null 2>&1 || true
+  done
 }
 
 bridge_cron_run_dir_grant_isolation() {

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys
 }
 
 add_all_integration() {
@@ -187,7 +187,7 @@ select_for_path() {
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -199,7 +199,8 @@ select_for_path() {
       # Issue #541 PR-A — memory-daily payload migration also lives in
       # bridge-cron.py; pull its smoke in for the same trigger set.
       # Issue #628 — cron mutation audit emission ditto.
-      add_required cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit queue
+      # Native cron shell payload runner regression.
+      add_required cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10363,6 +10363,10 @@ bash "$REPO_ROOT/scripts/smoke/cron-migrate-payloads.sh"
 log "running cron-mutation-audit smoke (issue #628)"
 bash "$REPO_ROOT/scripts/smoke/cron-mutation-audit.sh"
 
+# Native cron shell payload runner regression.
+log "running cron-shell-runner smoke"
+bash "$REPO_ROOT/scripts/smoke/cron-shell-runner.sh"
+
 # Issue #544 PR1 — curated bin/agb shim for isolated agents.
 log "running isolated-bin-agb smoke (issue #544 PR1)"
 log "isolated-bin-agb covers shim env-source/delegation/fallback only — live PATH injection requires isolate+restart"

--- a/scripts/smoke/cron-shell-runner.sh
+++ b/scripts/smoke/cron-shell-runner.sh
@@ -22,7 +22,16 @@ CURRENT_UID="$(id -u)"
 CURRENT_GID="$(id -g)"
 JOBS_FILE="$BRIDGE_HOME/cron/jobs.json"
 export CURRENT_USER CURRENT_UID CURRENT_GID JOBS_FILE
+export BRIDGE_NATIVE_CRON_JOBS_FILE="$JOBS_FILE"
 printf '{"format":"agent-bridge-cron-v1","jobs":[]}\n' >"$JOBS_FILE"
+cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "smoke-agent"
+BRIDGE_AGENT_DESC["smoke-agent"]="Smoke isolated agent"
+BRIDGE_AGENT_ENGINE["smoke-agent"]="claude"
+BRIDGE_AGENT_SESSION["smoke-agent"]="smoke-agent"
+BRIDGE_AGENT_ISOLATION_MODE["smoke-agent"]="linux-user"
+BRIDGE_AGENT_OS_USER["smoke-agent"]="$CURRENT_USER"
+EOF
 
 make_script() {
   local name="$1"
@@ -307,6 +316,100 @@ exit 0')"
   fi
 }
 
+smoke_t39b_invalid_json_tamper_terminal() {
+  local run_dir request status out
+  run_dir="$BRIDGE_CRON_STATE_DIR/runs/t39b-run"
+  mkdir -p "$run_dir"
+  request="$run_dir/request.json"
+  printf '{not-json\n' >"$request"
+  chmod 0770 "$run_dir"
+  chmod 0660 "$request"
+  if run_runner "$request" >/tmp/cron-shell-t39b.out 2>&1; then
+    smoke_fail "T39b expected invalid JSON/tamper rejection"
+  fi
+  out="$(cat /tmp/cron-shell-t39b.out)"
+  smoke_assert_not_contains "$out" "Traceback" "T39b no traceback"
+  status="$run_dir/status.json"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T39b status error"
+  smoke_assert_eq "request_artifact_tampered" "$(json_field "$status" runner_error)" "T39b terminal runner_error"
+}
+
+smoke_t39c_update_revalidates_shell_script() {
+  local script_path job_id out
+  if [[ "$(id -u)" == "0" ]]; then
+    smoke_skip "T39c root-owned script rejection" "current uid is root"
+    return 0
+  fi
+  script_path="$(make_script t39c.sh '#!/usr/bin/env bash
+exit 0')"
+  python3 "$SMOKE_REPO_ROOT/bridge-cron.py" native-create \
+    --jobs-file "$JOBS_FILE" \
+    --agent smoke-agent \
+    --schedule '* * * * *' \
+    --title shell-update-validate \
+    --kind shell \
+    --script "$script_path" \
+    --run-as-agent smoke-agent >/dev/null
+  job_id="$(python3 - "$JOBS_FILE" <<'PY'
+import json, sys
+jobs = json.load(open(sys.argv[1], encoding="utf-8"))["jobs"]
+print(next(job["id"] for job in jobs if job["name"] == "shell-update-validate"))
+PY
+)"
+  if bash "$SMOKE_REPO_ROOT/bridge-cron.sh" update "$job_id" --script /bin/true >/tmp/cron-shell-t39c-root.out 2>&1; then
+    smoke_fail "T39c expected root-owned script update rejection"
+  fi
+  out="$(cat /tmp/cron-shell-t39c-root.out)"
+  smoke_assert_contains "$out" "owner must be controller uid or run-as uid" "T39c root-owned script rejection reason"
+
+  chmod 0775 "$script_path"
+  if bash "$SMOKE_REPO_ROOT/bridge-cron.sh" update "$job_id" --schedule '*/5 * * * *' >/tmp/cron-shell-t39c-mode.out 2>&1; then
+    smoke_fail "T39c expected existing unsafe script revalidation rejection"
+  fi
+  out="$(cat /tmp/cron-shell-t39c-mode.out)"
+  smoke_assert_contains "$out" "must not be group/other writable" "T39c existing script mode rejection reason"
+}
+
+smoke_t39d_validation_failure_terminal() {
+  local script_path request status result out
+  script_path="$(make_script t39d.sh '#!/usr/bin/env bash
+exit 0')"
+  request="$(write_request t39d-run t39d-job "$script_path")"
+  chmod 0775 "$script_path"
+  if run_runner "$request" >/tmp/cron-shell-t39d.out 2>&1; then
+    smoke_fail "T39d expected script validation failure"
+  fi
+  out="$(cat /tmp/cron-shell-t39d.out)"
+  smoke_assert_not_contains "$out" "Traceback" "T39d no traceback"
+  status="${request%/*}/status.json"
+  result="${request%/*}/result.json"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T39d status error"
+  smoke_assert_contains "$(json_field "$status" runner_error)" "script_validation_failed:" "T39d status runner_error"
+  smoke_assert_eq "error" "$(json_field "$result" status)" "T39d result error"
+
+  script_path="$(make_script t39d-env.sh '#!/usr/bin/env bash
+exit 0')"
+  request="$(write_request t39d-env-run t39d-env-job "$script_path")"
+  python3 - "$request" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+data = json.load(open(path, encoding="utf-8"))
+data["payload"]["env"] = {"BRIDGE_HOME": "override"}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, ensure_ascii=True, indent=2)
+    fh.write("\n")
+PY
+  if run_runner "$request" >/tmp/cron-shell-t39d-env.out 2>&1; then
+    smoke_fail "T39d expected protected env validation failure"
+  fi
+  out="$(cat /tmp/cron-shell-t39d-env.out)"
+  smoke_assert_not_contains "$out" "Traceback" "T39d env no traceback"
+  status="${request%/*}/status.json"
+  smoke_assert_contains "$(json_field "$status" runner_error)" "script_validation_failed:" "T39d env terminal runner_error"
+}
+
 smoke_run "T30 schema + update preservation" smoke_t30_schema_and_update
 smoke_run "T35 argv injection rejection" smoke_t35_reject_argv_injection
 smoke_run "T31 UID-drop access contract" smoke_t31_uid_drop_access_contract
@@ -317,5 +420,8 @@ smoke_run "T36 output cap" smoke_t36_output_cap
 smoke_run "T37 no Claude/Codex child" smoke_t37_no_model_child
 smoke_run "T38 lock contention is silent success" smoke_t38_lock_held_success
 smoke_run "T39 tamper rejection" smoke_t39_tamper_rejected
+smoke_run "T39b invalid JSON tamper writes terminal status" smoke_t39b_invalid_json_tamper_terminal
+smoke_run "T39c update revalidates shell script" smoke_t39c_update_revalidates_shell_script
+smoke_run "T39d validation failure writes terminal status" smoke_t39d_validation_failure_terminal
 
 smoke_log "all cron shell runner checks passed"

--- a/scripts/smoke/cron-shell-runner.sh
+++ b/scripts/smoke/cron-shell-runner.sh
@@ -334,6 +334,67 @@ smoke_t39b_invalid_json_tamper_terminal() {
   smoke_assert_eq "request_artifact_tampered" "$(json_field "$status" runner_error)" "T39b terminal runner_error"
 }
 
+smoke_t39e_corrupted_controller_private_json_terminal() {
+  local run_dir request status result out runner_error
+
+  run_dir="$BRIDGE_CRON_STATE_DIR/runs/t39e-array-run"
+  mkdir -p "$run_dir"
+  request="$run_dir/request.json"
+  printf '[]\n' >"$request"
+  chmod 0700 "$run_dir"
+  chmod 0600 "$request"
+  if run_runner "$request" >/tmp/cron-shell-t39e-array.out 2>&1; then
+    smoke_fail "T39e expected array request corruption"
+  fi
+  out="$(cat /tmp/cron-shell-t39e-array.out)"
+  smoke_assert_not_contains "$out" "Traceback" "T39e array no traceback"
+  status="$run_dir/status.json"
+  result="$run_dir/result.json"
+  runner_error="$(json_field "$status" runner_error)"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T39e array status error"
+  smoke_assert_contains "$runner_error" "request_artifact_corrupted" "T39e array runner_error"
+  smoke_assert_contains "$runner_error" "non_dict_top_level" "T39e array runner_error category"
+  smoke_assert_eq "error" "$(json_field "$result" status)" "T39e array result error"
+
+  run_dir="$BRIDGE_CRON_STATE_DIR/runs/t39e-null-run"
+  mkdir -p "$run_dir"
+  request="$run_dir/request.json"
+  printf 'null\n' >"$request"
+  chmod 0700 "$run_dir"
+  chmod 0600 "$request"
+  if run_runner "$request" >/tmp/cron-shell-t39e-null.out 2>&1; then
+    smoke_fail "T39e expected scalar request corruption"
+  fi
+  out="$(cat /tmp/cron-shell-t39e-null.out)"
+  smoke_assert_not_contains "$out" "Traceback" "T39e scalar no traceback"
+  status="$run_dir/status.json"
+  result="$run_dir/result.json"
+  runner_error="$(json_field "$status" runner_error)"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T39e scalar status error"
+  smoke_assert_contains "$runner_error" "request_artifact_corrupted" "T39e scalar runner_error"
+  smoke_assert_contains "$runner_error" "non_dict_top_level" "T39e scalar runner_error category"
+  smoke_assert_eq "error" "$(json_field "$result" status)" "T39e scalar result error"
+
+  run_dir="$BRIDGE_CRON_STATE_DIR/runs/t39e-binary-run"
+  mkdir -p "$run_dir"
+  request="$run_dir/request.json"
+  printf '\377\376\000\001' >"$request"
+  chmod 0700 "$run_dir"
+  chmod 0600 "$request"
+  if run_runner "$request" >/tmp/cron-shell-t39e-binary.out 2>&1; then
+    smoke_fail "T39e expected binary request corruption"
+  fi
+  out="$(cat /tmp/cron-shell-t39e-binary.out)"
+  smoke_assert_not_contains "$out" "Traceback" "T39e binary no traceback"
+  status="$run_dir/status.json"
+  result="$run_dir/result.json"
+  runner_error="$(json_field "$status" runner_error)"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T39e binary status error"
+  smoke_assert_contains "$runner_error" "request_artifact_corrupted" "T39e binary runner_error"
+  smoke_assert_contains "$runner_error" "UnicodeDecodeError" "T39e binary runner_error category"
+  smoke_assert_eq "error" "$(json_field "$result" status)" "T39e binary result error"
+}
+
 smoke_t39c_update_revalidates_shell_script() {
   local script_path job_id out
   if [[ "$(id -u)" == "0" ]]; then
@@ -423,5 +484,6 @@ smoke_run "T39 tamper rejection" smoke_t39_tamper_rejected
 smoke_run "T39b invalid JSON tamper writes terminal status" smoke_t39b_invalid_json_tamper_terminal
 smoke_run "T39c update revalidates shell script" smoke_t39c_update_revalidates_shell_script
 smoke_run "T39d validation failure writes terminal status" smoke_t39d_validation_failure_terminal
+smoke_run "T39e corrupted controller-private JSON writes terminal status" smoke_t39e_corrupted_controller_private_json_terminal
 
 smoke_log "all cron shell runner checks passed"

--- a/scripts/smoke/cron-shell-runner.sh
+++ b/scripts/smoke/cron-shell-runner.sh
@@ -238,9 +238,19 @@ python3 \"$SMOKE_REPO_ROOT/bridge-queue.py\" create --to worker-a --from cron-sh
 }
 
 smoke_t34_timeout_killpg() {
-  local script_path request status result
+  # T34 verifies the timeout path issues `killpg` against the child's
+  # process group, not just the direct parent — without this, a script
+  # that backgrounds work would leak children past the cron timeout.
+  # The script forks a background `sleep`, persists its PID under the
+  # run dir via $CRON_RUN_DIR, and waits on it. After the runner
+  # times out we assert that the background PID is no longer alive.
+  local script_path request status result child_pid_file child_pid attempts
   script_path="$(make_script t34.sh '#!/usr/bin/env bash
-sleep 30')"
+set -u
+sleep 30 &
+child_pid=$!
+printf "%s" "$child_pid" >"$CRON_RUN_DIR/t34-child.pid"
+wait "$child_pid"')"
   request="$(write_request t34-run t34-job "$script_path" 1)"
   if run_runner "$request" >/tmp/cron-shell-t34.out 2>&1; then
     smoke_fail "T34 expected timeout exit"
@@ -249,17 +259,44 @@ sleep 30')"
   result="${request%/*}/result.json"
   smoke_assert_eq "timed_out" "$(json_field "$status" state)" "T34 status timed_out"
   smoke_assert_contains "$(json_field "$result" runner_error)" "timed out after 1s" "T34 timeout result"
+
+  child_pid_file="${request%/*}/t34-child.pid"
+  if [[ ! -s "$child_pid_file" ]]; then
+    smoke_fail "T34 background child PID file missing or empty"
+  fi
+  child_pid="$(cat "$child_pid_file")"
+  # Bound the post-timeout drain — the runner SIGTERMs and then waits up
+  # to ~5s before SIGKILL, after which the kernel may take a moment to
+  # reap. 20 retries x 0.25s caps total wait at ~5s past runner exit.
+  attempts=0
+  while (( attempts < 20 )) && kill -0 "$child_pid" 2>/dev/null; do
+    sleep 0.25
+    attempts=$((attempts + 1))
+  done
+  if kill -0 "$child_pid" 2>/dev/null; then
+    smoke_fail "T34 background child $child_pid survived process-group kill"
+  fi
 }
 
 smoke_t36_output_cap() {
-  local script_path request result
+  # T36 verifies output cap enforcement. Per finding 2 of PR #625 r2 review,
+  # cap-exceeded is now a terminal error (`runner_error=output_cap_exceeded`)
+  # rather than a silent success — so the runner exits non-zero and the
+  # status/result reflect the cap trip.
+  local script_path request result status
   script_path="$(make_script t36.sh '#!/usr/bin/env bash
 printf "%080d\n" 1')"
   request="$(write_request t36-run t36-job "$script_path" 5 16)"
-  run_runner "$request" >/dev/null
+  if run_runner "$request" >/tmp/cron-shell-t36.out 2>&1; then
+    smoke_fail "T36 expected output_cap_exceeded non-zero exit"
+  fi
   result="${request%/*}/result.json"
+  status="${request%/*}/status.json"
   smoke_assert_eq "True" "$(json_field "$result" stdout_truncated)" "T36 stdout truncated flag"
   smoke_assert_contains "$(cat "${request%/*}/stdout.log")" "output truncated" "T36 truncation marker"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T36 status error"
+  smoke_assert_eq "output_cap_exceeded" "$(json_field "$status" runner_error)" "T36 runner_error"
+  smoke_assert_eq "error" "$(json_field "$result" status)" "T36 result error"
 }
 
 smoke_t37_no_model_child() {
@@ -399,6 +436,17 @@ smoke_t39c_update_revalidates_shell_script() {
   local script_path job_id out
   if [[ "$(id -u)" == "0" ]]; then
     smoke_skip "T39c root-owned script rejection" "current uid is root"
+    return 0
+  fi
+  # T39c exercises the `bridge-cron.sh update` wrapper, which requires
+  # linux-user isolation to be effective on the run-as agent. Off Linux,
+  # `bridge_agent_linux_user_isolation_effective` returns false and the
+  # wrapper dies before any update logic runs, so the assertions below
+  # cannot be exercised on macOS hosts. Gate the test on Linux to keep
+  # the smoke suite green on operator workstations (finding 4 of PR #625
+  # r2 review).
+  if ! smoke_is_linux; then
+    smoke_skip "T39c update revalidates shell script" "non-Linux (linux-user isolation not effective)"
     return 0
   fi
   script_path="$(make_script t39c.sh '#!/usr/bin/env bash

--- a/scripts/smoke/cron-shell-runner.sh
+++ b/scripts/smoke/cron-shell-runner.sh
@@ -299,6 +299,61 @@ printf "%080d\n" 1')"
   smoke_assert_eq "error" "$(json_field "$result" status)" "T36 result error"
 }
 
+smoke_t36b_cap_grace_sigterm_ignoring() {
+  # T36b verifies that the cap-exceeded SIGKILL grace fires from cap-fire,
+  # not from the cron timeout (finding 2 of PR #625 r2 review). The child
+  # ignores SIGTERM and prints 80 bytes (cap=16) before sleeping forever.
+  # Pre-r3 the runner waited the full timeoutSeconds before SIGKILL grace
+  # started, so this took ~13s with timeout=8 + 5s grace. After r3 the
+  # waiter wakes on cap_event, SIGTERMs immediately, then SIGKILLs after
+  # at most 5s — total ≤ ~6s under load.
+  local script_path request result status duration_ms duration_s child_pid_file child_pid attempts
+  script_path="$(make_script t36b.sh '#!/usr/bin/env bash
+python3 -c "
+import os, signal, sys, time
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+with open(os.environ[\"CRON_RUN_DIR\"] + \"/t36b-child.pid\", \"w\") as fh:
+    fh.write(str(os.getpid()))
+sys.stdout.write(\"x\" * 80 + \"\\n\")
+sys.stdout.flush()
+time.sleep(60)
+"')"
+  request="$(write_request t36b-run t36b-job "$script_path" 8 16)"
+  if run_runner "$request" >/tmp/cron-shell-t36b.out 2>&1; then
+    smoke_fail "T36b expected output_cap_exceeded non-zero exit"
+  fi
+  result="${request%/*}/result.json"
+  status="${request%/*}/status.json"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T36b status error"
+  smoke_assert_eq "output_cap_exceeded" "$(json_field "$status" runner_error)" "T36b runner_error"
+  smoke_assert_eq "error" "$(json_field "$result" status)" "T36b result error"
+  # Wall-clock budget: cap fires almost immediately, SIGTERM is ignored,
+  # 5s grace, SIGKILL. Allow up to 7s of total wall time so a slow CI
+  # box still passes; pre-r3 this was ~13.1s.
+  duration_ms="$(json_field "$result" duration_ms)"
+  duration_s="$(python3 -c "print(${duration_ms} / 1000.0)")"
+  if python3 -c "import sys; sys.exit(0 if ${duration_s} <= 7.0 else 1)"; then
+    :
+  else
+    smoke_fail "T36b duration ${duration_s}s exceeds cap-grace budget (≤ 7s expected)"
+  fi
+  # The SIGTERM-ignoring child should be dead after SIGKILL; allow a
+  # short reap window after the runner returns.
+  child_pid_file="${request%/*}/t36b-child.pid"
+  if [[ ! -s "$child_pid_file" ]]; then
+    smoke_fail "T36b child PID file missing or empty"
+  fi
+  child_pid="$(cat "$child_pid_file")"
+  attempts=0
+  while (( attempts < 20 )) && kill -0 "$child_pid" 2>/dev/null; do
+    sleep 0.25
+    attempts=$((attempts + 1))
+  done
+  if kill -0 "$child_pid" 2>/dev/null; then
+    smoke_fail "T36b SIGTERM-ignoring child $child_pid survived cap-grace SIGKILL"
+  fi
+}
+
 smoke_t37_no_model_child() {
   local script_path request status
   script_path="$(make_script t37.sh '#!/usr/bin/env bash
@@ -526,6 +581,7 @@ smoke_run "T32 silent success" smoke_t32_success_silent
 smoke_run "T33 script creates queue task" smoke_t33_script_can_create_queue_task
 smoke_run "T34 timeout killpg" smoke_t34_timeout_killpg
 smoke_run "T36 output cap" smoke_t36_output_cap
+smoke_run "T36b cap grace fires from cap-trip not cron timeout" smoke_t36b_cap_grace_sigterm_ignoring
 smoke_run "T37 no Claude/Codex child" smoke_t37_no_model_child
 smoke_run "T38 lock contention is silent success" smoke_t38_lock_held_success
 smoke_run "T39 tamper rejection" smoke_t39_tamper_rejected

--- a/scripts/smoke/cron-shell-runner.sh
+++ b/scripts/smoke/cron-shell-runner.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# scripts/smoke/cron-shell-runner.sh — native cron payload.kind=shell smoke.
+
+set -euo pipefail
+
+SMOKE_NAME="cron-shell-runner"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "cron-shell-runner"
+export BRIDGE_CRON_STATE_DIR="$BRIDGE_STATE_DIR/cron"
+mkdir -p "$BRIDGE_CRON_STATE_DIR/runs" "$BRIDGE_CRON_STATE_DIR/locks" "$BRIDGE_HOME/cron"
+
+CURRENT_USER="$(id -un)"
+CURRENT_UID="$(id -u)"
+CURRENT_GID="$(id -g)"
+JOBS_FILE="$BRIDGE_HOME/cron/jobs.json"
+export CURRENT_USER CURRENT_UID CURRENT_GID JOBS_FILE
+printf '{"format":"agent-bridge-cron-v1","jobs":[]}\n' >"$JOBS_FILE"
+
+make_script() {
+  local name="$1"
+  local body="$2"
+  local path="$SMOKE_TMP_ROOT/$name"
+  printf '%s\n' "$body" >"$path"
+  chmod 0755 "$path"
+  printf '%s' "$path"
+}
+
+write_request() {
+  local run_id="$1"
+  local job_id="$2"
+  local script_path="$3"
+  local timeout="${4:-5}"
+  local output_cap="${5:-65536}"
+  local args_json="${6:-[]}"
+  local env_json="${7:-{}}"
+  local run_dir="$BRIDGE_CRON_STATE_DIR/runs/$run_id"
+  mkdir -p "$run_dir"
+  chmod 0700 "$run_dir"
+  python3 - "$run_dir/request.json" "$run_id" "$job_id" "$script_path" "$timeout" "$output_cap" "$args_json" "$env_json" <<PY
+import json
+import os
+import sys
+
+request_file, run_id, job_id, script_path, timeout, output_cap, args_json, env_json = sys.argv[1:]
+run_dir = os.path.dirname(request_file)
+payload = {
+    "run_id": run_id,
+    "job_id": job_id,
+    "job_name": job_id,
+    "family": "smoke",
+    "source_agent": "smoke-agent",
+    "target_agent": "smoke-target",
+    "target_engine": "shell",
+    "payload_kind": "shell",
+    "slot": "manual",
+    "dispatch_task_id": 0,
+    "created_at": "2026-05-06T00:00:00+00:00",
+    "dispatch_body_file": os.path.join(run_dir, "body.md"),
+    "payload_file": os.path.join(run_dir, "payload.md"),
+    "result_file": os.path.join(run_dir, "result.json"),
+    "status_file": os.path.join(run_dir, "status.json"),
+    "stdout_log": os.path.join(run_dir, "stdout.log"),
+    "stderr_log": os.path.join(run_dir, "stderr.log"),
+    "source_file": os.environ["JOBS_FILE"],
+    "payload": {
+        "kind": "shell",
+        "script": script_path,
+        "args": json.loads(args_json),
+        "env": json.loads(env_json),
+        "timeoutSeconds": int(timeout),
+        "outputCapBytes": int(output_cap),
+    },
+    "execution": {
+        "run_as_agent": "smoke-agent",
+        "os_user": os.environ["CURRENT_USER"],
+        "uid": int(os.environ["CURRENT_UID"]),
+        "gid": int(os.environ["CURRENT_GID"]),
+        "home": os.environ["HOME"],
+        "agent_env_file": os.path.join(run_dir, "agent-env.sh"),
+        "env_snapshot": {
+            "HOME": os.environ["HOME"],
+            "PATH": os.environ.get("PATH", ""),
+            "USER": os.environ["CURRENT_USER"],
+            "LOGNAME": os.environ["CURRENT_USER"],
+            "BRIDGE_HOME": os.environ["BRIDGE_HOME"],
+            "BRIDGE_STATE_DIR": os.environ["BRIDGE_STATE_DIR"],
+            "BRIDGE_SHARED_DIR": os.environ["BRIDGE_SHARED_DIR"],
+            "BRIDGE_TASK_DB": os.environ["BRIDGE_TASK_DB"],
+            "BRIDGE_CRON_STATE_DIR": os.environ["BRIDGE_CRON_STATE_DIR"],
+            "BRIDGE_GATEWAY_PROXY": "0",
+            "BRIDGE_CLAUDE_BIN": "/bin/false",
+        },
+    },
+}
+with open(request_file, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh, ensure_ascii=True, indent=2)
+    fh.write("\n")
+os.chmod(request_file, 0o600)
+PY
+  printf '%s/request.json' "$run_dir"
+}
+
+json_field() {
+  local file="$1"
+  local expr="$2"
+  python3 - "$file" "$expr" <<'PY'
+import json
+import sys
+
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+value = data
+for part in sys.argv[2].split("."):
+    value = value.get(part)
+print(value if value is not None else "")
+PY
+}
+
+run_runner() {
+  python3 "$SMOKE_REPO_ROOT/bridge-cron-runner.py" run --request-file "$1"
+}
+
+smoke_t30_schema_and_update() {
+  local script_path job_id
+  script_path="$(make_script t30.sh '#!/usr/bin/env bash
+exit 0')"
+  python3 "$SMOKE_REPO_ROOT/bridge-cron.py" native-create \
+    --jobs-file "$JOBS_FILE" \
+    --agent smoke-agent \
+    --schedule '* * * * *' \
+    --title shell-smoke \
+    --kind shell \
+    --script "$script_path" \
+    --script-arg alpha \
+    --script-env SCRIPT_MODE=smoke \
+    --run-as-agent smoke-agent \
+    --timeout 7 \
+    --output-cap 99 >/dev/null
+  job_id="$(python3 - "$JOBS_FILE" <<'PY'
+import json, sys
+job = json.load(open(sys.argv[1], encoding="utf-8"))["jobs"][0]
+assert job["payload"]["kind"] == "shell"
+assert job["payload"]["script"].endswith("t30.sh")
+assert job["payload"]["args"] == ["alpha"]
+assert job["payload"]["env"] == {"SCRIPT_MODE": "smoke"}
+assert job["payload"]["timeoutSeconds"] == 7
+assert job["payload"]["outputCapBytes"] == 99
+assert job["execution"]["runAsAgent"] == "smoke-agent"
+print(job["id"])
+PY
+)"
+  python3 "$SMOKE_REPO_ROOT/bridge-cron.py" native-update --jobs-file "$JOBS_FILE" "$job_id" --title shell-smoke-renamed >/dev/null
+  smoke_assert_eq "shell" "$(python3 - "$JOBS_FILE" <<'PY'
+import json, sys
+print(json.load(open(sys.argv[1], encoding="utf-8"))["jobs"][0]["payload"]["kind"])
+PY
+)" "cron update preserves shell payload kind"
+}
+
+smoke_t35_reject_argv_injection() {
+  local script_path
+  script_path="$(make_script t35.sh '#!/usr/bin/env bash
+exit 0')"
+  if python3 "$SMOKE_REPO_ROOT/bridge-cron.py" native-create \
+    --jobs-file "$JOBS_FILE" \
+    --agent smoke-agent \
+    --schedule '* * * * *' \
+    --title bad-argv \
+    --kind shell \
+    --script "$script_path" \
+    --script-arg 'ok;rm -rf /' \
+    --run-as-agent smoke-agent >/tmp/cron-shell-t35.out 2>&1; then
+    smoke_fail "T35 expected argv injection rejection"
+  fi
+  smoke_assert_contains "$(cat /tmp/cron-shell-t35.out)" "shell metacharacters" "T35 rejection reason"
+}
+
+smoke_t32_success_silent() {
+  local script_path request result status
+  script_path="$(make_script t32.sh '#!/usr/bin/env bash
+exit 0')"
+  request="$(write_request t32-run t32-job "$script_path")"
+  run_runner "$request" >/dev/null
+  result="${request%/*}/result.json"
+  status="${request%/*}/status.json"
+  smoke_assert_eq "success" "$(json_field "$status" state)" "T32 status success"
+  smoke_assert_eq "success" "$(json_field "$result" status)" "T32 result success"
+  smoke_assert_eq "silent" "$(json_field "$result" reporting_decision)" "T32 silent reporting"
+  smoke_assert_eq "" "$(cat "${request%/*}/stdout.log")" "T32 empty stdout"
+}
+
+smoke_t31_uid_drop_access_contract() {
+  local script_path request out marker
+  python3 "$SMOKE_REPO_ROOT/bridge-queue.py" init >/dev/null
+  mkdir -p "$BRIDGE_STATE_DIR/agents/smoke-agent"
+  printf 'shared-ok\n' >"$BRIDGE_SHARED_DIR/t31.txt"
+  marker="$BRIDGE_STATE_DIR/agents/smoke-agent/t31.marker"
+  script_path="$(make_script t31.sh "#!/usr/bin/env bash
+set -euo pipefail
+test -r \"\$HOME\"
+grep -q shared-ok \"\$BRIDGE_SHARED_DIR/t31.txt\"
+printf state-ok >\"$marker\"
+python3 \"$SMOKE_REPO_ROOT/bridge-queue.py\" create --to worker-a --from cron-shell --priority normal --title t31-gateway --body t31 --format shell >/dev/null
+printf T31PASS")"
+  request="$(write_request t31-run t31-job "$script_path")"
+  run_runner "$request" >/dev/null
+  smoke_assert_eq "state-ok" "$(cat "$marker")" "T31 agent state write"
+  smoke_assert_contains "$(cat "${request%/*}/stdout.log")" "T31PASS" "T31 script completed access probes"
+  out="$(python3 "$SMOKE_REPO_ROOT/bridge-queue.py" inbox --agent worker-a)"
+  smoke_assert_contains "$out" "t31-gateway" "T31 queue access through script"
+}
+
+smoke_t33_script_can_create_queue_task() {
+  local script_path request out
+  python3 "$SMOKE_REPO_ROOT/bridge-queue.py" init >/dev/null
+  script_path="$(make_script t33.sh "#!/usr/bin/env bash
+python3 \"$SMOKE_REPO_ROOT/bridge-queue.py\" create --to worker-a --from cron-shell --priority normal --title shell-created --body shell-body --format shell")"
+  request="$(write_request t33-run t33-job "$script_path")"
+  run_runner "$request" >/dev/null
+  out="$(python3 "$SMOKE_REPO_ROOT/bridge-queue.py" inbox --agent worker-a)"
+  smoke_assert_contains "$out" "shell-created" "T33 script-created task reached inbox"
+}
+
+smoke_t34_timeout_killpg() {
+  local script_path request status result
+  script_path="$(make_script t34.sh '#!/usr/bin/env bash
+sleep 30')"
+  request="$(write_request t34-run t34-job "$script_path" 1)"
+  if run_runner "$request" >/tmp/cron-shell-t34.out 2>&1; then
+    smoke_fail "T34 expected timeout exit"
+  fi
+  status="${request%/*}/status.json"
+  result="${request%/*}/result.json"
+  smoke_assert_eq "timed_out" "$(json_field "$status" state)" "T34 status timed_out"
+  smoke_assert_contains "$(json_field "$result" runner_error)" "timed out after 1s" "T34 timeout result"
+}
+
+smoke_t36_output_cap() {
+  local script_path request result
+  script_path="$(make_script t36.sh '#!/usr/bin/env bash
+printf "%080d\n" 1')"
+  request="$(write_request t36-run t36-job "$script_path" 5 16)"
+  run_runner "$request" >/dev/null
+  result="${request%/*}/result.json"
+  smoke_assert_eq "True" "$(json_field "$result" stdout_truncated)" "T36 stdout truncated flag"
+  smoke_assert_contains "$(cat "${request%/*}/stdout.log")" "output truncated" "T36 truncation marker"
+}
+
+smoke_t37_no_model_child() {
+  local script_path request status
+  script_path="$(make_script t37.sh '#!/usr/bin/env bash
+echo no-model-needed')"
+  request="$(write_request t37-run t37-job "$script_path")"
+  run_runner "$request" >/dev/null
+  status="${request%/*}/status.json"
+  smoke_assert_eq "success" "$(json_field "$status" state)" "T37 succeeds despite BRIDGE_CLAUDE_BIN=/bin/false"
+}
+
+smoke_t38_lock_held_success() {
+  local script_path request_a request_b out_b status_a status_b
+  script_path="$(make_script t38.sh '#!/usr/bin/env bash
+sleep 2')"
+  request_a="$(write_request t38-run-a t38-job "$script_path" 5)"
+  request_b="$(write_request t38-run-b t38-job "$script_path" 5)"
+  run_runner "$request_a" >/tmp/cron-shell-t38-a.out 2>&1 &
+  local pid
+  pid=$!
+  sleep 0.3
+  out_b="$(run_runner "$request_b")"
+  wait "$pid"
+  status_a="${request_a%/*}/status.json"
+  status_b="${request_b%/*}/status.json"
+  smoke_assert_eq "success" "$(json_field "$status_a" state)" "T38 first run success"
+  smoke_assert_contains "$out_b" "lock_held" "T38 second run lock-held"
+  smoke_assert_eq "success" "$(json_field "$status_b" state)" "T38 lock-held status success"
+}
+
+smoke_t39_tamper_rejected() {
+  local script_path request status
+  script_path="$(make_script t39.sh '#!/usr/bin/env bash
+exit 0')"
+  request="$(write_request t39-run t39-job "$script_path")"
+  chmod 0770 "${request%/*}"
+  if run_runner "$request" >/tmp/cron-shell-t39.out 2>&1; then
+    smoke_fail "T39 expected tamper rejection"
+  fi
+  status="${request%/*}/status.json"
+  smoke_assert_eq "error" "$(json_field "$status" state)" "T39 chmod tamper status error"
+  smoke_assert_eq "request_artifact_tampered" "$(json_field "$status" runner_error)" "T39 chmod tamper runner_error"
+
+  if command -v setfacl >/dev/null 2>&1; then
+    request="$(write_request t39-acl-run t39-acl-job "$script_path")"
+    setfacl -m "u:${CURRENT_USER}:rwX" "${request%/*}"
+    if run_runner "$request" >/tmp/cron-shell-t39-acl.out 2>&1; then
+      smoke_fail "T39 expected ACL tamper rejection"
+    fi
+    smoke_assert_eq "request_artifact_tampered" "$(json_field "${request%/*}/status.json" runner_error)" "T39 ACL tamper runner_error"
+  else
+    smoke_skip "T39 ACL write exposure" "setfacl not available"
+  fi
+}
+
+smoke_run "T30 schema + update preservation" smoke_t30_schema_and_update
+smoke_run "T35 argv injection rejection" smoke_t35_reject_argv_injection
+smoke_run "T31 UID-drop access contract" smoke_t31_uid_drop_access_contract
+smoke_run "T32 silent success" smoke_t32_success_silent
+smoke_run "T33 script creates queue task" smoke_t33_script_can_create_queue_task
+smoke_run "T34 timeout killpg" smoke_t34_timeout_killpg
+smoke_run "T36 output cap" smoke_t36_output_cap
+smoke_run "T37 no Claude/Codex child" smoke_t37_no_model_child
+smoke_run "T38 lock contention is silent success" smoke_t38_lock_held_success
+smoke_run "T39 tamper rejection" smoke_t39_tamper_rejected
+
+smoke_log "all cron shell runner checks passed"


### PR DESCRIPTION
## Summary
- Add bridge-native cron `payload.kind=shell` schema/CLI for controlled shell jobs.
- Enqueue shell jobs with a self-contained execution block: run-as agent, os user/uid/gid/home, agent-env path, and env snapshot.
- Run shell payloads through a dedicated runner path with controller-owned request artifacts, no isolated run-dir write ACL grant, job-level flock, UID drop, process-group timeout, output caps, and silent result/status semantics.

## r5 implementation notes
- Shell request/run artifacts are normalized immediately after creation and after task-id patching to strip ACL/default ACL exposure and force controller-private modes.
- Shell runner derives fallback status/result/stdout/stderr paths from `request_file.parent` before trusting request JSON paths.
- Tamper checks cover owner/mode and ACL/default-ACL write exposure before script execution.

## r2 review fixes
- Move shell artifact routing ahead of request JSON parsing; malformed/tampered shell artifacts now produce terminal `status.json`/`result.json` instead of a traceback.
- Revalidate shell job scripts on every `cron update` of an existing shell job, including schedule-only updates and post-create script mode drift.
- Convert shell request/script/env validation failures into terminal artifacts with `runner_error=script_validation_failed: ...`.
- Extend cron-shell smoke with T39b/T39c/T39d for invalid JSON tamper, update validation bypass, and post-enqueue validation failures.

## r3 review fixes
- Treat shell-routed request JSON decode errors and non-object top-level payloads as `request_artifact_corrupted: ...` terminal artifacts.
- Extend cron-shell smoke with T39e for array, null, and binary-corrupted controller-private request files with no traceback.

## r2 changes (upstream review)

Dispatched directly by the orchestrator per the `feedback_upstream_review_merge_authority` policy after the orchestrator-side codex pair-review returned `needs-more` with 4 substantive findings (security + smoke quality). One commit on top of r5; no schema or wire-format changes.

- **Finding 1 (D2 TOCTOU under flock).** Restructure `cmd_run_shell` so the per-job flock is acquired BEFORE request and script validation. The lock path is derived from `request.job_id`/`run_id` immediately after parsing the request, then a single `with lock_file.open(...)` block:
  1. Tries `LOCK_EX | LOCK_NB`; on `BlockingIOError` writes the silent `lock_held` terminal as before.
  2. Re-runs `validate_shell_request_artifacts()` under the lock so a swap between validate and exec must contend with the same lock.
  3. Validates the script (`is_file`, `os.access`, `st_uid`, mode bits) under the lock, then again immediately before `subprocess.Popen` via the new `_validate_shell_script` helper.
  4. Holds the lock until the child exits AND the streaming collector threads drain.
- **Finding 2 (D6 OOM via unbounded `communicate()`).** Replace `process.communicate(timeout=…)` with a new `ShellStreamCollector` (one daemon thread per pipe). Each collector streams to its log file in 64KB chunks with a per-stream byte counter; once `outputCapBytes` is exceeded it stops writing, marks `truncated`, and invokes a callback that issues `os.killpg(SIGTERM)` on the child's process group (escalates to `SIGKILL` after a 5s grace if the process is still alive). The remainder of the pipe is drained but discarded so the child does not block on a full buffer. The new contract is terminal: cap-exceeded sets `final_state=error` and `runner_error=output_cap_exceeded` (it was previously a silent success on a truncated run).
- **Finding 3 (D5 timeout regression guard).** T34 now spawns a background `sleep 30` from the smoke script, persists its PID under the run dir via `$CRON_RUN_DIR/t34-child.pid`, and `wait`s on it. After the runner times out the test reads the PID file and bounded-polls `kill -0` to assert the background child has been terminated by the process-group SIGTERM. A foreground-only `sleep` would have passed the original assertion even if `killpg` was actually `kill`.
- **Finding 4 (T39c macOS abort).** T39c exercises the `bridge-cron.sh update` wrapper, which calls `bridge_cron_validate_shell_run_config` and dies on any host where `bridge_agent_linux_user_isolation_effective` is false (i.e. macOS / Windows / Linux without configured os_user). The test is now gated on `smoke_is_linux`; off Linux it skips with a clear reason instead of aborting the suite.

T36 (output cap) was updated alongside finding 2: the cap-exceeded contract changed from "silent success with `stdout_truncated=true`" to "terminal error with `runner_error=output_cap_exceeded`", so the test now asserts non-zero exit, `state=error`, and the new `runner_error`. The original `stdout_truncated=true` and "output truncated" marker assertions are preserved.

### r2 (upstream) verification
- `python3 -m py_compile bridge-cron.py bridge-cron-runner.py`
- `bash -n` + `shellcheck` on `scripts/smoke/cron-shell-runner.sh` (clean — shellcheck IS installed on this host).
- `bash scripts/smoke/cron-shell-runner.sh` — T30-T39e all pass; T34 child-pid killpg assertion passes; T36 terminal error path passes; T39c skipped with `(non-Linux (linux-user isolation not effective))`.
- `bash scripts/smoke/cron-migrate-payloads.sh` + `bash scripts/smoke/cron-run-artifacts-retention.sh` — pass.
- `git diff --check` clean.

## Scope
Framework-only. No PI/CRM private scripts, payloads, or environment config included.

## Acceptance / smoke
- `python3 -m py_compile bridge-cron.py bridge-cron-runner.py`
- `bash -n bridge-cron.sh lib/bridge-cron.sh scripts/ci-select-smoke.sh scripts/smoke-test.sh scripts/smoke/cron-shell-runner.sh`
- `git diff --check`
- `scripts/smoke/cron-shell-runner.sh` covers T30-T39e: schema/update preservation, UID-drop access probes, silent success, script-created queue task, timeout killpg (now with background-child PID assertion), argv injection rejection, output cap (now terminal error), no Claude/Codex child, lock-held success, tamper/ACL rejection, invalid JSON tamper terminal artifacts, update revalidation (Linux-gated), validation-failure terminal artifacts, and corrupted controller-private JSON terminal artifacts.
- `scripts/smoke/cron-migrate-payloads.sh`
- `scripts/smoke/cron-run-artifacts-retention.sh`
- `scripts/smoke/queue.sh` — pre-existing symlinked-home runtime-id parity flake remains; not attributable to this PR.
