### PR TITLE
fix(isolation): skip isolation-v2 migration on macOS shared-agent installs (no isolated agents = no-op)

### DIFF
--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -1745,6 +1745,27 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
     return 2
   }
 
+  # v0.13.6 hotfix track 4: silent no-op on macOS shared-agent installs.
+  # The isolation-v2 layout (group + setgid + named-UID ownership) only
+  # has operational effect on Linux hosts where agents run under their
+  # own `agent-bridge-<slug>` UIDs. On a single-OS-user host with no
+  # isolated agents (the macOS dev pattern), the migration's chgrp/chmod
+  # work has no effect and `bridge_isolation_v2_privilege_preflight`
+  # demands passwordless sudo just to perform that no-op — which aborts
+  # the upgrade when the operator (correctly) declines the prompt.
+  # Skip the entire migration body in that case and emit a benign no-op
+  # JSON. The branch is idempotent: every subsequent upgrade hits the
+  # same gate. `bridge_isolation_v2_roster_has_isolated_agents` is
+  # fail-safe — if it can't evaluate (predicate not declared, roster
+  # array missing) it returns non-zero, but we still gate on `uname -s
+  # != Linux` so the Linux migration path is strictly unchanged.
+  if [[ "$(uname -s 2>/dev/null || printf 'unknown')" != "Linux" ]] \
+      && ! bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null; then
+    printf '{"mode":"isolation-v2-migrate","status":"ok","skipped":true,"reason":"macos-shared-agent","platform":"%s","no_v080_code_installed":"yes"}\n' \
+      "$(uname -s 2>/dev/null || printf 'unknown')"
+    return 0
+  fi
+
   local data_root="${BRIDGE_DATA_ROOT:-$target_root}"
   local marker_path
   marker_path="$(bridge_isolation_v2_marker_path 2>/dev/null || \

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -1755,12 +1755,23 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
   # the upgrade when the operator (correctly) declines the prompt.
   # Skip the entire migration body in that case and emit a benign no-op
   # JSON. The branch is idempotent: every subsequent upgrade hits the
-  # same gate. `bridge_isolation_v2_roster_has_isolated_agents` is
-  # fail-safe — if it can't evaluate (predicate not declared, roster
-  # array missing) it returns non-zero, but we still gate on `uname -s
-  # != Linux` so the Linux migration path is strictly unchanged.
-  if [[ "$(uname -s 2>/dev/null || printf 'unknown')" != "Linux" ]] \
-      && ! bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null; then
+  # same gate.
+  #
+  # `bridge_isolation_v2_roster_has_isolated_agents` returns:
+  #   0 — has isolated agent (do NOT skip, fall through to migration)
+  #   1 — confirmed no isolated agent (safe to skip on non-Linux)
+  #   2 — unknown / predicate or roster array unavailable (do NOT skip,
+  #       fall through so the existing preflight path emits its own
+  #       error and the operator gets actionable remediation)
+  #
+  # codex r1 needs-more catch (PR #882 r2): treat rc=1 (confirmed) and
+  # rc=2 (unknown) differently. Original logic merged both via `!cmd`
+  # which would have let a Darwin host with a broken roster predicate
+  # take the skip branch silently — bypassing the preflight check.
+  local _iso_check_rc=0
+  bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null || _iso_check_rc=$?
+  if [[ "$(uname -s 2>/dev/null || printf 'unknown')" != "Linux" \
+        && "$_iso_check_rc" -eq 1 ]]; then
     printf '{"mode":"isolation-v2-migrate","status":"ok","skipped":true,"reason":"macos-shared-agent","platform":"%s","no_v080_code_installed":"yes"}\n' \
       "$(uname -s 2>/dev/null || printf 'unknown')"
     return 0

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1080,6 +1080,32 @@ bridge_isolation_v2_privilege_preflight() {
   return 1
 }
 
