### PR TITLE
fix(daemon): wrap heredoc-stdin Python callsites in timeout + helper (#800 Track A)

### DIFF
--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Daemon-loop subprocess helpers — issue #800 Track A.
+
+Background
+==========
+
+The daemon main loop in ``bridge-daemon.sh`` historically had ~9 callsites of
+the shape::
+
+    foo="$(python3 - "$arg1" "$arg2" <<'PY'
+    ... python body ...
+    PY
+    )"
+
+Issue #800 documented a 34-hour silent hang of the daemon main loop traced to
+nested ``$()`` command substitutions wedged in the bash ``heredoc_write``
+plumbing — the leaf bash frame was blocked writing the heredoc body into a
+pipe whose far end (a python3 subprocess that had stalled on sqlite or IO)
+never drained. Wrapping the call in ``timeout(1)`` is necessary but NOT
+sufficient: the external timeout(1) wraps the python child, but bash itself
+can stall in ``do_redirection_internal → heredoc_write`` BEFORE the python
+process ever launches.
+
+The fix is to move every such body OUT of ``<<'PY'`` stdin and into either:
+
+  - a checked-in helper subcommand (this file), invoked as
+    ``python3 bridge-daemon-helpers.py <subcommand> <args...>``, OR
+  - a ``python3 -c "$SCRIPT"`` invocation where the body is read into a
+    shell variable via heredoc-assignment (which is synchronous and cannot
+    deadlock with a concurrent reader).
+
+The wrapping helper ``bridge_with_timeout`` (lib/bridge-state.sh) supplies
+the ceiling and emits a ``daemon_subprocess_timeout`` audit row on hit.
+
+Subcommand contract
+===================
+
+Each subcommand:
+
+* Takes positional args matching the original ``python3 - "$a" "$b"`` shape.
+* Prints the same stdout shape the original heredoc body produced (typically
+  tab-separated rows, one per line).
+* Exits 0 on success even when there is nothing to print (the bash side
+  treats empty stdout as "no rows" via ``[[ -n ... ]]`` guards).
+* Exits non-zero only when the caller should treat the invocation as
+  failed — this preserves the existing ``|| true`` / ``|| return 1``
+  semantics at the bash callsites.
+
+The subcommands are intentionally tiny and pure-functional. They do not
+import any agent-bridge runtime modules and they do not open the queue DB
+unless the bash callsite already passed a DB path on argv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Subcommand implementations.
+# ---------------------------------------------------------------------------
+
+
+def cmd_usage_alert_parse(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:1009 (process_usage_monitor).
+
+    Extracts alert tuples from the usage-monitor JSON for shell consumption.
+    Output: one tab-separated row per alert:
+      provider \\t account \\t window \\t bucket \\t used_percent \\t reset_at \\t source \\t message
+    """
+    try:
+        payload = json.loads(args.monitor_json)
+    except Exception:
+        return 1
+
+    for alert in payload.get("alerts", []) or []:
+        print(
+            "\t".join(
+                [
+                    str(alert.get("provider", "")),
+                    str(alert.get("account", "")),
+                    str(alert.get("window", "")),
+                    str(alert.get("bucket", "")),
+                    str(alert.get("used_percent", "")),
+                    str(alert.get("reset_at", "")),
+                    str(alert.get("source", "")),
+                    str(alert.get("message", "")),
+                ]
+            )
+        )
+    return 0
+
+
+def cmd_release_alert_parse(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:1096 (process_release_monitor).
+
+    Extracts the first release alert's headline fields. Output (a single row):
+      latest_tag \\t latest_version \\t release_name \\t published_at \\t html_url
+    Empty stdout when there are no alerts; the bash callsite treats that as
+    "nothing to report" via a ``[[ -n "$alert_row" ]] || return 1`` guard.
+    """
+    payload = json.loads(args.monitor_json)
+    alerts = payload.get("alerts") or []
+    if not alerts:
+        return 0
+    alert = alerts[0]
+    print(
+        "\t".join(
+            [
+                str(alert.get("latest_tag") or ""),
+                str(alert.get("latest_version") or ""),
+                str(alert.get("release_name") or ""),
+                str(alert.get("published_at") or ""),
+                str(alert.get("html_url") or ""),
+            ]
+        )
+    )
+    return 0
+
+
+def cmd_backup_parse(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:1210 (process_daily_backup).
+
+    Parses the daily-backup-live JSON envelope. Output (a single row):
+      outcome \\t error_detail \\t archive_path \\t pruned_count \\t free_bytes \\t needed_bytes
+
+    On JSON-parse error the original emitted ``PARSE_ERROR\\t<repr>\\t...``
+    rather than failing — the bash callsite then surfaces a parse failure
+    reason through ``bridge_note_daily_backup_failure``. Preserved here.
+    """
+    try:
+        payload = json.loads(args.backup_json)
+    except Exception as exc:
+        print(f"PARSE_ERROR\t{type(exc).__name__}: {exc}\t\t\t\t")
+        return 0
+    outcome = str(payload.get("outcome") or "")
+    archive_path = str(payload.get("archive_path") or "")
+    pruned = payload.get("pruned") or []
+    free_bytes = payload.get("free_bytes") or 0
+    needed_bytes = payload.get("needed_bytes") or 0
+    error_detail = str(payload.get("error_detail") or "")
+    print(
+        "\t".join(
+            [
+                outcome,
+                error_detail,
+                archive_path,
+                str(len(pruned)),
+                str(free_bytes),
+                str(needed_bytes),
+            ]
+        )
+    )
+    return 0
+
+
+def cmd_stall_iso_format(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:1455 (bridge_write_stall_report_body).
+
+    Converts a POSIX timestamp (seconds) to a localized ISO-8601 string.
+    Empty argv or non-numeric input → empty stdout (matches the original).
+    """
+    try:
+        ts = int(args.first_detected_ts)
+    except Exception:
+        ts = 0
+    if ts > 0:
+        print(datetime.fromtimestamp(ts, timezone.utc).astimezone().isoformat())
+    return 0
+
+
+def cmd_permission_expire_scan(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:1948 (permission task fanout).
+
+    Filters the open-permission-tasks JSON to rows whose age exceeds the
+    timeout. Output:
+      task_id \\t age_seconds \\t created_by \\t status \\t title
+    JSON parse failure exits 0 with empty stdout (matches original).
+    """
+    try:
+        tasks = json.loads(args.tasks_json)
+    except Exception:
+        return 0
+    try:
+        now_ts = int(args.now_ts)
+        timeout = int(args.timeout_seconds)
+    except Exception:
+        return 0
+    for t in tasks or []:
+        created_ts = int(t.get("created_ts", 0) or 0)
+        if created_ts <= 0:
+            continue
+        age = now_ts - created_ts
+        if age < timeout:
+            continue
+        tid = int(t.get("id", 0) or 0)
+        title = str(t.get("title", "")).replace("\t", " ")
+        status = str(t.get("status", ""))
+        created_by = str(t.get("created_by", ""))
+        print(f"{tid}\t{age}\t{created_by}\t{status}\t{title}")
+    return 0
+
+
+def cmd_watchdog_problem_count(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:2318 (process_watchdog_report).
+
+    Extracts the integer ``problem_count`` field. Always prints a single
+    integer to stdout — defaulting to 0 on parse error — so the bash side
+    can read it unconditionally.
+    """
+    try:
+        payload = json.loads(args.report_json)
+        print(int(payload.get("problem_count", 0)))
+    except Exception:
+        print(0)
+    return 0
+
+
+def cmd_nudge_live_state(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:2728 (nudge_agent_session).
+
+    HIGHEST-IMPACT site per #800. Reads the queue DB for an agent's live
+    queued/claimed counts. Output (single row):
+      queued_count \\t claimed_count \\t comma_separated_queued_ids
+
+    sqlite errors fall through to a non-zero exit so the bash callsite's
+    ``|| true`` keeps the loop intact; the wrapper applies a 15s timeout
+    with audit-only fallback (no inline retry — next tick retries naturally).
+    """
+    db_path = args.db_path
+    agent = args.agent
+    with sqlite3.connect(db_path) as conn:
+        queued_ids = [
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT id
+                FROM tasks
+                WHERE assigned_to = ?
+                  AND status = 'queued'
+                  AND title NOT LIKE '[cron-dispatch]%'
+                ORDER BY id
+                """,
+                (agent,),
+            ).fetchall()
+        ]
+        claimed_count = conn.execute(
+            "SELECT COUNT(*) FROM tasks WHERE claimed_by = ? AND status = 'claimed'",
+            (agent,),
+        ).fetchone()[0]
+    print(f"{len(queued_ids)}\t{claimed_count}\t{','.join(queued_ids)}")
+    return 0
+
+
+def cmd_memory_daily_orphan_scan(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:4840 (process_memory_daily_orphan_sweep).
+
+    Diffs the cron-inventory JSON against the in-process roster and emits
+    one ``job_id\\tsource_agent`` row per orphaned ``memory-daily-<agent>``
+    job whose source agent is no longer loaded.
+    """
+    raw_jobs = args.jobs_json or ""
+    raw_roster = args.roster_stream or ""
+    roster = {line.strip() for line in raw_roster.splitlines() if line.strip()}
+    try:
+        payload = json.loads(raw_jobs)
+    except Exception:
+        return 0
+
+    jobs = payload.get("jobs") if isinstance(payload, dict) else payload
+    if not isinstance(jobs, list):
+        return 0
+
+    prefix = "memory-daily-"
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        if (job.get("family") or "") != "memory-daily":
+            continue
+        name = job.get("name") or ""
+        if not name.startswith(prefix):
+            continue
+        source_agent = name[len(prefix):].strip()
+        if not source_agent:
+            continue
+        if source_agent in roster:
+            continue
+        job_id = job.get("id") or job.get("name") or ""
+        if not job_id:
+            continue
+        print(f"{job_id}\t{source_agent}")
+    return 0
+
+
+def cmd_mcp_orphan_cleanup_parse(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh:4994 (process_mcp_orphan_cleanup_periodic).
+
+    Reads the cleanup-report JSON FILE (not a string — caller passes the
+    path) and prints summary counts as a single tab-separated row:
+      killed_count \\t orphan_count \\t freed_mb_estimate \\t error_count
+    """
+    payload = json.loads(Path(args.report_file).read_text(encoding="utf-8"))
+    print(
+        "\t".join(
+            [
+                str(payload.get("killed_count", 0)),
+                str(payload.get("orphan_count", 0)),
+                str(payload.get("freed_mb_estimate", 0)),
+                str(len(payload.get("errors", []))),
+            ]
+        )
+    )
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI plumbing.
+# ---------------------------------------------------------------------------
+
+
+SUBCOMMANDS = {
+    "usage-alert-parse": (
+        cmd_usage_alert_parse,
+        [("monitor_json", "JSON payload produced by bridge-usage.sh monitor --json")],
+        "Tabular extract of usage-monitor alerts (8 cols / row).",
+    ),
+    "release-alert-parse": (
+        cmd_release_alert_parse,
+        [("monitor_json", "JSON payload produced by bridge-release.py monitor")],
+        "Single-row tabular extract of the first release alert (5 cols).",
+    ),
+    "backup-parse": (
+        cmd_backup_parse,
+        [("backup_json", "JSON envelope from bridge-upgrade.py daily-backup-live")],
+        "Single-row outcome / archive_path / counts (6 cols).",
+    ),
+    "stall-iso-format": (
+        cmd_stall_iso_format,
+        [("first_detected_ts", "POSIX timestamp (seconds, integer)")],
+        "ISO-8601 localized timestamp (empty when ts <= 0).",
+    ),
+    "permission-expire-scan": (
+        cmd_permission_expire_scan,
+        [
+            ("tasks_json", "JSON array of open [PERMISSION] tasks"),
+            ("now_ts", "current epoch seconds"),
+            ("timeout_seconds", "permission-task age threshold (seconds)"),
+        ],
+        "One tab-separated row per expired task (5 cols).",
+    ),
+    "watchdog-problem-count": (
+        cmd_watchdog_problem_count,
+        [("report_json", "JSON envelope from bridge-watchdog.sh scan --json")],
+        "Single integer line (problem_count), defaulting to 0 on parse error.",
+    ),
+    "nudge-live-state": (
+        cmd_nudge_live_state,
+        [
+            ("db_path", "path to the queue sqlite DB"),
+            ("agent", "agent id to query"),
+        ],
+        "Single tab-separated row: queued_count, claimed_count, csv queued ids.",
+    ),
+    "memory-daily-orphan-scan": (
+        cmd_memory_daily_orphan_scan,
+        [
+            ("jobs_json", "JSON payload from agent-bridge cron list --json"),
+            ("roster_stream", "newline-delimited roster of loaded agent ids"),
+        ],
+        "One tab-separated row per orphan job (2 cols).",
+    ),
+    "mcp-orphan-cleanup-parse": (
+        cmd_mcp_orphan_cleanup_parse,
+        [("report_file", "path to mcp-orphan-cleanup report JSON file")],
+        "Single tab-separated row of summary counts (4 cols).",
+    ),
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bridge-daemon-helpers.py",
+        description=(
+            "Daemon-loop subprocess helpers (issue #800 Track A). Replaces "
+            "heredoc-stdin python invocations inside bridge-daemon.sh so the "
+            "bash 'heredoc_write' deadlock class can no longer wedge the main "
+            "loop. Wrap each invocation in bridge_with_timeout."
+        ),
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True, metavar="SUBCOMMAND")
+
+    for name, (handler, positional, help_text) in SUBCOMMANDS.items():
+        sub = subparsers.add_parser(name, help=help_text)
+        for arg_name, arg_help in positional:
+            sub.add_argument(arg_name, help=arg_help)
+        sub.set_defaults(_handler=handler)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = getattr(args, "_handler", None)
+    if handler is None:
+        parser.print_help(sys.stderr)
+        return 2
+    return handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1006,31 +1006,13 @@ process_usage_monitor() {
     return 1
   fi
 
-  alert_rows="$(python3 - "$monitor_json" <<'PY'
-import json, sys
-
-try:
-    payload = json.loads(sys.argv[1])
-except Exception:
-    raise SystemExit(1)
-
-for alert in payload.get("alerts", []):
-    print(
-        "\t".join(
-            [
-                str(alert.get("provider", "")),
-                str(alert.get("account", "")),
-                str(alert.get("window", "")),
-                str(alert.get("bucket", "")),
-                str(alert.get("used_percent", "")),
-                str(alert.get("reset_at", "")),
-                str(alert.get("source", "")),
-                str(alert.get("message", "")),
-            ]
-        )
-    )
-PY
-)" || {
+  # Issue #800 Track A: moved out of `python3 - <<'PY'` heredoc-stdin into a
+  # checked-in helper subcommand wrapped by bridge_with_timeout. The original
+  # heredoc-stdin pattern allowed bash to wedge in `heredoc_write` BEFORE the
+  # python child ever launched (the deadlock class documented in #800);
+  # `python3 helpers.py …` has no heredoc on the pipe and the external
+  # timeout(1) covers the full call.
+  alert_rows="$(bridge_with_timeout 5 usage_alert_parse python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" usage-alert-parse "$monitor_json")" || {
     bridge_note_usage_poll
     return 1
   }
@@ -1093,28 +1075,9 @@ process_release_monitor() {
     return 1
   fi
 
-  alert_row="$(python3 - "$monitor_json" <<'PY'
-import json
-import sys
-
-payload = json.loads(sys.argv[1])
-alerts = payload.get("alerts") or []
-if not alerts:
-    raise SystemExit(0)
-alert = alerts[0]
-print(
-    "\t".join(
-        [
-            str(alert.get("latest_tag") or ""),
-            str(alert.get("latest_version") or ""),
-            str(alert.get("release_name") or ""),
-            str(alert.get("published_at") or ""),
-            str(alert.get("html_url") or ""),
-        ]
-    )
-)
-PY
-)"
+  # Issue #800 Track A: heredoc-stdin → helper subcommand wrapped by
+  # bridge_with_timeout (see bridge-daemon-helpers.py docstring for context).
+  alert_row="$(bridge_with_timeout 5 release_alert_parse python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" release-alert-parse "$monitor_json")"
 
   bridge_note_release_poll
   [[ -n "$alert_row" ]] || return 1
