### PR TITLE
fix(launch): split controller watcher budget — foreground gate + session-liveness

### DIFF
--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -35,6 +35,26 @@ bridge_start_dev_channels_accept_timeout() {
   printf '%s' "$accept_timeout"
 }
 
+# Time budget for Claude to reach the foreground (i.e. begin presenting its
+# trust/dev-channels prompts) AFTER tmux session creation. The controller
+# watcher arms immediately at tmux-create time, but on a fresh-plugin-cache
+# launch bridge-run.sh first runs bridge_run_sync_dev_plugin_cache for the
+# four configured channels, which can take 3-5 minutes; only then does it
+# exec `claude`. The previous design only had a single 60s prompt-accept
+# budget — so the controller watcher would time out before Claude even
+# started, leaving the trust/dev-channels prompts unanswered and the
+# operator stuck pressing Enter manually. Split budget: this one covers
+# "wait until claude is in the foreground" and is intentionally generous.
+# The existing accept timeout (default 60s) then covers "from foreground
+# to prompt accepted" which is typically <10s.
+bridge_start_dev_channels_claude_foreground_timeout() {
+  local foreground_timeout="${BRIDGE_START_DEV_CHANNELS_CLAUDE_FOREGROUND_TIMEOUT_SECONDS:-600}"
+
+  [[ "$foreground_timeout" =~ ^[0-9]+$ ]] || foreground_timeout=600
+  (( foreground_timeout > 0 )) || foreground_timeout=600
+  printf '%s' "$foreground_timeout"
+}
+
 bridge_start_effective_dev_channels_csv() {
   local agent="$1"
   local suppress_missing="${2:-0}"
@@ -114,18 +134,20 @@ bridge_start_schedule_dev_channels_accept() {
   local session="$1"
   local agent="$2"
   local accept_timeout=""
+  local foreground_timeout=""
   local log_dir=""
   local logfile="/dev/null"
   local errfile="/dev/null"
 
   accept_timeout="$(bridge_start_dev_channels_accept_timeout)"
+  foreground_timeout="$(bridge_start_dev_channels_claude_foreground_timeout)"
   log_dir="$(bridge_agent_log_dir "$agent")"
   if mkdir -p "$log_dir" 2>/dev/null; then
     logfile="$log_dir/$(date '+%Y%m%d').log"
     errfile="$log_dir/$(date '+%Y%m%d').err.log"
   fi
 
-  echo "[info] controller-side Claude development-channels auto-accept armed for '$session' (timeout=${accept_timeout}s)"
+  echo "[info] controller-side Claude development-channels auto-accept armed for '$session' (foreground=${foreground_timeout}s, accept=${accept_timeout}s)"
   (
     "$BRIDGE_BASH_BIN" -lc '
       set -euo pipefail
@@ -133,7 +155,23 @@ bridge_start_schedule_dev_channels_accept() {
       session="$2"
       agent="$3"
       accept_timeout="$4"
+      foreground_timeout="$5"
       source "$script_dir/bridge-lib.sh"
+      if ! bridge_tmux_session_exists "$session"; then
+        printf "[%s] [warn] controller auto-accept dev-channels skipped: tmux session=%s already gone\n" \
+          "$(date "+%Y-%m-%d %H:%M:%S")" "$session" >&2
+        exit 0
+      fi
+      if ! bridge_tmux_wait_for_claude_foreground "$session" "$foreground_timeout" 2 $((foreground_timeout / 2 + 1)); then
+        if ! bridge_tmux_session_exists "$session"; then
+          printf "[%s] [warn] controller auto-accept dev-channels aborted: tmux session=%s ended before claude foreground (likely plugin-cache or launch failure)\n" \
+            "$(date "+%Y-%m-%d %H:%M:%S")" "$session" >&2
+        else
+          printf "[%s] [warn] controller auto-accept dev-channels timeout waiting for claude foreground on session=%s agent=%s after %ss\n" \
+            "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent" "$foreground_timeout" >&2
+        fi
+        exit 0
+      fi
       if bridge_tmux_wait_for_prompt "$session" claude "$accept_timeout" 1; then
         printf "[%s] [info] controller auto-accept dev-channels completed on session=%s agent=%s\n" \
           "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent"
@@ -141,7 +179,7 @@ bridge_start_schedule_dev_channels_accept() {
         printf "[%s] [warn] controller auto-accept dev-channels failed/timeout on session=%s agent=%s\n" \
           "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent" >&2
       fi
-    ' -- "$SCRIPT_DIR" "$session" "$agent" "$accept_timeout"
+    ' -- "$SCRIPT_DIR" "$session" "$agent" "$accept_timeout" "$foreground_timeout"
   ) </dev/null >>"$logfile" 2>>"$errfile" &
 }
 

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -138,6 +138,9 @@ bridge_tmux_wait_for_claude_foreground() {
 
   start_ts="$(date +%s)"
   while (( checks < max_checks )); do
+    if ! bridge_tmux_session_exists "$session"; then
+      return 1
+    fi
     if bridge_tmux_pane_foreground_is_claude "$session"; then
       return 0
     fi

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10430,6 +10430,12 @@ bash "$REPO_ROOT/scripts/smoke/shared-settings-preserve-user-keys.sh"
 log "running precompact-notify suite smoke (issue #597 Track D)"
 bash "$REPO_ROOT/tests/precompact-notify/smoke.sh"
 
+# bridge_tmux_wait_for_claude_foreground must honor session liveness mid-poll
+# so a dead session does not burn the full foreground budget (controller
+# watcher P2 — bridge-start.sh:113 split-budget review r2).
+log "running tmux-wait-foreground-liveness smoke (controller watcher P2)"
+bash "$REPO_ROOT/tests/tmux-wait-foreground-liveness/smoke.sh"
+
 # Issue #639 — codex-task-mode-policy.py write-shape detector redesign
 # (default-deny block-mode allow-list + common-shape parser). Covers all
 # 6 D1 gaps (multi-command, substitution, quoting, exec/bash recursion,

--- a/tests/devchannels-controller-autoaccept/smoke.sh
+++ b/tests/devchannels-controller-autoaccept/smoke.sh
@@ -37,16 +37,27 @@ start_env_line="$(line_no 'SESSION_CMD="BRIDGE_CONTROLLER_DEV_CHANNELS_ACCEPT=1 
 sudo_wrap_line="$(line_no 'if [[ $SUDO_WRAP_ACTIVE -eq 1 ]]; then' "$START_SH")"
 tmux_new_line="$(line_no 'tmux new-session -d -s "$SESSION"' "$START_SH")"
 schedule_call_line="$(line_no 'bridge_start_schedule_dev_channels_accept "$SESSION" "$AGENT"' "$START_SH")"
+foreground_wait_line="$(line_no 'bridge_tmux_wait_for_claude_foreground "$session" "$foreground_timeout"' "$START_SH")"
 controller_wait_line="$(line_no 'if bridge_tmux_wait_for_prompt "$session" claude "$accept_timeout" 1; then' "$START_SH")"
 log_dir_line="$(line_no 'log_dir="$(bridge_agent_log_dir "$agent")"' "$START_SH")"
+session_exists_guard_line="$(line_no 'if ! bridge_tmux_session_exists "$session"; then' "$START_SH")"
+foreground_timeout_getter_line="$(line_no 'bridge_start_dev_channels_claude_foreground_timeout()' "$START_SH")"
 run_skip_line="$(line_no 'BRIDGE_CONTROLLER_DEV_CHANNELS_ACCEPT:-0' "$RUN_SH")"
 run_legacy_line="$(line_no 'if ! bridge_tmux_wait_for_prompt "$session" claude "$accept_timeout" 1; then' "$RUN_SH")"
 
 assert_before "$start_env_line" "$sudo_wrap_line" "controller flag must be embedded before sudo wrapping"
 assert_before "$tmux_new_line" "$schedule_call_line" "controller watcher must be scheduled after tmux session creation"
+assert_before "$session_exists_guard_line" "$foreground_wait_line" "session-exists guard must precede the foreground wait"
+assert_before "$foreground_wait_line" "$controller_wait_line" "controller watcher must wait for claude foreground before waiting for prompt"
 assert_before "$run_skip_line" "$run_legacy_line" "bridge-run skip must guard the legacy agent-side watcher"
 
 [[ -n "$controller_wait_line" ]] || die "controller watcher does not allow devchannels in wait_for_prompt"
 [[ -n "$log_dir_line" ]] || die "controller watcher is not logging through the agent log dir"
+[[ -n "$foreground_timeout_getter_line" ]] || die "controller watcher missing foreground-timeout getter"
 
-printf '[devchannels-controller-autoaccept][ok] controller-side devchannels auto-accept wiring present\n'
+# Confirm both budgets are surfaced in the armed-info log line so operators see
+# the split, not just a single 60s number that no longer matches reality.
+grep -qF 'foreground=${foreground_timeout}s, accept=${accept_timeout}s' "$START_SH" \
+  || die "controller watcher armed-info log line does not mention both timeouts (foreground + accept)"
+
+printf '[devchannels-controller-autoaccept][ok] controller-side devchannels auto-accept wiring + foreground gate present\n'

--- a/tests/tmux-wait-foreground-liveness/smoke.sh
+++ b/tests/tmux-wait-foreground-liveness/smoke.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Runtime regression: bridge_tmux_wait_for_claude_foreground must return
+# promptly when the tmux session dies mid-wait, not burn the full timeout
+# budget. Catches the P2 liveness edge raised on the controller-watcher
+# foreground gate (bridge-start.sh:113): without an in-loop session-exists
+# check, a hard plugin-cache failure (session exits while watcher is
+# waiting) leaves the watcher polling for the full foreground budget — up
+# to 10 minutes per failed start under the default 600s ceiling.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+die() {
+  printf '[tmux-wait-foreground-liveness][error] %s\n' "$*" >&2
+  exit 1
+}
+
+command -v tmux >/dev/null 2>&1 || die "tmux not on PATH; runtime smoke requires tmux"
+
+SOCKET="ab-fg-liveness-$$"
+SESSION="ab-fg-liveness-session-$$"
+SOCKET_DIR="$(mktemp -d)"
+export TMUX_TMPDIR="$SOCKET_DIR"
+
+cleanup() {
+  command tmux -L "$SOCKET" kill-server >/dev/null 2>&1 || true
+  [[ -n "${SOCKET_DIR:-}" && -d "$SOCKET_DIR" ]] && rm -rf "$SOCKET_DIR"
+}
+trap cleanup EXIT
+
+# Route every bridge-tmux call to our isolated socket. Bash resolves function
+# names at call time, so this override applies to functions sourced below.
+tmux() { command tmux -L "$SOCKET" "$@"; }
+export -f tmux
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/lib/bridge-tmux.sh"
+
+tmux new-session -d -s "$SESSION" 'sleep 300'
+tmux has-session -t "$SESSION" >/dev/null 2>&1 \
+  || die "failed to create isolated test tmux session"
+
+# Kill the session ~1s into the wait. The helper must observe the dead
+# session and return rc=1 within a poll cycle, not after the 10s timeout.
+( sleep 1 && command tmux -L "$SOCKET" kill-session -t "=$SESSION" >/dev/null 2>&1 || true ) &
+killer_pid=$!
+
+rc=0
+t0=$(date +%s)
+bridge_tmux_wait_for_claude_foreground "$SESSION" 10 1 12 >/dev/null 2>&1 || rc=$?
+t1=$(date +%s)
+elapsed=$(( t1 - t0 ))
+
+wait "$killer_pid" 2>/dev/null || true
+
+(( rc == 1 )) || die "expected rc=1 from helper, got rc=$rc"
+(( elapsed <= 4 )) \
+  || die "expected helper to return within 4s of session-kill, got elapsed=${elapsed}s (in-loop session-liveness check missing or broken)"
+
+printf '[tmux-wait-foreground-liveness][ok] helper returned rc=1 in %ss after session kill (budget=10s)\n' "$elapsed"


### PR DESCRIPTION
## Summary
- split controller-side dev-channel auto-accept into a long Claude foreground wait and the existing prompt accept window
- keep the watcher on the controller side for isolated UID agents, but avoid burning the prompt timeout while bridge-run is still syncing plugin caches
- make bridge_tmux_wait_for_claude_foreground return promptly when the tmux session dies mid-wait, avoiding stale 10-minute watcher processes after hard plugin-cache failures

## Evidence / Rationale
Round-6 sales_sean restarts showed repeated controller auto-accept timeouts while a fresh multi-plugin cache sync was still running. The watcher was armed at tmux-create time, but Claude did not reach foreground until minutes later, so trust/dev-channel prompts were left unanswered.

Review r1 found that the first split-budget patch still left a stale foreground watcher if the tmux session exited during the long foreground wait. The r2 commit adds an in-loop session-liveness check and a runtime smoke for that exact failure mode.

## Verification
- bash -n lib/bridge-tmux.sh tests/tmux-wait-foreground-liveness/smoke.sh tests/devchannels-controller-autoaccept/smoke.sh scripts/smoke-test.sh
- bash tests/tmux-wait-foreground-liveness/smoke.sh
- bash tests/devchannels-controller-autoaccept/smoke.sh
- git diff --check 8704b15^ 8704b15
- manual killed-session repro: bridge_tmux_wait_for_claude_foreground returned rc=1 in 2s instead of waiting for the 10s test budget

Register-only PR; do not merge until operator approval.