### PR TITLE
fix(isolation): v2 matrix branches on shared mode; agent create stays bootable (closes #909)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2774,9 +2774,26 @@ report and reap test-fixture agents per their pattern."
       # fresh agent has no such head start). `bridge_linux_prepare_
       # agent_isolation` already covers linux-user above so this branch
       # is the shared-mode counterpart.
-      if ! bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1; then
-        bridge_warn "agent create: v2 shared-mode grant-matrix apply degraded for '$agent' (non-fatal)"
-      fi
+      #
+      # r2 P1 #3: hard-fail on apply error. apply_grant_matrix_for_agent
+      # returns rc=1 only when a `required` row is broken (`optional`
+      # rows demote to `degraded` and keep rc=0 — see the criticality
+      # split in lib/bridge-isolation-v2.sh's apply_grant_matrix_for_
+      # agent walker). Required apply failure here means marker writes
+      # through ensure_matrix_path will reject on the first daemon pass;
+      # swallowing the failure as "degraded continue" was exactly the
+      # #909 wedge shape (non-bootable agent with no operator signal).
+      # Surface the apply stderr and die so the operator sees the cause
+      # and can either remove the agent (`agb agent delete <name>
+      # --force`) or fix the underlying identity/permission issue.
+      local _v2_apply_err=""
+      _v2_apply_err="$(bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply 2>&1 >/dev/null)" \
+        || {
+          if [[ -n "$_v2_apply_err" ]]; then
+            printf '%s\n' "$_v2_apply_err" >&2
+          fi
+          bridge_die "agent create: v2 shared-mode grant-matrix apply failed for '$agent' — first daemon pass would wedge on missing rows. Inspect output above, then 'agb agent delete $agent --force' to roll back."
+        }
     fi
     # Issue #680: bridge-start.sh --dry-run is purely informational here — its
     # output is reprinted to the user as `start_dry_run:` for diagnostic

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2792,7 +2792,7 @@ report and reap test-fixture agents per their pattern."
           if [[ -n "$_v2_apply_err" ]]; then
             printf '%s\n' "$_v2_apply_err" >&2
           fi
-          bridge_die "agent create: v2 shared-mode grant-matrix apply failed for '$agent' — first daemon pass would wedge on missing rows. Inspect output above, then 'agb agent delete $agent --force' to roll back."
+          bridge_die "agent create: v2 shared-mode grant-matrix apply failed for '$agent' — first daemon pass would wedge on missing rows. Inspect output above, then 'agb agent delete $agent --force --purge-home' to roll back (the scaffolded home directory must be removed too)."
         }
     fi
     # Issue #680: bridge-start.sh --dry-run is purely informational here — its

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2760,6 +2760,23 @@ report and reap test-fixture agents per their pattern."
     bridge_sync_skill_docs "$agent" >/dev/null 2>&1 || true
     if [[ "$isolation_mode" == "linux-user" ]]; then
       bridge_linux_prepare_agent_isolation "$agent" "$os_user" "$workdir"
