### PR TITLE
fix(picker-sweep): dev-channels warning + codex cwd-confirm coverage

### DIFF
--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -132,10 +132,36 @@ fi
 # Add new options carefully — false-positive on Claude's own output is the
 # main failure mode. Prefer expanding the option enumeration to a whole new
 # regex only if Anthropic ships a new picker shape.
+#
+# 2026-05-16 additions (post-v0.14.1 ship E2E):
+#   - "I am using this for local development" — Claude Code's development-
+#     channels warning that blocks agent launch when channels env carries
+#     a development plugin. Default cursor `❯ 1` is on this option, so a
+#     bare Enter accepts and continues. Discovered when patch was stuck
+#     post-v0.14.1 upgrade with development-channels warning visible.
+#   - "Press enter to continue" — codex CLI's cwd-confirm prompt. Different
+#     shape from Claude's numbered picker (single confirmation line, no
+#     options). Has its own regex below (_PICKER_CODEX_CONFIRM_RE).
+#
+# NOT added (intentionally):
+#   - "Yes, I accept" / "No, exit" (Bypass Permissions warning) — Claude's
+#     default cursor is on "No, exit" (option 1). A bare Enter would EXIT
+#     Claude on first launch. Needs explicit "send 2 + Enter" support
+#     before adding. Operator must accept this warning interactively
+#     once per host; the result is persisted in Claude Code's local
+#     settings so subsequent launches skip the warning.
 # ---------------------------------------------------------------------------
 
-_PICKER_OPTION_LINE_RE='^[[:space:]]*(❯[[:space:]]*)?[0-9]+\.[[:space:]]+(Stop and wait for limit to reset|Switch to extra usage|Switch to Team plan|Resume from summary \(recommended\)|Resume full session as-is)[[:space:]]*$'
+_PICKER_OPTION_LINE_RE='^[[:space:]]*(❯[[:space:]]*)?[0-9]+\.[[:space:]]+(Stop and wait for limit to reset|Switch to extra usage|Switch to Team plan|Resume from summary \(recommended\)|Resume full session as-is|I am using this for local development)[[:space:]]*$'
 _PICKER_TAIL_RE='^[[:space:]]*Enter to confirm · Esc to cancel[[:space:]]*$'
+
+# Codex picker shape — fundamentally different from Claude's. Codex emits
+# a single "Press enter to continue" line (no numbered options) when
+# confirming the working directory at launch. Auto-Enter is safe because
+# there's only one action path. Added 2026-05-16 after codex patch-dev
+# was blocked at the cwd-confirm prompt during the v0.13.x → v0.14.1
+# upgrade supervise flow.
+_PICKER_CODEX_CONFIRM_RE='^[[:space:]]*Press enter to continue[[:space:]]*$'
 
 # ---------------------------------------------------------------------------
 # Test seams. The smoke replaces these with fixture-driven wrappers.
@@ -203,6 +229,10 @@ while IFS= read -r agent; do
         else
             matched_pattern="picker option line"
         fi
+    elif printf '%s\n' "$cap" | grep -qE "$_PICKER_CODEX_CONFIRM_RE"; then
+        # Codex cwd-confirm picker (single "Press enter to continue" line,
+        # no numbered options). Safe to auto-Enter — only one action path.
+        matched_pattern="codex cwd-confirm"
     fi
 
     if [[ -n "$matched_pattern" ]]; then

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -278,4 +278,61 @@ smoke_assert_eq "1" "$(count_lines "$SEND_LOG")" "6 one send"
 smoke_assert_eq "0" "$(count_lines "$TASK_LOG")" "6 no task (notify empty)"
 smoke_assert_contains "$(cat "$BRIDGE_PICKER_SWEEP_LOG")" "BRIDGE_PICKER_SWEEP_NOTIFY unset" "6 notify-skip logged"
 
