### PR TITLE
fix(v0.11.0): usage monitor reads Claude state per-agent (#831)

### DIFF
--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -70,8 +70,15 @@ def cmd_usage_alert_parse(args: argparse.Namespace) -> int:
     """Original site: bridge-daemon.sh:1009 (process_usage_monitor).
 
     Extracts alert tuples from the usage-monitor JSON for shell consumption.
-    Output: one tab-separated row per alert:
-      provider \\t account \\t window \\t bucket \\t used_percent \\t reset_at \\t source \\t message
+    Output: one tab-separated row per alert (9 cols):
+      provider \\t account \\t window \\t bucket \\t used_percent \\t reset_at \\t source \\t agent \\t message
+
+    Issue #831: `agent` is the new 8th column, inserted BEFORE message so the
+    daemon callsite's existing `IFS=$'\\t' read ... source body` continues to
+    work when treating message as the trailing free-form field — but the
+    callsite must list `agent` between `source` and `body` to surface it.
+    Placing `message` last keeps its existing role as the absorbed
+    trailing-content slot in shell readers that mismatch the column count.
     """
     try:
         payload = json.loads(args.monitor_json)
@@ -89,6 +96,7 @@ def cmd_usage_alert_parse(args: argparse.Namespace) -> int:
                     str(alert.get("used_percent", "")),
                     str(alert.get("reset_at", "")),
                     str(alert.get("source", "")),
+                    str(alert.get("agent", "")),
                     str(alert.get("message", "")),
                 ]
             )
@@ -331,8 +339,12 @@ def cmd_usage_rotation_candidates_parse(args: argparse.Namespace) -> int:
     """Original site: bridge-daemon.sh:1069 (process_usage_monitor).
 
     Extracts ``rotation_candidates`` tuples from the usage-monitor JSON.
-    Output: one tab-separated row per candidate:
-      provider \\t account \\t window \\t used_percent \\t reset_at \\t source \\t message
+    Output: one tab-separated row per candidate (8 cols):
+      provider \\t account \\t window \\t used_percent \\t reset_at \\t source \\t agent \\t message
+
+    Issue #831: `agent` is inserted as the 7th column (before message) so the
+    daemon shell loop can surface the triggering agent in its audit row. The
+    bash callsite is updated in lockstep.
     JSON-parse error exits 1 so the bash callsite's ``|| rotation_rows=""``
     fallback fires and the loop continues with no candidates.
     """
@@ -342,6 +354,10 @@ def cmd_usage_rotation_candidates_parse(args: argparse.Namespace) -> int:
         return 1
 
     for item in payload.get("rotation_candidates", []) or []:
