### PR TITLE
fix(upgrade): invoke picker-sweep one-shot after restart-agents (closes #978)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -2225,6 +2225,48 @@ if [[ $RESTART_AGENTS -eq 1 ]]; then
   # candidate under Bash 5.3.9. Stage via tempfile.
   bridge_upgrade_capture_to_var AGENT_RESTART_JSON \
     bridge_upgrade_agent_restart_json "$AGENT_RESTART_REPORT" 1 "$DRY_RUN"
+
+  # Issue #978 (closes #978, refs #879): post-restart agents — especially
+  # codex-engine agents — frequently land on an interactive picker that
+  # the controller-side auto-accept watcher does not arm for. The picker-
+  # sweep cron (`*/10 * * * *`) eventually unsticks them, but that leaves
+  # an operator-visible 10-minute window where the codex pane sits at
+  # "Press enter to continue" and inbox/queue progress stalls.
+  #
+  # Run picker-sweep one-shot synchronously now so codex pickers (and any
+  # Claude pickers the cold-start watcher missed) are cleared before the
+  # upgrade returns. This is the reactive primitive that already handles
+  # BOTH engines (see scripts/picker-sweep.sh's _PICKER_CODEX_CONFIRM_RE
+  # added 2026-05-16); we just invoke it earlier than the next cron tick.
+  #
+  # Skip when dry-run (no actual restart happened), when no agent reached
+  # status="restarted" (avoids running against an all-attached install),
+  # and when no admin agent is configured (the cron payload uses the
+  # admin for SELF/NOTIFY; same contract here).
+  if [[ $DRY_RUN -ne 1 ]] \
+      && printf '%s\n' "$AGENT_RESTART_REPORT" | grep -qE $'\t''restarted'$'\t' \
+      && [[ -n "${ADMIN_AGENT_ID:-}" ]]; then
+    if [[ -x "$TARGET_ROOT/scripts/picker-sweep.sh" || -r "$TARGET_ROOT/scripts/picker-sweep.sh" ]]; then
+      _picker_sweep_post_restart_output=""
+      if _picker_sweep_post_restart_output="$(
+        bridge_with_timeout 15 "upgrade_post_restart_picker_sweep" \
+          env BRIDGE_PICKER_SWEEP_ENABLED=1 \
+              BRIDGE_PICKER_SWEEP_SELF="$ADMIN_AGENT_ID" \
+              BRIDGE_PICKER_SWEEP_NOTIFY="$ADMIN_AGENT_ID" \
+              BRIDGE_HOME="$TARGET_ROOT" \
+          "$BRIDGE_BASH_BIN" "$TARGET_ROOT/scripts/picker-sweep.sh" 2>&1
+      )"; then
+        if [[ -n "$_picker_sweep_post_restart_output" ]]; then
+          printf '%s\n' "$_picker_sweep_post_restart_output" >&2
+        fi
+      else
+        # Sweep failure (timeout, non-zero exit) is non-fatal — the
+        # */10 cron will retry and any stuck pane is still operator-
+        # actionable. Surface the failure to stderr without aborting.
+        echo "[bridge-upgrade] WARN: post-restart picker-sweep failed (non-fatal — cron will retry): $_picker_sweep_post_restart_output" >&2
+      fi
+    fi
+  fi
 fi
 
 if [[ $JSON -eq 1 ]]; then

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -2248,13 +2248,46 @@ if [[ $RESTART_AGENTS -eq 1 ]]; then
       && [[ -n "${ADMIN_AGENT_ID:-}" ]]; then
     if [[ -x "$TARGET_ROOT/scripts/picker-sweep.sh" || -r "$TARGET_ROOT/scripts/picker-sweep.sh" ]]; then
       _picker_sweep_post_restart_output=""
+      # Run picker-sweep under bridge_upgrade_with_target_env so the
+      # sweep's children (bridge-task, bridge-auth, bridge-queue) see a
+      # clean target-rooted env and never inherit the caller's source-
+      # checkout BRIDGE_* paths or any agent-scoped BRIDGE_AGENT_ID /
+      # BRIDGE_ACTIVE_AGENT_DIR. Without this wrap, picker-sweep's
+      # task-create notification could write to the wrong BRIDGE_TASK_DB
+      # or under the wrong agent scope.
+      #
+      # bridge_with_timeout can't wrap a shell function (it execs `timeout
+      # <secs> <argv>` and `timeout` only knows how to exec binaries), so
+      # we apply the 15s envelope INSIDE the target-env subprocess by
+      # routing through bash -c that invokes GNU timeout itself when
+      # available and otherwise falls through (the */10 picker-sweep cron
+      # remains as the hard backstop for any hang).
       if _picker_sweep_post_restart_output="$(
