### PR TITLE
upgrade: clean stale BRIDGE_LAYOUT from tmux server-env + gate resolver warn (refs #4798)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1924,6 +1924,21 @@ if [[ $RESTART_DAEMON -eq 1 && $DRY_RUN -eq 0 ]]; then
   bash "$TARGET_ROOT/bridge-daemon.sh" ensure >/dev/null
 fi
 
+# Patch #4798 — tmux server-env cleanup. Pre-PR-#926 installs leaked
+# BRIDGE_LAYOUT / BRIDGE_DATA_ROOT into the tmux server's global env
+# via inheritance from the original `agent-bridge` invocation that
+# started the server. Once leaked, every new pane inherits the stale
+# value and the layout resolver fires its "stale pre-v0.8.0 env
+# override" warning on every CLI command. PR #926 stopped the export
+# prefix from re-forwarding the vars but did NOT clean the existing
+# tmux server-level entries.  `tmux setenv -u -g` is idempotent — when
+# the server has no entry the call is a no-op. Suppress all output so
+# operators without a running tmux server don't see error noise.
+if [[ $DRY_RUN -eq 0 ]] && command -v tmux >/dev/null 2>&1; then
+  tmux setenv -u -g BRIDGE_LAYOUT 2>/dev/null || true
+  tmux setenv -u -g BRIDGE_DATA_ROOT 2>/dev/null || true
+fi
+
 
 # Bug #507 — auto-cleanup of daily-backup residue on every successful
 # `agb upgrade --apply`. Idempotent; reports failures via cleanup_failures

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -168,7 +168,21 @@ bridge_layout_resolver_validate_env() {
             | sed -E "s/^[[:space:]]*BRIDGE_LAYOUT[[:space:]]*=//; s/^[\"']//; s/[\"']$//"
         )"
         if [[ "$_marker_layout" == "v2" ]]; then
-          bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc."
+          # Patch #4798: gate the warning behind a once-per-process
+          # sentinel. When the stale BRIDGE_LAYOUT lives at the tmux
+          # server-env level (operator hit by a pre-PR-#926 install
+          # that leaked it via setenv -g), every spawned child inherits
+          # the value and the resolver re-fires the warning for every
+          # `agent-bridge` / `agb` call — drowning the operator in
+          # noise. Export the sentinel so any child shell that
+          # re-sources bridge-lib.sh inside the same process tree
+          # stays quiet too; the parent upgrade flow has a one-shot
+          # `tmux setenv -u -g` cleanup that actually removes the
+          # server-level leak (bridge-upgrade.sh).
+          if [[ -z "${_BRIDGE_LAYOUT_STALE_ENV_WARNED:-}" ]]; then
+            bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc (and run \`agent-bridge upgrade --apply\` once to clear any tmux server-level leak)."
+            export _BRIDGE_LAYOUT_STALE_ENV_WARNED=1
+          fi
           BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV="BRIDGE_LAYOUT (stale ${layout} override; marker=v2)"
           unset BRIDGE_LAYOUT
           unset BRIDGE_DATA_ROOT

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10922,6 +10922,16 @@ bash "$REPO_ROOT/scripts/smoke/classify-stale-dynamic-exemption.sh"
 log "running bridge-export-prefix-no-stale-layout smoke (patch #4725)"
 bash "$REPO_ROOT/scripts/smoke/bridge-export-prefix-no-stale-layout.sh"
 
+# Companion regression to patch #4725: PR #926 stopped the bridge-core
+# export prefix from forwarding stale BRIDGE_LAYOUT/BRIDGE_DATA_ROOT,
+# but did not clean values that already lived in the tmux server's
+# GLOBAL env from pre-PR-#926 installs. Patch #4798 adds a one-shot
+# `tmux setenv -u -g` cleanup to bridge-upgrade.sh and gates the
+# resolver warning to once-per-process so transitional installs are
+# not drowned in noise. Smoke pins both halves.
+log "running tmux-server-bridge-layout-cleanup smoke (patch #4798)"
+bash "$REPO_ROOT/scripts/smoke/tmux-server-bridge-layout-cleanup.sh"
+
 # `_ENV_DUMP_PATTERNS` in hooks/tool-policy.py used to false-positive on
 # natural-language `env` and `printenv` (e.g. task titles like
 # "stale env override" denied as if they were process-env dumps). Guard

--- a/scripts/smoke/tmux-server-bridge-layout-cleanup-driver.sh
+++ b/scripts/smoke/tmux-server-bridge-layout-cleanup-driver.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# scripts/smoke/tmux-server-bridge-layout-cleanup-driver.sh —
+# child-process driver for tmux-server-bridge-layout-cleanup.sh
+# C2 check. Kept as a standalone file (per the
+# `bridge-export-prefix-no-stale-layout-driver.sh` precedent) so the
+# parent smoke does not have to embed a here-doc body that would trip
+# the Bash 5.3.9 heredoc-stdin deadlock when sample environments
+# happen to nest the smoke inside a `$(...)` capture (footgun #11).
+#
+# Usage: tmux-server-bridge-layout-cleanup-driver.sh REPO_ROOT
+# Effect: sources bridge-lib.sh, then re-sources
+#   lib/bridge-layout-resolver.sh TWICE with BRIDGE_LAYOUT=legacy in
+#   the env each time. The parent smoke greps the combined output for
+#   the resolver's stale-env warning marker to verify the
+#   `_BRIDGE_LAYOUT_STALE_ENV_WARNED` once-per-process gate holds.
+#
+# Both sources run in the SAME process so the sentinel survives.
+# Between sources the BRIDGE_LAYOUT_SOURCE / ignored-partial-env state
+# vars are blanked so the resolver re-enters the env-override branch
+# and would re-emit the warning if the gate were missing.
+
+# Bash 4+ re-exec — bridge-lib.sh requires declare -g + assoc arrays.
+_DRIVER_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_DRIVER_TARGET" ]]; then
+    for cand in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$cand" && -x "$cand" ]] || continue
+      if "$cand" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$cand" "$_DRIVER_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke-driver:tmux-server-bridge-layout-cleanup] needs Bash 4+." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+REPO_ROOT="${1:?REPO_ROOT required}"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/bridge-lib.sh"
+
+# Re-source the resolver with a freshly-primed stale env value, twice.
+# The first call must emit the warning; the second must not.
+BRIDGE_LAYOUT_SOURCE=""
+BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV=""
+export BRIDGE_LAYOUT=legacy
+# shellcheck source=/dev/null
+source "$REPO_ROOT/lib/bridge-layout-resolver.sh"
+
+echo "----second-source----"
+
+BRIDGE_LAYOUT_SOURCE=""
+BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV=""
+export BRIDGE_LAYOUT=legacy
+# shellcheck source=/dev/null
+source "$REPO_ROOT/lib/bridge-layout-resolver.sh"

--- a/scripts/smoke/tmux-server-bridge-layout-cleanup.sh
+++ b/scripts/smoke/tmux-server-bridge-layout-cleanup.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# scripts/smoke/tmux-server-bridge-layout-cleanup.sh — regression for
+# patch ticket #4798 (2026-05-17). Pre-PR-#926 installs leaked
+# BRIDGE_LAYOUT / BRIDGE_DATA_ROOT into the tmux server's GLOBAL env
+# via the original `agent-bridge` invocation's environment inheritance
+# at tmux server startup. Once leaked, every new pane inherits the
+# stale value and the layout resolver fires its
+#   `[경고] BRIDGE_LAYOUT=legacy is a stale pre-v0.8.0 env override; ...`
+# warning on every CLI command. PR #926 stopped the export prefix from
+# re-forwarding the vars, but did NOT clean the existing tmux server-
+# level entries; the operator saw the warning on every `agb`/`agent-
+# bridge` invocation until they restarted the tmux server by hand.
+#
+# This test pins two contracts:
+#
+#   C1: a v2 install on a host that has tmux available will, on
+#       upgrade `--apply`, issue `tmux setenv -u -g BRIDGE_LAYOUT`
+#       (and the same for BRIDGE_DATA_ROOT). The actual upgrade flow
+#       is not exercised end-to-end (that requires a live install); we
+#       instead verify the cleanup snippet itself by seeding a private
+#       tmux server, setting the stale vars on it, running the same
+#       `tmux setenv -u -g` calls the upgrader runs, and asserting
+#       they are gone.
+#
+#   C2: the layout resolver warning is gated by a once-per-process
+#       sentinel (`_BRIDGE_LAYOUT_STALE_ENV_WARNED`). Even when
+#       BRIDGE_LAYOUT=legacy is set in the env and a valid v2 marker
+#       is on disk, sourcing the resolver twice in the same process
+#       only emits the warning once.
+
+# Bash 4+ re-exec — sourcing the resolver needs declare -g and
+# associative arrays. Mirror the prelude used by sibling smokes.
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:tmux-server-bridge-layout-cleanup] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="tmux-server-bridge-layout-cleanup"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+failed=0
+
+# ---------------------------------------------------------------------------
+# C1: tmux server-env cleanup snippet actually unsets the stale vars.
+# ---------------------------------------------------------------------------
+# We run the SAME `tmux setenv -u -g BRIDGE_LAYOUT|BRIDGE_DATA_ROOT` calls
+# bridge-upgrade.sh runs, against a private tmux server we seed with the
+# stale values. If tmux isn't available on the host (CI minimal image),
+# skip C1 — the snippet's `command -v tmux` guard already makes it a no-op
+# in that case, and the upgrader path is unreachable without tmux.
+TMUX_SOCKET_DIR=""
+TMUX_SOCKET_NAME=""
+if ! command -v tmux >/dev/null 2>&1; then
+  echo "  SKIP  C1: tmux not available on host (snippet is no-op without tmux)"
+else
+  TMUX_SOCKET_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-smoke-tmux.XXXXXX")"
+  TMUX_SOCKET_NAME="agb-smoke-$$"
+
+  # `start-server` doesn't allocate a real session — but `setenv -g`
+  # requires a running server. Seed with a detached session that has no
+  # window-side effects.
+  if ! tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+        new-session -d -s smoke -x 80 -y 24 'sleep 60' >/dev/null 2>&1; then
+    echo "  SKIP  C1: could not start a private tmux server (host restriction)"
+  else
+    tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+      setenv -g BRIDGE_LAYOUT legacy
+    tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+      setenv -g BRIDGE_DATA_ROOT /tmp/should-not-survive
+
+    # Sanity: vars are present before cleanup.
+    pre_layout="$(tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+      show-environment -g BRIDGE_LAYOUT 2>/dev/null || true)"
+    if [[ "$pre_layout" != "BRIDGE_LAYOUT=legacy" ]]; then
+      echo "  FAIL  C1 setup: expected BRIDGE_LAYOUT=legacy on the test server, got '$pre_layout'" >&2
+      failed=1
+    fi
+
+    # Apply the same cleanup the upgrader runs.
+    tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+      setenv -u -g BRIDGE_LAYOUT 2>/dev/null || true
+    tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+      setenv -u -g BRIDGE_DATA_ROOT 2>/dev/null || true
+
+    post_layout="$(tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+      show-environment -g BRIDGE_LAYOUT 2>/dev/null || true)"
+    post_data_root="$(tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+      show-environment -g BRIDGE_DATA_ROOT 2>/dev/null || true)"
+
+    # `show-environment -g <name>` on an unset var prints `-<name>` on
+    # current tmux versions (the "removed-from-server" sentinel) or an
+    # empty line on very old tmuxes. Either is a pass for our purposes;
+    # what must NOT show up is `<name>=<value>`.
+    if [[ "$post_layout" == BRIDGE_LAYOUT=* ]]; then
+      echo "  FAIL  C1: BRIDGE_LAYOUT still set on tmux server after cleanup (got '$post_layout')" >&2
+      failed=1
+    else
+      echo "  PASS  C1: BRIDGE_LAYOUT removed from tmux server-env"
+    fi
+
+    if [[ "$post_data_root" == BRIDGE_DATA_ROOT=* ]]; then
+      echo "  FAIL  C1: BRIDGE_DATA_ROOT still set on tmux server after cleanup (got '$post_data_root')" >&2
+      failed=1
+    else
+      echo "  PASS  C1: BRIDGE_DATA_ROOT removed from tmux server-env"
+    fi
+
+    # Idempotency: running the cleanup a second time with the vars
+    # already unset must not error.
+    if ! tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" \
+          setenv -u -g BRIDGE_LAYOUT 2>/dev/null; then
+      echo "  WARN  C1: second 'tmux setenv -u -g' returned non-zero; snippet swallows this via '|| true', but the call is documented as idempotent."
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# C2: layout resolver warning is gated to once per process.
+# ---------------------------------------------------------------------------
+# Seed a fake $BRIDGE_HOME with a valid v2 marker, point the env at it,
+# then source bridge-lib.sh twice from a single child shell while the
+# stale BRIDGE_LAYOUT=legacy is in the env. The first source must emit
+# the `stale pre-v0.8.0` warning; the second source must NOT.
+
+C2_HOME="$(mktemp -d "${TMPDIR:-/tmp}/agb-smoke-c2.XXXXXX")"
+C2_OUT="$(mktemp "${TMPDIR:-/tmp}/agb-c2-out.XXXXXX")"
+trap '
+  rm -rf "$C2_HOME"
+  rm -f "$C2_OUT"
+  if [[ -n "${TMUX_SOCKET_NAME:-}" && -n "${TMUX_SOCKET_DIR:-}" ]]; then
+    tmux -L "$TMUX_SOCKET_NAME" -S "$TMUX_SOCKET_DIR/sock" kill-server 2>/dev/null || true
+    rm -rf "$TMUX_SOCKET_DIR"
+  fi
+' EXIT
+mkdir -p "$C2_HOME/state" "$C2_HOME/agents" "$C2_HOME/data"
+
+# Write a valid v2 marker. Owner must be the current UID (resolver
+# rejects markers owned by anyone else), mode must have no group/world
+# write bits. Built via printf rather than a `cat >file <<EOF` heredoc
+# to stay outside footgun #11's reach when this smoke gets invoked
+# from inside a $(...) capture.
+MARKER="$C2_HOME/state/layout-marker.sh"
+printf 'BRIDGE_LAYOUT=v2\nBRIDGE_DATA_ROOT=%s\n' "'$C2_HOME/data'" >"$MARKER"
+chmod 0640 "$MARKER"
+
+# Existing-install evidence (tasks.db) so the resolver does NOT classify
+# this fake home as fresh-install-candidate and demand the bypass.
+: >"$C2_HOME/state/tasks.db"
+
+C2_DRIVER="$SCRIPT_DIR/tmux-server-bridge-layout-cleanup-driver.sh"
+if [[ ! -x "$C2_DRIVER" ]]; then
+  echo "  FAIL  C2: missing driver: $C2_DRIVER" >&2
+  exit 2
+fi
+
+# Run the driver with the fake home; capture combined stdout+stderr.
+# Unset any inherited sentinel so the first source sees a virgin slate.
+env -u _BRIDGE_LAYOUT_STALE_ENV_WARNED \
+  BRIDGE_HOME="$C2_HOME" \
+  BRIDGE_LAYOUT_MARKER_DIR="$C2_HOME/state" \
+  BRIDGE_LAYOUT=legacy \
+  "$C2_DRIVER" "$REPO_ROOT" >"$C2_OUT" 2>&1 || {
+  echo "  FAIL  C2 driver exited non-zero. Output:" >&2
+  sed 's/^/    /' "$C2_OUT" >&2
+  failed=1
+}
+
+# Count the "stale pre-v0.8.0" warning occurrences. The marker text is
+# stable in the resolver. We accept both Korean `[경고]` prefix and the
+# raw English snippet because terminals stripping ANSI / UTF8 in CI
+# could mangle the prefix.
+warn_count="$(grep -c 'stale pre-v0\.8\.0 env override' "$C2_OUT" || true)"
+if [[ "$warn_count" -eq 1 ]]; then
+  echo "  PASS  C2: stale-env warning emitted exactly once across two resolver sources"
+elif [[ "$warn_count" -eq 0 ]]; then
+  echo "  FAIL  C2: stale-env warning was NOT emitted on first source (gate over-fired)" >&2
+  sed 's/^/    /' "$C2_OUT" >&2
+  failed=1
+else
+  echo "  FAIL  C2: stale-env warning emitted $warn_count time(s) — gate did not hold" >&2
+  sed 's/^/    /' "$C2_OUT" >&2
+  failed=1
+fi
+
+if (( failed )); then
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] all checks passed"


