### PR TITLE
fix(isolate-reapply): refuse to mark state done on prepare_agent_isolation failure (refs #752 H4)

### DIFF
--- a/lib/bridge-migration.sh
+++ b/lib/bridge-migration.sh
@@ -136,8 +136,13 @@ bridge_migration_isolate() {
       printf '[done] isolation plan (reapply) printed for %s\n' "$agent"
       return 0
     fi
-    bridge_linux_prepare_agent_isolation "$agent" "$os_user" "$workdir" "$(bridge_current_user)" || \
-      bridge_warn "bridge_linux_prepare_agent_isolation returned non-zero for $agent; re-run isolate or check acceptance runbook §2"
+    # Issue #752 H4 — ACL prep is the load-bearing step of --reapply.
+    # If it fails, refuse to print [done] / return 0; otherwise the operator
+    # sees a clean reapply on top of partially-applied isolation perms.
+    if ! bridge_linux_prepare_agent_isolation "$agent" "$os_user" "$workdir" "$(bridge_current_user)"; then
+      bridge_warn "bridge_linux_prepare_agent_isolation failed for $agent during --reapply; refusing to mark reapply complete. Address the underlying cause (sudo policy, missing os_user, perm denied on $workdir) and re-run 'agent-bridge isolate $agent --reapply'. See acceptance runbook §2."
+      return 1
+    fi
     # Issue #544 PR3 — refresh the bridge-native skills under the
     # isolated HOME (.claude/skills/) so existing isolated agents pick
     # up new/changed skills on `--reapply` without unisolate→isolate.


### PR DESCRIPTION
## Summary

`agent-bridge isolate <agent> --reapply` (`bridge_migration_isolate` reapply branch, `lib/bridge-migration.sh:139`) was treating `bridge_linux_prepare_agent_isolation` failure as a warning and still printing `[done] ACL reapply complete` / returning 0. The agent's roster state already says `linux-user`, so the operator had no signal that the ACL/queue-gateway plumbing was only partially reinstalled. This is the bug-class **D — Idempotent-skip warns-not-fatal** finding from the post-#746/#747 audit (refs #752, HIGH H4).

## Change

- Replace the warn-only `||` chain at the load-bearing ACL prep call with an explicit `if ! ...; then bridge_warn ...; return 1; fi`.
- Warn message names the likely root causes (sudo policy, missing os_user, perm denied on workdir) and explicitly says the reapply is being refused, so the operator knows to fix the underlying cause and re-run.
- Bounded to the reapply branch's `bridge_linux_prepare_agent_isolation` call. The follow-up best-effort `bridge_sync_isolated_home_claude_skills` (line 148) and `bridge_install_isolated_home_settings` (line 164) calls keep their existing warn-and-continue behavior — those are tracked separately as M8+M9 in #752 and are not in this track. The first-time isolation flow's symmetric warn-only call (line ~238) is also separate.

7 added / 2 removed = 9 LOC delta.

## Test plan

- [x] `bash -n lib/bridge-migration.sh` — pass
- [x] `shellcheck lib/bridge-migration.sh` — clean
- [x] `./scripts/smoke-test.sh` lint stage passes; downstream failure at the `bridge-run.sh --dry-run` step reproduces on unmodified `main` (same rc=1, same `current_layout=legacy` v2 guard) — pre-existing, unrelated to this edit.
- [ ] Linux operator validates `agent-bridge isolate <agent> --reapply` against an agent where ACL prep deliberately fails (e.g. revoke sudo policy or remove the os_user briefly) and confirms the command now exits non-zero, the warn message names the root cause, and the agent's runtime perms can no longer be reported as "reapply ok" while inconsistent.

Cannot repro the actual Linux failure on darwin (no Linux user namespace, no setpriv) per CLAUDE.md / brief — relying on the lint + smoke + visual review here.

## Notes for reviewer

Co-file with H1 (different function: unisolate at line 650). Worktree-isolated; whichever lands second will rebase against this. Independent fixes — no shared state.

refs #752 H4