### PR TITLE
feat(skills): bundle wave-orchestration in upstream + auto-distribute via shared-skill bootstrap

### DIFF
--- a/.claude/skills/wave-orchestration/SKILL.md
+++ b/.claude/skills/wave-orchestration/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: wave-orchestration
+description: Ship multiple GitHub issues or tracks **in parallel** as 2-4-PR waves. Use whenever the user has multiple open issues/PRs to process, mentions "wave", "Track A/B/C/D", "parallel fixer", "ship these issues", asks to dispatch issue-fix agents, wants codex code review on a complex PR, or describes a backlog they want batched into focused PRs rather than one bundled change. **Parallelism is the default, not the exception** — independent fixers are dispatched in one message with multiple Agent tool calls so they fan out via run_in_background. Captures the field-tested orchestration pattern (brief writing → issue-fixer dispatch into isolated worktrees → codex-rescue review for >300-LOC specialized work or direct orchestrator review for mid-size → squash-merge with structured notes) that has landed 15+ PRs per session with zero regressions on the Agent Bridge repo. Bundles a project-agnostic `issue-fixer` agent and a `general-purpose` fallback dispatch shape so the workflow is portable across Claude Code installs. Includes a catalog of 8 high-cost footguns the orchestrator should never re-trip.
+---
+
+# Wave orchestration — parallel issue/PR ships
+
+## When to use this skill
+
+Use when:
+- You have **2+ independent issues** open and the user wants them processed in parallel
+- An issue is split into **Tracks A/B/C/D** and each track is potentially its own PR
+- A PR is **>300 LOC + specialized domain** (Linux ACL, daemon scheduler, security primitives, etc.) and needs codex review for a second opinion
+- A PR sits on a **third-party fork** (different `gh` user) and you need to push fix commits to that branch from your own session
+- The user says "process the backlog", "ship these issues", "dispatch fixers", "wave 1/2/3", "Track A of #N", "needs-more on PR #N", or describes a set of GitHub issues they want batched without bundling into one mega-PR
+
+Do NOT use when:
+- A single small one-off bug fix → just edit and PR directly
+- Architectural design discussion that needs the human → brainstorm first, do not dispatch
+- Refactor with >5 file moves and ambiguous scope → write a plan first, get user signoff, *then* maybe dispatch
+- The work fits comfortably in 50 LOC and the user is online to review interactively
+
+## Why this pattern exists
+
+Sequential long-lived reviewer agents (one Codex session that reviews every PR back-to-back) accumulate ~3 review rounds per PR and ~150 minutes per 5 PRs. Replacing that with **wave-sized ephemeral fixers + targeted codex-rescue review** drops to ~25 minutes per wave with zero regressions across waves. The win is that each wave is small enough to land r1 `implement-ok` 90%+ of the time, and parallel dispatch hides the per-fixer wall time behind whatever the orchestrator is doing next.
+
+## Core pattern
+
+```dot
+digraph wave {
+  read_issue [shape=box label="1. Read issue thoroughly\n  - gh issue view\n  - identify Tracks\n  - find files via grep, not the issue body"];
+  write_brief [shape=box label="2. Write brief at /tmp/<topic>-fixer.md\n  - 11 sections (see references/brief-template.md)\n  - include footgun callouts"];
+  dispatch [shape=box label="3. Dispatch fixer\n  - subagent_type: upstream-issue-fixer\n  - isolation: worktree\n  - run_in_background: true"];
+  decide_review [shape=diamond label="PR size?"];
+  codex_review [shape=box label="codex-rescue review\n(big or specialized)"];
+  direct_review [shape=box label="orchestrator-direct review\n(mid-size, ~45-400 LOC)"];
+  squash [shape=box label="4. Squash merge\n  - implement-ok note\n  - cleanup branch + worktree"];
+  comment [shape=box label="5. Comment on issue + close if all tracks done"];
+
+  read_issue -> write_brief -> dispatch -> decide_review;
+  decide_review -> codex_review [label=">300 LOC + specialized"];
+  decide_review -> direct_review [label="mid-size"];
+  codex_review -> squash;
+  direct_review -> squash;
+  squash -> comment;
+}
+```
+
+## Step 1 — Read the issue thoroughly
+
+```bash
+gh issue view <N> --json title,body --jq '"# \(.title)\n\n\(.body)"'
+```
+
+Identify:
+- **Track structure** (A/B/C/D? landing in one PR or split into multiple waves?)
+- **Concrete files to touch** — verify by grepping the actual repo (`find` / `rg`); the issue body sometimes refers to files that don't exist or have moved
+- **Out-of-scope items** the brief must explicitly forbid (over-scoping is the #1 reason r2 review rounds happen)
+- **File overlap with other open PRs** — if two waves would both touch `lib/foo.sh`, serialize them
+
+Don't skip this step. A brief written from a misread issue wastes the entire fixer dispatch.
+
+## Step 2 — Write the brief
+
+Briefs go to `/tmp/<topic>-fixer.md` and run ~150-300 lines. The full template is in `references/brief-template.md`. Required sections in order:
+
+1. Repo / branch / scope
+2. Read first (do not skip)
+3. What to change (per-file recipe)
+4. Out of scope (do NOT do)
+5. Verification (exact bash commands the fixer must run)
+6. CI status (note pre-existing failures so the fixer doesn't waste time on them)
+7. PR opening (title, body shape, auth switch, `--no-maintainer-edit`)
+8. CRITICAL — close-keyword footgun warning (see `references/footguns.md`)
+9. Stop point (where to halt, what to return)
+10. Reminders (worktree-relative paths, single commit, no VERSION/CHANGELOG)
+11. Output (JSON schema)
+
+The brief is the contract. Vague briefs produce r2 rounds. Concrete briefs land r1.
+
+## Step 3 — Dispatch the fixer
+
+This skill bundles a project-agnostic `issue-fixer` agent at `agents/issue-fixer.md`. It is **not auto-installed** — Claude Code does not pick up skill-bundled agents into the main `Agent` tool's `subagent_type` field by default.
+
+### Install the bundled agent (one-time)
+
+```bash
+# user-level install — available across all your Claude Code sessions
+mkdir -p ~/.claude/agents
+cp ~/.claude/skills/wave-orchestration/agents/issue-fixer.md ~/.claude/agents/issue-fixer.md
+```
+
+After this, `subagent_type: "issue-fixer"` is available.
+
+### Dispatch (preferred — when the bundled agent is installed)
+
+```javascript
+Agent({
+  description: "Wave N: <issue> Track <X>",
+  subagent_type: "issue-fixer",
+  prompt: <self-contained-prompt-pointing-at-brief-file>,
+  isolation: "worktree",
+  run_in_background: true
+})
+```
+
+### Fallback dispatch (when the bundled agent is NOT installed)
+
+`general-purpose` works as a substitute when paired with a sufficiently detailed brief. The brief must do more lifting because `general-purpose` has no built-in single-issue contract:
+
+```javascript
+Agent({
+  description: "Wave N: <issue> Track <X>",
+  subagent_type: "general-purpose",
+  prompt: `You are dispatched as a single-issue fixer. Read the brief in full first: /tmp/<topic>-fixer.md
+The brief specifies: repo, issue number, branch, files to edit, verification matrix, JSON return schema, footgun callouts.
+Work autonomously per the brief. Stop at commit (or PR open per brief). Return the JSON schema the brief specifies.
+
+Critical conventions the brief reinforces:
+- Worktree-relative paths only (never absolute paths into operator's primary checkout)
+- Smallest focused edit; don't refactor adjacent code
+- Don't write \`closes #<N>\` in commit subject or PR title — GitHub's close-keyword regex is greedy
+- Single commit, no VERSION/CHANGELOG bump unless the brief explicitly asks
+- Verify before committing per the brief's matrix; failed verification → don't commit, return failure with evidence`,
+  isolation: "worktree",
+  run_in_background: true
+})
+```
+
+Either way, critical flags:
+- `isolation: "worktree"` — fixer runs in an isolated git worktree at `<repo>/.claude/worktrees/agent-<hash>/`. Without this, the fixer can mutate your primary checkout. **This is footgun #1.**
+- `run_in_background: true` — main session continues while fixer works; you get a notification on completion. Do not block.
+- The `prompt` field is a **brief overview**, not the brief itself. Refer to `/tmp/<topic>-fixer.md`. Keep dispatch prompts under 50 lines.
+
+### Project-specific fixer (when you have one)
+
+Some repos ship their own specialized fixer (e.g., Agent Bridge has `upstream-issue-fixer` with hardcoded `BRIDGE_HOME` / smoke conventions). When operating on a repo with a specialized fixer, use that instead — it has built-in awareness of the project's verification matrix and won't need the brief to spell out as much. The bundled `issue-fixer` is the **portable default** for repos without a dedicated agent.
+
+## Step 4 — Review
+
+### Reviewer selection — DEFAULT IS codex-rescue PAIR-REVIEW
+
+**Pair-review every non-trivial PR.** Default reviewer is `codex-rescue` (or whichever pair-reviewer the project's `AGENTS.md` / contributing docs designate, e.g., `agb-dev-codex-2` on Agent Bridge). Merge **only after** the reviewer's note opens with `implement-ok`. This is the project-level rule on most repos that ship an `AGENTS.md`; it overrides the orchestrator's preference.
+
+| PR size / scenario | Reviewer | Notes |
+|---|---|---|
+| Any non-trivial PR (>~10 LOC, any domain) | **codex-rescue** | Default. Always pair-review unless project docs explicitly authorize direct review. |
+| Trivial mechanical revert / typo fix / single-line doc change | direct OK | Operator can usually verify by eye; codex-rescue overhead is wasted. State the rationale in the merge note. |
+| Operator explicitly orders direct review for this PR | direct | Annotate the merge note with "operator-directed direct review" and the reason. |
+| author = fork | post review as PR comment, then iterate via author or push fixes from fork account | Cross-fork PRs use the same pair-review contract. |
+
+**Why the rule is `codex-rescue first`**:
+1. Most projects with multi-agent contributors (the kind of repo this skill targets) have an `AGENTS.md` rule like "Pair-review every non-trivial PR. Merge only after implement-ok." That rule **overrides** the orchestrator's "direct review for <300 LOC mid-size" instinct.
+2. Direct review by the orchestrator is high-trust but single-actor. Pair-review with codex-rescue catches semantic bugs (missing reschedule, leaked secrets, broken finalize paths) that orchestrator review under context pressure misses.
+3. Operator-directed reverts of "merged without pair-review" PRs cost more time than the pair-review would have. Real instance: 2026-04-26 — three PRs reverted because the orchestrator skipped codex review citing the (then-existing) <300 LOC carve-out. Don't be that orchestrator.
+
+**Do not invent carve-outs**. If you find yourself rationalizing "this is small enough to skip review", check the project's `AGENTS.md` first. If the rule says "every non-trivial PR", skip is allowed only for the trivial-mechanical category in the table above.
+
+### codex-rescue dispatch — must include the wait-for-completion line
+
+```javascript
+Agent({
+  description: "Codex review of <PR>",
+  subagent_type: "codex:codex-rescue",
+  prompt: `... brief + diff path + PR body + checklist ...
+
+Wait for completion in your final assistant message. Do not return a thread id and exit.`,
+  run_in_background: true
+})
+```
+
+If you omit "Wait for completion in your final assistant message", codex-rescue is async-default and returns an empty thread id, which is useless. **This is footgun #8 — every other dispatch hits it.**
+
+Before dispatching codex-rescue, verify codex is set up:
+
+```bash
+codex --version 2>/dev/null && command -v codex   # confirm codex CLI is installed and on PATH
+```
+
+If `codex` is not on the agent's PATH (homebrew installs to `/opt/homebrew/bin` on macOS, `/usr/local/bin` on Linux), the fixer may incorrectly report "Codex CLI is not installed" — re-dispatch with explicit `PATH` guidance, or invoke codex directly via its absolute path.
+
+### Direct review for mid-size PRs
+
+```bash
+gh pr diff <N>
+```
+
+Verify:
+- Every brief acceptance criterion is met
+- No unintended files were touched (worktree path footgun)
+- VERSION/CHANGELOG untouched (release contract)
+- Verification commands in the brief actually pass
+
+If satisfied, squash merge with a structured note (see Step 5).
+
+### Pair-review loop for `needs-more`
+
+If the reviewer returns `needs-more: ...`:
+1. Post the review verbatim as a PR comment.
+2. Write `/tmp/<topic>-r2-fixer.md` listing each finding with **file:line** citation and a concrete fix recipe — do not paraphrase.
+3. Dispatch a fresh fixer (not the same one) with the r2 brief.
+4. After 3 rounds without `implement-ok`, **stop and reconsider scope**. Often the PR is too big or the spec is ambiguous; split it.
+
+## Step 5 — Squash merge with structured note
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+implement-ok
+
+<reviewer-context: direct or codex-rescue>
+
+Verified:
+- <acceptance criterion 1>
+- <acceptance criterion 2>
+- ...
+- No VERSION bump, no CHANGELOG entry — release contract preserved
+- Single commit, <N> file(s)
+- PR title uses '(#<N> Track X)' — close-keyword footgun avoided
+
+<issue-stays-open-or-closes context>
+
+Approved.
+EOF
+)"
+```
+
+The `implement-ok` opener is the convention — reviewer agents and human reviewers both grep for it. Always start with that literal string.
+
+After merge:
+
+```bash
+git -C <repo> pull --ff-only origin main
+git -C <repo> worktree remove -f -f <repo>/.claude/worktrees/agent-<hash>
+gh api -X DELETE /repos/<owner>/<repo>/git/refs/heads/<branch>
+```
+
+`gh pr merge --delete-branch` fails when local main is checked out in a worktree (`fatal: 'main' is already used by worktree`). Skip the `--delete-branch` flag and use the `gh api` call to delete the remote ref directly.
+
+## Step 6 — Comment on the issue
+
+If the PR closes the issue, GitHub auto-closes via the `closes #N` keyword (see footgun #2 — be careful). Otherwise, comment on the issue summarizing what landed and which tracks remain:
+
+```bash
+gh issue comment <N> --body "Track X landed in PR #<M> (\`<short-sha>\`).
+
+<one-paragraph what-changed>
+
+Tracks Y, Z remain open. Closing once those are addressed or explicitly deferred."
+```
+
+When all tracks land:
+
+```bash
+gh issue close <N> --comment "All tracks landed. ..."
+```
+
+## Footgun catalog
+
+8 footguns have all bitten me. Each has cost a session's worth of recovery. **Read `references/footguns.md` before dispatching; have it open while reviewing PRs.**
+
+Quick summary:
+1. Worktree path leakage (absolute paths in brief)
+2. GitHub close-keyword regex (`closes #283 Track B` → closes #283)
+3. `gh auth` account mismatch (cross-fork PR fails on wrong account)
+4. VERSION/CHANGELOG bleeding into feature PRs
+5. macOS Bash 3.2 vs Bash 4+ (`source bridge-lib.sh` vs `source ./bridge-lib.sh`)
+6. Committed source vs heredoc-generated content (brief targets wrong file)
+7. Cross-fork PR push from fork account (not new branch)
+8. codex-rescue async-default (missing wait-for-completion line)
+
+## Wave size — parallelism is the default, not the exception
+
+**Always parallelize independent fixers.** A single sequential fixer chain is a wasted hour every time. The default mental model: scan the open backlog, identify which items have non-overlapping file surfaces, write a brief per item, and dispatch them all in **one message with multiple Agent tool calls** (the tool runtime fans out only when the calls are in the same response — sequential dispatch in successive turns serializes them).
+
+### Sizing rules
+
+- **Sweet spot: 2-4 fixers per wave.** Each fixer is in its own `isolation: "worktree"`, so no shared state. Larger waves (5+) hit your own context-budget pressure when reviewing returns; if you have more independent work than that, dispatch the second batch as soon as the first batch's reviews start landing.
+- **Same-file conflicts force serial execution.** Before dispatching, list each fixer's expected file touches and check for overlaps. Two fixers writing to the same `lib/foo.sh` will both succeed individually but the second-merging PR has to rebase. Acceptable for unrelated functions in a long file (just rebase at merge); not acceptable for the same function or block.
+- **One brief per fixer at `/tmp/<topic>-fixer.md`.** Briefs are written and saved before any dispatch. The dispatch prompt is a 30-50 line overview pointing at the brief; the fixer reads the brief on first turn.
+
+### Dispatch idiom (ONE message, multiple Agent calls)
+
+```javascript
+// All three of these go in a SINGLE assistant turn.
+// Sending them across three separate turns would serialize them.
+Agent({ description: "Wave: #A", subagent_type: "issue-fixer", prompt: <points-at-/tmp/A-fixer.md>, isolation: "worktree", run_in_background: true })
+Agent({ description: "Wave: #B", subagent_type: "issue-fixer", prompt: <points-at-/tmp/B-fixer.md>, isolation: "worktree", run_in_background: true })
+Agent({ description: "Wave: #C", subagent_type: "issue-fixer", prompt: <points-at-/tmp/C-fixer.md>, isolation: "worktree", run_in_background: true })
+```
+
+The orchestrator can also have a fixer running while it dispatches *new* fixers in subsequent turns — the parallelism comes from `run_in_background: true`, not from same-message dispatch alone. But same-message dispatch is the cleanest signal of intent and avoids accidental serialization when you're triaging multiple briefs at once.
+
+### What's safe to parallelize
+
+| Scenario | Parallel? | Notes |
+|---|---|---|
+| Two fixers touching wholly disjoint files | yes | The default safe case |
+| Two fixers touching different functions in the same file | yes | Worktree isolation handles it; merge order may need rebase |
+| Two fixers touching the same function | no | Serialize; the second waits for the first to merge so its base is current |
+| Docs PR + code PR in the same area | yes | Different surfaces; review independently |
+| Fixer + codex-rescue review of an existing PR | yes | Different actors; codex review doesn't write to the worktree |
+| 3+ fixers all touching `lib/bridge-core.sh` | partial | Fan out 2 max with the explicit acknowledgement that the third will rebase; consider whether some can be combined into one fixer |
+
+### Backlog scan pattern
+
+When the user says "process the backlog" or "do the next wave":
+
+1. `gh issue list --state open --limit 30` and `gh pr list --state open --limit 10`
+2. Triage by **scope** (small/mid/large) and **surface** (which files each touches)
+3. Bucket into waves — pack 2-4 small/mid items with disjoint surfaces into the next wave
+4. Defer any item that requires user input (design discussion, breaking-change confirmation, brainstorm)
+5. Defer any item that requires a reproducer the host can't run (e.g., `linux-user` isolation tests on macOS)
+6. Write all briefs first, then **dispatch the whole batch in one message**
+
+### After a wave
+
+- Pause to: verify all PRs landed, run cross-PR regression checks if any pair touched related areas
+- Order squash-merges if there are file-overlap conflicts (smaller / earlier-completing PR first; the second rebases against current main)
+- Update memory if patterns shifted (new footgun, new tooling, new naming convention)
+
+## Verification before completion (every PR)
+
+Don't claim "done" without:
+- `bash -n` on every touched `.sh` file
+- `shellcheck` on every touched `.sh` file (warnings OK; errors not OK)
+- `python3 -c "import ast; ast.parse(open('<file>').read())"` on every touched `.py` file
+- Live test of any new helper function via fresh bash + source `./bridge-lib.sh` (note the `./`)
+- `git diff --cached --stat` before commit — confirm only the intended files are staged
+- `gh pr diff <N>` after PR open — confirm fixer didn't touch unintended files (worktree path footgun)
+
+## Reference files
+
+- `references/brief-template.md` — fully worked brief template with section-by-section rationale
+- `references/footguns.md` — all 8 footguns with reproduction, root cause, and fix instructions
+- `references/recipes.md` — concrete recipes: cross-fork push, codex setup verification, worktree cleanup, releasing PR conventions
+- `references/wave-examples.md` — 4 worked waves from the Agent Bridge repo (#306 docs, #311 fixture cleanup, #313 generator, PR #302 r2)
+
+## Bundled agent
+
+- `agents/issue-fixer.md` — project-agnostic single-issue fixer. **Not auto-installed.** Copy to `~/.claude/agents/issue-fixer.md` for user-level install, or to `<repo>/.claude/agents/issue-fixer.md` for repo-level install, to make `subagent_type: "issue-fixer"` available. Fall back to `general-purpose` per Step 3 above when neither install is present.
+
+Agents created via `agent-bridge` (the Agent Bridge multi-agent orchestrator) inherit the repo's `.claude/skills/` and `.claude/agents/` automatically, so when this skill ships in the Agent Bridge upstream every dynamic / static agent picks it up on next bootstrap. No manual copy step required for those agents.
+
+## Agent Bridge integration
+
+When the orchestrator is itself an Agent Bridge agent (claude or codex), there are two distinct dispatch surfaces:
+
+1. **Agent tool dispatch** (claude only) — what this skill describes throughout. `Agent({ subagent_type: "issue-fixer", isolation: "worktree", run_in_background: true })` spawns an ephemeral subagent in an isolated git worktree. Best for parallel waves of independent fixers.
+2. **Bridge queue dispatch** (claude + codex) — `bash bridge-task.sh create --from <self> --to <peer-agent> --title "..." --body-file /tmp/<topic>-fixer.md` enqueues work for a long-lived peer (e.g., the codex pair partner). Best for cross-engine collaboration where the queue's persistence + audit trail matter, and for codex agents that don't have the `Agent` tool.
+
+Both surfaces are compatible with the same brief format. The dispatching brief is the contract; the surface is just how the brief reaches the executor.
+
+For codex-rescue review specifically (Step 4), claude orchestrators use `Agent({ subagent_type: "codex:codex-rescue", run_in_background: true })`. Codex orchestrators delegate review to their claude pair via the bridge queue (`bridge-task.sh create --to <claude-pair> --title "[review PR #N]"`).
+
+Read these on demand; the SKILL.md above is the orchestration spine and should stay under 300 lines.

--- a/.claude/skills/wave-orchestration/agents/issue-fixer.md
+++ b/.claude/skills/wave-orchestration/agents/issue-fixer.md
@@ -1,0 +1,124 @@
+---
+name: issue-fixer
+description: Use this agent when fixing a single GitHub issue (or a single track of an issue) end-to-end through commit. Dispatch one agent per issue/track. The agent reads the issue via `gh`, orients itself from the project's documented entry-point files (described in the dispatching brief), applies a minimal focused edit, runs the verification matrix the brief specifies, and commits on a feature branch named per the brief. Returns a structured JSON report so the orchestrator can review, push, and open the PR. Use this instead of doing the whole fix in the main thread when the work is well-scoped, the dispatching brief is detailed, and the orchestrator wants parallelism.
+model: opus
+---
+
+You are a focused contributor patching a single GitHub issue (or a single track of one) per the dispatching brief. You own one fix end-to-end up to the commit; the orchestrator may push and open the PR, or the brief may instruct you to push to an existing PR branch on a fork.
+
+**This agent is project-agnostic.** Project specifics — repo name, default branch, doc-set to read on orient, verification matrix, test fixture conventions — come from the dispatching brief, not from this agent definition. If the brief is missing critical context, stop and report rather than guess.
+
+## Core role
+
+- Read the issue with `gh issue view <N> --repo <owner>/<repo>` and extract: symptom, root cause, suggested fix, reproduction, references.
+- Read the project doc set the brief names. If the brief says "skim ARCHITECTURE.md and docs/handover.md", do that. If the brief says nothing, default to `README.md`, `AGENTS.md`, and any `CLAUDE.md` at the repo root — but rely on the brief's reading list as authoritative.
+- Apply the **smallest** focused edit that closes the issue (or the track of it the brief scopes). Don't refactor adjacent code. Don't add defensive guards for conditions that can't happen. Don't add comments that restate what well-named code already does.
+- Verify with whatever subset of the brief's verification matrix actually exercises the change.
+- Commit on the feature branch the brief names. One issue (or track) per branch.
+
+## Working principles
+
+- **Source checkout vs live runtime**: if the project distinguishes between a source checkout and a live runtime install (Agent Bridge does; many projects don't), the brief will name the runtime path that must NOT be touched. Default rule: never edit anything under `~/.<projectname>/` or other operator-managed runtime directories. Tests that need a runtime use a `mktemp -d` working directory.
+- **Tracked source stays machine-agnostic.** No private team names, channel IDs, tokens, real operator emails, or absolute machine paths in tracked files.
+- **Trust the suggested fix when it exists, but verify.** Issues usually carry a "Suggested Fix" section that names the file and the shape of the change. Confirm it still matches the current code before applying it; if the code has drifted, update the plan and note the drift in your report.
+- **Respect pre-existing working-tree changes.** Never `git stash drop`, `git reset --hard`, or overwrite other in-flight edits without explicit orchestrator instruction.
+- **Worktree-relative paths only** when running in `isolation: "worktree"` mode. Never write to absolute paths into the operator's primary checkout — that is the most common footgun in this workflow.
+
+## Input contract (from orchestrator)
+
+The dispatching brief should provide at minimum:
+- `repo`: the GitHub `<owner>/<repo>` to operate against
+- `issue`: the issue number (required), or the PR number when patching a sitting PR
+- `base_branch`: default `main`
+- `branch_name`: the feature branch to create (or, for PR-patching, the existing PR branch)
+- `verification_matrix`: explicit commands the brief expects you to run before committing
+- `auth_account` (optional): the gh account to switch to before any `gh pr create` or `git push`
+- `out_of_scope`: explicit deny-list of files/concepts NOT to touch
+- `output_schema`: the JSON shape the brief expects you to return (default: `files_changed`, `checks_run`, `acceptance_met`, `blockers`, `user_review_needed`, `user_message`)
+
+If the brief is missing any of these and you can't infer safely, **stop and ask** rather than guess.
+
+## Workflow
+
+1. **Orient.**
+   - `git branch --show-current`, `git status --short`. If working tree is dirty with changes unrelated to this issue, stop and ask.
+   - `git checkout <base_branch>` only if the current branch is clean or the dirt belongs on this base.
+   - Read the doc set the brief names. Skim sections relevant to the issue area.
+
+2. **Read the issue.**
+   - `gh issue view <N>` — note suggested fix file/line refs.
+   - If the issue references related issues (e.g., companion #XX), at least read their titles to avoid scope collisions.
+
+3. **Locate code.**
+   - Use `Grep` / `Read` to verify the suggested fix still maps to the current source. If not, investigate with `git log -p <file>` to find where it moved.
+
+4. **Plan.**
+   - Mentally list: files to edit, the concrete change in each, and what to verify.
+   - If the plan would require editing more than ~3 files or >150 lines, stop and tell the orchestrator the issue exceeds "small-fix" scope.
+
+5. **Branch.**
+   - `git checkout -b <branch_name>` (the brief names the branch). Slug should be kebab-case if the brief leaves it to you.
+
+6. **Edit.**
+   - Use `Edit` / `Write` (prefer `Edit` for existing files). Smallest change that closes the issue.
+   - **Worktree footgun**: when running in `isolation: "worktree"` mode, all edits must use **relative paths** from your worktree root. Never write absolute paths into the operator's primary checkout.
+
+7. **Verify** (pick the subset of the brief's matrix that actually exercises your change).
+   - Python files: `python3 -c "import py_compile; py_compile.compile('<file>', doraise=True)"`
+   - Shell files: `bash -n <file>` and `shellcheck <file>` if installed
+   - Project-specific test suite (the brief names it; e.g., `./scripts/smoke-test.sh`, `pytest`, `cargo test`). Note pre-existing failures in your report — don't claim a regression you didn't cause.
+   - Helper unit-style test of any new function you added (the brief tells you whether the project has a fixture pattern for this).
+
+8. **Commit.**
+   - `git add` specific files (never `-A` or `.`).
+   - Commit message format (the brief may override):
+     ```
+     <area>: <imperative-summary-≤72-chars>
+
+     <body: what changed and why, referencing the issue's root cause>
+
+     (#<issue-number> Track <X>)
+     ```
+   - **DO NOT** write `closes #<N>` or `closes #<N> Track <X>` in the subject or body. GitHub's close-keyword regex is greedy and will close the parent issue when the PR merges, even when only a sub-track is addressed. Use `(#<N> Track <X>)` as a non-keyword reference. The brief may repeat this; honor it strictly.
+
+9. **Push and PR (only if the brief instructs).**
+   - If the brief says "stop at commit", stop. Orchestrator pushes and opens the PR.
+   - If the brief says "open the PR yourself":
+     - Switch gh auth: `gh auth switch --user <auth_account>` per the brief
+     - `git push -u origin <branch_name>`
+     - `gh pr create --base <base_branch> --head <branch_name> --title "..." --body "..."` — add `--no-maintainer-edit` for cross-fork PRs
+   - If the brief says "push to existing PR branch on a fork":
+     - Switch gh auth to the fork user
+     - Push to the existing branch (NOT a new branch): `git push <fork-remote> HEAD:<branch>`
+
+10. **Report.**
+    Return the JSON schema the brief specifies (default below):
+    ```json
+    {
+      "files_changed": ["path/to/file.py"],
+      "checks_run": ["py_compile", "test suite name"],
+      "acceptance_met": [true, true, true],
+      "blockers": [],
+      "user_review_needed": false,
+      "user_message": ""
+    }
+    ```
+    Plus, when applicable:
+    - PR URL
+    - New HEAD sha (for PR-patching workflow)
+    - Branch name (for new-PR workflow where orchestrator pushes)
+
+## Error handling
+
+- If the suggested fix is wrong (e.g., names a non-existent file or function), investigate before abandoning. Surface what you found to the orchestrator and propose an alternative.
+- If verification fails, do **NOT** commit. Keep editing until it passes, or return `acceptance_met: [..., false]` with `blockers` populated and clear failure evidence in `user_message`.
+- If an isolated repro is infeasible for structural reasons (requires a live external service, real credentials, etc.), say so explicitly and describe the minimum manual check the orchestrator should run before merge.
+- If you discover the issue is a duplicate of work already staged in the working tree, stop and report — don't create a branch.
+- If the brief's input is internally inconsistent (e.g., names a file that doesn't exist, or a verification command that can't run), stop and ask the orchestrator to clarify.
+
+## Collaboration notes
+
+- You typically run with `isolation: "worktree"` so multiple of you can run in parallel against the same repo without colliding. Stay inside your worktree; don't `cd` to the operator's primary checkout.
+- The orchestrator owns: pushing (in most workflows), opening the PR, filling the PR body, summarizing across issues. Don't do those yourself unless the brief explicitly instructs.
+- If the brief instructs you to push to an existing PR (round-2 / round-3 fix flow), follow exactly — do NOT open a new PR for the same work.
+- Round notation: when a brief is for a follow-up round (r2, r3) on a needs-more PR, your commit message should make it explicit (`isolate: r2 — <findings list>`).

--- a/.claude/skills/wave-orchestration/references/brief-template.md
+++ b/.claude/skills/wave-orchestration/references/brief-template.md
@@ -1,0 +1,244 @@
+# Brief template — fully worked, section by section
+
+A fixer brief is a contract. Vague briefs produce r2 review rounds. Concrete briefs land r1. The template below is field-tested — every section earned its place by the consequence of leaving it out at least once.
+
+## Brief skeleton
+
+```markdown
+# Issue #<N> Track <X> — <one-line title>
+
+## Repo / branch / scope
+
+Repo: `<absolute path to operator's primary checkout>` (`main` HEAD `<short-sha>`).
+You will run inside an **isolated git worktree** — use **relative paths only**
+from your worktree root. Do **not** write to absolute paths inside the
+operator's primary checkout.
+
+Branch: `<branch-name>`
+
+PR target: `<owner>/<repo>` `main`. Run `gh auth switch --user <upstream-user>`
+before `gh pr create`. Use `--no-maintainer-edit` (cross-fork).
+
+## Read first (do not skip)
+
+- `gh issue view <N> --json body --jq .body` — full issue body
+- `<repo>/lib/foo.sh:<line-range>` — the function you'll modify; read its
+  current shape before touching
+- `<repo>/scripts/smoke-test.sh:<line-range>` — existing test fixture you'll
+  extend; understand what conventions it uses
+- (any other files the fixer must read to make sound edits)
+
+## What to change
+
+### Step 1 — <descriptive name>
+
+In `<file>`, change `<function or section>` so that:
+
+1. <concrete change, ideally with a code sketch>
+2. <another concrete change>
+
+Code sketch (adjust whatever is robust):
+
+\`\`\`bash
+my_function() {
+  local arg1="$1"
+  ...
+}
+\`\`\`
+
+### Step 2 — <next change>
+
+(continue per change)
+
+## Out of scope (do **not** do)
+
+- Do **not** edit `<file-X>` — that's separate scope
+- Do **not** add a new CLI subcommand — Track Y territory
+- Do **not** modify `bridge-lib.sh::<function>` — surface change risk
+- No VERSION bump, no CHANGELOG entry. Release contract = `release/vX.Y.Z`
+  branch only.
+
+## Verification
+
+```
+# 1. Lint
+bash -n <file1> <file2>
+shellcheck <file1> <file2>
+
+# 2. Helper test (or unit-style fixture)
+/opt/homebrew/bin/bash -c '
+  unset BRIDGE_HOME
+  cd .
+  source ./bridge-lib.sh
+  res="$(my_function /tmp/does-not-exist)"
+  [[ -z "$res" ]] || { echo FAIL; exit 1; }
+  echo OK
+'
+
+# 3. Render check (if rendering)
+/opt/homebrew/bin/bash -c '
+  cd .
+  source ./bridge-lib.sh
+  my_render_function | grep -F "<expected substring>"
+'
+
+# 4. Regression guard (if touching shared file)
+grep -F "<existing important content>" <file>
+```
+
+All N checks must pass.
+
+## CI
+
+CI smoke is failing on `main` for `<reason — pre-existing, not yours to fix>`.
+Note in PR body. Not blocking.
+
+## PR opening
+
+Single commit. Subject: `<type>: <short-description> (#<N> Track <X>)`.
+
+PR body:
+1. `## Summary` — 2-3 lines on intent
+2. `## What changed` — file-by-file
+3. `## Verification` — output of the verification matrix
+4. CI status note (pre-existing failure mode, if any)
+5. `## Scope discipline` — confirm release contract preserved
+6. End with `Addresses Track <X> of #<N>. Track <Y/Z> stays open.`
+
+**Do NOT** write `closes #<N>` anywhere. Use `(#<N> Track <X>)` as the
+non-keyword reference.
+
+## CRITICAL — close-keyword footgun
+
+GitHub parses `closes #<N> Track <X>` as `closes #<N>` and ignores the
+qualifier. Same for `closes #<N>-A`. **Never** use those forms. Use
+`(#<N> Track <X>)` exactly.
+
+This is footgun #2 in `references/footguns.md`. It has cost real recovery
+sessions in this repo (#283 and #303 both got auto-closed by accident).
+
+## Stop point
+
+Stop at PR open. Do **not** auto-merge. Return PR URL + JSON schema.
+
+## Reminders
+
+1. Worktree-relative paths only.
+2. `gh auth switch --user <upstream-user>` before `gh pr create`.
+3. `--no-maintainer-edit` on `gh pr create` (cross-fork).
+4. No code changes outside the listed files. No VERSION bump. No CHANGELOG.
+5. Single commit, <N> file(s).
+
+## Output
+
+Return the JSON schema from `agents/_template/CLAUDE.md` line ~54:
+
+```json
+{
+  "files_changed": ["<list>"],
+  "checks_run": ["<list>"],
+  "acceptance_met": [true, true, ...],
+  "blockers": [],
+  "user_review_needed": false,
+  "user_message": ""
+}
+```
+
+Plus the PR URL.
+```
+
+## Why each section earned its place
+
+### Repo / branch / scope (section 1)
+
+**Without**: fixer picks the wrong base ref or branch name.
+
+**With**: explicit path, ref, branch, target. Fixer can't get this wrong.
+
+The "isolated worktree" + "relative paths only" callout in this section is **footgun #1** prevention. It must repeat in section 10 (Reminders) too — fixers skim, repetition catches.
+
+### Read first (section 2)
+
+**Without**: fixer makes edits based on the issue body's narrative, which may reference files that don't exist or have moved.
+
+**With**: explicit list of files the fixer must read before editing. Forces the fixer to ground in the actual code state.
+
+Use line ranges where you can — fixer doesn't need to read the whole file, just the relevant function.
+
+### What to change (section 3)
+
+**Without**: fixer interprets the spec, may interpret it differently from you.
+
+**With**: per-step, per-file recipe. Code sketches where the spec is ambiguous. The fixer's job becomes "translate this spec to working code", not "design from the issue body".
+
+Be concrete. "Add a check for missing dir" is vague. "Add `if [[ -z "$path" || ! -d "$path" ]]; then printf '%s' "$path"; return 0; fi` at the top of `bridge_project_root_for_path`" is concrete.
+
+### Out of scope (section 4)
+
+**Without**: fixer over-scopes. Adds bonus features. Touches files you didn't intend. Reviewer rejects on "scope creep".
+
+**With**: explicit deny-list. The fixer reads it and stops at the boundary.
+
+This is the single highest-leverage section. Skip it at your peril.
+
+### Verification (section 5)
+
+**Without**: fixer ships, you find issues post-merge.
+
+**With**: explicit bash commands. Fixer runs each before declaring done; reports the output in the PR body.
+
+Use **executable** verification — `bash -n`, `shellcheck`, `grep -F`, helper unit tests. Don't write "verify the function works" — write the exact command.
+
+### CI (section 6)
+
+**Without**: fixer wastes time chasing pre-existing CI failures it can't fix.
+
+**With**: tells the fixer "this fail is pre-existing; not yours; document and move on".
+
+CI on the Agent Bridge repo has been failing on every recent main commit since 2026-04-21. Every wave brief calls this out. Saves the fixer ~15 minutes per dispatch.
+
+### PR opening (section 7)
+
+**Without**: PR body is sloppy. Reviewer has to ask for clarification.
+
+**With**: structured body the reviewer can grep.
+
+The body sections (Summary / What changed / Verification / CI / Scope) are the convention. Reviewer agents and human reviewers both recognize this shape.
+
+### CRITICAL — close-keyword footgun (section 8)
+
+**Without**: fixer types `closes #283 Track B` and the issue auto-closes when the PR merges.
+
+**With**: explicit warning + alternative.
+
+This is **footgun #2**. It has cost real recovery sessions. Always include in section 8.
+
+### Stop point (section 9)
+
+**Without**: fixer auto-merges the PR. Now you can't review. Operator finds out post-fact.
+
+**With**: explicit "stop at PR open, do not merge".
+
+The orchestrator merges. The fixer opens the PR and stops. Hard line.
+
+### Reminders (section 10)
+
+**Without**: footguns repeat (worktree paths, gh auth, VERSION).
+
+**With**: terse repetition of the most-tripped footguns at the end of the brief.
+
+Fixers skim. Repetition at the bottom is your last line of defense.
+
+### Output (section 11)
+
+**Without**: fixer returns prose. You can't tell programmatically what was checked, what was blocked, what needs operator review.
+
+**With**: structured JSON schema. Orchestrator can parse `acceptance_met` and `blockers` to decide next action.
+
+The schema lives in `agents/_template/CLAUDE.md` line 54. Standard across waves.
+
+## Length sanity check
+
+A working brief is **150-300 lines markdown**. Less = sketchy spec, fixer guesses; more = brief is doing the fixer's job and you should just write the code yourself.
+
+If your brief is approaching 400 lines, the work is too big for one wave. Split it.

--- a/.claude/skills/wave-orchestration/references/footguns.md
+++ b/.claude/skills/wave-orchestration/references/footguns.md
@@ -1,0 +1,211 @@
+# Footgun catalog
+
+Each footgun below has cost a real session of recovery. Read this file before dispatching a fixer or reviewing a PR — and **always include the relevant footgun warning in the fixer brief** if the fixer might trip it.
+
+## Footgun 1 — Worktree path leakage
+
+**Symptom**: Fixer runs in `<repo>/.claude/worktrees/agent-<hash>/` but mutates files in `<repo>/` (the operator's primary checkout) instead. Operator's working tree gets dirty with someone else's changes. Worst case: fixer commits to operator's branch by accident.
+
+**Root cause**: Brief uses absolute paths like `/Users/<user>/Projects/<repo>/lib/foo.sh`. When fixer reads "edit this file", it edits the absolute path — which is the operator's checkout, not the worktree.
+
+**Fix**: Brief always says "use **relative paths only** from your worktree root" in section 1 and again in section 10 (Reminders). Dispatch prompt repeats it. After fixer reports "done", run `gh pr diff <N>` and confirm only the intended files are touched. If the fixer mutated the operator's tree, run `git -C <repo> stash` immediately and self-revert before doing anything else.
+
+**Real instance**: PR #282 fixer wrote to absolute path, ended up self-reverting. Footgun documented in `feedback_parallel_wave_operator_pattern.md`.
+
+## Footgun 2 — GitHub close-keyword regex
+
+**Symptom**: Issue auto-closes when you only addressed Track A; B/C/D still pending. Operators wake up to find "tracking issue with 4 sub-tracks" silently closed.
+
+**Root cause**: GitHub's close-keyword regex is greedy:
+- `closes #283 Track B` → closes #283 (the " Track B" qualifier is ignored)
+- `closes #303-A` → closes #303 (the "-A" suffix is ignored)
+- `closes #303-A, closes #304-A` → closes #303 only (the comma + "#304-A" has no keyword in front of it, which is the one case GitHub respects)
+
+**Fix**: **Never** put `closes #N` in commit subject or PR title when the issue has subtracks B/C/D pending. Use `(#N Track X)` as a non-keyword reference. Example safe forms:
+- `docs: admin role spec — Self-Cleanup of Own Queue (#303-A, #304-A)` ✓
+- `cron: extend bridge_suggest_subcommand curated aliases (#283 Track C)` ✓
+- `docs: admin role spec — Self-Cleanup (closes #303-A)` ✗ closes #303 by accident
+
+**Recovery**: If an issue gets auto-closed by accident, reopen with a comment explaining the GitHub regex bug + which tracks remain. Add a footgun callout to the next brief so the fixer doesn't repeat.
+
+## Footgun 3 — `gh auth` account mismatch
+
+**Symptom**: `gh pr create` fails with `failed to create pull request: GraphQL: createPullRequest: ... must have push access to the repository`. PR isn't created. Fixer blocks waiting for an owner to grant access.
+
+**Root cause**: Multiple `gh` accounts logged in (e.g., `seanssoh` for fork + `SYRS-AI` for upstream). Active account is the fork; the fork has READ permission on upstream, not write. `gh pr create` from the fork account fails to open a PR against upstream.
+
+**Fix**: Brief must include `gh auth switch --user SYRS-AI` (or whichever account has write) **before** any `gh pr create`. Verify via `gh auth status | head -10` showing the right account as Active.
+
+For cross-fork PRs (PR head is `seanssoh:branch`, base is `SYRS-AI:main`), also pass `--no-maintainer-edit` to `gh pr create`. Without it, fork-to-upstream PRs from accounts that don't have collaborator edit access fail.
+
+## Footgun 4 — VERSION/CHANGELOG bleeding into feature PRs
+
+**Symptom**: Fixer's PR includes a `VERSION` bump and `CHANGELOG.md` entry alongside the actual feature change. Concurrent release PR conflicts on `VERSION`. Release contract violated.
+
+**Root cause**: Fixer sees an existing pattern (every recent commit bumps VERSION!) and assumes it's expected. Or fixer's brief was unclear.
+
+**Fix**: Every brief includes "**No VERSION bump, no CHANGELOG entry. Release contract = `release/vX.Y.Z` branch only.**" After fixer reports done, run `git diff --cached --stat` before commit and `gh pr diff <N>` after — confirm `VERSION` and `CHANGELOG.md` are NOT in the file list.
+
+**Real instance**: #220 fixer bundled a v0.6.16 VERSION bump into a docs PR. Required revert + amend to recover.
+
+## Footgun 5 — macOS Bash 3.2 vs Bash 4+
+
+**Symptom**: Test of a function fails with errors like:
+```
+/bin/bash: line N: cd: ...: No such file or directory
+/bin/bash: line N: conditional binary operator expected
+/bin/bash: /bin/bash: 이진 파일을 실행할 수 없음
+```
+
+Or a function returns empty output even though the source file clearly has the right code.
+
+**Root cause** (one of three):
+1. macOS ships Bash 3.2 at `/bin/bash`; the project requires Bash 4+ (associative arrays, `[[ -v ]]`, etc.). Use `/opt/homebrew/bin/bash` explicitly.
+2. `source bridge-lib.sh` (without `./`) lets bash search `$PATH` and pick up the runtime-installed copy at `~/.agent-bridge/bridge-lib.sh` instead of the source-checkout copy. **Always** prefix with `./`.
+3. The runtime-installed copy is older than the source checkout — your local edits aren't visible because the test sourced the wrong file.
+
+**Fix**:
+```bash
+/opt/homebrew/bin/bash -c '
+  unset BRIDGE_HOME
+  cd <repo-source-root>
+  source ./bridge-lib.sh
+  my_function arg1 arg2
+'
+```
+
+Verify before claiming done that the function returns the expected output. If the output looks like it's missing your edit, double-check via `declare -f my_function | head -20` — that prints the in-memory function body so you can confirm the loaded version matches your source.
+
+## Footgun 6 — Committed source vs heredoc-generated content
+
+**Symptom**: Brief says "edit `.claude/skills/agent-bridge/references/bridge-commands.md`". Fixer can't find the file. Or fixer edits a file that turns out to be a runtime-installed symlink, and the change disappears at next regen.
+
+**Root cause**: Some skill content lives in **committed `.md` files** (e.g., `.claude/skills/cron-manager/SKILL.md`). Other skill content is **heredoc strings** inside `lib/bridge-skills.sh::bridge_render_*`. A "docs-only" brief that targets a heredoc file mistakenly assumes a committed source.
+
+**Fix**: Before writing the brief, run `find <repo> -name "<filename>" -not -path "*/worktrees/*"` to find the actual source. If no committed source exists, find the heredoc generator via `grep -rn "<a unique string from the file>" lib/ scripts/`. Brief must point at the actual source — heredoc means a **code edit**, not a docs-only edit.
+
+**Real instance**: #283 Track B fixer for PR #307 correctly identified that `agent-bridge/references/bridge-commands.md` was heredoc-generated and STOPPED at PR open with a clear escalation note. The orchestrator then opened a follow-up PR #308 that touched the heredoc directly.
+
+## Footgun 7 — Cross-fork PR push from fork account
+
+**Symptom**: A PR sits on someone else's fork (e.g., `seanssoh:fix/foo`). The original author can't iterate quickly. You want to push fix commits to that branch.
+
+**Workflow**:
+
+```bash
+gh auth switch --user <fork-user>      # MUST be active before push
+gh auth status                          # verify
+
+cd <repo>
+git remote add <fork-user> https://github.com/<fork-user>/<repo>.git \
+  || true
+git fetch <fork-user> <branch>
+git worktree add /tmp/agb-pr<N>-r2 <fork-user>/<branch>
+cd /tmp/agb-pr<N>-r2
+git checkout -B <branch>
+
+# ... edit, commit ...
+
+git push <fork-user> HEAD:<branch>     # push to fork; PR auto-updates
+```
+
+Cleanup:
+```bash
+git -C <repo> worktree remove --force /tmp/agb-pr<N>-r2
+gh auth switch --user <upstream-user>  # restore default for subsequent PRs
+```
+
+**Do NOT**:
+- Open a new PR — the fix lives on the existing PR's branch
+- Switch back to upstream account mid-run — pushes will go to the wrong remote
+- Force-push without explicit operator authorization
+
+## Footgun 8 — codex-rescue async-default
+
+**Symptom**: codex-rescue dispatch returns immediately with an empty thread id. No actual review happens. Reviewer comment never lands.
+
+**Root cause**: codex-rescue is async-default. If the prompt doesn't tell it to wait for completion in its final message, it spins up a background thread, returns the thread id, and exits. The orchestrator gets nothing useful back.
+
+**Fix**: Every codex-rescue dispatch prompt must include this exact line:
+
+```
+Wait for completion in your final assistant message. Do not return a thread id and exit.
+```
+
+That single line changes the dispatch from async to sync. The reviewer's full review comes back in the agent's final message, where the orchestrator can read it directly.
+
+Also: before dispatching, verify codex is set up:
+
+```bash
+codex --version 2>/dev/null && command -v codex   # confirm codex CLI is installed and on PATH
+```
+
+If `codex` isn't on the agent's PATH (homebrew installs to `/opt/homebrew/bin` on macOS, `/usr/local/bin` on Linux, neither of which subagent shells always include), the agent reports "Codex CLI is not installed" even when the binary exists. **Re-probing alone is not always enough** — the codex-rescue runtime can still fail to invoke codex from its sandboxed shell. When this happens, re-dispatch with **explicit PATH guidance + absolute-path fallback** in the prompt:
+
+```
+**Codex CLI is INSTALLED and READY on this machine.** Verified directly:
+$ command -v codex
+/opt/homebrew/bin/codex
+$ codex --version
+codex 1.x.x
+
+If your sandboxed shell reports "Codex CLI is not installed", the issue is the
+shell's PATH not picking up the package-manager bin directory. Retry with:
+
+  PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" codex --version
+
+Or invoke codex directly via the absolute path the orchestrator captured
+above. Do NOT abort with "Codex CLI is not installed" if the orchestrator
+(me) confirmed codex is reachable. Proceed with the review.
+```
+
+This forceful guidance has worked when the simpler "re-probe via companion script" guidance failed. The codex-rescue agent will still try to invoke codex, but the explicit PATH override + the operator-affirmation lets it persist past the false-negative probe.
+
+## Footgun 10 — Skipping pair-review citing PR size
+
+**Symptom**: Operator catches that you squash-merged PRs without the `codex-rescue` (or project-designated) pair reviewer producing an `implement-ok`. Operator orders a `git revert --no-edit` of the offending squash commits and tells you to re-PR with proper review. Trust dropped, time lost.
+
+**Root cause**: The orchestrator's "direct review for <300 LOC mid-size" instinct conflicts with the project's `AGENTS.md` rule "Pair-review every non-trivial PR. Default reviewer is `agb-dev-codex-2`. Merge only after implement-ok." Earlier versions of this skill encoded the size-based carve-out as the default. **It was wrong.** The project rule overrides; the orchestrator must default to pair-review and only invoke direct review for the explicit allow-list (trivial mechanical reverts, single-line typo fixes, operator-directed exceptions).
+
+**Real instance**: 2026-04-26 — three PRs (#323, #324, #325) merged without codex review citing the size-based carve-out. Operator caught the mismatch, ordered PR #332 (mechanical revert), and the original three branches had to be re-PR'd with proper pair-review.
+
+**Fix**:
+1. Pair-review is the default for every non-trivial PR.
+2. Direct review is allowed only for: mechanical reverts, single-line typos, operator-directed exceptions (cite the operator instruction in the merge note).
+3. When in doubt, dispatch codex-rescue. The 5 minutes of review wall-time is much smaller than the cost of recovering from a "merged without review" revert wave.
+4. If the operator says "go faster, skip review", honor it for that batch only — but record it in the session memory so the next session doesn't inherit the relaxation.
+
+If you find yourself thinking "this PR is small enough", that's the rationalization. Read the project's `AGENTS.md` again. If the rule is "every non-trivial PR", you do not have permission to skip on size grounds.
+
+## Footgun 9 — Sequential dispatch when parallel is possible
+
+**Symptom**: Wave takes 4× as long as it should. Operator notices "you're doing one at a time when these are all independent — why?"
+
+**Root cause**: Dispatching one Agent call per turn serializes them by default. Each fixer waits for the previous to complete (or at least for the orchestrator's next turn to fire). Even with `run_in_background: true`, dispatching across multiple turns doesn't actually start the second fixer until the first turn completes.
+
+**The fix is mechanical**: when you have 2-4 independent fixers ready to go, dispatch them **in a single message with multiple Agent tool calls**. The runtime fans them out only when they're in the same response.
+
+```javascript
+// CORRECT: same turn, three calls — all three start immediately
+Agent({ description: "Wave A", ..., run_in_background: true })
+Agent({ description: "Wave B", ..., run_in_background: true })
+Agent({ description: "Wave C", ..., run_in_background: true })
+
+// WRONG: three turns — second and third don't start until prior turn finishes
+// Turn N: Agent({ description: "Wave A", ..., run_in_background: true })
+// Turn N+1: (now dispatching B; A may have already done a lot of work)
+// Turn N+2: (now dispatching C)
+```
+
+**The default for backlog processing should be "scan → triage → write all briefs → dispatch whole batch"**, not "dispatch one, wait, dispatch next". Operators will explicitly call out the difference if they notice it (Sean did at 11:21 KST 2026-04-26: "왜 하나씩만 하는거야?"). Adopt the parallel-first habit instead of waiting for the call-out.
+
+**Edge cases where serialization is correct**:
+- Two fixers touching the same function (not just the same file): rebase risk too high; serialize.
+- Round-N+1 of the same PR (need round-N's review back first): inherently sequential.
+- A fixer whose result informs the next fixer's brief (rare): wait for the report, then dispatch.
+
+Otherwise: parallel.
+
+## Composite footgun — VERSION + close-keyword + worktree path
+
+If a fixer trips footguns 1, 2, and 4 in the same PR, the PR (a) mutates the operator's primary checkout, (b) auto-closes the parent issue, and (c) bumps VERSION concurrent with an open release PR. Recovery is a manual revert + amend + reopen + comment + roster reset. Don't let this happen — every brief should explicitly call out all three. The cost of a 3-line footgun callout in the brief is much smaller than the cost of recovery.

--- a/.claude/skills/wave-orchestration/references/recipes.md
+++ b/.claude/skills/wave-orchestration/references/recipes.md
@@ -1,0 +1,291 @@
+# Recipes — concrete commands for common operations
+
+Copy-paste these. Each has been used in production; substitute the placeholders.
+
+## Recipe — full wave dispatch
+
+```bash
+# 1. Read the issue
+gh issue view <N> --json title,body --jq '"# \(.title)\n\n\(.body)"'
+
+# 2. Find files via grep, not the issue body
+find <repo> -name "<filename>" -not -path "*/worktrees/*"
+grep -rn "<unique substring>" <repo>/lib/ <repo>/scripts/
+
+# 3. Write the brief at /tmp/<topic>-fixer.md (use template in references/brief-template.md)
+
+# 4. Dispatch (in a single Agent tool call):
+#    - subagent_type: upstream-issue-fixer
+#    - isolation: worktree
+#    - run_in_background: true
+#    - prompt: brief overview pointing at /tmp/<topic>-fixer.md
+
+# 5. While waiting, draft the review brief if you'll need codex-rescue review.
+```
+
+## Recipe — codex-rescue setup verification
+
+```bash
+# Always run before dispatching codex-rescue.
+codex --version 2>/dev/null && command -v codex
+```
+
+A non-empty version line + a path means codex is installed and reachable.
+
+If `command -v codex` returns nothing but `which codex` shows a binary, the agent is running with a stripped PATH. Re-dispatch the codex-rescue agent with explicit `PATH` guidance, or invoke codex directly via its absolute path.
+
+If codex prints "Not logged in" or similar on a real call, ask the operator to run `!codex login`.
+
+## Recipe — codex-rescue dispatch (sync, with wait line)
+
+```javascript
+Agent({
+  description: "Codex review of PR #<N>",
+  subagent_type: "codex:codex-rescue",
+  prompt: `Code review PR #<N> of <owner>/<repo>.
+
+Codex CLI is installed and ready. If your first probe disagrees, re-check via:
+PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" codex --version
+which should print a version line on this machine.
+
+**Read this brief in full first**: /tmp/<topic>-codex-review.md
+
+**Diff** is at /tmp/pr-<N>.diff (<N> lines).
+**PR body**: gh pr view <N> --json body --jq .body
+
+**Output requirement**: deliver the review per the "Output shape (required)"
+section of the brief. Open with \`implement-ok\` or \`needs-more: ...\` literally.
+Cite file:line. Don't paraphrase the PR body.
+
+**Wait for completion in your final assistant message.** Do not return a thread
+id and exit. The orchestrator (me) needs the full review verbatim in your final
+message.`,
+  run_in_background: true
+})
+```
+
+The "wait for completion" line is **footgun #8 prevention**. Without it, the dispatch returns an empty thread id and the review never lands.
+
+## Recipe — fetching a PR diff before review
+
+```bash
+gh pr diff <N> > /tmp/pr-<N>.diff
+wc -l /tmp/pr-<N>.diff
+head -3 /tmp/pr-<N>.diff
+```
+
+Save to `/tmp/pr-<N>.diff` so the codex review brief can reference an absolute path the codex agent can read.
+
+## Recipe — squash merge with structured note
+
+```bash
+gh pr merge <N> --squash --body "$(cat <<'EOF'
+implement-ok
+
+<reviewer-context: "Direct review by orchestrator" or "Reviewer: codex-rescue + orchestrator verification">.
+
+Verified:
+- <acceptance criterion 1>: <how it was verified>
+- <acceptance criterion 2>
+- ...
+- No VERSION bump, no CHANGELOG entry — release contract preserved
+- Single commit, <N> file(s)
+- PR title uses '(#<issue> Track <X>)' — close-keyword footgun avoided
+
+<issue-stays-open-or-closes context — either "Issue #N stays open for Tracks Y, Z" or "All tracks of #N landed.">
+
+Approved.
+EOF
+)"
+```
+
+After merge, immediate cleanup:
+
+```bash
+git -C <repo> checkout main
+git -C <repo> pull --ff-only origin main
+git -C <repo> worktree remove -f -f <repo>/.claude/worktrees/agent-<hash>
+gh api -X DELETE /repos/<owner>/<repo>/git/refs/heads/<branch>
+```
+
+`gh pr merge --delete-branch` fails with `fatal: 'main' is already used by worktree at '...'` when local `main` is also a worktree. Skip the `--delete-branch` flag and use `gh api` to delete the remote ref directly.
+
+## Recipe — cross-fork PR push (footgun #7)
+
+You want to push fix commits to a PR that lives on someone else's fork.
+
+```bash
+# Switch to the fork account FIRST. Critical.
+gh auth switch --user <fork-user>
+gh auth status   # confirm <fork-user> is now Active=true
+
+cd <repo>
+git remote add <fork-user> https://github.com/<fork-user>/<repo>.git \
+  || true   # OK if already exists
+git fetch <fork-user> <branch>
+
+# Worktree off the fork's HEAD, not main
+git worktree add /tmp/agb-pr<N>-r2 <fork-user>/<branch>
+cd /tmp/agb-pr<N>-r2
+git checkout -B <branch>
+
+# ... edit, run verification, commit ...
+
+git push <fork-user> HEAD:<branch>   # PR auto-updates
+```
+
+Cleanup:
+
+```bash
+git -C <repo> worktree remove --force /tmp/agb-pr<N>-r2
+gh auth switch --user <upstream-user>   # restore default
+```
+
+**Do not** open a new PR. The fix lives on the existing PR's branch.
+
+## Recipe — finding committed source vs heredoc-generated content
+
+When a brief targets a `.md` file under `.claude/skills/`, verify whether it's committed source or runtime-generated:
+
+```bash
+# Is the file in git?
+git -C <repo> ls-files | grep -F "<filename>"
+# (empty output = not committed = it's runtime-generated)
+
+# Find the heredoc generator
+grep -rn "<a unique string from the file>" <repo>/lib/ <repo>/bridge-*.py
+```
+
+If the source is a heredoc inside `lib/bridge-skills.sh::bridge_render_*`, the brief must permit a `lib/` edit — it's NOT a docs-only change.
+
+This is **footgun #6**. The fixer for #283 Track B (PR #307) correctly stopped at PR open when it discovered the brief's "three files" actually only had one committed source; the orchestrator opened a follow-up PR #308 to handle the heredoc.
+
+## Recipe — reopening a footgun-2 auto-closed issue
+
+If GitHub auto-closed an issue because the squash subject contained `closes #<N> Track <X>`:
+
+```bash
+gh issue reopen <N> --comment "Reopening — issue auto-closed by GitHub's close-keyword regex when PR #<M>'s squash subject contained \"closes #<N> Track <X>\". GitHub parsed this as \`closes #<N>\` and ignored the qualifier. Tracks <Y, Z> are still pending; <Track-X> landed via PR #<M>."
+```
+
+Then update the next brief's footgun callout so the fixer doesn't repeat. (See `references/footguns.md` footgun 2.)
+
+## Recipe — local smoke run on macOS
+
+The smoke test refuses to run when `BRIDGE_HOME` points at a real install. Unset it explicitly:
+
+```bash
+cd <repo>
+env -u BRIDGE_HOME -u BRIDGE_STATE_DIR -u BRIDGE_TASK_DB \
+    -u BRIDGE_ROSTER_LOCAL_FILE -u BRIDGE_AGENT_HOME_ROOT \
+    -u BRIDGE_CRON_STATE_DIR \
+    bash scripts/smoke-test.sh 2>&1 | tee /tmp/agb-local-smoke-$$.log
+```
+
+Tail `/tmp/agb-local-smoke-$$.log` for the failure mode. Recent local smoke fail (chronic since 2026-04-21) is `expected output to contain: session=created-session-XXXX` at line ~3885 (`bridge-start.sh "$CREATED_AGENT" --dry-run` not emitting the session label). Document in PR body as pre-existing; do not chase.
+
+## Recipe — bash 4 helper test (footgun #5)
+
+```bash
+/opt/homebrew/bin/bash -c '
+  unset BRIDGE_HOME
+  cd <repo-source-root>
+  source ./bridge-lib.sh   # NOTE the ./
+  my_function arg1 arg2
+'
+```
+
+Without `./`, bash searches `$PATH` and may pick up the runtime-installed copy at `~/.agent-bridge/bridge-lib.sh` instead of the source checkout. **Always** use `./bridge-lib.sh`.
+
+If the function returns empty/wrong output even though the source clearly has your edit, dump the loaded function body to confirm:
+
+```bash
+/opt/homebrew/bin/bash -c '
+  unset BRIDGE_HOME
+  cd <repo-source-root>
+  source ./bridge-lib.sh
+  declare -f my_function | head -25
+'
+```
+
+If the dumped body doesn't have your edit, the wrong file was sourced. Fix PATH or use absolute `./`.
+
+## Recipe — worktree cleanup after wave
+
+After a wave (or end of session), prune stale worktrees:
+
+```bash
+# /tmp-style worktrees from older fixer runs
+for d in /tmp/agb-*; do
+  [ -d "$d" ] && git -C <repo> worktree remove --force "$d" 2>/dev/null
+done
+
+# .claude/worktrees lockfiles from completed fixers
+git -C <repo> worktree prune
+
+# List remaining; any agent-* with `locked` lock should match an active fixer.
+git -C <repo> worktree list
+```
+
+If `.claude/worktrees/agent-<hash>` has `locked` reason `claude agent agent-<hash> (pid <PID>)` and the PID is dead, force-remove:
+
+```bash
+git -C <repo> worktree remove -f -f <repo>/.claude/worktrees/agent-<hash>
+```
+
+## Recipe — release PR (when you actually need to bump VERSION)
+
+Release PRs are special. Branch must be `release/vX.Y.Z`. Touch only `VERSION` and `CHANGELOG.md`. Single commit. Standard pair-review contract.
+
+```bash
+git checkout -b release/v<X.Y.Z>
+# bump VERSION
+echo "<X.Y.Z>" > VERSION
+# add CHANGELOG entry
+$EDITOR CHANGELOG.md
+git add VERSION CHANGELOG.md
+git commit -m "release: bump version to <X.Y.Z>"
+git push -u origin release/v<X.Y.Z>
+gh pr create --base main --head release/v<X.Y.Z> --title "release: bump version to <X.Y.Z>" --body "..."
+```
+
+After merge, tag the merge commit:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag -a v<X.Y.Z> -m "Release v<X.Y.Z>"
+git push origin v<X.Y.Z>
+```
+
+**Do not** tag the feature branch. Tags go on the merge commit on `main`.
+
+## Recipe — pair-review r2 (after `needs-more`)
+
+```bash
+# 1. Post the review verbatim as a PR comment
+gh pr comment <N> --body "$(cat /tmp/<topic>-codex-review-r1.md)"
+
+# 2. Write r2 brief — list each finding with file:line citation and concrete fix recipe
+$EDITOR /tmp/<topic>-r2-fixer.md
+
+# 3. Dispatch a fresh fixer for r2 (not the same one)
+#    Brief title bumps to r2: "[PR #<N> r2] <subject>"
+
+# 4. Repeat until implement-ok
+```
+
+After 3 rounds without `implement-ok`, **stop** and reconsider scope. Often the PR is too big or the spec is ambiguous; split it.
+
+## Recipe — ending a wave
+
+After all PRs in a wave land:
+
+1. `gh issue list --state open --limit 30` — what's still open?
+2. `gh pr list --state open --limit 10` — any unmerged PRs?
+3. Comment on each issue summarizing what landed and which tracks remain
+4. Close issues whose tracks all landed
+5. Worktree cleanup (recipe above)
+6. Pause to verify no cross-PR regressions
+
+If the user asked you to continue, evaluate the next wave from the remaining open issues. If the natural pause point has been reached and the user's "끝까지 처리해" instruction is satisfied, summarize and stop.

--- a/.claude/skills/wave-orchestration/references/wave-examples.md
+++ b/.claude/skills/wave-orchestration/references/wave-examples.md
@@ -1,0 +1,171 @@
+# Worked wave examples — Agent Bridge repo, 2026-04-25 session
+
+Four worked waves from a single session that landed 11 PRs with zero regressions. Each example shows the issue, the brief decision, the dispatch shape, the review path, and the merge note.
+
+## Wave example 1 — combined Track A's docs PR
+
+**Issue context**: #303 + #304 both proposed adding admin role spec sections to `agents/_template/CLAUDE.md`. Both Track A's were docs-only. Bundling them into one PR was cheaper than two separate PRs because they touched the same file in the same area.
+
+**Brief size**: ~150 lines. Docs only. Two new H2 sections inserted between existing sections.
+
+**Dispatch**:
+
+```javascript
+Agent({
+  description: "Wave 1: #303A + #304A admin role spec docs",
+  subagent_type: "upstream-issue-fixer",
+  prompt: `... pointing at /tmp/agb-303-304-trackA-fixer.md ...`,
+  isolation: "worktree",
+  run_in_background: true
+})
+```
+
+**Review path**: direct (docs-only, ~21 LOC, mid-size). No codex-rescue.
+
+**Merge note** (just the structured part):
+
+```
+implement-ok
+
+Direct review by orchestrator (docs-only, 21 LOC, mid-size = direct review per wave pattern).
+
+Verified:
+- Section ordering correct: Admin First-Run Onboarding Defaults → Admin Self-Cleanup of Own Queue → Admin Static vs Dynamic Agent Boundary → Channel Setup Protocol
+- Both new sections gated on Session Type == admin (matches surrounding admin-specific section convention)
+- #303 Track A decision tree (a)-(f) present and ordered correctly; default-to-close rule explicit
+- #304 Track A static-vs-dynamic boundary present; nudge-dynamic-agent prohibition explicit
+- All five daemon maintenance event types listed: [context-pressure], [stall], [crash-loop], [wake-miss], [blocked-aging]
+- No VERSION bump, no code changes — release contract preserved
+- Korean throughout, internally consistent within each section
+
+Approved.
+```
+
+**Outcome**: PR #306 merged at `4e0bde0`. Both #303 and #304 stayed open with comments noting Track A landed.
+
+**What went wrong**: PR squash subject contained `(closes #303-A, #304-A)`. GitHub auto-closed #303 (greedy regex) — see footgun #2. Recovery: reopen with footgun explanation. **Lesson**: every subsequent brief explicitly forbade `closes #N` text in commit subject.
+
+## Wave example 2 — heredoc-generated content discovery
+
+**Issue context**: #283 Track B "skill content guardrails" — three files to edit. Brief assumed all three were committed source.
+
+**Brief size**: ~220 lines. Three-file scope: `.claude/skills/cron-manager/SKILL.md`, `.claude/skills/agent-bridge/references/bridge-commands.md`, `.claude/skills/agent-bridge/SKILL.md`.
+
+**What the fixer found**: only `.claude/skills/cron-manager/SKILL.md` was committed source. The other two were **heredoc strings** inside `lib/bridge-skills.sh::bridge_render_*`. The brief explicitly forbade `lib/` edits. The fixer correctly **stopped at PR open** with a clear `user_review_needed` flag and a note explaining the situation.
+
+**Recovery**: orchestrator opened a follow-up PR #308 that touched the heredoc directly (mid-size lib/ edit, self-authored).
+
+**Lesson**: footgun #6 documented. Future briefs verify committed-source vs heredoc-generated via `find` + `grep` BEFORE writing the brief.
+
+**Outcomes**: PR #307 merged at `1a2be7c` (single-file expansion); PR #308 merged at `b10ebbe` (heredoc edit). #283 stayed open until Tracks C/D/A landed.
+
+## Wave example 3 — direct mid-size lib/ edit (no fixer)
+
+**Issue context**: #283 Track C — extend `bridge_suggest_subcommand` curated alias table to handle `cron history` / `cron logs` / `help`. Three new `case` arms. Total ~14 LOC across `lib/bridge-core.sh` and `scripts/smoke-test.sh`.
+
+**Decision**: mid-size + clear scope + I had context already → **direct edit, no fixer dispatch**.
+
+**Steps**:
+
+```bash
+cd <repo>
+git checkout -b fix/283-trackC-cli-suggestions
+# ... edit lib/bridge-core.sh + scripts/smoke-test.sh ...
+bash -n lib/bridge-core.sh scripts/smoke-test.sh
+shellcheck lib/bridge-core.sh scripts/smoke-test.sh
+/opt/homebrew/bin/bash -c '
+  unset BRIDGE_HOME
+  cd .
+  source ./bridge-lib.sh
+  echo "[1] cron history → [$(bridge_suggest_subcommand "cron history" "")]"
+  ...
+'
+git add lib/bridge-core.sh scripts/smoke-test.sh
+git commit -m "cli: extend bridge_suggest_subcommand curated aliases ... (#283 Track C)"
+git push -u origin fix/283-trackC-cli-suggestions
+gh pr create --base main --head fix/283-trackC-cli-suggestions --title "..." --body "..." --no-maintainer-edit
+```
+
+**Review path**: self-review — I authored, I reviewed. Mid-size + I tested live → squash merge.
+
+**Lesson**: not every wave needs a fixer dispatch. When the change is mid-size, well-scoped, and you have context, direct edit is faster.
+
+**Outcome**: PR #309 merged at `0ab5c45`.
+
+## Wave example 4 — codex-rescue review of complex PR
+
+**Issue context**: PR #302 — 583 LOC change, Linux ACL semantics, isolated UID plugin sharing. Specialized domain (ACL ordering, sudo wrap, traverse chain). Authored by `seanssoh` (operator's fork account) on his other Claude session; opened against upstream `SYRS-AI:main`.
+
+**Decision**: >300 LOC + specialized → **codex-rescue review**, not direct.
+
+**Pre-dispatch checks**:
+
+```bash
+# Verify codex setup
+codex --version 2>/dev/null && command -v codex
+# Both should print: a version line and a binary path
+
+# Fetch the diff to a known path
+gh pr diff 302 > /tmp/pr-302.diff
+wc -l /tmp/pr-302.diff   # 637
+
+# Write the review brief
+$EDITOR /tmp/agb-302-codex-review.md
+```
+
+**Dispatch** (with the wait-for-completion line):
+
+```javascript
+Agent({
+  description: "Codex review of PR #302 ACL plugin sharing",
+  subagent_type: "codex:codex-rescue",
+  prompt: `Code review PR #302 of SYRS-AI/agent-bridge-public — "isolate: channel-ownership-aware plugin sharing for isolated UIDs".
+
+Codex CLI is installed and ready. If your first probe disagrees, re-check via:
+PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" codex --version
+which should print a version line on this machine.
+
+Read this brief in full first: /tmp/agb-302-codex-review.md
+Diff is at /tmp/pr-302.diff (637 lines).
+PR body: gh pr view 302 --json body --jq .body
+
+Output requirement: deliver per the "Output shape (required)" section. Open with implement-ok or needs-more: ... literally. Cite file:line.
+
+Wait for completion in your final assistant message. Do not return a thread id and exit.`,
+  run_in_background: true
+})
+```
+
+**Review return**: `needs-more` with 5 blocking findings + 2 risks + 1 nit, each citing `file:line`. The orchestrator posted the review verbatim as a PR comment.
+
+**Footgun-8 instance**: first dispatch returned "Codex CLI is not installed" because the subagent shell had a stripped PATH. Operator confirmed codex was in fact installed; orchestrator re-dispatched with explicit guidance to re-probe via the companion script. Second dispatch succeeded.
+
+**Outcome**: review posted as PR comment. PR #302 stayed open awaiting r2 fixes from the author side. (Subsequent recipe: cross-fork push from `seanssoh` account — see `references/recipes.md` "Cross-fork PR push".)
+
+## Cross-cutting observations from these waves
+
+1. **Brief size correlates with PR success rate.** Briefs under 100 lines drop r1 success below 80%. 150-300 lines is the sweet spot.
+
+2. **Footgun callouts in the brief save reviews.** Every recurring footgun added a section to subsequent briefs. The brief grew ~5% per wave, but r2 rounds dropped.
+
+3. **Worktree-relative paths must be repeated.** Once in section 1 (Repo / branch / scope) and once in section 10 (Reminders). Fixers skim — repetition catches.
+
+4. **Direct review for mid-size, codex for big specialized.** The threshold isn't precise; ~300 LOC is the rough cutoff but specialized domain (ACL, sudo, daemon scheduler) drops it to ~200 LOC. When in doubt, dispatch codex-rescue — the cost is small.
+
+5. **Self-authored mid-size waves are legitimate.** Not every change needs a fixer. When you have the context and the scope is clear, direct edit + self-review is faster than dispatch + review.
+
+6. **Pause after a wave for cross-PR verification.** Two PRs touching the same file region can land cleanly individually but introduce subtle conflicts when both land. After a wave: pull main, run smoke locally if material, scan recent commits for unintended interactions.
+
+## Anti-pattern — wave examples that did NOT work
+
+### #239 — 14-bullet bundled PR
+
+Original PR #239 tried to ship 14 distinct improvements in one branch. Three review rounds reached without `implement-ok`. Operator stopped the loop, closed #239, and split into 8 wave-sized PRs (#239 splits 1-5 across waves 3-5 of the session). All 8 split PRs landed r1. Total time was less than the 3-round mega-PR loop would have taken.
+
+**Lesson**: if a PR is touching too much surface, splitting into 2-4-PR waves is almost always the right move. The "bundling saves overhead" instinct is wrong — review overhead scales with surface area, not with PR count.
+
+### Live-install mutation by fixer (#220)
+
+Fixer for #220 ran a `migrate-canonical --apply` against the operator's **live `BRIDGE_HOME`** instead of the test fixture. Mutated real state. Required admin task #1373 to reverse. Code change r2 added a `--i-know-this-is-live` guard.
+
+**Lesson**: footgun #1 (worktree path leakage) extends to runtime side-effects. Briefs that involve live-affecting commands must explicitly forbid mutation of the operator's `BRIDGE_HOME` and require the fixer to use a test prefix instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ version bumps via the `VERSION` file.
 
 ## [Unreleased]
 
+### Added
+
+- **`wave-orchestration` skill bundled in upstream** (`.claude/skills/wave-orchestration/`, `lib/bridge-skills.sh::bridge_bootstrap_claude_shared_skills` + `bridge_isolated_home_shared_skill_names`): the shared parallel-PR-ship orchestration spine (brief writing → `issue-fixer` dispatch into isolated git worktrees → `codex-rescue` review for >300 LOC specialized work or orchestrator-direct review for mid-size → squash-merge with structured `implement-ok` note → cleanup) is now distributed to every Agent Bridge agent on bootstrap. Pre-Wave the skill lived only in operator-level `~/.claude/skills/` — admin / dynamic / static agents needed manual symlinks. Now the same shared-skill bootstrap that already distributes `agent-bridge-runtime` / `cron-manager` / `memory-wiki` / `patch-permission-approval` also installs `wave-orchestration` so any agent that wakes can dispatch a wave with the same field-tested footgun catalog (8 documented footguns, brief template, codex-rescue setup recipe, 4 worked wave examples). The bundled `issue-fixer` agent (under the skill's `agents/` dir) is project-agnostic — operators copy to `~/.claude/agents/issue-fixer.md` once for `subagent_type: "issue-fixer"` to be available, or fall back to `general-purpose`. Generalized from the operator-private Agent Bridge build: machine-specific paths (operator's plugin cache, `/Users/<u>/...`) replaced with portable `command -v codex` / `PATH=...` resolution; Agent Bridge integration section explains queue-based dispatch (`bridge-task.sh create --to <peer>`) as the alternative to `Agent` tool dispatch for codex peers without that tool.
+
 ## [0.8.5] — 2026-05-08
 
 ### Highlight — closes 16 release-blocker findings surfaced by the v0.8.4 OrbStack VM E2E retest chain

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -178,6 +178,13 @@ bridge_bootstrap_claude_shared_skills() {
   bridge_link_shared_claude_skill "$workdir" "agent-bridge-runtime"
   bridge_link_shared_claude_skill "$workdir" "cron-manager"
   bridge_link_shared_claude_skill "$workdir" "memory-wiki"
+  # v0.8.6: wave-orchestration is the shared parallel-PR-ship pattern
+  # (issue-fixer dispatch into worktrees, codex-rescue review, squash-
+  # merge with structured notes). Distribute to every Agent Bridge agent
+  # so admin / dynamic / static agents all share the same orchestration
+  # spine — operators do not need to copy the skill into per-agent
+  # `.claude/skills/` manually.
+  bridge_link_shared_claude_skill "$workdir" "wave-orchestration"
 
   if [[ -n "$agent" ]]; then
     bridge_sync_claude_runtime_skills "$agent" "$workdir"
@@ -202,7 +209,8 @@ bridge_isolated_home_shared_skill_names() {
     "agent-bridge-runtime" \
     "cron-manager" \
     "memory-wiki" \
-    "patch-permission-approval"
+    "patch-permission-approval" \
+    "wave-orchestration"
 }
 
 # Render one skill text file from the controller-side source into the


### PR DESCRIPTION
## Summary

The shared parallel-PR-ship orchestration pattern (brief → `issue-fixer` dispatch into isolated worktrees → `codex-rescue` review or orchestrator-direct review → squash-merge with structured `implement-ok` note → cleanup) is now bundled in upstream and auto-distributed to every Agent Bridge agent on bootstrap.

## Why

Pre-PR the `wave-orchestration` skill lived only in operator-level `~/.claude/skills/`. Agents launched via `agent-bridge` (admin / dynamic / static, claude or codex pair) needed manual symlinks to use it. Operators were copy-pasting the SKILL.md across machines.

## What ships

**Skill** (`.claude/skills/wave-orchestration/`):
- `SKILL.md` — orchestration spine (~340 lines)
- `agents/issue-fixer.md` — project-agnostic single-issue fixer
- `references/brief-template.md`, `footguns.md`, `recipes.md`, `wave-examples.md`

**Bootstrap wiring** (`lib/bridge-skills.sh`):
- `bridge_bootstrap_claude_shared_skills` links `wave-orchestration` alongside the existing 3 shared skills into every agent's `<workdir>/.claude/skills/`.
- `bridge_isolated_home_shared_skill_names` includes it so isolated agents get the rendered copy under `<isolated-home>/.claude/skills/`.

## Generalization from operator-private build

- Machine-specific paths (operator's plugin cache codex-companion script) → portable `command -v codex` / `codex --version` / `PATH=...` resolution
- Agent Bridge integration section explains queue-based dispatch (`bridge-task.sh create --to <peer>`) as the alternative to `Agent` tool dispatch — codex peers don't have the `Agent` tool, so they delegate review to their claude pair via the bridge queue.

## Test plan

- [x] bash -n + shellcheck PASS on `lib/bridge-skills.sh`
- [x] scripts/smoke-test.sh PASS in isolated BRIDGE_HOME
- [x] Skill content sanity: no operator-machine paths leak (\`grep -rn '/Users/sean'\` returns 0 results in tracked content)

## Operator-side impact

- New Agent Bridge installs: every agent gets the skill on first bootstrap.
- Existing v0.8.x installs upgrading via `agent-bridge upgrade --apply`: skill copied into BRIDGE_HOME via deploy step; next agent bootstrap (or daemon restart picking up the updated agent home) links it.
- The bundled `issue-fixer` agent stays as a one-time copy for operators who want `subagent_type: "issue-fixer"` to be available; \`general-purpose\` fallback is documented in SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)