### PR TITLE
fix(backup): persistent exclude config via state/daily-backup/excludes.conf (closes #979)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -252,6 +252,13 @@ Backup 동작 조정 환경변수 (모두 `agent-roster.local.sh` 또는 systemd
 | `BRIDGE_UPGRADE_BACKUP_RETAIN_COUNT` | `5` | upgrade-* snapshot 최소 보존 개수 (현재 BACKUP_ROOT 는 항상 추가 보존). |
 | `BRIDGE_UPGRADE_BACKUP_RETAIN_DAYS` | `14` | retain count 를 넘긴 upgrade-* 중 이 일수보다 오래된 것만 prune. |
 
+추가 exclude 를 영구 설정하려면 (#979) env var 대신 `state/daily-backup/excludes.conf` 파일을 쓰는 것이 권장 방법이다 — 한 줄에 relpath 하나, `#` 로 시작하는 줄과 빈 줄은 무시한다. shell eval 이 없어 일반 에디터로 바로 편집할 수 있고 upgrade 후에도 유지된다. 파일이 없으면 무시되며, 최종 exclude 집합은 hardcoded ∪ `BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS` ∪ 이 파일의 합집합이다. 예시:
+
+```
+# regenerable plugin caches — see issue #974/#979
+agents/patch/home/.claude/plugins/cache
+```
+
 Health check (post-upgrade):
 
 ```bash

--- a/bridge-upgrade.py
+++ b/bridge-upgrade.py
@@ -724,6 +724,11 @@ DAILY_BACKUP_SQLITE_SNAPSHOT_TARGETS: tuple[tuple[str, str], ...] = (
 )
 
 DAILY_BACKUP_SNAPSHOT_DIR_REL = "state/backup-snapshots"
+# Issue #979: operator-facing persistent exclude config. One relpath per line,
+# `#`-prefixed and blank lines ignored. Read in addition to (union with) the
+# BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS env var and the hardcoded excludes — no
+# shell eval, so it's editable with a plain editor and survives upgrades.
+DAILY_BACKUP_EXCLUDES_CONF_REL = "state/daily-backup/excludes.conf"
 DAILY_BACKUP_LOCK_FILENAME = ".daily-backup.lock"
 DAILY_BACKUP_TMP_GLOB = "*.tgz.tmp.*"
 DAILY_BACKUP_FREE_SPACE_FLOOR_BYTES = 100 * 1024 * 1024  # 100 MiB
@@ -779,12 +784,42 @@ def _parse_extra_excluded_roots(value: str | None) -> list[tuple[str, ...]]:
     return parsed
 
 
+def _parse_excludes_conf_file(conf_path: Path) -> list[tuple[str, ...]]:
+    # Issue #979: parse the operator-facing excludes.conf — one relpath per
+    # line, `#`-prefixed lines and blank lines ignored, leading/trailing
+    # whitespace stripped. Each surviving line is normalized through
+    # `_parse_extra_excluded_roots` so it produces the same root tuples as the
+    # env var. A missing or unreadable file is treated as "no excludes".
+    try:
+        raw = conf_path.read_text(encoding="utf-8")
+    except (FileNotFoundError, NotADirectoryError):
+        return []
+    except OSError:
+        return []
+    parsed: list[tuple[str, ...]] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parsed.extend(_parse_extra_excluded_roots(stripped))
+    return parsed
+
+
 def resolve_daily_backup_excluded_roots(
     target_root: Path,
     backup_dir: Path,
     *,
     extra_excludes_env: str | None = None,
 ) -> list[tuple[str, ...]]:
+    # Excluded roots are the UNION of three sources, none of which overrides
+    # another (Issue #979):
+    #   1. DAILY_BACKUP_HARDCODED_ROOT_EXCLUDES — baked-in defaults.
+    #   2. BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS env var — one-shot / daemon-env.
+    #   3. <target_root>/state/daily-backup/excludes.conf — operator-facing
+    #      persistent config, the recommended way to set excludes permanently.
+    # The file path derives from target_root so isolated-BRIDGE_HOME tests and
+    # non-standard installs resolve it correctly. Order-equivalent duplicates
+    # are dropped while preserving first-seen order.
     excluded: list[tuple[str, ...]] = list(DAILY_BACKUP_HARDCODED_ROOT_EXCLUDES)
     try:
         relative_backup_dir = backup_dir.resolve().relative_to(target_root.resolve())
@@ -795,7 +830,17 @@ def resolve_daily_backup_excluded_roots(
     if extra_excludes_env is None:
         extra_excludes_env = os.environ.get("BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS", "")
     excluded.extend(_parse_extra_excluded_roots(extra_excludes_env))
-    return excluded
+    excluded.extend(
+        _parse_excludes_conf_file(target_root / DAILY_BACKUP_EXCLUDES_CONF_REL)
+    )
+    deduped: list[tuple[str, ...]] = []
+    seen: set[tuple[str, ...]] = set()
+    for parts in excluded:
+        if parts in seen:
+            continue
+        seen.add(parts)
+        deduped.append(parts)
+    return deduped
 
 
 def should_skip_daily_backup_relpath(

--- a/scripts/smoke/daily-backup-excludes-conf-test.py
+++ b/scripts/smoke/daily-backup-excludes-conf-test.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Issue #979 regression — exercise the excludes.conf union in
+`resolve_daily_backup_excluded_roots`.
+
+Standalone helper for `scripts/smoke/daily-backup.sh::step_excludes_conf_file`.
+Extracted to its own file to keep the smoke script free of
+heredoc-in-command-substitution patterns (Footgun #11 ratchet —
+see `lib/upgrade-helpers/` and CLAUDE.md §"Recent critical patches").
+
+Usage:
+    python3 scripts/smoke/daily-backup-excludes-conf-test.py \\
+        <bridge-upgrade.py> <bridge-home>
+
+The caller is expected to have created
+`<bridge-home>/state/daily-backup/excludes.conf` first. Exits 0 on PASS
+(with `PASS (<N> checks)` to stdout), 1 on FAIL (with per-check
+diagnostics to stdout).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+
+def _load_bridge_upgrade(path: str):
+    spec = importlib.util.spec_from_file_location(
+        "bridge_upgrade", str(pathlib.Path(path).resolve())
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load spec for {path!r}")
+    mod = importlib.util.module_from_spec(spec)
+    # Register in sys.modules BEFORE exec so dataclass+ClassVar field
+    # resolution can introspect the module under Python 3.9 (the dataclass
+    # machinery looks up cls.__module__ in sys.modules).
+    sys.modules["bridge_upgrade"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} <bridge-upgrade.py> <bridge-home>", file=sys.stderr)
+        return 2
+
+    mod = _load_bridge_upgrade(argv[1])
+    target_root = pathlib.Path(argv[2]).resolve()
+    backup_dir = target_root / "backups" / "daily"
+
+    failures: list[str] = []
+    checks = 0
+
+    def expect(parts: tuple[str, ...], present: bool, label: str, resolved) -> None:
+        nonlocal checks
+        checks += 1
+        got = parts in resolved
+        if got != present:
+            failures.append(
+                f"{label}: {'/'.join(parts)} expected_present={present} got={got}"
+            )
+
+    # Resolve with NO env var — the conf file is the only extra source.
+    resolved_file_only = mod.resolve_daily_backup_excluded_roots(
+        target_root, backup_dir, extra_excludes_env=""
+    )
+    # conf-file relpaths land in the excluded set
+    expect(("agents", "patch", "home", ".claude", "plugins", "cache"),
+           True, "conf relpath A present", resolved_file_only)
+    expect(("state", "huge-regenerable"), True,
+           "conf relpath B present", resolved_file_only)
+    # comment / blank lines are ignored — the `#`-prefixed token must not leak
+    for parts in resolved_file_only:
+        if any(p.startswith("#") for p in parts):
+            failures.append(f"comment line leaked into excludes: {parts}")
+    # a path that only appears in a comment line must NOT be excluded
+    expect(("commented", "out", "path"), False,
+           "commented-out path absent", resolved_file_only)
+    # hardcoded excludes still present alongside the file
+    expect(("logs",), True, "hardcoded exclude survives", resolved_file_only)
+
+    # Resolve WITH an env var — file + env must both contribute (union).
+    resolved_union = mod.resolve_daily_backup_excluded_roots(
+        target_root, backup_dir,
+        extra_excludes_env="env/only/dir:another/env/dir",
+    )
+    expect(("env", "only", "dir"), True,
+           "env exclude present alongside file", resolved_union)
+    expect(("agents", "patch", "home", ".claude", "plugins", "cache"),
+           True, "conf relpath still present with env set", resolved_union)
+    expect(("logs",), True, "hardcoded still present in union", resolved_union)
+
+    # No order-equivalent duplicates in the resolved list.
+    if len(resolved_union) != len(set(resolved_union)):
+        failures.append("resolved excluded list contains duplicate tuples")
+
+    if failures:
+        print("FAIL")
+        for f in failures:
+            print("  -", f)
+        return 1
+    print(f"PASS ({checks} checks)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/smoke/daily-backup.sh
+++ b/scripts/smoke/daily-backup.sh
@@ -326,6 +326,38 @@ step_path_part_excludes_multicomponent() {
   smoke_log "path-part excludes OK ($result)"
 }
 
+# issue #979 — operator-facing persistent exclude config. The resolver
+# must read state/daily-backup/excludes.conf (one relpath per line, `#`
+# comments + blank lines ignored) and UNION it with the env var and the
+# hardcoded excludes — none overrides another.
+step_excludes_conf_file() {
+  smoke_log "step 9: excludes.conf persistent config (#979 regression)"
+  setup_bridge_home
+
+  mkdir -p "$BRIDGE_HOME/state/daily-backup"
+  # One relpath per line + a `#` comment + a blank line. The commented
+  # path must not leak into the resolved excludes.
+  {
+    printf '# regenerable plugin caches — see issue #974/#979\n'
+    printf 'agents/patch/home/.claude/plugins/cache\n'
+    printf '\n'
+    printf '   state/huge-regenerable   \n'
+    printf '# commented/out/path\n'
+  } >"$BRIDGE_HOME/state/daily-backup/excludes.conf"
+
+  # Helper extracted to its own .py file to avoid heredoc-in-command-
+  # substitution (Footgun #11 ratchet — see lib/upgrade-helpers/).
+  local result
+  result="$(python3 "$SCRIPT_DIR/daily-backup-excludes-conf-test.py" \
+    "$SMOKE_REPO_ROOT/bridge-upgrade.py" "$BRIDGE_HOME" 2>&1)" \
+    || smoke_fail "excludes.conf resolver failed: $result"
+
+  if [[ "$result" != PASS* ]]; then
+    smoke_fail "excludes.conf resolver unexpected output: $result"
+  fi
+  smoke_log "excludes_conf_file OK ($result)"
+}
+
 main() {
   smoke_log "starting issue #507 regression smoke"
   step_snapshot_content
@@ -336,6 +368,7 @@ main() {
   step_cleanup_residue_happy_path
   step_timeout_resolution
   step_path_part_excludes_multicomponent
+  step_excludes_conf_file
   smoke_log "all daily-backup checks passed"
 }
 


### PR DESCRIPTION
## Summary

Closes #979. `BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS` is the env var for excluding large directories from the daily backup, but there was no clean way to set it persistently — the operator had to hand-edit `agent-roster.local.sh` (a shell file), and the config-guard hook blocks that edit.

**Operator chose Option 3** from the issue: a dedicated config file. The daily-backup exclude resolver now reads `state/daily-backup/excludes.conf` (one relpath per line, `#`-prefixed and blank lines ignored) in addition to — UNION with, none overriding — the hardcoded excludes and the `BRIDGE_DAILY_BACKUP_EXCLUDE_ROOTS` env var. No shell eval, editable with a plain editor, survives upgrades.

## Changes

- **`bridge-upgrade.py`** — `DAILY_BACKUP_EXCLUDES_CONF_REL` constant + `_parse_excludes_conf_file()` (reuses `_parse_extra_excluded_roots` for line normalization; graceful on missing/unreadable file) + `resolve_daily_backup_excluded_roots()` extended to union the file and dedupe preserving first-seen order. File path derived from `target_root` so isolated-`BRIDGE_HOME` tests resolve correctly.
- **`OPERATIONS.md`** — documents the file as the recommended persistent way to set excludes, with a worked example. (The new prose was placed *after* the env-var table, not inside it, to avoid splitting the markdown table.)
- **`scripts/smoke/daily-backup.sh`** — new step 9 exercising the resolver against a seeded `excludes.conf` (7 checks: file relpaths present, `#`-comment and blank lines ignored, env-var excludes still work alongside the file).
- **`scripts/smoke/daily-backup-excludes-conf-test.py`** — standalone helper invoked file-as-argv (no heredoc-in-command-substitution, per the footgun #11 ratchet).

## Operator usage

```
# ~/.agent-bridge/state/daily-backup/excludes.conf
# regenerable plugin caches — see issue #974/#979
agents/patch/home/.claude/plugins/cache
```

## Test plan

- [x] `python3 -m py_compile bridge-upgrade.py scripts/smoke/daily-backup-excludes-conf-test.py` — clean
- [x] `bash -n scripts/smoke/daily-backup.sh` — clean
- [x] `scripts/smoke/daily-backup.sh` — 9/9 steps pass (`excludes_conf_file OK (PASS (7 checks))`)
- [x] `scripts/lint-heredoc-ban.sh --baseline-check` — PASS at baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
