### PR TITLE
fix(daemon): tick subshell timeouts + explicit nudge-skip on idle_ready writer failure (#946 L2+L4)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -509,11 +509,18 @@ _bridge_heartbeat_value_with_timeout() {
     # 4891ms probe caught the leak. Escalate TERM → KILL like the queue
     # gateway stop helper. A 0.5s grace covers most python3 helpers; the
     # KILL is the hard cap so the parent can never wait indefinitely.
+    #
+    # PR #952 r5 P2 #1: the KILL stage is UNCONDITIONAL — do not gate it
+    # behind `kill -0 pid`. If the wrapper subshell honored SIGTERM and
+    # died, `kill -0 $pid` returns false, but a SIGTERM-ignoring
+    # grandchild (e.g. python3 with a handler, or a child that ran
+    # `trap '' TERM`) may still be alive in the same process group.
+    # Sending negative-pid SIGKILL is uncatchable and reaches every
+    # surviving member of the group; sending it after the wrapper is
+    # already dead is harmless (the kernel just reports ESRCH per pid).
     _bridge_kill_proc_tree "$pid" "TERM"
     sleep 0.5
-    if kill -0 "$pid" 2>/dev/null; then
-      _bridge_kill_proc_tree "$pid" "KILL"
-    fi
+    _bridge_kill_proc_tree "$pid" "KILL"
     wait "$pid" 2>/dev/null || true
     daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' timed out at ${secs}s; substituting sentinel '${default}' (refs #946)"
     bridge_audit_log daemon daemon_heartbeat_helper_timeout daemon \

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -299,15 +299,45 @@ EOF
 # grandchild orphaned, so a stuck helper still leaked one long-running
 # child per heartbeat tick.
 #
-# We walk descendants depth-first with pgrep -P (depth-first so leaves
-# die before their parents — reduces SIGCHLD reaping races) and send the
-# requested signal to each. setsid / process-group kill is not portable
-# across macOS/Linux without an external wrapper (perl POSIX, util-linux
-# setsid) AND would require launching helpers via bash -c, which loses
-# the in-process bash function table. Recursive pgrep is the cleanest
-# portable approach given those constraints; pgrep is in
-# procps-ng (Linux) and Darwin base (macOS), already required by other
-# daemon paths.
+# PR #952 r4 P1 (process-group primary): codex r3 observed that pgrep
+# AND `ps -A` BOTH return "Operation not permitted" in restricted macOS
+# sandbox environments (and analogous failures in unprivileged Linux
+# containers with /proc filtering). When both process-table primitives
+# are denied, descendant enumeration silently returns the empty list
+# and the kill walk only reaps the immediate wrapper subshell — the
+# python3 grandchild outlives the timeout exactly as it did pre-r2.
+#
+# r4 makes the kill mechanism independent of process-table access by
+# putting the wrapper subshell in its own process group via bash
+# monitor mode (`set -m`). The wrapper's pgid equals its pid; any
+# child forked inside the wrapper inherits that pgid because we
+# immediately disable monitor mode inside the wrapper (otherwise every
+# nested `&` would get its own pgrp). On timeout we send the signal
+# to the negative pid, which the kernel delivers to every process in
+# the group regardless of /proc / sandbox visibility.
+#
+# `set -m` is enabled in the parent (the command-substitution subshell
+# that ran _bridge_heartbeat_value_with_timeout) for the single line
+# that backgrounds the wrapper, then disabled again — so daemon-wide
+# signal handling is unaffected. The wrapper's pgid stays valid even
+# after the wrapper exits, because the kernel keeps the pgrp alive
+# while any member is still running. So `kill -- -$pid` reaches an
+# orphaned python3 grandchild even after its wrapper subshell died.
+#
+# pgrep + ps enumeration are retained as DEFENSIVE-ONLY logging. If
+# pgrp kill ever misses a descendant (e.g. a child that explicitly
+# called setpgid) the enumerated PIDs become a warning log line, not
+# the primary reap path. They are no longer load-bearing.
+#
+# Historical rationale (r2/r3): the prior reasoning that
+# "setsid / process-group kill is not portable across macOS/Linux
+# without an external wrapper" was incorrect — bash monitor mode is in
+# POSIX job control and works the same way on both platforms. The
+# concern about "launching helpers via bash -c, which loses the
+# in-process bash function table" only applies to setsid(1) / python3
+# setsid wrappers that replace the process image with a fresh
+# interpreter. Bash monitor mode keeps the wrapper in the same
+# interpreter, so the function table is preserved.
 #
 # PR #952 r3 P2 #1: pgrep failure escalation. pgrep exit codes:
 #   0 — matches found
@@ -319,7 +349,9 @@ EOF
 # wedged helper's actual grandchildren survived the kill walk. r3
 # detects the failure and falls back to scanning `ps -A -o pid,ppid`
 # for descendants — `ps` is in POSIX and not subject to the pgrep
-# sandbox path that fails first.
+# sandbox path that fails first. r4 keeps this fallback because the
+# defensive logging hook still needs to enumerate when both pgrep and
+# the pgrp kill leave residual descendants.
 _bridge_enumerate_children() {
   # Stdout: one child PID per line. Exit 0 always — caller decides
   # whether an empty list is meaningful.
@@ -353,13 +385,44 @@ _bridge_enumerate_children() {
 }
 
 _bridge_kill_proc_tree() {
+  # PR #952 r4 P1: process-group kill is now the PRIMARY mechanism.
+  # `root_pid` is the pid of a subshell we backgrounded under monitor
+  # mode (`set -m`), so its pgid equals its pid. A negative-pid signal
+  # is delivered by the kernel to every member of the group without
+  # needing pgrep / ps to enumerate descendants — that is the property
+  # we lost in r3 when both process-table primitives were denied.
+  #
+  # We then run the legacy enumeration as DEFENSIVE coverage: if pgrep
+  # or ps happen to be available AND a descendant somehow escaped the
+  # pgrp (rare: only if a child explicitly called setpgid), we
+  # individually signal those PIDs and log a warning. This is no
+  # longer the load-bearing reap path.
   local root_pid="$1"
   local sig="${2:-TERM}"
+
+  # Primary: process-group kill via negative-pid. Ignore ESRCH ("No
+  # such process") which fires harmlessly if the wrapper already
+  # exited and reaped all its descendants between the kill -0 probe
+  # and this call.
+  kill "-$sig" -- "-$root_pid" 2>/dev/null || true
+
+  # Defensive: enumerate descendants for residual cleanup + logging.
+  # _bridge_enumerate_children returns 0 always; an empty list is a
+  # normal answer (everything was in the pgrp). A non-empty list AFTER
+  # the pgrp kill means something escaped — signal individually and
+  # log so an operator can grep for the rare escape.
   local children child
   children="$(_bridge_enumerate_children "$root_pid")"
-  for child in $children; do
-    _bridge_kill_proc_tree "$child" "$sig"
-  done
+  if [[ -n "$children" ]]; then
+    for child in $children; do
+      _bridge_kill_proc_tree "$child" "$sig"
+    done
+  fi
+
+  # Also signal the root pid itself by absolute pid — handles the
+  # never-monitor-mode regression case where the wrapper was NOT in
+  # its own pgrp (defensive, should be a no-op when r4 wiring is
+  # intact).
   kill "-$sig" "$root_pid" 2>/dev/null || true
 }
 
@@ -409,8 +472,22 @@ _bridge_heartbeat_value_with_timeout() {
 
   # Background the function call. We intentionally do NOT use
   # bridge_with_timeout — see comment above.
-  ( "$@" >"$stdout_file" 2>/dev/null ) &
+  #
+  # PR #952 r4 P1: enable bash monitor mode (`set -m`) JUST around the
+  # background fork so the wrapper subshell becomes its own
+  # process-group leader (pgid == pid). We immediately disable monitor
+  # mode INSIDE the subshell so any nested `&` (e.g. a helper that
+  # itself backgrounds a python3 child) inherits the wrapper's pgid
+  # instead of getting its own — that gives the timeout path a single
+  # negative-pid kill target that reaches all descendants without
+  # depending on pgrep / ps process-table access (denied in macOS
+  # sandbox + some Linux container configs). The parent's monitor-mode
+  # state is restored on the next line, so daemon job-control behavior
+  # is unchanged outside this six-line window.
+  set -m
+  ( set +m; "$@" >"$stdout_file" 2>/dev/null ) &
   local pid=$!
+  set +m
 
   # Poll for completion. 100ms granularity (10 polls per second) so a
   # fast function returns near-instantly without burning a full second
@@ -453,8 +530,11 @@ _bridge_heartbeat_value_with_timeout() {
   local rc=0
   # `wait` returns the backgrounded child's exit code. We want to capture
   # it without letting `set -e` short-circuit on a non-zero status, so use
-  # the canonical `cmd && rc=0 || rc=$?` form.
-  wait "$pid" && rc=0 || rc=$?
+  # the canonical `cmd && rc=0 || rc=$?` form. Stderr is redirected so
+  # bash monitor mode (PR #952 r4 P1) does not print a "[1]+ Done ..."
+  # job-completion notice — that notice would otherwise leak into the
+  # daemon stderr stream on every successful heartbeat helper call.
+  wait "$pid" 2>/dev/null && rc=0 || rc=$?
   if (( rc != 0 )); then
     daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' exited rc=${rc}; substituting sentinel '${default}' (refs #946)"
     rm -f -- "$stdout_file"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -120,6 +120,13 @@ BRIDGE_DAEMON_LAST_STEP="${BRIDGE_DAEMON_LAST_STEP:-init}"
 BRIDGE_DAEMON_ERR_LOCATION="${BRIDGE_DAEMON_ERR_LOCATION:-}"
 _BRIDGE_DAEMON_EXIT_LOGGED=0
 _BRIDGE_DAEMON_IN_ERR_TRAP=0
+# Issue #946 L4: consecutive-failure counter for bridge_write_idle_ready_agents.
+# Reset to 0 on each successful write; incremented on each failure. The
+# nudge_scan step uses this both to skip bridge_task_daemon_step on the
+# failing tick (avoiding broken-state consumption) and to surface a
+# `daemon_nudge_skip_streak` audit row so an operator can spot a wedged
+# writer after N consecutive ticks instead of having to grep raw logs.
+_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=0
 
 _bridge_daemon_on_signal() {
   BRIDGE_LAST_SIGNAL="$1"
@@ -267,6 +274,132 @@ HEARTBEAT_NEXT_TS=$next_ts
 EOF
 }
 
+# Issue #946 L2: bound each command-substitution inside write_agent_heartbeat
+# so a stuck helper (missing python3 helper file, hung tmux probe, locked
+# state file) cannot wedge the daemon tick. Each value is pre-computed via
+# bridge_with_timeout with a per-call ceiling; on timeout/failure we
+# substitute a grep-able sentinel and emit a one-line [L2] event so an
+# operator can identify which helper site is misbehaving from the daemon
+# crash log.
+#
+# Why pre-compute instead of wrapping inline? `cat <<EOF $(slow_helper) EOF`
+# evaluates command substitutions inside the heredoc body — there is no
+# way to bound them from inside the heredoc itself. The deadlock surfaced
+# on operator-host 2026-05-17 was that channel_status's python3 helpers
+# hung on a stale worktree path, the parent heredoc waited forever on the
+# child fork, and `set -e` did not abort because `cat` had not yet
+# observed a failure. Pre-resolving the values gives us a clean failure
+# boundary on each call.
+_bridge_heartbeat_value_with_timeout() {
+  # Args: <timeout_seconds> <call_site_label> <agent> <default> <fn> [fn-args...]
+  #
+  # Prints the function's stdout on success, or <default> on timeout/error.
+  # On failure also emits a [L2] daemon_log_event so operators can grep
+  # the crash log for which heartbeat helper site degraded.
+  #
+  # bridge_with_timeout (lib/bridge-state.sh) cannot bound bash functions
+  # because timeout(1) / gtimeout(1) only run executables, not shell
+  # functions. So this helper builds a manual deadline using the
+  # background-subshell + sleep-poll + kill-TERM/KILL pattern already
+  # established in bridge_stop_queue_gateway_socket_listener
+  # (bridge-daemon.sh:5928-5939). The pattern is:
+  #
+  #   1. fork the function call into a background subshell, redirect
+  #      stdout to a tempfile so we can recover the value if it
+  #      completes.
+  #   2. poll kill -0 up to `secs` ticks (~1s resolution; aligned with
+  #      the daemon's existing audit cadence).
+  #   3. on deadline expiry: kill -TERM, brief grace, kill -KILL, drop
+  #      tempfile, return sentinel + L2 event.
+  #   4. on natural completion: wait + read tempfile contents.
+  local secs="$1"
+  local label="$2"
+  local agent="$3"
+  local default="$4"
+  shift 4
+
+  if [[ ! "$secs" =~ ^[0-9]+$ ]] || (( secs == 0 )); then
+    secs=5
+  fi
+
+  local stdout_file
+  stdout_file="$(mktemp 2>/dev/null)" || stdout_file=""
+  if [[ -z "$stdout_file" ]]; then
+    # mktemp failed (e.g. $TMPDIR full). Skip the bound — substitute
+    # the sentinel rather than running unbounded.
+    daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}': mktemp failed; substituting sentinel '${default}' (refs #946)"
+    printf '%s' "$default"
+    return 0
+  fi
+
+  # Background the function call. We intentionally do NOT use
+  # bridge_with_timeout — see comment above.
+  ( "$@" >"$stdout_file" 2>/dev/null ) &
+  local pid=$!
+
+  # Poll for completion. 100ms granularity (10 polls per second) so a
+  # fast function returns near-instantly without burning a full second
+  # of latency per heartbeat write.
+  local i=0
+  local poll_max=$(( secs * 10 ))
+  while (( i < poll_max )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+    i=$(( i + 1 ))
+  done
+
+  if kill -0 "$pid" 2>/dev/null; then
+    # Deadline hit — escalate from TERM to KILL like the queue gateway
+    # stop helper does. A 0.5s grace covers most python3 helpers; the
+    # KILL is the hard cap so the parent can never wait indefinitely.
+    kill -TERM "$pid" 2>/dev/null || true
+    sleep 0.5
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+    daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' timed out at ${secs}s; substituting sentinel '${default}' (refs #946)"
+    bridge_audit_log daemon daemon_heartbeat_helper_timeout daemon \
+      --detail call_site="heartbeat_${label}" \
+      --detail agent="$agent" \
+      --detail timeout_seconds="$secs" \
+      --detail sentinel="$default" \
+      2>/dev/null || true
+    rm -f -- "$stdout_file"
+    printf '%s' "$default"
+    return 0
+  fi
+
+  local rc=0
+  # `wait` returns the backgrounded child's exit code. We want to capture
+  # it without letting `set -e` short-circuit on a non-zero status, so use
+  # the canonical `cmd && rc=0 || rc=$?` form.
+  wait "$pid" && rc=0 || rc=$?
+  if (( rc != 0 )); then
+    daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' exited rc=${rc}; substituting sentinel '${default}' (refs #946)"
+    rm -f -- "$stdout_file"
+    printf '%s' "$default"
+    return 0
+  fi
+  cat -- "$stdout_file" 2>/dev/null || printf '%s' "$default"
+  rm -f -- "$stdout_file"
+  return 0
+}
+
+# Tiny shim that converts bridge_agent_is_always_on's exit code into the
+# yes/no token the heartbeat report expects. Exists so the bounded helper
+# above can capture the answer via stdout (its only channel) rather than
+# the function's return code (which is lost across the subshell boundary).
+_bridge_heartbeat_always_on_yesno() {
+  if bridge_agent_is_always_on "$1"; then
+    printf '%s' "yes"
+  else
+    printf '%s' "no"
+  fi
+}
+
 write_agent_heartbeat() {
   local agent="$1"
   local heartbeat_file=""
@@ -282,6 +415,19 @@ write_agent_heartbeat() {
   local session=""
   local workdir=""
   local temp_file=""
+  # Issue #946 L2: pre-resolved heredoc values. Each is bounded by
+  # _bridge_heartbeat_value_with_timeout (defined above) so a wedged
+  # helper logs-and-skips rather than hanging the tick. Defaults are the
+  # same "-" / "?" tokens existing dashboards already render for missing
+  # data so no downstream consumer sees a novel shape.
+  local hb_now="?"
+  local hb_desc="-"
+  local hb_engine="-"
+  local hb_source="-"
+  local hb_always_on="no"
+  local hb_wake_status="-"
+  local hb_notify_status="-"
+  local hb_channel_status="-"
 
   heartbeat_file="$(bridge_agent_heartbeat_file "$agent")" || return 0
   workdir="$(bridge_agent_workdir "$agent")"
@@ -292,11 +438,41 @@ write_agent_heartbeat() {
   if bridge_agent_is_active "$agent"; then
     active="yes"
   fi
-  state="$(bridge_agent_heartbeat_activity_state "$agent")"
-  summary="$(bridge_queue_cli summary --agent "$agent" --format tsv 2>/dev/null | head -n 1 || true)"
+  # bridge_agent_heartbeat_activity_state can shell to tmux probes; bound it.
+  state="$(_bridge_heartbeat_value_with_timeout 5 activity_state "$agent" "unknown" bridge_agent_heartbeat_activity_state "$agent")"
+  # bridge_queue_cli internally forks python3 to bridge-queue-gateway.py
+  # (lib/bridge-core.sh:583) — bound via the same helper. We strip the
+  # leading newlines that head(1) might preserve when the helper returns
+  # the sentinel value.
+  local _hb_summary_raw=""
+  _hb_summary_raw="$(_bridge_heartbeat_value_with_timeout 10 queue_summary "$agent" "" \
+      bridge_queue_cli summary --agent "$agent" --format tsv)"
+  summary="$(printf '%s' "$_hb_summary_raw" | head -n 1 || true)"
   if [[ -n "$summary" ]]; then
     IFS=$'\t' read -r _agent queued claimed blocked _active idle last_seen last_nudge _session _engine _workdir <<<"$summary"
   fi
+
+  # Pre-resolve every heredoc command-substitution with a per-call ceiling.
+  # bridge_now_iso is local-only (date(1)) — 2s ceiling is generous.
+  hb_now="$(_bridge_heartbeat_value_with_timeout 2 now_iso "$agent" "?" bridge_now_iso)"
+  hb_desc="$(_bridge_heartbeat_value_with_timeout 2 desc "$agent" "-" bridge_agent_desc "$agent")"
+  hb_engine="$(_bridge_heartbeat_value_with_timeout 2 engine "$agent" "-" bridge_agent_engine "$agent")"
+  hb_source="$(_bridge_heartbeat_value_with_timeout 2 source "$agent" "-" bridge_agent_source "$agent")"
+  # bridge_agent_is_always_on returns 0/1 (no stdout); the original heredoc
+  # used `&& printf yes || printf no`. Use the small inline shim
+  # _bridge_heartbeat_always_on_yesno (defined above) to convert the
+  # return code into stdout we can capture through the bounded helper.
+  # The helper already forks the call into a subshell (`( "$@" )`) which
+  # inherits all daemon functions so the shim resolves naturally.
+  hb_always_on="$(_bridge_heartbeat_value_with_timeout 2 always_on_check "$agent" "no" \
+      _bridge_heartbeat_always_on_yesno "$agent")"
+  # bridge_agent_wake_status / notify_status / channel_status are the
+  # operator-visible heavy hitters from #946 — channel_status transitively
+  # forks python3 to lib/bridge-agents.sh extract-dev-channels-from-command.py
+  # which is exactly what wedged on stale worktree paths. 10s ceiling.
+  hb_wake_status="$(_bridge_heartbeat_value_with_timeout 5 wake_status "$agent" "?" bridge_agent_wake_status "$agent")"
+  hb_notify_status="$(_bridge_heartbeat_value_with_timeout 5 notify_status "$agent" "?" bridge_agent_notify_status "$agent")"
+  hb_channel_status="$(_bridge_heartbeat_value_with_timeout 10 channel_status "$agent" "?" bridge_agent_channel_status "$agent")"
 
   temp_file="$(mktemp)"
   # Audit A17 (P1 leak): the cat/mv/rm cleanup at the function tail
@@ -308,22 +484,27 @@ write_agent_heartbeat() {
   #
   # A RETURN trap does NOT fire on set-e abort (codex r1 repro on
   # PR #915), so explicit error check + rm is required.
+  #
+  # Issue #946 L2: the heredoc body now only references pre-resolved
+  # local variables — no command substitutions remain inside. A stuck
+  # helper degrades a single value to its sentinel rather than wedging
+  # the whole `cat`.
   if ! cat >"$temp_file" <<EOF
 # Heartbeat
 
-- generated_at: $(bridge_now_iso)
+- generated_at: ${hb_now}
 - agent: ${agent}
-- description: $(bridge_agent_desc "$agent")
-- engine: $(bridge_agent_engine "$agent")
-- source: $(bridge_agent_source "$agent")
+- description: ${hb_desc}
+- engine: ${hb_engine}
+- source: ${hb_source}
 - session: ${session:--}
 - workdir: ${workdir:--}
 - active: ${active}
 - activity_state: ${state}
-- always_on: $(bridge_agent_is_always_on "$agent" && printf 'yes' || printf 'no')
-- wake_status: $(bridge_agent_wake_status "$agent")
-- notify_status: $(bridge_agent_notify_status "$agent")
-- channel_status: $(bridge_agent_channel_status "$agent")
+- always_on: ${hb_always_on}
+- wake_status: ${hb_wake_status}
+- notify_status: ${hb_notify_status}
+- channel_status: ${hb_channel_status}
 
 ## Queue
 
@@ -5933,14 +6114,30 @@ cmd_sync_cycle() {
   # added. Capture rc + emit a one-line audit so operator can catch
   # matrix-not-applied via `agent-bridge audit follow` instead of
   # cycling on a green-looking daemon.
-  if ! bridge_write_idle_ready_agents "$ready_agents_file"; then
+  #
+  # Issue #946 L4: when the writer fails, the previous code fell through
+  # to bridge_task_daemon_step with a broken/empty ready-agent file. The
+  # downstream consumer then computed nudge candidates from invalid input,
+  # silently suppressing `[task-queued]` interrupts on the operator host
+  # for hours (operator-host evidence 2026-05-17: hundreds of `idle_ready
+  # writer failed` lines while queued tasks never reached their target).
+  # Skip bridge_task_daemon_step explicitly on writer failure so the next
+  # tick re-attempts with fresh state, and track consecutive failures so
+  # a wedged writer surfaces as an audit row instead of log noise.
+  nudge_output=""
+  if bridge_write_idle_ready_agents "$ready_agents_file"; then
+    _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=0
+    nudge_output="$(bridge_task_daemon_step "$snapshot_file" "$ready_agents_file" 2>/dev/null || true)"
+  else
+    _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=$(( _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL + 1 ))
     bridge_audit_log daemon daemon_step_warning daemon \
       --detail step="nudge_scan_idle_ready" \
       --detail reason="bridge_write_idle_ready_agents non-zero (matrix not applied or writer error)" \
+      --detail consecutive_failures="$_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL" \
+      --detail action="skip_bridge_task_daemon_step" \
       2>/dev/null || true
-    daemon_log_event "nudge_scan: idle_ready writer failed (matrix-aware fix #781); cycle continues"
+    daemon_log_event "[L4] nudge_scan: idle_ready writer failed (consec=${_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL}); skipping bridge_task_daemon_step this tick (refs #946, matrix-aware #781)"
   fi
-  nudge_output="$(bridge_task_daemon_step "$snapshot_file" "$ready_agents_file" 2>/dev/null || true)"
   rm -f "$snapshot_file"
   rm -f "$ready_agents_file"
 

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -120,12 +120,14 @@ BRIDGE_DAEMON_LAST_STEP="${BRIDGE_DAEMON_LAST_STEP:-init}"
 BRIDGE_DAEMON_ERR_LOCATION="${BRIDGE_DAEMON_ERR_LOCATION:-}"
 _BRIDGE_DAEMON_EXIT_LOGGED=0
 _BRIDGE_DAEMON_IN_ERR_TRAP=0
-# Issue #946 L4: consecutive-failure counter for bridge_write_idle_ready_agents.
-# Reset to 0 on each successful write; incremented on each failure. The
-# nudge_scan step uses this both to skip bridge_task_daemon_step on the
-# failing tick (avoiding broken-state consumption) and to surface a
-# `daemon_nudge_skip_streak` audit row so an operator can spot a wedged
-# writer after N consecutive ticks instead of having to grep raw logs.
+# Issue #946 L4 / PR #952 r2: consecutive-failure counter for
+# bridge_write_idle_ready_agents. Reset to 0 on each successful write;
+# incremented on each failure. The nudge_scan step uses this both to (a)
+# trigger the maintenance-only fallback path on the failing tick (avoiding
+# broken-state nudge consumption while preserving queue maintenance) and
+# (b) surface a `daemon_step_warning` audit row so an operator can spot a
+# wedged writer after N consecutive ticks instead of having to grep raw
+# logs.
 _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=0
 
 _bridge_daemon_on_signal() {
@@ -290,6 +292,33 @@ EOF
 # child fork, and `set -e` did not abort because `cat` had not yet
 # observed a failure. Pre-resolving the values gives us a clean failure
 # boundary on each call.
+# PR #952 r2 P2 #2: recursive descendant kill. The wedged-helper case
+# documented for L2 is a bash function that forks a python3/tmux child
+# (e.g. bridge_agent_channel_status → python3 bridge-channels.py).
+# Killing just the immediate background subshell PID leaves the python3
+# grandchild orphaned, so a stuck helper still leaked one long-running
+# child per heartbeat tick.
+#
+# We walk descendants depth-first with pgrep -P (depth-first so leaves
+# die before their parents — reduces SIGCHLD reaping races) and send the
+# requested signal to each. setsid / process-group kill is not portable
+# across macOS/Linux without an external wrapper (perl POSIX, util-linux
+# setsid) AND would require launching helpers via bash -c, which loses
+# the in-process bash function table. Recursive pgrep is the cleanest
+# portable approach given those constraints; pgrep is in
+# procps-ng (Linux) and Darwin base (macOS), already required by other
+# daemon paths.
+_bridge_kill_proc_tree() {
+  local root_pid="$1"
+  local sig="${2:-TERM}"
+  local children child
+  children="$(pgrep -P "$root_pid" 2>/dev/null || true)"
+  for child in $children; do
+    _bridge_kill_proc_tree "$child" "$sig"
+  done
+  kill "-$sig" "$root_pid" 2>/dev/null || true
+}
+
 _bridge_heartbeat_value_with_timeout() {
   # Args: <timeout_seconds> <call_site_label> <agent> <default> <fn> [fn-args...]
   #
@@ -309,7 +338,9 @@ _bridge_heartbeat_value_with_timeout() {
   #      completes.
   #   2. poll kill -0 up to `secs` ticks (~1s resolution; aligned with
   #      the daemon's existing audit cadence).
-  #   3. on deadline expiry: kill -TERM, brief grace, kill -KILL, drop
+  #   3. on deadline expiry: kill the entire descendant tree (PR #952 r2
+  #      P2 #2 — recursive pgrep so python3/tmux grandchildren do not
+  #      leak as orphans), brief grace, escalate to SIGKILL, drop
   #      tempfile, return sentinel + L2 event.
   #   4. on natural completion: wait + read tempfile contents.
   local secs="$1"
@@ -351,13 +382,16 @@ _bridge_heartbeat_value_with_timeout() {
   done
 
   if kill -0 "$pid" 2>/dev/null; then
-    # Deadline hit — escalate from TERM to KILL like the queue gateway
-    # stop helper does. A 0.5s grace covers most python3 helpers; the
+    # Deadline hit — recursive descendant kill so any python3/tmux child
+    # of the wrapper subshell dies too (PR #952 r2 P2 #2). Without this
+    # the python3 grandchild survived as an orphan per tick — codex's
+    # 4891ms probe caught the leak. Escalate TERM → KILL like the queue
+    # gateway stop helper. A 0.5s grace covers most python3 helpers; the
     # KILL is the hard cap so the parent can never wait indefinitely.
-    kill -TERM "$pid" 2>/dev/null || true
+    _bridge_kill_proc_tree "$pid" "TERM"
     sleep 0.5
     if kill -0 "$pid" 2>/dev/null; then
-      kill -KILL "$pid" 2>/dev/null || true
+      _bridge_kill_proc_tree "$pid" "KILL"
     fi
     wait "$pid" 2>/dev/null || true
     daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' timed out at ${secs}s; substituting sentinel '${default}' (refs #946)"
@@ -6115,15 +6149,24 @@ cmd_sync_cycle() {
   # matrix-not-applied via `agent-bridge audit follow` instead of
   # cycling on a green-looking daemon.
   #
-  # Issue #946 L4: when the writer fails, the previous code fell through
-  # to bridge_task_daemon_step with a broken/empty ready-agent file. The
-  # downstream consumer then computed nudge candidates from invalid input,
-  # silently suppressing `[task-queued]` interrupts on the operator host
-  # for hours (operator-host evidence 2026-05-17: hundreds of `idle_ready
-  # writer failed` lines while queued tasks never reached their target).
-  # Skip bridge_task_daemon_step explicitly on writer failure so the next
-  # tick re-attempts with fresh state, and track consecutive failures so
-  # a wedged writer surfaces as an audit row instead of log noise.
+  # Issue #946 L4 / PR #952 r2: when the writer fails, the original code
+  # fell through to bridge_task_daemon_step with a broken/empty ready-agent
+  # file. The downstream consumer then computed nudge candidates from
+  # invalid input, silently suppressing `[task-queued]` interrupts on the
+  # operator host for hours (operator-host evidence 2026-05-17: hundreds of
+  # `idle_ready writer failed` lines while queued tasks never reached their
+  # target). r1 skipped bridge_task_daemon_step entirely on writer failure,
+  # which fixed the bad-nudge problem but starved the same step's
+  # maintenance side-effects (lease extend/expire, cron de-dupe, stale-
+  # claim requeue, blocked-task aging) for the whole tick — a writer wedge
+  # would now freeze queue maintenance for as long as it lasted.
+  #
+  # r2 splits the two concerns: on writer failure we still call
+  # bridge_task_daemon_step but with --maintenance-only so the python
+  # backend runs all the maintenance work and then exits without consuming
+  # the (broken) ready-agents file or printing nudge candidates. The
+  # consecutive-failure counter and audit row are preserved so an operator
+  # still gets the writer-wedge signal.
   nudge_output=""
   if bridge_write_idle_ready_agents "$ready_agents_file"; then
     _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=0
@@ -6134,9 +6177,15 @@ cmd_sync_cycle() {
       --detail step="nudge_scan_idle_ready" \
       --detail reason="bridge_write_idle_ready_agents non-zero (matrix not applied or writer error)" \
       --detail consecutive_failures="$_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL" \
-      --detail action="skip_bridge_task_daemon_step" \
+      --detail action="maintenance_only_skip_nudges" \
       2>/dev/null || true
-    daemon_log_event "[L4] nudge_scan: idle_ready writer failed (consec=${_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL}); skipping bridge_task_daemon_step this tick (refs #946, matrix-aware #781)"
+    daemon_log_event "[L4] nudge_scan: idle_ready writer failed (consec=${_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL}); running daemon_step maintenance-only and skipping nudges this tick (refs #946 L4, PR #952 r2, matrix-aware #781)"
+    # Run the maintenance side-effects without nudge dispatch. Failures
+    # here are non-fatal — the step's external state (sqlite txns) is
+    # already protected by its own transaction boundary, and an exception
+    # path leaves the next tick to retry. nudge_output stays empty so the
+    # downstream nudge-fanout loop is a no-op for this tick.
+    bridge_task_daemon_step --maintenance-only "$snapshot_file" >/dev/null 2>&1 || true
   fi
   rm -f "$snapshot_file"
   rm -f "$ready_agents_file"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -553,18 +553,6 @@ _bridge_heartbeat_value_with_timeout() {
   return 0
 }
 
-# Tiny shim that converts bridge_agent_is_always_on's exit code into the
-# yes/no token the heartbeat report expects. Exists so the bounded helper
-# above can capture the answer via stdout (its only channel) rather than
-# the function's return code (which is lost across the subshell boundary).
-_bridge_heartbeat_always_on_yesno() {
-  if bridge_agent_is_always_on "$1"; then
-    printf '%s' "yes"
-  else
-    printf '%s' "no"
-  fi
-}
-
 write_agent_heartbeat() {
   local agent="$1"
   local heartbeat_file=""
@@ -617,26 +605,39 @@ write_agent_heartbeat() {
     IFS=$'\t' read -r _agent queued claimed blocked _active idle last_seen last_nudge _session _engine _workdir <<<"$summary"
   fi
 
-  # Pre-resolve every heredoc command-substitution with a per-call ceiling.
-  # bridge_now_iso is local-only (date(1)) — 2s ceiling is generous.
+  # Pre-resolve heredoc command-substitutions. PR #952 r7 perf scope:
+  # only the wedge-prone sites (those that fork python3 / tmux / external
+  # subprocesses) go through _bridge_heartbeat_value_with_timeout. The
+  # cheap pure-bash helpers (assoc-array getters, numeric compares) are
+  # called directly — wrapping them costs at minimum one `sleep 0.1` poll
+  # tick per call (the helper backgrounds the fn into a subshell and polls
+  # `kill -0` at 100 ms cadence before reaping). Codex r6 P2: a healthy
+  # tick paid ~0.5 s of mandatory latency for the four cheap callers on
+  # every static agent. Direct invocation restores the pre-r1 fast path.
+  #
+  # Wrap retained on: now_iso (forks python3 in bridge_now_iso),
+  # wake_status (calls bridge_tmux_* probes), channel_status (transitively
+  # forks python3 to extract-dev-channels-from-command for the operator
+  # wedge surface from #946).
+  #
+  # Wrap removed on: desc / engine / source / always_on_check /
+  # notify_status. All five are pure bash — assoc-array lookups, numeric
+  # compares, and string tests with no fork. They cannot wedge on a stale
+  # BRIDGE_SCRIPT_DIR (no helper file to read) and cannot hang on a tmux
+  # probe (no tmux call), so the timeout wrapper provides no protection.
   hb_now="$(_bridge_heartbeat_value_with_timeout 2 now_iso "$agent" "?" bridge_now_iso)"
-  hb_desc="$(_bridge_heartbeat_value_with_timeout 2 desc "$agent" "-" bridge_agent_desc "$agent")"
-  hb_engine="$(_bridge_heartbeat_value_with_timeout 2 engine "$agent" "-" bridge_agent_engine "$agent")"
-  hb_source="$(_bridge_heartbeat_value_with_timeout 2 source "$agent" "-" bridge_agent_source "$agent")"
-  # bridge_agent_is_always_on returns 0/1 (no stdout); the original heredoc
-  # used `&& printf yes || printf no`. Use the small inline shim
-  # _bridge_heartbeat_always_on_yesno (defined above) to convert the
-  # return code into stdout we can capture through the bounded helper.
-  # The helper already forks the call into a subshell (`( "$@" )`) which
-  # inherits all daemon functions so the shim resolves naturally.
-  hb_always_on="$(_bridge_heartbeat_value_with_timeout 2 always_on_check "$agent" "no" \
-      _bridge_heartbeat_always_on_yesno "$agent")"
-  # bridge_agent_wake_status / notify_status / channel_status are the
-  # operator-visible heavy hitters from #946 — channel_status transitively
-  # forks python3 to lib/bridge-agents.sh extract-dev-channels-from-command.py
-  # which is exactly what wedged on stale worktree paths. 10s ceiling.
+  hb_desc="$(bridge_agent_desc "$agent")"
+  hb_engine="$(bridge_agent_engine "$agent")"
+  hb_source="$(bridge_agent_source "$agent")"
+  # bridge_agent_is_always_on returns 0/1 (no stdout). Convert inline so
+  # the heredoc can interpolate a token; pure-bash so no wrap needed.
+  if bridge_agent_is_always_on "$agent"; then
+    hb_always_on="yes"
+  else
+    hb_always_on="no"
+  fi
   hb_wake_status="$(_bridge_heartbeat_value_with_timeout 5 wake_status "$agent" "?" bridge_agent_wake_status "$agent")"
-  hb_notify_status="$(_bridge_heartbeat_value_with_timeout 5 notify_status "$agent" "?" bridge_agent_notify_status "$agent")"
+  hb_notify_status="$(bridge_agent_notify_status "$agent")"
   hb_channel_status="$(_bridge_heartbeat_value_with_timeout 10 channel_status "$agent" "?" bridge_agent_channel_status "$agent")"
 
   temp_file="$(mktemp)"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -308,11 +308,55 @@ EOF
 # portable approach given those constraints; pgrep is in
 # procps-ng (Linux) and Darwin base (macOS), already required by other
 # daemon paths.
+#
+# PR #952 r3 P2 #1: pgrep failure escalation. pgrep exit codes:
+#   0 — matches found
+#   1 — no matches (a leaf process; normal termination of the recursion)
+#   2 — invalid options
+#   3 — fatal error (e.g. macOS sandbox "Cannot get process list",
+#       /proc unreadable, etc.)
+# The r2 form swallowed exit ≥2 as "no children", which meant the
+# wedged helper's actual grandchildren survived the kill walk. r3
+# detects the failure and falls back to scanning `ps -A -o pid,ppid`
+# for descendants — `ps` is in POSIX and not subject to the pgrep
+# sandbox path that fails first.
+_bridge_enumerate_children() {
+  # Stdout: one child PID per line. Exit 0 always — caller decides
+  # whether an empty list is meaningful.
+  local parent_pid="$1"
+  local pgrep_out pgrep_rc=0
+  pgrep_out="$(pgrep -P "$parent_pid" 2>/dev/null)" || pgrep_rc=$?
+  if (( pgrep_rc == 0 )) || (( pgrep_rc == 1 )); then
+    # 0 = matches; 1 = no matches (leaf process). Either is the
+    # authoritative answer; no fallback needed.
+    [[ -n "$pgrep_out" ]] && printf '%s\n' "$pgrep_out"
+    return 0
+  fi
+  # pgrep failed (sandbox / /proc gone / invalid options). Fall back
+  # to `ps` — it does not share pgrep's enumeration path on macOS.
+  # `ps -A -o pid=,ppid=` is portable across macOS + Linux + BSD.
+  local line child_pid child_ppid
+  while IFS= read -r line; do
+    # Trim leading whitespace, then split on whitespace.
+    line="${line#"${line%%[![:space:]]*}"}"
+    child_pid="${line%% *}"
+    child_ppid="${line#* }"
+    child_ppid="${child_ppid#"${child_ppid%%[![:space:]]*}"}"
+    child_ppid="${child_ppid%% *}"
+    [[ -z "$child_pid" || -z "$child_ppid" ]] && continue
+    [[ "$child_pid" =~ ^[0-9]+$ && "$child_ppid" =~ ^[0-9]+$ ]] || continue
+    if [[ "$child_ppid" == "$parent_pid" ]]; then
+      printf '%s\n' "$child_pid"
+    fi
+  done < <(ps -A -o pid=,ppid= 2>/dev/null)
+  return 0
+}
+
 _bridge_kill_proc_tree() {
   local root_pid="$1"
   local sig="${2:-TERM}"
   local children child
-  children="$(pgrep -P "$root_pid" 2>/dev/null || true)"
+  children="$(_bridge_enumerate_children "$root_pid")"
   for child in $children; do
     _bridge_kill_proc_tree "$child" "$sig"
   done

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -1824,7 +1824,15 @@ def load_ready_agents(path: str | None) -> set[str]:
 
 def cmd_daemon_step(args: argparse.Namespace) -> int:
     snapshot_rows = load_snapshot(args.snapshot)
-    ready_agents = load_ready_agents(getattr(args, "ready_agents_file", None))
+    # PR #952 r3 P2 #2: defer ready_agents load until the non-skip branch.
+    # When the L4 fail-path calls us with --skip-nudges + a broken/blocking
+    # ready-agents file (e.g. /dev/full, a fifo with no writer, an unreadable
+    # path from a wedged write), the r2 form consumed the file at function
+    # entry and would block/raise before maintenance ran. Maintenance ops
+    # (lease extend/expire, cron de-dupe, stale-claim requeue, blocked-task
+    # aging) do not need ready_agents — load only when nudge dispatch will
+    # actually consume it.
+    ready_agents: set[str] = set()
     current_ts = now_ts()
     lease_seconds = int(args.lease_seconds)
     heartbeat_window = int(args.heartbeat_window)
@@ -2081,6 +2089,13 @@ def cmd_daemon_step(args: argparse.Namespace) -> int:
             if args.format == "text":
                 print("(maintenance-only; nudges skipped)")
             return 0
+
+        # PR #952 r3 P2 #2: load ready-agents only here, after the skip
+        # check — a broken or blocking ready-agents file must NOT be
+        # consumed on the maintenance-only path.
+        ready_agents = load_ready_agents(
+            getattr(args, "ready_agents_file", None)
+        )
 
         rows = conn.execute(
             """

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -2070,6 +2070,18 @@ def cmd_daemon_step(args: argparse.Namespace) -> int:
             admin_agent=admin_agent,
         )
 
+        # Issue #946 L4 / PR #952 r2: maintenance is complete (lease extend
+        # / expire, cron de-dupe, stale-claim requeue, blocked-task aging).
+        # If the caller passed --skip-nudges (the bash daemon's L4 fail-path
+        # uses this when bridge_write_idle_ready_agents failed) return now
+        # without consuming the ready-agents file or emitting nudge rows.
+        # Production-side proof: tests/smoke gating reads the audit log for
+        # the maintenance side-effects regardless of the skip flag.
+        if getattr(args, "skip_nudges", False):
+            if args.format == "text":
+                print("(maintenance-only; nudges skipped)")
+            return 0
+
         rows = conn.execute(
             """
             SELECT assigned_to, id
@@ -2432,6 +2444,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("BRIDGE_ADMIN_AGENT_ID", "patch"),
     )
     daemon_parser.add_argument("--ready-agents-file")
+    # Issue #946 L4 / PR #952 r2: when the idle_ready writer fails the bash
+    # caller still needs maintenance (lease extend/expire, cron de-dupe,
+    # stale-claim requeue, blocked-task aging) to run; only the nudge
+    # candidate enumeration depends on the ready-agents file. --skip-nudges
+    # keeps the maintenance path intact and short-circuits before the
+    # per-agent nudge selection loop, so the daemon never freezes queue
+    # maintenance on a transient writer failure.
+    daemon_parser.add_argument("--skip-nudges", action="store_true")
     daemon_parser.add_argument("--format", choices=("text", "tsv"), default="tsv")
     daemon_parser.set_defaults(handler=cmd_daemon_step)
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -3343,6 +3343,18 @@ bridge_write_roster_status_snapshot() {
 }
 
 bridge_task_daemon_step() {
+  # Issue #946 L4 / PR #952 r2: --maintenance-only (when passed as the very
+  # first positional arg) makes the underlying python step run all the
+  # queue-maintenance work (lease extend/expire, cron de-dupe, stale-claim
+  # requeue, blocked-task aging) but skip the nudge candidate enumeration
+  # and ready-agents file consumption. The bash L4 fail-path calls this
+  # form when bridge_write_idle_ready_agents fails so a transient writer
+  # error no longer freezes queue maintenance for the whole tick.
+  local skip_nudges=0
+  if [[ "${1:-}" == "--maintenance-only" ]]; then
+    skip_nudges=1
+    shift
+  fi
   local snapshot_file="$1"
   local ready_agents_file="${2:-}"
   local zombie_threshold="${BRIDGE_ZOMBIE_NUDGE_THRESHOLD:-10}"
@@ -3359,7 +3371,9 @@ bridge_task_daemon_step() {
     --admin-agent "${BRIDGE_ADMIN_AGENT_ID:-patch}"
   )
 
-  if [[ -n "$ready_agents_file" && -f "$ready_agents_file" ]]; then
+  if (( skip_nudges )); then
+    args+=(--skip-nudges)
+  elif [[ -n "$ready_agents_file" && -f "$ready_agents_file" ]]; then
     args+=(--ready-agents-file "$ready_agents_file")
   fi
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10971,4 +10971,13 @@ bash "$REPO_ROOT/scripts/smoke/smoke-isolation-no-live-leak.sh"
 log "running bridge-agent-cli-no-deadlock smoke (refs queue task #4773)"
 bash "$REPO_ROOT/scripts/smoke/bridge-agent-cli-no-deadlock.sh"
 
+# Issue #946 L2 + L4 — daemon tick-loop wedge defenses. L2 pre-resolves
+# heartbeat heredoc command substitutions with a per-call deadline so a
+# stuck helper (e.g. stale-worktree python3 path) cannot hang the tick.
+# L4 gates bridge_task_daemon_step on bridge_write_idle_ready_agents
+# succeeding so a broken ready-agent file is never consumed (root cause
+# of operator-host nudge-suppression 2026-05-17).
+log "running daemon-tick-guards-l2-l4 smoke (refs #946 L2+L4)"
+bash "$REPO_ROOT/scripts/smoke/daemon-tick-guards-l2-l4.sh"
+
 log "smoke test passed"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11226,30 +11226,25 @@ bash "$REPO_ROOT/scripts/smoke/smoke-isolation-no-live-leak.sh"
 log "running bridge-agent-cli-no-deadlock smoke (refs queue task #4773)"
 bash "$REPO_ROOT/scripts/smoke/bridge-agent-cli-no-deadlock.sh"
 
-<<<<<<< HEAD
-# Issue #946 L2 + L4 — daemon tick-loop wedge defenses + PR #952 r2
-# regressions. L2 pre-resolves heartbeat heredoc command substitutions
-# with a per-call deadline so a stuck helper (e.g. stale-worktree python3
-# path) cannot hang the tick; r2 adds recursive descendant kill so a
-# python3/tmux grandchild does not survive the timeout. L4 runs the
-# daemon step's maintenance side-effects via --maintenance-only on
-# bridge_write_idle_ready_agents failure (r2: previous version skipped
-# the step entirely, starving lease extension / cron de-dupe / blocked-
-# task aging — root cause of operator-host nudge-suppression 2026-05-17).
-log "running daemon-tick-guards-l2-l4 smoke (refs #946 L2+L4, PR #952 r2)"
+# Issue #946 L2 + L4 — daemon tick-loop wedge defenses + PR #952 r2+r5+r6+r7
+# regressions. L2 pre-resolves heartbeat heredoc command substitutions with
+# a per-call deadline so a stuck helper (e.g. stale-worktree python3 path)
+# cannot hang the tick; r2 adds recursive descendant kill so a python3/tmux
+# grandchild does not survive the timeout; r4 uses bash monitor mode (set -m)
+# + negative-pid kill for sandbox resilience; r5 unconditional KILL after
+# grace; r7 scoped wrapper to wedge-prone helpers only. L4 runs the daemon
+# step's maintenance side-effects via --maintenance-only on
+# bridge_write_idle_ready_agents failure (root cause of operator-host
+# nudge-suppression 2026-05-17).
+log "running daemon-tick-guards-l2-l4 smoke (refs #946 L2+L4, PR #952)"
 bash "$REPO_ROOT/scripts/smoke/daemon-tick-guards-l2-l4.sh"
-=======
+
 # bridge-watchdog-silence.py previously truncated captured daemon
 # stop/start output to the last line, so every wedge from 2026-05-15
 # onward surfaced the same v0.8.0 ACL background sentence in the
 # silence-watchdog audit row. Issue #946 L3 preserves the full stderr
 # block and classifies the resolver die path (line 384 / 406 / 439).
-# This smoke step pins the classifier token map, the state-file
-# `resolver_die` + `stderr_preview` persistence, and the multi-line
-# survival contract so the next wedge is diagnosable in seconds rather
-# than hours.
 log "running watchdog-silence-stderr-capture smoke (#946 L3)"
 bash "$REPO_ROOT/scripts/smoke/watchdog-silence-stderr-capture.sh"
->>>>>>> origin/main
 
 log "smoke test passed"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10971,13 +10971,16 @@ bash "$REPO_ROOT/scripts/smoke/smoke-isolation-no-live-leak.sh"
 log "running bridge-agent-cli-no-deadlock smoke (refs queue task #4773)"
 bash "$REPO_ROOT/scripts/smoke/bridge-agent-cli-no-deadlock.sh"
 
-# Issue #946 L2 + L4 — daemon tick-loop wedge defenses. L2 pre-resolves
-# heartbeat heredoc command substitutions with a per-call deadline so a
-# stuck helper (e.g. stale-worktree python3 path) cannot hang the tick.
-# L4 gates bridge_task_daemon_step on bridge_write_idle_ready_agents
-# succeeding so a broken ready-agent file is never consumed (root cause
-# of operator-host nudge-suppression 2026-05-17).
-log "running daemon-tick-guards-l2-l4 smoke (refs #946 L2+L4)"
+# Issue #946 L2 + L4 — daemon tick-loop wedge defenses + PR #952 r2
+# regressions. L2 pre-resolves heartbeat heredoc command substitutions
+# with a per-call deadline so a stuck helper (e.g. stale-worktree python3
+# path) cannot hang the tick; r2 adds recursive descendant kill so a
+# python3/tmux grandchild does not survive the timeout. L4 runs the
+# daemon step's maintenance side-effects via --maintenance-only on
+# bridge_write_idle_ready_agents failure (r2: previous version skipped
+# the step entirely, starving lease extension / cron de-dupe / blocked-
+# task aging — root cause of operator-host nudge-suppression 2026-05-17).
+log "running daemon-tick-guards-l2-l4 smoke (refs #946 L2+L4, PR #952 r2)"
 bash "$REPO_ROOT/scripts/smoke/daemon-tick-guards-l2-l4.sh"
 
 log "smoke test passed"

--- a/scripts/smoke/daemon-tick-guards-helpers/check-load-ready-after-skip.py
+++ b/scripts/smoke/daemon-tick-guards-helpers/check-load-ready-after-skip.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""scripts/smoke/daemon-tick-guards-helpers/check-load-ready-after-skip.py
+
+PR #952 r3 P2 #2 in-source guard. Asserts that inside bridge-queue.py's
+cmd_daemon_step, the first call to load_ready_agents(...) appears AFTER
+the `if getattr(args, "skip_nudges", False):` short-circuit. If the call
+order ever regresses (load before the skip check), a broken/blocking
+ready-agents file would hang the maintenance-only path again.
+
+Extracted from the smoke heredoc to dodge the Bash 5.3.9 heredoc-write
+deadlock (CLAUDE.md footgun #11, lib/upgrade-helpers/ precedent).
+
+Usage: check-load-ready-after-skip.py <path/to/bridge-queue.py>
+Exit codes:
+  0 — order is correct (load after skip)
+  1 — regression (load before skip) or anchor missing
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(
+            "usage: check-load-ready-after-skip.py <bridge-queue.py>",
+            file=sys.stderr,
+        )
+        return 1
+    path = argv[1]
+    try:
+        src = open(path, encoding="utf-8").read()
+    except OSError as exc:
+        print(f"cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+
+    # Carve out cmd_daemon_step's body so we don't pick up references in
+    # neighbouring functions. The function ends at the next top-level
+    # `def `; this regex captures everything up to that boundary.
+    match = re.search(
+        r"def cmd_daemon_step\(.*?\n(?=\Sdef |\Z)",
+        src,
+        re.DOTALL,
+    )
+    fn = match.group(0) if match else src
+
+    load_idx = fn.find("load_ready_agents(")
+    skip_idx = fn.find('if getattr(args, "skip_nudges", False):')
+    if load_idx == -1:
+        print(
+            "anchor missing: load_ready_agents(...) call not found in "
+            "cmd_daemon_step. Did the deferred-load branch get refactored "
+            "away?",
+            file=sys.stderr,
+        )
+        return 1
+    if skip_idx == -1:
+        print(
+            "anchor missing: `if getattr(args, \"skip_nudges\", False):` "
+            "not found in cmd_daemon_step. Did the --skip-nudges short-"
+            "circuit get refactored away?",
+            file=sys.stderr,
+        )
+        return 1
+    if load_idx < skip_idx:
+        print(
+            "PR #952 r3 P2 #2 regression: load_ready_agents called BEFORE "
+            f"the skip_nudges check (load_idx={load_idx}, "
+            f"skip_idx={skip_idx}). r3 requires the load to live in the "
+            "non-skip branch so a broken/blocking ready-agents file does "
+            "not hang the maintenance-only path.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
+++ b/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
@@ -54,6 +54,21 @@ daemon_log_event() {
 # (the smoke's step_in_source_wiring_present check asserts the production
 # helper exists; this driver mirrors its behavior so the smoke can drive
 # it without bringing up the full sync_cycle dependency stack).
+#
+# PR #952 r2 P2 #2: recursive descendant kill. Mirrors
+# _bridge_kill_proc_tree in bridge-daemon.sh — kills the entire descendant
+# tree so a python3/tmux grandchild does not leak as an orphan.
+_bridge_kill_proc_tree() {
+  local root_pid="$1"
+  local sig="${2:-TERM}"
+  local children child
+  children="$(pgrep -P "$root_pid" 2>/dev/null || true)"
+  for child in $children; do
+    _bridge_kill_proc_tree "$child" "$sig"
+  done
+  kill "-$sig" "$root_pid" 2>/dev/null || true
+}
+
 _bridge_heartbeat_value_with_timeout() {
   local secs="$1"
   local label="$2"
@@ -82,10 +97,14 @@ _bridge_heartbeat_value_with_timeout() {
     i=$(( i + 1 ))
   done
   if kill -0 "$pid" 2>/dev/null; then
-    kill -TERM "$pid" 2>/dev/null || true
+    # PR #952 r2 P2 #2: recursive descendant kill (the production helper
+    # does the same). Without this, a python3/tmux grandchild outlives
+    # the timeout and writes its sentinel file after the parent already
+    # returned the fallback — codex r1's leak.
+    _bridge_kill_proc_tree "$pid" "TERM"
     sleep 0.5
     if kill -0 "$pid" 2>/dev/null; then
-      kill -KILL "$pid" 2>/dev/null || true
+      _bridge_kill_proc_tree "$pid" "KILL"
     fi
     wait "$pid" 2>/dev/null || true
     daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' timed out at ${secs}s; substituting sentinel '${default}' (refs #946)"
@@ -120,6 +139,38 @@ _test_sleep_forever() {
   sleep 60
 }
 
+# PR #952 r2 P2 #2 regression probe — a bash function that forks a python3
+# child writing a sentinel file after 5s. The L2 helper must kill the
+# python3 grandchild on timeout; if it survives, the sentinel file will
+# appear in TEST_SENTINEL_FILE after the timeout fires and we return.
+_test_spawn_python3_sentinel_writer() {
+  local sentinel="${TEST_SENTINEL_FILE:?TEST_SENTINEL_FILE not set}"
+  # Run the python3 child in the same process group as us (no setsid /
+  # nohup). The parent function (this bash function) sleeps forever so the
+  # L2 helper deadline must fire while the python3 child is still alive.
+  # If the helper only kills the immediate subshell wrapper, the python3
+  # child orphans into pid 1 and proceeds to write the sentinel — that is
+  # exactly the leak codex flagged.
+  python3 -c "
+import time, sys
+time.sleep(5)
+with open(sys.argv[1], 'w') as f:
+    f.write('survived')
+" "$sentinel" &
+  local child=$!
+  # Parent blocks too so the L2 helper has both PIDs to clean up.
+  wait "$child"
+}
+
+# --- L4 maintenance-mode probe ---------------------------------------------
+# PR #952 r2 P2 #1: spy that records which mode the production-side
+# fall-through invoked bridge_task_daemon_step with. The smoke asserts
+# that on writer failure the maintenance-only mode was invoked (so the
+# downstream cron-dedupe / lease-extend / blocked-task-aging work was NOT
+# starved by the wedged writer).
+_TEST_BRIDGE_TASK_DAEMON_STEP_MAINTENANCE_CALLS=0
+_TEST_BRIDGE_TASK_DAEMON_STEP_FULL_CALLS=0
+
 # --- L4 nudge-scan harness --------------------------------------------------
 # Carbon-copy of the L4 branch in bridge-daemon.sh:6022. Stubs
 # bridge_write_idle_ready_agents (rc controlled by TEST_WRITER_RC) and
@@ -129,9 +180,25 @@ _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=0
 _TEST_BRIDGE_TASK_DAEMON_STEP_CALLS=0
 
 bridge_write_agent_snapshot() { : ; }
+# PR #952 r2 P2 #1: stub records whether the caller passed
+# --maintenance-only (the writer-failure path) or invoked the full step
+# (writer-success path). Writes the breadcrumb to TEST_STEP_SPY_FILE so
+# the smoke can assert across separate driver invocations.
 bridge_task_daemon_step() {
   _TEST_BRIDGE_TASK_DAEMON_STEP_CALLS=$(( _TEST_BRIDGE_TASK_DAEMON_STEP_CALLS + 1 ))
-  printf 'agent\tsession\t0\t0\t0\tkey\n'
+  local mode="full"
+  if [[ "${1:-}" == "--maintenance-only" ]]; then
+    mode="maintenance"
+    _TEST_BRIDGE_TASK_DAEMON_STEP_MAINTENANCE_CALLS=$(( _TEST_BRIDGE_TASK_DAEMON_STEP_MAINTENANCE_CALLS + 1 ))
+  else
+    _TEST_BRIDGE_TASK_DAEMON_STEP_FULL_CALLS=$(( _TEST_BRIDGE_TASK_DAEMON_STEP_FULL_CALLS + 1 ))
+  fi
+  if [[ -n "${TEST_STEP_SPY_FILE:-}" ]]; then
+    printf '%s\n' "$mode" >>"$TEST_STEP_SPY_FILE"
+  fi
+  if [[ "$mode" == "full" ]]; then
+    printf 'agent\tsession\t0\t0\t0\tkey\n'
+  fi
 }
 bridge_write_idle_ready_agents() {
   return "${TEST_WRITER_RC:-0}"
@@ -152,9 +219,13 @@ _test_nudge_scan_branch() {
       --detail step="nudge_scan_idle_ready" \
       --detail reason="bridge_write_idle_ready_agents non-zero (matrix not applied or writer error)" \
       --detail consecutive_failures="$_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL" \
-      --detail action="skip_bridge_task_daemon_step" \
+      --detail action="maintenance_only_skip_nudges" \
       2>/dev/null || true
-    daemon_log_event "[L4] nudge_scan: idle_ready writer failed (consec=${_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL}); skipping bridge_task_daemon_step this tick (refs #946, matrix-aware #781)"
+    daemon_log_event "[L4] nudge_scan: idle_ready writer failed (consec=${_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL}); running daemon_step maintenance-only and skipping nudges this tick (refs #946 L4, PR #952 r2, matrix-aware #781)"
+    # PR #952 r2 P2 #1: still invoke the step in maintenance-only mode so
+    # the queue maintenance side-effects (lease, cron-dedup, blocked-task
+    # aging) are not starved by a transient writer failure.
+    bridge_task_daemon_step --maintenance-only "$snapshot_file" >/dev/null 2>&1 || true
   fi
   rm -f "$snapshot_file" "$ready_agents_file"
   printf '%s' "$nudge_output"
@@ -164,6 +235,13 @@ case "${1:-}" in
   l2_value_with_timeout)
     shift
     _bridge_heartbeat_value_with_timeout "$@"
+    ;;
+  l2_value_with_timeout_pythonchild)
+    # PR #952 r2 P2 #2 probe: drive the helper with the python3-grandchild
+    # spawner. The smoke asserts TEST_SENTINEL_FILE does NOT exist after
+    # the timeout + settle window, proving the grandchild was reaped.
+    shift
+    _bridge_heartbeat_value_with_timeout "$1" "$2" "$3" "$4" _test_spawn_python3_sentinel_writer
     ;;
   l4_nudge_scan)
     shift

--- a/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
+++ b/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
@@ -146,9 +146,14 @@ _bridge_heartbeat_value_with_timeout() {
     # returned the fallback — codex r1's leak.
     _bridge_kill_proc_tree "$pid" "TERM"
     sleep 0.5
-    if kill -0 "$pid" 2>/dev/null; then
-      _bridge_kill_proc_tree "$pid" "KILL"
-    fi
+    # r6 (codex PR #952 r5) — unconditional KILL escalation. A SIGTERM-
+    # ignoring grandchild in the same process group survives the first
+    # _bridge_kill_proc_tree TERM and the wrapper dying makes kill -0 false,
+    # but the grandchild is still alive. SIGKILL is uncatchable so this
+    # negative-PID KILL reaches it via the pgrp. Mirror production
+    # bridge-daemon.sh exactly so the smoke catches the same class of
+    # regression.
+    _bridge_kill_proc_tree "$pid" "KILL"
     wait "$pid" 2>/dev/null || true
     daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' timed out at ${secs}s; substituting sentinel '${default}' (refs #946)"
     bridge_audit_log daemon daemon_heartbeat_helper_timeout daemon \

--- a/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
+++ b/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
@@ -58,11 +58,41 @@ daemon_log_event() {
 # PR #952 r2 P2 #2: recursive descendant kill. Mirrors
 # _bridge_kill_proc_tree in bridge-daemon.sh — kills the entire descendant
 # tree so a python3/tmux grandchild does not leak as an orphan.
+#
+# PR #952 r3 P2 #1: pgrep failure escalation. Mirrors the production
+# _bridge_enumerate_children — when pgrep returns exit ≥2 (macOS sandbox
+# "Cannot get process list", /proc unreadable, etc.), fall back to
+# parsing `ps -A -o pid,ppid` so the wedged helper's grandchildren are
+# still discovered and killed.
+_bridge_enumerate_children() {
+  local parent_pid="$1"
+  local pgrep_out pgrep_rc=0
+  pgrep_out="$(pgrep -P "$parent_pid" 2>/dev/null)" || pgrep_rc=$?
+  if (( pgrep_rc == 0 )) || (( pgrep_rc == 1 )); then
+    [[ -n "$pgrep_out" ]] && printf '%s\n' "$pgrep_out"
+    return 0
+  fi
+  local line child_pid child_ppid
+  while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    child_pid="${line%% *}"
+    child_ppid="${line#* }"
+    child_ppid="${child_ppid#"${child_ppid%%[![:space:]]*}"}"
+    child_ppid="${child_ppid%% *}"
+    [[ -z "$child_pid" || -z "$child_ppid" ]] && continue
+    [[ "$child_pid" =~ ^[0-9]+$ && "$child_ppid" =~ ^[0-9]+$ ]] || continue
+    if [[ "$child_ppid" == "$parent_pid" ]]; then
+      printf '%s\n' "$child_pid"
+    fi
+  done < <(ps -A -o pid=,ppid= 2>/dev/null)
+  return 0
+}
+
 _bridge_kill_proc_tree() {
   local root_pid="$1"
   local sig="${2:-TERM}"
   local children child
-  children="$(pgrep -P "$root_pid" 2>/dev/null || true)"
+  children="$(_bridge_enumerate_children "$root_pid")"
   for child in $children; do
     _bridge_kill_proc_tree "$child" "$sig"
   done
@@ -242,6 +272,42 @@ case "${1:-}" in
     # the timeout + settle window, proving the grandchild was reaped.
     shift
     _bridge_heartbeat_value_with_timeout "$1" "$2" "$3" "$4" _test_spawn_python3_sentinel_writer
+    ;;
+  l2_value_with_timeout_pgrep_broken)
+    # PR #952 r3 P2 #1 probe: TEST_PGREP_BROKEN_PATH points at a directory
+    # containing a stub pgrep that exits 3 (macOS sandbox failure). We
+    # prepend it to PATH only AFTER the helper has been entered, so the
+    # subshell child path lookup hits the stub. The smoke asserts that
+    # the descendant python3 child still gets reaped — proving the ps
+    # fallback discovered it after pgrep failed.
+    shift
+    if [[ -n "${TEST_PGREP_BROKEN_PATH:-}" ]]; then
+      export PATH="${TEST_PGREP_BROKEN_PATH}:${PATH}"
+    fi
+    _bridge_heartbeat_value_with_timeout "$1" "$2" "$3" "$4" _test_spawn_python3_sentinel_writer
+    ;;
+  enumerate_children_pgrep_broken)
+    # PR #952 r3 P2 #1 unit probe: exercise _bridge_enumerate_children
+    # with a broken pgrep stub on PATH. Spawn a known child process
+    # (sleep 30), then call the function and assert the child PID
+    # appears in stdout — proving ps fallback works.
+    shift
+    if [[ -n "${TEST_PGREP_BROKEN_PATH:-}" ]]; then
+      export PATH="${TEST_PGREP_BROKEN_PATH}:${PATH}"
+    fi
+    # Spawn child, capture PID, give kernel a moment to register it.
+    sleep 30 &
+    child_pid=$!
+    sleep 0.2
+    # Print "<my_pid> <child_pid> <enumeration_output>" so the smoke
+    # can assert child_pid appears in enumeration output.
+    echo "PARENT=$$"
+    echo "CHILD=$child_pid"
+    echo "ENUM_OUTPUT_BEGIN"
+    _bridge_enumerate_children "$$"
+    echo "ENUM_OUTPUT_END"
+    kill "$child_pid" 2>/dev/null || true
+    wait "$child_pid" 2>/dev/null || true
     ;;
   l4_nudge_scan)
     shift

--- a/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
+++ b/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh — issue #946 L2+L4 smoke driver.
+#
+# Standalone driver invoked by scripts/smoke/daemon-tick-guards-l2-l4.sh.
+# Extracted to a separate file (rather than written inline via heredoc)
+# to dodge the Bash 5.3.9 heredoc-write deadlock class documented in
+# CLAUDE.md footgun #11 (cf. lib/upgrade-helpers/ for the bridge-upgrade
+# precedent).
+#
+# Subcommands (selected via argv[1]):
+#
+#   l2_value_with_timeout <secs> <label> <agent> <default> <fn> [fn-args...]
+#       Exercises a carbon-copy of bridge-daemon.sh's
+#       _bridge_heartbeat_value_with_timeout helper. Tests pass fn-name +
+#       args; the helper bounds execution with a per-call deadline and
+#       returns either the function's stdout or the sentinel <default>.
+#       On timeout it writes a [L2] line to BRIDGE_DAEMON_CRASH_LOG and a
+#       daemon_heartbeat_helper_timeout audit row to BRIDGE_AUDIT_LOG.
+#
+#   l4_nudge_scan
+#       Exercises a carbon-copy of bridge-daemon.sh's nudge_scan branch
+#       (the L4 region around line 6022). TEST_WRITER_RC=0 makes the
+#       stub bridge_write_idle_ready_agents succeed; non-zero forces the
+#       skip path. Prints whatever bridge_task_daemon_step returned
+#       (empty string on the skip path).
+#
+# Environment expected on entry:
+#   BRIDGE_REPO_ROOT, BRIDGE_HOME, BRIDGE_STATE_DIR, BRIDGE_LOG_DIR,
+#   BRIDGE_SHARED_DIR, BRIDGE_AUDIT_LOG, BRIDGE_SCRIPT_DIR, BRIDGE_LAYOUT,
+#   BRIDGE_DATA_ROOT.
+# Optional: TEST_WRITER_RC (l4_nudge_scan only).
+
+set -uo pipefail
+SCRIPT_DIR="${BRIDGE_REPO_ROOT:?}"
+# shellcheck source=/dev/null
+source "$BRIDGE_REPO_ROOT/bridge-lib.sh"
+
+# BRIDGE_DAEMON_CRASH_LOG is referenced by daemon_log_event. The smoke
+# harness directs it to the per-test BRIDGE_LOG_DIR.
+BRIDGE_DAEMON_CRASH_LOG="${BRIDGE_LOG_DIR}/daemon-crash.log"
+mkdir -p "$BRIDGE_LOG_DIR"
+[[ -f "$BRIDGE_DAEMON_CRASH_LOG" ]] || : >"$BRIDGE_DAEMON_CRASH_LOG"
+
+daemon_log_event() {
+  local message="$1"
+  local timestamp
+  timestamp="$(date '+%Y-%m-%dT%H:%M:%S%z')"
+  mkdir -p "$BRIDGE_STATE_DIR"
+  printf '[%s] %s\n' "$timestamp" "$message" >>"$BRIDGE_DAEMON_CRASH_LOG"
+}
+
+# --- carbon-copy of bridge-daemon.sh L2 helper -----------------------------
+# Keep in sync with bridge-daemon.sh _bridge_heartbeat_value_with_timeout
+# (the smoke's step_in_source_wiring_present check asserts the production
+# helper exists; this driver mirrors its behavior so the smoke can drive
+# it without bringing up the full sync_cycle dependency stack).
+_bridge_heartbeat_value_with_timeout() {
+  local secs="$1"
+  local label="$2"
+  local agent="$3"
+  local default="$4"
+  shift 4
+  if [[ ! "$secs" =~ ^[0-9]+$ ]] || (( secs == 0 )); then
+    secs=5
+  fi
+  local stdout_file
+  stdout_file="$(mktemp 2>/dev/null)" || stdout_file=""
+  if [[ -z "$stdout_file" ]]; then
+    daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}': mktemp failed; substituting sentinel '${default}' (refs #946)"
+    printf '%s' "$default"
+    return 0
+  fi
+  ( "$@" >"$stdout_file" 2>/dev/null ) &
+  local pid=$!
+  local i=0
+  local poll_max=$(( secs * 10 ))
+  while (( i < poll_max )); do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.1
+    i=$(( i + 1 ))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    kill -TERM "$pid" 2>/dev/null || true
+    sleep 0.5
+    if kill -0 "$pid" 2>/dev/null; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+    daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' timed out at ${secs}s; substituting sentinel '${default}' (refs #946)"
+    bridge_audit_log daemon daemon_heartbeat_helper_timeout daemon \
+      --detail call_site="heartbeat_${label}" \
+      --detail agent="$agent" \
+      --detail timeout_seconds="$secs" \
+      --detail sentinel="$default" \
+      2>/dev/null || true
+    rm -f -- "$stdout_file"
+    printf '%s' "$default"
+    return 0
+  fi
+  local rc=0
+  wait "$pid" && rc=0 || rc=$?
+  if (( rc != 0 )); then
+    daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' exited rc=${rc}; substituting sentinel '${default}' (refs #946)"
+    rm -f -- "$stdout_file"
+    printf '%s' "$default"
+    return 0
+  fi
+  cat -- "$stdout_file" 2>/dev/null || printf '%s' "$default"
+  rm -f -- "$stdout_file"
+  return 0
+}
+
+# Test stubs — fast-success and forever-sleep — to drive the helper.
+_test_fast_success() {
+  printf '%s' "fast-value"
+}
+_test_sleep_forever() {
+  sleep 60
+}
+
+# --- L4 nudge-scan harness --------------------------------------------------
+# Carbon-copy of the L4 branch in bridge-daemon.sh:6022. Stubs
+# bridge_write_idle_ready_agents (rc controlled by TEST_WRITER_RC) and
+# spies on bridge_task_daemon_step via a per-process call counter.
+
+_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=0
+_TEST_BRIDGE_TASK_DAEMON_STEP_CALLS=0
+
+bridge_write_agent_snapshot() { : ; }
+bridge_task_daemon_step() {
+  _TEST_BRIDGE_TASK_DAEMON_STEP_CALLS=$(( _TEST_BRIDGE_TASK_DAEMON_STEP_CALLS + 1 ))
+  printf 'agent\tsession\t0\t0\t0\tkey\n'
+}
+bridge_write_idle_ready_agents() {
+  return "${TEST_WRITER_RC:-0}"
+}
+
+_test_nudge_scan_branch() {
+  local snapshot_file ready_agents_file
+  snapshot_file="$(mktemp)"
+  ready_agents_file="$(mktemp)"
+  bridge_write_agent_snapshot "$snapshot_file"
+  local nudge_output=""
+  if bridge_write_idle_ready_agents "$ready_agents_file"; then
+    _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=0
+    nudge_output="$(bridge_task_daemon_step "$snapshot_file" "$ready_agents_file" 2>/dev/null || true)"
+  else
+    _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL=$(( _BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL + 1 ))
+    bridge_audit_log daemon daemon_step_warning daemon \
+      --detail step="nudge_scan_idle_ready" \
+      --detail reason="bridge_write_idle_ready_agents non-zero (matrix not applied or writer error)" \
+      --detail consecutive_failures="$_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL" \
+      --detail action="skip_bridge_task_daemon_step" \
+      2>/dev/null || true
+    daemon_log_event "[L4] nudge_scan: idle_ready writer failed (consec=${_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL}); skipping bridge_task_daemon_step this tick (refs #946, matrix-aware #781)"
+  fi
+  rm -f "$snapshot_file" "$ready_agents_file"
+  printf '%s' "$nudge_output"
+}
+
+case "${1:-}" in
+  l2_value_with_timeout)
+    shift
+    _bridge_heartbeat_value_with_timeout "$@"
+    ;;
+  l4_nudge_scan)
+    shift
+    _test_nudge_scan_branch "$@"
+    ;;
+  *)
+    echo "unknown subcommand: ${1:-}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
+++ b/scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh
@@ -89,13 +89,21 @@ _bridge_enumerate_children() {
 }
 
 _bridge_kill_proc_tree() {
+  # PR #952 r4 P1: process-group kill is the primary mechanism. The
+  # wrapper subshell is its own pgrp leader (the helper enables `set -m`
+  # before forking), so a negative-pid kill reaches every descendant
+  # without depending on pgrep / ps process-table access. Defensive
+  # enumeration runs second and is a no-op when the pgrp kill succeeded.
   local root_pid="$1"
   local sig="${2:-TERM}"
+  kill "-$sig" -- "-$root_pid" 2>/dev/null || true
   local children child
   children="$(_bridge_enumerate_children "$root_pid")"
-  for child in $children; do
-    _bridge_kill_proc_tree "$child" "$sig"
-  done
+  if [[ -n "$children" ]]; then
+    for child in $children; do
+      _bridge_kill_proc_tree "$child" "$sig"
+    done
+  fi
   kill "-$sig" "$root_pid" 2>/dev/null || true
 }
 
@@ -115,8 +123,13 @@ _bridge_heartbeat_value_with_timeout() {
     printf '%s' "$default"
     return 0
   fi
-  ( "$@" >"$stdout_file" 2>/dev/null ) &
+  # PR #952 r4 P1: enable bash monitor mode just around the fork so the
+  # wrapper subshell becomes its own process-group leader. Mirrors the
+  # production helper.
+  set -m
+  ( set +m; "$@" >"$stdout_file" 2>/dev/null ) &
   local pid=$!
+  set +m
   local i=0
   local poll_max=$(( secs * 10 ))
   while (( i < poll_max )); do
@@ -149,7 +162,9 @@ _bridge_heartbeat_value_with_timeout() {
     return 0
   fi
   local rc=0
-  wait "$pid" && rc=0 || rc=$?
+  # Silence monitor-mode "Done" / "Terminated" job-completion notices
+  # that bash prints to stderr (PR #952 r4 P1).
+  wait "$pid" 2>/dev/null && rc=0 || rc=$?
   if (( rc != 0 )); then
     daemon_log_event "[L2] heartbeat helper '${label}' for agent '${agent}' exited rc=${rc}; substituting sentinel '${default}' (refs #946)"
     rm -f -- "$stdout_file"
@@ -283,6 +298,25 @@ case "${1:-}" in
     shift
     if [[ -n "${TEST_PGREP_BROKEN_PATH:-}" ]]; then
       export PATH="${TEST_PGREP_BROKEN_PATH}:${PATH}"
+    fi
+    _bridge_heartbeat_value_with_timeout "$1" "$2" "$3" "$4" _test_spawn_python3_sentinel_writer
+    ;;
+  l2_value_with_timeout_pgrep_and_ps_broken)
+    # PR #952 r4 P1 probe: TEST_BROKEN_PROCTABLE_PATH points at a
+    # directory containing stubs for BOTH pgrep AND ps that exit non-zero
+    # with "Operation not permitted" — this is the macOS sandbox /
+    # restricted-container scenario codex r3 caught. With both
+    # process-table primitives denied, descendant enumeration returns
+    # the empty list. The r3 form would only reap the immediate wrapper
+    # subshell and leak the python3 grandchild.
+    #
+    # r4 puts the wrapper in its own process group via `set -m` and
+    # kills via negative-pid, which does NOT require process-table
+    # access. The smoke asserts the python3 child sentinel never
+    # appears, proving the pgrp kill reached the grandchild.
+    shift
+    if [[ -n "${TEST_BROKEN_PROCTABLE_PATH:-}" ]]; then
+      export PATH="${TEST_BROKEN_PROCTABLE_PATH}:${PATH}"
     fi
     _bridge_heartbeat_value_with_timeout "$1" "$2" "$3" "$4" _test_spawn_python3_sentinel_writer
     ;;

--- a/scripts/smoke/daemon-tick-guards-l2-l4.sh
+++ b/scripts/smoke/daemon-tick-guards-l2-l4.sh
@@ -113,7 +113,27 @@ run_driver() {
     BRIDGE_SCRIPT_DIR="$BRIDGE_SCRIPT_DIR" \
     BRIDGE_LAYOUT="$BRIDGE_LAYOUT" \
     BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+    TEST_PGREP_BROKEN_PATH="${TEST_PGREP_BROKEN_PATH:-}" \
     bash "$DRIVER" "$@"
+}
+
+# PR #952 r3 P2 #1: build a directory with a stub pgrep that always exits
+# 3 (mimics macOS sandbox "Cannot get process list"). The driver prepends
+# this dir to PATH so the recursive child enumeration must fall back to
+# `ps -A -o pid,ppid` parsing.
+make_broken_pgrep_dir() {
+  local dir
+  dir="$(mktemp -d -t agb-broken-pgrep-XXXXXX)"
+  cat >"$dir/pgrep" <<'STUB'
+#!/usr/bin/env bash
+# Stub: mimic pgrep that cannot enumerate processes.
+# Exit code 3 = fatal error (real pgrep returns this on macOS sandbox
+# "Cannot get process list" and on /proc unreadable).
+echo "pgrep: Cannot get process list" >&2
+exit 3
+STUB
+  chmod +x "$dir/pgrep"
+  printf '%s' "$dir"
 }
 
 # --- L2: deadline kills a wedged helper -------------------------------------
@@ -335,6 +355,159 @@ step_l4_writer_success_runs_step() {
   rm -f -- "$spy_file"
 }
 
+# --- PR #952 r3 P2 #1: pgrep failure → ps fallback regression --------------
+
+step_r3_pgrep_failure_enumerates_via_ps() {
+  # PR #952 r3 P2 #1: when pgrep returns exit ≥2 (real failure, not
+  # "no matches"), the r2 form silently treated the result as an empty
+  # child list — the wedged helper's grandchild survived the kill walk.
+  # r3 detects the failure and falls back to `ps -A -o pid,ppid`.
+  #
+  # Probe: spawn a known child (sleep 30) under the driver process,
+  # then call _bridge_enumerate_children with a stub pgrep on PATH that
+  # exits 3. The child PID MUST appear in the enumeration output —
+  # proving the ps fallback discovered it.
+  smoke_log "r3 step 1: _bridge_enumerate_children must use ps fallback when pgrep fails (exit ≥2)"
+
+  local broken_dir
+  broken_dir="$(make_broken_pgrep_dir)"
+  # shellcheck disable=SC2064  # we want the value expanded now.
+  trap "rm -rf '$broken_dir' 2>/dev/null || true" RETURN
+
+  local out
+  out="$(TEST_PGREP_BROKEN_PATH="$broken_dir" run_driver enumerate_children_pgrep_broken)"
+  local child_pid enum_block
+  child_pid="$(printf '%s\n' "$out" | sed -n 's/^CHILD=//p')"
+  if [[ -z "$child_pid" ]]; then
+    smoke_fail "r3 enumerate probe did not print CHILD= line; got: $out"
+  fi
+  enum_block="$(printf '%s\n' "$out" | awk '/^ENUM_OUTPUT_BEGIN/{f=1;next} /^ENUM_OUTPUT_END/{f=0} f')"
+  if ! grep -qx -- "$child_pid" <<<"$enum_block"; then
+    smoke_fail "r3 P2 #1 regression: ps fallback did not list child PID $child_pid. enum block: $enum_block. full output: $out"
+  fi
+  smoke_log "  ps fallback found child PID $child_pid after pgrep stub exited 3"
+}
+
+step_r3_pgrep_failure_reaps_grandchild() {
+  # PR #952 r3 P2 #1 end-to-end: a wedged helper with a python3
+  # grandchild must still get reaped when pgrep is broken. Without
+  # the ps fallback the python3 child would survive the timeout and
+  # write the sentinel file — the leak we already caught in r2 for
+  # the non-broken-pgrep case.
+  smoke_log "r3 step 2: timeout kill walks descendants via ps fallback when pgrep is broken"
+
+  local broken_dir
+  broken_dir="$(make_broken_pgrep_dir)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$broken_dir' 2>/dev/null || true" RETURN
+
+  local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
+  : >"$crash_log"
+  : >"$BRIDGE_AUDIT_LOG"
+
+  local sentinel
+  sentinel="$(mktemp -t r3-pgrep-broken-XXXXXX)"
+  rm -f -- "$sentinel"
+
+  local output started ended elapsed
+  started="$(date +%s)"
+  output="$(TEST_PGREP_BROKEN_PATH="$broken_dir" TEST_SENTINEL_FILE="$sentinel" \
+    run_driver l2_value_with_timeout_pgrep_broken 2 pgrep_broken agent-w SENTINEL_FALLBACK)"
+  ended="$(date +%s)"
+  elapsed=$(( ended - started ))
+
+  smoke_assert_eq "SENTINEL_FALLBACK" "$output" "r3 timeout should still substitute sentinel when pgrep is broken"
+  if (( elapsed > 6 )); then
+    smoke_fail "r3 ceiling did not fire promptly with broken pgrep — elapsed=${elapsed}s"
+  fi
+
+  # python3 child sleeps 5s; deadline fires at 2s. Wait 4s past return
+  # so a surviving child would have written by now.
+  sleep 4
+  if [[ -f "$sentinel" ]]; then
+    smoke_fail "r3 P2 #1 regression: python3 grandchild survived timeout when pgrep was broken — sentinel exists: $(ls -l "$sentinel" 2>/dev/null; cat "$sentinel" 2>/dev/null || true). ps fallback did not enumerate descendants."
+  fi
+  smoke_log "  python3 grandchild reaped via ps fallback after pgrep stub exited 3"
+  rm -f -- "$sentinel"
+}
+
+# --- PR #952 r3 P2 #2: skip-nudges does not consume ready-agents file ------
+
+step_r3_skip_nudges_does_not_read_ready_file() {
+  # PR #952 r3 P2 #2: in r2 cmd_daemon_step called load_ready_agents
+  # at function entry, before the --skip-nudges short-circuit. A
+  # broken/blocking ready-agents file (fifo with no writer, an
+  # unreadable path) would block / raise before maintenance ran.
+  #
+  # r3 defers the load to the non-skip branch. Probe: run daemon-step
+  # with --skip-nudges + --ready-agents-file pointing at a fifo with
+  # no writer. The call MUST return within the budget and emit the
+  # "(maintenance-only; nudges skipped)" marker; the fifo MUST NOT
+  # have been opened (we can't test the latter directly, but if the
+  # call hangs we fail on the timeout).
+  smoke_log "r3 step 3: --skip-nudges must NOT consume ready-agents file (P2 #2 regression)"
+
+  # Stand up a minimal snapshot file — daemon-step requires --snapshot.
+  local snapshot fifo_path
+  snapshot="$SMOKE_TMP_ROOT/r3-skip-snapshot.tsv"
+  cat >"$snapshot" <<'EOF'
+agent	queued	claimed	blocked	active	idle	last_seen	last_nudge	session	engine	workdir	session_activity_ts
+EOF
+
+  # Create a fifo with NO writer attached. The r2 form would block on
+  # open() (or first read()); r3 must skip the load entirely.
+  fifo_path="$SMOKE_TMP_ROOT/r3-blocking-ready-agents.fifo"
+  rm -f -- "$fifo_path"
+  mkfifo "$fifo_path"
+
+  local out rc=0 started ended elapsed
+  started="$(date +%s)"
+  # Cap with a wall-clock budget — if the deferred load fix is missing,
+  # the open() blocks indefinitely. 8s is well above any reasonable
+  # maintenance pass. Use a background timer + kill to enforce the cap
+  # since `timeout` is not universally available on macOS without coreutils.
+  (
+    out="$(python3 "$BRIDGE_REPO_ROOT/bridge-queue.py" daemon-step \
+      --snapshot "$snapshot" \
+      --skip-nudges \
+      --ready-agents-file "$fifo_path" \
+      --idle-threshold 120 \
+      --nudge-cooldown 900 \
+      --format text 2>&1)" || rc=$?
+    printf '%s\n=== rc=%s ===\n' "$out" "$rc"
+  ) >"$SMOKE_TMP_ROOT/r3-skip-out.txt" 2>&1 &
+  local probe_pid=$!
+
+  local waited=0
+  while (( waited < 8 )); do
+    if ! kill -0 "$probe_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.5
+    waited=$(( waited + 1 ))
+  done
+  if kill -0 "$probe_pid" 2>/dev/null; then
+    kill -KILL "$probe_pid" 2>/dev/null || true
+    wait "$probe_pid" 2>/dev/null || true
+    rm -f -- "$fifo_path"
+    smoke_fail "r3 P2 #2 regression: daemon-step --skip-nudges hung on blocking ready-agents fifo (>4s wall clock). The r2 form consumed the file at entry; r3 must defer the load."
+  fi
+  wait "$probe_pid" 2>/dev/null || true
+  ended="$(date +%s)"
+  elapsed=$(( ended - started ))
+
+  out="$(cat "$SMOKE_TMP_ROOT/r3-skip-out.txt")"
+  # Maintenance-only marker must appear in text format output.
+  if ! grep -q '(maintenance-only; nudges skipped)' <<<"$out"; then
+    smoke_fail "r3 P2 #2: expected '(maintenance-only; nudges skipped)' marker in daemon-step output; got: $out"
+  fi
+  if ! grep -q '=== rc=0 ===' <<<"$out"; then
+    smoke_fail "r3 P2 #2: daemon-step exited non-zero with --skip-nudges + blocking fifo: $out"
+  fi
+  smoke_log "  daemon-step --skip-nudges returned in ${elapsed}s without reading the blocking fifo"
+  rm -f -- "$fifo_path"
+}
+
 # --- proof of in-source wiring ----------------------------------------------
 #
 # The driver above is a carbon-copy of the production helpers. Guard
@@ -395,6 +568,44 @@ step_in_source_wiring_present() {
     smoke_fail "bridge-daemon.sh missing KILL-recursive kill on timeout — P2 #2 regression"
   fi
 
+  # PR #952 r3 P2 #1 wiring: pgrep failure must escalate to ps fallback.
+  # The kill helper now delegates child enumeration to
+  # _bridge_enumerate_children which detects pgrep exit ≥2 and falls back
+  # to `ps -A -o pid,ppid` parsing.
+  if ! grep -q '^_bridge_enumerate_children()' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing _bridge_enumerate_children helper — r3 P2 #1 regression"
+  fi
+  if ! grep -q 'ps -A -o pid=,ppid=' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing ps fallback in _bridge_enumerate_children — r3 P2 #1 regression"
+  fi
+  if ! grep -q '_bridge_enumerate_children "$root_pid"' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh _bridge_kill_proc_tree no longer delegates to _bridge_enumerate_children — r3 P2 #1 regression"
+  fi
+  # The legacy form (direct `pgrep -P ... || true` swallow) must NOT
+  # appear inside _bridge_kill_proc_tree any more.
+  if awk '/^_bridge_kill_proc_tree\(\)/,/^}/' "$daemon_sh" | grep -q 'pgrep -P'; then
+    smoke_fail "bridge-daemon.sh _bridge_kill_proc_tree reintroduced direct pgrep call (must go through _bridge_enumerate_children) — r3 P2 #1 regression"
+  fi
+
+  # PR #952 r3 P2 #2 wiring: cmd_daemon_step must defer load_ready_agents
+  # until AFTER the skip_nudges short-circuit. The legacy form loaded the
+  # file at function entry and would block on a broken/blocking path
+  # before maintenance ran.
+  if ! grep -q 'r3 P2 #2: defer ready_agents load until the non-skip branch' "$queue_py"; then
+    smoke_fail "bridge-queue.py missing the r3 P2 #2 deferred-load comment marker — regression marker drifted"
+  fi
+  # The first load_ready_agents call must live AFTER the skip_nudges
+  # return statement, not before it. Delegated to a standalone helper
+  # because embedding the python check as a `<<'PY'` heredoc in this
+  # smoke trips Bash 5.3.9 footgun #11 (heredoc-write deadlock once
+  # body exceeds PIPE_BUF). Same pattern as the tick-guard-driver and
+  # lib/upgrade-helpers/ — see CLAUDE.md.
+  local order_check="$SCRIPT_DIR/daemon-tick-guards-helpers/check-load-ready-after-skip.py"
+  smoke_assert_file_exists "$order_check" "check-load-ready-after-skip.py helper"
+  if ! python3 "$order_check" "$queue_py"; then
+    smoke_fail "bridge-queue.py r3 P2 #2 source-order check failed (load_ready_agents called before skip_nudges short-circuit)"
+  fi
+
   # write_agent_heartbeat heredoc body must no longer contain inline
   # command substitutions for the helpers we pre-resolved. The grep below
   # asserts the heredoc references the local vars (hb_channel_status) and
@@ -417,6 +628,9 @@ smoke_run "L2 helper: fast path passes through silently" step_l2_fast_path_passe
 smoke_run "L2 helper: python3 grandchild reaped on timeout (P2 #2 regression)" step_l2_python3_grandchild_reaped
 smoke_run "L4 nudge_scan: writer failure runs maintenance-only step + skips nudges (P2 #1 regression)" step_l4_writer_failure_runs_maintenance_only
 smoke_run "L4 nudge_scan: writer success invokes full step + silent" step_l4_writer_success_runs_step
+smoke_run "r3: _bridge_enumerate_children falls back to ps when pgrep fails (P2 #1 regression)" step_r3_pgrep_failure_enumerates_via_ps
+smoke_run "r3: timeout reaps python3 grandchild via ps fallback when pgrep is broken (P2 #1 regression)" step_r3_pgrep_failure_reaps_grandchild
+smoke_run "r3: daemon-step --skip-nudges does NOT consume blocking ready-agents fifo (P2 #2 regression)" step_r3_skip_nudges_does_not_read_ready_file
 smoke_run "in-source: bridge-daemon.sh L2/L4 wiring is present and not regressed" step_in_source_wiring_present
 
 smoke_log "PASS"

--- a/scripts/smoke/daemon-tick-guards-l2-l4.sh
+++ b/scripts/smoke/daemon-tick-guards-l2-l4.sh
@@ -397,7 +397,19 @@ step_r3_pgrep_failure_enumerates_via_ps() {
   # then call _bridge_enumerate_children with a stub pgrep on PATH that
   # exits 3. The child PID MUST appear in the enumeration output —
   # proving the ps fallback discovered it.
+  #
+  # PR #952 r5 P2 #2: this probe is meaningless when the real `ps -A`
+  # is ALSO denied (restricted macOS sandbox, some Codex sandbox envs,
+  # SELinux-locked containers). In that environment the r4 pgrp-kill
+  # path — exercised by step_r4_pgrp_kill_under_denied_proctable — is
+  # the load-bearing reap mechanism, and it does not depend on ps.
+  # Skip the ps-specific assertion rather than fail-by-environment.
   smoke_log "r3 step 1: _bridge_enumerate_children must use ps fallback when pgrep fails (exit ≥2)"
+
+  if ! ps -A -o pid=,ppid= >/dev/null 2>&1; then
+    smoke_log "  SKIP: real \`ps -A\` is denied in this environment; r4 pgrp-kill is the load-bearing path"
+    return 0
+  fi
 
   local broken_dir
   broken_dir="$(make_broken_pgrep_dir)"

--- a/scripts/smoke/daemon-tick-guards-l2-l4.sh
+++ b/scripts/smoke/daemon-tick-guards-l2-l4.sh
@@ -38,12 +38,17 @@
 #   2. _bridge_heartbeat_value_with_timeout passes through stdout for a
 #      fast-completing function — no [L2] event, no audit row.
 #   3. The L4 path: when bridge_write_idle_ready_agents returns non-zero,
-#      bridge_task_daemon_step is NOT called, the [L4] log line names the
-#      consecutive-failure counter, and the audit row carries
-#      action="skip_bridge_task_daemon_step".
+#      bridge_task_daemon_step is invoked with --maintenance-only (PR
+#      #952 r2 P2 #1) so queue maintenance side-effects still run, but
+#      the nudge candidate enumeration is skipped. The [L4] log line
+#      names the consecutive-failure counter, and the audit row carries
+#      action="maintenance_only_skip_nudges".
 #   4. The L4 success path: when bridge_write_idle_ready_agents succeeds
 #      after a streak of failures, the counter resets to 0 and the next
 #      success does NOT produce a daemon_step_warning audit row.
+#   5. PR #952 r2 P2 #2: a helper that forks a python3 grandchild is
+#      reaped recursively — the L2 timeout descendant-kill closes the
+#      orphan window codex r1 flagged.
 #
 # Hermetic: isolated BRIDGE_HOME; never touches the live install. No real
 # daemon process is started — we exercise the bash functions directly to
@@ -170,40 +175,109 @@ step_l2_fast_path_passes_through() {
   smoke_log "  fast path silent, stdout passed through"
 }
 
-# --- L4: writer failure skips bridge_task_daemon_step + counts streak --------
-
-step_l4_writer_failure_skips_step() {
-  smoke_log "L4 step 1: writer failure must skip bridge_task_daemon_step and tag the audit row"
+step_l2_python3_grandchild_reaped() {
+  # PR #952 r2 P2 #2 regression: codex r1 flagged that the previous
+  # implementation killed only the immediate background subshell PID, not
+  # the real python3/tmux grandchild started inside the helper. A wedged
+  # helper would still leak a long-running child per heartbeat tick.
+  #
+  # This probe wires a bash function that spawns a python3 subprocess
+  # which sleeps 5s and then writes a sentinel file. The L2 timeout is
+  # set to 2s. After timeout + 4s settle, the sentinel MUST NOT exist —
+  # proving the python3 grandchild was killed alongside the subshell
+  # wrapper. Pre-r2 code left the python3 child alive and the sentinel
+  # appeared.
+  smoke_log "L2 step 3: a helper spawning a python3 grandchild must reap the grandchild on timeout"
 
   local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
   : >"$crash_log"
   : >"$BRIDGE_AUDIT_LOG"
 
+  # Sentinel file lives outside BRIDGE_HOME so a destructive cleanup of
+  # BRIDGE_HOME on test end does not race with the child write.
+  local sentinel
+  sentinel="$(mktemp -t l2-pychild-XXXXXX)"
+  rm -f -- "$sentinel"
+
+  local output started ended elapsed
+  started="$(date +%s)"
+  output="$(TEST_SENTINEL_FILE="$sentinel" run_driver l2_value_with_timeout_pythonchild 2 pychild_test agent-z SENTINEL_FALLBACK)"
+  ended="$(date +%s)"
+  elapsed=$(( ended - started ))
+
+  # Helper must have returned the sentinel inside the 2s + grace budget.
+  smoke_assert_eq "SENTINEL_FALLBACK" "$output" "L2 timeout should substitute the sentinel default"
+  if (( elapsed > 6 )); then
+    smoke_fail "L2 ceiling did not fire promptly — elapsed=${elapsed}s (budget 2s + grace)"
+  fi
+
+  # The python3 child sleeps 5s before writing. The L2 fires at 2s. Wait
+  # 4 more seconds past return so the child (if it survived) finishes
+  # its sleep and writes. Total wall time from start: ~2s helper +
+  # ~0.5s kill + 4s settle = ~6.5s.
+  sleep 4
+
+  if [[ -f "$sentinel" ]]; then
+    smoke_fail "L2 P2 #2 regression: python3 grandchild survived the timeout — sentinel exists: $(ls -l "$sentinel"; cat "$sentinel" 2>/dev/null || true)"
+  fi
+  smoke_log "  python3 grandchild reaped — sentinel file did not appear after $((elapsed + 4))s total"
+  rm -f -- "$sentinel"
+}
+
+# --- L4: writer failure skips bridge_task_daemon_step + counts streak --------
+
+step_l4_writer_failure_runs_maintenance_only() {
+  # PR #952 r2 P2 #1: r1 skipped bridge_task_daemon_step entirely on
+  # writer failure, which starved the same step's queue maintenance
+  # side-effects (lease extension/expire, cron de-dupe, stale-claim
+  # requeue, blocked-task aging) for the whole tick. r2 splits the two
+  # concerns: nudge dispatch is still skipped on writer failure, but the
+  # maintenance path runs via bridge_task_daemon_step --maintenance-only.
+  smoke_log "L4 step 1: writer failure must (a) skip nudge dispatch and (b) still run maintenance-only step"
+
+  local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
+  : >"$crash_log"
+  : >"$BRIDGE_AUDIT_LOG"
+
+  # Cross-process step-mode spy: each driver invocation appends its
+  # bridge_task_daemon_step mode ("maintenance" or "full") to this file.
+  local spy_file
+  spy_file="$(mktemp -t l4-step-spy-XXXXXX)"
+  : >"$spy_file"
+
   # Three consecutive failures to prove the consecutive-failure counter
   # increments rather than resetting on each tick.
   local nudge_output_1 nudge_output_2 nudge_output_3
-  nudge_output_1="$(TEST_WRITER_RC=1 run_driver l4_nudge_scan)"
-  nudge_output_2="$(TEST_WRITER_RC=1 run_driver l4_nudge_scan)"
-  nudge_output_3="$(TEST_WRITER_RC=1 run_driver l4_nudge_scan)"
+  nudge_output_1="$(TEST_WRITER_RC=1 TEST_STEP_SPY_FILE="$spy_file" run_driver l4_nudge_scan)"
+  nudge_output_2="$(TEST_WRITER_RC=1 TEST_STEP_SPY_FILE="$spy_file" run_driver l4_nudge_scan)"
+  nudge_output_3="$(TEST_WRITER_RC=1 TEST_STEP_SPY_FILE="$spy_file" run_driver l4_nudge_scan)"
 
   # Each invocation is a separate driver process, so the consec counter
   # resets between invocations from THE SMOKE'S point of view. But the
-  # audit row from each tick must still be present and the bridge_task_
-  # daemon_step spy MUST be zero across all three (the L4 fix is per-tick
-  # state, the cross-tick counter behavior is the production-code
-  # responsibility verified by reading bridge-daemon.sh).
-  smoke_assert_eq "" "$nudge_output_1" "L4 writer failure should produce empty nudge_output (no step call)"
+  # audit row from each tick must still be present.
+  smoke_assert_eq "" "$nudge_output_1" "L4 writer failure should produce empty nudge_output (no nudge dispatch)"
   smoke_assert_eq "" "$nudge_output_2" "L4 writer failure (2nd) should produce empty nudge_output"
   smoke_assert_eq "" "$nudge_output_3" "L4 writer failure (3rd) should produce empty nudge_output"
 
-  # The spy lives in the driver process — we read it via a separate
-  # subcommand. Across all three invocations the driver was fresh, so each
-  # process saw 0 step calls. The cross-process check we do here is the
-  # cumulative audit-log presence (one row per failed tick).
+  # P2 #1 regression assertion: the maintenance-only step MUST have run
+  # on each of the three failed ticks (3 rows, all mode=maintenance, no
+  # "full" rows).
+  local maintenance_runs full_runs
+  maintenance_runs="$(grep -c '^maintenance$' "$spy_file" || true)"
+  full_runs="$(grep -c '^full$' "$spy_file" || true)"
+  if (( maintenance_runs < 3 )); then
+    smoke_fail "L4 P2 #1 regression: expected >=3 maintenance-only step invocations across 3 failed ticks, got ${maintenance_runs} (spy file: $(cat "$spy_file"))"
+  fi
+  if (( full_runs > 0 )); then
+    smoke_fail "L4 writer-failure path should not invoke the full step (got ${full_runs} full runs): $(cat "$spy_file")"
+  fi
+  smoke_log "  3 failed ticks invoked bridge_task_daemon_step --maintenance-only (queue maintenance preserved)"
+
+  # The cumulative audit-log presence (one row per failed tick).
   local skip_rows
-  skip_rows="$(grep -c '"action": "skip_bridge_task_daemon_step"' "$BRIDGE_AUDIT_LOG" || true)"
+  skip_rows="$(grep -c '"action": "maintenance_only_skip_nudges"' "$BRIDGE_AUDIT_LOG" || true)"
   if (( skip_rows < 3 )); then
-    smoke_fail "L4 audit should have >=3 skip rows, got $skip_rows: $(cat "$BRIDGE_AUDIT_LOG")"
+    smoke_fail "L4 audit should have >=3 maintenance_only_skip_nudges rows, got $skip_rows: $(cat "$BRIDGE_AUDIT_LOG")"
   fi
   if ! grep -q '"step": "nudge_scan_idle_ready"' "$BRIDGE_AUDIT_LOG"; then
     smoke_fail "L4 audit missing nudge_scan_idle_ready step tag: $(cat "$BRIDGE_AUDIT_LOG")"
@@ -213,38 +287,52 @@ step_l4_writer_failure_skips_step() {
     smoke_fail "L4 audit missing consecutive_failures=1 (first failure in each fresh process): $(cat "$BRIDGE_AUDIT_LOG")"
   fi
 
-  # The [L4] crash log line must mention the consec counter and the skip
-  # decision so an operator can grep for the wedge.
+  # The [L4] crash log line must mention the consec counter and the
+  # maintenance-only intent so an operator can grep for the wedge.
   if ! grep -q "\[L4\] nudge_scan: idle_ready writer failed" "$crash_log"; then
     smoke_fail "[L4] line missing from crash log: $(cat "$crash_log")"
   fi
-  if ! grep -q "skipping bridge_task_daemon_step this tick" "$crash_log"; then
-    smoke_fail "[L4] line missing skip phrasing: $(cat "$crash_log")"
+  if ! grep -q "running daemon_step maintenance-only and skipping nudges this tick" "$crash_log"; then
+    smoke_fail "[L4] line missing maintenance-only phrasing: $(cat "$crash_log")"
   fi
-  smoke_log "  3 failed ticks emitted [L4] + audit row; bridge_task_daemon_step was not invoked on any"
+  smoke_log "  3 failed ticks emitted [L4] + audit row + maintenance-only invocation"
+  rm -f -- "$spy_file"
 }
 
 step_l4_writer_success_runs_step() {
-  smoke_log "L4 step 2: writer success must invoke bridge_task_daemon_step AND not emit a skip row"
+  smoke_log "L4 step 2: writer success must invoke bridge_task_daemon_step (full mode) AND not emit a skip row"
 
   local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
   : >"$crash_log"
   : >"$BRIDGE_AUDIT_LOG"
 
+  local spy_file
+  spy_file="$(mktemp -t l4-step-spy-success-XXXXXX)"
+  : >"$spy_file"
+
   local nudge_output
-  nudge_output="$(TEST_WRITER_RC=0 run_driver l4_nudge_scan)"
+  nudge_output="$(TEST_WRITER_RC=0 TEST_STEP_SPY_FILE="$spy_file" run_driver l4_nudge_scan)"
 
   # The bridge_task_daemon_step stub prints 'agent\tsession\t0\t0\t0\tkey'
-  # — assert we got it back, proving the step ran.
+  # — assert we got it back, proving the step ran (full mode).
   smoke_assert_contains "$nudge_output" "agent" "L4 success path should invoke bridge_task_daemon_step"
 
-  if grep -q 'skip_bridge_task_daemon_step' "$BRIDGE_AUDIT_LOG" 2>/dev/null; then
-    smoke_fail "L4 success path wrote a skip audit row — should be silent: $(cat "$BRIDGE_AUDIT_LOG")"
+  # Spy must show exactly one full invocation and no maintenance-only
+  # invocation on the success path.
+  local full_runs maintenance_runs
+  full_runs="$(grep -c '^full$' "$spy_file" || true)"
+  maintenance_runs="$(grep -c '^maintenance$' "$spy_file" || true)"
+  smoke_assert_eq "1" "$full_runs" "L4 success path should invoke the FULL step exactly once"
+  smoke_assert_eq "0" "$maintenance_runs" "L4 success path should not invoke maintenance-only step"
+
+  if grep -q 'maintenance_only_skip_nudges' "$BRIDGE_AUDIT_LOG" 2>/dev/null; then
+    smoke_fail "L4 success path wrote a maintenance_only_skip_nudges audit row — should be silent: $(cat "$BRIDGE_AUDIT_LOG")"
   fi
   if grep -q '\[L4\]' "$crash_log" 2>/dev/null; then
     smoke_fail "L4 success path wrote a [L4] crash log line — should be silent: $(cat "$crash_log")"
   fi
-  smoke_log "  success path invoked the step and stayed silent"
+  smoke_log "  success path invoked the full step and stayed silent"
+  rm -f -- "$spy_file"
 }
 
 # --- proof of in-source wiring ----------------------------------------------
@@ -254,10 +342,14 @@ step_l4_writer_success_runs_step() {
 # shape are present in the checked-in bridge-daemon.sh.
 
 step_in_source_wiring_present() {
-  smoke_log "in-source check: bridge-daemon.sh defines the L2 helper and the L4 skip branch"
+  smoke_log "in-source check: bridge-daemon.sh defines the L2 helper and the L4 maintenance-only branch"
 
   local daemon_sh="$BRIDGE_REPO_ROOT/bridge-daemon.sh"
+  local state_sh="$BRIDGE_REPO_ROOT/lib/bridge-state.sh"
+  local queue_py="$BRIDGE_REPO_ROOT/bridge-queue.py"
   smoke_assert_file_exists "$daemon_sh" "bridge-daemon.sh"
+  smoke_assert_file_exists "$state_sh" "lib/bridge-state.sh"
+  smoke_assert_file_exists "$queue_py" "bridge-queue.py"
 
   if ! grep -q '^_bridge_heartbeat_value_with_timeout()' "$daemon_sh"; then
     smoke_fail "bridge-daemon.sh missing _bridge_heartbeat_value_with_timeout helper definition"
@@ -268,8 +360,39 @@ step_in_source_wiring_present() {
   if ! grep -q '_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL' "$daemon_sh"; then
     smoke_fail "bridge-daemon.sh missing the L4 consecutive-failure counter"
   fi
-  if ! grep -q 'skipping bridge_task_daemon_step this tick' "$daemon_sh"; then
-    smoke_fail "bridge-daemon.sh missing the [L4] skip message"
+  # PR #952 r2 P2 #1 wiring: the L4 fail-path now runs the maintenance-
+  # only step instead of skipping the whole call.
+  if ! grep -q 'running daemon_step maintenance-only and skipping nudges this tick' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing the [L4] r2 maintenance-only message — P2 #1 regression"
+  fi
+  if ! grep -q 'bridge_task_daemon_step --maintenance-only' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing the --maintenance-only invocation on the L4 fail-path — P2 #1 regression"
+  fi
+  # PR #952 r2 P2 #1 wiring (state.sh wrapper): the --maintenance-only
+  # first-arg branch must be present so the python step receives
+  # --skip-nudges.
+  if ! grep -q -- '--maintenance-only' "$state_sh"; then
+    smoke_fail "lib/bridge-state.sh missing the --maintenance-only first-arg branch in bridge_task_daemon_step — P2 #1 regression"
+  fi
+  if ! grep -q -- '--skip-nudges' "$state_sh"; then
+    smoke_fail "lib/bridge-state.sh missing the --skip-nudges arg propagation — P2 #1 regression"
+  fi
+  # PR #952 r2 P2 #1 wiring (python): cmd_daemon_step must short-circuit
+  # before the nudge enumeration when --skip-nudges is set.
+  if ! grep -q 'skip_nudges' "$queue_py"; then
+    smoke_fail "bridge-queue.py missing the skip_nudges arg handling — P2 #1 regression"
+  fi
+
+  # PR #952 r2 P2 #2 wiring: the recursive descendant kill helper must
+  # exist AND be invoked on the timeout path.
+  if ! grep -q '^_bridge_kill_proc_tree()' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing _bridge_kill_proc_tree helper — P2 #2 regression"
+  fi
+  if ! grep -q '_bridge_kill_proc_tree "$pid" "TERM"' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing TERM-recursive kill on timeout — P2 #2 regression"
+  fi
+  if ! grep -q '_bridge_kill_proc_tree "$pid" "KILL"' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing KILL-recursive kill on timeout — P2 #2 regression"
   fi
 
   # write_agent_heartbeat heredoc body must no longer contain inline
@@ -286,13 +409,14 @@ step_in_source_wiring_present() {
   if grep -q 'channel_status: \$(bridge_agent_channel_status' "$daemon_sh"; then
     smoke_fail "bridge-daemon.sh heartbeat heredoc reintroduced inline \$(bridge_agent_channel_status …) — the L2 wedge surface is back"
   fi
-  smoke_log "  L2 helper + L4 counter + skip-branch + heredoc-pre-resolution all wired"
+  smoke_log "  L2 helper + tree-kill + L4 maintenance-only + heredoc-pre-resolution all wired"
 }
 
 smoke_run "L2 helper: deadline fires on wedged helper + sentinel + [L2] + audit" step_l2_timeout_substitutes_sentinel
 smoke_run "L2 helper: fast path passes through silently" step_l2_fast_path_passes_through
-smoke_run "L4 nudge_scan: writer failure skips bridge_task_daemon_step + audit row" step_l4_writer_failure_skips_step
-smoke_run "L4 nudge_scan: writer success invokes step + silent" step_l4_writer_success_runs_step
+smoke_run "L2 helper: python3 grandchild reaped on timeout (P2 #2 regression)" step_l2_python3_grandchild_reaped
+smoke_run "L4 nudge_scan: writer failure runs maintenance-only step + skips nudges (P2 #1 regression)" step_l4_writer_failure_runs_maintenance_only
+smoke_run "L4 nudge_scan: writer success invokes full step + silent" step_l4_writer_success_runs_step
 smoke_run "in-source: bridge-daemon.sh L2/L4 wiring is present and not regressed" step_in_source_wiring_present
 
 smoke_log "PASS"

--- a/scripts/smoke/daemon-tick-guards-l2-l4.sh
+++ b/scripts/smoke/daemon-tick-guards-l2-l4.sh
@@ -114,6 +114,7 @@ run_driver() {
     BRIDGE_LAYOUT="$BRIDGE_LAYOUT" \
     BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
     TEST_PGREP_BROKEN_PATH="${TEST_PGREP_BROKEN_PATH:-}" \
+    TEST_BROKEN_PROCTABLE_PATH="${TEST_BROKEN_PROCTABLE_PATH:-}" \
     bash "$DRIVER" "$@"
 }
 
@@ -133,6 +134,35 @@ echo "pgrep: Cannot get process list" >&2
 exit 3
 STUB
   chmod +x "$dir/pgrep"
+  printf '%s' "$dir"
+}
+
+# PR #952 r4 P1: build a directory with stubs for BOTH pgrep AND ps that
+# fail with "Operation not permitted" — this models the macOS sandbox /
+# restricted-container environment codex r3 caught. Under r3 both stubs
+# return empty / non-zero and descendant enumeration produces the empty
+# list; the wrapper subshell got reaped but the python3 grandchild
+# outlived the timeout. r4's pgrp-kill primary mechanism must still
+# reap the grandchild despite both stubs failing.
+make_broken_proctable_dir() {
+  local dir
+  dir="$(mktemp -d -t agb-broken-proctable-XXXXXX)"
+  cat >"$dir/pgrep" <<'STUB'
+#!/usr/bin/env bash
+# Stub: real macOS sandbox failure surface.
+echo "pgrep: Operation not permitted" >&2
+exit 3
+STUB
+  cat >"$dir/ps" <<'STUB'
+#!/usr/bin/env bash
+# Stub: real macOS sandbox failure surface. POSIX ps exits non-zero on
+# permission denial; some environments emit nothing on stdout, others
+# emit a partial header. We model both by emitting nothing and returning
+# 1, which is what restricted SIP environments do.
+echo "ps: Operation not permitted" >&2
+exit 1
+STUB
+  chmod +x "$dir/pgrep" "$dir/ps"
   printf '%s' "$dir"
 }
 
@@ -431,6 +461,69 @@ step_r3_pgrep_failure_reaps_grandchild() {
   rm -f -- "$sentinel"
 }
 
+# --- PR #952 r4 P1: process-group kill works under denied pgrep+ps ---------
+
+step_r4_pgrp_kill_under_denied_proctable() {
+  # PR #952 r4 P1 regression: codex r3 caught that in macOS sandbox /
+  # restricted-container environments BOTH pgrep AND `ps -A` return
+  # "Operation not permitted". r3's ps fallback was just as denied as
+  # the pgrep primary, so _bridge_enumerate_children silently returned
+  # the empty list and the kill walk only reaped the immediate wrapper
+  # subshell — the python3 grandchild outlived the timeout exactly as
+  # it did pre-r2.
+  #
+  # r4 makes the timeout reap independent of process-table access by
+  # putting the wrapper subshell in its own process group via `set -m`.
+  # On timeout, the helper sends the signal to the negative pid; the
+  # kernel delivers it to every member of the group regardless of
+  # /proc / sandbox visibility.
+  #
+  # Probe: prepend a directory with BROKEN pgrep AND ps stubs to PATH,
+  # then drive a python3-grandchild helper through the 2s timeout. The
+  # sentinel file MUST NOT exist after the timeout + settle window —
+  # proving the pgrp kill reached the grandchild without enumeration.
+  smoke_log "r4 step: pgrp kill must reap grandchild when BOTH pgrep AND ps are denied"
+
+  local broken_dir
+  broken_dir="$(make_broken_proctable_dir)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$broken_dir' 2>/dev/null || true" RETURN
+
+  local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
+  : >"$crash_log"
+  : >"$BRIDGE_AUDIT_LOG"
+
+  local sentinel
+  sentinel="$(mktemp -t r4-pgrp-kill-XXXXXX)"
+  rm -f -- "$sentinel"
+
+  local output started ended elapsed
+  started="$(date +%s)"
+  output="$(TEST_BROKEN_PROCTABLE_PATH="$broken_dir" TEST_SENTINEL_FILE="$sentinel" \
+    run_driver l2_value_with_timeout_pgrep_and_ps_broken 2 pgrp_kill_test agent-r4 SENTINEL_FALLBACK)"
+  ended="$(date +%s)"
+  elapsed=$(( ended - started ))
+
+  smoke_assert_eq "SENTINEL_FALLBACK" "$output" "r4 timeout should still substitute sentinel when both pgrep and ps are denied"
+  # Budget is generous because `sleep 0.1` polling on macOS bash 5.x
+  # is ~0.2s per tick (a 2s budget actually takes 4-5s wall clock).
+  # The smoke is just checking the ceiling DID fire, not the exact
+  # latency. The real failure surface is the sentinel-survives case
+  # below — that fails categorically, not by timing.
+  if (( elapsed > 10 )); then
+    smoke_fail "r4 ceiling did not fire with broken pgrep+ps — elapsed=${elapsed}s (budget 10s, ~5x the 2s deadline to absorb sleep 0.1 quantization)"
+  fi
+
+  # python3 child sleeps 5s; deadline fires at 2s. Wait 4s past return
+  # so a surviving child would have written by now.
+  sleep 4
+  if [[ -f "$sentinel" ]]; then
+    smoke_fail "r4 P1 regression: python3 grandchild survived timeout when BOTH pgrep AND ps were denied — sentinel exists: $(ls -l "$sentinel" 2>/dev/null; cat "$sentinel" 2>/dev/null || true). The pgrp kill mechanism did not reach the grandchild. Process-table-independent reap is broken."
+  fi
+  smoke_log "  python3 grandchild reaped via pgrp kill after both pgrep AND ps stubs failed"
+  rm -f -- "$sentinel"
+}
+
 # --- PR #952 r3 P2 #2: skip-nudges does not consume ready-agents file ------
 
 step_r3_skip_nudges_does_not_read_ready_file() {
@@ -587,6 +680,36 @@ step_in_source_wiring_present() {
     smoke_fail "bridge-daemon.sh _bridge_kill_proc_tree reintroduced direct pgrep call (must go through _bridge_enumerate_children) — r3 P2 #1 regression"
   fi
 
+  # PR #952 r4 P1 wiring: the heartbeat helper must enable bash monitor
+  # mode around the background fork so the wrapper subshell gets its own
+  # process group, and _bridge_kill_proc_tree must use a negative-pid
+  # kill as the PRIMARY mechanism. Without these the timeout reap depends
+  # on process-table access (pgrep / ps) which is denied in macOS sandbox
+  # and some restricted Linux containers.
+  #
+  # Slurp each function body into a tempfile (NOT a `<<<` here-string) —
+  # bash 5.3.9 deadlocks on here-strings larger than PIPE_BUF when used
+  # inside an `if !` under `set -e`. Same class as CLAUDE.md footgun #11
+  # / lib/upgrade-helpers/ rationale. The heartbeat function body is
+  # ~5KB; the kill helper body is ~2KB. Both exceed PIPE_BUF on macOS.
+  local hb_body_file kill_body_file
+  hb_body_file="$(mktemp -t agb-r4-hb-XXXXXX)"
+  kill_body_file="$(mktemp -t agb-r4-kill-XXXXXX)"
+  # shellcheck disable=SC2064
+  trap "rm -f -- '$hb_body_file' '$kill_body_file' 2>/dev/null || true" RETURN
+  awk '/^_bridge_heartbeat_value_with_timeout\(\)/,/^}/' "$daemon_sh" >"$hb_body_file"
+  awk '/^_bridge_kill_proc_tree\(\)/,/^}/' "$daemon_sh" >"$kill_body_file"
+
+  if ! grep -qE '^[[:space:]]*set -m[[:space:]]*$' "$hb_body_file"; then
+    smoke_fail "bridge-daemon.sh _bridge_heartbeat_value_with_timeout missing 'set -m' before background fork — r4 P1 regression (pgrp kill needs wrapper as pgrp leader)"
+  fi
+  if ! grep -q 'set +m;' "$hb_body_file"; then
+    smoke_fail "bridge-daemon.sh _bridge_heartbeat_value_with_timeout missing 'set +m;' inside wrapper subshell — r4 P1 regression (without it nested forks each get their own pgrp)"
+  fi
+  if ! grep -q 'kill "-\$sig" -- "-\$root_pid"' "$kill_body_file"; then
+    smoke_fail "bridge-daemon.sh _bridge_kill_proc_tree missing negative-pid kill ('kill -SIG -- -PID') — r4 P1 regression (process-table-independent reap path)"
+  fi
+
   # PR #952 r3 P2 #2 wiring: cmd_daemon_step must defer load_ready_agents
   # until AFTER the skip_nudges short-circuit. The legacy form loaded the
   # file at function entry and would block on a broken/blocking path
@@ -630,6 +753,7 @@ smoke_run "L4 nudge_scan: writer failure runs maintenance-only step + skips nudg
 smoke_run "L4 nudge_scan: writer success invokes full step + silent" step_l4_writer_success_runs_step
 smoke_run "r3: _bridge_enumerate_children falls back to ps when pgrep fails (P2 #1 regression)" step_r3_pgrep_failure_enumerates_via_ps
 smoke_run "r3: timeout reaps python3 grandchild via ps fallback when pgrep is broken (P2 #1 regression)" step_r3_pgrep_failure_reaps_grandchild
+smoke_run "r4: pgrp kill reaps grandchild when BOTH pgrep AND ps are denied (P1 regression)" step_r4_pgrp_kill_under_denied_proctable
 smoke_run "r3: daemon-step --skip-nudges does NOT consume blocking ready-agents fifo (P2 #2 regression)" step_r3_skip_nudges_does_not_read_ready_file
 smoke_run "in-source: bridge-daemon.sh L2/L4 wiring is present and not regressed" step_in_source_wiring_present
 

--- a/scripts/smoke/daemon-tick-guards-l2-l4.sh
+++ b/scripts/smoke/daemon-tick-guards-l2-l4.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+#
+# scripts/smoke/daemon-tick-guards-l2-l4.sh — issue #946 L2 + L4 regression.
+#
+# Proves that bridge-daemon.sh tick-loop defenses survive the two wedge
+# vectors operator-host evidence (2026-05-17) caught:
+#
+#   L2: write_agent_heartbeat used to evaluate command substitutions
+#       (bridge_agent_channel_status, etc.) inline inside its `cat <<EOF`
+#       heredoc body. A wedged downstream helper (most commonly: a python3
+#       fork against a stale-worktree helper path) would hang the heredoc
+#       and accumulate stuck child processes per tick.
+#
+#       After the L2 fix every command-substitution is pre-resolved via
+#       _bridge_heartbeat_value_with_timeout, which forks the helper into
+#       a background subshell, polls for completion with a per-call ceiling,
+#       and on deadline kills the child + substitutes a sentinel + logs a
+#       [L2] event.
+#
+#   L4: nudge_scan used to fall through to bridge_task_daemon_step even
+#       when bridge_write_idle_ready_agents failed — the downstream step
+#       then consumed an empty/broken ready-agent file and silently
+#       suppressed [task-queued] interrupts for the duration of the wedge.
+#
+#       After the L4 fix bridge_task_daemon_step is gated on the writer's
+#       success: the broken ready-agent file is never consumed, the
+#       failure increments a consecutive-failure counter that surfaces in
+#       the audit log as `daemon_step_warning` with
+#       `consecutive_failures=N`, and a [L4] event with the same counter
+#       is appended to the crash log.
+#
+# What we exercise:
+#
+#   1. _bridge_heartbeat_value_with_timeout fires its deadline on a
+#      function that sleeps past the ceiling — returns the sentinel and
+#      emits a [L2] line + daemon_heartbeat_helper_timeout audit row
+#      tagged with the call_site label.
+#   2. _bridge_heartbeat_value_with_timeout passes through stdout for a
+#      fast-completing function — no [L2] event, no audit row.
+#   3. The L4 path: when bridge_write_idle_ready_agents returns non-zero,
+#      bridge_task_daemon_step is NOT called, the [L4] log line names the
+#      consecutive-failure counter, and the audit row carries
+#      action="skip_bridge_task_daemon_step".
+#   4. The L4 success path: when bridge_write_idle_ready_agents succeeds
+#      after a streak of failures, the counter resets to 0 and the next
+#      success does NOT produce a daemon_step_warning audit row.
+#
+# Hermetic: isolated BRIDGE_HOME; never touches the live install. No real
+# daemon process is started — we exercise the bash functions directly to
+# avoid bringing up the full sync_cycle dependency stack (roster + tmux +
+# queue schema + ...).
+
+# Bash 4+ re-exec (mirrors scripts/smoke/daemon-heredoc-timeout.sh).
+_SMOKE_REEXEC_TARGET="${BASH_SOURCE[0]}"
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  if [[ -f "$_SMOKE_REEXEC_TARGET" ]]; then
+    for smoke_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "${BASH4_BIN:-}"; do
+      [[ -n "$smoke_candidate_bash" && -x "$smoke_candidate_bash" ]] || continue
+      if "$smoke_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        exec "$smoke_candidate_bash" "$_SMOKE_REEXEC_TARGET" "$@"
+      fi
+    done
+  fi
+  echo "[smoke:daemon-tick-guards-l2-l4] requires Bash 4+; install homebrew bash or set BASH4_BIN." >&2
+  exit 1
+fi
+
+set -euo pipefail
+
+SMOKE_NAME="daemon-tick-guards-l2-l4"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+export BRIDGE_REPO_ROOT="$SMOKE_REPO_ROOT"
+export BRIDGE_SCRIPT_DIR="$BRIDGE_REPO_ROOT"
+: >"$BRIDGE_AUDIT_LOG"
+
+# Driver lives in a separate checked-in helper file (NOT written via
+# heredoc) to dodge Bash 5.3.9's footgun #11 (heredoc-write deadlock
+# under set -e parents wedges `cat >FILE <<EOF...EOF` once the body
+# exceeds the PIPE_BUF threshold). See CLAUDE.md §"Recent critical
+# patches (v0.13.7-v0.13.10)" for the full catalog and
+# lib/upgrade-helpers/ for the bridge-upgrade precedent.
+DRIVER="$SCRIPT_DIR/daemon-tick-guards-helpers/tick-guard-driver.sh"
+[[ -x "$DRIVER" ]] || smoke_fail "missing tick-guard driver: $DRIVER"
+
+# Helper that invokes the driver with the smoke harness environment.
+run_driver() {
+  env \
+    HOME="$HOME" \
+    PATH="$PATH" \
+    BRIDGE_HOME="$BRIDGE_HOME" \
+    BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+    BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+    BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
+    BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+    BRIDGE_REPO_ROOT="$BRIDGE_REPO_ROOT" \
+    BRIDGE_SCRIPT_DIR="$BRIDGE_SCRIPT_DIR" \
+    BRIDGE_LAYOUT="$BRIDGE_LAYOUT" \
+    BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+    bash "$DRIVER" "$@"
+}
+
+# --- L2: deadline kills a wedged helper -------------------------------------
+
+step_l2_timeout_substitutes_sentinel() {
+  smoke_log "L2 step 1: a 2s ceiling on a sleep-forever helper must return the sentinel"
+  local started ended elapsed
+  started="$(date +%s)"
+  local output
+  # Args: <secs> <label> <agent> <default> <fn-name>
+  output="$(run_driver l2_value_with_timeout 2 sleep_test agent-x SENTINEL_FALLBACK _test_sleep_forever)"
+  ended="$(date +%s)"
+  elapsed=$(( ended - started ))
+  if (( elapsed > 6 )); then
+    smoke_fail "L2 ceiling did not fire — elapsed=${elapsed}s (budget 2s + grace); the deadlock would still wedge the daemon"
+  fi
+  smoke_assert_eq "SENTINEL_FALLBACK" "$output" "L2 timeout should substitute the sentinel default"
+  smoke_log "  elapsed=${elapsed}s output='$output' — deadline fired, sentinel returned"
+
+  # Confirm [L2] crash log entry.
+  local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
+  if [[ ! -s "$crash_log" ]]; then
+    smoke_fail "L2 crash log empty after timeout — daemon_log_event did not fire: $crash_log"
+  fi
+  if ! grep -q "\[L2\] heartbeat helper 'sleep_test' for agent 'agent-x' timed out at 2s" "$crash_log"; then
+    smoke_fail "L2 crash log missing the expected timeout line: $(cat "$crash_log")"
+  fi
+  smoke_log "  [L2] timeout line written to $crash_log"
+
+  # Confirm audit row tagged with call_site + agent.
+  if ! grep -q '"call_site": "heartbeat_sleep_test"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "audit log missing heartbeat_sleep_test call_site: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  if ! grep -q 'daemon_heartbeat_helper_timeout' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "audit log missing daemon_heartbeat_helper_timeout action: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  smoke_log "  audit row daemon_heartbeat_helper_timeout present"
+}
+
+step_l2_fast_path_passes_through() {
+  smoke_log "L2 step 2: a fast-completing helper must return its stdout verbatim with NO [L2] event"
+
+  # Snapshot the crash log + audit log first so we can prove nothing new
+  # is appended on the success path.
+  local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
+  : >"$crash_log"
+  : >"$BRIDGE_AUDIT_LOG"
+
+  local output
+  output="$(run_driver l2_value_with_timeout 5 fast_test agent-y SHOULD_NOT_APPEAR _test_fast_success)"
+  smoke_assert_eq "fast-value" "$output" "L2 fast path should pass through stdout"
+
+  if [[ -s "$crash_log" ]]; then
+    smoke_fail "L2 success path wrote a crash log line — should be silent: $(cat "$crash_log")"
+  fi
+  if grep -q 'daemon_heartbeat_helper_timeout' "$BRIDGE_AUDIT_LOG" 2>/dev/null; then
+    smoke_fail "L2 success path wrote a timeout audit row — should not: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  smoke_log "  fast path silent, stdout passed through"
+}
+
+# --- L4: writer failure skips bridge_task_daemon_step + counts streak --------
+
+step_l4_writer_failure_skips_step() {
+  smoke_log "L4 step 1: writer failure must skip bridge_task_daemon_step and tag the audit row"
+
+  local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
+  : >"$crash_log"
+  : >"$BRIDGE_AUDIT_LOG"
+
+  # Three consecutive failures to prove the consecutive-failure counter
+  # increments rather than resetting on each tick.
+  local nudge_output_1 nudge_output_2 nudge_output_3
+  nudge_output_1="$(TEST_WRITER_RC=1 run_driver l4_nudge_scan)"
+  nudge_output_2="$(TEST_WRITER_RC=1 run_driver l4_nudge_scan)"
+  nudge_output_3="$(TEST_WRITER_RC=1 run_driver l4_nudge_scan)"
+
+  # Each invocation is a separate driver process, so the consec counter
+  # resets between invocations from THE SMOKE'S point of view. But the
+  # audit row from each tick must still be present and the bridge_task_
+  # daemon_step spy MUST be zero across all three (the L4 fix is per-tick
+  # state, the cross-tick counter behavior is the production-code
+  # responsibility verified by reading bridge-daemon.sh).
+  smoke_assert_eq "" "$nudge_output_1" "L4 writer failure should produce empty nudge_output (no step call)"
+  smoke_assert_eq "" "$nudge_output_2" "L4 writer failure (2nd) should produce empty nudge_output"
+  smoke_assert_eq "" "$nudge_output_3" "L4 writer failure (3rd) should produce empty nudge_output"
+
+  # The spy lives in the driver process — we read it via a separate
+  # subcommand. Across all three invocations the driver was fresh, so each
+  # process saw 0 step calls. The cross-process check we do here is the
+  # cumulative audit-log presence (one row per failed tick).
+  local skip_rows
+  skip_rows="$(grep -c '"action": "skip_bridge_task_daemon_step"' "$BRIDGE_AUDIT_LOG" || true)"
+  if (( skip_rows < 3 )); then
+    smoke_fail "L4 audit should have >=3 skip rows, got $skip_rows: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  if ! grep -q '"step": "nudge_scan_idle_ready"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "L4 audit missing nudge_scan_idle_ready step tag: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  # Each failure should carry a consecutive_failures detail.
+  if ! grep -q '"consecutive_failures": "1"' "$BRIDGE_AUDIT_LOG"; then
+    smoke_fail "L4 audit missing consecutive_failures=1 (first failure in each fresh process): $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+
+  # The [L4] crash log line must mention the consec counter and the skip
+  # decision so an operator can grep for the wedge.
+  if ! grep -q "\[L4\] nudge_scan: idle_ready writer failed" "$crash_log"; then
+    smoke_fail "[L4] line missing from crash log: $(cat "$crash_log")"
+  fi
+  if ! grep -q "skipping bridge_task_daemon_step this tick" "$crash_log"; then
+    smoke_fail "[L4] line missing skip phrasing: $(cat "$crash_log")"
+  fi
+  smoke_log "  3 failed ticks emitted [L4] + audit row; bridge_task_daemon_step was not invoked on any"
+}
+
+step_l4_writer_success_runs_step() {
+  smoke_log "L4 step 2: writer success must invoke bridge_task_daemon_step AND not emit a skip row"
+
+  local crash_log="$BRIDGE_LOG_DIR/daemon-crash.log"
+  : >"$crash_log"
+  : >"$BRIDGE_AUDIT_LOG"
+
+  local nudge_output
+  nudge_output="$(TEST_WRITER_RC=0 run_driver l4_nudge_scan)"
+
+  # The bridge_task_daemon_step stub prints 'agent\tsession\t0\t0\t0\tkey'
+  # — assert we got it back, proving the step ran.
+  smoke_assert_contains "$nudge_output" "agent" "L4 success path should invoke bridge_task_daemon_step"
+
+  if grep -q 'skip_bridge_task_daemon_step' "$BRIDGE_AUDIT_LOG" 2>/dev/null; then
+    smoke_fail "L4 success path wrote a skip audit row — should be silent: $(cat "$BRIDGE_AUDIT_LOG")"
+  fi
+  if grep -q '\[L4\]' "$crash_log" 2>/dev/null; then
+    smoke_fail "L4 success path wrote a [L4] crash log line — should be silent: $(cat "$crash_log")"
+  fi
+  smoke_log "  success path invoked the step and stayed silent"
+}
+
+# --- proof of in-source wiring ----------------------------------------------
+#
+# The driver above is a carbon-copy of the production helpers. Guard
+# against drift by asserting the exact bash function and the L4 branch
+# shape are present in the checked-in bridge-daemon.sh.
+
+step_in_source_wiring_present() {
+  smoke_log "in-source check: bridge-daemon.sh defines the L2 helper and the L4 skip branch"
+
+  local daemon_sh="$BRIDGE_REPO_ROOT/bridge-daemon.sh"
+  smoke_assert_file_exists "$daemon_sh" "bridge-daemon.sh"
+
+  if ! grep -q '^_bridge_heartbeat_value_with_timeout()' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing _bridge_heartbeat_value_with_timeout helper definition"
+  fi
+  if ! grep -q '_bridge_heartbeat_value_with_timeout 10 channel_status' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing the channel_status bounded call (the operator-host wedge surface)"
+  fi
+  if ! grep -q '_BRIDGE_NUDGE_IDLE_READY_CONSEC_FAIL' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing the L4 consecutive-failure counter"
+  fi
+  if ! grep -q 'skipping bridge_task_daemon_step this tick' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh missing the [L4] skip message"
+  fi
+
+  # write_agent_heartbeat heredoc body must no longer contain inline
+  # command substitutions for the helpers we pre-resolved. The grep below
+  # asserts the heredoc references the local vars (hb_channel_status) and
+  # that the failing legacy form (\$(bridge_agent_channel_status) inside
+  # the heredoc) is gone.
+  if ! grep -q 'channel_status: \${hb_channel_status}' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh heartbeat heredoc no longer uses pre-resolved hb_channel_status — the regression returned"
+  fi
+  # Specifically catch the legacy form. We grep for the literal substring
+  # so a future refactor that re-introduces inline $(bridge_agent_*) calls
+  # inside the heartbeat heredoc trips this.
+  if grep -q 'channel_status: \$(bridge_agent_channel_status' "$daemon_sh"; then
+    smoke_fail "bridge-daemon.sh heartbeat heredoc reintroduced inline \$(bridge_agent_channel_status …) — the L2 wedge surface is back"
+  fi
+  smoke_log "  L2 helper + L4 counter + skip-branch + heredoc-pre-resolution all wired"
+}
+
+smoke_run "L2 helper: deadline fires on wedged helper + sentinel + [L2] + audit" step_l2_timeout_substitutes_sentinel
+smoke_run "L2 helper: fast path passes through silently" step_l2_fast_path_passes_through
+smoke_run "L4 nudge_scan: writer failure skips bridge_task_daemon_step + audit row" step_l4_writer_failure_skips_step
+smoke_run "L4 nudge_scan: writer success invokes step + silent" step_l4_writer_success_runs_step
+smoke_run "in-source: bridge-daemon.sh L2/L4 wiring is present and not regressed" step_in_source_wiring_present
+
+smoke_log "PASS"


### PR DESCRIPTION
## Summary

- `bridge-daemon.sh`: every command substitution that survived in `write_agent_heartbeat`'s `cat <<EOF` heredoc is now pre-resolved through a new module-private helper `_bridge_heartbeat_value_with_timeout`. The helper forks the call into a backgrounded subshell, polls with 100 ms granularity, and on per-call deadline expiry sends `SIGTERM` → 0.5 s grace → `SIGKILL`, then substitutes a grep-able sentinel + emits a `[L2]` line + `daemon_heartbeat_helper_timeout` audit row tagged with `call_site` + agent. Heartbeats can no longer wedge the tick on a stuck helper (e.g. stale-worktree `python3 extract-dev-channels-from-command.py` cascade observed on operator host 2026-05-17).
- `bridge-daemon.sh:6022` (was 5936): `bridge_task_daemon_step` is now gated on `bridge_write_idle_ready_agents` returning success. The previous code fell through with a broken/empty ready-agent file, silently suppressing `[task-queued]` interrupts. The skip path emits `[L4]` + a `daemon_step_warning` audit row carrying `action="skip_bridge_task_daemon_step"` and a `consecutive_failures` counter that resets to 0 on the next successful tick so an operator can spot a wedged writer instead of grepping a log noise stream.
- `scripts/smoke/daemon-tick-guards-l2-l4.sh` + `scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh`: five-step regression smoke. Drives the L2 helper with a sleep-forever stub to prove the deadline fires + sentinel substitutes + log + audit row land. Drives the L4 nudge_scan branch with a stub writer that returns 0 / non-zero to prove the skip decision + audit detail. Plus an in-source guard that fails if the heartbeat heredoc body reintroduces inline `$(bridge_agent_channel_status …)` (regression catch for the original wedge surface).
- Driver lives in a standalone helper file rather than an inline heredoc to dodge Bash 5.3.9 footgun #11 (heredoc-write deadlock under `set -e` parents) — mirrors the `lib/upgrade-helpers/` precedent from v0.13.9.

## Why

Closes L2 + L4 of the daemon-hang cascade in #946. Operator-host evidence (2026-05-17, ~/.agent-bridge) showed:

- L2: 24+ consecutive `python3` helper-not-found cascades from `lib/bridge-agents.sh extract-dev-channels-from-command.py` + `lib/bridge-state.sh launch-cmd-claude-channels.py`, all pointing at a stale fixer worktree path. Each fork+exec+fail is wasted tick budget; combined with L4 below it accumulated stuck children until the tick wedged.
- L4: hundreds of `nudge_scan: idle_ready writer failed (matrix-aware fix #781); cycle continues` lines while `bridge_task_daemon_step` continued to consume the broken state file. Net effect: task #4805 to `agb-dev-codex` queued 1+ hour without `[task-queued]` delivery.

Bundled into one PR because both fixes touch `bridge-daemon.sh` in the same tick-loop region — splitting would force the second PR to rebase. L1 (BRIDGE_SCRIPT_DIR validate) and L3 (watchdog stderr capture) are separate PRs per the orchestrator's brief.

## Verification matrix

- [x] `bash -n bridge-daemon.sh scripts/smoke-test.sh scripts/smoke/daemon-tick-guards-l2-l4.sh scripts/smoke/daemon-tick-guards-helpers/tick-guard-driver.sh` pass
- [x] `shellcheck` clean on all four files
- [x] New smoke `scripts/smoke/daemon-tick-guards-l2-l4.sh` runs standalone in <10 s on macOS Bash 5.3.9, all 5 steps pass
- [x] L2 deadline fires within 5 s on a 60 s sleep helper (2 s budget + grace), sentinel returned, `[L2]` line + `daemon_heartbeat_helper_timeout` audit row present
- [x] L2 fast path stays silent (no `[L2]` event, no audit row)
- [x] L4 writer-failure path skips `bridge_task_daemon_step` (verified via the spy in the helper driver) + emits `daemon_step_warning` with `action="skip_bridge_task_daemon_step"`
- [x] L4 writer-success path invokes `bridge_task_daemon_step` and stays silent
- [x] In-source guard fails if `channel_status: $(bridge_agent_channel_status …)` is reintroduced inside the heartbeat heredoc (regression catch)
- [x] Full smoke baseline matched — see step `running daemon-tick-guards-l2-l4 smoke (refs #946 L2+L4)` near the tail of `scripts/smoke-test.sh`

## Out of scope

- L1 (`BRIDGE_SCRIPT_DIR` validate + helper-not-found cascade halt) and L3 (silence-watchdog stderr capture for the `daemon stop` failure) are separate PRs.
- The orphan `state/daemon-autostart/*.env` sweep (H4 in diagnosis) is handled by PR #942 already merged; no change needed.
- The silence-watchdog → `bridge-daemon.sh stop` resolver-die loop (H1) is L3 territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
