### PR TITLE
fix: v0.14.1 completeness backlog — discriminator readiness + race tolerance

### DIFF
--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -1076,11 +1076,36 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     # under the normal start path, root under sudo-backed reapply).
     effective_path.parent.mkdir(parents=True, exist_ok=True)
     tmp = effective_path.with_suffix(effective_path.suffix + ".tmp")
-    with tmp.open("w", encoding="utf-8") as handle:
-        json.dump(merged, handle, ensure_ascii=False, indent=2)
-        handle.write("\n")
-    os.chmod(tmp, 0o644)
-    os.replace(tmp, effective_path)
+    # E2E test on Ubuntu 24.04 VM (2026-05-16) caught a race: under
+    # concurrent bootstrap (bridge-bootstrap.sh) + patch first-start +
+    # watchdog firing, the parent dir occasionally gets recreated by
+    # a sibling process between mkdir and os.replace, and the tmp
+    # file disappears with the dir. Retry once with a fresh write
+    # cycle before propagating; if it still fails after the retry,
+    # treat as a soft warning and continue (the effective_path may
+    # have been written by another writer in the meantime, or the
+    # next agent-start tick will re-render).
+    def _atomic_write_effective() -> None:
+        with tmp.open("w", encoding="utf-8") as handle:
+            json.dump(merged, handle, ensure_ascii=False, indent=2)
+            handle.write("\n")
+        os.chmod(tmp, 0o644)
+        os.replace(tmp, effective_path)
+
+    try:
+        _atomic_write_effective()
+    except FileNotFoundError:
+        # Race window — parent dir got nuked between mkdir and replace,
+        # or tmp got removed by a sibling cleanup. Retry once.
+        effective_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            _atomic_write_effective()
+        except FileNotFoundError as exc:
+            sys.stderr.write(
+                "[bridge-hooks] effective-settings atomic write raced "
+                f"twice; continuing — next agent-start tick will re-render. "
+                f"detail={exc}\n"
+            )
 
     # 4. Atomic symlink: settings.json -> settings.effective.json. Replace
     # any prior regular file (we already preserved its user keys above) or

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -656,7 +656,26 @@ bridge_agent_clear_broken_launch "$AGENT"
 BRIDGE_AGENT_CREATED_AT["$AGENT"]="$(date +%s)"
 bridge_persist_agent_state "$AGENT"
 
-tmux new-session -d -s "$SESSION" -c "$WORK_DIR" "$SESSION_CMD"
+_bridge_start_new_session_err="$(mktemp 2>/dev/null || printf '/tmp/agb-newsession-err.%s' "$$")"
+if ! tmux new-session -d -s "$SESSION" -c "$WORK_DIR" "$SESSION_CMD" 2>"$_bridge_start_new_session_err"; then
+  # Race: the early `bridge_tmux_session_exists` check at the top of the
+  # script may not have caught a daemon-spawned session that landed in
+  # the gap. tmux emits `duplicate session: <name>` on stderr — that's
+  # cosmetic noise, not a real failure. Treat existing-session as OK,
+  # everything else as a real failure surface the captured stderr.
+  if bridge_tmux_session_exists "$SESSION" 2>/dev/null; then
+    if grep -q 'duplicate session' "$_bridge_start_new_session_err" 2>/dev/null; then
+      printf '[info] tmux session %s already exists (race with daemon spawn) — proceeding with attached attach\n' "$SESSION"
+    fi
+  else
+    printf '[error] tmux new-session failed for %s:\n' "$SESSION" >&2
+    cat "$_bridge_start_new_session_err" >&2 2>/dev/null || true
+    rm -f "$_bridge_start_new_session_err"
+    exit 1
+  fi
+fi
+rm -f "$_bridge_start_new_session_err"
+unset _bridge_start_new_session_err
 bridge_tmux_bootstrap_session_options "$SESSION"
 if [[ "$ENGINE" == "claude" ]]; then
   bridge_tmux_prepare_claude_session "$SESSION" 8 >/dev/null 2>&1 || true

