### PR TITLE
fix(isolation): v0.8.4 — markerless fresh install auto-marker + Linux migration daemon restart (refs #665 #668)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -4,6 +4,27 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# Issue #665 (r2): the public CLI wrapper sources bridge-lib.sh BEFORE it
+# dispatches to bridge-init.sh / bridge-bootstrap.sh, so the resolver
+# fires here in the wrapper process — armed with the wrapper's PID and
+# argv ("agent-bridge"). Without arming the fresh-install bypass before
+# the source below, a markerless fresh home dies inside the resolver
+# (line ~369 of lib/bridge-layout-resolver.sh) before the wrapper ever
+# reaches the dispatch table. Mirror what bridge-init.sh / bridge-
+# bootstrap.sh do for direct invocations: peek at $1 and arm the bypass
+# only for the fresh-install-creating subcommands. The handshake in
+# lib/bridge-layout-resolver.sh accepts "agent-bridge" alongside
+# "bridge-init.sh" / "bridge-bootstrap.sh" for exactly this case.
+case "${1:-}" in
+  init|bootstrap)
+    if [[ -z "${BRIDGE_LAYOUT_RESOLVER_BYPASS:-}" ]]; then
+      _BRIDGE_AGENT_BRIDGE_BYPASS_NONCE="$(date -u '+%Y%m%dT%H%M%SZ')-$$-${RANDOM}${RANDOM}"
+      export BRIDGE_LAYOUT_RESOLVER_BYPASS="fresh-install:${_BRIDGE_AGENT_BRIDGE_BYPASS_NONCE}"
+      export BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID=$$
+      trap 'unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID' EXIT
+    fi
+    ;;
+esac
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 CLI_NAME="$(basename "$0")"

--- a/bridge-bootstrap.sh
+++ b/bridge-bootstrap.sh
@@ -4,6 +4,17 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# Issue #665: arm the fresh-install resolver bypass before sourcing
+# bridge-lib.sh. See bridge-init.sh for the rationale and contract — the
+# resolver only honors the bypass when classification is
+# fresh-install-candidate, so an existing markerless install still trips
+# the v0.8.0 fail-fast. The trap clears the bypass on exit so a crashed
+# bootstrap does not leave the env in a state that disarms the resolver
+# for sibling shells.
+_BRIDGE_BOOTSTRAP_BYPASS_NONCE="$(date -u '+%Y%m%dT%H%M%SZ')-$$-${RANDOM}${RANDOM}"
+export BRIDGE_LAYOUT_RESOLVER_BYPASS="fresh-install:${_BRIDGE_BOOTSTRAP_BYPASS_NONCE}"
+export BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID=$$
+trap 'unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID' EXIT
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -4,6 +4,19 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# Issue #665: the layout resolver fails fast on markerless installs. On a
+# fresh install the marker does not yet exist, so we MUST arm the
+# fresh-install bypass before sourcing bridge-lib.sh. The resolver only
+# honors the bypass when classification is fresh-install-candidate
+# (no existing-install evidence) — an existing markerless install still
+# trips the v0.8.0 fail-fast and is sent to `agent-bridge upgrade --apply`.
+# The bypass value carries a unique nonce, and the resolver only honors
+# it when the calling process is a descendant of the init owner PID, so
+# a leaked or copied env var alone cannot disarm the fail-fast guard.
+_BRIDGE_INIT_BYPASS_NONCE="$(date -u '+%Y%m%dT%H%M%SZ')-$$-${RANDOM}${RANDOM}"
+export BRIDGE_LAYOUT_RESOLVER_BYPASS="fresh-install:${_BRIDGE_INIT_BYPASS_NONCE}"
+export BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID=$$
+trap 'unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID' EXIT
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 # shellcheck source=lib/bridge-admin-pair.sh

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1747,10 +1747,18 @@ if [[ $JSON -eq 1 ]]; then
   # (matches the OPERATIONS.md contract). Empty file when cleanup didn't
   # run (e.g. dry-run paths that bypass the cleanup block above).
   printf '%s' "${CLEANUP_JSON:-}" >"$_json_payload_dir/cleanup.json"
