### PR TITLE
fix(isolation-v2): operator-visible blockers — macOS noise + stale BRIDGE_LAYOUT=legacy unblock (S2)

### DIFF
--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1572,7 +1572,12 @@ bridge_isolation_v2_apply_row() {
       return $?
       ;;
     group_setgid)
-      :
+      # macOS no-op: POSIX setgid groups are not the security primitive
+      # on Darwin. Skip silently so callers (apply_grant_matrix_for_agent,
+      # ensure_matrix_path) don't see false-negative chown/chmod failures
+      # against an `agent-bridge-*` user/group that does not exist on
+      # this host. S2 operator-visible blocker (audit doc C-S1).
+      [[ "$(uname)" == "Darwin" ]] && return 0
       ;;
     *)
       bridge_warn "apply_row($row_name): unknown grant_mechanism '$mechanism'"
@@ -1780,6 +1785,13 @@ bridge_isolation_v2_ensure_matrix_path() {
     bridge_warn "ensure_matrix_path: row_name and agent required"
     return 1
   }
+  # macOS no-op: POSIX setgid groups are not the security primitive on
+  # Darwin (the upgrade flow does not create `agent-bridge-*` OS users
+  # or `ab-*` groups there). Daemon writers should proceed with the
+  # caller's normal FS perms; returning 1 here would spam the warning
+  # log for every per-agent state-marker write (S2 operator-visible
+  # blocker, audit doc C-S1 / B17).
+  [[ "$(uname)" == "Darwin" ]] && return 0
   local row
   row="$(bridge_isolation_v2_matrix_rows_for_agent "$agent" \
           | awk -F'|' -v n="$row_name" '$1 == n {print; exit}')"

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -132,11 +132,25 @@ bridge_layout_resolver_validate_env() {
       return 0
       ;;
     legacy|v1)
