### PR TITLE
[antigravity wave] C1 — agy launch contract: settings preseed + launch builder + bootstrap

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -162,6 +162,7 @@ bridge_ensure_memory_precompact_hook() {
 
 bridge_agent_default_launch_cmd() {
   local engine="$1"
+  local agent="${2:-}"
 
   case "$engine" in
     claude)
@@ -180,12 +181,13 @@ bridge_agent_default_launch_cmd() {
       printf '%s' 'codex -c features.fast_mode=true --dangerously-bypass-approvals-and-sandbox --no-alt-screen'
       ;;
     antigravity)
-      # Antigravity wave (Track A0): minimal launch command so static
-      # `create --engine antigravity` succeeds end-to-end. This is the
-      # bare form (no `-i` bootstrap) — actual launch is still blocked by
-      # the temporary guard in bridge-start.sh. Track C1 upgrades this
-      # arm to the bootstrap-carrying contract.
-      printf '%s' 'agy --dangerously-skip-permissions'
+      # Antigravity wave (Track C1): a static agy agent's stored roster
+      # launch_cmd carries the mandatory `-i` bootstrap (the SessionStart-
+      # injection analogue) via the canonical launch builder. The fresh
+      # form is selected by passing continue=0 / empty session_id. When no
+      # agent id is supplied (defensive call sites) the builder still emits
+      # a well-formed bootstrap prompt addressed to the bare role name.
+      bridge_antigravity_dynamic_launch_cmd "$agent" 0 ""
       ;;
     *)
       bridge_die "지원하지 않는 engine 입니다: $engine"
