### PR TITLE
fix(upgrade): v0.8.4 — apply_for_upgrade copies release files even without isolation migration (refs #666)

### DIFF
--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -155,6 +155,24 @@ def read_source_version(source_root: Path) -> str:
     return version or "0.0.0-dev"
 
 
+def read_target_version(target_root: Path) -> str:
+    """Read the live install's `VERSION` file, mirror of `read_source_version`.
+
+    Returns "" when the file is missing or empty so callers can distinguish
+    "no live VERSION recorded" (fresh / corrupt install) from a real
+    semver string. Issue #666: used by `analyze_live` to recover from a
+    missing/unreachable `base_ref` on a real cross-version upgrade by
+    treating content-drifted files as `upstream_only` instead of
+    `unknown_base_live_diff` (which silently keeps live and never copies).
+    """
+    version_path = target_root / "VERSION"
+    try:
+        version = version_path.read_text(encoding="utf-8").splitlines()[0].strip()
+    except (FileNotFoundError, IndexError, OSError):
+        return ""
+    return version
+
+
 def load_json_arg(value: str = "", file_path: str = "") -> dict[str, Any]:
     if file_path:
         return json.loads(Path(file_path).read_text(encoding="utf-8"))
@@ -1373,6 +1391,21 @@ def analyze_live(source_root: Path, target_root: Path, base_ref: str) -> dict[st
         "mode_drift": 0,
     }
 
+    # Issue #666: when the source release ref differs from the live VERSION
+    # (a real cross-version upgrade) but `base_ref` could not be resolved
+    # / its commit is unreachable in this source clone, the previous
+    # classifier sent every content-drifted file to `unknown_base_live_diff`
+    # → `keep_live` and copied 0 files. Result: rc=0 + installed metadata
+    # bumped + live runtime stayed on the prior version (silent failed
+    # upgrade). Compute the version-mismatch flag once up-front so per-file
+    # classification can fall back to `upstream_only` (deploy_upstream)
+    # when there is no usable `base` *and* we know upstream is a different
+    # release — preserving the "rerun same version → keep operator edits"
+    # contract by gating on the version mismatch, not just on `base is None`.
+    source_version = read_source_version(source_root)
+    target_version = read_target_version(target_root)
+    versions_differ = bool(target_version) and source_version != target_version
+
     for relpath in tracked_files(source_root):
         if should_skip_relpath(relpath):
             continue
@@ -1410,8 +1443,20 @@ def analyze_live(source_root: Path, target_root: Path, base_ref: str) -> dict[st
                 classification = "unchanged"
                 strategy = "noop"
         elif not base_ref or base is None:
-            classification = "unknown_base_live_diff"
-            strategy = "keep_live"
+            # Issue #666: no usable base for this file. If the source
+            # release ref is a different version from the live install,
+            # treat as a forward-rolling upgrade and deploy upstream
+            # (release-shipped files like VERSION, bridge-upgrade.py,
+            # lib/bridge-isolation-v2*.sh must actually land). On a
+            # same-version rerun (e.g. re-applying v0.8.3 over v0.8.3
+            # without recorded base_ref), keep_live still wins —
+            # operator-edited content is preserved.
+            if versions_differ:
+                classification = "upstream_only"
+                strategy = "deploy_upstream"
+            else:
+                classification = "unknown_base_live_diff"
+                strategy = "keep_live"
         elif base == live:
             classification = "upstream_only"
             strategy = "deploy_upstream"

--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -1404,7 +1404,21 @@ def analyze_live(source_root: Path, target_root: Path, base_ref: str) -> dict[st
     # contract by gating on the version mismatch, not just on `base is None`.
     source_version = read_source_version(source_root)
     target_version = read_target_version(target_root)
-    versions_differ = bool(target_version) and source_version != target_version
+    # `read_source_version` falls back to the dev sentinel "0.0.0-dev" when
+    # the source checkout has no `VERSION` file (a dev clone, not a real
+    # release). Treating that as a real version would flip every
+    # content-drifted file to `upstream_only` on a same-version rerun from
+    # a dev clone, force-deploying over operator edits. Treat the sentinel
+    # as "unknown" for `versions_differ` only; do NOT change the function's
+    # return value because other callers (payload["version"], the
+    # `--version` default in cmd_perform_replace) still need a non-empty
+    # string.
+    versions_differ = (
+        bool(source_version)
+        and bool(target_version)
+        and source_version != target_version
+        and source_version != "0.0.0-dev"
+    )
 
     for relpath in tracked_files(source_root):
         if should_skip_relpath(relpath):


### PR DESCRIPTION
## Summary

Fixes the v0.8.3 silent-failed-upgrade pattern reported in #666: `agent-bridge upgrade --apply` from v0.8.2 → v0.8.3 returned `rc=0` with `files_copied: 0`, wrote installed metadata for v0.8.3, but left live `~/.agent-bridge/VERSION` and the entire release-shipped surface on v0.8.2.

## Root cause

In `bridge-upgrade.py::analyze_live`, when `base_ref` is empty (no `state/upgrade/last-upgrade.json`, or its `source_head` isn't reachable in this source clone) every content-drifted file falls through to the `not base_ref or base is None` branch and is classified as `unknown_base_live_diff` → `keep_live`. Correct for "operator edited, base unknown"; wrong for "real upgrade, base missing", where the right answer is to deploy upstream.

PR #660 wired `emit_plan` into the v1→v2 isolation migration path. The v0.8.x → v0.8.x no-migration case (v2 marker already valid, `bridge_isolation_v2_migrate_apply_for_upgrade` returns `skipped:marker-present`, then `apply-live` runs) still hit the same `keep_live` short-circuit and copied 0 files.

## Fix

`analyze_live` now computes `versions_differ` once from `read_source_version(source_root)` vs a new `read_target_version(target_root)`. In the `not base_ref or base is None` branch, when `versions_differ` is true the file classifies as `upstream_only` (deploy_upstream) instead of `unknown_base_live_diff`. Same-version reruns (operator drift) and brand-new installs without a live `VERSION` file stay on the existing `keep_live` path, so:

- Real cross-version upgrade without resolvable `base_ref`: files actually land. `files_copied > 0`. Live `VERSION` advances.
- Same-version rerun with operator drift: `unknown_base_live_diff` → `keep_live`. Operator edits preserved.
- Brand-new install with no live `VERSION` file: conservative, no force-deploy.

`read_target_version` returns `""` on missing/empty so the fallback can distinguish "no live VERSION recorded" from a real semver mismatch.

Out of scope: did not touch the v1→v2 migration path (PR #660), `files_preserved_live` semantics, VERSION/CHANGELOG, or CLI surface.

## Verification

```
bash -n bridge-upgrade.sh           # OK
shellcheck bridge-upgrade.sh        # OK
python3 -c "import ast; ast.parse(open('bridge-upgrade.py').read())"  # OK
```

Host-side repro at `/tmp/v084-issue666-repro.py` (not committed) builds a synthetic v0.8.3 source repo + v0.8.2 live target with no `last-upgrade.json` and exercises `analyze_live` + `apply_live`:

| Case | Before | After |
|---|---|---|
| Cross-version (0.8.2 → 0.8.3), empty base_ref | `unknown_base_live_diff: 5`, `files_copied: 0`, live VERSION stays 0.8.2 | `upstream_only: 5`, `files_copied: 5`, live VERSION → 0.8.3 |
| Same-version rerun (0.8.3 → 0.8.3) with operator drift | `unknown_base_live_diff: 4`, files preserved | unchanged: `unknown_base_live_diff: 4`, files preserved |
| No live `VERSION` file (corrupt/fresh install) | `unknown_base_live_diff: 4` | unchanged: `unknown_base_live_diff: 4` |

Repro source (paste into `/tmp/v084-issue666-repro.py`):

```python
import importlib.util, json, subprocess, sys, tempfile
from pathlib import Path
REPO = Path("/path/to/repo")
spec = importlib.util.spec_from_file_location("bridge_upgrade", REPO / "bridge-upgrade.py")
mod = importlib.util.module_from_spec(spec); sys.modules["bridge_upgrade"] = mod; spec.loader.exec_module(mod)
# … init synthetic source + target trees, call mod.analyze_live / mod.apply_live, assert counts
```

`./scripts/smoke-test.sh` fails identically on this host (macOS) **with and without** the patch at the redactor (#428 r2) step because the live install lacks the isolation-v2 marker. Reproduces against `origin/main` at `3310008` without any edits — pre-existing, unrelated. Patch is a pure Python change; no shell paths touched.

## Recommended follow-up verification (operator)

OrbStack VM E2E retest of #666's exact repro:

```bash
# pre-state: VERSION=0.8.2, agent-bridge version → 0.8.2
cd ~/agb-source && git fetch --tags --prune origin && git checkout v0.8.4
~/.agent-bridge/agent-bridge upgrade --apply --source ~/agb-source --target ~/.agent-bridge
# expect: files_copied > 0 + live VERSION advances + agent-bridge version → 0.8.4
```

## Refs

- #666 — silent failed upgrade (release-blocker for v0.8.3)
- #660 — v1→v2 migration emit_plan wiring (additive, not a precondition)