### PR TITLE
fix(watchdog): bind DAEMON_SCRIPT to BRIDGE_HOME + ship launchd plist + pidlock (#800 Track C)

### DIFF
--- a/bridge-bootstrap.sh
+++ b/bridge-bootstrap.sh
@@ -31,6 +31,7 @@ Bootstrap options:
   --skip-launchagent      Do not install/load the macOS LaunchAgent
   --skip-systemd          Do not install/enable the Linux systemd user unit
   --skip-liveness         Do not install the daemon liveness watcher (issue #265 D)
+  --skip-watchdog-silence Do not install the silence watchdog OS unit (issue #800 C)
   --dry-run
   --json
 
@@ -50,6 +51,7 @@ skip_daemon=0
 skip_launchagent=0
 skip_systemd=0
 skip_liveness=0
+skip_watchdog_silence=0
 dry_run=0
 json_mode=0
 init_args=()
@@ -84,6 +86,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-liveness)
       skip_liveness=1
+      shift
+      ;;
+    --skip-watchdog-silence)
+      skip_watchdog_silence=1
       shift
       ;;
     --dry-run)
@@ -131,6 +137,7 @@ daemon_status="skipped"
 launchagent_status="skipped"
 systemd_status="skipped"
 liveness_status="skipped"
+watchdog_silence_status="skipped"
 next_command="agb admin"
 reload_command="source \"$bootstrap_rcfile\" || export PATH=\"\$HOME/.agent-bridge:\$PATH\""
 bootstrap_os="${BRIDGE_BOOTSTRAP_OS:-$(uname -s)}"
@@ -213,8 +220,52 @@ if [[ $skip_liveness -eq 0 ]]; then
   esac
 fi
 
+# Issue #800 Track C: install the silence-watchdog OS unit alongside the
+# liveness watcher. The two are sibling recovery layers — liveness checks
+# the heartbeat-file mtime on a timer, silence-watchdog reads audit `ts`
+# columns from the log and stop+starts the daemon when no tick has been
+# written in the threshold window. Both must be canonical OS-managed
+# processes; ad-hoc launches from test sessions / worktrees were what
+# the issue documented as the recurring failure mode.
+if [[ $skip_watchdog_silence -eq 0 ]]; then
+  case "$bootstrap_os" in
+    Darwin)
+      if [[ $skip_launchagent -eq 1 ]]; then
+        watchdog_silence_status="skipped"
+      else
+        watchdog_silence_status="planned"
+        if [[ $dry_run -eq 0 ]]; then
+          "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/scripts/install-watchdog-silence-launchagent.sh" --apply --load >/dev/null
+          watchdog_silence_status="loaded"
+        fi
+      fi
+      ;;
+    Linux)
+      if [[ $skip_systemd -eq 1 ]]; then
+        watchdog_silence_status="skipped"
+      else
+        watchdog_silence_status="planned"
+        if [[ $dry_run -eq 0 ]]; then
+          "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/scripts/install-watchdog-silence-systemd.sh" --apply --enable >/dev/null
+          watchdog_silence_status="enabled"
+        fi
+      fi
+      ;;
+    *)
+      watchdog_silence_status="unsupported"
+      ;;
+  esac
+
+  # Cleanup orphan watchdog instances left behind by prior test sessions
+  # before launchd/systemd kickstart claims the canonical slot. This is
+  # idempotent — a fresh install with nothing to clean is a no-op.
+  if [[ $dry_run -eq 0 && -f "$SCRIPT_DIR/bridge-watchdog-silence.py" ]]; then
+    python3 "$SCRIPT_DIR/bridge-watchdog-silence.py" cleanup-orphans >/dev/null 2>&1 || true
+  fi
+fi
+
 if [[ $json_mode -eq 1 ]]; then
-  python3 - "$init_json" "$shell_status" "$bootstrap_shell" "$bootstrap_rcfile" "$daemon_status" "$launchagent_status" "$systemd_status" "$next_command" "$reload_command" "$liveness_status" <<'PY'
+  python3 - "$init_json" "$shell_status" "$bootstrap_shell" "$bootstrap_rcfile" "$daemon_status" "$launchagent_status" "$systemd_status" "$next_command" "$reload_command" "$liveness_status" "$watchdog_silence_status" <<'PY'
 import json
 import sys
 
