### PR TITLE
fix(status): exempt dynamic-source agents from stale-health classification

### DIFF
--- a/bridge-status.py
+++ b/bridge-status.py
@@ -80,8 +80,26 @@ def fmt_garden(blocked_count: int, oldest_blocked_ts: int | None) -> str:
     return f"{int(blocked_count)}d"
 
 
-def classify_stale(active: bool, activity_ts: int | None, warn_seconds: int, critical_seconds: int) -> str:
+def classify_stale(
+    active: bool,
+    activity_ts: int | None,
+    warn_seconds: int,
+    critical_seconds: int,
+    source: str | None = None,
+) -> str:
+    # Stale-health classification is only meaningful for agents that are
+    # expected to be doing autonomous work — i.e. static-source roles
+    # (librarian, patch, admin, …) whose long idle is a real "broken"
+    # signal. Dynamic-source agents (crm-dev, agb-dev-claude, …) are
+    # operator-driven containers that the human keeps running between
+    # interactive sessions; classifying their idle time as warn/crit
+    # produces a constant false-positive on every healthy host. Treat
+    # active dynamic agents as not-applicable ("-") so the dashboard
+    # `health warn/crit` counter and the per-row column stay focused on
+    # static roles that actually need attention.
     if not active:
+        return "-"
+    if source == "dynamic":
         return "-"
     if not activity_ts:
         return "crit"
@@ -624,6 +642,7 @@ def render_dashboard(args: argparse.Namespace) -> str:
             int(activity_ts) if activity_ts else None,
             args.stale_warn_seconds,
             args.stale_critical_seconds,
+            source=str(row.get("source", "")) or None,
         )
         if stale == "warn":
             health_warn_count += 1
@@ -739,6 +758,7 @@ def render_dashboard(args: argparse.Namespace) -> str:
             int(activity_ts) if activity_ts else None,
             args.stale_warn_seconds,
             args.stale_critical_seconds,
+            source=str(row.get("source", "")) or None,
         )
         load_bar = f"q:{render_bar(queued, width=4, char='=')} c:{render_bar(claimed, width=4, char='*')}"
         wake_state = "zmb" if zombie else (row.get("wake") or "-")
@@ -866,6 +886,7 @@ def render_dashboard_json(args: argparse.Namespace) -> str:
                     int(activity_ts) if activity_ts else None,
                     args.stale_warn_seconds,
                     args.stale_critical_seconds,
+                    source=str(row.get("source", "")) or None,
                 ),
             },
             "plugins": plugins_for_agent(row),

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10720,4 +10720,12 @@ bash "$REPO_ROOT/scripts/smoke/dynamic-agent-shared-mode-workdir.sh"
 log "running v2-scaffold-home-and-workdir smoke (issue #686)"
 bash "$REPO_ROOT/scripts/smoke/v2-scaffold-home-and-workdir.sh"
 
