### PR TITLE
fix(bridge-state): skip-and-continue on per-marker reconcile failures (refs #752 M3)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2674,8 +2674,12 @@ bridge_reconcile_idle_markers() {
     file="$(bridge_agent_idle_since_file "$agent")"
     [[ -f "$file" ]] || continue
 
+    # #752 M3: per-marker best-effort under bridge-sync's `set -e` — a single
+    # locked dir / perm-denied marker must not cascade-abort subsequent agents.
     if ! bridge_agent_is_active "$agent"; then
-      bridge_agent_clear_idle_marker "$agent"
+      if ! bridge_agent_clear_idle_marker "$agent" 2>/dev/null; then
+        bridge_warn "reconcile_idle_markers: clear (inactive) failed for agent='$agent' — skipping; next reconcile will retry"
+      fi
       continue
     fi
 
@@ -2684,7 +2688,10 @@ bridge_reconcile_idle_markers() {
       continue
     }
     if ! [[ "$value" =~ ^[0-9]+$ ]]; then
-      bridge_agent_clear_idle_marker "$agent"
+      if ! bridge_agent_clear_idle_marker "$agent" 2>/dev/null; then
+        bridge_warn "reconcile_idle_markers: clear (non-numeric) failed for agent='$agent' — skipping; next reconcile will retry"
+        continue
+      fi
     fi
   done
 }


### PR DESCRIPTION
## Summary

`bridge_reconcile_idle_markers` (in `lib/bridge-state.sh`) iterates idle markers and cleans up stale entries. It is invoked from `bridge-sync.sh`, which runs under `set -euo pipefail`. Two of the per-iteration cleanup calls — the inactive-agent path at line 2678 and the non-numeric-value path at line 2687 — propagated their failure rc to the caller's errexit, aborting the entire loop. A single locked marker directory, perm-denied `rmdir`, or any other transient cleanup failure would silently strand every subsequent agent's marker until the next reconcile pass.

This is item M3 of the post-#746/#747 audit umbrella (#752, Bug-A — `set -e` cascade in per-iteration loops).

## Change

Wrap each substantive `bridge_agent_clear_idle_marker` call in `if ! …; then bridge_warn … fi` so:

- per-agent failure is surfaced via the existing `bridge_warn` channel,
- the loop advances to the next agent rather than aborting,
- the next reconcile pass retries automatically.

The pattern mirrors the existing `|| true` guard on the cat-failure cleanup path that already lived in the same loop. Net diff: +9 / -2 LOC, single file.

## Verification

- `bash -n lib/bridge-state.sh` — pass
- `shellcheck lib/bridge-state.sh` — clean (rc=0)
- `env -u BRIDGE_HOME -u BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT ./scripts/smoke-test.sh` — pre-existing redirect-only failure on `main` (verified by re-running on a clean `origin/main` checkout); my branch reproduces the identical 3-line output, confirming no regression.

## Out of scope

- M1+M2 / M4 / M5 / Bug-B/C/D bundle / LOW sweep — separate fixers per the umbrella's wave plan.

refs #752