### PR DESCRIPTION
## Summary
- Adds tmux server-env cleanup (`tmux setenv -u -g BRIDGE_LAYOUT|BRIDGE_DATA_ROOT`) to `bridge-upgrade.sh`'s post-daemon-restart phase so pre-PR-#926 installs stop drowning the operator in `[경고] BRIDGE_LAYOUT=legacy is a stale pre-v0.8.0 env override` on every CLI command.
- Gates that resolver warning behind a once-per-process sentinel (`_BRIDGE_LAYOUT_STALE_ENV_WARNED`) so transitional installs (between upgrade-apply runs) see it once instead of per-invocation, and updates the message to point operators at `agent-bridge upgrade --apply` to clear the tmux server-level leak.
- New regression smoke `scripts/smoke/tmux-server-bridge-layout-cleanup.sh` (+ standalone driver) pinning both halves end-to-end.

## Background
Patch task #4798: operator's shell rc had no `BRIDGE_LAYOUT`, but every `agent-bridge` / `agb` command still warned. Root cause: the tmux SERVER's global env still carried `BRIDGE_LAYOUT=legacy` from the original pre-PR-#926 invocation that started it. PR #926 stopped the export prefix from re-forwarding the vars, but never cleaned what the server already had. Every new pane inherited the stale value via tmux env-inheritance and the resolver re-fired the warning per command.

