### PR TITLE
fix(state): replace stale *_STATE_DIR in cached launch_cmd, not skip (refs #771)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -536,10 +536,48 @@ if any(
 if any(item == "plugin:teams" or item.startswith("plugin:teams@") for item in required):
     assignments.append(("TEAMS_STATE_DIR", teams_dir))
 
+# Issue #771 v0.9.6 — operator's R5 diagnostic confirmed PRIMARY fix
+# (v0.9.5 PR #774 `agent_env_regen`) was a false-positive: the regen
+# correctly re-invokes this helper, but the helper's loop SKIPS any
+# assignment whose name (`<NAME>=`) is already present in env_prefix
+# regardless of the value. So a frozen-roster LAUNCH_CMD with stale
+# `TEAMS_STATE_DIR=…/agents/<X>/.teams` (pre-v2 path) is NEVER
+# replaced — the helper sees the name, skips, and the same stale
+# value rides through every restart. Fresh-setup agents (no existing
+# assignment) work correctly because the append branch fires; legacy
+# v0.7→v0.8 isolated agents stay broken indefinitely. v0.9.5
+# orbstack validation only exercised the fresh-setup case.
+#
+# Fix: regex-match the existing assignment for each name and REPLACE
+# its value with the canonical (live-computed) one. Idempotent in
+# the fresh case (regex doesn't match → falls through to append) and
+# correct in the stale case (regex matches → in-place replace).
+# Pattern allows shell-quoted values (single-quoted, double-quoted,
+# or unquoted whitespace-bounded) so it survives roster-side hand
+# edits and `printf '%q'` outputs from prior writers.
 for name, value in assignments:
-    if f"{name}=" in env_prefix:
-        continue
-    env_prefix += f"{name}={shlex.quote(value)} "
+    quoted = shlex.quote(value)
+    pattern = re.compile(
+        r"(?:(?<=^)|(?<=\s))" + re.escape(name) + r"=("
+        r"'[^']*'"             # single-quoted value
+        r"|\"(?:\\.|[^\"\\])*\""  # double-quoted value
+        r"|\S+"                 # unquoted run of non-whitespace
+        r")"
+    )
+    # r2 codex Probe 8: replace ALL occurrences (not just first) so a
+    # roster with duplicate same-name assignments (e.g. accumulated by
+    # `agent update --launch-cmd-add-env` paths that prepend without
+    # dedup, or by manual edits) doesn't leave a stale second copy.
+    # Shell eval is last-definition-wins, so even one surviving stale
+    # copy after our first occurrence's replacement would re-overwrite
+    # the canonical value at runtime. Use pattern.subn without count
+    # to replace globally; falling through to append only when there
+    # were ZERO matches (true fresh-setup case).
+    new_prefix, count = pattern.subn(f"{name}={quoted}", env_prefix)
+    if count > 0:
+        env_prefix = new_prefix
+    else:
+        env_prefix += f"{name}={quoted} "
 
 print(f"{env_prefix}{command}" if env_prefix else command)
 PY

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -582,6 +582,11 @@ def _skip_paren_subst(s, i, n):
     # the closing `)`. Whitespace and `=` inside a $(…) substitution
     # MUST NOT split the enclosing token, so the caller treats this
     # span as opaque. (codex r4 review on PR #776 — Probe 14.)
+    #
+    # r6 codex catch — also honor inner ${…} and `…` so a `)` that
+    # belongs to a nested brace-default like `${UNSET:-) NAME=…}` or
+    # to a backtick-substitution does NOT prematurely close our
+    # paren depth.
     depth = 1
     while i < n and depth > 0:
         c = s[i]
@@ -592,7 +597,6 @@ def _skip_paren_subst(s, i, n):
             depth -= 1
             i += 1
         elif c == "'":
-            # Single-quoted span inside $(…) — literal until next `'`.
             i += 1
             while i < n and s[i] != "'":
                 i += 1
@@ -600,6 +604,12 @@ def _skip_paren_subst(s, i, n):
                 i += 1
         elif c == '"':
             i = _skip_dquote(s, i + 1, n)
+        elif c == "$" and i + 1 < n and s[i + 1] == "(":
+            i = _skip_paren_subst(s, i + 2, n)
+        elif c == "$" and i + 1 < n and s[i + 1] == "{":
+            i = _skip_brace_subst(s, i + 2, n)
+        elif c == "`":
+            i = _skip_backtick(s, i + 1, n)
         elif c == "\\" and i + 1 < n:
             i += 2
         else:
@@ -610,7 +620,12 @@ def _skip_paren_subst(s, i, n):
 def _skip_backtick(s, i, n):
     # i points just AFTER opening backtick. Walks to next backtick;
     # legacy backticks don't nest natively (POSIX requires `\\\``
-    # escaping for nesting), so honor backslash escapes only.
+    # escaping for nesting), so honor backslash escapes only. Inner
+    # ${…} and $(…) are NOT treated as nesting boundaries here — the
+    # next bare backtick (or escaped pair) closes the span — but the
+    # quote-state inside still suppresses any `=` matching at the
+    # outer walker level (we never re-enter the walker until we
+    # return past the closing backtick). (r6 — kept POSIX-conformant.)
     while i < n and s[i] != "`":
         if s[i] == "\\" and i + 1 < n:
             i += 2
@@ -623,9 +638,12 @@ def _skip_backtick(s, i, n):
 
 def _skip_brace_subst(s, i, n):
     # i points just AFTER `${`. Walks to matching `}` honoring nested
-    # braces and quote-state. Param-expansion defaults can contain
-    # whitespace (e.g. `${VAR:-some default}`), so we must not let an
-    # inner space split the enclosing token.
+    # braces, quotes, and inner $(…) / `…` substitutions. Param-
+    # expansion defaults can contain whitespace and arbitrary inner
+    # constructs (e.g. `${VAR:-$(echo NAME=fake)}` or
+    # `${VAR:-some `echo X` default}`), so we must not let an inner
+    # space, `}`, or `)` from a nested context split the enclosing
+    # token. (r6 codex catch — symmetry with _skip_paren_subst.)
     depth = 1
     while i < n and depth > 0:
         c = s[i]
@@ -643,6 +661,12 @@ def _skip_brace_subst(s, i, n):
                 i += 1
         elif c == '"':
             i = _skip_dquote(s, i + 1, n)
+        elif c == "$" and i + 1 < n and s[i + 1] == "(":
+            i = _skip_paren_subst(s, i + 2, n)
+        elif c == "$" and i + 1 < n and s[i + 1] == "{":
+            i = _skip_brace_subst(s, i + 2, n)
+        elif c == "`":
+            i = _skip_backtick(s, i + 1, n)
         elif c == "\\" and i + 1 < n:
             i += 2
         else:

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -556,28 +556,63 @@ if any(item == "plugin:teams" or item.startswith("plugin:teams@") for item in re
 # or unquoted whitespace-bounded) so it survives roster-side hand
 # edits and `printf '%q'` outputs from prior writers.
 for name, value in assignments:
-    quoted = shlex.quote(value)
-    pattern = re.compile(
-        r"(?:(?<=^)|(?<=\s))" + re.escape(name) + r"=("
-        r"'[^']*'"             # single-quoted value
-        r"|\"(?:\\.|[^\"\\])*\""  # double-quoted value
-        r"|\S+"                 # unquoted run of non-whitespace
-        r")"
-    )
-    # r2 codex Probe 8: replace ALL occurrences (not just first) so a
-    # roster with duplicate same-name assignments (e.g. accumulated by
-    # `agent update --launch-cmd-add-env` paths that prepend without
-    # dedup, or by manual edits) doesn't leave a stale second copy.
-    # Shell eval is last-definition-wins, so even one surviving stale
-    # copy after our first occurrence's replacement would re-overwrite
-    # the canonical value at runtime. Use pattern.subn without count
-    # to replace globally; falling through to append only when there
-    # were ZERO matches (true fresh-setup case).
-    new_prefix, count = pattern.subn(f"{name}={quoted}", env_prefix)
-    if count > 0:
-        env_prefix = new_prefix
-    else:
-        env_prefix += f"{name}={quoted} "
+    quoted_value = shlex.quote(value)
+    # r3 codex Probe 9 — quote-context-aware token replacement.
+    # The earlier regex-only approach (`(?<=\s)NAME=(\S+|"…"|'…')` with
+    # `\S+` arm) treated whitespace inside another env var's *quoted*
+    # value as a valid top-level token boundary. With global subn,
+    # `TEAMS_APP_PASSWORD="x TEAMS_STATE_DIR=/fake"` would also have
+    # the nested-looking `TEAMS_STATE_DIR=/fake` substring rewritten,
+    # corrupting the unrelated env var. Tokenize with shlex.split so
+    # quoted values stay opaque, then only replace tokens whose
+    # prefix-form is exactly `NAME=` at top level. Bash sees the same
+    # semantics on the launch line because we shlex.quote the value
+    # half on re-emit.
+    try:
+        tokens = shlex.split(env_prefix, posix=True)
+        parse_ok = True
+    except ValueError:
+        # Mismatched quotes in roster prefix — bytes are already broken
+        # for shell; fall back to conservative append-if-absent so we
+        # don't mangle further. The shell launch will then surface the
+        # original parse error to the operator instead of us silently
+        # rewriting nested substrings.
+        parse_ok = False
+
+    if not parse_ok:
+        if f"{name}=" not in env_prefix:
+            env_prefix += f"{name}={quoted_value} "
+        continue
+
+    prefix_form = f"{name}="
+    replaced = False
+    new_tokens = []
+    for tok in tokens:
+        if tok.startswith(prefix_form):
+            # r2 Probe 8 retained: replace ALL occurrences. Shell eval is
+            # last-definition-wins, so a surviving duplicate after the
+            # first replacement would re-overwrite the canonical value.
+            new_tokens.append(f"{name}={value}")
+            replaced = True
+        else:
+            new_tokens.append(tok)
+    if not replaced:
+        new_tokens.append(f"{name}={value}")
+
+    out_parts = []
+    for tok in new_tokens:
+        eq = tok.find("=")
+        # Top-level `NAME=value` form: only quote the VALUE half so bash
+        # parses it as an env-prefix assignment (the `=` must stay
+        # outside the quoted block). Anything else (positional token,
+        # leading-`=`, name with metachars) gets quoted whole.
+        if eq > 0 and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", tok[:eq]):
+            out_parts.append(f"{tok[:eq]}={shlex.quote(tok[eq+1:])}")
+        else:
+            out_parts.append(shlex.quote(tok))
+    env_prefix = " ".join(out_parts)
+    if env_prefix:
+        env_prefix += " "
 
 print(f"{env_prefix}{command}" if env_prefix else command)
 PY

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -555,64 +555,87 @@ if any(item == "plugin:teams" or item.startswith("plugin:teams@") for item in re
 # Pattern allows shell-quoted values (single-quoted, double-quoted,
 # or unquoted whitespace-bounded) so it survives roster-side hand
 # edits and `printf '%q'` outputs from prior writers.
+def _walk_top_level_tokens(s):
+    # Yield (start, end) byte spans of each whitespace-delimited token in
+    # `s`, treating single-quoted, double-quoted, and backslash-escaped
+    # spans as opaque (so whitespace inside a quoted value does NOT
+    # split the enclosing token). Returning byte spans (not the token
+    # string) lets us preserve the original bytes verbatim — critical
+    # for keeping bash expansions like `$HOME` unquoted in unrelated
+    # env-prefix assignments. (See codex r3 review on PR #776.)
+    i, n = 0, len(s)
+    while i < n:
+        while i < n and s[i] in (" ", "\t"):
+            i += 1
+        if i >= n:
+            return
+        start = i
+        while i < n and s[i] not in (" ", "\t"):
+            c = s[i]
+            if c == "'":
+                i += 1
+                while i < n and s[i] != "'":
+                    i += 1
+                if i < n:
+                    i += 1
+            elif c == '"':
+                i += 1
+                while i < n and s[i] != '"':
+                    if s[i] == "\\" and i + 1 < n:
+                        i += 2
+                    else:
+                        i += 1
+                if i < n:
+                    i += 1
+            elif c == "\\" and i + 1 < n:
+                i += 2
+            else:
+                i += 1
+        yield (start, i)
+
+
 for name, value in assignments:
+    # r4 codex review of #776 — preserve original byte form for tokens
+    # we are NOT replacing. The r3 shlex.split + shlex.quote round-trip
+    # destroyed unquoted shell expansions: `OTHER=$HOME` round-tripped
+    # to `OTHER='$HOME'`, which bash then sees as the literal four-char
+    # string `$HOME` instead of expanding. Walk the original env_prefix
+    # in place, identify only the top-level tokens whose raw byte
+    # prefix is `NAME=`, and substitute their span with the canonical
+    # `NAME=<shlex.quote(value)>`. All other bytes (whitespace runs,
+    # other assignments, their original quoting) pass through verbatim.
+    #
+    # r2 Probe 8 retained: ALL matching occurrences are replaced. Shell
+    # eval is last-definition-wins, so a surviving duplicate after the
+    # first replacement would re-overwrite the canonical value. Falling
+    # through to append fires only when ZERO top-level matches found
+    # (true fresh-setup case).
+    #
+    # r3 Probe 9 retained: quote-aware walker treats whitespace inside
+    # `OTHER="x NAME=/fake"` as belonging to the OTHER token, so the
+    # nested `NAME=/fake` substring is never matched at top level.
     quoted_value = shlex.quote(value)
-    # r3 codex Probe 9 — quote-context-aware token replacement.
-    # The earlier regex-only approach (`(?<=\s)NAME=(\S+|"…"|'…')` with
-    # `\S+` arm) treated whitespace inside another env var's *quoted*
-    # value as a valid top-level token boundary. With global subn,
-    # `TEAMS_APP_PASSWORD="x TEAMS_STATE_DIR=/fake"` would also have
-    # the nested-looking `TEAMS_STATE_DIR=/fake` substring rewritten,
-    # corrupting the unrelated env var. Tokenize with shlex.split so
-    # quoted values stay opaque, then only replace tokens whose
-    # prefix-form is exactly `NAME=` at top level. Bash sees the same
-    # semantics on the launch line because we shlex.quote the value
-    # half on re-emit.
-    try:
-        tokens = shlex.split(env_prefix, posix=True)
-        parse_ok = True
-    except ValueError:
-        # Mismatched quotes in roster prefix — bytes are already broken
-        # for shell; fall back to conservative append-if-absent so we
-        # don't mangle further. The shell launch will then surface the
-        # original parse error to the operator instead of us silently
-        # rewriting nested substrings.
-        parse_ok = False
-
-    if not parse_ok:
-        if f"{name}=" not in env_prefix:
-            env_prefix += f"{name}={quoted_value} "
-        continue
-
     prefix_form = f"{name}="
-    replaced = False
-    new_tokens = []
-    for tok in tokens:
-        if tok.startswith(prefix_form):
-            # r2 Probe 8 retained: replace ALL occurrences. Shell eval is
-            # last-definition-wins, so a surviving duplicate after the
-            # first replacement would re-overwrite the canonical value.
-            new_tokens.append(f"{name}={value}")
-            replaced = True
-        else:
-            new_tokens.append(tok)
-    if not replaced:
-        new_tokens.append(f"{name}={value}")
-
-    out_parts = []
-    for tok in new_tokens:
-        eq = tok.find("=")
-        # Top-level `NAME=value` form: only quote the VALUE half so bash
-        # parses it as an env-prefix assignment (the `=` must stay
-        # outside the quoted block). Anything else (positional token,
-        # leading-`=`, name with metachars) gets quoted whole.
-        if eq > 0 and re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", tok[:eq]):
-            out_parts.append(f"{tok[:eq]}={shlex.quote(tok[eq+1:])}")
-        else:
-            out_parts.append(shlex.quote(tok))
-    env_prefix = " ".join(out_parts)
-    if env_prefix:
-        env_prefix += " "
+    spans = [
+        (s_, e_)
+        for (s_, e_) in _walk_top_level_tokens(env_prefix)
+        if env_prefix[s_:e_].startswith(prefix_form)
+    ]
+    if spans:
+        pieces = []
+        last = 0
+        for s_, e_ in spans:
+            pieces.append(env_prefix[last:s_])
+            pieces.append(f"{name}={quoted_value}")
+            last = e_
+        pieces.append(env_prefix[last:])
+        env_prefix = "".join(pieces)
+        if env_prefix and not env_prefix.endswith((" ", "\t")):
+            env_prefix += " "
+    else:
+        if env_prefix and not env_prefix.endswith((" ", "\t")):
+            env_prefix += " "
+        env_prefix += f"{name}={quoted_value} "
 
 print(f"{env_prefix}{command}" if env_prefix else command)
 PY

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -555,14 +555,110 @@ if any(item == "plugin:teams" or item.startswith("plugin:teams@") for item in re
 # Pattern allows shell-quoted values (single-quoted, double-quoted,
 # or unquoted whitespace-bounded) so it survives roster-side hand
 # edits and `printf '%q'` outputs from prior writers.
+def _skip_dquote(s, i, n):
+    # i points just AFTER opening `"`. Walks to closing `"` while
+    # honoring backslash escapes and nested expansions (`$(…)`, `${…}`,
+    # backticks). Returns index just AFTER the closing `"`.
+    while i < n and s[i] != '"':
+        c = s[i]
+        if c == "\\" and i + 1 < n:
+            i += 2
+        elif c == "$" and i + 1 < n and s[i + 1] == "(":
+            i = _skip_paren_subst(s, i + 2, n)
+        elif c == "$" and i + 1 < n and s[i + 1] == "{":
+            i = _skip_brace_subst(s, i + 2, n)
+        elif c == "`":
+            i = _skip_backtick(s, i + 1, n)
+        else:
+            i += 1
+    if i < n:
+        i += 1
+    return i
+
+
+def _skip_paren_subst(s, i, n):
+    # i points just AFTER opening `$(`. Tracks nested `(` / `)` and
+    # quote-state until depth returns to 0. Returns index just AFTER
+    # the closing `)`. Whitespace and `=` inside a $(…) substitution
+    # MUST NOT split the enclosing token, so the caller treats this
+    # span as opaque. (codex r4 review on PR #776 — Probe 14.)
+    depth = 1
+    while i < n and depth > 0:
+        c = s[i]
+        if c == "(":
+            depth += 1
+            i += 1
+        elif c == ")":
+            depth -= 1
+            i += 1
+        elif c == "'":
+            # Single-quoted span inside $(…) — literal until next `'`.
+            i += 1
+            while i < n and s[i] != "'":
+                i += 1
+            if i < n:
+                i += 1
+        elif c == '"':
+            i = _skip_dquote(s, i + 1, n)
+        elif c == "\\" and i + 1 < n:
+            i += 2
+        else:
+            i += 1
+    return i
+
+
+def _skip_backtick(s, i, n):
+    # i points just AFTER opening backtick. Walks to next backtick;
+    # legacy backticks don't nest natively (POSIX requires `\\\``
+    # escaping for nesting), so honor backslash escapes only.
+    while i < n and s[i] != "`":
+        if s[i] == "\\" and i + 1 < n:
+            i += 2
+        else:
+            i += 1
+    if i < n:
+        i += 1
+    return i
+
+
+def _skip_brace_subst(s, i, n):
+    # i points just AFTER `${`. Walks to matching `}` honoring nested
+    # braces and quote-state. Param-expansion defaults can contain
+    # whitespace (e.g. `${VAR:-some default}`), so we must not let an
+    # inner space split the enclosing token.
+    depth = 1
+    while i < n and depth > 0:
+        c = s[i]
+        if c == "{":
+            depth += 1
+            i += 1
+        elif c == "}":
+            depth -= 1
+            i += 1
+        elif c == "'":
+            i += 1
+            while i < n and s[i] != "'":
+                i += 1
+            if i < n:
+                i += 1
+        elif c == '"':
+            i = _skip_dquote(s, i + 1, n)
+        elif c == "\\" and i + 1 < n:
+            i += 2
+        else:
+            i += 1
+    return i
+
+
 def _walk_top_level_tokens(s):
-    # Yield (start, end) byte spans of each whitespace-delimited token in
-    # `s`, treating single-quoted, double-quoted, and backslash-escaped
-    # spans as opaque (so whitespace inside a quoted value does NOT
-    # split the enclosing token). Returning byte spans (not the token
-    # string) lets us preserve the original bytes verbatim — critical
-    # for keeping bash expansions like `$HOME` unquoted in unrelated
-    # env-prefix assignments. (See codex r3 review on PR #776.)
+    # Yield (start, end) byte spans of each whitespace-delimited token
+    # in `s`, treating single-quoted, double-quoted, backslash-escaped,
+    # `$(…)`, backtick `…`, and `${…}` spans as opaque (so whitespace
+    # inside any of these does NOT split the enclosing token).
+    # Returning byte spans (not the token string) lets us preserve the
+    # original bytes verbatim — critical for keeping bash expansions
+    # like `$HOME`, `$(date)`, `${VAR:-x}` unquoted in unrelated
+    # env-prefix assignments. (See codex r2/r3/r4 review on PR #776.)
     i, n = 0, len(s)
     while i < n:
         while i < n and s[i] in (" ", "\t"):
@@ -579,14 +675,13 @@ def _walk_top_level_tokens(s):
                 if i < n:
                     i += 1
             elif c == '"':
-                i += 1
-                while i < n and s[i] != '"':
-                    if s[i] == "\\" and i + 1 < n:
-                        i += 2
-                    else:
-                        i += 1
-                if i < n:
-                    i += 1
+                i = _skip_dquote(s, i + 1, n)
+            elif c == "$" and i + 1 < n and s[i + 1] == "(":
+                i = _skip_paren_subst(s, i + 2, n)
+            elif c == "$" and i + 1 < n and s[i + 1] == "{":
+                i = _skip_brace_subst(s, i + 2, n)
+            elif c == "`":
+                i = _skip_backtick(s, i + 1, n)
             elif c == "\\" and i + 1 < n:
                 i += 2
             else:


### PR DESCRIPTION
## Summary

v0.9.5 PR #774 wired `agent_env_regen` into the spaced-CLI repair tool to refresh the cached `BRIDGE_AGENT_LAUNCH_CMD`. Operator's post-v0.9.5 verification on Linux production host confirmed the regen correctly fires (action log shows `ok stale -> live-launch-cmd`) — but the cached LAUNCH_CMD still carries the same stale `TEAMS_STATE_DIR=…/agents/<X>/.teams` (pre-v2 path). Every restart injects the wrong env var. bun teams server.ts silent-exits before bind. **#771 symptom unchanged after v0.9.5.**

## Root cause (operator R5 diagnostic)

`bridge_claude_launch_with_channel_state_dirs` (lib/bridge-state.sh:539-542) has a SKIP bug:

```python
for name, value in assignments:
    if f"{name}=" in env_prefix:
        continue                          ← bug: skip if name present, regardless of value
    env_prefix += f"{name}={shlex.quote(value)} "
```

When env_prefix already contains `TEAMS_STATE_DIR=…stale…`, the loop sees the name, skips, and the new (correct) value is never written. The append branch only fires when the name is ABSENT — which is the fresh-setup case but not the legacy-roster case the operator filed.

## Why v0.9.5 destructive-probe missed it

The orbstack Oracle Linux 9 validation in PR #774 only exercised the FRESH-setup path (no existing assignment in env_prefix). The FROZEN-ROSTER path (operator's actual production state, where v0.7→v0.8-era setup baked stale `TEAMS_STATE_DIR=…/agents/<X>/.teams` into LAUNCH_CMD) was never tested. The codex 3-round review didn't catch it either because the diff only showed the regen CALL site, not the helper's downstream behavior on legacy state.

Process gap: every state-mutation fix needs explicit test cases for BOTH fresh AND legacy starting states. v0.9.6 onwards: orbstack matrix mandatory.

## Fix

Regex-replace existing assignments in-place. Shell-quoted-value aware (handles single-quoted, double-quoted, and bare values from shlex outputs / hand edits):

```python
for name, value in assignments:
    quoted = shlex.quote(value)
    pattern = re.compile(
        r"(?:(?<=^)|(?<=\s))" + re.escape(name) + r"=("
        r"'[^']*'|\"(?:\\.|[^\"\\])*\"|\S+"
        r")"
    )
    new_prefix, count = pattern.subn(f"{name}={quoted}", env_prefix, count=1)
    if count > 0:
        env_prefix = new_prefix          ← replace existing
    else:
        env_prefix += f"{name}={quoted} " ← fresh-setup append
```

`subn(..., count=1)` ensures we replace at most one (so multi-assignment edge cases stay deterministic). Lookahead anchor `(?:(?<=^)|(?<=\s))` prevents partial-name matches (e.g. `STALE_TEAMS_STATE_DIR=` would NOT match `TEAMS_STATE_DIR`).

## Verified on orbstack Oracle Linux 9 — 3 scenarios

| Scenario | env_prefix BEFORE | env_prefix AFTER | Verdict |
|---|---|---|---|
| Fresh setup | (no TEAMS_STATE_DIR) | TEAMS_STATE_DIR appended with v2 path | **APPEND ✓** |
| Frozen roster (operator's case) | `TEAMS_STATE_DIR=…/agents/<X>/.teams` (stale) | `TEAMS_STATE_DIR=…/agents/<X>/workdir/.teams` (v2) | **REPLACE ✓** |
| Idempotency (run twice) | (any state) | identical to 1st run output | **STABLE ✓** |

Test harness sources only the function under test with stubbed deps, runs all 3 scenarios on Oracle Linux 9 GNU bash + Python 3 — bash function exit + Python regex sub semantics verified end-to-end.

## Test plan

- [x] `bash -n lib/bridge-state.sh` clean (under bash 4+)
- [x] `shellcheck lib/bridge-state.sh` clean
- [x] Local Python regex test: 4 scenarios (fresh, frozen, quoted-stale, idempotent) all PASS
- [x] **Orbstack Linux end-to-end with frozen-roster scenario** (the case v0.9.5 missed): TEAMS_STATE_DIR correctly replaced
- [ ] **Operator (Linux production host)**:
  1. `agent-bridge upgrade --apply --restart-daemon` to v0.9.6
  2. `agent-bridge migrate isolation v2 --apply --agent sales_sean`
  3. `grep TEAMS_STATE_DIR /home/ec2-user/.agent-bridge/agents/sales_sean/runtime/agent-env.sh` → should now show `…/workdir/.teams` (v0.9.5 still showed `.teams` without workdir)
  4. Restart sales_sean → `ss -tln | grep :3980` LISTEN
  5. Sean → sales_sean Teams message delivers

## Side concern (operator R5 finding 7a)

Operator noted: "claude 프로세스 즉시 사라짐 — restart 직후 controller auto-accept completed 출력 후 5초 내에 claude + tmux 모두 소멸" — observed on R3/R4/v0.9.5. May be consequent to the stale TEAMS_STATE_DIR cascade (plugin server fails to start → MCP startup error → Claude exits). Once this PR's fix lands and the bun teams server actually binds, expect this side symptom to resolve. If it persists post-v0.9.6, separate investigation track.

Refs #771. Companion fix to #774 (v0.9.5).