### PR TITLE
fix(portability): replace BSD/GNU-divergent `mktemp -t` with positional template

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3607,7 +3607,7 @@ PY
   if [[ $orphan_tasks -eq 1 && "$open_count" -gt 0 && -f "$BRIDGE_TASK_DB" ]]; then
     bridge_require_python
     local _orphan_err
-    _orphan_err="$(mktemp -t agb-orphan-err.XXXXXX)"
+    _orphan_err="$(mktemp "${TMPDIR:-/tmp}/agb-orphan-err.XXXXXX")"
     if ! python3 - "$BRIDGE_TASK_DB" "$agent" "agent retired via 'agent delete'" <<'PY' 2>"$_orphan_err"
 import sqlite3
 import sys

--- a/bridge-auth.sh
+++ b/bridge-auth.sh
@@ -357,7 +357,7 @@ bridge_auth_sync_agents() {
   local -a synced=()
   local -a failed=()
 
-  selection_error="$(mktemp -t agb-auth-select.XXXXXX 2>/dev/null || printf '%s' "/tmp/agb-auth-select.$$.$RANDOM")"
+  selection_error="$(mktemp "${TMPDIR:-/tmp}/agb-auth-select.XXXXXX" 2>/dev/null || printf '%s' "/tmp/agb-auth-select.$$.$RANDOM")"
   if ! selection_output="$(bridge_auth_selected_agents "$spec" 2>"$selection_error")"; then
     if [[ "$json_mode" == "1" ]]; then
       python3 - "$selection_error" <<'PY'

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -787,7 +787,7 @@ bridge_emit_daily_backup_failure_admin_task() {
   (( cooldown > 0 )) || cooldown=3600
   resume_at="$(bridge_daily_backup_format_epoch "$(( $(date +%s) + cooldown ))")"
 
-  body_file="$(mktemp -t bridge-daily-backup-fail.XXXXXX.md)"
+  body_file="$(mktemp "${TMPDIR:-/tmp}/bridge-daily-backup-fail.md.XXXXXX")"
   case "$reason" in
     disk_full)
       _bridge_render_disk_full_task_body "$detail" "$resume_at" "$cooldown" >"$body_file"
@@ -1502,7 +1502,7 @@ process_daily_backup() {
   # the subprocess. Capture the rc directly via `set +e` / `set -e` toggle
   # so timeouts (124) and non-zero rc map to real failure reasons.
   local stderr_capture=""
-  stderr_capture="$(mktemp -t bridge-daily-backup.XXXXXX.err)"
+  stderr_capture="$(mktemp "${TMPDIR:-/tmp}/bridge-daily-backup.err.XXXXXX")"
   set +e
   backup_json="$(bridge_with_timeout 120 daily_backup python3 "$SCRIPT_DIR/bridge-upgrade.py" daily-backup-live --target-root "$BRIDGE_HOME" --backup-dir "$BRIDGE_DAILY_BACKUP_DIR" --retain-days "$retain_days" 2>"$stderr_capture")"
   subprocess_rc=$?

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -320,7 +320,7 @@ bridge_upgrade_capture_to_var() {
   local _bucv_var="$1"
   shift
   local _bucv_tmp _bucv_rc=0
-  _bucv_tmp="$(mktemp -t agb-upg-capture.XXXXXX)" || return 1
+  _bucv_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-upg-capture.XXXXXX")" || return 1
   # The `|| _bucv_rc=$?` idiom disarms `set -e` AND captures the real exit
   # status. A bare `if ! "$@"; then ... $? ... fi` would lose the original
   # rc because the `!` resets `$?` inside the then-branch to 0 (the inverted
@@ -569,7 +569,7 @@ bridge_upgrade_reconcile_agent_restart_recovery() {
     # tempfile and stream `< $tempfile` instead of `done <<<"$report"`.
     # The here-string form wedges Bash 5.3.9 in `read_comsub` /
     # `heredoc_write` during a v0.7.x → v0.13.x upgrade --apply leap.
-    _rep_tmp="$(mktemp -t agb-upg-rep.XXXXXX)"
+    _rep_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-upg-rep.XXXXXX")"
     # shellcheck disable=SC2064
     trap "rm -f -- \"$_rep_tmp\"" EXIT
     # Trailing newline matches the original `<<<` semantics so the last
@@ -1415,7 +1415,7 @@ if [[ $DRY_RUN -eq 0 ]]; then
   # capture is kept for symmetry with the failure-handling frame and so
   # `_migrate_rc=$?` captures the bash exit code, not mktemp/rm.
   set +e
-  _iso_v2_migrate_tmp="$(mktemp -t agb-upg-isov2.XXXXXX)"
+  _iso_v2_migrate_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-upg-isov2.XXXXXX")"
   # v0.13.10: BRIDGE_UPGRADE_CONTEXT=1 signals
   # `bridge_isolation_v2_migrate_apply_for_upgrade` that the caller is the
   # upgrader (vs. a direct `agent-bridge migrate isolation v2 --apply` run)
@@ -1910,7 +1910,7 @@ if [[ $DRY_RUN -eq 0 ]]; then
     done
   fi
   if [[ -n "$_post_admin" && -x "$TARGET_ROOT/agent-bridge" ]]; then
-    _post_body="$(mktemp -t bridge-upgrade-post.XXXXXX)"
+    _post_body="$(mktemp "${TMPDIR:-/tmp}/bridge-upgrade-post.XXXXXX")"
     cat >"$_post_body" <<POST_EOF
 # Agent Bridge upgrade completed
 
@@ -2069,7 +2069,7 @@ POST_EOF
     mkdir -p "$_post_body_persist_dir"
     _post_body_persist="$_post_body_persist_dir/upgrade-complete-$(date -u +%Y%m%dT%H%M%SZ).md"
     cp "$_post_body" "$_post_body_persist"
-    _post_task_log="$(mktemp -t bridge-upgrade-post-task.XXXXXX.log)"
+    _post_task_log="$(mktemp "${TMPDIR:-/tmp}/bridge-upgrade-post-task.log.XXXXXX")"
     if bridge_upgrade_with_target_env "$TARGET_ROOT" "$TARGET_ROOT/agent-bridge" task create \
         --to "$_post_admin" --priority normal --from "$_post_admin" \
         --title "[upgrade-complete] Agent Bridge $SOURCE_VERSION — run bootstrap" \

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -307,7 +307,7 @@ USAGE
   # the smoke fixture with 3 fixture worktrees plus merge commits. A
   # temp file decouples the producer from the read loop entirely.
   local porcelain_tmp
-  porcelain_tmp="$(mktemp -t bridge-worktree-doctor.XXXXXX)"
+  porcelain_tmp="$(mktemp "${TMPDIR:-/tmp}/bridge-worktree-doctor.XXXXXX")"
   printf '%s\n' "$porcelain" >"$porcelain_tmp"
 
   local wt_path="" wt_branch="" line

--- a/lib/bridge-cleanup.sh
+++ b/lib/bridge-cleanup.sh
@@ -141,7 +141,7 @@ python3 -c "import json,os; json.load(open(os.path.expanduser('~/.claude.json'))
 # 6. Latest SQL snapshot restore self-test (writes to a temp DB, not live)
 LATEST=\$(ls -1t "\$TARGET_ROOT/state/backup-snapshots"/tasks-*.sql.gz 2>/dev/null | head -1)
 if [[ -n "\$LATEST" ]]; then
-  TMPDB=\$(mktemp -t agb-restore-check.XXXXXX.sqlite)
+  TMPDB=\$(mktemp "\${TMPDIR:-/tmp}/agb-restore-check.sqlite.XXXXXX")
   if gunzip -c "\$LATEST" | sqlite3 "\$TMPDB" >/dev/null 2>&1; then
     echo "snapshot restorable: \$LATEST"
   else

--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -495,7 +495,7 @@ bridge_isolation_v2_reapply_one_agent() {
         # cases). We re-use the writer rather than open-coding the
         # body so future changes to the launch_cmd format propagate.
         local _tmp_env=""
-        _tmp_env="$(mktemp -t agent-env.regen.XXXXXX 2>/dev/null || true)"
+        _tmp_env="$(mktemp "${TMPDIR:-/tmp}/agent-env.regen.XXXXXX" 2>/dev/null || true)"
         if [[ -n "$_tmp_env" ]] \
             && bridge_write_linux_agent_env_file "$agent" "$_tmp_env" 2>/dev/null; then
           if [[ -f "$_env_file" && ! -L "$_env_file" ]] \

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -352,7 +352,7 @@ bridge_isolation_v2_exec_with_secret_env() {
   # only the loader-failure branch creates; the parent then checks the
   # marker independently of the exit code.
   local _fail_marker
-  _fail_marker="$(mktemp -t agb-secret-fail.XXXXXX 2>/dev/null || printf '%s' "/tmp/agb-secret-fail.$$.$RANDOM")"
+  _fail_marker="$(mktemp "${TMPDIR:-/tmp}/agb-secret-fail.XXXXXX" 2>/dev/null || printf '%s' "/tmp/agb-secret-fail.$$.$RANDOM")"
   rm -f "$_fail_marker"
   local _rc=0
   if (

--- a/lib/bridge-isolation-v3-channel-dotenv.sh
+++ b/lib/bridge-isolation-v3-channel-dotenv.sh
@@ -486,9 +486,9 @@ bridge_isolation_v3_channel_dotenv_cli() {
   fi
 
   local actions_file errors_file
-  actions_file="$(mktemp -t agb-isolation-v3-actions.XXXXXX)" \
+  actions_file="$(mktemp "${TMPDIR:-/tmp}/agb-isolation-v3-actions.XXXXXX")" \
     || bridge_die "migrate isolation v3: cannot create temp actions file"
-  errors_file="$(mktemp -t agb-isolation-v3-errors.XXXXXX)" \
+  errors_file="$(mktemp "${TMPDIR:-/tmp}/agb-isolation-v3-errors.XXXXXX")" \
     || bridge_die "migrate isolation v3: cannot create temp errors file"
   # shellcheck disable=SC2064
   trap "rm -f '$actions_file' '$errors_file'" RETURN

--- a/lib/bridge-wave.sh
+++ b/lib/bridge-wave.sh
@@ -269,7 +269,7 @@ _bridge_wave_dispatch_member() {
   fi
 
   local spawn_log
-  spawn_log="$(mktemp -t "wave-spawn-${member_id}.XXXXXX")"
+  spawn_log="$(mktemp "${TMPDIR:-/tmp}/wave-spawn-${member_id}.XXXXXX")"
 
   local ab_bin="$BRIDGE_SCRIPT_DIR/agent-bridge"
   if [[ ! -x "$ab_bin" ]]; then

--- a/scripts/bulk-register-precompact.sh
+++ b/scripts/bulk-register-precompact.sh
@@ -260,7 +260,7 @@ main() {
         : > "$LOG_FILE"
     else
         # Dry-run: route log to a tmp path so the real state dir stays clean.
-        LOG_FILE="$(mktemp -t precompact-dryrun.XXXXXX).jsonl"
+        LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/precompact-dryrun.XXXXXX").jsonl"
     fi
 
     local targets

--- a/scripts/e2e-bootstrap-verify.sh
+++ b/scripts/e2e-bootstrap-verify.sh
@@ -108,7 +108,7 @@ required_crons=(
   wiki-dedup-weekly
 )
 
-cron_list_json="$(mktemp -t e2e-crons.XXXXXX.json)"
+cron_list_json="$(mktemp "${TMPDIR:-/tmp}/e2e-crons.json.XXXXXX")"
 trap 'rm -f "$cron_list_json"' EXIT
 "$BRIDGE_AGB" cron list --agent patch --json >"$cron_list_json" 2>/dev/null || echo '[]' > "$cron_list_json"
 

--- a/scripts/smoke/bridge-export-prefix-no-stale-layout.sh
+++ b/scripts/smoke/bridge-export-prefix-no-stale-layout.sh
@@ -51,7 +51,7 @@ echo "[smoke:${SMOKE_NAME}] starting"
 # itself is not polluted by sourcing bridge-core. We use a here-doc
 # bash invocation (NOT heredoc-stdin to a captured subprocess, so the
 # footgun #11 chain is avoided) and write the result to a tmpfile.
-TMP_OUT="$(mktemp -t agb-prefix.XXXXXX)"
+TMP_OUT="$(mktemp "${TMPDIR:-/tmp}/agb-prefix.XXXXXX")"
 trap 'rm -f "$TMP_OUT"' EXIT
 
 PREFIX_DRIVER="$SCRIPT_DIR/bridge-export-prefix-no-stale-layout-driver.sh"

--- a/scripts/wiki-copy-full-backfill.sh
+++ b/scripts/wiki-copy-full-backfill.sh
@@ -27,7 +27,7 @@ log_audit "$JOB" "starting $JOB" >/dev/null
 
 trap 'file_failure_task "$JOB" "$LOG"' ERR
 
-SUMMARY_JSON="$(mktemp -t wiki-copy-full-backfill.XXXXXX.json)"
+SUMMARY_JSON="$(mktemp "${TMPDIR:-/tmp}/wiki-copy-full-backfill.json.XXXXXX")"
 # shellcheck disable=SC2064
 trap "rm -f '$SUMMARY_JSON'; file_failure_task '$JOB' '$LOG'" ERR
 

--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -97,7 +97,7 @@ write_watermark_atomic() {
 # Lane A — daily-note byte-replica copy (no librarian involvement)
 # -------------------------------------------------------------------------
 
-COPY_JSON="$(mktemp -t wiki-daily-copy.XXXXXX.json)"
+COPY_JSON="$(mktemp "${TMPDIR:-/tmp}/wiki-daily-copy.json.XXXXXX")"
 # shellcheck disable=SC2064
 trap "rm -f '$COPY_JSON'" EXIT
 
@@ -200,7 +200,7 @@ if [[ "${BRIDGE_LAYOUT:-legacy}" == "v2" \
     exit 2
   fi
 
-  _lane_b_stderr="$(mktemp -t wiki-daily-ingest.agb-stderr.XXXXXX)"
+  _lane_b_stderr="$(mktemp "${TMPDIR:-/tmp}/wiki-daily-ingest.agb-stderr.XXXXXX")"
 
   agent_list_json="$("$BRIDGE_AGB" agent list --json 2>"$_lane_b_stderr")"
   agb_exit=$?

--- a/scripts/wiki-mention-scan.sh
+++ b/scripts/wiki-mention-scan.sh
@@ -22,7 +22,7 @@ log_audit "$JOB" "starting $JOB" >/dev/null
 
 trap 'file_failure_task "$JOB" "$LOG"' ERR
 
-SCAN_JSON="$(mktemp -t wiki-mention-scan.XXXXXX.json)"
+SCAN_JSON="$(mktemp "${TMPDIR:-/tmp}/wiki-mention-scan.json.XXXXXX")"
 # shellcheck disable=SC2064
 trap "rm -f '$SCAN_JSON'; file_failure_task '$JOB' '$LOG'" ERR
 

--- a/scripts/wiki-repair-links.sh
+++ b/scripts/wiki-repair-links.sh
@@ -17,7 +17,7 @@ log_audit "$JOB" "starting $JOB" >/dev/null
 
 trap 'file_failure_task "$JOB" "$LOG"' ERR
 
-REPORT_JSON="$(mktemp -t wiki-repair-links.XXXXXX.json)"
+REPORT_JSON="$(mktemp "${TMPDIR:-/tmp}/wiki-repair-links.json.XXXXXX")"
 # shellcheck disable=SC2064
 trap "rm -f '$REPORT_JSON'; file_failure_task '$JOB' '$LOG'" ERR
 


### PR DESCRIPTION
## Summary
Replaces `mktemp -t TEMPLATE` invocations with the portable positional form `mktemp ${TMPDIR:-/tmp}/TEMPLATE.XXXXXX`. The `-t` flag has divergent semantics across BSD (macOS) and GNU (Linux), causing silent failures or unexpected paths on Linux installs (OrbStack VM, OSS users like #895 ymprince WSL2).

## Why
- BSD (macOS) `mktemp -t TEMPLATE`: treats argument as filename prefix in `$TMPDIR`
- GNU (Linux) `mktemp -t`: deprecated; treats argument as a directory or errors
- Positional form `mktemp /path/template.XXXXXX` works identically on both and honors `$TMPDIR`

## Sites fixed
All non-test production-code sites caught by pre-flight grep (`mktemp -t` in `lib/ bridge-*.sh scripts/`):

- `lib/bridge-agents.sh:310` — `bridge_agents_worktree_doctor`
- `lib/bridge-isolation-v3-channel-dotenv.sh:489,491` — migrate v3 helper
- `lib/bridge-cleanup.sh:144` — docstring example
- `lib/bridge-isolation-v2-reapply.sh:498`
- `lib/bridge-isolation-v2.sh:355`
- `lib/bridge-wave.sh:272`
- `bridge-auth.sh:360`
- `bridge-agent.sh:3610`
- `bridge-daemon.sh:790,1505`
- `bridge-upgrade.sh:323,572,1418,1913,2072`
- `scripts/wiki-daily-ingest.sh:100,203`
- `scripts/bulk-register-precompact.sh:263`
- `scripts/wiki-copy-full-backfill.sh:30`
- `scripts/wiki-mention-scan.sh:25`
- `scripts/e2e-bootstrap-verify.sh:111`
- `scripts/wiki-repair-links.sh:20`
- `scripts/smoke/bridge-export-prefix-no-stale-layout.sh:54`

Test fixture in `tests/isolation-v2-pr-c/smoke.sh:507` left untouched per brief scope (`Do NOT touch test fixtures unless they trigger CI failure on Linux`).

## Verified
- `bash -n` (Bash 5.3.9 / Homebrew): PASS on all 17 edited files
- `shellcheck 0.11.0`: clean on all 17 files
- `./scripts/smoke-test.sh`: PASS except pre-existing `spool: count after 3 appends` failure (reproduces on clean HEAD `ff6d219` without these edits — leaked tmp state, not regression)
- Self-audit grep `\bmktemp -t\b` in `lib/ bridge-*.sh scripts/`: clean

Refs: audit 2026-05-17, macOS/Linux portability, #895 territory