### PR TITLE
fix(isolation): v0.8.4 — Linux 32-char group-name truncation + agent dir group-write (refs #667)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2166,6 +2166,14 @@ report and reap test-fixture agents per their pattern."
       isolation_mode="shared"
       os_user=""
     else
+      # v0.8.4: enforce the group-name char policy upfront so a name
+      # accepted by `agent create` will always compose to a valid Linux
+      # group name (length is hash-truncated separately by
+      # bridge_isolation_v2_agent_group_name; the chars must still be
+      # [a-z_][a-z0-9_-]* per groupadd).
+      if [[ ! "$agent" =~ ^[a-z_][a-z0-9_-]*$ ]]; then
+        bridge_die "linux-user isolation requires agent name to match [a-z_][a-z0-9_-]* (groupadd policy): '$agent'"
+      fi
       os_user="${os_user:-$(bridge_agent_default_os_user "$agent")}"
     fi
   fi

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2875,19 +2875,27 @@ bridge_linux_prepare_agent_isolation() {
 
   # v2 layout: lay down the per-agent private root before any ACL grants
   # touch its children. The contract is:
-  #   $BRIDGE_AGENT_ROOT_V2/<agent>            owner=root, group=ab-agent-<name>, mode 2770
+  #   $BRIDGE_AGENT_ROOT_V2/<agent>            owner=root, group=ab-agent-<name>, mode 2750
   #   ├── home/, workdir/, runtime/, logs/,
   #   │   requests/, responses/                 owner=isolated, group=ab-agent-<name>, mode 2770
   #   └── credentials/                          owner=controller, group=ab-agent-<name>, mode 2750
   #       └── launch-secrets.env                owner=controller, group=ab-agent-<name>, mode 0640
-  # The root mode 2770 (v0.8.4): both controller and isolated UID are
-  # group members. Group rwx + setgid lets the controller `mkdir runtime/`
-  # and write `runtime/history.env` from outside the prepare codepath
-  # (e.g. `bridge_load_static_agent_history` -> `bridge_write_agent_state_file`),
-  # which previously failed with Permission denied under mode 2750.
-  # Trade-off: the isolated UID can also write at the per-agent root, so
-  # `credentials/` is protected by its own owner=controller + 2750
-  # subdir mode (group r-x, isolated UID cannot write inside).
+  # Root mode 2750 (group r-x, no group write) is load-bearing: the
+  # isolated UID is in the agent group, so any group-write at the root
+  # would let it `rmdir credentials/` or `mv credentials creds.bak`
+  # regardless of credentials/'s own mode (POSIX requires write on the
+  # *parent* directory to delete or rename an entry inside it). 2750
+  # blocks that. The credentials/ subdir's own 2750 + controller-owner
+  # then prevents writes *inside* credentials/.
+  # Trade-off: the controller — also a group member, but not the owner —
+  # cannot directly `mkdir runtime/` from non-prepare codepaths under
+  # 2750 either. Controller writes that must land under the per-agent
+  # root (notably `runtime/history.env` via
+  # `bridge_load_static_agent_history` ->
+  # `bridge_write_agent_state_file`) therefore go through a sudo-handoff
+  # helper in lib/bridge-state.sh, mirroring the
+  # `bridge_install_isolated_home_settings` cross-UID write pattern in
+  # lib/bridge-hooks.sh.
   local _v2_agent_group _v2_agent_root _v2_credentials_dir _v2_subdir
   _v2_agent_group="$(bridge_isolation_v2_agent_group_name "$agent")" \
     || bridge_die "isolation v2: invalid agent name '$agent' for group composition"
@@ -2924,10 +2932,14 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_sudo_root mkdir -p "$_v2_agent_root"
   bridge_linux_sudo_root chown root: "$_v2_agent_root"
   bridge_linux_sudo_root chgrp "$_v2_agent_group" "$_v2_agent_root"
-  # v0.8.4: 2770 (was 2750) so the controller — group member, not owner —
-  # can mkdir subdirs (e.g. runtime/) from non-prepare codepaths. See
-  # the layout comment above for the credentials/ protection contract.
-  bridge_linux_sudo_root chmod 2770 "$_v2_agent_root"
+  # 2750 (root-owner, group r-x, no group write at the root level): the
+  # isolated UID — in the agent group — cannot rmdir/rename
+  # credentials/ here, so the credentials isolation contract holds.
+  # Controller writes under per-agent root that previously relied on
+  # group write at the root (mkdir runtime/, etc.) now go through the
+  # sudo-handoff helpers (see lib/bridge-state.sh
+  # bridge_state_sudo_install_v2_file). See the layout comment above.
+  bridge_linux_sudo_root chmod 2750 "$_v2_agent_root"
   for _v2_subdir in home workdir runtime logs requests responses; do
     bridge_linux_sudo_root mkdir -p "$_v2_agent_root/$_v2_subdir"
     bridge_linux_sudo_root chown "$os_user" "$_v2_agent_root/$_v2_subdir"
@@ -3319,7 +3331,7 @@ bridge_agent_workdir() {
   local explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
 
   # v2 takes precedence over explicit roster workdirs: the per-agent private
-  # root (root-owned, group rwx, mode 2770 in v0.8.4+) IS the isolation contract. An
+  # root (root-owned, group r-x, mode 2750) IS the isolation contract. An
   # explicit workdir outside that root would launch the agent into a
   # directory the per-agent group cannot reach — or worse, a directory that
   # other isolated UIDs can reach — silently breaking PR-C's per-agent

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2875,14 +2875,19 @@ bridge_linux_prepare_agent_isolation() {
 
   # v2 layout: lay down the per-agent private root before any ACL grants
   # touch its children. The contract is:
-  #   $BRIDGE_AGENT_ROOT_V2/<agent>            owner=root, group=ab-agent-<name>, mode 2750
+  #   $BRIDGE_AGENT_ROOT_V2/<agent>            owner=root, group=ab-agent-<name>, mode 2770
   #   ├── home/, workdir/, runtime/, logs/,
   #   │   requests/, responses/                 owner=isolated, group=ab-agent-<name>, mode 2770
   #   └── credentials/                          owner=controller, group=ab-agent-<name>, mode 2750
   #       └── launch-secrets.env                owner=controller, group=ab-agent-<name>, mode 0640
-  # The root mode 2750 means unrelated UIDs cannot traverse/list the
-  # private root; the isolated UID enters via group r-x but cannot write
-  # at the root level — so it cannot rm/mv `credentials/` or its file.
+  # The root mode 2770 (v0.8.4): both controller and isolated UID are
+  # group members. Group rwx + setgid lets the controller `mkdir runtime/`
+  # and write `runtime/history.env` from outside the prepare codepath
+  # (e.g. `bridge_load_static_agent_history` -> `bridge_write_agent_state_file`),
+  # which previously failed with Permission denied under mode 2750.
+  # Trade-off: the isolated UID can also write at the per-agent root, so
+  # `credentials/` is protected by its own owner=controller + 2750
+  # subdir mode (group r-x, isolated UID cannot write inside).
   local _v2_agent_group _v2_agent_root _v2_credentials_dir _v2_subdir
   _v2_agent_group="$(bridge_isolation_v2_agent_group_name "$agent")" \
     || bridge_die "isolation v2: invalid agent name '$agent' for group composition"
@@ -2919,7 +2924,10 @@ bridge_linux_prepare_agent_isolation() {
   bridge_linux_sudo_root mkdir -p "$_v2_agent_root"
   bridge_linux_sudo_root chown root: "$_v2_agent_root"
   bridge_linux_sudo_root chgrp "$_v2_agent_group" "$_v2_agent_root"
-  bridge_linux_sudo_root chmod 2750 "$_v2_agent_root"
+  # v0.8.4: 2770 (was 2750) so the controller — group member, not owner —
+  # can mkdir subdirs (e.g. runtime/) from non-prepare codepaths. See
+  # the layout comment above for the credentials/ protection contract.
+  bridge_linux_sudo_root chmod 2770 "$_v2_agent_root"
   for _v2_subdir in home workdir runtime logs requests responses; do
     bridge_linux_sudo_root mkdir -p "$_v2_agent_root/$_v2_subdir"
     bridge_linux_sudo_root chown "$os_user" "$_v2_agent_root/$_v2_subdir"
@@ -3311,7 +3319,7 @@ bridge_agent_workdir() {
   local explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
 
   # v2 takes precedence over explicit roster workdirs: the per-agent private
-  # root (root-owned, group r-x, mode 2750) IS the isolation contract. An
+  # root (root-owned, group rwx, mode 2770 in v0.8.4+) IS the isolation contract. An
   # explicit workdir outside that root would launch the agent into a
   # directory the per-agent group cannot reach — or worse, a directory that
   # other isolated UIDs can reach — silently breaking PR-C's per-agent

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -741,12 +741,15 @@ bridge_isolation_v2_migrate_normalize_layout() {
       || { bridge_warn "normalize_layout: state/ chgrp_setgid_recursive failed"; return 1; }
   fi
 
-  # Per-agent root must be 2750 (isolated UID enters via group r-x but
-  # MUST NOT have group write at the root, otherwise it could rename or
-  # delete credentials/ even though credentials/ itself is 2750). r3
-  # review caught the broad recursive 2770 pass making the root
-  # writable. Spec: lib/bridge-isolation-v2.sh:45-59 +
-  # lib/bridge-agents.sh:2116-2152 (`# 2750 — isolated UID r-x at root`).
+  # v0.8.4: per-agent root is 2770 (was 2750). The controller is a group
+  # member but NOT the owner, so under 2750 (group r-x, no write) it
+  # could not `mkdir runtime/` from non-prepare codepaths and the
+  # `runtime/history.env` writer failed with Permission denied. 2770
+  # gives the group write + setgid; credentials/ is protected by its
+  # own owner=controller + 2750 subdir mode so the isolated UID still
+  # cannot mutate launch secrets even with group write at the root.
+  # Spec: lib/bridge-isolation-v2.sh:45-59 +
+  # lib/bridge-agents.sh `# 2770 (was 2750)` comment in the prepare path.
   local agent agent_grp agent_root sub
   local writable_subs=(home workdir runtime logs requests responses)
   while IFS= read -r agent; do
@@ -755,8 +758,8 @@ bridge_isolation_v2_migrate_normalize_layout() {
     agent_root="$data_root/agents/$agent"
     [[ -d "$agent_root" ]] || continue
 
-    # Per-agent root: SINGLE-DIR normalize at 2750. No recursion.
-    bridge_isolation_v2_chgrp_setgid_dir "$agent_grp" 2750 "$agent_root" \
+    # Per-agent root: SINGLE-DIR normalize at 2770. No recursion.
+    bridge_isolation_v2_chgrp_setgid_dir "$agent_grp" 2770 "$agent_root" \
       || { bridge_warn "normalize_layout: agents/$agent root chgrp_setgid_dir failed"; return 1; }
 
     # Writable children: 2770/0660 recursive (group rwx + setgid +

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -741,15 +741,19 @@ bridge_isolation_v2_migrate_normalize_layout() {
       || { bridge_warn "normalize_layout: state/ chgrp_setgid_recursive failed"; return 1; }
   fi
 
-  # v0.8.4: per-agent root is 2770 (was 2750). The controller is a group
-  # member but NOT the owner, so under 2750 (group r-x, no write) it
-  # could not `mkdir runtime/` from non-prepare codepaths and the
-  # `runtime/history.env` writer failed with Permission denied. 2770
-  # gives the group write + setgid; credentials/ is protected by its
-  # own owner=controller + 2750 subdir mode so the isolated UID still
-  # cannot mutate launch secrets even with group write at the root.
-  # Spec: lib/bridge-isolation-v2.sh:45-59 +
-  # lib/bridge-agents.sh `# 2770 (was 2750)` comment in the prepare path.
+  # Per-agent root must be 2750 (isolated UID enters via group r-x but
+  # MUST NOT have group write at the root, otherwise it could rename or
+  # delete credentials/ even though credentials/ itself is 2750). r3
+  # review caught the broad recursive 2770 pass making the root
+  # writable. v0.8.4 r2 reaffirmed 2750 after a brief 2770 detour:
+  # group write at the root broke credentials isolation (POSIX requires
+  # write on the *parent* directory to delete or rename an entry inside
+  # it). Controller writes under per-agent root that must land outside
+  # the prepare codepath (notably `runtime/history.env`) go through a
+  # sudo-handoff helper in lib/bridge-state.sh instead of relying on
+  # group write at the root. Spec: lib/bridge-isolation-v2.sh:45-59 +
+  # lib/bridge-agents.sh `# 2750 — isolated UID r-x at root` comment in
+  # the prepare path.
   local agent agent_grp agent_root sub
   local writable_subs=(home workdir runtime logs requests responses)
   while IFS= read -r agent; do
@@ -758,8 +762,8 @@ bridge_isolation_v2_migrate_normalize_layout() {
     agent_root="$data_root/agents/$agent"
     [[ -d "$agent_root" ]] || continue
 
-    # Per-agent root: SINGLE-DIR normalize at 2770. No recursion.
-    bridge_isolation_v2_chgrp_setgid_dir "$agent_grp" 2770 "$agent_root" \
+    # Per-agent root: SINGLE-DIR normalize at 2750. No recursion.
+    bridge_isolation_v2_chgrp_setgid_dir "$agent_grp" 2750 "$agent_root" \
       || { bridge_warn "normalize_layout: agents/$agent root chgrp_setgid_dir failed"; return 1; }
 
     # Writable children: 2770/0660 recursive (group rwx + setgid +
@@ -1357,9 +1361,49 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
     printf '%s/state/layout-marker.sh' "$target_root")"
 
   # Idempotent skip: marker already present + valid -> already migrated.
+  # v0.8.4 r2: even on the skip path, run normalize_layout so existing
+  # v0.8.0~v0.8.3 isolated installs (which may carry drifted modes,
+  # including the brief r1 2770 root) get re-pinned to the v0.8.4
+  # canonical 2750 per-agent root + 2770 writable subdirs + 2750
+  # credentials/. The pass is idempotent on already-canonical layouts
+  # (chgrp + chmod to current values is a no-op). Failures here are
+  # warned but not fatal: the operator can rerun `upgrade --apply` once
+  # the underlying problem (e.g. a missing agent group) is corrected,
+  # and a stale-mode install is strictly safer than aborting an
+  # otherwise-successful upgrade — the upgrade has not advanced any
+  # state at this point. The full migrate path below has its own
+  # normalize_layout call with stricter error handling.
   if [[ -f "$marker_path" ]] \
       && bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; then
-    printf '{"mode":"isolation-v2-migrate","skipped":true,"reason":"marker-present","marker":"%s","data_root":"%s"}\n' \
+    if bridge_isolation_v2_privilege_preflight 2>/dev/null \
+        && bridge_isolation_v2_active 2>/dev/null; then
+      bridge_isolation_v2_migrate_mkstate
+      bridge_isolation_v2_migrate_capture_all_agents_snapshot
+      local _norm_snapshot
+      _norm_snapshot="$(bridge_isolation_v2_migrate_all_agents_snapshot_path)"
+      local _saved_layout_norm="${BRIDGE_LAYOUT:-}"
+      local _saved_data_root_norm="${BRIDGE_DATA_ROOT:-}"
+      BRIDGE_LAYOUT="v2"
+      BRIDGE_DATA_ROOT="$data_root"
+      export BRIDGE_LAYOUT BRIDGE_DATA_ROOT
+      if ! bridge_isolation_v2_migrate_normalize_layout \
+            "$_norm_snapshot" "$data_root"; then
+        bridge_warn "apply_for_upgrade: normalize_layout pass on already-migrated install reported failures; layout may carry drifted modes (rerun \`agent-bridge upgrade --apply\` after addressing the warned cause)"
+      fi
+      BRIDGE_LAYOUT="$_saved_layout_norm"
+      BRIDGE_DATA_ROOT="$_saved_data_root_norm"
+      if [[ -n "$_saved_layout_norm" ]]; then
+        export BRIDGE_LAYOUT
+      else
+        unset BRIDGE_LAYOUT
+      fi
+      if [[ -n "$_saved_data_root_norm" ]]; then
+        export BRIDGE_DATA_ROOT
+      else
+        unset BRIDGE_DATA_ROOT
+      fi
+    fi
+    printf '{"mode":"isolation-v2-migrate","skipped":true,"reason":"marker-present","marker":"%s","data_root":"%s","normalize_refresh":"attempted"}\n' \
       "$marker_path" "$data_root"
     return 0
   fi

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -44,7 +44,7 @@
 #   │   ├── skills/, docs/
 #   ├── agents/                             owner=root,       group=root,         mode 755
 #   │   └── <agent>/                        owner=root,
-#   │                                       group=ab-agent-<name>,                mode 2750
+#   │                                       group=ab-agent-<name>,                mode 2770
 #   │       ├── home/                       owner=agent-bridge-<name>,
 #   │       │                               group=ab-agent-<name>,                mode 2770
 #   │       ├── workdir/                    owner=agent-bridge-<name>,
@@ -169,9 +169,10 @@ bridge_isolation_v2_agent_root() {
 bridge_isolation_v2_agent_credentials_dir() {
   # Controller-owned subtree under the per-agent root. Mode 2750: the
   # isolated UID can read launch-secrets.env via group r-x but cannot
-  # write/rm/mv anything inside it. Parent (per-agent root) is also
-  # mode 2750 root-owned so the credentials/ directory itself cannot
-  # be renamed/removed by the isolated UID.
+  # write/rm/mv anything inside it. v0.8.4: parent (per-agent root) is
+  # now mode 2770 (was 2750) so the controller can mkdir subdirs as a
+  # group member; credentials/ keeps its 2750 + controller-owner so the
+  # isolated UID still cannot rename/remove the file inside.
   local agent="$1"
   local root
   root="$(bridge_isolation_v2_agent_root "$agent")" || return 1
@@ -386,16 +387,74 @@ bridge_isolation_v2_agent_group_name() {
     return 1
   fi
   local composed="${BRIDGE_AGENT_GROUP_PREFIX}${agent}"
-  # v0.8.3: platform-branched length limit. Linux groupadd is 32-char;
-  # macOS dseditgroup tolerates much longer names. The previous
-  # unconditional 32-char check rejected long-named agents on macOS too.
-  local _limit=32
-  [[ "$(uname)" == "Darwin" ]] && _limit=255
-  if (( ${#composed} > _limit )); then
-    bridge_warn "agent_group_name: '$composed' exceeds ${_limit}-char group-name limit on $(uname)"
+  # v0.8.4: platform-branched length policy.
+  # - macOS: dseditgroup tolerates 255-char names; pass through unchanged.
+  # - Linux: groupadd hard-caps at 32 chars. v0.8.3 hard-rejected; v0.8.4
+  #   deterministically hash-truncates so any name accepted by `agent
+  #   create` composes to a unique <=32-char group. The agent name
+  #   segment is reduced to `<first-N-chars>-<7-char-sha256>` where the
+  #   hash is taken over the full untruncated name; two agents whose
+  #   names share the first N chars but differ later still get distinct
+  #   group names because the hash discriminates.
+  if [[ "$(uname)" == "Darwin" ]]; then
+    if (( ${#composed} > 255 )); then
+      bridge_warn "agent_group_name: '$composed' exceeds 255-char group-name limit on Darwin"
+      return 1
+    fi
+    printf '%s' "$composed"
+    return 0
+  fi
+  if (( ${#composed} <= 32 )); then
+    printf '%s' "$composed"
+    return 0
+  fi
+  local _prefix_len=${#BRIDGE_AGENT_GROUP_PREFIX}
+  local _avail=$(( 32 - _prefix_len ))
+  # Need at least 1 char + '-' + 7-char hash = 9 chars for the segment.
+  if (( _avail < 9 )); then
+    bridge_warn "agent_group_name: BRIDGE_AGENT_GROUP_PREFIX '$BRIDGE_AGENT_GROUP_PREFIX' leaves no room (${_avail}) for a hash-truncated agent segment under the 32-char Linux limit"
     return 1
   fi
-  printf '%s' "$composed"
+  local _keep=$(( _avail - 1 - 7 ))
+  local _hash
+  _hash="$(bridge_isolation_v2_short_sha256 "$agent" 7)" || {
+    bridge_warn "agent_group_name: short-sha256 hash failed for '$agent'"
+    return 1
+  }
+  local _head="${agent:0:_keep}"
+  # Tail dashes/underscores before the inserted '-' would produce '--' or
+  # '_-'; both are still valid for groupadd ([a-z_][a-z0-9_-]*) but the
+  # leading char of $_head is taken from the original agent name which
+  # already passed the [a-z_] anchor regex above, so the composed name
+  # remains policy-compliant.
+  printf '%s%s-%s' "$BRIDGE_AGENT_GROUP_PREFIX" "$_head" "$_hash"
+}
+
+bridge_isolation_v2_short_sha256() {
+  # Emit the first <len> hex chars of sha256(<text>). Used by
+  # bridge_isolation_v2_agent_group_name to compose a deterministic
+  # collision-resistant suffix when the raw agent name plus prefix would
+  # exceed Linux's 32-char group-name limit.
+  local text="$1"
+  local len="${2:-7}"
+  [[ "$len" =~ ^[0-9]+$ ]] || return 1
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$text" "$len" <<'PY'
+import hashlib, sys
+text, length = sys.argv[1], int(sys.argv[2])
+print(hashlib.sha256(text.encode("utf-8")).hexdigest()[:length])
+PY
+    return $?
+  fi
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$text" | shasum -a 256 | cut -c "1-${len}"
+    return $?
+  fi
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$text" | sha256sum | cut -c "1-${len}"
+    return $?
+  fi
+  return 1
 }
 
 # ---------------------------------------------------------------------------

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -44,7 +44,7 @@
 #   │   ├── skills/, docs/
 #   ├── agents/                             owner=root,       group=root,         mode 755
 #   │   └── <agent>/                        owner=root,
-#   │                                       group=ab-agent-<name>,                mode 2770
+#   │                                       group=ab-agent-<name>,                mode 2750
 #   │       ├── home/                       owner=agent-bridge-<name>,
 #   │       │                               group=ab-agent-<name>,                mode 2770
 #   │       ├── workdir/                    owner=agent-bridge-<name>,
@@ -169,10 +169,15 @@ bridge_isolation_v2_agent_root() {
 bridge_isolation_v2_agent_credentials_dir() {
   # Controller-owned subtree under the per-agent root. Mode 2750: the
   # isolated UID can read launch-secrets.env via group r-x but cannot
-  # write/rm/mv anything inside it. v0.8.4: parent (per-agent root) is
-  # now mode 2770 (was 2750) so the controller can mkdir subdirs as a
-  # group member; credentials/ keeps its 2750 + controller-owner so the
-  # isolated UID still cannot rename/remove the file inside.
+  # write/rm/mv anything inside it. Parent (per-agent root) is also
+  # mode 2750 root-owned, so the isolated UID has only group r-x at
+  # the root level — it cannot rmdir/rename `credentials/` either,
+  # even though it shares the agent group, because POSIX requires
+  # write on the *parent* directory to remove or rename an entry
+  # inside it. Controller writes that need to land under the
+  # per-agent root (e.g. `runtime/history.env`) go through the
+  # sudo-handoff path in lib/bridge-state.sh rather than relying on
+  # group-write at the root.
   local agent="$1"
   local root
   root="$(bridge_isolation_v2_agent_root "$agent")" || return 1

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1558,6 +1558,85 @@ bridge_dynamic_agent_ids() {
   done
 }
 
+bridge_state_v2_isolated_target() {
+  # v0.8.4 r2: predicate for "this controller-side write must land
+  # under the v2 per-agent root because the agent is linux-user
+  # isolated". Used by bridge_write_agent_state_file to pick between
+  # the direct-write fast path and the sudo-handoff slow path.
+  #
+  # The slow path is only required when:
+  #   - the host is Linux (no-op on macOS / mock hosts)
+  #   - isolation v2 is active for this install
+  #   - the target path lives under $BRIDGE_AGENT_ROOT_V2/<agent>/
+  #   - the agent is configured with linux-user isolation effectively
+  #     (BRIDGE_AGENT_ISOLATION_MODE[<agent>] resolves to linux-user)
+  # Anything else (shared-mode agent in a v2 install, dynamic agent
+  # whose env file lives under controller-owned state/agents/) keeps
+  # the direct-write fast path so non-isolated codepaths are
+  # unaffected.
+  local agent="$1"
+  local target="$2"
+
+  [[ -n "$agent" && -n "$target" ]] || return 1
+  [[ "$(bridge_host_platform 2>/dev/null || uname)" == "Linux" ]] || return 1
+  bridge_isolation_v2_active 2>/dev/null || return 1
+  [[ -n "$BRIDGE_AGENT_ROOT_V2" ]] || return 1
+  case "$target" in
+    "$BRIDGE_AGENT_ROOT_V2"/"$agent"/*) ;;
+    *) return 1 ;;
+  esac
+  bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null || return 1
+  return 0
+}
+
+bridge_state_sudo_install_v2_file() {
+  # v0.8.4 r2: stage `$content` into a controller-owned tempfile, then
+  # `bridge_linux_sudo_root install -m <mode> -o <owner> -g <group>`
+  # the staged file into the per-agent root. Mirrors the cross-UID
+  # write pattern PR #673 added in lib/bridge-hooks.sh
+  # (bridge_install_isolated_home_settings).
+  #
+  # This is the controller-side escape hatch for files whose final
+  # location is under $BRIDGE_AGENT_ROOT_V2/<agent>/ but whose author
+  # is the controller, not the isolated UID — runtime/history.env is
+  # the canonical example. The per-agent root mode 2750 (group r-x,
+  # no group write) prevents the controller — a group member but not
+  # the owner — from creating the parent dir or replacing the file
+  # via the direct path; sudo with the right `install` invocation
+  # bypasses that without weakening the root mode.
+  local target="$1"
+  local mode="$2"
+  local owner="$3"
+  local group="$4"
+  local content="$5"
+
+  [[ -n "$target" && -n "$mode" && -n "$owner" && -n "$group" ]] \
+    || return 2
+
+  local tmp=""
+  tmp="$(mktemp "${TMPDIR:-/tmp}/bridge-state-v2.XXXXXX")" || return 1
+  printf '%s' "$content" >"$tmp" || { rm -f "$tmp"; return 1; }
+
+  bridge_linux_sudo_root mkdir -p "$(dirname "$target")" 2>/dev/null || {
+    rm -f "$tmp"
+    return 1
+  }
+  if ! bridge_linux_sudo_root install -m "$mode" -o "$owner" -g "$group" "$tmp" "$target" 2>/dev/null; then
+    # Older `install` builds reject `-o`/`-g` even under sudo; fall back
+    # to plain install + chown.
+    if ! bridge_linux_sudo_root install -m "$mode" "$tmp" "$target" 2>/dev/null; then
+      rm -f "$tmp"
+      return 1
+    fi
+    bridge_linux_sudo_root chown "$owner:$group" "$target" 2>/dev/null || {
+      rm -f "$tmp"
+      return 1
+    }
+  fi
+  rm -f "$tmp"
+  return 0
+}
+
 bridge_write_agent_state_file() {
   local agent="$1"
   local file="$2"
@@ -1576,8 +1655,8 @@ bridge_write_agent_state_file() {
 
   BRIDGE_AGENT_UPDATED_AT["$agent"]="$updated_at"
 
-  mkdir -p "$(dirname "$file")"
-  cat >"$file" <<EOF
+  local content
+  content="$(cat <<EOF
 AGENT_ID=$(printf '%q' "$agent")
 AGENT_DESC=$(printf '%q' "$desc")
 AGENT_ENGINE=$(printf '%q' "$engine")
@@ -1590,6 +1669,31 @@ AGENT_HISTORY_KEY=$(printf '%q' "$history_key")
 AGENT_CREATED_AT=$(printf '%q' "$created_at")
 AGENT_UPDATED_AT=$(printf '%q' "$updated_at")
 EOF
+)"
+
+  # v0.8.4 r2: when the target lives under the v2 per-agent root and
+  # the agent is linux-user isolated, the controller — group member
+  # but not the owner of the 2750 root — cannot mkdir/replace the file
+  # directly. Route through the sudo-handoff helper. The file lands
+  # owned by the isolated UID with mode 0640 + group=ab-agent-<name>,
+  # matching what bridge_linux_prepare_agent_isolation seeds for
+  # history.env (touch + chown $os_user) so the isolated UID can
+  # read/rewrite it from inside its session and the controller can
+  # read it via group r--.
+  if bridge_state_v2_isolated_target "$agent" "$file"; then
+    local _v2_owner _v2_group
+    _v2_owner="$(bridge_agent_os_user "$agent" 2>/dev/null || true)"
+    _v2_group="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || true)"
+    if [[ -n "$_v2_owner" && -n "$_v2_group" ]] \
+        && bridge_state_sudo_install_v2_file \
+            "$file" 0640 "$_v2_owner" "$_v2_group" "$content"; then
+      return 0
+    fi
+    bridge_warn "bridge_write_agent_state_file: sudo-handoff write failed for $file (agent=$agent); falling back to direct write — expect Permission denied if the per-agent root is not writable to the controller"
+  fi
+
+  mkdir -p "$(dirname "$file")"
+  printf '%s' "$content" >"$file"
 }
 
 bridge_write_dynamic_agent_file() {


### PR DESCRIPTION
## Summary

Two related fixes for the v0.8.3 Linux isolation v2 regressions (refs #667):

### Long-name truncation

\`bridge_isolation_v2_agent_group_name\` (\`lib/bridge-isolation-v2.sh\`) on Linux:
- Was hard-rejecting any composed group name >32 chars (PR #658 only platform-branched, didn't truncate).
- Now deterministically hash-truncates: agent-name segment becomes \`<first-N-chars>-<7-char-sha256>\`. Hash is over the full untruncated name → two agents sharing the first N chars but differing later still get distinct group names.
- Darwin path unchanged (255-char tolerance).

\`bridge_linux_prepare_agent_isolation\` (\`lib/bridge-agents.sh\`) uses the same truncated group name + asserts the name passes composition before proceeding. Eliminates the asymmetry where \`agent create\` accepted names that died mid-create at group composition.

### Permission path (mode 2770)

Per-agent root mode goes from \`2750\` to \`2770\`. Reasoning:
- Controller is in the agent's group. With \`2750\` (group r-x, no group write), the controller couldn't \`mkdir runtime/\` or write \`runtime/history.env\` (lib/bridge-state.sh:1201) — Permission denied even on a fresh short-name isolated agent.
- With \`2770\` + setgid, both controller and isolated UID are group members and can write at the per-agent root.
- Trade-off: isolated UID can also write at the root. \`credentials/\` is protected by its own \`owner=controller + 2750\` subdir mode (group r-x, isolated UID cannot write inside) — preserves the original credentials isolation guarantee.

The 2770 docstrings in lib/bridge-isolation-v2.sh + lib/bridge-agents.sh + lib/bridge-isolation-v2-migrate.sh are updated to match.

## Verification

- \`bash -n bridge-agent.sh lib/bridge-agents.sh lib/bridge-isolation-v2-migrate.sh lib/bridge-isolation-v2.sh\` — pass
- \`shellcheck\` on the same set — pass
- \`./scripts/smoke-test.sh\` — pre-existing #665 gate on macOS host (same as \`main\`@3310008).

Cross-UID success path needs a Linux+sudo+isolated-agent VM verify (OrbStack agb-test or linux-systemd-test). That is the wave-end retest.

Out of scope: VERSION/CHANGELOG (release PR), Darwin 255-char policy (unchanged), v1→v2 migration plan logic.

## Refs
- refs #667