+  # Issue #668 (r2): surface the isolation-v2 migration payload in --json
+  # output so operators reading the JSON envelope can detect the macOS
+  # supplemental-group cache caveat (`migration_requires_relogin`) and the
+  # Linux daemon-restart deferred path. The payload is emitted by
+  # lib/bridge-isolation-v2-migrate.sh:1578 on apply, and a dry-run-shaped
+  # placeholder on dry-run. Always-present so JSON consumers can branch on
+  # the field's contents instead of having to handle missing-key vs value.
+  printf '%s' "${ISOLATION_V2_MIGRATION_JSON:-}" >"$_json_payload_dir/isolation-v2-migration.json"
   set +e
-  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" "$_json_payload_dir/source-reclassify.json" "$_json_payload_dir/shared-settings-rerender.json" "$_json_payload_dir/cleanup.json" <<'PY'
+  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" "$_json_payload_dir/source-reclassify.json" "$_json_payload_dir/shared-settings-rerender.json" "$_json_payload_dir/cleanup.json" "$_json_payload_dir/isolation-v2-migration.json" <<'PY'
 import json, sys
-source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file, source_reclassify_json_file, shared_settings_rerender_json_file, cleanup_json_file = sys.argv[1:]
+source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file, source_reclassify_json_file, shared_settings_rerender_json_file, cleanup_json_file, isolation_v2_migration_json_file = sys.argv[1:]
 
 def load_json(path):
     with open(path, encoding="utf-8") as fh:
@@ -1778,6 +1786,12 @@ channel_guard_payload = load_json(channel_guard_json_file)
 source_reclassify_payload = load_json(source_reclassify_json_file)
 shared_settings_rerender_payload = load_json(shared_settings_rerender_json_file)
 cleanup_payload = load_optional_json(cleanup_json_file)
