### PR TITLE
fix(cache): skip + warn on source/node_modules symlinks pointing outside source root (refs #786)

### DIFF
--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -404,7 +404,46 @@ def _copy_file_if_changed(src: Path, dst: Path) -> bool:
     return True
 
 
-def _overlay_dir(src: Path, dst: Path) -> bool:
+def _is_symlink_outside_source_root(entry: Path, source_root: Path) -> bool:
+    """True when ``entry`` is a symlink whose resolved target is outside ``source_root``.
+
+    v0.9.8 #786 Finding 1 — operator hosts that migrated from v0.7→v0.8
+    isolation often carry leftover ``source/node_modules`` symlinks that
+    point at the controller's plugin cache (e.g.
+    ``/home/<controller>/.claude/plugins/cache/...``). When the linker
+    runs as the isolated UID, the controller path is unreadable and a
+    blind ``iterdir()`` through the symlink raises ``PermissionError``,
+    failing the whole sync. Detect symlinks-to-outside-source up front
+    so the linker can skip them with a WARN instead of crashing.
+
+    ``source_root`` must already be resolved by the caller; ``entry``
+    is resolved here. ``Path.resolve()`` only follows the readlink
+    chain and does not require read access on the final target, so the
+    symlink target being permission-denied to the running UID does not
+    block the check.
+    """
+    if not entry.is_symlink():
+        return False
+    try:
+        resolved = entry.resolve()
+    except OSError:
+        # Loop or other resolution failure — treat as outside so we
+        # skip+warn rather than crash on iterdir().
+        return True
+    try:
+        # Python 3.9+: Path.is_relative_to. Available everywhere this
+        # repo's `python3` runs (CI + macOS Homebrew + Amazon Linux 2023).
+        return not resolved.is_relative_to(source_root)
+    except AttributeError:
+        # Defensive fallback for unexpectedly old interpreters.
+        try:
+            resolved.relative_to(source_root)
+            return False
+        except ValueError:
+            return True
+
+
+def _overlay_dir(src: Path, dst: Path, source_root: Path) -> bool:
     """Recursively overlay src onto dst. Returns True if anything was written.
 
     r4 codex catch — entries that are symlinks-to-directory (created
@@ -416,6 +455,11 @@ def _overlay_dir(src: Path, dst: Path) -> bool:
     the symlink — this materializes the dependency tree into the
     cache as a real directory copy regardless of whether source's
     node_modules is a symlink (r1/r2 leftover) or a real dir.
+
+    v0.9.8 #786 Finding 1 — guard against v1-isolation leftover
+    symlinks-to-outside-source BEFORE the is_dir() recursion, otherwise
+    iterdir() would walk into a controller path the isolated UID
+    cannot read.
     """
     changed = False
     if dst.exists() and not dst.is_dir():
@@ -423,8 +467,15 @@ def _overlay_dir(src: Path, dst: Path) -> bool:
     dst.mkdir(parents=True, exist_ok=True)
     for entry in src.iterdir():
         target = dst / entry.name
+        if _is_symlink_outside_source_root(entry, source_root):
+            sys.stderr.write(
+                f"[bridge-dev-plugin-cache] WARNING: skipping symlink {entry} -> "
+                f"{entry.resolve()} (outside source root {source_root}; "
+                f"likely v1-isolation leftover, run cleanup helper)\n"
+            )
+            continue
         if entry.is_dir():  # includes symlinks-to-directory (resolved-stat)
-            if _overlay_dir(entry, target):
+            if _overlay_dir(entry, target, source_root):
                 changed = True
         elif entry.is_file() or entry.is_symlink():
             if _copy_file_if_changed(entry, target):
@@ -444,15 +495,30 @@ def overlay_source_to_cache(source_path: Path, cache_version_path: Path) -> bool
     copy node_modules into the cache too. Disk overhead is bounded by
     the plugin's installed dependency tree per agent (operator
     acknowledged 100-300 MB / agent in design v2).
