### PR TITLE
fix(isolation-v2): post-verify setfacl -bR on Linux (refs #752 H2, refs #746)

### DIFF
--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -875,6 +875,35 @@ bridge_isolation_v2_acl_scrub() {
     bridge_warn "acl_scrub: setfacl -bR failed at $root (rc=${_rc}); see ${_scrub_err}"
     return 1
   fi
+  # Self-verify: mirrors the issue #746 / PR #749 fix shape for the
+  # recursive chgrp path. `_bridge_isolation_v2_run_root_or_sudo` tries
+  # direct first and may return rc=0 even when per-entry strip didn't
+  # land (e.g. `acl` package build differences across distros, or the
+  # sudo path silently degraded). Without this, the migrator advances
+  # the v2 marker on a tree with surviving named ACLs and controller
+  # group reads drift the same way #746 reported.
+  #
+  # When getfacl is unavailable on this Linux box we fall through to
+  # the existing rc-only check (mirrors the pre-check fallback above).
+  if command -v getfacl >/dev/null 2>&1; then
+    local _residual_acl
+    _residual_acl="$(getfacl --absolute-names --skip-base -R "$root" 2>/dev/null \
+                      | grep -E '^(user|group|default:user|default:group):[^:]+:' | head -n1 || true)"
+    if [[ -n "$_residual_acl" ]]; then
+      # Retry sudo-only (skip direct-first), in case direct succeeded
+      # on rc but failed on per-entry strip.
+      if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+        sudo -n setfacl -bR "$root" 2>/dev/null || true
+      fi
+      _residual_acl="$(getfacl --absolute-names --skip-base -R "$root" 2>/dev/null \
+                        | grep -E '^(user|group|default:user|default:group):[^:]+:' | head -n1 || true)"
+      if [[ -n "$_residual_acl" ]]; then
+        bridge_warn "acl_scrub: residual named ACL after setfacl -bR + sudo retry: $_residual_acl"
+        [[ "$_scrub_err" != "/dev/null" ]] && rm -f "$_scrub_err"
+        return 1
+      fi
+    fi
+  fi
   [[ "$_scrub_err" != "/dev/null" ]] && rm -f "$_scrub_err"
   return 0
 }


### PR DESCRIPTION
## Summary

Mirror the #749 self-verify+sudo-retry pattern around the Linux `setfacl -bR` scrub in `bridge_isolation_v2_acl_scrub` (`lib/bridge-isolation-v2.sh:871`). `_bridge_isolation_v2_run_root_or_sudo setfacl -bR` may rc=0 even when per-entry strip didn't land — same class of silent-success bug #746 reported on the recursive chgrp path. Without this, the migrator advances the v2 marker on a tree with surviving named ACLs and controller-group reads drift identically to #746.

After the existing rc!=0 fail-fast, run `getfacl --absolute-names --skip-base -R "\$root"` and grep for any `user:`/`group:`/`default:user:`/`default:group:` entries. On drift, retry sudo-only (skip direct-first) and re-verify; on still-drift, `bridge_warn` with the first surviving entry and `return 1` so the migration caller `bridge_die`s.

When `getfacl` is unavailable on this Linux box (rare), the verify falls through to the existing rc-only check — mirrors the pre-check fallback already in this function.

## Out of scope

- Darwin `chmod -R -P -N` counterpart (M7) — separate fixer's lane, untouched.
- `_bridge_isolation_v2_run_root_or_sudo` helper itself — untouched.
- No docs / VERSION / CHANGELOG churn.

29 LOC added, 0 removed. Single file: `lib/bridge-isolation-v2.sh`.

## Test plan

- [x] `bash -n lib/bridge-isolation-v2.sh` — PASS
- [x] `shellcheck lib/bridge-isolation-v2.sh` — PASS
- [x] Tempdir self-check on darwin (clean tree → Darwin path returns rc=0 before the new Linux block):
  ```
  TMPHOME="$(mktemp -d)" && mkdir -p "$TMPHOME/test" && touch "$TMPHOME/test/foo"
  source ./lib/bridge-isolation-v2.sh
  bridge_isolation_v2_acl_scrub "$TMPHOME/test"; echo "rc=\$?"
  # rc=0
  ```
- [x] `env -u BRIDGE_HOME -u BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT ./scripts/smoke-test.sh` — pre-existing failure on `bridge-run.sh --dry-run #428 r2` step (markerless BRIDGE_HOME hits v0.8.0 layout-resolver hard-cut). Confirmed reproduces on origin/main HEAD `c3a09a0` baseline without this PR's edits — not introduced here.
- [ ] Linux `acl` package repro: not attempted (darwin host — `getfacl` not installed; new Linux verify path is exercised only via static review on this host). Operator retest on Linux host before closing #752 H2.

Refs #752 H2, refs #746.