### PR TITLE
fix(hooks): clean up unused imports/locals from PR #624 (lint follow-up)

### DIFF
--- a/hooks/prompt-guard.py
+++ b/hooks/prompt-guard.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1159,7 +1159,6 @@ def _bash_argv_references_system_config(command: str) -> bool:
 
 
 def protected_alias_reason(text: str, agent: str) -> str | None:
-    home_root = agent_home_root()
     admin = is_admin_agent(agent)
     # The two checks below use shlex argv matching rather than substring
     # matching (closes #252). A Bash invocation that actually opens the


### PR DESCRIPTION
## Summary

Tiny lint follow-up to already-merged PR #624 (`fix(hooks): absolute-path guard load survives isolated UID --x ROOT ACL`, merged at d840a65). Codex r1 review flagged two pyflakes findings that did not gate the merge:

```
hooks/prompt-guard.py:7:1: 'os' imported but unused
hooks/tool-policy.py:1162:5: local variable 'home_root' is assigned to but never used
```

Both are mechanical:

1. **`hooks/prompt-guard.py`** — drop `import os`. Unused after the `load_guard_module()` refactor moved path-resolution into `bridge_hook_common.py`. Verified by `grep -nE '(^|[^A-Za-z_])os([^A-Za-z_]|$)' hooks/prompt-guard.py` — the only hit is line 7.
2. **`hooks/tool-policy.py`** — remove dead `home_root = agent_home_root()` assignment at the top of `protected_alias_reason()`. The function is pure (no side effects) and `home_root` was never read in the body. Sibling helpers (`protected_path_reason`, `permitted_path_reason`, etc.) each call `agent_home_root()` directly when they need it; no missing check is implied. Per the brief: pure-function dead assignment → remove the line.

The `agent_home_root` import in `tool-policy.py` is retained — it is still referenced at lines 90, 151, 176, 471, 797, 886.

No functional change. No test plan delta vs PR #624's H1-H8 + parent-dir fixture, which were all green.

## Verification

```bash
python3 -m py_compile hooks/bridge_hook_common.py hooks/tool-policy.py hooks/prompt-guard.py hooks/permission_escalation.py
# → PASS

uvx pyflakes hooks/bridge_hook_common.py hooks/tool-policy.py hooks/prompt-guard.py hooks/permission_escalation.py
# → 0 findings (down from 2: prompt-guard.py:7 and tool-policy.py:1162)
```

Diff: `hooks/prompt-guard.py | 1 -` + `hooks/tool-policy.py | 1 -` (2 deletions, 0 additions).

## Test plan

- [x] py_compile clean across all four hook files
- [x] pyflakes 0 findings across all four hook files
- [ ] Codex pair-review (`agb-dev-codex-2`) — implement-ok confirmation

Refs #624.

🤖 Generated with [Claude Code](https://claude.com/claude-code)