### PR TITLE
fix(doctor): v0.8.4 — isolate codex hook registration so agent-doctor doesn't leak stale paths (refs #670)

### DIFF
--- a/lib/bridge-doctor.sh
+++ b/lib/bridge-doctor.sh
@@ -242,9 +242,31 @@ bridge_doctor_invoke_agent() {
 
   # Subshell isolation — BRIDGE_AGENT_HOME_ROOT is exported only here.
   # shellcheck disable=SC2030 # subshell-scoped export is the design.
+  #
+  # Issue #670 — also pin BRIDGE_CODEX_HOOKS_FILE into the isolated
+  # BRIDGE_HOME for the duration of every child invocation. Without
+  # this, the doctor's `create --engine codex` step downstream-runs
+  # `bridge-start.sh --dry-run`, which calls `bridge_ensure_codex_hooks`.
+  # That helper resolves to `$HOME/.codex/hooks.json` by default and
+  # writes PreToolUse + Stop entries whose `command` strings reference
+  # `$BRIDGE_HOME/hooks/codex-task-mode-policy.py` and
+  # `$BRIDGE_HOME/hooks/codex-review-output-shape.py`. When the
+  # doctor's temp BRIDGE_HOME is cleaned up, those entries become
+  # stale references in the operator's real `~/.codex/hooks.json`,
+  # permanently breaking every codex session on the host (PreToolUse
+  # blocks every command with `python3: can't open file ...`).
+  #
+  # Pinning BRIDGE_CODEX_HOOKS_FILE to a path inside the isolated
+  # BRIDGE_HOME redirects the writes to a hooks.json that dies with
+  # the temp dir on doctor exit. The operator's hooks.json is never
+  # touched. Guarded by [[ -n "${BRIDGE_HOME:-}" ]] (validated up in
+  # bridge_doctor_run) so the export is always safe here.
   local rc=0
   (
     export BRIDGE_AGENT_HOME_ROOT="$fixture_home_root"
+    if [[ -n "${BRIDGE_HOME:-}" ]]; then
+      export BRIDGE_CODEX_HOOKS_FILE="$BRIDGE_HOME/.codex/hooks.json"
+    fi
     exec "${BRIDGE_BASH_BIN:-bash}" "$agent_script" "$verb" "$@"
   ) >"$stdout_log" 2>"$stderr_log" || rc=$?
 


### PR DESCRIPTION
## Summary

`agent-bridge agent doctor` permanently breaks every codex session on the host. The doctor runs its 7-step CRUD self-check against an isolated `BRIDGE_HOME` (a `mktemp -d` tree under `/tmp/agent-doctor.<rand>/bridge-home`), but its codex create step downstream-runs `bridge-start.sh --dry-run`, which calls `bridge_ensure_codex_hooks`. That helper resolves to `$HOME/.codex/hooks.json` (the operator's real config) by default and writes PreToolUse + Stop entries whose `command` strings reference `$BRIDGE_HOME/hooks/codex-task-mode-policy.py` and `$BRIDGE_HOME/hooks/codex-review-output-shape.py` — paths inside the doctor's temp tree.

When the doctor exits and the temp tree is cleaned up, those entries become stale references. Every subsequent codex session fails with `python3: can't open file '...': [Errno 2] No such file or directory` from the PreToolUse + Stop hooks pointing at deleted files. Codex CLI cannot even run `agb` commands.

## Chosen option

**Option 1 from the brief — redirect via `BRIDGE_CODEX_HOOKS_FILE`.** The bridge already supports an explicit hooks-file override: `bridge_codex_hooks_file()` in `lib/bridge-hooks.sh` checks `BRIDGE_CODEX_HOOKS_FILE` before falling back to `$HOME/.codex/hooks.json`. The smoke harness uses this override every test run. The doctor wrapper `bridge_doctor_invoke_agent` is the single chokepoint for every CRUD child invocation (including the cleanup-trap delete). Adding a one-shot `export BRIDGE_CODEX_HOOKS_FILE="$BRIDGE_HOME/.codex/hooks.json"` to the existing subshell pinpoints the redirect to the doctor's lifetime only — the operator's `~/.codex/hooks.json` is never touched, and the redirected hooks.json dies with the temp BRIDGE_HOME on doctor exit.

Why not Option 2 (try/finally cleanup): would require tracking which entries the doctor added vs operator-added, exposing a marker schema in tracked source, and a cleanup path that runs on success/failure/signal. Larger surface, more failure modes (mid-cleanup crash leaks).

Why not Option 3 (ship the hooks at a stable persistent location): the two scripts already live in source `hooks/` — the leak isn't about missing scripts, it's about the `$BRIDGE_HOME` substitution in `bridge_ensure_codex_hooks`. Option 3 would require redesigning where every codex hook command's path is rooted, which is much larger surface than this single bug.

## Verification

- `bash -n lib/bridge-doctor.sh` — pass
- `shellcheck -x lib/bridge-doctor.sh` — pass (no findings)
- `python3 -c "import ast; ast.parse(open('bridge-hooks.py').read())"` — pass
- `bash scripts/smoke/agent-doctor.sh` — all 6 tests pass (T1-T6)
- `bash scripts/smoke/hooks.sh` (Codex hooks ensure/status) — pass
- `bash scripts/smoke/codex-task-mode-policy-comprehensive.sh` — 64 assertions pass
- `bash scripts/smoke-test.sh` blocks at the same v0.8.0 isolation gate it blocks on `main` (pre-existing host-environment limitation, not introduced by this change).

### End-to-end probe

Snapshot `~/.codex/hooks.json` sha256, run `bridge-agent.sh doctor --json` against an isolated `BRIDGE_HOME` with the same v2 layout the smoke uses, confirm sha256 unchanged post-run, and confirm the redirected `$BRIDGE_HOME/.codex/hooks.json` got the four codex hook events with commands inside the temp tree.

With this PR:
```
snapshot: existed, sha256=b15c4244...
doctor rc=0
doctor overall_exit=0
PASS: ~/.codex/hooks.json unchanged
PASS: isolated $BRIDGE_HOME/.codex/hooks.json was created (redirect in effect)
  isolated events: ['PreToolUse', 'SessionStart', 'Stop', 'UserPromptSubmit']
  commands point at $BRIDGE_HOME/hooks/...
```

Without this PR (`git stash` baseline against the same probe):
```
diff baseline → after-doctor:
+  PreToolUse: command "/usr/bin/python3 /var/folders/.../bridge-home/hooks/codex-task-mode-policy.py"
+  Stop: command "/usr/bin/python3 /var/folders/.../bridge-home/hooks/codex-review-output-shape.py"
   UserPromptSubmit replaced with /var/folders/.../bridge-home/hooks/prompt_timestamp.py path
```

Reproduces the issue exactly: stale `/var/folders/.../bridge-home/hooks/codex-*.py` entries land in the real `~/.codex/hooks.json` and persist after the temp BRIDGE_HOME is cleaned up.

## Operator workaround for hosts already in the broken state

```bash
python3 -c '
import json, pathlib
p = pathlib.Path.home() / ".codex/hooks.json"
data = json.loads(p.read_text())
def keep(entry):
    cmds = " ".join(h.get("command","") for h in entry.get("hooks",[]))
    return "agent-doctor" not in cmds
for ev in ("PreToolUse","Stop","SessionStart","UserPromptSubmit"):
    if ev in data["hooks"]:
        data["hooks"][ev] = [e for e in data["hooks"][ev] if keep(e)]
p.write_text(json.dumps(data, indent=2))
'
```

For hosts where the temp paths don't contain `agent-doctor` (depends on `mktemp` template), filter on `/var/folders/` or `/T/tmp.` instead.

## Files changed

- `lib/bridge-doctor.sh` (+22/-0): export `BRIDGE_CODEX_HOOKS_FILE` to `$BRIDGE_HOME/.codex/hooks.json` inside the existing `bridge_doctor_invoke_agent` subshell, alongside the existing `BRIDGE_AGENT_HOME_ROOT` export.

Refs #670