### PR TITLE
fix(start): pane-content trigger for controller dev-channels auto-accept (#825)

### DIFF
--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -162,19 +162,66 @@ bridge_start_schedule_dev_channels_accept() {
           "$(date "+%Y-%m-%d %H:%M:%S")" "$session" >&2
         exit 0
       fi
-      if ! bridge_tmux_wait_for_claude_foreground "$session" "$foreground_timeout" 2 $((foreground_timeout / 2 + 1)); then
+      # Issue #825: primary trigger is pane-content-text match for the
+      # dev-channels picker. The foreground-basename gate has been observed
+      # to false-negative on v0.11.0+ live installs (Claude apparently
+      # presents the picker from a wrapper whose `comm` does not match
+      # claude|claude-*|claude.*) which wedged the watcher indefinitely.
+      # We poll BOTH the picker text AND the legacy foreground gate;
+      # whichever fires first wins. The picker text (specifically the
+      # "WARNING: Loading development channels" + "I am using this for
+      # local development" pair detected by
+      # bridge_tmux_pane_has_dev_channels_picker) is unique to the Claude
+      # dev-channels load path, so its presence alone is sufficient
+      # evidence the picker has been drawn — we do not require an
+      # additional process-name match on top. The picker-sweep allow-list
+      # (scripts/picker-sweep.sh:137-138) does NOT include the dev-channels
+      # picker text, so the two watcher surfaces stay disjoint.
+      picker_seen=0
+      foreground_ready=0
+      poll_seconds="${BRIDGE_START_DEV_CHANNELS_PICKER_POLL_SECONDS:-2}"
+      [[ "$poll_seconds" =~ ^[0-9]+([.][0-9]+)?$ ]] || poll_seconds=2
+      start_ts="$(date +%s)"
+      while :; do
         if ! bridge_tmux_session_exists "$session"; then
-          printf "[%s] [warn] controller auto-accept dev-channels aborted: tmux session=%s ended before claude foreground (likely plugin-cache or launch failure)\n" \
+          printf "[%s] [warn] controller auto-accept dev-channels aborted: tmux session=%s ended before picker/foreground (likely plugin-cache or launch failure)\n" \
             "$(date "+%Y-%m-%d %H:%M:%S")" "$session" >&2
-        else
-          printf "[%s] [warn] controller auto-accept dev-channels timeout waiting for claude foreground on session=%s agent=%s after %ss\n" \
-            "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent" "$foreground_timeout" >&2
+          exit 0
         fi
-        exit 0
+        if bridge_tmux_pane_has_dev_channels_picker "$session"; then
+          picker_seen=1
+          break
+        fi
+        if bridge_tmux_pane_foreground_is_claude "$session"; then
+          foreground_ready=1
+          break
+        fi
+        elapsed=$(( $(date +%s) - start_ts ))
+        if (( elapsed >= foreground_timeout )); then
+          printf "[%s] [warn] controller auto-accept dev-channels timeout waiting for picker/claude foreground on session=%s agent=%s after %ss\n" \
+            "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent" "$foreground_timeout" >&2
+          exit 0
+        fi
+        sleep "$poll_seconds"
+      done
+      # Picker-text-trigger short-circuits the secondary foreground gate
+      # inside bridge_tmux_claude_advance_blocker (lib/bridge-tmux.sh:677).
+      # The picker text IS the direct signal — Claude has drawn the
+      # dev-channels prompt, so requiring an additional foreground match
+      # on top would just resurrect the bug this commit closes. The
+      # legacy gate is preserved for the non-picker trigger path so other
+      # callers (and non-dev-channels callers) are unaffected.
+      if (( picker_seen == 1 )); then
+        export BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND=0
       fi
       if bridge_tmux_wait_for_prompt "$session" claude "$accept_timeout" 1; then
-        printf "[%s] [info] controller auto-accept dev-channels completed on session=%s agent=%s\n" \
-          "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent"
+        if (( picker_seen == 1 )); then
+          printf "[%s] [info] controller auto-accept dev-channels completed (picker-text trigger) on session=%s agent=%s\n" \
+            "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent"
+        else
+          printf "[%s] [info] controller auto-accept dev-channels completed (foreground trigger) on session=%s agent=%s\n" \
+            "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent"
+        fi
       else
         printf "[%s] [warn] controller auto-accept dev-channels failed/timeout on session=%s agent=%s\n" \
           "$(date "+%Y-%m-%d %H:%M:%S")" "$session" "$agent" >&2

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -363,6 +363,29 @@ bridge_tmux_claude_blocker_state() {
   bridge_tmux_claude_blocker_state_from_text "$recent"
 }
 
+# Issue #825: pane-content-only check for the dev-channels picker. Returns
+# 0 iff the pane has the picker text in view, regardless of foreground
+# process basename. This is the primary trigger condition for the
+# controller-side auto-accept watcher (bridge-start.sh::
+# bridge_start_schedule_dev_channels_accept): on v0.11.0+ live installs the
+# foreground basename gate has been observed to false-negative (Claude
+# launches under a wrapper whose `comm` does not match the
+# claude|claude-*|claude.* regex even after the picker is drawn), wedging
+# the watcher indefinitely. The picker text pair detected here
+# ("WARNING: Loading development channels" + "I am using this for local
+# development") is unique to the Claude dev-channels load path, so its
+# presence alone is sufficient evidence the picker has been drawn; no
+# additional process-name match is required.
+bridge_tmux_pane_has_dev_channels_picker() {
+  local session="$1"
+  local recent=""
+
+  recent="$(bridge_capture_recent "$session" 80 2>/dev/null || true)"
+  [[ -n "$recent" ]] || return 1
+
+  [[ "$(bridge_tmux_claude_blocker_state_from_text "$recent")" == "devchannels" ]]
+}
+
 bridge_tmux_claude_prompt_line_ready() {
   local trimmed="$1"
   local remainder=""

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6409,6 +6409,15 @@ done
 assert_contains "$(cat "$DEV_CHANNELS_DISPATCH_ACK")" "<enter>"
 tmux kill-session -t "=$DEV_CHANNELS_DISPATCH_SESSION" >/dev/null 2>&1 || true
 
+# Issue #825 regression suite: controller-side dev-channels auto-accept
+# watcher must fire on pane-content-text trigger (not solely on the
+# foreground basename gate). Pre-fix the watcher would wedge indefinitely
+# on live v0.11.0+ installs when the picker text was visible but the
+# foreground process name did not match claude|claude-*|claude.*.
+log "running issue #825 controller dev-channels auto-accept regression"
+bash "$REPO_ROOT/scripts/test-controller-dev-channels-accept.sh" \
+  || die "issue #825 controller dev-channels auto-accept suite failed"
+
 log "classifying admin foreground exit by onboarding state"
 ONBOARDING_ADMIN_WORKDIR="$TMP_ROOT/onboarding-admin"
 mkdir -p "$ONBOARDING_ADMIN_WORKDIR"

--- a/scripts/test-controller-dev-channels-accept.sh
+++ b/scripts/test-controller-dev-channels-accept.sh
@@ -78,10 +78,10 @@ unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID
 TEST_BRIDGE_HOME="$TMP_ROOT/bridge-home"
 mkdir -p "$TEST_BRIDGE_HOME/state" "$TEST_BRIDGE_HOME/data"
 MARKER_PATH="$TEST_BRIDGE_HOME/state/layout-marker.sh"
-cat >"$MARKER_PATH" <<MARKER
-BRIDGE_LAYOUT=v2
-BRIDGE_DATA_ROOT=$TEST_BRIDGE_HOME/data
-MARKER
+{
+  printf '%s\n' 'BRIDGE_LAYOUT=v2'
+  printf 'BRIDGE_DATA_ROOT=%s/data\n' "$TEST_BRIDGE_HOME"
+} >"$MARKER_PATH"
 chmod 0644 "$MARKER_PATH"
 export BRIDGE_HOME="$TEST_BRIDGE_HOME"
 export BRIDGE_STATE_DIR="$TEST_BRIDGE_HOME/state"
@@ -195,24 +195,24 @@ R1_DRIVER="$TMP_ROOT/r1-driver.sh"
 # A "claude" symlink to bash so `ps -o comm=` on the pane PID reports
 # basename `claude` (matches bridge_tmux_command_name_is_claude).
 ln -sf "$(command -v bash)" "$R1_BIN_DIR/claude"
-cat >"$R1_PAYLOAD" <<R1PAY
-IFS= read -r line
-printf '%s\n' "\${line:-<enter>}" >"$R1_ACK"
-# Print a Claude-style ready prompt so bridge_tmux_session_has_prompt
-# succeeds and bridge_tmux_wait_for_prompt returns 0 after the picker
-# Enter is sent. The picker text up the buffer no longer matters; only
-# the most recent 20 lines are scanned.
-printf '\n❯ \n'
-sleep 2
-R1PAY
+{
+  printf '%s\n' 'IFS= read -r line'
+  printf '%s\n' 'printf '\''%s\n'\'' "${line:-<enter>}" >"'"$R1_ACK"'"'
+  printf '%s\n' '# Print a Claude-style ready prompt so bridge_tmux_session_has_prompt'
+  printf '%s\n' '# succeeds and bridge_tmux_wait_for_prompt returns 0 after the picker'
+  printf '%s\n' '# Enter is sent. The picker text up the buffer no longer matters; only'
+  printf '%s\n' '# the most recent 20 lines are scanned.'
+  printf '%s\n' 'printf '\''\n❯ \n'\'''
+  printf '%s\n' 'sleep 2'
+} >"$R1_PAYLOAD"
 chmod +x "$R1_PAYLOAD"
-cat >"$R1_DRIVER" <<R1DRV
-#!/usr/bin/env bash
-printf 'WARNING: Loading development channels\n'
-printf 'I am using this for local development\n'
-printf 'Enter to confirm · Esc to cancel\n'
-exec "$R1_BIN_DIR/claude" "$R1_PAYLOAD"
-R1DRV
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'printf '\''WARNING: Loading development channels\n'\'''
+  printf '%s\n' 'printf '\''I am using this for local development\n'\'''
+  printf '%s\n' 'printf '\''Enter to confirm · Esc to cancel\n'\'''
+  printf 'exec "%s/claude" "%s"\n' "$R1_BIN_DIR" "$R1_PAYLOAD"
+} >"$R1_DRIVER"
 chmod +x "$R1_DRIVER"
 tmux new-session -d -s "$R1_SESSION" "$R1_DRIVER"
 SMOKE_SESSIONS+=("$R1_SESSION")
@@ -253,22 +253,22 @@ R2_DRIVER="$TMP_ROOT/r2-driver.sh"
 # exact pre-fix wedge shape: foreground != claude, no claude under it,
 # but picker text on screen.
 ln -sf "$(command -v bash)" "$R2_BIN_DIR/node"
-cat >"$R2_PAYLOAD" <<R2PAY
-IFS= read -r line
-printf '%s\n' "\${line:-<enter>}" >"$R2_ACK"
-# Same prompt-render trick as R1 so wait_for_prompt returns 0 after the
-# picker Enter is sent.
-printf '\n❯ \n'
-sleep 2
-R2PAY
+{
+  printf '%s\n' 'IFS= read -r line'
+  printf '%s\n' 'printf '\''%s\n'\'' "${line:-<enter>}" >"'"$R2_ACK"'"'
+  printf '%s\n' '# Same prompt-render trick as R1 so wait_for_prompt returns 0 after the'
+  printf '%s\n' '# picker Enter is sent.'
+  printf '%s\n' 'printf '\''\n❯ \n'\'''
+  printf '%s\n' 'sleep 2'
+} >"$R2_PAYLOAD"
 chmod +x "$R2_PAYLOAD"
-cat >"$R2_DRIVER" <<R2DRV
-#!/usr/bin/env bash
-printf 'WARNING: Loading development channels\n'
-printf 'I am using this for local development\n'
-printf 'Enter to confirm · Esc to cancel\n'
-exec "$R2_BIN_DIR/node" "$R2_PAYLOAD"
-R2DRV
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'printf '\''WARNING: Loading development channels\n'\'''
+  printf '%s\n' 'printf '\''I am using this for local development\n'\'''
+  printf '%s\n' 'printf '\''Enter to confirm · Esc to cancel\n'\'''
+  printf 'exec "%s/node" "%s"\n' "$R2_BIN_DIR" "$R2_PAYLOAD"
+} >"$R2_DRIVER"
 chmod +x "$R2_DRIVER"
 tmux new-session -d -s "$R2_SESSION" "$R2_DRIVER"
 SMOKE_SESSIONS+=("$R2_SESSION")
@@ -371,11 +371,11 @@ fi
 step "R4: watcher times out cleanly when neither picker nor foreground appears"
 R4_SESSION="agb-825-r4-$$"
 R4_DRIVER="$TMP_ROOT/r4-driver.sh"
-cat >"$R4_DRIVER" <<R4DRV
-#!/usr/bin/env bash
-printf 'unrelated pane output — neither picker nor claude foreground here\n'
-exec "$(command -v sleep)" 10
-R4DRV
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'printf '\''unrelated pane output — neither picker nor claude foreground here\n'\'''
+  printf 'exec "%s" 10\n' "$(command -v sleep)"
+} >"$R4_DRIVER"
 chmod +x "$R4_DRIVER"
 tmux new-session -d -s "$R4_SESSION" "$R4_DRIVER"
 SMOKE_SESSIONS+=("$R4_SESSION")

