### PR TITLE
fix(stall): skip codex agent glyphs + flush-left wrap continuations

### DIFF
--- a/bridge-stall.py
+++ b/bridge-stall.py
@@ -201,15 +201,25 @@ def classify(normalized: str) -> tuple[str, str, str]:
     # become a self-sustaining stall loop.
     #
     # Block-aware extension: codex renders tool/diff output as a glyph-prefixed
-    # head line followed by indented continuation lines that carry no glyph
-    # (wrapped diff bodies, multi-line tool stdout). Glyph-only filtering let
-    # those wrapped lines reach classify and match e.g. "401 Unauthorized"
-    # quoted from a smoke test. Once we enter an agent block on a glyph line,
-    # skip subsequent non-empty lines whose RAW text starts with whitespace;
-    # exit the block on a blank line or the next non-indented, non-glyph line
-    # (which is itself eligible for matching). Issue #329 Track D's
-    # walk-line-by-line semantics are preserved so matched_line_hash keeps its
-    # dedup behavior.
+    # head line followed by continuation lines that carry no glyph (wrapped
+    # diff bodies, multi-line tool stdout). Glyph-only filtering let those
+    # continuation lines reach classify and match e.g. "401 Unauthorized"
+    # quoted from a smoke test or from a tracked review report.
+    #
+    # An earlier version of this rule treated the block as "indented lines
+    # only" — but codex wraps long head lines too, e.g.
+    #     • Added /very/long/path/to/file.md (+34
+    #     -0)
+    #     1 +...
+    # where `-0)` lands flush-left and looks like a block exit. Once exited,
+    # the indented diff body that followed was eligible to match. The rule
+    # below treats *any* non-empty line inside an agent block as part of the
+    # block, regardless of indentation; the block ends on the next blank line.
+    # A subsequent glyph line restarts the block. This is broader than the
+    # original indented-only rule but matches how codex actually structures
+    # output: top-level pane items are separated by blank lines, and any
+    # rendering inside one item is the agent narrating. Issue #329 Track D's
+    # walk-line-by-line semantics and matched_line_hash dedup are preserved.
     in_agent_block = False
     for raw in normalized.splitlines():
         stripped = raw.strip()
@@ -220,9 +230,7 @@ def classify(normalized: str) -> tuple[str, str, str]:
             in_agent_block = True
             continue
         if in_agent_block:
-            if raw[:1].isspace():
-                continue
-            in_agent_block = False
+            continue
         haystack = stripped.lower()
         for classification, patterns in PATTERN_GROUPS:
             for pattern in patterns:

--- a/bridge-stall.py
+++ b/bridge-stall.py
@@ -126,6 +126,32 @@ AGENT_GLYPH_PREFIXES = (
     "•", "│", "└",
 )
 
+# Raw provider/system error prefixes that should break out of an in-agent
+# block and reach classification even when they immediately follow a glyph
+# line without a blank separator. Without this escape hatch, a real stall
+# like `Error: HTTP 429 too many requests` arriving directly under a codex
+# `• Running smoke` head line would be swallowed by the in-block skip — an
+# actually-rate-limited agent would appear idle to bridge-stall.
+#
+# Anchored at the *raw* line start (no leading whitespace allowed) + word
+# boundary + colon-or-whitespace separator. Indentation matters here:
+# codex renders tool/diff output as indented continuation lines under a
+# glyph head, and a continuation that quotes a prior error (e.g.
+# `  Error: HTTP 429 ...` two spaces in, transcript inside a tool block)
+# must NOT escape. Only flush-left raw provider output qualifies. Casual
+# narration ("the user got an error", "errors are common") and diff bodies
+# ("1 +error_message =") cannot match the line-start anchor either.
+# Tool-output continuations like `└ tool: error: file not found` are not
+# affected here — those start with the `└` glyph and are skipped by
+# AGENT_GLYPH_PREFIXES before this rule is evaluated. The keyword set is
+# the minimal shape of raw provider/runtime error lines we have actually
+# seen in stall captures; extend only when a new false-negative is
+# reproduced.
+RAW_ERROR_PREFIXES_RE = re.compile(
+    r"^(error|err|warning|fatal|panic|exception)\b\s*[:\s]",
+    re.IGNORECASE,
+)
+
 
 def looks_like_agent_output(stripped: str) -> bool:
     # Re-enter capture after an [Agent Bridge] nudge as soon as we see either
