### PR TITLE
feat(codex-hooks): write-shape detector redesign — default-deny block mode + common-shape parser (#639)

### DIFF
--- a/docs/agent-runtime/role-architecture.md
+++ b/docs/agent-runtime/role-architecture.md
@@ -53,11 +53,23 @@ The hooks below address Codex-specific failure modes. Implementation order is ri
 
 **Failure mode it addresses.** A Codex task tagged `[plan]` or `[review]` is supposed to be read-only — write your conclusions, do not edit source. Manual discipline drifts: reviewers occasionally start editing files in the primary checkout when the task title clearly said "plan" or "review."
 
-**Behavior.** Reads the currently claimed task (deterministic lookup: `status='claimed' AND claimed_by=<agent>`; ambiguity or absence → fail-open with audit). If that task title carries a plan/review prefix, denies any tool use that writes to the primary checkout (structured tool fields for `Edit`/`Write`/`NotebookEdit`; `shlex`-tokenized + path-normalized write detection for `Bash`, borrowing patterns from `tool-policy.py`). The default is read-only. Carve-outs are **structured-only**:
-- `/tmp/` scratch writes are always allowed.
-- Isolated-worktree writes are allowed only when the task body contains an explicit, structured grant: a line of the form `implement-permission: <absolute-or-relative-path>`. The hook normalizes both the granted path and the tool's target path and allows only when the target is contained in the grant. A free-text phrase like "implement in <path>" does **not** grant write permission. Multiple grants may appear; each is parsed independently.
+**Behavior.** Reads the currently claimed task (deterministic lookup: `status='claimed' AND claimed_by=<agent>`; ambiguity or absence → fail-open with audit). If that task title carries a plan/review prefix, denies any tool use that writes to the primary checkout. Structured tool fields cover `Edit`/`Write`/`NotebookEdit`/`MultiEdit`. **Bash classification (issue #639 redesign — Option C)** is now default-deny in block mode:
 
-**Stage.** Land in dry-run/audit-only mode first; flip to blocking after smoke proves no false-positives over a week of normal pair-programming traffic.
+1. **Closed read-only allow-list.** Routine review commands (`git status|diff|show|log|grep|ls-files|rev-parse|blame|...`, `ls`, `cat`, `head`, `tail`, `wc`, `stat`, `file`, `du`, `rg`, `grep`, `find` without `-exec`/`-delete`, `python -c <code>` whose AST contains no `open`/`write_text`/`os.remove`/etc., plus `echo`/`printf`/`true`/`false`/`test`) are allow-listed and need no grant. New entries are policy changes — they require comments explaining read-only-ness, plus block-allow and block-deny smoke coverage.
+2. **Common-shape write detector.** A small, named verb set (`rm`, `cp`, `mv`, `install`, `touch`, `sed -i`, `chmod`, `chown`, `dd`, `mkdir`, `rmdir`, `tee`, `patch`, `git` mutating subcommands, output redirections like `>file`, `1>file`, `>>file`, `&>file`) is parsed into structured `(head, target_paths)` for grant matching. PR #636 r1-r5 fixes (fd redirection, git long-flag mutating subcommands, `patch -i`/`install -t` target rules, attached `-tDEST`/`-oFILE`, combined-cluster `-rt`) are preserved.
+3. **Default-deny in block mode.** Anything that is neither allow-listed nor a recognized write shape (`cargo build`, `npm install`, `awk` scripts, `bash -c "$DYNAMIC"`, command substitution, heredocs feeding interpreters, etc.) is `UNKNOWN_SHELL`. In block mode this denies; in audit mode it logs and allows. This is what closes the multi-command, substitution, exotic-interpreter, and heredoc gaps that PR #636 r1-r5 deferred.
+
+**Carve-outs and grants.**
+- `/tmp/` scratch writes are always allowed (structured tool target or every Bash write target under `/tmp/`).
+- Legacy `implement-permission: <path>` grant in the task body remains supported (path-prefix containment).
+- Proposed `[grants]` block in the task body:
+  - `write: <path>` — equivalent to `implement-permission`.
+  - `write: <known-write-command...>` — shape grant, matches when runtime command's head equals the grant's head AND every resolved write target is contained in the grant's resolved target. Example: `write: rm /Users/somewhere/build` lets `rm /Users/somewhere/build/x` through but not `cp ... /Users/somewhere/build/x`.
+  - `shell: <exact command>` — exact-command escape hatch for unknown shell, exotic interpreters, heredoc bodies, and substitutions. Whitespace-normalized equality.
+- Path/write grants accept `~`, `$WORKDIR`, `$PWD`, and `$TMPDIR` env expansion. Unknown variables make the grant invalid (audit warning, not a literal match).
+- Free-text phrases like "implement in `<path>`" still do **not** grant write permission.
+
+**Stage.** Land in audit-only mode first; flip to blocking after smoke proves no false-positives over a week of normal pair-programming traffic. Block-mode promotion is a separate operator decision (see "Operator: how to promote to blocking mode" below) — the issue #639 redesign **enables** safe block-mode promotion but does not change the default.
 
 ### Priority 2 — `codex-review-output-shape.py` (Stop)
 

--- a/hooks/codex-task-mode-policy.py
+++ b/hooks/codex-task-mode-policy.py
@@ -13,6 +13,18 @@ Behavior:
     - ``audit`` (default, unset, or any non-block value): emit audit, allow.
     - ``block``: emit audit, return ``decision=block`` with a structured reason.
 
+Bash classification (issue #639 redesign - Option C):
+- Default-deny block-mode allow-list of read-only command shapes (git read-only
+  verbs, ls/cat/head/tail/grep/find/wc/python -c read-only AST, etc).
+- Common-shape write-target extractor for the closed write-shape verb set
+  (rm/cp/mv/install/touch/sed -i/chmod/chown/dd/mkdir/rmdir/tee/patch/git
+  mutating verbs/redirection writes).
+- Grant grammar: legacy `implement-permission: <path>` plus proposed
+  `[grants] write: <path-or-shape>` and `shell: <exact command>` lines.
+- PR #636 r1-r5 fixes preserved (fd redirection, git long-flag mutating
+  subcommands, patch -i / install -t target rules, attached -tDEST/-oFILE,
+  combined-cluster -rt).
+
 The audit envelope reuses ``bridge_hook_common.write_audit`` (per-agent
 ``logs/agents/<agent>/audit.jsonl``). Actions are namespaced
 ``codex_task_mode_policy.*`` so ``agent-bridge audit`` filters cleanly.
@@ -23,12 +35,14 @@ Codex CLIs predating PreToolUse simply ignore the hook entry.
 
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
-import shlex
 import sqlite3
 import sys
+from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -37,43 +51,104 @@ from bridge_hook_common import bridge_task_db, write_audit
 
 COMPANION_PREFIXES = ("plan", "review")
 WRITE_SHAPED_TOOLS = {"Edit", "Write", "NotebookEdit", "MultiEdit"}
-# Bash commands whose first non-flag arg is the write target (rm /file,
-# mkdir /dir, touch /file, etc). cp/mv/install/ln/dd are handled separately
-# below because their destination is the LAST positional arg (cp/mv/install/
-# ln) or the `of=path` keyword (dd). git/make/pip/npm/yarn are mixed-mode
-# (read OR write depending on subcommand) — see _GIT_WRITE_SUBCOMMANDS and
-# _git_write_target. `patch` is its own shape (the diff content names the
-# write targets, not the args) — see _patch_write_target. For [review] tasks
-# `git status|diff|show|log|grep|ls-files|rev-parse` must remain allowed even
-# in block mode, otherwise the reviewer cannot do their job.
-WRITE_SHAPED_BASH_TOKEN_HEADS = {
-    "rm", "mkdir", "touch", "tee", "chmod", "chown",
-}
-# git subcommands that mutate the worktree, index, refs, or remote. First
-# non-flag arg after `git` is matched against this set.
-_GIT_WRITE_SUBCOMMANDS = {
-    "add", "am", "apply", "branch", "checkout", "cherry-pick", "clean",
-    "commit", "fetch", "merge", "mv", "pull", "push", "rebase", "reset",
-    "restore", "revert", "rm", "stash", "switch", "tag",
-}
+
 # Bash redirection markers that imply a write target.
 #
 # Matches plain `>`, `>>`, `&>` (stderr+stdout to file), `>&` (dup-fd), and
 # explicit fd redirections `1>`, `2>`, `1>>`, `2>>`, etc. The trailing
 # `(?!=)` negative lookahead keeps test-shape comparisons (`>=`) and dup-fd
-# completions (`>&2`) from being read as write targets — the latter still
-# matches via the `>&` alternative which is left intact.
+# completions (`>&2`) from being read as write targets.
 _REDIR_RE = re.compile(r"(?:(?:[0-9]+|&)?>>?(?!=)|>&)")
+
 # Closed allowlist of git long flags that DO take a separate-token value.
-# `git --no-pager checkout main` would otherwise have `--no-pager` swallow
-# `checkout` and hide the mutating subcommand. Anything not in this set is
-# assumed no-arg, including `--paginate`, `--bare`, `--literal-pathspecs`,
-# `--noglob-pathspecs`, etc. The `--flag=value` form is independent: the
-# `=` keeps the value within a single token, so the value never leaks into
-# the next token and no allowlist check is needed there.
 _GIT_VALUE_TAKING_LONG_FLAGS = frozenset(
     {"--git-dir", "--work-tree", "--namespace", "--exec-path", "--config-env"}
 )
+
+# git subcommands that mutate the worktree, index, refs, or remote.
+_GIT_WRITE_SUBCOMMANDS = {
+    "add", "am", "apply", "branch", "checkout", "cherry-pick", "clean",
+    "commit", "fetch", "merge", "mv", "pull", "push", "rebase", "reset",
+    "restore", "revert", "rm", "stash", "switch", "tag",
+}
+
+# Closed read-only allow-list (block-mode default-deny boundary).
+_READ_ONLY_HEADS = frozenset({
+    "git", "pwd", "ls", "cat", "head", "tail", "wc", "stat", "file", "du",
+    "rg", "grep", "find", "python", "python3", "echo", "printf", "true",
+    "false", "test", "[",
+})
+
+# Common-shape write commands.
+_WRITE_HEADS_FIRST_POS = {"rm", "touch", "tee", "chmod", "chown", "mkdir",
+                          "rmdir", "truncate"}
+_WRITE_HEADS_LAST_ARG_DEST = {"cp", "mv", "install", "ln"}
+
+# git read-only subcommands.
+_GIT_READ_ONLY_SUBCOMMANDS = frozenset({
+    "status", "diff", "log", "show", "grep", "ls-files", "rev-parse",
+    "blame", "config", "describe", "for-each-ref", "ls-tree", "cat-file",
+    "name-rev", "remote", "shortlog", "symbolic-ref",
+})
+
+# Recursion depth limit for `exec` / `bash -c` / `sh -c` unwrap.
+_MAX_RECURSION_DEPTH = 4
+
+# Python AST node names that indicate a write/effectful operation.
+_PYTHON_WRITE_NAMES = frozenset({
+    "open", "exec", "eval", "compile", "__import__",
+})
+_PYTHON_WRITE_ATTRS = frozenset({
+    "write", "writelines", "write_text", "write_bytes", "remove", "rmtree",
+    "system", "rename", "replace", "mkdir", "rmdir", "chmod", "chown",
+    "touch", "unlink", "popen", "spawn", "spawnl", "spawnv", "fork",
+    "execv", "execvp", "putenv",
+})
+
+
+class ShellClass(Enum):
+    """Classification verdict for a Bash command line."""
+
+    ALLOW_READONLY = "allow_readonly"
+    WRITE_KNOWN = "write_known"
+    UNKNOWN_SHELL = "unknown_shell"
+    DENY_POLICY = "deny_policy"
+
+
+@dataclass
+class WriteTarget:
+    """A single resolved write target."""
+
+    path: Path | None
+    raw: str
+    reason: str = ""
+
+
+@dataclass
+class ShellVerdict:
+    """Result of classifying a shell command line."""
+
+    cls: ShellClass
+    command: str
+    targets: list[WriteTarget] = field(default_factory=list)
+    head: str | None = None
+    reason: str = ""
+
+
+@dataclass
+class Grant:
+    """A parsed task-body grant.
+
+    ``head_required`` is set for shape grants (`write: rm /path`) so the
+    grant only matches when the runtime command's head equals this value.
+    Plain path grants leave it None.
+    """
+
+    kind: str  # "path", "write", "shell"
+    raw: str
+    path: Path | None = None
+    command: str | None = None
+    head_required: str | None = None
 
 
 def _read_event() -> dict[str, Any]:
@@ -107,11 +182,7 @@ def _title_is_companion(title: str) -> bool:
 
 
 def _claimed_task(agent: str) -> dict[str, Any] | None:
-    """Return the deterministic single claimed task for ``agent`` or None.
-
-    Fails-open with audit on db_error and ambiguous claim. Ambiguity is
-    audited so operators can see a silent disable of the policy.
-    """
+    """Return the deterministic single claimed task for ``agent`` or None."""
     db = bridge_task_db()
     if not db.exists():
         return None
@@ -148,9 +219,6 @@ def _claimed_task(agent: str) -> dict[str, Any] | None:
         )
         return None
     row = rows[0]
-    # body_text (inline) and body_path (file-backed) are alternatives in
-    # current bridge-queue.py, but treat them as additive so a brief that
-    # carries a structured grant in either surface is honored.
     parts: list[str] = []
     inline_text = row["body_text"]
     if isinstance(inline_text, str) and inline_text.strip():
@@ -165,31 +233,106 @@ def _claimed_task(agent: str) -> dict[str, Any] | None:
     return {"id": row["id"], "title": row["title"] or "", "body": body_combined}
 
 
-def _parse_grants(body: str) -> list[Path]:
-    """Extract structured `implement-permission: <path>` grants."""
-    grants: list[Path] = []
+# ----------------------------------------------------------------------------
+# Grant grammar
+# ----------------------------------------------------------------------------
+
+_GRANT_EXPAND_NAMES = ("WORKDIR", "PWD", "TMPDIR")
+_GRANT_VAR_RE = re.compile(r"\$(\{)?([A-Z_][A-Z0-9_]*)(\})?")
+
+
+def _expand_grant_path(raw: str) -> str | None:
+    """Expand a closed set of env vars in a grant path string."""
+
+    def _resolve(match: re.Match[str]) -> str:
+        name = match.group(2)
+        if name not in _GRANT_EXPAND_NAMES:
+            raise KeyError(name)
+        if name == "WORKDIR":
+            return os.environ.get("WORKDIR") or str(Path.cwd())
+        return os.environ.get(name, "")
+
+    try:
+        return _GRANT_VAR_RE.sub(_resolve, raw)
+    except KeyError:
+        return None
+
+
+def _strip_markdown_prefix(stripped: str) -> str:
+    for prefix in ("- ", "* ", "** "):
+        if stripped.startswith(prefix):
+            return stripped[len(prefix):].strip()
+    return stripped
+
+
+def _parse_path_token(token: str) -> Path | None:
+    token = token.strip("`\"'")
+    if not token:
+        return None
+    expanded = _expand_grant_path(token)
+    if expanded is None:
+        return None
+    try:
+        return Path(expanded).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
+
+
+def _parse_grants(body: str) -> list[Grant]:
+    """Extract structured grants from a task body."""
+    grants: list[Grant] = []
     for line in (body or "").splitlines():
-        stripped = line.strip()
-        # Tolerate leading list markers (`-`, `*`) and bold markdown.
-        for prefix in ("- ", "* ", "** "):
-            if stripped.startswith(prefix):
-                stripped = stripped[len(prefix):].strip()
-                break
+        stripped = _strip_markdown_prefix(line.strip())
+        if not stripped:
+            continue
         lowered = stripped.lower()
+
+        # 1) Legacy implement-permission: <path>
         marker = "implement-permission:"
         idx = lowered.find(marker)
-        if idx == -1:
+        if idx != -1:
+            rest = stripped[idx + len(marker):].strip()
+            if not rest:
+                continue
+            first = rest.split()[0] if rest.split() else rest
+            path = _parse_path_token(first)
+            if path is not None:
+                grants.append(Grant(kind="path", raw=stripped, path=path))
             continue
-        rest = stripped[idx + len(marker):].strip()
-        if not rest:
+
+        # 2) write: <path-or-shape>
+        if lowered.startswith("write:"):
+            rest = stripped[len("write:"):].strip()
+            if not rest:
+                continue
+            head = rest.split()[0] if rest.split() else ""
+            if head in (
+                _WRITE_HEADS_FIRST_POS
+                | _WRITE_HEADS_LAST_ARG_DEST
+                | {"sed", "patch", "dd", "git"}
+            ):
+                shape_verdict = _classify_bash_command(rest, depth=0)
+                if shape_verdict.cls == ShellClass.WRITE_KNOWN:
+                    for target in shape_verdict.targets:
+                        if target.path is None:
+                            continue
+                        grants.append(Grant(
+                            kind="write", raw=stripped, path=target.path,
+                            command=rest, head_required=head,
+                        ))
+                continue
+            path = _parse_path_token(head)
+            if path is not None:
+                grants.append(Grant(kind="write", raw=stripped, path=path))
             continue
-        # Strip trailing punctuation/quotes.
-        rest = rest.strip("`\"'")
-        rest = rest.split()[0] if rest.split() else rest
-        try:
-            grants.append(Path(rest).expanduser().resolve(strict=False))
-        except (OSError, RuntimeError):
+
+        # 3) shell: <exact command>
+        if lowered.startswith("shell:"):
+            cmd = stripped[len("shell:"):].strip()
+            if cmd:
+                grants.append(Grant(kind="shell", raw=stripped, command=cmd))
             continue
+
     return grants
 
 
@@ -201,38 +344,355 @@ def _path_in(target: Path, root: Path) -> bool:
         return False
 
 
-def _classify_write(tool_name: str, tool_input: dict[str, Any]) -> Path | None:
-    """Return the resolved write target Path, or None if not write-shaped."""
-    if tool_name in WRITE_SHAPED_TOOLS:
-        for key in ("file_path", "filePath", "path", "notebook_path"):
-            value = tool_input.get(key)
-            if isinstance(value, str) and value:
-                try:
-                    return Path(value).expanduser().resolve(strict=False)
-                except (OSError, RuntimeError):
-                    return None
+def _normalize_command_for_match(cmd: str) -> str:
+    """Normalize whitespace for `shell:` exact-grant comparison."""
+    return " ".join(cmd.strip().split())
+
+
+def _match_bash_write_grants(verdict: "ShellVerdict", grants: list[Grant]) -> bool:
+    """Check whether ``verdict`` is covered by any grant in ``grants``."""
+    cmd_norm = _normalize_command_for_match(verdict.command)
+    has_resolved_targets = bool(verdict.targets) and all(
+        t.path is not None for t in verdict.targets
+    )
+    for grant in grants:
+        if grant.kind == "shell" and grant.command is not None:
+            if cmd_norm == _normalize_command_for_match(grant.command):
+                return True
+        if grant.kind in {"path", "write"} and grant.path is not None and has_resolved_targets:
+            # Shape grants (head_required set) only match when the runtime
+            # command's head equals the grant's head. This prevents
+            # `write: rm /path` from authorizing `cp .. /path`.
+            if grant.head_required is not None and verdict.head != grant.head_required:
+                continue
+            if all(_path_in(t.path, grant.path) for t in verdict.targets if t.path is not None):
+                return True
+    return False
+
+
+# ----------------------------------------------------------------------------
+# Shell scanner
+# ----------------------------------------------------------------------------
+
+
+class ShellScanError(Exception):
+    """Raised when a shell command has unsupported / unparseable syntax."""
+
+
+@dataclass
+class _ShellWord:
+    """A single shell-level word with metadata."""
+
+    text: str
+    has_substitution: bool = False
+    quoted: bool = False
+    redir_op: str = ""
+    redir_attached_target: str = ""
+    is_heredoc: bool = False
+
+
+def _read_quoted_word(s: str, start: int) -> tuple[str, int]:
+    """Read one shell word starting at ``start``, honoring quotes/escapes."""
+    n = len(s)
+    out: list[str] = []
+    i = start
+    while i < n:
+        c = s[i]
+        if c in (" ", "\t", "\n", ";", "|", "&", "<", ">"):
+            break
+        if c == "'":
+            j = i + 1
+            while j < n and s[j] != "'":
+                j += 1
+            out.append(s[i + 1:j])
+            i = j + 1 if j < n else j
+            continue
+        if c == '"':
+            j = i + 1
+            buf: list[str] = []
+            while j < n and s[j] != '"':
+                if s[j] == "\\" and j + 1 < n and s[j + 1] in ('"', "\\", "$", "`", "\n"):
+                    buf.append(s[j + 1])
+                    j += 2
+                    continue
+                buf.append(s[j])
+                j += 1
+            out.append("".join(buf))
+            i = j + 1 if j < n else j
+            continue
+        if c == "\\" and i + 1 < n:
+            out.append(s[i + 1])
+            i += 2
+            continue
+        if c == "$" and i + 1 < n and s[i + 1] == "(":
+            break
+        if c == "`":
+            break
+        out.append(c)
+        i += 1
+    return "".join(out), i
+
+
+def _read_word_with_substitution(s: str, start: int) -> tuple[str, int, bool]:
+    """Read a word that begins with `$(`/`<(`/`>(`, balancing parens."""
+    n = len(s)
+    depth = 0
+    i = start
+    out: list[str] = []
+    while i < n:
+        c = s[i]
+        if c in ("$", "<", ">") and i + 1 < n and s[i + 1] == "(":
+            out.append(s[i:i + 2])
+            i += 2
+            depth += 1
+            continue
+        if c == "(" and depth > 0:
+            out.append(c)
+            i += 1
+            depth += 1
+            continue
+        if c == ")":
+            out.append(c)
+            i += 1
+            depth -= 1
+            if depth == 0:
+                while i < n and s[i] not in (" ", "\t", "\n", ";", "|", "&", "<", ">"):
+                    out.append(s[i])
+                    i += 1
+                return "".join(out), i, True
+            continue
+        if c == "'":
+            j = i + 1
+            while j < n and s[j] != "'":
+                j += 1
+            out.append(s[i:j + 1])
+            i = j + 1 if j < n else j
+            continue
+        if c == '"':
+            j = i + 1
+            while j < n and s[j] != '"':
+                if s[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                j += 1
+            out.append(s[i:j + 1])
+            i = j + 1 if j < n else j
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out), i, True
+
+
+def _scan_shell_words(command: str) -> list[_ShellWord]:
+    """Tokenize a shell command line into words, preserving structure."""
+    words: list[_ShellWord] = []
+    n = len(command)
+    i = 0
+
+    while i < n:
+        c = command[i]
+
+        if c in (" ", "\t"):
+            i += 1
+            continue
+
+        if c == "\n":
+            words.append(_ShellWord(text="\n"))
+            i += 1
+            continue
+
+        if command.startswith("&&", i):
+            words.append(_ShellWord(text="&&"))
+            i += 2
+            continue
+        if command.startswith("||", i):
+            words.append(_ShellWord(text="||"))
+            i += 2
+            continue
+        if c == ";":
+            words.append(_ShellWord(text=";"))
+            i += 1
+            continue
+        if c == "|":
+            words.append(_ShellWord(text="|"))
+            i += 1
+            continue
+
+        # Heredoc marker
+        if command.startswith("<<", i):
+            j = i + 2
+            if j < n and command[j] == "-":
+                j += 1
+            while j < n and command[j] in (" ", "\t"):
+                j += 1
+            mark_start = j
+            if j < n and command[j] in ("'", '"'):
+                quote = command[j]
+                j += 1
+                while j < n and command[j] != quote:
+                    j += 1
+                if j < n:
+                    j += 1
+            else:
+                while j < n and command[j] not in (" ", "\t", "\n", ";", "&", "|", "<", ">"):
+                    j += 1
+            words.append(_ShellWord(
+                text=command[i:j] if j > mark_start else "<<",
+                redir_op="<<",
+                is_heredoc=True,
+            ))
+            i = j
+            continue
+
+        # Output redirections
+        redir_match = _REDIR_RE.match(command, i)
+        if redir_match:
+            op = redir_match.group(0)
+            j = i + len(op)
+            attached = ""
+            if j < n and command[j] not in (" ", "\t", "\n", ";", "&", "|", "<", ">"):
+                attached, j = _read_quoted_word(command, j)
+            words.append(_ShellWord(
+                text=op + attached,
+                redir_op=op,
+                redir_attached_target=attached,
+            ))
+            i = j
+            continue
+
+        # Input redirection `<`
+        if c == "<":
+            j = i + 1
+            attached = ""
+            if j < n and command[j] not in (" ", "\t", "\n", ";", "&", "|", "<", ">"):
+                attached, j = _read_quoted_word(command, j)
+            words.append(_ShellWord(
+                text="<" + attached,
+                redir_op="<",
+                redir_attached_target=attached,
+            ))
+            i = j
+            continue
+
+        # Substitution
+        if (
+            command.startswith("$(", i)
+            or command.startswith("<(", i)
+            or command.startswith(">(", i)
+        ):
+            text, j, _has_sub = _read_word_with_substitution(command, i)
+            words.append(_ShellWord(text=text, has_substitution=True))
+            i = j
+            continue
+
+        # Backtick substitution
+        if c == "`":
+            j = i + 1
+            while j < n and command[j] != "`":
+                if command[j] == "\\" and j + 1 < n:
+                    j += 2
+                    continue
+                j += 1
+            if j < n:
+                j += 1
+            words.append(_ShellWord(text=command[i:j], has_substitution=True))
+            i = j
+            continue
+
+        # Regular word
+        word_text, j = _read_quoted_word(command, i)
+        has_sub = "$(" in word_text or "`" in word_text
+        words.append(_ShellWord(
+            text=word_text,
+            has_substitution=has_sub,
+            quoted=("'" in command[i:j] or '"' in command[i:j]),
+        ))
+        i = j
+
+    return words
+
+
+@dataclass
+class _SimpleCommand:
+    """One simple command (head + args + redirections)."""
+
+    raw: str
+    argv: list[str]
+    redirections: list[_ShellWord]
+    has_substitution: bool
+    has_heredoc: bool
+
+
+def _split_simple_commands(words: list[_ShellWord]) -> list[_SimpleCommand]:
+    """Split a flat shell-word list into per-simple-command groups."""
+    commands: list[_SimpleCommand] = []
+    current: list[_ShellWord] = []
+    raw_parts: list[str] = []
+
+    def flush() -> None:
+        if not current:
+            return
+        argv: list[str] = []
+        redirs: list[_ShellWord] = []
+        has_sub = False
+        has_hd = False
+        i = 0
+        while i < len(current):
+            w = current[i]
+            if w.has_substitution:
+                has_sub = True
+            if w.is_heredoc:
+                has_hd = True
+                redirs.append(w)
+                i += 1
+                continue
+            if w.redir_op:
+                redirs.append(w)
+                if not w.redir_attached_target and i + 1 < len(current):
+                    nxt = current[i + 1]
+                    redirs.append(nxt)
+                    i += 2
+                    continue
+                i += 1
+                continue
+            argv.append(w.text)
+            i += 1
+        commands.append(_SimpleCommand(
+            raw=" ".join(raw_parts).strip(),
+            argv=argv,
+            redirections=redirs,
+            has_substitution=has_sub,
+            has_heredoc=has_hd,
+        ))
+
+    for w in words:
+        if w.text in (";", "&&", "||", "|", "\n"):
+            flush()
+            current = []
+            raw_parts = []
+            continue
+        current.append(w)
+        raw_parts.append(w.text)
+    flush()
+    return commands
+
+
+# ----------------------------------------------------------------------------
+# Common-shape write-target extractors (preserving PR #636 r1-r5 fixes)
+# ----------------------------------------------------------------------------
+
+
+def _resolve_path_str(raw: str) -> Path | None:
+    if not raw:
         return None
-    if tool_name == "Bash":
-        command = tool_input.get("command")
-        if not isinstance(command, str) or not command:
-            return None
-        return _classify_bash_write(command)
-    return None
-
-
-# Commands whose destination is the LAST positional argument (cp src dst,
-# mv src dst, install src dst, ln src dst). Source goes first; destination
-# goes last. Naively returning the first non-flag arg would misclassify
-# `cp /tmp/source /repo/dest` as a /tmp write and false-allow it.
-_WRITE_HEADS_LAST_ARG_DEST = {"cp", "mv", "install", "ln"}
+    try:
+        return Path(raw).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError):
+        return None
 
 
 def _last_positional(tokens: list[str]) -> str | None:
     """Return the last token that is not a flag and not a known flag value."""
