### PR TITLE
[antigravity wave] B1 — tmux prompt/submit semantics

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -347,7 +347,14 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
   local marker_file=""
   local previous_session_id="${1:-}"
 
-  [[ "$ENGINE" == "claude" ]] || return 0
+  # Antigravity wave B1: agy joins claude on the runtime inbox-bootstrap
+  # re-injection path — a queue task that lands after launch gets the
+  # `agb inbox` nudge at prompt-ready time. (codex deliberately stays off
+  # this path; its launch-time bootstrap is its only injection point.)
+  case "$ENGINE" in
+    claude|antigravity) ;;
+    *) return 0 ;;
+  esac
   [[ $SAFE_MODE -eq 0 ]] || return 0
   marker_file="$(bridge_agent_initial_inbox_marker_file "$AGENT")"
 
@@ -360,15 +367,21 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
       marker_file="$4"
       next_file="$5"
       previous_session_id="$6"
+      engine="$7"
       source "$script_dir/bridge-lib.sh"
-      if bridge_tmux_wait_for_prompt "$session" claude 30; then
-        if [[ -f "$next_file" && -n "$previous_session_id" ]]; then
-          bridge_refresh_agent_session_id "$agent" 24 0.5 "$previous_session_id" >/dev/null 2>&1 || true
-        elif [[ -z "$(bridge_agent_session_id "$agent")" ]]; then
-          # Claude session metadata can appear after tmux startup. Refresh once
-          # more at prompt-ready time so static resume state is persisted before
-          # the agent later goes inactive.
-          bridge_refresh_agent_session_id "$agent" 24 0.5 >/dev/null 2>&1 || true
+      if bridge_tmux_wait_for_prompt "$session" "$engine" 30; then
+        # Session-id refresh is claude-only: the agy conversation-id
+        # detector/resolver is Track A1 and is not wired here. claude keeps
+        # its post-startup metadata refresh; agy skips it until A1 lands.
+        if [[ "$engine" == "claude" ]]; then
+          if [[ -f "$next_file" && -n "$previous_session_id" ]]; then
+            bridge_refresh_agent_session_id "$agent" 24 0.5 "$previous_session_id" >/dev/null 2>&1 || true
+          elif [[ -z "$(bridge_agent_session_id "$agent")" ]]; then
+            # Claude session metadata can appear after tmux startup. Refresh once
+            # more at prompt-ready time so static resume state is persisted before
+            # the agent later goes inactive.
+            bridge_refresh_agent_session_id "$agent" 24 0.5 >/dev/null 2>&1 || true
+          fi
         fi
         bridge_agent_mark_idle_now "$agent"
         if [[ ! -f "$next_file" && ! -f "$marker_file" ]]; then
@@ -379,13 +392,13 @@ bridge_run_schedule_idle_marker_and_inbox_bootstrap() {
             else
               inject_text="[Agent Bridge] ACTION REQUIRED — queued tasks detected. Run exactly: ~/.agent-bridge/agb inbox $agent"
             fi
-            bridge_tmux_send_and_submit "$session" claude "$inject_text" "$agent"
+            bridge_tmux_send_and_submit "$session" "$engine" "$inject_text" "$agent"
           fi
           mkdir -p "$(dirname "$marker_file")"
           printf "%s\n" "$(date +%s)" >"$marker_file"
         fi
       fi
-    ' -- "$SCRIPT_DIR" "$SESSION" "$AGENT" "$marker_file" "$next_file" "$previous_session_id"
+    ' -- "$SCRIPT_DIR" "$SESSION" "$AGENT" "$marker_file" "$next_file" "$previous_session_id" "$ENGINE"
   ) >/dev/null 2>&1 &
 }
 

--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -17,6 +17,28 @@
 # Only `tmux send-keys` is wrapped — `tmux capture-pane`, `display-message`,
 # `set-buffer`, etc. are not on the documented hang path and wrapping them
 # would add cost to hot, well-behaved calls.
