### PR TITLE
fix(cron): add subprocess timeout guards to bridge-cron.py

### DIFF
--- a/bridge-cron.py
+++ b/bridge-cron.py
@@ -810,9 +810,17 @@ def _iter_processes_psutil():
 def _iter_processes_ps():
     try:
         out = subprocess.check_output(
-            ["ps", "-eo", "pid=,args="], text=True, stderr=subprocess.DEVNULL
+            ["ps", "-eo", "pid=,args="],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError, OSError):
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        OSError,
+    ):
         return []
     items = []
     for raw_line in out.splitlines():


### PR DESCRIPTION
## Summary
Adds `timeout=` kwarg to the unguarded `subprocess.check_output` call in `bridge-cron.py`. MED-severity defensive fix to prevent indefinite hangs if /proc is over NFS or `ps` wedges.

## Sites fixed
- `bridge-cron.py:812` (`_iter_processes_ps`) — `timeout=5`, plus `subprocess.TimeoutExpired` added to the except tuple so the helper still returns `[]` on timeout.

## Brief audit clarification
The brief named a second site at `bridge-cron.py:910` (`subprocess.run`) as also unguarded. AST audit shows it already carries `timeout=15` on its continuation line; the brief's pre-flight regex grep was a false positive (the `timeout=` keyword sits on a separate physical line from the `subprocess.run(` call). No edit needed there. Confirmed via an AST walk for `subprocess.<method>(...)` Call nodes lacking a `timeout` kwarg — only line 812 qualified.

## Verified
- `python3 -c "import ast; ast.parse(open('bridge-cron.py').read())"` — PASS
- `python3 -m py_compile bridge-cron.py` — PASS
- AST self-audit for unguarded `subprocess.{run,check_output,check_call,Popen,call}` — clean
- `scripts/smoke-test.sh` — PASS except pre-existing `[smoke][error] spool: count after 3 appends: expected 3, got N` (reproduces on `main` HEAD ff6d219 without any edits; unrelated to cron)

Refs: audit 2026-05-17 (cron subprocess hardening)