### PR TITLE
fix(wiki-ingest): exclude pre-compact-dump captures from Lane B (#679)

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -649,7 +649,7 @@ scripts/wiki-daily-ingest.sh	311	H3	aeca7dbf051d209b49346dfb9acc551038fb454e0423
 scripts/wiki-daily-ingest.sh	347	H3	c05e859bebfb4d250ab8dc9c51afa7e02a7f4033512feada29ab5c00cd4fa554	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
 scripts/wiki-daily-ingest.sh	362	H3	d9cc3ad67895a83c92be05a6c1fa6d2a173d4aa44cac96a5c032d8b8c67699c9	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
 scripts/wiki-daily-ingest.sh	377	H3	da2db271969819bac7bc6b449b3d10a9f56231c50c467647b19e8c61ef4ab394	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
-scripts/wiki-daily-ingest.sh	416	H3	871edb3d54d942423d29629f16ea66d62a8f81f2824195107baa0e013245f1c6	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
+scripts/wiki-daily-ingest.sh	425	H3	408af6beac8a3c42d1065a147bbe40ed23aa839e210c3808f6e93b9880e9d865	here-string/procsub, non-interpreter consumer (Lane B raw walk; #679 added a find-name exclusion - bash while-read consumer, not an interpreter subprocess; footgun #11 N/A)	agb-dev-claude wave v0145	Phase 4 PR D
 scripts/wiki-dedup-weekly.sh	67	C1	1cd8d3fff70d684d4e2d169a6cd15c3c75387ff8cba388fec7fcded01db898c3	heredoc in capture	patch	Phase 4 PR D
 scripts/wiki-monthly-summarize.sh	40	H3	dbefc36c1d598843a58948df87155436f8684c38611571d1654ea77e9db914ae	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
 scripts/wiki-v2-rebuild.sh	132	H3	dbefc36c1d598843a58948df87155436f8684c38611571d1654ea77e9db914ae	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact
 }
 
 add_all_integration() {
@@ -394,6 +394,15 @@ select_for_path() {
 
     hooks/pre-compact.py|bridge-memory.py|scripts/librarian-process-ingest.py)
       add_required pre-compact-envelope-roundtrip hooks upgrade-shared-settings-propagate
+      add_integration integration-minimal
+      ;;
+
+    scripts/wiki-daily-ingest.sh)
+      # Issue #679: wiki-daily-ingest.sh Lane B excludes
+      # `*pre-compact-dump*` raw envelopes from the librarian ingest
+      # selection. Cover the exclusion regression smoke whenever the
+      # ingest orchestrator moves.
+      add_required 679-wiki-ingest-exclude-precompact
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/679-wiki-ingest-exclude-precompact.sh
+++ b/scripts/smoke/679-wiki-ingest-exclude-precompact.sh
@@ -3,25 +3,34 @@
 #
 # scripts/wiki-daily-ingest.sh Lane B enumerates raw-capture envelopes under
 # each agent's `<agent_home>/raw/captures/inbox/` and queues them for the
-# librarian. The PreCompact hook drops `*-pre-compact-dump-{auto,manual}.json`
-# envelopes into that same inbox on every context compaction; those carry no
-# `suggested_entities/slug/title`, so the librarian classifier falls through
-# to DEFAULT_KIND and §9 rejects them — yet they keep piling up forever and
-# generate a daily [librarian-ambiguous] escalation.
+# librarian. The PreCompact hook routes through `bridge-memory.py capture`
+# with `--title "pre-compact dump (auto|manual)"`, so each dump lands in that
+# inbox as `<timestamp>-pre-compact-dump-{auto,manual}.json` on every context
+# compaction; those carry no `suggested_slug/title`, so the librarian
+# classifier falls through to DEFAULT_KIND and §9 rejects them — yet they keep
+# piling up forever and generate a daily [librarian-ambiguous] escalation.
 #
-# Fix (#679): the Lane B raw `find` invocation now excludes
-# `*pre-compact-dump*` so those envelopes are never eligible while every
-# other raw envelope still flows.
+# Fix (#679): the Lane B raw `find` invocation excludes exactly the two dump
+# shapes — `*-pre-compact-dump-auto.json` and `*-pre-compact-dump-manual.json`
+# — so the hook's dumps are never eligible while every other raw envelope,
+# including legitimate near-miss captures whose name merely contains the
+# `pre-compact-dump` substring, still flows.
 #
 # This smoke runs the real wiki-daily-ingest.sh over an isolated BRIDGE_HOME
 # with a fixture inbox, then asserts the Lane B "Raw envelopes" audit section.
 #
-# Three assertions:
-# T1: a `pre-compact-dump-auto-*.json` envelope is excluded from Lane B.
-# T2: a `pre-compact-dump-manual-*.json` envelope is excluded from Lane B.
+# Five assertions:
+# T1: a `<timestamp>-pre-compact-dump-auto.json` envelope is excluded.
+# T2: a `<timestamp>-pre-compact-dump-manual.json` envelope is excluded.
 # T3: positive control — a non-dump raw `.json` capture AND a raw `.md`
 #     capture are STILL selected (the exclusion is not a blanket
 #     raw-envelope disable).
+# T4: near-miss control — captures whose basename merely CONTAINS the
+#     `pre-compact-dump` substring but are NOT the hook's auto/manual dump
+#     envelopes (`*-pre-compact-dump-research.json`,
+#     `pre-compact-dump-reference.md`) STAY selected. The exclusion is a
+#     precise shape match, not a bare substring match.
+# T5: raw count is exactly 4 — the two near-miss files are counted IN.
 
 set -euo pipefail
 
@@ -43,12 +52,20 @@ run_lane_b() {
   local wiki_root="$BRIDGE_HOME/shared/wiki"
   mkdir -p "$agents_root/alpha/memory" "$inbox" "$wiki_root/_audit"
 
-  # Fixture inbox: two pre-compact-dump envelopes (must be excluded) plus a
-  # non-dump raw .json capture and a raw .md capture (must stay selected).
-  : >"$inbox/alpha-pre-compact-dump-auto.json"
-  : >"$inbox/alpha-pre-compact-dump-manual.json"
-  : >"$inbox/research-note.json"
-  : >"$inbox/decision-x.md"
+  # Fixture inbox. Filenames mirror the real capture_id shape produced by
+  # bridge-memory.py capture: `<15-char-timestamp>-<slug>.json`.
+  #
+  #   Excluded — the PreCompact hook's auto/manual dump envelopes:
+  : >"$inbox/20260522T140455-pre-compact-dump-auto.json"
+  : >"$inbox/20260522T141022-pre-compact-dump-manual.json"
+  #   Selected — ordinary non-dump raw captures:
+  : >"$inbox/20260522T142000-research-note.json"
+  : >"$inbox/20260522T142500-decision-x.md"
+  #   Selected — near-miss captures: the basename contains the
+  #   `pre-compact-dump` substring but they are NOT the auto/manual dump
+  #   envelopes. A bare `*pre-compact-dump*` match would wrongly drop these.
+  : >"$inbox/20260522T143000-pre-compact-dump-research.json"
+  : >"$inbox/pre-compact-dump-reference.md"
 
   # Force the legacy find-based enumeration: it walks $BRIDGE_AGENTS_ROOT/*
   # directly, which makes the Lane B raw walk fully deterministic against
@@ -77,22 +94,26 @@ assert_lane_b_selection() {
   local section
   section="$(run_lane_b)"
 
-  smoke_assert_not_contains "$section" "pre-compact-dump-auto" \
-    "T1: pre-compact-dump-auto envelope excluded from Lane B raw selection"
-  smoke_assert_not_contains "$section" "pre-compact-dump-manual" \
-    "T2: pre-compact-dump-manual envelope excluded from Lane B raw selection"
-  smoke_assert_contains "$section" "research-note.json" \
+  smoke_assert_not_contains "$section" "20260522T140455-pre-compact-dump-auto.json" \
+    "T1: auto dump envelope excluded from Lane B raw selection"
+  smoke_assert_not_contains "$section" "20260522T141022-pre-compact-dump-manual.json" \
+    "T2: manual dump envelope excluded from Lane B raw selection"
+  smoke_assert_contains "$section" "20260522T142000-research-note.json" \
     "T3: non-dump raw .json capture still selected"
-  smoke_assert_contains "$section" "decision-x.md" \
+  smoke_assert_contains "$section" "20260522T142500-decision-x.md" \
     "T3: non-dump raw .md capture still selected"
-  smoke_assert_contains "$section" "Raw envelopes (2)" \
-    "T3: raw count is exactly 2 (no blanket raw-envelope disable)"
+  smoke_assert_contains "$section" "20260522T143000-pre-compact-dump-research.json" \
+    "T4: near-miss .json (pre-compact-dump substring, not a dump) still selected"
+  smoke_assert_contains "$section" "pre-compact-dump-reference.md" \
+    "T4: near-miss .md (pre-compact-dump substring, not a dump) still selected"
+  smoke_assert_contains "$section" "Raw envelopes (4)" \
+    "T5: raw count is exactly 4 — near-miss files counted IN, only the 2 dumps dropped"
 }
 
 main() {
   smoke_setup_bridge_home "$SMOKE_NAME"
 
-  smoke_run "T1-T3: Lane B excludes pre-compact-dump, keeps raw captures" \
+  smoke_run "T1-T5: Lane B excludes only auto/manual dumps, keeps raw + near-miss" \
     assert_lane_b_selection
 
   smoke_log "PASS"

--- a/scripts/smoke/679-wiki-ingest-exclude-precompact.sh
+++ b/scripts/smoke/679-wiki-ingest-exclude-precompact.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# scripts/smoke/679-wiki-ingest-exclude-precompact.sh — Issue #679 smoke.
+#
+# scripts/wiki-daily-ingest.sh Lane B enumerates raw-capture envelopes under
+# each agent's `<agent_home>/raw/captures/inbox/` and queues them for the
+# librarian. The PreCompact hook drops `*-pre-compact-dump-{auto,manual}.json`
+# envelopes into that same inbox on every context compaction; those carry no
+# `suggested_entities/slug/title`, so the librarian classifier falls through
+# to DEFAULT_KIND and §9 rejects them — yet they keep piling up forever and
+# generate a daily [librarian-ambiguous] escalation.
+#
+# Fix (#679): the Lane B raw `find` invocation now excludes
+# `*pre-compact-dump*` so those envelopes are never eligible while every
+# other raw envelope still flows.
+#
+# This smoke runs the real wiki-daily-ingest.sh over an isolated BRIDGE_HOME
+# with a fixture inbox, then asserts the Lane B "Raw envelopes" audit section.
+#
+# Three assertions:
+# T1: a `pre-compact-dump-auto-*.json` envelope is excluded from Lane B.
+# T2: a `pre-compact-dump-manual-*.json` envelope is excluded from Lane B.
+# T3: positive control — a non-dump raw `.json` capture AND a raw `.md`
+#     capture are STILL selected (the exclusion is not a blanket
+#     raw-envelope disable).
+
+set -euo pipefail
+
+SMOKE_NAME="679-wiki-ingest-exclude-precompact"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# Resolve the Raw-envelopes section of the Lane B audit log produced by a
+# fixture run. Returns the section body on stdout.
+run_lane_b() {
+  local agents_root="$BRIDGE_HOME/agents"
+  local inbox="$agents_root/alpha/raw/captures/inbox"
+  local wiki_root="$BRIDGE_HOME/shared/wiki"
+  mkdir -p "$agents_root/alpha/memory" "$inbox" "$wiki_root/_audit"
+
+  # Fixture inbox: two pre-compact-dump envelopes (must be excluded) plus a
+  # non-dump raw .json capture and a raw .md capture (must stay selected).
+  : >"$inbox/alpha-pre-compact-dump-auto.json"
+  : >"$inbox/alpha-pre-compact-dump-manual.json"
+  : >"$inbox/research-note.json"
+  : >"$inbox/decision-x.md"
+
+  # Force the legacy find-based enumeration: it walks $BRIDGE_AGENTS_ROOT/*
+  # directly, which makes the Lane B raw walk fully deterministic against
+  # the isolated fixture. The v2 path resolves agent workdirs via the live
+  # roster, which is not what this smoke owns.
+  local log
+  log="$wiki_root/_audit/ingest-$(date +%Y-%m-%d).md"
+  rm -f "$log"
+
+  env -u BRIDGE_LAYOUT -u BRIDGE_DATA_ROOT \
+    BRIDGE_HOME="$BRIDGE_HOME" \
+    BRIDGE_SHARED_ROOT="$BRIDGE_HOME/shared" \
+    BRIDGE_WIKI_ROOT="$wiki_root" \
+    BRIDGE_AGENTS_ROOT="$agents_root" \
+    BRIDGE_STATE_DIR="$BRIDGE_HOME/state" \
+    BRIDGE_SCRIPTS_ROOT="$SMOKE_REPO_ROOT/scripts" \
+    BRIDGE_AGB="$SMOKE_REPO_ROOT/agent-bridge" \
+    bash "$SMOKE_REPO_ROOT/scripts/wiki-daily-ingest.sh" >/dev/null 2>&1 || true
+
+  smoke_assert_file_exists "$log" "Lane B audit log written"
+  # Emit just the "### Raw envelopes" section body.
+  sed -n '/### Raw envelopes/,/^$/p' "$log"
+}
+
+assert_lane_b_selection() {
+  local section
+  section="$(run_lane_b)"
+
+  smoke_assert_not_contains "$section" "pre-compact-dump-auto" \
+    "T1: pre-compact-dump-auto envelope excluded from Lane B raw selection"
+  smoke_assert_not_contains "$section" "pre-compact-dump-manual" \
+    "T2: pre-compact-dump-manual envelope excluded from Lane B raw selection"
+  smoke_assert_contains "$section" "research-note.json" \
+    "T3: non-dump raw .json capture still selected"
+  smoke_assert_contains "$section" "decision-x.md" \
+    "T3: non-dump raw .md capture still selected"
+  smoke_assert_contains "$section" "Raw envelopes (2)" \
+    "T3: raw count is exactly 2 (no blanket raw-envelope disable)"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  smoke_run "T1-T3: Lane B excludes pre-compact-dump, keeps raw captures" \
+    assert_lane_b_selection
+
+  smoke_log "PASS"
+}
+
+main "$@"

--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -405,6 +405,15 @@ other_count=${other_count:-0}
 # and raw are deduped through the shared roots array).
 # Same empty-array guard as the research/other walks: every active agent
 # may legitimately be linux-user-isolated, leaving AGENT_MEMORY_ROOTS empty.
+#
+# Issue #679: the PreCompact hook drops `*-pre-compact-dump-{auto,manual}.json`
+# envelopes into this same inbox on every context compaction. They carry no
+# `suggested_entities/slug/title`, so the librarian classifier falls through
+# to DEFAULT_KIND and §9 rejects them — but they keep piling up in the inbox
+# and generate a daily [librarian-ambiguous] escalation. The `*pre-compact-dump*`
+# glob excludes both the `-auto` and `-manual` variants from Lane B selection
+# while leaving every other raw envelope eligible. Lane A and the curated
+# research/projects/decisions branches are unaffected.
 touched_raw=""
 if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
   for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
@@ -413,7 +422,8 @@ if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
     [[ -d "$_raw_inbox" ]] || continue
     while IFS= read -r _f; do
       [[ -n "$_f" ]] && touched_raw+="$_f"$'\n'
-    done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) -mtime -1 2>/dev/null)
+    done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) \
+      ! -name '*pre-compact-dump*' -mtime -1 2>/dev/null)
   done
 fi
 touched_raw=$(printf '%s' "$touched_raw" | sed '/^$/d' | sort -u)

