### PR TITLE
fix(picker-sweep): explicit option-N send for Bypass Permissions + Auto mode warnings (#948)

### DIFF
--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -268,8 +268,24 @@ while IFS= read -r agent; do
     cap="$(_psw_capture_pane "$agent" || true)"
     matched_pattern=""
     explicit_option=""   # #948 — when set, send "N + Enter" instead of bare Enter
-    if printf '%s\n' "$cap" | grep -qE "$_PICKER_BYPASS_PERMISSIONS_ACCEPT_RE" \
-        && printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
+
+    # r4 (codex PR #949 r3) — scope explicit-option detection to the ACTIVE
+    # picker only. capture-pane returns ~25 lines of scrollback, so a
+    # fresh-install sequence (bypass accepted -> auto mode picker now showing)
+    # can have BOTH "2. Yes, I accept" (stale) and "1. Yes, and make it my
+    # default mode" (active) in the same capture. The bypass regex would win
+    # first and send option 2 into the auto-mode menu instead of option 1,
+    # and the ack would not persist across restarts. active_picker extracts
+    # only the lines of the LAST picker block (ending with the most recent
+    # tail), which is the menu actively waiting for input.
+    active_picker="$(printf '%s\n' "$cap" | awk -v tail_re="$_PICKER_TAIL_RE" '
+      $0 ~ tail_re { last = buf $0; buf = ""; next }
+      { buf = buf $0 "\n" }
+      END { if (last != "") print last }
+    ')"
+
+    if [[ -n "$active_picker" ]] \
+        && printf '%s\n' "$active_picker" | grep -qE "$_PICKER_BYPASS_PERMISSIONS_ACCEPT_RE"; then
         # Bypass Permissions warning (#948). Default cursor is "No, exit",
         # so we must EXPLICITLY send "2" to accept. Both the distinctive
         # accept line ("2. Yes, I accept") AND the canonical tail are
@@ -278,8 +294,8 @@ while IFS= read -r agent; do
         # include "No, exit".
         matched_pattern="bypass-permissions warning"
         explicit_option="2"
-    elif printf '%s\n' "$cap" | grep -qE "$_PICKER_AUTO_MODE_ACCEPT_RE" \
-        && printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
+    elif [[ -n "$active_picker" ]] \
+        && printf '%s\n' "$active_picker" | grep -qE "$_PICKER_AUTO_MODE_ACCEPT_RE"; then
         # Auto mode warning (#948). Send "1" so the mode becomes the user
         # default — next claude restart won't re-prompt. Same r3 hardening
         # as bypass — match the distinctive "Yes, and make it my default

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -285,11 +285,16 @@ while IFS= read -r agent; do
     # line that follows it. Stale text outside that window (free-prose,
     # previous picker rounds, unrelated warnings) is excluded.
     active_picker="$(printf '%s\n' "$cap" | awk -v tail_re="$_PICKER_TAIL_RE" '
-      /^[[:space:]]*WARNING:/ { start = NR; have_start = 1; have_end = 0 }
+      /^[[:space:]]*WARNING:/ { start = NR; have_start = 1; have_end = 0; bail = 0 }
       have_start && $0 ~ tail_re { end = NR; have_end = 1 }
+      # r6 (codex PR #949 r5) — if any non-blank line appears AFTER the
+      # tail, the picker has already been answered and the bottom of the
+      # pane is now showing later output. Bail; the warning+tail block in
+      # scrollback is stale and must not fire.
+      have_end && NR > end && /[^[:space:]]/ { bail = 1 }
       { lines[NR] = $0 }
       END {
-        if (have_start && have_end) {
+        if (have_start && have_end && !bail) {
           for (i = start; i <= end; i++) print lines[i]
         }
       }

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -290,14 +290,18 @@ while IFS= read -r agent; do
                 _psw_log "  send-option failed for $agent"
                 continue
             fi
+            # #948 r2 — record the actual action so the admin task body below
+            # reports the safety-sensitive explicit option, not the default
+            # "Enter". Codex PR #949 review caught the misreport.
+            unstuck_agents+=("$agent:$matched_pattern (sent option $explicit_option)")
         else
             _psw_log "PICKER detected on '$agent' ($matched_pattern) — sending Enter for default"
             if ! _psw_send_enter "$agent"; then
                 _psw_log "  send-enter failed for $agent"
                 continue
             fi
+            unstuck_agents+=("$agent:$matched_pattern (sent Enter)")
         fi
-        unstuck_agents+=("$agent:$matched_pattern")
     fi
 done < <(_psw_list_sessions)
 
@@ -314,22 +318,35 @@ if [[ -z "$NOTIFY_AGENT" ]]; then
     exit 0
 fi
 
-task_body=$(cat <<EOF
-Claude Code interactive picker auto-unstick result:
+# #948 r2 — admin task body. Rewritten to use a plain multi-line string
+# assignment (no heredoc-inside-command-substitution) so the parse path
+# stays robust across the Bash 5.3.9 + macOS shell harness contexts where
+# `$(cat <<EOF ... EOF)` with longer bodies tripped a parser edge case
+# (unexpected EOF while looking for matching backtick-paren). Backslash-
+# escaped quotes keep the body readable while staying within standard
+# double-quoted string rules.
+task_body="Claude Code interactive picker auto-unstick result:
 
 $joined
 
-Each session was advanced via the default option (Enter). The default for
-rate-limit pickers is "Stop and wait for limit to reset" (safest); the default
-for resume-from-summary is "Resume from summary (recommended)".
+Each entry shows the agent, picker pattern, and the actual action taken
+(\"sent Enter\" for default-option pickers, \"sent option N\" for explicit
+picks). The explicit-option path is used for safety-sensitive prompts
+(e.g., Bypass Permissions warning, Auto mode warning - refs #948) where the
+default cursor would EXIT Claude rather than accept; sweeper sends the
+documented \"accept\" option (option 2 for Bypass Permissions, option 1 for
+Auto mode \"make default\").
+
+For default-Enter pickers: rate-limit pickers default to \"Stop and wait
+for limit to reset\" (safest); resume-from-summary defaults to
+\"Resume from summary (recommended)\".
 
 This cron is best-effort. If the same agent shows up across multiple sweeps,
-investigate manually — repeated picker hits usually indicate a deeper
-plan-level issue (rate limit window saturated, broken summary, etc).
+investigate manually - repeated picker hits usually indicate a deeper
+plan-level issue (rate limit window saturated, broken summary, etc.) or
+that the explicit-option ack did not persist across claude restarts.
 
-log: $LOG
-EOF
-)
+log: $LOG"
 
 if ! _psw_create_task \
         "[picker-sweep] ${#unstuck_agents[@]} agent(s) auto-unstuck from interactive picker" \

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -172,16 +172,26 @@ _PICKER_CODEX_CONFIRM_RE='^[[:space:]]*Press enter to continue[[:space:]]*$'
 # to accept. The warning is emitted whenever launch_cmd uses
 # `--dangerously-skip-permissions` (agent-bridge's static admin contract)
 # and the user/machine hasn't acked it yet.
-_PICKER_BYPASS_PERMISSIONS_RE='^[[:space:]]*(❯[[:space:]]*)?[12]\.[[:space:]]+(No, exit|Yes, I accept)[[:space:]]*$'
+#
+# r3 — key the matcher off the DISTINCTIVE "Yes, I accept" line, not the
+# generic "No, exit" / "1. No, exit". Codex PR #949 r2 review caught that
+# matching on the generic option could false-positive on any other Claude
+# warning whose menu also offered "No, exit", causing the sweeper to send
+# a safety-sensitive "2" against an unrelated prompt. Requiring the
+# accept-option line ensures we only fire on the actual Bypass warning.
+_PICKER_BYPASS_PERMISSIONS_ACCEPT_RE='^[[:space:]]*(❯[[:space:]]*)?2\.[[:space:]]+Yes, I accept[[:space:]]*$'
 
 # #948 — Auto mode warning. 3-option picker:
 #   1. Yes, and make it my default mode
 #   2. Yes, enable auto mode (just this once)
 #   3. No, exit
 # Default cursor is on option 1. Send "1" + Enter so subsequent claude
-# restarts don't re-prompt and crash-loop the agent. This is the variant
-# the operator preference suggested in #948 ("auto mode 사용할 수 있는지").
-_PICKER_AUTO_MODE_RE='^[[:space:]]*(❯[[:space:]]*)?[123]\.[[:space:]]+(Yes, and make it my default mode|Yes, enable auto mode|No, exit)[[:space:]]*$'
+# restarts don't re-prompt and crash-loop the agent.
+#
+# r3 — key the matcher off the DISTINCTIVE "Yes, and make it my default
+# mode" line, not the generic "No, exit". Same false-positive guard as the
+# bypass regex above.
+_PICKER_AUTO_MODE_ACCEPT_RE='^[[:space:]]*(❯[[:space:]]*)?1\.[[:space:]]+Yes, and make it my default mode[[:space:]]*$'
 
 # ---------------------------------------------------------------------------
 # Test seams. The smoke replaces these with fixture-driven wrappers.
@@ -258,17 +268,22 @@ while IFS= read -r agent; do
     cap="$(_psw_capture_pane "$agent" || true)"
     matched_pattern=""
     explicit_option=""   # #948 — when set, send "N + Enter" instead of bare Enter
-    if printf '%s\n' "$cap" | grep -qE "$_PICKER_BYPASS_PERMISSIONS_RE" \
+    if printf '%s\n' "$cap" | grep -qE "$_PICKER_BYPASS_PERMISSIONS_ACCEPT_RE" \
         && printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
         # Bypass Permissions warning (#948). Default cursor is "No, exit",
-        # so we must EXPLICITLY send "2" to accept. Tail-required to avoid
-        # false-positive on free-prose contexts (docs / logs / PR bodies).
+        # so we must EXPLICITLY send "2" to accept. Both the distinctive
+        # accept line ("2. Yes, I accept") AND the canonical tail are
+        # required — r3 hardening (codex PR #949 r2) ensures we don't
+        # false-positive on any other Claude warning that happens to
+        # include "No, exit".
         matched_pattern="bypass-permissions warning"
         explicit_option="2"
-    elif printf '%s\n' "$cap" | grep -qE "$_PICKER_AUTO_MODE_RE" \
+    elif printf '%s\n' "$cap" | grep -qE "$_PICKER_AUTO_MODE_ACCEPT_RE" \
         && printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
         # Auto mode warning (#948). Send "1" so the mode becomes the user
-        # default — next claude restart won't re-prompt.
+        # default — next claude restart won't re-prompt. Same r3 hardening
+        # as bypass — match the distinctive "Yes, and make it my default
+        # mode" line, not the generic "No, exit".
         matched_pattern="auto-mode warning"
         explicit_option="1"
     elif printf '%s\n' "$cap" | grep -qE "$_PICKER_OPTION_LINE_RE"; then

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -143,13 +143,16 @@ fi
 #     shape from Claude's numbered picker (single confirmation line, no
 #     options). Has its own regex below (_PICKER_CODEX_CONFIRM_RE).
 #
-# NOT added (intentionally):
+# 2026-05-17 additions (#948 — fresh-install spawn crash-loop):
 #   - "Yes, I accept" / "No, exit" (Bypass Permissions warning) — Claude's
-#     default cursor is on "No, exit" (option 1). A bare Enter would EXIT
-#     Claude on first launch. Needs explicit "send 2 + Enter" support
-#     before adding. Operator must accept this warning interactively
-#     once per host; the result is persisted in Claude Code's local
-#     settings so subsequent launches skip the warning.
+#     default cursor is on "No, exit" (option 1). Bare Enter would EXIT
+#     Claude. Now handled via _PICKER_BYPASS_PERMISSIONS_RE +
+#     explicit "send 2 + Enter" through the new option-N send mechanism
+#     (BRIDGE_PICKER_SWEEP_SEND_OPTION_FN seam below).
+#   - Auto mode warning ("Yes, and make it my default mode" /
+#     "Yes, enable auto mode" / "No, exit") — same pattern. Sweeper sends
+#     option 1 (make-default) so subsequent claude restarts don't re-prompt
+#     and crash-loop the agent.
 # ---------------------------------------------------------------------------
 
 _PICKER_OPTION_LINE_RE='^[[:space:]]*(❯[[:space:]]*)?[0-9]+\.[[:space:]]+(Stop and wait for limit to reset|Switch to extra usage|Switch to Team plan|Resume from summary \(recommended\)|Resume full session as-is|I am using this for local development)[[:space:]]*$'
@@ -162,6 +165,23 @@ _PICKER_TAIL_RE='^[[:space:]]*Enter to confirm · Esc to cancel[[:space:]]*$'
 # was blocked at the cwd-confirm prompt during the v0.13.x → v0.14.1
 # upgrade supervise flow.
 _PICKER_CODEX_CONFIRM_RE='^[[:space:]]*Press enter to continue[[:space:]]*$'
+
+# #948 — Bypass Permissions warning. Claude CLI default cursor is on
+# "No, exit" (option 1), so bare Enter would EXIT Claude on first launch
+# in a fresh install / fresh user account. Must explicitly send "2" + Enter
+# to accept. The warning is emitted whenever launch_cmd uses
+# `--dangerously-skip-permissions` (agent-bridge's static admin contract)
+# and the user/machine hasn't acked it yet.
+_PICKER_BYPASS_PERMISSIONS_RE='^[[:space:]]*(❯[[:space:]]*)?[12]\.[[:space:]]+(No, exit|Yes, I accept)[[:space:]]*$'
+
+# #948 — Auto mode warning. 3-option picker:
+#   1. Yes, and make it my default mode
+#   2. Yes, enable auto mode (just this once)
+#   3. No, exit
+# Default cursor is on option 1. Send "1" + Enter so subsequent claude
+# restarts don't re-prompt and crash-loop the agent. This is the variant
+# the operator preference suggested in #948 ("auto mode 사용할 수 있는지").
+_PICKER_AUTO_MODE_RE='^[[:space:]]*(❯[[:space:]]*)?[123]\.[[:space:]]+(Yes, and make it my default mode|Yes, enable auto mode|No, exit)[[:space:]]*$'
 
 # ---------------------------------------------------------------------------
 # Test seams. The smoke replaces these with fixture-driven wrappers.
@@ -187,6 +207,18 @@ _psw_default_send_enter() {
     tmux send-keys -t "$target" Enter 2>/dev/null
 }
 
+# #948 — send an explicit option number followed by Enter. Used for pickers
+# whose default cursor lands on a destructive option (e.g., Bypass Permissions
+# warning defaults to "No, exit"). The send is split into two calls so the
+# digit input is committed before Enter fires it — tmux send-keys collapses
+# adjacent string args, and a stray "2Enter" literal can confuse the TUI.
+# shellcheck disable=SC2329 # invoked indirectly via $_PSW_*_FN below
+_psw_default_send_option() {
+    local target="$1" option_num="$2"
+    tmux send-keys -t "$target" "$option_num" 2>/dev/null && \
+        tmux send-keys -t "$target" Enter 2>/dev/null
+}
+
 # shellcheck disable=SC2329 # invoked indirectly via $_PSW_*_FN below
 _psw_default_create_task() {
     local title="$1" body="$2" recipient="$3"
@@ -202,11 +234,13 @@ _psw_default_create_task() {
 _PSW_LIST_SESSIONS_FN="${BRIDGE_PICKER_SWEEP_LIST_SESSIONS_FN:-_psw_default_list_sessions}"
 _PSW_CAPTURE_PANE_FN="${BRIDGE_PICKER_SWEEP_CAPTURE_PANE_FN:-_psw_default_capture_pane}"
 _PSW_SEND_ENTER_FN="${BRIDGE_PICKER_SWEEP_SEND_ENTER_FN:-_psw_default_send_enter}"
+_PSW_SEND_OPTION_FN="${BRIDGE_PICKER_SWEEP_SEND_OPTION_FN:-_psw_default_send_option}"
 _PSW_CREATE_TASK_FN="${BRIDGE_PICKER_SWEEP_CREATE_TASK_FN:-_psw_default_create_task}"
 
 _psw_list_sessions() { "$_PSW_LIST_SESSIONS_FN"; }
 _psw_capture_pane()  { "$_PSW_CAPTURE_PANE_FN"  "$@"; }
 _psw_send_enter()    { "$_PSW_SEND_ENTER_FN"    "$@"; }
+_psw_send_option()   { "$_PSW_SEND_OPTION_FN"   "$@"; }
 _psw_create_task()   { "$_PSW_CREATE_TASK_FN"   "$@"; }
 
 # ---------------------------------------------------------------------------
@@ -223,7 +257,21 @@ while IFS= read -r agent; do
 
     cap="$(_psw_capture_pane "$agent" || true)"
     matched_pattern=""
-    if printf '%s\n' "$cap" | grep -qE "$_PICKER_OPTION_LINE_RE"; then
+    explicit_option=""   # #948 — when set, send "N + Enter" instead of bare Enter
+    if printf '%s\n' "$cap" | grep -qE "$_PICKER_BYPASS_PERMISSIONS_RE" \
+        && printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
+        # Bypass Permissions warning (#948). Default cursor is "No, exit",
+        # so we must EXPLICITLY send "2" to accept. Tail-required to avoid
+        # false-positive on free-prose contexts (docs / logs / PR bodies).
+        matched_pattern="bypass-permissions warning"
+        explicit_option="2"
+    elif printf '%s\n' "$cap" | grep -qE "$_PICKER_AUTO_MODE_RE" \
+        && printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
+        # Auto mode warning (#948). Send "1" so the mode becomes the user
+        # default — next claude restart won't re-prompt.
+        matched_pattern="auto-mode warning"
+        explicit_option="1"
+    elif printf '%s\n' "$cap" | grep -qE "$_PICKER_OPTION_LINE_RE"; then
         if printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
             matched_pattern="picker option line + tail"
         else
@@ -236,10 +284,18 @@ while IFS= read -r agent; do
     fi
 
     if [[ -n "$matched_pattern" ]]; then
-        _psw_log "PICKER detected on '$agent' ($matched_pattern) — sending Enter for default"
-        if ! _psw_send_enter "$agent"; then
-            _psw_log "  send-enter failed for $agent"
-            continue
+        if [[ -n "$explicit_option" ]]; then
+            _psw_log "PICKER detected on '$agent' ($matched_pattern) — sending option $explicit_option + Enter"
+            if ! _psw_send_option "$agent" "$explicit_option"; then
+                _psw_log "  send-option failed for $agent"
+                continue
+            fi
+        else
+            _psw_log "PICKER detected on '$agent' ($matched_pattern) — sending Enter for default"
+            if ! _psw_send_enter "$agent"; then
+                _psw_log "  send-enter failed for $agent"
+                continue
+            fi
         fi
         unstuck_agents+=("$agent:$matched_pattern")
     fi

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -269,19 +269,30 @@ while IFS= read -r agent; do
     matched_pattern=""
     explicit_option=""   # #948 — when set, send "N + Enter" instead of bare Enter
 
-    # r4 (codex PR #949 r3) — scope explicit-option detection to the ACTIVE
-    # picker only. capture-pane returns ~25 lines of scrollback, so a
-    # fresh-install sequence (bypass accepted -> auto mode picker now showing)
-    # can have BOTH "2. Yes, I accept" (stale) and "1. Yes, and make it my
-    # default mode" (active) in the same capture. The bypass regex would win
-    # first and send option 2 into the auto-mode menu instead of option 1,
-    # and the ack would not persist across restarts. active_picker extracts
-    # only the lines of the LAST picker block (ending with the most recent
-    # tail), which is the menu actively waiting for input.
+    # r4 (codex PR #949 r3) + r5 (codex PR #949 r4) — scope explicit-option
+    # detection to the ACTIVE picker block ONLY. capture-pane returns ~25
+    # lines of scrollback, so two false-positive shapes need defending:
+    #   r4 case — stale bypass accept line + active auto picker in same
+    #             capture: bypass regex would win and send option 2 into
+    #             the auto menu (= "just this once" instead of "make
+    #             default"), ack would not persist.
+    #   r5 case — stale "2. Yes, I accept" in free-text (above an unrelated
+    #             active picker that ends with the canonical tail): would
+    #             fire bypass branch and send option 2 into the unrelated
+    #             menu (safety-sensitive false-positive).
+    # active_picker now extracts only lines between the MOST RECENT
+    # WARNING header (the canonical menu opener) and the MOST RECENT tail
+    # line that follows it. Stale text outside that window (free-prose,
+    # previous picker rounds, unrelated warnings) is excluded.
     active_picker="$(printf '%s\n' "$cap" | awk -v tail_re="$_PICKER_TAIL_RE" '
-      $0 ~ tail_re { last = buf $0; buf = ""; next }
-      { buf = buf $0 "\n" }
-      END { if (last != "") print last }
+      /^[[:space:]]*WARNING:/ { start = NR; have_start = 1; have_end = 0 }
+      have_start && $0 ~ tail_re { end = NR; have_end = 1 }
+      { lines[NR] = $0 }
+      END {
+        if (have_start && have_end) {
+          for (i = start; i <= end; i++) print lines[i]
+        }
+      }
     ')"
 
     if [[ -n "$active_picker" ]] \

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -311,17 +311,27 @@ while IFS= read -r agent; do
       }
     ')"
 
+    # r8 (codex PR #949 r7) — require the active picker to contain the
+    # bypass-specific or auto-mode-specific discriminator text in addition
+    # to the accept-option line. Without this, a different WARNING: picker
+    # that happens to include "2. Yes, I accept" in its options would fire
+    # the bypass branch and send a safety-sensitive 2 into an unrelated
+    # menu. Discriminators:
+    #   bypass: "Bypass Permissions mode"
+    #   auto:   "Auto mode" | "auto mode" | "Enable auto mode"
     if [[ -n "$active_picker" ]] \
+        && printf '%s\n' "$active_picker" | grep -q "Bypass Permissions mode" \
         && printf '%s\n' "$active_picker" | grep -qE "$_PICKER_BYPASS_PERMISSIONS_ACCEPT_RE"; then
         # Bypass Permissions warning (#948). Default cursor is "No, exit",
-        # so we must EXPLICITLY send "2" to accept. Both the distinctive
-        # accept line ("2. Yes, I accept") AND the canonical tail are
-        # required — r3 hardening (codex PR #949 r2) ensures we don't
-        # false-positive on any other Claude warning that happens to
-        # include "No, exit".
+        # so we must EXPLICITLY send "2" to accept. r8 requires BOTH the
+        # canonical "Bypass Permissions mode" discriminator text AND the
+        # accept-option line. r3 hardening (codex PR #949 r2) ensures we
+        # don't false-positive on warnings that share "No, exit". r5/r6
+        # active_picker extraction excludes stale text.
         matched_pattern="bypass-permissions warning"
         explicit_option="2"
     elif [[ -n "$active_picker" ]] \
+        && printf '%s\n' "$active_picker" | grep -qE "(Auto mode|auto mode|Enable auto mode)" \
         && printf '%s\n' "$active_picker" | grep -qE "$_PICKER_AUTO_MODE_ACCEPT_RE"; then
         # Auto mode warning (#948). Send "1" so the mode becomes the user
         # default — next claude restart won't re-prompt. Same r3 hardening

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -285,12 +285,23 @@ while IFS= read -r agent; do
     # line that follows it. Stale text outside that window (free-prose,
     # previous picker rounds, unrelated warnings) is excluded.
     active_picker="$(printf '%s\n' "$cap" | awk -v tail_re="$_PICKER_TAIL_RE" '
-      /^[[:space:]]*WARNING:/ { start = NR; have_start = 1; have_end = 0; bail = 0 }
+      # r7 (codex PR #949 r6) — accept multiple header forms because Claude
+      # CLI may render the auto-mode confirmation with a title other than
+      # the literal "WARNING:" token (e.g. "Enable auto mode?!"). Headers
+      # we anchor on:
+      #   - "WARNING:" — canonical bypass + current auto (claude 2.1.143)
+      #   - "Enable auto mode" — hypothetical alternate auto title
+      #   - "Bypass Permissions mode" — hypothetical alternate bypass title
+      # Each header opens a new picker block. The previous r4-r6 contract is
+      # preserved: emit only when a tail line follows the header AND no
+      # non-blank content appears below the tail.
+      /^[[:space:]]*(WARNING:|Enable auto mode|Bypass Permissions mode)/ {
+        start = NR; have_start = 1; have_end = 0; bail = 0
+      }
       have_start && $0 ~ tail_re { end = NR; have_end = 1 }
-      # r6 (codex PR #949 r5) — if any non-blank line appears AFTER the
-      # tail, the picker has already been answered and the bottom of the
-      # pane is now showing later output. Bail; the warning+tail block in
-      # scrollback is stale and must not fire.
+      # r6 (codex PR #949 r5) — bail when the picker has been answered:
+      # any non-blank line after the tail means the bottom of the pane is
+      # now showing later output, not the prompt.
       have_end && NR > end && /[^[:space:]]/ { bail = 1 }
       { lines[NR] = $0 }
       END {

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -225,7 +225,7 @@ smoke_assert_contains "$(cat "$SEND_LOG")" "stuck-agent" "4 send target"
 smoke_assert_eq "1" "$(grep -c "^---$" "$TASK_LOG" || true)" "4 one task"
 smoke_assert_contains "$(cat "$TASK_LOG")" "recipient=admin" "4 task recipient"
 smoke_assert_contains "$(cat "$TASK_LOG")" "1 agent(s) auto-unstuck" "4 task title"
-smoke_assert_contains "$(cat "$TASK_LOG")" "stuck-agent:picker option line" "4 task body lists agent"
+smoke_assert_contains "$(cat "$TASK_LOG")" "stuck-agent:picker option line + tail (sent Enter)" "4 task body lists agent + action"
 
 # ---------------------------------------------------------------------------
 # Test 5 — Tail-only (no option line) must be REJECTED.
@@ -370,7 +370,7 @@ run_sweep
 smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "10 no bare-Enter send (would EXIT Claude)"
 smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "10 one option send"
 smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "bypass-agent:option=2" "10 send option=2 (Yes I accept)"
-smoke_assert_contains "$(cat "$TASK_LOG")" "bypass-agent:bypass-permissions warning" "10 task body identifies pattern"
+smoke_assert_contains "$(cat "$TASK_LOG")" "bypass-agent:bypass-permissions warning (sent option 2)" "10 task body records explicit option send"
 
 # ---------------------------------------------------------------------------
 # Test 11 — Auto mode warning (#948). 3-option picker; send option 1 so the
@@ -394,7 +394,7 @@ run_sweep
 smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "11 no bare-Enter send"
 smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "11 one option send"
 smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "auto-agent:option=1" "11 send option=1 (make default)"
-smoke_assert_contains "$(cat "$TASK_LOG")" "auto-agent:auto-mode warning" "11 task body identifies pattern"
+smoke_assert_contains "$(cat "$TASK_LOG")" "auto-agent:auto-mode warning (sent option 1)" "11 task body records explicit option send"
 
 # ---------------------------------------------------------------------------
 # Test 12 — Bypass/auto patterns must NOT fire on free-prose mention.

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -530,4 +530,30 @@ run_sweep
 smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "16 no bare-Enter send"
 smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "16 no option send (stale WARNING block must not replay)"
 
+# ---------------------------------------------------------------------------
+# Test 17 — r7 hardening (codex PR #949 r6): hypothetical auto-mode prompt
+# without "WARNING:" header (e.g. claude CLI rendering it as
+# "Enable auto mode?!"). r6 anchored on "WARNING:" only and would have
+# missed this shape. r7 accepts "Enable auto mode" and "Bypass Permissions
+# mode" as alternate headers.
+# ---------------------------------------------------------------------------
+
+smoke_log "17. auto-mode prompt with 'Enable auto mode' title → send option 1 (r7)"
+reset_fixture
+printf '%s\n' "alt-title-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-alt-title-agent" <<'PANE'
+  Enable auto mode?!
+
+  ❯ 1. Yes, and make it my default mode
+    2. Yes, enable auto mode
+    3. No, exit
+
+  Enter to confirm · Esc to cancel
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "17 no bare-Enter send"
+smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "17 one option send"
+smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "alt-title-agent:option=1" "17 send option=1 (alternate title)"
+
 smoke_log "all checks passed"

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -440,4 +440,38 @@ run_sweep
 smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "13 no bare-Enter send"
 smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "13 no option send (generic exit ≠ bypass/auto accept)"
 
+# ---------------------------------------------------------------------------
+# Test 14 — r4 hardening (codex PR #949 r3): capture contains a STALE
+# bypass-warning accept line above an ACTIVE auto-mode picker. The bypass
+# branch would otherwise win and send option 2 into the auto-mode menu
+# (= "Yes, enable auto mode just this once"), and the ack would not
+# persist across restarts. The fix scopes detection to the last picker
+# block (after the most recent tail), so only the active picker's accept
+# line matters.
+# ---------------------------------------------------------------------------
+
+smoke_log "14. stale bypass + active auto-mode in same capture → send auto's option 1 (r4)"
+reset_fixture
+printf '%s\n' "combo-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-combo-agent" <<'PANE'
+  WARNING: Claude Code running in Bypass Permissions mode
+
+  ❯ 1. No, exit
+    2. Yes, I accept
+
+  Enter to confirm · Esc to cancel
+  WARNING: Auto mode allows Claude to run commands automatically.
+
+  ❯ 1. Yes, and make it my default mode
+    2. Yes, enable auto mode
+    3. No, exit
+
+  Enter to confirm · Esc to cancel
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "14 no bare-Enter send"
+smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "14 one option send (active picker only)"
+smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "combo-agent:option=1" "14 send option=1 (auto-mode active, NOT stale bypass option 2)"
+
 smoke_log "all checks passed"

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -474,4 +474,34 @@ smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "14 no bare-Enter send"
 smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "14 one option send (active picker only)"
 smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "combo-agent:option=1" "14 send option=1 (auto-mode active, NOT stale bypass option 2)"
 
+# ---------------------------------------------------------------------------
+# Test 15 — r5 hardening (codex PR #949 r4): stale "2. Yes, I accept" in
+# free-text scrollback above an UNRELATED active picker (with the canonical
+# tail). The r4 active_picker extraction (last block ending with tail)
+# would still include the stale accept line and fire the bypass branch,
+# sending option 2 into the unrelated menu. The r5 fix anchors active_picker
+# extraction to lines between the MOST RECENT "WARNING:" header and the
+# MOST RECENT tail after it — stale text outside that window is excluded.
+# ---------------------------------------------------------------------------
+
+smoke_log "15. stale accept above unrelated active picker → must NOT trigger bypass send (r5)"
+reset_fixture
+printf '%s\n' "stale-accept-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-stale-accept-agent" <<'PANE'
+notes from a previous answer:
+  2. Yes, I accept
+
+  WARNING: An unrelated Claude warning that happens to share menu shape.
+
+  ❯ 1. No, exit
+    2. Do something completely unrelated to permissions
+    3. Try another path
+
+  Enter to confirm · Esc to cancel
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "15 no bare-Enter send"
+smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "15 no option send (stale accept must not fire bypass on unrelated menu)"
+
 smoke_log "all checks passed"

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -556,4 +556,29 @@ smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "17 no bare-Enter send"
 smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "17 one option send"
 smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "alt-title-agent:option=1" "17 send option=1 (alternate title)"
 
+# ---------------------------------------------------------------------------
+# Test 18 — r8 hardening (codex PR #949 r7): an UNRELATED WARNING picker
+# that happens to include "2. Yes, I accept" as one of its options must
+# NOT fire the bypass branch. r7 captured the warning block but the
+# branch keyed on the generic accept line alone. r8 requires the
+# bypass-specific "Bypass Permissions mode" discriminator text.
+# ---------------------------------------------------------------------------
+
+smoke_log "18. unrelated WARNING with 'Yes, I accept' option → must NOT fire bypass (r8)"
+reset_fixture
+printf '%s\n' "unrelated-accept-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-unrelated-accept-agent" <<'PANE'
+  WARNING: Some other Claude policy notice requires acknowledgement.
+
+  ❯ 1. No, exit
+    2. Yes, I accept
+    3. Defer the choice
+
+  Enter to confirm · Esc to cancel
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "18 no bare-Enter send"
+smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "18 no option send (unrelated WARNING ≠ bypass-permissions discriminator)"
+
 smoke_log "all checks passed"

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -504,4 +504,30 @@ run_sweep
 smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "15 no bare-Enter send"
 smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "15 no option send (stale accept must not fire bypass on unrelated menu)"
 
+# ---------------------------------------------------------------------------
+# Test 16 — r6 hardening (codex PR #949 r5): stale bypass WARNING+tail in
+# scrollback with NEWER output below (picker already answered, pane is
+# back to a normal prompt or unrelated content). r5's WARNING-anchored
+# extraction would replay the stale block; r6 bails when non-blank
+# content appears AFTER the tail.
+# ---------------------------------------------------------------------------
+
+smoke_log "16. stale WARNING+tail with output below → must NOT replay (r6)"
+reset_fixture
+printf '%s\n' "stale-warning-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-stale-warning-agent" <<'PANE'
+  WARNING: Claude Code running in Bypass Permissions mode
+
+  ❯ 1. No, exit
+    2. Yes, I accept
+
+  Enter to confirm · Esc to cancel
+assistant: continuing after accepted warning
+> ready for next input
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "16 no bare-Enter send"
+smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "16 no option send (stale WARNING block must not replay)"
+
 smoke_log "all checks passed"

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -81,13 +81,20 @@ mock_send_enter() {
     printf '%s\n' "$target" >> "$SEND_LOG"
 }
 
+# #948 — mock for the explicit "send N + Enter" path. Records the agent and
+# option number so smoke assertions can verify the correct option was sent.
+mock_send_option() {
+    local target="$1" option_num="$2"
+    printf '%s:option=%s\n' "$target" "$option_num" >> "$SEND_OPTION_LOG"
+}
+
 mock_create_task() {
     local title="$1" body="$2" recipient="$3"
     printf 'recipient=%s\ntitle=%s\nbody=%s\n---\n' \
         "$recipient" "$title" "$body" >> "$TASK_LOG"
 }
 
-export -f mock_list_sessions mock_capture_pane mock_send_enter mock_create_task
+export -f mock_list_sessions mock_capture_pane mock_send_enter mock_send_option mock_create_task
 MOCK_EOF
 # shellcheck source=/dev/null
 source "$MOCK_LIB"
@@ -96,16 +103,19 @@ source "$MOCK_LIB"
 export BRIDGE_PICKER_SWEEP_LIST_SESSIONS_FN=mock_list_sessions
 export BRIDGE_PICKER_SWEEP_CAPTURE_PANE_FN=mock_capture_pane
 export BRIDGE_PICKER_SWEEP_SEND_ENTER_FN=mock_send_enter
+export BRIDGE_PICKER_SWEEP_SEND_OPTION_FN=mock_send_option
 export BRIDGE_PICKER_SWEEP_CREATE_TASK_FN=mock_create_task
 
 # Pin the log file so the smoke can inspect it.
 export BRIDGE_PICKER_SWEEP_LOG="$FIXTURE_DIR/picker-sweep.log"
-export FIXTURE_DIR SEND_LOG TASK_LOG
+SEND_OPTION_LOG="$FIXTURE_DIR/sent-options.log"
+export FIXTURE_DIR SEND_LOG SEND_OPTION_LOG TASK_LOG
 
 reset_fixture() {
-    rm -f "$FIXTURE_DIR/sessions" "$FIXTURE_DIR"/pane-* "$SEND_LOG" "$TASK_LOG" "$BRIDGE_PICKER_SWEEP_LOG"
+    rm -f "$FIXTURE_DIR/sessions" "$FIXTURE_DIR"/pane-* "$SEND_LOG" "$SEND_OPTION_LOG" "$TASK_LOG" "$BRIDGE_PICKER_SWEEP_LOG"
     : >"$FIXTURE_DIR/sessions"
     : >"$SEND_LOG"
+    : >"$SEND_OPTION_LOG"
     : >"$TASK_LOG"
 }
 
@@ -334,5 +344,76 @@ PANE
 
 run_sweep
 smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "9 no send (codex confirm in '>' quote)"
+
+# ---------------------------------------------------------------------------
+# Test 10 — Bypass Permissions warning (#948). Default cursor is on
+# "No, exit" so bare Enter would EXIT Claude. Must send option 2 explicitly.
+# ---------------------------------------------------------------------------
+
+smoke_log "10. bypass-permissions warning → send option 2"
+reset_fixture
+printf '%s\n' "bypass-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-bypass-agent" <<'PANE'
+  WARNING: Claude Code running in Bypass Permissions mode
+
+  In Bypass Permissions mode, Claude Code will not ask for your approval
+  before running potentially dangerous commands.
+
+  ❯ 1. No, exit
+    2. Yes, I accept
+
+  Enter to confirm · Esc to cancel
+PANE
+
+export BRIDGE_PICKER_SWEEP_NOTIFY="admin"
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "10 no bare-Enter send (would EXIT Claude)"
+smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "10 one option send"
+smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "bypass-agent:option=2" "10 send option=2 (Yes I accept)"
+smoke_assert_contains "$(cat "$TASK_LOG")" "bypass-agent:bypass-permissions warning" "10 task body identifies pattern"
+
+# ---------------------------------------------------------------------------
+# Test 11 — Auto mode warning (#948). 3-option picker; send option 1 so the
+# mode becomes the user default and subsequent claude restarts skip the prompt.
+# ---------------------------------------------------------------------------
+
+smoke_log "11. auto-mode warning → send option 1"
+reset_fixture
+printf '%s\n' "auto-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-auto-agent" <<'PANE'
+  WARNING: Auto mode allows Claude to run commands automatically.
+
+  ❯ 1. Yes, and make it my default mode
+    2. Yes, enable auto mode
+    3. No, exit
+
+  Enter to confirm · Esc to cancel
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "11 no bare-Enter send"
+smoke_assert_eq "1" "$(count_lines "$SEND_OPTION_LOG")" "11 one option send"
+smoke_assert_contains "$(cat "$SEND_OPTION_LOG")" "auto-agent:option=1" "11 send option=1 (make default)"
+smoke_assert_contains "$(cat "$TASK_LOG")" "auto-agent:auto-mode warning" "11 task body identifies pattern"
+
+# ---------------------------------------------------------------------------
+# Test 12 — Bypass/auto patterns must NOT fire on free-prose mention.
+# Same false-positive defence as Test 3/9 but for the new regexes.
+# ---------------------------------------------------------------------------
+
+smoke_log "12. bypass/auto patterns — false-positive defence (free-prose)"
+reset_fixture
+printf '%s\n' "doc-agent3" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-doc-agent3" <<'PANE'
+> The picker reads:
+>   ❯ 1. No, exit
+>     2. Yes, I accept
+> When the operator selects "2. Yes, I accept" the warning is acked.
+> Auto mode picker similar: 1. Yes, and make it my default mode / 2. Yes, enable auto mode / 3. No, exit
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "12 no bare-Enter send (free-prose)"
+smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "12 no option send (free-prose)"
 
 smoke_log "all checks passed"

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -416,4 +416,28 @@ run_sweep
 smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "12 no bare-Enter send (free-prose)"
 smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "12 no option send (free-prose)"
 
+# ---------------------------------------------------------------------------
+# Test 13 — Generic exit-option menu (#948 r3 hardening from codex PR #949
+# r2 review). A different Claude warning whose menu also lists "No, exit"
+# must NOT trigger the bypass-permissions / auto-mode send paths — those
+# now key off the distinctive accept-option line, not the generic exit.
+# ---------------------------------------------------------------------------
+
+smoke_log "13. generic exit-option menu — must NOT trigger bypass/auto send (r3 hardening)"
+reset_fixture
+printf '%s\n' "generic-exit-agent" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-generic-exit-agent" <<'PANE'
+  WARNING: An unrelated Claude warning that happens to share menu shape.
+
+  ❯ 1. No, exit
+    2. Do something completely unrelated to permissions
+    3. Try another path
+
+  Enter to confirm · Esc to cancel
+PANE
+
+run_sweep
+smoke_assert_eq "0" "$(count_lines "$SEND_LOG")" "13 no bare-Enter send"
+smoke_assert_eq "0" "$(count_lines "$SEND_OPTION_LOG")" "13 no option send (generic exit ≠ bypass/auto accept)"
+
 smoke_log "all checks passed"


### PR DESCRIPTION
## Summary

- `scripts/picker-sweep.sh`: new `_psw_default_send_option <agent> <N>` wrapper + `BRIDGE_PICKER_SWEEP_SEND_OPTION_FN` seam → explicit option-number send instead of bare Enter.
- Two new regexes + sweep branches:
  - `_PICKER_BYPASS_PERMISSIONS_RE` → send option `2` (Yes, I accept). Default cursor is on "No, exit" → bare Enter would EXIT Claude on fresh install.
  - `_PICKER_AUTO_MODE_RE` → send option `1` (Yes, and make it my default mode). Makes mode persistent so subsequent claude restarts skip the prompt — avoids 5s-restart crash-loop documented in #948.
- Both patterns require canonical "Enter to confirm · Esc to cancel" tail → matches Test 3/9 false-positive defence (free-prose mentions in docs/PR bodies/logs do NOT trigger send-keys).
- `scripts/smoke/picker-sweep.sh`: 3 new tests (10/11/12) covering the new patterns + false-positive defence. All 12 tests pass locally.

## Why this PR exists

Fresh install / new VM / new user account: bridge spawn invokes `claude --dangerously-skip-permissions` → claude emits Bypass Permissions warning → bridge's onboarding nudge enqueues "안녕하세요..." onto the prompt input → input collision → exit 1 → 5s restart → same prompt → **infinite crash-loop**.

Previously picker-sweep documented this trap at `scripts/picker-sweep.sh:146-153` as "NOT added (intentionally) — needs explicit 'send 2 + Enter' support before adding". This PR adds that mechanism.

Operator preference (#948 thread): "auto mode 사용하는걸로 해결이 되는지 확인" — `--permission-mode auto` was tested in the VM and turned out to have its OWN first-launch prompt (3-option picker). So this PR handles both auto mode AND bypass-permissions in the same dispatch. Operator host is unaffected (already acked these warnings interactively).

## Mechanism details

```bash
# BEFORE (bare Enter — destroyed Claude on Bypass Permissions because default cursor was option 1)
tmux send-keys -t "$target" Enter

# AFTER (explicit "N + Enter" — commits the digit before submission)
tmux send-keys -t "$target" "$option_num"
tmux send-keys -t "$target" Enter
```

Two-call form is intentional: tmux send-keys with adjacent string args sometimes coalesces to a literal "2Enter" string that the TUI doesn't interpret as digit+submit. Splitting forces the digit input to commit first.

## Verification

```bash
bash -n scripts/picker-sweep.sh scripts/smoke/picker-sweep.sh   # syntax OK
shellcheck scripts/picker-sweep.sh scripts/smoke/picker-sweep.sh # clean
bash scripts/smoke/picker-sweep.sh   # all 12 tests pass (12 logged + "all checks passed")
```

Live reproducer for the next fresh install: register a new user, install agent-bridge per README, run `agb agent start patch`. With this PR landed, the picker-sweep cron (`*/10 * * * *`) auto-unsticks the spawn-time prompt within 10 min instead of letting the crash-loop continue indefinitely.

## Out of scope

- Reducing the 10-min picker-sweep cadence on fresh installs — separate UX issue (would benefit by triggering sweep once explicitly right after bootstrap to shorten first-time wait).
- Replacing `--dangerously-skip-permissions` with `--permission-mode auto` in agent-bridge launch_cmd — tested and rejected because both modes have their own first-launch prompt. The fix lives in the sweeper, not in the launch_cmd.
- Other claude/codex prompts not yet observed in the wild.

## Test plan

- [x] bash -n + shellcheck clean on both files
- [x] Smoke 12/12 pass
- [x] Verified Bypass Permissions prompt shape in macOS Sequoia VM matches the new regex (operator-host reproducer)
- [x] Verified `--permission-mode auto` prompt shape matches the auto-mode regex
- [ ] Live fresh-install run on macOS VM after merge to confirm auto-unstick within 10-min cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
