### PR TITLE
fix(agent-update): redact secret env values in launch-cmd diff output (#1023)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3141,12 +3141,32 @@ run_update() {
     bridge_die "agent update 변경 플래그가 하나 이상 필요합니다."
   fi
 
+  # Issue #1023: a `--launch-cmd-add-env KEY=VALUE` op carries a raw,
+  # possibly comma-containing secret value. Redact each launch op's
+  # payload HERE — while the ops are still the discrete TSV stream
+  # `launch_cmd_ops` — so a comma inside a value is never confused with
+  # an op delimiter. The redactor emits the `launch:<op>=<payload>`
+  # lines directly; redacting AFTER the comma-join would strand the
+  # value's suffix as a bare token that escapes redaction. Value-only:
+  # env key names stay visible so audit readers see which key changed.
+  # `launch_cmd_ops` itself is untouched — the applier downstream still
+  # sees the real value.
+  local launch_ops_summary_lines=""
+  if [[ -n "$launch_cmd_ops" ]]; then
+    launch_ops_summary_lines="$(
+      python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
+        launch-ops "$launch_cmd_ops"
+    )"
+  fi
+
   # Capture the operation summary for the audit row (compact one-line
   # description of what the operator asked for).
   local operation_summary=""
   operation_summary="$(
     {
-      printf '%s' "$launch_cmd_ops" | sed 's/\t/=/' | sed 's/^/launch:/'
+      if [[ -n "$launch_ops_summary_lines" ]]; then
+        printf '%s\n' "$launch_ops_summary_lines"
+      fi
       printf '%s' "$channels_ops" | sed 's/\t/=/' | sed 's/^/chan:/'
       # Issue #580 Track 2: surface typed-flag mutations in the audit
       # operation summary so audit-log readers see the same shape they
@@ -3164,17 +3184,6 @@ run_update() {
       fi
       if [[ $class_present    -eq 1 ]]; then printf 'class=%s\n' "$class_value"; fi
     } | tr '\n' ',' | sed 's/,$//'
-  )"
-
-  # Issue #1023: a `--launch-cmd-add-env KEY=VALUE` op puts the raw
-  # value into the operation summary (`launch:add-env=KEY=VALUE`). The
-  # summary flows into the audit detail and is otherwise log-visible —
-  # redact credential-bearing env values before any downstream use.
-  # Value-only: env key names stay visible so audit readers still see
-  # which key changed.
-  operation_summary="$(
-    python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
-      op-summary "$operation_summary"
   )"
 
   # Caller validation: admin identity + operator-trusted source.

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3166,6 +3166,17 @@ run_update() {
     } | tr '\n' ',' | sed 's/,$//'
   )"
 
+  # Issue #1023: a `--launch-cmd-add-env KEY=VALUE` op puts the raw
+  # value into the operation summary (`launch:add-env=KEY=VALUE`). The
+  # summary flows into the audit detail and is otherwise log-visible —
+  # redact credential-bearing env values before any downstream use.
+  # Value-only: env key names stay visible so audit readers still see
+  # which key changed.
+  operation_summary="$(
+    python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
+      op-summary "$operation_summary"
+  )"
+
   # Caller validation: admin identity + operator-trusted source.
   local caller_agent caller_source
   caller_agent="$(bridge_agent_update_caller_agent "$from_agent")"
@@ -3391,11 +3402,26 @@ PY
     return 0
   fi
 
+  # Issue #1023: the plain-text result echoes the full before/after
+  # launch command, whose leading env-prefix routinely carries
+  # credential-bearing values. Redact secret env values (value-only,
+  # key name kept) before printing. Output-rendering only — the stored
+  # launch command written above is unchanged.
+  local before_launch_cmd_display new_launch_cmd_display
+  before_launch_cmd_display="$(
+    python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
+      launch-cmd "$before_launch_cmd"
+  )"
+  new_launch_cmd_display="$(
+    python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
+      launch-cmd "$new_launch_cmd"
+  )"
+
   printf 'agent: %s\n' "$agent"
   printf 'changed: %s\n' "$([[ $changed -eq 1 ]] && echo yes || echo no)"
   printf 'dry_run: %s\n' "$([[ $dry_run -eq 1 ]] && echo yes || echo no)"
-  printf 'before_launch_cmd: %s\n' "$before_launch_cmd"
-  printf 'after_launch_cmd: %s\n' "$new_launch_cmd"
+  printf 'before_launch_cmd: %s\n' "$before_launch_cmd_display"
+  printf 'after_launch_cmd: %s\n' "$new_launch_cmd_display"
   printf 'before_channels: %s\n' "$before_channels"
   printf 'after_channels: %s\n' "$new_channels"
   printf 'before_sha: %s\n' "$before_sha"