@@ -220,6 +246,19 @@ def classify(normalized: str) -> tuple[str, str, str]:
     # output: top-level pane items are separated by blank lines, and any
     # rendering inside one item is the agent narrating. Issue #329 Track D's
     # walk-line-by-line semantics and matched_line_hash dedup are preserved.
+    #
+    # Escape hatch: raw provider/system error lines (`Error: HTTP 429 ...`,
+    # `Fatal: ...`, etc.) that land directly under a glyph head without a
+    # blank separator MUST still classify — otherwise an actually-rate-
+    # limited agent appears idle to bridge-stall. The block-skip is gated
+    # on RAW_ERROR_PREFIXES_RE matched against the *raw* line (with
+    # original leading whitespace) so an indented continuation that quotes
+    # an error inside a tool block (`  Error: HTTP 429 ...` two spaces in)
+    # stays suppressed; only flush-left raw provider output escapes. Diff
+    # bodies (`1 +HTTP/1.1 401 Unauthorized`), tool output continuations
+    # (`└ HTTP/1.1 200 OK` — already glyph-skipped), and flush-left wrap
+    # continuations (`-0)`) do not start with one of the raw-error keywords
+    # and therefore stay suppressed.
     in_agent_block = False
     for raw in normalized.splitlines():
         stripped = raw.strip()
@@ -229,7 +268,7 @@ def classify(normalized: str) -> tuple[str, str, str]:
         if stripped.startswith(AGENT_GLYPH_PREFIXES):
             in_agent_block = True
             continue
-        if in_agent_block:
+        if in_agent_block and not RAW_ERROR_PREFIXES_RE.match(raw):
             continue
         haystack = stripped.lower()
         for classification, patterns in PATTERN_GROUPS:

--- a/bridge-stall.py
+++ b/bridge-stall.py
@@ -113,10 +113,18 @@ IGNORED_LINES = {
     "The current task appears stalled. Check the current state, summarize what is blocking progress, and continue if work can proceed.",
 }
 
-# Claude Code UI glyphs used to mark agent-authored output lines (prompt
-# carets, tool-call markers, status pips, etc.). Any line beginning with
-# one of these is the agent narrating — never raw provider error output.
-AGENT_GLYPH_PREFIXES = ("❯", ">", "›", "⏺", "⎿", "✢", "✻", "✱", "ℹ", "✓", "✗")
+# Agent-authored output glyphs. Any line beginning with one of these is the
+# agent narrating — never raw provider error output.
+#   Claude Code: ❯ > › ⏺ ⎿ ✢ ✻ ✱ ℹ ✓ ✗  (prompt caret, tool-call markers,
+#       status pips).
+#   Codex CLI: • │ └  (tool/action bullet, continuation body, continuation
+#       tail). Without codex glyphs here, lines like `└ HTTP/1.1 401
+#       Unauthorized` produced by an intentional smoke test re-fire as
+#       false-positive auth stalls every daemon tick.
+AGENT_GLYPH_PREFIXES = (
+    "❯", ">", "›", "⏺", "⎿", "✢", "✻", "✱", "ℹ", "✓", "✗",
+    "•", "│", "└",
+)
 
 
 def looks_like_agent_output(stripped: str) -> bool:
@@ -191,25 +199,35 @@ def classify(normalized: str) -> tuple[str, str, str]:
     # the agent narrating a previous error (e.g. "⏺ inbox empty, no 429
     # reoccurrence"). Without this, agent replies referencing past errors
     # become a self-sustaining stall loop.
