### PR TITLE
chore(lint): heredoc-ban ratchet for bridge-upgrade.sh (S1.5)

### DIFF
--- a/scripts/lint-heredoc-ban.sh
+++ b/scripts/lint-heredoc-ban.sh
@@ -17,10 +17,17 @@
 # - PRs that add new heredoc-stdin without removing one push count over
 #   the ceiling and fail this lint.
 #
-# Pattern detected:
-#   <bash -s ...|python3 - ...> ... <<EOF | <<'EOF' | <<"EOF" | <<PY | <<'PY' | <<"PY" | <<-...
-# at the start of a non-comment line (so doc strings and comment mentions
-# don't trip the lint).
+# Pattern detected (4 wrapper shapes — all reproduce the v0.13.7-v0.13.9
+# deadlock chain when the subprocess is slow to drain):
+#   1. command-start:    bash -s … <<EOF                / python3 - … <<PY
+#   2. if-wrapped:       if [!] bash -s … <<EOF         / if [!] python3 - … <<PY
+#   3. `$()`-wrapped:    var=$(bash -s … <<EOF)         / var=$(python3 - … <<PY)
+#                        var="$(bash -s … <<EOF)"       / var="$(python3 - … <<PY)"
+#   4. piped + `$()`:    var="$(printf … | bash -s … <<EOF)"  etc.
+#
+# Comment-only lines (first non-whitespace char is `#`) do NOT match —
+# doc strings and audit-trail references to heredoc shapes do not trip
+# the lint.
 #
 # This script is NOT a substitute for the migration work in S10-late;
 # it's the regression guard during S2-S9 so the bridge-upgrade.sh heredoc
@@ -30,6 +37,7 @@
 # Usage:
 #   scripts/lint-heredoc-ban.sh              # check, exit 1 if over ceiling
 #   scripts/lint-heredoc-ban.sh --list       # list all detected sites
+#   scripts/lint-heredoc-ban.sh --self-test  # verify pattern against fixtures
 #   BRIDGE_UPGRADE_HEREDOC_CEILING=10 ...    # override ceiling for testing
 
 set -euo pipefail
@@ -38,14 +46,81 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 target_file="$repo_root/bridge-upgrade.sh"
 ceiling="${BRIDGE_UPGRADE_HEREDOC_CEILING:-18}"
 
+# Pattern: heredoc-stdin invocation of bash -s / python3 - in any of the 4
+# wrapper shapes (see header comment). The optional leading-context
+# alternation captures:
+#   - `if [!] ` prefix (alternative #1)
+#   - any non-comment text containing `$(` optionally followed by
+#     non-paren text (alternative #2 — handles assignment with `$()`,
+#     piped command-substitution, etc.)
+# Comment lines fail the leading-context alternation because `[^#]*` cannot
+# consume `#`, and the bare command-start anchor `[[:space:]]*` requires
+# the next char to be `b` or `p` (start of `bash`/`python3`).
+pattern='^[[:space:]]*((if[[:space:]]+!?[[:space:]]*)|([^#]*\$\([^()]*))?(bash[[:space:]]+-s|python3[[:space:]]+-)[[:space:]].*<<-?["'"'"']?(EOF|PY)["'"'"']?'
+
+run_self_test() {
+  local fixture
+  fixture="$(mktemp)"
+  trap 'rm -f "$fixture"' RETURN
+
+  cat >"$fixture" <<'FIXTURE'
+# Comment line that mentions python3 - <<'PY' should NOT match.
+  # Indented comment with bash -s -- <<'EOF' should NOT match.
+echo "doc string with python3 - <<PY embedded" >/dev/null
+bash -s -- "$arg" <<'EOF'
+python3 - "$payload" <<'PY'
+  bash -s -- "$arg" <<EOF
+  python3 - <<-PY
+if bash -s -- "$arg" <<'EOF'; then
+if ! python3 - "$payload" <<'PY'; then
+  if bash -s -- "$arg" <<EOF; then
+  if ! python3 - <<PY; then
+out="$(python3 - "$payload" <<'PY')"
+out=$(python3 - "$payload" <<'PY')
+out="$(bash -s -- "$arg" <<'EOF')"
+out=$(bash -s -- "$arg" <<EOF)
+local out="$(python3 - "$payload" <<'PY')"
+result="$(printf '%s' "$json" | python3 - "$arg" <<'PY')"
+result="$(printf '%s' "$json" | bash -s -- "$arg" <<'EOF')"
+echo done
+true
+FIXTURE
+
+  # Expected: 15 positive matches (every line that starts a real invocation).
+  # Negative cases: 5 (two comments + echo doc-string + 2 trailing no-op lines).
+  local expected=15
+  local got
+  got="$(grep -cE "$pattern" "$fixture" || true)"
+
+  if [[ "$got" != "$expected" ]]; then
+    echo "[lint-heredoc-ban] SELF-TEST FAIL: expected $expected matches, got $got" >&2
+    echo "[lint-heredoc-ban] matches:" >&2
+    grep -nE "$pattern" "$fixture" | sed 's/^/[lint-heredoc-ban]   /' >&2 || true
+    return 1
+  fi
+
+  # Negative checks: comment-only lines and doc strings must NOT match.
+  local negatives
+  negatives="$(grep -nE "$pattern" "$fixture" | grep -E '^[0-9]+:[[:space:]]*#|echo "doc string' || true)"
+  if [[ -n "$negatives" ]]; then
+    echo "[lint-heredoc-ban] SELF-TEST FAIL: comment/doc-string lines matched:" >&2
+    printf '%s\n' "$negatives" | sed 's/^/[lint-heredoc-ban]   /' >&2
+    return 1
+  fi
+
+  echo "[lint-heredoc-ban] SELF-TEST PASS: pattern catches $got synthetic invocations across all 4 shapes."
+  return 0
+}
+
+if [[ "${1:-}" == "--self-test" ]]; then
+  run_self_test
+  exit $?
+fi
+
 if [[ ! -f "$target_file" ]]; then
   echo "[lint-heredoc-ban] target file missing: $target_file" >&2
   exit 2
 fi