--- a/scripts/test-controller-dev-channels-accept.sh
+++ b/scripts/test-controller-dev-channels-accept.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# Regression coverage for issue #825 — controller-side dev-channels
+# auto-accept watcher silent failure.
+#
+# Background: bridge-start.sh::bridge_start_schedule_dev_channels_accept
+# previously waited for `bridge_tmux_wait_for_claude_foreground` to succeed
+# before dispatching the Enter that clears the
+# `--dangerously-load-development-channels` picker. The foreground gate is
+# basename-matched (`claude|claude-*|claude.*`) plus a process-tree walk;
+# on live v0.11.0+ installs the gate was observed to false-negative even
+# after the picker was on screen, wedging the watcher indefinitely. The
+# fix (this commit) makes pane-content-text the PRIMARY trigger: when the
+# dev-channels picker text is visible in the pane, the watcher dispatches
+# Enter regardless of foreground basename.
+#
+# Cases:
+#   R1 Positive control: exact-basename `claude` stub prints the picker
+#      text + waits on stdin; watcher fires Enter via the picker-text
+#      trigger; ack file records `<enter>`.
+#   R2 Negative control (the bug): foreground process is NOT named
+#      `claude` and the process tree has no claude descendant, but the
+#      pane contains the picker text. Pre-fix would time out without
+#      sending Enter; post-fix the picker-text trigger fires.
+#   R3 Neighbor guard: the picker-sweep allow-list
+#      (scripts/picker-sweep.sh:137-138) does NOT include the dev-channels
+#      picker text, so picker-sweep does not grab a dev-channels pane.
+#   R4 Timeout-still-works: pane has neither picker text nor claude
+#      foreground; bridge_tmux_pane_has_dev_channels_picker returns 1
+#      forever, the legacy foreground gate also returns 1, and the
+#      watcher times out at foreground_timeout instead of looping
+#      forever.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+
+PASS=0
+FAIL=0
+LAST_DESC=""
+
+step() { LAST_DESC="$*"; }
+ok() { PASS=$((PASS + 1)); printf '  PASS: %s\n' "$LAST_DESC"; }
+err() { FAIL=$((FAIL + 1)); printf '  FAIL: %s — %s\n' "$LAST_DESC" "$*" >&2; }
+
+TMP_ROOT="$(mktemp -d -t agb-825-controller-accept.XXXXXX)"
+SMOKE_SESSIONS=()
+# shellcheck disable=SC2329 # invoked via `trap cleanup EXIT`
+cleanup() {
+  local s
+  for s in "${SMOKE_SESSIONS[@]:-}"; do
+    [[ -n "$s" ]] && tmux kill-session -t "=$s" >/dev/null 2>&1 || true
+  done
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+if ! command -v tmux >/dev/null 2>&1; then
+  printf 'tmux not available — skipping issue #825 regression suite\n' >&2
+  exit 0
+fi
+
+BASH_BIN="${BRIDGE_BASH_BIN:-bash}"
+
+# v0.8.0 hard-cut: bridge-lib.sh refuses to source on an installation that
+# is not isolation-v2. The regression test owns a throwaway BRIDGE_HOME, so
+# write a minimal valid v2 marker (layout-marker.sh) into it so the
+# resolver enters the marker branch and lets sourcing proceed. This is the
+# same shape `agent-bridge upgrade --apply` writes after migration.
+#
+# Scrub inherited BRIDGE_* env first so the parent shell's live-runtime
+# values (BRIDGE_LAYOUT=legacy, BRIDGE_HOME=$HOME/.agent-bridge, etc.) do
+# not bleed into the isolated test home. The resolver runs the env
+# validator BEFORE the marker load, so a stale BRIDGE_LAYOUT=legacy
+# in the parent env would hard-die before the marker is even read.
+unset BRIDGE_LAYOUT BRIDGE_DATA_ROOT BRIDGE_LAYOUT_SOURCE
+unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID
+TEST_BRIDGE_HOME="$TMP_ROOT/bridge-home"
+mkdir -p "$TEST_BRIDGE_HOME/state" "$TEST_BRIDGE_HOME/data"
+MARKER_PATH="$TEST_BRIDGE_HOME/state/layout-marker.sh"
+cat >"$MARKER_PATH" <<MARKER
+BRIDGE_LAYOUT=v2
+BRIDGE_DATA_ROOT=$TEST_BRIDGE_HOME/data
+MARKER
+chmod 0644 "$MARKER_PATH"
+export BRIDGE_HOME="$TEST_BRIDGE_HOME"
+export BRIDGE_STATE_DIR="$TEST_BRIDGE_HOME/state"
+export BRIDGE_LAYOUT_MARKER_DIR="$TEST_BRIDGE_HOME/state"
+
+# ---------------------------------------------------------------------------
+# Helper: wait until the pane of a tmux session contains a given substring.
+# Returns 0 on match, 1 on timeout.
+# ---------------------------------------------------------------------------
+wait_for_pane_text() {
+  local session="$1"
+  local needle="$2"
+  local attempts="${3:-50}"
+  local sleep_secs="${4:-0.1}"
+  local i
+  for ((i = 0; i < attempts; i++)); do
+    if tmux capture-pane -p -t "=${session}:" 2>/dev/null \
+        | grep -Fq "$needle"; then
+      return 0
+    fi
+    sleep "$sleep_secs"
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run the controller watcher subshell body in-process so we can
+# assert on its outcome. The real bridge_start_schedule_dev_channels_accept
+# launches the watcher in the background; here we run it foreground with
+# tightened timeouts so the test reports pass/fail synchronously.
+#
+# Returns:
+#   stdout: log lines from the watcher
+#   exit code: forwarded from the watcher subshell body
+# ---------------------------------------------------------------------------
+run_controller_watcher_inline() {
+  local session="$1"
+  local agent="$2"
+  local accept_timeout="${3:-3}"
+  local foreground_timeout="${4:-3}"
+  local poll_seconds="${5:-0.1}"
+
+  BRIDGE_START_DEV_CHANNELS_PICKER_POLL_SECONDS="$poll_seconds" \
+  BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_WAIT_SECONDS=2 \
+  BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_POLL_SECONDS=0.1 \
+  BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_MAX_CHECKS=20 \
+  BRIDGE_TMUX_DEV_CHANNELS_FOREGROUND_SETTLE_SECONDS=0.05 \
+    "$BASH_BIN" -lc '
+      set -euo pipefail
+      script_dir="$1"
+      session="$2"
+      agent="$3"
+      accept_timeout="$4"
+      foreground_timeout="$5"
+      source "$script_dir/bridge-lib.sh"
+      if ! bridge_tmux_session_exists "$session"; then
+        printf "session-gone\n" >&2
+        exit 0
+      fi
+      picker_seen=0
+      foreground_ready=0
+      poll_seconds="${BRIDGE_START_DEV_CHANNELS_PICKER_POLL_SECONDS:-2}"
+      [[ "$poll_seconds" =~ ^[0-9]+([.][0-9]+)?$ ]] || poll_seconds=2
+      start_ts="$(date +%s)"
+      while :; do
+        if ! bridge_tmux_session_exists "$session"; then
+          printf "session-ended-mid-wait\n" >&2
+          exit 0
+        fi
+        if bridge_tmux_pane_has_dev_channels_picker "$session"; then
+          picker_seen=1
+          break
+        fi
+        if bridge_tmux_pane_foreground_is_claude "$session"; then
+          foreground_ready=1
+          break
+        fi
+        elapsed=$(( $(date +%s) - start_ts ))
+        if (( elapsed >= foreground_timeout )); then
+          printf "timeout-waiting-for-picker-or-foreground\n" >&2
+          exit 2
+        fi
+        sleep "$poll_seconds"
+      done
+      if (( picker_seen == 1 )); then
+        export BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND=0
+        printf "trigger=picker\n"
+      else
+        printf "trigger=foreground\n"
+      fi
+      if bridge_tmux_wait_for_prompt "$session" claude "$accept_timeout" 1; then
+        printf "dispatch=ok\n"
+        exit 0
+      else
+        printf "dispatch=fail\n" >&2
+        exit 3
+      fi
+    ' -- "$ROOT_DIR" "$session" "$agent" "$accept_timeout" "$foreground_timeout"
+}
+
+# ---------------------------------------------------------------------------
+# R1: positive control — exact-basename `claude` foreground stub.
+# ---------------------------------------------------------------------------
+step "R1: exact-basename claude stub triggers dev-channels Enter"
+R1_BIN_DIR="$TMP_ROOT/r1-bin"
+mkdir -p "$R1_BIN_DIR"
+R1_SESSION="agb-825-r1-$$"
+R1_ACK="$TMP_ROOT/r1-ack.txt"
+R1_PAYLOAD="$TMP_ROOT/r1-payload.sh"
+R1_DRIVER="$TMP_ROOT/r1-driver.sh"
+# A "claude" symlink to bash so `ps -o comm=` on the pane PID reports
+# basename `claude` (matches bridge_tmux_command_name_is_claude).
+ln -sf "$(command -v bash)" "$R1_BIN_DIR/claude"
+cat >"$R1_PAYLOAD" <<R1PAY
+IFS= read -r line
+printf '%s\n' "\${line:-<enter>}" >"$R1_ACK"
+# Print a Claude-style ready prompt so bridge_tmux_session_has_prompt
+# succeeds and bridge_tmux_wait_for_prompt returns 0 after the picker
+# Enter is sent. The picker text up the buffer no longer matters; only
+# the most recent 20 lines are scanned.
+printf '\n❯ \n'
+sleep 2
+R1PAY
+chmod +x "$R1_PAYLOAD"
+cat >"$R1_DRIVER" <<R1DRV
+#!/usr/bin/env bash
+printf 'WARNING: Loading development channels\n'
+printf 'I am using this for local development\n'
+printf 'Enter to confirm · Esc to cancel\n'
+exec "$R1_BIN_DIR/claude" "$R1_PAYLOAD"
+R1DRV
+chmod +x "$R1_DRIVER"
+tmux new-session -d -s "$R1_SESSION" "$R1_DRIVER"
+SMOKE_SESSIONS+=("$R1_SESSION")
+wait_for_pane_text "$R1_SESSION" "WARNING: Loading development channels" 50 0.1 \
+  || { err "R1 driver did not render dev-channels banner"; }
+if [[ "$FAIL" -eq 0 ]]; then
+  if run_controller_watcher_inline "$R1_SESSION" "r1-agent" 3 3 0.1 >/dev/null 2>&1; then
+    for _ in {1..30}; do
+      [[ -s "$R1_ACK" ]] && break
+      sleep 0.1
+    done
+    if [[ -s "$R1_ACK" ]] && grep -q "<enter>" "$R1_ACK"; then
+      ok
+    else
+      err "R1 expected Enter ack but file empty/wrong: $(cat "$R1_ACK" 2>/dev/null || echo MISSING)"
+    fi
+  else
+    err "R1 watcher rc != 0"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# R2: negative control — non-claude foreground basename + no claude
+# descendant in the process tree + picker text visible. This is the bug
+# shape from issue #825. Pre-fix watcher would time out at the foreground
+# gate; post-fix watcher must dispatch via the picker-text trigger.
+# ---------------------------------------------------------------------------
+step "R2: non-claude foreground + picker text triggers dispatch (the bug)"
+R2_BIN_DIR="$TMP_ROOT/r2-bin"
+mkdir -p "$R2_BIN_DIR"
+R2_SESSION="agb-825-r2-$$"
+R2_ACK="$TMP_ROOT/r2-ack.txt"
+R2_PAYLOAD="$TMP_ROOT/r2-payload.sh"
+R2_DRIVER="$TMP_ROOT/r2-driver.sh"
+# A "node" symlink to bash so `ps -o comm=` of the pane PID reports
+# basename `node` (does NOT match bridge_tmux_command_name_is_claude).
+# This stub has no claude descendant in its process tree — it is the
+# exact pre-fix wedge shape: foreground != claude, no claude under it,
+# but picker text on screen.
+ln -sf "$(command -v bash)" "$R2_BIN_DIR/node"
+cat >"$R2_PAYLOAD" <<R2PAY
+IFS= read -r line
+printf '%s\n' "\${line:-<enter>}" >"$R2_ACK"
+# Same prompt-render trick as R1 so wait_for_prompt returns 0 after the
+# picker Enter is sent.
+printf '\n❯ \n'
+sleep 2
+R2PAY
+chmod +x "$R2_PAYLOAD"
+cat >"$R2_DRIVER" <<R2DRV
+#!/usr/bin/env bash
+printf 'WARNING: Loading development channels\n'
+printf 'I am using this for local development\n'
+printf 'Enter to confirm · Esc to cancel\n'
+exec "$R2_BIN_DIR/node" "$R2_PAYLOAD"
+R2DRV
+chmod +x "$R2_DRIVER"
+tmux new-session -d -s "$R2_SESSION" "$R2_DRIVER"
+SMOKE_SESSIONS+=("$R2_SESSION")
+wait_for_pane_text "$R2_SESSION" "I am using this for local development" 50 0.1 \
+  || { err "R2 driver did not render dev-channels banner"; }
+if [[ "$FAIL" -eq 0 || ("$LAST_DESC" == "R2"* && "$R2_ACK" != "" ) ]]; then
+  # Verify the pre-condition: foreground gate alone DOES fail here. If
+  # this assertion fails the test is invalid (the stub somehow inherited
+  # a claude descendant via PATH).
+  if "$BASH_BIN" -c '
+    source "'"$ROOT_DIR"'/bridge-lib.sh"
+    bridge_tmux_pane_foreground_is_claude "'"$R2_SESSION"'"
+  ' >/dev/null 2>&1; then
+    err "R2 invariant failed: foreground gate succeeded on the node-stub pane (no claude descendant expected)"
+  else
+    R2_LOG="$TMP_ROOT/r2-watcher.log"
+    if run_controller_watcher_inline "$R2_SESSION" "r2-agent" 3 3 0.1 >"$R2_LOG" 2>&1; then
+      for _ in {1..30}; do
+        [[ -s "$R2_ACK" ]] && break
+        sleep 0.1
+      done
+      if [[ -s "$R2_ACK" ]] && grep -q "<enter>" "$R2_ACK" \
+        && grep -q '^trigger=picker$' "$R2_LOG" \
+        && grep -q '^dispatch=ok$' "$R2_LOG"; then
+        ok
+      else
+        err "R2 expected picker-trigger + dispatch=ok, got log: $(cat "$R2_LOG"); ack: $(cat "$R2_ACK" 2>/dev/null || echo MISSING)"
+      fi
+    else
+      err "R2 watcher rc != 0 (pre-fix would behave this way); log: $(cat "$R2_LOG" 2>/dev/null || true)"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# R3: neighbor guard — the picker-sweep allow-list does NOT include the
+# dev-channels picker text. We exercise picker-sweep against a dev-channels
+# pane and assert the sweep does not send Enter into it.
+# ---------------------------------------------------------------------------
+step "R3: picker-sweep does NOT match dev-channels picker text"
+R3_DIR="$TMP_ROOT/r3"
+mkdir -p "$R3_DIR/lib" "$R3_DIR/state/install" "$R3_DIR/scripts"
+cp "$ROOT_DIR/lib/bridge-host-profile.sh" "$R3_DIR/lib/"
+cp "$ROOT_DIR/scripts/picker-sweep.sh" "$R3_DIR/scripts/"
+printf '{"profile":"server"}\n' > "$R3_DIR/state/install/host-profile.json"
+
+R3_SEND_RECORD="$R3_DIR/picker-sweep-sends.log"
+R3_TASKS_RECORD="$R3_DIR/picker-sweep-tasks.log"
+: > "$R3_SEND_RECORD" "$R3_TASKS_RECORD"
+
+# Test seam shims: list a single fake session that capture-pane will
+# return the dev-channels picker text for. If picker-sweep wrongly grabs
+# this pane it will call _send_enter, which records to the log.
+# shellcheck disable=SC2329 # invoked via BRIDGE_PICKER_SWEEP_*_FN env seam
+r3_list_sessions() {
+  printf '%s\n' "r3-fake-devchannels"
+}
+# shellcheck disable=SC2329 # invoked via BRIDGE_PICKER_SWEEP_*_FN env seam
+r3_capture_pane() {
+  printf '%s\n' "WARNING: Loading development channels"
+  printf '%s\n' "❯ 1. I am using this for local development"
+  printf '%s\n' "  2. Exit"
+  printf '%s\n' "Enter to confirm · Esc to cancel"
+}
+# shellcheck disable=SC2329 # invoked via BRIDGE_PICKER_SWEEP_*_FN env seam
+r3_send_enter() {
+  printf '%s\n' "$1" >>"$R3_SEND_RECORD"
+}
+# shellcheck disable=SC2329 # invoked via BRIDGE_PICKER_SWEEP_*_FN env seam
+r3_create_task() {
+  printf '%s\n' "$1|$2|$3" >>"$R3_TASKS_RECORD"
+}
+export -f r3_list_sessions r3_capture_pane r3_send_enter r3_create_task
+
+R3_STDERR="$R3_DIR/r3-stderr"
+R3_RC=0
+BRIDGE_PICKER_SWEEP_ENABLED=1 \
+  BRIDGE_HOME="$R3_DIR" \
+  BRIDGE_STATE_DIR="$R3_DIR/state" \
+  BRIDGE_PICKER_SWEEP_LIST_SESSIONS_FN=r3_list_sessions \
+  BRIDGE_PICKER_SWEEP_CAPTURE_PANE_FN=r3_capture_pane \
+  BRIDGE_PICKER_SWEEP_SEND_ENTER_FN=r3_send_enter \
+  BRIDGE_PICKER_SWEEP_CREATE_TASK_FN=r3_create_task \
+  "$BASH_BIN" "$R3_DIR/scripts/picker-sweep.sh" 2>"$R3_STDERR" >/dev/null || R3_RC=$?
+
+# Picker-sweep must exit 0 (no matching picker) AND must not have called
+# _send_enter. If it had grabbed the dev-channels pane, R3_SEND_RECORD
+# would contain "=r3-fake-devchannels:".
+if [[ "$R3_RC" == "0" && ! -s "$R3_SEND_RECORD" ]]; then
+  ok
+else
+  err "R3 picker-sweep grabbed dev-channels pane (rc=$R3_RC, sends=$(cat "$R3_SEND_RECORD" 2>/dev/null || true), stderr=$(cat "$R3_STDERR" 2>/dev/null || true))"
+fi
+
+# ---------------------------------------------------------------------------
+# R4: timeout-still-works — pane has neither picker text nor claude
+# foreground; watcher must exit with timeout exit code (2), not loop
+# forever.
+# ---------------------------------------------------------------------------
+step "R4: watcher times out cleanly when neither picker nor foreground appears"
+R4_SESSION="agb-825-r4-$$"
+R4_DRIVER="$TMP_ROOT/r4-driver.sh"
+cat >"$R4_DRIVER" <<R4DRV
+#!/usr/bin/env bash
+printf 'unrelated pane output — neither picker nor claude foreground here\n'
+exec "$(command -v sleep)" 10
+R4DRV
+chmod +x "$R4_DRIVER"
+tmux new-session -d -s "$R4_SESSION" "$R4_DRIVER"
+SMOKE_SESSIONS+=("$R4_SESSION")
+# Give the pane a moment to be ready.
+wait_for_pane_text "$R4_SESSION" "unrelated pane output" 50 0.1 || true
+
+R4_LOG="$TMP_ROOT/r4-watcher.log"
+R4_RC=0
+# foreground_timeout=1 second, poll=0.1s — watcher should finish in <2s.
+R4_START="$(date +%s)"
+run_controller_watcher_inline "$R4_SESSION" "r4-agent" 1 1 0.1 >"$R4_LOG" 2>&1 || R4_RC=$?
+R4_ELAPSED=$(( $(date +%s) - R4_START ))
+
+# Exit code 2 == "timeout-waiting-for-picker-or-foreground" sentinel from
+# the inline watcher.
+if [[ "$R4_RC" == "2" ]] && (( R4_ELAPSED < 5 )) \
+  && grep -q '^timeout-waiting-for-picker-or-foreground$' "$R4_LOG"; then
+  ok
+else
+  err "R4 timeout path: rc=$R4_RC elapsed=${R4_ELAPSED}s log=$(cat "$R4_LOG")"
+fi
+
+# ---------------------------------------------------------------------------
+TOTAL=$((PASS + FAIL))
+printf '\n# Issue #825 controller dev-channels auto-accept suite: %s/%s passed\n' "$PASS" "$TOTAL"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Controller-side dev-channels auto-accept watcher (`bridge_start_schedule_dev_channels_accept`) silently stops firing for newly-launched Claude sessions on v0.11.0+ live installs. The watcher arms via `BRIDGE_CONTROLLER_DEV_CHANNELS_ACCEPT=1` correctly, but its foreground gate (`bridge_tmux_wait_for_claude_foreground` → basename match `claude|claude-*|claude.*`) appears to false-negative on the operator's install, leaving the watcher armed indefinitely. Operator must manually `tmux send-keys -t <agent> Enter` per stuck pane; downstream cron-dispatch backlogs behind the still-blocked agents.

Fix: pane-content text becomes the PRIMARY trigger. A new `bridge_tmux_pane_has_dev_channels_picker` helper detects the picker by the same text pair already recognized by `bridge_tmux_claude_blocker_state_from_text` (`WARNING: Loading development channels` + `I am using this for local development`). The watcher subshell polls BOTH the picker text and the legacy `bridge_tmux_pane_foreground_is_claude` gate; whichever fires first wins. When the picker-text trigger fires, the watcher exports `BRIDGE_TMUX_DEV_CHANNELS_REQUIRE_CLAUDE_FOREGROUND=0` so the secondary foreground gate inside `bridge_tmux_claude_advance_blocker` (`lib/bridge-tmux.sh:677`) does not resurrect the bug one layer deeper.

The picker text pair is unique to the Claude dev-channels load path. The picker-sweep allow-list (`scripts/picker-sweep.sh:137-138`) does NOT include either string, so the two watcher surfaces stay disjoint.

Diagnosis: codex-spec for #825, full output in `/tmp/issue-825-codex-spec-result.md` (orchestrator-side artifact).

Closes #825

## Hypothesis verification

Verified on this macOS host that `ps -o comm= -p $(pgrep claude)` reports `claude` for every currently-running Claude CLI process (including those invoked via absolute path — `comm` returns the full path, basename `${path##*/}` still resolves to `claude`). The v0.11.0 false-negative is therefore not directly reproducible from a clean macOS shell — the wrapper behavior described in the codex-spec output is presumably triggered by the operator's live-install invocation path (Linux server, fnm-managed node, plugin wrapper, etc.).

The fix is robust regardless because the pane-content trigger does not depend on process-name detection at all. The legacy foreground gate remains in place as the fallback trigger for the non-picker path, so other callers (and non-dev-channels callers) are unaffected.

## Files changed

- `bridge-start.sh` (+55 / -6) — `bridge_start_schedule_dev_channels_accept` subshell rewrites the wait loop to poll picker text AND foreground in parallel, then short-circuits the secondary foreground gate on picker-text-trigger.
- `lib/bridge-tmux.sh` (+23) — new `bridge_tmux_pane_has_dev_channels_picker` helper next to `bridge_tmux_claude_blocker_state_from_text`.
- `scripts/test-controller-dev-channels-accept.sh` (NEW, 407 lines) — 4-case regression suite (positive control, negative control reproducing the bug, picker-sweep neighbor guard, timeout-still-works).
- `scripts/smoke-test.sh` (+9) — invokes the new regression after the existing dev-channels dispatch fixture.

## Verification

- [x] `bash -n bridge-start.sh lib/bridge-tmux.sh scripts/test-controller-dev-channels-accept.sh scripts/smoke-test.sh` — PASS
- [x] `shellcheck bridge-start.sh lib/bridge-tmux.sh scripts/test-controller-dev-channels-accept.sh` — clean
- [x] `BRIDGE_HOME=$(mktemp -d)/bridge-home bash scripts/test-controller-dev-channels-accept.sh` — 4/4 PASS
- [x] Pre-fix repro: temporarily stashing the source-side changes makes R2 fail (`bridge_tmux_pane_has_dev_channels_picker: command not found` from the inline watcher body), confirming the regression is meaningful.
- [x] Primary checkout pollution check: only known runtime entries (`.agents/`, `.claude/scheduled_tasks.lock`, `.claude/settings.json`, `.claude/skills/agent-bridge/`, `.claude/worktrees/`, `memory/`).
- [ ] Full `./scripts/smoke-test.sh` — not run end-to-end; the new regression is wired in and passes in isolation. Smoke harness has a known-failing `[smoke] creating queue task` step pre-existing on `main`.
- [ ] Live verification on the operator's wedged install — deferred to operator. The picker-text trigger should fire on the existing stuck agents without any manual Enter.

## Out of scope

- Picker-sweep allow-list (intentionally disjoint from the dev-channels picker text).
- Daemon stall-handling path (`bridge-daemon.sh:1549-1552`) — its current behavior of NOT typing into the pane is correct.
- `bridge-run.sh` agent-side watcher skip behavior at `:418-420` — that is the correct degradation when controller-side is armed.
- No VERSION / CHANGELOG bump (release is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)