### PR TITLE
feat(queue): auto-notify requester on claimed→blocked transition (refs #697)

### DIFF
--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -222,6 +222,87 @@ notify_task_requester() {
   bridge_dispatch_notification "$creator" "$TASK_TITLE" "$notice_message" "$TASK_ID" "$TASK_PRIORITY" || true
 }
 
+# notify_task_blocker
+#
+# Issue #697 — mirror of notify_task_requester for the claimed→blocked
+# transition. Inserts a `[task-blocked] task #<id>: <title>` task addressed
+# to the original requester so a dispatcher-style agent (e.g. `patch`) sees
+# the block in its inbox instead of having to poll the worker's tmux pane.
+#
+# Idempotency: the title format `[task-blocked] task #<id>:` is unique per
+# original task; we query find-open with that prefix and bail if a
+# notification already exists, so re-blocking the same task (or repeated
+# blocked refresh updates) does not duplicate.
+notify_task_blocker() {
+  local task_id="$1"
+  local actor="$2"
+  local note="$3"
+  local note_file="$4"
+  local TASK_ID=""
+  local TASK_TITLE=""
+  local TASK_CREATED_BY=""
+  local TASK_PRIORITY=""
+  local creator
+  local creator_engine=""
+  local blocked_title=""
+  local blocked_body=""
+  local notice_message=""
+  local existing_id=""
+  local ORIG_TASK_ID=""
+  local ORIG_TASK_TITLE=""
+  local ORIG_TASK_PRIORITY=""
+
+  ensure_roster_loaded
+  bridge_queue_source_shell show "$task_id" --format shell
+
+  creator="$TASK_CREATED_BY"
+  [[ -n "$creator" ]] || return 0
+  [[ "$creator" != "$actor" ]] || return 0
+  bridge_agent_exists "$creator" || return 0
+  # Never auto-notify on a notification task — guards against loops if a
+  # requester ever ends up claiming + blocking the [task-blocked] task we
+  # just inserted for them.
+  [[ "$TASK_TITLE" == \[task-blocked\]* ]] && return 0
+  [[ "$TASK_TITLE" == \[task-complete\]* ]] && return 0
+  creator_engine="$(bridge_agent_engine "$creator")"
+
+  ORIG_TASK_ID="$TASK_ID"
+  ORIG_TASK_TITLE="$TASK_TITLE"
+  ORIG_TASK_PRIORITY="$TASK_PRIORITY"
+
+  blocked_title="[task-blocked] task #${ORIG_TASK_ID}: ${ORIG_TASK_TITLE}"
+
+  # Idempotency check — re-blocking the same task (or any subsequent
+  # blocked refresh) must not create a duplicate notification. Use the
+  # title prefix `[task-blocked] task #<id>:` which is unique per
+  # original task.
+  existing_id="$(bridge_queue_cli find-open --agent "$creator" --title-prefix "[task-blocked] task #${ORIG_TASK_ID}:" --format id 2>/dev/null || true)"
+  if [[ -n "$existing_id" ]]; then
+    return 0
+  fi
+
+  blocked_body="blocked_by: ${actor}"
+  blocked_body+=$'\n'"original_task: #${ORIG_TASK_ID}"
+  blocked_body+=$'\n'"inspect: agb show ${ORIG_TASK_ID}"
+  if [[ -n "$note" ]]; then
+    blocked_body+=$'\n\n'"block_reason:"$'\n'"${note}"
+  elif [[ -n "$note_file" ]]; then
+    blocked_body+=$'\n'"block_reason_file: ${note_file}"
+  fi
+
+  TASK_ID=""
+  TASK_TITLE=""
+  TASK_PRIORITY=""
+  bridge_queue_source_shell create --to "$creator" --title "$blocked_title" --from bridge --priority "$ORIG_TASK_PRIORITY" --body "$blocked_body" --format shell
+
+  if [[ "$creator_engine" != "claude" ]] && ! bridge_agent_is_active "$creator"; then
+    return 0
+  fi
+
+  notice_message="agb inbox ${creator}"
+  bridge_dispatch_notification "$creator" "$TASK_TITLE" "$notice_message" "$TASK_ID" "$TASK_PRIORITY" || true
+}
+
 cmd_create() {
   local target=""
   local title=""
@@ -542,6 +623,12 @@ cmd_done() {
 cmd_update() {
   local task_id=""
   local actor=""
+  local new_status=""
+  local note_arg=""
+  local note_file_arg=""
+  local prior_status=""
+  local TASK_STATUS=""
+  local i
 
   task_id="${1:-}"
   shift || true
@@ -549,7 +636,57 @@ cmd_update() {
 
   actor="$(infer_actor_if_possible "")"
 
+  # Issue #697 — peek at --status / --note / --note-file / --actor so we
+  # can auto-notify the requester on a claimed→blocked transition. We do
+  # not consume the args; the queue CLI still receives them unchanged
+  # (argparse uses the last --actor when both are present, matching this
+  # peek).
+  local -a update_args=("$@")
+  local total="${#update_args[@]}"
+  i=0
+  while (( i < total )); do
+    case "${update_args[$i]}" in
+      --status)
+        (( i + 1 < total )) && new_status="${update_args[$((i + 1))]}"
+        ;;
+      --status=*)
+        new_status="${update_args[$i]#--status=}"
+        ;;
+      --note)
+        (( i + 1 < total )) && note_arg="${update_args[$((i + 1))]}"
+        ;;
+      --note=*)
+        note_arg="${update_args[$i]#--note=}"
+        ;;
+      --note-file)
+        (( i + 1 < total )) && note_file_arg="${update_args[$((i + 1))]}"
+        ;;
+      --note-file=*)
+        note_file_arg="${update_args[$i]#--note-file=}"
+        ;;
+      --actor)
+        (( i + 1 < total )) && actor="${update_args[$((i + 1))]}"
+        ;;
+      --actor=*)
+        actor="${update_args[$i]#--actor=}"
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  # Snapshot prior status only when a blocked-notify is plausible, so the
+  # extra `show` round-trip is paid only on the relevant code path.
+  if [[ "$new_status" == "blocked" ]] && { [[ -n "$note_arg" ]] || [[ -n "$note_file_arg" ]]; }; then
+    if bridge_queue_source_shell show "$task_id" --format shell 2>/dev/null; then
+      prior_status="$TASK_STATUS"
+    fi
+  fi
+
   bridge_queue_cli update "$task_id" --actor "$actor" "$@"