Companion to PR #926. Together: PR #926 stops the leak source; this PR cleans the existing leak and gates the warning.

## Changes

| File | Change |
|------|--------|
| `bridge-upgrade.sh` | +15 LOC: after `bridge-daemon.sh ensure`, run `tmux setenv -u -g BRIDGE_LAYOUT` / `BRIDGE_DATA_ROOT` (idempotent — no-op when tmux is missing or the server has no entry). |
| `lib/bridge-layout-resolver.sh` | +16 / -1 LOC: gate the stale-env `bridge_warn` behind `_BRIDGE_LAYOUT_STALE_ENV_WARNED` (exported), updated message tells operators to run `agent-bridge upgrade --apply`. |
| `scripts/smoke/tmux-server-bridge-layout-cleanup.sh` (new) | C1: seed a private tmux server, run the same `tmux setenv -u -g` calls, assert vars are removed. C2: source the resolver twice with `BRIDGE_LAYOUT=legacy` priming each time, assert the warning fires exactly once. |
| `scripts/smoke/tmux-server-bridge-layout-cleanup-driver.sh` (new) | Standalone driver for the C2 child source — kept separate per the footgun #11 anti-pattern (no embedded heredoc-stdin in subprocess capture contexts). Same shape as `bridge-export-prefix-no-stale-layout-driver.sh`. |
| `scripts/smoke-test.sh` | Wires the new smoke next to PR #926's sibling. |

