### PR TITLE
fix(hooks): allow `agent-bridge config set` wrapper through path-argv gate

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1158,6 +1158,45 @@ def _bash_argv_references_system_config(command: str) -> bool:
     return False
 
 
+def _is_config_set_wrapper(text: str) -> bool:
+    """True iff *text* is the sanctioned ``agent-bridge config set`` /
+    ``agb config set`` wrapper invocation.
+
+    The hook normally denies any Bash command whose argv mentions a
+    protected path. That blocks the very wrapper #341 prescribes:
+    ``agent-bridge config set --path <protected> --change ...`` was
+    routed through `_bash_argv_references_path()` and rejected because
+    the protected path appears as the wrapper's argument — wrapper
+    self-block deadlock, even for admin (the deny message itself points
+    operators back at the same wrapper they were trying to call).
+
+    The wrapper layers its own gate (`bridge-config.py:detect_caller_source`
+    + before/after sha256 audit row), so once we let it through the hook
+    the only thing that changes is "audit chain stops being doubled".
+    A non-operator caller still gets denied at the wrapper.
+
+    Match shape: leading word is ``agent-bridge`` or ``agb`` (or a
+    ``/path/to/`` prefix thereof) and the next position after ``config``
+    is exactly ``set``. ``config get`` / ``config list-protected`` keep
+    the existing read-intent carve-out — this helper is only for the
+    write surface that the path-argv gate would otherwise self-block.
+    """
+    try:
+        tokens = shlex.split(text, posix=True, comments=False)
+    except ValueError:
+        return False
+    if not tokens:
+        return False
+    leaf = tokens[0].rsplit("/", 1)[-1]
+    if leaf not in {"agent-bridge", "agb"}:
+        return False
+    try:
+        idx = tokens.index("config")
+    except ValueError:
+        return False
+    return len(tokens) > idx + 1 and tokens[idx + 1] == "set"
+
+
 def protected_alias_reason(text: str, agent: str) -> str | None:
     admin = is_admin_agent(agent)
     # The two checks below use shlex argv matching rather than substring
@@ -1180,6 +1219,17 @@ def protected_alias_reason(text: str, agent: str) -> str | None:
     # structured-read surface and direct sqlite reads still bypass that
     # contract.
     read_intent = _is_read_intent_bash(text)
+    # Wrapper self-block carve-out: the sanctioned `agent-bridge config
+    # set` wrapper layers its own caller-source + audit gate
+    # (bridge-config.py). Without this carve-out the path-argv check
+    # below denies the wrapper invocation because the protected path
+    # appears as the wrapper's --path argument — leaving operators in a
+    # deadlock where the deny message points back at the same wrapper
+    # they just tried to call. Letting the wrapper through here only
+    # delegates audit responsibility to the wrapper itself; non-operator
+    # callers still get rejected at bridge-config.py.
+    if _is_config_set_wrapper(text):
+        return None
     if _bash_argv_references_path(text, roster_local_path()):
         if read_intent:
             return None

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1160,7 +1160,8 @@ def _bash_argv_references_system_config(command: str) -> bool:
 
 def _is_config_set_wrapper(text: str) -> bool:
     """True iff *text* is the sanctioned ``agent-bridge config set`` /
-    ``agb config set`` wrapper invocation as a single command.
+    ``agb config set`` wrapper invocation as a single, side-effect-free
+    shell command.
 
     The hook normally denies any Bash command whose argv mentions a
     protected path. That blocks the very wrapper #341 prescribes:
@@ -1175,12 +1176,22 @@ def _is_config_set_wrapper(text: str) -> bool:
     the only thing that changes is "audit chain stops being doubled".
     A non-operator caller still gets denied at the wrapper.
 
-    Match shape (strict — codex r1 #726):
+    Match shape (strict — codex r2 #726):
 
     - The text contains *no* shell separators (`;` / `&&` / `||` / `|` /
       `&` / newline). Multi-command pipelines drop straight back to the
       regular path-argv gate so a trailing `; sqlite3 .../tasks.db
       .dump` cannot ride through.
+    - The text contains *no* shell embeddings — command substitution
+      (``$(...)`` / backticks), process substitution (``<(...)`` /
+      ``>(...)``), heredoc / here-string (``<<`` / ``<<<``).
+      ``--change foo=$(sqlite3 .../tasks.db .dump)`` would otherwise
+      let the shell read the queue DB before the wrapper even starts.
+    - The text contains *no* I/O redirection tokens (``>`` / ``>>`` /
+      ``<`` / ``&>``, 2>`` other than the SAFE stderr-discard forms).
+      ``... > ~/.agent-bridge/agent-roster.local.sh`` would otherwise
+      let the shell open/truncate the protected file before any
+      argv-side gate runs.
     - shlex tokens[0] leaf is ``agent-bridge`` or ``agb`` (path prefix
       tolerated).
     - Subcommand sits at the strict positional ``tokens[1] == "config"``
@@ -1192,20 +1203,41 @@ def _is_config_set_wrapper(text: str) -> bool:
     read-intent carve-out — this helper is only for the write surface
     that the path-argv gate would otherwise self-block.
     """