+
+  if [[ "$new_status" == "blocked" ]] && [[ "$prior_status" == "claimed" ]] && { [[ -n "$note_arg" ]] || [[ -n "$note_file_arg" ]]; }; then
+    notify_task_blocker "$task_id" "$actor" "$note_arg" "$note_file_arg"
+  fi
 }
 
 cmd_cancel() {

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -3302,6 +3302,68 @@ assert_contains "$REQUESTER_SHOW_OUTPUT" "assigned_to: $REQUESTER_AGENT"
 assert_contains "$REQUESTER_SHOW_OUTPUT" "original_task: #$NOTICE_TASK_ID"
 assert_contains "$REQUESTER_SHOW_OUTPUT" "completed_by: $SMOKE_AGENT"
 
+# Issue #697 — claimed→blocked transition with a non-empty note must
+# auto-notify the requester with a `[task-blocked]` task, and a second
+# blocked update on the same task must not create a duplicate.
+log "auto-notifying requester on claimed→blocked transition (#697)"
+BLOCKED_NOTIFY_CREATE_OUTPUT="$(bash "$REPO_ROOT/bridge-task.sh" create --to "$SMOKE_AGENT" --title "smoke blocked-notify" --body "needs human input" --from "$REQUESTER_AGENT")"
+assert_contains "$BLOCKED_NOTIFY_CREATE_OUTPUT" "created task #"
+BLOCKED_NOTIFY_TASK_ID="$(printf '%s\n' "$BLOCKED_NOTIFY_CREATE_OUTPUT" | sed -n 's/^created task #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+[[ "$BLOCKED_NOTIFY_TASK_ID" =~ ^[0-9]+$ ]] || die "could not parse blocked-notify task id"
+bash "$REPO_ROOT/bridge-task.sh" claim "$BLOCKED_NOTIFY_TASK_ID" --agent "$SMOKE_AGENT" >/dev/null
+bash "$REPO_ROOT/bridge-task.sh" update "$BLOCKED_NOTIFY_TASK_ID" --actor "$SMOKE_AGENT" --status blocked --note "operator decision needed: scope A or B" >/dev/null
+REQUESTER_BLOCKED_INBOX="$(bash "$REPO_ROOT/bridge-task.sh" inbox "$REQUESTER_AGENT")"
+assert_contains "$REQUESTER_BLOCKED_INBOX" "[task-blocked] task #${BLOCKED_NOTIFY_TASK_ID}: smoke blocked-notify"
+BLOCKED_NOTIFY_NOTICE_ID="$(python3 "$REPO_ROOT/bridge-queue.py" find-open --agent "$REQUESTER_AGENT" --title-prefix "[task-blocked] task #${BLOCKED_NOTIFY_TASK_ID}:")"
+[[ "$BLOCKED_NOTIFY_NOTICE_ID" =~ ^[0-9]+$ ]] || die "blocked-notify notice id was not numeric: $BLOCKED_NOTIFY_NOTICE_ID"
+BLOCKED_NOTIFY_SHOW="$(bash "$REPO_ROOT/bridge-task.sh" show "$BLOCKED_NOTIFY_NOTICE_ID")"
+assert_contains "$BLOCKED_NOTIFY_SHOW" "assigned_to: $REQUESTER_AGENT"
+assert_contains "$BLOCKED_NOTIFY_SHOW" "original_task: #${BLOCKED_NOTIFY_TASK_ID}"
+assert_contains "$BLOCKED_NOTIFY_SHOW" "blocked_by: $SMOKE_AGENT"
+assert_contains "$BLOCKED_NOTIFY_SHOW" "operator decision needed: scope A or B"
+
+# Idempotency — re-blocking the same task must not duplicate the notice.
+bash "$REPO_ROOT/bridge-task.sh" update "$BLOCKED_NOTIFY_TASK_ID" --actor "$SMOKE_AGENT" --status blocked --note "still waiting" >/dev/null
+BLOCKED_NOTIFY_COUNT="$(BRIDGE_TASK_DB="$BRIDGE_TASK_DB" REQUESTER_AGENT="$REQUESTER_AGENT" BLOCKED_NOTIFY_TASK_ID="$BLOCKED_NOTIFY_TASK_ID" python3 - <<'PY'
+import os
+import sqlite3
+
+db = os.environ["BRIDGE_TASK_DB"]
+agent = os.environ["REQUESTER_AGENT"]
+prefix = f"[task-blocked] task #{os.environ['BLOCKED_NOTIFY_TASK_ID']}:"
+with sqlite3.connect(db) as conn:
+    row = conn.execute(
+        "SELECT COUNT(*) FROM tasks WHERE assigned_to = ? AND title LIKE ?",
+        (agent, prefix + "%"),
+    ).fetchone()
+print(int(row[0]))
+PY
+)"
+[[ "$BLOCKED_NOTIFY_COUNT" == "1" ]] || die "expected exactly one [task-blocked] notice, got $BLOCKED_NOTIFY_COUNT"
+
+# Negative — a blocked update WITHOUT a note must not create a notice.
+BLOCKED_NONOTE_CREATE_OUTPUT="$(bash "$REPO_ROOT/bridge-task.sh" create --to "$SMOKE_AGENT" --title "smoke blocked-no-note" --body "x" --from "$REQUESTER_AGENT")"
+BLOCKED_NONOTE_TASK_ID="$(printf '%s\n' "$BLOCKED_NONOTE_CREATE_OUTPUT" | sed -n 's/^created task #\([0-9][0-9]*\).*/\1/p' | head -n1)"
+[[ "$BLOCKED_NONOTE_TASK_ID" =~ ^[0-9]+$ ]] || die "could not parse blocked-no-note task id"
+bash "$REPO_ROOT/bridge-task.sh" claim "$BLOCKED_NONOTE_TASK_ID" --agent "$SMOKE_AGENT" >/dev/null
+bash "$REPO_ROOT/bridge-task.sh" update "$BLOCKED_NONOTE_TASK_ID" --actor "$SMOKE_AGENT" --status blocked >/dev/null
+BLOCKED_NONOTE_COUNT="$(BRIDGE_TASK_DB="$BRIDGE_TASK_DB" REQUESTER_AGENT="$REQUESTER_AGENT" BLOCKED_NONOTE_TASK_ID="$BLOCKED_NONOTE_TASK_ID" python3 - <<'PY'
+import os
+import sqlite3
+
+db = os.environ["BRIDGE_TASK_DB"]
+agent = os.environ["REQUESTER_AGENT"]
+prefix = f"[task-blocked] task #{os.environ['BLOCKED_NONOTE_TASK_ID']}:"
+with sqlite3.connect(db) as conn:
+    row = conn.execute(
+        "SELECT COUNT(*) FROM tasks WHERE assigned_to = ? AND title LIKE ?",
+        (agent, prefix + "%"),
+    ).fetchone()
+print(int(row[0]))
+PY
+)"
+[[ "$BLOCKED_NONOTE_COUNT" == "0" ]] || die "expected no [task-blocked] notice when no note, got $BLOCKED_NONOTE_COUNT"
+
 log "cancelling an orphan task without a roster entry"
 ORPHAN_TASK_ID=""
 ORPHAN_CREATE_OUTPUT="$(BRIDGE_TASK_DB="$BRIDGE_TASK_DB" python3 "$REPO_ROOT/bridge-queue.py" create --to tester --title "orphan cleanup" --from smoke --priority high --body "cleanup me" --format shell)"


