### PR TITLE
fix(systemd): KillMode=process on Linux user service so daemon restarts don't SIGKILL agent children

### DIFF
--- a/scripts/install-daemon-systemd.sh
+++ b/scripts/install-daemon-systemd.sh
@@ -90,6 +90,13 @@ WorkingDirectory=${BRIDGE_HOME_TARGET}
 Environment=BRIDGE_HOME=${BRIDGE_HOME_TARGET}
 Restart=always
 RestartSec=5
+# Without KillMode=process the default control-group mode SIGKILLs every
+# child in the daemon's service cgroup on every restart — tmux servers,
+# claude, codex, plugin processes — which makes "stop the daemon" silently
+# mean "kill every running agent on this host." KillMode=process limits the
+# kill to the daemon process itself; agent children stay up across daemon
+# restarts initiated by the upgrader, the silence watchdog, or admin tooling.
+KillMode=process
 StandardOutput=append:${LOG_PATH}
 StandardError=append:${LOG_PATH}
 


### PR DESCRIPTION
## Summary

- ``agent-bridge-daemon.service`` is generated without an explicit ``KillMode``, so systemd uses the default ``control-group``. Every daemon stop/restart asks systemd to ``SIGKILL`` every child in the daemon's service cgroup — tmux servers, claude, codex, plugin processes — which silently turns ``stop the daemon`` into ``kill every running agent on this host``.
- ``KillMode=process`` keeps the kill scoped to the daemon process; agent children stay up across the daemon's normal restart cycles, and the daemon re-attaches to them on the next tick.
- Linux-only bug. macOS hosts run under launchd and are unaffected.

## Reproduce

On any Linux install with at least one active agent tmux session:

```bash
systemctl --user show agent-bridge-daemon.service -p KillMode
# KillMode=control-group  (current default)
journalctl --user -u agent-bridge-daemon.service -f &
bash bridge-upgrade.sh --apply
```

Journal during the stop window prints:

```
agent-bridge-daemon.service: Killing process ... (tmux: server) with signal SIGKILL.
agent-bridge-daemon.service: Killing process ... (claude) with signal SIGKILL.
agent-bridge-daemon.service: Killing process ... (codex) with signal SIGKILL.
```

After this fix:

```bash
systemctl --user show agent-bridge-daemon.service -p KillMode
# KillMode=process
```

The same upgrade run leaves agent children running.

## Files

- ``scripts/install-daemon-systemd.sh`` — emit ``KillMode=process`` in the ``[Service]`` block (+7 lines, comment included).

macOS path (``scripts/install-daemon-launchagent.sh``) is untouched.

## Test plan

- [x] ``bash -n scripts/install-daemon-systemd.sh``
- [x] ``scripts/install-daemon-systemd.sh --bridge-home /tmp/agent-bridge-review`` renders exactly one ``KillMode=process`` in ``[Service]`` and no other unit options change.
- [x] ``systemd-analyze verify --user`` accepts the generated unit.
- [x] On the live Linux host: applied the same value as a temporary drop-in (``~/.config/systemd/user/agent-bridge-daemon.service.d/killmode.conf``) plus ``systemctl --user daemon-reload`` reports ``KillMode=process``. Existing drop-in does not conflict with the new installer default.
- [x] macOS launchd generator path verified to be on a separate script (``scripts/install-daemon-launchagent.sh``) and unaffected.

## Background

Investigation lives in ``shared/watchdog/daemon-sigterm-storm-investigation-20260506-dev-codex.md`` (dev-codex, 2026-05-06). The user-visible symptom on a Linux install with one ``isolated`` linux-user agent (``sales_sean``) was ``the daemon dies and every agent disappears`` whenever the upgrader, the silence watchdog, or admin tooling restarted the daemon. Root cause is the systemd cgroup boundary, not the restart itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)