### PR TITLE
fix(watchdog): engine-aware home-profile contract; exempt antigravity

### DIFF
--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -266,6 +266,16 @@ def heartbeat_age_seconds(agent_dir: Path) -> tuple[bool, int | None]:
 NON_ONBOARDING_SESSION_TYPES = frozenset({"dynamic", "cron"})
 
 
+# Engines with no Claude-runtime profile contract at the agent home root
+# — none of these CLIs read CLAUDE.md / SOUL.md / SESSION-TYPE.md, so the
+# watchdog must not assert profile drift on them. This is an explicit
+# allowlist, NOT "anything that isn't claude": a genuinely unknown engine
+# string stays under the conservative Claude-default contract so a new
+# engine surfaces as drift (prompting a watchdog update) instead of
+# silently skipping the check. Add a new exempt engine here.
+NON_CONTRACT_ENGINES = frozenset({"codex", "antigravity"})
+
+
 def has_home_profile_contract(engine: str, agent_source: str) -> bool:
     """Whether the watchdog should hold this agent to the Claude-style
     home-profile contract: the ``CLAUDE_REQUIRED_FILES`` set, the managed
@@ -277,24 +287,29 @@ def has_home_profile_contract(engine: str, agent_source: str) -> bool:
     (``antigravity``, v0.14.5) then fell through to the Claude default and
     surfaced as a false ``status=error`` on every scan, because none of
     those three call sites knew about it. This predicate is the single
-    gate so a new engine is exempt by construction.
+    gate so a known exempt engine is exempt by construction.
 
-    Only Claude *static* (or unknown-source — the conservative legacy
-    default) agents carry the contract:
+    The contract holds for:
 
-      - ``agent_source == "dynamic"`` is a full exemption regardless of
+      - Claude agents, static or unknown-source.
+      - Any *unknown* engine string, static or unknown-source — the
+        conservative legacy default (#905). An unknown engine is held to
+        the contract so it surfaces as drift; the fix is to add it to
+        ``NON_CONTRACT_ENGINES`` once the watchdog is taught about it.
+
+    The contract is waived for:
+
+      - ``agent_source == "dynamic"`` — a full exemption regardless of
         engine. Dynamic agents are ad-hoc spawns
         (``agent-bridge --<engine> --name``) that never run
         ``bridge_scaffold_agent_home``, so legitimately have no profile
         files, no managed block, and no SESSION-TYPE.md. The watchdog has
         no finer "scaffolded vs ad-hoc" signal than ``agent_source``.
-      - Non-Claude engines (codex, antigravity) have no Claude-runtime
-        profile-file contract at the agent home root — none of those CLIs
-        read CLAUDE.md / SOUL.md / SESSION-TYPE.md.
+      - The known non-Claude engines in ``NON_CONTRACT_ENGINES``.
     """
     if agent_source == "dynamic":
         return False
-    return engine == "claude"
+    return engine not in NON_CONTRACT_ENGINES
 
 
 def required_profile_files(engine: str, agent_source: str = "") -> tuple[str, ...]:
@@ -321,18 +336,21 @@ def classify_status(
     agent_source: str = "",
     engine: str = "claude",
 ) -> str:
-    if missing_files:
-        return "error"
-    # The onboarding-staleness and managed-block signals only apply to
-    # agents under the home-profile contract (see
-    # has_home_profile_contract). Non-Claude engines have no
-    # SESSION-TYPE.md / managed-CLAUDE.md contract (#905, originally codex
-    # only — now also antigravity), and dynamic agents are ad-hoc spawns
-    # that legitimately land with `missing_managed_claude_block=yes` and
-    # `onboarding_state=pending` until their first run; flagging either is
-    # admin alert-fatigue for a condition admin cannot resolve (#907,
-    # #303/#304/#343 anti-pattern).
+    # All three drift signals — missing required files, managed-block,
+    # onboarding staleness — are gated on the home-profile contract (see
+    # has_home_profile_contract). Known non-Claude engines have no
+    # SESSION-TYPE.md / managed-CLAUDE.md / required-file contract (#905,
+    # originally codex only — now also antigravity), and dynamic agents
+    # are ad-hoc spawns that legitimately land with
+    # `missing_managed_claude_block=yes` and `onboarding_state=pending`
+    # until their first run; flagging any of these is admin alert-fatigue
+    # for a condition admin cannot resolve (#907, #303/#304/#343
+    # anti-pattern). missing_files is gated here too so classify_status is
+    # internally consistent and does not depend on the caller having
+    # pre-emptied `required` via required_profile_files.
     contract = has_home_profile_contract(engine, agent_source)