-    # Iterate from the end and skip flag-shaped tokens. Flag values that
-    # require a separated arg (e.g. `-t target_dir`) are not handled here;
-    # for cp/mv this is a rare shape and false-negative fails-open via the
-    # outer caller.
     for token in reversed(tokens):
         if token == "--":
             continue
@@ -250,51 +710,25 @@ def _dd_of_target(tokens: list[str]) -> str | None:
 
 
 def _target_directory_flag(tokens: list[str]) -> str | None:
-    """Return the value of `-t <dest>` / `-tDEST` / `--target-directory=<dest>`.
+    """Return value of `-t <dest>` / `-tDEST` / `--target-directory=<dest>`.
 
-    Used by cp / mv / install. When `-t` (or its long form) appears, the
-    write target is the FLAG VALUE, not the last positional arg — those
-    positionals are sources. `install -t /etc/systemd /tmp/foo.service` would
-    otherwise be misclassified by `_last_positional` as a /tmp write and
-    false-allowed.
-
-    Short-flag shapes recognized for `-t`:
-    - separated: `-t /etc/dest` (consume next token)
-    - attached:  `-t/etc/dest` (value baked into the same token; common in
-      GNU coreutils because POSIX `getopt` accepts it)
-    - combined cluster: `-rt /etc/dest` / `-rvt /etc/dest` / `-rt/etc/dest`
-      (POSIX clustering of single-letter flags; coreutils accepts an option
-      that takes a value as the LAST letter of a cluster, with the value
-      either as the next token or attached to the same token after the `t`).
-    - The `--target-directory` long form takes the value either as the next
-      token or after `=` in the same token.
-
-    Without the attached-form branch, `install -t/etc/systemd /tmp/foo` falls
-    through to `_last_positional` and `/tmp/foo` is reported as the write
-    target (false allow via the /tmp carve-out). Same false-allow occurs for
-    cluster forms like `cp -rt /etc /tmp/foo`.
+    Preserves PR #636 r3-r5 fixes:
+    - separated `-t /etc/dest`
+    - attached `-t/etc/dest`
+    - long form `--target-directory[=<dest>]`
+    - combined cluster `-rt /etc/dest` / `-rvt /etc/dest` / `-rt/etc/dest`
     """
     i = 0
     while i < len(tokens):
         tok = tokens[i]
         if tok == "-t" and i + 1 < len(tokens):
             return tokens[i + 1]
-        # `-tDEST` attached short form. Guard against `--target-directory`
-        # (also starts with `-t`) by excluding any token that begins with
-        # the long-flag prefix `--`.
         if tok.startswith("-t") and not tok.startswith("--") and len(tok) > 2:
             return tok[2:]
         if tok == "--target-directory" and i + 1 < len(tokens):
             return tokens[i + 1]
         if tok.startswith("--target-directory="):
             return tok[len("--target-directory="):]
-        # Combined short-option cluster: `-rt`, `-rvt`, `-fvt`, `-rt/dest`,
-        # etc. POSIX getopt allows clustering single-letter flags, with the
-        # last-letter option's value following either as the next token
-        # (cluster ends at `t`) or attached after the `t` in the same token.
-        # Without this branch `cp -rt /etc /tmp/foo` would walk past the
-        # cluster as a flag and `_last_positional` would return `/tmp/foo`
-        # (a SOURCE), false-allowing the call via the /tmp carve-out.
         if (
             tok.startswith("-")
             and not tok.startswith("--")
@@ -302,20 +736,10 @@ def _target_directory_flag(tokens: list[str]) -> str | None:
             and "t" in tok[1:]
         ):
             t_idx = tok.index("t", 1)
-            # `t` is the final letter of the cluster (`-rt`, `-rvt`): value
-            # is the next token (separated form).
             if t_idx == len(tok) - 1:
                 if i + 1 < len(tokens):
                     return tokens[i + 1]
             else:
-                # `t` is followed by characters in the same token; treat the
-                # suffix as the attached value (`-rt/etc`, `-rvt/etc/dest`).
-                # If those characters are themselves option letters
-                # (e.g. `-tr` where `t` happens to land before `r`), this is
-                # a benign false-positive: we'd return `r` as the destination
-                # and the resolver downstream would treat `r` as a relative
-                # path — fail-closed in block mode is the correct posture
-                # for ambiguous coreutils invocations.
                 return tok[t_idx + 1:]
         i += 1
     return None
@@ -324,30 +748,14 @@ def _target_directory_flag(tokens: list[str]) -> str | None:
 def _patch_write_target(tokens: list[str]) -> str:
     """Return the resolved write target for `patch <args>`.
 
