### PR TITLE
fix(test-harness): isolate cron state dirs in smoke_setup_bridge_home (#1007)

### DIFF
--- a/scripts/smoke/lib.sh
+++ b/scripts/smoke/lib.sh
@@ -31,6 +31,15 @@ smoke_setup_bridge_home() {
   local label="${1:-$SMOKE_NAME}"
   smoke_make_temp_root "$label"
 
+  # Narrowly drop leak-prone vars this helper re-pins, so an inherited value
+  # from the operator's shell (e.g. BRIDGE_LAYOUT_MARKER_DIR or the cron state
+  # vars) can never survive into the isolated run. A blanket `unset BRIDGE_*`
+  # would clobber bridge vars some smoke callers intentionally pass in.
+  unset BRIDGE_LAYOUT_MARKER_DIR \
+    BRIDGE_CRON_STATE_DIR \
+    BRIDGE_CRON_HOME_DIR \
+    BRIDGE_NATIVE_CRON_JOBS_FILE
+
   export BRIDGE_HOME="$SMOKE_TMP_ROOT/bridge-home"
   export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
   export BRIDGE_LOG_DIR="$BRIDGE_HOME/logs"
@@ -50,6 +59,13 @@ smoke_setup_bridge_home() {
   export BRIDGE_RUNTIME_CONFIG_FILE="$BRIDGE_RUNTIME_ROOT/bridge-config.json"
   export BRIDGE_HOOKS_DIR="$BRIDGE_HOME/hooks"
   export BRIDGE_AUDIT_LOG="$BRIDGE_LOG_DIR/audit.jsonl"
+  # Pin the layout marker dir + cron state vars under the isolated root, so an
+  # isolated daemon's cron-inventory tick / layout resolver never falls back to
+  # the operator's live bridge home. Defaults mirror bridge-lib.sh.
+  export BRIDGE_LAYOUT_MARKER_DIR="$BRIDGE_STATE_DIR"
+  export BRIDGE_CRON_STATE_DIR="$BRIDGE_STATE_DIR/cron"
+  export BRIDGE_CRON_HOME_DIR="$BRIDGE_HOME/cron"
+  export BRIDGE_NATIVE_CRON_JOBS_FILE="$BRIDGE_CRON_HOME_DIR/jobs.json"
 
   mkdir -p \
     "$BRIDGE_HOME" \
@@ -63,7 +79,9 @@ smoke_setup_bridge_home() {
     "$BRIDGE_AGENT_ROOT_V2" \
     "$BRIDGE_CONTROLLER_STATE_ROOT" \
     "$BRIDGE_RUNTIME_ROOT" \
-    "$BRIDGE_HOOKS_DIR"
+    "$BRIDGE_HOOKS_DIR" \
+    "$BRIDGE_CRON_STATE_DIR" \
+    "$BRIDGE_CRON_HOME_DIR"
   : >"$BRIDGE_ROSTER_FILE"
   : >"$BRIDGE_ROSTER_LOCAL_FILE"
   cat >"$BRIDGE_STATE_DIR/layout-marker.sh" <<EOF

--- a/scripts/smoke/lib.sh
+++ b/scripts/smoke/lib.sh
@@ -38,7 +38,10 @@ smoke_setup_bridge_home() {
   unset BRIDGE_LAYOUT_MARKER_DIR \
     BRIDGE_CRON_STATE_DIR \
     BRIDGE_CRON_HOME_DIR \
-    BRIDGE_NATIVE_CRON_JOBS_FILE
+    BRIDGE_NATIVE_CRON_JOBS_FILE \
+    BRIDGE_CRON_DISPATCH_WORKER_DIR \
+    BRIDGE_SOURCE_CRON_JOBS_FILE \
+    BRIDGE_OPENCLAW_CRON_JOBS_FILE
 
   export BRIDGE_HOME="$SMOKE_TMP_ROOT/bridge-home"
   export BRIDGE_STATE_DIR="$BRIDGE_HOME/state"
@@ -66,6 +69,13 @@ smoke_setup_bridge_home() {
   export BRIDGE_CRON_STATE_DIR="$BRIDGE_STATE_DIR/cron"
   export BRIDGE_CRON_HOME_DIR="$BRIDGE_HOME/cron"
   export BRIDGE_NATIVE_CRON_JOBS_FILE="$BRIDGE_CRON_HOME_DIR/jobs.json"
+  export BRIDGE_CRON_DISPATCH_WORKER_DIR="$BRIDGE_CRON_STATE_DIR/workers"
+  # Legacy/source cron jobs path family — bridge_cron_source_jobs_file()
+  # falls back to BRIDGE_SOURCE_CRON_JOBS_FILE when the native jobs file is
+  # absent, so an inherited live value must not survive. Pin both under the
+  # isolated root (BRIDGE_OPENCLAW_CRON_JOBS_FILE is the same path family).
+  export BRIDGE_SOURCE_CRON_JOBS_FILE="$BRIDGE_CRON_HOME_DIR/legacy-jobs.json"
+  export BRIDGE_OPENCLAW_CRON_JOBS_FILE="$BRIDGE_SOURCE_CRON_JOBS_FILE"
 
   mkdir -p \
     "$BRIDGE_HOME" \
@@ -81,7 +91,8 @@ smoke_setup_bridge_home() {
     "$BRIDGE_RUNTIME_ROOT" \
     "$BRIDGE_HOOKS_DIR" \
     "$BRIDGE_CRON_STATE_DIR" \
-    "$BRIDGE_CRON_HOME_DIR"
+    "$BRIDGE_CRON_HOME_DIR" \
+    "$BRIDGE_CRON_DISPATCH_WORKER_DIR"
   : >"$BRIDGE_ROSTER_FILE"
   : >"$BRIDGE_ROSTER_LOCAL_FILE"
   cat >"$BRIDGE_STATE_DIR/layout-marker.sh" <<EOF


### PR DESCRIPTION
## Summary

Test-harness isolation gap (#1007): `smoke_setup_bridge_home` in
`scripts/smoke/lib.sh` pinned `BRIDGE_HOME`, the v2 layout marker, and the
agent/shared roots — but never the cron state vars or `BRIDGE_LAYOUT_MARKER_DIR`.
An isolated daemon's cron-inventory tick therefore fell back to the operator's
**live** `cron/jobs.json` under the real bridge home (observed: live file mtime
moved during an isolated QA run; content benign — empty jobs registry, no data
loss). Test-harness only, no product code.

## What changed

`scripts/smoke/lib.sh`, `smoke_setup_bridge_home()`:

- Pin `BRIDGE_CRON_STATE_DIR`, `BRIDGE_CRON_HOME_DIR`,
  `BRIDGE_NATIVE_CRON_JOBS_FILE` and `BRIDGE_LAYOUT_MARKER_DIR` under the
  isolated `BRIDGE_HOME`. Defaults mirror `bridge-lib.sh`
  (`$BRIDGE_STATE_DIR/cron`, `$BRIDGE_HOME/cron`, `$BRIDGE_CRON_HOME_DIR/jobs.json`,
  `$BRIDGE_STATE_DIR` for the marker dir — the location the helper already
  writes `layout-marker.sh` to). `mkdir -p` the new cron dirs.
- Narrowly `unset` only those four leak-prone vars at the top of the helper,
  **before** re-export, so an inherited value from the operator's shell cannot
  survive into the isolated run. No blanket `unset BRIDGE_*` — some smoke
  callers intentionally pass bridge variables.

## Verification

- `bash -n scripts/smoke/lib.sh` — OK
- `shellcheck scripts/smoke/lib.sh` — OK
- Isolation probe: with the four leak-prone vars pre-set to live-looking
  `~/.agent-bridge` paths, calling `smoke_setup_bridge_home` in a subshell
  resolves all four UNDER the isolated `BRIDGE_HOME`; inherited values did not
  survive; cron dirs created.
- `scripts/smoke/cron-run-artifacts-retention.sh` and
  `scripts/smoke/cron-mutation-audit.sh` — both pass (no regression).
- Live `~/.agent-bridge/cron/jobs.json` mtime UNCHANGED before/after both
  isolated cron smoke runs — the actual bug no longer reproduces.

## Scope

`scripts/smoke/lib.sh` only. No product code, no VERSION bump, no CHANGELOG entry.