+
+# ---------------------------------------------------------------------------
+# Test 7 — Claude Code development-channels warning (post-v0.14.1 addition).
+# ---------------------------------------------------------------------------
+
+smoke_log "7. dev-channels warning → unstick"
+reset_fixture
+printf '%s\n' "dev-channels-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-dev-channels-agent" <<'PANE'
+  WARNING: Loading development channels
+
+  --dangerously-load-development-channels is for local channel development only.
+
+  Channels: plugin:teams@agent-bridge, plugin:ms365@agent-bridge
+
+  ❯ 1. I am using this for local development
+    2. Exit
+
+  Enter to confirm · Esc to cancel
+PANE
+
+export BRIDGE_PICKER_SWEEP_NOTIFY="admin"
+run_sweep
+smoke_assert_eq "1" "$(count_lines "$SEND_LOG")" "7 one send (dev-channels warning auto-accepted)"
+smoke_assert_eq "1" "$(grep -c "^---$" "$TASK_LOG" || true)" "7 one task (notify admin)"
+
+# ---------------------------------------------------------------------------
+# Test 8 — Codex CLI "Press enter to continue" cwd-confirm prompt.
+# ---------------------------------------------------------------------------
+
+smoke_log "8. codex cwd-confirm → unstick"
+reset_fixture
+printf '%s\n' "codex-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-codex-agent" <<'PANE'
+  Working directory: /home/sean/agent-bridge-public
+  Press enter to continue
+PANE
+
+run_sweep
+smoke_assert_eq "1" "$(count_lines "$SEND_LOG")" "8 one send (codex cwd-confirm auto-accepted)"
+smoke_assert_eq "1" "$(grep -c "^---$" "$TASK_LOG" || true)" "8 one task (notify admin)"
+
+# ---------------------------------------------------------------------------
+# Test 9 — codex confirm regex must NOT trip on free-prose mention.
+# ---------------------------------------------------------------------------
+
+smoke_log "9. codex confirm — false-positive defence (free-prose)"
+reset_fixture
+printf '%s\n' "doc-agent2" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-doc-agent2" <<'PANE'
+> When codex shows "Press enter to continue" the operator types Enter.
+> See codex docs for the cwd-confirm flow.
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "9 no send (codex confirm in '>' quote)"
+
 smoke_log "all checks passed"

--- a/scripts/test-controller-dev-channels-accept.sh
+++ b/scripts/test-controller-dev-channels-accept.sh
@@ -21,9 +21,12 @@
 #      `claude` and the process tree has no claude descendant, but the
 #      pane contains the picker text. Pre-fix would time out without
 #      sending Enter; post-fix the picker-text trigger fires.
-#   R3 Neighbor guard: the picker-sweep allow-list
-#      (scripts/picker-sweep.sh:137-138) does NOT include the dev-channels
-#      picker text, so picker-sweep does not grab a dev-channels pane.
+#   R3 Sweep coverage: the picker-sweep allow-list
+#      (scripts/picker-sweep.sh:155) NOW includes the dev-channels
+#      picker text 'I am using this for local development' (added in
+#      PR #923 on 2026-05-16 after operator's host got blocked on this
+#      picker post-v0.14.1 upgrade). The test asserts picker-sweep
+#      auto-accepts the dev-channels pane.
 #   R4 Timeout-still-works: pane has neither picker text nor claude
 #      foreground; bridge_tmux_pane_has_dev_channels_picker returns 1
 #      forever, the legacy foreground gate also returns 1, and the
@@ -304,11 +307,14 @@ if [[ "$FAIL" -eq 0 || ("$LAST_DESC" == "R2"* && "$R2_ACK" != "" ) ]]; then
 fi
 
 # ---------------------------------------------------------------------------
-# R3: neighbor guard — the picker-sweep allow-list does NOT include the
-# dev-channels picker text. We exercise picker-sweep against a dev-channels
-# pane and assert the sweep does not send Enter into it.
+# R3: sweep coverage — the picker-sweep allow-list NOW includes the
+# dev-channels picker text 'I am using this for local development'
+# (added in PR #923, 2026-05-16, after operator's host got blocked on
+# this picker post-v0.14.1 upgrade). Exercise picker-sweep against a
+# dev-channels pane and assert the sweep auto-accepts (default cursor
+# is on option 1 so a bare Enter accepts).
 # ---------------------------------------------------------------------------
