### PR TITLE
fix(upgrade): remove here-string deadlocks blocking v0.7.x → v0.13.x leap (footgun #11 recurrence)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -239,16 +239,18 @@ bridge_upgrade_current_ref() {
 
 bridge_upgrade_latest_stable_tag() {
   local root="$1"
-  local tags
-  tags="$(git -C "$root" tag --list 'v[0-9]*.[0-9]*.[0-9]*')"
-  python3 -c '
+  # Footgun #11 (heredoc/here-string deadlock — refs #265 / #800 / #815):
+  # piping `git tag` output directly into python3 avoids the
+  # `python3 ... <<<"$tags"` here-string that wedges Bash 5.3.9 in
+  # `read_comsub` during a v0.7.x → v0.13.x upgrade --apply leap.
+  git -C "$root" tag --list 'v[0-9]*.[0-9]*.[0-9]*' | python3 -c '
 import re
 import sys
 
 tags = [line.strip() for line in sys.stdin if re.fullmatch(r"v\d+\.\d+\.\d+", line.strip())]
 tags.sort(key=lambda tag: tuple(int(part) for part in tag[1:].split(".")))
 print(tags[-1] if tags else "")
-' <<<"$tags"
+'
 }
 
 bridge_upgrade_normalize_version_tag() {
@@ -534,7 +536,9 @@ bridge_upgrade_reconcile_agent_restart_recovery() {
     return 0
   fi
   # Skip the wait entirely when there is nothing to reconcile.
-  if ! grep -qE $'\t''failed'$'\t' <<<"$report"; then
+  # Footgun #11 (refs #265 / #800 / #815): pipe instead of here-string
+  # to keep Bash 5.3.9 from wedging in `read_comsub` during apply leaps.
+  if ! printf '%s\n' "$report" | grep -qE $'\t''failed'$'\t'; then
     printf '%s' "$report"
     return 0
   fi
@@ -555,6 +559,18 @@ bridge_upgrade_reconcile_agent_restart_recovery() {
     # the bash versions we support.
     TAB="$(printf "\t")"
 
+    # Footgun #11 (refs #265 / #800 / #815): stage the report through a
+    # tempfile and stream `< $tempfile` instead of `done <<<"$report"`.
+    # The here-string form wedges Bash 5.3.9 in `read_comsub` /
+    # `heredoc_write` during a v0.7.x → v0.13.x upgrade --apply leap.
+    _rep_tmp="$(mktemp -t agb-upg-rep.XXXXXX)"
+    # shellcheck disable=SC2064
+    trap "rm -f -- \"$_rep_tmp\"" EXIT
+    # Trailing newline matches the original `<<<` semantics so the last
+    # row is delivered to read. Command substitution strips trailing
+    # newlines from the caller report, so we re-add one here.
+    printf "%s\n" "$report" > "$_rep_tmp"
+
     # Collect the agents that need a recovery probe up front so the
     # poll loop can short-circuit as soon as all of them are active.
     failed_agents=()
@@ -563,7 +579,7 @@ bridge_upgrade_reconcile_agent_restart_recovery() {
       if [[ "$status" == "failed" ]]; then
         failed_agents+=("$agent")
       fi
-    done <<<"$report"
+    done < "$_rep_tmp"
 
     declare -A recovered=()
     if (( ${#failed_agents[@]} > 0 )); then
@@ -612,7 +628,7 @@ bridge_upgrade_reconcile_agent_restart_recovery() {
           "$agent" "$status" "$reason" "$attached" "$session" \
           "$exit_code" "$log_tail_b64"
       fi
-    done <<<"$report"
+    done < "$_rep_tmp"
   ' -- "$target_root" "$source_root" "$settle_seconds" "$report"
 }
 


### PR DESCRIPTION
## Summary

`agent-bridge upgrade --apply` silently hangs on every retry when leaping from a v0.7.x install to a v0.13.x source. The patch host (Linux ec2-user, task #4526) hit this 6× in a row with no error output — Bash 5.3.9 is wedged in `read_comsub`, waiting on a pipe that never closes. Same class as footgun #11 (refs #265 / #800 / #815).

Wedge point: `bridge-upgrade.sh:251` — `python3 -c '<script>' <<<"$tags"`. Three additional sites (line 537 `grep -qE … <<<"$report"`, lines 566+615 `done <<<"$report"` inside the reconcile-recovery `-lc` body) carry the same shape and would deadlock on the same leap path.

This PR removes all 4 here-strings, replacing them with the established pipe / tempfile pattern from `lib/bridge-agents.sh:4855`. No semantic change — output is byte-identical for both the latest-tag selector and the 7-column report rewrite.

## Fix shape

| Site | Line (before) | Pattern |
| ---- | ------------- | ------- |
| 1 | `python3 ... <<<"$tags"` | Pipe `git tag` directly into `python3`, drop the intermediate `$tags` var |
| 2 | `grep -qE ... <<<"$report"` | `printf '%s\n' "$report" \| grep -qE ...` |
| 3+4 | `done <<<"$report"` ×2 inside `-lc` body | Single shared tempfile (`mktemp`), `printf "%s\n" "$report" > $_rep_tmp` matches `<<<` trailing-newline semantics, `done < "$_rep_tmp"` for both loops, `trap … EXIT` cleanup scoped to the inner subshell |

Each edit carries a `Footgun #11 (refs #265 / #800 / #815)` comment so the surface is documented and a future reader will not regress.

## Test plan

- [x] `bash -n bridge-upgrade.sh` — PASS
- [x] `shellcheck bridge-upgrade.sh` — PASS
- [x] `grep -nE '<<<' bridge-upgrade.sh` after comment-stripping — 0 operator hits
- [x] Isolated `bridge_upgrade_latest_stable_tag` over a 3-tag local repo returns `v0.13.6` in <1s with `timeout 10` (no hang)
- [x] Isolated `bridge_upgrade_reconcile_agent_restart_recovery` exercises all 3 short-circuit branches (empty / no-failed / dry-run) and exits clean — verifies the new Site 2 `printf … | grep` path
- [x] Inner `-lc` body tempfile pattern reproduces original `<<<` row-count (`total=2`, `failed=1`) on a 2-row TSV
- [ ] **Manual verification on the patch host** (operator): rerun `agent-bridge upgrade --apply` from a v0.7.6 install against this branch — expect completion in normal time, not silent hang. Required before merging.

## Scope discipline

- Single file (`bridge-upgrade.sh`), 4 sites, +23/-7.
- **No VERSION bump.** Release PR follows separately.
- Other `bridge-*.sh` / `lib/*.sh` here-strings out of scope (separate audit).
- Footgun #11 catalog already covers the class; this PR closes the upgrader instance only.

Refs operator report 2026-05-15 patch host task #4526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)