### PR TITLE
fix(setup): sudo as agent for isolated workdir env reads (refs #737)

### DIFF
--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -225,12 +225,21 @@ def _safe_read_env(path: Path) -> dict[str, str]:
         return {}
     try:
         return load_dotenv(path)
-    except PermissionError:
+    except PermissionError as exc:
         if os_user is None:
             raise
         result = _sudo_run_as(os_user, "cat", str(path))
-        if result.returncode != 0:
-            raise
+        rc = result.returncode
+        if rc == 127:
+            raise PermissionError(
+                f"sudo not available; cannot read {path} as {os_user}. "
+                f"Recovery requires either installing sudo or running this "
+                f"command directly as {os_user}."
+            ) from exc
+        if rc != 0:
+            raise PermissionError(
+                f"sudo cat failed for {path} as {os_user} (rc={rc})"
+            ) from exc
         return _parse_dotenv_text(result.stdout)
 
 
@@ -250,12 +259,21 @@ def _safe_load_json(path: Path, default: Any) -> Any:
         return default
     try:
         return load_json(path, default)
-    except PermissionError:
+    except PermissionError as exc:
         if os_user is None:
             raise
         result = _sudo_run_as(os_user, "cat", str(path))
-        if result.returncode != 0:
-            raise
+        rc = result.returncode
+        if rc == 127:
+            raise PermissionError(
+                f"sudo not available; cannot read {path} as {os_user}. "
+                f"Recovery requires either installing sudo or running this "
+                f"command directly as {os_user}."
+            ) from exc
+        if rc != 0:
+            raise PermissionError(
+                f"sudo cat failed for {path} as {os_user} (rc={rc})"
+            ) from exc
         try:
             return json.loads(result.stdout or "null") or default
         except json.JSONDecodeError:

--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -10,6 +10,7 @@ import json
 import os
 import re
 import socket
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -109,6 +110,158 @@ def load_dotenv(path: Path) -> dict[str, str]:
     return payload
 
 
+def _parse_dotenv_text(text: str) -> dict[str, str]:
+    payload: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        payload[key.strip()] = value.strip()
+    return payload
+
+
+def _isolated_workdir_owner(path: Path) -> str | None:
+    # Mirror of bridge-hooks.py `_isolated_workdir_owner` (#714 / #694
+    # family). bridge-setup.py runs as the controller user during
+    # `agent-bridge setup teams|telegram|discord <agent>` recovery; when
+    # the plugin state files (`.teams/.env`, `.telegram/.env`,
+    # `.discord/.env`) are owned by an isolated `agent-bridge-<slug>` UID
+    # in 0600 mode, the controller's `.env` read raises PermissionError
+    # before the recovery flow can reach `save_text` (#737 Q5). We fall
+    # back to `sudo -n -u <agent-user> cat` for the read; this helper
+    # picks the target user from the path's filesystem owner. Returns
+    # None on non-Linux hosts and for non-isolated paths so the
+    # fallback-only callers stay no-ops on dev machines.
+    if sys.platform != "linux":
+        return None
+    try:
+        stat_result = path.lstat()
+    except OSError:
+        return None
+    try:
+        import pwd
+
+        owner = pwd.getpwuid(stat_result.st_uid).pw_name
+    except (KeyError, ImportError):
+        return None
+    if stat_result.st_uid == os.getuid():
+        return None
+    if not owner.startswith("agent-bridge-"):
+        return None
+    return owner
+
+
+def _sudo_run_as(os_user: str, *cmd: str) -> subprocess.CompletedProcess[str]:
+    # Mirror of bridge-hooks.py `_sudo_run_as` (#714 / #694 family);
+    # captures stdout/stderr so callers (`_safe_read_env`) can parse
+    # the output instead of just inspecting the rc.
+    full = ["sudo", "-n", "-u", os_user, *cmd]
+    try:
+        return subprocess.run(full, check=False, capture_output=True, text=True)
+    except FileNotFoundError:
+        # sudo missing — non-Linux dev hosts don't ship it. Mirror
+        # bridge-hooks.py: emit a one-line warn and synthesize a
+        # non-zero CompletedProcess so the caller surfaces the original
+        # PermissionError shape rather than a confusing FileNotFoundError.
+        print(
+            f"[bridge-setup] sudo not available; cannot escalate to "
+            f"'{os_user}' for {cmd}",
+            file=sys.stderr,
+        )
+        return subprocess.CompletedProcess(args=full, returncode=127, stdout="", stderr="")
+
+
+def _safe_path_check(check: str, path: Path, os_user: str | None) -> bool:
+    """PermissionError-safe filesystem predicate for isolated plugin state.
+
+    Mirror of bridge-hooks.py `_safe_path_check` (PR #718 r2). On
+    isolated installs, `path.exists()` may raise PermissionError before
+    `load_dotenv`/`load_json` ever run (e.g. when the plugin dir's
+    parent is mode 0700 owned by the agent user, leaving the controller
+    without `+x` traversal). Falls back to `sudo -n -u <agent-user>
+    test -e/-h <path>` so the controller can still detect "exists" and
+    take the recovery path. `os_user=None` (non-Linux / non-isolated)
+    re-raises so callers preserve the original error shape.
+    """
+    try:
+        if check == "exists":
+            return path.exists()
+        if check == "is_symlink":
+            return path.is_symlink()
+    except PermissionError:
+        if os_user is None:
+            raise
+        flag = "-e" if check == "exists" else "-h"
+        result = _sudo_run_as(os_user, "test", flag, str(path))
+        return result.returncode == 0
+    return False
+
+
+def _safe_read_env(path: Path) -> dict[str, str]:
+    """PermissionError-safe `load_dotenv` for isolated plugin `.env` files.
+
+    On a linux-user-isolated install, `agents/<agent>/workdir/.teams/.env`
+    (and equivalents for telegram/discord) is `agent-bridge-<slug>:agent-group
+    0600`. `agent-bridge setup teams <agent>` runs as the controller and
+    its inspect_*_dir → load_dotenv → path.read_text() raises
+    PermissionError before the recovery flow can rewrite the file —
+    the documented recovery primitive cannot run on a file that exists
+    but is owner-only (#737 Q5).
+
+    Strategy mirrors PR #718 family: try direct read first (covers
+    non-isolated installs and macOS dev hosts), then fall back to
+    `sudo -n -u <agent-user> cat <path>` and parse the captured stdout
+    with the same dotenv schema as `load_dotenv`. The metadata probe
+    (`exists`) is also wrapped because the parent dir may itself be
+    0700 owned by the agent user. Returns `{}` when the path doesn't
+    exist (matches `load_dotenv`); re-raises the original PermissionError
+    when no isolated owner can be identified (non-Linux, non-isolated,
+    or sudo unavailable) so the caller surfaces the same error shape it
+    had before.
+    """
+    os_user = _isolated_workdir_owner(path) or _isolated_workdir_owner(path.parent)
+    if not _safe_path_check("exists", path, os_user):
+        return {}
+    try:
+        return load_dotenv(path)
+    except PermissionError:
+        if os_user is None:
+            raise
+        result = _sudo_run_as(os_user, "cat", str(path))
+        if result.returncode != 0:
+            raise
+        return _parse_dotenv_text(result.stdout)
+
+
+def _safe_load_json(path: Path, default: Any) -> Any:
+    """PermissionError-safe `load_json` for isolated plugin state files.
+
+    Companion to `_safe_read_env` for `access.json` / `state.json` that
+    live alongside the `.env` in the same isolated plugin dir. Falls
+    back to `sudo -n -u <agent-user> cat` and `json.loads` when the
+    direct read fails. Returns `default` for missing files (matches
+    `load_json`) or when the sudo fallback succeeds but the body is
+    not valid JSON (best-effort — recovery flow rebuilds the doc from
+    operator input).
+    """
+    os_user = _isolated_workdir_owner(path) or _isolated_workdir_owner(path.parent)
+    if not _safe_path_check("exists", path, os_user):
+        return default
+    try:
+        return load_json(path, default)
+    except PermissionError:
+        if os_user is None:
+            raise
+        result = _sudo_run_as(os_user, "cat", str(path))
+        if result.returncode != 0:
+            raise
+        try:
+            return json.loads(result.stdout or "null") or default
+        except json.JSONDecodeError:
+            return default
+
+
 def normalize_id_list(values: list[str] | tuple[str, ...] | None, label: str) -> list[str]:
     results: list[str] = []
     seen: set[str] = set()
@@ -183,8 +336,13 @@ def prompt_yes_no(prompt: str, default: bool) -> bool:
 def inspect_discord_dir(discord_dir: Path) -> dict[str, Any]:
     env_path = discord_dir / ".env"
     access_path = discord_dir / "access.json"
-    env = load_dotenv(env_path)
-    access_payload = load_json(access_path, {})
+    # #737 Q5: isolated agent's `.env` is `agent-bridge-<slug>:agent-group
+    # 0600`; controller-side `load_dotenv` raises PermissionError before
+    # `agent-bridge setup discord <agent>` can recover. `_safe_read_env`
+    # / `_safe_load_json` fall back to `sudo -n -u <agent-user> cat` on
+    # Linux isolated installs; no-op on non-Linux dev hosts.
+    env = _safe_read_env(env_path)
+    access_payload = _safe_load_json(access_path, {})
     groups = access_payload.get("groups") or {}
     channels = [str(channel_id) for channel_id in groups.keys() if str(channel_id).strip()]
     allow_from = normalize_id_list(access_payload.get("allowFrom") or [], "allow_from")
@@ -288,8 +446,9 @@ def candidate_channel_accounts(agent: str, accounts: dict[str, dict[str, Any]]) 
 def inspect_telegram_dir(telegram_dir: Path) -> dict[str, Any]:
     env_path = telegram_dir / ".env"
     access_path = telegram_dir / "access.json"
-    env = load_dotenv(env_path)
-    access_payload = load_json(access_path, {})
+    # #737 Q5: see inspect_discord_dir.
+    env = _safe_read_env(env_path)
+    access_payload = _safe_load_json(access_path, {})
     allow_from = normalize_id_list(access_payload.get("allowFrom") or [], "allow_from")
     default_chat = str(access_payload.get("defaultChatId") or "").strip()
     return {
@@ -306,9 +465,13 @@ def inspect_teams_dir(teams_dir: Path) -> dict[str, Any]:
     env_path = teams_dir / ".env"
     access_path = teams_dir / "access.json"
     state_path = teams_dir / "state.json"
-    env = load_dotenv(env_path)
-    access_payload = load_json(access_path, {})
-    state_payload = load_json(state_path, {})
+    # #737 Q5: see inspect_discord_dir. This is the path called out in
+    # the issue body — `bridge-setup.py:inspect_teams_dir → load_dotenv`
+    # was the first observed PermissionError on the documented recovery
+    # primitive (`agent-bridge setup teams <agent>`).
+    env = _safe_read_env(env_path)
+    access_payload = _safe_load_json(access_path, {})
+    state_payload = _safe_load_json(state_path, {})
     groups = access_payload.get("groups") or {}
     conversations = [str(key) for key in groups.keys() if str(key).strip()]
     allow_from = normalize_teams_id_list(access_payload.get("allowFrom") or [], "allow_from")


### PR DESCRIPTION
## Summary

- `bridge-setup.py`의 `inspect_<plugin>_dir` 함수들 (discord/telegram/teams) 이 linux-user-isolated agent의 owner-only `.env` (`agent-bridge-<slug>:agent-group 0600`) read 시 PermissionError 발생.
- 운영자가 `agent-bridge setup teams <agent>` recovery 시도해도 동일 path에서 실패 → 수동 `chgrp` / `chmod` 우회 강제. 이번 PR로 documented recovery primitive가 isolated install 에서도 동작.
- PR #718 family pattern을 그대로 미러 (`_isolated_workdir_owner` + `_sudo_run_as` + `_safe_path_check` + `_safe_read_env` / `_safe_load_json`). 새 sudo helper API 신규 도입 없음.

## Changes

`bridge-setup.py`:
- `_isolated_workdir_owner(path)` — `lstat` + `pwd` 로 agent user 식별. `sys.platform != "linux"` / controller 소유 / `agent-bridge-` 비-prefix → `None` 반환 (sudo escalation 차단).
- `_sudo_run_as(os_user, *cmd)` — `sudo -n -u <user>` + capture_output. sudo 미설치 dev host는 rc=127 + 경고 후 caller 가 원본 PermissionError 재발생.
- `_safe_path_check("exists"|"is_symlink", path, os_user)` — metadata probe PermissionError 시 `sudo -n test -e/-h` 폴백 (PR #718 r2 metadata 보호 동일).
- `_safe_read_env(path)` — `load_dotenv` PermissionError 시 `sudo cat | _parse_dotenv_text` 폴백. metadata probe도 보호.
- `_safe_load_json(path, default)` — `load_json` PermissionError 시 `sudo cat | json.loads` 폴백.
- `inspect_discord_dir` / `inspect_telegram_dir` / `inspect_teams_dir` 의 `load_dotenv` + `load_json` 호출만 safe variants로 교체.

## Refs

- refs #737 Q5 — `bridge-setup.py:309 inspect_teams_dir → load_dotenv → path.read_text` 가 isolated `.env` (owner-only) 에서 PermissionError 일으켜 documented recovery primitive 가 막힌 문제.
- 관련 PR #718 family — bridge-hooks.py 의 `_safe_path_check` / `_sudo_run_as` / `_isolated_workdir_owner` 동일 패턴 미러.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bridge-setup.py').read())"` PASS
- [x] `python3 -c "import py_compile; py_compile.compile('bridge-setup.py', doraise=True)"` PASS
- [x] 새 helper unit-style 검증 (macOS): `_safe_read_env` / `_safe_load_json` / `_isolated_workdir_owner` / `_parse_dotenv_text` 모두 정상 동작 (PermissionError 없는 경로에서는 기존 `load_dotenv` / `load_json` 과 동일 결과).
- [x] `inspect_discord_dir` / `inspect_telegram_dir` / `inspect_teams_dir` 임시 디렉토리에서 end-to-end PASS — 기존 dict schema 유지.
- [x] `./scripts/smoke-test.sh` — 사전 존재 isolation-v2 layout 요구 실패 (bridge-run.sh `--dry-run` 단계, 이번 PR 과 무관). main HEAD `6f9c89e` 에서도 동일 실패 확인 (smoke 환경 이슈).
- [ ] (수동) Linux isolated host 에서 `agent-bridge setup teams <agent>` 가 `.env` owner-only 에서도 inspect → 재기록 PASS 확인.
- [ ] (수동) macOS / non-isolated host 에서 `agent-bridge setup teams <agent>` 기존 동작 유지 확인 (sys.platform != linux → `_isolated_workdir_owner` None → fallback 분기 미진입).