### PR TITLE
fix(daemon): periodic claude token sync tick (every N seconds, default 3600)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1193,6 +1193,114 @@ process_usage_monitor() {
   (( alert_count > 0 || rotation_count > 0 ))
 }
 
+# --- Periodic claude-token sync (v0.13.6 hotfix) -----------------------------
+# Issue context: process_claude_token_recovery above only calls
+# `bridge-auth.sh claude-token sync` when `sync_recommended=1` — i.e. when the
+# recover-due pass actually rotated or re-enabled a token. Cron-only static
+# agents (no live Claude Code session, no rotation event) consequently inherit
+# whatever token the controller had on the day they were created and never see
+# a refresh. Operator-observed symptom (2026-05-15 patch host on Linux): three
+# static cron agents (dev_mun / sales_choi / mgt_ahn) carrying a 5/12 token
+# while patch's own Claude Code refreshed to 5/15; mgt_ahn hit 429 because the
+# stale token was still pinned to the original credential.
+#
+# Fix: a low-frequency, idempotent sync tick that pushes the controller's
+# active claude token to every in-scope static agent every N seconds
+# (default 3600s = 1 hour) regardless of rotation/recovery events. The sync
+# itself is the same `bridge-auth.sh claude-token sync` that today's recovery
+# branch already invokes — we are not introducing a new sync mechanism, just
+# guaranteeing the existing one runs on a wall-clock cadence.
+#
+# Env contract:
+#   - BRIDGE_CLAUDE_TOKEN_SYNC_INTERVAL_SECONDS — sync cadence (default 3600).
+#     Set to 0 to disable the periodic tick entirely.
+#   - BRIDGE_CLAUDE_TOKEN_SYNC_AGENTS — agent scope (default "static"); same
+#     semantic as the recovery branch.
+#
+# Audit row: `claude_token_periodic_sync` with status / agent_scope /
+# interval_seconds / trigger=periodic so the operator can see the cadence
+# alongside the existing rotation / recovery rows when reading audit.jsonl.
+bridge_daemon_periodic_token_sync_state_file() {
+  printf '%s/daemon/last-token-sync' "$BRIDGE_STATE_DIR"
+}
+
+bridge_daemon_periodic_token_sync_due() {
+  local interval="${BRIDGE_CLAUDE_TOKEN_SYNC_INTERVAL_SECONDS:-3600}"
+  local file=""
+  local last_ts=0
+  local now=0
+  local elapsed=0
+
+  [[ "$interval" =~ ^[0-9]+$ ]] || interval=3600
+  # Interval 0 == disabled. Treat as never-due so the tick is a no-op.
+  (( interval > 0 )) || return 1
+  file="$(bridge_daemon_periodic_token_sync_state_file)"
+  # First-call case: no state file yet — fire immediately so a freshly-started
+  # daemon does not wait a full interval before first sync.
+  [[ -f "$file" ]] || return 0
+  last_ts="$(cat "$file" 2>/dev/null | tr -dc '0-9' || printf '0')"
+  [[ -n "$last_ts" ]] || last_ts=0
+  now="$(date +%s)"
+  elapsed=$(( now - last_ts ))
+  (( elapsed >= interval ))
+}
+
+bridge_daemon_periodic_token_sync_tick() {
+  local target="${BRIDGE_ADMIN_AGENT_ID:-daemon}"
+  local interval="${BRIDGE_CLAUDE_TOKEN_SYNC_INTERVAL_SECONDS:-3600}"
+  local agent_scope="${BRIDGE_CLAUDE_TOKEN_SYNC_AGENTS:-static}"
+  local file=""
+  local now=0
+  local sync_json=""
+  local sync_status=""
+
+  [[ "${BRIDGE_CLAUDE_TOKEN_PERIODIC_SYNC_ENABLED:-1}" == "1" ]] || return 1
+  [[ "$interval" =~ ^[0-9]+$ ]] || interval=3600
+  (( interval > 0 )) || return 1
+  bridge_daemon_periodic_token_sync_due || return 1
+
+  file="$(bridge_daemon_periodic_token_sync_state_file)"
+  now="$(date +%s)"
+
+  if sync_json="$("$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-auth.sh" claude-token sync \
+      --agents "$agent_scope" --json 2>/dev/null)"; then
+    # 5s ceiling — pure JSON parse + dict lookup; rc=124|137 leaves
+    # sync_status empty and the surrounding audit_log captures sync_status=""
+    # so the operator sees the gap alongside the daemon_subprocess_timeout
+    # row. Mirrors the parse pattern in process_claude_token_recovery.
+    sync_status="$(bridge_with_timeout 5 sync_status_parse python3 \
+      "$SCRIPT_DIR/bridge-daemon-helpers.py" sync-status-parse "$sync_json" \
+      2>/dev/null || printf '')"
+    mkdir -p "$(dirname "$file")" 2>/dev/null || true
+    # Always record the attempt timestamp so a persistent sync failure does
+    # not retrigger every poll tick. The audit row below carries the failure
+    # signal; operator inspects audit.jsonl for the actual status.
+    printf '%s\n' "$now" >"$file" 2>/dev/null || true
+    bridge_audit_log daemon claude_token_periodic_sync "$target" \
+      --detail status="${sync_status:-unknown}" \
+      --detail trigger=periodic \
+      --detail agent_scope="$agent_scope" \
+      --detail interval_seconds="$interval" \
+      2>/dev/null || true
+    daemon_info "claude token periodic sync: status=${sync_status:-unknown} agents=$agent_scope interval=${interval}s"
+    return 0
+  fi
+
+  # bridge-auth.sh sync failed outright (non-zero rc, no JSON). Still record
+  # the attempt to avoid hot-looping the failure, but tag it so the operator
+  # can correlate with the launchagent log.
+  mkdir -p "$(dirname "$file")" 2>/dev/null || true
+  printf '%s\n' "$now" >"$file" 2>/dev/null || true
+  bridge_audit_log daemon claude_token_periodic_sync "$target" \
+    --detail status=failed \
+    --detail trigger=periodic \
+    --detail agent_scope="$agent_scope" \
+    --detail interval_seconds="$interval" \
+    2>/dev/null || true
+  daemon_warn "claude token periodic sync failed (bridge-auth.sh exited non-zero; see audit log)"
+  return 1
+}
+
 process_claude_token_recovery() {
   local target="${BRIDGE_ADMIN_AGENT_ID:-daemon}"
   local recovery_json=""
@@ -5709,6 +5817,14 @@ cmd_sync_cycle() {
   fi
   BRIDGE_DAEMON_LAST_STEP="claude_token_recovery"
   if process_claude_token_recovery; then
+    changed=0
+  fi
+  # v0.13.6 hotfix — refs operator report 2026-05-15 patch host.
+  # Cron-only static agents never trigger the rotation/recovery branch above
+  # and so go stale (mgt_ahn hit 429 after 3 days on a 5/12 token). The
+  # periodic tick guarantees a wall-clock sync regardless of rotation events.
+  BRIDGE_DAEMON_LAST_STEP="claude_token_periodic_sync"
+  if bridge_daemon_periodic_token_sync_tick; then
     changed=0
   fi
   BRIDGE_DAEMON_LAST_STEP="usage_monitor"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link
 }
 
 add_all_integration() {
@@ -215,7 +215,13 @@ select_for_path() {
       # per-process memoization. Triggered on bridge-sync.sh and on
       # lib/bridge-state.sh (which hosts bridge_roster_cache_invalidate
       # / bridge_load_roster).
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo
+      #
+      # v0.13.6 hotfix (refs operator report 2026-05-15 patch host):
+      # bridge-daemon.sh exposes a new periodic claude-token sync tick so
+      # cron-only static agents do not go stale between rotation events.
+      # daemon-periodic-token-sync covers the due-check / tick / audit /
+      # state-file cadence contract.
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke/daemon-periodic-token-sync.sh
+++ b/scripts/smoke/daemon-periodic-token-sync.sh
@@ -39,10 +39,12 @@
 #       rc=1. The status-failed branch is the operator's visibility into
 #       persistent sync breakage.
 #
-# Footgun #11 mitigation: every helper body in this smoke is written to a
-# tempfile (`cat > "$path" <<'EOF' ... EOF`) and invoked via `bash <path>`
-# rather than passed through `bash -s <<<` here-strings or `python3 - <<'PY'`
-# heredoc-stdin. This mirrors the post-#800 / post-PR #801 convention.
+# Footgun #11 mitigation: every helper body in this smoke lives in a
+# committed fixture file under scripts/smoke/fixtures/<smoke-name>/ and is
+# copied into the temp root via `cp` rather than written through
+# `cat > "$path" <<'EOF' ... EOF` heredocs or `bash -s <<<` here-strings.
+# This mirrors the post-#800 / post-PR #801 / post-PR #883 r1 convention
+# (codex review caught new heredocs at lines 111, 124, 144).
 
 # Bash 4+ re-exec (mirrors scripts/smoke/daemon.sh).
 _SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
@@ -105,29 +107,20 @@ done
 SHIM_DIR="$SMOKE_TMP_ROOT/shim"
 mkdir -p "$SHIM_DIR"
 
+# Fixture root: each helper body lives in its own committed file. We copy
+# rather than heredoc-write to comply with footgun #11.
+FIXTURE_DIR="$SMOKE_REPO_ROOT/scripts/smoke/fixtures/daemon-periodic-token-sync"
+[[ -d "$FIXTURE_DIR" ]] || smoke_fail "fixture dir not found: $FIXTURE_DIR"
+
 # bridge-auth.sh shim: by default prints a valid `claude-token sync --json`
 # envelope and exits 0. The A4 case rewrites this to exit non-zero.
 make_auth_shim_success() {
-  cat >"$SHIM_DIR/bridge-auth.sh" <<'EOF'
-#!/usr/bin/env bash
-# Test shim for bridge-auth.sh — emits a minimal `claude-token sync --json`
-# envelope so the daemon helper's sync-status-parse subcommand returns "ok".
-set -euo pipefail
-# Drain argv; we only honor `claude-token sync --json` shape but do not
-# enforce it here — the daemon callsite passes a fixed shape.
-printf '{"status": "ok", "synced_agents": ["test-agent"]}\n'
-EOF
+  cp "$FIXTURE_DIR/bridge-auth-shim-success.sh" "$SHIM_DIR/bridge-auth.sh"
   chmod +x "$SHIM_DIR/bridge-auth.sh"
 }
 
 make_auth_shim_failure() {
-  cat >"$SHIM_DIR/bridge-auth.sh" <<'EOF'
-#!/usr/bin/env bash
-# Test shim for bridge-auth.sh — simulates the bridge-auth.sh sync command
-# failing (e.g. controller token missing). Exit non-zero so the tick takes
-# the status=failed branch.
-exit 7
-EOF
+  cp "$FIXTURE_DIR/bridge-auth-shim-failure.sh" "$SHIM_DIR/bridge-auth.sh"
   chmod +x "$SHIM_DIR/bridge-auth.sh"
 }
 
@@ -140,81 +133,10 @@ ln -sf "$SMOKE_REPO_ROOT/bridge-daemon-helpers.py" "$SHIM_DIR/bridge-daemon-help
 # Driver runs in a subshell with stubs for daemon_info / daemon_warn /
 # bridge_audit_log / bridge_with_timeout, points SCRIPT_DIR at the shim,
 # sources the extracted function bodies, and invokes the requested action.
+# Body lives in scripts/smoke/fixtures/daemon-periodic-token-sync/driver.sh
+# (committed) and is copied in to comply with footgun #11.
 DRIVER="$SMOKE_TMP_ROOT/driver.sh"
-cat >"$DRIVER" <<'EOF'
-#!/usr/bin/env bash
-# args: <action: due|tick> [extra args ignored]
-set -uo pipefail
-
-# Required env (caller sets all):
-#   SHIM_DIR, BRIDGE_STATE_DIR, FUNCS_SH, AUDIT_FILE
-: "${SHIM_DIR:?}"
-: "${BRIDGE_STATE_DIR:?}"
-: "${FUNCS_SH:?}"
-: "${AUDIT_FILE:?}"
-
-# Daemon function bodies reference "$SCRIPT_DIR/bridge-auth.sh" and
-# "$SCRIPT_DIR/bridge-daemon-helpers.py" — point that at our shim dir.
-SCRIPT_DIR="$SHIM_DIR"
-BRIDGE_BASH_BIN="${BASH:-bash}"
-export BRIDGE_STATE_DIR
-
-# Stubs for daemon-side helpers the function body calls. We capture every
-# bridge_audit_log call as one line per row in $AUDIT_FILE so the smoke
-# can grep the action + status fields after the call.
-daemon_info()  { printf '[info] %s\n' "$*" >&2; }
-daemon_warn()  { printf '[warn] %s\n' "$*" >&2; }
-bridge_audit_log() {
-  # signature: <actor> <action> <target> [--detail k=v ...]
-  local actor="$1" action="$2" target="$3"; shift 3 || true
-  local row="action=$action actor=$actor target=$target"
-  while (( $# )); do
-    if [[ "$1" == "--detail" ]]; then
-      shift
-      row+=" $1"
-    fi
-    shift || true
-  done
-  printf '%s\n' "$row" >>"$AUDIT_FILE"
-}
-# bridge_with_timeout — pass-through (no real timeout binary needed; the
-# shim helper returns instantly). Mirrors the test-double in
-# tests/codex-composer/smoke.sh.
-bridge_with_timeout() {
-  # <secs> <label> <cmd> [args...]
-  shift 2 || true
-  "$@"
-}
-
-# Source the extracted function bodies.
-# shellcheck source=/dev/null
-source "$FUNCS_SH"
-
-action="${1:-}"
-case "$action" in
-  due)
-    if bridge_daemon_periodic_token_sync_due; then
-      echo "DUE"
-    else
-      echo "NOT-DUE"
-    fi
-    ;;
-  tick)
-    if bridge_daemon_periodic_token_sync_tick; then
-      echo "TICK-OK"
-    else
-      echo "TICK-FAIL"
-    fi
-    ;;
-  state-file)
-    echo "$(bridge_daemon_periodic_token_sync_state_file)"
-    ;;
-  *)
-    echo "unknown action: $action" >&2
-    exit 2
-    ;;
-esac
-EOF
+cp "$FIXTURE_DIR/driver.sh" "$DRIVER"
 chmod +x "$DRIVER"
 
 AUDIT_FILE="$SMOKE_TMP_ROOT/audit.log"

--- a/scripts/smoke/daemon-periodic-token-sync.sh
+++ b/scripts/smoke/daemon-periodic-token-sync.sh
@@ -18,7 +18,7 @@
 # rotation / recovery event, writes a `claude_token_periodic_sync` audit
 # row, and updates the last-sync timestamp.
 #
-# This smoke exercises four cases (A1-A4) directly against the two
+# This smoke exercises five cases (A1-A5) directly against the two
 # extracted functions, using a shim `bridge-auth.sh` so we never touch the
 # real sync path. We intentionally do not boot the daemon — those cases
 # are covered by the live-tmux-daemon smoke. The unit-level coverage

--- a/scripts/smoke/daemon-periodic-token-sync.sh
+++ b/scripts/smoke/daemon-periodic-token-sync.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+#
+# scripts/smoke/daemon-periodic-token-sync.sh — v0.13.6 hotfix regression.
+#
+# Operator-observed context (2026-05-15 patch host on Linux): three static
+# cron-only Claude agents (dev_mun / sales_choi / mgt_ahn) carried a 5/12
+# claude-token while the controller (patch) refreshed to 5/15 via its own
+# Claude Code refresh. mgt_ahn hit a 429 because the stale token was still
+# pinned. Daemon log showed zero rotation / sync / usage events between
+# 5/12 and 5/15 — process_claude_token_recovery's sync branch only fires
+# when `sync_recommended=1`, which never happens for cron-only agents.
+#
+# Fix (v0.13.6): bridge-daemon.sh now exposes
+# `bridge_daemon_periodic_token_sync_due` + `bridge_daemon_periodic_token_sync_tick`
+# wired into the main poll loop. Every N seconds (env override
+# BRIDGE_CLAUDE_TOKEN_SYNC_INTERVAL_SECONDS, default 3600) the tick calls
+# `bridge-auth.sh claude-token sync --agents <scope>` regardless of any
+# rotation / recovery event, writes a `claude_token_periodic_sync` audit
+# row, and updates the last-sync timestamp.
+#
+# This smoke exercises four cases (A1-A4) directly against the two
+# extracted functions, using a shim `bridge-auth.sh` so we never touch the
+# real sync path. We intentionally do not boot the daemon — those cases
+# are covered by the live-tmux-daemon smoke. The unit-level coverage
+# proves the cadence + audit + state-file contract.
+#
+# Cases:
+#   A1. First call after fresh BRIDGE_STATE_DIR — `_due` returns 0 (no
+#       state file yet), `_tick` fires, writes last-sync, emits audit row,
+#       and exits rc=0.
+#   A2. Immediate second call — `_due` returns 1 (elapsed=0 < interval),
+#       `_tick` no-ops, audit row count unchanged, last-sync timestamp
+#       unchanged.
+#   A3. Backdate last-sync to (now - interval - margin) — `_due` returns 0
+#       again, `_tick` fires a second time, audit row count increments,
+#       last-sync timestamp is refreshed.
+#   A4. Shim bridge-auth.sh returns non-zero — `_tick` records the attempt
+#       (so we do not hot-loop), writes a status=failed audit row, returns
+#       rc=1. The status-failed branch is the operator's visibility into
+#       persistent sync breakage.
+#
+# Footgun #11 mitigation: every helper body in this smoke is written to a
+# tempfile (`cat > "$path" <<'EOF' ... EOF`) and invoked via `bash <path>`
+# rather than passed through `bash -s <<<` here-strings or `python3 - <<'PY'`
+# heredoc-stdin. This mirrors the post-#800 / post-PR #801 convention.
+
+# Bash 4+ re-exec (mirrors scripts/smoke/daemon.sh).
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:daemon-periodic-token-sync] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="daemon-periodic-token-sync"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+smoke_require_cmd awk
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+DAEMON_SRC="$SMOKE_REPO_ROOT/bridge-daemon.sh"
+[[ -f "$DAEMON_SRC" ]] || smoke_fail "bridge-daemon.sh not found at $DAEMON_SRC"
+
+# Extract the two functions under test. The state-file helper is also
+# pulled because _due and _tick both call it.
+FUNCS_SH="$SMOKE_TMP_ROOT/periodic-sync-functions.sh"
+{
+  awk '/^bridge_daemon_periodic_token_sync_state_file\(\) \{/,/^}/' "$DAEMON_SRC"
+  printf '\n'
+  awk '/^bridge_daemon_periodic_token_sync_due\(\) \{/,/^}/' "$DAEMON_SRC"
+  printf '\n'
+  awk '/^bridge_daemon_periodic_token_sync_tick\(\) \{/,/^}/' "$DAEMON_SRC"
+} >"$FUNCS_SH"
+
+# Sanity-check the extraction so a future refactor that renames the
+# functions surfaces here rather than in a confusing downstream failure.
+for fn in bridge_daemon_periodic_token_sync_state_file \
+          bridge_daemon_periodic_token_sync_due \
+          bridge_daemon_periodic_token_sync_tick; do
+  if ! grep -q "^${fn}() {" "$FUNCS_SH"; then
+    smoke_fail "could not extract function: $fn (check bridge-daemon.sh for rename)"
+  fi
+done
+
+# Shim directory for bridge-auth.sh + the daemon-helpers script. We put
+# the shim path in $SCRIPT_DIR so the function body finds the right
+# bridge-auth.sh / bridge-daemon-helpers.py via "$SCRIPT_DIR/...".
+SHIM_DIR="$SMOKE_TMP_ROOT/shim"
+mkdir -p "$SHIM_DIR"
+
+# bridge-auth.sh shim: by default prints a valid `claude-token sync --json`
+# envelope and exits 0. The A4 case rewrites this to exit non-zero.
+make_auth_shim_success() {
+  cat >"$SHIM_DIR/bridge-auth.sh" <<'EOF'
+#!/usr/bin/env bash
+# Test shim for bridge-auth.sh — emits a minimal `claude-token sync --json`
+# envelope so the daemon helper's sync-status-parse subcommand returns "ok".
+set -euo pipefail
+# Drain argv; we only honor `claude-token sync --json` shape but do not
+# enforce it here — the daemon callsite passes a fixed shape.
+printf '{"status": "ok", "synced_agents": ["test-agent"]}\n'
+EOF
+  chmod +x "$SHIM_DIR/bridge-auth.sh"
+}
+
+make_auth_shim_failure() {
+  cat >"$SHIM_DIR/bridge-auth.sh" <<'EOF'
+#!/usr/bin/env bash
+# Test shim for bridge-auth.sh — simulates the bridge-auth.sh sync command
+# failing (e.g. controller token missing). Exit non-zero so the tick takes
+# the status=failed branch.
+exit 7
+EOF
+  chmod +x "$SHIM_DIR/bridge-auth.sh"
+}
+
+# bridge-daemon-helpers.py shim: re-uses the real helper. We only need to
+# expose `sync-status-parse`, which the real helper provides. We symlink
+# rather than re-implement so any future schema change in the real helper
+# automatically applies to this smoke.
+ln -sf "$SMOKE_REPO_ROOT/bridge-daemon-helpers.py" "$SHIM_DIR/bridge-daemon-helpers.py"
+
+# Driver runs in a subshell with stubs for daemon_info / daemon_warn /
+# bridge_audit_log / bridge_with_timeout, points SCRIPT_DIR at the shim,
+# sources the extracted function bodies, and invokes the requested action.
+DRIVER="$SMOKE_TMP_ROOT/driver.sh"
+cat >"$DRIVER" <<'EOF'
+#!/usr/bin/env bash
+# args: <action: due|tick> [extra args ignored]
+set -uo pipefail
+
+# Required env (caller sets all):
+#   SHIM_DIR, BRIDGE_STATE_DIR, FUNCS_SH, AUDIT_FILE
+: "${SHIM_DIR:?}"
+: "${BRIDGE_STATE_DIR:?}"
+: "${FUNCS_SH:?}"
+: "${AUDIT_FILE:?}"
+
+# Daemon function bodies reference "$SCRIPT_DIR/bridge-auth.sh" and
+# "$SCRIPT_DIR/bridge-daemon-helpers.py" — point that at our shim dir.
+SCRIPT_DIR="$SHIM_DIR"
+BRIDGE_BASH_BIN="${BASH:-bash}"
+export BRIDGE_STATE_DIR
+
+# Stubs for daemon-side helpers the function body calls. We capture every
+# bridge_audit_log call as one line per row in $AUDIT_FILE so the smoke
+# can grep the action + status fields after the call.
+daemon_info()  { printf '[info] %s\n' "$*" >&2; }
+daemon_warn()  { printf '[warn] %s\n' "$*" >&2; }
+bridge_audit_log() {
+  # signature: <actor> <action> <target> [--detail k=v ...]
+  local actor="$1" action="$2" target="$3"; shift 3 || true
+  local row="action=$action actor=$actor target=$target"
+  while (( $# )); do
+    if [[ "$1" == "--detail" ]]; then
+      shift
+      row+=" $1"
+    fi
+    shift || true
+  done
+  printf '%s\n' "$row" >>"$AUDIT_FILE"
+}
+# bridge_with_timeout — pass-through (no real timeout binary needed; the
+# shim helper returns instantly). Mirrors the test-double in
+# tests/codex-composer/smoke.sh.
+bridge_with_timeout() {
+  # <secs> <label> <cmd> [args...]
+  shift 2 || true
+  "$@"
+}
+
+# Source the extracted function bodies.
+# shellcheck source=/dev/null
+source "$FUNCS_SH"
+
+action="${1:-}"
+case "$action" in
+  due)
+    if bridge_daemon_periodic_token_sync_due; then
+      echo "DUE"
+    else
+      echo "NOT-DUE"
+    fi
+    ;;
+  tick)
+    if bridge_daemon_periodic_token_sync_tick; then
+      echo "TICK-OK"
+    else
+      echo "TICK-FAIL"
+    fi
+    ;;
+  state-file)
+    echo "$(bridge_daemon_periodic_token_sync_state_file)"
+    ;;
+  *)
+    echo "unknown action: $action" >&2
+    exit 2
+    ;;
+esac
+EOF
+chmod +x "$DRIVER"
+
+AUDIT_FILE="$SMOKE_TMP_ROOT/audit.log"
+: >"$AUDIT_FILE"
+
+run_driver() {
+  # Returns the driver's stdout marker on its own line. The driver exit
+  # code is intentionally ignored — the markers (DUE/NOT-DUE, TICK-OK/
+  # TICK-FAIL) are the authoritative outcome signal because the driver's
+  # final `echo` always exits 0. We use `tail -n 1` to discard stub-side
+  # info/warn output that some bash builds emit on stdout when redirected.
+  local action="$1"
+  local interval="${2:-3600}"
+  env \
+      SHIM_DIR="$SHIM_DIR" \
+      BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+      FUNCS_SH="$FUNCS_SH" \
+      AUDIT_FILE="$AUDIT_FILE" \
+      BRIDGE_CLAUDE_TOKEN_SYNC_INTERVAL_SECONDS="$interval" \
+      BRIDGE_CLAUDE_TOKEN_SYNC_AGENTS="static" \
+      bash "$DRIVER" "$action" 2>/dev/null | tail -n 1
+}
+
+# Exact-marker assertion helper. `smoke_assert_contains "$out" "DUE"` would
+# match "NOT-DUE", so we equality-check the trimmed marker instead.
+assert_marker() {
+  local marker="$1"
+  local expected="$2"
+  local ctx="$3"
+  smoke_assert_eq "$expected" "$marker" "$ctx"
+}
+
+# Resolve the state file path from the production function so the smoke
+# stays decoupled from a future state-file-path refactor.
+STATE_FILE="$(run_driver state-file)"
+[[ -n "$STATE_FILE" ]] || smoke_fail "could not resolve state file path from driver"
+
+# Ensure clean slate.
+rm -f "$STATE_FILE"
+
+audit_row_count() {
+  grep -c '^action=claude_token_periodic_sync ' "$AUDIT_FILE" 2>/dev/null || true
+}
+
+audit_last_row() {
+  grep '^action=claude_token_periodic_sync ' "$AUDIT_FILE" 2>/dev/null | tail -n 1
+}
+
+# Case A1 — first call from fresh state: due and tick fire, audit + state file.
+step_a1_first_call_fires() {
+  smoke_log "A1: first call from fresh BRIDGE_STATE_DIR — due + tick + audit"
+  make_auth_shim_success
+  rm -f "$STATE_FILE"
+  : >"$AUDIT_FILE"
+
+  assert_marker "$(run_driver due 3600)" "DUE" "A1 due-check (no state file → must be due)"
+  assert_marker "$(run_driver tick 3600)" "TICK-OK" "A1 tick"
+
+  [[ -f "$STATE_FILE" ]] || smoke_fail "A1: state file should be written after tick: $STATE_FILE"
+  local count
+  count="$(audit_row_count)"
+  smoke_assert_eq "1" "$count" "A1: exactly one audit row after first tick"
+  local row
+  row="$(audit_last_row)"
+  smoke_assert_contains "$row" "status=ok" "A1: audit row reflects success"
+  smoke_assert_contains "$row" "trigger=periodic" "A1: audit row tags trigger"
+  smoke_assert_contains "$row" "agent_scope=static" "A1: audit row tags scope"
+  smoke_assert_contains "$row" "interval_seconds=3600" "A1: audit row tags interval"
+}
+
+# Case A2 — immediate second call: not due, tick no-ops.
+step_a2_immediate_second_call_skips() {
+  smoke_log "A2: immediate second call — not-due, tick is a no-op"
+  local before_ts before_count
+  before_ts="$(cat "$STATE_FILE" 2>/dev/null || printf '0')"
+  before_count="$(audit_row_count)"
+  [[ -n "$before_ts" && "$before_ts" -gt 0 ]] || smoke_fail "A2 precondition: state file should carry a ts > 0"
+
+  assert_marker "$(run_driver due 3600)" "NOT-DUE" "A2 due-check (elapsed << interval)"
+  assert_marker "$(run_driver tick 3600)" "TICK-FAIL" "A2 tick (not-due → no-op)"
+
+  local after_ts after_count
+  after_ts="$(cat "$STATE_FILE" 2>/dev/null || printf '0')"
+  after_count="$(audit_row_count)"
+  smoke_assert_eq "$before_ts" "$after_ts" "A2: state file timestamp must NOT advance when not-due"
+  smoke_assert_eq "$before_count" "$after_count" "A2: no new audit row when not-due"
+}
+
+# Case A3 — backdate last-sync past interval: due fires again, tick refreshes.
+step_a3_overdue_fires_again() {
+  smoke_log "A3: backdate last-sync past interval — due + tick + audit row count increments"
+  local before_count
+  before_count="$(audit_row_count)"
+  local backdated
+  backdated="$(( $(date +%s) - 10000 ))"   # well past default 3600s
+  printf '%s\n' "$backdated" >"$STATE_FILE"
+
+  assert_marker "$(run_driver due 3600)" "DUE" "A3 due-check (elapsed > interval)"
+  assert_marker "$(run_driver tick 3600)" "TICK-OK" "A3 tick (overdue → fires)"
+
+  local after_count after_ts
+  after_count="$(audit_row_count)"
+  after_ts="$(cat "$STATE_FILE" 2>/dev/null || printf '0')"
+  (( after_count == before_count + 1 )) || smoke_fail "A3: audit row count should increment by exactly 1 (before=$before_count after=$after_count)"
+  (( after_ts > backdated )) || smoke_fail "A3: state file timestamp should refresh past backdated value (backdated=$backdated after=$after_ts)"
+}
+
+# Case A4 — bridge-auth.sh failure: status=failed audit row, rc=1, state still updated.
+step_a4_sync_failure_records_status_failed() {
+  smoke_log "A4: bridge-auth.sh failure — status=failed audit row, no hot-loop"
+  make_auth_shim_failure
+  # Make it due again.
+  local backdated
+  backdated="$(( $(date +%s) - 10000 ))"
+  printf '%s\n' "$backdated" >"$STATE_FILE"
+
+  local before_count after_count
+  before_count="$(audit_row_count)"
+
+  assert_marker "$(run_driver tick 3600)" "TICK-FAIL" "A4 tick (sync failure → rc=1)"
+
+  after_count="$(audit_row_count)"
+  (( after_count == before_count + 1 )) || smoke_fail "A4: audit row count should increment by exactly 1 (before=$before_count after=$after_count)"
+  local row
+  row="$(audit_last_row)"
+  smoke_assert_contains "$row" "status=failed" "A4: audit row tags failure"
+  smoke_assert_contains "$row" "trigger=periodic" "A4: audit row tags trigger"
+
+  # state-file is refreshed even on failure so a persistent breakage does
+  # not hot-loop the daemon. The next due-check should return NOT-DUE.
+  local after_ts
+  after_ts="$(cat "$STATE_FILE" 2>/dev/null || printf '0')"
+  (( after_ts > backdated )) || smoke_fail "A4: state file timestamp should refresh even on failure (backdated=$backdated after=$after_ts)"
+
+  assert_marker "$(run_driver due 3600)" "NOT-DUE" "A4 follow-up due-check (next tick deferred, not hot-looped)"
+
+  # Restore success shim for any subsequent assertions / future steps.
+  make_auth_shim_success
+}
+
+# Case A5 — interval=0 disables the tick entirely.
+step_a5_interval_zero_disables() {
+  smoke_log "A5: interval=0 disables the periodic tick"
+  # Even a missing state file does not flip due to true when interval=0.
+  rm -f "$STATE_FILE"
+  assert_marker "$(run_driver due 0)" "NOT-DUE" "A5 due-check with interval=0 must be NOT-DUE"
+  assert_marker "$(run_driver tick 0)" "TICK-FAIL" "A5 tick with interval=0 must no-op"
+  [[ ! -f "$STATE_FILE" ]] || smoke_fail "A5: disabled tick must not create state file"
+}
+
+smoke_run "A1 first call from fresh state fires + writes audit + state file" step_a1_first_call_fires
+smoke_run "A2 immediate second call is a no-op" step_a2_immediate_second_call_skips
+smoke_run "A3 overdue last-sync triggers another tick" step_a3_overdue_fires_again
+smoke_run "A4 sync failure records status=failed and avoids hot-loop" step_a4_sync_failure_records_status_failed
+smoke_run "A5 interval=0 disables the periodic tick" step_a5_interval_zero_disables
+
+smoke_log "PASS"

