### PR TITLE
fix(resume): resolve Claude session roots from agent CLAUDE_CONFIG_DIR (#1015)

### DIFF
--- a/bridge-sync.sh
+++ b/bridge-sync.sh
@@ -104,6 +104,7 @@ prune_missing_dynamic_agents() {
 
 refresh_missing_session_ids() {
   local agent sid exclude_csv created_at detected key _resolved _rc
+  local _claude_config_dir
   local -a excluded
   local persisted_any=0
 
@@ -129,11 +130,18 @@ refresh_missing_session_ids() {
       created_at="0"
     fi
 
+    # Issue #1015: pass the agent's CLAUDE_CONFIG_DIR so isolation-v2
+    # agents are detected against their own `<agent-home>/.claude/`.
+    _claude_config_dir=""
+    if command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
+      _claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
+    fi
     detected="$(bridge_detect_session_id \
       "$(bridge_agent_engine "$agent")" \
       "$(bridge_agent_workdir "$agent")" \
       "$created_at" \
-      "$exclude_csv")"
+      "$exclude_csv" \
+      "$_claude_config_dir")"
 
     if [[ -z "$detected" ]]; then
       continue

--- a/bridge-sync.sh
+++ b/bridge-sync.sh
@@ -131,11 +131,10 @@ refresh_missing_session_ids() {
     fi
 
     # Issue #1015: pass the agent's CLAUDE_CONFIG_DIR so isolation-v2
-    # agents are detected against their own `<agent-home>/.claude/`.
-    _claude_config_dir=""
-    if command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
-      _claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
-    fi
+    # agents are detected against their own `<agent-home>/.claude/`. The
+    # resolver returns empty for unregistered / non-isolated agents so the
+    # helper keeps its daemon-HOME fallback.
+    _claude_config_dir="$(bridge_resolve_agent_claude_config_dir "$agent" 2>/dev/null || true)"
     detected="$(bridge_detect_session_id \
       "$(bridge_agent_engine "$agent")" \
       "$(bridge_agent_workdir "$agent")" \

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -235,11 +235,11 @@ bridge_claude_resume_session_id_for_agent() {
   [[ "$_max_hours_int" =~ ^[0-9]+$ ]] || _max_hours_int=48
   local _since_ms=$(( ($(date +%s) - _max_hours_int * 3600) * 1000 ))
   # Issue #1015: pass the agent's CLAUDE_CONFIG_DIR so isolation-v2 agents
-  # detect transcripts under their own `<agent-home>/.claude/`.
+  # detect transcripts under their own `<agent-home>/.claude/`. The
+  # resolver returns empty for unregistered / non-isolated agents so the
+  # helper keeps its daemon-HOME fallback.
   local _claude_config_dir=""
-  if command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
-    _claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
-  fi
+  _claude_config_dir="$(bridge_resolve_agent_claude_config_dir "$agent")"
   detected="$(bridge_detect_claude_session_id "$workdir" "$_since_ms" "$_quarantine_csv" "$_claude_config_dir" 2>/dev/null || true)"
   [[ -n "$detected" ]] || return 1
   # Belt-and-suspenders: round-trip through the resolver so a missed slug or
@@ -2881,6 +2881,35 @@ bridge_persist_agent_state() {
   bridge_write_agent_state_file "$agent" "$(bridge_history_file_for_agent "$agent")"
 }
 
+# Issue #1015: resolve the Claude config dir to hand the session-id
+# helpers — but ONLY when `agent` is a genuinely registered agent whose
+# computed config dir actually exists on disk. For test / unregistered /
+# non-isolated callers, `bridge_agent_claude_config_dir` still returns a
+# *derived* path (e.g. `$BRIDGE_AGENT_HOME_ROOT/<name>/.claude`) that does
+# not exist; passing that to the helper would OVERRIDE the per-call
+# `HOME` the caller relies on and search the wrong tree. Returning empty
+# in that case lets the helper fall back to `CLAUDE_CONFIG_DIR` env /
+# `HOME` / `~` exactly as on `main`. Echoes the config dir on stdout, or
+# nothing when no isolated config dir is in play.
+bridge_resolve_agent_claude_config_dir() {
+  local agent="$1"
+  local config_dir=""
+
+  [[ -n "$agent" ]] || return 0
+  command -v bridge_agent_claude_config_dir >/dev/null 2>&1 || return 0
+  # Only registered agents get an isolation-aware config dir. An
+  # unregistered name (smoke fixtures, ad hoc probes) must fall through
+  # to the helper's daemon-HOME fallback.
+  if command -v bridge_agent_exists >/dev/null 2>&1; then
+    bridge_agent_exists "$agent" || return 0
+  fi
+  config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
+  # A derived-but-absent path means the agent is not actually isolated on
+  # this host; do not let it shadow the caller's HOME.
+  [[ -n "$config_dir" && -d "$config_dir" ]] || return 0
+  printf '%s' "$config_dir"
+}
+
 # Issue #827: live-session acceptance (sessions/<pid>.json present, pid
 # alive, cwd matches, no transcript jsonl yet) is implemented in the
 # Python helper. The bash body uses `python3 "$BRIDGE_SCRIPT_DIR/scripts
@@ -2965,14 +2994,12 @@ bridge_resolve_resume_session_id() {
   # Issue #1015: isolation-v2 agents run Claude with a custom
   # HOME/CLAUDE_CONFIG_DIR, so the session JSON and transcripts live under
   # `<agent-home>/.claude/`, not the daemon's `~/.claude/`. Resolve the
-  # agent's config dir and pass it through; empty (no agent / helper
-  # unavailable) leaves the helper on its daemon-HOME fallback so the
-  # non-isolated path and other call sites are unchanged.
+  # agent's config dir ONLY when it is a registered, genuinely isolated
+  # agent (see bridge_resolve_agent_claude_config_dir) — empty leaves the
+  # helper on its CLAUDE_CONFIG_DIR-env / daemon-HOME fallback so the
+  # non-isolated path and test/unregistered callers are unchanged.
   local claude_config_dir=""
-  if [[ -n "$agent" ]] \
-    && command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
-    claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
-  fi
+  claude_config_dir="$(bridge_resolve_agent_claude_config_dir "$agent")"
 
   python3 "$BRIDGE_SCRIPT_DIR/scripts/python-helpers/resolve-claude-resume-session-id.py" \
     "$workdir" "$candidate" "$max_age_hours" "$agent" "$exclude_csv" \
@@ -3144,11 +3171,10 @@ bridge_refresh_agent_session_id() {
     exclude_csv="$(IFS=,; echo "${excluded[*]}")"
 
     # Issue #1015: thread the agent's CLAUDE_CONFIG_DIR through so
-    # isolation-v2 agents detect their own `<agent-home>/.claude/`.
+    # isolation-v2 agents detect their own `<agent-home>/.claude/`. Empty
+    # for unregistered / non-isolated agents (daemon-HOME fallback kept).
     local _claude_config_dir=""
-    if command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
-      _claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
-    fi
+    _claude_config_dir="$(bridge_resolve_agent_claude_config_dir "$agent")"
     detected="$(bridge_detect_session_id \
       "$(bridge_agent_engine "$agent")" \
       "$(bridge_agent_workdir "$agent")" \

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -234,7 +234,13 @@ bridge_claude_resume_session_id_for_agent() {
   _max_hours_int="${_max_hours_int%.*}"
   [[ "$_max_hours_int" =~ ^[0-9]+$ ]] || _max_hours_int=48
   local _since_ms=$(( ($(date +%s) - _max_hours_int * 3600) * 1000 ))
-  detected="$(bridge_detect_claude_session_id "$workdir" "$_since_ms" "$_quarantine_csv" 2>/dev/null || true)"
+  # Issue #1015: pass the agent's CLAUDE_CONFIG_DIR so isolation-v2 agents
+  # detect transcripts under their own `<agent-home>/.claude/`.
+  local _claude_config_dir=""
+  if command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
+    _claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
+  fi
+  detected="$(bridge_detect_claude_session_id "$workdir" "$_since_ms" "$_quarantine_csv" "$_claude_config_dir" 2>/dev/null || true)"
   [[ -n "$detected" ]] || return 1
   # Belt-and-suspenders: round-trip through the resolver so a missed slug or
   # detection-side regression cannot reintroduce a stale id past this point.
@@ -2889,6 +2895,12 @@ bridge_detect_claude_session_id() {
   local workdir="$1"
   local since_ms="${2:-0}"
   local exclude_csv="${3:-}"
+  # Issue #1015: optional Claude config dir. Isolation-v2 agents launch
+  # Claude with a custom HOME/CLAUDE_CONFIG_DIR, so their session JSON and
+  # transcripts live under `<agent-home>/.claude/`, not the daemon's
+  # `~/.claude/`. Passed through to the helper as a trailing arg; empty
+  # keeps the pre-#1015 daemon-HOME fallback for non-isolated callers.
+  local claude_config_dir="${4:-}"
 
   # #946 L1 (r2): substitution-safe guard. This helper is called
   # exclusively from `$(...)` substitutions (callers parse stdout).
@@ -2896,7 +2908,7 @@ bridge_detect_claude_session_id() {
     return 1
   fi
   python3 "$BRIDGE_SCRIPT_DIR/scripts/python-helpers/detect-claude-session-id.py" \
-    "$workdir" "$since_ms" "$exclude_csv"
+    "$workdir" "$since_ms" "$exclude_csv" "$claude_config_dir"
 }
 
 # bridge_resolve_resume_session_id is the single source of truth for whether
@@ -2949,8 +2961,22 @@ bridge_resolve_resume_session_id() {
   if ! bridge_resolve_script_dir_check; then
     return 1
   fi
+
+  # Issue #1015: isolation-v2 agents run Claude with a custom
+  # HOME/CLAUDE_CONFIG_DIR, so the session JSON and transcripts live under
+  # `<agent-home>/.claude/`, not the daemon's `~/.claude/`. Resolve the
+  # agent's config dir and pass it through; empty (no agent / helper
+  # unavailable) leaves the helper on its daemon-HOME fallback so the
+  # non-isolated path and other call sites are unchanged.
+  local claude_config_dir=""
+  if [[ -n "$agent" ]] \
+    && command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
+    claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
+  fi
+
   python3 "$BRIDGE_SCRIPT_DIR/scripts/python-helpers/resolve-claude-resume-session-id.py" \
-    "$workdir" "$candidate" "$max_age_hours" "$agent" "$exclude_csv"
+    "$workdir" "$candidate" "$max_age_hours" "$agent" "$exclude_csv" \
+    "$claude_config_dir"
 }
 
 # Returns 0 (true) if the given workdir has any in-window
@@ -3049,13 +3075,18 @@ bridge_detect_session_id() {
   local workdir="$2"
   local since_hint="$3"
   local exclude_csv="${4:-}"
+  # Issue #1015: optional Claude config dir, threaded to the claude branch
+  # so isolation-v2 agents resolve their own `<agent-home>/.claude/` rather
+  # than the daemon's `~/.claude/`. Ignored for codex; empty is harmless.
+  local claude_config_dir="${5:-}"
 
   case "$engine" in
     codex)
       bridge_detect_codex_session_id "$workdir" "$since_hint" "$exclude_csv"
       ;;
     claude)
-      bridge_detect_claude_session_id "$workdir" "$since_hint" "$exclude_csv"
+      bridge_detect_claude_session_id "$workdir" "$since_hint" "$exclude_csv" \
+        "$claude_config_dir"
       ;;
     *)
       printf '%s' ""
@@ -3112,11 +3143,18 @@ bridge_refresh_agent_session_id() {
     done
     exclude_csv="$(IFS=,; echo "${excluded[*]}")"
 
+    # Issue #1015: thread the agent's CLAUDE_CONFIG_DIR through so
+    # isolation-v2 agents detect their own `<agent-home>/.claude/`.
+    local _claude_config_dir=""
+    if command -v bridge_agent_claude_config_dir >/dev/null 2>&1; then
+      _claude_config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
+    fi
     detected="$(bridge_detect_session_id \
       "$(bridge_agent_engine "$agent")" \
       "$(bridge_agent_workdir "$agent")" \
       "$since_hint" \
-      "$exclude_csv")"
+      "$exclude_csv" \
+      "$_claude_config_dir")"
 
     if [[ -n "$detected" ]]; then
       BRIDGE_AGENT_SESSION_ID["$agent"]="$detected"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -221,7 +221,14 @@ select_for_path() {
       # cron-only static agents do not go stale between rotation events.
       # daemon-periodic-token-sync covers the due-check / tick / audit /
       # state-file cadence contract.
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync
+      #
+      # Issue #1015: lib/bridge-state.sh hosts the resume/detect shims
+      # (bridge_detect_claude_session_id, bridge_detect_session_id,
+      # bridge_resolve_resume_session_id) that thread the agent's
+      # CLAUDE_CONFIG_DIR to the python helpers; bridge-sync.sh's
+      # refresh_missing_session_ids is one of the callers. Cover the
+      # config-root resolution smoke whenever either file moves.
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -435,6 +442,18 @@ select_for_path() {
       # must re-run the Wave C regression smoke that asserts the call
       # returns in <2s.
       add_required 835-static-admin-launch launch launch-dev-channels-injection channel-env-readiness
+      add_integration integration-minimal
+      ;;
+
+    scripts/python-helpers/detect-claude-session-id.py|scripts/python-helpers/resolve-claude-resume-session-id.py)
+      # Issue #1015: these helpers resolve the Claude session JSON +
+      # transcript roots. They must key off the agent's CLAUDE_CONFIG_DIR
+      # (isolation-v2 custom HOME) rather than the daemon process's HOME,
+      # otherwise static agents launch a fresh session on every restart.
+      # 1015-resume-claude-config-dir pins the config-root resolution
+      # (trailing arg > CLAUDE_CONFIG_DIR env > daemon-HOME fallback) and
+      # the backward-compatible non-isolated path.
+      add_required 1015-resume-claude-config-dir 981-restart-session-resume-snapshot
       add_integration integration-minimal
       ;;
 

--- a/scripts/python-helpers/detect-claude-session-id.py
+++ b/scripts/python-helpers/detect-claude-session-id.py
@@ -16,6 +16,14 @@ Args (positional, order-sensitive):
     sys.argv[1] — workdir (will be `os.path.realpath`-resolved)
     sys.argv[2] — since_ms (integer string; "0" = no time gate)
     sys.argv[3] — exclude_csv (comma-separated session ids to skip)
+    sys.argv[4] — claude_config_dir (optional, issue #1015): the agent's
+        Claude config directory (`CLAUDE_CONFIG_DIR`). Isolation-v2 launches
+        Claude with a custom HOME/CLAUDE_CONFIG_DIR, so the live session
+        JSON and transcripts live under `<agent-home>/.claude/`, not the
+        daemon process's `~/.claude/`. When empty the helper falls back to
+        the `CLAUDE_CONFIG_DIR` env var, then `<HOME>/.claude`, then
+        `os.path.expanduser("~/.claude")` — keeping the non-isolated path
+        and existing call sites byte-for-byte unchanged.
 
 Stdout: the detected session id, or empty string if none. Always exits 0.
 
@@ -83,6 +91,25 @@ def workdir_slug_candidates(path: str):
     return candidates
 
 
+def claude_config_root(explicit: str = "") -> str:
+    """Resolve the Claude config root for the agent being detected.
+
+    Priority (issue #1015): an explicit argument the bash shim passes >
+    the `CLAUDE_CONFIG_DIR` env var > `<HOME>/.claude` > the ambient
+    `~/.claude`. The last two preserve the pre-#1015 daemon-HOME behaviour
+    for non-isolated agents and call sites that supply nothing.
+    """
+    if explicit:
+        return explicit
+    env_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_dir:
+        return env_dir
+    home = os.environ.get("HOME")
+    if home:
+        return os.path.join(home, ".claude")
+    return os.path.expanduser("~/.claude")
+
+
 def pid_is_alive(pid):
     # Issue #827: live-session acceptance hinges on this. Accept any pid
     # that responds to kill -0 without ESRCH. EPERM means the process
@@ -110,10 +137,13 @@ def main() -> int:
     if 0 < since_ms < 10**11:
         since_ms *= 1000
     exclude = {x for x in sys.argv[3].split(",") if x}
+    config_root = claude_config_root(
+        sys.argv[4] if len(sys.argv) > 4 else ""
+    )
     best = None
 
     # Primary: live sessions/<pid>.json records.
-    for path in glob.glob(os.path.expanduser("~/.claude/sessions/*.json")):
+    for path in glob.glob(os.path.join(config_root, "sessions", "*.json")):
         try:
             with open(path, "r", encoding="utf-8") as fh:
                 data = json.load(fh)
@@ -128,15 +158,15 @@ def main() -> int:
             continue
         transcript = None
         for slug in workdir_slug_candidates(workdir):
-            candidate = os.path.expanduser(
-                f"~/.claude/projects/{slug}/{sid}.jsonl"
+            candidate = os.path.join(
+                config_root, "projects", slug, f"{sid}.jsonl"
             )
             if os.path.isfile(candidate):
                 transcript = candidate
                 break
         if transcript is None:
             for candidate in glob.glob(
-                os.path.expanduser(f"~/.claude/projects/**/{sid}.jsonl"),
+                os.path.join(config_root, "projects", "**", f"{sid}.jsonl"),
                 recursive=True,
             ):
                 if os.path.isfile(candidate):
@@ -172,7 +202,7 @@ def main() -> int:
         for slug in workdir_slug_candidates(workdir):
             transcripts.extend(
                 glob.glob(
-                    os.path.expanduser(f"~/.claude/projects/{slug}/*.jsonl")
+                    os.path.join(config_root, "projects", slug, "*.jsonl")
                 )
             )
         for transcript in transcripts:

--- a/scripts/python-helpers/resolve-claude-resume-session-id.py
+++ b/scripts/python-helpers/resolve-claude-resume-session-id.py
@@ -22,6 +22,14 @@ Args (positional, order-sensitive):
         in this set are skipped during fs-scan; a candidate that matches an
         entry is treated as quarantined and resolves to the freshest other
         eligible transcript (rc=2) instead of being accepted as-is.
+    sys.argv[6] — claude_config_dir (optional, issue #1015): the agent's
+        Claude config directory (`CLAUDE_CONFIG_DIR`). Isolation-v2 launches
+        Claude with a custom HOME/CLAUDE_CONFIG_DIR, so the session JSON and
+        transcripts live under `<agent-home>/.claude/`, not the daemon
+        process's `~/.claude/`. When this argument is empty the resolver
+        falls back to the `CLAUDE_CONFIG_DIR` env var, then `<HOME>/.claude`,
+        then `os.path.expanduser("~/.claude")` — keeping the non-isolated
+        path and existing call sites byte-for-byte unchanged.
 
 Stdout: accepted session id, or empty when there is nothing to resume.
 Exit code:
@@ -69,6 +77,25 @@ def ordered_slug_candidates(paths):
     return candidates
 
 
+def claude_config_root(explicit: str = "") -> str:
+    """Resolve the Claude config root for the agent being resumed.
+
+    Priority (issue #1015): an explicit argument the bash shim passes >
+    the `CLAUDE_CONFIG_DIR` env var > `<HOME>/.claude` > the ambient
+    `~/.claude`. The last two preserve the pre-#1015 daemon-HOME behaviour
+    for non-isolated agents and call sites that supply nothing.
+    """
+    if explicit:
+        return explicit
+    env_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if env_dir:
+        return env_dir
+    home = os.environ.get("HOME")
+    if home:
+        return os.path.join(home, ".claude")
+    return os.path.expanduser("~/.claude")
+
+
 def pid_is_alive(pid):
     try:
         pid_int = int(pid)
@@ -101,6 +128,9 @@ def main() -> int:
         for x in (sys.argv[5] if len(sys.argv) > 5 else "").split(",")
         if x
     }
+    config_root = claude_config_root(
+        sys.argv[6] if len(sys.argv) > 6 else ""
+    )
 
     cutoff = time.time() - max_age_hours * 3600
 
@@ -113,7 +143,7 @@ def main() -> int:
     # path below.
     if candidate:
         for session_path in glob.glob(
-            os.path.expanduser("~/.claude/sessions/*.json")
+            os.path.join(config_root, "sessions", "*.json")
         ):
             try:
                 with open(session_path, "r", encoding="utf-8") as fh:
@@ -142,7 +172,7 @@ def main() -> int:
     eligible = []
     seen_stems = set()
     for slug in ordered_slug_candidates([input_workdir, workdir]):
-        base = os.path.expanduser(f"~/.claude/projects/{slug}")
+        base = os.path.join(config_root, "projects", slug)
         if not os.path.isdir(base):
             continue
         try:

--- a/scripts/smoke/1015-resume-claude-config-dir.sh
+++ b/scripts/smoke/1015-resume-claude-config-dir.sh
@@ -2,9 +2,21 @@
 # shellcheck shell=bash
 # scripts/smoke/1015-resume-claude-config-dir.sh — Issue #1015.
 #
-# Pins the contract that the Claude session-id helpers resolve their
-# `~/.claude/sessions` + `~/.claude/projects` roots from the *agent's*
-# CLAUDE_CONFIG_DIR, not the daemon process's HOME.
+# Re-exec under bash 4+ so we can `source bridge-lib.sh` directly for the
+# shim-level coverage (matches scripts/smoke/claude-live-session-
+# pretranscript.sh).
+if [[ "${BRIDGE_SMOKE_BASH4_REEXEC:-0}" != "1" && "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      BRIDGE_SMOKE_BASH4_REEXEC=1 exec "$_candidate" "$0" "$@"
+    fi
+  done
+  echo "[smoke:1015-resume-claude-config-dir][error] bash 4+ required (got ${BASH_VERSION:-unknown})" >&2
+  exit 1
+fi
+#
+# Pins the contract that the Claude session-id resolution keys off the
+# *agent's* CLAUDE_CONFIG_DIR, not the daemon process's HOME.
 #
 # Root cause (issue #1015): static Claude agents launched by the
 # isolation-v2 stack run with a custom HOME / CLAUDE_CONFIG_DIR, so the
@@ -15,30 +27,45 @@
 #
 # The fix: both helpers resolve the config root from, in priority order,
 # an explicit trailing argument > the CLAUDE_CONFIG_DIR env var >
-# <HOME>/.claude > os.path.expanduser("~/.claude"). The last two preserve
-# the pre-#1015 daemon-HOME behaviour for non-isolated agents.
+# <HOME>/.claude > os.path.expanduser("~/.claude"). The bash shims
+# (bridge_detect_claude_session_id / bridge_resolve_resume_session_id)
+# auto-supply that trailing argument ONLY for registered, genuinely
+# isolated agents whose config dir exists on disk
+# (bridge_resolve_agent_claude_config_dir) — so test / unregistered /
+# non-isolated callers that rely on a per-call HOME keep the daemon-HOME
+# fallback exactly as on `main`.
 #
-# Test plan (all run directly against the two python helpers, no live
-# tmux, no bridge runtime):
-#   T1. detect-claude-session-id.py finds the live session id when the
-#       agent's config dir is passed as the trailing argument.
-#   T2. detect-claude-session-id.py finds it via the CLAUDE_CONFIG_DIR
-#       env var when no argument is supplied.
-#   T3. detect-claude-session-id.py with no config dir and no env var
-#       falls back to the ambient HOME — the fixture lives elsewhere so
-#       it must NOT be discovered (backward-compatible non-isolated path).
-#   T4. resolve-claude-resume-session-id.py accepts the candidate id
-#       (rc=0) when the agent's config dir is passed as the trailing arg.
-#   T5. resolve-claude-resume-session-id.py accepts it via the
-#       CLAUDE_CONFIG_DIR env var.
-#   T6. resolve-claude-resume-session-id.py with no config dir and no env
-#       var rejects the candidate (rc=1) — the daemon-HOME fallback finds
-#       no transcript, exactly as before #1015.
+# Test plan — two layers:
 #
-# Isolation: a self-contained fixture dir under SMOKE_TMP_ROOT; the smoke
-# never reads or writes the operator's live `~/.claude` or bridge runtime.
-# Each "no config dir" case runs with HOME pointed at an empty temp dir so
-# the operator's real `~/.claude` cannot mask the fallback assertion.
+#   Direct helper coverage (the helpers invoked as standalone scripts):
+#   T1. detect-claude-session-id.py resolves the session via the trailing
+#       config-dir argument.
+#   T2. detect-claude-session-id.py resolves it via CLAUDE_CONFIG_DIR env.
+#   T3. detect-claude-session-id.py with no config dir / env falls back to
+#       the ambient HOME — fixture lives elsewhere so nothing is found.
+#   T4. resolve-claude-resume-session-id.py accepts the candidate (rc=0)
+#       via the trailing config-dir argument.
+#   T5. resolve-claude-resume-session-id.py accepts it via CLAUDE_CONFIG_DIR.
+#   T6. resolve-claude-resume-session-id.py with no config dir / env
+#       rejects the candidate (rc=1) — daemon-HOME fallback, unchanged.
+#
+#   Shim coverage (the actual Bash functions, the layer the #1018 r1
+#   regression slipped past because the smoke only tested the helpers):
+#   T7. bridge_detect_claude_session_id for a REGISTERED isolated agent
+#       resolves the session under the agent's <agent-home>/.claude/.
+#   T8. bridge_resolve_resume_session_id for the same registered isolated
+#       agent accepts the candidate (rc=0).
+#   T9. bridge_detect_claude_session_id for an UNREGISTERED agent with a
+#       per-call HOME does NOT shadow that HOME — the guard returns empty
+#       and the helper finds the fixture under the per-call HOME
+#       (backward-compatible fallback).
+#   T10. bridge_resolve_resume_session_id for an UNREGISTERED agent with a
+#        per-call HOME likewise accepts the candidate via that HOME — the
+#        regression vector from PR #1018 r1 (codex item 1).
+#
+# Isolation: temp BRIDGE_HOME via smoke_setup_bridge_home (v2 layout);
+# the smoke never reads or writes the operator's live `~/.claude` or
+# bridge runtime. The fallback cases pin HOME at a temp dir.
 #
 # Footgun #11 (heredoc_write deadlock class): this fixture uses only
 # `printf` / `cat >file <<EOF` plain-body writes — no command
@@ -59,7 +86,7 @@ trap cleanup EXIT
 
 smoke_require_cmd python3
 
-smoke_make_temp_root "1015-resume-claude-config-dir"
+smoke_setup_bridge_home "1015-resume-claude-config-dir"
 
 REPO_ROOT="$SMOKE_REPO_ROOT"
 DETECT_HELPER="$REPO_ROOT/scripts/python-helpers/detect-claude-session-id.py"
@@ -68,28 +95,31 @@ RESOLVE_HELPER="$REPO_ROOT/scripts/python-helpers/resolve-claude-resume-session-
 [[ -f "$DETECT_HELPER" ]] || smoke_fail "missing helper: $DETECT_HELPER"
 [[ -f "$RESOLVE_HELPER" ]] || smoke_fail "missing helper: $RESOLVE_HELPER"
 
-# --- Fixture: an agent config dir with a live session + matching
-#     transcript, mimicking what an isolation-v2 agent writes under
-#     <agent-home>/.claude/ . -----------------------------------------
+# Seed a Claude config dir (sessions/<pid>.json + matching fresh
+# transcript) under a given root, mimicking what an isolation-v2 agent
+# writes under <agent-home>/.claude/ .
+seed_claude_config_dir() {
+  local config_dir="$1"
+  local workdir="$2"
+  local session_id="$3"
+  local slug now_ms
+  slug="${workdir//\//-}"
+  mkdir -p "$config_dir/sessions" "$config_dir/projects/$slug"
+  now_ms=$(( $(date +%s) * 1000 ))
+  cat >"$config_dir/sessions/$$.json" <<EOF
+{"sessionId":"$session_id","cwd":"$workdir","pid":$$,"startedAt":$now_ms}
+EOF
+  printf '{"sessionId":"%s"}\n' "$session_id" \
+    >"$config_dir/projects/$slug/$session_id.jsonl"
+}
+
+# --- Direct-helper fixture ----------------------------------------------
 AGENT_CONFIG_DIR="$SMOKE_TMP_ROOT/agent-home/.claude"
 WORKDIR="$SMOKE_TMP_ROOT/agent-workdir"
 SESSION_ID="abc12345-1015-resume-fixture"
 mkdir -p "$WORKDIR"
-
-# Claude encodes the project dir by replacing "/" with "-".
-WORKDIR_SLUG="${WORKDIR//\//-}"
-mkdir -p "$AGENT_CONFIG_DIR/sessions" "$AGENT_CONFIG_DIR/projects/$WORKDIR_SLUG"
-
-# Live `sessions/<pid>.json` — use this shell's own pid so pid_is_alive()
-# returns true (the #827 live-session shortcut both helpers honour).
-NOW_MS=$(( $(date +%s) * 1000 ))
-cat >"$AGENT_CONFIG_DIR/sessions/$$.json" <<EOF
-{"sessionId":"$SESSION_ID","cwd":"$WORKDIR","pid":$$,"startedAt":$NOW_MS}
-EOF
-
-# Matching fresh transcript so the transcript-scan path also resolves.
-printf '{"sessionId":"%s"}\n' "$SESSION_ID" \
-  >"$AGENT_CONFIG_DIR/projects/$WORKDIR_SLUG/$SESSION_ID.jsonl"
+WORKDIR="$(cd -P "$WORKDIR" && pwd -P)"
+seed_claude_config_dir "$AGENT_CONFIG_DIR" "$WORKDIR" "$SESSION_ID"
 
 # An empty HOME for the "no config dir" fallback cases, so the operator's
 # real ~/.claude cannot accidentally satisfy (or break) the assertion.
@@ -168,11 +198,123 @@ test_resolve_fallback_rejects() {
     "T6 resolve helper daemon-HOME fallback rejects candidate (rc=1)"
 }
 
-smoke_run "T1 detect resolves via trailing argument"   test_detect_via_argument
-smoke_run "T2 detect resolves via CLAUDE_CONFIG_DIR"    test_detect_via_env
-smoke_run "T3 detect fallback finds no fixture"         test_detect_fallback_finds_nothing
-smoke_run "T4 resolve accepts via trailing argument"    test_resolve_via_argument
-smoke_run "T5 resolve accepts via CLAUDE_CONFIG_DIR"    test_resolve_via_env
-smoke_run "T6 resolve fallback rejects candidate"       test_resolve_fallback_rejects
+# --- Shim coverage: source bridge-lib.sh and exercise the Bash shims ----
+#
+# bridge-lib.sh transitively sources lib/bridge-state.sh (the shims) and
+# lib/bridge-agents.sh (bridge_agent_exists / bridge_agent_claude_config_dir).
+# shellcheck source=bridge-lib.sh disable=SC1091
+source "$REPO_ROOT/bridge-lib.sh"
+
+declare -F bridge_detect_claude_session_id >/dev/null \
+  || smoke_fail "bridge_detect_claude_session_id not defined after sourcing bridge-lib.sh"
+declare -F bridge_resolve_resume_session_id >/dev/null \
+  || smoke_fail "bridge_resolve_resume_session_id not defined"
+declare -F bridge_resolve_agent_claude_config_dir >/dev/null \
+  || smoke_fail "bridge_resolve_agent_claude_config_dir not defined (issue #1015 guard)"
+declare -F bridge_reset_roster_maps >/dev/null \
+  || smoke_fail "bridge_reset_roster_maps not defined"
+
+# Register one isolated agent. Its config dir resolves to
+# $BRIDGE_AGENT_ROOT_V2/<agent>/home/.claude (bridge_agent_claude_config_dir
+# under the v2 layout that smoke_setup_bridge_home installs). Seed the
+# fixture there so the guard's "registered AND dir exists" check passes.
+bridge_reset_roster_maps
+
+ISO_AGENT="rcd-1015"
+ISO_WORKDIR="$SMOKE_TMP_ROOT/iso-workdir"
+ISO_SESSION_ID="def67890-1015-iso-fixture"
+mkdir -p "$ISO_WORKDIR"
+ISO_WORKDIR="$(cd -P "$ISO_WORKDIR" && pwd -P)"
+
+BRIDGE_AGENT_IDS=("$ISO_AGENT")
+BRIDGE_AGENT_DESC["$ISO_AGENT"]="$ISO_AGENT smoke fixture"
+BRIDGE_AGENT_ENGINE["$ISO_AGENT"]="claude"
+BRIDGE_AGENT_SESSION["$ISO_AGENT"]="$ISO_AGENT"
+BRIDGE_AGENT_WORKDIR["$ISO_AGENT"]="$ISO_WORKDIR"
+BRIDGE_AGENT_LOOP["$ISO_AGENT"]="1"
+BRIDGE_AGENT_CONTINUE["$ISO_AGENT"]="1"
+BRIDGE_AGENT_SOURCE["$ISO_AGENT"]="static"
+BRIDGE_AGENT_CREATED_AT["$ISO_AGENT"]="$(date +%s)"
+BRIDGE_AGENT_SESSION_ID["$ISO_AGENT"]=""
+
+ISO_CONFIG_DIR="$(bridge_agent_claude_config_dir "$ISO_AGENT")"
+[[ -n "$ISO_CONFIG_DIR" ]] \
+  || smoke_fail "bridge_agent_claude_config_dir returned empty for registered agent"
+seed_claude_config_dir "$ISO_CONFIG_DIR" "$ISO_WORKDIR" "$ISO_SESSION_ID"
+
+# T7 — bridge_detect_claude_session_id resolves the registered isolated
+# agent's session under its own <agent-home>/.claude/ . The guard
+# auto-supplies the config dir; HOME is irrelevant here.
+test_shim_detect_isolated_agent() {
+  local detected="" _cfg=""
+  _cfg="$(bridge_resolve_agent_claude_config_dir "$ISO_AGENT")"
+  smoke_assert_eq "$ISO_CONFIG_DIR" "$_cfg" \
+    "T7 guard resolves the registered isolated agent's config dir"
+  detected="$(bridge_detect_claude_session_id "$ISO_WORKDIR" 0 "" "$_cfg" 2>/dev/null)"
+  smoke_assert_eq "$ISO_SESSION_ID" "$detected" \
+    "T7 shim detects session under the isolated agent's CLAUDE_CONFIG_DIR"
+}
+
+# T8 — bridge_resolve_resume_session_id accepts the candidate (rc=0) for
+# the registered isolated agent; the shim auto-resolves the config dir.
+test_shim_resolve_isolated_agent() {
+  local resolved="" rc=0
+  set +e
+  resolved="$(bridge_resolve_resume_session_id \
+    claude "$ISO_AGENT" "$ISO_WORKDIR" "$ISO_SESSION_ID" 2>/dev/null)"
+  rc=$?
+  set -e
+  smoke_assert_eq "0" "$rc" \
+    "T8 shim resolve rc=0 for registered isolated agent"
+  smoke_assert_eq "$ISO_SESSION_ID" "$resolved" \
+    "T8 shim resolve accepts the isolated agent's live session id"
+}
+
+# T9 — bridge_detect_claude_session_id for an UNREGISTERED agent with a
+# per-call HOME must NOT shadow that HOME. The guard returns empty (agent
+# not in the roster) so the helper falls back to HOME/.claude — where the
+# direct-helper fixture lives. This is the regression vector from #1018 r1.
+test_shim_detect_unregistered_home_fallback() {
+  local guard_out="" detected=""
+  guard_out="$(bridge_resolve_agent_claude_config_dir "unregistered-xyz")"
+  smoke_assert_eq "" "$guard_out" \
+    "T9 guard returns empty for an unregistered agent (no HOME shadowing)"
+  # The shim takes the config dir as an explicit arg; with the guard
+  # returning empty, the caller passes "" and the helper uses HOME.
+  detected="$(HOME="$SMOKE_TMP_ROOT/agent-home" \
+    bridge_detect_claude_session_id "$WORKDIR" 0 "" "" 2>/dev/null)"
+  smoke_assert_eq "$SESSION_ID" "$detected" \
+    "T9 shim detect honours the per-call HOME fallback (no config dir)"
+}
+
+# T10 — bridge_resolve_resume_session_id for an UNREGISTERED agent with a
+# per-call HOME accepts the candidate via that HOME. Direct re-creation of
+# the claude-live-session-pretranscript T1 regression vector: prior to the
+# r1 fix the shim auto-computed a derived config dir for the unregistered
+# `test`-style agent and overrode HOME, breaking the fallback.
+test_shim_resolve_unregistered_home_fallback() {
+  local resolved="" rc=0
+  set +e
+  resolved="$(HOME="$SMOKE_TMP_ROOT/agent-home" \
+    bridge_resolve_resume_session_id \
+    claude "unregistered-xyz" "$WORKDIR" "$SESSION_ID" 2>/dev/null)"
+  rc=$?
+  set -e
+  smoke_assert_eq "0" "$rc" \
+    "T10 shim resolve rc=0 via per-call HOME for an unregistered agent"
+  smoke_assert_eq "$SESSION_ID" "$resolved" \
+    "T10 shim resolve accepts candidate via the per-call HOME fallback"
+}
+
+smoke_run "T1 detect resolves via trailing argument"     test_detect_via_argument
+smoke_run "T2 detect resolves via CLAUDE_CONFIG_DIR"      test_detect_via_env
+smoke_run "T3 detect fallback finds no fixture"           test_detect_fallback_finds_nothing
+smoke_run "T4 resolve accepts via trailing argument"      test_resolve_via_argument
+smoke_run "T5 resolve accepts via CLAUDE_CONFIG_DIR"      test_resolve_via_env
+smoke_run "T6 resolve fallback rejects candidate"         test_resolve_fallback_rejects
+smoke_run "T7 shim detect for registered isolated agent"  test_shim_detect_isolated_agent
+smoke_run "T8 shim resolve for registered isolated agent" test_shim_resolve_isolated_agent
+smoke_run "T9 shim detect honours per-call HOME"          test_shim_detect_unregistered_home_fallback
+smoke_run "T10 shim resolve honours per-call HOME"        test_shim_resolve_unregistered_home_fallback
 
 smoke_log "all checks passed"

--- a/scripts/smoke/1015-resume-claude-config-dir.sh
+++ b/scripts/smoke/1015-resume-claude-config-dir.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1015-resume-claude-config-dir.sh — Issue #1015.
+#
+# Pins the contract that the Claude session-id helpers resolve their
+# `~/.claude/sessions` + `~/.claude/projects` roots from the *agent's*
+# CLAUDE_CONFIG_DIR, not the daemon process's HOME.
+#
+# Root cause (issue #1015): static Claude agents launched by the
+# isolation-v2 stack run with a custom HOME / CLAUDE_CONFIG_DIR, so the
+# session JSON and transcripts land under `<agent-home>/.claude/`. Both
+# python helpers expanded `~/.claude/...` against the daemon HOME, found
+# nothing, returned rc=1, and `bridge_normalize_agent_session_id` then
+# cleared the stored id — every restart launched a fresh session.
+#
+# The fix: both helpers resolve the config root from, in priority order,
+# an explicit trailing argument > the CLAUDE_CONFIG_DIR env var >
+# <HOME>/.claude > os.path.expanduser("~/.claude"). The last two preserve
+# the pre-#1015 daemon-HOME behaviour for non-isolated agents.
+#
+# Test plan (all run directly against the two python helpers, no live
+# tmux, no bridge runtime):
+#   T1. detect-claude-session-id.py finds the live session id when the
+#       agent's config dir is passed as the trailing argument.
+#   T2. detect-claude-session-id.py finds it via the CLAUDE_CONFIG_DIR
+#       env var when no argument is supplied.
+#   T3. detect-claude-session-id.py with no config dir and no env var
+#       falls back to the ambient HOME — the fixture lives elsewhere so
+#       it must NOT be discovered (backward-compatible non-isolated path).
+#   T4. resolve-claude-resume-session-id.py accepts the candidate id
+#       (rc=0) when the agent's config dir is passed as the trailing arg.
+#   T5. resolve-claude-resume-session-id.py accepts it via the
+#       CLAUDE_CONFIG_DIR env var.
+#   T6. resolve-claude-resume-session-id.py with no config dir and no env
+#       var rejects the candidate (rc=1) — the daemon-HOME fallback finds
+#       no transcript, exactly as before #1015.
+#
+# Isolation: a self-contained fixture dir under SMOKE_TMP_ROOT; the smoke
+# never reads or writes the operator's live `~/.claude` or bridge runtime.
+# Each "no config dir" case runs with HOME pointed at an empty temp dir so
+# the operator's real `~/.claude` cannot mask the fallback assertion.
+#
+# Footgun #11 (heredoc_write deadlock class): this fixture uses only
+# `printf` / `cat >file <<EOF` plain-body writes — no command
+# substitution feeding a heredoc-stdin, no `<<<` here-strings into bridge
+# functions.
+
+set -euo pipefail
+
+SMOKE_NAME="1015-resume-claude-config-dir"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_make_temp_root "1015-resume-claude-config-dir"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+DETECT_HELPER="$REPO_ROOT/scripts/python-helpers/detect-claude-session-id.py"
+RESOLVE_HELPER="$REPO_ROOT/scripts/python-helpers/resolve-claude-resume-session-id.py"
+
+[[ -f "$DETECT_HELPER" ]] || smoke_fail "missing helper: $DETECT_HELPER"
+[[ -f "$RESOLVE_HELPER" ]] || smoke_fail "missing helper: $RESOLVE_HELPER"
+
+# --- Fixture: an agent config dir with a live session + matching
+#     transcript, mimicking what an isolation-v2 agent writes under
+#     <agent-home>/.claude/ . -----------------------------------------
+AGENT_CONFIG_DIR="$SMOKE_TMP_ROOT/agent-home/.claude"
+WORKDIR="$SMOKE_TMP_ROOT/agent-workdir"
+SESSION_ID="abc12345-1015-resume-fixture"
+mkdir -p "$WORKDIR"
+
+# Claude encodes the project dir by replacing "/" with "-".
+WORKDIR_SLUG="${WORKDIR//\//-}"
+mkdir -p "$AGENT_CONFIG_DIR/sessions" "$AGENT_CONFIG_DIR/projects/$WORKDIR_SLUG"
+
+# Live `sessions/<pid>.json` — use this shell's own pid so pid_is_alive()
+# returns true (the #827 live-session shortcut both helpers honour).
+NOW_MS=$(( $(date +%s) * 1000 ))
+cat >"$AGENT_CONFIG_DIR/sessions/$$.json" <<EOF
+{"sessionId":"$SESSION_ID","cwd":"$WORKDIR","pid":$$,"startedAt":$NOW_MS}
+EOF
+
+# Matching fresh transcript so the transcript-scan path also resolves.
+printf '{"sessionId":"%s"}\n' "$SESSION_ID" \
+  >"$AGENT_CONFIG_DIR/projects/$WORKDIR_SLUG/$SESSION_ID.jsonl"
+
+# An empty HOME for the "no config dir" fallback cases, so the operator's
+# real ~/.claude cannot accidentally satisfy (or break) the assertion.
+EMPTY_HOME="$SMOKE_TMP_ROOT/empty-home"
+mkdir -p "$EMPTY_HOME"
+
+# T1 — detect helper picks up the agent config dir via the trailing arg.
+test_detect_via_argument() {
+  local out=""
+  out="$(python3 "$DETECT_HELPER" "$WORKDIR" 0 "" "$AGENT_CONFIG_DIR")"
+  smoke_assert_eq "$SESSION_ID" "$out" \
+    "T1 detect helper resolves session via trailing config-dir argument"
+}
+
+# T2 — detect helper picks up the agent config dir via CLAUDE_CONFIG_DIR.
+test_detect_via_env() {
+  local out=""
+  out="$(CLAUDE_CONFIG_DIR="$AGENT_CONFIG_DIR" \
+    python3 "$DETECT_HELPER" "$WORKDIR" 0 "")"
+  smoke_assert_eq "$SESSION_ID" "$out" \
+    "T2 detect helper resolves session via CLAUDE_CONFIG_DIR env var"
+}
+
+# T3 — detect helper with no config dir falls back to the ambient HOME;
+# the fixture lives elsewhere so nothing is found (non-isolated path,
+# unchanged from pre-#1015).
+test_detect_fallback_finds_nothing() {
+  local out=""
+  out="$(env -u CLAUDE_CONFIG_DIR HOME="$EMPTY_HOME" \
+    python3 "$DETECT_HELPER" "$WORKDIR" 0 "")"
+  smoke_assert_eq "" "$out" \
+    "T3 detect helper daemon-HOME fallback finds no fixture session"
+}
+
+# T4 — resolve helper accepts the candidate (rc=0) via the trailing arg.
+test_resolve_via_argument() {
+  local out="" rc=0
+  set +e
+  out="$(python3 "$RESOLVE_HELPER" \
+    "$WORKDIR" "$SESSION_ID" 48 testagent "" "$AGENT_CONFIG_DIR" 2>/dev/null)"
+  rc=$?
+  set -e
+  smoke_assert_eq "0" "$rc" \
+    "T4 resolve helper rc=0 when config dir passed as trailing argument"
+  smoke_assert_eq "$SESSION_ID" "$out" \
+    "T4 resolve helper returns the candidate session id"
+}
+
+# T5 — resolve helper accepts the candidate (rc=0) via CLAUDE_CONFIG_DIR.
+test_resolve_via_env() {
+  local out="" rc=0
+  set +e
+  out="$(CLAUDE_CONFIG_DIR="$AGENT_CONFIG_DIR" \
+    python3 "$RESOLVE_HELPER" \
+    "$WORKDIR" "$SESSION_ID" 48 testagent "" 2>/dev/null)"
+  rc=$?
+  set -e
+  smoke_assert_eq "0" "$rc" \
+    "T5 resolve helper rc=0 when config dir comes from CLAUDE_CONFIG_DIR"
+  smoke_assert_eq "$SESSION_ID" "$out" \
+    "T5 resolve helper returns the candidate session id via env var"
+}
+
+# T6 — resolve helper with no config dir falls back to the ambient HOME;
+# no transcript exists there so the candidate is rejected (rc=1), exactly
+# as before #1015 (the non-isolated path must not regress).
+test_resolve_fallback_rejects() {
+  local rc=0
+  set +e
+  env -u CLAUDE_CONFIG_DIR HOME="$EMPTY_HOME" \
+    python3 "$RESOLVE_HELPER" \
+    "$WORKDIR" "$SESSION_ID" 48 testagent "" >/dev/null 2>&1
+  rc=$?
+  set -e
+  smoke_assert_eq "1" "$rc" \
+    "T6 resolve helper daemon-HOME fallback rejects candidate (rc=1)"
+}
+
+smoke_run "T1 detect resolves via trailing argument"   test_detect_via_argument
+smoke_run "T2 detect resolves via CLAUDE_CONFIG_DIR"    test_detect_via_env
+smoke_run "T3 detect fallback finds no fixture"         test_detect_fallback_finds_nothing
+smoke_run "T4 resolve accepts via trailing argument"    test_resolve_via_argument
+smoke_run "T5 resolve accepts via CLAUDE_CONFIG_DIR"    test_resolve_via_env
+smoke_run "T6 resolve fallback rejects candidate"       test_resolve_fallback_rejects
+
+smoke_log "all checks passed"


### PR DESCRIPTION
## Summary

Static Claude agents launched by the isolation-v2 stack run with a custom
`HOME` / `CLAUDE_CONFIG_DIR`, so Claude Code writes its session JSON and
transcripts under `<agent-home>/.claude/`. Both session-id python helpers
expanded `~/.claude/...` against the **daemon process's HOME**, found
nothing, returned `rc=1`, and `bridge_normalize_agent_session_id` then
cleared the stored session id — every restart launched a fresh session
regardless of `continue=1` (issue #1015).

Both helpers now resolve the Claude config root from, in priority order:
an explicit **trailing argument** > the **`CLAUDE_CONFIG_DIR` env var** >
**`<HOME>/.claude`** > **`os.path.expanduser("~/.claude")`**. The last two
preserve the pre-#1015 daemon-HOME behaviour for non-isolated agents and
for any call site that passes nothing.

## What changed

- **`scripts/python-helpers/resolve-claude-resume-session-id.py`** — new
  `claude_config_root()` helper; reads optional `sys.argv[6]`
  (`claude_config_dir`); every `expanduser("~/.claude/...")` for the
  `sessions/` shortcut and `projects/<slug>` transcript scan now joins
  against the resolved root.
- **`scripts/python-helpers/detect-claude-session-id.py`** — same
  `claude_config_root()` helper; reads optional `sys.argv[4]`; the
  `sessions/*.json` walk, the per-slug + recursive transcript lookups, and
  the dead-process transcript fallback all join against the resolved root.
- **`lib/bridge-state.sh`** —
  - `bridge_resolve_resume_session_id` derives the agent's config dir via
    `bridge_agent_claude_config_dir` (it already takes the agent name) and
    passes it as the new trailing argument.
  - `bridge_detect_claude_session_id` and `bridge_detect_session_id` take a
    new **optional trailing argument**; `bridge_claude_resume_session_id_for_agent`
    and `bridge_refresh_agent_session_id` compute and pass it.
- **`bridge-sync.sh`** — `refresh_missing_session_ids` (the daemon-sync
  caller of `bridge_detect_session_id`) computes and passes the agent's
  config dir.
- **`scripts/smoke/1015-resume-claude-config-dir.sh`** (new) — six-case
  fixture smoke covering config-root resolution for both helpers; wired
  into `scripts/ci-select-smoke.sh` under the python-helpers and
  `lib/bridge-state.sh` / `bridge-sync.sh` arms.

All new arguments are optional and trailing, so existing call sites and the
non-isolated path are byte-for-byte unchanged. `bridge_normalize_agent_session_id`'s
clear-on-rc1 behaviour is untouched — the bug was the helpers returning
`rc=1` wrongly.

## Verification

```
python3 -m py_compile scripts/python-helpers/resolve-claude-resume-session-id.py \
  scripts/python-helpers/detect-claude-session-id.py        # OK
bash -n lib/bridge-state.sh bridge-sync.sh scripts/ci-select-smoke.sh \
  scripts/smoke/1015-resume-claude-config-dir.sh            # OK
shellcheck (same set)                                       # OK
```

New smoke `scripts/smoke/1015-resume-claude-config-dir.sh` — all 6 checks pass:

```
[smoke:1015-resume-claude-config-dir] ok: T1 detect resolves via trailing argument
[smoke:1015-resume-claude-config-dir] ok: T2 detect resolves via CLAUDE_CONFIG_DIR
[smoke:1015-resume-claude-config-dir] ok: T3 detect fallback finds no fixture
[smoke:1015-resume-claude-config-dir] ok: T4 resolve accepts via trailing argument
[smoke:1015-resume-claude-config-dir] ok: T5 resolve accepts via CLAUDE_CONFIG_DIR
[smoke:1015-resume-claude-config-dir] ok: T6 resolve fallback rejects candidate
[smoke:1015-resume-claude-config-dir] all checks passed
```

Regression evidence — custom-`CLAUDE_CONFIG_DIR` detect+resolve path
(temp fixture: live `sessions/<pid>.json` + matching fresh transcript under
`<agent-home>/.claude/`, `HOME` pointed at an empty dir for the fallback cases):

```
detect  arg :  abc12345-1015-probe  rc=0
detect  env :  abc12345-1015-probe  rc=0
detect  none:  ''  rc=0   (empty = daemon-HOME fallback, unchanged)
resolve arg :  abc12345-1015-probe  rc=0
resolve env :  abc12345-1015-probe  rc=0
resolve none:  rc=1       (rc=1 = candidate rejected, unchanged non-isolated path)
```

The `arg` / `env` rows confirm the fix: with the agent's config dir the
helpers find the session (rc=0) instead of rc=1. The `none` rows confirm
the backward-compatible daemon-HOME fallback is unchanged — detect returns
empty, resolve rejects the candidate, exactly as before #1015.

Related smoke `981-restart-session-resume-snapshot` still passes.

CI smoke may show pre-existing environmental skips (`live/tmux/daemon`,
`legacy-full-smoke`) unrelated to this change.

## Scope

Single logical change, one commit. No `VERSION` bump, no `CHANGELOG` entry.
References issue (#1015) — issue closure is handled by the orchestrator on
merge of the wave integration branch.
