### PR TITLE
fix(teams): normalize CRLF line endings in compactText

### DIFF
--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -324,29 +324,33 @@ function loadAccess(): Access {
   return BOOT_ACCESS ?? loadJson<Access>(ACCESS_FILE, defaultAccess())
 }
 
+// Normalize CRLF and bare CR to LF. Applied by both compactText and htmlToText
+// so every text path into runPromptGuard/channel delivery is LF-only.
+function normalizeLineEndings(s: string): string {
+  return s.replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+}
+
 function compactText(text: string): string {
-  return text
-    .replace(/<at>[^<]+<\/at>/g, '')
-    .replace(/\r\n/g, '\n')
-    .replace(/\r/g, '\n')
-    .trim()
+  return normalizeLineEndings(text.replace(/<at>[^<]+<\/at>/g, '')).trim()
 }
 
 // Extract plain text from an HTML string. Used when Teams delivers the message
 // body as an inline text/html attachment (activity.text is empty) rather than
 // in activity.text directly. Handles common inline elements and basic entities.
 function htmlToText(html: string): string {
-  return html
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/p>/gi, '\n')
-    .replace(/<\/div>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
-    .replace(/&nbsp;/g, ' ')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+  return normalizeLineEndings(
+    html
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/<\/p>/gi, '\n')
+      .replace(/<\/div>/gi, '\n')
+      .replace(/<[^>]+>/g, '')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&amp;/g, '&')
+      .replace(/&nbsp;/g, ' ')
+      .replace(/&quot;/g, '"')
+      .replace(/&#39;/g, "'")
+  )
     .replace(/\n{3,}/g, '\n\n')
     .trim()
 }

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -325,7 +325,11 @@ function loadAccess(): Access {
 }
 
 function compactText(text: string): string {
-  return text.replace(/<at>[^<]+<\/at>/g, '').trim()
+  return text
+    .replace(/<at>[^<]+<\/at>/g, '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .trim()
 }
 
 // Extract plain text from an HTML string. Used when Teams delivers the message


### PR DESCRIPTION
## Problem

Teams occasionally delivers `activity.text` with `\r\n` line endings. These passed through `compactText()` unchanged. Bare carriage returns can cause unexpected behavior in downstream consumers and the Claude Code MCP notification handler may silently drop the message.

Additionally, `TEAMS_DELIVERY_MODE` defaults to `channel` — a silent notification drop (busy-turn race) means permanent message loss with no fallback.

## Changes

- `compactText()`: normalize `\r\n` and bare `\r` to `\n` before downstream processing
- Runtime note: `TEAMS_DELIVERY_MODE=both` added to `dev_mun`'s `.teams/.env` (not tracked source) so bridge queue acts as delivery fallback

## Test plan
- [ ] Send multiline Teams message → agent receives LF-only text, not CRLF
- [ ] Single-line messages unaffected
- [ ] With `DELIVERY_MODE=both`: message during agent mid-turn → bridge queue task created as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)