### PR TITLE
fix(launch): canonicalize MS365 state dir for Claude plugin channels

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -752,21 +752,39 @@ for name, value in assignments:
         # final assignment. Even though shell eval is last-wins (so the
         # value would still be correct), duplicate exported assignments
         # are a code smell and surface in audit/logs as if multiple
-        # stale values survived. Final re.sub collapses any double
-        # spaces left by drops.
+        # stale values survived.
+        #
+        # r3 codex catch on PR #790: a global `re.sub(r" {2,}", " ", …)`
+        # post-pass would also collapse multi-space runs INSIDE quoted
+        # values elsewhere in env_prefix (e.g. `OTHER="a  b"` would be
+        # mangled to `OTHER="a b"`). Instead, when dropping a duplicate
+        # span, strip ONE leading whitespace character from the gap
+        # between the previous token and the dropped span — this
+        # collapses the dedupe artifact locally without touching any
+        # other whitespace in env_prefix.
         pieces = []
         last = 0
         first = True
         for s_, e_ in spans:
-            pieces.append(env_prefix[last:s_])
             if first:
+                # Keep the full gap before the first matching span,
+                # then emit the canonical assignment.
+                pieces.append(env_prefix[last:s_])
                 pieces.append(f"{name}={quoted_value}")
                 first = False
-            # else: drop this span entirely (no append)
+            else:
+                # Dropping this duplicate span: also drop ONE leading
+                # whitespace separator (space or tab) from the gap so
+                # the surrounding tokens collapse from "…  …" to "… …".
+                # Local to the drop site — does NOT touch spaces inside
+                # quoted values elsewhere in env_prefix.
+                gap = env_prefix[last:s_]
+                if gap and gap[0] in (" ", "\t"):
+                    gap = gap[1:]
+                pieces.append(gap)
             last = e_
         pieces.append(env_prefix[last:])
         env_prefix = "".join(pieces)
