### PR TITLE
fix(cron): disable is idempotent — skip deferral writer on disabled jobs (#627)

### DIFF
--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -2063,6 +2063,42 @@ def run_native_finalize(args):
         final_status = "success"
     else:
         final_status = "error"
+
+    # #627: A deferral that lands after the operator disables the job
+    # must not mutate state — disable should be idempotent. The dispatcher
+    # contract says only enabled jobs get scheduled, so a deferred slot
+    # finishing on a disabled job is an inflight-after-disable race.
+    # Drop the deferral provenance update entirely (no lastDeferredAtMs,
+    # nextRunAtMs, or updatedAtMs bump) so `agb cron show` keeps showing
+    # the disable timestamp as the last mutation. The success/error paths
+    # are intentionally NOT gated here — they carry consecutive-error
+    # accounting that operators may still want recorded; #628 (audit gap)
+    # tracks broader trace coverage separately.
+    if final_status == "deferred" and not job.get("enabled", True):
+        print(
+            f"info: dropping deferred state writer for disabled job "
+            f"{job_id} run={run_id}",
+            file=sys.stderr,
+        )
+        payload = {
+            "status": "skipped",
+            "reason": "job_disabled",
+            "job_id": job_id,
+            "run_id": run_id,
+            "final_status": final_status,
+            "jobs_file": str(jobs_path),
+        }
+        if args.json:
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+        else:
+            print("status: skipped")
+            print("reason: job_disabled")
+            print(f"job_id: {job_id}")
+            print(f"run_id: {run_id}")
+            print(f"final_status: {final_status}")
+            print(f"jobs_file: {jobs_path}")
+        return 0
+
     duration_ms = result.get("duration_ms")
     try:
         duration_ms = int(duration_ms) if duration_ms not in (None, "") else None


### PR DESCRIPTION
Closes #627.

## Symptom

`bridge-cron.py:run_native_finalize` (the deferral writer at lines 2118-2133 on `main`) didn't check the job's `enabled` flag, so a `state=deferred` status from an inflight slot would mutate `state.lastDeferredAtMs`, `state.lastDeferredReason`, `state.nextRunAtMs`, and bump `job.updatedAtMs` on a job that the operator had already disabled.

Concrete incident from the SYRS install on 2026-05-02 12:48~13:23 (quoted in the issue body): 13 disabled crons, 5 of them gained fresh `lastDeferredReason: memory_pressure` writes after the disable timestamp. The dashboard then showed a future `nextRunAtMs` on a disabled job, and operators couldn't tell if disable had really taken effect.

## Fix (Option 1 from issue body)

Gate the `final_status == "deferred"` writer block on `job.get("enabled", True)`. If the job is disabled, the function returns a `{"status": "skipped", "reason": "job_disabled"}` payload without touching state:
- no `lastDeferredAtMs` / `lastDeferredReason` write
- no `nextRunAtMs` advance
- no `updatedAtMs` bump (disable transition stays the last mutation visible to `agb cron show`)
- a one-line `info: dropping deferred state writer for disabled job <id> run=<run_id>` is emitted to stderr so the absorbed deferral is still log-traceable

## Why the other final_status branches were left ungated

The brief explicitly limits scope to the deferral path. The `success` / `error` branches do still touch a disabled job's `consecutiveErrors` / `lastError*` fields when an inflight result lands after disable, but those are internal accounting (no user-visible "next run scheduled" lie) and operators may want them recorded for post-mortem. Issue #628 (cron mutation audit gap) tracks the broader audit-trail concern.

## Out of scope (per issue body)

- `audit.jsonl` cron mutation tracking (#628)
- `PRESSURE_DEFER_SECONDS` tuning (#263)
- Disable-transition inflight-slot recovery (separate; current `agb cron disable` does not reclaim inflight slots)

## Verification

Driven via direct `bridge-cron.py native-finalize-run` invocation against synthetic `jobs.json` / `status.json` / `result.json` / `request.json` in a `mktemp -d` tree (no `BRIDGE_HOME` mutation):

1. **Disabled-job repro** (issue's reproduction steps 1-6 condensed): pre-state has `enabled=false`, `lastDeferredAtMs` frozen at disable-time, `nextRunAtMs=0`. Status payload says `state=deferred`, `deferred_seconds=600`, `deferred_reason=memory_pressure`. After finalize: state unchanged, `updatedAtMs` unchanged, stdout payload is `status=skipped, reason=job_disabled`, stderr has the audit line. **PASS.**
2. **Enabled-job regression**: same `state=deferred` status payload but on `enabled=true` job. After finalize: `lastDeferredAtMs` and `nextRunAtMs` updated as before, `lastDeferredReason=memory_pressure` recorded. **PASS.**
3. **Disabled-job success path (intentionally ungated)**: `enabled=false` job, `state=success` payload. After finalize: `consecutiveErrors=0`, `lastStatus=success`, `enabled` still `false`. Confirms the gate is scoped to the deferred branch. **PASS.**

Also verified:
- `python3 -m py_compile bridge-cron.py bridge-cron-runner.py` — clean
- `bash -n *.sh agent-bridge agb lib/*.sh scripts/*.sh` — clean
- `shellcheck *.sh agent-bridge agb lib/*.sh agent-roster.local.example.sh` — clean
- `./scripts/smoke-test.sh` — passes except a pre-existing failure on `[smoke] guarding isolated agent-env writes from stale tmp controller env (#365 follow-up)` reproduced on `origin/main d840a65` without this change

## Manual verification on a live install

The targeted finalize harness above is sufficient because the writer is a pure function of `job.enabled` + the status/result payloads, but for full live confidence:

```
agb cron create --agent <a> --schedule "every 5min" --title "627-test" --payload "noop"
# wait for one slot to be enqueued
# induce memory pressure so runner writes state=deferred
agb cron disable <id>
# wait until the inflight slot finalizes
agb cron show <id>  # expect: enabled=false, lastDeferredAtMs unchanged from pre-disable timestamp
```