### PR TITLE
feat(isolation): sudo write helper symmetric to PR #836 read helper (refs #857 PR-1)

### DIFF
--- a/lib/bridge-isolation-helpers.sh
+++ b/lib/bridge-isolation-helpers.sh
@@ -125,3 +125,131 @@ bridge_isolation_run_as_agent_user_via_bash() {
   fi
   return "$rc"
 }
+
+# bridge_isolation_write_file_as_agent_user_via_bash <agent> <dest_path> [mode]
+#
+# Symmetric WRITE counterpart to bridge_isolation_run_as_agent_user_via_bash.
+# Reads content from stdin and atomically writes it to <dest_path> as the
+# agent's isolated UID via:
+#   sudo -n -u <os_user> ${BRIDGE_BASH_BIN:-bash} -c "$script" bridge-isolation "$dest_path" "$mode"
+#
+# The inline script:
+#   1. Validates the destination directory exists (does NOT mkdir).
+#   2. Tightens umask to 0077 so the in-flight temp file is never world/group
+#      visible.
+#   3. Creates a temp file inside the destination directory (same-fs, so
+#      `mv -f` is atomic).
+#   4. Streams stdin into the temp file via `cat -` (NOT a heredoc).
+#   5. chmods the temp file to <mode> BEFORE the rename so the published file
+#      lands at the correct mode without a race.
+#   6. mv -f temp -> dest.
+#
+# Returns (mirrors the read helper):
+#   0   — agent isolated, sudo OK, write succeeded.
+#   1   — agent NOT in linux-user isolation (caller should fall back to a
+#         direct controller-side write).
+#   2   — agent isolated but passwordless sudo unavailable.
+#   3+  — agent isolated, sudo OK, script returned non-zero. Matches the
+#         read helper's convention: a script rc of 1 or 2 is shifted into
+#         the 3+ band (rc+2) so it stays distinct from the pre-flight rc
+#         band; a script rc of 3 or higher is returned unchanged. The
+#         inline script reserves these exit codes:
+#           script rc 5  -> destination directory missing
+#           script rc 6  -> mktemp failed (disk full, perm)
+#           script rc 7  -> stdin write failed
+#           script rc 8  -> chmod failed
+#           script rc 9  -> rename (mv -f) failed
+#
+# Mode defaults to 0600. No flags — positional args only.
+#
+# stdout: empty on success. stderr: suppressed unless
+# BRIDGE_ISOLATION_HELPERS_DEBUG=1.
+#
+# Implementation notes:
+#   - The inline script body is a single-quoted string so $variables inside
+#     are NOT expanded by the controller's bash; they expand only inside the
+#     sudo'd bash. This matches the read helper's pattern exactly and avoids
+#     the bash heredoc_write deadlock class (issue #815 Wave D / footgun #11).
+#   - Content is streamed via stdin pipe — callers must use a producer
+#     pipeline (e.g. `printf '%s\n' "$content" | bridge_isolation_write_...`)
+#     or input redirection from an existing file
+#     (`bridge_isolation_write_... < /path/to/source`). NEVER pass content
+#     via heredoc / here-string at the call site.
+#   - DRY with the read helper: pre-check goes through
+#     bridge_isolation_can_sudo_to_agent so both helpers share the
+#     isolation+sudo gating contract.
+bridge_isolation_write_file_as_agent_user_via_bash() {
+  local agent="$1"
+  local dest_path="$2"
+  local mode="${3:-0600}"
+
+  [[ -n "$agent" ]] || return 1
+  [[ -n "$dest_path" ]] || return 1
+
+  local sudo_rc=0
+  bridge_isolation_can_sudo_to_agent "$agent" 2>/dev/null || sudo_rc=$?
+  case "$sudo_rc" in
+    0) ;;
+    1) return 1 ;;
+    2) return 2 ;;
+    *) return 2 ;;
+  esac
+
+  local os_user=""
+  os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+  [[ -n "$os_user" ]] || return 1
+
+  local bash_bin="${BRIDGE_BASH_BIN:-bash}"
+  local debug="${BRIDGE_ISOLATION_HELPERS_DEBUG:-0}"
+
+  # Inline write script. Single-quoted so $variables resolve inside the
+  # sudo'd bash only. $0 will be the literal 'bridge-isolation' tag,
+  # $1 is the destination path, $2 is the mode.
+  #
+  # `cat -` reads stdin (NOT a heredoc). Do NOT introduce <<<, <<EOF, or
+  # any other here-document construct anywhere in this body — that would
+  # re-open the Bash 5.3.9 heredoc_write deadlock class (footgun #11).
+  local script
+  script='
+dest_path="$1"
+mode="$2"
+dest_dir="$(dirname "$dest_path")"
+if [[ ! -d "$dest_dir" ]]; then
+  exit 5
+fi
+umask 0077
+tmp="$(mktemp "$dest_dir/.$(basename "$dest_path").bridge-write-tmp.XXXXXX")" || exit 6
+trap "rm -f \"$tmp\" 2>/dev/null" EXIT INT TERM
+if ! cat - >"$tmp"; then
+  exit 7
+fi
+if ! chmod "$mode" "$tmp"; then
+  exit 8
+fi
+if ! mv -f "$tmp" "$dest_path"; then
+  exit 9
+fi
+trap - EXIT INT TERM
+exit 0
+'
+
+  local rc=0
+  if [[ "$debug" == "1" ]]; then
+    sudo -n -u "$os_user" "$bash_bin" -c "$script" bridge-isolation "$dest_path" "$mode"
+    rc=$?
+  else
+    sudo -n -u "$os_user" "$bash_bin" -c "$script" bridge-isolation "$dest_path" "$mode" 2>/dev/null
+    rc=$?
+  fi
+
+  if [[ "$rc" -eq 0 ]]; then
+    return 0
+  fi
+  # Preserve the script's exit code with a +2 shift so callers can
+  # disambiguate from the 0/1/2 pre-flight band (same convention as the
+  # read helper above).
+  if [[ "$rc" -lt 3 ]]; then
+    return $((rc + 2))
+  fi
+  return "$rc"
+}

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper
 }
 
 add_all_integration() {
@@ -250,7 +250,11 @@ select_for_path() {
       # isolation lib moves. v0.8.1 hotfix: lock-portability smoke
       # also lives in this trigger row (mkdir-based atomic lock in
       # bridge-isolation-v2-migrate.sh).
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability launch
+      # Issue #857 PR-1: bridge_isolation_write_file_as_agent_user_via_bash
+      # lives in lib/bridge-isolation-helpers.sh; pull its regression
+      # smoke in on every isolation-lib move so the write helper's
+      # pre-check + atomic write rc map stays covered.
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability 857-pr1-isolation-write-helper launch
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10660,4 +10660,12 @@ bash "$REPO_ROOT/scripts/smoke/isolation-v2-migrate-lock-portability.sh"
 log "running upgrade-isolated-agent-migrate smoke (v0.8.2 hotfix, issue #652)"
 bash "$REPO_ROOT/scripts/smoke/upgrade-isolated-agent-migrate.sh"
 
+# Issue #857 PR-1 — bridge_isolation_write_file_as_agent_user_via_bash
+# is the WRITE counterpart to PR #836's read helper, used by later PRs in
+# the #857 ACL deprecation umbrella to migrate channel-dotenv ownership
+# to the isolated UID. Cover the helper's pre-check rc bands and atomic
+# write sequence whenever lib/bridge-isolation-helpers.sh moves.
+log "running 857-pr1-isolation-write-helper smoke (#857 PR-1)"
+bash "$REPO_ROOT/scripts/smoke/857-pr1-isolation-write-helper.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/857-pr1-isolation-write-helper.sh
+++ b/scripts/smoke/857-pr1-isolation-write-helper.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# Issue #857 PR-1 — regression smoke for bridge_isolation_write_file_as_agent_user_via_bash.
+#
+# Coverage:
+#   Default mocked-sudo cases (always run):
+#     A1 — happy path: write content, mode 0600 default, no temp leak.
+#     A2 — custom mode 0640 propagates to the published file.
+#     A3 — destination directory missing -> caller-visible rc=5
+#          (script-band rc, preserved unchanged per the read helper
+#          convention — only rc=1/2 are shifted into the 3+ band).
+#     A4 — empty stdin content (cat - on /dev/null) -> success with empty file.
+#     A5 — sudo policy denial via shim rc=1 -> caller-visible rc=2.
+#     A6 — pre-check returns rc=1 (not isolated) -> caller-visible rc=1.
+#     A7 — pre-check returns rc=2 (isolated, no sudo) -> caller-visible rc=2.
+#   Real two-UID case (env-gated, skipped otherwise):
+#     B1 — write to a tmp dir as BRIDGE_ISOLATION_HELPERS_TEST_UID via real sudo
+#          and verify file owner via stat.
+
+set -uo pipefail
+
+SMOKE_NAME="857-pr1-isolation-write-helper"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# --- harness helpers ---------------------------------------------------------
+
+# Build a PATH directory containing a `sudo` shim. The shim strips `-n -u
+# <user>` and execs the remaining command as the current user, so the helper's
+# `sudo -n -u <user> bash -c "$script" bridge-isolation <dest> <mode>`
+# invocation actually runs the inline write script. SHIM_RC=0 means the shim
+# transparently exec's; SHIM_RC=1 simulates a sudo policy denial (rc=1, no
+# exec).
+build_sudo_shim() {
+  local dir="$1"
+  local shim_rc="$2"
+  mkdir -p "$dir"
+  # NOTE: emitted via printf to a file (NOT a heredoc) to stay clear of the
+  # footgun #11 surface (Bash 5.3.9 heredoc_write deadlock class). The shim
+  # body itself is a small bash program, so emitting it line-by-line via
+  # printf into a target file is the safest form here.
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' '# Mocked sudo for smoke test #857 PR-1. Strips -n -u <user>'
+    printf '%s\n' '# and execs the remainder as the current user.'
+    printf 'shim_rc=%s\n' "$shim_rc"
+    printf '%s\n' 'if [[ "$shim_rc" -ne 0 ]]; then'
+    printf '%s\n' '  exit "$shim_rc"'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'args=()'
+    printf '%s\n' 'skip_next=0'
+    printf '%s\n' 'for arg in "$@"; do'
+    printf '%s\n' '  if [[ "$skip_next" -eq 1 ]]; then'
+    printf '%s\n' '    skip_next=0'
+    printf '%s\n' '    continue'
+    printf '%s\n' '  fi'
+    printf '%s\n' '  case "$arg" in'
+    printf '%s\n' '    -n) ;;'
+    printf '%s\n' '    -u) skip_next=1 ;;'
+    printf '%s\n' '    *) args+=("$arg") ;;'
+    printf '%s\n' '  esac'
+    printf '%s\n' 'done'
+    printf '%s\n' 'exec "${args[@]}"'
+  } >"$dir/sudo"
+  chmod +x "$dir/sudo"
+}
+
+# Source the helper into the current shell with mocked predicates so we can
+# call bridge_isolation_write_file_as_agent_user_via_bash directly. Each test
+# re-imports a fresh copy because we may want to flip predicate stubs.
+import_helper_with_mocks() {
+  local can_sudo_rc="$1"
+  local os_user="$2"
+  # We re-source the helper file but then redefine the predicates so the
+  # write helper's pre-check sees our stubs. The helper file does NOT
+  # define these predicates itself — they live in lib/bridge-agents.sh —
+  # so a bare source + stub definition is sufficient.
+  # shellcheck source=lib/bridge-isolation-helpers.sh
+  source "$SMOKE_REPO_ROOT/lib/bridge-isolation-helpers.sh"
+  eval "bridge_isolation_can_sudo_to_agent() { return $can_sudo_rc; }"
+  eval "bridge_agent_os_user() { printf '%s' '$os_user'; }"
+  # The stub below is invoked indirectly by the real
+  # bridge_isolation_can_sudo_to_agent (when that mock isn't taken).
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+}
+
+# --- case A1: happy path -----------------------------------------------------
+
+case_a1_happy_path_default_mode() {
+  local tmp dest content actual_content actual_mode rc
+  tmp="$SMOKE_TMP_ROOT/a1"
+  mkdir -p "$tmp"
+  dest="$tmp/payload.env"
+  content="hello-from-pr1"
+  rc=0
+  printf '%s\n' "$content" | bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" || rc=$?
+  smoke_assert_eq 0 "$rc" "A1: helper returns 0 on success"
+  smoke_assert_file_exists "$dest" "A1: destination file created"
+  actual_content="$(cat "$dest")"
+  smoke_assert_eq "$content" "$actual_content" "A1: content roundtrips through stdin pipe"
+  actual_mode="$(stat -f '%Lp' "$dest" 2>/dev/null || stat -c '%a' "$dest")"
+  smoke_assert_eq "600" "$actual_mode" "A1: default mode 0600 applied"
+  # No temp leak in the dest dir (only `payload.env` should remain).
+  local leak
+  leak="$(find "$tmp" -name '.payload.env.bridge-write-tmp.*' -print 2>/dev/null | head -n 1)"
+  [[ -z "$leak" ]] || smoke_fail "A1: temp file leak detected: $leak"
+}
+
+# --- case A2: custom mode ----------------------------------------------------
+
+case_a2_custom_mode() {
+  local tmp dest rc actual_mode
+  tmp="$SMOKE_TMP_ROOT/a2"
+  mkdir -p "$tmp"
+  dest="$tmp/payload.env"
+  rc=0
+  printf 'k=v\n' | bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" 0640 || rc=$?
+  smoke_assert_eq 0 "$rc" "A2: helper returns 0 with custom mode"
+  actual_mode="$(stat -f '%Lp' "$dest" 2>/dev/null || stat -c '%a' "$dest")"
+  smoke_assert_eq "640" "$actual_mode" "A2: custom mode 0640 propagated"
+}
+
+# --- case A3: destination directory missing ----------------------------------
+
+case_a3_dest_dir_missing() {
+  local tmp dest rc
+  tmp="$SMOKE_TMP_ROOT/a3"
+  # NOTE: intentionally do NOT mkdir the dest dir.
+  dest="$tmp/missing-subdir/payload.env"
+  rc=0
+  printf 'irrelevant\n' | bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" || rc=$?
+  # rc=5 is the script-band exit for missing dest dir; the wrapper only
+  # shifts rcs 1 and 2 into the 3+ band, so rc=5 reaches the caller as 5
+  # (read helper convention preserved).
+  smoke_assert_eq 5 "$rc" "A3: missing dest dir -> caller-visible rc=5"
+  [[ ! -f "$dest" ]] || smoke_fail "A3: dest file unexpectedly created"
+}
+
+# --- case A4: empty stdin content --------------------------------------------
+
+case_a4_empty_stdin() {
+  local tmp dest rc actual_size
+  tmp="$SMOKE_TMP_ROOT/a4"
+  mkdir -p "$tmp"
+  dest="$tmp/empty.env"
+  rc=0
+  bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" </dev/null || rc=$?
+  smoke_assert_eq 0 "$rc" "A4: empty stdin write returns 0"
+  smoke_assert_file_exists "$dest" "A4: empty file created"
+  actual_size="$(wc -c <"$dest" | tr -d ' ')"
+  smoke_assert_eq "0" "$actual_size" "A4: empty file is zero bytes"
+}
+
+# --- case A5: sudo shim denies ----------------------------------------------
+
+case_a5_sudo_denial() {
+  local tmp dest rc
+  tmp="$SMOKE_TMP_ROOT/a5"
+  mkdir -p "$tmp"
+  dest="$tmp/should-not-exist.env"
+  rc=0
+  printf 'ignored\n' | bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" || rc=$?
+  # Helper short-circuits on the bridge_isolation_can_sudo_to_agent stub when
+  # it returns rc=2, so the caller sees rc=2 BEFORE the sudo shim is ever
+  # invoked. To reach the "sudo invoked but rc=1" branch we have to make
+  # can_sudo return 0 AND use a denying shim — see case A5b below; in this
+  # case A5 keeps the pre-check happy and exercises the shim-denial path.
+  smoke_assert_eq 3 "$rc" "A5: sudo shim returns 1 -> +2 shift -> caller rc=3 (script-band)"
+  [[ ! -f "$dest" ]] || smoke_fail "A5: dest unexpectedly created on sudo denial"
+}
+
+# --- case A6: pre-check says not isolated ------------------------------------
+
+case_a6_not_isolated() {
+  local tmp dest rc
+  tmp="$SMOKE_TMP_ROOT/a6"
+  mkdir -p "$tmp"
+  dest="$tmp/payload.env"
+  rc=0
+  printf 'ignored\n' | bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" || rc=$?
+  smoke_assert_eq 1 "$rc" "A6: pre-check rc=1 -> caller rc=1 (caller falls back to direct write)"
+  [[ ! -f "$dest" ]] || smoke_fail "A6: dest unexpectedly created"
+}
+
+# --- case A7: pre-check says no sudo -----------------------------------------
+
+case_a7_no_sudo() {
+  local tmp dest rc
+  tmp="$SMOKE_TMP_ROOT/a7"
+  mkdir -p "$tmp"
+  dest="$tmp/payload.env"
+  rc=0
+  printf 'ignored\n' | bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" || rc=$?
+  smoke_assert_eq 2 "$rc" "A7: pre-check rc=2 -> caller rc=2"
+  [[ ! -f "$dest" ]] || smoke_fail "A7: dest unexpectedly created"
+}
+
+# --- case B1: real two-UID write --------------------------------------------
+
+case_b1_real_two_uid() {
+  local test_uid_user="${BRIDGE_ISOLATION_HELPERS_TEST_UID:-}"
+  if [[ -z "$test_uid_user" ]]; then
+    smoke_log "skip B1: BRIDGE_ISOLATION_HELPERS_TEST_UID unset"
+    return 0
+  fi
+  if ! command -v sudo >/dev/null 2>&1; then
+    smoke_log "skip B1: sudo not on PATH"
+    return 0
+  fi
+  if ! sudo -n -u "$test_uid_user" bash -c 'exit 0' 2>/dev/null; then
+    smoke_log "skip B1: passwordless sudo to $test_uid_user unavailable"
+    return 0
+  fi
+
+  local tmp dest rc actual_owner
+  tmp="$SMOKE_TMP_ROOT/b1"
+  mkdir -p "$tmp"
+  # The dest dir must be writable by $test_uid_user. The simplest portable
+  # arrangement is to chmod 0777 so the isolated UID can drop a temp file
+  # there; the actual file ownership check is what we care about.
+  chmod 0777 "$tmp"
+  dest="$tmp/real.env"
+
+  # Stub predicates to declare $test_uid_user as the agent's os_user and
+  # short-circuit the linux-user-isolation predicate.
+  # shellcheck source=lib/bridge-isolation-helpers.sh
+  source "$SMOKE_REPO_ROOT/lib/bridge-isolation-helpers.sh"
+  # Stubs invoked indirectly by the real isolation helper code path.
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+  # shellcheck disable=SC2329
+  bridge_agent_os_user() { printf '%s' "$test_uid_user"; }
+  # Let bridge_isolation_can_sudo_to_agent run for real here.
+
+  rc=0
+  printf 'real-two-uid-write\n' | bridge_isolation_write_file_as_agent_user_via_bash \
+    agent-test "$dest" || rc=$?
+  smoke_assert_eq 0 "$rc" "B1: real two-UID write returns 0"
+  smoke_assert_file_exists "$dest" "B1: dest file created"
+  actual_owner="$(stat -f '%Su' "$dest" 2>/dev/null || stat -c '%U' "$dest")"
+  smoke_assert_eq "$test_uid_user" "$actual_owner" "B1: dest owned by isolated UID"
+}
+
+# --- main --------------------------------------------------------------------
+
+main() {
+  smoke_setup_bridge_home "857-pr1-isolation-write-helper"
+
+  # Build a per-test sudo shim directory and prepend to PATH. The shim only
+  # needs to exist on PATH while the helper invokes sudo, so we keep the
+  # original PATH around and switch in setup.
+  local shim_dir_ok shim_dir_deny
+  shim_dir_ok="$SMOKE_TMP_ROOT/sudo-shim-ok"
+  shim_dir_deny="$SMOKE_TMP_ROOT/sudo-shim-deny"
+  build_sudo_shim "$shim_dir_ok" 0
+  build_sudo_shim "$shim_dir_deny" 1
+
+  local original_path="$PATH"
+
+  # Cases A1, A2, A3, A4: pre-check OK, shim execs cleanly.
+  (
+    PATH="$shim_dir_ok:$original_path"
+    import_helper_with_mocks 0 "$(id -un)"
+    case_a1_happy_path_default_mode
+    case_a2_custom_mode
+    case_a3_dest_dir_missing
+    case_a4_empty_stdin
+  ) || smoke_fail "A1-A4 sub-shell failed"
+  smoke_log "ok: A1-A4 (default-mode write, custom mode, missing-dir rc=5, empty stdin)"
+
+  # Case A5: pre-check OK, shim returns 1.
+  (
+    PATH="$shim_dir_deny:$original_path"
+    import_helper_with_mocks 0 "$(id -un)"
+    case_a5_sudo_denial
+  ) || smoke_fail "A5 sub-shell failed"
+  smoke_log "ok: A5 (sudo shim denial)"
+
+  # Case A6: pre-check says not isolated -> caller rc=1 BEFORE sudo invoked.
+  (
+    PATH="$shim_dir_ok:$original_path"
+    import_helper_with_mocks 1 "$(id -un)"
+    case_a6_not_isolated
+  ) || smoke_fail "A6 sub-shell failed"
+  smoke_log "ok: A6 (pre-check not-isolated short-circuits to rc=1)"
+
+  # Case A7: pre-check says no sudo -> caller rc=2 BEFORE sudo invoked.
+  (
+    PATH="$shim_dir_ok:$original_path"
+    import_helper_with_mocks 2 "$(id -un)"
+    case_a7_no_sudo
+  ) || smoke_fail "A7 sub-shell failed"
+  smoke_log "ok: A7 (pre-check no-sudo short-circuits to rc=2)"
+
+  # Case B1: real two-UID via env gate (skip with explicit log when unset).
+  (
+    PATH="$original_path"
+    case_b1_real_two_uid
+  ) || smoke_fail "B1 sub-shell failed"
+
+  smoke_log "passed"
+}
+
+main "$@"

--- a/scripts/smoke/857-pr1-isolation-write-helper.sh
+++ b/scripts/smoke/857-pr1-isolation-write-helper.sh
@@ -30,6 +30,16 @@ trap cleanup EXIT
 
 # --- harness helpers ---------------------------------------------------------
 
+# Portable `stat` shims. On Linux (GNU coreutils), `stat -c '%a' <file>` returns
+# the mode digits; `stat -f` instead prints filesystem status (verbose), which
+# is the CI failure mode this helper exists to avoid. On macOS (BSD), `stat -c`
+# is invalid and exits non-zero, so the GNU form must be tried FIRST and we
+# fall back to the BSD `-f '%Lp'` / `-f '%Su'` form when it fails. Same shape
+# for owner lookup. Kept as single-line conditionals to stay off the heredoc
+# footgun surface (Bash 5.3.9 heredoc_write deadlock class).
+file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+file_owner() { stat -c '%U' "$1" 2>/dev/null || stat -f '%Su' "$1" 2>/dev/null; }
+
 # Build a PATH directory containing a `sudo` shim. The shim strips `-n -u
 # <user>` and execs the remaining command as the current user, so the helper's
 # `sudo -n -u <user> bash -c "$script" bridge-isolation <dest> <mode>`
@@ -105,7 +115,7 @@ case_a1_happy_path_default_mode() {
   smoke_assert_file_exists "$dest" "A1: destination file created"
   actual_content="$(cat "$dest")"
   smoke_assert_eq "$content" "$actual_content" "A1: content roundtrips through stdin pipe"
-  actual_mode="$(stat -f '%Lp' "$dest" 2>/dev/null || stat -c '%a' "$dest")"
+  actual_mode="$(file_mode "$dest")"
   smoke_assert_eq "600" "$actual_mode" "A1: default mode 0600 applied"
   # No temp leak in the dest dir (only `payload.env` should remain).
   local leak
@@ -124,7 +134,7 @@ case_a2_custom_mode() {
   printf 'k=v\n' | bridge_isolation_write_file_as_agent_user_via_bash \
     agent-test "$dest" 0640 || rc=$?
   smoke_assert_eq 0 "$rc" "A2: helper returns 0 with custom mode"
-  actual_mode="$(stat -f '%Lp' "$dest" 2>/dev/null || stat -c '%a' "$dest")"
+  actual_mode="$(file_mode "$dest")"
   smoke_assert_eq "640" "$actual_mode" "A2: custom mode 0640 propagated"
 }
 
@@ -250,7 +260,7 @@ case_b1_real_two_uid() {
     agent-test "$dest" || rc=$?
   smoke_assert_eq 0 "$rc" "B1: real two-UID write returns 0"
   smoke_assert_file_exists "$dest" "B1: dest file created"
-  actual_owner="$(stat -f '%Su' "$dest" 2>/dev/null || stat -c '%U' "$dest")"
+  actual_owner="$(file_owner "$dest")"
   smoke_assert_eq "$test_uid_user" "$actual_owner" "B1: dest owned by isolated UID"
 }
 

--- a/scripts/smoke/857-pr1-isolation-write-helper.sh
+++ b/scripts/smoke/857-pr1-isolation-write-helper.sh
@@ -213,15 +213,15 @@ case_a7_no_sudo() {
 case_b1_real_two_uid() {
   local test_uid_user="${BRIDGE_ISOLATION_HELPERS_TEST_UID:-}"
   if [[ -z "$test_uid_user" ]]; then
-    smoke_log "skip B1: BRIDGE_ISOLATION_HELPERS_TEST_UID unset"
+    smoke_log "SKIP: B1 real two-UID — BRIDGE_ISOLATION_HELPERS_TEST_UID unset"
     return 0
   fi
   if ! command -v sudo >/dev/null 2>&1; then
-    smoke_log "skip B1: sudo not on PATH"
+    smoke_log "SKIP: B1 real two-UID — sudo not on PATH"
     return 0
   fi
   if ! sudo -n -u "$test_uid_user" bash -c 'exit 0' 2>/dev/null; then
-    smoke_log "skip B1: passwordless sudo to $test_uid_user unavailable"
+    smoke_log "SKIP: B1 real two-UID — passwordless sudo to $test_uid_user unavailable"
     return 0
   fi
 


### PR DESCRIPTION
## Summary

PR-1 of the #857 ACL deprecation umbrella. New helper `bridge_isolation_write_file_as_agent_user_via_bash` in `lib/bridge-isolation-helpers.sh` symmetric to PR #836's read helper. PR-2/-3 will use this to rewrite channel dotenv setup (setup discord/telegram, setup teams/ms365) without controller-side ACL grants. PR-5 will then remove the ACL stop-gap from #851/PR #855.

API shape (per codex design consult):
- `bridge_isolation_write_file_as_agent_user_via_bash <agent> <dest_path> [mode]`, stdin pipe for content, default mode 0600.
- RC mirrors the read helper exactly: 0 success / 1 not isolated / 2 sudo unavailable / 3+ script rc (rcs 1 and 2 shifted into the 3+ band by +2, rcs ≥3 returned unchanged).
- Atomic write inside isolated UID: temp file in dest dir (same-fs rename), umask 0077, chmod BEFORE mv -f.
- Pre-check via existing `bridge_isolation_can_sudo_to_agent` (DRY with read helper).
- Script reserves rcs 5/6/7/8/9 for missing-dest-dir / mktemp / stdin-write / chmod / rename failure.

Inline script body is a single-quoted string; stdin is consumed via `cat -` (NOT a heredoc) to stay clear of the Bash 5.3.9 heredoc_write deadlock class (footgun #11). No call-site rewires in this PR.

New regression smoke `scripts/smoke/857-pr1-isolation-write-helper.sh` with seven mocked-sudo cases (happy path, custom mode 0640, missing dest dir, empty stdin content, sudo denial, pre-check rc=1, pre-check rc=2) plus one env-gated real two-UID case. Hooked into `scripts/smoke-test.sh` and `scripts/ci-select-smoke.sh` (`lib/bridge-isolation*.sh` trigger + `add_all_required_static`).

refs #857 PR-1

## Test plan

- [x] `bash -n` clean across changed files
- [x] `shellcheck --severity=warning` clean across changed files
- [x] Mocked-sudo smoke (7 cases) passes in isolated `BRIDGE_HOME`
- [ ] Real two-UID smoke: requires `BRIDGE_ISOLATION_HELPERS_TEST_UID` (deferred to operator install)
- [x] Existing `scripts/smoke/isolation.sh` unchanged after edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)