### PR TITLE
feat(isolation): v0.8.0 T5 — BRIDGE_DISABLE_ISOLATION rollback hatch

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -467,3 +467,24 @@ glyph regression preventing prompt detection) AND a cron keeps queuing
 tasks against it, the spool file grows without bound. Mitigation: stop
 the offending cron, or run `agent-bridge agent stop <agent>` to clear
 the spool. Future hardening: a max-line guard on the append helper.
+
+## 22. Layout v2 — rollback hatch via `BRIDGE_DISABLE_ISOLATION=1`
+
+v0.8.0 hard-cuts v1 (named-ACL) isolation: T1 fails fast on legacy
+markers, T2 deletes the v1 helpers, T3 wires the migration. If v2
+isolation hits an unforeseen issue post-deploy on a specific install,
+operators can set `BRIDGE_DISABLE_ISOLATION=1` in the controller
+environment and restart the daemon + affected agents to keep work
+flowing while debugging.
+
+The hatch disables v2 wraps at runtime — agents run as the controller
+UID with no group/setgid contract. The configured `isolation_mode`
+stays in the roster, the layout marker is not mutated, and v2 resumes
+when the env is unset and the daemon + agents restart. Operations
+status surface (`agent-bridge agent show <agent>`, `agent list`)
+reports `isolation: disabled-by-env` while the hatch is active.
+
+This is a debugging escape, not a permanent operating mode.
+Long-term operation without isolation is unsupported in v0.8.0.
+Report the underlying v2 issue upstream. Full operator notes:
+[`OPERATIONS.md` "Rollback hatch — `BRIDGE_DISABLE_ISOLATION=1`"](OPERATIONS.md).

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -733,6 +733,44 @@ otherwise):
    agent-bridge migrate isolation-v2 commit --yes
    ```
 
+### Rollback hatch — `BRIDGE_DISABLE_ISOLATION=1`
+
+If v2 isolation hits an unforeseen issue post-deploy, set
+`BRIDGE_DISABLE_ISOLATION=1` in the controller environment (the daemon
+unit, the operator's shell, or both — anywhere the bridge entry points
+read the env), and restart the daemon plus any affected agents.
+
+What it does:
+
+- Skips the v2 secret-env exec wrap and the `umask 007` wrap in
+  `bridge-run.sh`. The agent runs under the controller UID with the
+  default 0077 umask.
+- Skips the v2 group/sudo prep in `bridge-start.sh`. SUDO_WRAP stays
+  inactive, no per-agent `agent-env.sh` is written, no Claude
+  credential repair is attempted.
+- Surfaces `isolation: disabled-by-env` in `agent-bridge agent show
+  <agent>` and replaces the iso column in `agent-bridge agent list`
+  with `disabled-by-env`. The configured `isolation_mode` is left in
+  place so the JSON form still carries both fields.
+
+What it does NOT do:
+
+- Does NOT re-enable v1 ACL helpers — they are deleted in v0.8.0.
+- Does NOT mutate the layout marker or any per-agent `isolation_mode`.
+  v2 resumes the moment the env is unset and the daemon + agents
+  restart.
+- Does NOT call `agent-bridge migrate isolation-v2 commit`. Legacy
+  paths (if any remain) are preserved.
+
+This is a debugging escape, not a permanent operating mode. Operators
+who set this should report the underlying issue upstream so v2 can be
+fixed; long-term operation without isolation is unsupported in v0.8.0.
+
+```bash
+# Set in the daemon environment, then restart.
+BRIDGE_DISABLE_ISOLATION=1 ./agent-bridge daemon restart
+```
+
 ### Editing profile / skills / memory after activation
 
 After v2 activation, runtime resolvers (`bridge-skills.sh`,

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1095,8 +1095,16 @@ bridge_agent_records_tsv() {
 emit_agent_records_json() {
   local mode="$1"
   local tsv="$2"
+  # v0.8.0 T5: snapshot the runtime isolation state once per emit (it
+  # is a controller-process-wide value, not per-agent) and pass it as a
+  # third argv so every JSON record carries the same string. The
+  # alternative — adding a TSV column — would touch the schema in 4
+  # places (header, row builder, local-var declaration, JSON
+  # conversion) for a value that is identical across all rows.
+  local runtime_state
+  runtime_state="$(bridge_isolation_runtime_state)"
 
-  bridge_agent_manage_python "$mode" "$tsv" <<'PY'
+  bridge_agent_manage_python "$mode" "$tsv" "$runtime_state" <<'PY'
 import csv
 import io
 import json
@@ -1104,6 +1112,7 @@ import sys
 
 mode = sys.argv[1]
 rows = list(csv.DictReader(io.StringIO(sys.argv[2]), delimiter="\t"))
+runtime_state = sys.argv[3] if len(sys.argv) > 3 else ""
 bool_fields = {"active", "profile_source", "always_on", "admin"}
 int_fields = {"loop", "continue", "idle_timeout", "queue_queued", "queue_claimed", "queue_blocked"}
 
@@ -1152,6 +1161,7 @@ def convert_row(row: dict) -> dict:
         "isolation": {
             "mode": converted["isolation_mode"],
             "os_user": converted["os_user"],
+            "runtime_state": runtime_state,
         },
         "queue": {
             "queued": converted["queue_queued"],
@@ -1205,6 +1215,14 @@ for item in items:
     mode = isolation.get("mode") or "shared"
     os_user = isolation.get("os_user") or ""
     iso_text = f"{mode}:{os_user}" if os_user else mode
+    # v0.8.0 T5: when the runtime hatch is on, override the iso column
+    # so a glance at `agent-bridge agent list` makes it obvious the
+    # boundary is off across the whole controller. The configured
+    # isolation_mode stays available in the JSON form and in `agent
+    # show` for operators who want both fields.
+    runtime_state = isolation.get("runtime_state") or ""
+    if runtime_state == "disabled-by-env":
+        iso_text = "disabled-by-env"
     queue = item.get("queue", {}) or {}
     notify = item.get("notify", {}) or {}
     channels = item.get("channels", {}) or {}
