### PR TITLE
Fix picker-sweep rate-limit token rotation

### DIFF
--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -40,7 +40,7 @@
 # See OPERATIONS.md "picker-sweep" for the bridge-native cron variant and the
 # trade-offs (self-recursion risk, future #663 shell-payload mode).
 #
-# Test seams: this script reads four wrapper-function names from the
+# Test seams: this script reads wrapper-function names from the
 # environment so the smoke can replace tmux/queue calls with fixtures without
 # patching the script. See `_psw_run_*` calls below.
 
@@ -156,6 +156,7 @@ fi
 # ---------------------------------------------------------------------------
 
 _PICKER_OPTION_LINE_RE='^[[:space:]]*(❯[[:space:]]*)?[0-9]+\.[[:space:]]+(Stop and wait for limit to reset|Switch to extra usage|Switch to Team plan|Resume from summary \(recommended\)|Resume full session as-is|I am using this for local development)[[:space:]]*$'
+_PICKER_RATE_LIMIT_OPTION_RE='^[[:space:]]*(❯[[:space:]]*)?[0-9]+\.[[:space:]]+Stop and wait for limit to reset[[:space:]]*$'
 _PICKER_TAIL_RE='^[[:space:]]*Enter to confirm · Esc to cancel[[:space:]]*$'
 
 # Codex picker shape — fundamentally different from Claude's. Codex emits
@@ -240,24 +241,80 @@ _psw_default_create_task() {
         --body "$body" 2>&1
 }
 
