### PR TITLE
fix: harden isolated restart and socket listener recovery

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -4172,10 +4172,20 @@ run_restart() {
   # timeout created a death loop (issue #69 Defect C). Default 5.
   local verify_max_attempts="${BRIDGE_AGENT_RESTART_CHANNEL_VERIFY_MAX_ATTEMPTS:-5}"
   local verify_attempts=0
+  local os_user=""
+  local current_user=""
 
   shift || true
   [[ -n "$agent" ]] || bridge_die "Usage: $(basename "$0") restart <agent> [...]"
   bridge_require_agent "$agent"
+  if [[ "${BRIDGE_AGENT_ID:-}" == "$agent" ]] \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || true)"
+    current_user="$(id -un 2>/dev/null || true)"
+    if [[ -n "$os_user" && "$current_user" == "$os_user" ]]; then
+      bridge_die "isolated agent '$agent' cannot restart itself from inside its linux-user session. Ask a controller/admin agent to run: agent-bridge agent restart $agent"
+    fi
+  fi
   session="$(bridge_agent_session "$agent")"
   [[ -n "$session" ]] || bridge_die "세션 이름이 없습니다: $agent"
   engine="$(bridge_agent_engine "$agent")"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -6069,6 +6069,14 @@ bridge_start_queue_gateway_socket_listener() {
   return 0
 }
 
