### PR TITLE
fix(isolation): sudo-handoff for watchdog scan + manual-stop clear + hooks workdir (refs #715 #714 #694)

### DIFF
--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -8,6 +8,8 @@ import json
 import os
 import shutil
 import shlex
+import subprocess
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -1106,11 +1108,92 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     return 0
 
 
+def _isolated_workdir_owner(workdir: Path) -> str | None:
+    # v0.8.8 #714 (item 3) / #694: bridge-hooks.py runs as the controller
+    # user. When the agent's workdir is owned by a linux-user-isolated
+    # account (`agent-bridge-<name>:agent-group mode 0750` from
+    # `bridge_isolation_v2_migrate_normalize_layout`), controller `mkdir`
+    # / `unlink` / `symlink_to` / `shutil.copy2` raise PermissionError.
+    # We don't have the agent name in this entry-point's argv, so derive
+    # the target user from the workdir's filesystem owner — that's the
+    # account the isolated UID was provisioned as. Returns None on
+    # non-Linux hosts, when stat fails, when the owner looks like
+    # root/controller, or when /etc/passwd lookup fails. The caller
+    # gates sudo escalation on a non-None return.
+    if sys.platform != "linux":
+        return None
+    try:
+        stat_result = workdir.stat()
+    except OSError:
+        # Workdir parent likely also unreadable — let the direct path
+        # raise the original PermissionError so callers see the same
+        # error shape they had before.
+        return None
+    try:
+        import pwd
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except (KeyError, ImportError):
+        return None
+    # Only escalate when the owner is clearly an isolated agent user.
+    # The bridge-isolation-v2 layout names them `agent-bridge-<slug>`;
+    # avoid escalating for controller-owned (current uid) workdirs so
+    # this is a no-op for shared-mode agents.
+    if stat_result.st_uid == os.getuid():
+        return None
+    if not owner.startswith("agent-bridge-"):
+        return None
+    return owner
+
+
+def _sudo_run_as(os_user: str, *cmd: str) -> int:
+    # Mirrors `bridge_linux_sudo_root` shape from `lib/bridge-agents.sh`
+    # but targets a specific isolated UID instead of root. Returns the
+    # subprocess return code; non-zero callers warn-and-continue.
+    full = ["sudo", "-n", "-u", os_user, *cmd]
+    try:
+        return subprocess.run(full, check=False).returncode
+    except FileNotFoundError:
+        # sudo missing — non-Linux dev hosts don't ship it. Treat as
+        # "escalation impossible" so the caller surfaces the original
+        # PermissionError instead of a confusing FileNotFoundError.
+        return 127
+
+
+def _ensure_dir_with_sudo(path: Path, os_user: str | None) -> None:
+    # Try direct mkdir first — non-isolated hosts and already-existing
+    # dirs hit this branch. On PermissionError, fall back to
+    # `sudo -n -u <agent-user> mkdir -p` so the isolated workdir gets
+    # `.claude/` created with the right owner. If sudo also fails the
+    # original PermissionError is re-raised so the caller's stderr
+    # shows the same error shape pre-#714.
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        return
+    except PermissionError:
+        if os_user is None:
+            raise
+        rc = _sudo_run_as(os_user, "mkdir", "-p", str(path))
+        if rc != 0:
+            raise
+
+
 def cmd_link_shared_settings(args: argparse.Namespace) -> int:
     settings_path = Path(args.workdir).expanduser() / ".claude" / "settings.json"
     shared_path = Path(args.shared_settings_file).expanduser()
-    settings_path.parent.mkdir(parents=True, exist_ok=True)
-    shared_path.parent.mkdir(parents=True, exist_ok=True)
+    # v0.8.8 #714 item 3 / #694: when the agent workdir is owned by a
+    # linux-user-isolated account, controller-side `mkdir` / `unlink` /
+    # `symlink_to` / `shutil.copy2` raise PermissionError because the
+    # workdir is mode 0750 owned by `agent-bridge-<name>:<group>`. The
+    # rerender / start path that drives this command runs as the
+    # controller, so we sniff the workdir owner and escalate via
+    # `sudo -n -u <agent-user>` for the file-system mutations only.
+    # On non-isolated agents `os_user` is None and every fallback is a
+    # no-op — the direct ops succeed first try, byte-for-byte
+    # unchanged.
+    workdir = Path(args.workdir).expanduser()
+    os_user = _isolated_workdir_owner(workdir)
+    _ensure_dir_with_sudo(settings_path.parent, os_user)
+    _ensure_dir_with_sudo(shared_path.parent, None)
 
     backup_path = ""
     status = "unchanged"
@@ -1121,12 +1204,33 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
         if current_target == desired_target:
             status = "unchanged"
         else:
-            settings_path.unlink()
+            try:
+                settings_path.unlink()
+            except PermissionError:
+                if os_user is None:
+                    raise
+                rc = _sudo_run_as(os_user, "rm", "-f", str(settings_path))
+                if rc != 0:
+                    raise
             status = "updated"
     elif settings_path.exists():
         backup = next_backup_path(settings_path)
-        shutil.copy2(settings_path, backup)
-        settings_path.unlink()
+        try:
+            shutil.copy2(settings_path, backup)
+        except PermissionError:
+            if os_user is None:
+                raise
+            rc = _sudo_run_as(os_user, "cp", "-p", str(settings_path), str(backup))
+            if rc != 0:
+                raise
+        try:
+            settings_path.unlink()
+        except PermissionError:
+            if os_user is None:
+                raise
+            rc = _sudo_run_as(os_user, "rm", "-f", str(settings_path))
+            if rc != 0:
+                raise
         backup_path = str(backup)
         status = "updated"
     else:
@@ -1134,7 +1238,14 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
 
     if not settings_path.exists():
         rel_target = os.path.relpath(shared_path, start=settings_path.parent)
-        settings_path.symlink_to(rel_target)
+        try:
+            settings_path.symlink_to(rel_target)
+        except PermissionError:
+            if os_user is None:
+                raise
+            rc = _sudo_run_as(os_user, "ln", "-s", rel_target, str(settings_path))
+            if rc != 0:
+                raise
 
     payload = {
         "HOOK_SETTINGS_FILE": str(settings_path),

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -1123,7 +1123,14 @@ def _isolated_workdir_owner(workdir: Path) -> str | None:
     if sys.platform != "linux":
         return None
     try:
-        stat_result = workdir.stat()
+        # v0.8.8 r2 (codex CHECK 4): use lstat so a workdir that is itself
+        # a symlink (rare but possible when a dynamic agent's worktree is
+        # symlinked into ~/.agent-bridge/agents/<name>) reports the link's
+        # owner rather than the dereferenced target. The fallback below
+        # only escalates to `sudo -n -u agent-bridge-<slug>`, so reading
+        # the link itself is the right signal — escalating to the target's
+        # owner would be a category error.
+        stat_result = workdir.lstat()
     except OSError:
         # Workdir parent likely also unreadable — let the direct path
         # raise the original PermissionError so callers see the same
@@ -1156,6 +1163,15 @@ def _sudo_run_as(os_user: str, *cmd: str) -> int:
         # sudo missing — non-Linux dev hosts don't ship it. Treat as
         # "escalation impossible" so the caller surfaces the original
         # PermissionError instead of a confusing FileNotFoundError.
+        # v0.8.8 r2 (codex CHECK 6): emit a one-line warn so the
+        # operator sees *why* fallback is impossible (this would
+        # otherwise be a silent 127 → caller re-raises the original
+        # PermissionError without context).
+        print(
+            f"[bridge-hooks] sudo not available; cannot escalate to "
+            f"'{os_user}' for {cmd}",
+            file=sys.stderr,
+        )
         return 127
 
 
@@ -1175,6 +1191,64 @@ def _ensure_dir_with_sudo(path: Path, os_user: str | None) -> None:
         rc = _sudo_run_as(os_user, "mkdir", "-p", str(path))
         if rc != 0:
             raise
+
+
+def _safe_path_check(check: str, path: Path, os_user: str | None) -> bool:
+    """PermissionError-safe filesystem predicate for isolated workdirs.
+
+    `check` is one of: "exists", "is_symlink".
+
+    v0.8.8 r2 (codex review needs-more, refs #715-B / #714-2 / #694):
+    `cmd_link_shared_settings` previously called `settings_path.is_symlink()`
+    and `settings_path.exists()` directly. On a linux-user-isolated workdir
+    (`agent-bridge-<slug>:agent-group 0750`), the controller process gets
+    `r-x` on the parent dir but the inode metadata read still succeeds in
+    practice — *until* the agent dir is locked down further (e.g. ACL
+    drift, group-membership timing post-relogin, or 0700 mode), at which
+    point `is_symlink()` / `exists()` raise PermissionError before the
+    rm/cp/ln fallback ever runs. Same isolated-permission shape that
+    drives the rest of this function. Wrap the metadata probes in a
+    sudo-fallback so the controller can interrogate the path via
+    `sudo -n -u agent-bridge-<slug> test -e/-h` when direct stat fails.
+    Falls back to plain raise when `os_user` is None (non-isolated).
+    """
+    try:
+        if check == "exists":
+            return path.exists()
+        if check == "is_symlink":
+            return path.is_symlink()
+    except PermissionError:
+        if os_user is None:
+            raise
+        flag = "-e" if check == "exists" else "-h"
+        rc = _sudo_run_as(os_user, "test", flag, str(path))
+        return rc == 0
+    return False  # unreachable on supported `check` values; satisfies type checkers
+
+
+def _safe_realpath(path: Path, os_user: str | None) -> str:
+    """PermissionError-safe `os.path.realpath` for isolated workdirs.
+
+    Companion to `_safe_path_check`. `os.path.realpath` resolves symlinks
+    by stat-ing each component; on an isolated workdir the controller
+    can hit PermissionError mid-resolution. Fall back to
+    `sudo -n -u <agent-user> readlink -f`. Returns the original path
+    string when the sudo fallback also fails (best-effort — the caller
+    compares two realpaths for equality, so falling back to the raw
+    string just forces the "not equal" branch and re-creates the link).
+    """
+    try:
+        return os.path.realpath(path)
+    except PermissionError:
+        if os_user is None:
+            raise
+        result = subprocess.run(
+            ["sudo", "-n", "-u", os_user, "readlink", "-f", str(path)],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip() or str(path)
 
 
 def cmd_link_shared_settings(args: argparse.Namespace) -> int:
@@ -1198,9 +1272,13 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
     backup_path = ""
     status = "unchanged"
 
-    if settings_path.is_symlink():
-        current_target = os.path.realpath(settings_path)
-        desired_target = os.path.realpath(shared_path)
+    if _safe_path_check("is_symlink", settings_path, os_user):
+        current_target = _safe_realpath(settings_path, os_user)
+        # `shared_path` is controller-owned (lives under shared/ in the
+        # bridge runtime, never inside an isolated workdir). Pass
+        # os_user=None to keep the realpath straightforward and avoid
+        # an unnecessary sudo escalation surface.
+        desired_target = _safe_realpath(shared_path, None)
         if current_target == desired_target:
             status = "unchanged"
         else:
@@ -1213,7 +1291,7 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
                 if rc != 0:
                     raise
             status = "updated"
-    elif settings_path.exists():
+    elif _safe_path_check("exists", settings_path, os_user):
         backup = next_backup_path(settings_path)
         try:
             shutil.copy2(settings_path, backup)
@@ -1236,7 +1314,7 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
     else:
         status = "updated"
 
-    if not settings_path.exists():
+    if not _safe_path_check("exists", settings_path, os_user):
         rel_target = os.path.relpath(shared_path, start=settings_path.parent)
         try:
             settings_path.symlink_to(rel_target)

--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -109,24 +110,59 @@ def classify_status(
 
 
 def scan_agent(agent_dir: Path) -> AgentWatch:
-    missing_files = [name for name in REQUIRED_FILES if not (agent_dir / name).exists()]
-    claude_text = read_text(agent_dir / "CLAUDE.md") if (agent_dir / "CLAUDE.md").exists() else ""
-    missing_block = MANAGED_START not in claude_text or MANAGED_END not in claude_text
-    session_type, onboarding_state = parse_session_type(agent_dir)
-    heartbeat_present, heartbeat_age = heartbeat_age_seconds(agent_dir)
-    broken_links = collect_broken_links(agent_dir)
-    status = classify_status(missing_files, broken_links, onboarding_state, missing_block, session_type)
-    return AgentWatch(
-        agent=agent_dir.name,
-        session_type=session_type,
-        onboarding_state=onboarding_state,
-        status=status,
-        missing_files=missing_files,
-        broken_links=broken_links,
-        missing_managed_claude_block=missing_block,
-        heartbeat_present=heartbeat_present,
-        heartbeat_age_seconds=heartbeat_age,
-    )
+    # v0.8.8 #715-B / #694: linux-user-isolated agents own
+    # `agents/<name>/CLAUDE.md` as `agent-bridge-<name>:<group> 0640`.
+    # When the controller process credentials don't include the new
+    # group (typical post-migration / post-relogin window), `.exists()`
+    # / `.read_text()` on that path raise `PermissionError` and the
+    # outer list-comprehension in `main()` propagates the exception —
+    # one isolated agent kills the whole watchdog walk and every other
+    # agent's row stays stale. Same shape PR #688 handled in
+    # `bridge-status.py::pending_upgrade_conflict_count` and PR #695's
+    # follow-up `workdir_display`. Wrap the per-agent scan so the row
+    # downgrades to a `warn` placeholder and the outer walk continues
+    # for the rest of the roster. Missing-files / heartbeat / broken-
+    # links fields default to "empty" because we genuinely don't know
+    # — surfacing the `permission denied during scan` note on the
+    # `broken_links` channel keeps the existing markdown render
+    # unchanged (no new `AgentWatch` fields, per spec).
+    try:
+        missing_files = [name for name in REQUIRED_FILES if not (agent_dir / name).exists()]
+        claude_text = read_text(agent_dir / "CLAUDE.md") if (agent_dir / "CLAUDE.md").exists() else ""
+        missing_block = MANAGED_START not in claude_text or MANAGED_END not in claude_text
+        session_type, onboarding_state = parse_session_type(agent_dir)
+        heartbeat_present, heartbeat_age = heartbeat_age_seconds(agent_dir)
+        broken_links = collect_broken_links(agent_dir)
+        status = classify_status(missing_files, broken_links, onboarding_state, missing_block, session_type)
+        return AgentWatch(
+            agent=agent_dir.name,
+            session_type=session_type,
+            onboarding_state=onboarding_state,
+            status=status,
+            missing_files=missing_files,
+            broken_links=broken_links,
+            missing_managed_claude_block=missing_block,
+            heartbeat_present=heartbeat_present,
+            heartbeat_age_seconds=heartbeat_age,
+        )
+    except (PermissionError, FileNotFoundError) as exc:
+        print(
+            f"[bridge-watchdog] skipped {agent_dir.name}: "
+            f"{type(exc).__name__} during scan ({exc.strerror or exc}); "
+            f"likely isolated agent unreadable to controller",
+            file=sys.stderr,
+        )
+        return AgentWatch(
+            agent=agent_dir.name,
+            session_type="unknown",
+            onboarding_state="unknown",
+            status="warn",
+            missing_files=[],
+            broken_links=[f"permission denied during scan: {type(exc).__name__}"],
+            missing_managed_claude_block=False,
+            heartbeat_present=False,
+            heartbeat_age_seconds=None,
+        )
 
 
 def render_markdown(records: list[AgentWatch], bridge_home: Path) -> str:

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2631,8 +2631,38 @@ bridge_agent_clear_manual_stop() {
 
   file="$(bridge_agent_manual_stop_file "$agent")"
   dir="$(bridge_agent_idle_marker_dir "$agent")"
-  rm -f "$file"
-  rmdir "$dir" >/dev/null 2>&1 || true
+
+  # v0.8.8 #714 (item 2): when the host runs linux-user isolation, the
+  # idle-marker directory `state/agents/<agent>/` is owned by
+  # `agent-bridge-<agent>:ab-controller mode 2750` (per
+  # bridge_linux_prepare_agent_isolation). The controller user is in
+  # the group but only has `r-x` at the marker dir, so plain `rm -f`
+  # on the manual-stop file inside it raises EACCES. Same shape PR
+  # #692 solved for `runtime/history.env` via
+  # `bridge_state_v2_isolated_target` + sudo install. Here the file is
+  # under `state/agents/`, not `$BRIDGE_AGENT_ROOT_V2/`, so the
+  # existing predicate doesn't match — we gate on
+  # `bridge_agent_linux_user_isolation_effective` directly. On
+  # non-Linux hosts `bridge_linux_sudo_root` falls through to the
+  # direct invocation, so this branch is a no-op there and on
+  # non-isolated agents the plain `rm -f` already succeeded.
+  if ! rm -f "$file" 2>/dev/null; then
+    if bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+      if ! bridge_linux_sudo_root rm -f "$file" 2>/dev/null; then
+        bridge_warn "bridge_agent_clear_manual_stop: failed to remove $file (agent=$agent); manual-stop may persist and re-suppress autostart"
+      fi
+    else
+      bridge_warn "bridge_agent_clear_manual_stop: failed to remove $file (agent=$agent); manual-stop may persist and re-suppress autostart"
+    fi
+  fi
+
+  if ! rmdir "$dir" >/dev/null 2>&1; then
+    if bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+      # rmdir on a non-empty dir is expected and not an error; suppress
+      # only the silent-fail path. The sudo attempt is best-effort.
+      bridge_linux_sudo_root rmdir "$dir" >/dev/null 2>&1 || true
+    fi
+  fi
 }
 
 bridge_reconcile_idle_markers() {


### PR DESCRIPTION
## Summary
- `bridge-watchdog.py:scan_agent`에 try/except — isolated `agents/<name>/CLAUDE.md` `PermissionError`가 전체 walk를 죽이지 않음. PR #688 / #695 패턴 reference.
- `lib/bridge-state.sh:bridge_agent_clear_manual_stop` sudo-handoff — `state/agents/<agent>/manual-stop` (mode 2750 owned by isolated UID) 가 plain `rm -f`로 안 지워지던 #714 item 2 회귀 차단. 실패 시 `bridge_warn`(silent-fail이 #714 진단 비용 키운 원인).
- `bridge-hooks.py:cmd_link_shared_settings` sudo-handoff — isolated workdir(`mode 0750 owner=agent-bridge-<name>`)에서 controller가 `.claude/` mkdir / unlink / symlink_to / shutil.copy2 실패 시 `sudo -n -u <agent-user>` fallback. agent-user는 `pwd.getpwuid(workdir.stat().st_uid)`로 sniff(별도 인자 도입 없음).

비-isolated, 비-Linux 호스트에서는 모든 fallback이 no-op — direct path가 먼저 성공하고 macOS에서는 `bridge_linux_sudo_root`가 직접 호출로 떨어지므로 byte-for-byte 동일 동작.

## Refs
- #715 항목 B (bridge-watchdog crash on isolated CLAUDE.md)
- #714 항목 2 (manual-stop clear EACCES) + 항목 3 (hooks workdir mkdir EACCES)
- #694 (Wave-3 multi-site PermissionError, third + fourth site)

## Out of scope
- 새 helper API 도입 (기존 `bridge_agent_linux_user_isolation_effective` / `bridge_linux_sudo_root` 재사용)
- VERSION / CHANGELOG bump
- watchdog markdown 출력 포맷 변경 (`AgentWatch` dataclass에 신규 필드 없음)
- 다른 sudo-handoff 결함 site 추적 — 이번 3개로 범위 고정

## Test plan
- [x] `bash -n lib/bridge-state.sh` — clean
- [x] `shellcheck -x lib/bridge-state.sh` — clean
- [x] `python3 -c \"import ast; ast.parse(open('bridge-watchdog.py').read())\"` — ok
- [x] `python3 -c \"import ast; ast.parse(open('bridge-hooks.py').read())\"` — ok
- [x] manual: 정상 agent + chmod 000 CLAUDE.md 인 bad agent 섞어서 watchdog scan → bad는 warn placeholder, good은 정상 row, walk 안 죽음
- [x] manual: link-shared-settings tmp workdir 에서 정상 symlink 생성 (non-isolated path)
- [ ] (수동) Linux isolated agent host에서 daemon 재기동 후 status / agb attach / start 패스 무에러 — VM 검증은 wave-end OrbStack retest로 deferred (`bridge_linux_sudo_root` chain은 Linux에서만 활성)
- [ ] smoke-test: pre-existing isolation-v2 layout gate (bridge-run.sh dryrun-redact-smoke) 가 main에서도 동일 fail (`current_layout=legacy`) — 본 PR과 무관한 fresh-host gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)