### PR TITLE
perf(dispatch): batch sha1 + roster memo + help short-circuit (#848)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -112,8 +112,17 @@ CLI_NAME="$(basename "$0")"
 # the roster lazily when they actually need it; skipping here keeps
 # `agb status` / `agb agent list` / `agb inbox <agent>` / `agb daemon
 # start` startup well under 5s on the operator's live host.
+#
+# Issue #848: also skip for `--help` / `-h` / `help` / `--version` / `-V`
+# (and the `version` subcommand token already covered above). `agb
+# --help` previously paid the full roster-hydration cost just to render
+# the static usage block (~0.8-1.1s of python3 cold-starts on macOS);
+# the help text only uses `$CLI_NAME`, so the roster isn't needed. The
+# matching short-circuit DISPATCH for the flag spellings lives below
+# (after `usage()` is defined) — this entry only keeps the *roster*
+# off the hot path.
 case "${1:-}" in
-  version|status|daemon|agent|task|inbox) ;;
+  version|status|daemon|agent|task|inbox|help|--help|-h|--version|-V) ;;
   init)
     # bridge-isolation-v2.sh's `BRIDGE_LAYOUT="${BRIDGE_LAYOUT:-legacy}"`
     # default fires during our bridge-lib.sh source above and exports the
@@ -376,6 +385,25 @@ Primary command: \`agent-bridge\`
 Short alias: \`agb\`
 EOF
 }
+
+# Issue #848: actual short-circuit dispatch for the help / version flag
+# spellings. Placed AFTER `usage()` is defined (the function references
+# `$CLI_NAME`, set at line 98) and AFTER the skip-roster case above so
+# bridge_load_roster has not run for these tokens. The matching skip-
+# list entries above keep the *roster* off the hot path; this block
+# keeps the *dispatch* off it too. `--version` / `-V` are rewritten to
+# the existing `version` subcommand handler downstream to avoid
+# duplicating its `--json` + source-ref + upgrade-state formatting
+# logic.
+case "${1:-}" in
+  --help|-h)
+    usage
+    exit 0
+    ;;
+  --version|-V)
+    set -- version "${@:2}"
+    ;;
+esac
 
 is_tty() {
   [[ -t 0 && -t 1 ]]

--- a/agent-bridge
+++ b/agent-bridge
@@ -93,9 +93,68 @@ HELP_EOF
   done
   unset _arg
 fi
+# Issue #848 (codex r1 Vector 3): handle --help / -h / --version / -V
+# BEFORE sourcing bridge-lib.sh. The previous short-circuit at the
+# bottom of this file skipped bridge_load_roster but still paid the
+# cost of `source bridge-lib.sh`, which transitively sources every
+# `lib/bridge-*.sh` module — ~25 sources for ~50-80ms of cold-start
+# residual on macOS. With the template-backed renderer below, neither
+# the `--help` nor the `--version` short-circuit needs anything from
+# bridge-lib.sh, so we exit before paying the source cost.
+#
+# The positional `version` subcommand continues to flow through the
+# downstream handler (sourced bridge-lib, full --json / source-ref /
+# upgrade-state formatting) since callers typing `agb version` are
+# asking for the full version snapshot; only the `--version` / `-V`
+# flag spellings get the fast print here.
+#
+# `usage()` downstream also reads from the same template via
+# `bridge_print_usage_from_template`, so the slow (invalid-arg)
+# fallback path stays in sync with this fast path automatically.
+CLI_NAME="$(basename "$0")"
+
+# Print the usage template with `__CLI_NAME__` substituted for the
+# resolved CLI invocation name. Pure shell + sed — no bridge-lib
+# dependency. Used by both the top-level --help short-circuit and
+# the downstream usage() function so both paths stay byte-identical.
+bridge_print_usage_from_template() {
+  local template="$SCRIPT_DIR/scripts/cli-help/agent-bridge-usage.txt"
+  if [[ ! -f "$template" ]]; then
+    # Defensive fallback: template missing from a partial install.
+    # Print a minimal hand-rolled hint so --help still exits 0 with
+    # something actionable rather than dying silently.
+    printf 'Usage: %s <subcommand> [options...]\n' "$CLI_NAME"
+    printf '       %s --help     show full subcommand list\n' "$CLI_NAME"
+    printf '       %s --version  show installed version\n' "$CLI_NAME"
+    printf '(usage template missing: %s)\n' "$template" >&2
+    return 0
+  fi
+  # Use a sed delimiter that cannot appear in CLI_NAME (`/`, `_`, `:`).
+  # CLI_NAME is the result of `basename "$0"` so it is a filename
+  # component without slashes — `|` is safe.
+  sed "s|__CLI_NAME__|$CLI_NAME|g" "$template"
+}
+
+case "${1:-}" in
+  --help|-h)
+    bridge_print_usage_from_template
+    exit 0
+    ;;
+  --version|-V)
+    # Read VERSION directly — no bridge-lib (bridge_version lives in
+    # lib/bridge-core.sh which we are explicitly avoiding sourcing on
+    # this hot path).
+    if [[ -f "$SCRIPT_DIR/VERSION" ]]; then
+      printf 'Agent Bridge %s\n' "$(head -n 1 "$SCRIPT_DIR/VERSION" | tr -d '[:space:]')"
+    else
+      printf 'Agent Bridge 0.0.0-dev\n'
+    fi
+    exit 0
+    ;;
+esac
+
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
-CLI_NAME="$(basename "$0")"
 
 # Skip roster load for commands that must remain mutation-free or own their
 # own load timing. `init` defers bridge_load_roster until after argument
@@ -113,14 +172,16 @@ CLI_NAME="$(basename "$0")"
 # `agb status` / `agb agent list` / `agb inbox <agent>` / `agb daemon
 # start` startup well under 5s on the operator's live host.
 #
-# Issue #848: also skip for `--help` / `-h` / `help` / `--version` / `-V`
-# (and the `version` subcommand token already covered above). `agb
-# --help` previously paid the full roster-hydration cost just to render
-# the static usage block (~0.8-1.1s of python3 cold-starts on macOS);
-# the help text only uses `$CLI_NAME`, so the roster isn't needed. The
-# matching short-circuit DISPATCH for the flag spellings lives below
-# (after `usage()` is defined) — this entry only keeps the *roster*
-# off the hot path.
+# Issue #848: `--help` / `-h` / `--version` / `-V` are now handled at
+# the TOP of this file (before `source bridge-lib.sh` above) — those
+# tokens exit before they ever reach this case statement. The flag
+# spellings are kept in the skip-list below as a belt-and-suspenders
+# guard so that any future move of the top short-circuit cannot
+# accidentally re-introduce the full roster-hydration cost (~0.8-1.1s
+# of python3 cold-starts on macOS) on the help path. The `help`
+# subcommand token is also kept so that an `agb help` style invocation
+# (if a future patch adds the subcommand handler) does not eat the
+# roster cost either.
 case "${1:-}" in
   version|status|daemon|agent|task|inbox|help|--help|-h|--version|-V) ;;
   init)