+bridge_daemon_ensure_queue_gateway_socket_listener() {
+  if bridge_start_queue_gateway_socket_listener; then
+    return 0
+  fi
+  daemon_log_event "queue gateway socket listener ensure failed"
+  return 1
+}
+
 bridge_stop_queue_gateway_socket_listener() {
   # PR #571 r3 finding 4: only signal the recorded pid when ALL three
   # are true: pid alive, socket file present, AND connect probe accepts.
@@ -6796,7 +6804,9 @@ cmd_run() {
   BRIDGE_DAEMON_LAST_STEP="startup"
   echo "$$" >"$BRIDGE_DAEMON_PID_FILE"
   BRIDGE_DAEMON_LAST_STEP="queue_gateway_socket_listener"
-  bridge_start_queue_gateway_socket_listener
+  if ! bridge_daemon_ensure_queue_gateway_socket_listener; then
+    :
+  fi
   BRIDGE_DAEMON_LAST_STEP="startup"
 
   # Issue #265: emit a periodic audit `daemon_tick` so external monitoring
@@ -6827,6 +6837,10 @@ cmd_run() {
   last_heartbeat_ts="$now_ts"
 
   while true; do
+    BRIDGE_DAEMON_LAST_STEP="queue_gateway_socket_listener"
+    if ! bridge_daemon_ensure_queue_gateway_socket_listener; then
+      :
+    fi
     BRIDGE_DAEMON_LAST_STEP="sync_cycle"
     if cmd_sync_cycle; then
       :
@@ -6974,6 +6988,7 @@ cmd_stop() {
 
 cmd_status() {
   local socket_status="off"
+  local daemon_running=0
   if bridge_queue_gateway_listener_requested; then
     socket_status="stopped"
     if bridge_queue_gateway_socket_is_running; then
@@ -6981,9 +6996,13 @@ cmd_status() {
     fi
   fi
   if bridge_daemon_is_running; then
+    daemon_running=1
     echo "running pid=$(bridge_daemon_pid) interval=${BRIDGE_DAEMON_INTERVAL}s db=${BRIDGE_TASK_DB} socket_listener=${socket_status}"
   else
     echo "stopped socket_listener=${socket_status}"
+  fi
+  if [[ $daemon_running -eq 1 && "$socket_status" == "stopped" ]]; then
+    echo "warning: socket_listener=stopped (queue gateway socket listener requested but not accepting connections; daemon will retry)"
   fi
 
   # Issue #815 Wave C: surface tick freshness + derived health so

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2699,6 +2699,7 @@ assert restart_end is not None, "run_restart end `}` not found"
 preflight_idx = None
 clear_idx_agent = None
 dry_run_idx_agent = None
+isolated_self_guard_idx = None
 for i in range(restart_start, restart_end + 1):
     line = agent_src[i]
     if "bridge_agent_restart_preflight_reason" in line and preflight_idx is None:
@@ -2707,9 +2708,17 @@ for i in range(restart_start, restart_end + 1):
         clear_idx_agent = i
     if "if [[ $dry_run_mode -eq 1 ]]; then" in line and dry_run_idx_agent is None:
         dry_run_idx_agent = i
+    if "cannot restart itself from inside its linux-user session" in line and isolated_self_guard_idx is None:
+        isolated_self_guard_idx = i
 assert preflight_idx is not None, "run_restart no longer calls bridge_agent_restart_preflight_reason"
 assert clear_idx_agent is not None, "run_restart must call bridge_agent_clear_broken_launch"
 assert dry_run_idx_agent is not None, "run_restart no longer branches on dry_run_mode"
+assert isolated_self_guard_idx is not None, "run_restart must reject isolated self-service restart with a clean error before bridge-start hook setup"
+assert isolated_self_guard_idx < dry_run_idx_agent, (
+    f"run_restart isolated-self guard is at line {isolated_self_guard_idx + 1}, "
+    f"after the dry-run bridge-start path at line {dry_run_idx_agent + 1}. "
+    "That lets an isolated self `agent restart --dry-run` enter bridge-start hook setup and traceback on controller-owned settings."
+)
 assert clear_idx_agent > preflight_idx, (
     f"run_restart clears broken-launch at line {clear_idx_agent + 1}, "
     f"which is before the preflight guard at line {preflight_idx + 1}. "

--- a/scripts/smoke/daemon.sh
+++ b/scripts/smoke/daemon.sh
@@ -689,6 +689,78 @@ EOF
   [[ ! -S "$socket_path" ]] || smoke_fail "daemon exit should remove queue socket"
 }
 
+daemon_socket_listener_loop_restart() {
+  local bridge_id socket_path pid_file daemon_log first_pid second_pid create_out task_id show_out i
+
+  export BRIDGE_GATEWAY_TRANSPORT=file
+  export BRIDGE_GATEWAY_LISTENER=auto
+  export BRIDGE_AGENT_ID=""
+  export BRIDGE_AGENT_ENV_FILE=""
+  export BRIDGE_QUEUE_GATEWAY_PEERS="$(id -u):worker-a"
+  export BRIDGE_QUEUE_GATEWAY_RUNTIME_ROOT="$SMOKE_TMP_ROOT/daemon-socket-runtime-loop"
+  export BRIDGE_TMPFILES_DIR="$SMOKE_TMP_ROOT/tmpfiles-loop.d"
+  export BRIDGE_TMPFILES_DRIVER=shim
+  export BRIDGE_QUEUE_GATEWAY_SOCKET_START_WAIT_SECONDS=2
+  export BRIDGE_DAEMON_INTERVAL=1
+
+  bridge_id="$(python3 "$SMOKE_REPO_ROOT/bridge-queue-gateway.py" print-runtime-id --bridge-home "$BRIDGE_HOME")"
+  socket_path="$BRIDGE_QUEUE_GATEWAY_RUNTIME_ROOT/$bridge_id/queue-gateway.sock"
+  pid_file="$BRIDGE_STATE_DIR/queue-gateway-socket.pid"
+  daemon_log="$SMOKE_TMP_ROOT/daemon-loop-restart.log"
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "worker-a"
+BRIDGE_AGENT_ENGINE["worker-a"]="claude"
+BRIDGE_AGENT_SESSION["worker-a"]="worker-a"
+BRIDGE_AGENT_WORKDIR["worker-a"]="$SMOKE_TMP_ROOT/worker-a"
+BRIDGE_AGENT_LAUNCH_CMD["worker-a"]="BRIDGE_GATEWAY_TRANSPORT=socket claude"
+BRIDGE_AGENT_ISOLATION_MODE["worker-a"]="linux-user"
+BRIDGE_AGENT_OS_USER["worker-a"]="agent-bridge-worker-a"
+EOF
+  mkdir -p "$SMOKE_TMP_ROOT/worker-a"
+  bash "$SMOKE_REPO_ROOT/bridge-daemon.sh" run >"$daemon_log" 2>&1 &
+  DAEMON_SOCKET_PID="$!"
+
+  for ((i = 0; i < 50; i++)); do
+    if [[ -S "$socket_path" && -f "$pid_file" ]] && kill -0 "$DAEMON_SOCKET_PID" 2>/dev/null; then
+      first_pid="$(sed -n '1p' "$pid_file" 2>/dev/null || true)"
+      [[ "$first_pid" =~ ^[0-9]+$ ]] && break
+    fi
+    sleep 0.1
+  done
+  [[ "$first_pid" =~ ^[0-9]+$ ]] || smoke_fail "loop-restart: daemon did not start initial listener; log=$(cat "$daemon_log" 2>/dev/null || true)"
+
+  kill "$first_pid" >/dev/null 2>&1 || true
+
+  second_pid=""
+  for ((i = 0; i < 80; i++)); do
+    if [[ -S "$socket_path" && -f "$pid_file" ]] && kill -0 "$DAEMON_SOCKET_PID" 2>/dev/null; then
+      second_pid="$(sed -n '1p' "$pid_file" 2>/dev/null || true)"
+      if [[ "$second_pid" =~ ^[0-9]+$ && "$second_pid" != "$first_pid" ]]; then
+        break
+      fi
+    fi
+    sleep 0.1
+  done
+  [[ "$second_pid" =~ ^[0-9]+$ && "$second_pid" != "$first_pid" ]] \
+    || smoke_fail "loop-restart: daemon did not restart dead queue socket listener (first=$first_pid second=${second_pid:-}); log=$(cat "$daemon_log" 2>/dev/null || true)"
+
+  create_out="$(
+    BRIDGE_GATEWAY_PROXY=1 BRIDGE_AGENT_ID=worker-a BRIDGE_GATEWAY_TRANSPORT=socket python3 "$SMOKE_REPO_ROOT/bridge-queue.py" create \
+      --to worker-a \
+      --from forged \
+      --title "daemon socket restart smoke" \
+      --body "daemon socket restart body" \
+      --format shell
+  )"
+  task_id="$(smoke_shell_field TASK_ID "$create_out")"
+  show_out="$(BRIDGE_GATEWAY_PROXY=0 python3 "$SMOKE_REPO_ROOT/bridge-queue.py" show "$task_id" --format shell)"
+  smoke_assert_contains "$show_out" "TASK_CREATED_BY=worker-a" "loop-restarted socket listener proxies as peer"
+
+  kill "$DAEMON_SOCKET_PID" >/dev/null 2>&1 || true
+  wait "$DAEMON_SOCKET_PID" >/dev/null 2>&1 || true
+  DAEMON_SOCKET_PID=""
+}
+
 # r2 finding 4: daemon listener lifecycle joint pid+socket validation.
 # A stale pid file (process gone, no socket) plus a stale socket file
 # (no owning pid) must both be cleaned up before the next start, so the
@@ -861,10 +933,12 @@ main() {
   # non-Linux so the daemon smoke stays green on operator workstations.
   if smoke_is_linux; then
     smoke_run "queue gateway socket listener lifecycle" daemon_socket_listener_contract
+    smoke_run "queue gateway socket listener loop restart" daemon_socket_listener_loop_restart
     smoke_run "queue gateway socket listener stale recovery" daemon_socket_listener_stale_recovery
     smoke_run "queue gateway socket listener false-positive liveness" daemon_socket_listener_false_positive_liveness
   else
     smoke_skip "queue gateway socket listener lifecycle" "non-Linux"
+    smoke_skip "queue gateway socket listener loop restart" "non-Linux"
     smoke_skip "queue gateway socket listener stale recovery" "non-Linux"
     smoke_skip "queue gateway socket listener false-positive liveness" "non-Linux"
   fi


### PR DESCRIPTION
## Summary
- reject linux-user isolated self-service `agent restart <self>` before bridge-start hook setup, replacing PermissionError tracebacks with an admin-escalation message
- re-ensure the queue gateway socket listener on every daemon loop, not just daemon startup
- add daemon status warning and smoke coverage for listener death/restart

## Issues
- Fixes #990 isolated self restart traceback path
- Fixes #991 queue gateway socket listener no-recovery window

## Verification
- `bash -n bridge-agent.sh bridge-daemon.sh scripts/smoke/daemon.sh scripts/smoke-test.sh`
- `python3 -m py_compile bridge-hooks.py bridge-queue.py bridge-queue-gateway.py`
- `scripts/smoke/daemon.sh`
- patched live repro: isolated `dev_mun` self `agent restart --dry-run` now exits with clean admin-escalation error
- controller `agent restart dev_mun --dry-run` still prints normal launch plan
- `git diff --check`
- `shellcheck bridge-agent.sh bridge-daemon.sh scripts/smoke/daemon.sh`