### PR TITLE
fix(isolation): v0.8.3 — launchctl bootout/bootstrap around daemon stop on macOS

### DIFF
--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -38,7 +38,10 @@
 #     untrusted (warm-cache problem). Postflight probes each agent UID and
 #     the controller via fresh `sudo -u <user> id -nG`.
 #   * Self-cleanup in this module never installs a long-lived EXIT trap
-#     (would clobber the existing COPY_JSON trap conventions in scripts/).
+#     (would clobber the existing COPY_JSON trap conventions in scripts/),
+#     with one exception: the v0.8.3 macOS launchd-restore trap installed
+#     in apply_for_upgrade and apply chains the prior trap body so the
+#     existing convention is preserved.
 #
 # shellcheck shell=bash disable=SC2034
 
@@ -747,6 +750,14 @@ bridge_isolation_v2_migrate_wait_daemon_present() {
 bridge_isolation_v2_migrate_orchestrate_stop() {
   local snapshot_path="$1"
 
+  # v0.8.3: on macOS, unload the launchd unit BEFORE per-agent stop so
+  # the KeepAlive=true daemon doesn't respawn during the 10s
+  # wait_daemon_gone window. restore_if_needed handles the case where a
+  # previous migration crashed between bootout and bootstrap. Both are
+  # no-ops on Linux/non-launchd hosts.
+  bridge_isolation_v2_launchd_restore_if_needed
+  bridge_isolation_v2_launchd_unload
+
   # Per-agent stop.
   local agent
   while IFS= read -r agent; do
@@ -771,9 +782,21 @@ bridge_isolation_v2_migrate_orchestrate_stop() {
 bridge_isolation_v2_migrate_orchestrate_restart() {
   local snapshot_path="$1"
 
-  "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-daemon.sh" start >/dev/null 2>&1 \
-    || bridge_die "daemon restart failed"
-  bridge_isolation_v2_migrate_wait_daemon_present 10
+  # v0.8.3: on macOS, bring the daemon back under launchd supervision
+  # via `launchctl bootstrap` instead of `bridge-daemon.sh start`. The
+  # latter would race a future launchd respawn once the unit is
+  # re-loaded. On Linux/non-launchd hosts, fall through to the plain
+  # daemon start.
+  if [[ "$(uname)" == "Darwin" ]] \
+      && [[ -f "$(bridge_isolation_v2_launchd_plist_path)" ]]; then
+    bridge_isolation_v2_launchd_bootstrap \
+      || bridge_die "daemon restart failed (launchctl bootstrap)"
+    bridge_isolation_v2_migrate_wait_daemon_present 10
+  else
+    "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-daemon.sh" start >/dev/null 2>&1 \
+      || bridge_die "daemon restart failed"
+    bridge_isolation_v2_migrate_wait_daemon_present 10
+  fi
 
   local agent
   while IFS= read -r agent; do
@@ -900,6 +923,21 @@ bridge_isolation_v2_migrate_apply() {
   fi
 
   install -d -m 0755 "$data_root" 2>/dev/null || mkdir -p "$data_root"
+
+  # v0.8.3: see apply_for_upgrade for rationale. The EXIT trap fires
+  # only on uncaught crashes; normal-path errors call orchestrate_restart
+  # (which invokes launchd_bootstrap) before returning.
+  if [[ "$(uname)" == "Darwin" ]]; then
+    local _prior_exit_trap
+    _prior_exit_trap="$(trap -p EXIT 2>/dev/null \
+      | sed -E "s/^trap -- '(.*)' EXIT\$/\\1/")"
+    if [[ -n "$_prior_exit_trap" ]]; then
+      # shellcheck disable=SC2064
+      trap "bridge_isolation_v2_launchd_bootstrap >/dev/null 2>&1 || true; ${_prior_exit_trap}" EXIT
+    else
+      trap 'bridge_isolation_v2_launchd_bootstrap >/dev/null 2>&1 || true' EXIT
+    fi
+  fi
 
   bridge_isolation_v2_migrate_orchestrate_stop "$snapshot"
 
@@ -1182,6 +1220,25 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
   # instead inline the post-lock steps. This stays within the
   # established review boundaries — same primitives, same order.
   install -d -m 0755 "$data_root" 2>/dev/null || mkdir -p "$data_root"
+
+  # v0.8.3: install an EXIT trap that re-bootstraps the launchd unit on
+  # macOS if the upgrade process crashes between `orchestrate_stop`
+  # (which calls launchd_unload) and `orchestrate_restart` (which calls
+  # launchd_bootstrap). The bootstrap helper is a no-op on Linux and on
+  # macOS hosts where the restore file is already gone. `bridge-upgrade.sh`
+  # already installs an EXIT trap; preserve it by capturing and re-running
+  # the prior trap body inside the new trap.
+  if [[ "$(uname)" == "Darwin" ]]; then
+    local _prior_exit_trap
+    _prior_exit_trap="$(trap -p EXIT 2>/dev/null \
+      | sed -E "s/^trap -- '(.*)' EXIT\$/\\1/")"
+    if [[ -n "$_prior_exit_trap" ]]; then
+      # shellcheck disable=SC2064
+      trap "bridge_isolation_v2_launchd_bootstrap >/dev/null 2>&1 || true; ${_prior_exit_trap}" EXIT
+    else
+      trap 'bridge_isolation_v2_launchd_bootstrap >/dev/null 2>&1 || true' EXIT
+    fi
+  fi
 
   if [[ "$active_count" -gt 0 ]]; then
     bridge_isolation_v2_migrate_self_stop_guard "$active_snapshot" || {

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -788,6 +788,111 @@ bridge_isolation_v2_layout_summary() {
 }
 
 # ---------------------------------------------------------------------------
+# 6b. launchd lifecycle helpers (macOS upgrade) - v0.8.3
+# ---------------------------------------------------------------------------
+#
+# `bridge_isolation_v2_migrate_wait_daemon_gone` polls 10s for an empty
+# `bridge_daemon_all_pids` after `bridge-daemon.sh stop`. On macOS hosts
+# installed via `scripts/install-daemon-launchagent.sh` the daemon is
+# supervised by launchd with `KeepAlive=true`, so the unit respawns
+# within 1-2 seconds of the kill. The poll never sees a clean window
+# and the migration aborts with "daemon stop verification failed".
+#
+# Modern macOS (10.11+) deprecated `launchctl load`; the reliable
+# lifecycle is `launchctl bootout` / `launchctl bootstrap` against the
+# `gui/<uid>` domain. KeepAlive plist edits are not equivalent because
+# they don't catch the dict-form `KeepAlive.AfterInitialDemand` or the
+# legacy `OnDemand` key.
+#
+# State is recorded under `$BRIDGE_STATE_DIR/migration/launchd-restore.json`
+# so a migration that crashes between bootout and bootstrap can be
+# recovered on the next run via `restore_if_needed`.
+
+bridge_isolation_v2_launchd_plist_path() {
+  printf '%s/Library/LaunchAgents/%s.plist' \
+    "$HOME" "${BRIDGE_DAEMON_LAUNCHAGENT_LABEL:-ai.agent-bridge.daemon}"
+}
+
+bridge_isolation_v2_launchd_restore_file() {
+  printf '%s/migration/launchd-restore.json' "${BRIDGE_STATE_DIR}"
+}
+
+bridge_isolation_v2_launchd_unload() {
+  [[ "$(uname)" == "Darwin" ]] || return 0
+
+  local plist_path
+  plist_path="$(bridge_isolation_v2_launchd_plist_path)"
+  [[ -f "$plist_path" ]] || return 0  # not launchd-managed
+
+  local restore_file
+  restore_file="$(bridge_isolation_v2_launchd_restore_file)"
+  install -d -m 0755 "$(dirname "$restore_file")" 2>/dev/null \
+    || mkdir -p "$(dirname "$restore_file")"
+
+  local uid
+  uid="$(id -u)"
+
+  # Record what we're about to do so a crash can recover.
+  printf '{"plist_path":"%s","uid":%s,"unloaded_at":"%s","restored_at":null}\n' \
+    "$plist_path" "$uid" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$restore_file"
+
+  # Best-effort bootout. Tolerate "service not loaded" - modern launchctl
+  # returns non-zero in that case but the post-condition (unit not
+  # loaded) is what we want regardless.
+  launchctl bootout "gui/${uid}" "$plist_path" 2>/dev/null || true
+
+  # Verify daemon process actually gone - KeepAlive race window is
+  # ~1-2s, so 50 attempts at 0.2s = 10s ceiling matches the existing
+  # wait_daemon_gone budget.
+  local attempt
+  for attempt in $(seq 1 50); do
+    if [[ -z "$(bridge_daemon_all_pids 2>/dev/null || true)" ]]; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  bridge_warn "launchd_unload: daemon still alive after bootout - may need manual launchctl bootout"
+  return 1
+}
+
+bridge_isolation_v2_launchd_bootstrap() {
+  [[ "$(uname)" == "Darwin" ]] || return 0
+
+  local plist_path
+  plist_path="$(bridge_isolation_v2_launchd_plist_path)"
+  [[ -f "$plist_path" ]] || return 0
+
+  local restore_file
+  restore_file="$(bridge_isolation_v2_launchd_restore_file)"
+  local uid
+  uid="$(id -u)"
+
+  if ! launchctl bootstrap "gui/${uid}" "$plist_path" 2>/dev/null; then
+    bridge_warn "launchd_bootstrap: bootstrap failed; daemon may need manual restart"
+    return 1
+  fi
+
+  # Mark restore complete by removing the save file.
+  if [[ -f "$restore_file" ]]; then
+    rm -f "$restore_file" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# Recovery hook: call from the migrate apply path BEFORE bootout, so a
+# previous-run leftover bootout (no bootstrap yet) gets restored first.
+# This is the cross-run safety net for the case where the EXIT trap in
+# `apply_for_upgrade` did not fire (SIGKILL / power loss / OOM).
+bridge_isolation_v2_launchd_restore_if_needed() {
+  [[ "$(uname)" == "Darwin" ]] || return 0
+  local restore_file
+  restore_file="$(bridge_isolation_v2_launchd_restore_file)"
+  [[ -f "$restore_file" ]] || return 0
+  bridge_warn "launchd: detected stale unload from prior run - restoring before retry"
+  bridge_isolation_v2_launchd_bootstrap
+}
+
+# ---------------------------------------------------------------------------
 # 7. exports
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

macOS launchd KeepAlive races the migration's 10s daemon-stop verification window. Every macOS upgrade aborts before any state mutation with `daemon stop verification failed: still running PIDs after 10s`.

Codex review recommended `launchctl bootout` / `launchctl bootstrap` over PlistBuddy + `launchctl load` (deprecated on 10.11+, doesn't catch `KeepAlive.AfterInitialDemand` dict variant or legacy `OnDemand` key). This PR implements the bootout/bootstrap approach with cross-run recovery via `launchd-restore.json`.

## Changes

- `lib/bridge-isolation-v2.sh` (new section 6b):
  - `bridge_isolation_v2_launchd_plist_path` / `_restore_file` — small accessors honoring `BRIDGE_DAEMON_LAUNCHAGENT_LABEL` and `BRIDGE_STATE_DIR`.
  - `bridge_isolation_v2_launchd_unload` — `launchctl bootout gui/<uid>` + verify `bridge_daemon_all_pids` is empty (50 × 0.2s = 10s ceiling, matches existing `wait_daemon_gone` budget). Records state to `$BRIDGE_STATE_DIR/migration/launchd-restore.json`.
  - `bridge_isolation_v2_launchd_bootstrap` — `launchctl bootstrap gui/<uid>` + cleans the restore file on success.
  - `bridge_isolation_v2_launchd_restore_if_needed` — cross-run recovery hook for crashed migrations (SIGKILL / power loss / OOM, where the EXIT trap didn't fire).
  - All three short-circuit to `return 0` when `uname != Darwin` or when no user-level plist exists.
- `lib/bridge-isolation-v2-migrate.sh`:
  - `orchestrate_stop` calls `restore_if_needed` + `unload` before per-agent stop, so the KeepAlive race window is closed for the duration of the migration.
  - `orchestrate_restart` branches: macOS calls `launchd_bootstrap` (which causes launchd to spawn the daemon under supervision) instead of `bridge-daemon.sh start` (which would race a future launchd respawn once the unit is re-loaded).
  - `apply_for_upgrade` and `apply` install an EXIT trap that calls `launchd_bootstrap` for crash recovery within a run. The trap chains the prior trap body so the existing convention from `bridge-upgrade.sh` is preserved. Module-header policy comment updated to document the exception.

## Verification

- `bash -n lib/bridge-isolation-v2.sh lib/bridge-isolation-v2-migrate.sh` — PASS
- `shellcheck lib/bridge-isolation-v2.sh lib/bridge-isolation-v2-migrate.sh` — PASS (no warnings)
- Sourced both files in an isolated bash subshell; confirmed all five new helpers are defined and dispatch correctly:
  - non-Darwin: all three lifecycle helpers `return 0` immediately.
  - Darwin without plist: all three `return 0` (graceful no-op for non-launchd-managed installs).
  - Darwin with stale `launchd-restore.json`: `restore_if_needed` warns and attempts `bootstrap` as designed.
- `./scripts/smoke-test.sh` — fails at the same pre-existing checkpoint (`[smoke] bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor`) on `main` with no PR applied; not a regression introduced by this change.

### Manual macOS verification matrix (run by orchestrator before merge)

1. Install v0.7.8 baseline with `scripts/install-daemon-launchagent.sh --apply --load`.
2. Confirm daemon is supervised: `launchctl print gui/$(id -u)/ai.agent-bridge.daemon`.
3. Reproduce the bug pre-PR: `bash bridge-daemon.sh stop` is followed by a launchd respawn within 1-2s (matches the symptom in `bridge_isolation_v2_migrate_wait_daemon_gone`).
4. Apply this PR. Run `agent-bridge upgrade --apply` (or directly `agent-bridge migrate isolation-v2 apply --data-root <path> --yes`).
5. Expected: migration completes; `wait_daemon_gone` sees a clean window because the unit is unloaded; `wait_daemon_present` confirms launchd re-spawn after `bootstrap`.
6. Confirm `$BRIDGE_STATE_DIR/migration/launchd-restore.json` is absent post-success.
7. Confirm `launchctl print` shows the daemon back under supervision.
8. Crash-recovery check: simulate a crash by sending SIGKILL to the upgrade process between `orchestrate_stop` and `orchestrate_restart`. On the next `agent-bridge upgrade --apply`, expect `restore_if_needed` to warn and re-bootstrap before retrying the run.

## Out of scope

- systemd / Linux equivalent — unaffected; uses `bridge-daemon.sh stop` directly with no supervisor race.
- File relocation fix (PR-A, separate)
- 32-char limit fix (PR-B, separate)
- PlistBuddy + KeepAlive flip alternative — explicitly rejected in codex review as deprecated/unreliable.

## Merge ordering note

PR-A is also editing `orchestrate_stop` / `orchestrate_restart` (attached-agent skip on restart). The launchd helpers in this PR are added as a clean block at the top of each function, separate from PR-A's per-agent loop changes, so the merge conflict surface is minimal. Suggested merge order: PR-A first, then this PR, resolving the trivial conflict in `orchestrate_restart`.

Closes other half of #655 (Bug A — KeepAlive race).