### PR TITLE
fix(agent): extract registry/list/show JSON to standalone helpers to dodge read_comsub deadlock (refs #4773)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1391,44 +1391,30 @@ run_list() {
     emit_agent_records_json list "$output"
     return 0
   fi
-  bridge_agent_manage_python "$(emit_agent_records_json list "$output")" <<'PY'
-import json
-import sys
-
-items = json.loads(sys.argv[1])
-print("agent | eng | src | active | state | iso | q/c/b | wake | notify | chan | session | workdir")
-for item in items:
-    suffix = " [admin]" if item.get("admin") else ""
-    isolation = item.get("isolation", {}) or {}
-    mode = isolation.get("mode") or "shared"
-    os_user = isolation.get("os_user") or ""
-    iso_text = f"{mode}:{os_user}" if os_user else mode
-    # v0.8.0 T5: when the runtime hatch is on, override the iso column
-    # so a glance at `agent-bridge agent list` makes it obvious the
-    # boundary is off across the whole controller. The configured
-    # isolation_mode stays available in the JSON form and in `agent
-    # show` for operators who want both fields.
-    runtime_state = isolation.get("runtime_state") or ""
-    if runtime_state == "disabled-by-env":
-        iso_text = "disabled-by-env"
-    queue = item.get("queue", {}) or {}
-    notify = item.get("notify", {}) or {}
-    channels = item.get("channels", {}) or {}
-    print(
-        f"{item.get('agent','')}{suffix} | "
-        f"{item.get('engine','')} | "
-        f"{item.get('source','')} | "
-        f"{'yes' if item.get('active') else 'no'} | "
-        f"{item.get('activity_state','')} | "
-        f"{iso_text} | "
-        f"{queue.get('queued',0)}/{queue.get('claimed',0)}/{queue.get('blocked',0)} | "
-        f"{item.get('wake_status','')} | "
-        f"{notify.get('status','')} | "
-        f"{channels.get('status','')} | "
-        f"{item.get('session','')} | "
-        f"{item.get('workdir','')}"
-    )
-PY
+  # Bash 5.3.9 deadlock (footgun #11, KNOWN_ISSUES.md §26 — refs queue
+  # task #4773): the original form
+  # `bridge_agent_manage_python "$(emit_agent_records_json list "$output")" <<'PY'`
+  # nested two heredoc-stdin python3 subprocesses (emit_agent_records_json
+  # itself is a `python3 - "$tsv" <<'PY'` consumer), and the
+  # function-wrapper + heredoc-stdin combination wedged `read_comsub` on
+  # operator hosts (7-17 hour hangs on `agent list`). Spool the JSON to a
+  # tempfile and dispatch to a standalone helper script — no
+  # heredoc-stdin anywhere on the call path. Same precedent as
+  # lib/upgrade-helpers/agent-restart-json.py.
+  bridge_require_python
+  local _list_dir _list_rc
+  _list_dir="$(mktemp -d "${TMPDIR:-/tmp}/bridge-agent-list-json.XXXXXX")"
+  emit_agent_records_json list "$output" >"$_list_dir/records.json"
+  # codex PR #940 r2 BLOCKING: RETURN trap does NOT fire on `set -e`
+  # errexit abort (Bash 5.3.9 forced-failure probe confirmed). Use the
+  # explicit set +e / capture-rc / set -e pattern so cleanup ALWAYS runs
+  # regardless of helper rc, and propagate the helper's exit status.
+  set +e
+  python3 "$SCRIPT_DIR/lib/agent-cli-helpers/list-format-text.py" "$_list_dir/records.json"
+  _list_rc=$?
+  set -e
+  rm -rf "$_list_dir"
+  return "$_list_rc"
 }
 
 # run_registry — issue #598 Track 1. Read-only enumeration of every
@@ -1520,36 +1506,28 @@ run_registry() {
     done
   fi
 
-  bridge_agent_manage_python "$rows" <<'PY'
-import json
-import sys
-
-raw = sys.argv[1] if len(sys.argv) > 1 else ""
-records = []
-for line in raw.splitlines():
-    if not line.strip():
-        continue
-    parts = line.split("\t")
-    if len(parts) < 10:
-        continue
-    (id_, cls, agent_source, privilege_class, home, workdir,
-     engine, session, is_alive, source) = parts[:10]
-    records.append({
-        "id": id_,
-        "class": cls,
-        "agent_source": agent_source,
-        "privilege_class": privilege_class,
-        "home": home,
-        "workdir": workdir,
-        "engine": engine,
-        "session": session,
-        "is_alive": is_alive == "1",
-        "source": source,
-    })
-
-records.sort(key=lambda r: r["id"])
-print(json.dumps(records, ensure_ascii=False, indent=2))
-PY
+  # Bash 5.3.9 deadlock (footgun #11 — refs queue task #4773): the
+  # original form `bridge_agent_manage_python "$rows" <<'PY'` wedged
+  # `read_comsub` on the operator host even though no `$()` capture
+  # surrounded the call. The function-wrapper indirection through
+  # `bridge_agent_manage_python` (which expands to `python3 - "$@"`)
+  # combined with heredoc-stdin reliably hung 7-17 hours during
+  # `bridge-agent.sh registry` on bash 5.3.9. Spool rows to a tempfile
+  # and dispatch to a standalone helper — same precedent as
+  # lib/upgrade-helpers/agent-restart-json.py.
+  bridge_require_python
+  local _registry_dir _registry_rc
+  _registry_dir="$(mktemp -d "${TMPDIR:-/tmp}/bridge-agent-registry.XXXXXX")"
+  printf '%s' "$rows" >"$_registry_dir/rows.tsv"
+  # codex PR #940 r2 BLOCKING: see run_list above for the RETURN-trap-
+  # bypass rationale. Same explicit set +e / capture-rc / set -e pattern
+  # ensures the tempdir is removed regardless of helper rc.
+  set +e
+  python3 "$SCRIPT_DIR/lib/agent-cli-helpers/registry-format-json.py" "$_registry_dir/rows.tsv"
+  _registry_rc=$?
+  set -e
+  rm -rf "$_registry_dir"
+  return "$_registry_rc"
 }
 
 # Issue #780 — multi-signal alive determination for `agent show --json`.