+    elif command -v bridge_isolation_v2_active >/dev/null 2>&1 \
+        && bridge_isolation_v2_active 2>/dev/null \
+        && command -v bridge_isolation_v2_apply_grant_matrix_for_agent >/dev/null 2>&1; then
+      # #909: shared-mode agents on a v2-active install must also leave
+      # the matrix in a check-passing state. Without this, the first
+      # daemon write through write_agent_state_marker hits ensure_matrix_
+      # path → apply_row → chown, and on a tree the controller already
+      # owns this is a no-op success. The call is here so a fresh
+      # `agent create <X>` on a shared-only v2 install mirrors the
+      # bootstrap/upgrade-provisioned shape (patch / librarian survive
+      # only because their matrix paths were materialized earlier; a
+      # fresh agent has no such head start). `bridge_linux_prepare_
+      # agent_isolation` already covers linux-user above so this branch
+      # is the shared-mode counterpart.
+      if ! bridge_isolation_v2_apply_grant_matrix_for_agent "$agent" --apply >/dev/null 2>&1; then
+        bridge_warn "agent create: v2 shared-mode grant-matrix apply degraded for '$agent' (non-fatal)"
+      fi
     fi
     # Issue #680: bridge-start.sh --dry-run is purely informational here — its
     # output is reprinted to the user as `start_dry_run:` for diagnostic

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1349,6 +1349,29 @@ bridge_isolation_v2_matrix_rows_for_agent() {
   local iso_home_root="${BRIDGE_LINUX_ISOLATED_USER_HOME_ROOT:-/home}"
   local iso_home="${iso_home_root}/${iso_user}"
 
+  # #909: branch the per-agent matrix rows on the agent's isolation_mode.
+  # Same family as #895 (workdir resolver) — v2 layout can be active while
+  # individual agents run in shared mode (default for `agb --claude --name
+  # <X>` dynamic spawn and for installs that never opted any agent into
+  # linux-user isolation). Linux-user rows reference the per-agent UID
+  # `agent-bridge-<X>` and group `ab-agent-<X>`, neither of which exists
+  # on a shared-only install. Without this branch a freshly created
+  # shared agent fails ensure_matrix_path on every state-marker write
+  # (chown to nonexistent user/group), so write_agent_state_marker returns
+  # 1, the idle-since marker never lands, and the always-on daemon
+  # restart-loops the tmux session indefinitely.
+  local _v2_isolation_mode="linux-user"
+  if command -v bridge_agent_isolation_mode >/dev/null 2>&1; then
+    _v2_isolation_mode="$(bridge_agent_isolation_mode "$agent" 2>/dev/null || printf 'linux-user')"
+  fi
+  # Anything outside the {shared, linux-user} pair (unknown / "") preserves
+  # the legacy linux-user matrix — defensive default for any roster entry
+  # that pre-dates the isolation_mode field.
+  case "$_v2_isolation_mode" in
+    shared) ;;
+    *) _v2_isolation_mode="linux-user" ;;
+  esac
+
   # ----- shared/ row family (catalog/source only — RC6 per-agent cache
   # lands in PR 2 as a separate row family) -----
   if [[ -n "$shared_root" ]]; then
