### PR TITLE
fix(watchdog): registry-anchored enumeration (refs #4796)

### DIFF
--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -7,6 +7,8 @@ import argparse
 import json
 import os
 import re
+import shutil
+import subprocess
 import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -34,20 +36,149 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="ignore")
 
 
-def list_agent_dirs(root: Path, selected: list[str]) -> list[Path]:
+# Directory basenames under $BRIDGE_AGENT_HOME_ROOT that are bridge-managed
+# infrastructure rather than per-agent homes; the watchdog skips them.
+# Mirrors bridge-doctor.py:ORPHAN_SKIP_NAMES — keep the two lists in lockstep.
+WATCHDOG_SKIP_NAMES = frozenset({"_template", "shared"})
+
+
+def list_agent_dirs(
+    root: Path,
+    selected: list[str],
+    registry_ids: set[str] | None = None,
+) -> tuple[list[Path], list[str]]:
+    """Enumerate per-agent home directories to scan.
+
+    Returns (scan_paths, orphan_names).
+
+    When ``registry_ids`` is provided (registry-anchored mode, default), only
+    directories whose basename appears in the registry are scanned. Directories
+    on disk that are not in the registry are returned in ``orphan_names`` so
+    the caller can surface them under a separate ``orphan_directories`` alert
+    bucket — they no longer drive ``profile_drift`` warns (refs queue #4796).
+
+    When ``registry_ids`` is ``None``, every directory is scanned (legacy
+    behavior, used only when the caller passes ``--no-registry-anchored``).
+
+    When ``selected`` is non-empty, both filters defer to the explicit
+    selection so ``agent-bridge watchdog scan <agent>`` keeps working even
+    if the registry lookup failed.
+    """
     if not root.exists():
-        return []
-    paths = []
+        return [], []
+    paths: list[Path] = []
+    orphans: list[str] = []
     selected_set = set(selected)
     for path in sorted(root.iterdir()):
         if not path.is_dir():
             continue
-        if path.name.startswith(".") or path.name in {"_template", "shared"}:
+        if path.name.startswith(".") or path.name in WATCHDOG_SKIP_NAMES:
             continue
-        if selected and path.name not in selected_set:
+        if selected:
+            if path.name in selected_set:
+                paths.append(path)
+            continue
+        if registry_ids is not None and path.name not in registry_ids:
+            orphans.append(path.name)
             continue
         paths.append(path)
-    return paths
+    return paths, orphans
+
+
+def load_registry_agent_ids(
+    args: argparse.Namespace,
+    bridge_home: Path,
+) -> set[str] | None:
+    """Return the set of agent ids known to ``agent registry --json``.
+
+    Returns ``None`` when registry-anchoring is disabled or the lookup fails;
+    the caller falls back to the legacy listing-only mode in that case so the
+    watchdog never goes silent because of a broken registry endpoint.
+
+    Tests inject ``--agent-registry-json <file>`` to skip the subprocess; the
+    file shape mirrors ``bridge-doctor.py`` (JSON array of objects with an
+    ``id`` field) so the same fixtures work for both detectors.
+    """
+    if args.agent_registry_json:
+        path = Path(args.agent_registry_json).expanduser()
+        if not path.is_file():
+            print(
+                f"[bridge-watchdog] --agent-registry-json file not found: {path}",
+                file=sys.stderr,
+            )
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(
+                f"[bridge-watchdog] --agent-registry-json unreadable ({exc}); "
+                "falling back to listing-only enumeration",
+                file=sys.stderr,
+            )
+            return None
+        return _registry_ids_from_payload(data)
+
+    binary = args.agent_bridge or os.environ.get("BRIDGE_AGENT_BRIDGE_BIN", "").strip()
+    if not binary:
+        sibling = Path(__file__).resolve().parent / "agent-bridge"
+        if sibling.is_file():
+            binary = str(sibling)
+        else:
+            located = shutil.which("agent-bridge")
+            if not located:
+                print(
+                    "[bridge-watchdog] agent-bridge binary not found; "
+                    "falling back to listing-only enumeration",
+                    file=sys.stderr,
+                )
+                return None
+            binary = located
+    env = os.environ.copy()
+    env["BRIDGE_HOME"] = str(bridge_home)
+    try:
+        proc = subprocess.run(
+            [binary, "agent", "registry", "--json"],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        stderr = getattr(exc, "stderr", "") or ""
+        print(
+            f"[bridge-watchdog] agent registry --json failed ({type(exc).__name__}: "
+            f"{stderr.strip() or exc}); falling back to listing-only enumeration",
+            file=sys.stderr,
+        )
+        return None
+    try:
+        data = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        print(
+            f"[bridge-watchdog] agent registry --json returned invalid JSON ({exc}); "
+            "falling back to listing-only enumeration",
+            file=sys.stderr,
+        )
+        return None
+    return _registry_ids_from_payload(data)
+
+
+def _registry_ids_from_payload(data: object) -> set[str] | None:
+    if not isinstance(data, list):
+        print(
+            "[bridge-watchdog] agent registry payload is not a JSON array; "
+            "falling back to listing-only enumeration",
+            file=sys.stderr,
+        )
+        return None
+    ids: set[str] = set()
+    for row in data:
+        if not isinstance(row, dict):
+            continue
+        agent_id = str(row.get("id") or "").strip()
+        if agent_id:
+            ids.add(agent_id)
+    return ids
 
 
 def collect_broken_links(agent_dir: Path) -> list[str]:
@@ -165,9 +296,14 @@ def scan_agent(agent_dir: Path) -> AgentWatch:
         )
 
 