+
+    v0.9.8 #786 Finding 1 — ``source_path`` doubles as the plugin's
+    source root for ``_is_symlink_outside_source_root``. Symlinks
+    pointing outside the plugin source tree (e.g. v1-isolation
+    leftover ``node_modules -> /<controller>/.claude/plugins/cache/...``)
+    are skipped with a WARN log instead of triggering a
+    ``PermissionError`` on iterdir() under the isolated UID.
     """
+    source_root = source_path.resolve()
     changed = False
     for entry in source_path.iterdir():
         target = cache_version_path / entry.name
+        if _is_symlink_outside_source_root(entry, source_root):
+            sys.stderr.write(
+                f"[bridge-dev-plugin-cache] WARNING: skipping symlink {entry} -> "
+                f"{entry.resolve()} (outside source root {source_root}; "
+                f"likely v1-isolation leftover, run cleanup helper)\n"
+            )
+            continue
         # r4 codex catch — is_dir() FIRST so symlinks-to-directory are
         # materialized into the cache as a real directory copy. Old
         # ordering matched is_symlink first → shutil.copy2 → corrupt cache.
         if entry.is_dir():
-            if _overlay_dir(entry, target):
+            if _overlay_dir(entry, target, source_root):
                 changed = True
         elif entry.is_file() or entry.is_symlink():
             if _copy_file_if_changed(entry, target):

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -483,7 +483,11 @@ def _overlay_dir(src: Path, dst: Path, source_root: Path) -> bool:
     return changed
 
 
-def overlay_source_to_cache(source_path: Path, cache_version_path: Path) -> bool:
+def overlay_source_to_cache(
+    source_path: Path,
+    cache_version_path: Path,
+    source_root: Path | None = None,
+) -> bool:
     """Mirror EVERYTHING from source onto cache, including node_modules.
 
     r3 codex catch — earlier overlay skipped node_modules and
@@ -496,14 +500,27 @@ def overlay_source_to_cache(source_path: Path, cache_version_path: Path) -> bool
     the plugin's installed dependency tree per agent (operator
     acknowledged 100-300 MB / agent in design v2).
 