+bridge_isolation_v2_roster_has_isolated_agents() {
+  # Returns 0 when at least one agent in the loaded roster has effective
+  # linux-user isolation; non-zero when no agent is effectively isolated
+  # (roster empty, not loaded, or every agent resolves to shared).
+  #
+  # Used by `bridge_isolation_v2_migrate_apply_for_upgrade` to short-circuit
+  # the migration on hosts where the v2 layout (group + setgid + per-agent
+  # named-UID) has no operational effect — notably macOS shared-agent
+  # installs where every agent runs as the controller's own OS user.
+  #
+  # Fail-safe: if the predicate or roster array is unavailable (e.g. lib
+  # source order edge case), returns 1 so callers that gate on "no isolated
+  # agents" do NOT take the skip branch — i.e. behavior falls back to the
+  # pre-fix migration path.
+  declare -F bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 || return 1
+  declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 || return 1
+  local _roster_agent
+  for _roster_agent in "${BRIDGE_AGENT_IDS[@]}"; do
+    [[ -n "$_roster_agent" ]] || continue
+    if bridge_agent_linux_user_isolation_effective "$_roster_agent" 2>/dev/null; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # 5. umask helpers — restore on every path
 # ---------------------------------------------------------------------------

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1081,21 +1081,21 @@ bridge_isolation_v2_privilege_preflight() {
 }
 
 bridge_isolation_v2_roster_has_isolated_agents() {
-  # Returns 0 when at least one agent in the loaded roster has effective
-  # linux-user isolation; non-zero when no agent is effectively isolated
-  # (roster empty, not loaded, or every agent resolves to shared).
+  # Returns:
+  #   0  — at least one roster agent has effective linux-user isolation
+  #   1  — roster fully iterated, NO agent is effectively isolated (confirmed
+  #        shared-only / safe to skip)
+  #   2  — predicate function or BRIDGE_AGENT_IDS array unavailable
+  #        (unknown — callers MUST fall through to the existing path
+  #        rather than treat as "no isolated")
   #
-  # Used by `bridge_isolation_v2_migrate_apply_for_upgrade` to short-circuit
-  # the migration on hosts where the v2 layout (group + setgid + per-agent
-  # named-UID) has no operational effect — notably macOS shared-agent
-  # installs where every agent runs as the controller's own OS user.
-  #
-  # Fail-safe: if the predicate or roster array is unavailable (e.g. lib
-  # source order edge case), returns 1 so callers that gate on "no isolated
-  # agents" do NOT take the skip branch — i.e. behavior falls back to the
-  # pre-fix migration path.
-  declare -F bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 || return 1
-  declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 || return 1
+  # codex r1 needs-more catch (PR #882): merging rc=1 (confirmed-no-iso) and
+  # rc=2 (unknown) in a single non-zero would let a Darwin host with a
+  # broken roster predicate take the macOS skip branch, bypassing the
+  # legitimate preflight. Splitting the unknown state into rc=2 lets the
+  # caller gate "skip" on the confirmed rc=1 only.
+  declare -F bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 || return 2
+  declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 || return 2
   local _roster_agent
   for _roster_agent in "${BRIDGE_AGENT_IDS[@]}"; do
     [[ -n "$_roster_agent" ]] || continue

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link
 }
 
 add_all_integration() {
@@ -287,7 +287,7 @@ select_for_path() {
       # dotenv migrator lives in lib/bridge-isolation-v3-channel-dotenv.sh
       # and depends directly on v2-reapply primitives; pull its smoke
       # for every isolation-lib + bridge-migrate.sh move.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke/isolation-v2-migrate-macos-skip.sh
+++ b/scripts/smoke/isolation-v2-migrate-macos-skip.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# v0.13.6 hotfix track 4 — regression smoke for the macOS shared-agent
+# silent-skip branch in `bridge_isolation_v2_migrate_apply_for_upgrade`.
+#
+# Reproduces the v0.13.5 regression: on a macOS host with no isolated
+# agents (operator's patch host), the platform-agnostic migration body
+# called `bridge_isolation_v2_privilege_preflight` which demanded
+# passwordless sudo and aborted the upgrade when the operator declined.
+#
+# Coverage:
+#   T1 — Darwin + no isolated agents → JSON `skipped=true reason=macos-shared-agent`
+#        + `sudo` is never invoked (verified via PATH shim that records calls).
+#   T2 — Idempotent: a second call produces the same skip JSON.
+#   T3 — Linux + no isolated agents → does NOT take the skip branch
+#        (proceeds far enough to hit the existing migration body — the
+#        body itself is allowed to fail in this temp fixture; what we
+#        assert is the JSON envelope shape).
+#   T4 — Darwin + at least one isolated agent in the roster → does NOT
+#        take the skip branch (same envelope assertion as T3).
+#   T5 — `bridge_isolation_v2_roster_has_isolated_agents` standalone
+#        sanity: returns 1 with no isolated agents, returns 0 once one is
+#        present.
+#
+# All scripted shell snippets are emitted as $'…' literals or `mktemp`
+# + `printf` to a script file — no heredocs or here-strings (Bash 5.3.9
+# heredoc_write deadlock class, footgun #11).
+
+set -uo pipefail
+
+SMOKE_NAME="isolation-v2-migrate-macos-skip"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# --- harness helpers ---------------------------------------------------------
+
+# Build a `bin/` directory shim:
+#   * `uname` always reports the requested kernel (Darwin or Linux).
+#   * `sudo` records every call to a log file. The skip branch must NOT
+#     invoke sudo.
+#
+# Emitted via printf-to-file (no heredocs).
+build_platform_shim() {
+  local shim_dir="$1"
+  local fake_uname="$2"
+  local sudo_log="$3"
+
+  mkdir -p "$shim_dir"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' '# uname shim — reports the requested platform regardless of'
+    printf '%s\n' '# the host kernel, so the skip branch can be exercised on'
+    printf '%s\n' '# any CI runner.'
+    printf 'FAKE_UNAME=%q\n' "$fake_uname"
+    printf '%s\n' 'if [[ $# -eq 0 ]]; then'
+    printf '%s\n' '  printf "%s\n" "$FAKE_UNAME"'
+    printf '%s\n' '  exit 0'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'while [[ $# -gt 0 ]]; do'
+    printf '%s\n' '  case "$1" in'
+    printf '%s\n' '    -s) printf "%s\n" "$FAKE_UNAME" ;;'
+    printf '%s\n' '    -m) printf "%s\n" "x86_64" ;;'
+    printf '%s\n' '    -r) printf "%s\n" "0.0.0" ;;'
+    printf '%s\n' '    -a) printf "%s shim 0.0.0 #0 SMP x86_64\n" "$FAKE_UNAME" ;;'
+    printf '%s\n' '    *) printf "%s\n" "$FAKE_UNAME" ;;'
+    printf '%s\n' '  esac'
+    printf '%s\n' '  shift'
+    printf '%s\n' 'done'
+  } >"$shim_dir/uname"
+  chmod +x "$shim_dir/uname"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' '# sudo shim — records the call and exits non-zero so any'
+    printf '%s\n' '# accidental sudo invocation in the skip branch turns into a'
+    printf '%s\n' '# loud test failure rather than a silent state mutation.'
+    printf 'LOG=%q\n' "$sudo_log"
+    printf '%s\n' 'printf "[sudo-shim] %s\n" "$*" >>"$LOG"'
+    printf '%s\n' 'exit 99'
+  } >"$shim_dir/sudo"
+  chmod +x "$shim_dir/sudo"
+}
+
+# Symlink the other PATH essentials into the shim dir so the driver
+# subshell still has access to bash/mkdir/rm/printf/cat/grep when we
+# replace PATH wholesale.
+populate_basic_path() {
+  local shim_dir="$1"
+  local cmd target
+  for cmd in bash mkdir rm cat tr grep sed awk printf id stat tee chmod dirname env date mktemp readlink ls cp mv touch wc head tail find sort uniq true false python3 git tmux jq sqlite3 sha256sum md5; do
+    target="$(command -v "$cmd" 2>/dev/null || true)"
+    # command -v on shell builtins returns the bare command name, not a
+    # path. Only symlink real filesystem targets — the builtin will still
+    # resolve inside the child shell because bash falls back to builtins
+    # when PATH lookup misses.
+    [[ -n "$target" && "${target:0:1}" == "/" ]] || continue
+    # Use -L so existing symlinks (even with absent targets) are detected;
+    # bare -e returns false for broken symlinks and we'd retry the ln.
+    [[ -L "$shim_dir/$cmd" || -e "$shim_dir/$cmd" ]] && continue
+    ln -s "$target" "$shim_dir/$cmd" 2>/dev/null || true
+  done
+}
+
+# Build a one-shot driver script. `printf` line-by-line into a tempfile
+# so we never cross the heredoc surface.
+write_driver_script() {
+  local out="$1"
+  shift
+  : >"$out"
+  local line
+  for line in "$@"; do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+# --- T5 first: standalone helper sanity check --------------------------------
+
+smoke_log "T5: bridge_isolation_v2_roster_has_isolated_agents standalone sanity"
+
+T5_HOME="$SMOKE_TMP_ROOT/t5"
+mkdir -p "$T5_HOME/state"
+
+T5_DRIVER="$SMOKE_TMP_ROOT/t5-driver.sh"
+write_driver_script "$T5_DRIVER" \
+  '#!/usr/bin/env bash' \
+  'set -uo pipefail' \
+  'cd "$REPO_ROOT"' \
+  'export BRIDGE_HOME="$T5_HOME"' \
+  'export BRIDGE_STATE_DIR="$T5_HOME/state"' \
+  'export BRIDGE_LOG_DIR="$T5_HOME/logs"' \
+  'export BRIDGE_SHARED_DIR="$T5_HOME/shared"' \
+  'export BRIDGE_DATA_ROOT="$T5_HOME/data"' \
+  'export BRIDGE_LAYOUT="v2"' \
+  'mkdir -p "$BRIDGE_LOG_DIR" "$BRIDGE_SHARED_DIR" "$BRIDGE_DATA_ROOT/shared" "$BRIDGE_DATA_ROOT/agents" "$BRIDGE_DATA_ROOT/state"' \
+  ': >"$T5_HOME/agent-roster.local.sh"' \
+  'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+  'declare -F bridge_isolation_v2_roster_has_isolated_agents >/dev/null 2>&1 || { echo "[t5] helper missing"; exit 1; }' \
+  'rc=0; bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null || rc=$?' \
+  'echo "empty=$rc"' \
+  'BRIDGE_AGENT_IDS=(test_shared)' \
+  'bridge_agent_linux_user_isolation_effective() { return 1; }' \
+  'rc=0; bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null || rc=$?' \
+  'echo "shared_only=$rc"' \
+  'BRIDGE_AGENT_IDS=(test_shared test_isolated)' \
+  'bridge_agent_linux_user_isolation_effective() { local a="${1:-}"; case "$a" in test_isolated) return 0;; *) return 1;; esac; }' \
+  'rc=0; bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null || rc=$?' \
+  'echo "mixed=$rc"'
+
+T5_OUT="$(REPO_ROOT="$REPO_ROOT" T5_HOME="$T5_HOME" "$BRIDGE_BASH" "$T5_DRIVER" 2>&1)" || true
+
+case "$T5_OUT" in
+  *"empty=1"*) ;;
+  *) smoke_fail "T5 expected empty=1 (no roster → non-zero), got: $T5_OUT" ;;
+esac
+case "$T5_OUT" in
+  *"shared_only=1"*) ;;
+  *) smoke_fail "T5 expected shared_only=1 (no isolated agents → non-zero), got: $T5_OUT" ;;
+esac
+case "$T5_OUT" in
+  *"mixed=0"*) ;;
+  *) smoke_fail "T5 expected mixed=0 (at least one isolated → zero), got: $T5_OUT" ;;
+esac
+smoke_log "T5 PASS: helper distinguishes empty / shared-only / mixed rosters"
+
+# --- shared fixture for T1..T4 -----------------------------------------------
+
+# Generate a JSON-extraction helper inline rather than depending on jq —
+# the apply_for_upgrade wrapper emits a single-line JSON object so a
+# grep is sufficient.
+assert_skipped() {
+  local label="$1"
+  local payload="$2"
+  case "$payload" in
+    *'"skipped":true'*) ;;
+    *) smoke_fail "$label expected payload to carry skipped=true, got: $payload" ;;
+  esac
+  case "$payload" in
+    *'"reason":"macos-shared-agent"'*) ;;
+    *) smoke_fail "$label expected reason=macos-shared-agent, got: $payload" ;;
+  esac
+  case "$payload" in
+    *'"mode":"isolation-v2-migrate"'*) ;;
+    *) smoke_fail "$label expected mode=isolation-v2-migrate, got: $payload" ;;
+  esac
+}
+
+assert_not_skipped_for_macos_branch() {
+  # The skip branch emits the specific `reason=macos-shared-agent` token.
+  # Anything else (success / privilege error / migration body output)
+  # must not carry that token — that is the regression we're protecting
+  # against in T3/T4.
+  local label="$1"
+  local payload="$2"
+  case "$payload" in
+    *'"reason":"macos-shared-agent"'*)
+      smoke_fail "$label: macos-shared-agent skip branch fired on a path that should NOT take it. payload=$payload" ;;
+  esac
+}
+
+# Build a Darwin-shim PATH with sudo recorder, then run a one-shot driver
+# that sources the bridge libs + calls the apply_for_upgrade wrapper.
+run_apply_for_upgrade() {
+  local fake_uname="$1"        # Darwin | Linux
+  local roster_kind="$2"       # empty | shared | isolated
+  local home_dir="$3"
+  local out_file="$4"
+
+  local shim_dir="$home_dir/shim-bin"
+  local sudo_log="$home_dir/sudo-calls.log"
+  : >"$sudo_log"
+  build_platform_shim "$shim_dir" "$fake_uname" "$sudo_log"
+  populate_basic_path "$shim_dir"
+
+  mkdir -p "$home_dir/state" "$home_dir/logs" "$home_dir/shared"
+
+  local roster_setup
+  case "$roster_kind" in
+    empty)
+      roster_setup='unset BRIDGE_AGENT_IDS 2>/dev/null || true'
+      ;;
+    shared)
+      # Roster has agents, but all return non-zero from
+      # bridge_agent_linux_user_isolation_effective. Force the predicate
+      # to return 1 unconditionally.
+      roster_setup='BRIDGE_AGENT_IDS=(a1 a2); bridge_agent_linux_user_isolation_effective() { return 1; }'
+      ;;
+    isolated)
+      # At least one agent returns 0 from the predicate.
+      roster_setup='BRIDGE_AGENT_IDS=(a1 a2); bridge_agent_linux_user_isolation_effective() { local a="${1:-}"; case "$a" in a2) return 0;; *) return 1;; esac; }'
+      ;;
+    *) smoke_fail "internal: unknown roster_kind=$roster_kind" ;;
+  esac
+
+  mkdir -p "$home_dir/data/shared" "$home_dir/data/agents" "$home_dir/data/state"
+  : >"$home_dir/agent-roster.local.sh"
+
+  local driver="$home_dir/driver.sh"
+  write_driver_script "$driver" \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'export BRIDGE_HOME="$HOME_DIR"' \
+    'export BRIDGE_STATE_DIR="$HOME_DIR/state"' \
+    'export BRIDGE_LOG_DIR="$HOME_DIR/logs"' \
+    'export BRIDGE_SHARED_DIR="$HOME_DIR/shared"' \
+    'export BRIDGE_DATA_ROOT="$HOME_DIR/data"' \
+    'export BRIDGE_LAYOUT="v2"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'source "$REPO_ROOT/lib/bridge-isolation-v2-migrate.sh" >/dev/null 2>&1' \
+    "$roster_setup" \
+    'bridge_isolation_v2_migrate_apply_for_upgrade --target-root "$HOME_DIR" --json 2>/dev/null || true'
+
+  # PATH = shim-dir only, so `uname` and `sudo` resolve to our shims.
+  PATH="$shim_dir" \
+    REPO_ROOT="$REPO_ROOT" \
+    HOME_DIR="$home_dir" \
+    BRIDGE_HOME="$home_dir" \
+    BRIDGE_STATE_DIR="$home_dir/state" \
+    BRIDGE_LOG_DIR="$home_dir/logs" \
+    BRIDGE_SHARED_DIR="$home_dir/shared" \
+    BRIDGE_DATA_ROOT="$home_dir/data" \
+    BRIDGE_LAYOUT="v2" \
+    "$BRIDGE_BASH" "$driver" >"$out_file" 2>&1 || true
+}
+
+# --- T1: Darwin + no isolated agents → skip branch + no sudo ----------------
+
+smoke_log "T1: Darwin + no isolated agents → skip branch (no sudo invocation)"
+
+T1_HOME="$SMOKE_TMP_ROOT/t1"
+mkdir -p "$T1_HOME"
+T1_OUT="$T1_HOME/out.txt"
+run_apply_for_upgrade Darwin shared "$T1_HOME" "$T1_OUT"
+T1_PAYLOAD="$(cat "$T1_OUT")"
+assert_skipped "T1" "$T1_PAYLOAD"
+
+if [[ -s "$T1_HOME/sudo-calls.log" ]]; then
+  smoke_fail "T1: sudo shim recorded calls — skip branch must NOT call sudo. log=$(cat "$T1_HOME/sudo-calls.log")"
+fi
+smoke_log "T1 PASS: skip JSON emitted + sudo never invoked"
+
+# --- T2: idempotent — second call same result --------------------------------
+
+smoke_log "T2: idempotent — repeated call produces the same skip JSON"
+
+T2_HOME="$SMOKE_TMP_ROOT/t2"
+mkdir -p "$T2_HOME"
+T2_OUT_A="$T2_HOME/out-a.txt"
+T2_OUT_B="$T2_HOME/out-b.txt"
+run_apply_for_upgrade Darwin shared "$T2_HOME" "$T2_OUT_A"
+run_apply_for_upgrade Darwin shared "$T2_HOME" "$T2_OUT_B"
+T2_A="$(cat "$T2_OUT_A")"
+T2_B="$(cat "$T2_OUT_B")"
+assert_skipped "T2-A" "$T2_A"
+assert_skipped "T2-B" "$T2_B"
+
+if [[ -s "$T2_HOME/sudo-calls.log" ]]; then
+  smoke_fail "T2: sudo shim recorded calls across idempotent runs. log=$(cat "$T2_HOME/sudo-calls.log")"
+fi
+smoke_log "T2 PASS: idempotent skip + no sudo across two calls"
+
+# --- T3: Linux + no isolated agents → NOT the skip branch -------------------
+
+smoke_log "T3: Linux + no isolated agents → must NOT take the macOS skip branch"
+
+T3_HOME="$SMOKE_TMP_ROOT/t3"
+mkdir -p "$T3_HOME"
+T3_OUT="$T3_HOME/out.txt"
+run_apply_for_upgrade Linux shared "$T3_HOME" "$T3_OUT"
+T3_PAYLOAD="$(cat "$T3_OUT")"
+assert_not_skipped_for_macos_branch "T3" "$T3_PAYLOAD"
+smoke_log "T3 PASS: Linux path bypasses the macOS skip branch"
+
+# --- T4: Darwin + at least one isolated agent → NOT the skip branch ---------
+
+smoke_log "T4: Darwin + at least one isolated agent → must NOT take the macOS skip branch"
+
+T4_HOME="$SMOKE_TMP_ROOT/t4"
+mkdir -p "$T4_HOME"
+T4_OUT="$T4_HOME/out.txt"
+run_apply_for_upgrade Darwin isolated "$T4_HOME" "$T4_OUT"
+T4_PAYLOAD="$(cat "$T4_OUT")"
+assert_not_skipped_for_macos_branch "T4" "$T4_PAYLOAD"
+smoke_log "T4 PASS: Darwin+isolated-present bypasses the skip branch"
+
+smoke_log "all 5 tests PASS"


