### PR TITLE
fix(unisolate): xargs+post-verify on default-ACL strip (refs #752 H1, refs #746)

### DIFF
--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -644,10 +644,39 @@ bridge_migration_unisolate() {
   for _acl_target in "${acl_strip_paths_recursive[@]}"; do
     [[ -n "$_acl_target" ]] || continue
     bridge_migration_print_step "$dry_run" "setfacl -R -x u:${os_user} ${_acl_target}"
-    bridge_migration_print_step "$dry_run" "find ${_acl_target} -type d -exec setfacl -d -x u:${os_user} {} +"
+    bridge_migration_print_step "$dry_run" "find ${_acl_target} -type d -print0 | xargs -0 -r setfacl -d -x u:${os_user}"
     if [[ "$dry_run" != "1" ]]; then
       bridge_linux_sudo_root setfacl -R -x "u:${os_user}" "$_acl_target" 2>/dev/null || true
-      bridge_linux_sudo_root find "$_acl_target" -type d -exec setfacl -d -x "u:${os_user}" {} + 2>/dev/null || true
+      # Default-ACL strip: `find -exec setfacl ... +` was observed to
+      # return rc=0 even when individual setfacl calls failed (issue
+      # #746 root cause). Pipe through `xargs -0 -r` instead so per-
+      # invocation failures propagate via xargs rc. The whole pipeline
+      # runs under `sh -c` because `bridge_linux_sudo_root find ... |
+      # xargs ...` would only sudo the find half. `xargs -r` is GNU-
+      # only but this is a Linux-only path (bridge_migration_require_linux).
+      bridge_linux_sudo_root sh -c \
+        'find "$1" -type d -print0 | xargs -0 -r setfacl -d -x "u:$2"' \
+        _ "$_acl_target" "$os_user" 2>/dev/null || true
+      # Post-verify: any surviving named ACL for os_user is a regression
+      # (the audit invariant from #752 H1). Retry once sudo-only; if
+      # still drifted, warn loudly with the first surviving path.
+      # Best-effort — unisolate must not abort on residual ACL.
+      if command -v getfacl >/dev/null 2>&1; then
+        local _residual
+        _residual="$(bridge_linux_sudo_root getfacl --absolute-names --skip-base -R "$_acl_target" 2>/dev/null \
+                      | grep -E "^(user|default:user):${os_user}:" | head -n1 || true)"
+        if [[ -n "$_residual" ]]; then
+          bridge_linux_sudo_root setfacl -R -x "u:${os_user}" "$_acl_target" 2>/dev/null || true
+          bridge_linux_sudo_root sh -c \
+            'find "$1" -type d -print0 | xargs -0 -r setfacl -d -x "u:$2"' \
+            _ "$_acl_target" "$os_user" 2>/dev/null || true
+          _residual="$(bridge_linux_sudo_root getfacl --absolute-names --skip-base -R "$_acl_target" 2>/dev/null \
+                        | grep -E "^(user|default:user):${os_user}:" | head -n1 || true)"
+          if [[ -n "$_residual" ]]; then
+            bridge_warn "unisolate: residual ACL after strip on $_acl_target: $_residual (operator: investigate underlying setfacl/sudo failure; rerun unisolate after addressing it)"
+          fi
+        fi
+      fi
     fi
   done
   # history_file is a regular file (not a directory). `-R` is a no-op


### PR DESCRIPTION
## Summary

Closes the #752 H1 finding: `lib/bridge-migration.sh:650`'s unisolate default-ACL strip used `find … -type d -exec setfacl -d -x … {} + 2>/dev/null || true`, which exhibits the same exit-propagation issue as the #746 root cause — per-invocation `setfacl` failures don't propagate through `find -exec ... +` reliably across findutils builds, and the trailing `|| true` swallows whatever rc does escape.

Net effect of the bug: stale `default:user:<isolated-uid>:rwx` ACL grants can persist on directories after `agent-bridge migrate isolation unisolate`, so subsequently created files keep inheriting grants for the (now-decommissioned) isolated UID. Operator believes unisolate is clean; child files keep getting wrong ACLs. HIGH severity per the audit because it silently breaks the unisolate invariant.

## Fix shape

Two complementary changes inside the existing recursive-strip loop (lines 644-652):

1. **xargs propagation**: replace `bridge_linux_sudo_root find … -exec setfacl -d -x … {} +` with `bridge_linux_sudo_root sh -c 'find "$1" -type d -print0 | xargs -0 -r setfacl -d -x "u:$2"' _ "$_acl_target" "$os_user"`. xargs propagates per-invocation failure to its own exit status more reliably than `find -exec ... +`. The `sh -c` wrap is required because piping a `bridge_linux_sudo_root find … | xargs …` would only sudo the find half.
2. **getfacl post-verify**: after the strip pass, run `getfacl --absolute-names --skip-base -R "$_acl_target"` and grep for any surviving `^(user|default:user):${os_user}:` line. On drift, retry the strip once and re-verify. If still drifted, `bridge_warn` with the first surviving path — best-effort, unisolate continues so a residual ACL doesn't abort the whole flow, but the operator sees the warning instead of silent persistence.

Mirrors the self-verify+sudo-retry shape #749 introduced in `bridge_isolation_v2_chgrp_setgid_recursive` (lines 707-733 of `lib/bridge-isolation-v2.sh`).

## Out of scope

- The access-ACL line at 649 (`setfacl -R -x`) is intentionally unchanged — `setfacl -R` propagates rc reliably; only the find-exec line needed the xargs treatment.
- H2 (`lib/bridge-isolation-v2.sh:871`), H3 (`lib/bridge-isolation-v2-migrate.sh:1683`), and H4 (`lib/bridge-migration.sh:139`) ship as separate fixers.
- `bridge_linux_sudo_root` itself is unchanged (load-bearing across many callers).
- `xargs -r` is GNU-only, but this is a Linux-only path (guarded by `bridge_migration_require_linux`).

## Test plan

- [x] `bash -n lib/bridge-migration.sh` — pass
- [x] `shellcheck lib/bridge-migration.sh` — clean (no new warnings)
- [x] `env -u BRIDGE_HOME -u BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT ./scripts/smoke-test.sh` — pre-existing darwin smoke failure on `bridge-run.sh --dry-run` (isolation-v2 layout marker check) reproduces unchanged on `origin/main` without this PR; not introduced here.
- [ ] Linux ACL repro: `not_attempted (darwin host)` — macOS has no POSIX ACL `setfacl`. Operator needs to run on a Linux host with at least one `linux-user` isolated agent that has had its workdir touched (so default ACLs accumulated), then `agent-bridge migrate isolation unisolate <agent>` and verify `getfacl -R agents/<agent>/workdir | grep -E '^(user|default:user):agent-bridge-<agent>:'` returns empty.

Diff: 31 added / 2 removed (33 LOC), single file.

refs #752 H1, refs #746