### PR TITLE
fix(core): drop stale layout vars from bridge_export_env_prefix (patch #4725)

### DIFF
--- a/lib/bridge-core.sh
+++ b/lib/bridge-core.sh
@@ -794,8 +794,20 @@ bridge_export_env_prefix() {
     BRIDGE_ROSTER_FILE
     BRIDGE_ROSTER_LOCAL_FILE
     BRIDGE_STATE_DIR
-    BRIDGE_LAYOUT
-    BRIDGE_DATA_ROOT
+    # NOTE 2026-05-16 (patch ticket #4725): BRIDGE_LAYOUT and
+    # BRIDGE_DATA_ROOT were intentionally REMOVED from this prefix.
+    # On a v2-migrated install, the marker at state/layout-marker.sh
+    # is the source of truth — children re-resolve via the resolver
+    # at startup. When this prefix was re-exporting the parent's
+    # potentially-stale BRIDGE_LAYOUT, every spawned child inherited
+    # the legacy value and triggered the
+    # `BRIDGE_LAYOUT=legacy is a stale pre-v0.8.0 env override; …
+    # Preferring marker.` warning on every CLI invocation — visible
+    # to the operator dozens of times per command output. The
+    # underlying resolver behavior is correct (marker wins); the
+    # noise was self-inflicted by re-propagating the demoted value
+    # into the child shell. Dropping these two names lets the child
+    # resolver compute the layout cleanly.
     BRIDGE_LAYOUT_MARKER_DIR
     BRIDGE_ACTIVE_AGENT_DIR
     BRIDGE_HISTORY_DIR

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10728,4 +10728,13 @@ bash "$REPO_ROOT/scripts/smoke/v2-scaffold-home-and-workdir.sh"
 log "running classify-stale-dynamic-exemption smoke"
 bash "$REPO_ROOT/scripts/smoke/classify-stale-dynamic-exemption.sh"
 
+# bridge_export_env_prefix was re-exporting BRIDGE_LAYOUT and
+# BRIDGE_DATA_ROOT from the parent process into every spawned child
+# (patch ticket #4725, 2026-05-16). On a v2-migrated install, parents
+# can carry a legacy value and every child then triggers the
+# resolver-demote warning on every CLI command. Guard the trimmed
+# prefix list.
+log "running bridge-export-prefix-no-stale-layout smoke (patch #4725)"
+bash "$REPO_ROOT/scripts/smoke/bridge-export-prefix-no-stale-layout.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/bridge-export-prefix-no-stale-layout-driver.sh
+++ b/scripts/smoke/bridge-export-prefix-no-stale-layout-driver.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scripts/smoke/bridge-export-prefix-no-stale-layout-driver.sh --
+# helper invoked by bridge-export-prefix-no-stale-layout.sh. Kept as a
+# standalone file so the smoke driver does not need to embed a
+# $()/source pair inline (that nesting failed bash parsing when this
+# file was first inlined; the standalone shape avoids that and stays
+# resilient to footgun #11 if a future caller wraps the parent driver
+# in command substitution).
+#
+# Usage: bridge-export-prefix-no-stale-layout-driver.sh REPO_ROOT
+# Effect: cd into REPO_ROOT, source lib/bridge-core.sh, call
+# bridge_export_env_prefix and write the result to stdout.
+
+# Bash 4+ re-exec -- macOS ships /bin/bash 3.2 which cannot source
+# lib/bridge-core.sh (needs declare -g and associative arrays). Mirror
+# the same prelude used in scripts/smoke/status-engine-detect.sh.
+_DRIVER_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_DRIVER_TARGET" ]]; then
+    for cand in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$cand" && -x "$cand" ]] || continue
+      if "$cand" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$cand" "$_DRIVER_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke-driver:bridge-export-prefix-no-stale-layout] needs Bash 4+." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+REPO_ROOT="${1:?REPO_ROOT required}"
+
+cd "$REPO_ROOT"
+# shellcheck source=/dev/null
+source lib/bridge-core.sh
+
+bridge_export_env_prefix

--- a/scripts/smoke/bridge-export-prefix-no-stale-layout.sh
+++ b/scripts/smoke/bridge-export-prefix-no-stale-layout.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# scripts/smoke/bridge-export-prefix-no-stale-layout.sh — regression
+# for patch ticket #4725 (2026-05-16). On a v2-migrated install the
+# operator was seeing the
+#   `[경고] BRIDGE_LAYOUT=legacy is a stale pre-v0.8.0 env override...
+#    Preferring marker.`
+# warning on every CLI invocation, even with a clean shell rc. Root
+# cause: `bridge_export_env_prefix` (lib/bridge-core.sh) was
+# re-exporting BRIDGE_LAYOUT and BRIDGE_DATA_ROOT from the parent
+# process into every spawned child, so once the parent had a stale
+# legacy value (e.g. inherited from an old tmux session) every child
+# triggered the resolver-demote warning. Fix: remove those two vars
+# from the prefix list -- the marker at state/layout-marker.sh is the
+# source of truth and the child resolver re-computes the layout
+# cleanly.
+#
+# This test pins:
+#   1. Even when BRIDGE_LAYOUT=legacy and BRIDGE_DATA_ROOT=/tmp/x are
+#      set in the parent shell, bridge_export_env_prefix does NOT
+#      include them in the produced prefix string.
+#   2. Other prefix vars (BRIDGE_LAYOUT_MARKER_DIR here as the
+#      smoke-friendly probe) continue to be forwarded when set --
+#      regression guard against accidentally pruning more than
+#      intended.
+
+# Bash 4+ re-exec (sourcing lib/bridge-core.sh needs declare -g and
+# associative arrays).
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:bridge-export-prefix-no-stale-layout] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="bridge-export-prefix-no-stale-layout"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+# Run the prefix computation in a child shell so the smoke harness
+# itself is not polluted by sourcing bridge-core. We use a here-doc
+# bash invocation (NOT heredoc-stdin to a captured subprocess, so the
+# footgun #11 chain is avoided) and write the result to a tmpfile.
+TMP_OUT="$(mktemp -t agb-prefix.XXXXXX)"
+trap 'rm -f "$TMP_OUT"' EXIT
+
+PREFIX_DRIVER="$SCRIPT_DIR/bridge-export-prefix-no-stale-layout-driver.sh"
+if [[ ! -x "$PREFIX_DRIVER" ]]; then
+  echo "[smoke:${SMOKE_NAME}] missing driver: $PREFIX_DRIVER" >&2
+  exit 2
+fi
+
+BRIDGE_LAYOUT=legacy \
+BRIDGE_DATA_ROOT=/tmp/should-not-be-forwarded \
+BRIDGE_LAYOUT_MARKER_DIR=/tmp/marker-fixture \
+"$PREFIX_DRIVER" "$REPO_ROOT" >"$TMP_OUT"
+
+PREFIX_OUTPUT="$(cat "$TMP_OUT")"
+
+failed=0
+
+if grep -qE '(^| )BRIDGE_LAYOUT=' <<<"$PREFIX_OUTPUT"; then
+  echo "  FAIL  BRIDGE_LAYOUT was forwarded by bridge_export_env_prefix" >&2
+  echo "        prefix=${PREFIX_OUTPUT}" >&2
+  failed=1
+else
+  echo "  PASS  BRIDGE_LAYOUT not forwarded"
+fi
+
+if grep -qE '(^| )BRIDGE_DATA_ROOT=' <<<"$PREFIX_OUTPUT"; then
+  echo "  FAIL  BRIDGE_DATA_ROOT was forwarded by bridge_export_env_prefix" >&2
+  echo "        prefix=${PREFIX_OUTPUT}" >&2
+  failed=1
+else
+  echo "  PASS  BRIDGE_DATA_ROOT not forwarded"
+fi
+
+if grep -qE '(^| )BRIDGE_LAYOUT_MARKER_DIR=' <<<"$PREFIX_OUTPUT"; then
+  echo "  PASS  BRIDGE_LAYOUT_MARKER_DIR forwarded (regression guard)"
+else
+  echo "  FAIL  BRIDGE_LAYOUT_MARKER_DIR was unexpectedly dropped" >&2
+  echo "        prefix=${PREFIX_OUTPUT}" >&2
+  failed=1
+fi
+
+if (( failed )); then
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] all checks passed"