-        bridge_with_timeout 15 "upgrade_post_restart_picker_sweep" \
-          env BRIDGE_PICKER_SWEEP_ENABLED=1 \
-              BRIDGE_PICKER_SWEEP_SELF="$ADMIN_AGENT_ID" \
-              BRIDGE_PICKER_SWEEP_NOTIFY="$ADMIN_AGENT_ID" \
-              BRIDGE_HOME="$TARGET_ROOT" \
-          "$BRIDGE_BASH_BIN" "$TARGET_ROOT/scripts/picker-sweep.sh" 2>&1
+        bridge_upgrade_with_target_env "$TARGET_ROOT" \
+          "$BRIDGE_BASH_BIN" -c '
+            set -u
+            target_root="$1"
+            admin_id="$2"
+            if command -v timeout >/dev/null 2>&1; then
+              timeout_bin=timeout
+            elif command -v gtimeout >/dev/null 2>&1; then
+              timeout_bin=gtimeout
+            else
+              timeout_bin=""
+            fi
+            sweep_cmd=(
+              env
+                BRIDGE_PICKER_SWEEP_ENABLED=1
+                BRIDGE_PICKER_SWEEP_SELF="$admin_id"
+                BRIDGE_PICKER_SWEEP_NOTIFY="$admin_id"
+                bash "$target_root/scripts/picker-sweep.sh"
+            )
+            if [[ -n "$timeout_bin" ]]; then
+              "$timeout_bin" 15 "${sweep_cmd[@]}"
+            else
+              "${sweep_cmd[@]}"
+            fi
+          ' bridge_upgrade_picker_sweep "$TARGET_ROOT" "$ADMIN_AGENT_ID" 2>&1
       )"; then
         if [[ -n "$_picker_sweep_post_restart_output" ]]; then
           printf '%s\n' "$_picker_sweep_post_restart_output" >&2

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -2256,37 +2256,27 @@ if [[ $RESTART_AGENTS -eq 1 ]]; then
       # task-create notification could write to the wrong BRIDGE_TASK_DB
       # or under the wrong agent scope.
       #
-      # bridge_with_timeout can't wrap a shell function (it execs `timeout
-      # <secs> <argv>` and `timeout` only knows how to exec binaries), so
-      # we apply the 15s envelope INSIDE the target-env subprocess by
-      # routing through bash -c that invokes GNU timeout itself when
-      # available and otherwise falls through (the */10 picker-sweep cron
-      # remains as the hard backstop for any hang).
+      # bridge_with_timeout can't be invoked directly from a target-env
+      # subprocess we exec'd with `env -i` (it's a shell function defined
+      # in bridge-lib.sh, not a binary). Source bridge-lib.sh inside the
+      # target-env bash -c body and call bridge_with_timeout from there
+      # — that preserves both target-env isolation AND bridge_with_timeout's
+      # portable Tier 2 (python3 subprocess.run) fallback for hosts
+      # without GNU timeout/gtimeout (notably bare macOS). The `*/10`
+      # picker-sweep cron remains as the hard backstop.
       if _picker_sweep_post_restart_output="$(
         bridge_upgrade_with_target_env "$TARGET_ROOT" \
           "$BRIDGE_BASH_BIN" -c '
             set -u
             target_root="$1"
             admin_id="$2"
