### PR TITLE
fix(daemon): preflight stale supplementary groups before start (closes #712)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -488,3 +488,35 @@ This is a debugging escape, not a permanent operating mode.
 Long-term operation without isolation is unsupported in v0.8.0.
 Report the underlying v2 issue upstream. Full operator notes:
 [`OPERATIONS.md` "Rollback hatch — `BRIDGE_DISABLE_ISOLATION=1`"](OPERATIONS.md).
+
+## 23. v1→v2 migration leaves the daemon "half-alive" if started from a stale shell (#712)
+
+After a v1→v2 isolation migration, a long-lived shell that predates
+the upgrade still carries the kernel-cached pre-upgrade supplementary
+group set even though `usermod` has added the operator to
+`ab-controller` (and any `ab-agent-*` groups) in passwd. A daemon
+spawned from such a shell starts successfully but cannot read
+`group=ab-controller mode 0640` state files — `agb status` then
+surfaces `bridge-state.sh:997 source "$file": Permission denied`.
+
+`bridge-daemon.sh start` now refuses with a re-login remediation
+when the current process is missing v2 groups its passwd entry
+includes. Linux-only; installs without `ab-controller` (e.g. macOS,
+or a fresh install that hasn't run v2 group setup) pass through
+unchanged.
+
+Diagnose:
+```
+cat /proc/$DAEMON_PID/status | grep ^Groups
+id -G
+```
+
+Recover (Linux):
+```
+exec sudo -i -u $USER bash
+bash bridge-daemon.sh start
+```
+
+Debug-only override: `BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS=1`
+(the `Permission denied` errors will return — set only when you
+need to inspect a specific failure mode).

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -5441,7 +5441,8 @@ bridge_daemon_supplementary_group_preflight() {
   # current process's supplementary GID set.
   case "${BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS:-}" in
     1|yes|YES|Yes|on|ON|On|true|TRUE|True)
-      daemon_warn "preflight: BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS set — skipping supplementary-group check"
+      # Silent skip: operator opted in to FORCE-start; do not pollute
+      # daemon stderr with a warn line on every start.
       return 0
       ;;
   esac
@@ -5505,7 +5506,13 @@ bridge_daemon_supplementary_group_preflight() {
   daemon_warn "누락: ${missing[*]}"
   daemon_warn ""
   daemon_warn "셸을 재로그인 (예: exec sudo -i -u \$USER bash) 후 다시 시도하세요."
-  daemon_warn "자세한 진단:"
+  daemon_warn ""
+  daemon_warn "[error] daemon refused to start: current shell's supplementary"
+  daemon_warn "  group set is missing v2 isolation groups."
+  daemon_warn "Missing: ${missing[*]}"
+  daemon_warn "Re-login (e.g. \`exec sudo -i -u \$USER bash\`) and retry."
+  daemon_warn ""
+  daemon_warn "자세한 진단 / Diagnostic:"
   daemon_warn "  cat /proc/\$\$/status | grep ^Groups"
   daemon_warn "  id -G"
   daemon_warn ""

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -5415,6 +5415,109 @@ bridge_stop_silence_watchdog() {
   fi
 }
 
+bridge_daemon_supplementary_group_preflight() {
+  # Issue #712: refuse `bridge-daemon.sh start` when the *current shell*
+  # is missing v2 isolation supplementary groups that the operator's
+  # passwd entry says they belong to. This is the v1→v2 stale-shell
+  # failure mode #668's migration-time warn does not cover (operator
+  # later restarts the daemon from the same pre-upgrade shell, daemon
+  # comes up "half-alive", reads of group=ab-controller mode 0640 env
+  # files trip Permission denied on bridge-state.sh:997).
+  #
+  # Returns 0 (PASS) — start may proceed — when:
+  #   - BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS is truthy (debug hatch), OR
+  #   - BRIDGE_DISABLE_ISOLATION is truthy (isolation off entirely), OR
+  #   - the host is not Linux (this stale-cache class is a Linux usermod
+  #     symptom; macOS has its own dseditgroup membership-refresh story
+  #     handled outside this preflight), OR
+  #   - getent / id are unavailable (cannot reason about groups; do no
+  #     harm), OR
+  #   - the controller group (ab-controller) does not exist on the host
+  #     (linux-user isolation is not deployed here — e.g. fresh install
+  #     that never ran v2 group setup).
+  #
+  # Returns non-zero (REFUSE) when at least one v2 group from the
+  # operator's passwd-driven static group set is absent from the
+  # current process's supplementary GID set.
+  case "${BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS:-}" in
+    1|yes|YES|Yes|on|ON|On|true|TRUE|True)
+      daemon_warn "preflight: BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS set — skipping supplementary-group check"
+      return 0
+      ;;
+  esac
+  if declare -F bridge_isolation_disabled_by_env >/dev/null 2>&1 \
+      && bridge_isolation_disabled_by_env; then
+    return 0
+  fi
+  [[ "$(uname -s)" == "Linux" ]] || return 0
+  command -v getent >/dev/null 2>&1 || return 0
+  command -v id >/dev/null 2>&1 || return 0
+
+  local controller_group="${BRIDGE_CONTROLLER_GROUP:-ab-controller}"
+  local agent_group_prefix="${BRIDGE_AGENT_GROUP_PREFIX:-ab-agent-}"
+  local shared_group="${BRIDGE_SHARED_GROUP:-ab-shared}"
+
+  # If the controller group itself is absent, linux-user isolation is
+  # not deployed on this host. Treat as not-applicable (PASS).
+  getent group "$controller_group" >/dev/null 2>&1 || return 0
+
+  # Static (passwd-driven) supplementary group set for the operator —
+  # includes any group memberships added by `usermod -aG` even when the
+  # current shell hasn't picked them up yet.
+  local operator="${USER:-$(id -un 2>/dev/null || true)}"
+  [[ -n "$operator" ]] || return 0
+  local static_groups
+  static_groups="$(id -nG -- "$operator" 2>/dev/null || true)"
+  [[ -n "$static_groups" ]] || return 0
+
+  # Current process supplementary GID set (numeric). On Linux `id -G`
+  # without a user argument reflects the running process's kernel-cached
+  # supp set, which is exactly the set the spawned daemon will inherit.
+  local proc_gids
+  proc_gids="$(id -G 2>/dev/null || true)"
+  [[ -n "$proc_gids" ]] || return 0
+
+  local missing=()
+  local g
+  for g in $static_groups; do
+    case "$g" in
+      "$controller_group"|"$shared_group"|"${agent_group_prefix}"*)
+        local gid
+        gid="$(getent group "$g" 2>/dev/null | awk -F: '{print $3}')"
+        [[ -n "$gid" ]] || continue
+        # Word-boundary match against the space-separated proc_gids.
+        case " $proc_gids " in
+          *" $gid "*) ;;
+          *) missing+=("$g") ;;
+        esac
+        ;;
+    esac
+  done
+
+  if (( ${#missing[@]} == 0 )); then
+    return 0
+  fi
+
+  daemon_warn ""
+  daemon_warn "============================================================"
+  daemon_warn "[오류] 데몬을 시작할 수 없습니다: 현재 셸의 supplementary group set이"
+  daemon_warn "  v2 isolation 그룹들을 포함하지 않습니다."
+  daemon_warn "누락: ${missing[*]}"
+  daemon_warn ""
+  daemon_warn "셸을 재로그인 (예: exec sudo -i -u \$USER bash) 후 다시 시도하세요."
+  daemon_warn "자세한 진단:"
+  daemon_warn "  cat /proc/\$\$/status | grep ^Groups"
+  daemon_warn "  id -G"
+  daemon_warn ""
+  daemon_warn "디버깅용 우회: BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS=1"
+  daemon_warn "(권한 오류가 isolated agent history env 읽기에서 다시 발생할 수 있음)"
+  daemon_warn "============================================================"
+  bridge_audit_log daemon daemon_start_refused daemon \
+    --detail reason=stale_supplementary_groups \
+    --detail missing="${missing[*]}" >/dev/null 2>&1 || true
+  return 1
+}
+
 cmd_start() {
   local start_deadline
   local recorded_pid=""
@@ -5449,6 +5552,15 @@ cmd_start() {
     daemon_info "bridge daemon already running (pid=$(bridge_daemon_pid))"
     bridge_start_silence_watchdog || true
     return 0
+  fi
+
+  # Issue #712: stale supplementary-group cache after v1→v2 migration
+  # leaves the daemon "half-alive" — it starts, but every read of an
+  # isolated-agent state file (group=ab-controller mode 0640) errors
+  # with Permission denied. Refuse to start when the current shell's
+  # supp set is missing v2 isolation groups it should have per passwd.
+  if ! bridge_daemon_supplementary_group_preflight; then
+    bridge_die "bridge daemon start refused: stale supplementary groups (set BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS=1 to override)"
   fi
 
   mkdir -p "$BRIDGE_STATE_DIR" "$BRIDGE_LOG_DIR"


### PR DESCRIPTION
## Summary
- bridge-daemon.sh start에 supplementary group preflight 추가
- v1→v2 migration 후 stale shell에서 데몬 시작 차단 + 재로그인 안내
- linux-user isolation 미사용 install (macOS, fresh install 등) 은 영향 없음
- `BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS=1` escape hatch (debug-only)
- KNOWN_ISSUES.md §23 — symptom + diagnostic + recovery 항목 추가

## What changes

새 helper `bridge_daemon_supplementary_group_preflight` (bridge-daemon.sh, top-level):

1. Linux 외 / `BRIDGE_DISABLE_ISOLATION=1` / `getent`·`id` 부재 / `ab-controller` group 부재 → PASS through (no-op).
2. 그 외에는 operator passwd 기준 v2 group set (`ab-controller`, `ab-shared`, `ab-agent-*`) 을 enumerate 하고, 각 group의 GID 가 현재 *process* 의 supplementary GID set (`id -G`) 에 있는지 확인.
3. 누락 발견 시 `bridge_die` 로 daemon start 중단 + Korean remediation 출력 + audit log (`daemon_start_refused`, reason=`stale_supplementary_groups`).

`cmd_start` 의 호출 위치는 "이미 실행 중" early return 후, 실제 spawn 직전 — healthy 데몬을 가진 stale shell 은 그대로 빠져나가고 새 spawn 만 보호.

## Refs
- closes #712
- 관련 #668 (migration 시점 fix), #683 (post-upgrade daemon 일관성)
- `lib/bridge-isolation-v2-migrate.sh:1162-1190` — migration-time deferred-restart 경고와 같은 family 의 post-migration restart 측 보호

## Test plan
- [x] `bash -n bridge-daemon.sh lib/bridge-isolation-v2.sh` PASS
- [x] `shellcheck -x bridge-daemon.sh lib/bridge-isolation-v2.sh` clean
- [x] `./scripts/smoke-test.sh` — pre-existing failure at `bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor (#428 r2)` unrelated to this PR (reproduces on clean ad0f578 HEAD)
- [x] 단독 helper 시뮬:
  - macOS host (no `ab-controller`) → PASS
  - `BRIDGE_DAEMON_FORCE_START_WITH_STALE_GROUPS=1` → PASS + warn
  - Linux + stale process supp set vs healthy passwd set → REFUSE + bilingual error block
  - Linux + matching supp set → PASS
- [ ] (수동 — reviewer side) linux-user isolation host 에서 stale shell 재현 → preflight refuse, `exec sudo -i -u $USER bash` 후 재시도 시 PASS