### PR TITLE
fix(cleanup): handle empty cleanup payload stdin silently (closes #872)

### DIFF
--- a/lib/bridge-cleanup.sh
+++ b/lib/bridge-cleanup.sh
@@ -66,92 +66,44 @@ bridge_cleanup_daily_backup_residue() {
 # Stdin: JSON cleanup payload from bridge_cleanup_daily_backup_residue.
 # Stdout: markdown block.
 bridge_cleanup_render_summary() {
-  # Issue #872: previously this used `python3 - <<'PY' ... PY`, which makes
-  # the heredoc body itself python3's stdin (because `-` reads the script
-  # from stdin). That meant the caller's `printf '%s' "$CLEANUP_JSON" |
-  # bridge_cleanup_render_summary` pipe was inaccessible to the renderer
-  # — sys.stdin always returned empty and json.load surfaced
+  # Issue #872 / PR #886:
+  #
+  # Round 1 history: the original surface used `python3 - <<'PY' ... PY`,
+  # which makes the heredoc body itself python3's stdin (because `-` reads
+  # the script from stdin). The caller's `printf '%s' "$CLEANUP_JSON" |
+  # bridge_cleanup_render_summary` pipe was therefore inaccessible to the
+  # renderer — sys.stdin always returned empty and json.load surfaced
   # JSONDecodeError verbatim into the [upgrade-complete] task body.
   #
-  # Fix follows the post-#800 pattern in lib/bridge-init-default-crons.sh
-  # (see footgun #11 mitigation note there): write the python script to a
-  # tempfile and exec it with `python3 <tempfile>`, which leaves fd 0
-  # pointing at the caller's pipe so sys.stdin.read() actually sees the
-  # JSON payload. The renderer also degrades to friendly placeholders on
-  # empty or unparseable input instead of leaking the raw exception text.
-  local script_tmp
-  script_tmp="$(mktemp 2>/dev/null)" || {
-    printf '## Backup residue cleanup\n\n_Renderer could not allocate a temp file._\n'
+  # Round 1 fix (PR #886 r1) replaced the heredoc-stdin form with a
+  # `cat >"$script_tmp" <<'PY' ... PY` tempfile-script form. r1 codex
+  # review correctly flagged this as self-contradictory: the original
+  # bug class is "heredoc-as-content-delivery is fragile under the
+  # post-#800 heredoc/here-string toolchain" (see HANDOFF_2026-05-08).
+  # Mitigating a footgun #11 trip with another heredoc still leaves the
+  # heredoc-content boundary in the source — every new heredoc is a
+  # fresh failure surface and a regression magnet (#840 docstring-literal
+  # trip is the most recent recurrence).
+  #
+  # Round 2 fix (this commit): the renderer body lives as a tracked
+  # python file under scripts/python-helpers/cleanup-payload-renderer.py
+  # and we invoke it as `python3 <path>`. fd 0 still points at the
+  # caller's pipe so sys.stdin.read() sees the JSON payload as intended.
+  # No heredoc, no tempfile script write — the script is content the
+  # repo ships, not content this function emits.
+  #
+  # We self-resolve the script path from BASH_SOURCE so the helper works
+  # both inside the full upgrader (BRIDGE_SCRIPT_DIR set by bridge-lib.sh)
+  # and under the smoke runner (only lib/bridge-cleanup.sh sourced).
+  local _self_dir
+  _self_dir="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+  local renderer="$_self_dir/scripts/python-helpers/cleanup-payload-renderer.py"
+  if [[ ! -f "$renderer" ]]; then
+    printf '## Backup residue cleanup\n\n_Renderer payload missing at %s._\n' \
+      "$renderer"
     return 0
-  }
-  # shellcheck disable=SC2064
-  trap "rm -f -- '$script_tmp'" RETURN
-  cat >"$script_tmp" <<'PY'
-import json
-import sys
-
-raw = sys.stdin.read()
-if not raw.strip():
-    print("## Backup residue cleanup\n\n"
-          "_Cleanup helper returned empty payload (no work performed)._")
-    raise SystemExit(0)
-
-try:
-    data = json.loads(raw)
-except Exception:
-    print("## Backup residue cleanup\n\n"
-          "_Cleanup payload could not be parsed; see daemon logs for details._")
-    raise SystemExit(0)
-
-stale = data.get("stale_tmp_removed") or []
-daily = data.get("daily_pruned") or []
-snaps = data.get("snapshots_pruned") or []
-upg = data.get("upgrade_backups") or {}
-upg_pruned = upg.get("pruned") or []
-upg_preserved = upg.get("preserved") or []
-cfg = data.get("claude_config") or {}
-fails = data.get("cleanup_failures") or []
-
-freed_human = data.get("bytes_freed_human") or "0 B"
-before_human = data.get("free_bytes_before_human") or "?"
-after_human = data.get("free_bytes_after_human") or "?"
-
-lines = ["## Backup residue cleanup", ""]
-lines.append(f"- Disk free before → after: **{before_human} → {after_human}** "
-             f"(freed: **{freed_human}**)")
-lines.append(f"- Stale `*.tgz.tmp.*` reaped: **{len(stale)}**")
-lines.append(f"- Daily archives pruned (retain=7d default): **{len(daily)}**")
-lines.append(f"- SQL snapshots pruned: **{len(snaps)}**")
-if upg.get("skipped_no_backup_mode"):
-    lines.append("- Upgrade-* backups: **skipped** (--no-backup mode)")
-else:
-    lines.append(f"- Upgrade-* backups pruned: **{len(upg_pruned)}** "
-                 f"(preserved {len(upg_preserved)} including current)")
-
-cfg_status = cfg.get("status", "unknown")
-status_blurb = {
-    "ok": "valid JSON",
-    "missing": "not present (no Claude Code installed for this user?)",
-    "corrupted": "**CORRUPTED — recover from ~/.claude/backups/**",
-    "unreadable": "unreadable (permissions?)",
-}.get(cfg_status, cfg_status)
-lines.append(f"- `~/.claude.json`: {status_blurb}")
-if cfg_status == "corrupted" and cfg.get("recovery_candidate"):
-    lines.append(f"  - Suggested recovery source: `{cfg['recovery_candidate']}`")
-
-if fails:
-    lines.append("")
-    lines.append("### Cleanup failures (manual follow-up required)")
-    for failure in fails:
-        step = failure.get("step", "?")
-        err = failure.get("error", "?")
-        path = failure.get("path", "")
-        suffix = f" (path={path})" if path else ""
-        lines.append(f"- `{step}`: {err}{suffix}")
-
-print("\n".join(lines))
-PY
-  python3 "$script_tmp"
+  fi
+  python3 "$renderer"
 }
 
 # Render the agent-safe verification block embedded in the [upgrade-complete]

--- a/lib/bridge-cleanup.sh
+++ b/lib/bridge-cleanup.sh
@@ -66,14 +66,41 @@ bridge_cleanup_daily_backup_residue() {
 # Stdin: JSON cleanup payload from bridge_cleanup_daily_backup_residue.
 # Stdout: markdown block.
 bridge_cleanup_render_summary() {
-  python3 - <<'PY'
+  # Issue #872: previously this used `python3 - <<'PY' ... PY`, which makes
+  # the heredoc body itself python3's stdin (because `-` reads the script
+  # from stdin). That meant the caller's `printf '%s' "$CLEANUP_JSON" |
+  # bridge_cleanup_render_summary` pipe was inaccessible to the renderer
+  # — sys.stdin always returned empty and json.load surfaced
+  # JSONDecodeError verbatim into the [upgrade-complete] task body.
+  #
+  # Fix follows the post-#800 pattern in lib/bridge-init-default-crons.sh
+  # (see footgun #11 mitigation note there): write the python script to a
+  # tempfile and exec it with `python3 <tempfile>`, which leaves fd 0
+  # pointing at the caller's pipe so sys.stdin.read() actually sees the
+  # JSON payload. The renderer also degrades to friendly placeholders on
+  # empty or unparseable input instead of leaking the raw exception text.
+  local script_tmp
+  script_tmp="$(mktemp 2>/dev/null)" || {
+    printf '## Backup residue cleanup\n\n_Renderer could not allocate a temp file._\n'
+    return 0
+  }
+  # shellcheck disable=SC2064
+  trap "rm -f -- '$script_tmp'" RETURN
+  cat >"$script_tmp" <<'PY'
 import json
 import sys
 
+raw = sys.stdin.read()
+if not raw.strip():
+    print("## Backup residue cleanup\n\n"
+          "_Cleanup helper returned empty payload (no work performed)._")
+    raise SystemExit(0)
+
 try:
-    data = json.load(sys.stdin)
-except Exception as exc:
-    print(f"## Backup residue cleanup\n\nCould not parse cleanup payload: {exc}")
+    data = json.loads(raw)
+except Exception:
+    print("## Backup residue cleanup\n\n"
+          "_Cleanup payload could not be parsed; see daemon logs for details._")
     raise SystemExit(0)
 
 stale = data.get("stale_tmp_removed") or []
@@ -124,6 +151,7 @@ if fails:
 
 print("\n".join(lines))
 PY
+  python3 "$script_tmp"
 }
 
 # Render the agent-safe verification block embedded in the [upgrade-complete]

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872
 }
 
 add_all_integration() {
@@ -385,7 +385,22 @@ select_for_path() {
       # apply-live `find scripts/ -type d -exec chmod a+rX {} +` step
       # (R2). Pull the per-regression smoke whenever the upgrade entry
       # moves so the umask=077 dir normalization stays pinned.
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions
+      # Issue #872 (v0.13.6 track 7): bridge_cleanup_render_summary's
+      # empty-stdin / invalid-payload degradation is invoked from
+      # bridge-upgrade.sh's [upgrade-complete] task body composer; pull
+      # its regression smoke in whenever the upgrade entry moves so the
+      # task body cannot regress to leaking raw JSONDecodeError text.
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872
+      add_integration integration-minimal
+      ;;
+
+    lib/bridge-cleanup.sh)
+      # Issue #872 (v0.13.6 track 7): the cleanup payload renderer must
+      # degrade gracefully on empty / invalid stdin so the
+      # [upgrade-complete] task body never contains a raw Python
+      # JSONDecodeError. Cover the regression whenever the cleanup lib
+      # moves.
+      add_required cleanup-payload-empty-stdin-872 upgrade telegram-relay-residue-cleanup
       add_integration integration-minimal
       ;;
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -425,6 +425,16 @@ select_for_path() {
       add_integration integration-minimal
       ;;
 
+    scripts/python-helpers/cleanup-payload-renderer.py)
+      # PR #886 r2: bridge_cleanup_render_summary delegates the JSON →
+      # markdown render to this fixture file so the renderer body lives
+      # outside any heredoc (post-#800 footgun #11 mitigation). Any
+      # change to the fixture must re-run the empty-stdin regression
+      # smoke that asserts the renderer never leaks JSONDecodeError.
+      add_required cleanup-payload-empty-stdin-872 upgrade telegram-relay-residue-cleanup
+      add_integration integration-minimal
+      ;;
+
     bridge-lib.sh|lib/bridge-core.sh|lib/bridge-agents.sh|agent-roster.sh|agent-roster.local.example.sh|bridge-config.sh)
       add_all_required_static
       add_all_integration

--- a/scripts/python-helpers/cleanup-payload-renderer.py
+++ b/scripts/python-helpers/cleanup-payload-renderer.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Renderer body for bridge_cleanup_render_summary (lib/bridge-cleanup.sh).
+
+Lives as a tracked file under scripts/python-helpers/ so the shell caller can
+invoke it via `python3 <path>` instead of feeding the body through a
+`cat > tmp <<'PY' ... PY` heredoc. The heredoc form is footgun #11
+(see lib/bridge-init-default-crons.sh, #800, HANDOFF_2026-05-08) — even when
+the heredoc target is a tempfile rather than python3's stdin directly, every
+new heredoc in mitigation code creates a fresh failure surface. PR #886 r1
+codex review flagged that the original #872 fix wrote the python body via
+`cat > "$script_tmp" <<'PY'` inside the very function that was supposed to
+mitigate the footgun — self-contradictory. This file is the r2 fix:
+fixture-file delivery, no heredoc.
+
+Contract:
+  stdin  — JSON cleanup payload from bridge_cleanup_daily_backup_residue
+           (empty / unparseable / valid all supported).
+  stdout — markdown summary block suitable for the upgrade stdout output
+           and the [upgrade-complete] task body.
+  exit   — always 0; the renderer never breaks the upgrade tail.
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(
+            "## Backup residue cleanup\n\n"
+            "_Cleanup helper returned empty payload (no work performed)._"
+        )
+        return 0
+
+    try:
+        data = json.loads(raw)
+    except Exception:
+        print(
+            "## Backup residue cleanup\n\n"
+            "_Cleanup payload could not be parsed; see daemon logs for details._"
+        )
+        return 0
+
+    stale = data.get("stale_tmp_removed") or []
+    daily = data.get("daily_pruned") or []
+    snaps = data.get("snapshots_pruned") or []
+    upg = data.get("upgrade_backups") or {}
+    upg_pruned = upg.get("pruned") or []
+    upg_preserved = upg.get("preserved") or []
+    cfg = data.get("claude_config") or {}
+    fails = data.get("cleanup_failures") or []
+
+    freed_human = data.get("bytes_freed_human") or "0 B"
+    before_human = data.get("free_bytes_before_human") or "?"
+    after_human = data.get("free_bytes_after_human") or "?"
+
+    lines = ["## Backup residue cleanup", ""]
+    lines.append(
+        f"- Disk free before → after: **{before_human} → {after_human}** "
+        f"(freed: **{freed_human}**)"
+    )
+    lines.append(f"- Stale `*.tgz.tmp.*` reaped: **{len(stale)}**")
+    lines.append(f"- Daily archives pruned (retain=7d default): **{len(daily)}**")
+    lines.append(f"- SQL snapshots pruned: **{len(snaps)}**")
+    if upg.get("skipped_no_backup_mode"):
+        lines.append("- Upgrade-* backups: **skipped** (--no-backup mode)")
+    else:
+        lines.append(
+            f"- Upgrade-* backups pruned: **{len(upg_pruned)}** "
+            f"(preserved {len(upg_preserved)} including current)"
+        )
+
+    cfg_status = cfg.get("status", "unknown")
+    status_blurb = {
+        "ok": "valid JSON",
+        "missing": "not present (no Claude Code installed for this user?)",
+        "corrupted": "**CORRUPTED — recover from ~/.claude/backups/**",
+        "unreadable": "unreadable (permissions?)",
+    }.get(cfg_status, cfg_status)
+    lines.append(f"- `~/.claude.json`: {status_blurb}")
+    if cfg_status == "corrupted" and cfg.get("recovery_candidate"):
+        lines.append(f"  - Suggested recovery source: `{cfg['recovery_candidate']}`")
+
+    if fails:
+        lines.append("")
+        lines.append("### Cleanup failures (manual follow-up required)")
+        for failure in fails:
+            step = failure.get("step", "?")
+            err = failure.get("error", "?")
+            path = failure.get("path", "")
+            suffix = f" (path={path})" if path else ""
+            lines.append(f"- `{step}`: {err}{suffix}")
+
+    print("\n".join(lines))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/cleanup-payload-empty-stdin-872.sh
+++ b/scripts/smoke/cleanup-payload-empty-stdin-872.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+# Issue #872: bridge_cleanup_render_summary previously surfaced
+# json.JSONDecodeError verbatim ("Could not parse cleanup payload:
+# Expecting value: line 1 column 1 (char 0)") into the
+# [upgrade-complete] task body when the cleanup helper returned empty
+# stdout on a successful exit. Lock the contract that:
+#   T1: empty stdin renders a friendly noop block, not the raw
+#       exception text;
+#   T2: invalid JSON stdin renders a generic placeholder, not the raw
+#       exception text;
+#   T3: valid JSON stdin still renders the structured summary block.
+
+set -euo pipefail
+
+SMOKE_NAME="cleanup-payload-empty-stdin-872"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+trap 'smoke_cleanup_temp_root' EXIT
+
+smoke_require_cmd python3
+smoke_require_cmd bash
+
+CLEANUP_LIB="$SMOKE_REPO_ROOT/lib/bridge-cleanup.sh"
+[[ -f "$CLEANUP_LIB" ]] || smoke_fail "missing $CLEANUP_LIB"
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+# Wrap bridge_cleanup_render_summary in a sourced shell so the function
+# under test runs in the same Bash environment the upgrader uses.
+render() {
+  bash -c "set -euo pipefail; source '$CLEANUP_LIB'; bridge_cleanup_render_summary"
+}
+
+# T1: empty stdin must not leak json.JSONDecodeError text.
+T1_OUT="$(printf '' | render)"
+case "$T1_OUT" in
+  *"Expecting value"*|*"JSONDecodeError"*|*"Could not parse cleanup payload"*)
+    smoke_fail "T1: empty stdin still leaks raw exception text: $T1_OUT"
+    ;;
+esac
+case "$T1_OUT" in
+  *"## Backup residue cleanup"*) ;;
+  *) smoke_fail "T1: empty stdin output missing section header: $T1_OUT" ;;
+esac
+smoke_log "T1 ok — empty stdin renders friendly noop block"
+
+# T2: invalid JSON must not leak the raw exception text either.
+T2_OUT="$(printf 'not-json-at-all' | render)"
+case "$T2_OUT" in
+  *"Expecting value"*|*"JSONDecodeError"*|*"Could not parse cleanup payload"*)
+    smoke_fail "T2: invalid JSON still leaks raw exception text: $T2_OUT"
+    ;;
+esac
+case "$T2_OUT" in
+  *"## Backup residue cleanup"*) ;;
+  *) smoke_fail "T2: invalid JSON output missing section header: $T2_OUT" ;;
+esac
+smoke_log "T2 ok — invalid JSON renders generic placeholder"
+
+# T3: valid JSON renders the structured summary block.
+VALID_JSON='{
+  "stale_tmp_removed": ["a"],
+  "daily_pruned": [],
+  "snapshots_pruned": [],
+  "upgrade_backups": {"pruned": [], "preserved": []},
+  "claude_config": {"status": "ok"},
+  "cleanup_failures": [],
+  "bytes_freed_human": "1.2 KB",
+  "free_bytes_before_human": "10 GB",
+  "free_bytes_after_human": "10 GB"
+}'
+T3_OUT="$(printf '%s' "$VALID_JSON" | render)"
+case "$T3_OUT" in
+  *"Stale "*"reaped: **1**"*) ;;
+  *) smoke_fail "T3: valid JSON output missing stale count line: $T3_OUT" ;;
+esac
+case "$T3_OUT" in
+  *"Disk free before"*"1.2 KB"*) ;;
+  *) smoke_fail "T3: valid JSON output missing freed bytes line: $T3_OUT" ;;
+esac
+smoke_log "T3 ok — valid JSON renders structured summary"
+
+smoke_log "PASS"


