### PR TITLE
fix(isolation): reap OS user + named-user ACEs on isolated agent delete (#1010)

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -232,6 +232,7 @@ lib/bridge-isolation-v2.sh	2079	H3	01c839785d78efd2144369683041e308b0ce282f4761b
 lib/bridge-isolation-v2.sh	2211	H3	71b634ac5ee39a265c89fbe6aa01962da11e48af1857e829e91757984c7df8c1	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-isolation-v2.sh	2213	H3	319caf7d2408586ea437f1ee5a220f5473fd59db5e01ed1bc85a8d5bac625ca1	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-isolation-v2.sh	2256	H3	319caf7d2408586ea437f1ee5a220f5473fd59db5e01ed1bc85a8d5bac625ca1	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
+lib/bridge-isolation-v2.sh	2446	H3	319caf7d2408586ea437f1ee5a220f5473fd59db5e01ed1bc85a8d5bac625ca1	same cred-ancestors procsub pattern as existing baselined sites L2213/L2256/L2347 - bash function consumer, not an interpreter subprocess; footgun #11 N/A	agb-dev-claude wave v0145	Phase 5 PR E (review per site)
 lib/bridge-isolation-v2.sh	2347	H3	58a0b7f22b5c4ee542c9dab74c5b4b42a91ebe63e6221f3e5ab657a398647407	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-isolation-v3-channel-dotenv.sh	506	H3	6ea2bf841d5322aa59c0f8097db35b7e96c081e55a995361e6b266badbd089a6	here-string/procsub, non-interpreter consumer	patch	Phase 5 PR E (review per site)
 lib/bridge-migration.sh	74	C3	6702fdf57ae0cefde8722a08390e40596652642313009dad2e89585410426973	interpreter heredoc, no capture	patch	Phase 3 PR C

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3685,6 +3685,25 @@ PY
     rm -f "$BRIDGE_STATE_DIR/daemon-autostart/$agent.env" 2>/dev/null || true
   fi
 
+  # Issue #1010: reap the dedicated OS user + its named-user traversal
+  # ACEs for an isolated (linux-user) agent. Unlike --purge-home (which
+  # only removes home *files*), the orphan OS user and stale
+  # `user:agent-bridge-<name>:--x` ACEs are a host-level leak that
+  # accumulates on every isolated create/delete cycle — so this runs
+  # unconditionally on the delete path, not behind a flag. The helper is
+  # hard-gated (Linux only, exact `agent-bridge-<name>` name match) and
+  # fully best-effort: every failure is reported via bridge_warn but
+  # never aborts the delete (the roster mutation already succeeded).
+  # Non-isolated / macOS / shared-mode agents have no dedicated OS user;
+  # the helper skips silently for those.
+  if command -v bridge_isolation_v2_reap_isolated_agent_account >/dev/null 2>&1 \
+     && command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+     && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    local _delete_os_user
+    _delete_os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+    bridge_isolation_v2_reap_isolated_agent_account "$agent" "$_delete_os_user"
+  fi
+
   if [[ $purge_crons -eq 1 ]]; then
     # Best-effort: list native crons for this agent and delete each.
     # Failures are non-fatal — the roster block is already gone and

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -2379,16 +2379,31 @@ bridge_isolation_v2_reap_isolated_agent_account() {
   # user; nothing to reap. Skip silently.
   [[ "$(uname -s)" == "Linux" ]] || return 0
 
-  # Gate 2 — exact-name match. The resolved OS user MUST be exactly
-  # "<prefix><agent>". This is the core safety gate: it guarantees we
-  # never run userdel/groupdel/setfacl against an account the bridge did
-  # not create or that does not belong to this delete target. A loose
-  # pattern match is explicitly avoided.
-  local pfx="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}"
-  local expected="${pfx}${agent}"
+  # Gate 2 — exact-name match. The resolved OS user MUST exactly equal the
+  # generated bridge-managed account name for this agent. This is the core
+  # safety gate: it guarantees we never run userdel/groupdel/setfacl
+  # against an account the bridge did not create or that does not belong
+  # to this delete target. A loose pattern match is explicitly avoided.
+  #
+  # The expected name MUST be computed via bridge_agent_default_os_user —
+  # the same helper `agent create` uses (bridge-agent.sh) — NOT a raw
+  # "<prefix><agent>" concatenation. `agent create` accepts agent names
+  # longer than the Linux 32-char account budget and that helper
+  # TRUNCATES the composed name to fit. A raw prefix+agent string would
+  # not equal the truncated account the bridge actually created, so the
+  # gate would skip cleanup for every long-named isolated agent — leaving
+  # behind exactly the orphan this function exists to reap (issue #1010).
   if [[ -z "$os_user" ]]; then
     # No OS user resolved from the roster — agent was never an isolated
     # linux-user agent (or its account is already gone). Nothing to do.
+    return 0
+  fi
+  local expected=""
+  if command -v bridge_agent_default_os_user >/dev/null 2>&1; then
+    expected="$(bridge_agent_default_os_user "$agent" 2>/dev/null || printf '')"
+  fi
+  if [[ -z "$expected" ]]; then
+    bridge_warn "agent delete: skipping OS-user cleanup for '$agent' — could not compute the expected bridge account name (refusing to act without an exact-match reference)"
     return 0
   fi
   if [[ "$os_user" != "$expected" ]]; then
@@ -2454,13 +2469,20 @@ bridge_isolation_v2_reap_isolated_agent_account() {
   # ---------------------------------------------------------------------
   # Step 3 — drop the per-agent group, if one was created.
   #
-  # Optional and exact-match guarded: only "<group-prefix><agent>". Best-
-  # effort; a non-empty group (still has members) makes groupdel fail and
-  # that is fine — report and move on.
+  # Optional and exact-match guarded. The group name MUST be composed via
+  # bridge_isolation_v2_agent_group_name — the same helper the grant path
+  # uses — NOT a raw "<group-prefix><agent>" concatenation. On Linux that
+  # helper hash-truncates any name that would exceed the 32-char groupadd
+  # limit, so a raw concatenation would miss (and never groupdel) the real
+  # hashed group for every long-named agent. Best-effort; a non-empty
+  # group (still has members) makes groupdel fail and that is fine —
+  # report and move on.
   # ---------------------------------------------------------------------
-  local grp_pfx="${BRIDGE_AGENT_GROUP_PREFIX:-ab-agent-}"
-  local agent_grp="${grp_pfx}${agent}"
-  if getent group "$agent_grp" >/dev/null 2>&1; then
+  local agent_grp=""
+  if command -v bridge_isolation_v2_agent_group_name >/dev/null 2>&1; then
+    agent_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')"
+  fi
+  if [[ -n "$agent_grp" ]] && getent group "$agent_grp" >/dev/null 2>&1; then
     if command -v groupdel >/dev/null 2>&1; then
       if ! _bridge_isolation_v2_run_root_or_sudo groupdel "$agent_grp"; then
         bridge_warn "agent delete: groupdel '$agent_grp' failed (best-effort — group may still have members; manual 'groupdel $agent_grp' may be needed)"

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -2349,6 +2349,130 @@ bridge_isolation_v2_check_controller_credentials_read_grant() {
   return 0
 }
 
+# bridge_isolation_v2_reap_isolated_agent_account — issue #1010.
+#
+# Cleanup hook for `agent delete` on an isolated (linux-user) agent. Reaps
+# the dedicated OS user `agent-bridge-<name>`, strips its named-user
+# traversal ACEs from the controller credential ancestor set, and (best-
+# effort) drops a matching per-agent group. ALL destructive steps are
+# hard-gated and best-effort: a failure never aborts the delete, but every
+# failure is reported visibly via bridge_warn so the operator can clean up
+# by hand.
+#
+# Args:
+#   $1 — agent name (the `<name>` being deleted)
+#   $2 — expected OS user, resolved by the caller from the roster. This
+#        function will ONLY ever act on a user whose name is EXACTLY
+#        "${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}<name>" — a non-
+#        matching argument is rejected outright (never userdel a user the
+#        bridge did not create).
+#
+# Returns 0 always (best-effort); skips silently on non-Linux / missing
+# tooling / non-isolated agents.
+bridge_isolation_v2_reap_isolated_agent_account() {
+  local agent="$1"
+  local os_user="$2"
+
+  [[ -n "$agent" ]] || return 0
+
+  # Gate 1 — Linux only. macOS / shared-mode hosts have no dedicated OS
+  # user; nothing to reap. Skip silently.
+  [[ "$(uname -s)" == "Linux" ]] || return 0
+
+  # Gate 2 — exact-name match. The resolved OS user MUST be exactly
+  # "<prefix><agent>". This is the core safety gate: it guarantees we
+  # never run userdel/groupdel/setfacl against an account the bridge did
+  # not create or that does not belong to this delete target. A loose
+  # pattern match is explicitly avoided.
+  local pfx="${BRIDGE_AGENT_OS_USER_PREFIX:-agent-bridge-}"
+  local expected="${pfx}${agent}"
+  if [[ -z "$os_user" ]]; then
+    # No OS user resolved from the roster — agent was never an isolated
+    # linux-user agent (or its account is already gone). Nothing to do.
+    return 0
+  fi
+  if [[ "$os_user" != "$expected" ]]; then
+    bridge_warn "agent delete: skipping OS-user cleanup for '$agent' — resolved user '$os_user' does not exactly match expected '$expected' (refusing to touch a non-bridge account)"
+    return 0
+  fi
+
+  # ---------------------------------------------------------------------
+  # Step 2 (run before Step 1) — strip the named-user traversal ACEs.
+  #
+  # Must happen while the user still exists: setfacl -x by name resolves
+  # the principal, and stripping after userdel would leave numeric stale
+  # entries. Reuse isolation-v2's own credential-ancestor logic
+  # (_bridge_isolation_v2_cred_ancestors) so the ancestor set matches
+  # exactly what the grant path operated on — do not re-derive it.
+  # ---------------------------------------------------------------------
+  if command -v setfacl >/dev/null 2>&1; then
+    local ctrl_user ctrl_home
+    ctrl_user="${SUDO_USER:-${USER:-${LOGNAME:-}}}"
+    if [[ -n "$ctrl_user" ]]; then
+      ctrl_home="$(getent passwd "$ctrl_user" 2>/dev/null | cut -d: -f6)"
+      [[ -n "$ctrl_home" ]] || ctrl_home="${HOME:-}"
+    fi
+    if [[ -n "${ctrl_home:-}" ]]; then
+      # Same credential-file path the grant path uses.
+      local cred_file="${ctrl_home}/.claude/.credentials.json"
+      local anc
+      while IFS= read -r anc; do
+        [[ -e "$anc" ]] || continue
+        # Only act when the ACE is actually present, so a clean host
+        # produces no noise. getfacl is best-effort.
+        if command -v getfacl >/dev/null 2>&1; then
+          getfacl -p "$anc" 2>/dev/null \
+            | grep -qE "^user:${os_user}:" || continue
+        fi
+        if ! _bridge_isolation_v2_run_root_or_sudo \
+             setfacl -x "u:${os_user}" "$anc"; then
+          bridge_warn "agent delete: failed to strip traversal ACE u:${os_user} from $anc (best-effort; manual 'setfacl -x u:${os_user} $anc' may be needed)"
+        fi
+      done < <(_bridge_isolation_v2_cred_ancestors "$cred_file")
+    else
+      bridge_warn "agent delete: could not resolve controller home — skipping traversal-ACE strip for '$os_user' (manual cleanup may be needed)"
+    fi
+  fi
+
+  # ---------------------------------------------------------------------
+  # Step 1 — remove the dedicated OS user.
+  #
+  # Gate: the user must actually exist in passwd AND match the exact
+  # expected name (already verified above). A userdel failure (user
+  # logged in, processes running, etc.) is non-fatal but reported.
+  # ---------------------------------------------------------------------
+  if getent passwd "$os_user" >/dev/null 2>&1; then
+    if command -v userdel >/dev/null 2>&1; then
+      if ! _bridge_isolation_v2_run_root_or_sudo userdel "$os_user"; then
+        bridge_warn "agent delete: userdel '$os_user' failed (best-effort — the user may be logged in or have running processes; manual 'userdel $os_user' may be needed)"
+      fi
+    else
+      bridge_warn "agent delete: userdel not available — orphan OS user '$os_user' left behind (manual cleanup needed)"
+    fi
+  fi
+
+  # ---------------------------------------------------------------------
+  # Step 3 — drop the per-agent group, if one was created.
+  #
+  # Optional and exact-match guarded: only "<group-prefix><agent>". Best-
+  # effort; a non-empty group (still has members) makes groupdel fail and
+  # that is fine — report and move on.
+  # ---------------------------------------------------------------------
+  local grp_pfx="${BRIDGE_AGENT_GROUP_PREFIX:-ab-agent-}"
+  local agent_grp="${grp_pfx}${agent}"
+  if getent group "$agent_grp" >/dev/null 2>&1; then
+    if command -v groupdel >/dev/null 2>&1; then
+      if ! _bridge_isolation_v2_run_root_or_sudo groupdel "$agent_grp"; then
+        bridge_warn "agent delete: groupdel '$agent_grp' failed (best-effort — group may still have members; manual 'groupdel $agent_grp' may be needed)"
+      fi
+    else
+      bridge_warn "agent delete: groupdel not available — per-agent group '$agent_grp' left behind (manual cleanup needed)"
+    fi
+  fi
+
+  return 0
+}
+
 bridge_isolation_v2_write_agent_state_marker() {
   # Atomic-ish writer for daemon-side per-agent state markers
   # (idle-since, manual-stop, missing-marker-retries, etc.). Ensures the

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -256,7 +256,10 @@ select_for_path() {
       # bridge-agent.sh::bridge_agent_activity_state consumes them.
       # Cover both Wave C's integration smoke + Wave B's unit smoke
       # whenever either file moves.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch
+      # Issue #1010: bridge-agent.sh::run_delete now calls the isolated-
+      # agent OS-user reap helper; cover its gating-decision smoke so a
+      # regression in the delete-path wire-up is caught.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -305,7 +308,11 @@ select_for_path() {
       # (T1-T5 marker-write contract + T6 post-marker workdir resolver)
       # for every isolation-lib + bridge-migrate.sh move so the fast-path
       # stays covered.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch
+      # Issue #1010: bridge_isolation_v2_reap_isolated_agent_account
+      # (isolated-agent OS-user + traversal-ACE reaper) lives in
+      # lib/bridge-isolation-v2.sh; pull its gating-decision smoke for
+      # every isolation-lib move.
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch isolated-agent-delete-reap
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke/isolated-agent-delete-reap.py
+++ b/scripts/smoke/isolated-agent-delete-reap.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# scripts/smoke/isolated-agent-delete-reap.py — direct callee for
+# scripts/smoke/isolated-agent-delete-reap.sh. Kept as a standalone file
+# (not inlined as heredoc-stdin to python3) so the smoke is immune to
+# footgun #11 (Bash 5.3.9 `read_comsub` / `heredoc_write` deadlock) even
+# if a future caller wraps it in `$()` capture.
+#
+# Composes the generated isolated-agent OS-account name EXACTLY the way
+# `agent create` does via bridge_agent_default_os_user
+# (lib/bridge-agents.sh:990-1007) — including the Linux 32-char account
+# truncation. The reaper's exact-match safety gate depends on this exact
+# composition; the smoke re-uses it both to construct correctly-truncated
+# probe arguments and (inside the probe) to stand in for the helper that
+# lives in the too-heavy-to-source-standalone lib/bridge-agents.sh.
+
+import re
+import sys
+
+
+def default_os_user(agent: str) -> str:
+    agent = agent.strip().lower()
+    slug = re.sub(r"[^a-z0-9_-]+", "-", agent).strip("-")
+    slug = slug or "agent"
+    prefix = "agent-bridge-"
+    max_len = 32
+    keep = max_len - len(prefix)
+    if keep < 1:
+        keep = 1
+    return prefix + slug[:keep]
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: isolated-agent-delete-reap.py <agent-name>", file=sys.stderr)
+        return 2
+    print(default_os_user(sys.argv[1]))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke/isolated-agent-delete-reap.sh
+++ b/scripts/smoke/isolated-agent-delete-reap.sh
@@ -43,6 +43,16 @@ source "$SCRIPT_DIR/lib.sh"
 #   SETFACL -x <u:user> <path>
 #   GROUPDEL <group>
 #   WARN <text>
+#
+# The OS-account / group identity the reaper composes for its exact-match
+# safety gate is computed inside the reaper via bridge_agent_default_os_user
+# and bridge_isolation_v2_agent_group_name — the SAME helpers `agent create`
+# and the grant path use, including Linux 32-char truncation / hash. The
+# probe therefore does NOT hardcode the expected names: getent passwd
+# resolves the exact `os_user` it is handed, and getent group resolves any
+# `${grp_pfx}*` name (the reaper computed it correctly or it would not be
+# asking). This is what lets the long-name case (C5) verify the truncation
+# path without the test re-deriving the composition.
 run_reap_probe() {
   local fake_uname="$1"
   local agent="$2"
@@ -58,8 +68,10 @@ uname() { printf '%s\n' "${fake_uname}"; }
 userdel() { printf 'USERDEL %s\n' "\$*"; return 0; }
 groupdel() { printf 'GROUPDEL %s\n' "\$*"; return 0; }
 setfacl() { printf 'SETFACL %s\n' "\$*"; return 0; }
-# getent: passwd <user> resolves only the exact probe user; group <grp>
-# resolves only the exact per-agent group. Everything else is "absent".
+# getent: passwd <user> resolves only the exact user the reaper was handed
+# (it never composes a passwd lookup itself — it uses the resolved arg);
+# group <grp> resolves any ab-agent-* name (the reaper composed it via
+# bridge_isolation_v2_agent_group_name). Everything else is "absent".
 getent() {
   case "\$1" in
     passwd)
@@ -67,7 +79,7 @@ getent() {
       return 2
       ;;
     group)
-      [[ "\$2" == "ab-agent-${agent}" ]] && { printf '%s:x:9999:\n' "\$2"; return 0; }
+      [[ "\$2" == ab-agent-* ]] && { printf '%s:x:9999:\n' "\$2"; return 0; }
       return 2
       ;;
   esac
@@ -82,27 +94,69 @@ getfacl() {
   return 0
 }
 command() {
-  # Make the helper believe userdel/groupdel/setfacl/getfacl exist.
+  # Make the helper believe userdel/groupdel/setfacl/getfacl exist, and
+  # that the composition helpers (resolved below) are present.
   if [[ "\$1" == "-v" ]]; then
     case "\$2" in
-      userdel|groupdel|setfacl|getfacl) printf '%s\n' "\$2"; return 0 ;;
+      userdel|groupdel|setfacl|getfacl|bridge_agent_default_os_user|bridge_isolation_v2_agent_group_name)
+        printf '%s\n' "\$2"; return 0 ;;
     esac
   fi
   builtin command "\$@"
 }
 bridge_warn() { printf 'WARN %s\n' "\$*" >&2; }
 bridge_die()  { printf 'DIE %s\n' "\$*" >&2; exit 1; }
+bridge_require_python() { :; }
+
+# bridge_agent_default_os_user lives in lib/bridge-agents.sh, which is too
+# heavy to source standalone. Reproduce it here VERBATIM from
+# lib/bridge-agents.sh:990-1007 — the smoke breaks loudly if that logic
+# drifts, which is the intended coupling (the reaper's exact-match gate
+# depends on this exact composition).
+bridge_agent_default_os_user() {
+  python3 - "\$1" <<'PY'
+import re, sys
+agent = sys.argv[1].strip().lower()
+slug = re.sub(r"[^a-z0-9_-]+", "-", agent).strip("-")
+slug = slug or "agent"
+prefix = "agent-bridge-"
+max_len = 32
+keep = max_len - len(prefix)
+if keep < 1:
+    keep = 1
+print(prefix + slug[:keep])
+PY
+}
 
 # The helper walks credential ancestors of \$HOME/.claude/.credentials.json.
 # Point HOME at the temp dir whose tree contains the designated ace_dir so
 # _bridge_isolation_v2_cred_ancestors yields it.
 export HOME="${SMOKE_TMP_ROOT}/ctrlhome"
 export SUDO_USER="" USER="probe" LOGNAME="probe"
+export BRIDGE_AGENT_GROUP_PREFIX="ab-agent-"
 
 source "${SMOKE_REPO_ROOT}/lib/bridge-isolation-v2.sh"
 
 bridge_isolation_v2_reap_isolated_agent_account "${agent}" "${os_user}" 2>&1
 PROBE
+}
+
+# Compute the expected generated OS-user name the same way agent create
+# does (lib/bridge-agents.sh) — the test caller uses this to construct a
+# correctly-truncated `os_user` argument for the exact-match cases.
+expected_os_user() {
+  python3 - "$1" <<'PY'
+import re, sys
+agent = sys.argv[1].strip().lower()
+slug = re.sub(r"[^a-z0-9_-]+", "-", agent).strip("-")
+slug = slug or "agent"
+prefix = "agent-bridge-"
+max_len = 32
+keep = max_len - len(prefix)
+if keep < 1:
+    keep = 1
+print(prefix + slug[:keep])
+PY
 }
 
 # Build a controller-home tree whose .claude ancestor chain contains a
@@ -130,12 +184,18 @@ test_non_linux_skips() {
 }
 
 # ---------------------------------------------------------------------------
-# C2 — Linux + exact name match: full reap (userdel + setfacl -x + groupdel).
+# C2 — Linux + exact name match (short name): full reap (userdel +
+# setfacl -x + groupdel). For a short name the generated account name
+# equals the raw `agent-bridge-<name>` concatenation.
 # ---------------------------------------------------------------------------
 test_linux_exact_match_reaps() {
   setup_ctrl_home
+  local os_user
+  os_user="$(expected_os_user "bob")"
+  smoke_assert_eq "agent-bridge-bob" "$os_user" \
+    "C2 pre: short name composes to the un-truncated account name"
   local out
-  out="$(run_reap_probe "Linux" "bob" "agent-bridge-bob" \
+  out="$(run_reap_probe "Linux" "bob" "$os_user" \
     "$SMOKE_TMP_ROOT/ctrlhome/.claude" "yes")"
 
   smoke_assert_contains "$out" "USERDEL agent-bridge-bob" \
@@ -186,19 +246,67 @@ test_empty_os_user_noop() {
     "C4: empty OS user is a clean silent no-op (no warnings)"
 }
 
+# ---------------------------------------------------------------------------
+# C5 — Linux + LONG valid agent name: the reaper must compose the expected
+# account/group identity through bridge_agent_default_os_user (32-char
+# truncated) and bridge_isolation_v2_agent_group_name (hash-truncated), NOT
+# a raw `agent-bridge-<name>` / `ab-agent-<name>` concatenation. A long name
+# is the exact case where a raw concatenation would not equal the account
+# the bridge created — the gate would skip and leave the orphan behind
+# (the #1010 bug). This case proves the truncation/hash composition path is
+# used: the reaper must still attempt the full reap.
+# ---------------------------------------------------------------------------
+test_long_name_uses_truncated_identity() {
+  setup_ctrl_home
+  # 41 chars — well past the agent-bridge- prefixed 32-char Linux budget.
+  local long_agent="worker-very-long-isolated-agent-name-here"
+  local os_user
+  os_user="$(expected_os_user "$long_agent")"
+
+  # Sanity: the generated account name IS truncated to <=32 and is NOT the
+  # raw concatenation — otherwise the case would not exercise the bug.
+  smoke_assert_eq "agent-bridge-worker-very-long-is" "$os_user" \
+    "C5 pre: long name composes to a 32-char-truncated account name"
+  if [[ "$os_user" == "agent-bridge-${long_agent}" ]]; then
+    smoke_fail "C5 pre: truncated account name unexpectedly equals raw concatenation"
+  fi
+
+  local out
+  out="$(run_reap_probe "Linux" "$long_agent" "$os_user" \
+    "$SMOKE_TMP_ROOT/ctrlhome/.claude" "yes")"
+
+  # With the raw-concatenation bug the exact-match gate would reject this
+  # (raw != truncated) and emit nothing destructive. The fix composes via
+  # bridge_agent_default_os_user so the gate matches and the reap runs.
+  smoke_assert_contains "$out" "USERDEL ${os_user}" \
+    "C5: userdel attempted on the truncated generated account for a long name"
+  smoke_assert_contains "$out" "SETFACL -x u:${os_user}" \
+    "C5: traversal ACE stripped using the truncated account name"
+  # Group name is composed via bridge_isolation_v2_agent_group_name; on
+  # Linux a long name is hash-truncated. Assert a groupdel happened against
+  # an ab-agent-* group (the shim resolved whatever the reaper composed).
+  smoke_assert_contains "$out" "GROUPDEL ab-agent-" \
+    "C5: per-agent group dropped using the composed (hash-truncated) name"
+  smoke_assert_not_contains "$out" "does not exactly match" \
+    "C5: long name does NOT trip the mismatch gate (identity composed correctly)"
+}
+
 main() {
   smoke_require_cmd bash
+  smoke_require_cmd python3
   smoke_make_temp_root "isolated-agent-delete-reap"
   trap smoke_cleanup_temp_root EXIT
 
   smoke_run "C1 non-Linux host: reap helper is a complete no-op" \
     test_non_linux_skips
-  smoke_run "C2 Linux + exact agent-bridge-<name> match: full reap" \
+  smoke_run "C2 Linux + exact agent-bridge-<name> match (short name): full reap" \
     test_linux_exact_match_reaps
   smoke_run "C3 naming gate: non-matching resolved user is not touched" \
     test_naming_gate_blocks_mismatch
   smoke_run "C4 empty OS user (never isolated): silent no-op" \
     test_empty_os_user_noop
+  smoke_run "C5 long valid name: reap uses truncated/hashed composition" \
+    test_long_name_uses_truncated_identity
 
   smoke_log "passed"
 }

--- a/scripts/smoke/isolated-agent-delete-reap.sh
+++ b/scripts/smoke/isolated-agent-delete-reap.sh
@@ -109,23 +109,13 @@ bridge_die()  { printf 'DIE %s\n' "\$*" >&2; exit 1; }
 bridge_require_python() { :; }
 
 # bridge_agent_default_os_user lives in lib/bridge-agents.sh, which is too
-# heavy to source standalone. Reproduce it here VERBATIM from
-# lib/bridge-agents.sh:990-1007 — the smoke breaks loudly if that logic
-# drifts, which is the intended coupling (the reaper's exact-match gate
-# depends on this exact composition).
+# heavy to source standalone. The reaper composes the expected account
+# name through it, so the probe stands it in with the sidecar
+# scripts/smoke/isolated-agent-delete-reap.py — which reproduces
+# bridge-agents.sh:990-1007 verbatim. The sidecar (file-as-argv, not
+# heredoc-stdin) keeps this off footgun #11's broken surface.
 bridge_agent_default_os_user() {
-  python3 - "\$1" <<'PY'
-import re, sys
-agent = sys.argv[1].strip().lower()
-slug = re.sub(r"[^a-z0-9_-]+", "-", agent).strip("-")
-slug = slug or "agent"
-prefix = "agent-bridge-"
-max_len = 32
-keep = max_len - len(prefix)
-if keep < 1:
-    keep = 1
-print(prefix + slug[:keep])
-PY
+  python3 "${SMOKE_REPO_ROOT}/scripts/smoke/isolated-agent-delete-reap.py" "\$1"
 }
 
 # The helper walks credential ancestors of \$HOME/.claude/.credentials.json.
@@ -143,20 +133,11 @@ PROBE
 
 # Compute the expected generated OS-user name the same way agent create
 # does (lib/bridge-agents.sh) — the test caller uses this to construct a
-# correctly-truncated `os_user` argument for the exact-match cases.
+# correctly-truncated `os_user` argument for the exact-match cases. The
+# composition lives in the sidecar scripts/smoke/isolated-agent-delete-reap.py
+# (file-as-argv, not heredoc-stdin — footgun #11 immune).
 expected_os_user() {
-  python3 - "$1" <<'PY'
-import re, sys
-agent = sys.argv[1].strip().lower()
-slug = re.sub(r"[^a-z0-9_-]+", "-", agent).strip("-")
-slug = slug or "agent"
-prefix = "agent-bridge-"
-max_len = 32
-keep = max_len - len(prefix)
-if keep < 1:
-    keep = 1
-print(prefix + slug[:keep])
-PY
+  python3 "$SMOKE_REPO_ROOT/scripts/smoke/isolated-agent-delete-reap.py" "$1"
 }
 
 # Build a controller-home tree whose .claude ancestor chain contains a

--- a/scripts/smoke/isolated-agent-delete-reap.sh
+++ b/scripts/smoke/isolated-agent-delete-reap.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# scripts/smoke/isolated-agent-delete-reap.sh — issue #1010.
+#
+# `agent delete` on an isolated (linux-user) agent must reap the dedicated
+# OS user `agent-bridge-<name>` and strip its named-user traversal ACEs
+# from the controller credential ancestor set. Before the fix, those
+# orphan accounts + stale `user:agent-bridge-*:--x` ACEs accumulated on
+# the host on every isolated create/delete cycle.
+#
+# This smoke exercises the *decision logic* of
+# `bridge_isolation_v2_reap_isolated_agent_account` — it cannot create or
+# delete real OS users in CI, so the destructive commands (`userdel`,
+# `groupdel`, `setfacl`) are shimmed as bash functions that record the
+# argv they were asked to run. The test then asserts WHICH commands the
+# helper decided to invoke given the engine / platform / name inputs.
+#
+# Cases:
+#   C1. Non-Linux host — the helper must skip entirely (no userdel /
+#       setfacl / groupdel attempted).
+#   C2. Linux + exact-name match — the helper must attempt userdel on the
+#       exact `agent-bridge-<name>` user, strip the named-user ACE from
+#       each ancestor that carries it, and groupdel the per-agent group.
+#   C3. Naming gate — a resolved OS user that does NOT exactly match
+#       `agent-bridge-<name>` must NOT trigger userdel; the helper must
+#       skip + warn instead (never touch a non-bridge account).
+#   C4. Empty OS user (agent was never isolated) — silent no-op.
+#
+# The fully destructive path (a real userdel against a live isolated
+# agent) can only be verified on a live Linux host — see the PR's
+# "Manual verification needed" section.
+
+set -euo pipefail
+
+SMOKE_NAME="isolated-agent-delete-reap"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# Run the helper in a fully isolated subshell with the OS commands shimmed.
+# Args: <uname> <agent> <os_user> <ancestor-with-ace> <ace-present:yes|no>
+# Prints, one per line, a decision trace the caller can grep:
+#   USERDEL <user>
+#   SETFACL -x <u:user> <path>
+#   GROUPDEL <group>
+#   WARN <text>
+run_reap_probe() {
+  local fake_uname="$1"
+  local agent="$2"
+  local os_user="$3"
+  local ace_dir="$4"
+  local ace_present="$5"
+
+  bash <<PROBE
+set -uo pipefail
+
+# --- shims: record decisions instead of mutating the host ---------------
+uname() { printf '%s\n' "${fake_uname}"; }
+userdel() { printf 'USERDEL %s\n' "\$*"; return 0; }
+groupdel() { printf 'GROUPDEL %s\n' "\$*"; return 0; }
+setfacl() { printf 'SETFACL %s\n' "\$*"; return 0; }
+# getent: passwd <user> resolves only the exact probe user; group <grp>
+# resolves only the exact per-agent group. Everything else is "absent".
+getent() {
+  case "\$1" in
+    passwd)
+      [[ "\$2" == "${os_user}" && -n "${os_user}" ]] && { printf '%s:x:9999:9999::/home/%s:/bin/bash\n' "\$2" "\$2"; return 0; }
+      return 2
+      ;;
+    group)
+      [[ "\$2" == "ab-agent-${agent}" ]] && { printf '%s:x:9999:\n' "\$2"; return 0; }
+      return 2
+      ;;
+  esac
+  return 2
+}
+# getfacl: report the named-user ACE only on the designated ancestor dir.
+getfacl() {
+  shift  # drop -p
+  if [[ "\$1" == "${ace_dir}" && "${ace_present}" == "yes" && -n "${os_user}" ]]; then
+    printf 'user:${os_user}:--x\n'
+  fi
+  return 0
+}
+command() {
+  # Make the helper believe userdel/groupdel/setfacl/getfacl exist.
+  if [[ "\$1" == "-v" ]]; then
+    case "\$2" in
+      userdel|groupdel|setfacl|getfacl) printf '%s\n' "\$2"; return 0 ;;
+    esac
+  fi
+  builtin command "\$@"
+}
+bridge_warn() { printf 'WARN %s\n' "\$*" >&2; }
+bridge_die()  { printf 'DIE %s\n' "\$*" >&2; exit 1; }
+
+# The helper walks credential ancestors of \$HOME/.claude/.credentials.json.
+# Point HOME at the temp dir whose tree contains the designated ace_dir so
+# _bridge_isolation_v2_cred_ancestors yields it.
+export HOME="${SMOKE_TMP_ROOT}/ctrlhome"
+export SUDO_USER="" USER="probe" LOGNAME="probe"
+
+source "${SMOKE_REPO_ROOT}/lib/bridge-isolation-v2.sh"
+
+bridge_isolation_v2_reap_isolated_agent_account "${agent}" "${os_user}" 2>&1
+PROBE
+}
+
+# Build a controller-home tree whose .claude ancestor chain contains a
+# directory we can flag as carrying the stale ACE.
+setup_ctrl_home() {
+  mkdir -p "$SMOKE_TMP_ROOT/ctrlhome/.claude"
+  : >"$SMOKE_TMP_ROOT/ctrlhome/.claude/.credentials.json"
+}
+
+# ---------------------------------------------------------------------------
+# C1 — non-Linux: helper is a complete no-op.
+# ---------------------------------------------------------------------------
+test_non_linux_skips() {
+  setup_ctrl_home
+  local out
+  out="$(run_reap_probe "Darwin" "bob" "agent-bridge-bob" \
+    "$SMOKE_TMP_ROOT/ctrlhome/.claude" "yes")"
+
+  smoke_assert_not_contains "$out" "USERDEL" \
+    "C1: no userdel attempted on non-Linux host"
+  smoke_assert_not_contains "$out" "SETFACL" \
+    "C1: no setfacl attempted on non-Linux host"
+  smoke_assert_not_contains "$out" "GROUPDEL" \
+    "C1: no groupdel attempted on non-Linux host"
+}
+
+# ---------------------------------------------------------------------------
+# C2 — Linux + exact name match: full reap (userdel + setfacl -x + groupdel).
+# ---------------------------------------------------------------------------
+test_linux_exact_match_reaps() {
+  setup_ctrl_home
+  local out
+  out="$(run_reap_probe "Linux" "bob" "agent-bridge-bob" \
+    "$SMOKE_TMP_ROOT/ctrlhome/.claude" "yes")"
+
+  smoke_assert_contains "$out" "USERDEL agent-bridge-bob" \
+    "C2: userdel attempted on the exact agent-bridge-<name> user"
+  smoke_assert_contains "$out" "SETFACL -x u:agent-bridge-bob" \
+    "C2: named-user traversal ACE stripped from the ancestor carrying it"
+  smoke_assert_contains "$out" "GROUPDEL ab-agent-bob" \
+    "C2: per-agent group dropped"
+}
+
+# ---------------------------------------------------------------------------
+# C3 — naming gate: a non-matching resolved user must NOT be userdel'd.
+# ---------------------------------------------------------------------------
+test_naming_gate_blocks_mismatch() {
+  setup_ctrl_home
+  # The agent being deleted is `bob`, but the roster resolved a user that
+  # is NOT `agent-bridge-bob` — e.g. a hand-edited / stale roster value.
+  local out
+  out="$(run_reap_probe "Linux" "bob" "operator" \
+    "$SMOKE_TMP_ROOT/ctrlhome/.claude" "yes")"
+
+  smoke_assert_not_contains "$out" "USERDEL" \
+    "C3: userdel NOT attempted when resolved user != agent-bridge-<name>"
+  smoke_assert_not_contains "$out" "SETFACL" \
+    "C3: setfacl NOT attempted for a non-matching user"
+  smoke_assert_not_contains "$out" "GROUPDEL" \
+    "C3: groupdel NOT attempted for a non-matching user"
+  smoke_assert_contains "$out" "WARN" \
+    "C3: mismatch is reported visibly via bridge_warn"
+}
+
+# ---------------------------------------------------------------------------
+# C4 — empty OS user (agent was never isolated): silent no-op.
+# ---------------------------------------------------------------------------
+test_empty_os_user_noop() {
+  setup_ctrl_home
+  local out
+  out="$(run_reap_probe "Linux" "bob" "" \
+    "$SMOKE_TMP_ROOT/ctrlhome/.claude" "no")"
+
+  smoke_assert_not_contains "$out" "USERDEL" \
+    "C4: no userdel when OS user is empty"
+  smoke_assert_not_contains "$out" "SETFACL" \
+    "C4: no setfacl when OS user is empty"
+  smoke_assert_not_contains "$out" "GROUPDEL" \
+    "C4: no groupdel when OS user is empty"
+  smoke_assert_not_contains "$out" "WARN" \
+    "C4: empty OS user is a clean silent no-op (no warnings)"
+}
+
+main() {
+  smoke_require_cmd bash
+  smoke_make_temp_root "isolated-agent-delete-reap"
+  trap smoke_cleanup_temp_root EXIT
+
+  smoke_run "C1 non-Linux host: reap helper is a complete no-op" \
+    test_non_linux_skips
+  smoke_run "C2 Linux + exact agent-bridge-<name> match: full reap" \
+    test_linux_exact_match_reaps
+  smoke_run "C3 naming gate: non-matching resolved user is not touched" \
+    test_naming_gate_blocks_mismatch
+  smoke_run "C4 empty OS user (never isolated): silent no-op" \
+    test_empty_os_user_noop
+
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Deleting an isolated (linux-user) agent removed its runtime home and
roster entry but never removed the dedicated OS user `agent-bridge-<name>`
or stripped that user's named-user traversal ACEs from the controller
credential ancestor directories. Orphan OS users and stale
`user:agent-bridge-<name>:--x` ACEs accumulated on the host on every
isolated create/delete cycle — exactly the named-user-ACE construct the
#998 ACL-deprecation set is moving away from. Closes the gap reported in
(#1010).

## What changed

- **`lib/bridge-isolation-v2.sh`** — new helper
  `bridge_isolation_v2_reap_isolated_agent_account <agent> <os_user>`:
  - **Step 2 (named-user ACEs)** — strips `setfacl -x u:agent-bridge-<name>`
    from each credential ancestor, reusing isolation-v2's own
    `_bridge_isolation_v2_cred_ancestors` so the stripped set matches the
    grant path exactly (no re-derivation). Runs before userdel so the
    principal still resolves.
  - **Step 1 (OS user)** — removes the dedicated OS user via `userdel`.
  - **Step 3 (per-agent group)** — drops `ab-agent-<name>` via `groupdel`.
- **`bridge-agent.sh`** — `run_delete` calls the helper on the isolated-
  agent delete path, after the roster mutation succeeds. It runs
  unconditionally on the delete path (not behind `--purge-home`), since
  the orphan account/ACE leak is host-level and independent of home files.

### Hard safety gates (per codex plan r1 #4)

- **Linux only** — macOS / shared-mode hosts have no dedicated OS user; the
  helper skips silently.
- **Exact-name match** — the resolved OS user must be *exactly*
  `agent-bridge-<name>` for the delete target. A loose pattern match is
  explicitly avoided; a non-matching user is skipped + warned, never
  `userdel`'d. The bridge never touches an account it did not create.
- **Best-effort, visible** — every `userdel` / `setfacl` / `groupdel`
  failure is non-fatal (the delete already succeeded) but reported via
  `bridge_warn` so the operator knows manual cleanup is needed.

## Verification

- `bash -n` + `shellcheck` clean on `bridge-agent.sh`,
  `lib/bridge-isolation-v2.sh`, `scripts/ci-select-smoke.sh`,
  `scripts/smoke/isolated-agent-delete-reap.sh`.
- New `scripts/smoke/isolated-agent-delete-reap.sh` (4 cases, all pass) —
  exercises the *decision* logic with `userdel`/`setfacl`/`groupdel`
  shimmed:
  - C1 non-Linux host → complete no-op
  - C2 Linux + exact `agent-bridge-<name>` match → full reap (userdel +
    setfacl -x + groupdel)
  - C3 naming gate → non-matching resolved user is not touched, warns
  - C4 empty OS user (never isolated) → silent no-op
- Wired into `ci-select-smoke.sh` on both the `bridge-agent.sh` and
  `lib/bridge-isolation*.sh` trigger rows.
- Regression: `scripts/smoke/agent-delete-task-gc.sh`,
  `isolation-v2-bucket2-gates` pass; `v2-cross-class-read` skips on macOS
  as expected.

## Scope

- No VERSION bump, no CHANGELOG entry.
- Non-isolated (shared-mode) delete path unchanged.
- The doctor-side orphan-reaping sweep mentioned in (#1010) as optional is
  intentionally out of scope — separate follow-up.

## Manual verification needed

The destructive `userdel` / `setfacl -x` / `groupdel` paths can only be
fully exercised on a live Linux host with a real isolated agent — CI
shims the OS commands and tests only the decision. For Phase 5 manual
check: on a Linux host, create an isolated linux-user agent, confirm
`agent-bridge-<name>` exists in `getent passwd` and a
`user:agent-bridge-<name>:--x` ACE is present on a private credential
ancestor; delete the agent; confirm both the OS user and the ACE are gone
and no non-bridge account/ACE was touched.