### PR TITLE
fix(hud): restore token-rotation usage cache via stdin tap pipeline

### DIFF
--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -1584,6 +1584,135 @@ def _relink_agent_profile_paths(agent_home: Path, home_dir: Path) -> dict[str, l
     return result
 
 
+def _is_hud_status_line(cmd: str) -> bool:
+    """Return True if *cmd* looks like a claude-hud statusLine command."""
+    return "claude-hud" in cmd or "src/index.ts" in cmd or "index.js" in cmd
+
+
+def _hud_tap_present(cmd: str) -> bool:
+    return "hud-usage-tap" in cmd
+
+
+def _patch_hud_command(cmd: str, tap_path: str) -> str:
+    """Insert `python3 <tap_path> |` before the final bun/node exec call.
+
+    Handles both `exec "…bun…"` and `exec "…node…"` patterns.  If no
+    exec-runtime pattern is found, prepend the tap unconditionally so the
+    tap is still active (minor format change is better than silent no-op).
+    """
+    import re
+
+    tap_prefix = f"python3 {shlex.quote(tap_path)} | "
+    pattern = re.compile(r'(exec\s+"[^"]*(?:bun|node)[^"]*")')
+    if pattern.search(cmd):
+        return pattern.sub(rf"{tap_prefix}\1", cmd, count=1)
+    # Fallback: prepend at start of last semicolon-separated clause.
+    parts = cmd.rsplit(";", 1)
+    if len(parts) == 2:
+        return parts[0] + "; " + tap_prefix + parts[1].lstrip()
+    return tap_prefix + cmd
+
+
+def cmd_ensure_hud_usage_tap(args: argparse.Namespace) -> int:
+    """Patch a HUD statusLine command to pipe through hud-usage-tap.py.
+
+    Reads the current statusLine.command from settings.json.  If it is a
+    HUD command but does not yet include the tap, rewrites it in-place to
+    prepend `python3 <bridge_home>/scripts/hud-usage-tap.py |` before the
+    bun/node exec call.  Idempotent: re-running after patching is a no-op.
+    """
+    bridge_home = Path(args.bridge_home).expanduser()
+    tap_path = str(bridge_home / "scripts" / "hud-usage-tap.py")
+    settings_path = resolve_settings_path(args)
+    settings = ensure_settings_root(settings_path)
+
+    sl = settings.get("statusLine")
+    if not isinstance(sl, dict):
+        payload = {
+            "HOOK_SETTINGS_FILE": str(settings_path),
+            "HOOK_STATUS": "no-hud",
+            "HOOK_STOP_HOOK": "",
+            "HOOK_PROMPT_HOOK": "",
+            "HOOK_COMMAND": "",
+        }
+        print_payload(payload, args.format)
+        if args.format != "shell":
+            print("hud_usage_tap: no-hud (statusLine not present or not a dict)")
+        return 1
+
+    cmd = sl.get("command", "")
+    if not isinstance(cmd, str) or not _is_hud_status_line(cmd):
+        payload = {
+            "HOOK_SETTINGS_FILE": str(settings_path),
+            "HOOK_STATUS": "no-hud",
+            "HOOK_STOP_HOOK": "",
+            "HOOK_PROMPT_HOOK": "",
+            "HOOK_COMMAND": cmd,
+        }
+        print_payload(payload, args.format)
+        if args.format != "shell":
+            print("hud_usage_tap: no-hud (statusLine.command is not a HUD command)")
+        return 1
+
+    if _hud_tap_present(cmd):
+        payload = {
+            "HOOK_SETTINGS_FILE": str(settings_path),
+            "HOOK_STATUS": "present",
+            "HOOK_STOP_HOOK": "",
+            "HOOK_PROMPT_HOOK": "",
+            "HOOK_COMMAND": cmd,
+        }
+        print_payload(payload, args.format)
+        if args.format != "shell":
+            print("hud_usage_tap: present")
+        return 0
+
+    patched = _patch_hud_command(cmd, tap_path)
+    settings["statusLine"]["command"] = patched
+    save_json(settings_path, settings)
+
+    payload = {
+        "HOOK_SETTINGS_FILE": str(settings_path),
+        "HOOK_STATUS": "updated",
+        "HOOK_STOP_HOOK": "",
+        "HOOK_PROMPT_HOOK": "",
+        "HOOK_COMMAND": patched,
+    }
+    print_payload(payload, args.format)
+    if args.format != "shell":
+        print("hud_usage_tap: updated")
+    return 0
+
+
+def cmd_status_hud_usage_tap(args: argparse.Namespace) -> int:
+    settings_path = resolve_settings_path(args)
+    settings = ensure_settings_root(settings_path)
+
+    sl = settings.get("statusLine")
+    cmd = (sl or {}).get("command", "") if isinstance(sl, dict) else ""
+    if not cmd or not _is_hud_status_line(cmd):
+        status = "no-hud"
+        rc = 1
+    elif _hud_tap_present(cmd):
+        status = "present"
+        rc = 0
+    else:
+        status = "missing"
+        rc = 1
+
+    payload = {
+        "HOOK_SETTINGS_FILE": str(settings_path),
+        "HOOK_STATUS": status,
+        "HOOK_STOP_HOOK": "",
+        "HOOK_PROMPT_HOOK": "",
+        "HOOK_COMMAND": cmd,
+    }
+    print_payload(payload, args.format)
+    if args.format != "shell":
+        print(f"hud_usage_tap: {status}")
+    return rc
+
+
 def _resolve_agent_home_root(args: argparse.Namespace) -> Path:
     """Return the directory under which `<agent>/` agent homes live."""
     if getattr(args, "agent_home_root", None):
@@ -1852,6 +1981,31 @@ def build_parser() -> argparse.ArgumentParser:
         help="Emit a JSON payload instead of the human-readable summary.",
     )
     relink_profile_parser.set_defaults(handler=cmd_relink_agent_profile_paths)