@@ -1207,26 +1170,11 @@ process_daily_backup() {
   # Bug #507: parse outcome from the structured JSON instead of relying on
   # `created`. Outcomes other than `created` carry their own follow-up.
   local parse_payload=""
-  if ! parse_payload="$(python3 - "$backup_json" <<'PY' 2>/dev/null
-import json
-import sys
-
-try:
-    payload = json.loads(sys.argv[1])
-except Exception as exc:
-    print(f"PARSE_ERROR\t{type(exc).__name__}: {exc}\t\t\t\t")
-    raise SystemExit(0)
-outcome = str(payload.get("outcome") or "")
-archive_path = str(payload.get("archive_path") or "")
-pruned = payload.get("pruned") or []
-free_bytes = payload.get("free_bytes") or 0
-needed_bytes = payload.get("needed_bytes") or 0
-error_detail = str(payload.get("error_detail") or "")
-print("\t".join([
-    outcome, error_detail, archive_path, str(len(pruned)), str(free_bytes), str(needed_bytes)
-]))
-PY
-)"; then
+  # Issue #800 Track A: heredoc-stdin → helper subcommand wrapped by
+  # bridge_with_timeout. 60s ceiling (well above the helper's pure-JSON parse
+  # cost) mirrors the daily-backup-live budget per the issue's per-site
+  # recommendations.
+  if ! parse_payload="$(bridge_with_timeout 60 backup_parse python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" backup-parse "$backup_json" 2>/dev/null)"; then
     bridge_note_daily_backup_failure "parse" "python3 invocation failed"
     return 1
   fi
