### PR TITLE
refs #737 Q6 — agent delete --purge-home covers actual Linux home

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3558,6 +3558,50 @@ PY
         bridge_warn "agent delete: --purge-home refused: resolved home outside expected agent roots: $home_dir"
         ;;
     esac
+
+    # Issue #737 Q6: also cover the isolated agent's actual Linux home
+    # (`/home/agent-bridge-<agent>/`). `bridge_agent_default_home` only
+    # resolves the agents/<agent>/home tree; under linux-user isolation
+    # the agent runs as `agent-bridge-<agent>` whose real OS home is a
+    # separate path on disk and would otherwise leak after delete.
+    #
+    # Discovery rules (defensive):
+    #  - Must be a linux-user-isolated agent (effective, not just
+    #    requested) so we never run sudo+rm on hosts where the agent is
+    #    actually shared-mode.
+    #  - Resolve the OS user from the roster, then read its home from
+    #    `getent passwd` (never hardcode — operator may have customized
+    #    the home root).
+    #  - Refuse anything that doesn't match `^/home/agent-bridge-<slug>$`.
+    #    This blocks operator home, /, /root, /tmp, /var/lib/..., etc.,
+    #    even if a misconfigured passwd entry pointed there.
+    #  - Use bridge_linux_sudo_root because the tree is owned by the
+    #    isolated UID (and dotfiles inside it are often root-owned via
+    #    upgrade-time fixups), so the controller alone cannot rm it.
+    #  - Failures warn-only; the agent is already removed from the
+    #    roster, so an unreachable home is operator-followup, not a
+    #    fail-loud condition.
+    #
+    # Out of scope (separate follow-up): `userdel` of the Linux account.
+    # `--purge-home` cleans home files only; account removal is a
+    # distinct destructive action that deserves its own opt-in flag.
+    if command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+       && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+      local agent_user linux_home
+      agent_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+      if [[ -n "$agent_user" ]] && getent passwd "$agent_user" >/dev/null 2>&1; then
+        linux_home="$(getent passwd "$agent_user" | cut -d: -f6)"
+        if [[ -n "$linux_home" && "$linux_home" =~ ^/home/agent-bridge-[a-zA-Z0-9_-]+$ ]]; then
+          if [[ -d "$linux_home" ]]; then
+            bridge_warn "agent delete: --purge-home also removing isolated Linux home: $linux_home"
+            bridge_linux_sudo_root rm -rf -- "$linux_home" || \
+              bridge_warn "agent delete: --purge-home best-effort Linux home rm failed: $linux_home (operator manual cleanup may be required)"
+          fi
+        elif [[ -n "$linux_home" ]]; then
+          bridge_warn "agent delete: --purge-home refused isolated Linux home (does not match /home/agent-bridge-* guard): $linux_home"
+        fi
+      fi
+    fi
   fi
 
   local after_sha


### PR DESCRIPTION
## Summary

- `agent delete --purge-home` now also removes the isolated agent's actual Linux home (`/home/agent-bridge-<agent>/`) in addition to `bridge_agent_default_home` (the `agents/<agent>/home` tree).
- The home path is resolved via `getent passwd <user> | cut -d: -f6` (no hardcoded path — respects `BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT` overrides).
- Regex guard `^/home/agent-bridge-[a-zA-Z0-9_-]+$` protects operator home, `/`, `/root`, `/tmp`, etc., even when a malformed passwd entry points outside the isolated layout.
- Removal uses `bridge_linux_sudo_root rm -rf` because the tree is owned by the isolated UID (and upgrade-time fixups occasionally leave root-owned subtrees inside it).
- On rm failure: warn only — the agent is already removed from the roster, so an unreachable home is operator follow-up, not fail-loud.
- Linux user account removal (`userdel`) is **out of scope** — separate follow-up. `--purge-home` semantics stay "home files only".

## Why

Currently, deleting an isolated agent leaks its real OS home — `bridge_agent_default_home` only resolves the controller-side `agents/<agent>/home`. Operators who delete and re-create isolated agents accumulate stale `/home/agent-bridge-<agent>/` trees on the host.

## Behavior matrix

| Agent type | Effective change |
|---|---|
| Shared-mode agent (no linux-user isolation) | Unchanged — guard short-circuits on `bridge_agent_linux_user_isolation_effective`. |
| Linux-user isolated agent, passwd home matches `^/home/agent-bridge-<slug>$` | Linux home `rm -rf`'d via `bridge_linux_sudo_root`. |
| Linux-user isolated agent, passwd home points elsewhere (e.g. `/home/sean`, `/root`) | Refused with warning, never rm'd. |
| Linux-user isolated agent, no passwd entry | Silently skipped (the user account doesn't exist; nothing to clean). |
| Linux home rm failure (sudo missing, permission, etc.) | Warning emitted; subcommand still succeeds (roster mutation already committed). |

## Refs

- refs #737 Q6

## Test plan

- [x] `bash -n bridge-agent.sh agent-bridge` PASS
- [x] `shellcheck -x bridge-agent.sh` — no new findings (10 pre-existing info-level SC2031 lines, identical to baseline)
- [x] Regex guard verified against: matches `/home/agent-bridge-test`, `/home/agent-bridge-agent-A`, `/home/agent-bridge-agent_X-1`; refuses `/home/sean`, `/`, `/root`, `/home/agent-bridge-test/..`, empty
- [x] `./scripts/smoke-test.sh` — pre-existing failure on this checkout (legacy layout marker; baseline reproduces same EXIT=1 with same truncation), no new failure introduced
- [ ] (Operator manual, requires Linux + isolated agent) Create a test linux-user-isolated agent, populate `/home/agent-bridge-<test>/`, run `agent-bridge agent delete <test> --purge-home`, confirm both `agents/<test>/home` and `/home/agent-bridge-<test>/` are removed and the audit row records the delete.