@@ -1085,7 +1087,7 @@ bridge_agent_reclassify_static_admin() {
   workdir="$(bridge_expand_user_path "$(bridge_agent_workdir "$agent")")"
   profile_home="$(bridge_expand_user_path "$(bridge_agent_profile_home "$agent")")"
   launch_cmd="$(bridge_agent_launch_cmd_raw "$agent")"
-  [[ -n "$launch_cmd" ]] || launch_cmd="$(bridge_agent_default_launch_cmd "$engine")"
+  [[ -n "$launch_cmd" ]] || launch_cmd="$(bridge_agent_default_launch_cmd "$engine" "$agent")"
   channels="$(bridge_agent_channels_csv "$agent")"
   discord_channel="$(bridge_agent_discord_channel_id "$agent")"
   notify_kind="$(bridge_agent_notify_kind "$agent")"
@@ -2695,7 +2697,7 @@ report and reap test-fixture agents per their pattern."
   description="${description:-$agent static role}"
   display_name="${display_name:-$agent}"
   role_text="${role_text:-Long-lived agent role}"
-  launch_cmd="${launch_cmd:-$(bridge_agent_default_launch_cmd "$engine")}"
+  launch_cmd="${launch_cmd:-$(bridge_agent_default_launch_cmd "$engine" "$agent")}"
   channels="$(bridge_normalize_channels_csv "$channels")"
   users_json="$(bridge_normalize_user_specs_json "${user_specs[@]}")"
   if [[ "$isolation_mode" == "linux-user" ]]; then

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -361,6 +361,11 @@ bridge_source_module "bridge-agents.sh"
 # helpers depend on bridge_agent_os_user /
 # bridge_agent_linux_user_isolation_effective.
 bridge_source_module "bridge-isolation-helpers.sh"
+# Antigravity (`agy`) launch contract (Track C1). Sourced after bridge-core.sh
+# / bridge-agents.sh (its deps: bridge_join_quoted, bridge_require_python,
+# bridge_resolve_script_dir_check, BRIDGE_HOME) and before bridge-skills.sh /
+# bridge-state.sh, which call its launch-builder + path helpers.
+bridge_source_module "bridge-antigravity.sh"
 bridge_source_module "bridge-guard.sh"
 bridge_source_module "bridge-tmux.sh"
 bridge_source_module "bridge-skills.sh"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -356,17 +356,6 @@ WORK_DIR="$(bridge_agent_workdir "$AGENT")"
 DEFAULT_WORK_DIR="$(bridge_agent_default_home "$AGENT")"
 ENGINE="$(bridge_agent_engine "$AGENT")"
 
-# Antigravity wave (Track A0): temporary no-launch guard. A0 makes every
-# public surface ACCEPT the `antigravity` engine (CLI flags, wave, static
-# create/update) but the launch path is not built yet. bridge-start.sh is
-# the single launch chokepoint — both the `agent-bridge` dynamic path
-# (which execs into here) and direct static starts pass through — so the
-# intermediate integration state fails loudly on every launch attempt.
-# Temporary guard — Track C1 removes it when the agy launch branch lands.
-if [[ "$ENGINE" == "antigravity" ]]; then
-  bridge_die "antigravity 엔진 런치 경로는 아직 준비되지 않았습니다 (C1 트랙 대기)"
-fi
-
 RUNNER="$SCRIPT_DIR/bridge-run.sh"
 ENV_PREFIX="$(bridge_export_env_prefix)"
 EFFECTIVE_CONTINUE_MODE="$(bridge_agent_continue "$AGENT")"
@@ -508,6 +497,25 @@ elif [[ "$ENGINE" == "codex" && $SAFE_MODE -eq 0 ]]; then
   fi
   if ! bridge_ensure_codex_hooks >/dev/null; then
     bridge_die "Codex hook 설정에 실패했습니다: $WORK_DIR"
+  fi
+elif [[ "$ENGINE" == "antigravity" && $SAFE_MODE -eq 0 ]]; then
+  # Antigravity wave (Track C1): the real agy launch path. agy has no
+  # native Claude-style SessionStart-hook surface, so there are no hook
+  # ensures here — the launch-time `agy -i <bootstrap-prompt>` (built by
+  # bridge_antigravity_dynamic_launch_cmd) is the SessionStart analogue.
+  # Preseed the agy settings.json BEFORE launch: trust the workdir
+  # (pre-empts the trust selector), allow the bridge CLIs, and force
+  # altScreenMode=inline so tmux capture-pane idle detection works.
+  if ! bridge_antigravity_settings_preseed "$WORK_DIR"; then
+    bridge_warn "Antigravity settings preseed skipped or failed: $WORK_DIR"
+  fi
+  if ! bridge_project_skill_bootstrap_needed "$ENGINE" "$WORK_DIR"; then
+    FORCE_FRESH_SESSION=1
+  fi
+  if [[ $INSTALL_PROJECT_SKILL -eq 1 ]]; then
+    if ! bridge_bootstrap_project_skill "$ENGINE" "$WORK_DIR"; then
+      bridge_warn "Antigravity bridge skill bootstrap skipped or conflicted: $WORK_DIR"
+    fi
   fi
 fi
 

--- a/lib/bridge-antigravity.sh
+++ b/lib/bridge-antigravity.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# lib/bridge-antigravity.sh — Antigravity (`agy`) launch contract.
+#
+# Track C1 of the Antigravity engine wave. This module owns everything the
+# bridge needs to make a managed `agy` agent actually spawnable WITH the
+# bridge context the Claude/Codex agents get via SessionStart hooks:
+#
+#   - bridge_antigravity_settings_preseed — atomic preseed of the agy
+#     settings.json (trust workspace, allow the bridge CLIs, force
+#     altScreenMode=inline so tmux idle detection works).
+#   - bridge_antigravity_dynamic_launch_cmd — builds the launch argv with
+#     the mandatory `-i <bootstrap-prompt>` for fresh sessions and the
+#     `--conversation <id>` resume form.
+#   - conversation-state path helpers under ~/.gemini/antigravity-cli/
+#     (consumed by Track A1's conversation-id detector).
+#
+# agy has no native Claude-style SessionStart hook surface; the launch-time
+# `agy -i <bootstrap-prompt>` form is the SessionStart-injection analogue.
+# Depends on lib/bridge-core.sh (bridge_join_quoted, bridge_require_python,
+# bridge_resolve_script_dir_check) and is sourced by bridge-lib.sh after
+# bridge-core.sh / bridge-agents.sh and before bridge-state.sh /
+# bridge-skills.sh which call into it.
+
+# --- agy config / conversation-state paths -------------------------------
+
+# Root of the agy CLI config + conversation state. Honors GEMINI_HOME for
+# isolated tests; defaults to ~/.gemini.
+bridge_antigravity_config_root() {
+  printf '%s/antigravity-cli' "${GEMINI_HOME:-$HOME/.gemini}"
+}
+
+# Path to the agy settings.json (trust + permissions + altScreenMode).
+bridge_antigravity_settings_file() {
+  printf '%s/settings.json' "$(bridge_antigravity_config_root)"
+}
+
+# Directory holding per-conversation state. Track A1 builds its
+# conversation-id detector on top of this helper — keep it stable.
+bridge_antigravity_conversation_state_dir() {
+  printf '%s/conversations' "$(bridge_antigravity_config_root)"
+}
+
+# Path to the agy conversation history index (one JSON object per line).
+# Also consumed by Track A1's detector.
+bridge_antigravity_history_file() {
+  printf '%s/history.jsonl' "$(bridge_antigravity_config_root)"
+}
+
+# --- settings / trust preseed --------------------------------------------
+
+# bridge_antigravity_settings_preseed <workdir>
+#
+# Atomic read-modify-write of the agy settings.json: add <workdir> to
+# trustedWorkspaces (pre-empts the trust selector), add the bridge CLIs to
+# permissions.allow, and force altScreenMode=inline. All pre-existing keys
+# are preserved; idempotent. Runs BEFORE launch — not a reactive tmux
+# workaround. The JSON mutation is done by a standalone python helper
+# invoked file-as-argv (no heredoc-stdin — footgun #11).
+bridge_antigravity_settings_preseed() {
+  local workdir="$1"
+  local settings_file agb_path agent_bridge_path
+
+  if [[ -z "$workdir" ]]; then
+    bridge_warn "antigravity settings preseed: empty workdir; skipping."
+    return 1
+  fi
+
+  bridge_require_python
+  if ! bridge_resolve_script_dir_check; then
+    return 1
+  fi
+
+  settings_file="$(bridge_antigravity_settings_file)"
+  # The bridge CLIs live in the live runtime root ($BRIDGE_HOME), which is
+  # what an agy agent invokes (`~/.agent-bridge/agb`, `agent-bridge`).
+  agb_path="$BRIDGE_HOME/agb"
+  agent_bridge_path="$BRIDGE_HOME/agent-bridge"
+
+  python3 "$BRIDGE_SCRIPT_DIR/scripts/python-helpers/antigravity-settings-preseed.py" \
+    "$settings_file" "$workdir" "$agb_path" "$agent_bridge_path"
+}
+
+# --- launch-time bootstrap prompt ----------------------------------------
+
+# bridge_antigravity_bootstrap_prompt <agent>
+#
+# The `-i` bootstrap prompt — the SessionStart-injection analogue for agy.
+# It points the agent at its on-disk context (SOUL.md / CLAUDE.md in the
+# workdir) and the queue signal (`agb inbox <agent>`), mirroring the intent
+# of the Claude SessionStart hook (hooks/bridge_hook_common.py
+# session_start_context). Emitted as a single well-formed line so it quotes
+# cleanly into the launch argv.
+bridge_antigravity_bootstrap_prompt() {
+  local agent="$1"
+  local inbox_cli="${BRIDGE_HOME:-$HOME/.agent-bridge}/agb"
+
+  printf '%s' \
+"[Agent Bridge] You are the managed agent '${agent}'. Before any other work: \
+read SOUL.md and CLAUDE.md in this working directory for your role and \
+project context, then run exactly '${inbox_cli} inbox ${agent}' to pull \
+your queued tasks. Use the agent-bridge queue (claim / done) for all \
+inter-agent work; reserve urgent sends for true interrupts."
+}
+
+# --- launch-command builder ----------------------------------------------
+
+# bridge_antigravity_dynamic_launch_cmd <agent> <continue> <session_id>
+#
+# Builds the agy launch argv:
+#   fresh  : agy --dangerously-skip-permissions -i <bootstrap-prompt>
+#   resume : agy --dangerously-skip-permissions --conversation <session_id>
+#
+# The `-i` bootstrap is for FRESH sessions only. A resumed conversation
+# already carries its prior context, so the resume form skips `-i` — this
+# mirrors how the claude/codex resume builders skip fresh-session bootstrap
+# (bridge-state.sh bridge_build_resume_launch_cmd). Resume is selected only
+# when continue=1 AND a non-empty session_id is supplied.
+bridge_antigravity_dynamic_launch_cmd() {
+  local agent="$1"
+  local continue_mode="$2"
+  local session_id="$3"
+
+  if [[ "$continue_mode" == "1" && -n "$session_id" ]]; then
+    bridge_join_quoted agy --dangerously-skip-permissions \
+      --conversation "$session_id"
+    return 0
+  fi
+
+  bridge_join_quoted agy --dangerously-skip-permissions \
+    -i "$(bridge_antigravity_bootstrap_prompt "$agent")"
+}

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -27,6 +27,12 @@ bridge_project_skill_dir_for() {
     codex)
       printf '%s/.agents/skills/agent-bridge' "$workdir"
       ;;
+    antigravity)
+      # Track C1: agy reuses codex's `.agents/skills/` path — the skill
+      # content is engine-neutral markdown and agy can also pull it via
+      # `agy plugin import claude`.
+      printf '%s/.agents/skills/agent-bridge' "$workdir"
+      ;;
     claude)
       printf '%s/.claude/skills/agent-bridge' "$workdir"
       ;;
