### PR TITLE
feat(worktree): doctor subcommand for stale worktree cleanup

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -387,6 +387,15 @@ Managed worktrees live under:
 ~/.agent-bridge/worktrees/<repo-slug>/<agent>
 ```
 
+Stale fixer worktrees accumulated under `<repo>/.claude/worktrees/agent-*` (or
+`ab-*`) can be reaped safely with `agb worktree doctor`. The doctor classifies
+each fixer-style worktree as REMOVE (branch merged into `main`), STALE
+(unmerged but >14 days old), SKIP (stash entries present — refs/stash is shared
+across worktrees, so we never remove when a stash is in flight), or KEEP.
+Default is `--dry-run`; pass `--apply` to actually run `git worktree remove
+-f`. See `agb worktree doctor --help` for `--target-branch`, `--max-age-days`,
+`--include-stale`, and `--prune-branches`.
+
 ## Status And Debugging
 
 Use these first:

--- a/agent-bridge
+++ b/agent-bridge
@@ -203,6 +203,7 @@ Usage:
   $CLI_NAME handoff <task-id> --to <agent> [--from <agent>] [--note <text> | --note-file <path>]
   $CLI_NAME summary [agent...]
   $CLI_NAME worktree list
+  $CLI_NAME worktree doctor [--dry-run|--apply] [--max-age-days N] [--target-branch ref] [--include-stale] [--prune-branches]
   $CLI_NAME profile status [agent|--all]
   $CLI_NAME profile diff <agent>
   $CLI_NAME profile deploy <agent> [--dry-run] [--force]
@@ -1060,6 +1061,11 @@ EOF
             bridge_die "Usage: $CLI_NAME worktree list"
           fi
           bridge_list_worktrees
+          exit 0
+          ;;
+        doctor)
+          shift
+          bridge_worktree_doctor "$@"
           exit 0
           ;;
         *)

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -155,6 +155,305 @@ bridge_list_worktrees() {
   fi
 }
 
+# bridge_worktree_doctor — reap stale .claude/worktrees/<agent-*|ab-*> worktrees.
+#
+# Scans `git worktree list --porcelain` from the current repo and classifies each
+# fixer-style worktree (matching the `.claude/worktrees/agent-*` or
+# `.claude/worktrees/ab-*` pattern) into one of:
+#
+#   REMOVE  — branch is merged into the target branch (default `main`) AND the
+#             worktree has no stash entries.
+#   STALE   — branch is NOT merged but its last commit is older than
+#             --max-age-days (default 14). Reported but only removed under
+#             --apply --include-stale (operator opts in twice).
+#   SKIP    — worktree has 1+ stash entries. Refuse to touch (shared
+#             .git/refs/stash means popping in the wrong worktree can pull
+#             another lane's WIP — see feedback_worktree_stash_shared_git_dir).
+#   KEEP    — branch unmerged AND last commit is recent. Untouched.
+#
+# Default is --dry-run: prints the classification table and would-be actions.
+# --apply actually runs `git worktree remove -f <path>`. --prune-branches also
+# deletes the local branch ref via `git branch -D` once the worktree is gone.
+#
+# Stash safety is checked from the WORKTREE'S directory (`git -C <wt> stash list`).
+# Because all worktrees in a repo share refs/stash, the count seen there is the
+# global count; we treat any non-zero as "skip" rather than guessing ownership.
+#
+# Args: doctor [--dry-run] [--apply] [--max-age-days N] [--target-branch ref]
+#              [--include-stale] [--prune-branches] [--repo PATH]
+bridge_worktree_doctor() {
+  local mode="dry-run"
+  local max_age_days=14
+  local target_branch="main"
+  local include_stale=0
+  local prune_branches=0
+  local repo_root=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)
+        mode="dry-run"
+        shift
+        ;;
+      --apply)
+        mode="apply"
+        shift
+        ;;
+      --max-age-days)
+        [[ $# -lt 2 ]] && bridge_die "--max-age-days 뒤에 숫자를 지정하세요."
+        if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+          bridge_die "--max-age-days 값은 정수여야 합니다: $2"
+        fi
+        max_age_days="$2"
+        shift 2
+        ;;
+      --target-branch)
+        [[ $# -lt 2 ]] && bridge_die "--target-branch 뒤에 ref 이름을 지정하세요."
+        target_branch="$2"
+        shift 2
+        ;;
+      --include-stale)
+        include_stale=1
+        shift
+        ;;
+      --prune-branches)
+        prune_branches=1
+        shift
+        ;;
+      --repo)
+        [[ $# -lt 2 ]] && bridge_die "--repo 뒤에 경로를 지정하세요."
+        repo_root="$2"
+        shift 2
+        ;;
+      -h|--help)
+        cat <<'USAGE'
+Usage:
+  agent-bridge worktree doctor [--dry-run|--apply]
+                               [--max-age-days N] [--target-branch ref]
+                               [--include-stale] [--prune-branches]
+                               [--repo PATH]
+
+Reap stale .claude/worktrees/(agent-*|ab-*) worktrees safely.
+
+  --dry-run         (default) print classification + intended actions only
+  --apply           actually run `git worktree remove -f` on REMOVE rows
+  --max-age-days N  STALE threshold for unmerged branches (default: 14)
+  --target-branch R branch to test "merged into" against (default: main)
+  --include-stale   also remove STALE rows under --apply (operator opts in)
+  --prune-branches  also delete the local branch ref via `git branch -D`
+  --repo PATH       repo root to inspect (default: current working directory)
+
+Stash safety: any worktree with `git stash list` non-empty is SKIPped — the
+shared refs/stash store across worktrees means removing one can orphan stash
+refs that another lane might pop and inadvertently mix in WIP.
+USAGE
+        return 0
+        ;;
+      *)
+        bridge_die "지원하지 않는 doctor 옵션입니다: $1"
+        ;;
+    esac
+  done
+
+  if [[ -z "$repo_root" ]]; then
+    repo_root="$(pwd -P)"
+  fi
+  if ! repo_root="$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null)"; then
+    bridge_die "현재 경로는 git 저장소가 아닙니다: ${repo_root:-$(pwd -P)}"
+  fi
+
+  local porcelain
+  if ! porcelain="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null)"; then
+    bridge_die "git worktree list 실행 실패: $repo_root"
+  fi
+
+  local now_epoch
+  now_epoch="$(date +%s)"
+  local age_threshold_secs=$(( max_age_days * 86400 ))
+
+  # Counters for summary — read/written by _bridge_worktree_doctor_classify_one
+  # via Bash dynamic scope (intentional: keeps the porcelain parse loop simple).
+  local total_scanned=0
+  local n_remove=0
+  local n_stale=0
+  local n_skip=0
+  local n_keep=0
+  local n_removed=0
+  local n_remove_failed=0
+
+  # Iterate porcelain blocks. Each block starts with `worktree <path>` and
+  # ends at a blank line. Fields we care about: worktree, branch.
+  #
+  # NOTE: we deliberately use a temp-file fd redirection rather than a
+  # `<<<"$porcelain"` here-string or `done < <(printf ...)` process
+  # substitution. macOS Homebrew Bash 5.3.9 has a heredoc_write bug where
+  # write(2) into the parent's heredoc anon-pipe deadlocks when the body
+  # contains multiple `worktree`/`branch`/empty-line records — observed
+  # on this repo's own checkout (~152 fixer worktrees) and reproduced in
+  # the smoke fixture with 3 fixture worktrees plus merge commits. A
+  # temp file decouples the producer from the read loop entirely.
+  local porcelain_tmp
+  porcelain_tmp="$(mktemp -t bridge-worktree-doctor.XXXXXX)"
+  printf '%s\n' "$porcelain" >"$porcelain_tmp"
+
+  local wt_path="" wt_branch="" line
+  printf '%-7s | %-7s | %-7s | %s\n' "STATUS" "STASH" "AGE" "WORKTREE"
+  printf -- '--------+---------+---------+----------------------------------------\n'
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      "worktree "*)
+        wt_path="${line#worktree }"
+        wt_branch=""
+        ;;
+      "branch "*)
+        wt_branch="${line#branch }"
+        ;;
+      "")
+        if [[ -n "$wt_path" ]]; then
+          _bridge_worktree_doctor_classify_one \
+            "$repo_root" "$wt_path" "$wt_branch" \
+            "$target_branch" "$now_epoch" "$age_threshold_secs" \
+            "$mode" "$include_stale" "$prune_branches"
+        fi
+        wt_path=""
+        wt_branch=""
+        ;;
+    esac
+  done <"$porcelain_tmp"
+  rm -f "$porcelain_tmp"
+  # Trailing entry without blank line terminator.
+  if [[ -n "$wt_path" ]]; then
+    _bridge_worktree_doctor_classify_one \
+      "$repo_root" "$wt_path" "$wt_branch" \
+      "$target_branch" "$now_epoch" "$age_threshold_secs" \
+      "$mode" "$include_stale" "$prune_branches"
+  fi
+
+  echo ""
+  echo "Summary (mode=$mode, target-branch=$target_branch, max-age-days=$max_age_days):"
+  printf '  scanned    : %d\n' "$total_scanned"
+  printf '  REMOVE     : %d (merged into %s, no stash)\n' "$n_remove" "$target_branch"
+  printf '  STALE      : %d (unmerged, >%d days old)\n' "$n_stale" "$max_age_days"
+  printf '  SKIP       : %d (stash entries present)\n' "$n_skip"
+  printf '  KEEP       : %d (recent/unmerged)\n' "$n_keep"
+  if [[ "$mode" == "apply" ]]; then
+    printf '  removed    : %d\n' "$n_removed"
+    if (( n_remove_failed > 0 )); then
+      printf '  failed     : %d\n' "$n_remove_failed"
+    fi
+  else
+    echo "  (dry-run; rerun with --apply to actually remove REMOVE rows)"
+  fi
+}
+
+# Helper used only by bridge_worktree_doctor. Lives outside the main function
+# so the counter mutations stay in one place. Reads/writes the n_* and
+# total_scanned counters from the calling function's scope via Bash dynamic
+# scope.
+_bridge_worktree_doctor_classify_one() {
+  local repo_root="$1"
+  local wt_path="$2"
+  local wt_branch="$3"
+  local target_branch="$4"
+  local now_epoch="$5"
+  local age_threshold_secs="$6"
+  local mode="$7"
+  local include_stale="$8"
+  local prune_branches="$9"
+
+  # Match only fixer-style worktree paths: */.claude/worktrees/agent-*
+  # or */.claude/worktrees/ab-*. Operator's primary checkout and ad-hoc
+  # locations are NOT in scope — this is intentional, doctor is a focused
+  # reaper, not a general worktree cleaner.
+  if [[ "$wt_path" != *"/.claude/worktrees/agent-"* ]] \
+     && [[ "$wt_path" != *"/.claude/worktrees/ab-"* ]]; then
+    return 0
+  fi
+
+  total_scanned=$(( total_scanned + 1 ))
+
+  local short_branch=""
+  if [[ "$wt_branch" == refs/heads/* ]]; then
+    short_branch="${wt_branch#refs/heads/}"
+  else
+    short_branch="$wt_branch"
+  fi
+
+  # Stash safety check — count stash entries from inside the worktree.
+  # Best-effort: if `git -C <wt>` errors (worktree dir gone, locked refs),
+  # treat as 0 stash entries since there's nothing to lose.
+  local stash_count=0
+  if [[ -d "$wt_path" ]]; then
+    stash_count="$(git -C "$wt_path" stash list 2>/dev/null | wc -l | tr -d ' ')"
+    [[ -z "$stash_count" ]] && stash_count=0
+  fi
+
+  # Last commit age on the branch (epoch seconds). Fall back to 0 if the
+  # ref is gone — that itself is a signal the worktree is stale.
+  local last_commit_epoch=0
+  if [[ -n "$short_branch" ]]; then
+    last_commit_epoch="$(git -C "$repo_root" log -1 --format=%ct "$short_branch" 2>/dev/null || printf '0')"
+  fi
+  local age_secs=0
+  if [[ "$last_commit_epoch" =~ ^[0-9]+$ ]] && (( last_commit_epoch > 0 )); then
+    age_secs=$(( now_epoch - last_commit_epoch ))
+  fi
+  local age_days=$(( age_secs / 86400 ))
+
+  # Merged check: branch reachable from target_branch tip.
+  local is_merged=0
+  if [[ -n "$short_branch" ]]; then
+    if git -C "$repo_root" merge-base --is-ancestor "$short_branch" "$target_branch" 2>/dev/null; then
+      is_merged=1
+    fi
+  fi
+
+  local status="KEEP"
+  if (( stash_count > 0 )); then
+    status="SKIP"
+    n_skip=$(( n_skip + 1 ))
+  elif (( is_merged == 1 )); then
+    status="REMOVE"
+    n_remove=$(( n_remove + 1 ))
+  elif (( age_secs > age_threshold_secs )); then
+    status="STALE"
+    n_stale=$(( n_stale + 1 ))
+  else
+    status="KEEP"
+    n_keep=$(( n_keep + 1 ))
+  fi
+
+  printf '%-7s | %-7s | %3dd    | %s\n' \
+    "$status" "${stash_count}" "$age_days" "$wt_path"
+
+  if [[ "$mode" != "apply" ]]; then
+    return 0
+  fi
+
+  # Apply mode — REMOVE always, STALE only with --include-stale.
+  local should_remove=0
+  if [[ "$status" == "REMOVE" ]]; then
+    should_remove=1
+  elif [[ "$status" == "STALE" && "$include_stale" == "1" ]]; then
+    should_remove=1
+  fi
+
+  if (( should_remove == 1 )); then
+    if git -C "$repo_root" worktree remove -f "$wt_path" >/dev/null 2>&1; then
+      n_removed=$(( n_removed + 1 ))
+      printf '         [apply] removed: %s\n' "$wt_path"
+      if [[ "$prune_branches" == "1" && -n "$short_branch" ]]; then
+        if git -C "$repo_root" branch -D "$short_branch" >/dev/null 2>&1; then
+          printf '         [apply] deleted branch: %s\n' "$short_branch"
+        fi
+      fi
+    else
+      n_remove_failed=$(( n_remove_failed + 1 ))
+      printf '         [apply] FAILED to remove: %s\n' "$wt_path" >&2
+    fi
+  fi
+}
+
 bridge_static_agents_for_project_engine() {
   local project_root="$1"
   local engine="$2"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -175,9 +175,13 @@ bridge_list_worktrees() {
 # --apply actually runs `git worktree remove -f <path>`. --prune-branches also
 # deletes the local branch ref via `git branch -D` once the worktree is gone.
 #
-# Stash safety is checked from the WORKTREE'S directory (`git -C <wt> stash list`).
-# Because all worktrees in a repo share refs/stash, the count seen there is the
-# global count; we treat any non-zero as "skip" rather than guessing ownership.
+# Stash safety is checked ONCE at the repo level (`git -C <repo_root> stash list`)
+# BEFORE the per-worktree classification loop. Because all worktrees in a repo
+# share refs/stash, any stash entry anywhere blocks all removal — the doctor
+# refuses to touch any worktree until the operator handles the stashes first.
+# Doing the check at repo-level (rather than per-worktree) is load-bearing: a
+# porcelain-listed worktree whose directory is missing on disk would otherwise
+# read stash_count=0 and fall through to REMOVE, silently bypassing the policy.
 #
 # Args: doctor [--dry-run] [--apply] [--max-age-days N] [--target-branch ref]
 #              [--include-stale] [--prune-branches] [--repo PATH]
@@ -267,6 +271,16 @@ USAGE
     bridge_die "git worktree list 실행 실패: $repo_root"
   fi
 
+  # Repo-level stash check. refs/stash is shared across every worktree in the
+  # repo, so a single `git stash list` at the repo root captures the global
+  # count. ANY non-zero count blocks removal for every worktree — even ones
+  # whose on-disk directory has gone missing (the prior per-worktree check
+  # silently returned 0 in that case and let REMOVE fire, which violated the
+  # "any stash anywhere blocks all" policy).
+  local repo_stash_count=0
+  repo_stash_count="$(git -C "$repo_root" stash list 2>/dev/null | wc -l | tr -d ' ')"
+  [[ -z "$repo_stash_count" ]] && repo_stash_count=0
+
   local now_epoch
   now_epoch="$(date +%s)"
   local age_threshold_secs=$(( max_age_days * 86400 ))
@@ -313,7 +327,8 @@ USAGE
           _bridge_worktree_doctor_classify_one \
             "$repo_root" "$wt_path" "$wt_branch" \
             "$target_branch" "$now_epoch" "$age_threshold_secs" \
-            "$mode" "$include_stale" "$prune_branches"
+            "$mode" "$include_stale" "$prune_branches" \
+            "$repo_stash_count"
         fi
         wt_path=""
         wt_branch=""
@@ -326,7 +341,8 @@ USAGE
     _bridge_worktree_doctor_classify_one \
       "$repo_root" "$wt_path" "$wt_branch" \
       "$target_branch" "$now_epoch" "$age_threshold_secs" \
-      "$mode" "$include_stale" "$prune_branches"
+      "$mode" "$include_stale" "$prune_branches" \
+      "$repo_stash_count"
   fi
 
   echo ""
@@ -360,6 +376,7 @@ _bridge_worktree_doctor_classify_one() {
   local mode="$7"
   local include_stale="$8"
   local prune_branches="$9"
+  local repo_stash_count="${10:-0}"
 
   # Match only fixer-style worktree paths: */.claude/worktrees/agent-*
   # or */.claude/worktrees/ab-*. Operator's primary checkout and ad-hoc
@@ -379,14 +396,13 @@ _bridge_worktree_doctor_classify_one() {
     short_branch="$wt_branch"
   fi
 
-  # Stash safety check — count stash entries from inside the worktree.
-  # Best-effort: if `git -C <wt>` errors (worktree dir gone, locked refs),
-  # treat as 0 stash entries since there's nothing to lose.
-  local stash_count=0
-  if [[ -d "$wt_path" ]]; then
-    stash_count="$(git -C "$wt_path" stash list 2>/dev/null | wc -l | tr -d ' ')"
-    [[ -z "$stash_count" ]] && stash_count=0
-  fi
+  # Stash count is the GLOBAL repo-level count captured once by
+  # bridge_worktree_doctor before the porcelain loop. Using the global value
+  # (rather than a per-worktree `git -C <wt> stash list`) is what makes
+  # "any stash anywhere blocks all removal" actually hold: a porcelain-listed
+  # worktree whose on-disk directory is missing would previously read 0 here
+  # and fall through to REMOVE under --apply, silently bypassing the policy.
+  local stash_count="$repo_stash_count"
 
   # Last commit age on the branch (epoch seconds). Fall back to 0 if the
   # ref is gone — that itself is a signal the worktree is stale.

--- a/scripts/smoke/worktree-doctor.sh
+++ b/scripts/smoke/worktree-doctor.sh
@@ -196,6 +196,66 @@ case_apply_reaps_merged_only() {
     "git still tracks unmerged worktree"
 }
 
+# Build a repo where one fixer worktree has been MERGED into main (and would
+# normally classify REMOVE), but its on-disk directory has been removed — the
+# `git worktree list --porcelain` output still lists it because the metadata
+# under .git/worktrees/<name> is still present. A second, unrelated worktree
+# holds a stash entry. Because refs/stash is shared, the global stash count is
+# non-zero. The doctor must SKIP the orphan-dir worktree (NOT REMOVE it),
+# because "any stash anywhere blocks all removal" must hold even when the
+# per-worktree dir is gone (regression catch for codex r1 BLOCKING on PR #807:
+# the prior check `if [[ -d "$wt_path" ]]; then ... stash_count=...` left
+# stash_count=0 for missing dirs and let REMOVE fire under --apply).
+build_repo_orphan_dir_with_global_stash() {
+  local repo="$1"
+  rm -rf "$repo"
+  mkdir -p "$repo/.claude/worktrees"
+  git -C "$repo" init -q -b main
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com commit -q --allow-empty -m "init"
+
+  # Worktree #1: merged into main, then its on-disk dir is rm -rf'd. The
+  # porcelain entry survives because we never `git worktree remove` it.
+  git -C "$repo" branch fix/merged-orphan
+  git -C "$repo" worktree add -q "$repo/.claude/worktrees/agent-orphan" fix/merged-orphan
+  printf 'm\n' >"$repo/.claude/worktrees/agent-orphan/m.txt"
+  git -C "$repo/.claude/worktrees/agent-orphan" \
+    -c user.name=smoke -c user.email=smoke@example.com add m.txt
+  git -C "$repo/.claude/worktrees/agent-orphan" \
+    -c user.name=smoke -c user.email=smoke@example.com commit -q -m "merged orphan"
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com \
+    merge -q --no-ff fix/merged-orphan -m "merge orphan"
+  rm -rf "$repo/.claude/worktrees/agent-orphan"
+
+  # Worktree #2: holds the stash entry. Some other lane's WIP. We do NOT want
+  # the orphan worktree above to be reaped while this stash exists, because
+  # the stash ref is shared across all worktrees in the repo.
+  git -C "$repo" branch fix/stash-holder
+  git -C "$repo" worktree add -q "$repo/.claude/worktrees/agent-stash-holder" fix/stash-holder
+  printf 'baseline\n' >"$repo/.claude/worktrees/agent-stash-holder/keep.txt"
+  git -C "$repo/.claude/worktrees/agent-stash-holder" \
+    -c user.name=smoke -c user.email=smoke@example.com add keep.txt
+  git -C "$repo/.claude/worktrees/agent-stash-holder" \
+    -c user.name=smoke -c user.email=smoke@example.com commit -q -m "baseline"
+  printf 'unsaved WIP\n' >"$repo/.claude/worktrees/agent-stash-holder/wip.txt"
+  git -C "$repo/.claude/worktrees/agent-stash-holder" \
+    -c user.name=smoke -c user.email=smoke@example.com add wip.txt
+  git -C "$repo/.claude/worktrees/agent-stash-holder" \
+    -c user.name=smoke -c user.email=smoke@example.com \
+    stash push -q -m "orphan-smoke-stash" -- wip.txt
+
+  # Sanity — porcelain still lists the orphan, and the global stash count is 1.
+  local porcelain
+  porcelain="$(git -C "$repo" worktree list --porcelain)"
+  smoke_assert_contains "$porcelain" "agent-orphan" \
+    "porcelain still references orphan worktree after rm -rf"
+  if [[ -d "$repo/.claude/worktrees/agent-orphan" ]]; then
+    smoke_fail "orphan worktree dir should not exist after setup rm -rf"
+  fi
+  local repo_stash_count
+  repo_stash_count="$(git -C "$repo" stash list | wc -l | tr -d ' ')"
+  smoke_assert_eq "1" "$repo_stash_count" "global repo stash count is 1"
+}
+
 case_stash_skip_all() {
   smoke_setup_bridge_home "$SMOKE_NAME-stash"
   load_doctor_fns
@@ -242,8 +302,58 @@ case_stash_skip_all() {
     "stash worktree retained when stash present"
 }
 
+case_global_stash_refuse_blocks_orphan_worktrees() {
+  smoke_setup_bridge_home "$SMOKE_NAME-orphan"
+  load_doctor_fns
+  local repo="$SMOKE_TMP_ROOT/repo-orphan"
+  build_repo_orphan_dir_with_global_stash "$repo"
+
+  # Dry-run: the orphan-dir worktree (merged + missing on disk) must classify
+  # SKIP, not REMOVE, because the global stash count is non-zero. The
+  # stash-holder worktree must also classify SKIP.
+  local dry_out
+  dry_out="$(bridge_worktree_doctor --dry-run --repo "$repo" 2>&1)"
+
+  local orphan_row stash_row
+  orphan_row="$(printf '%s\n' "$dry_out" | grep agent-orphan || true)"
+  stash_row="$(printf '%s\n' "$dry_out" | grep agent-stash-holder || true)"
+  smoke_assert_contains "$orphan_row" "SKIP" \
+    "orphan worktree (dir missing) SKIP'd because global stash is non-zero"
+  smoke_assert_contains "$stash_row" "SKIP" \
+    "stash-holder worktree SKIP'd"
+
+  # And explicitly: the orphan row must NOT be REMOVE. The prior per-worktree
+  # check would have read stash_count=0 here (the dir is gone), let merged →
+  # REMOVE win, and reaped it under --apply.
+  smoke_assert_not_contains "$orphan_row" "REMOVE" \
+    "orphan worktree must NOT classify REMOVE while stash exists anywhere"
+
+  # The orphan row's STASH column should reflect the GLOBAL count (1), not 0.
+  # This is the load-bearing assertion of the fix: a row whose on-disk dir
+  # is gone still shows the repo-level stash count.
+  if [[ ! "$orphan_row" =~ \|[[:space:]]+[1-9] ]]; then
+    smoke_fail "orphan worktree row should show non-zero stash count (global): $orphan_row"
+  fi
+
+  # Apply: nothing should be removed; the orphan must NOT be reaped.
+  local apply_out
+  apply_out="$(bridge_worktree_doctor --apply --repo "$repo" 2>&1)"
+  smoke_assert_not_contains "$apply_out" "removed: " \
+    "apply does not remove anything when global stash is non-zero"
+  smoke_assert_not_contains "$apply_out" "removed: $repo/.claude/worktrees/agent-orphan" \
+    "apply must NOT reap orphan worktree while stash present"
+
+  # Porcelain should still list the orphan after --apply.
+  local porcelain_after
+  porcelain_after="$(git -C "$repo" worktree list --porcelain)"
+  smoke_assert_contains "$porcelain_after" "agent-orphan" \
+    "orphan worktree porcelain entry survived --apply (stash blocked removal)"
+}
+
 smoke_log "starting smoke: $SMOKE_NAME"
 smoke_run "dry-run classification (merged → REMOVE, unmerged → KEEP)" case_dry_run_classification
 smoke_run "apply removes only merged, leaves unmerged"               case_apply_reaps_merged_only
 smoke_run "stash anywhere → all worktrees SKIP (apply is a no-op)"   case_stash_skip_all
+smoke_run "global stash refuse blocks orphan (missing-dir) worktrees" \
+                                                                     case_global_stash_refuse_blocks_orphan_worktrees
 smoke_log "all worktree-doctor cases passed"

--- a/scripts/smoke/worktree-doctor.sh
+++ b/scripts/smoke/worktree-doctor.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SMOKE_NAME="worktree-doctor"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# This smoke exercises `bridge_worktree_doctor` as a function rather than
+# through the full `agent-bridge worktree doctor` CLI:
+#
+#   - The CLI dispatcher pulls in bridge-lib.sh which fires the v0.8.0
+#     isolation-v2 layout resolver. That requires either a BRIDGE_LAYOUT=v2
+#     marker on disk or env overrides — environment fragile for a CI smoke.
+#   - The doctor function is self-contained and only depends on `git`,
+#     `bridge_die`, `bridge_warn`, `printf`, `cat`, `date`, `wc`, `tr` —
+#     all available without the full bridge runtime.
+#
+# We slice `bridge_worktree_doctor` + `_bridge_worktree_doctor_classify_one`
+# out of lib/bridge-agents.sh via awk and source the snippet alone, with a
+# small `bridge_die` shim so we don't pull in the upstream module graph.
+#
+# Three cases (per the brief):
+#   1. merged + unmerged + no stash → REMOVE for merged, KEEP for unmerged
+#   2. apply only removes REMOVE rows, leaves KEEP rows
+#   3. stash entry anywhere in the repo → ALL worktrees SKIP'd (conservative
+#      safety: refs/stash is shared across worktrees so any stash anywhere
+#      is treated as fail-safe — refuse to remove)
+
+load_doctor_fns() {
+  # Minimal stubs the doctor function calls.
+  # shellcheck disable=SC2329  # called indirectly from the sourced snippet
+  bridge_die() { printf '[stub:bridge_die] %s\n' "$*" >&2; exit 1; }
+  # shellcheck disable=SC2329  # called indirectly from the sourced snippet
+  bridge_warn() { printf '[stub:bridge_warn] %s\n' "$*" >&2; }
+  export -f bridge_die bridge_warn
+
+  local agents_sh="$SMOKE_REPO_ROOT/lib/bridge-agents.sh"
+  smoke_assert_file_exists "$agents_sh" "bridge-agents.sh source"
+
+  local snippet="$SMOKE_TMP_ROOT/doctor.sh"
+  awk '
+    /^bridge_static_agents_for_project_engine\(\)/ { in_doctor=0 }
+    in_doctor { print }
+    /^bridge_worktree_doctor\(\)/ { in_doctor=1; print }
+  ' "$agents_sh" >"$snippet"
+  smoke_assert_file_exists "$snippet" "doctor snippet"
+
+  # shellcheck source=/dev/null
+  source "$snippet"
+  if ! declare -F bridge_worktree_doctor >/dev/null; then
+    smoke_fail "bridge_worktree_doctor not defined after sourcing snippet"
+  fi
+  if ! declare -F _bridge_worktree_doctor_classify_one >/dev/null; then
+    smoke_fail "_bridge_worktree_doctor_classify_one not defined after sourcing snippet"
+  fi
+}
+
+# Build a clean repo with merged + unmerged worktrees but no stash.
+build_repo_no_stash() {
+  local repo="$1"
+  rm -rf "$repo"
+  mkdir -p "$repo/.claude/worktrees"
+  git -C "$repo" init -q -b main
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com commit -q --allow-empty -m "init"
+
+  # 1) Merged branch → expect REMOVE.
+  git -C "$repo" branch fix/merged-track-a
+  git -C "$repo" worktree add -q "$repo/.claude/worktrees/agent-merged" fix/merged-track-a
+  printf 'merged change\n' >"$repo/.claude/worktrees/agent-merged/file.txt"
+  git -C "$repo/.claude/worktrees/agent-merged" \
+    -c user.name=smoke -c user.email=smoke@example.com add file.txt
+  git -C "$repo/.claude/worktrees/agent-merged" \
+    -c user.name=smoke -c user.email=smoke@example.com commit -q -m "merged work"
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com \
+    merge -q --no-ff fix/merged-track-a -m "merge fix/merged"
+
+  # 2) Unmerged branch, recent commit → expect KEEP.
+  git -C "$repo" branch fix/unmerged-track-b
+  git -C "$repo" worktree add -q "$repo/.claude/worktrees/agent-unmerged" fix/unmerged-track-b
+  printf 'unmerged WIP\n' >"$repo/.claude/worktrees/agent-unmerged/wip.txt"
+  git -C "$repo/.claude/worktrees/agent-unmerged" \
+    -c user.name=smoke -c user.email=smoke@example.com add wip.txt
+  git -C "$repo/.claude/worktrees/agent-unmerged" \
+    -c user.name=smoke -c user.email=smoke@example.com commit -q -m "wip"
+}
+
+# Build a repo with two worktrees (one merged) plus a third worktree that
+# holds a stash entry. Because refs/stash is shared across worktrees, the
+# stash will be visible from EVERY worktree's perspective — the doctor must
+# refuse to remove any of them. This is the documented conservative policy
+# in the brief: "Refuse to clean if stash present."
+build_repo_with_stash() {
+  local repo="$1"
+  rm -rf "$repo"
+  mkdir -p "$repo/.claude/worktrees"
+  git -C "$repo" init -q -b main
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com commit -q --allow-empty -m "init"
+
+  git -C "$repo" branch fix/merged
+  git -C "$repo" worktree add -q "$repo/.claude/worktrees/agent-merged" fix/merged
+  printf 'm\n' >"$repo/.claude/worktrees/agent-merged/m.txt"
+  git -C "$repo/.claude/worktrees/agent-merged" \
+    -c user.name=smoke -c user.email=smoke@example.com add m.txt
+  git -C "$repo/.claude/worktrees/agent-merged" \
+    -c user.name=smoke -c user.email=smoke@example.com commit -q -m "merged"
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com \
+    merge -q --no-ff fix/merged -m "merge"
+
+  # Stash-holding worktree. Commit a baseline file so the worktree is
+  # non-empty after we stash the WIP file; otherwise the post-stash
+  # assertion that the stash worktree dir survives would be fragile.
+  git -C "$repo" branch fix/stash
+  git -C "$repo" worktree add -q "$repo/.claude/worktrees/agent-stash" fix/stash
+  printf 'baseline\n' >"$repo/.claude/worktrees/agent-stash/keep.txt"
+  git -C "$repo/.claude/worktrees/agent-stash" \
+    -c user.name=smoke -c user.email=smoke@example.com add keep.txt
+  git -C "$repo/.claude/worktrees/agent-stash" \
+    -c user.name=smoke -c user.email=smoke@example.com commit -q -m "baseline"
+  # WIP that we will stash.
+  printf 'unsaved local diff\n' >"$repo/.claude/worktrees/agent-stash/wip.txt"
+  git -C "$repo/.claude/worktrees/agent-stash" \
+    -c user.name=smoke -c user.email=smoke@example.com add wip.txt
+  git -C "$repo/.claude/worktrees/agent-stash" \
+    -c user.name=smoke -c user.email=smoke@example.com \
+    stash push -q -m "smoke-stash" -- wip.txt
+
+  # Sanity — stash should now be visible from any worktree's perspective.
+  local stash_seen
+  stash_seen="$(git -C "$repo/.claude/worktrees/agent-stash" stash list | wc -l | tr -d ' ')"
+  smoke_assert_eq "1" "$stash_seen" "stash setup recorded one entry"
+}
+
+case_dry_run_classification() {
+  smoke_setup_bridge_home "$SMOKE_NAME-dry"
+  load_doctor_fns
+  local repo="$SMOKE_TMP_ROOT/repo-dry"
+  build_repo_no_stash "$repo"
+
+  local out
+  out="$(bridge_worktree_doctor --dry-run --repo "$repo" 2>&1)"
+
+  smoke_assert_contains "$out" "REMOVE" "dry-run reports REMOVE row"
+  smoke_assert_contains "$out" "KEEP" "dry-run reports KEEP row"
+  smoke_assert_contains "$out" "agent-merged" "dry-run lists merged worktree"
+  smoke_assert_contains "$out" "agent-unmerged" "dry-run lists unmerged worktree"
+
+  # The agent-merged row should be REMOVE, the agent-unmerged row KEEP.
+  local merged_row unmerged_row
+  merged_row="$(printf '%s\n' "$out" | grep agent-merged || true)"
+  unmerged_row="$(printf '%s\n' "$out" | grep agent-unmerged || true)"
+  smoke_assert_contains "$merged_row" "REMOVE" "agent-merged classified REMOVE"
+  smoke_assert_contains "$unmerged_row" "KEEP" "agent-unmerged classified KEEP"
+
+  # No filesystem mutation in dry-run.
+  smoke_assert_file_exists \
+    "$repo/.claude/worktrees/agent-merged/file.txt" \
+    "dry-run did not delete merged worktree"
+  smoke_assert_file_exists \
+    "$repo/.claude/worktrees/agent-unmerged/wip.txt" \
+    "dry-run did not delete unmerged worktree"
+}
+
+case_apply_reaps_merged_only() {
+  smoke_setup_bridge_home "$SMOKE_NAME-apply"
+  load_doctor_fns
+  local repo="$SMOKE_TMP_ROOT/repo-apply"
+  build_repo_no_stash "$repo"
+
+  local out
+  out="$(bridge_worktree_doctor --apply --repo "$repo" 2>&1)"
+
+  smoke_assert_contains "$out" "removed: $repo/.claude/worktrees/agent-merged" \
+    "apply removes merged worktree"
+  smoke_assert_not_contains "$out" "removed: $repo/.claude/worktrees/agent-unmerged" \
+    "apply does NOT remove unmerged worktree"
+
+  if [[ -d "$repo/.claude/worktrees/agent-merged" ]]; then
+    smoke_fail "merged worktree dir should be gone after --apply"
+  fi
+  smoke_assert_file_exists \
+    "$repo/.claude/worktrees/agent-unmerged/wip.txt" \
+    "unmerged worktree retained after --apply"
+
+  local porcelain
+  porcelain="$(git -C "$repo" worktree list --porcelain)"
+  smoke_assert_not_contains "$porcelain" "agent-merged" \
+    "git no longer tracks the removed worktree"
+  smoke_assert_contains "$porcelain" "agent-unmerged" \
+    "git still tracks unmerged worktree"
+}
+
+case_stash_skip_all() {
+  smoke_setup_bridge_home "$SMOKE_NAME-stash"
+  load_doctor_fns
+  local repo="$SMOKE_TMP_ROOT/repo-stash"
+  build_repo_with_stash "$repo"
+
+  # Dry run first: every worktree should classify SKIP because the shared
+  # refs/stash makes the stash entry visible everywhere. This is the safe
+  # behavior — the brief explicitly says "Refuse to clean if stash present."
+  local dry_out
+  dry_out="$(bridge_worktree_doctor --dry-run --repo "$repo" 2>&1)"
+  smoke_assert_contains "$dry_out" "SKIP" "dry-run reports at least one SKIP row"
+  # Match data rows (which start with the STATUS column) — not the summary
+  # block (which prefixes labels with `  REMOVE     : <count>`). A data row
+  # starts at column 1 with the STATUS keyword followed by ` | `.
+  local data_rows
+  data_rows="$(printf '%s\n' "$dry_out" | grep '^[A-Z]\+[[:space:]]*|' || true)"
+  smoke_assert_not_contains "$data_rows" "REMOVE" \
+    "no data row should be REMOVE while stash present"
+
+  local merged_row stash_row
+  merged_row="$(printf '%s\n' "$dry_out" | grep agent-merged || true)"
+  stash_row="$(printf '%s\n' "$dry_out" | grep agent-stash || true)"
+  smoke_assert_contains "$merged_row" "SKIP" "agent-merged SKIP'd due to shared stash"
+  smoke_assert_contains "$stash_row"  "SKIP" "agent-stash SKIP'd"
+  # Both rows should show non-zero stash count.
+  if [[ ! "$merged_row" =~ \|[[:space:]]+[1-9] ]]; then
+    smoke_fail "agent-merged row should show non-zero stash count: $merged_row"
+  fi
+  if [[ ! "$stash_row" =~ \|[[:space:]]+[1-9] ]]; then
+    smoke_fail "agent-stash row should show non-zero stash count: $stash_row"
+  fi
+
+  # Apply: nothing should be removed because every row is SKIP.
+  local apply_out
+  apply_out="$(bridge_worktree_doctor --apply --repo "$repo" 2>&1)"
+  smoke_assert_not_contains "$apply_out" "removed: " \
+    "apply does not remove anything when stash is present"
+  smoke_assert_file_exists \
+    "$repo/.claude/worktrees/agent-merged/m.txt" \
+    "merged worktree retained when stash present (safety)"
+  smoke_assert_file_exists \
+    "$repo/.claude/worktrees/agent-stash/keep.txt" \
+    "stash worktree retained when stash present"
+}
+
+smoke_log "starting smoke: $SMOKE_NAME"
+smoke_run "dry-run classification (merged → REMOVE, unmerged → KEEP)" case_dry_run_classification
+smoke_run "apply removes only merged, leaves unmerged"               case_apply_reaps_merged_only
+smoke_run "stash anywhere → all worktrees SKIP (apply is a no-op)"   case_stash_skip_all
+smoke_log "all worktree-doctor cases passed"


### PR DESCRIPTION
## Summary
- Add `agent-bridge worktree doctor [--dry-run|--apply]` to reap stale
  worktrees safely. Skip worktrees with stash entries (shared refs/stash
  safety).
- Default --dry-run; operator opts into --apply explicitly.
- Smoke covers 3 cases: merged-cleanup / unmerged-keep / stash-skip.

## Context
`feedback_worktree_stash_shared_git_dir.md`: parallel fixers share `.git/refs/stash`.
Operator's checkout has accumulated ~152 `agent-*` worktrees from merged PRs.
Cleanup needs an explicit stash-safety check to avoid losing in-flight WIP.

Classification matrix:
- REMOVE  : branch merged into target (default `main`), no stash entries
- STALE   : unmerged but last commit older than `--max-age-days` (14)
- SKIP    : stash entries present anywhere — refs/stash is shared across
            worktrees, so any in-flight stash blocks all removal (operator
            handles stashes first)
- KEEP    : unmerged + recent

## Validation
- `bash -n` + `shellcheck` clean on touched files
- `scripts/smoke/worktree-doctor.sh` runs 3 cases — all pass
- Dry-run against operator's actual checkout: scanned 156 fixer worktrees,
  all SKIP'd because of 5 in-flight stash entries (intended conservative
  behavior — the operator resolves stashes before reaping)

## Implementation notes
- `bridge_worktree_doctor` + `_bridge_worktree_doctor_classify_one` in
  `lib/bridge-agents.sh`
- Dispatcher hook in `agent-bridge` next to the existing `worktree list` verb
- Usage line and `OPERATIONS.md` worktree section updated
- The porcelain parse loop reads from a temp file rather than a
  `<<<"$porcelain"` here-string — macOS Homebrew Bash 5.3.9 has a
  `heredoc_write` deadlock that fires on multi-record porcelain. The temp
  file decouples producer/consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)