### PR TITLE
fix(upgrade): markerless-existing-install marker-only migrate path (Track A v0.13.10)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -299,6 +299,7 @@ bridge_upgrade_with_target_env() {
     BRIDGE_DISCORD_RELAY_STATE_FILE="$target_root/state/discord-relay.json" \
     BRIDGE_LAYOUT_RESOLVER_BYPASS="${BRIDGE_LAYOUT_RESOLVER_BYPASS:-}" \
     BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID="${BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID:-}" \
+    BRIDGE_UPGRADE_CONTEXT="${BRIDGE_UPGRADE_CONTEXT:-}" \
     "$@"
 }
 
@@ -1415,6 +1416,13 @@ if [[ $DRY_RUN -eq 0 ]]; then
   # `_migrate_rc=$?` captures the bash exit code, not mktemp/rm.
   set +e
   _iso_v2_migrate_tmp="$(mktemp -t agb-upg-isov2.XXXXXX)"
+  # v0.13.10: BRIDGE_UPGRADE_CONTEXT=1 signals
+  # `bridge_isolation_v2_migrate_apply_for_upgrade` that the caller is the
+  # upgrader (vs. a direct `agent-bridge migrate isolation v2 --apply` run)
+  # so it can take the markerless-existing-install + no-isolated-roster
+  # marker-only fast-path. The env var must be propagated through
+  # `bridge_upgrade_with_target_env`'s `env -i` filter.
+  BRIDGE_UPGRADE_CONTEXT=1 \
   bridge_upgrade_with_target_env "$TARGET_ROOT" \
     "$BRIDGE_BASH_BIN" \
     "$SOURCE_ROOT/lib/upgrade-helpers/isolation-v2-migrate.sh" \

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -1378,6 +1378,51 @@ bridge_isolation_v2_migrate_marker_remove() {
   rm -f "$marker_path"
 }
 
