### PR TITLE
fix(migrate-isolation-v2): self-verify recursive chgrp on workdir (refs #746)

### DIFF
--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -947,6 +947,21 @@ bridge_isolation_v2_migrate_normalize_layout() {
         "$agent_grp" 2750 0640 "$agent_root/credentials" \
         || { bridge_warn "normalize_layout: agents/$agent/credentials chgrp_setgid_recursive failed"; return 1; }
     fi
+
+    # v0.9.x #746: explicit re-verify on workdir specifically. Files
+    # mirrored from v0.7→v0.8 layouts retained their pre-isolation
+    # owner-group long after the migrator believed it had repaired
+    # them. The helper now self-verifies, but log a per-agent OK/FAIL
+    # so the operator can grep the migration log for "workdir-verify".
+    if [[ -d "$agent_root/workdir" ]]; then
+      if bridge_isolation_v2_verify_chgrp_setgid_recursive \
+            "$agent_grp" 2770 0660 "$agent_root/workdir" 2>/dev/null; then
+        printf '[migrate] workdir-verify ok agent=%s grp=%s\n' "$agent" "$agent_grp" >&2
+      else
+        bridge_warn "[migrate] workdir-verify FAIL agent=$agent grp=$agent_grp — see preceding warnings"
+        return 1
+      fi
+    fi
   done < "$snapshot_path"
 
   return 0

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -704,6 +704,105 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
   _bridge_isolation_v2_run_root_or_sudo find "$root" -type f -exec chgrp "$group" {} + || return 1
   _bridge_isolation_v2_run_root_or_sudo find "$root" -type d -exec chmod "$dir_mode" {} + || return 1
   _bridge_isolation_v2_run_root_or_sudo find "$root" -type f -exec chmod "$file_mode" {} + || return 1
+
+  # Self-verify: catches the symptom from issue #746 where the
+  # direct-first path returns 0 with no actual mutations (e.g. find
+  # exit-status not propagating through `-exec ... +` on some findutils
+  # builds, or the sudo path silently degraded). Without this, the
+  # migrator advances the v2 marker on a half-repaired tree and the
+  # controller-group read sweep keeps failing every Saturday.
+  if ! bridge_isolation_v2_verify_chgrp_setgid_recursive \
+        "$group" "$dir_mode" "$file_mode" "$root"; then
+    # Drift detected. Retry with sudo-only (skip direct-first), in case
+    # the direct-first attempt succeeded-on-find-but-failed-on-chgrp.
+    # If still drifted after the sudo retry, surface clearly so the
+    # migrator caller can abort instead of writing the v2 marker on a
+    # half-repaired tree.
+    if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+      sudo -n find "$root" -type d -exec chgrp "$group" {} + 2>/dev/null || true
+      sudo -n find "$root" -type f -exec chgrp "$group" {} + 2>/dev/null || true
+      sudo -n find "$root" -type d -exec chmod "$dir_mode" {} + 2>/dev/null || true
+      sudo -n find "$root" -type f -exec chmod "$file_mode" {} + 2>/dev/null || true
+    fi
+    if ! bridge_isolation_v2_verify_chgrp_setgid_recursive \
+          "$group" "$dir_mode" "$file_mode" "$root"; then
+      bridge_warn "chgrp_setgid_recursive: tree under $root still has drifted group/mode after sudo retry — see preceding verify warnings"
+      return 1
+    fi
+  fi
+  return 0
+}
+
+bridge_isolation_v2_verify_chgrp_setgid_recursive() {
+  # Confirm the recursive chgrp/chmod actually landed on every entry
+  # under root. Used as a belt-and-braces check after
+  # bridge_isolation_v2_chgrp_setgid_recursive — see issue #746 for the
+  # symptom (helper returns 0 but files keep their pre-migration group/
+  # mode, leaving controller-group reads broken on isolated agent
+  # workdirs).
+  local group="$1"
+  local dir_mode="$2"
+  local file_mode="$3"
+  local root="$4"
+  [[ -n "$group" && -n "$dir_mode" && -n "$file_mode" && -n "$root" ]] || {
+    bridge_warn "verify_chgrp_setgid_recursive: group, dir_mode, file_mode, root required"
+    return 1
+  }
+  [[ -d "$root" ]] || return 0  # nothing to verify
+
+  # Normalize expected modes to %04o so `stat` output ("2770", "660")
+  # compares cleanly across BSD/macOS and GNU coreutils.
+  local exp_dir_mode exp_file_mode
+  exp_dir_mode="$(printf '%04o' "$((8#$dir_mode))" 2>/dev/null || printf '%s' "$dir_mode")"
+  exp_file_mode="$(printf '%04o' "$((8#$file_mode))" 2>/dev/null || printf '%s' "$file_mode")"
+
+  local stat_fmt
+  if [[ "$(uname)" == "Darwin" ]]; then
+    stat_fmt=(-f %A)
+  else
+    stat_fmt=(-c %a)
+  fi
+
+  # First dir whose group != expected. `\! -group` is portable across
+  # BSD/macOS find and GNU findutils; `-not` is GNU-only.
+  local mismatch_path
+  mismatch_path="$(find "$root" -type d \! -group "$group" -print 2>/dev/null | head -n1)"
+  if [[ -n "$mismatch_path" ]]; then
+    bridge_warn "verify_chgrp_setgid_recursive: dir group mismatch under $root (first: $mismatch_path expected=$group)"
+    return 1
+  fi
+  mismatch_path="$(find "$root" -type f \! -group "$group" -print 2>/dev/null | head -n1)"
+  if [[ -n "$mismatch_path" ]]; then
+    bridge_warn "verify_chgrp_setgid_recursive: file group mismatch under $root (first: $mismatch_path expected=$group)"
+    return 1
+  fi
+  # Sample mode check (one entry per type) — a full mode walk is
+  # expensive on large trees; the sample is enough to catch the silent-
+  # no-op failure mode where every entry kept its pre-migration mode.
+  local sample_dir sample_file actual_mode normalized_actual
+  sample_dir="$(find "$root" -type d -print 2>/dev/null | head -n1)"
+  sample_file="$(find "$root" -type f -print 2>/dev/null | head -n1)"
+  if [[ -n "$sample_dir" ]]; then
+    actual_mode="$(stat "${stat_fmt[@]}" "$sample_dir" 2>/dev/null || true)"
+    if [[ -n "$actual_mode" ]]; then
+      normalized_actual="$(printf '%04o' "$((8#$actual_mode))" 2>/dev/null || printf '%s' "$actual_mode")"
+      if [[ "$normalized_actual" != "$exp_dir_mode" ]]; then
+        bridge_warn "verify_chgrp_setgid_recursive: dir mode mismatch at $sample_dir (expected=$exp_dir_mode actual=$normalized_actual)"
+        return 1
+      fi
+    fi
+  fi
+  if [[ -n "$sample_file" ]]; then
+    actual_mode="$(stat "${stat_fmt[@]}" "$sample_file" 2>/dev/null || true)"
+    if [[ -n "$actual_mode" ]]; then
+      normalized_actual="$(printf '%04o' "$((8#$actual_mode))" 2>/dev/null || printf '%s' "$actual_mode")"
+      if [[ "$normalized_actual" != "$exp_file_mode" ]]; then
+        bridge_warn "verify_chgrp_setgid_recursive: file mode mismatch at $sample_file (expected=$exp_file_mode actual=$normalized_actual)"
+        return 1
+      fi
+    fi
+  fi
+  return 0
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

After `agent-bridge upgrade --apply` + `agent-bridge migrate isolation v2 --apply`
on a host that was migrated through v0.7.x → v0.8.x → v0.9.0, the migrator
reports success and shows every directory entry as `ok` / `ok:already-canonical`,
but pre-existing files inside `agents/<X>/workdir/` retain their pre-isolation
owner-group. The controller user (in `ab-agent-<X>` group) then cannot read
those files, so the centralized Saturday `agent-bridge memory rebuild-index`
cron sweep silently fails for every migrated isolated agent.

This PR makes `bridge_isolation_v2_chgrp_setgid_recursive` self-verify after
its four find-exec passes:
- Sample-check that the tree's group + sample dir/file modes actually match the
  expected values.
- On drift, retry with `sudo -n find … -exec chgrp / chmod {} +` (no direct-first)
  and re-verify.
- If still drifted, return non-zero with a `bridge_warn` naming the first
  mismatch — `bridge_isolation_v2_migrate_normalize_layout` will then propagate
  the failure (the full apply path aborts with `bridge_die`; the upgrade-path
  wrapper logs a `workdir-verify FAIL` warning per agent).

The rootless primary-group regression case (smoke test's own group + mode as
target) is unaffected — verify trivially passes on the smoke's clean tree.

## Test plan

- [x] `bash -n lib/bridge-isolation-v2.sh lib/bridge-isolation-v2-migrate.sh` passes
- [x] `shellcheck lib/bridge-isolation-v2.sh lib/bridge-isolation-v2-migrate.sh` passes (no new SC*** vs origin/main)
- [x] `./scripts/smoke-test.sh` — pre-existing failure on darwin host at the `bridge-run.sh --dry-run` block (unrelated to this PR; reproduces on origin/main `9f13a90`); not regressed
- [x] Isolated tempdir self-check: caller's primary group + 2770/0660 tree → verify rc=0
- [ ] Operator retest on Linux host with same drift state — pending #746 follow-up

Refs #746. Companion #747.