@@ -1362,19 +1385,44 @@ bridge_isolation_v2_matrix_rows_for_agent() {
 
   # ----- per-agent root + writable subdirs + credentials -----
   if [[ -n "$agent_root" ]]; then
-    printf 'agent-root|%s|dir|root|%s|2750||1|group_setgid|required|root-owned 2750: isolated UID enters via group r-x, no group write\n' \
-      "$agent_root" "$agent_grp"
-    local sub
-    for sub in home workdir runtime logs requests responses; do
-      printf 'agent-%s|%s/%s|dir|%s|%s|2770|0660|1|group_setgid|required|writable subtree (RC4=runtime RC5=logs)\n' \
-        "$sub" "$agent_root" "$sub" "$iso_user" "$agent_grp"
-    done
-    printf 'agent-credentials-dir|%s/credentials|dir|controller|%s|2750|0640|1|group_setgid|required|controller writes launch-secrets.env, group reads\n' \
-      "$agent_root" "$agent_grp"
-    printf 'agent-launch-secrets|%s/credentials/launch-secrets.env|file|controller|%s||0640|0|group_setgid|required|launch secret env file (mode 0640 contract)\n' \
-      "$agent_root" "$agent_grp"
-    printf 'agent-env-sh|%s/runtime/agent-env.sh|file|controller|%s||0640|0|group_setgid|required|cached launch env\n' \
-      "$agent_root" "$agent_grp"
+    if [[ "$_v2_isolation_mode" == "shared" ]]; then
+      # #909 shared-mode row family: operator-owned, controller primary
+      # group. Mode 2750 for the root mirrors linux-user (root-owned
+      # 2750: only the controller can write at the root), but the
+      # writable subdirs widen to mode 2770 with `controller`+
+      # `controller_group` so the controller (which IS the agent process
+      # in shared mode) can write. No `ab-agent-<X>` group required, no
+      # `agent-bridge-<X>` user required. The credentials/runtime files
+      # keep mode 0640 (controller-only write, group-read) so a future
+      # mode migration to per-agent isolation does not regress secrets.
+      printf 'agent-root|%s|dir|controller|controller_group|2750||1|group_setgid|required|#909 shared-mode: controller-owned per-agent root\n' \
+        "$agent_root"
+      local sub
+      for sub in home workdir runtime logs requests responses; do
+        printf 'agent-%s|%s/%s|dir|controller|controller_group|2770|0660|1|group_setgid|required|#909 shared-mode writable subtree\n' \
+          "$sub" "$agent_root" "$sub"
+      done
+      printf 'agent-credentials-dir|%s/credentials|dir|controller|controller_group|2750|0640|1|group_setgid|required|#909 shared-mode credentials dir\n' \
+        "$agent_root"
+      printf 'agent-launch-secrets|%s/credentials/launch-secrets.env|file|controller|controller_group||0640|0|group_setgid|required|#909 shared-mode launch secret env file\n' \
+        "$agent_root"
+      printf 'agent-env-sh|%s/runtime/agent-env.sh|file|controller|controller_group||0640|0|group_setgid|required|#909 shared-mode cached launch env\n' \
+        "$agent_root"
+    else
+      printf 'agent-root|%s|dir|root|%s|2750||1|group_setgid|required|root-owned 2750: isolated UID enters via group r-x, no group write\n' \
+        "$agent_root" "$agent_grp"
+      local sub
+      for sub in home workdir runtime logs requests responses; do
+        printf 'agent-%s|%s/%s|dir|%s|%s|2770|0660|1|group_setgid|required|writable subtree (RC4=runtime RC5=logs)\n' \
+          "$sub" "$agent_root" "$sub" "$iso_user" "$agent_grp"
+      done
+      printf 'agent-credentials-dir|%s/credentials|dir|controller|%s|2750|0640|1|group_setgid|required|controller writes launch-secrets.env, group reads\n' \
+        "$agent_root" "$agent_grp"
+      printf 'agent-launch-secrets|%s/credentials/launch-secrets.env|file|controller|%s||0640|0|group_setgid|required|launch secret env file (mode 0640 contract)\n' \
+        "$agent_root" "$agent_grp"
+      printf 'agent-env-sh|%s/runtime/agent-env.sh|file|controller|%s||0640|0|group_setgid|required|cached launch env\n' \
+        "$agent_root" "$agent_grp"
+    fi
   fi
 
   # ----- RC1/RC2: $BRIDGE_HOME/state/{,agents/,agents/<X>} -----
@@ -1388,8 +1436,18 @@ bridge_isolation_v2_matrix_rows_for_agent() {
       "$state_root" "$shared_grp"
     printf 'state-agents-root|%s|dir_only_traverse|controller|%s|0710||0|group_setgid|required|isolated UID needs --x to reach its own leaf\n' \
       "$state_agents_root" "$shared_grp"
-    printf 'state-agent-dir|%s|dir|controller|%s|2770|0660|1|group_setgid|required|RC1: per-agent state leaf, isolated UID + controller rwx\n' \
-      "$state_agent_dir" "$agent_grp"
+    if [[ "$_v2_isolation_mode" == "shared" ]]; then
+      # #909: state-agent-dir under shared mode is operator-owned; the
+      # `ab-agent-<X>` group does not exist. write_agent_state_marker
+      # calls ensure_matrix_path "state-agent-dir" before every idle-since
+      # write, so this row is the hottest fail surface on a shared-only
+      # install.
+      printf 'state-agent-dir|%s|dir|controller|controller_group|2770|0660|1|group_setgid|required|#909 shared-mode per-agent state leaf\n' \
+        "$state_agent_dir"
+    else
+      printf 'state-agent-dir|%s|dir|controller|%s|2770|0660|1|group_setgid|required|RC1: per-agent state leaf, isolated UID + controller rwx\n' \
+        "$state_agent_dir" "$agent_grp"
+    fi
     # RC2: file-level rows are not enforced for files that may be absent
     # at apply time (idle-since, manual-stop, missing-marker-retries,
     # webhook-port, next-session.sha). The matrix grants the parent +
@@ -1418,7 +1476,14 @@ bridge_isolation_v2_matrix_rows_for_agent() {
   fi
 
   # ----- isolated user's own private home (catalog symlink target etc.) -----
-  if [[ -n "$iso_home_root" ]]; then
+  # #909: skip the entire isolated-user-home + per-agent plugin row family
+  # for shared-mode agents. These rows reference `agent-bridge-<X>` (a
+  # Linux account that is never created for shared agents) — emitting them
+  # would re-introduce the chown-to-nonexistent-user failure this fix
+  # exists to close. Plugin install in shared mode lands under the
+  # controller's own ~/.claude (the legacy path) instead of the per-agent
+  # isolated home.
+  if [[ -n "$iso_home_root" ]] && [[ "$_v2_isolation_mode" != "shared" ]]; then
     printf 'isolated-user-home|%s|dir|%s|%s|0700||0|install_managed|required|isolated UIDs private home\n' \
       "$iso_home" "$iso_user" "$iso_user"
 
@@ -1538,6 +1603,72 @@ bridge_isolation_v2_controller_user() {
   printf '%s' "$controller_user"
 }
 
+bridge_isolation_v2_controller_primary_group() {
+  # Resolve the controller user's primary group name. Used by the shared-
+  # mode matrix branch (#909) — shared-mode per-agent rows are owned by the
+  # operator (controller) and grouped by the operator's primary group rather
+  # than the per-agent `ab-agent-<X>` group (which exists only for
+  # linux-user isolation). This keeps `chown`/`chgrp` against real local
+  # identifiers so apply_row does not fail with "user/group does not exist"
+  # on a shared-only install.
+  local controller_user=""
+  controller_user="$(bridge_isolation_v2_controller_user 2>/dev/null || true)"
+  [[ -n "$controller_user" ]] || return 1
+  local group=""
+  group="$(id -gn "$controller_user" 2>/dev/null || true)"
+  [[ -n "$group" ]] || return 1
+  printf '%s' "$group"
+}
+
+bridge_isolation_v2_identity_exists() {
+  # Probe whether a POSIX user or group name resolves on the local host.
+  # Used by apply_row's #909 belt-and-braces guard so a row referencing a
+  # non-existent identity (e.g., `agent-bridge-mgmt` on a shared-only
+  # install) is skipped rather than wedging the daemon.
+  # Args: name, kind ("user" | "group")
+  local name="$1"
+  local kind="$2"
+  [[ -n "$name" && -n "$kind" ]] || return 1
+  case "$kind" in
+    user)
+      # Propagate getent's rc on Linux (authoritative). Fall through to
+      # `id -u` on hosts without getent (macOS) — `id -u <missing>` is
+      # also authoritative (rc=1).
+      if command -v getent >/dev/null 2>&1; then
+        getent passwd "$name" >/dev/null 2>&1
+        return $?
+      fi
+      id -u "$name" >/dev/null 2>&1
+      return $?
+      ;;
+    group)
+      # Try getent first (Linux NSS). If getent is present, propagate its
+      # rc — a successful lookup is rc=0, NSS-absent is non-zero, and
+      # either result is authoritative.
+      if command -v getent >/dev/null 2>&1; then
+        getent group "$name" >/dev/null 2>&1
+        return $?
+      fi
+      # macOS fallback: dscl returns rc=56 for eDSRecordNotFound. When
+      # dscl is available, propagate its rc directly so the probe is
+      # authoritative on macOS too (early-`return 0`-only made the probe
+      # non-authoritative, defeating the purpose of the belt-and-braces
+      # guard on macOS smokes).
+      if command -v dscl >/dev/null 2>&1; then
+        dscl . -read "/Groups/$name" >/dev/null 2>&1
+        return $?
+      fi
+      # No probe primitive available — return success so the downstream
+      # chown proceeds and surfaces its own error path. This is the
+      # non-Linux, non-macOS fallback (rare in practice).
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 bridge_isolation_v2_apply_row() {
   # Internal dispatcher — applies (or checks) one matrix row.
   # Args:
@@ -1564,6 +1695,16 @@ bridge_isolation_v2_apply_row() {
     owner="$(bridge_isolation_v2_controller_user 2>/dev/null || true)"
     [[ -n "$owner" ]] || {
       bridge_warn "apply_row($row_name): cannot resolve controller user"
+      return 1
+    }
+  fi
+  # #909: same indirection for the group field so shared-mode rows can
+  # emit `controller_group` without baking the operator's primary group
+  # name into the static matrix.
+  if [[ "$group" == "controller_group" ]]; then
+    group="$(bridge_isolation_v2_controller_primary_group 2>/dev/null || true)"
+    [[ -n "$group" ]] || {
+      bridge_warn "apply_row($row_name): cannot resolve controller primary group"
       return 1
     }
   fi
@@ -1614,6 +1755,28 @@ bridge_isolation_v2_apply_row() {
       return 1
       ;;
   esac
+
+  # #909 belt-and-braces: if the resolved owner/group does not exist on
+  # this host, treat the apply branch as a non-fatal degraded skip. The
+  # primary fix is the shared-mode row branch in matrix_rows_for_agent,
+  # which emits operator-owned rows that ALWAYS resolve. This guard is
+  # the second line of defense: if any matrix row still slips through
+  # referencing a non-existent identity (e.g., a future row family or a
+  # mis-routed caller passing an `ab-agent-<X>` group on a shared-only
+  # install), the agent should NOT wedge into a daemon restart-loop the
+  # operator cannot mitigate from an agent session — same failure shape
+  # the original #909 report documents.
+  if [[ "$mode" == "apply" ]] \
+      && [[ "$mechanism" == "group_setgid" ]]; then
+    if ! bridge_isolation_v2_identity_exists "$owner" "user" 2>/dev/null; then
+      bridge_warn "apply_row($row_name): owner '$owner' does not exist on host — skipping apply (#909 non-fatal in non-isolated mode)"
+      return 0
+    fi
+    if ! bridge_isolation_v2_identity_exists "$group" "group" 2>/dev/null; then
+      bridge_warn "apply_row($row_name): group '$group' does not exist on host — skipping apply (#909 non-fatal in non-isolated mode)"
+      return 0
+    fi
+  fi
 
   # group_setgid path — the common case.
   case "$access_type" in

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1332,11 +1332,7 @@ bridge_isolation_v2_matrix_rows_for_agent() {
     bridge_warn "matrix_rows_for_agent: agent name required"
     return 1
   }
-  local agent_grp data_root shared_root
-  agent_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null)" || {
-    bridge_warn "matrix_rows_for_agent: cannot resolve agent group for '$agent'"
-    return 1
-  }
+  local data_root shared_root
   data_root="${BRIDGE_DATA_ROOT:-}"
   shared_root="${BRIDGE_SHARED_ROOT:-${data_root:+$data_root/shared}}"
   local agent_root="${data_root:+$data_root/agents/$agent}"
@@ -1371,6 +1367,22 @@ bridge_isolation_v2_matrix_rows_for_agent() {
     shared) ;;
     *) _v2_isolation_mode="linux-user" ;;
   esac
+
+  # r2 P1 #1: defer agent_grp resolution until we know we're in linux-user
+  # mode. bridge_isolation_v2_agent_group_name rejects names outside
+  # `[a-z_][a-z0-9_-]*` (POSIX group-name shape), but bridge-core.sh accepts
+  # broader names in shared mode (digits/dots/hyphens/uppercase). Resolving
+  # here in shared mode would fail the whole matrix emit for a legitimate
+  # shared agent like `foo.bar`, which is the exact wedge the #909 fix
+  # exists to close. Shared rows use `controller_group` (resolved at
+  # apply_row time) instead of the per-agent group.
+  local agent_grp=""
+  if [[ "$_v2_isolation_mode" != "shared" ]]; then
+    agent_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null)" || {
+      bridge_warn "matrix_rows_for_agent: cannot resolve agent group for '$agent'"
+      return 1
+    }
+  fi
 
   # ----- shared/ row family (catalog/source only — RC6 per-agent cache
   # lands in PR 2 as a separate row family) -----