-    # Reject multi-command pipelines first. shlex does not treat shell
+    # Reject shell embeddings on raw text first. `_command_has_shell_embedding`
+    # catches `$(...)`, backticks, `<(...)`, `>(...)`, `<<` / `<<<` — these
+    # are the signals we want, so we deliberately don't pre-sanitize. Same
+    # threat shape as multi-command pipelines: the shell evaluates the
+    # embedded command before the wrapper process even runs, so
+    # bridge-config.py cannot guard the file the subshell opens (codex
+    # r2 #726).
+    if _command_has_shell_embedding(text):
+        return False
+    # Strip the safe stderr-suppression / fd-dup tokens BEFORE the
+    # multi-command and redirection checks. `2>&1` legitimately contains
+    # the `&` token-boundary character that `_COMMAND_OPERATOR_RE` would
+    # otherwise read as a backgrounding signal, and `2>/dev/null` looks
+    # like output redirection but cannot mutate the filesystem. The safe
+    # forms must remain allowed for the carve-out to be useful in
+    # `2>/dev/null`-suffixed wrapper invocations.
+    sanitized = _SAFE_REDIRECT_RE.sub(" ", text)
+    # Reject multi-command pipelines. shlex does not treat shell
     # operators as separators — `agent-bridge config set --path X;
     # sqlite3 .../tasks.db .dump` arrives as one shlex run, and a naive
     # leaf check would hand the whole text a None reason and let the
     # second command bypass the queue-DB / system-config gates. The
     # carve-out only applies when the wrapper invocation stands alone.
-    if _COMMAND_OPERATOR_RE.search(text):
+    if _COMMAND_OPERATOR_RE.search(sanitized):
         return False
     try:
-        tokens = shlex.split(text, posix=True, comments=False)
+        tokens = shlex.split(sanitized, posix=True, comments=False)
     except ValueError:
         return False
     if len(tokens) < 3:
         return False
+    for tok in tokens:
+        for prefix in ("&>", "2>", ">>", ">", "<"):
+            if tok.startswith(prefix):
+                return False
     leaf = tokens[0].rsplit("/", 1)[-1]
     if leaf not in {"agent-bridge", "agb"}:
         return False

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1220,6 +1220,16 @@ def _is_config_set_wrapper(text: str) -> bool:
     # forms must remain allowed for the carve-out to be useful in
     # `2>/dev/null`-suffixed wrapper invocations.
     sanitized = _SAFE_REDIRECT_RE.sub(" ", text)