+_psw_rate_limit_rotation_state_file() {
+    printf '%s' "${BRIDGE_PICKER_SWEEP_RATE_LIMIT_ROTATE_STATE_FILE:-$BRIDGE_HOME/state/picker-sweep/rate-limit-rotation.env}"
+}
+
+_psw_rate_limit_rotation_due() {
+    local cooldown="${BRIDGE_PICKER_SWEEP_RATE_LIMIT_ROTATE_COOLDOWN_SECONDS:-1800}"
+    local file="" next_ts="" now=0
+
+    [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=1800
+    (( cooldown > 0 )) || return 0
+
+    file="$(_psw_rate_limit_rotation_state_file)"
+    [[ -f "$file" ]] || return 0
+    next_ts="$(awk -F= '$1 == "NEXT_TS" { print $2; exit }' "$file" 2>/dev/null || true)"
+    [[ "$next_ts" =~ ^[0-9]+$ ]] || return 0
+    now="$(date +%s)"
+    (( now >= next_ts ))
+}
+
+_psw_note_rate_limit_rotation_attempt() {
+    local cooldown="${BRIDGE_PICKER_SWEEP_RATE_LIMIT_ROTATE_COOLDOWN_SECONDS:-1800}"
+    local file="" now=0 next_ts=0
+
+    [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=1800
+    (( cooldown > 0 )) || return 0
+
+    file="$(_psw_rate_limit_rotation_state_file)"
+    mkdir -p "$(dirname "$file")" 2>/dev/null || return 0
+    now="$(date +%s)"
+    next_ts=$(( now + cooldown ))
+    {
+        printf 'UPDATED_TS=%s\n' "$now"
+        printf 'NEXT_TS=%s\n' "$next_ts"
+    } >"$file" 2>/dev/null || true
+}
+
+_psw_compact_one_line() {
+    tr '\n' ' ' | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//' | cut -c1-300
+}
+
+_psw_default_rotate_claude_token() {
+    local agent="$1"
+    local scope="${BRIDGE_PICKER_SWEEP_TOKEN_ROTATE_AGENTS:-${BRIDGE_CLAUDE_TOKEN_SYNC_AGENTS:-static}}"
+
+    bash "$BRIDGE_HOME/bridge-auth.sh" claude-token rotate \
+        --if-auto-enabled \
+        --sync \
+        --agents "$scope" \
+        --reason "picker-sweep-rate-limit:${agent}" \
+        --json
+}
+
 # Resolve seam overrides (smoke supplies executable paths / function names).
 _PSW_LIST_SESSIONS_FN="${BRIDGE_PICKER_SWEEP_LIST_SESSIONS_FN:-_psw_default_list_sessions}"
 _PSW_CAPTURE_PANE_FN="${BRIDGE_PICKER_SWEEP_CAPTURE_PANE_FN:-_psw_default_capture_pane}"
 _PSW_SEND_ENTER_FN="${BRIDGE_PICKER_SWEEP_SEND_ENTER_FN:-_psw_default_send_enter}"
 _PSW_SEND_OPTION_FN="${BRIDGE_PICKER_SWEEP_SEND_OPTION_FN:-_psw_default_send_option}"
 _PSW_CREATE_TASK_FN="${BRIDGE_PICKER_SWEEP_CREATE_TASK_FN:-_psw_default_create_task}"
+_PSW_ROTATE_CLAUDE_TOKEN_FN="${BRIDGE_PICKER_SWEEP_ROTATE_CLAUDE_TOKEN_FN:-_psw_default_rotate_claude_token}"
 
 _psw_list_sessions() { "$_PSW_LIST_SESSIONS_FN"; }
 _psw_capture_pane()  { "$_PSW_CAPTURE_PANE_FN"  "$@"; }
 _psw_send_enter()    { "$_PSW_SEND_ENTER_FN"    "$@"; }
 _psw_send_option()   { "$_PSW_SEND_OPTION_FN"   "$@"; }
 _psw_create_task()   { "$_PSW_CREATE_TASK_FN"   "$@"; }
+_psw_rotate_claude_token() { "$_PSW_ROTATE_CLAUDE_TOKEN_FN" "$@"; }
 
 # ---------------------------------------------------------------------------
 # Sweep.
 # ---------------------------------------------------------------------------
 
 unstuck_agents=()
+rate_limit_rotations=()
+rate_limit_rotation_attempted=0
 
 while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
@@ -268,6 +325,7 @@ while IFS= read -r agent; do
     cap="$(_psw_capture_pane "$agent" || true)"
     matched_pattern=""
     explicit_option=""   # #948 — when set, send "N + Enter" instead of bare Enter
+    rate_limit_picker=0
 
     # r4 (codex PR #949 r3) + r5 (codex PR #949 r4) — scope explicit-option
     # detection to the ACTIVE picker block ONLY. capture-pane returns ~25
@@ -340,6 +398,9 @@ while IFS= read -r agent; do
         matched_pattern="auto-mode warning"
         explicit_option="1"
     elif printf '%s\n' "$cap" | grep -qE "$_PICKER_OPTION_LINE_RE"; then
+        if printf '%s\n' "$cap" | grep -qE "$_PICKER_RATE_LIMIT_OPTION_RE"; then
+            rate_limit_picker=1
+        fi
         if printf '%s\n' "$cap" | grep -qE "$_PICKER_TAIL_RE"; then
             matched_pattern="picker option line + tail"
         else
@@ -370,6 +431,28 @@ while IFS= read -r agent; do
             fi
             unstuck_agents+=("$agent:$matched_pattern (sent Enter)")
         fi
+
+        if [[ "$rate_limit_picker" -eq 1 ]]; then
+            if [[ "${BRIDGE_PICKER_SWEEP_RATE_LIMIT_ROTATE_ENABLED:-1}" != "1" ]]; then
+                _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate disabled by BRIDGE_PICKER_SWEEP_RATE_LIMIT_ROTATE_ENABLED"
+            elif [[ "$rate_limit_rotation_attempted" -ne 0 ]]; then
+                _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate skipped (already attempted this sweep)"
+            elif ! _psw_rate_limit_rotation_due; then
+                _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate skipped (cooldown active)"
+            else
+                rate_limit_rotation_attempted=1
+                rotate_output="$(_psw_rotate_claude_token "$agent" 2>&1)"
+                rotate_rc=$?
+                _psw_note_rate_limit_rotation_attempt
+                rotate_summary="$(printf '%s' "$rotate_output" | _psw_compact_one_line)"
+                if [[ "$rotate_rc" -eq 0 ]]; then
+                    _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate result: ${rotate_summary:-ok}"
+                else
+                    _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate failed rc=$rotate_rc: ${rotate_summary:-no output}"
+                fi
+                rate_limit_rotations+=("$agent:rc=$rotate_rc ${rotate_summary:-no output}")
+            fi
+        fi
     fi
 done < <(_psw_list_sessions)
 
@@ -397,6 +480,9 @@ task_body="Claude Code interactive picker auto-unstick result:
 
 $joined
 
+Rate-limit token rotation attempts:
+$(if (( ${#rate_limit_rotations[@]} > 0 )); then printf '%s\n' "${rate_limit_rotations[@]}"; else printf 'none\n'; fi)
+
 Each entry shows the agent, picker pattern, and the actual action taken
 (\"sent Enter\" for default-option pickers, \"sent option N\" for explicit
 picks). The explicit-option path is used for safety-sensitive prompts
@@ -408,6 +494,12 @@ Auto mode \"make default\").
 For default-Enter pickers: rate-limit pickers default to \"Stop and wait
 for limit to reset\" (safest); resume-from-summary defaults to
 \"Resume from summary (recommended)\".
+
+When a rate-limit picker is detected, picker-sweep also attempts one
+claude-token auto-rotation per sweep if registry auto-rotate is enabled.
+This is intentionally independent from the optional claude-hud usage cache,
+so a missing HUD/statusline cannot silently strand agents on an exhausted
+Claude token.
 
 This cron is best-effort. If the same agent shows up across multiple sweeps,
 investigate manually - repeated picker hits usually indicate a deeper

--- a/scripts/picker-sweep.sh
+++ b/scripts/picker-sweep.sh
@@ -281,6 +281,119 @@ _psw_compact_one_line() {
     tr '\n' ' ' | sed 's/[[:space:]][[:space:]]*/ /g; s/^ //; s/ $//' | cut -c1-300
 }
 
+# ---------------------------------------------------------------------------
+# Cross-process rotation lock — codex PR #971 r1 BLOCKING fix.
+#
+# `_psw_rate_limit_rotation_due` reads the cooldown state file and
+# `_psw_rotate_claude_token` calls `bridge-auth.sh claude-token rotate`
+# without any inter-process serialisation. Two cron-driven picker-sweep
+# runs that co-fire (the */10 picker-sweep cron + a manual `bash
+# scripts/picker-sweep.sh`, two separate cron crontab entries, an OS cron
+# tick that overruns its predecessor by a few seconds, etc.) can both
+# pass the due check, both rotate, and burn two Claude tokens for one
+# rate-limit event.
+#
+# We guard the (due-check → rotate → note-attempt) critical section with
+# a mkdir-as-lock at $BRIDGE_HOME/state/picker-sweep/rotation.lock. mkdir
+# is the only POSIX-portable atomic single-step "create directory if it
+# does not already exist" primitive — flock(1) is unavailable on macOS
+# bash without coreutils, and a touch-based lock is not atomic.
+#
+# Stale-lock reclaim: if mkdir fails, we read `owner.pid` from the lock
+# dir. If the PID is no longer alive AND the lock dir mtime is older
+# than BRIDGE_PICKER_SWEEP_ROTATION_LOCK_STALE_SECONDS (default 300s),
+# we log a warning and reclaim. We never reclaim silently — a stale
+# lock is a real signal (previous sweep crashed before releasing) and
+# the warning is the only audit trail.
+#
+# In-process dedup (rate_limit_rotation_attempted=0 below) still handles
+# the multi-agent case within ONE sweep. The cross-process lock handles
+# concurrent sweeps. The two layers are complementary, not redundant.
+# ---------------------------------------------------------------------------
+
+_psw_rotation_lock_dir() {
+    printf '%s' "${BRIDGE_PICKER_SWEEP_ROTATION_LOCK_DIR:-$BRIDGE_HOME/state/picker-sweep/rotation.lock}"
+}
+
+# Stat-based mtime epoch; portable across macOS and Linux. Returns 0
+# when the path doesn't exist or stat fails (caller should treat zero
+# as "newly created, ignore staleness").
+_psw_rotation_lock_mtime() {
+    local path="$1" mtime=0
+    if [[ -e "$path" ]]; then
+        mtime="$(stat -f %m "$path" 2>/dev/null || stat -c %Y "$path" 2>/dev/null || printf '0')"
+    fi
+    [[ "$mtime" =~ ^[0-9]+$ ]] || mtime=0
+    printf '%s' "$mtime"
+}
+
+# Returns 0 if PID is alive, 1 otherwise. `kill -0` is POSIX and does
+# not actually deliver a signal — it just checks signal-deliverability.
+_psw_pid_alive() {
+    local pid="$1"
+    [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null
+}
+
+_psw_acquire_rotation_lock() {
+    local lock_dir="" stale_secs="${BRIDGE_PICKER_SWEEP_ROTATION_LOCK_STALE_SECONDS:-300}"
+    local owner_pid="" mtime=0 now=0 age=0
+    lock_dir="$(_psw_rotation_lock_dir)"
+
+    [[ "$stale_secs" =~ ^[0-9]+$ ]] || stale_secs=300
+
+    mkdir -p "$(dirname "$lock_dir")" 2>/dev/null || return 1
+
+    if mkdir "$lock_dir" 2>/dev/null; then
+        printf '%s\n' "$$" >"$lock_dir/owner.pid" 2>/dev/null || true
+        return 0
+    fi
+
+    # mkdir failed — lock is held. Decide between honouring the holder
+    # and reclaiming a stale lock.
+    owner_pid="$(cat "$lock_dir/owner.pid" 2>/dev/null || true)"
+    mtime="$(_psw_rotation_lock_mtime "$lock_dir")"
+    now="$(date +%s)"
+    age=$(( now - mtime ))
+
+    if [[ -n "$owner_pid" ]] && _psw_pid_alive "$owner_pid"; then
+        # Live holder. Defer to it.
+        return 1
+    fi
+
+    if (( age < stale_secs )); then
+        # Owner PID is dead (or unreadable) but the lock is recent —
+        # the holder may still be in a window between mkdir and pid
+        # write, or the PID file race. Defer one more cycle.
+        return 1
+    fi
+
+    # Stale. Surface it loudly and reclaim.
+    _psw_log "warn: rotation lock at $lock_dir is stale (owner_pid=${owner_pid:-unknown} age=${age}s threshold=${stale_secs}s) — reclaiming"
+    rm -rf "$lock_dir" 2>/dev/null || true
+    if mkdir "$lock_dir" 2>/dev/null; then
+        printf '%s\n' "$$" >"$lock_dir/owner.pid" 2>/dev/null || true
+        return 0
+    fi
+    # Lost a reclaim race with another process — let them have it.
+    return 1
+}
+
+_psw_release_rotation_lock() {
+    local lock_dir="" current_owner=""
+    lock_dir="$(_psw_rotation_lock_dir)"
+    # Only release a lock we actually own. Defensive against the EXIT
+    # trap firing after a reclaim handed the lock to another sweep
+    # mid-flight (vanishingly rare but worth the cheap guard).
+    if [[ -f "$lock_dir/owner.pid" ]]; then
+        current_owner="$(cat "$lock_dir/owner.pid" 2>/dev/null || true)"
+        if [[ "$current_owner" != "$$" ]]; then
+            return 0
+        fi
+    fi
+    rm -rf "$lock_dir" 2>/dev/null || true
+}
+
 _psw_default_rotate_claude_token() {
     local agent="$1"
     local scope="${BRIDGE_PICKER_SWEEP_TOKEN_ROTATE_AGENTS:-${BRIDGE_CLAUDE_TOKEN_SYNC_AGENTS:-static}}"
@@ -437,20 +550,41 @@ while IFS= read -r agent; do
                 _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate disabled by BRIDGE_PICKER_SWEEP_RATE_LIMIT_ROTATE_ENABLED"
             elif [[ "$rate_limit_rotation_attempted" -ne 0 ]]; then
                 _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate skipped (already attempted this sweep)"
-            elif ! _psw_rate_limit_rotation_due; then
-                _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate skipped (cooldown active)"
             else
-                rate_limit_rotation_attempted=1
-                rotate_output="$(_psw_rotate_claude_token "$agent" 2>&1)"
-                rotate_rc=$?
-                _psw_note_rate_limit_rotation_attempt
-                rotate_summary="$(printf '%s' "$rotate_output" | _psw_compact_one_line)"
-                if [[ "$rotate_rc" -eq 0 ]]; then
-                    _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate result: ${rotate_summary:-ok}"
+                # Acquire the cross-process rotation lock BEFORE checking
+                # cooldown — otherwise two concurrent sweeps would both
+                # observe "due", both pass the check, and both rotate.
+                # Codex PR #971 r1 BLOCKING finding.
+                if ! _psw_acquire_rotation_lock; then
+                    _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate deferred (another sweep holds the rotation lock)"
+                    # Mark attempted so subsequent agents this cycle don't
+                    # also try and re-log the same defer. The lock holder
+                    # will write the cooldown; this sweep should not.
+                    rate_limit_rotation_attempted=1
+                elif ! _psw_rate_limit_rotation_due; then
+                    _psw_release_rotation_lock
+                    _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate skipped (cooldown active)"
+                    rate_limit_rotation_attempted=1
                 else
-                    _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate failed rc=$rotate_rc: ${rotate_summary:-no output}"
+                    # Critical section: due-check passed under the lock,
+                    # rotate, then write the cooldown, then release. The
+                    # EXIT trap ensures the lock is freed even if the
+                    # rotate call traps or the script is killed mid-flight.
+                    trap '_psw_release_rotation_lock' EXIT INT TERM
+                    rate_limit_rotation_attempted=1
+                    rotate_output="$(_psw_rotate_claude_token "$agent" 2>&1)"
+                    rotate_rc=$?
+                    _psw_note_rate_limit_rotation_attempt
+                    _psw_release_rotation_lock
+                    trap - EXIT INT TERM
+                    rotate_summary="$(printf '%s' "$rotate_output" | _psw_compact_one_line)"
+                    if [[ "$rotate_rc" -eq 0 ]]; then
+                        _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate result: ${rotate_summary:-ok}"
+                    else
+                        _psw_log "rate-limit picker on '$agent' — claude-token auto-rotate failed rc=$rotate_rc: ${rotate_summary:-no output}"
+                    fi
+                    rate_limit_rotations+=("$agent:rc=$rotate_rc ${rotate_summary:-no output}")
                 fi
-                rate_limit_rotations+=("$agent:rc=$rotate_rc ${rotate_summary:-no output}")
             fi
         fi
     fi

--- a/scripts/smoke/picker-sweep-concurrent-rotation.sh
+++ b/scripts/smoke/picker-sweep-concurrent-rotation.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+# scripts/smoke/picker-sweep-concurrent-rotation.sh — cross-process
+# rotation-lock regression smoke for picker-sweep (codex PR #971 r1
+# BLOCKING fix).
+#
+# Without the cross-process lock in scripts/picker-sweep.sh, two
+# picker-sweep processes that co-fire against the same BRIDGE_HOME both
+# pass the cooldown due-check (the cooldown state file is only WRITTEN
+# AFTER a successful rotate call) and both invoke `bridge-auth.sh
+# claude-token rotate` — burning two tokens for one rate-limit event.
+#
+# This smoke proves the lock works by:
+#   1. Planting a rate-limit picker on a single agent so each sweep
+#      would naturally try to rotate.
+#   2. Stubbing the rotate seam with a script that records each invocation
+#      to a counter file under flock, then sleeps long enough that two
+#      concurrent sweeps would land inside the critical section without
+#      serialisation.
+#   3. Launching two `bash scripts/picker-sweep.sh` processes in parallel,
+#      waiting for both to complete cleanly, and asserting exactly ONE
+#      rotate-stub invocation.
+#
+# The smoke runs the parallel launch 5 times to reduce the chance that
+# a scheduler quirk hides a race window during the very first run.
+#
+# Bug-detection guarantee: removing the lock (or making
+# _psw_acquire_rotation_lock unconditionally return 0) MUST cause this
+# smoke to fail. See Test 8 manual verification step in the PR brief.
+
+set -euo pipefail
+
+SMOKE_NAME="picker-sweep-concurrent-rotation"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+    smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PICKER_SWEEP="$REPO_ROOT/scripts/picker-sweep.sh"
+[[ -x "$PICKER_SWEEP" ]] || smoke_fail "picker-sweep.sh missing or not executable: $PICKER_SWEEP"
+
+FIXTURE_DIR="$SMOKE_TMP_ROOT/fixtures"
+mkdir -p "$FIXTURE_DIR"
+
+# How many parallel-launch rounds to run. Race detection needs reps;
+# this is the operator-overridable knob if a flake ever surfaces.
+ROUNDS="${BRIDGE_PICKER_SWEEP_CONCURRENT_SMOKE_ROUNDS:-5}"
+[[ "$ROUNDS" =~ ^[1-9][0-9]*$ ]] || ROUNDS=5
+
+# How long the rotate stub sleeps to widen the critical-section race
+# window. 250ms is enough to make two processes' due-check + rotate
+# overlap on any sane scheduler, while keeping the whole smoke under
+# ~5s total. Tunable for slow VMs.
+ROTATE_SLEEP_SECS="${BRIDGE_PICKER_SWEEP_CONCURRENT_SMOKE_SLEEP:-0.25}"
+
+# ---------------------------------------------------------------------------
+# Mock harness. Each sweep gets the SAME mock function names exported
+# from the same MOCK_LIB; we wire seams via env vars, and the rotate
+# stub records calls to a shared file under FIXTURE_DIR (the only
+# inter-process channel).
+# ---------------------------------------------------------------------------
+
+# Files inspected after each round.
+SESSIONS_FILE="$FIXTURE_DIR/sessions"
+PANE_FILE="$FIXTURE_DIR/pane-stuck-agent"
+ROTATE_COUNT_FILE="$FIXTURE_DIR/rotate-count"
+ROTATE_LOG="$FIXTURE_DIR/rotate-calls.log"
+SWEEP_LOG_A="$FIXTURE_DIR/sweep-a.log"
+SWEEP_LOG_B="$FIXTURE_DIR/sweep-b.log"
+
+MOCK_LIB="$FIXTURE_DIR/mock-lib.sh"
+cat >"$MOCK_LIB" <<'MOCK_EOF'
+#!/usr/bin/env bash
+# Test seams for the concurrent-rotation smoke. Sourced by the sweep
+# subprocess shells so they expose the right function names.
+
+mock_list_sessions() {
+    [[ -f "$SESSIONS_FILE" ]] && cat "$SESSIONS_FILE"
+}
+
+mock_capture_pane() {
+    local target="$1"
+    [[ -f "$FIXTURE_DIR/pane-$target" ]] && cat "$FIXTURE_DIR/pane-$target"
+}
+
+mock_send_enter() {
+    # No-op for this smoke; we only care about rotation count.
+    :
+}
+
+mock_send_option() {
+    :
+}
+
+mock_create_task() {
+    # Swallow task creation — irrelevant to the race assertion.
+    :
+}
+
+# Race-window widener: each call sleeps ROTATE_SLEEP_SECS to ensure
+# two concurrent processes' critical sections overlap. Records its
+# own PID + a timestamp so the smoke can confirm both sweeps actually
+# attempted to enter the rotation branch in the no-lock counterfactual.
+#
+# Counter is incremented under a flock-equivalent (mkdir lock) so the
+# count is accurate even if the rotate function was somehow called
+# concurrently — the count assertion is the actual race-detection
+# signal, not just a side effect of fewer calls.
+mock_rotate_claude_token() {
+    local agent="$1" lock_dir="$FIXTURE_DIR/.counter-lock"
+    local count=0
+
+    # Record the entry timestamp BEFORE the sleep so the smoke can see
+    # whether both sweeps actually entered this function.
+    printf '%s pid=%s agent=%s entered\n' "$(date +%s.%N)" "$$" "$agent" >> "$ROTATE_LOG"
+
+    sleep "$ROTATE_SLEEP_SECS"
+
+    # Atomic increment of the counter file under mkdir-lock. We retry
+    # for up to ~2s — if the counter lock is contested longer than
+    # that, something is wrong with the smoke itself.
+    local i
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+        if mkdir "$lock_dir" 2>/dev/null; then
+            count="$(cat "$ROTATE_COUNT_FILE" 2>/dev/null || printf '0')"
+            count=$(( count + 1 ))
+            printf '%s\n' "$count" > "$ROTATE_COUNT_FILE"
+            rm -rf "$lock_dir"
+            break
+        fi
+        sleep 0.05
+    done
+
+    printf '{"status":"rotated","active_token_id":"next-%s","reason":"smoke"}\n' "$count"
+    return 0
+}
+
+export -f mock_list_sessions mock_capture_pane mock_send_enter mock_send_option mock_create_task mock_rotate_claude_token
+MOCK_EOF
+
+# Build the per-sweep wrapper. It sources MOCK_LIB, exports seams,
+# then execs picker-sweep.sh. We use a wrapper file (rather than a
+# string passed to `bash -c`) so each subprocess starts from a clean
+# parent env and so the harness is easy to inspect if the smoke fails.
+SWEEP_WRAPPER="$FIXTURE_DIR/run-sweep.sh"
+cat >"$SWEEP_WRAPPER" <<'WRAP_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Inherit FIXTURE_DIR, ROTATE_COUNT_FILE, ROTATE_LOG, SESSIONS_FILE,
+# ROTATE_SLEEP_SECS, BRIDGE_HOME, etc. from the caller's exported env.
+# shellcheck source=/dev/null
+source "$FIXTURE_DIR/mock-lib.sh"
+
+export BRIDGE_PICKER_SWEEP_LIST_SESSIONS_FN=mock_list_sessions
+export BRIDGE_PICKER_SWEEP_CAPTURE_PANE_FN=mock_capture_pane
+export BRIDGE_PICKER_SWEEP_SEND_ENTER_FN=mock_send_enter
+export BRIDGE_PICKER_SWEEP_SEND_OPTION_FN=mock_send_option
+export BRIDGE_PICKER_SWEEP_CREATE_TASK_FN=mock_create_task
+export BRIDGE_PICKER_SWEEP_ROTATE_CLAUDE_TOKEN_FN=mock_rotate_claude_token
+
+# Pin per-sweep log so we can see which sweep won the lock and which
+# deferred.
+export BRIDGE_PICKER_SWEEP_LOG="$1"
+
+# Force enable; the smoke's BRIDGE_HOME has no host-profile.json so
+# host_profile is unknown — be explicit.
+export BRIDGE_PICKER_SWEEP_ENABLED=1
+export BRIDGE_PICKER_SWEEP_NOTIFY=""  # don't try to enqueue a real task
+
+exec bash "$PICKER_SWEEP"
+WRAP_EOF
+chmod +x "$SWEEP_WRAPPER"
+
+# ---------------------------------------------------------------------------
+# Fixture: one tmux session "stuck-agent" sitting on a rate-limit picker.
+# Both sweeps will see this session and try to rotate.
+# ---------------------------------------------------------------------------
+
+printf '%s\n' "stuck-agent" > "$SESSIONS_FILE"
+cat >"$PANE_FILE" <<'PANE'
+Some prior output
+❯ 1. Stop and wait for limit to reset
+  2. Switch to extra usage
+  3. Switch to Team plan
+Enter to confirm · Esc to cancel
+PANE
+
+export FIXTURE_DIR PICKER_SWEEP SESSIONS_FILE ROTATE_COUNT_FILE ROTATE_LOG ROTATE_SLEEP_SECS
+
+# Disable host_profile dev-skip explicitly (BRIDGE_HOME has no
+# host-profile.json; bridge_host_profile_is_dev returns false, but
+# being explicit guards against future helper changes).
+export BRIDGE_PICKER_SWEEP_ENABLED=1
+
+reset_round() {
+    : > "$ROTATE_COUNT_FILE"
+    printf '0\n' > "$ROTATE_COUNT_FILE"
+    : > "$ROTATE_LOG"
+    : > "$SWEEP_LOG_A"
+    : > "$SWEEP_LOG_B"
+    # Wipe the cooldown state + rotation lock state from any prior
+    # round so each round is a clean "rotation is due" starting point.
+    rm -rf "$BRIDGE_HOME/state/picker-sweep" 2>/dev/null || true
+    mkdir -p "$BRIDGE_HOME/state/picker-sweep"
+}
+
+run_round() {
+    local round_num="$1"
+    reset_round
+
+    smoke_log "round $round_num — launching two concurrent picker-sweep processes"
+
+    local pid_a pid_b rc_a rc_b
+    "$SWEEP_WRAPPER" "$SWEEP_LOG_A" &
+    pid_a=$!
+    "$SWEEP_WRAPPER" "$SWEEP_LOG_B" &
+    pid_b=$!
+
+    # Use set +e around `wait` so we can capture each rc independently
+    # without bailing the smoke (a non-zero sweep exit IS a failure but
+    # the assertion shape should surface what specifically happened).
+    set +e
+    wait "$pid_a"; rc_a=$?
+    wait "$pid_b"; rc_b=$?
+    set -e
+
+    smoke_assert_eq "0" "$rc_a" "round $round_num sweep-a exited cleanly"
+    smoke_assert_eq "0" "$rc_b" "round $round_num sweep-b exited cleanly"
+
+    local count
+    count="$(cat "$ROTATE_COUNT_FILE" 2>/dev/null || printf '0')"
+    smoke_assert_eq "1" "$count" "round $round_num exactly one rotate call (rotation lock serialised the two sweeps)"
+
+    # At least one sweep should have logged a defer message. If neither
+    # did, the two sweeps happened to land non-overlapping in time and
+    # the lock wasn't even contested — that's a valid no-op outcome
+    # (test still proves no double-rotate), so we make this assertion
+    # soft: count it across the run and warn only if NONE of ROUNDS
+    # rounds saw a defer. The hard assertion is the rotate count.
+    if grep -q "deferred (another sweep holds the rotation lock)" "$SWEEP_LOG_A" "$SWEEP_LOG_B" 2>/dev/null; then
+        deferred_round_count=$(( deferred_round_count + 1 ))
+    fi
+}
+
+deferred_round_count=0
+for round in $(seq 1 "$ROUNDS"); do
+    run_round "$round"
+done
+
+if (( deferred_round_count == 0 )); then
+    smoke_log "warn: no round observed a lock-defer log — the smoke proved no double-rotate but did not exercise the contested-lock path. Consider raising BRIDGE_PICKER_SWEEP_CONCURRENT_SMOKE_SLEEP."
+fi
+
+smoke_log "all checks passed ($ROUNDS rounds, deferred in $deferred_round_count round(s))"

--- a/scripts/smoke/picker-sweep.sh
+++ b/scripts/smoke/picker-sweep.sh
@@ -15,6 +15,8 @@
 #      confirmation prompts that codex r1 flagged as a false-positive vector)
 #   5b. Picker option line + tail combined → send Enter (canonical positive)
 #   6. Notify-empty path: BRIDGE_PICKER_SWEEP_NOTIFY="" → send Enter, no task
+#   6b. Rate-limit picker triggers at most one claude-token rotation attempt
+#       per sweep, while non-rate-limit pickers do not rotate.
 #
 # Test seams: this smoke replaces tmux + agent-bridge calls with mock shell
 # functions exported through BRIDGE_PICKER_SWEEP_*_FN env vars. The mocks
@@ -45,6 +47,7 @@ mkdir -p "$FIXTURE_DIR"
 # Captured side effects from the mocks (one line per call).
 SEND_LOG="$FIXTURE_DIR/sent-keys.log"
 TASK_LOG="$FIXTURE_DIR/created-tasks.log"
+ROTATE_LOG="$FIXTURE_DIR/token-rotations.log"
 
 # ---------------------------------------------------------------------------
 # Mock harness — written to a file the test can sourceable as functions.
@@ -94,7 +97,13 @@ mock_create_task() {
         "$recipient" "$title" "$body" >> "$TASK_LOG"
 }
 
-export -f mock_list_sessions mock_capture_pane mock_send_enter mock_send_option mock_create_task
+mock_rotate_claude_token() {
+    local target="$1"
+    printf '%s\n' "$target" >> "$ROTATE_LOG"
+    printf '{"status":"rotated","active_token_id":"next","reason":"smoke"}\n'
+}
+
+export -f mock_list_sessions mock_capture_pane mock_send_enter mock_send_option mock_create_task mock_rotate_claude_token
 MOCK_EOF
 # shellcheck source=/dev/null
 source "$MOCK_LIB"
@@ -105,18 +114,21 @@ export BRIDGE_PICKER_SWEEP_CAPTURE_PANE_FN=mock_capture_pane
 export BRIDGE_PICKER_SWEEP_SEND_ENTER_FN=mock_send_enter
 export BRIDGE_PICKER_SWEEP_SEND_OPTION_FN=mock_send_option
 export BRIDGE_PICKER_SWEEP_CREATE_TASK_FN=mock_create_task
+export BRIDGE_PICKER_SWEEP_ROTATE_CLAUDE_TOKEN_FN=mock_rotate_claude_token
 
 # Pin the log file so the smoke can inspect it.
 export BRIDGE_PICKER_SWEEP_LOG="$FIXTURE_DIR/picker-sweep.log"
 SEND_OPTION_LOG="$FIXTURE_DIR/sent-options.log"
-export FIXTURE_DIR SEND_LOG SEND_OPTION_LOG TASK_LOG
+export FIXTURE_DIR SEND_LOG SEND_OPTION_LOG TASK_LOG ROTATE_LOG
 
 reset_fixture() {
-    rm -f "$FIXTURE_DIR/sessions" "$FIXTURE_DIR"/pane-* "$SEND_LOG" "$SEND_OPTION_LOG" "$TASK_LOG" "$BRIDGE_PICKER_SWEEP_LOG"
+    rm -f "$FIXTURE_DIR/sessions" "$FIXTURE_DIR"/pane-* "$SEND_LOG" "$SEND_OPTION_LOG" "$TASK_LOG" "$ROTATE_LOG" "$BRIDGE_PICKER_SWEEP_LOG"
     : >"$FIXTURE_DIR/sessions"
     : >"$SEND_LOG"
     : >"$SEND_OPTION_LOG"
     : >"$TASK_LOG"
+    : >"$ROTATE_LOG"
+    rm -rf "$BRIDGE_HOME/state/picker-sweep"
 }
 
 run_sweep() {
@@ -222,10 +234,13 @@ PANE
 run_sweep
 smoke_assert_eq "1" "$(count_lines "$SEND_LOG")" "4 one send"
 smoke_assert_contains "$(cat "$SEND_LOG")" "stuck-agent" "4 send target"
+smoke_assert_eq "1" "$(count_lines "$ROTATE_LOG")" "4 one claude-token rotate attempt"
+smoke_assert_contains "$(cat "$ROTATE_LOG")" "stuck-agent" "4 rotate attributed to rate-limit agent"
 smoke_assert_eq "1" "$(grep -c "^---$" "$TASK_LOG" || true)" "4 one task"
 smoke_assert_contains "$(cat "$TASK_LOG")" "recipient=admin" "4 task recipient"
 smoke_assert_contains "$(cat "$TASK_LOG")" "1 agent(s) auto-unstuck" "4 task title"
 smoke_assert_contains "$(cat "$TASK_LOG")" "stuck-agent:picker option line + tail (sent Enter)" "4 task body lists agent + action"
+smoke_assert_contains "$(cat "$TASK_LOG")" "Rate-limit token rotation attempts:" "4 task body includes rotation section"
 
 # ---------------------------------------------------------------------------
 # Test 5 — Tail-only (no option line) must be REJECTED.
@@ -268,6 +283,7 @@ PANE
 run_sweep
 smoke_assert_eq "1" "$(count_lines "$SEND_LOG")" "5b one send (option+tail match)"
 smoke_assert_contains "$(cat "$SEND_LOG")" "full-picker-agent" "5b send target"
+smoke_assert_eq "0" "$(count_lines "$ROTATE_LOG")" "5b resume picker does not rotate claude token"
 
 # ---------------------------------------------------------------------------
 # Test 6 — Notify-empty path.
@@ -285,8 +301,39 @@ PANE
 export BRIDGE_PICKER_SWEEP_NOTIFY=""
 run_sweep
 smoke_assert_eq "1" "$(count_lines "$SEND_LOG")" "6 one send"
+smoke_assert_eq "0" "$(count_lines "$ROTATE_LOG")" "6 resume picker does not rotate claude token"
 smoke_assert_eq "0" "$(count_lines "$TASK_LOG")" "6 no task (notify empty)"
 smoke_assert_contains "$(cat "$BRIDGE_PICKER_SWEEP_LOG")" "BRIDGE_PICKER_SWEEP_NOTIFY unset" "6 notify-skip logged"
+
+# ---------------------------------------------------------------------------
+# Test 6b — Multiple rate-limit pickers in one sweep should produce one token
+# rotation attempt total. Without this, one cron tick could cycle through
+# every configured token if several agents are simultaneously blocked on the
+# same exhausted Claude account.
+# ---------------------------------------------------------------------------
+
+smoke_log "6b. multiple rate-limit pickers → one claude-token rotate attempt"
+reset_fixture
+printf '%s\n%s\n' "limited-a" "limited-b" > "$FIXTURE_DIR/sessions"
+cat >"$FIXTURE_DIR/pane-limited-a" <<'PANE'
+❯ 1. Stop and wait for limit to reset
+  2. Switch to extra usage
+  3. Switch to Team plan
+Enter to confirm · Esc to cancel
+PANE
+cat >"$FIXTURE_DIR/pane-limited-b" <<'PANE'
+❯ 1. Stop and wait for limit to reset
+  2. Switch to extra usage
+  3. Switch to Team plan
+Enter to confirm · Esc to cancel
+PANE
+
+export BRIDGE_PICKER_SWEEP_NOTIFY="admin"
+run_sweep
+smoke_assert_eq "2" "$(count_lines "$SEND_LOG")" "6b both pickers get Enter"
+smoke_assert_eq "1" "$(count_lines "$ROTATE_LOG")" "6b only one rotate attempt per sweep"
+smoke_assert_contains "$(cat "$ROTATE_LOG")" "limited-a" "6b first rate-limit agent triggers rotation"
+smoke_assert_contains "$(cat "$BRIDGE_PICKER_SWEEP_LOG")" "already attempted this sweep" "6b second rate-limit agent skips extra rotation"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- trigger `claude-token rotate --if-auto-enabled --sync` when picker-sweep detects a Claude rate-limit picker
- limit rotation to one attempt per sweep with a cooldown state file so multiple blocked agents cannot cycle through every token in one cron tick
- report rate-limit rotation attempts in the picker-sweep admin task body

## RCA
Auto-rotation currently depends on `bridge-usage` producing Claude snapshots from the optional `claude-hud` usage cache. If an agent is missing HUD/statusLine wiring, Claude Code can show `You've hit your limit` / the rate-limit picker while `rotation_candidates` remains empty. picker-sweep already sees that pane state, but previously only pressed Enter on the safe default and never invoked token rotation.

## Verification
- `bash -n scripts/picker-sweep.sh scripts/smoke/picker-sweep.sh`
- `bash scripts/smoke/picker-sweep.sh`
