### PR TITLE
fix(worktree-doctor): reap orphaned children when reaping worktree directories

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -442,6 +442,16 @@ _bridge_worktree_doctor_classify_one() {
   printf '%-7s | %-7s | %3dd    | %s\n' \
     "$status" "${stash_count}" "$age_days" "$wt_path"
 
+  # Dry-run surfaces which orphaned children WOULD be reaped on REMOVE
+  # rows so the operator sees the full picture before opting into --apply.
+  # MUST run BEFORE the early `mode != apply` return below — the r1 of
+  # PR #927 put this call inside the apply branch and codex caught it as
+  # unreachable. Smoke `worktree-doctor-reap-zombies-dry-run.sh` is the
+  # integration regression guard.
+  if [[ "$mode" == "dry-run" && "$status" == "REMOVE" ]]; then
+    _bridge_worktree_doctor_reap_children "$wt_path" "dry-run"
+  fi
+
   if [[ "$mode" != "apply" ]]; then
     return 0
   fi
@@ -455,6 +465,14 @@ _bridge_worktree_doctor_classify_one() {
   fi
 
   if (( should_remove == 1 )); then
+    # Before removing the worktree directory itself, reap any leftover
+    # daemonized child processes whose argv references the worktree path.
+    # Operator-observed (Sean, 2026-05-16): 7 bridge-watchdog-silence.py
+    # processes parented to init(1), alive 8-12 days, scripts pointing at
+    # worktree dirs that had been pruned long ago. `git worktree remove -f`
+    # does NOT cascade to such children — it only touches metadata and the
+    # filesystem. We must do it ourselves.
+    _bridge_worktree_doctor_reap_children "$wt_path" "$mode"
     if git -C "$repo_root" worktree remove -f "$wt_path" >/dev/null 2>&1; then
       n_removed=$(( n_removed + 1 ))
       printf '         [apply] removed: %s\n' "$wt_path"
@@ -467,6 +485,151 @@ _bridge_worktree_doctor_classify_one() {
       n_remove_failed=$(( n_remove_failed + 1 ))
       printf '         [apply] FAILED to remove: %s\n' "$wt_path" >&2
     fi
+  fi
+}
+
+# _bridge_worktree_doctor_reap_children — terminate any process whose argv
+# references the given worktree path. Used by the doctor BEFORE removing a
+# worktree directory so daemonized children (e.g. python helpers) that were
+# reparented to init(1) don't outlive their worktree.
+#
+# Args: wt_path mode
+#   wt_path  absolute path of the worktree about to be removed
+#   mode     "apply" → actually send SIGTERM then SIGKILL after a short wait
+#            anything else (including "dry-run") → report PIDs only, no signals
+#
+# Anchor policy (the critical correctness call):
+#   Match a process if any whitespace-delimited token in its `ps` `command`
+#   field starts with "<wt_path>/". This is anchored (NOT a naive substring
+#   "contains"), so:
+#     - It catches direct-exec children where argv[0] is the worktree
+#       binary path (e.g. `/path/to/.claude/worktrees/agent-X/foo.sh ...`).
+#     - It catches interpreter-exec children where argv[0] is the
+#       interpreter and argv[1+] is a script path under the worktree
+#       (e.g. `Python /path/to/.claude/worktrees/agent-X/bridge-watchdog-silence.py run`
+#       — the exact shape of the 7 zombie processes Sean observed on
+#       2026-05-16).
+#     - It does NOT catch a `git` process running against the worktree
+#       (git's argv doesn't include the worktree path as a path token —
+#       paths are passed via `-C` separately).
+#     - It does NOT catch the doctor itself (this function's argv is the
+#       caller's argv, which doesn't include "<wt_path>/" as a token).
+#   We also defensively skip our own PID and any `git` basename.
+#
+# Cross-platform `ps` contract:
+#   We invoke `ps -eo pid=,command=` (= suppresses headers). This flag set
+#   works identically on macOS BSD `ps` and Linux procps `ps`. We avoid
+#   `pgrep -f` because the `-f` flag's argv-matching semantics drift between
+#   BSD pgrep (matches against process name only by default) and Linux
+#   pgrep (matches full command line); using `ps` + a pure-bash token scan
+#   keeps the behavior identical on both.
+#
+# Signal ordering: TERM → wait up to ~2s (polling at 100ms) → KILL.
+_bridge_worktree_doctor_reap_children() {
+  local wt_path="$1"
+  local mode="$2"
+
+  # Refuse to operate on an empty path or "/" (defense in depth — a bug
+  # upstream that passed wt_path="" would otherwise match every process
+  # whose command line contains "/").
+  if [[ -z "$wt_path" || "$wt_path" == "/" ]]; then
+    return 0
+  fi
+
+  local self_pid=$$
+  # Path prefix we anchor against. We anchor on "<wt_path>/" specifically
+  # (trailing slash mandatory) so we never match a sibling worktree whose
+  # name happens to start with the same prefix (e.g. agent-foo vs
+  # agent-foo-bar).
+  local anchor="${wt_path%/}/"
+
+  # Snapshot the process table once. Output format: "<pid> <command...>".
+  # ps -eo pid=,command= works on both macOS BSD ps and Linux procps ps;
+  # the trailing = suppresses the header.
+  local ps_out
+  if ! ps_out="$(ps -eo pid=,command= 2>/dev/null)"; then
+    return 0
+  fi
+
+  local -a matched_pids=()
+  local line pid cmd token
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    # Split into pid + command. Leading whitespace from BSD ps is stripped
+    # by the read.
+    line="${line#"${line%%[![:space:]]*}"}"
+    pid="${line%%[[:space:]]*}"
+    cmd="${line#"$pid"}"
+    cmd="${cmd#"${cmd%%[![:space:]]*}"}"
+
+    [[ "$pid" =~ ^[0-9]+$ ]] || continue
+    # Skip self and our parent (the caller). Safer than only skipping $$.
+    if [[ "$pid" == "$self_pid" || "$pid" == "$PPID" ]]; then
+      continue
+    fi
+    # Skip git plumbing. The doctor itself runs git subprocesses that
+    # happen during/after this scan; we don't want to ever target them.
+    local first_token="${cmd%%[[:space:]]*}"
+    local first_basename="${first_token##*/}"
+    if [[ "$first_basename" == "git" ]]; then
+      continue
+    fi
+
+    # Token-level anchor: does any whitespace-separated token in the
+    # command line start with the worktree path + "/"?
+    local matched=0
+    # shellcheck disable=SC2086  # intentional word-splitting on the cmd line
+    for token in $cmd; do
+      if [[ "$token" == "$anchor"* ]]; then
+        matched=1
+        break
+      fi
+    done
+    if (( matched == 1 )); then
+      matched_pids+=("$pid")
+    fi
+  done <<<"$ps_out"
+
+  if (( ${#matched_pids[@]} == 0 )); then
+    return 0
+  fi
+
+  if [[ "$mode" != "apply" ]]; then
+    printf '         [dry-run] would reap %d orphaned child PID(s) under %s: %s\n' \
+      "${#matched_pids[@]}" "$wt_path" "${matched_pids[*]}"
+    return 0
+  fi
+
+  # Apply mode: SIGTERM, poll up to ~2s, then SIGKILL stragglers.
+  local p
+  for p in "${matched_pids[@]}"; do
+    kill -TERM "$p" 2>/dev/null || true
+  done
+  printf '         [apply] sent SIGTERM to %d orphan(s) under %s: %s\n' \
+    "${#matched_pids[@]}" "$wt_path" "${matched_pids[*]}"
+
+  # Poll for exit. 20 iterations × 0.1s = ~2s budget.
+  local iter
+  local -a still_alive=()
+  for (( iter = 0; iter < 20; iter++ )); do
+    still_alive=()
+    for p in "${matched_pids[@]}"; do
+      if kill -0 "$p" 2>/dev/null; then
+        still_alive+=("$p")
+      fi
+    done
+    if (( ${#still_alive[@]} == 0 )); then
+      break
+    fi
+    sleep 0.1
+  done
+
+  if (( ${#still_alive[@]} > 0 )); then
+    for p in "${still_alive[@]}"; do
+      kill -KILL "$p" 2>/dev/null || true
+    done
+    printf '         [apply] SIGKILL escalation for %d straggler(s): %s\n' \
+      "${#still_alive[@]}" "${still_alive[*]}" >&2
   fi
 }
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10745,4 +10745,19 @@ bash "$REPO_ROOT/scripts/smoke/bridge-export-prefix-no-stale-layout.sh"
 log "running tool-policy-process-dump-regex smoke"
 bash "$REPO_ROOT/scripts/smoke/tool-policy-process-dump-regex.sh"
 
+# bridge_worktree_doctor previously left daemonized children alive after
+# pruning their worktree dir — Sean observed 7 orphaned bridge-watchdog
+# processes parented to init(1) on 2026-05-16. The doctor now reaps argv-
+# anchored children before removing the worktree; this smoke is the
+# regression catch for both shapes (direct-exec + interpreter-exec).
+log "running worktree-doctor-reap-zombies smoke"
+bash "$REPO_ROOT/scripts/smoke/worktree-doctor-reap-zombies.sh"
+
+# Integration test for the dry-run path through bridge_worktree_doctor:
+# proves --dry-run actually invokes the reap helper for REMOVE rows
+# (catches the r1 regression where the helper call lived after the early
+# `mode != apply` return and was therefore unreachable).
+log "running worktree-doctor-reap-zombies-dry-run integration smoke"
+bash "$REPO_ROOT/scripts/smoke/worktree-doctor-reap-zombies-dry-run.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/worktree-doctor-reap-zombies-dry-run.sh
+++ b/scripts/smoke/worktree-doctor-reap-zombies-dry-run.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# scripts/smoke/worktree-doctor-reap-zombies-dry-run.sh — Track C of the
+# 2026-05-16 operator-audit wave, r2 follow-up.
+#
+# Integration regression guard for PR #927 r1: codex caught that the
+# dry-run reap call lived inside the apply branch of
+# `_bridge_worktree_doctor_classify_one`, which is unreachable when
+# mode=dry-run because the function early-returns on `mode != apply`
+# before reaching it. The companion smoke
+# (`worktree-doctor-reap-zombies.sh`) only exercised the helper in
+# isolation and so missed the bug.
+#
+# This smoke goes end-to-end: it invokes `bridge_worktree_doctor
+# --dry-run --repo <fixture>` against a fixture where one worktree is
+# classified REMOVE and a matching child process exists. Assertions:
+#
+#   1. Output contains a "would reap" line and the child's PID. This
+#      proves the dry-run path actually invokes the reap helper.
+#   2. The child process REMAINS ALIVE after the dry-run completes.
+#      Dry-run must never signal.
+#   3. The control sleep (no worktree path in its argv) is also alive
+#      (false-positive guard).
+#
+# Why this is a separate smoke from worktree-doctor-reap-zombies.sh:
+# this one slices the full `bridge_worktree_doctor` + classifier + reap
+# helper triple and drives the public function, where the companion
+# smoke only sources the leaf reap helper. The two together pin both
+# the helper's behavior AND its wire-up.
+#
+# Footgun #11 self-audit: no <<EOF / <<'PY' heredoc-stdin captured into
+# $(). The git fixture builders use plain git commands; the awk slice
+# writes to a file.
+
+# Bash 4+ re-exec (mirrors scripts/smoke/worktree-doctor.sh shape via
+# status-engine-detect.sh).
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:worktree-doctor-reap-zombies-dry-run] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="worktree-doctor-reap-zombies-dry-run"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+SPAWNED_PIDS=()
+
+cleanup() {
+  local p
+  for p in "${SPAWNED_PIDS[@]:-}"; do
+    [[ -z "$p" ]] && continue
+    kill -KILL "$p" 2>/dev/null || true
+  done
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# Slice `bridge_worktree_doctor` through to just before
+# `bridge_static_agents_for_project_engine`. That range includes
+# `bridge_worktree_doctor`, `_bridge_worktree_doctor_classify_one`, AND
+# `_bridge_worktree_doctor_reap_children` — exactly the trio we want to
+# exercise end-to-end.
+load_doctor_fns() {
+  # shellcheck disable=SC2329  # called from the sourced snippet
+  bridge_die() { printf '[stub:bridge_die] %s\n' "$*" >&2; exit 1; }
+  # shellcheck disable=SC2329  # called from the sourced snippet
+  bridge_warn() { printf '[stub:bridge_warn] %s\n' "$*" >&2; }
+  export -f bridge_die bridge_warn
+
+  local agents_sh="$SMOKE_REPO_ROOT/lib/bridge-agents.sh"
+  smoke_assert_file_exists "$agents_sh" "bridge-agents.sh source"
+
+  local snippet="$SMOKE_TMP_ROOT/doctor.sh"
+  awk '
+    /^bridge_static_agents_for_project_engine\(\)/ { in_doctor=0 }
+    in_doctor { print }
+    /^bridge_worktree_doctor\(\)/ { in_doctor=1; print }
+  ' "$agents_sh" >"$snippet"
+  smoke_assert_file_exists "$snippet" "doctor snippet"
+
+  # shellcheck source=/dev/null
+  source "$snippet"
+  if ! declare -F bridge_worktree_doctor >/dev/null; then
+    smoke_fail "bridge_worktree_doctor not defined after sourcing snippet"
+  fi
+  if ! declare -F _bridge_worktree_doctor_classify_one >/dev/null; then
+    smoke_fail "_bridge_worktree_doctor_classify_one not defined after sourcing snippet"
+  fi
+  if ! declare -F _bridge_worktree_doctor_reap_children >/dev/null; then
+    smoke_fail "_bridge_worktree_doctor_reap_children not defined after sourcing snippet"
+  fi
+}
+
+# Build a repo with one MERGED fixer worktree (will classify REMOVE
+# under dry-run) and no stash entries (no SKIP override). Mirrors the
+# `build_repo_no_stash` pattern in scripts/smoke/worktree-doctor.sh.
+build_repo_merged_only() {
+  local repo="$1"
+  rm -rf "$repo"
+  mkdir -p "$repo/.claude/worktrees"
+  git -C "$repo" init -q -b main
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com commit -q --allow-empty -m "init"
+
+  git -C "$repo" branch fix/merged-with-zombie
+  git -C "$repo" worktree add -q "$repo/.claude/worktrees/agent-zombie-host" fix/merged-with-zombie
+  printf 'm\n' >"$repo/.claude/worktrees/agent-zombie-host/f.txt"
+  git -C "$repo/.claude/worktrees/agent-zombie-host" \
+    -c user.name=smoke -c user.email=smoke@example.com add f.txt
+  git -C "$repo/.claude/worktrees/agent-zombie-host" \
+    -c user.name=smoke -c user.email=smoke@example.com commit -q -m "merged work"
+  git -C "$repo" -c user.name=smoke -c user.email=smoke@example.com \
+    merge -q --no-ff fix/merged-with-zombie -m "merge merged-with-zombie"
+}
+
+case_dry_run_invokes_reap_helper_without_signaling() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+  load_doctor_fns
+
+  local repo="$SMOKE_TMP_ROOT/repo-dry-reap"
+  build_repo_merged_only "$repo"
+
+  local wt_path="$repo/.claude/worktrees/agent-zombie-host"
+  # Resolve to the same path shape the doctor sees from
+  # `git worktree list --porcelain` (no /private prefix dance), so the
+  # anchor in the reap helper matches the spawned child's argv.
+  wt_path="$(cd -P "$wt_path" && pwd -P)"
+
+  # Spawn a direct-exec zombie: symlink sleep into the worktree, run it.
+  # argv[0] is the absolute worktree path — matches the helper anchor.
+  local sleep_bin
+  sleep_bin="$(command -v sleep)" || smoke_fail "sleep binary not found"
+  ln -s "$sleep_bin" "$wt_path/zombie-direct"
+  "$wt_path/zombie-direct" 600 &
+  local zombie_pid=$!
+  SPAWNED_PIDS+=("$zombie_pid")
+
+  # Control sleep with no worktree path in its argv.
+  sleep 600 &
+  local control_pid=$!
+  SPAWNED_PIDS+=("$control_pid")
+
+  # Give the kernel a beat to set up exec.
+  sleep 0.3
+
+  # Sanity: both alive before we drive the doctor.
+  for p in "$zombie_pid" "$control_pid"; do
+    if ! kill -0 "$p" 2>/dev/null; then
+      smoke_fail "test fixture broken: pid $p exited before dry-run ran"
+    fi
+  done
+
+  # Drive the full dry-run path.
+  local dry_out
+  dry_out="$(bridge_worktree_doctor --dry-run --repo "$repo" 2>&1)"
+
+  # Assertion 1: REMOVE classification fired for our fixture worktree.
+  smoke_assert_contains "$dry_out" "REMOVE" "dry-run classifies merged worktree as REMOVE"
+  smoke_assert_contains "$dry_out" "agent-zombie-host" \
+    "dry-run lists the fixture worktree path"
+
+  # Assertion 2: the reap helper was actually invoked from dry-run.
+  # If a future regression puts the call back inside the apply branch,
+  # this 'would reap' line will be absent and the smoke fails.
+  smoke_assert_contains "$dry_out" "would reap" \
+    "dry-run output announces a would-reap line (helper was invoked)"
+  smoke_assert_contains "$dry_out" "$zombie_pid" \
+    "dry-run output names the zombie PID that would be reaped"
+
+  # Assertion 3: false-positive guard. The control sleep PID must NOT
+  # appear in the would-reap line.
+  smoke_assert_not_contains "$dry_out" "$control_pid" \
+    "dry-run does NOT name the control PID"
+
+  # Assertion 4: dry-run must not signal anything. Give it a generous
+  # 2s window to be sure no late SIGTERM is in flight, then confirm
+  # both processes are still alive.
+  sleep 0.5
+  if ! kill -0 "$zombie_pid" 2>/dev/null; then
+    smoke_fail "dry-run wrongly killed zombie pid $zombie_pid (must not signal)"
+  fi
+  if ! kill -0 "$control_pid" 2>/dev/null; then
+    smoke_fail "dry-run wrongly killed control pid $control_pid (must not signal)"
+  fi
+}
+
+smoke_log "starting smoke: $SMOKE_NAME"
+smoke_run "bridge_worktree_doctor --dry-run invokes reaper for REMOVE rows, but never signals" \
+  case_dry_run_invokes_reap_helper_without_signaling
+smoke_log "all $SMOKE_NAME cases passed"

--- a/scripts/smoke/worktree-doctor-reap-zombies.sh
+++ b/scripts/smoke/worktree-doctor-reap-zombies.sh
@@ -1,0 +1,254 @@
+#!/usr/bin/env bash
+# scripts/smoke/worktree-doctor-reap-zombies.sh — Track C of the 2026-05-16
+# operator-audit wave.
+#
+# Guards `_bridge_worktree_doctor_reap_children` in lib/bridge-agents.sh.
+# The doctor function `bridge_worktree_doctor` reaps stale fixer worktrees
+# under .claude/worktrees/<agent-*|ab-*>, but BEFORE this fix it only
+# pruned the directory + the git worktree metadata. Any daemonized child
+# process that had been spawned from inside the worktree and reparented to
+# init(1) was left running forever — Sean observed 7 such
+# bridge-watchdog-silence.py processes on his Mac (2026-05-16), parented
+# to pid 1, alive 8-12 days, with absolute argv pointing at worktree dirs
+# that had been pruned long ago.
+#
+# This smoke exercises two zombie shapes and one false-positive guard:
+#
+#   Case 1 (direct-exec zombie): a `sleep` child renamed via a symlink so
+#   its argv[0] is the absolute worktree path. The reap helper MUST
+#   identify and terminate it.
+#
+#   Case 2 (interpreter-exec zombie): a `bash -c '...'` child whose argv
+#   contains the worktree path as a script-argument token (mirrors the
+#   exact shape of the observed `Python /path/to/worktree/foo.py run`
+#   zombies — argv[0] is the interpreter, argv[1] is a worktree path
+#   token). The reap helper MUST terminate it. This is the load-bearing
+#   case: a naive "command starts with worktree path" anchor would MISS it.
+#
+#   Case 3 (control, false-positive guard): a `sleep` child whose argv
+#   contains NO worktree path. The reap helper MUST leave it alive — the
+#   match anchor must not bleed into unrelated processes.
+#
+# Footgun #11 self-audit: no <<EOF / <<'PY' heredoc-stdin captured into
+# $(). All multi-line data crosses fd boundaries via `mktemp + < file` or
+# direct `>>` append.
+
+# Bash 4+ re-exec (mirrors scripts/smoke/status-engine-detect.sh).
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:worktree-doctor-reap-zombies] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="worktree-doctor-reap-zombies"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# Track spawned helper PIDs so the cleanup trap always wipes them, even
+# on assertion failure. The test itself asserts which ones should be dead
+# vs alive — this is the belt-and-suspenders teardown.
+SPAWNED_PIDS=()
+
+cleanup() {
+  local p
+  for p in "${SPAWNED_PIDS[@]:-}"; do
+    [[ -z "$p" ]] && continue
+    kill -KILL "$p" 2>/dev/null || true
+  done
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# Load `_bridge_worktree_doctor_reap_children` out of bridge-agents.sh
+# without pulling in the upstream module graph. The function and its
+# dependencies (none, beyond `ps`, `kill`, `sleep`, `printf`) are
+# self-contained, mirroring the slice-and-source pattern in
+# scripts/smoke/worktree-doctor.sh.
+load_reap_fn() {
+  local agents_sh="$SMOKE_REPO_ROOT/lib/bridge-agents.sh"
+  smoke_assert_file_exists "$agents_sh" "bridge-agents.sh source"
+
+  local snippet="$SMOKE_TMP_ROOT/reap.sh"
+  awk '
+    /^bridge_static_agents_for_project_engine\(\)/ { in_block=0 }
+    in_block { print }
+    /^_bridge_worktree_doctor_reap_children\(\)/ { in_block=1; print }
+  ' "$agents_sh" >"$snippet"
+  smoke_assert_file_exists "$snippet" "reap snippet"
+
+  # shellcheck source=/dev/null
+  source "$snippet"
+  if ! declare -F _bridge_worktree_doctor_reap_children >/dev/null; then
+    smoke_fail "_bridge_worktree_doctor_reap_children not defined after sourcing snippet"
+  fi
+}
+
+# Wait for a PID to disappear, up to timeout_secs. Returns 0 if dead, 1 if
+# still alive. Polls every 100ms.
+wait_for_pid_death() {
+  local pid="$1"
+  local timeout_secs="${2:-5}"
+  local deadline_iters=$(( timeout_secs * 10 ))
+  local i
+  for (( i = 0; i < deadline_iters; i++ )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+case_reap_direct_exec_and_interpreter_exec_but_not_control() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+  load_reap_fn
+
+  local wt_path="$SMOKE_TMP_ROOT/.claude/worktrees/agent-fakezombie"
+  mkdir -p "$wt_path"
+
+  # --- Case 1 setup: direct-exec zombie. Symlink `sleep` into the
+  # worktree under a deterministic name. When exec'd, argv[0] will be the
+  # symlink's absolute path — which starts with "<wt_path>/" — satisfying
+  # the anchor.
+  local sleep_bin
+  sleep_bin="$(command -v sleep)" || smoke_fail "sleep binary not found on PATH"
+  ln -s "$sleep_bin" "$wt_path/zombie-direct"
+  "$wt_path/zombie-direct" 600 &
+  local direct_pid=$!
+  SPAWNED_PIDS+=("$direct_pid")
+
+  # --- Case 2 setup: interpreter-exec zombie. argv looks like
+  # `bash <wt_path>/zombie-script.sh`. argv[0] is the interpreter (no
+  # worktree prefix), argv[1] is the worktree path — exactly the operator
+  # observation shape (Python + script-path). NOTE: the inner script must
+  # NOT `exec` into another binary — that would replace the interpreter
+  # and clear the script-path token from argv, defeating the test.
+  cat >"$wt_path/zombie-script.sh" <<'INNER'
+#!/usr/bin/env bash
+# Propagate signals to the child sleep so the test fixture doesn't leak
+# orphaned sleeps after SIGTERM lands on the parent bash.
+trap 'kill -TERM "$child_pid" 2>/dev/null; wait "$child_pid" 2>/dev/null; exit 0' TERM INT
+sleep 600 &
+child_pid=$!
+wait "$child_pid"
+INNER
+  chmod +x "$wt_path/zombie-script.sh"
+  bash "$wt_path/zombie-script.sh" &
+  local interp_pid=$!
+  SPAWNED_PIDS+=("$interp_pid")
+
+  # --- Case 3 setup: control sleep, no worktree path in its argv.
+  sleep 600 &
+  local control_pid=$!
+  SPAWNED_PIDS+=("$control_pid")
+
+  # Give the kernel a beat to set up exec for all three.
+  sleep 0.3
+
+  # Sanity: all three are alive before we run the reaper.
+  for p in "$direct_pid" "$interp_pid" "$control_pid"; do
+    if ! kill -0 "$p" 2>/dev/null; then
+      smoke_fail "test fixture broken: pid $p exited before reap ran"
+    fi
+  done
+
+  # --- Dry-run first: must list both zombie PIDs and NOT kill anything.
+  local dry_out
+  dry_out="$(_bridge_worktree_doctor_reap_children "$wt_path" "dry-run" 2>&1)"
+  smoke_assert_contains "$dry_out" "would reap" "dry-run announces reap intent"
+  smoke_assert_contains "$dry_out" "$direct_pid" "dry-run lists direct-exec PID"
+  smoke_assert_contains "$dry_out" "$interp_pid" "dry-run lists interpreter-exec PID"
+  smoke_assert_not_contains "$dry_out" "$control_pid" "dry-run does NOT list control PID"
+
+  # Dry-run must not actually have killed them.
+  if ! kill -0 "$direct_pid" 2>/dev/null; then
+    smoke_fail "dry-run wrongly killed direct-exec PID $direct_pid"
+  fi
+  if ! kill -0 "$interp_pid" 2>/dev/null; then
+    smoke_fail "dry-run wrongly killed interpreter-exec PID $interp_pid"
+  fi
+  if ! kill -0 "$control_pid" 2>/dev/null; then
+    smoke_fail "dry-run wrongly killed control PID $control_pid"
+  fi
+
+  # --- Apply: zombies must die within 5s, control must survive.
+  local apply_out
+  apply_out="$(_bridge_worktree_doctor_reap_children "$wt_path" "apply" 2>&1)"
+  smoke_assert_contains "$apply_out" "sent SIGTERM" "apply announces SIGTERM"
+  smoke_assert_contains "$apply_out" "$direct_pid" "apply targets direct-exec PID"
+  smoke_assert_contains "$apply_out" "$interp_pid" "apply targets interpreter-exec PID"
+  smoke_assert_not_contains "$apply_out" "$control_pid" "apply does NOT target control PID"
+
+  if ! wait_for_pid_death "$direct_pid" 5; then
+    smoke_fail "direct-exec zombie pid $direct_pid still alive after apply + 5s"
+  fi
+  if ! wait_for_pid_death "$interp_pid" 5; then
+    smoke_fail "interpreter-exec zombie pid $interp_pid still alive after apply + 5s"
+  fi
+
+  if ! kill -0 "$control_pid" 2>/dev/null; then
+    smoke_fail "control sleep pid $control_pid was killed (false positive)"
+  fi
+}
+
+# Anchor edge-case: a sibling worktree whose name shares a prefix with the
+# target must NOT be touched. e.g. ".../agent-foo/" reaper must leave
+# ".../agent-foo-bar/" processes alone. This is the "trailing slash on
+# the anchor" assertion — drop the trailing slash from the implementation
+# and this case fails.
+case_anchor_does_not_bleed_into_sibling_prefix() {
+  smoke_setup_bridge_home "$SMOKE_NAME-anchor"
+  load_reap_fn
+
+  local target_wt="$SMOKE_TMP_ROOT/.claude/worktrees/agent-foo"
+  local sibling_wt="$SMOKE_TMP_ROOT/.claude/worktrees/agent-foo-bar"
+  mkdir -p "$target_wt" "$sibling_wt"
+
+  local sleep_bin
+  sleep_bin="$(command -v sleep)"
+  # Zombie under the SIBLING (longer-named) worktree — must NOT be reaped
+  # when we run the reaper on the SHORTER target.
+  ln -s "$sleep_bin" "$sibling_wt/zombie-sibling"
+  "$sibling_wt/zombie-sibling" 600 &
+  local sibling_pid=$!
+  SPAWNED_PIDS+=("$sibling_pid")
+
+  # Real zombie under the target.
+  ln -s "$sleep_bin" "$target_wt/zombie-target"
+  "$target_wt/zombie-target" 600 &
+  local target_pid=$!
+  SPAWNED_PIDS+=("$target_pid")
+
+  sleep 0.3
+
+  local apply_out
+  apply_out="$(_bridge_worktree_doctor_reap_children "$target_wt" "apply" 2>&1)"
+  smoke_assert_contains "$apply_out" "$target_pid" "apply targets the target-worktree PID"
+  smoke_assert_not_contains "$apply_out" "$sibling_pid" \
+    "apply does NOT target sibling worktree PID (prefix-trap guard)"
+
+  if ! wait_for_pid_death "$target_pid" 5; then
+    smoke_fail "target zombie pid $target_pid still alive after apply + 5s"
+  fi
+  if ! kill -0 "$sibling_pid" 2>/dev/null; then
+    smoke_fail "sibling-prefix zombie pid $sibling_pid was killed (anchor leaked across worktree boundary)"
+  fi
+}
+
+smoke_log "starting smoke: $SMOKE_NAME"
+smoke_run "direct + interpreter zombies reaped, control survives" \
+  case_reap_direct_exec_and_interpreter_exec_but_not_control
+smoke_run "anchor does not bleed into sibling-prefix worktree" \
+  case_anchor_does_not_bleed_into_sibling_prefix
+smoke_log "all worktree-doctor-reap-zombies cases passed"


### PR DESCRIPTION
## Summary

`bridge_worktree_doctor` previously reaped stale `.claude/worktrees/<agent-*|ab-*>` directories (and their git worktree registrations) but did not terminate any leftover **daemonized child processes** that had been spawned from inside those worktrees. Those orphaned children got reparented to `init(1)` when the worktree was pruned and continued running indefinitely.

Operator-observed evidence (Mac, 2026-05-16):

```
$ ps -eo pid,ppid,stat,etime,command | grep bridge-watchdog-silence
37709     1 S    10-10:49:07 /.../Python ~/Projects/agent-bridge-public/.claude/worktrees/agent-afe0f02678c3a918a/bridge-watchdog-silence.py run
...  (7 such processes, 8-12 days old)
```

The shape is `interpreter <worktree-path>/<script> <args>` — argv[0] is the Python interpreter, argv[1] is the script that lives in the worktree. A literal "command field starts with worktree path" anchor would miss every one of these.

## Fix

New helper `_bridge_worktree_doctor_reap_children` in `lib/bridge-agents.sh` (~157 LOC). Called from `_bridge_worktree_doctor_classify_one` right before `git worktree remove -f` under `--apply`. In `--dry-run` mode (default), it logs the PIDs that would be killed without acting.

Key design notes (full notes in commit message):
- **Per-token start anchor**: any whitespace-delimited token in `ps -eo pid,command` output that starts with `<worktree-path>/` counts as a match. Catches both direct-exec zombies and interpreter-exec zombies (the operator's actual shape).
- **Trailing `/` is load-bearing**: prevents prefix-bleed into sibling worktrees like `agent-foo` vs `agent-foo-bar`. Smoke explicitly tests this.
- **TERM → 2s grace → KILL** ordering.
- **Self/parent PID skip**: doctor can't kill itself.
- **Cross-platform `ps`**: only `pid` and `command` columns used.

## Test plan

- [x] `scripts/smoke/worktree-doctor-reap-zombies.sh` — new, 2 cases:
  - Case 1: direct + interpreter zombies reaped + control sleep outside worktree survives
  - Case 2: anchor does not bleed into sibling-prefix worktree (`agent-foo` vs `agent-foo-bar`)
- [x] `bash -n` + `shellcheck` on `lib/bridge-agents.sh` and the new smoke (under bash 5+)
- [x] Wired into `scripts/smoke-test.sh` after the classify-stale case
- [x] Existing `worktree-doctor.sh` smoke still passes (4 cases)
- [ ] Codex pair-review

## Why this matters

These zombies hold FDs, memory, and (in some cases) tmux+daemon watchdog state forever. On a long-lived install they accumulate one per cleaned-up worktree. The operator's Mac had 7 such processes alive 8-12 days after the worktrees themselves were already gone from `git worktree list`.

## Non-changes (intentional)

- No VERSION / CHANGELOG bump — per stabilization policy.
- `bridge_worktree_doctor` public signature is unchanged; only an internal helper added + invoked.
- Cross-process kill of arbitrary PIDs is gated on `--apply` exactly like the worktree directory removal — dry-run is read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
