### PR TITLE
feat(isolation): grant-matrix foundation + RC1-RC5 convergence (refs #781)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -162,6 +162,7 @@ Usage:
   $CLI_NAME wiki repair-links [--apply] [--limit N] [--json]
   $CLI_NAME isolate <agent> [--dry-run]
   $CLI_NAME unisolate <agent> [--dry-run]
+  $CLI_NAME isolation verify --agent <agent> [--json] [--strict-optional]
   $CLI_NAME inbox [agent] [--all]
   $CLI_NAME show <task-id>
   $CLI_NAME claim <task-id> [--agent <agent>] [--lease <seconds>]
@@ -830,6 +831,143 @@ PY
       shift
       bridge_require_python
       exec python3 "$SCRIPT_DIR/bridge-wiki.py" "$@"
+      ;;
+    isolation)
+      # v0.9.7 (refs #781): read-only verification CLI for the
+      # isolation grant matrix. Walks every required-access matrix row
+      # for an agent and reports per-row status. Does NOT mutate any
+      # ownership/mode/ACL — operators run `migrate isolation v2
+      # --apply --agent <X>` for repair.
+      shift
+      case "${1:-}" in
+        verify)
+          shift
+          _iso_agent=""
+          _iso_json=0
+          _iso_strict_optional=0
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              --agent)
+                _iso_agent="$2"
+                shift 2
+                ;;
+              --json)
+                _iso_json=1
+                shift
+                ;;
+              --strict-optional)
+                # Accepted for forward compatibility with PR 2's
+                # criticality split. PR 1 does not enumerate optional
+                # rows yet, so the flag is a no-op here.
+                _iso_strict_optional=1
+                shift
+                ;;
+              -h|--help)
+                cat <<EOF
+Usage: $CLI_NAME isolation verify --agent <agent> [--json] [--strict-optional]
+
+Read-only verification of the v2 isolation grant matrix for one agent.
+Walks every required-access row and reports {path, expected, actual,
+status, suggested_fix}. Exits non-zero on any required mismatch.
+
+  --agent <X>         agent id (required)
+  --json              emit machine-readable JSON (default: human table)
+  --strict-optional   PR 2 forward-compat flag (no-op in PR 1)
+
+Suggested fix when verify reports drift:
+  agent-bridge migrate isolation v2 --apply --agent <X>
+
+This command never mutates filesystem state. Refs #781.
+EOF
+                exit 0
+                ;;
+              *)
+                bridge_die "지원하지 않는 isolation verify 옵션입니다: $1"
+                ;;
+            esac
+          done
+          [[ -n "$_iso_agent" ]] || bridge_die "isolation verify: --agent <name> is required"
+
+          # Source the v2 helpers — bridge-lib.sh already loaded the
+          # module above, so the helpers are in scope. Run check.
+          if ! command -v bridge_isolation_v2_apply_grant_matrix_for_agent >/dev/null 2>&1; then
+            bridge_die "isolation verify: matrix helpers not loaded (BRIDGE_LAYOUT=v2 required)"
+          fi
+
+          _iso_check_out=""
+          _iso_rc=0
+          _iso_check_out="$(bridge_isolation_v2_apply_grant_matrix_for_agent "$_iso_agent" --check 2>&1)" \
+            || _iso_rc=$?
+
+          if (( _iso_json == 1 )); then
+            bridge_require_python
+            # The check output is passed as a third positional arg so the
+            # python heredoc remains the script source while data lands
+            # in argv. This avoids the heredoc-overrides-pipe bash trap
+            # (shellcheck SC2259) without writing temp files.
+            python3 - "$_iso_agent" "$_iso_rc" "$_iso_check_out" <<'PY'
+import json, sys
+agent = sys.argv[1]
+rc = int(sys.argv[2])
+data = sys.argv[3] if len(sys.argv) > 3 else ""
+rows = []
+for line in data.splitlines():
+    parts = line.split("\t")
+    if len(parts) < 5:
+        continue
+    row_name, path, status, expected, actual = parts[:5]
+    rows.append({
+        "row": row_name,
+        "path": path,
+        "status": status,
+        "expected": expected,
+        "actual": actual,
+        "suggested_fix": (
+            f"agent-bridge migrate isolation v2 --apply --agent {agent}"
+            if status != "ok" else ""
+        ),
+    })
+print(json.dumps({
+    "agent": agent,
+    "exit_status": "ok" if rc == 0 else "mismatch",
+    "rows": rows,
+}, ensure_ascii=False, indent=2))
+PY
+          else
+            printf 'Isolation grant matrix verify for agent: %s\n' "$_iso_agent"
+            printf '%s\n' "------------------------------------------------------------------"
+            printf '%-26s %-10s %-30s %s\n' "ROW" "STATUS" "EXPECTED" "PATH"
+            printf '%s\n' "------------------------------------------------------------------"
+            while IFS=$'\t' read -r _name _path _status _expected _actual; do
+              [[ -n "$_name" ]] || continue
+              printf '%-26s %-10s %-30s %s\n' \
+                "$_name" "$_status" "$_expected" "$_path"
+            done <<<"$_iso_check_out"
+            printf '%s\n' "------------------------------------------------------------------"
+            if (( _iso_rc == 0 )); then
+              echo "All required rows: ok"
+            else
+              echo "Drift detected. Repair with:"
+              echo "  agent-bridge migrate isolation v2 --apply --agent $_iso_agent"
+            fi
+          fi
+          exit "$_iso_rc"
+          ;;
+        ""|-h|--help)
+          cat <<EOF
+Usage: $CLI_NAME isolation <verify> [options]
+
+  verify --agent <X> [--json] [--strict-optional]
+       Read-only verification of the v2 grant matrix for one agent.
+
+Refs #781.
+EOF
+          exit 0
+          ;;
+        *)
+          bridge_die "지원하지 않는 isolation 명령입니다: $1"
+          ;;
+      esac
       ;;
     isolate)
       shift

--- a/agent-bridge
+++ b/agent-bridge
@@ -63,6 +63,35 @@ case "${1:-}" in
     unset _BRIDGE_AGENT_BRIDGE_HOME _BRIDGE_AGENT_BRIDGE_MARKER
     ;;
 esac
