### PR TITLE
fix(smoke): export v2 layout for auto-isolated BRIDGE_HOME so matrix runs past step 266 (#946)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -25,6 +25,12 @@ if [[ -z "${BRIDGE_HOME:-}" ]]; then
   BRIDGE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/agb-smoke-isolated.XXXXXX")/.agent-bridge"
   export BRIDGE_HOME
   _SMOKE_AUTO_ISOLATED=1
+  # r5 (codex PR #947 r4) — export so child bash -s blocks see it.
+  # Without export, the conditional refresh blocks at line ~1148 and ~1330
+  # in child shells see _SMOKE_AUTO_ISOLATED as empty and never re-derive
+  # BRIDGE_DATA_ROOT, so pending-attention state ends up under the initial
+  # auto-isolated home outside $scratch / $TMP_ROOT.
+  export _SMOKE_AUTO_ISOLATED
   printf '[smoke] BRIDGE_HOME auto-isolated to %s (was unset)\n' "$BRIDGE_HOME"
   # #946: when the smoke matrix runs against an auto-isolated fresh
   # temp BRIDGE_HOME, every child shell that sources bridge-lib.sh

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1150,6 +1150,14 @@ export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
 export BRIDGE_ACTIVE_AGENT_DIR="$BRIDGE_STATE_DIR/agents"
 export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
 export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
+# #946 r3 — match BRIDGE_DATA_ROOT to the new scratch home so v2-derived
+# paths (BRIDGE_AGENT_ROOT_V2 etc.) inside any bridge-lib.sh source that
+# follows write under $scratch instead of the auto-isolated home from
+# line 44. Only refresh under the auto-isolation contract — operator-
+# supplied BRIDGE_HOME keeps full control of layout state.
+if [[ "${_SMOKE_AUTO_ISOLATED:-0}" == "1" ]]; then
+  export BRIDGE_DATA_ROOT="$BRIDGE_HOME/data"
+fi
 agent="spool-test"
 
 # Round-trip escape/unescape over the four escape classes.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -40,6 +40,14 @@ if [[ -z "${BRIDGE_HOME:-}" ]]; then
   # behavior of v0.14.1 fresh installs. Only applied for the auto-
   # isolated path — when the caller exports BRIDGE_HOME (CI runner,
   # custom rig) they remain responsible for layout state.
+  # r4 (codex PR #947 r3) — unset derived v2 roots that bridge-isolation-v2.sh
+  # preserves via the ${VAR:-default} idiom. Without unsetting, an operator
+  # shell that already exported these (e.g. an Agent Bridge-managed admin
+  # session running smoke against this checkout) would let later helpers
+  # write runtime/shared/state under the LIVE install despite the auto-
+  # isolated BRIDGE_HOME. Unsetting forces bridge-isolation-v2.sh to
+  # recompute from the freshly set BRIDGE_DATA_ROOT.
+  unset BRIDGE_AGENT_ROOT_V2 BRIDGE_SHARED_ROOT BRIDGE_CONTROLLER_STATE_ROOT
   export BRIDGE_LAYOUT="v2"
   export BRIDGE_DATA_ROOT="$BRIDGE_HOME/data"
 fi
@@ -1156,6 +1164,8 @@ export BRIDGE_SHARED_DIR="$BRIDGE_HOME/shared"
 # line 44. Only refresh under the auto-isolation contract — operator-
 # supplied BRIDGE_HOME keeps full control of layout state.
 if [[ "${_SMOKE_AUTO_ISOLATED:-0}" == "1" ]]; then
+  # r4 (PR #947 r3) — same derived-root reset as the auto-isolation block.
+  unset BRIDGE_AGENT_ROOT_V2 BRIDGE_SHARED_ROOT BRIDGE_CONTROLLER_STATE_ROOT
   export BRIDGE_DATA_ROOT="$BRIDGE_HOME/data"
 fi
 agent="spool-test"
@@ -1346,6 +1356,8 @@ export BRIDGE_HOME="$TMP_ROOT/bridge-home"
 # that operator-supplied BRIDGE_HOME (CI runner / custom rig) keeps full
 # control of layout state.
 if [[ "${_SMOKE_AUTO_ISOLATED:-0}" == "1" ]]; then
+  # r4 (PR #947 r3) — same derived-root reset as the auto-isolation block.
+  unset BRIDGE_AGENT_ROOT_V2 BRIDGE_SHARED_ROOT BRIDGE_CONTROLLER_STATE_ROOT
   export BRIDGE_DATA_ROOT="$BRIDGE_HOME/data"
 fi
 export BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1329,6 +1329,17 @@ SPOOL_UT
 
 TMP_ROOT="$(cd "$(mktemp -d)" && pwd -P)"
 export BRIDGE_HOME="$TMP_ROOT/bridge-home"
+# #946 r2 — refresh BRIDGE_DATA_ROOT when BRIDGE_HOME is reassigned mid-script.
+# Without this re-export, the auto-isolation block's BRIDGE_DATA_ROOT (line 44)
+# still pointed at the obsolete `agb-smoke-isolated.../data` tree, so v2 paths
+# such as BRIDGE_AGENT_ROOT_V2 derived under bridge-lib.sh would escape
+# $TMP_ROOT and cleanup would miss the state files. Only refresh when the
+# auto-isolation path armed v2 in the first place — preserves the contract
+# that operator-supplied BRIDGE_HOME (CI runner / custom rig) keeps full
+# control of layout state.
+if [[ "${_SMOKE_AUTO_ISOLATED:-0}" == "1" ]]; then
+  export BRIDGE_DATA_ROOT="$BRIDGE_HOME/data"
+fi
 export BRIDGE_ALLOW_EPHEMERAL_CONTROLLER_ENV=1
 # Issue #403 fix #4: pin the isolated-user home root under TMP_ROOT so any
 # inner test path that builds `<root>/<os_user>/.agent-bridge` cannot

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -26,6 +26,22 @@ if [[ -z "${BRIDGE_HOME:-}" ]]; then
   export BRIDGE_HOME
   _SMOKE_AUTO_ISOLATED=1
   printf '[smoke] BRIDGE_HOME auto-isolated to %s (was unset)\n' "$BRIDGE_HOME"
+  # #946: when the smoke matrix runs against an auto-isolated fresh
+  # temp BRIDGE_HOME, every child shell that sources bridge-lib.sh
+  # would otherwise be classified as `fresh-install-candidate` and
+  # die at the v0.8.0 isolation hard-cut (the fresh-install bypass
+  # handshake requires the owner to be bridge-init.sh / bridge-
+  # bootstrap.sh / agent-bridge — smoke is none of those). Export
+  # an explicit v2 layout override so resolver step 1 (env) wins
+  # and the matrix can actually run. macOS platform discriminator
+  # skips the v2 isolation enforcement (no `ab-shared` group), so
+  # the override is safe; on Linux without v2 primitives the same
+  # discriminator silently skips enforcement, matching the auto
+  # behavior of v0.14.1 fresh installs. Only applied for the auto-
+  # isolated path — when the caller exports BRIDGE_HOME (CI runner,
+  # custom rig) they remain responsible for layout state.
+  export BRIDGE_LAYOUT="v2"
+  export BRIDGE_DATA_ROOT="$BRIDGE_HOME/data"
 fi
 if [[ -n "${BRIDGE_HOME:-}" ]]; then
   _smoke_allowed_tmp_prefix=""
@@ -282,11 +298,23 @@ EOF
 # operator-shell defaults would silently steer bridge-run.sh at the live
 # roster and the test would be a no-op (or worse, an env-pollution false
 # pass against unrelated agents).
+#
+# Explicit BRIDGE_LAYOUT=v2 + BRIDGE_DATA_ROOT take resolver step 1 (env
+# override) so the dummy agent-roster.local.sh written above does not trip
+# bridge_layout_resolver_has_existing_evidence — that would classify the
+# fresh temp dir as `markerless(existing-install)` and silently kill the
+# entire smoke matrix here via the v0.8.0 isolation hard-cut (#946). The
+# evidence-based fail-fast still protects real installs; this is the
+# correct shape for an isolated dry-run probe whose only on-disk artifact
+# is the roster definition the test itself wrote.
 LAUNCH_DRYRUN_OUTPUT="$(env -u BRIDGE_ROSTER_FILE -u BRIDGE_ROSTER_LOCAL_FILE \
   -u BRIDGE_STATE_DIR -u BRIDGE_ACTIVE_AGENT_DIR -u BRIDGE_LOG_DIR \
   -u BRIDGE_SHARED_DIR -u BRIDGE_TASK_DB \
   BRIDGE_HOME="$LAUNCH_DRYRUN_HOME" \
-  "$BASH4_BIN" "$REPO_ROOT/bridge-run.sh" "dryrun-redact-smoke" --dry-run 2>&1)"
+  BRIDGE_LAYOUT="v2" \
+  BRIDGE_DATA_ROOT="$LAUNCH_DRYRUN_HOME/data" \
+  "$BASH4_BIN" "$REPO_ROOT/bridge-run.sh" "dryrun-redact-smoke" --dry-run 2>&1)" \
+  || die "bridge-run.sh --dry-run probe failed (rc=$?); output: $LAUNCH_DRYRUN_OUTPUT"
 assert_contains "$LAUNCH_DRYRUN_OUTPUT" "launch=MS365_CLIENT_SECRET=***redacted***"
 assert_contains "$LAUNCH_DRYRUN_OUTPUT" "MY_API_TOKEN=***redacted***"
 # Non-secret BRIDGE_LAYOUT_MARKER_KEY must round-trip with its real value