--- a/scripts/smoke/fixtures/daemon-periodic-token-sync/bridge-auth-shim-failure.sh
+++ b/scripts/smoke/fixtures/daemon-periodic-token-sync/bridge-auth-shim-failure.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Test shim for bridge-auth.sh — simulates the bridge-auth.sh sync command
+# failing (e.g. controller token missing). Exit non-zero so the tick takes
+# the status=failed branch.
+exit 7

--- a/scripts/smoke/fixtures/daemon-periodic-token-sync/bridge-auth-shim-success.sh
+++ b/scripts/smoke/fixtures/daemon-periodic-token-sync/bridge-auth-shim-success.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Test shim for bridge-auth.sh — emits a minimal `claude-token sync --json`
+# envelope so the daemon helper's sync-status-parse subcommand returns "ok".
+set -euo pipefail
+# Drain argv; we only honor `claude-token sync --json` shape but do not
+# enforce it here — the daemon callsite passes a fixed shape.
+printf '{"status": "ok", "synced_agents": ["test-agent"]}\n'

--- a/scripts/smoke/fixtures/daemon-periodic-token-sync/driver.sh
+++ b/scripts/smoke/fixtures/daemon-periodic-token-sync/driver.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# args: <action: due|tick> [extra args ignored]
+set -uo pipefail
+
+# Required env (caller sets all):
+#   SHIM_DIR, BRIDGE_STATE_DIR, FUNCS_SH, AUDIT_FILE
+: "${SHIM_DIR:?}"
+: "${BRIDGE_STATE_DIR:?}"
+: "${FUNCS_SH:?}"
+: "${AUDIT_FILE:?}"
+
+# Daemon function bodies reference "$SCRIPT_DIR/bridge-auth.sh" and
+# "$SCRIPT_DIR/bridge-daemon-helpers.py" — point that at our shim dir.
+SCRIPT_DIR="$SHIM_DIR"
+BRIDGE_BASH_BIN="${BASH:-bash}"
+export BRIDGE_STATE_DIR
+
+# Stubs for daemon-side helpers the function body calls. We capture every
+# bridge_audit_log call as one line per row in $AUDIT_FILE so the smoke
+# can grep the action + status fields after the call.
+daemon_info()  { printf '[info] %s\n' "$*" >&2; }
+daemon_warn()  { printf '[warn] %s\n' "$*" >&2; }
+bridge_audit_log() {
+  # signature: <actor> <action> <target> [--detail k=v ...]
+  local actor="$1" action="$2" target="$3"; shift 3 || true
+  local row="action=$action actor=$actor target=$target"
+  while (( $# )); do
+    if [[ "$1" == "--detail" ]]; then
+      shift
+      row+=" $1"
+    fi
+    shift || true
+  done
+  printf '%s\n' "$row" >>"$AUDIT_FILE"
+}
+# bridge_with_timeout — pass-through (no real timeout binary needed; the
+# shim helper returns instantly). Mirrors the test-double in
+# tests/codex-composer/smoke.sh.
+bridge_with_timeout() {
+  # <secs> <label> <cmd> [args...]
+  shift 2 || true
+  "$@"
+}
+
+# Source the extracted function bodies.
+# shellcheck source=/dev/null
+source "$FUNCS_SH"
+
+action="${1:-}"
+case "$action" in
+  due)
+    if bridge_daemon_periodic_token_sync_due; then
+      echo "DUE"
+    else
+      echo "NOT-DUE"
+    fi
+    ;;
+  tick)
+    if bridge_daemon_periodic_token_sync_tick; then
+      echo "TICK-OK"
+    else
+      echo "TICK-FAIL"
+    fi
+    ;;
+  state-file)
+    bridge_daemon_periodic_token_sync_state_file
+    ;;
+  *)
+    echo "unknown action: $action" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Symptom

