### PR TITLE
fix(start): post-launch tmux has-session polling + log tail surface (refs #715 #714)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -539,7 +539,25 @@ if [[ $# -gt 0 ]]; then
         exit 0
       fi
 
-      exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "--$ADMIN_ENGINE" --name "$ADMIN_AGENT" --workdir "$ADMIN_WORKDIR" --loop "$@"
+      # Issue #715-C / #714-5: bridge-start.sh now exits non-zero when a
+      # spawned tmux session dies inside the post-launch verify window.
+      # Propagate that signal here (instead of `exec`-ing) so we can append
+      # an admin-targeted remediation hint after the child's own log tail.
+      "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "--$ADMIN_ENGINE" --name "$ADMIN_AGENT" --workdir "$ADMIN_WORKDIR" --loop "$@"
+      _admin_rc=$?
+      if [[ $_admin_rc -ne 0 ]]; then
+        cat >&2 <<EOF
+[오류] '$ADMIN_AGENT' 어드민 세션이 시작 직후 종료되었습니다.
+진단:
+  bash bridge-daemon.sh status
+  grep "plugin MCP liveness miss\\|$ADMIN_AGENT died" "\$BRIDGE_HOME/state/daemon.log" | tail
+  tail -20 "\$BRIDGE_HOME/agents/$ADMIN_AGENT/logs/\$(date +%Y%m%d).log"
+설정 누락 가능성:
+  agb setup discord    # discord relay token 등록
+  agb setup teams      # microsoft teams access.json 등록
+EOF
+      fi
+      exit "$_admin_rc"
       ;;
     bootstrap)
       shift

