### PR TITLE
fix(smoke): admin-pair dry-run probe plants codex/claude shim so CI passes

### DIFF
--- a/scripts/smoke/admin-pair-no-auto-backfill.sh
+++ b/scripts/smoke/admin-pair-no-auto-backfill.sh
@@ -206,10 +206,15 @@ admin_pair_runtime_dry_run_text() {
   local out=""
   local budget="${BRIDGE_SMOKE_INIT_TIMEOUT:-45}"
   # bridge-init.sh accepts only `claude` or `codex` as --engine values.
-  # `codex` is on PATH in the supported smoke-test environments (the
-  # operator's macOS dev box, the Ubuntu 24.04 CI host, the Linux
-  # production server). The dry-run path never invokes the engine
-  # binary; it just gates with `command -v <engine>`.
+  # The dry-run path never invokes the engine binary, but bridge-init.sh
+  # still gates with `bridge_init_require_command <engine>` early in the
+  # flow (so a real init can fail loudly on misconfiguration). The CI
+  # runner does not have `codex` on PATH (only tmux + shellcheck are
+  # apt-installed by .github/workflows/ci.yml), and `claude` is also
+  # absent — both engines fail the same probe. To keep the smoke
+  # self-contained without imposing CI image obligations, we plant a
+  # no-op `codex` shim in a tmp dir and prepend it to PATH. The shim
+  # is exit-0 only; bridge-init.sh dry-run never invokes it for real.
   #
   # Text output (NOT --json) is used here because bridge-init.sh's
   # `bridge_init_emit_json` helper (line 57) uses `python3 - … <<'PY'`
@@ -221,15 +226,21 @@ admin_pair_runtime_dry_run_text() {
   # The `timeout` wrapper bounds the call so a host that nevertheless
   # hits a different heredoc deadlock degrades to "no output" rather
   # than blocking the smoke indefinitely.
+  local shim_dir
+  shim_dir="$(mktemp -d "${TMPDIR:-/tmp}/agent-bridge-${label}-shim.XXXXXX")"
+  printf '#!/bin/sh\nexit 0\n' >"$shim_dir/codex"
+  printf '#!/bin/sh\nexit 0\n' >"$shim_dir/claude"
+  chmod +x "$shim_dir/codex" "$shim_dir/claude"
   out="$(timeout --kill-after=5s "${budget}s" \
         env -u BRIDGE_ADMIN_AGENT_ID \
             BRIDGE_HOME="$bridge_home" \
+            PATH="$shim_dir:$PATH" \
             bash "$SMOKE_REPO_ROOT/bridge-init.sh" \
               --skip-channel-setup --skip-validate --skip-send-test \
               --dry-run \
               --engine codex \
               "$@" 2>/dev/null)" || true
-  rm -rf -- "$(dirname "$bridge_home")"
+  rm -rf -- "$(dirname "$bridge_home")" "$shim_dir"
   printf '%s' "$out"
 }
 

--- a/scripts/smoke/upgrade-source-preservation.sh
+++ b/scripts/smoke/upgrade-source-preservation.sh
@@ -114,7 +114,7 @@ assert_explicit_setup_admin_writes_scalar() {
   # scalar post-#4769. Confirm the recovery recipe (reclassify → setup
   # admin) lands the scalar exactly once and flips the admin flag.
   BRIDGE_HOME="$BRIDGE_HOME" "$SMOKE_REPO_ROOT/agent-bridge" setup admin patch >/dev/null
-  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" "BRIDGE_ADMIN_AGENT_ID=patch" \
+  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" 'BRIDGE_ADMIN_AGENT_ID="patch"' \
     "explicit setup admin persists admin scalar"
   smoke_assert_eq "yes" "$(agent_admin_flag patch)" \
     "explicit setup admin flips admin flag"


### PR DESCRIPTION
## Summary

Unblocks the `unit/static smoke` CI gate that has been **red on main for 2+ days** (since 2026-05-17 13:01 UTC, last green = `5307581`). Two compounding regressions, both in `scripts/smoke/`:

1. `upgrade-source-preservation.sh:117` asserted unquoted `BRIDGE_ADMIN_AGENT_ID=patch` but the writer now emits quoted `BRIDGE_ADMIN_AGENT_ID="patch"`.
2. `admin-pair-no-auto-backfill.sh:C1` calls `bridge-init.sh --dry-run` which early-gates with `bridge_init_require_command codex` — but neither `codex` nor `claude` is installed on the GH Actions Ubuntu runner.

Originally this was going to ship as two PRs (#967 for fix-1, #969 for fix-2). Bundling here because either fix alone leaves the smoke red — both must land together to make CI green. **Closes PR #967 as redundant.**

## Root causes

### Fix 1 — quoted writer vs unquoted assertion

`bridge_setup_write_local_scalar` in `bridge-setup.sh:251` emits `BRIDGE_ADMIN_AGENT_ID="patch"` (key="value" form, future-proof against values with spaces). The pre-writer smoke assertion at line 117 did `smoke_assert_contains "..." "BRIDGE_ADMIN_AGENT_ID=patch"` (substring) which no longer matches the quoted form.

### Fix 2 — codex binary missing on CI runner

`bridge-init.sh` early-gates with `bridge_init_require_command "$engine"` so a real init fails loudly on misconfiguration. The GH Actions Ubuntu runner has **no `codex` (or `claude`) binary on PATH** — `.github/workflows/ci.yml` only `apt-install`s tmux + shellcheck. The smoke's prior comment claimed `codex` was available on the CI host; that was inaccurate.

CI Linux `bash -x` trace from diagnostic PR #968 (closed) confirmed it:

```
+ bridge_init_require_command codex
+ command -v codex
+ bridge_die '필수 명령을 찾지 못했습니다: codex'
+ exit 1
```

## Fixes

### Fix 1 — `scripts/smoke/upgrade-source-preservation.sh:117`

```diff
-  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" "BRIDGE_ADMIN_AGENT_ID=patch" \
+  smoke_assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" 'BRIDGE_ADMIN_AGENT_ID="patch"' \
```

### Fix 2 — `scripts/smoke/admin-pair-no-auto-backfill.sh: admin_pair_runtime_dry_run_text`

mktemp a shim dir, plant exit-0 `codex` + `claude` shims, prepend `$shim_dir:$PATH` for the timeout-wrapped `bridge-init.sh` invocation only. bridge-init.sh sees the engine on PATH, passes `bridge_init_require_command` gate, prints the dashboard, smoke parses `admin_agent: patch` correctly.

- **No production code change** (bridge-init.sh, bridge-setup.sh untouched)
- **No CI image change** (no new apt-install)
- **Smoke is self-contained** on hosts without either engine installed
- Operator + macOS dev hosts (which have real codex on PATH) are unaffected — the shim is shadowed when a real binary exists; dry-run only runs `command -v`, never executes

## Test plan

- [x] `bash -n` + `shellcheck` PASS on both touched smoke files
- [x] Local repro on macOS: `admin-pair-no-auto-backfill.sh` C1-C5 all PASS, `upgrade-source-preservation.sh` all PASS
- [x] CI trigger pending — expect `unit/static smoke` to flip green

## Unblock chain

This PR (green) → PR #966 (release/v0.14.5-beta prerelease) can rebase + go green → tag `v0.14.5-beta` + GitHub Pre-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)