-    candidate_lines: list[str] = []
+    #
+    # Block-aware extension: codex renders tool/diff output as a glyph-prefixed
+    # head line followed by indented continuation lines that carry no glyph
+    # (wrapped diff bodies, multi-line tool stdout). Glyph-only filtering let
+    # those wrapped lines reach classify and match e.g. "401 Unauthorized"
+    # quoted from a smoke test. Once we enter an agent block on a glyph line,
+    # skip subsequent non-empty lines whose RAW text starts with whitespace;
+    # exit the block on a blank line or the next non-indented, non-glyph line
+    # (which is itself eligible for matching). Issue #329 Track D's
+    # walk-line-by-line semantics are preserved so matched_line_hash keeps its
+    # dedup behavior.
+    in_agent_block = False
     for raw in normalized.splitlines():
         stripped = raw.strip()
-        if not stripped or stripped.startswith(AGENT_GLYPH_PREFIXES):
+        if not stripped:
+            in_agent_block = False
             continue
-        candidate_lines.append(stripped)
-    if not candidate_lines:
-        return "", "", ""
-    # Issue #329 Track D: walk lines individually so the classifier can return
-    # the actual matched line. Previously classify() searched the joined
-    # haystack and only knew which (group, pattern) fired; the daemon dedup
-    # therefore had to fall back on excerpt_hash, which churned every loop
-    # whenever any other text moved through the pane.
-    for line in candidate_lines:
-        haystack = line.lower()
+        if stripped.startswith(AGENT_GLYPH_PREFIXES):
+            in_agent_block = True
+            continue
+        if in_agent_block:
+            if raw[:1].isspace():
+                continue
+            in_agent_block = False
+        haystack = stripped.lower()
         for classification, patterns in PATTERN_GROUPS:
             for pattern in patterns:
                 if re.search(pattern, haystack, flags=re.IGNORECASE):
-                    return classification, pattern, _normalize_matched_line(line)
+                    return classification, pattern, _normalize_matched_line(stripped)
     return "", "", ""
 
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -951,6 +951,54 @@ run_stall_classify_case "CJK prose discussing access -> silent" \
   "" \
   $'승인 안 된 액세스를 묘님이 검토 중\n'
 
+log "stall-detector codex glyph in-block raw-error escape (PR #965 fixer)"
+# PR #965 originally skipped every line inside an agent-glyph block until
+# the next blank line, to suppress false-positives from codex wrap
+# continuations (`-0)`) and diff bodies (`1 +HTTP/1.1 401 Unauthorized`).
+# That swallowed real raw provider errors landing directly under a glyph
+# head without a blank — e.g. `• Running smoke\nError: HTTP 429 ...`
+# would classify as silent, hiding an actually-rate-limited agent from
+# bridge-stall. The follow-up gates the in-block skip on
+# RAW_ERROR_PREFIXES_RE so lines starting with `Error:` / `Fatal:` /
+# `Warning:` / `Panic:` / `Exception:` break out and still classify.
+# Verify both the recovered false-negative cases AND the original
+# false-positive guards.
+run_stall_classify_case "glyph + Error: HTTP 429 (no blank) -> rate_limit" \
+  "rate_limit" \
+  $'• Running smoke\nError: HTTP 429 too many requests\n'
+run_stall_classify_case "glyph + blank + Error: HTTP 429 -> rate_limit" \
+  "rate_limit" \
+  $'• Running smoke\n\nError: HTTP 429 too many requests\n'
+run_stall_classify_case "glyph + Fatal: connection reset -> network" \
+  "network" \
+  $'• Running smoke\nFatal: connection reset by peer\n'
+# Negative regressions: the original false-positive set PR #965 was
+# protecting against must remain silent.
+run_stall_classify_case "glyph + box-drawing tail HTTP 200 -> silent" \
+  "" \
+  $'• Running smoke\n└ Processing request 1 of 12\n└ HTTP/1.1 200 OK\n'
+run_stall_classify_case "glyph + box-drawing tail HTTP 401 (smoke transcript) -> silent" \
+  "" \
+  $'• Running smoke\n└ HTTP/1.1 401 Unauthorized\n'
+run_stall_classify_case "glyph + flush-left wrap continuation -> silent" \
+  "" \
+  $'• Added /very/long/path/to/file.md (+34\n-0)\n1 +HTTP/1.1 401 Unauthorized\n'
+run_stall_classify_case "glyph + tool-output error continuation -> silent" \
+  "" \
+  $'• Tool call\n└ tool: error: file not found\n'
+# Indented continuation quoting an error inside a tool block must stay
+# silent: the raw-error escape hatch is anchored to flush-left raw lines
+# only. Any leading whitespace means it is a tool/diff continuation, not
+# a fresh provider error stream.
+run_stall_classify_case "glyph + indented Error: continuation -> silent" \
+  "" \
+  $'• Running smoke\n  Error: HTTP 429 too many requests\n'
+# Block reset across consecutive glyph blocks: after a blank line, a
+# fresh raw error must still classify (in_agent_block is reset).
+run_stall_classify_case "two glyph blocks separated by blank + trailing error -> rate_limit" \
+  "rate_limit" \
+  $'• Glyph A\n• Glyph B\n\nError: HTTP 429 rate limit exceeded\n'
+
 log "stall-detector matched_line_hash dedup (#329 Track D)"
 # Track D fallback: even if a future false-positive slips past the narrowed
 # regex, dedup on the matched line itself (not the shifting excerpt window)