+# Antigravity wave B1: bridge_tmux_command_name_matches_engine /
+# bridge_agent_engine_process_alive route the engine VALUE through
+# bridge_engine_binary_name (defined in lib/bridge-core.sh, sourced before
+# this file by bridge-lib.sh). A few smoke harnesses
+# (scripts/smoke/status-engine-detect.sh,
+# scripts/smoke/835-static-admin-launch-helpers/engine-alive-driver.sh)
+# deliberately source ONLY this module to avoid triggering bridge_load_roster.
+# Provide a self-contained fallback so those direct-source paths do not exit
+# 127 ("bridge_engine_binary_name: command not found"). When bridge-core.sh
+# IS loaded its definition is sourced first and wins — this guard is inert.
+if ! declare -F bridge_engine_binary_name >/dev/null 2>&1; then
+  bridge_engine_binary_name() {
+    local engine="${1:-}"
+    case "$engine" in
+      antigravity) printf 'agy' ;;
+      claude) printf 'claude' ;;
+      codex) printf 'codex' ;;
+      *) printf '%s' "$engine" ;;
+    esac
+  }
+fi
+
 bridge_tmux_send_keys_with_timeout() {
   local label="$1"
   shift
@@ -68,19 +90,26 @@ bridge_tmux_command_name_is_claude() {
 
 # Issue #835 Wave B: generalized engine-name predicate used by the
 # tmux-without-engine detection helper. Mirrors bridge_tmux_command_name_is_claude
-# but covers both claude and codex by argument. Kept as a separate function
-# (rather than absorbing into _is_claude with an extra arg) so existing
+# but covers claude, codex and antigravity by argument. Kept as a separate
+# function (rather than absorbing into _is_claude with an extra arg) so existing
 # claude-only call sites keep their narrow contract and a future engine
 # kind (e.g., a wrapper "claude-code") is added by extending the case here.
+#
+# Antigravity wave B1: the engine VALUE ("antigravity") differs from its
+# on-disk binary base name ("agy"), so the engine arg is routed through A0's
+# bridge_engine_binary_name before the basename match. claude/codex are
+# value==binary so they are unaffected.
 bridge_tmux_command_name_matches_engine() {
   local command_name="${1:-}"
   local engine="${2:-}"
   local base=""
+  local binary=""
 
   [[ -n "$command_name" ]] || return 1
   [[ -n "$engine" ]] || return 1
   base="${command_name##*/}"
-  case "$engine" in
+  binary="$(bridge_engine_binary_name "$engine")"
+  case "$binary" in
     claude)
       case "$base" in
         claude|claude-*|claude.*) return 0 ;;
@@ -90,6 +119,12 @@ bridge_tmux_command_name_matches_engine() {
     codex)
       case "$base" in
         codex|codex-*|codex.*) return 0 ;;
+        *) return 1 ;;
+      esac
+      ;;
+    agy)
+      case "$base" in
+        agy|agy-*|agy.*) return 0 ;;
         *) return 1 ;;
       esac
       ;;
@@ -218,9 +253,11 @@ bridge_agent_engine_process_alive() {
   fi
   # Defined only for prompt-driven engines. Anything else returns 1
   # (caller must treat the helper as "unknown" / fall through to the
-  # legacy active-by-tmux check).
+  # legacy active-by-tmux check). antigravity is prompt-driven (B1);
+  # bridge_tmux_process_tree_has_engine routes the engine value through
+  # bridge_engine_binary_name so the `agy` process is matched.
   case "$engine" in
-    claude|codex) ;;
+    claude|codex|antigravity) ;;
     *) return 1 ;;
   esac
 
@@ -320,7 +357,7 @@ bridge_tmux_engine_requires_prompt() {
   local engine="$1"
 
   case "$engine" in
-    claude|codex)
+    claude|codex|antigravity)
       return 0
       ;;
     *)
@@ -413,6 +450,35 @@ bridge_tmux_codex_prompt_line_ready() {
   [[ "$trimmed" == ›* || "$trimmed" == '>'* ]]
 }
 
