### PR TITLE
[antigravity wave] fix — preseed altScreenMode=always (agy v1.0.0 rejects inline)

### DIFF
--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -504,8 +504,9 @@ elif [[ "$ENGINE" == "antigravity" && $SAFE_MODE -eq 0 ]]; then
   # ensures here — the launch-time `agy -i <bootstrap-prompt>` (built by
   # bridge_antigravity_dynamic_launch_cmd) is the SessionStart analogue.
   # Preseed the agy settings.json BEFORE launch: trust the workdir
-  # (pre-empts the trust selector), allow the bridge CLIs, and force
-  # altScreenMode=inline so tmux capture-pane idle detection works.
+  # (pre-empts the trust selector), allow the bridge CLIs, and pin
+  # altScreenMode=always so tmux capture-pane idle detection is
+  # deterministic (agy v1.0.0 rejects the "inline" value).
   if ! bridge_antigravity_settings_preseed "$WORK_DIR"; then
     bridge_warn "Antigravity settings preseed skipped or failed: $WORK_DIR"
   fi

--- a/lib/bridge-antigravity.sh
+++ b/lib/bridge-antigravity.sh
@@ -6,8 +6,9 @@
 # bridge context the Claude/Codex agents get via SessionStart hooks:
 #
 #   - bridge_antigravity_settings_preseed — atomic preseed of the agy
-#     settings.json (trust workspace, allow the bridge CLIs, force
-#     altScreenMode=inline so tmux idle detection works).
+#     settings.json (trust workspace, allow the bridge CLIs, pin
+#     altScreenMode=always so tmux capture-pane idle detection is
+#     deterministic — agy v1.0.0 rejects the "inline" value).
 #   - bridge_antigravity_dynamic_launch_cmd — builds the launch argv with
 #     the mandatory `-i <bootstrap-prompt>` for fresh sessions and the
 #     `--conversation <id>` resume form.
@@ -52,7 +53,7 @@ bridge_antigravity_history_file() {
 #
 # Atomic read-modify-write of the agy settings.json: add <workdir> to
 # trustedWorkspaces (pre-empts the trust selector), add the bridge CLIs to
-# permissions.allow, and force altScreenMode=inline. All pre-existing keys
+# permissions.allow, and pin altScreenMode=always. All pre-existing keys
 # are preserved; idempotent. Runs BEFORE launch — not a reactive tmux
 # workaround. The JSON mutation is done by a standalone python helper
 # invoked file-as-argv (no heredoc-stdin — footgun #11).

--- a/scripts/python-helpers/antigravity-settings-preseed.py
+++ b/scripts/python-helpers/antigravity-settings-preseed.py
@@ -11,8 +11,11 @@ Read-modify-write of `~/.gemini/antigravity-cli/settings.json`:
     pre-empted before launch;
   - add `command(<agb>)` and `command(<agent-bridge>)` to
     `permissions.allow` so the bridge CLIs run without per-call prompts;
-  - set `altScreenMode` to `inline` so `tmux capture-pane` idle detection
-    works on the normal screen (mandated by the wave plan — de-risks B1).
+  - set `altScreenMode` to `always` so the agy render mode is deterministic
+    for `tmux capture-pane` idle detection. (The wave plan first specified
+    `inline`, but agy v1.0.0 rejects that value with a blocking "Settings
+    Error" selector — verified live at Phase-5b QA. `always` is accepted and
+    `tmux capture-pane` reads the alternate screen fine.)
 
 ALL pre-existing keys are preserved. Idempotent: a second run adds nothing
 duplicate. The write is atomic (temp file in the same directory + rename).
@@ -85,8 +88,10 @@ def main(argv: list[str]) -> int:
         if entry not in allow:
             allow.append(entry)
 
-    # altScreenMode — inline keeps tmux capture-pane idle detection working.
-    data["altScreenMode"] = "inline"
+    # altScreenMode — pin a deterministic render mode for tmux capture-pane
+    # idle detection. agy v1.0.0 rejects "inline" (blocking Settings Error);
+    # "always" is accepted and capture-pane reads the alternate screen fine.
+    data["altScreenMode"] = "always"
 
     target_dir = os.path.dirname(os.path.abspath(settings_file)) or "."
     try:

--- a/scripts/smoke/antigravity-settings-preseed.sh
+++ b/scripts/smoke/antigravity-settings-preseed.sh
@@ -13,7 +13,7 @@
 # Assertions:
 # T1: preseed preserves ALL pre-existing keys, adds the workdir to
 #     trustedWorkspaces, adds both command(...) allow entries, sets
-#     altScreenMode=inline.
+#     altScreenMode=always (overwriting the fixture's prior value).
 # T2: preseed is idempotent — a second run adds nothing duplicate.
 # T3: fresh launch cmd carries `agy --dangerously-skip-permissions -i
 #     <bootstrap-prompt>`; resume launch cmd carries `--conversation <id>`
@@ -58,7 +58,7 @@ assert_preseed_preserves_and_adds() {
     "allow": ["command(/usr/bin/git)"],
     "deny": ["command(/bin/rm)"]
   },
-  "altScreenMode": "always"
+  "altScreenMode": "auto"
 }
 JSON
 
@@ -80,7 +80,7 @@ JSON
   smoke_assert_contains "$dump" "denyPreserved=True"      "T1: permissions.deny preserved"
   smoke_assert_contains "$dump" "agbAllow=True"           "T1: agb command(...) allow added"
   smoke_assert_contains "$dump" "agentBridgeAllow=True"   "T1: agent-bridge command(...) allow added"
-  smoke_assert_contains "$dump" "altScreenMode=inline"    "T1: altScreenMode set to inline"
+  smoke_assert_contains "$dump" "altScreenMode=always"    "T1: altScreenMode set to always (overwrote fixture's 'auto')"
 }
 
 assert_preseed_idempotent() {


### PR DESCRIPTION
## Phase-5b QA defect — release-blocking

The Phase-5b live agy QA (spawn a real bridge-managed agy agent on macOS) found that **agy v1.0.0 rejects `altScreenMode: "inline"`**:

```
⚠ Settings Error — invalid settings: altScreenMode: unrecognized value "inline"
[ Exit | Continue with default settings ]
```

The agy session hard-stalls on that selector. Reproduced 3/3 by the QA agent (and independently first-seen by the B1 fixer). C1's `bridge_antigravity_settings_preseed` wrote `inline` per the wave plan's "agy facts" — but `inline` is a UI **label**, not an accepted JSON enum value for the installed binary. The QA verified `"always"` IS accepted.

## Fix

`scripts/python-helpers/antigravity-settings-preseed.py` pins `altScreenMode = "always"` instead of `"inline"`. `tmux capture-pane` reads the alternate screen fine (verified in the v1 investigation; the QA's functional checks all passed with agy on an altscreen-equivalent render mode).

- `scripts/smoke/antigravity-settings-preseed.sh` — T1 asserts `altScreenMode=always`; the fixture's prior value changed `always` → `auto` so the overwrite is still meaningfully tested.
- `lib/bridge-antigravity.sh` — comments updated.
- Agreed wave plan doc "agy facts" corrected (`~/.agent-bridge/shared/antigravity-wave-plan-v4-AGREED.md`, untracked reference artifact).

## Verification

- py_compile + bash -n + shellcheck clean.
- `antigravity-settings-preseed.sh` 4/4 PASS.
- End-to-end re-QA with `altScreenMode=always` to follow this merge (Phase-5b re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)