Operator-observed on the 2026-05-15 patch host (Linux, fnm/AL2023):

- `patch` (admin Claude controller): claude-token refreshed 5/15 01:17 UTC by Claude Code itself.
- `dev_mun` / `sales_choi` / `mgt_ahn` (cron-only static agents): claude-token frozen at 5/12 13:35 UTC — three days stale.
- `mgt_ahn` hit a 429 at 5/15 03:49 KST because the stale token was still pinned to the original credential.
- Daemon log between 5/12 and 5/15: zero rotation / sync / usage events.

## Root cause

`bridge-daemon.sh::process_claude_token_recovery` already invokes
`bridge-auth.sh claude-token sync --agents <scope>`, but **only** when the
recover-due pass reports `sync_recommended=1` — i.e. only after a token
rotation or re-enable. Cron-only agents have no live Claude Code session,
trigger no rotation, and therefore never reach that branch. They inherit
whatever active token the controller had on the day they were created and
stay stale until something forces operator intervention.

## Fix shape

This PR adds two helpers to `bridge-daemon.sh` and wires them into the main
poll loop directly after `claude_token_recovery`:

- `bridge_daemon_periodic_token_sync_due` — cheap due-check against a
  per-daemon state file (`$BRIDGE_STATE_DIR/daemon/last-token-sync`).