## Verification
```
$ bash -n bridge-upgrade.sh lib/bridge-layout-resolver.sh \
    scripts/smoke/tmux-server-bridge-layout-cleanup.sh \
    scripts/smoke/tmux-server-bridge-layout-cleanup-driver.sh \
    scripts/smoke-test.sh
# PASS (all 5 files)

$ /opt/homebrew/bin/shellcheck bridge-upgrade.sh lib/bridge-layout-resolver.sh \
    scripts/smoke/tmux-server-bridge-layout-cleanup.sh \
    scripts/smoke/tmux-server-bridge-layout-cleanup-driver.sh
# PASS (clean)

$ bash scripts/smoke/tmux-server-bridge-layout-cleanup.sh
[smoke:tmux-server-bridge-layout-cleanup] starting
  PASS  C1: BRIDGE_LAYOUT removed from tmux server-env
  PASS  C1: BRIDGE_DATA_ROOT removed from tmux server-env
  PASS  C2: stale-env warning emitted exactly once across two resolver sources
[smoke:tmux-server-bridge-layout-cleanup] all checks passed
```

Full `./scripts/smoke-test.sh` was attempted but timed out at 540s long before reaching the new entry — consistent with the pre-existing slow-suite footprint (the sibling `bridge-export-prefix-no-stale-layout` smoke also hangs in some invocation contexts on this host, an unrelated environment trap). The new smoke runs cleanly via the same `bash "$REPO_ROOT/scripts/smoke/..."` shape `smoke-test.sh` uses.

## Notes
- High-risk surface: touches `bridge-upgrade.sh` (upgrade path is in the project doc's "high-risk" list) and `lib/bridge-layout-resolver.sh`. The new tmux block is fully guarded by `command -v tmux >/dev/null` and `$DRY_RUN -eq 0`, with `|| true` on each `setenv -u -g`. The resolver gate is purely additive — same warning text, same conditions, just a sentinel check.
- No VERSION / CHANGELOG bump (stabilization PR per operator policy 2026-05-15).
- Parallel fixers in flight (#4795 daemon area / #4796 / #4797): no overlapping files.

Refs #4798. NOT a close-keyword — the patch task tracks both this fix and follow-up operator-host verification.
