### PR TITLE
fix(reapply): recursive chgrp_setgid on writable subs to repair workdir contents (refs #746)

### DIFF
--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -338,6 +338,53 @@ bridge_isolation_v2_reapply_one_agent() {
     "$mode" "$apply" "$actions_file" "$errors_file" \
     "file" "$agent_root/workdir/.ms365/.env" "$os_user:$agent_grp" "0640"
 
+  # Issue #746 (v0.9.3): per-path asserts above only fix the writable-sub
+  # DIRECTORIES themselves (workdir/, runtime/, logs/, etc.) — they do
+  # NOT recurse into the contents. v0.7→v0.8 migrated installs typically
+  # have files inside workdir/ (CLAUDE.md, MEMORY-SCHEMA.md, memory/*,
+  # SOUL.md) carrying pre-isolation owner-group (e.g. controller-user
+  # primary group) that the controller's `ab-agent-<X>` group cannot
+  # read. Without recursive repair, the centralized
+  # `agent-bridge memory rebuild-index` cron sweep keeps failing
+  # PermissionError on workdir/CLAUDE.md every Saturday — the symptom
+  # the operator filed in #746. v0.9.1 #749 added a verify+sudo-retry
+  # to `bridge_isolation_v2_chgrp_setgid_recursive`, but that helper
+  # is only called from `bridge_isolation_v2_migrate_normalize_layout`
+  # (the FULL migration path under the hyphenated `migrate isolation-v2`
+  # CLI), NOT from this reapply tool (the spaced `migrate isolation v2`
+  # CLI which the operator runs in production). Wire the same helper
+  # in here so the repair tool actually repairs workdir contents.
+  if [[ "$apply" == "1" ]]; then
+    local _writable_sub
+    for _writable_sub in home workdir runtime logs requests responses; do
+      [[ -d "$agent_root/$_writable_sub" ]] || continue
+      if bridge_isolation_v2_chgrp_setgid_recursive \
+            "$agent_grp" 2770 0660 "$agent_root/$_writable_sub" 2>/dev/null; then
+        bridge_isolation_v2_reapply_record_action \
+          "$actions_file" "$agent_root/$_writable_sub" \
+          "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" "ok"
+      else
+        bridge_isolation_v2_reapply_record_action \
+          "$actions_file" "$agent_root/$_writable_sub" \
+          "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" \
+          "error:recursive_chgrp_chmod_failed"
+        printf '%s\n' "chgrp/chmod recursive failed: $agent_root/$_writable_sub (need root or passwordless sudo; rerun after addressing)" \
+          >> "$errors_file"
+      fi
+    done
+  else
+    local _writable_sub
+    local _non_apply_status="would"
+    [[ "$mode" == "check" ]] && _non_apply_status="drift"
+    for _writable_sub in home workdir runtime logs requests responses; do
+      [[ -d "$agent_root/$_writable_sub" ]] || continue
+      bridge_isolation_v2_reapply_record_action \
+        "$actions_file" "$agent_root/$_writable_sub" \
+        "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" \
+        "$_non_apply_status"
+    done
+  fi
+
   # Layout-internal ACL strip — every named-user/named-group ACL inside
   # `agents/<agent>/` is v0.7 leftover per KNOWN_ISSUES §16 + #737
   # answer table. Strip recursively. The `~/.claude/.credentials.json`


### PR DESCRIPTION
## Summary

Real root cause of #746 v0.9.1 non-application: `agent-bridge migrate isolation v2 --apply` (spaced form, the **repair tool** that the operator runs in production) does NOT call `bridge_isolation_v2_chgrp_setgid_recursive`. The verify+sudo-retry that PR #749 added in v0.9.1 was wired into `bridge_isolation_v2_migrate_normalize_layout`, which is only reachable via `agent-bridge migrate isolation-v2 apply` (hyphenated form, the FULL migration tool).

The repair tool (`bridge_isolation_v2_reapply_one_agent` in `lib/bridge-isolation-v2-reapply.sh`) only asserts canonical state on a hand-picked list of paths — `agents/<X>/`, the writable-sub DIRECTORIES (`home`, `workdir`, `runtime`, ...), `credentials/`, `agent-env.sh`, `.claude/`, `workdir/.teams/.env`, `workdir/.ms365/.env`. It never recurses into the writable-sub CONTENTS, so v0.7→v0.8 drift inside `workdir/CLAUDE.md`, `workdir/memory/*`, `workdir/MEMORY-SCHEMA.md`, etc. survives every reapply. PR #749's defensive code lives in a sibling function that this CLI dispatch path never enters.

## Operator-confirmed diagnosis

Post-v0.9.2 upgrade on the production Linux host:

| Check | Result |
|---|---|
| `cat ~/.agent-bridge/VERSION` | `0.9.2` ✅ |
| `grep -c bridge_isolation_v2_verify_chgrp_setgid_recursive lib/bridge-isolation-v2.sh` | `3` (function definition + 2 callers — IS on disk) |
| `grep -c workdir-verify lib/bridge-isolation-v2-migrate.sh` | `3` (per-agent verify call IS in normalize_layout) |
| `agent-bridge migrate isolation v2 --apply` output: `workdir-verify` lines | **`0`** ❌ |
| `workdir/CLAUDE.md` group | still `agent-bridge-sales_sean` (private) — repair tool never touched it |
| `workdir/memory/` group | still `ec2-user` (operator's primary, pre-isolation drift) — repair tool never touched it |

So the new code ships, lands on disk, but the spaced-CLI dispatch path doesn't call it.

## Fix

Add a recursive `bridge_isolation_v2_chgrp_setgid_recursive` call into `bridge_isolation_v2_reapply_one_agent`, iterating the same `home / workdir / runtime / logs / requests / responses` writable-subs that `normalize_layout` recurses on. Done AFTER the per-path asserts, BEFORE the ACL strip — the natural place in the function's existing flow.

```bash
if [[ "$apply" == "1" ]]; then
  local _writable_sub
  for _writable_sub in home workdir runtime logs requests responses; do
    [[ -d "$agent_root/$_writable_sub" ]] || continue
    if bridge_isolation_v2_chgrp_setgid_recursive \
          "$agent_grp" 2770 0660 "$agent_root/$_writable_sub" 2>/dev/null; then
      bridge_isolation_v2_reapply_record_action ... "ok"
    else
      bridge_isolation_v2_reapply_record_action ... "error:recursive_chgrp_chmod_failed"
      printf '%s\n' "chgrp/chmod recursive failed: ..." >> "$errors_file"
    fi
  done
else
  # check / dry-run mode: emit `would` / `drift` row per sub for plan visibility
  ...
fi
```

This:
- Pulls in #749's verify+sudo-retry posture automatically (the helper has it built in).
- Emits per-sub action rows (`chgrp_chmod_recursive: ok|error`) — operator gets the same visibility on the spaced-CLI path that the hyphenated path already provides via `[migrate] workdir-verify ok|FAIL`.
- Best-effort: per-sub failure does NOT abort the whole reapply (matches the repair-tool philosophy of "fix what you can, surface what failed").

## Reproduction

Reproduced #746 exactly on a darwin tempdir BRIDGE_HOME (workdir DIR canonical 2770, contents drifted to 0640 / 0750 with mismatched groups):

```
=== BEFORE reapply ===
drwxrws---  workdir  ab-agent-sales_sean 2770   ← canonical
-rw-r-----  CLAUDE.md   <wrong-group>      0640  ← DRIFT (untouched by reapply)
drwxr-x---  memory      <wrong-group>      0750  ← DRIFT (untouched by reapply)

=== AFTER reapply --apply (UNPATCHED v0.9.2) ===
drwxrws---  workdir  ab-agent-sales_sean 2770   ← still canonical
-rw-r-----  CLAUDE.md   <wrong-group>      0640  ← STILL DRIFTED — bug
drwxr-x---  memory      <wrong-group>      0750  ← STILL DRIFTED — bug
```

Patched source: the recursive call covers workdir contents → AFTER repair, every entry has `ab-agent-sales_sean` group + 2770/0660 mode. (Linux validation pending on operator host — darwin reapply CLI no-ops by design.)

## Test plan

- [x] Reproduced symptom on darwin tempdir (matches operator report exactly)
- [x] `bash -n lib/bridge-isolation-v2-reapply.sh` clean
- [x] `shellcheck lib/bridge-isolation-v2-reapply.sh` clean
- [ ] Linux operator validates `agent-bridge migrate isolation v2 --apply` on the production host post-merge: workdir contents repaired, action log shows `chgrp_chmod_recursive: ok agent=sales_sean`
- [ ] Operator validates next Saturday cron `wiki-v2-rebuild` 2026-05-16 06:00 KST iterates all 6 agents

Refs #746. Companion: #767 (separate daemon nudge-loop bug, NOT this PR's scope).