### PR TITLE
Fix Teams channel notification metadata shape

### DIFF
--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -69,7 +69,12 @@ When a Teams user attaches a file or image, the plugin downloads each attachment
 <TEAMS_STATE_DIR>/attachments/<message_id>/<filename>
 ```
 
-(directory mode 0700, file mode 0600). The Claude channel notification meta gains an `attachments` array with `name`, `content_type`, `download_status` (`ok` / `skipped_non_file` / `failed`), and — on success — `local_path` and `size_bytes`. Cards (`application/vnd.microsoft.card.*` and `application/vnd.microsoft.teams.card.*`) are recorded with `skipped_non_file` so the agent still sees the metadata.
+(directory mode 0700, file mode 0600). Attachment metadata is exposed in two shapes:
+
+- **Direct Claude channel notification** (`notifications/claude/channel`) — meta is kept **flat and string-only**: scalar `attachment_count` and `attachment_names` fields. It does **not** carry a nested `attachments` array. The flat shape is what keeps the direct channel notification reliable (see #1022).
+- **Bridge queue / audit / replay body** — retains the rich nested `attachments` array, each entry with `name`, `content_type`, `download_status` (`ok` / `skipped_non_file` / `failed`), and — on success — `local_path` and `size_bytes`.
+
+Cards (`application/vnd.microsoft.card.*` and `application/vnd.microsoft.teams.card.*`) are recorded with `skipped_non_file` so the agent still sees the metadata.
 
 Downloaded content types:
 

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -928,11 +928,10 @@ function runPromptGuard(command: 'scan' | 'sanitize', text: string): Record<stri
 }
 
 /**
- * Build the channel meta object used by BOTH the `notifications/claude/channel`
- * notification AND the bridge-mode queue task body. Centralizing here keeps
- * the two delivery paths from drifting (PR #961 r1 found bridge body was
- * missing conversation_id / tenant_id / service_url / attachment_count that
- * the channel notification carries).
+ * Build the rich Teams metadata used by bridge-mode queue task bodies and
+ * local replay/audit paths. Keep notifications/claude/channel on the scalar
+ * projection below: Claude Code channel delivery has silently dropped some
+ * notifications when nested arrays/objects are present in params.meta.
  */
 function buildChannelMeta(
   activity: Activity,
@@ -966,6 +965,54 @@ function buildChannelMeta(
         }
       : {}),
   }
+}
+
+function compactMetaList(values: Array<string | undefined>): string {
+  const cleaned = values
+    .map(value => String(value ?? '').trim())
+    .filter(value => value.length > 0)
+  return cleaned.join(', ').slice(0, 1000)
+}
+
+/**
+ * Claude channel notification metadata must stay flat and string-only. Rich
+ * attachment details remain available in buildChannelMeta for bridge-mode and
+ * fetch/replay flows; this projection keeps direct channel injection from
+ * depending on nested JSON support in Claude Code's notification handler.
+ */
+function buildChannelNotificationMeta(
+  activity: Activity,
+  stored: StoredMessage,
+  attachments: StoredAttachment[],
+): Record<string, string> {
+  const meta: Record<string, string> = {
+    source: 'teams',
+    chat_id: stored.chat_id,
+    conversation_id: stored.chat_id,
+    message_id: stored.message_id,
+    user: stored.user,
+    user_id: stored.user_id,
+    aad_object_id: stored.aad_object_id,
+    tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
+    service_url: String(activity.serviceUrl ?? ''),
+    text: stored.text,
+    ts: stored.ts,
+  }
+  if (stored.revision) meta.revision = stored.revision
+  if (attachments.length > 0) {
+    meta.attachment_count = String(attachments.length)
+    const names = compactMetaList(attachments.map(att => att.name))
+    const contentTypes = compactMetaList(attachments.map(att => att.content_type))
+    const downloadStatuses = compactMetaList(attachments.map(att => att.download_status))
+    const localPaths = compactMetaList(attachments.map(att => att.local_path))
+    const downloadErrors = compactMetaList(attachments.map(att => att.download_error))
+    if (names) meta.attachment_names = names
+    if (contentTypes) meta.attachment_content_types = contentTypes
+    if (downloadStatuses) meta.attachment_download_statuses = downloadStatuses
+    if (localPaths) meta.attachment_local_paths = localPaths
+    if (downloadErrors) meta.attachment_download_errors = downloadErrors
+  }
+  return meta
 }
 
 /**
@@ -1823,7 +1870,7 @@ async function handleActivity(context: TurnContext): Promise<void> {
         method: 'notifications/claude/channel',
         params: {
           content: text || (attachments.length > 0 ? '(attachment)' : ''),
-          meta: buildChannelMeta(activity, stored, attachments),
+          meta: buildChannelNotificationMeta(activity, stored, attachments),
         },
       })
       channelDelivered = true
@@ -2019,9 +2066,15 @@ if (CLI_SUBCOMMAND === 'send-managed') {
 // `_smoke-record-activity` invokes writeTeamsActivityIndex directly so the
 // smoke can validate the activity-index file schema without spinning up a
 // full Bot Framework adapter. `_smoke-should-record` reports whether a
-// synthesized activity would be skipped by the bot-self filter. Both
+// synthesized activity would be skipped by the bot-self filter.
+// `_smoke-channel-meta` asserts the direct Claude channel notification uses
+// scalar metadata, not the richer bridge queue payload. All smoke commands
 // short-circuit before httpServer.listen.
-if (CLI_SUBCOMMAND === '_smoke-record-activity' || CLI_SUBCOMMAND === '_smoke-should-record') {
+if (
+  CLI_SUBCOMMAND === '_smoke-record-activity'
+  || CLI_SUBCOMMAND === '_smoke-should-record'
+  || CLI_SUBCOMMAND === '_smoke-channel-meta'
+) {
   const argv = process.argv.slice(3)
   const flags: Record<string, string> = {}
   for (let i = 0; i < argv.length; i++) {
@@ -2043,6 +2096,32 @@ if (CLI_SUBCOMMAND === '_smoke-record-activity' || CLI_SUBCOMMAND === '_smoke-sh
       process.exit(2)
     }
     writeTeamsActivityIndex(agent, channelId, messageId, userId, new Date(tsMs))
+    process.exit(0)
+  }
+  if (CLI_SUBCOMMAND === '_smoke-channel-meta') {
+    const fakeActivity: any = {
+      channelData: { tenant: { id: 'tenant-smoke' } },
+      serviceUrl: 'https://example.invalid/teams',
+    }
+    const stored: StoredMessage = {
+      chat_id: 'chat-smoke',
+      message_id: 'message-smoke',
+      user: 'Smoke User',
+      user_id: 'user-smoke',
+      aad_object_id: 'aad-smoke',
+      text: 'hello smoke',
+      ts: '2026-01-01T00:00:00.000Z',
+      revision: 'revision-smoke',
+    }
+    const attachments: StoredAttachment[] = [
+      {
+        attachment_id: 'attachment-smoke',
+        name: 'smoke.html',
+        content_type: 'text/html',
+        download_status: 'skipped_non_file',
+      },
+    ]
+    process.stdout.write(JSON.stringify(buildChannelNotificationMeta(fakeActivity, stored, attachments)) + '\n')
     process.exit(0)
   }
   // _smoke-should-record

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6153,18 +6153,7 @@ PY
   assert_not_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "spawnSync(agb, ['urgent'"
   assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "ignoring deprecated TEAMS_BRIDGE_MODE"
   TEAMS_CHANNEL_META_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && TEAMS_STATE_DIR="$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams" bun server.ts _smoke-channel-meta)"
-  python3 - "$TEAMS_CHANNEL_META_OUTPUT" <<'PY'
-import json
-import sys
-
-meta = json.loads(sys.argv[1])
-assert meta["source"] == "teams", meta
-assert meta["chat_id"] == "chat-smoke", meta
-assert meta["attachment_count"] == "1", meta
-assert meta["attachment_names"] == "smoke.html", meta
-assert "attachments" not in meta, meta
-assert all(isinstance(k, str) and isinstance(v, str) for k, v in meta.items()), meta
-PY
+  python3 "$REPO_ROOT/scripts/smoke/teams-channel-meta-assert.py" "$TEAMS_CHANNEL_META_OUTPUT"
   TEAMS_DEDUPE_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { createRecentMessageDeduper } from "./dedupe.ts"; const dedupe = createRecentMessageDeduper(2); console.log(JSON.stringify([dedupe.seen("1775901127484"), dedupe.seen("1775901127484"), dedupe.seen("1775901127485"), dedupe.seen("1775901127486"), dedupe.seen("1775901127484")]))')"
   assert_contains "$TEAMS_DEDUPE_OUTPUT" "[false,true,false,false,false]"
   # Round-2: channel-failure path — forget() must roll back the dedupe entry

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6152,6 +6152,19 @@ PY
   assert_not_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "agent-bridge urgent"
   assert_not_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "spawnSync(agb, ['urgent'"
   assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "ignoring deprecated TEAMS_BRIDGE_MODE"
+  TEAMS_CHANNEL_META_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && TEAMS_STATE_DIR="$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams" bun server.ts _smoke-channel-meta)"
+  python3 - "$TEAMS_CHANNEL_META_OUTPUT" <<'PY'
+import json
+import sys
+
+meta = json.loads(sys.argv[1])
+assert meta["source"] == "teams", meta
+assert meta["chat_id"] == "chat-smoke", meta
+assert meta["attachment_count"] == "1", meta
+assert meta["attachment_names"] == "smoke.html", meta
+assert "attachments" not in meta, meta
+assert all(isinstance(k, str) and isinstance(v, str) for k, v in meta.items()), meta
+PY
   TEAMS_DEDUPE_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { createRecentMessageDeduper } from "./dedupe.ts"; const dedupe = createRecentMessageDeduper(2); console.log(JSON.stringify([dedupe.seen("1775901127484"), dedupe.seen("1775901127484"), dedupe.seen("1775901127485"), dedupe.seen("1775901127486"), dedupe.seen("1775901127484")]))')"
   assert_contains "$TEAMS_DEDUPE_OUTPUT" "[false,true,false,false,false]"
   # Round-2: channel-failure path — forget() must roll back the dedupe entry

--- a/scripts/smoke/teams-channel-meta-assert.py
+++ b/scripts/smoke/teams-channel-meta-assert.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Assert the Teams channel-meta JSON shape (smoke helper for #1022).
+
+Extracted to a sidecar file (file-as-argv) to avoid an interpreter heredoc-stdin
+site in scripts/smoke-test.sh — see KNOWN_ISSUES.md footgun #11 / lint-heredoc-ban.
+"""
+import json
+import sys
+
+meta = json.loads(sys.argv[1])
+assert meta["source"] == "teams", meta
+assert meta["chat_id"] == "chat-smoke", meta
+assert meta["attachment_count"] == "1", meta
+assert meta["attachment_names"] == "smoke.html", meta
+assert "attachments" not in meta, meta
+assert all(isinstance(k, str) and isinstance(v, str) for k, v in meta.items()), meta


### PR DESCRIPTION
## Summary
- Split Teams rich bridge metadata from direct Claude channel notification metadata.
- Keep direct `notifications/claude/channel` metadata flat and string-only so nested attachment arrays cannot make Claude Code silently drop the notification.
- Preserve the rich bridge queue/audit/replay payload, including attachment details.
- Add `_smoke-channel-meta` coverage and wire it into `scripts/smoke-test.sh`.

Fixes #1022.

## Root Cause
Teams inbound HTML-body messages produce an attachment record (`content_type: text/html`) even when the visible text is extracted correctly. The plugin reused the same rich metadata object for both delivery paths:

- bridge queue body: safe to keep nested JSON like `attachments: [{ ... }]`
- Claude direct channel notification: sent as `params.meta` on `notifications/claude/channel`

Live testing showed `mcp.notification()` could resolve while Claude Code did not inject the message into the pane when `params.meta` contained nested arrays/objects. Bridge fallback still enqueued the message, which made the failure look like “Agent Bridge task works, direct channel does not.”

## Fix
- `buildChannelMeta(...)` remains the rich payload for bridge queue/audit/replay.
- New `buildChannelNotificationMeta(...)` projects the direct channel metadata to `Record<string, string>`.
- Attachment details are represented as scalar strings (`attachment_count`, `attachment_names`, `attachment_content_types`, `attachment_download_statuses`, etc.) instead of nested arrays.
- Direct channel delivery now calls `buildChannelNotificationMeta(...)`.

## Tests
- `bun build plugins/teams/server.ts --target=bun --outfile /tmp/teams-server-smoke.js`
- `TEAMS_APP_ID=smoke TEAMS_APP_PASSWORD=smoke bun plugins/teams/server.ts _smoke-channel-meta` + Python shape assertion
- `timeout 180 bash tests/precompact-notify/teams-mattermost-adapter.sh`

## Live Verification
Validated on the operator host after hotpatching the live Teams plugin and restarting the affected agents:

- `sales_sean`: Teams DM arrived as `← teams ...` direct injection in the Claude pane; `agb inbox sales_sean` stayed empty.
- `dev_mun`: Teams DM `테스트8` arrived as `← teams · 문대정 ...: 테스트8` direct injection in the Claude pane; `agb inbox dev_mun` stayed empty; message also appeared in `workdir/.teams/messages.jsonl`.
- Verified this was not bridge fallback by keeping Agent Bridge inboxes empty during the test.

## Note
- Full `scripts/smoke-test.sh` was attempted with temp `BRIDGE_HOME`; it failed in the existing live-install leak guard path (`TMPDIR: unbound variable`) after cleaning its generated run dirs, unrelated to this Teams metadata change.