### PR DESCRIPTION
## Summary
When a downstream agent transitions a task from `claimed` to `blocked` with a non-empty note, `agb update` now auto-creates a `[task-blocked] task #<id>: <title>` notification task addressed to the original requester. Mirrors the existing `[task-complete]` pattern.

## Why
Issue #697: currently only `done` triggers an auto-notification; `blocked` is invisible upstream. Dynamic worker agents (loop=0) that block mid-plan become silent stalls — the dispatcher has no signal to relay to the operator and has to either poll `agb show <id>` or peek into the worker's tmux pane.

## Behavior
- On `agb update <id> --status blocked --note "..."`:
  - If the task is transitioning from `claimed` → `blocked` (not blocked → blocked refresh, not queued → blocked direct),
  - And a non-empty note (or `--note-file`) is provided,
  - Then insert a new task to the original requester:
    - Title: `[task-blocked] task #<id>: <original-title>`
    - Body: `blocked_by: <actor>` / `original_task: #<id>` / `inspect: agb show <id>` / `block_reason: <note>`
    - Priority: inherited from the original task
    - Source: `bridge` (matches the `[task-complete]` flow)
  - Idempotent: the `[task-blocked] task #<id>:` title prefix is unique per original task; a `find-open --title-prefix` check skips emission if a notification already exists. Re-blocks and refresh-blocked updates do not duplicate.