### PR DESCRIPTION
## Summary

- `scripts/smoke-test.sh` 의 auto-isolated `BRIDGE_HOME` path 가 v0.8.0 isolation hard-cut 에 silent kill 당하는 회귀를 해소 (#946).
- 두 곳 패치: (1) top-level auto-isolation 직후 `BRIDGE_LAYOUT=v2` + `BRIDGE_DATA_ROOT` export 추가 → 모든 child shell 이 resolver step 1 (env override) 로 통과. (2) line 314 의 `bridge-run.sh --dry-run` 호출에 `|| die "..."` 추가 → 같은 silent-kill 패턴 재발 시 진단 메시지 surface.
- macOS Sequoia 15.7.3 + Bash 5.3.9 VM 에서 smoke 가 5 줄 silent exit 1 → 159 줄 (수많은 `[ok]` 통과) 까지 확장. 159 줄에서 멈춘 unrelated assertion ("smoke-agent status activity check") 은 별도 issue, 이 PR 범위 밖.

## 회귀 분석

- 이전 동작: smoke-test 가 fresh `mktemp` BRIDGE_HOME 작성 → bridge-run.sh / bridge-lib.sh 호출 → resolver 가 `markerless(fresh-install-candidate)` 또는 `markerless(existing-install)` 로 분류 → v0.8.0 hard-cut `bridge_die`. `set -e` 안 `$(...)` substitution 이 non-zero 를 catch 해서 die 메시지조차 capture 안 되고 그냥 exit 1.
- fresh-install bypass 의 handshake (`_bridge_layout_resolver_fresh_install_bypass_active`) 는 owner argv 가 `bridge-init.sh` / `bridge-bootstrap.sh` / `agent-bridge` 일 때만 통과 → smoke 가 매칭될 방법 없음.
- 결과: smoke 의 첫 substantive step (#266 redactor) 이래로 모든 step 이 skip → 회귀 catch 능력 0. 2026-05-15 v0.13.5 작업 메모리에 "pre-existing main 에서도 재현, 무관" 으로 박혀있었지만 별도 이슈 트래킹 없었음.

## 수정 셰이프

- **A) auto-isolation 안의 env override**: resolver step 1 (env) 우선 → evidence detection 안 거침. 의도된 contract 와 일치 — fresh temp dir 은 정의상 fresh install 이고 layout 을 explicit 하게 선언하는 것이 자연스러움.
- **safety**: `BRIDGE_LAYOUT=v2` 가 v2 isolation enforcement 를 invoke 하지 않음 (platform discriminator `lib/bridge-isolation-discriminator.sh` 가 macOS 에선 `ab-shared` group 부재 → silent skip, Linux 에서도 `agent-bridge migrate isolation v2 --apply` 안 한 호스트면 silent skip). v0.14.1 fresh-install 동작과 일치.
- **scope**: only auto-isolated path. 명시 BRIDGE_HOME 으로 CI runner 가 호출하면 layout 책임은 caller 에게 위임 — caller 가 마커를 미리 작성하거나 explicit override 줘야 함.

## 다른 후보와의 비교 (참고)

- **B) state/layout-marker.sh 미리 작성**: 무겁고 marker 파일 contract 와 결합 — 미래에 marker schema 바뀌면 smoke 가 깨질 risk. A 보다 fragile.
- **C) resolver evidence 함수 fine-grained 처리** ("roster only, no tasks.db/agents/" → fresh): v0.8.0 design intent (markerless = existing) 와 충돌. 운영자 호스트의 markerless install 회귀 risk. 거부.

## Test plan

- [x] `bash -n scripts/smoke-test.sh` (syntax)
- [x] macOS Sequoia 15.7.3 VM + Bash 5.3.9 에서 smoke 재실행 → 159 줄, 새 fail 은 별도 assertion (out of scope)
- [ ] Linux CI 에서 smoke 가 158+ 줄까지 진행하는지 (이전엔 silent kill 되어 main 에서도 5 줄 + exit 1 가능성)
- [ ] codex review (`agb-dev-codex` queue)

## Follow-up (이 PR 밖)

- 159 줄에서 멈춘 smoke-agent activity assertion 은 macOS-specific 인지 universal 인지 별도 진단 필요. 추정: claude/codex binary 부재로 agent spawn 이 idle 도달 못 함 — VM 환경의 한계. CI 에는 영향 없을 수 있음.
- `set -e` + `$()` silent-kill 패턴은 smoke 의 다른 substantive step 에서도 잠복 가능. 전역 `trap '...' ERR` 또는 명시적 `|| die` 보강 후보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
