### PR TITLE
fix(lint): SC2088 false-positive in bridge_expand_user_path (unblocks CI)

### DIFF
--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -251,7 +251,7 @@ bridge_expand_user_path() {
   case "$raw" in
     '')   printf '%s' "" ;;
     '~')  printf '%s' "$HOME" ;;
-    '~/'*) printf '%s%s' "$HOME" "${raw#\~}" ;;
+    \~/*) printf '%s%s' "$HOME" "${raw:1}" ;;
     *)    printf '%s' "$raw" ;;
   esac
 }


### PR DESCRIPTION
## Summary

`lib/bridge-core.sh:254` carried a case-pattern `'~/'*` that shellcheck flags as **SC2088** ("Tilde does not expand in quotes. Use \$HOME."). The warning was a false-positive — tildes in case-pattern labels never expand in bash, regardless of quoting — but the CI `lint` job runs at `--severity=warning` with `set -e`, so the single warning broke CI and gated every downstream smoke job (`unit/static smoke`, `integration smoke`, `live/tmux/daemon smoke`, `legacy-full-smoke`).

CI on `main` has been red since 2026-05-09 (push 25600170798). PR #790, PR #793, and every v0.9.6+ release push has had red CI for two-plus days, even though the warning had nothing to do with the changes in those PRs.

### The fix (one line)

```diff
-    '~/'*) printf '%s%s' "$HOME" "${raw#\~}" ;;
+    \~/*) printf '%s%s' "$HOME" "${raw:1}" ;;
```

- Pattern `\~/*` is a literal escaped tilde with no quotes, so SC2088 has nothing to fire on.
- Body `${raw:1}` strips the first character. The `\~/*` pattern guarantees `$raw` starts with `~/`, so this is byte-equivalent to the previous `${raw#\~}`.
- No `# shellcheck disable=SC2088` — masking the rule in the function scope could hide a future genuine SC2088 elsewhere.

### Why not just disable the rule?

A `# shellcheck disable=SC2088` directive would mask the rule for the rest of the function (or worse, file scope if placed loosely). Rewriting the pattern removes the surface the rule fires on without taking the rule off the table for any future code.

### Note on the brief

The dispatching brief proposed only swapping the body's `${raw#\~}` for `${raw:1}`. That alone did NOT clear the warning, because shellcheck's report column was on the case-pattern (`'~/'` at column 5), not on the body. Verified locally with `shellcheck --format=json1` before and after the body-only change — warning persisted. Kept the body's `${raw:1}` improvement (still a readability win the brief endorsed) and also rewrote the pattern.

## Test plan

- [x] `bash -n lib/bridge-core.sh` — passes.
- [x] `shellcheck --severity=warning lib/bridge-core.sh` — clean.
- [x] Full CI lint scope: `shellcheck --severity=warning *.sh agent-bridge agb lib/*.sh scripts/*.sh scripts/smoke/*.sh agent-roster.local.example.sh` — no SC2088. (Note: local shellcheck 0.11.0 reports SC2327/SC2328 in `scripts/smoke/queue.sh:408,410`, but those are pre-existing on `main` HEAD `a2519b0` and CI's older shellcheck does not flag them — confirmed by reading the lint log of run `25638203537`, which printed exactly one warning, the SC2088 this PR removes.)
- [x] Behavior parity for the canonical five inputs:
  - `~/.agent-bridge` → `$HOME/.agent-bridge`
  - `~` → `$HOME`
  - `/abs/path` → `/abs/path`
  - `rel/path` → `rel/path`
  - `""` → `""`
- [x] Edge cases: `~/` → `$HOME/`, `~/a/b/c` → `$HOME/a/b/c`, `~foo` → `~foo` (literal — not expanded, as before).
- [ ] CI green on this PR.
- [ ] After merge: re-trigger CI on PR #790 and PR #793 — both should now go green.

## Unblocks

- PR #790
- PR #793
- v0.9.6+ release pushes

🤖 Generated with [Claude Code](https://claude.com/claude-code)