+    if missing_files and contract:
+        return "error"
     onboarding_stale = (
         contract
         and onboarding_state in {"pending", "missing"}
@@ -369,12 +387,15 @@ def scan_agent(
         required = required_profile_files(engine, agent_source)
         missing_files = [name for name in required if not (agent_dir / name).exists()]
         # The `missing_managed_claude_block` FIELD records actual file
-        # state, so it is gated on engine alone: only Claude agents own a
-        # CLAUDE.md to inspect (codex / antigravity don't). A dynamic
-        # Claude agent still gets an accurate field — #907 keeps the field
-        # truthful and suppresses only the classification *signal*, which
-        # classify_status gates through has_home_profile_contract.
-        if engine == "claude":
+        # state, so it is gated on engine alone, NOT the contract: any
+        # engine that could own a CLAUDE.md (Claude + unknown engines —
+        # same conservative set as the contract) gets a truthful field;
+        # the known non-Claude engines in NON_CONTRACT_ENGINES definitively
+        # don't own one. A dynamic Claude agent still gets an accurate
+        # field — #907 keeps the field truthful and suppresses only the
+        # classification *signal*, which classify_status gates through
+        # has_home_profile_contract.
+        if engine not in NON_CONTRACT_ENGINES:
             claude_text = read_text(agent_dir / "CLAUDE.md") if (agent_dir / "CLAUDE.md").exists() else ""
             missing_block = MANAGED_START not in claude_text or MANAGED_END not in claude_text
         else:

--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -266,24 +266,50 @@ def heartbeat_age_seconds(agent_dir: Path) -> tuple[bool, int | None]:
 NON_ONBOARDING_SESSION_TYPES = frozenset({"dynamic", "cron"})
 
 
-def required_profile_files(engine: str) -> tuple[str, ...]:
-    """Per-engine required profile-file set.
+def has_home_profile_contract(engine: str, agent_source: str) -> bool:
+    """Whether the watchdog should hold this agent to the Claude-style
+    home-profile contract: the ``CLAUDE_REQUIRED_FILES`` set, the managed
+    ``CLAUDE.md`` block, and the ``SESSION-TYPE.md`` onboarding state.
 
-    Issue #905: the watchdog used to assert ``CLAUDE_REQUIRED_FILES`` on
-    every agent regardless of engine, so codex agents (which don't read
-    any of those Claude-runtime files) surfaced as ``status=error`` with
-    every required file marked missing. Codex CLI has no equivalent
-    required-file contract at the agent home root, so the codex path
-    returns an empty tuple — the missing-files check effectively becomes
-    a no-op for codex and the watchdog stops manufacturing drift for an
-    engine it doesn't actually monitor.
+    Issues #905 / #907 each special-cased one slice of this — codex was
+    exempted from required files, the managed block, and onboarding;
+    dynamic agents were exempted from the managed block. A third engine
+    (``antigravity``, v0.14.5) then fell through to the Claude default and
+    surfaced as a false ``status=error`` on every scan, because none of
+    those three call sites knew about it. This predicate is the single
+    gate so a new engine is exempt by construction.
+
+    Only Claude *static* (or unknown-source — the conservative legacy
+    default) agents carry the contract:
+
+      - ``agent_source == "dynamic"`` is a full exemption regardless of
+        engine. Dynamic agents are ad-hoc spawns
+        (``agent-bridge --<engine> --name``) that never run
+        ``bridge_scaffold_agent_home``, so legitimately have no profile
+        files, no managed block, and no SESSION-TYPE.md. The watchdog has
+        no finer "scaffolded vs ad-hoc" signal than ``agent_source``.
+      - Non-Claude engines (codex, antigravity) have no Claude-runtime
+        profile-file contract at the agent home root — none of those CLIs
+        read CLAUDE.md / SOUL.md / SESSION-TYPE.md.
     """
-    if engine == "codex":
-        return ()
-    # Claude (and any future / unknown engine — conservative default
-    # preserves the pre-#905 behavior so missing roster metadata never
-    # silently turns off the drift check for a real Claude agent).
-    return CLAUDE_REQUIRED_FILES
+    if agent_source == "dynamic":
+        return False
+    return engine == "claude"
+
+
+def required_profile_files(engine: str, agent_source: str = "") -> tuple[str, ...]:
+    """Required profile-file set for an agent.
+
+    Returns ``CLAUDE_REQUIRED_FILES`` only for agents under the
+    home-profile contract (see :func:`has_home_profile_contract`); every
+    other agent returns an empty tuple so the missing-files check is a
+    no-op. ``agent_source`` defaults to ``""`` so a legacy positional
+    ``required_profile_files(engine)`` call keeps the conservative
+    Claude-default behavior for an unknown source.
+    """
+    if has_home_profile_contract(engine, agent_source):
+        return CLAUDE_REQUIRED_FILES
+    return ()
 
 
 def classify_status(
@@ -297,30 +323,22 @@ def classify_status(
 ) -> str:
     if missing_files:
         return "error"
-    # Issue #905: codex agents have no SESSION-TYPE.md / onboarding-state
-    # contract — they're operated entirely through the Codex CLI, which
-    # never reads either file. The watchdog's onboarding-staleness check
-    # was firing on every codex agent (`session_type=unknown`,
-    # `onboarding_state=missing`) and contributing to problem_count even
-    # after the missing-files check was made engine-aware. Skip the
-    # onboarding-stale signal entirely for codex.
+    # The onboarding-staleness and managed-block signals only apply to
+    # agents under the home-profile contract (see
+    # has_home_profile_contract). Non-Claude engines have no
+    # SESSION-TYPE.md / managed-CLAUDE.md contract (#905, originally codex
+    # only — now also antigravity), and dynamic agents are ad-hoc spawns
+    # that legitimately land with `missing_managed_claude_block=yes` and
+    # `onboarding_state=pending` until their first run; flagging either is
+    # admin alert-fatigue for a condition admin cannot resolve (#907,
+    # #303/#304/#343 anti-pattern).
+    contract = has_home_profile_contract(engine, agent_source)
     onboarding_stale = (
-        engine != "codex"
+        contract
         and onboarding_state in {"pending", "missing"}
         and session_type not in NON_ONBOARDING_SESSION_TYPES
     )
-    # Issue #907: dynamic agents (system-provisioned, e.g. `librarian`)
-    # land with `missing_managed_claude_block=yes` until their first run
-    # fills the block in. The watchdog was emitting a high-priority
-    # admin-inbox profile-drift task on every cycle for that
-    # fresh-provision default — a condition admin has no authority to
-    # resolve per ADMIN-PROTOCOL's static/dynamic boundary (#303/#304/
-    # #343 anti-pattern). Suppress the `missing_block` warn signal for
-    # dynamic agents so a fresh-provisioned dynamic with no other drift
-    # classifies as `ok` and never reaches `problem_count`.
-    effective_missing_block = missing_block
-    if agent_source == "dynamic":
-        effective_missing_block = False
+    effective_missing_block = missing_block if contract else False
     if broken_links or effective_missing_block or onboarding_stale:
         return "warn"
     return "ok"
@@ -348,16 +366,19 @@ def scan_agent(
     # `broken_links` channel keeps the existing markdown render
     # unchanged (no new `AgentWatch` fields, per spec).
     try:
-        required = required_profile_files(engine)
+        required = required_profile_files(engine, agent_source)
         missing_files = [name for name in required if not (agent_dir / name).exists()]
-        # The managed-block check only applies to Claude — codex agents
-        # don't own a CLAUDE.md and shouldn't be flagged for a block they
-        # have no contract to maintain (#905).
-        if engine == "codex":
-            missing_block = False
-        else:
+        # The `missing_managed_claude_block` FIELD records actual file
+        # state, so it is gated on engine alone: only Claude agents own a
+        # CLAUDE.md to inspect (codex / antigravity don't). A dynamic
+        # Claude agent still gets an accurate field — #907 keeps the field
+        # truthful and suppresses only the classification *signal*, which
+        # classify_status gates through has_home_profile_contract.
+        if engine == "claude":
             claude_text = read_text(agent_dir / "CLAUDE.md") if (agent_dir / "CLAUDE.md").exists() else ""
             missing_block = MANAGED_START not in claude_text or MANAGED_END not in claude_text
+        else:
+            missing_block = False
         session_type, onboarding_state = parse_session_type(agent_dir)
         heartbeat_present, heartbeat_age = heartbeat_age_seconds(agent_dir)
         broken_links = collect_broken_links(agent_dir)

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -454,6 +454,19 @@ select_for_path() {
       add_live live-tmux-daemon
       ;;
 
+    bridge-watchdog.py)
+      # bridge-watchdog.py owns the home-profile-contract check
+      # (has_home_profile_contract): the required profile files, the
+      # managed CLAUDE.md block, and the onboarding-staleness signal only
+      # apply to Claude static agents. A new engine (antigravity, v0.14.5)
+      # otherwise falls through to the Claude default and surfaces as a
+      # false status=error. Cover the contract truth-table smoke plus the
+      # registry-anchoring and stderr-capture regressions whenever the
+      # watchdog moves.
+      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture queue
+      add_integration integration-minimal
+      ;;
+
     bridge-docs.py)
       # v0.13.6 hotfix track 1: bridge-docs.py owns AGENT_SHARED_LINKS and
       # the shared-doc render dispatch. The admin-protocol-shared-link

--- a/scripts/smoke/watchdog-profile-contract.py
+++ b/scripts/smoke/watchdog-profile-contract.py
@@ -50,10 +50,15 @@ def main() -> int:
     check("contract: claude+dynamic", has_contract("claude", "dynamic"), False)
     check("contract: codex+static", has_contract("codex", "static"), False)
     check("contract: codex+dynamic", has_contract("codex", "dynamic"), False)
-    # The antigravity regression: a newer engine must be exempt by
-    # construction, not fall through to the Claude default.
+    # The antigravity regression: a *known* newer engine must be exempt
+    # by construction (it is in NON_CONTRACT_ENGINES).
     check("contract: antigravity+static", has_contract("antigravity", "static"), False)
     check("contract: antigravity+dynamic", has_contract("antigravity", "dynamic"), False)
+    # An *unknown* engine string is NOT exempted — it stays under the
+    # conservative Claude-default contract so a new engine surfaces as
+    # drift instead of silently skipping the check.
+    check("contract: unknown-engine+static", has_contract("future-engine", "static"), True)
+    check("contract: unknown-engine+dynamic", has_contract("future-engine", "dynamic"), False)
 
     # --- required_profile_files -----------------------------------------
     check(
@@ -77,6 +82,12 @@ def main() -> int:
         required_profile_files("claude", "dynamic"),
         (),
     )
+    # An unknown engine stays under the conservative contract.
+    check(
+        "required: unknown-engine+static -> CLAUDE_REQUIRED_FILES",
+        required_profile_files("future-engine", "static"),
+        claude_required,
+    )
 
     # --- classify_status: regression guard ------------------------------
     # A Claude static agent missing profile files must still be error.
@@ -87,6 +98,35 @@ def main() -> int:
             session_type="admin", agent_source="static", engine="claude",
         ),
         "error",
+    )
+    # An unknown engine is held to the conservative contract: missing
+    # files still escalate to error.
+    check(
+        "classify: unknown-engine+static+missing-files -> error",
+        classify_status(
+            ["CLAUDE.md"], [], "complete", False,
+            session_type="", agent_source="static", engine="future-engine",
+        ),
+        "error",
+    )
+    # classify_status gates missing_files through the predicate too: a
+    # non-contract agent with missing_files passed in must not error,
+    # independent of whether the caller pre-emptied `required`.
+    check(
+        "classify: codex+static+missing-files -> ok",
+        classify_status(
+            ["CLAUDE.md"], [], "missing", False,
+            session_type="unknown", agent_source="static", engine="codex",
+        ),
+        "ok",
+    )
+    check(
+        "classify: claude+dynamic+missing-files -> ok",
+        classify_status(
+            ["CLAUDE.md"], [], "pending", False,
+            session_type="dynamic", agent_source="dynamic", engine="claude",
+        ),
+        "ok",
     )
 
     # --- classify_status: antigravity exemptions (the fix) --------------

--- a/scripts/smoke/watchdog-profile-contract.py
+++ b/scripts/smoke/watchdog-profile-contract.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# scripts/smoke/watchdog-profile-contract.py — direct callee for
+# scripts/smoke/watchdog-profile-contract.sh. Kept as a standalone file
+# (not inlined as heredoc-stdin to python3) so the smoke is immune to
+# footgun #11 (Bash 5.3.9 `read_comsub` / `heredoc_write` deadlock).
+#
+# Loads bridge-watchdog.py via importlib (the file name has a hyphen so a
+# plain import won't work) and pins the home-profile-contract truth table:
+# has_home_profile_contract, required_profile_files, and the classify_status
+# signals it gates. The regression of record is the antigravity engine
+# (v0.14.5) surfacing as a false status=error, plus the guard that a Claude
+# static agent with missing files must still classify as error.
+
+import importlib.util
+import pathlib
+import sys
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    watchdog_path = repo_root / "bridge-watchdog.py"
+    spec = importlib.util.spec_from_file_location(
+        "bridge_watchdog_under_test", watchdog_path
+    )
+    if spec is None or spec.loader is None:
+        print(f"[smoke] cannot load {watchdog_path}", file=sys.stderr)
+        return 2
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec_module so dataclass field resolution
+    # (AgentWatch) can look the module up via sys.modules.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    has_contract = module.has_home_profile_contract
+    required_profile_files = module.required_profile_files
+    classify_status = module.classify_status
+    claude_required = module.CLAUDE_REQUIRED_FILES
+
+    failures: list[str] = []
+
+    def check(label: str, got: object, want: object) -> None:
+        if got != want:
+            failures.append(f"{label}: got {got!r}, want {want!r}")
+        else:
+            print(f"  PASS  {label} = {got!r}")
+
+    # --- has_home_profile_contract --------------------------------------
+    check("contract: claude+static", has_contract("claude", "static"), True)
+    check("contract: claude+unknown-source", has_contract("claude", ""), True)
+    check("contract: claude+dynamic", has_contract("claude", "dynamic"), False)
+    check("contract: codex+static", has_contract("codex", "static"), False)
+    check("contract: codex+dynamic", has_contract("codex", "dynamic"), False)
+    # The antigravity regression: a newer engine must be exempt by
+    # construction, not fall through to the Claude default.
+    check("contract: antigravity+static", has_contract("antigravity", "static"), False)
+    check("contract: antigravity+dynamic", has_contract("antigravity", "dynamic"), False)
+
+    # --- required_profile_files -----------------------------------------
+    check(
+        "required: claude+static -> CLAUDE_REQUIRED_FILES",
+        required_profile_files("claude", "static"),
+        claude_required,
+    )
+    check(
+        "required: claude legacy positional -> CLAUDE_REQUIRED_FILES",
+        required_profile_files("claude"),
+        claude_required,
+    )
+    check("required: codex+static -> ()", required_profile_files("codex", "static"), ())
+    check(
+        "required: antigravity+static -> ()",
+        required_profile_files("antigravity", "static"),
+        (),
+    )
+    check(
+        "required: claude+dynamic -> ()",
+        required_profile_files("claude", "dynamic"),
+        (),
+    )
+
+    # --- classify_status: regression guard ------------------------------
+    # A Claude static agent missing profile files must still be error.
+    check(
+        "classify: claude+static+missing-files -> error",
+        classify_status(
+            ["CLAUDE.md"], [], "complete", False,
+            session_type="admin", agent_source="static", engine="claude",
+        ),
+        "error",
+    )
+
+    # --- classify_status: antigravity exemptions (the fix) --------------
+    # antigravity static with no profile files reported (required is now
+    # empty so missing_files is []), missing managed block, pending
+    # onboarding -> ok, not warn/error.
+    check(
+        "classify: antigravity+static+missing-block -> ok",
+        classify_status(
+            [], [], "missing", True,
+            session_type="unknown", agent_source="static", engine="antigravity",
+        ),
+        "ok",
+    )
+
+    # --- classify_status: claude contract still enforced ----------------
+    check(
+        "classify: claude+static+missing-block -> warn",
+        classify_status(
+            [], [], "complete", True,
+            session_type="admin", agent_source="static", engine="claude",
+        ),
+        "warn",
+    )
+    check(
+        "classify: claude+static+pending-onboarding -> warn",
+        classify_status(
+            [], [], "pending", False,
+            session_type="admin", agent_source="static", engine="claude",
+        ),
+        "warn",
+    )
+
+    # --- classify_status: dynamic / codex exemptions (no regression) ----
+    check(
+        "classify: claude+dynamic+missing-block -> ok",
+        classify_status(
+            [], [], "pending", True,
+            session_type="dynamic", agent_source="dynamic", engine="claude",
+        ),
+        "ok",
+    )
+    check(
+        "classify: codex+static+missing-block -> ok",
+        classify_status(
+            [], [], "missing", True,
+            session_type="unknown", agent_source="static", engine="codex",
+        ),
+        "ok",
+    )
+
+    # broken_links is not gated by the contract — a genuine drift signal
+    # for any agent.
+    check(
+        "classify: antigravity+static+broken-links -> warn",
+        classify_status(
+            [], ["MEMORY.md -> missing"], "missing", False,
+            session_type="unknown", agent_source="static", engine="antigravity",
+        ),
+        "warn",
+    )
+
+    if failures:
+        for f in failures:
+            print(f"  FAIL  {f}", file=sys.stderr)
+        return 1
+    print("[smoke:watchdog-profile-contract] all checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/watchdog-profile-contract.sh
+++ b/scripts/smoke/watchdog-profile-contract.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# scripts/smoke/watchdog-profile-contract.sh — regression for the
+# bridge-watchdog.py home-profile-contract check. The watchdog's
+# required-files / managed-CLAUDE.md-block / onboarding-staleness signals
+# only apply to Claude static agents. Issues #905 / #907 each special-
+# cased one slice (codex, then dynamic), but the antigravity engine
+# (v0.14.5) fell through to the Claude default and surfaced as a false
+# status=error on every scan. This smoke pins has_home_profile_contract()
+# as the single gate and guards that a Claude static agent with missing
+# profile files still classifies as error.
+#
+# The actual assertions live in scripts/smoke/watchdog-profile-
+# contract.py — kept as a standalone .py file (not heredoc-stdin to
+# python3) so the smoke is immune to footgun #11 even if a future caller
+# wraps this driver in `$()` capture.
+
+set -euo pipefail
+
+SMOKE_NAME="watchdog-profile-contract"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+"$PYTHON_BIN" "$SCRIPT_DIR/watchdog-profile-contract.py"


### PR DESCRIPTION
## Summary

- The watchdog's required-files / managed-`CLAUDE.md`-block / onboarding-staleness drift checks only apply to Claude static agents. Issues #905 (codex) and #907 (dynamic) each special-cased one slice in a different call site. The `antigravity` engine (v0.14.5) fell through to the Claude default and surfaced as a false `status=error` on every scan, with all 5 Claude profile files reported "missing".
- Introduces `has_home_profile_contract(engine, agent_source)` as the single gate. `agent_source == "dynamic"` is a full exemption regardless of engine; engines in the explicit `NON_CONTRACT_ENGINES = {codex, antigravity}` allowlist are exempt. A genuinely unknown engine string stays under the conservative Claude-default contract so a new engine surfaces as drift (prompting a watchdog update) rather than silently skipping the check.
- `classify_status` gates all three drift signals — `missing_files`, managed-block, onboarding staleness — through the predicate, so it is internally consistent and does not depend on the caller pre-emptying `required` via `required_profile_files`.
- The `missing_managed_claude_block` field stays engine-gated (computed for any engine that could own a `CLAUDE.md`), so a dynamic Claude agent keeps a truthful field (#907 C9) while only the classification signal is suppressed.

## Test plan

- [x] `python3 -m py_compile bridge-watchdog.py scripts/smoke/watchdog-profile-contract.py`
- [x] `bash -n` + `shellcheck` on `scripts/smoke/watchdog-profile-contract.sh` and `scripts/ci-select-smoke.sh`
- [x] New `scripts/smoke/watchdog-profile-contract.sh` — 25/25 (predicate truth table, `required_profile_files`, `classify_status` incl. unknown-engine conservative enforcement and non-contract `missing_files` gating)
- [x] `scripts/smoke/watchdog-registry-anchored.sh` — C1–C9b pass, including #905 C8 (codex) and #907 C9/C9b (dynamic field preservation)
- [x] `scripts/smoke/watchdog-silence-stderr-capture.sh` passes
- [x] `ci-select-smoke.sh` selects the three watchdog smokes via the new `bridge-watchdog.py)` case
- [x] Direct scan probe: a `future-engine` static agent now classifies `status=error` (5 required files flagged), confirming conservative unknown-engine enforcement

Pair-reviewed by `patch-dev` (codex): plan #5165 `plan-ok`, code review #5173 → #5175 `implement-ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)