+
+    hud_tap_ensure_parser = subparsers.add_parser(
+        "ensure-hud-usage-tap",
+        help="Patch a HUD statusLine command to pipe through hud-usage-tap.py.",
+    )
+    hud_tap_ensure_parser.add_argument("--workdir")
+    hud_tap_ensure_parser.add_argument("--settings-file")
+    hud_tap_ensure_parser.add_argument("--bridge-home", required=True)
+    hud_tap_ensure_parser.add_argument("--python-bin", required=True)
+    hud_tap_ensure_parser.add_argument(
+        "--format", choices=("text", "shell"), default="text"
+    )
+    hud_tap_ensure_parser.set_defaults(handler=cmd_ensure_hud_usage_tap)
+
+    hud_tap_status_parser = subparsers.add_parser(
+        "status-hud-usage-tap",
+        help="Report whether the HUD statusLine command includes hud-usage-tap.py.",
+    )
+    hud_tap_status_parser.add_argument("--workdir")
+    hud_tap_status_parser.add_argument("--settings-file")
+    hud_tap_status_parser.add_argument("--bridge-home", required=True)
+    hud_tap_status_parser.add_argument(
+        "--format", choices=("text", "shell"), default="text"
+    )
+    hud_tap_status_parser.set_defaults(handler=cmd_status_hud_usage_tap)
 
     return parser
 

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -764,6 +764,7 @@ while true; do
     bridge_ensure_claude_launch_channel_plugins "$AGENT"
     bridge_run_schedule_dev_channels_accept "$LAUNCH_CMD"
     bridge_run_schedule_idle_marker_and_inbox_bootstrap "$previous_session_id"
+    bridge_ensure_hud_usage_tap "$WORKDIR" "$LAUNCH_CMD" "$AGENT" >/dev/null 2>&1 || true
   fi
 
   log_line "실행: ${local_launch_cmd_display}"

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -764,7 +764,7 @@ while true; do
     bridge_ensure_claude_launch_channel_plugins "$AGENT"
     bridge_run_schedule_dev_channels_accept "$LAUNCH_CMD"
     bridge_run_schedule_idle_marker_and_inbox_bootstrap "$previous_session_id"