+# Antigravity wave B1: agy (Antigravity CLI v1.0.0) ready-for-input detection.
+#
+# Pinned against a live bridge-managed agy session 2026-05-21. The agy TUI
+# always draws a composer box whose input line is a bare `>` framed by
+# horizontal-rule lines — that glyph is present *both* at a ready prompt and
+# mid-turn, so a codex-style bare-`>` line check would false-positive while
+# agy is generating. The reliable ready/busy discriminator is the status
+# footer:
+#   ready : "? for shortcuts" ............ "Gemini <model>"
+#   busy  : "esc to cancel"   ............ "Gemini <model>"  (+ a
+#           "<spinner> Generating..." line above the composer)
+# So a prompt is ready iff the capture footer carries the "? for shortcuts"
+# affordance AND no in-flight "esc to cancel" / "Generating..." marker.
+#
+# This is a whole-capture predicate (the ready and busy signals live on
+# different lines), so it is evaluated once on the full text rather than per
+# line in the bridge_tmux_session_has_prompt_from_text iterator.
+bridge_tmux_antigravity_prompt_ready_from_text() {
+  local text="$1"
+
+  [[ -n "$text" ]] || return 1
+  # In-flight turn: the footer shows the cancel affordance and/or the
+  # generation spinner line. Either one means agy is busy, not ready.
+  [[ "$text" == *"esc to cancel"* ]] && return 1
+  [[ "$text" == *"Generating..."* ]] && return 1
+  # Ready: the idle footer affordance is drawn.
+  [[ "$text" == *"? for shortcuts"* ]]
+}
+
 bridge_tmux_prompt_line_has_pending_input() {
   local engine="$1"
   local trimmed="$2"
@@ -482,6 +548,15 @@ bridge_tmux_session_has_prompt_from_text() {
 
   bridge_tmux_engine_requires_prompt "$engine" || return 0
   [[ -n "$recent" ]] || return 1
+
+  # Antigravity wave B1: agy's ready/busy signals live on distinct footer
+  # lines, so it is a whole-capture predicate evaluated before the per-line
+  # iterator (the bare `>` composer glyph is drawn mid-turn too — see
+  # bridge_tmux_antigravity_prompt_ready_from_text).
+  if [[ "$engine" == "antigravity" ]]; then
+    bridge_tmux_antigravity_prompt_ready_from_text "$recent"
+    return $?
+  fi
 
   # Issue #815 Wave A: feeding a large tmux capture into the iterator via
   # here-string blocked Bash in `heredoc_write` on the operator's stale
@@ -1203,6 +1278,15 @@ bridge_tmux_send_and_submit() {
   case "$engine" in
     claude)
       bridge_tmux_type_and_submit "$session" "$text" "$engine"
+      ;;
+    antigravity)
+      # Antigravity wave B1: agy accepts bracketed paste into its composer
+      # and submits on C-m, like codex — verified against a live agy session
+      # 2026-05-21 (queued task pasted + submitted, processed to completion).
+      # The codex-specific placeholder/composer-state retries inside
+      # bridge_tmux_paste_and_submit are guarded by `engine == codex`, so the
+      # agy path takes the plain paste + verify/retry-on-C-m flow.
+      bridge_tmux_paste_and_submit "$session" "$text" "$engine"
       ;;
     *)
       bridge_tmux_paste_and_submit "$session" "$text" "$engine"


### PR DESCRIPTION
## Track B1 — Antigravity (agy) tmux prompt/busy/send semantics + runtime inbox-bootstrap

