### PR TITLE
fix(cron): RESULT_SCHEMA compliance with OpenAI Structured Outputs strict mode

### DIFF
--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -66,28 +66,49 @@ RESULT_SCHEMA = {
             "type": "string",
             "enum": list(DELIVERY_INTENT_VALUES),
         },
+        # Conditional fields — must be present in every codex emission per
+        # OpenAI Structured Outputs strict mode. Use `anyOf [object, null]`
+        # so codex emits `null` when the conditional is not applicable;
+        # `normalize_forward_target` / `normalize_channel_relay` already
+        # handle None → return None and the validator branches at
+        # validate_result preserve the existing conditional semantics.
         "forward_target": {
-            "type": "object",
-            "properties": {
-                "channel": {"type": "string", "enum": list(FORWARD_CHANNEL_VALUES)},
-                "target_ref": {"type": "string"},
-                "format": {"type": "string", "enum": list(FORWARD_FORMAT_VALUES)},
-            },
-            "required": ["channel", "target_ref", "format"],
-            "additionalProperties": False,
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "channel": {"type": "string", "enum": list(FORWARD_CHANNEL_VALUES)},
+                        "target_ref": {"type": "string"},
+                        "format": {"type": "string", "enum": list(FORWARD_FORMAT_VALUES)},
+                    },
+                    "required": ["channel", "target_ref", "format"],
+                    "additionalProperties": False,
+                },
+                {"type": "null"},
+            ],
         },
-        "summary_short": {"type": "string", "maxLength": SUMMARY_SHORT_MAX},
+        "summary_short": {
+            "anyOf": [
+                {"type": "string", "maxLength": SUMMARY_SHORT_MAX},
+                {"type": "null"},
+            ],
+        },
         "channel_relay": {
-            "type": "object",
-            "properties": {
-                "body": {"type": "string"},
-                "urgency": {"type": "string"},
-                "transport": {"type": "string"},
-                "target": {"type": "string"},
-                "subject": {"type": "string"},
-            },
-            "required": ["body"],
-            "additionalProperties": False,
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "body": {"type": "string"},
+                        "urgency": {"type": "string"},
+                        "transport": {"type": "string"},
+                        "target": {"type": "string"},
+                        "subject": {"type": "string"},
+                    },
+                    "required": ["body", "urgency", "transport", "target", "subject"],
+                    "additionalProperties": False,
+                },
+                {"type": "null"},
+            ],
         },
     },
     "required": [
@@ -100,6 +121,9 @@ RESULT_SCHEMA = {
         "artifacts",
         "confidence",
         "delivery_intent",
+        "forward_target",
+        "summary_short",
+        "channel_relay",
     ],
     "additionalProperties": False,
 }
@@ -1415,12 +1439,13 @@ def build_prompt(request: dict[str, Any], payload_text: str) -> str:
         "## Required JSON fields (in addition to the schema's existing keys)",
         "",
         "- `delivery_intent`: one of `silent | main_session_only | forward_to_user`. Required.",
-        "- `summary_short`: ≤ 200 chars, operator-facing summary. Required when `delivery_intent != silent`.",
-        "- `forward_target`: required when `delivery_intent = forward_to_user`. Object with:",
+        "- `summary_short`: ≤ 200 chars, operator-facing summary. Required (non-null) when `delivery_intent != silent`; set to `null` for `silent`.",
+        "- `forward_target`: required (non-null) when `delivery_intent = forward_to_user`; set to `null` otherwise. Object with:",
         "    - `channel`: one of `telegram | discord | mattermost`.",
         "    - `target_ref`: a logical target name (NOT a chat id, NOT a webhook URL). The parent resolves it against its own routing config.",
         "    - `format`: `markdown` or `text`.",
