### PR TITLE
fix(upgrade,agent): canonical_dir sudo fallback + JSON guard for isolated agents (closes #731)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -960,8 +960,26 @@ bridge_agent_session_type_from_home() {
 
 bridge_agent_canonical_dir() {
   local path="$1"
+  local resolved=""
+  # Issue #731: under linux-user isolation the controller user has stat
+  # permission on the parent + lookup on the entry (so `[[ -d ]]` is true)
+  # but not traverse on the directory itself when the workdir is owned by
+  # a separate Linux user with mode 2750. The plain `cd -P` aborts the
+  # subshell silently and the caller hands an empty payload to downstream
+  # JSON parsers (`bridge-upgrade.sh` SHARED_SETTINGS_RERENDER_JSON), which
+  # then surfaces as a raw JSONDecodeError traceback. Mirror the v0.8
+  # sudo-handoff trio (PR #718) by retrying through `bridge_linux_sudo_root`
+  # before falling back to a path passthrough.
   if [[ -d "$path" ]]; then
-    (cd -P "$path" && pwd -P)
+    resolved="$( (cd -P "$path" 2>/dev/null && pwd -P) || true)"
+    if [[ -z "$resolved" ]] && command -v bridge_linux_sudo_root >/dev/null 2>&1; then
+      resolved="$(bridge_linux_sudo_root sh -c 'cd -P "$1" && pwd -P' _ "$path" 2>/dev/null || true)"
+    fi
+    if [[ -n "$resolved" ]]; then
+      printf '%s' "$resolved"
+    else
+      printf '%s' "$path"
+    fi
   else
     printf '%s' "$path"
   fi

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1444,7 +1444,21 @@ if [[ $DRY_RUN -eq 0 ]]; then
   if ! python3 - "$SHARED_SETTINGS_RERENDER_JSON" <<'PY'
 import json
 import sys
-payload = json.loads(sys.argv[1])
+# Issue #731: empty/non-JSON payload happens when an isolated agent's
+# canonical_dir lookup fails (controller can't traverse mode-2750 workdir)
+# and the rerender helper hands back nothing for that agent. Treat it as
+# a non-fatal skip with a named diagnostic instead of dumping a raw
+# JSONDecodeError traceback into the upgrade log.
+raw = (sys.argv[1] if len(sys.argv) > 1 else "").strip()
+if not raw:
+    print("[bridge-upgrade] WARN: shared-settings rerender returned empty payload (likely isolated agent canonical_dir failure — see #731)", file=sys.stderr)
+    sys.exit(0)
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError as exc:
+    print(f"[bridge-upgrade] WARN: shared-settings rerender returned non-JSON payload: {exc}", file=sys.stderr)
+    print(f"[bridge-upgrade] payload preview: {raw[:200]!r}", file=sys.stderr)
+    sys.exit(0)
 raise SystemExit(0 if int(payload.get("failed_count") or 0) == 0 else 1)
 PY
   then
@@ -2038,7 +2052,19 @@ for item in payload.get("candidates") or []:
 PY
 python3 - "$SHARED_SETTINGS_RERENDER_JSON" <<'PY'
 import json, sys
-payload = json.loads(sys.argv[1])
+# Issue #731: same defensive guard as the verification heredoc above —
+# empty/non-JSON SHARED_SETTINGS_RERENDER_JSON should not raise a raw
+# traceback in the post-upgrade summary, just emit a named WARN.
+raw = (sys.argv[1] if len(sys.argv) > 1 else "").strip()
+if not raw:
+    print("[bridge-upgrade] WARN: shared-settings rerender returned empty payload (likely isolated agent canonical_dir failure — see #731)", file=sys.stderr)
+    sys.exit(0)
+try:
+    payload = json.loads(raw)
+except json.JSONDecodeError as exc:
+    print(f"[bridge-upgrade] WARN: shared-settings rerender returned non-JSON payload: {exc}", file=sys.stderr)
+    print(f"[bridge-upgrade] payload preview: {raw[:200]!r}", file=sys.stderr)
+    sys.exit(0)
 count = int(payload.get("count") or 0)
 failed = int(payload.get("failed_count") or 0)
 mode = payload.get("mode") or "skipped"


### PR DESCRIPTION
## Summary
- `bridge_agent_canonical_dir` falls back to `bridge_linux_sudo_root` when `cd -P` hits PermissionError (isolated agent mode-2750 workdir), and finally passes through the original path if both fail. Mirrors the v0.8 sudo-handoff trio added by PR #718.
- Both `bridge-upgrade.sh` python heredocs that parse `SHARED_SETTINGS_RERENDER_JSON` (`:1444` verification + `:2039` post-upgrade summary) now guard against empty / non-JSON argv: emit a named WARN with `raw[:200]` preview and `sys.exit(0)` instead of dumping a raw `JSONDecodeError` traceback.
- Net effect: the upgrade either resolves the isolated workdir via sudo, or emits an actionable named diagnostic instead of an opaque Python traceback.

## Refs
- closes #731
- related PR #718 (sudo-handoff trio family — `bridge-watchdog.scan_agent`, `bridge_agent_clear_manual_stop`, `cmd_link_shared_settings`)

## Test plan
- [x] `bash -n bridge-agent.sh bridge-upgrade.sh` — OK
- [x] `shellcheck -x bridge-agent.sh bridge-upgrade.sh` — same 11 SC2031 info-level warnings as base, no new issues
- [x] manual: `bridge_agent_canonical_dir` returns passthrough for nonexistent path, resolved path for `/tmp` (`/private/tmp`), and passthrough for mode-000 dir when sudo also fails
- [x] manual: JSON guard handles empty / non-JSON / well-formed payloads with rc=0; only emits raw Python traceback if the post-guard `failed_count` parse itself raises (which the guarded payload prevents)
- [ ] (manual, follow-up by operator) Linux isolated-agent host: run `agb upgrade --apply` and confirm no raw JSONDecodeError traceback in the log