### PR TITLE
fix(status,attach): show offline static agents + attach remediation hint (refs #714)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -766,7 +766,14 @@ PY
       fi
       session="$(bridge_agent_session "$agent")"
       if [[ -z "$session" ]] || ! bridge_tmux_session_exists "$session"; then
-        bridge_die "에이전트 '$agent' 세션이 존재하지 않습니다."
+        # Issue #714 (#7): operators previously had no on-screen remediation
+        # path when an attach target was offline (e.g. after an upgrade where
+        # orchestrate_restart silently failed). Surface the two recovery
+        # commands that almost always close the loop before falling into
+        # bridge_die's red error line.
+        echo "[hint] 세션을 다시 시작하려면: bash bridge-start.sh $agent" >&2
+        echo "[hint] (admin 에이전트인 경우) $CLI_NAME admin" >&2
+        bridge_die "에이전트 '$agent'의 tmux 세션이 없습니다."
       fi
       bridge_attach_tmux_session "$session"
       ;;

--- a/bridge-status.py
+++ b/bridge-status.py
@@ -631,10 +631,16 @@ def render_dashboard(args: argparse.Namespace) -> str:
             health_critical_count += 1
 
     if not args.all_agents:
+        # Issue #714 (#6): static-source agents must remain visible in the
+        # default dashboard even when they have no tmux session — otherwise a
+        # post-upgrade host where every static restart failed silently looks
+        # like total roster loss. Dynamic agents that have died still get
+        # filtered out, so this only surfaces roster-declared static roles.
         roster = [
             row
             for row in roster
             if str(row.get("active", "0")) == "1"
+            or str(row.get("source", "")) == "static"
             or int(metrics.get(row["agent"], {}).get("queued_count", 0) or 0) > 0
             or int(metrics.get(row["agent"], {}).get("claimed_count", 0) or 0) > 0
             or int(metrics.get(row["agent"], {}).get("blocked_count", 0) or 0) > 0


### PR DESCRIPTION
## Summary

Two small UX fixes from the issue #714 post-upgrade walkthrough (Track E,
items 5 + 6) so a host where every static-agent restart silently failed
no longer looks like total roster loss.

- **`bridge-status.py` default filter** now also surfaces rows whose
  `source=static`, not only rows that are active or have queue work.
  Dynamic agents that have died still get filtered out behind
  `--all-agents`, so this only widens visibility for roster-declared
  static roles. Without this, after a v0.7.x → v0.8.x upgrade where
  `orchestrate_restart` left every static tmux session offline,
  `agb status` rendered `shown 1` and 7 of 8 agents disappeared from
  the dashboard.
- **`agent-bridge attach` branch** now prints two `[hint]` lines to
  stderr before the red error line when the requested agent's tmux
  session is gone. The hints surface `bash bridge-start.sh <agent>`
  and `<cli> admin` — the two recovery commands that close the loop
  in ~80% of the diagnosis cases the issue describes. Error text was
  also tightened from "세션이 존재하지 않습니다" to "tmux 세션이 없습니다"
  so it matches the underlying cause an operator will look for.

## Test plan

- [x] `bash -n agent-bridge` — pass
- [x] `shellcheck -x agent-bridge` — pass
- [x] `python3 -c "import ast; ast.parse(open('bridge-status.py').read())"` — pass
- [x] `./scripts/smoke-test.sh` — same exit/output as origin/main baseline (pre-existing dryrun-redact env failure, not caused by this PR)
- [x] Manual functional check on `bridge-status.py` with a 3-agent fixture roster (1 static-active, 1 static-offline, 1 dynamic-offline):
  - default render: `shown 2` (static-active + static-offline visible; dynamic-offline hidden)
  - `--all-agents`: `shown 3` (all visible) — confirming the dynamic-only suppression still works.
- [ ] Manual `agb attach <offline-agent>` smoke test — operator runs against a live install where one static agent's tmux session has been killed; expect two `[hint]` lines preceding the error.

Refs #714 (Track E — items 5 dashboard offline static, 6 attach remediation hint). Does not close the parent issue; other tracks remain.