+    # Reject *any* remaining `<` / `>` after the safe-redirect strip.
+    # bash accepts arbitrary numeric file-descriptor prefixes
+    # (`1>`, `0<`, `3<`, `9>>`, `3<>`, ...) — the codex r3 #726 review
+    # caught that the previous per-token `tok.startswith(">")` check
+    # missed `1>`, `0<`, etc. and let the shell open/truncate/read a
+    # protected path before the wrapper started. Any `<` or `>` outside
+    # the safe-redirect forms means the shell is doing I/O the wrapper
+    # cannot guard.
+    if "<" in sanitized or ">" in sanitized:
+        return False
     # Reject multi-command pipelines. shlex does not treat shell
     # operators as separators — `agent-bridge config set --path X;
     # sqlite3 .../tasks.db .dump` arrives as one shlex run, and a naive
@@ -1234,10 +1244,6 @@ def _is_config_set_wrapper(text: str) -> bool:
         return False
     if len(tokens) < 3:
         return False
-    for tok in tokens:
-        for prefix in ("&>", "2>", ">>", ">", "<"):
-            if tok.startswith(prefix):
-                return False
     leaf = tokens[0].rsplit("/", 1)[-1]
     if leaf not in {"agent-bridge", "agb"}:
         return False

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1160,7 +1160,7 @@ def _bash_argv_references_system_config(command: str) -> bool:
 
 def _is_config_set_wrapper(text: str) -> bool:
     """True iff *text* is the sanctioned ``agent-bridge config set`` /
-    ``agb config set`` wrapper invocation.
+    ``agb config set`` wrapper invocation as a single command.
 
     The hook normally denies any Bash command whose argv mentions a
     protected path. That blocks the very wrapper #341 prescribes:
@@ -1175,26 +1175,41 @@ def _is_config_set_wrapper(text: str) -> bool:
     the only thing that changes is "audit chain stops being doubled".
     A non-operator caller still gets denied at the wrapper.
 
-    Match shape: leading word is ``agent-bridge`` or ``agb`` (or a
-    ``/path/to/`` prefix thereof) and the next position after ``config``
-    is exactly ``set``. ``config get`` / ``config list-protected`` keep
-    the existing read-intent carve-out — this helper is only for the
-    write surface that the path-argv gate would otherwise self-block.
+    Match shape (strict — codex r1 #726):
+
+    - The text contains *no* shell separators (`;` / `&&` / `||` / `|` /
+      `&` / newline). Multi-command pipelines drop straight back to the
+      regular path-argv gate so a trailing `; sqlite3 .../tasks.db
+      .dump` cannot ride through.
+    - shlex tokens[0] leaf is ``agent-bridge`` or ``agb`` (path prefix
+      tolerated).
+    - Subcommand sits at the strict positional ``tokens[1] == "config"``
+      and ``tokens[2] == "set"``. A later embedded ``config set`` inside
+      a different subcommand's argv (e.g. ``agent-bridge wave run config
+      set``) does not fire the carve-out.
+
+    ``config get`` / ``config list-protected`` keep the existing
+    read-intent carve-out — this helper is only for the write surface
+    that the path-argv gate would otherwise self-block.
     """
+    # Reject multi-command pipelines first. shlex does not treat shell
+    # operators as separators — `agent-bridge config set --path X;
+    # sqlite3 .../tasks.db .dump` arrives as one shlex run, and a naive
+    # leaf check would hand the whole text a None reason and let the
+    # second command bypass the queue-DB / system-config gates. The
+    # carve-out only applies when the wrapper invocation stands alone.
+    if _COMMAND_OPERATOR_RE.search(text):
+        return False
     try:
         tokens = shlex.split(text, posix=True, comments=False)
     except ValueError:
         return False
-    if not tokens:
+    if len(tokens) < 3:
         return False
     leaf = tokens[0].rsplit("/", 1)[-1]
     if leaf not in {"agent-bridge", "agb"}:
         return False
-    try:
-        idx = tokens.index("config")
-    except ValueError:
-        return False
-    return len(tokens) > idx + 1 and tokens[idx + 1] == "set"
+    return tokens[1] == "config" and tokens[2] == "set"
 
 
 def protected_alias_reason(text: str, agent: str) -> str | None:


### PR DESCRIPTION
## Summary