- Guards: self-blocks (`actor == creator`) are silent; missing creators in the roster are silent; updating a task whose title already starts with `[task-blocked]` or `[task-complete]` is silent (loop guard).
- Dispatch: when the creator's engine is `claude` or the creator session is active, `bridge_dispatch_notification` fires after the insert so the dispatcher pane gets the same wake nudge it gets for `[task-complete]`.

## Files changed
- `bridge-task.sh` — new `notify_task_blocker` helper (mirror of `notify_task_requester`) + extended `cmd_update` that pre-parses `--status` / `--note` / `--note-file` / `--actor` to detect the transition (without consuming the args; the queue CLI still receives them unchanged)
- `scripts/smoke-test.sh` — three new assertions: (a) claim→block with note creates exactly one `[task-blocked]` notice, (b) re-blocking does not duplicate, (c) blocked without a note does not create a notice

## Verified
- `python3 -c "import ast; ast.parse(open('bridge-queue.py').read())"` — PASS
- `bash -n bridge-task.sh scripts/smoke-test.sh` — PASS
- `shellcheck bridge-task.sh scripts/smoke-test.sh` — PASS (0 warnings)
- `./scripts/smoke-test.sh` — stops at the pre-existing `[smoke] tmux pending-attention spool` failure (`count after 3 appends: expected 3, got 37`) that reproduces on a clean checkout of `ff6d219` (verified via `git stash`); new test sits after `[task-complete] smoke queue notice` and is not yet reached on this host
- Manual repro in isolated `BRIDGE_HOME=$(mktemp -d)/bridge` against the patched bash entry point exercised the full case matrix (claim→block + note, re-block idempotency, no-note, queued→blocked without prior claim, self-block, empty-string note, priority inheritance) — all behaved as specified

Refs: #697