### PR TITLE
fix(migrate): skip leading-hyphen orphan dirs + grep -- separator (refs #708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ version bumps via the `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **#708 v0.7→v0.8 migration aborted when an orphan agent dir name started with `-`** (`lib/bridge-isolation-v2-migrate.sh::bridge_isolation_v2_migrate_capture_all_agents_snapshot`): an operator running `bridge-upgrade.sh --apply` on a v0.7.8 install whose `$BRIDGE_AGENT_HOME_ROOT` contained a stray dir like `agents/--help` (created by an earlier flag-typo'd `agent create` on a pre-v0.8 install or a manual `mkdir`) hit `isolation-v2 migration failed (rc=1) reason=groups-ensure`. Root cause: the markerless directory walk called `grep -qFx "$name" "$roster_lookup"` without the `--` end-of-options separator. When `$name` started with `-`, GNU grep parsed it as a flag (`-q -F -x --help`), printed its help text to stdout (which `2>/dev/null` does not silence), and the curly-brace block's stdout was piped into `sort -u > "$snapshot"` — so `state/migration/all-agents.snapshot` ended up containing ~70 lines of grep help text mixed with real agent ids. Downstream `ensure_groups_and_memberships` then ran `bridge_isolation_v2_agent_group_name` on the polluted lines, validation failed (e.g. `'                            ACTION is 'read' or 'skip'' has invalid chars`), the migration aborted, and `restart_agents` failed for every agent. v0.8.7 hotfix: (a) add `-*` to the case-filter denylist so `--`-prefixed dirs are skipped from the walk entirely; (b) add `--` to the `grep -qFx` invocation as defense-in-depth so any future callsite that drops the case filter cannot regress the same way. Operators on v0.8.6 with a stray `--`-prefixed orphan dir can move it under `backups/` (which the case filter already excluded) and rerun `bridge-upgrade.sh --apply` without manual intervention. Closes #708.
+
 ## [0.8.6] — 2026-05-08
 
 ### Highlight — closes 4 v0.7→v0.8 admin-pair migration findings + bundles wave-orchestration

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -267,7 +267,17 @@ bridge_isolation_v2_migrate_capture_all_agents_snapshot() {
         # scratch) get skipped instead of accidentally enrolled into
         # the v2 group/perm pass.
         case "$name" in
-          .*|backups|state|logs|shared|worktrees|agents-archive)
+          # Issue #708 (v0.8.7 hotfix): exclude dirs whose name starts with
+          # `-` so a stray `agents/--help` (e.g. created by a flag-typo'd
+          # v0.7.x `agent create` that bypassed name validation, or by a
+          # manual `mkdir`) never reaches the `grep -qFx "$name"` call
+          # below where grep would parse the leading `--` as its own help
+          # option and dump help text into the snapshot stdout. The grep
+          # call also gets the `--` end-of-options separator below as
+          # defense-in-depth, but skipping the dir up-front keeps the
+          # snapshot clean and matches the existing intent of pruning
+          # non-agent directories.
+          .*|-*|backups|state|logs|shared|worktrees|agents-archive)
             continue
             ;;
         esac
@@ -275,7 +285,12 @@ bridge_isolation_v2_migrate_capture_all_agents_snapshot() {
           # v0.8.3: silent for v1-layout agents in roster (they will
           # migrate via the roster path above and emit_plan rows). Warn
           # only for genuinely orphan dirs that are NOT in BRIDGE_AGENT_IDS.
-          if ! grep -qFx "$name" "$roster_lookup" 2>/dev/null; then
+          # Issue #708 (v0.8.7 hotfix): `--` end-of-options separator so a
+          # `$name` that begins with `-` cannot be parsed by grep as a flag.
+          # This is a safety belt — the case filter above already excludes
+          # `-*` dirs from the walk — but the separator ensures no future
+          # callsite that drops the case filter regresses the same way.
+          if ! grep -qFx -- "$name" "$roster_lookup" 2>/dev/null; then
             bridge_warn "isolation-v2 migration: skipping orphan dir $entry (not in roster, no home/ subdir)"
           fi
           continue


### PR DESCRIPTION
## Summary

Closes the v0.7→v0.8 migration abort the operator hit on v0.8.6 (issue #708): `bridge_isolation_v2_migrate_capture_all_agents_snapshot` could pollute `state/migration/all-agents.snapshot` with grep `--help` text when an orphan dir like `agents/--help` existed under `\$BRIDGE_AGENT_HOME_ROOT`.

## Root cause (verbatim from issue #708)

`grep -qFx "\$name" "\$roster_lookup"` without the `--` end-of-options separator. When `\$name` starts with `-`, GNU grep parses it as a flag (`-q -F -x --help`), prints help text to **stdout** (which `2>/dev/null` does not silence), and the curly-brace block's stdout pipes into `sort -u > "\$snapshot"`. Downstream `ensure_groups_and_memberships` then iterates the polluted snapshot, fails at `bridge_isolation_v2_agent_group_name`, and aborts the upgrade with `reason=groups-ensure`.

## Fix

Two-layer per operator's recommendation:

1. **case-filter denylist** (`lib/bridge-isolation-v2-migrate.sh:269`): add `-*` so `--`-prefixed dirs are skipped from the walk entirely. Matches the existing intent of pruning non-agent directories.
2. **grep `--` separator** (`lib/bridge-isolation-v2-migrate.sh:278`): defense-in-depth so any future callsite that drops the case filter cannot regress the same way.

## Operator workaround until lands

Operators on v0.8.6 with a stray `--`-prefixed orphan dir under `agents/`:

```bash
mv ~/.agent-bridge/agents/--help \
   ~/.agent-bridge/backups/agents-help-orphan-rescue-\$(date -u +%Y%m%dT%H%M%SZ)
```

Then rerun `bridge-upgrade.sh --apply` — the case filter already excludes `backups/`.

## Out of scope (future PRs)

- **agent create flag-typo guard hardening** (operator's "Suggested companion change"): `bridge_validate_agent_name` already requires `^[A-Za-z0-9]` as the first char (PR #526) so v0.8.x flow already rejects `--help`. The orphan dir in the operator's install was scaffolded by a pre-v0.8 install where the regex was looser. Captured separately if a defensive secondary check in `bridge-init.sh` flag parsing is wanted.
- **Source-tree daemon reaper** (operator's "Recovery state observed"): `bridge-upgrade.sh` may leave a `bridge-daemon.sh run` from `~/.agent-bridge-source/...` after the upgrade exit. Separate scope; track in a follow-up.

## Test plan

- [x] bash -n + shellcheck PASS
- [x] scripts/smoke-test.sh PASS
- [ ] Manual repro: \`mkdir ~/.agent-bridge/agents/--help && bash bridge-upgrade.sh --target ~/.agent-bridge --apply --pull --json\` — pre-fix fails, post-fix succeeds (deferred to v0.8.7 OrbStack VM verify if a wave-end retest is dispatched, otherwise operator-side validation on the original install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)