### PR TITLE
fix(isolation): channel dotenv mask::r-- runtime self-heal (#851)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3552,15 +3552,24 @@ process_channel_health() {
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do
     [[ -z "$agent" ]] && continue
 
-    # Issue #851: when an isolated agent's channel dotenv shows
-    # `auth=unreadable` (the v0.11.0+ runtime regression where plugin
-    # writes silently revert the ACL mask to `---`), re-assert the
-    # contracted dotenv ACL before reporting. The helper is idempotent
-    # on a healthy file. Only the named-user + mask drift is fixed
-    # here — true "missing token" / "missing access.json" reasons fall
-    # through to bridge_report_channel_health_miss unchanged. Disable
-    # via BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL=0.
-    if [[ "${BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL:-1}" == "1" ]] \
+    # Issue #851 (r2 stop-gap classification): when an isolated agent's
+    # channel dotenv shows `auth=unreadable` (the v0.11.0+ runtime
+    # regression where plugin writes silently revert the ACL mask to
+    # `---`), re-assert the contracted dotenv ACL before reporting. The
+    # helper is idempotent on a healthy file. Only the named-user + mask
+    # drift is fixed here — true "missing token" / "missing access.json"
+    # reasons fall through to bridge_report_channel_health_miss
+    # unchanged.
+    #
+    # r2 codex review (PR #855): the operator + daemon concurrent
+    # re-assert path is a known race that can produce a silent
+    # half-broken ACL. Operator decision: ship the pre-launch repair
+    # (bridge-start.sh) as the primary remediation and leave the daemon
+    # path OFF BY DEFAULT until the long-term controller-blind redesign
+    # (umbrella issue, see PR #855 description) removes the surface.
+    # Operators who want the daemon hook may opt in with
+    # BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL=1.
+    if [[ "${BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL:-0}" == "1" ]] \
         && command -v bridge_isolation_v2_apply_channel_state_dotenv_acl >/dev/null 2>&1 \
         && command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
         && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -3551,6 +3551,28 @@ process_channel_health() {
   [[ "${BRIDGE_CHANNEL_HEALTH_ENABLED:-1}" == "1" ]] || return 1
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do
     [[ -z "$agent" ]] && continue
+
+    # Issue #851: when an isolated agent's channel dotenv shows
+    # `auth=unreadable` (the v0.11.0+ runtime regression where plugin
+    # writes silently revert the ACL mask to `---`), re-assert the
+    # contracted dotenv ACL before reporting. The helper is idempotent
+    # on a healthy file. Only the named-user + mask drift is fixed
+    # here — true "missing token" / "missing access.json" reasons fall
+    # through to bridge_report_channel_health_miss unchanged. Disable
+    # via BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL=0.
+    if [[ "${BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL:-1}" == "1" ]] \
+        && command -v bridge_isolation_v2_apply_channel_state_dotenv_acl >/dev/null 2>&1 \
+        && command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+        && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+      local _ch_reason=""
+      _ch_reason="$(bridge_agent_channel_status_reason "$agent" 2>/dev/null || true)"
+      case "$_ch_reason" in
+        *unreadable:*)
+          bridge_isolation_v2_apply_channel_state_dotenv_acl "$agent" >/dev/null 2>&1 || true
+          ;;
+      esac
+    fi
+
     bridge_report_channel_health_miss "$agent" || true
   done
 }

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -415,7 +415,23 @@ if [[ $CONTINUE_EXPLICIT -eq 1 && "$CONTINUE_MODE" == "0" ]]; then
   unset _persisted_session_id
 fi
 
+# Issue #851 r2 codex finding 3 — the pre-launch ACL re-assert MUST run
+# BEFORE the channel-status check below. Otherwise, when the dotenv mask
+# has reverted to `---` (the v0.11.0+ runtime regression this PR addresses)
+# the status check returns `unreadable:` and bridge_die fires before the
+# repair ever runs. The status helper recomputes off live filesystem state
+# (no cache — see bridge_agent_channel_status_reason in lib/bridge-agents.sh)
+# so re-asserting the ACL then re-running the check picks up the healed
+# state. Idempotent on a healthy file; warns and continues on a non-Linux
+# host. Suppress operator-visible noise — the helper logs via bridge_warn
+# when something actually fails, and the post-launch verify still surfaces
+# a hard channel-auth failure separately.
 if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
+  if ! bridge_isolation_disabled_by_env \
+      && bridge_agent_linux_user_isolation_effective "$AGENT" \
+      && command -v bridge_isolation_v2_apply_channel_state_dotenv_acl >/dev/null 2>&1; then
+    bridge_isolation_v2_apply_channel_state_dotenv_acl "$AGENT" >/dev/null 2>&1 || true
+  fi
   CHANNEL_REASON="$(bridge_agent_channel_status_reason "$AGENT")"
   if [[ -n "$CHANNEL_REASON" ]]; then
     if bridge_agent_should_stop_on_attached_clean_exit "$AGENT"; then
@@ -432,17 +448,6 @@ if bridge_isolation_disabled_by_env; then
 elif bridge_agent_linux_user_isolation_effective "$AGENT"; then
   AGENT_ENV_FILE="$(bridge_agent_linux_env_file "$AGENT")"
   bridge_write_linux_agent_env_file "$AGENT" "$AGENT_ENV_FILE"
-  # Issue #851: pre-launch re-assert of the channel dotenv ACL. The
-  # daemon's health loop also self-heals on observed drift, but an
-  # operator running `agent start` should not have to wait a daemon
-  # cycle when the dotenv mask has reverted to `---` since the last
-  # session shutdown. Idempotent on a healthy file; warns and continues
-  # on a non-Linux host. Suppress operator-visible noise — the helper
-  # logs via bridge_warn when something actually fails, and the post
-  # launch verify still surfaces a hard channel-auth failure separately.
-  if command -v bridge_isolation_v2_apply_channel_state_dotenv_acl >/dev/null 2>&1; then
-    bridge_isolation_v2_apply_channel_state_dotenv_acl "$AGENT" >/dev/null 2>&1 || true
-  fi
 fi
 
 SESSION_CMD="$(bridge_join_quoted "$BRIDGE_BASH_BIN" "$RUNNER" "$AGENT")"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -432,6 +432,17 @@ if bridge_isolation_disabled_by_env; then
 elif bridge_agent_linux_user_isolation_effective "$AGENT"; then
   AGENT_ENV_FILE="$(bridge_agent_linux_env_file "$AGENT")"
   bridge_write_linux_agent_env_file "$AGENT" "$AGENT_ENV_FILE"
