### PR TITLE
fix(install): clean install regressions — _template evidence + fresh-install daemon-restart

### DIFF
--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -82,9 +82,19 @@ bridge_layout_resolver_has_existing_evidence() {
   fi
 
   if [[ -d "$home/agents" ]]; then
-    local entry
+    local entry name
     for entry in "$home/agents"/*/; do
       [[ -d "$entry" ]] || continue
+      # Skip non-agent reserved entries — names starting with `_` or `.`
+      # are documentation / template dirs (e.g. `_template/` for fresh
+      # agent scaffolding, `_shared/` for cross-agent assets) that ship
+      # with every fresh source checkout. Clean install would otherwise
+      # be misclassified as `markerless(existing-install)` and hard-die
+      # on first bootstrap.
+      name="$(basename "${entry%/}")"
+      case "$name" in
+        _*|.*) continue ;;
+      esac
       # Non-empty agent home directory (CLAUDE.md, settings.json, etc.).
       if compgen -G "$entry"'*' >/dev/null 2>&1; then
         return 0

--- a/scripts/deploy-live-install.sh
+++ b/scripts/deploy-live-install.sh
@@ -280,6 +280,16 @@ if [[ "$RESTART_DAEMON" == "1" ]]; then
   if [[ "$DRY_RUN" == "1" ]]; then
     printf '[dry-run] bash %s/bridge-daemon.sh stop --force\n' "$TARGET_ROOT"
     printf '[dry-run] bash %s/bridge-daemon.sh ensure\n' "$TARGET_ROOT"
+  elif [[ ! -f "$TARGET_ROOT/state/layout-marker.sh" ]]; then
+    # Clean install path: layout-marker.sh hasn't been written yet
+    # (bridge-bootstrap.sh writes it on first run). Skipping daemon
+    # restart here — the bootstrap step that follows is the canonical
+    # marker-writer + first daemon-start. Without this skip,
+    # bridge-daemon.sh ensure would source bridge-lib.sh, which would
+    # hard-die in bridge_layout_resolver_init at
+    # `markerless(fresh-install-candidate)` because the bypass nonce
+    # is not armed for this subprocess.
+    DAEMON_RESTART_SKIPPED=1
   else
     # --force: deploy-live-install is a sanctioned daemon stop+restart path
     # and must not be blocked by the #314/#315 active-agent guard.
@@ -297,4 +307,8 @@ if [[ "$DRY_RUN" == "0" ]]; then
   printf 'verified_files: %s\n' "$VERIFIED_COUNT"
   printf 'upgrade_state_written: %s\n' "$([[ "$UPGRADE_STATE_WRITTEN" == "1" ]] && printf yes || printf no)"
 fi
-printf 'daemon_restarted: %s\n' "$([[ "$RESTART_DAEMON" == "1" ]] && printf yes || printf no)"
+if [[ "${DAEMON_RESTART_SKIPPED:-0}" == "1" ]]; then
+  printf 'daemon_restarted: skipped-fresh-install\n'
+else
+  printf 'daemon_restarted: %s\n' "$([[ "$RESTART_DAEMON" == "1" ]] && printf yes || printf no)"
+fi


### PR DESCRIPTION
## Summary
- E2E clean install test on Ubuntu 24.04 VM (agb-clean-test, 2026-05-16) caught TWO regressions blocking the README installer flow.
- Both fixes land in this PR (single commit, 2 files).

## Issues found

### #1 — `_template/` misclassified as real agent home (BLOCKING)
`bridge_layout_resolver_has_existing_evidence` iterates `agents/*/` and treats every non-empty dir as evidence of an existing install. The tracked source ships `agents/_template/` (agent scaffolding base) which `deploy-live-install.sh` copies into fresh BRIDGE_HOME. That trips evidence detection → resolver classifies as `markerless(existing-install)` → hard-die — even though `bridge-bootstrap.sh` armed the fresh-install bypass.

**Fix**: skip basenames starting with `_` (template/shared reserved) or `.` (hidden) in evidence iteration.

### #2 — `deploy-live-install.sh --restart-daemon` on fresh install (BLOCKING)
After #1 fix, deploy-live-install proceeded to "fresh-install-candidate" classification, but `--restart-daemon` still calls `bridge-daemon.sh ensure`. That subprocess sources `bridge-lib.sh` without the bypass nonce armed, hits the resolver, and hard-dies again. The fresh install hasn't been bootstrapped yet — there's no daemon to restart.

**Fix**: if `state/layout-marker.sh` is missing, skip daemon restart silently. Report `daemon_restarted: skipped-fresh-install` so operators see why. `bridge-bootstrap.sh` (the step that follows in the README installer) is the canonical marker-writer + first daemon-start.

## Verification

Reproduced + fixed on agb-clean-test (Ubuntu 24.04, Bash 5.2.21):

Pre-fix:
```
$ bash scripts/deploy-live-install.sh --target ~/.agent-bridge --restart-daemon
[오류] Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
  current_layout=markerless(existing-install)
```

Post-fix:
```
$ bash scripts/deploy-live-install.sh --target ~/.agent-bridge --restart-daemon
[info] deploy-live-install: critical-perm verification passed
...
daemon_restarted: skipped-fresh-install
deploy exit=0
```

## Test plan
- [x] `bash -n` + `shellcheck` clean
- [x] Reproduce + verify on agb-clean-test VM
- [x] `lint-heredoc-ban` count=18 unchanged
- [ ] CI green
- [ ] Post-fix verify: bridge-bootstrap.sh follows up cleanly (Phase 4 of E2E test, pending Claude CLI install on VM)

release-impact: user-visible — fixes README clean install flow. Batch into next release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