Track B1 of the Antigravity engine-support wave (#5039). Builds on **A0** (engine enum + `bridge_engine_binary_name`) and **C1** (agy launch contract), both already merged to `feat/antigravity-engine-integration`. **PR base is the integration branch, not `main`.**

B1 makes the daemon detect a live `agy` session's prompt state and push queued tasks into the agy console reliably.

### Changes

**`lib/bridge-tmux.sh`**
- `bridge_tmux_engine_requires_prompt` — `antigravity` joins the return-0 arm.
- `bridge_tmux_command_name_matches_engine` — the engine VALUE is routed through A0's `bridge_engine_binary_name`, so `antigravity` matches the `agy` process basename. Added a self-contained `declare -F` fallback for `bridge_engine_binary_name` (before the first function) so the smokes that source this module alone (`status-engine-detect.sh`, 835 `engine-alive-driver.sh`) do not exit 127; `bridge-core.sh`'s real definition wins on the normal `bridge-lib.sh` load path (core sourced before tmux).
- `bridge_agent_engine_process_alive` — `antigravity` joins the prompt-driven gate; the process-tree walker now matches the agy process.
- `bridge_tmux_antigravity_prompt_ready_from_text` (new) — the agy TUI draws a bare `>` composer glyph **both** at a ready prompt and mid-turn, so the reliable ready/busy discriminator is the status footer: ready shows `? for shortcuts`, busy shows `esc to cancel` + a `Generating...` line.
- `bridge_tmux_session_has_prompt_from_text` — `antigravity` is a whole-capture predicate, evaluated before the per-line iterator.
- `bridge_tmux_send_and_submit` — explicit `antigravity` arm: paste-and-submit like codex (codex-only placeholder retries stay engine-gated).

**`bridge-run.sh`**
- `bridge_run_schedule_idle_marker_and_inbox_bootstrap` — the claude-only gate extended to `claude|antigravity`, so a queue task arriving after launch gets the `agb inbox` re-injection at prompt-ready time. The `bash -lc` subprocess body takes a 7th `engine` positional arg; the session-id refresh stays claude-only (agy conversation-id resolution is Track A1).

### Verification matrix

| Check | Result |
|---|---|
| `bash -n lib/bridge-tmux.sh bridge-run.sh` | PASS |
| `shellcheck lib/bridge-tmux.sh bridge-run.sh` | PASS (0 errors) |
| `lint-heredoc-ban.sh --baseline-check` | PASS (baseline ratchet held) |
| `./scripts/smoke-test.sh` | only pre-existing `#4793` leak + `activity-state` errors — **confirmed identical on the untouched integration baseline** (not a B1 regression) |
| `antigravity-engine-acceptance.sh` (A0) | PASS |
| `antigravity-settings-preseed.sh` (C1) | PASS |
| `status-engine-detect.sh` | PASS (the smoke codex r1 flagged) |
| `835-static-admin-launch.sh` | PASS (parent of `engine-alive-driver.sh`) |

### Live-marker evidence — HARD merge criterion (a) PROVEN

A bridge-managed agy session was spawned in an isolated `BRIDGE_HOME` (`mktemp -d`) via `agent-bridge --agy`. Against agy v1.0.0:

- The agy ready footer is the literal `? for shortcuts`; mid-turn it is `esc to cancel` + a `<spinner> Generating...` line. The bare `>` composer glyph alone is **not** a reliable marker (drawn mid-turn too).
- **11/11** live agy-pane predicate checks PASSED (`engine_requires_prompt`, `session_has_prompt_from_text` ready vs busy, `command_name_matches_engine` agy/claude/codex matrix, `antigravity_prompt_ready_from_text` ready vs busy).
- **End-to-end**: `bridge_tmux_wait_for_prompt` detected prompt-ready, `bridge_tmux_send_and_submit` pushed a queued-task nudge into the agy console, agy processed it and replied with the exact expected token, the session returned to the ready footer — no send into a busy TUI / trust selector.

Criterion **(a) capture-pane prompt-ready marker** is satisfied; `--log-file` tailing (criterion b) was not needed.

### Phase-4 finding (NOT a B1 blocker)

agy v1.0.0 **rejects `altScreenMode: "inline"`** — only `always` / `never` / `disabled` are accepted; an `inline` value triggers an agy startup-blocking "Settings Error" selector. C1's settings preseed writes `inline`. B1's marker was pinned with agy running on default `altScreenMode` (which still renders inline-style on the normal screen, so `capture-pane` works). **Recommend Phase 4 patch C1's preseed to a valid value.**

### Internal codex self-review

`codex:codex-rescue` review: **implement-ok** after 2 rounds. r1 found one blocker (the `bridge_engine_binary_name` direct-source 127 in two smokes) → fixed with the `declare -F` fallback; r2 confirmed the fix sound and no other regressions.

(#5039 Track B1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)