### PR TITLE
fix(isolation): regenerate agent-env.sh with v2 state paths on isolated restart (closes #989)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3340,6 +3340,27 @@ PY
       "$new_class" \
       "$loop_explicit_off_arg" >/dev/null
     after_sha="$(bridge_agent_update_file_sha256 "$roster_path")"
+
+    # Issue #989: a channel-list / launch-cmd mutation must refresh the
+    # cached `runtime/agent-env.sh` for a linux-user isolated agent.
+    # bridge_write_role_block only rewrites the roster file — the
+    # in-memory roster maps still hold the pre-mutation values, and the
+    # cached agent-env.sh (the only roster snapshot an isolated UID can
+    # read) keeps a stale BRIDGE_AGENT_LAUNCH_CMD until the next full
+    # bridge-start.sh run. A stale launch cmd carries a pre-v2 channel
+    # state path (e.g. agents/<X>/.teams instead of
+    # agents/<X>/workdir/.teams), which gives the isolated UID EACCES on
+    # the channel state dir and silently breaks inbound delivery (#771
+    # regression). Invalidate the per-process roster cache (issue #848 —
+    # bridge_load_roster short-circuits on BRIDGE_ROSTER_CACHE_LOADED=1
+    # otherwise, and the writer would replay the pre-mutation maps) then
+    # reload so the writer sees the new channels, then regenerate. Same
+    # invalidate+reload pattern as the create path above. NO-OP for
+    # non-isolated agents.
+    bridge_roster_cache_invalidate
+    bridge_load_roster
+    bridge_ensure_isolated_agent_env_current "$agent" \
+      || bridge_warn "agent update: cached agent-env.sh regeneration reported a problem for '$agent'; run 'agent-bridge migrate isolation v2 --apply --agent $agent' before the next restart"
   else
     after_sha="$before_sha"
   fi

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3341,26 +3341,16 @@ PY
       "$loop_explicit_off_arg" >/dev/null
     after_sha="$(bridge_agent_update_file_sha256 "$roster_path")"
 
-    # Issue #989: a channel-list / launch-cmd mutation must refresh the
-    # cached `runtime/agent-env.sh` for a linux-user isolated agent.
-    # bridge_write_role_block only rewrites the roster file — the
-    # in-memory roster maps still hold the pre-mutation values, and the
-    # cached agent-env.sh (the only roster snapshot an isolated UID can
-    # read) keeps a stale BRIDGE_AGENT_LAUNCH_CMD until the next full
-    # bridge-start.sh run. A stale launch cmd carries a pre-v2 channel
-    # state path (e.g. agents/<X>/.teams instead of
-    # agents/<X>/workdir/.teams), which gives the isolated UID EACCES on
-    # the channel state dir and silently breaks inbound delivery (#771
-    # regression). Invalidate the per-process roster cache (issue #848 —
-    # bridge_load_roster short-circuits on BRIDGE_ROSTER_CACHE_LOADED=1
-    # otherwise, and the writer would replay the pre-mutation maps) then
-    # reload so the writer sees the new channels, then regenerate. Same
-    # invalidate+reload pattern as the create path above. NO-OP for
-    # non-isolated agents.
-    bridge_roster_cache_invalidate
-    bridge_load_roster
-    bridge_ensure_isolated_agent_env_current "$agent" \
-      || bridge_warn "agent update: cached agent-env.sh regeneration reported a problem for '$agent'; run 'agent-bridge migrate isolation v2 --apply --agent $agent' before the next restart"
+    # Issue #989: bridge_write_role_block just rewrote the roster file —
+    # for a linux-user isolated agent the cached `runtime/agent-env.sh`
+    # (the only roster snapshot the isolated UID can read) now holds a
+    # stale BRIDGE_AGENT_LAUNCH_CMD whose embedded channel state paths
+    # may be pre-v2 (`agents/<X>/.teams` instead of
+    # `agents/<X>/workdir/.teams`) → EACCES → silent inbound delivery
+    # loss (#771 regression). The shared helper invalidates the
+    # per-process roster cache, reloads from disk, and regenerates the
+    # cached env file. NO-OP for non-isolated agents.
+    bridge_refresh_isolated_agent_env_after_channel_mutation "$agent"
   else
     after_sha="$before_sha"
   fi

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -515,6 +515,11 @@ run_discord() {
       bridge_setup_write_local_assoc "BRIDGE_AGENT_NOTIFY_ACCOUNT" "$agent" "$channel_account" >/dev/null
     fi
     bridge_ensure_claude_channel_plugins "$agent"
+    # Issue #989: bridge_setup_add_agent_channel rewrote BRIDGE_AGENT_CHANNELS
+    # in agent-roster.local.sh — refresh the isolated agent's cached
+    # runtime/agent-env.sh so its launch cmd cannot keep a pre-v2 channel
+    # state path. NO-OP for non-isolated agents.
+    bridge_refresh_isolated_agent_env_after_channel_mutation "$agent"
   fi
 }
 
@@ -582,6 +587,10 @@ run_telegram() {
       bridge_setup_write_local_assoc "BRIDGE_AGENT_NOTIFY_ACCOUNT" "$agent" "$channel_account" >/dev/null
     fi
     bridge_ensure_claude_channel_plugins "$agent"
+    # Issue #989: bridge_setup_replace_agent_telegram_channel rewrote
+    # BRIDGE_AGENT_CHANNELS in agent-roster.local.sh — refresh the isolated
+    # agent's cached runtime/agent-env.sh. NO-OP for non-isolated agents.
+    bridge_refresh_isolated_agent_env_after_channel_mutation "$agent"
   fi
 }
 
@@ -651,6 +660,14 @@ run_teams() {
       bridge_setup_write_local_assoc "BRIDGE_AGENT_NOTIFY_ACCOUNT" "$agent" "$channel_account" >/dev/null
     fi
     bridge_ensure_claude_channel_plugins "$agent"
+    # Issue #989: setup teams rewrote BOTH BRIDGE_AGENT_CHANNELS
+    # (bridge_setup_add_agent_channel) AND BRIDGE_AGENT_LAUNCH_CMD
+    # (bridge_setup_ensure_development_channels_launch_flag) in
+    # agent-roster.local.sh. Refresh the isolated agent's cached
+    # runtime/agent-env.sh AFTER both writes so the regenerated launch
+    # cmd reflects the channel add and the dev-channel launch flag.
+    # NO-OP for non-isolated agents.
+    bridge_refresh_isolated_agent_env_after_channel_mutation "$agent"
   fi
 }
 

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1734,6 +1734,28 @@ PY
       if [[ -n "$RELAY_CLEANUP_JSON" ]]; then
         bridge_audit_log upgrade telegram_relay_residue_cleanup_applied "$TARGET_VERSION" \
           --detail summary="$RELAY_CLEANUP_JSON" >/dev/null 2>&1 || true
+        # Issue #989: bridge-relay-cleanup.py rewrote BRIDGE_AGENT_CHANNELS
+        # / BRIDGE_AGENT_LAUNCH_CMD in agent-roster.local.sh (dropping the
+        # legacy telegram-relay channel + dev-channel loader). For a
+        # linux-user isolated agent the cached runtime/agent-env.sh now
+        # carries a stale launch cmd — and isolation-v2-migrate already
+        # ran earlier in this upgrade, so nothing downstream regenerates
+        # it. Refresh every isolated agent's cache via the shared helper
+        # so the next start does not bind a pre-v2 channel state path
+        # (#771-class silent inbound delivery failure). NO-OP for
+        # non-isolated agents; tolerant on failure so cleanup success is
+        # not downgraded by a per-agent regen hiccup.
+        bridge_upgrade_with_target_env "$TARGET_ROOT" "$BRIDGE_BASH_BIN" -lc '
+          set -euo pipefail
+          source "$1/bridge-lib.sh"
+          bridge_load_roster
+          for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+            command -v bridge_refresh_isolated_agent_env_after_channel_mutation \
+              >/dev/null 2>&1 || continue
+            bridge_refresh_isolated_agent_env_after_channel_mutation "$agent" \
+              >/dev/null 2>&1 || true
+          done
+        ' -- "$SOURCE_ROOT" >/dev/null 2>&1 || true
       fi
     fi
     rm -rf "$_relay_cleanup_preview_dir"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3410,6 +3410,32 @@ bridge_ensure_isolated_agent_env_current() {
   return 1
 }
 
+# Issue #989: shared post-mutation refresh for the channel-list / launch-cmd
+# write paths. A mutator that rewrites agent-roster.local.sh (run_update's
+# bridge_write_role_block, or bridge-setup.sh's bridge_setup_write_local_assoc)
+# leaves the per-process roster cache stale: bridge_load_roster short-circuits
+# on BRIDGE_ROSTER_CACHE_LOADED=1 (issue #848 memo), so a bare reload replays
+# the pre-mutation in-memory maps and bridge_ensure_isolated_agent_env_current
+# would regenerate runtime/agent-env.sh from the OLD channel set. Invalidate
+# the cache first so the reload re-reads disk, then regenerate. NO-OP for
+# non-isolated agents (the inner helper gates on isolation).
+#
+# Call this from EVERY roster-mutation path that touches BRIDGE_AGENT_CHANNELS
+# or BRIDGE_AGENT_LAUNCH_CMD, after the on-disk write completes.
+bridge_refresh_isolated_agent_env_after_channel_mutation() {
+  local agent="$1"
+
+  [[ -n "$agent" ]] || return 0
+  if command -v bridge_roster_cache_invalidate >/dev/null 2>&1; then
+    bridge_roster_cache_invalidate
+  fi
+  if command -v bridge_load_roster >/dev/null 2>&1; then
+    bridge_load_roster
+  fi
+  bridge_ensure_isolated_agent_env_current "$agent" \
+    || bridge_warn "channel mutation: cached agent-env.sh regeneration reported a problem for '$agent'; run 'agent-bridge migrate isolation v2 --apply --agent $agent' before the next restart"
+}
+
 bridge_linux_prepare_agent_isolation() {
   local agent="$1"
   local os_user="$2"

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3332,6 +3332,84 @@ EOF
   fi
 }
 
+# Issue #989: refresh the cached `runtime/agent-env.sh` for a linux-user
+# isolated agent so a roster mutation (channel-add / channel-remove /
+# launch-cmd edit) can never leave the cached `BRIDGE_AGENT_LAUNCH_CMD`
+# pointing at a pre-v2 channel state path.
+#
+# Background. `runtime/agent-env.sh` is the ONLY roster snapshot an
+# isolated UID can read (the real roster files are not group-reachable;
+# `bridge_write_linux_agent_env_file` sets BRIDGE_ROSTER_FILE="" inside
+# the emitted file). The cached launch cmd embeds `TEAMS_STATE_DIR` and
+# the sibling `*_STATE_DIR` assignments. For a v0.7->v0.8-migrated agent
+# the raw roster launch cmd still carries the pre-v2 path
+# `agents/<X>/.teams` (owned ec2-user mode 700); the v2-correct
+# `agents/<X>/workdir/.teams` is injected at launch by
+# `bridge_claude_launch_with_channel_state_dirs`, but ONLY for channels
+# still present in the effective channel set. `agent update --channels-*`
+# rewrites the roster yet never regenerated this cache, so the stale
+# snapshot survived until the next full `bridge-start.sh` run — and a
+# channel server that bound the pre-v2 path got EACCES and silently
+# stopped delivering inbound messages (the #771 regression this closes).
+#
+# This is the same recompute `isolation-v2-reapply` performs (see
+# lib/bridge-isolation-v2-reapply.sh:448-528). Calling it eagerly after
+# a roster mutation keeps the cache v2-correct without waiting for a
+# reapply pass.
+#
+# NO-OP contract: returns 0 immediately for non-isolated (shared-mode /
+# non-linux-user) agents — only linux-user isolation has the cached
+# `runtime/agent-env.sh`. Also a no-op when isolation is disabled by env
+# or when the writer / path helpers are not loaded in the current entry
+# path (load-order guard mirrors isolation-v2-reapply.sh:471).
+bridge_ensure_isolated_agent_env_current() {
+  local agent="$1"
+
+  [[ -n "$agent" ]] || return 0
+  if command -v bridge_isolation_disabled_by_env >/dev/null 2>&1 \
+      && bridge_isolation_disabled_by_env; then
+    return 0
+  fi
+  bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null || return 0
+
+  # Load-order guard: these helpers may not be sourced in every entry
+  # path. A silent skip would mask the regression, so warn loudly —
+  # mirrors the isolation-v2-reapply contract.
+  if ! command -v bridge_write_linux_agent_env_file >/dev/null 2>&1 \
+      || ! command -v bridge_agent_linux_env_file >/dev/null 2>&1; then
+    bridge_warn "bridge_ensure_isolated_agent_env_current: writer/path helper not loaded for '$agent' (load-order regression?); cached agent-env.sh left stale — channel servers may bind pre-v2 state paths"
+    return 1
+  fi
+
+  local env_file=""
+  env_file="$(bridge_agent_linux_env_file "$agent" 2>/dev/null || true)"
+  [[ -n "$env_file" ]] || return 0
+
+  # Idempotency: generate to a temp path first; if the existing file is
+  # a regular file already byte-identical to what the writer produces,
+  # skip the rewrite to preserve mtime/ctime (matches the reapply
+  # tool's already-canonical short-circuit).
+  local tmp_env=""
+  tmp_env="$(mktemp "${TMPDIR:-/tmp}/agent-env.regen.XXXXXX" 2>/dev/null || true)"
+  if [[ -n "$tmp_env" ]] \
+      && bridge_write_linux_agent_env_file "$agent" "$tmp_env" 2>/dev/null; then
+    if [[ -f "$env_file" && ! -L "$env_file" ]] \
+        && cmp -s "$tmp_env" "$env_file" 2>/dev/null; then
+      rm -f "$tmp_env"
+      return 0
+    fi
+    rm -f "$tmp_env"
+    if bridge_write_linux_agent_env_file "$agent" "$env_file" 2>/dev/null; then
+      return 0
+    fi
+    bridge_warn "bridge_ensure_isolated_agent_env_current: failed to regenerate $env_file for '$agent' (next agent start will use stale BRIDGE_AGENT_LAUNCH_CMD — channel servers may bind pre-v2 state paths)"
+    return 1
+  fi
+  [[ -n "$tmp_env" ]] && rm -f "$tmp_env"
+  bridge_warn "bridge_ensure_isolated_agent_env_current: failed to stage temp agent-env.sh for '$agent'"
+  return 1
+}
+
 bridge_linux_prepare_agent_isolation() {
   local agent="$1"
   local os_user="$2"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11337,4 +11337,11 @@ bash "$REPO_ROOT/scripts/smoke/watchdog-silence-stderr-capture.sh"
 log "running 981-restart-session-resume-snapshot smoke (issue #981)"
 bash "$REPO_ROOT/scripts/smoke/981-restart-session-resume-snapshot.sh"
 
+# Issue #989 — a roster mutation (channel-add/remove, launch-cmd edit)
+# must refresh the cached runtime/agent-env.sh for a linux-user isolated
+# agent so the cached launch cmd can never regress to a pre-v2 channel
+# state path (the #771-class silent Teams inbound delivery failure).
+log "running 989-isolated-agent-env-state-dir smoke (issue #989)"
+bash "$REPO_ROOT/scripts/smoke/989-isolated-agent-env-state-dir.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/989-isolated-agent-env-state-dir.sh
+++ b/scripts/smoke/989-isolated-agent-env-state-dir.sh
@@ -39,6 +39,20 @@
 #       maps and the regenerated env file misses the new channel. The
 #       fix invalidates the cache first. T4 proves both directions: bare
 #       reload → stale; invalidate+reload → fresh.
+#   T5. Setup-style direct-write path — `bridge-setup.sh`'s discord /
+#       telegram / teams entrypoints mutate BRIDGE_AGENT_CHANNELS /
+#       BRIDGE_AGENT_LAUNCH_CMD via a single-line assoc rewrite
+#       (bridge_setup_write_local_assoc), NOT via bridge_write_role_block.
+#       T5 exercises that vector + the shared
+#       `bridge_refresh_isolated_agent_env_after_channel_mutation` helper
+#       and asserts the regenerated cache carries the v2 workdir path and
+#       the newly-added channel.
+#   T6. relay-cleanup upgrade vector — `bridge-relay-cleanup.py` (run by
+#       `agent-bridge upgrade --apply`) rewrites BRIDGE_AGENT_CHANNELS /
+#       BRIDGE_AGENT_LAUNCH_CMD to strip the legacy telegram-relay
+#       plugin. T6 runs the real cleanup tool against an isolated agent's
+#       roster then the shared helper (the call the upgrade block now
+#       makes), asserting the regenerated cache reflects the strip.
 #
 # Isolation: temp BRIDGE_HOME with v2 layout via smoke_setup_bridge_home;
 # the smoke never reads or writes the operator's live runtime.
@@ -252,7 +266,7 @@ BRIDGE_AGENT_ENGINE["${agent}"]='claude'
 BRIDGE_AGENT_SESSION["${agent}"]='${agent}'
 BRIDGE_AGENT_SOURCE["${agent}"]="static"
 BRIDGE_AGENT_LAUNCH_CMD["${agent}"]='claude --dangerously-skip-permissions'
-BRIDGE_AGENT_CHANNELS["${agent}"]='${channels}'
+BRIDGE_AGENT_CHANNELS["${agent}"]="${channels}"
 BRIDGE_AGENT_ISOLATION_MODE["${agent}"]='linux-user'
 BRIDGE_AGENT_OS_USER["${agent}"]='agent-bridge-${agent}'
 BRIDGE_AGENT_CONTINUE["${agent}"]="1"
@@ -313,6 +327,125 @@ test_cache_staleness_guard() {
     "T4 invalidate+reload+regen: original channel still present"
 }
 
+# --- T5: setup-style direct write path + shared post-mutation helper ---------
+
+# Rewrite ONLY the BRIDGE_AGENT_CHANNELS assignment line in the roster file
+# in place — this mirrors bridge-setup.sh's bridge_setup_write_local_assoc
+# (a single-line assoc rewrite), as opposed to bridge_write_role_block's
+# whole managed-role block rewrite that run_update / T1-T4 exercise.
+setup_style_rewrite_channels() {
+  local agent="$1"
+  local channels="$2"
+  local tmp
+  tmp="$(mktemp "${TMPDIR:-/tmp}/roster.XXXXXX")"
+  while IFS= read -r line; do
+    case "$line" in
+      "BRIDGE_AGENT_CHANNELS[\"$agent\"]="*)
+        # Double-quoted value form, matching bridge_setup_write_local_assoc.
+        printf '%s\n' "BRIDGE_AGENT_CHANNELS[\"$agent\"]=\"$channels\""
+        ;;
+      *)
+        printf '%s\n' "$line"
+        ;;
+    esac
+  done <"$BRIDGE_ROSTER_LOCAL_FILE" >"$tmp"
+  mv "$tmp" "$BRIDGE_ROSTER_LOCAL_FILE"
+}
+
+test_setup_style_mutation_refreshes_cache() {
+  local agent="setup-989"
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+
+  # Roster starts with teams only; load it (per-process cache memo set).
+  write_isolated_roster "$agent" "plugin:teams@agent-bridge"
+  bridge_roster_cache_invalidate
+  bridge_load_roster
+
+  local env_file
+  env_file="$(bridge_agent_linux_env_file "$agent")"
+  mkdir -p "$(dirname "$env_file")"
+
+  # Simulate `agent-bridge setup discord <agent>`: the setup mutator
+  # rewrites the BRIDGE_AGENT_CHANNELS line on disk AND updates the
+  # in-process map, then the entrypoint calls the shared post-mutation
+  # helper. Reproduce that exact two-step here.
+  setup_style_rewrite_channels "$agent" "plugin:teams@agent-bridge,plugin:discord@agent-bridge"
+  BRIDGE_AGENT_CHANNELS["$agent"]="plugin:teams@agent-bridge,plugin:discord@agent-bridge"
+
+  local rc=0
+  bridge_refresh_isolated_agent_env_after_channel_mutation "$agent" || rc=$?
+  smoke_assert_eq "0" "$rc" "T5 shared helper returns 0 after a setup-style mutation"
+
+  # The regenerated cache must carry the v2 workdir path AND the new channel.
+  local workdir_line channels_line
+  workdir_line="$(grep "^BRIDGE_AGENT_WORKDIR\[" "$env_file" | head -n 1)"
+  smoke_assert_contains "$workdir_line" "$BRIDGE_AGENT_ROOT_V2/$agent/workdir" \
+    "T5 regenerated env file carries the v2 workdir path"
+  channels_line="$(env_file_channels_line "$agent" "$env_file")"
+  smoke_assert_contains "$channels_line" "discord" \
+    "T5 setup-style channel add propagated to the regenerated cache"
+  smoke_assert_contains "$channels_line" "teams" \
+    "T5 original channel still present after the setup-style mutation"
+
+  local teams_dir
+  teams_dir="$(bridge_agent_teams_state_dir "$agent")"
+  smoke_assert_contains "$teams_dir" "/workdir/.teams" \
+    "T5 teams state dir resolves to the v2 workdir/.teams path"
+}
+
+# --- T6: relay-cleanup upgrade vector + shared helper ------------------------
+
+# bridge-relay-cleanup.py is the v0.7.x telegram-relay residue cleanup that
+# `agent-bridge upgrade --apply` runs. It rewrites BRIDGE_AGENT_CHANNELS to
+# drop the legacy `plugin:telegram-relay@*` item — another roster-mutation
+# path. The upgrade block now calls the shared helper after relay-cleanup;
+# T6 exercises that end-to-end: real relay-cleanup roster rewrite + the
+# shared helper, asserting the regenerated cache reflects the relay-stripped
+# channel set with the v2 workdir path.
+test_relay_cleanup_vector_refreshes_cache() {
+  local agent="relay-989"
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+
+  # Roster carries the legacy relay channel; load it (cache memo set).
+  write_isolated_roster "$agent" "plugin:telegram-relay@claude-plugins-official"
+  bridge_roster_cache_invalidate
+  bridge_load_roster
+
+  local env_file
+  env_file="$(bridge_agent_linux_env_file "$agent")"
+  mkdir -p "$(dirname "$env_file")"
+
+  # Run the REAL relay-cleanup tool against this roster (no backup —
+  # mirrors the in-upgrade caller). It rewrites BRIDGE_AGENT_CHANNELS to
+  # drop the relay item and ensure plugin:telegram@claude-plugins-official.
+  python3 "$REPO_ROOT/bridge-relay-cleanup.py" \
+    --target-root "$BRIDGE_HOME" \
+    --roster-file "$BRIDGE_ROSTER_LOCAL_FILE" \
+    --no-backup >/dev/null 2>&1
+
+  # Sanity: the relay channel is gone from the roster file on disk.
+  local roster_channels_line
+  roster_channels_line="$(grep "BRIDGE_AGENT_CHANNELS\[" "$BRIDGE_ROSTER_LOCAL_FILE" | head -n 1)"
+  smoke_assert_not_contains "$roster_channels_line" "telegram-relay" \
+    "T6 pre-condition: relay-cleanup stripped plugin:telegram-relay from the roster"
+
+  # The shared helper (the call the upgrade block now makes after
+  # relay-cleanup) must propagate that into the cached env file.
+  local rc=0
+  bridge_refresh_isolated_agent_env_after_channel_mutation "$agent" || rc=$?
+  smoke_assert_eq "0" "$rc" "T6 shared helper returns 0 after the relay-cleanup rewrite"
+
+  local channels_line workdir_line
+  channels_line="$(env_file_channels_line "$agent" "$env_file")"
+  smoke_assert_not_contains "$channels_line" "telegram-relay" \
+    "T6 regenerated cache no longer carries the legacy relay channel"
+  workdir_line="$(grep "^BRIDGE_AGENT_WORKDIR\[" "$env_file" | head -n 1)"
+  smoke_assert_contains "$workdir_line" "$BRIDGE_AGENT_ROOT_V2/$agent/workdir" \
+    "T6 regenerated cache carries the v2 workdir path"
+}
+
 # --- main --------------------------------------------------------------------
 
 # Each test reseeds the maps and runs in its own sub-shell so a stubbed
@@ -328,5 +461,11 @@ smoke_log "ok: T3 (idempotent — second call leaves the file byte-identical)"
 
 ( test_cache_staleness_guard ) || smoke_fail "T4 sub-shell failed"
 smoke_log "ok: T4 (cache invalidate+reload required before regen picks up roster changes)"
+
+( test_setup_style_mutation_refreshes_cache ) || smoke_fail "T5 sub-shell failed"
+smoke_log "ok: T5 (setup-style direct-write mutation + shared helper refreshes the cache)"
+
+( test_relay_cleanup_vector_refreshes_cache ) || smoke_fail "T6 sub-shell failed"
+smoke_log "ok: T6 (relay-cleanup roster rewrite + shared helper refreshes the cache)"
 
 smoke_log "passed"

--- a/scripts/smoke/989-isolated-agent-env-state-dir.sh
+++ b/scripts/smoke/989-isolated-agent-env-state-dir.sh
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/989-isolated-agent-env-state-dir.sh — Issue #989.
+#
+# Pins the contract that a roster mutation (channel-add / channel-remove /
+# launch-cmd edit) refreshes the cached `runtime/agent-env.sh` for a
+# linux-user isolated agent so the cached BRIDGE_AGENT_LAUNCH_CMD /
+# BRIDGE_AGENT_WORKDIR can never regress to a pre-v2 channel state path.
+#
+# The bug (#989, a regression of #771): `agent update --channels-*`
+# rewrote agent-roster.local.sh but never regenerated the cached
+# `runtime/agent-env.sh` — the ONLY roster snapshot an isolated UID can
+# read. The stale snapshot kept a launch cmd whose embedded
+# `TEAMS_STATE_DIR` pointed at the pre-v2 path `agents/<X>/.teams`
+# (owned ec2-user mode 700) instead of `agents/<X>/workdir/.teams`. The
+# isolated UID then got EACCES on the channel state dir and silently
+# stopped delivering inbound Teams messages.
+#
+# The fix introduced in this PR:
+#   `bridge_ensure_isolated_agent_env_current` (lib/bridge-agents.sh) —
+#   regenerates `runtime/agent-env.sh` via bridge_write_linux_agent_env_file
+#   for linux-user isolated agents, mirroring the isolation-v2-reapply
+#   recompute (lib/bridge-isolation-v2-reapply.sh:448-528). NO-OP for
+#   non-isolated agents. `run_update` calls it after the roster rewrite.
+#
+# Test plan (all run against the bash helpers, no live tmux / Claude):
+#   T1. Stale pre-v2 `runtime/agent-env.sh` → after the helper runs, the
+#       regenerated file carries the v2 `workdir/` path in
+#       BRIDGE_AGENT_WORKDIR (and never a bare base-dir path).
+#   T2. The helper is a NO-OP for a non-isolated (shared-mode) agent —
+#       a pre-existing agent-env.sh is left byte-identical (not even
+#       created if absent).
+#   T3. Idempotency — a second call against an already-canonical file
+#       leaves it byte-identical (mtime preserved).
+#   T4. Cache-staleness guard — pins the invalidate+reload+regen sequence
+#       `run_update` performs. `bridge_load_roster` short-circuits on
+#       BRIDGE_ROSTER_CACHE_LOADED=1 (issue #848 per-process memo), so a
+#       bare reload after a roster-file rewrite replays the pre-mutation
+#       maps and the regenerated env file misses the new channel. The
+#       fix invalidates the cache first. T4 proves both directions: bare
+#       reload → stale; invalidate+reload → fresh.
+#
+# Isolation: temp BRIDGE_HOME with v2 layout via smoke_setup_bridge_home;
+# the smoke never reads or writes the operator's live runtime.
+#
+# Footgun #11 (heredoc_write deadlock class): this fixture uses only
+# `printf '%s\n' >$tmp` and plain `cat >file <<EOF` bodies on flat
+# string variables — no command substitution feeding a heredoc-stdin,
+# no `<<<` here-strings into bridge functions.
+
+set -euo pipefail
+
+# Re-exec under Bash 4+ for associative arrays. macOS ships /bin/bash
+# 3.2 — match the recipe used by scripts/smoke/981-restart-session-resume-snapshot.sh.
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash"; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$_candidate" "${BASH_SOURCE[0]}" "$@"
+    fi
+  done
+  echo "[smoke:989-isolated-agent-env-state-dir] requires Bash 4+ (host is ${BASH_VERSION})" >&2
+  exit 1
+fi
+
+SMOKE_NAME="989-isolated-agent-env-state-dir"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "989-isolated-agent-env-state-dir"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# shellcheck source=bridge-lib.sh disable=SC1091
+source "$REPO_ROOT/bridge-lib.sh"
+
+if ! declare -F bridge_ensure_isolated_agent_env_current >/dev/null; then
+  smoke_fail "bridge_ensure_isolated_agent_env_current not defined after sourcing bridge-lib.sh"
+fi
+if ! declare -F bridge_write_linux_agent_env_file >/dev/null; then
+  smoke_fail "bridge_write_linux_agent_env_file not defined (sanity check)"
+fi
+if ! declare -F bridge_agent_linux_env_file >/dev/null; then
+  smoke_fail "bridge_agent_linux_env_file not defined (sanity check)"
+fi
+
+bridge_reset_roster_maps
+
+# --- shared fixture ----------------------------------------------------------
+
+# Seed a minimal in-memory agent record. The writer reads ~25 BRIDGE_AGENT_*
+# maps; seed every one it touches so bridge_write_linux_agent_env_file
+# produces a complete file. linux-user isolation is declared so
+# bridge_agent_workdir resolves the v2 anchor (BRIDGE_AGENT_ROOT_V2/<X>/workdir).
+seed_agent() {
+  local agent="$1"
+  local isolation="$2"
+  BRIDGE_AGENT_IDS=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent smoke fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]=""
+  BRIDGE_AGENT_PROFILE_HOME["$agent"]=""
+  BRIDGE_AGENT_LAUNCH_CMD["$agent"]="TEAMS_STATE_DIR=$BRIDGE_AGENT_ROOT_V2/$agent/.teams claude --plugin plugin:teams@agent-bridge"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_LOOP["$agent"]="1"
+  BRIDGE_AGENT_CONTINUE["$agent"]="1"
+  BRIDGE_AGENT_SESSION_ID["$agent"]=""
+  BRIDGE_AGENT_HISTORY_KEY["$agent"]=""
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_UPDATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_IDLE_TIMEOUT["$agent"]="600"
+  BRIDGE_AGENT_NOTIFY_KIND["$agent"]=""
+  BRIDGE_AGENT_NOTIFY_TARGET["$agent"]=""
+  BRIDGE_AGENT_NOTIFY_ACCOUNT["$agent"]=""
+  BRIDGE_AGENT_DISCORD_CHANNEL_ID["$agent"]=""
+  BRIDGE_AGENT_CHANNELS["$agent"]="plugin:teams@agent-bridge"
+  BRIDGE_AGENT_ISOLATION_MODE["$agent"]="$isolation"
+  BRIDGE_AGENT_OS_USER["$agent"]="agent-bridge-$agent"
+}
+
+# Plant a STALE pre-v2 runtime/agent-env.sh: BRIDGE_AGENT_WORKDIR points at
+# the bare base agent dir (no `/workdir`), exactly the shape a v0.7->v0.8
+# migrated agent's cache had before #771 / this fix.
+plant_stale_env_file() {
+  local agent="$1"
+  local env_file="$2"
+  mkdir -p "$(dirname "$env_file")"
+  cat >"$env_file" <<EOF
+#!/usr/bin/env bash
+# stale pre-v2 cache (smoke fixture)
+BRIDGE_AGENT_WORKDIR[$agent]=$BRIDGE_AGENT_ROOT_V2/$agent
+BRIDGE_AGENT_LAUNCH_CMD[$agent]='TEAMS_STATE_DIR=$BRIDGE_AGENT_ROOT_V2/$agent/.teams claude'
+EOF
+}
+
+# --- T1: stale isolated agent-env.sh is regenerated with the v2 path ---------
+
+test_isolated_regenerates_v2_path() {
+  local agent="iso-989"
+  seed_agent "$agent" "linux-user"
+
+  # Stub the isolation predicate to return 0 so the helper exercises the
+  # regenerate path on a non-Linux smoke host (mirrors the mocking
+  # convention in scripts/smoke/857-pr1-isolation-write-helper.sh). The
+  # writer's Linux-only chgrp/chmod branch is skipped because
+  # bridge_host_platform still reports the real (non-Linux) host.
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+
+  local env_file
+  env_file="$(bridge_agent_linux_env_file "$agent")"
+  plant_stale_env_file "$agent" "$env_file"
+
+  # Pre-condition: the planted file has the pre-v2 (bare base-dir) path.
+  local stale_workdir_line
+  stale_workdir_line="$(grep "BRIDGE_AGENT_WORKDIR\[$agent\]" "$env_file")"
+  smoke_assert_not_contains "$stale_workdir_line" "/workdir" \
+    "T1 pre-condition: planted env file has the stale pre-v2 path"
+
+  local rc=0
+  bridge_ensure_isolated_agent_env_current "$agent" || rc=$?
+  smoke_assert_eq "0" "$rc" "T1 helper returns 0 for an isolated agent"
+  smoke_assert_file_exists "$env_file" "T1 env file still exists after regen"
+
+  # The regenerated file must carry the v2 workdir anchor.
+  local fresh_workdir_line
+  fresh_workdir_line="$(grep "^BRIDGE_AGENT_WORKDIR\[" "$env_file" | head -n 1)"
+  smoke_assert_contains "$fresh_workdir_line" "$BRIDGE_AGENT_ROOT_V2/$agent/workdir" \
+    "T1 regenerated env file carries the v2 workdir path"
+
+  # And the channel state dir derived from workdir lands under workdir/.
+  local teams_dir
+  teams_dir="$(bridge_agent_teams_state_dir "$agent")"
+  smoke_assert_contains "$teams_dir" "/workdir/.teams" \
+    "T1 teams state dir resolves to the v2 workdir/.teams path"
+}
+
+# --- T2: NO-OP for a non-isolated (shared-mode) agent ------------------------
+
+test_non_isolated_noop() {
+  local agent="shared-989"
+  seed_agent "$agent" "shared"
+
+  # No isolation-predicate stub here: on this non-Linux smoke host
+  # bridge_agent_linux_user_isolation_effective returns 1 for a
+  # shared-mode agent, which is exactly the NO-OP gate we want to pin.
+  local env_file
+  env_file="$(bridge_agent_linux_env_file "$agent")"
+  mkdir -p "$(dirname "$env_file")"
+  printf '%s\n' "SENTINEL=untouched" >"$env_file"
+
+  local rc=0
+  bridge_ensure_isolated_agent_env_current "$agent" || rc=$?
+  smoke_assert_eq "0" "$rc" "T2 helper returns 0 (NO-OP) for a non-isolated agent"
+
+  local after
+  after="$(cat "$env_file")"
+  smoke_assert_eq "SENTINEL=untouched" "$after" \
+    "T2 non-isolated agent-env.sh left byte-identical (NO-OP)"
+}
+
+# --- T3: idempotency — a second call leaves the file unchanged ---------------
+
+test_idempotent_second_call() {
+  local agent="idem-989"
+  seed_agent "$agent" "linux-user"
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+
+  local env_file
+  env_file="$(bridge_agent_linux_env_file "$agent")"
+  mkdir -p "$(dirname "$env_file")"
+
+  # First call generates the canonical file.
+  bridge_ensure_isolated_agent_env_current "$agent"
+  smoke_assert_file_exists "$env_file" "T3 first call generated the env file"
+  local first_sum
+  first_sum="$(cksum <"$env_file")"
+
+  # Second call against an already-canonical file must not rewrite it.
+  local rc=0
+  bridge_ensure_isolated_agent_env_current "$agent" || rc=$?
+  smoke_assert_eq "0" "$rc" "T3 second call returns 0"
+  local second_sum
+  second_sum="$(cksum <"$env_file")"
+  smoke_assert_eq "$first_sum" "$second_sum" \
+    "T3 already-canonical env file left byte-identical on the second call"
+}
+
+# --- T4: cache-staleness guard (the invalidate+reload+regen sequence) --------
+
+# Write a roster file (agent-roster.local.sh) with a single isolated agent
+# whose channel set is `$channels`. v2 layout markers are already seeded by
+# smoke_setup_bridge_home.
+write_isolated_roster() {
+  local agent="$1"
+  local channels="$2"
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+BRIDGE_ADMIN_AGENT_ID=${agent}
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${agent}
+bridge_add_agent_id_if_missing ${agent}
+BRIDGE_AGENT_DESC["${agent}"]='isolated smoke fixture'
+BRIDGE_AGENT_ENGINE["${agent}"]='claude'
+BRIDGE_AGENT_SESSION["${agent}"]='${agent}'
+BRIDGE_AGENT_SOURCE["${agent}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${agent}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CHANNELS["${agent}"]='${channels}'
+BRIDGE_AGENT_ISOLATION_MODE["${agent}"]='linux-user'
+BRIDGE_AGENT_OS_USER["${agent}"]='agent-bridge-${agent}'
+BRIDGE_AGENT_CONTINUE["${agent}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${agent}
+EOF
+}
+
+# Extract the BRIDGE_AGENT_CHANNELS assignment for $agent from a generated
+# agent-env.sh (the writer emits it as `BRIDGE_AGENT_CHANNELS[<q>]=<q>`).
+env_file_channels_line() {
+  local agent="$1"
+  local env_file="$2"
+  grep "BRIDGE_AGENT_CHANNELS\[" "$env_file" | grep "$agent" | head -n 1
+}
+
+test_cache_staleness_guard() {
+  local agent="cache-989"
+  # shellcheck disable=SC2329
+  bridge_agent_linux_user_isolation_effective() { return 0; }
+
+  # 1. Roster on disk starts with ONLY teams; load it (sets the
+  #    per-process BRIDGE_ROSTER_CACHE_LOADED=1 memo, mirroring what
+  #    bridge-agent.sh does at script load before run_update).
+  write_isolated_roster "$agent" "plugin:teams@agent-bridge"
+  bridge_roster_cache_invalidate
+  bridge_load_roster
+
+  local env_file
+  env_file="$(bridge_agent_linux_env_file "$agent")"
+  mkdir -p "$(dirname "$env_file")"
+
+  # 2. Simulate a channel-add: rewrite the roster file on disk with an
+  #    extra channel (this is what bridge_write_role_block does inside
+  #    run_update — it only touches the file, not the in-memory maps).
+  write_isolated_roster "$agent" "plugin:teams@agent-bridge,plugin:discord@agent-bridge"
+
+  # 2a. Negative control: a BARE reload (no cache invalidation) is a
+  #     no-op because of the #848 memo, so the regenerated env file
+  #     still misses the new channel. This is the exact bug a missing
+  #     bridge_roster_cache_invalidate re-introduces.
+  bridge_load_roster
+  bridge_ensure_isolated_agent_env_current "$agent"
+  local stale_line
+  stale_line="$(env_file_channels_line "$agent" "$env_file")"
+  smoke_assert_not_contains "$stale_line" "discord" \
+    "T4 negative control: bare reload (no invalidate) replays stale maps — discord absent"
+
+  # 2b. The fix: invalidate THEN reload picks up the new channel from
+  #     disk; the regenerated env file now carries it.
+  bridge_roster_cache_invalidate
+  bridge_load_roster
+  bridge_ensure_isolated_agent_env_current "$agent"
+  local fresh_line
+  fresh_line="$(env_file_channels_line "$agent" "$env_file")"
+  smoke_assert_contains "$fresh_line" "discord" \
+    "T4 invalidate+reload+regen: regenerated env file carries the newly-added channel"
+  smoke_assert_contains "$fresh_line" "teams" \
+    "T4 invalidate+reload+regen: original channel still present"
+}
+
+# --- main --------------------------------------------------------------------
+
+# Each test reseeds the maps and runs in its own sub-shell so a stubbed
+# bridge_agent_linux_user_isolation_effective does not leak across cases.
+( test_isolated_regenerates_v2_path ) || smoke_fail "T1 sub-shell failed"
+smoke_log "ok: T1 (stale isolated agent-env.sh regenerated with v2 workdir path)"
+
+( test_non_isolated_noop ) || smoke_fail "T2 sub-shell failed"
+smoke_log "ok: T2 (NO-OP for non-isolated agent)"
+
+( test_idempotent_second_call ) || smoke_fail "T3 sub-shell failed"
+smoke_log "ok: T3 (idempotent — second call leaves the file byte-identical)"
+
+( test_cache_staleness_guard ) || smoke_fail "T4 sub-shell failed"
+smoke_log "ok: T4 (cache invalidate+reload required before regen picks up roster changes)"
+
+smoke_log "passed"


### PR DESCRIPTION
## Summary

- `agent update --channels-add/--channels-remove/--launch-cmd-*` rewrote `agent-roster.local.sh` but never refreshed the cached `runtime/agent-env.sh` — the only roster snapshot a linux-user isolated agent's UID can read. The stale cache kept a launch cmd whose embedded `TEAMS_STATE_DIR` (and sibling `*_STATE_DIR` vars) pointed at the pre-v2 path `agents/<X>/.teams` (owned `ec2-user` mode 700) instead of `agents/<X>/workdir/.teams`. The isolated UID then got `EACCES`, the Teams bun `server.ts` swallowed the failure (`catch {}`), and inbound Teams delivery silently stopped — a regression of #771.
- Adds `bridge_ensure_isolated_agent_env_current` in `lib/bridge-agents.sh`, which regenerates `runtime/agent-env.sh` via `bridge_write_linux_agent_env_file`, mirroring the `isolation-v2-reapply` recompute (`lib/bridge-isolation-v2-reapply.sh:448-528`): NO-OP for non-isolated agents, load-order guard on the writer + path helpers, mktemp + `cmp` idempotency short-circuit.
- `run_update` calls it after the roster rewrite — invalidating the per-process roster cache (#848 memo) and reloading first so the writer sees the new channels, then regenerating. A channel-list change can no longer leave the cached launch cmd with stale pre-v2 state paths.
- Adds `scripts/smoke/989-isolated-agent-env-state-dir.sh` (stale→v2 regen, non-isolated NO-OP, idempotency, and a cache-staleness guard with a negative control), registered in `scripts/smoke-test.sh`.

## High-risk area

Touches isolation (CLAUDE.md High-Risk Area #4). Internal codex pair-review: round 1 caught a BLOCKING cache-staleness bug (`run_update`'s bare `bridge_load_roster` short-circuited on `BRIDGE_ROSTER_CACHE_LOADED=1`); round 2 returned `implement-ok` after the `bridge_roster_cache_invalidate` fix, all 8 acceptance criteria pass.

## Test plan

- [x] `bash -n` + `shellcheck` on all changed files — PASS
- [x] `scripts/lint-heredoc-ban.sh --baseline-check` — PASS (ratchet green)
- [x] `scripts/smoke/989-isolated-agent-env-state-dir.sh` standalone — T1/T2/T3/T4 PASS
- [x] Mutation test: removing `bridge_roster_cache_invalidate` makes T4 FAIL — the regression test is load-bearing
- [x] Full `scripts/smoke-test.sh` — fails only at the pre-existing macOS "starting isolated tmux role" silent-kill (issue #946), reproduces identically on clean `main`, not a regression from this diff

## Manual verification (operator, Linux host)

Reproduced live on isolated agent `dev_mun` per issue #989:
1. `agb agent update <agent> --from <admin> --channels-add plugin:X@Y` for an isolated agent that has Teams working.
2. Confirm `runtime/agent-env.sh` immediately carries the v2 path: `grep TEAMS_STATE_DIR ~/.agent-bridge/agents/<agent>/runtime/agent-env.sh` should show `.../workdir/.teams`, not a bare `.../.teams`.
3. `agb agent restart <agent>`, send a Teams message, confirm `← teams` direct delivery and `agb inbox <agent>`.
4. `agb migrate isolation v2 --check --agent <agent>` should no longer report `agent_env_regen: drift`.

## Notes

- Pushed to `origin` (SYRS-AI) — `seanssoh` fork push was permission-denied.
- The issue's secondary ask (wiring `migrate isolation v2 --check` into the post-restart health check) was SKIPPED to keep scope tight — it is a separate health-surfacing concern. Recommend a follow-up issue. The primary fix (regenerate on roster mutation) is the must-have and is complete.
- Does not touch the Teams `server.ts` `catch {}` silent-swallow — that is a separate error-surfacing concern.

Fixes #989. Relates to #771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)