### PR TITLE
fix(bridge-tmux): redirection-order on pending-attention lock PID write (refs #752 W3a)

### DIFF
--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -1135,7 +1135,7 @@ bridge_tmux_pending_attention_with_lock() {
     sleep 0.05
   done
 
-  printf '%d' $$ >"$pid_file" 2>/dev/null
+  printf '%d' $$ 2>/dev/null >"$pid_file"
   "$action" "$agent" "$@"
   rc=$?
   rm -f "$pid_file" 2>/dev/null


### PR DESCRIPTION
## Summary

`lib/bridge-tmux.sh:1138` writes the pending-attention lock PID via:

```bash
printf '%d' $$ >"$pid_file" 2>/dev/null
```

The `>"$pid_file"` open happens BEFORE `2>/dev/null` is applied, so a perm-denied pid file emits a bash diagnostic to inherited stderr (daemon log / tmux pane / cron log) before the redirect silences anything. Same redirection-order leak class as #747 — fixed in #748 for `scripts/wiki-v2-rebuild.sh:38` with the stderr-first pattern.

Swap to stderr-first:

```bash
printf '%d' $$ 2>/dev/null >"$pid_file"
```

## Lock-cleanup correctness

The cleanup branch (`rm -f "$pid_file" 2>/dev/null` + `rmdir "$lock_dir"`) is unconditional, with no `if ! ...` or `|| ...` gating on the pid write rc. The original was best-effort; the swap is purely a stderr-behavior change. Cleanup still runs identically.

## Verification

```bash
bash -n lib/bridge-tmux.sh                   # PASS
shellcheck lib/bridge-tmux.sh                # PASS (clean)
./scripts/smoke-test.sh                      # rc=1 from pre-existing SC2088 in lib/bridge-core.sh:254 (per W3a brief)
```

Local repro of the leak before/after:

```
$ ROFLOCK=$(mktemp); chmod 0400 "$ROFLOCK"
$ bash -c '{ printf "%d" $$ >"$1" 2>/dev/null; } 2>&1' _ "$ROFLOCK"
_: /var/folders/.../tmp.XXX: Permission denied
$ bash -c '{ printf "%d" $$ 2>/dev/null >"$1"; } 2>&1' _ "$ROFLOCK"
(silent)
```

## Test plan

- [x] `bash -n lib/bridge-tmux.sh`
- [x] `shellcheck lib/bridge-tmux.sh` clean
- [x] Repro shows BEFORE leaks `Permission denied` to stderr; AFTER is silent
- [x] Lock-cleanup branch verified unconditional — no rc-dependence on pid write
- [x] Single file, 1 LOC swap

refs #752 W3a