### PR TITLE
fix(hooks): managed default disables Claude Code inline-suggestion (#630)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -213,6 +213,34 @@ orphaned but harmless after migration (no symlink references it);
 operators may delete it manually after verifying the per-agent files
 exist and contain the expected `autoCompactWindow` value.
 
+### promptSuggestionEnabled default (v0.7.x+, issue #630)
+
+`bridge-hooks.py render-shared-settings` writes a managed
+`promptSuggestionEnabled: false` default for every managed Claude
+agent, alongside `autoCompactWindow`. This disables Claude Code's
+inline composer ghost text — the dimmed "Try asking …" suggestion
+that appears in the input box after a turn completes.
+
+Why this is a managed default: the daemon's pending-input detector
+(`bridge_tmux_session_inject_busy` →
+`bridge_tmux_line_has_sgr_dim`, `lib/bridge-tmux.sh:1322`) reads the
+ghost text as real typed input and defers the first send of every
+queued task until the nudge fallback fires (~30s–1min latency). PR
+\#566 added an SGR-2 (dim) detector to filter the dim form, but
+newer Claude Code builds render the suggestion with other ANSI
+shapes (24-bit gray, 256-color faint, `\x1b[90m`) the narrow
+detector misses (#630). Disabling the feature at the settings layer
+is the stable fix — bridge-managed agents are operated through the
+queue, not by a human typing in the composer, so the suggestion has
+no value here.
+
+Operator opt-out (re-enable for an agent you attach to interactively):
+add `"promptSuggestionEnabled": true` to the per-agent overlay
+(`settings.local.json`) or to the install-wide overlay
+(`$BRIDGE_AGENT_HOME_ROOT/.claude/settings.local.json`). Overlay wins
+over managed defaults via the renderer's
+`managed defaults < base < overlay < preserved user keys` order.
+
 ### PreCompact channel auto-notify (issue #597, in-flight)
 
 Agent Bridge can post a one-line notice to the channel that most

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -58,8 +58,26 @@ def managed_claude_settings_defaults(
     launch_cmd: str | None,
     agent_class: str | None = None,
 ) -> dict[str, Any]:
+    # `promptSuggestionEnabled: False` disables Claude Code's inline
+    # composer ghost text (the dimmed "Try asking …" suggestion that
+    # appears in the input box after a turn completes). On bridge-managed
+    # agents the daemon's pending-input detector
+    # (`bridge_tmux_session_inject_busy` → `bridge_tmux_line_has_sgr_dim`,
+    # `lib/bridge-tmux.sh:1322`) reads that ghost text as real typed
+    # input and defers the first send of every queued task until the
+    # nudge fallback fires (~30s–1min latency). PR #566 added an SGR-2
+    # detector to filter the dim form, but newer Claude Code builds
+    # render the suggestion with other ANSI shapes (24-bit gray,
+    # 256-color faint, `\x1b[90m`) the narrow detector misses (#630).
+    # Disabling the feature at the settings layer is the stable fix —
+    # bridge-managed agents are operated through the queue, not by a
+    # human typing in the composer, so the suggestion has no value here.
+    # Operators who attach interactively and want it back can set
+    # `promptSuggestionEnabled: true` in the per-agent overlay
+    # (`settings.local.json`) — overlay wins over managed defaults.
     return {
         "autoCompactWindow": resolve_managed_autocompact_window(launch_cmd, agent_class),
+        "promptSuggestionEnabled": False,
     }
 
 

--- a/scripts/smoke/managed-autocompact-window.sh
+++ b/scripts/smoke/managed-autocompact-window.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-# scripts/smoke/managed-autocompact-window.sh — Issue #570 / #593 regression smoke.
+# scripts/smoke/managed-autocompact-window.sh — Issue #570 / #593 / #630 regression smoke.
 #
-# Covers `bridge-hooks.py render-shared-settings` resolution of the managed
-# autoCompactWindow default. Issue #593 made the resolver class-aware:
-# static→400_000, dynamic→1_000_000, unknown/missing→1_000_000 (back-compat).
+# Covers `bridge-hooks.py render-shared-settings` resolution of the
+# managed Claude Code defaults. Issue #593 made the autoCompactWindow
+# resolver class-aware: static→400_000, dynamic→1_000_000,
+# unknown/missing→1_000_000 (back-compat). Issue #630 added a
+# promptSuggestionEnabled=false managed default so bridge-managed
+# Claude agents render with the inline composer ghost text disabled
+# (the daemon's SGR-2 dim detector misses newer Claude builds; the
+# stable fix is to turn the feature off at the settings layer rather
+# than chase ANSI shapes — see PR #566 history).
 # The `--launch-cmd` flag is still accepted for backwards compatibility but
 # is no longer consulted; the new `--agent-class` flag drives the decision.
 #
@@ -17,6 +23,8 @@
 #   - CLAUDE_CODE_AUTO_COMPACT_WINDOW                 → operator escape hatch (env
 #     wins via Claude Code's resolution order; verified at the runtime layer,
 #     not in this renderer-only smoke).
+#   - promptSuggestionEnabled default false (#630)
+#   - overlay re-enables promptSuggestionEnabled       (#630 operator opt-out)
 
 set -euo pipefail
 
@@ -45,6 +53,30 @@ payload = json.loads(Path(effective_file).read_text(encoding="utf-8"))
 actual = payload.get("autoCompactWindow")
 if actual != int(expected):
     raise SystemExit(f"{context}: autoCompactWindow expected {expected}, got {actual!r}")
+PY
+}
+
+# Issue #630: managed default disables Claude Code inline composer ghost
+# text so the daemon's pending-input detector cannot mistake it for real
+# typed input. Operator overlays still win.
+assert_prompt_suggestion() {
+  local effective_file="$1"
+  local expected="$2"
+  local context="$3"
+
+  python3 - "$effective_file" "$expected" "$context" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+effective_file, expected, context = sys.argv[1:]
+payload = json.loads(Path(effective_file).read_text(encoding="utf-8"))
+actual = payload.get("promptSuggestionEnabled")
+expected_bool = {"true": True, "false": False}[expected.lower()]
+if actual is not expected_bool:
+    raise SystemExit(
+        f"{context}: promptSuggestionEnabled expected {expected_bool}, got {actual!r}"
+    )
 PY
 }
 
@@ -114,7 +146,22 @@ main() {
     --launch-cmd "claude [1m]"
   assert_window "$effective" "475000" "explicit overlay value overrides managed default"
 
-  smoke_log "PASS: managed autoCompactWindow resolver matrix (#570 / #593)"
+  # Issue #630 — promptSuggestionEnabled managed default.
+  rm -f "$base" "$overlay"
+
+  smoke_log "case: promptSuggestionEnabled defaults to false (#630 ghost-text disable)"
+  run_render "$base" "$overlay" "$effective" --launch-cmd ""
+  assert_prompt_suggestion "$effective" "false" \
+    "managed default disables inline composer ghost text"
+
+  smoke_log "case: overlay can re-enable promptSuggestionEnabled (#630 operator opt-out path)"
+  printf '%s\n' '{"promptSuggestionEnabled":true}' >"$overlay"
+  run_render "$base" "$overlay" "$effective" --launch-cmd ""
+  assert_prompt_suggestion "$effective" "true" \
+    "operator overlay re-enables ghost text"
+  rm -f "$overlay"
+
+  smoke_log "PASS: managed autoCompactWindow resolver matrix (#570 / #593) + promptSuggestionEnabled (#630)"
 }
 
 main "$@"


### PR DESCRIPTION
Closes #630.

## Summary

Disables Claude Code inline-suggestion (ghost text) at the settings layer rather than chasing new ANSI shapes in `bridge_tmux_line_has_sgr_dim` (`lib/bridge-tmux.sh:1322`). PR #566 added a narrow SGR 2 detector; #630 reports newer Claude builds use ANSI shapes that detector misses (24-bit gray, 256-color faint, `\x1b[90m`).

Rather than playing detector whack-a-mole with each Claude Code build, this PR sets `promptSuggestionEnabled: false` as a managed default in `bridge-hooks.py:managed_claude_settings_defaults()`. The setting is a real Claude Code feature key (already in operator's own `~/.claude/settings.json`).

## Changes

- `bridge-hooks.py` (+18) — add `promptSuggestionEnabled: false` to managed defaults.
- `scripts/smoke/managed-autocompact-window.sh` (+52/-5) — extend with two #630 cases (default-false, overlay-re-enables).
- `OPERATIONS.md` (+28) — add policy paragraph mirroring autoCompactWindow doc.

## Why this approach over expanding the detector

- **Stable across Claude builds** — settings layer doesn't depend on ANSI shape.
- **Zero detector maintenance** — no new patterns to add for each build.
- **Operator opt-out preserved** — per-agent or install-wide `settings.local.json` overlay can re-enable; `managed defaults < base < overlay < preserved user keys` composition order in bridge-hooks.py honors operator override.

## Detector intentionally retained

PR #566's `bridge_tmux_line_has_sgr_dim` and friends are unchanged. They still help for:
- Older Claude Code builds.
- Codex placeholder ghost text (separate code path, #201).
- Operator-overlaid agents that re-enable suggestion via `settings.local.json`.

## Verification

- `python3 -m py_compile bridge-hooks.py` — PASS
- `bash -n scripts/smoke/managed-autocompact-window.sh` — PASS
- `shellcheck scripts/smoke/managed-autocompact-window.sh` — PASS
- `bash scripts/smoke/managed-autocompact-window.sh` — PASS (10 cases: 8 prior + 2 #630)
- `bash scripts/smoke/hooks.sh` — PASS
- `bash scripts/smoke/per-agent-settings-rendering.sh` — PASS
- E2E `render-isolated-home-settings`: settings.effective.json shows both `autoCompactWindow=400000` (static class) and `promptSuggestionEnabled=false`

## Concerns / dependencies

- `promptSuggestionEnabled` is a Claude Code feature key, not part of the bridge schema. If future Claude renames the key, the managed default becomes silent no-op. Documented in OPERATIONS.md.
- Setting intentionally NOT in `PRESERVED_USER_KEYS` — bridge re-asserts on every render. Operators wanting per-agent override use `settings.local.json` (which IS preserved).
- Live behavior verification (start an agent, observe ghost text, queue task, check first-send latency) requires a real Claude session. Operator should verify post-merge.

## Pre-existing smoke flake

`scripts/smoke-test.sh` fails at "#365 follow-up" (refusing to write isolated agent-env.sh from ephemeral controller path). Verified reproduces on clean `origin/main` without these edits — unrelated to this PR.
