### PR TITLE
[antigravity wave] A1 — conversation-id detector/resolver + resume

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -2949,6 +2949,30 @@ bridge_resolve_resume_session_id() {
   local max_age_hours="${5:-${BRIDGE_RESUME_MAX_AGE_HOURS:-48}}"
   local exclude_csv="${6:-}"
 
+  # Antigravity (`agy`) gets a real resolution path with stale-id
+  # rejection — it must NOT fall through to the blind passthrough below.
+  # A conversation id older than max_age_hours resolves to empty + rc=1
+  # so the agent launches a fresh conversation rather than false-resuming
+  # a dead one (the resume-builder routes `agy --conversation <id>` only
+  # when a non-empty session_id survives). The Python body is a standalone
+  # helper invoked file-as-argv (footgun #11).
+  if [[ "$engine" == "antigravity" ]]; then
+    [[ -n "$workdir" ]] || return 1
+    # Issue #820 parity: when the caller passed no explicit exclude list
+    # but supplied an agent, inherit the per-agent resume-quarantine CSV.
+    if [[ -z "$exclude_csv" && -n "$agent" ]]; then
+      exclude_csv="$(bridge_agent_resume_quarantine_ids "$agent" 2>/dev/null || true)"
+    fi
+    if ! bridge_resolve_script_dir_check; then
+      return 1
+    fi
+    python3 "$BRIDGE_SCRIPT_DIR/scripts/python-helpers/resolve-antigravity-resume-session-id.py" \
+      "$workdir" "$candidate" "$max_age_hours" "$agent" "$exclude_csv" \
+      "$(bridge_antigravity_history_file)" \
+      "$(bridge_antigravity_conversation_state_dir)"
+    return $?
+  fi
+
   if [[ "$engine" != "claude" ]]; then
     if [[ -n "$candidate" ]]; then printf '%s' "$candidate"; fi
     return 0
@@ -3069,6 +3093,34 @@ print(best[1] if best else "")
 PY
 }
 
+# bridge_detect_antigravity_session_id <workdir> <since_hint> <exclude_csv>
+#
+# Resolves the most recent Antigravity (`agy`) conversation id for the
+# agent's workdir by parsing the agy conversation index
+# (~/.gemini/antigravity-cli/history.jsonl) and confirming the
+# conversation's `<id>.pb` state file still exists under conversations/.
+# Mirrors the recency / since-hint / exclude semantics of
+# bridge_detect_codex_session_id. The agy config root honors GEMINI_HOME
+# via bridge_antigravity_config_root (Track C1), so isolated tests can
+# point at a fixture tree. The Python body lives in a standalone helper
+# invoked file-as-argv — NOT a Python heredoc-stdin — for the footgun #11
+# deadlock reason documented on bridge_detect_claude_session_id.
+bridge_detect_antigravity_session_id() {
+  local workdir="$1"
+  local since_hint="${2:-0}"
+  local exclude_csv="${3:-}"
+
+  # #946 L1: substitution-safe guard. This helper is called exclusively
+  # from `$(...)` substitutions (callers parse stdout).
+  if ! bridge_resolve_script_dir_check; then
+    return 1
+  fi
+  python3 "$BRIDGE_SCRIPT_DIR/scripts/python-helpers/detect-antigravity-session-id.py" \
+    "$workdir" "$since_hint" "$exclude_csv" \
+    "$(bridge_antigravity_history_file)" \
+    "$(bridge_antigravity_conversation_state_dir)"
+}
+
 bridge_detect_session_id() {
   local engine="$1"
   local workdir="$2"
@@ -3082,12 +3134,21 @@ bridge_detect_session_id() {
     claude)
       bridge_detect_claude_session_id "$workdir" "$since_hint" "$exclude_csv"
       ;;
+    antigravity)
+      bridge_detect_antigravity_session_id "$workdir" "$since_hint" "$exclude_csv"
+      ;;
     *)
       printf '%s' ""
       ;;
   esac
 }
 
