### PR TITLE
fix(bridge-agent): skip-and-continue on per-target rerender-settings probe failures (refs #752 M4)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2110,10 +2110,32 @@ run_rerender_settings() {
   fi
 
   rows_file="$(mktemp "${TMPDIR:-/tmp}/bridge-rerender-settings.XXXXXX")"
+  local _probe_stderr=""
+  local _probe_err=""
+  local _probe_mode=""
   for target in "${targets[@]}"; do
     agent="${target%%$'\t'*}"
     workdir="${target#*$'\t'}"
-    before_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir")"
+    # Issue #752 M4: under `set -e`, a single per-target probe failure
+    # (python crash, sudo denial on isolated read, mktemp ENOSPC) would
+    # abort the whole loop and leave later targets un-rerendered with no
+    # signal which agents were skipped. Capture rc explicitly, emit a
+    # structured error row that satisfies the bridge_agent_print_rerender_*
+    # consumers (status/agent/workdir/mode), warn, and continue.
+    _probe_stderr="$(mktemp "${TMPDIR:-/tmp}/bridge-rerender-probe-err.XXXXXX")"
+    if ! before_json="$(bridge_agent_shared_settings_plan_json "$agent" "$workdir" 2>"$_probe_stderr")"; then
+      _probe_err="$(<"$_probe_stderr")"
+      rm -f "$_probe_stderr"
+      bridge_warn "rerender-settings: probe 실패로 target='$agent' 건너뜁니다 (workdir=$workdir): ${_probe_err:-no stderr captured}"
+      _probe_mode="$([[ $apply -eq 1 ]] && printf apply || printf dry-run)"
+      row_json="$(BRIDGE_PROBE_AGENT="$agent" BRIDGE_PROBE_WORKDIR="$workdir" \
+        BRIDGE_PROBE_MODE="$_probe_mode" BRIDGE_PROBE_ERROR="${_probe_err:-probe failed}" \
+        python3 -c 'import json,os; print(json.dumps({"agent":os.environ["BRIDGE_PROBE_AGENT"],"workdir":os.environ["BRIDGE_PROBE_WORKDIR"],"mode":os.environ["BRIDGE_PROBE_MODE"],"status":"error","reason":"probe_failed","error":os.environ["BRIDGE_PROBE_ERROR"]}, ensure_ascii=False, sort_keys=True))')"
+      printf '%s\n' "$row_json" >>"$rows_file"
+      failed_count=$((failed_count + 1))
+      continue
+    fi
+    rm -f "$_probe_stderr"
     error=""
     if [[ $apply -eq 1 ]]; then
       # Issue #570: managed autoCompactWindow default is unconditionally


### PR DESCRIPTION
## Summary

`run_rerender_settings` in `bridge-agent.sh` iterates targets and calls `bridge_agent_shared_settings_plan_json` (the "plan probe") at the top of the loop. Under `set -euo pipefail`, a single probe failure (python crash, sudo denial on the cross-UID isolated read path, mktemp ENOSPC) aborted the entire sweep — later targets were silently skipped and the operator saw partial-rerender state with no signal which agents were affected.

This PR wraps the per-target probe in `if ! …; then warn; record_error_row; continue; fi`:

- Probe stderr is captured to a tempfile so the warn line surfaces the underlying cause.
- A structured error row is appended to `rows_file` matching the in-loop JSON shape (`agent` / `workdir` / `mode` / `status` / `reason` / `error`) so both `bridge_agent_print_rerender_json` and `bridge_agent_print_rerender_text` render the failed target instead of dropping it.
- `failed_count` is bumped on each skip, so the function's overall rc (`[[ $failed_count -eq 0 ]]`) still reflects "any target failed" and the upgrade caller in `bridge-upgrade.sh:1441` can decide whether to abort.

Tracks the M4 lane of the umbrella audit in #752. M1+M2/M3/M5 are separate fixers per the wave brief; the upgrader-side reaction (M9) is bundled with M10/M11 in Wave 3.

refs #752 M4

## Verification

- `bash -n bridge-agent.sh` — pass
- `shellcheck bridge-agent.sh` — pass (no findings)
- Loop-semantics repro (3 targets, middle one forced to fail): under the new wrapper, `failed_count=1`, the failing target's row is `status=error reason=probe_failed`, the trailing target is still processed, and the warn line surfaces the captured stderr.
- Synthetic error row JSON round-trips through `python3 -c "import json,sys; json.loads(...)"` with a multi-line stderr containing whitespace and special chars.
- `./scripts/smoke-test.sh` — fails identically on a clean checkout of `main` at the v2 isolation preflight (`bridge-run.sh dryrun-redact-smoke --dry-run` returns the v0.8.0 isolation-v2 error against a `mktemp -d` BRIDGE_HOME). Pre-existing; unrelated to this change.

## Out of scope

- M1+M2 / M3 / M5 — separate fixers in the same wave.
- `bridge-upgrade.sh:1441` consumer behavior (M9 / Wave 3).
- `bridge-hooks.py rerender-settings` itself.
- Docs / VERSION / CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)