### PR DESCRIPTION
## Summary

`bridge_cleanup_render_summary` previously surfaced a raw `json.JSONDecodeError` (\"Could not parse cleanup payload: Expecting value: line 1 column 1 (char 0)\") into the `[upgrade-complete]` task body on every `agb upgrade --apply` run.

**Root cause**: the `python3 - <<'PY' ... PY` heredoc-stdin form makes the heredoc body itself python3's stdin (because `-` reads the script from stdin), so the caller's `printf '%s' \"\$CLEANUP_JSON\" | bridge_cleanup_render_summary` pipe was never accessible to the renderer — `sys.stdin` always returned empty and `json.load` surfaced its exception verbatim through the bare except branch.

**Fix**: switch to the post-#800 footgun #11 mitigation pattern (see `lib/bridge-init-default-crons.sh`): write the python script to a tempfile and exec it with `python3 <tempfile>`, which leaves fd 0 pointing at the caller's pipe so the renderer actually sees the JSON payload. The renderer also degrades to friendly placeholders on empty or unparseable input instead of leaking the raw exception text.

## Changes

- `lib/bridge-cleanup.sh` — heredoc-stdin → tempfile-script pattern; empty/invalid input degrade to friendly markdown placeholders.
- `scripts/smoke/cleanup-payload-empty-stdin-872.sh` (new) — T1 empty stdin, T2 invalid JSON, T3 valid JSON renders structured summary.
- `scripts/ci-select-smoke.sh` — wire new smoke into `lib/bridge-cleanup.sh` (dedicated row) + `bridge-upgrade.sh` (caller row) + `__ALL__` static set.

## Verification

- `bash -n lib/bridge-cleanup.sh scripts/smoke/cleanup-payload-empty-stdin-872.sh scripts/ci-select-smoke.sh` — PASS
- `shellcheck` on edited files — PASS (no new warnings).
- `bash scripts/smoke/cleanup-payload-empty-stdin-872.sh` — PASS (T1/T2/T3 all green).
- `bash scripts/smoke/upgrade.sh` — PASS (existing caller-side upgrade smoke still green).
- `bash scripts/ci-select-smoke.sh --changed-file lib/bridge-cleanup.sh` — includes the new smoke as expected.
- `bash scripts/ci-select-smoke.sh --changed-file bridge-upgrade.sh` — includes the new smoke as expected.

## Why this fixes #872 fully

The original bug surfaces *only* when `CLEANUP_JSON` is empty per the issue's reproducer, but the heredoc-stdin pattern means the renderer never saw piped JSON at all — every successful upgrade was effectively in the \"empty payload\" branch silently. Replacing the heredoc-stdin invocation with the tempfile-script pattern restores the renderer's documented behavior (valid JSON → structured summary block) and the new empty/invalid-input fallbacks ensure the raw `JSONDecodeError` text can never leak again.

Closes #872.

🤖 Generated with [Claude Code](https://claude.com/claude-code)