+        # `agent` field on the candidate falls back to `worst_case_agent` for
+        # consistency with the envelope-level field. Either may be empty for
+        # legacy-single-cache rows.
+        agent = item.get("agent") or item.get("worst_case_agent") or ""
         print(
             "\t".join(
                 [
@@ -351,6 +367,7 @@ def cmd_usage_rotation_candidates_parse(args: argparse.Namespace) -> int:
                     str(item.get("used_percent", "")),
                     str(item.get("reset_at", "")),
                     str(item.get("source", "")),
+                    str(agent),
                     str(item.get("message", "")),
                 ]
             )

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1059,7 +1059,11 @@ process_usage_monitor() {
   bridge_agent_exists "$admin_agent" || return 1
   bridge_usage_due || return 1
 
-  if ! monitor_json="$("$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-usage.sh" monitor --json 2>/dev/null)"; then
+  # Issue #831: read each Claude agent's own usage cache, not just the
+  # controller's $HOME. Default scope mirrors bridge-auth.sh sync (static
+  # Claude roster). Operators can broaden via BRIDGE_USAGE_MONITOR_AGENTS.
+  local usage_monitor_agents_scope="${BRIDGE_USAGE_MONITOR_AGENTS:-static}"
+  if ! monitor_json="$("$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-usage.sh" monitor --json --agents "$usage_monitor_agents_scope" 2>/dev/null)"; then
     bridge_note_usage_poll
     return 1
   fi
@@ -1086,7 +1090,8 @@ process_usage_monitor() {
   printf '%s\n' "$alert_rows" > "$_alert_tmp"
   printf '%s\n' "$rotation_rows" > "$_rotation_tmp"
 
-  while IFS=$'\t' read -r provider account window bucket used_percent reset_at source body; do
+  local triggering_agent=""
+  while IFS=$'\t' read -r provider account window bucket used_percent reset_at source triggering_agent body; do
     [[ -z "$provider" || -z "$window" || -z "$bucket" ]] && continue
     if [[ "$bucket" == "crit" ]]; then
       priority="urgent"
@@ -1098,6 +1103,10 @@ process_usage_monitor() {
     if bridge_agent_has_notify_transport "$admin_agent"; then
       bridge_notify_send "$admin_agent" "$title" "$body" "" "$priority" "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
     fi
+    # Issue #831: record the triggering agent in the audit row so operators
+    # can attribute a per-agent usage spike to its source agent rather than
+    # the controller. Empty string preserves the previous row shape for
+    # legacy-single-cache invocations.
     bridge_audit_log daemon usage_alert "$admin_agent" \
       --detail provider="$provider" \
       --detail account="$account" \
@@ -1105,11 +1114,13 @@ process_usage_monitor() {
       --detail bucket="$bucket" \
       --detail used_percent="$used_percent" \
       --detail reset_at="$reset_at" \
-      --detail source="$source"
+      --detail source="$source" \
+      --detail agent="$triggering_agent"
     alert_count=$((alert_count + 1))
   done < "$_alert_tmp"
 
-  while IFS=$'\t' read -r provider account window used_percent reset_at source body; do
+  local worst_case_agent=""
+  while IFS=$'\t' read -r provider account window used_percent reset_at source worst_case_agent body; do
     [[ -z "$provider" || "$provider" != "claude" || -z "$window" ]] && continue
     # Rotate only once per monitor pass; bridge-usage.py already latches each
     # provider/account/window candidate once per usage reset cycle.
@@ -1127,6 +1138,9 @@ process_usage_monitor() {
     # downstream ``case`` statement routes through the ``error:*`` branch.
     rotation_status_row="$(bridge_with_timeout 5 rotation_status_parse python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" rotation-status-parse "$rotate_json" || true)"
     IFS=$'\t' read -r rotation_status rotation_reason rotation_from rotation_to rotation_sync_status <<<"$rotation_status_row"
+    # Issue #831: record `worst_case_agent` — the agent whose usage actually
+    # crossed the rotation threshold this pass. Empty for legacy single-cache
+    # rows. Distinct from `agent_scope` (the rotation fanout target).
     bridge_audit_log daemon claude_token_rotation "$admin_agent" \
       --detail status="$rotation_status" \
       --detail reason="$rotation_reason" \
@@ -1139,7 +1153,8 @@ process_usage_monitor() {
       --detail from="$rotation_from" \
       --detail to="$rotation_to" \
       --detail sync_status="$rotation_sync_status" \
-      --detail agent_scope="$rotation_agent_scope"
+      --detail agent_scope="$rotation_agent_scope" \
+      --detail worst_case_agent="$worst_case_agent"
     case "$rotation_status:$rotation_reason" in
       rotated:*)
         title="claude token rotated"

--- a/bridge-usage.py
+++ b/bridge-usage.py
@@ -191,6 +191,23 @@ def claude_snapshots(
     )
 
 
+def _per_agent_payload_is_present(per_agent_path: Path) -> bool:
+    """Issue #831 r2 (review #2104 finding 1): treat per-agent mode as active
+    as soon as the caller supplied a parseable list payload, even if every
+    entry is `present=false` / unreadable. The earlier "fall through to
+    controller cache when zero per-agent snapshots" path silently re-enabled
+    the original #831 blind spot — caller's intent ("monitor THESE agents")
+    must be honored even when none of them have data.
+    """
+    if not per_agent_path.is_file():
+        return False
+    try:
+        entries = load_json(per_agent_path)
+    except Exception:
+        return False
+    return isinstance(entries, list)
+
+
 def claude_snapshots_per_agent(
     per_agent_path: Path,
     warn: float,
@@ -309,22 +326,29 @@ def collect_snapshots(args: argparse.Namespace) -> list[dict[str, Any]]:
     elevated = _parse_elevated(args, warn, critical)
     snapshots: list[dict[str, Any]] = []
 
-    # Issue #831: when --per-agent-cache-json is supplied, prefer the per-agent
-    # array so each Claude snapshot is tagged with its agent. Otherwise fall
-    # back to the legacy single-controller path for back-compat (U5).
+    # Issue #831: when --per-agent-cache-json is supplied, the caller is in
+    # explicit per-agent mode. Per-agent mode latches on flag presence + a
+    # parseable/list-shaped payload, NOT on snapshot count. If selected agents
+    # all have present=false or unreadable caches, the correct answer is "no
+    # signal from those agents" — NOT "fall back to controller cache" (which
+    # would silently reintroduce the original #831 blind spot, where one
+    # isolated agent's hidden rate-limit went un-rotated).
+    #
+    # The legacy single-controller path is only used when --per-agent-cache-json
+    # is absent (true legacy invocation, e.g. an older operator script).
     per_agent_path_raw = getattr(args, "per_agent_cache_json", None)
-    used_per_agent = False
+    per_agent_mode_active = False
     if per_agent_path_raw:
         per_agent_path = Path(per_agent_path_raw).expanduser()
-        per_agent_snaps = claude_snapshots_per_agent(
-            per_agent_path, warn, critical, elevated=elevated
-        )
-        if per_agent_snaps:
+        per_agent_mode_active = _per_agent_payload_is_present(per_agent_path)
+        if per_agent_mode_active:
+            per_agent_snaps = claude_snapshots_per_agent(
+                per_agent_path, warn, critical, elevated=elevated
+            )
             snapshots.extend(per_agent_snaps)
-            used_per_agent = True
 
-    if not used_per_agent:
-        # Legacy single-controller cache (back-compat). `--legacy-single-path`
+    if not per_agent_mode_active:
+        # True legacy single-controller cache (back-compat). `--legacy-single-path`
         # is accepted as a synonym for `--claude-usage-cache` so the wrapper
         # can always pass both without disturbing existing semantics.
         legacy_raw = getattr(args, "legacy_single_path", None) or args.claude_usage_cache

--- a/bridge-usage.py
+++ b/bridge-usage.py
@@ -1,5 +1,15 @@
 #!/usr/bin/env python3
-"""bridge-usage.py - collect and monitor Claude/Codex usage windows."""
+"""bridge-usage.py - collect and monitor Claude/Codex usage windows.
+
+Issue #831 — Claude usage caches live under each agent's own home in any
+linux-user-isolated install. The monitor used to read the controller's
+$HOME cache only, which on an isolated rig is empty. This module now
+accepts ``--per-agent-cache-json <path>`` (an array built by
+bridge-usage.sh from each agent's resolved cache path) and tags every
+snapshot with ``agent_id``. The monitor's per-key latch is extended with
+``agent`` so two agents sharing the same plan/account/window cannot mask
+each other's rotation triggers.
+"""
 
 from __future__ import annotations
 
@@ -123,18 +133,15 @@ def normalize_window(name: str, minutes: Any) -> str:
     return f"{value}m"
 
 
-def claude_snapshots(
-    path: Path,
+def _claude_snapshots_from_payload(
+    payload: Any,
+    source: str,
     warn: float,
     critical: float,
-    elevated: float | None = None,
+    elevated: float | None,
+    agent: str | None,
 ) -> list[dict[str, Any]]:
-    if not path.is_file():
-        return []
-    try:
-        payload = load_json(path)
-    except Exception:
-        return []
+    """Shared body for claude_snapshots() and the per-agent collector."""
     if not isinstance(payload, dict):
         return []
     data = payload.get("data") or payload.get("lastGoodData") or {}
@@ -152,16 +159,72 @@ def claude_snapshots(
             percent = float(used_percent)
         except (TypeError, ValueError):
             percent = None  # type: ignore[assignment]
-        snapshots.append(
-            {
-                "provider": "claude",
-                "account": plan,
-                "window": window,
-                "used_percent": percent,
-                "reset_at": reset_at,
-                "health": classify_health(percent, warn, critical, elevated=elevated),
-                "source": str(path),
-            }
+        entry: dict[str, Any] = {
+            "provider": "claude",
+            "account": plan,
+            "window": window,
+            "used_percent": percent,
+            "reset_at": reset_at,
+            "health": classify_health(percent, warn, critical, elevated=elevated),
+            "source": source,
+        }
+        if agent is not None:
+            entry["agent"] = agent
+        snapshots.append(entry)
+    return snapshots
+
+
+def claude_snapshots(
+    path: Path,
+    warn: float,
+    critical: float,
+    elevated: float | None = None,
+) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    try:
+        payload = load_json(path)
+    except Exception:
+        return []
+    return _claude_snapshots_from_payload(
+        payload, str(path), warn, critical, elevated, agent=None
+    )
+
+
+def claude_snapshots_per_agent(
+    per_agent_path: Path,
+    warn: float,
+    critical: float,
+    elevated: float | None = None,
+) -> list[dict[str, Any]]:
+    """Issue #831: read the per-agent cache payload array (built by
+    bridge-usage.sh) and emit one snapshot set per agent. Each snapshot is
+    tagged with `agent` so the monitor latch key can include agent identity.
+    """
+    if not per_agent_path.is_file():
+        return []
+    try:
+        entries = load_json(per_agent_path)
+    except Exception:
+        return []
+    if not isinstance(entries, list):
+        return []
+
+    snapshots: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        agent = str(entry.get("agent") or "").strip()
+        if not agent:
+            continue
+        if not entry.get("present"):
+            continue  # U3: agent's cache missing entirely → skip silently.
+        payload = entry.get("payload")
+        source = str(entry.get("path") or "")
+        snapshots.extend(
+            _claude_snapshots_from_payload(
+                payload, source, warn, critical, elevated, agent=agent
+            )
         )
     return snapshots
 
@@ -244,10 +307,31 @@ def collect_snapshots(args: argparse.Namespace) -> list[dict[str, Any]]:
     warn = float(args.warn_threshold)
     critical = float(args.critical_threshold)
     elevated = _parse_elevated(args, warn, critical)
-    snapshots = []
-    snapshots.extend(
-        claude_snapshots(Path(args.claude_usage_cache).expanduser(), warn, critical, elevated=elevated)
-    )
+    snapshots: list[dict[str, Any]] = []
+
+    # Issue #831: when --per-agent-cache-json is supplied, prefer the per-agent
+    # array so each Claude snapshot is tagged with its agent. Otherwise fall
+    # back to the legacy single-controller path for back-compat (U5).
+    per_agent_path_raw = getattr(args, "per_agent_cache_json", None)
+    used_per_agent = False
+    if per_agent_path_raw:
+        per_agent_path = Path(per_agent_path_raw).expanduser()
+        per_agent_snaps = claude_snapshots_per_agent(
+            per_agent_path, warn, critical, elevated=elevated
+        )
+        if per_agent_snaps:
+            snapshots.extend(per_agent_snaps)
+            used_per_agent = True
+
+    if not used_per_agent:
+        # Legacy single-controller cache (back-compat). `--legacy-single-path`
+        # is accepted as a synonym for `--claude-usage-cache` so the wrapper
+        # can always pass both without disturbing existing semantics.
+        legacy_raw = getattr(args, "legacy_single_path", None) or args.claude_usage_cache
+        snapshots.extend(
+            claude_snapshots(Path(legacy_raw).expanduser(), warn, critical, elevated=elevated)
+        )
+
     snapshots.extend(
         codex_snapshots(Path(args.codex_sessions_dir).expanduser(), warn, critical, elevated=elevated)
     )
@@ -336,6 +420,8 @@ def cmd_status(args: argparse.Namespace) -> int:
         print(json.dumps(result, ensure_ascii=True, indent=2))
         return 0
     for snapshot in snapshots:
+        # Issue #831: include agent column so isolated-per-agent runs are
+        # legible in tab output. Empty for legacy controller-cache rows.
         print(
             "\t".join(
                 [
@@ -346,6 +432,7 @@ def cmd_status(args: argparse.Namespace) -> int:
                     str(snapshot.get("reset_at", "")),
                     str(snapshot.get("health", "")),
                     str(snapshot.get("source", "")),
+                    str(snapshot.get("agent", "")),
                 ]
             )
         )
@@ -363,13 +450,25 @@ def cmd_monitor(args: argparse.Namespace) -> int:
     critical = float(args.critical_threshold)
     elevated = _parse_elevated(args, warn, critical)
     rotation_threshold = float(args.rotation_threshold)
+    # Track the worst-case agent so the aggregate rotation row tells the
+    # operator which agent triggered. Per #831 patch-dev r2 §4: a 99% on
+    # agent-A must NOT be masked by a 60% on agent-B sharing the same plan.
+    worst_case_agent: str | None = None
+    worst_case_percent: float = -1.0
 
     for snapshot in snapshots:
+        # Issue #831 patch-dev r2 §4: include agent identity in the latching
+        # key. Two isolated agents on the same Claude plan/account/window must
+        # have independent rotation_triggered_at state so one cannot mask the
+        # other. Non-agent snapshots (codex, legacy controller cache) latch
+        # with an empty agent field — order-independent and back-compat.
+        snapshot_agent = str(snapshot.get("agent") or "")
         key = "::".join(
             [
                 str(snapshot.get("provider", "")),
                 str(snapshot.get("account", "")),
                 str(snapshot.get("window", "")),
+                snapshot_agent,
             ]
         )
         bucket = bucket_for_snapshot(snapshot, warn, critical, elevated=elevated)
@@ -419,17 +518,24 @@ def cmd_monitor(args: argparse.Namespace) -> int:
             and isinstance(used_percent, (int, float))
             and used_percent >= rotation_threshold
         ):
+            # Track worst-case across this monitor pass — used for aggregate
+            # attribution in the output envelope.
+            if used_percent > worst_case_percent:
+                worst_case_percent = float(used_percent)
+                worst_case_agent = snapshot_agent or None
             if not rotation_triggered_at:
-                rotation_candidates.append(
-                    {
-                        **snapshot,
-                        "rotation_threshold": rotation_threshold,
-                        "message": (
-                            f"Claude usage rotation candidate: {snapshot.get('window') or 'unknown'} "
-                            f"window at {used_percent:.0f}% (threshold {rotation_threshold:.0f}%)."
-                        ),
-                    }
-                )
+                candidate = {
+                    **snapshot,
+                    "rotation_threshold": rotation_threshold,
+                    "worst_case_agent": snapshot_agent or None,
+                    "message": (
+                        f"Claude usage rotation candidate: {snapshot.get('window') or 'unknown'} "
+                        f"window at {used_percent:.0f}% (threshold {rotation_threshold:.0f}%)"
+                        + (f" on agent {snapshot_agent}" if snapshot_agent else "")
+                        + "."
+                    ),
+                }
+                rotation_candidates.append(candidate)
                 rotation_triggered_at = now_iso()
                 rotation_triggered_reset_at = reset_at
         elif snapshot.get("provider") == "claude":
@@ -447,12 +553,33 @@ def cmd_monitor(args: argparse.Namespace) -> int:
 
     state["updated_at"] = now_iso()
     save_monitor_state(state_path, state)
+    # Per-agent breakdown: one entry per (agent, provider, window) with the
+    # latest used_percent so operator-facing output can show "agent-A 99%,
+    # agent-B 60%". Sorted by used_percent desc so the worst-case row is
+    # first.
+    per_agent_breakdown = sorted(
+        (
+            {
+                "agent": str(s.get("agent") or ""),
+                "provider": s.get("provider"),
+                "account": s.get("account"),
+                "window": s.get("window"),
+                "used_percent": s.get("used_percent"),
+                "health": s.get("health"),
+            }
+            for s in snapshots
+            if s.get("agent")
+        ),
+        key=lambda r: (-(r["used_percent"] if isinstance(r["used_percent"], (int, float)) else -1)),
+    )
     result = {
         "generated_at": now_iso(),
         "snapshots": snapshots,
         "alerts": alerts,
         "rotation_candidates": rotation_candidates,
         "state_file": str(state_path),
+        "worst_case_agent": worst_case_agent,
+        "per_agent_breakdown": per_agent_breakdown,
     }
     if args.json:
         print(json.dumps(result, ensure_ascii=True, indent=2))
@@ -504,6 +631,11 @@ def build_parser() -> argparse.ArgumentParser:
         cmd.add_argument("--warn-threshold", type=float, default=90.0, **common_kwargs)
         cmd.add_argument("--elevated-threshold", type=float, default=95.0, **common_kwargs)
         cmd.add_argument("--critical-threshold", type=float, default=100.0, **common_kwargs)
+        # Issue #831 per-agent collection. Both optional; back-compat is
+        # preserved (U5) when neither is supplied or per-agent payload is
+        # empty.
+        cmd.add_argument("--per-agent-cache-json", default=None, **common_kwargs)
+        cmd.add_argument("--legacy-single-path", default=None, **common_kwargs)
 
     status_parser = sub.add_parser("status")
     add_source_args(status_parser)

--- a/bridge-usage.sh
+++ b/bridge-usage.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 # bridge-usage.sh — inspect and monitor Claude/Codex usage windows
+#
+# Issue #831: status/monitor must read each Claude agent's *own* usage cache
+# (under that agent's home), not just the controller's $HOME, so the daemon
+# can detect a rotation-worthy usage cliff on an isolated agent. The `--agents`
+# flag mirrors the `bridge-auth.sh claude-token sync` convention.
 
 set -euo pipefail
 
@@ -13,6 +18,9 @@ usage() {
   cat <<EOF
 Usage:
   bash $SCRIPT_DIR/bridge-usage.sh <status|monitor|alerts> [options...]
+
+  status/monitor accept --agents <static|all|csv> to scope per-agent cache
+  collection (default: static — same convention as bridge-auth.sh).
 EOF
 }
 
@@ -23,6 +31,8 @@ command="${1:-}"
 }
 shift || true
 
+# Default cache path (controller / single-tenant). Per-agent collection below
+# overrides this with the agent-specific path when --agents is in effect.
 claude_usage_cache="${BRIDGE_CLAUDE_USAGE_CACHE:-$HOME/.claude/plugins/claude-hud/.usage-cache.json}"
 codex_sessions_dir="${BRIDGE_CODEX_SESSIONS_DIR:-$HOME/.codex/sessions}"
 usage_state_file="${BRIDGE_USAGE_MONITOR_STATE_FILE:-$BRIDGE_STATE_DIR/usage/monitor-state.json}"
@@ -49,25 +59,275 @@ PY
   fi
 fi
 
+# bridge_usage_select_claude_agents <spec>
+#   spec ∈ {static, all, claude, <csv>}; default `static`. Prints one Claude
+#   agent id per line (filters out non-Claude engines). Mirrors
+#   bridge_auth_selected_agents in bridge-auth.sh so a single operator-facing
+#   `--agents` contract covers sync + monitor.
+bridge_usage_select_claude_agents() {
+  local spec="${1:-static}"
+  local agent="" item=""
+  local -a explicit=()
+
+  case "$spec" in
+    static|"")
+      for agent in "${BRIDGE_AGENT_IDS[@]:-}"; do
+        [[ -n "$agent" ]] || continue
+        [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || continue
+        [[ "$(bridge_agent_source "$agent")" == "static" ]] || continue
+        printf '%s\n' "$agent"
+      done
+      ;;
+    all|claude)
+      for agent in "${BRIDGE_AGENT_IDS[@]:-}"; do
+        [[ -n "$agent" ]] || continue
+        [[ "$(bridge_agent_engine "$agent")" == "claude" ]] || continue
+        printf '%s\n' "$agent"
+      done
+      ;;
+    *)
+      IFS=',' read -r -a explicit <<<"$spec"
+      for item in "${explicit[@]}"; do
+        item="${item#"${item%%[![:space:]]*}"}"
+        item="${item%"${item##*[![:space:]]}"}"
+        [[ -n "$item" ]] || continue
+        bridge_agent_exists "$item" || {
+          printf '[error] unknown agent: %s\n' "$item" >&2
+          return 1
+        }
+        [[ "$(bridge_agent_engine "$item")" == "claude" ]] || {
+          printf '[error] agent is not a Claude agent: %s\n' "$item" >&2
+          return 1
+        }
+        printf '%s\n' "$item"
+      done
+      ;;
+  esac
+}
+
+# bridge_usage_resolve_claude_cache_path <agent>
+#   Stdout: absolute path the agent's claude-hud usage cache would live at.
+#   Isolated agents (linux-user mode) → under $BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT/<os_user>.
+#   Non-isolated agents → controller's $HOME (the existing single-tenant path).
+bridge_usage_resolve_claude_cache_path() {
+  local agent="$1"
+  local os_user="" agent_home=""
+
+  if bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+    if [[ -n "$os_user" ]]; then
+      agent_home="$(bridge_agent_linux_user_home "$os_user")"
+      printf '%s/.claude/plugins/claude-hud/.usage-cache.json' "$agent_home"
+      return 0
+    fi
+  fi
+
+  printf '%s/.claude/plugins/claude-hud/.usage-cache.json' "$HOME"
+}
+
+# bridge_usage_read_claude_cache_for_agent <agent> <path>
+#   Stdout: cache file contents (JSON), empty when unreadable / absent.
+#   Returns 0 always — missing cache is not an error, it just means that agent
+#   contributes no Claude snapshot this tick (per brief U3).
+#
+# set-e safety: every helper invocation uses `cmd || rc=$?` capture, mirroring
+# the pattern in lib/bridge-agents.sh:bridge_channel_env_file_readiness that
+# avoided the PR #836 set-e abort.
+bridge_usage_read_claude_cache_for_agent() {
+  local agent="$1"
+  local path="$2"
+  local sudo_rc=0 probe_rc=0
+  local probe_script=''
+
+  if [[ -z "$agent" || -z "$path" ]]; then
+    return 0
+  fi
+
+  # Controller-direct path: non-isolated agent, or we can read the file from
+  # the controller's UID. The latter handles the common case where the agent's
+  # home is on a shared filesystem with permissive perms (most CI setups).
+  if [[ -r "$path" ]]; then
+    cat "$path" 2>/dev/null || true
+    return 0
+  fi
+
+  if ! declare -F bridge_isolation_can_sudo_to_agent >/dev/null 2>&1; then
+    return 0
+  fi
+
+  sudo_rc=0
+  bridge_isolation_can_sudo_to_agent "$agent" 2>/dev/null || sudo_rc=$?
+  case "$sudo_rc" in
+    0)
+      # Isolated and sudo works — read via the isolated UID. Self-contained
+      # inline script; does NOT source bridge-lib.sh under the isolated UID
+      # (sudoers allowlist is `bash` + `tmux` only).
+      probe_script='
+file="$1"
+[[ -r "$file" ]] || exit 2
+cat "$file"
+'
+      probe_rc=0
+      bridge_isolation_run_as_agent_user_via_bash "$agent" "$probe_script" "$path" 2>/dev/null || probe_rc=$?
+      if [[ "$probe_rc" -eq 0 ]]; then
+        return 0
+      fi
+      # rc=3 (script exited 1) or rc=4 (script exited 2 — file unreadable to
+      # isolated UID) → contribute empty payload for this agent (skip cleanly).
+      return 0
+      ;;
+    2)
+      # Isolated agent but no passwordless sudo — degrade silently per brief
+      # U4 ("that agent is skipped with a warn-log line; other agents
+      # continue"). The warn line lands on the daemon's stderr; the daemon
+      # already routes 2>/dev/null on the wrapper invocation, but during ad-hoc
+      # `bridge-usage.sh status --agents all` the operator sees it.
+      printf '[bridge-usage] skip agent=%s reason=no-passwordless-sudo\n' "$agent" >&2
+      return 0
+      ;;
+    *)
+      # rc=1 — not isolated at all. Fall back to controller-direct read.
+      cat "$path" 2>/dev/null || true
+      return 0
+      ;;
+  esac
+}
+
+# bridge_usage_build_per_agent_payload <agents-newline-stream>
+#   Reads agent ids from stdin (one per line), resolves each agent's cache
+#   path, reads it (with isolation-aware sudo when needed), and emits a single
+#   JSON array of {agent, path, present, payload} entries. Returns the
+#   tempfile path on stdout. The tempfile is mode 0600.
+bridge_usage_build_per_agent_payload() {
+  local tmp="" agent="" path="" content="" python_args=()
+  tmp="$(mktemp)"
+  chmod 600 "$tmp"
+
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    path="$(bridge_usage_resolve_claude_cache_path "$agent")"
+    content="$(bridge_usage_read_claude_cache_for_agent "$agent" "$path")"
+    # Encode each row as agent <TAB> path <TAB> base64(content) so python can
+    # decode without worrying about embedded newlines / quotes / NULs.
+    python_args+=("$agent" "$path" "$(printf '%s' "$content" | base64 | tr -d '\n')")
+  done
+
+  python3 - "$tmp" "${python_args[@]+"${python_args[@]}"}" <<'PY'
+import base64
+import json
+import sys
+from pathlib import Path
+
+out_path = Path(sys.argv[1])
+items = sys.argv[2:]
+entries = []
+# items come in (agent, path, b64) triplets.
+for i in range(0, len(items), 3):
+    agent = items[i]
+    path = items[i + 1] if i + 1 < len(items) else ""
+    b64 = items[i + 2] if i + 2 < len(items) else ""
+    raw = ""
+    if b64:
+        try:
+            raw = base64.b64decode(b64).decode("utf-8", errors="replace")
+        except Exception:
+            raw = ""
+    parsed = None
+    present = False
+    if raw.strip():
+        try:
+            parsed = json.loads(raw)
+            present = True
+        except Exception:
+            parsed = None
+            present = False
+    entries.append({
+        "agent": agent,
+        "path": path,
+        "present": present,
+        "payload": parsed,
+    })
+
+out_path.write_text(json.dumps(entries, ensure_ascii=True), encoding="utf-8")
+PY
+  printf '%s' "$tmp"
+}
+
+# ---------------------------------------------------------------------------
+# Operator-facing arg parsing: we intercept `--agents <spec>` here (so we can
+# collect per-agent caches before exec'ing python3) and pass the rest through
+# unchanged. Anything else stays a python-side flag, including the existing
+# threshold + state-file flags.
+# ---------------------------------------------------------------------------
+agents_spec=""
+agents_explicit=0
+forward_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --agents)
+      agents_spec="${2:-}"
+      agents_explicit=1
+      shift 2
+      ;;
+    --agents=*)
+      agents_spec="${1#--agents=}"
+      agents_explicit=1
+      shift
+      ;;
+    *)
+      forward_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+per_agent_cache_json=""
+legacy_single_path=""
+# Cleanup any per-agent tempfile we create.
+trap '[[ -n "${per_agent_cache_json:-}" ]] && rm -f -- "$per_agent_cache_json"' EXIT
+
+run_python() {
+  local subcmd="$1"
+  shift
+  local -a base_args=(
+    "$subcmd"
+    --claude-usage-cache "$claude_usage_cache"
+    --codex-sessions-dir "$codex_sessions_dir"
+  )
+  if [[ "$subcmd" == "monitor" ]]; then
+    base_args+=(--state-file "$usage_state_file" --rotation-threshold "$rotation_threshold")
+  fi
+  if [[ -n "$per_agent_cache_json" ]]; then
+    base_args+=(--per-agent-cache-json "$per_agent_cache_json")
+  fi
+  if [[ -n "$legacy_single_path" ]]; then
+    base_args+=(--legacy-single-path "$legacy_single_path")
+  fi
+  base_args+=("$@")
+  python3 "$SCRIPT_DIR/bridge-usage.py" "${base_args[@]}"
+}
+
 case "$command" in
