### PR TITLE
feat(isolation): RC6 silent-failure fix + per-agent plugin cache + criticality split (refs #781)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -82,7 +82,8 @@ Read-only — no chmod/chgrp/setfacl/mkdir. Exit non-zero on required mismatch.
 Options:
   --agent <name>       Agent id (required).
   --json               Emit machine-readable output instead of the table.
-  --strict-optional    Treat optional plugin rows as required (PR 2).
+  --strict-optional    Treat optional plugin rows as required (CLI exit
+                       non-zero on any optional row reporting 'degraded').
 
 Available even on legacy/markerless installs to advise upgrade.
 Run `agent-bridge upgrade --apply` first to populate the v2 layout.
@@ -885,9 +886,10 @@ PY
                 shift
                 ;;
               --strict-optional)
-                # Accepted for forward compatibility with PR 2's
-                # criticality split. PR 1 does not enumerate optional
-                # rows yet, so the flag is a no-op here.
+                # v0.9.7 PR 2 (refs #781): with this flag, `degraded`
+                # rows (criticality=optional, mismatch) escalate to
+                # `mismatch` and the CLI exits non-zero. Without it,
+                # only required-row mismatches flip the exit code.
                 _iso_strict_optional=1
                 shift
                 ;;
@@ -897,11 +899,13 @@ Usage: $CLI_NAME isolation verify --agent <agent> [--json] [--strict-optional]
 
 Read-only verification of the v2 isolation grant matrix for one agent.
 Walks every required-access row and reports {path, expected, actual,
-status, suggested_fix}. Exits non-zero on any required mismatch.
+status, criticality, suggested_fix}. Exits non-zero on any required
+mismatch.
 
   --agent <X>         agent id (required)
   --json              emit machine-readable JSON (default: human table)
-  --strict-optional   PR 2 forward-compat flag (no-op in PR 1)
+  --strict-optional   treat optional row failures as required (CLI exit
+                      non-zero on any optional 'degraded' row)
 
 Suggested fix when verify reports drift:
   agent-bridge migrate isolation v2 --apply --agent <X>
@@ -928,29 +932,50 @@ EOF
           _iso_check_out="$(bridge_isolation_v2_apply_grant_matrix_for_agent "$_iso_agent" --check 2>&1)" \
             || _iso_rc=$?
 
+          # v0.9.7 PR 2 (refs #781): apply_grant_matrix_for_agent now
+          # demotes optional-row failures to status=`degraded` and does
+          # NOT flip rc for them. With `--strict-optional`, the CLI
+          # treats any `degraded` row as a hard mismatch for exit code
+          # purposes (the row data itself stays `degraded` so the
+          # operator can see which rows are optional vs required).
+          if (( _iso_strict_optional == 1 )) \
+              && [[ "$_iso_check_out" == *$'\tdegraded\t'* ]]; then
+            _iso_rc=1
+          fi
+
           if (( _iso_json == 1 )); then
             bridge_require_python
             # The check output is passed as a third positional arg so the
             # python heredoc remains the script source while data lands
             # in argv. This avoids the heredoc-overrides-pipe bash trap
             # (shellcheck SC2259) without writing temp files.
-            python3 - "$_iso_agent" "$_iso_rc" "$_iso_check_out" <<'PY'
+            python3 - "$_iso_agent" "$_iso_rc" "$_iso_check_out" "$_iso_strict_optional" <<'PY'
 import json, sys
 agent = sys.argv[1]
 rc = int(sys.argv[2])
 data = sys.argv[3] if len(sys.argv) > 3 else ""
+strict_optional = sys.argv[4] == "1" if len(sys.argv) > 4 else False
 rows = []
 for line in data.splitlines():
     parts = line.split("\t")
+    # 6-column format added in v0.9.7 PR 2: row, path, status,
+    # expected, actual, criticality. Tolerate older 5-column lines so
+    # consumers reading the upgrader's pre-upgrade snapshot don't break.
     if len(parts) < 5:
         continue
