### PR TITLE
docs(operations,known-issues,v2-migration): canonical isolation-v2 state + migration runbook (refs #737)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -295,6 +295,55 @@ Rollback: operators on v0.7.x with the legacy ACL-grant surface can
 stay on v0.7.x; v0.8.0 is the cut-over and there is no per-agent
 auto-migration of the operator's credential file.
 
+### v0.7 → v0.8 migration ACL leftovers
+
+Pre-v2 installs may carry transitional named-user POSIX ACLs that the
+v2 contract expects to be absent. The most common leftover is on
+`/home/agent-bridge-<agent>/.claude/` — pre-v2 it was created as
+`root:agent-bridge-<agent>` with a named-user ACL granting the
+controller traversal/read; v2 contract requires the agent itself to
+own its Linux home with no ACL of any kind.
+
+The planned `agent-bridge migrate isolation v2 --apply` command
+(v0.9.0+) detects and strips these leftovers, covering both
+`~/.agent-bridge/agents/<agent>/...` and `/home/agent-bridge-<agent>/...`.
+The single retained ACL surface — the `~/.claude/.credentials.json`
+`r--` grant plus the `--x` traverse chain in the operator's home —
+is preserved (see the entry above).
+
+If the migration command is unavailable (older install / scripted
+environment), manual recovery:
+
+```bash
+A=<agent>
+USER=agent-bridge-$A
+GROUP=ab-agent-$A
+CTRL=$(id -un)
+
+# 1. Restore agent ownership of the agent's actual Linux home and strip
+#    any transitional named-user ACL that pre-v2 installs left behind.
+sudo chown -R "$USER:$USER" "/home/$USER/"
+sudo chmod -R u+rwX,go-rwx "/home/$USER/"
+sudo setfacl -bR "/home/$USER/"
+
+# 2. Realign plugin readiness state files to the v2 group-read contract
+#    (controller readiness probe reads via the per-agent group).
+for f in "$HOME/.agent-bridge/agents/$A/workdir/.teams/.env" \
+         "$HOME/.agent-bridge/agents/$A/workdir/.ms365/.env"; do
+  [[ -f "$f" ]] && sudo chgrp "$GROUP" "$f" && sudo chmod 0640 "$f"
+done
+
+# 3. Re-launch and verify.
+agent-bridge agent start "$A"
+```
+
+Do **not** strip ACLs from `~/.claude/.credentials.json` or its
+ancestor chain — that is the one transitional surface the v2 contract
+keeps. The full canonical state table and a deeper drift-recovery
+reference live at
+[`OPERATIONS.md` § "Isolation v2 canonical state and migration"](./OPERATIONS.md#isolation-v2-canonical-state-and-migration)
+and [`docs/agent-runtime/v2-isolation-migration.md`](./docs/agent-runtime/v2-isolation-migration.md).
+
 ## 17. Layout v2 requires the engine CLI in a base-readable path (enforcement deferred to runtime)
 
 The v2 group contract has no path INTO the operator's home. If

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -298,49 +298,63 @@ auto-migration of the operator's credential file.
 ### v0.7 → v0.8 migration ACL leftovers
 
 Pre-v2 installs may carry transitional named-user POSIX ACLs that the
-v2 contract expects to be absent. The most common leftover is on
-`/home/agent-bridge-<agent>/.claude/` — pre-v2 it was created as
-`root:agent-bridge-<agent>` with a named-user ACL granting the
-controller traversal/read; v2 contract requires the agent itself to
-own its Linux home with no ACL of any kind.
+v2 layout does **not** allow (per the §16 hard-cut above — v2 has no
+named-user ACL surface at all). The most common leftover is on
+`/home/agent-bridge-<agent>/.claude/`, where the v0.7 install left a
+`root:agent-bridge-<agent>` ownership + a controller-only `r-x` ACL
+that prevents the agent UID from reading its own home.
 
 The planned `agent-bridge migrate isolation v2 --apply` command
-(v0.9.0+) detects and strips these leftovers, covering both
-`~/.agent-bridge/agents/<agent>/...` and `/home/agent-bridge-<agent>/...`.
-The single retained ACL surface — the `~/.claude/.credentials.json`
-`r--` grant plus the `--x` traverse chain in the operator's home —
-is preserved (see the entry above).
+(v0.9.0+) detects and strips these leftovers across both
+`$BRIDGE_DATA_ROOT/agents/<agent>/...` and
+`/home/agent-bridge-<agent>/...`. ACL preservation count: **0**.
+The migration is a strip-only pass; no named-user ACL is retained on
+either subtree.
 
 If the migration command is unavailable (older install / scripted
-environment), manual recovery:
+environment), manual recovery (run as the controller, with `sudo`
+available):
 
 ```bash
-A=<agent>
-USER=agent-bridge-$A
-GROUP=ab-agent-$A
+# ⚠️  Input validation FIRST — never run with empty/invalid agent name.
+A="<agent>"
+[[ "$A" =~ ^[a-zA-Z0-9_-]+$ ]] || { echo "agent name validation failed"; exit 1; }
+
+USER="agent-bridge-$A"
+GROUP="ab-agent-$A"
 CTRL=$(id -un)
 
-# 1. Restore agent ownership of the agent's actual Linux home and strip
-#    any transitional named-user ACL that pre-v2 installs left behind.
-sudo chown -R "$USER:$USER" "/home/$USER/"
-sudo chmod -R u+rwX,go-rwx "/home/$USER/"
-sudo setfacl -bR "/home/$USER/"
+# Sanity check — confirm the user exists and its home matches the
+# expected shape. Refuses to run if either is wrong.
+getent passwd "$USER" >/dev/null || { echo "no Linux user $USER"; exit 1; }
+LINUX_HOME="$(getent passwd "$USER" | cut -d: -f6)"
+[[ "$LINUX_HOME" == "/home/$USER" ]] || {
+  echo "ERROR: $USER home does not match /home/$USER (got: $LINUX_HOME)"
+  exit 1
+}
+
+# 1. Re-own the agent's actual Linux home and strip transitional ACLs.
+sudo chown -R "$USER:$USER" "$LINUX_HOME"
+sudo chmod -R u+rwX,go-rwx "$LINUX_HOME"
+sudo setfacl -bR "$LINUX_HOME"
 
 # 2. Realign plugin readiness state files to the v2 group-read contract
 #    (controller readiness probe reads via the per-agent group).
-for f in "$HOME/.agent-bridge/agents/$A/workdir/.teams/.env" \
-         "$HOME/.agent-bridge/agents/$A/workdir/.ms365/.env"; do
+for f in "$BRIDGE_DATA_ROOT/agents/$A/workdir/.teams/.env" \
+         "$BRIDGE_DATA_ROOT/agents/$A/workdir/.ms365/.env"; do
   [[ -f "$f" ]] && sudo chgrp "$GROUP" "$f" && sudo chmod 0640 "$f"
 done
 
-# 3. Re-launch and verify.
+# 3. Create the controller-side .claude/ shadow if missing.
+sudo install -d -o "$CTRL" -g "$CTRL" -m 0700 \
+  "$BRIDGE_DATA_ROOT/agents/$A/.claude"
+
+# 4. Re-launch and verify.
 agent-bridge agent start "$A"
 ```
 
-Do **not** strip ACLs from `~/.claude/.credentials.json` or its
-ancestor chain — that is the one transitional surface the v2 contract
-keeps. The full canonical state table and a deeper drift-recovery
-reference live at
+The full canonical state table and a deeper drift-recovery reference
+live at
 [`OPERATIONS.md` § "Isolation v2 canonical state and migration"](./OPERATIONS.md#isolation-v2-canonical-state-and-migration)
 and [`docs/agent-runtime/v2-isolation-migration.md`](./docs/agent-runtime/v2-isolation-migration.md).
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -718,20 +718,18 @@ The contract itself is documented in source at
 
 ### POSIX ACL role
 
-The v2 layout itself contains **no named-user POSIX ACLs**. PR-E removed
-all named-user ACLs from the v2 layout in favor of group ownership +
-setgid (see "[v2 ACL contract (PR-E)](#v2-acl-contract-pr-e)" below).
+The v2 layout itself contains **no named-user POSIX ACLs at all**. PR-E
+moved the v2 layout off named-user ACLs in favor of group ownership +
+setgid, and PR #641 (v0.8.0, T2) hard-cut the remaining v0.7
+`bridge_linux_grant_claude_credentials_access` helper that previously
+granted the agent UID an `r--` ACL on the operator's
+`~/.claude/.credentials.json` plus `--x` traverse up the ancestor chain.
+There is no retained ACL surface on either the v2 tree or the operator's
+home; v2 reaches Claude credentials via per-agent `claude login` (or a
+pre-populated `launch-secrets.env`) — see
+[`KNOWN_ISSUES.md` §16](./KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080).
 
-The single transitional exception is `~/.claude/.credentials.json` in
-the operator's home — the operator's home is *outside* the v2 layout,
-so the credentials surface uses a named-user `r--` ACL plus `--x`
-traverse on the ancestor chain, granted by
-`bridge_linux_grant_claude_credentials_access`. See
-[`KNOWN_ISSUES.md` §16](./KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
-for the long-term plan to retire that surface entirely (per-agent
-`claude login`).
-
-If you find any other named-user ACL inside the v2 tree
+If you find any named-user ACL inside the v2 tree
 (`~/.agent-bridge/agents/<agent>/...`) or on `/home/agent-bridge-<agent>/`,
 it is drift — the migration runbook below strips it.
 
@@ -759,9 +757,10 @@ For an isolated agent that drifted across the v0.7 → v0.8 cut:
    ```
 
    The migration covers `~/.agent-bridge/agents/<agent>/...` *and*
-   `/home/agent-bridge-<agent>/...`, strips transitional named-user
-   ACLs everywhere inside the v2 tree, and preserves the single
-   `~/.claude/.credentials.json` ACL surface.
+   `/home/agent-bridge-<agent>/...`, and strips all named-user POSIX
+   ACLs across both subtrees. ACL preservation count: **0** — PR #641
+   (v0.8.0, T2) deleted every v2-layer ACL-grant helper, so the
+   migration is a strip-only pass with no surface to step around.
 
 4. Re-launch the agent and verify the fix:
 
@@ -907,10 +906,12 @@ the install-root copy is left in place so existing admin tooling and a
 clean rollback remain possible. A future PR (PR-G) is expected to either
 unify the two locations or mark the install-root copy read-only.
 
-### v2 ACL contract (PR-E)
+### v2 ACL contract (PR-E + PR #641 hard-cut)
 
-PR-E removes named-user POSIX ACLs from v2 mode in favor of POSIX group
-ownership + setgid. Scope and exceptions:
+PR-E removed named-user POSIX ACLs from v2 mode in favor of POSIX group
+ownership + setgid. PR #641 (v0.8.0, T2) then hard-cut the remaining v0.7
+`bridge_linux_grant_claude_credentials_access` exception, leaving the v2
+layout with zero named-user ACL surface. Scope:
 
 - **Scope.** When `bridge_isolation_v2_active`, every named-user ACL
   primitive (`bridge_linux_acl_add`, `bridge_linux_acl_add_recursive`,
@@ -936,15 +937,17 @@ ownership + setgid. Scope and exceptions:
     so files created by the agent process tree land at 0660 with
     correct group ownership.
 
-- **Transitional exception (Claude credentials).** The v2 layout does
-  not include the operator's `~/.claude/.credentials.json`, so
-  `bridge_linux_grant_claude_credentials_access` retains named-user
-  ACL access in v2 mode for that single file plus the traversal chain
-  up to the operator's home. This is the **only** v2 surface that uses
-  ACLs. PR-F or a future PR is expected to replace this with per-agent
-  `claude login` (operator workflow change). The helper itself fails
-  loud (`bridge_die`) when `setfacl` is unavailable, so silent breakage
-  is impossible.
+- **No transitional exception (PR #641, v0.8.0 T2).** v0.7.x carried a
+  single transitional exception for `~/.claude/.credentials.json` via
+  `bridge_linux_grant_claude_credentials_access`. PR #641 deleted that
+  helper as part of the v1 ACL hard-cut. The v2 layout now has zero
+  named-user ACL surface — neither inside the v2 tree nor on the
+  operator's home. v2 reaches Claude credentials via per-agent
+  `claude login` (which writes
+  `$BRIDGE_AGENT_ROOT_V2/<agent>/home/.claude/.credentials.json` owned
+  by the per-agent UID) or a pre-populated
+  `$BRIDGE_AGENT_ROOT_V2/<agent>/credentials/launch-secrets.env`. See
+  [`KNOWN_ISSUES.md` §16](./KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080).
 
 - **Engine CLI prerequisite (v2).** v2 mode requires the engine CLI to
   resolve to a base-readable path (`other::r-x` along the entire
@@ -954,10 +957,10 @@ ownership + setgid. Scope and exceptions:
   `/usr/local/bin` (or another path with no controller-home ancestor)
   before activating v2.
 
-- **`acl` package.** v2 + non-Claude engines do not require the `acl`
-  package. v2 + Claude does, because the credential exception above
-  uses `setfacl`. `bridge_linux_prepare_agent_isolation` gates
-  `bridge_linux_require_setfacl` accordingly.
+- **`acl` package.** v2 (with or without Claude) does not require the
+  `acl` package — the v2 layout has no named-user ACL surface to grant
+  or revoke (PR #641, v0.8.0 T2). `bridge_linux_prepare_agent_isolation`
+  no longer gates on `bridge_linux_require_setfacl` for v2 mode.
 
 - **`BRIDGE_SHARED_GROUP` membership.** v2 prep ensures the isolated
   UID is a member of `ab-shared` (default) so it can read the shared

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -677,6 +677,96 @@ agent-bridge isolate <agent> --reapply
 then restarting the agent so the next session loads the synced skills
 and reads the rendered settings.
 
+## Isolation v2 canonical state and migration
+
+Agent Bridge v0.8 cut over to layout v2 (per-agent Linux user + private
+group, group-based access, no named-user POSIX ACLs in the v2 layout
+itself). Operators upgrading from v0.7.x or earlier may end up with an
+install whose runtime tree drifted from the v2 contract — the most
+common failure mode is leftover transitional ACLs from the v0.7 helper
+`bridge_linux_grant_claude_credentials_access` (deleted in v0.8.0) that
+were never stripped because the v2 cut-over did not migrate per-agent
+home trees.
+
+This section is the canonical v2 state spec and the recovery runbook.
+The deeper reference (drift signatures, diagnostics, manual recovery
+commands) lives at
+[`docs/agent-runtime/v2-isolation-migration.md`](./docs/agent-runtime/v2-isolation-migration.md).
+
+The contract itself is documented in source at
+`lib/bridge-isolation-v2.sh:38-62`.
+
+### Canonical state table
+
+| Path | Owner | Group | Mode | Notes |
+|---|---|---|---|---|
+| `~/.agent-bridge/shared/` | controller | `ab-shared` | `2750` | read-only public assets (controller writes) |
+| `~/.agent-bridge/state/` | controller | `ab-controller` | `2750` | controller-only state |
+| `~/.agent-bridge/agents/<agent>/` | **root** | `ab-agent-<agent>` | `2750` | per-agent private root, root-owned |
+| `~/.agent-bridge/agents/<agent>/{home,workdir,runtime,logs,requests,responses}/` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `2770` | agent owns; controller reads via group |
+| `~/.agent-bridge/agents/<agent>/credentials/` | controller | `ab-agent-<agent>` | `2750` | controller writes, agent reads via group |
+| `~/.agent-bridge/agents/<agent>/credentials/launch-secrets.env` | controller | `ab-agent-<agent>` | `0640` | |
+| `~/.agent-bridge/agents/<agent>/agent-env.sh` | controller | `ab-agent-<agent>` | `0640` | |
+| `~/.agent-bridge/agents/<agent>/workdir/.teams/.env`, `.../.ms365/.env` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `0640` | controller readiness probe reads via group |
+| `/home/agent-bridge-<agent>/` (the agent's actual Linux home) | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | **agent owns. No ACL of any kind.** |
+| `/home/agent-bridge-<agent>/.claude/`, sub-tree | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | same — agent-only, no ACL |
+
+### POSIX ACL role
+
+The v2 layout itself contains **no named-user POSIX ACLs**. PR-E removed
+all named-user ACLs from the v2 layout in favor of group ownership +
+setgid (see "[v2 ACL contract (PR-E)](#v2-acl-contract-pr-e)" below).
+
+The single transitional exception is `~/.claude/.credentials.json` in
+the operator's home — the operator's home is *outside* the v2 layout,
+so the credentials surface uses a named-user `r--` ACL plus `--x`
+traverse on the ancestor chain, granted by
+`bridge_linux_grant_claude_credentials_access`. See
+[`KNOWN_ISSUES.md` §16](./KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
+for the long-term plan to retire that surface entirely (per-agent
+`claude login`).
+
+If you find any other named-user ACL inside the v2 tree
+(`~/.agent-bridge/agents/<agent>/...`) or on `/home/agent-bridge-<agent>/`,
+it is drift — the migration runbook below strips it.
+
+### v0.7 → v0.8 migration runbook
+
+For an isolated agent that drifted across the v0.7 → v0.8 cut:
+
+1. Upgrade and restart the daemon:
+
+   ```bash
+   agent-bridge upgrade --apply --restart-daemon
+   ```
+
+2. Inspect drift (planned for v0.9.0; until then run the manual
+   recovery in `KNOWN_ISSUES.md` §16):
+
+   ```bash
+   agent-bridge migrate isolation v2 --check        # v0.9.0+
+   ```
+
+3. Apply the fix:
+
+   ```bash
+   agent-bridge migrate isolation v2 --apply        # v0.9.0+
+   ```
+
+   The migration covers `~/.agent-bridge/agents/<agent>/...` *and*
+   `/home/agent-bridge-<agent>/...`, strips transitional named-user
+   ACLs everywhere inside the v2 tree, and preserves the single
+   `~/.claude/.credentials.json` ACL surface.
+
+4. Re-launch the agent and verify the fix:
+
+   ```bash
+   agent-bridge agent start <agent>
+   ```
+
+If `agent-bridge migrate isolation v2` is not available (older install),
+follow the manual recovery in `KNOWN_ISSUES.md` §16.
+
 ## Migrating to layout v2
 
 The v2 layout (PR-A/B/C, shipped in v0.6.19) replaces named-ACL access on

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -698,16 +698,21 @@ The contract itself is documented in source at
 
 ### Canonical state table
 
+> Path prefix `$BRIDGE_DATA_ROOT` is the install environment variable
+> (see `lib/bridge-isolation-v2.sh:36-62`). Default value is
+> `~/.agent-bridge`; if the operator overrides it explicitly, the
+> override path applies.
+
 | Path | Owner | Group | Mode | Notes |
 |---|---|---|---|---|
-| `~/.agent-bridge/shared/` | controller | `ab-shared` | `2750` | read-only public assets (controller writes) |
-| `~/.agent-bridge/state/` | controller | `ab-controller` | `2750` | controller-only state |
-| `~/.agent-bridge/agents/<agent>/` | **root** | `ab-agent-<agent>` | `2750` | per-agent private root, root-owned |
-| `~/.agent-bridge/agents/<agent>/{home,workdir,runtime,logs,requests,responses}/` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `2770` | agent owns; controller reads via group |
-| `~/.agent-bridge/agents/<agent>/credentials/` | controller | `ab-agent-<agent>` | `2750` | controller writes, agent reads via group |
-| `~/.agent-bridge/agents/<agent>/credentials/launch-secrets.env` | controller | `ab-agent-<agent>` | `0640` | |
-| `~/.agent-bridge/agents/<agent>/agent-env.sh` | controller | `ab-agent-<agent>` | `0640` | |
-| `~/.agent-bridge/agents/<agent>/workdir/.teams/.env`, `.../.ms365/.env` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `0640` | controller readiness probe reads via group |
+| `$BRIDGE_DATA_ROOT/shared/` | controller | `ab-shared` | `2750` | read-only public assets (controller writes) |
+| `$BRIDGE_DATA_ROOT/state/` | controller | `ab-controller` | `2750` | controller-only state |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/` | **root** | `ab-agent-<agent>` | `2750` | per-agent private root, root-owned |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/{home,workdir,runtime,logs,requests,responses}/` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `2770` | agent owns; controller reads via group |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/credentials/` | controller | `ab-agent-<agent>` | `2750` | controller writes, agent reads via group |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/credentials/launch-secrets.env` | controller | `ab-agent-<agent>` | `0640` | |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/agent-env.sh` | controller | `ab-agent-<agent>` | `0640` | |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/workdir/.teams/.env`, `.../.ms365/.env` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `0640` | controller readiness probe reads via group |
 | `/home/agent-bridge-<agent>/` (the agent's actual Linux home) | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | **agent owns. No ACL of any kind.** |
 | `/home/agent-bridge-<agent>/.claude/`, sub-tree | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | same — agent-only, no ACL |
 

--- a/docs/agent-runtime/v2-isolation-migration.md
+++ b/docs/agent-runtime/v2-isolation-migration.md
@@ -7,8 +7,8 @@ from it. Pair with:
 - [`OPERATIONS.md` § "Isolation v2 canonical state and migration"](../../OPERATIONS.md#isolation-v2-canonical-state-and-migration)
   — the short surface-level operator runbook.
 - [`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
-  — the single retained ACL surface (`~/.claude/.credentials.json`)
-  and the v0.7→v0.8 ACL-leftover manual recovery.
+  — the v2 hard-cut (PR #641 deleted every named-user ACL helper from
+  the v2 layout) and the v0.7→v0.8 ACL-leftover manual recovery.
 - [`docs/isolation-migration-guide.md`](../isolation-migration-guide.md)
   — the older v0.6→v0.7 `shared → linux-user` migration walkthrough
   (separate, predates v2).
@@ -29,16 +29,21 @@ The canonical state table for an isolated agent named `<agent>` (its
 backing Linux UID is `agent-bridge-<agent>`, its private group is
 `ab-agent-<agent>`):
 
+> Path prefix `$BRIDGE_DATA_ROOT` is the install environment variable
+> (see `lib/bridge-isolation-v2.sh:36-62`). Default value is
+> `~/.agent-bridge`; if the operator overrides it explicitly, the
+> override path applies.
+
 | Path | Owner | Group | Mode | Notes |
 |---|---|---|---|---|
-| `~/.agent-bridge/shared/` | controller | `ab-shared` | `2750` | read-only public assets |
-| `~/.agent-bridge/state/` | controller | `ab-controller` | `2750` | controller-only |
-| `~/.agent-bridge/agents/<agent>/` | **root** | `ab-agent-<agent>` | `2750` | per-agent private root |
-| `~/.agent-bridge/agents/<agent>/{home,workdir,runtime,logs,requests,responses}/` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `2770` | agent owns; controller via group |
-| `~/.agent-bridge/agents/<agent>/credentials/` | controller | `ab-agent-<agent>` | `2750` | controller writes, agent reads |
-| `~/.agent-bridge/agents/<agent>/credentials/launch-secrets.env` | controller | `ab-agent-<agent>` | `0640` | |
-| `~/.agent-bridge/agents/<agent>/agent-env.sh` | controller | `ab-agent-<agent>` | `0640` | |
-| `~/.agent-bridge/agents/<agent>/workdir/.teams/.env`, `.../.ms365/.env` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `0640` | controller readiness probe via group |
+| `$BRIDGE_DATA_ROOT/shared/` | controller | `ab-shared` | `2750` | read-only public assets |
+| `$BRIDGE_DATA_ROOT/state/` | controller | `ab-controller` | `2750` | controller-only |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/` | **root** | `ab-agent-<agent>` | `2750` | per-agent private root |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/{home,workdir,runtime,logs,requests,responses}/` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `2770` | agent owns; controller via group |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/credentials/` | controller | `ab-agent-<agent>` | `2750` | controller writes, agent reads |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/credentials/launch-secrets.env` | controller | `ab-agent-<agent>` | `0640` | |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/agent-env.sh` | controller | `ab-agent-<agent>` | `0640` | |
+| `$BRIDGE_DATA_ROOT/agents/<agent>/workdir/.teams/.env`, `.../.ms365/.env` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `0640` | controller readiness probe via group |
 | `/home/agent-bridge-<agent>/` | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | agent's actual Linux home, no ACL |
 | `/home/agent-bridge-<agent>/.claude/`, sub-tree | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | same — no ACL |
 
@@ -58,12 +63,14 @@ Two access mechanisms only:
    through the v2 tree (via `agents/<agent>/credentials/` for secrets,
    via `agents/<agent>/workdir/...` for plugin state, etc.).
 
-The single transitional ACL exception (`~/.claude/.credentials.json`
-in the operator's home) is documented in
+The v2 layout has **no named-user POSIX ACL surface at all** — PR #641
+(v0.8.0, T2) deleted every ACL-grant helper (including the v0.7
+`bridge_linux_grant_claude_credentials_access` for the operator's
+`~/.claude/.credentials.json`). The migration is strip-only: it
+removes any ACL drift it finds and preserves nothing. See
 [`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
-— that surface is *outside* the v2 layout and uses a named-user `r--`
-ACL plus an `--x` traverse chain because it is the operator's home
-file. It is preserved by the migration command.
+for the credential-seeding flow under v2 (per-agent `claude login` or
+pre-populated `launch-secrets.env`).
 
 ## 2. Drift signatures from v0.7
 
@@ -167,13 +174,12 @@ What `--apply` does:
    of the canonical state table for each isolated agent (idempotent
    when the row is already canonical).
 2. Strips any named-user POSIX ACL it finds inside the v2 tree
-   (`~/.agent-bridge/agents/<agent>/...`) and on the agent's actual
+   (`$BRIDGE_DATA_ROOT/agents/<agent>/...`) and on the agent's actual
    Linux home (`/home/agent-bridge-<agent>/...`). Equivalent to
    `setfacl -bR <path>` on each of those subtrees.
-3. **Preserves** the `~/.claude/.credentials.json` named-user ACL plus
-   the `--x` traverse chain in the operator's home — that is the
-   single transitional exception (see
-   [`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)).
+3. ACL preservation count: **0**. PR #641 (v0.8.0, T2) deleted every
+   v2-layer ACL-grant helper, so the migration is a strip-only pass —
+   no named-user ACL is preserved on either subtree.
 4. Re-runs the readiness-probe shape check on the controller-side
    `.claude/` shadow and the workdir plugin state files, fixing any
    drift in §2.2 and §2.3 above.
@@ -185,23 +191,35 @@ What `--apply` does:
 
 For installs where the v0.9.0 migration command is unavailable. Run
 each block as the controller (the user that owns
-`~/.agent-bridge/`), with `sudo` available.
+`$BRIDGE_DATA_ROOT`), with `sudo` available.
 
 ```bash
-# Identify the agent and its UID/GID names.
-A=<agent>
-USER=agent-bridge-$A
-GROUP=ab-agent-$A
+# ⚠️  Input validation FIRST — never run with empty/invalid agent name.
+A="<agent>"
+[[ "$A" =~ ^[a-zA-Z0-9_-]+$ ]] || { echo "agent name validation failed"; exit 1; }
+
+USER="agent-bridge-$A"
+GROUP="ab-agent-$A"
 CTRL=$(id -un)
 
+# Sanity check — confirm the user exists and its home matches the
+# expected shape. Refuses to run if either is wrong (protects the
+# operator's home and arbitrary paths from accidental chown/setfacl).
+getent passwd "$USER" >/dev/null || { echo "no Linux user $USER"; exit 1; }
+LINUX_HOME="$(getent passwd "$USER" | cut -d: -f6)"
+[[ "$LINUX_HOME" == "/home/$USER" ]] || {
+  echo "ERROR: $USER home does not match /home/$USER (got: $LINUX_HOME)"
+  exit 1
+}
+
 # 1. Re-own the agent's actual Linux home and strip transitional ACLs.
-sudo chown -R "$USER:$USER" "/home/$USER/"
-sudo chmod -R u+rwX,go-rwx "/home/$USER/"
-sudo setfacl -bR "/home/$USER/"
+sudo chown -R "$USER:$USER" "$LINUX_HOME"
+sudo chmod -R u+rwX,go-rwx "$LINUX_HOME"
+sudo setfacl -bR "$LINUX_HOME"
 
 # 2. Realign plugin state files to v2 group-read contract.
-for f in "$HOME/.agent-bridge/agents/$A/workdir/.teams/.env" \
-         "$HOME/.agent-bridge/agents/$A/workdir/.ms365/.env"; do
+for f in "$BRIDGE_DATA_ROOT/agents/$A/workdir/.teams/.env" \
+         "$BRIDGE_DATA_ROOT/agents/$A/workdir/.ms365/.env"; do
   if [[ -f "$f" ]]; then
     sudo chown "$USER:$GROUP" "$f"
     sudo chmod 0640 "$f"
@@ -210,33 +228,35 @@ done
 
 # 3. Create the controller-side .claude/ shadow if missing.
 sudo install -d -o "$CTRL" -g "$CTRL" -m 0700 \
-  "$HOME/.agent-bridge/agents/$A/.claude"
+  "$BRIDGE_DATA_ROOT/agents/$A/.claude"
 
 # 4. (Optional) Re-assert the canonical group + mode on the v2 agent root.
-sudo chown root:"$GROUP" "$HOME/.agent-bridge/agents/$A"
-sudo chmod 2750 "$HOME/.agent-bridge/agents/$A"
+sudo chown root:"$GROUP" "$BRIDGE_DATA_ROOT/agents/$A"
+sudo chmod 2750 "$BRIDGE_DATA_ROOT/agents/$A"
 
 # 5. Restart the agent.
 agent-bridge agent start "$A"
 ```
 
-**Do not** run `setfacl -b` on `~/.claude/.credentials.json` or its
-ancestor chain. That is the single retained ACL surface; stripping it
-breaks first-launch credential read for every isolated agent on the
-host until you re-run isolation prep.
+The recovery is strip-only across both the v2 tree
+(`$BRIDGE_DATA_ROOT/agents/<agent>/...`) and the agent's actual Linux
+home (`/home/agent-bridge-<agent>/...`). PR #641 (v0.8.0, T2) deleted
+every v2-layer ACL-grant helper, so there is no preserved ACL surface
+to step around — no `setfacl -b` exclusion is needed.
 
 ## 5. POSIX ACL contract — quick summary
 
 | Surface | ACL? | Notes |
 |---|---|---|
-| `~/.agent-bridge/...` (entire v2 layout) | **No** | group ownership + setgid only |
+| `$BRIDGE_DATA_ROOT/...` (entire v2 layout) | **No** | group ownership + setgid only |
 | `/home/agent-bridge-<agent>/...` | **No** | agent-only `0700`, no ACL |
-| `~/.claude/.credentials.json` + ancestor chain | **Yes** | single transitional named-user ACL |
-| Anywhere else outside the v2 layout | **No** | no ACL surface |
+| Operator home (`~/.claude/...`) | **No** | PR #641 deleted the v0.7 `bridge_linux_grant_claude_credentials_access` helper; v2 reaches credentials via per-agent `claude login` instead |
+| Anywhere else | **No** | no ACL surface |
 
-See [`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
-for the long-term plan to replace the transitional surface with
-per-agent `claude login` (operator workflow change).
+The v2 layout has zero named-user ACL surface. See
+[`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
+for the credential-seeding flow under v2 (per-agent `claude login` or
+pre-populated `launch-secrets.env`).
 
 ## 6. Diagnostic commands
 
@@ -248,10 +268,10 @@ USER=agent-bridge-$A
 GROUP=ab-agent-$A
 
 # Per-agent v2 root: should be `root:ab-agent-<agent> 2750`.
-stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A"
+stat -c "%U:%G %a" "$BRIDGE_DATA_ROOT/agents/$A"
 
 # Per-agent home (inside v2 layout): should be `<USER>:<GROUP> 2770`.
-stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A/home"
+stat -c "%U:%G %a" "$BRIDGE_DATA_ROOT/agents/$A/home"
 
 # Agent's actual Linux home: should be `<USER>:<USER> 700`, no ACL.
 sudo stat -c "%U:%G %a" "/home/$USER"
@@ -259,8 +279,8 @@ sudo getfacl --skip-base "/home/$USER"
 sudo getfacl --skip-base "/home/$USER/.claude" 2>/dev/null
 
 # Plugin state files: should be `<USER>:<GROUP> 640`.
-stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A/workdir/.teams/.env" 2>/dev/null
-stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A/workdir/.ms365/.env" 2>/dev/null
+stat -c "%U:%G %a" "$BRIDGE_DATA_ROOT/agents/$A/workdir/.teams/.env" 2>/dev/null
+stat -c "%U:%G %a" "$BRIDGE_DATA_ROOT/agents/$A/workdir/.ms365/.env" 2>/dev/null
 
 # Per-agent group membership (controller + agent UID).
 getent group "$GROUP"
@@ -280,7 +300,7 @@ empty inside the agent's home.
   v0.9.0 migration command.
 - **#720** — drift report for the v0.7 → v0.8 home-ownership leftover
   (§2.1 above).
-- **#730** — `bridge_linux_grant_claude_credentials_access` removal +
-  the single retained ACL surface.
+- **#730** — `bridge_linux_grant_claude_credentials_access` removal
+  (PR #641, v0.8.0 T2) + replacement credential-seeding flow.
 - **#731** — readiness probe vs. plugin state file mode mismatch
   (§2.2 above).

--- a/docs/agent-runtime/v2-isolation-migration.md
+++ b/docs/agent-runtime/v2-isolation-migration.md
@@ -1,0 +1,286 @@
+# Isolation v2 — drift-recovery and migration reference
+
+Deep reference for operators bringing a v0.7.x → v0.8 install onto the
+canonical isolation-v2 contract, or recovering an install that drifted
+from it. Pair with:
+
+- [`OPERATIONS.md` § "Isolation v2 canonical state and migration"](../../OPERATIONS.md#isolation-v2-canonical-state-and-migration)
+  — the short surface-level operator runbook.
+- [`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
+  — the single retained ACL surface (`~/.claude/.credentials.json`)
+  and the v0.7→v0.8 ACL-leftover manual recovery.
+- [`docs/isolation-migration-guide.md`](../isolation-migration-guide.md)
+  — the older v0.6→v0.7 `shared → linux-user` migration walkthrough
+  (separate, predates v2).
+- `lib/bridge-isolation-v2.sh:38-62` — the contract source of truth.
+
+This document is reference material — copy-pasteable diagnostic and
+recovery commands plus the drift signatures we have seen on real
+installs. The expected operator entry point is the
+`agent-bridge migrate isolation v2` CLI added in v0.9.0; everything
+below also serves as the manual-recovery procedure when that CLI is
+not available.
+
+---
+
+## 1. v2 layout overview
+
+The canonical state table for an isolated agent named `<agent>` (its
+backing Linux UID is `agent-bridge-<agent>`, its private group is
+`ab-agent-<agent>`):
+
+| Path | Owner | Group | Mode | Notes |
+|---|---|---|---|---|
+| `~/.agent-bridge/shared/` | controller | `ab-shared` | `2750` | read-only public assets |
+| `~/.agent-bridge/state/` | controller | `ab-controller` | `2750` | controller-only |
+| `~/.agent-bridge/agents/<agent>/` | **root** | `ab-agent-<agent>` | `2750` | per-agent private root |
+| `~/.agent-bridge/agents/<agent>/{home,workdir,runtime,logs,requests,responses}/` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `2770` | agent owns; controller via group |
+| `~/.agent-bridge/agents/<agent>/credentials/` | controller | `ab-agent-<agent>` | `2750` | controller writes, agent reads |
+| `~/.agent-bridge/agents/<agent>/credentials/launch-secrets.env` | controller | `ab-agent-<agent>` | `0640` | |
+| `~/.agent-bridge/agents/<agent>/agent-env.sh` | controller | `ab-agent-<agent>` | `0640` | |
+| `~/.agent-bridge/agents/<agent>/workdir/.teams/.env`, `.../.ms365/.env` | `agent-bridge-<agent>` | `ab-agent-<agent>` | `0640` | controller readiness probe via group |
+| `/home/agent-bridge-<agent>/` | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | agent's actual Linux home, no ACL |
+| `/home/agent-bridge-<agent>/.claude/`, sub-tree | `agent-bridge-<agent>` | `agent-bridge-<agent>` | `0700` | same — no ACL |
+
+Two access mechanisms only:
+
+1. **Group + setgid**, throughout the v2 layout under
+   `~/.agent-bridge/agents/<agent>/`. The controller reads the agent
+   tree by virtue of membership in `ab-agent-<agent>`; the per-agent
+   UID is the owner. New files inherit the group via the setgid bit
+   on the parent directory plus the agent process's `umask 007`
+   (applied by `bridge_run_apply_v2_umask_if_needed`).
+
+2. **Plain owner-only**, on the agent's actual Linux home
+   (`/home/agent-bridge-<agent>/`). The controller has no path into
+   this tree at all. Anything outside the v2 layout that the
+   controller needs to share with the agent must be re-mediated
+   through the v2 tree (via `agents/<agent>/credentials/` for secrets,
+   via `agents/<agent>/workdir/...` for plugin state, etc.).
+
+The single transitional ACL exception (`~/.claude/.credentials.json`
+in the operator's home) is documented in
+[`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
+— that surface is *outside* the v2 layout and uses a named-user `r--`
+ACL plus an `--x` traverse chain because it is the operator's home
+file. It is preserved by the migration command.
+
+## 2. Drift signatures from v0.7
+
+The most common shapes of drift on a v0.7-upgraded install. None of
+these are catastrophic on their own, but each one breaks at least one
+controller workflow until corrected.
+
+### 2.1 Pre-v2 ACL leftovers on the agent's Linux home
+
+```text
+/home/agent-bridge-<agent>/                root:agent-bridge-<agent>  0750
+/home/agent-bridge-<agent>/.claude/        root:agent-bridge-<agent>  0750
+                                           + named-user ACL: u:<controller>:r-x
+```
+
+**v2 expects**:
+
+```text
+/home/agent-bridge-<agent>/                agent-bridge-<agent>:agent-bridge-<agent>  0700
+/home/agent-bridge-<agent>/.claude/        agent-bridge-<agent>:agent-bridge-<agent>  0700
+                                           no ACL
+```
+
+Cause: v0.7's `bridge_linux_prepare_agent_isolation` created the home
+as `root` and granted the controller a named-user ACL for traversal
+and read. v0.8.0 deleted that helper but the v2 cut-over did not
+chown the existing home back to the agent or strip the ACL. The
+controller still has read access via the leftover ACL, which is
+exactly the surface v2 contract removed.
+
+Why this matters: any tooling that walks `/home/agent-bridge-<agent>/`
+expecting it to be `0700` agent-only (e.g. the audit fast-path that
+asserts "only the agent can read its own home") sees the leftover
+controller ACL and reports false-positive drift.
+
+### 2.2 Plugin state files at `0600` controller-owned
+
+```text
+~/.agent-bridge/agents/<agent>/workdir/.teams/.env       <controller>:<controller>  0600
+~/.agent-bridge/agents/<agent>/workdir/.ms365/.env       <controller>:<controller>  0600
+```
+
+**v2 expects**:
+
+```text
+~/.agent-bridge/agents/<agent>/workdir/.teams/.env   agent-bridge-<agent>:ab-agent-<agent>  0640
+~/.agent-bridge/agents/<agent>/workdir/.ms365/.env   agent-bridge-<agent>:ab-agent-<agent>  0640
+```
+
+Cause: pre-v2 the readiness probe ran as the controller against a
+controller-owned file. v2 moved the probe behind a group read so the
+file must be agent-owned with `ab-agent-<agent>` group + `0640`.
+
+Why this matters: the controller-side readiness probe for a Teams /
+MS365 plugin can no longer read the file it is probing, because the
+agent process now writes through the v2 umask and the file lands
+agent-owned, not controller-owned. The probe surfaces as a perpetual
+"not ready".
+
+### 2.3 Missing `agents/<agent>/.claude/`
+
+```text
+~/.agent-bridge/agents/<agent>/.claude/   (does not exist)
+```
+
+**v2 expects**:
+
+```text
+~/.agent-bridge/agents/<agent>/.claude/   <controller>:<controller>  0700
+```
+
+Cause: the controller-side `.claude/` shadow that the readiness probe
+and admin tooling reach for is created lazily; on installs that never
+exercised the lazy path, the directory is simply missing.
+
+Why this matters: `agent-bridge agent show <agent>` and other
+controller-side admin commands that look at the controller-side
+`.claude/` raise FileNotFoundError instead of "not configured yet".
+
+## 3. Migration command (v0.9.0+)
+
+The operator-facing entry point for the recovery. Three forms:
+
+```bash
+# Drift report only — never mutates.
+agent-bridge migrate isolation v2 --check
+
+# Print the planned mutations without applying them.
+agent-bridge migrate isolation v2 --dry-run
+
+# Apply the fix. Idempotent on a canonical install.
+agent-bridge migrate isolation v2 --apply
+```
+
+Scope each invocation to a single agent with `--agent <name>`; the
+default fans out across every isolated agent in the roster.
+
+What `--apply` does:
+
+1. Re-asserts the canonical owner / group / mode triplet on every row
+   of the canonical state table for each isolated agent (idempotent
+   when the row is already canonical).
+2. Strips any named-user POSIX ACL it finds inside the v2 tree
+   (`~/.agent-bridge/agents/<agent>/...`) and on the agent's actual
+   Linux home (`/home/agent-bridge-<agent>/...`). Equivalent to
+   `setfacl -bR <path>` on each of those subtrees.
+3. **Preserves** the `~/.claude/.credentials.json` named-user ACL plus
+   the `--x` traverse chain in the operator's home — that is the
+   single transitional exception (see
+   [`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)).
+4. Re-runs the readiness-probe shape check on the controller-side
+   `.claude/` shadow and the workdir plugin state files, fixing any
+   drift in §2.2 and §2.3 above.
+
+`--check` and `--dry-run` produce the same plan but never mutate.
+`--check` is the form intended for periodic operator audits.
+
+## 4. Manual recovery
+
+For installs where the v0.9.0 migration command is unavailable. Run
+each block as the controller (the user that owns
+`~/.agent-bridge/`), with `sudo` available.
+
+```bash
+# Identify the agent and its UID/GID names.
+A=<agent>
+USER=agent-bridge-$A
+GROUP=ab-agent-$A
+CTRL=$(id -un)
+
+# 1. Re-own the agent's actual Linux home and strip transitional ACLs.
+sudo chown -R "$USER:$USER" "/home/$USER/"
+sudo chmod -R u+rwX,go-rwx "/home/$USER/"
+sudo setfacl -bR "/home/$USER/"
+
+# 2. Realign plugin state files to v2 group-read contract.
+for f in "$HOME/.agent-bridge/agents/$A/workdir/.teams/.env" \
+         "$HOME/.agent-bridge/agents/$A/workdir/.ms365/.env"; do
+  if [[ -f "$f" ]]; then
+    sudo chown "$USER:$GROUP" "$f"
+    sudo chmod 0640 "$f"
+  fi
+done
+
+# 3. Create the controller-side .claude/ shadow if missing.
+sudo install -d -o "$CTRL" -g "$CTRL" -m 0700 \
+  "$HOME/.agent-bridge/agents/$A/.claude"
+
+# 4. (Optional) Re-assert the canonical group + mode on the v2 agent root.
+sudo chown root:"$GROUP" "$HOME/.agent-bridge/agents/$A"
+sudo chmod 2750 "$HOME/.agent-bridge/agents/$A"
+
+# 5. Restart the agent.
+agent-bridge agent start "$A"
+```
+
+**Do not** run `setfacl -b` on `~/.claude/.credentials.json` or its
+ancestor chain. That is the single retained ACL surface; stripping it
+breaks first-launch credential read for every isolated agent on the
+host until you re-run isolation prep.
+
+## 5. POSIX ACL contract — quick summary
+
+| Surface | ACL? | Notes |
+|---|---|---|
+| `~/.agent-bridge/...` (entire v2 layout) | **No** | group ownership + setgid only |
+| `/home/agent-bridge-<agent>/...` | **No** | agent-only `0700`, no ACL |
+| `~/.claude/.credentials.json` + ancestor chain | **Yes** | single transitional named-user ACL |
+| Anywhere else outside the v2 layout | **No** | no ACL surface |
+
+See [`KNOWN_ISSUES.md` §16](../../KNOWN_ISSUES.md#16-layout-v2--claude-first-launch-login-required-pr-641--v080)
+for the long-term plan to replace the transitional surface with
+per-agent `claude login` (operator workflow change).
+
+## 6. Diagnostic commands
+
+Probe a single agent:
+
+```bash
+A=<agent>
+USER=agent-bridge-$A
+GROUP=ab-agent-$A
+
+# Per-agent v2 root: should be `root:ab-agent-<agent> 2750`.
+stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A"
+
+# Per-agent home (inside v2 layout): should be `<USER>:<GROUP> 2770`.
+stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A/home"
+
+# Agent's actual Linux home: should be `<USER>:<USER> 700`, no ACL.
+sudo stat -c "%U:%G %a" "/home/$USER"
+sudo getfacl --skip-base "/home/$USER"
+sudo getfacl --skip-base "/home/$USER/.claude" 2>/dev/null
+
+# Plugin state files: should be `<USER>:<GROUP> 640`.
+stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A/workdir/.teams/.env" 2>/dev/null
+stat -c "%U:%G %a" "$HOME/.agent-bridge/agents/$A/workdir/.ms365/.env" 2>/dev/null
+
+# Per-agent group membership (controller + agent UID).
+getent group "$GROUP"
+
+# Agent UID's effective groups (must include $GROUP and ab-shared).
+sudo -u "$USER" id -nG
+```
+
+`--skip-base` on `getfacl` filters out the default UNIX permission
+entries, leaving only any extended (named-user / named-group / mask)
+entries — i.e. exactly the surface that v2 contract says should be
+empty inside the agent's home.
+
+## 7. Related issues
+
+- **#737** — the originating spec for this document and for the
+  v0.9.0 migration command.
+- **#720** — drift report for the v0.7 → v0.8 home-ownership leftover
+  (§2.1 above).
+- **#730** — `bridge_linux_grant_claude_credentials_access` removal +
+  the single retained ACL surface.
+- **#731** — readiness probe vs. plugin state file mode mismatch
+  (§2.2 above).


### PR DESCRIPTION
## Summary

- **OPERATIONS.md**: new "Isolation v2 canonical state and migration" section — canonical state table sourced from `lib/bridge-isolation-v2.sh:38-62`, ACL role clarification (layout-internal ACLs absent, only `~/.claude/.credentials.json` named-user ACL is the transitional exception), and operator-facing `agent-bridge migrate isolation v2` runbook.
- **KNOWN_ISSUES.md §16**: appended "v0.7 → v0.8 migration ACL leftovers" subsection — pre-v2 named-user ACLs on `/home/agent-bridge-<agent>/.claude/`, the planned migration command's behaviour, plus a manual recovery script for installs that cannot run it.
- **`docs/agent-runtime/v2-isolation-migration.md`** (new): deeper reference — layout overview, drift signatures from v0.7, command spec, manual recovery, ACL contract summary, diagnostic commands, related issues.

## Refs

- refs #737 Track Q (upstream answer comment is the contract source)
- Source-of-truth: `lib/bridge-isolation-v2.sh:38-62`

## Notes

Docs-only. No code or behaviour change. The `agent-bridge migrate isolation v2` CLI is documented as planned for v0.9.0 (Track N delivers it); this PR ships the spec/runbook so operators can also recover manually until then.