@@ -1418,6 +1436,13 @@ PY
     printf 'channels: %s\n' "${channels:--}"
     printf 'discord_channel_id: %s\n' "${discord_channel_id:--}"
     printf 'isolation_mode: %s\n' "${isolation_mode:--}"
+    # v0.8.0 T5: surface the runtime isolation state alongside the
+    # configured isolation_mode. `disabled-by-env` indicates that
+    # `BRIDGE_DISABLE_ISOLATION=1` is in the controller environment and
+    # the v2 wraps are short-circuited; `v2-active` is the normal
+    # post-migration state. Field is additive — existing parsers ignore
+    # unknown keys.
+    printf 'isolation: %s\n' "$(bridge_isolation_runtime_state)"
     printf 'os_user: %s\n' "${os_user:--}"
     printf 'queue: queued=%s claimed=%s blocked=%s\n' "$queue_queued" "$queue_claimed" "$queue_blocked"
     printf 'actions: %s\n' "$actions"

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -338,6 +338,10 @@ bridge_source_module "bridge-hooks.sh"
 bridge_source_module "bridge-channels.sh"
 bridge_source_module "bridge-state.sh"
 bridge_source_module "bridge-isolation-v2.sh"
+# v0.8.0 T5: runtime-only `BRIDGE_DISABLE_ISOLATION=1` escape hatch.
+# Sourced after bridge-isolation-v2.sh so bridge_isolation_v2_active is
+# already defined (the runtime state helper composes the two).
+bridge_source_module "bridge-isolation-runtime.sh"
 bridge_source_module "bridge-profiles.sh"
 bridge_source_module "bridge-cron.sh"
 bridge_source_module "bridge-discord.sh"

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -29,6 +29,17 @@ source "$SCRIPT_DIR/bridge-lib.sh"
 # /proc/<pid>/status. Inert when unset.
 bridge_run_apply_v2_umask_if_needed() {
   local agent="$1"
+  # v0.8.0 T5: BRIDGE_DISABLE_ISOLATION=1 short-circuits the umask 007
+  # wrap so the child inherits bridge-lib.sh's default 0077. With the
+  # boundary off, the agent runs as the controller UID and private mode
+  # (controller-only readable) is the correct contract — group bits do
+  # not need to be set for a peer UID that no longer exists.
+  if bridge_isolation_disabled_by_env; then
+    if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
+      umask >"$BRIDGE_RUN_UMASK_PROBE_FILE" 2>/dev/null || true
+    fi
+    return 0
+  fi
   if bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
     umask 007
   fi
@@ -557,8 +568,17 @@ while true; do
   # any tee'd stderr. Loading inside the launch subshell (not the parent)
   # also prevents stale secrets from persisting across restart-loop
   # iterations after the credentials file is rotated, emptied, or removed.
+  #
+  # v0.8.0 T5: BRIDGE_DISABLE_ISOLATION=1 short-circuits the secret-env
+  # wrap. Skipping this means the child does NOT see launch secrets
+  # placed under credentials/launch-secrets.env — operators using the
+  # rollback hatch must inject any required secrets through the
+  # controller environment directly. We log once per launch so the
+  # boundary drop is visible in agent stderr/logs, not silent.
   _v2_secret_file=""
-  if bridge_isolation_v2_active; then
+  if bridge_isolation_disabled_by_env; then
+    bridge_warn "BRIDGE_DISABLE_ISOLATION=1 — running '${AGENT}' without v2 isolation (security boundary disabled, secret-env wrap skipped)"
+  elif bridge_isolation_v2_active; then
     _v2_secret_file="$(bridge_isolation_v2_agent_secret_env_file "$AGENT" 2>/dev/null || true)"
     [[ -n "$_v2_secret_file" && -f "$_v2_secret_file" ]] || _v2_secret_file=""
   fi

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -303,7 +303,9 @@ if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
   fi
 fi
 
-if bridge_agent_linux_user_isolation_effective "$AGENT"; then
+if bridge_isolation_disabled_by_env; then
+  bridge_warn "BRIDGE_DISABLE_ISOLATION=1 — skipping v2 isolation prep for '$AGENT' (security boundary disabled, agent will run as controller UID without sudo wrap or per-agent env file)"
+elif bridge_agent_linux_user_isolation_effective "$AGENT"; then
   AGENT_ENV_FILE="$(bridge_agent_linux_env_file "$AGENT")"
   bridge_write_linux_agent_env_file "$AGENT" "$AGENT_ENV_FILE"
 fi
@@ -337,7 +339,13 @@ fi
 SUDO_WRAP_ACTIVE=0
 SUDO_WRAP_OS_USER=""
 SUDO_WRAP_FALLBACK_REASON=""
-if bridge_agent_linux_user_isolation_effective "$AGENT"; then
+# v0.8.0 T5: BRIDGE_DISABLE_ISOLATION=1 short-circuits the sudo wrap so
+# the SESSION_CMD runs unwrapped under the controller UID. The earlier
+# env-file guard already emitted the operator warning; this branch
+# stays silent to avoid a duplicate per-restart log line.
+if bridge_isolation_disabled_by_env; then
+  :
+elif bridge_agent_linux_user_isolation_effective "$AGENT"; then
   SUDO_WRAP_OS_USER="$(bridge_agent_os_user "$AGENT")"
   if [[ "$(id -u)" == "0" ]]; then
     SUDO_WRAP_FALLBACK_REASON="controller is root; sudo wrap skipped"

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -780,6 +780,11 @@ bridge_export_env_prefix() {
     BRIDGE_DISCORD_RELAY_COOLDOWN_SECONDS
     BRIDGE_CODEX_TASK_MODE_POLICY
     BRIDGE_CODEX_OUTPUT_SHAPE_ENFORCE
+    # v0.8.0 T5: rollback hatch must propagate from the controller env
+    # into the per-agent SESSION_CMD child so bridge-run.sh sees the
+    # same value the daemon does (otherwise the wrap-skip logic would
+    # fire only at start time, not on subsequent runtime restarts).
+    BRIDGE_DISABLE_ISOLATION
   )
 
   for name in "${names[@]}"; do

--- a/lib/bridge-isolation-runtime.sh
+++ b/lib/bridge-isolation-runtime.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bridge-isolation-runtime.sh — runtime-only escape hatch for v2 isolation.
+#
+# v0.8.0 hard-cuts the v1 (named-ACL) isolation path: T1 fails fast on
+# legacy markers, T2 deletes the v1 helpers, T3 wires the migration. If
+# v2 isolation hits an unforeseen issue post-deploy on a specific
+# install, operators need a way to keep agents running while debugging
+# without resurrecting the deleted v1 code path.
+#
+# `BRIDGE_DISABLE_ISOLATION=1` is that hatch. It is intentionally narrow:
+#   - launch (bridge-run.sh): skip the v2 secret-env exec wrap and the
+#     umask 007 wrap; child runs under the controller UID with the
+#     default 0077 umask.
+#   - start (bridge-start.sh): skip v2 group/sudo prep; SUDO_WRAP stays
+#     inactive and no per-agent env file is written.
+#   - status (bridge-agent.sh show): surfaces `isolation: disabled-by-env`
+#     so operators can see at a glance that the boundary is off.
+#
+# The hatch DOES NOT:
+#   - re-enable v1 ACL helpers (deleted in T2; resurrection is anti-spec)
+#   - mutate the layout marker or any agent isolation_mode (so v2
+#     resumes the moment the env unset + restart cycle completes)
+#   - call `migrate commit` (legacy paths, if any remain, are preserved)
+#
+# Setting via env (not a flag) is intentional: the operator must
+# restart the daemon and any affected agent to take effect, which
+# makes the choice loud and reversible.
+
+bridge_isolation_disabled_by_env() {
+  # Returns 0 (true) iff BRIDGE_DISABLE_ISOLATION is set to a truthy
+  # value. Truthy = 1 / yes / true / on (case-insensitive). Anything
+  # else — including unset, empty, "0", "false" — returns 1 (isolation
+  # stays enabled). This is intentionally one-way: the operator is
+  # choosing to drop a security boundary, so silence-on-typo is safer
+  # than silence-on-set.
+  case "${BRIDGE_DISABLE_ISOLATION:-}" in
+    1|yes|YES|Yes|on|ON|On|true|TRUE|True)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+bridge_isolation_runtime_state() {
+  # Print the active runtime isolation state for the status surface.
+  #   disabled-by-env  — BRIDGE_DISABLE_ISOLATION is set to a truthy value
+  #   v2-active        — BRIDGE_LAYOUT=v2 + BRIDGE_DATA_ROOT set
+  #   v2-inactive      — v2 helpers loaded but not in effect (e.g.
+  #                      pre-migration legacy install, or a fresh-install
+  #                      candidate before marker bootstrap).
+  # Callers MUST treat the returned value as opaque text — additive
+  # values may be introduced without bumping the caller schema.
+  if bridge_isolation_disabled_by_env; then
+    printf '%s' "disabled-by-env"
+    return 0
+  fi
+  if bridge_isolation_v2_active 2>/dev/null; then
+    printf '%s' "v2-active"
+    return 0
+  fi
+  printf '%s' "v2-inactive"
+}


### PR DESCRIPTION
## Summary

T5 of v0.8.0 isolation hard-cut. Adds `BRIDGE_DISABLE_ISOLATION=1` as a runtime-only escape hatch for emergency rollback if v2 isolation hits unforeseen issues post-deploy. Per Q6 spec: narrow scope — launch/start/show paths only, no v1 re-enable, no marker mutation, no `migrate commit`.

## Changes

- `lib/bridge-isolation-runtime.sh` (new) — `bridge_isolation_disabled_by_env` helper (truthy on `1`/`yes`/`true`/`on`, case-insensitive) + `bridge_isolation_runtime_state` helper that returns `disabled-by-env` / `v2-active` / `v2-inactive`. Sourced from `bridge-lib.sh` after `lib/bridge-isolation-v2.sh`.
- `bridge-run.sh` — short-circuit `bridge_run_apply_v2_umask_if_needed` and the `bridge_isolation_v2_exec_with_secret_env` wrap when the hatch is on; warn once per launch.
- `bridge-start.sh` — skip per-agent env file write and `SUDO_WRAP_*` isolation prep when the hatch is on; warn once per restart.
- `bridge-agent.sh` — `agent show` gains an `isolation:` line; JSON form gains an `isolation.runtime_state` field; `agent list` overrides the `iso` column with `disabled-by-env`.
- `lib/bridge-core.sh` — propagate `BRIDGE_DISABLE_ISOLATION` through the SESSION_CMD env prefix so subsequent runtime restarts see it.
- `OPERATIONS.md` — "Rollback hatch" section under "Migrating to layout v2".
- `KNOWN_ISSUES.md` — entry 22 cross-referencing the OPERATIONS.md section.

## Verification

Performed in an isolated `BRIDGE_HOME` with a hand-written `state/layout-marker.sh` (BRIDGE_LAYOUT=v2 + BRIDGE_DATA_ROOT) so v2 actually resolves under T1's hard-cut.

- `bash -n` clean across `bridge-run.sh`, `bridge-start.sh`, `bridge-agent.sh`, `bridge-lib.sh`, `agent-bridge`, `agb`, `lib/bridge-isolation-runtime.sh`, `lib/bridge-core.sh`
- `shellcheck -S warning` clean on the same set
- Helper truth table:
  - `1`, `yes`, `YES`, `Yes`, `on`, `ON`, `true`, `TRUE`, `True` → disabled
  - `0`, `false`, empty, unset, arbitrary text → enabled
- `bridge_isolation_runtime_state` truth table:
  - hatch on (anywhere) → `disabled-by-env`
  - v2 marker valid + hatch off → `v2-active`
  - no v2 marker + hatch off → `v2-inactive`
- `./bridge-run.sh test-agent --dry-run` runs cleanly under both default and hatch-on cases
- `./bridge-start.sh test-agent --dry-run` under hatch emits the operator warning, skips SUDO_WRAP, and propagates `BRIDGE_DISABLE_ISOLATION=1` in the SESSION_CMD env prefix
- `./agent-bridge agent show test-agent` emits `isolation: v2-active` (default) and `isolation: disabled-by-env` (hatch on)
- `./agent-bridge agent show test-agent --json` carries the new `isolation.runtime_state` field
- `./agent-bridge agent list` overrides the `iso` column with `disabled-by-env` for every row when the hatch is on
- `./scripts/smoke-test.sh` fails at the same step (`[smoke] bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor (#428 r2)`) on baseline `release/v0.8.0` with no T5 patch — confirmed pre-existing macOS smoke flake; T5 does not regress it

## Out of scope

- T1-T4 (separate PRs / merged)
- VERSION / CHANGELOG bump — T7
- Daemon channel-health / cron-dispatch isolation paths — `bridge-daemon.sh` carries no `bridge_isolation_v2_*` or `bridge_agent_linux_user_isolation_effective` references after T2; the hatch propagates through env to spawned cron workers naturally
- `bridge-cron.sh` `bridge_cron_validate_shell_run_config` — operator-facing validation for shell-kind cron creation, not a runtime path; brief explicitly scopes to launch/start/daemon

Tracks v0.8.0 spec Q6.