-def render_markdown(records: list[AgentWatch], bridge_home: Path) -> str:
+def render_markdown(
+    records: list[AgentWatch],
+    bridge_home: Path,
+    orphan_directories: list[str] | None = None,
+) -> str:
     now_iso = datetime.now().astimezone().isoformat()
     problems = [item for item in records if item.status != "ok"]
+    orphan_directories = orphan_directories or []
     lines = [
         "# Watchdog Report",
         "",
@@ -175,8 +311,18 @@ def render_markdown(records: list[AgentWatch], bridge_home: Path) -> str:
         f"- bridge_home: {bridge_home}",
         f"- agents: {len(records)}",
         f"- problems: {len(problems)}",
+        f"- orphan_directories: {len(orphan_directories)}",
         "",
     ]
+    if orphan_directories:
+        # Refs queue #4796: orphan dirs (smoke leaks, manual mkdir) used to
+        # surface as profile_drift warns when the watchdog enumerated
+        # `agents/` directly. Surface them under a separate bucket so
+        # operators can triage with `agent-bridge doctor --detectors
+        # orphan-agent-dir` instead of treating them as live-agent drift.
+        lines.append("## orphan_directories")
+        lines.extend(f"- {name}" for name in orphan_directories)
+        lines.append("")
     if not records:
         lines.append("- no agents scanned")
         return "\n".join(lines) + "\n"
@@ -208,23 +354,60 @@ def main() -> int:
     parser.add_argument("--bridge-home", default=os.environ.get("BRIDGE_HOME", str(Path.home() / ".agent-bridge")))
     parser.add_argument("--agent-home-root", default=None)
     parser.add_argument("--json", action="store_true")
+    # Refs queue #4796: registry-anchored enumeration is the default. Orphan
+    # directories under $BRIDGE_AGENT_HOME_ROOT no longer drive profile_drift
+    # warns; they surface in the separate `orphan_directories` bucket. Pass
+    # --no-registry-anchored to restore the legacy listing-only behavior
+    # (every dir is scanned as if it were a registered agent).
+    parser.add_argument(
+        "--registry-anchored",
+        dest="registry_anchored",
+        action="store_true",
+        default=True,
+        help="enumerate agents from `agent registry --json` (default)",
+    )
+    parser.add_argument(
+        "--no-registry-anchored",
+        dest="registry_anchored",
+        action="store_false",
+        help="legacy listing-only enumeration (scan every dir under agents/)",
+    )
+    parser.add_argument(
+        "--agent-bridge",
+        default=None,
+        help="path to the agent-bridge binary used for the registry query",
+    )
+    parser.add_argument(
+        "--agent-registry-json",
+        default=None,
+        help="path to a JSON file with the registry payload (test injection)",
+    )
     args = parser.parse_args()
 
     bridge_home = Path(args.bridge_home).expanduser()
     agent_root = Path(args.agent_home_root).expanduser() if args.agent_home_root else bridge_home / "agents"