+  # Issue #851: pre-launch re-assert of the channel dotenv ACL. The
+  # daemon's health loop also self-heals on observed drift, but an
+  # operator running `agent start` should not have to wait a daemon
+  # cycle when the dotenv mask has reverted to `---` since the last
+  # session shutdown. Idempotent on a healthy file; warns and continues
+  # on a non-Linux host. Suppress operator-visible noise — the helper
+  # logs via bridge_warn when something actually fails, and the post
+  # launch verify still surfaces a hard channel-auth failure separately.
+  if command -v bridge_isolation_v2_apply_channel_state_dotenv_acl >/dev/null 2>&1; then
+    bridge_isolation_v2_apply_channel_state_dotenv_acl "$AGENT" >/dev/null 2>&1 || true
+  fi
 fi
 
 SESSION_CMD="$(bridge_join_quoted "$BRIDGE_BASH_BIN" "$RUNNER" "$AGENT")"

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -2069,14 +2069,20 @@ bridge_isolation_v2_apply_channel_state_dotenv_acl() {
   }
 
   local iso_user="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}"
-  # Sanity-resolve the controller user — the helper only needs to confirm
-  # one is available (mirrors the credentials helper preflight); the chown
-  # target on channel dotenvs is the isolated UID owning the agent workdir,
-  # not the controller, so we do not consume the resolved value here.
-  if ! bridge_isolation_v2_controller_user >/dev/null 2>&1; then
+  # r2 codex finding 1 — KEEP the resolved controller user. Channel dotenvs
+  # are owned by the isolated UID (the agent owns its own workdir), so the
+  # controller needs a named-user `u:<ctrl>:r--` ACL grant to read the file.
+  # r1 resolved the controller for a preflight sanity check and then dropped
+  # it, which meant the stale-strip below removed any pre-existing controller
+  # grant and the final setfacl re-asserted only roster agents. Net effect:
+  # after one repair call the controller could no longer read the dotenv —
+  # a regression strictly worse than the original mask::--- it was repairing.
+  # Mirrors the credentials helper at :1796-1799.
+  local ctrl_user="${SUDO_USER:-${USER:-${LOGNAME:-}}}"
+  [[ -n "$ctrl_user" ]] || {
     bridge_warn "apply_channel_state_dotenv_acl: cannot resolve controller user"
     return 1
-  fi
+  }
 
   # Build the roster-aware set of UIDs that legitimately hold a r-- grant
   # on channel dotenv files. Mirrors the credentials helper's roster