- `bridge_daemon_periodic_token_sync_tick` — runs the same
  `bridge-auth.sh claude-token sync --agents <scope>` the recovery branch
  already uses, regardless of any rotation / recovery event. Writes a
  `claude_token_periodic_sync` audit row (status / agent_scope /
  interval_seconds / trigger=periodic) so the operator can see the cadence
  alongside the existing rotation / recovery rows.

The state-file timestamp is refreshed **even on failure** so a persistent
sync breakage cannot hot-loop the daemon — the `status=failed` audit row
is the operator's visibility into that case.

## Env contract

| Variable | Default | Effect |
|---|---|---|
| `BRIDGE_CLAUDE_TOKEN_SYNC_INTERVAL_SECONDS` | `3600` | Wall-clock cadence in seconds. Set to `0` to disable the periodic tick entirely. |
| `BRIDGE_CLAUDE_TOKEN_SYNC_AGENTS` | `static` | Agent scope passed to `bridge-auth.sh claude-token sync --agents` (same semantic as the existing recovery branch). |
| `BRIDGE_CLAUDE_TOKEN_PERIODIC_SYNC_ENABLED` | `1` | Kill switch — set to `0` to fully disable the tick. |

## Observability additions

- New audit action `claude_token_periodic_sync` written via
  `bridge_audit_log` on every tick (success and failure paths). Details:
  `status`, `trigger=periodic`, `agent_scope`, `interval_seconds`.
