### PR TITLE
fix(wiki-v2-rebuild): skip-and-continue on lock-init failures (refs #747)

### DIFF
--- a/scripts/wiki-v2-rebuild.sh
+++ b/scripts/wiki-v2-rebuild.sh
@@ -30,8 +30,16 @@ while IFS=$'\t' read -r agent home; do
   tmp_db="$live_db.rebuilding"
   lock_file="$live_db.lock"
 
-  mkdir -p "$(dirname "$live_db")"
-  : >> "$lock_file"
+  if ! mkdir -p "$(dirname "$live_db")" 2>/dev/null; then
+    log_audit "$JOB" "MKDIR_FAIL skip agent=$agent path=$(dirname "$live_db")" >/dev/null
+    skipped=$((skipped + 1))
+    continue
+  fi
+  if ! : 2>/dev/null >> "$lock_file"; then
+    log_audit "$JOB" "LOCK_INIT_FAIL skip agent=$agent path=$lock_file" >/dev/null
+    skipped=$((skipped + 1))
+    continue
+  fi
 
   # Acquire an exclusive lock so a manual rebuild can't interleave.
   # shellcheck disable=SC2094


### PR DESCRIPTION
## Summary

`scripts/wiki-v2-rebuild.sh` runs under `set -euo pipefail`. The per-agent loop
already protects every substantive step with `if ! ...; then log_audit; skipped++; continue; fi`,
but the lock-file init at the top of the body (`mkdir -p` + `: >> "$lock_file"`) was
outside that protection. A single permission-denied condition there aborted the
whole Saturday cron sweep before reaching subsequent agents.

This wave wraps both lock-init steps in the existing skip-and-continue shape
with new audit tags (`MKDIR_FAIL`, `LOCK_INIT_FAIL`), so one bad agent costs
one skip — not 5 silent miss-rebuilds.

## Test plan

- [x] `bash -n scripts/wiki-v2-rebuild.sh` passes
- [x] `shellcheck scripts/wiki-v2-rebuild.sh` passes
- [x] `./scripts/smoke-test.sh` passes
- [x] Visual diff confirms only the two `if !` blocks are added; rest untouched

Refs #747.