### PR TITLE
fix(docs): wire ADMIN-PROTOCOL.md into AGENT_SHARED_LINKS so admin home gets the symlink

### DIFF
--- a/bridge-docs.py
+++ b/bridge-docs.py
@@ -24,6 +24,7 @@ AGENT_SHARED_LINKS = (
     "COMMON-INSTRUCTIONS.md",
     "CHANGE-POLICY.md",
     "TOOLS.md",
+    "ADMIN-PROTOCOL.md",
 )
 DEPRECATED_SHARED_FILES = (
     "ROSTER.md",
@@ -589,6 +590,48 @@ def render_shared_change_policy_md(bridge_home: Path) -> str:
 """
 
 
+ADMIN_PROTOCOL_FALLBACK = """# ADMIN-PROTOCOL.md — Agent Bridge Admin Protocol
+
+<!-- Managed by agent-bridge. Source: docs/agent-runtime/admin-protocol.md missing at render time. -->
+
+Source document `docs/agent-runtime/admin-protocol.md` was not present in this
+install at render time. Re-run `agent-bridge upgrade` from a complete source
+checkout to repopulate this file. See repository docs for the canonical admin
+protocol body.
+"""
+
+
+def render_shared_admin_protocol_md(bridge_home: Path) -> str:
+    """Propagate docs/agent-runtime/admin-protocol.md into the shared dir.
+
+    Rationale: the agent CLAUDE.md managed block points admin sessions at
+    `ADMIN-PROTOCOL.md` (see `_admin_block_lines`), but until this renderer
+    existed the file was never written to `<bridge_home>/shared/` and the
+    matching symlink was therefore missing from every admin agent home
+    (`COMMON-INSTRUCTIONS.md`, `CHANGE-POLICY.md`, `TOOLS.md` had the wiring
+    via `AGENT_SHARED_LINKS`, `ADMIN-PROTOCOL.md` did not). Reading the
+    source-of-truth body keeps the shared copy in lockstep with the doc the
+    repo already maintains, rather than duplicating 30KB of protocol text
+    inline here.
+
+    `bridge_home` is accepted for parity with the other shared renderers
+    (dispatch table calls every renderer with the same signature) even
+    though this renderer derives content from REPO_ROOT alone.
+    """
+    del bridge_home  # signature parity with other renderers
+    source = REPO_ROOT / "docs" / "agent-runtime" / "admin-protocol.md"
+    if not source.exists():
+        return ADMIN_PROTOCOL_FALLBACK
+    body = read_text(source)
+    header = (
+        "<!-- Managed by agent-bridge. "
+        "Source: docs/agent-runtime/admin-protocol.md. "
+        "Edits to this file will be overwritten on the next "
+        "`agent-bridge upgrade`. -->\n\n"
+    )
+    return header + body
+
+
 SKILLS_DOC_MODES = ("legacy-catalog", "plugin-routing", "disabled")
 
 
@@ -990,6 +1033,7 @@ def sync_shared_docs(bridge_home: Path, source_shared: Path, dry_run: bool, stam
         "TOOLS.md": render_shared_tools_md,
         "COMMON-INSTRUCTIONS.md": render_shared_common_instructions_md,
         "CHANGE-POLICY.md": render_shared_change_policy_md,
+        "ADMIN-PROTOCOL.md": render_shared_admin_protocol_md,
     }
     # BRIDGE_SKILLS_DOC_MODE chooses the catalog rendering strategy.
     # Whichever file is *not* selected gets cleaned up so a mode flip

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -165,6 +165,19 @@ select_for_path() {
     return 0
   fi
 
+  # v0.13.6 hotfix track 1 r2 (codex catch): docs/agent-runtime/admin-protocol.md
+  # is the SSOT body that bridge-docs.py renders into <bridge_home>/shared/
+  # ADMIN-PROTOCOL.md. A change to the SSOT must trigger the propagation smoke
+  # so the rendered body stays in lockstep with the wire-up. This case must
+  # precede the is_docs_only_path early-return below, which would otherwise
+  # short-circuit on the .md extension and select only the global required
+  # smokes.
+  case "$path" in
+    docs/agent-runtime/admin-protocol.md)
+      add_required admin-protocol-shared-link
+      ;;
+  esac
+
   if is_docs_only_path "$path"; then
     return 0
   fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link
 }
 
 add_all_integration() {
@@ -373,6 +373,17 @@ select_for_path() {
       add_all_required_static
       add_all_integration
       add_live live-tmux-daemon
+      ;;
+
+    bridge-docs.py)
+      # v0.13.6 hotfix track 1: bridge-docs.py owns AGENT_SHARED_LINKS and
+      # the shared-doc render dispatch. The admin-protocol-shared-link
+      # smoke pins the wire-up that propagates docs/agent-runtime/
+      # admin-protocol.md into <bridge_home>/shared/ADMIN-PROTOCOL.md and
+      # symlinks it from every agent home. Cover it on every bridge-docs.py
+      # move so the dispatch table and link tuple stay in lockstep.
+      add_required admin-protocol-shared-link
+      add_integration integration-minimal
       ;;
 
     *.sh|lib/*.sh|scripts/*.sh|*.py|scripts/*.py)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10632,6 +10632,13 @@ bash "$REPO_ROOT/scripts/smoke/per-agent-settings-rendering.sh"
 log "running shared-settings-preserve-user-keys smoke (issue #613)"
 bash "$REPO_ROOT/scripts/smoke/shared-settings-preserve-user-keys.sh"
 
+# v0.13.6 hotfix track 1 — ADMIN-PROTOCOL.md wire-up. The agent CLAUDE.md
+# managed block points admin sessions at ADMIN-PROTOCOL.md but until
+# this smoke landed the file was never propagated into <bridge_home>/
+# shared/ and the matching symlink was missing from every agent home.
+log "running admin-protocol-shared-link smoke (v0.13.6 hotfix track 1)"
+bash "$REPO_ROOT/scripts/smoke/admin-protocol-shared-link.sh"
+
 # Issue #597 Track D — precompact-notify suite. Exercises the Discord
 # relay activity-index writer, the Track A route-primitive end-to-end
 # with the writer-populated index, and the pre-compact.py hook

--- a/scripts/smoke/admin-protocol-shared-link.sh
+++ b/scripts/smoke/admin-protocol-shared-link.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# admin-protocol-shared-link smoke
+#
+# Pins the wire-up that propagates docs/agent-runtime/admin-protocol.md
+# into <bridge_home>/shared/ADMIN-PROTOCOL.md and links it from each
+# agent home as ADMIN-PROTOCOL.md -> ../shared/ADMIN-PROTOCOL.md.
+#
+# Before this smoke landed, the agent CLAUDE.md managed block pointed
+# admin sessions at `ADMIN-PROTOCOL.md` but `AGENT_SHARED_LINKS` did
+# not list it and no shared renderer existed, so the file was never
+# created and the symlink was missing from every agent home (admin
+# included). This smoke fails fast if either half regresses.
+#
+# macOS-friendly. No heredocs / here-strings in this body (footgun #11).
+
+set -euo pipefail
+
+SMOKE_NAME="admin-protocol-shared-link"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+seed_agent_home() {
+  local agent_home="$BRIDGE_AGENT_HOME_ROOT/patch"
+  mkdir -p "$agent_home/.claude"
+  printf '# patch soul\n' >"$agent_home/SOUL.md"
+  printf '# Session Type\n\n- Session Type: admin\n' >"$agent_home/SESSION-TYPE.md"
+  # Minimal CLAUDE.md — bridge-docs.py apply will wrap the managed
+  # block around it; we only care that the agent dir exists and is
+  # recognized as a valid agent home.
+  printf '# patch\n\nadmin smoke fixture\n' >"$agent_home/CLAUDE.md"
+}
+
+run_bridge_docs_apply() {
+  python3 "$SMOKE_REPO_ROOT/bridge-docs.py" apply patch \
+    --bridge-home "$BRIDGE_HOME" \
+    --target-root "$BRIDGE_AGENT_HOME_ROOT" \
+    --source-shared "$SMOKE_TMP_ROOT/nonexistent-source-shared" \
+    >/dev/null
+}
+
+assert_shared_file_written() {
+  local shared_file="$BRIDGE_HOME/shared/ADMIN-PROTOCOL.md"
+  smoke_assert_file_exists "$shared_file" \
+    "shared ADMIN-PROTOCOL.md must be written by render dispatch"
+
+  local body
+  body="$(cat "$shared_file")"
+  smoke_assert_contains "$body" "Managed by agent-bridge" \
+    "shared ADMIN-PROTOCOL.md must carry the managed header marker"
+  smoke_assert_contains "$body" "Admin Protocol" \
+    "shared ADMIN-PROTOCOL.md must include the canonical source body"
+  smoke_assert_contains "$body" "Session Type" \
+    "shared ADMIN-PROTOCOL.md must reference Session Type gating (source body sentinel)"
+}
+
+assert_agent_symlink_created() {
+  local agent_home="$BRIDGE_AGENT_HOME_ROOT/patch"
+  local link="$agent_home/ADMIN-PROTOCOL.md"
+
+  [[ -L "$link" ]] || smoke_fail \
+    "agent home must contain ADMIN-PROTOCOL.md as a symlink (got non-symlink or missing)"
+
+  local target
+  target="$(readlink "$link")"
+  smoke_assert_eq "../shared/ADMIN-PROTOCOL.md" "$target" \
+    "ADMIN-PROTOCOL.md symlink must point to ../shared/ADMIN-PROTOCOL.md"
+
+  # Resolve must succeed — broken symlinks would defeat the wire-up.
+  [[ -f "$link" ]] || smoke_fail \
+    "ADMIN-PROTOCOL.md symlink target must resolve to an existing file"
+
+  # Companion symlinks must still be wired (regression guard so adding
+  # ADMIN-PROTOCOL.md to AGENT_SHARED_LINKS did not displace the others).
+  [[ -L "$agent_home/COMMON-INSTRUCTIONS.md" ]] || smoke_fail \
+    "COMMON-INSTRUCTIONS.md symlink must remain wired alongside ADMIN-PROTOCOL.md"
+  [[ -L "$agent_home/CHANGE-POLICY.md" ]] || smoke_fail \
+    "CHANGE-POLICY.md symlink must remain wired alongside ADMIN-PROTOCOL.md"
+  [[ -L "$agent_home/TOOLS.md" ]] || smoke_fail \
+    "TOOLS.md symlink must remain wired alongside ADMIN-PROTOCOL.md"
+}
+
+assert_idempotent_rerun() {
+  # Second apply must not break anything: shared file still present,
+  # symlink still pointing at the right target.
+  run_bridge_docs_apply
+  assert_shared_file_written
+  assert_agent_symlink_created
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_setup_bridge_home "admin-protocol"
+  seed_agent_home
+  smoke_run "bridge-docs.py apply writes shared/ADMIN-PROTOCOL.md from source body" \
+    run_bridge_docs_apply
+  smoke_run "shared ADMIN-PROTOCOL.md exists with managed marker and source body" \
+    assert_shared_file_written
+  smoke_run "agent home links ADMIN-PROTOCOL.md -> ../shared/ADMIN-PROTOCOL.md" \
+    assert_agent_symlink_created
+  smoke_run "second apply is idempotent and preserves the wire-up" \
+    assert_idempotent_rerun
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Symptom

The admin agent (Linux host) opens its tracked `CLAUDE.md`, follows the managed block to `ADMIN-PROTOCOL.md`, and the file is **missing** — no symlink, no copy. Compare with the working trio `COMMON-INSTRUCTIONS.md`, `CHANGE-POLICY.md`, `TOOLS.md`, all symlinked to `../shared/...`.

Observed during v0.13.5 post-upgrade verification on the operator's Linux host (report 2026-05-15).

## Root Cause Trace

- `bridge-docs.py:23-27` `AGENT_SHARED_LINKS = ("COMMON-INSTRUCTIONS.md", "CHANGE-POLICY.md", "TOOLS.md")` — `ADMIN-PROTOCOL.md` is **not in the tuple** that `ensure_agent_shared_links` iterates over.
- `bridge-docs.py:989-993` `generated_renderers` dispatch maps the trio to their inline renderers; no entry for `ADMIN-PROTOCOL.md`, so even if the symlink existed it would dangle.
- `bridge-docs.py:1128` (`_admin_block_lines`) and `bridge-docs.py:1166` (`render_agent_bridge_block` general body) both tell the agent "admin-only 운영 본문은 `ADMIN-PROTOCOL.md` 에 있다" — the pointer is correct, the file just never gets written.
- `docs/agent-runtime/admin-protocol.md` (~30KB) is the source body and is already shipped to live runtime by `scripts/deploy-live-install.sh` via `git ls-files`.

## Fix

Minimal, scoped to closing the wire-up gap:

1. `AGENT_SHARED_LINKS` += `"ADMIN-PROTOCOL.md"`.
2. New `render_shared_admin_protocol_md` reads `REPO_ROOT/docs/agent-runtime/admin-protocol.md` and prepends a managed-by header marker. Falls back to a self-describing stub if the source file is missing (defensive — should never trip in practice since it ships with every install).
3. Renderer registered in `generated_renderers` so `sync_shared_docs` writes `<bridge_home>/shared/ADMIN-PROTOCOL.md` on every `bridge-docs.py apply` (which `agent-bridge upgrade` calls).
4. New smoke `scripts/smoke/admin-protocol-shared-link.sh` pins:
   - shared file written with header marker + canonical body sentinel
   - agent home symlink exists, target is `../shared/ADMIN-PROTOCOL.md`, target resolves
   - companion symlinks (`COMMON-INSTRUCTIONS.md`, `CHANGE-POLICY.md`, `TOOLS.md`) remain wired
   - second apply is idempotent
5. Wired into `scripts/smoke-test.sh` and `scripts/ci-select-smoke.sh` (new `bridge-docs.py` dispatch row + appended to `add_all_required_static`).

## Out of Scope (deliberately deferred)

- **Admin-only filtering.** The new symlink is created in every agent home (admin + static + dynamic), matching the existing trio's behavior. Whether non-admin homes should also carry `ADMIN-PROTOCOL.md` is a separate design question and not part of this hotfix.
- **Managed block pointer text.** `_admin_block_lines` and `render_agent_bridge_block` are unchanged — they already point at the right filename; the bug was the file not existing.
- **VERSION / CHANGELOG.** Release PR follows separately.
- **Credential rotation regression.** Tracked as a separate v0.13.6 hotfix track, unrelated to this PR.

## Verification

- `python3 -c "import ast; ast.parse(open('bridge-docs.py').read())"` — PASS
- `bash -n` on every touched shell file — PASS
- `shellcheck` on the new smoke + `scripts/ci-select-smoke.sh` + `scripts/smoke-test.sh` — PASS (no findings)
- `bash scripts/smoke/admin-protocol-shared-link.sh` — 4/4 assertions PASS
- Spot-checked related smokes (`upgrade-shared-settings-propagate`, `agent-doctor`, `upgrade-source-preservation`) — all PASS, no collateral regressions in adjacent doc-sync paths.
- `./scripts/smoke-test.sh` hangs pre-existing on the macOS `bridge-run.sh --dry-run` isolation-v2 gate step (reproduces on `main` HEAD `7148f7e` without any edits); unrelated to this diff.

## Refs

Operator report 2026-05-15 (Linux host post-v0.13.5 verification, no open issue tracked yet).

---

Generated with Claude Code