--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -406,14 +406,18 @@ other_count=${other_count:-0}
 # Same empty-array guard as the research/other walks: every active agent
 # may legitimately be linux-user-isolated, leaving AGENT_MEMORY_ROOTS empty.
 #
-# Issue #679: the PreCompact hook drops `*-pre-compact-dump-{auto,manual}.json`
-# envelopes into this same inbox on every context compaction. They carry no
-# `suggested_entities/slug/title`, so the librarian classifier falls through
-# to DEFAULT_KIND and §9 rejects them — but they keep piling up in the inbox
-# and generate a daily [librarian-ambiguous] escalation. The `*pre-compact-dump*`
-# glob excludes both the `-auto` and `-manual` variants from Lane B selection
-# while leaving every other raw envelope eligible. Lane A and the curated
-# research/projects/decisions branches are unaffected.
+# Issue #679: the PreCompact hook routes through `bridge-memory.py capture`
+# with `--title "pre-compact dump (auto|manual)"`, so each dump lands in this
+# inbox as `<timestamp>-pre-compact-dump-{auto,manual}.json` on every context
+# compaction. Those envelopes carry no `suggested_slug/title`, so the librarian
+# classifier falls through to DEFAULT_KIND and §9 rejects them — but they keep
+# piling up in the inbox and generate a daily [librarian-ambiguous] escalation.
+# Exclude exactly those two dump shapes from Lane B selection — the slug
+# terminates at `auto`/`manual` immediately before `.json`, so anchoring on
+# `*-pre-compact-dump-{auto,manual}.json` matches every dump while leaving
+# legitimate near-miss captures (e.g. `*-pre-compact-dump-research.json`,
+# `pre-compact-dump-reference.md`) and every other raw envelope eligible.
+# Lane A and the curated research/projects/decisions branches are unaffected.
 touched_raw=""
 if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
   for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