-  status)
-    exec python3 "$SCRIPT_DIR/bridge-usage.py" status \
-      --claude-usage-cache "$claude_usage_cache" \
-      --codex-sessions-dir "$codex_sessions_dir" \
-      "$@"
-    ;;
-  monitor)
-    exec python3 "$SCRIPT_DIR/bridge-usage.py" monitor \
-      --claude-usage-cache "$claude_usage_cache" \
-      --codex-sessions-dir "$codex_sessions_dir" \
-      --state-file "$usage_state_file" \
-      --rotation-threshold "$rotation_threshold" \
-      "$@"
+  status|monitor)
+    if [[ "$agents_explicit" -eq 1 ]]; then
+      agent_stream=""
+      agent_stream="$(bridge_usage_select_claude_agents "$agents_spec")" || exit 1
+      if [[ -n "$agent_stream" ]]; then
+        per_agent_cache_json="$(printf '%s\n' "$agent_stream" | bridge_usage_build_per_agent_payload)"
+        # Back-compat: preserve the single-controller-cache path so any
+        # downstream tooling that ignores the per-agent array still sees the
+        # legacy field unchanged.
+        legacy_single_path="$claude_usage_cache"
+      fi
+    fi
+    run_python "$command" "${forward_args[@]+"${forward_args[@]}"}"
+    rc=$?
+    exit "$rc"
     ;;
   alerts)
     exec python3 "$SCRIPT_DIR/bridge-usage.py" alerts \
       --audit-file "$BRIDGE_AUDIT_LOG" \