-    v0.9.8 #786 Finding 1 — ``source_path`` doubles as the plugin's
-    source root for ``_is_symlink_outside_source_root``. Symlinks
-    pointing outside the plugin source tree (e.g. v1-isolation
+    v0.9.8 #786 Finding 1 r1 — used the plugin's own source path as
+    the boundary for symlink-outside-source detection. r2 catch:
+    that boundary was too narrow — a plugin that legitimately uses
+    ``node_modules -> ../dist`` (a sibling dir inside the same
+    marketplace) was wrongly skipped because ``../dist`` is outside
+    the plugin path even though it is inside the marketplace.
+
+    r2 fix: caller passes the MARKETPLACE root via ``source_root``.
+    Symlinks resolving inside the marketplace are recursed (intra-
+    marketplace deps OK); symlinks resolving outside (e.g. v1-isolation
     leftover ``node_modules -> /<controller>/.claude/plugins/cache/...``)
     are skipped with a WARN log instead of triggering a
     ``PermissionError`` on iterdir() under the isolated UID.
+
+    Back-compat: when ``source_root`` is omitted (legacy callers),
+    fall back to ``source_path`` as before.
     """
-    source_root = source_path.resolve()
+    if source_root is None:
+        source_root = source_path.resolve()
+    else:
+        source_root = source_root.resolve()
     changed = False
     for entry in source_path.iterdir():
         target = cache_version_path / entry.name
@@ -694,7 +711,7 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
                 plugin_cache_root.parent.chmod(0o700)
             cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
             cache_version_path.chmod(0o700)  # explicit, defensive against umask
-            overlay_source_to_cache(source_path, cache_version_path)
+            overlay_source_to_cache(source_path, cache_version_path, source_root=root)
             status = "updated"
             cache_type = "directory"
         elif cache_version_path.is_dir():
@@ -703,7 +720,7 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
             # the cache, while preserving the cache's installed
             # node_modules dir. The source root's node_modules is then
             # linked back to the cache below.
-            changed = overlay_source_to_cache(source_path, cache_version_path)
+            changed = overlay_source_to_cache(source_path, cache_version_path, source_root=root)
             status = "updated" if changed else "unchanged"
             cache_type = "directory"
         elif cache_version_path.exists():
@@ -719,7 +736,7 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
                 plugin_cache_root.parent.chmod(0o700)
             cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
             cache_version_path.chmod(0o700)  # explicit, defensive against umask
-            overlay_source_to_cache(source_path, cache_version_path)
+            overlay_source_to_cache(source_path, cache_version_path, source_root=root)
             status = "updated"
             cache_type = "directory"
         else:
@@ -734,7 +751,7 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
                 plugin_cache_root.parent.chmod(0o700)
             cache_version_path.mkdir(parents=False, exist_ok=False, mode=0o700)
             cache_version_path.chmod(0o700)  # explicit, defensive against umask
-            overlay_source_to_cache(source_path, cache_version_path)
+            overlay_source_to_cache(source_path, cache_version_path, source_root=root)
             status = "linked"
             cache_type = "directory"
     except OSError as exc:


### PR DESCRIPTION
## Summary

PR 1 of v0.9.8 — addresses **#786 Finding 1 only** (Finding 2 ships in a separate PR).

v0.9.7 RC6's per-agent dev-plugin-cache linker recursed through source-tree symlinks via `entry.iterdir()`. On operator hosts that carry v0.7 → v0.8 isolation leftovers — e.g. `source/node_modules -> /home/<controller>/.claude/plugins/cache/<m>/<p>/<v>/node_modules` — the controller path is unreadable to the isolated UID and `iterdir()` raises `PermissionError`. The whole sync exits `install-failed`, the criticality split aborts the channel, and `installed_plugins.json` rewrite never runs. (Operator's `ms365` plugin reproduced this in production while `teams`, `cosmax-crm`, `cosmax-ep-approval` happened to have been hand-cleaned.)

## Fix shape

- New helper `_is_symlink_outside_source_root(entry, source_root)`: True when `entry.is_symlink()` AND `entry.resolve()` is not relative to `source_root.resolve()`. `Path.resolve()` only follows the readlink chain, so it succeeds even when the target is permission-denied to the running UID.
- `overlay_source_to_cache` now resolves `source_path` once, and threads `source_root` through `_overlay_dir` so the recursion measures distance from the *plugin* root (not the recursed subdir).
- Both functions check `_is_symlink_outside_source_root` *before* the `is_dir()` and `is_file() or is_symlink()` branches, and skip + WARN to stderr instead of raising.
- Intra-source symlinks (e.g. relative `./dist`) continue to be materialized as before.

This is containment-only: when the leftover symlink is present, the cache will simply lack `node_modules`. A follow-up cleanup helper and the `installed_plugins.json` rewrite ordering issue raised in #786 are out of scope for this PR (still tracked in the same issue).

## v0.9.7 process lesson applied

The reproducer below is the operator's exact frozen production state — symlink to an unreadable controller path — **not** a fresh install. The v0.9.5 → v0.9.6 → v0.9.7 cycle shipped the same regression three times because the codex-review reproducer kept exercising fresh setup; this PR's verification leads with operator state by construction.

## Verification scenarios (all pass)

Run the script from a clean tree on this branch:

```bash
TMPSRC=\$(mktemp -d)
TMPCACHE=\$(mktemp -d)
TMPCONTROLLER_CACHE=\$(mktemp -d)

# Marketplace fixture
mkdir -p \"\$TMPSRC/.claude-plugin\" \"\$TMPSRC/plugin/0.1.0\"
cat > \"\$TMPSRC/.claude-plugin/marketplace.json\" <<JSON
{
  \"name\": \"root\",
  \"metadata\": {\"version\": \"0.1.0\"},
  \"plugins\": [{\"name\": \"test\", \"source\": \"plugin/0.1.0\", \"version\": \"0.1.0\"}]
}
JSON
echo '{\"name\":\"test\",\"version\":\"0.1.0\"}' > \"\$TMPSRC/plugin/0.1.0/package.json\"
echo 'console.log(\"hi\")' > \"\$TMPSRC/plugin/0.1.0/index.js\"
```

### Scenario 1 — operator's exact ms365 state (CRITICAL)

`source/node_modules` symlinked to a chmod-0700 path outside source root.

```bash
mkdir -p \"\$TMPCONTROLLER_CACHE/lodash\"
echo '{\"name\":\"lodash\"}' > \"\$TMPCONTROLLER_CACHE/lodash/package.json\"
chmod 0700 \"\$TMPCONTROLLER_CACHE\"
ln -s \"\$TMPCONTROLLER_CACHE\" \"\$TMPSRC/plugin/0.1.0/node_modules\"

BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT=\"\$TMPCACHE\" \\
  python3 bridge-dev-plugin-cache.py sync \\
    --channels plugin:test@root \\
    --required-channels plugin:test@root \\
    --optional-channels '' \\
    --root \"\$TMPSRC\" --agent test-agent
```

Expected: stderr contains `WARNING: skipping symlink ... (outside source root ...; likely v1-isolation leftover, run cleanup helper)`; exit 0; cache materialized at `\$TMPCACHE/root/test/0.1.0/` with `package.json` + `index.js` and **no** `node_modules`.

### Scenario 2 — clean install (real `node_modules` dir)

```bash
rm \"\$TMPSRC/plugin/0.1.0/node_modules\"; rm -rf \"\$TMPCACHE\"; TMPCACHE=\$(mktemp -d)
mkdir -p \"\$TMPSRC/plugin/0.1.0/node_modules/lodash\"
echo '{\"name\":\"lodash\"}' > \"\$TMPSRC/plugin/0.1.0/node_modules/lodash/package.json\"

BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT=\"\$TMPCACHE\" \\
  python3 bridge-dev-plugin-cache.py sync \\
    --channels plugin:test@root \\
    --required-channels plugin:test@root \\
    --optional-channels '' \\
    --root \"\$TMPSRC\" --agent test-agent
```

Expected: no warning; exit 0; cache contains `node_modules/lodash/package.json`.

### Scenario 3 — intra-source symlink (relative target inside source root)

```bash
rm -rf \"\$TMPSRC/plugin/0.1.0/node_modules\"; rm -rf \"\$TMPCACHE\"; TMPCACHE=\$(mktemp -d)
mkdir -p \"\$TMPSRC/plugin/0.1.0/dist\"
echo '{\"name\":\"lodash\"}' > \"\$TMPSRC/plugin/0.1.0/dist/lodash.js\"
ln -s ./dist \"\$TMPSRC/plugin/0.1.0/node_modules\"

BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT=\"\$TMPCACHE\" \\
  python3 bridge-dev-plugin-cache.py sync \\
    --channels plugin:test@root \\
    --required-channels plugin:test@root \\
    --optional-channels '' \\
    --root \"\$TMPSRC\" --agent test-agent
```

Expected: no warning; exit 0; `\$TMPCACHE/root/test/0.1.0/node_modules/lodash.js` exists (recurses through the intra-source symlink as before).

All three scenarios were exercised on this branch and passed.

## Test plan

- [ ] Reviewer runs Scenario 1 (operator's frozen state) FIRST — that is the regression vector v0.9.5/v0.9.6/v0.9.7 missed.
- [ ] Reviewer runs Scenarios 2 + 3 to confirm clean-install + intra-source-symlink semantics are unchanged.
- [ ] `python3 -c \"import py_compile; py_compile.compile('bridge-dev-plugin-cache.py', doraise=True)\"` clean.
- [ ] Spot-check `_is_symlink_outside_source_root` against:
  - broken symlink (target does not exist) — should still skip+warn rather than raise.
  - absolute symlink whose target *is* under `source_root` — should fall through and recurse.
- [ ] `installed_plugins.json` rewrite ordering (Suggested Fix item 3 in #786) is intentionally **not** addressed here; confirm scope.

Refs #786. **Does not** close #786 — Finding 2 (memory-daily harvester vs grant matrix mismatch) ships separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)