### PR TITLE
feat(init): host_profile prompt runs before channel bootstrap; dev short-circuits channel setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ version bumps via the `VERSION` file.
 
 ## [Unreleased]
 
+### Changed
+
+- **`bridge-init.sh` host_profile question moved before channel bootstrap; `dev` answer now also short-circuits channel setup and emits the heavy-feature advisory in one block** (refs Issue #713 follow-up). Previously `bridge_host_profile_run` fired after `Discord/Telegram/Teams/Mattermost` setup, so a developer-laptop install was forced to walk through (or `--skip-channel-setup` past) the channel branches before being told it could skip them. The question now runs immediately after admin-agent + `<admin>-dev` codex-pair materialization and immediately before the channel setup blocks; on `host_profile=dev` the call site flips `skip_channel_setup=1` and appends an init warning when the operator-passed `--channels` is non-empty (so the explicit channel csv is acknowledged rather than silently dropped). `bridge_host_profile_emit_dev_advisories` (new helper in `lib/bridge-host-profile.sh`) prints a unified "this is what dev profile skips" block: external-channel bootstrap, multi-tenant v2 isolation migration (stays opt-in via `agent-bridge migrate isolation-v2`), librarian / wiki-* maintenance crons (already disabled by the existing offer), and the operator's `--admin <name>` + `<name>-dev` static-pair-only floor (codex r2 round threaded `admin_agent` through the helper so the advisory renders the real pair names rather than the literal `patch`/`patch-dev` defaults; no extra static roles get auto-created — operators add them in `agent-roster.local.sh` when they upgrade to server). Server / CI / `--json` paths are unchanged: non-interactive still defaults to `server`, and `--reconfigure` still re-prompts. Idempotent against re-runs (the existing `[host-profile] already=…` sentinel still wins).
+
 ## [0.10.0] — 2026-05-13
 
 ### Highlight — credential file delivery + daemon hang fixes + worktree doctor

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -558,7 +558,8 @@ if [[ $dry_run -eq 0 ]]; then
     "$host_profile_cli" \
     "$host_profile_reconfigure" \
     "$host_profile_override" \
-    "$json_mode")" || host_profile_chosen=""
+    "$json_mode" \
+    "$admin_agent")" || host_profile_chosen=""
   if [[ "$host_profile_chosen" == "dev" ]] && [[ $skip_channel_setup -eq 0 ]]; then
     skip_channel_setup=1
     if [[ -n "$channels" ]]; then

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -534,6 +534,39 @@ if [[ $dry_run -eq 0 ]] && [[ "$(bridge_agent_engine "$admin_agent" 2>/dev/null 
   fi
 fi
 
+# Issue #713 follow-up: ask the operator whether this is a server (always-on
+# production host) or a developer PC, then let the dev branch short-circuit the
+# heavy server-only setup that follows. Must run AFTER the admin agent and its
+# codex pair exist (the dev advisory references them by id) but BEFORE channel
+# bootstrap so a `dev` answer skips Discord/Telegram/Teams/Mattermost setup
+# entirely instead of forcing the operator to confirm or `--skip-channel-setup`
+# every flag. Re-running init on an already-answered host is idempotent unless
+# `--reconfigure` is passed; non-interactive (`--json`, no TTY) defaults to
+# `server` to preserve today's behavior on hosted installs. Skipped on
+# `--dry-run` (mutation-free contract).
+if [[ $dry_run -eq 0 ]]; then
+  bridge_init_ensure_live_cli
+  # Prefer the live CLI deployed under $BRIDGE_HOME (canonical post-init
+  # surface — bridge_init_ensure_live_cli just materialized it). Fall back
+  # to the source checkout's CLI when init is invoked from $BRIDGE_HOME
+  # itself (the self-deploy short-circuit branch).
+  host_profile_cli="$BRIDGE_HOME/agent-bridge"
+  if [[ ! -x "$host_profile_cli" ]]; then
+    host_profile_cli="$SCRIPT_DIR/agent-bridge"
+  fi
+  host_profile_chosen="$(bridge_host_profile_run \
+    "$host_profile_cli" \
+    "$host_profile_reconfigure" \
+    "$host_profile_override" \
+    "$json_mode")" || host_profile_chosen=""
+  if [[ "$host_profile_chosen" == "dev" ]] && [[ $skip_channel_setup -eq 0 ]]; then
+    skip_channel_setup=1
+    if [[ -n "$channels" ]]; then
+      bridge_init_append_warning "host_profile=dev: requested channels (${channels}) — channel bootstrap skipped this init. Re-run \`agb setup <channel> ${admin_agent}\` later or pass \`--profile server\` to enable on this install."
+    fi
+  fi
+fi
+
 if [[ $skip_channel_setup -eq 0 ]] && [[ $dry_run -eq 0 ]]; then
   channel_setup_status="ok"
   if bridge_channel_csv_contains "$channels" "plugin:discord"; then
@@ -626,28 +659,10 @@ fi
 
 bridge_init_ensure_live_cli
 
-# Issue #713: ask the operator whether this is a server (always-on production
-# host) or a developer PC, and on `dev` offer to disable the production-style
-# librarian/wiki maintenance crons that drown a laptop in `[cron-followup]`
-# tasks every transient API blip. Skipped on --dry-run (mutation-free
-# contract). Non-interactive contexts (`--json`, no TTY) default to `server`
-# to preserve today's behavior on hosted installs. Re-running init on an
-# already-answered host is a no-op unless `--reconfigure` is passed.
-if [[ $dry_run -eq 0 ]]; then
-  # Prefer the live CLI deployed under $BRIDGE_HOME (canonical post-init
-  # surface — bridge_init_ensure_live_cli just materialized it). Fall back
-  # to the source checkout's CLI when init is invoked from $BRIDGE_HOME
-  # itself (the self-deploy short-circuit branch).
-  host_profile_cli="$BRIDGE_HOME/agent-bridge"
-  if [[ ! -x "$host_profile_cli" ]]; then
-    host_profile_cli="$SCRIPT_DIR/agent-bridge"
-  fi
-  host_profile_chosen="$(bridge_host_profile_run \
-    "$host_profile_cli" \
-    "$host_profile_reconfigure" \
-    "$host_profile_override" \
-    "$json_mode")" || host_profile_chosen=""
-fi
+# Note: host_profile_run (Issue #713) was called earlier — before channel
+# bootstrap — so a `dev` answer can short-circuit the Discord/Telegram/Teams/
+# Mattermost setup steps. host_profile_chosen is already populated by that
+# call (or empty on --dry-run).
 
 warnings_json="$(bridge_init_warnings_json)"
 

--- a/lib/bridge-host-profile.sh
+++ b/lib/bridge-host-profile.sh
@@ -315,7 +315,30 @@ bridge_host_profile_run() {
 
   if [[ "$profile" == "dev" ]]; then
     bridge_host_profile_offer_dev_cron_disable "$agent_bridge_cli" "$interactive" >/dev/null || true
+    bridge_host_profile_emit_dev_advisories >&2 || true
   fi
 
   printf '%s\n' "$profile"
+}
+
+# Emit one-shot advisory text for the operator on profile=dev. Currently
+# covers: (a) external-channel setup will be skipped during this init run,
+# (b) the v2 multi-tenant isolation layout is not required for dev hosts
+# and stays opt-in via BRIDGE_LAYOUT=v2 / `agent-bridge migrate isolation-v2`.
+# No mutations — channel-skip is enforced at the bridge-init.sh call site,
+# isolation is operator-opt-in. The block is informational so the dev
+# operator sees in one place why the rest of the init flow looks lighter.
+bridge_host_profile_emit_dev_advisories() {
+  printf '\n'
+  printf '[host-profile=dev] 다음 운영용 기능은 이번 init 에서 건너뛰거나 비활성 상태로 둡니다:\n'
+  printf '  - 외부 채널 (Discord / Telegram / Teams / Mattermost) 부트스트랩: skip\n'
+  printf '    필요해지면 `agb setup discord <admin>` 등으로 나중에 켤 수 있습니다.\n'
+  printf '  - 멀티테넌트 v2 isolation 레이아웃: legacy 유지 (마이그레이션 비강제)\n'
+  printf '    Linux 운영 호스트에서 다중 사용자 분리가 필요해지면\n'
+  printf '    `agent-bridge migrate isolation-v2 --apply` 로 전환할 수 있습니다.\n'
+  printf '  - librarian / wiki-* 정기 크론: 위 단계에서 disable 처리됨\n'
+  printf '\n'
+  printf '정적 에이전트는 admin(`patch` 기본) + admin-dev(`patch-dev` codex pair) 2개로\n'
+  printf '시작합니다. 추가 정적 역할은 운영 모드에서만 필요한 경우가 일반적입니다.\n'
+  printf '\n'
 }

--- a/lib/bridge-host-profile.sh
+++ b/lib/bridge-host-profile.sh
@@ -225,6 +225,10 @@ bridge_host_profile_offer_dev_cron_disable() {
 #   $2 = reconfigure (1=force re-prompt even if file exists)
 #   $3 = profile_override ("server"|"dev"|"" = ask)
 #   $4 = json_mode (1=non-interactive contract: default server, no prompt)
+#   $5 = admin agent id (used by the dev advisory to render the real static
+#        pair names; falls back to "admin" inside the advisory helper when
+#        empty so older callers without this arg still get a sensible
+#        message)
 # Echoes the chosen/loaded profile; non-zero exit only on fatal write
 # failures.
 bridge_host_profile_run() {
@@ -232,6 +236,7 @@ bridge_host_profile_run() {
   local reconfigure="${2:-0}"
   local profile_override="${3:-}"
   local json_mode="${4:-0}"
+  local admin_agent="${5:-}"
 
   # Idempotent fast-path: existing profile + no --reconfigure and no
   # explicit override.
@@ -315,7 +320,7 @@ bridge_host_profile_run() {
 
   if [[ "$profile" == "dev" ]]; then
     bridge_host_profile_offer_dev_cron_disable "$agent_bridge_cli" "$interactive" >/dev/null || true
-    bridge_host_profile_emit_dev_advisories >&2 || true
+    bridge_host_profile_emit_dev_advisories "$admin_agent" >&2 || true
   fi
 
   printf '%s\n' "$profile"
@@ -328,17 +333,24 @@ bridge_host_profile_run() {
 # No mutations — channel-skip is enforced at the bridge-init.sh call site,
 # isolation is operator-opt-in. The block is informational so the dev
 # operator sees in one place why the rest of the init flow looks lighter.
+#
+# Args:
+#   $1 = admin agent id (e.g. "patch"). Used to render the static-pair line
+#        accurately when --admin is non-default. Falls back to "admin" when
+#        empty so legacy callers still get a sensible message.
 bridge_host_profile_emit_dev_advisories() {
+  local admin_agent="${1:-admin}"
+  local admin_pair="${admin_agent}-dev"
   printf '\n'
   printf '[host-profile=dev] 다음 운영용 기능은 이번 init 에서 건너뛰거나 비활성 상태로 둡니다:\n'
   printf '  - 외부 채널 (Discord / Telegram / Teams / Mattermost) 부트스트랩: skip\n'
-  printf '    필요해지면 `agb setup discord <admin>` 등으로 나중에 켤 수 있습니다.\n'
+  printf '    필요해지면 `agb setup discord %s` 등으로 나중에 켤 수 있습니다.\n' "$admin_agent"
   printf '  - 멀티테넌트 v2 isolation 레이아웃: legacy 유지 (마이그레이션 비강제)\n'
   printf '    Linux 운영 호스트에서 다중 사용자 분리가 필요해지면\n'
   printf '    `agent-bridge migrate isolation-v2 --apply` 로 전환할 수 있습니다.\n'
   printf '  - librarian / wiki-* 정기 크론: 위 단계에서 disable 처리됨\n'
   printf '\n'
-  printf '정적 에이전트는 admin(`patch` 기본) + admin-dev(`patch-dev` codex pair) 2개로\n'
+  printf '정적 에이전트는 admin(`%s`) + admin-dev(`%s` codex pair) 2개로\n' "$admin_agent" "$admin_pair"
   printf '시작합니다. 추가 정적 역할은 운영 모드에서만 필요한 경우가 일반적입니다.\n'
   printf '\n'
 }


### PR DESCRIPTION
## Summary

- Moves `bridge_host_profile_run` (Issue #713) from after the channel-setup loop to immediately before it, and on `host_profile=dev` flips `skip_channel_setup=1` so dev installs don't walk Discord/Telegram/Teams/Mattermost branches at all.
- Adds `bridge_host_profile_emit_dev_advisories` — one block listing what dev profile skips: external channels (this init), multi-tenant v2 isolation (stays opt-in via `agent-bridge migrate isolation-v2`), librarian/wiki cron families (already disabled by the existing offer), and the `<admin>` + `<admin>-dev` codex-pair static floor.

## What this PR does NOT add

- A new `BRIDGE_PROFILE=dev` master env toggle — the existing host-profile mechanism is reused.
- Auto-rewrite of the v2 isolation layout — stays opt-in via `agent-bridge migrate isolation-v2 --apply`.
- A "filter the roster down to patch + patch-dev" enforcement — unnecessary because the shipped `agent-roster.sh` is empty by design (only the operator's `agent-roster.local.sh` adds static roles, and `bridge_ensure_admin_codex_pair` already gives every fresh install the `<admin>` + `<admin>-dev` pair).

## Operator-facing behavior

| install | flow |
|---|---|
| `bash bridge-init.sh --admin patch --engine claude` (interactive, answer `b` → dev) | admin agent + codex pair created → cron-disable offer (default-yes) → dev advisory block → channel setup **skipped** → preflight + handoff |
| `bash bridge-init.sh --admin patch --profile server` (or interactive `a`) | unchanged — channel setup runs as before |
| `bash bridge-init.sh --admin patch --profile dev --channels plugin:telegram@…` | `host_profile=dev` overrides channel runtime bootstrap; init warning explains the csv is acknowledged but skipped this init; operator can `agb setup telegram patch` later |
| CI / `--json` / no TTY | unchanged — non-interactive defaults to `server` |
| `--reconfigure` re-flip to dev on a previously-server install | new init steps respect `dev`; existing configured channels are not torn down (out of scope) |

## Verification

- `bash -n bridge-init.sh lib/bridge-host-profile.sh` clean
- `shellcheck bridge-init.sh lib/bridge-host-profile.sh` clean
- Isolated source + call `bridge_host_profile_emit_dev_advisories` → exits 0, prints expected 11-line block
- `declare -f bridge_host_profile_run | grep emit_dev_advisories` confirms wired into dev branch
- Smoke matrix re-run in a working TTY against fresh `BRIDGE_HOME` requested before merge (`./scripts/smoke-test.sh` hangs on the orchestrator's host on a `cat` heredoc — reproducible on unchanged `main`, not introduced here)

## Test plan

- [ ] On a fresh `BRIDGE_HOME` (`mktemp -d /tmp/agb.XXXXXX`), run `bash bridge-init.sh --admin patch --engine claude` interactively and answer `b` → confirm channel setup never runs and the advisory block prints once
- [ ] Same with `--profile dev` non-interactively — confirm idempotent (`[host-profile] already=dev` sentinel on second run)
- [ ] On a fresh `BRIDGE_HOME`, run `--profile server` and confirm channel setup still runs unchanged
- [ ] Run `./scripts/smoke-test.sh` in fresh `BRIDGE_HOME` from a working tty and confirm green

🤖 Generated with [Claude Code](https://claude.com/claude-code)