### PR TITLE
fix(footgun-11): pre-capture $() args in bridge_cron heredoc helpers

### DIFF
--- a/lib/bridge-cron.sh
+++ b/lib/bridge-cron.sh
@@ -354,7 +354,12 @@ bridge_cron_write_completion_note() {
   local followup_task_id="${3:-}"
 
   bridge_require_python
-  python3 - "$run_id" "$note_file" "$followup_task_id" "$(bridge_cron_request_file_by_id "$run_id")" "$(bridge_cron_result_file_by_id "$run_id")" "$(bridge_cron_status_file_by_id "$run_id")" <<'PY'
+  # Pre-capture nested $() into locals to avoid footgun #11 (Bash 5.3.9 read_comsub/heredoc_write deadlock under I/O pressure).
+  local request_file result_file status_file
+  request_file="$(bridge_cron_request_file_by_id "$run_id")"
+  result_file="$(bridge_cron_result_file_by_id "$run_id")"
+  status_file="$(bridge_cron_status_file_by_id "$run_id")"
+  python3 - "$run_id" "$note_file" "$followup_task_id" "$request_file" "$result_file" "$status_file" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -429,7 +434,12 @@ bridge_cron_write_followup_body() {
   local body_file="$2"
 
   bridge_require_python
-  python3 - "$run_id" "$body_file" "$(bridge_cron_request_file_by_id "$run_id")" "$(bridge_cron_result_file_by_id "$run_id")" "$(bridge_cron_status_file_by_id "$run_id")" <<'PY'
+  # Pre-capture nested $() into locals to avoid footgun #11 (Bash 5.3.9 read_comsub/heredoc_write deadlock under I/O pressure).
+  local request_file result_file status_file
+  request_file="$(bridge_cron_request_file_by_id "$run_id")"
+  result_file="$(bridge_cron_result_file_by_id "$run_id")"
+  status_file="$(bridge_cron_status_file_by_id "$run_id")"
+  python3 - "$run_id" "$body_file" "$request_file" "$result_file" "$status_file" <<'PY'
 import json
 import sys
 from pathlib import Path


### PR DESCRIPTION
## Summary
Removes the only remaining instances of footgun #11 (Bash 5.3.9 `read_comsub`/`heredoc_write` deadlock) that match the **nested $() inside python3 heredoc** shape across the audited modules.

The pattern was systematically removed from `bridge-upgrade.sh` in v0.13.7-v0.13.9. This PR closes the same shape in two `bridge_cron_*` helpers that resolve cron run-files inline as nested command substitutions.

## Sites fixed (2)
- `lib/bridge-cron.sh:357` — `bridge_cron_write_completion_note`: extracted 3 nested `$(bridge_cron_*_file_by_id …)` into locals before the `python3 - … <<'PY'` invocation.
- `lib/bridge-cron.sh:432` — `bridge_cron_write_followup_body`: same transform, 3 nested resolver calls.

## Sites audited but already safe (2 — no change)
- `bridge-intake.sh:185` — `python3 - "$triage_json" <<'PY'` already uses a pre-captured local (`$triage_json`), no nested `$()`. Same shape on lines 191/212/245.
- `lib/bridge-doctor.sh:893` — `count="$(python3 - "$stdout_log_3" "$fixture_id" <<'PY' 2>/dev/null || echo 0`: args are already pre-captured locals; the `|| echo 0` fallback is preserved.

Per brief pre-flight ("Some sites may already use the safe pattern (positional args only), in which case skip with note"), these two sites are intentionally untouched.

## Fix shape
Pre-capture all `$(...)` substitution args into local variables BEFORE the python3 heredoc invocation, then pass them as positional args. This eliminates the nested-capture subshells that race with bash's heredoc-feed of python3's stdin under I/O pressure. Python `sys.argv` contracts are preserved exactly.

```diff
+  local request_file result_file status_file
+  request_file="$(bridge_cron_request_file_by_id "$run_id")"
+  result_file="$(bridge_cron_result_file_by_id "$run_id")"
+  status_file="$(bridge_cron_status_file_by_id "$run_id")"
-  python3 - "$run_id" "$note_file" "$followup_task_id" "$(bridge_cron_request_file_by_id "$run_id")" "$(bridge_cron_result_file_by_id "$run_id")" "$(bridge_cron_status_file_by_id "$run_id")" <<'PY'
+  python3 - "$run_id" "$note_file" "$followup_task_id" "$request_file" "$result_file" "$status_file" <<'PY'
```

## Verified
- `bash -n lib/bridge-cron.sh bridge-intake.sh lib/bridge-doctor.sh` — passes.
- `shellcheck lib/bridge-cron.sh bridge-intake.sh lib/bridge-doctor.sh` — clean (rc=0).
- `scripts/smoke-test.sh` — pre-existing failure at the spool count assertion (`spool: count after 3 appends: expected 3, got 7`) reproduces on `main` HEAD without these edits. State-leakage in the smoke harness (count grew to 10 on re-run after reverting), unrelated to this PR.
- Self-audit grep — no `result=$(python3 … <<` or nested `$()` args remain in the touched files.
- No VERSION/CHANGELOG bump (stabilization policy).

Refs: `KNOWN_ISSUES.md` §26 footgun #11, v0.13.7-v0.13.10 hotfix wave, audit 2026-05-17.