### PR TITLE
fix(runtime): gate idle-nudge on task age, drop stale BRIDGE_LAYOUT propagation, unblock roster reads (#1014)

### DIFF
--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -1841,7 +1841,23 @@ def cmd_daemon_step(args: argparse.Namespace) -> int:
     blocked_reminder_seconds = max(0, int(args.blocked_reminder_seconds))
     blocked_escalate_seconds = max(0, int(args.blocked_escalate_seconds))
     admin_agent = str(args.admin_agent or "").strip()
+    # Issue #1014 A: a freshly-queued task already triggered the task-arrival
+    # push notification. The daemon idle-nudge measures agent-idle-duration, so
+    # an agent parked idle past idle_threshold gets a redundant ACTION REQUIRED
+    # nudge on the very next tick (~5s) for a task it is already acting on.
+    # Gate the nudge on task-queued age: a queued task younger than the nudge
+    # redelivery window does not count as a fresh nudge trigger. Once it ages
+    # past the window without progress, the nudge fires normally.
+    try:
+        nudge_redelivery_seconds = int(
+            os.environ.get("BRIDGE_DAEMON_NUDGE_REDELIVERY_SECONDS", "60")
+        )
+    except (TypeError, ValueError):
+        nudge_redelivery_seconds = 60
+    if nudge_redelivery_seconds < 0:
+        nudge_redelivery_seconds = 0
     queued_ids_by_agent: dict[str, list[int]] = {}
+    queued_created_by_id: dict[int, int] = {}
 
     with closing(connect()) as conn, conn:
         for row in snapshot_rows:
@@ -2099,7 +2115,7 @@ def cmd_daemon_step(args: argparse.Namespace) -> int:
 
         rows = conn.execute(
             """
-            SELECT assigned_to, id
+            SELECT assigned_to, id, created_ts
             FROM tasks
             WHERE status = 'queued'
               AND title NOT LIKE '[cron-dispatch]%'
@@ -2107,7 +2123,9 @@ def cmd_daemon_step(args: argparse.Namespace) -> int:
             """
         ).fetchall()
         for row in rows:
-            queued_ids_by_agent.setdefault(str(row["assigned_to"]), []).append(int(row["id"]))
+            task_id = int(row["id"])
+            queued_ids_by_agent.setdefault(str(row["assigned_to"]), []).append(task_id)
+            queued_created_by_id[task_id] = int(row["created_ts"] or 0)
 
         rows = conn.execute(
             f"""
@@ -2163,7 +2181,27 @@ def cmd_daemon_step(args: argparse.Namespace) -> int:
         if zombie:
             continue
         last_nudged_ids = {item for item in last_nudge_key.split(",") if item}
-        has_new_queue_ids = any(str(task_id) not in last_nudged_ids for task_id in queue_ids)
+        # Issue #1014 A: a "new" queued task id only counts as a fresh nudge
+        # trigger once it has aged past the redelivery window. A task younger
+        # than that window already drew a task-arrival push, so an ACTION
+        # REQUIRED re-nudge for it on the next tick is redundant noise.
+        # nudge_redelivery_seconds <= 0 disables the gate entirely.
+        new_queue_ids = [
+            task_id for task_id in queue_ids if str(task_id) not in last_nudged_ids
+        ]
+        has_new_queue_ids = any(
+            nudge_redelivery_seconds <= 0
+            or (current_ts - queued_created_by_id.get(task_id, 0))
+            >= nudge_redelivery_seconds
+            for task_id in new_queue_ids
+        )
+        # Issue #1014 A: if every queued task is both never-nudged AND still
+        # inside its redelivery window, there is nothing nudge-worthy yet —
+        # the task-arrival push is doing its job. Skip rather than emit a
+        # redundant ACTION REQUIRED. (A previously-nudged task that needs
+        # redelivery is in last_nudged_ids, so it does not gate here.)
+        if not last_nudged_ids and not has_new_queue_ids:
+            continue
         if last_nudge_ts and current_ts - last_nudge_ts < nudge_cooldown and not has_new_queue_ids:
             continue
         # Suppress repeats for the same queue until the session shows activity again,

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -527,6 +527,37 @@ _READ_INTENT_BASH_COMMANDS = frozenset(
 )
 
 
+# Issue #1014 C: provably non-mutating shell builtins that routinely
+# appear as a *prelude* stage in a read pipeline — `cd ~/.agent-bridge &&
+# grep BRIDGE agent-roster.local.sh`, `test -f roster && cat roster`,
+# `echo "checking"; grep …`. None of these can mutate the filesystem:
+# `cd`/`pwd` only move/print the working directory, `test`/`[` are
+# read-only predicates, `echo`/`printf` write to stdout (any redirection
+# is independently rejected by the per-token write-redirect check below),
+# and `true`/`false`/`:` are no-ops. Before #1014 a neutral prelude stage
+# disqualified the whole pipeline, so a routine `cd … && grep <protected>`
+# read was mis-classified as a write and drew the write-oriented
+# `config set` deny. Treating these stages as transparent does NOT widen
+# the write surface — a genuine write stage (or any output redirection)
+# anywhere in the pipeline still flips the classification to write-intent.
+_NEUTRAL_PRELUDE_BASH_COMMANDS = frozenset(
+    {
+        "cd",
+        "pushd",
+        "popd",
+        "pwd",
+        "test",
+        "[",
+        "[[",
+        "echo",
+        "printf",
+        "true",
+        "false",
+        ":",
+    }
+)
+
+
 def _stage_first_token(stage: str) -> str:
     """Return the leading command word of a single pipeline stage.
 
@@ -646,6 +677,12 @@ def _is_read_intent_bash(command: str) -> bool:
             continue
         # Strip any path component so `/usr/bin/cat` classifies as `cat`.
         leaf = first.rsplit("/", 1)[-1]
+        # Issue #1014 C: a neutral prelude stage (`cd`, `test`, `echo`, …)
+        # cannot mutate state — output redirection is already rejected by
+        # the per-token check above — so it must not disqualify an
+        # otherwise read-intent pipeline.
+        if leaf in _NEUTRAL_PRELUDE_BASH_COMMANDS:
+            continue
         if leaf in _READ_INTENT_BASH_COMMANDS:
             # Reject the in-place / write-mode flag forms even for tools
             # that are normally read-only (e.g. `sed -i`, `awk -i inplace`).

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1055,7 +1055,58 @@ def _command_substring_hits_protected_needle(command: str) -> bool:
     return False
 
 
-def _token_matches_protected(token: str, protected: Path) -> bool:
+def _command_cd_base_dir(tokens: list[str]) -> Path | None:
+    """Resolve the working directory established by a leading ``cd`` stage.
+
+    Issue #1014 C: a routine diagnostic prelude — ``cd $BRIDGE_HOME &&
+    grep BRIDGE agent-roster.local.sh`` — names the protected roster
+    file with a CWD-relative path. The argv path check compares each
+    token against the protected *absolute* path, so the relative
+    ``agent-roster.local.sh`` token never matches and the roster
+    allow(read)/deny(write) branch never fires — reads pass by accident
+    and, worse, writes pass too (a protected-path bypass).
+
+    This resolves a *simple* leading ``cd <dir>`` prelude so the caller
+    can also test relative path fragments against ``<dir>``. Deliberately
+    conservative: only a ``cd`` that is the first command stage and has
+    exactly one directory argument is honored. A `cd` buried later in
+    the pipeline, a `cd` with options, or a `cd -`/`cd ~`-with-no-arg is
+    not resolved — those are not the #1014 shape and resolving them would
+    widen surface for no benefit. Returns the absolute directory Path or
+    None.
+    """
+    # Find the first non-empty command stage.
+    first_stage: list[str] = []
+    for tok in tokens:
+        # A shell operator token ends the first stage.
+        if tok in (";", "&&", "||", "|", "&"):
+            break
+        first_stage.append(tok)
+    if len(first_stage) < 2 or first_stage[0] != "cd":
+        return None
+    # Exactly one argument: `cd <dir>`. Reject `cd -`, option flags, and
+    # multi-arg forms — none are the #1014 prelude shape.
+    dir_args = [t for t in first_stage[1:] if t]
+    if len(dir_args) != 1:
+        return None
+    raw_dir = dir_args[0]
+    if raw_dir.startswith("-"):
+        return None
+    expanded = os.path.expandvars(os.path.expanduser(raw_dir))
+    if not expanded:
+        return None
+    try:
+        candidate = Path(expanded)
+    except Exception:
+        return None
+    if not candidate.is_absolute():
+        return None
+    return candidate
+
+
+def _token_matches_protected(
+    token: str, protected: Path, base_dir: Path | None = None
+) -> bool:
     for fragment in _alias_path_fragments(token):
         expanded = os.path.expandvars(os.path.expanduser(fragment))
         if not expanded:
@@ -1066,6 +1117,17 @@ def _token_matches_protected(token: str, protected: Path) -> bool:
             continue
         if candidate == protected:
             return True
+        # Issue #1014 C: a CWD-relative fragment under a resolved `cd`
+        # prelude — `cd $BRIDGE_HOME && … agent-roster.local.sh` — must
+        # also be tested against the prelude directory so a relative
+        # reference to the protected file is detected (and the
+        # read/write branch then fires correctly).
+        if base_dir is not None and not candidate.is_absolute():
+            try:
+                if (base_dir / candidate) == protected:
+                    return True
+            except Exception:
+                pass
     return False
 
 
@@ -1351,8 +1413,13 @@ def _bash_argv_references_path(command: str, protected: Path) -> bool:
     except ValueError:
         return protected_str in command
 
+    # Issue #1014 C: resolve a leading `cd <dir>` prelude so a CWD-relative
+    # reference to the protected file (`cd $BRIDGE_HOME && … agent-roster
+    # .local.sh`) is detected, not silently missed.
+    cd_base_dir = _command_cd_base_dir(tokens)
+
     def _check_value_token(value: str) -> bool:
-        return _token_matches_protected(value, protected)
+        return _token_matches_protected(value, protected, cd_base_dir)
 
     skip_next_payload = False
     treat_next_as_value = False
@@ -1388,7 +1455,7 @@ def _bash_argv_references_path(command: str, protected: Path) -> bool:
             if _check_value_token(value):
                 return True
             continue
-        if _token_matches_protected(tok, protected):
+        if _token_matches_protected(tok, protected, cd_base_dir):
             return True
     return False
 
@@ -1425,6 +1492,11 @@ def _bash_argv_references_system_config(command: str) -> bool:
         # by a space still passes — see _PATH_PREFIX_CHARS for rationale.
         return _command_substring_hits_protected_needle(command)
 
+    # Issue #1014 C: resolve a leading `cd <dir>` prelude so a CWD-relative
+    # reference to a protected system-config file is detected — same
+    # bypass class as the roster path in _bash_argv_references_path.
+    cd_base_dir = _command_cd_base_dir(tokens)
+
     def _check_value(value: str) -> bool:
         for fragment in _alias_path_fragments(value):
             expanded = os.path.expandvars(os.path.expanduser(fragment))
@@ -1436,6 +1508,12 @@ def _bash_argv_references_system_config(command: str) -> bool:
                 continue
             if is_protected_path(candidate):
                 return True
+            if cd_base_dir is not None and not candidate.is_absolute():
+                try:
+                    if is_protected_path(cd_base_dir / candidate):
+                        return True
+                except Exception:
+                    pass
         return False
 
     skip_next_payload = False

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -1055,7 +1055,7 @@ def _command_substring_hits_protected_needle(command: str) -> bool:
     return False
 
 
-def _command_cd_base_dir(tokens: list[str]) -> Path | None:
+def _command_cd_base_dir(command: str) -> Path | None:
     """Resolve the working directory established by a leading ``cd`` stage.
 
     Issue #1014 C: a routine diagnostic prelude — ``cd $BRIDGE_HOME &&
@@ -1074,19 +1074,31 @@ def _command_cd_base_dir(tokens: list[str]) -> Path | None:
     not resolved — those are not the #1014 shape and resolving them would
     widen surface for no benefit. Returns the absolute directory Path or
     None.
+
+    Stage detection uses the raw command string and ``_COMMAND_OPERATOR_RE``
+    — the same shell-operator model ``_is_read_intent_bash`` uses — so the
+    first stage is recognized regardless of the separator form: ``&&``,
+    ``;``, ``||``, ``|``, ``&``, or a newline, with or without surrounding
+    whitespace. ``shlex.split`` does NOT emit ``;`` / newline as standalone
+    operator tokens in the no-space form (``cd $X;echo`` arrives as a
+    single ``$X;echo`` token), so relying on token equality missed those
+    shapes (codex r2 catch on PR #1019).
     """
-    # Find the first non-empty command stage.
-    first_stage: list[str] = []
-    for tok in tokens:
-        # A shell operator token ends the first stage.
-        if tok in (";", "&&", "||", "|", "&"):
-            break
-        first_stage.append(tok)
-    if len(first_stage) < 2 or first_stage[0] != "cd":
+    if not command.strip():
+        return None
+    # First shell stage = text before the first &&/;/|/||/&/newline.
+    first_stage = _COMMAND_OPERATOR_RE.split(command, maxsplit=1)[0].strip()
+    if not first_stage:
+        return None
+    try:
+        stage_tokens = shlex.split(first_stage, posix=True, comments=False)
+    except ValueError:
+        return None
+    if len(stage_tokens) < 2 or stage_tokens[0] != "cd":
         return None
     # Exactly one argument: `cd <dir>`. Reject `cd -`, option flags, and
     # multi-arg forms — none are the #1014 prelude shape.
-    dir_args = [t for t in first_stage[1:] if t]
+    dir_args = [t for t in stage_tokens[1:] if t]
     if len(dir_args) != 1:
         return None
     raw_dir = dir_args[0]
@@ -1415,8 +1427,10 @@ def _bash_argv_references_path(command: str, protected: Path) -> bool:
 
     # Issue #1014 C: resolve a leading `cd <dir>` prelude so a CWD-relative
     # reference to the protected file (`cd $BRIDGE_HOME && … agent-roster
-    # .local.sh`) is detected, not silently missed.
-    cd_base_dir = _command_cd_base_dir(tokens)
+    # .local.sh`) is detected, not silently missed. Pass the RAW command —
+    # the prelude detector splits on the shell-operator model so `;` /
+    # newline separators (no-space forms) are recognized too.
+    cd_base_dir = _command_cd_base_dir(command)
 
     def _check_value_token(value: str) -> bool:
         return _token_matches_protected(value, protected, cd_base_dir)
@@ -1494,8 +1508,9 @@ def _bash_argv_references_system_config(command: str) -> bool:
 
     # Issue #1014 C: resolve a leading `cd <dir>` prelude so a CWD-relative
     # reference to a protected system-config file is detected — same
-    # bypass class as the roster path in _bash_argv_references_path.
-    cd_base_dir = _command_cd_base_dir(tokens)
+    # bypass class as the roster path in _bash_argv_references_path. Pass
+    # the RAW command so `;` / newline separators are recognized.
+    cd_base_dir = _command_cd_base_dir(command)
 
     def _check_value(value: str) -> bool:
         for fragment in _alias_path_fragments(value):

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3091,6 +3091,30 @@ bridge_write_linux_agent_env_file() {
       rm -f "$file"
     fi
   fi
+  # Issue #1014 B: the launch envelope must not bake a stale BRIDGE_LAYOUT
+  # value into the per-agent env file. When a valid v2 layout marker exists
+  # the marker is authoritative — the child re-resolves the layout at startup
+  # via bridge_resolve_layout. Baking `BRIDGE_LAYOUT=legacy` here (the old
+  # `${BRIDGE_LAYOUT:-legacy}` default) made the stale value self-perpetuate
+  # through the daemon → agent-env → CLI process tree, so every restart
+  # re-injected it and the resolver's "stale pre-v0.8.0 env override" warning
+  # never cleared. Normalize to the marker value when a marker is present;
+  # only fall back to an explicit ambient BRIDGE_LAYOUT (no marker case).
+  local _agent_env_layout=""
+  local _agent_env_marker_path
+  _agent_env_marker_path="$(bridge_isolation_v2_marker_path 2>/dev/null || true)"
+  if [[ -n "$_agent_env_marker_path" && -f "$_agent_env_marker_path" ]] \
+      && bridge_isolation_v2_marker_validate "$_agent_env_marker_path" >/dev/null 2>&1; then
+    # Marker present and valid — it is the source of truth. Emit the
+    # marker-pinned value so the child never sees a stale legacy override.
+    _agent_env_layout="v2"
+  else
+    # No valid marker — preserve the prior behavior so markerless installs
+    # still carry an explicit layout, but never invent a stale `legacy`
+    # default: only propagate a BRIDGE_LAYOUT the caller actually set.
+    _agent_env_layout="${BRIDGE_LAYOUT:-}"
+  fi
+
   cat >"$file" <<EOF
 #!/usr/bin/env bash
 # shellcheck shell=bash disable=SC2034
@@ -3127,7 +3151,7 @@ BRIDGE_RUNTIME_SECRETS_DIR=$(printf '%q' "$BRIDGE_RUNTIME_SECRETS_DIR")
 BRIDGE_RUNTIME_CONFIG_FILE=$(printf '%q' "$BRIDGE_RUNTIME_CONFIG_FILE")
 BRIDGE_HOOKS_DIR=$(printf '%q' "$BRIDGE_HOOKS_DIR")
 BRIDGE_SHARED_DIR=$(printf '%q' "$BRIDGE_SHARED_DIR")
-BRIDGE_LAYOUT=$(printf '%q' "${BRIDGE_LAYOUT:-legacy}")
+BRIDGE_LAYOUT=$(printf '%q' "$_agent_env_layout")
 BRIDGE_DATA_ROOT=$(printf '%q' "${BRIDGE_DATA_ROOT:-}")
 BRIDGE_SHARED_ROOT=$(printf '%q' "${BRIDGE_SHARED_ROOT:-}")
 BRIDGE_AGENT_ROOT_V2=$(printf '%q' "${BRIDGE_AGENT_ROOT_V2:-}")

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -180,7 +180,7 @@ bridge_layout_resolver_validate_env() {
           # `tmux setenv -u -g` cleanup that actually removes the
           # server-level leak (bridge-upgrade.sh).
           if [[ -z "${_BRIDGE_LAYOUT_STALE_ENV_WARNED:-}" ]]; then
-            bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc (and run \`agent-bridge upgrade --apply\` once to clear any tmux server-level leak)."
+            bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc, then stop and restart the bridge daemon from a clean shell (\`bash bridge-daemon.sh stop\` then \`bash bridge-daemon.sh start\`) so long-running daemon/agent processes stop re-injecting the stale value. A leftover tmux server-level leak is cleared by \`agent-bridge upgrade --apply\`."
             export _BRIDGE_LAYOUT_STALE_ENV_WARNED=1
           fi
           BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV="BRIDGE_LAYOUT (stale ${layout} override; marker=v2)"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout
 }
 
 add_all_integration() {
@@ -199,7 +199,11 @@ select_for_path() {
       ;;
 
     bridge-queue.py|bridge-task.sh|bridge-audit.py)
-      add_required queue
+      # Issue #1014 A: bridge-queue.py's daemon idle-nudge now gates the
+      # ACTION REQUIRED nudge on task-queued age so a freshly-pushed task
+      # is not re-nudged within the redelivery window. Cover the
+      # regression smoke whenever the queue backend moves.
+      add_required queue nudge-task-age-gate
       add_integration integration-minimal
       ;;
 
@@ -283,7 +287,12 @@ select_for_path() {
       # credential deny surfaces (raw mention, env dump, argv path,
       # input path). Cover the regression smoke whenever tool-policy.py
       # moves so the exemption + mutation deny contract stays pinned.
-      add_required hooks agent-update v2-cross-class-read admin-hook-exemption
+      # Issue #1014 C: the Bash read-intent classifier now treats a
+      # neutral prelude stage (cd / test / echo / …) as transparent so a
+      # routine `cd … && grep agent-roster.local.sh` read is no longer
+      # mis-classified as a write. Cover the classifier regression smoke
+      # whenever tool-policy.py moves.
+      add_required hooks agent-update v2-cross-class-read admin-hook-exemption tool-policy-roster-read-classify
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11370,6 +11370,15 @@ bash "$REPO_ROOT/scripts/smoke/classify-stale-dynamic-exemption.sh"
 log "running bridge-export-prefix-no-stale-layout smoke (patch #4725)"
 bash "$REPO_ROOT/scripts/smoke/bridge-export-prefix-no-stale-layout.sh"
 
+# Issue #1014 B: bridge_write_linux_agent_env_file (lib/bridge-agents.sh)
+# baked BRIDGE_LAYOUT=${BRIDGE_LAYOUT:-legacy} into the per-agent launch
+# envelope, so a stale legacy value self-perpetuated through the
+# daemon -> agent-env -> CLI process tree. The writer now normalizes to
+# the v2 marker value when a marker exists. Smoke pins that the
+# generated agent-env.sh never carries a stale pre-v2 BRIDGE_LAYOUT.
+log "running agent-env-no-stale-bridge-layout smoke (issue #1014 B)"
+bash "$REPO_ROOT/scripts/smoke/agent-env-no-stale-bridge-layout.sh"
+
 # Companion regression to patch #4725: PR #926 stopped the bridge-core
 # export prefix from forwarding stale BRIDGE_LAYOUT/BRIDGE_DATA_ROOT,
 # but did not clean values that already lived in the tmux server's
@@ -11387,6 +11396,16 @@ bash "$REPO_ROOT/scripts/smoke/tmux-server-bridge-layout-cleanup.sh"
 # truth-table cases (operator-flagged 2026-05-16).
 log "running tool-policy-process-dump-regex smoke"
 bash "$REPO_ROOT/scripts/smoke/tool-policy-process-dump-regex.sh"
+
+# Issue #1014 C: the tool-policy Bash read-intent classifier required
+# every pipeline stage to lead with a read tool, so a routine
+# `cd ~/.agent-bridge && grep agent-roster.local.sh` diagnostic was
+# mis-classified as a write and drew the write-oriented `config set`
+# deny. The classifier now treats neutral prelude builtins (cd / test /
+# echo / …) as transparent. Smoke pins the #1014 shapes as read-intent
+# while genuine write shapes stay write-intent.
+log "running tool-policy-roster-read-classify smoke (issue #1014 C)"
+bash "$REPO_ROOT/scripts/smoke/tool-policy-roster-read-classify.sh"
 
 # bridge_worktree_doctor previously left daemonized children alive after
 # pruning their worktree dir — Sean observed 7 orphaned bridge-watchdog
@@ -11469,5 +11488,13 @@ bash "$REPO_ROOT/scripts/smoke/981-restart-session-resume-snapshot.sh"
 # state path (the #771-class silent Teams inbound delivery failure).
 log "running 989-isolated-agent-env-state-dir smoke (issue #989)"
 bash "$REPO_ROOT/scripts/smoke/989-isolated-agent-env-state-dir.sh"
+
+# Issue #1014 A — bridge-queue.py's daemon idle-nudge measured idle as
+# agent-idle-duration, so an agent parked idle past the threshold got a
+# redundant ACTION REQUIRED nudge on the next tick for a task it was
+# just pushed. The nudge scan now gates on task-queued age: a task
+# younger than the redelivery window does not re-nudge.
+log "running nudge-task-age-gate smoke (issue #1014 A)"
+bash "$REPO_ROOT/scripts/smoke/nudge-task-age-gate.sh"
 
 log "smoke test passed"

--- a/scripts/smoke/agent-env-no-stale-bridge-layout.sh
+++ b/scripts/smoke/agent-env-no-stale-bridge-layout.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/agent-env-no-stale-bridge-layout.sh — regression for
+# issue #1014 sub-bug B (2026-05-22).
+#
+# `bridge_write_linux_agent_env_file` (lib/bridge-agents.sh) wrote
+# `BRIDGE_LAYOUT=${BRIDGE_LAYOUT:-legacy}` into the per-agent launch
+# envelope (`runtime/agent-env.sh`). When the ambient BRIDGE_LAYOUT was
+# unset or a stale `legacy` value, the writer baked `legacy` into the
+# env file. On a v2-migrated install the marker at
+# state/layout-marker.sh is authoritative — but the baked value made the
+# stale layout SELF-PERPETUATE through the daemon -> agent-env -> CLI
+# process tree, so every agent restart re-injected it and the layout
+# resolver's "stale pre-v0.8.0 env override" warning never cleared.
+#
+# Fix: when a valid v2 layout marker exists the writer normalizes
+# BRIDGE_LAYOUT to the marker value (`v2`) instead of baking a stale
+# `legacy`. With no valid marker it only propagates a BRIDGE_LAYOUT the
+# caller actually set — it never invents a `legacy` default.
+#
+# This test pins:
+#   T1. With a valid v2 marker AND BRIDGE_LAYOUT=legacy in the ambient
+#       env, the generated agent-env.sh carries BRIDGE_LAYOUT=v2 — never
+#       `legacy`.
+#   T2. With a valid v2 marker AND a stale BRIDGE_LAYOUT=v1, the
+#       generated file is likewise normalized to v2 — never `v1`/`legacy`
+#       (the bug's self-perpetuation seed for any stale pre-v2 value).
+
+set -euo pipefail
+
+# Re-exec under Bash 4+ for associative arrays (macOS ships 3.2).
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash"; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$_candidate" "${BASH_SOURCE[0]}" "$@"
+    fi
+  done
+  echo "[smoke:agent-env-no-stale-bridge-layout] requires Bash 4+ (host is ${BASH_VERSION})" >&2
+  exit 1
+fi
+
+SMOKE_NAME="agent-env-no-stale-bridge-layout"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# shellcheck source=bridge-lib.sh disable=SC1091
+source "$REPO_ROOT/bridge-lib.sh"
+
+if ! declare -F bridge_write_linux_agent_env_file >/dev/null; then
+  smoke_fail "bridge_write_linux_agent_env_file not defined (sanity check)"
+fi
+if ! declare -F bridge_agent_linux_env_file >/dev/null; then
+  smoke_fail "bridge_agent_linux_env_file not defined (sanity check)"
+fi
+if ! declare -F bridge_isolation_v2_marker_validate >/dev/null; then
+  smoke_fail "bridge_isolation_v2_marker_validate not defined (sanity check)"
+fi
+
+bridge_reset_roster_maps
+
+# Confirm smoke_setup_bridge_home seeded a valid v2 marker — the test
+# only has meaning on the marker-present branch of the fix.
+marker_path="$(bridge_isolation_v2_marker_path)"
+if [[ ! -f "$marker_path" ]] || ! bridge_isolation_v2_marker_validate "$marker_path" >/dev/null 2>&1; then
+  smoke_fail "expected a valid v2 layout marker at $marker_path"
+fi
+
+# Seed a minimal in-memory agent record (mirrors 989-isolated-agent-env-
+# state-dir.sh). The writer reads ~25 BRIDGE_AGENT_* maps.
+seed_agent() {
+  local agent="$1"
+  BRIDGE_AGENT_IDS=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent smoke fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]=""
+  BRIDGE_AGENT_PROFILE_HOME["$agent"]=""
+  BRIDGE_AGENT_LAUNCH_CMD["$agent"]="claude --dangerously-skip-permissions"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_LOOP["$agent"]="1"
+  BRIDGE_AGENT_CONTINUE["$agent"]="1"
+  BRIDGE_AGENT_SESSION_ID["$agent"]=""
+  BRIDGE_AGENT_HISTORY_KEY["$agent"]=""
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_UPDATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_IDLE_TIMEOUT["$agent"]="600"
+  BRIDGE_AGENT_NOTIFY_KIND["$agent"]=""
+  BRIDGE_AGENT_NOTIFY_TARGET["$agent"]=""
+  BRIDGE_AGENT_NOTIFY_ACCOUNT["$agent"]=""
+  BRIDGE_AGENT_DISCORD_CHANNEL_ID["$agent"]=""
+  BRIDGE_AGENT_CHANNELS["$agent"]=""
+  BRIDGE_AGENT_ISOLATION_MODE["$agent"]="linux-user"
+  BRIDGE_AGENT_OS_USER["$agent"]="agent-bridge-$agent"
+}
+
+# Run the writer in a sub-shell so an ambient BRIDGE_LAYOUT export does
+# not leak across cases. Echoes the BRIDGE_LAYOUT assignment line from
+# the produced agent-env.sh (empty string if the writer omitted it).
+generate_and_extract_layout() {
+  local agent="$1"
+  local layout_env="$2"   # stale value to export as BRIDGE_LAYOUT
+  (
+    seed_agent "$agent"
+    export BRIDGE_LAYOUT="$layout_env"
+    env_file="$(bridge_agent_linux_env_file "$agent")"
+    mkdir -p "$(dirname "$env_file")"
+    bridge_write_linux_agent_env_file "$agent" "$env_file" >/dev/null
+    grep -E '^BRIDGE_LAYOUT=' "$env_file" | head -n 1 || true
+  )
+}
+
+failed=0
+
+# --- T1: stale BRIDGE_LAYOUT=legacy in env -> file carries v2 ----------
+t1_line="$(generate_and_extract_layout "iso-1014-t1" "legacy")"
+if [[ "$t1_line" == *legacy* ]]; then
+  echo "  FAIL  T1 agent-env.sh baked stale BRIDGE_LAYOUT=legacy" >&2
+  echo "        line: ${t1_line}" >&2
+  failed=1
+elif [[ "$t1_line" == *v2* ]]; then
+  echo "  PASS  T1 stale BRIDGE_LAYOUT=legacy normalized to marker value v2"
+else
+  echo "  FAIL  T1 expected BRIDGE_LAYOUT=v2 in agent-env.sh, got: ${t1_line}" >&2
+  failed=1
+fi
+
+# --- T2: stale BRIDGE_LAYOUT=v1 -> file normalized to v2, never v1 ----
+t2_line="$(generate_and_extract_layout "iso-1014-t2" "v1")"
+if [[ "$t2_line" == *v1* || "$t2_line" == *legacy* ]]; then
+  echo "  FAIL  T2 agent-env.sh propagated a stale pre-v2 BRIDGE_LAYOUT" >&2
+  echo "        line: ${t2_line}" >&2
+  failed=1
+elif [[ "$t2_line" == *v2* ]]; then
+  echo "  PASS  T2 stale BRIDGE_LAYOUT=v1 normalized to marker value v2"
+else
+  echo "  FAIL  T2 expected BRIDGE_LAYOUT=v2 in agent-env.sh, got: ${t2_line}" >&2
+  failed=1
+fi
+
+if (( failed )); then
+  smoke_fail "one or more #1014-B checks failed"
+fi
+smoke_log "passed"

--- a/scripts/smoke/agent-env-no-stale-bridge-layout.sh
+++ b/scripts/smoke/agent-env-no-stale-bridge-layout.sh
@@ -103,15 +103,34 @@ seed_agent() {
   BRIDGE_AGENT_OS_USER["$agent"]="agent-bridge-$agent"
 }
 
-# Run the writer in a sub-shell so an ambient BRIDGE_LAYOUT export does
-# not leak across cases. Echoes the BRIDGE_LAYOUT assignment line from
-# the produced agent-env.sh (empty string if the writer omitted it).
+# Run the writer in a sub-shell so neither an ambient BRIDGE_LAYOUT
+# export nor the platform stub below leaks across cases. Echoes the
+# BRIDGE_LAYOUT assignment line from the produced agent-env.sh (empty
+# string if the writer omitted it).
 generate_and_extract_layout() {
   local agent="$1"
   local layout_env="$2"   # stale value to export as BRIDGE_LAYOUT
   (
     seed_agent "$agent"
     export BRIDGE_LAYOUT="$layout_env"
+    # Host-portability: bridge_write_linux_agent_env_file has a
+    # Linux-only `chgrp ab-agent-<name>` / `chmod 0640` branch
+    # (lib/bridge-agents.sh) gated on `bridge_host_platform == Linux`.
+    # That per-agent group does not exist in this in-memory smoke
+    # fixture, so on the Linux CI runner the chgrp fails and the
+    # writer bridge_die()s. Stub bridge_host_platform to a non-Linux
+    # value so the chgrp/chmod branch is skipped on every host —
+    # mirrors the predicate-stub convention in
+    # scripts/smoke/989-isolated-agent-env-state-dir.sh and
+    # scripts/smoke/857-pr1-isolation-write-helper.sh. This is
+    # host-independent: the chgrp/chmod branch is the ONLY code in
+    # bridge_write_linux_agent_env_file gated on bridge_host_platform
+    # == Linux, and B-B's BRIDGE_LAYOUT=v2 assertion depends only on
+    # the marker resolver (bridge_isolation_v2_marker_*), which does
+    # not consult bridge_host_platform — so the stub cannot weaken
+    # what this smoke verifies.
+    # shellcheck disable=SC2329  # invoked indirectly by the real writer
+    bridge_host_platform() { printf 'Darwin\n'; }
     env_file="$(bridge_agent_linux_env_file "$agent")"
     mkdir -p "$(dirname "$env_file")"
     bridge_write_linux_agent_env_file "$agent" "$env_file" >/dev/null

--- a/scripts/smoke/nudge-task-age-gate-helpers/backdate-task-created-ts.py
+++ b/scripts/smoke/nudge-task-age-gate-helpers/backdate-task-created-ts.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# scripts/smoke/nudge-task-age-gate-helpers/backdate-task-created-ts.py
+#
+# Standalone helper for the issue #1014-A nudge smokes. Backdates the
+# `created_ts` (and `updated_ts`) of one or more queued tasks in a
+# bridge queue DB so the daemon idle-nudge's task-queued-age gate treats
+# them as aged past the redelivery window.
+#
+# Extracted as a file-as-argv helper (NOT a heredoc-stdin `python3 -`
+# subprocess) so the nudge smokes stay clear of the footgun #11
+# heredoc-stdin deadlock class — see scripts/lint-heredoc-ban.sh.
+#
+# Usage:
+#   backdate-task-created-ts.py <db-path> <created-ts> <task-id> [<task-id> ...]
+#   backdate-task-created-ts.py <db-path> <created-ts> --all
+#
+# With --all every row in `tasks` is backdated; otherwise only the
+# listed task ids. Exits non-zero on a usage error or a DB failure.
+
+import sqlite3
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 3:
+        print(
+            "usage: backdate-task-created-ts.py <db> <created-ts> "
+            "(<task-id> ... | --all)",
+            file=sys.stderr,
+        )
+        return 2
+    db_path = argv[0]
+    try:
+        created_ts = int(argv[1])
+    except ValueError:
+        print(f"invalid created-ts: {argv[1]!r}", file=sys.stderr)
+        return 2
+    targets = argv[2:]
+
+    conn = sqlite3.connect(db_path)
+    try:
+        if targets == ["--all"]:
+            conn.execute(
+                "UPDATE tasks SET created_ts = ?, updated_ts = ?",
+                (created_ts, created_ts),
+            )
+        else:
+            try:
+                task_ids = [int(t) for t in targets]
+            except ValueError:
+                print(f"invalid task id in {targets!r}", file=sys.stderr)
+                return 2
+            for task_id in task_ids:
+                conn.execute(
+                    "UPDATE tasks SET created_ts = ?, updated_ts = ? "
+                    "WHERE id = ?",
+                    (created_ts, created_ts, task_id),
+                )
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/smoke/nudge-task-age-gate.sh
+++ b/scripts/smoke/nudge-task-age-gate.sh
@@ -20,17 +20,24 @@
 #      a nudge candidate (within the redelivery window).
 #   2. The SAME task, once its created_ts is aged past the window, IS
 #      emitted as a nudge candidate.
+#
+# Footgun #11: the task is created via `bridge-queue.py create` and the
+# created_ts backdate is done by the standalone file-as-argv helper
+# nudge-task-age-gate-helpers/backdate-task-created-ts.py — no
+# interpreter heredoc-stdin, no `<<<` here-string (see
+# scripts/lint-heredoc-ban.sh).
 
 set -euo pipefail
 
 SMOKE_NAME="nudge-task-age-gate"
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+HELPER_DIR="$SCRIPT_DIR/nudge-task-age-gate-helpers"
 
 echo "[smoke:${SMOKE_NAME}] starting"
 
 TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-nudge.XXXXXX")"
-trap 'rm -f /tmp/agb-nudge-*.tmp 2>/dev/null; rm -rf "$TMP_DIR"' EXIT
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 DB="$TMP_DIR/tasks.db"
 SNAPSHOT="$TMP_DIR/snapshot.tsv"
@@ -56,36 +63,27 @@ run_daemon_step() {
     --format text
 }
 
+# True iff $1 (daemon-step output) lists $AGENT as a nudge candidate.
+output_nudges_agent() {
+  printf '%s\n' "$1" | grep -qE "^${AGENT}[[:space:]]"
+}
+
 failed=0
 
 # --- Phase 1: fresh task — must NOT be a nudge candidate -------------
-# Insert a queued task whose created_ts is NOW (fresh).
-python3 - "$DB" "$AGENT" "$NOW" <<'PY'
-import sqlite3, sys
-db, agent, now = sys.argv[1], sys.argv[2], int(sys.argv[3])
-conn = sqlite3.connect(db)
-conn.execute("PRAGMA journal_mode=WAL")
-conn.execute(
-    """CREATE TABLE IF NOT EXISTS tasks (
-      id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL,
-      assigned_to TEXT NOT NULL, created_by TEXT NOT NULL,
-      priority TEXT NOT NULL DEFAULT 'normal',
-      status TEXT NOT NULL DEFAULT 'queued',
-      created_ts INTEGER NOT NULL, updated_ts INTEGER NOT NULL,
-      body_text TEXT, body_path TEXT, claimed_by TEXT,
-      claimed_ts INTEGER, lease_until_ts INTEGER, closed_ts INTEGER)"""
-)
-conn.execute(
-    "INSERT INTO tasks (title, assigned_to, created_by, status, created_ts, updated_ts)"
-    " VALUES ('fresh task', ?, 'smoke', 'queued', ?, ?)",
-    (agent, now, now),
-)
-conn.commit()
-conn.close()
-PY
+# Create a queued task via the real CLI; created_ts is NOW (fresh).
+python3 "$REPO_ROOT/bridge-queue.py" create \
+  --to "$AGENT" \
+  --from requester \
+  --title "fresh task" \
+  --body "fresh body" \
+  --format shell >"$TMP_DIR/create-out.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/create-out.sh"
+task_id="$TASK_ID"
 
 OUT_FRESH="$(run_daemon_step)"
-if grep -qE "^${AGENT}[[:space:]]" <<<"$OUT_FRESH"; then
+if output_nudges_agent "$OUT_FRESH"; then
   echo "  FAIL  fresh task emitted as nudge candidate (should be gated)" >&2
   echo "        output: ${OUT_FRESH}" >&2
   failed=1
@@ -94,18 +92,11 @@ else
 fi
 
 # --- Phase 2: age the task past the window — must BE a candidate -----
-AGED_TS=$(( NOW - 600 ))   # 600s old, well past the 60s redelivery window
-python3 - "$DB" "$AGED_TS" <<'PY'
-import sqlite3, sys
-db, aged = sys.argv[1], int(sys.argv[2])
-conn = sqlite3.connect(db)
-conn.execute("UPDATE tasks SET created_ts = ?, updated_ts = ?", (aged, aged))
-conn.commit()
-conn.close()
-PY
+# Backdate created_ts 600s into the past, well past the 60s window.
+python3 "$HELPER_DIR/backdate-task-created-ts.py" "$DB" "$(( NOW - 600 ))" "$task_id"
 
 OUT_AGED="$(run_daemon_step)"
-if grep -qE "^${AGENT}[[:space:]]" <<<"$OUT_AGED"; then
+if output_nudges_agent "$OUT_AGED"; then
   echo "  PASS  aged queued task IS nudged once past the redelivery window"
 else
   echo "  FAIL  aged task not emitted as nudge candidate (should fire)" >&2

--- a/scripts/smoke/nudge-task-age-gate.sh
+++ b/scripts/smoke/nudge-task-age-gate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# scripts/smoke/nudge-task-age-gate.sh — regression for issue #1014
+# sub-bug A (2026-05-22).
+#
+# bridge-queue.py's daemon idle-nudge measured idle as agent-idle-
+# duration (now - session_activity_ts). An agent parked idle past the
+# 120s threshold — the normal state for an agent waiting for work — got
+# an `ACTION REQUIRED` nudge on the very next daemon tick (~5s) for a
+# task it was JUST pushed and is already acting on. The task-arrival
+# push and the daemon idle-nudge are two uncoordinated mechanisms.
+#
+# Fix: the nudge scan gates a "new" queued task id on task-queued age.
+# A queued task younger than the nudge redelivery window
+# (BRIDGE_DAEMON_NUDGE_REDELIVERY_SECONDS, default 60s) does not count
+# as a fresh nudge trigger — the task-arrival push already covered it.
+# Once the task ages past the window without progress, the nudge fires.
+#
+# This test pins:
+#   1. A freshly-created queued task for an idle agent is NOT emitted as
+#      a nudge candidate (within the redelivery window).
+#   2. The SAME task, once its created_ts is aged past the window, IS
+#      emitted as a nudge candidate.
+
+set -euo pipefail
+
+SMOKE_NAME="nudge-task-age-gate"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-nudge.XXXXXX")"
+trap 'rm -f /tmp/agb-nudge-*.tmp 2>/dev/null; rm -rf "$TMP_DIR"' EXIT
+
+DB="$TMP_DIR/tasks.db"
+SNAPSHOT="$TMP_DIR/snapshot.tsv"
+export BRIDGE_TASK_DB="$DB"
+export BRIDGE_DAEMON_NUDGE_REDELIVERY_SECONDS=60
+
+AGENT="nudge-tester"
+IDLE_SECONDS=600          # idle far past the 120s idle threshold
+THRESHOLD=120
+
+# Snapshot: one active agent, idle past the threshold.
+NOW="$(date +%s)"
+ACTIVITY_TS=$(( NOW - IDLE_SECONDS ))
+{
+  printf 'agent\tengine\tsession\tworkdir\tactive\tsession_activity_ts\n'
+  printf '%s\tclaude\t%s\t/tmp\t1\t%s\n' "$AGENT" "$AGENT" "$ACTIVITY_TS"
+} > "$SNAPSHOT"
+
+run_daemon_step() {
+  python3 "$REPO_ROOT/bridge-queue.py" daemon-step \
+    --snapshot "$SNAPSHOT" \
+    --idle-threshold "$THRESHOLD" \
+    --format text
+}
+
+failed=0
+
+# --- Phase 1: fresh task — must NOT be a nudge candidate -------------
+# Insert a queued task whose created_ts is NOW (fresh).
+python3 - "$DB" "$AGENT" "$NOW" <<'PY'
+import sqlite3, sys
+db, agent, now = sys.argv[1], sys.argv[2], int(sys.argv[3])
+conn = sqlite3.connect(db)
+conn.execute("PRAGMA journal_mode=WAL")
+conn.execute(
+    """CREATE TABLE IF NOT EXISTS tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT NOT NULL,
+      assigned_to TEXT NOT NULL, created_by TEXT NOT NULL,
+      priority TEXT NOT NULL DEFAULT 'normal',
+      status TEXT NOT NULL DEFAULT 'queued',
+      created_ts INTEGER NOT NULL, updated_ts INTEGER NOT NULL,
+      body_text TEXT, body_path TEXT, claimed_by TEXT,
+      claimed_ts INTEGER, lease_until_ts INTEGER, closed_ts INTEGER)"""
+)
+conn.execute(
+    "INSERT INTO tasks (title, assigned_to, created_by, status, created_ts, updated_ts)"
+    " VALUES ('fresh task', ?, 'smoke', 'queued', ?, ?)",
+    (agent, now, now),
+)
+conn.commit()
+conn.close()
+PY
+
+OUT_FRESH="$(run_daemon_step)"
+if grep -qE "^${AGENT}[[:space:]]" <<<"$OUT_FRESH"; then
+  echo "  FAIL  fresh task emitted as nudge candidate (should be gated)" >&2
+  echo "        output: ${OUT_FRESH}" >&2
+  failed=1
+else
+  echo "  PASS  fresh queued task not nudged within redelivery window"
+fi
+
+# --- Phase 2: age the task past the window — must BE a candidate -----
+AGED_TS=$(( NOW - 600 ))   # 600s old, well past the 60s redelivery window
+python3 - "$DB" "$AGED_TS" <<'PY'
+import sqlite3, sys
+db, aged = sys.argv[1], int(sys.argv[2])
+conn = sqlite3.connect(db)
+conn.execute("UPDATE tasks SET created_ts = ?, updated_ts = ?", (aged, aged))
+conn.commit()
+conn.close()
+PY
+
+OUT_AGED="$(run_daemon_step)"
+if grep -qE "^${AGENT}[[:space:]]" <<<"$OUT_AGED"; then
+  echo "  PASS  aged queued task IS nudged once past the redelivery window"
+else
+  echo "  FAIL  aged task not emitted as nudge candidate (should fire)" >&2
+  echo "        output: ${OUT_AGED}" >&2
+  failed=1
+fi
+
+if (( failed )); then
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] all checks passed"

--- a/scripts/smoke/queue.sh
+++ b/scripts/smoke/queue.sh
@@ -80,6 +80,19 @@ queue_daemon_step_contract() {
   task_id="$(smoke_shell_field TASK_ID "$create_out")"
   now_ts="$(date +%s)"
   activity_ts="$((now_ts - 300))"
+  # Issue #1014 A: the daemon idle-nudge now gates on task-queued age — a
+  # task younger than the nudge redelivery window does NOT re-nudge (the
+  # task-arrival push already covered it). This contract exercises the
+  # nudge-candidate path, so backdate created_ts past the window so the
+  # task is eligible for an ACTION REQUIRED nudge.
+  python3 - "$BRIDGE_TASK_DB" "$task_id" "$((now_ts - 600))" <<'PY'
+import sqlite3, sys
+db, task_id, aged = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+conn = sqlite3.connect(db)
+conn.execute("UPDATE tasks SET created_ts = ? WHERE id = ?", (aged, task_id))
+conn.commit()
+conn.close()
+PY
   snapshot="$SMOKE_TMP_ROOT/agent-summary.tsv"
   cat >"$snapshot" <<EOF
 agent	queued	claimed	blocked	active	idle	last_seen	last_nudge	session	engine	workdir	session_activity_ts
@@ -115,6 +128,18 @@ EOF
       --format shell
   )"
   second_id="$(smoke_shell_field TASK_ID "$create_out")"
+  # Issue #1014 A: backdate the second task past the redelivery window
+  # too — a never-nudged task only counts as a fresh nudge trigger once
+  # it has aged past the window (a still-fresh task is covered by its
+  # task-arrival push).
+  python3 - "$BRIDGE_TASK_DB" "$second_id" "$((now_ts - 600))" <<'PY'
+import sqlite3, sys
+db, task_id, aged = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+conn = sqlite3.connect(db)
+conn.execute("UPDATE tasks SET created_ts = ? WHERE id = ?", (aged, task_id))
+conn.commit()
+conn.close()
+PY
   new_out="$(
     python3 "$SMOKE_REPO_ROOT/bridge-queue.py" daemon-step \
       --snapshot "$snapshot" \

--- a/scripts/smoke/queue.sh
+++ b/scripts/smoke/queue.sh
@@ -84,15 +84,11 @@ queue_daemon_step_contract() {
   # task younger than the nudge redelivery window does NOT re-nudge (the
   # task-arrival push already covered it). This contract exercises the
   # nudge-candidate path, so backdate created_ts past the window so the
-  # task is eligible for an ACTION REQUIRED nudge.
-  python3 - "$BRIDGE_TASK_DB" "$task_id" "$((now_ts - 600))" <<'PY'
-import sqlite3, sys
-db, task_id, aged = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-conn = sqlite3.connect(db)
-conn.execute("UPDATE tasks SET created_ts = ? WHERE id = ?", (aged, task_id))
-conn.commit()
-conn.close()
-PY
+  # task is eligible for an ACTION REQUIRED nudge. The backdate runs
+  # through a standalone file-as-argv helper (no interpreter
+  # heredoc-stdin — footgun #11; see scripts/lint-heredoc-ban.sh).
+  python3 "$SCRIPT_DIR/nudge-task-age-gate-helpers/backdate-task-created-ts.py" \
+    "$BRIDGE_TASK_DB" "$((now_ts - 600))" "$task_id"
   snapshot="$SMOKE_TMP_ROOT/agent-summary.tsv"
   cat >"$snapshot" <<EOF
 agent	queued	claimed	blocked	active	idle	last_seen	last_nudge	session	engine	workdir	session_activity_ts
@@ -132,14 +128,8 @@ EOF
   # too — a never-nudged task only counts as a fresh nudge trigger once
   # it has aged past the window (a still-fresh task is covered by its
   # task-arrival push).
-  python3 - "$BRIDGE_TASK_DB" "$second_id" "$((now_ts - 600))" <<'PY'
-import sqlite3, sys
-db, task_id, aged = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
-conn = sqlite3.connect(db)
-conn.execute("UPDATE tasks SET created_ts = ? WHERE id = ?", (aged, task_id))
-conn.commit()
-conn.close()
-PY
+  python3 "$SCRIPT_DIR/nudge-task-age-gate-helpers/backdate-task-created-ts.py" \
+    "$BRIDGE_TASK_DB" "$((now_ts - 600))" "$second_id"
   new_out="$(
     python3 "$SMOKE_REPO_ROOT/bridge-queue.py" daemon-step \
       --snapshot "$snapshot" \

--- a/scripts/smoke/tool-policy-roster-read-classify.py
+++ b/scripts/smoke/tool-policy-roster-read-classify.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# scripts/smoke/tool-policy-roster-read-classify.py — regression for
+# issue #1014 sub-bug C (2026-05-22, surfaced bringing up an antigravity
+# agent).
+#
+# hooks/tool-policy.py already has read-intent bypasses for the protected
+# agent-roster.local.sh path (the path branch and the Bash argv branch).
+# But `_is_read_intent_bash` required EVERY pipeline stage's leading
+# command to be a known read tool, so a routine diagnostic prelude —
+#   cd ~/.agent-bridge && grep BRIDGE agent-roster.local.sh
+#   test -f agent-roster.local.sh && grep BRIDGE agent-roster.local.sh
+#   echo "checking"; grep BRIDGE agent-roster.local.sh
+# was mis-classified as a WRITE because `cd` / `test` / `echo` are not in
+# `_READ_INTENT_BASH_COMMANDS`. The grep read of the roster then drew the
+# write-oriented `Use \`agent-bridge config set\`` deny.
+#
+# Fix: a small set of provably non-mutating prelude builtins (cd / pwd /
+# test / [ / echo / printf / true / false / :) no longer disqualify a
+# read pipeline. Output redirection anywhere still flips the
+# classification, so the write surface is NOT broadened.
+#
+# This test pins:
+#   1. The exact #1014 command shapes classify as read-intent.
+#   2. Genuine write shapes (redirection, sed -i, source, rm, tee) still
+#      classify as write-intent.
+
+import importlib.util
+import pathlib
+import sys
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    policy_path = repo_root / "hooks" / "tool-policy.py"
+    spec = importlib.util.spec_from_file_location(
+        "tool_policy_roster_read", policy_path
+    )
+    if spec is None or spec.loader is None:
+        print(f"[smoke] cannot load {policy_path}", file=sys.stderr)
+        return 2
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    is_read = module._is_read_intent_bash
+
+    # (command, expected — True if it should classify as read-intent)
+    cases: list[tuple[str, bool]] = [
+        # ---- #1014 shapes — must classify as read-intent ----
+        ("cd ~/.agent-bridge && grep BRIDGE agent-roster.local.sh", True),
+        ("test -f agent-roster.local.sh && grep BRIDGE agent-roster.local.sh", True),
+        ("[ -f agent-roster.local.sh ] && cat agent-roster.local.sh", True),
+        ("echo done; grep BRIDGE agent-roster.local.sh", True),
+        ("pushd ~/.agent-bridge && grep CHAN agent-roster.local.sh", True),
+        ("cd /tmp; pwd", True),
+        ("true && grep BRIDGE agent-roster.local.sh", True),
+        # plain read shapes that already worked — regression guard
+        ("grep -n channel agent-roster.local.sh", True),
+        ("cat agent-roster.local.sh | grep BRIDGE", True),
+        # ---- write shapes — must still classify as write-intent ----
+        ("grep BRIDGE agent-roster.local.sh > /tmp/out", False),
+        ("cd ~/.agent-bridge && echo x > agent-roster.local.sh", False),
+        ("echo x >> agent-roster.local.sh", False),
+        ("cd ~/.agent-bridge && sed -i s/a/b/ agent-roster.local.sh", False),
+        ("source agent-roster.local.sh", False),
+        ("rm agent-roster.local.sh", False),
+        ("cd /tmp && tee agent-roster.local.sh", False),
+        ("echo x 1>/tmp/leak", False),
+    ]
+
+    failures: list[str] = []
+    for cmd, want in cases:
+        got = bool(is_read(cmd))
+        if got != want:
+            tag = "read-mis-as-write" if want else "write-mis-as-read"
+            failures.append(
+                f"  FAIL  [{tag}] _is_read_intent_bash({cmd!r}) = {got}, want {want}"
+            )
+        else:
+            print(f"  PASS  _is_read_intent_bash({cmd!r}) = {got}")
+
+    if failures:
+        print(f"\n{len(failures)} failure(s):", file=sys.stderr)
+        for f in failures:
+            print(f, file=sys.stderr)
+        return 1
+    print(
+        f"\n[smoke:tool-policy-roster-read-classify] all {len(cases)} cases passed"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/tool-policy-roster-read-classify.sh
+++ b/scripts/smoke/tool-policy-roster-read-classify.sh
@@ -66,13 +66,14 @@ AGENT_HOME="$BRIDGE_AGENT_HOME_ROOT/$AGENT"
 mkdir -p "$AGENT_HOME"
 printf -- '- session type: admin\n' >"$AGENT_HOME/SESSION-TYPE.md"
 
-# JSON-escape a Bash command string for embedding in the payload. Only
-# `\` and `"` need escaping for a JSON string; the smoke commands carry
-# neither control chars nor newlines.
+# JSON-escape a Bash command string for embedding in the payload.
+# Escapes `\`, `"`, and a literal newline (the newline-separated cd
+# prelude case carries one) as the JSON `\n` escape.
 json_escape() {
   local s="$1"
   s="${s//\\/\\\\}"
   s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
   printf '%s' "$s"
 }
 
@@ -127,20 +128,65 @@ assert_hook_verdict() {
 
 echo "[smoke:${SMOKE_NAME}] layer 2 — real PreToolUse hook end-to-end"
 
-# The exact codex r1 repro set.
+# The exact codex r1 repro set — `&&` separator.
 assert_hook_verdict \
-  "cd-prelude grep (read) of roster" \
+  "cd-prelude (&&) grep (read) of roster" \
   "cd $BRIDGE_HOME && grep BRIDGE agent-roster.local.sh" \
   "ALLOW"
 
 assert_hook_verdict \
-  "cd-prelude echo-redirect (write) to roster" \
+  "cd-prelude (&&) echo-redirect (write) to roster" \
   "cd $BRIDGE_HOME && echo x > agent-roster.local.sh" \
   "DENY"
 
 assert_hook_verdict \
-  "cd-prelude sed -i (write) of roster" \
+  "cd-prelude (&&) sed -i (write) of roster" \
   "cd $BRIDGE_HOME && sed -i s/a/b/ agent-roster.local.sh" \
+  "DENY"
+
+# codex r2 repro set — `;` (no surrounding space) and newline separators.
+# shlex.split() does not emit `;`/newline as standalone operator tokens
+# in these forms, so the r2 cd-prelude detector missed them and the
+# write bypass survived. The detector now uses the raw-string operator
+# model, so every separator form must behave identically.
+assert_hook_verdict \
+  "cd-prelude (; no space) grep (read) of roster" \
+  "cd $BRIDGE_HOME;grep BRIDGE agent-roster.local.sh" \
+  "ALLOW"
+
+assert_hook_verdict \
+  "cd-prelude (; no space) echo-redirect (write) to roster" \
+  "cd $BRIDGE_HOME;echo x > agent-roster.local.sh" \
+  "DENY"
+
+assert_hook_verdict \
+  "cd-prelude (; no space) sed -i (write) of roster" \
+  "cd $BRIDGE_HOME;sed -i s/a/b/ agent-roster.local.sh" \
+  "DENY"
+
+assert_hook_verdict \
+  "cd-prelude (; spaced) echo-redirect (write) to roster" \
+  "cd $BRIDGE_HOME ; echo x > agent-roster.local.sh" \
+  "DENY"
+
+assert_hook_verdict \
+  "cd-prelude (newline) grep (read) of roster" \
+  "$(printf 'cd %s\ngrep BRIDGE agent-roster.local.sh' "$BRIDGE_HOME")" \
+  "ALLOW"
+
+assert_hook_verdict \
+  "cd-prelude (newline) echo-redirect (write) to roster" \
+  "$(printf 'cd %s\necho x > agent-roster.local.sh' "$BRIDGE_HOME")" \
+  "DENY"
+
+assert_hook_verdict \
+  "cd-prelude (newline) tee (write) of roster" \
+  "$(printf 'cd %s\ntee agent-roster.local.sh' "$BRIDGE_HOME")" \
+  "DENY"
+
+assert_hook_verdict \
+  "cd-prelude (||) echo-redirect (write) to roster" \
+  "cd $BRIDGE_HOME || echo x > agent-roster.local.sh" \
   "DENY"
 
 assert_hook_verdict \

--- a/scripts/smoke/tool-policy-roster-read-classify.sh
+++ b/scripts/smoke/tool-policy-roster-read-classify.sh
@@ -1,21 +1,168 @@
 #!/usr/bin/env bash
 # scripts/smoke/tool-policy-roster-read-classify.sh — regression for
-# issue #1014 sub-bug C (2026-05-22): a routine `cd … && grep
-# agent-roster.local.sh` read was mis-classified as a write by the
-# tool-policy Bash classifier.
+# issue #1014 sub-bug C (2026-05-22, r2).
 #
-# The actual assertions live in
-# scripts/smoke/tool-policy-roster-read-classify.py — kept as a
-# standalone .py file (not heredoc-stdin to python3) so the smoke is
-# immune to footgun #11 even if a future caller wraps this driver in
-# `$()` capture.
+# Two layers, because the r1 smoke covered only the helper in isolation
+# and gave false confidence (codex r1 catch):
+#
+#   Layer 1 (helper unit) — tool-policy-roster-read-classify.py asserts
+#     _is_read_intent_bash() treats a neutral prelude stage (cd / test /
+#     echo / …) as transparent so a `cd … && grep` pipeline classifies
+#     as read-intent.
+#
+#   Layer 2 (REAL PreToolUse hook) — this script invokes
+#     hooks/tool-policy.py as an actual PreToolUse hook (stdin JSON ->
+#     permissionDecision), with BRIDGE_HOME set and an
+#     agent-roster.local.sh present, and asserts the end-to-end
+#     allow/deny verdict. The r1 helper-only test missed that a
+#     `cd $BRIDGE_HOME && …` prelude left the protected roster path
+#     CWD-relative and therefore invisible to the argv path matcher —
+#     reads passed by accident and, worse, WRITES passed too (a
+#     protected-path bypass). The fix resolves a leading `cd <dir>`
+#     prelude when matching argv fragments against the protected path.
+#
+# The hook-level cases mirror the exact codex r1 repro set:
+#   cd $BRIDGE_HOME && grep BRIDGE agent-roster.local.sh   -> allowed
+#   cd $BRIDGE_HOME && echo x > agent-roster.local.sh       -> DENIED
+#   cd $BRIDGE_HOME && sed -i s/a/b/ agent-roster.local.sh  -> DENIED
+#   cd / && echo x > $BRIDGE_HOME/agent-roster.local.sh     -> DENIED
+#
+# Footgun #11: the JSON stdin payload is built with `printf` (never an
+# interpreter here-string / heredoc-stdin) and piped into the hook with
+# `< file`, matching scripts/smoke/admin-hook-exemption.sh.
 
 set -euo pipefail
 
 SMOKE_NAME="tool-policy-roster-read-classify"
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
 
 PYTHON_BIN="${PYTHON_BIN:-python3}"
 
-echo "[smoke:${SMOKE_NAME}] starting"
+# --- Layer 1: helper unit assertions ----------------------------------------
+
+echo "[smoke:${SMOKE_NAME}] layer 1 — _is_read_intent_bash classifier unit"
 "$PYTHON_BIN" "$SCRIPT_DIR/tool-policy-roster-read-classify.py"
+
+# --- Layer 2: real PreToolUse hook end-to-end -------------------------------
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# The protected roster file must exist at $BRIDGE_HOME/agent-roster.local.sh
+# (roster_local_path() = bridge_home_dir()/agent-roster.local.sh).
+ROSTER_FILE="$BRIDGE_HOME/agent-roster.local.sh"
+printf '%s\n' '# smoke roster fixture' 'BRIDGE_AGENT_CHANNELS=secret-token' >"$ROSTER_FILE"
+
+# Admin agent — the #1014 scenario was an admin running roster
+# diagnostics. is_admin_agent() honors SESSION-TYPE.md == admin.
+AGENT="patch-1014"
+AGENT_HOME="$BRIDGE_AGENT_HOME_ROOT/$AGENT"
+mkdir -p "$AGENT_HOME"
+printf -- '- session type: admin\n' >"$AGENT_HOME/SESSION-TYPE.md"
+
+# JSON-escape a Bash command string for embedding in the payload. Only
+# `\` and `"` need escaping for a JSON string; the smoke commands carry
+# neither control chars nor newlines.
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  printf '%s' "$s"
+}
+
+# Write a PreToolUse Bash payload to a temp file with printf — no
+# interpreter heredoc-stdin (footgun #11). $1 target file, $2 command.
+write_bash_payload() {
+  local target="$1"
+  local command="$2"
+  local esc
+  esc="$(json_escape "$command")"
+  printf '%s\n' \
+    '{' \
+    '  "hook_event_name": "PreToolUse",' \
+    '  "tool_name": "Bash",' \
+    "  \"tool_input\": {\"command\": \"${esc}\"}," \
+    '  "tool_use_id": "smoke-1014",' \
+    '  "session_id": "smoke-session"' \
+    '}' \
+    >"$target"
+}
+
+run_pretool_hook() {
+  local payload_file="$1"
+  BRIDGE_AGENT_ID="$AGENT" \
+    "$PYTHON_BIN" "$SMOKE_REPO_ROOT/hooks/tool-policy.py" <"$payload_file"
+}
+
+# Assert the hook's verdict for a command. $1 label, $2 command, $3
+# verdict (ALLOW|DENY). ALLOW = no `permissionDecision: deny` emitted.
+assert_hook_verdict() {
+  local label="$1"
+  local command="$2"
+  local want="$3"
+  local payload out got
+  payload="$SMOKE_TMP_ROOT/payload-$RANDOM.json"
+  write_bash_payload "$payload" "$command"
+  out="$(run_pretool_hook "$payload")"
+  if [[ "$out" == *'"permissionDecision": "deny"'* ]]; then
+    got="DENY"
+  else
+    got="ALLOW"
+  fi
+  if [[ "$got" == "$want" ]]; then
+    smoke_log "ok: ${label} -> ${got}"
+  else
+    smoke_log "FAIL: ${label} -> ${got}, want ${want}"
+    smoke_log "      command: ${command}"
+    smoke_log "      hook output: ${out:-<empty>}"
+    smoke_fail "${label}: expected ${want}, got ${got}"
+  fi
+}
+
+echo "[smoke:${SMOKE_NAME}] layer 2 — real PreToolUse hook end-to-end"
+
+# The exact codex r1 repro set.
+assert_hook_verdict \
+  "cd-prelude grep (read) of roster" \
+  "cd $BRIDGE_HOME && grep BRIDGE agent-roster.local.sh" \
+  "ALLOW"
+
+assert_hook_verdict \
+  "cd-prelude echo-redirect (write) to roster" \
+  "cd $BRIDGE_HOME && echo x > agent-roster.local.sh" \
+  "DENY"
+
+assert_hook_verdict \
+  "cd-prelude sed -i (write) of roster" \
+  "cd $BRIDGE_HOME && sed -i s/a/b/ agent-roster.local.sh" \
+  "DENY"
+
+assert_hook_verdict \
+  "absolute-path echo-redirect (write) to roster" \
+  "cd / && echo x > $BRIDGE_HOME/agent-roster.local.sh" \
+  "DENY"
+
+# Absolute-path regression guards — the pre-#1014 cases must still hold.
+assert_hook_verdict \
+  "absolute-path grep (read) of roster" \
+  "grep BRIDGE $ROSTER_FILE" \
+  "ALLOW"
+
+assert_hook_verdict \
+  "absolute-path sed -i (write) of roster" \
+  "sed -i s/a/b/ $ROSTER_FILE" \
+  "DENY"
+
+# A neutral test-prelude before the read must also stay allowed.
+assert_hook_verdict \
+  "test-prelude cat (read) of roster" \
+  "cd $BRIDGE_HOME && test -f agent-roster.local.sh && cat agent-roster.local.sh" \
+  "ALLOW"
+
+smoke_log "passed"

--- a/scripts/smoke/tool-policy-roster-read-classify.sh
+++ b/scripts/smoke/tool-policy-roster-read-classify.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# scripts/smoke/tool-policy-roster-read-classify.sh — regression for
+# issue #1014 sub-bug C (2026-05-22): a routine `cd … && grep
+# agent-roster.local.sh` read was mis-classified as a write by the
+# tool-policy Bash classifier.
+#
+# The actual assertions live in
+# scripts/smoke/tool-policy-roster-read-classify.py — kept as a
+# standalone .py file (not heredoc-stdin to python3) so the smoke is
+# immune to footgun #11 even if a future caller wraps this driver in
+# `$()` capture.
+
+set -euo pipefail
+
+SMOKE_NAME="tool-policy-roster-read-classify"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+"$PYTHON_BIN" "$SCRIPT_DIR/tool-policy-roster-read-classify.py"


### PR DESCRIPTION
## Summary

Three independent runtime-friction bugs from issue (#1014), surfaced
bringing up an antigravity agent. Distinct subsystems — daemon nudge
timing / launch-env propagation / tool-policy guard — fixed together in
one PR per the issue's grouping.

## What changed

### A — redundant idle-nudge (`bridge-queue.py`)

`cmd_daemon_step` measured idle as agent-idle-duration
(`now - session_activity_ts`), so an agent parked idle past the 120s
threshold — the normal state for an agent waiting for work — got an
`ACTION REQUIRED` nudge on the next daemon tick (~5s) for a task it was
*just* pushed and is already acting on. The task-arrival push and the
daemon idle-nudge were two uncoordinated mechanisms.

- The nudge candidate scan now also collects each queued task's
  `created_ts`.
- A "new" (never-nudged) queued task id only counts as a fresh nudge
  trigger once it has aged past the nudge redelivery window
  (`BRIDGE_DAEMON_NUDGE_REDELIVERY_SECONDS`, default 60s).
- If every queued task for an agent is both never-nudged and still
  inside its redelivery window, the scan skips the agent — the
  task-arrival push already covered it.
- A previously-nudged task that needs genuine redelivery is in
  `last_nudge_key`, so it is unaffected. `nudge_redelivery_seconds <= 0`
  disables the gate.

### B — self-perpetuating `BRIDGE_LAYOUT=legacy` warning (`lib/bridge-agents.sh`, `lib/bridge-layout-resolver.sh`)

`bridge_write_linux_agent_env_file` baked
`BRIDGE_LAYOUT=${BRIDGE_LAYOUT:-legacy}` into the per-agent launch
envelope (`runtime/agent-env.sh`). A stale `legacy` value (or an unset
var defaulting to `legacy`) then self-perpetuated through the
daemon -> agent-env -> CLI process tree, so every agent restart
re-injected it and the layout resolver's "stale pre-v0.8.0 env
override" warning never cleared.

- `bridge_write_linux_agent_env_file`: when a valid v2 layout marker
  exists the writer normalizes `BRIDGE_LAYOUT` to the marker value
  (`v2`) — the marker is authoritative. With no valid marker it only
  propagates a `BRIDGE_LAYOUT` the caller actually set; it never invents
  a `legacy` default.
- `bridge_layout_resolver_validate_env`: the warning's remediation text
  now tells the operator to stop and restart the bridge daemon from a
  clean shell — the only step that clears the inherited process-env
  leak — instead of the inaccurate rc-only guidance.

### C — protected-path read mis-classified as a write (`hooks/tool-policy.py`)

`tool-policy.py` already has read-intent bypasses for the protected
`agent-roster.local.sh` path. But `_is_read_intent_bash` required
*every* pipeline stage to lead with a read tool, so a routine
diagnostic prelude — `cd ~/.agent-bridge && grep BRIDGE
agent-roster.local.sh`, `test -f roster && cat roster`,
`echo "checking"; grep ...` — was mis-classified as a write because
`cd` / `test` / `echo` are not read commands. The grep read of the
roster then drew the write-oriented config-set deny.

- A new `_NEUTRAL_PRELUDE_BASH_COMMANDS` set (`cd`, `pushd`, `popd`,
  `pwd`, `test`, `[`, `[[`, `echo`, `printf`, `true`, `false`, `:`) —
  provably non-mutating builtins — is treated as transparent by the
  read-intent classifier.
- The write surface is **not** broadened: output redirection anywhere
  in the pipeline still flips the classification to write-intent, so
  `cd ... && echo x > roster`, `sed -i`, `source`, `rm`, `tee` stay
  write-intent and blocked with the existing message.

## Verification

- `python3 -m py_compile bridge-queue.py hooks/tool-policy.py` — PASS
- `bash -n` + `shellcheck` on `bridge-start.sh`, `lib/bridge-agents.sh`,
  `lib/bridge-layout-resolver.sh`, `scripts/ci-select-smoke.sh`,
  `scripts/smoke-test.sh`, all new/edited smokes — PASS
- **B-A**: isolated queue fixture — a freshly-created task for an idle
  agent is NOT a nudge candidate; the same task aged past the window IS.
  Confirmed meaningful: `BRIDGE_DAEMON_NUDGE_REDELIVERY_SECONDS=0`
  (gate off) restores the old immediate nudge.
- **B-B**: `bridge_write_linux_agent_env_file` in an isolated
  `BRIDGE_HOME` with a v2 marker — generated `agent-env.sh` carries
  `BRIDGE_LAYOUT=v2` for both `BRIDGE_LAYOUT=legacy` and `=v1` ambient
  values; never a stale pre-v2 value.
- **B-C**: the policy decision for `cd ~/.agent-bridge && grep CHAN
  <roster>` as an admin agent is ALLOWED (hits the read bypass); a
  write (`... && echo x > <roster>`, `sed -i ... <roster>`) to the same
  path stays BLOCKED with the existing roster-local deny message.
- Three new regression smokes (`nudge-task-age-gate`,
  `agent-env-no-stale-bridge-layout`, `tool-policy-roster-read-classify`)
  pass and are wired into `scripts/smoke-test.sh` +
  `scripts/ci-select-smoke.sh`.
- Related existing smokes pass: `queue`, `hooks`,
  `layout-resolver-marker-over-env`, `bridge-export-prefix-no-stale-layout`,
  `989-isolated-agent-env-state-dir`, `admin-hook-exemption`,
  `tool-policy-process-dump-regex`.
- `queue.sh` pre-existing `queue gateway runtime id contract`
  (symlinked-home parity) failure reproduces on
  `feat/wave-v0145-integration` without this change — environmental,
  not a regression.

## Scope

Changed: `bridge-queue.py`, `hooks/tool-policy.py`,
`lib/bridge-agents.sh` (only `bridge_write_linux_agent_env_file`),
`lib/bridge-layout-resolver.sh` (warning text only), plus three new
smokes and the wiring/fixture updates in `scripts/ci-select-smoke.sh`,
`scripts/smoke-test.sh`, `scripts/smoke/queue.sh`. No VERSION/CHANGELOG
change. The `ci-select-smoke.sh` edit may conflict with sibling fixers
at merge (orchestrator-resolved).