--- a/lib/agent-cli-helpers/agent-update-result-json.py
+++ b/lib/agent-cli-helpers/agent-update-result-json.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""agent-update-result-json.py — pretty-print the `agent update` result
+envelope for `agent-bridge agent update --json`.
+
+Invocation contract (positional, all required, all may be empty
+strings):
+    sys.argv[1]  = agent
+    sys.argv[2]  = changed ("1" / "0")
+    sys.argv[3]  = dry_run ("1" / "0")
+    sys.argv[4]  = before_launch_cmd
+    sys.argv[5]  = after_launch_cmd
+    sys.argv[6]  = before_channels
+    sys.argv[7]  = after_channels
+    sys.argv[8]  = before_sha
+    sys.argv[9]  = after_sha
+    sys.argv[10] = actions_json (JSON array literal; empty/invalid -> [])
+
+Output: a single pretty-printed JSON object on stdout.
+
+Refs:
+    - Footgun #11 / KNOWN_ISSUES.md §26: the body used to live as
+      `python3 - … <<'PY' … PY` inside bridge_agent_update_emit_json.
+      Extracted to a standalone file invoked file-as-argv so the
+      heredoc-stdin path is gone (same precedent as PR #940 / #815).
+    - Issue #1023: launch commands routinely carry credential-bearing
+      env values. The `--json` envelope is pasted into terminals, logs,
+      and task reports, so before/after launch_cmd and the recorded
+      add-env actions are routed through the shared launch-cmd-redact
+      module. Redaction is value-only — env key names stay visible.
+"""
+
+import importlib
+import json
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "scripts",
+        "python-helpers",
+    ),
+)
+_redact = importlib.import_module("launch-cmd-redact")
+
+
+def main() -> int:
+    # 10 payload args + script name == 11.
+    if len(sys.argv) != 11:
+        print(
+            "usage: agent-update-result-json.py "
+            "<agent> <changed> <dry_run> <before_launch_cmd> "
+            "<after_launch_cmd> <before_channels> <after_channels> "
+            "<before_sha> <after_sha> <actions_json>",
+            file=sys.stderr,
+        )
+        return 2
+
+    (
+        agent,
+        changed,
+        dry_run,
+        before_launch_cmd,
+        after_launch_cmd,
+        before_channels,
+        after_channels,
+        before_sha,
+        after_sha,
+        actions_json,
+    ) = sys.argv[1:]
+
+    try:
+        actions = json.loads(actions_json) if actions_json else []
+    except (TypeError, ValueError):
+        actions = []
+
+    payload = {
+        "agent": agent,
+        "changed": changed == "1",
+        "dry_run": dry_run == "1",
+        "before": {
+            "launch_cmd": _redact.redact_launch_cmd(before_launch_cmd),
+            "channels": before_channels,
+        },
+        "after": {
+            "launch_cmd": _redact.redact_launch_cmd(after_launch_cmd),
+            "channels": after_channels,
+        },
+        "before_sha": before_sha,
+        "after_sha": after_sha,
+        "actions": _redact.redact_actions(actions),
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/agent-cli-helpers/audit-detail-json.py
+++ b/lib/agent-cli-helpers/audit-detail-json.py
@@ -39,10 +39,29 @@ Refs:
       to completion on Bash 5.3.9 hosts. Standalone helper invoked
       file-as-argv keeps the path off the broken surface, same
       precedent as PR #940's registry/list/show extraction.
+    - Issue #1023: launch commands routinely carry credential-bearing
+      env values. This helper writes them into the audit-log detail
+      (before/after launch_cmd + the recorded add-env actions), so it
+      routes both through the shared launch-cmd-redact module before
+      emission. The audit log keeps the SHA chain for tamper-evidence;
+      it does not need the raw secret.
 """
 
 import json
+import os
 import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "scripts",
+        "python-helpers",
+    ),
+)
+import importlib  # noqa: E402
+
+_redact = importlib.import_module("launch-cmd-redact")
 
 
 def main() -> int:
@@ -75,6 +94,10 @@ def main() -> int:
         actions_json,
     ) = sys.argv[1:]
 
+    # Issue #1023: redact credential-bearing env values before they
+    # land in the audit log. The redaction is value-only — env key
+    # names stay visible — so audit readers still see which keys
+    # changed.
     detail = {
         "kind": "system_config_mutation",
         "actor": actor,
@@ -85,8 +108,8 @@ def main() -> int:
         "operation": operation,
         "matched_pattern": "agent-roster.local.sh",
         "target_agent": target_agent,
-        "before_launch_cmd": before_launch_cmd,
-        "after_launch_cmd": after_launch_cmd,
+        "before_launch_cmd": _redact.redact_launch_cmd(before_launch_cmd),
+        "after_launch_cmd": _redact.redact_launch_cmd(after_launch_cmd),
         "before_channels": before_channels,
         "after_channels": after_channels,
     }
@@ -95,9 +118,10 @@ def main() -> int:
     if reason:
         detail["reason"] = reason
     try:
-        detail["actions"] = json.loads(actions_json) if actions_json else []
+        actions = json.loads(actions_json) if actions_json else []
     except (TypeError, ValueError):
-        detail["actions"] = []
+        actions = []
+    detail["actions"] = _redact.redact_actions(actions)
 
     print(json.dumps(detail, ensure_ascii=True, sort_keys=True))
     return 0

--- a/lib/bridge-agent-update.sh
+++ b/lib/bridge-agent-update.sh
@@ -303,6 +303,14 @@ bridge_agent_update_emit_audit() {
 }
 
 # bridge_agent_update_emit_json — pretty-print the result envelope.
