### PR TITLE
fix(isolation): v0.8.3 — branch group-name length limit by platform (32 Linux / 255 Darwin)

### DIFF
--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -382,12 +382,17 @@ bridge_isolation_v2_agent_group_name() {
   # Linux groupadd accepts [a-z_][a-z0-9_-]* with total length <= 32.
   # Reject early so _ensure_group does not fail opaquely later.
   if [[ ! "$agent" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
-    bridge_warn "agent_group_name: '$agent' has invalid chars for a Linux group name (allowed: [a-z_][a-z0-9_-]*)"
+    bridge_warn "agent_group_name: '$agent' has invalid chars for a group name (allowed: [a-z_][a-z0-9_-]*)"
     return 1
   fi
   local composed="${BRIDGE_AGENT_GROUP_PREFIX}${agent}"
-  if (( ${#composed} > 32 )); then
-    bridge_warn "agent_group_name: '$composed' exceeds 32-char Linux group-name limit"
+  # v0.8.3: platform-branched length limit. Linux groupadd is 32-char;
+  # macOS dseditgroup tolerates much longer names. The previous
+  # unconditional 32-char check rejected long-named agents on macOS too.
+  local _limit=32
+  [[ "$(uname)" == "Darwin" ]] && _limit=255
+  if (( ${#composed} > _limit )); then
+    bridge_warn "agent_group_name: '$composed' exceeds ${_limit}-char group-name limit on $(uname)"
     return 1
   fi
   printf '%s' "$composed"


### PR DESCRIPTION
## Summary

`bridge_isolation_v2_agent_group_name` enforced a 32-char limit (Linux groupadd) on every platform, including macOS where dseditgroup tolerates 255+ chars. Long-named agents (smoke-doctor pattern) hard-blocked the migration.

VM repro: Oracle 9.7 + agent `smoke-doctor-20260506024848-8556-ce5f` (47 chars) → migration rc=1 with "name required" error.

## Fix

Platform-branch the length cap: 32 on Linux, 255 on Darwin.

## Changes

- `lib/bridge-isolation-v2.sh:bridge_isolation_v2_agent_group_name` — `_limit=255` on Darwin, `_limit=32` elsewhere

## Verification

- bash -n / shellcheck clean
- Truth-table covering 14-char (ok), 47-char (Linux fail / Darwin ok), 269-char (both fail)

## Follow-up (out of scope)

- `agent create` should reject names that won't survive migration on the target platform — file as v0.8.4 polish.

Closes one of the two #655 blockers.