@@ -1680,25 +1658,38 @@ run_show() {
     # written alongside the existing `active` field. `active` stays as
     # the tmux-only signal so callers that depend on the old meaning
     # are unchanged; `alive` is the new operator-facing health value.
-    bridge_agent_manage_python \
-      "$(emit_agent_records_json show "$output")" \
-      "$(bridge_agent_channel_diagnostics_json "$agent")" \
-      "$(bridge_agent_session_health_json "$agent")" \
-      "$(bridge_agent_session_source_path "$agent")" \
-      "$(bridge_agent_alive_signals_json "$agent")" <<'PY'
-import json
-import sys
-
-payload = json.loads(sys.argv[1])
-payload.setdefault("channels", {})["diagnostics"] = json.loads(sys.argv[2])
-payload["session_health"] = json.loads(sys.argv[3])
-payload["session_source"] = sys.argv[4] if len(sys.argv) > 4 and sys.argv[4] else None
-alive_blob = json.loads(sys.argv[5]) if len(sys.argv) > 5 and sys.argv[5] else {}
-payload["alive"] = bool(alive_blob.get("alive", False))
-payload["alive_signals"] = alive_blob.get("signals", {})
-print(json.dumps(payload, ensure_ascii=False, indent=2))
-PY
-    return 0
+    #
+    # Bash 5.3.9 deadlock (footgun #11 — refs queue task #4773): the
+    # original form chained four nested `$()` captures (three of which
+    # were themselves `python3 - <<'PY'` heredoc-stdin consumers) into a
+    # `bridge_agent_manage_python ... <<'PY'` parent heredoc reader. The
+    # combination wedged `read_comsub` on the operator host. Spool each
+    # input to a tempfile and dispatch to a standalone helper —
+    # same precedent as lib/upgrade-helpers/agent-restart-json.py.
+    bridge_require_python
+    local _show_dir _show_rc
+    _show_dir="$(mktemp -d "${TMPDIR:-/tmp}/bridge-agent-show.XXXXXX")"
+    emit_agent_records_json show "$output" >"$_show_dir/records.json"
+    bridge_agent_channel_diagnostics_json "$agent" >"$_show_dir/diagnostics.json"
+    bridge_agent_session_health_json "$agent" >"$_show_dir/session-health.json"
+    bridge_agent_alive_signals_json "$agent" >"$_show_dir/alive.json"
+    bridge_agent_session_source_path "$agent" >"$_show_dir/session-source.txt"
+    # codex PR #940 r2 BLOCKING: see run_list above for the RETURN-trap-
+    # bypass rationale. Same explicit set +e / capture-rc / set -e pattern
+    # ensures the tempdir is removed regardless of helper rc. Cleanup
+    # lives INSIDE this json_mode branch so the text-mode path (which
+    # never created _show_dir) does not try to rm a non-existent dir.
+    set +e
+    python3 "$SCRIPT_DIR/lib/agent-cli-helpers/show-format-json.py" \
+      "$_show_dir/records.json" \
+      "$_show_dir/diagnostics.json" \
+      "$_show_dir/session-health.json" \
+      "$_show_dir/session-source.txt" \
+      "$_show_dir/alive.json"
+    _show_rc=$?
+    set -e
+    rm -rf "$_show_dir"
+    return "$_show_rc"
   fi
 
   # Issue 6 (v0.11.0): tab-separated rows with potentially-empty middle

--- a/lib/agent-cli-helpers/list-format-text.py
+++ b/lib/agent-cli-helpers/list-format-text.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""list-format-text.py — render the human-readable `agent list` table from
+the JSON envelope emitted by `emit_agent_records_json list`.
+
+Invocation contract:
+    sys.argv[1] = path to JSON file containing a list of agent records
+                  (output of `emit_agent_records_json list "$tsv"`).
+
+Output: the same multi-line table previously generated inline by the
+`run_list` heredoc body in bridge-agent.sh.
+
+Footgun #11 (refs queue task #4773): this body used to live as a
+`bridge_agent_manage_python "$(emit_agent_records_json list "$output")" <<'PY'`
+heredoc-stdin inside run_list. The double-nested pattern (outer parent
+heredoc reader + inner `$()` capture of another heredoc consumer) wedged
+Bash 5.3.9 `read_comsub`, producing 7-17 hour hangs on the operator host.
+Moved to a standalone file invoked as `python3 list-format-text.py <path>`
+to remove the heredoc-stdin path entirely — same precedent as
+lib/upgrade-helpers/agent-restart-json.py.
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        return 0
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        items = json.load(fh)
+
+    print("agent | eng | src | active | state | iso | q/c/b | wake | notify | chan | session | workdir")
+    for item in items:
+        suffix = " [admin]" if item.get("admin") else ""
+        isolation = item.get("isolation", {}) or {}
+        mode = isolation.get("mode") or "shared"
+        os_user = isolation.get("os_user") or ""
+        iso_text = f"{mode}:{os_user}" if os_user else mode
+        # v0.8.0 T5: when the runtime hatch is on, override the iso column
+        # so a glance at `agent-bridge agent list` makes it obvious the
+        # boundary is off across the whole controller. The configured
+        # isolation_mode stays available in the JSON form and in `agent
+        # show` for operators who want both fields.
+        runtime_state = isolation.get("runtime_state") or ""
+        if runtime_state == "disabled-by-env":
+            iso_text = "disabled-by-env"
+        queue = item.get("queue", {}) or {}
+        notify = item.get("notify", {}) or {}
+        channels = item.get("channels", {}) or {}
+        print(
+            f"{item.get('agent','')}{suffix} | "
+            f"{item.get('engine','')} | "
+            f"{item.get('source','')} | "
+            f"{'yes' if item.get('active') else 'no'} | "
+            f"{item.get('activity_state','')} | "
+            f"{iso_text} | "
+            f"{queue.get('queued',0)}/{queue.get('claimed',0)}/{queue.get('blocked',0)} | "
+            f"{item.get('wake_status','')} | "
+            f"{notify.get('status','')} | "
+            f"{channels.get('status','')} | "
+            f"{item.get('session','')} | "
+            f"{item.get('workdir','')}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/agent-cli-helpers/registry-format-json.py
+++ b/lib/agent-cli-helpers/registry-format-json.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""registry-format-json.py — render the JSON inventory emitted by
+`bridge-agent.sh registry` from the tab-separated rows produced by
+`run_registry`.
+
+Invocation contract:
+    sys.argv[1] = path to TSV file with the run_registry row format
+                  (10 tab-separated columns, see run_registry comment for
+                  the schema).
+
+Output: a single JSON document on stdout — sorted by `id` for stable
+diffs.
+
+Footgun #11 (refs queue task #4773): this body used to live as a
+`bridge_agent_manage_python "$rows" <<'PY'` heredoc-stdin inside
+run_registry. The function-wrapper + heredoc-stdin combination wedged
+Bash 5.3.9 `read_comsub` on the operator host, producing 7-17 hour hangs
+on every `bridge-agent.sh registry` invocation. Moved to a standalone
+file invoked as `python3 registry-format-json.py <path>` — same
+precedent as lib/upgrade-helpers/agent-restart-json.py.
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2 or not sys.argv[1]:
+        raw = ""
+    else:
+        with open(sys.argv[1], encoding="utf-8") as fh:
+            raw = fh.read()
+
+    records = []
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 10:
+            continue
+        (id_, cls, agent_source, privilege_class, home, workdir,
+         engine, session, is_alive, source) = parts[:10]
+        records.append({
+            "id": id_,
+            "class": cls,
+            "agent_source": agent_source,
+            "privilege_class": privilege_class,
+            "home": home,
+            "workdir": workdir,
+            "engine": engine,
+            "session": session,
+            "is_alive": is_alive == "1",
+            "source": source,
+        })
+
+    records.sort(key=lambda r: r["id"])
+    print(json.dumps(records, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/agent-cli-helpers/show-format-json.py
+++ b/lib/agent-cli-helpers/show-format-json.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""show-format-json.py — render the JSON envelope for
+`bridge-agent.sh show <agent> --json` by combining the inputs gathered
+by `run_show`.
+
+Invocation contract (5 positional arguments — file paths):
+    sys.argv[1] = records.json     (emit_agent_records_json show <tsv>)
+    sys.argv[2] = diagnostics.json (bridge_agent_channel_diagnostics_json)
+    sys.argv[3] = session-health.json (bridge_agent_session_health_json)
+    sys.argv[4] = session-source.txt (bridge_agent_session_source_path)
+    sys.argv[5] = alive.json       (bridge_agent_alive_signals_json)
+
+Output: a single JSON document on stdout matching the historical
+`agent show --json` schema.
+
+Footgun #11 (refs queue task #4773): this body used to live as a
+`bridge_agent_manage_python "$(emit_agent_records_json show ...)" "$(...)" ... <<'PY'`
+heredoc-stdin inside run_show. The deeply-nested `$()` captures (three
+of which were themselves `python3 - <<'PY'` heredoc-stdin consumers)
+plus the parent heredoc reader wedged Bash 5.3.9 `read_comsub`. Moved
+to a standalone file invoked as
+`python3 show-format-json.py <records> <diag> <health> <session-source> <alive>`
+to remove all heredoc-stdin paths — same precedent as
+lib/upgrade-helpers/agent-restart-json.py.
+"""
+
+import json
+import sys
+
+
+def _read_text(path: str) -> str:
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _read_json(path: str):
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def main() -> int:
+    payload = _read_json(sys.argv[1])
+    payload.setdefault("channels", {})["diagnostics"] = _read_json(sys.argv[2])
+    payload["session_health"] = _read_json(sys.argv[3])
+    session_source = _read_text(sys.argv[4]).strip()
+    payload["session_source"] = session_source if session_source else None
+    raw_alive = _read_text(sys.argv[5]).strip()
+    alive_blob = json.loads(raw_alive) if raw_alive else {}
+    payload["alive"] = bool(alive_blob.get("alive", False))
+    payload["alive_signals"] = alive_blob.get("signals", {})
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint-heredoc-ban.sh
+++ b/scripts/lint-heredoc-ban.sh
@@ -1,26 +1,32 @@
 #!/usr/bin/env bash
 # scripts/lint-heredoc-ban.sh — ratchet lint preventing NEW heredoc-stdin
-# subprocess sites in bridge-upgrade.sh.
+# subprocess sites in footgun-#11-prone files (currently bridge-upgrade.sh
+# and bridge-agent.sh).
 #
 # Context: footgun #11 (Bash 5.3.9 `read_comsub` / `heredoc_write` deadlock
-# chain — fixed in v0.13.7 through v0.13.9). Six leap-path sites were
-# extracted to standalone helpers under lib/upgrade-helpers/; 18 off-leap
-# sites remain in bridge-upgrade.sh deferred to the S10-late stabilization
-# wave. This lint ratchets the count downward — it fails CI if anyone
-# introduces a NEW heredoc-stdin subprocess line in bridge-upgrade.sh
-# without first migrating an existing one out.
+# chain — fixed in v0.13.7 through v0.13.9 for the upgrader and refs #4773
+# for the agent CLI). Six leap-path upgrader sites were extracted to
+# standalone helpers under lib/upgrade-helpers/; 18 off-leap sites remain
+# in bridge-upgrade.sh deferred to the S10-late stabilization wave. For
+# bridge-agent.sh, the three nested-$() heredoc-stdin sites in
+# run_list/run_registry/run_show were migrated to file-as-argv (operator
+# host hangs of 7-17 hours triaged in queue task #4773); 9 single-level
+# heredoc-stdin sites remain. This lint ratchets each count downward —
+# it fails CI if anyone introduces a NEW heredoc-stdin subprocess line
+# in either file without first migrating an existing one out.
 #
 # Ratchet semantics:
-# - BRIDGE_UPGRADE_HEREDOC_CEILING (default 18) is the current allowed count.
-# - When S10-late migrates sites, the ceiling drops to the new count via
-#   PR that updates this script's default.
+# - BRIDGE_UPGRADE_HEREDOC_CEILING (default 18) — bridge-upgrade.sh.
+# - BRIDGE_AGENT_HEREDOC_CEILING   (default  9) — bridge-agent.sh.
+# - When stabilization migrates more sites, the ceilings drop to the new
+#   counts via PR that updates this script's defaults.
 # - PRs that add new heredoc-stdin without removing one push count over
 #   the ceiling and fail this lint.
 #
 # Contract — broad-match:
-#   A "site" is any non-comment line in bridge-upgrade.sh that contains
-#   a heredoc-fed `bash -s ...` or `python3 - ...` subprocess on the
-#   same line — i.e., the sub-pattern
+#   A "site" is any non-comment line in a target file (bridge-upgrade.sh
+#   or bridge-agent.sh) that contains a heredoc-fed `bash -s ...` or
+#   `python3 - ...` subprocess on the same line — i.e., the sub-pattern
 #       <bash -s | python3 -> ... <<EOF | <<'EOF' | <<"EOF" | <<PY | <<'PY' | <<"PY" | <<-...
 #   appears anywhere on the line.
 #
@@ -46,16 +52,22 @@
 # progress.
 #
 # Usage:
-#   scripts/lint-heredoc-ban.sh              # check, exit 1 if over ceiling
-#   scripts/lint-heredoc-ban.sh --list       # list all detected sites
+#   scripts/lint-heredoc-ban.sh              # check every target, exit 1 over ceiling
+#   scripts/lint-heredoc-ban.sh --list       # list all detected sites in every target
 #   scripts/lint-heredoc-ban.sh --self-test  # verify pattern against fixtures
-#   BRIDGE_UPGRADE_HEREDOC_CEILING=10 ...    # override ceiling for testing
+#   BRIDGE_UPGRADE_HEREDOC_CEILING=10 ...    # override bridge-upgrade.sh ceiling
+#   BRIDGE_AGENT_HEREDOC_CEILING=8 ...       # override bridge-agent.sh ceiling
 
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-target_file="$repo_root/bridge-upgrade.sh"
-ceiling="${BRIDGE_UPGRADE_HEREDOC_CEILING:-18}"
+
+# Target files + their per-file ceiling env var name + default. Adding a
+# new target is a 1-line append. Each target is checked independently.
+declare -a TARGETS=(
+  "bridge-upgrade.sh:BRIDGE_UPGRADE_HEREDOC_CEILING:18"
+  "bridge-agent.sh:BRIDGE_AGENT_HEREDOC_CEILING:9"
+)
 
 # Core danger pattern. Anchored to "command name + space + heredoc op + tag",
 # but NOT anchored to start-of-line — so wrapper shape is irrelevant.
@@ -147,33 +159,55 @@ if [[ "${1:-}" == "--self-test" ]]; then
   exit $?
 fi
 
-if [[ ! -f "$target_file" ]]; then
-  echo "[lint-heredoc-ban] target file missing: $target_file" >&2
-  exit 2
-fi
-
+mode="check"
 if [[ "${1:-}" == "--list" ]]; then
-  list_sites "$target_file"
-  echo
-  echo "(ceiling: $ceiling)"
-  exit 0
+  mode="list"
 fi
 
-count="$(count_sites "$target_file")"
+overall_rc=0
+for spec in "${TARGETS[@]}"; do
+  rel_path="${spec%%:*}"
+  rest="${spec#*:}"
+  env_var="${rest%%:*}"
+  default_ceiling="${rest#*:}"
+  target_file="$repo_root/$rel_path"
 
-if [[ "$count" -gt "$ceiling" ]]; then
-  echo "[lint-heredoc-ban] FAIL: bridge-upgrade.sh has $count heredoc-stdin subprocess sites, exceeding the ceiling ($ceiling)." >&2
-  echo "[lint-heredoc-ban] This lint ratchets footgun #11 carry-over. New heredoc-stdin sites must be" >&2
-  echo "[lint-heredoc-ban] extracted to lib/upgrade-helpers/ (see existing examples)." >&2
-  echo "[lint-heredoc-ban]" >&2
-  echo "[lint-heredoc-ban] Detected sites:" >&2
-  list_sites "$target_file" | sed 's/^/[lint-heredoc-ban]   /' >&2
-  exit 1
-fi
+  # Resolve the ceiling via indirect expansion so we honor per-file env
+  # overrides without listing every var name here.
+  ceiling="${!env_var:-$default_ceiling}"
 
-if [[ "$count" -lt "$ceiling" ]]; then
-  echo "[lint-heredoc-ban] note: count=$count is below ceiling=$ceiling. Consider lowering the ceiling in scripts/lint-heredoc-ban.sh to ratchet."
-fi
+  if [[ ! -f "$target_file" ]]; then
+    echo "[lint-heredoc-ban] target file missing: $target_file" >&2
+    overall_rc=2
+    continue
+  fi
 
-echo "[lint-heredoc-ban] PASS: count=$count, ceiling=$ceiling"
-exit 0
+  if [[ "$mode" == "list" ]]; then
+    echo "== $rel_path (ceiling: $ceiling, env: $env_var) =="
+    list_sites "$target_file"
+    echo
+    continue
+  fi
+
+  count="$(count_sites "$target_file")"
+
+  if [[ "$count" -gt "$ceiling" ]]; then
+    echo "[lint-heredoc-ban] FAIL: $rel_path has $count heredoc-stdin subprocess sites, exceeding the ceiling ($ceiling)." >&2
+    echo "[lint-heredoc-ban] This lint ratchets footgun #11 carry-over. New heredoc-stdin sites must be" >&2
+    echo "[lint-heredoc-ban] extracted to lib/upgrade-helpers/ (see existing examples) or spooled to a tempfile" >&2
+    echo "[lint-heredoc-ban] (file-as-argv, see PR #937 status-print pattern)." >&2
+    echo "[lint-heredoc-ban]" >&2
+    echo "[lint-heredoc-ban] Detected sites in $rel_path:" >&2
+    list_sites "$target_file" | sed 's/^/[lint-heredoc-ban]   /' >&2
+    overall_rc=1
+    continue
+  fi
+
+  if [[ "$count" -lt "$ceiling" ]]; then
+    echo "[lint-heredoc-ban] note: $rel_path count=$count is below ceiling=$ceiling. Consider lowering the $env_var default in scripts/lint-heredoc-ban.sh to ratchet."
+  fi
+
+  echo "[lint-heredoc-ban] PASS: $rel_path count=$count, ceiling=$ceiling"
+done
+
+exit "$overall_rc"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10951,4 +10951,14 @@ bash "$REPO_ROOT/scripts/smoke/layout-evidence-empty-subdir.sh"
 log "running smoke-isolation-no-live-leak smoke (refs queue #4793)"
 bash "$REPO_ROOT/scripts/smoke/smoke-isolation-no-live-leak.sh"
 
+# Refs queue task #4773 — bridge-agent.sh registry/list/show JSON paths
+# wedged Bash 5.3.9 read_comsub via nested $() captures feeding
+# heredoc-stdin python3 subprocesses through the bridge_agent_manage_python
+# wrapper. Three sites migrated to standalone helpers under
+# lib/agent-cli-helpers/. Smoke verifies the registry path completes
+# within the timeout, produces valid JSON, and that no nested-$()-into-
+# heredoc combos remain in bridge-agent.sh.
+log "running bridge-agent-cli-no-deadlock smoke (refs queue task #4773)"
+bash "$REPO_ROOT/scripts/smoke/bridge-agent-cli-no-deadlock.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/bridge-agent-cli-no-deadlock.sh
+++ b/scripts/smoke/bridge-agent-cli-no-deadlock.sh
@@ -1,0 +1,294 @@
+#!/usr/bin/env bash
+# Regression smoke — bridge-agent.sh registry/list/show JSON paths must
+# complete without tripping the Bash 5.3.9 `read_comsub` deadlock.
+#
+# Background (refs queue task #4773, 2026-05-17):
+#   Operator host saw 7-17 hour hangs on `bridge-agent.sh registry`,
+#   `agent list`, and adjacent CLI subcommands. `sample <pid>` showed
+#   `reader_loop → read_comsub → read` — the same footgun #11 class as
+#   the v0.13.7-9 bridge-upgrade.sh chain. Root cause for the three
+#   JSON-emission sites fixed in this wave: nested `$()` command-
+#   substitution captures feeding heredoc-stdin python3 subprocesses to
+#   the `bridge_agent_manage_python` wrapper (which itself does
+#   `python3 - "$@" <<'PY'`). Parent + child heredoc readers deadlocked
+#   on operator hosts via the function indirection.
+#
+#   Fix: spool the inner JSON / TSV payloads to a tempfile and dispatch
+#   to standalone helpers under lib/agent-cli-helpers/, invoked as
+#   `python3 helper.py <file>` — no heredoc-stdin anywhere. Same
+#   precedent as lib/upgrade-helpers/ (v0.13.9 footgun #11 fix).
+#
+# Coverage:
+#   C1 — `bridge-agent.sh registry --json` returns within 10s and
+#        produces valid JSON. Asserts run_registry no longer deadlocks
+#        on its JSON-emission path (the operator-symptom path).
+#   C2 — source-level grep self-audit: assert no
+#        `bridge_agent_manage_python "$(...)"` nested-$()-capture
+#        combos remain in bridge-agent.sh. Catches future regressions.
+#   C3 — standalone helper scripts exist and parse JSON correctly
+#        in isolation (no heredoc-stdin path).
+#
+# NOT covered here:
+#   `agent list` and `agent show` text paths can hang for unrelated
+#   reasons (separate upstream `$(bridge_queue_cli ...)` captures
+#   feeding `bridge_agent_records_tsv` and friends). Those are out of
+#   scope for this PR — see queue task #4773 follow-up.
+
+set -uo pipefail
+
+SMOKE_NAME="bridge-agent-cli-no-deadlock"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# shellcheck disable=SC2329 # invoked indirectly via trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+smoke_require_cmd python3
+smoke_require_cmd timeout
+
+AGENT_BRIDGE_SCRIPT="$REPO_ROOT/bridge-agent.sh"
+smoke_assert_file_exists "$AGENT_BRIDGE_SCRIPT" "bridge-agent.sh source"
+smoke_assert_file_exists "$REPO_ROOT/lib/agent-cli-helpers/registry-format-json.py" "registry helper"
+smoke_assert_file_exists "$REPO_ROOT/lib/agent-cli-helpers/list-format-text.py" "list helper"
+smoke_assert_file_exists "$REPO_ROOT/lib/agent-cli-helpers/show-format-json.py" "show helper"
+
+# C1 — `bridge-agent.sh registry --json` must complete within the
+# timeout. Empty roster -> "[]" (valid JSON). The test is purely about
+# the no-deadlock contract on the run_registry path.
+smoke_log "C1: bridge-agent.sh registry --json completes without deadlock"
+c1_out="$(timeout 10 bash "$AGENT_BRIDGE_SCRIPT" registry --json 2>&1)"
+c1_rc=$?
+if (( c1_rc == 124 )); then
+  smoke_log "C1 timed out (>10s) — read_comsub deadlock REGRESSION"
+  smoke_fail "C1: registry --json hung past the 10s guard"
+fi
+if (( c1_rc != 0 )); then
+  smoke_log "C1 stdout/stderr:"; printf '%s\n' "$c1_out"
+  smoke_fail "C1: registry --json exited rc=$c1_rc"
+fi
+if ! printf '%s' "$c1_out" | python3 -c 'import json, sys; json.load(sys.stdin)' >/dev/null 2>&1; then
+  smoke_log "C1 stdout:"; printf '%s\n' "$c1_out"
+  smoke_fail "C1: registry --json did not emit valid JSON"
+fi
+smoke_log "C1 PASS"
+
+# C2 — per-function source assertion: each migrated function body must
+# NOT call `bridge_agent_manage_python` (the wrapper that was the
+# deadlock vector via `python3 - "$@" <<'PY'`). Scoped to the function
+# body via awk so multi-line wrapper-heredoc shapes (which a naive
+# same-line grep would miss — codex PR #940 r1 BLOCKING #1) are still
+# caught. Comment lines inside the body are stripped before the check
+# so in-source rationale (historical pattern, KNOWN_ISSUES references)
+# does not false-trip the assertion.
+smoke_log "C2: per-function audit — migrated functions must not call bridge_agent_manage_python"
+extract_fn_body() {
+  # Args: $1 = file, $2 = function name (matches `^<name>() {`).
+  # Emits the function body to stdout, stripping comment-only lines.
+  # End-of-function detected as `^}$` at column 0 (matches all 3 target
+  # functions' closing brace style in bridge-agent.sh).
+  awk -v fn="$2" '
+    $0 ~ ("^" fn "\\(\\) \\{") { inside = 1; next }
+    inside && /^}$/             { inside = 0; exit }
+    inside {
+      # Strip comment-only lines (first non-whitespace char == `#`).
+      line = $0
+      stripped = line
+      sub(/^[[:space:]]+/, "", stripped)
+      if (substr(stripped, 1, 1) == "#") next
+      print line
+    }
+  ' "$1"
+}
+
+for fn in run_list run_registry run_show; do
+  body="$(extract_fn_body "$AGENT_BRIDGE_SCRIPT" "$fn")"
+  if [[ -z "$body" ]]; then
+    smoke_fail "C2: could not locate function $fn() in $AGENT_BRIDGE_SCRIPT"
+  fi
+  if printf '%s\n' "$body" | grep -q 'bridge_agent_manage_python'; then
+    smoke_log "C2 $fn() still calls bridge_agent_manage_python:"
+    printf '%s\n' "$body" | grep -n 'bridge_agent_manage_python' | sed 's/^/  /'
+    smoke_fail "C2: $fn() still invokes the deadlock-prone wrapper"
+  fi
+  # Also catch any inline `python3 - <<'PY'` heredoc-stdin (would have the
+  # same hazard even without the wrapper indirection).
+  if printf '%s\n' "$body" | grep -qE 'python3[[:space:]]+-[[:space:]].*<<'; then
+    smoke_log "C2 $fn() has inline python3 heredoc-stdin:"
+    printf '%s\n' "$body" | grep -nE 'python3[[:space:]]+-[[:space:]].*<<' | sed 's/^/  /'
+    smoke_fail "C2: $fn() reintroduced direct python3 heredoc-stdin"
+  fi
+done
+smoke_log "C2 PASS"
+
+# C3 — Standalone helper round-trip: feed each helper a tiny synthetic
+# input and confirm it produces the expected output shape. This locks
+# in the file-as-argv contract (no heredoc-stdin) end-to-end.
+smoke_log "C3: standalone helpers parse synthetic inputs"
+c3_dir="$SMOKE_TMP_ROOT/c3"
+mkdir -p "$c3_dir"
+
+# Registry helper: single-row TSV → 1-element JSON array
+printf 'agent1\tdynamic\tdynamic\tuser\t/h\t/w\tclaude\tsess\t1\tstatic-roster\n' >"$c3_dir/rows.tsv"
+reg_out="$(python3 "$REPO_ROOT/lib/agent-cli-helpers/registry-format-json.py" "$c3_dir/rows.tsv" 2>&1)"
+if ! printf '%s' "$reg_out" | python3 -c 'import json, sys; data=json.load(sys.stdin); assert len(data)==1 and data[0]["id"]=="agent1"' 2>/dev/null; then
+  smoke_log "C3 registry helper output:"; printf '%s\n' "$reg_out"
+  smoke_fail "C3: registry-format-json.py did not produce expected output"
+fi
+
+# List helper: single-record JSON → 2-line text (header + 1 row)
+cat >"$c3_dir/records.json" <<'JSON'
+[
+  {"agent": "agent1", "engine": "claude", "source": "static", "active": true,
+   "activity_state": "ready", "isolation": {"mode": "shared"},
+   "queue": {"queued": 0, "claimed": 0, "blocked": 0},
+   "wake_status": "ok", "notify": {"status": "off"},
+   "channels": {"status": "off"}, "session": "agent1", "workdir": "/w",
+   "admin": false}
+]
+JSON
+list_out="$(python3 "$REPO_ROOT/lib/agent-cli-helpers/list-format-text.py" "$c3_dir/records.json" 2>&1)"
+smoke_assert_contains "$list_out" "agent | eng | src" "C3 list helper header"
+smoke_assert_contains "$list_out" "agent1" "C3 list helper row"
+
+# Show helper: 5 inputs → unified JSON
+cat >"$c3_dir/show-records.json" <<'JSON'
+{"agent": "agent1", "engine": "claude", "channels": {"status": "off"}}
+JSON
+printf '[]' >"$c3_dir/show-diag.json"
+printf '{"status": "ok"}' >"$c3_dir/show-health.json"
+printf '/etc/path/source\n' >"$c3_dir/show-source.txt"
+printf '{"alive": true, "signals": {"tmux": true}}' >"$c3_dir/show-alive.json"
+show_out="$(python3 "$REPO_ROOT/lib/agent-cli-helpers/show-format-json.py" \
+  "$c3_dir/show-records.json" "$c3_dir/show-diag.json" "$c3_dir/show-health.json" \
+  "$c3_dir/show-source.txt" "$c3_dir/show-alive.json" 2>&1)"
+if ! printf '%s' "$show_out" | python3 -c 'import json, sys; data=json.load(sys.stdin); assert data["alive"] is True and data["session_source"] == "/etc/path/source"' 2>/dev/null; then
+  smoke_log "C3 show helper output:"; printf '%s\n' "$show_out"
+  smoke_fail "C3: show-format-json.py did not produce expected output"
+fi
+smoke_log "C3 PASS"
+
+# C4 — forced-failure cleanup assertion (codex PR #940 r2 BLOCKING):
+# under `set -euo pipefail`, a helper that exits non-zero must NOT leak
+# its tempdir AND its exit status must propagate. r2's RETURN trap was
+# bypassed by errexit abort; the explicit set +e / capture / set -e /
+# rm -rf pattern at lines :1414, :1525, :1683 closes that gap. C4
+# replicates the production fragment for each of the 3 sites, forces
+# the helper to exit non-zero, and asserts (a) the tempdir is gone and
+# (b) the exit status reaches the caller.
+smoke_log "C4: forced-failure cleanup — tempdir removed + rc propagates under set -euo pipefail"
+c4_dir="$SMOKE_TMP_ROOT/c4"
+mkdir -p "$c4_dir"
+
+# Each fragment mirrors the production sequence exactly:
+#   1. local _<name>_dir _<name>_rc
+#   2. _<name>_dir="$(mktemp -d ...)"
+#   3. producer(s) populate the dir
+#   4. set +e; python3 helper ...; _<name>_rc=$?; set -e
+#   5. rm -rf "$_<name>_dir"
+#   6. return "$_<name>_rc"
+# The python3 invocation is replaced by `python3 -c "sys.exit(N)"` so
+# we drive the failure path deterministically without modifying the
+# real helpers.
+c4_probe="$c4_dir/probe.sh"
+cat >"$c4_probe" <<'PROBE'
+#!/usr/bin/env bash
+set -euo pipefail
+
+run_list_fragment() {
+  local _list_dir _list_rc
+  _list_dir="$(mktemp -d "${TMPDIR:-/tmp}/c4-list.XXXXXX")"
+  printf '%s' '[]' >"$_list_dir/records.json"
+  set +e
+  python3 -c "import sys; sys.exit(33)" "$_list_dir/records.json"
+  _list_rc=$?
+  set -e
+  rm -rf "$_list_dir"
+  return "$_list_rc"
+}
+
+run_registry_fragment() {
+  local _registry_dir _registry_rc
+  _registry_dir="$(mktemp -d "${TMPDIR:-/tmp}/c4-registry.XXXXXX")"
+  printf '%s' "" >"$_registry_dir/rows.tsv"
+  set +e
+  python3 -c "import sys; sys.exit(42)" "$_registry_dir/rows.tsv"
+  _registry_rc=$?
+  set -e
+  rm -rf "$_registry_dir"
+  return "$_registry_rc"
+}
+
+run_show_fragment() {
+  local _show_dir _show_rc
+  _show_dir="$(mktemp -d "${TMPDIR:-/tmp}/c4-show.XXXXXX")"
+  printf '%s' "{}" >"$_show_dir/records.json"
+  printf '%s' "[]" >"$_show_dir/diagnostics.json"
+  printf '%s' "{}" >"$_show_dir/session-health.json"
+  printf '%s' ""   >"$_show_dir/session-source.txt"
+  printf '%s' "{}" >"$_show_dir/alive.json"
+  set +e
+  python3 -c "import sys; sys.exit(55)" \
+    "$_show_dir/records.json" \
+    "$_show_dir/diagnostics.json" \
+    "$_show_dir/session-health.json" \
+    "$_show_dir/session-source.txt" \
+    "$_show_dir/alive.json"
+  _show_rc=$?
+  set -e
+  rm -rf "$_show_dir"
+  return "$_show_rc"
+}
+
+list_rc=0; run_list_fragment || list_rc=$?
+list_leaks="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'c4-list.*' 2>/dev/null | wc -l | tr -d ' ')"
+printf 'list_rc=%s list_leaks=%s\n' "$list_rc" "$list_leaks"
+
+registry_rc=0; run_registry_fragment || registry_rc=$?
+registry_leaks="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'c4-registry.*' 2>/dev/null | wc -l | tr -d ' ')"
+printf 'registry_rc=%s registry_leaks=%s\n' "$registry_rc" "$registry_leaks"
+
+show_rc=0; run_show_fragment || show_rc=$?
+show_leaks="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'c4-show.*' 2>/dev/null | wc -l | tr -d ' ')"
+printf 'show_rc=%s show_leaks=%s\n' "$show_rc" "$show_leaks"
+PROBE
+chmod +x "$c4_probe"
+
+# Clean any prior leftovers from the c4-* namespace before measuring.
+rm -rf "${TMPDIR:-/tmp}"/c4-list.* "${TMPDIR:-/tmp}"/c4-registry.* "${TMPDIR:-/tmp}"/c4-show.* 2>/dev/null || true
+
+c4_out="$(bash "$c4_probe" 2>&1)"
+c4_rc=$?
+if (( c4_rc != 0 )); then
+  smoke_log "C4 probe failed (rc=$c4_rc):"; printf '%s\n' "$c4_out"
+  smoke_fail "C4: probe script did not complete"
+fi
+
+# Parse the three key=value lines and assert each fragment's outcome.
+for spec in "list:33" "registry:42" "show:55"; do
+  fragment="${spec%%:*}"
+  expected_rc="${spec##*:}"
+  got_rc="$(printf '%s\n' "$c4_out" | sed -n "s/^${fragment}_rc=\([0-9]*\) .*/\1/p")"
+  got_leaks="$(printf '%s\n' "$c4_out" | sed -n "s/^${fragment}_rc=[0-9]* ${fragment}_leaks=\([0-9]*\)/\1/p")"
+  if [[ "$got_rc" != "$expected_rc" ]]; then
+    smoke_log "C4 ${fragment}_fragment: expected rc=$expected_rc, got rc=$got_rc"
+    smoke_log "C4 full probe output:"; printf '%s\n' "$c4_out"
+    smoke_fail "C4: ${fragment} fragment did not propagate helper rc"
+  fi
+  if [[ "$got_leaks" != "0" ]]; then
+    smoke_log "C4 ${fragment}_fragment leaked $got_leaks tempdir(s):"
+    find "${TMPDIR:-/tmp}" -maxdepth 1 -name "c4-${fragment}.*" 2>/dev/null
+    smoke_fail "C4: ${fragment} fragment leaked tempdir(s) on helper failure"
+  fi
+done
+smoke_log "C4 PASS — all 3 sites: helper failure cleans tempdir + propagates rc"
+
+smoke_log "PASS — bridge-agent.sh registry/list/show JSON paths no longer deadlock on read_comsub"
+exit 0


### PR DESCRIPTION
## Summary

Fixes Bash 5.3.9 `read_comsub → read` deadlock in `bridge-agent.sh` registry/list/show paths by extracting heredoc-stdin python3 bodies to standalone helper scripts under `lib/agent-cli-helpers/`. Same class as v0.13.7-9 footgun #11 (which fixed `bridge-upgrade.sh`). Operator host saw 7-17h hangs on `bridge-agent.sh registry` per queue task #4773.

## Sites fixed

- `bridge-agent.sh:1394` (`run_list`) — double-nested `$()` + heredoc-stdin via `bridge_agent_manage_python "$(emit_agent_records_json list ...)" <<'PY'`
- `bridge-agent.sh:1523` (`run_registry`) — function-wrapper + heredoc-stdin via `bridge_agent_manage_python "$rows" <<'PY'`
- `bridge-agent.sh:1683` (`run_show`) — 4-way nested `$()` capture chain feeding heredoc-stdin

## Why standalone helpers (not just tempfile-as-argv)

The PR #937 / lib/upgrade-helpers/ precedent showed two distinct mitigations:
1. **Tempfile-as-argv** (PR #937 status-print): spool JSON to file, pass filename. Works for ARG_MAX overflow but NOT this deadlock on bash 5.3.9.
2. **Standalone helper extraction** (v0.13.9 upgrade-helpers): move python body to `.py` file, invoke without any heredoc-stdin. Works for the deadlock.

Verified on the operator host (macOS, Bash 5.3.9, darwin25.1.0): tempfile-as-argv alone with `bridge_agent_manage_python "$file" <<'PY'` still deadlocked because the function-wrapper indirection + heredoc-stdin combination is itself the hazard. Only the standalone-helper extraction lets `bridge-agent.sh registry --json` return.

## Pattern

```bash
# Producer side stays the same (writes to file).
producer > "$_dir/input.json"

# Consumer: NO heredoc-stdin anywhere — dispatch to standalone script.
python3 "$SCRIPT_DIR/lib/agent-cli-helpers/registry-format-json.py" "$_dir/input.json"
local _rc=$?
rm -rf "$_dir"
return "$_rc"
```

Each helper script accepts file paths as positional argv and emits the historical output shape on stdout (unchanged JSON/text contract for callers).

## Ratchet

Expanded `scripts/lint-heredoc-ban.sh` to cover `bridge-agent.sh` (ceiling=9 — current count of non-deadlock `python3 - <<'PY'` heredoc-stdin sites that are off the operator's symptom path). Same lint runs from `scripts/oss-preflight.sh`.

## New smoke

`scripts/smoke/bridge-agent-cli-no-deadlock.sh`:
- C1: `bridge-agent.sh registry --json` returns valid JSON within 10s timeout
- C2: source-level grep — no `bridge_agent_manage_python "$(` nested-`$()`-into-heredoc combos remain
- C3: standalone helpers round-trip on synthetic inputs

Wired into `scripts/smoke-test.sh`.

## Out of scope — follow-up

- `agent list` / `agent show` text paths still hang on **separate** upstream `$()` captures around `bridge_queue_cli summary` feeding `bridge_agent_records_tsv`. Same footgun #11 class but a different file path; needs its own audit pass.
- 9 single-level `python3 - <<'PY'` sites in `bridge-agent.sh` tracked by the lint ratchet (none on the operator's symptom path).
- `lib/bridge-host-profile.sh`, `lib/bridge-agents.sh`, `lib/bridge-state.sh` secondary sites per brief.

## Verified

- `bash -n` PASS on `bridge-agent.sh`, `scripts/lint-heredoc-ban.sh`, `scripts/smoke-test.sh`, `scripts/smoke/bridge-agent-cli-no-deadlock.sh`
- `shellcheck` PASS on all touched shell files
- `py_compile` PASS on all 3 new helpers
- New smoke `scripts/smoke/bridge-agent-cli-no-deadlock.sh` PASS (C1/C2/C3)
- `scripts/lint-heredoc-ban.sh --self-test` PASS; main check PASS at `bridge-upgrade.sh count=18, ceiling=18` + `bridge-agent.sh count=9, ceiling=9`
- Direct host repro on Bash 5.3.9 darwin25.1.0: pre-fix `bridge-agent.sh registry --json` hung at 8s+ timeout; post-fix returns valid JSON (7-entry array) in well under 10s
- `scripts/smoke-test.sh` deferred (host contention with parallel fixers — operator directive)

Refs: queue task #4773, KNOWN_ISSUES.md §26 footgun #11
Precedent: PR #937 (status-print tempfile-as-argv), v0.13.9 lib/upgrade-helpers/ (standalone-helper extraction)