### PR TITLE
fix(migrate-isolation-v2): apply_for_upgrade returns partial-status on normalize_layout failure (refs #752 H3, refs #746)

### DIFF
--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -1678,10 +1678,14 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
       BRIDGE_LAYOUT="v2"
       BRIDGE_DATA_ROOT="$data_root"
       export BRIDGE_LAYOUT BRIDGE_DATA_ROOT
+
+      local _norm_rc=0
       if ! bridge_isolation_v2_migrate_normalize_layout \
             "$_norm_snapshot" "$data_root"; then
+        _norm_rc=1
         bridge_warn "apply_for_upgrade: normalize_layout pass on already-migrated install reported failures; layout may carry drifted modes (rerun \`agent-bridge upgrade --apply\` after addressing the warned cause)"
       fi
+
       BRIDGE_LAYOUT="$_saved_layout_norm"
       BRIDGE_DATA_ROOT="$_saved_data_root_norm"
       if [[ -n "$_saved_layout_norm" ]]; then
@@ -1694,8 +1698,26 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
       else
         unset BRIDGE_DATA_ROOT
       fi
+
+      if (( _norm_rc != 0 )); then
+        # H3 (refs #752 / #746): refuse to report clean success when the
+        # normalize_layout pass on an already-migrated install reports
+        # any failure. The upgrade caller can decide whether to abort or
+        # surface this as a partial-success warning, but we MUST NOT
+        # return 0 with `skipped:true` — that's the silent-success path
+        # the v0.9.0 production host hit (#746 / #747 / #749).
+        printf '{"mode":"isolation-v2-migrate","status":"partial","skipped":true,"reason":"normalize-refresh-failed","marker":"%s","data_root":"%s","normalize_refresh":"failed","last_error":"normalize_layout pass on already-migrated install reported failures — see preceding bridge_warn lines","remediation":"rerun agent-bridge upgrade --apply after addressing the warned cause; or run agent-bridge migrate isolation v2 --apply directly for the strict bridge_die contract"}\n' \
+          "$marker_path" "$data_root"
+        return 1
+      fi
+
+      printf '{"mode":"isolation-v2-migrate","status":"ok","skipped":true,"reason":"marker-present","marker":"%s","data_root":"%s","normalize_refresh":"attempted"}\n' \
+        "$marker_path" "$data_root"
+      return 0
     fi
-    printf '{"mode":"isolation-v2-migrate","skipped":true,"reason":"marker-present","marker":"%s","data_root":"%s","normalize_refresh":"attempted"}\n' \
+    # No-privilege / inactive path — keep existing skipped-true success
+    # since we couldn't even attempt normalize_layout.
+    printf '{"mode":"isolation-v2-migrate","status":"ok","skipped":true,"reason":"marker-present","marker":"%s","data_root":"%s","normalize_refresh":"skipped"}\n' \
       "$marker_path" "$data_root"
     return 0
   fi


### PR DESCRIPTION
## Summary

The marker-present idempotent skip path in `bridge_isolation_v2_migrate_apply_for_upgrade` (lib/bridge-isolation-v2-migrate.sh:1668) ran `normalize_layout` to refresh modes/groups on already-migrated installs, but swallowed any failure into `bridge_warn` and still returned 0 with `skipped:true`. The upgrade caller (`agent-bridge upgrade --apply`) therefore reported clean success on the v0.9.0 production host that #746/#747/#749 just closed, even though the layout still carried drifted modes / wrong groups / surviving ACLs.

## Change

- Capture `normalize_layout` rc into `_norm_rc`.
- After env restoration (`BRIDGE_LAYOUT` / `BRIDGE_DATA_ROOT` must be restored on every path before returning), if `_norm_rc != 0`, emit a `status:"partial"` JSON envelope with `reason:"normalize-refresh-failed"` + `last_error` + `remediation` fields and `return 1`.
- Add a `status` field to the success envelopes too (`status:"ok"`) so the upgrade caller can branch on a single field. Forward-compatible — callers that don't yet branch on `status` see no behavioral change.
- No-privilege / inactive fall-through stays `skipped:true,status:"ok",normalize_refresh:"skipped"` (we couldn't even attempt `normalize_layout`, so reporting success is correct).

The full apply path at `bridge_isolation_v2_migrate_apply` (line 1312) is unchanged — its existing `bridge_die` on normalize failure is the correct strict contract. `bridge-upgrade.sh` consumer wiring is M10's lane.

## Verification

- `bash -n lib/bridge-isolation-v2-migrate.sh` — PASS
- `shellcheck lib/bridge-isolation-v2-migrate.sh` — silent (PASS)
- All three JSON envelopes (`status:"partial"+normalize_refresh:"failed"`, `status:"ok"+normalize_refresh:"attempted"`, `status:"ok"+normalize_refresh:"skipped"`) parse cleanly under `python3 -m json` after bash printf substitution. Backtick-quoted command names were dropped from the remediation string because `` \` `` is not a JSON-spec escape sequence and rejected the partial-status envelope.
- `env -u BRIDGE_HOME -u BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT ./scripts/smoke-test.sh` matches the unmodified `origin/main` baseline on this macOS host (both stop at the same pre-existing layout-marker precondition; the function under change is dormant on the smoke-test path).
- Diff: +23/-1 LOC, single file `lib/bridge-isolation-v2-migrate.sh`.

## Out of scope

- H1 / H2 / H4 lanes from the umbrella audit (#752).
- Full apply path's existing fatal-on-normalize behavior (line 1312) — kept intact.
- `bridge-upgrade.sh` consumer wiring — that's the M10 lane.
- VERSION / CHANGELOG / docs.

refs #752 H3
refs #746