### PR TITLE
fix(bootstrap): skip admin codex pair when codex CLI absent

### DIFF
--- a/lib/bridge-admin-pair.sh
+++ b/lib/bridge-admin-pair.sh
@@ -34,6 +34,19 @@ bridge_ensure_admin_codex_pair() {
     return 0
   fi
 
+  # E2E test on Ubuntu 24.04 (2026-05-16) caught a fresh-install
+  # regression: bridge-bootstrap.sh always creates the codex pair, even
+  # when codex CLI is absent. The pair then crash-loops indefinitely,
+  # the watchdog files [crash-loop] tasks, and the admin agent's first
+  # autonomous action becomes "diagnose patch-dev failure" instead of
+  # onboarding. Skip pair creation when codex isn't on PATH — operator
+  # can run `agent-bridge agent create <admin>-dev --engine codex …`
+  # after installing the codex CLI.
+  if ! command -v codex >/dev/null 2>&1; then
+    printf '[admin-pair] skipped (codex CLI not on PATH): %s — install codex first, then re-run `bridge-bootstrap.sh --admin %s --engine claude` to backfill the pair and its picker-sweep cron.\n' "$pair_name" "$admin" >&2
+    return 0
+  fi
+
   pair_workdir="$(bridge_agent_workdir "$admin" 2>/dev/null || true)"
   if [[ -z "$pair_workdir" ]]; then
     pair_workdir="$(bridge_agent_default_home "$admin")"

--- a/lib/bridge-init-default-crons.sh
+++ b/lib/bridge-init-default-crons.sh
@@ -45,6 +45,18 @@ bridge_init_register_default_picker_sweep() {
     return 0
   fi
 
+  # Skip when the cron target <admin>-dev (the codex pair) is not in the
+  # roster. Without this guard the cron persists a job referencing an
+  # agent that does not exist — every dispatch then fails. Happens on
+  # hosts where bridge_ensure_admin_codex_pair was skipped because
+  # codex CLI was absent (see lib/bridge-admin-pair.sh). Operator can
+  # install codex + re-run bridge-bootstrap.sh to backfill both the
+  # pair AND this cron.
+  if ! bridge_agent_exists "$cron_agent" 2>/dev/null; then
+    printf '[init] picker-sweep cron skipped — target agent %s not in roster (codex pair absent). Install codex CLI and re-run bridge-bootstrap.sh to backfill.\n' "$cron_agent" >&2
+    return 0
+  fi
+
   # Idempotency check: list bridge-native crons (text-kind only is fine;
   # picker-sweep is registered as text-kind below) and look for an existing
   # job titled `picker-sweep`. `cron list --json` exits non-zero on a fresh


### PR DESCRIPTION
E2E test on Ubuntu 24.04 VM (2026-05-16) caught a fresh-install cascade:

1. `bridge-bootstrap.sh --admin patch --engine claude` always invokes `bridge_ensure_admin_codex_pair` → `patch-dev` (engine=codex) created unconditionally
2. On hosts without codex CLI (typical fresh dev VM), patch-dev crash-loops
3. Watchdog files `[crash-loop]` tasks within seconds
4. patch's first autonomous action: 'investigate patch-dev failure' (AskUserQuestion: 'Leave inactive / Switch to claude / Remove from roster'), NOT the welcome / onboarding flow

This was the observed cause behind operator's symptom 'patch waits for user input before doing anything' on the test VM — patch DID auto-trigger from CLAUDE.md instructions, but its first surfaced decision was the codex-absent diagnosis.

## Fix
`bridge_ensure_admin_codex_pair` early-returns 0 with a clear log when `command -v codex` is absent. Operator can install codex CLI later and run `agent-bridge agent create <admin>-dev --engine codex …` to add the pair manually.

## Test plan
- [x] bash -n + shellcheck clean
- [x] Reproduces on agb-clean-test VM (Ubuntu 24.04, no codex CLI)
- [ ] Re-verify post-fix that patch's first action is onboarding (not patch-dev triage)
- [ ] CI green

release-impact: user-visible — fixes clean install onboarding path on hosts without codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)