+# Always include the isolation-v2 migration field so JSON consumers can
+# branch on the contents (status="applied" + migration_requires_relogin,
+# skipped="dry-run", etc.) without missing-key handling. Falls back to
+# null when the variable was empty (defensive — current code paths always
+# set ISOLATION_V2_MIGRATION_JSON before reaching the JSON envelope).
+isolation_v2_migration_payload = load_optional_json(isolation_v2_migration_json_file)
 payload = {
     "mode": "upgrade",
     "version": source_version,
@@ -1812,6 +1826,7 @@ payload = {
     "channel_guard": channel_guard_payload,
     "agent_restart": agent_restart_payload,
     "agent_migration": migration_payload,
+    "isolation_v2_migration": isolation_v2_migration_payload,
     "source_reclassify": source_reclassify_payload,
     "shared_settings_rerender": shared_settings_rerender_payload,
     "cleanup": cleanup_payload,

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -901,6 +901,7 @@ bridge_isolation_v2_migrate_orchestrate_stop() {
 
 bridge_isolation_v2_migrate_orchestrate_restart() {
   local snapshot_path="$1"
+  local daemon_up=0
 
   # v0.8.3: on macOS, bring the daemon back under launchd supervision
   # via `launchctl bootstrap` instead of `bridge-daemon.sh start`. The
@@ -912,10 +913,28 @@ bridge_isolation_v2_migrate_orchestrate_restart() {
     bridge_isolation_v2_launchd_bootstrap \
       || bridge_die "daemon restart failed (launchctl bootstrap)"
     bridge_isolation_v2_migrate_wait_daemon_present 10
+    daemon_up=1
   else
-    "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-daemon.sh" start >/dev/null 2>&1 \
-      || bridge_die "daemon restart failed"
-    bridge_isolation_v2_migrate_wait_daemon_present 10
+    # Issue #668: on Linux (and non-launchd Darwin) the migration runs as
+    # a non-root operator with passwordless sudo. usermod just added the
+    # operator to the new ab-controller group, but supplemental group
+    # membership in an already-running shell is cached — until the next
+    # login, this process and its children still see the OLD group set.
+    # Spawning the daemon from this shell therefore inherits stale groups
+    # and the daemon dies the moment it tries to write to a 2770/ab-
+    # controller controller-state path. Treat both `bridge-daemon.sh
+    # start` and the `wait_daemon_present` poll as best-effort: warn,
+    # continue, and surface the relogin requirement in the caller's
+    # JSON. The caller (apply_for_upgrade) advances the marker and
+    # returns success so apply-live can install the v0.8.x code; the
+    # operator finishes the restart by re-logging in (which refreshes
+    # the supplemental-group cache) and running `agb daemon start`.
+    if "$BRIDGE_BASH_BIN" "$BRIDGE_SCRIPT_DIR/bridge-daemon.sh" start >/dev/null 2>&1 \
+        && bridge_isolation_v2_migrate_wait_daemon_present 10 2>/dev/null; then
+      daemon_up=1
+    else
+      bridge_warn "daemon restart deferred — supplemental-group cache requires a fresh login. Re-login and run 'agb daemon start' to finish bringing the daemon up."
+    fi
   fi
 
   # v0.8.3: skip restart for agents whose tmux session has an attached
@@ -923,6 +942,16 @@ bridge_isolation_v2_migrate_orchestrate_restart() {
   # as `agent_restart_skipped_attached`; mirroring the same predicate
   # here prevents the apply step from yanking the rug out from under a
   # live operator session.
+  #
+  # Issue #668: when the daemon could not be brought up (Linux relogin
+  # path), per-agent restarts would just fail, polluting the upgrade
+  # output with N copies of the same root cause. Defer them to the
+  # operator's post-relogin `agb daemon start` follow-up.
+  if (( daemon_up == 0 )); then
+    bridge_warn "per-agent restart deferred — re-login then run 'agb daemon start' to bring agents back up"
+    return 0
+  fi
+
   local agent session attached
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
@@ -1503,10 +1532,17 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
   fi
 
   # Per-agent completion markers — all_snapshot, one marker each.
-  # macOS supplemental group cache: dseditgroup-driven membership only
-  # takes effect after re-login, so flag every Darwin-side agent.
+  # Supplemental-group cache: both macOS dseditgroup membership AND
+  # Linux usermod -aG additions only take effect after re-login, so
+  # flag every agent regardless of platform when the migration ran as
+  # a non-root user (the only path that actually adds groups to the
+  # caller via usermod / dseditgroup). Issue #668: this was previously
+  # macOS-only, leaving the Linux upgrader to omit the relogin caveat
+  # even though the same group cache pitfall applies.
   local relogin_flag=0
-  [[ "$(uname)" == "Darwin" ]] && relogin_flag=1
+  if [[ "$(id -u)" -ne 0 ]]; then
+    relogin_flag=1
+  fi
   local agent agent_grp
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -190,7 +190,13 @@ _bridge_layout_resolver_fresh_install_bypass_active() {
   local val="${BRIDGE_LAYOUT_RESOLVER_BYPASS:-}"
   [[ "$val" == fresh-install:* ]] || return 1
   [[ "${val#fresh-install:}" != "" ]] || return 1
-  _bridge_layout_resolver_handshake_check "bridge-init.sh" "bridge-bootstrap.sh"
+  # `agent-bridge` accepted in addition to the underlying scripts because the
+  # public CLI wrapper sources bridge-lib.sh (which fires the resolver)
+  # BEFORE it execs to bridge-init.sh / bridge-bootstrap.sh. The wrapper
+  # arms the bypass for fresh-install-creating subcommands so that first
+  # resolver call passes; subsequent boots inside bridge-init.sh /
+  # bridge-bootstrap.sh re-arm with their own argv and still match.
+  _bridge_layout_resolver_handshake_check "bridge-init.sh" "bridge-bootstrap.sh" "agent-bridge"
 }
 
 _bridge_layout_resolver_handshake_check() {

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -172,6 +172,32 @@ _bridge_layout_resolver_bypass_active() {
   # Reject the empty-suffix form so a stale "upgrade-migrate:" without
   # a nonce body cannot disarm the resolver.
   [[ "${val#upgrade-migrate:}" != "" ]] || return 1
+  _bridge_layout_resolver_handshake_check "bridge-upgrade.sh"
+}
+
+# Fresh-install bypass — same handshake shape as the upgrade bypass but
+# armed by `bridge-init.sh` / `bridge-bootstrap.sh`. Differs in two ways:
+#   - The bypass only activates AFTER evidence-based classification, so an
+#     existing-install (any of: tasks.db, agent-roster.local.sh, populated
+#     state/agents, populated agents/<x>) still trips the v0.8.0 fail-fast
+#     and sends the operator to `agent-bridge upgrade --apply`.
+#   - The bypass does not set BRIDGE_LAYOUT/BRIDGE_DATA_ROOT itself; the
+#     init script is responsible for writing the v2 marker and re-resolving.
+# This keeps the resolver read-only by contract — the bypass just defers
+# the die so the init flow gets a chance to write the marker before the
+# next boot takes the marker branch.
+_bridge_layout_resolver_fresh_install_bypass_active() {
+  local val="${BRIDGE_LAYOUT_RESOLVER_BYPASS:-}"
+  [[ "$val" == fresh-install:* ]] || return 1
+  [[ "${val#fresh-install:}" != "" ]] || return 1
+  _bridge_layout_resolver_handshake_check "bridge-init.sh" "bridge-bootstrap.sh"
+}
+
+_bridge_layout_resolver_handshake_check() {
+  # Shared owner-PID + descendant walk used by both the upgrade-migrate
+  # and fresh-install bypasses. Accepts one or more allowed argv-substring
+  # patterns for the owner process command. Returns 0 when the handshake
+  # passes, 1 otherwise.
   local owner_pid="${BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID:-}"
   [[ -n "$owner_pid" ]] || return 1
   # Owner pid must be a positive integer >= 2. Anything else is hostile —
@@ -180,9 +206,9 @@ _bridge_layout_resolver_bypass_active() {
   [[ "$owner_pid" =~ ^[0-9]+$ ]] || return 1
   (( owner_pid >= 2 )) || return 1
   # Owner pid must point at a live process whose command line reveals it
-  # really IS bridge-upgrade.sh. A leaked env crossing into another
-  # process tree (or a re-used PID after upgrade.sh exited) fails this
-  # check because the unrelated process's argv won't match. Both ps
+  # really IS one of the allowed callers. A leaked env crossing into
+  # another process tree (or a re-used PID after the owner exited) fails
+  # this check because the unrelated process's argv won't match. Both ps
   # variants are tried (Linux ps -o args=, macOS ps -o command=) so the
   # check works on both platforms.
   local owner_cmd=""
@@ -191,7 +217,14 @@ _bridge_layout_resolver_bypass_active() {
     owner_cmd="$(ps -o command= -p "$owner_pid" 2>/dev/null | head -n 1)"
   fi
   [[ -n "$owner_cmd" ]] || return 1
-  [[ "$owner_cmd" == *"bridge-upgrade.sh"* ]] || return 1
+  local pat matched=0
+  for pat in "$@"; do
+    if [[ "$owner_cmd" == *"$pat"* ]]; then
+      matched=1
+      break
+    fi
+  done
+  (( matched == 1 )) || return 1
   # Caller must be a descendant of owner_pid. Walk up the process tree
   # bounded to 64 levels — well above any realistic shell-nesting depth
   # and prevents a pathological tree from trapping us in a loop.
@@ -308,16 +341,31 @@ bridge_resolve_layout() {
 
   # Fresh install candidate. Pre-v0.8.0 this branch left BRIDGE_LAYOUT
   # unset until `agent-bridge init` wrote the marker; with v1 removed,
-  # the only honest behavior is to refuse and point the operator at the
-  # migration / init tool. We still set BRIDGE_DEFAULT_DATA_ROOT so the
-  # init helper can compute its default before bridge_die fires —
-  # callers that legitimately need to inspect the unwritten layout
-  # (e.g. `agent-bridge init` itself) gate on BRIDGE_LAYOUT_SOURCE
-  # before invoking the resolver in fail-fast mode.
+  # the only honest behavior is to refuse unless the caller is the
+  # init/bootstrap flow that will write the marker before any other
+  # subsystem reads it. Without the bypass, even `bridge-init.sh` itself
+  # cannot run on a clean home — the resolver auto-fires while sourcing
+  # bridge-lib.sh and dies before the init's own marker-write reaches
+  # line 348.
   if [[ "${BRIDGE_LAYOUT_SOURCE:-}" != "invalid-marker(fallback)" ]]; then
     BRIDGE_LAYOUT_SOURCE="fresh-install-candidate"
   fi
   BRIDGE_DEFAULT_DATA_ROOT="${BRIDGE_HOME:-$HOME/.agent-bridge}/data"
+
+  # Issue #665: armed by bridge-init.sh / bridge-bootstrap.sh before they
+  # source bridge-lib.sh. The handshake (nonce + descendant of init/bootstrap
+  # PID + matching argv) keeps a leaked / forged env from disarming the
+  # v0.8.0 fail-fast for unrelated callers. The bypass only fires when
+  # classification is fresh-install-candidate — invalid-marker(fallback)
+  # is a corrupted existing install, not a fresh one, so it must still
+  # die so the operator runs `agent-bridge upgrade --apply`. The init
+  # flow takes over and writes the v2 marker; subsequent process boots
+  # take the marker branch and this bypass becomes a no-op.
+  if [[ "$BRIDGE_LAYOUT_SOURCE" == "fresh-install-candidate" ]] \
+      && _bridge_layout_resolver_fresh_install_bypass_active; then
+    return 0
+  fi
+
   bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
   current_layout=markerless(${BRIDGE_LAYOUT_SOURCE})
   remediation: run \`agent-bridge upgrade --apply\` to migrate this install to v2, or roll back to v0.7.x.


### PR DESCRIPTION
## Summary

Two layered fixes for v0.8.4 hotfix wave (refs #665, #668):

### Fix #665 — fresh install auto-marker

`bridge-bootstrap.sh` + `bridge-init.sh` arm a one-shot `BRIDGE_LAYOUT_RESOLVER_BYPASS=fresh-install:<nonce>` env before sourcing `bridge-lib.sh`. The new `lib/bridge-layout-resolver.sh` honors the bypass **only** when the layout classification is `markerless(fresh-install-candidate)`. Result: fresh install on a clean home auto-writes the v2 marker and proceeds; `markerless(existing-install)` still trips the v0.8.0 fail-fast (correct rejection). Trap clears the bypass on EXIT so a crashed bootstrap doesn't leave the env disarmed for sibling shells.

### Fix #668 — Linux migration daemon restart (supplemental-group cache)

`bridge_isolation_v2_migrate_orchestrate_restart` on non-launchd hosts now treats `bridge-daemon.sh start` + `wait_daemon_present` as best-effort.

Root cause: `usermod` just added the operator to the new `ab-controller` group, but supplemental-group membership in an already-running shell is cached until the next login. Spawning the daemon from this shell inherits stale groups and dies on first `2770`/`ab-controller` controller-state write.

The migration now: warns + advances the marker + lets `apply-live` install the v0.8.x code. Operator finishes by re-login + `agb daemon start`. The JSON envelope surfaces this state to the caller (no silent skip).

## Verification

- \`bash -n bridge-bootstrap.sh bridge-init.sh lib/bridge-isolation-v2-migrate.sh lib/bridge-layout-resolver.sh\` — pass
- \`shellcheck\` on the same set — pass
- \`./scripts/smoke-test.sh\` — fails at pre-existing #665 gate on macOS host (\`markerless(existing-install)\` v0.8.0 guard); same failure shape on \`main\`@3310008 without this patch. OrbStack VM retest is the gate; this PR makes it possible.

Out of scope: VERSION/CHANGELOG (release PR will bump), v1→v2 migration plan logic (PR #660 untouched), macOS launchd path (PR #661 unchanged), credentials/ subdir mode (still 0o2750 + controller-owned in #667 sibling PR).

## Refs
- refs #665, #668