### PR TITLE
fix(teams): TEAMS_DELIVERY_MODE env-var-gated bridge-mode fallback (refs #959)

### DIFF
--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -128,9 +128,21 @@ TEAMS_OUTBOUND_ATTACHMENT_MAX_BYTES=52428800            # default: 50 MB; clampe
 
 ## Delivery Mode
 
-By default, inbound Teams messages are delivered to Claude Code with `notifications/claude/channel`, and the server waits for the MCP stdio write before acknowledging the Teams webhook. If the MCP write fails, the webhook returns an error so Teams can retry.
+Inbound Teams messages can be delivered to Claude Code through the MCP channel notification, the Agent Bridge queue, or both. Select with `TEAMS_DELIVERY_MODE`:
 
-Legacy `TEAMS_BRIDGE_MODE` / `TEAMS_BRIDGE_AGENT` settings are ignored. Teams inbound delivery must not create Agent Bridge queue tasks; it should enter the active Claude Code session as a channel message. Accepted messages are written to the local log only after Claude Code accepts the channel notification, so Teams webhook retries can still recover from delivery failures without duplicating already delivered messages.
+| Mode | Behavior | Trade-offs |
+| --- | --- | --- |
+| `channel` *(default)* | Send `notifications/claude/channel` only. Webhook waits for the MCP stdio write before acknowledging Teams. | Lowest latency, single write. Risk: if Claude Code's MCP notification handler does not wake the session (see issue #959), the message persists in `messages.jsonl` but the agent stays idle. |
+| `bridge` | Skip the channel notification; enqueue an Agent Bridge queue task via `bridge-task.sh create` with the full message body. The daemon then wakes the agent through the standard inbox path. | Higher latency (daemon tick) but the wake is the same code path inbox messages use, so it cannot be silently dropped by a stalled MCP handler. Queue tasks accumulate if the agent is offline. Requires `BRIDGE_AGENT_ID` and `BRIDGE_HOME` to be set in the plugin's environment. |
+| `both` | Fire the channel notification AND enqueue the queue task. | Belt-and-braces: covers the issue #959 silent-drop window without removing the low-latency channel path. Risk: the agent can see the same message twice (once via channel, once via queue) if both succeed. |
+
+Default is `channel`, so existing installs see no behavior change. An invalid value logs a warning and falls back to `channel`.
+
+In `bridge` and `both` modes, queue enqueue failures (missing `BRIDGE_AGENT_ID`, missing `bridge-task.sh`, queue subprocess non-zero exit) are logged to stderr but do not cause the Teams webhook to retry. In `channel` and `both` modes, a channel-notification failure still throws so Teams retries — even in `both` mode where bridge delivery may have succeeded, to keep the at-least-once channel contract.
+
+Legacy `TEAMS_BRIDGE_MODE` / `TEAMS_BRIDGE_AGENT` env vars remain ignored; use `TEAMS_DELIVERY_MODE=bridge` instead. Accepted messages are written to the local log only after the chosen delivery path completes, so Teams webhook retries can still recover from delivery failures without duplicating already delivered messages.
+
+End-to-end verification of bridge-mode delivery requires a real Teams + Azure setup; CI smoke covers boot only.
 
 ## Current Scope
 

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -26,9 +26,11 @@ import {
   existsSync,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   readFileSync,
   realpathSync,
   renameSync,
+  rmdirSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -899,6 +901,47 @@ function runPromptGuard(command: 'scan' | 'sanitize', text: string): Record<stri
 }
 
 /**
+ * Build the channel meta object used by BOTH the `notifications/claude/channel`
+ * notification AND the bridge-mode queue task body. Centralizing here keeps
+ * the two delivery paths from drifting (PR #961 r1 found bridge body was
+ * missing conversation_id / tenant_id / service_url / attachment_count that
+ * the channel notification carries).
+ */
+function buildChannelMeta(
+  activity: Activity,
+  stored: StoredMessage,
+  attachments: StoredAttachment[],
+): Record<string, unknown> {
+  return {
+    source: 'teams',
+    chat_id: stored.chat_id,
+    conversation_id: stored.chat_id,
+    message_id: stored.message_id,
+    user: stored.user,
+    user_id: stored.user_id,
+    aad_object_id: stored.aad_object_id,
+    tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
+    service_url: String(activity.serviceUrl ?? ''),
+    text: stored.text,
+    ts: stored.ts,
+    ...(stored.revision ? { revision: stored.revision } : {}),
+    ...(attachments.length > 0
+      ? {
+          attachment_count: String(attachments.length),
+          attachments: attachments.map(att => ({
+            name: att.name,
+            content_type: att.content_type,
+            download_status: att.download_status,
+            ...(att.local_path ? { local_path: att.local_path } : {}),
+            ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
+            ...(att.download_error ? { download_error: att.download_error } : {}),
+          })),
+        }
+      : {}),
+  }
+}
+
+/**
  * Bridge-mode delivery (issue #959): enqueue the inbound Teams message as an
  * Agent Bridge queue task via `bridge-task.sh create`. Used when
  * TEAMS_DELIVERY_MODE is `bridge` or `both`. The daemon then wakes the agent
@@ -912,44 +955,52 @@ function runPromptGuard(command: 'scan' | 'sanitize', text: string): Record<stri
  * operator has opted into queue-only delivery and silent loss is preferable
  * to retry storms when the queue itself is unhealthy.
  */
-function deliverViaBridgeQueue(stored: StoredMessage): void {
+function deliverViaBridgeQueue(
+  activity: Activity,
+  stored: StoredMessage,
+  attachments: StoredAttachment[],
+): void {
   const agent = String(process.env.BRIDGE_AGENT_ID ?? '').trim()
   if (!agent) {
-    process.stderr.write(`teams channel: bridge-mode delivery skipped — BRIDGE_AGENT_ID unset\n`)
+    process.stderr.write(`teams channel: bridge-mode delivery skipped — BRIDGE_AGENT_ID unset, message_id=${stored.message_id}\n`)
     return
   }
   const taskScript = join(BRIDGE_HOME, 'bridge-task.sh')
   if (!existsSync(taskScript)) {
-    process.stderr.write(`teams channel: bridge-mode delivery skipped — bridge-task.sh not found at ${taskScript}\n`)
+    process.stderr.write(`teams channel: bridge-mode delivery skipped — bridge-task.sh not found at ${taskScript}, message_id=${stored.message_id}\n`)
     return
   }
 
-  const body = JSON.stringify({
-    source: 'teams',
-    chat_id: stored.chat_id,
-    message_id: stored.message_id,
-    user: stored.user,
-    user_id: stored.user_id,
-    aad_object_id: stored.aad_object_id,
-    text: stored.text,
-    ts: stored.ts,
-    ...(stored.revision ? { revision: stored.revision } : {}),
-    ...(stored.attachments ? { attachments: stored.attachments } : {}),
-  }, null, 2)
+  const body = JSON.stringify(buildChannelMeta(activity, stored, attachments), null, 2)
 
   // Tempfile delivery dodges argv length limits and shell-escaping of the
-  // arbitrary user-supplied body. 0o600 keeps the JSON payload (which may
+  // arbitrary user-supplied body. mkdtemp guarantees a fresh unique directory
+  // even on same-ms collisions; opening the file with 'wx' fails fast if an
+  // attacker pre-created the path. 0o600 keeps the JSON payload (which may
   // contain user PII / message text) off any group-readable tmp.
   const safeMid = stored.message_id.replace(/[^A-Za-z0-9._-]+/g, '_').slice(0, 80) || 'msg'
-  const bodyFile = join(tmpdir(), `teams-bridge-${safeMid}-${Date.now()}.json`)
+  let bodyDir: string
   try {
-    writeFileSync(bodyFile, body, { mode: 0o600 })
+    bodyDir = mkdtempSync(join(tmpdir(), 'teams-bridge-'))
   } catch (err) {
-    process.stderr.write(`teams channel: bridge-mode delivery skipped — could not write body file: ${err}\n`)
+    process.stderr.write(`teams channel: bridge-mode delivery skipped — could not create body dir: ${err}, message_id=${stored.message_id}\n`)
+    return
+  }
+  const bodyFile = join(bodyDir, `${safeMid}.json`)
+  try {
+    writeFileSync(bodyFile, body, { mode: 0o600, flag: 'wx' })
+  } catch (err) {
+    process.stderr.write(`teams channel: bridge-mode delivery skipped — could not write body file: ${err}, message_id=${stored.message_id}\n`)
+    try { rmdirSync(bodyDir) } catch {}
     return
   }
 
-  const title = `[teams] ${stored.user || 'user'}: ${(stored.text || '(attachment)').slice(0, 60)}`
+  // Title budget: cap WHOLE title (prefix + user + text) to TITLE_MAX so a
+  // long Teams display name can't push the user-visible text off the inbox
+  // row. Single ellipsis at the end keeps the truncation obvious.
+  const TITLE_MAX = 120
+  const rawTitle = `[teams] ${stored.user || 'user'}: ${stored.text || '(attachment)'}`
+  const title = rawTitle.length > TITLE_MAX ? rawTitle.slice(0, TITLE_MAX - 1) + '…' : rawTitle
   try {
     const r = spawnSync(
       'bash',
@@ -965,10 +1016,11 @@ function deliverViaBridgeQueue(stored: StoredMessage): void {
     )
     if (r.status !== 0) {
       const stderrTail = r.stderr ? r.stderr.toString().slice(0, 200) : ''
-      process.stderr.write(`teams channel: bridge-mode enqueue failed rc=${r.status}: ${stderrTail}\n`)
+      process.stderr.write(`teams channel: bridge-mode enqueue failed rc=${r.status}, message_id=${stored.message_id}: ${stderrTail}\n`)
     }
   } finally {
     try { unlinkSync(bodyFile) } catch {}
+    try { rmdirSync(bodyDir) } catch {}
   }
 }
 
@@ -1718,32 +1770,7 @@ async function handleActivity(context: TurnContext): Promise<void> {
         method: 'notifications/claude/channel',
         params: {
           content: text || (attachments.length > 0 ? '(attachment)' : ''),
-          meta: {
-            source: 'teams',
-            chat_id: chatId,
-            conversation_id: chatId,
-            message_id: messageId,
-            user: userName,
-            user_id: stored.user_id,
-            aad_object_id: aad,
-            tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
-            service_url: String(activity.serviceUrl ?? ''),
-            ts,
-            ...(revision ? { revision } : {}),
-            ...(attachments.length > 0
-              ? {
-                  attachment_count: String(attachments.length),
-                  attachments: attachments.map(att => ({
-                    name: att.name,
-                    content_type: att.content_type,
-                    download_status: att.download_status,
-                    ...(att.local_path ? { local_path: att.local_path } : {}),
-                    ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
-                    ...(att.download_error ? { download_error: att.download_error } : {}),
-                  })),
-                }
-              : {}),
-          },
+          meta: buildChannelMeta(activity, stored, attachments),
         },
       })
       channelDelivered = true
@@ -1756,7 +1783,7 @@ async function handleActivity(context: TurnContext): Promise<void> {
   if (mode === 'bridge' || mode === 'both') {
     // Bridge-mode failures log but do not throw — operators choosing bridge
     // or both have accepted best-effort enqueue. See deliverViaBridgeQueue.
-    deliverViaBridgeQueue(stored)
+    deliverViaBridgeQueue(activity, stored, attachments)
   }
 
   // Channel-mode (and both-mode) failure surfaces to Teams so it retries; in

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -955,6 +955,16 @@ function buildChannelMeta(
  * operator has opted into queue-only delivery and silent loss is preferable
  * to retry storms when the queue itself is unhealthy.
  */
+function truncateForTitle(s: string, maxCodepoints: number): string {
+  // String.slice operates on UTF-16 code units, which splits surrogate pairs
+  // (any non-BMP character — most emoji, CJK extensions, etc.) and leaves a
+  // lone surrogate. Spread iterates by Unicode codepoint, so the slice
+  // boundary always falls on a complete character.
+  const codepoints = [...s]
+  if (codepoints.length <= maxCodepoints) return s
+  return codepoints.slice(0, maxCodepoints - 1).join('') + '…'
+}
+
 function deliverViaBridgeQueue(
   activity: Activity,
   stored: StoredMessage,
@@ -991,6 +1001,9 @@ function deliverViaBridgeQueue(
     writeFileSync(bodyFile, body, { mode: 0o600, flag: 'wx' })
   } catch (err) {
     process.stderr.write(`teams channel: bridge-mode delivery skipped — could not write body file: ${err}, message_id=${stored.message_id}\n`)
+    // Mirror the success-path finally: drop the file (may exist as a partial
+    // write) before rmdir so a non-empty dir doesn't leak both artifacts.
+    try { unlinkSync(bodyFile) } catch {}
     try { rmdirSync(bodyDir) } catch {}
     return
   }
@@ -1000,7 +1013,7 @@ function deliverViaBridgeQueue(
   // row. Single ellipsis at the end keeps the truncation obvious.
   const TITLE_MAX = 120
   const rawTitle = `[teams] ${stored.user || 'user'}: ${stored.text || '(attachment)'}`
-  const title = rawTitle.length > TITLE_MAX ? rawTitle.slice(0, TITLE_MAX - 1) + '…' : rawTitle
+  const title = truncateForTitle(rawTitle, TITLE_MAX)
   try {
     const r = spawnSync(
       'bash',

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -33,7 +33,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from 'fs'
-import { homedir } from 'os'
+import { homedir, tmpdir } from 'os'
 import { basename, isAbsolute as pathIsAbsolute, join, resolve as pathResolve } from 'path'
 import { createRecentMessageDeduper, storedRowMatchesIncoming } from './dedupe.ts'
 
@@ -167,14 +167,24 @@ const STATIC = process.env.TEAMS_ACCESS_MODE === 'static'
 
 if (process.env.TEAMS_BRIDGE_MODE === '1' || process.env.TEAMS_BRIDGE_AGENT) {
   process.stderr.write(
-    'teams channel: ignoring deprecated TEAMS_BRIDGE_MODE/TEAMS_BRIDGE_AGENT; inbound messages use notifications/claude/channel\n',
+    'teams channel: legacy TEAMS_BRIDGE_MODE/TEAMS_BRIDGE_AGENT env vars are ignored; use TEAMS_DELIVERY_MODE=bridge instead\n',
   )
 }
-if (process.env.TEAMS_DELIVERY_MODE && process.env.TEAMS_DELIVERY_MODE !== 'channel') {
+
+type DeliveryMode = 'channel' | 'bridge' | 'both'
+
+// Resolve once at module load so an invalid value warns once on boot rather
+// than per inbound message. The resolved mode is reused by every
+// handleActivity call.
+const DELIVERY_MODE: DeliveryMode = (() => {
+  const raw = String(process.env.TEAMS_DELIVERY_MODE ?? '').trim().toLowerCase()
+  if (!raw) return 'channel'
+  if (raw === 'channel' || raw === 'bridge' || raw === 'both') return raw
   process.stderr.write(
-    `teams channel: unsupported TEAMS_DELIVERY_MODE=${process.env.TEAMS_DELIVERY_MODE}; using channel delivery\n`,
+    `teams channel: unsupported TEAMS_DELIVERY_MODE=${raw}; falling back to channel\n`,
   )
-}
+  return 'channel'
+})()
 
 const APP_ID = process.env.TEAMS_APP_ID ?? process.env.MicrosoftAppId
 const APP_PASSWORD = process.env.TEAMS_APP_PASSWORD ?? process.env.MicrosoftAppPassword
@@ -885,6 +895,80 @@ function runPromptGuard(command: 'scan' | 'sanitize', text: string): Record<stri
     return JSON.parse(result.stdout)
   } catch {
     return null
+  }
+}
+
+/**
+ * Bridge-mode delivery (issue #959): enqueue the inbound Teams message as an
+ * Agent Bridge queue task via `bridge-task.sh create`. Used when
+ * TEAMS_DELIVERY_MODE is `bridge` or `both`. The daemon then wakes the agent
+ * through the standard inbox path, sidestepping the channel-only failure
+ * mode where `await mcp.notification()` resolves but Claude Code's MCP
+ * notification handler never injects the message into the session.
+ *
+ * Best-effort: misconfiguration or queue failure logs to stderr but never
+ * throws. Throwing would force a Teams webhook retry, which the channel-mode
+ * path already covers when caller selected `both`; in `bridge`-only mode the
+ * operator has opted into queue-only delivery and silent loss is preferable
+ * to retry storms when the queue itself is unhealthy.
+ */
+function deliverViaBridgeQueue(stored: StoredMessage): void {
+  const agent = String(process.env.BRIDGE_AGENT_ID ?? '').trim()
+  if (!agent) {
+    process.stderr.write(`teams channel: bridge-mode delivery skipped — BRIDGE_AGENT_ID unset\n`)
+    return
+  }
+  const taskScript = join(BRIDGE_HOME, 'bridge-task.sh')
+  if (!existsSync(taskScript)) {
+    process.stderr.write(`teams channel: bridge-mode delivery skipped — bridge-task.sh not found at ${taskScript}\n`)
+    return
+  }
+
+  const body = JSON.stringify({
+    source: 'teams',
+    chat_id: stored.chat_id,
+    message_id: stored.message_id,
+    user: stored.user,
+    user_id: stored.user_id,
+    aad_object_id: stored.aad_object_id,
+    text: stored.text,
+    ts: stored.ts,
+    ...(stored.revision ? { revision: stored.revision } : {}),
+    ...(stored.attachments ? { attachments: stored.attachments } : {}),
+  }, null, 2)
+
+  // Tempfile delivery dodges argv length limits and shell-escaping of the
+  // arbitrary user-supplied body. 0o600 keeps the JSON payload (which may
+  // contain user PII / message text) off any group-readable tmp.
+  const safeMid = stored.message_id.replace(/[^A-Za-z0-9._-]+/g, '_').slice(0, 80) || 'msg'
+  const bodyFile = join(tmpdir(), `teams-bridge-${safeMid}-${Date.now()}.json`)
+  try {
+    writeFileSync(bodyFile, body, { mode: 0o600 })
+  } catch (err) {
+    process.stderr.write(`teams channel: bridge-mode delivery skipped — could not write body file: ${err}\n`)
+    return
+  }
+
+  const title = `[teams] ${stored.user || 'user'}: ${(stored.text || '(attachment)').slice(0, 60)}`
+  try {
+    const r = spawnSync(
+      'bash',
+      [
+        taskScript,
+        'create',
+        '--to', agent,
+        '--from', 'teams-channel',
+        '--title', title,
+        '--body-file', bodyFile,
+      ],
+      { stdio: ['ignore', 'pipe', 'pipe'] },
+    )
+    if (r.status !== 0) {
+      const stderrTail = r.stderr ? r.stderr.toString().slice(0, 200) : ''
+      process.stderr.write(`teams channel: bridge-mode enqueue failed rc=${r.status}: ${stderrTail}\n`)
+    }
+  } finally {
+    try { unlinkSync(bodyFile) } catch {}
   }
 }
 
@@ -1613,50 +1697,78 @@ async function handleActivity(context: TurnContext): Promise<void> {
     ...(revision ? { revision } : {}),
     ...(attachments.length > 0 ? { attachments } : {}),
   }
-  // Channel delivery and local log append are split: a delivery failure must
-  // surface as a non-2xx so Teams retries, but a successful delivery followed
-  // by a failed log append (disk full, EACCES, …) should NOT cause Teams to
-  // retry — the message is already in the active Claude session. The only
-  // observable consequence of a log-append failure is that fetch_messages
-  // can't replay this entry from the local audit log.
-  try {
-    await mcp.notification({
-      method: 'notifications/claude/channel',
-      params: {
-        content: text || (attachments.length > 0 ? '(attachment)' : ''),
-        meta: {
-          source: 'teams',
-          chat_id: chatId,
-          conversation_id: chatId,
-          message_id: messageId,
-          user: userName,
-          user_id: stored.user_id,
-          aad_object_id: aad,
-          tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
-          service_url: String(activity.serviceUrl ?? ''),
-          ts,
-          ...(revision ? { revision } : {}),
-          ...(attachments.length > 0
-            ? {
-                attachment_count: String(attachments.length),
-                attachments: attachments.map(att => ({
-                  name: att.name,
-                  content_type: att.content_type,
-                  download_status: att.download_status,
-                  ...(att.local_path ? { local_path: att.local_path } : {}),
-                  ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
-                  ...(att.download_error ? { download_error: att.download_error } : {}),
-                })),
-              }
-            : {}),
+  // Channel delivery and local log append are split: a channel-mode delivery
+  // failure must surface as a non-2xx so Teams retries, but a successful
+  // delivery followed by a failed log append (disk full, EACCES, …) should
+  // NOT cause Teams to retry — the message is already in the active Claude
+  // session. The only observable consequence of a log-append failure is that
+  // fetch_messages can't replay this entry from the local audit log.
+  //
+  // TEAMS_DELIVERY_MODE (issue #959): `channel` (default) preserves the
+  // existing notifications/claude/channel path; `bridge` enqueues a queue
+  // task instead (sidesteps Claude Code's silent notification-handler drop);
+  // `both` fires both for defense in depth (accepting possible duplicate
+  // delivery).
+  const mode = DELIVERY_MODE
+  let channelDelivered = false
+  let channelError: unknown = null
+  if (mode === 'channel' || mode === 'both') {
+    try {
+      await mcp.notification({
+        method: 'notifications/claude/channel',
+        params: {
+          content: text || (attachments.length > 0 ? '(attachment)' : ''),
+          meta: {
+            source: 'teams',
+            chat_id: chatId,
+            conversation_id: chatId,
+            message_id: messageId,
+            user: userName,
+            user_id: stored.user_id,
+            aad_object_id: aad,
+            tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
+            service_url: String(activity.serviceUrl ?? ''),
+            ts,
+            ...(revision ? { revision } : {}),
+            ...(attachments.length > 0
+              ? {
+                  attachment_count: String(attachments.length),
+                  attachments: attachments.map(att => ({
+                    name: att.name,
+                    content_type: att.content_type,
+                    download_status: att.download_status,
+                    ...(att.local_path ? { local_path: att.local_path } : {}),
+                    ...(att.size_bytes !== undefined ? { size_bytes: att.size_bytes } : {}),
+                    ...(att.download_error ? { download_error: att.download_error } : {}),
+                  })),
+                }
+              : {}),
+          },
         },
-      },
-    })
-  } catch (err) {
-    recentMessageIds.forget(dedupeKey(chatId, messageId, revision))
-    process.stderr.write(`teams channel: failed to deliver inbound message_id=${messageId}: ${err}\n`)
-    throw err
+      })
+      channelDelivered = true
+    } catch (err) {
+      channelError = err
+      process.stderr.write(`teams channel: failed to deliver inbound message_id=${messageId} via channel: ${err}\n`)
+    }
   }
+
+  if (mode === 'bridge' || mode === 'both') {
+    // Bridge-mode failures log but do not throw — operators choosing bridge
+    // or both have accepted best-effort enqueue. See deliverViaBridgeQueue.
+    deliverViaBridgeQueue(stored)
+  }
+
+  // Channel-mode (and both-mode) failure surfaces to Teams so it retries; in
+  // both-mode we re-throw on channel failure even though bridge may have
+  // succeeded, so Teams's at-least-once channel delivery contract holds.
+  // Bridge-only mode never throws here — its delivery is best-effort by
+  // design.
+  if ((mode === 'channel' || mode === 'both') && !channelDelivered) {
+    recentMessageIds.forget(dedupeKey(chatId, messageId, revision))
+    throw channelError
+  }
+
   try {
     appendMessage(stored)
   } catch (err) {


### PR DESCRIPTION
## Summary

Restores an opt-in plugin-side delivery fallback for Teams inbound messages so operators have a workaround for the silent-drop window described in #959.

PR #569 moved Teams inbound delivery from queue-based to `notifications/claude/channel`. Issue #959 shows that `await mcp.notification()` resolving is not a reliable end-to-end ack — `messages.jsonl` is populated and the MCP write returns success, but Claude Code's notification handler can silently drop the wake so the agent stays idle. Root cause lives in Claude Code; this patch gives operators a queue-based fallback now.

## Change

New env var `TEAMS_DELIVERY_MODE` selects the inbound path:

| Mode | Behavior |
| --- | --- |
| `channel` (default) | Current behavior. One `mcp.notification` per message. No behavior change for existing installs. |
| `bridge` | Skip the channel notification; enqueue the message via `bridge-task.sh create`. The daemon wakes the agent through the standard inbox path, sidestepping the notification-handler silent-drop. |
| `both` | Fire the notification AND enqueue the queue task. Belt-and-braces; operator accepts possible duplicate delivery. |

Resolved once at module load so an invalid value warns once on boot, not per message. Bridge enqueue failures (missing `BRIDGE_AGENT_ID`, missing `bridge-task.sh`, queue subprocess non-zero) log to stderr but never throw — only channel-mode failures still surface to the Teams webhook so it retries.

README §Delivery Mode rewritten with the three modes and trade-offs.

## Files changed

- `plugins/teams/server.ts` — new `DELIVERY_MODE` resolver + `deliverViaBridgeQueue()` helper + reworked `handleActivity` delivery block. Legacy `TEAMS_BRIDGE_MODE`/`TEAMS_BRIDGE_AGENT` warning text now points operators at the new env var.
- `plugins/teams/README.md` — §Delivery Mode rewritten with mode table and trade-offs; documents that end-to-end live verification requires a real Teams + Azure setup.

## Test plan

- [x] `bun build server.ts --target=node --outfile=/tmp/teams-bundle.js` — bundles clean (4.65 MB, 1007 modules, 0 type errors).
- [x] Boot test, `channel` (default): `/health` returns `{"ok":true,"channel":"teams","port":39791}`, stderr only logs `listening`.
- [x] Boot test, `TEAMS_DELIVERY_MODE=bridge`: same `/health`, no warning.
- [x] Boot test, `TEAMS_DELIVERY_MODE=both`: same `/health`, no warning.
- [x] Boot test, `TEAMS_DELIVERY_MODE=banana`: same `/health`, stderr logs `unsupported TEAMS_DELIVERY_MODE=banana; falling back to channel`.
- [x] Boot test, `TEAMS_BRIDGE_MODE=1`: same `/health`, stderr logs the legacy-ignored warning pointing at `TEAMS_DELIVERY_MODE=bridge`.
- [ ] End-to-end Teams round trip in `bridge` and `both` modes — requires real Azure bot + tenant; documented in README as out of CI scope. Operator running issue #959's repro should set `TEAMS_DELIVERY_MODE=both` and confirm the agent wakes via the queue path even if the channel path silently drops.

## Notes

- Default stays `channel` so existing installs see no behavior change. Issue stays open (used `refs #959` not `closes`) so the codex pair-review and operator's live verification gate it.
- `BRIDGE_HOME` is already a module constant; `bridge-task.sh` is looked up under it via the existing `BRIDGE_HOME ?? join(homedir(), '.agent-bridge')` resolution, matching how `bridge-guard.py` is resolved in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)