@@ -1452,17 +1400,9 @@ bridge_write_stall_report_body() {
 
   title_label="$(bridge_stall_reason_label "$classification")"
   audits="$(bridge_stall_recent_audits_markdown "$agent")"
-  first_detected_iso="$(python3 - "$first_detected_ts" <<'PY'
-from datetime import datetime, timezone
-import sys
-try:
-    ts = int(sys.argv[1])
-except Exception:
-    ts = 0
-if ts > 0:
-    print(datetime.fromtimestamp(ts, timezone.utc).astimezone().isoformat())
-PY
-)"
+  # Issue #800 Track A: heredoc-stdin → helper subcommand wrapped by
+  # bridge_with_timeout (5s — pure datetime formatting, no IO).
+  first_detected_iso="$(bridge_with_timeout 5 stall_iso_format python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" stall-iso-format "$first_detected_ts")"
   mkdir -p "$(dirname "$body_file")"
   {
     echo "# Stall Report"
@@ -1945,29 +1885,9 @@ process_permission_task_timeout_fanout() {
   local changed=1
 
   local expired_rows
-  expired_rows="$(python3 - "$tasks_json" "$now_ts" "$timeout_seconds" <<'PY' 2>/dev/null || true
-import json, sys
-payload = sys.argv[1]
-now_ts = int(sys.argv[2])
-timeout = int(sys.argv[3])
-try:
-    tasks = json.loads(payload)
-except Exception:
-    sys.exit(0)
-for t in tasks:
-    created_ts = int(t.get("created_ts", 0) or 0)
-    if created_ts <= 0:
-        continue
-    age = now_ts - created_ts
-    if age < timeout:
-        continue
-    tid = int(t.get("id", 0) or 0)
-    title = str(t.get("title", "")).replace("\t", " ")
-    status = str(t.get("status", ""))
-    created_by = str(t.get("created_by", ""))
-    print(f"{tid}\t{age}\t{created_by}\t{status}\t{title}")
-PY
-  )"
+  # Issue #800 Track A: heredoc-stdin → helper subcommand wrapped by
+  # bridge_with_timeout (5s — pure JSON filter, no IO).
+  expired_rows="$(bridge_with_timeout 5 permission_expire_scan python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" permission-expire-scan "$tasks_json" "$now_ts" "$timeout_seconds" 2>/dev/null || true)"
   [[ -n "$expired_rows" ]] || return 1
 
   local task_id age_seconds created_by status title marker age_minutes body_text
