### PR TITLE
fix(upgrade): move heredoc-stdin subprocess bodies to standalone files (3rd variant)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -673,114 +673,12 @@ bridge_upgrade_agent_restart_json() {
   local enabled="$2"
   local dry_run="${3:-0}"
 
-  # JSON key contract (post-#257): dry-run reports *eligibility*, not success;
-  # apply reports the `bridge-agent.sh restart` exit-0 count, not agent health.
-  #   - restart_eligible / restart_eligible_agents: dry-run candidates. This
-  #     is what we would attempt; it does NOT predict whether the agent will
-  #     stay stably up after launch (plugin resolution, settings corruption,
-  #     dependency outages can still surface at apply).
-  #   - restart_attempted_ok / restart_attempted_ok_agents: apply tally of
-  #     `bridge-agent.sh restart` commands that returned exit 0. Does NOT
-  #     prove the agent survived the first few seconds after launch; that
-  #     requires post-restart health reconciliation (tracked in #256).
-  # The prior keys `would_restart`/`restarted` over-promised at both layers
-  # and caused the #253→#254 misdiagnosis. Renamed here per issue #257.
-  python3 - "$enabled" "$dry_run" "$report" <<'PY'
-import base64
-import json
-import sys
-
-enabled = sys.argv[1] == "1"
-dry_run = sys.argv[2] == "1"
-report = sys.argv[3]
-payload = {
-    "enabled": enabled,
-    "dry_run": dry_run,
-    "considered": 0,
-    "eligible": 0,
-    "restart_eligible": 0,
-    "restart_attempted_ok": 0,
-    "recovered_by_daemon": 0,
-    "failed": 0,
-    "skipped": 0,
-    "restart_attempted_ok_agents": [],
-    "restart_eligible_agents": [],
-    "recovered_by_daemon_agents": [],
-    "failed_agents": [],
-    "failed_details": [],
-    "recovered_by_daemon_details": [],
-    "skipped_reasons": {},
-}
-
-
-def _decode_log_tail(raw_b64):
-    """Return the decoded log-tail string or None when absent/corrupt.
-
-    Deliberately plain-Python (no PEP 604 annotation) because the
-    reference install's system python is 3.9.6 — `str | None` would
-    raise `TypeError` at function-definition time before the summary
-    ever ran. See PR #261 round-1 review.
-    """
-    if not raw_b64:
-        return None
-    try:
-        decoded = base64.b64decode(raw_b64, validate=False)
-    except Exception:  # noqa: BLE001 — b64 is operator-captured log; failing open with None is fine
-        return None
-    return decoded.decode("utf-8", errors="replace")
-
-
-for raw in report.splitlines():
-    raw = raw.rstrip("\n")
-    if not raw:
-        continue
-    # Tuple format (see bridge_upgrade_collect_agent_restart_report): 7 cols.
-    # Older builds may emit 5 cols (pre-#256); tolerate that shape so a
-    # half-upgraded host doesn't crash the aggregator.
-    parts = (raw.split("\t", 6) + ["", "", "", "", "", "", ""])[:7]
-    agent, status, reason, _attached, _session, exit_code, log_tail_b64 = parts
-    payload["considered"] += 1
-    if reason == "eligible":
-        payload["eligible"] += 1
-    if status == "would-restart":
-        payload["restart_eligible"] += 1
-        payload["restart_eligible_agents"].append(agent)
-    elif status == "restarted":
-        payload["restart_attempted_ok"] += 1
-        payload["restart_attempted_ok_agents"].append(agent)
-    elif status == "failed":
-        payload["failed"] += 1
-        payload["failed_agents"].append(agent)
-        detail = {"agent": agent, "reason": reason}
-        try:
-            detail["exit_code"] = int(exit_code) if exit_code else None
-        except ValueError:
-            detail["exit_code"] = None
-        detail["last_log_tail"] = _decode_log_tail(log_tail_b64)
-        payload["failed_details"].append(detail)
-    elif status == "recovered_by_daemon":
-        # Issue 4 (v0.11.0): daemon launched the agent after our initial
-        # restart attempt failed/timed-out. Counted separately so the
-        # operator-facing summary stops over-reporting "failed" when the
-        # daemon cycle absorbed the transient. Preserves the original
-        # reason (encoded as `daemon-recovered:was=<original>`) plus the
-        # exit_code + log_tail so the underlying issue is still
-        # diagnosable from the JSON.
-        payload["recovered_by_daemon"] += 1
-        payload["recovered_by_daemon_agents"].append(agent)
-        detail = {"agent": agent, "was_reason": reason.split("was=", 1)[-1] if "was=" in reason else reason}
-        try:
-            detail["exit_code"] = int(exit_code) if exit_code else None
-        except ValueError:
-            detail["exit_code"] = None
-        detail["last_log_tail"] = _decode_log_tail(log_tail_b64)
-        payload["recovered_by_daemon_details"].append(detail)
-    else:
-        payload["skipped"] += 1
-        payload["skipped_reasons"][reason] = payload["skipped_reasons"].get(reason, 0) + 1
-
-print(json.dumps(payload, ensure_ascii=False))
-PY
+  # JSON key contract documented at the top of
+  # lib/upgrade-helpers/agent-restart-json.py (#253/#254/#257). Footgun #11
+  # (task #4538): the python heredoc body was moved into that file because
+  # `python3 - <<'PY' … PY` heredoc-stdin wedges Bash 5.3.9 (producer-side).
+  python3 "$SOURCE_ROOT/lib/upgrade-helpers/agent-restart-json.py" \
+    "$enabled" "$dry_run" "$report"
 }
 
 bridge_upgrade_print_agent_restart_summary() {
@@ -868,68 +766,24 @@ bridge_upgrade_channel_guard_report() {
   local source_root="$1"
   local target_root="$2"
 
-  bridge_upgrade_with_target_env "$target_root" "$BRIDGE_BASH_BIN" -s -- "$source_root" "$target_root" <<'EOF'
-set -euo pipefail
-source_root="$1"
-target_root="$2"
-source "$source_root/bridge-lib.sh"
-bridge_load_roster
-
-agent=""
-session=""
-active="no"
-reason=""
-required=""
-
-for agent in "${BRIDGE_AGENT_IDS[@]}"; do
-  if [[ "$(bridge_agent_channel_status "$agent")" != "miss" ]]; then
-    continue
-  fi
-  session="$(bridge_agent_session "$agent")"
-  active="no"
-  if [[ -n "$session" ]] && bridge_tmux_session_exists "$session"; then
-    active="yes"
-  fi
-  reason="$(bridge_agent_channel_runtime_drift_reason "$agent")"
-  if [[ -z "$reason" ]]; then
-    reason="$(bridge_agent_channel_status_reason "$agent")"
-  fi
-  reason="${reason//$'\t'/ }"
-  reason="${reason//$'\n'/ }"
-  required="$(bridge_agent_channels_csv "$agent")"
-  printf "%s\t%s\t%s\t%s\n" "$agent" "$active" "$required" "$reason"
-done
-EOF
+  # Footgun #11 third variant (task #4538): the heredoc body that used to
+  # live here wedges Bash 5.3.9 in `heredoc_write -> write()` (producer-side
+  # mirror of the read_comsub bug fixed in v0.13.7 and v0.13.8). The
+  # script body now lives in lib/upgrade-helpers/channel-guard-report.sh and
+  # is invoked as a regular file argument — no heredoc-stdin anywhere on
+  # this path.
+  bridge_upgrade_with_target_env "$target_root" "$BRIDGE_BASH_BIN" \
+    "$source_root/lib/upgrade-helpers/channel-guard-report.sh" \
+    "$source_root" "$target_root"
 }
 
 bridge_upgrade_channel_guard_json() {
   local report="$1"
 
-  python3 - "$report" <<'PY'
-import json
-import sys
-
-items = []
-active_count = 0
-for raw in sys.argv[1].splitlines():
-    raw = raw.rstrip("\n")
-    if not raw:
-        continue
-    agent, active, required, reason = (raw.split("\t", 3) + ["", "", "", ""])[:4]
-    is_active = active == "yes"
-    if is_active:
-        active_count += 1
-    items.append(
-        {
-            "agent": agent,
-            "active": is_active,
-            "required_channels": required,
-            "reason": reason,
-        }
-    )
-
-print(json.dumps({"count": len(items), "active_count": active_count, "agents": items}, ensure_ascii=False))
-PY
+  # Footgun #11 (task #4538): the python heredoc body that used to live here
+  # is now lib/upgrade-helpers/channel-guard-json.py — invoked with file-as-
+  # argv so no heredoc-stdin path remains.
+  python3 "$SOURCE_ROOT/lib/upgrade-helpers/channel-guard-json.py" "$report"
 }
 
 bridge_upgrade_print_channel_guard_summary() {
@@ -1172,26 +1026,12 @@ TARGET_ROOT="$(cd -P "$(dirname "$TARGET_ROOT")" && pwd -P)/$(basename "$TARGET_
 SOURCE_ROOT="$(cd -P "$SOURCE_ROOT" && pwd -P)"
 
 if [[ $SOURCE_EXPLICIT -eq 0 && "$SOURCE_ROOT" == "$TARGET_ROOT" ]]; then
-  # Footgun #11: stage the `python3 - <<'PY' …` heredoc output via tempfile
-  # to avoid the parent-`$()`-over-heredoc-stdin Bash 5.3.9 deadlock.
-  _recorded_source_root_tmp="$(mktemp -t agb-upg-recsrc.XXXXXX)"
-  python3 - "$TARGET_ROOT/state/upgrade/last-upgrade.json" >"$_recorded_source_root_tmp" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-try:
-    payload = json.loads(path.read_text(encoding="utf-8"))
-except (FileNotFoundError, json.JSONDecodeError):
-    print("")
-    raise SystemExit(0)
-
-source = str(payload.get("source_root") or "").strip()
-print(source)
-PY
-  RECORDED_SOURCE_ROOT="$(<"$_recorded_source_root_tmp")"
-  rm -f -- "$_recorded_source_root_tmp"
+  # Footgun #11 third variant (task #4538): replace the inline `python3 -
+  # <<'PY' …` heredoc-stdin with an invocation of the standalone helper at
+  # lib/upgrade-helpers/recorded-source-root.py. The v0.13.8 tempfile-capture
+  # only fixed the consumer-side `$()` deadlock; the inner heredoc-stdin to
+  # python still wedges Bash 5.3.9 in `heredoc_write -> write()`.
+  RECORDED_SOURCE_ROOT="$(python3 "$SOURCE_ROOT/lib/upgrade-helpers/recorded-source-root.py" "$TARGET_ROOT/state/upgrade/last-upgrade.json")"
   if [[ -n "$RECORDED_SOURCE_ROOT" && -d "$RECORDED_SOURCE_ROOT/.git" ]]; then
     SOURCE_ROOT="$(cd -P "$RECORDED_SOURCE_ROOT" && pwd -P)"
     if [[ "$SUBCOMMAND" == "apply" && $PULL_EXPLICIT -eq 0 ]]; then
@@ -1594,27 +1434,22 @@ if [[ $DRY_RUN -eq 0 ]]; then
   # forwards BRIDGE_LAYOUT_RESOLVER_BYPASS{,_OWNER_PID} explicitly so
   # the resolver inside the child still validates the handshake — the
   # process-tree walk traverses env → bash → upgrade.sh and matches.
-  # Footgun #11 (refs #890 / task #4532): the outer `$()` capture combined
-  # with `bash -s -- … <<'EOF' …` heredoc-fed stdin is the same shape that
-  # wedges Bash 5.3.9 in `read_comsub`. Stage stdout through a tempfile and
-  # read it back via `$(< file)` (bash builtin shortcut — no subshell
-  # fork, cannot wedge). The structural `set +e ; … ; rc=$? ; set -e`
-  # frame stays intact so the existing failure-handling block below still
-  # captures rc correctly.
+  # Footgun #11 third variant (task #4538): the v0.13.8 hotfix moved the
+  # `$()` capture to a tempfile but left the inner `bash -s -- … <<'EOF' …`
+  # heredoc-stdin in place. Bash 5.3.9 still wedges the parent in
+  # `heredoc_write -> write()` when the bash -s subprocess is slow to drain
+  # (sourcing bridge-lib.sh + lib/bridge-isolation-v2-migrate.sh before the
+  # heredoc write completes). The migration body now lives at
+  # lib/upgrade-helpers/isolation-v2-migrate.sh and is invoked with the file
+  # as argv — no heredoc-stdin anywhere on this path. The tempfile + `$(<)`
+  # capture is kept for symmetry with the failure-handling frame and so
+  # `_migrate_rc=$?` captures the bash exit code, not mktemp/rm.
   set +e
   _iso_v2_migrate_tmp="$(mktemp -t agb-upg-isov2.XXXXXX)"
   bridge_upgrade_with_target_env "$TARGET_ROOT" \
-    "$BRIDGE_BASH_BIN" -s -- "$SOURCE_ROOT" "$TARGET_ROOT" >"$_iso_v2_migrate_tmp" <<'EOF'
-set -euo pipefail
-source_root="$1"
-target_root="$2"
-# shellcheck source=/dev/null
-source "$source_root/bridge-lib.sh"
-bridge_load_roster
-# shellcheck source=lib/bridge-isolation-v2-migrate.sh
-source "$source_root/lib/bridge-isolation-v2-migrate.sh"
-bridge_isolation_v2_migrate_apply_for_upgrade --target-root "$target_root" --json
-EOF
+    "$BRIDGE_BASH_BIN" \
+    "$SOURCE_ROOT/lib/upgrade-helpers/isolation-v2-migrate.sh" \
+    "$SOURCE_ROOT" "$TARGET_ROOT" >"$_iso_v2_migrate_tmp"
   _migrate_rc=$?
   ISOLATION_V2_MIGRATION_JSON="$(<"$_iso_v2_migrate_tmp")"
   rm -f -- "$_iso_v2_migrate_tmp"

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -155,8 +155,17 @@ bridge_upgrade_emit_failure_json() {
   fi
   # Pass values via argv (escapes safely for any input — newlines, quotes,
   # unicode). Empty strings are forwarded as-is and rendered as null in the
-  # envelope when the corresponding bash var was empty.
-  if ! python3 - \
+  # envelope when the corresponding bash var was empty. Footgun #11 third
+  # variant (task #4538 codex r1 catch): body moved to
+  # lib/upgrade-helpers/emit-failure-json.py so the EXIT trap path no longer
+  # has a heredoc-stdin-to-python wedge candidate when the leap aborts
+  # pre-apply (e.g. isolation-v2 failure at lines ~1457-1469). The fallback
+  # printf below still fires if the helper script is missing or python is
+  # broken on the host. SOURCE_ROOT may be unset when this runs very early
+  # (before the source-root resolution block); fall back to SCRIPT_DIR which
+  # is set at script entry so the helper path always resolves.
+  local _emit_helper="${SOURCE_ROOT:-${SCRIPT_DIR:-}}/lib/upgrade-helpers/emit-failure-json.py"
+  if ! python3 "$_emit_helper" \
         "$rc" \
         "$reason" \
         "$detail" \
@@ -172,47 +181,7 @@ bridge_upgrade_emit_failure_json() {
         "${TARGET_HEAD:-}" \
         "${DRY_RUN:-0}" \
         "${ISOLATION_V2_MIGRATION_JSON:-}" \
-        <<'PY' 2>/dev/null
-import json, sys
-
-(rc, reason, detail, remediation,
- source_version, source_root, source_ref, source_head,
- target_root, channel, target_ref, target_version, target_head,
- dry_run, iso_v2_json) = sys.argv[1:16]
-
-def _or_none(s):
-    return s if s else None
-
-def _load_json_str(s):
-    if not s:
-        return None
-    try:
-        return json.loads(s)
-    except (ValueError, TypeError):
-        return {"_raw": s, "_parse_error": True}
-
-payload = {
-    "mode": "upgrade",
-    "rc": int(rc),
-    "error": {
-        "reason": reason,
-        "detail": detail,
-        "remediation": remediation,
-    },
-    "version": _or_none(source_version),
-    "source_root": _or_none(source_root),
-    "source_ref": _or_none(source_ref),
-    "source_head": _or_none(source_head),
-    "target_root": _or_none(target_root),
-    "channel": _or_none(channel),
-    "target_ref": _or_none(target_ref),
-    "target_version": _or_none(target_version),
-    "target_head": _or_none(target_head),
-    "dry_run": dry_run == "1",
-    "isolation_v2_migration": _load_json_str(iso_v2_json),
-}
-print(json.dumps(payload, ensure_ascii=False, indent=2))
-PY
+        2>/dev/null
   then
     # Fallback: minimal hand-rolled JSON if python invocation fails
     # entirely. Operators still get a parseable envelope.

--- a/lib/upgrade-helpers/agent-restart-json.py
+++ b/lib/upgrade-helpers/agent-restart-json.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""agent-restart-json.py — convert the tab-separated agent-restart report
+into the JSON structure embedded by `bridge_upgrade_agent_restart_json`.
+
+Invocation contract:
+    sys.argv[1] = enabled ("1" / anything else)
+    sys.argv[2] = dry_run ("1" / anything else)
+    sys.argv[3] = report (multi-line tab-separated string, see
+                          `bridge_upgrade_collect_agent_restart_report`
+                          for the 7-column tuple format)
+
+Output: a single JSON document on stdout.
+
+JSON key contract (post-#257): dry-run reports *eligibility*, not success;
+apply reports the `bridge-agent.sh restart` exit-0 count, not agent health.
+  - restart_eligible / restart_eligible_agents: dry-run candidates. This
+    is what we would attempt; it does NOT predict whether the agent will
+    stay stably up after launch (plugin resolution, settings corruption,
+    dependency outages can still surface at apply).
+  - restart_attempted_ok / restart_attempted_ok_agents: apply tally of
+    `bridge-agent.sh restart` commands that returned exit 0. Does NOT
+    prove the agent survived the first few seconds after launch; that
+    requires post-restart health reconciliation (tracked in #256).
+The prior keys `would_restart`/`restarted` over-promised at both layers
+and caused the #253→#254 misdiagnosis. Renamed here per issue #257.
+
+Footgun #11 (task #4538): this body used to live as a `python3 - <<'PY' … PY`
+heredoc-stdin inside bridge_upgrade_agent_restart_json. Moved to a standalone
+file to remove the heredoc-stdin path that wedges Bash 5.3.9.
+"""
+
+import base64
+import json
+import sys
+
+enabled = sys.argv[1] == "1"
+dry_run = sys.argv[2] == "1"
+report = sys.argv[3]
+payload = {
+    "enabled": enabled,
+    "dry_run": dry_run,
+    "considered": 0,
+    "eligible": 0,
+    "restart_eligible": 0,
+    "restart_attempted_ok": 0,
+    "recovered_by_daemon": 0,
+    "failed": 0,
+    "skipped": 0,
+    "restart_attempted_ok_agents": [],
+    "restart_eligible_agents": [],
+    "recovered_by_daemon_agents": [],
+    "failed_agents": [],
+    "failed_details": [],
+    "recovered_by_daemon_details": [],
+    "skipped_reasons": {},
+}
+
+
+def _decode_log_tail(raw_b64):
+    """Return the decoded log-tail string or None when absent/corrupt.
+
+    Deliberately plain-Python (no PEP 604 annotation) because the
+    reference install's system python is 3.9.6 — `str | None` would
+    raise `TypeError` at function-definition time before the summary
+    ever ran. See PR #261 round-1 review.
+    """
+    if not raw_b64:
+        return None
+    try:
+        decoded = base64.b64decode(raw_b64, validate=False)
+    except Exception:  # noqa: BLE001 — b64 is operator-captured log; failing open with None is fine
+        return None
+    return decoded.decode("utf-8", errors="replace")
+
+
+for raw in report.splitlines():
+    raw = raw.rstrip("\n")
+    if not raw:
+        continue
+    # Tuple format (see bridge_upgrade_collect_agent_restart_report): 7 cols.
+    # Older builds may emit 5 cols (pre-#256); tolerate that shape so a
+    # half-upgraded host doesn't crash the aggregator.
+    parts = (raw.split("\t", 6) + ["", "", "", "", "", "", ""])[:7]
+    agent, status, reason, _attached, _session, exit_code, log_tail_b64 = parts
+    payload["considered"] += 1
+    if reason == "eligible":
+        payload["eligible"] += 1
+    if status == "would-restart":
+        payload["restart_eligible"] += 1
+        payload["restart_eligible_agents"].append(agent)
+    elif status == "restarted":
+        payload["restart_attempted_ok"] += 1
+        payload["restart_attempted_ok_agents"].append(agent)
+    elif status == "failed":
+        payload["failed"] += 1
+        payload["failed_agents"].append(agent)
+        detail = {"agent": agent, "reason": reason}
+        try:
+            detail["exit_code"] = int(exit_code) if exit_code else None
+        except ValueError:
+            detail["exit_code"] = None
+        detail["last_log_tail"] = _decode_log_tail(log_tail_b64)
+        payload["failed_details"].append(detail)
+    elif status == "recovered_by_daemon":
+        # Issue 4 (v0.11.0): daemon launched the agent after our initial
+        # restart attempt failed/timed-out. Counted separately so the
+        # operator-facing summary stops over-reporting "failed" when the
+        # daemon cycle absorbed the transient. Preserves the original
+        # reason (encoded as `daemon-recovered:was=<original>`) plus the
+        # exit_code + log_tail so the underlying issue is still
+        # diagnosable from the JSON.
+        payload["recovered_by_daemon"] += 1
+        payload["recovered_by_daemon_agents"].append(agent)
+        detail = {"agent": agent, "was_reason": reason.split("was=", 1)[-1] if "was=" in reason else reason}
+        try:
+            detail["exit_code"] = int(exit_code) if exit_code else None
+        except ValueError:
+            detail["exit_code"] = None
+        detail["last_log_tail"] = _decode_log_tail(log_tail_b64)
+        payload["recovered_by_daemon_details"].append(detail)
+    else:
+        payload["skipped"] += 1
+        payload["skipped_reasons"][reason] = payload["skipped_reasons"].get(reason, 0) + 1
+
+print(json.dumps(payload, ensure_ascii=False))

--- a/lib/upgrade-helpers/channel-guard-json.py
+++ b/lib/upgrade-helpers/channel-guard-json.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""channel-guard-json.py — convert the tab-separated channel-guard report
+into the JSON structure embedded by `bridge_upgrade_channel_guard_json`.
+
+Invocation contract:
+    sys.argv[1] = report (multi-line tab-separated string;
+                          each row: "<agent>\\t<active>\\t<required>\\t<reason>")
+
+Output: a single JSON document on stdout.
+
+Footgun #11 (task #4538): this body used to live as a `python3 - <<'PY' … PY`
+heredoc-stdin inside bridge_upgrade_channel_guard_json. Moved to a standalone
+file to remove the heredoc-stdin path that wedges Bash 5.3.9.
+"""
+
+import json
+import sys
+
+items = []
+active_count = 0
+for raw in sys.argv[1].splitlines():
+    raw = raw.rstrip("\n")
+    if not raw:
+        continue
+    agent, active, required, reason = (raw.split("\t", 3) + ["", "", "", ""])[:4]
+    is_active = active == "yes"
+    if is_active:
+        active_count += 1
+    items.append(
+        {
+            "agent": agent,
+            "active": is_active,
+            "required_channels": required,
+            "reason": reason,
+        }
+    )
+
+print(
+    json.dumps(
+        {"count": len(items), "active_count": active_count, "agents": items},
+        ensure_ascii=False,
+    )
+)

--- a/lib/upgrade-helpers/channel-guard-report.sh
+++ b/lib/upgrade-helpers/channel-guard-report.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# channel-guard-report.sh — generate the channel-guard report table consumed
+# by bridge_upgrade_channel_guard_json.
+#
+# Invocation contract:
+#   $1 = source_root  (the agent-bridge source checkout)
+#   $2 = target_root  (the live install root being upgraded)
+#
+# Output: tab-separated rows (one per agent with a "miss" channel status):
+#   <agent>\t<active>\t<required_channels>\t<reason>
+#
+# Footgun #11 third variant (task #4538): this body used to live as a
+# `bridge_upgrade_with_target_env … bash -s -- … <<'EOF' … EOF` heredoc-stdin
+# inside bridge_upgrade_channel_guard_report. Bash 5.3.9 wedges the parent in
+# `heredoc_write -> write()` when sending the heredoc body to the bash -s
+# subprocess (producer-side mirror of the read_comsub bug fixed in v0.13.7
+# and v0.13.8). Moving the script body to a regular file and invoking it via
+# `bash $0 args` removes the heredoc-stdin path entirely.
+
+set -euo pipefail
+
+source_root="$1"
+target_root="$2"
+
+# shellcheck source=/dev/null
+source "$source_root/bridge-lib.sh"
+bridge_load_roster
+
+agent=""
+session=""
+active="no"
+reason=""
+required=""
+
+for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+  if [[ "$(bridge_agent_channel_status "$agent")" != "miss" ]]; then
+    continue
+  fi
+  session="$(bridge_agent_session "$agent")"
+  active="no"
+  if [[ -n "$session" ]] && bridge_tmux_session_exists "$session"; then
+    active="yes"
+  fi
+  reason="$(bridge_agent_channel_runtime_drift_reason "$agent")"
+  if [[ -z "$reason" ]]; then
+    reason="$(bridge_agent_channel_status_reason "$agent")"
+  fi
+  reason="${reason//$'\t'/ }"
+  reason="${reason//$'\n'/ }"
+  required="$(bridge_agent_channels_csv "$agent")"
+  printf "%s\t%s\t%s\t%s\n" "$agent" "$active" "$required" "$reason"
+done
+
+# silence shellcheck SC2034 for $target_root — kept in the signature for
+# future use and parity with the prior heredoc body.
+: "$target_root"

--- a/lib/upgrade-helpers/emit-failure-json.py
+++ b/lib/upgrade-helpers/emit-failure-json.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""emit-failure-json.py — render the failure-JSON envelope emitted by
+`bridge_upgrade_emit_failure_json` when the upgrader exits non-zero before
+reaching the success/dry-run JSON emission point.
+
+Invocation contract (argv[1:16]):
+    rc, reason, detail, remediation,
+    source_version, source_root, source_ref, source_head,
+    target_root, channel, target_ref, target_version, target_head,
+    dry_run, iso_v2_json
+
+Output: a single pretty-printed JSON document on stdout (indent=2).
+
+Footgun #11 third variant (task #4538 codex r1 catch): this body used to live
+as a `python3 - <<'PY' … PY` heredoc-stdin inside bridge_upgrade_emit_failure_json.
+The function is invoked by the EXIT trap on non-zero exits — including
+pre-apply isolation-v2 aborts at bridge-upgrade.sh:1457-1469 — so a heredoc
+wedge there would mask the actual failure with a hang. Moved to a standalone
+file to remove the heredoc-stdin path.
+"""
+
+import json
+import sys
+
+(
+    rc,
+    reason,
+    detail,
+    remediation,
+    source_version,
+    source_root,
+    source_ref,
+    source_head,
+    target_root,
+    channel,
+    target_ref,
+    target_version,
+    target_head,
+    dry_run,
+    iso_v2_json,
+) = sys.argv[1:16]
+
+
+def _or_none(s):
+    return s if s else None
+
+
+def _load_json_str(s):
+    if not s:
+        return None
+    try:
+        return json.loads(s)
+    except (ValueError, TypeError):
+        return {"_raw": s, "_parse_error": True}
+
+
+payload = {
+    "mode": "upgrade",
+    "rc": int(rc),
+    "error": {
+        "reason": reason,
+        "detail": detail,
+        "remediation": remediation,
+    },
+    "version": _or_none(source_version),
+    "source_root": _or_none(source_root),
+    "source_ref": _or_none(source_ref),
+    "source_head": _or_none(source_head),
+    "target_root": _or_none(target_root),
+    "channel": _or_none(channel),
+    "target_ref": _or_none(target_ref),
+    "target_version": _or_none(target_version),
+    "target_head": _or_none(target_head),
+    "dry_run": dry_run == "1",
+    "isolation_v2_migration": _load_json_str(iso_v2_json),
+}
+print(json.dumps(payload, ensure_ascii=False, indent=2))

--- a/lib/upgrade-helpers/emit-failure-json.py
+++ b/lib/upgrade-helpers/emit-failure-json.py
@@ -17,33 +17,20 @@ The function is invoked by the EXIT trap on non-zero exits — including
 pre-apply isolation-v2 aborts at bridge-upgrade.sh:1457-1469 — so a heredoc
 wedge there would mask the actual failure with a hang. Moved to a standalone
 file to remove the heredoc-stdin path.
+
+Body kept byte-for-byte (modulo this header docstring) with the prior heredoc
+at bridge-upgrade.sh:175-215 (v0.13.8) per codex r2 review on PR #894.
 """
 
-import json
-import sys
+import json, sys
 
-(
-    rc,
-    reason,
-    detail,
-    remediation,
-    source_version,
-    source_root,
-    source_ref,
-    source_head,
-    target_root,
-    channel,
-    target_ref,
-    target_version,
-    target_head,
-    dry_run,
-    iso_v2_json,
-) = sys.argv[1:16]
-
+(rc, reason, detail, remediation,
+ source_version, source_root, source_ref, source_head,
+ target_root, channel, target_ref, target_version, target_head,
+ dry_run, iso_v2_json) = sys.argv[1:16]
 
 def _or_none(s):
     return s if s else None
-
 
 def _load_json_str(s):
     if not s:
@@ -52,7 +39,6 @@ def _load_json_str(s):
         return json.loads(s)
     except (ValueError, TypeError):
         return {"_raw": s, "_parse_error": True}
-
 
 payload = {
     "mode": "upgrade",

--- a/lib/upgrade-helpers/isolation-v2-migrate.sh
+++ b/lib/upgrade-helpers/isolation-v2-migrate.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# isolation-v2-migrate.sh — apply the v0.8.0 T3 isolation-v2 migration as
+# part of an upgrade run. Invoked by bridge-upgrade.sh via
+# `bridge_upgrade_with_target_env $TARGET_ROOT $BRIDGE_BASH_BIN $0 $SOURCE_ROOT $TARGET_ROOT`.
+#
+# Invocation contract:
+#   $1 = source_root  (the agent-bridge source checkout)
+#   $2 = target_root  (the live install root being upgraded)
+#
+# Output: a single JSON document on stdout describing the migration outcome
+#         (see `bridge_isolation_v2_migrate_apply_for_upgrade --json` for the
+#         schema).
+#
+# Footgun #11 third variant (task #4538): this body used to live as a
+# `bridge_upgrade_with_target_env … bash -s -- … <<'EOF' … EOF` heredoc-stdin
+# inline in bridge-upgrade.sh. Bash 5.3.9 wedges the parent in
+# `heredoc_write -> write()` when the bash -s subprocess sources bridge-lib.sh
+# + lib/bridge-isolation-v2-migrate.sh before the heredoc-write completes.
+# Moving the body to a regular file removes the heredoc-stdin path entirely.
+
+set -euo pipefail
+
+source_root="$1"
+target_root="$2"
+
+# shellcheck source=/dev/null
+source "$source_root/bridge-lib.sh"
+bridge_load_roster
+# shellcheck source=lib/bridge-isolation-v2-migrate.sh
+source "$source_root/lib/bridge-isolation-v2-migrate.sh"
+bridge_isolation_v2_migrate_apply_for_upgrade --target-root "$target_root" --json

--- a/lib/upgrade-helpers/recorded-source-root.py
+++ b/lib/upgrade-helpers/recorded-source-root.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""recorded-source-root.py — read the recorded source_root from a previous
+upgrade's last-upgrade.json. Used by bridge-upgrade.sh when SOURCE_ROOT and
+TARGET_ROOT collapse to the same path so the upgrader can recover the
+original source checkout.
+
+Invocation contract:
+    sys.argv[1] = path to <target_root>/state/upgrade/last-upgrade.json
+
+Output: the recorded source_root string on stdout (empty string when the
+        file is missing, unreadable, or has no source_root field).
+
+Footgun #11 (task #4538): this body used to live as a `python3 - <<'PY' … PY`
+heredoc-stdin inline in bridge-upgrade.sh. Moved to a standalone file to
+remove the heredoc-stdin path that wedges Bash 5.3.9.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+try:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+except (FileNotFoundError, json.JSONDecodeError):
+    print("")
+    raise SystemExit(0)
+
+source = str(payload.get("source_root") or "").strip()
+print(source)


### PR DESCRIPTION
## Summary

- v0.13.8 still hangs on patch (task #4538). v0.13.7's `<<<` fix and v0.13.8's `$()`-capture-via-tempfile fix together closed two variants of the Bash 5.3.9 `read_comsub` / `heredoc_write` bug. The **third variant** is the **producer-side** wedge: parent bash blocks in `heredoc_write -> write()` when feeding a heredoc body to a child whose startup is slow (sourcing `bridge-lib.sh` + `bridge_load_roster` before draining the pipe).
- Wedge confirmed by patch at `bridge-upgrade.sh:871` — the inner `bridge_upgrade_with_target_env $BASH -s -- ... <<'EOF' ... EOF` heredoc-stdin inside `bridge_upgrade_channel_guard_report`. v0.13.8 capture_to_var helper verified working; the problem is upstream of it.
- Robust fix: remove the heredoc-stdin path entirely. Every leap-path heredoc-stdin body is moved to a standalone file under `lib/upgrade-helpers/` and invoked as a regular file argument.

## Files added

| File | Replaces |
|---|---|
| `lib/upgrade-helpers/channel-guard-report.sh` | bash heredoc in `channel_guard_report` (line 871 wedge) |
| `lib/upgrade-helpers/channel-guard-json.py` | python heredoc in `channel_guard_json` |
| `lib/upgrade-helpers/agent-restart-json.py` | python heredoc in `agent_restart_json` |
| `lib/upgrade-helpers/recorded-source-root.py` | inline python heredoc at line 1175 |
| `lib/upgrade-helpers/isolation-v2-migrate.sh` | inline bash heredoc at line ~1595 |

Each helper file is invoked as `bash $SOURCE_ROOT/lib/upgrade-helpers/<file>.sh <args>` or `python3 ... .py <args>`. No heredoc-stdin anywhere on the leap path.

## Functions intentionally NOT migrated

- `bridge_upgrade_installed_field`: heredoc python but only called in `--check-only` block (not on apply path), tiny single-field output.
- All other `python3 - <<'PY' …` patterns inside `--check` JSON output, `--analyze`, `--rollback`, and final JSON envelope. None are on the apply-time wedge path.

If a post-apply python heredoc wedges in a future scenario, follow up in v0.13.10. The **leap path** is now free of heredoc-stdin-to-subprocess patterns entirely.

## Test plan

- [x] `bash -n bridge-upgrade.sh` — PASS
- [x] `bash -n lib/upgrade-helpers/*.sh` — PASS
- [x] `shellcheck bridge-upgrade.sh lib/upgrade-helpers/*.sh` — PASS (no findings)
- [x] `python3 -c 'import ast; ast.parse(...)' lib/upgrade-helpers/*.py` — PASS
- [x] Functional smoke: `channel-guard-json.py` with 2-row report → correct JSON output
- [x] Functional smoke: `recorded-source-root.py` with missing file → empty stdout (graceful)
- [x] Audit: python regex walk for remaining `(bash -s|python3 -)\b.*<<'?[A-Z]+'?\s*$` patterns on the leap path → 0 sites (3 hits are all comments)
- [ ] **Operator-host leap retry** (patch, Linux ec2-user, Bash 5.3.9, v0.7.6 → v0.13.9 leap) — required before release sign-off. Third cycle of this bug class; must reach `apply-live` successfully.

## Refs

PR #890, PR #892, task #4526, task #4532, task #4538, footgun #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)