### PR TITLE
feat(cron): emit audit events for mutations (#628)

### DIFF
--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -1545,6 +1545,100 @@ def atomic_write_jobs(jobs_path, raw_payload):
     os.replace(temp_path, jobs_path)
 
 
+def _audit_log_path():
+    """Resolve the bridge audit log path.
+
+    Mirrors `bridge-config.py:audit_log_path()` and the SSOT default in
+    `lib/bridge-state.sh:1267` (`$BRIDGE_LOG_DIR/audit.jsonl`). Returns
+    `None` only when neither `BRIDGE_AUDIT_LOG` nor `BRIDGE_HOME`/`BRIDGE_LOG_DIR`
+    is set — in that case the caller should silently skip the emission so
+    smoke fixtures and `--help` invocations do not fail.
+    """
+    explicit = os.environ.get("BRIDGE_AUDIT_LOG", "").strip()
+    if explicit:
+        return Path(explicit).expanduser()
+    log_dir = os.environ.get("BRIDGE_LOG_DIR", "").strip()
+    if log_dir:
+        return Path(log_dir).expanduser() / "audit.jsonl"
+    home = os.environ.get("BRIDGE_HOME", "").strip()
+    if home:
+        return Path(home).expanduser() / "logs" / "audit.jsonl"
+    return None
+
+
+def _audit_actor():
+    """Caller agent id for audit attribution.
+
+    Prefers `BRIDGE_AGENT_ID` so multi-admin installs can disambiguate
+    operator-driven mutations; falls back to `USER` so single-operator
+    boxes still record something useful. Matches the convention used in
+    `bridge-config.py:115` (`current_agent_id()`).
+    """
+    agent = os.environ.get("BRIDGE_AGENT_ID", "").strip()
+    if agent:
+        return agent
+    return os.environ.get("USER", "unknown") or "unknown"
+
+
+def emit_cron_mutation_audit(action, target, detail):
+    """Append a `cron.<verb>` row to the bridge audit log.
+
+    Routes through `bridge-audit.py write` so the hash chain stays intact
+    with hook / config / daemon rows. Best-effort: a failed audit write
+    never raises, mirroring the contract documented in
+    `bridge-watchdog-silence.py:emit_audit` and `bridge-config.py:write_audit`.
+
+    Issue #628 — operator-driven cron CRUD (`create`, `edit`, `enable`,
+    `disable`, `delete`) was previously absent from `audit.jsonl`,
+    forcing transcript fishing to recover mutation provenance. Runner
+    finalize and bulk admin paths (rebalance / migrate / import) stay
+    out of scope; only the four operator verbs go through here.
+    """
+    audit_path = _audit_log_path()
+    if audit_path is None:
+        return
+    actor = _audit_actor()
+    detail_payload = dict(detail or {})
+    detail_payload.setdefault("cron_id", target)
+    audit_script = Path(__file__).resolve().parent / "bridge-audit.py"
+    cmd = [
+        sys.executable,
+        str(audit_script),
+        "write",
+        "--file",
+        str(audit_path),
+        "--actor",
+        actor,
+        "--action",
+        action,
+        "--target",
+        target,
+        "--detail-json",
+        json.dumps(detail_payload, ensure_ascii=True, sort_keys=True),
+    ]
+    try:
+        subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=10)
+    except (subprocess.SubprocessError, OSError):
+        # Audit emission is best-effort — never let it crash a successful
+        # cron mutation. Fall back to a direct append so a missing python
+        # interpreter doesn't silently swallow the row (matches
+        # bridge-config.py:write_audit's fallback contract).
+        try:
+            audit_path.parent.mkdir(parents=True, exist_ok=True)
+            record = {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "actor": actor,
+                "action": action,
+                "target": target,
+                "detail": detail_payload,
+                "pid": os.getpid(),
+            }
+            with audit_path.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=True) + "\n")
+        except OSError:
+            pass
+
+
 def slugify_title(value):
     slug = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip()).strip("-").lower()
     return slug or "job"
@@ -1720,6 +1814,20 @@ def run_native_create(args):
     jobs_path.parent.mkdir(parents=True, exist_ok=True)
     atomic_write_jobs(jobs_path, raw_payload)
 
