### PR TITLE
fix(teams): extract text from inline text/html attachment when activity.text is empty

### DIFF
--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -328,6 +328,25 @@ function compactText(text: string): string {
   return text.replace(/<at>[^<]+<\/at>/g, '').trim()
 }
 
+// Extract plain text from an HTML string. Used when Teams delivers the message
+// body as an inline text/html attachment (activity.text is empty) rather than
+// in activity.text directly. Handles common inline elements and basic entities.
+function htmlToText(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/p>/gi, '\n')
+    .replace(/<\/div>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
 function idsFor(activity: Activity): string[] {
   const from = activity.from ?? {}
   const aad = String((from as any).aadObjectId ?? '').trim()
@@ -1744,7 +1763,20 @@ async function handleActivity(context: TurnContext): Promise<void> {
   const userName = String(activity.from?.name ?? activity.from?.id ?? 'teams-user')
   const userIds = idsFor(activity)
   const aad = userIds[0] ?? ''
-  const text = compactText(activity.text ?? '')
+  // Teams wraps formatted/multiline messages as an inline text/html attachment
+  // with activity.text set to empty string. Extract the body in that case so
+  // the message is not silently dropped (issue #983).
+  let text = compactText(activity.text ?? '')
+  if (!text && Array.isArray(activity.attachments)) {
+    const htmlAtt = activity.attachments.find(
+      att => String(att.contentType ?? '').trim() === 'text/html'
+        && typeof (att as any).content === 'string'
+        && (att as any).content,
+    )
+    if (htmlAtt) {
+      text = htmlToText(String((htmlAtt as any).content ?? ''))
+    }
+  }
   const guarded = runPromptGuard('scan', text)
   if (guarded?.blocked) return
   const ts = activity.timestamp instanceof Date ? activity.timestamp.toISOString() : new Date().toISOString()


### PR DESCRIPTION
## Root cause

Teams wraps formatted and multiline messages as an **inline** `text/html` attachment:
- `activity.text` → `""` (empty)
- `activity.attachments[0].contentType` → `"text/html"`
- `activity.attachments[0].content` → `"<p>line1</p><p>line2</p>"` (inline string, no URL)

`downloadAttachments()` checks `isGeneralFileContentType('text/html')` (passes), then looks for a download URL. There is none — the content is inline. So it sets `download_status: 'skipped_non_file'` and the text is never extracted.

The stored message ends up with `text: ""`, and the MCP channel notification delivers `content: "(attachment)"` with no downloadable attachment. The agent has no way to read the message body — **silent drop**.

## Fix

- Add `htmlToText()` that strips tags and decodes basic HTML entities (`<br>→\n`, `</p>→\n`, `&amp;`, etc.)
- In `handleActivity`, after computing `text = compactText(activity.text ?? '')`, if `text` is still empty, scan `activity.attachments` for a `text/html` entry whose `.content` is a non-empty string, and run it through `htmlToText()`

Single-line messages (where `activity.text` is already populated) are unaffected.

## Test

Reproduce with a multiline Teams message (line-break or formatting via the rich-text editor). Before this fix the agent received `(attachment)` with no body. After the fix it receives the plain-text content.

## Notes

- Closes issue #983
- Requires Teams plugin process restart to take effect (Bun caches the TS at startup)
- The `adaptWebResponse` shim present in the live runtime but not yet in source is a separate concern (pre-existing gap from a prior hotfix applied directly to live)

## Test plan
- [ ] Send plain text message → still delivers via `activity.text` path (unchanged)
- [ ] Send multiline/formatted message → `text` extracted from inline `text/html` attachment, agent sees actual message content
- [ ] Send file attachment alongside text → no regression in file download path

🤖 Generated with [Claude Code](https://claude.com/claude-code)