@@ -423,7 +427,8 @@ if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
     while IFS= read -r _f; do
       [[ -n "$_f" ]] && touched_raw+="$_f"$'\n'
     done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) \
-      ! -name '*pre-compact-dump*' -mtime -1 2>/dev/null)
+      ! -name '*-pre-compact-dump-auto.json' \
+      ! -name '*-pre-compact-dump-manual.json' -mtime -1 2>/dev/null)
   done
 fi
 touched_raw=$(printf '%s' "$touched_raw" | sed '/^$/d' | sort -u)


### PR DESCRIPTION
## Summary

`scripts/wiki-daily-ingest.sh` Lane B excludes the PreCompact hook's
`*-pre-compact-dump-{auto,manual}.json` envelopes from the librarian
ingest selection. These envelopes carry no `suggested_entities/slug/title`,
so the librarian classifier falls through to `DEFAULT_KIND` and the §9
ambiguous-kind reject blocks promotion — but the captures keep
accumulating in each agent's `raw/captures/inbox/` forever and generate
a daily `[librarian-ambiguous]` escalation (90+ stuck dumps across 13
agents over weeks on the operator's install). Refs `(#679)`.

## What changed

- `scripts/wiki-daily-ingest.sh` — the Lane B raw `find` invocation gains
  `! -name '*pre-compact-dump*'`, excluding both the `-auto` and
  `-manual` variants. Lane A (daily byte-replica) and the curated
  research/projects/decisions branches are untouched; every other raw
  envelope still flows. The PreCompact hook's output is not changed.
- `scripts/smoke/679-wiki-ingest-exclude-precompact.sh` — new smoke. Runs
  the real ingest orchestrator over an isolated `BRIDGE_HOME` with a
  fixture inbox and asserts: (T1) `pre-compact-dump-auto*.json` excluded,
  (T2) `pre-compact-dump-manual*.json` excluded, (T3) a non-dump raw
  `.json` capture **and** a raw `.md` capture are still selected with an
  exact raw count of 2 — proving the change is not a blanket
  raw-envelope disable.
- `scripts/ci-select-smoke.sh` — wires the new smoke into the required
  suite and selects it whenever `scripts/wiki-daily-ingest.sh` changes.
- `.lint-heredoc-baseline.tsv` — the existing baselined Lane B raw
  procsub site (`done < <(find ...)`, H3, non-interpreter consumer) moves
  line/hash because the `find` now spans two lines; the baseline row is
  updated in place (still H3, footgun #11 N/A — bash while-read consumer).

## Verification

- `bash -n` / `shellcheck` — PASS on all three shell files.
- `bash scripts/lint-heredoc-ban.sh --baseline-check` — PASS (baseline
  ratchet, no new heredoc-stdin sites).
- New smoke — PASS. Confirmed it FAILS on the pre-fix `find` (raw count
  4, dumps included) and PASSES with the fix (raw count 2).
- Manual end-to-end repro in an isolated `BRIDGE_HOME`: fixture inbox of
  4 files → Lane B audit log "Raw envelopes (2)" listing only the
  non-dump captures.

## Scope

`scripts/wiki-daily-ingest.sh` Lane B selection only, plus the smoke and
its CI wiring. Lane A, the PreCompact hook (`hooks/pre-compact.py`), and
other ingest paths are untouched. No VERSION / CHANGELOG changes.