-      "$@"
+      "${forward_args[@]+"${forward_args[@]}"}"
     ;;
   -h|--help|help)
     usage

--- a/bridge-usage.sh
+++ b/bridge-usage.sh
@@ -199,57 +199,77 @@ cat "$file"
 #   JSON array of {agent, path, present, payload} entries. Returns the
 #   tempfile path on stdout. The tempfile is mode 0600.
 bridge_usage_build_per_agent_payload() {
-  local tmp="" agent="" path="" content="" python_args=()
+  # Issue #831 r2 (review #2104 finding 2): per-agent cache contents must NOT
+  # transit through the python3 argv. Argv is process-table-visible, has
+  # ARG_MAX limits that the prior triplet encoding could hit on a large agent
+  # roster, and crosses the isolation boundary that the 0600 tempfile was
+  # supposed to enforce. Instead, write rows to a separate 0600 intermediate
+  # file (`rows_tmp`) using a TAB-delimited <agent><TAB><path><TAB><b64-content>
+  # framing, then pass ONLY the two file paths via argv. Python streams the
+  # rows file and emits the final JSON array into the output tempfile.
+  local tmp="" rows_tmp="" agent="" path="" content=""
   tmp="$(mktemp)"
-  chmod 600 "$tmp"
+  rows_tmp="$(mktemp)"
+  chmod 600 "$tmp" "$rows_tmp"
 
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
     path="$(bridge_usage_resolve_claude_cache_path "$agent")"
     content="$(bridge_usage_read_claude_cache_for_agent "$agent" "$path")"
-    # Encode each row as agent <TAB> path <TAB> base64(content) so python can
-    # decode without worrying about embedded newlines / quotes / NULs.
-    python_args+=("$agent" "$path" "$(printf '%s' "$content" | base64 | tr -d '\n')")
+    # Line per agent: <agent><TAB><path><TAB><base64-content>. base64 keeps
+    # the encoded value newline-free (tr -d '\n'), so a literal newline
+    # terminates the row safely.
+    printf '%s\t%s\t%s\n' "$agent" "$path" "$(printf '%s' "$content" | base64 | tr -d '\n')" >>"$rows_tmp"
   done
 
-  python3 - "$tmp" "${python_args[@]+"${python_args[@]}"}" <<'PY'
+  python3 - "$tmp" "$rows_tmp" <<'PY'
 import base64
 import json
 import sys
 from pathlib import Path
 
 out_path = Path(sys.argv[1])
-items = sys.argv[2:]
+rows_path = Path(sys.argv[2])
 entries = []
-# items come in (agent, path, b64) triplets.
-for i in range(0, len(items), 3):
-    agent = items[i]
-    path = items[i + 1] if i + 1 < len(items) else ""
-    b64 = items[i + 2] if i + 2 < len(items) else ""
-    raw = ""
-    if b64:
-        try:
-            raw = base64.b64decode(b64).decode("utf-8", errors="replace")
-        except Exception:
-            raw = ""
-    parsed = None
-    present = False
-    if raw.strip():
-        try:
-            parsed = json.loads(raw)
-            present = True
-        except Exception:
-            parsed = None
-            present = False
-    entries.append({
-        "agent": agent,
-        "path": path,
-        "present": present,
-        "payload": parsed,
-    })
+
+with rows_path.open("r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        parts = line.split("\t", 2)
+        agent = parts[0] if len(parts) > 0 else ""
+        path = parts[1] if len(parts) > 1 else ""
+        b64 = parts[2] if len(parts) > 2 else ""
+        raw = ""
+        if b64:
+            try:
+                raw = base64.b64decode(b64).decode("utf-8", errors="replace")
+            except Exception:
+                raw = ""
+        parsed = None
+        present = False
+        if raw.strip():
+            try:
+                parsed = json.loads(raw)
+                present = True
+            except Exception:
+                parsed = None
+                present = False
+        entries.append({
+            "agent": agent,
+            "path": path,
+            "present": present,
+            "payload": parsed,
+        })
 
 out_path.write_text(json.dumps(entries, ensure_ascii=True), encoding="utf-8")
 PY
+
+  # Clean up the intermediate rows file regardless of python3 exit; the final
+  # payload file (`tmp`) is the caller's responsibility (returned via stdout).
+  rm -f "$rows_tmp" 2>/dev/null || true
+
   printf '%s' "$tmp"
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10486,6 +10486,13 @@ bash "$REPO_ROOT/scripts/test-stale-resume.sh"
 log "running channel-probe-isolated regression suite (issue #832)"
 bash "$REPO_ROOT/scripts/test-channel-probe-isolated.sh"
 
+# Issue #831 — usage monitor must read each Claude agent's own usage cache
+# (per-agent latching), not just the controller's $HOME. Without this, two
+# isolated agents sharing the same plan can mask each other's rotation
+# triggers.
+log "running usage-monitor-isolated regression suite (issue #831)"
+bash "$REPO_ROOT/scripts/test-usage-monitor-isolated.sh"
+
 # Issue #541 PR-A — memory-daily payload jsonl-aware migration regression.
 log "running cron-migrate-payloads smoke (issue #541 PR-A)"
 bash "$REPO_ROOT/scripts/smoke/cron-migrate-payloads.sh"

--- a/scripts/test-usage-monitor-isolated.sh
+++ b/scripts/test-usage-monitor-isolated.sh
@@ -255,6 +255,59 @@ else
   err "agent_field='$U7_AGENT_FIELD' rot_col7='$ROT_COL7' (expected agent-a / agent-a)"
 fi
 
+# --- U8: explicit per-agent mode + all entries present=false MUST NOT fall ---
+# back to controller cache (review #2104 finding 1 regression trap). Without
+# this guardrail, "monitor THESE isolated agents" silently degrades to "read
+# controller cache instead", which is exactly the original #831 blind spot:
+# an isolated agent's hidden rate-limit goes un-rotated because the daemon
+# saw a healthy controller-cache signal from a different account.
+step "U8: explicit per-agent mode + all present=false ignores legacy cache (no false rotate)"
+# Build a per-agent payload with TWO entries, both present=false (cache
+# unreadable). Provide a legacy cache pinned at 99% — would normally trigger
+# a rotation if the loader fell back. Expect zero claude snapshots + zero
+# rotation candidates.
+U8_PAYLOAD="$TMP_HOME/u8-payload.json"
+cat >"$U8_PAYLOAD" <<'EOF'
+[
+  {"agent":"agent-a","path":"/nonexistent/a.json","present":false,"payload":null},
+  {"agent":"agent-b","path":"/nonexistent/b.json","present":false,"payload":null}
+]
+EOF
+U8_LEGACY_CACHE="$TMP_HOME/u8-legacy.json"
+make_cache "$U8_LEGACY_CACHE" "subscription" 99.5 "2099-01-01T00:00:00+00:00"
+STATE_U8="$TMP_HOME/u8-state.json"
+OUT_U8="$(python3 "$ROOT_DIR/bridge-usage.py" monitor \
+  --per-agent-cache-json "$U8_PAYLOAD" \
+  --legacy-single-path "$U8_LEGACY_CACHE" \
+  --claude-usage-cache "$U8_LEGACY_CACHE" \
+  --codex-sessions-dir "$TMP_HOME/nonexistent-codex" \
+  --state-file "$STATE_U8" \
+  --rotation-threshold 99 \
+  --json)"
+U8_CLAUDE_COUNT="$(printf '%s' "$OUT_U8" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(sum(1 for s in d.get("snapshots",[]) if s.get("provider")=="claude"))')"
+U8_ROT_COUNT="$(printf '%s' "$OUT_U8" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(len(d.get("rotation_candidates") or []))')"
+if [[ "$U8_CLAUDE_COUNT" == "0" && "$U8_ROT_COUNT" == "0" ]]; then
+  ok
+else
+  err "claude_count='$U8_CLAUDE_COUNT' rot_count='$U8_ROT_COUNT' (expected 0/0; legacy cache must NOT leak when per-agent mode is explicit)"
+fi
+
+# --- U9: cache payload never appears on python3 argv (review finding 2) ------
+# The shell helper bridge_usage_build_per_agent_payload must route cache
+# contents via a 0600 intermediate file, NOT via argv. We assert this by
+# checking that the function's body does not call `python3 - "$tmp"
+# "${python_args[@]+...}"` and instead passes only two file paths.
+step "U9: payload builder routes cache content via intermediate file, not argv"
+U9_BODY="$(awk '/^bridge_usage_build_per_agent_payload\(\) \{/{c=1} c{print} c && /^\}$/{c=0}' "$ROOT_DIR/bridge-usage.sh")"
+# Must NOT pass python_args (the old argv leak idiom).
+if printf '%s' "$U9_BODY" | grep -qE 'python_args'; then
+  err "bridge_usage_build_per_agent_payload still references python_args — argv leak regression"
+elif ! printf '%s' "$U9_BODY" | grep -qE 'python3 - "\$tmp" "\$rows_tmp"'; then
+  err "bridge_usage_build_per_agent_payload should invoke python3 with exactly two file-path argv (tmp + rows_tmp)"
+else
+  ok
+fi
+
 # --- Summary ----------------------------------------------------------------
 TOTAL=$((PASS + FAIL))
 printf '\n# Issue #831 usage-monitor per-agent suite: %s/%s passed\n' "$PASS" "$TOTAL"

--- a/scripts/test-usage-monitor-isolated.sh
+++ b/scripts/test-usage-monitor-isolated.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #831 — per-agent usage monitor.
+#
+# The daemon's process_usage_monitor used to read the controller's $HOME
+# .usage-cache.json, which on an isolated install belongs to no agent. When
+# two Claude agents share the same Claude plan/account, the monitor latch
+# previously keyed by provider::account::window — so a 99% on agent-A could
+# be masked by the same key carrying a 60% from agent-B, and rotation never
+# fired. This suite verifies:
+#
+#   U1 Per-agent latching: agent-99% triggers rotation, agent-60% does not
+#      mask it; both surface in per_agent_breakdown.
+#   U2 Order independence: U1 with the iteration order swapped produces an
+#      identical rotation outcome (latch is not order-dependent).
+#   U3 Missing cache: an agent with no .usage-cache.json is skipped silently.
+#   U4 Sudo unavailable: helper rc=2 from the wrapper degrades to skip with
+#      a warn-log line on stderr, no false-rotate.
+#   U5 Back-compat: legacy single-cache invocation (no --agents flag, no
+#      --per-agent-cache-json) produces the same row shape as before.
+#   U6 set-e safety: invoking the wrapper with `set -e` in the calling
+#      script does not abort on expected non-zero rc from helper.
+#   U7 Audit attribution: rotation candidate row includes the triggering
+#      agent so the daemon's audit detail can record worst_case_agent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+PASS=0
+FAIL=0
+LAST_DESC=""
+
+step() { LAST_DESC="$*"; }
+ok() { PASS=$((PASS + 1)); printf '  PASS: %s\n' "$LAST_DESC"; }
+err() { FAIL=$((FAIL + 1)); printf '  FAIL: %s — %s\n' "$LAST_DESC" "$*" >&2; }
+
+TMP_HOME="$(mktemp -d -t agb-usage-monitor-test.XXXXXX)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+export HOME="$TMP_HOME"
+export BRIDGE_HOME="$TMP_HOME/.agent-bridge"
+mkdir -p "$BRIDGE_HOME/state/usage"
+
+# Fixture cache builder — one Claude usage cache shape with given plan name
+# and percent for the 5h window (the rotation-relevant one).
+make_cache() {
+  local out="$1" plan="$2" five_h="$3" reset_at="$4"
+  python3 - "$out" "$plan" "$five_h" "$reset_at" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+out, plan, five_h, reset_at = sys.argv[1:5]
+Path(out).parent.mkdir(parents=True, exist_ok=True)
+payload = {
+    "data": {
+        "planName": plan,
+        "fiveHour": float(five_h),
+        "fiveHourResetAt": reset_at,
+        "sevenDay": 10.0,
+        "sevenDayResetAt": reset_at,
+    }
+}
+Path(out).write_text(json.dumps(payload), encoding="utf-8")
+PY
+}
+
+# Build a synthetic per-agent payload array (the on-disk shape bridge-usage.sh
+# emits via bridge_usage_build_per_agent_payload). We bypass the bash wrapper
+# here so the python latching logic gets exercised directly without needing a
+# real isolation rig.
+make_per_agent_payload() {
+  local out="$1"
+  shift
+  # Args: agent path
+  python3 - "$out" "$@" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+out = sys.argv[1]
+items = sys.argv[2:]
+entries = []
+for i in range(0, len(items), 2):
+    agent = items[i]
+    path = items[i + 1]
+    parsed = None
+    present = False
+    p = Path(path)
+    if p.is_file():
+        try:
+            parsed = json.loads(p.read_text(encoding="utf-8"))
+            present = True
+        except Exception:
+            parsed = None
+            present = False
+    entries.append({"agent": agent, "path": path, "present": present, "payload": parsed})
+Path(out).write_text(json.dumps(entries), encoding="utf-8")
+PY
+}
+
+run_monitor() {
+  local state="$1" per_agent="$2"; shift 2
+  python3 "$ROOT_DIR/bridge-usage.py" monitor \
+    --claude-usage-cache "$TMP_HOME/nonexistent-controller-cache.json" \
+    --codex-sessions-dir "$TMP_HOME/nonexistent-codex-sessions" \
+    --state-file "$state" \
+    --rotation-threshold 99 \
+    --per-agent-cache-json "$per_agent" \
+    --json "$@"
+}
+
+# --- U1: agent-A=99% triggers rotation; agent-B=60% does not mask -----------
+step "U1: per-agent latching surfaces 99% rotation on agent-A regardless of agent-B"
+CACHE_A="$TMP_HOME/u1/agent-a/.claude/plugins/claude-hud/.usage-cache.json"
+CACHE_B="$TMP_HOME/u1/agent-b/.claude/plugins/claude-hud/.usage-cache.json"
+make_cache "$CACHE_A" "subscription" 99.0 "2099-01-01T00:00:00+00:00"
+make_cache "$CACHE_B" "subscription" 60.0 "2099-01-01T00:00:00+00:00"
+PAYLOAD_U1="$TMP_HOME/u1-payload.json"
+make_per_agent_payload "$PAYLOAD_U1" "agent-a" "$CACHE_A" "agent-b" "$CACHE_B"
+STATE_U1="$TMP_HOME/u1-state.json"
+
+OUT_U1="$(run_monitor "$STATE_U1" "$PAYLOAD_U1")"
+U1_AGENT="$(printf '%s' "$OUT_U1" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(d.get("worst_case_agent") or "")')"
+U1_ROT_COUNT="$(printf '%s' "$OUT_U1" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(len(d.get("rotation_candidates") or []))')"
+U1_BREAKDOWN_LEN="$(printf '%s' "$OUT_U1" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(len(d.get("per_agent_breakdown") or []))')"
+if [[ "$U1_AGENT" == "agent-a" && "$U1_ROT_COUNT" == "1" && "$U1_BREAKDOWN_LEN" -ge 2 ]]; then
+  ok
+else
+  err "worst_case_agent='$U1_AGENT' rot_count='$U1_ROT_COUNT' breakdown_len='$U1_BREAKDOWN_LEN' (expected agent-a / 1 / >=2)"
+fi
+
+# --- U2: swap iteration order -- same outcome -------------------------------
+step "U2: per-agent latch is order-independent (swap agent order, same outcome)"
+PAYLOAD_U2="$TMP_HOME/u2-payload.json"
+# Build with agent-b first this time.
+make_per_agent_payload "$PAYLOAD_U2" "agent-b" "$CACHE_B" "agent-a" "$CACHE_A"
+STATE_U2="$TMP_HOME/u2-state.json"
+OUT_U2="$(run_monitor "$STATE_U2" "$PAYLOAD_U2")"
+U2_AGENT="$(printf '%s' "$OUT_U2" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(d.get("worst_case_agent") or "")')"
+U2_ROT_COUNT="$(printf '%s' "$OUT_U2" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(len(d.get("rotation_candidates") or []))')"
+if [[ "$U2_AGENT" == "agent-a" && "$U2_ROT_COUNT" == "1" ]]; then
+  ok
+else
+  err "worst_case_agent='$U2_AGENT' rot_count='$U2_ROT_COUNT' (expected agent-a / 1)"
+fi
+
+# --- U3: missing cache for one agent — skipped, others continue -------------
+step "U3: missing per-agent cache file is skipped without false-rotate"
+CACHE_C_PRESENT="$TMP_HOME/u3/agent-c/.claude/plugins/claude-hud/.usage-cache.json"
+CACHE_D_MISSING="$TMP_HOME/u3/agent-d/.claude/plugins/claude-hud/.usage-cache.json"
+make_cache "$CACHE_C_PRESENT" "subscription" 50.0 "2099-01-01T00:00:00+00:00"
+# Don't create CACHE_D_MISSING.
+PAYLOAD_U3="$TMP_HOME/u3-payload.json"
+make_per_agent_payload "$PAYLOAD_U3" "agent-c" "$CACHE_C_PRESENT" "agent-d" "$CACHE_D_MISSING"
+STATE_U3="$TMP_HOME/u3-state.json"
+OUT_U3="$(run_monitor "$STATE_U3" "$PAYLOAD_U3")"
+U3_SNAP_AGENTS="$(printf '%s' "$OUT_U3" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(",".join(sorted({s.get("agent","") for s in d.get("snapshots",[]) if s.get("agent")})))')"
+U3_ROT_COUNT="$(printf '%s' "$OUT_U3" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(len(d.get("rotation_candidates") or []))')"
+if [[ "$U3_SNAP_AGENTS" == "agent-c" && "$U3_ROT_COUNT" == "0" ]]; then
+  ok
+else
+  err "snap_agents='$U3_SNAP_AGENTS' rot_count='$U3_ROT_COUNT' (expected agent-c / 0)"
+fi
+
+# --- U4: sudo unavailable from wrapper -> agent skipped, no false rotate ----
+# Exercise the bash wrapper helper bridge_usage_read_claude_cache_for_agent
+# with a stub for bridge_isolation_can_sudo_to_agent returning 2.
+step "U4: wrapper degrades to skip-with-warn when isolated agent has no sudo"
+WRAPPER_TEST="$TMP_HOME/u4-wrapper.sh"
+cat >"$WRAPPER_TEST" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$ROOT_DIR"
+# Stub the isolation helpers so we don't need real sudo.
+bridge_agent_linux_user_isolation_effective() { return 0; }
+bridge_agent_os_user() { printf 'fake-user'; }
+bridge_isolation_can_sudo_to_agent() { return 2; }
+bridge_isolation_run_as_agent_user_via_bash() { return 2; }
+HOME="$TMP_HOME/u4-home"
+# Extract just the wrapper function.
+awk '/^bridge_usage_read_claude_cache_for_agent\(\) \{/{c=1} c{print} c && /^\}\$/{c=0}' "$ROOT_DIR/bridge-usage.sh" >"$TMP_HOME/u4-extract.sh"
+# shellcheck source=/dev/null
+source "$TMP_HOME/u4-extract.sh"
+out=\$(bridge_usage_read_claude_cache_for_agent agent-x /nonexistent/path.json 2>"$TMP_HOME/u4-stderr")
+printf 'STDOUT=[%s]\n' "\$out"
+printf 'STDERR='; cat "$TMP_HOME/u4-stderr"
+EOF
+chmod +x "$WRAPPER_TEST"
+U4_OUT="$(bash "$WRAPPER_TEST")"
+if printf '%s' "$U4_OUT" | grep -q "no-passwordless-sudo" && printf '%s' "$U4_OUT" | grep -q 'STDOUT=\[\]'; then
+  ok
+else
+  err "wrapper output unexpected: $U4_OUT"
+fi
+
+# --- U5: legacy single-cache call (no --agents, no --per-agent) -------------
+step "U5: legacy single-cache invocation produces snapshots from controller cache"
+LEGACY_CACHE="$TMP_HOME/legacy-controller-cache.json"
+make_cache "$LEGACY_CACHE" "subscription" 88.0 "2099-01-01T00:00:00+00:00"
+STATE_U5="$TMP_HOME/u5-state.json"
+OUT_U5="$(python3 "$ROOT_DIR/bridge-usage.py" monitor \
+  --claude-usage-cache "$LEGACY_CACHE" \
+  --codex-sessions-dir "$TMP_HOME/nonexistent-codex" \
+  --state-file "$STATE_U5" \
+  --rotation-threshold 99 \
+  --json)"
+U5_CLAUDE_COUNT="$(printf '%s' "$OUT_U5" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print(sum(1 for s in d.get("snapshots",[]) if s.get("provider")=="claude"))')"
+U5_WCA_PRESENT="$(printf '%s' "$OUT_U5" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); print("worst_case_agent" in d)')"
+if [[ "$U5_CLAUDE_COUNT" == "2" && "$U5_WCA_PRESENT" == "True" ]]; then
+  ok
+else
+  err "claude_count='$U5_CLAUDE_COUNT' worst_case_agent_field='$U5_WCA_PRESENT' (expected 2 / True)"
+fi
+
+# --- U6: set-e safety on the wrapper helper ---------------------------------
+step "U6: bridge_usage_read_claude_cache_for_agent under set -e does not abort"
+SETE_TEST="$TMP_HOME/u6-set-e.sh"
+cat >"$SETE_TEST" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+# Stub helpers so the function takes the sudo_rc=2 branch.
+bridge_agent_linux_user_isolation_effective() { return 0; }
+bridge_agent_os_user() { printf 'fake-user'; }
+bridge_isolation_can_sudo_to_agent() { return 2; }
+bridge_isolation_run_as_agent_user_via_bash() { return 2; }
+HOME="$TMP_HOME/u6-home"
+awk '/^bridge_usage_read_claude_cache_for_agent\(\) \{/{c=1} c{print} c && /^\}\$/{c=0}' "$ROOT_DIR/bridge-usage.sh" >"$TMP_HOME/u6-extract.sh"
+# shellcheck source=/dev/null
+source "$TMP_HOME/u6-extract.sh"
+# This MUST NOT abort under set -e even though the helper internally
+# captures non-zero rc from sub-calls.
+bridge_usage_read_claude_cache_for_agent agent-x /nonexistent/path.json >/dev/null 2>&1
+echo "survived"
+EOF
+chmod +x "$SETE_TEST"
+U6_OUT="$(bash "$SETE_TEST" 2>&1 || printf 'ABORTED rc=%s' "$?")"
+if [[ "$U6_OUT" == "survived" ]]; then
+  ok
+else
+  err "set -e wrapper output: '$U6_OUT'"
+fi
+
+# --- U7: rotation candidate row includes worst-case agent attribution -------
+step "U7: rotation candidate carries agent identity for audit attribution"
+U7_AGENT_FIELD="$(printf '%s' "$OUT_U1" | python3 -c 'import sys,json; d=json.loads(sys.stdin.read()); rc=d.get("rotation_candidates") or []; print(rc[0].get("agent") or rc[0].get("worst_case_agent") or "" if rc else "")')"
+# Also exercise the daemon-helpers tabular extractor: the agent column must
+# be column 7 (0-indexed 6) so the bash loop reads it correctly.
+ROT_ROW="$(python3 "$ROOT_DIR/bridge-daemon-helpers.py" usage-rotation-candidates-parse "$OUT_U1")"
+ROT_COL7="$(printf '%s' "$ROT_ROW" | awk -F'\t' '{print $7}')"
+if [[ "$U7_AGENT_FIELD" == "agent-a" && "$ROT_COL7" == "agent-a" ]]; then
+  ok
+else
+  err "agent_field='$U7_AGENT_FIELD' rot_col7='$ROT_COL7' (expected agent-a / agent-a)"
+fi
+
+# --- Summary ----------------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+printf '\n# Issue #831 usage-monitor per-agent suite: %s/%s passed\n' "$PASS" "$TOTAL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

The usage monitor used to read **only** the controller's `$HOME/.claude/plugins/claude-hud/.usage-cache.json`. On any install where Claude agents run in linux-user isolation (their HUD cache lives under the per-agent home), the controller's path is empty and the daemon never sees the real per-agent usage curve. Two agents sharing one Claude plan would also mask each other's rotation triggers because the monitor latch key was `provider::account::window` (no agent identity), so a 99% on agent-A could be silently overwritten by a 60% on agent-B in the same poll.

This PR:

- Adds `--agents <static|all|csv>` to `bridge-usage.sh` (mirrors the `bridge-auth.sh claude-token sync` convention; default `static`). For each selected Claude agent, the wrapper resolves that agent's HUD cache path under the agent's home, reads it via the controller UID when possible, and falls back to `bridge_isolation_run_as_agent_user_via_bash` (the helper added in #836) when the file is unreadable to the controller but the agent is in linux-user isolation and the sudoers allowlist is present.
- The per-agent payload array is serialized to a 0600 tempfile and passed to `bridge-usage.py monitor --per-agent-cache-json <path>`. Legacy single-controller invocations still work via `--legacy-single-path` (and via the no-flag fallback) so existing callers see no behavior change.
- `bridge-usage.py` tags each Claude snapshot with `agent_id`, and the monitor latch key becomes `provider::account::window::agent` so per-agent rotation state is independently latched. Rotation candidates surface `worst_case_agent`; the operator-facing JSON envelope adds `per_agent_breakdown` (sorted desc by `used_percent`).
- `bridge-daemon.sh:1062` now passes `--agents "${BRIDGE_USAGE_MONITOR_AGENTS:-static}"` and records the triggering agent + `worst_case_agent` in `usage_alert` / `claude_token_rotation` audit rows.
- `bridge-daemon-helpers.py` extends the tabular parses (`usage-alert-parse`, `usage-rotation-candidates-parse`) to emit `agent` between `source` and `message`; the daemon shell loop reads it into a new variable.

Every isolation-helper call uses the `cmd || rc=$?` capture pattern so `set -e` cannot abort the wrapper before the rc is inspected (the bug that bit PR #836's first round in CI).

Closes: #831

## Files touched

- `bridge-usage.sh`
- `bridge-usage.py`
- `bridge-daemon.sh`
- `bridge-daemon-helpers.py`
- `scripts/smoke-test.sh`
- `scripts/test-usage-monitor-isolated.sh` (new)

## Test plan

- [x] `bash -n` on all touched shell files
- [x] `python3 -c "import ast; ast.parse(...)"` on all touched python files
- [x] `shellcheck --severity=warning bridge-usage.sh bridge-daemon.sh lib/*.sh` — clean
- [x] `scripts/test-usage-monitor-isolated.sh` — 7/7 (U1–U7)
- [x] `scripts/smoke-test.sh` (see CI)

### Regression suite (`scripts/test-usage-monitor-isolated.sh`)

| Case | Scenario |
| --- | --- |
| U1 | Two isolated agents, same plan, 99% vs 60% — 99% triggers rotation; 60% does NOT mask it; both surface in per_agent_breakdown |
| U2 | Same as U1 with swapped iteration order — identical outcome (latch is order-independent) |
| U3 | One agent's cache missing entirely — skipped silently, no false-rotate |
| U4 | Isolated agent has no passwordless sudo — wrapper degrades to warn-log + skip, no false-rotate |
| U5 | Legacy single-cache call (no `--agents`, no `--per-agent-cache-json`) — back-compat preserved |
| U6 | `set -e` safety on `bridge_usage_read_claude_cache_for_agent` — no abort on expected non-zero rc |
| U7 | Rotation candidate row carries triggering agent for audit attribution |

## Out of scope

- No `bridge_guard*` / `BUILTIN_SCAN_RULES` changes (prompt-guard disabled on operator install).
- No `VERSION` / `CHANGELOG.md` bump (per wave brief — release PR is separate).
- No change to `bridge-auth.sh` rotation logic — the monitor only flags; rotation itself is unchanged.
