### PR TITLE
release: v0.14.5-beta4 re-cut — verification follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,15 @@ the integration branch additionally passed a full-branch codex review and a
 
 **Re-cut (2026-05-22):** `v0.14.5-beta4` was re-cut to fold in the bug found
 during its own live-VM verification plus the issues/PRs opened against beta4.
-The first-cut content above is retained; the re-cut adds the five items in the
-"Re-cut" subsection below. All five PRs (#1024, #1026, #1027, #1029) were codex
-pair-reviewed through the `feat/wave-v0145-b4recut-integration` branch, which
-passed a full-branch codex review; the `#1025`/`#1028` isolated-create fixes
-were re-verified live on an OrbStack Oracle Linux 9 VM (`agent create --isolate`
-→ `rc=0`, clean `start_dry_run`). The `v0.14.5-beta4` tag and GitHub prerelease
-point at this re-cut HEAD.
+The first-cut content above is retained; the re-cut adds the five follow-up
+items in the "Re-cut" subsection below, delivered by four PRs (#1024, #1026,
+#1027, #1029 — #1027 carries both #1025 and #1021). All four re-cut PRs were
+codex pair-reviewed through the `feat/wave-v0145-b4recut-integration` branch,
+which passed a full-branch codex review; the `#1025`/`#1028` isolated-create
+fixes were re-verified live on an OrbStack Oracle Linux 9 VM
+(`agent create --isolate` → `rc=0`, clean `start_dry_run`). The
+`v0.14.5-beta4` tag and GitHub prerelease are updated to the merged re-cut
+release commit.
 
 ### Re-cut — verification follow-ups (2026-05-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ version bumps via the `VERSION` file.
 
 ## [0.14.5-beta4] — 2026-05-22
 
-### Highlight — runtime-friction closeout wave
+### Highlight — runtime-friction closeout wave (+ verification re-cut)
 
 Operator-cued **fourth prerelease** in the v0.14.5 stabilization window. Bundles
 the six PRs that landed after `v0.14.5-beta3` (2026-05-21): two close-out PRs
@@ -18,6 +18,44 @@ branch. Every PR was codex pair-reviewed (`agb-dev-claude` + `agb-dev-codex`);
 the integration branch additionally passed a full-branch codex review and a
 `scripts/smoke-test.sh` pass. No new features. `-beta4` prerelease; matching tag
 `v0.14.5-beta4`, GitHub release marked **Pre-release**.
+
+**Re-cut (2026-05-22):** `v0.14.5-beta4` was re-cut to fold in the bug found
+during its own live-VM verification plus the issues/PRs opened against beta4.
+The first-cut content above is retained; the re-cut adds the five items in the
+"Re-cut" subsection below. All five PRs (#1024, #1026, #1027, #1029) were codex
+pair-reviewed through the `feat/wave-v0145-b4recut-integration` branch, which
+passed a full-branch codex review; the `#1025`/`#1028` isolated-create fixes
+were re-verified live on an OrbStack Oracle Linux 9 VM (`agent create --isolate`
+→ `rc=0`, clean `start_dry_run`). The `v0.14.5-beta4` tag and GitHub prerelease
+point at this re-cut HEAD.
+
+### Re-cut — verification follow-ups (2026-05-22)
+
+- **Isolated `agent create` no longer aborts** (#1025) — the isolation-v2
+  isolated-create scaffold built `runtime/agent-env.sh` with a controller-side
+  non-`sudo` write under the `root:ab-agent-<name>` `0750` agent root, so the
+  create aborted with `Permission denied`. The env file is now staged and
+  installed in one privileged `install -o <controller> -g <agent_grp> -m 0640`
+  (atomic owner/group/mode, no TOCTOU window), matching the v2 matrix contract.
+- **`start_dry_run` workdir false-error fixed** (#1028) — after #1025 unblocked
+  create, the post-create `start_dry_run` still emitted a false
+  `[오류] workdir … 존재하지 않음` because the controller-side `[[ -d ]]` check
+  cannot traverse the `0750` agent root. The workdir existence checks are now
+  privilege-aware (sudo-backed) for linux-user isolated agents.
+- **isolation-v2 apply no longer corrupts shared plugin perms** (#1021) —
+  `migrate isolation v2 --apply` recursively re-grouped shared plugin
+  `node_modules` to a private agent group, breaking other isolated agents that
+  load the same plugin source. The recursive chgrp/chmod now excludes shared
+  plugin material.
+- **`agent update` no longer leaks secrets** (#1023) — `agent update
+  --launch-cmd-*` printed credential-bearing env values (OAuth/MS365 secrets)
+  into terminal output, `--json`, dry-run, and `audit.jsonl`. Sensitive env
+  values are now redacted across every output surface (value redacted, key name
+  kept) — case-insensitively on `SECRET`/`TOKEN`/`PASSWORD`/`KEY`/`CREDENTIAL`/
+  `AUTH`/`AUTHORIZATION`/`BEARER`/`COOKIE`/`SESSION`/`JWT`.
+- **Teams channel notification no longer silent-drops** (#1022) — the direct
+  `notifications/claude/channel` metadata is kept flat/string-only; the rich
+  nested `attachments` array is retained for the bridge queue/audit/replay body.
 
 The #1010 isolated-agent reap path exercises destructive `userdel` / `setfacl` /
 `groupdel`; CI and review verified the gating *decision* (Linux-only, exact

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3141,12 +3141,32 @@ run_update() {
     bridge_die "agent update 변경 플래그가 하나 이상 필요합니다."
   fi
 
+  # Issue #1023: a `--launch-cmd-add-env KEY=VALUE` op carries a raw,
+  # possibly comma-containing secret value. Redact each launch op's
+  # payload HERE — while the ops are still the discrete TSV stream
+  # `launch_cmd_ops` — so a comma inside a value is never confused with
+  # an op delimiter. The redactor emits the `launch:<op>=<payload>`
+  # lines directly; redacting AFTER the comma-join would strand the
+  # value's suffix as a bare token that escapes redaction. Value-only:
+  # env key names stay visible so audit readers see which key changed.
+  # `launch_cmd_ops` itself is untouched — the applier downstream still
+  # sees the real value.
+  local launch_ops_summary_lines=""
+  if [[ -n "$launch_cmd_ops" ]]; then
+    launch_ops_summary_lines="$(
+      python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
+        launch-ops "$launch_cmd_ops"
+    )"
+  fi
+
   # Capture the operation summary for the audit row (compact one-line
   # description of what the operator asked for).
   local operation_summary=""
   operation_summary="$(
     {
-      printf '%s' "$launch_cmd_ops" | sed 's/\t/=/' | sed 's/^/launch:/'
+      if [[ -n "$launch_ops_summary_lines" ]]; then
+        printf '%s\n' "$launch_ops_summary_lines"
+      fi
       printf '%s' "$channels_ops" | sed 's/\t/=/' | sed 's/^/chan:/'
       # Issue #580 Track 2: surface typed-flag mutations in the audit
       # operation summary so audit-log readers see the same shape they
@@ -3391,11 +3411,26 @@ PY
     return 0
   fi
 
+  # Issue #1023: the plain-text result echoes the full before/after
+  # launch command, whose leading env-prefix routinely carries
+  # credential-bearing values. Redact secret env values (value-only,
+  # key name kept) before printing. Output-rendering only — the stored
+  # launch command written above is unchanged.
+  local before_launch_cmd_display new_launch_cmd_display
+  before_launch_cmd_display="$(
+    python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
+      launch-cmd "$before_launch_cmd"
+  )"
+  new_launch_cmd_display="$(
+    python3 "$SCRIPT_DIR/scripts/python-helpers/launch-cmd-redact.py" \
+      launch-cmd "$new_launch_cmd"
+  )"
+
   printf 'agent: %s\n' "$agent"
   printf 'changed: %s\n' "$([[ $changed -eq 1 ]] && echo yes || echo no)"
   printf 'dry_run: %s\n' "$([[ $dry_run -eq 1 ]] && echo yes || echo no)"
-  printf 'before_launch_cmd: %s\n' "$before_launch_cmd"
-  printf 'after_launch_cmd: %s\n' "$new_launch_cmd"
+  printf 'before_launch_cmd: %s\n' "$before_launch_cmd_display"
+  printf 'after_launch_cmd: %s\n' "$new_launch_cmd_display"
   printf 'before_channels: %s\n' "$before_channels"
   printf 'after_channels: %s\n' "$new_channels"
   printf 'before_sha: %s\n' "$before_sha"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -363,7 +363,23 @@ SUPPRESS_MISSING_CHANNELS=0
 CHANNEL_REASON=""
 AGENT_ENV_FILE=""
 
-if [[ ! -d "$WORK_DIR" ]]; then
+# workdir existence: for a linux-user isolated agent the agent root
+# (`<data-root>/agents/<agent>/`) is `root:ab-agent-<agent>` mode 0750
+# and `workdir/` is 2770 — the controller user is not in the agent
+# group at process scope, so a plain `[[ -d "$WORK_DIR" ]]` cannot
+# traverse the 0750 parent and false-negates even when workdir exists
+# (#1028). Probe via the existing sudo-handoff helper for isolated
+# agents; non-isolated agents keep the plain controller-side test.
+WORK_DIR_PRESENT=0
+if bridge_agent_linux_user_isolation_effective "$AGENT"; then
+  if bridge_linux_sudo_root test -d "$WORK_DIR" 2>/dev/null; then
+    WORK_DIR_PRESENT=1
+  fi
+elif [[ -d "$WORK_DIR" ]]; then
+  WORK_DIR_PRESENT=1
+fi
+
+if [[ $WORK_DIR_PRESENT -eq 0 ]]; then
   # Two auto-rebuild paths cover the post-migration "workdir vanished"
   # gap from #714 (item 10 — `patch-dev` static-role with no workdir
   # tree at all). #4 in the per-symptom table:
@@ -397,7 +413,13 @@ if [[ ! -d "$WORK_DIR" ]]; then
       bridge_linux_sudo_root mkdir -p "$WORK_DIR" || \
         bridge_die "workdir 자동 재생성 실패: $WORK_DIR"
     fi
-    if [[ ! -d "$WORK_DIR" ]]; then
+    # Post-regen re-check: same privilege-aware probe — a plain
+    # `[[ ! -d ]]` here false-negates on the isolated 0750 layout and
+    # would spuriously bridge_die even though workdir now exists (#1028).
+    if bridge_agent_linux_user_isolation_effective "$AGENT"; then
+      bridge_linux_sudo_root test -d "$WORK_DIR" 2>/dev/null \
+        || bridge_die "workdir 자동 재생성 후에도 존재하지 않음: $WORK_DIR"
+    elif [[ ! -d "$WORK_DIR" ]]; then
       bridge_die "workdir 자동 재생성 후에도 존재하지 않음: $WORK_DIR"
     fi
   else

--- a/lib/agent-cli-helpers/agent-update-result-json.py
+++ b/lib/agent-cli-helpers/agent-update-result-json.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""agent-update-result-json.py — pretty-print the `agent update` result
+envelope for `agent-bridge agent update --json`.
+
+Invocation contract (positional, all required, all may be empty
+strings):
+    sys.argv[1]  = agent
+    sys.argv[2]  = changed ("1" / "0")
+    sys.argv[3]  = dry_run ("1" / "0")
+    sys.argv[4]  = before_launch_cmd
+    sys.argv[5]  = after_launch_cmd
+    sys.argv[6]  = before_channels
+    sys.argv[7]  = after_channels
+    sys.argv[8]  = before_sha
+    sys.argv[9]  = after_sha
+    sys.argv[10] = actions_json (JSON array literal; empty/invalid -> [])
+
+Output: a single pretty-printed JSON object on stdout.
+
+Refs:
+    - Footgun #11 / KNOWN_ISSUES.md §26: the body used to live as
+      `python3 - … <<'PY' … PY` inside bridge_agent_update_emit_json.
+      Extracted to a standalone file invoked file-as-argv so the
+      heredoc-stdin path is gone (same precedent as PR #940 / #815).
+    - Issue #1023: launch commands routinely carry credential-bearing
+      env values. The `--json` envelope is pasted into terminals, logs,
+      and task reports, so before/after launch_cmd and the recorded
+      add-env actions are routed through the shared launch-cmd-redact
+      module. Redaction is value-only — env key names stay visible.
+"""
+
+import importlib
+import json
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "scripts",
+        "python-helpers",
+    ),
+)
+_redact = importlib.import_module("launch-cmd-redact")
+
+
+def main() -> int:
+    # 10 payload args + script name == 11.
+    if len(sys.argv) != 11:
+        print(
+            "usage: agent-update-result-json.py "
+            "<agent> <changed> <dry_run> <before_launch_cmd> "
+            "<after_launch_cmd> <before_channels> <after_channels> "
+            "<before_sha> <after_sha> <actions_json>",
+            file=sys.stderr,
+        )
+        return 2
+
+    (
+        agent,
+        changed,
+        dry_run,
+        before_launch_cmd,
+        after_launch_cmd,
+        before_channels,
+        after_channels,
+        before_sha,
+        after_sha,
+        actions_json,
+    ) = sys.argv[1:]
+
+    try:
+        actions = json.loads(actions_json) if actions_json else []
+    except (TypeError, ValueError):
+        actions = []
+
+    payload = {
+        "agent": agent,
+        "changed": changed == "1",
+        "dry_run": dry_run == "1",
+        "before": {
+            "launch_cmd": _redact.redact_launch_cmd(before_launch_cmd),
+            "channels": before_channels,
+        },
+        "after": {
+            "launch_cmd": _redact.redact_launch_cmd(after_launch_cmd),
+            "channels": after_channels,
+        },
+        "before_sha": before_sha,
+        "after_sha": after_sha,
+        "actions": _redact.redact_actions(actions),
+    }
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/agent-cli-helpers/audit-detail-json.py
+++ b/lib/agent-cli-helpers/audit-detail-json.py
@@ -39,10 +39,29 @@ Refs:
       to completion on Bash 5.3.9 hosts. Standalone helper invoked
       file-as-argv keeps the path off the broken surface, same
       precedent as PR #940's registry/list/show extraction.
+    - Issue #1023: launch commands routinely carry credential-bearing
+      env values. This helper writes them into the audit-log detail
+      (before/after launch_cmd + the recorded add-env actions), so it
+      routes both through the shared launch-cmd-redact module before
+      emission. The audit log keeps the SHA chain for tamper-evidence;
+      it does not need the raw secret.
 """
 
 import json
+import os
 import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "scripts",
+        "python-helpers",
+    ),
+)
+import importlib  # noqa: E402
+
+_redact = importlib.import_module("launch-cmd-redact")
 
 
 def main() -> int:
@@ -75,6 +94,10 @@ def main() -> int:
         actions_json,
     ) = sys.argv[1:]
 
+    # Issue #1023: redact credential-bearing env values before they
+    # land in the audit log. The redaction is value-only — env key
+    # names stay visible — so audit readers still see which keys
+    # changed.
     detail = {
         "kind": "system_config_mutation",
         "actor": actor,
@@ -85,8 +108,8 @@ def main() -> int:
         "operation": operation,
         "matched_pattern": "agent-roster.local.sh",
         "target_agent": target_agent,
-        "before_launch_cmd": before_launch_cmd,
-        "after_launch_cmd": after_launch_cmd,
+        "before_launch_cmd": _redact.redact_launch_cmd(before_launch_cmd),
+        "after_launch_cmd": _redact.redact_launch_cmd(after_launch_cmd),
         "before_channels": before_channels,
         "after_channels": after_channels,
     }
@@ -95,9 +118,10 @@ def main() -> int:
     if reason:
         detail["reason"] = reason
     try:
-        detail["actions"] = json.loads(actions_json) if actions_json else []
+        actions = json.loads(actions_json) if actions_json else []
     except (TypeError, ValueError):
-        detail["actions"] = []
+        actions = []
+    detail["actions"] = _redact.redact_actions(actions)
 
     print(json.dumps(detail, ensure_ascii=True, sort_keys=True))
     return 0

--- a/lib/bridge-agent-update.sh
+++ b/lib/bridge-agent-update.sh
@@ -303,6 +303,14 @@ bridge_agent_update_emit_audit() {
 }
 
 # bridge_agent_update_emit_json — pretty-print the result envelope.
+#
+# Footgun #11 (KNOWN_ISSUES.md §26): the body used to be a
+# `python3 - … <<'PY' … PY` heredoc-stdin block. Issue #1023 also needs
+# this surface to redact credential-bearing launch-cmd env values, so
+# the body was extracted to lib/agent-cli-helpers/agent-update-result-json.py
+# (invoked file-as-argv) — the heredoc-stdin path is gone and the
+# redaction lives in the shared launch-cmd-redact module the helper
+# imports.
 bridge_agent_update_emit_json() {
   local agent="$1"
   local changed="$2"
@@ -316,7 +324,11 @@ bridge_agent_update_emit_json() {
   local actions_json="${10}"
 
   bridge_require_python
-  python3 - \
+  # #946 L1: stale-source guard before the python3 fork.
+  if ! bridge_resolve_script_dir_check; then
+    return 1
+  fi
+  python3 "$BRIDGE_SCRIPT_DIR/lib/agent-cli-helpers/agent-update-result-json.py" \
     "$agent" \
     "$changed" \
     "$dry_run" \
@@ -326,44 +338,5 @@ bridge_agent_update_emit_json() {
     "$after_channels" \
     "$before_sha" \
     "$after_sha" \
-    "$actions_json" <<'PY'
-import json
-import sys
-
-(
-    agent,
-    changed,
-    dry_run,
-    before_launch_cmd,
-    after_launch_cmd,
-    before_channels,
-    after_channels,
-    before_sha,
-    after_sha,
-    actions_json,
-) = sys.argv[1:]
-
-try:
-    actions = json.loads(actions_json) if actions_json else []
-except (TypeError, ValueError):
-    actions = []
-
-payload = {
-    "agent": agent,
-    "changed": changed == "1",
-    "dry_run": dry_run == "1",
-    "before": {
-        "launch_cmd": before_launch_cmd,
-        "channels": before_channels,
-    },
-    "after": {
-        "launch_cmd": after_launch_cmd,
-        "channels": after_channels,
-    },
-    "before_sha": before_sha,
-    "after_sha": after_sha,
-    "actions": actions,
-}
-print(json.dumps(payload, ensure_ascii=False, indent=2))
-PY
+    "$actions_json"
 }

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3047,6 +3047,60 @@ bridge_write_linux_agent_env_file() {
 
   bridge_reject_ephemeral_controller_env_for_agent_env
 
+  # Issue #1025: when the agent is linux-user isolated, the final env
+  # file lives under `$BRIDGE_AGENT_ROOT_V2/<agent>/runtime/` — a tree
+  # the isolation-v2 scaffold leaves `root:ab-agent-<name>` (per-agent
+  # root 2750, `runtime/` 2770). The controller IS added to the
+  # `ab-agent-<name>` group during prepare, but a `usermod -aG` does not
+  # refresh the *running* controller process's supplementary group set,
+  # so within the same `agent create --isolate` invocation the
+  # controller can neither `mkdir -p` nor `cat >` into that tree (no
+  # `other` bits, stale group). A plain write aborts the create with
+  # `Permission denied`, leaving a half-created agent.
+  #
+  # Stage the whole file build into a controller-owned tempfile, then
+  # hand the finished file off to the per-agent `runtime/` via sudo
+  # (`install`, which the rest of the v2 scaffold/handoff paths already
+  # rely on). The non-isolated path is unchanged: it builds directly at
+  # `$file` exactly as before. `_env_stage_target` is the path every
+  # `cat >`/`cat >>`/`printf >>`/`chmod` below writes to; `_env_final`
+  # is the real destination.
+  local _env_final="$file"
+  local _env_stage_target="$file"
+  local _env_isolated_write=0
+  # Only stage+install when the destination is genuinely under the
+  # agent-group-owned per-agent root. Callers that pass an explicit
+  # tempfile path (the idempotency probe in
+  # bridge_ensure_isolated_agent_env_current) write to a controller-
+  # writable location already and must keep the direct-write path.
+  if [[ "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]] \
+      && command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null \
+      && command -v bridge_linux_sudo_root >/dev/null 2>&1 \
+      && [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" \
+            && "$_env_final" == "$BRIDGE_AGENT_ROOT_V2/"* ]]; then
+    _env_isolated_write=1
+    _env_stage_target="$(mktemp "${TMPDIR:-/tmp}/agent-env.stage.XXXXXX")" \
+      || bridge_die "bridge_write_linux_agent_env_file: cannot stage temp env file for '$agent'"
+    # #771 symlink defense for the real destination: when staging, the
+    # `[[ -L "$file" ]]` check below only sees the fresh tempfile. The
+    # final `install` would still write through a symlink planted at
+    # `_env_final` by the isolated UID. Clear any symlink at the
+    # destination here (via sudo — the dir is agent-group-owned) so the
+    # install lands on a regular file.
+    if bridge_linux_sudo_root test -L "$_env_final" 2>/dev/null; then
+      bridge_linux_sudo_root rm -f "$_env_final" 2>/dev/null || true
+      if bridge_linux_sudo_root test -L "$_env_final" 2>/dev/null; then
+        rm -f "$_env_stage_target"
+        bridge_warn "bridge_write_linux_agent_env_file: refusing to write — symlink at $_env_final survived rm attempt. Investigate and remove manually before retry."
+        return 1
+      fi
+    fi
+  fi
+  # `file` is repurposed as the write target for the build below so the
+  # rest of the function body needs no edits; `_env_final` keeps the
+  # real destination for the sudo install at the end.
+  file="$_env_stage_target"
   mkdir -p "$(dirname "$file")"
   # Issue #771 v0.9.5 r2/r3 hardening (codex destructive-probe finding 1):
   # `runtime/agent-env.sh` lives inside `agents/<X>/runtime/` which is
@@ -3332,14 +3386,69 @@ EOF
       "$(printf '%q' "$BRIDGE_HOME/bin")" >>"$file"
   fi
   chmod 600 "$file"
+
+  # Issue #1025: when the build was staged into a controller-owned
+  # tempfile, hand the finished file off to its real destination under
+  # the per-agent `runtime/` via sudo in a SINGLE privileged `install`
+  # invocation that sets owner, group, and mode atomically. The
+  # isolation-v2 matrix contract for `agent-env-sh` is
+  # `controller:<agent_grp>` mode `0640` (lib/bridge-isolation-v2.sh
+  # `agent-env-sh` row). Doing the metadata in one `install -o -g -m`
+  # — rather than `install` then a separate sudo `chgrp`/`chmod` —
+  # closes a TOCTOU window: `runtime/` is isolated-UID-owned and
+  # group-writable (2770), so a live isolated agent could swap
+  # `agent-env.sh` for a symlink between a bare install and a
+  # follow-prone second metadata touch. With no second touch, the file
+  # lands at the correct owner/group/mode in one step and the v2
+  # chgrp/chmod block below is skipped for the staged path.
+  if [[ $_env_isolated_write -eq 1 ]]; then
+    local _env_install_owner _env_install_group
+    _env_install_owner="$(bridge_current_user 2>/dev/null || id -un 2>/dev/null || printf '')"
+    _env_install_group="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')"
+    if [[ -z "$_env_install_owner" || -z "$_env_install_group" ]]; then
+      rm -f "$_env_stage_target"
+      bridge_die "bridge_write_linux_agent_env_file: cannot resolve controller user / agent group for '$agent' — refusing to install env file without the v2 owner:group contract"
+    fi
+    # Ensure the parent `runtime/` exists via sudo (prepare normally
+    # created it 2770 already — this is an idempotent safety net and
+    # also the operation that gets past the stale-group traversal block
+    # that is the #1025 root cause). `mkdir -p` is not used with
+    # `install -D` because BSD `install` does not create parent dirs;
+    # an explicit sudo `mkdir -p` is portable and keeps the file
+    # creation a single atomic `install`.
+    bridge_linux_sudo_root mkdir -p "$(dirname "$_env_final")" \
+      || {
+        rm -f "$_env_stage_target"
+        bridge_die "bridge_write_linux_agent_env_file: sudo mkdir of runtime dir for '$_env_final' failed"
+      }
+    # Single privileged `install` lands the file with owner, group, and
+    # mode set atomically — the isolation-v2 `agent-env-sh` matrix
+    # contract is `controller:<agent_grp>` mode 0640. No separate
+    # post-install chgrp/chmod (that second touch would reopen a TOCTOU
+    # symlink window on the group-writable 2770 `runtime/` dir).
+    bridge_linux_sudo_root install \
+        -o "$_env_install_owner" -g "$_env_install_group" -m 0640 \
+        "$_env_stage_target" "$_env_final" \
+      || {
+        rm -f "$_env_stage_target"
+        bridge_die "bridge_write_linux_agent_env_file: sudo install of staged env file to '$_env_final' (owner=$_env_install_owner group=$_env_install_group mode=0640) failed"
+      }
+    rm -f "$_env_stage_target"
+    file="$_env_final"
+  fi
   # PR-E: in v2 mode, replace the named-user ACL grant pair with a
   # group-mode contract — chgrp ab-agent-<name> + chmod 0640. The agent
   # group has both the isolated UID (read) and the controller (read+
   # owner write) as members per PR-C, so 0640 covers both without ACL.
-  # Owner stays controller (the redirect just above set up that owner
-  # already; the stale-inode drop earlier in this function self-heals
-  # any prior chowned-to-os_user state).
-  if [[ "$isolation_mode" == "linux-user" \
+  # Skipped entirely for the staged-write path above (#1025): the single
+  # `install -o -g -m` already set owner:group:mode atomically, and a
+  # separate post-install chgrp/chmod would reopen a TOCTOU symlink
+  # window on the group-writable `runtime/` dir. This block remains the
+  # contract enforcer ONLY for the direct (non-staged) write path —
+  # e.g. macOS, or callers passing an explicit controller-writable
+  # tempfile destination.
+  if [[ $_env_isolated_write -eq 0 \
+        && "$isolation_mode" == "linux-user" \
         && -n "$os_user" \
         && "$(bridge_host_platform 2>/dev/null || printf '')" == "Linux" ]]; then
     local _v2_grp

--- a/lib/bridge-isolation-v2-reapply.sh
+++ b/lib/bridge-isolation-v2-reapply.sh
@@ -398,6 +398,31 @@ bridge_isolation_v2_reapply_one_agent() {
   # bridge_isolation_v2_chgrp_setgid_recursive remains the helper that
   # matrix apply ultimately calls (the matrix dispatcher uses the same
   # mutation primitive set).
+  # Issue #1021: shared plugin material must NEVER be re-grouped to this
+  # agent's private group by a per-agent reapply — doing so drops the
+  # `ab-shared` group / world-read contract and breaks every OTHER
+  # isolated agent that loads the same shared plugin source. Fence the
+  # shared plugin roots out of the recursive chgrp/chmod with absolute
+  # --exclude-path prunes. Two roots are covered: the v2 canonical
+  # shared plugins cache (`$BRIDGE_SHARED_ROOT/plugins-cache`) and the
+  # legacy install-rooted plugins dir (`$BRIDGE_HOME/plugins`). Both are
+  # passed even when not reachable inside `$agent_root/<sub>` — the
+  # prune is a harmless no-op when the path is not in the tree, and is
+  # the load-bearing guard when it IS (bind mount, real nested dir, or
+  # a symlinked `<sub>` that `find` follows from the command line).
+  local -a _shared_plugin_excl=()
+  local _shared_plugins_cache=""
+  if command -v bridge_isolation_v2_shared_plugins_root >/dev/null 2>&1; then
+    _shared_plugins_cache="$(bridge_isolation_v2_shared_plugins_root 2>/dev/null || true)"
+  fi
+  if [[ -z "$_shared_plugins_cache" && -n "${BRIDGE_SHARED_ROOT:-}" ]]; then
+    _shared_plugins_cache="$BRIDGE_SHARED_ROOT/plugins-cache"
+  fi
+  [[ -n "$_shared_plugins_cache" ]] \
+    && _shared_plugin_excl+=(--exclude-path "$_shared_plugins_cache")
+  [[ -n "${BRIDGE_HOME:-}" ]] \
+    && _shared_plugin_excl+=(--exclude-path "$BRIDGE_HOME/plugins")
+
   local _writable_sub
   for _writable_sub in home workdir runtime logs requests responses; do
     [[ -d "$agent_root/$_writable_sub" ]] || continue
@@ -412,7 +437,8 @@ bridge_isolation_v2_reapply_one_agent() {
       fi
       if bridge_isolation_v2_chgrp_setgid_recursive \
             "$agent_grp" 2770 0660 "$agent_root/$_writable_sub" \
-            "${_ws_excl[@]}" 2>/dev/null; then
+            "${_ws_excl[@]}" \
+            "${_shared_plugin_excl[@]}" 2>/dev/null; then
         bridge_isolation_v2_reapply_record_action \
           "$actions_file" "$agent_root/$_writable_sub" \
           "chgrp_chmod_recursive" "drift|unknown" "$agent_grp 2770/0660" "ok"

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -728,7 +728,19 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
   # subdirs are pruned from all find passes; the dir nodes themselves are
   # still chgrp/chmod'd (v3 channel state dirs stay 2770/agent-group while
   # their files remain isolated-UID 0600).
+  #
+  # Optional --exclude-path <abs-path> args (#1021): an ABSOLUTE path
+  # whose whole subtree — the node itself AND its contents — is pruned
+  # from every find pass. Unlike --exclude-subdir (a leaf name relative
+  # to $root), --exclude-path takes a fully-qualified path so a caller
+  # can fence off a shared tree (e.g. the shared plugins cache) that
+  # might be reachable inside $root via a bind mount, a real nested
+  # directory, or — when $root itself is a symlink that `find` follows
+  # from the command line — a sibling subtree. This guarantees the
+  # recursive chgrp/chmod can never re-group shared plugin material to
+  # the per-agent group and break other isolated agents.
   local -a _excl_names=()
+  local -a _excl_paths=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --exclude-subdir)
@@ -737,6 +749,14 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
           return 1
         }
         _excl_names+=("$2"); shift 2
+        ;;
+      --exclude-path)
+        [[ $# -ge 2 ]] || {
+          bridge_warn "chgrp_setgid_recursive: --exclude-path requires a value"
+          return 1
+        }
+        [[ -n "$2" ]] && _excl_paths+=("$2")
+        shift 2
         ;;
       *) bridge_warn "chgrp_setgid_recursive: unknown option: $1"; return 1 ;;
     esac
@@ -748,10 +768,23 @@ bridge_isolation_v2_chgrp_setgid_recursive() {
   for _fp_n in "${_excl_names[@]}"; do
     _find_prune+=('-path' "$root/$_fp_n/*" '-prune' '-o')
   done
+  # --exclude-path prunes the matched node AND everything beneath it:
+  # `-path "$abs" -prune -o -path "$abs/*" -prune -o`. The bare `-path
+  # "$abs"` prune covers the node itself so it is neither chgrp'd nor
+  # chmod'd; the `/*` prune covers its contents.
+  local _fp_p
+  for _fp_p in "${_excl_paths[@]}"; do
+    _find_prune+=('-path' "$_fp_p" '-prune' '-o'
+                  '-path' "$_fp_p/*" '-prune' '-o')
+  done
   local -a _excl_args=()
   local _ea_n
   for _ea_n in "${_excl_names[@]}"; do
     _excl_args+=('--exclude-subdir' "$_ea_n")
+  done
+  local _ea_p
+  for _ea_p in "${_excl_paths[@]}"; do
+    _excl_args+=('--exclude-path' "$_ea_p")
   done
   # Platform discriminator gate (S5 Track A1, extending S3 pattern):
   # recursive chgrp + setgid bit only has a security model on hosts
@@ -865,9 +898,11 @@ bridge_isolation_v2_verify_chgrp_setgid_recursive() {
   }
   [[ -d "$root" ]] || return 0  # nothing to verify
   local -a _excl_names=()
+  local -a _excl_paths=()
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --exclude-subdir) _excl_names+=("$2"); shift 2 ;;
+      --exclude-path) [[ -n "${2:-}" ]] && _excl_paths+=("$2"); shift 2 ;;
       *) shift ;;
     esac
   done
@@ -875,6 +910,14 @@ bridge_isolation_v2_verify_chgrp_setgid_recursive() {
   local _fp_n
   for _fp_n in "${_excl_names[@]}"; do
     _find_prune+=('-path' "$root/$_fp_n/*" '-prune' '-o')
+  done
+  # #1021: prune --exclude-path subtrees from the verify scan too, so a
+  # deliberately-excluded shared tree (left at its shared group on
+  # purpose) does not register as a verify mismatch.
+  local _fp_p
+  for _fp_p in "${_excl_paths[@]}"; do
+    _find_prune+=('-path' "$_fp_p" '-prune' '-o'
+                  '-path' "$_fp_p/*" '-prune' '-o')
   done
 
   # Normalize expected modes to %04o so `stat` output ("2770", "660")

--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -69,7 +69,12 @@ When a Teams user attaches a file or image, the plugin downloads each attachment
 <TEAMS_STATE_DIR>/attachments/<message_id>/<filename>
 ```
 
-(directory mode 0700, file mode 0600). The Claude channel notification meta gains an `attachments` array with `name`, `content_type`, `download_status` (`ok` / `skipped_non_file` / `failed`), and — on success — `local_path` and `size_bytes`. Cards (`application/vnd.microsoft.card.*` and `application/vnd.microsoft.teams.card.*`) are recorded with `skipped_non_file` so the agent still sees the metadata.
+(directory mode 0700, file mode 0600). Attachment metadata is exposed in two shapes:
+
+- **Direct Claude channel notification** (`notifications/claude/channel`) — meta is kept **flat and string-only**: scalar `attachment_count` and `attachment_names` fields. It does **not** carry a nested `attachments` array. The flat shape is what keeps the direct channel notification reliable (see #1022).
+- **Bridge queue / audit / replay body** — retains the rich nested `attachments` array, each entry with `name`, `content_type`, `download_status` (`ok` / `skipped_non_file` / `failed`), and — on success — `local_path` and `size_bytes`.
+
+Cards (`application/vnd.microsoft.card.*` and `application/vnd.microsoft.teams.card.*`) are recorded with `skipped_non_file` so the agent still sees the metadata.
 
 Downloaded content types:
 

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -928,11 +928,10 @@ function runPromptGuard(command: 'scan' | 'sanitize', text: string): Record<stri
 }
 
 /**
- * Build the channel meta object used by BOTH the `notifications/claude/channel`
- * notification AND the bridge-mode queue task body. Centralizing here keeps
- * the two delivery paths from drifting (PR #961 r1 found bridge body was
- * missing conversation_id / tenant_id / service_url / attachment_count that
- * the channel notification carries).
+ * Build the rich Teams metadata used by bridge-mode queue task bodies and
+ * local replay/audit paths. Keep notifications/claude/channel on the scalar
+ * projection below: Claude Code channel delivery has silently dropped some
+ * notifications when nested arrays/objects are present in params.meta.
  */
 function buildChannelMeta(
   activity: Activity,
@@ -966,6 +965,54 @@ function buildChannelMeta(
         }
       : {}),
   }
+}
+
+function compactMetaList(values: Array<string | undefined>): string {
+  const cleaned = values
+    .map(value => String(value ?? '').trim())
+    .filter(value => value.length > 0)
+  return cleaned.join(', ').slice(0, 1000)
+}
+
+/**
+ * Claude channel notification metadata must stay flat and string-only. Rich
+ * attachment details remain available in buildChannelMeta for bridge-mode and
+ * fetch/replay flows; this projection keeps direct channel injection from
+ * depending on nested JSON support in Claude Code's notification handler.
+ */
+function buildChannelNotificationMeta(
+  activity: Activity,
+  stored: StoredMessage,
+  attachments: StoredAttachment[],
+): Record<string, string> {
+  const meta: Record<string, string> = {
+    source: 'teams',
+    chat_id: stored.chat_id,
+    conversation_id: stored.chat_id,
+    message_id: stored.message_id,
+    user: stored.user,
+    user_id: stored.user_id,
+    aad_object_id: stored.aad_object_id,
+    tenant_id: String((activity.channelData as any)?.tenant?.id ?? TENANT_ID),
+    service_url: String(activity.serviceUrl ?? ''),
+    text: stored.text,
+    ts: stored.ts,
+  }
+  if (stored.revision) meta.revision = stored.revision
+  if (attachments.length > 0) {
+    meta.attachment_count = String(attachments.length)
+    const names = compactMetaList(attachments.map(att => att.name))
+    const contentTypes = compactMetaList(attachments.map(att => att.content_type))
+    const downloadStatuses = compactMetaList(attachments.map(att => att.download_status))
+    const localPaths = compactMetaList(attachments.map(att => att.local_path))
+    const downloadErrors = compactMetaList(attachments.map(att => att.download_error))
+    if (names) meta.attachment_names = names
+    if (contentTypes) meta.attachment_content_types = contentTypes
+    if (downloadStatuses) meta.attachment_download_statuses = downloadStatuses
+    if (localPaths) meta.attachment_local_paths = localPaths
+    if (downloadErrors) meta.attachment_download_errors = downloadErrors
+  }
+  return meta
 }
 
 /**
@@ -1823,7 +1870,7 @@ async function handleActivity(context: TurnContext): Promise<void> {
         method: 'notifications/claude/channel',
         params: {
           content: text || (attachments.length > 0 ? '(attachment)' : ''),
-          meta: buildChannelMeta(activity, stored, attachments),
+          meta: buildChannelNotificationMeta(activity, stored, attachments),
         },
       })
       channelDelivered = true
@@ -2019,9 +2066,15 @@ if (CLI_SUBCOMMAND === 'send-managed') {
 // `_smoke-record-activity` invokes writeTeamsActivityIndex directly so the
 // smoke can validate the activity-index file schema without spinning up a
 // full Bot Framework adapter. `_smoke-should-record` reports whether a
-// synthesized activity would be skipped by the bot-self filter. Both
+// synthesized activity would be skipped by the bot-self filter.
+// `_smoke-channel-meta` asserts the direct Claude channel notification uses
+// scalar metadata, not the richer bridge queue payload. All smoke commands
 // short-circuit before httpServer.listen.
-if (CLI_SUBCOMMAND === '_smoke-record-activity' || CLI_SUBCOMMAND === '_smoke-should-record') {
+if (
+  CLI_SUBCOMMAND === '_smoke-record-activity'
+  || CLI_SUBCOMMAND === '_smoke-should-record'
+  || CLI_SUBCOMMAND === '_smoke-channel-meta'
+) {
   const argv = process.argv.slice(3)
   const flags: Record<string, string> = {}
   for (let i = 0; i < argv.length; i++) {
@@ -2043,6 +2096,32 @@ if (CLI_SUBCOMMAND === '_smoke-record-activity' || CLI_SUBCOMMAND === '_smoke-sh
       process.exit(2)
     }
     writeTeamsActivityIndex(agent, channelId, messageId, userId, new Date(tsMs))
+    process.exit(0)
+  }
+  if (CLI_SUBCOMMAND === '_smoke-channel-meta') {
+    const fakeActivity: any = {
+      channelData: { tenant: { id: 'tenant-smoke' } },
+      serviceUrl: 'https://example.invalid/teams',
+    }
+    const stored: StoredMessage = {
+      chat_id: 'chat-smoke',
+      message_id: 'message-smoke',
+      user: 'Smoke User',
+      user_id: 'user-smoke',
+      aad_object_id: 'aad-smoke',
+      text: 'hello smoke',
+      ts: '2026-01-01T00:00:00.000Z',
+      revision: 'revision-smoke',
+    }
+    const attachments: StoredAttachment[] = [
+      {
+        attachment_id: 'attachment-smoke',
+        name: 'smoke.html',
+        content_type: 'text/html',
+        download_status: 'skipped_non_file',
+      },
+    ]
+    process.stdout.write(JSON.stringify(buildChannelNotificationMeta(fakeActivity, stored, attachments)) + '\n')
     process.exit(0)
   }
   // _smoke-should-record

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
 }
 
 add_all_integration() {
@@ -276,7 +276,13 @@ select_for_path() {
       # --json / plain text / dry-run). Pull the redaction smoke
       # whenever bridge-agent.sh or lib/bridge-agent-update.sh moves so
       # a future PR cannot regress a secret-leak surface.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap
+      # Issue #1028: bridge-start.sh's workdir-existence decision is
+      # privilege-aware for linux-user isolated agents (sudo-backed
+      # `test -d` instead of a plain controller `[[ -d ]]` that
+      # false-negates on the 0750 isolated agent root). Pull its unit
+      # smoke whenever bridge-start.sh moves so a future PR cannot
+      # regress the privilege-aware probe back to the plain check.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1028-isolated-workdir-check
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
 }
 
 add_all_integration() {
@@ -270,7 +270,13 @@ select_for_path() {
       # Issue #1010: bridge-agent.sh::run_delete now calls the isolated-
       # agent OS-user reap helper; cover its gating-decision smoke so a
       # regression in the delete-path wire-up is caught.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap
+      # Issue #1023: the typed `agent update --launch-cmd-*` path now
+      # redacts credential-bearing env values across every output
+      # surface (diff / operation_summary / actions / audit detail /
+      # --json / plain text / dry-run). Pull the redaction smoke
+      # whenever bridge-agent.sh or lib/bridge-agent-update.sh moves so
+      # a future PR cannot regress a secret-leak surface.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -457,7 +463,11 @@ select_for_path() {
       # `bridge_agent_launch_cmd` path. Any modification to these helpers
       # must re-run the Wave C regression smoke that asserts the call
       # returns in <2s.
-      add_required 835-static-admin-launch launch launch-dev-channels-injection channel-env-readiness
+      # Issue #1023: scripts/python-helpers/launch-cmd-redact.py is the
+      # shared secret-redaction surface every `agent update --launch-cmd-*`
+      # output path routes through; pull its regression smoke whenever
+      # any launch-cmd helper moves.
+      add_required 835-static-admin-launch launch launch-dev-channels-injection channel-env-readiness agent-update-launch-cmd-redaction
       add_integration integration-minimal
       ;;
 
@@ -514,6 +524,15 @@ select_for_path() {
       # COMMON-INSTRUCTIONS.local.md override; pin the no-op-when-absent
       # contract so a bridge-docs.py move can't regress it.
       add_required common-instructions-local-override
+      add_integration integration-minimal
+      ;;
+
+    lib/agent-cli-helpers/audit-detail-json.py|lib/agent-cli-helpers/agent-update-result-json.py)
+      # Issue #1023: these helpers render the `agent update` audit
+      # detail and the --json result envelope; both route launch-cmd
+      # values through the shared launch-cmd-redact module. Pull the
+      # redaction regression smoke whenever either renderer moves.
+      add_required agent-update agent-update-launch-cmd-redaction
       add_integration integration-minimal
       ;;
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
 }
 
 add_all_integration() {
@@ -334,7 +334,17 @@ select_for_path() {
       # (isolated-agent OS-user + traversal-ACE reaper) lives in
       # lib/bridge-isolation-v2.sh; pull its gating-decision smoke for
       # every isolation-lib move.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions launch isolated-agent-delete-reap
+      # Issue #1021: bridge_isolation_v2_chgrp_setgid_recursive's
+      # --exclude-path prune (lib/bridge-isolation-v2.sh) and the
+      # reapply caller's shared-plugin fence (lib/bridge-isolation-v2-
+      # reapply.sh) keep a per-agent apply from re-grouping shared
+      # plugin material; pull its regression smoke for every
+      # isolation-lib move.
+      # Issue #1025: the isolated-create env-file install asserts the
+      # `agent-env-sh` matrix contract (controller:<agent_grp> 0640)
+      # defined in lib/bridge-isolation-v2.sh; pull its smoke on every
+      # isolation-lib move so a matrix-row change re-checks the writer.
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install launch isolated-agent-delete-reap
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/python-helpers/launch-cmd-redact.py
+++ b/scripts/python-helpers/launch-cmd-redact.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""launch-cmd-redact.py — single shared redaction surface for the
+`agent-bridge agent update --launch-cmd-*` output path (issue #1023).
+
+`agent update` echoes the full `before_launch_cmd` / `after_launch_cmd`
+values, the operation summary, the recorded `add-env` actions, the audit
+detail, the `--json` envelope, and the plain-text result. A launch
+command's leading env-prefix routinely carries credential-bearing values
+(OAuth / MS365 client secrets, bearer tokens, session cookies). Echoing
+the raw value leaks the secret into terminal output, logs, transcripts,
+and task reports.
+
+This module is the ONE place the sensitive-key pattern set lives. Every
+surface that renders a launch command or a launch-cmd op routes through
+it so no surface is missed. It redacts the **value only** and keeps the
+env **key name** visible — `MS365_CLIENT_SECRET=supersecret` becomes
+`MS365_CLIENT_SECRET=***REDACTED***`. It is an output-rendering
+transform only: the stored/applied launch command is never mutated.
+
+Importable API:
+    redact_launch_cmd(value)     -> str
+    redact_action(action)        -> str
+    redact_actions(actions)      -> list[str]
+    redact_launch_ops(ops_tsv)   -> str
+    is_sensitive_key(key)        -> bool
+
+CLI (file-as-argv, no heredoc-stdin — footgun #11 / KNOWN_ISSUES.md §26):
+    launch-cmd-redact.py launch-cmd  <value>
+    launch-cmd-redact.py action      <action>
+    launch-cmd-redact.py launch-ops  <tsv-op-stream>
+Each prints the redacted form on stdout.
+"""
+
+import re
+import sys
+
+REDACTED = "***REDACTED***"
+
+# Codex r1 pattern set: a key is sensitive if it contains any of these
+# substrings, case-insensitively. Covers the issue's explicit list
+# (SECRET / TOKEN / PASSWORD / KEY / CLIENT_SECRET / ACCESS_TOKEN /
+# REFRESH_TOKEN — the latter three are caught by SECRET / TOKEN) plus
+# the common launch-env secret names AUTHORIZATION / BEARER / COOKIE /
+# SESSION / JWT, so `AUTHORIZATION=Bearer ...` and `SESSION_COOKIE=...`
+# also redact.
+_SENSITIVE_SUBSTRINGS = (
+    "SECRET",
+    "TOKEN",
+    "PASSWORD",
+    "KEY",
+    "CREDENTIAL",
+    "AUTH",
+    "AUTHORIZATION",
+    "BEARER",
+    "COOKIE",
+    "SESSION",
+    "JWT",
+)
+
+# A leading env-prefix token: KEY=VALUE where KEY is a shell-style
+# identifier. Mirrors agent-update-apply-launch-cmd.py's env_re so the
+# env/argv boundary is identified identically.
+_ENV_TOKEN_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)=(.*)$", re.DOTALL)
+
+
+def is_sensitive_key(key: str) -> bool:
+    """True if the env key name matches any sensitive substring."""
+    upper = key.upper()
+    return any(sub in upper for sub in _SENSITIVE_SUBSTRINGS)
+
+
+def _redact_env_token(token: str) -> str:
+    """Redact one ``KEY=VALUE`` token if KEY is sensitive; else verbatim.
+
+    A token without ``=`` or with a non-identifier key is returned
+    unchanged — only matched env assignments are touched.
+    """
+    m = _ENV_TOKEN_RE.match(token)
+    if not m:
+        return token
+    key, value = m.group(1), m.group(2)
+    if not is_sensitive_key(key):
+        return token
+    if value == "":
+        # Nothing to leak; leave an empty assignment untouched.
+        return token
+    return f"{key}={REDACTED}"
+
+
+def redact_launch_cmd(value: str) -> str:
+    """Redact sensitive env values in a launch command string.
+
+    Only the leading run of ``KEY=VALUE`` env-prefix tokens is
+    considered — once a non-env token is seen, the rest is argv and is
+    left verbatim (matches the env/argv split in
+    agent-update-apply-launch-cmd.py). Whitespace runs are collapsed to
+    single spaces, consistent with the applier's reassembly.
+    """
+    if not value:
+        return value
+    tokens = value.split()
+    out: list[str] = []
+    in_env_prefix = True
+    env_re = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+    for tok in tokens:
+        if in_env_prefix and not tok.startswith("-") and env_re.match(tok):
+            out.append(_redact_env_token(tok))
+        else:
+            in_env_prefix = False
+            out.append(tok)
+    return " ".join(out)
+
+
+def redact_action(action: str) -> str:
+    """Redact a recorded launch-cmd action string.
+
+    The only action that embeds a value is ``add-env KEY=VALUE``
+    (agent-update-apply-launch-cmd.py). ``remove-env KEY`` /
+    ``set-launch-cmd`` / dev-channel actions carry no env value, except
+    ``set-launch-cmd`` whose payload is not part of the action string.
+    """
+    prefix = "add-env "
+    if action.startswith(prefix):
+        return prefix + _redact_env_token(action[len(prefix):])
+    return action
+
+
+def redact_actions(actions: list) -> list:
+    """Redact every action string in an actions array."""
+    return [
+        redact_action(a) if isinstance(a, str) else a
+        for a in actions
+    ]
+
+
+def redact_launch_ops(ops_tsv: str) -> str:
+    """Redact a TAB-separated launch-cmd op stream, structured.
+
+    Input is the raw ``op<TAB>payload`` newline-delimited stream
+    bridge-agent.sh accumulates via ``add_launch_cmd_op``. Redaction
+    happens HERE — while each op and its full payload are still
+    discrete structured entries — so a value containing a comma (a
+    valid ``--launch-cmd-add-env KEY=v1,v2`` input) is never confused
+    with an op delimiter.
+
+    Output: one ``launch:<op>=<payload>`` line per op — the redacted
+    form bridge-agent.sh then flattens (``tr '\\n' ','``) into the
+    comma-joined operation summary.
+
+    Two op payloads embed a secret-bearing env VALUE and are redacted:
+      - ``add-env``        — payload is ``KEY=VALUE``; redact the value.
+      - ``set-launch-cmd`` — payload is a FULL launch command, whose
+        leading env-prefix can carry secrets; redact it the same way
+        before/after_launch_cmd is redacted (issue #1023 codex r2
+        BLOCKING — set-launch-cmd was passed through verbatim and the
+        raw value reached the audit ``operation`` field).
+    The remaining ops carry no env value and pass through verbatim:
+      - ``remove-env``     — payload is a bare KEY (validated key-only).
+      - ``add-dev-channel`` / ``remove-dev-channel`` — payload is a
+        channel spec (``plugin:foo@m`` / ``server:teams``), not env.
+
+    Redacting AFTER the comma-join is unsound — the join is lossy: a
+    comma inside a value is indistinguishable from an op delimiter, so
+    a post-join ``split(',')`` strands the value's suffix as a bare
+    non-``KEY=`` token that escapes redaction (issue #1023 codex r1
+    BLOCKING). Operating on the structured op closes that bypass.
+    """
+    out: list[str] = []
+    for line in ops_tsv.split("\n"):
+        if not line:
+            continue
+        parts = line.split("\t", 1)
+        op = parts[0]
+        payload = parts[1] if len(parts) == 2 else ""
+        if op == "add-env":
+            payload = _redact_env_token(payload)
+        elif op == "set-launch-cmd":
+            payload = redact_launch_cmd(payload)
+        out.append(f"launch:{op}={payload}")
+    return "\n".join(out)
+
+
+def _main(argv: list) -> int:
+    if len(argv) != 3:
+        print(
+            "usage: launch-cmd-redact.py "
+            "<launch-cmd|action|launch-ops> <value>",
+            file=sys.stderr,
+        )
+        return 2
+    mode, value = argv[1], argv[2]
+    if mode == "launch-cmd":
+        print(redact_launch_cmd(value))
+    elif mode == "action":
+        print(redact_action(value))
+    elif mode == "launch-ops":
+        print(redact_launch_ops(value))
+    else:
+        print(f"launch-cmd-redact.py: unknown mode: {mode}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main(sys.argv))

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6152,6 +6152,8 @@ PY
   assert_not_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "agent-bridge urgent"
   assert_not_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "spawnSync(agb, ['urgent'"
   assert_contains "$(cat "$REPO_ROOT/plugins/teams/server.ts")" "ignoring deprecated TEAMS_BRIDGE_MODE"
+  TEAMS_CHANNEL_META_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && TEAMS_STATE_DIR="$BRIDGE_AGENT_HOME_ROOT/$CREATED_AGENT/.teams" bun server.ts _smoke-channel-meta)"
+  python3 "$REPO_ROOT/scripts/smoke/teams-channel-meta-assert.py" "$TEAMS_CHANNEL_META_OUTPUT"
   TEAMS_DEDUPE_OUTPUT="$(cd "$REPO_ROOT/plugins/teams" && bun -e 'import { createRecentMessageDeduper } from "./dedupe.ts"; const dedupe = createRecentMessageDeduper(2); console.log(JSON.stringify([dedupe.seen("1775901127484"), dedupe.seen("1775901127484"), dedupe.seen("1775901127485"), dedupe.seen("1775901127486"), dedupe.seen("1775901127484")]))')"
   assert_contains "$TEAMS_DEDUPE_OUTPUT" "[false,true,false,false,false]"
   # Round-2: channel-failure path — forget() must roll back the dedupe entry

--- a/scripts/smoke/1021-isolation-v2-shared-plugin-perms.sh
+++ b/scripts/smoke/1021-isolation-v2-shared-plugin-perms.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# Issue #1021 regression smoke — isolation-v2 apply must not mutate shared
+# plugin material.
+#
+# Bug: `bridge_isolation_v2_chgrp_setgid_recursive` (driven by the
+# isolation-v2 reapply path at lib/bridge-isolation-v2-reapply.sh:401-435)
+# recursively chgrp/chmod's an isolated agent's writable subtrees. When a
+# shared plugin dependency tree (e.g. `plugins/teams/node_modules`) is
+# reachable inside that subtree, the recursive pass re-grouped it to the
+# target agent's private `ab-agent-<name>` group and dropped world/group
+# read — which broke every OTHER isolated agent that loads the same
+# shared plugin source.
+#
+# Fix: the helper learned `--exclude-path <abs-path>` and the reapply
+# caller fences the shared plugin roots out of the recursion.
+#
+# Two-agent shared-plugin fixture (codex r1 acceptance):
+#   - a shared plugin `node_modules` tree both agents reference,
+#   - isolated agent A whose writable subtree reaches the shared tree,
+#   - run the recursive apply for agent A with the shared-tree exclusion,
+#   - assert the shared tree's group + mode are UNCHANGED,
+#   - assert the agent's own tree WAS re-grouped/re-moded,
+#   - assert a second isolated agent B can still read the shared file.
+#
+# Observability: the helper's chgrp/chmod runs rootless against the
+# caller's own files; mode is the deterministic signal here (group on a
+# rootless host can only be the caller's groups). The exclude-path prune
+# is verified by the shared tree keeping its pre-apply mode while the
+# agent tree flips to the v2 contract mode.
+#
+# Footgun #11 (Bash 5.3.9 heredoc-class deadlock): all driver bodies are
+# emitted via printf-to-file — no heredocs, no here-strings.
+
+set -uo pipefail
+
+SMOKE_NAME="1021-isolation-v2-shared-plugin-perms"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# --- Fixture ---------------------------------------------------------
+# Layout:
+#   $FIX/agent-A-workdir/                  agent A's recursive-repair root
+#     plugins/teams/node_modules/debug/    SHARED plugin tree (must not move)
+#       package.json
+#     own/agent-private.txt                agent A's own file (must move)
+#   $FIX/agent-B-marker/can-read           agent B read-probe target
+FIX="$SMOKE_TMP_ROOT/fixture"
+SHARED_PLUGINS="$FIX/agent-A-workdir/plugins"
+SHARED_NM="$SHARED_PLUGINS/teams/node_modules/debug"
+AGENT_OWN="$FIX/agent-A-workdir/own"
+mkdir -p "$SHARED_NM" "$AGENT_OWN"
+
+SHARED_FILE="$SHARED_NM/package.json"
+AGENT_FILE="$AGENT_OWN/agent-private.txt"
+printf '{"name":"debug"}\n' >"$SHARED_FILE"
+printf 'agent A private state\n' >"$AGENT_FILE"
+
+# Pre-apply baseline: shared material is world/group-readable (0644 files,
+# 0755 dirs) — the `ab-shared` contract. The agent-private file starts at
+# the same baseline so the only thing that can change it is the apply.
+chmod 0755 "$SHARED_PLUGINS" "$SHARED_PLUGINS/teams" \
+  "$SHARED_PLUGINS/teams/node_modules" "$SHARED_NM"
+chmod 0644 "$SHARED_FILE"
+chmod 0755 "$AGENT_OWN"
+chmod 0644 "$AGENT_FILE"
+
+SHARED_FILE_MODE_BEFORE="$(stat -c '%a' "$SHARED_FILE" 2>/dev/null || stat -f '%Lp' "$SHARED_FILE")"
+SHARED_DIR_MODE_BEFORE="$(stat -c '%a' "$SHARED_NM" 2>/dev/null || stat -f '%Lp' "$SHARED_NM")"
+
+# --- Driver: run the recursive helper with --exclude-path -------------
+DRIVER="$SMOKE_TMP_ROOT/driver.sh"
+OUT="$SMOKE_TMP_ROOT/driver.out"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -uo pipefail'
+  printf 'cd %q\n' "$REPO_ROOT"
+  # Force isolation enforcement so the helper actually runs on a macOS
+  # dev host (bridge_isolation_v2_enforce returns 1 on non-Linux without
+  # this, and the helper would early-return 0 as a no-op).
+  printf '%s\n' 'export BRIDGE_ISOLATION_REQUIRED=yes'
+  printf '%s\n' 'export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=yes'
+  printf '%s\n' 'bridge_warn() { printf "[stub_warn] %s\n" "$*" >&2; }'
+  printf '%s\n' 'bridge_die() { printf "[stub_die] %s\n" "$*" >&2; exit 1; }'
+  printf '%s\n' 'source "$0_REPO_ROOT/lib/bridge-isolation-v2.sh" 2>&1'
+  # The agent's recursive-repair root is its workdir. The shared plugin
+  # tree lives inside it (the #1021 vector). Without --exclude-path the
+  # recursion would re-group/re-mode the shared tree; with it, the
+  # shared tree must be left untouched.
+  printf 'AGENT_WORKDIR=%q\n' "$FIX/agent-A-workdir"
+  printf 'SHARED_PLUGINS=%q\n' "$SHARED_PLUGINS"
+  printf '%s\n' 'CALLER_GROUP="$(id -gn)"'
+  printf '%s\n' 'if bridge_isolation_v2_chgrp_setgid_recursive "$CALLER_GROUP" 2770 0660 "$AGENT_WORKDIR" --exclude-path "$SHARED_PLUGINS"; then echo "HELPER_RC=0"; else echo "HELPER_RC=$?"; fi'
+} | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$DRIVER"
+chmod +x "$DRIVER"
+"$BRIDGE_BASH" "$DRIVER" >"$OUT" 2>&1 || true
+rm -f "$DRIVER"
+
+grep -q '^HELPER_RC=0$' "$OUT" || {
+  cat "$OUT"
+  smoke_fail "recursive helper returned non-zero with --exclude-path"
+}
+smoke_log "helper ran rc=0 with --exclude-path"
+
+# --- Assertion 1: shared plugin tree is UNCHANGED ---------------------
+SHARED_FILE_MODE_AFTER="$(stat -c '%a' "$SHARED_FILE" 2>/dev/null || stat -f '%Lp' "$SHARED_FILE")"
+SHARED_DIR_MODE_AFTER="$(stat -c '%a' "$SHARED_NM" 2>/dev/null || stat -f '%Lp' "$SHARED_NM")"
+
+if [[ "$SHARED_FILE_MODE_AFTER" != "$SHARED_FILE_MODE_BEFORE" ]]; then
+  cat "$OUT"
+  smoke_fail "shared plugin file mode changed ($SHARED_FILE_MODE_BEFORE -> $SHARED_FILE_MODE_AFTER) — apply recursed into shared material"
+fi
+if [[ "$SHARED_DIR_MODE_AFTER" != "$SHARED_DIR_MODE_BEFORE" ]]; then
+  cat "$OUT"
+  smoke_fail "shared plugin dir mode changed ($SHARED_DIR_MODE_BEFORE -> $SHARED_DIR_MODE_AFTER) — apply recursed into shared material"
+fi
+smoke_log "shared plugin node_modules tree left untouched (file=$SHARED_FILE_MODE_AFTER dir=$SHARED_DIR_MODE_AFTER)"
+
+# --- Assertion 2: the agent's own tree WAS re-moded -------------------
+# The v2 file contract chmod is exec-aware symbolic (g+rwX,o-rwx); a
+# plain-text file at 0644 lands at 0660 (group write, no other bits).
+AGENT_FILE_MODE_AFTER="$(stat -c '%a' "$AGENT_FILE" 2>/dev/null || stat -f '%Lp' "$AGENT_FILE")"
+if [[ "$AGENT_FILE_MODE_AFTER" == "644" ]]; then
+  cat "$OUT"
+  smoke_fail "agent-private file mode unchanged ($AGENT_FILE_MODE_AFTER) — recursive apply did not run on the agent tree (exclude-path over-pruned)"
+fi
+case "$AGENT_FILE_MODE_AFTER" in
+  660|*60)
+    smoke_log "agent's own file was re-moded by the apply ($AGENT_FILE_MODE_AFTER)"
+    ;;
+  *)
+    cat "$OUT"
+    smoke_fail "agent-private file unexpected mode after apply: $AGENT_FILE_MODE_AFTER (expected v2 contract g+rw, o-rwx)"
+    ;;
+esac
+
+# --- Assertion 3: a second agent can still read the shared file -------
+# Agent B is modeled by the world/group-read contract surviving on the
+# shared tree. On a rootless host the strongest portable check is that
+# the shared file is still readable (its mode kept the read bits a
+# different-UID process needs). Assert the `other` read bit is intact.
+case "$SHARED_FILE_MODE_AFTER" in
+  *4|*5|*6|*7)
+    smoke_log "agent B read contract intact — shared file keeps other-read ($SHARED_FILE_MODE_AFTER)"
+    ;;
+  *)
+    cat "$OUT"
+    smoke_fail "shared file lost the other-read bit ($SHARED_FILE_MODE_AFTER) — agent B can no longer load shared plugin material"
+  ;;
+esac
+test -r "$SHARED_FILE" || smoke_fail "shared plugin file is not readable after apply"
+
+# --- Assertion 4: control — without --exclude-path the shared tree IS
+# mutated (proves the smoke actually exercises the prune, not a no-op).
+CTRL_FIX="$SMOKE_TMP_ROOT/control"
+CTRL_NM="$CTRL_FIX/workdir/plugins/teams/node_modules/debug"
+mkdir -p "$CTRL_NM"
+CTRL_SHARED_FILE="$CTRL_NM/package.json"
+printf '{"name":"debug"}\n' >"$CTRL_SHARED_FILE"
+chmod 0644 "$CTRL_SHARED_FILE"
+
+CTRL_DRIVER="$SMOKE_TMP_ROOT/ctrl-driver.sh"
+CTRL_OUT="$SMOKE_TMP_ROOT/ctrl-driver.out"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -uo pipefail'
+  printf 'cd %q\n' "$REPO_ROOT"
+  printf '%s\n' 'export BRIDGE_ISOLATION_REQUIRED=yes'
+  printf '%s\n' 'export _BRIDGE_ISOLATION_PRIMITIVES_READY_CACHED=yes'
+  printf '%s\n' 'bridge_warn() { printf "[stub_warn] %s\n" "$*" >&2; }'
+  printf '%s\n' 'bridge_die() { printf "[stub_die] %s\n" "$*" >&2; exit 1; }'
+  printf '%s\n' 'source "$0_REPO_ROOT/lib/bridge-isolation-v2.sh" 2>&1'
+  printf 'CTRL_WORKDIR=%q\n' "$CTRL_FIX/workdir"
+  printf '%s\n' 'CALLER_GROUP="$(id -gn)"'
+  printf '%s\n' 'bridge_isolation_v2_chgrp_setgid_recursive "$CALLER_GROUP" 2770 0660 "$CTRL_WORKDIR" >/dev/null 2>&1 || true'
+  printf '%s\n' 'echo "CTRL_DONE=1"'
+} | sed "s#\$0_REPO_ROOT#$REPO_ROOT#g" >"$CTRL_DRIVER"
+chmod +x "$CTRL_DRIVER"
+"$BRIDGE_BASH" "$CTRL_DRIVER" >"$CTRL_OUT" 2>&1 || true
+rm -f "$CTRL_DRIVER"
+
+CTRL_MODE_AFTER="$(stat -c '%a' "$CTRL_SHARED_FILE" 2>/dev/null || stat -f '%Lp' "$CTRL_SHARED_FILE")"
+if [[ "$CTRL_MODE_AFTER" == "644" ]]; then
+  cat "$CTRL_OUT"
+  smoke_fail "control case: recursive helper did not mutate the tree at all — smoke is not exercising the code path"
+fi
+smoke_log "control confirmed — without --exclude-path the shared file IS mutated ($CTRL_MODE_AFTER), so the prune is the load-bearing guard"
+
+smoke_log "PASS — isolation-v2 apply scopes recursive perm changes away from shared plugin material (#1021)"
+exit 0

--- a/scripts/smoke/1025-isolated-create-agent-env-install.sh
+++ b/scripts/smoke/1025-isolated-create-agent-env-install.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1025-isolated-create-agent-env-install.sh — Issue #1025.
+#
+# Pins the contract that, for a linux-user isolated agent,
+# `bridge_write_linux_agent_env_file` (lib/bridge-agents.sh) hands the
+# cached `runtime/agent-env.sh` off to its per-agent destination through
+# a SINGLE privileged `install` invocation that sets owner, group, and
+# mode atomically — and performs NO separate post-install `chgrp`/
+# `chmod` on that destination.
+#
+# The bug (#1025): the writer built the env file directly under the
+# isolation-v2 per-agent root, which the scaffold leaves
+# `root:ab-agent-<name>`. A `usermod -aG` during prepare does not
+# refresh the running controller process's supplementary group set, so
+# the same-invocation `mkdir`/`cat >` was refused and `agent create
+# --isolate` aborted with `Permission denied`, leaving a half-created
+# agent.
+#
+# The fix stages the build into a controller-owned tempfile and
+# `install`s it via sudo. Codex r1 BLOCKING items on the first fix:
+#   B1 — a bare `install` + a separate `chgrp`/`chmod` left the file
+#        root-owned (the isolation-v2 matrix requires
+#        `controller:<agent_grp>` mode 0640) and is not always repaired
+#        later (`bridge_ensure_isolated_agent_env_current` calls the
+#        writer directly with no matrix reapply).
+#   B2 — the separate post-install metadata touch reopened a TOCTOU
+#        symlink window: `runtime/` is isolated-UID-owned + group-
+#        writable 2770, so a live isolated agent could swap
+#        `agent-env.sh` for a symlink between install and chgrp/chmod.
+# Both are closed by collapsing install + owner + group + mode into one
+# `install -o -g -m 0640` call with no second touch.
+#
+# Test plan (in-process bash helpers — no live tmux / Claude / sudo):
+#   T1. linux-user isolated agent, dest under BRIDGE_AGENT_ROOT_V2 →
+#       the writer issues EXACTLY ONE `install` carrying `-o <controller>`
+#       `-g <agent_grp>` `-m 0640`, and ZERO `chgrp`/`chmod` against the
+#       per-agent destination. (B1 + B2.)
+#   T2. The installed file's recorded owner:group:mode is
+#       `<controller>:<agent_grp> 0640` — the v2 matrix contract. (B1.)
+#   T3. The pre-install symlink defense is retained — a symlink planted
+#       at the destination is removed before the install.
+#
+# `bridge_linux_sudo_root` is stubbed to a recorder that runs the
+# command without sudo (the smoke host is not root and has no
+# ab-agent-* groups) and appends each invocation to a log, so the smoke
+# can assert the exact privileged-call shape on any platform.
+#
+# Footgun #11 (heredoc_write deadlock class): fixture uses only
+# `printf '%s\n' >file` — no command substitution feeding heredoc-stdin,
+# no `<<<` here-strings into bridge functions.
+
+set -euo pipefail
+
+# Re-exec under Bash 4+ for associative arrays (macOS ships 3.2).
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash"; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$_candidate" "${BASH_SOURCE[0]}" "$@"
+    fi
+  done
+  echo "[smoke:1025-isolated-create-agent-env-install] requires Bash 4+ (host is ${BASH_VERSION})" >&2
+  exit 1
+fi
+
+SMOKE_NAME="1025-isolated-create-agent-env-install"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "1025-isolated-create-agent-env-install"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# shellcheck source=bridge-lib.sh disable=SC1091
+source "$REPO_ROOT/bridge-lib.sh"
+
+if ! declare -F bridge_write_linux_agent_env_file >/dev/null; then
+  smoke_fail "bridge_write_linux_agent_env_file not defined after sourcing bridge-lib.sh"
+fi
+
+bridge_reset_roster_maps
+
+# --- Recording stub for bridge_linux_sudo_root -------------------------------
+# Logs each privileged call (one space-joined line) to $SUDO_LOG, then
+# executes it directly (no `sudo`) so file ops still take effect on the
+# unprivileged smoke host. `install -o/-g` to a non-existent user/group
+# would fail here, so the `-o`/`-g` values are remapped to the current
+# identity for execution while the LOG keeps the requested values — the
+# assertions read the log, the filesystem effect just needs to succeed.
+SUDO_LOG="$SMOKE_TMP_ROOT/sudo-calls.log"
+: >"$SUDO_LOG"
+# shellcheck disable=SC2329
+bridge_linux_sudo_root() {
+  printf '%s\n' "$*" >>"$SUDO_LOG"
+  local -a run=()
+  local a
+  for a in "$@"; do
+    case "$a" in
+      "$REQUESTED_OWNER") run+=("$(id -un)") ;;
+      "$REQUESTED_GROUP") run+=("$(id -gn)") ;;
+      *) run+=("$a") ;;
+    esac
+  done
+  "${run[@]}"
+}
+
+# Force the writer's Linux-only isolated-write branch on a non-Linux host.
+export BRIDGE_HOST_PLATFORM_OVERRIDE="Linux"
+# shellcheck disable=SC2329
+bridge_agent_linux_user_isolation_effective() { return 0; }
+
+# --- shared fixture ----------------------------------------------------------
+
+AGENT="iso-1025"
+REQUESTED_OWNER="$(id -un)"
+REQUESTED_GROUP="$(bridge_isolation_v2_agent_group_name "$AGENT")"
+[[ -n "$REQUESTED_GROUP" ]] || smoke_fail "could not derive agent group for $AGENT"
+
+seed_agent() {
+  local agent="$1"
+  BRIDGE_AGENT_IDS=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent smoke fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]=""
+  BRIDGE_AGENT_PROFILE_HOME["$agent"]=""
+  BRIDGE_AGENT_LAUNCH_CMD["$agent"]="claude"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_LOOP["$agent"]="1"
+  BRIDGE_AGENT_CONTINUE["$agent"]="1"
+  BRIDGE_AGENT_SESSION_ID["$agent"]=""
+  BRIDGE_AGENT_HISTORY_KEY["$agent"]=""
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_UPDATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_IDLE_TIMEOUT["$agent"]="600"
+  BRIDGE_AGENT_NOTIFY_KIND["$agent"]=""
+  BRIDGE_AGENT_NOTIFY_TARGET["$agent"]=""
+  BRIDGE_AGENT_NOTIFY_ACCOUNT["$agent"]=""
+  BRIDGE_AGENT_DISCORD_CHANNEL_ID["$agent"]=""
+  BRIDGE_AGENT_CHANNELS["$agent"]=""
+  BRIDGE_AGENT_ISOLATION_MODE["$agent"]="linux-user"
+  BRIDGE_AGENT_OS_USER["$agent"]="agent-bridge-$agent"
+}
+
+seed_agent "$AGENT"
+
+ENV_FILE="$(bridge_agent_linux_env_file "$AGENT")"
+# Sanity: the destination must be under the per-agent v2 root, which is
+# the predicate that arms the staged-install branch.
+case "$ENV_FILE" in
+  "$BRIDGE_AGENT_ROOT_V2/$AGENT"/*) ;;
+  *) smoke_fail "env file '$ENV_FILE' is not under BRIDGE_AGENT_ROOT_V2 — fixture mis-seeded" ;;
+esac
+
+# --- T3 fixture: plant a symlink at the destination --------------------------
+# The pre-install symlink defense must remove it before the install.
+mkdir -p "$(dirname "$ENV_FILE")"
+DECOY="$SMOKE_TMP_ROOT/decoy-target"
+printf 'decoy\n' >"$DECOY"
+ln -sf "$DECOY" "$ENV_FILE"
+[[ -L "$ENV_FILE" ]] || smoke_fail "T3 pre-condition: failed to plant symlink at $ENV_FILE"
+
+# --- run the writer ----------------------------------------------------------
+rc=0
+bridge_write_linux_agent_env_file "$AGENT" || rc=$?
+smoke_assert_eq "0" "$rc" "writer returns 0 for an isolated agent"
+smoke_assert_file_exists "$ENV_FILE" "agent-env.sh exists after the writer runs"
+
+# --- T1: exactly one `install`, zero post-install chgrp/chmod on the dest ----
+install_calls="$(grep -c '^install ' "$SUDO_LOG" || true)"
+smoke_assert_eq "1" "$install_calls" \
+  "T1: writer issues exactly ONE privileged install for the staged env file"
+
+# No `chgrp`/`chmod` against the per-agent destination after install.
+# (`install -m` carries the mode; `-o`/`-g` carry the owner/group — a
+# separate metadata touch is the TOCTOU window codex flagged.)
+if grep -E "^(chgrp|chmod) .*${AGENT}" "$SUDO_LOG" >/dev/null 2>&1; then
+  echo "--- sudo call log ---" >&2
+  cat "$SUDO_LOG" >&2
+  smoke_fail "T1: found a post-install chgrp/chmod against the per-agent env file — TOCTOU window reopened"
+fi
+smoke_log "T1 PASS — single install, no follow-prone second metadata touch"
+
+# --- T2: the install carries the v2 matrix owner:group:mode contract ---------
+install_line="$(grep '^install ' "$SUDO_LOG" | head -n1)"
+smoke_assert_contains "$install_line" "-o $REQUESTED_OWNER" \
+  "T2: install sets owner to the controller user"
+smoke_assert_contains "$install_line" "-g $REQUESTED_GROUP" \
+  "T2: install sets group to the per-agent group ($REQUESTED_GROUP)"
+smoke_assert_contains "$install_line" "-m 0640" \
+  "T2: install sets mode 0640 (isolation-v2 agent-env-sh contract)"
+
+# Filesystem effect: the recorder remapped -o/-g to the current identity
+# for execution, but mode is identity-independent — assert it landed.
+env_mode="$(stat -c '%a' "$ENV_FILE" 2>/dev/null || stat -f '%Lp' "$ENV_FILE")"
+smoke_assert_eq "640" "$env_mode" \
+  "T2: installed agent-env.sh is mode 0640 on disk"
+smoke_log "T2 PASS — install lands controller:<agent_grp> 0640 atomically"
+
+# --- T3: the pre-install symlink defense removed the planted symlink ---------
+[[ -L "$ENV_FILE" ]] && smoke_fail "T3: env file is still a symlink — pre-install defense did not fire"
+[[ -f "$ENV_FILE" ]] || smoke_fail "T3: env file is not a regular file after the writer ran"
+if grep -q "$DECOY" "$ENV_FILE" 2>/dev/null; then
+  smoke_fail "T3: writer wrote THROUGH the planted symlink — decoy content reached the destination"
+fi
+grep -q '^BRIDGE_AGENT_ID=' "$ENV_FILE" \
+  || smoke_fail "T3: installed file does not look like a real agent-env.sh"
+smoke_log "T3 PASS — planted symlink removed; install landed a fresh regular file"
+
+smoke_log "PASS — isolated-create env-file install is atomic owner:group:mode, no TOCTOU window (#1025)"
+exit 0

--- a/scripts/smoke/1028-isolated-workdir-check.sh
+++ b/scripts/smoke/1028-isolated-workdir-check.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1028-isolated-workdir-check.sh — Issue #1028.
+#
+# Pins the contract that `bridge-start.sh`'s workdir-existence decision is
+# privilege-aware for a linux-user isolated agent.
+#
+# The bug (#1028): for an isolated agent the agent root
+# (`<data-root>/agents/<agent>/`) is `root:ab-agent-<agent>` mode 0750 and
+# `workdir/` is 2770. The controller process is not in the agent group, so
+# a plain `[[ -d "$WORK_DIR" ]]` cannot traverse the 0750 parent and
+# false-negates even though `workdir/` exists. Result: every post-create
+# `start_dry_run` for an isolated agent printed a spurious
+#   [info] '<agent>' static workdir 누락, 자동 재생성: ...
+#   [오류] workdir 자동 재생성 후에도 존재하지 않음: ...
+# and reported `start_dry_run: warn (rc=1)` — a confusing false alarm even
+# though the agent (incl. `workdir/`) was scaffolded correctly.
+#
+# The fix makes BOTH the upstream "is workdir missing" decision AND the
+# post-regen re-check probe existence through `bridge_linux_sudo_root
+# test -d` when the agent is a linux-user isolated agent. Non-isolated
+# agents keep the plain `[[ -d ]]` controller-side test.
+#
+# Test plan (in-process bash — no live tmux / Claude / sudo). The smoke
+# extracts just the workdir-check block from `bridge-start.sh` and drives
+# it with stubbed `bridge_agent_linux_user_isolation_effective` +
+# `bridge_linux_sudo_root` so the decision can be asserted on any host:
+#
+#   T1. Isolated agent, `workdir/` EXISTS but is unreadable to the
+#       controller (plain `[[ -d ]]` would false-negate). The block must
+#       NOT enter the regen branch — no spurious "누락" line, no
+#       bridge_die, exit 0.
+#   T2. Isolated agent, `workdir/` genuinely MISSING. The block enters the
+#       regen branch, the sudo-handoff mkdir creates it, the privilege-
+#       aware post-regen re-check passes, exit 0.
+#   T3. Non-isolated agent, `workdir/` MISSING. The plain `[[ -d ]]` test
+#       still routes into the default-home mkdir branch and materializes
+#       it (the non-isolated path is unchanged by the fix).
+#
+# `bridge_linux_sudo_root` is stubbed to run the command directly (the
+# smoke host is not root and has no ab-agent-* groups). The stub also
+# records the `test -d` probe so the smoke can prove the privilege-aware
+# branch — not the plain controller test — drove the decision.
+#
+# Footgun #11 (heredoc_write deadlock class): the driver is emitted with
+# `printf '%s\n' >file` — no command substitution feeding heredoc-stdin,
+# no `<<<` here-strings into bridge functions.
+
+set -uo pipefail
+
+SMOKE_NAME="1028-isolated-workdir-check"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# --- locate the workdir-check block in bridge-start.sh -----------------------
+# The block is bounded by a stable comment anchor and the matching `fi`.
+# Extracting by anchor (not a hard-coded line range) keeps the smoke from
+# silently going stale if the surrounding script shifts.
+BLOCK_START="$(grep -n '^# workdir existence: for a linux-user isolated agent' \
+  "$REPO_ROOT/bridge-start.sh" | head -n1 | cut -d: -f1)"
+[[ -n "$BLOCK_START" ]] \
+  || smoke_fail "could not locate workdir-check block anchor in bridge-start.sh"
+# The block ends at the first `^fi$` at or after the `if [[ $WORK_DIR_PRESENT`
+# guard. Find that guard, then the next bare `fi`.
+GUARD_LINE="$(grep -n '^if \[\[ \$WORK_DIR_PRESENT -eq 0 \]\]; then' \
+  "$REPO_ROOT/bridge-start.sh" | head -n1 | cut -d: -f1)"
+[[ -n "$GUARD_LINE" ]] \
+  || smoke_fail "could not locate WORK_DIR_PRESENT guard in bridge-start.sh"
+BLOCK_END="$(awk -v start="$GUARD_LINE" 'NR>=start && $0=="fi"{print NR; exit}' \
+  "$REPO_ROOT/bridge-start.sh")"
+[[ -n "$BLOCK_END" ]] \
+  || smoke_fail "could not locate end of workdir-check block in bridge-start.sh"
+smoke_log "extracting bridge-start.sh workdir-check block lines $BLOCK_START..$BLOCK_END"
+
+BLOCK_FILE="$SMOKE_TMP_ROOT/workdir-check-block.sh"
+sed -n "${BLOCK_START},${BLOCK_END}p" "$REPO_ROOT/bridge-start.sh" >"$BLOCK_FILE"
+
+# --- driver builder ----------------------------------------------------------
+# The driver stubs the privilege helpers + bridge_die, sets the small env
+# the block reads ($AGENT, $WORK_DIR, $DEFAULT_WORK_DIR, $BRIDGE_AGENT_ROOT_V2),
+# sources the extracted block, and reports the outcome on stdout.
+write_driver_script() {
+  local out="$1"
+
+  : >"$out"
+  local line
+  for line in \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'PROBE_LOG="$DRIVER_PROBE_LOG"' \
+    ': >"$PROBE_LOG"' \
+    '# bridge_die: record + abort the block (mimics the real fatal exit).' \
+    'bridge_die() { echo "BRIDGE_DIE: $*"; exit 70; }' \
+    '# Isolation predicate: ISO_EFFECTIVE=1 → isolated agent.' \
+    'bridge_agent_linux_user_isolation_effective() {' \
+    '  [[ "${ISO_EFFECTIVE:-0}" == "1" ]]' \
+    '}' \
+    '# sudo-handoff helper: record `test -d` probes so the smoke can prove' \
+    '# the privilege-aware path drove the decision, then run the command' \
+    '# directly (no sudo — smoke host is unprivileged).' \
+    'bridge_linux_sudo_root() {' \
+    '  if [[ "$1" == "test" ]]; then' \
+    '    printf "PROBE %s\n" "$*" >>"$PROBE_LOG"' \
+    '  fi' \
+    '  "$@"' \
+    '}' \
+    'echo "=== block start ==="' \
+    'source "$BLOCK_FILE"' \
+    'echo "=== block end rc=$? ==="'
+  do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+DRIVER="$SMOKE_TMP_ROOT/driver.sh"
+PROBE_LOG="$SMOKE_TMP_ROOT/probe.log"
+write_driver_script "$DRIVER"
+
+run_block() {
+  # run_block <iso_effective> <agent> <work_dir> <default_work_dir> <v2_root>
+  ISO_EFFECTIVE="$1" \
+  AGENT="$2" \
+  WORK_DIR="$3" \
+  DEFAULT_WORK_DIR="$4" \
+  BRIDGE_AGENT_ROOT_V2="$5" \
+  BLOCK_FILE="$BLOCK_FILE" \
+  DRIVER_PROBE_LOG="$PROBE_LOG" \
+  "$BRIDGE_BASH" "$DRIVER" 2>&1
+}
+
+# --- T1: isolated agent, workdir EXISTS → no regen, no spurious 누락 ----------
+smoke_log "T1: isolated agent with an existing workdir does not enter the regen/누락 branch"
+
+T1_V2_ROOT="$SMOKE_TMP_ROOT/t1-v2"
+T1_AGENT="iso_t1"
+T1_WORKDIR="$T1_V2_ROOT/$T1_AGENT/workdir"
+mkdir -p "$T1_WORKDIR"
+
+T1_OUT="$(run_block 1 "$T1_AGENT" "$T1_WORKDIR" "$T1_V2_ROOT/$T1_AGENT/home" "$T1_V2_ROOT")"
+T1_RC=$?
+
+smoke_assert_eq "0" "$T1_RC" "T1: workdir-check block exits 0 for an isolated agent with an existing workdir"
+smoke_assert_not_contains "$T1_OUT" "누락" \
+  "T1: no spurious 'workdir 누락' info line when the workdir already exists"
+smoke_assert_not_contains "$T1_OUT" "BRIDGE_DIE" \
+  "T1: block does not false-die for an isolated agent whose workdir exists"
+# Prove the decision went through the privilege-aware probe, not the plain
+# controller `[[ -d ]]` test.
+if ! grep -q "^PROBE test -d $T1_WORKDIR" "$PROBE_LOG"; then
+  echo "--- probe log ---" >&2
+  cat "$PROBE_LOG" >&2
+  smoke_fail "T1: expected a 'bridge_linux_sudo_root test -d' probe for the isolated workdir"
+fi
+smoke_log "T1 PASS — isolated existing-workdir path is privilege-aware, no false alarm"
+
+# --- T2: isolated agent, workdir MISSING → regen succeeds, no false-die ------
+smoke_log "T2: isolated agent with a genuinely missing workdir is regenerated, post-regen re-check passes"
+
+T2_V2_ROOT="$SMOKE_TMP_ROOT/t2-v2"
+T2_AGENT="iso_t2"
+T2_WORKDIR="$T2_V2_ROOT/$T2_AGENT/workdir"
+mkdir -p "$T2_V2_ROOT/$T2_AGENT"   # parent exists; workdir/ deliberately absent
+[[ ! -d "$T2_WORKDIR" ]] || smoke_fail "T2 pre-condition: workdir should not exist yet"
+
+T2_OUT="$(run_block 1 "$T2_AGENT" "$T2_WORKDIR" "$T2_V2_ROOT/$T2_AGENT/home" "$T2_V2_ROOT")"
+T2_RC=$?
+
+smoke_assert_eq "0" "$T2_RC" "T2: workdir-check block exits 0 after regenerating a missing isolated workdir"
+smoke_assert_contains "$T2_OUT" "누락" \
+  "T2: a genuinely missing workdir still emits the '누락, 자동 재생성' info line"
+smoke_assert_not_contains "$T2_OUT" "BRIDGE_DIE" \
+  "T2: post-regen privilege-aware re-check does not false-die after the workdir is created"
+[[ -d "$T2_WORKDIR" ]] || smoke_fail "T2: workdir was not created by the regen branch"
+smoke_log "T2 PASS — genuine-missing path still regenerates and the re-check is privilege-aware"
+
+# --- T3: non-isolated agent, workdir MISSING → plain path unchanged ----------
+smoke_log "T3: non-isolated agent keeps the plain [[ -d ]] check and default-home mkdir"
+
+T3_AGENT="shared_t3"
+T3_DEFAULT_HOME="$SMOKE_TMP_ROOT/t3-default-home"
+[[ ! -d "$T3_DEFAULT_HOME" ]] || smoke_fail "T3 pre-condition: default home should not exist yet"
+: >"$PROBE_LOG"
+
+# WORK_DIR == DEFAULT_WORK_DIR → the plain default-home mkdir branch.
+T3_OUT="$(run_block 0 "$T3_AGENT" "$T3_DEFAULT_HOME" "$T3_DEFAULT_HOME" "$SMOKE_TMP_ROOT/t3-v2")"
+T3_RC=$?
+
+smoke_assert_eq "0" "$T3_RC" "T3: workdir-check block exits 0 for a non-isolated agent (plain mkdir branch)"
+smoke_assert_not_contains "$T3_OUT" "BRIDGE_DIE" "T3: non-isolated path does not die"
+[[ -d "$T3_DEFAULT_HOME" ]] || smoke_fail "T3: default home was not created by the plain mkdir branch"
+# The non-isolated path must NOT route through the sudo-backed probe.
+if grep -q '^PROBE ' "$PROBE_LOG"; then
+  echo "--- probe log ---" >&2
+  cat "$PROBE_LOG" >&2
+  smoke_fail "T3: non-isolated agent must not invoke the privilege-aware sudo probe"
+fi
+smoke_log "T3 PASS — non-isolated path unchanged (plain controller-side check)"
+
+smoke_log "all tests PASS — bridge-start.sh workdir-check is privilege-aware for isolated agents (#1028)"
+exit 0

--- a/scripts/smoke/agent-update-launch-cmd-redaction.sh
+++ b/scripts/smoke/agent-update-launch-cmd-redaction.sh
@@ -1,0 +1,392 @@
+#!/usr/bin/env bash
+# scripts/smoke/agent-update-launch-cmd-redaction.sh — Issue #1023 smoke.
+#
+# `agent-bridge agent update --launch-cmd-*` echoes the before/after
+# launch command, the operation summary, the recorded add-env actions,
+# the audit detail, the --json envelope, the plain-text result, and the
+# dry-run output. A launch command's leading env-prefix routinely
+# carries credential-bearing values (OAuth / MS365 client secrets,
+# bearer tokens). This smoke pins that the raw secret literal survives
+# in NONE of those surfaces, while a benign env value is left intact and
+# the actually-applied launch command on disk still carries the real
+# value.
+#
+# Surfaces asserted (codex r1 — redacting only before/after diff is
+# insufficient):
+#   - before_launch_cmd / after_launch_cmd diff (plain text)
+#   - --json envelope (before/after launch_cmd + actions)
+#   - operation_summary + audit detail (audit.jsonl)
+#   - recorded add-env actions
+#   - dry-run output (default + --json modes)
+#
+# Caller-source trust is forced via BRIDGE_CALLER_SOURCE=operator-tui so
+# the smoke does not depend on a real TTY (CI / pipe execution).
+
+set -euo pipefail
+
+SMOKE_NAME="agent-update-launch-cmd-redaction"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+ADMIN="testadmin"
+WORKER="testworker"
+
+# The secret literals. These must never appear in any rendered output.
+SECRET_VALUE="supersecretClientSecretXYZ"
+BEARER_VALUE="BearerTok-abc123def456"
+# A sensitive value that CONTAINS a comma — `--launch-cmd-add-env` only
+# rejects newlines, so a comma is a valid value char. The redactor must
+# redact the whole value structurally; a post-comma-join redactor would
+# strand SECRET_VALUE (the suffix) as a bare token (issue #1023 codex
+# r1 BLOCKING).
+COMMA_SECRET_VALUE="left,${SECRET_VALUE}"
+# A benign env value — must survive un-redacted in the diff.
+BENIGN_VALUE="benign-debug-flag-99"
+
+write_roster_fixture() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+BRIDGE_ADMIN_AGENT_ID=${ADMIN}
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${ADMIN}
+bridge_add_agent_id_if_missing ${ADMIN}
+BRIDGE_AGENT_DESC["${ADMIN}"]='admin role'
+BRIDGE_AGENT_ENGINE["${ADMIN}"]='claude'
+BRIDGE_AGENT_SESSION["${ADMIN}"]='${ADMIN}'
+BRIDGE_AGENT_WORKDIR["${ADMIN}"]='${BRIDGE_AGENT_HOME_ROOT}/${ADMIN}'
+BRIDGE_AGENT_SOURCE["${ADMIN}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${ADMIN}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${ADMIN}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${ADMIN}
+
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${WORKER}
+bridge_add_agent_id_if_missing ${WORKER}
+BRIDGE_AGENT_DESC["${WORKER}"]='worker role'
+BRIDGE_AGENT_ENGINE["${WORKER}"]='claude'
+BRIDGE_AGENT_SESSION["${WORKER}"]='${WORKER}'
+BRIDGE_AGENT_WORKDIR["${WORKER}"]='${BRIDGE_AGENT_HOME_ROOT}/${WORKER}'
+BRIDGE_AGENT_SOURCE["${WORKER}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${WORKER}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${WORKER}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${WORKER}
+EOF
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$WORKER" "$BRIDGE_AGENT_HOME_ROOT/$ADMIN"
+}
+
+run_update() {
+  # Run as admin from operator-trusted source. $@ supplies mode flags
+  # (--json / --dry-run) and the launch-cmd mutation flags.
+  BRIDGE_ADMIN_AGENT_ID="$ADMIN" \
+  BRIDGE_CALLER_SOURCE="operator-tui" \
+  BRIDGE_AGENT_ID="$ADMIN" \
+    bash "$SMOKE_REPO_ROOT/bridge-agent.sh" update "$WORKER" "$@"
+}
+
+read_launch_line() {
+  grep "^BRIDGE_AGENT_LAUNCH_CMD\\[\"${WORKER}\"\\]=" \
+    "$BRIDGE_ROSTER_LOCAL_FILE" | head -n 1
+}
+
+# assert_no_secret <label> <text>
+# Fail if either secret literal appears anywhere in <text>.
+assert_no_secret() {
+  local label="$1"
+  local text="$2"
+  if [[ "$text" == *"$SECRET_VALUE"* ]]; then
+    smoke_fail "secret literal leaked into $label: $text"
+  fi
+  if [[ "$text" == *"$BEARER_VALUE"* ]]; then
+    smoke_fail "bearer token literal leaked into $label: $text"
+  fi
+}
+
+assert_default_text_redacts_secret() {
+  # Default (non-JSON) plain-text output across two sensitive env adds.
+  local output
+  output="$(run_update \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${SECRET_VALUE}" \
+    --launch-cmd-add-env "AUTHORIZATION=${BEARER_VALUE}")"
+
+  assert_no_secret "plain-text result" "$output"
+  smoke_assert_contains "$output" "MS365_CLIENT_SECRET=" \
+    "plain-text result still shows the redacted key name"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "plain-text result shows the redaction placeholder"
+
+  # The roster on disk must still carry the REAL secret — redaction is
+  # output-rendering only.
+  local line
+  line="$(read_launch_line)"
+  smoke_assert_contains "$line" "$SECRET_VALUE" \
+    "applied launch_cmd on disk still carries the real secret value"
+  smoke_assert_contains "$line" "$BEARER_VALUE" \
+    "applied launch_cmd on disk still carries the real bearer token"
+}
+
+assert_json_redacts_secret() {
+  # --json envelope: before/after launch_cmd + actions array.
+  local output
+  output="$(run_update --json \
+    --launch-cmd-add-env "REFRESH_TOKEN=${SECRET_VALUE}")"
+
+  assert_no_secret "--json envelope" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["changed"] is True, payload
+secret = sys.argv[2]
+blob = json.dumps(payload)
+assert secret not in blob, f"secret in --json payload: {payload}"
+assert "REFRESH_TOKEN=" in payload["after"]["launch_cmd"], payload
+assert "***REDACTED***" in payload["after"]["launch_cmd"], payload
+# Recorded add-env action must be redacted too.
+joined = " ".join(a for a in payload["actions"] if isinstance(a, str))
+assert "add-env REFRESH_TOKEN=" in joined, payload
+assert secret not in joined, payload
+' "$output" "$SECRET_VALUE"
+}
+
+assert_benign_env_not_redacted() {
+  # A non-sensitive key (BRIDGE_HOME / DEBUG) must NOT be redacted —
+  # the diff signal for benign env stays intact.
+  local output
+  output="$(run_update --json \
+    --launch-cmd-add-env "DEBUG=${BENIGN_VALUE}")"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+benign = sys.argv[1 + 1]
+assert benign in payload["after"]["launch_cmd"], payload
+joined = " ".join(a for a in payload["actions"] if isinstance(a, str))
+assert f"add-env DEBUG={benign}" in joined, payload
+' "$output" "$BENIGN_VALUE"
+  # Clean up the benign add so downstream assertions start clean.
+  run_update --json --launch-cmd-remove-env DEBUG >/dev/null
+}
+
+assert_audit_log_redacts_secret() {
+  # The audit log carries the operation summary + detail (before/after
+  # launch_cmd, actions). The SHA chain is the tamper-evidence; the raw
+  # secret must not be in the JSONL.
+  : >"$BRIDGE_AUDIT_LOG" 2>/dev/null || true
+  run_update --json \
+    --launch-cmd-add-env "CLIENT_SECRET=${SECRET_VALUE}" >/dev/null
+  if [[ ! -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_fail "expected an audit row after a launch-cmd mutation"
+  fi
+  local audit_blob
+  audit_blob="$(cat "$BRIDGE_AUDIT_LOG")"
+  assert_no_secret "audit.jsonl" "$audit_blob"
+  smoke_assert_contains "$audit_blob" "CLIENT_SECRET" \
+    "audit detail still records which key changed"
+  smoke_assert_contains "$audit_blob" "***REDACTED***" \
+    "audit detail carries the redaction placeholder"
+}
+
+assert_dry_run_redacts_secret() {
+  # Dry-run output (default + --json). The roster must not change AND
+  # the planned secret must not appear in the dry-run render.
+  local before_line output
+  before_line="$(read_launch_line)"
+
+  output="$(run_update --dry-run \
+    --launch-cmd-add-env "API_KEY=${SECRET_VALUE}")"
+  assert_no_secret "dry-run plain-text output" "$output"
+  smoke_assert_contains "$output" "dry_run: yes" "dry-run flag echoed"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "dry-run plain-text output is redacted"
+
+  output="$(run_update --json --dry-run \
+    --launch-cmd-add-env "API_KEY=${SECRET_VALUE}")"
+  assert_no_secret "dry-run --json output" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+assert payload["dry_run"] is True, payload
+assert sys.argv[2] not in json.dumps(payload), payload
+' "$output" "$SECRET_VALUE"
+
+  local after_line
+  after_line="$(read_launch_line)"
+  smoke_assert_eq "$before_line" "$after_line" \
+    "dry-run did not mutate the roster launch_cmd line"
+}
+
+assert_comma_value_secret_redacted_everywhere() {
+  # Issue #1023 codex r1 BLOCKING regression: a sensitive add-env value
+  # containing a comma. The operation summary is built by comma-joining
+  # the op stream; redacting AFTER that join split the value at its
+  # comma and let the suffix (SECRET_VALUE) survive as a bare token in
+  # the audit `operation` string. The redactor now operates on the
+  # structured op, so the whole value — comma and all — is redacted in
+  # EVERY surface: --json, plain text, audit detail, operation summary,
+  # actions, dry-run.
+  : >"$BRIDGE_AUDIT_LOG" 2>/dev/null || true
+
+  # --json + plain text in one apply run (default mode prints text).
+  local output
+  output="$(run_update \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE}")"
+  assert_no_secret "comma-value plain-text result" "$output"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "comma-value plain-text result is redacted"
+
+  output="$(run_update --json --launch-cmd-remove-env MS365_CLIENT_SECRET)"
+  # Re-add via --json so we can assert the envelope too.
+  output="$(run_update --json \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE}")"
+  assert_no_secret "comma-value --json envelope" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+suffix = sys.argv[2]
+blob = json.dumps(payload)
+assert suffix not in blob, f"comma-value secret suffix in --json: {payload}"
+assert "MS365_CLIENT_SECRET=" in payload["after"]["launch_cmd"], payload
+assert "***REDACTED***" in payload["after"]["launch_cmd"], payload
+joined = " ".join(a for a in payload["actions"] if isinstance(a, str))
+assert suffix not in joined, payload
+' "$output" "$SECRET_VALUE"
+
+  # Audit log: the `operation` summary string is the surface the
+  # post-join redactor leaked through. Assert the suffix is gone there.
+  if [[ ! -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_fail "expected an audit row after a comma-value launch-cmd mutation"
+  fi
+  local audit_blob
+  audit_blob="$(cat "$BRIDGE_AUDIT_LOG")"
+  assert_no_secret "comma-value audit.jsonl" "$audit_blob"
+  # Explicitly pull the audit `operation` field and assert the suffix
+  # is absent — this is the exact field the lossy comma-join leaked.
+  python3 -c '
+import json, sys
+suffix = sys.argv[2]
+for line in sys.argv[1].splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    row = json.loads(line)
+    detail = row.get("detail") or {}
+    op = detail.get("operation", "")
+    assert suffix not in op, f"comma-value secret suffix in audit operation: {op!r}"
+' "$audit_blob" "$SECRET_VALUE"
+  smoke_assert_contains "$audit_blob" "MS365_CLIENT_SECRET" \
+    "comma-value audit detail still records which key changed"
+
+  # Dry-run must redact the comma value too.
+  output="$(run_update --dry-run \
+    --launch-cmd-add-env "MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE}")"
+  assert_no_secret "comma-value dry-run output" "$output"
+
+  # The applied launch command on disk still carries the REAL comma
+  # value — redaction is output-rendering only.
+  local line
+  line="$(read_launch_line)"
+  smoke_assert_contains "$line" "$COMMA_SECRET_VALUE" \
+    "applied launch_cmd on disk still carries the real comma value"
+
+  # Clean up so downstream assertions start from a known state.
+  run_update --json --launch-cmd-remove-env MS365_CLIENT_SECRET >/dev/null
+}
+
+assert_set_launch_cmd_secret_redacted_everywhere() {
+  # Issue #1023 codex r2 BLOCKING regression: `--set-launch-cmd` replaces
+  # the WHOLE launch command, and that payload can carry a credential-
+  # bearing env-prefix. The op-stream redactor passed `set-launch-cmd`
+  # through verbatim, so the raw env value reached the audit `operation`
+  # field. The redactor now runs the set-launch-cmd payload through the
+  # same launch-cmd redactor used for before/after_launch_cmd.
+  : >"$BRIDGE_AUDIT_LOG" 2>/dev/null || true
+
+  local secret_cmd
+  secret_cmd="MS365_CLIENT_SECRET=${COMMA_SECRET_VALUE} claude --dangerously-skip-permissions"
+
+  # Default mode prints plain text.
+  local output
+  output="$(run_update --set-launch-cmd "$secret_cmd")"
+  assert_no_secret "set-launch-cmd plain-text result" "$output"
+  smoke_assert_contains "$output" "***REDACTED***" \
+    "set-launch-cmd plain-text result is redacted"
+
+  # --json envelope.
+  output="$(run_update --json --set-launch-cmd "$secret_cmd")"
+  assert_no_secret "set-launch-cmd --json envelope" "$output"
+  python3 -c '
+import json, sys
+payload = json.loads(sys.argv[1])
+suffix = sys.argv[2]
+blob = json.dumps(payload)
+assert suffix not in blob, f"set-launch-cmd secret in --json: {payload}"
+assert "MS365_CLIENT_SECRET=" in payload["after"]["launch_cmd"], payload
+assert "***REDACTED***" in payload["after"]["launch_cmd"], payload
+' "$output" "$SECRET_VALUE"
+
+  # Audit `operation` field — the exact surface codex r2 flagged. The
+  # set-launch-cmd above wrote an audit row.
+  if [[ ! -s "$BRIDGE_AUDIT_LOG" ]]; then
+    smoke_fail "expected an audit row after a set-launch-cmd mutation"
+  fi
+  local audit_blob
+  audit_blob="$(cat "$BRIDGE_AUDIT_LOG")"
+  assert_no_secret "set-launch-cmd audit.jsonl" "$audit_blob"
+  python3 -c '
+import json, sys
+suffix = sys.argv[2]
+saw_set = False
+for line in sys.argv[1].splitlines():
+    line = line.strip()
+    if not line:
+        continue
+    row = json.loads(line)
+    detail = row.get("detail") or {}
+    op = detail.get("operation", "")
+    assert suffix not in op, f"set-launch-cmd secret in audit operation: {op!r}"
+    if "set-launch-cmd" in op:
+        saw_set = True
+assert saw_set, "expected a set-launch-cmd audit operation row"
+' "$audit_blob" "$SECRET_VALUE"
+
+  # Dry-run must redact the set-launch-cmd payload too.
+  output="$(run_update --dry-run --set-launch-cmd "$secret_cmd")"
+  assert_no_secret "set-launch-cmd dry-run output" "$output"
+
+  # The applied launch command on disk still carries the REAL value.
+  local line
+  line="$(read_launch_line)"
+  smoke_assert_contains "$line" "$COMMA_SECRET_VALUE" \
+    "applied launch_cmd on disk still carries the real set-launch-cmd value"
+
+  # Restore the fixture launch cmd for any downstream assertion.
+  run_update --json \
+    --set-launch-cmd "claude --dangerously-skip-permissions" >/dev/null
+}
+
+main() {
+  smoke_require_cmd python3
+  smoke_require_cmd bash
+  smoke_setup_bridge_home "agent-update-launch-cmd-redaction"
+  write_roster_fixture
+  smoke_run "default plain-text output redacts secret env values" \
+    assert_default_text_redacts_secret
+  smoke_run "--json envelope redacts launch_cmd + actions" \
+    assert_json_redacts_secret
+  smoke_run "benign env value is left un-redacted" \
+    assert_benign_env_not_redacted
+  smoke_run "audit log redacts secret env values" \
+    assert_audit_log_redacts_secret
+  smoke_run "dry-run output (default + --json) redacts secret" \
+    assert_dry_run_redacts_secret
+  smoke_run "comma-containing secret value redacted in every surface" \
+    assert_comma_value_secret_redacted_everywhere
+  smoke_run "set-launch-cmd secret value redacted in every surface" \
+    assert_set_launch_cmd_secret_redacted_everywhere
+  smoke_log "passed"
+}
+
+main "$@"

--- a/scripts/smoke/teams-channel-meta-assert.py
+++ b/scripts/smoke/teams-channel-meta-assert.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Assert the Teams channel-meta JSON shape (smoke helper for #1022).
+
+Extracted to a sidecar file (file-as-argv) to avoid an interpreter heredoc-stdin
+site in scripts/smoke-test.sh — see KNOWN_ISSUES.md footgun #11 / lint-heredoc-ban.
+"""
+import json
+import sys
+
+meta = json.loads(sys.argv[1])
+assert meta["source"] == "teams", meta
+assert meta["chat_id"] == "chat-smoke", meta
+assert meta["attachment_count"] == "1", meta
+assert meta["attachment_names"] == "smoke.html", meta
+assert "attachments" not in meta, meta
+assert all(isinstance(k, str) and isinstance(v, str) for k, v in meta.items()), meta


### PR DESCRIPTION
## Summary

Re-cut of **v0.14.5-beta4**. Brings the `feat/wave-v0145-b4recut-integration`
branch to `main` and amends the `CHANGELOG.md` `[0.14.5-beta4]` section. VERSION
stays `0.14.5-beta4`; the `v0.14.5-beta4` tag + GitHub prerelease will move to
this HEAD.

Folds in the bug found during beta4's own live-VM verification plus the
issues/PRs opened against beta4:

- #1025 — isolated `agent create` abort (controller non-sudo write under root:0750 home)
- #1028 — `start_dry_run` workdir false-error (controller-side `[[ -d ]]` false-negative)
- #1021 — isolation-v2 apply corrupting shared plugin `node_modules` perms
- #1023 — `agent update` launch-cmd secret leak
- #1022 — Teams channel notification metadata shape (PR #1024)

## Verification

- Each PR (#1024/#1026/#1027/#1029): codex pair-review `implement-ok`, CI green
- Integration branch full-branch codex review: `implement-ok` (#5343)
- Live VM re-verification (agb-test, Oracle Linux 9): `agent create --isolate` → rc=0, clean `start_dry_run: ok`; agent-env.sh `controller:<agent_grp> 0640`

## Test plan

- [ ] codex release-PR pair-review
- [ ] CI green on the release PR
- [ ] tag `v0.14.5-beta4` moved to the merge commit; GitHub prerelease notes updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)