### PR TITLE
fix(redirection-order): bash redirect-order leak sweep across daemon/state/log paths (refs #752 LOW B)

### DIFF
--- a/bin/agb
+++ b/bin/agb
@@ -139,7 +139,7 @@ if (( _isolated_invocation == 1 )); then
     "$(_json_escape "$_decision")" \
     "$(_json_escape "$_reason")")"
   if mkdir -p "$_audit_dir" 2>/dev/null && [[ -w "$_audit_dir" ]]; then
-    printf '%s\n' "$_audit_row" >>"$_audit_log" 2>/dev/null || true
+    printf '%s\n' "$_audit_row" 2>/dev/null >>"$_audit_log" || true
   fi
 
   if [[ "$_decision" == "deny" ]]; then

--- a/bootstrap-memory-system.sh
+++ b/bootstrap-memory-system.sh
@@ -440,7 +440,7 @@ CRON_SPECS=(
 
 # Fetch existing crons once, parse JSON, cache a title→{schedule,tz,id} map.
 EXISTING_CRONS_JSON="$(mktemp -t bootstrap-crons.XXXXXX.json)"
-"$BRIDGE_AGB" cron list --agent "$BRIDGE_ADMIN_AGENT" --json >"$EXISTING_CRONS_JSON" 2>/dev/null || echo '[]' > "$EXISTING_CRONS_JSON"
+"$BRIDGE_AGB" cron list --agent "$BRIDGE_ADMIN_AGENT" --json 2>/dev/null >"$EXISTING_CRONS_JSON" || echo '[]' > "$EXISTING_CRONS_JSON"
 
 cron_lookup() {
   # cron_lookup <title> — prints "id<TAB>schedule<TAB>tz<TAB>payload_preview"

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -1009,7 +1009,7 @@ run_sync() {
         if [[ -n "${BRIDGE_CRON_RUN_ARTIFACTS_OLDER_THAN_DAYS:-}" ]]; then
           rga_args+=(--older-than-days "$BRIDGE_CRON_RUN_ARTIFACTS_OLDER_THAN_DAYS")
         fi
-        bridge_cron_python "${rga_args[@]}" >"$tmp_dir/native-run-artifacts-cleanup.json" 2>/dev/null || true
+        bridge_cron_python "${rga_args[@]}" 2>/dev/null >"$tmp_dir/native-run-artifacts-cleanup.json" || true
       fi
     fi
   fi

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -159,7 +159,7 @@ _bridge_daemon_on_exit() {
   mkdir -p "$BRIDGE_STATE_DIR" 2>/dev/null || true
   printf '[%s] [info] daemon exit pid=%d ec=%d sig=%s last_step=%s err_location=%s\n' \
     "$ts" "$$" "$ec" "$sig" "$step" "${err_location:-none}" \
-    >>"$BRIDGE_LAUNCHAGENT_LOG" 2>/dev/null || true
+    2>/dev/null >>"$BRIDGE_LAUNCHAGENT_LOG" || true
 
   # bridge_audit_log shells out to python; wrap so an audit failure cannot
   # mask the original exit code.
@@ -3678,8 +3678,8 @@ print("raw_trigger\t" + str(data.get("raw_trigger") or ""))
   fi
 
   # Persist dedup state and pending-notice JSON for the follow-up handler.
-  printf '%s\n' "$now_ts" >"$last_ts_file" 2>/dev/null || true
-  printf '%s\n' "$event_id" >"$last_event_file" 2>/dev/null || true
+  printf '%s\n' "$now_ts" 2>/dev/null >"$last_ts_file" || true
+  printf '%s\n' "$event_id" 2>/dev/null >"$last_event_file" || true
 
   local pending_path="$agent_state_dir/precompact-notice-pending.json"
   python3 -c '
@@ -4015,7 +4015,7 @@ if isinstance(data, dict):
   #   2. Run record-precompact-completion to mutate precompact-stats.json.
   #   3. Update the pending JSON in place, then archive + move the marker.
   mkdir -p "$recorded_flag_dir" 2>/dev/null || true
-  : >"$recorded_flag" 2>/dev/null || true
+  : 2>/dev/null >"$recorded_flag" || true
 
   bridge_with_timeout 10 precompact_stats_record python3 "$BRIDGE_SCRIPT_DIR/bridge-channels.py" \
     record-precompact-completion \
@@ -5705,7 +5705,7 @@ cmd_run() {
       # daemon process tree, so a hung daemon cannot interfere with it being
       # observed. See scripts/bridge-daemon-liveness.sh and
       # scripts/install-daemon-liveness-{launchagent,systemd}.sh.
-      printf '%s\n' "$now_ts" >"$BRIDGE_STATE_DIR/daemon.heartbeat" 2>/dev/null || true
+      printf '%s\n' "$now_ts" 2>/dev/null >"$BRIDGE_STATE_DIR/daemon.heartbeat" || true
       last_heartbeat_ts="$now_ts"
     fi
     BRIDGE_DAEMON_LAST_STEP="idle_sleep"

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -36,7 +36,7 @@ bridge_run_apply_v2_umask_if_needed() {
   # not need to be set for a peer UID that no longer exists.
   if bridge_isolation_disabled_by_env; then
     if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
-      umask >"$BRIDGE_RUN_UMASK_PROBE_FILE" 2>/dev/null || true
+      umask 2>/dev/null >"$BRIDGE_RUN_UMASK_PROBE_FILE" || true
     fi
     return 0
   fi
@@ -44,7 +44,7 @@ bridge_run_apply_v2_umask_if_needed() {
     umask 007
   fi
   if [[ -n "${BRIDGE_RUN_UMASK_PROBE_FILE:-}" ]]; then
-    umask >"$BRIDGE_RUN_UMASK_PROBE_FILE" 2>/dev/null || true
+    umask 2>/dev/null >"$BRIDGE_RUN_UMASK_PROBE_FILE" || true
   fi
 }
 

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -452,10 +452,10 @@ bridge_install_isolated_home_settings() {
     # symlink branch, then seed the stage effective from the live one.
     ln -s "settings.effective.json" "$stage_settings" 2>/dev/null || true
     if bridge_linux_sudo_root test -f "$target_effective" 2>/dev/null; then
-      bridge_linux_sudo_root cat "$target_effective" >"$stage_effective" 2>/dev/null || true
+      bridge_linux_sudo_root cat "$target_effective" 2>/dev/null >"$stage_effective" || true
     fi
   elif bridge_linux_sudo_root test -f "$target_settings" 2>/dev/null; then
-    bridge_linux_sudo_root cat "$target_settings" >"$stage_settings" 2>/dev/null || true
+    bridge_linux_sudo_root cat "$target_settings" 2>/dev/null >"$stage_settings" || true
   fi
 
   if ! bridge_hooks_python render-isolated-home-settings \

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -117,7 +117,7 @@ bridge_isolation_v2_migrate_record_force_killed() {
   {
     printf '{"timestamp":"%s","force_killed_sessions":[%s]}\n' \
       "$stamp" "$agents_json"
-  } > "$sidecar" 2>/dev/null || true
+  } 2>/dev/null > "$sidecar" || true
 
   printf '%s' "$agents_json"
 }
@@ -168,7 +168,7 @@ bridge_isolation_v2_migrate_acquire_lock() {
   owner_pid_file="${lock_dir}/owner.pid"
 
   if mkdir "$lock_dir" 2>/dev/null; then
-    printf '%s\n' "$$" >"$owner_pid_file" 2>/dev/null || true
+    printf '%s\n' "$$" 2>/dev/null >"$owner_pid_file" || true
     BRIDGE_ISOLATION_V2_MIGRATE_LOCK_DIR="$lock_dir"
     trap 'bridge_isolation_v2_migrate_release_lock' EXIT
     return 0
@@ -192,7 +192,7 @@ bridge_isolation_v2_migrate_acquire_lock() {
     bridge_die "another isolation-v2 migrate operation is in progress (lock=$lock_dir, stale-cleanup-failed)"
   fi
   if mkdir "$lock_dir" 2>/dev/null; then
-    printf '%s\n' "$$" >"$owner_pid_file" 2>/dev/null || true
+    printf '%s\n' "$$" 2>/dev/null >"$owner_pid_file" || true
     BRIDGE_ISOLATION_V2_MIGRATE_LOCK_DIR="$lock_dir"
     trap 'bridge_isolation_v2_migrate_release_lock' EXIT
     return 0

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -338,7 +338,7 @@ bridge_isolation_v2_exec_with_secret_env() {
   local _rc=0
   if (
     bridge_isolation_v2_load_secret_env "$_secret_file" || {
-      : > "$_fail_marker" 2>/dev/null || true
+      : 2>/dev/null > "$_fail_marker" || true
       exit 1
     }
     exec "$_bash_bin" -lc "$_launch_cmd"

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2384,7 +2384,7 @@ bridge_agent_write_crash_report() {
   tail_file="$(bridge_agent_crash_tail_file "$agent")"
   mkdir -p "$(dirname "$report_file")"
   if [[ -f "$stderr_file" ]]; then
-    tail -n 50 "$stderr_file" >"$tail_file" 2>/dev/null || true
+    tail -n 50 "$stderr_file" 2>/dev/null >"$tail_file" || true
     stderr_tail="$(cat "$tail_file" 2>/dev/null || true)"
   else
     : >"$tail_file"

--- a/scripts/bridge-daemon-liveness.sh
+++ b/scripts/bridge-daemon-liveness.sh
@@ -121,7 +121,7 @@ cooldown_active() {
 
 record_cooldown() {
   mkdir -p "$(dirname "$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE")" 2>/dev/null || true
-  printf '%s\n' "$(now_ts)" >"$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" 2>/dev/null || true
+  printf '%s\n' "$(now_ts)" 2>/dev/null >"$BRIDGE_DAEMON_LIVENESS_COOLDOWN_FILE" || true
 }
 
 restart_daemon() {

--- a/scripts/librarian-idle-exit.sh
+++ b/scripts/librarian-idle-exit.sh
@@ -24,7 +24,7 @@ AGENT="librarian"
 LOG="$BRIDGE_HOME/state/librarian-watchdog.log"
 GRACE_SECONDS="${LIBRARIAN_IDLE_GRACE_SECONDS:-60}"
 
-log() { printf '%s [idle-exit] %s\n' "$(date +%FT%T%z)" "$*" >>"$LOG" 2>/dev/null || true; }
+log() { printf '%s [idle-exit] %s\n' "$(date +%FT%T%z)" "$*" 2>/dev/null >>"$LOG" || true; }
 
 if ! "$BRIDGE_CLI" agent list 2>/dev/null | awk '{print $1}' | grep -qx "$AGENT"; then
   log "librarian not registered — nothing to stop"


### PR DESCRIPTION
## Summary

Mechanical sweep for the bash redirection-order leak class (refs #752 LOW B):
when `>` or `>>` is written before `2>/dev/null`, the file open happens before
stderr is silenced, so an open failure (perm denied, ENOSPC, ENAMETOOLONG,
missing parent) emits a bash diagnostic to inherited stderr (daemon log /
cron output / tmux pane) before the redirect masks it. All sites are
`|| true`-protected — purely cosmetic noise on degraded filesystems.

Per-site swap: `cmd >"\$f" 2>/dev/null` → `cmd 2>/dev/null >"\$f"`.
For the brace-grouped site (`lib/bridge-isolation-v2-migrate.sh:120`,
`{ ... } > "\$sidecar" 2>/dev/null`), the swap targets the redirections
AFTER the brace group; brace-internal stderr handling is unchanged.

`|| true` clauses are preserved verbatim.

Same pattern fixed point-wise in #748 (`scripts/wiki-v2-rebuild.sh:38`)
and W3a #761 (`lib/bridge-tmux.sh:1138`); this PR closes the long tail
identified in the #752 LOW B audit.

## Sites swapped (19 across 11 files)

- `bridge-daemon.sh:162` — daemon-exit launchagent log append
- `bridge-daemon.sh:3681` — precompact follow-up dedup last_ts persist
- `bridge-daemon.sh:3682` — precompact follow-up dedup last_event persist
- `bridge-daemon.sh:4018` — precompact recorded-flag touch
- `bridge-daemon.sh:5708` — daemon liveness heartbeat write
- `bin/agb:142` — isolated-invocation policy audit append
- `lib/bridge-isolation-v2.sh:341` — secret-env load fail marker touch
- `bridge-run.sh:39` — umask probe (isolation-disabled branch)
- `bridge-run.sh:47` — umask probe (isolation-effective branch)
- `bootstrap-memory-system.sh:443` — cron list snapshot
- `lib/bridge-hooks.sh:455` — sudo-cat target_effective stage seed
- `lib/bridge-hooks.sh:458` — sudo-cat target_settings stage seed
- `lib/bridge-isolation-v2-migrate.sh:120` — force-killed sidecar JSON (brace)
- `lib/bridge-isolation-v2-migrate.sh:171` — lock owner.pid initial write
- `lib/bridge-isolation-v2-migrate.sh:195` — lock owner.pid post-cleanup write
- `lib/bridge-state.sh:2387` — crash-report stderr tail
- `scripts/bridge-daemon-liveness.sh:124` — liveness restart cooldown
- `bridge-cron.sh:1012` — native run-artifacts cleanup JSON
- `scripts/librarian-idle-exit.sh:27` — librarian idle-exit log append

Diff stat: `11 files changed, 19 insertions(+), 19 deletions(-)` — one
mechanical token reorder per site.

## Out of scope (already fixed elsewhere)

- `lib/bridge-tmux.sh:1138` — fixed in W3a #761
- `bridge-upgrade.sh:1638` — addressed in W3d #762

## Test plan

- [x] `bash -n bridge-*.sh agent-bridge agb lib/*.sh scripts/*.sh bin/agb bootstrap-memory-system.sh` rc=0
- [x] `shellcheck` clean on all 11 touched files (pre-existing SC2088 in `lib/bridge-core.sh:254` + SC2031 in `bridge-agent.sh` are not ours)
- [x] `env -u BRIDGE_HOME -u BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT ./scripts/smoke-test.sh` rc=0
- [x] Isolated repro: read-only target file leaks `_: <path>: Permission denied` BEFORE; silent AFTER. Confirmed for `>`, `>>`, and `{ ... } >` shapes.

```
ROFILE=\$(mktemp); chmod 0400 "\$ROFILE"
bash -c '{ printf x >> "\$1" 2>/dev/null; } 2>&1' _ "\$ROFILE"   # leaks
bash -c '{ printf x 2>/dev/null >> "\$1"; } 2>&1' _ "\$ROFILE"   # silent
```

refs #752