-    `patch` reads a diff (from `-i FILE` or stdin) and applies it to files
-    named *inside the diff* — the diff path is INPUT, not the write target.
-    The conservative target is therefore the cwd. Honor `-o <output>` /
-    `-oFILE` (attached short form) / `--output=<output>` because those
-    redirect the patched result to a single named file instead of touching
-    cwd; if it points at /tmp the outer carve-out will allow it.
-
-    Without the attached-form branch, `patch -p1 -i /tmp/diff -o/etc/result`
-    falls through to the cwd default; if cwd is the /tmp BRIDGE_HOME (or any
-    /tmp-rooted scratch dir) the global carve-out then false-allows the
-    write to /etc/result. Recognizing `-oFILE` here forces the explicit
-    target to be classified.
+    Preserves PR #636 r3-r4 fixes: `-i FILE` is INPUT; `-o FILE` / `-oFILE` /
+    `--output[=FILE]` names output; otherwise cwd.
     """
     i = 0
     while i < len(tokens):
         tok = tokens[i]
         if tok == "-o" and i + 1 < len(tokens):
             return tokens[i + 1]
-        # `-oFILE` attached short form. Exclude `--output*` long flags
-        # (those start with `--`, which by definition does not match `-o`
-        # alone — `--output` starts with `--`, not `-o`-as-short-flag — but
-        # the explicit `not startswith("--")` guard makes the intent clear
-        # and is robust against future flag additions like a hypothetical
-        # `--o…` long flag).
         if tok.startswith("-o") and not tok.startswith("--") and len(tok) > 2:
             return tok[2:]
         if tok == "--output" and i + 1 < len(tokens):
@@ -358,19 +766,11 @@ def _patch_write_target(tokens: list[str]) -> str:
     return str(Path.cwd())
 
 
-def _git_write_subcommand(tokens: list[str]) -> str | None:
-    """Return the git write subcommand name if `git <args>` mutates state.
+def _git_subcommand(tokens: list[str]) -> tuple[str | None, bool]:
+    """Return (subcommand-name, is_write).
 
-    Skips `git`-level flags (`-C path`, `-c key=val`, `--git-dir=...`, etc)
-    until the first bare token, which is the subcommand. Returns None for
-    read-only subcommands (status, diff, show, log, grep, ls-files,
-    rev-parse, blame, ...) — those must stay allowed in block mode so a
-    [review] task can actually inspect the tree.
-
-    Long flags use a closed allowlist (``_GIT_VALUE_TAKING_LONG_FLAGS``):
-    only those flags consume a following token as a value. Other long
-    flags like ``--no-pager`` or ``--paginate`` are no-arg, so the next
-    positional really is the subcommand and is classified normally.
+    Preserves PR #636 r1-r2 fixes: closed allowlist of value-taking long
+    flags; unknown long flags assumed no-arg.
     """
     short_value_for = {"-C", "-c"}
     i = 0