-step "R3: picker-sweep does NOT match dev-channels picker text"
+step "R3: picker-sweep auto-accepts dev-channels picker text"
 R3_DIR="$TMP_ROOT/r3"
 mkdir -p "$R3_DIR/lib" "$R3_DIR/state/install" "$R3_DIR/scripts"
 cp "$ROOT_DIR/lib/bridge-host-profile.sh" "$R3_DIR/lib/"
@@ -318,10 +324,11 @@ printf '{"profile":"server"}\n' > "$R3_DIR/state/install/host-profile.json"
 R3_SEND_RECORD="$R3_DIR/picker-sweep-sends.log"
 R3_TASKS_RECORD="$R3_DIR/picker-sweep-tasks.log"
 : > "$R3_SEND_RECORD" "$R3_TASKS_RECORD"
+export R3_SEND_RECORD R3_TASKS_RECORD
 
 # Test seam shims: list a single fake session that capture-pane will
-# return the dev-channels picker text for. If picker-sweep wrongly grabs
-# this pane it will call _send_enter, which records to the log.
+# return the dev-channels picker text for. PR #923 makes picker-sweep
+# auto-accept this pane — verify _send_enter was called.
 # shellcheck disable=SC2329 # invoked via BRIDGE_PICKER_SWEEP_*_FN env seam
 r3_list_sessions() {
   printf '%s\n' "r3-fake-devchannels"
@@ -354,13 +361,14 @@ BRIDGE_PICKER_SWEEP_ENABLED=1 \
   BRIDGE_PICKER_SWEEP_CREATE_TASK_FN=r3_create_task \
   "$BASH_BIN" "$R3_DIR/scripts/picker-sweep.sh" 2>"$R3_STDERR" >/dev/null || R3_RC=$?
 
-# Picker-sweep must exit 0 (no matching picker) AND must not have called
-# _send_enter. If it had grabbed the dev-channels pane, R3_SEND_RECORD
-# would contain "=r3-fake-devchannels:".
-if [[ "$R3_RC" == "0" && ! -s "$R3_SEND_RECORD" ]]; then
+# Picker-sweep must exit 0 AND must have called _send_enter exactly once
+# with the fake session name. Pre-PR-#923 this test asserted the
+# opposite (NO send); post-PR-#923 a send IS expected.
+if [[ "$R3_RC" == "0" && -s "$R3_SEND_RECORD" ]] \
+   && grep -q '^r3-fake-devchannels$' "$R3_SEND_RECORD"; then
   ok
 else
-  err "R3 picker-sweep grabbed dev-channels pane (rc=$R3_RC, sends=$(cat "$R3_SEND_RECORD" 2>/dev/null || true), stderr=$(cat "$R3_STDERR" 2>/dev/null || true))"
+  err "R3 picker-sweep did NOT auto-accept dev-channels pane (rc=$R3_RC, sends=$(cat "$R3_SEND_RECORD" 2>/dev/null || true), stderr=$(cat "$R3_STDERR" 2>/dev/null || true))"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Sean's host got blocked on TWO picker shapes during v0.13.6 → v0.14.1 upgrade flow that the existing allow-list did not cover.

## Phase 1 — Claude Code 'Loading development channels' warning
Numbered-options shape (already structurally matched), but option text 'I am using this for local development' was missing from `_PICKER_OPTION_LINE_RE`. Default cursor on this option → bare Enter accepts. Safe to auto-sweep.

## Phase 2 — Codex CLI 'Press enter to continue' (cwd-confirm)
Different shape from Claude (single confirmation line, no numbered options). New `_PICKER_CODEX_CONFIRM_RE` + detection loop branch.

## NOT in this PR
Claude 'Bypass Permissions' warning — default cursor on 'No, exit'. Bare Enter would EXIT Claude. Needs 'send option-number then Enter' helper. Operator accepts once per host; Claude Code persists.

## Smoke
- 9 cases (was 6). New: 7 dev-channels, 8 codex confirm, 9 codex free-prose false-positive defence.
- All pass locally.

## Test plan
- [x] bash -n + shellcheck clean
- [x] picker-sweep smoke 9/9 PASS
- [x] False-positive defences preserved (free-prose mentions of picker text don't trigger sweep)
- [ ] CI green

release-impact: user-visible. Batch into next release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)