### PR TITLE
fix(isolation-v2): post-verify Darwin chmod -R -P -N (refs #752 W3b, refs #746)

### DIFF
--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -842,7 +842,31 @@ bridge_isolation_v2_acl_scrub() {
     _rc=$?
     if (( _rc != 0 )); then
       bridge_warn "acl_scrub: chmod -R -P -N failed at $root (rc=${_rc}); see ${_scrub_err}"
+      [[ "$_scrub_err" != "/dev/null" ]] && rm -f "$_scrub_err"
       return 1
+    fi
+    # Self-verify: counterpart of the Linux setfacl post-verify added by
+    # H2 / PR #755. `_bridge_isolation_v2_run_root_or_sudo` direct-first
+    # may rc=0 even when the per-entry ACL strip didn't land. Darwin has
+    # no getfacl; ACL entries surface as numbered prefix lines (`  0:`,
+    # `  1:`, …) in `ls -le` output. Best-effort — empty trees or BSD ls
+    # without ACL support yield no match, so verify passes.
+    local _residual_acl
+    _residual_acl="$(find "$root" -print0 2>/dev/null \
+                      | xargs -0 ls -leOd 2>/dev/null \
+                      | grep -E '^[[:space:]]+[0-9]+:' | head -n1 || true)"
+    if [[ -n "$_residual_acl" ]]; then
+      if [[ "$(id -u)" -ne 0 ]] && command -v sudo >/dev/null 2>&1; then
+        sudo -n chmod -R -P -N "$root" 2>/dev/null || true
+      fi
+      _residual_acl="$(find "$root" -print0 2>/dev/null \
+                        | xargs -0 ls -leOd 2>/dev/null \
+                        | grep -E '^[[:space:]]+[0-9]+:' | head -n1 || true)"
+      if [[ -n "$_residual_acl" ]]; then
+        bridge_warn "acl_scrub: residual ACL after chmod -R -P -N + sudo retry: $_residual_acl"
+        [[ "$_scrub_err" != "/dev/null" ]] && rm -f "$_scrub_err"
+        return 1
+      fi
     fi
     [[ "$_scrub_err" != "/dev/null" ]] && rm -f "$_scrub_err"
     return 0


### PR DESCRIPTION
## Summary

Darwin counterpart of the Linux setfacl post-verify landed by H2 / PR #755 in `bridge_isolation_v2_acl_scrub`. The existing block at `lib/bridge-isolation-v2.sh:840` calls `_bridge_isolation_v2_run_root_or_sudo chmod -R -P -N "$root"` and trusts rc=0 — but the helper's direct-first attempt can rc=0 with no actual mutation (same shape as #746 / #749), advancing the v2 marker on a tree with surviving ACLs.

This adds a self-verify probe immediately after the strip succeeds, mirroring the Linux block at L871-908 but adapted for Darwin (which has no `getfacl`):

- `find "$root" -print0 | xargs -0 ls -leOd | grep -E '^[[:space:]]+[0-9]+:'` — ACL entries surface as numbered prefix lines (`  0:`, `  1:`, …) in `ls -le` output.
- On residual hit, retry sudo-only (`sudo -n chmod -R -P -N`) and re-verify; emit `bridge_warn` + return 1 on persistent residual.
- Best-effort: empty trees or `ls -le` without ACL support yield no match, so verify passes — fail-open on missing primitives, not closed.

The Linux block at L871-908 is unchanged (already self-verified via H2 / PR #755).

## Verification

- `bash -n lib/bridge-isolation-v2.sh` — PASS
- `shellcheck lib/bridge-isolation-v2.sh` — PASS (rc=0)
- Tempdir self-check on Darwin (this host):
  - Created `$TMPHOME/foo` + added named ACL via `chmod +a "user:$(id -un) allow read"`.
  - Confirmed `find … | xargs ls -leOd | grep -E '^\s+[0-9]+:'` matched ` 0: user:sean allow read` before scrub.
  - Ran `bridge_isolation_v2_acl_scrub "$TMPHOME"` with `_bridge_isolation_v2_run_root_or_sudo` stubbed to call directly. rc=0; post-verify probe found no residual.
  - Failure-mode test: stubbed helper to noop (rc=0 without mutation) and stubbed sudo to noop. Probe correctly tripped, emitted `[warn] acl_scrub: residual ACL after chmod -R -P -N + sudo retry:  0: user:sean allow read`, returned rc=1.
- `./scripts/smoke-test.sh` — pre-existing failure on `bridge-run.sh --dry-run` step (`requires isolation-v2 (POSIX group + setgid)` against an empty BRIDGE_HOME). Reproduces independently of this change; the function this PR modifies is not exercised by the smoke harness.

## Scope

- 24 LOC added to a single file (`lib/bridge-isolation-v2.sh`).
- Linux block untouched.
- No docs / VERSION / CHANGELOG updates.

## Cross-refs

refs #752 (umbrella audit, W3b — MED Bug-C M7 — Darwin counterpart of HIGH H2)
refs #746 (root-cause-of-record bug-class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)