-
-# Pattern: command-line invocation of bash -s / python3 - with a heredoc
-# end-marker on the same line, optionally wrapped in `if [!] ...`.
-pattern='^[[:space:]]*(if[[:space:]]+!?[[:space:]]*)?(bash[[:space:]]+-s|python3[[:space:]]+-)[[:space:]].*<<-?["'"'"']?(EOF|PY)["'"'"']?'
 
 if [[ "${1:-}" == "--list" ]]; then
   grep -nE "$pattern" "$target_file" || true

--- a/scripts/lint-heredoc-ban.sh
+++ b/scripts/lint-heredoc-ban.sh
@@ -17,17 +17,28 @@
 # - PRs that add new heredoc-stdin without removing one push count over
 #   the ceiling and fail this lint.
 #
-# Pattern detected (4 wrapper shapes — all reproduce the v0.13.7-v0.13.9
-# deadlock chain when the subprocess is slow to drain):
-#   1. command-start:    bash -s … <<EOF                / python3 - … <<PY
-#   2. if-wrapped:       if [!] bash -s … <<EOF         / if [!] python3 - … <<PY
-#   3. `$()`-wrapped:    var=$(bash -s … <<EOF)         / var=$(python3 - … <<PY)
-#                        var="$(bash -s … <<EOF)"       / var="$(python3 - … <<PY)"
-#   4. piped + `$()`:    var="$(printf … | bash -s … <<EOF)"  etc.
+# Contract — broad-match:
+#   A "site" is any non-comment line in bridge-upgrade.sh that contains
+#   a heredoc-fed `bash -s ...` or `python3 - ...` subprocess on the
+#   same line — i.e., the sub-pattern
+#       <bash -s | python3 -> ... <<EOF | <<'EOF' | <<"EOF" | <<PY | <<'PY' | <<"PY" | <<-...
+#   appears anywhere on the line.
 #
-# Comment-only lines (first non-whitespace char is `#`) do NOT match —
-# doc strings and audit-trail references to heredoc shapes do not trip
-# the lint.
+#   Wrapper shape does NOT matter: command-start, `if [!] ` wrapped,
+#   `var=$(...)` / `var="$(...)"` command-substitution, piped + `$()`,
+#   nested `$(...)` deeper than one level, backtick command-sub, or even
+#   the pattern embedded inside a double-quoted string — all count.
+#
+#   The only false-positive surface is a literal mention of the
+#   sub-pattern inside a string on a NON-comment line. In practice
+#   bridge-upgrade.sh has zero such strings, and the right place to
+#   document the danger pattern in code is a comment line (those are
+#   excluded — see below).
+#
+# Comment-line skip:
+#   Lines whose first non-whitespace char is `#` are excluded from the
+#   count. Audit-trail references, doc strings inside comments, and
+#   intent-explaining notes do not trip the lint.
 #
 # This script is NOT a substitute for the migration work in S10-late;
 # it's the regression guard during S2-S9 so the bridge-upgrade.sh heredoc