+# v0.13.10: marker-only write for the markerless-existing-install +
+# no-isolated-roster upgrade fast-path. Same on-disk bytes as the full
+# `bridge_isolation_v2_migrate_marker_write` (BRIDGE_LAYOUT=v2 +
+# BRIDGE_DATA_ROOT=<path>), validator-compatible, but skips the
+# `_bridge_isolation_v2_run_root_or_sudo chown root:<group>` step that
+# requires passwordless sudo on Linux and `dseditgroup` on macOS. Used
+# only from `bridge_isolation_v2_migrate_apply_for_upgrade` when:
+#   - the caller is the upgrade flow (BRIDGE_UPGRADE_CONTEXT=1), AND
+#   - the roster has zero linux-user-isolated agents (rc=1 from
+#     bridge_isolation_v2_roster_has_isolated_agents).
+# The marker bytes are wire-compatible with markers written by the full
+# migrate path; the validator's owner check passes via the
+# `owner_uid == current controller UID` second branch in
+# bridge_isolation_v2_marker_validate.
+bridge_isolation_v2_migrate_marker_write_minimal() {
+  local data_root="$1"
+  [[ -n "$data_root" && "${data_root:0:1}" == "/" ]] || {
+    bridge_warn "marker_write_minimal: --data-root <abs-path> required"
+    return 1
+  }
+
+  local marker_path
+  marker_path="$(bridge_isolation_v2_marker_path)"
+
+  bridge_isolation_v2_migrate_mkstate
+  install -d -m 0750 "$(dirname "$marker_path")" 2>/dev/null \
+    || mkdir -p "$(dirname "$marker_path")"
+
+  local tmp="${marker_path}.tmp.$$"
+  {
+    printf 'BRIDGE_LAYOUT=%s\n' "$(printf %q "v2")"
+    printf 'BRIDGE_DATA_ROOT=%s\n' "$(printf %q "$data_root")"
+  } > "$tmp" || { rm -f "$tmp"; bridge_warn "marker_write_minimal: write to $tmp failed"; return 1; }
+
+  chmod 0640 "$tmp" || { rm -f "$tmp"; bridge_warn "marker_write_minimal: chmod failed"; return 1; }
+  mv -f "$tmp" "$marker_path" || { bridge_warn "marker_write_minimal: mv to $marker_path failed"; return 1; }
+
+  if ! bridge_isolation_v2_marker_validate "$marker_path"; then
+    rm -f "$marker_path"
+    bridge_warn "marker_write_minimal: marker validation failed after write — removed"
+    return 1
+  fi
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # 10. legacy data path enumeration (commit candidate filter)
 # ---------------------------------------------------------------------------
@@ -1770,17 +1815,89 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
   # take the skip branch silently — bypassing the preflight check.
   local _iso_check_rc=0
   bridge_isolation_v2_roster_has_isolated_agents 2>/dev/null || _iso_check_rc=$?
+
+  local data_root="${BRIDGE_DATA_ROOT:-$target_root}"
+  local marker_path
+  marker_path="$(bridge_isolation_v2_marker_path 2>/dev/null || \
+    printf '%s/state/layout-marker.sh' "$target_root")"
+
+  # v0.13.10: markerless-existing-install + no-isolated-roster fast-path.
+  #
+  # The v0.8.0+ layout resolver rejects `markerless(existing-install)` and
+  # tells the operator to run `agent-bridge upgrade --apply`. The upgrader
+  # is supposed to write the marker as part of this migrate step, but
+  # before v0.13.10 the marker-write path was gated behind
+  # `bridge_isolation_v2_privilege_preflight` (needs root or passwordless
+  # sudo) and behind group ops that require `dseditgroup` (macOS) or
+  # `groupadd`/`usermod` (Linux). A v0.7.x → v0.13.x leap on a single-OS-
+  # user host with no isolated agents would therefore either:
+  #   - hit the macos-shared-agent skip below (status=ok, but marker NOT
+  #     written), so the next boot still hits the layout-resolver reject; OR
+  #   - fail privilege preflight on Linux without sudo (same outcome).
+  #
+  # The minimum semantic change needed to unblock the leap is to write the
+  # v2 marker — the marker is metadata. Without isolated agents, no
+  # group/setgid/ownership operations are required for correctness:
+  #   - `shared`-mode agents do not depend on `ab-agent-<slug>` groups.
+  #   - the marker bytes are wire-compatible with the full-migrate marker.
+  #   - the operator's later `agent-bridge agent add --isolated <name>`
+  #     flow handles group setup at THAT point (with its own sudo check).
+  #
+  # Guard:
+  #   - BRIDGE_UPGRADE_CONTEXT=1 — only fire when invoked by the upgrader
+  #     (preserves existing semantics for direct
+  #     `agent-bridge migrate isolation v2 --apply` calls, which keep the
+  #     macos-shared-agent skip below).
+  #   - _iso_check_rc == 1 — confirmed-no-isolated (rc=2 unknown falls
+  #     through to the existing preflight so the operator gets actionable
+  #     remediation rather than a silent metadata-only success).
+  #   - marker NOT already valid — if a valid marker exists, the next
+  #     branch (marker-present skip) handles idempotency + normalize_layout
+  #     refresh. We must not pre-empt that path.
+  if [[ "${BRIDGE_UPGRADE_CONTEXT:-0}" == "1" \
+        && "$_iso_check_rc" -eq 1 ]] \
+      && { [[ ! -f "$marker_path" ]] \
+           || ! bridge_isolation_v2_marker_validate "$marker_path" 2>/dev/null; }; then
+    if bridge_isolation_v2_migrate_marker_write_minimal "$data_root"; then
+      printf '{"mode":"isolation-v2-migrate","status":"ok","skipped":false,"reason":"marker-only-no-isolated-roster","marker":"%s","data_root":"%s","group_ops":"skipped","platform":"%s"}\n' \
+        "$marker_path" "$data_root" "$(uname -s 2>/dev/null || printf 'unknown')"
+      return 0
+    fi
+    # Fall through on write failure — `bridge_warn` already fired inside
+    # the helper. The existing preflight/migration body below will emit
+    # its own structured error so the operator sees one canonical
+    # last_error rather than a duplicate marker-write warning.
+  fi
+
+  # v0.13.6 hotfix track 4: silent no-op on macOS shared-agent installs.
+  # The isolation-v2 layout (group + setgid + named-UID ownership) only
+  # has operational effect on Linux hosts where agents run under their
+  # own `agent-bridge-<slug>` UIDs. On a single-OS-user host with no
+  # isolated agents (the macOS dev pattern), the migration's chgrp/chmod
+  # work has no effect and `bridge_isolation_v2_privilege_preflight`
+  # demands passwordless sudo just to perform that no-op — which aborts
+  # the upgrade when the operator (correctly) declines the prompt.
+  # Skip the entire migration body in that case and emit a benign no-op
+  # JSON. The branch is idempotent: every subsequent upgrade hits the
+  # same gate.
+  #
+  # `bridge_isolation_v2_roster_has_isolated_agents` returns:
+  #   0 — has isolated agent (do NOT skip, fall through to migration)
+  #   1 — confirmed no isolated agent (safe to skip on non-Linux)
+  #   2 — unknown / predicate or roster array unavailable (do NOT skip,
+  #       fall through so the existing preflight path emits its own
+  #       error and the operator gets actionable remediation)
+  #
+  # codex r1 needs-more catch (PR #882 r2): treat rc=1 (confirmed) and
+  # rc=2 (unknown) differently. Original logic merged both via `!cmd`
+  # which would have let a Darwin host with a broken roster predicate
+  # take the skip branch silently — bypassing the preflight check.
   if [[ "$(uname -s 2>/dev/null || printf 'unknown')" != "Linux" \
         && "$_iso_check_rc" -eq 1 ]]; then
     printf '{"mode":"isolation-v2-migrate","status":"ok","skipped":true,"reason":"macos-shared-agent","platform":"%s","no_v080_code_installed":"yes"}\n' \
       "$(uname -s 2>/dev/null || printf 'unknown')"
     return 0
   fi
-
-  local data_root="${BRIDGE_DATA_ROOT:-$target_root}"
-  local marker_path
-  marker_path="$(bridge_isolation_v2_marker_path 2>/dev/null || \
-    printf '%s/state/layout-marker.sh' "$target_root")"
 
   # Idempotent skip: marker already present + valid -> already migrated.
   # v0.8.4 r2: even on the skip path, run normalize_layout so existing

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir
 }
 
 add_all_integration() {
@@ -299,7 +299,13 @@ select_for_path() {
       # dotenv migrator lives in lib/bridge-isolation-v3-channel-dotenv.sh
       # and depends directly on v2-reapply primitives; pull its smoke
       # for every isolation-lib + bridge-migrate.sh move.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
+      # PR #897 (v0.13.10 Track A): `bridge_isolation_v2_migrate_apply_for_upgrade`'s
+      # markerless-existing-install + no-isolated-roster fast-path lives
+      # in lib/bridge-isolation-v2-migrate.sh; pull its regression smoke
+      # (T1-T5 marker-write contract + T6 post-marker workdir resolver)
+      # for every isolation-lib + bridge-migrate.sh move so the fast-path
+      # stays covered.
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -390,7 +396,14 @@ select_for_path() {
       # bridge-upgrade.sh's [upgrade-complete] task body composer; pull
       # its regression smoke in whenever the upgrade entry moves so the
       # task body cannot regress to leaking raw JSONDecodeError text.
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872
+      # PR #897 (v0.13.10 Track A): bridge-upgrade.sh sets
+      # `BRIDGE_UPGRADE_CONTEXT=1` on the isolation-v2 migrate call and
+      # propagates it through `bridge_upgrade_with_target_env`'s `env -i`
+      # filter; the env var gates the markerless-existing-install
+      # marker-only fast-path. Pull the regression smoke (T3 specifically
+      # asserts the env-propagation contract — fast-path NOT fired when
+      # BRIDGE_UPGRADE_CONTEXT is unset) whenever the upgrade entry moves.
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10674,6 +10674,15 @@ bash "$REPO_ROOT/scripts/smoke/agent-doctor.sh"
 log "running isolation-v2-migrate-lock-portability smoke (v0.8.1 hotfix)"
 bash "$REPO_ROOT/scripts/smoke/isolation-v2-migrate-lock-portability.sh"
 
+# v0.13.10 Track A regression smoke — verifies the marker-only fast-path
+# in bridge_isolation_v2_migrate_apply_for_upgrade: a markerless install
+# with no isolated agents that runs under BRIDGE_UPGRADE_CONTEXT=1 must
+# write the v2 marker without invoking sudo / group ops, and the gating
+# must hold for the non-upgrade context, has-isolated rosters, and
+# rc=2 (unknown) roster predicates.
+log "running isolation-v2-marker-only-migrate smoke (v0.13.10 Track A)"
+bash "$REPO_ROOT/scripts/smoke/isolation-v2-marker-only-migrate.sh"
+
 # v0.8.2 hotfix regression smoke (issue #652) — verifies cmd_migrate_agents
 # does NOT abort the multi-agent loop when one agent home is owned by a
 # different UID (controller cannot stat into 0700 memory tree). Two

--- a/scripts/smoke/isolation-v2-marker-only-migrate.sh
+++ b/scripts/smoke/isolation-v2-marker-only-migrate.sh
@@ -1,0 +1,339 @@
+#!/usr/bin/env bash
+# v0.13.10 Track A — regression smoke for the marker-only fast-path in
+# `bridge_isolation_v2_migrate_apply_for_upgrade`.
+#
+# Reproduces the v0.13.9 gate that blocks v0.7.x → v0.13.x leaps on hosts
+# without sudo: operator host has no isolation-v2 marker and no isolated
+# agents in the roster. Pre-v0.13.10, the migrate helper either took the
+# macos-shared-agent skip (status=ok but marker NOT written, so the next
+# resolver call still rejects) or failed privilege preflight on Linux
+# without root.
+#
+# Coverage:
+#   T1 — markerless + no-isolated + BRIDGE_UPGRADE_CONTEXT=1 →
+#        status=ok, reason=marker-only-no-isolated-roster, marker WRITTEN
+#        on disk, sudo NEVER invoked, group_ops=skipped.
+#   T2 — same as T1 + re-run → second call hits marker-present skip
+#        (idempotent, no re-write).
+#   T3 — markerless + no-isolated + BRIDGE_UPGRADE_CONTEXT UNSET → the
+#        new fast-path does NOT fire; existing macos-shared-agent skip
+#        still applies (regression guard for direct
+#        `agent-bridge migrate isolation v2 --apply` callers).
+#   T4 — markerless + has-isolated-agent + BRIDGE_UPGRADE_CONTEXT=1 →
+#        the new fast-path does NOT fire (reason != marker-only-…);
+#        roster predicate rc=0 must keep the existing migration path.
+#   T5 — markerless + roster predicate unavailable (rc=2) +
+#        BRIDGE_UPGRADE_CONTEXT=1 → the new fast-path does NOT fire
+#        (rc=2 is "unknown" — must surface the existing preflight error
+#        rather than silently writing a marker on an install whose
+#        roster cannot be inspected).
+#
+# Footgun #11 (Bash 5.3.9 heredoc-class deadlock): all driver bodies are
+# emitted via printf-to-file (no heredocs, no here-strings).
+
+set -uo pipefail
+
+SMOKE_NAME="isolation-v2-marker-only-migrate"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# --- harness helpers ---------------------------------------------------------
+
+# Build a `bin/` shim dir that records every `sudo` invocation. The
+# marker-only fast-path must NOT call sudo (no group ops, no chown).
+build_sudo_recorder_shim() {
+  local shim_dir="$1"
+  local sudo_log="$2"
+
+  mkdir -p "$shim_dir"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' '# sudo recorder shim — logs each call and exits non-zero so a'
+    printf '%s\n' '# silent state mutation surfaces as a loud test failure.'
+    printf 'LOG=%q\n' "$sudo_log"
+    printf '%s\n' 'printf "[sudo-shim] %s\n" "$*" >>"$LOG"'
+    printf '%s\n' 'exit 99'
+  } >"$shim_dir/sudo"
+  chmod +x "$shim_dir/sudo"
+}
+
+# Symlink the other PATH essentials into the shim dir so the driver
+# subshell still has access to bash/mkdir/rm/printf/cat/grep/etc when
+# PATH is replaced wholesale.
+populate_basic_path() {
+  local shim_dir="$1"
+  local cmd target
+  for cmd in bash mkdir rm cat tr grep sed awk printf id stat tee chmod dirname env date mktemp readlink ls cp mv touch wc head tail find sort uniq true false python3 git tmux jq sqlite3 sha256sum md5 uname install; do
+    target="$(command -v "$cmd" 2>/dev/null || true)"
+    [[ -n "$target" && "${target:0:1}" == "/" ]] || continue
+    [[ -L "$shim_dir/$cmd" || -e "$shim_dir/$cmd" ]] && continue
+    ln -s "$target" "$shim_dir/$cmd" 2>/dev/null || true
+  done
+}
+
+# Build a one-shot driver script via printf line-by-line. No heredocs.
+write_driver_script() {
+  local out="$1"
+  shift
+  : >"$out"
+  local line
+  for line in "$@"; do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+# Stage a markerless-existing-install fixture under $home_dir:
+#   - state/, agents/, logs/, shared/, data/ subdirs present
+#   - empty roster files
+#   - layout-marker.sh ABSENT (no $home_dir/state/layout-marker.sh)
+stage_markerless_install() {
+  local home_dir="$1"
+  mkdir -p "$home_dir/state" "$home_dir/agents" "$home_dir/logs" \
+           "$home_dir/shared" "$home_dir/data/shared" \
+           "$home_dir/data/agents" "$home_dir/data/state"
+  : >"$home_dir/agent-roster.local.sh"
+  rm -f "$home_dir/state/layout-marker.sh"
+}
+
+# Invoke `bridge_isolation_v2_migrate_apply_for_upgrade` under a PATH
+# that contains our sudo recorder.
+#
+# Args:
+#   $1 = home_dir          (absolute path)
+#   $2 = roster_kind       (empty|shared|isolated|unknown)
+#   $3 = upgrade_context   (1|<empty>)
+#   $4 = out_file          (absolute path; captures stdout+stderr)
+run_apply_for_upgrade() {
+  local home_dir="$1"
+  local roster_kind="$2"
+  local upgrade_context="$3"
+  local out_file="$4"
+
+  local shim_dir="$home_dir/shim-bin"
+  local sudo_log="$home_dir/sudo-calls.log"
+  : >"$sudo_log"
+  build_sudo_recorder_shim "$shim_dir" "$sudo_log"
+  populate_basic_path "$shim_dir"
+
+  local roster_setup
+  case "$roster_kind" in
+    empty)
+      # roster array unset -> predicate returns rc=2 (unknown)
+      roster_setup='unset BRIDGE_AGENT_IDS 2>/dev/null || true'
+      ;;
+    shared)
+      # roster has agents but all return rc=1 -> predicate rc=1 (confirmed-no)
+      roster_setup='BRIDGE_AGENT_IDS=(a1 a2); bridge_agent_linux_user_isolation_effective() { return 1; }'
+      ;;
+    isolated)
+      # at least one agent returns rc=0 -> predicate rc=0 (has-isolated)
+      roster_setup='BRIDGE_AGENT_IDS=(a1 a2); bridge_agent_linux_user_isolation_effective() { local a="${1:-}"; case "$a" in a2) return 0;; *) return 1;; esac; }'
+      ;;
+    unknown)
+      # remove the predicate function -> rc=2 (unknown)
+      roster_setup='BRIDGE_AGENT_IDS=(a1); unset -f bridge_agent_linux_user_isolation_effective 2>/dev/null || true'
+      ;;
+    *) smoke_fail "internal: unknown roster_kind=$roster_kind" ;;
+  esac
+
+  local driver="$home_dir/driver.sh"
+  # BRIDGE_LAYOUT=v2 is exported BEFORE bridge-lib.sh so the layout
+  # resolver takes the env-set source-path and does not bridge_die on
+  # the markerless fixture. In the live upgrade flow, the same bypass
+  # happens via BRIDGE_LAYOUT_RESOLVER_BYPASS. We pick BRIDGE_LAYOUT=v2
+  # for the test fixture because the migrate function does not gate on
+  # the resolver's source enum — it inspects the on-disk marker via
+  # bridge_isolation_v2_marker_path, which is anchored on
+  # BRIDGE_LAYOUT_MARKER_DIR (also exported).
+  write_driver_script "$driver" \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'export BRIDGE_HOME="$HOME_DIR"' \
+    'export BRIDGE_STATE_DIR="$HOME_DIR/state"' \
+    'export BRIDGE_LAYOUT_MARKER_DIR="$HOME_DIR/state"' \
+    'export BRIDGE_LOG_DIR="$HOME_DIR/logs"' \
+    'export BRIDGE_SHARED_DIR="$HOME_DIR/shared"' \
+    'export BRIDGE_DATA_ROOT="$HOME_DIR/data"' \
+    'export BRIDGE_LAYOUT="v2"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'source "$REPO_ROOT/lib/bridge-isolation-v2-migrate.sh" >/dev/null 2>&1' \
+    "$roster_setup" \
+    'bridge_isolation_v2_migrate_apply_for_upgrade --target-root "$HOME_DIR" --json 2>/dev/null || true'
+
+  PATH="$shim_dir" \
+    REPO_ROOT="$REPO_ROOT" \
+    HOME_DIR="$home_dir" \
+    BRIDGE_HOME="$home_dir" \
+    BRIDGE_STATE_DIR="$home_dir/state" \
+    BRIDGE_LAYOUT_MARKER_DIR="$home_dir/state" \
+    BRIDGE_LOG_DIR="$home_dir/logs" \
+    BRIDGE_SHARED_DIR="$home_dir/shared" \
+    BRIDGE_DATA_ROOT="$home_dir/data" \
+    BRIDGE_LAYOUT="v2" \
+    BRIDGE_UPGRADE_CONTEXT="$upgrade_context" \
+    "$BRIDGE_BASH" "$driver" >"$out_file" 2>&1 || true
+}
+
+assert_marker_only_path() {
+  local label="$1"
+  local payload="$2"
+  case "$payload" in
+    *'"reason":"marker-only-no-isolated-roster"'*) ;;
+    *) smoke_fail "$label expected reason=marker-only-no-isolated-roster, got: $payload" ;;
+  esac
+  case "$payload" in
+    *'"status":"ok"'*) ;;
+    *) smoke_fail "$label expected status=ok, got: $payload" ;;
+  esac
+  case "$payload" in
+    *'"group_ops":"skipped"'*) ;;
+    *) smoke_fail "$label expected group_ops=skipped, got: $payload" ;;
+  esac
+  case "$payload" in
+    *'"mode":"isolation-v2-migrate"'*) ;;
+    *) smoke_fail "$label expected mode=isolation-v2-migrate, got: $payload" ;;
+  esac
+}
+
+assert_not_marker_only_path() {
+  local label="$1"
+  local payload="$2"
+  case "$payload" in
+    *'"reason":"marker-only-no-isolated-roster"'*)
+      smoke_fail "$label: marker-only fast-path fired on a context that should NOT take it. payload=$payload" ;;
+  esac
+}
+
+# --- T1: markerless + no-isolated + upgrade context → marker written ---------
+
+smoke_log "T1: markerless + no-isolated + BRIDGE_UPGRADE_CONTEXT=1 → marker-only path"
+
+T1_HOME="$SMOKE_TMP_ROOT/t1"
+mkdir -p "$T1_HOME"
+stage_markerless_install "$T1_HOME"
+T1_OUT="$T1_HOME/out.txt"
+run_apply_for_upgrade "$T1_HOME" shared 1 "$T1_OUT"
+T1_PAYLOAD="$(cat "$T1_OUT")"
+assert_marker_only_path "T1" "$T1_PAYLOAD"
+
+# Marker file MUST exist on disk and carry BRIDGE_LAYOUT=v2.
+T1_MARKER="$T1_HOME/state/layout-marker.sh"
+if [[ ! -f "$T1_MARKER" ]]; then
+  smoke_fail "T1: expected marker at $T1_MARKER to exist after marker-only path"
+fi
+if ! grep -q '^BRIDGE_LAYOUT=' "$T1_MARKER"; then
+  smoke_fail "T1: marker $T1_MARKER missing BRIDGE_LAYOUT= line. contents=$(cat "$T1_MARKER")"
+fi
+if ! grep -q '^BRIDGE_DATA_ROOT=' "$T1_MARKER"; then
+  smoke_fail "T1: marker $T1_MARKER missing BRIDGE_DATA_ROOT= line. contents=$(cat "$T1_MARKER")"
+fi
+
+# sudo MUST NOT have been invoked.
+if [[ -s "$T1_HOME/sudo-calls.log" ]]; then
+  smoke_fail "T1: sudo shim recorded calls — marker-only path must NOT call sudo. log=$(cat "$T1_HOME/sudo-calls.log")"
+fi
+smoke_log "T1 PASS: marker written + sudo never invoked"
+
+# --- T2: idempotent — second run hits marker-present skip --------------------
+
+smoke_log "T2: second call hits marker-present skip (idempotent)"
+
+T2_OUT_B="$T1_HOME/out-b.txt"
+run_apply_for_upgrade "$T1_HOME" shared 1 "$T2_OUT_B"
+T2_PAYLOAD_B="$(cat "$T2_OUT_B")"
+case "$T2_PAYLOAD_B" in
+  *'"reason":"marker-present"'*) ;;
+  *'"reason":"macos-shared-agent"'*) ;;
+  *)
+    # On Linux without sudo + valid marker, the marker-present branch
+    # falls back to "no-privilege/inactive" which still uses
+    # reason=marker-present. macOS path also acceptable when the
+    # privilege preflight fails. Reject anything carrying our new
+    # marker-only reason (we already wrote the marker, T2 must NOT
+    # re-fire the marker-only path).
+    case "$T2_PAYLOAD_B" in
+      *'"reason":"marker-only-no-isolated-roster"'*)
+        smoke_fail "T2: second call re-took the marker-only path; should have hit marker-present skip. payload=$T2_PAYLOAD_B" ;;
+    esac
+    ;;
+esac
+smoke_log "T2 PASS: idempotent — second call did not re-take the marker-only path"
+
+# --- T3: markerless + no-isolated + UPGRADE_CONTEXT unset → old skip ---------
+
+smoke_log "T3: markerless + no-isolated + BRIDGE_UPGRADE_CONTEXT unset → fast-path NOT fired"
+
+T3_HOME="$SMOKE_TMP_ROOT/t3"
+mkdir -p "$T3_HOME"
+stage_markerless_install "$T3_HOME"
+T3_OUT="$T3_HOME/out.txt"
+run_apply_for_upgrade "$T3_HOME" shared "" "$T3_OUT"
+T3_PAYLOAD="$(cat "$T3_OUT")"
+assert_not_marker_only_path "T3" "$T3_PAYLOAD"
+
+# Marker file MUST NOT have been written (the existing macOS/Linux
+# branches do not write a marker without privilege preflight).
+T3_MARKER="$T3_HOME/state/layout-marker.sh"
+if [[ -f "$T3_MARKER" ]]; then
+  smoke_fail "T3: marker $T3_MARKER unexpectedly written without BRIDGE_UPGRADE_CONTEXT=1. contents=$(cat "$T3_MARKER")"
+fi
+smoke_log "T3 PASS: marker-only path stays gated behind BRIDGE_UPGRADE_CONTEXT=1"
+
+# --- T4: markerless + has-isolated + upgrade context → fast-path NOT fired --
+
+smoke_log "T4: markerless + has-isolated + BRIDGE_UPGRADE_CONTEXT=1 → fast-path NOT fired"
+
+T4_HOME="$SMOKE_TMP_ROOT/t4"
+mkdir -p "$T4_HOME"
+stage_markerless_install "$T4_HOME"
+T4_OUT="$T4_HOME/out.txt"
+run_apply_for_upgrade "$T4_HOME" isolated 1 "$T4_OUT"
+T4_PAYLOAD="$(cat "$T4_OUT")"
+assert_not_marker_only_path "T4" "$T4_PAYLOAD"
+smoke_log "T4 PASS: has-isolated-roster path bypasses the marker-only fast-path"
+
+# --- T5: markerless + roster predicate unavailable (rc=2) → fast-path NOT fired
+
+smoke_log "T5: markerless + roster predicate rc=2 (unknown) → fast-path NOT fired"
+
+T5_HOME="$SMOKE_TMP_ROOT/t5"
+mkdir -p "$T5_HOME"
+stage_markerless_install "$T5_HOME"
+T5_OUT="$T5_HOME/out.txt"
+run_apply_for_upgrade "$T5_HOME" unknown 1 "$T5_OUT"
+T5_PAYLOAD="$(cat "$T5_OUT")"
+assert_not_marker_only_path "T5" "$T5_PAYLOAD"
+
+# Marker file MUST NOT have been written under rc=2 — silently writing a
+# marker on an install whose roster cannot be inspected would mask the
+# legitimate preflight error the operator needs to see.
+T5_MARKER="$T5_HOME/state/layout-marker.sh"
+if [[ -f "$T5_MARKER" ]]; then
+  smoke_fail "T5: marker $T5_MARKER unexpectedly written under rc=2 (unknown roster). contents=$(cat "$T5_MARKER")"
+fi
+smoke_log "T5 PASS: rc=2 unknown roster keeps the operator-visible preflight path"
+
+smoke_log "all 5 tests PASS"