-            if command -v timeout >/dev/null 2>&1; then
-              timeout_bin=timeout
-            elif command -v gtimeout >/dev/null 2>&1; then
-              timeout_bin=gtimeout
-            else
-              timeout_bin=""
-            fi
-            sweep_cmd=(
-              env
-                BRIDGE_PICKER_SWEEP_ENABLED=1
-                BRIDGE_PICKER_SWEEP_SELF="$admin_id"
-                BRIDGE_PICKER_SWEEP_NOTIFY="$admin_id"
-                bash "$target_root/scripts/picker-sweep.sh"
-            )
-            if [[ -n "$timeout_bin" ]]; then
-              "$timeout_bin" 15 "${sweep_cmd[@]}"
-            else
-              "${sweep_cmd[@]}"
-            fi
+            # shellcheck disable=SC1091
+            source "$target_root/bridge-lib.sh"
+            bridge_with_timeout 15 "upgrade_post_restart_picker_sweep" \
+              env BRIDGE_PICKER_SWEEP_ENABLED=1 \
+                  BRIDGE_PICKER_SWEEP_SELF="$admin_id" \
+                  BRIDGE_PICKER_SWEEP_NOTIFY="$admin_id" \
+              bash "$target_root/scripts/picker-sweep.sh"
           ' bridge_upgrade_picker_sweep "$TARGET_ROOT" "$ADMIN_AGENT_ID" 2>&1
       )"; then
         if [[ -n "$_picker_sweep_post_restart_output" ]]; then


### PR DESCRIPTION
## Summary

After `agent-bridge upgrade --apply --restart-agents`, codex-engine static agents (e.g. `patch-dev`) land on the codex CLI's `Press enter to continue` cwd-confirm picker and sit there until the next `*/10` `picker-sweep` cron tick — an operator-visible 10-minute window during which inbox/queue progress for those agents halts. Companion variant of #879 (Claude side).

This PR invokes `scripts/picker-sweep.sh` synchronously at the end of the upgrade restart block. `picker-sweep` already handles BOTH engines (`_PICKER_CODEX_CONFIRM_RE` was added 2026-05-16), so no detector change is needed — the fix is purely about firing the existing primitive earlier than the next cron tick.

## Design notes

- Guard 1 — `[[ $DRY_RUN -ne 1 ]]`: dry-run never actually restarts anything, so there's nothing to unstick.
- Guard 2 — `grep -qE $'\t''restarted'$'\t'` against the post-reconcile report: skip when no agent reached `status="restarted"`. This avoids running picker-sweep against an all-attached install or an all-failed batch. `would-restart` (dry-run shape) and `recovered_by_daemon` (daemon already absorbed the transient) do not match, by design.
- Guard 3 — `[[ -n "${ADMIN_AGENT_ID:-}" ]]`: the sweep's `SELF`/`NOTIFY` envs require an admin agent id; matches the cron payload's contract.
- `bridge_with_timeout 15`: a hung sweep can never block the upgrade from returning. Sweep failure (non-zero rc, timeout) is logged as a non-fatal warning — the `*/10` cron will retry on the next tick.
- Env contract mirrors `lib/bridge-init-default-crons.sh::bridge_init_register_default_picker_sweep`: `BRIDGE_PICKER_SWEEP_ENABLED=1 BRIDGE_PICKER_SWEEP_SELF=<admin> BRIDGE_PICKER_SWEEP_NOTIFY=<admin>` plus `BRIDGE_HOME=$TARGET_ROOT`.

## Scope

42 LOC added, 1 file (`bridge-upgrade.sh`). No detector additions (picker-sweep already handles codex).

## Test plan

- [x] `bash -n bridge-upgrade.sh scripts/picker-sweep.sh lib/bridge-tmux.sh` — clean
- [x] `shellcheck bridge-upgrade.sh` — no new findings in the edit range (one pre-existing SC2329 in `scripts/picker-sweep.sh` from `main`)
- [x] `./scripts/smoke-test.sh` — same pre-existing infrastructure failures (smoke harness leaks smoke-prefixed agent dirs into live install) as `main` baseline; no new failures
- [x] `./scripts/test-picker-sweep-registration.sh` — same 3/6 pass on this branch and on `main` baseline; pre-existing
- [x] Unit-style guard logic verified against mock reports: `restarted` row triggers; no-restart, dry-run `would-restart`, and `recovered_by_daemon` all correctly skip
- [ ] **Live verification (operator)**: on the next `agent-bridge upgrade --apply --restart-agents` with a codex static agent that was inactive (so `bridge-agent.sh restart` actually fires), confirm:
  - `tmux capture-pane -t <codex-agent> -p | tail -10` no longer shows the `Press enter to continue` line within seconds of the upgrade returning.
  - The upgrade still returns within its normal envelope (sweep is 15s-capped).
  - On dry-run, the new branch is skipped (no sweep output in stderr).
  - On an install where every static agent was already attached, the new branch is skipped (no `\trestarted\t` row in the report).

## References

- Closes #978
- Refs #879 (Claude variant — same root cause family, different engine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)