### PR DESCRIPTION
## Summary

`bridge_export_env_prefix` in `lib/bridge-core.sh` listed `BRIDGE_LAYOUT` and `BRIDGE_DATA_ROOT` in its names array, so the parent process's potentially-stale legacy values were re-exported into every spawned child. On every v2-migrated install, the child resolver then demoted the legacy value and emitted the
`BRIDGE_LAYOUT=legacy is a stale pre-v0.8.0 ... Preferring marker.` warning on every CLI invocation — visible to the operator dozens of times per command output.

The resolver behavior is correct (marker wins); the noise was self-inflicted by re-propagating the demoted value into the child shell.

Patch ticket #4725 (2026-05-16) — patch confirmed via `ps eww` that the tmux new-session argv prefix carried `BRIDGE_LAYOUT=legacy BRIDGE_DATA_ROOT=''`. The operator's shell rc, launchctl, and roster have no such line — propagation came from agent-bridge itself.

## Fix

Drop `BRIDGE_LAYOUT` and `BRIDGE_DATA_ROOT` from the prefix names array. The marker at `state/layout-marker.sh` is the source of truth and the child resolver re-computes the layout cleanly. Same fix applies to every v2-migrated install, not just the operator host.

## Test plan

- [x] `scripts/smoke/bridge-export-prefix-no-stale-layout.sh` — new, sets both vars in the parent, sources bridge-core, calls the prefix builder, asserts (a) neither var appears in the output and (b) a regression-guard third var (`BRIDGE_LAYOUT_MARKER_DIR`) is still forwarded
- [x] Standalone driver helper (re-execs under Bash 4+ for declare -g)
- [x] `bash -n` + `shellcheck` on both files
- [x] Wired into `scripts/smoke-test.sh` after the classify-stale smoke
- [ ] Codex pair-review

## Why

Originating evidence came from patch's host-level investigation of the operator-flagged "every CLI command shows BRIDGE_LAYOUT warning" issue. patch ruled out every shell-rc / launchctl / roster source and traced the propagation back to this single prefix function. Brief came back as task #4725 with focus checklist and reproducer.

## Non-changes (intentional)

- No VERSION / CHANGELOG bump — per stabilization policy stabilization PRs accumulate; next release is operator-cued and batches accumulated user-visible items.
- The remaining 30+ prefix vars are untouched.
- The marker resolver itself is untouched — fix is at the propagation layer, not the resolver layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