-    bridge_ensure_hud_usage_tap "$WORKDIR" "$LAUNCH_CMD" "$AGENT" >/dev/null 2>&1 || true
+    bridge_ensure_hud_usage_tap "$WORK_DIR" "$LAUNCH_CMD" "$AGENT" >/dev/null 2>&1 || true
   fi
 
   log_line "실행: ${local_launch_cmd_display}"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -460,6 +460,11 @@ if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
   if ! bridge_ensure_claude_tool_policy_hooks "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null; then
     bridge_die "Claude tool policy hook 설정에 실패했습니다: $WORK_DIR"
   fi
+  # Ensure HUD stdin tap is in place before the sudo-wrap so that linux-user
+  # isolated agents get their isolated-home settings rendered from controller
+  # context. bridge_ensure_hud_usage_tap is a no-op when no HUD statusLine is
+  # configured or when the tap is already present.
+  bridge_ensure_hud_usage_tap "$WORK_DIR" "$AGENT_LAUNCH_CMD" "$AGENT" >/dev/null 2>&1 || true
   if ! bridge_disable_claude_webhook_channel "$AGENT" "$WORK_DIR" >/dev/null 2>&1; then
     bridge_warn "Claude backlog webhook channel cleanup skipped: $WORK_DIR"
   fi

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -384,6 +384,11 @@ bridge_upgrade_propagate_claude_hooks() {
       # no settings.json wire. Adding it here closes that gap on every
       # subsequent upgrade.
       bridge_ensure_claude_pre_compact_hook "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
+      # Patch HUD statusLine to include hud-usage-tap.py so bridge-usage.py
+      # keeps receiving .usage-cache.json data after claude-hud v0.0.12+
+      # removed background OAuth polling. No-op for agents without a HUD
+      # statusLine or those already patched.
+      bridge_ensure_hud_usage_tap "$workdir" "$launch_cmd" "$agent" >/dev/null 2>&1 || true
     done
   ' -- "$target_root"
 }

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -321,6 +321,23 @@ bridge_ensure_claude_pre_compact_hook() {
   fi
 }
 