@@ -143,267 +204,20 @@ case "${1:-}" in
 esac
 
 usage() {
-  cat <<EOF
-Usage:
-  $CLI_NAME status [--watch] [--refresh <seconds>] [--open-limit <count>] [--all-agents]
-  $CLI_NAME version [--json]
-  $CLI_NAME list
-  $CLI_NAME admin [--safe-mode] [--replace] [--continue|--no-continue] [--no-attach] [--no-project-skill]
-  $CLI_NAME bootstrap [bootstrap options...] [init options...]
-  $CLI_NAME init [--admin <agent>] [--engine claude|codex] [--session <name>] [--channels <csv>] [--dry-run] [--json]
-  $CLI_NAME upgrade [--apply] [--check] [--channel stable|dev|current] [--version <semver>] [--ref <git-ref>] [--pull|--no-pull] [--restart-daemon] [--dry-run] [--json] [--strict-merge]
-  $CLI_NAME upgrade analyze [--target <bridge-home>] [--json]
-  $CLI_NAME upgrade rollback [--target <bridge-home>] [--backup-root <dir>] [--json]
-  $CLI_NAME upgrade conflicts <list|diff|adopt|discard|archive|reconcile> [--target <bridge-home>] [--json|--yes|--auto-archive] [<conflict-path>]
-  $CLI_NAME daemon <ensure|status|start|stop|sync|run> ...
-  $CLI_NAME auth claude-token <add|list|activate|sync|rotate|auto-rotate> ...
-  $CLI_NAME escalate question --agent <agent> --question "<text>" [--context "<text>"] [--wait-seconds <seconds>] [--json]
-  $CLI_NAME upstream <draft|propose|review> ...
-  $CLI_NAME review <policy|request|complete> ...
-  $CLI_NAME user <set|show> ...
-  $CLI_NAME guard <status|scan|sanitize> ...
-  $CLI_NAME diagnose <acl> [--json]
-  $CLI_NAME doctor [--json] [--detectors <kind[,kind...]>] [--state-dir <path>] [--task-db <path>]
-  $CLI_NAME knowledge <init|operator|capture|promote|search|lint> ...
-  $CLI_NAME skills <list> [--agent <name>] [--json]
-  $CLI_NAME config <set|get|list-protected> ...
-  $CLI_NAME bundle <create|show> ...
-  $CLI_NAME intake <triage|show> ...
-  $CLI_NAME wave <dispatch|list|show|templates|close-issue> ...
-  $CLI_NAME agent <create|update|delete|retire|list|registry|show|reclassify|start|safe-mode|stop|restart|attach|compact|handoff> ...
-  $CLI_NAME kill <number|all>
-  $CLI_NAME attach [number|name]
-  $CLI_NAME urgent <agent> "<message>" [--wait <seconds>]
-  $CLI_NAME task <create|inbox|show|claim|done|update|handoff|summary> ...
-  $CLI_NAME profile <status|diff|deploy> ...
-  $CLI_NAME setup <discord|telegram|teams|agent|admin> ...
-  $CLI_NAME cron <inventory|show|import|list|create|update|delete|rebalance-memory-daily|enqueue|sync|run-subagent|errors|cleanup> ...
-  $CLI_NAME memory <init|capture|ingest|promote|remember|lint|search|rebuild-index|query> ...
-  $CLI_NAME audit [list] [--agent <name>] [--action <type>] [--since <datetime>] [--limit N] [--json]
-  $CLI_NAME audit follow --agent <name> [--action <type>] [--contains <text>] [--follow]
-  $CLI_NAME audit verify
-  $CLI_NAME usage <status|monitor|alerts> ...
-  $CLI_NAME watchdog scan [agent...] [--json]
-  $CLI_NAME discord <status|sync>
-  $CLI_NAME migrate runtime inventory [--json] [--report <path>]
-  $CLI_NAME migrate runtime sync [--dry-run]
-  $CLI_NAME migrate runtime rewrite-cron [--dry-run] [--json]
-  $CLI_NAME migrate runtime rewrite-files [--dry-run] [--json]
-  $CLI_NAME migrate docs audit [--all] [agent...]
-  $CLI_NAME migrate docs apply [--all] [agent...] [--dry-run]
-  $CLI_NAME watchdog scan
-  $CLI_NAME migrate workspace plan <agent>
-  $CLI_NAME migrate workspace copy <agent> [--dry-run]
-  $CLI_NAME migrate workspace cutover <agent> --dry-run
-  $CLI_NAME migrate overhead pre-migrate [--output <file>] [--json]
-  $CLI_NAME migrate overhead dry-run [--agent <name>|--all] [--json]
-  $CLI_NAME migrate overhead apply [--agent <name>|--all] --yes [--dry-run] [--json]
-  $CLI_NAME migrate overhead rollback --stamp <YYYYMMDD-HHMMSS-<pid>> [--json]
-  $CLI_NAME migrate isolation-v2 dry-run --data-root <path>
-  $CLI_NAME migrate isolation-v2 apply --data-root <path> --yes
-  $CLI_NAME migrate isolation-v2 rollback --yes
-  $CLI_NAME migrate isolation-v2 commit --yes
-  $CLI_NAME migrate isolation-v2 status
-  $CLI_NAME migrate isolation v2 [--check|--dry-run|--apply] [--agent <name>] [--json]
-  $CLI_NAME wiki bootstrap [--agent <name>] [--shared-root <path>] [--dry-run] [--json]
-  $CLI_NAME wiki validate [--full|--frontmatter|--broken-link|--tree-edge] [--json]
-  $CLI_NAME wiki dedup-scan [--output <file>] [--json]
-  $CLI_NAME wiki dedup-apply --plan <file> [--dry-run] [--json]
-  $CLI_NAME wiki repair-links [--apply] [--limit N] [--json]
-  $CLI_NAME isolate <agent> [--dry-run]
-  $CLI_NAME unisolate <agent> [--dry-run]
-  $CLI_NAME isolation verify --agent <agent> [--json] [--strict-optional]
-  $CLI_NAME inbox [agent] [--all]
-  $CLI_NAME show <task-id>
-  $CLI_NAME claim <task-id> [--agent <agent>] [--lease <seconds>]
-  $CLI_NAME done <task-id> [--agent <agent>] [--note <text> | --note-file <path>]
-  $CLI_NAME cancel <task-id> [--actor <name>] [--note <text> | --note-file <path>]
-  $CLI_NAME update <task-id> [--status queued|claimed|blocked|in_progress] [--priority ...] [--note ...]
-  $CLI_NAME handoff <task-id> --to <agent> [--from <agent>] [--note <text> | --note-file <path>]
-  $CLI_NAME summary [agent...]
-  $CLI_NAME worktree list
-  $CLI_NAME worktree doctor [--dry-run|--apply] [--max-age-days N] [--target-branch ref] [--include-stale] [--prune-branches]
-  $CLI_NAME profile status [agent|--all]
-  $CLI_NAME profile diff <agent>
-  $CLI_NAME profile deploy <agent> [--dry-run] [--force]
-  $CLI_NAME agent create <agent> [--engine claude|codex] [--session <name>] [--workdir <path>] [--always-on] [--dry-run] [--json]
-  $CLI_NAME agent list [--json]
-  $CLI_NAME agent registry [--json]
-  $CLI_NAME agent show <agent> [--json]
-  $CLI_NAME agent reclassify [--agent <agent>] [--apply] [--json]
-  $CLI_NAME agent start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
-  $CLI_NAME agent safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
-  $CLI_NAME agent stop <agent>
-  $CLI_NAME agent restart <agent> [--attach|--no-attach] [--continue|--no-continue] [--dry-run]
-  $CLI_NAME agent attach <agent>
-  $CLI_NAME agent compact <agent> [--note <text>]
-  $CLI_NAME agent handoff <agent> [--note <text>]
-  $CLI_NAME setup discord <agent> [--channel <id>]... [--channel-account <account>]
-  $CLI_NAME setup telegram <agent> [--allow-from <id>]... [--channel-account <account>]
-  $CLI_NAME setup teams <agent> [--app-id <id>] [--tenant-id <id>] [--allow-from <id>]... [--conversation <id>]...
-  $CLI_NAME setup agent <agent> [--skip-discord] [--skip-telegram] [--skip-teams] [--test-start]
-  $CLI_NAME discord status
-  $CLI_NAME discord sync
-  $CLI_NAME cron inventory [--mode recurring|one-shot|all] [--family <family>] [--limit <count>]
-  $CLI_NAME cron show <job-name-or-id>
-  $CLI_NAME cron import [--source-jobs-file <path>] [--dry-run]
-  $CLI_NAME cron list [--agent <bridge-agent>] [--enabled yes|no|all] [--limit <count>] [--json]
-  $CLI_NAME cron create --agent <bridge-agent> (--schedule "<cron-expr>" | --at "<iso-datetime>") --title "<title>" [--payload "<text>" | --payload-file <path>] [--tz <iana-tz>] [--delete-after-run]
-  $CLI_NAME cron update <job-id> [--agent <bridge-agent>] [--schedule "<cron-expr>" | --at "<iso-datetime>"] [--title "<title>"] [--payload "<text>" | --payload-file <path>] [--tz <iana-tz>] [--enable|--disable] [--delete-after-run|--keep-after-run]
-  $CLI_NAME cron delete <job-id>
-  $CLI_NAME cron enqueue <job-name-or-id> [--slot <slot-key>] [--dry-run]
-  $CLI_NAME cron sync [--dry-run] [--json] [--since <iso-datetime>] [--now <iso-datetime>]
-  $CLI_NAME cron run-subagent <run-id> [--dry-run]
-  $CLI_NAME cron errors report [--agent <agent>] [--family <family>] [--limit <count>] [--json]
-  $CLI_NAME cron cleanup report [--mode expired-one-shot] [--json]
-  $CLI_NAME cron cleanup prune [--mode expired-one-shot] [--dry-run]
-  $CLI_NAME memory init --agent <agent> [--user <id[:display-name]>] [--json]
-  $CLI_NAME knowledge init [--team-name <name>] [--json]
-  $CLI_NAME knowledge operator set --user owner --name "<name>"
-  $CLI_NAME knowledge operator show [--json]
-  $CLI_NAME bundle create --to reviewer --title "QA handoff" --summary "Review attached draft" --action "Return blockers" --artifact ~/agent-bridge/shared/report.md::draft
-  $CLI_NAME intake triage --capture <capture-id> --owner patch --summary "Customer needs ETA update" --category support --route
-  $CLI_NAME knowledge capture --source chat --text "..."
-  $CLI_NAME knowledge promote --kind people --summary "..."
-  $CLI_NAME knowledge search --query "..."
-  $CLI_NAME memory capture --agent <agent> --source discord --user owner --text "..."
-  $CLI_NAME memory ingest --agent <agent> --latest
-  $CLI_NAME memory promote --agent <agent> --kind shared --page personal-preferences --capture <id>
-  $CLI_NAME memory remember --agent <agent> --source chat --user owner --text "..." [--kind user|shared|project|decision]
-  $CLI_NAME memory lint --agent <agent>
-  $CLI_NAME migrate workspace plan <agent>
-  $CLI_NAME migrate workspace copy <agent> [--dry-run]
-  $CLI_NAME migrate workspace cutover <agent> --dry-run
-  $CLI_NAME --codex|--claude --name <agent> [--loop] [--no-continue] [--workdir <dir>] [--replace] [--no-attach] [--no-project-skill] [--prefer wake|new|shared] [--test-fixture]
-
-Examples:
-  $CLI_NAME status
-  $CLI_NAME status --watch
-  $CLI_NAME version
-  $CLI_NAME admin
-  $CLI_NAME admin --safe-mode
-  $CLI_NAME bootstrap --admin manager --engine claude --channels plugin:telegram@claude-plugins-official
-  $CLI_NAME init --admin manager --engine claude --channels plugin:telegram@claude-plugins-official
-  $CLI_NAME upgrade
-  $CLI_NAME upgrade --strict-merge --json
-  $CLI_NAME upgrade analyze --json
-  $CLI_NAME upgrade rollback --json
-  $CLI_NAME upgrade conflicts list --json
-  $CLI_NAME upgrade conflicts reconcile --auto-archive
-  $CLI_NAME upgrade conflicts adopt --yes <conflict-path>
-  $CLI_NAME auth claude-token add --id claude-a --stdin --activate --sync
-  $CLI_NAME auth claude-token auto-rotate enable --threshold 99
-  $CLI_NAME escalate question --agent reviewer --question "Should I ship this now?" --context "Second ask without a user reply."
-  $CLI_NAME upstream draft --title "setup fails" --symptom "..." --why "..." --output /tmp/issue.md
-  $CLI_NAME upstream propose --title "setup fails" --body-file /tmp/issue.md
-  $CLI_NAME review request --subject "release check" --reviewer reviewer --body-file /tmp/plan.md
-  $CLI_NAME user set --name "Sean" --timezone Asia/Seoul
-  $CLI_NAME user show --json
-  $CLI_NAME knowledge init --team-name "Acme"
-  $CLI_NAME knowledge operator set --user owner --name "Sean"
-  $CLI_NAME bundle show 20260411T130000+0900-qa-handoff --json
-  $CLI_NAME intake show 20260411T130000+0900-mail --json
-  $CLI_NAME knowledge search --query "primary operator"
-  $CLI_NAME config list-protected
-  $CLI_NAME config get --path \$BRIDGE_HOME/agents/foo/.discord/access.json
-  $CLI_NAME config set --path \$BRIDGE_HOME/agents/foo/.discord/access.json --change groups.append=12345
-  $CLI_NAME list
-  $CLI_NAME kill 1
-  $CLI_NAME kill all
-  $CLI_NAME agent create reviewer --engine claude
-  $CLI_NAME agent list --json
-  $CLI_NAME agent registry --json
-  $CLI_NAME agent show reviewer --json
-  $CLI_NAME agent reclassify --apply
-  $CLI_NAME agent start reviewer --dry-run
-  $CLI_NAME agent restart reviewer --attach
-  $CLI_NAME agent compact static-discord-bot
-  $CLI_NAME agent handoff static-discord-bot --note "context critical"
-  $CLI_NAME attach
-  $CLI_NAME attach 1
-  $CLI_NAME attach reviewer
-  $CLI_NAME worktree list
-  $CLI_NAME cron inventory --family memory-daily --limit 10
-  $CLI_NAME cron import --dry-run
-  $CLI_NAME cron list --agent <agent>
-  $CLI_NAME cron create --agent <agent> --schedule "0 9 * * *" --title "일일 모니터링"
-  $CLI_NAME cron rebalance-memory-daily --dry-run
-  $CLI_NAME cron enqueue <memory-daily-job-id> --slot 2026-04-05 --dry-run
-  $CLI_NAME cron sync --dry-run
-  $CLI_NAME cron run-subagent <run-id> --dry-run
-  $CLI_NAME cron errors report --limit 20
-  $CLI_NAME cron cleanup report
-  $CLI_NAME memory init --agent assistant --user owner:Owner
-  $CLI_NAME memory capture --agent assistant --source telegram --user owner --author "Alice" --text "I prefer morning updates."
-  $CLI_NAME memory ingest --agent assistant --latest
-  $CLI_NAME memory promote --agent assistant --kind user --user owner --summary "User prefers concise morning updates."
-  $CLI_NAME memory promote --agent assistant --kind user-profile --user owner --summary "답변 없으면 Discord로 에스컬레이션."   # appends to shared users/<uid>/USER.md Stable Preferences
-  $CLI_NAME memory remember --agent assistant --source chat --user owner --text "User prefers concise morning updates." --kind user
-  $CLI_NAME memory lint --agent assistant
-  $CLI_NAME memory search --agent assistant --user owner --query "concise morning updates"
-  $CLI_NAME memory rebuild-index --agent assistant
-  $CLI_NAME memory query --agent assistant --user owner --query "morning updates"
-  $CLI_NAME audit --agent patch --limit 20
-  $CLI_NAME audit follow --agent patch --follow
-  $CLI_NAME audit verify
-  $CLI_NAME usage status --json
-  $CLI_NAME usage alerts --json
-  $CLI_NAME setup discord tester
-  $CLI_NAME setup telegram tester --allow-from 123456789
-  $CLI_NAME setup teams tester --allow-from 00000000-0000-0000-0000-000000000000
-  $CLI_NAME setup agent tester
-  $CLI_NAME migrate runtime inventory
-  $CLI_NAME migrate runtime sync --dry-run
-  $CLI_NAME migrate runtime rewrite-cron --dry-run
-  $CLI_NAME migrate runtime rewrite-files --dry-run
-  $CLI_NAME migrate docs audit --all
-  $CLI_NAME migrate docs apply --all --dry-run
-  $CLI_NAME migrate workspace plan <agent>
-  $CLI_NAME migrate workspace copy <agent> --dry-run
-  $CLI_NAME migrate workspace cutover <agent> --dry-run
-  $CLI_NAME inbox developer
-  $CLI_NAME task create --to tester --title "재테스트" --body-file ~/agent-bridge/shared/report.md
-  $CLI_NAME claim 12 --agent tester
-  $CLI_NAME urgent developer "[TESTER] 프로덕션 장애 확인 필요"
-  $CLI_NAME --codex --name dev
-  $CLI_NAME --codex --name qa --loop
-  $CLI_NAME --claude --name reviewer --workdir /path/to/repo
-  $CLI_NAME --codex --name worker-a --prefer new
-
-By default, $CLI_NAME installs a project-local agent-bridge skill in the target workdir:
-  Codex  -> .agents/skills/agent-bridge/SKILL.md
-  Claude -> .claude/skills/agent-bridge/SKILL.md
-
-Bridge-owned Claude homes also receive shared runtime skills:
-  .claude/skills/agent-bridge-runtime/SKILL.md
-  .claude/skills/cron-manager/SKILL.md
-
-If a same-name session is already active with different engine/workdir/loop settings,
-$CLI_NAME will refuse to attach. Use \`$CLI_NAME kill <number>\` or rerun with \`--replace\`.
-
-Primary command: \`agent-bridge\`
-Short alias: \`agb\`
-EOF
+  # Issue #848 (codex r1 Vector 3): delegate to the shared template
+  # renderer defined near the top of this file. Keeps the slow-path
+  # invalid-arg fallback (which lands here after bridge-lib has been
+  # sourced) byte-identical to the fast-path `--help` short-circuit.
+  bridge_print_usage_from_template
 }
 
-# Issue #848: actual short-circuit dispatch for the help / version flag
-# spellings. Placed AFTER `usage()` is defined (the function references
-# `$CLI_NAME`, set at line 98) and AFTER the skip-roster case above so
-# bridge_load_roster has not run for these tokens. The matching skip-
-# list entries above keep the *roster* off the hot path; this block
-# keeps the *dispatch* off it too. `--version` / `-V` are rewritten to
-# the existing `version` subcommand handler downstream to avoid
-# duplicating its `--json` + source-ref + upgrade-state formatting
-# logic.
-case "${1:-}" in
-  --help|-h)
-    usage
-    exit 0
-    ;;
-  --version|-V)
-    set -- version "${@:2}"
-    ;;
-esac
+
+# Issue #848 r2 (codex Vector 3): `--help` / `-h` / `--version` / `-V`
+# are handled at the TOP of this file before `source bridge-lib.sh`.
+# No dispatch needed here anymore — those flags exit before this point.
+# The positional `version` subcommand still flows through the dispatch
+# table below (sourced bridge-lib path) to keep the full `--json` /
+# `source-ref` / upgrade-state output for callers typing `agb version`.
 
 is_tty() {
   [[ -t 0 && -t 1 ]]

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2736,6 +2736,10 @@ report and reap test-fixture agents per their pattern."
       "$always_on" \
       "$isolation_mode" \
       "$os_user" >/dev/null
+    # Issue #848: bridge_write_role_block just appended a new entry to
+    # the local roster file; invalidate the per-process cache so the
+    # next load re-reads disk instead of replaying the pre-create map.
+    bridge_roster_cache_invalidate
     bridge_load_roster
     if [[ "$engine" == "claude" ]]; then
       # Issue #570: managed autoCompactWindow default is unconditionally

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -5556,7 +5556,11 @@ cmd_sync_cycle() {
 
   # The daemon is long-lived, so dynamic agents created after startup will not
   # exist in memory unless we reload the roster each cycle.
+  # Issue #848: per-process roster memoization means the bare
+  # bridge_load_roster call would no-op after the first cycle —
+  # invalidate the cache here so each cycle observes fresh disk state.
   BRIDGE_DAEMON_LAST_STEP="load_roster"
+  bridge_roster_cache_invalidate
   bridge_load_roster
 
   # Discord relay runs FIRST — lowest-latency path for DM wake
@@ -5575,6 +5579,10 @@ cmd_sync_cycle() {
   # wedge the daemon main loop. 30s ceiling — bridge-sync.sh reconciles roster
   # + state under normal conditions in <1s; timeouts here are pathological.
   bridge_with_timeout 30 bridge_sync "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-sync.sh" >/dev/null 2>&1 || true
+  # Issue #848: bridge-sync.sh ran as a child process and may have
+  # touched the roster files; invalidate so this in-loop reload picks
+  # up any newly-registered dynamic agents.
+  bridge_roster_cache_invalidate
   bridge_load_roster
   BRIDGE_DAEMON_LAST_STEP="queue_gateway"
   if process_queue_gateway_requests; then

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -500,6 +500,10 @@ else
   fi
   "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "${create_args[@]}" >/dev/null
   created=1
+  # Issue #848: the child `agent create` invocation mutated the roster
+  # files on disk, so the next `bridge_load_roster` MUST re-parse them
+  # rather than serve cached state from the earlier load above.
+  bridge_roster_cache_invalidate
   bridge_load_roster
 fi
 
@@ -516,6 +520,10 @@ if [[ $dry_run -eq 0 ]]; then
     bridge_init_append_warning "admin-pair backfill failed: ${pair_output}"
   else
     [[ -n "$pair_output" ]] && printf '%s\n' "$pair_output" >&2
+    # Issue #848: bridge_ensure_admin_codex_pair may have appended a new
+    # static agent to the roster file — invalidate before the re-load
+    # so the next call observes the new entry.
+    bridge_roster_cache_invalidate
     bridge_load_roster
     inject_output=""
     if ! inject_output="$(python3 "$SCRIPT_DIR/bridge-upgrade.py" inject-admin-pair-block --target-root "$BRIDGE_HOME" --admin-agent "$admin_agent" 2>&1)"; then

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -272,6 +272,10 @@ bridge_run_refresh_roster_if_changed() {
     return 0
   fi
 
+  # Issue #848: signature changed on disk — discard the per-process
+  # cache so the next bridge_load_roster actually re-reads the files
+  # instead of returning the cached pre-change state.
+  bridge_roster_cache_invalidate
   bridge_load_roster
   bridge_require_agent "$AGENT"
   # PR-E: re-apply isolation umask after roster reload — bridge-lib.sh's

--- a/bridge-sync.sh
+++ b/bridge-sync.sh
@@ -69,12 +69,24 @@ prune_missing_dynamic_agents() {
       bridge_warn "bridge-sync: archive_dynamic_agent failed for agent='$agent' — skipping; next sweep will retry"
       continue
     fi
+    # Issue #848 (codex r2 Vector 2): bridge_archive_dynamic_agent has just
+    # written the agent's history env to disk via
+    # bridge_write_agent_state_file (lib/bridge-state.sh:2755-2761). That
+    # write alone is sufficient to make the in-process roster cache stale,
+    # so flag the agent for invalidation BEFORE the cleanup half runs.
+    # Without this early flag, an archive-succeeds-but-remove-fails path
+    # falls through the bridge_remove_dynamic_agent_file `continue` below
+    # with the on-disk roster already mutated and the cache flag never set
+    # — bridge_render_active_roster downstream then mis-reports the
+    # pruned-and-archived agent as active.
+    # Rule: track mutation immediately after each successful writer call,
+    # not only after full prune success.
+    PRUNED_DYNAMIC["$agent"]=1
     if ! bridge_remove_dynamic_agent_file "$agent" 2>/dev/null; then
       bridge_warn "bridge-sync: remove_dynamic_agent_file failed for agent='$agent' — skipping; next sweep will retry"
       continue
     fi
     bridge_agent_clear_idle_marker "$agent" 2>/dev/null || true
-    PRUNED_DYNAMIC["$agent"]=1
   done < <(bridge_dynamic_agent_ids)
 
   # Issue #848 (codex r1 Vector 2): bridge_archive_dynamic_agent and

--- a/bridge-sync.sh
+++ b/bridge-sync.sh
@@ -76,11 +76,24 @@ prune_missing_dynamic_agents() {
     bridge_agent_clear_idle_marker "$agent" 2>/dev/null || true
     PRUNED_DYNAMIC["$agent"]=1
   done < <(bridge_dynamic_agent_ids)
+
+  # Issue #848 (codex r1 Vector 2): bridge_archive_dynamic_agent and
+  # bridge_remove_dynamic_agent_file above mutate the roster files on
+  # disk (history env + dynamic .env removal). The Issue #848 per-process
+  # roster memoization in lib/bridge-state.sh means the next
+  # bridge_load_roster call no-ops unless we drop the cache flag here.
+  # Without this invalidate, pruned agents linger in BRIDGE_AGENT_IDS /
+  # BRIDGE_AGENT_* maps for the rest of the sync pass and the downstream
+  # bridge_render_active_roster reports them as active.
+  if [[ ${#PRUNED_DYNAMIC[@]} -gt 0 ]]; then
+    bridge_roster_cache_invalidate
+  fi
 }
 
 refresh_missing_session_ids() {
   local agent sid exclude_csv created_at detected key _resolved _rc
   local -a excluded
+  local persisted_any=0
 
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do
     [[ -z "$agent" ]] && continue
@@ -133,7 +146,19 @@ refresh_missing_session_ids() {
       bridge_warn "bridge-sync: persist_agent_state failed for agent='$agent' — skipping; next sweep will retry"
       continue
     fi
+    persisted_any=1
   done
+
+  # Issue #848 (codex r1 Vector 2): bridge_persist_agent_state writes the
+  # AGENT_SESSION_ID / AGENT_UPDATED_AT fields to the history env (and
+  # the dynamic .env for dynamic agents). With the Issue #848 per-process
+  # roster memoization in place, the caller's next bridge_load_roster
+  # would otherwise no-op and leave BRIDGE_AGENT_SESSION_ID stale for the
+  # downstream bridge_reconcile_idle_markers / bridge_render_active_roster
+  # pass.
+  if [[ "$persisted_any" -eq 1 ]]; then
+    bridge_roster_cache_invalidate
+  fi
 }
 
 bridge_sync_main() {
@@ -145,6 +170,17 @@ bridge_sync_main() {
   refresh_missing_session_ids
   bridge_load_roster
   bridge_reconcile_idle_markers
+  # Issue #848 (codex r1 Vector 6): defensive invalidate immediately
+  # before the active-roster render. The prune/refresh helpers above
+  # invalidate after their own mutations, so the bridge_load_roster
+  # right above this comment already reloaded fresh maps in the normal
+  # path. The defensive invalidate here guarantees that ANY future
+  # mutation slipped into bridge_reconcile_idle_markers (or a helper it
+  # transitively calls) cannot strand bridge_render_active_roster on
+  # stale BRIDGE_AGENT_* maps, which would mis-report pruned dynamic
+  # agents as still-active in the rendered TSV/MD snapshot.
+  bridge_roster_cache_invalidate
+  bridge_load_roster
   bridge_render_active_roster
 }
 

--- a/lib/bridge-admin-pair.sh
+++ b/lib/bridge-admin-pair.sh
@@ -71,6 +71,9 @@ bridge_ensure_admin_codex_pair() {
     # made it. This keeps the install convergent on transient failures
     # rather than leaving an admin with a registered pair but no SOP block.
     # (Issue #517 r1 review finding 3.)
+    # Issue #848: the child process touched the roster files on disk,
+    # so the in-process cache must be discarded before re-reading.
+    bridge_roster_cache_invalidate
     bridge_load_roster
     if bridge_agent_exists "$pair_name"; then
       printf '[admin-pair] create-partial-but-registered: %s\n%s\n' "$pair_name" "$create_output" >&2

--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -494,6 +494,16 @@ print(hashlib.sha1(sys.argv[1].encode("utf-8")).hexdigest())
 PY
 }
 
+# Batch variant of bridge_sha1 — one python3 spawn hashes N inputs. Reads
+# one input per line from stdin, emits hex digests one per line in the
+# same order. Use when a caller knows the full set of inputs upfront
+# (canonical case: roster hydration's per-agent history-key hashing,
+# which used to pay one python3 cold-start per agent). Refs #848.
+bridge_sha1_batch() {
+  bridge_require_python
+  python3 "$BRIDGE_SCRIPT_DIR/scripts/python-helpers/sha1-batch.py"
+}
+
 bridge_redact_inline_env_secrets() {
   local text="${1-}"
   local redacted=""

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -941,6 +941,19 @@ bridge_load_static_histories() {
 }
 
 bridge_load_roster() {
+  # Issue #848: per-process memoization. `agent-bridge`,
+  # `bridge-run.sh`, `bridge-daemon.sh`, and `bridge-start.sh` are
+  # independent processes that each `source bridge-lib.sh`, so the cache
+  # only ever short-circuits inside ONE shell. Within that shell, the
+  # roster files cannot change unless the caller explicitly invalidates
+  # via `bridge_roster_cache_invalidate`, so a single "loaded" flag is
+  # sufficient. Set `BRIDGE_ROSTER_CACHE_DISABLE=1` in env to bypass the
+  # cache entirely (tests).
+  if [[ "${BRIDGE_ROSTER_CACHE_DISABLE:-0}" != "1" \
+        && "${BRIDGE_ROSTER_CACHE_LOADED:-0}" == "1" ]]; then
+    return 0
+  fi
+
   local agent
   local fast_load="${BRIDGE_FAST_ROSTER_LOAD:-0}"
   local isolated_env_file="${BRIDGE_AGENT_ENV_FILE:-}"
@@ -1073,6 +1086,46 @@ bridge_load_roster() {
 
   bridge_init_dirs
 
+  # Issue #848: precompute history keys for all roster entries that still
+  # need one in a single batched python3 invocation. The previous loop
+  # called `bridge_history_key_for → bridge_sha1` per agent, which paid
+  # one python3 cold-start (~50-80ms on macOS) per agent. With ~7 roster
+  # entries that's ~0.5s just on hash spawns; batching collapses that to
+  # one spawn. The agents that already carry an explicit
+  # BRIDGE_AGENT_HISTORY_KEY (set by the roster file) are skipped so we
+  # don't waste a hash slot on them.
+  local -a _bridge_history_key_pending=()
+  local _agent_engine _agent_workdir _hash_input
+  for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+    if [[ -z "${BRIDGE_AGENT_HISTORY_KEY[$agent]:-}" ]]; then
+      _bridge_history_key_pending+=("$agent")
+    fi
+  done
+  if ((${#_bridge_history_key_pending[@]} > 0)) \
+      && command -v python3 >/dev/null 2>&1; then
+    local _hash_inputs=""
+    for agent in "${_bridge_history_key_pending[@]}"; do
+      _agent_engine="$(bridge_agent_engine "$agent")"
+      _agent_workdir="$(bridge_agent_workdir "$agent")"
+      _hash_input="${_agent_engine}|${agent}|${_agent_workdir}"
+      _hash_inputs+="${_hash_input}"$'\n'
+    done
+    # Footgun #11 / here-string deadlock — split the batch output into
+    # an array without `<<<` and without heredoc-stdin. `mapfile` reads
+    # from the pipe directly inside a process substitution, which avoids
+    # the bash 5.3.9 `<<<` write-end stall observed in the v0.10/v0.11
+    # heredoc_write class.
+    local -a _hash_lines=()
+    mapfile -t _hash_lines < <(printf '%s' "$_hash_inputs" | bridge_sha1_batch)
+    local _hash_idx=0
+    for agent in "${_bridge_history_key_pending[@]}"; do
+      BRIDGE_AGENT_HISTORY_KEY["$agent"]="${_hash_lines[$_hash_idx]:-}"
+      _hash_idx=$((_hash_idx + 1))
+    done
+    unset _hash_inputs _hash_lines _hash_idx
+  fi
+  unset _bridge_history_key_pending _agent_engine _agent_workdir _hash_input
+
   for agent in "${BRIDGE_AGENT_IDS[@]}"; do
     BRIDGE_AGENT_SOURCE["$agent"]="${BRIDGE_AGENT_SOURCE[$agent]-static}"
     # Issue #598 Track 1: any id surfaced by the roster files (without an
@@ -1084,6 +1137,9 @@ bridge_load_roster() {
     fi
     BRIDGE_AGENT_LOOP["$agent"]="${BRIDGE_AGENT_LOOP[$agent]-1}"
     BRIDGE_AGENT_CONTINUE["$agent"]="${BRIDGE_AGENT_CONTINUE[$agent]-1}"
+    # Issue #848: per-agent sha1 fallback kept for the edge case where
+    # python3 was unavailable above (batched path skipped). All happy-
+    # path roster entries already have BRIDGE_AGENT_HISTORY_KEY set.
     BRIDGE_AGENT_HISTORY_KEY["$agent"]="${BRIDGE_AGENT_HISTORY_KEY[$agent]-$(bridge_history_key_for "$(bridge_agent_engine "$agent")" "$agent" "$(bridge_agent_workdir "$agent")")}"
     BRIDGE_AGENT_IDLE_TIMEOUT["$agent"]="${BRIDGE_AGENT_IDLE_TIMEOUT[$agent]-$BRIDGE_ON_DEMAND_IDLE_SECONDS}"
     # Issue #597 Track B: default OFF for PreCompact auto-notify. Per-agent
@@ -1108,6 +1164,21 @@ bridge_load_roster() {
     fi
     bridge_reconcile_dynamic_agents_from_tmux
   fi
+
+  # Issue #848: mark the per-process cache populated. Skipped when the
+  # escape hatch is engaged so tests that simulate multiple invocations
+  # in one shell still re-parse the roster files.
+  if [[ "${BRIDGE_ROSTER_CACHE_DISABLE:-0}" != "1" ]]; then
+    BRIDGE_ROSTER_CACHE_LOADED=1
+  fi
+}
+
+# Drop the per-process roster cache. Callers that mutate the roster
+# files mid-shell (e.g., `agb roster edit`, dynamic-agent registration
+# helpers that write directly to disk) MUST invoke this before they
+# expect the next `bridge_load_roster` to re-read disk. Refs #848.
+bridge_roster_cache_invalidate() {
+  BRIDGE_ROSTER_CACHE_LOADED=0
 }
 
 bridge_audit_log() {

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -196,7 +196,13 @@ select_for_path() {
       # bridge_write_roster_status_snapshot 'starting/stalled before
       # engine' branch (Wave B). Cover the regression smoke + the
       # engine-alive unit smoke when this file moves.
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch
+      #
+      # Issue #848 r2: bridge-sync-roster-memo guards the bridge-sync.sh
+      # roster-cache invalidation contract added on top of the r1
+      # per-process memoization. Triggered on bridge-sync.sh and on
+      # lib/bridge-state.sh (which hosts bridge_roster_cache_invalidate
+      # / bridge_load_roster).
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/cli-help/agent-bridge-usage.txt
+++ b/scripts/cli-help/agent-bridge-usage.txt
@@ -1,0 +1,239 @@
+Usage:
+  __CLI_NAME__ status [--watch] [--refresh <seconds>] [--open-limit <count>] [--all-agents]
+  __CLI_NAME__ version [--json]
+  __CLI_NAME__ list
+  __CLI_NAME__ admin [--safe-mode] [--replace] [--continue|--no-continue] [--no-attach] [--no-project-skill]
+  __CLI_NAME__ bootstrap [bootstrap options...] [init options...]
+  __CLI_NAME__ init [--admin <agent>] [--engine claude|codex] [--session <name>] [--channels <csv>] [--dry-run] [--json]
+  __CLI_NAME__ upgrade [--apply] [--check] [--channel stable|dev|current] [--version <semver>] [--ref <git-ref>] [--pull|--no-pull] [--restart-daemon] [--dry-run] [--json] [--strict-merge]
+  __CLI_NAME__ upgrade analyze [--target <bridge-home>] [--json]
+  __CLI_NAME__ upgrade rollback [--target <bridge-home>] [--backup-root <dir>] [--json]
+  __CLI_NAME__ upgrade conflicts <list|diff|adopt|discard|archive|reconcile> [--target <bridge-home>] [--json|--yes|--auto-archive] [<conflict-path>]
+  __CLI_NAME__ daemon <ensure|status|start|stop|sync|run> ...
+  __CLI_NAME__ auth claude-token <add|list|activate|sync|rotate|auto-rotate> ...
+  __CLI_NAME__ escalate question --agent <agent> --question "<text>" [--context "<text>"] [--wait-seconds <seconds>] [--json]
+  __CLI_NAME__ upstream <draft|propose|review> ...
+  __CLI_NAME__ review <policy|request|complete> ...
+  __CLI_NAME__ user <set|show> ...
+  __CLI_NAME__ guard <status|scan|sanitize> ...
+  __CLI_NAME__ diagnose <acl> [--json]
+  __CLI_NAME__ doctor [--json] [--detectors <kind[,kind...]>] [--state-dir <path>] [--task-db <path>]
+  __CLI_NAME__ knowledge <init|operator|capture|promote|search|lint> ...
+  __CLI_NAME__ skills <list> [--agent <name>] [--json]
+  __CLI_NAME__ config <set|get|list-protected> ...
+  __CLI_NAME__ bundle <create|show> ...
+  __CLI_NAME__ intake <triage|show> ...
+  __CLI_NAME__ wave <dispatch|list|show|templates|close-issue> ...
+  __CLI_NAME__ agent <create|update|delete|retire|list|registry|show|reclassify|start|safe-mode|stop|restart|attach|compact|handoff> ...
+  __CLI_NAME__ kill <number|all>
+  __CLI_NAME__ attach [number|name]
+  __CLI_NAME__ urgent <agent> "<message>" [--wait <seconds>]
+  __CLI_NAME__ task <create|inbox|show|claim|done|update|handoff|summary> ...
+  __CLI_NAME__ profile <status|diff|deploy> ...
+  __CLI_NAME__ setup <discord|telegram|teams|agent|admin> ...
+  __CLI_NAME__ cron <inventory|show|import|list|create|update|delete|rebalance-memory-daily|enqueue|sync|run-subagent|errors|cleanup> ...
+  __CLI_NAME__ memory <init|capture|ingest|promote|remember|lint|search|rebuild-index|query> ...
+  __CLI_NAME__ audit [list] [--agent <name>] [--action <type>] [--since <datetime>] [--limit N] [--json]
+  __CLI_NAME__ audit follow --agent <name> [--action <type>] [--contains <text>] [--follow]
+  __CLI_NAME__ audit verify
+  __CLI_NAME__ usage <status|monitor|alerts> ...
+  __CLI_NAME__ watchdog scan [agent...] [--json]
+  __CLI_NAME__ discord <status|sync>
+  __CLI_NAME__ migrate runtime inventory [--json] [--report <path>]
+  __CLI_NAME__ migrate runtime sync [--dry-run]
+  __CLI_NAME__ migrate runtime rewrite-cron [--dry-run] [--json]
+  __CLI_NAME__ migrate runtime rewrite-files [--dry-run] [--json]
+  __CLI_NAME__ migrate docs audit [--all] [agent...]
+  __CLI_NAME__ migrate docs apply [--all] [agent...] [--dry-run]
+  __CLI_NAME__ watchdog scan
+  __CLI_NAME__ migrate workspace plan <agent>
+  __CLI_NAME__ migrate workspace copy <agent> [--dry-run]
+  __CLI_NAME__ migrate workspace cutover <agent> --dry-run
+  __CLI_NAME__ migrate overhead pre-migrate [--output <file>] [--json]
+  __CLI_NAME__ migrate overhead dry-run [--agent <name>|--all] [--json]
+  __CLI_NAME__ migrate overhead apply [--agent <name>|--all] --yes [--dry-run] [--json]
+  __CLI_NAME__ migrate overhead rollback --stamp <YYYYMMDD-HHMMSS-<pid>> [--json]
+  __CLI_NAME__ migrate isolation-v2 dry-run --data-root <path>
+  __CLI_NAME__ migrate isolation-v2 apply --data-root <path> --yes
+  __CLI_NAME__ migrate isolation-v2 rollback --yes
+  __CLI_NAME__ migrate isolation-v2 commit --yes
+  __CLI_NAME__ migrate isolation-v2 status
+  __CLI_NAME__ migrate isolation v2 [--check|--dry-run|--apply] [--agent <name>] [--json]
+  __CLI_NAME__ wiki bootstrap [--agent <name>] [--shared-root <path>] [--dry-run] [--json]
+  __CLI_NAME__ wiki validate [--full|--frontmatter|--broken-link|--tree-edge] [--json]
+  __CLI_NAME__ wiki dedup-scan [--output <file>] [--json]
+  __CLI_NAME__ wiki dedup-apply --plan <file> [--dry-run] [--json]
+  __CLI_NAME__ wiki repair-links [--apply] [--limit N] [--json]
+  __CLI_NAME__ isolate <agent> [--dry-run]
+  __CLI_NAME__ unisolate <agent> [--dry-run]
+  __CLI_NAME__ isolation verify --agent <agent> [--json] [--strict-optional]
+  __CLI_NAME__ inbox [agent] [--all]
+  __CLI_NAME__ show <task-id>
+  __CLI_NAME__ claim <task-id> [--agent <agent>] [--lease <seconds>]
+  __CLI_NAME__ done <task-id> [--agent <agent>] [--note <text> | --note-file <path>]
+  __CLI_NAME__ cancel <task-id> [--actor <name>] [--note <text> | --note-file <path>]
+  __CLI_NAME__ update <task-id> [--status queued|claimed|blocked|in_progress] [--priority ...] [--note ...]
+  __CLI_NAME__ handoff <task-id> --to <agent> [--from <agent>] [--note <text> | --note-file <path>]
+  __CLI_NAME__ summary [agent...]
+  __CLI_NAME__ worktree list
+  __CLI_NAME__ worktree doctor [--dry-run|--apply] [--max-age-days N] [--target-branch ref] [--include-stale] [--prune-branches]
+  __CLI_NAME__ profile status [agent|--all]
+  __CLI_NAME__ profile diff <agent>
+  __CLI_NAME__ profile deploy <agent> [--dry-run] [--force]
+  __CLI_NAME__ agent create <agent> [--engine claude|codex] [--session <name>] [--workdir <path>] [--always-on] [--dry-run] [--json]
+  __CLI_NAME__ agent list [--json]
+  __CLI_NAME__ agent registry [--json]
+  __CLI_NAME__ agent show <agent> [--json]
+  __CLI_NAME__ agent reclassify [--agent <agent>] [--apply] [--json]
+  __CLI_NAME__ agent start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
+  __CLI_NAME__ agent safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
+  __CLI_NAME__ agent stop <agent>
+  __CLI_NAME__ agent restart <agent> [--attach|--no-attach] [--continue|--no-continue] [--dry-run]
+  __CLI_NAME__ agent attach <agent>
+  __CLI_NAME__ agent compact <agent> [--note <text>]
+  __CLI_NAME__ agent handoff <agent> [--note <text>]
+  __CLI_NAME__ setup discord <agent> [--channel <id>]... [--channel-account <account>]
+  __CLI_NAME__ setup telegram <agent> [--allow-from <id>]... [--channel-account <account>]
+  __CLI_NAME__ setup teams <agent> [--app-id <id>] [--tenant-id <id>] [--allow-from <id>]... [--conversation <id>]...
+  __CLI_NAME__ setup agent <agent> [--skip-discord] [--skip-telegram] [--skip-teams] [--test-start]
+  __CLI_NAME__ discord status
+  __CLI_NAME__ discord sync
+  __CLI_NAME__ cron inventory [--mode recurring|one-shot|all] [--family <family>] [--limit <count>]
+  __CLI_NAME__ cron show <job-name-or-id>
+  __CLI_NAME__ cron import [--source-jobs-file <path>] [--dry-run]
+  __CLI_NAME__ cron list [--agent <bridge-agent>] [--enabled yes|no|all] [--limit <count>] [--json]
+  __CLI_NAME__ cron create --agent <bridge-agent> (--schedule "<cron-expr>" | --at "<iso-datetime>") --title "<title>" [--payload "<text>" | --payload-file <path>] [--tz <iana-tz>] [--delete-after-run]
+  __CLI_NAME__ cron update <job-id> [--agent <bridge-agent>] [--schedule "<cron-expr>" | --at "<iso-datetime>"] [--title "<title>"] [--payload "<text>" | --payload-file <path>] [--tz <iana-tz>] [--enable|--disable] [--delete-after-run|--keep-after-run]
+  __CLI_NAME__ cron delete <job-id>
+  __CLI_NAME__ cron enqueue <job-name-or-id> [--slot <slot-key>] [--dry-run]
+  __CLI_NAME__ cron sync [--dry-run] [--json] [--since <iso-datetime>] [--now <iso-datetime>]
+  __CLI_NAME__ cron run-subagent <run-id> [--dry-run]
+  __CLI_NAME__ cron errors report [--agent <agent>] [--family <family>] [--limit <count>] [--json]
+  __CLI_NAME__ cron cleanup report [--mode expired-one-shot] [--json]
+  __CLI_NAME__ cron cleanup prune [--mode expired-one-shot] [--dry-run]
+  __CLI_NAME__ memory init --agent <agent> [--user <id[:display-name]>] [--json]
+  __CLI_NAME__ knowledge init [--team-name <name>] [--json]
+  __CLI_NAME__ knowledge operator set --user owner --name "<name>"
+  __CLI_NAME__ knowledge operator show [--json]
+  __CLI_NAME__ bundle create --to reviewer --title "QA handoff" --summary "Review attached draft" --action "Return blockers" --artifact ~/agent-bridge/shared/report.md::draft
+  __CLI_NAME__ intake triage --capture <capture-id> --owner patch --summary "Customer needs ETA update" --category support --route
+  __CLI_NAME__ knowledge capture --source chat --text "..."
+  __CLI_NAME__ knowledge promote --kind people --summary "..."
+  __CLI_NAME__ knowledge search --query "..."
+  __CLI_NAME__ memory capture --agent <agent> --source discord --user owner --text "..."
+  __CLI_NAME__ memory ingest --agent <agent> --latest
+  __CLI_NAME__ memory promote --agent <agent> --kind shared --page personal-preferences --capture <id>
+  __CLI_NAME__ memory remember --agent <agent> --source chat --user owner --text "..." [--kind user|shared|project|decision]
+  __CLI_NAME__ memory lint --agent <agent>
+  __CLI_NAME__ migrate workspace plan <agent>
+  __CLI_NAME__ migrate workspace copy <agent> [--dry-run]
+  __CLI_NAME__ migrate workspace cutover <agent> --dry-run
+  __CLI_NAME__ --codex|--claude --name <agent> [--loop] [--no-continue] [--workdir <dir>] [--replace] [--no-attach] [--no-project-skill] [--prefer wake|new|shared] [--test-fixture]
+
+Examples:
+  __CLI_NAME__ status
+  __CLI_NAME__ status --watch
+  __CLI_NAME__ version
+  __CLI_NAME__ admin
+  __CLI_NAME__ admin --safe-mode
+  __CLI_NAME__ bootstrap --admin manager --engine claude --channels plugin:telegram@claude-plugins-official
+  __CLI_NAME__ init --admin manager --engine claude --channels plugin:telegram@claude-plugins-official
+  __CLI_NAME__ upgrade
+  __CLI_NAME__ upgrade --strict-merge --json
+  __CLI_NAME__ upgrade analyze --json
+  __CLI_NAME__ upgrade rollback --json
+  __CLI_NAME__ upgrade conflicts list --json
+  __CLI_NAME__ upgrade conflicts reconcile --auto-archive
+  __CLI_NAME__ upgrade conflicts adopt --yes <conflict-path>
+  __CLI_NAME__ auth claude-token add --id claude-a --stdin --activate --sync
+  __CLI_NAME__ auth claude-token auto-rotate enable --threshold 99
+  __CLI_NAME__ escalate question --agent reviewer --question "Should I ship this now?" --context "Second ask without a user reply."
+  __CLI_NAME__ upstream draft --title "setup fails" --symptom "..." --why "..." --output /tmp/issue.md
+  __CLI_NAME__ upstream propose --title "setup fails" --body-file /tmp/issue.md
+  __CLI_NAME__ review request --subject "release check" --reviewer reviewer --body-file /tmp/plan.md
+  __CLI_NAME__ user set --name "Sean" --timezone Asia/Seoul
+  __CLI_NAME__ user show --json
+  __CLI_NAME__ knowledge init --team-name "Acme"
+  __CLI_NAME__ knowledge operator set --user owner --name "Sean"
+  __CLI_NAME__ bundle show 20260411T130000+0900-qa-handoff --json
+  __CLI_NAME__ intake show 20260411T130000+0900-mail --json
+  __CLI_NAME__ knowledge search --query "primary operator"
+  __CLI_NAME__ config list-protected
+  __CLI_NAME__ config get --path $BRIDGE_HOME/agents/foo/.discord/access.json
+  __CLI_NAME__ config set --path $BRIDGE_HOME/agents/foo/.discord/access.json --change groups.append=12345
+  __CLI_NAME__ list
+  __CLI_NAME__ kill 1
+  __CLI_NAME__ kill all
+  __CLI_NAME__ agent create reviewer --engine claude
+  __CLI_NAME__ agent list --json
+  __CLI_NAME__ agent registry --json
+  __CLI_NAME__ agent show reviewer --json
+  __CLI_NAME__ agent reclassify --apply
+  __CLI_NAME__ agent start reviewer --dry-run
+  __CLI_NAME__ agent restart reviewer --attach
+  __CLI_NAME__ agent compact static-discord-bot
+  __CLI_NAME__ agent handoff static-discord-bot --note "context critical"
+  __CLI_NAME__ attach
+  __CLI_NAME__ attach 1
+  __CLI_NAME__ attach reviewer
+  __CLI_NAME__ worktree list
+  __CLI_NAME__ cron inventory --family memory-daily --limit 10
+  __CLI_NAME__ cron import --dry-run
+  __CLI_NAME__ cron list --agent <agent>
+  __CLI_NAME__ cron create --agent <agent> --schedule "0 9 * * *" --title "일일 모니터링"
+  __CLI_NAME__ cron rebalance-memory-daily --dry-run
+  __CLI_NAME__ cron enqueue <memory-daily-job-id> --slot 2026-04-05 --dry-run
+  __CLI_NAME__ cron sync --dry-run
+  __CLI_NAME__ cron run-subagent <run-id> --dry-run
+  __CLI_NAME__ cron errors report --limit 20
+  __CLI_NAME__ cron cleanup report
+  __CLI_NAME__ memory init --agent assistant --user owner:Owner
+  __CLI_NAME__ memory capture --agent assistant --source telegram --user owner --author "Alice" --text "I prefer morning updates."
+  __CLI_NAME__ memory ingest --agent assistant --latest
+  __CLI_NAME__ memory promote --agent assistant --kind user --user owner --summary "User prefers concise morning updates."
+  __CLI_NAME__ memory promote --agent assistant --kind user-profile --user owner --summary "답변 없으면 Discord로 에스컬레이션."   # appends to shared users/<uid>/USER.md Stable Preferences
+  __CLI_NAME__ memory remember --agent assistant --source chat --user owner --text "User prefers concise morning updates." --kind user
+  __CLI_NAME__ memory lint --agent assistant
+  __CLI_NAME__ memory search --agent assistant --user owner --query "concise morning updates"
+  __CLI_NAME__ memory rebuild-index --agent assistant
+  __CLI_NAME__ memory query --agent assistant --user owner --query "morning updates"
+  __CLI_NAME__ audit --agent patch --limit 20
+  __CLI_NAME__ audit follow --agent patch --follow
+  __CLI_NAME__ audit verify
+  __CLI_NAME__ usage status --json
+  __CLI_NAME__ usage alerts --json
+  __CLI_NAME__ setup discord tester
+  __CLI_NAME__ setup telegram tester --allow-from 123456789
+  __CLI_NAME__ setup teams tester --allow-from 00000000-0000-0000-0000-000000000000
+  __CLI_NAME__ setup agent tester
+  __CLI_NAME__ migrate runtime inventory
+  __CLI_NAME__ migrate runtime sync --dry-run
+  __CLI_NAME__ migrate runtime rewrite-cron --dry-run
+  __CLI_NAME__ migrate runtime rewrite-files --dry-run
+  __CLI_NAME__ migrate docs audit --all
+  __CLI_NAME__ migrate docs apply --all --dry-run
+  __CLI_NAME__ migrate workspace plan <agent>
+  __CLI_NAME__ migrate workspace copy <agent> --dry-run
+  __CLI_NAME__ migrate workspace cutover <agent> --dry-run
+  __CLI_NAME__ inbox developer
+  __CLI_NAME__ task create --to tester --title "재테스트" --body-file ~/agent-bridge/shared/report.md
+  __CLI_NAME__ claim 12 --agent tester
+  __CLI_NAME__ urgent developer "[TESTER] 프로덕션 장애 확인 필요"
+  __CLI_NAME__ --codex --name dev
+  __CLI_NAME__ --codex --name qa --loop
+  __CLI_NAME__ --claude --name reviewer --workdir /path/to/repo
+  __CLI_NAME__ --codex --name worker-a --prefer new
+
+By default, __CLI_NAME__ installs a project-local agent-bridge skill in the target workdir:
+  Codex  -> .agents/skills/agent-bridge/SKILL.md
+  Claude -> .claude/skills/agent-bridge/SKILL.md
+
+Bridge-owned Claude homes also receive shared runtime skills:
+  .claude/skills/agent-bridge-runtime/SKILL.md
+  .claude/skills/cron-manager/SKILL.md
+
+If a same-name session is already active with different engine/workdir/loop settings,
+__CLI_NAME__ will refuse to attach. Use `__CLI_NAME__ kill <number>` or rerun with `--replace`.
+
+Primary command: `agent-bridge`
+Short alias: `agb`

--- a/scripts/python-helpers/sha1-batch.py
+++ b/scripts/python-helpers/sha1-batch.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Batch SHA1 digester for `bridge_sha1_batch`.
+
+Reads one input per line from stdin, prints the hex digest of each input
+to stdout in the same order. One newline per output digest. Avoids the
+per-call ``python3`` cold-start that ``bridge_sha1`` pays when the caller
+already knows the full set of inputs (e.g. roster hydration hashing one
+key per agent). Refs issue #848.
+"""
+
+import hashlib
+import sys
+
+
+def main() -> None:
+    out = sys.stdout
+    for line in sys.stdin:
+        # The wire format strips exactly one trailing newline per input.
+        # `rstrip("\n")` (not bare `rstrip()`) preserves trailing spaces
+        # and other whitespace that the per-call `bridge_sha1` would
+        # otherwise hash verbatim. Matches the encoding used by
+        # `bridge_sha1` (utf-8, no trailing newline).
+        out.write(
+            hashlib.sha1(line.rstrip("\n").encode("utf-8")).hexdigest()
+        )
+        out.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke/bridge-sync-roster-memo.sh
+++ b/scripts/smoke/bridge-sync-roster-memo.sh
@@ -341,10 +341,51 @@ test_sync_main_render_excludes_pruned() {
   fi
 }
 
+# T6 — Issue #848 codex r2 Vector 2: archive succeeds + remove fails
+# must STILL invalidate the cache, because the archive write has already
+# mutated the on-disk history env. Pre-r3 the flag was only flipped AFTER
+# remove succeeded, so this path fell through `continue` with the cache
+# left stale. Override `bridge_remove_dynamic_agent_file` to return 1 so
+# we exercise the half-success branch deterministically.
+test_prune_archive_ok_remove_fail_still_invalidates() {
+  reset_stubs
+  local now
+  now="$(date +%s)"
+  register_dynamic_agent "stale-half-fail" "$((now - 21600))"  # 6h ago
+  BRIDGE_AGENT_IDS=(stale-half-fail)
+  BRIDGE_ROSTER_CACHE_LOADED=1
+
+  # Override the remove stub for this test only — archive still succeeds
+  # via the existing stub at line 110.
+  # shellcheck disable=SC2329  # invoked indirectly via prune_missing_dynamic_agents
+  bridge_remove_dynamic_agent_file() {
+    STUB_REMOVED[$1]=0
+    return 1
+  }
+
+  unset BRIDGE_DYNAMIC_START_GRACE_SECONDS
+  prune_missing_dynamic_agents
+
+  # Restore the default stub so subsequent tests see the success path.
+  # shellcheck disable=SC2329  # invoked indirectly via prune_missing_dynamic_agents
+  bridge_remove_dynamic_agent_file() {
+    STUB_REMOVED[$1]=1
+    return 0
+  }
+
+  smoke_assert_eq "1" "${STUB_ARCHIVED[stale-half-fail]-0}" \
+    "T6 archive ran (history env mutated on disk)"
+  smoke_assert_eq "0" "${STUB_REMOVED[stale-half-fail]-1}" \
+    "T6 remove failed (simulated)"
+  smoke_assert_eq "0" "${BRIDGE_ROSTER_CACHE_LOADED}" \
+    "T6 cache flag invalidated even though remove failed (archive write alone is sufficient)"
+}
+
 smoke_run "T1 prune invalidates cache on churn"            test_prune_invalidates_on_churn
 smoke_run "T2 prune leaves cache intact without churn"     test_prune_skips_invalidate_without_churn
 smoke_run "T3 refresh invalidates cache on persist"        test_refresh_invalidates_on_persist
 smoke_run "T4 refresh leaves cache intact without churn"   test_refresh_skips_invalidate_without_churn
 smoke_run "T5 sync render excludes pruned dynamic"         test_sync_main_render_excludes_pruned
+smoke_run "T6 prune archive-ok+remove-fail still invalidates" test_prune_archive_ok_remove_fail_still_invalidates
 
 smoke_log "all checks passed"

--- a/scripts/smoke/bridge-sync-roster-memo.sh
+++ b/scripts/smoke/bridge-sync-roster-memo.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/bridge-sync-roster-memo.sh — Issue #848 r2 (codex Vector
+# 2 + 6) regression fixture.
+#
+# Guards bridge-sync.sh's roster-cache invalidation contract from
+# regressing. The Issue #848 r1 perf patch added per-process memoization
+# to `bridge_load_roster` (BRIDGE_ROSTER_CACHE_LOADED flag in
+# lib/bridge-state.sh). codex r1 review caught that bridge-sync.sh
+# mutates the roster files (archive / remove / persist) but the
+# second/third `bridge_load_roster` calls in `bridge_sync_main` were
+# no-oping against the cache — so pruned dynamic agents lingered in
+# BRIDGE_AGENT_* maps for the rest of the sync pass and the downstream
+# `bridge_render_active_roster` reported them as still-active.
+#
+# r2 fix: prune_missing_dynamic_agents / refresh_missing_session_ids
+# now call `bridge_roster_cache_invalidate` after their mutations, and
+# `bridge_sync_main` has a defensive invalidate immediately before
+# `bridge_render_active_roster`.
+#
+# Test plan:
+#   T1. `prune_missing_dynamic_agents` flips
+#       BRIDGE_ROSTER_CACHE_LOADED from 1 -> 0 when it prunes at least
+#       one stale dynamic agent.
+#   T2. `prune_missing_dynamic_agents` does NOT touch the flag when
+#       there is nothing to prune (no churn => no invalidation).
+#   T3. `refresh_missing_session_ids` flips the flag from 1 -> 0 when
+#       it persists at least one agent state.
+#   T4. `refresh_missing_session_ids` leaves the flag intact when no
+#       agent needs a fresh session id (no churn => no invalidation).
+#   T5. `bridge_sync_main` end-to-end: spawn 2 dynamic agents, archive
+#       1, run sync, verify the rendered active-roster has 1 (not 2).
+#
+# Like scripts/smoke/dynamic-start-grace.sh, this fixture sources
+# bridge-sync.sh directly and shadows the real bridge-state.sh helpers
+# so we can drive the prune/refresh logic without a live tmux/queue
+# stack. T5 stubs `bridge_render_active_roster` itself to capture which
+# agents are visible at render time, since the real render path runs
+# `bridge_queue_cli` (sqlite) + python3 helpers that pull in a much
+# larger surface than this smoke needs to exercise.
+#
+# Footgun #11 (heredoc_write deadlock class): this fixture writes
+# `printf '%s\n' >$tmp` only — no `python3 - <<'PY'`, no `cat <<EOF
+# > $tmp` with multi-line bodies, no `<<<` here-strings. See
+# `memory/feedback_bash_heredoc_write_class_recurrence.md`.
+
+set -euo pipefail
+
+# Re-exec under Bash 4+ for associative arrays. macOS ships /bin/bash
+# 3.2 — match the recipe used by scripts/smoke/dynamic-start-grace.sh.
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash"; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$_candidate" "${BASH_SOURCE[0]}" "$@"
+    fi
+  done
+  echo "[smoke:bridge-sync-roster-memo] requires Bash 4+ (host is ${BASH_VERSION})" >&2
+  exit 1
+fi
+
+SMOKE_NAME="bridge-sync-roster-memo"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "bridge-sync-roster-memo"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/bridge-sync.sh"
+
+if ! declare -F prune_missing_dynamic_agents >/dev/null; then
+  smoke_fail "prune_missing_dynamic_agents not defined after sourcing bridge-sync.sh"
+fi
+if ! declare -F refresh_missing_session_ids >/dev/null; then
+  smoke_fail "refresh_missing_session_ids not defined after sourcing bridge-sync.sh"
+fi
+if ! declare -F bridge_sync_main >/dev/null; then
+  smoke_fail "bridge_sync_main not defined after sourcing bridge-sync.sh"
+fi
+if ! declare -F bridge_roster_cache_invalidate >/dev/null; then
+  smoke_fail "bridge_roster_cache_invalidate not defined after sourcing bridge-sync.sh (lib/bridge-state.sh missing?)"
+fi
+
+# Stub state — same pattern as scripts/smoke/dynamic-start-grace.sh.
+declare -g -A STUB_DYNAMIC_AGENTS=()
+declare -g -A STUB_ACTIVE=()
+declare -g -A STUB_ARCHIVED=()
+declare -g -A STUB_REMOVED=()
+declare -g -A STUB_PERSISTED=()
+declare -g -A STUB_RENDER_SEEN=()
+
+bridge_agent_is_active() {
+  [[ -n "${STUB_ACTIVE[$1]+x}" ]]
+}
+
+bridge_dynamic_agent_ids() {
+  local a
+  for a in "${!STUB_DYNAMIC_AGENTS[@]}"; do
+    printf '%s\n' "$a"
+  done | sort
+}
+
+bridge_archive_dynamic_agent() {
+  STUB_ARCHIVED[$1]=1
+  return 0
+}
+
+bridge_remove_dynamic_agent_file() {
+  STUB_REMOVED[$1]=1
+  return 0
+}
+
+bridge_agent_clear_idle_marker() {
+  return 0
+}
+
+bridge_agent_session_id() {
+  printf '%s' "${BRIDGE_AGENT_SESSION_ID[$1]-}"
+}
+
+bridge_agent_engine() {
+  printf 'codex'
+}
+
+bridge_agent_workdir() {
+  printf '/tmp/smoke-workdir'
+}
+
+bridge_detect_session_id() {
+  # signature: (engine, workdir, created_at, exclude_csv)
+  # return a fixed synthetic id so refresh_missing_session_ids has
+  # something to persist.
+  printf 'session-id-%s\n' "$$"
+}
+
+bridge_resolve_resume_session_id() {
+  # signature: (engine, agent, workdir, detected). pass through the
+  # detected value so refresh_missing_session_ids proceeds to persist.
+  printf '%s' "${4-}"
+}
+
+bridge_persist_agent_state() {
+  STUB_PERSISTED[$1]=1
+  return 0
+}
+
+bridge_reconcile_idle_markers() {
+  return 0
+}
+
+bridge_render_active_roster() {
+  # Capture which agents are visible at render time so T5 can assert
+  # the pruned agent disappears from the rendered set.
+  local agent
+  for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+    if bridge_agent_is_active "$agent"; then
+      STUB_RENDER_SEEN[$agent]=1
+    fi
+  done
+}
+
+bridge_warn() {
+  printf '[warn] %s\n' "$*" >&2
+}
+
+# bridge_load_roster replacement that simulates a real reload by
+# repopulating BRIDGE_AGENT_IDS from the live STUB_DYNAMIC_AGENTS set
+# (minus anything we've already marked archived+removed). This lets T5
+# detect whether `bridge_sync_main` actually re-reads the roster after
+# pruning. When the cache flag is set, the memo no-op is preserved by
+# the real implementation in lib/bridge-state.sh — but we replace it
+# with a stub here so the smoke does not need a real roster file on
+# disk. The stub honors the cache flag in the same way.
+bridge_load_roster() {
+  if [[ "${BRIDGE_ROSTER_CACHE_LOADED:-0}" == "1" ]]; then
+    return 0
+  fi
+  # Repopulate BRIDGE_AGENT_IDS from STUB_DYNAMIC_AGENTS minus already-
+  # pruned entries. Mirrors what the real lib/bridge-state.sh would do
+  # after the dynamic .env files are removed.
+  unset BRIDGE_AGENT_IDS
+  declare -g -a BRIDGE_AGENT_IDS=()
+  local a
+  for a in "${!STUB_DYNAMIC_AGENTS[@]}"; do
+    if [[ -n "${STUB_ARCHIVED[$a]+x}" && -n "${STUB_REMOVED[$a]+x}" ]]; then
+      continue
+    fi
+    BRIDGE_AGENT_IDS+=("$a")
+  done
+  BRIDGE_ROSTER_CACHE_LOADED=1
+}
+
+declare -g -A BRIDGE_AGENT_CREATED_AT=()
+declare -g -A BRIDGE_AGENT_SESSION_ID=()
+declare -g -a BRIDGE_AGENT_IDS=()
+
+reset_stubs() {
+  unset STUB_DYNAMIC_AGENTS STUB_ACTIVE STUB_ARCHIVED STUB_REMOVED STUB_PERSISTED STUB_RENDER_SEEN
+  unset BRIDGE_AGENT_CREATED_AT BRIDGE_AGENT_SESSION_ID BRIDGE_AGENT_IDS
+  unset CLAIMED_SESSION_IDS PRUNED_DYNAMIC
+  declare -g -A STUB_DYNAMIC_AGENTS=()
+  declare -g -A STUB_ACTIVE=()
+  declare -g -A STUB_ARCHIVED=()
+  declare -g -A STUB_REMOVED=()
+  declare -g -A STUB_PERSISTED=()
+  declare -g -A STUB_RENDER_SEEN=()
+  declare -g -A BRIDGE_AGENT_CREATED_AT=()
+  declare -g -A BRIDGE_AGENT_SESSION_ID=()
+  declare -g -a BRIDGE_AGENT_IDS=()
+  declare -g -A CLAIMED_SESSION_IDS=()
+  declare -g -A PRUNED_DYNAMIC=()
+  BRIDGE_ROSTER_CACHE_LOADED=0
+}
+
+register_dynamic_agent() {
+  local agent="$1"
+  local created_at="$2"
+  STUB_DYNAMIC_AGENTS["$agent"]=1
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$created_at"
+}
+
+# T1 — prune_missing_dynamic_agents invalidates cache when it prunes.
+test_prune_invalidates_on_churn() {
+  reset_stubs
+  local now
+  now="$(date +%s)"
+  register_dynamic_agent "stale-prune" "$((now - 21600))"  # 6h ago, will prune
+  # Seed roster maps then pre-set the cache as "loaded" so we can see
+  # whether prune flips it back.
+  BRIDGE_AGENT_IDS=(stale-prune)
+  BRIDGE_ROSTER_CACHE_LOADED=1
+
+  unset BRIDGE_DYNAMIC_START_GRACE_SECONDS
+  prune_missing_dynamic_agents
+
+  smoke_assert_eq "1" "${STUB_ARCHIVED[stale-prune]-0}" \
+    "T1 stale dynamic was archived"
+  smoke_assert_eq "0" "${BRIDGE_ROSTER_CACHE_LOADED}" \
+    "T1 cache flag invalidated after prune"
+}
+
+# T2 — prune_missing_dynamic_agents leaves cache intact when nothing
+# to prune (no churn ⇒ no need to drop the cache).
+test_prune_skips_invalidate_without_churn() {
+  reset_stubs
+  local now
+  now="$(date +%s)"
+  register_dynamic_agent "fresh-keep" "$((now - 60))"  # 60s ago, within grace
+  STUB_ACTIVE[active-keep]=1  # active agent never pruned
+  register_dynamic_agent "active-keep" "$((now - 21600))"
+
+  BRIDGE_AGENT_IDS=(fresh-keep active-keep)
+  BRIDGE_ROSTER_CACHE_LOADED=1
+
+  unset BRIDGE_DYNAMIC_START_GRACE_SECONDS
+  prune_missing_dynamic_agents
+
+  smoke_assert_eq "" "${STUB_ARCHIVED[fresh-keep]-}" \
+    "T2 fresh dynamic NOT archived (within grace)"
+  smoke_assert_eq "" "${STUB_ARCHIVED[active-keep]-}" \
+    "T2 active dynamic NOT archived (live session)"
+  smoke_assert_eq "1" "${BRIDGE_ROSTER_CACHE_LOADED}" \
+    "T2 cache flag preserved when no prune happened"
+}
+
+# T3 — refresh_missing_session_ids invalidates cache when it persists.
+test_refresh_invalidates_on_persist() {
+  reset_stubs
+  local now
+  now="$(date +%s)"
+  STUB_DYNAMIC_AGENTS[needs-session]=1
+  STUB_ACTIVE[needs-session]=1
+  BRIDGE_AGENT_CREATED_AT[needs-session]="$now"
+  # Empty session_id triggers the detect+persist branch.
+  BRIDGE_AGENT_SESSION_ID[needs-session]=""
+  BRIDGE_AGENT_IDS=(needs-session)
+  BRIDGE_ROSTER_CACHE_LOADED=1
+
+  refresh_missing_session_ids
+
+  smoke_assert_eq "1" "${STUB_PERSISTED[needs-session]-0}" \
+    "T3 needs-session agent persisted"
+  smoke_assert_eq "0" "${BRIDGE_ROSTER_CACHE_LOADED}" \
+    "T3 cache flag invalidated after persist"
+}
+
+# T4 — refresh_missing_session_ids leaves cache intact when no agent
+# needs a fresh session id (no churn ⇒ no need to drop the cache).
+test_refresh_skips_invalidate_without_churn() {
+  reset_stubs
+  local now
+  now="$(date +%s)"
+  STUB_DYNAMIC_AGENTS[already-known]=1
+  STUB_ACTIVE[already-known]=1
+  BRIDGE_AGENT_CREATED_AT[already-known]="$now"
+  # Non-empty session_id => refresh short-circuits without persisting.
+  BRIDGE_AGENT_SESSION_ID[already-known]="already-known-session-xyz"
+  BRIDGE_AGENT_IDS=(already-known)
+  BRIDGE_ROSTER_CACHE_LOADED=1
+
+  refresh_missing_session_ids
+
+  smoke_assert_eq "" "${STUB_PERSISTED[already-known]-}" \
+    "T4 already-known agent NOT re-persisted"
+  smoke_assert_eq "1" "${BRIDGE_ROSTER_CACHE_LOADED}" \
+    "T4 cache flag preserved when nothing was persisted"
+}
+
+# T5 — bridge_sync_main end-to-end: pruned agent does not appear in
+# the rendered active roster. The regression vector is: r1 perf patch
+# without invalidate ⇒ bridge_render_active_roster sees the stale
+# BRIDGE_AGENT_IDS that still contains the pruned agent.
+test_sync_main_render_excludes_pruned() {
+  reset_stubs
+  local now
+  now="$(date +%s)"
+  # Two dynamic agents — one active (kept), one stale (pruned).
+  register_dynamic_agent "alpha-keep" "$((now - 21600))"  # 6h old
+  STUB_ACTIVE[alpha-keep]=1  # has tmux ⇒ kept
+  register_dynamic_agent "beta-prune" "$((now - 21600))"  # 6h old
+  # beta-prune has no STUB_ACTIVE entry ⇒ pruned by sync.
+
+  unset BRIDGE_DYNAMIC_START_GRACE_SECONDS
+  bridge_sync_main
+
+  smoke_assert_eq "1" "${STUB_ARCHIVED[beta-prune]-0}" \
+    "T5 stale agent (beta-prune) archived during sync"
+  smoke_assert_eq "" "${STUB_ARCHIVED[alpha-keep]-}" \
+    "T5 active agent (alpha-keep) NOT archived"
+  smoke_assert_eq "1" "${STUB_RENDER_SEEN[alpha-keep]-0}" \
+    "T5 active agent (alpha-keep) visible in rendered active roster"
+  if [[ -n "${STUB_RENDER_SEEN[beta-prune]+x}" ]]; then
+    smoke_fail "T5 pruned agent (beta-prune) leaked into rendered active roster — cache invalidation regression"
+  fi
+}
+
+smoke_run "T1 prune invalidates cache on churn"            test_prune_invalidates_on_churn
+smoke_run "T2 prune leaves cache intact without churn"     test_prune_skips_invalidate_without_churn
+smoke_run "T3 refresh invalidates cache on persist"        test_refresh_invalidates_on_persist
+smoke_run "T4 refresh leaves cache intact without churn"   test_refresh_skips_invalidate_without_churn
+smoke_run "T5 sync render excludes pruned dynamic"         test_sync_main_render_excludes_pruned
+
+smoke_log "all checks passed"


### PR DESCRIPTION
## Summary

`agb --help` cold-start was ~1.0s on macOS Bash 5.x, dominated by 18 `python3` cold-starts per invocation (~50-80ms each on macOS). Three targeted reductions:

- **`bridge_sha1_batch` helper** (`lib/bridge-core.sh` + `scripts/python-helpers/sha1-batch.py`) — one `python3` spawn hashes N inputs from stdin. Roster hydration's per-agent history-key sha1 loop in `lib/bridge-state.sh::bridge_load_roster` now precomputes every key in a single batched invocation instead of paying one cold-start per agent.
- **Per-process `bridge_load_roster` memoization** — `agent-bridge`, `bridge-run.sh`, `bridge-daemon.sh`, `bridge-init.sh`, `bridge-cron.sh` etc. each load the roster independently; within one shell the second+ call now no-ops. `bridge_roster_cache_invalidate` is wired into every call site that mutates the roster files on disk via a child process (`bridge-init`, `bridge-agent create`, admin-pair backfill, daemon-loop iterations, `bridge-run` signature-changed reload). `BRIDGE_ROSTER_CACHE_DISABLE=1` env opts out (tests).
- **`--help` / `-h` / `--version` / `-V` short-circuit** in `agent-bridge` — paid the full roster-hydration cost only to print static usage / version text. Now exits before `bridge_load_roster`. `agb` is a one-line `exec` shim, so it inherits the fix. `--version` / `-V` rewrite to the existing `version` subcommand handler via `set --` to avoid duplicating its `--json` + source-ref formatting.

Closes #848

## Measurements

Isolated `BRIDGE_HOME` with a 7-agent roster fixture (5 runs each, `/usr/bin/time -p`):

| | Mean wall-clock | python3 spawns |
| --- | --- | --- |
| Before (`agent-bridge --help`) | 1.008 s | 7 (one `bridge_sha1` per agent) |
| After (`agent-bridge --help`) | 0.088 s | 0 (skipped) |
| **Improvement** | **~91%** | — |

`bridge_sha1_batch` produces byte-identical digests to the per-call `bridge_sha1` across normal inputs, trailing-whitespace inputs, and empty lines.

`bridge_load_roster` second-call wall-clock with cache: 0.000s. After `bridge_roster_cache_invalidate`: full reload restored.

## Footgun discipline

- New `scripts/python-helpers/sha1-batch.py` is a real file (NOT heredoc-stdin / `python3 - <<'PY'`) — honors footgun #11.
- The roster-key batch wiring in `bridge-state.sh` uses `mapfile -t … < <(…)` not `<<<`, to avoid the bash 5.3.9 here-string write-end stall observed in the v0.10/v0.11 heredoc_write class.
- Every Edit/Write touched a path under the worktree only; primary checkout stayed clean.

## Test plan

- [x] `bash -n` PASS on all touched files (`agent-bridge`, `bridge-agent.sh`, `bridge-daemon.sh`, `bridge-init.sh`, `bridge-run.sh`, `lib/bridge-admin-pair.sh`, `lib/bridge-core.sh`, `lib/bridge-state.sh`)
- [x] `shellcheck -x` PASS with no new warnings (pre-existing SC2031 on bridge-agent.sh unrelated, confirmed against base via stash diff)
- [x] `python3 -c "import ast; ast.parse(open('scripts/python-helpers/sha1-batch.py').read())"` PASS
- [x] `bridge_sha1_batch` digest equivalence: matches per-call `bridge_sha1` on `foo`, `bar`, `baz`, `'  spaces  '`, empty line
- [x] `agent-bridge --help` / `-h` render usage; `agent-bridge --version` / `-V` / `version` render version block
- [x] `agent-bridge list` end-to-end still hydrates roster (trace shows 1 batched sha1-batch.py spawn instead of 7 per-agent spawns)
- [x] `bridge_load_roster` memo: second call 0.000s; invalidate + load restores 0.97s reload
- [x] `BRIDGE_ROSTER_CACHE_DISABLE=1` bypasses memo (both calls ~0.78s)
- [x] `scripts/smoke-test.sh` exits at the same pre-existing SC2026 lint gate on `bridge-upgrade.sh:551` with or without these changes (verified via `git stash` cross-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)