--- a/agent-bridge
+++ b/agent-bridge
@@ -543,8 +543,12 @@ if [[ $# -gt 0 ]]; then
       # spawned tmux session dies inside the post-launch verify window.
       # Propagate that signal here (instead of `exec`-ing) so we can append
       # an admin-targeted remediation hint after the child's own log tail.
-      "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "--$ADMIN_ENGINE" --name "$ADMIN_AGENT" --workdir "$ADMIN_WORKDIR" --loop "$@"
-      _admin_rc=$?
+      # NOTE: `set -e` at the top of this script would terminate before
+      # `_admin_rc=$?` runs on a nonzero child; the `|| _admin_rc=$?`
+      # tail keeps the heredoc + exit-propagation reachable.
+      _admin_rc=0
+      "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "--$ADMIN_ENGINE" --name "$ADMIN_AGENT" --workdir "$ADMIN_WORKDIR" --loop "$@" \
+        || _admin_rc=$?
       if [[ $_admin_rc -ne 0 ]]; then
         cat >&2 <<EOF
 [오류] '$ADMIN_AGENT' 어드민 세션이 시작 직후 종료되었습니다.

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -58,6 +58,58 @@ bridge_start_should_controller_accept_dev_channels() {
   [[ -n "$effective" ]]
 }
 
+bridge_start_post_launch_verify() {
+  # Issue #715-C / #714-5: tmux new-session reports success even if the
+  # session dies a few hundred ms later (plugin MCP liveness restart loop,
+  # missing operator config, isolation permission errors). Poll
+  # bridge_tmux_session_exists for a short window and surface a log tail +
+  # remediation hint when the session disappears, so `agb admin` and
+  # `bash bridge-start.sh <agent>` no longer report success on a dead
+  # tmux pane.
+  local session="$1"
+  local agent="$2"
+  local attempts="${BRIDGE_START_VERIFY_POLL_ATTEMPTS:-10}"
+  local interval="${BRIDGE_START_VERIFY_POLL_INTERVAL_SECONDS:-1}"
+  local tail_lines="${BRIDGE_START_VERIFY_LOG_TAIL_LINES:-20}"
+  local i log_dir log_file=""
+
+  [[ "$attempts" =~ ^[0-9]+$ ]] || attempts=10
+  [[ "$interval" =~ ^[0-9]+$ ]] || interval=1
+  [[ "$tail_lines" =~ ^[0-9]+$ ]] || tail_lines=20
+  (( attempts > 0 )) || return 0
+  (( interval > 0 )) || interval=1
+
+  # Defensive: if tmux helper isn't loaded for any reason, preserve prior
+  # behaviour (silent skip) rather than spuriously failing healthy starts.
+  declare -F bridge_tmux_session_exists >/dev/null 2>&1 || return 0
+
+  for ((i = 0; i < attempts; i++)); do
+    sleep "$interval"
+    if ! bridge_tmux_session_exists "$session"; then
+      log_dir="$(bridge_agent_log_dir "$agent" 2>/dev/null || true)"
+      if [[ -n "$log_dir" ]]; then
+        log_file="$log_dir/$(date '+%Y%m%d').log"
+      fi
+      bridge_warn "세션 '$session'이 시작 직후 종료되었습니다 (시작 후 $((i + 1)) 회차 polling)."
+      if [[ -n "$log_file" && -r "$log_file" ]]; then
+        printf '[info] 마지막 로그 (%s):\n' "$log_file" >&2
+        tail -n "$tail_lines" "$log_file" >&2 || true
+      else
+        printf '[info] 에이전트 로그를 찾지 못했습니다 (확인 경로: %s)\n' "${log_file:-<unknown>}" >&2
+      fi
+      cat >&2 <<EOF
+[info] 가능한 원인:
+  - daemon 쪽 plugin MCP liveness restart loop
+    (확인: grep "plugin MCP liveness miss" "\$BRIDGE_HOME/state/daemon.log")
+  - operator-config 누락 (예: discord/teams 토큰; agb setup discord / agb setup teams)
+  - workdir 권한 (linux-user isolation; agent workdir 소유권/모드 확인)
+EOF
+      return 1
+    fi
+  done
+  return 0
+}
+
 bridge_start_schedule_dev_channels_accept() {
   local session="$1"
   local agent="$2"
@@ -446,6 +498,14 @@ if [[ -z "$(bridge_agent_session_id "$AGENT")" ]]; then
   bridge_refresh_agent_session_id "$AGENT" 12 0.25 >/dev/null 2>&1 || true
 fi
 echo "[info] 세션 '$SESSION' 시작 완료"
+
+# Issue #715-C / #714-5: short post-launch has-session polling so a session
+# that dies inside the first few seconds (e.g. daemon restart loop on an
+# unconfigured plugin MCP, isolation permission failure) is surfaced with
+# a log tail and remediation hint instead of a silent success.
+if ! bridge_start_post_launch_verify "$SESSION" "$AGENT"; then
+  exit 1
+fi
 
 if [[ $ATTACH -eq 1 ]]; then
   bridge_attach_tmux_session "$SESSION"


### PR DESCRIPTION
## Summary
- `bridge-start.sh` 세션 시작 후 짧은 has-session 폴링 (default 10x1s, env: `BRIDGE_START_VERIFY_POLL_ATTEMPTS` / `BRIDGE_START_VERIFY_POLL_INTERVAL_SECONDS`) 추가.
- 폴링 중 세션이 죽으면 agent log tail (`BRIDGE_START_VERIFY_LOG_TAIL_LINES=20`) + 한국어 remediation hint 출력 + 비-0 exit.
- `agent-bridge admin` slow-path 의 `exec` 를 wait-and-propagate 로 교체. 어드민 dead-tmux 시 추가 진단 블록 (`bash bridge-daemon.sh status`, `grep "plugin MCP liveness miss"`, `agb setup discord`/`teams`) 을 child log tail 위에 덧붙임.

## What changes

### `bridge-start.sh`
- 새 helper `bridge_start_post_launch_verify` (top-level): polling 후 `bridge_tmux_session_exists` 가 false 가 되면 log tail + remediation hint 를 stderr 로 출력하고 1 반환.
- `tmux new-session` 직후, `[info] 세션 'X' 시작 완료` 출력 다음에 위 helper 를 호출. 비-0 시 `exit 1`.
- Defensive: `declare -F bridge_tmux_session_exists` 미정의 시 silent skip (기존 거동 보존).
- DRY_RUN 경로는 영향 없음 (DRY_RUN exit 0 이 새 코드 전에 발생).

### `agent-bridge` (admin slow path)
- `exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" --claude --name patch ...` 를 conditional run + `exit \"$_admin_rc\"` 로 변경.
- 비-0 rc 시 어드민 한정 한국어 diagnostic block 을 stderr 로 출력 (agb setup discord / teams hint 포함).

## Behavioral impact

- 정상 (살아있는) 세션: polling 한 번만 sleep 한 뒤 즉시 통과 — 기존 60s dev-channels arming 비용은 그대로 (영향 거의 없음).
- 시작 직후 죽는 세션: 최대 10초 안에 감지 + log tail + remediation hint + 비-0 exit. `agb admin` 이 60초 동안 거짓 성공 보고하던 cliff 제거.

## Refs
- #715 항목 C — `agb admin` slow-path always burns 60s + lies about session liveness
- #714 항목 5 — bridge-start.sh reports success then session dies; no diagnosis surface

## Test plan
- [x] `bash -n bridge-start.sh agent-bridge` PASS
- [x] `shellcheck -x bridge-start.sh agent-bridge` clean
- [x] `bridge_start_post_launch_verify` 단위 테스트 (Bash 5, non-existent session): correctly returns 1 with warn message
- [x] `./scripts/smoke-test.sh` — pre-existing failure at `bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor (#428 r2)` reproduces on clean `ad0f578` HEAD; unrelated to this PR
- [ ] (수동, 리뷰어 측) post-launch death 시뮬: tmux kill-session in <10s → bridge-start.sh 비-0 exit + log tail 출력
- [ ] (수동) `agb admin` 의 fast-attach (이미 살아있는 세션) 경로는 `exec` 회피 분기를 거치지 않으므로 영향 없음 확인

## Out of scope
- `BRIDGE_START_DEV_CHANNELS_ACCEPT_TIMEOUT_SECONDS=60` default 줄이기 (별도 design)
- daemon plugin-MCP-liveness restart cap (Track A — 별도 PR)
- dashboard / `agb attach` UX hint (Track E — Wave 2 예정)