@@ -231,6 +282,7 @@ payload = {
     "launchagent": {"status": sys.argv[6]},
     "systemd": {"status": sys.argv[7]},
     "liveness": {"status": sys.argv[10]},
+    "watchdog_silence": {"status": sys.argv[11]},
     "next_command": sys.argv[8],
     "reload_command": sys.argv[9],
     "handoff_steps": [
@@ -258,6 +310,7 @@ printf 'daemon: %s\n' "$daemon_status"
 printf 'launchagent: %s\n' "$launchagent_status"
 printf 'systemd: %s\n' "$systemd_status"
 printf 'liveness: %s\n' "$liveness_status"
+printf 'watchdog_silence: %s\n' "$watchdog_silence_status"
 printf 'rc_reload_command: %s\n' "$reload_command"
 echo
 echo "handoff:"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -6042,12 +6042,12 @@ cmd_status() {
     # supervises) cannot block `daemon status` itself. The watchdog status
     # path opens the audit JSONL and seeks into it; on a healthy host this
     # returns in <100ms, on a sick host we'd rather show stale-or-missing
-    # rows than hang the daemon status caller.
-    if command -v timeout >/dev/null 2>&1; then
-      watchdog_out="$(timeout 5 python3 "$watchdog_py" status 2>/dev/null || true)"
-    else
-      watchdog_out="$(python3 "$watchdog_py" status 2>/dev/null || true)"
-    fi
+    # rows than hang the daemon status caller. Use the project-wide
+    # bridge_with_timeout wrapper (lib/bridge-state.sh) so the timeout
+    # works on hosts that don't ship GNU `timeout(1)` — notably macOS
+    # without coreutils, where the previous bare `command -v timeout` test
+    # failed and the call ran unbounded.
+    watchdog_out="$(bridge_with_timeout 5 cmd_status_watchdog python3 "$watchdog_py" status 2>/dev/null || true)"
     if [[ -n "$watchdog_out" ]]; then
       local line
       while IFS= read -r line; do

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -6029,6 +6029,41 @@ cmd_status() {
   if [[ "$BRIDGE_LAUNCHAGENT_LOG" != "$BRIDGE_DAEMON_LOG" ]]; then
     echo "launchagent_log=${BRIDGE_LAUNCHAGENT_LOG}"
   fi
+
+  # Issue #800 Track C: surface the silence-watchdog state so operators
+  # can answer "is anything recovering me if I hang again?" without an
+  # extra pgrep / journalctl roundtrip. We call into the watchdog's own
+  # `status` subcommand and translate its key lines into `watchdog_*=...`
+  # rows so the daemon status grep-grammar stays single-line key=value.
+  local watchdog_py="$SCRIPT_DIR/bridge-watchdog-silence.py"
+  if [[ -f "$watchdog_py" ]]; then
+    local watchdog_out
+    # Hard timeout so a wedged audit log (the very condition the watchdog
+    # supervises) cannot block `daemon status` itself. The watchdog status
+    # path opens the audit JSONL and seeks into it; on a healthy host this
+    # returns in <100ms, on a sick host we'd rather show stale-or-missing
+    # rows than hang the daemon status caller.
+    if command -v timeout >/dev/null 2>&1; then
+      watchdog_out="$(timeout 5 python3 "$watchdog_py" status 2>/dev/null || true)"
+    else
+      watchdog_out="$(python3 "$watchdog_py" status 2>/dev/null || true)"
+    fi
+    if [[ -n "$watchdog_out" ]]; then
+      local line
+      while IFS= read -r line; do
+        case "$line" in
+          "daemon_script: "*)         echo "watchdog_daemon_script=${line#daemon_script: }" ;;
+          "last_daemon_tick: "*)      echo "watchdog_${line//: /=}" ;;
+          "last_detection_epoch: "*)  echo "watchdog_${line//: /=}" ;;
+          "last_restart_epoch: "*)    echo "watchdog_${line//: /=}" ;;
+          "watchdog: "*)              echo "watchdog_process=${line#watchdog: }" ;;
+          *) ;;
+        esac
+      done <<EOF
+$watchdog_out
+EOF
+    fi
+  fi
 }
 
 while [[ $# -gt 0 ]]; do

--- a/bridge-watchdog-silence.py
+++ b/bridge-watchdog-silence.py
@@ -29,6 +29,7 @@ Trust model (issue #591):
 Usage:
     python3 bridge-watchdog-silence.py run [--once]
     python3 bridge-watchdog-silence.py status
+    python3 bridge-watchdog-silence.py cleanup-orphans [--dry-run]
 
 Environment:
     BRIDGE_HOME                                       runtime root
@@ -41,11 +42,14 @@ Environment:
     BRIDGE_DAEMON_SILENCE_RESTART_COOLDOWN_SECONDS    default 300
     BRIDGE_DAEMON_SILENCE_TAIL_BYTES                  audit tail window (default 4 MiB)
     BRIDGE_DAEMON_SILENCE_RESTART_TIMEOUT_SECONDS     stop+start timeout (default 30)
+    BRIDGE_DAEMON_SCRIPT                              override DAEMON_SCRIPT resolution
+    BRIDGE_DAEMON_SILENCE_PIDLOCK                     override pidlock path (default state/silence-watchdog.pidlock)
 """
 
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import logging
 import os
@@ -70,8 +74,46 @@ BRIDGE_DAEMON_PID_FILE = Path(
 COOLDOWN_FILE = Path(
     os.environ.get("BRIDGE_DAEMON_SILENCE_COOLDOWN_FILE", BRIDGE_STATE_DIR / "silence-watchdog.json")
 )
+PIDLOCK_FILE = Path(
+    os.environ.get("BRIDGE_DAEMON_SILENCE_PIDLOCK", BRIDGE_STATE_DIR / "silence-watchdog.pidlock")
+)
+
+
+def _default_daemon_script() -> Path:
+    """Resolve the canonical daemon script path.
+
+    Issue #800 Track C: the previous default of ``SCRIPT_DIR / "bridge-daemon.sh"``
+    permanently bound watchdog instances launched from temp / worktree paths to
+    those (often-deleted) paths. Every recovery attempt then exited 127 on
+    "No such file or directory" and the live daemon was never restarted.
+
+    Resolution precedence (each step must point at an existing file):
+
+    1. ``BRIDGE_HOME/bridge-daemon.sh`` — the canonical install location.
+       This is the path the launchd plist / systemd unit shipped via
+       ``scripts/install-watchdog-silence-launchagent.sh`` resolves to.
+    2. ``~/.agent-bridge/bridge-daemon.sh`` — documented canonical install
+       fallback used when ``BRIDGE_HOME`` is unset.
+    3. ``SCRIPT_DIR / "bridge-daemon.sh"`` — last-resort in-tree development
+       fallback so ``python3 bridge-watchdog-silence.py …`` still works when
+       run directly out of a source checkout.
+
+    The explicit ``BRIDGE_DAEMON_SCRIPT`` env-var override (handled by the
+    caller) wins above all of these and is kept for tests.
+    """
+    home = os.environ.get("BRIDGE_HOME", "").strip()
+    if home:
+        candidate = Path(home).expanduser() / "bridge-daemon.sh"
+        if candidate.is_file():
+            return candidate
+    default_home_candidate = Path.home() / ".agent-bridge" / "bridge-daemon.sh"
+    if default_home_candidate.is_file():
+        return default_home_candidate
+    return SCRIPT_DIR / "bridge-daemon.sh"
+
+
 DAEMON_SCRIPT = Path(
-    os.environ.get("BRIDGE_DAEMON_SCRIPT", SCRIPT_DIR / "bridge-daemon.sh")
+    os.environ.get("BRIDGE_DAEMON_SCRIPT") or _default_daemon_script()
 )
 
 
@@ -257,6 +299,91 @@ def pid_alive(pid: int) -> bool:
     return True
 
 
+def acquire_pidlock() -> "tuple[object, Path] | None":
+    """Acquire an exclusive non-blocking flock on the watchdog pidlock.
+
+    Issue #800 Track C compounding factor: multiple watchdog instances
+    accumulated on the same host (10 concurrent on the affected install),
+    each looping detection without ever advancing ``last_restart_epoch``.
+    A pidlock at ``state/silence-watchdog.pidlock`` makes ``run`` self-
+    deduplicate so the second-and-later invocations exit cleanly with a
+    log line pointing at the holder.
+
+    Returns ``(lock_fd, lock_path)`` on success, ``None`` if another
+    instance already holds the lock (caller should exit 0).
+
+    The lock file path is resolved from ``$BRIDGE_HOME/state/`` (or the
+    explicit ``BRIDGE_DAEMON_SILENCE_PIDLOCK`` override) — never
+    ``SCRIPT_DIR``, so concurrent watchdogs launched from different temp
+    paths still contend on the same lockfile.
+    """
+    lock_path = PIDLOCK_FILE
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        log.error("pidlock parent mkdir failed: %s", exc)
+        return None
+
+    # Open for read+write (create if missing) so we can both flock and
+    # write the holder pid for diagnostics.
+    try:
+        fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o644)
+    except OSError as exc:
+        log.error("pidlock open failed for %s: %s", lock_path, exc)
+        return None
+
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        # Someone else holds it. Read the pid for the log message and exit
+        # cleanly — concurrent watchdogs are an expected condition on hosts
+        # with stale launches, not an error.
+        try:
+            with open(str(lock_path), "r", encoding="utf-8") as handle:
+                other = handle.read().strip() or "unknown"
+        except OSError:
+            other = "unknown"
+        finally:
+            os.close(fd)
+        log.info(
+            "another bridge-watchdog-silence instance already running "
+            "(holder_pid=%s lock=%s) — exiting cleanly",
+            other, lock_path,
+        )
+        return None
+
+    # We hold the lock. Stamp our pid so a future contender can see who
+    # owns it. truncate-then-write keeps the file size in sync with the
+    # current holder rather than appending across handoffs.
+    try:
+        os.ftruncate(fd, 0)
+        os.write(fd, f"{os.getpid()}\n".encode("utf-8"))
+        os.fsync(fd)
+    except OSError as exc:
+        log.warning("pidlock write failed (lock still held): %s", exc)
+
+    return (fd, lock_path)
+
+
+def release_pidlock(handle: "tuple[object, Path] | None") -> None:
+    """Release the watchdog pidlock acquired by :func:`acquire_pidlock`."""
+    if handle is None:
+        return
+    fd, lock_path = handle
+    try:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+    except OSError:
+        pass
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+    # We deliberately leave the lock file on disk so the next instance can
+    # contend on the same inode without a recreate race. Stale pid bytes
+    # are harmless (re-stamped on next acquire).
+    _ = lock_path  # keep the path available for callers that want to log it
+
+
 def emit_audit(action: str, detail: dict) -> None:
     """Write an audit row via bridge-audit.py so we share the hash chain
     and rotation logic with every other bridge writer."""
@@ -410,26 +537,38 @@ def tick(now: float | None = None) -> str:
 
 
 def cmd_run(args: argparse.Namespace) -> int:
-    if args.once:
-        outcome = tick()
-        log.info("once outcome: %s", outcome)
+    # Issue #800 Track C: pidlock before any work so a second concurrent
+    # `run` (the common orphan-accumulation shape) exits cleanly instead
+    # of looping detections that fight for the same recovery cooldown.
+    lock_handle = acquire_pidlock()
+    if lock_handle is None:
         return 0
+    try:
+        if args.once:
+            outcome = tick()
+            log.info("once outcome: %s", outcome)
+            return 0
 
-    log.info(
-        "silence watchdog started (threshold=%ds poll=%ds cooldown=%ds heartbeat=%ds)",
-        SILENCE_THRESHOLD, POLL_INTERVAL, RESTART_COOLDOWN, HEARTBEAT_INTERVAL,
-    )
-    while True:
-        try:
-            tick()
-        except Exception as exc:  # noqa: BLE001 — supervisor must not die on any cycle error
-            log.error("watchdog cycle error: %s", exc)
-        time.sleep(POLL_INTERVAL)
+        log.info(
+            "silence watchdog started (threshold=%ds poll=%ds cooldown=%ds heartbeat=%ds daemon_script=%s)",
+            SILENCE_THRESHOLD, POLL_INTERVAL, RESTART_COOLDOWN, HEARTBEAT_INTERVAL,
+            DAEMON_SCRIPT,
+        )
+        while True:
+            try:
+                tick()
+            except Exception as exc:  # noqa: BLE001 — supervisor must not die on any cycle error
+                log.error("watchdog cycle error: %s", exc)
+            time.sleep(POLL_INTERVAL)
+    finally:
+        release_pidlock(lock_handle)
 
 
 def cmd_status(args: argparse.Namespace) -> int:
     print(f"audit_log: {BRIDGE_AUDIT_LOG}")
     print(f"daemon_pid_file: {BRIDGE_DAEMON_PID_FILE}")
+    print(f"daemon_script: {DAEMON_SCRIPT} (exists={DAEMON_SCRIPT.is_file()})")
+    print(f"pidlock: {PIDLOCK_FILE}")
     print(f"heartbeat_interval_seconds: {HEARTBEAT_INTERVAL}")
     print(f"silence_threshold_seconds: {SILENCE_THRESHOLD}")
     print(f"poll_interval_seconds: {POLL_INTERVAL}")
@@ -437,8 +576,13 @@ def cmd_status(args: argparse.Namespace) -> int:
     last = find_last_daemon_tick(BRIDGE_AUDIT_LOG, TAIL_BYTES)
     if last is None:
         print("last_daemon_tick: (none in tail window)")
+        print("last_detection_epoch: (none)")
     else:
         print(f"last_daemon_tick: {last.raw_ts} (age={int(last.age_seconds)}s)")
+        if last.age_seconds > SILENCE_THRESHOLD:
+            print(f"last_detection_epoch: {last.epoch:.0f} (silence age={int(last.age_seconds)}s)")
+        else:
+            print("last_detection_epoch: (none — within threshold)")
     cooldown_epoch = read_cooldown()
     if cooldown_epoch:
         age = int(time.time() - cooldown_epoch)
@@ -450,6 +594,241 @@ def cmd_status(args: argparse.Namespace) -> int:
         print("daemon: (no pid file)")
     else:
         print(f"daemon: pid={pid} alive={pid_alive(pid)}")
+    # Surface the watchdog's own running instance so daemon-status callers
+    # can answer "is the watchdog itself up?" without an extra pgrep.
+    watchdog_pid = _read_pidlock_holder()
+    if watchdog_pid:
+        alive = pid_alive(watchdog_pid)
+        print(f"watchdog: pid={watchdog_pid} alive={alive}")
+    else:
+        print("watchdog: (not running — no pidlock holder)")
+    return 0
+
+
+def _read_pidlock_holder() -> int | None:
+    """Read the pid recorded inside the watchdog pidlock, if any.
+
+    Returns ``None`` if the lockfile is absent, empty, or unparseable.
+    Note this does NOT prove the holder is still alive — callers should
+    cross-check with :func:`pid_alive`.
+    """
+    try:
+        text = PIDLOCK_FILE.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError):
+        return None
+    if not text:
+        return None
+    try:
+        return int(text.splitlines()[0].strip())
+    except (ValueError, IndexError):
+        return None
+
+
+def _watchdog_cmdline(pid: int) -> str:
+    """Return the command line of pid <pid>, empty string on any failure.
+
+    Uses ``ps -p <pid> -o command=`` which is portable across macOS and
+    Linux; ``/proc/<pid>/cmdline`` would be Linux-only.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "command="],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return ""
+    return (result.stdout or "").strip()
+
+
+def _process_ppid(pid: int) -> int | None:
+    """Return the parent pid of <pid>, ``None`` on failure.
+
+    Uses ``ps -p <pid> -o ppid=`` for cross-platform portability. A ppid
+    of 1 indicates the process was reparented to init/launchd, the usual
+    fingerprint of an orphan watchdog whose owning session is gone.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "ppid="],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    text = (result.stdout or "").strip()
+    if not text:
+        return None
+    try:
+        return int(text.split()[0])
+    except (ValueError, IndexError):
+        return None
+
+
+def _canonical_watchdog_script_paths() -> "list[Path]":
+    """Return the set of paths a *non-orphan* watchdog should be running from.
+
+    Anything outside this set, with ppid=1, is an orphan candidate. The
+    BRIDGE_DAEMON_SCRIPT env-var override is intentionally read here
+    because operators with test rigs that legitimately run the watchdog
+    out of a custom path can extend the allow-list.
+    """
+    canonical: list[Path] = []
+    seen: set[str] = set()
+    home = os.environ.get("BRIDGE_HOME", "").strip()
+    if home:
+        candidate = Path(home).expanduser() / "bridge-watchdog-silence.py"
+        seen.add(str(candidate.resolve()) if candidate.exists() else str(candidate))
+        canonical.append(candidate)
+    default_home = Path.home() / ".agent-bridge" / "bridge-watchdog-silence.py"
+    key = str(default_home.resolve()) if default_home.exists() else str(default_home)
+    if key not in seen:
+        canonical.append(default_home)
+        seen.add(key)
+    override = os.environ.get("BRIDGE_DAEMON_SCRIPT", "").strip()
+    if override:
+        # When operators pin DAEMON_SCRIPT, treat the sibling watchdog
+        # script next to it as canonical too.
+        sibling = Path(override).expanduser().parent / "bridge-watchdog-silence.py"
+        skey = str(sibling.resolve()) if sibling.exists() else str(sibling)
+        if skey not in seen:
+            canonical.append(sibling)
+            seen.add(skey)
+    return canonical
+
+
+def cmd_cleanup_orphans(args: argparse.Namespace) -> int:
+    """Find + reap orphan watchdog instances launched from non-canonical paths.
+
+    Issue #800 Track C compounding factor: the affected install had 10
+    concurrent watchdog instances, all from worktree / temp paths, none
+    of which could recover the live daemon. None had a parent in their
+    original session — they were all reparented to launchd (ppid=1).
+
+    Reaping policy:
+
+    1. ``pgrep -fl bridge-watchdog-silence.py`` to discover candidates.
+    2. For each, read the command line. If the script path is in the
+       canonical allow-list (``$BRIDGE_HOME`` or ``~/.agent-bridge`` or
+       the ``BRIDGE_DAEMON_SCRIPT`` sibling) we skip — that's our own
+       canonical instance, not an orphan.
+    3. If ppid=1 (reparented to init/launchd), SIGTERM, sleep 2s, then
+       SIGKILL if still alive. Skip non-orphans (ppid != 1) to avoid
+       killing a fixer's own live test invocation.
+
+    With ``--dry-run``, prints what it would kill without sending signals.
+    Idempotent — running again after a clean sweep is a no-op.
+    """
+    dry_run = bool(getattr(args, "dry_run", False))
+    self_pid = os.getpid()
+    try:
+        result = subprocess.run(
+            ["pgrep", "-fl", "bridge-watchdog-silence.py"],
+            capture_output=True, text=True, timeout=10, check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        log.error("pgrep failed: %s", exc)
+        return 1
+
+    candidates: list[tuple[int, str]] = []
+    for line in (result.stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        head, _, rest = line.partition(" ")
+        try:
+            pid = int(head)
+        except ValueError:
+            continue
+        if pid == self_pid:
+            continue
+        candidates.append((pid, rest))
+
+    if not candidates:
+        log.info("cleanup-orphans: no watchdog instances found")
+        return 0
+
+    canonical_paths = _canonical_watchdog_script_paths()
+    canonical_resolved = set()
+    for p in canonical_paths:
+        try:
+            canonical_resolved.add(str(p.resolve()))
+        except OSError:
+            canonical_resolved.add(str(p))
+
+    killed = 0
+    skipped = 0
+    for pid, cmdline in candidates:
+        cmdline_full = _watchdog_cmdline(pid) or cmdline
+        # Extract the script path from the cmdline. The shape is normally
+        # `python3 /some/path/bridge-watchdog-silence.py run` — find the
+        # first token ending in bridge-watchdog-silence.py.
+        script_path: Path | None = None
+        for token in cmdline_full.split():
+            if token.endswith("bridge-watchdog-silence.py"):
+                script_path = Path(token)
+                break
+        if script_path is None:
+            log.info(
+                "cleanup-orphans: skip pid=%s (cannot parse script path from cmdline=%r)",
+                pid, cmdline_full,
+            )
+            skipped += 1
+            continue
+
+        try:
+            resolved = str(script_path.resolve())
+        except OSError:
+            resolved = str(script_path)
+
+        if resolved in canonical_resolved:
+            log.info(
+                "cleanup-orphans: skip pid=%s (canonical path=%s)",
+                pid, resolved,
+            )
+            skipped += 1
+            continue
+
+        ppid = _process_ppid(pid)
+        if ppid != 1:
+            log.info(
+                "cleanup-orphans: skip pid=%s (non-orphan ppid=%s path=%s)",
+                pid, ppid, resolved,
+            )
+            skipped += 1
+            continue
+
+        if dry_run:
+            log.info(
+                "cleanup-orphans: would TERM pid=%s (orphan path=%s ppid=%s)",
+                pid, resolved, ppid,
+            )
+            killed += 1
+            continue
+
+        log.info(
+            "cleanup-orphans: SIGTERM pid=%s (orphan path=%s ppid=%s)",
+            pid, resolved, ppid,
+        )
+        try:
+            os.kill(pid, 15)
+        except ProcessLookupError:
+            continue
+        except OSError as exc:
+            log.warning("cleanup-orphans: SIGTERM pid=%s failed: %s", pid, exc)
+            continue
+        # Grace period, then SIGKILL if still alive.
+        time.sleep(2)
+        if pid_alive(pid):
+            log.warning("cleanup-orphans: SIGKILL pid=%s (TERM grace expired)", pid)
+            try:
+                os.kill(pid, 9)
+            except (ProcessLookupError, OSError):
+                pass
+        killed += 1
+
+    log.info(
+        "cleanup-orphans: %s %d orphan(s), skipped %d canonical/non-orphan instance(s)",
+        "would kill" if dry_run else "killed", killed, skipped,
+    )
     return 0
 
 
@@ -464,11 +843,26 @@ def main() -> int:
     status_p = sub.add_parser("status")
     status_p.set_defaults(handler=cmd_status)
 
+    cleanup_p = sub.add_parser(
+        "cleanup-orphans",
+        help="Find + reap orphan watchdog instances (#800 Track C).",
+    )
+    cleanup_p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be killed without sending signals.",
+    )
+    cleanup_p.set_defaults(handler=cmd_cleanup_orphans)
+
     args = parser.parse_args()
     # Issue #591: refuse to run with a cross-home pid file before any state
     # read or audit peek so a leaked-env orphan terminates itself instead of
-    # cross-home killing the live daemon.
-    _validate_cross_home()
+    # cross-home killing the live daemon. cleanup-orphans does not read the
+    # daemon pid file (it operates on its own pgrep results) so it is exempt
+    # — and the exemption matters because cleanup is most useful precisely
+    # when the operator is recovering from a cross-home env leak.
+    if args.command != "cleanup-orphans":
+        _validate_cross_home()
     return int(args.handler(args))
 
 

--- a/bridge-watchdog-silence.py
+++ b/bridge-watchdog-silence.py
@@ -109,7 +109,23 @@ def _default_daemon_script() -> Path:
     default_home_candidate = Path.home() / ".agent-bridge" / "bridge-daemon.sh"
     if default_home_candidate.is_file():
         return default_home_candidate
-    return SCRIPT_DIR / "bridge-daemon.sh"
+    # Last-resort dev fallback. Production installs should NEVER reach this
+    # branch — it indicates the watchdog is running from a non-canonical
+    # location (temp dir, worktree, etc.) and is the exact failure class
+    # issue #800 / #265 documented. Log a clear warning so operators see
+    # the problem rather than silently inheriting the broken default. The
+    # module-level `log` is not yet bound at import time when this resolver
+    # runs, so use `logging.getLogger` directly — it's the same handler the
+    # rest of the module will attach to once `logging.basicConfig` runs.
+    fallback = SCRIPT_DIR / "bridge-daemon.sh"
+    logging.getLogger("watchdog-silence").warning(
+        "DAEMON_SCRIPT resolved via SCRIPT_DIR fallback (%s) — "
+        "no BRIDGE_HOME or ~/.agent-bridge install found. "
+        "This is the failure mode #800 Track C documented; "
+        "set BRIDGE_HOME or install canonically via 'agent-bridge upgrade'.",
+        fallback,
+    )
+    return fallback
 
 
 DAEMON_SCRIPT = Path(

--- a/scripts/install-watchdog-silence-launchagent.sh
+++ b/scripts/install-watchdog-silence-launchagent.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# install-watchdog-silence-launchagent.sh — issue #800 Track C
+#
+# Installs a macOS LaunchAgent that runs bridge-watchdog-silence.py from the
+# live install (`$BRIDGE_HOME/bridge-watchdog-silence.py`) under launchd
+# KeepAlive. Sibling of ai.agent-bridge.daemon-liveness — see
+# scripts/install-daemon-liveness-launchagent.sh for the parallel pattern.
+#
+# Why a separate plist:
+#   The silence watchdog is the second-line recovery layer for daemon
+#   silent-hangs (issue #265). Before this script existed, the watchdog was
+#   only ever launched ad-hoc out of test sessions / worktrees — every one
+#   of those instances permanently bound DAEMON_SCRIPT to a now-deleted
+#   path and could not recover the live daemon. A canonical KeepAlive
+#   process under launchd ensures the recovery layer survives reboots,
+#   crashes, and operator session churn without operator intervention.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+BRIDGE_HOME_DEFAULT="${HOME}/.agent-bridge"
+BRIDGE_HOME_TARGET="$BRIDGE_HOME_DEFAULT"
+LABEL_DEFAULT="ai.agent-bridge.watchdog-silence"
+LABEL="$LABEL_DEFAULT"
+PLIST_PATH=""
+LOG_PATH=""
+APPLY=0
+LOAD=0
+BASH_PATH=""
+PYTHON_PATH=""
+
+# Pass-through env knobs. Empty means "let the script use its built-in
+# default" so we don't lock the operator into a value here.
+SILENCE_THRESHOLD="${BRIDGE_DAEMON_SILENCE_THRESHOLD_SECONDS:-}"
+SILENCE_POLL="${BRIDGE_DAEMON_SILENCE_POLL_INTERVAL_SECONDS:-}"
+RESTART_COOLDOWN="${BRIDGE_DAEMON_SILENCE_RESTART_COOLDOWN_SECONDS:-}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--bridge-home <dir>] [--label <launchd-label>] [--plist <path>] [--log-path <path>] [--threshold <secs>] [--poll <secs>] [--cooldown <secs>] [--apply] [--load]
+
+Without --apply, prints the LaunchAgent plist for the silence watchdog.
+With --apply, writes the plist to ~/Library/LaunchAgents (or --plist target).
+With --load, also bootstraps and kickstarts the LaunchAgent after writing.
+
+Issue #800 Track C: canonical install of bridge-watchdog-silence.py so the
+daemon silent-hang recovery layer runs from a known-good path under
+launchd KeepAlive, instead of accumulating orphan instances from worktrees
+and temp dirs that get deleted.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bridge-home)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      BRIDGE_HOME_TARGET="$2"
+      shift 2
+      ;;
+    --label)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      LABEL="$2"
+      shift 2
+      ;;
+    --plist)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      PLIST_PATH="$2"
+      shift 2
+      ;;
+    --log-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      LOG_PATH="$2"
+      shift 2
+      ;;
+    --threshold)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SILENCE_THRESHOLD="$2"
+      shift 2
+      ;;
+    --poll)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SILENCE_POLL="$2"
+      shift 2
+      ;;
+    --cooldown)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      RESTART_COOLDOWN="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --load)
+      APPLY=1
+      LOAD=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[error] unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for v in "$SILENCE_THRESHOLD" "$SILENCE_POLL" "$RESTART_COOLDOWN"; do
+  [[ -z "$v" ]] && continue
+  [[ "$v" =~ ^[0-9]+$ ]] || { echo "[error] integer env knob got non-integer value: $v" >&2; exit 1; }
+done
+
+[[ -n "$PLIST_PATH" ]] || PLIST_PATH="$HOME/Library/LaunchAgents/${LABEL}.plist"
+[[ -n "$LOG_PATH" ]] || LOG_PATH="$BRIDGE_HOME_TARGET/state/watchdog-silence.log"
+
+for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+  [[ -n "$candidate" && -x "$candidate" ]] || continue
+  BASH_PATH="$candidate"
+  break
+done
+
+if [[ -z "$BASH_PATH" ]]; then
+  echo "[error] bash not found" >&2
+  exit 1
+fi
+
+for candidate in /opt/homebrew/bin/python3 /usr/local/bin/python3 "$(command -v python3 2>/dev/null || true)" /usr/bin/python3; do
+  [[ -n "$candidate" && -x "$candidate" ]] || continue
+  PYTHON_PATH="$candidate"
+  break
+done
+
+if [[ -z "$PYTHON_PATH" ]]; then
+  echo "[error] python3 not found" >&2
+  exit 1
+fi
+
+# We point ProgramArguments at $BRIDGE_HOME_TARGET/bridge-watchdog-silence.py
+# (the deployed live-install copy), not the source checkout, so an `agb
+# upgrade` that lays down a new script body is picked up on the next launchd
+# respawn without re-editing the plist.
+ENV_LINES=()
+ENV_LINES+=("    <key>BRIDGE_HOME</key>")
+ENV_LINES+=("    <string>${BRIDGE_HOME_TARGET}</string>")
+if [[ -n "$SILENCE_THRESHOLD" ]]; then
+  ENV_LINES+=("    <key>BRIDGE_DAEMON_SILENCE_THRESHOLD_SECONDS</key>")
+  ENV_LINES+=("    <string>${SILENCE_THRESHOLD}</string>")
+fi
+if [[ -n "$SILENCE_POLL" ]]; then
+  ENV_LINES+=("    <key>BRIDGE_DAEMON_SILENCE_POLL_INTERVAL_SECONDS</key>")
+  ENV_LINES+=("    <string>${SILENCE_POLL}</string>")
+fi
+if [[ -n "$RESTART_COOLDOWN" ]]; then
+  ENV_LINES+=("    <key>BRIDGE_DAEMON_SILENCE_RESTART_COOLDOWN_SECONDS</key>")
+  ENV_LINES+=("    <string>${RESTART_COOLDOWN}</string>")
+fi
+
+ENV_BLOCK=$(printf '%s\n' "${ENV_LINES[@]}")
+
+PLIST_CONTENT="$(cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LABEL}</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>${PYTHON_PATH}</string>
+    <string>${BRIDGE_HOME_TARGET}/bridge-watchdog-silence.py</string>
+    <string>run</string>
+  </array>
+
+  <key>WorkingDirectory</key>
+  <string>${BRIDGE_HOME_TARGET}</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+${ENV_BLOCK}
+  </dict>
+
+  <key>KeepAlive</key>
+  <true/>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>${LOG_PATH}</string>
+
+  <key>StandardErrorPath</key>
+  <string>${LOG_PATH}</string>
+</dict>
+</plist>
+EOF
+)"
+
+if [[ $APPLY -eq 0 ]]; then
+  printf 'plist_path: %s\n' "$PLIST_PATH"
+  printf 'bridge_home: %s\n' "$BRIDGE_HOME_TARGET"
+  printf 'log_path: %s\n' "$LOG_PATH"
+  printf 'label: %s\n' "$LABEL"
+  printf 'python_path: %s\n' "$PYTHON_PATH"
+  if [[ -n "$SILENCE_THRESHOLD" ]]; then printf 'threshold_seconds: %s\n' "$SILENCE_THRESHOLD"; fi
+  if [[ -n "$SILENCE_POLL" ]]; then printf 'poll_seconds: %s\n' "$SILENCE_POLL"; fi
+  if [[ -n "$RESTART_COOLDOWN" ]]; then printf 'cooldown_seconds: %s\n' "$RESTART_COOLDOWN"; fi
+  printf '\n'
+  printf '%s\n' "$PLIST_CONTENT"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$PLIST_PATH")" "$(dirname "$LOG_PATH")"
+printf '%s\n' "$PLIST_CONTENT" >"$PLIST_PATH"
+echo "[info] wrote LaunchAgent plist: $PLIST_PATH"
+
+if [[ $LOAD -eq 1 ]]; then
+  launchctl bootout "gui/$UID/$LABEL" >/dev/null 2>&1 || true
+  launchctl bootstrap "gui/$UID" "$PLIST_PATH"
+  launchctl enable "gui/$UID/$LABEL" >/dev/null 2>&1 || true
+  launchctl kickstart "gui/$UID/$LABEL"
+  echo "[info] loaded LaunchAgent: $LABEL"
+  echo "[info] inspect with: launchctl print gui/$UID/$LABEL"
+fi
+
+echo "[info] bridge_home: $BRIDGE_HOME_TARGET"
+echo "[info] log_path: $LOG_PATH"
+echo "[info] plist_path: $PLIST_PATH"
+
+# Reference unused for shellcheck — REPO_ROOT is kept for parity with the
+# sibling installers in case future work needs source-checkout discovery.
+: "${REPO_ROOT}"

--- a/scripts/install-watchdog-silence-systemd.sh
+++ b/scripts/install-watchdog-silence-systemd.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# install-watchdog-silence-systemd.sh — issue #800 Track C
+#
+# Installs a systemd --user .service that runs bridge-watchdog-silence.py
+# from the live install (`$BRIDGE_HOME/bridge-watchdog-silence.py`) under
+# Restart=always. Linux sibling of
+# scripts/install-watchdog-silence-launchagent.sh.
+#
+# Unlike the daemon-liveness pair (oneshot + timer), the silence watchdog
+# itself runs a long-lived poll loop with its own pidlock, so a plain
+# Type=simple Restart=always service is the right shape — there's no need
+# for systemd to manage the poll cadence.
+
+set -euo pipefail
+
+BRIDGE_HOME_TARGET="${HOME}/.agent-bridge"
+SERVICE_NAME="agent-bridge-watchdog-silence.service"
+SERVICE_PATH=""
+LOG_PATH=""
+APPLY=0
+ENABLE=0
+PYTHON_PATH=""
+
+# Pass-through env knobs. Empty means use script defaults.
+SILENCE_THRESHOLD="${BRIDGE_DAEMON_SILENCE_THRESHOLD_SECONDS:-}"
+SILENCE_POLL="${BRIDGE_DAEMON_SILENCE_POLL_INTERVAL_SECONDS:-}"
+RESTART_COOLDOWN="${BRIDGE_DAEMON_SILENCE_RESTART_COOLDOWN_SECONDS:-}"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--bridge-home <dir>] [--service <name>] [--service-path <path>] [--log-path <path>] [--threshold <secs>] [--poll <secs>] [--cooldown <secs>] [--apply] [--enable]
+
+Without --apply, prints the systemd user .service unit file.
+With --apply, writes the unit to ~/.config/systemd/user (or --service-path target).
+With --enable, also runs systemctl --user daemon-reload and enable --now on the service.
+
+Issue #800 Track C: canonical install of bridge-watchdog-silence.py so the
+daemon silent-hang recovery layer runs from a known-good path under
+systemd Restart=always.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bridge-home)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      BRIDGE_HOME_TARGET="$2"
+      shift 2
+      ;;
+    --service)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SERVICE_NAME="$2"
+      shift 2
+      ;;
+    --service-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SERVICE_PATH="$2"
+      shift 2
+      ;;
+    --log-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      LOG_PATH="$2"
+      shift 2
+      ;;
+    --threshold)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SILENCE_THRESHOLD="$2"
+      shift 2
+      ;;
+    --poll)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SILENCE_POLL="$2"
+      shift 2
+      ;;
+    --cooldown)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      RESTART_COOLDOWN="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --enable)
+      APPLY=1
+      ENABLE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[error] unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+for v in "$SILENCE_THRESHOLD" "$SILENCE_POLL" "$RESTART_COOLDOWN"; do
+  [[ -z "$v" ]] && continue
+  [[ "$v" =~ ^[0-9]+$ ]] || { echo "[error] integer env knob got non-integer value: $v" >&2; exit 1; }
+done
+
+[[ -n "$SERVICE_PATH" ]] || SERVICE_PATH="$HOME/.config/systemd/user/$SERVICE_NAME"
+[[ -n "$LOG_PATH" ]] || LOG_PATH="$BRIDGE_HOME_TARGET/state/systemd-watchdog-silence.log"
+
+for candidate in /opt/homebrew/bin/python3 /usr/local/bin/python3 "$(command -v python3 2>/dev/null || true)" /usr/bin/python3; do
+  [[ -n "$candidate" && -x "$candidate" ]] || continue
+  PYTHON_PATH="$candidate"
+  break
+done
+
+if [[ -z "$PYTHON_PATH" ]]; then
+  echo "[error] python3 not found" >&2
+  exit 1
+fi
+
+ENV_LINES=()
+ENV_LINES+=("Environment=BRIDGE_HOME=${BRIDGE_HOME_TARGET}")
+if [[ -n "$SILENCE_THRESHOLD" ]]; then
+  ENV_LINES+=("Environment=BRIDGE_DAEMON_SILENCE_THRESHOLD_SECONDS=${SILENCE_THRESHOLD}")
+fi
+if [[ -n "$SILENCE_POLL" ]]; then
+  ENV_LINES+=("Environment=BRIDGE_DAEMON_SILENCE_POLL_INTERVAL_SECONDS=${SILENCE_POLL}")
+fi
+if [[ -n "$RESTART_COOLDOWN" ]]; then
+  ENV_LINES+=("Environment=BRIDGE_DAEMON_SILENCE_RESTART_COOLDOWN_SECONDS=${RESTART_COOLDOWN}")
+fi
+
+ENV_BLOCK=$(printf '%s\n' "${ENV_LINES[@]}")
+
+SERVICE_CONTENT="$(cat <<EOF
+[Unit]
+Description=Agent Bridge Daemon Silence Watchdog (#800 Track C)
+After=agent-bridge-daemon.service
+
+[Service]
+Type=simple
+ExecStart=${PYTHON_PATH} ${BRIDGE_HOME_TARGET}/bridge-watchdog-silence.py run
+WorkingDirectory=${BRIDGE_HOME_TARGET}
+${ENV_BLOCK}
+Restart=always
+RestartSec=10
+StandardOutput=append:${LOG_PATH}
+StandardError=append:${LOG_PATH}
+
+[Install]
+WantedBy=default.target
+EOF
+)"
+
+if [[ $APPLY -eq 0 ]]; then
+  printf 'service_path: %s\n' "$SERVICE_PATH"
+  printf 'bridge_home: %s\n' "$BRIDGE_HOME_TARGET"
+  printf 'log_path: %s\n' "$LOG_PATH"
+  printf 'service: %s\n' "$SERVICE_NAME"
+  printf 'python_path: %s\n' "$PYTHON_PATH"
+  if [[ -n "$SILENCE_THRESHOLD" ]]; then printf 'threshold_seconds: %s\n' "$SILENCE_THRESHOLD"; fi
+  if [[ -n "$SILENCE_POLL" ]]; then printf 'poll_seconds: %s\n' "$SILENCE_POLL"; fi
+  if [[ -n "$RESTART_COOLDOWN" ]]; then printf 'cooldown_seconds: %s\n' "$RESTART_COOLDOWN"; fi
+  printf '\n# %s\n' "$SERVICE_NAME"
+  printf '%s\n' "$SERVICE_CONTENT"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$SERVICE_PATH")" "$(dirname "$LOG_PATH")"
+printf '%s\n' "$SERVICE_CONTENT" >"$SERVICE_PATH"
+echo "[info] wrote systemd user service: $SERVICE_PATH"
+
+if [[ $ENABLE -eq 1 ]]; then
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "[error] systemctl not found; wrote unit but cannot enable" >&2
+    exit 1
+  fi
+  systemctl --user daemon-reload
+  systemctl --user enable --now "$SERVICE_NAME"
+  echo "[info] enabled systemd user service: $SERVICE_NAME"
+  echo "[info] inspect with: systemctl --user status $SERVICE_NAME"
+fi
+
+echo "[info] bridge_home: $BRIDGE_HOME_TARGET"
+echo "[info] log_path: $LOG_PATH"
+echo "[info] service_path: $SERVICE_PATH"


### PR DESCRIPTION
## Summary

- Default `DAEMON_SCRIPT` to `$BRIDGE_HOME/bridge-daemon.sh`, not `SCRIPT_DIR`
  (the watchdog's own install location). Watchdog instances launched from
  temp/worktree paths permanently bound to those (now-deleted) paths and
  exited 127 on every recovery — `last_restart_epoch` never advanced even
  though detection fired correctly. The `BRIDGE_DAEMON_SCRIPT` env-var
  override stays for tests.
- Add `fcntl` pidlock at `state/silence-watchdog.pidlock` so concurrent
  instances exit cleanly. The affected install had 10 watchdog instances
  looping detections without ever recovering the live daemon; the lock
  makes only one win the cooldown contention.
- Add `scripts/install-watchdog-silence-launchagent.sh` — canonical macOS
  LaunchAgent with `KeepAlive=true`, sibling of
  `install-daemon-liveness-launchagent.sh`. Wired into `bridge-bootstrap`
  alongside the existing liveness install. Linux sibling
  `scripts/install-watchdog-silence-systemd.sh` ships a `Type=simple`
  `Restart=always` `--user` service.
- Add `cleanup-orphans` subcommand that finds + reaps watchdog instances
  whose script path is outside the canonical allow-list AND whose ppid
  is 1 (reparented to launchd/init). Idempotent. Invoked from bootstrap
  so a fresh install sweeps stale orphans before launchd kickstart.
- Surface watchdog state in `agent-bridge daemon status` — DAEMON_SCRIPT
  resolution (with `exists=` flag), last detection epoch, last_restart_epoch,
  watchdog pid. The status call is `timeout 5` wrapped so a wedged audit
  log cannot block the daemon-status caller (the watchdog supervises the
  very thing it would otherwise be blocked on).

## Why this change

Issue #800 root-cause section documents the operator-visible failure on
v0.7.6: `daemon status` reports healthy, queue work stalls, no auto-recovery
ever fires. Live install had **zero** canonical watchdog processes — what
was running were 10 orphan instances from prior test sessions / codex
worktrees, all bound to deleted paths via `SCRIPT_DIR`. This PR binds the
recovery layer to canonical install paths and installs it as a proper
OS-managed unit so a fresh install gets working recovery without operator
intervention.

## Validation

- `python3 -m py_compile bridge-watchdog-silence.py` — pass
- `shellcheck` on new install scripts, `bridge-bootstrap.sh`,
  `bridge-daemon.sh` — clean (pre-existing SC2031 warnings in unrelated
  files untouched)
- Default-resolution test: `BRIDGE_HOME=/tmp/agb-800-test-home` with stub
  `bridge-daemon.sh` resolved `daemon_script` under the test home —
  `daemon_script: /tmp/agb-800-test-home/bridge-daemon.sh (exists=True)`
- Pidlock test: second concurrent `run` exited 0 with
  `another bridge-watchdog-silence instance already running (holder_pid=…)`
- Plist dry-run + `plutil -lint` on the generated XML — both passed
- `cleanup-orphans --dry-run` on the affected host listed all 10 of the
  orphan worktree/temp instances documented in #800 (would-kill summary
  matched the issue body exactly)
- `./scripts/smoke-test.sh` — pre-existing isolation-v2-marker failure on
  this host, confirmed identical exit on unmodified `main` (not a
  regression introduced by this PR)

## Linux

Linux gets the systemd `--user` service via
`scripts/install-watchdog-silence-systemd.sh`. The bootstrap wiring mirrors
the existing liveness install (Darwin → launchagent, Linux → systemd),
gated by `--skip-watchdog-silence`. Tested launchd path on macOS; Linux
unit was lint-only (no Linux host available in the fixer session).

Refs #800 Track C. Track A (daemon `\$(python3 - <<'PY' … PY)` heredoc
timeout wrapping) is handled in a separate PR per the brief.