### PR TITLE
fix(daily-backup): skip isolated-agent EACCES files instead of aborting archive (refs #785)

### DIFF
--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -1203,6 +1203,14 @@ def create_daily_backup_archive(
         with contextlib.suppress(FileNotFoundError):
             tmp_path.unlink()
 
+        # Issue #785: under v0.9.7 unified isolation, files inside
+        # `agents/<X>/` are owned by `agent-bridge-<X>:ab-agent-<X>` with
+        # `0640/0700`. The controller (`ec2-user`) can `readdir` the parent
+        # (2750 SetGID) but cannot `open` the inner files. Without a
+        # per-member catch the first EACCES aborts the whole archive after
+        # writing 0 bytes. Mirrors the `agent_migration` PermissionError
+        # pattern (above) — accumulate skip records, surface in JSON.
+        skipped_isolated: list[dict[str, str]] = []
         try:
             with tarfile.open(
                 tmp_path, "w:gz", format=tarfile.PAX_FORMAT, dereference=False
@@ -1214,22 +1222,49 @@ def create_daily_backup_archive(
                         stat_result = os.lstat(src_path)
                     except FileNotFoundError:
                         continue
+                    except PermissionError:
+                        skipped_isolated.append({"path": str(src_path), "stage": "lstat"})
+                        continue
                     if S_ISSOCK(stat_result.st_mode) or S_ISFIFO(stat_result.st_mode):
                         continue
-                    archive.add(src_path, arcname=arcname, recursive=False)
+                    try:
+                        archive.add(src_path, arcname=arcname, recursive=False)
+                    except PermissionError:
+                        skipped_isolated.append({"path": str(src_path), "stage": "add"})
+                        continue
+                    except OSError as exc:
+                        # CPython usually raises PermissionError, but
+                        # tarfile.add may surface raw OSError(EACCES) for
+                        # certain paths; treat both as the same isolation
+                        # boundary.
+                        if exc.errno == errno.EACCES:
+                            skipped_isolated.append({"path": str(src_path), "stage": "add"})
+                            continue
+                        raise
 
                 # Explicitly add today's snapshot dumps. The walk excluded
                 # state/backup-snapshots/ so prior days' dumps don't bloat
-                # this archive.
+                # this archive. Snapshots are written by the controller so
+                # EACCES is unlikely, but defend symmetrically with the main
+                # loop in case a future snapshot path becomes isolated.
                 for entry in snapshots:
                     snap_path = Path(entry["snapshot_path"])
                     if not snap_path.exists():
                         continue
-                    archive.add(
-                        snap_path,
-                        arcname=entry["snapshot_relpath"],
-                        recursive=False,
-                    )
+                    try:
+                        archive.add(
+                            snap_path,
+                            arcname=entry["snapshot_relpath"],
+                            recursive=False,
+                        )
+                    except PermissionError:
+                        skipped_isolated.append({"path": str(snap_path), "stage": "add_snapshot"})
+                        continue
+                    except OSError as exc:
+                        if exc.errno == errno.EACCES:
+                            skipped_isolated.append({"path": str(snap_path), "stage": "add_snapshot"})
+                            continue
+                        raise
         except OSError as exc:
             with contextlib.suppress(FileNotFoundError):
                 tmp_path.unlink()
@@ -1263,6 +1298,18 @@ def create_daily_backup_archive(
             result["archive_bytes"] = archive_path.stat().st_size
         except FileNotFoundError:
             result["archive_bytes"] = 0
+        if skipped_isolated:
+            # Bound the path list so operator JSON stays grep-able even when
+            # an isolated agent home has thousands of files (e.g. venv).
+            result["skipped_isolated_count"] = len(skipped_isolated)
+            if len(skipped_isolated) <= 60:
+                result["skipped_isolated"] = skipped_isolated
+            else:
+                result["skipped_isolated"] = (
+                    skipped_isolated[:50]
+                    + [{"path": "...", "stage": "truncated"}]
+                    + skipped_isolated[-10:]
+                )
         return result
 
 
@@ -2076,6 +2123,13 @@ def cmd_daily_backup_live(args: argparse.Namespace) -> int:
         payload["archive_bytes"] = result["archive_bytes"]
     if "error_detail" in result:
         payload["error_detail"] = result["error_detail"]
+    # Issue #785: surface per-member EACCES skips so operators can see what
+    # was excluded from the archive instead of treating a partial-but-created
+    # outcome as a silent success.
+    if "skipped_isolated_count" in result:
+        payload["skipped_isolated_count"] = result["skipped_isolated_count"]
+    if "skipped_isolated" in result:
+        payload["skipped_isolated"] = result["skipped_isolated"]
 
     if result["outcome"] == "created":
         payload["created"] = True


### PR DESCRIPTION
## Summary

Daily-backup walker aborts the entire archive on the first EACCES from a
per-UID isolated-agent file. Under v0.9.7 unified isolation, the controller
(`ec2-user`) can `readdir` an `agents/<X>/` SetGID 2750 parent but cannot
`open` the inner files (owned by `agent-bridge-<X>:ab-agent-<X>` mode 0640).
The first `archive.add()` raises `PermissionError`, the outer `except OSError`
catches it, returns `outcome=error_oserror_13`, and the daemon's daily slot
fails every day with a 1-hour cooldown.

This change adds per-member EACCES skip with `skipped_isolated` accumulation,
mirroring the proven pattern in `agent_migration` (line 553-569) and
`_resolve_free_bytes_override` (line 932). The walker now produces a partial
archive plus a structured `skipped_isolated` list in the JSON outcome so
operators see exactly what was excluded.

## Changes

- `bridge-upgrade.py:create_daily_backup_archive`
  - Per-member `try/except PermissionError / except OSError(EACCES)` around
    both `os.lstat` and `archive.add`. Both exception shapes are caught
    because CPython raises `PermissionError` for most paths but `tarfile.add`
    can surface raw `OSError(EACCES)` depending on the underlying call.
  - Same defensive guard on the snapshot append loop (defense-in-depth — the
    controller writes snapshots today, but the contract should be symmetric).
  - Bounded `skipped_isolated` list (first 50 + truncation marker + last 10)
    so operator JSON stays grep-able when an isolated home has thousands of
    files (e.g. `.memkraft-venv`).
  - `skipped_isolated_count` + `skipped_isolated` propagated into result JSON.
- `bridge-upgrade.py:cmd_daily_backup_live` — propagate the new fields to
  the operator-facing CLI payload.

## Test plan

Mock EACCES reproducer:

\`\`\`bash
TMP=\$(mktemp -d)
mkdir -p \"\$TMP/agents/test\" \"\$TMP/state\" \"\$TMP/backups/daily\"
echo 'test' > \"\$TMP/agents/test/CLAUDE.md\"
chmod 0000 \"\$TMP/agents/test/CLAUDE.md\"  # simulate isolated UID readability gap
python3 bridge-upgrade.py daily-backup-live \\
  --target-root \"\$TMP\" --backup-dir \"\$TMP/backups/daily\"
\`\`\`

**Before this PR:** `outcome=error_oserror_13`, archive aborts at 0 bytes.

**After this PR:**
\`\`\`
outcome: created
archive_bytes: 343
skipped_isolated_count: 1
skipped_isolated[0].path: .../agents/test/CLAUDE.md
skipped_isolated[0].stage: add
\`\`\`

- [x] `python3 -c \"import ast; ast.parse(open('bridge-upgrade.py').read())\"` — pass
- [x] Mock reproducer on Python 3.9.6 (system) — pass
- [x] Mock reproducer on Python 3.14.4 (Homebrew) — pass
- [x] `scripts/smoke-test.sh` in isolated `BRIDGE_HOME` — pass
- [ ] Operator-host validation: run `\$BRIDGE_HOME/bridge-upgrade.py daily-backup-live` on a v0.9.7 production install with at least one linux-user-isolated agent registered; confirm `outcome=created` and `skipped_isolated_count >= 1` with paths under `agents/<isolated-agent>/`

## Scope

- NO matrix change
- NO env var change
- NO VERSION / CHANGELOG bump
- Optional follow-up (auto-extend `iter_daily_backup_members` with isolated home prefixes, mirroring `BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS`) tracked separately per operator's issue note

refs #785

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>