### PR TITLE
fix(isolation+status): scaffold sudo-handoff + status graceful partial-agent (refs #677 #681)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ version bumps via the `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **#677 isolated agent scaffold Permission denied on `agent create`** (`bridge-agent.sh::bridge_scaffold_agent_home`): scaffold now uses sudo-handoff (`bridge_linux_sudo_root mkdir/chown/chmod`) to pre-create the per-agent v2 root and `$home` with controller ownership when `bridge_agent_linux_user_isolation_effective` returns true, so the rest of the scaffold (template renders, mkdirs, chmods) runs as plain controller writes. `bridge_linux_prepare_agent_isolation` (which runs after scaffold) then normalizes ownership/mode to the canonical `root:ab-agent-<name> 2750` per-agent root + `<isolated>:ab-agent-<name> 2770` subdirs and `chown -R $os_user $workdir` transfers scaffolded contents to the isolated UID. Closes the front-line failure that PR #675 had scope-controlled out — fresh `agent create <name> --engine codex --isolate --os-user <u>` on Debian / Oracle Linux now completes rc=0 with no Permission denied. Mirrors PR #675's `bridge_state_sudo_install_v2_file` sudo-handoff pattern in `lib/bridge-state.sh`.
+- **#681 `agent-bridge status --all-agents` PermissionError crash on partial isolated agent state** (`bridge-status.py::pending_upgrade_conflict_count`): the `home.rglob("*.upgrade-conflict")` walk used by the dashboard's `pending upgrade-conflicts` warning line propagated the first `PermissionError` raised by an unreadable `data/agents/<broken-agent>/workdir/` subtree out of the function, crashing the entire status render. Replaced with an explicit `os.scandir` stack walk that catches `PermissionError`/`OSError` per directory: a single denied subtree is skipped, iteration continues, and operators retain dashboard observability of the partial-create state they need to triage. `backups/...` exclusion behavior preserved.
+
 ## [0.8.4] — 2026-05-07
 
 ### Highlight — closes 5 release-blocker regressions surfaced by v0.8.3 OrbStack VM E2E

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -402,6 +402,53 @@ bridge_scaffold_agent_home() {
   local rel=""
   local target=""
 
+  # v0.8.5 #677: when the agent will be linux-user isolated under v2,
+  # `$home` lives under `$BRIDGE_AGENT_ROOT_V2/<agent>/...`. The
+  # `agents/` ancestor is root-owned (mode 755) and a stale per-agent
+  # root from a prior failed `agent create` may already exist as
+  # root:ab-agent-<name> mode 2750 — neither gives the controller mkdir
+  # permission, so the plain `mkdir -p "$home"` below would fail with
+  # `Permission denied` and abort the scaffold before
+  # `bridge_linux_prepare_agent_isolation` (which normally lays this
+  # tree down via sudo) ever runs.
+  #
+  # Pre-create the per-agent root and `$home` via sudo with controller
+  # ownership so the rest of the scaffold (template renders, mkdirs,
+  # chmods) executes as plain controller writes. `bridge_linux_prepare_agent_isolation`
+  # runs after scaffold (bridge-agent.sh:2287) and normalizes
+  # ownership/mode to the canonical `root:ab-agent-<name> 2750` per-agent
+  # root + `<isolated>:ab-agent-<name> 2770` subdirs, then `chown -R
+  # $os_user $workdir` transfers the scaffolded contents to the
+  # isolated UID. Mirrors PR #675's `bridge_state_sudo_install_v2_file`
+  # sudo-handoff pattern in lib/bridge-state.sh.
+  if [[ -n "$home" ]] \
+      && command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null \
+      && command -v bridge_linux_sudo_root >/dev/null 2>&1; then
+    local _scaffold_v2_root=""
+    local _scaffold_controller=""
+    if command -v bridge_isolation_v2_agent_root >/dev/null 2>&1; then
+      _scaffold_v2_root="$(bridge_isolation_v2_agent_root "$agent" 2>/dev/null || printf '')"
+    fi
+    _scaffold_controller="$(bridge_current_user 2>/dev/null || id -un 2>/dev/null || printf '')"
+    if [[ -n "$_scaffold_v2_root" && -n "$_scaffold_controller" ]]; then
+      # Per-agent root: idempotent. If a prior failed run left it as
+      # root:ab-agent-<name> 2750, retake it as controller-owned 0755 so
+      # we (and any nested mkdirs) can write into it. Prepare will reset
+      # ownership/mode to the canonical contract.
+      bridge_linux_sudo_root mkdir -p "$_scaffold_v2_root" 2>/dev/null || true
+      bridge_linux_sudo_root chown "$_scaffold_controller" "$_scaffold_v2_root" 2>/dev/null || true
+      bridge_linux_sudo_root chmod 0755 "$_scaffold_v2_root" 2>/dev/null || true
+      # Scaffold target ($home is typically $_scaffold_v2_root/home but
+      # may be overridden via BRIDGE_AGENT_WORKDIR). Pre-create via sudo
+      # in case it lives under a path the controller cannot mkdir
+      # directly (same parent-owned-by-root problem as above).
+      bridge_linux_sudo_root mkdir -p "$home" 2>/dev/null || true
+      bridge_linux_sudo_root chown "$_scaffold_controller" "$home" 2>/dev/null || true
+      bridge_linux_sudo_root chmod 0755 "$home" 2>/dev/null || true
+    fi
+  fi
+
   mkdir -p "$home"
   [[ -d "$template_root" ]] || bridge_die "agent template root가 없습니다: $template_root"
   [[ -f "$session_template" ]] || bridge_die "session type template가 없습니다: $session_type"

--- a/bridge-status.py
+++ b/bridge-status.py
@@ -341,6 +341,15 @@ def pending_upgrade_conflict_count(bridge_home: str) -> int:
 
     Returns 0 if the path does not exist or is not a directory; the
     counter is purely additive on healthy hosts.
+
+    v0.8.5 #681: tolerate `PermissionError`/`OSError` raised mid-walk
+    when a partial isolated agent (e.g. broken `agent create
+    --isolate`) leaves a `data/agents/<agent>/workdir` subtree the
+    controller cannot read. Without this guard `Path.rglob` propagates
+    the first such EACCES out and crashes `agent-bridge status
+    --all-agents` — operators lose dashboard observability of the very
+    state they need to triage. We walk manually so a single denied
+    branch only excludes that subtree, not the whole count.
     """
     if not bridge_home:
         return 0
@@ -348,15 +357,45 @@ def pending_upgrade_conflict_count(bridge_home: str) -> int:
     if not home.is_dir():
         return 0
     count = 0
-    for path in home.rglob("*.upgrade-conflict"):
+    stack: list[Path] = [home]
+    while stack:
+        current = stack.pop()
         try:
-            rel = path.relative_to(home).as_posix()
-        except ValueError:
+            entries = list(os.scandir(current))
+        except (PermissionError, OSError):
+            # Partial isolated-agent state, missing dir, or any other
+            # filesystem drift. Skip this subtree only — keep counting.
             continue
-        if rel.startswith("backups/"):
-            continue
-        if path.is_file():
-            count += 1
+        for entry in entries:
+            try:
+                is_dir = entry.is_dir(follow_symlinks=False)
+            except OSError:
+                continue
+            if is_dir:
+                # Prune `backups/` at the BRIDGE_HOME root before
+                # descending — same exclusion the rglob/relative_to
+                # branch enforced previously.
+                try:
+                    rel = Path(entry.path).relative_to(home).as_posix()
+                except ValueError:
+                    rel = ""
+                if rel == "backups" or rel.startswith("backups/"):
+                    continue
+                stack.append(Path(entry.path))
+                continue
+            if entry.name.endswith(".upgrade-conflict"):
+                try:
+                    rel = Path(entry.path).relative_to(home).as_posix()
+                except ValueError:
+                    continue
+                if rel.startswith("backups/"):
+                    continue
+                try:
+                    is_file = entry.is_file(follow_symlinks=False)
+                except OSError:
+                    continue
+                if is_file:
+                    count += 1
     return count
 
 


### PR DESCRIPTION
## Summary

Two related v0.8.5 wave-2 Track 1 fixes that both touch the isolated-agent partial-state path surfaced by v0.8.4 OrbStack VM E2E retest (task #4195 Scenario A). Both crashes occur when an isolated `agent create --isolate --os-user ...` fails partway through and leaves on-disk state the controller can't fully read/write.

**Single-release contract**: `[Unreleased]` CHANGELOG entry only. **No VERSION bump.** Release cuts after all v0.8.5 wave-2 tracks pass OrbStack VM E2E.

## Per-issue fix

### #677 — `bridge_scaffold_agent_home` Permission denied for short-name isolated agents

- File: `bridge-agent.sh::bridge_scaffold_agent_home`
- Root cause: scaffold runs **before** `bridge_linux_prepare_agent_isolation` in `agent create`. On Linux, the `data/agents/` ancestor is root-owned mode 755, and a stale per-agent root left by a prior failed create sits at `root:ab-agent-<name>` mode 2750 — neither gives the controller mkdir permission, so the plain `mkdir -p "$home"` aborted the scaffold.
- Fix: prepend a sudo-handoff block at the top of `bridge_scaffold_agent_home`. When `bridge_agent_linux_user_isolation_effective "$agent"` returns true, `bridge_linux_sudo_root mkdir -p / chown <controller> / chmod 0755` the per-agent root and `$home` so the rest of the scaffold runs as plain controller writes. `bridge_linux_prepare_agent_isolation` (called after scaffold at `bridge-agent.sh:2287`) then normalizes ownership/mode to the canonical contract: `root:ab-agent-<name> 2750` per-agent root + `<isolated>:ab-agent-<name> 2770` subdirs, plus `chown -R $os_user $workdir` to transfer scaffolded contents to the isolated UID. Mirrors PR #675's `bridge_state_sudo_install_v2_file` sudo-handoff pattern.
- Macos / non-isolation no-op: gated on `command -v bridge_agent_linux_user_isolation_effective`, `bridge_agent_linux_user_isolation_effective` (which checks Linux + os_user set), and `command -v bridge_linux_sudo_root`. All-or-nothing best-effort; sudo failures don't break the call (the existing `mkdir -p` below still runs and returns its own error if the sudo handoff didn't help).

### #681 — `agent-bridge status --all-agents` PermissionError crash on partial isolated agent

- File: `bridge-status.py::pending_upgrade_conflict_count`
- Root cause: `home.rglob("*.upgrade-conflict")` raises `PermissionError` on the first unreadable `data/agents/<broken-agent>/workdir/` subtree it encounters, propagating out of the function and crashing the entire status render.
- Fix: replaced the rglob with an explicit `os.scandir` stack walk that catches `PermissionError`/`OSError` per directory. A single denied subtree is skipped; iteration continues to the rest of `BRIDGE_HOME`. `backups/...` exclusion behavior preserved (checked before descending and again before counting). Operators retain dashboard observability of the very partial-create state they need to triage.

## Out of scope (deferred per brief)

- `agent show <agent> --json` reporting `runtime_state: v2-active` for a broken create — separate bug, brief allows deferral.
- Restructuring `agent create` order beyond the minimal scaffold sudo-handoff.
- Doctor / migration / upgrade paths.

## Verification

```text
bash -n bridge-agent.sh                       OK
bash -n *.sh agent-bridge agb lib/*.sh ...    OK (all)
shellcheck bridge-agent.sh lib/bridge-state.sh OK (clean)
python3 -c "import ast; ast.parse(open('bridge-status.py').read())"  OK
./scripts/smoke-test.sh                       fails at the same pre-existing #680 macOS-host gate as `main` (compared against fresh `git clone main` — both exit=1 at `bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor (#428 r2)`). No new regression introduced by this branch.
```

Isolated functional test of the #681 fix on darwin host (mock unreadable subtree under a tempdir BRIDGE_HOME):

```python
# pending_upgrade_conflict_count(tmp) with:
#   tmp/state/foo.upgrade-conflict          (counted: 1)
#   tmp/backups/old.upgrade-conflict        (excluded: 0)
#   tmp/data/agents/broken/workdir/         (chmod 000 → unreadable; should be skipped)
#   tmp/data/agents/broken/workdir/shadow.upgrade-conflict (would count if walked, but parent denies)
# Result: count=1 (no crash). Confirmed.
```

## Linux + sudo verify (deferred to wave-end OrbStack retest)

`bridge_linux_sudo_root` is a no-op on Darwin (falls through to direct invocation per its existing guard), so the #677 sudo-handoff path can only be exercised end-to-end on Linux + isolated VM. Wave orchestrator will run the OrbStack VM E2E (Debian 12 + Oracle 9.7) before the v0.8.5 release cut. Acceptance: fresh `agent-bridge agent create freshshort --engine codex --isolate --os-user abshortu --json` rc=0, no `Permission denied` at any step, post-create `status --all-agents` rc=0.

Refs #677 #681