### PR TITLE
feat(isolation-v2): S5 Track A2 — Bucket 2 gate for v2-reapply strip_layout_acls

### DIFF
--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -82,6 +82,20 @@
 # 1. helpers — platform / agent enumeration
 # ---------------------------------------------------------------------------
 
+# Source the platform discriminator if not already loaded. Same two-path
+# pattern as lib/bridge-isolation-v2.sh:122-129 — bridge-lib.sh / bridge-
+# migrate.sh sources it before us in the normal flow, but a direct caller
+# (e.g., a tool that sources only this module) needs the helper brought
+# in here so `bridge_isolation_v2_enforce` resolves at line 753 below.
+if ! declare -f bridge_isolation_v2_enforce >/dev/null 2>&1; then
+  _BRIDGE_V2_REAPPLY_MODULE_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+  if [[ -f "$_BRIDGE_V2_REAPPLY_MODULE_DIR/bridge-isolation-discriminator.sh" ]]; then
+    # shellcheck source=bridge-isolation-discriminator.sh
+    source "$_BRIDGE_V2_REAPPLY_MODULE_DIR/bridge-isolation-discriminator.sh"
+  fi
+  unset _BRIDGE_V2_REAPPLY_MODULE_DIR
+fi
+
 bridge_isolation_v2_reapply_supported_platform() {
   # Reapply touches Linux-only primitives (sudo chown to a foreign UID,
   # setfacl). On non-Linux hosts the linux-user isolation mode itself is

--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -742,6 +742,21 @@ bridge_isolation_v2_reapply_strip_layout_acls() {
     return 0
   fi
 
+  # Platform discriminator gate (S5 Track A2, audit C-S2 Bucket 2):
+  # POSIX `setfacl` is Linux-only. The tool-presence check below would
+  # false-pass on a Darwin host with Homebrew-installed Linux setfacl
+  # (BSD ACL semantics differ — silent no-op or attribute-error). The
+  # discriminator gate is platform-aware and pre-empts the tool-presence
+  # check on non-Linux hosts. Operator can force via
+  # BRIDGE_ISOLATION_REQUIRED=yes (the tool-presence check still
+  # protects against missing setfacl on Linux).
+  if ! bridge_isolation_v2_enforce; then
+    bridge_isolation_v2_reapply_record_action \
+      "$actions_file" "$root" "setfacl_strip_recursive" \
+      "non-linux-host" "non-linux-host" "skipped:platform-discriminator"
+    return 0
+  fi
+
   if ! command -v setfacl >/dev/null 2>&1; then
     # ACL toolchain absent → nothing was set, nothing to strip.
     bridge_isolation_v2_reapply_record_action \

--- a/scripts/smoke/isolation-v2-bucket2-gates.sh
+++ b/scripts/smoke/isolation-v2-bucket2-gates.sh
@@ -230,5 +230,83 @@ if grep -q '^RC=0$' "$G6_OUT"; then
 fi
 smoke_log "G6 PASS (explicit opt-in engaged enforcement on Darwin)"
 
-smoke_log "PASS — Bucket 2 gates wired correctly across 6 cases (C08: G1/G2/G3, C13: G4/G5/G6)"
+# --- C-S2 direct coverage (reapply_strip_layout_acls) ---------------------
+# Audit C-S2 (S5 Track A2): the setfacl tool-presence check would false-pass
+# on Darwin with Homebrew-installed Linux setfacl. The discriminator gate
+# pre-empts that. Verifies the new action-record code path.
+
+run_strip_probe() {
+  # Args: $1 = env_required, $2 = host_override, $3 = out_file
+  local env_required="$1"
+  local host_override="$2"
+  local out_file="$3"
+  local driver="$SMOKE_TMP_ROOT/strip-driver-$$.sh"
+  local actions_file="$SMOKE_TMP_ROOT/strip-actions-$$.tsv"
+  local errors_file="$SMOKE_TMP_ROOT/strip-errors-$$.tsv"
+  local target_dir="$SMOKE_TMP_ROOT/strip-target-$$"
+  mkdir -p "$target_dir"
+  : >"$actions_file"
+  : >"$errors_file"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'set -uo pipefail'
+    printf 'cd %q\n' "$REPO_ROOT"
+    printf 'export BRIDGE_HOME=%q\n' "$SMOKE_TMP_ROOT/strip-bh-$$"
+    printf 'export BRIDGE_STATE_DIR=%q\n' "$SMOKE_TMP_ROOT/strip-bh-$$/state"
+    printf 'export BRIDGE_LAYOUT=v2\n'
+    printf 'export BRIDGE_DATA_ROOT=%q\n' "$SMOKE_TMP_ROOT/strip-bh-$$/data"
+    printf 'export BRIDGE_HOST_PLATFORM_OVERRIDE=%q\n' "$host_override"
+    if [[ -n "$env_required" ]]; then
+      printf 'export BRIDGE_ISOLATION_REQUIRED=%q\n' "$env_required"
+    fi
+    printf '%s\n' 'mkdir -p "$BRIDGE_HOME/state" "$BRIDGE_DATA_ROOT"'
+    printf '%s\n' 'source "$0_REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1'
+    printf 'bridge_isolation_v2_reapply_strip_layout_acls apply 1 %q %q %q; echo "RC=$?"\n' \
+      "$actions_file" "$errors_file" "$target_dir"
+    printf 'echo "ACTIONS:"; cat %q\n' "$actions_file"
+  } | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$driver"
+  chmod +x "$driver"
+
+  "$BRIDGE_BASH" "$driver" >"$out_file" 2>&1
+  rm -f "$driver"
+}
+
+# G7 — strip_layout_acls Darwin default → skipped:platform-discriminator
+smoke_log "G7: strip_layout_acls Darwin default → discriminator skip"
+G7_OUT="$SMOKE_TMP_ROOT/g7.out"
+run_strip_probe "" "Darwin" "$G7_OUT"
+
+if ! grep -q '^RC=0$' "$G7_OUT"; then
+  cat "$G7_OUT"; smoke_fail "G7: expected RC=0 (silent no-op on Darwin)"
+fi
+if ! grep -q 'skipped:platform-discriminator' "$G7_OUT"; then
+  cat "$G7_OUT"; smoke_fail "G7: expected the new platform-discriminator action record on Darwin"
+fi
+smoke_log "G7 PASS"
+
+# G8 — strip_layout_acls Linux default → engages, hits the
+# tool-presence check or proceeds to setfacl. RC=0 either way (since
+# the function always records and returns 0 on missing tooling or
+# completed strip).
+smoke_log "G8: strip_layout_acls Linux default → gate engaged (not skipped:platform-discriminator)"
+G8_OUT="$SMOKE_TMP_ROOT/g8.out"
+run_strip_probe "" "Linux" "$G8_OUT"
+
+if grep -q 'skipped:platform-discriminator' "$G8_OUT"; then
+  cat "$G8_OUT"; smoke_fail "G8: gate short-circuited on host=Linux (should engage)"
+fi
+smoke_log "G8 PASS (gate engaged on host=Linux)"
+
+# G9 — strip_layout_acls Darwin + opt-in → engages
+smoke_log "G9: strip_layout_acls Darwin + opt-in → gate engaged"
+G9_OUT="$SMOKE_TMP_ROOT/g9.out"
+run_strip_probe "yes" "Darwin" "$G9_OUT"
+
+if grep -q 'skipped:platform-discriminator' "$G9_OUT"; then
+  cat "$G9_OUT"; smoke_fail "G9: gate short-circuited on Darwin+opt-in (should engage)"
+fi
+smoke_log "G9 PASS (explicit opt-in overrode Darwin default)"
+
+smoke_log "PASS — Bucket 2 gates wired correctly across 9 cases (C08: G1/G2/G3, C13: G4/G5/G6, C-S2: G7/G8/G9)"
 exit 0

--- a/scripts/smoke/isolation-v2-bucket2-gates.sh
+++ b/scripts/smoke/isolation-v2-bucket2-gates.sh
@@ -308,5 +308,40 @@ if grep -q 'skipped:platform-discriminator' "$G9_OUT"; then
 fi
 smoke_log "G9 PASS (explicit opt-in overrode Darwin default)"
 
-smoke_log "PASS — Bucket 2 gates wired correctly across 9 cases (C08: G1/G2/G3, C13: G4/G5/G6, C-S2: G7/G8/G9)"
+# G10 — standalone reapply module source brings in discriminator.
+# Codex r1 catch on PR #911: a direct caller sourcing only
+# lib/bridge-isolation-v2-reapply.sh (without bridge-lib.sh) hit
+# `bridge_isolation_v2_enforce: command not found`. r2 added the
+# guarded self-source pattern. This case verifies the regression
+# guard for the standalone source path.
+smoke_log "G10: standalone reapply module source brings in discriminator"
+G10_OUT="$SMOKE_TMP_ROOT/g10.out"
+G10_DRIVER="$SMOKE_TMP_ROOT/g10-driver.sh"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -uo pipefail'
+  printf 'cd %q\n' "$REPO_ROOT"
+  # Stub bridge_warn / bridge_die as the standalone harness pattern does.
+  printf '%s\n' 'bridge_warn() { printf "[stub_warn] %s\n" "$*" >&2; }'
+  printf '%s\n' 'bridge_die() { printf "[stub_die] %s\n" "$*" >&2; exit 1; }'
+  # Source ONLY the reapply module (no bridge-lib.sh).
+  printf '%s\n' 'source "$0_REPO_ROOT/lib/bridge-isolation-v2-reapply.sh" 2>&1'
+  printf '%s\n' 'if declare -f bridge_isolation_v2_enforce >/dev/null 2>&1; then echo "ENFORCE_DEFINED=yes"; else echo "ENFORCE_DEFINED=no"; fi'
+  # Sanity probe: with host=Linux, the gate must engage (not the discriminator-skip path).
+  printf '%s\n' 'export BRIDGE_HOST_PLATFORM_OVERRIDE=Linux'
+  printf '%s\n' 'bridge_isolation_v2_enforce; echo "ENFORCE_RC=$?"'
+} | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$G10_DRIVER"
+chmod +x "$G10_DRIVER"
+"$BRIDGE_BASH" "$G10_DRIVER" >"$G10_OUT" 2>&1 || true
+rm -f "$G10_DRIVER"
+
+if ! grep -q '^ENFORCE_DEFINED=yes$' "$G10_OUT"; then
+  cat "$G10_OUT"; smoke_fail "G10: standalone reapply source did not bring in bridge_isolation_v2_enforce"
+fi
+if ! grep -q '^ENFORCE_RC=0$' "$G10_OUT"; then
+  cat "$G10_OUT"; smoke_fail "G10: bridge_isolation_v2_enforce did not return 0 with host=Linux override"
+fi
+smoke_log "G10 PASS"
+
+smoke_log "PASS — Bucket 2 gates wired correctly across 10 cases (C08: G1/G2/G3, C13: G4/G5/G6, C-S2: G7/G8/G9, standalone: G10)"
 exit 0


### PR DESCRIPTION
## Summary
- S5 Track A2 of the v0.14.x stabilization plan — extends platform-discriminator gate to `bridge_isolation_v2_reapply_strip_layout_acls` per audit C-S2.
- Audit C-S2 concern: the existing tool-presence check (`command -v setfacl`) would false-pass on Darwin with Homebrew-installed Linux setfacl (BSD ACL semantics differ).
- Smoke extended to 9 cases total (added G7/G8/G9 for C-S2 direct coverage).

release-impact: migration (part of v0.14.0 milestone bundle). Default behavior unchanged.

Per plan §"Version policy", no VERSION/CHANGELOG bump.

## Test plan
- [x] `bash -n` + `shellcheck` clean
- [x] `iso*-bucket2*.sh` 9/9 PASS (macOS)
- [x] Linux VM (linux-systemd-test) 9/9 PASS
- [x] All S2/S3 regressions still green
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