### PR DESCRIPTION
## Symptom (operator report 2026-05-15 via task #4522)

v0.13.5 upgrade attempt from v0.7.6 source on macOS patch host:

- New upgrader call OK (`~/Projects/agent-bridge-public/agent-bridge upgrade --apply`)
- isolation-v2 migration step calls `bridge_isolation_v2_privilege_preflight` -> sudo prompt
- operator declines password -> migration aborts with `bridge_die`
- install left at `VERSION=0.7.6`, `no_v080_code_installed=yes` (i.e. the upgrade made zero progress)

The v0.13.4 changelog's "macOS shared-agent install — not directly affected" promise was only partially true:
the v3 channel-dotenv migrator already no-ops on macOS, but the underlying v2 layout migration (#857 baseline)
still tries to grab passwordless sudo on every host.

## Root cause

`bridge_isolation_v2_migrate_apply_for_upgrade` (`lib/bridge-isolation-v2-migrate.sh:1712`) was platform-agnostic:

1. Markerless input (any v0.7.x install on first v0.8+ upgrade) takes the "no marker present, must migrate" branch.
2. The branch calls `bridge_isolation_v2_privilege_preflight` (`lib/bridge-isolation-v2.sh:1061`).
3. The preflight demands `sudo -n` (passwordless) and the macOS user prompt rejects the requirement.
4. `bridge_die` fires, abort.

But on a single-OS-user host with no isolated agents (the macOS dev pattern):

- isolation-v2's group + setgid + named-UID layout has no operational effect — every agent shares the controller's UID.
- The chgrp/chmod work the preflight is gating is itself a no-op.
- So the abort is gating sudo on work that wouldn't do anything anyway.

## Fix

Insert an early guard in `bridge_isolation_v2_migrate_apply_for_upgrade` right after argument validation:

```bash
if [[ "$(uname -s 2>/dev/null || printf 'unknown')" != "Linux" ]] \
    && ! bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null; then
  printf '{"mode":"isolation-v2-migrate","status":"ok","skipped":true,"reason":"macos-shared-agent",...}\n' ...
  return 0
fi
```

Both conditions must hold:

- `uname -s != Linux` — never affects Linux hosts, even when their roster is shared-only (Linux still has the option to add isolated agents later, and the layout primitives there are non-trivial).
- `bridge_isolation_v2_roster_has_isolated_agents` returns non-zero — no roster agent has `bridge_agent_linux_user_isolation_effective() == 0`. The predicate already returns 1 on non-Linux platforms (it gates on `bridge_host_platform == Linux`), so this is belt-and-suspenders but explicit about intent.

The new helper is fail-safe: if `bridge_agent_linux_user_isolation_effective` isn't declared or `BRIDGE_AGENT_IDS` is unset, it returns 1 (caller interprets that as "can't confirm any isolated agents"). With the `uname` gate, that means a missing-roster macOS host takes the skip branch (correct: no isolated agents possible) and a missing-roster Linux host falls through to the existing migration path (correct: existing behavior).

## What changed

- `lib/bridge-isolation-v2.sh` (+27) — new helper `bridge_isolation_v2_roster_has_isolated_agents`.
- `lib/bridge-isolation-v2-migrate.sh` (+21) — macOS-skip guard at the start of `bridge_isolation_v2_migrate_apply_for_upgrade`. Marker handling, privilege preflight, and migration body are strictly unchanged.
- `scripts/smoke/isolation-v2-migrate-macos-skip.sh` (+347) — new regression smoke. PATH-shim mocks `uname` (reports requested platform) and `sudo` (records every call to a log file; the skip branch must NOT invoke it).
- `scripts/ci-select-smoke.sh` (+2/-2) — wires the new smoke onto both the always-required list and the `lib/bridge-isolation*.sh` trigger row.

## Coverage

`scripts/smoke/isolation-v2-migrate-macos-skip.sh` — five cases:

| # | Platform | Roster | Expected | Sudo invocation |
|---|---|---|---|---|
| T1 | Darwin | no isolated agents | `skipped=true reason=macos-shared-agent` | never |
| T2 | Darwin | no isolated agents | same JSON on second call (idempotent) | never |
| T3 | Linux | no isolated agents | does NOT take the skip branch | (don't care — existing path) |
| T4 | Darwin | at least one isolated agent | does NOT take the skip branch | (don't care) |
| T5 | n/a | helper standalone | discriminates empty / shared-only / mixed rosters | n/a |

All five PASS on the macOS dev host (`uname -s=Darwin`, brew Bash 5.3.9). The sibling smokes `isolation-v2-migrate-lock-portability`, `857-pr1-isolation-write-helper`, and `864-upgrade-perm-regressions` still PASS (sanity for the same library zone).

## Verification

```text
bash -n lib/bridge-isolation-v2.sh lib/bridge-isolation-v2-migrate.sh \
        scripts/smoke/isolation-v2-migrate-macos-skip.sh scripts/ci-select-smoke.sh
shellcheck lib/bridge-isolation-v2.sh lib/bridge-isolation-v2-migrate.sh \
           scripts/smoke/isolation-v2-migrate-macos-skip.sh scripts/ci-select-smoke.sh
bash scripts/smoke/isolation-v2-migrate-macos-skip.sh   # all 5 PASS
```

`./scripts/smoke-test.sh` fails identically before and after this PR on the macOS dev host at the
`bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor (#428 r2)` assertion. That failure is
unrelated to the layout-migration surface this PR touches (verified with a clean `git stash -u` round-trip).

## Out of scope

- isolation-v2 marker policy changes (markerless detection logic is untouched).
- Linux isolated-agent migration logic (Linux + isolated path is strictly unchanged).
- `privilege_preflight` itself (still demands root/sudo on Linux).
- `bridge-upgrade.sh` wrapper (already calls the upgrade-apply function via child shell — no edit needed).
- macOS isolation in the future (would be a separate design).
- VERSION / CHANGELOG bumps (release PR follows separately).

## Refs

Operator report 2026-05-15 via task #4522 (patch host upgrade abort).