### PR TITLE
fix(agent): GC orphaned inbox tasks on agent delete --orphan-tasks (refs #4797)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3363,8 +3363,11 @@ PY
 # managed-role block from agent-roster.local.sh. Trust model mirrors
 # run_update (admin agent identity + operator-trusted source). Safety
 # gates: refuse if agent missing, refuse self-delete of admin, refuse
-# active session without --force, refuse open inbox tasks without
-# --orphan-tasks. Optional --purge-home / --purge-crons cleanup.
+# active session without --force, refuse open inbox tasks (queued /
+# claimed / blocked) without --orphan-tasks. With --orphan-tasks every
+# open row assigned to the agent is closed to status `cancelled` with
+# closed_ts set (refs #4797) so the row stops counting in `agb task
+# summary`. Optional --purge-home / --purge-crons cleanup.
 run_delete() {
   local agent=""
   local from_agent=""
@@ -3523,7 +3526,7 @@ PY
     fi
     [[ "$open_count" =~ ^[0-9]+$ ]] || open_count=0
     if [[ "$open_count" -gt 0 && $orphan_tasks -eq 0 ]]; then
-      deny_reason="agent '$agent' has $open_count open inbox task(s) — pass --orphan-tasks to mark them blocked"
+      deny_reason="agent '$agent' has $open_count open inbox task(s) — pass --orphan-tasks to close them"
     fi
   fi
 
@@ -3570,24 +3573,12 @@ PY
 
     if [[ $json_output -eq 1 ]]; then
       bridge_require_python
+      # Footgun #11: invoke the JSON formatter via file-as-argv (not
+      # heredoc-stdin) so the dry-run path does not wedge Bash 5.3.9.
       AGENT="$agent" CALLER_SOURCE="$caller_source" OPEN_COUNT="$open_count" \
       ORPHAN_TASKS="$orphan_tasks" PURGE_HOME="$purge_home" PURGE_CRONS="$purge_crons" \
-      python3 - <<'PY'
-import json
-import os
-
-payload = {
-    "agent": os.environ["AGENT"],
-    "deleted": False,
-    "dry_run": True,
-    "purge_home": os.environ["PURGE_HOME"] == "1",
-    "purge_crons": os.environ["PURGE_CRONS"] == "1",
-    "orphan_tasks": os.environ["ORPHAN_TASKS"] == "1",
-    "open_inbox_tasks": int(os.environ["OPEN_COUNT"] or 0),
-    "caller_source": os.environ["CALLER_SOURCE"],
-}
-print(json.dumps(payload, ensure_ascii=False, indent=2))
-PY
+      DELETED=0 DRY_RUN=1 BEFORE_SHA="" AFTER_SHA="" \
+        python3 "$SCRIPT_DIR/lib/agent-cli-helpers/delete-result-json.py"
     else
       printf 'agent: %s\n' "$agent"
       printf 'deleted: no\n'
@@ -3606,96 +3597,40 @@ PY
 
   if [[ $orphan_tasks -eq 1 && "$open_count" -gt 0 && -f "$BRIDGE_TASK_DB" ]]; then
     bridge_require_python
-    local _orphan_err
+    local _orphan_err _orphan_note _orphan_helper
     _orphan_err="$(mktemp "${TMPDIR:-/tmp}/agb-orphan-err.XXXXXX")"
-    if ! python3 - "$BRIDGE_TASK_DB" "$agent" "agent retired via 'agent delete'" <<'PY' 2>"$_orphan_err"
-import sqlite3
-import sys
-import time
-
-db_path, agent, note = sys.argv[1], sys.argv[2], sys.argv[3]
-now_ts = int(time.time())
-conn = sqlite3.connect(db_path)
-try:
-    with conn:
-        rows = conn.execute(
-            """
-            SELECT id FROM tasks
-            WHERE assigned_to = ?
-              AND status IN ('queued', 'claimed')
-              AND title NOT LIKE '[cron-dispatch]%'
-            """,
-            (agent,),
-        ).fetchall()
-        for (task_id,) in rows:
-            # `blocked` is an open status (bridge-queue.py:22), so leave
-            # closed_ts untouched — only cancelled/done set it. Restrict
-            # the UPDATE WHERE to the same queued/claimed set so already
-            # blocked rows are not redundantly bumped (idempotent).
-            conn.execute(
-                """
-                UPDATE tasks
-                SET status = 'blocked', updated_ts = ?
-                WHERE id = ?
-                  AND status IN ('queued', 'claimed')
-                  AND title NOT LIKE '[cron-dispatch]%'
-                """,
-                (now_ts, task_id),
-            )
-            conn.execute(
-                """
-                INSERT INTO task_events (
-                  task_id, event_type, actor, created_ts, note_text,
-                  note_path, from_agent, to_agent
-                ) VALUES (?, 'blocked', 'agent-delete', ?, ?, NULL, NULL, ?)
-                """,
-                (task_id, now_ts, note, agent),
-            )
-finally:
-    conn.close()
-PY
-    then
+    # Completion note format (refs #4797): include agent name and the
+    # operator-facing trigger so `agb task show <id>` after a ghost GC
+    # surfaces *why* the row was closed without reading the audit log.
+    _orphan_note="agent ${agent} deleted, task orphaned by --orphan-tasks"
+    _orphan_helper="$SCRIPT_DIR/lib/agent-cli-helpers/orphan-tasks-gc.py"
+    # Footgun #11: do NOT feed this body via `python3 - <<'PY' … PY`.
+    # The previous implementation used a heredoc-stdin and deadlocked
+    # Bash 5.3.9 `heredoc_write` the moment any caller exercised the
+    # orphan-tasks branch, leaving every --orphan-tasks invocation hung
+    # before the SQL ran. Standalone helper invoked file-as-argv keeps
+    # the path off the broken surface (same precedent as
+    # lib/upgrade-helpers/recorded-source-root.py and
+    # lib/agent-cli-helpers/registry-format-json.py).
+    if ! python3 "$_orphan_helper" "$BRIDGE_TASK_DB" "$agent" "$_orphan_note" 2>"$_orphan_err"; then
       local _orphan_err_text
       _orphan_err_text="$(cat "$_orphan_err" 2>/dev/null || true)"
       rm -f "$_orphan_err"
-      bridge_die "agent delete: failed to mark inbox tasks blocked for '$agent'${_orphan_err_text:+ ($_orphan_err_text)}"
+      bridge_die "agent delete: failed to cancel orphaned inbox tasks for '$agent'${_orphan_err_text:+ ($_orphan_err_text)}"
     fi
     rm -f "$_orphan_err"
   fi
 
   # Remove the managed-role block from the roster file. Same regex the
   # block writer in bridge_write_role_block uses, with re.sub("") to
-  # excise instead of replace.
-  bridge_agent_manage_python "$roster_path" "$agent" >/dev/null <<'PY'
-from pathlib import Path
-import re
-import sys
-
-path = Path(sys.argv[1])
-agent = sys.argv[2]
-text = path.read_text(encoding="utf-8")
-begin = f"# BEGIN AGENT BRIDGE MANAGED ROLE: {agent}"
-end = f"# END AGENT BRIDGE MANAGED ROLE: {agent}"
-if begin not in text or end not in text:
-    raise SystemExit(f"managed block not found for {agent}: {path}")
-pattern = re.compile(
-    rf"^# BEGIN AGENT BRIDGE MANAGED ROLE: {re.escape(agent)}\n.*?^# END AGENT BRIDGE MANAGED ROLE: {re.escape(agent)}\n?",
-    flags=re.MULTILINE | re.DOTALL,
-)
-# Mirror bridge-agent.sh:717 — verify the regex matches before writing.
-# subn returns (new_text, count); refuse to write unless exactly one
-# managed block was excised.
-new_text, count = pattern.subn("", text, count=1)
-if count != 1:
-    raise SystemExit(
-        f"managed block not found or matched {count} times for {agent}: {path}"
-    )
-text = new_text
-# Collapse the triple-newline left behind by block removal (cosmetic).
-text = re.sub(r"\n{3,}", "\n\n", text)
-path.write_text(text, encoding="utf-8")
-print(path)
-PY
+  # excise instead of replace. Helper is invoked file-as-argv (not
+  # heredoc-stdin) to dodge the Bash 5.3.9 `heredoc_write` deadlock
+  # documented in KNOWN_ISSUES.md §26 (footgun #11). Same shape as
+  # PR #940's registry/list/show extraction.
+  bridge_require_python
+  python3 "$SCRIPT_DIR/lib/agent-cli-helpers/roster-excise-block.py" \
+    "$roster_path" "$agent" >/dev/null \
+    || bridge_die "agent delete: failed to excise managed-role block for '$agent' from $roster_path"
 
   # Issue #4795: drop the daemon's auto-start backoff state file for this
   # agent so the daemon's next sync tick does not log a spurious
@@ -3841,27 +3776,12 @@ PY
 
   if [[ $json_output -eq 1 ]]; then
     bridge_require_python
+    # Footgun #11: invoke the JSON formatter via file-as-argv (not
+    # heredoc-stdin) so the apply path does not wedge Bash 5.3.9.
     AGENT="$agent" CALLER_SOURCE="$caller_source" OPEN_COUNT="$open_count" \
     ORPHAN_TASKS="$orphan_tasks" PURGE_HOME="$purge_home" PURGE_CRONS="$purge_crons" \
-    BEFORE_SHA="$before_sha" AFTER_SHA="$after_sha" \
-    python3 - <<'PY'
-import json
-import os
-
-payload = {
-    "agent": os.environ["AGENT"],
-    "deleted": True,
-    "dry_run": False,
-    "purge_home": os.environ["PURGE_HOME"] == "1",
-    "purge_crons": os.environ["PURGE_CRONS"] == "1",
-    "orphan_tasks": os.environ["ORPHAN_TASKS"] == "1",
-    "open_inbox_tasks": int(os.environ["OPEN_COUNT"] or 0),
-    "caller_source": os.environ["CALLER_SOURCE"],
-    "before_sha": os.environ["BEFORE_SHA"],
-    "after_sha": os.environ["AFTER_SHA"],
-}
-print(json.dumps(payload, ensure_ascii=False, indent=2))
-PY
+    DELETED=1 DRY_RUN=0 BEFORE_SHA="$before_sha" AFTER_SHA="$after_sha" \
+      python3 "$SCRIPT_DIR/lib/agent-cli-helpers/delete-result-json.py"
   else
     printf 'agent: %s\n' "$agent"
     printf 'deleted: yes\n'

--- a/lib/agent-cli-helpers/audit-detail-json.py
+++ b/lib/agent-cli-helpers/audit-detail-json.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""audit-detail-json.py — build the `system_config_mutation` detail JSON
+that `bridge_agent_update_emit_audit` writes to the audit log when the
+agent CRUD subcommands (`agent update`, `agent delete`, future
+`agent reclassify`) emit deny / dry-run / apply rows.
+
+Invocation contract (positional, all required, all may be empty
+strings):
+    sys.argv[1]  = trigger_label (e.g. agent-update-apply,
+                   agent-delete-apply, agent-delete-deny,
+                   agent-delete-dry-run)
+    sys.argv[2]  = actor (caller agent id or "operator")
+    sys.argv[3]  = actor_source (operator-tui / operator-trusted-id /
+                   unknown)
+    sys.argv[4]  = target_agent
+    sys.argv[5]  = roster path
+    sys.argv[6]  = before_sha (sha256 of roster pre-mutation)
+    sys.argv[7]  = after_sha  (sha256 post-mutation; empty for deny)
+    sys.argv[8]  = operation (e.g. update / delete / reclassify)
+    sys.argv[9]  = reason (deny reason; empty when apply)
+    sys.argv[10] = before_launch_cmd
+    sys.argv[11] = after_launch_cmd
+    sys.argv[12] = before_channels
+    sys.argv[13] = after_channels
+    sys.argv[14] = actions_json (JSON array literal; empty/invalid is
+                   coerced to [])
+
+Output: a single JSON object on stdout, matching the wrapper-apply /
+wrapper-deny detail shape that `bridge-config.py:cmd_set` writes for
+config-set rows. This is the same shape `agent-bridge audit verify`
+already accepts for agent-update.
+
+Refs:
+    - Footgun #11 / KNOWN_ISSUES.md §26: the body used to live as
+      `python3 - … <<'PY' … PY` inside a `$()` capture in
+      bridge_agent_update_emit_audit. Bash 5.3.9 `heredoc_write`
+      deadlocked the moment any CRUD subcommand emitted an audit row,
+      so the unregistered agent-update / agent-delete smokes never ran
+      to completion on Bash 5.3.9 hosts. Standalone helper invoked
+      file-as-argv keeps the path off the broken surface, same
+      precedent as PR #940's registry/list/show extraction.
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    # 14 payload args + script name == 15.
+    if len(sys.argv) != 15:
+        print(
+            "usage: audit-detail-json.py "
+            "<trigger> <actor> <actor_source> <target_agent> <path> "
+            "<before_sha> <after_sha> <operation> <reason> "
+            "<before_launch_cmd> <after_launch_cmd> "
+            "<before_channels> <after_channels> <actions_json>",
+            file=sys.stderr,
+        )
+        return 2
+
+    (
+        trigger,
+        actor,
+        actor_source,
+        target_agent,
+        path,
+        before_sha,
+        after_sha,
+        operation,
+        reason,
+        before_launch_cmd,
+        after_launch_cmd,
+        before_channels,
+        after_channels,
+        actions_json,
+    ) = sys.argv[1:]
+
+    detail = {
+        "kind": "system_config_mutation",
+        "actor": actor,
+        "actor_source": actor_source,
+        "trigger": trigger,
+        "path": path,
+        "before_sha256": before_sha,
+        "operation": operation,
+        "matched_pattern": "agent-roster.local.sh",
+        "target_agent": target_agent,
+        "before_launch_cmd": before_launch_cmd,
+        "after_launch_cmd": after_launch_cmd,
+        "before_channels": before_channels,
+        "after_channels": after_channels,
+    }
+    if after_sha:
+        detail["after_sha256"] = after_sha
+    if reason:
+        detail["reason"] = reason
+    try:
+        detail["actions"] = json.loads(actions_json) if actions_json else []
+    except (TypeError, ValueError):
+        detail["actions"] = []
+
+    print(json.dumps(detail, ensure_ascii=True, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/agent-cli-helpers/delete-result-json.py
+++ b/lib/agent-cli-helpers/delete-result-json.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""delete-result-json.py — render the `agent-bridge agent delete --json`
+result envelope. Used by both the dry-run and apply branches in
+`run_delete`.
+
+Invocation contract (all required, all read from os.environ — same
+shape as the original inline heredoc to avoid touching every caller):
+    AGENT
+    DELETED          ("0" | "1")
+    DRY_RUN          ("0" | "1")
+    PURGE_HOME       ("0" | "1")
+    PURGE_CRONS      ("0" | "1")
+    ORPHAN_TASKS     ("0" | "1")
+    OPEN_COUNT       (str(int))
+    CALLER_SOURCE
+    BEFORE_SHA       (apply-only; "" on dry-run)
+    AFTER_SHA        (apply-only; "" on dry-run)
+
+Output: one JSON object on stdout. Mirrors the historical inline
+payload exactly so on-disk parsers and the e2e harness see no schema
+drift.
+
+Refs:
+    - Footgun #11 / KNOWN_ISSUES.md §26: the previous implementation
+      used `python3 - <<'PY' … PY` heredoc-stdin. Standalone file
+      invoked file-as-argv (zero positional args — payload is via
+      env) keeps the path off the broken Bash 5.3.9 surface.
+"""
+
+import json
+import os
+import sys
+
+
+def _flag(name: str) -> bool:
+    return os.environ.get(name, "0") == "1"
+
+
+def main() -> int:
+    payload = {
+        "agent": os.environ["AGENT"],
+        "deleted": _flag("DELETED"),
+        "dry_run": _flag("DRY_RUN"),
+        "purge_home": _flag("PURGE_HOME"),
+        "purge_crons": _flag("PURGE_CRONS"),
+        "orphan_tasks": _flag("ORPHAN_TASKS"),
+        "open_inbox_tasks": int(os.environ.get("OPEN_COUNT") or 0),
+        "caller_source": os.environ["CALLER_SOURCE"],
+    }
+    before_sha = os.environ.get("BEFORE_SHA", "")
+    after_sha = os.environ.get("AFTER_SHA", "")
+    if before_sha or after_sha:
+        # Apply-path emits both; preserve key order parity with the old
+        # inline body (before_sha before after_sha).
+        payload["before_sha"] = before_sha
+        payload["after_sha"] = after_sha
+
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/agent-cli-helpers/orphan-tasks-gc.py
+++ b/lib/agent-cli-helpers/orphan-tasks-gc.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""orphan-tasks-gc.py — close every open queue row assigned to an agent
+that is being deleted via `agent-bridge agent delete <name> --orphan-tasks`.
+
+Invocation contract:
+    sys.argv[1] = path to BRIDGE_TASK_DB (SQLite file).
+    sys.argv[2] = agent name (matches tasks.assigned_to).
+    sys.argv[3] = completion note to attach to each emitted task_event row.
+
+Behavior:
+    For every row in `tasks` where assigned_to=<agent> and status IN
+    ('queued', 'claimed', 'blocked') and title NOT LIKE
+    '[cron-dispatch]%', update status to terminal `cancelled` with
+    claimed_by/claimed_ts/lease_until_ts cleared and closed_ts populated
+    (mirrors the cancel path in bridge-queue.py). Insert a `cancelled`
+    task_event with actor='agent-delete' carrying the supplied note so
+    `agb task show <id>` and the audit timeline both record *why* the
+    row closed. Idempotent: rows already in a terminal status are
+    skipped by the WHERE clause.
+
+Refs:
+    - queue task #4797: before this code path the orphan path marked
+      rows `blocked` (an open status, see bridge-queue.py:22). That left
+      ghost agents accumulating in `agb task summary` for weeks.
+    - Footgun #11 / KNOWN_ISSUES.md §26: this body used to live as a
+      `python3 - … <<'PY' … PY` heredoc-stdin inline in bridge-agent.sh.
+      The Bash 5.3.9 `heredoc_write` deadlock wedged the orphan-tasks
+      branch the moment any caller exercised it. Moved to a standalone
+      file invoked with file-as-argv to remove the heredoc-stdin path,
+      same precedent as lib/upgrade-helpers/recorded-source-root.py and
+      lib/agent-cli-helpers/registry-format-json.py.
+"""
+
+import sqlite3
+import sys
+import time
+
+
+def main() -> int:
+    if len(sys.argv) < 4:
+        print(
+            "usage: orphan-tasks-gc.py <db_path> <agent> <note>",
+            file=sys.stderr,
+        )
+        return 2
+
+    db_path = sys.argv[1]
+    agent = sys.argv[2]
+    note = sys.argv[3]
+    now_ts = int(time.time())
+
+    conn = sqlite3.connect(db_path)
+    try:
+        with conn:
+            rows = conn.execute(
+                """
+                SELECT id FROM tasks
+                WHERE assigned_to = ?
+                  AND status IN ('queued', 'claimed', 'blocked')
+                  AND title NOT LIKE '[cron-dispatch]%'
+                """,
+                (agent,),
+            ).fetchall()
+            for (task_id,) in rows:
+                conn.execute(
+                    """
+                    UPDATE tasks
+                    SET status = 'cancelled',
+                        claimed_by = NULL,
+                        claimed_ts = NULL,
+                        lease_until_ts = NULL,
+                        updated_ts = ?,
+                        closed_ts = ?
+                    WHERE id = ?
+                      AND status IN ('queued', 'claimed', 'blocked')
+                      AND title NOT LIKE '[cron-dispatch]%'
+                    """,
+                    (now_ts, now_ts, task_id),
+                )
+                conn.execute(
+                    """
+                    INSERT INTO task_events (
+                      task_id, event_type, actor, created_ts, note_text,
+                      note_path, from_agent, to_agent
+                    ) VALUES (?, 'cancelled', 'agent-delete', ?, ?, NULL, NULL, ?)
+                    """,
+                    (task_id, now_ts, note, agent),
+                )
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/agent-cli-helpers/roster-excise-block.py
+++ b/lib/agent-cli-helpers/roster-excise-block.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""roster-excise-block.py — remove the managed-role block for an agent
+from agent-roster.local.sh (or any other roster file passed by argv).
+
+Invocation contract:
+    sys.argv[1] = path to roster file (read-write).
+    sys.argv[2] = agent name (matches the BEGIN/END marker).
+
+Output: the roster path on stdout when the block was excised; raises
+SystemExit with a non-zero exit code and a stderr message when the
+BEGIN/END markers are missing or matched a non-unique count.
+
+Behavior matches the writer in bridge-agent.sh's
+`bridge_write_role_block` — the regex pins the literal markers used at
+write time, with re.sub() used to excise rather than replace. Triple
+newlines left behind by the removal are collapsed for readability.
+
+Refs:
+    - Footgun #11 / KNOWN_ISSUES.md §26: this body used to live as a
+      `bridge_agent_manage_python <args> >/dev/null <<'PY' … PY`
+      heredoc-stdin inline in `run_delete`. The Bash 5.3.9
+      `heredoc_write` deadlock wedged every `agent delete` call (even
+      without --orphan-tasks) before the roster mutation completed.
+      Standalone helper invoked file-as-argv keeps the path off the
+      broken surface, same precedent as PR #940's registry/list/show
+      helpers under lib/agent-cli-helpers/.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(
+            "usage: roster-excise-block.py <roster_path> <agent>",
+            file=sys.stderr,
+        )
+        return 2
+
+    path = Path(sys.argv[1])
+    agent = sys.argv[2]
+    text = path.read_text(encoding="utf-8")
+    begin = f"# BEGIN AGENT BRIDGE MANAGED ROLE: {agent}"
+    end = f"# END AGENT BRIDGE MANAGED ROLE: {agent}"
+    if begin not in text or end not in text:
+        print(
+            f"managed block not found for {agent}: {path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    pattern = re.compile(
+        rf"^# BEGIN AGENT BRIDGE MANAGED ROLE: {re.escape(agent)}\n.*?^# END AGENT BRIDGE MANAGED ROLE: {re.escape(agent)}\n?",
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    # Mirror bridge-agent.sh:717 — verify the regex matches exactly once
+    # before writing. subn returns (new_text, count); refuse to write
+    # unless exactly one managed block was excised.
+    new_text, count = pattern.subn("", text, count=1)
+    if count != 1:
+        print(
+            f"managed block not found or matched {count} times for {agent}: {path}",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Collapse the triple-newline left behind by block removal
+    # (cosmetic).
+    new_text = re.sub(r"\n{3,}", "\n\n", new_text)
+    path.write_text(new_text, encoding="utf-8")
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/bridge-agent-update.sh
+++ b/lib/bridge-agent-update.sh
@@ -231,8 +231,15 @@ bridge_agent_update_emit_audit() {
 
   bridge_require_python
   local detail_json
+  # Footgun #11 (KNOWN_ISSUES.md §26): this used to be `python3 - …
+  # <<'PY' … PY` inside a `$()` capture. Bash 5.3.9 `heredoc_write`
+  # deadlocks the moment any CRUD path emits an audit row, so the
+  # unregistered agent-update / agent-delete smokes never finished on
+  # the operator host. Standalone helper invoked file-as-argv removes
+  # the heredoc-stdin path; same shape PR #940 used for registry/list
+  # /show.
   detail_json="$(
-    python3 - \
+    python3 "$BRIDGE_SCRIPT_DIR/lib/agent-cli-helpers/audit-detail-json.py" \
       "$trigger_label" \
       "$actor" \
       "$actor_source" \
@@ -246,55 +253,7 @@ bridge_agent_update_emit_audit() {
       "$after_launch_cmd" \
       "$before_channels" \
       "$after_channels" \
-      "$actions_json" <<'PY'
-import json
-import sys
-
-(
-    trigger,
-    actor,
-    actor_source,
-    target_agent,
-    path,
-    before_sha,
-    after_sha,
-    operation,
-    reason,
-    before_launch_cmd,
-    after_launch_cmd,
-    before_channels,
-    after_channels,
-    actions_json,
-) = sys.argv[1:]
-
-# Mirror bridge-config.py:cmd_set's wrapper-apply / wrapper-deny detail
-# shape so end-to-end audit verification (`agent-bridge audit verify`)
-# treats agent-update rows the same way it treats config-set rows.
-detail = {
-    "kind": "system_config_mutation",
-    "actor": actor,
-    "actor_source": actor_source,
-    "trigger": trigger,
-    "path": path,
-    "before_sha256": before_sha,
-    "operation": operation,
-    "matched_pattern": "agent-roster.local.sh",
-    "target_agent": target_agent,
-    "before_launch_cmd": before_launch_cmd,
-    "after_launch_cmd": after_launch_cmd,
-    "before_channels": before_channels,
-    "after_channels": after_channels,
-}
-if after_sha:
-    detail["after_sha256"] = after_sha
-if reason:
-    detail["reason"] = reason
-try:
-    detail["actions"] = json.loads(actions_json) if actions_json else []
-except (TypeError, ValueError):
-    detail["actions"] = []
-print(json.dumps(detail, ensure_ascii=True, sort_keys=True))
-PY
+      "$actions_json"
   )"
 
   python3 "$BRIDGE_SCRIPT_DIR/bridge-audit.py" write \

--- a/scripts/smoke/agent-delete-task-gc.sh
+++ b/scripts/smoke/agent-delete-task-gc.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+# scripts/smoke/agent-delete-task-gc.sh — refs #4797.
+#
+# Before this fix, `agent-bridge agent delete <name> --orphan-tasks` left
+# every queued/claimed task assigned to the deleted agent in status
+# `blocked` (an open status). Those rows accumulated in `agb task
+# summary` for the now-defunct agent name and never aged out — the
+# operator host had 27-day-old crm-cli, 22-day admin-smoke, etc. ghost
+# rows.
+#
+# After the fix, `--orphan-tasks` closes every open row (queued /
+# claimed / blocked) assigned to the agent to terminal status
+# `cancelled` with `closed_ts` set, and emits a `cancelled` task_event
+# whose note records the trigger.
+#
+# Cases:
+#   C1. agent delete --orphan-tasks closes one queued, one claimed, one
+#       blocked task to `cancelled` with `closed_ts` populated, leaves
+#       `[cron-dispatch]%` rows untouched, and writes a `cancelled`
+#       task_event whose note mentions `--orphan-tasks`.
+#   C2. agent delete WITHOUT --orphan-tasks against an agent that has
+#       open inbox rows is denied with a clear reason and the rows are
+#       left untouched (no status change, no closed_ts).
+#   C3. agent delete --orphan-tasks against an agent that has zero open
+#       rows is a no-op on the task DB (no spurious task_events) and
+#       still removes the managed-role block from the roster.
+#
+# Isolated BRIDGE_HOME via smoke_setup_bridge_home — never touches the
+# operator's live runtime.
+
+set -euo pipefail
+
+SMOKE_NAME="agent-delete-task-gc"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+ADMIN="testadmin"
+GHOST="ghostworker"
+
+write_roster_fixture() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+BRIDGE_ADMIN_AGENT_ID=${ADMIN}
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${ADMIN}
+bridge_add_agent_id_if_missing ${ADMIN}
+BRIDGE_AGENT_DESC["${ADMIN}"]='admin role'
+BRIDGE_AGENT_ENGINE["${ADMIN}"]='claude'
+BRIDGE_AGENT_SESSION["${ADMIN}"]='${ADMIN}'
+BRIDGE_AGENT_WORKDIR["${ADMIN}"]='${BRIDGE_AGENT_HOME_ROOT}/${ADMIN}'
+BRIDGE_AGENT_SOURCE["${ADMIN}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${ADMIN}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${ADMIN}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${ADMIN}
+
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${GHOST}
+bridge_add_agent_id_if_missing ${GHOST}
+BRIDGE_AGENT_DESC["${GHOST}"]='ghost worker (about to be deleted)'
+BRIDGE_AGENT_ENGINE["${GHOST}"]='claude'
+BRIDGE_AGENT_SESSION["${GHOST}"]='${GHOST}'
+BRIDGE_AGENT_WORKDIR["${GHOST}"]='${BRIDGE_AGENT_HOME_ROOT}/${GHOST}'
+BRIDGE_AGENT_SOURCE["${GHOST}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${GHOST}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${GHOST}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${GHOST}
+EOF
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$ADMIN" "$BRIDGE_AGENT_HOME_ROOT/$GHOST"
+}
+
+# Initialize the queue schema by running a no-op task summary against the
+# isolated DB. `cmd_summary` opens the connection through `connect()`,
+# which runs CREATE TABLE IF NOT EXISTS for every queue table.
+init_task_db() {
+  python3 "$SMOKE_REPO_ROOT/bridge-queue.py" summary >/dev/null
+}
+
+# Drop every row from tasks/task_events between tests so assertions on
+# row counts are not polluted by an earlier test's residue. The schema
+# itself is left in place (cheaper than a full DB recreate).
+reset_task_db() {
+  [[ -f "$BRIDGE_TASK_DB" ]] || return 0
+  python3 - "$BRIDGE_TASK_DB" <<'PY'
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+try:
+    with conn:
+        conn.execute("DELETE FROM task_events")
+        conn.execute("DELETE FROM tasks")
+finally:
+    conn.close()
+PY
+}
+
+# Insert task rows directly via sqlite3 (Python). We hand-pick statuses so
+# the test does not depend on the wider claim/handoff state machine.
+seed_tasks_for_ghost() {
+  python3 - "$BRIDGE_TASK_DB" "$GHOST" <<'PY'
+import sqlite3
+import sys
+import time
+
+db, agent = sys.argv[1], sys.argv[2]
+now = int(time.time())
+conn = sqlite3.connect(db)
+try:
+    with conn:
+        # queued
+        conn.execute(
+            """
+            INSERT INTO tasks (title, assigned_to, created_by, priority,
+              status, created_ts, updated_ts, body_text)
+            VALUES (?, ?, 'tester', 'normal', 'queued', ?, ?, 'queued body')
+            """,
+            ("ghost queued task", agent, now, now),
+        )
+        # claimed
+        conn.execute(
+            """
+            INSERT INTO tasks (title, assigned_to, created_by, priority,
+              status, created_ts, updated_ts, body_text, claimed_by,
+              claimed_ts, lease_until_ts)
+            VALUES (?, ?, 'tester', 'normal', 'claimed', ?, ?,
+              'claimed body', ?, ?, ?)
+            """,
+            ("ghost claimed task", agent, now, now, agent, now, now + 900),
+        )
+        # blocked
+        conn.execute(
+            """
+            INSERT INTO tasks (title, assigned_to, created_by, priority,
+              status, created_ts, updated_ts, body_text)
+            VALUES (?, ?, 'tester', 'normal', 'blocked', ?, ?,
+              'blocked body')
+            """,
+            ("ghost blocked task", agent, now, now),
+        )
+        # cron-dispatch noise — must NOT be touched.
+        conn.execute(
+            """
+            INSERT INTO tasks (title, assigned_to, created_by, priority,
+              status, created_ts, updated_ts, body_text)
+            VALUES (?, ?, 'cron', 'normal', 'queued', ?, ?, 'cron body')
+            """,
+            ("[cron-dispatch] hourly", agent, now, now),
+        )
+        # already-done — must NOT be touched.
+        conn.execute(
+            """
+            INSERT INTO tasks (title, assigned_to, created_by, priority,
+              status, created_ts, updated_ts, body_text, closed_ts)
+            VALUES (?, ?, 'tester', 'normal', 'done', ?, ?, 'done body',
+              ?)
+            """,
+            ("ghost finished task", agent, now - 7200, now - 3600, now - 3600),
+        )
+finally:
+    conn.close()
+PY
+}
+
+run_delete() {
+  BRIDGE_ADMIN_AGENT_ID="$ADMIN" \
+  BRIDGE_CALLER_SOURCE="operator-tui" \
+  BRIDGE_AGENT_ID="$ADMIN" \
+    bash "$SMOKE_REPO_ROOT/bridge-agent.sh" delete "$@"
+}
+
+# Helper — count rows matching a status filter for the ghost agent.
+count_rows_by_status() {
+  local status="$1"
+  python3 - "$BRIDGE_TASK_DB" "$GHOST" "$status" <<'PY'
+import sqlite3
+import sys
+
+db, agent, status = sys.argv[1], sys.argv[2], sys.argv[3]
+conn = sqlite3.connect(db)
+try:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM tasks
+        WHERE assigned_to = ?
+          AND status = ?
+          AND title NOT LIKE '[cron-dispatch]%'
+        """,
+        (agent, status),
+    ).fetchone()
+    print(int(row[0] or 0))
+finally:
+    conn.close()
+PY
+}
+
+count_cron_rows_untouched() {
+  python3 - "$BRIDGE_TASK_DB" "$GHOST" <<'PY'
+import sqlite3
+import sys
+
+db, agent = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db)
+try:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM tasks
+        WHERE assigned_to = ?
+          AND title LIKE '[cron-dispatch]%'
+          AND status = 'queued'
+        """,
+        (agent,),
+    ).fetchone()
+    print(int(row[0] or 0))
+finally:
+    conn.close()
+PY
+}
+
+count_cancelled_events_with_note() {
+  python3 - "$BRIDGE_TASK_DB" "$GHOST" <<'PY'
+import sqlite3
+import sys
+
+db, agent = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db)
+try:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM task_events
+        WHERE event_type = 'cancelled'
+          AND actor = 'agent-delete'
+          AND to_agent = ?
+          AND note_text LIKE '%--orphan-tasks%'
+        """,
+        (agent,),
+    ).fetchone()
+    print(int(row[0] or 0))
+finally:
+    conn.close()
+PY
+}
+
+count_total_open_for_ghost_in_summary() {
+  # Mirror the queued+claimed+blocked rollup `agb task summary` performs
+  # for a single agent (bridge-queue.py:agent_summary_rows). Returns the
+  # number that would render in the dashboard.
+  python3 - "$BRIDGE_TASK_DB" "$GHOST" <<'PY'
+import sqlite3
+import sys
+
+db, agent = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db)
+try:
+    row = conn.execute(
+        """
+        SELECT COUNT(*) FROM tasks
+        WHERE assigned_to = ?
+          AND status IN ('queued', 'claimed', 'blocked')
+          AND title NOT LIKE '[cron-dispatch]%'
+        """,
+        (agent,),
+    ).fetchone()
+    print(int(row[0] or 0))
+finally:
+    conn.close()
+PY
+}
+
+# ---------------------------------------------------------------------------
+# C1 — --orphan-tasks closes every open row to `cancelled` with closed_ts.
+# ---------------------------------------------------------------------------
+test_orphan_tasks_closes_open_rows() {
+  write_roster_fixture
+  init_task_db
+  reset_task_db
+  seed_tasks_for_ghost
+
+  # Pre-conditions.
+  smoke_assert_eq "3" "$(count_total_open_for_ghost_in_summary)" \
+    "C1 pre: 3 open rows for ghost (queued+claimed+blocked, cron excluded)"
+
+  run_delete "$GHOST" --orphan-tasks --json >/dev/null
+
+  # Post-conditions: every open row gone, all three are now cancelled.
+  smoke_assert_eq "0" "$(count_total_open_for_ghost_in_summary)" \
+    "C1 post: dashboard rollup empty (no queued/claimed/blocked left)"
+  smoke_assert_eq "3" "$(count_rows_by_status cancelled)" \
+    "C1 post: queued + claimed + blocked all cancelled"
+  smoke_assert_eq "1" "$(count_cron_rows_untouched)" \
+    "C1 post: [cron-dispatch] row left untouched"
+
+  # closed_ts must be populated on every cancelled row (mirrors the
+  # cancel path in bridge-queue.py).
+  python3 - "$BRIDGE_TASK_DB" "$GHOST" <<'PY' || smoke_fail "C1: closed_ts not set on a cancelled row"
+import sqlite3
+import sys
+
+db, agent = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db)
+try:
+    rows = conn.execute(
+        """
+        SELECT id, closed_ts FROM tasks
+        WHERE assigned_to = ?
+          AND status = 'cancelled'
+          AND title NOT LIKE '[cron-dispatch]%'
+        """,
+        (agent,),
+    ).fetchall()
+    if not rows:
+        raise SystemExit("no cancelled rows for ghost")
+    for tid, closed_ts in rows:
+        if not closed_ts or int(closed_ts) <= 0:
+            raise SystemExit(f"task {tid} has empty closed_ts")
+finally:
+    conn.close()
+PY
+
+  # task_events: every cancellation emitted an audit event with a note
+  # mentioning --orphan-tasks (refs #4797 trigger string).
+  smoke_assert_eq "3" "$(count_cancelled_events_with_note)" \
+    "C1 post: three cancelled task_events with --orphan-tasks note"
+
+  # Roster block excised.
+  if grep -q "BEGIN AGENT BRIDGE MANAGED ROLE: ${GHOST}" "$BRIDGE_ROSTER_LOCAL_FILE"; then
+    smoke_fail "C1 post: ghost managed-role block was not excised"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# C2 — without --orphan-tasks, delete is refused and DB is untouched.
+# ---------------------------------------------------------------------------
+test_refuse_without_orphan_tasks_flag() {
+  write_roster_fixture
+  init_task_db
+  reset_task_db
+  seed_tasks_for_ghost
+
+  local rc=0 out
+  out="$(run_delete "$GHOST" 2>&1)" || rc=$?
+  (( rc != 0 )) || smoke_fail "C2: delete without --orphan-tasks should have failed (rc=$rc, out=$out)"
+  smoke_assert_contains "$out" "--orphan-tasks" "C2 refusal mentions --orphan-tasks remedy"
+
+  # All three open rows must still be open (none cancelled).
+  smoke_assert_eq "3" "$(count_total_open_for_ghost_in_summary)" \
+    "C2: open rows unchanged after refusal"
+  smoke_assert_eq "0" "$(count_rows_by_status cancelled)" \
+    "C2: nothing was cancelled by the refused call"
+
+  # Roster block still present.
+  grep -q "BEGIN AGENT BRIDGE MANAGED ROLE: ${GHOST}" "$BRIDGE_ROSTER_LOCAL_FILE" \
+    || smoke_fail "C2: ghost managed-role block must remain after refusal"
+}
+
+# ---------------------------------------------------------------------------
+# C3 — --orphan-tasks against an agent with no open rows is a no-op on the
+# task DB but still removes the managed-role block.
+# ---------------------------------------------------------------------------
+test_orphan_tasks_with_no_open_rows() {
+  write_roster_fixture
+  init_task_db
+  reset_task_db
+  # Intentionally do NOT seed tasks — ghost has zero rows.
+
+  run_delete "$GHOST" --orphan-tasks --json >/dev/null
+
+  smoke_assert_eq "0" "$(count_rows_by_status cancelled)" \
+    "C3: no spurious cancelled rows produced"
+  smoke_assert_eq "0" "$(count_cancelled_events_with_note)" \
+    "C3: no spurious task_events produced"
+
+  if grep -q "BEGIN AGENT BRIDGE MANAGED ROLE: ${GHOST}" "$BRIDGE_ROSTER_LOCAL_FILE"; then
+    smoke_fail "C3: ghost managed-role block was not excised"
+  fi
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_require_cmd bash
+  smoke_setup_bridge_home "agent-delete-task-gc"
+
+  smoke_run "C1 --orphan-tasks closes queued+claimed+blocked to cancelled" \
+    test_orphan_tasks_closes_open_rows
+  smoke_run "C2 refuse delete without --orphan-tasks when open rows exist" \
+    test_refuse_without_orphan_tasks_flag
+  smoke_run "C3 --orphan-tasks no-op on empty inbox still removes roster block" \
+    test_orphan_tasks_with_no_open_rows
+
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

`agent-bridge agent delete <name> --orphan-tasks` previously marked every open inbox row assigned to the agent as `blocked`. `blocked` is an open status (`bridge-queue.py:22`) so the deleted-agent row kept showing up in `agb task summary` indefinitely. Operator host had a 27-day-old `crm-cli`, 22-day `admin-smoke`, 21-day `agb-dev-codex-1`, and several smoke-fixture ghosts accumulated for weeks (refs queue task #4797).

Now every open row (queued / claimed / blocked, `[cron-dispatch]` rows excluded) is moved to terminal status `cancelled` with `closed_ts` populated — mirroring `bridge-queue.py`'s cancel path. Each transition emits a `cancelled` task_event with `actor='agent-delete'` carrying the note `\"agent <name> deleted, task orphaned by --orphan-tasks\"` so both `agb task show <id>` and the audit timeline record *why* the row closed.

### Why this PR is larger than the brief estimated

While exercising the new path I tripped a **pre-existing Bash 5.3.9 `heredoc_write` deadlock** (footgun #11, KNOWN_ISSUES.md §26) in four sites that were silent until the new smoke ran:

| Site | Shape |
| --- | --- |
| `bridge-agent.sh` `run_delete` orphan-tasks GC | `python3 - <<'PY'` (~50 LOC body) |
| `bridge-agent.sh` `run_delete` roster-block excision | `bridge_agent_manage_python … <<'PY'` |
| `lib/bridge-agent-update.sh` `bridge_agent_update_emit_audit` detail JSON | `$(python3 - … <<'PY')` |
| `bridge-agent.sh` `run_delete` apply/dry-run `--json` payload printer | `python3 - <<'PY'` |

These wedged every `agent delete` invocation on Bash 5.3.9 hosts the moment the new `--orphan-tasks` branch was exercised, so the GC work and the deadlock fix had to land together. Each body was moved to a standalone helper under `lib/agent-cli-helpers/` invoked file-as-argv — same precedent PR #940 used for `registry` / `list` / `show`.

`agent-update` (which also rides `bridge_agent_update_emit_audit`) now reaches further than it did before, but still hangs at a separate heredoc inside `bridge_agent_update_emit_json` (line 322, lib/bridge-agent-update.sh). Out of scope for this PR — flag for a follow-up cleanup.

### New helpers

- `lib/agent-cli-helpers/orphan-tasks-gc.py` — terminal close of orphaned inbox rows + `cancelled` task_event emission.
- `lib/agent-cli-helpers/roster-excise-block.py` — managed-role block removal from agent-roster.local.sh.
- `lib/agent-cli-helpers/audit-detail-json.py` — `system_config_mutation` audit detail JSON formatter (used by every CRUD path).
- `lib/agent-cli-helpers/delete-result-json.py` — `agent delete --json` result envelope (dry-run + apply paths).

### Smoke test

Adds `scripts/smoke/agent-delete-task-gc.sh` (not yet registered in `scripts/smoke-test.sh` — same staging convention as `agent-retire.sh` / `agent-update.sh`):

- **C1** — `--orphan-tasks` closes queued + claimed + blocked → `cancelled` with `closed_ts` set, leaves `[cron-dispatch]` rows untouched, emits `cancelled` task_events whose notes mention `--orphan-tasks`, excises the managed-role block.
- **C2** — `delete` WITHOUT `--orphan-tasks` against an agent with open rows is denied with a clear remedy reason; both DB rows and the roster block are left untouched.
- **C3** — `--orphan-tasks` against an agent with zero open rows is a no-op on the task DB (no spurious cancelled rows or task_events) and still removes the managed-role block.

## Test plan

- [x] `bash -n bridge-agent.sh lib/bridge-agent-update.sh scripts/smoke/agent-delete-task-gc.sh`
- [x] `shellcheck bridge-agent.sh lib/bridge-agent-update.sh && shellcheck -x scripts/smoke/agent-delete-task-gc.sh`
- [x] `python3 -m py_compile` on each new helper and on `bridge-queue.py`
- [x] `bash scripts/smoke/agent-delete-task-gc.sh` → all three cases pass against an isolated `BRIDGE_HOME` on Bash 5.3.9 (this previously hung indefinitely on `main`).
- [ ] Operator manual check — run `agb agent delete <ghost-name> --orphan-tasks` on the live host, confirm `agb task summary` no longer surfaces the deleted agent's row.

Refs #4797
Refs KNOWN_ISSUES.md §26 (footgun #11)