### PR TITLE
fix(v0.11.0): channel-health probe degrades to controller-blind on isolated dotenv (#832)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3186,6 +3186,10 @@ bridge_report_channel_health_miss() {
   [[ "$admin_agent" != "$agent" ]] || return 0
 
   status="$(bridge_agent_channel_status "$agent")"
+  # Issue #832: `unknown` (controller-blind) is an indeterminate readiness,
+  # not a confirmed mismatch. Treat it like `ok`/`-` for audit purposes —
+  # do NOT fire a channel_health_miss row, and clear any stale state so we
+  # do not leak a "still firing" signal once the operator fixes ACLs.
   if [[ "$status" != "miss" ]]; then
     bridge_clear_channel_health_state "$agent"
     return 0

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -331,6 +331,11 @@ bridge_source_module "bridge-marker-bootstrap.sh"
 # child env defaults. Read-only — never writes the marker.
 bridge_source_module "bridge-layout-resolver.sh"
 bridge_source_module "bridge-agents.sh"
+# Issue #832: small probes for running a snippet as the isolated UID of a
+# linux-user-isolated agent. Sourced after bridge-agents.sh because the
+# helpers depend on bridge_agent_os_user /
+# bridge_agent_linux_user_isolation_effective.
+bridge_source_module "bridge-isolation-helpers.sh"
 bridge_source_module "bridge-guard.sh"
 bridge_source_module "bridge-tmux.sh"
 bridge_source_module "bridge-skills.sh"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4315,10 +4315,10 @@ shift
 keys=("$@")
 [[ -r "$file" ]] || exit 2
 if [[ ${#keys[@]} -eq 0 ]]; then
-  grep -Eq "^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*[^[:space:]]" "$file" && exit 0 || exit 1
+  grep -Eq "^[[:space:]]*(export[[:space:]]+)?[A-Za-z_][A-Za-z0-9_]*=[^[:space:]#]" "$file" && exit 0 || exit 1
 fi
 for k in "${keys[@]}"; do
-  grep -Eq "^[[:space:]]*${k}[[:space:]]*=[[:space:]]*[^[:space:]]" "$file" && exit 0
+  grep -Eq "^[[:space:]]*(export[[:space:]]+)?${k}=[^[:space:]#].*" "$file" && exit 0
 done
 exit 1
 '

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4297,8 +4297,8 @@ bridge_channel_env_file_readiness() {
   # Without this branch the daemon would emit a false channel_health_miss
   # for a healthy isolated agent.
   if declare -F bridge_isolation_can_sudo_to_agent >/dev/null 2>&1; then
-    bridge_isolation_can_sudo_to_agent "$agent" 2>/dev/null
-    sudo_rc=$?
+    sudo_rc=0
+    bridge_isolation_can_sudo_to_agent "$agent" 2>/dev/null || sudo_rc=$?
     case "$sudo_rc" in
       0)
         # Agent isolated AND we can sudo to its UID — probe via that UID.
@@ -4322,8 +4322,8 @@ for k in "${keys[@]}"; do
 done
 exit 1
 '
-        bridge_isolation_run_as_agent_user_via_bash "$agent" "$probe_script" "$file" "$@" >/dev/null
-        probe_rc=$?
+        probe_rc=0
+        bridge_isolation_run_as_agent_user_via_bash "$agent" "$probe_script" "$file" "$@" >/dev/null 2>&1 || probe_rc=$?
         # The helper preserves script's exit code shifted into the 3+ band
         # when nonzero (rc=0 stays 0; script-rc 1 -> 3; script-rc 2 -> 4).
         # See lib/bridge-isolation-helpers.sh docstring.

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4249,16 +4249,26 @@ bridge_env_file_has_any_nonempty_key() {
 #
 # Usage:
 #   case "$(bridge_channel_env_file_readiness <agent> <item> <file> <key>...)" in
-#     present)    ... ;;
-#     missing)    ... ;;
-#     unreadable) ... ;;   # caller may then call bridge_channel_env_file_acl_diagnostic
+#     present)          ... ;;
+#     missing)          ... ;;
+#     unreadable)       ... ;;   # caller may then call bridge_channel_env_file_acl_diagnostic
+#     controller-blind) ... ;;   # issue #832: isolated dotenv, controller cannot sudo to verify
 #   esac
+#
+# Issue #832: when the controller cannot `[[ -r ]]` the file AND the agent
+# is linux-user isolated AND passwordless sudo to the agent's os_user is
+# unavailable, returns `"controller-blind"` instead of `"unreadable"`.
+# That distinct state lets the caller emit a controller-blind reason and
+# the status mapping degrade to `"unknown"` (fail-open) rather than
+# firing a false channel_health_miss audit row.
 bridge_channel_env_file_readiness() {
   local agent="$1"
   local item="$2"
   local file="$3"
   shift 3 || true
   local rc=0
+  local sudo_rc=0
+  local probe_rc=0
 
   if [[ ! -e "$file" ]]; then
     printf 'missing'
@@ -4278,6 +4288,81 @@ bridge_channel_env_file_readiness() {
     # File readable; helper just didn't find a non-empty matching key.
     printf 'missing'
     return 0
+  fi
+
+  # Issue #832: controller cannot read the file. Before declaring unreadable,
+  # see if we can probe via the agent's isolated UID (linux-user mode only).
+  # The agent's own UID can read its own dotenv when ACL drift left the
+  # controller unable to, and operators have correctly configured tokens.
+  # Without this branch the daemon would emit a false channel_health_miss
+  # for a healthy isolated agent.
+  if declare -F bridge_isolation_can_sudo_to_agent >/dev/null 2>&1; then
+    bridge_isolation_can_sudo_to_agent "$agent" 2>/dev/null
+    sudo_rc=$?
+    case "$sudo_rc" in
+      0)
+        # Agent isolated AND we can sudo to its UID — probe via that UID.
+        # Self-contained inline script: tests readability and key presence
+        # without sourcing bridge-lib.sh inside the isolated UID.
+        # Exit codes from the inline script:
+        #   0 — readable and at least one nonempty matching KEY=value line
+        #   1 — readable but no matching nonempty key
+        #   2 — not readable even to the isolated UID
+        local probe_script
+        probe_script='
+file="$1"
+shift
+keys=("$@")
+[[ -r "$file" ]] || exit 2
+if [[ ${#keys[@]} -eq 0 ]]; then
+  grep -Eq "^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=[[:space:]]*[^[:space:]]" "$file" && exit 0 || exit 1
+fi
+for k in "${keys[@]}"; do
+  grep -Eq "^[[:space:]]*${k}[[:space:]]*=[[:space:]]*[^[:space:]]" "$file" && exit 0
+done
+exit 1
+'
+        bridge_isolation_run_as_agent_user_via_bash "$agent" "$probe_script" "$file" "$@" >/dev/null
+        probe_rc=$?
+        # The helper preserves script's exit code shifted into the 3+ band
+        # when nonzero (rc=0 stays 0; script-rc 1 -> 3; script-rc 2 -> 4).
+        # See lib/bridge-isolation-helpers.sh docstring.
+        case "$probe_rc" in
+          0)
+            : "${item}"
+            printf 'present'
+            return 0
+            ;;
+          3)
+            : "${item}"
+            printf 'missing'
+            return 0
+            ;;
+          4)
+            : "${item}"
+            printf 'unreadable'
+            return 0
+            ;;
+          *)
+            # Probe itself failed unexpectedly (e.g. sudoers raced) —
+            # fall through to the standard unreadable path.
+            ;;
+        esac
+        ;;
+      2)
+        # Agent IS isolated but passwordless sudo is unavailable. Controller
+        # cannot determine readiness either way — degrade to controller-blind
+        # rather than firing a false miss. Caller maps this to status=unknown.
+        : "${item}"
+        printf 'controller-blind'
+        return 0
+        ;;
+      *)
+        # rc=1 — agent not in linux-user isolation. Fall through to the
+        # standard unreadable path (true ACL drift on a controller-managed
+        # file).
+        ;;
+    esac
   fi
 
   # v2: no ACL repair retry. The per-agent group + setgid contract
@@ -4495,6 +4580,12 @@ bridge_channel_credentials_status_for_item() {
   # required key probe reports unreadable, the overall status is unreadable
   # (operators need to know the controller cannot read the file at all,
   # which is actionable via ACL repair, vs. truly missing keys).
+  #
+  # Issue #832: also propagate "controller-blind" — emitted by the readiness
+  # function when the controller cannot read the file AND the agent is
+  # linux-user isolated AND we cannot sudo to its UID to verify. unreadable
+  # takes precedence (a real ACL drift somewhere is more actionable than
+  # any single controller-blind path).
   case "$item" in
     plugin:discord|plugin:discord@*)
       r1="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" DISCORD_BOT_TOKEN BOT_TOKEN TOKEN)"
@@ -4509,6 +4600,8 @@ bridge_channel_credentials_status_for_item() {
       r2="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" TEAMS_APP_PASSWORD MicrosoftAppPassword)"
       if [[ "$r1" == "unreadable" || "$r2" == "unreadable" ]]; then
         printf '%s' "unreadable"
+      elif [[ "$r1" == "controller-blind" || "$r2" == "controller-blind" ]]; then
+        printf '%s' "controller-blind"
       elif [[ "$r1" == "present" && "$r2" == "present" ]]; then
         printf '%s' "present"
       else
@@ -4521,6 +4614,8 @@ bridge_channel_credentials_status_for_item() {
       r3="$(bridge_channel_env_file_readiness "$agent" "$item" "$dir/.env" MS365_TENANT_ID)"
       if [[ "$r1" == "unreadable" || "$r2" == "unreadable" || "$r3" == "unreadable" ]]; then
         printf '%s' "unreadable"
+      elif [[ "$r1" == "controller-blind" || "$r2" == "controller-blind" || "$r3" == "controller-blind" ]]; then
+        printf '%s' "controller-blind"
       elif [[ "$r1" == "present" && "$r2" == "present" && "$r3" == "present" ]]; then
         printf '%s' "present"
       else
@@ -4695,7 +4790,13 @@ bridge_agent_channel_diagnostics_tsv() {
     launch_allowlisted="$(bridge_agent_channel_launch_allowlisted_for_item "$agent" "$item")"
     access_status="$(bridge_channel_access_status_for_item "$agent" "$item")"
     credentials_status="$(bridge_channel_credentials_status_for_item "$agent" "$item")"
-    if bridge_agent_channel_runtime_ready_for_item "$agent" "$item"; then
+    # Issue #832: when credentials probe is controller-blind the runtime
+    # readiness is indeterminate, not yes/no. Render a distinct
+    # `indeterminate` so `agent show` can tell the operator
+    # "we cannot verify" apart from "we verified and it's missing".
+    if [[ "$credentials_status" == "controller-blind" ]]; then
+      runtime_ready="indeterminate"
+    elif bridge_agent_channel_runtime_ready_for_item "$agent" "$item"; then
       runtime_ready="yes"
     else
       runtime_ready="no"
@@ -4932,12 +5033,51 @@ bridge_agent_ready_channels_csv() {
   for item in "${items[@]}"; do
     item="$(bridge_trim_whitespace "$item")"
     [[ -n "$item" ]] || continue
+    # Issue #832: controller-blind channels are indeterminate, not ready.
+    # Skip them here — they surface via
+    # bridge_agent_controller_blind_channels_csv.
+    if [[ "$(bridge_channel_credentials_status_for_item "$agent" "$item")" == "controller-blind" ]]; then
+      continue
+    fi
     if bridge_agent_channel_runtime_ready_for_item "$agent" "$item"; then
       ready="$(bridge_append_csv_unique "$ready" "$item")"
     fi
   done
 
   printf '%s' "$ready"
+}
+
+# Issue #832: enumerate channels whose credentials probe returned
+# `controller-blind` — the controller cannot determine readiness because
+# the dotenv is unreadable AND we cannot sudo to the agent's UID to verify.
+# These channels MUST NOT appear in missing_channels_csv (no false miss)
+# and MUST NOT appear in ready_channels_csv (we have not verified them).
+# `bridge_agent_launch_channels_csv` re-includes them under
+# `BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS=1` so dev-mode launches do not
+# drop the channel just because the controller could not introspect it.
+bridge_agent_controller_blind_channels_csv() {
+  local agent="$1"
+  local required=""
+  local item=""
+  local blind=""
+  local -a items=()
+
+  required="$(bridge_agent_channels_csv "$agent")"
+  [[ -n "$required" ]] || {
+    printf '%s' ""
+    return 0
+  }
+
+  IFS=',' read -r -a items <<<"$required"
+  for item in "${items[@]}"; do
+    item="$(bridge_trim_whitespace "$item")"
+    [[ -n "$item" ]] || continue
+    if [[ "$(bridge_channel_credentials_status_for_item "$agent" "$item")" == "controller-blind" ]]; then
+      blind="$(bridge_append_csv_unique "$blind" "$item")"
+    fi
+  done
+
+  printf '%s' "$blind"
 }
 
 bridge_agent_missing_channels_csv() {
@@ -4957,6 +5097,12 @@ bridge_agent_missing_channels_csv() {
   for item in "${items[@]}"; do
     item="$(bridge_trim_whitespace "$item")"
     [[ -n "$item" ]] || continue
+    # Issue #832: controller-blind channels are indeterminate, not missing.
+    # Excluding them here is what makes the suppress-missing-channels
+    # launch path keep them in the launch flags instead of dropping them.
+    if [[ "$(bridge_channel_credentials_status_for_item "$agent" "$item")" == "controller-blind" ]]; then
+      continue
+    fi
     if ! bridge_agent_channel_runtime_ready_for_item "$agent" "$item"; then
       missing="$(bridge_append_csv_unique "$missing" "$item")"
     fi
@@ -4995,7 +5141,13 @@ bridge_agent_launch_channels_csv() {
   local channels=""
 
   if [[ "${BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS:-0}" == "1" ]]; then
-    channels="$(bridge_filter_approved_channels_csv "$(bridge_agent_ready_channels_csv "$agent")")"
+    # Issue #832: under suppress-missing-channels, fold controller-blind
+    # channels back in alongside ready ones. We cannot verify their
+    # credentials from the controller, but we also cannot prove they are
+    # broken — dropping them would silently strip a working channel from
+    # an isolated agent's launch flags.
+    channels="$(bridge_merge_channels_csv "$(bridge_agent_ready_channels_csv "$agent")" "$(bridge_agent_controller_blind_channels_csv "$agent")")"
+    channels="$(bridge_filter_approved_channels_csv "$channels")"
   else
     channels="$(bridge_filter_approved_channels_csv "$(bridge_agent_channels_csv "$agent")")"
   fi
@@ -5004,9 +5156,14 @@ bridge_agent_launch_channels_csv() {
 
 bridge_agent_effective_dev_channels_csv() {
   local agent="$1"
+  local channels=""
 
   if [[ "${BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS:-0}" == "1" ]]; then
-    bridge_filter_development_channels_csv "$(bridge_agent_ready_channels_csv "$agent")"
+    # Issue #832: same controller-blind merge as launch_channels_csv —
+    # keep the dev channel set inclusive of indeterminate channels under
+    # suppression so the merged plugin set still loads.
+    channels="$(bridge_merge_channels_csv "$(bridge_agent_ready_channels_csv "$agent")" "$(bridge_agent_controller_blind_channels_csv "$agent")")"
+    bridge_filter_development_channels_csv "$channels"
     return 0
   fi
 
@@ -5369,6 +5526,11 @@ bridge_agent_runtime_channel_status_reason() {
         "$discord_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$discord_dir/.env" "$repair_attempts")"
       return 0
     fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:discord:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$discord_dir" "$(bridge_channel_env_file_acl_diagnostic "$discord_dir/.env" "$repair_attempts")"
+      return 0
+    fi
     if [[ "$readiness" != "present" ]]; then
       printf 'missing Discord bot token under %s (.env with DISCORD_BOT_TOKEN required)' "$discord_dir"
       return 0
@@ -5385,6 +5547,11 @@ bridge_agent_runtime_channel_status_reason() {
     if [[ "$readiness" == "unreadable" ]]; then
       printf 'unreadable: Telegram .env under %s (ACL repair failed %s times; %s)' \
         "$telegram_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$telegram_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:telegram:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$telegram_dir" "$(bridge_channel_env_file_acl_diagnostic "$telegram_dir/.env" "$repair_attempts")"
       return 0
     fi
     if [[ "$readiness" != "present" ]]; then
@@ -5405,6 +5572,11 @@ bridge_agent_runtime_channel_status_reason() {
         "$teams_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$teams_dir/.env" "$repair_attempts")"
       return 0
     fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:teams:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$teams_dir" "$(bridge_channel_env_file_acl_diagnostic "$teams_dir/.env" "$repair_attempts")"
+      return 0
+    fi
     if [[ "$readiness" != "present" ]]; then
       printf 'missing Teams app id under %s (.env with TEAMS_APP_ID required)' "$teams_dir"
       return 0
@@ -5413,6 +5585,11 @@ bridge_agent_runtime_channel_status_reason() {
     if [[ "$readiness" == "unreadable" ]]; then
       printf 'unreadable: Teams .env under %s (ACL repair failed %s times; %s)' \
         "$teams_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$teams_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:teams:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$teams_dir" "$(bridge_channel_env_file_acl_diagnostic "$teams_dir/.env" "$repair_attempts")"
       return 0
     fi
     if [[ "$readiness" != "present" ]]; then
@@ -5433,6 +5610,11 @@ bridge_agent_runtime_channel_status_reason() {
         "$ms365_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
       return 0
     fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:ms365:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$ms365_dir" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
+      return 0
+    fi
     if [[ "$readiness" != "present" ]]; then
       printf 'missing MS365 client id under %s (.env with MS365_CLIENT_ID required)' "$ms365_dir"
       return 0
@@ -5443,6 +5625,11 @@ bridge_agent_runtime_channel_status_reason() {
         "$ms365_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
       return 0
     fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:ms365:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$ms365_dir" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
+      return 0
+    fi
     if [[ "$readiness" != "present" ]]; then
       printf 'missing MS365 client secret under %s (.env with MS365_CLIENT_SECRET required)' "$ms365_dir"
       return 0
@@ -5451,6 +5638,11 @@ bridge_agent_runtime_channel_status_reason() {
     if [[ "$readiness" == "unreadable" ]]; then
       printf 'unreadable: MS365 .env under %s (ACL repair failed %s times; %s)' \
         "$ms365_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:ms365:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$ms365_dir" "$(bridge_channel_env_file_acl_diagnostic "$ms365_dir/.env" "$repair_attempts")"
       return 0
     fi
     if [[ "$readiness" != "present" ]]; then
@@ -5470,6 +5662,11 @@ bridge_agent_runtime_channel_status_reason() {
     if [[ "$readiness" == "unreadable" ]]; then
       printf 'unreadable: Mattermost .env under %s (ACL repair failed %s times; %s)' \
         "$mattermost_dir" "$repair_attempts" "$(bridge_channel_env_file_acl_diagnostic "$mattermost_dir/.env" "$repair_attempts")"
+      return 0
+    fi
+    if [[ "$readiness" == "controller-blind" ]]; then
+      printf 'controller-blind:plugin:mattermost:%s/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) %s' \
+        "$mattermost_dir" "$(bridge_channel_env_file_acl_diagnostic "$mattermost_dir/.env" "$repair_attempts")"
       return 0
     fi
     if [[ "$readiness" != "present" ]]; then
@@ -5587,6 +5784,16 @@ bridge_agent_channel_status() {
 
   reason="$(bridge_agent_channel_status_reason "$agent")"
   if [[ -n "$reason" ]]; then
+    # Issue #832: a controller-blind dotenv is an indeterminate state, not
+    # a confirmed mismatch. Degrade to `unknown` so the daemon does not
+    # fire a false channel_health_miss audit row and so operators can
+    # tell "we cannot verify" apart from "we verified and it's broken".
+    case "$reason" in
+      controller-blind:*)
+        printf '%s' "unknown"
+        return 0
+        ;;
+    esac
     printf '%s' "miss"
     return 0
   fi

--- a/lib/bridge-isolation-helpers.sh
+++ b/lib/bridge-isolation-helpers.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# bridge-isolation-helpers.sh — small probes for running a snippet as the
+# isolated UID of a linux-user-isolated agent via the existing sudoers
+# allowlist (`bash` + `tmux` only — see bridge-migration.sh:773).
+#
+# Issue #832: channel-health probes need a way to read a dotenv file that the
+# controller cannot `[[ -r ]]` but the agent's isolated UID can. Without this,
+# the daemon collapses a controller-blind dotenv into a "miss" and fires a
+# false channel_health_miss audit row.
+#
+# These helpers depend only on already-loaded helpers from `bridge-agents.sh`
+# (sourced earlier in bridge-lib.sh): `bridge_agent_os_user`,
+# `bridge_agent_linux_user_isolation_effective`, and `BRIDGE_BASH_BIN`. They
+# do NOT source bridge-lib.sh inside the isolated UID — the inline script
+# passed to `sudo -n -u <user> bash -c` is self-contained.
+
+# bridge_isolation_can_sudo_to_agent <agent>
+#
+# Returns:
+#   0 — agent is in linux-user isolation AND passwordless sudo to its os_user
+#       succeeds.
+#   1 — agent is not in linux-user isolation (caller should run directly as
+#       the controller).
+#   2 — agent IS isolated but `sudo -n -u <os_user> bash -c true` fails
+#       (no passwordless sudoers rule).
+#
+# Non-fatal: never exits the shell, suppresses stderr unless
+# BRIDGE_ISOLATION_HELPERS_DEBUG=1 is set.
+bridge_isolation_can_sudo_to_agent() {
+  local agent="$1"
+  local os_user=""
+  local bash_bin="${BRIDGE_BASH_BIN:-bash}"
+  local debug="${BRIDGE_ISOLATION_HELPERS_DEBUG:-0}"
+
+  [[ -n "$agent" ]] || return 1
+
+  # Not isolated — caller should run directly.
+  if ! bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    return 1
+  fi
+
+  os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+  [[ -n "$os_user" ]] || return 1
+
+  if ! command -v sudo >/dev/null 2>&1; then
+    return 2
+  fi
+
+  if [[ "$debug" == "1" ]]; then
+    sudo -n -u "$os_user" "$bash_bin" -c 'exit 0' && return 0 || return 2
+  fi
+  if sudo -n -u "$os_user" "$bash_bin" -c 'exit 0' 2>/dev/null; then
+    return 0
+  fi
+  return 2
+}
+
+# bridge_isolation_run_as_agent_user_via_bash <agent> <script> [arg...]
+#
+# Runs the inline bash script as the agent's isolated UID via:
+#   sudo -n -u <os_user> ${BRIDGE_BASH_BIN:-bash} -c "$script" bridge-isolation "$@"
+#
+# The fixed "bridge-isolation" argument becomes "$0" inside the inline
+# script; user-supplied positional args are bound as "$1", "$2", ...
+#
+# Returns (distinct ranges):
+#   0   — agent isolated, sudo OK, script returned 0
+#   1   — agent NOT in linux-user isolation (caller should run directly)
+#   2   — agent isolated but passwordless sudo unavailable
+#   3+  — agent isolated, sudo OK, script returned non-zero. The script's
+#         actual exit code is preserved and returned unchanged (so caller
+#         can distinguish e.g. 1 = no-keys from 2 = unreadable inside the
+#         script's own contract).
+#
+# stdout: the script's stdout, unmodified.
+# stderr: suppressed unless BRIDGE_ISOLATION_HELPERS_DEBUG=1.
+#
+# Implementation note (#832): does NOT source bridge-lib.sh inside the
+# isolated UID's bash invocation. The script must be self-contained.
+bridge_isolation_run_as_agent_user_via_bash() {
+  local agent="$1"
+  local script="$2"
+  shift 2 || true
+
+  local os_user=""
+  local bash_bin="${BRIDGE_BASH_BIN:-bash}"
+  local debug="${BRIDGE_ISOLATION_HELPERS_DEBUG:-0}"
+  local rc=0
+
+  [[ -n "$agent" ]] || return 1
+  [[ -n "$script" ]] || return 1
+
+  if ! bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    return 1
+  fi
+
+  os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+  [[ -n "$os_user" ]] || return 1
+
+  if ! command -v sudo >/dev/null 2>&1; then
+    return 2
+  fi
+
+  if ! sudo -n -u "$os_user" "$bash_bin" -c 'exit 0' 2>/dev/null; then
+    return 2
+  fi
+
+  if [[ "$debug" == "1" ]]; then
+    sudo -n -u "$os_user" "$bash_bin" -c "$script" bridge-isolation "$@"
+    rc=$?
+  else
+    sudo -n -u "$os_user" "$bash_bin" -c "$script" bridge-isolation "$@" 2>/dev/null
+    rc=$?
+  fi
+
+  if [[ "$rc" -eq 0 ]]; then
+    return 0
+  fi
+  # Preserve the script's exit code unchanged for caller's distinct mapping.
+  # `sudo` itself returns 1 on policy denial — we already filtered that case
+  # above via the pre-flight true-probe, so any non-zero here is the script.
+  # Force-shift into the 3+ band so callers can disambiguate from rc=1/2.
+  if [[ "$rc" -lt 3 ]]; then
+    return $((rc + 2))
+  fi
+  return "$rc"
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10479,6 +10479,13 @@ assert_contains "$FP_STATUS_OUTPUT" "context-pressure FP rate (7d): 1/1 (100%)"
 log "running stale-resume regression suite"
 bash "$REPO_ROOT/scripts/test-stale-resume.sh"
 
+# Issue #832 — channel-health probe must degrade to controller-blind /
+# status=unknown when the controller cannot read an isolated agent's
+# dotenv AND we cannot sudo to that agent's UID. Without this, the daemon
+# fires a false channel_health_miss audit row on every health cycle.
+log "running channel-probe-isolated regression suite (issue #832)"
+bash "$REPO_ROOT/scripts/test-channel-probe-isolated.sh"
+
 # Issue #541 PR-A — memory-daily payload jsonl-aware migration regression.
 log "running cron-migrate-payloads smoke (issue #541 PR-A)"
 bash "$REPO_ROOT/scripts/smoke/cron-migrate-payloads.sh"

--- a/scripts/test-channel-probe-isolated.sh
+++ b/scripts/test-channel-probe-isolated.sh
@@ -295,6 +295,76 @@ case "$(printf 'present\nmissing\nunreadable\ncontroller-blind\n' | grep -Fx "$C
     ;;
 esac
 
+# --- C11: inline probe script regex parity with controller-side helper -------
+# The other isolated cases stub out bridge_isolation_run_as_agent_user_via_bash
+# entirely so they don't exercise the inline grep. This case extracts the
+# probe script literally from lib/bridge-agents.sh and runs it against fixture
+# files to verify regex parity with bridge_env_file_has_any_nonempty_key — in
+# particular that `export KEY=value` is accepted on the isolated path (the
+# controller helper at lib/bridge-agents.sh:4220 accepts that form).
+step "C11: inline probe accepts 'export KEY=value' (parity with controller helper)"
+
+INLINE_PROBE="$TMP_HOME/inline-probe.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  # Extract the probe_script body verbatim — between the single-quoted opener
+  # and the standalone closing quote line. This keeps the test trapping a
+  # future drift in the inline regex.
+  awk "
+    /^[[:space:]]*probe_script='\$/ { capture=1; next }
+    capture && /^'\$/ { capture=0; next }
+    capture { print }
+  " "$ROOT_DIR/lib/bridge-agents.sh"
+} >"$INLINE_PROBE"
+chmod +x "$INLINE_PROBE"
+# Sanity: the extraction produced a nonempty file
+if [[ ! -s "$INLINE_PROBE" ]]; then
+  err "could not extract probe_script from bridge-agents.sh"
+fi
+
+run_probe() {
+  bash "$INLINE_PROBE" "$@"
+}
+
+C11_FAIL=0
+# C11a: bare KEY=value, with key filter, present.
+F11a="$TMP_HOME/c11a.env"
+printf 'DISCORD_BOT_TOKEN=abc123\n' >"$F11a"
+run_probe "$F11a" DISCORD_BOT_TOKEN || { C11_FAIL=1; err "C11a bare key: expected 0 got $?"; }
+
+# C11b: export KEY=value, with key filter — must match.
+F11b="$TMP_HOME/c11b.env"
+printf 'export DISCORD_BOT_TOKEN=abc123\n' >"$F11b"
+run_probe "$F11b" DISCORD_BOT_TOKEN || { C11_FAIL=1; err "C11b export form: expected 0 got $?"; }
+
+# C11c: export with multiple spaces between export and key.
+F11c="$TMP_HOME/c11c.env"
+printf 'export   DISCORD_BOT_TOKEN=abc123\n' >"$F11c"
+run_probe "$F11c" DISCORD_BOT_TOKEN || { C11_FAIL=1; err "C11c multi-space export: expected 0 got $?"; }
+
+# C11d: keyless mode (no positional args after file) accepts export form too.
+F11d="$TMP_HOME/c11d.env"
+printf 'export FOO=bar\n' >"$F11d"
+run_probe "$F11d" || { C11_FAIL=1; err "C11d keyless export: expected 0 got $?"; }
+
+# C11e: empty value still rejected (existing controller helper rejects it too).
+F11e="$TMP_HOME/c11e.env"
+printf 'export DISCORD_BOT_TOKEN=\n' >"$F11e"
+if run_probe "$F11e" DISCORD_BOT_TOKEN 2>/dev/null; then
+  C11_FAIL=1
+  err "C11e empty value: expected 1, got 0 (regex too loose)"
+fi
+
+# C11f: comment line not treated as a value.
+F11f="$TMP_HOME/c11f.env"
+printf '# export DISCORD_BOT_TOKEN=abc\n' >"$F11f"
+if run_probe "$F11f" DISCORD_BOT_TOKEN 2>/dev/null; then
+  C11_FAIL=1
+  err "C11f commented line: expected 1, got 0"
+fi
+
+if [[ "$C11_FAIL" -eq 0 ]]; then ok; fi
+
 # --- Summary -----------------------------------------------------------------
 TOTAL=$((PASS + FAIL))
 printf '\n# Issue #832 channel-probe isolation suite: %s/%s passed\n' "$PASS" "$TOTAL"

--- a/scripts/test-channel-probe-isolated.sh
+++ b/scripts/test-channel-probe-isolated.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #832 — channel-health probe must degrade to
+# "controller-blind" / status "unknown" when the controller cannot read an
+# isolated agent's dotenv AND we cannot sudo to that agent's UID to verify.
+# Without this, the daemon collapses an indeterminate readiness into a
+# confirmed "miss" and fires a false channel_health_miss audit row on every
+# health cycle.
+#
+# Runs in an isolated $HOME and $BRIDGE_HOME and stubs `sudo` plus the
+# isolation-aware helpers so it never reads or writes the operator's live
+# runtime and never requires a real isolated-UID rig.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+PASS=0
+FAIL=0
+LAST_DESC=""
+
+step() { LAST_DESC="$*"; }
+ok() { PASS=$((PASS + 1)); printf '  PASS: %s\n' "$LAST_DESC"; }
+err() { FAIL=$((FAIL + 1)); printf '  FAIL: %s — %s\n' "$LAST_DESC" "$*" >&2; }
+
+TMP_HOME="$(mktemp -d -t agb-channel-probe-test.XXXXXX)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+export HOME="$TMP_HOME"
+export BRIDGE_HOME="$TMP_HOME/.agent-bridge"
+mkdir -p "$BRIDGE_HOME"
+
+# --- Extract just the functions under test --------------------------------
+# This keeps the test self-contained without sourcing the full bridge-lib.sh
+# (which would pull in roster, sudo install, daemon state, etc.).
+EXTRACT_TMP="$TMP_HOME/extract.sh"
+awk '
+  /^bridge_trim_whitespace\(\) \{/ ||
+  /^bridge_append_csv_unique\(\) \{/ ||
+  /^bridge_qualify_channel_item\(\) \{/ ||
+  /^bridge_merge_channels_csv\(\) \{/ ||
+  /^bridge_env_file_has_any_nonempty_key\(\) \{/ ||
+  /^bridge_channel_env_file_readiness\(\) \{/ ||
+  /^bridge_channel_env_file_acl_diagnostic\(\) \{/ ||
+  /^bridge_agent_channel_status\(\) \{/ {
+    copy = 1
+  }
+  copy { print }
+  copy && /^\}$/ { copy = 0; print "" }
+' "$ROOT_DIR/lib/bridge-agents.sh" >"$EXTRACT_TMP"
+
+# Inline the new isolation helpers verbatim so this test exercises the real
+# helpers under test, not stubs of them.
+cat "$ROOT_DIR/lib/bridge-isolation-helpers.sh" >>"$EXTRACT_TMP"
+
+# Stubs for transitive deps. Tests below override these per case.
+cat >>"$EXTRACT_TMP" <<'EOF'
+
+# Default: agent is NOT linux-user isolated. Override per-test.
+bridge_agent_linux_user_isolation_effective() { return 1; }
+# Default: agent has no os_user mapping.
+bridge_agent_os_user() { printf ''; }
+# Default: channels CSV — test sets via STUB_REQUIRED_CSV.
+bridge_agent_channels_csv() { printf '%s' "${STUB_REQUIRED_CSV:-}"; }
+bridge_agent_channel_status_reason() { printf '%s' "${STUB_STATUS_REASON:-}"; }
+EOF
+
+# shellcheck source=/dev/null
+source "$EXTRACT_TMP"
+
+# Sudo / sudo-helper stubs are managed per-test via shell function overrides
+# so we can simulate the three sudo behaviors (no-sudo, sudo-ok-script-0,
+# sudo-ok-script-1, sudo-ok-script-2). The shellcheck SC2329 disable is to
+# tell shellcheck these are intentional override stubs.
+
+stub_not_isolated() {
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 1; }
+  # shellcheck disable=SC2329
+  bridge_agent_os_user() { printf ''; }
+}
+
+stub_isolated_no_sudo() {
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+  # shellcheck disable=SC2329
+  bridge_agent_os_user() { printf 'fake-user'; }
+  # shellcheck disable=SC2329
+  bridge_isolation_can_sudo_to_agent() { return 2; }
+  # shellcheck disable=SC2329
+  bridge_isolation_run_as_agent_user_via_bash() { return 2; }
+}
+
+STUB_SCRIPT_RC=0
+stub_isolated_sudo_ok_script() {
+  STUB_SCRIPT_RC="$1"
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+  # shellcheck disable=SC2329
+  bridge_agent_os_user() { printf 'fake-user'; }
+  # shellcheck disable=SC2329
+  bridge_isolation_can_sudo_to_agent() { return 0; }
+  # Mimic the helper's exit-code translation: script rc 0 -> 0, rc 1 -> 3,
+  # rc 2 -> 4. STUB_SCRIPT_RC is the raw script exit code under test.
+  # shellcheck disable=SC2329
+  bridge_isolation_run_as_agent_user_via_bash() {
+    local _rc="$STUB_SCRIPT_RC"
+    if [[ "$_rc" -eq 0 ]]; then
+      return 0
+    fi
+    return $((_rc + 2))
+  }
+}
+
+# --- C1: controller-readable + not isolated -> "present" ---------------------
+step "C1: controller-readable + not isolated -> present"
+stub_not_isolated
+F1="$TMP_HOME/c1.env"
+printf 'DISCORD_BOT_TOKEN=abc123\n' >"$F1"
+chmod 600 "$F1"
+out="$(bridge_channel_env_file_readiness agent-test plugin:discord "$F1" DISCORD_BOT_TOKEN)"
+if [[ "$out" == "present" ]]; then ok; else err "got '$out'"; fi
+
+# --- C2: isolated + sudo OK + readable + has keys -> "present" ---------------
+# Simulate by making the controller-side `[[ -r ]]` fail (chmod 000) so the
+# code path falls through to the isolation probe, and then have the script
+# return 0.
+step "C2: isolated + sudo OK + readable + has keys -> present"
+F2="$TMP_HOME/c2.env"
+printf 'DISCORD_BOT_TOKEN=abc123\n' >"$F2"
+chmod 000 "$F2"
+stub_isolated_sudo_ok_script 0
+out="$(bridge_channel_env_file_readiness agent-test plugin:discord "$F2" DISCORD_BOT_TOKEN)"
+if [[ "$out" == "present" ]]; then ok; else err "got '$out'"; fi
+chmod 600 "$F2"  # restore so trap can clean
+
+# --- C3: isolated + sudo OK + readable + empty -> "missing" ------------------
+step "C3: isolated + sudo OK + readable + empty -> missing"
+F3="$TMP_HOME/c3.env"
+printf '# no keys\n' >"$F3"
+chmod 000 "$F3"
+stub_isolated_sudo_ok_script 1
+out="$(bridge_channel_env_file_readiness agent-test plugin:discord "$F3" DISCORD_BOT_TOKEN)"
+if [[ "$out" == "missing" ]]; then ok; else err "got '$out'"; fi
+chmod 600 "$F3"
+
+# --- C4: isolated + sudo OK + not-readable-by-isolated -> "unreadable" -------
+step "C4: isolated + sudo OK + script reports not-readable -> unreadable"
+F4="$TMP_HOME/c4.env"
+printf 'DISCORD_BOT_TOKEN=zzz\n' >"$F4"
+chmod 000 "$F4"
+stub_isolated_sudo_ok_script 2
+out="$(bridge_channel_env_file_readiness agent-test plugin:discord "$F4" DISCORD_BOT_TOKEN)"
+if [[ "$out" == "unreadable" ]]; then ok; else err "got '$out'"; fi
+chmod 600 "$F4"
+
+# --- C5: isolated + sudo UNAVAILABLE -> "controller-blind" -------------------
+step "C5: isolated + no passwordless sudo -> controller-blind"
+F5="$TMP_HOME/c5.env"
+printf 'DISCORD_BOT_TOKEN=zzz\n' >"$F5"
+chmod 000 "$F5"
+stub_isolated_no_sudo
+out="$(bridge_channel_env_file_readiness agent-test plugin:discord "$F5" DISCORD_BOT_TOKEN)"
+C5_RESULT="$out"
+if [[ "$out" == "controller-blind" ]]; then ok; else err "got '$out'"; fi
+chmod 600 "$F5"
+
+# --- C6: status mapping: controller-blind reason -> "unknown" ----------------
+step "C6: bridge_agent_channel_status returns 'unknown' for controller-blind reason"
+STUB_REQUIRED_CSV="plugin:discord"
+STUB_STATUS_REASON='controller-blind:plugin:discord:/some/path/.env:no-passwordless-sudo (set BRIDGE_AGENT_SUDOERS or grant agent dotenv read via group ACL) {"mode":"600"}'
+out="$(bridge_agent_channel_status agent-test)"
+if [[ "$out" == "unknown" ]]; then ok; else err "got '$out'"; fi
+
+# --- C7: confirm a confirmed-miss reason still maps to "miss" ---------------
+step "C7: confirmed miss reason still maps to 'miss' (regression sanity)"
+STUB_REQUIRED_CSV="plugin:discord"
+STUB_STATUS_REASON="missing Discord bot token under /tmp/x (.env with DISCORD_BOT_TOKEN required)"
+out="$(bridge_agent_channel_status agent-test)"
+if [[ "$out" == "miss" ]]; then ok; else err "got '$out'"; fi
+
+# --- C8: daemon channel_health_miss must NOT fire on "unknown" --------------
+# We exercise the daemon's gating clause directly without spinning the full
+# daemon — extract the early return logic and assert: when status="unknown",
+# the function returns early WITHOUT emitting an audit row.
+step "C8: bridge_report_channel_health_miss returns early on status=unknown"
+DAEMON_GATE_TMP="$TMP_HOME/daemon-gate.sh"
+cat >"$DAEMON_GATE_TMP" <<'EOF'
+# Minimal replica of the gating clause in bridge-daemon.sh's
+# bridge_report_channel_health_miss. If the clause loses the
+# `status != "miss"` early-return for "unknown", this test will see
+# AUDIT_FIRED=1 (regression).
+AUDIT_FIRED=0
+bridge_audit_log() { AUDIT_FIRED=1; }
+bridge_clear_channel_health_state() { :; }
+gate_status="$1"
+if [[ "$gate_status" != "miss" ]]; then
+  bridge_clear_channel_health_state foo
+  exit 0
+fi
+bridge_audit_log daemon channel_health_miss foo
+EOF
+unknown_rc=0
+( bash "$DAEMON_GATE_TMP" "unknown" ) || unknown_rc=$?
+miss_rc=0
+( bash "$DAEMON_GATE_TMP" "miss" ) || miss_rc=$?
+# When status=unknown: rc=0 and no audit. When status=miss: rc=0 but audit
+# would fire. We test by inspecting AUDIT_FIRED via sub-shell side-effects;
+# simpler — re-run with `set -x`-style tracking via env file.
+AUDIT_PROBE="$TMP_HOME/audit-probe.txt"
+cat >"$DAEMON_GATE_TMP" <<EOF
+AUDIT_FIRED=0
+bridge_audit_log() { AUDIT_FIRED=1; printf '%s\n' "fired" >"$AUDIT_PROBE"; }
+bridge_clear_channel_health_state() { :; }
+gate_status="\$1"
+if [[ "\$gate_status" != "miss" ]]; then
+  bridge_clear_channel_health_state foo
+  exit 0
+fi
+bridge_audit_log daemon channel_health_miss foo
+EOF
+rm -f "$AUDIT_PROBE"
+bash "$DAEMON_GATE_TMP" "unknown"
+if [[ ! -f "$AUDIT_PROBE" ]]; then
+  ok
+else
+  err "audit fired on status=unknown (regression: daemon would emit false miss)"
+fi
+
+# --- C9: launch path -- controller-blind NOT in missing_channels_csv --------
+# Re-source the full helpers we need: missing-channels CSV depends on
+# bridge_channel_credentials_status_for_item which we extract here.
+step "C9: bridge_agent_missing_channels_csv excludes controller-blind channels"
+EXTRACT_LAUNCH="$TMP_HOME/extract-launch.sh"
+awk '
+  /^bridge_trim_whitespace\(\) \{/ ||
+  /^bridge_append_csv_unique\(\) \{/ ||
+  /^bridge_qualify_channel_item\(\) \{/ ||
+  /^bridge_channel_credentials_status_for_item\(\) \{/ ||
+  /^bridge_agent_controller_blind_channels_csv\(\) \{/ ||
+  /^bridge_agent_ready_channels_csv\(\) \{/ ||
+  /^bridge_agent_missing_channels_csv\(\) \{/ {
+    copy = 1
+  }
+  copy { print }
+  copy && /^\}$/ { copy = 0; print "" }
+' "$ROOT_DIR/lib/bridge-agents.sh" >"$EXTRACT_LAUNCH"
+
+# shellcheck source=/dev/null
+source "$EXTRACT_LAUNCH"
+
+# Stubs for transitive deps used by the credentials helper.
+# Use a single channel dir regardless of qualified item form so the dotenv
+# path resolution stays deterministic (bridge_qualify_channel_item may
+# append `@claude-plugins-official` to a bare `plugin:discord`).
+C9_DIR="$BRIDGE_HOME/state/c9-discord"
+mkdir -p "$C9_DIR"
+# shellcheck disable=SC2329
+bridge_channel_state_dir_for_item() { printf '%s' "$C9_DIR"; }
+# Mark this channel as controller-blind by simulating an unreadable file
+# AND isolated + no-sudo via the existing readiness function.
+F9="$C9_DIR/.env"
+printf 'DISCORD_BOT_TOKEN=zzz\n' >"$F9"
+chmod 000 "$F9"
+stub_isolated_no_sudo
+# Override channels CSV for this test.
+# shellcheck disable=SC2329
+bridge_agent_channels_csv() { printf '%s' 'plugin:discord'; }
+# bridge_agent_channel_runtime_ready_for_item is required by missing/ready —
+# stub it to always say "no" so the missing branch decides based purely on
+# the controller-blind credentials short-circuit.
+# shellcheck disable=SC2329
+bridge_agent_channel_runtime_ready_for_item() { return 1; }
+
+missing_out="$(bridge_agent_missing_channels_csv agent-test)"
+ready_out="$(bridge_agent_ready_channels_csv agent-test)"
+blind_out="$(bridge_agent_controller_blind_channels_csv agent-test)"
+if [[ "$missing_out" == "" && "$ready_out" == "" && "$blind_out" == "plugin:discord" ]]; then
+  ok
+else
+  err "missing='$missing_out' ready='$ready_out' blind='$blind_out' (expected missing=empty ready=empty blind=plugin:discord)"
+fi
+chmod 600 "$F9"
+
+# --- C10: diagnostics renderer shape (controller-blind ↔ ready=indeterminate)
+# Light-touch: we just confirm the readiness function's output is one of the
+# four documented values. Full diagnostics integration is covered by smoke.
+step "C10: readiness function output is one of {present,missing,unreadable,controller-blind}"
+case "$(printf 'present\nmissing\nunreadable\ncontroller-blind\n' | grep -Fx "$C5_RESULT")" in
+  "")
+    err "C5 result '$C5_RESULT' not in documented set"
+    ;;
+  *)
+    ok
+    ;;
+esac
+
+# --- Summary -----------------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+printf '\n# Issue #832 channel-probe isolation suite: %s/%s passed\n' "$PASS" "$TOTAL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

When the controller cannot `[[ -r <dotenv> ]]` an isolated agent's channel `.env` (a real failure mode under linux-user isolation when the per-agent group ACL drifts, or simply when the file is mode 0600 and owned by the isolated UID), the daemon previously collapsed the indeterminate readiness into a confirmed `miss`. This fired a false `channel_health_miss` audit row every health-cycle for an agent whose credentials are in fact correctly placed — the controller just can't see them.

This change introduces a controller-blind degrade path:
- Adds `lib/bridge-isolation-helpers.sh` with `bridge_isolation_can_sudo_to_agent` and `bridge_isolation_run_as_agent_user_via_bash`. The helpers reuse the existing sudoers `bash` allowlist (see `lib/bridge-migration.sh:773`) — no new sudoers rules required, no sourcing of `bridge-lib.sh` inside the isolated UID.
- `bridge_channel_env_file_readiness` now probes the dotenv via the agent's isolated UID when the controller cannot read it. If passwordless sudo is unavailable, returns the new `"controller-blind"` state instead of collapsing to `"unreadable"`.
- `bridge_agent_channel_status` maps a `controller-blind:*` reason to a new `"unknown"` status. `bridge_report_channel_health_miss` already gates audit on `status == "miss"`, so the false audit row no longer fires.
- `bridge_agent_missing_channels_csv` / `bridge_agent_ready_channels_csv` exclude controller-blind channels. A new `bridge_agent_controller_blind_channels_csv` enumerates them. Under `BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS=1`, the launch path folds the controller-blind set back into the launch flags so dev-mode launches don't silently strip a working channel.
- Diagnostics render `credentials=controller-blind` / `ready=indeterminate` so `agent show` makes the indeterminate state distinguishable from a real miss.

## Verification

| Check                                      | Result |
| ------------------------------------------ | ------ |
| `bash -n` on all touched + repo shell files | pass   |
| `shellcheck --severity=warning` repo-wide  | pass   |
| `scripts/test-channel-probe-isolated.sh`   | 10/10  |
| `scripts/smoke-test.sh`                    | pass (see commit comments for the smoke wrapper used; the operator's live runtime was not touched) |
| `bridge_isolation_can_sudo_to_agent nonexistent-agent` smoke | exit=1 (not isolated), per brief §5.5 |

Regression cases in `scripts/test-channel-probe-isolated.sh`:
- C1 controller-readable + not isolated → `present`
- C2 isolated + sudo OK + readable + has keys → `present`
- C3 isolated + sudo OK + readable + empty → `missing`
- C4 isolated + sudo OK + not readable even to isolated UID → `unreadable`
- C5 isolated + sudo unavailable → `controller-blind`
- C6 `controller-blind:*` reason → `bridge_agent_channel_status` returns `unknown`
- C7 regression sanity: confirmed-miss reason still returns `miss`
- C8 daemon gating: `status=unknown` does NOT fire `channel_health_miss`
- C9 launch path: controller-blind channel excluded from missing AND ready CSVs, present in controller-blind CSV
- C10 readiness function output is in the documented set

The new test is wired into `scripts/smoke-test.sh` alongside `test-stale-resume.sh`.

## Notes

- No `VERSION` / `CHANGELOG` bump — this is a fix, not a release.
- No prompt-guard touch.
- No new dependencies.
- The sudoers contract (`bash` + `tmux` only — see `lib/bridge-migration.sh:773`) is respected: the privileged read goes through `sudo -n -u <user> bash -c '<inline>' bash <args>`, with the inline script self-contained (no `source bridge-lib.sh` under the isolated UID).

Closes: #832

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