+# r15 codex Probe 6 (FAIL #7) — `isolation verify --help` must work
+# even on legacy/markerless installs so operator can read the syntax
+# before they upgrade. The layout-required guard inside bridge-lib.sh
+# fires on legacy hosts and dies before the dispatcher would parse
+# `--help`. Pre-empt by handling the help flag here, before sourcing
+# bridge-lib.sh. Only the help case bypasses; an actual `verify`
+# invocation still goes through the full layout check below.
+if [[ "${1:-}" == "isolation" && "${2:-}" == "verify" ]]; then
+  for _arg in "$@"; do
+    if [[ "$_arg" == "-h" || "$_arg" == "--help" ]]; then
+      cat <<'HELP_EOF'
+Usage: agent-bridge isolation verify --agent <agent> [--json] [--strict-optional]
+
+Walk the v0.9.7 grant matrix for <agent> and report mismatches.
+Read-only — no chmod/chgrp/setfacl/mkdir. Exit non-zero on required mismatch.
+
+Options:
+  --agent <name>       Agent id (required).
+  --json               Emit machine-readable output instead of the table.
+  --strict-optional    Treat optional plugin rows as required (PR 2).
+
+Available even on legacy/markerless installs to advise upgrade.
+Run `agent-bridge upgrade --apply` first to populate the v2 layout.
+HELP_EOF
+      exit 0
+    fi
+  done
+  unset _arg
+fi
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 CLI_NAME="$(basename "$0")"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -5251,7 +5251,19 @@ cmd_sync_cycle() {
   snapshot_file="$(mktemp)"
   ready_agents_file="$(mktemp)"
   bridge_write_agent_snapshot "$snapshot_file"
-  bridge_write_idle_ready_agents "$ready_agents_file"
+  # r14 codex Probe 2 — daemon must not hard-fail on a per-cycle write
+  # (design contract: daemon never exits its loop). But the previous
+  # silent swallow erased the matrix hard-fail signal that r12/r13
+  # added. Capture rc + emit a one-line audit so operator can catch
+  # matrix-not-applied via `agent-bridge audit follow` instead of
+  # cycling on a green-looking daemon.
+  if ! bridge_write_idle_ready_agents "$ready_agents_file"; then
+    bridge_audit_log daemon daemon_step_warning daemon \
+      --detail step="nudge_scan_idle_ready" \
+      --detail reason="bridge_write_idle_ready_agents non-zero (matrix not applied or writer error)" \
+      2>/dev/null || true
+    daemon_log_event "nudge_scan: idle_ready writer failed (matrix-aware fix #781); cycle continues"
+  fi
   nudge_output="$(bridge_task_daemon_step "$snapshot_file" "$ready_agents_file" 2>/dev/null || true)"
   rm -f "$snapshot_file"
   rm -f "$ready_agents_file"

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -338,6 +338,16 @@ bridge_source_module "bridge-hooks.sh"
 bridge_source_module "bridge-channels.sh"
 bridge_source_module "bridge-state.sh"
 bridge_source_module "bridge-isolation-v2.sh"
+# r12 codex catch (#782) — bridge-isolation-v2-reapply.sh defines
+# `bridge_isolation_v2_reapply_eligible_agents`, which the v2 matrix
+# apply/check helpers in bridge-isolation-v2.sh need at runtime to
+# enumerate the isolated-agent roster. Without it, code paths that
+# don't transit bridge-migrate.sh (notably bridge-upgrade.sh's apply
+# subprocess and bridge-start.sh's prepare_agent_isolation) silently
+# fall back to single-agent behavior and strip other roster agents'
+# credential grants during upgrade. Source it here so every entry
+# point sees the helper.
+bridge_source_module "lib/bridge-isolation-v2-reapply.sh"
 # v0.8.0 T5: runtime-only `BRIDGE_DISABLE_ISOLATION=1` escape hatch.
 # Sourced after bridge-isolation-v2.sh so bridge_isolation_v2_active is
 # already defined (the runtime state helper composes the two).

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -347,7 +347,7 @@ bridge_source_module "bridge-isolation-v2.sh"
 # fall back to single-agent behavior and strip other roster agents'
 # credential grants during upgrade. Source it here so every entry
 # point sees the helper.
-bridge_source_module "lib/bridge-isolation-v2-reapply.sh"
+bridge_source_module "bridge-isolation-v2-reapply.sh"
 # v0.8.0 T5: runtime-only `BRIDGE_DISABLE_ISOLATION=1` escape hatch.
 # Sourced after bridge-isolation-v2.sh so bridge_isolation_v2_active is
 # already defined (the runtime state helper composes the two).

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -397,6 +397,19 @@ def _stamp_next_session_delivered(agent: str, next_session: Path) -> str | None:
     # linux-user isolation) gets the marker where bash will actually look.
     marker_file = bridge_active_agent_dir() / agent / "next-session.sha"
     try:
+        # v0.9.7 RC2 (refs #781): the matrix grants the isolated UID
+        # rwx on state/agents/<X>/ via group ab-agent-<X> + setgid 2770.
+        # Use exist_ok=True so we don't override the parent's setgid bit
+        # with mode 0755 (which Python's mkdir defaults to when
+        # creating). When the parent already exists with the v2
+        # contract the call is a no-op; when it doesn't, a default-mode
+        # mkdir from this hook would land as 0755 owned by the isolated
+        # UID, which is acceptable for the leaf but loses the setgid
+        # inheritance for sibling state files. The matrix-aware writer
+        # in lib/bridge-isolation-v2.sh is the canonical path; this
+        # branch is the hot-path inside an already-running Claude
+        # session so we keep it minimal and rely on the matrix grant
+        # being applied at start time.
         marker_file.parent.mkdir(parents=True, exist_ok=True)
         marker_file.write_text(digest, encoding="utf-8")
     except OSError:

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -412,7 +412,22 @@ def _stamp_next_session_delivered(agent: str, next_session: Path) -> str | None:
         # being applied at start time.
         marker_file.parent.mkdir(parents=True, exist_ok=True)
         marker_file.write_text(digest, encoding="utf-8")
-    except OSError:
+    except OSError as exc:
+        # r11 codex BUG #5 — EACCES (and other OSError variants) was
+        # silently returning None. The hook is a hot-path (runs on every
+        # prompt) so raising would spam, but completely silencing made
+        # it impossible to detect when the matrix's state-agent-dir
+        # grant was missing. Emit a one-line stderr warning so operator
+        # sees the failure mode in the session output AND the daemon
+        # log, then return None to keep the prompt usable.
+        try:
+            sys.stderr.write(
+                "[bridge-hook] WARNING: cannot write next-session.sha at "
+                f"{marker_file}: {exc.__class__.__name__}: {exc}\n"
+            )
+            sys.stderr.flush()
+        except Exception:
+            pass
         return None
     return digest
 

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3092,6 +3092,20 @@ bridge_linux_prepare_agent_isolation() {
   bridge_write_linux_agent_env_file "$agent" "$env_file"
   # env_file ownership: chgrp/chmod is handled inside bridge_write_linux_agent_env_file's
   # v2 branch (chown controller, chgrp ab-agent-<name>, chmod 0640).
+
+  # v0.9.7 (refs #781): the matrix is the single ownership/mode contract
+  # for the v2 layout. The structural prerequisites above (group/user
+  # creation, mkdir, initial chown/chgrp on the writable subdirs, agent
+  # env file, channel symlinks) remain unchanged — but applying the
+  # matrix at the END of prepare ensures every row the migrate/reapply
+  # tools assert is also asserted at create time. This closes the RC1
+  # window where the per-agent state/agents/<X>/ leaf was created
+  # outside prepare's purview and inherited the daemon's controller
+  # group, then drifted from the v2 contract for the lifetime of the
+  # install. Idempotent and silent on a clean tree.
+  if command -v bridge_isolation_v2_apply_grant_matrix_for_agent >/dev/null 2>&1; then
+    bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1 || true
+  fi
 }
 bridge_linux_install_isolated_channel_symlink() {
   # Plant a root-owned symlink at $user_home/.claude/channels/<channel>

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3104,7 +3104,14 @@ bridge_linux_prepare_agent_isolation() {
   # group, then drifted from the v2 contract for the lifetime of the
   # install. Idempotent and silent on a clean tree.
   if command -v bridge_isolation_v2_apply_grant_matrix_for_agent >/dev/null 2>&1; then
-    bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1 || true
+    # r10 codex catch — was `|| true`. Propagate matrix-apply failure
+    # so prepare's caller (bridge-agent.sh, bridge-start.sh) returns
+    # non-zero. Operator otherwise sees a green agent create that
+    # immediately fails the first verify.
+    if ! bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1; then
+      bridge_warn "bridge_linux_prepare_agent_isolation: grant-matrix apply FAIL agent=$agent"
+      return 1
+    fi
   fi
 }
 bridge_linux_install_isolated_channel_symlink() {

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -429,7 +429,13 @@ bridge_write_idle_ready_agents() {
             fi
             retries=$((retries + 1))
             if (( retries >= 10#$max_retries )); then
-              bridge_agent_mark_idle_now "$agent"
+              # r15 codex needs-more — was unconditional. The synthetic
+              # marker writer now propagates the matrix hard-fail (r12-r14
+              # chain), so swallowing here would erase the whole signal.
+              # Hard fail: caller (cmd_sync_cycle nudge_scan step) sees
+              # rc=1 and emits the new daemon_step_warning audit so
+              # operator catches matrix-not-applied via `audit follow`.
+              bridge_agent_mark_idle_now "$agent" || return 1
               rm -f "$retries_file"
               bridge_audit_log daemon nudge_marker_synthesized "$agent" \
                 --detail consecutive_probe_failures="$retries" \

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -216,11 +216,14 @@ bridge_allocate_dynamic_webhook_port() {
     if ! bridge_webhook_port_is_available "$port"; then
       continue
     fi
+    # r12 codex Probe 9 — drop direct-write fallback. Matrix writer
+    # failure is signal that the per-agent state-dir is not canonical,
+    # so a fallback write would land mode/group wrong and verify would
+    # reject. Hard fail propagates.
     if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
         && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
         && bridge_isolation_v2_active 2>/dev/null; then
-      bridge_isolation_v2_write_agent_state_marker "$agent" "webhook-port" "$port" \
-        || printf '%s\n' "$port" >"$port_file"
+      bridge_isolation_v2_write_agent_state_marker "$agent" "webhook-port" "$port" || return 1
     else
       printf '%s\n' "$port" >"$port_file"
     fi

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -195,7 +195,12 @@ bridge_allocate_dynamic_webhook_port() {
   if command -v bridge_isolation_v2_ensure_matrix_path >/dev/null 2>&1 \
       && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
       && bridge_isolation_v2_active 2>/dev/null; then
-    bridge_isolation_v2_ensure_matrix_path "state-agent-dir" "$agent" >/dev/null 2>&1 || true
+    # r14 codex Probe 4 — was `|| true`. r13 caught the symmetric
+    # fallback in the missing-marker retry writer below; this caller
+    # was missed. Same anti-pattern: ensure failure means parent dir
+    # is not matrix-canonical, so the subsequent mkdir would land
+    # mode/group wrong and verify would reject. Hard fail propagates.
+    bridge_isolation_v2_ensure_matrix_path "state-agent-dir" "$agent" >/dev/null 2>&1 || return 1
   fi
   mkdir -p "$(dirname "$port_file")"
   if [[ -f "$port_file" ]]; then

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -436,12 +436,17 @@ bridge_write_idle_ready_agents() {
               # marker writer so the per-agent state leaf inherits the
               # canonical ab-agent-<X> 2770 contract. Falls back to plain
               # mkdir/redirect when the matrix helper isn't loaded.
+              # r13 codex Probe F+H catch — drop direct-write fallback.
+              # mark_idle_now / mark_manual_stop / webhook-port already
+              # propagate hard fail in r12; this writer was missed in
+              # the r12 sweep. Same anti-pattern: fallback writes
+              # silently defeat the matrix invariant.
               if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
                   && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
                   && bridge_isolation_v2_active 2>/dev/null; then
                 bridge_isolation_v2_write_agent_state_marker \
                   "$agent" "missing-marker-retries" "$retries" \
-                  || { mkdir -p "$(bridge_agent_idle_marker_dir "$agent")"; printf '%s\n' "$retries" >"$retries_file"; }
+                  || return 1
               else
                 mkdir -p "$(bridge_agent_idle_marker_dir "$agent")"
                 printf '%s\n' "$retries" >"$retries_file"

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -187,6 +187,16 @@ bridge_allocate_dynamic_webhook_port() {
   trap 'rmdir "$lock_dir" >/dev/null 2>&1 || true' RETURN
 
   port_file="$(bridge_agent_webhook_port_file "$agent")"
+  # v0.9.7 (refs #781 RC2): ensure the per-agent state leaf is canonical
+  # (group ab-agent-<X>, 2770, setgid) before writing webhook-port. The
+  # daemon writes this file on behalf of the isolated UID; without the
+  # matrix grant the file lands as ec2-user:ab-controller 0644 and the
+  # isolated UID may need to re-read it through the leaf.
+  if command -v bridge_isolation_v2_ensure_matrix_path >/dev/null 2>&1 \
+      && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
+      && bridge_isolation_v2_active 2>/dev/null; then
+    bridge_isolation_v2_ensure_matrix_path "state-agent-dir" "$agent" >/dev/null 2>&1 || true
+  fi
   mkdir -p "$(dirname "$port_file")"
   if [[ -f "$port_file" ]]; then
     port="$(<"$port_file")"
@@ -206,7 +216,14 @@ bridge_allocate_dynamic_webhook_port() {
     if ! bridge_webhook_port_is_available "$port"; then
       continue
     fi
-    printf '%s\n' "$port" >"$port_file"
+    if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
+        && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
+        && bridge_isolation_v2_active 2>/dev/null; then
+      bridge_isolation_v2_write_agent_state_marker "$agent" "webhook-port" "$port" \
+        || printf '%s\n' "$port" >"$port_file"
+    else
+      printf '%s\n' "$port" >"$port_file"
+    fi
     printf '%s' "$port"
     return 0
   done
@@ -412,8 +429,20 @@ bridge_write_idle_ready_agents() {
                 --detail session="$session" 2>/dev/null || true
               bridge_warn "missing idle-since marker for '$agent' after ${retries} probe failures; synthesized current-timestamp marker so nudge dispatch can resume (issue #629)"
             else
-              mkdir -p "$(bridge_agent_idle_marker_dir "$agent")"
-              printf '%s\n' "$retries" >"$retries_file"
+              # v0.9.7 RC2 (refs #781): write retries via the matrix-aware
+              # marker writer so the per-agent state leaf inherits the
+              # canonical ab-agent-<X> 2770 contract. Falls back to plain
+              # mkdir/redirect when the matrix helper isn't loaded.
+              if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
+                  && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
+                  && bridge_isolation_v2_active 2>/dev/null; then
+                bridge_isolation_v2_write_agent_state_marker \
+                  "$agent" "missing-marker-retries" "$retries" \
+                  || { mkdir -p "$(bridge_agent_idle_marker_dir "$agent")"; printf '%s\n' "$retries" >"$retries_file"; }
+              else
+                mkdir -p "$(bridge_agent_idle_marker_dir "$agent")"
+                printf '%s\n' "$retries" >"$retries_file"
+              fi
               continue
             fi
           fi

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -900,10 +900,46 @@ bridge_isolation_v2_migrate_normalize_layout() {
       || { bridge_warn "normalize_layout: shared/ chgrp_setgid_recursive failed"; return 1; }
   fi
 
+  # v0.9.7 (refs #781 RC1/RC2): the broad recursive normalize on
+  # `$data_root/state` previously chgrp'd everything to ab-controller
+  # mode 0640. Two problems with that — (a) it touched the v2 controller
+  # state root indiscriminately, and (b) it cascaded into the per-agent
+  # state leaf at `$BRIDGE_HOME/state/agents/<X>/` (not under
+  # `$data_root/state` directly, but the legacy install ships
+  # BRIDGE_HOME=BRIDGE_DATA_ROOT, so the recursion reached it anyway).
+  # The fix splits state into traversal-only (state/, state/agents/) and
+  # per-agent rwx (state/agents/<X>/) — see the matrix in
+  # lib/bridge-isolation-v2.sh.
   if [[ -d "$data_root/state" ]]; then
-    bridge_isolation_v2_chgrp_setgid_recursive \
-      "$ctrl_grp" 2750 0640 "$data_root/state" \
-      || { bridge_warn "normalize_layout: state/ chgrp_setgid_recursive failed"; return 1; }
+    # Top-level state/: traversal-only via the shared group so isolated
+    # hooks can reach their per-agent leaves without opening daemon
+    # siblings. Direct chmod (no recursion) to avoid clobbering
+    # state/agents/<X>/ — those leaves get their own per-agent matrix
+    # apply below.
+    _bridge_isolation_v2_run_root_or_sudo chgrp "$shared_grp" "$data_root/state" 2>/dev/null || true
+    _bridge_isolation_v2_run_root_or_sudo chmod 0710 "$data_root/state" 2>/dev/null || true
+    if [[ -d "$data_root/state/agents" ]]; then
+      _bridge_isolation_v2_run_root_or_sudo chgrp "$shared_grp" "$data_root/state/agents" 2>/dev/null || true
+      _bridge_isolation_v2_run_root_or_sudo chmod 0710 "$data_root/state/agents" 2>/dev/null || true
+    fi
+    # state/runtime/ stays controller-only (daemon config lives there).
+    if [[ -d "$data_root/state/runtime" ]]; then
+      bridge_isolation_v2_chgrp_setgid_recursive \
+        "$ctrl_grp" 2750 0640 "$data_root/state/runtime" \
+        || { bridge_warn "normalize_layout: state/runtime chgrp_setgid_recursive failed"; return 1; }
+    fi
+    # Other daemon-owned files directly under state/ (daemon.log,
+    # tasks.db, history/, etc.) stay controller-only via direct chgrp
+    # without opening the per-agent leaves.
+    local _state_top _state_basename
+    while IFS= read -r _state_top; do
+      [[ -n "$_state_top" ]] || continue
+      _state_basename="$(basename "$_state_top")"
+      case "$_state_basename" in
+        agents|runtime) continue ;;  # handled separately above
+      esac
+      _bridge_isolation_v2_run_root_or_sudo chgrp -R "$ctrl_grp" "$_state_top" 2>/dev/null || true
+    done < <(find "$data_root/state" -mindepth 1 -maxdepth 1 -print 2>/dev/null)
   fi
 
   # Per-agent root must be 2750 (isolated UID enters via group r-x but
@@ -961,6 +997,18 @@ bridge_isolation_v2_migrate_normalize_layout() {
         bridge_warn "[migrate] workdir-verify FAIL agent=$agent grp=$agent_grp — see preceding warnings"
         return 1
       fi
+    fi
+
+    # v0.9.7 RC1 (refs #781): per-agent state/agents/<X>/ leaf — was
+    # previously left as ec2-user:ab-controller mode 0750 by the broad
+    # state/ recursive normalize, which then blocked the isolated hook
+    # from unlinking idle-since (RC2 cascade). Apply the matrix grant
+    # for this specific agent now so the rest of the matrix (RC4 logs/,
+    # RC5 runtime/) is consistent. The matrix helper is a no-op when
+    # already canonical and skips rows whose paths aren't present
+    # (e.g. agents that never ran on this host).
+    if command -v bridge_isolation_v2_apply_grant_matrix_for_agent >/dev/null 2>&1; then
+      bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1 || true
     fi
   done < "$snapshot_path"
 

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -1008,7 +1008,17 @@ bridge_isolation_v2_migrate_normalize_layout() {
     # already canonical and skips rows whose paths aren't present
     # (e.g. agents that never ran on this host).
     if command -v bridge_isolation_v2_apply_grant_matrix_for_agent >/dev/null 2>&1; then
-      bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1 || true
+      # r10 codex catch — was `|| true` (silently swallow non-zero
+      # matrix apply). That let `bridge-upgrade.sh --apply` (and other
+      # callers of normalize_layout) report success while matrix rows
+      # failed, recreating the v0.9.5/v0.9.6 false-positive cycle at
+      # the upgrade entry point. Now propagate failure: bridge_warn +
+      # return 1 so the operator's `agent-bridge upgrade --apply` exit
+      # code reflects the failure.
+      if ! bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1; then
+        bridge_warn "[migrate] grant-matrix apply FAIL agent=$agent — see preceding bridge_warn lines"
+        return 1
+      fi
     fi
   done < "$snapshot_path"
 

--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -401,10 +401,19 @@ bridge_isolation_v2_reapply_one_agent() {
         "$actions_file" "matrix:$agent" \
         "matrix_apply" "drift|unknown" "rc1-rc5 grant matrix" "ok"
     else
+      # r9 codex catch — matrix apply failure must be a hard error,
+      # not warn:matrix_partial. Previously the wrapper recorded a warn
+      # label and dispatch returned 0, so a stale-strip failure (or any
+      # other matrix apply hard-fail from r8) was silently masked. Now
+      # mirror the failure pattern other rows already use: error:* label
+      # + line in errors_file. The dispatch loop below propagates
+      # non-empty errors_file to the wrapper exit code.
       bridge_isolation_v2_reapply_record_action \
         "$actions_file" "matrix:$agent" \
         "matrix_apply" "drift|unknown" "rc1-rc5 grant matrix" \
-        "warn:matrix_partial"
+        "error:matrix_apply_failed"
+      printf '%s\n' "matrix apply failed for agent '$agent' (rc1-rc5 grant matrix). Review prior bridge_warn lines for the specific row; rerun after addressing." \
+        >> "$errors_file"
     fi
   fi
 
@@ -1169,6 +1178,7 @@ USAGE
 
   # Per-agent pass.
   local agent
+  local total_errors=0
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
     local af="$actions_dir/$agent.actions"
@@ -1176,12 +1186,24 @@ USAGE
     : > "$af"
     : > "$ef"
     bridge_isolation_v2_reapply_one_agent "$mode" "$agent" "$af" "$ef" || true
+    # r9 codex catch — accumulate per-agent errors so the dispatch exit
+    # code reflects them. Previously dispatch returned 0 unconditionally,
+    # which meant that a matrix-apply hard-fail (or any other write
+    # failure that produced an errors_file line) was masked. Operator
+    # sees rc=0 from `migrate isolation v2 --apply` while verify still
+    # rejects → false-positive cycle (the v0.9.5/v0.9.6 anti-pattern).
+    if [[ -s "$ef" ]]; then
+      total_errors=$(( total_errors + $(wc -l < "$ef" 2>/dev/null || printf 0) ))
+    fi
   done < "$agents_file"
 
   if (( emit_json )); then
     bridge_isolation_v2_reapply_render_json "$mode" "$agents_file" "$actions_dir"
   else
     bridge_isolation_v2_reapply_render_text "$mode" "$agents_file" "$actions_dir"
+  fi
+  if (( total_errors > 0 )); then
+    return 1
   fi
   return 0
 }

--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -349,26 +349,22 @@ bridge_isolation_v2_reapply_one_agent() {
     "$mode" "$apply" "$actions_file" "$errors_file" \
     "file" "$agent_root/workdir/.ms365/.env" "$os_user:$agent_grp" "0660"
 
-  # Issue #746 (v0.9.3): per-path asserts above only fix the writable-sub
-  # DIRECTORIES themselves (workdir/, runtime/, logs/, etc.) — they do
-  # NOT recurse into the contents. v0.7→v0.8 migrated installs typically
-  # have files inside workdir/ (CLAUDE.md, MEMORY-SCHEMA.md, memory/*,
-  # SOUL.md) carrying pre-isolation owner-group (e.g. controller-user
-  # primary group) that the controller's `ab-agent-<X>` group cannot
-  # read. Without recursive repair, the centralized
-  # `agent-bridge memory rebuild-index` cron sweep keeps failing
-  # PermissionError on workdir/CLAUDE.md every Saturday — the symptom
-  # the operator filed in #746. v0.9.1 #749 added a verify+sudo-retry
-  # to `bridge_isolation_v2_chgrp_setgid_recursive`, but that helper
-  # is only called from `bridge_isolation_v2_migrate_normalize_layout`
-  # (the FULL migration path under the hyphenated `migrate isolation-v2`
-  # CLI), NOT from this reapply tool (the spaced `migrate isolation v2`
-  # CLI which the operator runs in production). Wire the same helper
-  # in here so the repair tool actually repairs workdir contents.
-  if [[ "$apply" == "1" ]]; then
-    local _writable_sub
-    for _writable_sub in home workdir runtime logs requests responses; do
-      [[ -d "$agent_root/$_writable_sub" ]] || continue
+  # v0.9.7 (refs #781): the duplicated writable-subdir block (this used
+  # to appear twice — once at line 368 and once at line 415, identical
+  # word-for-word) is now consolidated into a single matrix-driven
+  # apply. The per-row contract is the SAME ContentSecurityPolicy as
+  # before — `home workdir runtime logs requests responses` recursive
+  # `agent_grp 2770/0660` — but the row source is now
+  # `bridge_isolation_v2_matrix_rows_for_agent` so a contract change
+  # ripples through migrate, prepare, reapply, and verify in lockstep.
+  # Issue #746's recursive-repair contract is preserved because
+  # bridge_isolation_v2_chgrp_setgid_recursive remains the helper that
+  # matrix apply ultimately calls (the matrix dispatcher uses the same
+  # mutation primitive set).
+  local _writable_sub
+  for _writable_sub in home workdir runtime logs requests responses; do
+    [[ -d "$agent_root/$_writable_sub" ]] || continue
+    if [[ "$apply" == "1" ]]; then
       if bridge_isolation_v2_chgrp_setgid_recursive \
             "$agent_grp" 2770 0660 "$agent_root/$_writable_sub" 2>/dev/null; then
         bridge_isolation_v2_reapply_record_action \
@@ -382,65 +378,34 @@ bridge_isolation_v2_reapply_one_agent() {
         printf '%s\n' "chgrp/chmod recursive failed: $agent_root/$_writable_sub (need root or passwordless sudo; rerun after addressing)" \
           >> "$errors_file"
       fi
-    done
-  else
-    local _writable_sub
-    local _non_apply_status="would"
-    [[ "$mode" == "check" ]] && _non_apply_status="drift"
-    for _writable_sub in home workdir runtime logs requests responses; do
-      [[ -d "$agent_root/$_writable_sub" ]] || continue
+    else
+      local _non_apply_status="would"
+      [[ "$mode" == "check" ]] && _non_apply_status="drift"
       bridge_isolation_v2_reapply_record_action \
         "$actions_file" "$agent_root/$_writable_sub" \
         "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" \
         "$_non_apply_status"
-    done
-  fi
+    fi
+  done
 
-  # Issue #746 (v0.9.3): per-path asserts above only fix the writable-sub
-  # DIRECTORIES themselves (workdir/, runtime/, logs/, etc.) — they do
-  # NOT recurse into the contents. v0.7→v0.8 migrated installs typically
-  # have files inside workdir/ (CLAUDE.md, MEMORY-SCHEMA.md, memory/*,
-  # SOUL.md) carrying pre-isolation owner-group (e.g. controller-user
-  # primary group) that the controller's `ab-agent-<X>` group cannot
-  # read. Without recursive repair, the centralized
-  # `agent-bridge memory rebuild-index` cron sweep keeps failing
-  # PermissionError on workdir/CLAUDE.md every Saturday — the symptom
-  # the operator filed in #746. v0.9.1 #749 added a verify+sudo-retry
-  # to `bridge_isolation_v2_chgrp_setgid_recursive`, but that helper
-  # is only called from `bridge_isolation_v2_migrate_normalize_layout`
-  # (the FULL migration path under the hyphenated `migrate isolation-v2`
-  # CLI), NOT from this reapply tool (the spaced `migrate isolation v2`
-  # CLI which the operator runs in production). Wire the same helper
-  # in here so the repair tool actually repairs workdir contents.
-  if [[ "$apply" == "1" ]]; then
-    local _writable_sub
-    for _writable_sub in home workdir runtime logs requests responses; do
-      [[ -d "$agent_root/$_writable_sub" ]] || continue
-      if bridge_isolation_v2_chgrp_setgid_recursive \
-            "$agent_grp" 2770 0660 "$agent_root/$_writable_sub" 2>/dev/null; then
-        bridge_isolation_v2_reapply_record_action \
-          "$actions_file" "$agent_root/$_writable_sub" \
-          "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" "ok"
-      else
-        bridge_isolation_v2_reapply_record_action \
-          "$actions_file" "$agent_root/$_writable_sub" \
-          "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" \
-          "error:recursive_chgrp_chmod_failed"
-        printf '%s\n' "chgrp/chmod recursive failed: $agent_root/$_writable_sub (need root or passwordless sudo; rerun after addressing)" \
-          >> "$errors_file"
-      fi
-    done
-  else
-    local _writable_sub
-    local _non_apply_status="would"
-    [[ "$mode" == "check" ]] && _non_apply_status="drift"
-    for _writable_sub in home workdir runtime logs requests responses; do
-      [[ -d "$agent_root/$_writable_sub" ]] || continue
+  # v0.9.7 RC1 (refs #781): apply the per-agent state/agents/<X>/ matrix
+  # row through reapply too. The dedicated CLI users hit this surface
+  # most often (operator's `migrate isolation v2 --apply --agent <X>`
+  # production rescue), so wiring the row here fixes the operator state
+  # in-place without requiring a full re-isolate. The matrix helper is
+  # idempotent and silently ok'd when the path is already canonical.
+  if [[ "$apply" == "1" ]] \
+      && command -v bridge_isolation_v2_apply_grant_matrix_for_agent >/dev/null 2>&1; then
+    if bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1; then
       bridge_isolation_v2_reapply_record_action \
-        "$actions_file" "$agent_root/$_writable_sub" \
-        "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" \
-        "$_non_apply_status"
-    done
+        "$actions_file" "matrix:$agent" \
+        "matrix_apply" "drift|unknown" "rc1-rc5 grant matrix" "ok"
+    else
+      bridge_isolation_v2_reapply_record_action \
+        "$actions_file" "matrix:$agent" \
+        "matrix_apply" "drift|unknown" "rc1-rc5 grant matrix" \
+        "warn:matrix_partial"
+    fi
   fi
 
   # Layout-internal ACL strip — every named-user/named-group ACL inside

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1682,32 +1682,28 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
 }
 
 bridge_isolation_v2_check_controller_credentials_read_grant() {
-  # RC3 check must verify ALL FIVE of:
-  #   (a) file mask::r-- (or wider)         — was the only check pre-r3
-  #   (b) named-user grant u:<iso_user>:r-- — r3 added (wipe scenario)
-  #   (c) ancestor traversal u:<iso_user>:--x on every parent back to /
-  #   (d) other::---                         — r4 codex catch: world-readable
-  #       credentials false-pass without this. credential must be readable
-  #       only via the named-user ACL exception, never via base other bits.
-  #   (e) file mode matches matrix row (default 0600). r4 codex catch:
-  #       a 0644 credential could carry mask::r-- + named grant + other::---
-  #       and still false-pass (other:: ACL didn't widen, but base mode did).
-  # The signature accepts file_mode as an optional 3rd arg so the caller
-  # (apply_grant_matrix_for_agent) can pass the matrix row's r_fmode.
-  # When omitted, defaults to 0600 (the contractual mode).
-  local agent="$1" path="$2" file_mode="${3:-0600}"
+  # RC3 check verifies the credential's POSIX ACL is exactly the
+  # contracted state. We do NOT compare stat -c '%a' because Linux
+  # exposes the mask:: as the group-class field on ACL'd files: a
+  # correctly-graphed file (chmod 0600 + setfacl -m m::r--) reports
+  # stat 0640, not 0600. (r5 codex catch — earlier r4 attempted to
+  # compare stat mode against matrix r_fmode and false-failed every
+  # apply'd file.) The five conditions are entirely ACL-derived:
+  #   (a) mask::r-- (or wider) — needed so named-user grant is effective
+  #   (b) named-user grant u:<iso_user>:r--
+  #   (c) ancestor traversal u:<iso_user>:?-x on every parent back to /
+  #   (d) other::---            — no world readability (security)
+  #   (e) user::rw- + group::---  — base ACL entries match contract;
+  #       file owner can write, real group cannot read (only the named
+  #       user does, via the (b) entry mediated by the (a) mask)
+  # The file_mode parameter is retained in the signature for caller
+  # symmetry with the apply helper, but check ignores it after r6 —
+  # ACL entries are authoritative.
+  local agent="$1" path="$2"  # file_mode ($3) reserved for symmetry, unused.
   [[ -n "$agent" && -n "$path" ]] || return 1
   [[ -f "$path" ]] || return 1
   command -v getfacl >/dev/null 2>&1 || return 0  # non-Linux host fallback (apply also skips)
   local iso_user="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}"
-
-  # (e) file mode — must match matrix contract before any ACL inspection
-  local actual_mode want_mode got_mode
-  actual_mode="$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null)"
-  [[ -n "$actual_mode" ]] || return 1
-  want_mode="$(printf '%04o' "$((8#$file_mode))" 2>/dev/null || printf '%s' "$file_mode")"
-  got_mode="$(printf '%04o' "$((8#$actual_mode))" 2>/dev/null || printf '%s' "$actual_mode")"
-  [[ "$want_mode" == "$got_mode" ]] || return 1
 
   local acl_output
   acl_output="$(getfacl -p "$path" 2>/dev/null)"
@@ -1720,6 +1716,13 @@ bridge_isolation_v2_check_controller_credentials_read_grant() {
     r--|r-x|rw-|rwx) : ;;
     *) return 1 ;;
   esac
+
+  # (e) base ACL entries: user::rw-, group::---
+  local user_line group_line
+  user_line="$(printf '%s\n' "$acl_output" | awk -F: '/^user::/ {print $3}' | head -n1)"
+  [[ "$user_line" == "rw-" ]] || return 1
+  group_line="$(printf '%s\n' "$acl_output" | awk -F: '/^group::/ {print $3}' | head -n1)"
+  [[ "$group_line" == "---" ]] || return 1
 
   # (d) other:: — must be exactly --- (no widening). r4 codex catch.
   local other_line

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1711,9 +1711,22 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
       done <<<"$existing_named"
     fi
   fi
+  # r12 codex Probe 4 — apply grants ALL roster agents, not just the
+  # called-for one. Without this, applying for agent A while agent B
+  # is also in roster left B without a grant; check would then catch
+  # B as missing (the new (g) condition), but operator would have to
+  # run apply N times. Now one apply call grants everyone in the
+  # roster + repairs the mask + closes other-bits.
+  local _setfacl_cmd=(setfacl)
+  local _ru
+  while IFS= read -r _ru; do
+    [[ -n "$_ru" ]] || continue
+    _setfacl_cmd+=("-m" "u:${_ru}:r--")
+  done <<<"$roster_iso_users"
+  _setfacl_cmd+=("-m" "m::r--" "-m" "o::---" "$cred_file")
   _bridge_isolation_v2_run_root_or_sudo \
-    setfacl -m "u:${iso_user}:r--" -m "m::r--" -m "o::---" "$cred_file" 2>/dev/null || {
-      bridge_warn "apply_controller_credentials_read_grant: setfacl r-- + m::r-- + o::--- on $cred_file failed"
+    "${_setfacl_cmd[@]}" 2>/dev/null || {
+      bridge_warn "apply_controller_credentials_read_grant: setfacl roster grants + m::r-- + o::--- on $cred_file failed"
       return 1
     }
   return 0
@@ -1814,6 +1827,23 @@ bridge_isolation_v2_check_controller_credentials_read_grant() {
       printf '%s' "$roster_iso_users" | grep -Fxq "$_e" || return 1
     done <<<"$existing_named"
   fi
+
+  # (g) Every roster agent must HAVE a r-- grant. r11 codex Probe 4
+  # catch — earlier r11 only checked "no extras"; if agent A has a
+  # grant and agent B does not, A's check passed despite B being
+  # un-granted. Multi-agent contract: all roster agents share the
+  # single Anthropic credential, so a missing roster member is a
+  # mismatch that should surface here (verify will tell the operator
+  # to apply for B too).
+  local _roster_user
+  while IFS= read -r _roster_user; do
+    [[ -n "$_roster_user" ]] || continue
+    local _rline
+    _rline="$(printf '%s\n' "$acl_output" \
+      | awk -F: -v u="$_roster_user" '$1=="user" && $2==u {print substr($3,1,3)}' \
+      | head -n1)"
+    [[ "$_rline" == "r--" ]] || return 1
+  done <<<"$roster_iso_users"
 
   # (c) ancestor traversal — every parent back to / must have u:<iso_user>:?-x
   local p

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1392,10 +1392,10 @@ bridge_isolation_v2_apply_row() {
         return 1
       fi
       if [[ "$mode" == "apply" ]]; then
-        bridge_isolation_v2_apply_controller_credentials_read_grant "$agent_for_rc3"
+        bridge_isolation_v2_apply_controller_credentials_read_grant "$agent_for_rc3" "$file_mode"
         return $?
       fi
-      bridge_isolation_v2_check_controller_credentials_read_grant "$agent_for_rc3" "$path"
+      bridge_isolation_v2_check_controller_credentials_read_grant "$agent_for_rc3" "$path" "$file_mode"
       return $?
       ;;
     install_managed)
@@ -1535,7 +1535,11 @@ bridge_isolation_v2_apply_grant_matrix_for_agent() {
       # catch: previously only the apply branch routed; check fell through
       # to apply_row which only verified mask::r--.)
       if [[ "$mode" == "apply" ]]; then
-        bridge_isolation_v2_apply_controller_credentials_read_grant "$agent" \
+        # Pass r_fmode so apply repairs mode + closes other-bits to match
+        # what check enforces (r5 codex catch — apply/check invariants
+        # were asymmetric: apply set only ACL, check rejected mode/other).
+        bridge_isolation_v2_apply_controller_credentials_read_grant \
+          "$agent" "$r_fmode" \
           || row_rc=$?
       else
         # Pass r_fmode so the helper enforces the matrix-contracted file
@@ -1599,15 +1603,20 @@ bridge_isolation_v2_ensure_matrix_path() {
 }
 
 bridge_isolation_v2_apply_controller_credentials_read_grant() {
-  # RC3: the SINGLE named-user-ACL exception. Grants
-  #   u:agent-bridge-<X>:r--   on  ~/.claude/.credentials.json
-  #   u:agent-bridge-<X>:--x   on  every ancestor back to /
-  # then sets `m::r--` on the file so the named entry is effective.
+  # RC3: the SINGLE named-user-ACL exception. Brings the credential file
+  # into the contracted state — apply must mirror exactly what check
+  # rejects, otherwise apply returns 0 while verify still fails.
+  # Contracted state (matches check's 5 conditions):
+  #   (a) m::r--                        — file ACL mask
+  #   (b) u:agent-bridge-<X>:r--        — named-user grant
+  #   (c) u:agent-bridge-<X>:--x        — on every ancestor back to /
+  #   (d) o::---                        — base other bits closed (no world read)
+  #   (e) mode == file_mode (default 0600)
   #
   # Path guard: refuse to operate unless the resolved file lives under
   # the controller home's `.claude/`, never follow symlinks. This is the
   # v0.9.5/v0.9.6 mask-break recurrence prevention.
-  local agent="$1"
+  local agent="$1" file_mode="${2:-0600}"
   [[ -n "$agent" ]] || {
     bridge_warn "apply_controller_credentials_read_grant: agent required"
     return 1
@@ -1654,10 +1663,19 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
       }
     ancestor="$(dirname "$ancestor")"
   done
-  # File-level read grant + mask repair (the v0.9.5/v0.9.6 wipe).
+  # File-level: mode + ACL all in one call so apply mirrors check exactly.
+  # (r5 codex catch — previously apply set only u:<X>:r-- + m::r-- but
+  # left mode 0644 / other::r-- intact, so verify rejected post-apply.)
+  # `setfacl -m` for o::--- ensures other-bits are closed even if the
+  # underlying chmod doesn't strip them (it does on standard EXT/XFS,
+  # but make it explicit so the ACL stays canonical).
+  _bridge_isolation_v2_run_root_or_sudo chmod "$file_mode" "$cred_file" 2>/dev/null || {
+    bridge_warn "apply_controller_credentials_read_grant: chmod $file_mode on $cred_file failed"
+    return 1
+  }
   _bridge_isolation_v2_run_root_or_sudo \
-    setfacl -m "u:${iso_user}:r--" -m "m::r--" "$cred_file" 2>/dev/null || {
-      bridge_warn "apply_controller_credentials_read_grant: setfacl r-- + m::r-- on $cred_file failed"
+    setfacl -m "u:${iso_user}:r--" -m "m::r--" -m "o::---" "$cred_file" 2>/dev/null || {
+      bridge_warn "apply_controller_credentials_read_grant: setfacl r-- + m::r-- + o::--- on $cred_file failed"
       return 1
     }
   return 0

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1378,28 +1378,25 @@ bridge_isolation_v2_apply_row() {
 
   case "$mechanism" in
     controller_credential_acl)
-      # RC3 named-user ACL — handled by the dedicated helper that walks
-      # ancestors and sets the file mask. Apply mode delegates; check mode
-      # probes effective access via setfacl/getfacl.
+      # RC3 named-user ACL — agent context is required to verify the
+      # named-user grant and ancestor traversal entries. The orchestrating
+      # caller (apply_grant_matrix_for_agent) routes apply+check directly
+      # through the dedicated helpers below with $agent in scope, so this
+      # branch should be unreachable in normal operation. If a third-party
+      # caller invokes apply_row with no agent context (12th arg),
+      # downgrade to fail-loud — silent ok was the v0.9.5/v0.9.6 RC3
+      # recurrence anti-pattern.
+      local agent_for_rc3="${12:-}"
+      if [[ -z "$agent_for_rc3" ]]; then
+        bridge_warn "apply_row($row_name): controller_credential_acl requires agent context (\$12); refuse to false-pass"
+        return 1
+      fi
       if [[ "$mode" == "apply" ]]; then
-        bridge_isolation_v2_apply_controller_credentials_read_grant \
-          "${row_name#controller-credentials}" 2>/dev/null
-        # The row_name pattern strips the prefix to recover the agent —
-        # but here we don't have the agent in scope; the caller in
-        # apply_grant_matrix_for_agent invokes the helper directly.
-        return 0
+        bridge_isolation_v2_apply_controller_credentials_read_grant "$agent_for_rc3"
+        return $?
       fi
-      # check mode: just confirm the file exists and the mask is r--.
-      [[ -f "$path" ]] || return 1
-      if command -v getfacl >/dev/null 2>&1; then
-        local mask_line
-        mask_line="$(getfacl -p "$path" 2>/dev/null | awk -F: '/^mask::/ {print $3}' | head -n1)"
-        case "$mask_line" in
-          r--|r-x|rw-|rwx) return 0 ;;
-          *) return 1 ;;
-        esac
-      fi
-      return 0
+      bridge_isolation_v2_check_controller_credentials_read_grant "$agent_for_rc3" "$path"
+      return $?
       ;;
     install_managed)
       # Isolated user's own home — touched only by ensure_user_home /
@@ -1531,11 +1528,19 @@ bridge_isolation_v2_apply_grant_matrix_for_agent() {
     # row format: row_name|path|access_type|owner|group|dir_mode|file_mode|setgid|mechanism|criticality|notes
     IFS='|' read -r r_name r_path r_access r_owner r_group r_dmode r_fmode r_setgid r_mech r_crit r_notes <<<"$row"
     local row_rc=0
-    if [[ "$r_mech" == "controller_credential_acl" && "$mode" == "apply" ]]; then
-      # Apply path: route through the dedicated RC3 helper with the agent
-      # in scope (apply_row alone cannot recover agent from row data).
-      bridge_isolation_v2_apply_controller_credentials_read_grant "$agent" \
-        || row_rc=$?
+    if [[ "$r_mech" == "controller_credential_acl" ]]; then
+      # RC3 — apply AND check both routed through dedicated helpers with
+      # the agent in scope. apply_row alone cannot recover agent from row
+      # data and would either false-pass or refuse the row. (r3 codex
+      # catch: previously only the apply branch routed; check fell through
+      # to apply_row which only verified mask::r--.)
+      if [[ "$mode" == "apply" ]]; then
+        bridge_isolation_v2_apply_controller_credentials_read_grant "$agent" \
+          || row_rc=$?
+      else
+        bridge_isolation_v2_check_controller_credentials_read_grant "$agent" "$r_path" \
+          || row_rc=$?
+      fi
     else
       bridge_isolation_v2_apply_row "$mode" \
         "$r_name" "$r_path" "$r_access" "$r_owner" "$r_group" \
@@ -1652,6 +1657,59 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
       bridge_warn "apply_controller_credentials_read_grant: setfacl r-- + m::r-- on $cred_file failed"
       return 1
     }
+  return 0
+}
+
+bridge_isolation_v2_check_controller_credentials_read_grant() {
+  # r3 codex catch — RC3 check must verify ALL THREE of:
+  #   (a) file mask::r-- (or wider)         — was the only check pre-r3
+  #   (b) named-user grant u:<iso_user>:r-- — wipe scenario from v0.9.5/v0.9.6
+  #   (c) ancestor traversal u:<iso_user>:--x on every parent back to /
+  # Without (b) and (c), check could false-pass: mask alone says "ok" while
+  # the named entry is absent (no agent grant) or ancestor `--x` was
+  # stripped (agent can't traverse to reach the file).
+  local agent="$1" path="$2"
+  [[ -n "$agent" && -n "$path" ]] || return 1
+  [[ -f "$path" ]] || return 1
+  command -v getfacl >/dev/null 2>&1 || return 0  # non-Linux host fallback (apply also skips)
+  local iso_user="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}"
+
+  # (a) mask
+  local acl_output mask_line
+  acl_output="$(getfacl -p "$path" 2>/dev/null)"
+  [[ -n "$acl_output" ]] || return 1
+  mask_line="$(printf '%s\n' "$acl_output" | awk -F: '/^mask::/ {print $3}' | head -n1)"
+  case "$mask_line" in
+    r--|r-x|rw-|rwx) : ;;
+    *) return 1 ;;
+  esac
+
+  # (b) named-user grant for this agent's UID
+  local named_line
+  named_line="$(printf '%s\n' "$acl_output" \
+    | awk -F: -v u="$iso_user" '$1=="user" && $2==u {print $3}' \
+    | head -n1)"
+  case "$named_line" in
+    r--|r-x|rw-|rwx) : ;;
+    *) return 1 ;;
+  esac
+
+  # (c) ancestor traversal — every parent back to / must have u:<iso_user>:?-x
+  local p
+  p="$(dirname "$path")"
+  while [[ -n "$p" && "$p" != "/" && "$p" != "." ]]; do
+    local pacl panchor
+    pacl="$(getfacl -p "$p" 2>/dev/null)" || return 1
+    panchor="$(printf '%s\n' "$pacl" \
+      | awk -F: -v u="$iso_user" '$1=="user" && $2==u {print $3}' \
+      | head -n1)"
+    case "$panchor" in
+      *x) : ;;  # any of --x / r-x / -wx / rwx counts as traverse
+      *) return 1 ;;
+    esac
+    p="$(dirname "$p")"
+  done
+
   return 0
 }
 

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -872,6 +872,35 @@ bridge_isolation_v2_verify_chgrp_setgid_recursive() {
 # 4b. ACL scrub — strip pre-v2 ACL entries before the chmod pass
 # ---------------------------------------------------------------------------
 
+bridge_isolation_v2_acl_scrub_path_allowed() {
+  # Returns 0 when the given root is inside an allow-list:
+  #   - $BRIDGE_DATA_ROOT/ (any subtree of the v2 data root)
+  #   - $BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT/agent-bridge-*  (per-agent home)
+  # Returns 1 for anything else, in particular the controller's home.
+  #
+  # Both target and the allow-list roots are passed through `cd -P`/`pwd -P`
+  # so symlinked prefixes (e.g. macOS `/tmp -> /private/tmp`) compare cleanly.
+  local target="$1"
+  [[ -n "$target" ]] || return 1
+  local target_abs
+  target_abs="$(cd -P "$target" 2>/dev/null && pwd -P)" || target_abs="$target"
+  local dr="${BRIDGE_DATA_ROOT:-}"
+  if [[ -n "$dr" ]]; then
+    local dr_abs
+    dr_abs="$(cd -P "$dr" 2>/dev/null && pwd -P)" || dr_abs="$dr"
+    case "$target_abs" in
+      "$dr_abs"|"$dr_abs"/*) return 0 ;;
+    esac
+  fi
+  local iso_root="${BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT:-/home}"
+  local iso_abs
+  iso_abs="$(cd -P "$iso_root" 2>/dev/null && pwd -P)" || iso_abs="$iso_root"
+  case "$target_abs" in
+    "$iso_abs"/agent-bridge-*) return 0 ;;
+  esac
+  return 1
+}
+
 bridge_isolation_v2_acl_scrub() {
   # Recursively remove every named ACL entry on the tree. Required by the
   # migration tool: pre-v2 (v1) installs left ACLs on agent paths that
@@ -897,6 +926,16 @@ bridge_isolation_v2_acl_scrub() {
     return 1
   }
   [[ -d "$root" ]] || return 0
+  # RC3 recurrence prevention (refs #781): refuse any root that lives
+  # outside the v2 data root or an isolated agent's private home.
+  # Without this guard, a misrouted scrub against the controller's
+  # `~/.claude/` would wipe the named-user ACL mask we deliberately
+  # apply on `.credentials.json` (the only sanctioned named-user
+  # exception), reproducing the v0.9.5/v0.9.6 `/login` infinite loop.
+  if ! bridge_isolation_v2_acl_scrub_path_allowed "$root"; then
+    bridge_warn "acl_scrub: refusing path outside BRIDGE_DATA_ROOT or /home/agent-bridge-* (controller credential ACL guard, refs #781): $root"
+    return 1
+  fi
   local _scrub_err _rc
   _scrub_err="$(mktemp 2>/dev/null || printf '/dev/null')"
   if [[ "$(uname)" == "Darwin" ]]; then
@@ -1174,6 +1213,470 @@ bridge_isolation_v2_launchd_restore_if_needed() {
   [[ -f "$restore_file" ]] || return 0
   bridge_warn "launchd: detected stale unload from prior run - restoring before retry"
   bridge_isolation_v2_launchd_bootstrap
+}
+
+# ---------------------------------------------------------------------------
+# 6c. isolation grant matrix — single contract for migrate/prepare/reapply/verify
+# ---------------------------------------------------------------------------
+#
+# v0.9.7 (refs #781): every required-access path for an isolated agent is now
+# enumerated in one matrix. Migration, prepare, reapply, daemon writers, and
+# the new `agent-bridge isolation verify` CLI all consume the same matrix
+# rows so a fix at one site cannot leave the next required path unverified.
+# See docs/agent-runtime/v2-isolation-grant-matrix.md (PR 3) for the design
+# rationale and the row-by-row breakdown.
+#
+# Row schema (one TSV per matrix entry — pipe-delimited because TSV columns
+# contain spaces in `notes`):
+#   row_name|path|access_type|owner|group|dir_mode|file_mode|setgid|grant_mechanism|criticality|notes
+#
+# Field meaning:
+#   row_name        stable identifier so callers can ensure_matrix_path by name
+#   path            absolute path with `<X>` already substituted for the agent
+#   access_type     dir | file | dir_only_traverse — verifier picks probes
+#   owner           expected owner (`controller` token resolved at apply time)
+#   group           expected group (`ab-agent-<X>`, `ab-shared`, `ab-controller`)
+#   dir_mode        for `access_type=dir`/`dir_only_traverse`, the directory mode
+#   file_mode       for `access_type=file`, the file mode (or '' if not file)
+#   setgid          1 when the dir mode includes the setgid bit, 0 otherwise
+#   grant_mechanism group_setgid | controller_credential_acl | install_managed
+#   criticality     required | optional | not-applicable (PR 1 has only required)
+#   notes           short human reference for the verify CLI's suggested_fix
+#
+# Out-of-scope for PR 1 (RC6 per-agent plugin cache + criticality split lands
+# in PR 2; upgrade reproducer + docs land in PR 3).
+
+bridge_isolation_v2_matrix_rows_for_agent() {
+  # Emit one matrix row per line for the named agent. Caller should pipe
+  # through a dispatcher (`bridge_isolation_v2_apply_grant_matrix_for_agent`)
+  # that resolves `controller` to the live controller user and applies or
+  # checks per row. Returns non-zero only when the agent argument is invalid
+  # (the matrix itself is static contract, not roster-dependent).
+  local agent="$1"
+  [[ -n "$agent" ]] || {
+    bridge_warn "matrix_rows_for_agent: agent name required"
+    return 1
+  }
+  local agent_grp data_root shared_root
+  agent_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null)" || {
+    bridge_warn "matrix_rows_for_agent: cannot resolve agent group for '$agent'"
+    return 1
+  }
+  data_root="${BRIDGE_DATA_ROOT:-}"
+  shared_root="${BRIDGE_SHARED_ROOT:-${data_root:+$data_root/shared}}"
+  local agent_root="${data_root:+$data_root/agents/$agent}"
+  local state_root="${BRIDGE_HOME:-}/state"
+  local state_agents_root="${state_root}/agents"
+  local state_agent_dir="${state_agents_root}/$agent"
+  local shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+  local ctrl_grp="${BRIDGE_CONTROLLER_GROUP:-ab-controller}"
+  local iso_user="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}"
+  local iso_home_root="${BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT:-/home}"
+  local iso_home="${iso_home_root}/${iso_user}"
+
+  # ----- shared/ row family (catalog/source only — RC6 per-agent cache
+  # lands in PR 2 as a separate row family) -----
+  if [[ -n "$shared_root" ]]; then
+    printf 'shared-root|%s|dir|controller|%s|2750||1|group_setgid|required|shared catalog/source root\n' \
+      "$shared_root" "$shared_grp"
+    printf 'shared-plugins-cache|%s/plugins-cache|dir|controller|%s|2750|0640|1|group_setgid|required|shared plugin catalog/source (RC6 per-agent cache is PR 2)\n' \
+      "$shared_root" "$shared_grp"
+    printf 'shared-memory-daily-aggregate|%s/memory-daily/aggregate|dir|controller|%s|2750|0640|1|group_setgid|required|memory-daily aggregate read by isolated UIDs\n' \
+      "$shared_root" "$shared_grp"
+  fi
+
+  # ----- per-agent root + writable subdirs + credentials -----
+  if [[ -n "$agent_root" ]]; then
+    printf 'agent-root|%s|dir|root|%s|2750||1|group_setgid|required|root-owned 2750: isolated UID enters via group r-x, no group write\n' \
+      "$agent_root" "$agent_grp"
+    local sub
+    for sub in home workdir runtime logs requests responses; do
+      printf 'agent-%s|%s/%s|dir|%s|%s|2770|0660|1|group_setgid|required|writable subtree (RC4=runtime RC5=logs)\n' \
+        "$sub" "$agent_root" "$sub" "$iso_user" "$agent_grp"
+    done
+    printf 'agent-credentials-dir|%s/credentials|dir|controller|%s|2750|0640|1|group_setgid|required|controller writes launch-secrets.env, group reads\n' \
+      "$agent_root" "$agent_grp"
+    printf 'agent-launch-secrets|%s/credentials/launch-secrets.env|file|controller|%s||0640|0|group_setgid|required|launch secret env file (mode 0640 contract)\n' \
+      "$agent_root" "$agent_grp"
+    printf 'agent-env-sh|%s/runtime/agent-env.sh|file|controller|%s||0640|0|group_setgid|required|cached launch env\n' \
+      "$agent_root" "$agent_grp"
+  fi
+
+  # ----- RC1/RC2: $BRIDGE_HOME/state/{,agents/,agents/<X>} -----
+  if [[ -n "$state_root" ]]; then
+    # RC1 design choice (Q2 in design v2): state/ + state/agents/ get
+    # execute-only traversal via the controller group so isolated hooks
+    # can reach the per-agent leaf without opening daemon-owned siblings.
+    # The leaf directory itself takes the writable per-agent contract so
+    # idle-since etc. can be unlinked by the isolated UID (RC2 fix).
+    printf 'state-root|%s|dir_only_traverse|controller|%s|0710||0|group_setgid|required|isolated UID needs --x to reach state/agents/<X>\n' \
+      "$state_root" "$shared_grp"
+    printf 'state-agents-root|%s|dir_only_traverse|controller|%s|0710||0|group_setgid|required|isolated UID needs --x to reach its own leaf\n' \
+      "$state_agents_root" "$shared_grp"
+    printf 'state-agent-dir|%s|dir|controller|%s|2770|0660|1|group_setgid|required|RC1: per-agent state leaf, isolated UID + controller rwx\n' \
+      "$state_agent_dir" "$agent_grp"
+    # RC2: file-level rows are not enforced for files that may be absent
+    # at apply time (idle-since, manual-stop, missing-marker-retries,
+    # webhook-port, next-session.sha). The matrix grants the parent +
+    # setgid so the writers inherit ab-agent-<X> automatically; the
+    # writer helper sets mode 0660 explicitly.
+  fi
+
+  # ----- RC3: controller Anthropic credentials read grant (named ACL) -----
+  # Resolve the controller home dynamically so the row stays
+  # machine-agnostic (operator host runs ec2-user; dev hosts run sean).
+  local ctrl_user="${SUDO_USER:-${USER:-${LOGNAME:-}}}"
+  if [[ -n "$ctrl_user" ]]; then
+    local ctrl_home
+    ctrl_home="$(getent passwd "$ctrl_user" 2>/dev/null | cut -d: -f6)"
+    if [[ -z "$ctrl_home" ]]; then
+      ctrl_home="${HOME:-}"
+    fi
+    if [[ -n "$ctrl_home" ]]; then
+      printf 'controller-credentials|%s/.claude/.credentials.json|file|%s|%s||0600|0|controller_credential_acl|required|RC3 named-user ACL exception (only cross-agent shared secret)\n' \
+        "$ctrl_home" "$ctrl_user" "$ctrl_user"
+    fi
+  fi
+
+  # ----- isolated user's own private home (catalog symlink target etc.) -----
+  if [[ -n "$iso_home_root" ]]; then
+    printf 'isolated-user-home|%s|dir|%s|%s|0700||0|install_managed|required|isolated UIDs private home\n' \
+      "$iso_home" "$iso_user" "$iso_user"
+  fi
+  return 0
+}
+
+bridge_isolation_v2_apply_row() {
+  # Internal dispatcher — applies (or checks) one matrix row.
+  # Args:
+  #   $1 mode    apply | check
+  #   $2..$11   row fields in matrix order (row_name path access_type owner
+  #             group dir_mode file_mode setgid grant_mechanism criticality)
+  # Returns 0 on apply success / clean check, non-zero otherwise. Caller
+  # is responsible for emitting per-row report rows; this helper only
+  # mutates filesystem state (apply) or compares (check).
+  local mode="$1"
+  local row_name="$2"
+  local path="$3"
+  local access_type="$4"
+  local owner="$5"
+  local group="$6"
+  local dir_mode="$7"
+  local file_mode="$8"
+  local setgid="$9"
+  local mechanism="${10}"
+  local criticality="${11}"
+
+  # Resolve `controller` token at apply time so the matrix stays static.
+  if [[ "$owner" == "controller" ]]; then
+    owner="${SUDO_USER:-${USER:-${LOGNAME:-}}}"
+    [[ -n "$owner" ]] || {
+      bridge_warn "apply_row($row_name): cannot resolve controller user"
+      return 1
+    }
+  fi
+
+  case "$mechanism" in
+    controller_credential_acl)
+      # RC3 named-user ACL — handled by the dedicated helper that walks
+      # ancestors and sets the file mask. Apply mode delegates; check mode
+      # probes effective access via setfacl/getfacl.
+      if [[ "$mode" == "apply" ]]; then
+        bridge_isolation_v2_apply_controller_credentials_read_grant \
+          "${row_name#controller-credentials}" 2>/dev/null
+        # The row_name pattern strips the prefix to recover the agent —
+        # but here we don't have the agent in scope; the caller in
+        # apply_grant_matrix_for_agent invokes the helper directly.
+        return 0
+      fi
+      # check mode: just confirm the file exists and the mask is r--.
+      [[ -f "$path" ]] || return 1
+      if command -v getfacl >/dev/null 2>&1; then
+        local mask_line
+        mask_line="$(getfacl -p "$path" 2>/dev/null | awk -F: '/^mask::/ {print $3}' | head -n1)"
+        case "$mask_line" in
+          r--|r-x|rw-|rwx) return 0 ;;
+          *) return 1 ;;
+        esac
+      fi
+      return 0
+      ;;
+    install_managed)
+      # Isolated user's own home — touched only by ensure_user_home /
+      # agent-remove. Apply is a no-op here (creating the user is a
+      # prerequisite of prepare). Check confirms the directory exists.
+      if [[ "$mode" == "apply" ]]; then
+        return 0
+      fi
+      [[ -d "$path" ]]
+      return $?
+      ;;
+    group_setgid)
+      :
+      ;;
+    *)
+      bridge_warn "apply_row($row_name): unknown grant_mechanism '$mechanism'"
+      return 1
+      ;;
+  esac
+
+  # group_setgid path — the common case.
+  case "$access_type" in
+    dir|dir_only_traverse)
+      if [[ "$mode" == "apply" ]]; then
+        # Create the directory if missing — most callers (prepare, daemon
+        # writers) reach apply with the dir already extant; the mkdir is
+        # for daemon ensure_matrix_path callers.
+        if [[ ! -d "$path" ]]; then
+          _bridge_isolation_v2_run_root_or_sudo mkdir -p "$path" || return 1
+        fi
+        _bridge_isolation_v2_run_root_or_sudo chown "$owner:$group" "$path" || return 1
+        _bridge_isolation_v2_run_root_or_sudo chmod "$dir_mode" "$path" || return 1
+        return 0
+      fi
+      # check
+      [[ -d "$path" ]] || return 1
+      local actual_mode
+      actual_mode="$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null)"
+      [[ -n "$actual_mode" ]] || return 1
+      local want
+      want="$(printf '%04o' "$((8#$dir_mode))" 2>/dev/null || printf '%s' "$dir_mode")"
+      local got
+      got="$(printf '%04o' "$((8#$actual_mode))" 2>/dev/null || printf '%s' "$actual_mode")"
+      [[ "$want" == "$got" ]]
+      return $?
+      ;;
+    file)
+      if [[ "$mode" == "apply" ]]; then
+        if [[ ! -e "$path" ]]; then
+          # Files are not created by apply — daemon writers create them
+          # via the matrix-aware writer. Treat absent as a no-op success
+          # (verify will report mismatch separately).
+          return 0
+        fi
+        _bridge_isolation_v2_run_root_or_sudo chown "$owner:$group" "$path" || return 1
+        if [[ -n "$file_mode" ]]; then
+          _bridge_isolation_v2_run_root_or_sudo chmod "$file_mode" "$path" || return 1
+        fi
+        return 0
+      fi
+      # check
+      [[ -e "$path" ]] || return 1
+      if [[ -n "$file_mode" ]]; then
+        local actual
+        actual="$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null)"
+        [[ -n "$actual" ]] || return 1
+        local want_f got_f
+        want_f="$(printf '%04o' "$((8#$file_mode))" 2>/dev/null || printf '%s' "$file_mode")"
+        got_f="$(printf '%04o' "$((8#$actual))" 2>/dev/null || printf '%s' "$actual")"
+        [[ "$want_f" == "$got_f" ]] || return 1
+      fi
+      return 0
+      ;;
+    *)
+      bridge_warn "apply_row($row_name): unknown access_type '$access_type'"
+      return 1
+      ;;
+  esac
+}
+
+bridge_isolation_v2_apply_grant_matrix_for_agent() {
+  # Walk every matrix row for the named agent and apply or check it.
+  # Args:
+  #   $1 agent
+  #   $2 --apply | --check (default --check)
+  # Output (--check mode): one line per row to stdout in TSV form
+  #   <row_name>\t<path>\t<status>\t<expected>\t<actual>
+  # Exit: 0 when every required row is satisfied; non-zero on any
+  # required mismatch (--check) or apply failure (--apply).
+  local agent="$1"
+  local mode_flag="${2:---check}"
+  [[ -n "$agent" ]] || {
+    bridge_warn "apply_grant_matrix_for_agent: agent required"
+    return 1
+  }
+  local mode="check"
+  case "$mode_flag" in
+    --apply) mode="apply" ;;
+    --check|--dry-run) mode="check" ;;
+    *)
+      bridge_warn "apply_grant_matrix_for_agent: unknown mode '$mode_flag'"
+      return 1
+      ;;
+  esac
+
+  local rc=0 row line
+  while IFS= read -r row || [[ -n "$row" ]]; do
+    [[ -n "$row" ]] || continue
+    # row format: row_name|path|access_type|owner|group|dir_mode|file_mode|setgid|mechanism|criticality|notes
+    IFS='|' read -r r_name r_path r_access r_owner r_group r_dmode r_fmode r_setgid r_mech r_crit r_notes <<<"$row"
+    local row_rc=0
+    if [[ "$r_mech" == "controller_credential_acl" && "$mode" == "apply" ]]; then
+      # Apply path: route through the dedicated RC3 helper with the agent
+      # in scope (apply_row alone cannot recover agent from row data).
+      bridge_isolation_v2_apply_controller_credentials_read_grant "$agent" \
+        || row_rc=$?
+    else
+      bridge_isolation_v2_apply_row "$mode" \
+        "$r_name" "$r_path" "$r_access" "$r_owner" "$r_group" \
+        "$r_dmode" "$r_fmode" "$r_setgid" "$r_mech" "$r_crit" \
+        || row_rc=$?
+    fi
+    if [[ "$mode" == "check" ]]; then
+      local status="ok" expected actual mode_part=""
+      if (( row_rc != 0 )); then
+        status="mismatch"
+        rc=1
+      fi
+      if [[ -n "$r_dmode" && -n "$r_fmode" ]]; then
+        mode_part="${r_dmode}/${r_fmode}"
+      elif [[ -n "$r_dmode" ]]; then
+        mode_part="$r_dmode"
+      elif [[ -n "$r_fmode" ]]; then
+        mode_part="$r_fmode"
+      fi
+      expected="$r_owner:$r_group${mode_part:+ }$mode_part"
+      actual="$(bridge_isolation_v2_reapply_probe_owner_group_mode "$r_path" 2>/dev/null || printf 'unknown')"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$r_name" "$r_path" "$status" "$expected" "$actual"
+    elif (( row_rc != 0 )); then
+      bridge_warn "apply_grant_matrix_for_agent($agent): row $r_name failed at $r_path"
+      rc=1
+    fi
+  done < <(bridge_isolation_v2_matrix_rows_for_agent "$agent")
+  return $rc
+}
+
+bridge_isolation_v2_ensure_matrix_path() {
+  # Fast path for daemon writers: ensure the named matrix row's path
+  # exists with correct ownership/mode before write. Idempotent — when
+  # the row is already canonical this returns 0 with no mutation.
+  # Args: row_name, agent
+  local row_name="$1"
+  local agent="$2"
+  [[ -n "$row_name" && -n "$agent" ]] || {
+    bridge_warn "ensure_matrix_path: row_name and agent required"
+    return 1
+  }
+  local row
+  row="$(bridge_isolation_v2_matrix_rows_for_agent "$agent" \
+          | awk -F'|' -v n="$row_name" '$1 == n {print; exit}')"
+  if [[ -z "$row" ]]; then
+    bridge_warn "ensure_matrix_path: row '$row_name' not found for agent '$agent'"
+    return 1
+  fi
+  IFS='|' read -r r_name r_path r_access r_owner r_group r_dmode r_fmode r_setgid r_mech r_crit r_notes <<<"$row"
+  bridge_isolation_v2_apply_row "apply" \
+    "$r_name" "$r_path" "$r_access" "$r_owner" "$r_group" \
+    "$r_dmode" "$r_fmode" "$r_setgid" "$r_mech" "$r_crit"
+}
+
+bridge_isolation_v2_apply_controller_credentials_read_grant() {
+  # RC3: the SINGLE named-user-ACL exception. Grants
+  #   u:agent-bridge-<X>:r--   on  ~/.claude/.credentials.json
+  #   u:agent-bridge-<X>:--x   on  every ancestor back to /
+  # then sets `m::r--` on the file so the named entry is effective.
+  #
+  # Path guard: refuse to operate unless the resolved file lives under
+  # the controller home's `.claude/`, never follow symlinks. This is the
+  # v0.9.5/v0.9.6 mask-break recurrence prevention.
+  local agent="$1"
+  [[ -n "$agent" ]] || {
+    bridge_warn "apply_controller_credentials_read_grant: agent required"
+    return 1
+  }
+  command -v setfacl >/dev/null 2>&1 || {
+    bridge_warn "apply_controller_credentials_read_grant: setfacl not available; skipping (non-Linux host)"
+    return 0
+  }
+  local iso_user="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}"
+  local ctrl_user="${SUDO_USER:-${USER:-${LOGNAME:-}}}"
+  [[ -n "$ctrl_user" ]] || {
+    bridge_warn "apply_controller_credentials_read_grant: cannot resolve controller user"
+    return 1
+  }
+  local ctrl_home
+  ctrl_home="$(getent passwd "$ctrl_user" 2>/dev/null | cut -d: -f6)"
+  [[ -n "$ctrl_home" ]] || ctrl_home="${HOME:-}"
+  [[ -n "$ctrl_home" ]] || {
+    bridge_warn "apply_controller_credentials_read_grant: cannot resolve controller home"
+    return 1
+  }
+  local cred_file="$ctrl_home/.claude/.credentials.json"
+  # Path guard — refuse symlink targets that escape ~/.claude/
+  if [[ -L "$cred_file" ]]; then
+    bridge_warn "apply_controller_credentials_read_grant: refusing symlink at $cred_file (path guard)"
+    return 1
+  fi
+  if [[ ! -f "$cred_file" ]]; then
+    # No Anthropic credential file present — nothing to grant. Not an
+    # error: an operator who has not run `claude /login` yet is in this
+    # state. Verify will report `not_applicable` for this row.
+    return 0
+  fi
+  # Apply ancestor traverse grants. We deliberately do NOT chmod or
+  # restripe other files in these directories — only setfacl -m to add
+  # the named entry. acl_scrub's path guard ensures it cannot reach
+  # back here and re-strip.
+  local ancestor="$(dirname "$cred_file")"
+  while [[ -n "$ancestor" && "$ancestor" != "/" ]]; do
+    _bridge_isolation_v2_run_root_or_sudo \
+      setfacl -m "u:${iso_user}:--x" "$ancestor" 2>/dev/null || {
+        bridge_warn "apply_controller_credentials_read_grant: setfacl --x on $ancestor failed"
+        return 1
+      }
+    ancestor="$(dirname "$ancestor")"
+  done
+  # File-level read grant + mask repair (the v0.9.5/v0.9.6 wipe).
+  _bridge_isolation_v2_run_root_or_sudo \
+    setfacl -m "u:${iso_user}:r--" -m "m::r--" "$cred_file" 2>/dev/null || {
+      bridge_warn "apply_controller_credentials_read_grant: setfacl r-- + m::r-- on $cred_file failed"
+      return 1
+    }
+  return 0
+}
+
+bridge_isolation_v2_write_agent_state_marker() {
+  # Atomic-ish writer for daemon-side per-agent state markers
+  # (idle-since, manual-stop, missing-marker-retries, etc.). Ensures the
+  # state-agent-dir matrix row is canonical, then writes mode 0660.
+  # Args: agent, marker_name, content
+  local agent="$1"
+  local marker_name="$2"
+  local content="$3"
+  [[ -n "$agent" && -n "$marker_name" ]] || {
+    bridge_warn "write_agent_state_marker: agent and marker_name required"
+    return 1
+  }
+  bridge_isolation_v2_ensure_matrix_path "state-agent-dir" "$agent" 2>/dev/null || true
+  local dir
+  dir="$(bridge_agent_idle_marker_dir "$agent" 2>/dev/null)" \
+    || dir="${BRIDGE_ACTIVE_AGENT_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/state/agents}/$agent"
+  mkdir -p "$dir" 2>/dev/null \
+    || _bridge_isolation_v2_run_root_or_sudo mkdir -p "$dir" \
+    || {
+      bridge_warn "write_agent_state_marker: cannot create $dir"
+      return 1
+    }
+  local target="$dir/$marker_name"
+  local tmp="${target}.tmp.$$"
+  printf '%s\n' "$content" > "$tmp" 2>/dev/null || {
+    # Direct write failed — fall back to sudo for controller-write paths.
+    if ! _bridge_isolation_v2_run_root_or_sudo bash -c "printf '%s\n' \"\$1\" > \"\$2\"" _ "$content" "$tmp" 2>/dev/null; then
+      bridge_warn "write_agent_state_marker: cannot write $tmp"
+      return 1
+    fi
+  }
+  mv -f "$tmp" "$target" 2>/dev/null \
+    || _bridge_isolation_v2_run_root_or_sudo mv -f "$tmp" "$target" \
+    || {
+      bridge_warn "write_agent_state_marker: cannot rename into $target"
+      rm -f "$tmp" 2>/dev/null \
+        || _bridge_isolation_v2_run_root_or_sudo rm -f "$tmp" 2>/dev/null || true
+      return 1
+    }
+  chmod 0660 "$target" 2>/dev/null \
+    || _bridge_isolation_v2_run_root_or_sudo chmod 0660 "$target" 2>/dev/null || true
+  return 0
 }
 
 # ---------------------------------------------------------------------------

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1538,7 +1538,10 @@ bridge_isolation_v2_apply_grant_matrix_for_agent() {
         bridge_isolation_v2_apply_controller_credentials_read_grant "$agent" \
           || row_rc=$?
       else
-        bridge_isolation_v2_check_controller_credentials_read_grant "$agent" "$r_path" \
+        # Pass r_fmode so the helper enforces the matrix-contracted file
+        # mode (r4 codex catch — world-readable credentials false-passed).
+        bridge_isolation_v2_check_controller_credentials_read_grant \
+          "$agent" "$r_path" "$r_fmode" \
           || row_rc=$?
       fi
     else
@@ -1661,26 +1664,50 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
 }
 
 bridge_isolation_v2_check_controller_credentials_read_grant() {
-  # r3 codex catch — RC3 check must verify ALL THREE of:
+  # RC3 check must verify ALL FIVE of:
   #   (a) file mask::r-- (or wider)         — was the only check pre-r3
-  #   (b) named-user grant u:<iso_user>:r-- — wipe scenario from v0.9.5/v0.9.6
+  #   (b) named-user grant u:<iso_user>:r-- — r3 added (wipe scenario)
   #   (c) ancestor traversal u:<iso_user>:--x on every parent back to /
-  # Without (b) and (c), check could false-pass: mask alone says "ok" while
-  # the named entry is absent (no agent grant) or ancestor `--x` was
-  # stripped (agent can't traverse to reach the file).
-  local agent="$1" path="$2"
+  #   (d) other::---                         — r4 codex catch: world-readable
+  #       credentials false-pass without this. credential must be readable
+  #       only via the named-user ACL exception, never via base other bits.
+  #   (e) file mode matches matrix row (default 0600). r4 codex catch:
+  #       a 0644 credential could carry mask::r-- + named grant + other::---
+  #       and still false-pass (other:: ACL didn't widen, but base mode did).
+  # The signature accepts file_mode as an optional 3rd arg so the caller
+  # (apply_grant_matrix_for_agent) can pass the matrix row's r_fmode.
+  # When omitted, defaults to 0600 (the contractual mode).
+  local agent="$1" path="$2" file_mode="${3:-0600}"
   [[ -n "$agent" && -n "$path" ]] || return 1
   [[ -f "$path" ]] || return 1
   command -v getfacl >/dev/null 2>&1 || return 0  # non-Linux host fallback (apply also skips)
   local iso_user="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}"
 
-  # (a) mask
-  local acl_output mask_line
+  # (e) file mode — must match matrix contract before any ACL inspection
+  local actual_mode want_mode got_mode
+  actual_mode="$(stat -c '%a' "$path" 2>/dev/null || stat -f '%Lp' "$path" 2>/dev/null)"
+  [[ -n "$actual_mode" ]] || return 1
+  want_mode="$(printf '%04o' "$((8#$file_mode))" 2>/dev/null || printf '%s' "$file_mode")"
+  got_mode="$(printf '%04o' "$((8#$actual_mode))" 2>/dev/null || printf '%s' "$actual_mode")"
+  [[ "$want_mode" == "$got_mode" ]] || return 1
+
+  local acl_output
   acl_output="$(getfacl -p "$path" 2>/dev/null)"
   [[ -n "$acl_output" ]] || return 1
+
+  # (a) mask
+  local mask_line
   mask_line="$(printf '%s\n' "$acl_output" | awk -F: '/^mask::/ {print $3}' | head -n1)"
   case "$mask_line" in
     r--|r-x|rw-|rwx) : ;;
+    *) return 1 ;;
+  esac
+
+  # (d) other:: — must be exactly --- (no widening). r4 codex catch.
+  local other_line
+  other_line="$(printf '%s\n' "$acl_output" | awk -F: '/^other::/ {print $3}' | head -n1)"
+  case "$other_line" in
+    ---) : ;;
     *) return 1 ;;
   esac
 

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1685,9 +1685,15 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
       local stale
       while IFS= read -r stale; do
         [[ -n "$stale" ]] || continue
+        # r8 codex catch — strip MUST hard fail. Previously a strip
+        # failure (sudo denied, fs locked) was warn-and-continue, which
+        # let the next setfacl -m succeed and apply return 0 with the
+        # stale entry intact. Verify then rejected via (f). That
+        # apply/check asymmetry was the r4/r5/r7 anti-pattern.
         _bridge_isolation_v2_run_root_or_sudo \
           setfacl -x "u:${stale}" "$cred_file" 2>/dev/null || {
-            bridge_warn "apply_controller_credentials_read_grant: setfacl -x u:${stale} on $cred_file failed (continuing)"
+            bridge_warn "apply_controller_credentials_read_grant: setfacl -x u:${stale} on $cred_file failed"
+            return 1
           }
       done <<<"$existing_named"
     fi

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1666,13 +1666,32 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
   # File-level: mode + ACL all in one call so apply mirrors check exactly.
   # (r5 codex catch — previously apply set only u:<X>:r-- + m::r-- but
   # left mode 0644 / other::r-- intact, so verify rejected post-apply.)
-  # `setfacl -m` for o::--- ensures other-bits are closed even if the
-  # underlying chmod doesn't strip them (it does on standard EXT/XFS,
-  # but make it explicit so the ACL stays canonical).
   _bridge_isolation_v2_run_root_or_sudo chmod "$file_mode" "$cred_file" 2>/dev/null || {
     bridge_warn "apply_controller_credentials_read_grant: chmod $file_mode on $cred_file failed"
     return 1
   }
+  # r7 codex W1 — strip stale named-user ACL entries before re-granting.
+  # Operator standing policy: only the current agent's named-user grant
+  # exists on the credential. Stale entries from removed/renamed agents
+  # would otherwise leak the credential to whatever UID still owns the
+  # name (or to a re-used UID). Enumerate every existing user:<name>
+  # entry; drop the ones that aren't the current iso_user.
+  if command -v getfacl >/dev/null 2>&1; then
+    local existing_named
+    existing_named="$(getfacl -p "$cred_file" 2>/dev/null \
+      | awk -F: -v u="$iso_user" \
+          '$1=="user" && $2!="" && $2!=u {print $2}')"
+    if [[ -n "$existing_named" ]]; then
+      local stale
+      while IFS= read -r stale; do
+        [[ -n "$stale" ]] || continue
+        _bridge_isolation_v2_run_root_or_sudo \
+          setfacl -x "u:${stale}" "$cred_file" 2>/dev/null || {
+            bridge_warn "apply_controller_credentials_read_grant: setfacl -x u:${stale} on $cred_file failed (continuing)"
+          }
+      done <<<"$existing_named"
+    fi
+  fi
   _bridge_isolation_v2_run_root_or_sudo \
     setfacl -m "u:${iso_user}:r--" -m "m::r--" -m "o::---" "$cred_file" 2>/dev/null || {
       bridge_warn "apply_controller_credentials_read_grant: setfacl r-- + m::r-- + o::--- on $cred_file failed"
@@ -1709,38 +1728,54 @@ bridge_isolation_v2_check_controller_credentials_read_grant() {
   acl_output="$(getfacl -p "$path" 2>/dev/null)"
   [[ -n "$acl_output" ]] || return 1
 
-  # (a) mask
+  # All perm extraction uses substr(field,1,3) so the `#effective:???`
+  # annotation that getfacl appends when a named entry is mask-clamped
+  # does not corrupt our exact-match comparisons. (r7 codex W2 catch.)
+
+  # (a) mask — must be exactly r-- (read-only). Wider mask (r-x, rw-,
+  # rwx) would let any named-user entry leak write/exec to the
+  # credential file. (r7 codex BLOCK — named-user grant must be capped
+  # at read-only AND mask must enforce that cap, not merely permit it.)
   local mask_line
-  mask_line="$(printf '%s\n' "$acl_output" | awk -F: '/^mask::/ {print $3}' | head -n1)"
-  case "$mask_line" in
-    r--|r-x|rw-|rwx) : ;;
-    *) return 1 ;;
-  esac
+  mask_line="$(printf '%s\n' "$acl_output" \
+    | awk -F: '/^mask::/ {print substr($3,1,3)}' | head -n1)"
+  [[ "$mask_line" == "r--" ]] || return 1
 
   # (e) base ACL entries: user::rw-, group::---
   local user_line group_line
-  user_line="$(printf '%s\n' "$acl_output" | awk -F: '/^user::/ {print $3}' | head -n1)"
+  user_line="$(printf '%s\n' "$acl_output" \
+    | awk -F: '/^user::/ {print substr($3,1,3)}' | head -n1)"
   [[ "$user_line" == "rw-" ]] || return 1
-  group_line="$(printf '%s\n' "$acl_output" | awk -F: '/^group::/ {print $3}' | head -n1)"
+  group_line="$(printf '%s\n' "$acl_output" \
+    | awk -F: '/^group::/ {print substr($3,1,3)}' | head -n1)"
   [[ "$group_line" == "---" ]] || return 1
 
   # (d) other:: — must be exactly --- (no widening). r4 codex catch.
   local other_line
-  other_line="$(printf '%s\n' "$acl_output" | awk -F: '/^other::/ {print $3}' | head -n1)"
-  case "$other_line" in
-    ---) : ;;
-    *) return 1 ;;
-  esac
+  other_line="$(printf '%s\n' "$acl_output" \
+    | awk -F: '/^other::/ {print substr($3,1,3)}' | head -n1)"
+  [[ "$other_line" == "---" ]] || return 1
 
-  # (b) named-user grant for this agent's UID
+  # (b) named-user grant for this agent's UID — must be exactly r--
+  # (read-only). Credential is a data file; +x is meaningless and +w
+  # would let the isolated UID modify the controller's token.
+  # (r7 codex BLOCK — named user with rw-/rwx false-passed in r6.)
   local named_line
   named_line="$(printf '%s\n' "$acl_output" \
-    | awk -F: -v u="$iso_user" '$1=="user" && $2==u {print $3}' \
+    | awk -F: -v u="$iso_user" '$1=="user" && $2==u {print substr($3,1,3)}' \
     | head -n1)"
-  case "$named_line" in
-    r--|r-x|rw-|rwx) : ;;
-    *) return 1 ;;
-  esac
+  [[ "$named_line" == "r--" ]] || return 1
+
+  # (f) operator standing policy: only the current agent's named-user
+  # grant may exist on the credential. Stale entries from removed
+  # agents leak the credential to whatever UID still owns that name
+  # (or to a re-used UID). r7 codex W1 catch — currently a security
+  # debt, not just cleanliness. Reject any named-user entry whose name
+  # is not the current iso_user.
+  local stale_named
+  stale_named="$(printf '%s\n' "$acl_output" \
+    | awk -F: -v u="$iso_user" '$1=="user" && $2!="" && $2!=u {print $2}')"
+  [[ -z "$stale_named" ]] || return 1
 
   # (c) ancestor traversal — every parent back to / must have u:<iso_user>:?-x
   local p
@@ -1749,7 +1784,7 @@ bridge_isolation_v2_check_controller_credentials_read_grant() {
     local pacl panchor
     pacl="$(getfacl -p "$p" 2>/dev/null)" || return 1
     panchor="$(printf '%s\n' "$pacl" \
-      | awk -F: -v u="$iso_user" '$1=="user" && $2==u {print $3}' \
+      | awk -F: -v u="$iso_user" '$1=="user" && $2==u {print substr($3,1,3)}' \
       | head -n1)"
     case "$panchor" in
       *x) : ;;  # any of --x / r-x / -wx / rwx counts as traverse

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1670,26 +1670,39 @@ bridge_isolation_v2_apply_controller_credentials_read_grant() {
     bridge_warn "apply_controller_credentials_read_grant: chmod $file_mode on $cred_file failed"
     return 1
   }
-  # r7 codex W1 — strip stale named-user ACL entries before re-granting.
-  # Operator standing policy: only the current agent's named-user grant
-  # exists on the credential. Stale entries from removed/renamed agents
-  # would otherwise leak the credential to whatever UID still owns the
-  # name (or to a re-used UID). Enumerate every existing user:<name>
-  # entry; drop the ones that aren't the current iso_user.
+  # r11 codex catch — strip is roster-aware, not "this agent only".
+  # All isolated agents in the roster need a named-user r-- grant on
+  # the controller's Anthropic credential (per design v2: single
+  # cross-agent shared secret). Strip ONLY entries whose user is not
+  # in the current isolated-agent roster. Previously (r7) the strip
+  # treated every other named-user as stale, so applying agent B
+  # silently revoked agent A's grant.
   if command -v getfacl >/dev/null 2>&1; then
+    local roster_iso_users
+    roster_iso_users=""
+    if command -v bridge_isolation_v2_reapply_eligible_agents >/dev/null 2>&1; then
+      local _ra
+      while IFS= read -r _ra; do
+        [[ -n "$_ra" ]] || continue
+        roster_iso_users+="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${_ra}"$'\n'
+      done < <(bridge_isolation_v2_reapply_eligible_agents 2>/dev/null || true)
+    fi
+    # Always include the current agent (so we never strip ourselves
+    # if the roster lookup is empty in a fresh-install transient).
+    roster_iso_users+="${iso_user}"$'\n'
+
     local existing_named
     existing_named="$(getfacl -p "$cred_file" 2>/dev/null \
-      | awk -F: -v u="$iso_user" \
-          '$1=="user" && $2!="" && $2!=u {print $2}')"
+      | awk -F: '$1=="user" && $2!="" {print $2}')"
     if [[ -n "$existing_named" ]]; then
       local stale
       while IFS= read -r stale; do
         [[ -n "$stale" ]] || continue
-        # r8 codex catch — strip MUST hard fail. Previously a strip
-        # failure (sudo denied, fs locked) was warn-and-continue, which
-        # let the next setfacl -m succeed and apply return 0 with the
-        # stale entry intact. Verify then rejected via (f). That
-        # apply/check asymmetry was the r4/r5/r7 anti-pattern.
+        # Keep if in roster
+        if printf '%s' "$roster_iso_users" | grep -Fxq "$stale"; then
+          continue
+        fi
+        # r8 codex catch — strip MUST hard fail.
         _bridge_isolation_v2_run_root_or_sudo \
           setfacl -x "u:${stale}" "$cred_file" 2>/dev/null || {
             bridge_warn "apply_controller_credentials_read_grant: setfacl -x u:${stale} on $cred_file failed"
@@ -1772,16 +1785,35 @@ bridge_isolation_v2_check_controller_credentials_read_grant() {
     | head -n1)"
   [[ "$named_line" == "r--" ]] || return 1
 
-  # (f) operator standing policy: only the current agent's named-user
-  # grant may exist on the credential. Stale entries from removed
-  # agents leak the credential to whatever UID still owns that name
-  # (or to a re-used UID). r7 codex W1 catch — currently a security
-  # debt, not just cleanliness. Reject any named-user entry whose name
-  # is not the current iso_user.
-  local stale_named
-  stale_named="$(printf '%s\n' "$acl_output" \
-    | awk -F: -v u="$iso_user" '$1=="user" && $2!="" && $2!=u {print $2}')"
-  [[ -z "$stale_named" ]] || return 1
+  # (f) operator standing policy: every named-user grant on the
+  # credential must correspond to a current isolated-agent in the
+  # roster. r11 codex catch — earlier r7 enforced "only this agent"
+  # which is wrong for multi-agent: applying agent B's check after
+  # agent A had been granted would reject the current state. Now
+  # accept any user in the roster; reject only entries whose name is
+  # NOT in the roster (stale / orphaned grants).
+  local roster_iso_users
+  roster_iso_users=""
+  if command -v bridge_isolation_v2_reapply_eligible_agents >/dev/null 2>&1; then
+    local _ra
+    while IFS= read -r _ra; do
+      [[ -n "$_ra" ]] || continue
+      roster_iso_users+="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${_ra}"$'\n'
+    done < <(bridge_isolation_v2_reapply_eligible_agents 2>/dev/null || true)
+  fi
+  # Always include the agent being checked.
+  roster_iso_users+="${iso_user}"$'\n'
+
+  local existing_named
+  existing_named="$(printf '%s\n' "$acl_output" \
+    | awk -F: '$1=="user" && $2!="" {print $2}')"
+  if [[ -n "$existing_named" ]]; then
+    local _e
+    while IFS= read -r _e; do
+      [[ -n "$_e" ]] || continue
+      printf '%s' "$roster_iso_users" | grep -Fxq "$_e" || return 1
+    done <<<"$existing_named"
+  fi
 
   # (c) ancestor traversal — every parent back to / must have u:<iso_user>:?-x
   local p
@@ -1814,7 +1846,17 @@ bridge_isolation_v2_write_agent_state_marker() {
     bridge_warn "write_agent_state_marker: agent and marker_name required"
     return 1
   }
-  bridge_isolation_v2_ensure_matrix_path "state-agent-dir" "$agent" 2>/dev/null || true
+  # r11 codex BUG #4 — was `|| true`. Same anti-pattern as the other
+  # apply/check paths: ensure_matrix_path failure was swallowed, so the
+  # subsequent mkdir/write proceeded against a state-dir that may have
+  # wrong group/mode (RC1 cascade), then the marker file inherited
+  # wrong group, then verify rejected. Hard fail propagates to the
+  # daemon writer's caller. Suppress only the per-call stderr because
+  # bridge_warn from inside ensure_matrix_path already logged.
+  bridge_isolation_v2_ensure_matrix_path "state-agent-dir" "$agent" 2>/dev/null || {
+    bridge_warn "write_agent_state_marker: ensure_matrix_path failed for agent=$agent marker=$marker_name"
+    return 1
+  }
   local dir
   dir="$(bridge_agent_idle_marker_dir "$agent" 2>/dev/null)" \
     || dir="${BRIDGE_ACTIVE_AGENT_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/state/agents}/$agent"

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -925,17 +925,31 @@ bridge_isolation_v2_acl_scrub() {
     bridge_warn "acl_scrub: root required"
     return 1
   }
-  [[ -d "$root" ]] || return 0
-  # RC3 recurrence prevention (refs #781): refuse any root that lives
-  # outside the v2 data root or an isolated agent's private home.
-  # Without this guard, a misrouted scrub against the controller's
-  # `~/.claude/` would wipe the named-user ACL mask we deliberately
-  # apply on `.credentials.json` (the only sanctioned named-user
-  # exception), reproducing the v0.9.5/v0.9.6 `/login` infinite loop.
+  # r15 codex Probe 5 — path guard FIRST, before the directory check.
+  # Earlier the guard ran AFTER `[[ -d "$root" ]] || return 0`, so a
+  # caller passing a controller-credential FILE (not directory) hit
+  # the early return and false-passed without the guard ever running.
+  # That meant a misrouted scrub against the Anthropic credential
+  # would silently no-op instead of refusing — operator could not
+  # tell whether the scrub had stripped the named-user ACL or not.
   if ! bridge_isolation_v2_acl_scrub_path_allowed "$root"; then
     bridge_warn "acl_scrub: refusing path outside BRIDGE_DATA_ROOT or /home/agent-bridge-* (controller credential ACL guard, refs #781): $root"
     return 1
   fi
+  if [[ -f "$root" ]]; then
+    # File path inside the allowlist: refuse loudly. Per-file ACL scrub
+    # is not part of the bulk-strip contract; callers that need to
+    # strip a single file's ACL should use setfacl directly with
+    # explicit named-entry deletion. This refusal prevents a caller
+    # from passing e.g. `agents/<X>/workdir/.teams/.env` and getting
+    # a silent rc=0 while the file's ACL stays intact.
+    bridge_warn "acl_scrub: refusing file path (use setfacl for per-file strip): $root"
+    return 1
+  fi
+  [[ -d "$root" ]] || {
+    bridge_warn "acl_scrub: $root is neither a directory nor regular file"
+    return 1
+  }
   local _scrub_err _rc
   _scrub_err="$(mktemp 2>/dev/null || printf '/dev/null')"
   if [[ "$(uname)" == "Darwin" ]]; then

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1443,7 +1443,18 @@ bridge_isolation_v2_apply_row() {
       want="$(printf '%04o' "$((8#$dir_mode))" 2>/dev/null || printf '%s' "$dir_mode")"
       local got
       got="$(printf '%04o' "$((8#$actual_mode))" 2>/dev/null || printf '%s' "$actual_mode")"
-      [[ "$want" == "$got" ]]
+      [[ "$want" == "$got" ]] || return 1
+      # r2 codex catch — also compare owner:group. Without this, RC1-style
+      # group drift (e.g. state/agents/<X> owned by ab-controller instead
+      # of ab-agent-<X>) false-passes the check despite mode being correct.
+      # apply path (chown above) doesn't accept token names ("controller"
+      # etc.) — caller must already resolve tokens to actual user/group
+      # names — so check uses the same resolved comparison.
+      local actual_og want_og
+      actual_og="$(stat -c '%U:%G' "$path" 2>/dev/null || stat -f '%Su:%Sg' "$path" 2>/dev/null)"
+      [[ -n "$actual_og" ]] || return 1
+      want_og="$owner:$group"
+      [[ "$actual_og" == "$want_og" ]]
       return $?
       ;;
     file)
@@ -1471,7 +1482,16 @@ bridge_isolation_v2_apply_row() {
         got_f="$(printf '%04o' "$((8#$actual))" 2>/dev/null || printf '%s' "$actual")"
         [[ "$want_f" == "$got_f" ]] || return 1
       fi
-      return 0
+      # r2 codex catch — owner:group drift also fails check, mirroring dir
+      # branch above. Files inherit group from setgid parent in normal
+      # operation, but a mis-grouped pre-existing file (e.g. RC2's
+      # ec2-user:ab-controller idle-since) must surface here.
+      local actual_og_f want_og_f
+      actual_og_f="$(stat -c '%U:%G' "$path" 2>/dev/null || stat -f '%Su:%Sg' "$path" 2>/dev/null)"
+      [[ -n "$actual_og_f" ]] || return 1
+      want_og_f="$owner:$group"
+      [[ "$actual_og_f" == "$want_og_f" ]]
+      return $?
       ;;
     *)
       bridge_warn "apply_row($row_name): unknown access_type '$access_type'"

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1913,8 +1913,15 @@ bridge_isolation_v2_write_agent_state_marker() {
         || _bridge_isolation_v2_run_root_or_sudo rm -f "$tmp" 2>/dev/null || true
       return 1
     }
+  # r14 codex Probe 4 — was `|| true`. chmod 0660 failure means the
+  # marker file's mode doesn't match the matrix contract; verify will
+  # reject. Hard fail propagates so callers see the asymmetry.
   chmod 0660 "$target" 2>/dev/null \
-    || _bridge_isolation_v2_run_root_or_sudo chmod 0660 "$target" 2>/dev/null || true
+    || _bridge_isolation_v2_run_root_or_sudo chmod 0660 "$target" 2>/dev/null \
+    || {
+      bridge_warn "write_agent_state_marker: cannot chmod 0660 $target"
+      return 1
+    }
   return 0
 }
 

--- a/lib/bridge-notify.sh
+++ b/lib/bridge-notify.sh
@@ -80,7 +80,11 @@ bridge_claude_session_try_mark_prompt_ready() {
   [[ -n "$session" ]] || return 1
   bridge_tmux_session_exists "$session" || return 1
   bridge_tmux_session_has_prompt "$session" claude || return 1
-  bridge_agent_mark_idle_now "$agent"
+  # r13 codex Probe E catch — was unconditional `return 0` after the
+  # mark_idle call, swallowing the new hard-fail propagation from r12.
+  # Now propagate so callers (channels prompt-detector, notify path)
+  # see the failure when the matrix writer rejects.
+  bridge_agent_mark_idle_now "$agent" || return 1
   return 0
 }
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2358,7 +2358,11 @@ bridge_agent_note_prompt_ready() {
   if command -v bridge_isolation_v2_ensure_matrix_path >/dev/null 2>&1 \
       && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
       && bridge_isolation_v2_active 2>/dev/null; then
-    bridge_isolation_v2_ensure_matrix_path "agent-runtime" "$agent" >/dev/null 2>&1 || true
+    # r13 codex Probe F catch — was `|| true` (silent swallow). When
+    # ensure_matrix_path fails we cannot trust the subsequent mkdir to
+    # land the correct ownership/mode for the runtime dir, so the
+    # written marker would later fail verify. Hard fail propagates.
+    bridge_isolation_v2_ensure_matrix_path "agent-runtime" "$agent" >/dev/null 2>&1 || return 1
   fi
   mkdir -p "$dir"
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2350,6 +2350,16 @@ bridge_agent_note_prompt_ready() {
   engine="$(bridge_agent_engine "$agent" 2>/dev/null || true)"
   session="$(bridge_agent_session "$agent" 2>/dev/null || true)"
   ts="$(date +%s)"
+  # v0.9.7 (refs #781 RC4): prompt-ready.env lives under runtime/, which
+  # is granted to the isolated UID + controller via the matrix. Ensure
+  # the matrix row before write so a fresh mkdir (parent absent) lands
+  # with the correct ownership/mode without relying on best-effort
+  # `mkdir -p` inheriting controller-only metadata.
+  if command -v bridge_isolation_v2_ensure_matrix_path >/dev/null 2>&1 \
+      && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
+      && bridge_isolation_v2_active 2>/dev/null; then
+    bridge_isolation_v2_ensure_matrix_path "agent-runtime" "$agent" >/dev/null 2>&1 || true
+  fi
   mkdir -p "$dir"
 
   # Idempotency: if a marker already exists for the current session, don't
@@ -2806,22 +2816,58 @@ bridge_agent_mark_idle_now() {
   local agent="$1"
   local dir
   local file
+  local ts
 
   dir="$(bridge_agent_idle_marker_dir "$agent")"
   file="$(bridge_agent_idle_since_file "$agent")"
-  mkdir -p "$dir"
-  printf '%s\n' "$(date +%s)" >"$file"
+  ts="$(date +%s)"
+
+  # v0.9.7 RC2 (refs #781): route through the matrix-aware writer so the
+  # per-agent state/agents/<X>/ leaf is canonicalized (group ab-agent-<X>,
+  # 2770, setgid) before write. Without this the daemon's previous plain
+  # `mkdir -p` + redirection produced ec2-user:ab-controller 0600 files
+  # that the isolated UserPromptSubmit hook could not unlink, surfacing
+  # as the "rm: cannot remove '.../idle-since': Permission denied" error
+  # in the operator's session output. Falls back to the legacy direct
+  # write path when the matrix helper isn't loaded (test fixtures).
+  if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
+      && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
+      && bridge_isolation_v2_active 2>/dev/null; then
+    bridge_isolation_v2_write_agent_state_marker "$agent" "idle-since" "$ts" \
+      || { mkdir -p "$dir"; printf '%s\n' "$ts" >"$file"; }
+  else
+    mkdir -p "$dir"
+    printf '%s\n' "$ts" >"$file"
+  fi
 }
 
 bridge_agent_mark_manual_stop() {
   local agent="$1"
   local dir
   local file
+  local ts
 
   dir="$(bridge_agent_idle_marker_dir "$agent")"
   file="$(bridge_agent_manual_stop_file "$agent")"
-  mkdir -p "$dir"
-  printf '%s\n' "$(date +%s)" >"$file"
+  ts="$(date +%s)"
+
+  # v0.9.7 RC2 (refs #781): same matrix-aware route as
+  # bridge_agent_mark_idle_now. manual-stop participates in the same
+  # state/agents/<X>/ leaf contract; without the matrix grant the
+  # isolated `bridge_agent_clear_manual_stop` rm path fell back to a
+  # sudo handoff in PR #714 — the matrix grant makes the sudo handoff
+  # unnecessary because the isolated UID is now in ab-agent-<X> and the
+  # parent dir is 2770. The sudo handoff stays as a fallback for hosts
+  # where the matrix has not been applied yet (rolling upgrade window).
+  if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
+      && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
+      && bridge_isolation_v2_active 2>/dev/null; then
+    bridge_isolation_v2_write_agent_state_marker "$agent" "manual-stop" "$ts" \
+      || { mkdir -p "$dir"; printf '%s\n' "$ts" >"$file"; }
+  else
+    mkdir -p "$dir"
+    printf '%s\n' "$ts" >"$file"
+  fi
 }
 
 bridge_agent_clear_idle_marker() {
@@ -2831,7 +2877,16 @@ bridge_agent_clear_idle_marker() {
 
   file="$(bridge_agent_idle_since_file "$agent")"
   dir="$(bridge_agent_idle_marker_dir "$agent")"
-  rm -f "$file"
+  # v0.9.7 RC2 (refs #781): when the matrix grant has been applied, the
+  # isolated UID is in ab-agent-<X> and the parent dir is 2770 setgid,
+  # so this plain `rm -f` succeeds from the isolated hook context.
+  # If it still fails, log a diagnostic so the verify CLI's
+  # `agent-bridge isolation verify` operator-side run can flag that the
+  # matrix is out of sync and `migrate isolation v2 --apply --agent <X>`
+  # is needed.
+  if [[ -f "$file" ]] && ! rm -f "$file" 2>/dev/null; then
+    bridge_warn "bridge_agent_clear_idle_marker: rm $file failed (agent=$agent) — grant matrix may be drifted; run \`agent-bridge isolation verify --agent $agent\`"
+  fi
   # Issue #629: drop the missing-marker retry counter so a future stale
   # marker scenario starts fresh — otherwise the counter could ratchet
   # the synthetic-marker fallback in earlier than warranted.

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2478,7 +2478,19 @@ bridge_agent_context_pressure_state_file() {
 
 bridge_agent_next_session_marker_file() {
   local agent="$1"
-  printf '%s/next-session.sha' "$(bridge_agent_runtime_state_dir "$agent")"
+  # r16 codex catch — was bridge_agent_runtime_state_dir, which on v2
+  # resolves to $BRIDGE_AGENT_ROOT_V2/<X>/runtime/. But the Python
+  # SessionStart hook (hooks/bridge_hook_common.py:398) writes the
+  # marker to bridge_active_agent_dir() / agent / "next-session.sha"
+  # = $BRIDGE_ACTIVE_AGENT_DIR/<X>/. Path divergence: Python wrote
+  # state/agents/<X>/next-session.sha, bash reader looked under
+  # runtime/, so the autoarchive delivery digest never matched and
+  # bridge-run.sh never saw the delivered handoff. Per design v2's
+  # state-agent-marker-files row, all markers (idle-since, manual-stop,
+  # missing-marker-retries, webhook-port, next-session.sha) belong
+  # in state/agents/<X>/. Use idle_marker_dir to match the other
+  # markers + the Python hook.
+  printf '%s/next-session.sha' "$(bridge_agent_idle_marker_dir "$agent")"
 }
 
 bridge_path_age_seconds() {

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2830,11 +2830,17 @@ bridge_agent_mark_idle_now() {
   # as the "rm: cannot remove '.../idle-since': Permission denied" error
   # in the operator's session output. Falls back to the legacy direct
   # write path when the matrix helper isn't loaded (test fixtures).
+  # r12 codex Probe 9 — drop the direct-write fallback when the
+  # matrix-aware writer fails. Falling back to plain mkdir+printf
+  # silently defeated the r10 BUG #4 hard-fail propagation: the
+  # writer would return 1 (signaling matrix not applied), the
+  # fallback would succeed with controller-owned mode, and verify
+  # would then reject. Hard fail here too — matrix needs to be
+  # applied before daemon can write.
   if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
       && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
       && bridge_isolation_v2_active 2>/dev/null; then
-    bridge_isolation_v2_write_agent_state_marker "$agent" "idle-since" "$ts" \
-      || { mkdir -p "$dir"; printf '%s\n' "$ts" >"$file"; }
+    bridge_isolation_v2_write_agent_state_marker "$agent" "idle-since" "$ts" || return 1
   else
     mkdir -p "$dir"
     printf '%s\n' "$ts" >"$file"
@@ -2859,11 +2865,13 @@ bridge_agent_mark_manual_stop() {
   # unnecessary because the isolated UID is now in ab-agent-<X> and the
   # parent dir is 2770. The sudo handoff stays as a fallback for hosts
   # where the matrix has not been applied yet (rolling upgrade window).
+  # r12 codex Probe 9 — same direct-write fallback removal as
+  # bridge_agent_mark_idle_now above. Hard fail when matrix writer
+  # fails so verify and apply stay in sync.
   if command -v bridge_isolation_v2_write_agent_state_marker >/dev/null 2>&1 \
       && command -v bridge_isolation_v2_active >/dev/null 2>&1 \
       && bridge_isolation_v2_active 2>/dev/null; then
-    bridge_isolation_v2_write_agent_state_marker "$agent" "manual-stop" "$ts" \
-      || { mkdir -p "$dir"; printf '%s\n' "$ts" >"$file"; }
+    bridge_isolation_v2_write_agent_state_marker "$agent" "manual-stop" "$ts" || return 1
   else
     mkdir -p "$dir"
     printf '%s\n' "$ts" >"$file"


### PR DESCRIPTION
## Summary

PR 1 of v0.9.7 — implements design v2 ([`/tmp/v097-isolation-grant-matrix-design-v2.md`](#)) matrix foundation. PR 2 (RC6 per-agent plugin cache + criticality split) and PR 3 (upgrade/reproducer/docs) follow.

- **Matrix foundation** in `lib/bridge-isolation-v2.sh`: `matrix_rows_for_agent`, `apply_grant_matrix_for_agent` (`--apply`/`--check`), `apply_row` dispatcher, `ensure_matrix_path`, `write_agent_state_marker`, `apply_controller_credentials_read_grant` (single RC3 ACL exception).
- **Path guard** added to `acl_scrub`: refuses any root outside `\$BRIDGE_DATA_ROOT` or `/home/agent-bridge-*` (RC3 recurrence prevention — no more controller credentials mask wipe).
- **Migration consolidation**: `migrate_normalize_layout` now uses explicit matrix rows for `state/`, `state/agents/`, `state/agents/<X>/` (replaces broad recursive pass). `reapply_one_agent` and `prepare_agent_isolation` consume the same matrix → drops duplicated writable-subdir blocks.
- **Daemon writers** (RC2/RC4/RC5): `mark_idle_now`, `mark_manual_stop`, missing-marker retry, webhook-port, next-session.sha all route through matrix ensure helpers. group `ab-agent-<X>`, mode `0660`, setgid-inherited.
- **New CLI**: `agent-bridge isolation verify --agent <X> [--json] [--strict-optional]` (read-only; exit non-zero on required mismatch).

## RCs addressed

- RC1: `state/agents/<X>/` group misalignment → matrix enforces `ab-agent-<X>` + setgid
- RC2: `idle-since` controller-owned + isolated hook unlink fail → marker writer route through matrix
- RC3: `~/.claude/.credentials.json` ACL mask wipe → single named-user ACL exception + path guard
- RC4: `runtime/` not traversable → matrix row covers
- RC5: `logs/` not traversable → matrix row covers

RC6 (dev-plugin-cache silent failure) is PR 2.

## Test plan

- [x] bash -n clean across all touched .sh
- [x] shellcheck clean
- [x] python3 ast.parse on hooks/bridge_hook_common.py
- [x] 5 new helpers loadable via fresh `source lib/bridge-isolation-v2.sh`
- [x] `agent-bridge` dispatcher recognizes `isolation` subcommand
- [ ] codex destructive-probe review (operator-authorized 5+ rounds)
- [ ] Operator host (AL2023) post-merge verification:
  - [ ] `migrate isolation v2 --apply` from RC1-5 workaround state → matrix-canonical state
  - [ ] `agent-bridge isolation verify --agent sales_sean` → exit 0
  - [ ] `setfacl -x` of named-user ACLs not required pre-upgrade
  - [ ] Unlink-by-isolated-hook of `idle-since` works without manual chgrp

scripts/smoke-test.sh: hangs identically on macOS dev host on this branch AND pristine main (3-line stop, exit=1) — unrelated to PR 1 changes.

Refs #781

🤖 Generated with [Claude Code](https://claude.com/claude-code)