+#
+# Footgun #11 (KNOWN_ISSUES.md §26): the body used to be a
+# `python3 - … <<'PY' … PY` heredoc-stdin block. Issue #1023 also needs
+# this surface to redact credential-bearing launch-cmd env values, so
+# the body was extracted to lib/agent-cli-helpers/agent-update-result-json.py
+# (invoked file-as-argv) — the heredoc-stdin path is gone and the
+# redaction lives in the shared launch-cmd-redact module the helper
+# imports.
 bridge_agent_update_emit_json() {
   local agent="$1"
   local changed="$2"
@@ -316,7 +324,11 @@ bridge_agent_update_emit_json() {
   local actions_json="${10}"
 
   bridge_require_python
-  python3 - \
+  # #946 L1: stale-source guard before the python3 fork.
+  if ! bridge_resolve_script_dir_check; then
+    return 1
+  fi
+  python3 "$BRIDGE_SCRIPT_DIR/lib/agent-cli-helpers/agent-update-result-json.py" \
     "$agent" \
     "$changed" \
     "$dry_run" \
@@ -326,44 +338,5 @@ bridge_agent_update_emit_json() {
     "$after_channels" \
     "$before_sha" \
     "$after_sha" \
-    "$actions_json" <<'PY'
-import json
-import sys
-
-(
-    agent,
-    changed,
-    dry_run,
-    before_launch_cmd,
-    after_launch_cmd,
-    before_channels,
-    after_channels,
-    before_sha,
-    after_sha,
-    actions_json,
-) = sys.argv[1:]
-
-try:
-    actions = json.loads(actions_json) if actions_json else []
-except (TypeError, ValueError):
-    actions = []
-
-payload = {
-    "agent": agent,
-    "changed": changed == "1",
-    "dry_run": dry_run == "1",
-    "before": {
-        "launch_cmd": before_launch_cmd,
-        "channels": before_channels,
-    },
-    "after": {
-        "launch_cmd": after_launch_cmd,
-        "channels": after_channels,
-    },
-    "before_sha": before_sha,
-    "after_sha": after_sha,
-    "actions": actions,
-}
-print(json.dumps(payload, ensure_ascii=False, indent=2))
-PY
+    "$actions_json"
 }

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
 }
 
 add_all_integration() {
@@ -270,7 +270,13 @@ select_for_path() {
       # Issue #1010: bridge-agent.sh::run_delete now calls the isolated-
       # agent OS-user reap helper; cover its gating-decision smoke so a
       # regression in the delete-path wire-up is caught.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap
+      # Issue #1023: the typed `agent update --launch-cmd-*` path now
+      # redacts credential-bearing env values across every output
+      # surface (diff / operation_summary / actions / audit detail /
+      # --json / plain text / dry-run). Pull the redaction smoke
+      # whenever bridge-agent.sh or lib/bridge-agent-update.sh moves so
+      # a future PR cannot regress a secret-leak surface.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -457,7 +463,11 @@ select_for_path() {
       # `bridge_agent_launch_cmd` path. Any modification to these helpers
       # must re-run the Wave C regression smoke that asserts the call
       # returns in <2s.
-      add_required 835-static-admin-launch launch launch-dev-channels-injection channel-env-readiness
+      # Issue #1023: scripts/python-helpers/launch-cmd-redact.py is the
+      # shared secret-redaction surface every `agent update --launch-cmd-*`
+      # output path routes through; pull its regression smoke whenever
+      # any launch-cmd helper moves.
+      add_required 835-static-admin-launch launch launch-dev-channels-injection channel-env-readiness agent-update-launch-cmd-redaction
       add_integration integration-minimal
       ;;
 
@@ -514,6 +524,15 @@ select_for_path() {
       # COMMON-INSTRUCTIONS.local.md override; pin the no-op-when-absent
       # contract so a bridge-docs.py move can't regress it.
       add_required common-instructions-local-override
+      add_integration integration-minimal
+      ;;
+
+    lib/agent-cli-helpers/audit-detail-json.py|lib/agent-cli-helpers/agent-update-result-json.py)
+      # Issue #1023: these helpers render the `agent update` audit
+      # detail and the --json result envelope; both route launch-cmd
+      # values through the shared launch-cmd-redact module. Pull the
+      # redaction regression smoke whenever either renderer moves.
+      add_required agent-update agent-update-launch-cmd-redaction
       add_integration integration-minimal
       ;;
 

--- a/scripts/python-helpers/launch-cmd-redact.py
+++ b/scripts/python-helpers/launch-cmd-redact.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""launch-cmd-redact.py — single shared redaction surface for the
+`agent-bridge agent update --launch-cmd-*` output path (issue #1023).
+
+`agent update` echoes the full `before_launch_cmd` / `after_launch_cmd`
+values, the operation summary, the recorded `add-env` actions, the audit
+detail, the `--json` envelope, and the plain-text result. A launch
+command's leading env-prefix routinely carries credential-bearing values
+(OAuth / MS365 client secrets, bearer tokens, session cookies). Echoing
+the raw value leaks the secret into terminal output, logs, transcripts,
+and task reports.
+
+This module is the ONE place the sensitive-key pattern set lives. Every
+surface that renders a launch command or a launch-cmd op routes through
+it so no surface is missed. It redacts the **value only** and keeps the
+env **key name** visible — `MS365_CLIENT_SECRET=supersecret` becomes
+`MS365_CLIENT_SECRET=***REDACTED***`. It is an output-rendering
+transform only: the stored/applied launch command is never mutated.
+
+Importable API:
+    redact_launch_cmd(value)         -> str
+    redact_action(action)            -> str
+    redact_actions(actions)          -> list[str]
+    redact_operation_summary(summary)-> str
+    is_sensitive_key(key)            -> bool
+
+CLI (file-as-argv, no heredoc-stdin — footgun #11 / KNOWN_ISSUES.md §26):
+    launch-cmd-redact.py launch-cmd  <value>
+    launch-cmd-redact.py action      <action>
+    launch-cmd-redact.py op-summary  <summary>
+Each prints the redacted form on stdout.
+"""
+
+import re
+import sys
+
+REDACTED = "***REDACTED***"
+
+# Codex r1 pattern set: a key is sensitive if it contains any of these
+# substrings, case-insensitively. Covers the issue's explicit list
+# (SECRET / TOKEN / PASSWORD / KEY / CLIENT_SECRET / ACCESS_TOKEN /
+# REFRESH_TOKEN — the latter three are caught by SECRET / TOKEN) plus
+# the common launch-env secret names AUTHORIZATION / BEARER / COOKIE /
+# SESSION / JWT, so `AUTHORIZATION=Bearer ...` and `SESSION_COOKIE=...`
+# also redact.
+_SENSITIVE_SUBSTRINGS = (
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "KEY",
+    "CREDENTIAL",
+    "AUTH",
+    "AUTHORIZATION",
+    "BEARER",
+    "COOKIE",
+    "SESSION",
+    "JWT",
+)
+
+# A leading env-prefix token: KEY=VALUE where KEY is a shell-style
+# identifier. Mirrors agent-update-apply-launch-cmd.py's env_re so the
+# env/argv boundary is identified identically.
+_ENV_TOKEN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", re.DOTALL)
+
+
+def is_sensitive_key(key: str) -> bool:
+    """True if the env key name matches any sensitive substring."""
+    upper = key.upper()
+    return any(sub in upper for sub in _SENSITIVE_SUBSTRINGS)
+
+
+def _redact_env_token(token: str) -> str:
+    """Redact one ``KEY=VALUE`` token if KEY is sensitive; else verbatim.
+
+    A token without ``=`` or with a non-identifier key is returned
+    unchanged — only matched env assignments are touched.
+    """
+    m = _ENV_TOKEN_RE.match(token)
+    if not m:
+        return token
+    key, value = m.group(1), m.group(2)
+    if not is_sensitive_key(key):
+        return token
+    if value == "":
+        # Nothing to leak; leave an empty assignment untouched.
+        return token
+    return f"{key}={REDACTED}"
+
+
+def redact_launch_cmd(value: str) -> str:
+    """Redact sensitive env values in a launch command string.
+
+    Only the leading run of ``KEY=VALUE`` env-prefix tokens is
+    considered — once a non-env token is seen, the rest is argv and is
+    left verbatim (matches the env/argv split in
+    agent-update-apply-launch-cmd.py). Whitespace runs are collapsed to
+    single spaces, consistent with the applier's reassembly.
+    """
+    if not value:
+        return value
+    tokens = value.split()
+    out: list[str] = []
+    in_env_prefix = True
+    env_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+    for tok in tokens:
+        if in_env_prefix and not tok.startswith("-") and env_re.match(tok):
+            out.append(_redact_env_token(tok))
+        else:
+            in_env_prefix = False
+            out.append(tok)
+    return " ".join(out)
+
+
+def redact_action(action: str) -> str:
+    """Redact a recorded launch-cmd action string.
+
+    The only action that embeds a value is ``add-env KEY=VALUE``
+    (agent-update-apply-launch-cmd.py). ``remove-env KEY`` /
+    ``set-launch-cmd`` / dev-channel actions carry no env value, except
+    ``set-launch-cmd`` whose payload is not part of the action string.
+    """
+    prefix = "add-env "
+    if action.startswith(prefix):
+        return prefix + _redact_env_token(action[len(prefix):])
+    return action
+
+
+def redact_actions(actions: list) -> list:
+    """Redact every action string in an actions array."""
+    return [
+        redact_action(a) if isinstance(a, str) else a
+        for a in actions
+    ]
+
+
+def redact_operation_summary(summary: str) -> str:
+    """Redact a comma-joined operation summary.
+
+    The launch-cmd chunks have the shape ``launch:add-env=KEY=VALUE``
+    (bridge-agent.sh builds them with ``sed 's/\\t/=/'`` over the TSV
+    op list). Only the ``launch:add-env=`` chunk embeds a value; the
+    rest of the summary (``chan:*``, ``desc=set``, ``engine=*``, …) is
+    left verbatim.
+    """
+    if not summary:
+        return summary
+    chunks = summary.split(",")
+    redacted: list[str] = []
+    add_env_prefix = "launch:add-env="
+    for chunk in chunks:
+        if chunk.startswith(add_env_prefix):
+            redacted.append(
+                add_env_prefix
+                + _redact_env_token(chunk[len(add_env_prefix):])
+            )
+        else:
+            redacted.append(chunk)
+    return ",".join(redacted)
+
+
+def _main(argv: list) -> int:
+    if len(argv) != 3:
+        print(
+            "usage: launch-cmd-redact.py "
+            "<launch-cmd|action|op-summary> <value>",
+            file=sys.stderr,
+        )
+        return 2
+    mode, value = argv[1], argv[2]
+    if mode == "launch-cmd":
+        print(redact_launch_cmd(value))
+    elif mode == "action":
+        print(redact_action(value))
+    elif mode == "op-summary":
+        print(redact_operation_summary(value))
+    else:
+        print(f"launch-cmd-redact.py: unknown mode: {mode}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/scripts/python-helpers/launch-cmd-redact.py
+++ b/scripts/python-helpers/launch-cmd-redact.py
@@ -18,16 +18,16 @@ env **key name** visible — `MS365_CLIENT_SECRET=supersecret` becomes
 transform only: the stored/applied launch command is never mutated.
 
 Importable API:
-    redact_launch_cmd(value)         -> str
-    redact_action(action)            -> str
-    redact_actions(actions)          -> list[str]
-    redact_operation_summary(summary)-> str
-    is_sensitive_key(key)            -> bool
+    redact_launch_cmd(value)     -> str
+    redact_action(action)        -> str
+    redact_actions(actions)      -> list[str]
+    redact_launch_ops(ops_tsv)   -> str
+    is_sensitive_key(key)        -> bool
 
 CLI (file-as-argv, no heredoc-stdin — footgun #11 / KNOWN_ISSUES.md §26):
     launch-cmd-redact.py launch-cmd  <value>
     launch-cmd-redact.py action      <action>
-    launch-cmd-redact.py op-summary  <summary>
+    launch-cmd-redact.py launch-ops  <tsv-op-stream>
 Each prints the redacted form on stdout.
 """
 
@@ -133,36 +133,47 @@ def redact_actions(actions: list) -> list:
     ]
 
 
-def redact_operation_summary(summary: str) -> str:
-    """Redact a comma-joined operation summary.
+def redact_launch_ops(ops_tsv: str) -> str:
+    """Redact a TAB-separated launch-cmd op stream, structured.
 
-    The launch-cmd chunks have the shape ``launch:add-env=KEY=VALUE``
-    (bridge-agent.sh builds them with ``sed 's/\\t/=/'`` over the TSV
-    op list). Only the ``launch:add-env=`` chunk embeds a value; the
-    rest of the summary (``chan:*``, ``desc=set``, ``engine=*``, …) is
-    left verbatim.
+    Input is the raw ``op<TAB>payload`` newline-delimited stream
+    bridge-agent.sh accumulates via ``add_launch_cmd_op``. Redaction
+    happens HERE — while each op and its full payload are still
+    discrete structured entries — so a value containing a comma (a
+    valid ``--launch-cmd-add-env KEY=v1,v2`` input) is never confused
+    with an op delimiter.
+
+    Output: one ``launch:<op>=<payload>`` line per op — the redacted
+    form bridge-agent.sh then flattens (``tr '\\n' ','``) into the
+    comma-joined operation summary. The only op whose payload embeds a
+    value is ``add-env`` (KEY=VALUE); every other op's payload
+    (``set-launch-cmd`` / ``remove-env`` / dev-channel specs) is passed
+    through verbatim.
+
+    Redacting AFTER the comma-join is unsound — the join is lossy: a
+    comma inside a value is indistinguishable from an op delimiter, so
+    a post-join ``split(',')`` strands the value's suffix as a bare
+    non-``KEY=`` token that escapes redaction (issue #1023 codex r1
+    BLOCKING). Operating on the structured op closes that bypass.
     """
-    if not summary:
-        return summary
-    chunks = summary.split(",")
-    redacted: list[str] = []
-    add_env_prefix = "launch:add-env="
-    for chunk in chunks:
-        if chunk.startswith(add_env_prefix):
-            redacted.append(
-                add_env_prefix
-                + _redact_env_token(chunk[len(add_env_prefix):])
-            )
-        else:
-            redacted.append(chunk)
-    return ",".join(redacted)
+    out: list[str] = []
+    for line in ops_tsv.split("\n"):
+        if not line:
+            continue
+        parts = line.split("\t", 1)
+        op = parts[0]
+        payload = parts[1] if len(parts) == 2 else ""
+        if op == "add-env":
+            payload = _redact_env_token(payload)
+        out.append(f"launch:{op}={payload}")
+    return "\n".join(out)
 
 
 def _main(argv: list) -> int:
     if len(argv) != 3:
         print(
             "usage: launch-cmd-redact.py "
-            "<launch-cmd|action|op-summary> <value>",
+            "<launch-cmd|action|launch-ops> <value>",
             file=sys.stderr,
         )
         return 2
@@ -171,8 +182,8 @@ def _main(argv: list) -> int:
         print(redact_launch_cmd(value))
     elif mode == "action":
         print(redact_action(value))
-    elif mode == "op-summary":
-        print(redact_operation_summary(value))
+    elif mode == "launch-ops":
+        print(redact_launch_ops(value))
     else:
         print(f"launch-cmd-redact.py: unknown mode: {mode}", file=sys.stderr)
         return 2

--- a/scripts/python-helpers/launch-cmd-redact.py
+++ b/scripts/python-helpers/launch-cmd-redact.py
@@ -145,10 +145,19 @@ def redact_launch_ops(ops_tsv: str) -> str:
 
     Output: one ``launch:<op>=<payload>`` line per op — the redacted
     form bridge-agent.sh then flattens (``tr '\\n' ','``) into the
-    comma-joined operation summary. The only op whose payload embeds a
-    value is ``add-env`` (KEY=VALUE); every other op's payload
-    (``set-launch-cmd`` / ``remove-env`` / dev-channel specs) is passed
-    through verbatim.
+    comma-joined operation summary.
+
+    Two op payloads embed a secret-bearing env VALUE and are redacted:
+      - ``add-env``        — payload is ``KEY=VALUE``; redact the value.
+      - ``set-launch-cmd`` — payload is a FULL launch command, whose
+        leading env-prefix can carry secrets; redact it the same way
+        before/after_launch_cmd is redacted (issue #1023 codex r2
+        BLOCKING — set-launch-cmd was passed through verbatim and the
+        raw value reached the audit ``operation`` field).
+    The remaining ops carry no env value and pass through verbatim:
+      - ``remove-env``     — payload is a bare KEY (validated key-only).
+      - ``add-dev-channel`` / ``remove-dev-channel`` — payload is a
+        channel spec (``plugin:foo@m`` / ``server:teams``), not env.
 
     Redacting AFTER the comma-join is unsound — the join is lossy: a
     comma inside a value is indistinguishable from an op delimiter, so
@@ -165,6 +174,8 @@ def redact_launch_ops(ops_tsv: str) -> str:
         payload = parts[1] if len(parts) == 2 else ""
         if op == "add-env":
             payload = _redact_env_token(payload)
+        elif op == "set-launch-cmd":
+            payload = redact_launch_cmd(payload)
         out.append(f"launch:{op}={payload}")
     return "\n".join(out)
 

--- a/scripts/smoke/agent-update-launch-cmd-redaction.sh
+++ b/scripts/smoke/agent-update-launch-cmd-redaction.sh
@@ -295,6 +295,78 @@ for line in sys.argv[1].splitlines():
   run_update --json --launch-cmd-remove-env MS365_CLIENT_SECRET >/dev/null
 }
 
+assert_set_launch_cmd_secret_redacted_everywhere() {
+  # Issue #1023 codex r2 BLOCKING regression: `--set-launch-cmd` replaces
+  # the WHOLE launch command, and that payload can carry a credential-
+  # bearing env-prefix. The op-stream redactor passed `set-launch-cmd`
+  # through verbatim, so the raw env value reached the audit `operation`
+  # field. The redactor now runs the set-launch-cmd payload through the
+  # same launch-cmd redactor used for before/after_launch_cmd.
+  : >"$BRIDGE_AUDIT_LOG" 2>/dev/null || true
+
+  local secret_cmd
+  secret_cmd="MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE} claude --dangerously-skip-permissions"
+
+  # Default mode prints plain text.
+  local output
+  output="$(run_update --set-launch-cmd "$secret_cmd")"
+  assert_no_secret "set-launch-cmd plain-text result" "$output"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "set-launch-cmd plain-text result is redacted"
+
+  # --json envelope.
+  output="$(run_update --json --set-launch-cmd "$secret_cmd")"
+  assert_no_secret "set-launch-cmd --json envelope" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+suffix = sys.argv[2]
+blob = json.dumps(payload)
+assert suffix not in blob, f"set-launch-cmd secret in --json: {payload}"
+assert "MS365_CLIENT_SECRET=" in payload["after"]["launch_cmd"], payload
+assert "***REDACTED***" in payload["after"]["launch_cmd"], payload
+' "$output" "$SECRET_VALUE"
+
+  # Audit `operation` field — the exact surface codex r2 flagged. The
+  # set-launch-cmd above wrote an audit row.
+  if [[ ! -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_fail "expected an audit row after a set-launch-cmd mutation"
+  fi
+  local audit_blob
+  audit_blob="$(cat "$BRIDGE_AUDIT_LOG")"
+  assert_no_secret "set-launch-cmd audit.jsonl" "$audit_blob"
+  python3 -c '
+import json, sys
+suffix = sys.argv[2]
+saw_set = False
+for line in sys.argv[1].splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    row = json.loads(line)
+    detail = row.get("detail") or {}
+    op = detail.get("operation", "")
+    assert suffix not in op, f"set-launch-cmd secret in audit operation: {op!r}"
+    if "set-launch-cmd" in op:
+        saw_set = True
+assert saw_set, "expected a set-launch-cmd audit operation row"
+' "$audit_blob" "$SECRET_VALUE"
+
+  # Dry-run must redact the set-launch-cmd payload too.
+  output="$(run_update --dry-run --set-launch-cmd "$secret_cmd")"
+  assert_no_secret "set-launch-cmd dry-run output" "$output"
+
+  # The applied launch command on disk still carries the REAL value.
+  local line
+  line="$(read_launch_line)"
+  smoke_assert_contains "$line" "$COMMA_SECRET_VALUE" \
+    "applied launch_cmd on disk still carries the real set-launch-cmd value"
+
+  # Restore the fixture launch cmd for any downstream assertion.
+  run_update --json \
+    --set-launch-cmd "claude --dangerously-skip-permissions" >/dev/null
+}
+
 main() {
   smoke_require_cmd python3
   smoke_require_cmd bash
@@ -312,6 +384,8 @@ main() {
     assert_dry_run_redacts_secret
   smoke_run "comma-containing secret value redacted in every surface" \
     assert_comma_value_secret_redacted_everywhere
+  smoke_run "set-launch-cmd secret value redacted in every surface" \
+    assert_set_launch_cmd_secret_redacted_everywhere
   smoke_log "passed"
 }
 

--- a/scripts/smoke/agent-update-launch-cmd-redaction.sh
+++ b/scripts/smoke/agent-update-launch-cmd-redaction.sh
@@ -40,6 +40,12 @@ WORKER="testworker"
 # The secret literals. These must never appear in any rendered output.
 SECRET_VALUE="supersecretClientSecretXYZ"
 BEARER_VALUE="BearerTok-abc123def456"
+# A sensitive value that CONTAINS a comma — `--launch-cmd-add-env` only
+# rejects newlines, so a comma is a valid value char. The redactor must
+# redact the whole value structurally; a post-comma-join redactor would
+# strand SECRET_VALUE (the suffix) as a bare token (issue #1023 codex
+# r1 BLOCKING).
+COMMA_SECRET_VALUE="left,${SECRET_VALUE}"
 # A benign env value — must survive un-redacted in the diff.
 BENIGN_VALUE="benign-debug-flag-99"
 
@@ -212,6 +218,83 @@ assert sys.argv[2] not in json.dumps(payload), payload
     "dry-run did not mutate the roster launch_cmd line"
 }
 
+assert_comma_value_secret_redacted_everywhere() {
+  # Issue #1023 codex r1 BLOCKING regression: a sensitive add-env value
+  # containing a comma. The operation summary is built by comma-joining
+  # the op stream; redacting AFTER that join split the value at its
+  # comma and let the suffix (SECRET_VALUE) survive as a bare token in
+  # the audit `operation` string. The redactor now operates on the
+  # structured op, so the whole value — comma and all — is redacted in
+  # EVERY surface: --json, plain text, audit detail, operation summary,
+  # actions, dry-run.
+  : >"$BRIDGE_AUDIT_LOG" 2>/dev/null || true
+
+  # --json + plain text in one apply run (default mode prints text).
+  local output
+  output="$(run_update \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE}")"
+  assert_no_secret "comma-value plain-text result" "$output"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "comma-value plain-text result is redacted"
+
+  output="$(run_update --json --launch-cmd-remove-env MS365_CLIENT_SECRET)"
+  # Re-add via --json so we can assert the envelope too.
+  output="$(run_update --json \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE}")"
+  assert_no_secret "comma-value --json envelope" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+suffix = sys.argv[2]
+blob = json.dumps(payload)
+assert suffix not in blob, f"comma-value secret suffix in --json: {payload}"
+assert "MS365_CLIENT_SECRET=" in payload["after"]["launch_cmd"], payload
+assert "***REDACTED***" in payload["after"]["launch_cmd"], payload
+joined = " ".join(a for a in payload["actions"] if isinstance(a, str))
+assert suffix not in joined, payload
+' "$output" "$SECRET_VALUE"
+
+  # Audit log: the `operation` summary string is the surface the
+  # post-join redactor leaked through. Assert the suffix is gone there.
+  if [[ ! -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_fail "expected an audit row after a comma-value launch-cmd mutation"
+  fi
+  local audit_blob
+  audit_blob="$(cat "$BRIDGE_AUDIT_LOG")"
+  assert_no_secret "comma-value audit.jsonl" "$audit_blob"
+  # Explicitly pull the audit `operation` field and assert the suffix
+  # is absent — this is the exact field the lossy comma-join leaked.
+  python3 -c '
+import json, sys
+suffix = sys.argv[2]
+for line in sys.argv[1].splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    row = json.loads(line)
+    detail = row.get("detail") or {}
+    op = detail.get("operation", "")
+    assert suffix not in op, f"comma-value secret suffix in audit operation: {op!r}"
+' "$audit_blob" "$SECRET_VALUE"
+  smoke_assert_contains "$audit_blob" "MS365_CLIENT_SECRET" \
+    "comma-value audit detail still records which key changed"
+
+  # Dry-run must redact the comma value too.
+  output="$(run_update --dry-run \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE}")"
+  assert_no_secret "comma-value dry-run output" "$output"
+
+  # The applied launch command on disk still carries the REAL comma
+  # value — redaction is output-rendering only.
+  local line
+  line="$(read_launch_line)"
+  smoke_assert_contains "$line" "$COMMA_SECRET_VALUE" \
+    "applied launch_cmd on disk still carries the real comma value"
+
+  # Clean up so downstream assertions start from a known state.
+  run_update --json --launch-cmd-remove-env MS365_CLIENT_SECRET >/dev/null
+}
+
 main() {
   smoke_require_cmd python3
   smoke_require_cmd bash
@@ -227,6 +310,8 @@ main() {
     assert_audit_log_redacts_secret
   smoke_run "dry-run output (default + --json) redacts secret" \
     assert_dry_run_redacts_secret
+  smoke_run "comma-containing secret value redacted in every surface" \
+    assert_comma_value_secret_redacted_everywhere
   smoke_log "passed"
 }
 

--- a/scripts/smoke/agent-update-launch-cmd-redaction.sh
+++ b/scripts/smoke/agent-update-launch-cmd-redaction.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# scripts/smoke/agent-update-launch-cmd-redaction.sh — Issue #1023 smoke.
+#
+# `agent-bridge agent update --launch-cmd-*` echoes the before/after
+# launch command, the operation summary, the recorded add-env actions,
+# the audit detail, the --json envelope, the plain-text result, and the
+# dry-run output. A launch command's leading env-prefix routinely
+# carries credential-bearing values (OAuth / MS365 client secrets,
+# bearer tokens). This smoke pins that the raw secret literal survives
+# in NONE of those surfaces, while a benign env value is left intact and
+# the actually-applied launch command on disk still carries the real
+# value.
+#
+# Surfaces asserted (codex r1 — redacting only before/after diff is
+# insufficient):
+#   - before_launch_cmd / after_launch_cmd diff (plain text)
+#   - --json envelope (before/after launch_cmd + actions)
+#   - operation_summary + audit detail (audit.jsonl)
+#   - recorded add-env actions
+#   - dry-run output (default + --json modes)
+#
+# Caller-source trust is forced via BRIDGE_CALLER_SOURCE=operator-tui so
+# the smoke does not depend on a real TTY (CI / pipe execution).
+
+set -euo pipefail
+
+SMOKE_NAME="agent-update-launch-cmd-redaction"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+ADMIN="testadmin"
+WORKER="testworker"
+
+# The secret literals. These must never appear in any rendered output.
+SECRET_VALUE="supersecretClientSecretXYZ"
+BEARER_VALUE="BearerTok-abc123def456"
+# A benign env value — must survive un-redacted in the diff.
+BENIGN_VALUE="benign-debug-flag-99"
+
+write_roster_fixture() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+BRIDGE_ADMIN_AGENT_ID=${ADMIN}
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${ADMIN}
+bridge_add_agent_id_if_missing ${ADMIN}
+BRIDGE_AGENT_DESC["${ADMIN}"]='admin role'
+BRIDGE_AGENT_ENGINE["${ADMIN}"]='claude'
+BRIDGE_AGENT_SESSION["${ADMIN}"]='${ADMIN}'
+BRIDGE_AGENT_WORKDIR["${ADMIN}"]='${BRIDGE_AGENT_HOME_ROOT}/${ADMIN}'
+BRIDGE_AGENT_SOURCE["${ADMIN}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${ADMIN}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${ADMIN}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${ADMIN}
+
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${WORKER}
+bridge_add_agent_id_if_missing ${WORKER}
+BRIDGE_AGENT_DESC["${WORKER}"]='worker role'
+BRIDGE_AGENT_ENGINE["${WORKER}"]='claude'
+BRIDGE_AGENT_SESSION["${WORKER}"]='${WORKER}'
+BRIDGE_AGENT_WORKDIR["${WORKER}"]='${BRIDGE_AGENT_HOME_ROOT}/${WORKER}'
+BRIDGE_AGENT_SOURCE["${WORKER}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${WORKER}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${WORKER}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${WORKER}
+EOF
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$WORKER" "$BRIDGE_AGENT_HOME_ROOT/$ADMIN"
+}
+
+run_update() {
+  # Run as admin from operator-trusted source. $@ supplies mode flags
+  # (--json / --dry-run) and the launch-cmd mutation flags.
+  BRIDGE_ADMIN_AGENT_ID="$ADMIN" \
+  BRIDGE_CALLER_SOURCE="operator-tui" \
+  BRIDGE_AGENT_ID="$ADMIN" \
+    bash "$SMOKE_REPO_ROOT/bridge-agent.sh" update "$WORKER" "$@"
+}
+
+read_launch_line() {
+  grep "^BRIDGE_AGENT_LAUNCH_CMD\\[\"${WORKER}\"\\]=" \
+    "$BRIDGE_ROSTER_LOCAL_FILE" | head -n 1
+}
+
+# assert_no_secret <label> <text>
+# Fail if either secret literal appears anywhere in <text>.
+assert_no_secret() {
+  local label="$1"
+  local text="$2"
+  if [[ "$text" == *"$SECRET_VALUE"* ]]; then
+    smoke_fail "secret literal leaked into $label: $text"
+  fi
+  if [[ "$text" == *"$BEARER_VALUE"* ]]; then
+    smoke_fail "bearer token literal leaked into $label: $text"
+  fi
+}
+
+assert_default_text_redacts_secret() {
+  # Default (non-JSON) plain-text output across two sensitive env adds.
+  local output
+  output="$(run_update \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${SECRET_VALUE}" \
+    --launch-cmd-add-env "AUTHORIZATION=${BEARER_VALUE}")"
+
+  assert_no_secret "plain-text result" "$output"
+  smoke_assert_contains "$output" "MS365_CLIENT_SECRET=" \
+    "plain-text result still shows the redacted key name"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "plain-text result shows the redaction placeholder"
+
+  # The roster on disk must still carry the REAL secret — redaction is
+  # output-rendering only.
+  local line
+  line="$(read_launch_line)"
+  smoke_assert_contains "$line" "$SECRET_VALUE" \
+    "applied launch_cmd on disk still carries the real secret value"
+  smoke_assert_contains "$line" "$BEARER_VALUE" \
+    "applied launch_cmd on disk still carries the real bearer token"
+}
+
+assert_json_redacts_secret() {
+  # --json envelope: before/after launch_cmd + actions array.
+  local output
+  output="$(run_update --json \
+    --launch-cmd-add-env "REFRESH_TOKEN=${SECRET_VALUE}")"
+
+  assert_no_secret "--json envelope" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["changed"] is True, payload
+secret = sys.argv[2]
+blob = json.dumps(payload)
+assert secret not in blob, f"secret in --json payload: {payload}"
+assert "REFRESH_TOKEN=" in payload["after"]["launch_cmd"], payload
+assert "***REDACTED***" in payload["after"]["launch_cmd"], payload
+# Recorded add-env action must be redacted too.
+joined = " ".join(a for a in payload["actions"] if isinstance(a, str))
+assert "add-env REFRESH_TOKEN=" in joined, payload
+assert secret not in joined, payload
+' "$output" "$SECRET_VALUE"
+}
+
+assert_benign_env_not_redacted() {
+  # A non-sensitive key (BRIDGE_HOME / DEBUG) must NOT be redacted —
+  # the diff signal for benign env stays intact.
+  local output
+  output="$(run_update --json \
+    --launch-cmd-add-env "DEBUG=${BENIGN_VALUE}")"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+benign = sys.argv[1 + 1]
+assert benign in payload["after"]["launch_cmd"], payload
+joined = " ".join(a for a in payload["actions"] if isinstance(a, str))
+assert f"add-env DEBUG={benign}" in joined, payload
+' "$output" "$BENIGN_VALUE"
+  # Clean up the benign add so downstream assertions start clean.
+  run_update --json --launch-cmd-remove-env DEBUG >/dev/null
+}
+
+assert_audit_log_redacts_secret() {
+  # The audit log carries the operation summary + detail (before/after
+  # launch_cmd, actions). The SHA chain is the tamper-evidence; the raw
+  # secret must not be in the JSONL.
+  : >"$BRIDGE_AUDIT_LOG" 2>/dev/null || true
+  run_update --json \
+    --launch-cmd-add-env "CLIENT_SECRET=${SECRET_VALUE}" >/dev/null
+  if [[ ! -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_fail "expected an audit row after a launch-cmd mutation"
+  fi
+  local audit_blob
+  audit_blob="$(cat "$BRIDGE_AUDIT_LOG")"
+  assert_no_secret "audit.jsonl" "$audit_blob"
+  smoke_assert_contains "$audit_blob" "CLIENT_SECRET" \
+    "audit detail still records which key changed"
+  smoke_assert_contains "$audit_blob" "***REDACTED***" \
+    "audit detail carries the redaction placeholder"
+}
+
+assert_dry_run_redacts_secret() {
+  # Dry-run output (default + --json). The roster must not change AND
+  # the planned secret must not appear in the dry-run render.
+  local before_line output
+  before_line="$(read_launch_line)"
+
+  output="$(run_update --dry-run \
+    --launch-cmd-add-env "API_KEY=${SECRET_VALUE}")"
+  assert_no_secret "dry-run plain-text output" "$output"
+  smoke_assert_contains "$output" "dry_run: yes" "dry-run flag echoed"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "dry-run plain-text output is redacted"
+
+  output="$(run_update --json --dry-run \
+    --launch-cmd-add-env "API_KEY=${SECRET_VALUE}")"
+  assert_no_secret "dry-run --json output" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["dry_run"] is True, payload
+assert sys.argv[2] not in json.dumps(payload), payload
+' "$output" "$SECRET_VALUE"
+
+  local after_line
+  after_line="$(read_launch_line)"
+  smoke_assert_eq "$before_line" "$after_line" \
+    "dry-run did not mutate the roster launch_cmd line"
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_require_cmd bash
+  smoke_setup_bridge_home "agent-update-launch-cmd-redaction"
+  write_roster_fixture
+  smoke_run "default plain-text output redacts secret env values" \
+    assert_default_text_redacts_secret
+  smoke_run "--json envelope redacts launch_cmd + actions" \
+    assert_json_redacts_secret
+  smoke_run "benign env value is left un-redacted" \
+    assert_benign_env_not_redacted
+  smoke_run "audit log redacts secret env values" \
+    assert_audit_log_redacts_secret
+  smoke_run "dry-run output (default + --json) redacts secret" \
+    assert_dry_run_redacts_secret
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

`agent-bridge agent update --launch-cmd-*` echoed full `before_launch_cmd` /
`after_launch_cmd` values, the operation summary, recorded `add-env` actions,
the audit detail, the `--json` envelope, the plain-text result, and dry-run
output. A launch command's leading env-prefix routinely carries
credential-bearing values (OAuth / MS365 client secrets, bearer tokens,
session cookies), so every one of those surfaces leaked secrets into terminal
output, logs, transcripts, and task reports. (#1023)

Redacting only the before/after diff is insufficient — the codex plan review
(r1) pinpointed that the raw secret also flows through `operation_summary`,
the recorded actions, the audit detail, and the `--json` envelope. This PR
covers every surface.

## What changed

- **New shared redaction surface** — `scripts/python-helpers/launch-cmd-redact.py`.
  Every output path routes through it, so the sensitive-key pattern set lives
  in one place and no surface is missed. It redacts the **value only** and
  keeps the env **key name** visible (`MS365_CLIENT_SECRET=***REDACTED***`),
  matching keys case-insensitively on `SECRET` / `TOKEN` / `PASSWORD` / `KEY` /
  `CREDENTIAL` / `AUTH` / `AUTHORIZATION` / `BEARER` / `COOKIE` / `SESSION` /
  `JWT`. Output-rendering only — the stored/applied launch command is never
  mutated.
- **Wired through every surface**: the plain-text result and `operation_summary`
  (`bridge-agent.sh`), the audit detail (`audit-detail-json.py`), and the
  `--json` envelope. Dry-run is covered automatically — it reuses the same
  render paths.
- **`--json` emit body extracted** from a heredoc-stdin block into
  `lib/agent-cli-helpers/agent-update-result-json.py` so it can import the
  shared module and to keep it off the Bash 5.3.9 heredoc-stdin deadlock
  surface (footgun #11). Net heredoc count goes down — the baseline ratchet
  still passes.
- **New smoke** — `scripts/smoke/agent-update-launch-cmd-redaction.sh` asserts
  the secret literal survives in NONE of the surfaces (diff / operation_summary
  / actions / audit detail / `--json` / plain text / dry-run) across default /
  `--json` / dry-run modes, that a benign env value is left un-redacted, and
  that the applied launch command on disk still carries the real value. Wired
  into `scripts/ci-select-smoke.sh`.

## Verification

- `bash -n` + `shellcheck` clean on `bridge-agent.sh`, `lib/bridge-agent-update.sh`,
  `scripts/ci-select-smoke.sh`, and the new smoke.
- `py_compile` clean on all three Python files.
- `scripts/lint-heredoc-ban.sh --baseline-check` — PASS (heredoc site count
  reduced, no new heredoc-stdin added).
- New smoke (5 cases) — PASS. Existing `scripts/smoke/agent-update.sh` — PASS
  (confirms the `--json` rewire is non-regressing).
- Verified the applied launch command on disk still carries the real secret
  after a `--launch-cmd-add-env` mutation (output-rendering redaction only).

## Scope

Output-rendering redaction only. No change to the launch-cmd mutation logic.
No `VERSION` / `CHANGELOG` changes. Does not touch `bridge-agent.sh` create
scaffold, `lib/bridge-isolation-v2*.sh` (Fixer A), or `plugins/teams/` (PR #1024).