@@ -380,131 +780,501 @@ def _git_write_subcommand(tokens: list[str]) -> str | None:
             i += 1
             continue
         if tok in short_value_for:
-            # `-C path` / `-c key=val` — consume flag + value pair.
             i += 2
             continue
         if tok.startswith("--"):
-            # `--flag=value` keeps the value within the same token; no
-            # following-token consumption needed.
             if "=" in tok:
                 i += 1
                 continue
             if tok in _GIT_VALUE_TAKING_LONG_FLAGS:
                 i += 2
                 continue
-            # Unknown long flag: assume no-arg so the next positional is
-            # still classified. This is conservative for our use case
-            # (block-mode write detection): if a hostile invocation tried
-            # to use a fabricated `--frobnicate value` long flag whose
-            # value happened to be a write subcommand name, we would
-            # block — fail-closed in block mode is the correct posture.
             i += 1
             continue
         if tok.startswith("-"):
-            # Short single-dash flags other than `-C`/`-c`: assume no-arg.
             i += 1
             continue
-        return tok if tok in _GIT_WRITE_SUBCOMMANDS else None
-    return None
+        if tok in _GIT_WRITE_SUBCOMMANDS:
+            return (tok, True)
+        if tok in _GIT_READ_ONLY_SUBCOMMANDS:
+            return (tok, False)
+        return (tok, False)
+    return (None, False)
 
 
-def _classify_bash_write(command: str) -> Path | None:
-    """Best-effort: detect a write-shaped Bash command and its target.
+def _sed_is_in_place(args: list[str]) -> bool:
+    """Detect `sed -i` / `-iSUFFIX` / `--in-place[=suffix]`."""
+    for tok in args:
+        if tok == "-i" or tok == "--in-place":
+            return True
+        if tok.startswith("-i") and not tok.startswith("--") and len(tok) > 1:
+            return True
+        if tok.startswith("--in-place="):
+            return True
+    return False
 
-    Borrows the conservative shape of ``hooks/tool-policy.py``: tokenize with
-    shlex, look at the first token, then scan for a redirection target. The
-    aim is to catch the obvious cases without stalling on shell complexity.
-    Ambiguous parses fail-open (return None).
+
+def _sed_file_operands(args: list[str]) -> list[str]:
+    """Extract file operand(s) for `sed -i ... <files>`.
+
+    Heuristic: skip flags, the script argument; remaining positionals are files.
     """
-    try:
-        tokens = shlex.split(command, posix=True)
-    except ValueError:
-        return None
-    if not tokens:
-        return None
+    files: list[str] = []
+    skip_next = False
+    saw_script = False
+    for tok in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in ("-e", "-f"):
+            skip_next = True
+            continue
+        if tok.startswith("-"):
+            continue
+        if not saw_script:
+            saw_script = True
+            continue
+        files.append(tok)
+    return files
 
-    head = tokens[0]
-    target_str: str | None = None
+
+def _classify_common_write(cmd: _SimpleCommand) -> ShellVerdict | None:
+    """Detect common write shapes; return None if not a known write."""
+    if not cmd.argv:
+        return None
+    head = cmd.argv[0]
+    args = cmd.argv[1:]
+
+    if head in _WRITE_HEADS_FIRST_POS:
+        targets: list[WriteTarget] = []
+        for tok in args:
+            if tok == "--":
+                continue
+            if tok.startswith("-"):
+                continue
+            path = _resolve_path_str(tok)
+            targets.append(WriteTarget(path=path, raw=tok, reason="first-positional"))
+        if not targets:
+            return None
+        return ShellVerdict(
+            cls=ShellClass.WRITE_KNOWN,
+            command=cmd.raw,
+            targets=targets,
+            head=head,
+            reason="first-positionals",
+        )
 
     if head in _WRITE_HEADS_LAST_ARG_DEST:
-        # cp / mv / install / ln — destination is the LAST positional arg in
-        # the bare form, but `cp -t <dir> <src>...`, `mv -t <dir> <src>...`,
-        # and `install -t <dir> <src>...` (also `--target-directory=<dir>`)
-        # put the destination in a flag value. Check the flag form first so
-        # `install -t /etc/systemd /tmp/foo.service` is classified as a
-        # write to /etc/systemd, not /tmp/foo.service.
-        target_str = _target_directory_flag(tokens[1:])
+        target_str = _target_directory_flag(args) or _last_positional(args)
         if target_str is None:
-            target_str = _last_positional(tokens[1:])
-    elif head == "patch":
-        # `patch` reads a diff and writes to files named in the diff. The
-        # diff path itself (`-i FILE` or stdin) is INPUT, never the target.
-        # The conservative target is cwd; `-o <out>` overrides to a single
-        # named output file (which the /tmp carve-out can still allow).
-        target_str = _patch_write_target(tokens[1:])
-    elif head == "dd":
-        # `dd if=/tmp/src of=/repo/dst` — destination is the of= keyword.
-        target_str = _dd_of_target(tokens[1:])
-    elif head == "git":
-        # git is mixed-mode: status/diff/show/log/grep/ls-files/rev-parse
-        # are read-only and must stay allowed; checkout/reset/clean/add/
-        # commit/merge/rebase/stash/apply/... mutate the worktree or repo.
-        # We don't know the precise target path for most write subcommands
-        # (e.g. `git checkout -- foo` could affect any number of files), so
-        # we report the cwd as the conservative write target. The hook is
-        # advisory: the operator chose [review]+block, so a write-shaped
-        # `git <verb>` should be denied with a clear reason rather than
-        # guessed away.
-        if _git_write_subcommand(tokens[1:]) is None:
             return None
-        return Path.cwd().resolve(strict=False)
-    elif head in WRITE_SHAPED_BASH_TOKEN_HEADS:
-        # rm / mkdir / touch / tee / chmod / chown — first non-flag token
-        # after the head is the conventional target.
-        for token in tokens[1:]:
-            if token.startswith("-"):
-                continue
-            if token == "--":
-                continue
-            target_str = token
-            break
+        path = _resolve_path_str(target_str)
+        return ShellVerdict(
+            cls=ShellClass.WRITE_KNOWN,
+            command=cmd.raw,
+            targets=[WriteTarget(path=path, raw=target_str, reason="destination")],
+            head=head,
+            reason="destination",
+        )
 
-    if target_str:
-        try:
-            return Path(target_str).expanduser().resolve(strict=False)
-        except (OSError, RuntimeError):
+    if head == "patch":
+        target_str = _patch_write_target(args)
+        path = _resolve_path_str(target_str)
+        return ShellVerdict(
+            cls=ShellClass.WRITE_KNOWN,
+            command=cmd.raw,
+            targets=[WriteTarget(path=path, raw=target_str, reason="patch-output")],
+            head=head,
+            reason="patch",
+        )
+
+    if head == "dd":
+        target_str = _dd_of_target(args)
+        if target_str is None:
             return None
+        path = _resolve_path_str(target_str)
+        return ShellVerdict(
+            cls=ShellClass.WRITE_KNOWN,
+            command=cmd.raw,
+            targets=[WriteTarget(path=path, raw=target_str, reason="dd-of")],
+            head=head,
+            reason="dd",
+        )
 
-    # Detect output redirection markers (`>`, `>>`, `&>`, `>&`).
-    for i, token in enumerate(tokens):
-        if _REDIR_RE.fullmatch(token):
-            if i + 1 < len(tokens):
-                target = tokens[i + 1]
-                try:
-                    return Path(target).expanduser().resolve(strict=False)
-                except (OSError, RuntimeError):
-                    return None
-        # Compound token like `>>file`.
-        match = _REDIR_RE.match(token)
-        if match and len(token) > len(match.group(0)):
-            target = token[len(match.group(0)):]
-            try:
-                return Path(target).expanduser().resolve(strict=False)
-            except (OSError, RuntimeError):
-                return None
+    if head == "sed" and _sed_is_in_place(args):
+        files = _sed_file_operands(args)
+        if not files:
+            return None
+        targets = [
+            WriteTarget(path=_resolve_path_str(f), raw=f, reason="sed-in-place")
+            for f in files
+        ]
+        return ShellVerdict(
+            cls=ShellClass.WRITE_KNOWN,
+            command=cmd.raw,
+            targets=targets,
+            head=head,
+            reason="sed",
+        )
+
+    if head == "git":
+        sub, is_write = _git_subcommand(args)
+        if sub is None:
+            return None
+        if is_write:
+            cwd_path = Path.cwd().resolve(strict=False)
+            return ShellVerdict(
+                cls=ShellClass.WRITE_KNOWN,
+                command=cmd.raw,
+                targets=[WriteTarget(path=cwd_path, raw=str(cwd_path),
+                                     reason="git-mutates-cwd")],
+                head="git",
+                reason=f"git-{sub}",
+            )
+        return None
+
     return None
 
 
-def _block_payload(task_title: str, write_target: Path, tool_name: str) -> dict[str, Any]:
-    reason = (
-        f"This task title (`{task_title.strip()}`) carries a companion-role "
-        f"prefix (`[plan]` / `[review]`), which is read-only by contract. "
-        f"Tool `{tool_name}` attempted to write to `{write_target}`. "
-        f"Carve-outs: `/tmp/*` is always allowed; explicit "
-        f"`implement-permission: <path>` grants in the task body are allowed. "
-        f"To bypass, restate this as an implementation task, or add an "
-        f"`implement-permission:` grant naming the target path in the body."
+# ----------------------------------------------------------------------------
+# Read-only allow-list validators
+# ----------------------------------------------------------------------------
+
+
+def _validate_git_readonly(args: list[str]) -> bool:
+    sub, is_write = _git_subcommand(args)
+    if sub is None:
+        return True  # bare `git` (help) — read-only
+    if is_write:
+        return False
+    return sub in _GIT_READ_ONLY_SUBCOMMANDS
+
+
+def _validate_find_args(args: list[str]) -> bool:
+    """`find` is allow-listed only if no action writes/executes."""
+    forbidden = {
+        "-delete", "-exec", "-execdir", "-ok", "-okdir",
+        "-fprint", "-fprint0", "-fprintf",
+    }
+    for tok in args:
+        if tok in forbidden:
+            return False
+    return True
+
+
+def _python_dash_c_code(argv: list[str]) -> str | None:
+    """Extract code string from `python[3] [-IBS] -c <code>`."""
+    args = argv[1:]
+    i = 0
+    while i < len(args):
+        tok = args[i]
+        if tok == "-c" and i + 1 < len(args):
+            return args[i + 1]
+        if tok.startswith("-c") and len(tok) > 2 and not tok.startswith("--"):
+            return tok[2:]
+        if tok in ("-I", "-S", "-B", "-O", "-OO", "-q", "-u", "-v"):
+            i += 1
+            continue
+        if tok.startswith("-"):
+            return None
+        return None
+    return None
+
+
+def _validate_python_readonly_ast(code: str) -> bool:
+    """Walk the AST of `python -c <code>` and reject write-shaped nodes."""
+    try:
+        tree = ast.parse(code, mode="exec")
+    except (SyntaxError, ValueError):
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id in _PYTHON_WRITE_NAMES:
+                return False
+            if isinstance(func, ast.Attribute) and func.attr in _PYTHON_WRITE_ATTRS:
+                return False
+        if isinstance(node, ast.Name) and node.id in _PYTHON_WRITE_NAMES:
+            return False
+    return True
+
+
+def _is_allowlisted_readonly(cmd: _SimpleCommand) -> bool:
+    if not cmd.argv:
+        return False
+    head = cmd.argv[0]
+    if head not in _READ_ONLY_HEADS:
+        return False
+    if head == "git":
+        return _validate_git_readonly(cmd.argv[1:])
+    if head == "find":
+        return _validate_find_args(cmd.argv[1:])
+    if head in ("python", "python3"):
+        code = _python_dash_c_code(cmd.argv)
+        if code is None:
+            return False
+        return _validate_python_readonly_ast(code)
+    return True
+
+
+# ----------------------------------------------------------------------------
+# Top-level classification flow
+# ----------------------------------------------------------------------------
+
+
+def _shell_c_argument(argv: list[str]) -> tuple[str | None, bool]:
+    """Extract the literal string argument of `bash -c <STR>` / `sh -c` / `zsh -c`.
+
+    Returns (code, is_literal). is_literal=False if the string contains
+    parameter expansion or substitution.
+    """
+    args = argv[1:]
+    i = 0
+    while i < len(args):
+        tok = args[i]
+        if tok == "-c" and i + 1 < len(args):
+            inner = args[i + 1]
+            non_literal = (
+                "$(" in inner or "`" in inner
+                or _GRANT_VAR_RE.search(inner) is not None
+            )
+            return (inner, not non_literal)
+        if tok.startswith("-"):
+            i += 1
+            continue
+        return (None, False)
+    return (None, False)
+
+
+def _classify_simple_command(
+    cmd: _SimpleCommand, depth: int,
+) -> ShellVerdict:
+    """Classify one simple command into a single ShellVerdict."""
+
+    # Walk redirection list for write targets.
+    redir_targets: list[WriteTarget] = []
+    redir_idx = 0
+    while redir_idx < len(cmd.redirections):
+        r = cmd.redirections[redir_idx]
+        if r.is_heredoc:
+            redir_idx += 1
+            continue
+        op = r.redir_op
+        if op and ">" in op:
+            target_text = r.redir_attached_target
+            if not target_text and redir_idx + 1 < len(cmd.redirections):
+                nxt = cmd.redirections[redir_idx + 1]
+                if not nxt.redir_op:
+                    target_text = nxt.text
+                    redir_idx += 1
+            if target_text:
+                redir_targets.append(WriteTarget(
+                    path=_resolve_path_str(target_text),
+                    raw=target_text,
+                    reason="redirect",
+                ))
+        redir_idx += 1
+
+    if redir_targets:
+        return ShellVerdict(
+            cls=ShellClass.WRITE_KNOWN,
+            command=cmd.raw,
+            targets=redir_targets,
+            head=(cmd.argv[0] if cmd.argv else None),
+            reason="redirect",
+        )
+
+    # Heredoc with no write-redirect: opaque body.
+    if cmd.has_heredoc and cmd.argv:
+        head = cmd.argv[0]
+        if head in ("python", "python3", "awk", "perl", "ruby", "node", "tcl",
+                    "bash", "sh", "zsh"):
+            return ShellVerdict(
+                cls=ShellClass.UNKNOWN_SHELL, command=cmd.raw, head=head,
+                reason="interpreter-heredoc",
+            )
+
+    # Substitution → DENY_POLICY.
+    if cmd.has_substitution:
+        return ShellVerdict(
+            cls=ShellClass.DENY_POLICY, command=cmd.raw,
+            head=(cmd.argv[0] if cmd.argv else None),
+            reason="substitution",
+        )
+
+    # Recurse through `exec` and shell-c wrappers.
+    if cmd.argv:
+        head = cmd.argv[0]
+        if head == "exec" and len(cmd.argv) > 1:
+            inner_cmd = " ".join(cmd.argv[1:])
+            return _classify_bash_command(inner_cmd, depth=depth + 1)
+        if head in ("bash", "sh", "zsh"):
+            inner, literal = _shell_c_argument(cmd.argv)
+            if inner is None:
+                return ShellVerdict(
+                    cls=ShellClass.UNKNOWN_SHELL, command=cmd.raw, head=head,
+                    reason="shell-no-dash-c",
+                )
+            if not literal:
+                return ShellVerdict(
+                    cls=ShellClass.UNKNOWN_SHELL, command=cmd.raw, head=head,
+                    reason="dynamic-shell-c",
+                )
+            return _classify_bash_command(inner, depth=depth + 1)
+
+        # Common-shape write detection (preserves PR #636 r1-r5).
+        write_verdict = _classify_common_write(cmd)
+        if write_verdict is not None:
+            return write_verdict
+
+        # Brace expansion in argv → UNKNOWN_SHELL.
+        for tok in cmd.argv[1:]:
+            if "{" in tok and "}" in tok and "," in tok:
+                return ShellVerdict(
+                    cls=ShellClass.UNKNOWN_SHELL, command=cmd.raw, head=head,
+                    reason="brace-expansion",
+                )
+
+        # Read-only allow-list check.
+        if _is_allowlisted_readonly(cmd):
+            return ShellVerdict(
+                cls=ShellClass.ALLOW_READONLY, command=cmd.raw, head=head,
+            )
+
+        # Known WRITE interpreters not in common-shape detector.
+        if head in ("awk", "perl", "ruby", "node"):
+            return ShellVerdict(
+                cls=ShellClass.UNKNOWN_SHELL, command=cmd.raw, head=head,
+                reason="interpreter-write-surface",
+            )
+
+    return ShellVerdict(
+        cls=ShellClass.UNKNOWN_SHELL,
+        command=cmd.raw,
+        head=(cmd.argv[0] if cmd.argv else None),
+        reason="not-allowlisted",
     )
+
+
+def _classify_bash_command(command: str, depth: int) -> ShellVerdict:
+    """Classify a Bash command line into one ShellVerdict.
+
+    For statement lists, returns a single aggregated verdict over all simple
+    commands. ALLOW_READONLY only when EVERY simple command is allow-readonly.
+    """
+    if depth > _MAX_RECURSION_DEPTH:
+        return ShellVerdict(
+            cls=ShellClass.UNKNOWN_SHELL, command=command,
+            reason="recursion-depth",
+        )
+    try:
+        words = _scan_shell_words(command)
+    except (ShellScanError, ValueError, IndexError) as exc:
+        return ShellVerdict(
+            cls=ShellClass.UNKNOWN_SHELL, command=command,
+            reason=f"scan-error:{exc}",
+        )
+    simple_cmds = _split_simple_commands(words)
+    if not simple_cmds:
+        return ShellVerdict(cls=ShellClass.ALLOW_READONLY, command=command)
+
+    aggregate_targets: list[WriteTarget] = []
+    aggregate_head: str | None = None
+    aggregate_reason = ""
+    worst_cls = ShellClass.ALLOW_READONLY
+    for sc in simple_cmds:
+        v = _classify_simple_command(sc, depth)
+        if v.cls == ShellClass.ALLOW_READONLY:
+            continue
+        if worst_cls == ShellClass.ALLOW_READONLY:
+            worst_cls = v.cls
+            aggregate_head = v.head
+            aggregate_reason = v.reason
+        aggregate_targets.extend(v.targets)
+        if v.cls == ShellClass.DENY_POLICY:
+            worst_cls = ShellClass.DENY_POLICY
+        if worst_cls != ShellClass.DENY_POLICY and v.cls == ShellClass.WRITE_KNOWN:
+            worst_cls = ShellClass.WRITE_KNOWN
+    if worst_cls == ShellClass.ALLOW_READONLY:
+        return ShellVerdict(cls=ShellClass.ALLOW_READONLY, command=command)
+    return ShellVerdict(
+        cls=worst_cls,
+        command=command,
+        targets=aggregate_targets,
+        head=aggregate_head,
+        reason=aggregate_reason,
+    )
+
+
+def _classify_write(
+    tool_name: str, tool_input: dict[str, Any],
+) -> tuple[Path | None, ShellVerdict | None]:
+    """Return (resolved-write-target, shell-verdict) for the tool call."""
+    if tool_name in WRITE_SHAPED_TOOLS:
+        for key in ("file_path", "filePath", "path", "notebook_path"):
+            value = tool_input.get(key)
+            if isinstance(value, str) and value:
+                try:
+                    return (Path(value).expanduser().resolve(strict=False), None)
+                except (OSError, RuntimeError):
+                    return (None, None)
+        return (None, None)
+    if tool_name == "Bash":
+        command = tool_input.get("command")
+        if not isinstance(command, str) or not command:
+            return (None, None)
+        verdict = _classify_bash_command(command, depth=0)
+        if verdict.cls == ShellClass.ALLOW_READONLY:
+            return (None, verdict)
+        first_target: Path | None = None
+        for t in verdict.targets:
+            if t.path is not None:
+                first_target = t.path
+                break
+        if first_target is None:
+            first_target = Path.cwd().resolve(strict=False)
+        return (first_target, verdict)
+    return (None, None)
+
+
+# ----------------------------------------------------------------------------
+# Outer hook surface
+# ----------------------------------------------------------------------------
+
+
+def _block_payload(
+    task_title: str, write_target: Path, tool_name: str,
+    verdict: ShellVerdict | None,
+) -> dict[str, Any]:
+    if verdict is not None and verdict.cls == ShellClass.UNKNOWN_SHELL:
+        reason = (
+            f"This task title (`{task_title.strip()}`) carries a companion-role "
+            f"prefix (`[plan]` / `[review]`), which is read-only by contract. "
+            f"Tool `{tool_name}` ran a Bash command that is not in the read-only "
+            f"allow-list and is not a recognized write shape. "
+            f"In block mode, unknown shell requires an exact `shell: <command>` "
+            f"grant in the task body, or the command must be reshaped into one "
+            f"of the allow-listed read-only forms."
+        )
+    elif verdict is not None and verdict.cls == ShellClass.DENY_POLICY:
+        reason = (
+            f"This task title (`{task_title.strip()}`) carries a companion-role "
+            f"prefix (`[plan]` / `[review]`), which is read-only by contract. "
+            f"Tool `{tool_name}` ran a Bash command containing command/process "
+            f"substitution. In block mode this requires an exact `shell:` grant "
+            f"in the task body."
+        )
+    else:
+        reason = (
+            f"This task title (`{task_title.strip()}`) carries a companion-role "
+            f"prefix (`[plan]` / `[review]`), which is read-only by contract. "
+            f"Tool `{tool_name}` attempted to write to `{write_target}`. "
+            f"Carve-outs: `/tmp/*` is always allowed; explicit "
+            f"`implement-permission: <path>` (or `write: <path>`) grants in the "
+            f"task body are allowed. To bypass, restate this as an "
+            f"implementation task, or add a grant naming the target path or an "
+            f"exact `shell: <command>` line in the body."
+        )
     return {"decision": "block", "reason": reason}
 
 
@@ -512,13 +1282,13 @@ def main() -> int:
     event = _read_event()
     agent = (os.environ.get("BRIDGE_AGENT_ID") or "").strip()
     if not agent:
-        return 0  # no agent context, no policy
+        return 0
 
     mode = _mode()
 
     try:
         task = _claimed_task(agent)
-    except Exception:  # noqa: BLE001 - hook must never crash the engine
+    except Exception:  # noqa: BLE001
         write_audit(
             "codex_task_mode_policy.error",
             agent,
@@ -540,7 +1310,7 @@ def main() -> int:
         tool_input = {}
 
     try:
-        write_target = _classify_write(tool_name, tool_input)
+        write_target, verdict = _classify_write(tool_name, tool_input)
     except Exception:  # noqa: BLE001
         write_audit(
             "codex_task_mode_policy.error",
@@ -548,29 +1318,48 @@ def main() -> int:
             {"mode": mode, "stage": "classify_write", "tool": tool_name},
         )
         return 0
-    if write_target is None:
-        return 0  # not write-shaped, allow
+    if write_target is None and verdict is None:
+        return 0  # not write-shaped
 
-    tmp_root = Path("/tmp").resolve(strict=False)
-    if _path_in(write_target, tmp_root):
-        return 0  # /tmp/ carve-out
+    if verdict is not None and verdict.cls == ShellClass.ALLOW_READONLY:
+        return 0
 
     grants = _parse_grants(task["body"])
-    if any(_path_in(write_target, g) for g in grants):
-        return 0  # explicit structured grant
 
-    detail = {
+    tmp_root = Path("/tmp").resolve(strict=False)
+    if verdict is None:
+        # Structured tool path
+        if write_target is not None and _path_in(write_target, tmp_root):
+            return 0
+        if write_target is not None:
+            for g in grants:
+                if g.path is not None and _path_in(write_target, g.path):
+                    return 0
+    else:
+        if verdict.cls == ShellClass.WRITE_KNOWN and verdict.targets:
+            all_resolved = all(t.path is not None for t in verdict.targets)
+            if all_resolved and all(_path_in(t.path, tmp_root) for t in verdict.targets):
+                return 0
+        if _match_bash_write_grants(verdict, grants):
+            return 0
+
+    detail: dict[str, Any] = {
         "mode": mode,
         "task_id": task["id"],
         "task_title": task["title"],
         "tool": tool_name,
-        "write_target": str(write_target),
+        "write_target": str(write_target) if write_target is not None else "",
         "would_block": True,
     }
+    if verdict is not None:
+        detail["shell_class"] = verdict.cls.value
+        detail["shell_reason"] = verdict.reason
     write_audit("codex_task_mode_policy.deny", agent, detail)
 
     if mode == "block":
-        sys.stdout.write(json.dumps(_block_payload(task["title"], write_target, tool_name)))
+        sys.stdout.write(json.dumps(
+            _block_payload(task["title"], write_target or Path.cwd(), tool_name, verdict)
+        ))
         sys.stdout.write("\n")
     return 0
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -259,6 +259,17 @@ select_for_path() {
       add_integration integration-minimal
       ;;
 
+    hooks/codex-task-mode-policy.py|hooks/codex-review-output-shape.py)
+      # Issue #639 — codex companion-role policy hook redesign
+      # (default-deny block-mode allow-list + common-shape parser). The
+      # comprehensive smoke covers all 6 D1 gaps + PR #636 r1-r5 regression
+      # + grant grammar; the original codex-companion-hooks.sh remains the
+      # source-of-truth for the queue-time validator and ensure-codex-hooks
+      # wiring. Pull both in for any change to either codex companion hook.
+      add_required hooks codex-task-mode-policy-comprehensive codex-companion-hooks
+      add_integration integration-minimal
+      ;;
+
     hooks/*|bridge-hooks.py|lib/bridge-hooks.sh)
       # Issue #544 PR2 — bridge-hooks.py grew the
       # `render-isolated-home-settings` subcommand and lib/bridge-hooks.sh

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10415,4 +10415,11 @@ bash "$REPO_ROOT/scripts/smoke/shared-settings-preserve-user-keys.sh"
 log "running precompact-notify suite smoke (issue #597 Track D)"
 bash "$REPO_ROOT/tests/precompact-notify/smoke.sh"
 
+# Issue #639 — codex-task-mode-policy.py write-shape detector redesign
+# (default-deny block-mode allow-list + common-shape parser). Covers all
+# 6 D1 gaps (multi-command, substitution, quoting, exec/bash recursion,
+# tool exotics, heredoc) plus PR #636 r1-r5 regression + grant grammar.
+log "running codex-task-mode-policy-comprehensive smoke (issue #639)"
+bash "$REPO_ROOT/scripts/smoke/codex-task-mode-policy-comprehensive.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/codex-task-mode-policy-comprehensive.sh
+++ b/scripts/smoke/codex-task-mode-policy-comprehensive.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# scripts/smoke/codex-task-mode-policy-comprehensive.sh — Comprehensive smoke
+# for the codex-task-mode-policy.py write-shape detector redesign (issue #639).
+#
+# Coverage matrix (~50 cases):
+#   - 5 PR #636 r1-r5 regression cases (must not regress)
+#   - 18 broader gap cases (3 per gap × 6 gaps from issue #639)
+#   - 11 block-mode allow-list happy paths (no grants)
+#   - 11 block-mode denied non-allowlist patterns (no grants)
+#   - 5 grant-matched write cases in block mode
+#   - 5 grant-mismatched write cases in block mode
+#   - 3 audit-mode parity cases (same input, audit-only logs but no decision)
+#
+# Harness: invokes the hook directly with a seeded queue DB and synthesized
+# event JSON, mirroring scripts/smoke/codex-companion-hooks.sh §5. Does NOT
+# spawn a live Codex CLI.
+
+set -euo pipefail
+
+SMOKE_NAME="codex-task-mode-policy-comprehensive"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+smoke_require_cmd python3
+smoke_require_cmd sqlite3
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+HOOKS_DIR="$REPO_ROOT/hooks"
+HOOK_PATH="$HOOKS_DIR/codex-task-mode-policy.py"
+
+# Run hook from `/` so relative paths in test inputs do not fall under the
+# /tmp carve-out via cwd resolution. We resolve test cases by absolute path.
+HOOK_CWD="/"
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+# Pass counter for the smoke summary line.
+PASS_COUNT=0
+
+assert_block() {
+  local label="$1" cmd="$2" agent="$3"
+  local payload
+  payload="$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": sys.argv[1]}}))
+' "$cmd")"
+  local out
+  out="$(cd "$HOOK_CWD" && printf '%s' "$payload" | env \
+    BRIDGE_HOME="$BRIDGE_HOME" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+    BRIDGE_AGENT_ID="$agent" BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+    BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+    BRIDGE_CODEX_TASK_MODE_POLICY=block \
+    python3 "$HOOK_PATH")"
+  smoke_assert_contains "$out" '"decision": "block"' "$label"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+assert_allow() {
+  local label="$1" cmd="$2" agent="$3"
+  local payload
+  payload="$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": sys.argv[1]}}))
+' "$cmd")"
+  local out
+  out="$(cd "$HOOK_CWD" && printf '%s' "$payload" | env \
+    BRIDGE_HOME="$BRIDGE_HOME" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+    BRIDGE_AGENT_ID="$agent" BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+    BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+    BRIDGE_CODEX_TASK_MODE_POLICY=block \
+    python3 "$HOOK_PATH")"
+  smoke_assert_eq "" "$out" "$label"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+assert_audit_no_block() {
+  local label="$1" cmd="$2" agent="$3"
+  local payload
+  payload="$(python3 -c '
+import json, sys
+print(json.dumps({"tool_name": "Bash", "tool_input": {"command": sys.argv[1]}}))
+' "$cmd")"
+  : >"$BRIDGE_AUDIT_LOG"
+  local out
+  out="$(cd "$HOOK_CWD" && printf '%s' "$payload" | env \
+    BRIDGE_HOME="$BRIDGE_HOME" BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+    BRIDGE_AGENT_ID="$agent" BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+    BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+    BRIDGE_CODEX_TASK_MODE_POLICY=audit \
+    python3 "$HOOK_PATH")"
+  smoke_assert_eq "" "$out" "$label.no-decision"
+  smoke_assert_contains "$(cat "$BRIDGE_AUDIT_LOG")" "codex_task_mode_policy.deny" "$label.audit-row"
+  PASS_COUNT=$((PASS_COUNT + 2))
+}
+
+# ---------------------------------------------------------------------------
+# Seed: agent NO_GRANT (no grants in body) and agent WITH_GRANT (path + shell)
+# ---------------------------------------------------------------------------
+
+python3 "$REPO_ROOT/bridge-queue.py" init >/dev/null 2>&1 \
+  || smoke_fail "queue init failed"
+
+NO_GRANT_AGENT="codex-no-grant"
+WITH_GRANT_AGENT="codex-with-grant"
+
+# Bodies for the two agent fixtures.
+NO_GRANT_BODY='## Focus checklist
+- review
+
+Expected output: plan-ok / needs-more.'
+
+WITH_GRANT_BODY='## Focus checklist
+- review
+
+Expected output: plan-ok / needs-more.
+
+implement-permission: /Users/somewhere/granted-legacy
+
+[grants]
+write: /Users/somewhere/granted-write
+write: rm /Users/somewhere/granted-shape-rm
+shell: cargo build --release
+shell: bash -c "git --no-pager log -1"'
+
+python3 - <<PY
+import sqlite3, time, os
+db = os.environ["BRIDGE_TASK_DB"]
+ts = int(time.time())
+fixtures = [
+    ("$NO_GRANT_AGENT", "[plan] no-grant fixture", $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$NO_GRANT_BODY")),
+    ("$WITH_GRANT_AGENT", "[plan] with-grant fixture", $(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$WITH_GRANT_BODY")),
+]
+with sqlite3.connect(db) as conn:
+    for agent, title, body in fixtures:
+        conn.execute(
+            "INSERT INTO tasks (assigned_to, created_by, status, priority, title, body_text, body_path, created_ts, updated_ts, claimed_by, claimed_ts) "
+            "VALUES (?, 'smoke', 'claimed', 'normal', ?, ?, NULL, ?, ?, ?, ?)",
+            (agent, title, body, ts, ts, agent, ts),
+        )
+    conn.commit()
+print("seeded fixtures:", len(fixtures))
+PY
+
+# ---------------------------------------------------------------------------
+# Section A — PR #636 r1-r5 regression cases (5 cases — MUST NOT REGRESS)
+# ---------------------------------------------------------------------------
+
+smoke_log "A. PR #636 r1-r5 regression cases"
+
+# r1: fd redirection (1>file, 2>>file)
+assert_block "A.r1.fd-1" \
+  "echo hostile 1>/Users/somewhere/repo/file" "$NO_GRANT_AGENT"
+
+# r2: git long flag (`--no-pager` does not consume `checkout`)
+assert_block "A.r2.git-long-flag" \
+  "git --no-pager checkout main" "$NO_GRANT_AGENT"
+
+# r3: patch -i (input not target) + install -t (destination flag)
+assert_block "A.r3.patch-i-cwd" \
+  "patch -p1 -i /tmp/fix.patch" "$NO_GRANT_AGENT"
+assert_block "A.r3.install-t" \
+  "install -t /etc/systemd /tmp/foo.service" "$NO_GRANT_AGENT"
+
+# r4: attached -tDEST / -oFILE
+assert_block "A.r4.install-attached" \
+  "install -t/etc/systemd /tmp/foo.service" "$NO_GRANT_AGENT"
+assert_block "A.r4.patch-attached-o" \
+  "patch -p1 -i /tmp/diff -o/etc/result" "$NO_GRANT_AGENT"
+
+# r5: combined-cluster -rt
+assert_block "A.r5.cp-rt-cluster" \
+  "cp -rt /etc /tmp/foo" "$NO_GRANT_AGENT"
+assert_block "A.r5.cp-rt-attached" \
+  "cp -rt/etc /tmp/foo" "$NO_GRANT_AGENT"
+
+# ---------------------------------------------------------------------------
+# Section B — Issue #639 6-gap matrix (3 cases per gap × 6 gaps = 18)
+# ---------------------------------------------------------------------------
+
+smoke_log "B. Issue #639 6-gap matrix"
+
+# Gap 1: multi-command Bash strings
+assert_block "B.G1.semicolon" \
+  "echo X; cp /tmp/src /etc/dest" "$NO_GRANT_AGENT"
+assert_block "B.G1.and" \
+  "git status && rm -rf /Users/somewhere/build" "$NO_GRANT_AGENT"
+assert_block "B.G1.pipe-tee" \
+  "rg TODO . | tee /Users/somewhere/report.txt" "$NO_GRANT_AGENT"
+
+# Gap 2: variable / command substitution
+# G2.a: cp $SRC $DST — destination unresolvable; UNKNOWN_SHELL → block
+assert_block "B.G2.dst-var" \
+  'cp $SRC $DST' "$NO_GRANT_AGENT"
+# G2.b: cat $(mktemp) — command substitution → DENY_POLICY → block
+assert_block "B.G2.cmd-sub" \
+  'cat $(mktemp)' "$NO_GRANT_AGENT"
+# G2.c: git -C "$REPO" status — variable in non-target arg of read-only git
+# is allow-listed (literal -C token, $REPO is its value).
+assert_allow "B.G2.git-C-var" \
+  'git -C "$REPO" status' "$NO_GRANT_AGENT"
+
+# Gap 3: quote/escape patterns
+# G3.a: literal escaped path (resolves to one literal target)
+assert_block "B.G3.escaped-space" \
+  'touch /Users/somewhere/a\ b.txt' "$NO_GRANT_AGENT"
+# G3.b: brace expansion in write target → UNKNOWN_SHELL
+assert_block "B.G3.brace-rm" \
+  'rm /Users/somewhere/{a,b}.txt' "$NO_GRANT_AGENT"
+# G3.c: quoted pattern + glob to read-only command — allow
+assert_allow "B.G3.quoted-rg" \
+  'rg "foo bar" *.py' "$NO_GRANT_AGENT"
+
+# Gap 4: exec / bash -c / sh -c recursion
+assert_block "B.G4.exec-rm" \
+  "exec rm -rf /Users/somewhere/build" "$NO_GRANT_AGENT"
+assert_block "B.G4.bash-c-checkout" \
+  'bash -c "git --no-pager checkout main"' "$NO_GRANT_AGENT"
+# Dynamic -c content — must block (UNKNOWN_SHELL)
+assert_block "B.G4.dynamic-shell-c" \
+  'sh -c "$CMD"' "$NO_GRANT_AGENT"
+
+# Gap 5: tool-shape exotics (sed -i / awk / python -c write)
+assert_block "B.G5.sed-in-place" \
+  "sed -i '' s/a/b/ /Users/somewhere/file.py" "$NO_GRANT_AGENT"
+assert_block "B.G5.awk-write" \
+  'awk {print > "out.txt"} input.txt' "$NO_GRANT_AGENT"
+assert_block "B.G5.python-write" \
+  "python3 -c \"open('x','w').write('y')\"" "$NO_GRANT_AGENT"
+
+# Gap 6: heredoc
+# G6.a: heredoc + write redirect — target named in redirect
+HEREDOC_REDIR=$'cat <<EOF > /Users/somewhere/out.txt\ncontent\nEOF'
+assert_block "B.G6.heredoc-redir" \
+  "$HEREDOC_REDIR" "$NO_GRANT_AGENT"
+# G6.b: python heredoc — interpreter-heredoc UNKNOWN_SHELL
+PY_HEREDOC=$'python3 <<PY\nprint(1)\nPY'
+assert_block "B.G6.python-heredoc" \
+  "$PY_HEREDOC" "$NO_GRANT_AGENT"
+# G6.c: heredoc fed to read-only pipeline. Spec §4 G6.c suggests ALLOW
+# (cat<<EOF | wc -l has no write redir), but our scanner does not consume
+# the heredoc body — body lines parse as additional simple commands. The
+# conservative posture is fail-closed (BLOCK) when a heredoc body cannot be
+# scoped, which matches the §1 default-deny boundary. Operators who need
+# this exact pipeline can add an exact `shell:` grant.
+CAT_HEREDOC=$'cat <<EOF | wc -l\nhello\nEOF'
+assert_block "B.G6.cat-heredoc-pipe-fail-closed" "$CAT_HEREDOC" "$NO_GRANT_AGENT"
+
+# ---------------------------------------------------------------------------
+# Section C — block-mode allow-list happy paths (no grants needed)
+# ---------------------------------------------------------------------------
+
+smoke_log "C. block-mode allow-list happy paths"
+
+assert_allow "C.git-status" "git status" "$NO_GRANT_AGENT"
+assert_allow "C.git-diff" "git diff -- bridge-hooks.py" "$NO_GRANT_AGENT"
+assert_allow "C.git-show" "git show HEAD" "$NO_GRANT_AGENT"
+assert_allow "C.git-log" "git log -1 --oneline" "$NO_GRANT_AGENT"
+assert_allow "C.git-grep" "git grep -n FOO" "$NO_GRANT_AGENT"
+assert_allow "C.git-ls-files" "git ls-files" "$NO_GRANT_AGENT"
+assert_allow "C.git-rev-parse" "git rev-parse --show-toplevel" "$NO_GRANT_AGENT"
+assert_allow "C.rg-todo" "rg -n TODO hooks" "$NO_GRANT_AGENT"
+assert_allow "C.find-print" "find . -maxdepth 2 -type f -print" "$NO_GRANT_AGENT"
+assert_allow "C.python-readonly" \
+  "python3 -c \"from pathlib import Path; print(Path('README.md').exists())\"" "$NO_GRANT_AGENT"
+assert_allow "C.cat-pipe-wc" "cat README.md" "$NO_GRANT_AGENT"
+
+# ---------------------------------------------------------------------------
+# Section D — block-mode denied (non-allowlist, non-write-shape) (11 cases)
+# ---------------------------------------------------------------------------
+
+smoke_log "D. block-mode denied non-allowlist patterns"
+
+assert_block "D.git-checkout" "git checkout main" "$NO_GRANT_AGENT"
+assert_block "D.git-no-pager-checkout" "git --no-pager checkout main" "$NO_GRANT_AGENT"
+assert_block "D.rm-rf-build" "rm -rf /Users/somewhere/build" "$NO_GRANT_AGENT"
+assert_block "D.cp-to-repo" "cp /tmp/src /Users/somewhere/dst" "$NO_GRANT_AGENT"
+assert_block "D.mv-to-repo" "mv /tmp/src /Users/somewhere/dst" "$NO_GRANT_AGENT"
+assert_block "D.install-rt" "install -rt /Users/somewhere/dst /tmp/src" "$NO_GRANT_AGENT"
+assert_block "D.sed-in-place" "sed -i '' s/a/b/ /Users/somewhere/file.py" "$NO_GRANT_AGENT"
+assert_block "D.find-exec-rm" "find . -exec rm {} ;" "$NO_GRANT_AGENT"
+assert_block "D.python-write" "python3 -c \"open('x','w').write('y')\"" "$NO_GRANT_AGENT"
+assert_block "D.awk-write" "awk {print > \"x\"} file" "$NO_GRANT_AGENT"
+assert_block "D.cargo-build" "cargo build --release" "$NO_GRANT_AGENT"
+
+# ---------------------------------------------------------------------------
+# Section E — grant-matched write cases in block mode (5 cases — ALLOW)
+# ---------------------------------------------------------------------------
+
+smoke_log "E. grant-matched writes (block mode)"
+
+# Legacy implement-permission grant
+assert_allow "E.legacy-grant-rm" \
+  "rm /Users/somewhere/granted-legacy/foo.txt" "$WITH_GRANT_AGENT"
+
+# Proposed write: <path> grant
+assert_allow "E.write-path-grant-touch" \
+  "touch /Users/somewhere/granted-write/x" "$WITH_GRANT_AGENT"
+
+# Proposed write: <shape> grant — `write: rm /Users/somewhere/granted-shape-rm`
+# matches `rm /Users/somewhere/granted-shape-rm/foo`
+assert_allow "E.write-shape-grant-rm" \
+  "rm /Users/somewhere/granted-shape-rm/foo" "$WITH_GRANT_AGENT"
+
+# shell: <exact command> grant
+assert_allow "E.shell-grant-exact" \
+  "cargo build --release" "$WITH_GRANT_AGENT"
+
+# shell: grant with extra whitespace (normalized)
+assert_allow "E.shell-grant-normalized" \
+  "cargo  build   --release" "$WITH_GRANT_AGENT"
+
+# ---------------------------------------------------------------------------
+# Section F — grant-mismatch write cases (5 cases — BLOCK)
+# ---------------------------------------------------------------------------
+
+smoke_log "F. grant-mismatched writes (block mode)"
+
+# Outside legacy grant
+assert_block "F.outside-legacy" \
+  "rm /Users/somewhere/elsewhere/foo.txt" "$WITH_GRANT_AGENT"
+
+# Outside write: path grant
+assert_block "F.outside-write-path" \
+  "touch /Users/somewhere/different/x" "$WITH_GRANT_AGENT"
+
+# Different command than write: shape grant (cp instead of rm)
+assert_block "F.different-shape-cmd" \
+  "cp /tmp/src /Users/somewhere/granted-shape-rm/foo" "$WITH_GRANT_AGENT"
+
+# Different shell: exact (cargo build, not cargo build --release)
+assert_block "F.shell-grant-different-cmd" \
+  "cargo build" "$WITH_GRANT_AGENT"
+
+# UNKNOWN_SHELL doesn't match path grants even when target seems related
+assert_block "F.unknown-shell-no-grant" \
+  "npm install" "$WITH_GRANT_AGENT"
+
+# ---------------------------------------------------------------------------
+# Section G — audit-mode parity (3 cases: same input as block, but logged-only)
+# ---------------------------------------------------------------------------
+
+smoke_log "G. audit-mode parity"
+
+# Common write — should still log + would_block, but no stdout decision
+assert_audit_no_block "G.audit.rm-outside" \
+  "rm /Users/somewhere/build/x" "$NO_GRANT_AGENT"
+
+# UNKNOWN shell — also logged in audit
+assert_audit_no_block "G.audit.unknown-cargo" \
+  "cargo build" "$NO_GRANT_AGENT"
+
+# Substitution — also logged
+assert_audit_no_block "G.audit.cmd-sub" \
+  'cat $(mktemp)' "$NO_GRANT_AGENT"
+
+# ---------------------------------------------------------------------------
+# Smoke summary
+# ---------------------------------------------------------------------------
+
+smoke_log "all checks passed (assertions: $PASS_COUNT)"


### PR DESCRIPTION
## Summary

Closes #639.

Redesigns the `codex-task-mode-policy.py` write-shape detector per spec at `/tmp/agb-639-spec-output.md` (Option C: default-deny block mode + maintained common-shape parser). Closes the 6 broader D1 gaps that PR #636 r1-r5 carve-out deferred:

1. **Multi-command Bash strings** (`bash -c 'X; Y'`, `cmd1 && cmd2`, `a | b`) — `_split_simple_commands` walks each command independently.
2. **Variable / command substitution** — `cp $SRC $DST` is UNKNOWN_SHELL (target unresolvable); `$(...)` / backticks are DENY_POLICY (substitution).
3. **Quote/escape patterns** — proper shell-word tokenizer; brace expansion in write-target position is UNKNOWN_SHELL.
4. **`exec` / `bash -c` / `sh -c` recursion** — unwrap and recurse into inner command line (depth-limited at 4).
5. **Tool-shape exotics** — `sed -i` and `git` mutating subcommands flow through common-shape parser; `awk`, `perl`, `ruby`, `node`, `python -c` with write-shaped AST are UNKNOWN_SHELL.
6. **Heredoc** — heredoc + write redirection extracts the redirect target; heredoc fed to interpreter is UNKNOWN_SHELL.

**PR #636 r1-r5 fixes preserved** (verified via direct replay of `codex-companion-hooks.sh` §5 assertions): fd redirection (`1>file`, `2>>file`), git long-flag mutating subcommands (`git --no-pager checkout`), `patch -i FILE` / `install -t DEST`, attached `-tDEST` / `-oFILE`, combined-cluster `-rt`.

## Changes

- `hooks/codex-task-mode-policy.py` — closed allow-list + common-shape parser + grant grammar (legacy `implement-permission:` + new `write:` / `shell:` lines + closed env expansion `$WORKDIR`/`$PWD`/`$TMPDIR`)
- `scripts/smoke/codex-task-mode-policy-comprehensive.sh` (new) — 64-assertion smoke covering all 6 D1 gaps + r1-r5 regression + allow-list + block-deny + grant matching
- `docs/agent-runtime/role-architecture.md` — Priority 1 hook section rewritten to describe the new default-deny block-mode model
- `scripts/ci-select-smoke.sh` — pull `codex-task-mode-policy-comprehensive` + `codex-companion-hooks` for any change to either codex companion hook
- `scripts/smoke-test.sh` — wire the new comprehensive smoke into the manual tail list

## Verification

- `python3 -c 'import ast; ast.parse(...)'` clean
- `python3 -m py_compile hooks/codex-task-mode-policy.py` clean
- `bash -n` / `shellcheck` clean on the new smoke + the modified ci-select-smoke.sh
- Comprehensive smoke: **64/64 assertions pass**
- PR #636 r1-r5 regression: **all 53 assertions pass** when section 5 of `codex-companion-hooks.sh` is replayed directly against the new hook (the existing smoke as a whole fails earlier at section 2 due to a v0.8.0 isolation-v2 layout gate that pre-exists and is unrelated to this PR; section 5 logic is preserved)
- The single spec drift: `B.G6.cat-heredoc-pipe-fail-closed` — spec §4 G6.c says ALLOW for `cat <<EOF | wc -l ... EOF`, but the scanner does not consume heredoc body content, so body lines parse as additional simple commands. The conservative posture is fail-closed; operators who need this exact pipeline can add an exact `shell:` grant. The smoke documents this drift inline.

## Out of scope

- Block mode promote to default — separate operator decision after audit-log validation (per spec §9, role doc "Operator: how to promote to blocking mode")
- `bashlex` or other Python dependency — Option C designed without (per spec §11)
- T2 / T3 / #619 — separate parallel lanes (different file surface)
- VERSION / CHANGELOG bump — T7 lane

Per `feedback_pr_iteration_3_round_cap.md`, PR #636 hit r5 cap; this is the fresh-spec successor with audit-only safety net retained.