-    row_name, path, status, expected, actual = parts[:5]
+    row_name = parts[0]
+    path = parts[1]
+    status = parts[2]
+    expected = parts[3]
+    actual = parts[4]
+    criticality = parts[5] if len(parts) > 5 else "required"
     rows.append({
         "row": row_name,
         "path": path,
         "status": status,
         "expected": expected,
         "actual": actual,
+        "criticality": criticality,
         "suggested_fix": (
             f"agent-bridge migrate isolation v2 --apply --agent {agent}"
             if status != "ok" else ""
@@ -959,22 +984,34 @@ for line in data.splitlines():
 print(json.dumps({
     "agent": agent,
     "exit_status": "ok" if rc == 0 else "mismatch",
+    "strict_optional": strict_optional,
     "rows": rows,
 }, ensure_ascii=False, indent=2))
 PY
           else
             printf 'Isolation grant matrix verify for agent: %s\n' "$_iso_agent"
+            if (( _iso_strict_optional == 1 )); then
+              printf '%s\n' "(strict-optional: degraded rows escalated to required)"
+            fi
             printf '%s\n' "------------------------------------------------------------------"
-            printf '%-26s %-10s %-30s %s\n' "ROW" "STATUS" "EXPECTED" "PATH"
+            printf '%-26s %-10s %-14s %-30s %s\n' "ROW" "STATUS" "CRITICALITY" "EXPECTED" "PATH"
             printf '%s\n' "------------------------------------------------------------------"
-            while IFS=$'\t' read -r _name _path _status _expected _actual; do
+            while IFS=$'\t' read -r _name _path _status _expected _actual _crit; do
               [[ -n "$_name" ]] || continue
-              printf '%-26s %-10s %-30s %s\n' \
-                "$_name" "$_status" "$_expected" "$_path"
+              # Tolerate 5-column input from older callers — fall back
+              # to `required` so the table still renders sensibly.
+              [[ -n "$_crit" ]] || _crit="required"
+              printf '%-26s %-10s %-14s %-30s %s\n' \
+                "$_name" "$_status" "$_crit" "$_expected" "$_path"
             done <<<"$_iso_check_out"
             printf '%s\n' "------------------------------------------------------------------"
             if (( _iso_rc == 0 )); then
-              echo "All required rows: ok"
+              if [[ "$_iso_check_out" == *$'\tdegraded\t'* ]]; then
+                echo "All required rows: ok (some optional rows degraded)"
+                echo "Run with --strict-optional to fail on optional row degradation."
+              else
+                echo "All required rows: ok"
+              fi
             else
               echo "Drift detected. Repair with:"
               echo "  agent-bridge migrate isolation v2 --apply --agent $_iso_agent"

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -462,6 +462,60 @@ def link_source_node_modules(source_path: Path, cache_version_path: Path) -> tup
     return "linked", str(cache_node_modules)
 
 
+def _verify_cache_version_path(
+    cache_version_path: Path, source_path: Path
+) -> tuple[bool, str]:
+    """Post-link verification under the running UID.
+
+    The Python process already runs as the isolated UID (bridge-start
+    wraps the whole bridge-run.sh session under `sudo -n -u <os_user> -H`
+    for linux-user-isolated agents — see bridge-start.sh:447). So an
+    `os.access` probe here measures what the isolated agent will actually
+    see when it tries to read the cache version directory.
+
+    Returns (ok, reason). reason is empty when ok=True. v0.9.7 RC6:
+    success labels (`linked-verified`, `updated-verified`,
+    `unchanged-verified`) MUST NOT be emitted unless this returns True.
+    The previous linker logged `linked-OK` based purely on the symlink
+    existing, even when the dest dir was unreadable for the isolated UID
+    or never created — that silent success is exactly the bug RC6 names.
+    """
+    try:
+        if not source_path.exists():
+            return False, f"source-missing:{source_path}"
+    except OSError as exc:
+        return False, f"source-stat-failed:{exc}"
+
+    if not os.access(str(source_path), os.R_OK):
+        return False, f"source-unreadable:{source_path}"
+
+    try:
+        resolved = cache_version_path.resolve()
+    except OSError as exc:
+        return False, f"cache-resolve-failed:{exc}"
+
+    if not resolved.is_dir():
+        return False, f"cache-version-dir-missing:{cache_version_path}"
+
+    if not os.access(str(resolved), os.R_OK):
+        return False, f"cache-version-dir-unreadable:{cache_version_path}"
+
+    # Every parent dir must be traversable for the isolated UID, otherwise
+    # the agent process can resolve the symlink but cannot enter the cache.
+    parent = resolved.parent
+    while True:
+        try:
+            if not os.access(str(parent), os.X_OK):
+                return False, f"parent-not-traversable:{parent}"
+        except OSError as exc:
+            return False, f"parent-access-failed:{parent}:{exc}"
+        if parent == parent.parent:
+            break
+        parent = parent.parent
+
+    return True, ""
+
+
 def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
     marketplace_name, plugins = load_marketplace(root)
 
@@ -485,12 +539,23 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
     source_rel = metadata.get("source") or ""
     version = metadata.get("version") or "0.1.0"
     source_path = (root / source_rel).resolve()
+    # RC6 pre-link assertion: source path must exist AND be readable by
+    # the running UID (which is the isolated agent UID under sudo wrap).
+    # The previous linker only checked existence; an unreadable source
+    # (group/ACL drift) would still log success.
     if not source_path.exists():
         return {
             "channel": channel,
             "plugin": plugin_name,
             "status": "missing",
             "reason": f"source-missing:{source_path}",
+        }
+    if not os.access(str(source_path), os.R_OK):
+        return {
+            "channel": channel,
+            "plugin": plugin_name,
+            "status": "install-failed",
+            "reason": f"source-unreadable:{source_path}",
         }
 
     # Defense-in-depth: every component about to be joined into the
@@ -517,35 +582,52 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
     orphan_removed = 0
     cache_type = "missing"
 
-    if cache_version_path.is_symlink():
-        current_target = cache_version_path.resolve()
-        if current_target == source_path:
-            status = "unchanged"
-        else:
-            cache_version_path.unlink(missing_ok=True)
-            cache_version_path.symlink_to(source_path, target_is_directory=True)
-            status = "updated"
-        cache_type = "symlink"
-    else:
-        if cache_version_path.is_dir():
-            # Real cache directories carry installed dependencies. Overlay source
-            # files (everything except node_modules) so operator edits reach the
-            # cache, while preserving the cache's installed node_modules dir. The
-            # source root's node_modules is then linked back to the cache below.
-            changed = overlay_source_to_cache(source_path, cache_version_path)
-            status = "updated" if changed else "unchanged"
-            cache_type = "directory"
-        elif cache_version_path.exists():
-            remove_tree(cache_version_path)
-            status = "updated"
+    try:
+        if cache_version_path.is_symlink():
+            current_target = cache_version_path.resolve()
+            if current_target == source_path:
+                status = "unchanged"
+            else:
+                cache_version_path.unlink(missing_ok=True)
+                cache_version_path.symlink_to(source_path, target_is_directory=True)
+                status = "updated"
             cache_type = "symlink"
-            plugin_cache_root.mkdir(parents=True, exist_ok=True)
-            cache_version_path.symlink_to(source_path, target_is_directory=True)
         else:
-            status = "linked"
-            cache_type = "symlink"
-            plugin_cache_root.mkdir(parents=True, exist_ok=True)
-            cache_version_path.symlink_to(source_path, target_is_directory=True)
+            if cache_version_path.is_dir():
+                # Real cache directories carry installed dependencies. Overlay source
+                # files (everything except node_modules) so operator edits reach the
+                # cache, while preserving the cache's installed node_modules dir. The
+                # source root's node_modules is then linked back to the cache below.
+                changed = overlay_source_to_cache(source_path, cache_version_path)
+                status = "updated" if changed else "unchanged"
+                cache_type = "directory"
+            elif cache_version_path.exists():
+                remove_tree(cache_version_path)
+                status = "updated"
+                cache_type = "symlink"
+                plugin_cache_root.mkdir(parents=True, exist_ok=True)
+                cache_version_path.symlink_to(source_path, target_is_directory=True)
+            else:
+                status = "linked"
+                cache_type = "symlink"
+                plugin_cache_root.mkdir(parents=True, exist_ok=True)
+                cache_version_path.symlink_to(source_path, target_is_directory=True)
+    except OSError as exc:
+        # Filesystem refused the install action — fail loud, do not
+        # fall through to a verified label. RC6 root cause was the
+        # opposite: actions silently failed and the linker still
+        # printed success.
+        return {
+            "channel": channel,
+            "plugin": plugin_name,
+            "marketplace": marketplace_name,
+            "version": version,
+            "source": str(source_path),
+            "cache": str(cache_version_path),
+            "cache_type": cache_type,
+            "status": "install-failed",
+            "reason": f"install-error:{exc}",
+        }
 
     if plugin_cache_root.exists():
         for marker in plugin_cache_root.rglob(".orphaned_at"):
@@ -553,6 +635,35 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             orphan_removed += 1
 
     node_modules_status, node_modules_target = link_source_node_modules(source_path, cache_version_path)
+
+    # RC6 post-link verification: a successful install action does not
+    # imply a usable cache for the isolated agent. We must verify under
+    # the running UID before promoting the status to a `*-verified`
+    # label. Failure relabels to `linked-failed` with a structured
+    # reason and the criticality split decides block vs warn.
+    verified, verify_reason = _verify_cache_version_path(cache_version_path, source_path)
+    if not verified:
+        return {
+            "channel": channel,
+            "plugin": plugin_name,
+            "marketplace": marketplace_name,
+            "version": version,
+            "source": str(source_path),
+            "cache": str(cache_version_path),
+            "cache_type": cache_type,
+            "status": "linked-failed",
+            "reason": verify_reason,
+            "node_modules_status": node_modules_status,
+            "node_modules_target": node_modules_target,
+            "orphan_removed": str(orphan_removed),
+        }
+
+    # Success path: relabel `linked` → `linked-verified`,
+    # `updated` → `updated-verified`, `unchanged` → `unchanged-verified`.
+    # Operators (and the bridge-run audit tail) rely on the `-verified`
+    # suffix to distinguish v0.9.7 RC6-fixed output from the older
+    # `linked-OK` lying-success line.
+    verified_status = f"{status}-verified"
 
     return {
         "channel": channel,
@@ -562,11 +673,31 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
         "source": str(source_path),
         "cache": str(cache_version_path),
         "cache_type": cache_type,
-        "status": status,
+        "status": verified_status,
         "node_modules_status": node_modules_status,
         "node_modules_target": node_modules_target,
         "orphan_removed": str(orphan_removed),
     }
+
+
+_VERIFIED_STATUSES = frozenset(
+    {"linked-verified", "updated-verified", "unchanged-verified"}
+)
+_BENIGN_STATUSES = frozenset({"ignored"})
+
+
+def _is_required_channel(channel: str, required: set[str]) -> bool:
+    """Return True when this channel should block on failure (Q4 split).
+
+    A channel is required when its full `plugin:<name>@<marketplace>`
+    string was passed in `--required-channels`, OR (back-compat) when
+    `--required-channels` is empty (legacy callers that don't yet pass
+    the split treat every channel as required, matching pre-v0.9.7
+    behavior of the bridge-run sync helper).
+    """
+    if not required:
+        return True
+    return channel in required
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -575,36 +706,136 @@ def main(argv: list[str] | None = None) -> int:
 
     sync_parser = sub.add_parser("sync")
     sync_parser.add_argument("--channels", required=True)
+    # v0.9.7 RC6 (Q4 decision): channel-required plugin failure must
+    # block bridge-start; optional plugin failure must warn and continue.
+    # The caller (bridge-run.sh) computes the two sets from
+    # `bridge_agent_effective_dev_channels_csv` and `BRIDGE_AGENT_PLUGINS`
+    # respectively and passes them as separate args. Defaulting both to
+    # empty preserves the pre-RC6 caller contract: with no split the
+    # linker treats every channel as required (block-on-fail), which
+    # matches the legacy bridge-run behavior of `bridge_warn` + return.
+    sync_parser.add_argument(
+        "--required-channels",
+        default="",
+        help=(
+            "CSV of channel-required plugin: entries (failure blocks "
+            "bridge-start). Default empty = treat every --channels item "
+            "as required (back-compat)."
+        ),
+    )
+    sync_parser.add_argument(
+        "--optional-channels",
+        default="",
+        help=(
+            "CSV of optional plugin: entries (failure warns and "
+            "continues). Items in this set are demoted to non-fatal "
+            "even if also listed in --channels."
+        ),
+    )
     sync_parser.add_argument("--root", default=str(repo_root()))
     sync_parser.add_argument("--json", action="store_true")
+    sync_parser.add_argument(
+        "--agent",
+        default="",
+        help="Agent name for log lines (operator-visible context).",
+    )
 
     args = parser.parse_args(argv)
     if args.command != "sync":
         return 1
 
     root = Path(args.root).expanduser().resolve()
+    required_set = set(normalize_channels(args.required_channels))
+    optional_set = set(normalize_channels(args.optional_channels))
+    # Optional always wins over required when an entry appears in both
+    # (operator listed the same plugin in BRIDGE_AGENT_CHANNELS and
+    # BRIDGE_AGENT_PLUGINS — treat the more lenient declaration as the
+    # binding one, since the operator explicitly opted into the
+    # warn-and-continue mode for that plugin).
+    required_set -= optional_set
+    agent_label = args.agent or "-"
+
     results = [
         sync_plugin_cache(resolve_marketplace_root(root, item), item)
         for item in normalize_channels(args.channels)
     ]
+
+    # Tag each result with criticality so the downstream reporter and
+    # exit-code logic can apply the Q4 split uniformly.
+    required_failures: list[dict[str, str]] = []
+    optional_failures: list[dict[str, str]] = []
+    for item in results:
+        channel = item.get("channel", "")
+        status = item.get("status", "unknown")
+        if channel in optional_set:
+            criticality = "optional"
+        elif _is_required_channel(channel, required_set):
+            criticality = "channel-required"
+        else:
+            criticality = "optional"
+        item["criticality"] = criticality
+
+        if status in _VERIFIED_STATUSES or status in _BENIGN_STATUSES:
+            continue
+        if criticality == "channel-required":
+            required_failures.append(item)
+        else:
+            optional_failures.append(item)
+
     if args.json:
-        json.dump({"results": results}, sys.stdout, ensure_ascii=False)
+        json.dump(
+            {
+                "results": results,
+                "agent": args.agent,
+                "required_failure_count": len(required_failures),
+                "optional_failure_count": len(optional_failures),
+            },
+            sys.stdout,
+            ensure_ascii=False,
+        )
         sys.stdout.write("\n")
-        return 0
+        # JSON callers still get the criticality-aware exit code so a
+        # programmatic consumer (bridge-run.sh) can branch identically
+        # whether or not it asked for human or JSON output.
+        return 1 if required_failures else 0
 
     for item in results:
         status = item.get("status", "unknown")
         plugin = item.get("plugin") or item.get("channel") or "-"
-        if status in {"linked", "updated", "unchanged"}:
+        criticality = item.get("criticality", "channel-required")
+        if status in _VERIFIED_STATUSES:
             print(
                 f"{plugin}: {status} cache={item.get('cache','-')} source={item.get('source','-')} "
                 f"node_modules={item.get('node_modules_status','-')} "
                 f"node_modules_target={item.get('node_modules_target','-') or '-'} "
-                f"orphan_removed={item.get('orphan_removed','0')}"
+                f"orphan_removed={item.get('orphan_removed','0')} "
+                f"criticality={criticality}"
             )
-        else:
+        elif status in _BENIGN_STATUSES:
             print(f"{plugin}: {status} ({item.get('reason','-')})")
-    return 0
+        else:
+            # Failure line — tag with criticality so the operator (and
+            # bridge-run audit) can tell `WARNING (optional)` apart from
+            # `ERROR (channel-required)` at a glance.
+            tag = "ERROR" if criticality == "channel-required" else "WARNING"
+            print(
+                f"{tag} {plugin}: {status} ({item.get('reason','-')}) "
+                f"criticality={criticality} agent={agent_label}"
+            )
+
+    if optional_failures and not required_failures:
+        # Q4 decision: optional plugin failures warn and continue. Emit
+        # one summary line per failed optional plugin so the operator
+        # sees `launched without it` in the launch log even when no
+        # ERROR line drew their attention to the per-plugin block above.
+        for item in optional_failures:
+            plugin = item.get("plugin") or item.get("channel") or "-"
+            print(
+                f"WARNING: plugin {plugin} missing for agent {agent_label}, "
+                f"launched without it"
+            )
+
+    return 1 if required_failures else 0
 
 
 if __name__ == "__main__":

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -822,12 +822,16 @@ def main(argv: list[str] | None = None) -> int:
     root = Path(args.root).expanduser().resolve()
     required_set = set(normalize_channels(args.required_channels))
     optional_set = set(normalize_channels(args.optional_channels))
-    # Optional always wins over required when an entry appears in both
-    # (operator listed the same plugin in BRIDGE_AGENT_CHANNELS and
-    # BRIDGE_AGENT_PLUGINS — treat the more lenient declaration as the
-    # binding one, since the operator explicitly opted into the
-    # warn-and-continue mode for that plugin).
-    required_set -= optional_set
+    # r5 codex catch (BLOCKING) — channel-required wins over optional
+    # when a plugin appears in BOTH lists. The earlier ordering had
+    # optional winning, which violated the original PR 2 spec
+    # ("channel-required = block, optional = warn+continue; both lists
+    # = channel-required is critical path"). Channel membership
+    # (BRIDGE_AGENT_CHANNELS=plugin:teams) means messages flow through
+    # that plugin — silently launching without it kills inbound
+    # delivery. Subtract required from optional so that any overlap
+    # is treated as channel-required.
+    optional_set -= required_set
     agent_label = args.agent or "-"
 
     results = [
@@ -842,10 +846,17 @@ def main(argv: list[str] | None = None) -> int:
     for item in results:
         channel = item.get("channel", "")
         status = item.get("status", "unknown")
-        if channel in optional_set:
-            criticality = "optional"
-        elif _is_required_channel(channel, required_set):
+        # r5 — channel-required check FIRST so a plugin that appears
+        # in both BRIDGE_AGENT_CHANNELS and BRIDGE_AGENT_PLUGINS is
+        # classified as channel-required (the criticality that means
+        # block-on-failure). Subtraction above already removed the
+        # overlap from optional_set, but order the explicit check
+        # defensively so future changes to set semantics don't flip
+        # the contract.
+        if _is_required_channel(channel, required_set):
             criticality = "channel-required"
+        elif channel in optional_set:
+            criticality = "optional"
         else:
             criticality = "optional"
         item["criticality"] = criticality

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -405,18 +405,29 @@ def _copy_file_if_changed(src: Path, dst: Path) -> bool:
 
 
 def _overlay_dir(src: Path, dst: Path) -> bool:
-    """Recursively overlay src onto dst. Returns True if anything was written."""
+    """Recursively overlay src onto dst. Returns True if anything was written.
+
+    r4 codex catch — entries that are symlinks-to-directory (created
+    accidentally by the r1/r2 link_source_node_modules path) were
+    matched by the `entry.is_symlink() or entry.is_file()` arm and sent
+    to shutil.copy2, producing a corrupt or absent cache. is_dir()
+    returns True for symlinks-to-directory because pathlib stats the
+    resolved target, so test for is_dir() FIRST and recurse through
+    the symlink — this materializes the dependency tree into the
+    cache as a real directory copy regardless of whether source's
+    node_modules is a symlink (r1/r2 leftover) or a real dir.
+    """
     changed = False
     if dst.exists() and not dst.is_dir():
         remove_tree(dst)
     dst.mkdir(parents=True, exist_ok=True)
     for entry in src.iterdir():
         target = dst / entry.name
-        if entry.is_symlink() or entry.is_file():
-            if _copy_file_if_changed(entry, target):
-                changed = True
-        elif entry.is_dir():
+        if entry.is_dir():  # includes symlinks-to-directory (resolved-stat)
             if _overlay_dir(entry, target):
+                changed = True
+        elif entry.is_file() or entry.is_symlink():
+            if _copy_file_if_changed(entry, target):
                 changed = True
     return changed
 
@@ -437,11 +448,14 @@ def overlay_source_to_cache(source_path: Path, cache_version_path: Path) -> bool
     changed = False
     for entry in source_path.iterdir():
         target = cache_version_path / entry.name
-        if entry.is_symlink() or entry.is_file():
-            if _copy_file_if_changed(entry, target):
-                changed = True
-        elif entry.is_dir():
+        # r4 codex catch — is_dir() FIRST so symlinks-to-directory are
+        # materialized into the cache as a real directory copy. Old
+        # ordering matched is_symlink first → shutil.copy2 → corrupt cache.
+        if entry.is_dir():
             if _overlay_dir(entry, target):
+                changed = True
+        elif entry.is_file() or entry.is_symlink():
+            if _copy_file_if_changed(entry, target):
                 changed = True
     return changed
 
@@ -605,7 +619,13 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             # into a real directory. Unlink the symlink, then mkdir +
             # overlay source so the cache is genuinely per-agent.
             cache_version_path.unlink(missing_ok=True)
+            # r4 codex Probe 7 — also chmod parent dirs to 0700 so a
+            # default umask (0o022) does not leave the marketplace +
+            # plugin level world-readable above the per-version cache.
             plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            plugin_cache_root.chmod(0o700)
+            if plugin_cache_root.parent != cache_root() and plugin_cache_root.parent.exists():
+                plugin_cache_root.parent.chmod(0o700)
             cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
             cache_version_path.chmod(0o700)  # explicit, defensive against umask
             overlay_source_to_cache(source_path, cache_version_path)
@@ -624,7 +644,13 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             # Stray non-directory entry (file, special) — remove and
             # rebuild as real directory.
             remove_tree(cache_version_path)
+            # r4 codex Probe 7 — also chmod parent dirs to 0700 so a
+            # default umask (0o022) does not leave the marketplace +
+            # plugin level world-readable above the per-version cache.
             plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            plugin_cache_root.chmod(0o700)
+            if plugin_cache_root.parent != cache_root() and plugin_cache_root.parent.exists():
+                plugin_cache_root.parent.chmod(0o700)
             cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
             cache_version_path.chmod(0o700)  # explicit, defensive against umask
             overlay_source_to_cache(source_path, cache_version_path)
@@ -633,7 +659,13 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
         else:
             # First-time install — create the per-agent directory and
             # overlay source files into it.
+            # r4 codex Probe 7 — also chmod parent dirs to 0700 so a
+            # default umask (0o022) does not leave the marketplace +
+            # plugin level world-readable above the per-version cache.
             plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            plugin_cache_root.chmod(0o700)
+            if plugin_cache_root.parent != cache_root() and plugin_cache_root.parent.exists():
+                plugin_cache_root.parent.chmod(0o700)
             cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
             cache_version_path.chmod(0o700)  # explicit, defensive against umask
             overlay_source_to_cache(source_path, cache_version_path)

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -422,11 +422,20 @@ def _overlay_dir(src: Path, dst: Path) -> bool:
 
 
 def overlay_source_to_cache(source_path: Path, cache_version_path: Path) -> bool:
-    """Mirror source files (except node_modules) onto cache. Returns True if changed."""
+    """Mirror EVERYTHING from source onto cache, including node_modules.
+
+    r3 codex catch — earlier overlay skipped node_modules and
+    link_source_node_modules then symlinked source/node_modules → cache,
+    which (a) modified the SOURCE tree (unsafe, source-of-truth must
+    stay clean) and (b) made every agent's sync race over the same
+    source/node_modules pointer (cross-agent collision). The fix is to
+    treat the cache as a fully self-contained per-agent snapshot:
+    copy node_modules into the cache too. Disk overhead is bounded by
+    the plugin's installed dependency tree per agent (operator
+    acknowledged 100-300 MB / agent in design v2).
+    """
     changed = False
     for entry in source_path.iterdir():
-        if entry.name == NODE_MODULES_NAME:
-            continue
         target = cache_version_path / entry.name
         if entry.is_symlink() or entry.is_file():
             if _copy_file_if_changed(entry, target):
@@ -597,7 +606,8 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             # overlay source so the cache is genuinely per-agent.
             cache_version_path.unlink(missing_ok=True)
             plugin_cache_root.mkdir(parents=True, exist_ok=True)
-            cache_version_path.mkdir(parents=False, exist_ok=False)
+            cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
+            cache_version_path.chmod(0o700)  # explicit, defensive against umask
             overlay_source_to_cache(source_path, cache_version_path)
             status = "updated"
             cache_type = "directory"
@@ -615,7 +625,8 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             # rebuild as real directory.
             remove_tree(cache_version_path)
             plugin_cache_root.mkdir(parents=True, exist_ok=True)
-            cache_version_path.mkdir(parents=False, exist_ok=False)
+            cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
+            cache_version_path.chmod(0o700)  # explicit, defensive against umask
             overlay_source_to_cache(source_path, cache_version_path)
             status = "updated"
             cache_type = "directory"
@@ -623,7 +634,8 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             # First-time install — create the per-agent directory and
             # overlay source files into it.
             plugin_cache_root.mkdir(parents=True, exist_ok=True)
-            cache_version_path.mkdir(parents=False, exist_ok=False)
+            cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
+            cache_version_path.chmod(0o700)  # explicit, defensive against umask
             overlay_source_to_cache(source_path, cache_version_path)
             status = "linked"
             cache_type = "directory"
@@ -649,7 +661,23 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             marker.unlink(missing_ok=True)
             orphan_removed += 1
 
-    node_modules_status, node_modules_target = link_source_node_modules(source_path, cache_version_path)
+    # r3 codex catch — link_source_node_modules MODIFIED the source's
+    # node_modules entry, making every agent's sync race over the same
+    # source pointer (cross-agent collision). The new overlay path
+    # above includes node_modules in the cache itself, so the cache is
+    # genuinely self-contained per-agent. We retain the status report
+    # for backward compat (downstream readers parse the field) but
+    # derive it from the cache's own node_modules now.
+    cache_node_modules = cache_version_path / "node_modules"
+    if cache_node_modules.is_dir():
+        node_modules_status = "present"
+        node_modules_target = str(cache_node_modules)
+    elif cache_node_modules.exists():
+        node_modules_status = "not-directory"
+        node_modules_target = str(cache_node_modules)
+    else:
+        node_modules_status = "missing"
+        node_modules_target = ""
 
     # RC6 post-link verification: a successful install action does not
     # imply a usable cache for the isolated agent. We must verify under

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -761,18 +761,30 @@ _VERIFIED_STATUSES = frozenset(
 _BENIGN_STATUSES = frozenset({"ignored"})
 
 
-def _is_required_channel(channel: str, required: set[str]) -> bool:
+def _is_required_channel(channel: str, required: set[str], optional: set[str]) -> bool:
     """Return True when this channel should block on failure (Q4 split).
 
-    A channel is required when its full `plugin:<name>@<marketplace>`
-    string was passed in `--required-channels`, OR (back-compat) when
-    `--required-channels` is empty (legacy callers that don't yet pass
-    the split treat every channel as required, matching pre-v0.9.7
-    behavior of the bridge-run sync helper).
+    Decision tree:
+      1. channel ∈ required (operator listed in BRIDGE_AGENT_CHANNELS) → required.
+      2. channel ∈ optional (BRIDGE_AGENT_PLUGINS only) → NOT required.
+      3. Both sets EMPTY (legacy caller without splits) → required (back-compat
+         with pre-v0.9.7 bridge-run sync helper).
+      4. Operator declared splits but this channel is in neither (e.g. orphan
+         from --channels but absent from both --required and --optional) →
+         NOT required (conservative; don't block on unlisted plugins).
+
+    r6 codex catch — earlier signature only took `required` and returned
+    True when `not required`, but with the r5 classification reorder
+    that empty-required fallback fired EVEN when --optional-channels
+    was non-empty, demoting genuinely optional plugins to channel-required.
     """
-    if not required:
+    if channel in required:
         return True
-    return channel in required
+    if channel in optional:
+        return False
+    if not required and not optional:
+        return True
+    return False
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -846,17 +858,13 @@ def main(argv: list[str] | None = None) -> int:
     for item in results:
         channel = item.get("channel", "")
         status = item.get("status", "unknown")
-        # r5 — channel-required check FIRST so a plugin that appears
-        # in both BRIDGE_AGENT_CHANNELS and BRIDGE_AGENT_PLUGINS is
-        # classified as channel-required (the criticality that means
-        # block-on-failure). Subtraction above already removed the
-        # overlap from optional_set, but order the explicit check
-        # defensively so future changes to set semantics don't flip
-        # the contract.
-        if _is_required_channel(channel, required_set):
+        # r5/r6 — pass BOTH sets so the helper can distinguish:
+        #   in required → channel-required (block)
+        #   in optional → optional (warn)
+        #   neither + both empty → channel-required (legacy back-compat)
+        #   neither + at least one set populated → optional (conservative)
+        if _is_required_channel(channel, required_set, optional_set):
             criticality = "channel-required"
-        elif channel in optional_set:
-            criticality = "optional"
         else:
             criticality = "optional"
         item["criticality"] = criticality

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -583,35 +583,50 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
     cache_type = "missing"
 
     try:
+        # r2 codex catch — operator's binding principle is per-agent
+        # isolated cache. r1 implementation used symlink to source which
+        # made each agent's distinct cache *path* resolve to the same
+        # *target*: cross-agent interference on writes, modifications
+        # to the source visible to every agent. Replace symlink with
+        # real per-agent directory (overlay copy of source into the
+        # isolated home). Disk overhead 100-300 MB per agent acknowledged
+        # in design v2 §"Per-Agent Cache Tradeoffs".
         if cache_version_path.is_symlink():
-            current_target = cache_version_path.resolve()
-            if current_target == source_path:
-                status = "unchanged"
-            else:
-                cache_version_path.unlink(missing_ok=True)
-                cache_version_path.symlink_to(source_path, target_is_directory=True)
-                status = "updated"
-            cache_type = "symlink"
+            # Migrate any pre-existing symlink (from r1 or v0.9.6 install)
+            # into a real directory. Unlink the symlink, then mkdir +
+            # overlay source so the cache is genuinely per-agent.
+            cache_version_path.unlink(missing_ok=True)
+            plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            cache_version_path.mkdir(parents=False, exist_ok=False)
+            overlay_source_to_cache(source_path, cache_version_path)
+            status = "updated"
+            cache_type = "directory"
+        elif cache_version_path.is_dir():
+            # Already a real per-agent directory. Overlay source files
+            # (except node_modules) so operator edits to source reach
+            # the cache, while preserving the cache's installed
+            # node_modules dir. The source root's node_modules is then
+            # linked back to the cache below.
+            changed = overlay_source_to_cache(source_path, cache_version_path)
+            status = "updated" if changed else "unchanged"
+            cache_type = "directory"
+        elif cache_version_path.exists():
+            # Stray non-directory entry (file, special) — remove and
+            # rebuild as real directory.
+            remove_tree(cache_version_path)
+            plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            cache_version_path.mkdir(parents=False, exist_ok=False)
+            overlay_source_to_cache(source_path, cache_version_path)
+            status = "updated"
+            cache_type = "directory"
         else:
-            if cache_version_path.is_dir():
-                # Real cache directories carry installed dependencies. Overlay source
-                # files (everything except node_modules) so operator edits reach the
-                # cache, while preserving the cache's installed node_modules dir. The
-                # source root's node_modules is then linked back to the cache below.
-                changed = overlay_source_to_cache(source_path, cache_version_path)
-                status = "updated" if changed else "unchanged"
-                cache_type = "directory"
-            elif cache_version_path.exists():
-                remove_tree(cache_version_path)
-                status = "updated"
-                cache_type = "symlink"
-                plugin_cache_root.mkdir(parents=True, exist_ok=True)
-                cache_version_path.symlink_to(source_path, target_is_directory=True)
-            else:
-                status = "linked"
-                cache_type = "symlink"
-                plugin_cache_root.mkdir(parents=True, exist_ok=True)
-                cache_version_path.symlink_to(source_path, target_is_directory=True)
+            # First-time install — create the per-agent directory and
+            # overlay source files into it.
+            plugin_cache_root.mkdir(parents=True, exist_ok=True)
+            cache_version_path.mkdir(parents=False, exist_ok=False)
+            overlay_source_to_cache(source_path, cache_version_path)
+            status = "linked"
+            cache_type = "directory"
     except OSError as exc:
         # Filesystem refused the install action — fail loud, do not
         # fall through to a verified label. RC6 root cause was the

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -449,27 +449,89 @@ bridge_run_schedule_dev_channels_accept() {
 }
 
 bridge_run_sync_dev_plugin_cache() {
-  local channels=""
+  # v0.9.7 RC6 (refs #781): the Python linker is now criticality-aware.
+  # Channel-required plugin failures (declared via BRIDGE_AGENT_CHANNELS=
+  # plugin:<id>) must block bridge-start; BRIDGE_AGENT_PLUGINS optional
+  # plugin failures warn and continue. The split is computed here and
+  # passed to Python via --required-channels / --optional-channels.
+  #
+  # Channels passed as --channels remain the union (effective dev
+  # channels), so the linker can sync everything in one pass; the
+  # criticality split only affects logging label (ERROR vs WARNING)
+  # and the Python exit code.
+  #
+  # Returns:
+  #   0 — all channel-required plugins verified (optional warnings OK)
+  #   non-zero — at least one channel-required plugin failed (block)
+  local channels="" required_channels="" optional_csv=""
   local output=""
   local line=""
+  local rc=0
 
   [[ "$ENGINE" == "claude" ]] || return 0
   [[ $SAFE_MODE -eq 0 ]] || return 0
   channels="$(bridge_agent_effective_dev_channels_csv "$AGENT")"
   [[ -n "$channels" ]] || return 0
 
-  if output="$(python3 "$SCRIPT_DIR/bridge-dev-plugin-cache.py" sync --channels "$channels" 2>&1)"; then
-    while IFS= read -r line; do
-      [[ -n "$line" ]] || continue
-      log_line "[dev-plugin-cache] $line"
-    done <<<"$output"
-  else
-    while IFS= read -r line; do
-      [[ -n "$line" ]] || continue
-      log_line "[dev-plugin-cache] $line"
-    done <<<"$output"
-    bridge_warn "development plugin cache sync failed for ${AGENT}"
+  # Required: every plugin: channel from the effective channel set.
+  # These come from BRIDGE_AGENT_CHANNELS — primary-channel config.
+  required_channels="$channels"
+
+  # Optional: BRIDGE_AGENT_PLUGINS allowlist entries (#272). These are
+  # bare plugin ids; qualify them with the agent-bridge marketplace so
+  # the Python comparator (which sees full plugin:<id>@<mkt> strings)
+  # can match. Items already in the channels CSV are also marked
+  # optional here — the Python side takes the lenient declaration as
+  # binding when both lists overlap.
+  optional_csv="$(bridge_agent_plugins_csv "$AGENT" 2>/dev/null || true)"
+  if [[ -n "$optional_csv" ]]; then
+    local _opt_qualified="" _opt_token="" _opt_item=""
+    local IFS_orig="$IFS"
+    IFS=','
+    # shellcheck disable=SC2206 # intentional split on `,`.
+    local -a _opt_arr=( $optional_csv )
+    IFS="$IFS_orig"
+    for _opt_token in "${_opt_arr[@]}"; do
+      _opt_token="${_opt_token## }"
+      _opt_token="${_opt_token%% }"
+      [[ -n "$_opt_token" ]] || continue
+      if [[ "$_opt_token" == *"@"* ]]; then
+        _opt_item="plugin:${_opt_token}"
+      else
+        _opt_item="plugin:${_opt_token}@agent-bridge"
+      fi
+      if [[ -n "$_opt_qualified" ]]; then
+        _opt_qualified+=",$_opt_item"
+      else
+        _opt_qualified="$_opt_item"
+      fi
+    done
+    optional_csv="$_opt_qualified"
   fi
+
+  output="$(python3 "$SCRIPT_DIR/bridge-dev-plugin-cache.py" sync \
+    --channels "$channels" \
+    --required-channels "$required_channels" \
+    --optional-channels "${optional_csv:-}" \
+    --agent "$AGENT" \
+    2>&1)" || rc=$?
+
+  while IFS= read -r line; do
+    [[ -n "$line" ]] || continue
+    log_line "[dev-plugin-cache] $line"
+  done <<<"$output"
+
+  if (( rc != 0 )); then
+    # Required-plugin failure — surface with bridge_warn AND propagate
+    # the non-zero exit upstream. bridge-run.sh's caller (bridge-start.sh
+    # via the sudo wrap) needs the non-zero status to block launch per
+    # the Q4 channel-required criticality decision. The legacy code
+    # path swallowed this with `bridge_warn` only and let the launch
+    # continue — which is exactly the silent-failure shape RC6 names.
+    bridge_warn "development plugin cache sync failed for ${AGENT} (channel-required plugin missing/unverified)"
+    return "$rc"
+  fi
+  return 0
 }
 
 bridge_run_safe_mode_resume_hint() {
@@ -551,7 +613,25 @@ while true; do
   local_launch_cmd_display="$(bridge_redact_inline_env_secrets "$LAUNCH_CMD")"
 
   if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
-    bridge_run_sync_dev_plugin_cache
+    # v0.9.7 RC6 (refs #781): channel-required plugin sync failure must
+    # block the launch — the agent is being started for that channel
+    # and an isolated-UID-unreadable cache directory means MCP servers
+    # never surface (which is exactly the silent-failure shape the RC6
+    # bug report names). Optional plugin failures are non-fatal and do
+    # not flip the helper's exit code, so the launch proceeds normally
+    # for them.
+    if ! bridge_run_sync_dev_plugin_cache; then
+      bridge_audit_log state dev_plugin_cache_blocked_launch "$AGENT" \
+        --field reason="channel-required plugin missing or unverified" \
+        >/dev/null 2>&1 || true
+      log_line "[error] aborting launch: channel-required plugin cache failed for ${AGENT}"
+      log_line "[error] repair with: agent-bridge isolation verify --agent ${AGENT}"
+      # Exit non-zero so the sudo wrap (bridge-start.sh:447) propagates
+      # the failure to the operator. Without this, the loop would
+      # continue and the agent would launch missing the very channel it
+      # was started for.
+      exit 65
+    fi
     bridge_ensure_claude_launch_channel_plugins "$AGENT"
     bridge_run_schedule_dev_channels_accept "$LAUNCH_CMD"
     bridge_run_schedule_idle_marker_and_inbox_bootstrap "$previous_session_id"

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1356,6 +1356,97 @@ bridge_isolation_v2_matrix_rows_for_agent() {
   if [[ -n "$iso_home_root" ]]; then
     printf 'isolated-user-home|%s|dir|%s|%s|0700||0|install_managed|required|isolated UIDs private home\n' \
       "$iso_home" "$iso_user" "$iso_user"
+
+    # ----- v0.9.7 PR 2 (refs #781) RC6: per-agent plugin subsystem rows -----
+    #
+    # Per design v2 §"Per-agent plugin contract" / §"dev-plugin-cache
+    # linker contract", v0.9.7 abandons the v1 shared dev-plugin-cache
+    # design and replaces it with four per-agent rows under the isolated
+    # home. Operator's binding principle: each isolated agent installs
+    # its own plugins, logs in separately, and never shares cache or
+    # credentials with another agent. Anthropic controller credentials
+    # remain the only cross-agent shared secret (RC3 row above).
+    #
+    # All four rows use grant_mechanism `install_managed`: the matrix
+    # apply path does not create or chmod these — `bridge_linux_share_
+    # plugin_catalog` and `bridge-dev-plugin-cache.py` (running as the
+    # isolated UID under bridge-start.sh's sudo wrap) own creation.
+    # The matrix's job is to enumerate the rows so `agent-bridge
+    # isolation verify` and the upgrader's pre/post checks measure
+    # exactly what the agent will see at runtime.
+    #
+    # Criticality split (Q4 decision): rows tied to plugins are
+    # `optional` for agents that declare no plugins (a Codex agent
+    # with zero plugin: channels and zero BRIDGE_AGENT_PLUGINS does
+    # not need a cache directory at all). Verify reports those as
+    # degraded only and the CLI's `--strict-optional` flag escalates
+    # them to required when the operator wants every row enforced
+    # regardless of declaration.
+    local iso_plugins_root="${iso_home}/.claude/plugins"
+    local _v2_plugin_channels="" _v2_plugin_allowlist=""
+    _v2_plugin_channels="$(bridge_agent_channels_csv "$agent" 2>/dev/null || true)"
+    _v2_plugin_allowlist="$(bridge_agent_plugins_csv "$agent" 2>/dev/null || true)"
+    local _v2_plugin_criticality="optional"
+    if [[ "$_v2_plugin_channels" == *plugin:* ]] \
+        || [[ -n "$_v2_plugin_allowlist" ]]; then
+      _v2_plugin_criticality="required"
+    fi
+
+    # 1. Per-agent plugin runtime data (OAuth tokens, session state).
+    #    Lifecycle: created by bridge_linux_share_plugin_catalog at
+    #    lib/bridge-agents.sh:2007; preserved by unshare; removed only
+    #    by explicit agent removal. Mode 0700 because plugin secrets
+    #    live here and must NEVER be group-readable, including by the
+    #    agent's own ab-agent-<X> group.
+    printf 'isolated-plugin-data|%s/data|dir|%s|%s|0700||0|install_managed|%s|per-agent plugin runtime state and OAuth tokens (private to isolated UID)\n' \
+      "$iso_plugins_root" "$iso_user" "$iso_user" "$_v2_plugin_criticality"
+
+    # 2. Per-agent plugin credentials. This is the generic row covering
+    #    ms365 Microsoft Graph tokens, cosmax-crm OAuth, GitHub PATs,
+    #    Telegram bot tokens, Discord tokens, Teams app passwords, etc.
+    #    Plugin install code controls the exact filename — the matrix
+    #    just verifies the parent dir is private to the isolated UID.
+    #    Files inside take 0600 when the plugin manages mode; dirs take
+    #    0700. `install_managed` means matrix verify probes ownership
+    #    and traversal but does not enforce a specific file mode.
+    #    Same path as data/ today (per design v2 line 44 — credentials
+    #    live under data/<plugin>/ in the current implementation), but
+    #    the row is enumerated separately so a future split (e.g.
+    #    plugins/credentials/) lands in one matrix entry rather than
+    #    requiring all callers to track two paths.
+    printf 'isolated-plugin-credentials|%s/data|dir|%s|%s|0700||0|install_managed|%s|per-agent plugin credential files (ms365/cosmax-crm/GitHub PAT etc; mode 0600 for files when plugin owns mode)\n' \
+      "$iso_plugins_root" "$iso_user" "$iso_user" "$_v2_plugin_criticality"
+
+    # 3. Per-agent plugin manifests (installed_plugins.json,
+    #    known_marketplaces.json, marketplaces/). These are root-owned,
+    #    group-readable so the isolated UID can read but not modify.
+    #    `installPath` entries inside installed_plugins.json must
+    #    resolve to the per-agent cache row below — never to a shared
+    #    dev-plugin-cache (rejected by Q3) and never to another agent's
+    #    home. Verification of `installPath` resolution lives in
+    #    `bridge-dev-plugin-cache.py` post-link checks, not in the
+    #    bash matrix apply.
+    printf 'isolated-plugin-manifests|%s|dir|root|%s|2750||1|install_managed|%s|per-agent plugin manifests (installed_plugins.json + marketplaces/) — installPath must resolve under same isolated home\n' \
+      "$iso_plugins_root" "$agent_grp" "$_v2_plugin_criticality"
+
+    # 4. Per-agent plugin cache root. Per design v2 line 46 / Q3
+    #    decision: NOT a symlink to a shared cache directory. The cache
+    #    is materialized inside the isolated UID's own home by code
+    #    running as that UID (bridge-dev-plugin-cache.py via the
+    #    bridge-start.sh sudo wrap). Cache version dirs land under
+    #    cache/<marketplace>/<plugin>/<version>/ and inherit the
+    #    isolated UID:UID ownership. Mode 0700 because cache content
+    #    is operationally private to one agent.
+    #
+    #    A missing cache directory is NOT itself a launch blocker —
+    #    bridge-run.sh's RC6 sync step attempts to create it. Failure
+    #    of the sync attempt routes through the criticality split in
+    #    bridge-dev-plugin-cache.py: channel-required plugin failures
+    #    block, optional (BRIDGE_AGENT_PLUGINS) plugin failures warn
+    #    and continue. The matrix row enumerates the path so verify
+    #    can probe ownership/mode when the directory exists.
+    printf 'isolated-plugin-cache|%s/cache|dir|%s|%s|0700||0|install_managed|%s|per-agent plugin cache root (Q3 decision: NEVER a symlink to shared cache; created on demand by isolated UID)\n' \
+      "$iso_plugins_root" "$iso_user" "$iso_user" "$_v2_plugin_criticality"
   fi
   return 0
 }
@@ -1571,8 +1662,22 @@ bridge_isolation_v2_apply_grant_matrix_for_agent() {
     if [[ "$mode" == "check" ]]; then
       local status="ok" expected actual mode_part=""
       if (( row_rc != 0 )); then
-        status="mismatch"
-        rc=1
+        # v0.9.7 PR 2 (Q4 split): a row whose criticality is `optional`
+        # demotes mismatch to `degraded` and does NOT flip the overall
+        # exit code by default. The CLI's `--strict-optional` flag
+        # post-processes the rows it cares about (it sees the
+        # criticality column emitted below) and escalates `degraded` to
+        # `mismatch` when the operator wants strict enforcement. Keeping
+        # the demotion here means matrix-direct callers
+        # (apply_grant_matrix_for_agent invoked from migrate apply) get
+        # the same lenient default — they only fail the apply when a
+        # required row is broken.
+        if [[ "$r_crit" == "optional" || "$r_crit" == "not-applicable" ]]; then
+          status="degraded"
+        else
+          status="mismatch"
+          rc=1
+        fi
       fi
       if [[ -n "$r_dmode" && -n "$r_fmode" ]]; then
         mode_part="${r_dmode}/${r_fmode}"
@@ -1583,10 +1688,24 @@ bridge_isolation_v2_apply_grant_matrix_for_agent() {
       fi
       expected="$r_owner:$r_group${mode_part:+ }$mode_part"
       actual="$(bridge_isolation_v2_reapply_probe_owner_group_mode "$r_path" 2>/dev/null || printf 'unknown')"
-      printf '%s\t%s\t%s\t%s\t%s\n' "$r_name" "$r_path" "$status" "$expected" "$actual"
+      # v0.9.7 PR 2 (refs #781): emit the criticality as a 6th column
+      # so `agent-bridge isolation verify --strict-optional` can promote
+      # `degraded` rows to `mismatch` post-hoc without re-walking the
+      # matrix. Existing 5-column consumers (PR 1's verify output)
+      # tolerate the extra column because they read with `IFS=$'\t' read
+      # -r _name _path _status _expected _actual` — trailing fields are
+      # silently absorbed by the last variable in plain `read` only when
+      # there are MORE fields than vars; with `read -r a b c d e` the
+      # 6th field tail-attaches to `e`. Verify CLI is updated to read
+      # the 6th column explicitly so the criticality stays addressable.
+      printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$r_name" "$r_path" "$status" "$expected" "$actual" "$r_crit"
     elif (( row_rc != 0 )); then
-      bridge_warn "apply_grant_matrix_for_agent($agent): row $r_name failed at $r_path"
-      rc=1
+      if [[ "$r_crit" == "optional" || "$r_crit" == "not-applicable" ]]; then
+        bridge_warn "apply_grant_matrix_for_agent($agent): optional row $r_name degraded at $r_path (continuing)"
+      else
+        bridge_warn "apply_grant_matrix_for_agent($agent): row $r_name failed at $r_path"
+        rc=1
+      fi
     fi
   done < <(bridge_isolation_v2_matrix_rows_for_agent "$agent")
   return $rc


### PR DESCRIPTION
## Summary

PR 2 of v0.9.7 isolation grant matrix work. Builds on PR 1 (#782, main `a25c7991`).

Five surfaces touched:

1. **`bridge-dev-plugin-cache.py`** — RC6 silent-failure fix.
   - Pre-link assertion: source plugin path must exist AND be readable by the running UID (the isolated agent UID, since bridge-start.sh wraps the bridge-run session under `sudo -n -u <os_user> -H`).
   - Post-link verification: cache version dir must exist, be readable, and every parent traversable. Without this the linker logged `linked-OK` purely on the symlink existing — the bug RC6 names.
   - Success labels: `linked-verified` / `updated-verified` / `unchanged-verified` (only emitted after post-link verification passes). Failure labels: `linked-failed: <reason>` / `install-failed: <reason>`.
   - New `--required-channels` and `--optional-channels` args drive the Q4 criticality split. Exit non-zero only when a channel-required plugin fails (optional failures keep exit 0). Back-compat: with neither split arg every channel is treated as required.

2. **`bridge-run.sh`** — failure propagation.
   - `bridge_run_sync_dev_plugin_cache` now computes the required vs optional split and passes both lists to Python. `BRIDGE_AGENT_PLUGINS` allowlist items are qualified (`<id>` → `plugin:<id>@agent-bridge`) before passing.
   - Non-zero from Python aborts the run with `exit 65` so the sudo wrap propagates the failure to bridge-start. Audit log line `dev_plugin_cache_blocked_launch` records the block.

3. **`bridge-start.sh`** — no edit required. The existing `bridge_start_post_launch_verify` already polls for the tmux session disappearing and surfaces the agent log tail (which now contains the new `[error] aborting launch:` lines). Confirmed by reading the current behavior at `bridge-start.sh:540`.

4. **`lib/bridge-isolation-v2.sh`** — 4 new matrix rows + criticality column.
   - `isolated-plugin-data` (design v2 line 43): per-agent plugin runtime state. `0700`, `agent-bridge-<X>:agent-bridge-<X>`.
   - `isolated-plugin-credentials` (design v2 line 44): per-agent plugin credential files (ms365 / cosmax-crm / GitHub PAT etc).
   - `isolated-plugin-manifests` (design v2 line 45): root-owned, group-readable installed_plugins.json + marketplaces/.
   - `isolated-plugin-cache` (design v2 line 46): per-agent cache root. **NOT** a symlink into shared cache (Q3 decision).
   - All four use `install_managed` mechanism. Criticality is `required` when the agent declares plugin: channels or `BRIDGE_AGENT_PLUGINS`, `optional` otherwise.
   - `apply_grant_matrix_for_agent` now emits a 6th `criticality` column and demotes optional-row failures to status=`degraded` — they don't flip the overall exit code by default.

5. **`agent-bridge`** — `isolation verify --strict-optional` wired.
   - With the flag: any `degraded` row escalates to mismatch and the CLI exits non-zero.
   - Without it: only required-row mismatches flip the exit code.
   - JSON output adds `criticality` per row + top-level `strict_optional`.
   - Table output adds a CRITICALITY column. 5-col input from legacy callers tolerated.

Operator's binding principle (per design v2): each isolated agent installs own plugins, logs in separately. Shared cache violates this — cross-agent credential bleed-through risk.

## Test plan

- [x] `bash -n bridge-run.sh bridge-start.sh agent-bridge lib/bridge-isolation-v2.sh` — PASS
- [x] `shellcheck bridge-run.sh bridge-start.sh agent-bridge lib/bridge-isolation-v2.sh` — PASS
- [x] `python3 -c "import ast; ast.parse(open('bridge-dev-plugin-cache.py').read())"` — PASS
- [x] Isolated repro of `bridge-dev-plugin-cache.py sync` with mocked marketplace/plugin tree, 5 cases:
  - all required + present → both `linked-verified`, exit 0
  - one source missing, marked required → `ERROR ms365: missing` + exit 1 (block)
  - same source missing, marked optional → `WARNING ms365: missing` + `WARNING: plugin ms365 missing for agent <X>, launched without it` + exit 0 (continue)
  - JSON output: `required_failure_count` and `optional_failure_count` reflect the split correctly
  - back-compat: omitting `--required-channels` treats every channel as required
- [x] Isolated repro of `bridge_isolation_v2_matrix_rows_for_agent` with various plugin declarations — confirmed criticality flips `optional` ↔ `required` across all 4 new rows depending on `bridge_agent_channels_csv` and `bridge_agent_plugins_csv` output
- [x] `agent-bridge isolation verify --help` — confirms `--strict-optional` is documented (no longer "no-op in PR 1")
- [x] `./scripts/smoke-test.sh` — exits 1 on the dry-run redaction smoke step on **both** this branch and base `a25c7991`. Pre-existing failure (v2 layout fail-fast in fresh BRIDGE_HOME), not introduced by this PR.

## Out of scope (lands in PR 3)

- `bridge-upgrade.sh` convergence path
- `docs/agent-runtime/v2-isolation-migration.md` updates
- `KNOWN_ISSUES.md` updates
- Orbstack reproducer scripts
- `CHANGELOG.md` / `VERSION` bump (release PR — separate)

#781 stays open for PR 3. This PR uses `Refs #781` deliberately so the issue is not auto-closed by merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)