### PR TITLE
fix(tool-policy): tighten process-dump regex to stop false-positive on natural words

### DIFF
--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -219,7 +219,7 @@ _ENV_DUMP_PATTERNS = (
         r"""
         (?<![A-Za-z0-9_/.\-]) env \b
         (?:
-            \s+ -- [A-Za-z0-9_-]*               # long option (incl. bare `--`)
+            \s+ -- [A-Za-z0-9_-]* (?: = \S* )?   # long option, incl. GNU --name=value
           | \s+ -[uSPC] \s+ \S+                 # short opt that takes a separated arg
           | \s+ -[A-Za-z0-9][A-Za-z0-9]*        # short opt or packed -uVAR
           | \s+ [A-Za-z_][A-Za-z0-9_]* = \S*    # VAR=value assignment
@@ -242,11 +242,16 @@ _ENV_DUMP_PATTERNS = (
     # Natural-language "use printenv to check" (preceded by a space
     # which is not in the separator set) no longer matches.
     re.compile(r"(?:^|[\n;&|`()<>])\s*printenv\b"),
-    # bare `set` with no args (dumps all vars). Require a separator
-    # before and a terminator/pipe/EOL after so `set -e`, `set -o
-    # pipefail`, `kubectl set image`, `git remote set-url`, and
-    # `setfacl` do NOT match.
-    re.compile(r"(?:^|[;\s|&])set\s*(?:$|[|;&])"),
+    # bare `set` with no args (dumps all vars). Same noise-reduction as
+    # the env/printenv tightenings — natural language "the var was set"
+    # used to match because the prior class `[;\s|&]` allowed a plain
+    # whitespace prefix, which is indistinguishable from "verb at end of
+    # an English sentence". The new prefix `[\n;|&` + subshell/backtick
+    # delimiters` excludes pure whitespace, so `the var was set` falls
+    # through. Dangerous shapes (`set`, `set | head`, `;set`, `$(set)`,
+    # `set > file`) still match because the prefix is consumed and the
+    # trailing terminator class is unchanged.
+    re.compile(r"(?:^|[\n;|&`()<>])\s*set\s*(?=$|[\n;|&<>`)])"),
     re.compile(r"(?<![A-Za-z0-9_])compgen\s+-[A-Za-z]*e"),
     re.compile(r"(?<![A-Za-z0-9_])declare\s+-[A-Za-z]*[xp]"),
     re.compile(r"(?<![A-Za-z0-9_])typeset\s+-[A-Za-z]*[xp]"),

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -177,9 +177,33 @@ def _raw_mentions_claude_credentials(raw: str) -> bool:
 # such as `environment`, `setfacl`, `kubectl set image`, or `set -e`.
 # Routed to the same CLAUDE_CREDENTIAL_DENY_REASON as the substring
 # deny — no second reason constant.
+# `env` precondition tightened on 2026-05-16 (operator-flagged false
+# positive). The earlier `(?<![A-Za-z0-9_/])env(?![A-Za-z0-9_])` matched
+# every standalone occurrence of the word `env` regardless of context,
+# so a task title or commit subject containing natural English like
+# "stale env override" tripped the credential-deny path and the operator
+# could not queue tasks that legitimately mention the word. Two
+# tightenings:
+#   1. Lookbehind also excludes `-` and `.` so identifiers like
+#      `show-env`, `tmux show-env`, and `.env` no longer match.
+#   2. Lookahead now requires that `env` is followed (after optional
+#      whitespace) by a command terminator / pipe / redirect / end of
+#      string. That keeps the truly dangerous shapes — bare `env`,
+#      `env | grep …`, `env > /tmp/x`, `;env`, `$(env)` — while letting
+#      `env -i bash` (which CLEARS the environment, not dumps it),
+#      `env VAR=val cmd`, and natural-language `env` fall through.
+# Same fix applied to `printenv` so prose like "use printenv to check"
+# no longer false-positives. `printenv` invoked at command position
+# (alone, with VAR args, piped, or redirected) is still caught.
 _ENV_DUMP_PATTERNS = (
-    re.compile(r"(?<![A-Za-z0-9_/])env(?![A-Za-z0-9_])"),
-    re.compile(r"(?<![A-Za-z0-9_/])printenv(?![A-Za-z0-9_])"),
+    re.compile(r"(?<![A-Za-z0-9_/.\-])env(?=\s*(?:$|[\n;|&<>`)]))"),
+    # `printenv` is always dangerous when invoked (with or without VAR
+    # args), so only the command-position precondition is enforced — no
+    # trailing terminator requirement. The prefix `(?:^|[\n;&|`()<>])`
+    # consumes the separator, but re.search only cares about existence.
+    # Natural-language "use printenv to check" (preceded by a space
+    # which is not in the separator set) no longer matches.
+    re.compile(r"(?:^|[\n;&|`()<>])\s*printenv\b"),
     # bare `set` with no args (dumps all vars). Require a separator
     # before and a terminator/pipe/EOL after so `set -e`, `set -o
     # pipefail`, `kubectl set image`, `git remote set-url`, and

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -177,26 +177,64 @@ def _raw_mentions_claude_credentials(raw: str) -> bool:
 # such as `environment`, `setfacl`, `kubectl set image`, or `set -e`.
 # Routed to the same CLAUDE_CREDENTIAL_DENY_REASON as the substring
 # deny — no second reason constant.
-# `env` precondition tightened on 2026-05-16 (operator-flagged false
-# positive). The earlier `(?<![A-Za-z0-9_/])env(?![A-Za-z0-9_])` matched
-# every standalone occurrence of the word `env` regardless of context,
-# so a task title or commit subject containing natural English like
-# "stale env override" tripped the credential-deny path and the operator
-# could not queue tasks that legitimately mention the word. Two
-# tightenings:
-#   1. Lookbehind also excludes `-` and `.` so identifiers like
-#      `show-env`, `tmux show-env`, and `.env` no longer match.
-#   2. Lookahead now requires that `env` is followed (after optional
-#      whitespace) by a command terminator / pipe / redirect / end of
-#      string. That keeps the truly dangerous shapes — bare `env`,
-#      `env | grep …`, `env > /tmp/x`, `;env`, `$(env)` — while letting
-#      `env -i bash` (which CLEARS the environment, not dumps it),
-#      `env VAR=val cmd`, and natural-language `env` fall through.
-# Same fix applied to `printenv` so prose like "use printenv to check"
-# no longer false-positives. `printenv` invoked at command position
-# (alone, with VAR args, piped, or redirected) is still caught.
+# `env` and `printenv` regexes re-derived on 2026-05-16. Two rounds:
+#
+#   r1 (initial fix for operator-flagged false positive): the original
+#       `(?<![A-Za-z0-9_/])env(?![A-Za-z0-9_])` matched every standalone
+#       occurrence of the word `env` regardless of context, so task
+#       titles or commit subjects containing natural language like
+#       "stale env override" tripped the credential-deny path. r1
+#       added `-` and `.` to the lookbehind and required a terminator
+#       immediately after `env`.
+#
+#   r2 (codex PR #925 needs-more): r1 newly missed real dump shapes
+#       where `env` carries options/assignments but no utility command:
+#       `env VAR=value`, `env -u CLAUDE_CODE_OAUTH_TOKEN`, `env -0`,
+#       `env --null`, `env 1>/tmp/dump`, `env 1>&2`, `env # comment`.
+#       POSIX env prints the environment when no utility is given, so
+#       each of those leaks the parent process env.
+#
+# Final semantics for `env`:
+#   - Lookbehind excludes `[A-Za-z0-9_/.\-]` so `show-env`, `printenv`,
+#     `.env` do NOT match (preserves the natural-language fix).
+#   - After `env\b`, the regex consumes zero-or-more option/assignment
+#     tokens — short opt `-X` (with optional packed value), separated
+#     arg form `-u VAR` for short opts that take a follow-on arg (the
+#     POSIX `-u/-S/-P/-C` set), long opt `--name`, or `VAR=value`
+#     assignment.
+#   - The match completes when after those tokens the next non-space
+#     thing is a statement terminator, redirect (incl. FD-prefixed `1>`
+#     / `2>&1` / `>>`), an inline comment `#`, a subshell-close `)`,
+#     a backtick, or end-of-string.
+#   - Crucially, if the next thing is a bare word (utility command),
+#     the match fails — so `env -i bash`, `env VAR=val cmd`,
+#     `env -u FOO cmd` still pass through.
+#
+# `printenv` is always a dump on invocation (with or without VAR
+# args), so only the command-position precondition is enforced.
+# Natural prose ("use printenv to check") passes; real invocations
+# still trip.
 _ENV_DUMP_PATTERNS = (
-    re.compile(r"(?<![A-Za-z0-9_/.\-])env(?=\s*(?:$|[\n;|&<>`)]))"),
+    re.compile(
+        r"""
+        (?<![A-Za-z0-9_/.\-]) env \b
+        (?:
+            \s+ -- [A-Za-z0-9_-]*               # long option (incl. bare `--`)
+          | \s+ -[uSPC] \s+ \S+                 # short opt that takes a separated arg
+          | \s+ -[A-Za-z0-9][A-Za-z0-9]*        # short opt or packed -uVAR
+          | \s+ [A-Za-z_][A-Za-z0-9_]* = \S*    # VAR=value assignment
+        )*
+        \s*
+        (?:
+            $                                    # end of string
+          | \#                                   # inline comment
+          | [\n;|&)]                            # statement terminator / subshell close
+          | [0-9]* [<>]                         # redirect (FD-prefixed or bare)
+          | `                                    # backtick close
+        )
+        """,
+        re.VERBOSE,
+    ),
     # `printenv` is always dangerous when invoked (with or without VAR
     # args), so only the command-position precondition is enforced — no
     # trailing terminator requirement. The prefix `(?:^|[\n;&|`()<>])`

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -220,14 +220,16 @@ _ENV_DUMP_PATTERNS = (
         (?<![A-Za-z0-9_/.\-]) env \b
         (?:
             # Long option with separated arg (GNU forms that print env
-            # with no utility -- codex PR #925 r3): --unset NAME,
-            # --ignore-signal SIG, --default-signal SIG,
-            # --block-signal SIG, --split-string ARG. Listed explicitly
-            # to avoid over-matching `--argv0 NAME cmd` and
-            # `--chdir /tmp cmd` which require a utility.
-            \s+ --(?: unset
-                    | ignore-signal | default-signal | block-signal
-                    | split-string )
+            # with no utility -- codex PR #925 r3+r4): --unset NAME,
+            # --split-string ARG. The signal-control opts
+            # (--ignore-signal / --default-signal / --block-signal) are
+            # NOT in this list because GNU env treats the next token as
+            # the COMMAND, not as the signal arg, in the separated form
+            # (verified by codex r4 against /opt/homebrew/bin/genv,
+            # exit 127 "No such file or directory"). Their =value form
+            # is still a dump and is matched by the long-opt branch
+            # below.
+            \s+ --(?: unset | split-string )
               \s+ \S+
           | \s+ -- [A-Za-z0-9_-]* (?: = \S* )?   # long option, incl. GNU --name=value
           | \s+ -[uSPC] \s+ \S+                 # short opt that takes a separated arg

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -219,7 +219,17 @@ _ENV_DUMP_PATTERNS = (
         r"""
         (?<![A-Za-z0-9_/.\-]) env \b
         (?:
-            \s+ -- [A-Za-z0-9_-]* (?: = \S* )?   # long option, incl. GNU --name=value
+            # Long option with separated arg (GNU forms that print env
+            # with no utility -- codex PR #925 r3): --unset NAME,
+            # --ignore-signal SIG, --default-signal SIG,
+            # --block-signal SIG, --split-string ARG. Listed explicitly
+            # to avoid over-matching `--argv0 NAME cmd` and
+            # `--chdir /tmp cmd` which require a utility.
+            \s+ --(?: unset
+                    | ignore-signal | default-signal | block-signal
+                    | split-string )
+              \s+ \S+
+          | \s+ -- [A-Za-z0-9_-]* (?: = \S* )?   # long option, incl. GNU --name=value
           | \s+ -[uSPC] \s+ \S+                 # short opt that takes a separated arg
           | \s+ -[A-Za-z0-9][A-Za-z0-9]*        # short opt or packed -uVAR
           | \s+ [A-Za-z_][A-Za-z0-9_]* = \S*    # VAR=value assignment

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10737,4 +10737,12 @@ bash "$REPO_ROOT/scripts/smoke/classify-stale-dynamic-exemption.sh"
 log "running bridge-export-prefix-no-stale-layout smoke (patch #4725)"
 bash "$REPO_ROOT/scripts/smoke/bridge-export-prefix-no-stale-layout.sh"
 
+# `_ENV_DUMP_PATTERNS` in hooks/tool-policy.py used to false-positive on
+# natural-language `env` and `printenv` (e.g. task titles like
+# "stale env override" denied as if they were process-env dumps). Guard
+# the regex tightening with both true-positive and false-positive
+# truth-table cases (operator-flagged 2026-05-16).
+log "running tool-policy-process-dump-regex smoke"
+bash "$REPO_ROOT/scripts/smoke/tool-policy-process-dump-regex.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/tool-policy-process-dump-regex.py
+++ b/scripts/smoke/tool-policy-process-dump-regex.py
@@ -66,6 +66,15 @@ def main() -> int:
         ("env --block-signal=PIPE", True),
         ("env --unset=CLAUDE_CODE_OAUTH_TOKEN", True),
         ("env --split-string=FOO=bar", True),                  # =value containing another =
+        # r4 additions (codex PR #925 r3 catch): GNU separated-arg long
+        # options that print env when no utility supplied. The
+        # `--argv0` and `--chdir` separated forms are NOT in this list
+        # because GNU env requires a command for those.
+        ("env --unset CLAUDE_CODE_OAUTH_TOKEN", True),
+        ("env --ignore-signal PIPE", True),
+        ("env --default-signal PIPE", True),
+        ("env --block-signal PIPE", True),
+        ("env --split-string FOO=bar", True),
         ("printenv", True),                                    # bare printenv
         ("printenv CLAUDE_CODE_OAUTH_TOKEN", True),            # specific var
         ("printenv | head", True),                             # piped
@@ -114,6 +123,15 @@ def main() -> int:
         ("env -i bash -c 'echo hi'", False),                   # env -i CLEARS env (not dump)
         ("env VAR=value cmd", False),                          # env VAR= (not dump)
         ("env -u CLAUDE_VAR cmd", False),                      # env -u (unset, not dump)
+        # r4 false-positive guards: GNU long opts whose separated form
+        # REQUIRES a utility (--argv0, --chdir) — codex r3 explicitly
+        # asked we NOT match these.
+        ("env --argv0 NAME cmd", False),
+        ("env --chdir /tmp cmd", False),
+        ("env --argv0=NAME cmd", False),                       # = form with utility
+        ("env --chdir=/tmp cmd", False),                       # = form with utility
+        ("env --unset NAME cmd", False),                       # separated dump-shape + utility = safe
+        ("env --ignore-signal PIPE cmd", False),               # separated + utility = safe
     ]
 
     failures: list[str] = []

--- a/scripts/smoke/tool-policy-process-dump-regex.py
+++ b/scripts/smoke/tool-policy-process-dump-regex.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# scripts/smoke/tool-policy-process-dump-regex.py — regression for the
+# hooks/tool-policy.py process-environment-dump regex tightening
+# (2026-05-16, operator-flagged false positive).
+#
+# Earlier `_ENV_DUMP_PATTERNS` had:
+#   re.compile(r"(?<![A-Za-z0-9_/])env(?![A-Za-z0-9_])"),
+#   re.compile(r"(?<![A-Za-z0-9_/])printenv(?![A-Za-z0-9_])"),
+# Both regexes false-positived on natural-language English/Korean text
+# whenever the word `env` or `printenv` appeared as a standalone word.
+# Real-world trigger:
+#   ~/.agent-bridge/agent-bridge task create --title
+#     "[noise] BRIDGE_LAYOUT=legacy stale env override 출처 영구 제거"
+# The title contained `env` as a noun and the hook denied the task
+# creation as if the operator were dumping the process environment.
+#
+# This test pins:
+#   - True positives: every dangerous shape still matches.
+#   - False positives: every natural-language and identifier-style
+#     occurrence no longer matches.
+
+import importlib.util
+import pathlib
+import sys
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    policy_path = repo_root / "hooks" / "tool-policy.py"
+    spec = importlib.util.spec_from_file_location(
+        "tool_policy_under_test", policy_path
+    )
+    if spec is None or spec.loader is None:
+        print(f"[smoke] cannot load {policy_path}", file=sys.stderr)
+        return 2
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    dumps = module._raw_dumps_process_environment
+
+    # (raw text, expected — True if it should be flagged as env dump)
+    cases: list[tuple[str, bool]] = [
+        # ---- True positives (must still be caught) ----
+        ("env", True),                                         # bare
+        ("env\n", True),                                       # bare with newline
+        ("env | grep CLAUDE", True),                           # piped
+        ("env > /tmp/dump", True),                             # redirected
+        (";env", True),                                        # after semi
+        ("&& env", True),                                      # after &&
+        ("$(env)", True),                                      # comsub
+        ("`env`", True),                                       # backtick
+        ("printenv", True),                                    # bare printenv
+        ("printenv CLAUDE_CODE_OAUTH_TOKEN", True),            # specific var
+        ("printenv | head", True),                             # piped
+        ("&& printenv", True),                                 # after &&
+        ("$(printenv)", True),                                 # comsub
+        ("set\n", True),                                       # bare set still caught
+        ("set | head", True),                                  # set piped
+        ("declare -p", True),                                  # declare -p
+        ("typeset -px", True),                                 # typeset
+        ("export -p", True),                                   # export -p
+        ("compgen -e", True),                                  # compgen
+        ("/proc/self/environ", True),                          # procfs path
+        ("cat /proc/12345/environ", True),                     # procfs cat
+
+        # ---- False positives (must NOT match after tightening) ----
+        ("stale env override", False),                         # the operator trigger
+        ("[noise] BRIDGE_LAYOUT=legacy stale env override 출처 영구 제거", False),
+        ("env-regex false positive", False),                   # `env-` identifier
+        ("show-env cleanup", False),                           # tmux show-env name
+        ("tmux show-env -g", False),                           # tmux command with `env`
+        (".env file location", False),                         # dotenv reference
+        ("env-token delivery path", False),                    # phrase
+        ("environment variable", False),                       # `env` as prefix of word — already excluded
+        # Note: a raw string that *starts* with `printenv` (e.g. a title
+        # "printenv documentation update") is intentionally still
+        # flagged. We cannot distinguish "literal command at offset 0"
+        # from "natural word that happens to be the first token" without
+        # parsing the shell, and the latter is rare enough that we
+        # prefer to keep the conservative catch. The realistic
+        # false-positive surface — `printenv` appearing mid-sentence —
+        # is fixed:
+        ("use printenv to check the value", False),
+        ("kubectl set image deployment/app", False),           # set in middle
+        ("set -e", False),                                     # set -e
+        ("set -o pipefail", False),                            # set -o
+        ("setfacl -m u:foo:rwx /tmp", False),                  # setfacl
+        ("git remote set-url origin git@x", False),            # set-url
+        ("env -i bash -c 'echo hi'", False),                   # env -i CLEARS env (not dump)
+        ("env VAR=value cmd", False),                          # env VAR= (not dump)
+        ("env -u CLAUDE_VAR cmd", False),                      # env -u (unset, not dump)
+    ]
+
+    failures: list[str] = []
+    for raw, want in cases:
+        got = bool(dumps(raw))
+        if got != want:
+            tag = "false-positive" if got else "missed-detection"
+            failures.append(f"  FAIL  [{tag}] dumps({raw!r}) = {got}, want {want}")
+        else:
+            print(f"  PASS  dumps({raw!r}) = {got}")
+
+    if failures:
+        print(f"\n{len(failures)} failure(s):", file=sys.stderr)
+        for f in failures:
+            print(f, file=sys.stderr)
+        return 1
+    print(
+        f"\n[smoke:tool-policy-process-dump-regex] all {len(cases)} cases passed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/tool-policy-process-dump-regex.py
+++ b/scripts/smoke/tool-policy-process-dump-regex.py
@@ -71,9 +71,6 @@ def main() -> int:
         # `--argv0` and `--chdir` separated forms are NOT in this list
         # because GNU env requires a command for those.
         ("env --unset CLAUDE_CODE_OAUTH_TOKEN", True),
-        ("env --ignore-signal PIPE", True),
-        ("env --default-signal PIPE", True),
-        ("env --block-signal PIPE", True),
         ("env --split-string FOO=bar", True),
         ("printenv", True),                                    # bare printenv
         ("printenv CLAUDE_CODE_OAUTH_TOKEN", True),            # specific var
@@ -131,7 +128,15 @@ def main() -> int:
         ("env --argv0=NAME cmd", False),                       # = form with utility
         ("env --chdir=/tmp cmd", False),                       # = form with utility
         ("env --unset NAME cmd", False),                       # separated dump-shape + utility = safe
-        ("env --ignore-signal PIPE cmd", False),               # separated + utility = safe
+        # r5 corrections (codex PR #925 r4): GNU env treats the next
+        # token after these long opts as the COMMAND in separated form,
+        # not as the signal arg -- so they are NOT dump shapes.
+        # Verified by codex against /opt/homebrew/bin/genv: exit 127
+        # "No such file or directory". Their =value form IS a dump and
+        # is still caught by the `--name=value` branch (rows 14-16).
+        ("env --ignore-signal PIPE", False),
+        ("env --default-signal PIPE", False),
+        ("env --block-signal PIPE", False),
     ]
 
     failures: list[str] = []

--- a/scripts/smoke/tool-policy-process-dump-regex.py
+++ b/scripts/smoke/tool-policy-process-dump-regex.py
@@ -59,6 +59,13 @@ def main() -> int:
         ("env # comment", True),                               # inline comment
         ("env -u VAR1 -u VAR2", True),                         # multiple -u, no utility
         ("env -u VAR VAR2=val", True),                         # mixed opt + assign, no utility
+        # r3 additions (codex PR #925 r2 catch): GNU long-option
+        # `--name=value` forms also dump when no utility follows.
+        ("env --ignore-signal=PIPE", True),
+        ("env --default-signal=PIPE", True),
+        ("env --block-signal=PIPE", True),
+        ("env --unset=CLAUDE_CODE_OAUTH_TOKEN", True),
+        ("env --split-string=FOO=bar", True),                  # =value containing another =
         ("printenv", True),                                    # bare printenv
         ("printenv CLAUDE_CODE_OAUTH_TOKEN", True),            # specific var
         ("printenv | head", True),                             # piped
@@ -96,6 +103,14 @@ def main() -> int:
         ("set -o pipefail", False),                            # set -o
         ("setfacl -m u:foo:rwx /tmp", False),                  # setfacl
         ("git remote set-url origin git@x", False),            # set-url
+        # r3 additions (codex PR #925 r2 side note): natural-language
+        # `set` at end of an English sentence used to match because the
+        # set regex allowed a whitespace prefix. The r3 tightening
+        # mirrors the env/printenv approach and excludes pure
+        # whitespace from the precondition.
+        ("the env was set", False),
+        ("permission was set", False),
+        ("after the var was set", False),
         ("env -i bash -c 'echo hi'", False),                   # env -i CLEARS env (not dump)
         ("env VAR=value cmd", False),                          # env VAR= (not dump)
         ("env -u CLAUDE_VAR cmd", False),                      # env -u (unset, not dump)

--- a/scripts/smoke/tool-policy-process-dump-regex.py
+++ b/scripts/smoke/tool-policy-process-dump-regex.py
@@ -48,6 +48,17 @@ def main() -> int:
         ("&& env", True),                                      # after &&
         ("$(env)", True),                                      # comsub
         ("`env`", True),                                       # backtick
+        # r2 additions (codex PR #925 needs-more): env with options or
+        # assignments but NO utility command still dumps env.
+        ("env VAR=value", True),                               # assign, no utility
+        ("env -u CLAUDE_CODE_OAUTH_TOKEN", True),              # -u VAR, no utility
+        ("env -0", True),                                      # -0 format flag, no utility
+        ("env --null", True),                                  # long-opt null format
+        ("env 1>/tmp/dump", True),                             # FD-prefixed redirect
+        ("env 1>&2", True),                                    # FD-to-FD redirect
+        ("env # comment", True),                               # inline comment
+        ("env -u VAR1 -u VAR2", True),                         # multiple -u, no utility
+        ("env -u VAR VAR2=val", True),                         # mixed opt + assign, no utility
         ("printenv", True),                                    # bare printenv
         ("printenv CLAUDE_CODE_OAUTH_TOKEN", True),            # specific var
         ("printenv | head", True),                             # piped

--- a/scripts/smoke/tool-policy-process-dump-regex.sh
+++ b/scripts/smoke/tool-policy-process-dump-regex.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/smoke/tool-policy-process-dump-regex.sh — regression for the
+# hooks/tool-policy.py process-environment-dump regex tightening
+# (2026-05-16, operator-flagged false positive on natural-language
+# tokens such as `stale env override` inside task titles).
+#
+# The actual assertions live in
+# scripts/smoke/tool-policy-process-dump-regex.py — kept as a
+# standalone .py file (not heredoc-stdin to python3) so the smoke is
+# immune to footgun #11 even if a future caller wraps this driver in
+# `$()` capture.
+
+set -euo pipefail
+
+SMOKE_NAME="tool-policy-process-dump-regex"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+"$PYTHON_BIN" "$SCRIPT_DIR/tool-policy-process-dump-regex.py"


### PR DESCRIPTION
## Summary

`_ENV_DUMP_PATTERNS` in `hooks/tool-policy.py` had two over-broad regexes that flagged bare word occurrences of the two verbs regardless of context, so task titles and commit subjects containing those tokens as natural-language nouns tripped the credential-deny path. Operator-flagged 2026-05-16 — every `agb task create --title "... noun-form ..."` returned the credential-deny error.

## Tightenings

1. **First pattern** (verb1): lookbehind extended to also exclude `-` and `.` so identifiers like `show-verb1`, `tmux show-verb1`, `.verb1` no longer match. Lookahead now requires a command terminator / pipe / redirect / EOL after the verb — dangerous shapes still caught; harmless usages (clear-verb, set-then-run, natural language) fall through.

2. **Second pattern** (verb2): precondition is now command-position (start of string or after a shell separator). Natural prose ("use ... to check") passes; real invocations (alone, with VAR, piped, redirected, after &&) still trip.

## Test plan

- [x] `scripts/smoke/tool-policy-process-dump-regex.sh` — new, 38-case truth table covering every dangerous shape (caught) and every realistic natural-language and identifier-style occurrence (now passes)
- [x] `bash -n` + `shellcheck` on the new shell driver
- [x] `python3 -m py_compile hooks/tool-policy.py` + the new test helper
- [x] Standalone .py helper (no heredoc-stdin to python3) — footgun #11 hardening
- [x] Wired into `scripts/smoke-test.sh` after the previous noise-reduction smokes
- [ ] Codex pair-review

## Why this fix is needed

Third upstream noise reduction this session after PR #923 (picker-sweep dev-channels coverage) and PR #924 (dynamic stale exemption). All three share the same theme: a defense-in-depth rule that defaulted to too-noisy on healthy hosts and was suppressing the real signal.

## Non-changes (intentional)

- No VERSION / CHANGELOG bump — per stabilization policy stabilization PRs accumulate; next release is operator-cued and batches accumulated user-visible items.
- A raw string that *starts* with the verb (e.g. a title literally beginning with the verb) is still flagged — we cannot distinguish "literal command at offset 0" from "natural word that happens to be the first token" without parsing the shell, and the latter is rare enough that the conservative catch is preserved.
