### PR TITLE
fix(daemon): nudge dispatcher recovers from persistent missing-marker probe failure (#629)

### DIFF
--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -351,6 +351,9 @@ bridge_write_idle_ready_agents() {
   local agent=""
   local session=""
   local engine=""
+  local retries_file=""
+  local retries=0
+  local max_retries="${BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS:-3}"
 
   : >"$file"
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do
@@ -366,7 +369,41 @@ bridge_write_idle_ready_agents() {
           # Reuse the visual-prompt probe that bridge_dispatch_notification
           # already calls at dispatch time so the agent rejoins the ready
           # list as soon as its tmux pane is back at a Claude prompt.
-          bridge_claude_session_try_mark_prompt_ready "$agent" "$session" || continue
+          retries_file="$(bridge_agent_missing_marker_retries_file "$agent")"
+          if bridge_claude_session_try_mark_prompt_ready "$agent" "$session"; then
+            # Probe succeeded — marker now written, reset the retry counter.
+            rm -f "$retries_file"
+          else
+            # Issue #629: a single probe failure used to exclude the agent
+            # from the nudge list; if the probe kept failing across cycles
+            # (dialog overlay, copy-mode, post-429 stall), the agent went
+            # silent indefinitely (SYRS librarian observed 5h+ silent on
+            # 5/5). Persist a per-agent retry counter and, after
+            # max_retries consecutive failures, synthesize an idle-since
+            # marker so the dispatcher's normal nudge logic can take over.
+            # The synthetic marker is conservative: at worst one nudge
+            # lands on a non-ready pane (recoverable); indefinite silence
+            # is worse.
+            retries=0
+            if [[ -f "$retries_file" ]]; then
+              retries="$(cat "$retries_file" 2>/dev/null || printf '0')"
+              [[ "$retries" =~ ^[0-9]+$ ]] || retries=0
+            fi
+            retries=$((retries + 1))
+            if (( retries >= max_retries )); then
+              bridge_agent_mark_idle_now "$agent"
+              rm -f "$retries_file"
+              bridge_audit_log daemon nudge_marker_synthesized "$agent" \
+                --detail consecutive_probe_failures="$retries" \
+                --detail max_retries="$max_retries" \
+                --detail session="$session" 2>/dev/null || true
+              bridge_warn "missing idle-since marker for '$agent' after ${retries} probe failures; synthesized current-timestamp marker so nudge dispatch can resume (issue #629)"
+            else
+              mkdir -p "$(bridge_agent_idle_marker_dir "$agent")"
+              printf '%s\n' "$retries" >"$retries_file"
+              continue
+            fi
+          fi
         fi
         ;;
       codex)

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -354,6 +354,19 @@ bridge_write_idle_ready_agents() {
   local retries_file=""
   local retries=0
   local max_retries="${BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS:-3}"
+  # Issue #633 codex r1 finding: an invalid override (non-numeric, empty,
+  # or <1) used to trip `set -u` at the arithmetic compare below
+  # (`abc: unbound variable`), aborting the entire daemon nudge_scan
+  # cycle. Fall back silently to the documented default 3 — the operator
+  # set the env var, so a one-time stderr warn surfaces the typo without
+  # spamming the daemon log on every cycle.
+  if ! [[ "$max_retries" =~ ^[0-9]+$ ]] || (( max_retries < 1 )); then
+    if [[ -z "${BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS_WARNED:-}" ]]; then
+      bridge_warn "BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS='${BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS:-}' is not a positive integer; falling back to default 3 (issue #629/#633)"
+      export BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS_WARNED=1
+    fi
+    max_retries=3
+  fi
 
   : >"$file"
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -360,7 +360,7 @@ bridge_write_idle_ready_agents() {
   # cycle. Fall back silently to the documented default 3 — the operator
   # set the env var, so a one-time stderr warn surfaces the typo without
   # spamming the daemon log on every cycle.
-  if ! [[ "$max_retries" =~ ^[0-9]+$ ]] || (( max_retries < 1 )); then
+  if ! [[ "$max_retries" =~ ^[0-9]+$ ]] || (( 10#$max_retries < 1 )); then
     if [[ -z "${BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS_WARNED:-}" ]]; then
       bridge_warn "BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS='${BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS:-}' is not a positive integer; falling back to default 3 (issue #629/#633)"
       export BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS_WARNED=1
@@ -403,7 +403,7 @@ bridge_write_idle_ready_agents() {
               [[ "$retries" =~ ^[0-9]+$ ]] || retries=0
             fi
             retries=$((retries + 1))
-            if (( retries >= max_retries )); then
+            if (( retries >= 10#$max_retries )); then
               bridge_agent_mark_idle_now "$agent"
               rm -f "$retries_file"
               bridge_audit_log daemon nudge_marker_synthesized "$agent" \

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1938,6 +1938,19 @@ bridge_agent_manual_stop_file() {
   printf '%s/manual-stop' "$(bridge_agent_idle_marker_dir "$agent")"
 }
 
+# Issue #629: missing-marker recovery probe retry counter.
+# bridge_write_idle_ready_agents falls back to a single prompt-ready probe
+# when the idle-since marker is absent. If that probe keeps failing (429
+# stall, dialog overlay, copy-mode), the agent stays excluded indefinitely.
+# This counter tracks consecutive probe failures across daemon cycles so
+# the dispatcher can escalate to a synthetic marker after a bounded number
+# of attempts. The file lives under the agent's idle marker dir so it is
+# cleaned up automatically by bridge_agent_clear_idle_marker.
+bridge_agent_missing_marker_retries_file() {
+  local agent="$1"
+  printf '%s/missing-marker-retries' "$(bridge_agent_idle_marker_dir "$agent")"
+}
+
 # Issue #589: prompt-ready latch.
 # Records when an agent's tmux session first reached a usable Claude/Codex
 # prompt during the current session. The auto-stop idle anchor in
@@ -2459,6 +2472,10 @@ bridge_agent_clear_idle_marker() {
   file="$(bridge_agent_idle_since_file "$agent")"
   dir="$(bridge_agent_idle_marker_dir "$agent")"
   rm -f "$file"
+  # Issue #629: drop the missing-marker retry counter so a future stale
+  # marker scenario starts fresh — otherwise the counter could ratchet
+  # the synthetic-marker fallback in earlier than warranted.
+  rm -f "$(bridge_agent_missing_marker_retries_file "$agent")"
   rmdir "$dir" >/dev/null 2>&1 || true
 }
 

--- a/scripts/smoke/nudge-marker-recovery.sh
+++ b/scripts/smoke/nudge-marker-recovery.sh
@@ -238,6 +238,32 @@ test_max_retries_env_override() {
   assert_counter_eq "$agent" "absent" "env-override: counter cleared on synthesis"
 }
 
+# --- octal-shape decimal: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=08/09 -----
+#
+# Issue #633 codex r2 finding: `08`/`09` pass the regex `^[0-9]+$` but Bash
+# treats them as invalid octal in `(( ... ))`. Without `10#$value` decimal
+# coercion at lib/bridge-channels.sh:363 and :406, the cycle aborts with
+# `value too great for base (error token is "08")`. r3 adds `10#` coercion
+# at both sites; this test ensures no abort and the cycle progresses.
+test_max_retries_env_octal_decimal_no_abort() {
+  local value="$1"
+  load_recovery_test_env
+
+  local agent="syrs-fi"
+  local ready_file="$SMOKE_TMP_ROOT/ready-octal-${value}.txt"
+
+  rm -rf "$(bridge_agent_idle_marker_dir "$agent")"
+
+  PROBE_SHOULD_SUCCEED=0
+  # Without `10#` coercion, this would abort with "value too great for base".
+  # With the fix, threshold is honored as decimal value (8 or 9).
+  BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS="$value" run_cycle "$ready_file"
+  if grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "octal-decimal=${value}: agent should be excluded on cycle 1 (max=${value})"
+  fi
+  assert_counter_eq "$agent" "1" "octal-decimal=${value}: counter=1 after cycle 1 (no abort)"
+}
+
 # --- env validation: invalid BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS --------
 #
 # Issue #633 codex r1 finding: an invalid override
@@ -300,6 +326,16 @@ main() {
 
   smoke_run "env validation: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS='' (empty)" \
     test_max_retries_env_invalid_fallback "" "empty"
+
+  # Bash treats `08`/`09` as invalid octal in `(( ... ))`. Without `10#$value`
+  # decimal coercion at lib/bridge-channels.sh:363 and :406, these would abort
+  # the daemon nudge_scan with `value too great for base (error token is "08")`.
+  # Codex r2 found this corner case after r1 added the regex/range validator.
+  smoke_run "env validation: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=08 (octal-shape decimal)" \
+    test_max_retries_env_octal_decimal_no_abort "08"
+
+  smoke_run "env validation: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=09 (octal-shape decimal)" \
+    test_max_retries_env_octal_decimal_no_abort "09"
 
   smoke_log "PASS: nudge-marker-recovery (#629 missing-marker bounded retry)"
 }

--- a/scripts/smoke/nudge-marker-recovery.sh
+++ b/scripts/smoke/nudge-marker-recovery.sh
@@ -238,6 +238,45 @@ test_max_retries_env_override() {
   assert_counter_eq "$agent" "absent" "env-override: counter cleared on synthesis"
 }
 
+# --- env validation: invalid BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS --------
+#
+# Issue #633 codex r1 finding: an invalid override
+# (BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=abc) used to trip set -u at the
+# arithmetic compare in bridge_write_idle_ready_agents, aborting the entire
+# daemon nudge_scan cycle. The validation must fall back to the default
+# threshold (3) and allow the cycle to complete normally.
+test_max_retries_env_invalid_fallback() {
+  local invalid_value="$1"
+  local label="$2"
+  load_recovery_test_env
+
+  local agent="syrs-fi"
+  local ready_file="$SMOKE_TMP_ROOT/ready-invalid.txt"
+
+  rm -rf "$(bridge_agent_idle_marker_dir "$agent")"
+  unset BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS_WARNED
+
+  PROBE_SHOULD_SUCCEED=0
+
+  # With invalid override, threshold must fall back to default 3 — this
+  # used to abort the function under `set -u`. Three failing cycles must
+  # complete without abort and progress counter→synth on cycle 3.
+  BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS="$invalid_value" run_cycle "$ready_file"
+  assert_counter_eq "$agent" "1" "$label: cycle 1 counter (default-3 fallback)"
+
+  BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS="$invalid_value" run_cycle "$ready_file"
+  assert_counter_eq "$agent" "2" "$label: cycle 2 counter (default-3 fallback)"
+
+  BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS="$invalid_value" run_cycle "$ready_file"
+  if ! grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "$label: agent should be INCLUDED on cycle 3 (synthetic marker via default-3 fallback)"
+  fi
+  if ! bridge_agent_idle_marker_exists "$agent"; then
+    smoke_fail "$label: synthetic marker should exist on cycle 3 with default-3 fallback"
+  fi
+  assert_counter_eq "$agent" "absent" "$label: counter cleared after synthesis"
+}
+
 main() {
   smoke_setup_bridge_home "$SMOKE_NAME"
 
@@ -249,6 +288,18 @@ main() {
 
   smoke_run "env override (BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=2)" \
     test_max_retries_env_override
+
+  smoke_run "env validation: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=abc (non-numeric)" \
+    test_max_retries_env_invalid_fallback "abc" "non-numeric"
+
+  smoke_run "env validation: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=0 (zero)" \
+    test_max_retries_env_invalid_fallback "0" "zero"
+
+  smoke_run "env validation: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=-3 (negative)" \
+    test_max_retries_env_invalid_fallback "-3" "negative"
+
+  smoke_run "env validation: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS='' (empty)" \
+    test_max_retries_env_invalid_fallback "" "empty"
 
   smoke_log "PASS: nudge-marker-recovery (#629 missing-marker bounded retry)"
 }

--- a/scripts/smoke/nudge-marker-recovery.sh
+++ b/scripts/smoke/nudge-marker-recovery.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# scripts/smoke/nudge-marker-recovery.sh — Issue #629 missing-marker recovery.
+#
+# Re-exec under bash 4+ (the literal "syrs-fi" subscript trick + declare -gA
+# require it). Same bootstrap pattern as scripts/smoke/idle-counter-latch.sh.
+if [[ "${BRIDGE_SMOKE_BASH4_REEXEC:-0}" != "1" && "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      BRIDGE_SMOKE_BASH4_REEXEC=1 exec "$_candidate" "$0" "$@"
+    fi
+  done
+  echo "[smoke:nudge-marker-recovery][error] bash 4+ required (got ${BASH_VERSION:-unknown})" >&2
+  exit 1
+fi
+#
+# Standalone smoke (NOT registered in scripts/smoke-test.sh; invoke directly).
+# Validates the bounded-retry recovery added to bridge_write_idle_ready_agents
+# in lib/bridge-channels.sh:
+#
+#   T1: cycle 1 — marker missing, probe fails → counter=1, agent excluded.
+#   T2: cycle 2 — same conditions → counter=2, agent excluded.
+#   T3: cycle 3 — counter would reach max_retries=3 → synthetic idle-since
+#       marker is created, counter cleared, agent INCLUDED in ready file.
+#   T4: cycle 4 — probe restored to success, marker exists from T3 → agent
+#       included; counter remains absent (no regression).
+#   T5: clearing the idle marker (e.g. via bridge_agent_clear_idle_marker
+#       on retire/sync) also drops the retries file so the next failure
+#       starts fresh.
+#
+# Run: bash scripts/smoke/nudge-marker-recovery.sh
+
+set -euo pipefail
+
+SMOKE_NAME="nudge-marker-recovery"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# --- environment / stubs --------------------------------------------------
+
+# Whether the next bridge_claude_session_try_mark_prompt_ready call should
+# succeed. Tests flip this between cycles.
+PROBE_SHOULD_SUCCEED=0
+
+load_recovery_test_env() {
+  # Stubs below are invoked indirectly by the library code we source; the
+  # SC2329 ("never invoked") warnings are spurious for that pattern (same
+  # treatment as scripts/smoke/idle-counter-latch.sh).
+  # shellcheck disable=SC2329
+  bridge_warn() { printf '[warn] %s\n' "$*" >&2; }
+  # shellcheck disable=SC2329
+  bridge_die() { printf '[die] %s\n' "$*" >&2; exit 1; }
+  # shellcheck disable=SC2329
+  bridge_audit_log() { :; }
+  # shellcheck disable=SC2329
+  bridge_require_python() { :; }
+
+  # Active-roster surface.
+  # shellcheck disable=SC2329
+  bridge_isolation_v2_active() { return 1; }
+  BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
+  BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
+  mkdir -p "$BRIDGE_ACTIVE_AGENT_DIR" "$BRIDGE_LOG_DIR"
+
+  # Roster: one claude agent.
+  # shellcheck disable=SC2034
+  declare -gA BRIDGE_AGENT_ENGINE=()
+  # shellcheck disable=SC2034
+  declare -gA BRIDGE_AGENT_SESSION=()
+  BRIDGE_AGENT_ENGINE["syrs-fi"]="claude"
+  BRIDGE_AGENT_SESSION["syrs-fi"]="syrs-fi"
+  # shellcheck disable=SC2034
+  BRIDGE_AGENT_IDS=("syrs-fi")
+
+  # shellcheck disable=SC2329
+  bridge_agent_engine() { printf 'claude'; }
+  # shellcheck disable=SC2329
+  bridge_agent_session() { printf 'syrs-fi'; }
+  # shellcheck disable=SC2329
+  bridge_agent_is_active() { return 0; }
+
+  # Source the helpers we exercise. bridge-state provides the path helpers
+  # and the synthetic-marker writer (bridge_agent_mark_idle_now).
+  # shellcheck source=lib/bridge-state.sh
+  source "$SMOKE_REPO_ROOT/lib/bridge-state.sh"
+  # shellcheck source=lib/bridge-channels.sh
+  source "$SMOKE_REPO_ROOT/lib/bridge-channels.sh"
+
+  # Re-stub bridge_audit_log AFTER sourcing libs — bridge-state.sh provides a
+  # python-backed implementation that needs $BRIDGE_SCRIPT_DIR (unset in this
+  # smoke fixture). We just need to confirm the call site fires; we don't
+  # need to verify the audit row contents.
+  # shellcheck disable=SC2329
+  bridge_audit_log() { :; }
+
+  # Probe stub: behaviour is controlled by PROBE_SHOULD_SUCCEED. When it
+  # "succeeds" we mimic the real helper by writing the idle marker.
+  # shellcheck disable=SC2329
+  bridge_claude_session_try_mark_prompt_ready() {
+    local agent="$1"
+    if (( PROBE_SHOULD_SUCCEED == 1 )); then
+      bridge_agent_mark_idle_now "$agent"
+      return 0
+    fi
+    return 1
+  }
+
+  # Codex prompt probe (unused for our claude-only fixture, but the
+  # function references it).
+  # shellcheck disable=SC2329
+  bridge_tmux_session_has_prompt() { return 0; }
+}
+
+# --- helpers --------------------------------------------------------------
+
+run_cycle() {
+  local out_file="$1"
+  bridge_write_idle_ready_agents "$out_file"
+}
+
+assert_counter_eq() {
+  local agent="$1" expected="$2" context="$3"
+  local file
+  file="$(bridge_agent_missing_marker_retries_file "$agent")"
+  if [[ "$expected" == "absent" ]]; then
+    if [[ -f "$file" ]]; then
+      smoke_fail "$context: expected counter file absent, got $(cat "$file")"
+    fi
+    return 0
+  fi
+  smoke_assert_file_exists "$file" "$context: counter file"
+  smoke_assert_eq "$expected" "$(cat "$file")" "$context"
+}
+
+# --- T1..T4: cycle progression -------------------------------------------
+
+test_bounded_retry_progression() {
+  load_recovery_test_env
+
+  local agent="syrs-fi"
+  local ready_file="$SMOKE_TMP_ROOT/ready.txt"
+
+  # Pre-state: agent has no idle-since marker (simulating a turn that
+  # aborted before mark-idle.sh fired).
+  rm -rf "$(bridge_agent_idle_marker_dir "$agent")"
+
+  # T1: cycle 1, probe fails → counter=1, agent excluded.
+  PROBE_SHOULD_SUCCEED=0
+  run_cycle "$ready_file"
+  if grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "T1: agent should be excluded on first probe failure"
+  fi
+  assert_counter_eq "$agent" "1" "T1: counter after first failure"
+
+  # T2: cycle 2, probe fails again → counter=2, agent still excluded.
+  run_cycle "$ready_file"
+  if grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "T2: agent should still be excluded on second probe failure"
+  fi
+  assert_counter_eq "$agent" "2" "T2: counter after second failure"
+
+  # T3: cycle 3, probe fails reaches max_retries=3 → synthetic marker
+  # written, counter cleared, agent INCLUDED.
+  run_cycle "$ready_file"
+  if ! grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "T3: agent should be INCLUDED after synthetic marker fallback"
+  fi
+  if ! bridge_agent_idle_marker_exists "$agent"; then
+    smoke_fail "T3: synthetic idle-since marker should exist after fallback"
+  fi
+  assert_counter_eq "$agent" "absent" "T3: counter cleared after synthetic marker"
+
+  # T4: cycle 4, marker exists (from T3), probe path not taken → agent
+  # included via the normal idle_marker_exists branch.
+  run_cycle "$ready_file"
+  if ! grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "T4: agent should remain included once synthetic marker is in place"
+  fi
+  assert_counter_eq "$agent" "absent" "T4: counter still absent on healthy cycle"
+}
+
+# --- T5: clear_idle_marker drops the retries file ------------------------
+
+test_clear_idle_marker_clears_counter() {
+  load_recovery_test_env
+
+  local agent="syrs-fi"
+  local retries_file
+  retries_file="$(bridge_agent_missing_marker_retries_file "$agent")"
+
+  # Seed a stale counter (simulating partial progress through the bounded
+  # retry window) then run the same cleanup path that retire/sync use.
+  mkdir -p "$(bridge_agent_idle_marker_dir "$agent")"
+  bridge_agent_mark_idle_now "$agent"
+  printf '2\n' >"$retries_file"
+  smoke_assert_file_exists "$retries_file" "T5 setup: counter seeded"
+
+  bridge_agent_clear_idle_marker "$agent"
+
+  if [[ -f "$retries_file" ]]; then
+    smoke_fail "T5: bridge_agent_clear_idle_marker should drop the missing-marker retry counter"
+  fi
+  if bridge_agent_idle_marker_exists "$agent"; then
+    smoke_fail "T5: bridge_agent_clear_idle_marker should also drop the idle-since marker"
+  fi
+}
+
+# --- env override: BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS -------------------
+
+test_max_retries_env_override() {
+  load_recovery_test_env
+
+  local agent="syrs-fi"
+  local ready_file="$SMOKE_TMP_ROOT/ready-env.txt"
+
+  rm -rf "$(bridge_agent_idle_marker_dir "$agent")"
+
+  # Lower the threshold to 2 so the synthetic fallback fires on cycle 2.
+  PROBE_SHOULD_SUCCEED=0
+  BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=2 run_cycle "$ready_file"
+  if grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "env-override: agent should be excluded on cycle 1"
+  fi
+  assert_counter_eq "$agent" "1" "env-override: counter=1 after cycle 1"
+
+  BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=2 run_cycle "$ready_file"
+  if ! grep -q "^${agent}$" "$ready_file"; then
+    smoke_fail "env-override: agent should be INCLUDED on cycle 2 with max_retries=2"
+  fi
+  if ! bridge_agent_idle_marker_exists "$agent"; then
+    smoke_fail "env-override: synthetic marker should exist on cycle 2 with max_retries=2"
+  fi
+  assert_counter_eq "$agent" "absent" "env-override: counter cleared on synthesis"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  smoke_run "T1..T4 (bounded retry → synthetic marker → steady state)" \
+    test_bounded_retry_progression
+
+  smoke_run "T5 (clear_idle_marker drops the retry counter)" \
+    test_clear_idle_marker_clears_counter
+
+  smoke_run "env override (BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=2)" \
+    test_max_retries_env_override
+
+  smoke_log "PASS: nudge-marker-recovery (#629 missing-marker bounded retry)"
+}
+
+main "$@"


### PR DESCRIPTION
Closes #629.

## Summary

Persistent missing `idle-since` marker caused agents to be excluded from nudge dispatch indefinitely (SYRS librarian: 5h+ silent on 5/5). The single recovery probe at `lib/bridge-channels.sh:349-382` failed silently when 429 quota / dialog overlay / copy-mode persisted across cycles.

## Fix

Multi-cycle retry counter with bounded synthesis fallback:

1. **Per-agent retry counter** — written to `state/bridge-nudge/missing-marker-retries-<agent>` across daemon cycles.
2. **Bounded retry** — after `BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS` (default 3) consecutive probe failures, emit audit warning + proactively synthesize an `idle-since` marker with current timestamp. Agent rejoins nudge candidate list.
3. **Reset on success** — probe success or organic marker creation clears the counter.
4. **Cleanup on agent retire/delete** — `bridge_agent_clear_idle_marker` drops both files.

Worst case if the synthetic probe is wrong about prompt-ready state: one nudge to a non-ready pane (recoverable). Indefinite silence is worse.

## Files

- `lib/bridge-channels.sh` (+38/-1)
- `lib/bridge-state.sh` (+17/-0)
- `scripts/smoke/nudge-marker-recovery.sh` (+255, new)

## Verification

- `bash -n` + `shellcheck` clean on touched files + full sweep
- New smoke `scripts/smoke/nudge-marker-recovery.sh` covers:
  - T1-T4: cycle progression (counter increments 1→2→synthesize at cycle 3 → marker exists in cycle 4)
  - T5: `bridge_agent_clear_idle_marker` drops both idle-since + retries
  - Env-override: `BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS=2` fires synthesis on cycle 2
- Pre-existing macOS smoke flake unrelated (`smoke tmux session not created`).

## Live verification (post-merge)

Operator should reproduce SYRS librarian incident: delete idle-since for one claude agent, force probe to fail for ≥3 cycles via copy-mode, observe synthesis warning + nudge resumption.

## Out of scope

- Issue #589 (idle counter starts during boot — different defect).


---

### r2 changes (commit c30f210)

Codex r1 finding addressed: validate `BRIDGE_NUDGE_RECOVER_MAX_PROBE_FAILS` before the arithmetic compare in `bridge_write_idle_ready_agents` so an invalid override (non-numeric, empty, zero, negative) no longer aborts the daemon nudge_scan under `set -u`. Falls back to default 3 with a one-time stderr warn. Smoke extended with four negative cases (`abc`, `0`, `-3`, empty).