@@ -2092,6 +2098,11 @@ bridge_isolation_v2_apply_channel_state_dotenv_acl() {
   fi
   # Always include the agent being applied for (fresh-install transient).
   roster_iso_users+="${iso_user}"$'\n'
+  # r2 finding 1 — include the controller user in the keep-and-grant set
+  # so the stale-strip never removes it AND the final setfacl re-grants
+  # it. Single source of truth: both the strip-skip-list (via grep -Fxq)
+  # and the apply-grant-list iterate this string.
+  roster_iso_users+="${ctrl_user}"$'\n'
 
   # Resolve the agent's workdir once so the path guard can refuse any
   # provider state dir that does not live under it.

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -2031,6 +2031,180 @@ bridge_isolation_v2_check_controller_credentials_read_grant() {
   return 0
 }
 
+bridge_isolation_v2_apply_channel_state_dotenv_acl() {
+  # Issue #851 (v0.11.0+ regression): runtime channel-state writes from
+  # Teams/MS365/etc. plugins inherit the controller's umask=077 and
+  # silently revert the dotenv's POSIX ACL `mask::---`, which then renders
+  # the named-user `r--` grant as `#effective:---`. Controller-side reads
+  # then fail and the next `agent start` blocks with
+  # `auth=unreadable ready=no`.
+  #
+  # #778 fixed the migration path. This helper covers the runtime path:
+  # it re-asserts (a) file mode, (b) one named-user r-- grant per roster
+  # isolated agent + controller, (c) mask::r--, (d) other::--- across
+  # every channel dotenv under <agent_home>/.{teams,ms365,discord,
+  # telegram,mattermost}/.env that already exists.
+  #
+  # Failure semantics:
+  #   - non-Linux host (no setfacl): warn-skip, return 0
+  #   - no dotenv exists for any provider: return 0 (no-op)
+  #   - one provider's repair fails but at least one other succeeded: warn,
+  #     return 0 (best-effort self-heal)
+  #   - every existing dotenv's repair failed: return 1
+  #
+  # Path guard: refuse symlinks and refuse paths that do not resolve
+  # under the agent's workdir + the known provider subdir.
+  local agent="$1" file_mode="${2:-0640}"
+  [[ -n "$agent" ]] || {
+    bridge_warn "apply_channel_state_dotenv_acl: agent required"
+    return 1
+  }
+  command -v setfacl >/dev/null 2>&1 || {
+    bridge_warn "apply_channel_state_dotenv_acl: setfacl not available; skipping (non-Linux host)"
+    return 0
+  }
+  command -v bridge_channel_state_dir_for_item >/dev/null 2>&1 || {
+    bridge_warn "apply_channel_state_dotenv_acl: bridge_channel_state_dir_for_item not loaded (lib/bridge-agents.sh not sourced)"
+    return 1
+  }
+
+  local iso_user="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}"
+  # Sanity-resolve the controller user — the helper only needs to confirm
+  # one is available (mirrors the credentials helper preflight); the chown
+  # target on channel dotenvs is the isolated UID owning the agent workdir,
+  # not the controller, so we do not consume the resolved value here.
+  if ! bridge_isolation_v2_controller_user >/dev/null 2>&1; then
+    bridge_warn "apply_channel_state_dotenv_acl: cannot resolve controller user"
+    return 1
+  fi
+
+  # Build the roster-aware set of UIDs that legitimately hold a r-- grant
+  # on channel dotenv files. Mirrors the credentials helper's roster
+  # logic — the strip step uses this set to keep only current isolated
+  # agents' grants and the apply step grants every roster member.
+  local roster_iso_users=""
+  if command -v bridge_isolation_v2_reapply_eligible_agents >/dev/null 2>&1; then
+    local _ra
+    while IFS= read -r _ra; do
+      [[ -n "$_ra" ]] || continue
+      roster_iso_users+="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${_ra}"$'\n'
+    done < <(bridge_isolation_v2_reapply_eligible_agents 2>/dev/null || true)
+  fi
+  # Always include the agent being applied for (fresh-install transient).
+  roster_iso_users+="${iso_user}"$'\n'
+
+  # Resolve the agent's workdir once so the path guard can refuse any
+  # provider state dir that does not live under it.
+  local agent_workdir=""
+  if command -v bridge_agent_workdir >/dev/null 2>&1; then
+    agent_workdir="$(bridge_agent_workdir "$agent" 2>/dev/null || true)"
+  fi
+
+  local providers=(plugin:teams plugin:ms365 plugin:discord plugin:telegram plugin:mattermost)
+  local existed=0 repaired=0
+  local provider state_dir dotenv
+
+  for provider in "${providers[@]}"; do
+    state_dir="$(bridge_channel_state_dir_for_item "$agent" "$provider" 2>/dev/null || true)"
+    [[ -n "$state_dir" ]] || continue
+    dotenv="$state_dir/.env"
+    [[ -e "$dotenv" ]] || continue
+    existed=$((existed + 1))
+
+    # Refuse symlinks (the credentials helper does the same — a symlink at
+    # the dotenv path is either a misconfigured deploy or a tampering
+    # attempt; we will not chmod/setfacl through it).
+    if [[ -L "$dotenv" ]]; then
+      bridge_warn "apply_channel_state_dotenv_acl: refusing symlink at $dotenv (path guard)"
+      continue
+    fi
+    # Refuse anything that is not a regular file.
+    [[ -f "$dotenv" ]] || {
+      bridge_warn "apply_channel_state_dotenv_acl: $dotenv is not a regular file; skipping"
+      continue
+    }
+    # Path guard: the dotenv must resolve to <agent_workdir>/.<provider>/.env
+    # (or, when agent_workdir is unavailable, at least live in a `.<provider>/`
+    # leaf so we never operate on an arbitrary path returned by a stub).
+    local provider_short="${provider#plugin:}"
+    local parent_basename
+    parent_basename="$(basename "$(dirname "$dotenv")")"
+    if [[ "$parent_basename" != ".${provider_short}" ]]; then
+      bridge_warn "apply_channel_state_dotenv_acl: $dotenv parent is not .${provider_short} (path guard); skipping"
+      continue
+    fi
+    if [[ -n "$agent_workdir" ]]; then
+      case "$dotenv" in
+        "$agent_workdir/.${provider_short}/.env")
+          : # ok
+          ;;
+        *)
+          bridge_warn "apply_channel_state_dotenv_acl: $dotenv outside $agent_workdir/.${provider_short}/ (path guard); skipping"
+          continue
+          ;;
+      esac
+    fi
+
+    # Step 1: chmod to the contracted file mode (0640 historically — controller
+    # writes, agent group reads via the named-user ACL mediated by mask::r--).
+    if ! _bridge_isolation_v2_run_root_or_sudo chmod "$file_mode" "$dotenv" 2>/dev/null; then
+      bridge_warn "apply_channel_state_dotenv_acl: chmod $file_mode on $dotenv failed"
+      continue
+    fi
+
+    # Step 2: roster-aware strip of stale named-user grants. Same pattern
+    # as bridge_isolation_v2_apply_controller_credentials_read_grant.
+    if command -v getfacl >/dev/null 2>&1; then
+      local existing_named
+      existing_named="$(getfacl -p "$dotenv" 2>/dev/null \
+        | awk -F: '$1=="user" && $2!="" {print $2}')"
+      if [[ -n "$existing_named" ]]; then
+        local strip_failed=0 stale
+        while IFS= read -r stale; do
+          [[ -n "$stale" ]] || continue
+          if printf '%s' "$roster_iso_users" | grep -Fxq "$stale"; then
+            continue
+          fi
+          if ! _bridge_isolation_v2_run_root_or_sudo \
+              setfacl -x "u:${stale}" "$dotenv" 2>/dev/null; then
+            bridge_warn "apply_channel_state_dotenv_acl: setfacl -x u:${stale} on $dotenv failed"
+            strip_failed=1
+            break
+          fi
+        done < <(printf '%s\n' "$existing_named")
+        if (( strip_failed == 1 )); then
+          continue
+        fi
+      fi
+    fi
+
+    # Step 3: re-grant every roster isolated UID r-- and re-assert the mask
+    # so the named entries are effective. o::--- closes world reads.
+    local _setfacl_cmd=(setfacl)
+    local _ru
+    while IFS= read -r _ru; do
+      [[ -n "$_ru" ]] || continue
+      _setfacl_cmd+=("-m" "u:${_ru}:r--")
+    done < <(printf '%s\n' "$roster_iso_users")
+    _setfacl_cmd+=("-m" "m::r--" "-m" "o::---" "$dotenv")
+    if ! _bridge_isolation_v2_run_root_or_sudo "${_setfacl_cmd[@]}" 2>/dev/null; then
+      bridge_warn "apply_channel_state_dotenv_acl: setfacl roster grants + m::r-- + o::--- on $dotenv failed"
+      continue
+    fi
+    repaired=$((repaired + 1))
+  done
+
+  # No dotenv existed → idempotent no-op success.
+  if (( existed == 0 )); then
+    return 0
+  fi
+  # At least one existed AND every repair failed → total failure.
+  if (( repaired == 0 )); then
+    return 1
+  fi
+  return 0
+}
+
 bridge_isolation_v2_write_agent_state_marker() {
   # Atomic-ish writer for daemon-side per-agent state markers
   # (idle-since, manual-stop, missing-marker-retries, etc.). Ensures the

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10502,6 +10502,14 @@ bash "$REPO_ROOT/scripts/test-stale-resume.sh"
 log "running channel-probe-isolated regression suite (issue #832)"
 bash "$REPO_ROOT/scripts/test-channel-probe-isolated.sh"
 
+# Issue #851 — runtime channel dotenv ACL mask reverts to --- after plugin
+# writes inherit the controller umask. Pins the new self-heal helper
+# bridge_isolation_v2_apply_channel_state_dotenv_acl that the daemon health
+# loop + pre-launch path call when an isolated agent's dotenv flips to
+# auth=unreadable.
+log "running channel-dotenv-mask-repair regression suite (issue #851)"
+bash "$REPO_ROOT/scripts/test-channel-dotenv-mask-repair.sh"
+
 # Issue #831 — usage monitor must read each Claude agent's own usage cache
 # (per-agent latching), not just the controller's $HOME. Without this, two
 # isolated agents sharing the same plan can mask each other's rotation

--- a/scripts/test-channel-dotenv-mask-repair.sh
+++ b/scripts/test-channel-dotenv-mask-repair.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Issue #851: regression coverage for the runtime channel dotenv ACL repair
+# helper bridge_isolation_v2_apply_channel_state_dotenv_acl.
+#
+# Symptom this test pins:
+#   After v0.11.0 runtime channel writes (Teams/MS365 plugin writes
+#   messages.jsonl / conversations.json), the dotenv ACL mask reverts to
+#   the empty triple. The named-user r-- grant then renders as
+#   effective:--- and controller reads fail, blocking agent start with
+#   auth=unreadable ready=no.
+#
+# What this fixture asserts:
+#   1. The helper restores the mask to r-- and re-effective the named-user
+#      grant.
+#   2. The helper is a no-op success when no dotenv exists for any provider.
+#   3. The helper is roster-aware: a stale named-user grant from an
+#      uninstalled / renamed agent is stripped; current roster members keep
+#      their grants.
+#   4. On a non-Linux host (no setfacl), the helper warns and returns 0.
+#
+# Cross-platform behavior:
+#   - Linux + setfacl + getfacl present: run the full regression matrix.
+#   - macOS / no setfacl: only the non-Linux graceful-skip case runs
+#     (cases 1-3 are marked SKIP); the test still exits 0 so smoke-test.sh
+#     stays green on developer macOS workstations.
+#
+# Runs in an isolated HOME / BRIDGE_HOME and never touches the live
+# runtime. Stubs the sudo dispatcher so the test does not require root.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+PASS=0
+FAIL=0
+SKIP=0
+LAST_DESC=""
+
+step() { LAST_DESC="$*"; }
+ok()   { PASS=$((PASS + 1)); printf '  PASS: %s\n' "$LAST_DESC"; }
+err()  { FAIL=$((FAIL + 1)); printf '  FAIL: %s -- %s\n' "$LAST_DESC" "$*" >&2; }
+skip() { SKIP=$((SKIP + 1)); printf '  SKIP: %s -- %s\n' "$LAST_DESC" "$*"; }
+
+TMP_HOME="$(mktemp -d -t agb-dotenv-mask-test.XXXXXX)"
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+export HOME="$TMP_HOME"
+export BRIDGE_HOME="$TMP_HOME/.agent-bridge"
+mkdir -p "$BRIDGE_HOME"
+
+# ---------------------------------------------------------------------------
+# 1. Extract the helper under test + write a self-contained stub harness.
+# ---------------------------------------------------------------------------
+# We do not source the full bridge-lib because that would require a roster,
+# matrix bootstrap, controller user, etc. Pull just the function body and
+# wire stubs for its few dependencies. The stub helpers are appended via
+# printf rather than a heredoc to avoid the documented bash 5.3 heredoc
+# class (footgun #11).
+
+EXTRACT_TMP="$TMP_HOME/extract.sh"
+awk '
+  /^bridge_isolation_v2_apply_channel_state_dotenv_acl\(\) \{/ {
+    copy = 1
+  }
+  copy { print }
+  copy && /^\}$/ { copy = 0; print "" }
+' "$ROOT_DIR/lib/bridge-isolation-v2.sh" >"$EXTRACT_TMP"
+
+# Sanity: extraction succeeded.
+if ! grep -q '^bridge_isolation_v2_apply_channel_state_dotenv_acl' "$EXTRACT_TMP"; then
+  printf '  FAIL: could not extract helper from lib/bridge-isolation-v2.sh\n' >&2
+  exit 1
+fi
+
+# Append the stub helpers. Use a separate stub file built with printf so we
+# never embed multi-line code via heredoc / here-string in this script.
+STUB_FILE="$TMP_HOME/stubs.sh"
+: >"$STUB_FILE"
+{
+  printf '%s\n' ''
+  printf '%s\n' 'bridge_warn() { printf "[warn] %s\n" "$*" >&2; }'
+  printf '%s\n' ''
+  printf '%s\n' '# Direct-only dispatcher: the test runs as the operator UID. The'
+  printf '%s\n' '# real helper falls back to sudo only when direct fails. Collapse'
+  printf '%s\n' '# to a direct exec so the test never escalates.'
+  printf '%s\n' '_bridge_isolation_v2_run_root_or_sudo() {'
+  printf '%s\n' '  "$@"'
+  printf '%s\n' '}'
+  printf '%s\n' ''
+  printf '%s\n' 'bridge_isolation_v2_controller_user() {'
+  printf '%s\n' '  printf "%s" "${USER:-${LOGNAME:-tester}}"'
+  printf '%s\n' '}'
+  printf '%s\n' ''
+  printf '%s\n' 'bridge_isolation_v2_reapply_eligible_agents() {'
+  printf '%s\n' '  if [[ -n "${STUB_ROSTER:-}" ]]; then'
+  printf '%s\n' '    printf "%s\n" "$STUB_ROSTER"'
+  printf '%s\n' '  fi'
+  printf '%s\n' '}'
+  printf '%s\n' ''
+  printf '%s\n' 'bridge_channel_state_dir_for_item() {'
+  printf '%s\n' '  case "$2" in'
+  printf '%s\n' '    plugin:teams)      printf "%s" "${STUB_STATE_DIR_TEAMS:-}";;'
+  printf '%s\n' '    plugin:ms365)      printf "%s" "${STUB_STATE_DIR_MS365:-}";;'
+  printf '%s\n' '    plugin:discord)    printf "%s" "${STUB_STATE_DIR_DISCORD:-}";;'
+  printf '%s\n' '    plugin:telegram)   printf "%s" "${STUB_STATE_DIR_TELEGRAM:-}";;'
+  printf '%s\n' '    plugin:mattermost) printf "%s" "${STUB_STATE_DIR_MATTERMOST:-}";;'
+  printf '%s\n' '    *) printf "%s" "";;'
+  printf '%s\n' '  esac'
+  printf '%s\n' '}'
+  printf '%s\n' ''
+  printf '%s\n' 'bridge_agent_workdir() {'
+  printf '%s\n' '  printf "%s" "${STUB_AGENT_WORKDIR:-}"'
+  printf '%s\n' '}'
+} >"$STUB_FILE"
+
+cat "$STUB_FILE" >>"$EXTRACT_TMP"
+
+# shellcheck source=/dev/null
+source "$EXTRACT_TMP"
+
+# ---------------------------------------------------------------------------
+# 2. Cross-platform gating.
+# ---------------------------------------------------------------------------
+
+HAVE_SETFACL=0
+HAVE_GETFACL=0
+if command -v setfacl >/dev/null 2>&1; then HAVE_SETFACL=1; fi
+if command -v getfacl >/dev/null 2>&1; then HAVE_GETFACL=1; fi
+
+# ---------------------------------------------------------------------------
+# Case 1: dotenv with mask reverted to --- is repaired to r-- + named-user
+# becomes effective r--.
+# ---------------------------------------------------------------------------
+step "Case 1: regressed mask is repaired and named-user grant becomes effective"
+
+if (( HAVE_SETFACL == 1 && HAVE_GETFACL == 1 )); then
+  AGENT_NAME="agent-851-fix"
+  STUB_AGENT_WORKDIR="$TMP_HOME/$AGENT_NAME/workdir"
+  TEAMS_DIR="$STUB_AGENT_WORKDIR/.teams"
+  mkdir -p "$TEAMS_DIR"
+  TEAMS_ENV="$TEAMS_DIR/.env"
+  printf 'TEAMS_APP_ID=abc\nTEAMS_APP_PASSWORD=secret\n' >"$TEAMS_ENV"
+  chmod 0640 "$TEAMS_ENV"
+
+  CTRL_UID_NAME="${USER:-${LOGNAME:-}}"
+  if [[ -z "$CTRL_UID_NAME" ]]; then
+    skip "could not resolve controller user (USER/LOGNAME unset)"
+  else
+    if ! setfacl -m "u:${CTRL_UID_NAME}:r--" "$TEAMS_ENV" 2>/dev/null; then
+      skip "setfacl named-user grant unsupported on this filesystem"
+    elif ! setfacl -m "m::---" "$TEAMS_ENV" 2>/dev/null; then
+      skip "setfacl mask manipulation unsupported on this filesystem"
+    else
+      pre_mask="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+        | awk -F: '/^mask::/ {print substr($3,1,3); exit}')"
+      if [[ "$pre_mask" != "---" ]]; then
+        err "pre-state mask was '$pre_mask', expected the regressed shape"
+      fi
+
+      STUB_STATE_DIR_TEAMS="$TEAMS_DIR"
+      STUB_STATE_DIR_MS365=""
+      STUB_STATE_DIR_DISCORD=""
+      STUB_STATE_DIR_TELEGRAM=""
+      STUB_STATE_DIR_MATTERMOST=""
+      STUB_ROSTER=""
+
+      # iso_user composition: helper uses
+      #   ${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}${agent}
+      # With an empty prefix and agent=$CTRL_UID_NAME the grant target is the
+      # controller user, which matches the precondition we just installed.
+      BRIDGE_AGENT_OS_USER_PREFIX=""
+      if ! bridge_isolation_v2_apply_channel_state_dotenv_acl "$CTRL_UID_NAME" 0640; then
+        err "helper returned non-zero on a recoverable file"
+      else
+        post_mask="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+          | awk -F: '/^mask::/ {print substr($3,1,3); exit}')"
+        post_named="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+          | awk -F: -v u="$CTRL_UID_NAME" '$1=="user" && $2==u {print substr($3,1,3); exit}')"
+        if [[ "$post_mask" == "r--" ]] && [[ "$post_named" == "r--" ]]; then
+          ok
+        else
+          err "post-state mask='$post_mask' named-user='$post_named' (want both r--)"
+        fi
+      fi
+      unset BRIDGE_AGENT_OS_USER_PREFIX
+    fi
+  fi
+else
+  skip "setfacl/getfacl not available on this host"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 2: no dotenv exists for any provider -> return 0 (no-op).
+# ---------------------------------------------------------------------------
+step "Case 2: no dotenv exists, helper is a no-op success"
+
+STUB_AGENT_WORKDIR="$TMP_HOME/case2-agent/workdir"
+mkdir -p "$STUB_AGENT_WORKDIR"
+STUB_STATE_DIR_TEAMS="$STUB_AGENT_WORKDIR/.teams"
+STUB_STATE_DIR_MS365="$STUB_AGENT_WORKDIR/.ms365"
+STUB_STATE_DIR_DISCORD=""
+STUB_STATE_DIR_TELEGRAM=""
+STUB_STATE_DIR_MATTERMOST=""
+STUB_ROSTER=""
+BRIDGE_AGENT_OS_USER_PREFIX=""
+
+rc=0
+bridge_isolation_v2_apply_channel_state_dotenv_acl "${USER:-tester}" 0640 || rc=$?
+if (( rc == 0 )); then
+  ok
+else
+  err "expected rc=0 on missing dotenvs, got rc=$rc"
+fi
+unset BRIDGE_AGENT_OS_USER_PREFIX
+
+# ---------------------------------------------------------------------------
+# Case 3: roster-aware strip - a stale grant is removed; the in-roster grant
+# survives.
+# ---------------------------------------------------------------------------
+step "Case 3: stale named-user grant is stripped, in-roster grant preserved"
+
+if (( HAVE_SETFACL == 1 && HAVE_GETFACL == 1 )); then
+  AGENT_NAME="case3-agent"
+  STUB_AGENT_WORKDIR="$TMP_HOME/$AGENT_NAME/workdir"
+  TEAMS_DIR="$STUB_AGENT_WORKDIR/.teams"
+  mkdir -p "$TEAMS_DIR"
+  TEAMS_ENV="$TEAMS_DIR/.env"
+  printf 'TEAMS_APP_ID=abc\n' >"$TEAMS_ENV"
+  chmod 0640 "$TEAMS_ENV"
+
+  CTRL_UID_NAME="${USER:-${LOGNAME:-}}"
+  STALE_USER="daemon"
+  if ! id -u "$STALE_USER" >/dev/null 2>&1; then
+    STALE_USER="nobody"
+  fi
+  if ! id -u "$STALE_USER" >/dev/null 2>&1; then
+    skip "no usable system UID for stale grant (daemon/nobody both missing)"
+  elif [[ -z "$CTRL_UID_NAME" ]]; then
+    skip "could not resolve controller user (USER/LOGNAME unset)"
+  elif ! setfacl -m "u:${CTRL_UID_NAME}:r--" "$TEAMS_ENV" 2>/dev/null \
+       || ! setfacl -m "u:${STALE_USER}:r--" "$TEAMS_ENV" 2>/dev/null; then
+    skip "setfacl multi-user grant unsupported on this filesystem"
+  else
+    STUB_STATE_DIR_TEAMS="$TEAMS_DIR"
+    STUB_STATE_DIR_MS365=""
+    STUB_STATE_DIR_DISCORD=""
+    STUB_STATE_DIR_TELEGRAM=""
+    STUB_STATE_DIR_MATTERMOST=""
+    STUB_ROSTER=""
+    BRIDGE_AGENT_OS_USER_PREFIX=""
+
+    if ! bridge_isolation_v2_apply_channel_state_dotenv_acl "$CTRL_UID_NAME" 0640; then
+      err "helper returned non-zero during strip case"
+    else
+      post_stale="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+        | awk -F: -v u="$STALE_USER" '$1=="user" && $2==u {print "found"; exit}')"
+      post_named="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+        | awk -F: -v u="$CTRL_UID_NAME" '$1=="user" && $2==u {print substr($3,1,3); exit}')"
+      if [[ -z "$post_stale" ]] && [[ "$post_named" == "r--" ]]; then
+        ok
+      else
+        err "post-state: stale-present='$post_stale' (want empty) named-user='$post_named' (want r--)"
+      fi
+    fi
+    unset BRIDGE_AGENT_OS_USER_PREFIX
+  fi
+else
+  skip "setfacl/getfacl not available on this host"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 4: non-Linux host (no setfacl) -> return 0 with a warning.
+# ---------------------------------------------------------------------------
+step "Case 4: setfacl absent on host, helper returns 0 with warning"
+
+# Build a sibling script that overrides `command` so any "command -v setfacl"
+# lookup returns 1. All other lookups still succeed. Compose via printf to
+# stay clear of multi-line heredoc patterns.
+SIM_TMP="$TMP_HOME/sim-no-setfacl.sh"
+cp "$EXTRACT_TMP" "$SIM_TMP"
+{
+  printf '%s\n' ''
+  printf '%s\n' '# Shadow command builtin: any "command -v setfacl" lookup returns 1;'
+  printf '%s\n' '# every other lookup delegates to the real builtin.'
+  printf '%s\n' 'command() {'
+  printf '%s\n' '  if [[ "$1" == "-v" && "$2" == "setfacl" ]]; then'
+  printf '%s\n' '    return 1'
+  printf '%s\n' '  fi'
+  printf '%s\n' '  builtin command "$@"'
+  printf '%s\n' '}'
+  printf '%s\n' ''
+  printf '%s\n' 'STUB_AGENT_WORKDIR="$HOME/case4-agent/workdir"'
+  printf '%s\n' 'mkdir -p "$STUB_AGENT_WORKDIR"'
+  printf '%s\n' 'STUB_STATE_DIR_TEAMS="$STUB_AGENT_WORKDIR/.teams"'
+  printf '%s\n' 'STUB_STATE_DIR_MS365=""'
+  printf '%s\n' 'STUB_STATE_DIR_DISCORD=""'
+  printf '%s\n' 'STUB_STATE_DIR_TELEGRAM=""'
+  printf '%s\n' 'STUB_STATE_DIR_MATTERMOST=""'
+  printf '%s\n' 'STUB_ROSTER=""'
+  printf '%s\n' 'BRIDGE_AGENT_OS_USER_PREFIX=""'
+  printf '%s\n' ''
+  printf '%s\n' 'rc=0'
+  printf '%s\n' 'warn_capture="$(bridge_isolation_v2_apply_channel_state_dotenv_acl "tester" 0640 2>&1)" || rc=$?'
+  printf '%s\n' 'printf "RC=%s\n" "$rc"'
+  printf '%s\n' 'printf "WARN=%s\n" "$warn_capture"'
+} >>"$SIM_TMP"
+
+sim_out="$(bash "$SIM_TMP" 2>&1)"
+sim_rc="$(printf '%s' "$sim_out" | awk -F= '/^RC=/ {print $2; exit}')"
+sim_warn="$(printf '%s' "$sim_out" | awk -F= '/^WARN=/ {sub("^WARN=",""); print}')"
+if [[ "$sim_rc" == "0" ]] && printf '%s' "$sim_warn" | grep -q "setfacl not available"; then
+  ok
+else
+  err "rc='$sim_rc' warn='$sim_warn' (want rc=0 + warning about setfacl absence)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS + FAIL + SKIP))
+printf '\n# Issue #851 dotenv-mask-repair suite: %s passed, %s skipped, %s failed (total %s)\n' \
+  "$PASS" "$SKIP" "$FAIL" "$TOTAL"
+if (( FAIL > 0 )); then
+  exit 1
+fi
+exit 0

--- a/scripts/test-channel-dotenv-mask-repair.sh
+++ b/scripts/test-channel-dotenv-mask-repair.sh
@@ -316,6 +316,126 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# Case 5 (r2 finding 1): controller grant is preserved across a repair call.
+# Pre-state: u:ctrl_user:r-- + u:agent-bridge-A:r-- (roster).
+# Post-state must include BOTH grants (and add agent-bridge-B from roster).
+# Without the r2 fix, the stale-strip removed u:ctrl_user and the final
+# setfacl only re-granted roster members, breaking controller reads.
+# ---------------------------------------------------------------------------
+step "Case 5 (r2 finding 1): controller grant is preserved + roster expansion"
+
+if (( HAVE_SETFACL == 1 && HAVE_GETFACL == 1 )); then
+  AGENT_NAME="case5-agent"
+  STUB_AGENT_WORKDIR="$TMP_HOME/$AGENT_NAME/workdir"
+  TEAMS_DIR="$STUB_AGENT_WORKDIR/.teams"
+  mkdir -p "$TEAMS_DIR"
+  TEAMS_ENV="$TEAMS_DIR/.env"
+  printf 'TEAMS_APP_ID=ctrl\n' >"$TEAMS_ENV"
+  chmod 0640 "$TEAMS_ENV"
+
+  CTRL_UID_NAME="${USER:-${LOGNAME:-}}"
+  # Roster member proxy: use a second real system uid distinct from CTRL.
+  ROSTER_A_USER="daemon"
+  if ! id -u "$ROSTER_A_USER" >/dev/null 2>&1; then
+    ROSTER_A_USER="nobody"
+  fi
+  # Second roster member we will assert is GRANTED post-call (was missing pre).
+  ROSTER_B_USER="bin"
+  if ! id -u "$ROSTER_B_USER" >/dev/null 2>&1; then
+    ROSTER_B_USER="sys"
+  fi
+  if [[ -z "$CTRL_UID_NAME" ]] \
+      || ! id -u "$ROSTER_A_USER" >/dev/null 2>&1 \
+      || ! id -u "$ROSTER_B_USER" >/dev/null 2>&1; then
+    skip "could not resolve three distinct system uids (ctrl/$ROSTER_A_USER/$ROSTER_B_USER)"
+  elif ! setfacl -m "u:${CTRL_UID_NAME}:r--" "$TEAMS_ENV" 2>/dev/null \
+       || ! setfacl -m "u:${ROSTER_A_USER}:r--" "$TEAMS_ENV" 2>/dev/null; then
+    skip "setfacl multi-user pre-state unsupported on this filesystem"
+  else
+    STUB_STATE_DIR_TEAMS="$TEAMS_DIR"
+    STUB_STATE_DIR_MS365=""
+    STUB_STATE_DIR_DISCORD=""
+    STUB_STATE_DIR_TELEGRAM=""
+    STUB_STATE_DIR_MATTERMOST=""
+    # Roster reports A and B as eligible agents — the helper will compose
+    # u:A:r-- and u:B:r-- grants. Empty prefix so STUB_ROSTER values map
+    # directly to existing uids without an `agent-bridge-` prefix.
+    STUB_ROSTER="$(printf '%s\n%s\n' "$ROSTER_A_USER" "$ROSTER_B_USER")"
+    BRIDGE_AGENT_OS_USER_PREFIX=""
+    # Stub controller to a STABLE name. The helper reads
+    # ${SUDO_USER:-${USER:-${LOGNAME:-}}}; force USER for determinism.
+    export USER="$CTRL_UID_NAME"
+
+    # The helper's agent argument becomes iso_user; pass an agent name
+    # that does NOT collide with ROSTER_A_USER / ROSTER_B_USER / CTRL.
+    # The roster set already covers the two real uids; this agent name
+    # gets appended too but won't resolve to a real uid (and the final
+    # setfacl will fail for that bogus name, so we use one of the roster
+    # uids as the called-for agent to keep the final grant set valid).
+    if ! bridge_isolation_v2_apply_channel_state_dotenv_acl "$ROSTER_A_USER" 0640; then
+      err "helper returned non-zero on controller-grant test"
+    else
+      post_ctrl="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+        | awk -F: -v u="$CTRL_UID_NAME" '$1=="user" && $2==u {print substr($3,1,3); exit}')"
+      post_a="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+        | awk -F: -v u="$ROSTER_A_USER" '$1=="user" && $2==u {print substr($3,1,3); exit}')"
+      post_b="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+        | awk -F: -v u="$ROSTER_B_USER" '$1=="user" && $2==u {print substr($3,1,3); exit}')"
+      post_mask="$(getfacl -p "$TEAMS_ENV" 2>/dev/null \
+        | awk -F: '/^mask::/ {print substr($3,1,3); exit}')"
+      if [[ "$post_ctrl" == "r--" ]] \
+          && [[ "$post_a" == "r--" ]] \
+          && [[ "$post_b" == "r--" ]] \
+          && [[ "$post_mask" == "r--" ]]; then
+        ok
+      else
+        err "post-state ctrl='$post_ctrl' A='$post_a' B='$post_b' mask='$post_mask' (want all r--)"
+      fi
+    fi
+    unset BRIDGE_AGENT_OS_USER_PREFIX
+    unset STUB_ROSTER
+  fi
+else
+  skip "setfacl/getfacl not available on this host"
+fi
+
+# ---------------------------------------------------------------------------
+# Case 6 (r2 finding 3): bridge-start.sh pre-launch ordering.
+# Static lexical assertion: the ACL repair call site must precede the
+# channel-status `bridge_die unreadable` guard. Without this ordering,
+# `agent start` dies on auth=unreadable before the helper ever runs.
+# Mocking the full bridge-start launch path is out of scope (operator
+# UIDs, sudo, isolation matrix); the file ordering invariant is the
+# accurate proxy and is what r2 actually changes.
+# ---------------------------------------------------------------------------
+step "Case 6 (r2 finding 3): bridge-start ACL repair runs before channel-status guard"
+
+START_SH="$ROOT_DIR/bridge-start.sh"
+if [[ ! -f "$START_SH" ]]; then
+  err "bridge-start.sh missing from \$ROOT_DIR=$ROOT_DIR"
+else
+  helper_line="$(grep -n 'bridge_isolation_v2_apply_channel_state_dotenv_acl "\$AGENT"' "$START_SH" \
+    | awk -F: 'NR==1 {print $1; exit}')"
+  status_line="$(grep -n 'bridge_agent_channel_status_reason "\$AGENT"' "$START_SH" \
+    | awk -F: 'NR==1 {print $1; exit}')"
+  if [[ -z "$helper_line" ]] || [[ -z "$status_line" ]]; then
+    err "could not locate helper or status callsite (helper='$helper_line' status='$status_line')"
+  elif (( helper_line < status_line )); then
+    ok
+  else
+    err "helper at line $helper_line is NOT before channel-status check at line $status_line"
+  fi
+fi
+
+# NOTE: r2 codex finding 5 (race between operator-driven and daemon-driven
+# re-assert) is INTENTIONALLY UNFIXED in this stop-gap PR. The operator
+# elected to (a) limit the daemon path by flipping the self-heal default
+# OFF (`BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL:-0` at bridge-daemon.sh:3563)
+# and (b) defer the structural fix to the controller-blind redesign that
+# removes the controller-side ACL surface entirely. A regression test for
+# the race would assert behavior we are not promising and is omitted.
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 TOTAL=$((PASS + FAIL + SKIP))


### PR DESCRIPTION
## Stop-gap classification (r2 operator decision)

**This PR is a minimum stop-gap restoring the v0.10.x channel-dotenv-readable contract while the controller-blind redesign in #857 is staged.** The race between operator-driven and daemon-driven re-assert is left intentionally unfixed because the redesign removes the surface entirely. The daemon self-heal default is flipped to `BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL=0` to limit new surface; operators who want the daemon hook may opt in explicitly. (Operator is filing the umbrella issue separately — orchestrator will substitute the real number for `#857` post-merge.)

r2 codex pair-review on r1 (38267a3) returned three BLOCKING findings:
- Finding 1 (controller grant drop) — **FIXED** in r2 (bc4374e).
- Finding 3 (pre-launch ordering bug) — **FIXED** in r2 (bc4374e).
- Finding 5 (operator + daemon re-assert race) — **INTENTIONALLY DEFERRED**. Mitigated by flipping daemon default OFF. Structural fix is the controller-blind redesign in #857.

## Summary

Channel dotenv (`<agent_home>/.{teams,ms365,discord,telegram,mattermost}/.env`) ACL mask reverts to `---` after runtime plugin writes propagate `umask=077` from the controller. The named-user `r--` grant becomes `#effective:---`, controller-side reads fail, agent start blocks with `auth=unreadable ready=no`.

#778 fixed the migration path. This PR adds the runtime path:

- New `bridge_isolation_v2_apply_channel_state_dotenv_acl` in `lib/bridge-isolation-v2.sh` mirrors the credentials helper but for channel dotenv files (file mode + roster-aware named-user grants + `mask::r--` + `o::---`, symlink-refusing path guard, non-Linux warn-skip with rc=0). **r2 finding 1 fix:** the controller user is now included in the keep-and-grant set so the stale-strip never removes it and the final setfacl re-asserts it alongside the roster agents.
- Daemon health loop (`process_channel_health` in `bridge-daemon.sh`) self-heals on observed drift when explicitly enabled: when an isolated agent's status reason contains `unreadable:`, the helper runs before the channel_health_miss reporter. **r2 stop-gap change:** gated by `BRIDGE_CHANNEL_HEALTH_DOTENV_SELFHEAL` with default `0` (OFF). Set to `1` to opt in. The race between this hook and the pre-launch hook is the known-but-deferred finding 5 — the long-term fix removes the surface, not the race.
- `bridge-start.sh` pre-launch re-assert for linux-user isolated agents so an operator-issued `agent start` does not have to wait a daemon cycle. **r2 finding 3 fix:** the re-assert now runs BEFORE the channel-status check so a regressed `mask::---` is healed in time for the `bridge_die unreadable:` guard to see the post-repair state.
- `scripts/test-channel-dotenv-mask-repair.sh` pins the contract cases (repair, no-op, roster-aware strip, non-Linux host) plus the r2 additions: controller-grant preservation across a repair call (finding 1 pin) and a static lexical assertion that the bridge-start.sh ACL repair precedes the channel-status guard (finding 3 pin). Wired into `scripts/smoke-test.sh` right after `test-channel-probe-isolated.sh`.

## Test plan

- [x] `bash -n` on all touched files
- [x] `shellcheck` on all touched files
- [x] `scripts/test-channel-dotenv-mask-repair.sh` runs in isolated `BRIDGE_HOME`; macOS exercises Cases 2 + 4 + 6 and skips 1 + 3 + 5 (no setfacl); Linux CI exercises the full matrix including the controller-grant preservation case
- [x] Primary checkout (operator's `~/Projects/agent-bridge-public`) untouched throughout the r1 + r2 fixer sessions
- [ ] Live verification on operator's install (deferred — operator must observe `auth=unreadable` post-runtime-write recovery with daemon hook OFF by default)

## Notes

- Smoke-test.sh exits 1 on macOS at the inherited baseline (`bridge-upgrade.sh:551` SC2026 + `bridge-run.sh --dry-run` v2-only check); both reproduce on a clean `main`. Linux CI baseline expected to remain green per the brief.
- `bridge-run.sh` itself runs under the isolated UID via the sudo wrap, so it cannot mutate ACLs; `bridge-start.sh` (the operator-facing entrypoint that composes the launch and still runs as the controller) is the correct pre-launch hook point.
- r2 deliberately does NOT add a per-agent flock around the helper. The operator + daemon race is real but mitigated by flipping the daemon default OFF; the structural fix is the controller-blind redesign that removes the controller-side ACL entirely.

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)

