### PR TITLE
fix(memory-daily): isolated harvester writes per-agent fragment, controller reducer combines (refs #786)

### DIFF
--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -358,8 +358,10 @@ bridge_isolation_v2_exec_with_secret_env() {
 
 bridge_isolation_v2_agent_memory_daily_root() {
   # Per-agent memory-daily root. Lives inside the per-agent root so it
-  # inherits the same isolation contract; the daily harvester aggregates
-  # into the shared aggregate dir (controller-owned, group-readable).
+  # inherits the same isolation contract; the daily harvester writes
+  # per-agent fragments here (group ab-shared, mode 2770) and the
+  # controller-side reducer (`scripts/memory-daily-reduce.sh`) combines
+  # fragments into the shared aggregate dir (#786 Finding 2 / Design A).
   local agent="$1"
   local root
   root="$(bridge_isolation_v2_agent_root "$agent")" || return 1
@@ -367,14 +369,17 @@ bridge_isolation_v2_agent_memory_daily_root() {
 }
 
 bridge_isolation_v2_memory_daily_shared_aggregate_dir() {
-  # Canonical shared aggregate directory — the harvester writes
-  # admin-aggregate-*.json files DIRECTLY under this path (not inside an
-  # extra `aggregate/` child). Lives under shared/ so other isolated UIDs
-  # may read the aggregate but never write it (design-r3 decision: shared
-  # writes are controller-only). PR-C r3: contract unified across all
-  # callers so prepare/migration grants the same path the Python writer
-  # uses, eliminating the parent-vs-child mismatch flagged in r2 review
-  # finding P2 #2.
+  # Canonical shared aggregate directory — controller-owned, group-readable.
+  # Lives under shared/ so isolated UIDs may read but never write the
+  # aggregate (design-r3 decision: shared writes are controller-only;
+  # matrix row `shared-memory-daily-aggregate` is mode 2750 / r-x by
+  # ab-shared). Per #786 Finding 2 (Design A), the controller-side reducer
+  # `scripts/memory-daily-reduce.sh` is the sole writer — isolated harvester
+  # invocations skip --shared-aggregate-dir and only emit per-agent
+  # fragments under `<agent_root>/runtime/memory-daily/`. PR-C r3: contract
+  # unified across all callers so prepare/migration grants the same path
+  # the reducer writes, eliminating the parent-vs-child mismatch flagged
+  # in r2 review finding P2 #2.
   [[ -n "$BRIDGE_SHARED_ROOT" ]] || return 1
   printf '%s/memory-daily/aggregate' "$BRIDGE_SHARED_ROOT"
 }

--- a/scripts/memory-daily-harvest.sh
+++ b/scripts/memory-daily-harvest.sh
@@ -111,12 +111,23 @@ v2_extra_args=()
 # (b) BRIDGE_DATA_ROOT is set, (c) BRIDGE_DATA_ROOT exists on disk, AND
 # (d) BRIDGE_AGENT_ROOT_V2 is set. Mirrors the wiki harvester gate at
 # scripts/wiki-daily-ingest.sh:174-176.
+#
+# Issue #786 Finding 2 (Design A binding): under linux-user isolation the
+# harvester effectively runs as the isolated UID, which has only r-x on
+# the controller-owned shared aggregate dir (matrix row
+# `shared-memory-daily-aggregate` = mode 2750). Passing --shared-aggregate-dir
+# from this context triggers EACCES on the admin-aggregate-*.json write.
+# Per Design A, the isolated UID writes only the per-agent fragment under
+# runtime/memory-daily/, and the controller-side reducer
+# (scripts/memory-daily-reduce.sh) combines fragments into the shared
+# aggregate. Legacy / non-isolated installs continue to pass both flags so
+# the controller-run harvester still produces aggregates directly.
 if [[ "${BRIDGE_LAYOUT:-legacy}" == "v2" ]] \
     && [[ -n "${BRIDGE_DATA_ROOT:-}" ]] \
     && [[ -d "${BRIDGE_DATA_ROOT}" ]] \
     && [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
   v2_extra_args+=(--per-agent-state-dir "$BRIDGE_AGENT_ROOT_V2/$AGENT/runtime/memory-daily")
-  if [[ -n "${BRIDGE_SHARED_ROOT:-}" ]]; then
+  if [[ -n "${BRIDGE_SHARED_ROOT:-}" && "$isolation_mode" != "linux-user" ]]; then
     v2_extra_args+=(--shared-aggregate-dir "$BRIDGE_SHARED_ROOT/memory-daily/aggregate")
   fi
 elif [[ "${BRIDGE_LAYOUT:-legacy}" == "v2" ]]; then

--- a/scripts/memory-daily-reduce.sh
+++ b/scripts/memory-daily-reduce.sh
@@ -74,8 +74,17 @@ for agent_dir in "$BRIDGE_AGENT_ROOT_V2"/*/; do
     # Atomic-ish copy: write to a tmp sibling then rename. Python's
     # _atomic_write_json convention reused so the controller-side reducer
     # composes well with concurrent readers.
+    #
+    # r2 codex catch — was `cp -p` which preserved the per-agent fragment
+    # mode (typically 0660 on the matrix runtime/memory-daily/ row). The
+    # aggregate row contract is `controller:ab-shared 0640`, so the copy
+    # must DROP the source mode and chmod 0640 on the destination tmp
+    # before rename. Otherwise verify reports the aggregate file as
+    # mismatch even though the directory mode is canonical.
     tmp="${target}.tmp.$$"
-    if cp -p "$fragment" "$tmp" 2>/dev/null && mv -f "$tmp" "$target" 2>/dev/null; then
+    if cp "$fragment" "$tmp" 2>/dev/null \
+        && chmod 0640 "$tmp" 2>/dev/null \
+        && mv -f "$tmp" "$target" 2>/dev/null; then
       reduced=$((reduced + 1))
     else
       rm -f "$tmp" 2>/dev/null || true

--- a/scripts/memory-daily-reduce.sh
+++ b/scripts/memory-daily-reduce.sh
@@ -108,11 +108,25 @@ for agent_dir in "$BRIDGE_AGENT_ROOT_V2"/*/; do
     #
     # r3 codex catch (defense-in-depth) — `cp -P` (no-dereference) so
     # even if a symlink slips past the [[ -L ]] guard above (TOCTOU
-    # race between the test and cp), cp would copy the symlink itself
-    # (which subsequently fails the `-f` check anyway) instead of
-    # following it. -P is BSD/GNU compatible.
+    # race between the test and cp), cp copies the symlink itself
+    # instead of following it. -P is BSD/GNU compatible.
+    #
+    # r4 codex catches:
+    #   1. TOCTOU swap — attacker swaps real file → symlink between
+    #      Layer 1/2 check and cp -P. cp -P copies symlink into tmp.
+    #      Without the post-copy `[[ -L "$tmp" || ! -f "$tmp" ]]`
+    #      check, mv would publish the symlink and the consumer
+    #      (controller reading aggregate) would dereference into the
+    #      attacker's chosen target. Defense: re-check tmp post-cp;
+    #      if symlink or non-regular, drop without publishing.
+    #   2. Malformed JSON — agent writes `{bad json` to fragment.
+    #      Reducer published as aggregate row. Consumers consuming
+    #      the aggregate JSON-parse downstream and fail noisily.
+    #      Defense: validate JSON parseability before publishing.
     tmp="${target}.tmp.$$"
     if cp -P "$fragment" "$tmp" 2>/dev/null \
+        && [[ -f "$tmp" && ! -L "$tmp" ]] \
+        && python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$tmp" 2>/dev/null \
         && chmod 0640 "$tmp" 2>/dev/null \
         && mv -f "$tmp" "$target" 2>/dev/null; then
       reduced=$((reduced + 1))

--- a/scripts/memory-daily-reduce.sh
+++ b/scripts/memory-daily-reduce.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# memory-daily reducer — controller-side helper that combines per-agent
+# memory-daily fragments into the canonical shared aggregate dir.
+#
+# Issue #786 Finding 2 / Design A: under linux-user isolation the
+# per-agent harvester runs as the isolated UID and writes only its own
+# fragment under `<agent_root>/runtime/memory-daily/` (matrix row
+# `agent-runtime` mode 2770 group=ab-shared). It does NOT write to the
+# shared aggregate dir (matrix row `shared-memory-daily-aggregate`
+# mode 2750), which is r-x only for isolated UIDs.
+#
+# This reducer runs as the controller, reads each isolated agent's
+# fragments via group read access, and copies them into the shared
+# aggregate dir as `admin-aggregate-<agent>-<filename>`. The minimal-
+# scope contract for v0.9.8: pass-through copy. A future PR may merge
+# fragments into a single combined admin-aggregate-*.json.
+#
+# Usage:
+#   scripts/memory-daily-reduce.sh
+#
+# Environment:
+#   BRIDGE_HOME            (default: $HOME/.agent-bridge)
+#   BRIDGE_LAYOUT          required: v2 (legacy installs are no-op)
+#   BRIDGE_DATA_ROOT       required under v2
+#   BRIDGE_AGENT_ROOT_V2   required under v2
+#   BRIDGE_SHARED_ROOT     required under v2
+set -euo pipefail
+
+: "${BRIDGE_HOME:=$HOME/.agent-bridge}"
+
+if [[ "${BRIDGE_LAYOUT:-legacy}" != "v2" ]]; then
+  printf '[memory-daily-reduce] layout=%s; reducer is v2-only, exiting cleanly\n' \
+    "${BRIDGE_LAYOUT:-legacy}" >&2
+  exit 0
+fi
+
+if [[ -z "${BRIDGE_AGENT_ROOT_V2:-}" || -z "${BRIDGE_SHARED_ROOT:-}" ]]; then
+  printf '[memory-daily-reduce] missing BRIDGE_AGENT_ROOT_V2 or BRIDGE_SHARED_ROOT under v2; exiting\n' >&2
+  exit 0
+fi
+
+if [[ ! -d "$BRIDGE_AGENT_ROOT_V2" ]]; then
+  printf '[memory-daily-reduce] BRIDGE_AGENT_ROOT_V2=%s does not exist; exiting\n' \
+    "$BRIDGE_AGENT_ROOT_V2" >&2
+  exit 0
+fi
+
+aggregate_dir="$BRIDGE_SHARED_ROOT/memory-daily/aggregate"
+mkdir -p "$aggregate_dir"
+
+reduced=0
+skipped=0
+errors=0
+
+# Iterate every per-agent root under BRIDGE_AGENT_ROOT_V2. Skip entries
+# that are not directories (e.g. dotfiles, transient marker files).
+shopt -s nullglob
+for agent_dir in "$BRIDGE_AGENT_ROOT_V2"/*/; do
+  agent_name="$(basename "$agent_dir")"
+  fragment_dir="$agent_dir/runtime/memory-daily"
+  [[ -d "$fragment_dir" ]] || { skipped=$((skipped + 1)); continue; }
+
+  for fragment in "$fragment_dir"/*.json; do
+    [[ -f "$fragment" ]] || continue
+    fragment_name="$(basename "$fragment")"
+    # Skip sidecar / adhoc artifacts — only canonical date-named fragments
+    # are eligible for reduction. Sidecars carry per-run scratch data and
+    # would noisily bloat the shared aggregate.
+    case "$fragment_name" in
+      adhoc.*|*.tmp.*|.*) continue ;;
+    esac
+
+    target="$aggregate_dir/admin-aggregate-${agent_name}-${fragment_name}"
+    # Atomic-ish copy: write to a tmp sibling then rename. Python's
+    # _atomic_write_json convention reused so the controller-side reducer
+    # composes well with concurrent readers.
+    tmp="${target}.tmp.$$"
+    if cp -p "$fragment" "$tmp" 2>/dev/null && mv -f "$tmp" "$target" 2>/dev/null; then
+      reduced=$((reduced + 1))
+    else
+      rm -f "$tmp" 2>/dev/null || true
+      errors=$((errors + 1))
+      printf '[memory-daily-reduce] copy failed: %s -> %s\n' "$fragment" "$target" >&2
+    fi
+  done
+done
+shopt -u nullglob
+
+printf '[memory-daily-reduce] reduced=%d skipped_agents=%d errors=%d aggregate_dir=%s\n' \
+  "$reduced" "$skipped" "$errors" "$aggregate_dir" >&2
+
+if [[ "$errors" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/memory-daily-reduce.sh
+++ b/scripts/memory-daily-reduce.sh
@@ -58,9 +58,33 @@ shopt -s nullglob
 for agent_dir in "$BRIDGE_AGENT_ROOT_V2"/*/; do
   agent_name="$(basename "$agent_dir")"
   fragment_dir="$agent_dir/runtime/memory-daily"
+  # r3 codex catch — refuse symlink agent dir or fragment dir. The
+  # isolated UID writes inside the agent home; if `runtime/memory-daily`
+  # itself is a symlink to a controller-only path, the iterdir walks
+  # through the symlink and exposes controller content as a fragment.
+  if [[ -L "$agent_dir" ]] || [[ -L "$fragment_dir" ]]; then
+    printf '[memory-daily-reduce] WARNING: refusing symlink under agent runtime (security): %s\n' \
+      "$fragment_dir" >&2
+    skipped=$((skipped + 1))
+    continue
+  fi
   [[ -d "$fragment_dir" ]] || { skipped=$((skipped + 1)); continue; }
 
   for fragment in "$fragment_dir"/*.json; do
+    # r3 codex catch (BLOCKING) — refuse symlink fragments. The
+    # isolated UID has write access to runtime/memory-daily/ (matrix
+    # row 2770), so it can plant a symlink to ANY controller-readable
+    # file (e.g. /home/ec2-user/.claude/.credentials.json) and the
+    # reducer's `cp` (without -P) follows the symlink, copying the
+    # target content into shared/aggregate/ where ab-shared group
+    # members read it. Path-traversal exfiltration vector. Reject
+    # symlinks loud; only real files allowed.
+    if [[ -L "$fragment" ]]; then
+      printf '[memory-daily-reduce] WARNING: refusing symlink fragment (security exfiltration vector): %s\n' \
+        "$fragment" >&2
+      errors=$((errors + 1))
+      continue
+    fi
     [[ -f "$fragment" ]] || continue
     fragment_name="$(basename "$fragment")"
     # Skip sidecar / adhoc artifacts — only canonical date-named fragments
@@ -81,8 +105,14 @@ for agent_dir in "$BRIDGE_AGENT_ROOT_V2"/*/; do
     # must DROP the source mode and chmod 0640 on the destination tmp
     # before rename. Otherwise verify reports the aggregate file as
     # mismatch even though the directory mode is canonical.
+    #
+    # r3 codex catch (defense-in-depth) — `cp -P` (no-dereference) so
+    # even if a symlink slips past the [[ -L ]] guard above (TOCTOU
+    # race between the test and cp), cp would copy the symlink itself
+    # (which subsequently fails the `-f` check anyway) instead of
+    # following it. -P is BSD/GNU compatible.
     tmp="${target}.tmp.$$"
-    if cp "$fragment" "$tmp" 2>/dev/null \
+    if cp -P "$fragment" "$tmp" 2>/dev/null \
         && chmod 0640 "$tmp" 2>/dev/null \
         && mv -f "$tmp" "$target" 2>/dev/null; then
       reduced=$((reduced + 1))


### PR DESCRIPTION
## Summary

Refs #786 Finding 2 (Design A binding). PR 2 of v0.9.8.

The v0.9.7 grant matrix declares `shared-memory-daily-aggregate` as mode 2750 (controller-owned, r-x for ab-shared) — isolated UIDs may read but never write. But `memory-daily-harvest.sh` passes `--shared-aggregate-dir` from the v2 branch even when running under linux-user isolation, which produces EACCES on every aggregate write the isolated harvester attempts. The operator hit this on `sales_sean` and worked around it with `chmod 2770` on the aggregate dir, leaving the matrix permanently in `mismatch` state.

The function comment in `bridge_isolation_v2_memory_daily_shared_aggregate_dir` even self-contradicts within one paragraph (declares "isolated UIDs may read but never write," then says "the harvester writes admin-aggregate-*.json files DIRECTLY under this path").

Per Design A (matrix follows v2 spec; aggregate is controller-write-only):

- **`scripts/memory-daily-harvest.sh`** — under linux-user isolation, drop `--shared-aggregate-dir`. The isolated UID writes only its per-agent fragment under `runtime/memory-daily/`. Legacy / non-isolated installs continue to pass both flags so the controller-run harvester still emits aggregates directly (small installations).

- **`scripts/memory-daily-reduce.sh`** (new) — controller-side reducer that iterates `<agent_root>/runtime/memory-daily/*.json` fragments across every isolated agent and atomically copies them into the canonical shared aggregate as `admin-aggregate-<agent>-<filename>.json`. Skips adhoc / sidecar artifacts. Operator hooks this into their crontab as a controller-context job (no sudo wrap).

- **`lib/bridge-isolation-v2.sh`** — rewrite the comments on `bridge_isolation_v2_memory_daily_shared_aggregate_dir` and `bridge_isolation_v2_agent_memory_daily_root` so the contract is unambiguous: controller-side reducer is the sole writer; isolated UIDs only read. No matrix row change — the row stays at 2750 and the operator's chmod 2770 workaround coexists harmlessly (the new harvester does not touch that dir at all from isolated UID).

## Out of scope (intentional)

- No `VERSION` / `CHANGELOG` bump (release PR will batch v0.9.8).
- No matrix row change (Design A: 2750 stays canonical).
- No automatic cron registration of the reducer — operator wires it into their controller crontab. v0.9.9 can lift this into bridge-cron.

## Test plan

- [x] `bash -n` clean on `scripts/memory-daily-harvest.sh`, `scripts/memory-daily-reduce.sh`, `lib/bridge-isolation-v2.sh`.
- [x] `shellcheck` clean on the two scripts and the lib helper.
- [x] Reducer happy path: 2 fragments across 2 agents + 1 agent without runtime + 1 adhoc sidecar → `reduced=2`, `skipped_agents=1`, sidecar correctly excluded, both canonical fragments land under `aggregate/admin-aggregate-<agent>-<file>`.
- [x] Reducer cleanly no-ops on `BRIDGE_LAYOUT=legacy`.
- [x] Reducer works against both `2770` (operator workaround state) and `2750` (canonical matrix) aggregate-dir modes — controller writes succeed in both because controller owns the dir.
- [x] Harvester gate logic: `isolation_mode=linux-user` emits only `--per-agent-state-dir`; `isolation_mode=none` emits both flags (small-install legacy unchanged).
- [ ] Live operator-host verification: run `scripts/memory-daily-reduce.sh` once as ec2-user after applying upgrade, confirm `agent-bridge isolation verify --agent sales_sean` no longer reports the aggregate row in `mismatch` once chmod 2770 workaround is reverted (post-merge).

## Reproduction (operator's actual host state)

```bash
# 1. Setup: simulate isolated agent fragment + canonical 2750 aggregate
TMP=$(mktemp -d)
mkdir -p "$TMP/agents/test/runtime/memory-daily"
echo '{"date":"2026-05-10","agent":"test","data":[]}' > "$TMP/agents/test/runtime/memory-daily/2026-05-10.json"
mkdir -p "$TMP/shared/memory-daily/aggregate"
chmod 2750 "$TMP/shared/memory-daily/aggregate"

# 2. Run reducer as controller
BRIDGE_LAYOUT=v2 BRIDGE_DATA_ROOT="$TMP" \
  BRIDGE_AGENT_ROOT_V2="$TMP/agents" \
  BRIDGE_SHARED_ROOT="$TMP/shared" \
  scripts/memory-daily-reduce.sh
# → reduced=1 errors=0
# → admin-aggregate-test-2026-05-10.json appears in aggregate/

# 3. Same with operator workaround state (chmod 2770) — also works
chmod 2770 "$TMP/shared/memory-daily/aggregate"
# (rerun) — still reduced=1 errors=0
```

Refs #786 (Finding 2 only — Finding 1 was merged in #787).