+# Dynamic agents are operator-driven containers; long idle is normal
+# state, not a health signal. The dashboard previously flagged them
+# as warn/crit purely on idle threshold (Sean, 2026-05-16). Guard the
+# classify_stale dynamic-source exemption so a future regression
+# brings the false-positive back into the health counter.
+log "running classify-stale-dynamic-exemption smoke"
+bash "$REPO_ROOT/scripts/smoke/classify-stale-dynamic-exemption.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/classify-stale-dynamic-exemption.py
+++ b/scripts/smoke/classify-stale-dynamic-exemption.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# scripts/smoke/classify-stale-dynamic-exemption.py — direct callee for
+# scripts/smoke/classify-stale-dynamic-exemption.sh. Kept as a standalone
+# file (not inlined as heredoc-stdin to python3) so the smoke is immune
+# to footgun #11 (Bash 5.3.9 `read_comsub` / `heredoc_write` deadlock)
+# even if a future caller wraps it in `$()` capture.
+#
+# Loads bridge-status.py via importlib (the file name has a hyphen so a
+# plain import won't work) and runs the classify_stale truth table for
+# dynamic-source exemption.
+
+import importlib.util
+import pathlib
+import sys
+import time
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    status_path = repo_root / "bridge-status.py"
+    spec = importlib.util.spec_from_file_location(
+        "bridge_status_under_test", status_path
+    )
+    if spec is None or spec.loader is None:
+        print(f"[smoke] cannot load {status_path}", file=sys.stderr)
+        return 2
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    classify_stale = module.classify_stale
+
+    now = int(time.time())
+    fresh = now - 60
+    warn_age = now - 3700
+    crit_age = now - 14500
+
+    failures: list[str] = []
+
+    def check(label: str, got: object, want: object) -> None:
+        if got != want:
+            failures.append(f"{label}: got {got!r}, want {want!r}")
+        else:
+            print(f"  PASS  {label} = {got!r}")
+
+    # static + active + crit-age -> crit (must not regress)
+    check(
+        "static-crit-stays-crit",
+        classify_stale(True, crit_age, 3600, 14400, source="static"),
+        "crit",
+    )
+
+    # dynamic + active + crit-age -> "-" (the new exemption)
+    check(
+        "dynamic-crit-becomes-na",
+        classify_stale(True, crit_age, 3600, 14400, source="dynamic"),
+        "-",
+    )
+
+    # dynamic + active + missing activity_ts -> "-"
+    check(
+        "dynamic-missing-ts-becomes-na",
+        classify_stale(True, None, 3600, 14400, source="dynamic"),
+        "-",
+    )
+
+    # dynamic + inactive -> "-" (early return still wins)
+    check(
+        "dynamic-inactive-stays-na",
+        classify_stale(False, crit_age, 3600, 14400, source="dynamic"),
+        "-",
+    )
+
+    # static + fresh -> ok
+    check(
+        "static-fresh-stays-ok",
+        classify_stale(True, fresh, 3600, 14400, source="static"),
+        "ok",
+    )
+
+    # static + warn-age -> warn
+    check(
+        "static-warn-stays-warn",
+        classify_stale(True, warn_age, 3600, 14400, source="static"),
+        "warn",
+    )
+
+    # legacy positional call (no source kwarg) keeps the old behavior so
+    # external diagnostic scripts that imported this function don't
+    # silently change semantics.
+    check(
+        "legacy-no-source-crit",
+        classify_stale(True, crit_age, 3600, 14400),
+        "crit",
+    )
+    check(
+        "legacy-no-source-warn",
+        classify_stale(True, warn_age, 3600, 14400),
+        "warn",
+    )
+    check(
+        "legacy-no-source-ok",
+        classify_stale(True, fresh, 3600, 14400),
+        "ok",
+    )
+
+    # source="" (unknown source) -> same as legacy (do not exempt)
+    check(
+        "empty-source-treated-as-static-like",
+        classify_stale(True, crit_age, 3600, 14400, source=""),
+        "crit",
+    )
+
+    if failures:
+        for f in failures:
+            print(f"  FAIL  {f}", file=sys.stderr)
+        return 1
+    print("[smoke:classify-stale-dynamic-exemption] all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/classify-stale-dynamic-exemption.sh
+++ b/scripts/smoke/classify-stale-dynamic-exemption.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# scripts/smoke/classify-stale-dynamic-exemption.sh — regression for the
+# bridge-status.py classify_stale upstream bug where dynamic-source
+# agents (operator-driven containers like crm-dev, agb-dev-claude) were
+# flagged as warn/crit purely on idle time. Idle is the normal state
+# for dynamic agents — the operator parks them between interactive
+# sessions — so the dashboard health counter on a healthy host
+# constantly produced false positives (Sean, 2026-05-16).
+#
+# The actual assertions live in scripts/smoke/classify-stale-dynamic-
+# exemption.py — kept as a standalone .py file (not heredoc-stdin to
+# python3) so the smoke is immune to footgun #11 even if a future
+# caller wraps this driver in `$()` capture.
+
+set -euo pipefail
+
+SMOKE_NAME="classify-stale-dynamic-exemption"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+"$PYTHON_BIN" "$SCRIPT_DIR/classify-stale-dynamic-exemption.py"


### PR DESCRIPTION
## Summary

- `bridge-status.py:classify_stale` was uniform on idle threshold (warn≥1h / crit≥4h) regardless of agent source — dynamic-source agents (crm-dev, agb-dev-claude, …) that the operator keeps running between interactive sessions constantly tripped the dashboard health counter and per-row stale column on every healthy host.
- Stale health only makes sense for static-source agents expected to do autonomous scheduled work (librarian, patch, admin, …). For dynamic agents, long idle is the **normal** state.
- Add an optional `source` kwarg to `classify_stale`; when `active=True` and `source=="dynamic"` it returns `-` (n/a). All three dashboard call sites pass `source=row.get("source")`. Empty/unknown source keeps the legacy behavior so external diagnostic scripts that import this function don't silently change.

## Why

Operator (Sean, 2026-05-16) hit a long-running daemon wedge on his Mac and noticed the dashboard was constantly flagging idle dynamic agents as warn/crit alongside legitimate static-agent breakage. The false-positive obscures the real signal. Patch (the on-host management agent) was also reading these flags into its own diagnostic logic.

## Reproducer (before the fix)

Open dashboard on a host where the operator keeps a dynamic agent (e.g. crm-dev) idle for >1h:

```
agb status
```

→ `crm-dev` shows `warn` in the stale column; `health warn=N` includes it.

After the fix: `crm-dev` shows `-` in the stale column; the health counter only includes static-source agents.

## Test plan

- [x] `scripts/smoke/classify-stale-dynamic-exemption.sh` — new, 10-case truth table (static-stays-stale, dynamic-becomes-na, missing-ts, inactive parity, legacy positional, source="" treated as static-like)
- [x] `bash -n` + `shellcheck` on the new smoke driver
- [x] `python3 -m py_compile` on bridge-status.py + new .py helper
- [x] `bash scripts/lint-heredoc-ban.sh` → PASS (no new heredoc-stdin to subprocess; helper is a standalone .py per footgun #11 hardening)
- [ ] Codex pair-review (agb-dev-codex)

## Notes

- No VERSION / CHANGELOG bump — per stabilization policy stabilization PRs accumulate, release is operator-cued.
- `bridge-dashboard.py:classify_state` is a separate function (stopped/working/idle activity state, not stale-health) — unaffected, correct as is.
- Empty-source / unknown-source rows keep legacy behavior so an external caller (patch host diagnostic) that imports classify_stale doesn't silently change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)