- `agent-bridge config set` is meant to be the only sanctioned write path for #341 protected files (e.g. `agent-roster.local.sh`), but `tool-policy.py:protected_alias_reason()` was scanning the wrapper's own argv for protected paths and denying the invocation. The deny message then pointed operators back at the same wrapper they just tried to call — a self-block deadlock that even admin couldn't escape.
- This adds a narrow carve-out (`_is_config_set_wrapper`) so the wrapper invocation flows through to `bridge-config.py`. The wrapper already gates on `detect_caller_source` (operator-tui / operator-trusted-id) and writes a before/after sha256 audit row, so the path-argv gate was just double-guarding an already audited path.

## Reproduction (pre-fix)

```
$ agent-bridge config set --path ~/.agent-bridge/agent-roster.local.sh \
    --change "FOO=bar" --from patch
agent-roster.local.sh is a protected system config path.
Use \`agent-bridge config set\` instead.
Admin role does not exempt this path — the wrapper preserves the audit chain.
```

Operator gets the wrapper deny pointing at the wrapper. No way through.

## Fix

- New helper `_is_config_set_wrapper(text)`:
  - shlex-splits the bash command
  - leaf in `{agent-bridge, agb}` (path prefix tolerated)
  - next position after `config` is exactly `set`
- `protected_alias_reason()` calls the helper before the roster / queue-DB / system-config argv checks. On hit, returns `None` so the command proceeds.
- `config get` / `config list-protected` keep the pre-existing read-intent carve-out — this commit only touches the write surface.

## Why this is safe

`bridge-config.py:detect_caller_source` requires `BRIDGE_CALLER_SOURCE=operator-tui|operator-trusted-id` (or a verified TTY) and emits a sha256-tracked audit row. A `agent-direct` caller flowing through this carve-out still gets rejected at the wrapper itself — the carve-out only delegates audit responsibility to the wrapper, never bypasses it.

Order of guards remains:
1. Read-intent (cat/grep/`config get`/etc.) — bypass (existing #383)
2. **Wrapper invocation (this PR)** — bypass; wrapper handles audit
3. Roster / queue-DB / system-config path-argv check — deny if hit
4. Cross-agent peer/shared aliases — deny per existing rules

## Tests

- 11 unit cases on `_is_config_set_wrapper`: agent-bridge / agb / absolute path leaf / config get / list-protected / task done / vim / cat / config without subcommand / empty / embedded-in-echo. All pass.
- 7 integration cases on `protected_alias_reason()`: wrapper write to roster (allow) / config get (allow) / vim (deny) / cat (allow) / list-protected (allow) / agb shorthand (allow) / unrelated task (allow). All pass.

## Smoke

- `scripts/smoke-test.sh` fails at the pre-existing `bridge-run.sh --dry-run` redactor test (#428 r2) on `main` too — unrelated to this change.

## Discovery

- 2026-05-07: patch admin hit this while trying to cut `BRIDGE_CRON_SUBAGENT_TIMEOUT_SECONDS` after a meta-ads cron timeout (#696 follow-up).
- 2026-05-08: Sean issued direct directive (#meta-ads 11:34 KST) — "버그는 발견되면 알아서 고쳐줘. 코덱스 리뷰 스킬 사용해서 검사 받고 반영해". This PR closes that directive's wrapper-deadlock branch.
- Local upstream candidate: `shared/upstream-candidates/2026-05-07-config-set-wrapper-self-block.md`

## Test plan

- [ ] CI lint + py-compile on changed file
- [ ] Existing smoke regression check (modulo pre-existing #428 r2 unrelated fail)
- [ ] Manual repro: `agent-bridge config set --path .../agent-roster.local.sh --change "X=Y" --from patch` from a Claude session — should now reach `bridge-config.py` and get rejected at the wrapper-side `detect_caller_source` (agent-direct), not at the hook.
- [ ] Manual repro with `BRIDGE_CALLER_SOURCE=operator-trusted-id` set (verified channel) — wrapper applies the change and writes the audit row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)