### PR TITLE
fix(start): auto-rebuild missing static workdir before launch (refs #714)

### DIFF
--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -230,16 +230,24 @@ if [[ ! -d "$WORK_DIR" ]]; then
   # gap from #714 (item 10 — `patch-dev` static-role with no workdir
   # tree at all). #4 in the per-symptom table:
   #   - DEFAULT_WORK_DIR: legacy default home path. Plain mkdir.
-  #   - bridge_agent_workdir(AGENT): v2 canonical workdir path. Same
+  #   - v2 canonical: $BRIDGE_AGENT_ROOT_V2/<agent>/workdir. Same
   #     identity as the just-resolved $WORK_DIR for static roles, but
   #     under v2 the parent (`<root>/agents/<agent>/`) may be
   #     root-owned, so fall back to bridge_linux_sudo_root.
   # Anything else (operator-supplied --workdir to a dynamic agent,
-  # roster-explicit non-default path) keeps the original die behavior:
-  # we don't want to silently materialize directories the operator
-  # named by mistake.
-  CANONICAL_WORK_DIR="$(bridge_agent_workdir "$AGENT")"
-  if [[ "$WORK_DIR" == "$DEFAULT_WORK_DIR" || "$WORK_DIR" == "$CANONICAL_WORK_DIR" ]]; then
+  # roster-explicit non-default path on a v2-disabled install) keeps
+  # the original die behavior: we don't want to silently materialize
+  # directories the operator named by mistake.
+  #
+  # Direct prefix-string comparison against $BRIDGE_AGENT_ROOT_V2 is
+  # used instead of re-invoking bridge_agent_workdir() — that helper
+  # falls through to BRIDGE_AGENT_WORKDIR[<agent>] (an external path)
+  # when v2 is not active, which would cause $WORK_DIR to compare
+  # equal to itself and erroneously skip the die branch on v2-disabled
+  # installs (codex r2 finding).
+  if [[ "$WORK_DIR" == "$DEFAULT_WORK_DIR" ]]; then
+    mkdir -p "$WORK_DIR"
+  elif [[ -n "$BRIDGE_AGENT_ROOT_V2" && "$WORK_DIR" == "$BRIDGE_AGENT_ROOT_V2/$AGENT/workdir" ]]; then
     echo "[info] '$AGENT' static workdir 누락, 자동 재생성: $WORK_DIR"
     if ! mkdir -p "$WORK_DIR" 2>/dev/null; then
       # v2 isolated layout: the parent agent root may be root-owned

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -226,8 +226,34 @@ CHANNEL_REASON=""
 AGENT_ENV_FILE=""
 
 if [[ ! -d "$WORK_DIR" ]]; then
-  if [[ "$WORK_DIR" == "$DEFAULT_WORK_DIR" ]]; then
-    mkdir -p "$WORK_DIR"
+  # Two auto-rebuild paths cover the post-migration "workdir vanished"
+  # gap from #714 (item 10 — `patch-dev` static-role with no workdir
+  # tree at all). #4 in the per-symptom table:
+  #   - DEFAULT_WORK_DIR: legacy default home path. Plain mkdir.
+  #   - bridge_agent_workdir(AGENT): v2 canonical workdir path. Same
+  #     identity as the just-resolved $WORK_DIR for static roles, but
+  #     under v2 the parent (`<root>/agents/<agent>/`) may be
+  #     root-owned, so fall back to bridge_linux_sudo_root.
+  # Anything else (operator-supplied --workdir to a dynamic agent,
+  # roster-explicit non-default path) keeps the original die behavior:
+  # we don't want to silently materialize directories the operator
+  # named by mistake.
+  CANONICAL_WORK_DIR="$(bridge_agent_workdir "$AGENT")"
+  if [[ "$WORK_DIR" == "$DEFAULT_WORK_DIR" || "$WORK_DIR" == "$CANONICAL_WORK_DIR" ]]; then
+    echo "[info] '$AGENT' static workdir 누락, 자동 재생성: $WORK_DIR"
+    if ! mkdir -p "$WORK_DIR" 2>/dev/null; then
+      # v2 isolated layout: the parent agent root may be root-owned
+      # (`<data-root>/agents/<agent>/` mode 0750 root:root) so the
+      # controller user cannot mkdir the workdir leaf directly. Reuse
+      # the existing sudo-handoff helper from lib/bridge-agents.sh
+      # (no new helper introduced — Track B owns sudo-handoff helper
+      # surface).
+      bridge_linux_sudo_root mkdir -p "$WORK_DIR" || \
+        bridge_die "workdir 자동 재생성 실패: $WORK_DIR"
+    fi
+    if [[ ! -d "$WORK_DIR" ]]; then
+      bridge_die "workdir 자동 재생성 후에도 존재하지 않음: $WORK_DIR"
+    fi
   else
     bridge_die "workdir가 없습니다: $WORK_DIR"
   fi


### PR DESCRIPTION
## Summary

- `bridge-start.sh`: WORK_DIR 누락 + `bridge_agent_workdir(AGENT)` 와 일치하면 die 대신 auto-rebuild
- 외부 임의 경로 (operator-supplied `--workdir`, roster-explicit non-default) 는 기존 die 동작 보존
- isolated agent 의 경우 기존 `bridge_linux_sudo_root` helper (lib/bridge-agents.sh) 재사용 — 새 sudo-handoff helper 도입 없음 (Track B 와 surface 충돌 회피)

## Background

#714 항목 10: post-migration `patch-dev` static-role 의 workdir 트리가 통째로 누락. v2 layout 하에서 `bridge_agent_workdir(AGENT)` = `<data-root>/agents/<agent>/workdir` 가 legacy `DEFAULT_WORK_DIR` 와 다르므로 기존 분기는 die 로 떨어졌음. 운영자는 `[오류] workdir가 없습니다` 만 보고 어떻게 복구해야 하는지 알 수 없었음.

## Behavior change

```
if [[ ! -d "$WORK_DIR" ]]; then
  CANONICAL_WORK_DIR="$(bridge_agent_workdir "$AGENT")"
  if [[ "$WORK_DIR" == "$DEFAULT_WORK_DIR" || "$WORK_DIR" == "$CANONICAL_WORK_DIR" ]]; then
    echo "[info] '$AGENT' static workdir 누락, 자동 재생성: $WORK_DIR"
    if ! mkdir -p "$WORK_DIR" 2>/dev/null; then
      bridge_linux_sudo_root mkdir -p "$WORK_DIR" || bridge_die "..."
    fi
    [[ -d "$WORK_DIR" ]] || bridge_die "..."
  else
    bridge_die "workdir가 없습니다: $WORK_DIR"
  fi
fi
```

- v2 layout: 부모 (`<root>/agents/<agent>/`) 가 root-owned 0750 일 때 plain `mkdir -p` 가 EACCES → `bridge_linux_sudo_root mkdir -p` 로 fallback. 둘 다 실패하면 fail-loud die.
- 비-v2 / DEFAULT_WORK_DIR 케이스는 plain mkdir 첫 시도가 통과.
- dynamic agent (`--workdir /tmp/manual-test`) 또는 roster-explicit non-default workdir 가 누락된 경우: 기존 die 그대로. 사용자가 typo 한 경로를 silent 하게 materialize 하지 않음.

## Verification

- `bash -n bridge-start.sh` — ok
- `shellcheck -x bridge-start.sh` — ok
- `./scripts/smoke-test.sh` — exit 1 reproduces on `origin/main` (pre-existing isolation-v2 marker check; not related to this change)

## Out of scope

- `bridge_scaffold_agent_home` v2 layout 미스매치 자체 fix (#686 — 별도 작업).
- 새 sudo-handoff helper 도입 (Track B 와 conflict).
- dynamic agent 자동 workdir 재생성.

(refs #714 Track F)