-      # v0.8.0 hard-cut: ACL-based isolation (v1) was removed. The only
-      # accepted BRIDGE_LAYOUT value is now `v2`. Fail-fast so operators
-      # who scripted `BRIDGE_LAYOUT=legacy` (or `=v1`) discover the
-      # required migration immediately instead of silently running on a
-      # half-removed code path.
+      # S2 stale-env unblock: if a valid v2 marker exists, the env value
+      # is a leftover from pre-v0.8.0 (e.g., an old shell rc, a stale
+      # tmux session, an operator script). Demote the hard-die to a
+      # warning and let the marker step run — the marker is authoritative
+      # for installs already migrated to v2. This is the codex-flagged
+      # operator-visible blocker (audit doc B17) where even the resolver
+      # consensus check trips on its own.
+      local _stale_marker_path
+      _stale_marker_path="$(bridge_isolation_v2_marker_path 2>/dev/null || true)"
+      if [[ -n "$_stale_marker_path" && -f "$_stale_marker_path" ]] \
+         && bridge_isolation_v2_marker_validate "$_stale_marker_path" >/dev/null 2>&1; then
+        bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc."
+        BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV="BRIDGE_LAYOUT (stale ${layout} override; marker=v2)"
+        unset BRIDGE_LAYOUT
+        unset BRIDGE_DATA_ROOT
+        return 1
+      fi
+      # No valid v2 marker on disk — operator hasn't migrated. Keep the
+      # original hard-die so the migration prompt surfaces.
       bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
   current_layout=${layout}
   remediation: run \`agent-bridge upgrade --apply\` to migrate, or roll back to v0.7.x.

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -139,15 +139,30 @@ bridge_layout_resolver_validate_env() {
       # for installs already migrated to v2. This is the codex-flagged
       # operator-visible blocker (audit doc B17) where even the resolver
       # consensus check trips on its own.
+      #
+      # Codex r1 catch (#904): only demote when the marker actually
+      # pins BRIDGE_LAYOUT=v2. A marker still pinned to v1 (un-migrated
+      # install) must fall through to the hard-die without the false
+      # "preferring marker" warning — that warning is part of the
+      # operator-visible contract and only correct when the marker
+      # is v2.
       local _stale_marker_path
       _stale_marker_path="$(bridge_isolation_v2_marker_path 2>/dev/null || true)"
       if [[ -n "$_stale_marker_path" && -f "$_stale_marker_path" ]] \
          && bridge_isolation_v2_marker_validate "$_stale_marker_path" >/dev/null 2>&1; then
-        bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc."
-        BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV="BRIDGE_LAYOUT (stale ${layout} override; marker=v2)"
-        unset BRIDGE_LAYOUT
-        unset BRIDGE_DATA_ROOT
-        return 1
+        local _marker_layout
+        _marker_layout="$(
+          grep -E '^[[:space:]]*BRIDGE_LAYOUT[[:space:]]*=' "$_stale_marker_path" 2>/dev/null \
+            | tail -1 \
+            | sed -E "s/^[[:space:]]*BRIDGE_LAYOUT[[:space:]]*=//; s/^[\"']//; s/[\"']$//"
+        )"
+        if [[ "$_marker_layout" == "v2" ]]; then
+          bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc."
+          BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV="BRIDGE_LAYOUT (stale ${layout} override; marker=v2)"
+          unset BRIDGE_LAYOUT
+          unset BRIDGE_DATA_ROOT
+          return 1
+        fi
       fi
       # No valid v2 marker on disk — operator hasn't migrated. Keep the
       # original hard-die so the migration prompt surfaces.

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression layout-resolver-marker-over-env upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-codex-pair mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir
 }
 
 add_all_integration() {
@@ -305,7 +305,7 @@ select_for_path() {
       # (T1-T5 marker-write contract + T6 post-marker workdir resolver)
       # for every isolation-lib + bridge-migrate.sh move so the fast-path
       # stays covered.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke/isolation-v2-macos-noise-suppression.sh
+++ b/scripts/smoke/isolation-v2-macos-noise-suppression.sh
@@ -91,7 +91,7 @@ if ! grep -q '^RC=0$' "$T1_OUT"; then
   smoke_log "T1 output:"; cat "$T1_OUT"
   smoke_fail "T1: ensure_matrix_path did not return 0 on Darwin"
 fi
-if grep -q 'ensure_matrix_path' "$T1_OUT" | grep -qE 'failed|not found|required'; then
+if grep -qE 'ensure_matrix_path.*(failed|not found|required)' "$T1_OUT"; then
   smoke_log "T1 output:"; cat "$T1_OUT"
   smoke_fail "T1: ensure_matrix_path emitted a warning on Darwin (must be silent no-op)"
 fi

--- a/scripts/smoke/isolation-v2-macos-noise-suppression.sh
+++ b/scripts/smoke/isolation-v2-macos-noise-suppression.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# S2 regression smoke — macOS isolation-v2 noise suppression.
+#
+# Reproduces the operator-visible blocker on Sean's mac (v0.13.10 audit
+# B17 / C-S1):
+#   `[경고] write_agent_state_marker: ensure_matrix_path failed for
+#    agent=... marker=idle-since`
+#
+# Root cause: on Darwin the isolation-v2 enforcement primitives (POSIX
+# setgid groups, `agent-bridge-*` OS users) are not the security model;
+# the upgrade flow does not create them. But `ensure_matrix_path` /
+# `apply_row` would still run the chown/chmod path and fail loudly,
+# spamming the warning log on every daemon state-marker write.
+#
+# Fix (lib/bridge-isolation-v2.sh): both functions now return 0 silently
+# on Darwin. This smoke is the regression guard.
+#
+# Coverage (Darwin-only):
+#   T1 — ensure_matrix_path returns 0 on Darwin without invoking the
+#        matrix lookup or emitting warnings.
+#   T2 — apply_row with mechanism=group_setgid returns 0 on Darwin
+#        without invoking chown/chmod.
+#
+# On Linux this smoke skip-passes (the gates don't engage and the
+# normal v2 enforcement path runs — that's covered by other smokes).
+
+set -uo pipefail
+
+SMOKE_NAME="isolation-v2-macos-noise-suppression"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+if [[ "$(uname -s 2>/dev/null || printf '')" != "Darwin" ]]; then
+  smoke_log "non-Darwin host; this smoke is a Darwin-only regression guard — PASS (skipped)"
+  exit 0
+fi
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ -x /opt/homebrew/bin/bash ]]; then
+  BRIDGE_BASH=/opt/homebrew/bin/bash
+elif [[ -x /usr/local/bin/bash ]]; then
+  BRIDGE_BASH=/usr/local/bin/bash
+fi
+
+run_isolation_call() {
+  # Invoke a v2 helper in a clean subshell and capture stdout+stderr.
+  # Args: $1 = call snippet, $2 = out_file
+  local snippet="$1"
+  local out_file="$2"
+  local driver="$SMOKE_TMP_ROOT/driver-$$.sh"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'set -uo pipefail'
+    printf 'cd %q\n' "$REPO_ROOT"
+    printf 'export BRIDGE_HOME=%q\n' "$SMOKE_TMP_ROOT/bh"
+    printf 'export BRIDGE_STATE_DIR=%q\n' "$SMOKE_TMP_ROOT/bh/state"
+    printf 'export BRIDGE_LAYOUT=v2\n'
+    printf 'export BRIDGE_DATA_ROOT=%q\n' "$SMOKE_TMP_ROOT/bh/data"
+    printf 'export BRIDGE_LAYOUT_RESOLVER_BYPASS_NONCE=smoke-noise\n'
+    printf '%s\n' 'mkdir -p "$BRIDGE_HOME/state" "$BRIDGE_DATA_ROOT"'
+    printf '%s\n' 'source "$0_REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1'
+    printf '%s\n' "$snippet"
+  } | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$driver"
+  chmod +x "$driver"
+
+  "$BRIDGE_BASH" "$driver" >"$out_file" 2>&1
+  local rc=$?
+  rm -f "$driver"
+  return $rc
+}
+
+# T1 — ensure_matrix_path on Darwin returns 0 silently.
+smoke_log "T1: ensure_matrix_path Darwin no-op"
+T1_OUT="$SMOKE_TMP_ROOT/t1.out"
+run_isolation_call \
+  'bridge_isolation_v2_ensure_matrix_path state-agent-dir testagent; echo "RC=$?"' \
+  "$T1_OUT" || true
+
+if ! grep -q '^RC=0$' "$T1_OUT"; then
+  smoke_log "T1 output:"; cat "$T1_OUT"
+  smoke_fail "T1: ensure_matrix_path did not return 0 on Darwin"
+fi
+if grep -q 'ensure_matrix_path' "$T1_OUT" | grep -qE 'failed|not found|required'; then
+  smoke_log "T1 output:"; cat "$T1_OUT"
+  smoke_fail "T1: ensure_matrix_path emitted a warning on Darwin (must be silent no-op)"
+fi
+smoke_log "T1 PASS"
+
+# T2 — apply_row group_setgid on Darwin returns 0 silently without chown/chmod.
+smoke_log "T2: apply_row group_setgid Darwin no-op"
+T2_OUT="$SMOKE_TMP_ROOT/t2.out"
+T2_PATH="$SMOKE_TMP_ROOT/t2-target-dir"
+run_isolation_call \
+  "mkdir -p \"$T2_PATH\"; bridge_isolation_v2_apply_row apply test-row \"$T2_PATH\" dir root ab-shared 2750 0640 1 group_setgid required; echo \"RC=\$?\"" \
+  "$T2_OUT" || true
+
+if ! grep -q '^RC=0$' "$T2_OUT"; then
+  smoke_log "T2 output:"; cat "$T2_OUT"
+  smoke_fail "T2: apply_row group_setgid did not return 0 on Darwin"
+fi
+if grep -qE 'chown:|chmod:|operation not permitted|cannot resolve|unknown grant' "$T2_OUT"; then
+  smoke_log "T2 output:"; cat "$T2_OUT"
+  smoke_fail "T2: apply_row group_setgid invoked chown/chmod (must be silent no-op on Darwin)"
+fi
+smoke_log "T2 PASS"
+
+smoke_log "PASS — macOS noise suppression intact"
+exit 0

