### PR TITLE
fix(watchdog): capture full stderr + classify resolver die path (#946 L3)

### DIFF
--- a/bridge-watchdog-silence.py
+++ b/bridge-watchdog-silence.py
@@ -422,10 +422,93 @@ def emit_audit(action: str, detail: dict) -> None:
         log.error("audit write failed for %s: %s", action, exc)
 
 
+# Stderr preview cap (bytes) for the persisted state file. The full stderr
+# block goes to the watchdog log unconditionally; the JSON state field is
+# capped so a runaway resolver message can't bloat silence-watchdog.json.
+STDERR_PREVIEW_MAX = 500
+
+
+def _stderr_preview(output: str) -> str:
+    """Trim and single-line-escape a captured stderr block for audit/state.
+
+    Multi-line resolver die messages are valuable in the watchdog log, but
+    the audit `--detail key=value` channel and the JSON state file are
+    easier to grep / round-trip when each preview is a single line. We
+    replace newlines with the literal `\\n` two-char sequence and cap to
+    `STDERR_PREVIEW_MAX` bytes so the persisted size stays bounded.
+    """
+    return output.strip().replace("\n", "\\n")[:STDERR_PREVIEW_MAX]
+
+
+def _indent_block(text: str, prefix: str = "    ") -> str:
+    """Indent every line of `text` with `prefix` for readable log output."""
+    if not text:
+        return ""
+    return "\n".join(prefix + line for line in text.rstrip("\n").splitlines())
+
+
+def _classify_resolver_die(stderr_text: str) -> str:
+    """Map a `bridge-layout-resolver.sh` `bridge_die` stderr block to a
+    short identifier of which die path fired.
+
+    Issue #946 L3: every silence-watchdog `daemon stop` failure from
+    2026-05-15 onward surfaced the same truncated v0.8.0 ACL-removal
+    sentence (the last line of the multi-line die message), making
+    post-mortem triage impossible without re-running the wedged invocation.
+    The full stderr already carries a `current_layout=` discriminator;
+    this helper substring-matches that discriminator against the three
+    known die paths in `lib/bridge-layout-resolver.sh` so the audit row
+    records which path fired without a parse pass.
+
+    Path map (verified against `lib/bridge-layout-resolver.sh` 2026-05-17):
+      - `current_layout=legacy` / `current_layout=v1` -> marker says
+        marker-pinned-legacy (line 384).
+      - `current_layout=markerless(existing-install)` -> evidence-based
+        markerless existing install (line 406).
+      - `current_layout=markerless(...)` (anything else, typically
+        `fresh-install-candidate` or `invalid-marker(fallback)`) ->
+        evidence-based markerless fresh-candidate (line 439).
+      - `ACL-based isolation` present without any of the above -> some
+        other v0.8.0 hard-cut surface we have not catalogued yet; caller
+        should look at the full stderr block.
+      - none of the above -> `other` (not a resolver die — could be a
+        permission error, missing pid file, timeout, etc.).
+
+    Returns a short token suitable for use as an audit detail value.
+    """
+    if not stderr_text:
+        return "other"
+    # Match the `current_layout=` discriminator first — it's emitted by all
+    # three resolver die paths and is the only field that disambiguates.
+    if "current_layout=markerless(existing-install)" in stderr_text:
+        return "markerless-existing (line 406)"
+    if "current_layout=markerless(" in stderr_text:
+        # Catches `fresh-install-candidate`, `invalid-marker(fallback)`,
+        # `missing-marker(existing)`, and any future markerless source.
+        return "markerless-fresh-candidate (line 439)"
+    if "current_layout=legacy" in stderr_text or "current_layout=v1" in stderr_text:
+        return "marker-legacy (line 384)"
+    # No `current_layout=` line, but the ACL-removal sentence is present —
+    # this is a v0.8.0 hard-cut surface we don't recognize. Surface that
+    # ambiguity clearly so post-mortem readers know to read the full
+    # stderr block (preserved in the log) rather than trust the label.
+    if "ACL-based isolation" in stderr_text:
+        return "v0.8.0-isolation-hard-cut (line unknown — see full stderr)"
+    return "other"
+
+
 def run_daemon_command(*verb_args: str) -> tuple[int, str]:
     """Run `bash bridge-daemon.sh <verb_args>` with a hard timeout. Returns
-    (exit_code, last-line-of-output) so the audit row can record why a
-    restart attempt failed."""
+    (exit_code, full-combined-output) so callers can both log the entire
+    block (grep-able) and classify the failure mode.
+
+    Issue #946 L3: the previous implementation truncated the captured
+    output to `splitlines()[-1]`, which discarded the multi-line resolver
+    die message and left every wedge surfacing the same generic ACL line.
+    Full capture is cheap (the daemon stop/start output is bounded by the
+    `RESTART_TIMEOUT` window) and is the only way to identify which die
+    path fired in a post-mortem.
+    """
     bash = os.environ.get("BRIDGE_BASH_BIN", "bash")
     cmd = [bash, str(DAEMON_SCRIPT), *verb_args]
     label = " ".join(verb_args)
@@ -439,8 +522,7 @@ def run_daemon_command(*verb_args: str) -> tuple[int, str]:
     except OSError as exc:
         return 127, f"bridge-daemon.sh {label} spawn failed: {exc}"
     output = (result.stdout or "") + (result.stderr or "")
-    last = output.strip().splitlines()[-1] if output.strip() else ""
-    return result.returncode, last
+    return result.returncode, output
 
 
 def attempt_restart(reason_detail: dict) -> None:
@@ -451,36 +533,66 @@ def attempt_restart(reason_detail: dict) -> None:
     # --force: the silence watchdog only fires on a wedged/silent daemon.
     # Bypass the issue #314/#315 active-agent guard so a stuck daemon can
     # still be restarted on a host with running agents.
-    stop_code, stop_msg = run_daemon_command("stop", "--force")
+    stop_code, stop_output = run_daemon_command("stop", "--force")
     if stop_code != 0:
+        # Issue #946 L3: classify which resolver die path fired (when the
+        # failure was a v0.8.0 isolation hard-cut) and quote the full
+        # stderr block in the watchdog log so post-mortem readers can
+        # disambiguate `marker-legacy` / `markerless-existing` /
+        # `markerless-fresh-candidate` without re-running the wedge.
+        stop_resolver_die = _classify_resolver_die(stop_output)
+        stop_preview = _stderr_preview(stop_output)
         emit_audit(
             "daemon_silence_restart_attempted",
             {
                 "outcome": "stop_failed",
                 "stop_exit": stop_code,
-                "stop_msg": stop_msg[:200],
+                "stop_resolver_die": stop_resolver_die,
+                "stop_msg": stop_preview,
                 **reason_detail,
             },
         )
-        log.error("daemon stop failed (exit=%s): %s", stop_code, stop_msg)
+        log.error(
+            "daemon stop failed (exit=%s, resolver_die=%s):\n%s",
+            stop_code, stop_resolver_die, _indent_block(stop_output),
+        )
         # Cooldown is set even on failure so we don't loop on a permanently
-        # broken daemon.
-        write_cooldown(time.time(), {"outcome": "stop_failed", "stop_exit": stop_code})
+        # broken daemon. Persist the resolver_die classification and the
+        # stderr preview in the JSON state so an operator (or future
+        # diagnosis pass) can grep `silence-watchdog.json` and immediately
+        # learn which die path fired without re-running anything.
+        write_cooldown(time.time(), {
+            "outcome": "stop_failed",
+            "stop_exit": stop_code,
+            "resolver_die": stop_resolver_die,
+            "stderr_preview": stop_preview,
+        })
         return
 
-    start_code, start_msg = run_daemon_command("start")
+    start_code, start_output = run_daemon_command("start")
     if start_code != 0:
+        start_resolver_die = _classify_resolver_die(start_output)
+        start_preview = _stderr_preview(start_output)
         emit_audit(
             "daemon_silence_restart_attempted",
             {
                 "outcome": "start_failed",
                 "start_exit": start_code,
-                "start_msg": start_msg[:200],
+                "start_resolver_die": start_resolver_die,
+                "start_msg": start_preview,
                 **reason_detail,
             },
         )
-        log.error("daemon start failed (exit=%s): %s", start_code, start_msg)
-        write_cooldown(time.time(), {"outcome": "start_failed", "start_exit": start_code})
+        log.error(
+            "daemon start failed (exit=%s, resolver_die=%s):\n%s",
+            start_code, start_resolver_die, _indent_block(start_output),
+        )
+        write_cooldown(time.time(), {
+            "outcome": "start_failed",
+            "start_exit": start_code,
+            "resolver_die": start_resolver_die,
+            "stderr_preview": start_preview,
+        })
         return
 
     new_pid = daemon_recorded_pid() or 0

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10971,4 +10971,16 @@ bash "$REPO_ROOT/scripts/smoke/smoke-isolation-no-live-leak.sh"
 log "running bridge-agent-cli-no-deadlock smoke (refs queue task #4773)"
 bash "$REPO_ROOT/scripts/smoke/bridge-agent-cli-no-deadlock.sh"
 
+# bridge-watchdog-silence.py previously truncated captured daemon
+# stop/start output to the last line, so every wedge from 2026-05-15
+# onward surfaced the same v0.8.0 ACL background sentence in the
+# silence-watchdog audit row. Issue #946 L3 preserves the full stderr
+# block and classifies the resolver die path (line 384 / 406 / 439).
+# This smoke step pins the classifier token map, the state-file
+# `resolver_die` + `stderr_preview` persistence, and the multi-line
+# survival contract so the next wedge is diagnosable in seconds rather
+# than hours.
+log "running watchdog-silence-stderr-capture smoke (#946 L3)"
+bash "$REPO_ROOT/scripts/smoke/watchdog-silence-stderr-capture.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/watchdog-silence-stderr-capture.sh
+++ b/scripts/smoke/watchdog-silence-stderr-capture.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# Regression smoke — bridge-watchdog-silence.py must (a) classify resolver
+# `bridge_die` stderr into the three known v0.8.0 die paths, (b) preserve
+# the full multi-line stderr block when the `daemon stop`/`start` call
+# fails, and (c) persist the classifier + stderr preview into
+# `state/silence-watchdog.json` so post-mortem readers can grep one file
+# instead of re-running a wedged invocation.
+#
+# Background (issue #946 L3, 2026-05-17):
+#   The silence watchdog's previous output capture kept only the last
+#   line of stderr (`output.strip().splitlines()[-1]`). Every wedge
+#   from 2026-05-15 onward then surfaced the same generic ACL-removal
+#   sentence — `marker-legacy` / `markerless-existing` /
+#   `markerless-fresh-candidate` were indistinguishable in the audit
+#   trail. L3 fixes diagnostics only; the wedge itself is closed by L1
+#   (BRIDGE_SCRIPT_DIR validation) + L2 (tick subshell guards).
+#
+# Coverage:
+#   C1 — `_classify_resolver_die` returns the expected token for each of
+#        the three known stderr shapes, the ambiguous ACL-only shape, and
+#        the unrelated-stderr/empty negatives. Catches future re-ordering
+#        of the substring checks.
+#   C2 — `attempt_restart` writes `state/silence-watchdog.json` with the
+#        `resolver_die` + `stderr_preview` keys populated when the stop
+#        helper returns non-zero. Asserts the post-mortem state file
+#        carries the disambiguator. Drives the call by replacing
+#        DAEMON_SCRIPT with a tiny shim that emits the
+#        `markerless(existing-install)` die shape on stderr.
+#   C3 — the multi-line stderr block is preserved end-to-end (the
+#        original truncation only kept the last line; this asserts the
+#        first non-trivial line of the die message survives into the
+#        preview).
+
+set -uo pipefail
+
+SMOKE_NAME="watchdog-silence-stderr-capture"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# shellcheck disable=SC2329 # invoked indirectly via trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+smoke_require_cmd python3
+
+WATCHDOG_SCRIPT="$REPO_ROOT/bridge-watchdog-silence.py"
+smoke_assert_file_exists "$WATCHDOG_SCRIPT" "watchdog source"
+
+# ---------------------------------------------------------------------------
+# C1 — _classify_resolver_die token map
+# ---------------------------------------------------------------------------
+# Drive the helper directly via a sibling python script (no heredoc-stdin
+# — keep the file-as-argv contract from lib/upgrade-helpers/ + footgun
+# #11). The probe loads the watchdog as a module so we exercise the
+# *real* function, not a paraphrase.
+smoke_log "C1: _classify_resolver_die maps stderr shapes to known tokens"
+c1_probe="$SMOKE_TMP_ROOT/c1-classify.py"
+cat >"$c1_probe" <<PROBE
+import importlib.util
+import sys
+
+spec = importlib.util.spec_from_file_location("bws", "$WATCHDOG_SCRIPT")
+mod = importlib.util.module_from_spec(spec)
+sys.modules["bws"] = mod
+spec.loader.exec_module(mod)
+classify = mod._classify_resolver_die
+
+cases = [
+    # (label, stderr_shape, expected_substring)
+    (
+        "marker-legacy",
+        "Agent Bridge v0.8.0 requires isolation-v2.\n"
+        "  current_layout=legacy\n"
+        "  marker=/some/path\n"
+        "  background: ACL-based isolation (v1) was removed.",
+        "marker-legacy",
+    ),
+    (
+        "markerless-existing",
+        "Agent Bridge v0.8.0 requires isolation-v2.\n"
+        "  current_layout=markerless(existing-install)\n"
+        "  background: ACL-based isolation (v1) was removed.",
+        "markerless-existing",
+    ),
+    (
+        "markerless-fresh-candidate",
+        "Agent Bridge v0.8.0 requires isolation-v2.\n"
+        "  current_layout=markerless(fresh-install-candidate)\n"
+        "  background: ACL-based isolation (v1) was removed.",
+        "markerless-fresh-candidate",
+    ),
+    (
+        "markerless-invalid-fallback (alias of fresh-candidate)",
+        "Agent Bridge v0.8.0 requires isolation-v2.\n"
+        "  current_layout=markerless(invalid-marker(fallback))\n"
+        "  background: ACL-based isolation (v1) was removed.",
+        "markerless-fresh-candidate",
+    ),
+    (
+        "marker-v1 alias",
+        "Agent Bridge v0.8.0 requires isolation-v2.\n"
+        "  current_layout=v1\n"
+        "  background: ACL-based isolation (v1) was removed.",
+        "marker-legacy",
+    ),
+    (
+        "uncatalogued v0.8.0 hard-cut",
+        "  background: ACL-based isolation (v1) was removed.\n"
+        "  see docs/isolation-migration-guide.md",
+        "isolation-hard-cut",
+    ),
+    ("unrelated stderr", "permission denied: /tmp/foo", "other"),
+    ("empty stderr", "", "other"),
+]
+
+failures = []
+for label, shape, expected in cases:
+    got = classify(shape)
+    if expected not in got:
+        failures.append(f"  case {label!r}: expected substring {expected!r}, got {got!r}")
+
+if failures:
+    print("FAIL")
+    for f in failures:
+        print(f)
+    sys.exit(1)
+
+print("PASS")
+PROBE
+
+c1_out="$(python3 "$c1_probe" 2>&1)"
+c1_rc=$?
+if (( c1_rc != 0 )); then
+  smoke_log "C1 output:"; printf '%s\n' "$c1_out"
+  smoke_fail "C1: classifier did not match expected token map"
+fi
+smoke_log "C1 PASS"
+
+# ---------------------------------------------------------------------------
+# C2 — attempt_restart persists resolver_die + stderr_preview to state JSON
+# ---------------------------------------------------------------------------
+# Drive `attempt_restart` directly with a fake DAEMON_SCRIPT that emits a
+# multi-line v0.8.0 die message on stderr and exits non-zero. We don't
+# need a real audit log or live daemon — the test asserts on the cooldown
+# state file, which is the post-mortem oracle.
+smoke_log "C2: attempt_restart persists resolver_die + stderr_preview into silence-watchdog.json"
+
+# Fake bridge-daemon.sh — emits the markerless(existing-install) die
+# shape on stderr and exits 1. Mirrors the operator-host wedge shape
+# (lib/bridge-layout-resolver.sh:406-410).
+fake_daemon="$SMOKE_TMP_ROOT/fake-bridge-daemon.sh"
+cat >"$fake_daemon" <<'FAKE'
+#!/usr/bin/env bash
+# Mimic `bridge_die` from lib/bridge-core.sh: write to stderr, exit 1.
+cat >&2 <<'DIE'
+Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
+  current_layout=markerless(existing-install)
+  remediation: run `agent-bridge upgrade --apply` to migrate this install to v2, or roll back to v0.7.x.
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details.
+DIE
+exit 1
+FAKE
+chmod +x "$fake_daemon"
+
+c2_probe="$SMOKE_TMP_ROOT/c2-restart.py"
+cat >"$c2_probe" <<PROBE
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# Pin BRIDGE_DAEMON_SCRIPT to the fake before loading the module so the
+# resolver picks it up at import time (it reads the env var on first
+# import of the module).
+os.environ["BRIDGE_DAEMON_SCRIPT"] = "$fake_daemon"
+# BRIDGE_HOME and friends are already exported by smoke_setup_bridge_home.
+
+spec = importlib.util.spec_from_file_location("bws", "$WATCHDOG_SCRIPT")
+mod = importlib.util.module_from_spec(spec)
+sys.modules["bws"] = mod
+spec.loader.exec_module(mod)
+
+# Sanity: confirm the fake is wired.
+assert str(mod.DAEMON_SCRIPT) == "$fake_daemon", \
+    f"DAEMON_SCRIPT resolution drifted: got {mod.DAEMON_SCRIPT!r}"
+
+# Drive attempt_restart with a fixed reason payload. The fake stops with
+# rc=1 -> stop_failed branch -> writes silence-watchdog.json detail with
+# resolver_die populated.
+mod.attempt_restart({"age_seconds": 9999, "threshold_seconds": 600,
+                     "last_tick_ts": "2026-05-17T00:00:00+00:00",
+                     "daemon_pid": 1})
+
+state_path = Path(os.environ["BRIDGE_STATE_DIR"]) / "silence-watchdog.json"
+if not state_path.exists():
+    print(f"FAIL: state file not written at {state_path}")
+    sys.exit(1)
+
+payload = json.loads(state_path.read_text("utf-8"))
+detail = payload.get("detail") or {}
+
+errors = []
+if detail.get("outcome") != "stop_failed":
+    errors.append(f"  outcome: expected 'stop_failed', got {detail.get('outcome')!r}")
+if detail.get("stop_exit") != 1:
+    errors.append(f"  stop_exit: expected 1, got {detail.get('stop_exit')!r}")
+resolver_die = detail.get("resolver_die", "")
+if "markerless-existing" not in resolver_die:
+    errors.append(f"  resolver_die: expected 'markerless-existing' substring, got {resolver_die!r}")
+stderr_preview = detail.get("stderr_preview", "")
+if "current_layout=markerless(existing-install)" not in stderr_preview:
+    errors.append(f"  stderr_preview missing current_layout discriminator: got {stderr_preview!r}")
+if "ACL-based isolation" not in stderr_preview:
+    errors.append(f"  stderr_preview missing ACL background line: got {stderr_preview!r}")
+# Newlines should be escaped (single-line for grep-friendliness).
+if "\n" in stderr_preview:
+    errors.append(f"  stderr_preview should be single-line (newlines as \\\\n): got {stderr_preview!r}")
+
+if errors:
+    print("FAIL")
+    for e in errors:
+        print(e)
+    print(f"  full detail: {detail!r}")
+    sys.exit(1)
+
+print("PASS")
+print(f"  resolver_die={resolver_die!r}")
+print(f"  stderr_preview_len={len(stderr_preview)}")
+PROBE
+
+c2_out="$(python3 "$c2_probe" 2>&1)"
+c2_rc=$?
+if (( c2_rc != 0 )); then
+  smoke_log "C2 output:"; printf '%s\n' "$c2_out"
+  smoke_fail "C2: attempt_restart did not persist resolver_die + stderr_preview"
+fi
+smoke_log "C2 PASS"
+printf '%s\n' "$c2_out" | sed 's/^/  /'
+
+# ---------------------------------------------------------------------------
+# C3 — full stderr block preserved end-to-end (no last-line truncation)
+# ---------------------------------------------------------------------------
+# The original bug was that only the *last* line of stderr survived, which
+# always happened to be the ACL background line. Assert that the FIRST
+# non-trivial line of the multi-line die message ("Agent Bridge v0.8.0
+# requires isolation-v2") also reaches the preview — that's the
+# regression catch for the truncation behaviour.
+smoke_log "C3: full multi-line stderr survives end-to-end (was truncated to last line)"
+state_path="$BRIDGE_STATE_DIR/silence-watchdog.json"
+if ! python3 - "$state_path" >/dev/null 2>"$SMOKE_TMP_ROOT/c3.err" <<'CHECK'
+import json
+import sys
+
+state = json.loads(open(sys.argv[1], "r", encoding="utf-8").read())
+preview = (state.get("detail") or {}).get("stderr_preview", "")
+expected_first_line_marker = "Agent Bridge v0.8.0 requires isolation-v2"
+if expected_first_line_marker not in preview:
+    raise SystemExit(f"first-line marker missing from preview: {preview!r}")
+CHECK
+then
+  smoke_log "C3 check stderr:"; cat "$SMOKE_TMP_ROOT/c3.err"
+  smoke_fail "C3: stderr_preview lost the first non-trivial line of the die message (regression to last-line truncation)"
+fi
+smoke_log "C3 PASS"
+
+smoke_log "PASS — bridge-watchdog-silence.py captures + classifies + persists resolver die diagnostics (#946 L3)"
+exit 0

--- a/scripts/smoke/watchdog-silence-stderr-capture.sh
+++ b/scripts/smoke/watchdog-silence-stderr-capture.sh
@@ -49,6 +49,14 @@ trap cleanup EXIT
 smoke_setup_bridge_home "$SMOKE_NAME"
 smoke_require_cmd python3
 
+# Strip operator-shell overrides that would steer the watchdog module's
+# import-time defaults outside this smoke's temp bridge home. The module
+# resolves COOLDOWN_FILE / PIDLOCK from these env vars at import; an
+# inherited override would mismatch our state-file assertions AND
+# (worse) write into the operator's live state. Defence-in-depth alongside
+# the module-resolved path checks below. Refs PR #950 codex review P2.
+unset BRIDGE_DAEMON_SILENCE_COOLDOWN_FILE BRIDGE_DAEMON_SILENCE_PIDLOCK
+
 WATCHDOG_SCRIPT="$REPO_ROOT/bridge-watchdog-silence.py"
 smoke_assert_file_exists "$WATCHDOG_SCRIPT" "watchdog source"
 
@@ -198,7 +206,13 @@ mod.attempt_restart({"age_seconds": 9999, "threshold_seconds": 600,
                      "last_tick_ts": "2026-05-17T00:00:00+00:00",
                      "daemon_pid": 1})
 
-state_path = Path(os.environ["BRIDGE_STATE_DIR"]) / "silence-watchdog.json"
+# Use the module's resolved COOLDOWN_FILE rather than re-deriving from
+# BRIDGE_STATE_DIR. The watchdog honors BRIDGE_DAEMON_SILENCE_COOLDOWN_FILE
+# at import time, so a shell that inherits that override would mismatch a
+# hard-coded path here and (worse) the write could land outside the
+# smoke's temp bridge home. Asserting on mod.COOLDOWN_FILE pins the
+# isolation invariant. Refs PR #950 codex review P2.
+state_path = Path(mod.COOLDOWN_FILE)
 if not state_path.exists():
     print(f"FAIL: state file not written at {state_path}")
     sys.exit(1)


### PR DESCRIPTION
## Summary
- `bridge-watchdog-silence.py`: full stderr capture instead of last-line truncation
- New `_classify_resolver_die` helper maps stderr → resolver die path (line 384 / 406 / 439)
- `state/silence-watchdog.json` `detail` now includes `resolver_die` + `stderr_preview`
- New `scripts/smoke/watchdog-silence-stderr-capture.sh` covers the classifier + JSON persistence + multi-line survival

## Why
Closes L3 of the daemon-hang cascade (refs #946). The silence watchdog's `daemon stop`/`start` failures from 2026-05-15 onward all surface the same truncated v0.8.0 ACL background sentence in the watchdog log — making post-mortem impossible without re-running the wedged invocation. Operator host evidence: `state/silence-watchdog.json` detail at 2026-05-16T11:55:54 says `outcome=stop_failed, stop_exit=1` with no resolver path identified, and the live log shows the same one-liner across every retry.

This PR does NOT fix the underlying wedge — that's L1 + L2's job (BRIDGE_SCRIPT_DIR validate + tick subshell guards, separate PRs). L3 ensures the NEXT wedge is diagnosable in seconds rather than hours by preserving the full multi-line resolver die message and labelling which path fired:

- `current_layout=legacy` / `v1` → `marker-legacy (line 384)`
- `current_layout=markerless(existing-install)` → `markerless-existing (line 406)`
- `current_layout=markerless(...)` (fresh-candidate, invalid-marker-fallback, etc) → `markerless-fresh-candidate (line 439)`
- Uncatalogued v0.8.0 hard-cut surface (no `current_layout=`) → `v0.8.0-isolation-hard-cut (line unknown — see full stderr)`
- Anything else → `other`

The full stderr block lands in the watchdog log (indented for readability) AND the first 500 bytes (newlines escaped) ride along in the audit row + JSON state file so a single grep on `silence-watchdog.json` resolves the post-mortem.

## Verification matrix
- [x] `python3 -m py_compile bridge-watchdog-silence.py` passes
- [x] `bash -n` + `shellcheck` clean on `scripts/smoke-test.sh` and `scripts/smoke/watchdog-silence-stderr-capture.sh`
- [x] `_classify_resolver_die` unit-style assertions pass (8 cases: 3 known die paths, fresh-candidate alias, v1 alias, uncatalogued ACL surface, unrelated stderr, empty)
- [x] `state/silence-watchdog.json` `detail.resolver_die` populated end-to-end (C2 drives `attempt_restart` against a fake `bridge-daemon.sh` shim that emits the `markerless(existing-install)` die shape)
- [x] Full stderr quoted into watchdog log (grep-able for the `Agent Bridge v0.8.0 requires isolation-v2` opener — C3 regression catch)
- [x] Standalone smoke step PASSes locally on macOS 26.3.2 / Bash 5.3.9
- [ ] Full `scripts/smoke-test.sh` blocked on the pre-existing step-266 silent-kill on `main` (the bug PR #947 fixes); cherry-picking PR #947 into a local probe branch unblocks the matrix — see "Probe" below

### Probe run (PR #947 cherry-picked into a temp branch)

The brief flagged that `origin/main` smoke is silently killed at step 266 until PR #947 lands. Cherry-picking PR #947 into a `_probe-with-pr947` branch let me run the full smoke matrix against my changes; the new step lands at the end of the file and passes alongside everything PR #947 unblocks. Probe branch is local-only and was discarded after verification.

## Out of scope
L1 (BRIDGE_SCRIPT_DIR validate), L2 (tick subshell guards), L4 (nudge skip on failure) are separate PRs. This PR keeps `Refs #946`, not `Fixes #946` — the issue stays open until all four layers land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
