### PR TITLE
fix(isolation-v2): preserve exec bits in chgrp_setgid_recursive (regression from v0.9.3 #768)

### DIFF
--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -338,6 +338,53 @@ bridge_isolation_v2_reapply_one_agent() {
     "$mode" "$apply" "$actions_file" "$errors_file" \
     "file" "$agent_root/workdir/.ms365/.env" "$os_user:$agent_grp" "0640"
 
+  # Issue #746 (v0.9.3): per-path asserts above only fix the writable-sub
+  # DIRECTORIES themselves (workdir/, runtime/, logs/, etc.) — they do
+  # NOT recurse into the contents. v0.7→v0.8 migrated installs typically
+  # have files inside workdir/ (CLAUDE.md, MEMORY-SCHEMA.md, memory/*,
+  # SOUL.md) carrying pre-isolation owner-group (e.g. controller-user
+  # primary group) that the controller's `ab-agent-<X>` group cannot
+  # read. Without recursive repair, the centralized
+  # `agent-bridge memory rebuild-index` cron sweep keeps failing
+  # PermissionError on workdir/CLAUDE.md every Saturday — the symptom
+  # the operator filed in #746. v0.9.1 #749 added a verify+sudo-retry
+  # to `bridge_isolation_v2_chgrp_setgid_recursive`, but that helper
+  # is only called from `bridge_isolation_v2_migrate_normalize_layout`
+  # (the FULL migration path under the hyphenated `migrate isolation-v2`
+  # CLI), NOT from this reapply tool (the spaced `migrate isolation v2`
+  # CLI which the operator runs in production). Wire the same helper
+  # in here so the repair tool actually repairs workdir contents.
+  if [[ "$apply" == "1" ]]; then
+    local _writable_sub
+    for _writable_sub in home workdir runtime logs requests responses; do
+      [[ -d "$agent_root/$_writable_sub" ]] || continue
+      if bridge_isolation_v2_chgrp_setgid_recursive \
+            "$agent_grp" 2770 0660 "$agent_root/$_writable_sub" 2>/dev/null; then
+        bridge_isolation_v2_reapply_record_action \
+          "$actions_file" "$agent_root/$_writable_sub" \
+          "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" "ok"
+      else
+        bridge_isolation_v2_reapply_record_action \
+          "$actions_file" "$agent_root/$_writable_sub" \
+          "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" \
+          "error:recursive_chgrp_chmod_failed"
+        printf '%s\n' "chgrp/chmod recursive failed: $agent_root/$_writable_sub (need root or passwordless sudo; rerun after addressing)" \
+          >> "$errors_file"
+      fi
+    done
+  else
+    local _writable_sub
+    local _non_apply_status="would"
+    [[ "$mode" == "check" ]] && _non_apply_status="drift"
+    for _writable_sub in home workdir runtime logs requests responses; do
+      [[ -d "$agent_root/$_writable_sub" ]] || continue
+      bridge_isolation_v2_reapply_record_action \
+        "$actions_file" "$agent_root/$_writable_sub" \
+        "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" \
+        "$_non_apply_status"
+    done
+  fi
+
   # Layout-internal ACL strip — every named-user/named-group ACL inside
   # `agents/<agent>/` is v0.7 leftover per KNOWN_ISSUES §16 + #737
   # answer table. Strip recursively. The `~/.claude/.credentials.json`

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -694,6 +694,43 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
     bridge_warn "chgrp_setgid_recursive: not a directory: $root"
     return 1
   }
+  # Issue #746 v0.9.4 followup: translate the numeric file_mode into a
+  # symbolic chmod that PRESERVES executable bits via `X` (uppercase).
+  # Background: v0.9.3 PR #768 wired this helper into the spaced-CLI
+  # repair tool (reapply_one_agent), which iterates `agents/<X>/home/`
+  # — that tree contains executable plugin scripts (e.g.
+  # `.claude/plugins/cache/<...>/scripts/*.sh` at 0750). The previous
+  # blanket `chmod 0660` on every file killed those exec bits and broke
+  # SessionStart hooks (`crm-mcp-token-sync.sh: Permission denied`) on
+  # the operator's production host. Symbolic mode with `X` adds group
+  # exec only when the file already has any exec bit (or is a dir),
+  # leaving textfiles at g+rw and scripts at g+rwx.
+  #
+  # User permissions are intentionally NOT touched — the file owner
+  # (agent UID) already has rw on its own files; we only assert the
+  # group + other invariants the v2 contract requires.
+  local _file_chmod_symbolic
+  # `u-s,g-s` explicitly strips any pre-existing setuid/setgid bits on
+  # regular files. Files in agents/<X>/{home,workdir,...} should never
+  # carry setuid/setgid (privilege escalation surface); strip them
+  # defensively as part of the canonical-state assertion. Dirs are
+  # handled by the literal `dir_mode` chmod above (e.g. 2770 INCLUDES
+  # the setgid bit, which is intentional — newly-created files inherit
+  # the group). The verify helper masks special bits when comparing
+  # file modes (line ~852), so without explicit strip a stray setuid
+  # bit could survive and verify as clean. r2 codex catch.
+  case "${file_mode#0}" in
+    660) _file_chmod_symbolic='u-s,g-s,g+rwX,o-rwx' ;;
+    640) _file_chmod_symbolic='u-s,g-s,g+rX,g-w,o-rwx' ;;
+    600) _file_chmod_symbolic='u-s,g-s,g-rwx,o-rwx' ;;
+    *)
+      # Unknown literal mode — fall back to the original blanket chmod
+      # so callers using novel modes get the legacy behavior. Future
+      # additions to the cases above should match the v2 contract surface.
+      _file_chmod_symbolic="$file_mode"
+      ;;
+  esac
+
   # `chgrp -R` follows symlinks on BSD/macOS by default while GNU
   # coreutils does not, so a symlink-to-directory inside $root could
   # lead the chown out of the tree on macOS. Restrict the recursion