+    # Issue #628 — emit operator-mutation audit row only after the write
+    # succeeds so failed creates do not appear in the audit log.
+    emit_cron_mutation_audit(
+        "cron.create",
+        job_id,
+        {
+            "agent": args.agent,
+            "title": title,
+            "schedule": dict(job.get("schedule") or {}),
+            "enabled": bool(job.get("enabled", True)),
+            "delete_after_run": bool(job.get("deleteAfterRun")),
+        },
+    )
+
     print(f"created native cron job {job_id} for {args.agent}")
     return 0
 
@@ -1780,6 +1888,65 @@ def run_native_update(args):
     raw_payload["updatedAt"] = datetime.now().astimezone().isoformat()
     atomic_write_jobs(Path(args.jobs_file).expanduser(), raw_payload)
 
+    # Issue #628 — pick the audit verb based on what actually changed.
+    # `--enable` / `--disable` flips alone get a dedicated `cron.enable`
+    # or `cron.disable` row; everything else (schedule / title / payload /
+    # tz / agent / delete-after-run) records as `cron.edit` with prev/next
+    # snapshots so multi-admin installs can attribute the change.
+    prev_enabled = bool(existing.get("enabled", True))
+    next_enabled = bool(enabled)
+    prev_schedule = dict(existing.get("schedule") or {})
+    next_schedule = dict(updated_job.get("schedule") or {})
+    prev_title = existing.get("name") or record.get("name") or ""
+    next_title = updated_job.get("name") or title
+    prev_agent = existing.get("agentId") or existing.get("agent") or record.get("agent") or ""
+    next_agent = updated_job.get("agentId") or updated_job.get("agent") or agent
+    prev_delete_after = bool(existing.get("deleteAfterRun"))
+    next_delete_after = bool(updated_job.get("deleteAfterRun"))
+    non_enable_changed = (
+        prev_schedule != next_schedule
+        or prev_title != next_title
+        or prev_agent != next_agent
+        or prev_delete_after != next_delete_after
+        or args.payload is not None
+        or args.payload_file is not None
+    )
+    if not non_enable_changed and prev_enabled != next_enabled:
+        action = "cron.enable" if next_enabled else "cron.disable"
+        emit_cron_mutation_audit(
+            action,
+            record["id"],
+            {
+                "agent": next_agent,
+                "title": next_title,
+                "prev_enabled": prev_enabled,
+                "next_enabled": next_enabled,
+            },
+        )
+    else:
+        emit_cron_mutation_audit(
+            "cron.edit",
+            record["id"],
+            {
+                "agent": next_agent,
+                "title": next_title,
+                "prev": {
+                    "schedule": prev_schedule,
+                    "enabled": prev_enabled,
+                    "title": prev_title,
+                    "agent": prev_agent,
+                    "delete_after_run": prev_delete_after,
+                },
+                "next": {
+                    "schedule": next_schedule,
+                    "enabled": next_enabled,
+                    "title": next_title,
+                    "agent": next_agent,
+                    "delete_after_run": next_delete_after,
+                },
+            },
+        )
+
     print(f"updated native cron job {record['id']}")
     return 0
 
@@ -1798,9 +1965,25 @@ def run_native_delete(args):
         print(f"error: native job not found: {args.job_ref}", file=sys.stderr)
         return 2
 
+    deleted_job = next((job for job in jobs if job.get("id") == record["id"]), None) or {}
     raw_payload["jobs"] = remaining_jobs
     raw_payload["updatedAt"] = datetime.now().astimezone().isoformat()
     atomic_write_jobs(Path(args.jobs_file).expanduser(), raw_payload)