@@ -796,6 +802,16 @@ Use this skill when the task depends on the shared agent bridge in \`${bridge_ho
 EOF
 }
 
+# Track C1: the agy project skill is byte-identical to codex's — both are
+# `.agents/skills/agent-bridge` engine-neutral markdown. Delegate rather
+# than duplicate the body so the two renderers cannot drift. The arm in
+# bridge_bootstrap_project_skill must still exist and call this (not fall
+# through `*) return 0`), otherwise `bridge_bootstrap_project_skill
+# antigravity` would silently write nothing.
+bridge_render_antigravity_project_skill() {
+  bridge_render_codex_project_skill "$@"
+}
+
 bridge_render_claude_project_skill() {
   local bridge_home="$1"
 
@@ -871,6 +887,10 @@ bridge_bootstrap_project_skill() {
     codex)
       legacy_skill_dir="$workdir/.agents/skills/agent-bridge-project"
       ;;
+    antigravity)
+      # Track C1: agy shares codex's `.agents/skills/` path.
+      legacy_skill_dir="$workdir/.agents/skills/agent-bridge-project"
+      ;;
     claude)
       legacy_skill_dir="$workdir/.claude/skills/agent-bridge-project"
       ;;
@@ -882,6 +902,11 @@ bridge_bootstrap_project_skill() {
   case "$engine" in
     codex)
       bridge_render_codex_project_skill "$BRIDGE_HOME" | bridge_write_managed_markdown "$skill_file" "Codex bridge skill" || return 1
+      ;;
+    antigravity)
+      # Track C1: explicit arm — without it the `*) return 0` below would
+      # make `bridge_bootstrap_project_skill antigravity` a silent no-op.
+      bridge_render_antigravity_project_skill "$BRIDGE_HOME" | bridge_write_managed_markdown "$skill_file" "Antigravity bridge skill" || return 1
       ;;
     claude)
       bridge_render_claude_project_skill "$BRIDGE_HOME" | bridge_write_managed_markdown "$skill_file" "Claude bridge skill" || return 1

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -130,6 +130,13 @@ bridge_build_dynamic_launch_cmd() {
       fi
       bridge_claude_dynamic_launch_cmd "$agent" "$effective_continue" "$continue_fallback" "$session_id"
       ;;
+    antigravity)
+      # Track C1: agy carries the mandatory `-i` bootstrap on fresh
+      # sessions; resume (continue=1 + a non-empty session_id) uses the
+      # `--conversation <id>` form. The session_id here is hydrated by
+      # bridge_normalize_agent_session_id above (the non-claude branch).
+      bridge_antigravity_dynamic_launch_cmd "$agent" "$continue_mode" "$session_id"
+      ;;
     *)
       printf '%s' "${BRIDGE_AGENT_LAUNCH_CMD[$agent]-}"
       ;;
@@ -177,6 +184,12 @@ bridge_build_resume_launch_cmd() {
       else
         printf '%s' "$resume_cmd"
       fi
+      ;;
+    antigravity)
+      # Track C1: the early-return guard above already proved
+      # continue_mode==1 and session_id non-empty, so the launch builder
+      # deterministically emits the `--conversation <id>` resume form.
+      bridge_antigravity_dynamic_launch_cmd "$agent" 1 "$session_id"
       ;;
     *)
       return 1
@@ -533,6 +546,18 @@ bridge_build_safe_launch_cmd() {
         launch_cmd="$(bridge_build_dynamic_launch_cmd "$agent")"
         bridge_codex_launch_with_hooks "$launch_cmd"
       fi
+      ;;
+    antigravity)
+      # Track C1: safe-mode launches agy BARE — no `-i` bootstrap, no
+      # settings preseed, no project-skill bootstrap. This mirrors
+      # claude/codex safe-mode, which also skip the bridge context
+      # injection so an operator can recover a wedged agent without the
+      # managed setup. (codex/claude safe-mode still route through their
+      # hook-pinning wrapper; agy has no hook surface to pin, so the bare
+      # `agy --dangerously-skip-permissions` is the deliberate analogue.)
+      # Explicit arm rather than the `*)` passthrough so the bare launch
+      # is auditable and not an accidental fall-through.
+      bridge_join_quoted agy --dangerously-skip-permissions
       ;;
     *)
       printf '%s' "${BRIDGE_AGENT_LAUNCH_CMD[$agent]-}"

