### PR TITLE
fix(smoke): update admin-scalar assertion to match writer's quoted form

### DIFF
--- a/scripts/smoke/upgrade-source-preservation.sh
+++ b/scripts/smoke/upgrade-source-preservation.sh
@@ -114,7 +114,7 @@ assert_explicit_setup_admin_writes_scalar() {
   # scalar post-#4769. Confirm the recovery recipe (reclassify → setup
   # admin) lands the scalar exactly once and flips the admin flag.
   BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" setup admin patch >/dev/null
-  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" "BRIDGE_ADMIN_AGENT_ID=patch" \
+  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" 'BRIDGE_ADMIN_AGENT_ID="patch"' \
     "explicit setup admin persists admin scalar"
   smoke_assert_eq "yes" "$(agent_admin_flag patch)" \
     "explicit setup admin flips admin flag"


### PR DESCRIPTION
## Summary

Unblocks the `unit/static smoke` CI gate that has been red on every PR since the writer-side quoting landed.

## Root cause

- `bridge_setup_write_local_scalar` in `bridge-setup.sh:251` writes the admin scalar as `BRIDGE_ADMIN_AGENT_ID=\"patch\"` (key=\"value\" form).
- `scripts/smoke/upgrade-source-preservation.sh:117` was asserting the pre-writer unquoted shape `BRIDGE_ADMIN_AGENT_ID=patch` via `smoke_assert_contains` (substring match).
- Substring match no longer hits — the on-disk roster contains `BRIDGE_ADMIN_AGENT_ID=\"patch\"`, so `BRIDGE_ADMIN_AGENT_ID=patch` (without the trailing `\"p`) isn't a substring of it.

## Fix

One-line assertion update from `BRIDGE_ADMIN_AGENT_ID=patch` → `BRIDGE_ADMIN_AGENT_ID=\"patch\"`. The writer's quoted form is the intended shape (future-proofs values with spaces); the assertion was just stale.

## Why fix the assertion, not the writer

The quoted form is the writer's deliberate output (defensive against value-containing-space cases). Other smoke files that touch this var:

- `upgrade-source-preservation.sh:106` / `:156` — use `smoke_assert_not_contains \"BRIDGE_ADMIN_AGENT_ID=\"` (substring match), so quoted/unquoted both correctly satisfy 'not present'.
- All other sites just env-var-assign for invocation, not parse the roster.

So this one assertion is the only stale check.

## Test plan

- [x] `bash -n scripts/smoke/upgrade-source-preservation.sh` — PASS
- [x] `shellcheck scripts/smoke/upgrade-source-preservation.sh` — PASS
- [x] Local repro before fix: assertion fails on `expected output to contain 'BRIDGE_ADMIN_AGENT_ID=patch', got: ...BRIDGE_ADMIN_AGENT_ID=\"patch\"...`
- [x] Local rerun with fix: assertion passes
- [ ] CI green on this PR (will verify after push)

Blocks: PR #966 (release/v0.14.5-beta prerelease) cannot merge until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)