### PR TITLE
fix(state): add Python subprocess.run fallback to bridge_with_timeout (#802 carry-over)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1841,12 +1841,16 @@ bridge_with_timeout() {
   fi
 
   # Tier 3: no wrap available — log once and run unwrapped (status quo).
+  # NOTE: bridge_audit_log itself calls bridge_require_python, which `exit`s
+  # via bridge_die when python3 is absent — the very condition that put us in
+  # tier 3. Wrap the audit call in a subshell so any such `exit` is contained
+  # to the subshell and the unwrapped exec below still runs.
   if (( _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED == 0 )); then
-    bridge_audit_log daemon daemon_subprocess_timeout_unavailable daemon \
-      --detail call_site="$label" \
-      --detail requested_seconds="$secs" \
-      --detail note="neither timeout/gtimeout nor python3 on PATH; running unwrapped" \
-      2>/dev/null || true
+    ( bridge_audit_log daemon daemon_subprocess_timeout_unavailable daemon \
+        --detail call_site="$label" \
+        --detail requested_seconds="$secs" \
+        --detail note="neither timeout/gtimeout nor python3 on PATH; running unwrapped" \
+        2>/dev/null ) || true
     _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED=1
   fi
   "$@"

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1710,7 +1710,7 @@ bridge_audit_log() {
   python3 "$BRIDGE_SCRIPT_DIR/bridge-audit.py" write --file "$BRIDGE_AUDIT_LOG" --actor "$actor" --action "$action" --target "$target" "$@" >/dev/null
 }
 
-# bridge_with_timeout — issue #265 proposal A.
+# bridge_with_timeout — issue #265 proposal A; #802 carry-over python fallback.
 #
 # Wraps an external command with `timeout(1)` so a single hung subprocess in
 # the daemon main loop cannot block the scheduler indefinitely (the canonical
@@ -1728,17 +1728,60 @@ bridge_audit_log() {
 #   when passed as empty string.
 # - <call_site_label> is the symbolic name used in the audit detail
 #   (e.g. "release_monitor", "stall_analyze").
-# - When neither `timeout` nor `gtimeout` is on PATH, the helper falls
-#   through to a plain exec so behavior on bare hosts matches today; a
-#   one-time `daemon_subprocess_timeout_unavailable` audit row is written
-#   the first time so the gap is visible without spamming the log.
+#
+# Three-tier fallback chain (#802 carry-over):
+#   1. `timeout(1)` / `gtimeout(1)` — preferred; POSIX exit codes (124/137).
+#   2. `python3 subprocess.run(timeout=)` — when neither binary is on PATH.
+#      python3 is a hard dependency of agent-bridge, so this branch is reached
+#      on bare macOS hosts without GNU coreutils installed. The python wrapper
+#      maps `TimeoutExpired` to exit code 124 to match GNU `timeout(1)` and
+#      `FileNotFoundError` to 127 (POSIX "command not found"). The audit row
+#      shape is identical to tier 1's so downstream log readers do not need
+#      to special-case it.
+#   3. Plain exec — last resort when even python3 is missing (a severely
+#      degraded host). A one-time `daemon_subprocess_timeout_unavailable`
+#      audit row is written so the gap is visible without spamming the log.
 #
 # Caveat: only wrappable around *external* commands. Bash functions cannot be
 # wrapped with `timeout(1)` directly — those must be exposed through a
 # subshell + `bash -c` first, which is out of scope for this helper.
 _BRIDGE_WITH_TIMEOUT_BIN_CACHED=0
 _BRIDGE_WITH_TIMEOUT_BIN=""
+_BRIDGE_WITH_TIMEOUT_PYTHON_CACHED=0
+_BRIDGE_WITH_TIMEOUT_PYTHON=""
 _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED=0
+
+# Inline python3 wrapper used by the tier-2 fallback. Authored here as a
+# module-level constant so we pass it via `python3 -c "$SCRIPT"` (here-string
+# variable + `-c`) instead of `python3 - <<'PY' ... PY` heredoc-stdin. The
+# heredoc-stdin form is the bash `heredoc_write` deadlock class documented in
+# issue #800 / PR #801; this wrapper is short and only invoked once per call
+# so the deadlock risk is low, but staying consistent with the post-#801
+# pattern across the codebase keeps the reasoning uniform.
+_BRIDGE_WITH_TIMEOUT_PY_WRAPPER='
+import subprocess
+import sys
+
+try:
+    deadline = float(sys.argv[1])
+except (IndexError, ValueError):
+    sys.stderr.write("bridge_with_timeout: invalid timeout seconds argv[1]\n")
+    sys.exit(2)
+cmd = sys.argv[2:]
+if not cmd:
+    sys.stderr.write("bridge_with_timeout: no command argv provided\n")
+    sys.exit(2)
+try:
+    proc = subprocess.run(cmd, timeout=deadline)
+    sys.exit(proc.returncode)
+except subprocess.TimeoutExpired:
+    # Match GNU timeout(1) exit code so downstream audit + caller branches
+    # treat python-fallback timeouts identically to the binary path.
+    sys.exit(124)
+except FileNotFoundError as exc:
+    sys.stderr.write("bridge_with_timeout: command not found: %s\n" % exc)
+    sys.exit(127)
+'
 
 bridge_with_timeout() {
   local secs="${1:-}"
@@ -1759,31 +1802,55 @@ bridge_with_timeout() {
 
   started_ts="$(date +%s 2>/dev/null || echo 0)"
 
-  if [[ -z "$_BRIDGE_WITH_TIMEOUT_BIN" ]]; then
-    if (( _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED == 0 )); then
-      bridge_audit_log daemon daemon_subprocess_timeout_unavailable daemon \
+  # Tier 1: GNU timeout(1) / gtimeout(1) — preferred.
+  if [[ -n "$_BRIDGE_WITH_TIMEOUT_BIN" ]]; then
+    "$_BRIDGE_WITH_TIMEOUT_BIN" "$secs" "$@"
+    rc=$?
+    if [[ "$rc" == "124" || "$rc" == "137" ]]; then
+      elapsed=$(( $(date +%s 2>/dev/null || echo "$started_ts") - started_ts ))
+      bridge_audit_log daemon daemon_subprocess_timeout daemon \
         --detail call_site="$label" \
-        --detail requested_seconds="$secs" \
-        --detail note="neither timeout nor gtimeout on PATH; running unwrapped" \
+        --detail timeout_seconds="$secs" \
+        --detail elapsed_seconds="$elapsed" \
+        --detail exit_code="$rc" \
+        --detail tier="binary" \
         2>/dev/null || true
-      _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED=1
     fi
-    "$@"
-    return $?
+    return "$rc"
   fi
 
-  "$_BRIDGE_WITH_TIMEOUT_BIN" "$secs" "$@"
-  rc=$?
-  if [[ "$rc" == "124" || "$rc" == "137" ]]; then
-    elapsed=$(( $(date +%s 2>/dev/null || echo "$started_ts") - started_ts ))
-    bridge_audit_log daemon daemon_subprocess_timeout daemon \
-      --detail call_site="$label" \
-      --detail timeout_seconds="$secs" \
-      --detail elapsed_seconds="$elapsed" \
-      --detail exit_code="$rc" \
-      2>/dev/null || true
+  # Tier 2: python3 subprocess.run(timeout=…) — bare-host fallback.
+  if (( _BRIDGE_WITH_TIMEOUT_PYTHON_CACHED == 0 )); then
+    _BRIDGE_WITH_TIMEOUT_PYTHON="$(command -v python3 2>/dev/null || true)"
+    _BRIDGE_WITH_TIMEOUT_PYTHON_CACHED=1
   fi
-  return "$rc"
+  if [[ -n "$_BRIDGE_WITH_TIMEOUT_PYTHON" ]]; then
+    "$_BRIDGE_WITH_TIMEOUT_PYTHON" -c "$_BRIDGE_WITH_TIMEOUT_PY_WRAPPER" "$secs" "$@"
+    rc=$?
+    if [[ "$rc" == "124" || "$rc" == "137" ]]; then
+      elapsed=$(( $(date +%s 2>/dev/null || echo "$started_ts") - started_ts ))
+      bridge_audit_log daemon daemon_subprocess_timeout daemon \
+        --detail call_site="$label" \
+        --detail timeout_seconds="$secs" \
+        --detail elapsed_seconds="$elapsed" \
+        --detail exit_code="$rc" \
+        --detail tier="python" \
+        2>/dev/null || true
+    fi
+    return "$rc"
+  fi
+
+  # Tier 3: no wrap available — log once and run unwrapped (status quo).
+  if (( _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED == 0 )); then
+    bridge_audit_log daemon daemon_subprocess_timeout_unavailable daemon \
+      --detail call_site="$label" \
+      --detail requested_seconds="$secs" \
+      --detail note="neither timeout/gtimeout nor python3 on PATH; running unwrapped" \
+      2>/dev/null || true
+    _BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED=1
+  fi
+  "$@"
+  return $?
 }
 
 bridge_mcp_orphan_cleanup_state_dir() {

--- a/scripts/smoke/bridge-with-timeout-fallback.sh
+++ b/scripts/smoke/bridge-with-timeout-fallback.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+#
+# scripts/smoke/bridge-with-timeout-fallback.sh — issue #802 carry-over.
+#
+# Exercises the three-tier fallback chain inside `bridge_with_timeout`
+# (lib/bridge-state.sh):
+#
+#   tier 1: GNU `timeout(1)` / `gtimeout(1)` on PATH — POSIX exit codes.
+#   tier 2: `python3 subprocess.run(timeout=)` when neither binary is on PATH.
+#           python3 is a hard dep of agent-bridge so this branch is reached
+#           on bare macOS hosts without GNU coreutils installed.
+#   tier 3: plain exec when even python3 is missing (severely degraded host).
+#
+# For each tier we assert (a) the exit code, (b) the elapsed-window so the
+# wrap-vs-no-wrap behavior is observable, and (c) the audit-log shape.
+#
+# Hermetic: isolated BRIDGE_HOME via smoke_setup_bridge_home; never touches
+# the live install. Uses a per-tier PATH shim to hide tier-1/2 binaries so
+# tier-2 and tier-3 branches are actually reached even on a fully-equipped
+# developer host.
+
+# Bash 4+ re-exec (mirrors scripts/smoke/daemon-heredoc-timeout.sh).
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:bridge-with-timeout-fallback] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="bridge-with-timeout-fallback"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+export BRIDGE_REPO_ROOT="$SMOKE_REPO_ROOT"
+export BRIDGE_SCRIPT_DIR="$BRIDGE_REPO_ROOT"
+: >"$BRIDGE_AUDIT_LOG"
+
+# Resolve the absolute paths to the binaries we may want to hide per tier.
+# `command -v` is enough for hermetic reasoning; we hide them by giving the
+# child shell a PATH that does not contain their parent directories.
+SYS_TIMEOUT="$(command -v timeout 2>/dev/null || true)"
+SYS_GTIMEOUT="$(command -v gtimeout 2>/dev/null || true)"
+SYS_PYTHON3="$(command -v python3)"   # required, asserted above
+DATE_BIN="$(command -v date)"
+SLEEP_BIN="$(command -v sleep)"
+BASH_BIN="$(command -v bash)"
+[[ -x "$DATE_BIN" && -x "$SLEEP_BIN" && -x "$BASH_BIN" ]] || smoke_fail "missing date/sleep/bash binaries"
+
+# Driver script that sources bridge_with_timeout and invokes it on argv. We
+# write it to disk to avoid layered quoting around `bash -c`.
+DRIVER="$SMOKE_TMP_ROOT/with-timeout-driver.sh"
+cat >"$DRIVER" <<'EOF'
+#!/usr/bin/env bash
+# args: <secs> <label> <cmd> [cmd_args...]
+set -uo pipefail
+SCRIPT_DIR="${BRIDGE_REPO_ROOT:?}"
+# shellcheck source=/dev/null
+source "$BRIDGE_REPO_ROOT/lib/bridge-state.sh"
+secs="$1"
+label="$2"
+shift 2
+bridge_with_timeout "$secs" "$label" "$@"
+EOF
+chmod +x "$DRIVER"
+
+# Build a per-tier PATH directory that contains only the binaries the tier
+# is allowed to see. We symlink rather than copy so identity-preserving
+# resolution (`command -v`) still works and we don't accidentally shadow.
+build_tier_path_dir() {
+  local dir="$1"
+  shift
+  rm -rf "$dir"
+  mkdir -p "$dir"
+  local bin
+  for bin in "$@"; do
+    [[ -n "$bin" && -x "$bin" ]] || continue
+    ln -sf "$bin" "$dir/$(basename "$bin")"
+  done
+  printf '%s\n' "$dir"
+}
+
+# Run the driver inside a child shell whose PATH is the supplied shim. We
+# also reset the per-cache state on bridge-state.sh by sourcing afresh each
+# call — the driver script does this since it sources the lib.
+#
+# We invoke bash via its absolute path (BASH_BIN) so the per-tier PATH shim
+# does not need to advertise bash itself — that would defeat the point of
+# hiding python3 in tier 3 (env(1) on macOS resolves the invoked binary via
+# the new PATH only when given as a bare name).
+run_in_tier() {
+  local tier_path="$1"
+  local secs="$2"
+  local label="$3"
+  shift 3
+  local rc=0
+  local started ended elapsed
+  started="$("$DATE_BIN" +%s)"
+  set +e
+  env -i \
+    HOME="$HOME" \
+    PATH="$tier_path" \
+    BRIDGE_HOME="$BRIDGE_HOME" \
+    BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+    BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+    BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
+    BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+    BRIDGE_REPO_ROOT="$BRIDGE_REPO_ROOT" \
+    BRIDGE_SCRIPT_DIR="$BRIDGE_SCRIPT_DIR" \
+    "$BASH_BIN" "$DRIVER" "$secs" "$label" "$@" >/dev/null 2>&1
+  rc=$?
+  set -e
+  ended="$("$DATE_BIN" +%s)"
+  elapsed=$(( ended - started ))
+  printf 'rc=%d elapsed=%d\n' "$rc" "$elapsed"
+}
+
+# --- tier 1: timeout(1) or gtimeout(1) present ------------------------------
+
+step_tier1_binary_path() {
+  smoke_log "tier 1: timeout(1)/gtimeout(1) on PATH must kill stalling cmd at budget"
+
+  if [[ -z "$SYS_TIMEOUT" && -z "$SYS_GTIMEOUT" ]]; then
+    smoke_skip "tier 1" "neither timeout(1) nor gtimeout(1) on host — cannot exercise the binary tier"
+    return 0
+  fi
+
+  local tier_dir
+  tier_dir="$(build_tier_path_dir "$SMOKE_TMP_ROOT/path-tier1" \
+    "$SYS_TIMEOUT" "$SYS_GTIMEOUT" "$SYS_PYTHON3" "$DATE_BIN" "$SLEEP_BIN")"
+
+  local output rc elapsed
+  output="$(run_in_tier "$tier_dir" 2 tier1_smoke "$SLEEP_BIN" 10)"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  elapsed="$(printf '%s\n' "$output" | sed -n 's/.*elapsed=\([0-9]*\).*/\1/p')"
+  [[ -n "$rc" ]] || smoke_fail "tier 1: could not parse rc from '$output'"
+  [[ -n "$elapsed" ]] || smoke_fail "tier 1: could not parse elapsed from '$output'"
+  if [[ "$rc" != "124" && "$rc" != "137" ]]; then
+    smoke_fail "tier 1: expected rc=124|137, got rc=$rc (elapsed=${elapsed}s)"
+  fi
+  if (( elapsed > 8 )); then
+    smoke_fail "tier 1: 2s budget not enforced (elapsed=${elapsed}s)"
+  fi
+
+  # Audit row must tag tier=binary and the call-site label.
+  if ! grep -q '"call_site": "tier1_smoke"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "tier 1: audit log missing call_site=tier1_smoke: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  if ! grep -q '"tier": "binary"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "tier 1: audit log missing tier=binary detail: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  smoke_log "  rc=$rc elapsed=${elapsed}s (binary tier killed at budget)"
+}
+
+# --- tier 2: python3 only ---------------------------------------------------
+
+step_tier2_python_kill() {
+  smoke_log "tier 2: with timeout(1)/gtimeout(1) hidden, python3 subprocess.run must kill at budget"
+
+  local tier_dir
+  tier_dir="$(build_tier_path_dir "$SMOKE_TMP_ROOT/path-tier2" \
+    "$SYS_PYTHON3" "$DATE_BIN" "$SLEEP_BIN")"
+
+  # Sanity: confirm the shim really hides timeout/gtimeout.
+  if env -i HOME="$HOME" PATH="$tier_dir" "$BASH_BIN" -c 'command -v timeout' >/dev/null 2>&1; then
+    smoke_fail "tier 2 PATH shim leaked timeout(1)"
+  fi
+  if env -i HOME="$HOME" PATH="$tier_dir" "$BASH_BIN" -c 'command -v gtimeout' >/dev/null 2>&1; then
+    smoke_fail "tier 2 PATH shim leaked gtimeout(1)"
+  fi
+
+  local output rc elapsed
+  output="$(run_in_tier "$tier_dir" 2 tier2_smoke "$SLEEP_BIN" 10)"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  elapsed="$(printf '%s\n' "$output" | sed -n 's/.*elapsed=\([0-9]*\).*/\1/p')"
+  [[ -n "$rc" ]] || smoke_fail "tier 2: could not parse rc from '$output'"
+  [[ -n "$elapsed" ]] || smoke_fail "tier 2: could not parse elapsed from '$output'"
+  # python wrapper maps TimeoutExpired -> 124 to match GNU timeout(1).
+  if [[ "$rc" != "124" ]]; then
+    smoke_fail "tier 2: expected rc=124 from python TimeoutExpired, got rc=$rc (elapsed=${elapsed}s)"
+  fi
+  if (( elapsed > 8 )); then
+    smoke_fail "tier 2: 2s budget not enforced (elapsed=${elapsed}s) — python wrap is broken"
+  fi
+
+  # Audit row must tag tier=python (not binary, not unavailable).
+  if ! grep -q '"call_site": "tier2_smoke"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "tier 2: audit log missing call_site=tier2_smoke: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  # Slice to lines belonging to tier2_smoke so we don't accidentally match
+  # tier1_smoke rows from the prior step.
+  local tier2_rows
+  tier2_rows="$(grep '"call_site": "tier2_smoke"' "$BRIDGE_AUDIT_LOG" || true)"
+  if ! printf '%s\n' "$tier2_rows" | grep -q '"tier": "python"'; then
+    smoke_fail "tier 2: audit row missing tier=python detail: $tier2_rows"
+  fi
+  if printf '%s\n' "$tier2_rows" | grep -q 'daemon_subprocess_timeout_unavailable'; then
+    smoke_fail "tier 2: should NOT log daemon_subprocess_timeout_unavailable (python succeeded as wrap)"
+  fi
+  smoke_log "  rc=$rc elapsed=${elapsed}s (python tier killed at budget)"
+}
+
+step_tier2_python_passthrough() {
+  smoke_log "tier 2: python wrap must pass through exit codes for fast-completing cmds"
+  local tier_dir
+  tier_dir="$(build_tier_path_dir "$SMOKE_TMP_ROOT/path-tier2-pass" \
+    "$SYS_PYTHON3" "$DATE_BIN" "$SLEEP_BIN")"
+
+  # `sleep 0` exits 0 immediately; budget 5s is well above that.
+  local output rc
+  output="$(run_in_tier "$tier_dir" 5 tier2_pass "$SLEEP_BIN" 0)"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  if [[ "$rc" != "0" ]]; then
+    smoke_fail "tier 2 passthrough: expected rc=0, got rc=$rc (output=$output)"
+  fi
+
+  # The fast-success path must NOT write a timeout audit row.
+  if grep -q '"call_site": "tier2_pass"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "tier 2 passthrough: unexpected audit row for successful run"
+  fi
+  smoke_log "  rc=$rc (python tier transparently passes success)"
+}
+
+# --- tier 3: nothing available ---------------------------------------------
+
+step_tier3_unwrapped_with_audit() {
+  smoke_log "tier 3: with no timeout AND no python3, helper runs unwrapped + logs unavailable"
+
+  # Hide python3 too. We still need date/sleep for the run, and we must NOT
+  # leak python3 — but bridge_audit_log -> bridge-audit.py internally calls
+  # python3 via bridge_require_python; we want the audit row written even
+  # when the wrap layer cannot find python3 on the *child PATH*. So we use
+  # bridge_audit_log's own python via the parent's PATH passed through, but
+  # only as part of bridge-state.sh's `bridge_require_python` resolution.
+  # Simplest: leave PATH bare of any python3 (also hides it from
+  # bridge_require_python), then validate by reading the audit log AFTER
+  # the run with PATH restored. If python3 isn't on the child PATH at all,
+  # bridge_audit_log will fail silently (it is wrapped in `2>/dev/null
+  # || true`), and we cannot prove the unavailable row was written. So
+  # instead we hide ONLY timeout/gtimeout AND make python3 unfindable
+  # specifically by the cache resolver inside bridge_with_timeout — we do
+  # that by giving the shim no python3 link but leaving bridge_require_python
+  # to find python3 via its own argv0 fallback. bridge_require_python uses
+  # `command -v python3` though, so that route also fails on a PATH without
+  # python3. Net: we accept that on this child PATH the audit log row may
+  # not actually land, and prove tier 3 a different way: by snapshotting
+  # the audit log size before/after the call and asserting the call ran
+  # unwrapped via the elapsed window (a 10-second sleep with a 2-second
+  # budget must take ~10s if no wrap fires).
+
+  local tier_dir
+  tier_dir="$(build_tier_path_dir "$SMOKE_TMP_ROOT/path-tier3" \
+    "$DATE_BIN" "$SLEEP_BIN")"
+
+  # Sanity: confirm the shim hides BOTH wrap binaries AND python3.
+  if env -i HOME="$HOME" PATH="$tier_dir" "$BASH_BIN" -c 'command -v timeout' >/dev/null 2>&1; then
+    smoke_fail "tier 3 PATH shim leaked timeout(1)"
+  fi
+  if env -i HOME="$HOME" PATH="$tier_dir" "$BASH_BIN" -c 'command -v gtimeout' >/dev/null 2>&1; then
+    smoke_fail "tier 3 PATH shim leaked gtimeout(1)"
+  fi
+  if env -i HOME="$HOME" PATH="$tier_dir" bash -c 'command -v python3' >/dev/null 2>&1; then
+    smoke_fail "tier 3 PATH shim leaked python3"
+  fi
+
+  # Run a 3-second sleep with a 2-second budget. If tier 3 falls through to
+  # unwrapped exec (status quo), the sleep runs to completion (~3s). If
+  # somehow tier 1 or tier 2 fires we would see ~2s + rc=124, which would be
+  # a test failure (the shim is incorrect).
+  local output rc elapsed
+  output="$(run_in_tier "$tier_dir" 2 tier3_smoke "$SLEEP_BIN" 3)"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  elapsed="$(printf '%s\n' "$output" | sed -n 's/.*elapsed=\([0-9]*\).*/\1/p')"
+  [[ -n "$rc" ]] || smoke_fail "tier 3: could not parse rc from '$output'"
+  [[ -n "$elapsed" ]] || smoke_fail "tier 3: could not parse elapsed from '$output'"
+  if [[ "$rc" != "0" ]]; then
+    smoke_fail "tier 3: expected rc=0 (sleep ran unwrapped), got rc=$rc"
+  fi
+  # The sleep runs ~3s; if some upstream layer killed it at 2s we'd see <=2.
+  if (( elapsed < 3 )); then
+    smoke_fail "tier 3: expected ~3s unwrapped sleep, got elapsed=${elapsed}s (a wrap fired unexpectedly)"
+  fi
+  smoke_log "  rc=$rc elapsed=${elapsed}s (unwrapped exec — status quo when both wrap layers absent)"
+}
+
+smoke_run "tier 1 (timeout/gtimeout binary) kills at budget"        step_tier1_binary_path
+smoke_run "tier 2 (python3) kills at budget when binary hidden"    step_tier2_python_kill
+smoke_run "tier 2 (python3) passes through fast-success commands"  step_tier2_python_passthrough
+smoke_run "tier 3 (no wrap) runs unwrapped when python3 hidden"    step_tier3_unwrapped_with_audit
+
+smoke_log "PASS"

--- a/scripts/smoke/bridge-with-timeout-fallback.sh
+++ b/scripts/smoke/bridge-with-timeout-fallback.sh
@@ -52,6 +52,13 @@ smoke_setup_bridge_home "$SMOKE_NAME"
 
 export BRIDGE_REPO_ROOT="$SMOKE_REPO_ROOT"
 export BRIDGE_SCRIPT_DIR="$BRIDGE_REPO_ROOT"
+# bridge-lib.sh (sourced by the driver) routes through bridge-layout-resolver,
+# which hard-aborts on a markerless install unless BRIDGE_LAYOUT=v2 +
+# BRIDGE_DATA_ROOT=<absolute> are exported. Seed an isolated v2 data root in
+# the temp BRIDGE_HOME so the driver can load the full lib chain.
+export BRIDGE_LAYOUT=v2
+export BRIDGE_DATA_ROOT="$BRIDGE_HOME/data"
+mkdir -p "$BRIDGE_DATA_ROOT/agents"
 : >"$BRIDGE_AUDIT_LOG"
 
 # Resolve the absolute paths to the binaries we may want to hide per tier.
@@ -70,14 +77,32 @@ BASH_BIN="$(command -v bash)"
 DRIVER="$SMOKE_TMP_ROOT/with-timeout-driver.sh"
 cat >"$DRIVER" <<'EOF'
 #!/usr/bin/env bash
-# args: <secs> <label> <cmd> [cmd_args...]
+# args: <tier_path> <secs> <label> <cmd> [cmd_args...]
+#
+# The driver sources bridge-lib.sh under the *load PATH* (BRIDGE_LOAD_PATH —
+# inherited from the smoke harness) so cd/dirname/basename are resolvable
+# while the lib chain initializes. Only after the source completes do we
+# narrow PATH to the per-tier shim — that is the PATH bridge_with_timeout's
+# own `command -v timeout/gtimeout/python3` resolution sees, so the tier
+# isolation still holds. Sourcing the full lib chain ensures
+# bridge_require_python is defined, so the tier-3 audit-before-exec bug
+# (codex r1 Finding 1) is reproducible from this harness.
 set -uo pipefail
 SCRIPT_DIR="${BRIDGE_REPO_ROOT:?}"
 # shellcheck source=/dev/null
-source "$BRIDGE_REPO_ROOT/lib/bridge-state.sh"
-secs="$1"
-label="$2"
-shift 2
+source "$BRIDGE_REPO_ROOT/bridge-lib.sh"
+tier_path="$1"
+secs="$2"
+label="$3"
+shift 3
+# Reset bridge_with_timeout's per-shell binary caches so the new PATH is
+# actually probed instead of returning a stale resolution from a prior call.
+_BRIDGE_WITH_TIMEOUT_BIN_CACHED=0
+_BRIDGE_WITH_TIMEOUT_BIN=""
+_BRIDGE_WITH_TIMEOUT_PYTHON_CACHED=0
+_BRIDGE_WITH_TIMEOUT_PYTHON=""
+_BRIDGE_WITH_TIMEOUT_UNAVAILABLE_LOGGED=0
+PATH="$tier_path"
 bridge_with_timeout "$secs" "$label" "$@"
 EOF
 chmod +x "$DRIVER"
@@ -115,9 +140,14 @@ run_in_tier() {
   local started ended elapsed
   started="$("$DATE_BIN" +%s)"
   set +e
+  # PATH passed to env -i is the *load PATH* — bridge-lib.sh's source-time
+  # initialization (cd, dirname, basename, etc.) needs the system PATH to
+  # resolve coreutils. The driver narrows PATH to "$tier_path" right before
+  # invoking bridge_with_timeout, so tier-1/2/3 isolation still applies to
+  # bridge_with_timeout's own binary probing.
   env -i \
     HOME="$HOME" \
-    PATH="$tier_path" \
+    PATH="$PATH" \
     BRIDGE_HOME="$BRIDGE_HOME" \
     BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
     BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
@@ -125,7 +155,9 @@ run_in_tier() {
     BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
     BRIDGE_REPO_ROOT="$BRIDGE_REPO_ROOT" \
     BRIDGE_SCRIPT_DIR="$BRIDGE_SCRIPT_DIR" \
-    "$BASH_BIN" "$DRIVER" "$secs" "$label" "$@" >/dev/null 2>&1
+    BRIDGE_LAYOUT="$BRIDGE_LAYOUT" \
+    BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+    "$BASH_BIN" "$DRIVER" "$tier_path" "$secs" "$label" "$@" >/dev/null 2>&1
   rc=$?
   set -e
   ended="$("$DATE_BIN" +%s)"
@@ -168,6 +200,33 @@ step_tier1_binary_path() {
     smoke_fail "tier 1: audit log missing tier=binary detail: $(cat "$BRIDGE_AUDIT_LOG")"
   fi
   smoke_log "  rc=$rc elapsed=${elapsed}s (binary tier killed at budget)"
+}
+
+step_tier1_binary_passthrough() {
+  smoke_log "tier 1: binary wrap must pass through exit codes for fast-completing cmds"
+
+  if [[ -z "$SYS_TIMEOUT" && -z "$SYS_GTIMEOUT" ]]; then
+    smoke_skip "tier 1 passthrough" "neither timeout(1) nor gtimeout(1) on host — cannot exercise the binary tier"
+    return 0
+  fi
+
+  local tier_dir
+  tier_dir="$(build_tier_path_dir "$SMOKE_TMP_ROOT/path-tier1-pass" \
+    "$SYS_TIMEOUT" "$SYS_GTIMEOUT" "$SYS_PYTHON3" "$DATE_BIN" "$SLEEP_BIN")"
+
+  # `sleep 0` exits 0 immediately; budget 5s is well above that.
+  local output rc
+  output="$(run_in_tier "$tier_dir" 5 tier1_pass "$SLEEP_BIN" 0)"
+  rc="$(printf '%s\n' "$output" | sed -n 's/.*rc=\([0-9]*\).*/\1/p')"
+  if [[ "$rc" != "0" ]]; then
+    smoke_fail "tier 1 passthrough: expected rc=0, got rc=$rc (output=$output)"
+  fi
+
+  # The fast-success path must NOT write a timeout audit row.
+  if grep -q '"call_site": "tier1_pass"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "tier 1 passthrough: unexpected audit row for successful run"
+  fi
+  smoke_log "  rc=$rc (binary tier transparently passes success)"
 }
 
 # --- tier 2: python3 only ---------------------------------------------------
@@ -302,6 +361,7 @@ step_tier3_unwrapped_with_audit() {
 }
 
 smoke_run "tier 1 (timeout/gtimeout binary) kills at budget"        step_tier1_binary_path
+smoke_run "tier 1 (binary) passes through fast-success commands"   step_tier1_binary_passthrough
 smoke_run "tier 2 (python3) kills at budget when binary hidden"    step_tier2_python_kill
 smoke_run "tier 2 (python3) passes through fast-success commands"  step_tier2_python_passthrough
 smoke_run "tier 3 (no wrap) runs unwrapped when python3 hidden"    step_tier3_unwrapped_with_audit


### PR DESCRIPTION
## Summary
- Add python3 subprocess.run(timeout=) tier-2 fallback to bridge_with_timeout
  when neither timeout(1) nor gtimeout is on PATH. Tier 1 (binary) unchanged;
  tier 3 (unwrapped exec) is now the last-resort when python3 also missing.
- Audit log: tier-2 timeout emits daemon_subprocess_timeout (same as tier 1);
  daemon_subprocess_timeout_unavailable now only fires on tier 3.

## Context
bridge_with_timeout was added in #265. PR #802 r2 documented that its
fallback path on bare macOS (no GNU coreutils) is an unwrapped exec —
so every downstream caller silently loses the timeout guarantee. With
python3 fallback the wrap holds on hosts that have python3 (= all
supported hosts; python3 is a hard dependency).

Python wrapper is invoked via \`python3 -c \"\$SCRIPT\"\` (here-string variable
+ -c) instead of heredoc-stdin, matching the post-#801 pattern that avoided
the #800 \`heredoc_write\` deadlock class.

## Validation
- bash -n + shellcheck on lib/bridge-state.sh (clean)
- new smoke scripts/smoke/bridge-with-timeout-fallback.sh exercises all 3 tiers
  in an isolated BRIDGE_HOME using per-tier PATH shims; all pass.
- existing scripts/smoke/daemon-heredoc-timeout.sh still passes (no regression
  in tier 1 path).
- scripts/smoke-test.sh fails at the pre-existing isolation-v2 marker check
  on this host (not introduced by this PR).