### PR TITLE
fix(init): bridge-init.sh first-run rc=1 regression on fresh install (refs #680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ version bumps via the `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **#680 `bridge-init.sh` first-run on fresh install exited rc=1 with empty log** (`bridge-agent.sh::run_create`): on a fresh v2 install, `agent create` invoked `bridge-start.sh <agent> --dry-run` purely as informational diagnostic capture, but `bridge_agent_workdir` resolves to `<agent-root>/workdir/` while `bridge_scaffold_agent_home` materializes `<agent-root>/home/` — the dry-run failed `workdir가 없습니다`, command-substitution propagated rc=1 to `set -e`, and `agent create` aborted silently before printing anything. `bridge-init.sh` redirected create's stdout to `/dev/null`, leaving operators with rc=1 + empty log on first-run init while the rerun (which short-circuits via `bridge_agent_exists`) succeeded. The dry-run capture now tolerates non-zero rc and surfaces the actual rc through the printed `start_dry_run:` field; first-run `bridge-init.sh` exits rc=0 on a clean home, idempotent rerun preserved, the underlying scaffold-vs-resolver mismatch remains visible in the create output for follow-up. (refs #680)
+
 ## [0.8.4] — 2026-05-07
 
 ### Highlight — closes 5 release-blocker regressions surfaced by v0.8.3 OrbStack VM E2E

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1986,6 +1986,7 @@ run_create() {
   local users_json=""
   local default_home=""
   local start_dry_run=""
+  local start_dry_run_status="ok"
   # Issue #598 Track 4: opt-in for test-artifact-prefix names.
   local test_fixture=0
 
@@ -2286,7 +2287,21 @@ report and reap test-fixture agents per their pattern."
     if [[ "$isolation_mode" == "linux-user" ]]; then
       bridge_linux_prepare_agent_isolation "$agent" "$os_user" "$workdir"
     fi
-    start_dry_run="$("$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" --dry-run 2>&1)"
+    # Issue #680: bridge-start.sh --dry-run is purely informational here — its
+    # output is reprinted to the user as `start_dry_run:` for diagnostic
+    # context. Letting its rc propagate via command-substitution + set -e
+    # silently aborts agent-create whenever dry-run reports a non-fatal
+    # warning (e.g. v2 fresh-install where the workdir path resolver expects
+    # `<agent-root>/workdir/` but bridge_scaffold_agent_home materializes
+    # `<agent-root>/home/`). Capture rc separately and surface a clear
+    # status field so a real first-run init no longer exits rc=1 with an
+    # empty log; the underlying scaffold-vs-resolver mismatch remains visible
+    # in the printed start_dry_run output for follow-up.
+    if start_dry_run="$("$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" --dry-run 2>&1)"; then
+      start_dry_run_status="ok"
+    else
+      start_dry_run_status="warn (rc=$?)"
+    fi
   fi
 
   if [[ $json_mode -eq 1 ]]; then
@@ -2319,7 +2334,7 @@ report and reap test-fixture agents per their pattern."
     echo "dry_run: yes"
   else
     echo "create: ok"
-    echo "start_dry_run: ok"
+    echo "start_dry_run: $start_dry_run_status"
     echo "$start_dry_run"
     echo "next_steps:"
     echo "  - agent-bridge setup agent $agent"


### PR DESCRIPTION
## Summary

- Wave-2 Track 2 fix for #680 — `bridge-init.sh` first-run on fresh install exited rc=1 with empty log; rerun returned rc=0.
- Root cause: `agent create` (invoked by `bridge-init.sh`) captures `bridge-start.sh <agent> --dry-run` purely for diagnostic output. On a v2 fresh install the dry-run fails `workdir가 없습니다` because `bridge_agent_workdir` resolves to `<agent-root>/workdir/` while `bridge_scaffold_agent_home` materializes `<agent-root>/home/`. Command-substitution propagated rc=1 → `set -e` → silent abort before any output. `bridge-init.sh` redirected create's stdout to `/dev/null`, leaving operators with rc=1 + empty log on first-run. The rerun "succeeded" only because `bridge_agent_exists` short-circuits the create branch on second pass, so the failing dry-run was never reached.
- Smallest fix at the failure point in `bridge-agent.sh::run_create`: capture the dry-run rc into a local status flag, fall through on non-zero, and surface the actual rc through the printed `start_dry_run:` field. First-run init now exits rc=0 on a clean home; idempotent rerun preserved; the underlying v2 scaffold-vs-resolver path mismatch stays visible in the create output for follow-up triage.

## Files changed

- `bridge-agent.sh` — `run_create` no longer aborts on `bridge-start.sh --dry-run` non-zero rc; surfaces `start_dry_run: warn (rc=N)` instead of `start_dry_run: ok`.
- `CHANGELOG.md` — `[Unreleased] / Fixed` entry.

## Verification

- `bash -n bridge-agent.sh`: pass
- `shellcheck bridge-agent.sh`: clean
- `./scripts/smoke-test.sh`: pre-existing macOS host gate (same on `main` at ff3ee1e, unchanged by this PR)
- Manual probe (matches issue repro):
  ```bash
  rm -rf /tmp/wave2-init-probe
  BRIDGE_HOME=/tmp/wave2-init-probe bash ./bridge-init.sh --admin admin --engine codex --skip-channel-setup
  echo "INIT_RC=$?"   # 0 (was 1)
  BRIDGE_HOME=/tmp/wave2-init-probe bash ./bridge-init.sh --admin admin --engine codex --skip-channel-setup
  echo "INIT_RERUN_RC=$?"   # 0 (unchanged)
  ```

  Direct `agent create` call shows the new diagnostic surface:
  ```
  create: ok
  start_dry_run: warn (rc=1)
  [오류] workdir가 없습니다: /tmp/.../data/agents/admin/workdir
  ```
  Operator now sees `warn (rc=1)` + the underlying error — the v2 home/workdir mismatch is no longer hidden behind an empty log.
- `--json` and `--dry-run` paths: pass (verified manually).

## Reviewer hints

- The deeper v2 layout issue (scaffold materializes `/home`, runtime resolver returns `/workdir`) is left intact per brief out-of-scope: `bridge_agent_default_home` (`agents/<agent>/home`) and `bridge_agent_workdir` (`agents/<agent>/workdir`) intentionally diverge, so the v2 scaffold path needs a follow-up to either materialize both directories or align the scaffold target. That belongs in v0.8.5+ as its own track — this PR only stops the silent rc=1 abort and surfaces the underlying state to the operator.
- No VERSION bump (single-release contract). `[Unreleased]` only.
- No close-keywords — issue closure is a release-time decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)