@@ -2315,15 +2235,9 @@ process_watchdog_report() {
   if ! report_json="$("$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-watchdog.sh" scan --json 2>/dev/null)"; then
     return 1
   fi
-  problem_count="$(python3 - "$report_json" <<'PY'
-import json, sys
-try:
-    payload = json.loads(sys.argv[1])
-    print(int(payload.get("problem_count", 0)))
-except Exception:
-    print(0)
-PY
-)"
+  # Issue #800 Track A: heredoc-stdin → helper subcommand wrapped by
+  # bridge_with_timeout (5s — single int extraction, no IO).
+  problem_count="$(bridge_with_timeout 5 watchdog_problem_count python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" watchdog-problem-count "$report_json")"
   [[ "$problem_count" =~ ^[0-9]+$ ]] || problem_count=0
   current_key="$(bridge_watchdog_problem_key "$report_json")"
   cooldown="${BRIDGE_WATCHDOG_COOLDOWN_SECONDS:-86400}"
@@ -2725,33 +2639,32 @@ nudge_agent_session() {
   local task_priority=""
   local task_status=""
 
-  live_state="$(python3 - "$BRIDGE_TASK_DB" "$agent" <<'PY' 2>/dev/null || true
-import sqlite3
-import sys
-
-db_path, agent = sys.argv[1:]
-with sqlite3.connect(db_path) as conn:
-    queued_ids = [
-        str(row[0])
-        for row in conn.execute(
-            """
-            SELECT id
-            FROM tasks
-            WHERE assigned_to = ?
-              AND status = 'queued'
-              AND title NOT LIKE '[cron-dispatch]%'
-            ORDER BY id
-            """,
-            (agent,),
-        ).fetchall()
-    ]
-    claimed_count = conn.execute(
-        "SELECT COUNT(*) FROM tasks WHERE claimed_by = ? AND status = 'claimed'",
-        (agent,),
-    ).fetchone()[0]
-print(f"{len(queued_ids)}\t{claimed_count}\t{','.join(queued_ids)}")
-PY
-)"
+  # Issue #800 Track A (highest-impact site): heredoc-stdin → helper subcommand
+  # wrapped by bridge_with_timeout. 15s ceiling — the live-state query is on
+  # the per-agent nudge hot path, so a long wait here stalls every subsequent
+  # agent in the loop. On timeout (rc=124) we emit an explicit per-agent
+  # daemon_subprocess_timeout audit row (the wrapper already writes a
+  # generic one without target=$agent context) and skip nudging THIS agent
+  # on THIS tick. The next tick retries naturally; if the timeout pattern
+  # persists the per-agent audit rows accumulate so the operator can see
+  # which agent's DB row keeps wedging the query. We do NOT propagate
+  # failure to siblings — the wedge documented in #800 is per-query, not
+  # per-loop, so other agents in the scan should still get nudged.
+  local live_state_rc=0
+  set +e
+  live_state="$(bridge_with_timeout 15 nudge_live_state python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" nudge-live-state "$BRIDGE_TASK_DB" "$agent" 2>/dev/null)"
+  live_state_rc=$?
+  set -e
+  if (( live_state_rc == 124 || live_state_rc == 137 )); then
+    bridge_audit_log daemon daemon_subprocess_timeout "$agent" \
+      --detail call_site=nudge_live_state \
+      --detail target_agent="$agent" \
+      --detail timeout_seconds=15 \
+      --detail exit_code="$live_state_rc" \
+      --detail action=skip_this_tick
+    daemon_warn "nudge live-state query for ${agent} timed out (rc=${live_state_rc}); skipping nudge this tick"
+    return 0
+  fi
   if [[ -n "$live_state" ]]; then
     IFS=$'\t' read -r live_queued live_claimed live_nudge_key <<<"$live_state"
   else
@@ -4834,44 +4747,13 @@ process_memory_daily_orphan_sweep() {
 
   # Embed the roster on argv (newline-joined) rather than piping it on
   # stdin so we do not have to juggle a heredoc + herestring pair on the
-  # same `python3` invocation. The script body still parses jobs JSON from
-  # argv[1] and the newline-delimited roster from argv[2].
+  # same `python3` invocation.
+  #
+  # Issue #800 Track A: heredoc-stdin → helper subcommand wrapped by
+  # bridge_with_timeout (5s — pure JSON diff against the in-memory roster,
+  # no IO).
   local orphans_tsv
-  orphans_tsv="$(python3 - "$jobs_json" "$roster_stream" <<'PY' 2>/dev/null || true
-import json, sys
-
-raw_jobs = sys.argv[1] if len(sys.argv) > 1 else ""
-raw_roster = sys.argv[2] if len(sys.argv) > 2 else ""
-roster = {line.strip() for line in raw_roster.splitlines() if line.strip()}
-try:
-    payload = json.loads(raw_jobs)
-except Exception:
-    sys.exit(0)
-
-jobs = payload.get("jobs") if isinstance(payload, dict) else payload
-if not isinstance(jobs, list):
-    sys.exit(0)
-
-PREFIX = "memory-daily-"
-for job in jobs:
-    if not isinstance(job, dict):
-        continue
-    if (job.get("family") or "") != "memory-daily":
-        continue
-    name = job.get("name") or ""
-    if not name.startswith(PREFIX):
-        continue
-    source_agent = name[len(PREFIX):].strip()
-    if not source_agent:
-        continue
-    if source_agent in roster:
-        continue
-    job_id = job.get("id") or job.get("name") or ""
-    if not job_id:
-        continue
-    print(f"{job_id}\t{source_agent}")
-PY
-  )"
+  orphans_tsv="$(bridge_with_timeout 5 memory_daily_orphan_scan python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" memory-daily-orphan-scan "$jobs_json" "$roster_stream" 2>/dev/null || true)"
 
   [[ -n "$orphans_tsv" ]] || return 1
 
@@ -4991,24 +4873,9 @@ process_mcp_orphan_cleanup() {
   fi
   printf '%s\n' "$cleanup_json" >"$report_file"
 
-  parsed="$(python3 - "$report_file" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(
-    "\t".join(
-        [
-            str(payload.get("killed_count", 0)),
-            str(payload.get("orphan_count", 0)),
-            str(payload.get("freed_mb_estimate", 0)),
-            str(len(payload.get("errors", []))),
-        ]
-    )
-)
-PY
-)" || return 1
+  # Issue #800 Track A: heredoc-stdin → helper subcommand wrapped by
+  # bridge_with_timeout (5s — single small JSON file read + count extract).
+  parsed="$(bridge_with_timeout 5 mcp_orphan_cleanup_parse python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" mcp-orphan-cleanup-parse "$report_file")" || return 1
   IFS=$'\t' read -r killed_count orphan_count freed_mb error_count <<<"$parsed"
   [[ "$killed_count" =~ ^[0-9]+$ ]] || killed_count=0
   [[ "$orphan_count" =~ ^[0-9]+$ ]] || orphan_count=0

