### PR TITLE
fix(pre-compact): populate suggested_entities to route dumps to agents kind (closes #976)

### DIFF
--- a/hooks/pre-compact.py
+++ b/hooks/pre-compact.py
@@ -285,7 +285,13 @@ def _build_envelope(agent: str, home: Path, payload: dict, snapshot_path: str) -
         "trigger": trigger,
         "source": "pre-compact-hook",
         "custom_instructions_excerpt": custom[:CUSTOM_EXCERPT_LIMIT],
-        "suggested_entities": [],
+        # Route pre-compact dumps to the `agents` wiki kind via the
+        # `agents/` prefix in ENTITY_KIND_PREFIXES (see
+        # scripts/librarian-process-ingest.py). Without this hint,
+        # infer_kind() falls through to DEFAULT_KIND=operating-rules,
+        # which the librarian §9 guard rejects as agent content, causing
+        # a [librarian-ambiguous] escalation loop. See issue #976.
+        "suggested_entities": [f"agents/{agent}/session-transcripts/"],
         "suggested_concepts": [],
         "suggested_slug": "",
         "suggested_title": "",


### PR DESCRIPTION
## Summary

Fixes #976. `hooks/pre-compact.py::_build_envelope()` hardcoded `suggested_entities: []`, so the librarian's `infer_kind()` fell through to `DEFAULT_KIND=operating-rules`, and the librarian §9 guard rejected every pre-compact dump as agent content. Each compaction produced a `[librarian-ambiguous]` escalation and the capture was discarded.

This patch populates `suggested_entities` with `agents/{agent}/session-transcripts/`. The `agents/` prefix matches `ENTITY_KIND_PREFIXES` in `scripts/librarian-process-ingest.py` (line 79) and routes the capture to `kind=agents` — a valid wiki kind that bypasses the §9 trap.

## Approach

Operator's **Option A** from the issue. The fix is a one-line change plus an inline comment.

**Option B** (`kind: "skip"` sentinel) is intentionally **not** pursued — it would require new short-circuit logic in `librarian-process-ingest.py` and changes the wiki-ingest contract. If the operator decides pre-compact dumps should be excluded from wiki ingest entirely (they are session artifacts, not structured knowledge), Option B can land as a small follow-up PR on top of this one.

## Verification

- `python3 -m py_compile hooks/pre-compact.py scripts/librarian-process-ingest.py` — PASS
- `bash scripts/smoke/pre-compact-envelope-roundtrip.sh` — PASS (3/3 assertions)
- `scripts/smoke-test.sh` — PASS modulo the pre-existing live-install bleed errors (refs #4793), which are unrelated to this change
- **Isolated regression repro** (proves the fix routes around §9):
  ```
  envelope = pre_compact._build_envelope(agent="testagent", ...)
  envelope["suggested_entities"]  # → ['agents/testagent/session-transcripts/']
  librarian.infer_kind(envelope)  # → 'agents'  (was 'operating-rules')
  ```

## Test plan

- [x] py_compile both touched files
- [x] pre-compact-envelope-roundtrip smoke passes
- [x] full smoke-test.sh passes (modulo pre-existing #4793 noise)
- [x] manual repro: patched envelope routes to `kind=agents`, not `operating-rules`
- [ ] live: observe next pre-compact event in operator's runtime — should land in `wiki/agents/<agent>/session-transcripts/` (or its current wiki destination) instead of escalating `[librarian-ambiguous]`

Regression assertion in the smoke test was **not** added: the existing `pre-compact-envelope-roundtrip.sh` is structured around envelope-shape unwrapping with synthetic fixtures, not around the live `_build_envelope()` call path. Adding a route-to-`agents` assertion would require duplicating the hook import and restructuring the test by more than 30 lines. The standalone repro above is the regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)