@@ -703,7 +740,7 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
   _bridge_isolation_v2_run_root_or_sudo find "$root" -type d -exec chgrp "$group" {} + || return 1
   _bridge_isolation_v2_run_root_or_sudo find "$root" -type f -exec chgrp "$group" {} + || return 1
   _bridge_isolation_v2_run_root_or_sudo find "$root" -type d -exec chmod "$dir_mode" {} + || return 1
-  _bridge_isolation_v2_run_root_or_sudo find "$root" -type f -exec chmod "$file_mode" {} + || return 1
+  _bridge_isolation_v2_run_root_or_sudo find "$root" -type f -exec chmod "$_file_chmod_symbolic" {} + || return 1
 
   # Self-verify: catches the symptom from issue #746 where the
   # direct-first path returns 0 with no actual mutations (e.g. find
@@ -711,6 +748,18 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
   # builds, or the sudo path silently degraded). Without this, the
   # migrator advances the v2 marker on a half-repaired tree and the
   # controller-group read sweep keeps failing every Saturday.
+  #
+  # Note (v0.9.4 followup): the verify helper takes the original numeric
+  # file_mode but only sample-checks ONE file's mode. With the new
+  # exec-preserving symbolic chmod, an executable file's post-chmod
+  # mode will not match `file_mode` exactly (it'll have the +x bit on).
+  # The verify check is best-effort and the verify failure here is
+  # primarily about catching wrong-group (which the symbolic chmod
+  # doesn't affect). On a sample mode mismatch the helper still emits
+  # a bridge_warn but the operator's centralized read access (the
+  # actual #746 contract) is still satisfied because group + base mode
+  # is correct. A future cleanup could make verify aware of symbolic
+  # modes, but it's not required for the #746 contract.
   if ! bridge_isolation_v2_verify_chgrp_setgid_recursive \
         "$group" "$dir_mode" "$file_mode" "$root"; then
     # Drift detected. Retry with sudo-only (skip direct-first), in case
@@ -722,7 +771,7 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
       sudo -n find "$root" -type d -exec chgrp "$group" {} + 2>/dev/null || true
       sudo -n find "$root" -type f -exec chgrp "$group" {} + 2>/dev/null || true
       sudo -n find "$root" -type d -exec chmod "$dir_mode" {} + 2>/dev/null || true
-      sudo -n find "$root" -type f -exec chmod "$file_mode" {} + 2>/dev/null || true
+      sudo -n find "$root" -type f -exec chmod "$_file_chmod_symbolic" {} + 2>/dev/null || true
     fi
     if ! bridge_isolation_v2_verify_chgrp_setgid_recursive \
           "$group" "$dir_mode" "$file_mode" "$root"; then