-        "- For `silent`, leave `summary_short` empty/unset and do not set `forward_target`.",
+        "- `channel_relay`: set to `null` unless this job opted into the legacy structured relay (deprecated; see below).",
+        "- For `silent`, set `summary_short` and `forward_target` to `null`.",
     ]
 
     if policy == "always_silent":

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -215,7 +215,12 @@ select_for_path() {
       # bridge-cron.py; pull its smoke in for the same trigger set.
       # Issue #628 — cron mutation audit emission ditto.
       # Native cron shell payload runner regression.
-      add_required cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner queue
+      # v0.13.5 hotfix — RESULT_SCHEMA must satisfy OpenAI Structured
+      # Outputs strict mode (every key in properties must appear in
+      # required at every nested object level). Cover the invariant
+      # smoke whenever bridge-cron-runner.py moves so a future PR can't
+      # silently regress the strict-mode contract.
+      add_required cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner cron-runner-schema-openai-strict queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/cron-runner-schema-openai-strict.sh
+++ b/scripts/smoke/cron-runner-schema-openai-strict.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# scripts/smoke/cron-runner-schema-openai-strict.sh — v0.13.5 hotfix smoke.
+#
+# Regression guard for the OpenAI Responses API "Structured Outputs strict
+# mode" contract that bridge-cron-runner.py's RESULT_SCHEMA must obey when
+# the codex engine handles a `payload_kind=text` cron job. Strict mode
+# requires that every key in every nested `properties` block also appear
+# in that block's `required` array, and that `additionalProperties: false`
+# is set on every object node.
+#
+# Before this PR, RESULT_SCHEMA had two violations:
+#   1. Top-level `required` listed 9 of 12 properties (omitted
+#      `forward_target`, `summary_short`, `channel_relay`).
+#   2. `channel_relay.required` listed only `["body"]` while
+#      `channel_relay.properties` had 5 keys (body, urgency, transport,
+#      target, subject).
+#
+# The live picker-sweep cron failed every 10 minutes against the upstream
+# Responses API with the verbatim error:
+#   'required' is required to be supplied and to be an array including
+#   every key in properties. Missing 'urgency'.
+#
+# The fix is schema-only (the runtime validator + normalizers are already
+# null-safe). This smoke fails the build if any future PR re-introduces
+# either violation.
+#
+# Footgun #11 (Bash 5.3.9 heredoc deadlock): this smoke writes its inline
+# Python helper via `printf` to a tmp file and runs `python3 <file>` — no
+# heredoc, no here-string.
+
+set -euo pipefail
+
+SMOKE_NAME="cron-runner-schema-openai-strict"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root
+
+HELPER="$SMOKE_TMP_ROOT/schema_invariant_check.py"
+
+# Build the helper line-by-line via printf — no heredoc / no here-string.
+{
+  printf '%s\n' 'import importlib.util, json, os, sys'
+  printf '%s\n' ''
+  printf '%s\n' 'repo_root = os.environ["REPO_ROOT"]'
+  printf '%s\n' 'target = os.path.join(repo_root, "bridge-cron-runner.py")'
+  printf '%s\n' 'spec = importlib.util.spec_from_file_location("bridge_cron_runner", target)'
+  printf '%s\n' 'module = importlib.util.module_from_spec(spec)'
+  printf '%s\n' 'spec.loader.exec_module(module)'
+  printf '%s\n' 'schema = module.RESULT_SCHEMA'
+  printf '%s\n' ''
+  printf '%s\n' 'errors = []'
+  printf '%s\n' ''
+  printf '%s\n' 'def walk(node, path):'
+  printf '%s\n' '    if not isinstance(node, dict):'
+  printf '%s\n' '        return'
+  printf '%s\n' '    if node.get("type") == "object":'
+  printf '%s\n' '        props = node.get("properties", {}) or {}'
+  printf '%s\n' '        req = set(node.get("required", []) or [])'
+  printf '%s\n' '        prop_keys = set(props.keys())'
+  printf '%s\n' '        missing = sorted(prop_keys - req)'
+  printf '%s\n' '        if missing:'
+  printf '%s\n' '            errors.append("required missing at {0}: {1}".format(path, missing))'
+  printf '%s\n' '        if node.get("additionalProperties", True) is not False:'
+  printf '%s\n' '            errors.append("additionalProperties != False at {0}".format(path))'
+  printf '%s\n' '        for k, v in props.items():'
+  printf '%s\n' '            walk(v, "{0}.{1}".format(path, k))'
+  printf '%s\n' '    for k, v in node.items():'
+  printf '%s\n' '        if k in ("anyOf", "allOf", "oneOf"):'
+  printf '%s\n' '            for i, item in enumerate(v):'
+  printf '%s\n' '                walk(item, "{0}.{1}[{2}]".format(path, k, i))'
+  printf '%s\n' ''
+  printf '%s\n' 'walk(schema, "$")'
+  printf '%s\n' ''
+  printf '%s\n' 'top_required = set(schema.get("required", []) or [])'
+  printf '%s\n' 'top_props = set((schema.get("properties", {}) or {}).keys())'
+  printf '%s\n' 'expected_required = {'
+  printf '%s\n' '    "status", "summary", "findings", "actions_taken",'
+  printf '%s\n' '    "needs_human_followup", "recommended_next_steps",'
+  printf '%s\n' '    "artifacts", "confidence", "delivery_intent",'
+  printf '%s\n' '    "forward_target", "summary_short", "channel_relay",'
+  printf '%s\n' '}'
+  printf '%s\n' 'if top_required != expected_required:'
+  printf '%s\n' '    errors.append("top-level required != expected; got {0}".format(sorted(top_required)))'
+  printf '%s\n' 'if top_props != expected_required:'
+  printf '%s\n' '    errors.append("top-level properties != expected; got {0}".format(sorted(top_props)))'
+  printf '%s\n' ''
+  printf '%s\n' '# channel_relay must require all 5 keys (the verbatim operator-host failure).'
+  printf '%s\n' 'cr_node = schema["properties"]["channel_relay"]'
+  printf '%s\n' 'cr_branches = cr_node.get("anyOf") or [cr_node]'
+  printf '%s\n' 'cr_object = next((b for b in cr_branches if b.get("type") == "object"), None)'
+  printf '%s\n' 'if cr_object is None:'
+  printf '%s\n' '    errors.append("channel_relay anyOf has no object branch")'
+  printf '%s\n' 'else:'
+  printf '%s\n' '    cr_required = set(cr_object.get("required", []) or [])'
+  printf '%s\n' '    cr_expected = {"body", "urgency", "transport", "target", "subject"}'
+  printf '%s\n' '    if cr_required != cr_expected:'
+  printf '%s\n' '        errors.append("channel_relay.required != expected; got {0}".format(sorted(cr_required)))'
+  printf '%s\n' ''
+  printf '%s\n' '# forward_target must require channel/target_ref/format.'
+  printf '%s\n' 'ft_node = schema["properties"]["forward_target"]'
+  printf '%s\n' 'ft_branches = ft_node.get("anyOf") or [ft_node]'
+  printf '%s\n' 'ft_object = next((b for b in ft_branches if b.get("type") == "object"), None)'
+  printf '%s\n' 'if ft_object is None:'
+  printf '%s\n' '    errors.append("forward_target anyOf has no object branch")'
+  printf '%s\n' 'else:'
+  printf '%s\n' '    ft_required = set(ft_object.get("required", []) or [])'
+  printf '%s\n' '    ft_expected = {"channel", "target_ref", "format"}'
+  printf '%s\n' '    if ft_required != ft_expected:'
+  printf '%s\n' '        errors.append("forward_target.required != expected; got {0}".format(sorted(ft_required)))'
+  printf '%s\n' ''
+  printf '%s\n' '# Each conditional top-level field must allow null via anyOf so codex can'
+  printf '%s\n' '# emit null without violating strict mode. Without this, the strict-required'
+  printf '%s\n' '# top-level array would force every cron payload to carry a non-null object.'
+  printf '%s\n' 'for field in ("forward_target", "summary_short", "channel_relay"):'
+  printf '%s\n' '    node = schema["properties"][field]'
+  printf '%s\n' '    branches = node.get("anyOf")'
+  printf '%s\n' '    if not branches:'
+  printf '%s\n' '        errors.append("{0} missing anyOf; cannot emit null".format(field))'
+  printf '%s\n' '        continue'
+  printf '%s\n' '    has_null = any(b.get("type") == "null" for b in branches)'
+  printf '%s\n' '    if not has_null:'
+  printf '%s\n' '        errors.append("{0} anyOf has no null branch".format(field))'
+  printf '%s\n' ''
+  printf '%s\n' '# Confirm schema is structurally valid JSON Schema. Prefer jsonschema if'
+  printf '%s\n' '# available; fall back to a json.dumps round-trip as a baseline sanity check.'
+  printf '%s\n' 'try:'
+  printf '%s\n' '    import jsonschema'
+  printf '%s\n' '    jsonschema.Draft202012Validator.check_schema(schema)'
+  printf '%s\n' '    print("[smoke] jsonschema.Draft202012Validator.check_schema ok")'
+  printf '%s\n' 'except ImportError:'
+  printf '%s\n' '    json.dumps(schema)'
+  printf '%s\n' '    print("[smoke] jsonschema not installed; json.dumps round-trip ok")'
+  printf '%s\n' ''
+  printf '%s\n' 'if errors:'
+  printf '%s\n' '    for e in errors:'
+  printf '%s\n' '        print("[smoke][error] " + e, file=sys.stderr)'
+  printf '%s\n' '    sys.exit(1)'
+  printf '%s\n' ''
+  printf '%s\n' 'print("[smoke] RESULT_SCHEMA OpenAI strict-mode invariants ok")'
+} >"$HELPER"
+
+smoke_log "running schema invariant check via $HELPER"
+REPO_ROOT="$REPO_ROOT" "$PY_BIN" "$HELPER"
+
+smoke_log "ok"


### PR DESCRIPTION
## Summary

Hotfix for codex-driven cron payload schema. OpenAI Responses API's Structured Outputs strict mode rejects schemas where the `required` array does not include every key in `properties` at every nested object level. The previous `RESULT_SCHEMA` violated this in two places:

- Top-level `required` listed 9 of 12 properties (missed `forward_target`, `summary_short`, `channel_relay`).
- `channel_relay.required` listed 1 of 5 properties (only `body`; missed `urgency`, `transport`, `target`, `subject`).

Operator-observed error verbatim:
```
'required' is required to be supplied and to be an array including every key in properties. Missing 'urgency'.
```

Every cron with `payload_kind=text` dispatching via codex was failing. picker-sweep was the canary that surfaced this.

## Fix

Use the `anyOf [{actual_type}, {"type": "null"}]` pattern for the three conditional top-level fields, so codex emits `null` when not applicable. Strict mode is now satisfied:

- All 12 top-level properties listed in top-level `required`.
- All 5 `channel_relay` properties listed in `channel_relay.required` (when codex chooses to emit a non-null channel_relay object).
- `forward_target.required` was already correct.

The runtime validator (`validate_result` + `normalize_forward_target` + `normalize_channel_relay`) is already null-safe — `result.get(key)` returns None for null values, and the normalizers return None on None input. Existing conditional-intent branches preserve the same semantics.

Prompt text updated to instruct codex explicitly to emit `null` for conditional fields when not applicable (the schema enforces this, but explicit instruction reduces model confusion).

## Changes

- `bridge-cron-runner.py` — `RESULT_SCHEMA` strict-mode-compliant
- `bridge-cron-runner.py` — prompt text "leave empty/unset" → "set to null"
- `scripts/smoke/cron-runner-schema-openai-strict.sh` — new regression smoke
- `scripts/ci-select-smoke.sh` — wire new smoke as required when `bridge-cron-runner.py` changes

## Tests

- `python3 -c "import ast; ast.parse(open('bridge-cron-runner.py').read())"` ok
- Schema invariant local check ok (every `properties` block has all keys in `required`)
- `bash scripts/smoke/cron-runner-schema-openai-strict.sh` ok
- `./scripts/smoke-test.sh` — pre-existing macOS failure at the `bridge-run.sh --dry-run` step (legacy-layout BRIDGE_HOME refuses isolation-v2 gate); reproduces on `main` at `10e5ade` with the exact same exit code, unrelated to this diff.
- Live operator-host validation deferred to post-merge cron re-enable.

## Operator-host follow-up

After v0.13.5 ships:
1. `~/Projects/agent-bridge-public/agent-bridge upgrade --apply` (or operator's preferred path)
2. `agent-bridge cron enable picker-sweep-<id>` (re-activate the cron disabled during diagnosis)
3. Observe next cron cycle for success

## Refs

- Operator-observed at 2026-05-15 by the Agent Bridge install on Linux server; surfaced via picker-sweep cron failing every 10 minutes
- Mirrors no prior PR — this is a new defect introduced by OpenAI's recent strict mode enforcement