### PR DESCRIPTION
## Summary

Fixes a false-positive `[STALL/AUTH]` classification class that re-fires every ~10–15 min against any codex session whose scrollback contains tool output quoting `401 Unauthorized` (or other auth-pattern text). Observed against `patch-dev` 20+ times in a single session.

`bridge-stall.py`'s issue #264 agent-glyph filter only knew about Claude Code glyphs (`❯ > › ⏺ ⎿ ✢ ✻ ✱ ℹ ✓ ✗`). Codex renders tool/diff/action output with a different set (`•` head bullet, `│` continuation body, `└` continuation tail), so codex tool-output lines passed straight through to `classify()`.

Adding the glyphs alone was insufficient because codex wraps long header lines too — `• Added /long/path.md (+34\n-0)\n     1 +<diff body>` puts a flush-left `-0)` continuation that looked like a block exit, leaving the indented diff body eligible to match.

Two commits:
1. `938bcda` — expand `AGENT_GLYPH_PREFIXES` with `•`, `│`, `└`; introduce indentation-aware block skip in `classify()`.
2. `b8cf651` — broaden the rule: inside an agent block, skip any non-empty line regardless of indentation; exit only on blank line. Matches codex's actual top-level-item-separated-by-blank-line structure.

Issue #329 Track D's per-line walk and `matched_line_hash` semantics are preserved. Bare top-level provider errors with no preceding glyph line still classify normally.

## Test plan

Local fixture harness (`/tmp/run-stall-fixtures.sh`, 11 cases, all PASS):
- [x] Single-line codex glyph cases (`└ HTTP/1.1 401 Unauthorized`, `│ token expired`, `• HTTP/1.1 401 Unauthorized`) → `""`
- [x] `[Agent Bridge] nudge` followed by codex tail → `""`
- [x] Codex wrapped diff block with `401 Unauthorized` in the diff body → `""`
- [x] Codex `• Added <path> (+34\n-0)\n     1 +…401 Unauthorized…` wrap-stat shape → `""`
- [x] Live `patch-dev` tmux capture (263 lines from the actual false-positive scrollback) → `""`
- [x] Bare top-level `Error: 401 Unauthorized` (no glyph, no indent) → still `auth`
- [x] Claude `⏺ … 401 unauthorized …` narration → still skipped (existing #264 behavior)
- [x] Bare `HTTP/1.1 429 Too Many Requests` → still `rate_limit`
- [x] Bare `request timed out while reading upstream` → still `network`

Pair-reviewed via the queue (patch + patch-dev): r1 plan → `needs-more` → r2 plan → `plan-ok` → r1 review → `implement-ok` → post-merge follow-up surfaced flush-left wrap edge → r2 review → `implement-ok`. Verification commands the reviewer ran are documented in `~/.agent-bridge/shared/task-3043-codex-glyph-stall-code-review.md` and `~/.agent-bridge/shared/task-3057-codex-stall-block-skip-r2-review.md`.

## Residual

- Fixture harness lives under `/tmp` for this PR. Should be promoted into tracked repo smoke coverage as a follow-up so future regressions trip CI automatically.
- No VERSION / CHANGELOG bump per the operator-cued release policy (2026-05-15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)