### PR TITLE
fix(upgrade): clear shellcheck SC2026 on apostrophe-bearing comment (unblock smoke)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -548,9 +548,11 @@ bridge_upgrade_reconcile_agent_restart_recovery() {
     source "$source_root/bridge-lib.sh"
     bridge_load_roster
 
-    # Tab-separated read inside this -lc body: ANSI-C $'tab' is awkward to
-    # embed in a single-quoted -lc heredoc, so materialise the tab into a
-    # variable. printf is portable across the bash versions we support.
+    # Tab-separated read inside this -lc body: the ANSI-C tab escape
+    # sequence is awkward to embed in a single-quoted -lc heredoc
+    # because the apostrophes terminate the outer quote, so we
+    # materialise the tab into a variable. printf is portable across
+    # the bash versions we support.
     TAB="$(printf "\t")"
 
     # Collect the agents that need a recovery probe up front so the


### PR DESCRIPTION
## Summary

`bridge-upgrade.sh:551` contains the literal `\$'tab'` apostrophe pair inside a `bash -lc '...'` body. Shellcheck's static analyzer (SC2026 info) flags the inner apostrophes as terminating the outer single-quoted string. Because `scripts/smoke-test.sh:210` runs `shellcheck` under `set -euo pipefail`, the info-severity finding exits the smoke gate with rc=1 — even though the runtime works.

Pre-existing since PR #834 (`4e54b27`, v0.13.0 cycle, 2026-05-12). Confirmed identical failure on clean main at `96c6424`.

This PR rewrites the comment to drop the apostrophe pair entirely. Pure comment edit, no runtime behavior change.

## Changes

- `bridge-upgrade.sh:551-555` — rewrite three comment lines to remove the `\$'tab'` apostrophe pair. The replacement paraphrases the same intent ("the ANSI-C tab escape sequence is awkward to embed in a single-quoted -lc heredoc because the apostrophes terminate the outer quote, so we materialise the tab into a variable").

## Tests

- `bash -n bridge-upgrade.sh` ✓
- `shellcheck bridge-upgrade.sh` ✓ (rc=0)
- `shellcheck *.sh agent-bridge agb bin/agb scripts/smoke-test.sh agent-roster.local.example.sh` ✓ (rc=0 — full smoke shellcheck argv)

## Why ship separately

Pre-existing CI gate issue unrelated to PR #868 (#857 PR-2). Landing this first unblocks smoke for PR #868's pre-merge verification and any future PR.