--- a/lib/bridge-isolation-discriminator.sh
+++ b/lib/bridge-isolation-discriminator.sh
@@ -101,9 +101,25 @@ bridge_isolation_discriminator_auto_resolve() {
 
 bridge_isolation_v2_enforce() {
   # Bucket 2 enforcement gate. Returns 0 (enforce v2) when:
-  #   - host is Linux and BRIDGE_ISOLATION_REQUIRED is auto/yes, OR
+  #   - host is Linux and BRIDGE_ISOLATION_REQUIRED is auto/yes, AND
+  #   - v2 primitives are initialized (POSIX groups exist), OR
   #   - operator explicitly set BRIDGE_ISOLATION_REQUIRED=yes
   # Returns 1 (skip v2 enforcement, silent no-op) otherwise.
+  #
+  # E2E test on Ubuntu 24.04 VM (2026-05-16) caught a Linux-side
+  # regression: discriminator returns "yes" on Linux + auto policy,
+  # but on a fresh install where isolation-v2 groups (ab-shared,
+  # ab-controller) haven't been created yet, the downstream
+  # chgrp/setgid primitives fail and emit
+  # `[경고] ensure_matrix_path failed for agent=<X> marker=idle-since`
+  # on every daemon write — same operator-visible noise class as
+  # macOS pre-S2. Add a primitives-readiness check: skip enforcement
+  # if the canonical v2 groups don't exist yet. Operator can complete
+  # v2 init via `agent-bridge migrate isolation v2 --apply` (which
+  # creates the groups), and subsequent calls then engage.
+  #
+  # Explicit `BRIDGE_ISOLATION_REQUIRED=yes` bypasses the readiness
+  # check (operator wants to see the loud failures during self-test).
   #
   # Codex r1 catch (PR #908): MUST NOT wrap auto_resolve in `$()` —
   # the subshell would prevent the cache var from persisting to the
@@ -114,7 +130,41 @@ bridge_isolation_v2_enforce() {
   # Usage at call site:
   #   bridge_isolation_v2_enforce || return 0
   bridge_isolation_discriminator_auto_resolve >/dev/null
-  [[ "$_BRIDGE_ISOLATION_DISCRIMINATOR_AUTO_RESOLVED" == "yes" ]]
+  [[ "$_BRIDGE_ISOLATION_DISCRIMINATOR_AUTO_RESOLVED" == "yes" ]] || return 1
+  # Auto-resolve said yes. If operator forced via env=yes, skip the
+  # readiness probe — they want to see chgrp/setfacl failures during
+  # self-test. Otherwise (auto on Linux), require primitives ready.
+  if [[ "${BRIDGE_ISOLATION_REQUIRED:-auto}" == "yes" ]]; then
+    return 0
+  fi
+  _bridge_isolation_discriminator_primitives_ready
+}
+
+_bridge_isolation_discriminator_primitives_ready() {
+  # Cached check: do the canonical v2 POSIX groups exist? On fresh
+  # installs the groups are absent until `agent-bridge migrate
+  # isolation v2 --apply` runs. While absent, every v2 enforcement
+  # primitive would fail and emit noise — treat as "not ready" and
+  # skip enforcement (gate returns 1).
+  #
+  # Cache result for the shell's lifetime to avoid the getent fork
+  # cost on every daemon-loop matrix-touch.
+  if [[ -n "${_BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED:-}" ]]; then
+    [[ "$_BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED" == "yes" ]]
+    return $?
+  fi
+  local shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+  if getent group "$shared_grp" >/dev/null 2>&1; then
+    _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=yes
+    return 0
+  fi
+  _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=no
+  return 1
+}
+
+bridge_isolation_discriminator_clear_primitives_cache() {
+  # Test hook — used by smokes that create groups mid-shell.
+  unset _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED
 }
 
 bridge_isolation_v2_require_linux() {
@@ -140,9 +190,10 @@ bridge_isolation_v2_require_linux() {
 }
 
 bridge_isolation_discriminator_clear_cache() {
-  # Test/tool hook: invalidate the resolved cache so a follow-up call
-  # to `_auto_resolve` re-reads BRIDGE_ISOLATION_REQUIRED. Not used in
-  # production code paths; smoke harnesses that mutate the env var
-  # mid-run need this.
+  # Test/tool hook: invalidate BOTH the resolved-policy cache AND the
+  # primitives-readiness cache. Smoke harnesses that mutate env or
+  # group state mid-run need to call this so subsequent _enforce
+  # calls re-evaluate.
   _BRIDGE_ISOLATION_DISCRIMINATOR_AUTO_RESOLVED=""
+  unset _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED
 }

--- a/scripts/smoke/isolation-v2-bucket2-gates.sh
+++ b/scripts/smoke/isolation-v2-bucket2-gates.sh
@@ -48,10 +48,12 @@ fi
 
 run_gate_probe() {
   # Args: $1 = env_required, $2 = host_override, $3 = snippet, $4 = out_file
+  #       $5 = primitives_ready_override ("yes"|"no" or empty)
   local env_required="$1"
   local host_override="$2"
   local snippet="$3"
   local out_file="$4"
+  local primitives_ready="${5:-}"
   local driver="$SMOKE_TMP_ROOT/driver-$$.sh"
 
   {
@@ -68,6 +70,13 @@ run_gate_probe() {
     fi
     printf '%s\n' 'mkdir -p "$BRIDGE_HOME/state" "$BRIDGE_DATA_ROOT"'
     printf '%s\n' 'source "$0_REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1'
+    # PR #919 readiness gate: bypass the getent probe so the smoke is
+    # deterministic regardless of whether the test host has an
+    # ab-shared group. "yes" → primitives ready, gate may engage;
+    # "no" → primitives missing, gate skips on auto policy.
+    if [[ -n "$primitives_ready" ]]; then
+      printf 'export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=%q\n' "$primitives_ready"
+    fi
     printf '%s\n' "$snippet"
   } | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$driver"
   chmod +x "$driver"
@@ -109,7 +118,7 @@ mkdir -p "$G2_TREE"
 touch "$G2_TREE/file"
 run_gate_probe "" "Linux" \
   "bridge_isolation_v2_chgrp_setgid_recursive definitely_missing_group_910 2750 0640 '$G2_TREE'; echo \"RC=\$?\"" \
-  "$G2_OUT" || true
+  "$G2_OUT" "yes" || true
 
 if grep -q '^RC=0$' "$G2_OUT"; then
   cat "$G2_OUT"; smoke_fail "G2: gate short-circuited (RC=0); enforcement did NOT engage on host=Linux"
@@ -129,7 +138,7 @@ mkdir -p "$G3_TREE"
 touch "$G3_TREE/file"
 run_gate_probe "yes" "Darwin" \
   "bridge_isolation_v2_chgrp_setgid_recursive definitely_missing_group_910 2750 0640 '$G3_TREE'; echo \"RC=\$?\"" \
-  "$G3_OUT" || true
+  "$G3_OUT" "no" || true
 
 if grep -q '^RC=0$' "$G3_OUT"; then
   cat "$G3_OUT"; smoke_fail "G3: gate short-circuited (RC=0); BRIDGE_ISOLATION_REQUIRED=yes did NOT override Darwin default"
@@ -158,10 +167,12 @@ stage_normalize_fixture() {
 
 run_normalize_probe() {
   # Args: $1 = env_required, $2 = host_override, $3 = data_root, $4 = out_file
+  #       $5 = primitives_ready_override ("yes"|"no" or empty)
   local env_required="$1"
   local host_override="$2"
   local data_root="$3"
   local out_file="$4"
+  local primitives_ready="${5:-}"
   local driver="$SMOKE_TMP_ROOT/normalize-driver-$$.sh"
   local snapshot="$SMOKE_TMP_ROOT/normalize-snapshot.json"
   printf '{}\n' >"$snapshot"
@@ -179,6 +190,9 @@ run_normalize_probe() {
     printf 'export BRIDGE_CONTROLLER_GROUP=definitely_missing_ctrl_grp_910\n'
     if [[ -n "$env_required" ]]; then
       printf 'export BRIDGE_ISOLATION_REQUIRED=%q\n' "$env_required"
+    fi
+    if [[ -n "$primitives_ready" ]]; then
+      printf 'export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=%q\n' "$primitives_ready"
     fi
     printf '%s\n' 'mkdir -p "$BRIDGE_HOME/state"'
     printf '%s\n' 'source "$0_REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1'
@@ -212,7 +226,7 @@ smoke_log "G4 PASS"
 smoke_log "G5: migrate_normalize_layout Linux engages (asserts non-zero RC on missing groups)"
 G5_DATA="$(stage_normalize_fixture "$SMOKE_TMP_ROOT/g5-data")"
 G5_OUT="$SMOKE_TMP_ROOT/g5.out"
-run_normalize_probe "" "Linux" "$G5_DATA" "$G5_OUT"
+run_normalize_probe "" "Linux" "$G5_DATA" "$G5_OUT" "yes"
 
 if grep -q '^RC=0$' "$G5_OUT"; then
   cat "$G5_OUT"; smoke_fail "G5: gate short-circuited on host=Linux (RC=0); enforcement did NOT engage"
@@ -223,7 +237,7 @@ smoke_log "G5 PASS (gate engaged on host=Linux; normalize_layout failed on missi
 smoke_log "G6: migrate_normalize_layout Darwin + opt-in engages"
 G6_DATA="$(stage_normalize_fixture "$SMOKE_TMP_ROOT/g6-data")"
 G6_OUT="$SMOKE_TMP_ROOT/g6.out"
-run_normalize_probe "yes" "Darwin" "$G6_DATA" "$G6_OUT"
+run_normalize_probe "yes" "Darwin" "$G6_DATA" "$G6_OUT" "no"
 
 if grep -q '^RC=0$' "$G6_OUT"; then
   cat "$G6_OUT"; smoke_fail "G6: gate short-circuited on Darwin+opt-in (RC=0); enforcement did NOT engage"
@@ -237,9 +251,11 @@ smoke_log "G6 PASS (explicit opt-in engaged enforcement on Darwin)"
 
 run_strip_probe() {
   # Args: $1 = env_required, $2 = host_override, $3 = out_file
+  #       $4 = primitives_ready_override ("yes"|"no" or empty)
   local env_required="$1"
   local host_override="$2"
   local out_file="$3"
+  local primitives_ready="${4:-}"
   local driver="$SMOKE_TMP_ROOT/strip-driver-$$.sh"
   local actions_file="$SMOKE_TMP_ROOT/strip-actions-$$.tsv"
   local errors_file="$SMOKE_TMP_ROOT/strip-errors-$$.tsv"
@@ -259,6 +275,9 @@ run_strip_probe() {
     printf 'export BRIDGE_HOST_PLATFORM_OVERRIDE=%q\n' "$host_override"
     if [[ -n "$env_required" ]]; then
       printf 'export BRIDGE_ISOLATION_REQUIRED=%q\n' "$env_required"
+    fi
+    if [[ -n "$primitives_ready" ]]; then
+      printf 'export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=%q\n' "$primitives_ready"
     fi
     printf '%s\n' 'mkdir -p "$BRIDGE_HOME/state" "$BRIDGE_DATA_ROOT"'
     printf '%s\n' 'source "$0_REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1'
@@ -291,7 +310,7 @@ smoke_log "G7 PASS"
 # completed strip).
 smoke_log "G8: strip_layout_acls Linux default → gate engaged (not skipped:platform-discriminator)"
 G8_OUT="$SMOKE_TMP_ROOT/g8.out"
-run_strip_probe "" "Linux" "$G8_OUT"
+run_strip_probe "" "Linux" "$G8_OUT" "yes"
 
 if grep -q 'skipped:platform-discriminator' "$G8_OUT"; then
   cat "$G8_OUT"; smoke_fail "G8: gate short-circuited on host=Linux (should engage)"
@@ -301,7 +320,7 @@ smoke_log "G8 PASS (gate engaged on host=Linux)"
 # G9 — strip_layout_acls Darwin + opt-in → engages
 smoke_log "G9: strip_layout_acls Darwin + opt-in → gate engaged"
 G9_OUT="$SMOKE_TMP_ROOT/g9.out"
-run_strip_probe "yes" "Darwin" "$G9_OUT"
+run_strip_probe "yes" "Darwin" "$G9_OUT" "no"
 
 if grep -q 'skipped:platform-discriminator' "$G9_OUT"; then
   cat "$G9_OUT"; smoke_fail "G9: gate short-circuited on Darwin+opt-in (should engage)"
@@ -327,8 +346,12 @@ G10_DRIVER="$SMOKE_TMP_ROOT/g10-driver.sh"
   # Source ONLY the reapply module (no bridge-lib.sh).
   printf '%s\n' 'source "$0_REPO_ROOT/lib/bridge-isolation-v2-reapply.sh" 2>&1'
   printf '%s\n' 'if declare -f bridge_isolation_v2_enforce >/dev/null 2>&1; then echo "ENFORCE_DEFINED=yes"; else echo "ENFORCE_DEFINED=no"; fi'
-  # Sanity probe: with host=Linux, the gate must engage (not the discriminator-skip path).
+  # Sanity probe: with host=Linux + primitives ready, the gate must
+  # engage (not the discriminator-skip path). PR #919 readiness gate:
+  # set the cache var to make this deterministic regardless of whether
+  # the test host has an ab-shared group.
   printf '%s\n' 'export BRIDGE_HOST_PLATFORM_OVERRIDE=Linux'
+  printf '%s\n' 'export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=yes'
   printf '%s\n' 'bridge_isolation_v2_enforce; echo "ENFORCE_RC=$?"'
 } | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$G10_DRIVER"
 chmod +x "$G10_DRIVER"

--- a/scripts/smoke/isolation-v2-platform-discriminator.sh
+++ b/scripts/smoke/isolation-v2-platform-discriminator.sh
@@ -53,10 +53,12 @@ run_predicate_probe() {
   #       $2 = host_override ("Linux"|"Darwin"),
   #       $3 = snippet (the test body),
   #       $4 = out_file
+  #       $5 = primitives_ready_override ("yes"|"no" or empty for auto/getent)
   local env_required="$1"
   local host_override="$2"
   local snippet="$3"
   local out_file="$4"
+  local primitives_ready="${5:-}"
   local driver="$SMOKE_TMP_ROOT/driver-$$.sh"
 
   {
@@ -75,6 +77,15 @@ run_predicate_probe() {
     fi
     printf '%s\n' 'mkdir -p "$BRIDGE_HOME/state" "$BRIDGE_DATA_ROOT"'
     printf '%s\n' 'source "$0_REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1'
+    # Discriminator readiness override — set the cache var BEFORE the
+    # snippet runs so the gate's primitives-readiness probe (getent
+    # ab-shared) is bypassed in favor of the deterministic value.
+    # Without this the smoke would depend on whether the test host
+    # happens to have an ab-shared group, which is not the case on
+    # macOS dev and is not the case on freshly-provisioned Linux CI.
+    if [[ -n "$primitives_ready" ]]; then
+      printf 'export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=%q\n' "$primitives_ready"
+    fi
     printf '%s\n' "$snippet"
   } | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$driver"
   chmod +x "$driver"
@@ -85,19 +96,33 @@ run_predicate_probe() {
   return $rc
 }
 
-# D1 — default + Linux → resolve=yes, enforce 0, require_linux 0
-smoke_log "D1: env=unset + host=Linux"
+# D1 — default + Linux + primitives ready → resolve=yes, enforce 0, require_linux 0
+smoke_log "D1: env=unset + host=Linux + primitives ready"
 D1_OUT="$SMOKE_TMP_ROOT/d1.out"
 run_predicate_probe "" "Linux" '
 echo "RESOLVE=$(bridge_isolation_discriminator_auto_resolve)"
 bridge_isolation_v2_enforce; echo "ENFORCE_RC=$?"
 bridge_isolation_v2_require_linux; echo "REQUIRE_RC=$?"
-' "$D1_OUT" || true
+' "$D1_OUT" "yes" || true
 
 grep -q '^RESOLVE=yes$' "$D1_OUT" || { cat "$D1_OUT"; smoke_fail "D1: expected RESOLVE=yes"; }
-grep -q '^ENFORCE_RC=0$' "$D1_OUT" || { cat "$D1_OUT"; smoke_fail "D1: expected ENFORCE_RC=0"; }
+grep -q '^ENFORCE_RC=0$' "$D1_OUT" || { cat "$D1_OUT"; smoke_fail "D1: expected ENFORCE_RC=0 (primitives ready)"; }
 grep -q '^REQUIRE_RC=0$' "$D1_OUT" || { cat "$D1_OUT"; smoke_fail "D1: expected REQUIRE_RC=0"; }
 smoke_log "D1 PASS"
+
+# D1b — default + Linux + primitives NOT ready → resolve=yes BUT enforce 1
+# Covers PR #919 readiness gate: clean install w/o ab-shared group should
+# skip enforcement instead of emitting ensure_matrix_path noise.
+smoke_log "D1b: env=unset + host=Linux + primitives NOT ready"
+D1B_OUT="$SMOKE_TMP_ROOT/d1b.out"
+run_predicate_probe "" "Linux" '
+echo "RESOLVE=$(bridge_isolation_discriminator_auto_resolve)"
+bridge_isolation_v2_enforce; echo "ENFORCE_RC=$?"
+' "$D1B_OUT" "no" || true
+
+grep -q '^RESOLVE=yes$' "$D1B_OUT" || { cat "$D1B_OUT"; smoke_fail "D1b: resolve should still be yes (Linux+auto)"; }
+grep -q '^ENFORCE_RC=1$' "$D1B_OUT" || { cat "$D1B_OUT"; smoke_fail "D1b: enforce should be 1 when primitives not ready"; }
+smoke_log "D1b PASS"
 
 # D2 — default + Darwin → resolve=no, enforce 1, require_linux DIES
 smoke_log "D2: env=unset + host=Darwin → require_linux must die"
@@ -118,16 +143,19 @@ fi
 grep -q 'operation requires Linux' "$D2_OUT" || { cat "$D2_OUT"; smoke_fail "D2: expected 'requires Linux' die message"; }
 smoke_log "D2 PASS"
 
-# D3 — explicit yes + Darwin → resolve=yes, enforce 0 (override)
-smoke_log "D3: env=yes + host=Darwin (explicit opt-in)"
+# D3 — explicit yes + Darwin → resolve=yes, enforce 0 (override AND bypass readiness)
+# PR #919 readiness gate: explicit yes bypasses the primitives-ready
+# probe — operator wants to see loud chgrp/setfacl failures during
+# self-test. Use primitives=no to verify the bypass.
+smoke_log "D3: env=yes + host=Darwin + primitives NOT ready (explicit opt-in bypasses readiness)"
 D3_OUT="$SMOKE_TMP_ROOT/d3.out"
 run_predicate_probe "yes" "Darwin" '
 echo "RESOLVE=$(bridge_isolation_discriminator_auto_resolve)"
 bridge_isolation_v2_enforce; echo "ENFORCE_RC=$?"
-' "$D3_OUT" || true
+' "$D3_OUT" "no" || true
 
 grep -q '^RESOLVE=yes$' "$D3_OUT" || { cat "$D3_OUT"; smoke_fail "D3: expected RESOLVE=yes (explicit)"; }
-grep -q '^ENFORCE_RC=0$' "$D3_OUT" || { cat "$D3_OUT"; smoke_fail "D3: expected ENFORCE_RC=0"; }
+grep -q '^ENFORCE_RC=0$' "$D3_OUT" || { cat "$D3_OUT"; smoke_fail "D3: expected ENFORCE_RC=0 (explicit yes bypasses readiness)"; }
 smoke_log "D3 PASS"
 
 # D4 — explicit no + Linux → resolve=no, enforce 1 (override)

--- a/tests/isolation-v2-primitives/smoke.sh
+++ b/tests/isolation-v2-primitives/smoke.sh
@@ -164,7 +164,14 @@ if [[ -n "$caller_group" ]]; then
   # operation directly. Run this WITHOUT relying on sudo by stubbing
   # out `sudo` to fail; a passing run proves the helper goes through
   # the direct path first and does not silently require sudo.
+  #
+  # PR #919 readiness gate: this test exercises the rootless chgrp
+  # primitive directly. The discriminator's readiness probe would
+  # short-circuit on a fresh CI host without an ab-shared group,
+  # so force the cache to "yes" — we're not testing readiness here,
+  # we're testing the chgrp/chmod behavior on a tree the caller owns.
   (
+    export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=yes
     sudo() { return 127; }
     export -f sudo
     bridge_isolation_v2_chgrp_setgid_recursive \
@@ -269,8 +276,13 @@ ok "legacy default does not leak v2 group exports to child env"
 if [[ -n "$caller_group" ]]; then
   single_dir="$TMP_ROOT/setgid-single"
   mkdir -p "$single_dir"
-  bridge_isolation_v2_chgrp_setgid_dir "$caller_group" 2750 "$single_dir" \
-    || die "chgrp_setgid_dir: failed on rootless primary-group path"
+  # PR #919 readiness gate: same rationale as the recursive variant
+  # above — testing chgrp/chmod behavior on caller-owned tree, not
+  # fresh-host readiness skip. Force the cache "yes" for this call.
+  (
+    export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=yes
+    bridge_isolation_v2_chgrp_setgid_dir "$caller_group" 2750 "$single_dir"
+  ) || die "chgrp_setgid_dir: failed on rootless primary-group path"
   single_mode="$(stat -c '%a' "$single_dir" 2>/dev/null || stat -f '%Lp' "$single_dir" 2>/dev/null)"
   case "$single_mode" in
     2750|02750|750) ok "chgrp_setgid_dir: applied mode (got $single_mode)" ;;


### PR DESCRIPTION
Bundles 4 E2E-discovered fixes for v0.14.1 release.

## #8 — Linux fresh-install ensure_matrix_path warning (HIGH)

Reproduced on Ubuntu 24.04 VM: discriminator returns 'yes' on Linux+auto but ab-shared / ab-controller groups aren't created until `agent-bridge migrate isolation v2 --apply` runs. Every daemon write tick fires `[경고] ensure_matrix_path failed for agent=<X> marker=idle-since`.

Fix: `bridge_isolation_v2_enforce` requires `_primitives_ready` (`getent ab-shared`) on auto policy. Explicit `BRIDGE_ISOLATION_REQUIRED=yes` bypasses for self-test loud mode. Verified on VM — warning fully silenced after fix.

## #4 — settings.effective.json.tmp race tolerance

`bridge-hooks.py` os.replace caught FileNotFoundError under concurrent bootstrap. Retry once with fresh mkdir+write, fall back to soft warning if still races.

## #7 — duplicate session cosmetic message

`bridge-start.sh` tmux new-session race with daemon. Capture stderr, on failure check session-exists; if exists with 'duplicate session' stderr, surface `[info]` line; else surface real error + exit 1.

## #6 — handled via PR #918's order placement
Discriminator fix (#8) closes the upstream warning source. No additional change needed beyond the `|| true` guard PR #918 already added.

## Verification (agb-clean-test VM)
- Pre-fix: `[경고] ensure_matrix_path failed` on every patch session tick
- Post-fix: 0 warnings, patch auto-onboarding still works, daemon health green
- Enforce gate probe: `enforce_rc=1 resolved=yes primitives_ready=no` confirms gate logic

release-impact: user-visible. Part of v0.14.1 release batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)