@@ -1675,6 +1687,9 @@ bridge_isolation_v2_apply_row() {
   #   $1 mode    apply | check
   #   $2..$11   row fields in matrix order (row_name path access_type owner
   #             group dir_mode file_mode setgid grant_mechanism criticality)
+  #   $12       agent (optional) — required for controller_credential_acl
+  #             and consulted by the #909 belt-and-braces fallback to gate
+  #             "missing identity = warn" on shared-mode agents only.
   # Returns 0 on apply success / clean check, non-zero otherwise. Caller
   # is responsible for emitting per-row report rows; this helper only
   # mutates filesystem state (apply) or compares (check).
@@ -1689,6 +1704,7 @@ bridge_isolation_v2_apply_row() {
   local setgid="$9"
   local mechanism="${10}"
   local criticality="${11}"
+  local agent="${12:-}"
 
   # Resolve `controller` token at apply/check time so the matrix stays static.
   if [[ "$owner" == "controller" ]]; then
@@ -1719,16 +1735,15 @@ bridge_isolation_v2_apply_row() {
       # caller invokes apply_row with no agent context (12th arg),
       # downgrade to fail-loud — silent ok was the v0.9.5/v0.9.6 RC3
       # recurrence anti-pattern.
-      local agent_for_rc3="${12:-}"
-      if [[ -z "$agent_for_rc3" ]]; then
+      if [[ -z "$agent" ]]; then
         bridge_warn "apply_row($row_name): controller_credential_acl requires agent context (\$12); refuse to false-pass"
         return 1
       fi
       if [[ "$mode" == "apply" ]]; then
-        bridge_isolation_v2_apply_controller_credentials_read_grant "$agent_for_rc3" "$file_mode"
+        bridge_isolation_v2_apply_controller_credentials_read_grant "$agent" "$file_mode"
         return $?
       fi
-      bridge_isolation_v2_check_controller_credentials_read_grant "$agent_for_rc3" "$path" "$file_mode"
+      bridge_isolation_v2_check_controller_credentials_read_grant "$agent" "$path" "$file_mode"
       return $?
       ;;
     install_managed)
@@ -1757,24 +1772,47 @@ bridge_isolation_v2_apply_row() {
   esac
 
   # #909 belt-and-braces: if the resolved owner/group does not exist on
-  # this host, treat the apply branch as a non-fatal degraded skip. The
-  # primary fix is the shared-mode row branch in matrix_rows_for_agent,
-  # which emits operator-owned rows that ALWAYS resolve. This guard is
-  # the second line of defense: if any matrix row still slips through
-  # referencing a non-existent identity (e.g., a future row family or a
-  # mis-routed caller passing an `ab-agent-<X>` group on a shared-only
-  # install), the agent should NOT wedge into a daemon restart-loop the
-  # operator cannot mitigate from an agent session — same failure shape
-  # the original #909 report documents.
+  # this host, treat the apply branch as a non-fatal degraded skip ONLY
+  # for shared-mode agents. The primary fix is the shared-mode row branch
+  # in matrix_rows_for_agent, which emits operator-owned rows that ALWAYS
+  # resolve. This guard is the second line of defense: if any matrix row
+  # still slips through referencing a non-existent identity (e.g., a
+  # future row family or a mis-routed caller passing an `ab-agent-<X>`
+  # group on a shared-only install), a shared agent should NOT wedge into
+  # a daemon restart-loop the operator cannot mitigate from an agent
+  # session — same failure shape the original #909 report documents.
+  #
+  # r2 P1 #2: gate the downgrade on shared-mode. Linux-user rows in
+  # matrix_rows_for_agent (`else` branches around the
+  # `_v2_isolation_mode == "shared"` checks) reference `agent-bridge-<X>`
+  # / `ab-agent-<X>`. A missing identity there is a real linux-user setup
+  # bug (e.g., bridge_linux_prepare_agent_isolation never ran, useradd
+  # failed silently); masking it with a warn would hide the bug and
+  # leave the agent half-prepared. Without an agent in scope ($12 unset
+  # — third-party caller), preserve the pre-r1 hard-fail behavior because
+  # we cannot prove shared-mode.
   if [[ "$mode" == "apply" ]] \
       && [[ "$mechanism" == "group_setgid" ]]; then
+    local _missing_kind="" _missing_name=""
     if ! bridge_isolation_v2_identity_exists "$owner" "user" 2>/dev/null; then
-      bridge_warn "apply_row($row_name): owner '$owner' does not exist on host — skipping apply (#909 non-fatal in non-isolated mode)"
-      return 0
+      _missing_kind="user"
+      _missing_name="$owner"
+    elif ! bridge_isolation_v2_identity_exists "$group" "group" 2>/dev/null; then
+      _missing_kind="group"
+      _missing_name="$group"
     fi
-    if ! bridge_isolation_v2_identity_exists "$group" "group" 2>/dev/null; then
-      bridge_warn "apply_row($row_name): group '$group' does not exist on host — skipping apply (#909 non-fatal in non-isolated mode)"
-      return 0
+    if [[ -n "$_missing_kind" ]]; then
+      local _agent_iso_mode=""
+      if [[ -n "$agent" ]] \
+          && command -v bridge_agent_isolation_mode >/dev/null 2>&1; then
+        _agent_iso_mode="$(bridge_agent_isolation_mode "$agent" 2>/dev/null || true)"
+      fi
+      if [[ "$_agent_iso_mode" == "shared" ]]; then
+        bridge_warn "apply_row($row_name): $_missing_kind '$_missing_name' does not exist on host — skipping apply (#909 shared-mode non-fatal)"
+        return 0
+      fi
+      bridge_warn "apply_row($row_name): $_missing_kind '$_missing_name' does not exist on host (agent='${agent:-<unknown>}', mode='${_agent_iso_mode:-<unknown>}') — refusing to false-pass linux-user setup"
+      return 1
     fi
   fi
 
@@ -1910,9 +1948,12 @@ bridge_isolation_v2_apply_grant_matrix_for_agent() {
           || row_rc=$?
       fi
     else
+      # r2 P1 #2: pass agent ($12) so apply_row's belt-and-braces fallback
+      # can gate "missing identity = warn" on shared-mode agents only.
       bridge_isolation_v2_apply_row "$mode" \
         "$r_name" "$r_path" "$r_access" "$r_owner" "$r_group" \
         "$r_dmode" "$r_fmode" "$r_setgid" "$r_mech" "$r_crit" \
+        "$agent" \
         || row_rc=$?
     fi
     if [[ "$mode" == "check" ]]; then
@@ -1993,14 +2034,18 @@ bridge_isolation_v2_ensure_matrix_path() {
     return 1
   fi
   IFS='|' read -r r_name r_path r_access r_owner r_group r_dmode r_fmode r_setgid r_mech r_crit r_notes <<<"$row"
+  # r2 P1 #2: pass agent ($12) so apply_row's belt-and-braces fallback
+  # can gate "missing identity = warn" on shared-mode agents only.
   if bridge_isolation_v2_apply_row "check" \
     "$r_name" "$r_path" "$r_access" "$r_owner" "$r_group" \
-    "$r_dmode" "$r_fmode" "$r_setgid" "$r_mech" "$r_crit" 2>/dev/null; then
+    "$r_dmode" "$r_fmode" "$r_setgid" "$r_mech" "$r_crit" \
+    "$agent" 2>/dev/null; then
     return 0
   fi
   bridge_isolation_v2_apply_row "apply" \
     "$r_name" "$r_path" "$r_access" "$r_owner" "$r_group" \
-    "$r_dmode" "$r_fmode" "$r_setgid" "$r_mech" "$r_crit"
+    "$r_dmode" "$r_fmode" "$r_setgid" "$r_mech" "$r_crit" \
+    "$agent"
 }
 
 bridge_isolation_v2_apply_controller_credentials_read_grant() {

--- a/scripts/smoke/isolation-v2-macos-noise-suppression.sh
+++ b/scripts/smoke/isolation-v2-macos-noise-suppression.sh
@@ -102,7 +102,7 @@ smoke_log "T2: apply_row group_setgid Darwin no-op"
 T2_OUT="$SMOKE_TMP_ROOT/t2.out"
 T2_PATH="$SMOKE_TMP_ROOT/t2-target-dir"
 run_isolation_call \
-  "mkdir -p \"$T2_PATH\"; bridge_isolation_v2_apply_row apply test-row \"$T2_PATH\" dir root ab-shared 2750 0640 1 group_setgid required; echo \"RC=\$?\"" \
+  "mkdir -p \"$T2_PATH\"; bridge_isolation_v2_apply_row apply test-row \"$T2_PATH\" dir root ab-shared 2750 0640 1 group_setgid required testagent; echo \"RC=\$?\"" \
   "$T2_OUT" || true
 
 if ! grep -q '^RC=0$' "$T2_OUT"; then


### PR DESCRIPTION
## Summary

Closes #909. `agent create <name>` on a v2-active shared-only install produced a non-bootable agent that wedged the daemon into a restart-loop. Root cause is the same #895/#906 family: v2 isolation logic emits a `linux-user` matrix (per-agent UID `agent-bridge-<X>`, group `ab-agent-<X>`) regardless of the agent's `isolation_mode`. On a shared-only install neither identity exists, so `chown` fails, `apply_row` returns 1, `ensure_matrix_path` returns 1, `write_agent_state_marker` returns 1, the idle-since marker never lands, and the always-on/loop daemon relaunches the tmux session every ~15–30 s indefinitely.

Three coordinated changes close the defect:

- **A. `lib/bridge-isolation-v2.sh: bridge_isolation_v2_matrix_rows_for_agent`** branches on `bridge_agent_isolation_mode`. Shared agents get a controller-owned row family (operator + operator-primary-group, modes 2750 / 2770), no isolated-user-home, no per-agent plugin rows. Linux-user matrix is byte-identical to legacy shape (owner / group / mode / notes preserved row-by-row). Unknown / "" defaults to linux-user (defensive backward-compat).
- **B. `lib/bridge-isolation-v2.sh: bridge_isolation_v2_apply_row`** belt-and-braces — if the resolved owner or group does not exist on the host, skip the apply branch non-fatally (warn + rc=0) instead of returning rc=1. Defends against any future row family or mis-routed caller still slipping through with a non-existent identity. Adds two helpers:
  - `bridge_isolation_v2_controller_primary_group` (resolves `id -gn` for the new `controller_group` token used by shared-mode rows)
  - `bridge_isolation_v2_identity_exists` (portable user/group probe via getent / id -u / dscl; authoritative on Linux + macOS)
- **C. `bridge-agent.sh: agent create`** runs `bridge_isolation_v2_apply_grant_matrix_for_agent --apply` for shared agents on a v2-active install (mirroring `bridge_linux_prepare_agent_isolation` for linux-user). A freshly created agent's matrix lands in a check-passing state so subsequent `ensure_matrix_path` calls short-circuit rc=0 — same shape that lets `patch`/`librarian` survive on the operator's existing install.

This is a high-severity fix: per the issue, the operator cannot mitigate the restart-loop from an agent session (`agent update --loop off` is a protected mutation that requires operator-TTY), so a single bad `agent create` wedges the host until upstream fix or manual TTY intervention.

## Test plan

- [x] `bash -n` + `shellcheck` clean for both files
- [x] Isolated `BRIDGE_HOME` repro (`BRIDGE_ISOLATION_REQUIRED=yes`) — verified:
  - Shared matrix rows contain zero `agent-bridge-<X>` / `ab-agent-<X>` / `isolated-user-home` references
  - `ensure_matrix_path state-agent-dir <agent>` → rc=0 (the #909 idle-since wedge surface; was rc=1 pre-fix)
  - `ensure_matrix_path agent-runtime <agent>` → rc=0 (the prompt-ready.env wedge surface; was rc=1 pre-fix)
  - `apply_grant_matrix_for_agent --apply <agent>` → rc=0 (the new `agent create` final step)
  - Linux-user matrix byte-identical to legacy shape (regression smoke)
  - Belt-and-braces guard with simulated stale `ab-agent-<X>` reference on macOS (no such group) → rc=0 + warn (was rc=1 pre-fix)
- [x] `scripts/smoke-test.sh` queue / daemon / static-role / CLI helpers all pass (72 assertions before hitting the pre-existing Bash 5.3.9 heredoc deadlock in `bridge_render_project_bridge_reference` — known footgun #11 on macOS, unrelated to this change)
- [ ] **Operator manual verification on the WSL2 install that filed the issue**: `agent-bridge agent create mgmt --engine claude --always-on --loop` followed by `agent-bridge agent start mgmt`. Expected: tmux session reaches healthy idle, daemon does not restart-loop, `bridge_isolation_v2_matrix_rows_for_agent mgmt` emits operator-owned rows only, `[경고] write_agent_state_marker: ensure_matrix_path failed` warnings disappear from `data/agents/mgmt/logs/<date>.log`.

Same defect family as #895 (shared-mode workdir resolver) and #906 — branching v2 logic on the agent's actual `isolation_mode` instead of assuming linux-user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)