--- a/scripts/smoke/layout-resolver-marker-over-env.sh
+++ b/scripts/smoke/layout-resolver-marker-over-env.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# S2 regression smoke — BRIDGE_LAYOUT=legacy stale-env demotion.
+#
+# Reproduces the operator-visible blocker (v0.13.10 audit B17) where the
+# layout resolver hard-died on `BRIDGE_LAYOUT=legacy` env even when the
+# install was already migrated to v2 (a valid v2 marker on disk). The
+# leak source is typically an old shell rc, a stale tmux session, or an
+# operator script left over from pre-v0.8.0.
+#
+# Fix (lib/bridge-layout-resolver.sh): when env says legacy|v1 AND a
+# valid v2 marker exists, demote to warning and prefer the marker.
+# When no marker exists, keep the original hard-die so the operator
+# sees the migration prompt.
+#
+# Coverage (cross-platform):
+#   C1 — env=legacy + valid v2 marker present → resolver does NOT die,
+#        warning emitted, BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV set,
+#        marker step takes over (resolver source becomes "marker").
+#   C2 — env=v2 + matching BRIDGE_DATA_ROOT (existing valid-env path) →
+#        resolver returns source="env" (regression guard for valid env
+#        overrides).
+#   C3 — env=legacy + NO marker → resolver DIES with the original
+#        migration prompt (regression guard for unmigrated installs).
+
+set -uo pipefail
+
+SMOKE_NAME="layout-resolver-marker-over-env"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# Build a v2 marker file the resolver will accept. Validator allows only
+# the keys in `marker_bootstrap.sh::bridge_isolation_v2_marker_validate`
+# (BRIDGE_LAYOUT, BRIDGE_DATA_ROOT, plus group/prefix vars). Mode must
+# not have group/world write bits.
+write_v2_marker() {
+  local home_dir="$1"
+  local data_root="$2"
+  local marker_dir="$home_dir/state"
+  local marker_file="$marker_dir/layout-marker.sh"
+  mkdir -p "$marker_dir"
+  {
+    printf '%s\n' '# bridge layout marker (v2) — written by smoke fixture'
+    printf 'BRIDGE_LAYOUT=v2\n'
+    printf 'BRIDGE_DATA_ROOT=%s\n' "$data_root"
+  } > "$marker_file"
+  chmod 0644 "$marker_file"
+}
+
+run_resolver() {
+  # Args: $1 = env_layout, $2 = env_data_root, $3 = home_dir, $4 = write_marker (1|0), $5 = out_file
+  local env_layout="$1"
+  local env_data_root="$2"
+  local home_dir="$3"
+  local write_marker="$4"
+  local out_file="$5"
+
+  mkdir -p "$home_dir/state" "$env_data_root"
+  if [[ "$write_marker" == "1" ]]; then
+    write_v2_marker "$home_dir" "$env_data_root"
+  else
+    rm -f "$home_dir/state/layout-marker.sh"
+  fi
+
+  local driver="$SMOKE_TMP_ROOT/driver-$$.sh"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'set -uo pipefail'
+    printf 'cd %q\n' "$REPO_ROOT"
+    printf 'export BRIDGE_HOME=%q\n' "$home_dir"
+    printf 'export BRIDGE_STATE_DIR=%q\n' "$home_dir/state"
+    printf 'export BRIDGE_LAYOUT_MARKER_DIR=%q\n' "$home_dir/state"
+    if [[ -n "$env_layout" ]]; then
+      printf 'export BRIDGE_LAYOUT=%q\n' "$env_layout"
+    fi
+    if [[ -n "$env_data_root" ]]; then
+      printf 'export BRIDGE_DATA_ROOT=%q\n' "$env_data_root"
+    fi
+    printf '%s\n' 'source "$0_REPO_ROOT/bridge-lib.sh" 2>&1; rc=$?'
+    printf '%s\n' 'echo "RC=$rc"'
+    printf '%s\n' 'echo "LAYOUT=$BRIDGE_LAYOUT"'
+    printf '%s\n' 'echo "SOURCE=${BRIDGE_LAYOUT_SOURCE:-<unset>}"'
+    printf '%s\n' 'echo "IGNORED=${BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV:-<unset>}"'
+  } | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$driver"
+  chmod +x "$driver"
+
+  "$BRIDGE_BASH" "$driver" >"$out_file" 2>&1
+  rm -f "$driver"
+}
+
+# C1 — env=legacy + valid v2 marker → demote, prefer marker
+smoke_log "C1: env=legacy + valid v2 marker → demote-to-warning"
+C1_HOME="$SMOKE_TMP_ROOT/c1-home"
+C1_DATA="$SMOKE_TMP_ROOT/c1-data"
+C1_OUT="$SMOKE_TMP_ROOT/c1.out"
+run_resolver "legacy" "$C1_DATA" "$C1_HOME" 1 "$C1_OUT"
+
+if grep -q 'requires isolation-v2' "$C1_OUT" && ! grep -q 'stale pre-v0.8.0 env override' "$C1_OUT"; then
+  smoke_log "C1 output:"; cat "$C1_OUT"
+  smoke_fail "C1: resolver still hard-died with stale legacy env over valid v2 marker"
+fi
+if ! grep -q 'stale pre-v0.8.0 env override' "$C1_OUT"; then
+  smoke_log "C1 output:"; cat "$C1_OUT"
+  smoke_fail "C1: expected demotion warning ('stale pre-v0.8.0 env override') not found"
+fi
+if ! grep -q 'SOURCE=marker' "$C1_OUT"; then
+  smoke_log "C1 output:"; cat "$C1_OUT"
+  smoke_fail "C1: expected SOURCE=marker after demotion (got: $(grep '^SOURCE=' "$C1_OUT"))"
+fi
+smoke_log "C1 PASS"
+
+# C2 — env=v2 + matching data_root (existing valid-env path)
+smoke_log "C2: env=v2 + matching data_root → source=env"
+C2_HOME="$SMOKE_TMP_ROOT/c2-home"
+C2_DATA="$SMOKE_TMP_ROOT/c2-data"
+C2_OUT="$SMOKE_TMP_ROOT/c2.out"
+run_resolver "v2" "$C2_DATA" "$C2_HOME" 0 "$C2_OUT"
+
+if ! grep -q 'SOURCE=env' "$C2_OUT"; then
+  smoke_log "C2 output:"; cat "$C2_OUT"
+  smoke_fail "C2: expected SOURCE=env for valid env override (got: $(grep '^SOURCE=' "$C2_OUT"))"
+fi
+smoke_log "C2 PASS"
+
+# C3 — env=legacy + NO marker → still die
+smoke_log "C3: env=legacy + no marker → preserve hard-die"
+C3_HOME="$SMOKE_TMP_ROOT/c3-home"
+C3_DATA="$SMOKE_TMP_ROOT/c3-data"
+C3_OUT="$SMOKE_TMP_ROOT/c3.out"
+run_resolver "legacy" "$C3_DATA" "$C3_HOME" 0 "$C3_OUT" || true
+
+if ! grep -q 'requires isolation-v2' "$C3_OUT"; then
+  smoke_log "C3 output:"; cat "$C3_OUT"
+  smoke_fail "C3: expected hard-die ('requires isolation-v2') when no v2 marker present"
+fi
+if grep -q 'stale pre-v0.8.0 env override' "$C3_OUT"; then
+  smoke_log "C3 output:"; cat "$C3_OUT"
+  smoke_fail "C3: must NOT demote when there is no v2 marker on disk"
+fi
+smoke_log "C3 PASS"
+
+smoke_log "PASS — stale-env demotion behaves correctly across 3 cases"
+exit 0

