### PR TITLE
fix(socket): replace named-user ACEs with ab-shared group mode on queue gateway socket

### DIFF
--- a/bridge-queue-gateway.py
+++ b/bridge-queue-gateway.py
@@ -30,7 +30,6 @@ import os
 import pwd
 import secrets
 import signal
-import shutil
 import socket
 import sqlite3
 import stat
@@ -47,6 +46,7 @@ SOCKET_NAME = "queue-gateway.sock"
 MAX_SOCKET_BYTES = 2 * 1024 * 1024
 SOCKET_TIMEOUT_SECONDS = 5.0
 SOCKET_ACL_REFRESH_SECONDS = 30.0
+BRIDGE_SHARED_GROUP_DEFAULT = "ab-shared"
 INLINE_OVERHEAD_BYTES = 64 * 1024
 INLINE_BODY_CAP_BYTES = MAX_SOCKET_BYTES - INLINE_OVERHEAD_BYTES
 SOCKET_LINUX_ONLY_MESSAGE = (
@@ -367,8 +367,18 @@ def verify_runtime_layout(home: str) -> tuple[bool, str]:
         return False, "parent_owner_mode"
 
     child = inst.stat()
-    if child.st_uid != current_uid or stat.S_IMODE(child.st_mode) != 0o711:
+    if child.st_uid != current_uid:
         return False, "instance_owner_mode"
+    shared_grp = _shared_group()
+    is_live = str(gateway_runtime_root()) == LIVE_GATEWAY_RUNTIME_ROOT
+    if shared_grp is not None:
+        if stat.S_IMODE(child.st_mode) != 0o2770 or child.st_gid != shared_grp.gr_gid:
+            return False, "instance_owner_mode"
+    elif is_live:
+        return False, "instance_shared_group_missing"
+    else:
+        if stat.S_IMODE(child.st_mode) != 0o711:
+            return False, "instance_owner_mode"
 
     return True, "ok"
 
@@ -417,7 +427,11 @@ def _conf_contents(home: str) -> tuple[str, str]:
         parent_user = user
         parent_group = group
     parent = f"d {root} 0755 {parent_user} {parent_group} -\n"
-    child = f"d {inst} 0711 {user} {group} -\n"
+    shared_grp = _shared_group()
+    if shared_grp is not None:
+        child = f"d {inst} 2770 {user} {shared_grp.gr_name} -\n"
+    else:
+        child = f"d {inst} 0711 {user} {group} -\n"
     return parent, child
 
 
@@ -436,8 +450,13 @@ def _apply_tmpfiles_shim(home: str) -> None:
     if str(root) == LIVE_GATEWAY_RUNTIME_ROOT and os.geteuid() == 0:
         os.chown(root, 0, 0)
     inst.mkdir(parents=True, exist_ok=True)
-    os.chmod(inst, 0o711)
-    os.chown(inst, os.getuid(), os.getgid())
+    shared_grp = _shared_group()
+    if shared_grp is not None:
+        os.chown(inst, os.getuid(), shared_grp.gr_gid)
+        os.chmod(inst, 0o2770)
+    else:
+        os.chown(inst, os.getuid(), os.getgid())
+        os.chmod(inst, 0o711)
 
 
 def _sudo_available() -> bool:
@@ -780,53 +799,46 @@ def _socket_acl_refresh_seconds() -> float:
     return value
 
 
-def _run_setfacl(args: list[str], context: str) -> None:
-    proc = subprocess.run(
-        args,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-    )
-    if proc.returncode != 0:
-        detail = proc.stderr.strip() or f"setfacl exited {proc.returncode}"
-        raise SystemExit(f"queue gateway socket {context} failed: {detail}")
+def _shared_group() -> grp.struct_group | None:
+    """Return the ab-shared group struct, or None if not present on this host."""
+    name = os.environ.get("BRIDGE_SHARED_GROUP", BRIDGE_SHARED_GROUP_DEFAULT).strip()
+    try:
+        return grp.getgrnam(name)
+    except KeyError:
+        return None
 
 
-def _set_socket_acl(path: Path, peer_map: dict[int, str]) -> None:
-    """Restrict socket access to the controller plus known isolated peer UIDs."""
-    setfacl = shutil.which("setfacl")
-    if setfacl:
-        _run_setfacl([setfacl, "-b", str(path)], "ACL reset")
-    os.chmod(path, 0o600)
-    current_uid = os.getuid()
-    specs = []
-    for uid, agent in sorted(peer_map.items()):
-        if uid == current_uid:
-            continue
-        try:
-            user = pwd.getpwuid(uid).pw_name
-        except KeyError as exc:
-            raise SystemExit(f"queue gateway socket peer has no local user: uid={uid} agent={agent}") from exc
-        specs.append(f"u:{user}:rw")
+def _set_socket_group_mode(path: Path, live: bool = False) -> None:
+    """Set socket to group=ab-shared mode 0660 — no named-user ACEs needed.
 
-    if not specs:
+    All isolated agent OS users are ab-shared members, so they get access
+    automatically without per-agent setfacl. In live mode, a missing group
+    is a hard failure. In smoke/dev mode, fall back to 0600 (owner-only).
+    """
+    g = _shared_group()
+    if g is None:
+        name = os.environ.get("BRIDGE_SHARED_GROUP", BRIDGE_SHARED_GROUP_DEFAULT).strip()
+        if live:
+            raise SystemExit(
+                f"queue gateway socket requires group '{name}' (BRIDGE_SHARED_GROUP). "
+                f"Create the group and add all isolated agent users to it, then restart the daemon."
+            )
+        os.chmod(path, 0o600)
         return
-
-    if not setfacl:
-        raise SystemExit("queue gateway socket peer ACL requires setfacl for isolated UID peers")
-
-    _run_setfacl(
-        [setfacl, "-m", ",".join(specs + ["m::rw"]), str(path)],
-        "peer ACL",
-    )
+    os.chown(path, -1, g.gr_gid)
+    os.chmod(path, 0o660)
 
 
-def _refresh_socket_acl(path: Path, peer_map: dict[int, str], script_dir: Path) -> None:
+def _refresh_socket_perms(path: Path, peer_map: dict[int, str], script_dir: Path, live: bool = False) -> None:
+    """Refresh peer_map from roster and reassert group/mode on the socket.
+
+    peer_map is kept current for SO_PEERCRED authorization in _handle_socket_request.
+    The filesystem permission change (group mode) makes it self-healing on each tick.
+    """
     latest = _peer_map_from_roster(script_dir)
     peer_map.clear()
     peer_map.update(latest)
-    _set_socket_acl(path, peer_map)
+    _set_socket_group_mode(path, live=live)
 
 
 def _task_row(home: str, task_id: int) -> sqlite3.Row | None:
@@ -1225,6 +1237,7 @@ def cmd_socket_server(args: argparse.Namespace) -> int:
     queue_script = Path(args.queue_script).expanduser()
     script_dir = queue_script.resolve().parent
     peer_map = _peer_map_from_roster(script_dir)
+    is_live = str(gateway_runtime_root()) == LIVE_GATEWAY_RUNTIME_ROOT
     acl_refresh_seconds = _socket_acl_refresh_seconds()
     next_acl_refresh = time.monotonic() + acl_refresh_seconds
     running = True
@@ -1260,7 +1273,7 @@ def cmd_socket_server(args: argparse.Namespace) -> int:
             server.bind(str(path))
         finally:
             os.umask(old_umask)
-        _set_socket_acl(path, peer_map)
+        _set_socket_group_mode(path, live=is_live)
         server.listen(64)
         server.settimeout(1.0)
         print(f"queue_gateway_listener socket={path}", file=sys.stderr, flush=True)
@@ -1269,7 +1282,7 @@ def cmd_socket_server(args: argparse.Namespace) -> int:
                 conn, _addr = server.accept()
             except (TimeoutError, socket.timeout):
                 if time.monotonic() >= next_acl_refresh:
-                    _refresh_socket_acl(path, peer_map, script_dir)
+                    _refresh_socket_perms(path, peer_map, script_dir, live=is_live)
                     next_acl_refresh = time.monotonic() + acl_refresh_seconds
                 continue
             except OSError:

--- a/bridge-queue-gateway.py
+++ b/bridge-queue-gateway.py
@@ -513,12 +513,45 @@ def ensure_runtime_layout(home: str, strict: bool) -> bool:
         if not _sudo_install_tmpfiles(home):
             return False
     else:
-        print(
-            "queue gateway runtime setup requires root once; run: "
-            f"sudo install -d -m 0755 -o root -g root {gateway_runtime_root()} && "
-            f"sudo install -d -m 0711 -o {_user_name(os.getuid())} -g {_group_name(os.getgid())} {gateway_instance_dir(home)}",
-            file=sys.stderr,
-        )
+        # The remediation must match what verify_runtime_layout() now requires
+        # for the instance dir, which depends on whether the shared group is
+        # present and whether this is a live runtime root:
+        #   - shared group present  -> 2770, group=<shared group>
+        #   - absent + live         -> no valid layout; the group itself must
+        #                              be created first (the old 0711 layout
+        #                              can never pass the live verifier)
+        #   - absent + non-live     -> 0711 owner-only (smoke/dev fallback)
+        root = gateway_runtime_root()
+        inst = gateway_instance_dir(home)
+        shared_grp = _shared_group()
+        if shared_grp is not None:
+            print(
+                "queue gateway runtime setup requires root once; run: "
+                f"sudo install -d -m 0755 -o root -g root {root} && "
+                f"sudo install -d -m 2770 -o {_user_name(os.getuid())} "
+                f"-g {shared_grp.gr_name} {inst}",
+                file=sys.stderr,
+            )
+        elif str(root) == LIVE_GATEWAY_RUNTIME_ROOT:
+            name = os.environ.get(
+                "BRIDGE_SHARED_GROUP", BRIDGE_SHARED_GROUP_DEFAULT
+            ).strip()
+            print(
+                f"queue gateway runtime setup requires the '{name}' group "
+                "(override via BRIDGE_SHARED_GROUP). Create the group, add the "
+                "controller user and every isolated agent user to it, then "
+                "restart the daemon. The pre-ab-shared owner-only layout is no "
+                "longer accepted on a live runtime root.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "queue gateway runtime setup requires root once; run: "
+                f"sudo install -d -m 0755 -o root -g root {root} && "
+                f"sudo install -d -m 0711 -o {_user_name(os.getuid())} "
+                f"-g {_group_name(os.getgid())} {inst}",
+                file=sys.stderr,
+            )
         return not strict
 
     ok, reason = verify_runtime_layout(home)

--- a/scripts/smoke/queue.sh
+++ b/scripts/smoke/queue.sh
@@ -329,16 +329,25 @@ queue_gateway_socket_group_mode_contract() {
     socket_gid="$(stat -c '%g' "$socket_path")"
     [[ "$socket_gid" == "$shared_gid" ]] \
       || smoke_fail "socket group should be $shared_grp (gid=$shared_gid), got gid=$socket_gid"
-    [[ "$socket_mode" == *60 ]] \
-      || smoke_fail "socket mode should be ?660 (group-rw), got $socket_mode"
+    [[ "$socket_mode" == "660" ]] \
+      || smoke_fail "socket mode should be 660 (group-rw), got $socket_mode"
+    # Instance dir must also be owned by ab-shared with setgid+rwx (2770)
+    local instance_dir inst_gid inst_mode
+    instance_dir="$(dirname "$socket_path")"
+    inst_gid="$(stat -c '%g' "$instance_dir")"
+    inst_mode="$(stat -c '%a' "$instance_dir")"
+    [[ "$inst_gid" == "$shared_gid" ]] \
+      || smoke_fail "instance dir group should be $shared_grp (gid=$shared_gid), got gid=$inst_gid"
+    [[ "$inst_mode" == "2770" ]] \
+      || smoke_fail "instance dir mode should be 2770 (setgid+rwx), got $inst_mode"
     # No named-user ACL entries (if getfacl is available)
     if command -v getfacl >/dev/null 2>&1; then
-      local acl_body
+      local acl_body named_acl
       acl_body="$(getfacl -cp "$socket_path")"
-      # named-user entries look like "user:<name>:"; owner entry is "user::<perms>" (empty name)
-      if echo "$acl_body" | grep -qP '^user:[^:]+:[^:]+$' | grep -qv '^user::'; then
-        smoke_fail "socket must have no named-user ACL entries; got: $(echo "$acl_body" | grep '^user:[^:]')"
-      fi
+      # named-user entries look like "user:<name>:"; owner entry is "user::<perms>" (empty name field)
+      named_acl="$(printf '%s\n' "$acl_body" | grep -E '^user:[^:]+:' || true)"
+      [[ -z "$named_acl" ]] \
+        || smoke_fail "socket must have no named-user ACL entries; got: $named_acl"
     fi
   else
     # ab-shared absent (smoke/dev fallback): assert owner-only (mode 0600) and no world bits

--- a/scripts/smoke/queue.sh
+++ b/scripts/smoke/queue.sh
@@ -350,10 +350,10 @@ queue_gateway_socket_group_mode_contract() {
         || smoke_fail "socket must have no named-user ACL entries; got: $named_acl"
     fi
   else
-    # ab-shared absent (smoke/dev fallback): assert owner-only (mode 0600) and no world bits
+    # ab-shared absent (smoke/dev fallback): assert owner-only — exactly 0600.
     smoke_log "note: $shared_grp group not found; asserting fallback mode 0600"
-    [[ "$socket_mode" == *00 ]] \
-      || smoke_fail "socket fallback mode should be ?600, got $socket_mode"
+    [[ "$socket_mode" == "600" ]] \
+      || smoke_fail "socket fallback mode should be exactly 600, got $socket_mode"
   fi
 
   queue_gateway_stop_socket_server

--- a/scripts/smoke/queue.sh
+++ b/scripts/smoke/queue.sh
@@ -300,93 +300,106 @@ PY
   smoke_assert_not_contains "$log_body" "${secret}" "socket gateway log stays payload-free after restart"
 }
 
-queue_gateway_socket_acl_contract() {
-  local socket_path server_log nobody_uid acl_body socket_mode
-
-  if ! command -v setfacl >/dev/null 2>&1 || ! command -v getfacl >/dev/null 2>&1; then
-    smoke_log "skip: queue gateway socket peer ACL contract requires setfacl/getfacl"
-    return 0
-  fi
-  if ! nobody_uid="$(id -u nobody 2>/dev/null)"; then
-    smoke_log "skip: queue gateway socket peer ACL contract requires nobody user"
-    return 0
-  fi
+queue_gateway_socket_group_mode_contract() {
+  # Verifies that the socket uses group-mode permissions (ab-shared, mode 0660)
+  # instead of named-user ACEs. If BRIDGE_SHARED_GROUP / ab-shared does not
+  # exist on this host (smoke/dev), asserts graceful fallback to 0600 with no
+  # world bits set.
+  local socket_path server_log socket_mode socket_gid shared_grp shared_gid
 
   queue_gateway_stop_socket_server
   queue_gateway_socket_env
-  export BRIDGE_QUEUE_GATEWAY_PEERS="$(id -u):worker-a,${nobody_uid}:worker-b"
   BRIDGE_GATEWAY_PROXY=0 python3 "$SMOKE_REPO_ROOT/bridge-queue.py" init >/dev/null
   python3 "$SMOKE_REPO_ROOT/bridge-queue-gateway.py" ensure-runtime --bridge-home "$BRIDGE_HOME" --strict >/dev/null
   socket_path="$(queue_gateway_socket_path)"
-  server_log="$SMOKE_TMP_ROOT/queue-gateway-socket-acl.log"
+  server_log="$SMOKE_TMP_ROOT/queue-gateway-socket-group-mode.log"
   queue_gateway_start_socket_server "$socket_path" "$server_log"
 
   socket_mode="$(stat -c '%a' "$socket_path")"
+  # No world bits ever (last octet must be 0)
   case "$socket_mode" in
     *[1-7])
-      smoke_fail "queue gateway ACL socket must not be world-writable/readable; mode=$socket_mode"
+      smoke_fail "queue gateway socket must not be world-accessible; mode=$socket_mode"
       ;;
   esac
-  acl_body="$(getfacl -cp "$socket_path")"
-  smoke_assert_contains "$acl_body" "user:nobody:rw-" "socket ACL grants known non-controller peer UID"
-  smoke_assert_contains "$acl_body" "other::---" "socket ACL denies unknown users at filesystem layer"
+
+  shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+  if shared_gid="$(getent group "$shared_grp" 2>/dev/null | cut -d: -f3)" && [[ -n "$shared_gid" ]]; then
+    # ab-shared exists: assert group=ab-shared mode=0660
+    socket_gid="$(stat -c '%g' "$socket_path")"
+    [[ "$socket_gid" == "$shared_gid" ]] \
+      || smoke_fail "socket group should be $shared_grp (gid=$shared_gid), got gid=$socket_gid"
+    [[ "$socket_mode" == *60 ]] \
+      || smoke_fail "socket mode should be ?660 (group-rw), got $socket_mode"
+    # No named-user ACL entries (if getfacl is available)
+    if command -v getfacl >/dev/null 2>&1; then
+      local acl_body
+      acl_body="$(getfacl -cp "$socket_path")"
+      # named-user entries look like "user:<name>:"; owner entry is "user::<perms>" (empty name)
+      if echo "$acl_body" | grep -qP '^user:[^:]+:[^:]+$' | grep -qv '^user::'; then
+        smoke_fail "socket must have no named-user ACL entries; got: $(echo "$acl_body" | grep '^user:[^:]')"
+      fi
+    fi
+  else
+    # ab-shared absent (smoke/dev fallback): assert owner-only (mode 0600) and no world bits
+    smoke_log "note: $shared_grp group not found; asserting fallback mode 0600"
+    [[ "$socket_mode" == *00 ]] \
+      || smoke_fail "socket fallback mode should be ?600, got $socket_mode"
+  fi
 
   queue_gateway_stop_socket_server
 }
 
-queue_gateway_socket_acl_refresh_contract() {
-  local socket_path server_log nobody_uid acl_body current_user i
-
-  if ! command -v setfacl >/dev/null 2>&1 || ! command -v getfacl >/dev/null 2>&1; then
-    smoke_log "skip: queue gateway socket ACL refresh contract requires setfacl/getfacl"
-    return 0
-  fi
-  if ! nobody_uid="$(id -u nobody 2>/dev/null)"; then
-    smoke_log "skip: queue gateway socket ACL refresh contract requires nobody user"
-    return 0
-  fi
+queue_gateway_socket_perms_refresh_contract() {
+  # Verifies that _refresh_socket_perms reasserts group/mode on the socket
+  # (does not revert to 0600) after a refresh tick. Uses a 1-second interval.
+  # Uses env-based peer discovery to avoid the bash roster probe path, keeping
+  # this test focused on the permission-refresh invariant rather than discovery.
+  local socket_path server_log socket_mode socket_mode_after i _i
 
   queue_gateway_stop_socket_server
   queue_gateway_socket_env
-  unset BRIDGE_QUEUE_GATEWAY_PEERS
+  # Keep BRIDGE_QUEUE_GATEWAY_PEERS set (env-based discovery, same as group-mode
+  # contract). This avoids the roster probe subprocess that is not relevant here.
   export BRIDGE_QUEUE_GATEWAY_ACL_REFRESH_SECONDS=1
-  current_user="$(id -un)"
-  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
-bridge_add_agent_id_if_missing "worker-a"
-BRIDGE_AGENT_ENGINE["worker-a"]="claude"
-BRIDGE_AGENT_SESSION["worker-a"]="worker-a"
-BRIDGE_AGENT_WORKDIR["worker-a"]="$SMOKE_TMP_ROOT/worker-a"
-BRIDGE_AGENT_ISOLATION_MODE["worker-a"]="linux-user"
-BRIDGE_AGENT_OS_USER["worker-a"]="$current_user"
-EOF
-
   BRIDGE_GATEWAY_PROXY=0 python3 "$SMOKE_REPO_ROOT/bridge-queue.py" init >/dev/null
   python3 "$SMOKE_REPO_ROOT/bridge-queue-gateway.py" ensure-runtime --bridge-home "$BRIDGE_HOME" --strict >/dev/null
   socket_path="$(queue_gateway_socket_path)"
-  server_log="$SMOKE_TMP_ROOT/queue-gateway-socket-acl-refresh.log"
+  server_log="$SMOKE_TMP_ROOT/queue-gateway-socket-perms-refresh.log"
   queue_gateway_start_socket_server "$socket_path" "$server_log"
-  acl_body="$(getfacl -cp "$socket_path")"
-  smoke_assert_not_contains "$acl_body" "user:nobody:rw-" "socket ACL starts without future peer"
 
-  cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
-bridge_add_agent_id_if_missing "worker-b"
-BRIDGE_AGENT_ENGINE["worker-b"]="claude"
-BRIDGE_AGENT_SESSION["worker-b"]="worker-b"
-BRIDGE_AGENT_WORKDIR["worker-b"]="$SMOKE_TMP_ROOT/worker-b"
-BRIDGE_AGENT_ISOLATION_MODE["worker-b"]="linux-user"
-BRIDGE_AGENT_OS_USER["worker-b"]="nobody"
-EOF
+  # Wait for the server's "queue_gateway_listener" line: emitted after
+  # server.listen(), guaranteeing _set_socket_group_mode has completed.
+  for ((_i = 0; _i < 50; _i++)); do
+    grep -q "queue_gateway_listener" "$server_log" 2>/dev/null && break
+    sleep 0.1
+  done
+  if ! [[ -S "$socket_path" ]]; then
+    smoke_fail "socket vanished before first stat; log: $(cat "$server_log" 2>/dev/null || true)"
+  fi
 
-  for ((i = 0; i < 30; i++)); do
-    acl_body="$(getfacl -cp "$socket_path")"
-    if [[ "$acl_body" == *"user:nobody:rw-"* ]]; then
-      queue_gateway_stop_socket_server
-      unset BRIDGE_QUEUE_GATEWAY_ACL_REFRESH_SECONDS
-      return 0
-    fi
+  socket_mode="$(stat -c '%a' "$socket_path")"
+
+  # Wait for at least two refresh ticks (interval=1s, wait 3s) then re-stat.
+  # The refresh must reassert group/mode, not revert to 0600.
+  for ((i = 0; i < 15; i++)); do
     sleep 0.2
   done
-  smoke_fail "queue gateway socket ACL did not refresh for newly rostered isolated peer"
+
+  if ! [[ -S "$socket_path" ]]; then
+    smoke_fail "socket vanished during refresh wait; log: $(cat "$server_log" 2>/dev/null || true)"
+  fi
+  socket_mode_after="$(stat -c '%a' "$socket_path")"
+  [[ "$socket_mode_after" == "$socket_mode" ]] \
+    || smoke_fail "socket mode changed after perms refresh: before=$socket_mode after=$socket_mode_after"
+  case "$socket_mode_after" in
+    *[1-7])
+      smoke_fail "socket must not be world-accessible after refresh; mode=$socket_mode_after"
+      ;;
+  esac
+
+  queue_gateway_stop_socket_server
+  unset BRIDGE_QUEUE_GATEWAY_ACL_REFRESH_SECONDS
 }
 
 queue_gateway_socket_duplicate_uid_contract() {
@@ -1076,8 +1089,8 @@ main() {
   # the queue smoke suite green on operator workstations.
   if smoke_is_linux; then
     smoke_run "queue gateway socket peer auth contract" queue_gateway_socket_contract
-    smoke_run "queue gateway socket peer ACL contract" queue_gateway_socket_acl_contract
-    smoke_run "queue gateway socket ACL refresh contract" queue_gateway_socket_acl_refresh_contract
+    smoke_run "queue gateway socket group-mode contract" queue_gateway_socket_group_mode_contract
+    smoke_run "queue gateway socket perms refresh contract" queue_gateway_socket_perms_refresh_contract
     smoke_run "queue gateway socket duplicate UID contract" queue_gateway_socket_duplicate_uid_contract
     smoke_run "queue gateway body-file inlining contract" queue_gateway_body_file_inlining_contract
     smoke_run "queue gateway inline argv privacy contract" queue_gateway_inline_argv_privacy_contract


### PR DESCRIPTION
## Problem

The queue gateway socket used `setfacl` named-user ACEs to grant isolated agents access:
```
setfacl -m u:agent-bridge-<name>:rw- /run/agent-bridge/<hash>/queue.sock
```
This silently broke whenever a new isolated agent was added or the daemon restarted, because the ACE list was only updated on `_refresh_socket_acl` — and the refresh used a roster snapshot that could be stale. It also directly conflicted with the ACL deprecation policy declared in #857 and #865.

Fixes #994. Related: #857, #865, PR #992 (which fixed two other socket failures but deferred this one pending operator decision on ACL strategy).

## Solution

Replace named-user ACEs with group ownership: `chgrp ab-shared + chmod 0660` on the socket, and `chgrp ab-shared + chmod 2770` (setgid) on the instance dir.

All isolated agents are already members of `ab-shared` by the v2 isolation setup contract, so no per-agent ACL maintenance is needed. `SO_PEERCRED`-based request authorization (`peer_map`) is preserved — the change only affects filesystem access control.

### Behavior

| Condition | Socket | Instance dir |
|-----------|--------|-------------|
| `ab-shared` group exists | `chgrp ab-shared` + `chmod 0660` | `chgrp ab-shared` + `chmod 2770` |
| `ab-shared` absent (non-live) | `chmod 0600` (graceful fallback) | `chmod 0711` (existing behavior) |
| `ab-shared` absent (live mode) | `SystemExit` — fail-closed | — |

Live mode is detected by comparing `gateway_runtime_root()` against `LIVE_GATEWAY_RUNTIME_ROOT`. The group name is configurable via `BRIDGE_SHARED_GROUP` env var (default: `ab-shared`).

### Removed

- `_run_setfacl`, `_set_socket_acl`, `_refresh_socket_acl` — all setfacl surface removed
- `import shutil` (was only used for `shutil.which("setfacl")`)

### Added

- `BRIDGE_SHARED_GROUP_DEFAULT = "ab-shared"` constant
- `_shared_group() -> grp.struct_group | None`
- `_set_socket_group_mode(path, live=False)`
- `_refresh_socket_perms(path, peer_map, script_dir, live=False)` — reasserts group/mode on each refresh tick, still updates `peer_map` for SO_PEERCRED auth

## Smoke test changes

- Replaced `queue_gateway_socket_acl_contract` → `queue_gateway_socket_group_mode_contract`: asserts group=ab-shared, exact mode=660, no named-user ACL entries (via `getfacl` if available), and instance dir mode=2770 with gid=ab-shared
- Replaced `queue_gateway_socket_acl_refresh_contract` → `queue_gateway_socket_perms_refresh_contract`: waits for `queue_gateway_listener` log line to avoid stat race, asserts mode is stable after refresh ticks

## Verification

```bash
bash -n bridge-queue-gateway.py   # actually: python3 -c "import py_compile; py_compile.compile(...)"
bash -n scripts/smoke/queue.sh
shellcheck scripts/smoke/queue.sh
bash scripts/smoke/queue.sh       # all 15 queue gateway tests pass
```

Full `smoke-test.sh` exits 0. One pre-existing unrelated failure (`spool: count after 3 appends: expected 3, got N`) is unchanged.

## Review

Pair-reviewed by `patch-dev` (codex):
- Plan: tasks #3462 (r1 needs-more), #3464 (r2 plan-ok)
- Code review: tasks #3469 (r1 needs-more — smoke false-pass), #3473 (r2 implement-ok)

🤖 Generated with [Claude Code](https://claude.com/claude-code)