-    records = [scan_agent(path) for path in list_agent_dirs(agent_root, args.agents)]
+    registry_ids: set[str] | None = None
+    if args.registry_anchored and not args.agents:
+        # Explicit agent args bypass the registry filter so the operator can
+        # still scope-scan a single agent even when the registry endpoint is
+        # broken. When no args are given the registry filter applies.
+        registry_ids = load_registry_agent_ids(args, bridge_home)
+    scan_paths, orphan_directories = list_agent_dirs(agent_root, args.agents, registry_ids)
+    records = [scan_agent(path) for path in scan_paths]
     payload = {
         "generated_at": datetime.now().astimezone().isoformat(),
         "bridge_home": str(bridge_home),
         "agent_home_root": str(agent_root),
         "agent_count": len(records),
         "problem_count": sum(1 for item in records if item.status != "ok"),
+        "orphan_directory_count": len(orphan_directories),
+        "orphan_directories": orphan_directories,
         "agents": [asdict(item) for item in records],
     }
     if args.json:
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
-        print(render_markdown(records, bridge_home), end="")
+        print(render_markdown(records, bridge_home, orphan_directories), end="")
     return 0
 
 

--- a/scripts/smoke/watchdog-registry-anchored.sh
+++ b/scripts/smoke/watchdog-registry-anchored.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# scripts/smoke/watchdog-registry-anchored.sh — refs queue task #4796.
+#
+# Regression for the watchdog enumeration footgun: the scanner used to walk
+# `$BRIDGE_HOME/agents/` directly, so every smoke-test leak / manual mkdir
+# under that root surfaced as a `profile_drift` warn. Operators saw 10/18
+# noise alerts on 2026-05-17 — none of those names were in the registry or
+# the roster. The fix anchors the default enumeration on
+# `agent registry --json`; dirs on disk not in the registry are reported
+# under the separate `orphan_directories` bucket and do NOT drive
+# `profile_drift` warns.
+#
+# Cases (mode axis — C1-C4):
+#   C1. Registered agent + orphan dir → registered agent scanned (rows=1),
+#       orphan surfaces in `orphan_directories`, problem_count derived
+#       only from the registered agent.
+#   C2. `--no-registry-anchored` restores the legacy listing-only walk:
+#       both dirs are scanned as if they were agents, orphan bucket empty.
+#   C3. Explicit `agent` argument bypasses the registry filter so scoped
+#       scans keep working even when the registry endpoint is broken /
+#       empty.
+#   C4. Registry lookup failure (no agent-bridge binary) falls back to
+#       listing-only enumeration (no silent zero-rows regression) and
+#       emits a stderr breadcrumb.
+#
+# Cases (population axis — C5-C7, codex PR #941 r1 BLOCKING):
+#   C5. agents/ exists but is empty → 0 agent rows, 0 orphans, 0 problems
+#       (no false drift on a freshly initialized BRIDGE_HOME).
+#   C6. All-orphan (no registered ids in registry) → 0 agent rows,
+#       N orphans, 0 problems (the operator's 2026-05-17 alert-noise
+#       shape: every disk dir surfaces in orphan_directories, drift
+#       stays clean).
+#   C7. All-registered (every dir in registry, no orphans) → N agent
+#       rows scanned, 0 orphans; problem_count reflects per-agent drift
+#       only (well-formed agent rows are ok, drift-shaped agent rows
+#       warn/error — the expected drift path is preserved).
+#
+# Uses an isolated BRIDGE_HOME via smoke_setup_bridge_home — never
+# touches the operator's live runtime.
+
+set -euo pipefail
+
+SMOKE_NAME="watchdog-registry-anchored"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "watchdog-registry-anchored"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+# Seed two directories under agents/: one "registered" (kept in the
+# fixture registry) and one "orphan" (NOT in the registry — this is the
+# smoke-leak / manual-mkdir shape from the operator host on 2026-05-17).
+REGISTERED_AGENT="registered-agent"
+ORPHAN_AGENT="smoke-orphan-leak-$$"
+REGISTERED_DIR="$BRIDGE_AGENT_HOME_ROOT/$REGISTERED_AGENT"
+ORPHAN_DIR="$BRIDGE_AGENT_HOME_ROOT/$ORPHAN_AGENT"
+mkdir -p "$REGISTERED_DIR" "$ORPHAN_DIR"
+
+# Both dirs get the minimum file set so scan_agent() does not turn either
+# into an `error` row — that way the only difference between them is
+# registry membership, which is the property under test.
+for d in "$REGISTERED_DIR" "$ORPHAN_DIR"; do
+  cat >"$d/CLAUDE.md" <<'EOF'
+<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->
+managed
+<!-- END AGENT BRIDGE DOC MIGRATION -->
+EOF
+  : >"$d/SOUL.md"
+  : >"$d/MEMORY-SCHEMA.md"
+  : >"$d/MEMORY.md"
+  cat >"$d/SESSION-TYPE.md" <<'EOF'
+# Session Type
+
+- Session Type: static-claude
+- Onboarding State: complete
+EOF
+done
+
+# Fixture registry payload — mirror the shape produced by
+# `agent registry --json` (a JSON array of objects keyed by `id`). The
+# orphan dir is intentionally absent.
+REGISTRY_JSON="$SMOKE_TMP_ROOT/registry.json"
+cat >"$REGISTRY_JSON" <<EOF
+[
+  {"id": "$REGISTERED_AGENT", "class": "static", "agent_source": "static"}
+]
+EOF
+
+run_watchdog() {
+  "$PY_BIN" "$REPO_ROOT/bridge-watchdog.py" "$@"
+}
+
+# --- C1: registry-anchored default --------------------------------------
+smoke_log "C1: registry-anchored default skips orphan dir"
+C1_JSON="$(run_watchdog scan --json --agent-registry-json "$REGISTRY_JSON")"
+"$PY_BIN" - "$C1_JSON" "$REGISTERED_AGENT" "$ORPHAN_AGENT" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+registered = sys.argv[2]
+orphan = sys.argv[3]
+agent_ids = {row["agent"] for row in payload["agents"]}
+assert registered in agent_ids, f"registered agent missing from scan: {agent_ids}"
+assert orphan not in agent_ids, f"orphan must not be scanned as agent: {agent_ids}"
+assert payload["agent_count"] == 1, f"expected 1 agent row, got {payload['agent_count']}"
+assert payload["orphan_directory_count"] == 1, payload["orphan_directory_count"]
+assert payload["orphan_directories"] == [orphan], payload["orphan_directories"]
+# The registered agent has a complete managed block + onboarding=complete
+# so it must classify as status=ok. The whole point of the fix is that
+# orphan dirs no longer leak into problem_count.
+registered_row = next(r for r in payload["agents"] if r["agent"] == registered)
+assert registered_row["status"] == "ok", registered_row
+assert payload["problem_count"] == 0, payload["problem_count"]
+PY
+
+# --- C2: --no-registry-anchored restores legacy listing walk ------------
+smoke_log "C2: --no-registry-anchored scans every dir under agents/"
+C2_JSON="$(run_watchdog scan --json --no-registry-anchored)"
+"$PY_BIN" - "$C2_JSON" "$REGISTERED_AGENT" "$ORPHAN_AGENT" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+registered = sys.argv[2]
+orphan = sys.argv[3]
+agent_ids = {row["agent"] for row in payload["agents"]}
+assert registered in agent_ids, agent_ids
+assert orphan in agent_ids, "legacy mode must still scan every dir"
+assert payload["orphan_directory_count"] == 0, payload["orphan_directory_count"]
+PY
+
+# --- C3: explicit agent arg bypasses the registry filter ----------------
+smoke_log "C3: explicit agent arg bypasses the registry filter"
+C3_JSON="$(run_watchdog scan "$ORPHAN_AGENT" --json --agent-registry-json "$REGISTRY_JSON")"
+"$PY_BIN" - "$C3_JSON" "$ORPHAN_AGENT" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+orphan = sys.argv[2]
+agent_ids = {row["agent"] for row in payload["agents"]}
+# Explicit selection wins — the orphan name behaves like a normal scope
+# arg, mirroring the existing `watchdog scan <agent>` ergonomics that
+# smoke-test.sh already depends on.
+assert orphan in agent_ids, f"explicit arg should be scanned: {agent_ids}"
+assert payload["orphan_directory_count"] == 0, payload["orphan_directory_count"]
+PY
+
+# --- C4: registry lookup failure falls back to listing-only -------------
+smoke_log "C4: missing agent-bridge binary falls back to listing-only"
+# Point --agent-bridge at /dev/null/missing so the subprocess fails; the
+# watchdog must keep scanning (no silent zero-rows) and emit a breadcrumb.
+C4_STDERR_FILE="$SMOKE_TMP_ROOT/c4-stderr.log"
+C4_JSON="$(run_watchdog scan --json --agent-bridge /nonexistent/agent-bridge 2>"$C4_STDERR_FILE")"
+"$PY_BIN" - "$C4_JSON" "$REGISTERED_AGENT" "$ORPHAN_AGENT" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+registered = sys.argv[2]
+orphan = sys.argv[3]
+agent_ids = {row["agent"] for row in payload["agents"]}
+assert registered in agent_ids, agent_ids
+# Fallback intentionally scans every dir so the watchdog does not go
+# silent when the registry endpoint breaks; the operator still sees data
+# (with the pre-fix noise) while the underlying issue is repaired.
+assert orphan in agent_ids, "fallback must keep scanning every dir"
+PY
+if ! grep -q "falling back to listing-only" "$C4_STDERR_FILE"; then
+  smoke_fail "expected fallback breadcrumb in stderr, got: $(cat "$C4_STDERR_FILE")"
+fi
+
+# Seed a populated agent dir to clone from in C7 — uses the same
+# well-formed shape as the C1 fixture so scan_agent() classifies it ok.
+# Defined as a function so each population case can rebuild a fresh root
+# without leaking state across cases.
+seed_well_formed_agent() {
+  local dir="$1"
+  mkdir -p "$dir"
+  cat >"$dir/CLAUDE.md" <<'EOF'
+<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->
+managed
+<!-- END AGENT BRIDGE DOC MIGRATION -->
+EOF
+  : >"$dir/SOUL.md"
+  : >"$dir/MEMORY-SCHEMA.md"
+  : >"$dir/MEMORY.md"
+  cat >"$dir/SESSION-TYPE.md" <<'EOF'
+# Session Type
+
+- Session Type: static-claude
+- Onboarding State: complete
+EOF
+}
+
+# --- C5: empty agents/ directory ----------------------------------------
+# Refs queue #4796 codex PR #941 r1 BLOCKING: a freshly initialized
+# BRIDGE_HOME (agents/ exists but is empty) must produce zero drift and
+# zero orphans — the watchdog should be silent, not surface a "no agents
+# registered" warn.
+smoke_log "C5: empty agents/ → 0 agents, 0 orphans, 0 problems"
+C5_ROOT="$SMOKE_TMP_ROOT/c5-agents"
+mkdir -p "$C5_ROOT"
+C5_REGISTRY="$SMOKE_TMP_ROOT/c5-registry.json"
+printf '[]\n' >"$C5_REGISTRY"
+C5_JSON="$(run_watchdog scan --json --agent-home-root "$C5_ROOT" --agent-registry-json "$C5_REGISTRY")"
+"$PY_BIN" - "$C5_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["agent_count"] == 0, f"expected 0 agents, got {payload['agent_count']}"
+assert payload["problem_count"] == 0, f"expected 0 problems, got {payload['problem_count']}"
+assert payload["orphan_directory_count"] == 0, payload["orphan_directory_count"]
+assert payload["orphan_directories"] == [], payload["orphan_directories"]
+assert payload["agents"] == [], payload["agents"]
+PY
+
+# --- C6: all-orphan, no registered agents -------------------------------
+# Refs queue #4796 codex PR #941 r1 BLOCKING: the operator's 2026-05-17
+# alert-noise shape — every dir on disk is unregistered. None of them
+# must surface as profile_drift; all of them must surface as orphans.
+smoke_log "C6: all-orphan agents/ → 0 drift, N orphans, 0 problems"
+C6_ROOT="$SMOKE_TMP_ROOT/c6-agents"
+mkdir -p "$C6_ROOT/foo" "$C6_ROOT/bar"
+C6_REGISTRY="$SMOKE_TMP_ROOT/c6-registry.json"
+printf '[]\n' >"$C6_REGISTRY"
+C6_JSON="$(run_watchdog scan --json --agent-home-root "$C6_ROOT" --agent-registry-json "$C6_REGISTRY")"
+"$PY_BIN" - "$C6_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["agent_count"] == 0, f"expected 0 agents (all orphan), got {payload['agent_count']}"
+assert payload["problem_count"] == 0, f"orphans must not drive problem_count, got {payload['problem_count']}"
+assert payload["orphan_directory_count"] == 2, payload["orphan_directory_count"]
+# sorted() in list_agent_dirs guarantees deterministic ordering.
+assert payload["orphan_directories"] == ["bar", "foo"], payload["orphan_directories"]
+assert payload["agents"] == [], payload["agents"]
+PY
+
+# --- C7: all-registered, no orphans -------------------------------------
+# Refs queue #4796 codex PR #941 r1 BLOCKING: every disk dir is in the
+# registry. The orphan bucket must be empty and the registered agents
+# must be scanned through the normal drift classifier — well-formed rows
+# are ok, drift-shaped rows still surface as warn/error (the
+# pre-existing drift detection path is preserved).
+smoke_log "C7: all-registered agents/ → N agents, 0 orphans"
+C7_ROOT="$SMOKE_TMP_ROOT/c7-agents"
+mkdir -p "$C7_ROOT"
+# Well-formed agent → expected status=ok.
+seed_well_formed_agent "$C7_ROOT/foo"
+# Drift-shaped agent (missing required files) → expected status=error so
+# we prove the registered-agent drift path still fires when warranted.
+mkdir -p "$C7_ROOT/baz"
+C7_REGISTRY="$SMOKE_TMP_ROOT/c7-registry.json"
+cat >"$C7_REGISTRY" <<'EOF'
+[
+  {"id": "foo", "class": "static", "agent_source": "static"},
+  {"id": "baz", "class": "static", "agent_source": "static"}
+]
+EOF
+C7_JSON="$(run_watchdog scan --json --agent-home-root "$C7_ROOT" --agent-registry-json "$C7_REGISTRY")"
+"$PY_BIN" - "$C7_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+agent_ids = sorted(row["agent"] for row in payload["agents"])
+assert agent_ids == ["baz", "foo"], f"expected both registered agents scanned, got {agent_ids}"
+assert payload["agent_count"] == 2, payload["agent_count"]
+assert payload["orphan_directory_count"] == 0, payload["orphan_directory_count"]
+assert payload["orphan_directories"] == [], payload["orphan_directories"]
+# Drift classifier must still react to the bare `baz` dir (missing every
+# required file → error). This confirms the registry filter is a
+# pre-scan gate, not a drift-detector bypass.
+rows = {row["agent"]: row for row in payload["agents"]}
+assert rows["foo"]["status"] == "ok", rows["foo"]
+assert rows["baz"]["status"] == "error", rows["baz"]
+assert payload["problem_count"] == 1, f"expected 1 problem (baz drift), got {payload['problem_count']}"
+PY
+
+smoke_log "PASS"