+# Persists the live session/conversation id into the per-agent history
+# slot once the session is up. Engine-agnostic: it routes detection
+# through bridge_detect_session_id, so the `antigravity` arm added there
+# is all that is needed for an agy agent's conversation id to be detected,
+# stored in BRIDGE_AGENT_SESSION_ID, and persisted — no explicit
+# antigravity branch is required in this function.
 bridge_refresh_agent_session_id() {
   local agent="$1"
   local attempts="${2:-8}"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -221,7 +221,15 @@ select_for_path() {
       # cron-only static agents do not go stale between rotation events.
       # daemon-periodic-token-sync covers the due-check / tick / audit /
       # state-file cadence contract.
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync
+      #
+      # Antigravity wave Track A1: lib/bridge-state.sh's detection region
+      # hosts bridge_detect_antigravity_session_id and the antigravity
+      # resolution path in bridge_resolve_resume_session_id (stale-id
+      # rejection). antigravity-conversation-resume pins the detector /
+      # resolver / `agy --conversation` resume contract — run it on every
+      # bridge-state.sh move so a future PR cannot silently regress the
+      # stale-id rejection.
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync antigravity-conversation-resume
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -435,6 +443,18 @@ select_for_path() {
       # must re-run the Wave C regression smoke that asserts the call
       # returns in <2s.
       add_required 835-static-admin-launch launch launch-dev-channels-injection channel-env-readiness
+      add_integration integration-minimal
+      ;;
+
+    scripts/python-helpers/detect-antigravity-session-id.py|scripts/python-helpers/resolve-antigravity-resume-session-id.py)
+      # Antigravity wave Track A1: these standalone helpers hold the agy
+      # conversation-id detector + resolver bodies (file-as-argv, footgun
+      # #11 mitigation). antigravity-conversation-resume asserts the
+      # detector recency/exclude/workspace scoping AND the resolver's
+      # stale-id rejection (an id older than BRIDGE_RESUME_MAX_AGE_HOURS
+      # must resolve to empty so the agent launches fresh). Any change to
+      # these helpers must re-run that smoke.
+      add_required antigravity-conversation-resume antigravity-engine-acceptance
       add_integration integration-minimal
       ;;
 

--- a/scripts/python-helpers/detect-antigravity-session-id.py
+++ b/scripts/python-helpers/detect-antigravity-session-id.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Detect the most recent Antigravity (`agy`) conversation id for a workdir.
+
+Backs `lib/bridge-state.sh::bridge_detect_antigravity_session_id` (Track A1
+of the Antigravity engine wave). The bash wrapper invokes this body
+file-as-argv rather than via a Python heredoc-stdin: on Bash 5.3.9 the
+heredoc-stdin pattern can wedge in `heredoc_write` when the wrapper is
+called inside a command substitution `$(...)` from a shell sourced via an
+absolute path (the footgun #11 deadlock class — issues #815 / #800 /
+#827). `bridge_detect_codex_session_id` still inlines its body that way;
+this helper deliberately follows the safer file-as-argv shape of
+`detect-claude-session-id.py` instead.
+
+Args (positional, order-sensitive):
+    sys.argv[1] — workdir (the agent workdir; `os.path.realpath`-resolved)
+    sys.argv[2] — since_hint (epoch string; "0" = no time gate. Seconds or
+                  milliseconds are both accepted — values > 10**11 are
+                  treated as ms and divided down, mirroring
+                  `bridge_detect_codex_session_id`.)
+    sys.argv[3] — exclude_csv (comma-separated conversation ids to skip)
+    sys.argv[4] — history_file (path to agy `history.jsonl`)
+    sys.argv[5] — conversation_state_dir (path to agy `conversations/`)
+
+Stdout: the detected conversation id, or empty string if none. Exits 0.
+
+Behavior:
+    agy records one JSON object per line in `history.jsonl`. Relevant
+    fields (confirmed against a real ~/.gemini/antigravity-cli/history.jsonl
+    on the host, 2026-05-21):
+        display        — the prompt text (ignored here)
+        timestamp      — int, epoch MILLISECONDS
+        workspace      — absolute workdir the conversation ran in
+        conversationId — UUID; present ONLY on entries that started a
+                         persisted conversation (some entries lack it)
+    Each conversationId maps to a `<id>.pb` protobuf file under
+    `conversations/`. This helper:
+      1. Walks every history entry whose `workspace` realpath matches the
+         requested workdir, that carries a non-empty `conversationId` not
+         in the exclude set, and (when since_hint is set) whose timestamp
+         is within the time gate.
+      2. Requires the conversation's `<id>.pb` to still exist on disk —
+         a history row whose state file was deleted is not resumable.
+      3. Returns the id with the freshest history timestamp.
+"""
+
+import json
+import os
+import sys
+
+
+def to_epoch_seconds(raw: str) -> float:
+    try:
+        value = float(raw or "0")
+    except ValueError:
+        return 0.0
+    # agy history timestamps are epoch ms; callers may also pass a seconds
+    # hint. Anything above ~Mar-2001-in-ms is treated as ms (mirrors
+    # bridge_detect_codex_session_id's `since_epoch > 10**11` guard).
+    if value > 10**11:
+        value /= 1000.0
+    return value
+
+
+def main() -> int:
+    workdir = os.path.realpath(sys.argv[1])
+    since_epoch = to_epoch_seconds(sys.argv[2] if len(sys.argv) > 2 else "0")
+    exclude = {
+        x for x in (sys.argv[3] if len(sys.argv) > 3 else "").split(",") if x
+    }
+    history_file = sys.argv[4] if len(sys.argv) > 4 else ""
+    conversation_state_dir = sys.argv[5] if len(sys.argv) > 5 else ""
+
+    best = None  # (timestamp_seconds, conversation_id)
+
+    try:
+        with open(history_file, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError:
+        print("")
+        return 0
+
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        cid = obj.get("conversationId")
+        if not cid or cid in exclude:
+            continue
+        ws = obj.get("workspace")
+        if not ws or os.path.realpath(str(ws)) != workdir:
+            continue
+        # history timestamp is epoch ms.
+        ts = to_epoch_seconds(str(obj.get("timestamp") or "0"))
+        # Time gate mirrors bridge_detect_codex_session_id: a 5-minute
+        # grace window absorbs clock skew between the launch hint and the
+        # conversation's recorded start.
+        if since_epoch and ts < max(0.0, since_epoch - 300.0):
+            continue
+        # The conversation must still have its on-disk state file — a row
+        # whose `<id>.pb` was pruned is not resumable.
+        pb_path = os.path.join(conversation_state_dir, f"{cid}.pb")
+        if not os.path.isfile(pb_path):
+            continue
+        if best is None or ts > best[0]:
+            best = (ts, cid)
+
+    print(best[1] if best else "")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python-helpers/resolve-antigravity-resume-session-id.py
+++ b/scripts/python-helpers/resolve-antigravity-resume-session-id.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Resolve the Antigravity (`agy`) resume conversation id for a workdir.
+
+Backs `lib/bridge-state.sh::bridge_resolve_resume_session_id` for the
+`antigravity` engine (Track A1). Invoked file-as-argv, never via a Python
+heredoc-stdin, for the footgun #11 deadlock reason documented in
+`detect-antigravity-session-id.py`.
+
+This is the single source of truth for whether an agy conversation id may
+be fed to `agy --conversation <id>`. It is pure: callers pass everything
+in and it neither reads nor writes bridge state.
+
+Args (positional, order-sensitive):
+    sys.argv[1] — workdir (the agent workdir; `os.path.realpath`-resolved)
+    sys.argv[2] — candidate conversation id (may be empty)
+    sys.argv[3] — max_age_hours (float string; default 48)
+    sys.argv[4] — agent name (debug-only)
+    sys.argv[5] — exclude_csv (comma-separated conversation ids to skip)
+    sys.argv[6] — history_file (path to agy `history.jsonl`)
+    sys.argv[7] — conversation_state_dir (path to agy `conversations/`)
+
+Stdout: accepted conversation id, or empty when there is nothing safe to
+    resume.
+Exit code (mirrors the Claude resolver contract so the bash call sites'
+`case "$_rc" in 0|2) ... *) clear` logic is reused unchanged):
+    0 = candidate accepted as-is (or empty candidate resolved to the
+        freshest eligible conversation)
+    1 = no eligible (in-window) conversation — caller MUST launch fresh,
+        NOT `agy --conversation`. This is the STALE-ID REJECTION path: a
+        candidate older than max_age_hours yields empty stdout + rc=1 so
+        the agent starts a fresh conversation instead of false-resuming a
+        dead one.
+    2 = candidate ineligible/stale but a fresher in-window conversation
+        exists for the same workdir; that fresher id is on stdout.
+
+Two distinct time signals — kept deliberately separate:
+
+  * STALENESS GATE: a conversation is "in-window" when its *freshness*
+    timestamp — MAX of the history `timestamp` (epoch ms, seconds-normalized)
+    and the `<id>.pb` state-file mtime — is within max_age_hours. Taking the
+    max is conservative: a conversation whose `.pb` was touched recently
+    (still being used) is NOT rejected just because its history row is old.
+
+  * RANKING: among in-window conversations, the freshest is chosen by the
+    history `timestamp` — the SAME ordering the detector
+    (detect-antigravity-session-id.py) uses, so detector and resolver agree
+    on "which is newest". The `.pb` mtime is a tie-break only. Ranking on
+    `.pb` mtime directly would diverge from the detector, since `.pb` files
+    written in the same wall-clock second sort unpredictably.
+"""
+
+import json
+import os
+import sys
+import time
+
+
+def history_ts_seconds(raw) -> float:
+    try:
+        value = float(raw or "0")
+    except (TypeError, ValueError):
+        return 0.0
+    # agy history timestamps are epoch ms.
+    if value > 10**11:
+        value /= 1000.0
+    return value
+
+
+def collect_conversations(history_file, conversation_state_dir, workdir, exclude):
+    """Return {conversation_id: (freshness, hist_ts)} for the workdir.
+
+    `freshness` = max(history timestamp, `<id>.pb` mtime) — drives the
+    in-window staleness gate. `hist_ts` = the raw history timestamp —
+    drives ranking (matches the detector's pure-timestamp ordering).
+
+    Only conversations whose `<id>.pb` still exists are included; a history
+    row whose state file was pruned is not resumable.
+    """
+    result = {}
+    try:
+        with open(history_file, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except OSError:
+        return result
+
+    for raw in lines:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        cid = obj.get("conversationId")
+        if not cid or cid in exclude:
+            continue
+        ws = obj.get("workspace")
+        if not ws or os.path.realpath(str(ws)) != workdir:
+            continue
+        pb_path = os.path.join(conversation_state_dir, f"{cid}.pb")
+        try:
+            pb_mtime = os.path.getmtime(pb_path)
+        except OSError:
+            # state file gone -> not resumable.
+            continue
+        hist_ts = history_ts_seconds(obj.get("timestamp"))
+        freshness = max(hist_ts, pb_mtime)
+        # A workdir can have multiple history rows for the same id; keep
+        # the one with the newest history timestamp (and its freshness).
+        if cid not in result or hist_ts > result[cid][1]:
+            result[cid] = (freshness, hist_ts)
+    return result
+
+
+def main() -> int:
+    workdir = os.path.realpath(sys.argv[1])
+    candidate = (sys.argv[2] if len(sys.argv) > 2 else "") or ""
+    try:
+        max_age_hours = float(sys.argv[3] if len(sys.argv) > 3 else "48")
+    except ValueError:
+        max_age_hours = 48.0
+    agent = (sys.argv[4] if len(sys.argv) > 4 else "") or ""
+    exclude = {
+        x for x in (sys.argv[5] if len(sys.argv) > 5 else "").split(",") if x
+    }
+    history_file = sys.argv[6] if len(sys.argv) > 6 else ""
+    conversation_state_dir = sys.argv[7] if len(sys.argv) > 7 else ""
+
+    cutoff = time.time() - max_age_hours * 3600
+
+    conversations = collect_conversations(
+        history_file, conversation_state_dir, workdir, exclude
+    )
+    # In-window gate uses `freshness` (tuple[0] = max(hist_ts, pb_mtime)).
+    eligible = {
+        cid: rank
+        for cid, rank in conversations.items()
+        if rank[0] >= cutoff
+    }
+
+    if not eligible:
+        # STALE-ID REJECTION: candidate (if any) is older than the
+        # max-age window, or there is simply no conversation for this
+        # workdir. Either way -> launch fresh, never false-resume.
+        sys.stderr.write(
+            f"[debug] agy resume id rejected: no conversation within "
+            f"{max_age_hours}h for workdir={workdir} agent={agent} "
+            f"candidate={candidate or '(none)'}\n"
+        )
+        print("", end="")
+        return 1
+
+    # Rank by history timestamp (tuple[1]) — same ordering as the
+    # detector — with freshness (tuple[0]) only as a tie-break.
+    freshest = max(
+        eligible, key=lambda c: (eligible[c][1], eligible[c][0])
+    )
+
+    # A candidate explicitly excluded (quarantined) must not be accepted
+    # even if in-window — resolve to the freshest non-excluded id (rc=2).
+    if candidate and candidate in exclude:
+        sys.stderr.write(
+            f"[debug] agy resume id quarantined: candidate={candidate} "
+            f"freshest={freshest} workdir={workdir} agent={agent}\n"
+        )
+        print(freshest, end="")
+        return 2
+
+    if candidate and candidate in eligible:
+        # Candidate is itself in-window -> accept as-is.
+        print(candidate, end="")
+        return 0
+
+    if candidate:
+        # Candidate is stale (not in `eligible`) but the workdir has a
+        # fresher conversation -> swap (rc=2).
+        sys.stderr.write(
+            f"[debug] agy resume id replaced: candidate={candidate} "
+            f"freshest={freshest} workdir={workdir} agent={agent}\n"
+        )
+        print(freshest, end="")
+        return 2
+
+    # Empty candidate: freshest eligible is an acceptance, not a swap.
+    print(freshest, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/antigravity-conversation-resume.sh
+++ b/scripts/smoke/antigravity-conversation-resume.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# scripts/smoke/antigravity-conversation-resume.sh — Antigravity wave Track A1.
+#
+# Validates the agy conversation-id detector / resolver / resume surface
+# A1 owns in lib/bridge-state.sh:
+#   - bridge_detect_antigravity_session_id parses the agy conversation
+#     index (history.jsonl) + conversations/ state dir and returns the
+#     freshest conversation id for the agent's workdir;
+#   - bridge_resolve_resume_session_id (engine=antigravity) accepts a
+#     fresh candidate (rc=0) and REJECTS a stale one (empty stdout, rc=1)
+#     so the agent launches fresh instead of false-resuming a dead
+#     conversation;
+#   - the resolved id then flows into C1's bridge_antigravity_dynamic_launch_cmd
+#     resume form (`agy --conversation <id>`).
+#
+# The agy config root honors GEMINI_HOME (bridge_antigravity_config_root,
+# Track C1), so the whole fixture lives under an isolated temp tree.
+#
+# Assertions:
+# T1: bridge_detect_antigravity_session_id returns the freshest in-workdir
+#     conversation id, ignores a different-workdir conversation, and skips
+#     a history row whose `<id>.pb` state file is missing.
+# T2: bridge_resolve_resume_session_id accepts a fresh candidate as-is
+#     (rc=0) and accepts the freshest id for an empty candidate (rc=0).
+# T3: STALE-ID REJECTION — a conversation older than max_age_hours yields
+#     empty stdout + rc=1 (caller launches fresh, never false-resumes).
+# T4: the detected/resolved id carried into C1's launch builder produces
+#     `agy --conversation <id>`; a stale (empty) resolution produces the
+#     fresh `-i` bootstrap form instead.
+
+set -euo pipefail
+
+SMOKE_NAME="antigravity-conversation-resume"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+load_bridge_lib() {
+  export BRIDGE_SCRIPT_DIR="$SMOKE_REPO_ROOT"
+  # shellcheck source=bridge-lib.sh
+  source "$SMOKE_REPO_ROOT/bridge-lib.sh"
+}
+
+# Fixture conversation ids.
+FRESH_ID="11111111-1111-4111-8111-111111111111"
+OLDER_ID="22222222-2222-4222-8222-222222222222"
+STALE_ID="33333333-3333-4333-8333-333333333333"
+OTHERWD_ID="44444444-4444-4444-8444-444444444444"
+GHOST_ID="55555555-5555-4555-8555-555555555555"
+
+GEMINI_ROOT=""
+AGY_WORKDIR=""
+OTHER_WORKDIR=""
+
+# epoch-ms helpers — agy history timestamps are epoch milliseconds.
+now_ms() { printf '%s000' "$(date +%s)"; }
+ms_hours_ago() {
+  local hours="$1"
+  printf '%s000' "$(( $(date +%s) - hours * 3600 ))"
+}
+
+seed_fixture() {
+  GEMINI_ROOT="$SMOKE_TMP_ROOT/gemini"
+  AGY_WORKDIR="$SMOKE_TMP_ROOT/agy-workdir"
+  OTHER_WORKDIR="$SMOKE_TMP_ROOT/other-workdir"
+  local cfg_dir="$GEMINI_ROOT/antigravity-cli"
+  local conv_dir="$cfg_dir/conversations"
+  mkdir -p "$conv_dir" "$AGY_WORKDIR" "$OTHER_WORKDIR"
+
+  local history="$cfg_dir/history.jsonl"
+  local fresh_ms older_ms stale_ms other_ms ghost_ms
+  fresh_ms="$(now_ms)"
+  older_ms="$(ms_hours_ago 5)"
+  stale_ms="$(ms_hours_ago 240)"   # 10 days — far past the 48h window
+  other_ms="$(now_ms)"
+  ghost_ms="$(now_ms)"
+
+  # history.jsonl — one JSON object per line (agy real shape: display,
+  # timestamp [epoch ms], workspace, conversationId).
+  {
+    printf '{"display":"older task","timestamp":%s,"workspace":"%s","conversationId":"%s"}\n' \
+      "$older_ms" "$AGY_WORKDIR" "$OLDER_ID"
+    printf '{"display":"fresh task","timestamp":%s,"workspace":"%s","conversationId":"%s"}\n' \
+      "$fresh_ms" "$AGY_WORKDIR" "$FRESH_ID"
+    printf '{"display":"other-workdir task","timestamp":%s,"workspace":"%s","conversationId":"%s"}\n' \
+      "$other_ms" "$OTHER_WORKDIR" "$OTHERWD_ID"
+    # A row whose state file was never written / was pruned — not resumable.
+    printf '{"display":"ghost task","timestamp":%s,"workspace":"%s","conversationId":"%s"}\n' \
+      "$ghost_ms" "$AGY_WORKDIR" "$GHOST_ID"
+    # A row with no conversationId at all (agy writes these) — must be skipped.
+    printf '{"display":"no-conversation row","timestamp":%s,"workspace":"%s"}\n' \
+      "$fresh_ms" "$AGY_WORKDIR"
+  } >"$history"
+
+  # conversation state files. The GHOST_ID intentionally has NO .pb.
+  : >"$conv_dir/$FRESH_ID.pb"
+  : >"$conv_dir/$OLDER_ID.pb"
+  : >"$conv_dir/$STALE_ID.pb"
+  : >"$conv_dir/$OTHERWD_ID.pb"
+
+  # Backdate the stale conversation's .pb mtime AND give it a history row
+  # so it is a fully-formed-but-old conversation. The resolver's freshness
+  # anchor is max(history timestamp, .pb mtime) — both must be old for the
+  # rejection to fire.
+  printf '{"display":"stale task","timestamp":%s,"workspace":"%s","conversationId":"%s"}\n' \
+    "$stale_ms" "$AGY_WORKDIR" "$STALE_ID" >>"$history"
+  # touch -t needs [[CC]YY]MMDDhhmm — 10 days back.
+  touch -t "$(date -v-10d +%Y%m%d%H%M 2>/dev/null \
+    || date -d '10 days ago' +%Y%m%d%H%M)" "$conv_dir/$STALE_ID.pb"
+}
+
+assert_detect() {
+  local detected
+  detected="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_detect_antigravity_session_id "$AGY_WORKDIR" 0 "")"
+  smoke_assert_eq "$FRESH_ID" "$detected" \
+    "T1: detector returns the freshest in-workdir conversation id"
+
+  # Exclude the freshest id -> detector falls back to the next in-workdir id.
+  local detected_excl
+  detected_excl="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_detect_antigravity_session_id "$AGY_WORKDIR" 0 "$FRESH_ID")"
+  smoke_assert_eq "$OLDER_ID" "$detected_excl" \
+    "T1: detector honors the exclude list (falls back to next id)"
+
+  # A different workdir resolves to its own conversation, never the agy one.
+  local detected_other
+  detected_other="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_detect_antigravity_session_id "$OTHER_WORKDIR" 0 "")"
+  smoke_assert_eq "$OTHERWD_ID" "$detected_other" \
+    "T1: detector scopes by workspace (no cross-workdir bleed)"
+
+  # The ghost row (no .pb on disk) must never be returned. Excluding both
+  # real ids would surface it if the missing-state-file guard were absent.
+  local detected_noghost
+  detected_noghost="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_detect_antigravity_session_id "$AGY_WORKDIR" 0 \
+    "$FRESH_ID,$OLDER_ID,$STALE_ID")"
+  smoke_assert_eq "" "$detected_noghost" \
+    "T1: detector skips a history row whose .pb state file is missing"
+}
+
+assert_resolve_fresh() {
+  local accepted rc
+  rc=0
+  accepted="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_resolve_resume_session_id antigravity agyrole "$AGY_WORKDIR" \
+    "$FRESH_ID" 2>/dev/null)" || rc=$?
+  smoke_assert_eq "$FRESH_ID" "$accepted" \
+    "T2: resolver accepts a fresh candidate as-is"
+  smoke_assert_eq "0" "$rc" \
+    "T2: resolver returns rc=0 for an accepted fresh candidate"
+
+  # Empty candidate -> resolver picks the freshest eligible conversation.
+  rc=0
+  accepted="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_resolve_resume_session_id antigravity agyrole "$AGY_WORKDIR" \
+    "" 2>/dev/null)" || rc=$?
+  smoke_assert_eq "$FRESH_ID" "$accepted" \
+    "T2: resolver picks the freshest id for an empty candidate"
+  smoke_assert_eq "0" "$rc" \
+    "T2: resolver returns rc=0 for an empty-candidate resolution"
+}
+
+assert_resolve_stale_rejected() {
+  # The stale conversation id is 10 days old — well past BRIDGE_RESUME_MAX_AGE_HOURS
+  # (48h). Run with ONLY that conversation visible (exclude every fresher id)
+  # so the resolver cannot fall back to a fresh swap — it must reject outright.
+  local accepted rc
+  rc=0
+  accepted="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_resolve_resume_session_id antigravity agyrole "$AGY_WORKDIR" \
+    "$STALE_ID" 48 "$FRESH_ID,$OLDER_ID,$GHOST_ID" 2>/dev/null)" || rc=$?
+  smoke_assert_eq "" "$accepted" \
+    "T3: STALE-ID REJECTION — stale candidate resolves to empty"
+  smoke_assert_eq "1" "$rc" \
+    "T3: STALE-ID REJECTION — stale candidate returns rc=1 (launch fresh)"
+
+  # With fresher conversations visible, a stale candidate is SWAPPED for the
+  # freshest one (rc=2) — never accepted as-is.
+  rc=0
+  accepted="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_resolve_resume_session_id antigravity agyrole "$AGY_WORKDIR" \
+    "$STALE_ID" 48 "" 2>/dev/null)" || rc=$?
+  smoke_assert_eq "$FRESH_ID" "$accepted" \
+    "T3: stale candidate with a fresher sibling swaps to the fresh id"
+  smoke_assert_eq "2" "$rc" \
+    "T3: stale-candidate swap returns rc=2"
+}
+
+assert_launch_cmd_carries_conversation() {
+  # Fresh path: detect -> resolve -> launch builder must carry --conversation.
+  local detected accepted resume_cmd
+  detected="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_detect_antigravity_session_id "$AGY_WORKDIR" 0 "")"
+  accepted="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_resolve_resume_session_id antigravity agyrole "$AGY_WORKDIR" \
+    "$detected" 2>/dev/null)"
+  resume_cmd="$(bridge_antigravity_dynamic_launch_cmd agyrole 1 "$accepted")"
+  smoke_assert_contains "$resume_cmd" "--conversation $FRESH_ID" \
+    "T4: resolved fresh id flows into agy --conversation <id>"
+
+  # Stale path: resolver returns empty -> launch builder falls back to the
+  # fresh `-i` bootstrap form (no --conversation).
+  local stale_accepted rc fresh_cmd
+  rc=0
+  stale_accepted="$(GEMINI_HOME="$GEMINI_ROOT" \
+    bridge_resolve_resume_session_id antigravity agyrole "$AGY_WORKDIR" \
+    "$STALE_ID" 48 "$FRESH_ID,$OLDER_ID,$GHOST_ID" 2>/dev/null)" || rc=$?
+  fresh_cmd="$(bridge_antigravity_dynamic_launch_cmd agyrole 1 "$stale_accepted")"
+  smoke_assert_not_contains "$fresh_cmd" "--conversation" \
+    "T4: a stale (empty) resolution does NOT produce --conversation"
+  smoke_assert_contains "$fresh_cmd" " -i " \
+    "T4: a stale (empty) resolution falls back to the fresh -i bootstrap"
+}
+
+assert_other_engines_unaffected() {
+  # Regression guard: claude / codex still take their own resolution path,
+  # not the new antigravity branch. Non-claude/non-antigravity engines keep
+  # the historical passthrough behavior.
+  local accepted rc
+  rc=0
+  accepted="$(bridge_resolve_resume_session_id codex codexrole \
+    "$AGY_WORKDIR" "codex-candidate-xyz" 2>/dev/null)" || rc=$?
+  smoke_assert_eq "codex-candidate-xyz" "$accepted" \
+    "T5: codex engine still uses passthrough resolution (unaffected)"
+  smoke_assert_eq "0" "$rc" \
+    "T5: codex passthrough returns rc=0"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+  load_bridge_lib
+  seed_fixture
+
+  smoke_run "T1: detector returns freshest in-workdir id"  assert_detect
+  smoke_run "T2: resolver accepts a fresh candidate"        assert_resolve_fresh
+  smoke_run "T3: resolver rejects a stale candidate"        assert_resolve_stale_rejected
+  smoke_run "T4: resolved id flows into --conversation"     assert_launch_cmd_carries_conversation
+  smoke_run "T5: claude/codex resolution unaffected"        assert_other_engines_unaffected
+
+  smoke_log "PASS"
+}
+
+main "$@"


### PR DESCRIPTION
## Track A1 — Antigravity conversation-id detector / resolver + `--conversation` resume

Part of the Antigravity (`agy`) engine-support wave (#5039). Base branch:
`feat/antigravity-engine-integration` (A0 + C1 already merged).

A1 makes a bridge-managed `agy` agent **resume its prior conversation** across
restart by detecting, resolving, and refreshing the agy conversation id —
feeding C1's already-built `agy --conversation <id>` resume launch form. All
edits are in the **detection region** of `lib/bridge-state.sh`, disjoint from
C1's launch-builder region.

### Scope

- **`bridge_detect_antigravity_session_id`** (new) — parses the agy conversation
  index (`~/.gemini/antigravity-cli/history.jsonl`) and confirms the
  conversation's `<id>.pb` state file still exists under `conversations/`.
  Mirrors `bridge_detect_codex_session_id`'s recency / since-hint / exclude
  shape. Built on C1's `GEMINI_HOME`-aware path helpers.
- **`bridge_detect_session_id`** — new `antigravity)` arm.
- **`bridge_resolve_resume_session_id`** — real `antigravity` resolution path
  replacing the blind non-`claude` passthrough, **with stale-id rejection**: a
  conversation id older than `BRIDGE_RESUME_MAX_AGE_HOURS` (default 48h)
  resolves to **empty stdout + rc=1**, so the agent launches a fresh
  conversation instead of false-resuming a dead one. The rc contract
  (0 accept / 1 no-eligible / 2 swap-to-fresher) matches the Claude resolver,
  so the existing call sites' `case "$_rc" in 0|2) keep *) clear` logic is
  reused unchanged.
- **`bridge_refresh_agent_session_id`** — already engine-agnostic via
  `bridge_detect_session_id`; the new `antigravity)` arm there is sufficient
  for the conversation id to be detected, stored, and persisted (documented
  in a comment, no behavior change to this function).
- Two **standalone python helpers** invoked file-as-argv —
  `detect-antigravity-session-id.py`, `resolve-antigravity-resume-session-id.py`
  — NOT `$(python3 - <<'PY')` heredoc-stdin (footgun #11).
- New durable smoke `scripts/smoke/antigravity-conversation-resume.sh`, wired
  into `scripts/ci-select-smoke.sh` for `bridge-state.sh` + both helpers.

### `history.jsonl` field shape (confirmed against a real host file)

JSONL, one object per line. Keys: `display` (prompt text), `timestamp` (int,
**epoch milliseconds**), `workspace` (absolute workdir), `conversationId`
(UUID — present **only** on entries that started a persisted conversation;
some rows lack it). Each `conversationId` maps to a `<uuid>.pb` protobuf file
under `conversations/`.

### Stale-id rejection design (Phase 4 please scrutinize)

Two distinct time signals, kept deliberately separate in the resolver:

- **Staleness gate**: a conversation is in-window when `max(history timestamp,
  <id>.pb mtime)` is within `max_age_hours`. Taking the max is conservative —
  a conversation whose `.pb` was touched recently is not rejected just because
  its history row is old.
- **Ranking**: among in-window conversations, the freshest is chosen by the
  **history timestamp** (same ordering the detector uses), with `.pb` mtime as
  a tie-break only. Ranking on `.pb` mtime directly would diverge from the
  detector, since `.pb` files written in the same wall-clock second sort
  unpredictably (caught during smoke-test development — T2 empty-candidate
  resolution).

### Verification

| Command | Result |
| --- | --- |
| `bash -n lib/bridge-state.sh scripts/ci-select-smoke.sh scripts/smoke/antigravity-conversation-resume.sh` | PASS |
| `shellcheck` (same files) | 0 errors |
| `py_compile` both new python helpers | PASS |
| `bash scripts/lint-heredoc-ban.sh --baseline-check` | PASS (no new heredoc-stdin) |
| `./scripts/smoke-test.sh` | exit 0 (pre-existing known #4793 leak noise only — not an A1 regression) |
| `scripts/smoke/antigravity-engine-acceptance.sh` | PASS (still) |
| `scripts/smoke/antigravity-settings-preseed.sh` | PASS (still) |
| `scripts/smoke/antigravity-conversation-resume.sh` | PASS (5/5: detect, resolve-fresh, **stale-id rejection**, `--conversation` flow, claude/codex unaffected) |

### Internal codex self-review

Phase-3 `codex:codex-rescue` review: round 1 `needs-more` (CI selector did not
wire the new smoke) → fix applied to `scripts/ci-select-smoke.sh` → round 2
**`implement-ok`**. 2 rounds, under the 5-round cap.

(#5039 Track A1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
