### PR TITLE
fix(auth): isolated UID claude credential sync via sudo-as-isolated-UID helper

### DIFF
--- a/bridge-auth.py
+++ b/bridge-auth.py
@@ -1209,6 +1209,50 @@ def ensure_claude_settings_file(
     return path
 
 
+def cmd_emit_credential_payload(args: argparse.Namespace) -> int:
+    """Emit the Claude credentials JSON payload for the registry's active
+    token to stdout — no file write, no chown, no parent-dir creation.
+
+    PR #883 (v0.13.6 hotfix track 5): the standard ``sync-agent`` path
+    chowns the credential file to the isolated UID *before* ``os.replace``
+    (PR #799 r2), but that still requires the controller-run sync process
+    to write the tempfile into the agent's home — a directory mode 0700
+    owned by the isolated UID where the controller is ``EACCES`` and the
+    write silently no-ops. ``emit-credential-payload`` lets the
+    isolation-aware shell sync path read the token via the registry
+    (which the controller does own), pipe the resulting JSON body
+    through ``bridge_isolation_write_file_as_agent_user_via_bash``, and
+    have the isolated UID itself perform the atomic write inside its
+    own home.
+
+    The payload shape MUST match what ``write_claude_credentials_file``
+    would have produced: ``claudeAiOauth.{accessToken,expiresAt,scopes}``.
+    The ``--agent`` arg is accepted for audit-log symmetry with
+    ``sync-agent`` but is not consulted to look up state — the registry's
+    ``active_token_id`` is the sole input.
+    """
+    json_mode = bool(args.json)
+    try:
+        registry = load_registry(Path(args.registry).expanduser())
+        active_id = str(registry.get("active_token_id") or "")
+        if not active_id:
+            raise ValueError("no active token id")
+        row = find_token(registry, active_id)
+        if row is None:
+            raise ValueError(f"active token id is missing from registry: {active_id}")
+        if not bool(row.get("enabled", True)):
+            raise ValueError(f"active token id is disabled: {active_id}")
+        token = str(row.get("token") or "")
+        validate_token(token)
+        payload = claude_oauth_credentials_payload(token)
+    except Exception as exc:
+        return fail(str(exc), json_mode)
+    # Emit raw JSON body — same shape ``write_claude_credentials_file``
+    # writes to disk. Caller pipes this into the isolation write helper.
+    sys.stdout.write(json.dumps(payload, ensure_ascii=True, indent=2) + "\n")
+    return 0
+
+
 def cmd_sync_agent(args: argparse.Namespace) -> int:
     json_mode = bool(args.json)
     try:
@@ -1328,6 +1372,18 @@ def build_parser() -> argparse.ArgumentParser:
     auto_parser.add_argument("--threshold", type=float)
     auto_parser.add_argument("--json", action="store_true")
     auto_parser.set_defaults(handler=cmd_auto_rotate)
+
+    emit_parser = sub.add_parser("emit-credential-payload")
+    # ``--agent`` is accepted for audit-log symmetry with ``sync-agent``;
+    # the registry's ``active_token_id`` is the sole state input. The
+    # shell caller passes it through so debug logs show which agent the
+    # payload was emitted for. ``--json`` is accepted but does NOT change
+    # output shape (the body is always raw JSON, never wrapped) — the
+    # flag exists so the shell-side combined-JSON emitter does not have
+    # to special-case the argv.
+    emit_parser.add_argument("--agent", required=True)
+    emit_parser.add_argument("--json", action="store_true", help=argparse.SUPPRESS)
+    emit_parser.set_defaults(handler=cmd_emit_credential_payload)
 
     sync_parser = sub.add_parser("sync-agent")
     sync_parser.add_argument("--agent", required=True)

--- a/bridge-auth.sh
+++ b/bridge-auth.sh
@@ -248,6 +248,96 @@ bridge_auth_fix_legacy_secret_file_mode() {
   chmod "$file_mode" "$file" 2>/dev/null || bridge_auth_run_privileged chmod "$file_mode" "$file"
 }
 
+bridge_auth_sync_agent_isolated_via_sudo() {
+  # PR #883 (v0.13.6 hotfix track 5) — isolated-UID credential sync via the
+  # PR #861 helper. The standard ``bridge_auth_sync_agent_python`` path
+  # writes the credentials tempfile from the controller process and then
+  # ``os.replace``s it into the final path. The controller already
+  # ``chown``s the tempfile to the isolated UID before the replace
+  # (PR #799 r2), but the tempfile is created INSIDE the agent's
+  # ``~/.claude/`` directory — which is mode 0700 owned by the isolated
+  # UID. The controller's ``tempfile.mkstemp`` therefore fails with
+  # ``EACCES`` and the sync silently no-ops, leaving the agent without a
+  # ``.credentials.json``.
+  #
+  # This helper reuses ``bridge_isolation_write_file_as_agent_user_via_bash``
+  # (PR #861, lib/bridge-isolation-helpers.sh:181) — a controller-driven
+  # ``sudo -n -u <os_user> bash -c <inline-write>`` that streams stdin
+  # into ``$dest_dir/.<basename>.bridge-write-tmp.XXXXXX``, chmods to
+  # ``0600`` before the atomic rename, and leaves no temp residue on
+  # failure. Token material flows controller -> Python (which loads the
+  # registry and emits the payload to stdout) -> shell pipe -> isolated
+  # UID via sudo. The token never lands on disk in a controller-owned
+  # tempfile.
+  #
+  # Returns:
+  #   0       — write succeeded; caller proceeds to legacy-env update.
+  #   non-0   — failure; caller appends ``<agent>:<reason>`` to ``failed``
+  #             and continues to the next agent. ``reason`` distinguishes
+  #             which sub-step failed for the operator's audit-log
+  #             readback.
+  local agent="$1"
+  local registry="$2"
+  local file="$3"
+  local payload=""
+
+  if ! command -v bridge_isolation_write_file_as_agent_user_via_bash >/dev/null 2>&1 \
+        && ! declare -F bridge_isolation_write_file_as_agent_user_via_bash >/dev/null 2>&1; then
+    printf 'isolation_helper_unavailable\n'
+    return 1
+  fi
+
+  # Emit the credential payload — Python reads the registry, validates the
+  # active token, and prints the JSON body to stdout. No file write, no
+  # parent-dir creation. ``2>/dev/null`` swallows stderr so a registry
+  # error surfaces as a return-code failure rather than leaking the raw
+  # ``[error] ...`` line into the failure-reason string the caller picks
+  # up (the bash caller's audit only consumes our stdout reason).
+  if ! payload="$(python3 "$SCRIPT_DIR/bridge-auth.py" --registry "$registry" \
+        emit-credential-payload --agent "$agent" 2>/dev/null)"; then
+    printf 'emit_payload_failed\n'
+    return 1
+  fi
+
+  if [[ -z "$payload" ]]; then
+    printf 'emit_payload_empty\n'
+    return 1
+  fi
+
+  # Pipe the payload to the isolation write helper. Content is streamed
+  # via stdin (`cat -` inside the inline sudo'd script), NEVER a heredoc
+  # / here-string — that surface re-opens the Bash 5.3.9 heredoc_write
+  # deadlock class (footgun #11, PR #815 Wave D + PR #840 docstring-
+  # literal recurrence).
+  local helper_rc=0
+  printf '%s' "$payload" \
+    | bridge_isolation_write_file_as_agent_user_via_bash "$agent" "$file" 0600 \
+    >/dev/null 2>&1 || helper_rc=$?
+  case "$helper_rc" in
+    0)
+      return 0
+      ;;
+    1)
+      # Helper says "not isolated" — should be impossible because the
+      # caller only takes this branch when ``bridge_agent_linux_user_isolation_effective``
+      # returned true. Treat as a contract violation, not a sudo issue.
+      printf 'isolated_write_not_isolated\n'
+      return 1
+      ;;
+    2)
+      printf 'isolated_write_no_sudo\n'
+      return 1
+      ;;
+    *)
+      # script-band rc 3+ — preserve in the failure reason so operators
+      # can disambiguate the helper's documented exit codes (5=dest
+      # missing, 6=mktemp, 7=stdin, 8=chmod, 9=mv).
+      printf 'isolated_write_failed_rc=%s\n' "$helper_rc"
+      return 1
+      ;;
+  esac
+}
+
 bridge_auth_sync_agent_python() {
   local agent="$1"
   local registry="$2"
@@ -402,10 +492,27 @@ PY
       rc=1
       continue
     fi
-    if ! output="$(bridge_auth_sync_agent_python "$agent" "$registry" "$file" 2>&1)"; then
-      failed+=("$agent:$output")
-      rc=1
-      continue
+    # PR #883 (v0.13.6 hotfix track 5) — isolated agents get a sudo-as-
+    # isolated-UID write path. The standard Python sync from the
+    # controller cannot create a tempfile inside the agent's
+    # ``~/.claude/`` (mode 0700 owned by the isolated UID), so the
+    # ``mkstemp`` fails with EACCES and the sync silently no-ops. The
+    # isolation-aware branch lets the isolated UID itself perform the
+    # atomic write via PR #861's helper, then falls through to the
+    # legacy-env update which is privileged on the controller side and
+    # already isolation-aware (chown to v2 group).
+    if bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+      if ! output="$(bridge_auth_sync_agent_isolated_via_sudo "$agent" "$registry" "$file" 2>&1)"; then
+        failed+=("$agent:$output")
+        rc=1
+        continue
+      fi
+    else
+      if ! output="$(bridge_auth_sync_agent_python "$agent" "$registry" "$file" 2>&1)"; then
+        failed+=("$agent:$output")
+        rc=1
+        continue
+      fi
     fi
     # PR #799 r3 codex finding 1 — Python's ``write_private_file_atomic``
     # writes the tempfile, chmod/chown's it (when --owner-uid/--owner-gid

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions
+  add_required queue daemon launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy isolated-credential-sync v2-cross-class-read isolation-v2-migrate-lock-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions
 }
 
 add_all_integration() {
@@ -273,6 +273,19 @@ select_for_path() {
       add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
       add_integration integration-minimal
       add_live live-tmux-daemon
+      ;;
+
+    bridge-auth.sh|bridge-auth.py)
+      # PR #883 (v0.13.6 hotfix track 5) — bridge-auth.sh gained an
+      # isolation-aware credential-sync branch that pipes the token
+      # payload (emitted by bridge-auth.py's new
+      # ``emit-credential-payload`` subcommand) through
+      # ``bridge_isolation_write_file_as_agent_user_via_bash`` (PR #861).
+      # Pull the regression smoke for every move on either entry point.
+      # Also re-run the PR #861 write-helper smoke since this row's fix
+      # consumes that helper's exit-code contract.
+      add_required isolated-credential-sync 857-pr1-isolation-write-helper
+      add_integration integration-minimal
       ;;
 
     bin/agb|bin/*)

--- a/scripts/smoke/isolated-credential-sync-helpers/strip-bridge-auth-dispatch.py
+++ b/scripts/smoke/isolated-credential-sync-helpers/strip-bridge-auth-dispatch.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Strip the trailing argv-dispatch tail from bridge-auth.sh.
+
+The isolated-credential-sync smoke imports bridge-auth.sh's helper
+functions without triggering its top-level CLI dispatch. This script:
+
+  1. Reads ``bridge-auth.sh`` from argv[1].
+  2. Locates the ``command="${1:-}"`` marker and drops everything from
+     that line onward.
+  3. Drops the SCRIPT_DIR resolver + ``source bridge-lib.sh`` lines —
+     the smoke caller pre-sources bridge-lib.sh from the real repo and
+     re-anchors SCRIPT_DIR itself before sourcing the stripped copy.
+  4. Drops the bootstrap calls (``bridge_load_roster``,
+     ``bridge_require_python``) since the smoke runs in a pre-arranged
+     environment.
+  5. Writes the function-only body to argv[2].
+
+Extracted out of scripts/smoke/isolated-credential-sync.sh to keep that
+file free of embedded heredocs (footgun #11: heredoc/here-string into
+bash variable contexts).
+"""
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(
+            "usage: strip-bridge-auth-dispatch.py <bridge-auth.sh> <out>",
+            file=sys.stderr,
+        )
+        return 2
+    src = Path(sys.argv[1]).read_text(encoding="utf-8")
+    dst = Path(sys.argv[2])
+    marker = '\ncommand="${1:-}"'
+    idx = src.find(marker)
+    if idx < 0:
+        raise SystemExit("bridge-auth.sh dispatch marker not found")
+    head = src[:idx]
+    out_lines = []
+    for line in head.splitlines():
+        stripped_line = line.strip()
+        if stripped_line.startswith("SCRIPT_DIR="):
+            continue
+        if stripped_line == 'source "$SCRIPT_DIR/bridge-lib.sh"':
+            continue
+        if stripped_line == "bridge_load_roster":
+            continue
+        if stripped_line == "bridge_require_python":
+            continue
+        if stripped_line in ("# shellcheck source=/dev/null",):
+            continue
+        out_lines.append(line)
+    dst.write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/isolated-credential-sync.sh
+++ b/scripts/smoke/isolated-credential-sync.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# v0.13.6 hotfix track 5 (PR #883) — regression smoke for the
+# isolation-aware credential-sync path in bridge-auth.sh.
+#
+# Coverage (mocked sudo + mocked isolation predicates):
+#   A1 — isolated agent: bridge_auth_sync_agents writes the credential
+#        file via bridge_isolation_write_file_as_agent_user_via_bash, and
+#        the file content equals the JSON payload emitted by
+#        ``bridge-auth.py emit-credential-payload``.
+#   A2 — non-isolated agent: bridge_auth_sync_agent_python is exercised
+#        (call counted via a stub), the isolated helper is NOT invoked,
+#        and the file is written.
+#   A3 — emit-credential-payload alone: registry with active token ->
+#        payload JSON on stdout with the documented shape
+#        (claudeAiOauth.accessToken + expiresAt + scopes).
+#   A4 — emit-credential-payload alone: registry with no active token ->
+#        rc=1, stdout empty, '[error]' on stderr.
+#
+# Notes:
+#   - No heredoc / here-string anywhere in the test body (footgun #11).
+#   - Mock predicates are defined AFTER sourcing bridge-lib.sh so they
+#     win in the function table. bridge_auth_sync_agents itself is
+#     untouched.
+#   - The sudo shim mirrors PR #861 PR-1's pattern: strips ``-n -u
+#     <user>`` and exec's the remaining command as the current user, so
+#     the real isolation write helper actually runs its inline write
+#     script (but as the smoke caller's UID).
+
+set -uo pipefail
+
+SMOKE_NAME="isolated-credential-sync"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# --- sudo shim builder -------------------------------------------------------
+
+# Mirrors PR #861 PR-1's harness: build a directory containing a ``sudo``
+# shim that drops ``-n -u <user>`` and exec's the remaining argv as the
+# current user. SHIM_RC=0 means the shim transparently exec's; any other
+# value short-circuits and returns it (simulates sudoers denial).
+build_sudo_shim() {
+  local dir="$1"
+  local shim_rc="$2"
+  mkdir -p "$dir"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' '# Mocked sudo for isolated-credential-sync smoke.'
+    printf 'shim_rc=%s\n' "$shim_rc"
+    printf '%s\n' 'if [[ "$shim_rc" -ne 0 ]]; then'
+    printf '%s\n' '  exit "$shim_rc"'
+    printf '%s\n' 'fi'
+    printf '%s\n' 'args=()'
+    printf '%s\n' 'skip_next=0'
+    printf '%s\n' 'for arg in "$@"; do'
+    printf '%s\n' '  if [[ "$skip_next" -eq 1 ]]; then'
+    printf '%s\n' '    skip_next=0'
+    printf '%s\n' '    continue'
+    printf '%s\n' '  fi'
+    printf '%s\n' '  case "$arg" in'
+    printf '%s\n' '    -n) ;;'
+    printf '%s\n' '    -u) skip_next=1 ;;'
+    printf '%s\n' '    *) args+=("$arg") ;;'
+    printf '%s\n' '  esac'
+    printf '%s\n' 'done'
+    printf '%s\n' 'exec "${args[@]}"'
+  } >"$dir/sudo"
+  chmod +x "$dir/sudo"
+}
+
+# --- registry helper ---------------------------------------------------------
+
+# Write a minimal token registry with one active token. We piggy-back on
+# the real ``bridge-auth.py add`` so the registry shape stays in sync
+# with whatever cmd_add writes (version, normalization, etc.).
+seed_registry_with_active_token() {
+  local registry="$1"
+  local token="$2"
+  # ``add`` reads the token from stdin; emit it via printf (no heredoc).
+  printf '%s\n' "$token" | python3 \
+    "$SMOKE_REPO_ROOT/bridge-auth.py" \
+    --registry "$registry" add --id test-token --stdin --activate >/dev/null
+}
+
+# --- case A3: emit-credential-payload happy path -----------------------------
+
+case_a3_emit_payload_happy() {
+  local registry payload exit_rc
+  registry="$SMOKE_TMP_ROOT/a3/reg.json"
+  mkdir -p "$(dirname "$registry")"
+  seed_registry_with_active_token "$registry" "sk-fake-token-very-long-enough"
+  exit_rc=0
+  payload="$(python3 "$SMOKE_REPO_ROOT/bridge-auth.py" --registry "$registry" \
+    emit-credential-payload --agent some-agent)" || exit_rc=$?
+  smoke_assert_eq 0 "$exit_rc" "A3: emit-credential-payload rc=0"
+  smoke_assert_contains "$payload" '"claudeAiOauth"' "A3: payload contains claudeAiOauth"
+  smoke_assert_contains "$payload" '"accessToken": "sk-fake-token-very-long-enough"' \
+    "A3: payload contains the active token"
+  smoke_assert_contains "$payload" '"expiresAt": 4102444800000' "A3: payload contains expiresAt"
+  smoke_assert_contains "$payload" '"user:inference"' "A3: payload contains inference scope"
+  smoke_assert_contains "$payload" '"user:profile"' "A3: payload contains profile scope"
+}
+
+# --- case A4: emit-credential-payload no active token ------------------------
+
+case_a4_emit_payload_no_active() {
+  local registry exit_rc stdout_out stderr_out
+  registry="$SMOKE_TMP_ROOT/a4/reg.json"
+  mkdir -p "$(dirname "$registry")"
+  # Write an empty registry that ``load_registry`` will normalize.
+  printf '{}\n' >"$registry"
+  exit_rc=0
+  # Capture stdout and stderr separately to assert error shape without
+  # heredoc/here-string. We redirect stderr to a tempfile.
+  local stderr_file="$SMOKE_TMP_ROOT/a4/stderr"
+  stdout_out="$(python3 "$SMOKE_REPO_ROOT/bridge-auth.py" --registry "$registry" \
+    emit-credential-payload --agent some-agent 2>"$stderr_file")" || exit_rc=$?
+  stderr_out="$(cat "$stderr_file")"
+  smoke_assert_eq 1 "$exit_rc" "A4: emit-credential-payload rc=1 on empty registry"
+  smoke_assert_eq "" "$stdout_out" "A4: stdout is empty when active token missing"
+  smoke_assert_contains "$stderr_out" "no active token id" \
+    "A4: stderr names the missing-active-token failure mode"
+}
+
+# --- bridge-auth.sh sourcing harness -----------------------------------------
+
+# We need to source bridge-auth.sh's helper functions WITHOUT triggering
+# its top-level command dispatch. bridge-auth.sh's bottom calls
+# ``case "$command" in ... esac`` after argv parsing; we work around
+# this by setting an empty argv and re-sourcing the file in a sub-shell
+# context that runs only the function-definition phase via a guard.
+#
+# Simpler approach: define a wrapper that sources bridge-lib.sh + the
+# helper function bodies directly. bridge-auth.sh's helpers are
+# well-encapsulated bash functions — we extract them by sourcing the
+# full file in a sub-shell with a stub ``case`` that catches the
+# dispatch. The cleanest way is to set the BRIDGE_AUTH_SMOKE_SOURCE_ONLY
+# guard — but that doesn't exist yet, and we don't want to add a
+# top-level guard to bridge-auth.sh just for smoke. Instead we source
+# bridge-lib.sh ourselves and then ``source`` bridge-auth.sh with the
+# trailing dispatch tail trimmed off via sed-on-tempfile (NO sed
+# redirection chain — we write the trimmed copy explicitly).
+import_bridge_auth_helpers() {
+  local repo_root="$SMOKE_REPO_ROOT"
+  local stripped="$SMOKE_TMP_ROOT/bridge-auth-helpers-only.sh"
+  # Stripping logic lives in a sibling fixture script — keeping it out
+  # of this file avoids embedding a Python heredoc here (footgun #11:
+  # heredoc/here-string into shell-side contexts).
+  #
+  # Anchor on a locally-resolved path rather than the top-level
+  # SCRIPT_DIR global; the helper reassigns SCRIPT_DIR to
+  # $SMOKE_REPO_ROOT below before sourcing the stripped bridge-auth.sh,
+  # and we want to stay correct regardless of caller ordering.
+  local fixture_dir
+  fixture_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/isolated-credential-sync-helpers"
+  # Strip:
+  #   - the top-of-file ``source bridge-lib.sh`` chain (we source it
+  #     ourselves from the real repo root so SCRIPT_DIR-relative paths
+  #     resolve correctly);
+  #   - the trailing ``command="${1:-}"`` argv dispatch (we want only
+  #     function defs, not the CLI).
+  python3 "$fixture_dir/strip-bridge-auth-dispatch.py" \
+    "$repo_root/bridge-auth.sh" "$stripped"
+  # Pre-source bridge-lib.sh against the real repo so SCRIPT_DIR resolves
+  # to $SMOKE_REPO_ROOT, then re-anchor SCRIPT_DIR for the bridge-auth
+  # helper bodies (they use $SCRIPT_DIR/bridge-auth.py from inside the
+  # isolated and non-isolated sync paths).
+  # shellcheck source=bridge-lib.sh
+  source "$SMOKE_REPO_ROOT/bridge-lib.sh"
+  SCRIPT_DIR="$SMOKE_REPO_ROOT"
+  # shellcheck disable=SC1090
+  source "$stripped"
+}
+
+# --- case A1 helpers ---------------------------------------------------------
+
+# Stub predicates that mimic the isolated agent. The real
+# ``bridge_agent_linux_user_isolation_effective`` requires a Linux host
+# AND a v2 roster entry; we mock it to return 0. ``bridge_agent_os_user``
+# returns the smoke caller's own username so the sudo shim's exec
+# succeeds.
+mock_agent_isolated() {
+  local agent_name="$1"
+  local os_user
+  os_user="$(id -un)"
+  # shellcheck disable=SC2329
+  eval "bridge_agent_linux_user_isolation_effective() { [[ \"\$1\" == \"$agent_name\" ]]; }"
+  # shellcheck disable=SC2329
+  eval "bridge_agent_os_user() { printf '%s' '$os_user'; }"
+  # bridge_isolation_can_sudo_to_agent's positive branch needs both
+  # predicates above + the sudo shim. Force-stub it to rc=0 (sudo OK).
+  # shellcheck disable=SC2329
+  bridge_isolation_can_sudo_to_agent() { return 0; }
+  # The credential file path resolution helper needs an existing
+  # agent-home root we control. Mock it to a smoke-owned tempdir.
+  # shellcheck disable=SC2329
+  eval "bridge_auth_claude_credentials_file_for_agent() {
+    printf '%s' '$SMOKE_TMP_ROOT/agents/$agent_name/home/.claude/.credentials.json'
+  }"
+  # Mock prepare to just mkdir -p the parent — the real implementation
+  # uses bridge_auth_run_privileged which needs the v2 isolation API on
+  # the host. We just need the dir present for the write helper.
+  # shellcheck disable=SC2329
+  eval "bridge_auth_prepare_credential_file() {
+    mkdir -p \"\$(dirname \"\$2\")\" || return 1
+    return 0
+  }"
+  # Mock the legacy env update to no-op (we're not exercising it).
+  # shellcheck disable=SC2329
+  bridge_auth_update_legacy_claude_config_env() { return 0; }
+  # Mock the legacy file path helper.
+  # shellcheck disable=SC2329
+  eval "bridge_auth_legacy_secret_env_file_for_agent() {
+    printf '%s' '$SMOKE_TMP_ROOT/agents/\$1/legacy.env'
+  }"
+  # Selected agents — make the selector return our test agent regardless
+  # of spec.
+  # shellcheck disable=SC2329
+  eval "bridge_auth_selected_agents() { printf '%s\n' '$agent_name'; }"
+}
+
+mock_agent_not_isolated() {
+  local agent_name="$1"
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 1; }
+  # shellcheck disable=SC2329
+  eval "bridge_auth_claude_credentials_file_for_agent() {
+    printf '%s' '$SMOKE_TMP_ROOT/agents/$agent_name/home/.claude/.credentials.json'
+  }"
+  # shellcheck disable=SC2329
+  eval "bridge_auth_prepare_credential_file() {
+    mkdir -p \"\$(dirname \"\$2\")\" || return 1
+    return 0
+  }"
+  # Track that the python path was invoked — write a marker file and
+  # do a passable credential write so the caller's success path runs.
+  # shellcheck disable=SC2329
+  eval "bridge_auth_sync_agent_python() {
+    : >'$SMOKE_TMP_ROOT/python-path-called'
+    printf '{\"status\":\"synced\"}\n'
+    printf 'mocked-python-credential-write' >\"\$3\"
+    return 0
+  }"
+  # Track that the isolated path was NOT invoked.
+  # shellcheck disable=SC2329
+  eval "bridge_auth_sync_agent_isolated_via_sudo() {
+    : >'$SMOKE_TMP_ROOT/isolated-path-called'
+    printf 'should_not_be_called\n'
+    return 1
+  }"
+  # shellcheck disable=SC2329
+  bridge_auth_update_legacy_claude_config_env() { return 0; }
+  # shellcheck disable=SC2329
+  eval "bridge_auth_legacy_secret_env_file_for_agent() {
+    printf '%s' '$SMOKE_TMP_ROOT/agents/\$1/legacy.env'
+  }"
+  # shellcheck disable=SC2329
+  eval "bridge_auth_selected_agents() { printf '%s\n' '$agent_name'; }"
+}
+
+# --- case A1: isolated agent end-to-end --------------------------------------
+
+case_a1_isolated_writes_via_helper() {
+  local registry token cred_file expected actual rc
+  local agent_name="smoke-isolated-agent"
+  registry="$SMOKE_TMP_ROOT/a1/reg.json"
+  mkdir -p "$(dirname "$registry")"
+  token="sk-fake-isolated-token-very-long-enough"
+  seed_registry_with_active_token "$registry" "$token"
+
+  mock_agent_isolated "$agent_name"
+
+  cred_file="$SMOKE_TMP_ROOT/agents/$agent_name/home/.claude/.credentials.json"
+  # Marker to detect that bridge_auth_sync_agent_python was NOT called
+  # in the isolated branch.
+  rm -f "$SMOKE_TMP_ROOT/python-path-called"
+  # shellcheck disable=SC2329
+  eval "bridge_auth_sync_agent_python() {
+    : >'$SMOKE_TMP_ROOT/python-path-called'
+    printf 'python_path_called_unexpectedly\n'
+    return 1
+  }"
+
+  rc=0
+  bridge_auth_sync_agents "$registry" "$agent_name" 0 >/dev/null 2>&1 || rc=$?
+  smoke_assert_eq 0 "$rc" "A1: bridge_auth_sync_agents returns 0 for isolated agent"
+  smoke_assert_file_exists "$cred_file" "A1: credential file written"
+  [[ ! -f "$SMOKE_TMP_ROOT/python-path-called" ]] \
+    || smoke_fail "A1: bridge_auth_sync_agent_python invoked on isolated path"
+
+  # Compute the expected payload via emit-credential-payload itself —
+  # the file must equal that bytes-for-bytes (minus the trailing newline
+  # the helper writes after JSON, which is present in both sides).
+  expected="$(python3 "$SMOKE_REPO_ROOT/bridge-auth.py" --registry "$registry" \
+    emit-credential-payload --agent "$agent_name")"
+  actual="$(cat "$cred_file")"
+  # The helper's ``cat -`` preserves stdin bytes-for-bytes. The shell-
+  # side wrapper uses ``printf '%s' "$payload"`` which strips the
+  # trailing newline that the Python emitter appended. Compare with the
+  # same normalization.
+  expected_normalized="$(printf '%s' "$expected")"
+  smoke_assert_eq "$expected_normalized" "$actual" \
+    "A1: file content equals emit-credential-payload output (newline-stripped)"
+}
+
+# --- case A2: non-isolated agent falls through to python ---------------------
+
+case_a2_non_isolated_uses_python() {
+  local registry token cred_file rc
+  local agent_name="smoke-non-isolated-agent"
+  registry="$SMOKE_TMP_ROOT/a2/reg.json"
+  mkdir -p "$(dirname "$registry")"
+  token="sk-fake-noniso-token-very-long-enough"
+  seed_registry_with_active_token "$registry" "$token"
+
+  mock_agent_not_isolated "$agent_name"
+
+  cred_file="$SMOKE_TMP_ROOT/agents/$agent_name/home/.claude/.credentials.json"
+  rm -f "$SMOKE_TMP_ROOT/python-path-called" "$SMOKE_TMP_ROOT/isolated-path-called"
+
+  rc=0
+  bridge_auth_sync_agents "$registry" "$agent_name" 0 >/dev/null 2>&1 || rc=$?
+  smoke_assert_eq 0 "$rc" "A2: bridge_auth_sync_agents returns 0 for non-isolated agent"
+  smoke_assert_file_exists "$SMOKE_TMP_ROOT/python-path-called" \
+    "A2: bridge_auth_sync_agent_python WAS invoked"
+  [[ ! -f "$SMOKE_TMP_ROOT/isolated-path-called" ]] \
+    || smoke_fail "A2: isolated path invoked on non-isolated agent"
+  smoke_assert_file_exists "$cred_file" "A2: credential file written via mocked python path"
+}
+
+# --- main --------------------------------------------------------------------
+
+main() {
+  smoke_setup_bridge_home "isolated-credential-sync"
+
+  # Always-on standalone payload cases first — no sourcing required.
+  case_a3_emit_payload_happy
+  smoke_log "ok: A3 (emit-credential-payload happy path)"
+  case_a4_emit_payload_no_active
+  smoke_log "ok: A4 (emit-credential-payload empty registry)"
+
+  # Build sudo shim and put it on PATH.
+  local shim_dir="$SMOKE_TMP_ROOT/sudo-shim"
+  build_sudo_shim "$shim_dir" 0
+  local original_path="$PATH"
+
+  # A1: isolated agent end-to-end. Run in a sub-shell so the function
+  # table mutations stay scoped — A2 needs a clean slate.
+  (
+    PATH="$shim_dir:$original_path"
+    import_bridge_auth_helpers
+    case_a1_isolated_writes_via_helper
+  ) || smoke_fail "A1 sub-shell failed"
+  smoke_log "ok: A1 (isolated agent writes via bridge_isolation_write_file_as_agent_user_via_bash)"
+
+  # A2: non-isolated agent end-to-end. Fresh sub-shell so the A1 stubs
+  # do not bleed in.
+  (
+    PATH="$original_path"
+    import_bridge_auth_helpers
+    case_a2_non_isolated_uses_python
+  ) || smoke_fail "A2 sub-shell failed"
+  smoke_log "ok: A2 (non-isolated agent falls through to bridge_auth_sync_agent_python)"
+
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

v0.13.6 hotfix track 5 — isolated UID claude credential propagation via sudo helper.

Operator's 2026-05-15 patch-host diagnosis on the isolated `sales_sean` agent (`agent-bridge-sales_sean` UID, mode 0700 isolated home) showed `~/.agent-bridge/agents/sales_sean/home/.claude/.credentials.json` was missing entirely after `bridge-auth.sh claude-token sync --agents static`. The sync enumerated the agent (engine=claude + source=static) and entered the isolated branch, but the write silently no-op'd.

## Root cause

`bridge_auth_sync_agent_python` (bridge-auth.sh:251) handles isolated agents by calling

```bash
bridge_linux_sudo_root python3 "$SCRIPT_DIR/bridge-auth.py" --registry "$registry" sync-agent ...
```

`bridge_linux_sudo_root` resolves to `sudo -n <cmd>` on Linux. The sudoers entry installed by Agent Bridge (`bridge_migration_sudoers_entry`) whitelists only `bash` and `tmux` — not arbitrary commands and not `python3`. On any host without a separate NOPASSWD root sudoers grant for python3 (the default for fresh installs), `sudo -n python3 ...` exits with `[sudo] password is required for ...` and the caller catches the failure-line in the local `failed[]` array — but operators have no easy way to see that array unless they invoke with `--json`, so the empty agent home looks like a silent no-op.

`bridge-auth.py write_claude_credentials_file` would not save us even if it could be invoked: the controller process is `EACCES` to mkstemp inside `~agent-bridge-sales_sean/.claude/` (mode 0700, owned by the isolated UID) when not running as root.

## Fix

Reuse PR #861 (v0.13.1)'s `bridge_isolation_write_file_as_agent_user_via_bash` helper — `sudo -n -u <os_user> bash -c <inline-write>` is whitelisted by the existing sudoers entry — to write the credential file as the isolated UID itself.

- **`bridge-auth.py`** gains `emit-credential-payload` subcommand: reads the registry, validates the active token, prints the JSON body to stdout. No file write, no parent-dir creation. Payload shape matches `write_claude_credentials_file`.
- **`bridge-auth.sh`** gains `bridge_auth_sync_agent_isolated_via_sudo`: pipes `emit-credential-payload` stdout through `bridge_isolation_write_file_as_agent_user_via_bash`. Content flows controller -> Python -> shell pipe -> isolated UID via sudo. Token never lands on disk in a controller-owned tempfile. `bridge_auth_sync_agents` branches on `bridge_agent_linux_user_isolation_effective` before calling either path.
- **New smoke** `scripts/smoke/isolated-credential-sync.sh`: covers (A1) isolated agent end-to-end write via the helper, (A2) non-isolated agent falls through to `bridge_auth_sync_agent_python`, (A3/A4) `emit-credential-payload` happy path + empty-registry rc=1. Wired into `add_all_required_static` + a new `bridge-auth.sh|bridge-auth.py` trigger row in `ci-select-smoke.sh`.

## MVP scope

Credential file only. `.claude/.claude.json` (config) and `.claude/settings.json` for isolated agents stay on the existing sudo-python-as-root path — same brittle surface, but Claude CLI falls back to defaults when those are missing, so leaving them as a follow-up does not block the production fix. Tracked separately.

## Verification

- `bash -n bridge-auth.sh scripts/smoke/isolated-credential-sync.sh scripts/ci-select-smoke.sh`: PASS
- `python3 -c "import py_compile; py_compile.compile('bridge-auth.py', doraise=True)"`: PASS
- `shellcheck bridge-auth.sh scripts/smoke/isolated-credential-sync.sh scripts/ci-select-smoke.sh`: PASS
- `bash scripts/smoke/isolated-credential-sync.sh`: PASS (4 cases: A1 isolated end-to-end, A2 non-isolated fallthrough, A3 emit happy, A4 emit empty-registry)
- `bash scripts/smoke/857-pr1-isolation-write-helper.sh`: PASS (regression for the helper this PR consumes)
- `bash scripts/smoke-test.sh`: pre-existing hang at `bridge-run.sh --dry-run pipes launch_cmd through env-secret redactor (#428 r2)` on `main` HEAD `7148f7e` (verified by clean-clone test); independent of this change.

## Footguns avoided

- **#11** (heredoc/here-string into bash variable contexts): payload travels via `printf` + `|` pipe; smoke shim emits via `printf '%s\n'` per line into a file, never `var=$(cat <<EOF)`.
- **#2** (close-keyword): "Refs operator report 2026-05-15", not a `fixes/closes` line — no GitHub issue should auto-close on this PR.

## Independence

Independent of v0.13.6 hotfix tracks 1/2/3/4 (auth surface only — bridge-auth.{sh,py} + new smoke + ci-select row). Safe to merge in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)