--- a/scripts/smoke/isolation-v2-marker-only-migrate.sh
+++ b/scripts/smoke/isolation-v2-marker-only-migrate.sh
@@ -336,4 +336,163 @@ if [[ -f "$T5_MARKER" ]]; then
 fi
 smoke_log "T5 PASS: rc=2 unknown roster keeps the operator-visible preflight path"
 
-smoke_log "all 5 tests PASS"
+# --- T6: post-marker boot resolves shared-mode agent workdir + CLAUDE.md ----
+#
+# Codex r1 BLOCKING on PR #897: the original T1-T5 only validated the
+# marker bytes and the absence of sudo. They never started a clean
+# post-marker process and exercised `bridge_agent_workdir <agent>` to
+# confirm the marker-only fast-path does not strand a shared-mode agent
+# whose CLAUDE.md (and project tree) live at an operator-explicit
+# workdir.
+#
+# Why this matters with Track A's marker-only path: after the fast-path
+# writes the marker, the next process to source `bridge-lib.sh` will see
+# `BRIDGE_LAYOUT=v2` via the marker, `bridge-isolation-v2.sh` will
+# compute `BRIDGE_AGENT_ROOT_V2=$BRIDGE_DATA_ROOT/agents`, and
+# `bridge_agent_workdir` (lib/bridge-agents.sh:3702) enters its v2-anchor
+# gate. Pre-#895 the gate fired unconditionally; post-#895 (Track C,
+# merged 2026-05-15 main HEAD 9e909be) it fires only for `linux-user`
+# mode. Shared-mode agents — the entire v0.7.x → v0.13.x upgrade target
+# population — must fall through to the explicit
+# `BRIDGE_AGENT_WORKDIR[<agent>]` so the operator's project (and its
+# CLAUDE.md) stay reachable.
+#
+# T6 stages a markerless install with one shared-mode agent whose
+# explicit workdir contains a CLAUDE.md, applies the marker-only path,
+# then spawns a FRESH bash subprocess that exports only `BRIDGE_HOME`
+# (the marker on disk is what makes BRIDGE_LAYOUT=v2 take effect; no
+# pre-set BRIDGE_LAYOUT / BRIDGE_DATA_ROOT in env). The subprocess
+# sources bridge-lib.sh, calls `bridge_load_roster` to populate
+# BRIDGE_AGENT_WORKDIR[], then invokes `bridge_agent_workdir <agent>`
+# and we assert the returned path equals the explicit workdir and
+# contains the staged CLAUDE.md.
+
+smoke_log "T6: post-marker boot resolves shared-mode agent workdir + CLAUDE.md (codex r1)"
+
+T6_HOME="$SMOKE_TMP_ROOT/t6"
+mkdir -p "$T6_HOME"
+stage_markerless_install "$T6_HOME"
+
+# Stage a shared-mode agent with CLAUDE.md at an operator-explicit workdir.
+# The workdir lives OUTSIDE $T6_HOME/data/agents/ (the v2 anchor that
+# pre-#895 would have re-rooted to) so the assertion can distinguish
+# explicit-cwd-honored from v2-anchor-stomp.
+T6_AGENT="t6_legacy_shared"
+T6_EXPLICIT_WORKDIR="$T6_HOME/operator-project"
+mkdir -p "$T6_EXPLICIT_WORKDIR"
+printf '# %s CLAUDE.md (post-marker reachability fixture)\n' "$T6_AGENT" \
+  >"$T6_EXPLICIT_WORKDIR/CLAUDE.md"
+
+# Roster file: shared-mode agent, isolation_mode UNSET so it exercises
+# the default-fallback contract (bridge_agent_isolation_mode normalizes
+# unset to "shared" per lib/bridge-agents.sh:799-802 — same path
+# operator's v0.7.x roster rows hit on upgrade).
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# shellcheck shell=bash disable=SC2034\n'
+  printf 'bridge_add_agent_id_if_missing %q\n' "$T6_AGENT"
+  printf 'BRIDGE_AGENT_ENGINE[%s]=claude\n' "$T6_AGENT"
+  printf 'BRIDGE_AGENT_SESSION[%s]=%s\n' "$T6_AGENT" "$T6_AGENT"
+  printf 'BRIDGE_AGENT_WORKDIR[%s]=%q\n' "$T6_AGENT" "$T6_EXPLICIT_WORKDIR"
+} >"$T6_HOME/agent-roster.local.sh"
+
+# Step 1: apply the marker-only fast-path (same harness as T1).
+T6_APPLY_OUT="$T6_HOME/apply-out.txt"
+run_apply_for_upgrade "$T6_HOME" shared 1 "$T6_APPLY_OUT"
+T6_APPLY_PAYLOAD="$(cat "$T6_APPLY_OUT")"
+assert_marker_only_path "T6.apply" "$T6_APPLY_PAYLOAD"
+
+# Confirm marker landed (same invariant as T1's post-condition).
+T6_MARKER="$T6_HOME/state/layout-marker.sh"
+if [[ ! -f "$T6_MARKER" ]]; then
+  smoke_fail "T6: marker $T6_MARKER missing after marker-only fast-path"
+fi
+
+# Step 2: clean post-marker boot. Spawn a fresh bash with a SCRUBBED env
+# (`env -i`) so leaked controller-shell `BRIDGE_*` exports from the
+# operator's live agent session cannot mask the marker pickup. Only
+# BRIDGE_HOME + the four standard inherited vars (HOME / PATH / TMPDIR /
+# USER) are passed through; everything else — including
+# BRIDGE_LAYOUT_MARKER_DIR, BRIDGE_LAYOUT, BRIDGE_DATA_ROOT — is
+# deliberately absent so the marker on disk is the only signal that can
+# set BRIDGE_LAYOUT=v2. This pins the contract that a fresh shell
+# launched on the upgraded install picks up v2 layout from the marker
+# alone, which is exactly what the next `agent-bridge ...` process does
+# after `agent-bridge upgrade --apply` exits.
+T6_POSTMARKER_DRIVER="$T6_HOME/postmarker-driver.sh"
+write_driver_script "$T6_POSTMARKER_DRIVER" \
+  '#!/usr/bin/env bash' \
+  'set -uo pipefail' \
+  'cd "$REPO_ROOT"' \
+  'export BRIDGE_HOME="$HOME_DIR"' \
+  '# Roster cache lives per-process. Forcing a re-read keeps the' \
+  '# driver immune to any future change that might pre-cache the' \
+  '# roster before bridge_load_roster runs.' \
+  'export BRIDGE_ROSTER_CACHE_DISABLE=1' \
+  'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+  'bridge_load_roster' \
+  'printf "BRIDGE_LAYOUT=%s\n" "${BRIDGE_LAYOUT:-unset}"' \
+  'printf "BRIDGE_DATA_ROOT=%s\n" "${BRIDGE_DATA_ROOT:-unset}"' \
+  'printf "BRIDGE_AGENT_ROOT_V2=%s\n" "${BRIDGE_AGENT_ROOT_V2:-unset}"' \
+  'printf "BRIDGE_LAYOUT_SOURCE=%s\n" "${BRIDGE_LAYOUT_SOURCE:-unset}"' \
+  'printf "resolved=%s\n" "$(bridge_agent_workdir "$AGENT_ID")"'
+
+T6_POSTMARKER_OUT="$(env -i \
+  HOME="${HOME:-}" \
+  PATH="${PATH:-/usr/bin:/bin}" \
+  TMPDIR="${TMPDIR:-/tmp}" \
+  USER="${USER:-}" \
+  REPO_ROOT="$REPO_ROOT" \
+  HOME_DIR="$T6_HOME" \
+  AGENT_ID="$T6_AGENT" \
+  "$BRIDGE_BASH" "$T6_POSTMARKER_DRIVER" 2>&1)" || true
+
+# Assert: marker activated v2 layout in the clean boot.
+case "$T6_POSTMARKER_OUT" in
+  *"BRIDGE_LAYOUT=v2"*) ;;
+  *)
+    smoke_fail "T6: post-marker boot did not pick up BRIDGE_LAYOUT=v2 from marker. output:
+$T6_POSTMARKER_OUT" ;;
+esac
+
+# Assert: BRIDGE_AGENT_ROOT_V2 is set (proves isolation-v2.sh derived
+# it from the marker's BRIDGE_DATA_ROOT). Without this, the
+# `bridge_agent_workdir` v2-anchor gate (lib/bridge-agents.sh:3727)
+# would have been a no-op for trivial reasons and the assertion below
+# would not actually exercise the shared-mode fall-through.
+case "$T6_POSTMARKER_OUT" in
+  *"BRIDGE_AGENT_ROOT_V2=$T6_HOME/data/agents"*) ;;
+  *)
+    smoke_fail "T6: post-marker boot did not derive BRIDGE_AGENT_ROOT_V2=$T6_HOME/data/agents from marker. output:
+$T6_POSTMARKER_OUT" ;;
+esac
+
+# Assert: bridge_agent_workdir <agent> returned the explicit workdir,
+# NOT the v2 anchor. This is the post-#895 shared-mode contract Track A's
+# marker activation must not violate.
+T6_RESOLVED="$(printf '%s\n' "$T6_POSTMARKER_OUT" | sed -n 's/^resolved=//p' | tail -n 1)"
+if [[ -z "$T6_RESOLVED" ]]; then
+  smoke_fail "T6: post-marker boot did not emit a resolved= line. output:
+$T6_POSTMARKER_OUT"
+fi
+if [[ "$T6_RESOLVED" != "$T6_EXPLICIT_WORKDIR" ]]; then
+  smoke_fail "T6: bridge_agent_workdir returned '$T6_RESOLVED', expected '$T6_EXPLICIT_WORKDIR'. Marker-only fast-path must NOT strand shared-mode agents at the v2 anchor (codex r1 catch on PR #897; see #895 / Track C / lib/bridge-agents.sh:3702-3742). output:
+$T6_POSTMARKER_OUT"
+fi
+
+# Defense-in-depth: returned path must NOT be under the v2 agent root.
+case "$T6_RESOLVED" in
+  "$T6_HOME/data/agents"*|"$T6_HOME/data/agents/"*)
+    smoke_fail "T6: resolved workdir '$T6_RESOLVED' is under \$BRIDGE_AGENT_ROOT_V2 — shared-mode agent must not be re-rooted to v2 anchor. output:
+$T6_POSTMARKER_OUT" ;;
+esac
+
+# Assert: CLAUDE.md is reachable at the resolved workdir.
+if [[ ! -f "$T6_RESOLVED/CLAUDE.md" ]]; then
+  smoke_fail "T6: CLAUDE.md not reachable at resolved workdir '$T6_RESOLVED' — marker activation broke shared-mode agent path. output:
+$T6_POSTMARKER_OUT"
+fi
+
+smoke_log "T6 PASS: marker-only + shared-mode agent preserves legacy workdir + CLAUDE.md (resolved=$T6_RESOLVED)"
+
+smoke_log "all 6 tests PASS"