-        env_prefix = re.sub(r" {2,}", " ", env_prefix)
         if env_prefix and not env_prefix.endswith((" ", "\t")):
             env_prefix += " "
     else:

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -476,6 +476,7 @@ bridge_claude_launch_with_channel_state_dirs() {
   local discord_dir=""
   local telegram_dir=""
   local teams_dir=""
+  local ms365_dir=""
 
   required="$(bridge_agent_effective_launch_plugin_channels_csv "$agent")"
   launch_channels="$(bridge_extract_channels_from_command "$original")"
@@ -491,14 +492,15 @@ bridge_claude_launch_with_channel_state_dirs() {
   discord_dir="$(bridge_agent_discord_state_dir "$agent")"
   telegram_dir="$(bridge_agent_telegram_state_dir "$agent")"
   teams_dir="$(bridge_agent_teams_state_dir "$agent")"
+  ms365_dir="$(bridge_agent_ms365_state_dir "$agent")"
 
   bridge_require_python
-  python3 - "$original" "$required" "$discord_dir" "$telegram_dir" "$teams_dir" <<'PY'
+  python3 - "$original" "$required" "$discord_dir" "$telegram_dir" "$teams_dir" "$ms365_dir" <<'PY'
 import re
 import shlex
 import sys
 
-original, required_csv, discord_dir, telegram_dir, teams_dir = sys.argv[1:]
+original, required_csv, discord_dir, telegram_dir, teams_dir, ms365_dir = sys.argv[1:]
 
 def normalize(raw: str):
     values = []
@@ -535,6 +537,8 @@ if any(
     assignments.append(("TELEGRAM_STATE_DIR", telegram_dir))
 if any(item == "plugin:teams" or item.startswith("plugin:teams@") for item in required):
     assignments.append(("TEAMS_STATE_DIR", teams_dir))
+if any(item == "plugin:ms365" or item.startswith("plugin:ms365@") for item in required):
+    assignments.append(("MS365_STATE_DIR", ms365_dir))
 
 # Issue #771 v0.9.6 — operator's R5 diagnostic confirmed PRIMARY fix
 # (v0.9.5 PR #774 `agent_env_regen`) was a false-positive: the regen

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -745,14 +745,28 @@ for name, value in assignments:
         if env_prefix[s_:e_].startswith(prefix_form)
     ]
     if spans:
+        # r2 codex catch on PR #790: replace the FIRST matching span
+        # with canonical, drop all subsequent spans entirely. Otherwise
+        # `NAME=/old1 NAME=/old2` produces two canonical entries
+        # (`NAME=/new NAME=/new`) instead of collapsing to a single
+        # final assignment. Even though shell eval is last-wins (so the
+        # value would still be correct), duplicate exported assignments
+        # are a code smell and surface in audit/logs as if multiple
+        # stale values survived. Final re.sub collapses any double
+        # spaces left by drops.
         pieces = []
         last = 0
+        first = True
         for s_, e_ in spans:
             pieces.append(env_prefix[last:s_])
-            pieces.append(f"{name}={quoted_value}")
+            if first:
+                pieces.append(f"{name}={quoted_value}")
+                first = False
+            # else: drop this span entirely (no append)
             last = e_
         pieces.append(env_prefix[last:])
         env_prefix = "".join(pieces)
+        env_prefix = re.sub(r" {2,}", " ", env_prefix)
         if env_prefix and not env_prefix.endswith((" ", "\t")):
             env_prefix += " "
     else:

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5533,6 +5533,43 @@ matches = re.findall(r"\bTEAMS_STATE_DIR=", command)
 assert len(matches) == 1, f"expected 1 TEAMS_STATE_DIR=, got {len(matches)}: {command!r}"
 PY
 
+# PR #790 r3 codex catch (BLOCKING) — the r2 fix introduced a global
+# `re.sub(r" {2,}", " ", env_prefix)` post-pass to clean up the double
+# space left when a duplicate span was dropped. That cleanup was too
+# coarse: it collapsed multi-space runs ANYWHERE in env_prefix,
+# including INSIDE quoted env values. `OTHER="a  b"` got silently
+# mangled to `OTHER="a b"`, breaking pass-through correctness for any
+# upstream env value that intentionally contained consecutive spaces.
+# r3 fix: strip ONE leading whitespace at each dedupe drop site
+# (local to the span boundary) instead of a global post-pass. Fixture
+# asserts both halves of the contract:
+#   1. Duplicate MS365_STATE_DIR spans still collapse to exactly one.
+#   2. An unrelated OTHER='keep  with  multi  spaces' value with
+#      intentional multi-space runs is preserved BYTE-FOR-BYTE.
+OTHER_QUOTED_PRESERVED_LAUNCH="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CHANNELS["'"$CREATED_AGENT"'"]="plugin:ms365@agent-bridge"
+  raw="OTHER='\''keep  with  multi  spaces'\'' MS365_STATE_DIR=/stale1/.ms365 MS365_STATE_DIR=/stale2/.ms365 claude --dangerously-load-development-channels plugin:ms365@agent-bridge --dangerously-skip-permissions --name '"$CREATED_AGENT"'"
+  bridge_claude_launch_with_channel_state_dirs "'"$CREATED_AGENT"'" "$raw"
+')"
+# OTHER's internal multi-space content must be preserved exactly.
+assert_contains "$OTHER_QUOTED_PRESERVED_LAUNCH" "OTHER='keep  with  multi  spaces'"
+# Dedupe still produces exactly one canonical MS365_STATE_DIR.
+assert_contains "$OTHER_QUOTED_PRESERVED_LAUNCH" "MS365_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.ms365"
+assert_not_contains "$OTHER_QUOTED_PRESERVED_LAUNCH" "/stale1/.ms365"
+assert_not_contains "$OTHER_QUOTED_PRESERVED_LAUNCH" "/stale2/.ms365"
+python3 - "$OTHER_QUOTED_PRESERVED_LAUNCH" <<'PY'
+import re
+import sys
+command = sys.argv[1]
+ms365_matches = re.findall(r"\bMS365_STATE_DIR=", command)
+assert len(ms365_matches) == 1, f"expected 1 MS365_STATE_DIR=, got {len(ms365_matches)}: {command!r}"
+# Belt-and-suspenders: assert the OTHER value passed through byte-for-byte.
+assert "OTHER='keep  with  multi  spaces'" in command, \
+    f"OTHER multi-space content mangled: {command!r}"
+PY
+
 if command -v bun >/dev/null 2>&1; then
   log "exercising Teams channel plugin health"
   TEAMS_SMOKE_PORT="$(python3 - <<'PY'

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5488,6 +5488,51 @@ assert_contains "$TEAMS_MS365_BOTH_LAUNCH" "OTHER_ENV=keep"
 assert_not_contains "$TEAMS_MS365_BOTH_LAUNCH" "TEAMS_STATE_DIR=/stale/.teams"
 assert_not_contains "$TEAMS_MS365_BOTH_LAUNCH" "MS365_STATE_DIR=/stale/.ms365"
 
+# PR #790 r2 codex catch — duplicate stale assignments for the SAME VAR
+# must collapse to exactly ONE canonical entry. The replacement loop
+# previously emitted a canonical assignment for EACH matching span,
+# producing `MS365_STATE_DIR=/new MS365_STATE_DIR=/new` instead of a
+# single final assignment. Shell eval is last-wins so the value is
+# still correct, but duplicate exported assignments surface in audit
+# logs / `ps` output as if multiple stale entries survived. The fix
+# is symmetric across all four channel state dirs; verify both an
+# MS365 case and a TEAMS case so the contract is enforced for the
+# whole family.
+MS365_DUP_LAUNCH="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CHANNELS["'"$CREATED_AGENT"'"]="plugin:ms365@agent-bridge"
+  raw="MS365_STATE_DIR=/stale1/.ms365 MS365_STATE_DIR=/stale2/.ms365 claude --dangerously-load-development-channels plugin:ms365@agent-bridge --dangerously-skip-permissions --name '"$CREATED_AGENT"'"
+  bridge_claude_launch_with_channel_state_dirs "'"$CREATED_AGENT"'" "$raw"
+')"
+assert_contains "$MS365_DUP_LAUNCH" "MS365_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.ms365"
+assert_not_contains "$MS365_DUP_LAUNCH" "/stale1/.ms365"
+assert_not_contains "$MS365_DUP_LAUNCH" "/stale2/.ms365"
+python3 - "$MS365_DUP_LAUNCH" <<'PY'
+import re
+import sys
+command = sys.argv[1]
+matches = re.findall(r"\bMS365_STATE_DIR=", command)
+assert len(matches) == 1, f"expected 1 MS365_STATE_DIR=, got {len(matches)}: {command!r}"
+PY
+TEAMS_DUP_LAUNCH="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CHANNELS["'"$CREATED_AGENT"'"]="plugin:teams@agent-bridge"
+  raw="TEAMS_STATE_DIR=/stale1/.teams TEAMS_STATE_DIR=/stale2/.teams claude --dangerously-load-development-channels plugin:teams@agent-bridge --dangerously-skip-permissions --name '"$CREATED_AGENT"'"
+  bridge_claude_launch_with_channel_state_dirs "'"$CREATED_AGENT"'" "$raw"
+')"
+assert_contains "$TEAMS_DUP_LAUNCH" "TEAMS_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams"
+assert_not_contains "$TEAMS_DUP_LAUNCH" "/stale1/.teams"
+assert_not_contains "$TEAMS_DUP_LAUNCH" "/stale2/.teams"
+python3 - "$TEAMS_DUP_LAUNCH" <<'PY'
+import re
+import sys
+command = sys.argv[1]
+matches = re.findall(r"\bTEAMS_STATE_DIR=", command)
+assert len(matches) == 1, f"expected 1 TEAMS_STATE_DIR=, got {len(matches)}: {command!r}"
+PY
+
 if command -v bun >/dev/null 2>&1; then
   log "exercising Teams channel plugin health"
   TEAMS_SMOKE_PORT="$(python3 - <<'PY'

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5450,6 +5450,44 @@ TEAMS_DEV_STATE_DIR_LAUNCH="$("$BASH4_BIN" -c '
 ')"
 assert_contains "$TEAMS_DEV_STATE_DIR_LAUNCH" "TEAMS_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams"
 
+# Issue #786 follow-up — bridge_claude_launch_with_channel_state_dirs must
+# also canonicalize MS365_STATE_DIR. Frozen-roster launch_cmd previously kept
+# stale pre-v2 path → ms365 plugin server.ts mkdir EACCES → MCP entry dropped.
+MS365_STALE_LAUNCH="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CHANNELS["'"$CREATED_AGENT"'"]="plugin:ms365@agent-bridge"
+  raw="MS365_STATE_DIR=/stale/.ms365 claude --dangerously-load-development-channels plugin:ms365@agent-bridge --dangerously-skip-permissions --name '"$CREATED_AGENT"'"
+  bridge_claude_launch_with_channel_state_dirs "'"$CREATED_AGENT"'" "$raw"
+')"
+assert_contains "$MS365_STALE_LAUNCH" "MS365_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.ms365"
+assert_not_contains "$MS365_STALE_LAUNCH" "MS365_STATE_DIR=/stale/.ms365"
+python3 - "$MS365_STALE_LAUNCH" <<'PY'
+import sys
+command = sys.argv[1]
+assert command.count("plugin:ms365@agent-bridge") == 1, command
+PY
+MS365_FRESH_LAUNCH="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CHANNELS["'"$CREATED_AGENT"'"]="plugin:ms365@agent-bridge"
+  raw="claude --dangerously-load-development-channels plugin:ms365@agent-bridge --dangerously-skip-permissions --name '"$CREATED_AGENT"'"
+  bridge_claude_launch_with_channel_state_dirs "'"$CREATED_AGENT"'" "$raw"
+')"
+assert_contains "$MS365_FRESH_LAUNCH" "MS365_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.ms365"
+TEAMS_MS365_BOTH_LAUNCH="$("$BASH4_BIN" -c '
+  source "'"$REPO_ROOT"'/bridge-lib.sh"
+  bridge_load_roster
+  BRIDGE_AGENT_CHANNELS["'"$CREATED_AGENT"'"]="plugin:teams@agent-bridge,plugin:ms365@agent-bridge"
+  raw="OTHER_ENV=keep TEAMS_STATE_DIR=/stale/.teams MS365_STATE_DIR=/stale/.ms365 claude --dangerously-load-development-channels plugin:teams@agent-bridge --dangerously-load-development-channels plugin:ms365@agent-bridge --dangerously-skip-permissions --name '"$CREATED_AGENT"'"
+  bridge_claude_launch_with_channel_state_dirs "'"$CREATED_AGENT"'" "$raw"
+')"
+assert_contains "$TEAMS_MS365_BOTH_LAUNCH" "TEAMS_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams"
+assert_contains "$TEAMS_MS365_BOTH_LAUNCH" "MS365_STATE_DIR=$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.ms365"
+assert_contains "$TEAMS_MS365_BOTH_LAUNCH" "OTHER_ENV=keep"
+assert_not_contains "$TEAMS_MS365_BOTH_LAUNCH" "TEAMS_STATE_DIR=/stale/.teams"
+assert_not_contains "$TEAMS_MS365_BOTH_LAUNCH" "MS365_STATE_DIR=/stale/.ms365"
+
 if command -v bun >/dev/null 2>&1; then
   log "exercising Teams channel plugin health"
   TEAMS_SMOKE_PORT="$(python3 - <<'PY'


### PR DESCRIPTION
## Summary

- ms365 plugin was the only stdio MCP plugin missing from the launch-time state-dir canonicalization, so isolated agents inherited stale pre-v2 `MS365_STATE_DIR` paths and the plugin died at startup with EACCES.
- Add `MS365_STATE_DIR` to `bridge_claude_launch_with_channel_state_dirs` alongside the existing Discord/Telegram/Teams handling, reusing the same top-level-token replacement loop.
- Smoke coverage: stale-replace, fresh-append, and combined Teams+MS365 with an unrelated env preserved.

## Background

`bridge_claude_launch_with_channel_state_dirs` (lib/bridge-state.sh) is the helper that takes a frozen-roster launch_cmd and replaces stale env-prefix tokens with the canonical workdir-scoped state dirs for the channel plugins the agent declares. Discord, Telegram, and Teams are already handled. ms365 was missing.

On a linux-user-isolated agent (v0.9.7+), the agent root `/home/ec2-user/.agent-bridge/agents/<X>` is `root:ab-agent-<X> 2750`. A stale roster value `MS365_STATE_DIR=.../agents/<X>/.ms365` (a pre-v2 path under that SetGID root) is inherited verbatim into the claude launch env. `plugins/ms365/server.ts` calls `mkdir(MS365_STATE_DIR)` in `ensureDirs()` at startup, the isolated UID has no write permission on the SetGID parent, the call fails with EACCES, and the MCP server exits before completing the MCP handshake. The `plugin:ms365:ms365` entry never appears in the interactive deferred tool registry, even though `claude mcp list` (which builds its own env) reports it Connected.

## Reproduction (before this PR)

Interactive `claude --debug --debug-file=...` on the affected isolated agent:

```
[ERROR] MCP server "plugin:ms365:ms365" Server stderr:
EACCES: permission denied, mkdir '/home/ec2-user/.agent-bridge/agents/sales_sean/.ms365'
    at ensureDirs (/home/ec2-user/.agent-bridge/plugins/ms365/server.ts:64:3)
[ERROR] MCP server "plugin:ms365:ms365" Connection failed: MCP error -32000
```

After the fix, the launcher rewrites `MS365_STATE_DIR` to the canonical `.../agents/<X>/workdir/.ms365` (which v0.9.7 isolation v2 already creates with `agent-bridge-<X>:ab-agent-<X> 2770` ownership), `ensureDirs()` succeeds, and `claude mcp list` from the same isolated UID reports:

```
ms365: bun --cwd .../ms365/0.1.0 ... server.ts - ✓ Connected
```

## Test plan

- [x] `bash -n lib/bridge-state.sh scripts/smoke-test.sh`
- [x] Manual helper exercise on an isolated host:
  - stale `MS365_STATE_DIR=/stale/.ms365` → canonicalized to `<workdir>/.ms365`
  - no `MS365_STATE_DIR` in raw → canonical value appended
  - teams + ms365 together → both canonicalized, unrelated `OTHER_ENV` preserved
- [x] `claude mcp list` (isolated UID, canonical env) reports `ms365: ✓ Connected`
- [ ] Smoke runner: new assertions colocated with existing Teams `TEAMS_DEV_STATE_DIR_LAUNCH` block; `./scripts/smoke-test.sh` was not run end-to-end in the verification turn.

## Out of scope

- ms365 plugin's `ensureDirs()` could improve its EACCES diagnostic (separate plugin track).
- cosmax-ep on the same agent fails with `EHOSTUNREACH 10.242.2.20:8000` — endpoint/network issue, not covered here.

refs #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)