### PR TITLE
fix(status): multi-signal alive determination (#780)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1546,12 +1546,12 @@ PY
 #              here by adding more sources of truth without changing the
 #              public field shape.
 #   3. channel — at least one channel plugin port from
-#                `bridge_agent_plugin_ports` is in LISTEN state. Uses
-#                `bridge_port_is_listening` if a sibling helper exists
-#                (Track D / #779), otherwise an inline socket-connect
-#                probe. We treat *any* port that this agent is supposed
-#                to bind as a positive channel signal — channel plugins
-#                only listen while the agent runtime is alive.
+#                `bridge_agent_plugin_ports` is in LISTEN state. Delegates
+#                to `bridge_port_is_listening` (Track D / #779, lives in
+#                lib/bridge-agents.sh) so the LISTEN probe stays a single
+#                source of truth. We treat *any* port that this agent is
+#                supposed to bind as a positive channel signal — channel
+#                plugins only listen while the agent runtime is alive.
 #
 # Zombie tmux protection: when the tmux session exists but agent
 # processes are dead, we still report alive=true based on the tmux
@@ -1573,34 +1573,15 @@ bridge_agent_alive_pid_signal() {
 }
 
 bridge_agent_alive_port_is_listening() {
-  # Track D (#779) is expected to expose `bridge_port_is_listening`.
-  # If that lands first, prefer it (single source of truth). Otherwise
-  # use an inline socket-connect probe so this fix stands alone.
+  # Delegate to the canonical LISTEN probe shipped by Track D (#779) in
+  # lib/bridge-agents.sh. bridge-agent.sh loads bridge-lib.sh →
+  # bridge-agents.sh at startup, so the helper is always defined here.
+  # No defensive fallback: keeping a forbidden heredoc-stdin Python
+  # callsite around as "just in case" violates the #800 deadlock-class
+  # convention (PR #801) and the branch can never reach it in practice.
   local port="$1"
   [[ -n "$port" ]] || return 1
-  if [[ "$(type -t bridge_port_is_listening 2>/dev/null)" == "function" ]]; then
-    bridge_port_is_listening "$port"
-    return $?
-  fi
-  python3 - "$port" <<'PY' >/dev/null 2>&1
-import socket
-import sys
-
-try:
-    port = int(sys.argv[1])
-except (TypeError, ValueError):
-    sys.exit(1)
-# Connect-to-localhost is a portable LISTEN probe: a listening socket
-# accepts the connection; nothing bound → ECONNREFUSED. Avoids needing
-# ss/lsof/netstat which differ across macOS/Linux/Alpine.
-for host in ("127.0.0.1", "::1"):
-    try:
-        with socket.create_connection((host, port), timeout=0.25):
-            sys.exit(0)
-    except OSError:
-        continue
-sys.exit(1)
-PY
+  bridge_port_is_listening "$port"
 }
 
 bridge_agent_alive_channel_signal() {

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1531,6 +1531,120 @@ print(json.dumps(records, ensure_ascii=False, indent=2))
 PY
 }
 
+# Issue #780 — multi-signal alive determination for `agent show --json`.
+#
+# Controller-side health probe historically only checked tmux session
+# existence. That yields `alive=null` (or implicit-false) when the agent
+# itself is running outside a tmux session (systemd-direct, dynamic
+# detach, custom launcher) but its channel servers / claude session are
+# alive. The new `alive` field is the OR of three signals so any one
+# being live is enough to report `alive=true`:
+#
+#   1. tmux  — `bridge_agent_is_active` (existing single signal)
+#   2. pid   — `<agent_home>/runtime/agent.pid` exists + the PID is alive
+#              (kill -0). Future systemd-unit signal can be folded in
+#              here by adding more sources of truth without changing the
+#              public field shape.
+#   3. channel — at least one channel plugin port from
+#                `bridge_agent_plugin_ports` is in LISTEN state. Uses
+#                `bridge_port_is_listening` if a sibling helper exists
+#                (Track D / #779), otherwise an inline socket-connect
+#                probe. We treat *any* port that this agent is supposed
+#                to bind as a positive channel signal — channel plugins
+#                only listen while the agent runtime is alive.
+#
+# Zombie tmux protection: when the tmux session exists but agent
+# processes are dead, we still report alive=true based on the tmux
+# signal. That's an accepted residue — `agent-bridge doctor` is the
+# path to detect zombies.
+bridge_agent_alive_pid_signal() {
+  local agent="$1"
+  local home=""
+  local pid_file=""
+  local pid_raw=""
+
+  home="$(bridge_agent_default_home "$agent" 2>/dev/null || true)"
+  [[ -n "$home" ]] || return 1
+  pid_file="$home/runtime/agent.pid"
+  [[ -f "$pid_file" ]] || return 1
+  pid_raw="$(head -n 1 "$pid_file" 2>/dev/null | tr -d '[:space:]')"
+  [[ -n "$pid_raw" && "$pid_raw" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid_raw" 2>/dev/null
+}
+
+bridge_agent_alive_port_is_listening() {
+  # Track D (#779) is expected to expose `bridge_port_is_listening`.
+  # If that lands first, prefer it (single source of truth). Otherwise
+  # use an inline socket-connect probe so this fix stands alone.
+  local port="$1"
+  [[ -n "$port" ]] || return 1
+  if [[ "$(type -t bridge_port_is_listening 2>/dev/null)" == "function" ]]; then
+    bridge_port_is_listening "$port"
+    return $?
+  fi
+  python3 - "$port" <<'PY' >/dev/null 2>&1
+import socket
+import sys
+
+try:
+    port = int(sys.argv[1])
+except (TypeError, ValueError):
+    sys.exit(1)
+# Connect-to-localhost is a portable LISTEN probe: a listening socket
+# accepts the connection; nothing bound → ECONNREFUSED. Avoids needing
+# ss/lsof/netstat which differ across macOS/Linux/Alpine.
+for host in ("127.0.0.1", "::1"):
+    try:
+        with socket.create_connection((host, port), timeout=0.25):
+            sys.exit(0)
+    except OSError:
+        continue
+sys.exit(1)
+PY
+}
+
+bridge_agent_alive_channel_signal() {
+  local agent="$1"
+  local line=""
+  local port=""
+
+  if ! type bridge_agent_plugin_ports >/dev/null 2>&1; then
+    return 1
+  fi
+  # bridge_agent_plugin_ports emits one "<port>\t<binary>\t<plugin>" per
+  # known long-lived listener for the agent. Any one in LISTEN is enough.
+  while IFS=$'\t' read -r port _ _; do
+    [[ -n "$port" ]] || continue
+    if bridge_agent_alive_port_is_listening "$port"; then
+      return 0
+    fi
+  done < <(bridge_agent_plugin_ports "$agent" 2>/dev/null || true)
+  return 1
+}
+
+bridge_agent_alive_signals_json() {
+  local agent="$1"
+  local tmux_signal="false"
+  local pid_signal="false"
+  local channel_signal="false"
+  local alive="false"
+
+  if bridge_agent_is_active "$agent" 2>/dev/null; then
+    tmux_signal="true"
+  fi
+  if bridge_agent_alive_pid_signal "$agent" 2>/dev/null; then
+    pid_signal="true"
+  fi
+  if bridge_agent_alive_channel_signal "$agent" 2>/dev/null; then
+    channel_signal="true"
+  fi
+  if [[ "$tmux_signal" == "true" || "$pid_signal" == "true" || "$channel_signal" == "true" ]]; then
+    alive="true"
+  fi
+  printf '{"alive":%s,"signals":{"tmux":%s,"pid":%s,"channel":%s}}' \
+    "$alive" "$tmux_signal" "$pid_signal" "$channel_signal"
+}
+
 run_show() {
   local agent="${1:-}"
   local json_mode=0
@@ -1559,11 +1673,17 @@ run_show() {
     # output is intentionally unchanged; only --json exposes the path so
     # operators can pipe it into recovery scripts (e.g. forget-session
     # follow-ups) without parsing the human format.
+    #
+    # alive (issue #780): multi-signal OR (tmux | pid | channel LISTEN)
+    # written alongside the existing `active` field. `active` stays as
+    # the tmux-only signal so callers that depend on the old meaning
+    # are unchanged; `alive` is the new operator-facing health value.
     bridge_agent_manage_python \
       "$(emit_agent_records_json show "$output")" \
       "$(bridge_agent_channel_diagnostics_json "$agent")" \
       "$(bridge_agent_session_health_json "$agent")" \
-      "$(bridge_agent_session_source_path "$agent")" <<'PY'
+      "$(bridge_agent_session_source_path "$agent")" \
+      "$(bridge_agent_alive_signals_json "$agent")" <<'PY'
 import json
 import sys
 
@@ -1571,6 +1691,9 @@ payload = json.loads(sys.argv[1])
 payload.setdefault("channels", {})["diagnostics"] = json.loads(sys.argv[2])
 payload["session_health"] = json.loads(sys.argv[3])
 payload["session_source"] = sys.argv[4] if len(sys.argv) > 4 and sys.argv[4] else None
+alive_blob = json.loads(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[5] else {}
+payload["alive"] = bool(alive_blob.get("alive", False))
+payload["alive_signals"] = alive_blob.get("signals", {})
 print(json.dumps(payload, ensure_ascii=False, indent=2))
 PY
     return 0

--- a/scripts/smoke/alive-multi-signal.sh
+++ b/scripts/smoke/alive-multi-signal.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# scripts/smoke/alive-multi-signal.sh — Issue #780 smoke.
+#
+# Validates the new multi-signal `alive` field on
+# `agent-bridge show <agent> --json`. The field is an OR of three
+# signals; any one being live → alive=true. This smoke exercises each
+# signal in isolation plus the all-dead baseline:
+#
+#   T1. tmux-only           → alive=true, signals.tmux=true
+#   T2. pid-only            → alive=true, signals.pid=true
+#   T3. channel-LISTEN only → alive=true, signals.channel=true
+#   T4. nothing active      → alive=false, all signals=false
+#
+# Uses an isolated BRIDGE_HOME via smoke_setup_bridge_home — never
+# touches the operator's live runtime. tmux + channel signals are
+# faked via roster-level shell overrides (same trick that
+# agent-retire.sh uses to fake `bridge_agent_is_active`), so the smoke
+# needs no real tmux server, no real channel plugin, and no
+# privileged listener.
+
+set -euo pipefail
+
+SMOKE_NAME="alive-multi-signal"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+LISTENER_PID=""
+LISTENER_PORT=""
+
+cleanup() {
+  if [[ -n "$LISTENER_PID" ]] && kill -0 "$LISTENER_PID" 2>/dev/null; then
+    kill "$LISTENER_PID" 2>/dev/null || true
+    wait "$LISTENER_PID" 2>/dev/null || true
+  fi
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "alive-multi-signal"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BASH4_BIN="${BASH:-bash}"
+if (( BASH_VERSINFO[0] < 4 )); then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BASH4_BIN="/opt/homebrew/bin/bash"
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BASH4_BIN="/usr/local/bin/bash"
+  fi
+fi
+
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+agent_show_json() {
+  local agent="$1"
+  "$BASH4_BIN" "$REPO_ROOT/bridge-agent.sh" show "$agent" --json
+}
+
+# Pluck a JSON path out of show output via python (jq may not be
+# installed on every smoke host).
+jget() {
+  local payload="$1"
+  local path="$2"
+  "$PY_BIN" - "$payload" "$path" <<'PY'
+import json
+import sys
+
+doc = json.loads(sys.argv[1])
+path = sys.argv[2]
+cur = doc
+for part in path.split("."):
+    if part == "":
+        continue
+    if isinstance(cur, dict) and part in cur:
+        cur = cur[part]
+    else:
+        cur = None
+        break
+if isinstance(cur, bool):
+    print("true" if cur else "false")
+elif cur is None:
+    print("null")
+else:
+    print(cur)
+PY
+}
+
+# Roster writer — single static agent + a hook block that overrides
+# the alive helpers we want to mock. The hook block is appended after
+# the agent registration so it always wins. `keep_*` flags decide
+# which signals the hooks force to true.
+write_roster() {
+  local agent="$1"
+  local force_tmux="$2"     # 0|1
+  local fake_port="$3"      # empty | port number for channel mock
+
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "$agent"
+BRIDGE_AGENT_ENGINE["$agent"]="claude"
+BRIDGE_AGENT_SESSION["$agent"]="$agent"
+BRIDGE_AGENT_WORKDIR["$agent"]="$BRIDGE_AGENT_HOME_ROOT/$agent"
+EOF
+
+  if [[ "$force_tmux" == "1" ]]; then
+    cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+
+# T1: pretend tmux session is alive without booting a real one.
+bridge_agent_is_active() {
+  if [[ "\$1" == "$agent" ]]; then
+    return 0
+  fi
+  return 1
+}
+EOF
+  else
+    cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+
+# Force tmux-signal false so other cases isolate the remaining
+# signals. The default helper returns false anyway in an isolated
+# BRIDGE_HOME (no tmux session), but override explicitly so the
+# smoke is robust to a stray live tmux server on the build host.
+bridge_agent_is_active() {
+  return 1
+}
+EOF
+  fi
+
+  if [[ -n "$fake_port" ]]; then
+    cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+
+# T3: surface a single fake plugin port so the channel-LISTEN signal
+# can be exercised without a real teams .env or plugin process. The
+# alive helper iterates this output and runs an actual socket probe
+# against the port the smoke harness opens.
+bridge_agent_plugin_ports() {
+  printf '%s\t%s\t%s\n' "$fake_port" "smoke-listener" "smoke"
+}
+EOF
+  fi
+}
+
+# Spin up a TCP listener on a free port; export the port so the
+# roster can advertise it. We use Python so we don't depend on
+# `nc -l` flavor differences across macOS/Linux/BusyBox.
+start_listener() {
+  local port_file
+  port_file="$SMOKE_TMP_ROOT/listener.port"
+  rm -f "$port_file"
+  "$PY_BIN" - "$port_file" <<'PY' &
+import socket
+import sys
+import time
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(8)
+    port = sock.getsockname()[1]
+    with open(sys.argv[1], "w") as fh:
+        fh.write(str(port))
+    # Accept loop — keep listening until the parent kills us. We
+    # close each accepted socket immediately; the probe only checks
+    # that connect() succeeds.
+    sock.settimeout(0.5)
+    deadline = time.monotonic() + 30.0
+    while time.monotonic() < deadline:
+        try:
+            client, _ = sock.accept()
+        except socket.timeout:
+            continue
+        try:
+            client.close()
+        except OSError:
+            pass
+PY
+  LISTENER_PID=$!
+  # Wait up to ~2s for the port file to appear.
+  local attempts=0
+  while (( attempts < 40 )); do
+    if [[ -f "$port_file" ]]; then
+      LISTENER_PORT="$(cat "$port_file")"
+      [[ -n "$LISTENER_PORT" ]] && return 0
+    fi
+    sleep 0.05
+    attempts=$((attempts + 1))
+  done
+  smoke_fail "listener failed to publish its port within 2s"
+}
+
+stop_listener() {
+  if [[ -n "$LISTENER_PID" ]] && kill -0 "$LISTENER_PID" 2>/dev/null; then
+    kill "$LISTENER_PID" 2>/dev/null || true
+    wait "$LISTENER_PID" 2>/dev/null || true
+  fi
+  LISTENER_PID=""
+  LISTENER_PORT=""
+}
+
+# Materialize <agent_home>/runtime/agent.pid with the given pid. The
+# alive helper resolves home via bridge_agent_default_home, which under
+# the v2 layout returns $BRIDGE_AGENT_ROOT_V2/<agent>/home (see
+# scripts/smoke/lib.sh — BRIDGE_LAYOUT is forced to v2).
+write_agent_pid_file() {
+  local agent="$1"
+  local pid="$2"
+  local home="$BRIDGE_AGENT_ROOT_V2/$agent/home"
+  mkdir -p "$home/runtime"
+  printf '%s\n' "$pid" >"$home/runtime/agent.pid"
+}
+
+clear_agent_pid_file() {
+  local agent="$1"
+  local home="$BRIDGE_AGENT_ROOT_V2/$agent/home"
+  rm -f "$home/runtime/agent.pid"
+}
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+test_tmux_only() {
+  local agent="alpha"
+  clear_agent_pid_file "$agent"
+  write_roster "$agent" 1 ""
+
+  local payload
+  payload="$(agent_show_json "$agent")"
+  smoke_assert_eq "true"  "$(jget "$payload" "alive")"                  "T1 alive"
+  smoke_assert_eq "true"  "$(jget "$payload" "alive_signals.tmux")"     "T1 signals.tmux"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.pid")"      "T1 signals.pid"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.channel")"  "T1 signals.channel"
+}
+
+test_pid_only() {
+  local agent="alpha"
+  write_agent_pid_file "$agent" "$$"
+  write_roster "$agent" 0 ""
+
+  local payload
+  payload="$(agent_show_json "$agent")"
+  smoke_assert_eq "true"  "$(jget "$payload" "alive")"                  "T2 alive"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.tmux")"     "T2 signals.tmux"
+  smoke_assert_eq "true"  "$(jget "$payload" "alive_signals.pid")"      "T2 signals.pid"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.channel")"  "T2 signals.channel"
+  clear_agent_pid_file "$agent"
+}
+
+test_listen_only() {
+  local agent="alpha"
+  clear_agent_pid_file "$agent"
+  start_listener
+  write_roster "$agent" 0 "$LISTENER_PORT"
+
+  local payload
+  payload="$(agent_show_json "$agent")"
+  smoke_assert_eq "true"  "$(jget "$payload" "alive")"                  "T3 alive"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.tmux")"     "T3 signals.tmux"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.pid")"      "T3 signals.pid"
+  smoke_assert_eq "true"  "$(jget "$payload" "alive_signals.channel")"  "T3 signals.channel"
+  stop_listener
+}
+
+test_nothing_active() {
+  local agent="alpha"
+  clear_agent_pid_file "$agent"
+  stop_listener
+  write_roster "$agent" 0 ""
+
+  local payload
+  payload="$(agent_show_json "$agent")"
+  smoke_assert_eq "false" "$(jget "$payload" "alive")"                  "T4 alive"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.tmux")"     "T4 signals.tmux"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.pid")"      "T4 signals.pid"
+  smoke_assert_eq "false" "$(jget "$payload" "alive_signals.channel")"  "T4 signals.channel"
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+smoke_run "T1 tmux-only"           test_tmux_only
+smoke_run "T2 pid-only"            test_pid_only
+smoke_run "T3 channel-LISTEN only" test_listen_only
+smoke_run "T4 nothing active"      test_nothing_active
+
+smoke_log "all cases passed"


### PR DESCRIPTION
## Summary

`agent-bridge show <agent> --json` reported `alive=null` (no key) when the tmux session was absent — even when the agent's claude process and channel servers were still running. Controller-side health probe was tmux-only → false-negative on detach/systemd-direct/custom launchers.

This adds a multi-signal `alive` field (OR of three signals; any one alive → `alive=true`):

1. **tmux** — `bridge_agent_is_active` (existing single signal, preserved)
2. **pid** — `<agent_home>/runtime/agent.pid` exists + the PID is alive via `kill -0`
3. **channel** — at least one channel plugin port from `bridge_agent_plugin_ports` is in LISTEN state

The existing `active` field is **preserved** as the tmux-only signal — callers that depend on the old meaning are unchanged. `alive` is the new operator-facing health value, with a sibling `alive_signals` object exposing the three inputs for debugging.

### Cross-track coordination (#779)

Track D (#779) introduces `bridge_port_is_listening`. This PR defensively detects that helper via `type -t` and reuses it when present; otherwise it falls back to an inline Python `socket.create_connection` probe (portable across macOS/Linux/Alpine, no `ss`/`lsof`/`netstat` dependency). Either track can merge first.

### Reproducer (from #780)

Operator's v0.9.6 ec2-user observation:
```
agent-bridge show sales_sean --json | jq '.alive, .channels'
# → alive: null
# → channels.teams: { ready: true, creds: present }   (server LISTEN OK)
ps -u agent-bridge-sales_sean
# → bun + claude both alive
ss -tln | grep :3980
# → LISTEN
```

### Before → After

Before:
```
$ agent-bridge show sales_sean --json | jq '.alive'
null
```

After:
```
$ agent-bridge show sales_sean --json | jq '.alive, .alive_signals'
true
{
  "tmux": false,
  "pid": false,
  "channel": true
}
```

### Zombie-tmux behavior (acceptance criterion)

When tmux session exists but agent processes are dead, `alive=true` based on the tmux signal — accepted residue per the issue ("좀비 tmux"). `agent-bridge doctor` remains the zombie-detection path.

## Test plan

- [x] `bash -n bridge-agent.sh` — pass
- [x] `shellcheck bridge-agent.sh` — pass
- [x] `bash -n scripts/smoke/alive-multi-signal.sh` — pass
- [x] `shellcheck scripts/smoke/alive-multi-signal.sh` — pass
- [x] `bash scripts/smoke/alive-multi-signal.sh` — all 4 cases pass (tmux-only, pid-only, channel-LISTEN only, nothing active)
- [x] `./scripts/smoke-test.sh` — fails at the pre-existing isolation-v2 marker check (legacy → v2 layout migration required on this host); unrelated to this change

Closes #780.