+# Patch the HUD statusLine command to pipe through hud-usage-tap.py so
+# bridge-usage.py keeps receiving .usage-cache.json data even after
+# claude-hud v0.0.12+ removed background OAuth polling.  No-op when:
+# (a) no statusLine is configured, (b) the statusLine is not a HUD
+# command, or (c) the tap is already present.  Idempotent.
+bridge_ensure_hud_usage_tap() {
+  local workdir="$1"
+  local launch_cmd="${2-}"
+  local agent="${3-}"
+  if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
+    bridge_hooks_python ensure-hud-usage-tap --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
+    bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
+  else
+    bridge_hooks_python ensure-hud-usage-tap --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
+  fi
+}
+
 # Issue #544 PR2 — install bridge-managed Claude hook entries into the
 # isolated UID's HOME `.claude/settings.json` (as a controller-owned
 # symlink to a controller-owned `settings.effective.json` rendered next

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -333,6 +333,12 @@ bridge_ensure_hud_usage_tap() {
   if [[ "$(bridge_claude_settings_mode "$workdir")" == "shared" ]]; then
     bridge_hooks_python ensure-hud-usage-tap --settings-file "$(bridge_hook_shared_settings_base_file)" --bridge-home "$BRIDGE_HOME" --python-bin python3 >/dev/null
     bridge_link_claude_settings_to_shared "$workdir" "$launch_cmd" "$agent"
+    # bridge_link_claude_settings_to_shared skips linux-user isolated agents
+    # (the mirror is under a foreign UID). Re-render the isolated home so the
+    # patched shared base propagates there too. No-op for non-isolated agents.
+    if [[ -n "$agent" ]] && command -v bridge_install_isolated_home_settings >/dev/null 2>&1; then
+      bridge_install_isolated_home_settings "$agent" "$launch_cmd" >/dev/null 2>&1 || true
+    fi
   else
     bridge_hooks_python ensure-hud-usage-tap --workdir "$workdir" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
   fi

--- a/scripts/hud-usage-tap.py
+++ b/scripts/hud-usage-tap.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tap Claude Code rate_limits from HUD stdin → .usage-cache.json.
+
+Claude Code HUD v0.0.12+ reads usage from stdin rate_limits rather than
+writing .usage-cache.json (OAuth polling removed). bridge-usage.py still
+reads .usage-cache.json to drive the token-rotation monitor. This script
+bridges the gap:
+
+  1. Read the full stdin JSON that Claude Code sends to the statusLine process.
+  2. Extract rate_limits.{five_hour,seven_day}.{used_percentage,resets_at}.
+  3. Write .usage-cache.json in the format bridge-usage.py expects (fiveHour /
+     sevenDay / fiveHourResetAt / sevenDayResetAt under a "data" key).
+  4. Pass stdin through unchanged to stdout so the HUD process receives it.
+
+Usage (statusLine command):
+    python3 /path/to/hud-usage-tap.py | bun --env-file /dev/null "${plugin_dir}src/index.ts"
+
+The write is atomic (temp-then-replace) and capped at 0.5 s via a daemon
+thread so it never delays HUD rendering.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _write_cache(data: dict) -> None:
+    try:
+        rl = data.get("rate_limits")
+        if not isinstance(rl, dict) or not rl:
+            return
+
+        five_hour = rl.get("five_hour") or {}
+        seven_day = rl.get("seven_day") or {}
+
+        used_5h = five_hour.get("used_percentage")
+        used_7d = seven_day.get("used_percentage")
+        if used_5h is None and used_7d is None:
+            return
+
+        try:
+            fh = float(used_5h) if used_5h is not None else None
+        except (TypeError, ValueError):
+            fh = None
+        try:
+            sd = float(used_7d) if used_7d is not None else None
+        except (TypeError, ValueError):
+            sd = None
+
+        cache = {
+            "data": {
+                "planName": "subscription",
+                "fiveHour": fh,
+                "sevenDay": sd,
+                "fiveHourResetAt": five_hour.get("resets_at"),
+                "sevenDayResetAt": seven_day.get("resets_at"),
+            },
+            "_source": "stdin-tap",
+            "_written_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        home = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+        cache_dir = Path(home) / "plugins" / "claude-hud"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = cache_dir / ".usage-cache.json"
+
+        fd, tmp = tempfile.mkstemp(
+            dir=str(cache_dir), prefix=".usage-cache.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(cache, f, ensure_ascii=False)
+            os.replace(tmp, cache_path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except Exception:
+                pass
+    except Exception:
+        pass
+
+
+def main() -> None:
+    raw = sys.stdin.buffer.read()
+
+    try:
+        data = json.loads(raw)
+        t = threading.Thread(target=_write_cache, args=(data,), daemon=True)
+        t.start()
+        t.join(timeout=0.5)
+    except Exception:
+        pass
+
+    sys.stdout.buffer.write(raw)
+    sys.stdout.buffer.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hud-usage-tap.py
+++ b/scripts/hud-usage-tap.py
@@ -28,6 +28,34 @@ import tempfile
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
+
+
+def _to_iso(value: Any) -> str | None:
+    """Normalise a reset-at value to an ISO-8601 string.
+
+    Claude Code stdin emits resets_at as epoch seconds (integer) or an ISO
+    string. bridge-usage.py's reset_cycle_advanced/format_reset parse the
+    stored value with datetime.fromisoformat, which rejects bare integers.
+    Normalise here so the latch-clearing path works across reset windows.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip():
+        try:
+            datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return value
+        except ValueError:
+            pass
+        # fall through to epoch parse below
+    if isinstance(value, (int, float)) and value > 0:
+        ts = float(value)
+        if ts > 1e11:  # milliseconds → seconds
+            ts /= 1000
+        return datetime.fromtimestamp(ts, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S+00:00"
+        )
+    return None
 
 
 def _write_cache(data: dict) -> None:
@@ -58,8 +86,8 @@ def _write_cache(data: dict) -> None:
                 "planName": "subscription",
                 "fiveHour": fh,
                 "sevenDay": sd,
-                "fiveHourResetAt": five_hour.get("resets_at"),
-                "sevenDayResetAt": seven_day.get("resets_at"),
+                "fiveHourResetAt": _to_iso(five_hour.get("resets_at")),
+                "sevenDayResetAt": _to_iso(seven_day.get("resets_at")),
             },
             "_source": "stdin-tap",
             "_written_at": datetime.now(timezone.utc).isoformat(),

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7145,6 +7145,42 @@ assert_contains "$(cat "$REPO_ROOT/.claude/skills/memory-wiki/SKILL.md")" "memor
 assert_contains "$(cat "$REPO_ROOT/.claude/skills/memory-wiki/SKILL.md")" "Raw-Source Ingest Workflow"
 assert_contains "$(cat "$REPO_ROOT/.claude/skills/memory-wiki/SKILL.md")" "capture -> ingest"
 
+log "ensuring HUD usage tap statusLine patching (ensure-hud-usage-tap)"
+HUD_TAP_WORKDIR="$TMP_ROOT/hud-tap-workdir"
+mkdir -p "$HUD_TAP_WORKDIR/.claude"
+# Seed an unpatched HUD statusLine in settings.json
+python3 -c "
+import json, pathlib
+cfg = {
+  'statusLine': {
+    'type': 'command',
+    'command': 'bash -c \'plugin_dir=x; exec \"/usr/bin/bun\" --env-file /dev/null \"\${plugin_dir}src/index.ts\"\''
+  }
+}
+pathlib.Path('$HUD_TAP_WORKDIR/.claude/settings.json').write_text(json.dumps(cfg, indent=2))
+"
+HUD_TAP_STATUS_BEFORE="$(python3 "$REPO_ROOT/bridge-hooks.py" status-hud-usage-tap --workdir "$HUD_TAP_WORKDIR" --bridge-home "$BRIDGE_HOME")"
+assert_contains "$HUD_TAP_STATUS_BEFORE" "status: missing"
+assert_contains "$HUD_TAP_STATUS_BEFORE" "hud_usage_tap: missing"
+HUD_TAP_ENSURE_OUTPUT="$(python3 "$REPO_ROOT/bridge-hooks.py" ensure-hud-usage-tap --workdir "$HUD_TAP_WORKDIR" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)")"
+assert_contains "$HUD_TAP_ENSURE_OUTPUT" "status: updated"
+assert_contains "$HUD_TAP_ENSURE_OUTPUT" "hud_usage_tap: updated"
+assert_contains "$(cat "$HUD_TAP_WORKDIR/.claude/settings.json")" "hud-usage-tap"
+HUD_TAP_STATUS_AFTER="$(python3 "$REPO_ROOT/bridge-hooks.py" status-hud-usage-tap --workdir "$HUD_TAP_WORKDIR" --bridge-home "$BRIDGE_HOME")"
+assert_contains "$HUD_TAP_STATUS_AFTER" "status: present"
+assert_contains "$HUD_TAP_STATUS_AFTER" "hud_usage_tap: present"
+# Idempotent: second ensure must not change the file
+HUD_TAP_BEFORE_HASH="$(md5sum "$HUD_TAP_WORKDIR/.claude/settings.json" | cut -d' ' -f1)"
+python3 "$REPO_ROOT/bridge-hooks.py" ensure-hud-usage-tap --workdir "$HUD_TAP_WORKDIR" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)" >/dev/null
+HUD_TAP_AFTER_HASH="$(md5sum "$HUD_TAP_WORKDIR/.claude/settings.json" | cut -d' ' -f1)"
+[[ "$HUD_TAP_BEFORE_HASH" == "$HUD_TAP_AFTER_HASH" ]] || die "ensure-hud-usage-tap is not idempotent: settings.json changed on second call"
+# No-HUD settings must return no-hud
+HUD_TAP_NOHUD_WORKDIR="$TMP_ROOT/hud-tap-nohud"
+mkdir -p "$HUD_TAP_NOHUD_WORKDIR/.claude"
+echo '{}' >"$HUD_TAP_NOHUD_WORKDIR/.claude/settings.json"
+HUD_TAP_NOHUD_OUT="$(python3 "$REPO_ROOT/bridge-hooks.py" status-hud-usage-tap --workdir "$HUD_TAP_NOHUD_WORKDIR" --bridge-home "$BRIDGE_HOME" || true)"
+assert_contains "$HUD_TAP_NOHUD_OUT" "no-hud"
+
 log "ensuring Claude project trust seed and startup blocker detection"
 CLAUDE_USER_FILE="$TMP_ROOT/claude-user.json"
 echo '{}' >"$CLAUDE_USER_FILE"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7229,6 +7229,21 @@ HUD_TAP_ISOLATED_SPY="$TMP_ROOT/hud-isolated-spy"
 assert_contains "$(cat "$HUD_TAP_SHARED_BASE_DIR/settings.json")" "hud-usage-tap"
 [[ -f "$HUD_TAP_ISOLATED_SPY" ]] || die "isolated propagation: bridge_install_isolated_home_settings not reached from shared-mode branch"
 
+# Regression guard: bridge-run.sh runs under `set -u`, so an unset variable
+# in the launch-preflight block aborts the shell before `|| true` can catch
+# it — and shellcheck's SC2154 deliberately does NOT flag all-caps names
+# (they may be environment vars), so a `$WORKDIR`-for-`$WORK_DIR` typo slips
+# past CI lint. (That exact bug shipped in the first cut of this PR and
+# would have aborted every Claude bridge-run.sh launch loop.) bridge-run.sh
+# defines the launch workdir as WORK_DIR; assert no bare $WORKDIR survives
+# and that the HUD-tap call uses the correct name.
+HUD_TAP_RUN_SH="$REPO_ROOT/bridge-run.sh"
+if grep -nE '\$\{?WORKDIR\}?\b' "$HUD_TAP_RUN_SH"; then
+  die "bridge-run.sh references undefined \$WORKDIR (set -u abort risk); the launch workdir variable is \$WORK_DIR"
+fi
+HUD_TAP_RUN_CALL="$(grep -n 'bridge_ensure_hud_usage_tap' "$HUD_TAP_RUN_SH" || true)"
+assert_contains "$HUD_TAP_RUN_CALL" 'bridge_ensure_hud_usage_tap "$WORK_DIR"'
+
 log "ensuring Claude project trust seed and startup blocker detection"
 CLAUDE_USER_FILE="$TMP_ROOT/claude-user.json"
 echo '{}' >"$CLAUDE_USER_FILE"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7180,6 +7180,27 @@ mkdir -p "$HUD_TAP_NOHUD_WORKDIR/.claude"
 echo '{}' >"$HUD_TAP_NOHUD_WORKDIR/.claude/settings.json"
 HUD_TAP_NOHUD_OUT="$(python3 "$REPO_ROOT/bridge-hooks.py" status-hud-usage-tap --workdir "$HUD_TAP_NOHUD_WORKDIR" --bridge-home "$BRIDGE_HOME" || true)"
 assert_contains "$HUD_TAP_NOHUD_OUT" "no-hud"
+# Shell wrapper path: bridge_ensure_hud_usage_tap sources bridge-lib.sh and
+# calls bridge-hooks.py. Verify the shared-base path works end-to-end by
+# seeding a fresh unpatched HUD settings.json and calling the bash wrapper.
+HUD_TAP_WRAP_WORKDIR="$TMP_ROOT/hud-tap-wrap-workdir"
+mkdir -p "$HUD_TAP_WRAP_WORKDIR/.claude"
+python3 -c "
+import json, pathlib
+cfg = {
+  'statusLine': {
+    'type': 'command',
+    'command': 'bash -c \'plugin_dir=x; exec \"/usr/bin/bun\" --env-file /dev/null \"\${plugin_dir}src/index.ts\"\''
+  }
+}
+pathlib.Path('$HUD_TAP_WRAP_WORKDIR/.claude/settings.json').write_text(json.dumps(cfg, indent=2))
+"
+HUD_TAP_WRAP_OUT="$("$BASH4_BIN" -lc "
+  source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+  bridge_ensure_hud_usage_tap '$HUD_TAP_WRAP_WORKDIR' '' '' 2>&1 || true
+" 2>&1 || true)"
+# The call must not error; the settings must now contain hud-usage-tap
+assert_contains "$(cat "$HUD_TAP_WRAP_WORKDIR/.claude/settings.json")" "hud-usage-tap"
 
 log "ensuring Claude project trust seed and startup blocker detection"
 CLAUDE_USER_FILE="$TMP_ROOT/claude-user.json"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -7180,9 +7180,8 @@ mkdir -p "$HUD_TAP_NOHUD_WORKDIR/.claude"
 echo '{}' >"$HUD_TAP_NOHUD_WORKDIR/.claude/settings.json"
 HUD_TAP_NOHUD_OUT="$(python3 "$REPO_ROOT/bridge-hooks.py" status-hud-usage-tap --workdir "$HUD_TAP_NOHUD_WORKDIR" --bridge-home "$BRIDGE_HOME" || true)"
 assert_contains "$HUD_TAP_NOHUD_OUT" "no-hud"
-# Shell wrapper path: bridge_ensure_hud_usage_tap sources bridge-lib.sh and
-# calls bridge-hooks.py. Verify the shared-base path works end-to-end by
-# seeding a fresh unpatched HUD settings.json and calling the bash wrapper.
+# Shell wrapper — local (per-workdir) path: workdir outside BRIDGE_AGENT_HOME_ROOT
+# takes the else branch (lib/bridge-hooks.sh:370) which patches workdir settings.json.
 HUD_TAP_WRAP_WORKDIR="$TMP_ROOT/hud-tap-wrap-workdir"
 mkdir -p "$HUD_TAP_WRAP_WORKDIR/.claude"
 python3 -c "
@@ -7195,12 +7194,40 @@ cfg = {
 }
 pathlib.Path('$HUD_TAP_WRAP_WORKDIR/.claude/settings.json').write_text(json.dumps(cfg, indent=2))
 "
-HUD_TAP_WRAP_OUT="$("$BASH4_BIN" -lc "
+"$BASH4_BIN" -lc "
   source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
   bridge_ensure_hud_usage_tap '$HUD_TAP_WRAP_WORKDIR' '' '' 2>&1 || true
-" 2>&1 || true)"
-# The call must not error; the settings must now contain hud-usage-tap
+" 2>&1 || true
 assert_contains "$(cat "$HUD_TAP_WRAP_WORKDIR/.claude/settings.json")" "hud-usage-tap"
+# Shell wrapper — shared path: workdir under BRIDGE_AGENT_HOME_ROOT triggers shared
+# mode (lib/bridge-hooks.sh:361-368). Seed the shared base with an unpatched HUD
+# command, verify the base is patched, and spy that bridge_install_isolated_home_settings
+# is reached (the r4 isolated-propagation block). The spy overrides the function after
+# sourcing so no actual sudo / real OS user is required.
+HUD_TAP_SHARED_AGENT="hud-tap-smoke-agent"
+HUD_TAP_SHARED_WDIR="$BRIDGE_HOME/agents/$HUD_TAP_SHARED_AGENT/workdir"
+HUD_TAP_SHARED_BASE_DIR="$BRIDGE_HOME/agents/.claude"
+mkdir -p "$HUD_TAP_SHARED_WDIR" "$HUD_TAP_SHARED_BASE_DIR"
+python3 -c "
+import json, pathlib
+cfg = {
+  'statusLine': {
+    'type': 'command',
+    'command': 'bash -c \'plugin_dir=x; exec \"/usr/bin/bun\" --env-file /dev/null \"\${plugin_dir}src/index.ts\"\''
+  }
+}
+pathlib.Path('$HUD_TAP_SHARED_BASE_DIR/settings.json').write_text(json.dumps(cfg, indent=2))
+"
+HUD_TAP_ISOLATED_SPY="$TMP_ROOT/hud-isolated-spy"
+"$BASH4_BIN" -lc "
+  export BRIDGE_HOME='$BRIDGE_HOME'
+  export BRIDGE_AGENT_HOME_ROOT='$BRIDGE_HOME/agents'
+  source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+  bridge_install_isolated_home_settings() { touch '$HUD_TAP_ISOLATED_SPY'; return 0; }
+  bridge_ensure_hud_usage_tap '$HUD_TAP_SHARED_WDIR' '' '$HUD_TAP_SHARED_AGENT' 2>&1 || true
+" 2>&1 || true
+assert_contains "$(cat "$HUD_TAP_SHARED_BASE_DIR/settings.json")" "hud-usage-tap"
+[[ -f "$HUD_TAP_ISOLATED_SPY" ]] || die "isolated propagation: bridge_install_isolated_home_settings not reached from shared-mode branch"
 
 log "ensuring Claude project trust seed and startup blocker detection"
 CLAUDE_USER_FILE="$TMP_ROOT/claude-user.json"


### PR DESCRIPTION
## Summary

claude-hud v0.0.12+ removed the OAuth polling loop that previously wrote `usage-cache.json`. Agent Bridge's token-rotation and rate-limit logic depends on that cache. This PR restores the feature by injecting a stdin tap script into the HUD pipeline command.

- Adds `scripts/hud-usage-tap.py` — reads Claude's piped output, forwards it to the real HUD process, and maintains `usage-cache.json` as a side-effect
- Adds `bridge_ensure_hud_usage_tap()` in `lib/bridge-hooks.sh` — idempotent wrapper that patches `settings.json` to inject the tap; shared-mode and local-mode paths handled separately
- Wires the ensure call into `bridge-run.sh` (post-launch), `bridge-upgrade.sh` (post-agent-restart loop), and `bridge-start.sh` (pre-sudo controller context, so linux-user isolated agents get their isolated home rendered before the UID switch)
- Adds `bridge_install_isolated_home_settings` re-render call inside the shared-mode branch so the patched shared base propagates to isolated agent homes
- Full smoke-test coverage: local path, shared path + isolated-home-settings spy, no-HUD early-exit

## Commits

| SHA | Message |
|-----|---------|
| e36f67b | feat(hud): add stdin tap to restore token-rotation usage cache |
| 60aaed9 | fix(hud-tap): epoch→ISO + bridge-hooks ensure-hud-usage-tap wiring |
| 1e87d4e | fix: wire hud-usage-tap lifecycle into launch and upgrade paths |
| 526f76f | fix: propagate HUD tap to linux-user isolated agent homes |
| 6ed2fec | test: cover shared-mode branch + isolated spy in HUD tap smoke |

## Test plan

- [x] `bash -n` + `shellcheck` clean on all modified `.sh` files
- [x] `python3 -m py_compile` clean on `bridge-hooks.py` and `hud-usage-tap.py`
- [x] Smoke test — HUD tap section: local path, shared + isolated spy, no-HUD exit — all PASS
- [ ] Live verify: start an agent with HUD configured, confirm `usage-cache.json` is written and updates on token rotation

## Files changed

- `scripts/hud-usage-tap.py` (new)
- `lib/bridge-hooks.sh`
- `bridge-hooks.py`
- `bridge-run.sh`
- `bridge-upgrade.sh`
- `bridge-start.sh`
- `scripts/smoke-test.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)