- `daemon_info` on success (cadence visible in launchagent log).
- `daemon_warn` on `bridge-auth.sh` non-zero rc.

## Smoke

`scripts/smoke/daemon-periodic-token-sync.sh` extracts the two new
functions via `awk` and drives them in an isolated `BRIDGE_STATE_DIR` with
a shim `bridge-auth.sh`. Five cases covered:

- **A1** First call from fresh state: `_due` returns 0, `_tick` fires,
  writes state file, emits audit row tagged `status=ok`.
- **A2** Immediate second call: `_due` returns 1 (elapsed << interval),
  `_tick` no-ops, audit row count unchanged, state file unchanged.
- **A3** Backdate last-sync past interval: `_due` returns 0 again,
  `_tick` fires, audit row count increments, state file refreshed.
- **A4** Shim `bridge-auth.sh` exits non-zero: tick returns rc=1,
  audit row tagged `status=failed`, state file still refreshed (no
  hot-loop), follow-up due-check returns `NOT-DUE`.
- **A5** `BRIDGE_CLAUDE_TOKEN_SYNC_INTERVAL_SECONDS=0`: due-check returns
  `NOT-DUE` even from fresh state, tick no-ops, no state file written.

Wired into `scripts/ci-select-smoke.sh` under the `bridge-daemon.sh`
required set and into `add_all_required_static` so full-suite triggers
exercise it too.

## Out of scope

- Token recovery / on-rotation sync logic (already works — no change).
- Isolated-UID credential propagation (track 5, separate PR).
- `bridge-auth.sh sync` logic itself (already correct).
- Threshold-based rotation (`bridge-auth.py auto-rotate` — usage-based,
  unchanged).

## Verification

```
bash -n bridge-daemon.sh                                  # OK
shellcheck bridge-daemon.sh                               # OK
bash scripts/smoke/daemon-periodic-token-sync.sh          # PASS (5/5 cases)
bash scripts/smoke/daemon.sh                              # PASS (no regression)
scripts/ci-select-smoke.sh --suite required \
    --changed-file bridge-daemon.sh                       # picks the new smoke
```

Refs operator report 2026-05-15 patch host. No `Closes` keyword — the
follow-up `release/v0.13.6` PR will catalog the hotfix track set.