### PR TITLE
fix(bridge-sync): skip-and-continue on per-agent archive + persist failures (refs #752 M1+M2)

### DIFF
--- a/bridge-sync.sh
+++ b/bridge-sync.sh
@@ -46,9 +46,15 @@ prune_missing_dynamic_agents() {
       unset "CLAIMED_SESSION_IDS[$sid]"
     fi
 
-    bridge_archive_dynamic_agent "$agent"
-    bridge_remove_dynamic_agent_file "$agent"
-    bridge_agent_clear_idle_marker "$agent"
+    if ! bridge_archive_dynamic_agent "$agent" 2>/dev/null; then
+      bridge_warn "bridge-sync: archive_dynamic_agent failed for agent='$agent' — skipping; next sweep will retry"
+      continue
+    fi
+    if ! bridge_remove_dynamic_agent_file "$agent" 2>/dev/null; then
+      bridge_warn "bridge-sync: remove_dynamic_agent_file failed for agent='$agent' — skipping; next sweep will retry"
+      continue
+    fi
+    bridge_agent_clear_idle_marker "$agent" 2>/dev/null || true
     PRUNED_DYNAMIC["$agent"]=1
   done < <(bridge_dynamic_agent_ids)
 }
@@ -104,7 +110,10 @@ refresh_missing_session_ids() {
     # shellcheck disable=SC2034
     BRIDGE_AGENT_SESSION_ID["$agent"]="$detected"
     CLAIMED_SESSION_IDS["$detected"]="$agent"
-    bridge_persist_agent_state "$agent"
+    if ! bridge_persist_agent_state "$agent" 2>/dev/null; then
+      bridge_warn "bridge-sync: persist_agent_state failed for agent='$agent' — skipping; next sweep will retry"
+      continue
+    fi
   done
 }
 


### PR DESCRIPTION
## Summary

Bundle two MED Bug-A cascade fixes in `bridge-sync.sh` (refs #752 M1+M2). Same file, same fix shape — single PR.

`bridge-sync.sh` runs under `set -euo pipefail` and has two per-agent iteration loops where a substantive step could fail under errexit and abort sweep coverage for every subsequent agent (same shape as the #747 / PR #748 cascade in `scripts/wiki-v2-rebuild.sh`).

- **M1 — line 49** (`prune_missing_dynamic_agents`): wrap `bridge_archive_dynamic_agent` and `bridge_remove_dynamic_agent_file` in `if !; then warn; continue; fi`. Idle-marker clear already softened to `|| true` since it is informational.
- **M2 — line 107** (`refresh_missing_session_ids`): wrap `bridge_persist_agent_state` in the same guard so a persist failure on one agent does not block subsequent agents' state refresh; next sync sweep will retry.

Caller-side guards only — helpers in `lib/bridge-state.sh` are untouched, and `set -euo pipefail` is preserved at the script level (mirrors the #748 contract).

## Diff size

- `bridge-sync.sh`: +13 / -4

## Test plan

- [x] `bash -n bridge-sync.sh` — PASS
- [x] `shellcheck bridge-sync.sh` — PASS (clean, no warnings)
- [x] Visual diff sanity: only the two per-agent loop bodies have new `if !` guards; no other lines changed
- [ ] `./scripts/smoke-test.sh` — pre-existing failure on macOS (isolation-v2 layout requirement; bails before `bridge-sync.sh` is exercised). Not a regression from this change. Linux smoke run recommended pre-merge if available.

## Out of scope

- M3 (`lib/bridge-state.sh:2678`), M4 (`bridge-agent.sh:2116`), M5 (`scripts/apply-channel-policy.sh:707`) — separate fixers' lanes in Wave 2.
- No CHANGELOG / VERSION / docs touched.

refs #752 M1+M2