@@ -796,8 +845,22 @@ bridge_isolation_v2_verify_chgrp_setgid_recursive() {
     actual_mode="$(stat "${stat_fmt[@]}" "$sample_file" 2>/dev/null || true)"
     if [[ -n "$actual_mode" ]]; then
       normalized_actual="$(printf '%04o' "$((8#$actual_mode))" 2>/dev/null || printf '%s' "$actual_mode")"
-      if [[ "$normalized_actual" != "$exp_file_mode" ]]; then
-        bridge_warn "verify_chgrp_setgid_recursive: file mode mismatch at $sample_file (expected=$exp_file_mode actual=$normalized_actual)"
+      # Issue #746 v0.9.4 followup: chgrp_setgid_recursive uses
+      # exec-preserving symbolic chmod on files (g+rwX,o-rwx), so an
+      # originally-executable file (e.g. plugin script 0750) lands at
+      # 0770 post-fix while the caller still passes the canonical
+      # numeric file_mode (0660) as the verify target. Compare only
+      # the rw bits (0666 mask) so the verify is exec-aware: it still
+      # catches "didn't chmod at all" (rw bits would be wrong) but
+      # tolerates the preserved exec bit. Sticky/setgid/setuid not
+      # expected on regular files; if they appear we'd want to flag,
+      # but the existing helper doesn't set them either, so masking
+      # them out here is consistent with the chmod target.
+      local masked_actual masked_expected
+      masked_actual="$(printf '%04o' $(( 8#$normalized_actual & 8#0666 )) 2>/dev/null || printf '%s' "$normalized_actual")"
+      masked_expected="$(printf '%04o' $(( 8#$exp_file_mode & 8#0666 )) 2>/dev/null || printf '%s' "$exp_file_mode")"
+      if [[ "$masked_actual" != "$masked_expected" ]]; then
+        bridge_warn "verify_chgrp_setgid_recursive: file mode (rw bits) mismatch at $sample_file (expected_rw=$masked_expected actual_full=$normalized_actual)"
         return 1
       fi
     fi


### PR DESCRIPTION
## Summary

v0.9.3 PR #768 wired `bridge_isolation_v2_chgrp_setgid_recursive` into the spaced-CLI repair tool (`reapply_one_agent`) to address the #746 workdir-contents drift. The helper's existing contract was "chmod files to literal numeric file_mode (e.g. 0660)" — this CLOBBERS exec bits on plugin scripts.

Operator's production host post-v0.9.3 reapply hit:
- `agents/<X>/home/.claude/plugins/cache/.../scripts/*.sh` 0750 → 0660 (exec dead)
- Result: `SessionStart:startup hook error ... crm-mcp-token-sync.sh: Permission denied`
- Plugin scripts no longer executable on next agent start

Operator already applied workaround (`chmod g+rx ...`) — production unblocked, but every reapply re-damages.

## Two-part fix

### 1. exec-preserving chmod

Translate the numeric `file_mode` into a symbolic chmod that preserves exec via `X` (uppercase = "x only if dir or already has any exec"):

```
0660 → g+rwX,o-rwx
0640 → g+rX,g-w,o-rwx
0600 → g-rwx,o-rwx
```

User permissions intentionally NOT touched. Owner (agent UID) already has rw on its own files; we only assert the group + other invariants the v2 contract requires.

### 2. exec-aware verify

`bridge_isolation_v2_verify_chgrp_setgid_recursive` masks the file mode comparison to the rw bits (`& 0666`). Without this, an exec-preserved file (e.g. 0770) would mismatch the expected numeric file_mode (0660) and the helper would return rc=1 — a brand-new false-positive regression that codex r1 catch caught. The masked compare still catches "didn't chmod at all" while tolerating the preserved exec bit.

## Verified on darwin tempdir

| File | Original | v0.9.3 result | v0.9.4 result |
|---|---|---|---|
| plugin script (0750) | 0750 | 0660 ❌ exec dead | **0770 ✓ exec preserved** |
| CLAUDE.md (0640) | 0640 | 0660 | 0660 |
| MEMORY-SCHEMA (0600) | 0600 | 0660 | 0660 |
| shared script in 0640 case (0750) | 0750 | 0640 ❌ exec dead | **0750 ✓ preserved** |
| shared README (0640) | 0640 | 0640 | 0640 |

Verify behavior:
- exec-preserved tree (script 0770 + doc 0660) → rc=0 PASS
- dir mode drift (2750 vs expected 2770) → rc=1 FAIL
- file rw drift (0600 vs expected 0660) → rc=1 FAIL (masked compare catches it)

## Test plan

- [x] Reproduced regression on darwin tempdir (matches operator report exactly)
- [x] Fix verified on darwin tempdir — exec preserved on both 0660 and 0640 file_mode call paths
- [x] Verify-helper exec-aware (masked rw compare)
- [x] `bash -n lib/bridge-isolation-v2.sh` clean
- [x] `shellcheck lib/bridge-isolation-v2.sh` clean
- [x] codex r1 caught the verify false-positive risk; r2 has the masked compare landing
- [ ] **orbstack VM (Oracle Linux 9) end-to-end**: simulate operator's drift state, apply v0.9.3 (regression), apply this PR (fix), verify exec bits preserved + reapply rc=0
- [ ] Linux operator validates v0.9.4 post-tag

Both CLI paths inherit this fix transparently — they all call the same helper. Both `migrate isolation-v2 apply` (hyphenated normalize_layout) and `migrate isolation v2 --apply` (spaced reapply) are now exec-safe.

## Caveats

- Operator's other regression items #B (creds.json mask `---`) and #C (state/agents/<X>/ mode 2750) are NOT addressed in this PR — they are NOT my v0.9.3 patch's direct effect (path scope outside `agents/<X>/{home,workdir,...}`). Investigate separately.

Refs #746, refs #768.