### PR TITLE
fix(memory): filter self-signals in librarian harvester activity classifier (closes #728)

### DIFF
--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -2814,6 +2814,42 @@ def _probe_legacy(home: Path, date: str) -> tuple[bool, list[dict]]:
     return (present and non_empty), checked
 
 
+# Self-signal filter — see issue #728.
+# The memory-daily harvester must not count its own cron-dispatch events,
+# prior-round backfill placeholders, or no-op "checked ok" markers as
+# "real activity" — otherwise an idle librarian slot perpetually re-queues
+# a backfill that consists only of its own self-signals.
+SELF_SIGNAL_PATTERNS = (
+    re.compile(r"^\[memory-daily\] backfill "),       # prior-round backfill task
+    re.compile(r"^\[memory-daily-skip-admin\] "),     # admin skip aggregate
+    re.compile(r"^\[memory-daily-escalated\] "),      # escalation aggregate
+    re.compile(r" checked ok\s*$"),                   # no-op placeholder
+    re.compile(r"^\[cron-followup\] memory-daily-"),  # cron failure followup
+)
+SELF_SIGNAL_FROM_PREFIXES = ("memory-daily", "cron-dispatch", "cron-followup")
+
+
+def _is_self_signal_event(event: dict) -> bool:
+    """Return True if a queue/transcript event should not count as real activity.
+
+    Accepts a dict with optional ``title``, ``from`` (or ``source``), and
+    ``payload_kind`` keys. Events without those keys (e.g. transcript-session
+    summaries from ``_scan_transcripts``) fall through and return False, so
+    the helper is a safe no-op for shapes that lack metadata.
+    """
+    title = event.get("title") or ""
+    from_field = event.get("from") or event.get("source") or ""
+    payload_kind = event.get("payload_kind") or ""
+
+    if any(p.search(title) for p in SELF_SIGNAL_PATTERNS):
+        return True
+    if any(from_field.startswith(p) for p in SELF_SIGNAL_FROM_PREFIXES):
+        return True
+    if payload_kind in {"text", "agentTurn"} and "memory-daily" in title.lower():
+        return True
+    return False
+
+
 def _scan_transcripts(
     workdir: str,
     start: datetime,
@@ -2904,7 +2940,10 @@ def _scan_transcripts(
                     "last_ts": datetime.fromtimestamp(last_ts).isoformat(timespec="seconds"),
                     "event_counts": counts,
                 })
-    return results
+    # Filter self-signals (issue #728). Transcript dicts have no title/from
+    # fields so this is a no-op for typical session summaries — but the wire-up
+    # keeps both scan helpers symmetric and ready for future event-shape changes.
+    return [r for r in results if not _is_self_signal_event(r)]
 
 
 def _scan_queue_events(db_path: Path, agent: str, start: datetime, end: datetime) -> list[int]:
@@ -2915,21 +2954,35 @@ def _scan_queue_events(db_path: Path, agent: str, start: datetime, end: datetime
     try:
         conn = sqlite3.connect(str(db_path))
         try:
+            # Join into ``tasks`` so we can drop self-signals (issue #728):
+            # cron-dispatch wakes, prior-round [memory-daily] backfill placeholders,
+            # admin aggregate skip/escalation tasks, and cron-followup chains
+            # must not count as "real activity" for the harvester classifier.
             cur = conn.execute(
                 """
-                SELECT DISTINCT task_id FROM task_events
-                WHERE event_type IN ('claimed','done')
-                  AND actor = ?
-                  AND created_ts BETWEEN ? AND ?
-                ORDER BY task_id
+                SELECT DISTINCT te.task_id, t.title, t.created_by
+                FROM task_events te
+                JOIN tasks t ON t.id = te.task_id
+                WHERE te.event_type IN ('claimed','done')
+                  AND te.actor = ?
+                  AND te.created_ts BETWEEN ? AND ?
+                ORDER BY te.task_id
                 """,
                 (agent, start_s, end_s),
             )
-            return [int(row[0]) for row in cur.fetchall()]
+            rows = cur.fetchall()
         finally:
             conn.close()
     except sqlite3.Error:
         return []
+    filtered: list[int] = []
+    for row in rows:
+        task_id = int(row[0])
+        event = {"title": row[1] or "", "from": row[2] or ""}
+        if _is_self_signal_event(event):
+            continue
+        filtered.append(task_id)
+    return filtered
 
 
 def _task_status(db_path: Path, task_id: int) -> tuple[str | None, int | None]:
@@ -3057,6 +3110,27 @@ def _render_backfill_body(agent: str, date: str, activity: dict, daily_note: dic
 
 
 def _queue_backfill(agent: str, date: str, home: Path, workdir: str, activity: dict, daily_note: dict, dry_run: bool) -> int | None:
+    # Defensive guard (issue #728): if every post-filter activity bucket is
+    # empty, do not enqueue another backfill — that is exactly the self-signal
+    # loop the filter is meant to break. The decision logic upstream already
+    # short-circuits on source_confidence == "none", but we re-check here so a
+    # future caller that bypasses the classifier still cannot trigger the loop.
+    strong = (activity.get("strong") or {}).get("transcript_sessions") or []
+    medium = activity.get("medium") or {}
+    weak = activity.get("weak") or {}
+    total_events = (
+        len(strong)
+        + len(medium.get("queue_task_ids") or [])
+        + len(medium.get("ingested_captures_non_precompact") or [])
+        + len(weak.get("precompact_captures") or [])
+        + len(weak.get("git_commits") or [])
+    )
+    if total_events == 0:
+        sys.stderr.write(
+            f"memory-daily: slot={date} agent={agent} "
+            f"reason=no-real-activity-after-self-signal-filter\n"
+        )
+        return None
     bridge_home = os.environ.get("BRIDGE_HOME") or str(Path.home() / ".agent-bridge")
     task_cli = Path(bridge_home).expanduser() / "bridge-task.sh"
     if not task_cli.exists() or dry_run:

--- a/bridge-memory.py
+++ b/bridge-memory.py
@@ -2829,25 +2829,59 @@ SELF_SIGNAL_PATTERNS = (
 SELF_SIGNAL_FROM_PREFIXES = ("memory-daily", "cron-dispatch", "cron-followup")
 
 
+def _is_system_sender(from_field: str) -> bool:
+    """True only if the sender is a known memory-daily / cron internal source.
+
+    The librarian harvester only wants to suppress events authored by its own
+    cron / dispatch chain. Any non-empty sender that does *not* match a known
+    system prefix is treated as human (or other-agent) work and must never be
+    classified as a self-signal — see issue #728 (codex r2).
+    """
+    if not from_field:
+        return False
+    return any(from_field.startswith(p) for p in SELF_SIGNAL_FROM_PREFIXES)
+
+
 def _is_self_signal_event(event: dict) -> bool:
     """Return True if a queue/transcript event should not count as real activity.
 
-    Accepts a dict with optional ``title``, ``from`` (or ``source``), and
-    ``payload_kind`` keys. Events without those keys (e.g. transcript-session
-    summaries from ``_scan_transcripts``) fall through and return False, so
-    the helper is a safe no-op for shapes that lack metadata.
+    Accepts a dict with optional ``title``, ``from`` (or ``source`` /
+    ``created_by``), and ``payload_kind`` keys. Events without those keys
+    (e.g. transcript-session summaries from ``_scan_transcripts``) fall
+    through and return False, so the helper is a safe no-op for shapes that
+    lack metadata.
+
+    The sender is a hard gate: a human-authored task whose title happens to
+    match a self-signal pattern (e.g. ``"weekly recap — checked ok"``) must
+    not be silently dropped. Only events whose ``from`` / ``source`` /
+    ``created_by`` matches a known internal prefix are even considered for
+    title-regex or payload-kind suppression.
     """
     title = event.get("title") or ""
-    from_field = event.get("from") or event.get("source") or ""
-    payload_kind = event.get("payload_kind") or ""
+    from_field = (
+        event.get("from")
+        or event.get("source")
+        or event.get("created_by")
+        or ""
+    )
+
+    # Sender gate — short-circuit before any title/payload inspection.
+    # A non-system sender (human, other agent, anonymous) is never a
+    # self-signal, regardless of title shape.
+    if not _is_system_sender(from_field):
+        return False
 
     if any(p.search(title) for p in SELF_SIGNAL_PATTERNS):
         return True
-    if any(from_field.startswith(p) for p in SELF_SIGNAL_FROM_PREFIXES):
-        return True
+
+    payload_kind = event.get("payload_kind") or ""
     if payload_kind in {"text", "agentTurn"} and "memory-daily" in title.lower():
         return True
-    return False
+
+    # Sender is a system agent (memory-daily / cron-dispatch / cron-followup)
+    # but title did not match a known pattern. The bare cron-dispatch wake
+    # case from issue #728 lands here — still a self-signal.
+    return True
 
 
 def _scan_transcripts(


### PR DESCRIPTION
## Summary

- `bridge-memory.py` 에 `_is_self_signal_event` helper 추가
- cron-dispatch / prior `[memory-daily] backfill ...` task / `checked ok` no-op / `[cron-followup] memory-daily-*` 를 활동에서 제외
- `_scan_queue_events` 가 `tasks` 와 join 해서 title + created_by 기반으로 필터
- `_scan_transcripts` 도 동일 helper wire (현재 shape 에는 no-op 이지만 symmetric)
- `_queue_backfill` 에 defensive guard — 필터 후 모든 activity bucket 이 비면 backfill 안 만들고 stderr 에 `slot=<date> agent=<agent> reason=no-real-activity-after-self-signal-filter` 1 줄 + return None
- 8-day 빈-슬롯 backfill loop 종결

## Refs

- closes #728
- 관련: memory-daily 디스포저블 librarian contract (out of scope: librarian role 자체 변경, cron-dispatch 측 activity-gating — Option 1 follow-up)

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-memory.py').read())"` PASS
- [x] helper unit checks (positive/negative cases) PASS — see verification block in commit body
- [x] `_scan_queue_events` end-to-end with temp SQLite DB (4 rows: backfill placeholder, cron-dispatch, real admin task, checked-ok) → returns only real admin task ID
- [x] `_queue_backfill` defensive guard — empty activity dict returns None and emits audit line
- [ ] (운영) 다음 KST 슬롯에서 `[memory-daily] backfill librarian` 신규 task 안 생기는지 확인

## Notes

- smoke-test.sh 의 `bridge-run.sh --dry-run` 단계는 isolation-v2 setgid 레이아웃을 요구해서 mktemp `BRIDGE_HOME` 환경에서 `[오류] Agent Bridge v0.8.0 requires isolation-v2` 로 실패 — 본 변경 이전 working-tree 에서도 동일하게 실패하는 환경 한계 (regression 아님).

🤖 Generated with [Claude Code](https://claude.com/claude-code)