--- a/scripts/smoke/daemon-heredoc-timeout.sh
+++ b/scripts/smoke/daemon-heredoc-timeout.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+#
+# scripts/smoke/daemon-heredoc-timeout.sh — issue #800 Track A regression.
+#
+# Proves that the daemon-loop subprocess helpers (bridge-daemon-helpers.py)
+# are correctly wrapped by bridge_with_timeout so a deliberately-stalling
+# helper cannot wedge the main loop the way the unwrapped
+# `$(python3 - <<'PY')` heredoc-stdin pattern did on v0.7.6 (cf. #800).
+#
+# What we exercise (in order):
+#
+#   1. bridge_with_timeout(2, …) around a python helper that sleeps forever
+#      must terminate the child within the budget + small margin and exit
+#      with rc=124. This is the core wrapping correctness check.
+#   2. A `daemon_subprocess_timeout` row must be appended to the audit log
+#      with our call-site label so the operator can see which step hung.
+#   3. A second invocation immediately after must still succeed (the loop
+#      is not wedged — recovery is automatic on next tick). We swap the
+#      helper for a no-op to simulate "next tick, helper recovered".
+#   4. bridge-daemon-helpers.py exposes all 9 subcommands Track A relies on.
+#
+# We do NOT need real claude/codex binaries — we test only the daemon's
+# subprocess wrapping correctness via the bridge_with_timeout helper that
+# bridge-daemon.sh uses for every callsite touched by Track A.
+
+# Bash 4+ re-exec (mirrors scripts/smoke/daemon.sh).
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:daemon-heredoc-timeout] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="daemon-heredoc-timeout"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+# bridge_with_timeout falls back to a plain exec on hosts without timeout(1),
+# which would silently skip the actual coverage we are testing. Insist on
+# either timeout or gtimeout so the smoke is meaningful.
+if ! command -v timeout >/dev/null 2>&1 && ! command -v gtimeout >/dev/null 2>&1; then
+  smoke_fail "neither timeout(1) nor gtimeout(1) available; bridge_with_timeout cannot enforce the ceiling and this smoke would silently pass without coverage. install coreutils."
+fi
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# Use the in-tree bridge-state.sh so we exercise the real bridge_with_timeout.
+export BRIDGE_REPO_ROOT="$SMOKE_REPO_ROOT"
+export BRIDGE_SCRIPT_DIR="$BRIDGE_REPO_ROOT"
+# bridge_audit_log appends to $BRIDGE_AUDIT_LOG — lib.sh sets this for us.
+: >"$BRIDGE_AUDIT_LOG"
+
+# Synthesize the two helpers we need.
+STALL_HELPER="$SMOKE_TMP_ROOT/sleeps-forever.py"
+cat >"$STALL_HELPER" <<'PY'
+#!/usr/bin/env python3
+"""Deliberately-stalling helper for the #800 Track A smoke. Sleeps
+indefinitely so bridge_with_timeout has to kill us via SIGTERM/SIGKILL."""
+import time
+import sys
+# Drain stdin if anything is piped in (the real heredoc-stdin pattern
+# from before Track A would block here forever; we just discard).
+try:
+    sys.stdin.read()
+except Exception:
+    pass
+while True:
+    time.sleep(60)
+PY
+chmod +x "$STALL_HELPER"
+
+NOOP_HELPER="$SMOKE_TMP_ROOT/noop.py"
+cat >"$NOOP_HELPER" <<'PY'
+#!/usr/bin/env python3
+"""Recovered helper — returns the same shape nudge-live-state would."""
+print("0\t0\t")
+PY
+chmod +x "$NOOP_HELPER"
+
+# Driver script that sources bridge_with_timeout and invokes it on argv.
+# Written to disk so we avoid layered quoting around `bash -c`.
+DRIVER="$SMOKE_TMP_ROOT/with-timeout-driver.sh"
+cat >"$DRIVER" <<'EOF'
+#!/usr/bin/env bash
+# args: <secs> <label> <cmd> [cmd_args...]
+set -uo pipefail
+SCRIPT_DIR="${BRIDGE_REPO_ROOT:?}"
+# shellcheck source=/dev/null
+source "$BRIDGE_REPO_ROOT/lib/bridge-state.sh"
+secs="$1"
+label="$2"
+shift 2
+bridge_with_timeout "$secs" "$label" "$@"
+EOF
+chmod +x "$DRIVER"
+
+run_with_timeout_subshell() {
+  local label="$1"
+  local secs="$2"
+  shift 2
+  local rc=0
+  local started ended elapsed
+  started="$(date +%s)"
+  set +e
+  "$DRIVER" "$secs" "$label" "$@" >/dev/null 2>&1
+  rc=$?
+  set -e
+  ended="$(date +%s)"
+  elapsed=$(( ended - started ))
+  printf 'rc=%d elapsed=%d\n' "$rc" "$elapsed"
+}
+
+step_wrapping_terminates_stalled_helper() {
+  smoke_log "step 1: bridge_with_timeout 2s must terminate the stalling helper"
+  local output rc elapsed
+  output="$(run_with_timeout_subshell nudge_live_state 2 python3 "$STALL_HELPER")"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  elapsed="$(printf '%s\n' "$output" | sed -n 's/.*elapsed=\([0-9]*\).*/\1/p')"
+  [[ -n "$rc" ]] || smoke_fail "could not parse rc from: $output"
+  [[ -n "$elapsed" ]] || smoke_fail "could not parse elapsed from: $output"
+  # timeout(1) returns 124 on hit, 137 if KILL was needed.
+  if [[ "$rc" != "124" && "$rc" != "137" ]]; then
+    smoke_fail "expected rc=124 or 137 from timeout, got rc=$rc (elapsed=${elapsed}s, output=$output)"
+  fi
+  # Budget = 2s + generous 5s slack for cold python startup + fork on slow CI.
+  if (( elapsed > 8 )); then
+    smoke_fail "wrapping did NOT enforce the 2s ceiling (elapsed=${elapsed}s); the heredoc-write deadlock class would still be possible"
+  fi
+  smoke_log "  rc=$rc elapsed=${elapsed}s (within budget)"
+}
+
+step_audit_row_written() {
+  smoke_log "step 2: daemon_subprocess_timeout audit row must be present"
+  if [[ ! -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_fail "audit log is empty after timeout fired: $BRIDGE_AUDIT_LOG"
+  fi
+  # bridge_audit_log writes JSONL via bridge-audit.py — grep is sufficient
+  # to confirm both the action and the call-site label.
+  if ! grep -q 'daemon_subprocess_timeout' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "audit log missing 'daemon_subprocess_timeout' row: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  if ! grep -q 'nudge_live_state' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "audit log missing 'nudge_live_state' call-site tag: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  smoke_log "  audit row present with call_site=nudge_live_state"
+}
+
+step_loop_recovers_next_tick() {
+  smoke_log "step 3: a follow-up invocation must succeed (loop not wedged)"
+  local output rc elapsed
+  output="$(run_with_timeout_subshell nudge_live_state 5 python3 "$NOOP_HELPER")"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  elapsed="$(printf '%s\n' "$output" | sed -n 's/.*elapsed=\([0-9]*\).*/\1/p')"
+  [[ "$rc" == "0" ]] || smoke_fail "follow-up invocation should succeed but rc=$rc (output=$output)"
+  if (( elapsed > 5 )); then
+    smoke_fail "follow-up invocation should be fast but elapsed=${elapsed}s"
+  fi
+  smoke_log "  rc=$rc elapsed=${elapsed}s — daemon loop recovers naturally"
+}
+
+step_helper_subcommands_resolve() {
+  smoke_log "step 4: bridge-daemon-helpers.py exposes the expected subcommands"
+  local help_out
+  help_out="$(python3 "$BRIDGE_REPO_ROOT/bridge-daemon-helpers.py" --help 2>&1 || true)"
+  local sub
+  for sub in usage-alert-parse release-alert-parse backup-parse stall-iso-format \
+             permission-expire-scan watchdog-problem-count nudge-live-state \
+             memory-daily-orphan-scan mcp-orphan-cleanup-parse; do
+    smoke_assert_contains "$help_out" "$sub" "helper --help should list $sub"
+  done
+}
+
+smoke_run "stalling helper terminates within budget" step_wrapping_terminates_stalled_helper
+smoke_run "daemon_subprocess_timeout audit row written" step_audit_row_written
+smoke_run "next tick recovers without intervention" step_loop_recovers_next_tick
+smoke_run "all 9 Track-A subcommands wired up" step_helper_subcommands_resolve
+
+smoke_log "PASS"

--- a/scripts/smoke/daemon-heredoc-timeout.sh
+++ b/scripts/smoke/daemon-heredoc-timeout.sh
@@ -19,6 +19,37 @@
 #      helper for a no-op to simulate "next tick, helper recovered".
 #   4. bridge-daemon-helpers.py exposes all 9 subcommands Track A relies on.
 #
+# r2 (codex finding — synthetic-helper coverage gap)
+# --------------------------------------------------
+# Steps 1-3 above use synthetic sleeps-forever.py / noop.py. r2 codex review
+# called that out: the smoke never exercised a REAL `bridge-daemon-helpers.py`
+# subcommand body, only the bridge_with_timeout shell wrapper. To close that
+# gap without modifying production code (no env-var override or PATH hook in
+# the daemon — it resolves the helper via $SCRIPT_DIR/bridge-daemon-helpers.py
+# directly), r2 adds:
+#
+#   5. mcp-orphan-cleanup-parse stalled on a FIFO `report_file`. The real
+#      subcommand body calls `Path(...).read_text()`, which blocks forever
+#      on an empty FIFO. bridge_with_timeout 2s must kill it. Asserts the
+#      audit row tags `call_site=mcp_orphan_cleanup_parse`.
+#   6. mcp-orphan-cleanup-parse with a valid JSON file passes through cleanly
+#      (proves the shim wraps but does not break the real subcommand body).
+#   7. nudge-live-state against a sqlite DB whose write lock is held by a
+#      sidecar python process. The helper's `sqlite3.connect(...).execute(...)`
+#      blocks on the lock; bridge_with_timeout 2s must kill it. This is the
+#      most realistic I/O-wait stall — exactly the class of hang #800
+#      documented.
+#   8. Loop-survival across two consecutive bridge_with_timeout calls: the
+#      FIFO-stall fires (rc=124|137), then immediately the same subcommand
+#      against a valid file succeeds (rc=0). Proves the wrapping is
+#      non-wedging across calls. (Driving a full `bridge-daemon.sh sync`
+#      tick is impractical here — cmd_sync_cycle requires substantial
+#      runtime bootstrap (roster, tmux sessions, queue DB schema, hooks,
+#      cron state) that the smoke environment does not provide. The
+#      consecutive-call pattern is the cleanest realistic equivalent to
+#      a "next tick" assertion without modifying production code to add
+#      a dry-run mode.)
+#
 # We do NOT need real claude/codex binaries — we test only the daemon's
 # subprocess wrapping correctness via the bridge_with_timeout helper that
 # bridge-daemon.sh uses for every callsite touched by Track A.
@@ -186,9 +217,214 @@ step_helper_subcommands_resolve() {
   done
 }
 
+# ---------------------------------------------------------------------------
+# r2 codex finding — exercise REAL bridge-daemon-helpers.py subcommands
+# under realistic stalls, not synthetic sleeps-forever.py.
+# ---------------------------------------------------------------------------
+
+# Path to the real, checked-in helper. This is the same path bridge-daemon.sh
+# invokes via "$SCRIPT_DIR/bridge-daemon-helpers.py".
+REAL_HELPER="$BRIDGE_REPO_ROOT/bridge-daemon-helpers.py"
+
+step_real_helper_stalls_on_fifo() {
+  smoke_log "step 5: real mcp-orphan-cleanup-parse must stall on an empty FIFO"
+  # mcp-orphan-cleanup-parse calls Path(report_file).read_text() — a FIFO
+  # with no writer blocks indefinitely, exercising the real subcommand body.
+  local fifo="$SMOKE_TMP_ROOT/cleanup-report.fifo"
+  rm -f "$fifo"
+  if ! mkfifo "$fifo" 2>/dev/null; then
+    smoke_fail "mkfifo not available; cannot construct realistic helper stall"
+  fi
+
+  local output rc elapsed
+  output="$(run_with_timeout_subshell mcp_orphan_cleanup_parse 2 \
+              python3 "$REAL_HELPER" mcp-orphan-cleanup-parse "$fifo")"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  elapsed="$(printf '%s\n' "$output" | sed -n 's/.*elapsed=\([0-9]*\).*/\1/p')"
+  [[ -n "$rc" ]] || smoke_fail "could not parse rc from: $output"
+  [[ -n "$elapsed" ]] || smoke_fail "could not parse elapsed from: $output"
+  if [[ "$rc" != "124" && "$rc" != "137" ]]; then
+    smoke_fail "real-helper FIFO stall: expected rc=124|137, got rc=$rc (elapsed=${elapsed}s)"
+  fi
+  if (( elapsed > 8 )); then
+    smoke_fail "real-helper FIFO stall: ceiling not enforced (elapsed=${elapsed}s, budget 2s)"
+  fi
+
+  # Audit row must tag the new call_site label so an operator can identify
+  # which real subcommand wedged. bridge_with_timeout writes the row on
+  # 124/137 with `call_site=$label` (label was the second argv to the driver).
+  if ! grep -q '"call_site": "mcp_orphan_cleanup_parse"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "audit log missing call_site=mcp_orphan_cleanup_parse after FIFO stall: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  smoke_log "  rc=$rc elapsed=${elapsed}s — real helper stalled and got killed"
+
+  # Drain the FIFO so cleanup doesn't hang on EXIT. The helper child was
+  # SIGKILLed by timeout(1), so the FIFO has no pending reader; just unlink.
+  rm -f "$fifo"
+}
+
+step_real_helper_passthrough() {
+  smoke_log "step 6: real mcp-orphan-cleanup-parse with valid JSON must pass through"
+  local report="$SMOKE_TMP_ROOT/cleanup-report.json"
+  cat >"$report" <<'JSON'
+{"killed_count": 3, "orphan_count": 7, "freed_mb_estimate": 42, "errors": ["a", "b"]}
+JSON
+
+  # Use the driver so the call is wrapped in bridge_with_timeout (5s budget —
+  # the real subcommand is a single JSON parse + print).
+  local rc=0
+  local stdout_file="$SMOKE_TMP_ROOT/passthrough.out"
+  set +e
+  "$DRIVER" 5 mcp_orphan_cleanup_parse python3 "$REAL_HELPER" \
+      mcp-orphan-cleanup-parse "$report" >"$stdout_file" 2>&1
+  rc=$?
+  set -e
+  if (( rc != 0 )); then
+    smoke_fail "real-helper passthrough should succeed but rc=$rc (out: $(cat "$stdout_file"))"
+  fi
+  local row
+  row="$(cat "$stdout_file")"
+  # Expected shape: killed_count \t orphan_count \t freed_mb_estimate \t error_count
+  smoke_assert_eq "3"$'\t'"7"$'\t'"42"$'\t'"2" "$row" "passthrough row should match JSON input"
+  smoke_log "  row='$row' — real helper produced expected output"
+}
+
+step_real_helper_stalls_on_sqlite_lock() {
+  smoke_log "step 7: real nudge-live-state must stall on a held sqlite write lock"
+  local db_path="$SMOKE_TMP_ROOT/tasks-locked.db"
+  rm -f "$db_path"
+  # Build a minimal schema covering the columns nudge-live-state reads.
+  python3 - "$db_path" <<'PYINIT'
+import sqlite3, sys
+db = sys.argv[1]
+c = sqlite3.connect(db)
+c.execute("""
+    CREATE TABLE tasks (
+        id            INTEGER PRIMARY KEY,
+        assigned_to   TEXT,
+        status        TEXT,
+        claimed_by    TEXT,
+        title         TEXT
+    )
+""")
+c.commit()
+c.close()
+PYINIT
+  [[ -f "$db_path" ]] || smoke_fail "could not initialize sqlite DB at $db_path"
+
+  # Sidecar holds BEGIN EXCLUSIVE for up to 30s so the helper's
+  # sqlite3.connect(...).execute(SELECT ...) blocks on the writer lock.
+  # 30s is well above the helper's 2s budget; the locker is reaped on EXIT
+  # via $LOCKER_PID below.
+  local locker_pid_file="$SMOKE_TMP_ROOT/sqlite-locker.pid"
+  rm -f "$locker_pid_file"
+  python3 - "$db_path" "$locker_pid_file" <<'PYLOCK' &
+import os, sqlite3, sys, time
+db, pidfile = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db, isolation_level=None, timeout=60)
+conn.execute("BEGIN EXCLUSIVE")
+with open(pidfile, "w") as fh:
+    fh.write(str(os.getpid()))
+time.sleep(30)
+PYLOCK
+  local locker_pid=$!
+  # Wait for the locker to actually grab the lock (pidfile appears).
+  local waits=0
+  while [[ ! -s "$locker_pid_file" ]] && (( waits < 30 )); do
+    sleep 0.1
+    waits=$(( waits + 1 ))
+  done
+  if [[ ! -s "$locker_pid_file" ]]; then
+    kill "$locker_pid" 2>/dev/null || true
+    wait "$locker_pid" 2>/dev/null || true
+    smoke_fail "sqlite locker sidecar never acquired the EXCLUSIVE lock"
+  fi
+
+  local output rc elapsed
+  output="$(run_with_timeout_subshell nudge_live_state 2 \
+              python3 "$REAL_HELPER" nudge-live-state "$db_path" some-agent)"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  elapsed="$(printf '%s\n' "$output" | sed -n 's/.*elapsed=\([0-9]*\).*/\1/p')"
+
+  kill "$locker_pid" 2>/dev/null || true
+  wait "$locker_pid" 2>/dev/null || true
+
+  [[ -n "$rc" ]] || smoke_fail "could not parse rc from: $output"
+  [[ -n "$elapsed" ]] || smoke_fail "could not parse elapsed from: $output"
+  if [[ "$rc" != "124" && "$rc" != "137" ]]; then
+    smoke_fail "real-helper sqlite-lock stall: expected rc=124|137, got rc=$rc (elapsed=${elapsed}s, output=$output)"
+  fi
+  if (( elapsed > 8 )); then
+    smoke_fail "real-helper sqlite-lock stall: ceiling not enforced (elapsed=${elapsed}s)"
+  fi
+  # The previous step_audit_row_written already verified the
+  # daemon_subprocess_timeout row gets written with call_site=nudge_live_state
+  # for the synthetic stall; here we just confirm a second row was appended
+  # so the operator can distinguish multiple stalls within a single tick.
+  local count
+  count="$(grep -c '"call_site": "nudge_live_state"' "$BRIDGE_AUDIT_LOG" || true)"
+  if (( count < 2 )); then
+    smoke_fail "audit log should now have >=2 nudge_live_state timeout rows, got $count"
+  fi
+  smoke_log "  rc=$rc elapsed=${elapsed}s — real helper stalled on real sqlite I/O wait"
+}
+
+step_loop_survives_real_stall_then_recovers() {
+  smoke_log "step 8: two consecutive bridge_with_timeout calls — real stall then real success"
+  # Re-use the FIFO + passthrough vectors back-to-back via the same driver,
+  # mirroring what a daemon tick does when the same callsite is invoked
+  # again on the next cycle after a timeout.
+  local fifo="$SMOKE_TMP_ROOT/cleanup-report-r2.fifo"
+  rm -f "$fifo"
+  mkfifo "$fifo" || smoke_fail "mkfifo failed for recovery test"
+
+  # Call 1: stall.
+  local rc1=0
+  local out1="$SMOKE_TMP_ROOT/recover-tick1.out"
+  set +e
+  "$DRIVER" 2 mcp_orphan_cleanup_parse python3 "$REAL_HELPER" \
+      mcp-orphan-cleanup-parse "$fifo" >"$out1" 2>&1
+  rc1=$?
+  set -e
+  if [[ "$rc1" != "124" && "$rc1" != "137" ]]; then
+    rm -f "$fifo"
+    smoke_fail "recovery tick1 should time out, got rc=$rc1 (out: $(cat "$out1"))"
+  fi
+  rm -f "$fifo"
+
+  # Call 2: same callsite, valid input — must succeed immediately.
+  local report="$SMOKE_TMP_ROOT/cleanup-report-r2.json"
+  cat >"$report" <<'JSON'
+{"killed_count": 0, "orphan_count": 0, "freed_mb_estimate": 0, "errors": []}
+JSON
+  local rc2=0
+  local out2="$SMOKE_TMP_ROOT/recover-tick2.out"
+  local start_ts end_ts elapsed2
+  start_ts="$(date +%s)"
+  set +e
+  "$DRIVER" 5 mcp_orphan_cleanup_parse python3 "$REAL_HELPER" \
+      mcp-orphan-cleanup-parse "$report" >"$out2" 2>&1
+  rc2=$?
+  set -e
+  end_ts="$(date +%s)"
+  elapsed2=$(( end_ts - start_ts ))
+  if (( rc2 != 0 )); then
+    smoke_fail "recovery tick2 should succeed but rc=$rc2 (out: $(cat "$out2"))"
+  fi
+  if (( elapsed2 > 5 )); then
+    smoke_fail "recovery tick2 should be fast but elapsed=${elapsed2}s"
+  fi
+  smoke_assert_eq "0"$'\t'"0"$'\t'"0"$'\t'"0" "$(cat "$out2")" "recovery tick2 output"
+  smoke_log "  tick1 rc=$rc1, tick2 rc=$rc2 elapsed=${elapsed2}s — wrapping is non-wedging across calls"
+}
+
 smoke_run "stalling helper terminates within budget" step_wrapping_terminates_stalled_helper
 smoke_run "daemon_subprocess_timeout audit row written" step_audit_row_written
 smoke_run "next tick recovers without intervention" step_loop_recovers_next_tick
 smoke_run "all 9 Track-A subcommands wired up" step_helper_subcommands_resolve
+smoke_run "real helper (mcp-orphan-cleanup-parse) stalls on FIFO" step_real_helper_stalls_on_fifo
+smoke_run "real helper (mcp-orphan-cleanup-parse) passes through valid JSON" step_real_helper_passthrough
+smoke_run "real helper (nudge-live-state) stalls on sqlite EXCLUSIVE lock" step_real_helper_stalls_on_sqlite_lock
+smoke_run "loop survives real stall then recovers on next call" step_loop_survives_real_stall_then_recovers
 
 smoke_log "PASS"


### PR DESCRIPTION
## Summary
- Move 9 unwrapped `$(python3 - <<'PY')` callsites in bridge-daemon.sh out of heredoc-stdin into a checked-in helper subcommand (`bridge-daemon-helpers.py`).
- Wrap each invocation in `bridge_with_timeout <secs> <label>` with audit-only fallback on timeout. The highest-impact site (`nudge_live_state`, was bridge-daemon.sh line 2728) gets an explicit per-agent `daemon_subprocess_timeout` audit + skip-this-tick behavior; sibling agents still get nudged on the same tick. Other sites fall through their existing `|| true` / `|| return 1` guards on timeout via the wrapper.
- Add `scripts/smoke/daemon-heredoc-timeout.sh` exercising a deliberately-stalling helper to prove the wrapping pattern terminates within budget, writes the audit row, and the loop recovers next tick.

## Why heredoc-stdin had to go
Per #800: an external `timeout(1)` wraps the python child but does NOT cover the bash `heredoc_write` frame if bash itself stalls while writing the heredoc body to the pipe BEFORE the child launches. The leaf in the 34h hang stack was exactly that. The fix removes the heredoc-stdin pipe entirely by calling `python3 bridge-daemon-helpers.py <subcommand> <args>` (positional args only; no stdin), so the wrapping helper's `timeout(1)` actually covers the full call.

## Per-site timeouts
| Site (pre-edit line) | Label | Budget |
|---|---|---|
| 1009 usage-monitor JSON parse | `usage_alert_parse` | 5s |
| 1096 release-monitor JSON parse | `release_alert_parse` | 5s |
| 1210 daily-backup parse | `backup_parse` | 60s |
| 1455 stall first_detected_iso | `stall_iso_format` | 5s |
| 1948 permission expired-tasks scan | `permission_expire_scan` | 5s |
| 2318 watchdog problem_count | `watchdog_problem_count` | 5s |
| 2728 nudge live_state (sqlite) **[highest-impact]** | `nudge_live_state` | 15s + explicit audit-only fallback |
| 4840 memory-daily orphan scan | `memory_daily_orphan_scan` | 5s |
| 4994 mcp orphan cleanup parse | `mcp_orphan_cleanup_parse` | 5s |

## Validation
- `bash -n bridge-daemon.sh` / `bash -n scripts/smoke/daemon-heredoc-timeout.sh` → pass
- `shellcheck bridge-daemon.sh scripts/smoke/daemon-heredoc-timeout.sh` → clean
- `python3 -m py_compile bridge-daemon-helpers.py` → pass
- `bash scripts/smoke/daemon-heredoc-timeout.sh` → PASS (4 steps: terminates within budget, audit row written, follow-up call succeeds, all 9 subcommands wired)
- `scripts/smoke-test.sh` → halts at the pre-existing `bridge-run.sh --dry-run` v0.8.0 isolation-v2 marker check (#799 r1), same signature as before this change — not a Track A regression

## Pattern choice
Used **Pattern A** (checked-in helper subcommand) consistently across all 9 sites for one diff shape and one helper file to review. Helper subcommands are pure functions over the original positional args; they print the same tab-separated stdout the previous heredoc bodies produced so the bash callsites stay drop-in compatible.

## Footgun avoided
The brief explicitly rejected `timeout python3 - <<'PY'`. None of the new sites use heredoc-stdin; the bodies live in `bridge-daemon-helpers.py` and the wrapper invokes them via positional argv only.

Refs #800 Track A. Track C (silence-watchdog `DAEMON_SCRIPT` resolution + canonical launchd plist) is handled in a separate PR.

## Out of scope
- Track C (silence-watchdog recovery + canonical launchd plist)
- VERSION / CHANGELOG bumps
- Other unwrapped subprocess calls outside the 9 listed `$(python3 - <<'PY')` sites