--- a/scripts/python-helpers/antigravity-settings-preseed.py
+++ b/scripts/python-helpers/antigravity-settings-preseed.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""antigravity-settings-preseed.py — atomic preseed of agy settings.json.
+
+Track C1 of the Antigravity (`agy`) engine wave. Invoked by
+`bridge_antigravity_settings_preseed` in lib/bridge-antigravity.sh with
+file-as-argv (NOT heredoc-stdin — footgun #11 / KNOWN_ISSUES.md §26).
+
+Read-modify-write of `~/.gemini/antigravity-cli/settings.json`:
+  - add <workdir> to `trustedWorkspaces` (array of trusted dirs) so the
+    agy trust selector ("Do you trust the contents of this project?") is
+    pre-empted before launch;
+  - add `command(<agb>)` and `command(<agent-bridge>)` to
+    `permissions.allow` so the bridge CLIs run without per-call prompts;
+  - set `altScreenMode` to `inline` so `tmux capture-pane` idle detection
+    works on the normal screen (mandated by the wave plan — de-risks B1).
+
+ALL pre-existing keys are preserved. Idempotent: a second run adds nothing
+duplicate. The write is atomic (temp file in the same directory + rename).
+
+argv:
+  1  settings_file   path to settings.json (created if absent)
+  2  workdir         absolute path to add to trustedWorkspaces
+  3  agb_path        absolute path to the `agb` CLI
+  4  agent_bridge    absolute path to the `agent-bridge` CLI
+
+Exit non-zero on any failure; prints a one-line reason to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+
+
+def _load(path: str) -> dict:
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError) as exc:
+        raise SystemExit(f"antigravity-settings-preseed: cannot read {path}: {exc}")
+    if not isinstance(data, dict):
+        raise SystemExit(
+            f"antigravity-settings-preseed: {path} is not a JSON object"
+        )
+    return data
+
+
+def _ensure_list(container: dict, key: str) -> list:
+    value = container.get(key)
+    if not isinstance(value, list):
+        value = []
+        container[key] = value
+    return value
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 5:
+        sys.stderr.write(
+            "antigravity-settings-preseed: expected 4 args "
+            "(settings_file workdir agb_path agent_bridge_path)\n"
+        )
+        return 2
+
+    settings_file, workdir, agb_path, agent_bridge_path = argv[1:5]
+
+    data = _load(settings_file)
+
+    # trustedWorkspaces — pre-empt the agy trust selector.
+    trusted = _ensure_list(data, "trustedWorkspaces")
+    if workdir not in trusted:
+        trusted.append(workdir)
+
+    # permissions.allow — auto-allow the bridge CLIs.
+    permissions = data.get("permissions")
+    if not isinstance(permissions, dict):
+        permissions = {}
+        data["permissions"] = permissions
+    allow = _ensure_list(permissions, "allow")
+    for cli in (agb_path, agent_bridge_path):
+        entry = f"command({cli})"
+        if entry not in allow:
+            allow.append(entry)
+
+    # altScreenMode — inline keeps tmux capture-pane idle detection working.
+    data["altScreenMode"] = "inline"
+
+    target_dir = os.path.dirname(os.path.abspath(settings_file)) or "."
+    try:
+        os.makedirs(target_dir, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".settings-preseed-", dir=target_dir)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, ensure_ascii=False, indent=2)
+                handle.write("\n")
+            os.replace(tmp_path, settings_file)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except OSError as exc:
+        sys.stderr.write(
+            f"antigravity-settings-preseed: cannot write {settings_file}: {exc}\n"
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/antigravity-engine-acceptance.sh
+++ b/scripts/smoke/antigravity-engine-acceptance.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# scripts/smoke/antigravity-engine-acceptance.sh — Antigravity wave Track A0.
+# scripts/smoke/antigravity-engine-acceptance.sh — Antigravity wave Track A0
+# (T6 updated by Track C1 — the A0 launch guard it removed is now gone).
 #
 # Validates that the `antigravity` engine is accepted on every public
 # surface A0 owns, that `agy`/`gemini` aliases normalize to the canonical
-# `antigravity` value, and that launching is still blocked by the
-# temporary bridge-start.sh guard (Track C1 removes that guard).
+# `antigravity` value, and that the dynamic spawn parser still recognizes
+# the `--agy` flag now that the real C1 launch branch has landed.
 #
 # Assertions:
 # T1: helper-level — bridge_engine_binary_name maps engine VALUE -> binary
@@ -17,10 +18,10 @@
 # T4: `agent create ... --engine agy --dry-run` — the alias normalizes;
 #     the planned engine is stored as `antigravity`.
 # T5: linux-user + antigravity create is refused with a clear message.
-# T6: `agent-bridge --agy --name ... --no-attach` parses all the way
-#     through and stops only at the bridge-start.sh launch guard.
-# T7: positive control — `agent-bridge --codex` is unaffected (does not
-#     hit the antigravity launch guard).
+# T6: `agent-bridge --agy --name ... --no-attach` parses the flag and
+#     proceeds PAST the (C1-removed) A0 launch guard.
+# T7: positive control — `agent-bridge --codex` is unaffected (never
+#     emitted the antigravity launch guard).
 
 set -euo pipefail
 
@@ -148,17 +149,20 @@ assert_linux_user_guard() {
     "create antigravity + linux-user refused with a clear message"
 }
 
-assert_spawn_reaches_launch_guard() {
+assert_spawn_past_launch_guard() {
   reset_runtime
   local probe_dir="$SMOKE_TMP_ROOT/agy-probe"
   mkdir -p "$probe_dir"
   local out
-  # --no-attach keeps us out of an interactive tmux attach. The flag
-  # parses through, validation + scaffold run, and the launch finally
-  # stops at the temporary bridge-start.sh guard.
+  # --no-attach keeps us out of an interactive tmux attach. Track C1
+  # removed the temporary bridge-start.sh launch guard and landed the
+  # real agy launch branch, so the spawn now parses + proceeds PAST the
+  # (removed) guard. This smoke only asserts the guard is gone and the
+  # flag still parses — the full launch contract is covered by
+  # antigravity-settings-preseed.sh and the C1 launch-builder checks.
   out="$(run_agent_bridge --agy --name agyprobe --workdir "$probe_dir" --no-attach)"
-  smoke_assert_contains "$out" "C1 트랙 대기" \
-    "--agy spawn reaches the temporary bridge-start.sh launch guard"
+  smoke_assert_not_contains "$out" "C1 트랙 대기" \
+    "--agy spawn no longer hits the (removed) A0 launch guard"
   smoke_assert_not_contains "$out" "알 수 없는 옵션" \
     "--agy flag is recognized by the dynamic spawn parser"
 }
@@ -180,7 +184,7 @@ main() {
   smoke_run "T3: create --engine antigravity"      assert_create_antigravity
   smoke_run "T4: create --engine agy alias"        assert_create_agy_alias
   smoke_run "T5: linux-user + antigravity guard"   assert_linux_user_guard
-  smoke_run "T6: --agy spawn reaches launch guard" assert_spawn_reaches_launch_guard
+  smoke_run "T6: --agy spawn past launch guard"    assert_spawn_past_launch_guard
   smoke_run "T7: --codex unaffected"               assert_codex_unaffected
 
   smoke_log "PASS"

--- a/scripts/smoke/antigravity-settings-preseed-assert.py
+++ b/scripts/smoke/antigravity-settings-preseed-assert.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Assertion helper for scripts/smoke/antigravity-settings-preseed.sh.
+
+Extracted to a standalone file (invoked file-as-argv) rather than an inline
+`python3 - <<'PY'` heredoc-stdin so the smoke test does not reintroduce the
+Bash 5.3.9 `read_comsub` / `heredoc_write` deadlock class (footgun #11) —
+the smoke captures this helper's output in `$(...)`, which is exactly the
+parent-comsub + child-heredoc-stdin shape that deadlocks.
+
+Usage:
+  antigravity-settings-preseed-assert.py preserve <settings.json> <workdir>
+  antigravity-settings-preseed-assert.py counts   <settings.json> <workdir>
+
+`preserve` prints space-joined `key=value` checks proving the preseed kept
+every pre-existing key and added the expected entries. `counts` prints the
+occurrence counts that prove the preseed is idempotent on re-run.
+"""
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        sys.stderr.write(
+            "usage: antigravity-settings-preseed-assert.py "
+            "<preserve|counts> <settings.json> <workdir>\n"
+        )
+        return 2
+    mode, settings, workdir = sys.argv[1], sys.argv[2], sys.argv[3]
+    with open(settings, encoding="utf-8") as fh:
+        data = json.load(fh)
+    allow = data.get("permissions", {}).get("allow", [])
+
+    if mode == "preserve":
+        checks = [
+            "colorScheme=%s" % data.get("colorScheme"),
+            "enableTelemetry=%s" % data.get("enableTelemetry"),
+            "preExistingTrust=%s"
+            % ("/pre/existing/dir" in data.get("trustedWorkspaces", [])),
+            "workdirTrust=%s" % (workdir in data.get("trustedWorkspaces", [])),
+            "preExistingAllow=%s" % ("command(/usr/bin/git)" in allow),
+            "denyPreserved=%s"
+            % ("command(/bin/rm)" in data.get("permissions", {}).get("deny", [])),
+            "agbAllow=%s" % any(e.endswith("/agb)") for e in allow),
+            "agentBridgeAllow=%s"
+            % any(e.endswith("/agent-bridge)") for e in allow),
+            "altScreenMode=%s" % data.get("altScreenMode"),
+        ]
+        print(" ".join(checks))
+        return 0
+
+    if mode == "counts":
+        trusted = data.get("trustedWorkspaces", [])
+        print(
+            "trustWorkdir=%d allowAgb=%d allowBridge=%d"
+            % (
+                trusted.count(workdir),
+                sum(1 for e in allow if e.endswith("/agb)")),
+                sum(1 for e in allow if e.endswith("/agent-bridge)")),
+            )
+        )
+        return 0
+
+    sys.stderr.write("unknown mode: %s\n" % mode)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/antigravity-settings-preseed.sh
+++ b/scripts/smoke/antigravity-settings-preseed.sh
@@ -65,26 +65,12 @@ JSON
   GEMINI_HOME="$gemini_root" bridge_antigravity_settings_preseed "$workdir" \
     || smoke_fail "T1: preseed exited non-zero"
 
+  # Assertion logic lives in a standalone file invoked file-as-argv (not an
+  # inline `python3 - <<'PY'` heredoc-stdin) — capturing a heredoc-fed
+  # subprocess in `$(...)` is the footgun #11 deadlock shape.
   local dump
-  dump="$(python3 - "$settings" "$workdir" <<'PY'
-import json, sys
-settings, workdir = sys.argv[1], sys.argv[2]
-with open(settings, encoding="utf-8") as fh:
-    data = json.load(fh)
-checks = []
-checks.append("colorScheme=%s" % data.get("colorScheme"))
-checks.append("enableTelemetry=%s" % data.get("enableTelemetry"))
-checks.append("preExistingTrust=%s" % ("/pre/existing/dir" in data.get("trustedWorkspaces", [])))
-checks.append("workdirTrust=%s" % (workdir in data.get("trustedWorkspaces", [])))
-allow = data.get("permissions", {}).get("allow", [])
-checks.append("preExistingAllow=%s" % ("command(/usr/bin/git)" in allow))
-checks.append("denyPreserved=%s" % ("command(/bin/rm)" in data.get("permissions", {}).get("deny", [])))
-checks.append("agbAllow=%s" % any(e.endswith("/agb)") for e in allow))
-checks.append("agentBridgeAllow=%s" % any(e.endswith("/agent-bridge)") for e in allow))
-checks.append("altScreenMode=%s" % data.get("altScreenMode"))
-print(" ".join(checks))
-PY
-)"
+  dump="$(python3 "$SCRIPT_DIR/antigravity-settings-preseed-assert.py" \
+    preserve "$settings" "$workdir")"
 
   smoke_assert_contains "$dump" "colorScheme=dark"        "T1: colorScheme preserved"
   smoke_assert_contains "$dump" "enableTelemetry=False"   "T1: enableTelemetry preserved"
@@ -107,20 +93,8 @@ assert_preseed_idempotent() {
     || smoke_fail "T2: second preseed exited non-zero"
 
   local counts
-  counts="$(python3 - "$settings" "$workdir" <<'PY'
-import json, sys
-settings, workdir = sys.argv[1], sys.argv[2]
-with open(settings, encoding="utf-8") as fh:
-    data = json.load(fh)
-trusted = data.get("trustedWorkspaces", [])
-allow = data.get("permissions", {}).get("allow", [])
-print("trustWorkdir=%d allowAgb=%d allowBridge=%d" % (
-    trusted.count(workdir),
-    sum(1 for e in allow if e.endswith("/agb)")),
-    sum(1 for e in allow if e.endswith("/agent-bridge)")),
-))
-PY
-)"
+  counts="$(python3 "$SCRIPT_DIR/antigravity-settings-preseed-assert.py" \
+    counts "$settings" "$workdir")"
 
   smoke_assert_contains "$counts" "trustWorkdir=1"  "T2: workdir trusted exactly once"
   smoke_assert_contains "$counts" "allowAgb=1"      "T2: agb allow entry present exactly once"

--- a/scripts/smoke/antigravity-settings-preseed.sh
+++ b/scripts/smoke/antigravity-settings-preseed.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# scripts/smoke/antigravity-settings-preseed.sh — Antigravity wave Track C1.
+#
+# Validates the agy launch-contract surface C1 owns:
+#   - bridge_antigravity_settings_preseed performs an ATOMIC, key-preserving
+#     mutation of the agy settings.json (trustedWorkspaces + permissions.allow
+#     + altScreenMode), and is idempotent on re-run;
+#   - bridge_antigravity_dynamic_launch_cmd emits the fresh form (`-i
+#     <bootstrap>`) and the resume form (`--conversation <id>`);
+#   - bridge_bootstrap_project_skill antigravity writes a non-empty SKILL.md
+#     (proving the renderer arm is not a silent no-op).
+#
+# Assertions:
+# T1: preseed preserves ALL pre-existing keys, adds the workdir to
+#     trustedWorkspaces, adds both command(...) allow entries, sets
+#     altScreenMode=inline.
+# T2: preseed is idempotent — a second run adds nothing duplicate.
+# T3: fresh launch cmd carries `agy --dangerously-skip-permissions -i
+#     <bootstrap-prompt>`; resume launch cmd carries `--conversation <id>`
+#     and drops `-i`.
+# T4: bridge_bootstrap_project_skill antigravity writes a non-empty
+#     SKILL.md under .agents/skills/agent-bridge/.
+
+set -euo pipefail
+
+SMOKE_NAME="antigravity-settings-preseed"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# Load the bridge library in this isolated environment so the C1 helpers
+# are callable directly.
+load_bridge_lib() {
+  export BRIDGE_SCRIPT_DIR="$SMOKE_REPO_ROOT"
+  # shellcheck source=bridge-lib.sh
+  source "$SMOKE_REPO_ROOT/bridge-lib.sh"
+}
+
+assert_preseed_preserves_and_adds() {
+  local gemini_root="$SMOKE_TMP_ROOT/gemini"
+  local cfg_dir="$gemini_root/antigravity-cli"
+  local settings="$cfg_dir/settings.json"
+  local workdir="$SMOKE_TMP_ROOT/agy-workdir"
+  mkdir -p "$cfg_dir" "$workdir"
+
+  # Pre-existing settings with keys the preseed must NOT clobber.
+  cat >"$settings" <<'JSON'
+{
+  "colorScheme": "dark",
+  "enableTelemetry": false,
+  "trustedWorkspaces": ["/pre/existing/dir"],
+  "permissions": {
+    "allow": ["command(/usr/bin/git)"],
+    "deny": ["command(/bin/rm)"]
+  },
+  "altScreenMode": "always"
+}
+JSON
+
+  GEMINI_HOME="$gemini_root" bridge_antigravity_settings_preseed "$workdir" \
+    || smoke_fail "T1: preseed exited non-zero"
+
+  local dump
+  dump="$(python3 - "$settings" "$workdir" <<'PY'
+import json, sys
+settings, workdir = sys.argv[1], sys.argv[2]
+with open(settings, encoding="utf-8") as fh:
+    data = json.load(fh)
+checks = []
+checks.append("colorScheme=%s" % data.get("colorScheme"))
+checks.append("enableTelemetry=%s" % data.get("enableTelemetry"))
+checks.append("preExistingTrust=%s" % ("/pre/existing/dir" in data.get("trustedWorkspaces", [])))
+checks.append("workdirTrust=%s" % (workdir in data.get("trustedWorkspaces", [])))
+allow = data.get("permissions", {}).get("allow", [])
+checks.append("preExistingAllow=%s" % ("command(/usr/bin/git)" in allow))
+checks.append("denyPreserved=%s" % ("command(/bin/rm)" in data.get("permissions", {}).get("deny", [])))
+checks.append("agbAllow=%s" % any(e.endswith("/agb)") for e in allow))
+checks.append("agentBridgeAllow=%s" % any(e.endswith("/agent-bridge)") for e in allow))
+checks.append("altScreenMode=%s" % data.get("altScreenMode"))
+print(" ".join(checks))
+PY
+)"
+
+  smoke_assert_contains "$dump" "colorScheme=dark"        "T1: colorScheme preserved"
+  smoke_assert_contains "$dump" "enableTelemetry=False"   "T1: enableTelemetry preserved"
+  smoke_assert_contains "$dump" "preExistingTrust=True"   "T1: pre-existing trusted dir preserved"
+  smoke_assert_contains "$dump" "workdirTrust=True"       "T1: workdir added to trustedWorkspaces"
+  smoke_assert_contains "$dump" "preExistingAllow=True"   "T1: pre-existing allow entry preserved"
+  smoke_assert_contains "$dump" "denyPreserved=True"      "T1: permissions.deny preserved"
+  smoke_assert_contains "$dump" "agbAllow=True"           "T1: agb command(...) allow added"
+  smoke_assert_contains "$dump" "agentBridgeAllow=True"   "T1: agent-bridge command(...) allow added"
+  smoke_assert_contains "$dump" "altScreenMode=inline"    "T1: altScreenMode set to inline"
+}
+
+assert_preseed_idempotent() {
+  local gemini_root="$SMOKE_TMP_ROOT/gemini"
+  local settings="$gemini_root/antigravity-cli/settings.json"
+  local workdir="$SMOKE_TMP_ROOT/agy-workdir"
+
+  # Second run on the already-seeded file from T1.
+  GEMINI_HOME="$gemini_root" bridge_antigravity_settings_preseed "$workdir" \
+    || smoke_fail "T2: second preseed exited non-zero"
+
+  local counts
+  counts="$(python3 - "$settings" "$workdir" <<'PY'
+import json, sys
+settings, workdir = sys.argv[1], sys.argv[2]
+with open(settings, encoding="utf-8") as fh:
+    data = json.load(fh)
+trusted = data.get("trustedWorkspaces", [])
+allow = data.get("permissions", {}).get("allow", [])
+print("trustWorkdir=%d allowAgb=%d allowBridge=%d" % (
+    trusted.count(workdir),
+    sum(1 for e in allow if e.endswith("/agb)")),
+    sum(1 for e in allow if e.endswith("/agent-bridge)")),
+))
+PY
+)"
+
+  smoke_assert_contains "$counts" "trustWorkdir=1"  "T2: workdir trusted exactly once"
+  smoke_assert_contains "$counts" "allowAgb=1"      "T2: agb allow entry present exactly once"
+  smoke_assert_contains "$counts" "allowBridge=1"   "T2: agent-bridge allow entry present exactly once"
+}
+
+assert_launch_builder_fresh_and_resume() {
+  local fresh resume prompt
+  fresh="$(bridge_antigravity_dynamic_launch_cmd agyrole 0 "")"
+  smoke_assert_contains "$fresh" "agy --dangerously-skip-permissions" \
+    "T3: fresh launch cmd uses agy --dangerously-skip-permissions"
+  smoke_assert_contains "$fresh" " -i " \
+    "T3: fresh launch cmd carries the -i bootstrap flag"
+  smoke_assert_not_contains "$fresh" "--conversation" \
+    "T3: fresh launch cmd has no --conversation"
+
+  # The -i argument is %q-quoted into the argv; assert on the raw
+  # bootstrap-prompt string so whitespace escaping is not in the way.
+  prompt="$(bridge_antigravity_bootstrap_prompt agyrole)"
+  smoke_assert_contains "$prompt" "agb inbox agyrole" \
+    "T3: fresh -i bootstrap prompt points the agent at its inbox"
+  smoke_assert_contains "$prompt" "SOUL.md and CLAUDE.md" \
+    "T3: fresh -i bootstrap prompt points the agent at its context files"
+
+  resume="$(bridge_antigravity_dynamic_launch_cmd agyrole 1 conv-abc123)"
+  smoke_assert_contains "$resume" "--conversation conv-abc123" \
+    "T3: resume launch cmd carries --conversation <id>"
+  smoke_assert_not_contains "$resume" " -i " \
+    "T3: resume launch cmd drops the -i bootstrap"
+}
+
+assert_project_skill_written() {
+  local workdir="$SMOKE_TMP_ROOT/agy-skill"
+  mkdir -p "$workdir"
+  bridge_bootstrap_project_skill antigravity "$workdir" \
+    || smoke_fail "T4: bridge_bootstrap_project_skill antigravity exited non-zero"
+  local skill_file="$workdir/.agents/skills/agent-bridge/SKILL.md"
+  smoke_assert_file_exists "$skill_file" "T4: antigravity SKILL.md written"
+  [[ -s "$skill_file" ]] || smoke_fail "T4: antigravity SKILL.md is empty"
+  smoke_assert_contains "$(cat "$skill_file")" "name: agent-bridge" \
+    "T4: antigravity SKILL.md has the skill frontmatter"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+  load_bridge_lib
+
+  smoke_run "T1: preseed preserves keys + adds entries" assert_preseed_preserves_and_adds
+  smoke_run "T2: preseed idempotent on re-run"          assert_preseed_idempotent
+  smoke_run "T3: launch builder fresh + resume forms"   assert_launch_builder_fresh_and_resume
+  smoke_run "T4: project-skill writes SKILL.md"         assert_project_skill_written
+
+  smoke_log "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
## Track C1 — agy launch contract: settings preseed + launch builder + bootstrap

Track C1 of the Antigravity (`agy`) engine wave (#5039). C1 is the single
owner of the agy **launch contract** — it makes a bridge-managed agy agent
actually spawnable with the bridge context that Claude/Codex agents get via
SessionStart hooks. Builds on Track A0 (engine acceptance everywhere).

**Base: `feat/antigravity-engine-integration`** (wave integration branch — NOT main).

### Scope

- **New `lib/bridge-antigravity.sh`** (wired into the `bridge-lib.sh` module
  loader after `bridge-agents.sh`, before `bridge-skills.sh`/`bridge-state.sh`):
  - `bridge_antigravity_settings_preseed` — atomic, key-preserving mutation of
    `~/.gemini/antigravity-cli/settings.json`: adds the workdir to
    `trustedWorkspaces` (pre-empts the trust selector), adds the bridge CLIs
    to `permissions.allow`, forces `altScreenMode: inline` (so `tmux
    capture-pane` idle detection works — de-risks B1). Done via a standalone
    python helper invoked **file-as-argv** — no heredoc-stdin (footgun #11).
  - `bridge_antigravity_dynamic_launch_cmd` — fresh form carries the mandatory
    `agy -i <bootstrap-prompt>` (the SessionStart-injection analogue); resume
    form (`continue=1` + `session_id`) uses `--conversation <id>`.
  - `bridge_antigravity_bootstrap_prompt` — a single `%q`-quotable prompt
    pointing the agent at `SOUL.md`/`CLAUDE.md` + `agb inbox <agent>`.
  - conversation-state path helpers for **Track A1**'s detector to build on.
- **New `scripts/python-helpers/antigravity-settings-preseed.py`** — the
  atomic JSON mutator (temp file in the same dir + `os.replace`).
- **`lib/bridge-state.sh`** — antigravity arms on **all three** launch
  builders: `bridge_build_dynamic_launch_cmd`,
  `bridge_build_resume_launch_cmd`, `bridge_build_safe_launch_cmd`.
  **Safe-mode launches agy BARE** (`agy --dangerously-skip-permissions`, no
  `-i` bootstrap) — deliberate, mirrors claude/codex safe-mode; explicit arm
  rather than an accidental `*)` fall-through.
- **`bridge-start.sh`** — **removes the A0 temporary no-launch guard**
  (`"... C1 트랙 대기"`) and adds the real `antigravity` launch branch
  (settings preseed + project-skill bootstrap; no Claude-style hook ensures —
  agy has no native SessionStart-hook surface, the `-i` bootstrap is the
  analogue).
- **`bridge-agent.sh`** — upgrades A0's minimal
  `bridge_agent_default_launch_cmd` antigravity arm so a static agy agent's
  stored roster `launch_cmd` carries the `-i` bootstrap (optional agent param
  threaded through both call sites).
- **`lib/bridge-skills.sh`** — 3 edits: `bridge_project_skill_dir_for`,
  `legacy_skill_dir` case, and the `bridge_bootstrap_project_skill` renderer
  dispatch each get an `antigravity` arm + a new
  `bridge_render_antigravity_project_skill` (the agy project skill is
  byte-identical to codex's — delegates to avoid drift; the arm exists and
  actually writes `SKILL.md`, not a silent no-op).
- **`scripts/smoke/antigravity-settings-preseed.sh`** — new durable smoke for
  the preseed (key preservation + idempotency), launch builders, project-skill.
- **`scripts/smoke/antigravity-engine-acceptance.sh`** — T6 updated: the A0
  launch guard C1 removes is now gone, so T6 asserts the spawn proceeds
  **past** it.

> ⚠️ **A0-guard removal**: this PR removes the temporary `bridge-start.sh`
> `bridge_die` guard that Track A0 deliberately added. That is the intended
> hand-off — A0's PR description called this out.

### Verification

| Check | Result |
|---|---|
| `bash -n` (8 touched `.sh` files) | PASS |
| `shellcheck` (8 touched `.sh` files) | PASS (exit 0) |
| `py_compile` (settings-preseed.py) | PASS |
| `lint-heredoc-ban.sh --baseline-check` | PASS (ratchet unchanged) |
| `scripts/smoke/antigravity-settings-preseed.sh` (new) | PASS — 4/4 |
| `scripts/smoke/antigravity-engine-acceptance.sh` (A0) | PASS — 7/7 |
| `scripts/smoke/v2-scaffold-home-and-workdir.sh` | PASS |
| `./scripts/smoke-test.sh` | EXIT 1 — **pre-existing, not a C1 regression** |
| launch-builder direct probe (fresh + resume) | PASS — argv well-formed |

**`./scripts/smoke-test.sh` EXIT 1**: the same 4 errors (`status should show
activity state`, `smoke leaked agent dirs into the live install` — refs
#4793) reproduce on the **untouched A0 integration-branch baseline** (verified
in a fresh temp clone of `origin/feat/antigravity-engine-integration` @
`a4df640`). This is a pre-existing smoke-leak-into-live-install environment
issue in the isolated-daemon/tmux-role section — a region C1 does not touch.

### Internal codex self-review (Phase 3)

`codex:codex-rescue` reviewed the full staged diff — **`implement-ok`,
round 1, no blocking findings**. Confirmed: helper wired before its
consumers, fresh/resume/safe launch builders match the contract, the `-i`
prompt is one `%q`-quoted argv argument, settings mutation is file-as-argv
with temp-file + `os.replace`, A0 guard removed, no new production
heredoc-stdin.

### For Phase 4 pair-review to scrutinize

- The `-i` bootstrap prompt content (`bridge_antigravity_bootstrap_prompt`) —
  faithful SessionStart analogue? Single well-formed quoted string.
- The settings.json atomic mutation — key preservation + idempotency
  (covered by the new smoke T1/T2).
- The A0-guard removal in `bridge-start.sh`.

(#5039 Track C1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