### PR DESCRIPTION
## Summary

- v0.13.9 fixed the Bash 5.3.9 heredoc deadlock chain. The next gate that blocks the v0.7.x → v0.13.x leap is the `markerless(existing-install)` reject at `lib/bridge-layout-resolver.sh:352`. Operator-host evidence: patch task #4538/#4546 + Sean's mac install broken at 2026-05-15 17:01 (recovered via backup rsync).
- Track A adds a marker-only fast-path to `bridge_isolation_v2_migrate_apply_for_upgrade` for the markerless-existing-install + no-isolated-roster case. No group ops, no sudo required. Works on macOS (no `dseditgroup`), Linux (no root), BSD.
- Reuses `bridge_isolation_v2_roster_has_isolated_agents` rc=1 (confirmed-no) added in PR #882 (v0.13.6). rc=0 has-isolated and rc=2 unknown both fall through to the existing preflight path.
- Rebased onto `origin/main` HEAD `9e909be` (Track C #899 — `bridge_agent_workdir` isolation-mode branch fix). The earlier T5 expectation fix commit dropped on rebase because Track C cherry-picked it.

## Commits

1. **`5abacaf` fix(upgrade): markerless-existing-install marker-only migrate path** — Track A change itself: new `bridge_isolation_v2_migrate_marker_write_minimal` helper + new early branch in `bridge_isolation_v2_migrate_apply_for_upgrade`; `bridge-upgrade.sh` sets and propagates `BRIDGE_UPGRADE_CONTEXT=1` through `bridge_upgrade_with_target_env`'s `env -i` filter; new 5-case regression smoke registered in `scripts/smoke-test.sh`.
2. **`31ae075` feat(smoke): add T6 post-marker regression assertion (codex r1 catch on PR #897)** — addresses codex r1 BLOCKING: T1-T5 only validated marker bytes + sudo absence; T6 stages a markerless install with one shared-mode agent whose explicit workdir holds a CLAUDE.md, applies the fast-path, then spawns a fresh `env -i` bash that exports only `BRIDGE_HOME` and asserts the post-marker boot picks up `BRIDGE_LAYOUT=v2` from source=marker, derives `BRIDGE_AGENT_ROOT_V2`, and `bridge_agent_workdir <agent>` returns the operator's explicit cwd (NOT the v2 anchor) with CLAUDE.md reachable. Bite-checked: reverting Track C's `linux-user`-only gate at `lib/bridge-agents.sh:3729` causes T6 to FAIL with the exact "stranded at v2 anchor" symptom; with the fix in place, T6 passes.

## Files touched

- `lib/bridge-isolation-v2-migrate.sh`
  - new helper `bridge_isolation_v2_migrate_marker_write_minimal` — writes wire-compatible marker bytes (`BRIDGE_LAYOUT=v2` + `BRIDGE_DATA_ROOT=<path>`) without `chown root:<group>` (no sudo / `dseditgroup` required).
  - new early branch in `bridge_isolation_v2_migrate_apply_for_upgrade` guarded on `BRIDGE_UPGRADE_CONTEXT=1` + `_iso_check_rc == 1` + marker-not-already-valid. Falls through to the existing macos-shared-agent skip / privilege preflight on any other condition.
- `bridge-upgrade.sh` — sets `BRIDGE_UPGRADE_CONTEXT=1` on the inline migrate call and propagates the env var through `bridge_upgrade_with_target_env`'s `env -i` filter.
- `scripts/smoke/isolation-v2-marker-only-migrate.sh` — new regression smoke; 6 tests (T6 added in commit 2).
- `scripts/smoke-test.sh` — registers the new smoke.

## Why this is safe

- The v2 marker is metadata. Writing it does not change runtime semantics for agents in `shared` isolation mode (the default for single-OS-user hosts).
- When the operator later adds an isolated agent via `agent-bridge agent add --isolated <name>`, that flow handles group setup at that point (with its own sudo check), cleanly separated from the upgrade.
- `markerless-existing-install` + no-isolated-roster is exactly the v0.7.x → v0.13.x upgrade signature; v0.7.x predates isolated agents.
- The marker bytes match what `bridge_isolation_v2_migrate_marker_write` produces — same validator passes on the next boot, same downstream code paths.
- T6 actively asserts that the marker activation does NOT regress shared-mode workdir resolution post-#895 (Track C). Bite-checked against a pre-#895 resolver state.

## Verification

- `bash -n` + `shellcheck` clean on `bridge-upgrade.sh`, `lib/bridge-isolation-v2-migrate.sh`, `scripts/smoke/isolation-v2-marker-only-migrate.sh`.
- New smoke `bash scripts/smoke/isolation-v2-marker-only-migrate.sh` — all 6 tests PASS:
  - T1: markerless + no-isolated + `BRIDGE_UPGRADE_CONTEXT=1` → `reason=marker-only-no-isolated-roster`, marker written, sudo never invoked, `group_ops=skipped`.
  - T2: second call hits marker-present skip (idempotent — does NOT re-take marker-only path).
  - T3: `BRIDGE_UPGRADE_CONTEXT` unset → fast-path NOT fired, marker NOT written.
  - T4: has-isolated roster (rc=0) → fast-path NOT fired.
  - T5: roster predicate unavailable (rc=2 unknown) → fast-path NOT fired.
  - T6: post-marker boot (env -i clean shell, BRIDGE_HOME only) picks up `BRIDGE_LAYOUT=v2` from source=marker, derives `BRIDGE_AGENT_ROOT_V2`, `bridge_agent_workdir <shared-agent>` returns the operator's explicit cwd, CLAUDE.md reachable.
- Adjacent smokes verified green: `isolation-v2-migrate-macos-skip` (5/5), `isolation-v2-migrate-lock-portability` (3/3), `dynamic-agent-shared-mode-workdir` (3/3).
- Functional check on isolated `BRIDGE_HOME` (markerless fixture, no-isolated roster, `BRIDGE_UPGRADE_CONTEXT=1`): payload `{"status":"ok","reason":"marker-only-no-isolated-roster","group_ops":"skipped","platform":"Darwin"}`, marker on disk contains exactly `BRIDGE_LAYOUT=v2\nBRIDGE_DATA_ROOT=<fixture>/data\n` at mode 0640.

## Refs

- Track A of the v0.13.10 wave (no upstream issue — operator-host report only).
- Operator-host context: patch task #4538 (Linux), Sean's mac install at 2026-05-15 17:01.
- Reuses: PR #882 (v0.13.6) `bridge_isolation_v2_roster_has_isolated_agents`.
- Track C dependency (post-rebase): PR #899 — `bridge_agent_workdir` shared-mode fix (issue #895). T6 is bite-checked against the Track C contract.
- T5 expectation fix landed via Track C #899; not part of this branch post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)