### PR DESCRIPTION
## Summary
- Watchdog enumerated `$BRIDGE_HOME/agents/` directly, so any orphan dir under that root (smoke-test leak, manual `mkdir`, retired-agent home not yet quarantined) surfaced as a `profile_drift` warn. Operator host saw 10/18 noise alerts on 2026-05-17 — none of those names were in `agent registry --json` or the roster.
- Anchor the default enumeration on `agent registry --json` (same source of truth that `bridge-doctor.py`'s orphan-agent-dir detector uses). Dirs on disk not in the registry surface in a new `orphan_directories` JSON bucket instead of driving drift alerts.
- New smoke `scripts/smoke/watchdog-registry-anchored.sh` covers 4 cases (registry-anchored default, `--no-registry-anchored`, explicit-arg bypass, registry-lookup-failure fallback).

## Backward compatibility
- `agent-bridge watchdog scan <agent>` explicit args bypass the registry filter — existing `scripts/smoke-test.sh` assertions (lines 5266 / 5288 / 5301) keep passing.
- Registry lookup failures (missing `agent-bridge` binary, broken endpoint, malformed JSON) fall back to the legacy listing-only walk with a stderr breadcrumb — the watchdog never goes silent.
- `--no-registry-anchored` flag restores the pre-fix behavior on demand.
- Daemon consumers (`bridge-daemon.sh:bridge_watchdog_problem_key`, `bridge-daemon-helpers.py:watchdog-problem-count`) read `problem_count` and `agents[]` only — both unchanged. Only new keys (`orphan_directory_count`, `orphan_directories`) are added.

## Test plan
- [x] `python3 -c "import py_compile; py_compile.compile('bridge-watchdog.py', doraise=True)"`
- [x] `bash -n bridge-watchdog.sh scripts/smoke/watchdog-registry-anchored.sh`
- [x] `shellcheck bridge-watchdog.sh scripts/smoke/watchdog-registry-anchored.sh`
- [x] `bash scripts/smoke/watchdog-registry-anchored.sh` — C1/C2/C3/C4 all PASS
- [x] Manual repro of operator scenario: isolated `BRIDGE_HOME` with 1 registered agent + 1 orphan dir → registered scanned (problem_count=0), orphan surfaces in `orphan_directories=['smoke-orphan']`

Refs queue task #4796 (NO close-keyword — operator decides when to close).