--- a/scripts/smoke/layout-resolver-marker-over-env.sh
+++ b/scripts/smoke/layout-resolver-marker-over-env.sh
@@ -21,6 +21,11 @@
 #        overrides).
 #   C3 — env=legacy + NO marker → resolver DIES with the original
 #        migration prompt (regression guard for unmigrated installs).
+#   C4 — env=legacy + marker pinned to v1 → resolver DIES WITHOUT the
+#        false "preferring marker" warning. Codex r1 catch on PR #904:
+#        the demotion contract is "env=legacy + marker=v2 → demote";
+#        a v1 marker is itself un-migrated and must surface the hard-die
+#        without the misleading warning.
 
 set -uo pipefail
 
@@ -65,20 +70,39 @@ write_v2_marker() {
   chmod 0644 "$marker_file"
 }
 
+# Build a v1 (un-migrated) marker for the false-positive guard. The
+# validator returns 0 for this shape (only the v2 branch checks
+# data_root) — codex r1 caught that we were demoting based on validator
+# rc alone.
+write_v1_marker() {
+  local home_dir="$1"
+  local marker_dir="$home_dir/state"
+  local marker_file="$marker_dir/layout-marker.sh"
+  mkdir -p "$marker_dir"
+  {
+    printf '%s\n' '# bridge layout marker (v1) — un-migrated, smoke fixture'
+    printf 'BRIDGE_LAYOUT=v1\n'
+  } > "$marker_file"
+  chmod 0644 "$marker_file"
+}
+
 run_resolver() {
-  # Args: $1 = env_layout, $2 = env_data_root, $3 = home_dir, $4 = write_marker (1|0), $5 = out_file
+  # Args: $1 = env_layout, $2 = env_data_root, $3 = home_dir,
+  #       $4 = marker_kind (v2|v1|none), $5 = out_file
   local env_layout="$1"
   local env_data_root="$2"
   local home_dir="$3"
-  local write_marker="$4"
+  local marker_kind="$4"
   local out_file="$5"
 
   mkdir -p "$home_dir/state" "$env_data_root"
-  if [[ "$write_marker" == "1" ]]; then
-    write_v2_marker "$home_dir" "$env_data_root"
-  else
-    rm -f "$home_dir/state/layout-marker.sh"
-  fi
+  case "$marker_kind" in
+    v2) write_v2_marker "$home_dir" "$env_data_root" ;;
+    v1) write_v1_marker "$home_dir" ;;
+    none|0) rm -f "$home_dir/state/layout-marker.sh" ;;
+    1) write_v2_marker "$home_dir" "$env_data_root" ;;
+    *) smoke_fail "internal: unknown marker_kind=$marker_kind" ;;
+  esac
 
   local driver="$SMOKE_TMP_ROOT/driver-$$.sh"
   {
@@ -157,5 +181,22 @@ if grep -q 'stale pre-v0.8.0 env override' "$C3_OUT"; then
 fi
 smoke_log "C3 PASS"
 
-smoke_log "PASS — stale-env demotion behaves correctly across 3 cases"
+# C4 — env=legacy + marker pinned to v1 (un-migrated) → no false demote
+smoke_log "C4: env=legacy + marker pinned to v1 → hard-die WITHOUT demotion warning"
+C4_HOME="$SMOKE_TMP_ROOT/c4-home"
+C4_DATA="$SMOKE_TMP_ROOT/c4-data"
+C4_OUT="$SMOKE_TMP_ROOT/c4.out"
+run_resolver "legacy" "$C4_DATA" "$C4_HOME" "v1" "$C4_OUT" || true
+
+if ! grep -q 'requires isolation-v2' "$C4_OUT"; then
+  smoke_log "C4 output:"; cat "$C4_OUT"
+  smoke_fail "C4: expected hard-die ('requires isolation-v2') when marker pins layout to v1"
+fi
+if grep -q 'stale pre-v0.8.0 env override' "$C4_OUT"; then
+  smoke_log "C4 output:"; cat "$C4_OUT"
+  smoke_fail "C4: must NOT emit the 'preferring marker' demotion warning when marker pins layout to v1"
+fi
+smoke_log "C4 PASS"
+
+smoke_log "PASS — stale-env demotion behaves correctly across 4 cases"
 exit 0


### PR DESCRIPTION
## Summary
- S2 of the v0.14.x stabilization plan — two narrow operator-visible blockers (audit B17 + C-S1).
- Track 2A: macOS isolation-v2 matrix-path noise suppression (`bridge_isolation_v2_ensure_matrix_path` + `apply_row` group_setgid path → Darwin early-return).
- Track 2B: `BRIDGE_LAYOUT=legacy` stale-env demotion in `bridge_layout_resolver_validate_env` — when a valid v2 marker exists, log warning + prefer marker (was hard-die).
- 2 new smoke tests registered in `ci-select-smoke.sh`: `isolation-v2-macos-noise-suppression` (Darwin-only, 2 cases) and `layout-resolver-marker-over-env` (3 cases).

release-impact: user-visible
- macOS operators stop seeing the per-marker `ensure_matrix_path failed` noise.
- Operators with leaked `BRIDGE_LAYOUT=legacy` get a one-line warning pointing at the rc to unset, instead of a hard-die.

Per the stabilization plan's version policy (operator directive 2026-05-15), this PR does NOT bump VERSION/CHANGELOG. The next release PR is operator-cued and batches accumulated user-visible items.

## Test plan
- [x] `bash -n` + `shellcheck` clean on edited files
- [x] `bash scripts/smoke/isolation-v2-macos-noise-suppression.sh` — T1/T2 PASS on macOS
- [x] `bash scripts/smoke/layout-resolver-marker-over-env.sh` — C1/C2/C3 PASS on macOS
- [x] `bash scripts/lint-heredoc-ban.sh` — count=18, no regression
- [ ] CI green (syntax / lint / oss-preflight / smoke matrix)
- [ ] OrbStack Linux VM verification (linux-systemd-test) — defer to merge gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