@@ -46,17 +57,32 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 target_file="$repo_root/bridge-upgrade.sh"
 ceiling="${BRIDGE_UPGRADE_HEREDOC_CEILING:-18}"
 
-# Pattern: heredoc-stdin invocation of bash -s / python3 - in any of the 4
-# wrapper shapes (see header comment). The optional leading-context
-# alternation captures:
-#   - `if [!] ` prefix (alternative #1)
-#   - any non-comment text containing `$(` optionally followed by
-#     non-paren text (alternative #2 — handles assignment with `$()`,
-#     piped command-substitution, etc.)
-# Comment lines fail the leading-context alternation because `[^#]*` cannot
-# consume `#`, and the bare command-start anchor `[[:space:]]*` requires
-# the next char to be `b` or `p` (start of `bash`/`python3`).
-pattern='^[[:space:]]*((if[[:space:]]+!?[[:space:]]*)|([^#]*\$\([^()]*))?(bash[[:space:]]+-s|python3[[:space:]]+-)[[:space:]].*<<-?["'"'"']?(EOF|PY)["'"'"']?'
+# Core danger pattern. Anchored to "command name + space + heredoc op + tag",
+# but NOT anchored to start-of-line — so wrapper shape is irrelevant.
+danger_pattern='(bash[[:space:]]+-s|python3[[:space:]]+-)[[:space:]].*<<-?["'"'"']?(EOF|PY)["'"'"']?'
+
+# Comment-prefix on `grep -nE` output (format: LINENO:CONTENT). Lines whose
+# CONTENT (after optional whitespace) begins with `#` are comment-only.
+comment_prefix='^[0-9]+:[[:space:]]*#'
+
+count_sites() {
+  local file="$1"
+  local n
+  # 1st pass: every line containing the danger pattern (with line numbers).
+  # 2nd pass: drop comment-only lines.
+  # `grep -vc` outputs "0" with exit 1 when the input stream is empty —
+  # accept that via `|| true` so set -o pipefail doesn't trip.
+  n="$(grep -nE "$danger_pattern" "$file" 2>/dev/null \
+        | grep -vcE "$comment_prefix" 2>/dev/null || true)"
+  [[ -z "$n" ]] && n=0
+  printf '%s\n' "$n"
+}
+
+list_sites() {
+  local file="$1"
+  grep -nE "$danger_pattern" "$file" 2>/dev/null \
+    | grep -vE "$comment_prefix" || true
+}
 
 run_self_test() {
   local fixture
@@ -66,7 +92,7 @@ run_self_test() {
   cat >"$fixture" <<'FIXTURE'
 # Comment line that mentions python3 - <<'PY' should NOT match.
   # Indented comment with bash -s -- <<'EOF' should NOT match.
-echo "doc string with python3 - <<PY embedded" >/dev/null
+# Comment with nested $(python3 - <<PY) should NOT match either.
 bash -s -- "$arg" <<'EOF'
 python3 - "$payload" <<'PY'
   bash -s -- "$arg" <<EOF
@@ -82,33 +108,37 @@ out=$(bash -s -- "$arg" <<EOF)
 local out="$(python3 - "$payload" <<'PY')"
 result="$(printf '%s' "$json" | python3 - "$arg" <<'PY')"
 result="$(printf '%s' "$json" | bash -s -- "$arg" <<'EOF')"
+nested="$(other "$(bar)" | python3 - "$payload" <<'PY')"
+backtick=`python3 - "$payload" <<'PY'`
+echo "doc string with python3 - <<PY embedded" >/dev/null
 echo done
 true
 FIXTURE
 
-  # Expected: 15 positive matches (every line that starts a real invocation).
-  # Negative cases: 5 (two comments + echo doc-string + 2 trailing no-op lines).
-  local expected=15
+  # 18 positives: every non-comment line containing the danger pattern.
+  # Includes broad-match positives — nested $(), backtick wrapper, and the
+  # doc-string literal — to make the broad-match contract explicit.
+  # 5 negatives: 3 comment lines + 2 trailing no-ops.
+  local expected=18
   local got
-  got="$(grep -cE "$pattern" "$fixture" || true)"
+  got="$(count_sites "$fixture")"
 
   if [[ "$got" != "$expected" ]]; then
     echo "[lint-heredoc-ban] SELF-TEST FAIL: expected $expected matches, got $got" >&2
     echo "[lint-heredoc-ban] matches:" >&2
-    grep -nE "$pattern" "$fixture" | sed 's/^/[lint-heredoc-ban]   /' >&2 || true
+    list_sites "$fixture" | sed 's/^/[lint-heredoc-ban]   /' >&2
     return 1
   fi
 
-  # Negative checks: comment-only lines and doc strings must NOT match.
-  local negatives
-  negatives="$(grep -nE "$pattern" "$fixture" | grep -E '^[0-9]+:[[:space:]]*#|echo "doc string' || true)"
-  if [[ -n "$negatives" ]]; then
-    echo "[lint-heredoc-ban] SELF-TEST FAIL: comment/doc-string lines matched:" >&2
-    printf '%s\n' "$negatives" | sed 's/^/[lint-heredoc-ban]   /' >&2
+  local comment_hits
+  comment_hits="$(list_sites "$fixture" | grep -cE "$comment_prefix" || true)"
+  if [[ "${comment_hits:-0}" != "0" ]]; then
+    echo "[lint-heredoc-ban] SELF-TEST FAIL: $comment_hits comment-prefixed line(s) matched (must be 0):" >&2
+    list_sites "$fixture" | grep -E "$comment_prefix" | sed 's/^/[lint-heredoc-ban]   /' >&2
     return 1
   fi
 
-  echo "[lint-heredoc-ban] SELF-TEST PASS: pattern catches $got synthetic invocations across all 4 shapes."
+  echo "[lint-heredoc-ban] SELF-TEST PASS: $got positives caught (broad-match across all wrapper shapes), 0 comment-line false positives."
   return 0
 }
 
@@ -123,13 +153,13 @@ if [[ ! -f "$target_file" ]]; then
 fi
 
 if [[ "${1:-}" == "--list" ]]; then
-  grep -nE "$pattern" "$target_file" || true
+  list_sites "$target_file"
   echo
   echo "(ceiling: $ceiling)"
   exit 0
 fi
 
-count="$(grep -cE "$pattern" "$target_file" || true)"
+count="$(count_sites "$target_file")"
 
 if [[ "$count" -gt "$ceiling" ]]; then
   echo "[lint-heredoc-ban] FAIL: bridge-upgrade.sh has $count heredoc-stdin subprocess sites, exceeding the ceiling ($ceiling)." >&2
@@ -137,7 +167,7 @@ if [[ "$count" -gt "$ceiling" ]]; then
   echo "[lint-heredoc-ban] extracted to lib/upgrade-helpers/ (see existing examples)." >&2
   echo "[lint-heredoc-ban]" >&2
   echo "[lint-heredoc-ban] Detected sites:" >&2
-  grep -nE "$pattern" "$target_file" | sed 's/^/[lint-heredoc-ban]   /' >&2 || true
+  list_sites "$target_file" | sed 's/^/[lint-heredoc-ban]   /' >&2
   exit 1
 fi
 

--- a/scripts/lint-heredoc-ban.sh
+++ b/scripts/lint-heredoc-ban.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# scripts/lint-heredoc-ban.sh — ratchet lint preventing NEW heredoc-stdin
+# subprocess sites in bridge-upgrade.sh.
+#
+# Context: footgun #11 (Bash 5.3.9 `read_comsub` / `heredoc_write` deadlock
+# chain — fixed in v0.13.7 through v0.13.9). Six leap-path sites were
+# extracted to standalone helpers under lib/upgrade-helpers/; 18 off-leap
+# sites remain in bridge-upgrade.sh deferred to the S10-late stabilization
+# wave. This lint ratchets the count downward — it fails CI if anyone
+# introduces a NEW heredoc-stdin subprocess line in bridge-upgrade.sh
+# without first migrating an existing one out.
+#
+# Ratchet semantics:
+# - BRIDGE_UPGRADE_HEREDOC_CEILING (default 18) is the current allowed count.
+# - When S10-late migrates sites, the ceiling drops to the new count via
+#   PR that updates this script's default.
+# - PRs that add new heredoc-stdin without removing one push count over
+#   the ceiling and fail this lint.
+#
+# Pattern detected:
+#   <bash -s ...|python3 - ...> ... <<EOF | <<'EOF' | <<"EOF" | <<PY | <<'PY' | <<"PY" | <<-...
+# at the start of a non-comment line (so doc strings and comment mentions
+# don't trip the lint).
+#
+# This script is NOT a substitute for the migration work in S10-late;
+# it's the regression guard during S2-S9 so the bridge-upgrade.sh heredoc
+# carry-over doesn't grow while the rest of the stabilization is in
+# progress.
+#
+# Usage:
+#   scripts/lint-heredoc-ban.sh              # check, exit 1 if over ceiling
+#   scripts/lint-heredoc-ban.sh --list       # list all detected sites
+#   BRIDGE_UPGRADE_HEREDOC_CEILING=10 ...    # override ceiling for testing
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+target_file="$repo_root/bridge-upgrade.sh"
+ceiling="${BRIDGE_UPGRADE_HEREDOC_CEILING:-18}"
+
+if [[ ! -f "$target_file" ]]; then
+  echo "[lint-heredoc-ban] target file missing: $target_file" >&2
+  exit 2
+fi
+
+# Pattern: command-line invocation of bash -s / python3 - with a heredoc
+# end-marker on the same line, optionally wrapped in `if [!] ...`.
+pattern='^[[:space:]]*(if[[:space:]]+!?[[:space:]]*)?(bash[[:space:]]+-s|python3[[:space:]]+-)[[:space:]].*<<-?["'"'"']?(EOF|PY)["'"'"']?'
+
+if [[ "${1:-}" == "--list" ]]; then
+  grep -nE "$pattern" "$target_file" || true
+  echo
+  echo "(ceiling: $ceiling)"
+  exit 0
+fi
+
+count="$(grep -cE "$pattern" "$target_file" || true)"
+
+if [[ "$count" -gt "$ceiling" ]]; then
+  echo "[lint-heredoc-ban] FAIL: bridge-upgrade.sh has $count heredoc-stdin subprocess sites, exceeding the ceiling ($ceiling)." >&2
+  echo "[lint-heredoc-ban] This lint ratchets footgun #11 carry-over. New heredoc-stdin sites must be" >&2
+  echo "[lint-heredoc-ban] extracted to lib/upgrade-helpers/ (see existing examples)." >&2
+  echo "[lint-heredoc-ban]" >&2
+  echo "[lint-heredoc-ban] Detected sites:" >&2
+  grep -nE "$pattern" "$target_file" | sed 's/^/[lint-heredoc-ban]   /' >&2 || true
+  exit 1
+fi
+
+if [[ "$count" -lt "$ceiling" ]]; then
+  echo "[lint-heredoc-ban] note: count=$count is below ceiling=$ceiling. Consider lowering the ceiling in scripts/lint-heredoc-ban.sh to ratchet."
+fi
+
+echo "[lint-heredoc-ban] PASS: count=$count, ceiling=$ceiling"
+exit 0

--- a/scripts/oss-preflight.sh
+++ b/scripts/oss-preflight.sh
@@ -119,4 +119,13 @@ if (( fail != 0 )); then
   exit 1
 fi
 
+# Heredoc-ban ratchet for bridge-upgrade.sh (footgun #11 carry-over).
+# See scripts/lint-heredoc-ban.sh for policy.
+if [[ -x "$repo_root/scripts/lint-heredoc-ban.sh" ]]; then
+  if ! "$repo_root/scripts/lint-heredoc-ban.sh"; then
+    echo "[oss] heredoc-ban ratchet failed — see scripts/lint-heredoc-ban.sh policy"
+    exit 1
+  fi
+fi
+
 echo "[oss] preflight passed"


### PR DESCRIPTION
## Summary

S1.5 of the stabilization plan. release-impact: none.

Prevents NEW heredoc-stdin subprocess sites in `bridge-upgrade.sh` (footgun #11 class — Bash 5.3.9 `read_comsub` / `heredoc_write` deadlock). Six leap-path sites were extracted to `lib/upgrade-helpers/` in v0.13.7-v0.13.9. The remaining 18 off-leap sites are deferred to S10-late. This ratchet ensures the count doesn't grow during S2-S9.

## Files

- **NEW** `scripts/lint-heredoc-ban.sh` (74 lines): counts matching pattern lines vs `BRIDGE_UPGRADE_HEREDOC_CEILING` (default 18). Verbose mode + diagnostic listing on failure.
- **Modified** `scripts/oss-preflight.sh`: invokes the new lint at the tail, after the existing sensitive-string scan. Piggybacks on the existing `oss-preflight` CI job.

## Test plan

- [x] bash -n + shellcheck on lint script: clean
- [x] Running lint with current ceiling=18 (matches actual count): PASS
- [x] Running lint with ceiling=10 (synthetic regression): FAIL with diagnostic listing all 18 sites
- [x] Running lint with ceiling=25 (synthetic forgiveness): PASS
- [x] Wired into oss-preflight.sh; CI's oss-preflight job will pick it up automatically

## Refs

- Plan stage S1.5 (sequenced BEFORE S2-S5 per codex r2 correction)
- Audit E E01 (18 deferred sites catalogued)
- Footgun #11 chain: v0.13.7 PR #890, v0.13.8 PR #892, v0.13.9 PR #894, v0.13.10 release #900

🤖 Generated with [Claude Code](https://claude.com/claude-code)