### PR TITLE
fix(backup): exclude plugins/cache + bump timeout default to 600s (closes #974 #975)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -246,9 +246,9 @@ Backup 동작 조정 환경변수 (모두 `agent-roster.local.sh` 또는 systemd
 | `BRIDGE_DAILY_BACKUP_HOUR` | `4` | 시도 시작 시각 (0–23). |
 | `BRIDGE_DAILY_BACKUP_RETAIN_DAYS` | `7` | tarball + SQL snapshot 보관 일수. v0.7.2 에서 30 → 7 로 축소 (#507). |
 | `BRIDGE_DAILY_BACKUP_FAILURE_COOLDOWN_SECONDS` | `3600` | 실패 후 다음 시도 억제 시간. cooldown window 당 `daemon_warn` + audit row 1회. |
-| `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS` | `300` | daemon-side daily-backup walk+tar+gzip 의 `bridge_with_timeout` 상한 (#745, v0.13.x 에서 hardcoded 120s → env-driven 300s). ~1.4GB+ tarball 을 가진 큰 install 은 더 올려서 사용 (예: 600). 비숫자/0/음수는 기본값 300 으로 폴백. |
-| `BRIDGE_DAILY_BACKUP_TMP_GRACE_SECONDS` | `360` | `*.tgz.tmp.*` reaper 가 무시할 최소 나이 (= daemon timeout 300s + grace 60s). #745 에서 180 → 360 으로 갱신; 직접 `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS` 를 올리면 이 값도 비례해서 함께 올리는 것을 권장. |
-| `BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS` | (empty) | tar walk 추가 exclude (콜론 또는 콤마 구분 relpath). hardcoded 기본 제외: `logs/`, `worktrees/`, `runtime/{assets,media,extensions}/`, `.claude/worktrees/`, `state/backup-snapshots/`, plus any-depth `__pycache__` / `node_modules`. |
+| `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS` | `600` | daemon-side daily-backup walk+tar+gzip 의 `bridge_with_timeout` 상한 (#745 에서 hardcoded 120s → env-driven 300s, #975 에서 300s → 600s 로 multi-agent install 의 fresh-default timeout 여유 확보). 큰 install 은 더 올려서 사용 (예: 900). 비숫자/0/음수는 기본값 600 으로 폴백. |
+| `BRIDGE_DAILY_BACKUP_TMP_GRACE_SECONDS` | `660` | `*.tgz.tmp.*` reaper 가 무시할 최소 나이 (= daemon timeout 600s + grace 60s). #745 에서 180 → 360 으로, #975 에서 360 → 660 으로 갱신; 직접 `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS` 를 올리면 이 값도 비례해서 함께 올리는 것을 권장. |
+| `BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS` | (empty) | tar walk 추가 exclude (콜론 또는 콤마 구분 relpath). hardcoded 기본 제외: `logs/`, `worktrees/`, `runtime/{assets,media,extensions}/`, `.claude/worktrees/`, `state/backup-snapshots/`, plus any-depth `__pycache__` / `node_modules` / `plugins/cache` (#974 — Claude plugin cache, fully regenerable). |
 | `BRIDGE_UPGRADE_BACKUP_RETAIN_COUNT` | `5` | upgrade-* snapshot 최소 보존 개수 (현재 BACKUP_ROOT 는 항상 추가 보존). |
 | `BRIDGE_UPGRADE_BACKUP_RETAIN_DAYS` | `14` | retain count 를 넘긴 upgrade-* 중 이 일수보다 오래된 것만 prune. |
 

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -901,17 +901,18 @@ bridge_daily_backup_int() {
   fi
 }
 
-# Issue #745: resolve the daily-backup timeout from
-# BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS. Default 300s (was hardcoded 120s)
-# so installs with ~1.4GB+ tarballs don't trip the timeout. Rejects 0,
-# negatives, and non-numeric input back to the default — never returns
-# an unsafe value that would make `bridge_with_timeout` complain.
+# Issue #745 / #975: resolve the daily-backup timeout from
+# BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS. Default 600s (history: 120 -> 300
+# in #745, 300 -> 600 in #975) so multi-agent installs whose tarball walk
+# takes well over 300s don't fire spurious backup-failed:timeout urgents.
+# Rejects 0, negatives, and non-numeric input back to the default — never
+# returns an unsafe value that would make `bridge_with_timeout` complain.
 bridge_daily_backup_resolve_timeout() {
-  local raw="${BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS:-300}"
+  local raw="${BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS:-600}"
   if [[ "$raw" =~ ^[0-9]+$ ]] && (( raw > 0 )); then
     printf '%s' "$raw"
   else
-    printf '%s' "300"
+    printf '%s' "600"
   fi
 }
 
@@ -1280,7 +1281,7 @@ detail: ${detail:-(no detail)}
 
 ## What this could mean
 
-- \`timeout\`: the backup walk exceeded the ${backup_timeout}s daemon timeout. Check whether \`$BRIDGE_HOME\` has unexpectedly large directories (e.g. an unbacked \`shared/\` or accidentally-included \`worktrees/\`). Tune \`BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS\` to skip transient subtrees, or raise \`BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS\` (default 300) for larger installs.
+- \`timeout\`: the backup walk exceeded the ${backup_timeout}s daemon timeout. Check whether \`$BRIDGE_HOME\` has unexpectedly large directories (e.g. an unbacked \`shared/\` or accidentally-included \`worktrees/\`). Tune \`BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS\` to skip transient subtrees, or raise \`BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS\` (default 600) for larger installs.
 - \`parse\` / \`subprocess_rc_*\`: the python3 helper exited unexpectedly. Stderr should be in the daemon log; \`tail -n 200 $BRIDGE_HOME/state/daemon.log\`.
 - \`error_sqlite_snapshot\`: \`state/tasks.db\` exists but its hot snapshot failed (corruption, locked). Run \`python3 $BRIDGE_HOME/bridge-upgrade.py verify-tasks-db --target-root $BRIDGE_HOME\` to diagnose.
 - \`error_oserror_*\`: filesystem error from tar write or rename. Check disk health.
@@ -1806,10 +1807,10 @@ process_daily_backup() {
   # Issue #265 proposal A: daily-backup walks BRIDGE_HOME (large file tree on
   # long-lived installs) and writes a tarball; a hung filesystem (NFS,
   # external mount, full disk waiting on flush) would otherwise stall the
-  # daemon main loop. Issue #745: the ceiling is now resolved from
-  # BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS (default 300s, raised from the
-  # original 120s) so operators with larger installs can tune without
-  # patching source.
+  # daemon main loop. Issue #745 / #975: the ceiling is now resolved from
+  # BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS (default 600s; history: 120 -> 300
+  # in #745, 300 -> 600 in #975) so multi-agent installs don't trip the
+  # timeout without operator-side tuning.
   # Bug #507: capture stderr too (separate file) so an error_detail can be
   # surfaced to state.env / audit instead of silently swallowed.
   #

--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -695,8 +695,17 @@ DAILY_BACKUP_HARDCODED_ROOT_EXCLUDES: tuple[tuple[str, ...], ...] = (
 
 # Path-part excludes: drop any path that contains one of these components at
 # any depth (mirrors the legacy __pycache__ skip). Cheap defense against
-# committing or backing up vendored / generated trees.
-DAILY_BACKUP_PATH_PART_EXCLUDES: tuple[str, ...] = ("__pycache__", "node_modules")
+# committing or backing up vendored / generated trees. Entries containing a
+# "/" match a consecutive sequence of components (e.g. "plugins/cache" matches
+# .../<anything>/plugins/cache/... so the agent-name path segment doesn't
+# matter). Issue #974: "plugins/cache" excludes the Claude plugin cache
+# (~100-300 MB per agent home, 1+ GB on a 6-agent install, fully regenerable)
+# which otherwise pushes the daily-backup walk past the default timeout.
+DAILY_BACKUP_PATH_PART_EXCLUDES: tuple[str, ...] = (
+    "__pycache__",
+    "node_modules",
+    "plugins/cache",
+)
 
 # Raw sqlite databases that must never enter the tarball — they're handled
 # via online snapshot dumps instead. Keep the list small and explicit; new
@@ -799,7 +808,17 @@ def should_skip_daily_backup_relpath(
     if not parts:
         return False
     for skip_part in path_part_excludes:
-        if skip_part in parts:
+        # Multi-component entry (e.g. "plugins/cache"): match a consecutive
+        # subsequence anywhere in the path. Single-component entries keep
+        # the legacy fast-path `in parts` check.
+        if "/" in skip_part:
+            sub = tuple(p for p in skip_part.split("/") if p)
+            if sub:
+                n = len(sub)
+                for i in range(len(parts) - n + 1):
+                    if parts[i : i + n] == sub:
+                        return True
+        elif skip_part in parts:
             return True
     relpath_posix = relpath.as_posix()
     for raw_relpath in DAILY_BACKUP_RAW_SQLITE_EXCLUDES:
@@ -849,13 +868,14 @@ def _resolve_grace_seconds(override: int | None = None) -> int:
     # file, so only files older than (daemon_timeout + grace) are removed.
     # Issue #745: default raised 180 -> 360 to track the daemon-side
     # BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS default bump (120 -> 300) plus
-    # the original 60s slack.
+    # the original 60s slack. Issue #975: bumped again 360 -> 660 to track
+    # the timeout default bump (300 -> 600); preserves the 60s slack.
     if override is not None:
         return max(0, int(override))
     raw = os.environ.get("BRIDGE_DAILY_BACKUP_TMP_GRACE_SECONDS", "")
     if raw.isdigit():
         return max(0, int(raw))
-    return 360
+    return 660
 
 
 def reap_stale_daily_backup_tmp(

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1110,15 +1110,15 @@ bridge_load_roster() {
   # this window so a chronically-full disk doesn't burn one tarball
   # attempt per daemon cycle. One warn + one audit per window.
   : "${BRIDGE_DAILY_BACKUP_FAILURE_COOLDOWN_SECONDS:=3600}"
-  # Issue #745: daily-backup walk+tar+gzip timeout. Default 300s (was
-  # hardcoded 120s in bridge-daemon.sh) so installs with ~1.4GB+ tarballs
-  # don't trip the timeout. Raise further for very large installs.
-  : "${BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS:=300}"
+  # Issue #745 / #975: daily-backup walk+tar+gzip timeout. Default 600s
+  # (history: 120 -> 300 in #745, 300 -> 600 in #975) so multi-agent
+  # installs don't trip the timeout. Raise further for very large installs.
+  : "${BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS:=600}"
   # Bug #507 (concurrency): grace window for stale tmp reaping. Should
   # exceed the daemon-side BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS ceiling
-  # plus buffer; default 360s = 300 + 60 (was 180s = 120 + 60 before
-  # #745 timeout bump).
-  : "${BRIDGE_DAILY_BACKUP_TMP_GRACE_SECONDS:=360}"
+  # plus buffer; default 660s = 600 + 60 (history: 180s = 120 + 60 pre-#745,
+  # 360s = 300 + 60 post-#745, 660s = 600 + 60 post-#975).
+  : "${BRIDGE_DAILY_BACKUP_TMP_GRACE_SECONDS:=660}"
   # Daily-backup exclude roots additive to the hardcoded list in
   # bridge-upgrade.py (logs/, worktrees/, runtime/{assets,media,extensions},
   # .claude/worktrees/, state/backup-snapshots/). Colon- or comma-separated.

--- a/scripts/smoke/daily-backup-path-part-test.py
+++ b/scripts/smoke/daily-backup-path-part-test.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Issue #974 regression — exercise `should_skip_daily_backup_relpath`.
+
+Standalone helper for `scripts/smoke/daily-backup.sh::step_path_part_excludes_multicomponent`.
+Extracted to its own file to keep the smoke script free of
+heredoc-in-command-substitution patterns (Footgun #11 ratchet —
+see `lib/upgrade-helpers/` and CLAUDE.md §"Recent critical patches").
+
+Usage:
+    python3 scripts/smoke/daily-backup-path-part-test.py <bridge-upgrade.py>
+
+Exits 0 on PASS (with `PASS (<N> cases)` to stdout), 1 on FAIL (with
+per-case diagnostics to stdout).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+def _load_bridge_upgrade(path: str):
+    spec = importlib.util.spec_from_file_location(
+        "bridge_upgrade", str(pathlib.Path(path).resolve())
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {path!r}")
+    mod = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec so dataclass+ClassVar field
+    # resolution can introspect the module under Python 3.9 (the dataclass
+    # machinery looks up cls.__module__ in sys.modules).
+    sys.modules["bridge_upgrade"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CASES: list[tuple[str, bool, str]] = [
+    # (relpath, expected_excluded, label)
+    ("agents/patch/home/.claude/plugins/cache/foo", True, "target case (excluded)"),
+    ("agents/patch/home/.claude/plugins/cache", True, "no trailing slash (excluded)"),
+    ("plugins/cache/foo", True, "top-level adjacency (excluded)"),
+    ("foo/__pycache__/bar", True, "legacy single-component __pycache__"),
+    ("node_modules/x", True, "legacy single-component node_modules"),
+    ("plugins/elsewhere.json", False, "plugins alone, no cache adjacency (kept)"),
+    ("agents/cache/home/x.txt", False, "cache alone, not after plugins (kept)"),
+    ("state/cache/plugins/x.txt", False, "reversed order (kept)"),
+    ("random/plugins/cache_other/x", False, "cache_other != cache (kept)"),
+    ("plugins-archive/cache/x", False, "plugins-archive != plugins (kept)"),
+]
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <bridge-upgrade.py>", file=sys.stderr)
+        return 2
+
+    mod = _load_bridge_upgrade(argv[1])
+
+    failures: list[str] = []
+    for relpath, expected, label in CASES:
+        got = mod.should_skip_daily_backup_relpath(pathlib.Path(relpath), [])
+        if got != expected:
+            failures.append(
+                f"{label}: relpath={relpath!r} expected={expected} got={got}"
+            )
+
+    if failures:
+        print("FAIL")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print(f"PASS ({len(CASES)} cases)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/smoke/daily-backup.sh
+++ b/scripts/smoke/daily-backup.sh
@@ -313,54 +313,12 @@ step_timeout_resolution() {
 # fast-path `in parts` behaviour.
 step_path_part_excludes_multicomponent() {
   smoke_log "step 8: path-part subsequence matcher (#974 regression)"
+  # Helper extracted to its own .py file to avoid heredoc-in-command-
+  # substitution (Footgun #11 ratchet — see lib/upgrade-helpers/).
   local result
-  result="$(python3 -c "$(cat <<'PY'
-import importlib.util, pathlib, sys
-spec = importlib.util.spec_from_file_location(
-    "bridge_upgrade",
-    str(pathlib.Path(sys.argv[1]).resolve()),
-)
-mod = importlib.util.module_from_spec(spec)
-# Register in sys.modules BEFORE exec so dataclass+ClassVar field
-# resolution can introspect the module under Python 3.9 (the dataclass
-# machinery looks up cls.__module__ in sys.modules).
-sys.modules["bridge_upgrade"] = mod
-spec.loader.exec_module(mod)
-
-def excluded(relpath_str: str) -> bool:
-    return mod.should_skip_daily_backup_relpath(
-        pathlib.Path(relpath_str),
-        [],
-    )
-
-cases = [
-    # (relpath, expected_excluded, label)
-    ("agents/patch/home/.claude/plugins/cache/foo", True, "target case (excluded)"),
-    ("agents/patch/home/.claude/plugins/cache", True, "no trailing slash (excluded)"),
-    ("plugins/cache/foo", True, "top-level adjacency (excluded)"),
-    ("foo/__pycache__/bar", True, "legacy single-component __pycache__"),
-    ("node_modules/x", True, "legacy single-component node_modules"),
-    ("plugins/elsewhere.json", False, "plugins alone, no cache adjacency (kept)"),
-    ("agents/cache/home/x.txt", False, "cache alone, not after plugins (kept)"),
-    ("state/cache/plugins/x.txt", False, "reversed order (kept)"),
-    ("random/plugins/cache_other/x", False, "cache_other != cache (kept)"),
-    ("plugins-archive/cache/x", False, "plugins-archive != plugins (kept)"),
-]
-
-failures = []
-for relpath, expected, label in cases:
-    got = excluded(relpath)
-    if got != expected:
-        failures.append(f"{label}: relpath={relpath!r} expected={expected} got={got}")
-
-if failures:
-    print("FAIL")
-    for f in failures:
-        print("  -", f)
-    sys.exit(1)
-print(f"PASS ({len(cases)} cases)")
-PY
-)" "$SMOKE_REPO_ROOT/bridge-upgrade.py" 2>&1)" || smoke_fail "path-part subsequence matcher failed: $result"
+  result="$(python3 "$SCRIPT_DIR/daily-backup-path-part-test.py" \
+    "$SMOKE_REPO_ROOT/bridge-upgrade.py" 2>&1)" \
+    || smoke_fail "path-part subsequence matcher failed: $result"
 
   if [[ "$result" != PASS* ]]; then
     smoke_fail "path-part subsequence matcher unexpected output: $result"

--- a/scripts/smoke/daily-backup.sh
+++ b/scripts/smoke/daily-backup.sh
@@ -305,6 +305,69 @@ step_timeout_resolution() {
   smoke_log "timeout_resolution OK (5/5 cases + rc=124 detail wiring)"
 }
 
+# issue #974 — multi-component path-part exclude (`plugins/cache`)
+# must match a consecutive subsequence anywhere in the relpath, must NOT
+# false-positive on (a) the components alone, (b) the components in the
+# wrong order, or (c) substring-only matches like `cache_other`. Legacy
+# single-component entries (`__pycache__`, `node_modules`) must keep the
+# fast-path `in parts` behaviour.
+step_path_part_excludes_multicomponent() {
+  smoke_log "step 8: path-part subsequence matcher (#974 regression)"
+  local result
+  result="$(python3 -c "$(cat <<'PY'
+import importlib.util, pathlib, sys
+spec = importlib.util.spec_from_file_location(
+    "bridge_upgrade",
+    str(pathlib.Path(sys.argv[1]).resolve()),
+)
+mod = importlib.util.module_from_spec(spec)
+# Register in sys.modules BEFORE exec so dataclass+ClassVar field
+# resolution can introspect the module under Python 3.9 (the dataclass
+# machinery looks up cls.__module__ in sys.modules).
+sys.modules["bridge_upgrade"] = mod
+spec.loader.exec_module(mod)
+
+def excluded(relpath_str: str) -> bool:
+    return mod.should_skip_daily_backup_relpath(
+        pathlib.Path(relpath_str),
+        [],
+    )
+
+cases = [
+    # (relpath, expected_excluded, label)
+    ("agents/patch/home/.claude/plugins/cache/foo", True, "target case (excluded)"),
+    ("agents/patch/home/.claude/plugins/cache", True, "no trailing slash (excluded)"),
+    ("plugins/cache/foo", True, "top-level adjacency (excluded)"),
+    ("foo/__pycache__/bar", True, "legacy single-component __pycache__"),
+    ("node_modules/x", True, "legacy single-component node_modules"),
+    ("plugins/elsewhere.json", False, "plugins alone, no cache adjacency (kept)"),
+    ("agents/cache/home/x.txt", False, "cache alone, not after plugins (kept)"),
+    ("state/cache/plugins/x.txt", False, "reversed order (kept)"),
+    ("random/plugins/cache_other/x", False, "cache_other != cache (kept)"),
+    ("plugins-archive/cache/x", False, "plugins-archive != plugins (kept)"),
+]
+
+failures = []
+for relpath, expected, label in cases:
+    got = excluded(relpath)
+    if got != expected:
+        failures.append(f"{label}: relpath={relpath!r} expected={expected} got={got}")
+
+if failures:
+    print("FAIL")
+    for f in failures:
+        print("  -", f)
+    sys.exit(1)
+print(f"PASS ({len(cases)} cases)")
+PY
+)" "$SMOKE_REPO_ROOT/bridge-upgrade.py" 2>&1)" || smoke_fail "path-part subsequence matcher failed: $result"
+
+  if [[ "$result" != PASS* ]]; then
+    smoke_fail "path-part subsequence matcher unexpected output: $result"
+  fi
+  smoke_log "path-part excludes OK ($result)"
+}
+
 main() {
   smoke_log "starting issue #507 regression smoke"
   step_snapshot_content
@@ -314,6 +377,7 @@ main() {
   step_corrupted_tasks_db_blocks_archive
   step_cleanup_residue_happy_path
   step_timeout_resolution
+  step_path_part_excludes_multicomponent
   smoke_log "all daily-backup checks passed"
 }
 

--- a/scripts/smoke/daily-backup.sh
+++ b/scripts/smoke/daily-backup.sh
@@ -243,11 +243,12 @@ step_cleanup_residue_happy_path() {
 }
 
 step_timeout_resolution() {
-  # Issue #745: bridge_daily_backup_resolve_timeout honours
-  # BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS, defaults to 300, and clamps
-  # invalid input (0, negative, non-numeric) back to 300. Also asserts
-  # the env var name appears in the daemon's rc=124 failure detail wiring
-  # so operators see actionable guidance.
+  # Issue #745 / #975: bridge_daily_backup_resolve_timeout honours
+  # BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS, defaults to 600 (history: 120 in
+  # the original, 300 post-#745, 600 post-#975), and clamps invalid input
+  # (0, negative, non-numeric) back to that default. Also asserts the env
+  # var name appears in the daemon's rc=124 failure detail wiring so
+  # operators see actionable guidance.
   local daemon_src="$SMOKE_REPO_ROOT/bridge-daemon.sh"
   [[ -f "$daemon_src" ]] \
     || smoke_fail "timeout_resolution: bridge-daemon.sh missing at $daemon_src"
@@ -268,11 +269,11 @@ step_timeout_resolution() {
   # given env value, then prints the resolved timeout.
   local case_input case_want got
   for case_pair in \
-      "::300" \
-      "600:600" \
-      "0:300" \
-      "-1:300" \
-      "abc:300"; do
+      "::600" \
+      "900:900" \
+      "0:600" \
+      "-1:600" \
+      "abc:600"; do
     case_input="${case_pair%%:*}"
     case_want="${case_pair##*:}"
     if [[ -z "$case_input" ]]; then


### PR DESCRIPTION
## Summary

Bundles two closely-related daily-backup defaults fixes:

- **#974** — exclude `agents/*/home/.claude/plugins/cache` (~100-300 MB per agent, 1+ GB total on a 6-agent install, fully regenerable) from the daily-backup walk. This was the dominant size driver pushing the walk past the timeout.
- **#975** — raise default `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS` from 300s → 600s so a fresh multi-agent install does not require operator-side env tuning to avoid spurious `backup-failed:timeout` urgent tasks.

Together these two restore the design intent ("daily backup just works on a typical install").

## Changes

### #974 — `plugins/cache` exclude

- `bridge-upgrade.py:699` — added `"plugins/cache"` to `DAILY_BACKUP_PATH_PART_EXCLUDES`.
- `bridge-upgrade.py:should_skip_daily_backup_relpath` — the existing matcher only checked single-component membership (`if skip_part in parts`), so a literal `"plugins/cache"` would have silently never matched (path components cannot contain `/`). Extended the matcher to treat `/`-delimited entries as a consecutive-subsequence match anywhere in the path. This matches the issue's proposed-fix API exactly without hardcoding agent names or adding a glob engine. Single-component entries (`__pycache__`, `node_modules`) keep the legacy fast path.

### #975 — timeout default 300s → 600s

Bumped in all three source-of-truth sites (kept in sync because they cannot be derived from each other):

- `bridge-daemon.sh:910,914` — `bridge_daily_backup_resolve_timeout` default + clamp fallback.
- `lib/bridge-state.sh:1116` — roster `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS` default.
- `lib/bridge-state.sh:1121` — corresponding `BRIDGE_DAILY_BACKUP_TMP_GRACE_SECONDS` default 360 → 660 (preserves the 60s slack invariant over the new timeout — the stale-tmp reaper must never unlink an in-flight peer's tmp).
- `bridge-upgrade.py:_resolve_grace_seconds` — same 360 → 660 bump on the Python side.

### Comment / operator-facing message updates

Each currently-documented "default 300" reference updated to "default 600" with the `300 -> 600 (issue #975)` history preserved:

- `bridge-daemon.sh:904-909` (function header)
- `bridge-daemon.sh:1283` (operator-facing rc=124 failure message)
- `bridge-daemon.sh:1810` (block comment in `process_daily_backup`)
- `bridge-upgrade.py:868-872` (`_resolve_grace_seconds` header)
- `lib/bridge-state.sh:1113-1115, 1117-1120` (roster default comments)
- `scripts/smoke/daily-backup.sh:245-250` (test header)

### Smoke test update

`scripts/smoke/daily-backup.sh:step_timeout_resolution` validates the resolved default + clamp behaviour with 5 cases. Updated the expected default from 300 → 600 in 4 of the 5 cases (`::600`, `0:600`, `-1:600`, `abc:600`) and bumped the "explicit override is honoured" case from `600:600` to `900:900` so the matrix continues to prove "operator-supplied value passes through unchanged".

## Test plan

- [x] `python3 -m py_compile bridge-upgrade.py`
- [x] `bash -n` + `shellcheck` on `bridge-daemon.sh`, `lib/bridge-state.sh`, `scripts/smoke/daily-backup.sh`
- [x] `./scripts/smoke/daily-backup.sh` — 7/7 steps pass, including `timeout_resolution OK (5/5 cases + rc=124 detail wiring)`
- [x] Ad-hoc unit harness exercises the new path-part subsequence matcher: 7 positive (excluded) + 6 negative (kept) all behave as expected. Crucially `agents/<name>/home/.claude/plugins/cache/...` is excluded for arbitrary `<name>`, while `cache` alone (e.g. `agents/cache/home/x.txt`) and `plugins` alone (e.g. `plugins/elsewhere.json`) are **not** excluded — the multi-component matcher is strict about the consecutive `plugins → cache` sequence.
- [x] `./scripts/smoke-test.sh` — matches main baseline. The isolated tmux role startup leak (`smoke-agent-NNNN` directory leak into the live install) reproduces on `bce856f` without these edits and is unrelated to this PR.

## Risk notes

- **Path-part matcher change** is a generalisation, not a behaviour change for any existing entry. Single-component entries (`__pycache__`, `node_modules`) take the unchanged `elif skip_part in parts:` branch. Only entries containing `/` exercise the new consecutive-subsequence loop.
- **Default bumps** are recoverable per-install via `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS=<seconds>` env, so any operator who relied on the old 300s ceiling to surface walk regressions can keep that signal.
- **Grace window bump** is mandatory in lockstep with the timeout bump: if the timeout were 600s but grace stayed at 360s, an in-flight backup tmp file could be reaped 240s before its parent process times out. The 60s slack invariant is preserved.

Fixes #974
Fixes #975