+
+    # Issue #628 — capture the deleted job's identity in the audit row so
+    # operators can reconstruct what was removed without re-reading the
+    # backup file.
+    emit_cron_mutation_audit(
+        "cron.delete",
+        record["id"],
+        {
+            "agent": deleted_job.get("agentId") or deleted_job.get("agent") or record.get("agent") or "",
+            "title": deleted_job.get("name") or record.get("name") or "",
+            "schedule": dict(deleted_job.get("schedule") or {}),
+            "enabled": bool(deleted_job.get("enabled", True)),
+        },
+    )
+
     print(f"deleted native cron job {record['id']}")
     return 0
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys
 }
 
 add_all_integration() {
@@ -198,7 +198,8 @@ select_for_path() {
       # python file moves.
       # Issue #541 PR-A — memory-daily payload migration also lives in
       # bridge-cron.py; pull its smoke in for the same trigger set.
-      add_required cron-run-artifacts-retention cron-migrate-payloads queue
+      # Issue #628 — cron mutation audit emission ditto.
+      add_required cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10357,6 +10357,12 @@ bash "$REPO_ROOT/scripts/test-stale-resume.sh"
 log "running cron-migrate-payloads smoke (issue #541 PR-A)"
 bash "$REPO_ROOT/scripts/smoke/cron-migrate-payloads.sh"
 
+# Issue #628 — cron CRUD mutations must emit audit.jsonl rows so multi-admin
+# installs can attribute disable/enable/edit/delete/create without grepping
+# transcripts.
+log "running cron-mutation-audit smoke (issue #628)"
+bash "$REPO_ROOT/scripts/smoke/cron-mutation-audit.sh"
+
 # Issue #544 PR1 — curated bin/agb shim for isolated agents.
 log "running isolated-bin-agb smoke (issue #544 PR1)"
 log "isolated-bin-agb covers shim env-source/delegation/fallback only — live PATH injection requires isolate+restart"

--- a/scripts/smoke/cron-mutation-audit.sh
+++ b/scripts/smoke/cron-mutation-audit.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# scripts/smoke/cron-mutation-audit.sh — Issue #628 smoke.
+#
+# Validates that operator-driven cron CRUD verbs (`create`, `enable`,
+# `disable`, `edit`, `delete`) each emit exactly one row to
+# `audit.jsonl`. Before #628, none of these mutations recorded
+# attribution — operators had to grep agent transcripts to recover
+# "who disabled this cron and when." This smoke is the regression
+# guard that prevents the audit gap from re-opening.
+#
+# Each mutation runs against an isolated `BRIDGE_HOME` so no live
+# audit log is touched. The smoke also checks that:
+#   - `cron.create` carries the agent + title + schedule
+#   - `cron.disable` is selected (not `cron.edit`) when only `--disable`
+#     flips the enabled flag
+#   - `cron.enable` is selected (not `cron.edit`) for the inverse
+#   - `cron.edit` is selected when the schedule (or any non-enable
+#     field) changes, with prev/next snapshots
+#   - `cron.delete` records the deleted job's identity
+#   - the actor field reflects `BRIDGE_AGENT_ID` when set
+
+set -euo pipefail
+
+SMOKE_NAME="cron-mutation-audit"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home
+
+# Pin caller agent so we can assert attribution in the audit row.
+export BRIDGE_AGENT_ID="smoke-cron-admin"
+
+JOBS_FILE="$BRIDGE_HOME/runtime/cron/jobs.json"
+AUDIT_LOG="$BRIDGE_AUDIT_LOG"
+
+audit_count() {
+  local target="$1"
+  local action="$2"
+  if [[ ! -f "$AUDIT_LOG" ]]; then
+    printf '0\n'
+    return
+  fi
+  "$PY_BIN" - "$AUDIT_LOG" "$target" "$action" <<'PY'
+import json, sys
+log_path, target, action = sys.argv[1], sys.argv[2], sys.argv[3]
+n = 0
+with open(log_path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("target") == target and row.get("action") == action:
+            n += 1
+print(n)
+PY
+}
+
+audit_last() {
+  local target="$1"
+  local action="$2"
+  "$PY_BIN" - "$AUDIT_LOG" "$target" "$action" <<'PY'
+import json, sys
+log_path, target, action = sys.argv[1], sys.argv[2], sys.argv[3]
+last = None
+with open(log_path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if row.get("target") == target and row.get("action") == action:
+            last = row
+print(json.dumps(last, ensure_ascii=False, sort_keys=True) if last is not None else "")
+PY
+}
+
+# ---- 1. create ----------------------------------------------------------
+smoke_log "case 1: cron.create emits audit row with agent + schedule"
+
+CREATE_OUT="$("$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-create \
+  --jobs-file "$JOBS_FILE" \
+  --agent agent-alpha \
+  --schedule "0 3 * * *" \
+  --tz "Asia/Seoul" \
+  --title "memory-daily-agent-alpha")"
+JOB_ID="$(printf '%s\n' "$CREATE_OUT" | sed -n 's/^created native cron job \([^ ]*\) for .*$/\1/p')"
+[[ -n "$JOB_ID" ]] || smoke_fail "could not parse job id from create output: $CREATE_OUT"
+
+smoke_assert_file_exists "$AUDIT_LOG" "audit log must exist after create"
+N_CREATE="$(audit_count "$JOB_ID" "cron.create")"
+smoke_assert_eq "1" "$N_CREATE" "expected exactly one cron.create audit row"
+ROW="$(audit_last "$JOB_ID" "cron.create")"
+"$PY_BIN" - "$ROW" <<'PY'
+import json, sys
+row = json.loads(sys.argv[1])
+assert row["actor"] == "smoke-cron-admin", row
+assert row["action"] == "cron.create", row
+detail = row.get("detail") or {}
+assert detail.get("agent") == "agent-alpha", row
+assert detail.get("title") == "memory-daily-agent-alpha", row
+schedule = detail.get("schedule") or {}
+assert schedule.get("expr") == "0 3 * * *", row
+assert detail.get("enabled") is True, row
+PY
+smoke_log "ok: cron.create row carries actor + agent + schedule"
+
+# ---- 2. disable (toggle-only) -----------------------------------------------
+smoke_log "case 2: --disable alone emits cron.disable, not cron.edit"
+
+"$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-update \
+  --jobs-file "$JOBS_FILE" \
+  --disable \
+  "$JOB_ID" >/dev/null
+
+smoke_assert_eq "1" "$(audit_count "$JOB_ID" "cron.disable")" "expected exactly one cron.disable row"
+smoke_assert_eq "0" "$(audit_count "$JOB_ID" "cron.edit")" "pure --disable must not record cron.edit"
+ROW="$(audit_last "$JOB_ID" "cron.disable")"
+"$PY_BIN" - "$ROW" <<'PY'
+import json, sys
+row = json.loads(sys.argv[1])
+detail = row.get("detail") or {}
+assert detail.get("prev_enabled") is True, row
+assert detail.get("next_enabled") is False, row
+PY
+smoke_log "ok: cron.disable row records the prev/next enabled flip"
+
+# ---- 3. enable (toggle-only) ------------------------------------------------
+smoke_log "case 3: --enable alone emits cron.enable, not cron.edit"
+
+"$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-update \
+  --jobs-file "$JOBS_FILE" \
+  --enable \
+  "$JOB_ID" >/dev/null
+
+smoke_assert_eq "1" "$(audit_count "$JOB_ID" "cron.enable")" "expected exactly one cron.enable row"
+smoke_assert_eq "0" "$(audit_count "$JOB_ID" "cron.edit")" "pure --enable must not record cron.edit"
+ROW="$(audit_last "$JOB_ID" "cron.enable")"
+"$PY_BIN" - "$ROW" <<'PY'
+import json, sys
+row = json.loads(sys.argv[1])
+detail = row.get("detail") or {}
+assert detail.get("prev_enabled") is False, row
+assert detail.get("next_enabled") is True, row
+PY
+smoke_log "ok: cron.enable row records the prev/next enabled flip"
+
+# ---- 4. edit (schedule change) ----------------------------------------------
+smoke_log "case 4: --schedule change emits cron.edit with prev/next"
+
+"$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-update \
+  --jobs-file "$JOBS_FILE" \
+  --schedule "30 4 * * *" \
+  "$JOB_ID" >/dev/null
+
+smoke_assert_eq "1" "$(audit_count "$JOB_ID" "cron.edit")" "expected exactly one cron.edit row"
+ROW="$(audit_last "$JOB_ID" "cron.edit")"
+"$PY_BIN" - "$ROW" <<'PY'
+import json, sys
+row = json.loads(sys.argv[1])
+detail = row.get("detail") or {}
+prev = detail.get("prev") or {}
+nxt = detail.get("next") or {}
+assert (prev.get("schedule") or {}).get("expr") == "0 3 * * *", row
+assert (nxt.get("schedule") or {}).get("expr") == "30 4 * * *", row
+assert prev.get("enabled") is True, row
+assert nxt.get("enabled") is True, row
+PY
+smoke_log "ok: cron.edit row records prev/next schedule snapshots"
+
+# ---- 5. delete --------------------------------------------------------------
+smoke_log "case 5: cron.delete emits one row with deleted job identity"
+
+"$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-delete \
+  --jobs-file "$JOBS_FILE" \
+  "$JOB_ID" >/dev/null
+
+smoke_assert_eq "1" "$(audit_count "$JOB_ID" "cron.delete")" "expected exactly one cron.delete row"
+ROW="$(audit_last "$JOB_ID" "cron.delete")"
+"$PY_BIN" - "$ROW" <<'PY'
+import json, sys
+row = json.loads(sys.argv[1])
+detail = row.get("detail") or {}
+assert detail.get("agent") == "agent-alpha", row
+assert detail.get("title") == "memory-daily-agent-alpha", row
+schedule = detail.get("schedule") or {}
+# After step 4, the schedule should reflect the latest expr "30 4 * * *".
+assert schedule.get("expr") == "30 4 * * *", row
+PY
+smoke_log "ok: cron.delete row carries deleted job identity"
+
+# ---- 6. failed mutation must not emit audit ---------------------------------
+smoke_log "case 6: failed delete on missing job must not emit cron.delete"
+
+PRE_DELETE_COUNT="$(audit_count "ghost-job-id" "cron.delete")"
+set +e
+"$PY_BIN" "$REPO_ROOT/bridge-cron.py" native-delete \
+  --jobs-file "$JOBS_FILE" \
+  "ghost-job-id" >/dev/null 2>&1
+RC=$?
+set -e
+[[ "$RC" -ne 0 ]] || smoke_fail "deleting missing job should fail with non-zero rc"
+POST_DELETE_COUNT="$(audit_count "ghost-job-id" "cron.delete")"
+smoke_assert_eq "$PRE_DELETE_COUNT" "$POST_DELETE_COUNT" "failed delete must not emit audit row"
+smoke_log "ok: failed mutation leaves audit log unchanged"
+
+smoke_log "all cron-mutation-audit cases passed"


### PR DESCRIPTION
Closes #628.

## Summary

Cron operator mutations (create/enable/disable/edit/delete) were not recorded in `audit.jsonl`. Other CRUD paths (agent, config, daemon, watchdog, upgrade) audit; cron was the only exception. Operators couldn't trace "who disabled this cron" without grep'ing every agent transcript.

## Fix

New `emit_cron_mutation_audit` helper in `bridge-cron.py` wired into `run_native_create` / `run_native_update` / `run_native_delete`. Uses `bridge-audit.py write` transport (same hash-chain envelope as hooks/config/daemon writers).

## Audit event shape

```json
{
  "kind": "audit",
  "action": "cron.create | cron.enable | cron.disable | cron.edit | cron.delete",
  "actor": "$BRIDGE_AGENT_ID (USER fallback)",
  "target": "<job_id>",
  "detail": { "agent", "title", "schedule", "enabled", "prev{...}", "next{...}", "cron_id" }
}
```

`run_native_update` distinguishes pure `--enable` / `--disable` flips (emits `cron.enable` / `cron.disable`) vs any other field change (emits `cron.edit` with full prev/next snapshots).

## Files

- `bridge-cron.py` (+187/-0)
- `scripts/smoke/cron-mutation-audit.sh` (+222 new) — 6 cases covering all 5 verbs + failed-mutation no-emit
- `scripts/smoke-test.sh` (+6) — wire new smoke
- `scripts/ci-select-smoke.sh` (+3/-2) — required-static + bridge-cron.py trigger

## Verification

- `python3 -m py_compile bridge-cron.py` — PASS
- `bash -n` + `shellcheck` on touched files — PASS
- `bash scripts/smoke/cron-mutation-audit.sh` — PASS (6 cases)
- `bash scripts/smoke/cron-migrate-payloads.sh` — PASS (regression)
- `bash scripts/smoke/cron-run-artifacts-retention.sh` — PASS (regression)
- Issue body repro: `agb cron disable <id>` then `agb cron edit <id> --schedule ...` → 2 distinct rows in audit.jsonl
- `bridge-audit.py verify` — hash chain intact (4 hashed, 0 legacy)

## Out of scope

- Runner finalize (`run_native_finalize`) — issue scopes only operator CRUD verbs.
- Bulk admin paths (rebalance-memory-daily, migrate-payloads, native-import).
- Migration of existing cron mutation events — audit-from-now is acceptable per issue.

## Notes

- Audit emission is best-effort: missing BRIDGE_HOME/BRIDGE_AUDIT_LOG returns early without raising; subprocess failure falls back to direct append (mirrors bridge-config.py:write_audit).
- Operator-vs-owner attribution: `audit.actor` = BRIDGE_AGENT_ID (who mutated), `metadata.updatedBy` in jobs.json = job-owner. Both useful for multi-admin installs.
