### PR TITLE
release: v0.14.5-beta4 re-cut round 2 — #1031 + #679

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -649,7 +649,7 @@ scripts/wiki-daily-ingest.sh	311	H3	aeca7dbf051d209b49346dfb9acc551038fb454e0423
 scripts/wiki-daily-ingest.sh	347	H3	c05e859bebfb4d250ab8dc9c51afa7e02a7f4033512feada29ab5c00cd4fa554	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
 scripts/wiki-daily-ingest.sh	362	H3	d9cc3ad67895a83c92be05a6c1fa6d2a173d4aa44cac96a5c032d8b8c67699c9	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
 scripts/wiki-daily-ingest.sh	377	H3	da2db271969819bac7bc6b449b3d10a9f56231c50c467647b19e8c61ef4ab394	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
-scripts/wiki-daily-ingest.sh	416	H3	871edb3d54d942423d29629f16ea66d62a8f81f2824195107baa0e013245f1c6	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
+scripts/wiki-daily-ingest.sh	425	H3	408af6beac8a3c42d1065a147bbe40ed23aa839e210c3808f6e93b9880e9d865	here-string/procsub, non-interpreter consumer (Lane B raw walk; #679 added a find-name exclusion - bash while-read consumer, not an interpreter subprocess; footgun #11 N/A)	agb-dev-claude wave v0145	Phase 4 PR D
 scripts/wiki-dedup-weekly.sh	67	C1	1cd8d3fff70d684d4e2d169a6cd15c3c75387ff8cba388fec7fcded01db898c3	heredoc in capture	patch	Phase 4 PR D
 scripts/wiki-monthly-summarize.sh	40	H3	dbefc36c1d598843a58948df87155436f8684c38611571d1654ea77e9db914ae	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D
 scripts/wiki-v2-rebuild.sh	132	H3	dbefc36c1d598843a58948df87155436f8684c38611571d1654ea77e9db914ae	here-string/procsub, non-interpreter consumer	patch	Phase 4 PR D

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ fixes were re-verified live on an OrbStack Oracle Linux 9 VM
 `v0.14.5-beta4` tag and GitHub prerelease are updated to the merged re-cut
 release commit.
 
+**Re-cut round 2 (2026-05-22):** still before any download, `v0.14.5-beta4` was
+re-cut a second time to fold in two further bug-class issues (#1031, #679) — see
+the "Re-cut round 2" subsection below. The tag and prerelease move again to the
+round-2 release commit.
+
 ### Re-cut — verification follow-ups (2026-05-22)
 
 - **Isolated `agent create` no longer aborts** (#1025) — the isolation-v2
@@ -58,6 +63,24 @@ release commit.
 - **Teams channel notification no longer silent-drops** (#1022) — the direct
   `notifications/claude/channel` metadata is kept flat/string-only; the rich
   nested `attachments` array is retained for the bridge queue/audit/replay body.
+
+### Re-cut round 2 — additional bug fixes (2026-05-22)
+
+`v0.14.5-beta4` was re-cut a second time (still before any download) to fold in
+two more bug-class issues. Both PRs were codex pair-reviewed through the
+`feat/wave-v0145-b4r2-integration` branch, which passed a full-branch codex review.
+
+- **Teams attachment downloads authenticate** (#1031) — a Teams user pasting or
+  dragging an inline image triggered a download that failed `HTTP 401`:
+  `streamDownload()` issued a bare unauthenticated `fetch()`. The download now
+  attaches the bot's `Authorization: Bearer` token, scoped by **exact-host
+  match** to the Bot Framework / AMS attachment endpoints only (no token leak to
+  other hosts); the pre-signed `file.download.info` path stays unauthenticated.
+- **wiki-daily-ingest skips PreCompact dumps** (#679) — Lane B ingested the
+  PreCompact hook's `pre-compact-dump-{auto,manual}*.json` capture envelopes,
+  accumulating stuck captures. Lane B now excludes exactly those two dump
+  shapes; ordinary raw captures (including unrelated `pre-compact-dump-*` names)
+  are still ingested.
 
 The #1010 isolated-agent reap path exercises destructive `userdel` / `setfacl` /
 `groupdel`; CI and review verified the gating *decision* (Linux-only, exact

--- a/plugins/teams/package.json
+++ b/plugins/teams/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "botbuilder": "^4.23.0"
+    "botbuilder": "^4.23.0",
+    "botframework-connector": "^4.23.0"
   }
 }

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -15,6 +15,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { BotFrameworkAdapter, TurnContext, ActivityTypes } from 'botbuilder'
 import type { ConversationReference, Activity } from 'botbuilder'
+import { MicrosoftAppCredentials } from 'botframework-connector'
 import { createServer } from 'http'
 import { randomUUID } from 'crypto'
 import { spawnSync } from 'child_process'
@@ -568,12 +569,60 @@ function sanitizeFilename(name: string): string {
   return clean
 }
 
+// Token-leak guard: the bot's Bot Framework access token must only ever be
+// attached to a host that is provably a Bot Framework / AMS attachment
+// endpoint. A malicious or misconfigured `contentUrl` could otherwise
+// exfiltrate the bot token to an arbitrary host.
+//
+// Matching is by EXACT host, never by bare suffix — a bare suffix like
+// `trafficmanager.net` would also match `attacker.trafficmanager.net` (anyone
+// can create an Azure Traffic Manager hostname) and `skype.com` would match
+// every non-AMS Skype host. Both are token-exfiltration surfaces.
+//
+//  - `smba.trafficmanager.net` — Bot Framework service-url attachment host
+//    (`/v3/attachments/...`). Exact host only; regional variants, if any,
+//    must be enumerated exactly here rather than suffix-matched.
+//  - `*.asm.skype.com` — Azure Media Service (AMS) hosts for inline-image /
+//    general-attachment content URLs (e.g. `api.asm.skype.com`). Allowed as
+//    the exact host `asm.skype.com` or a true subdomain of it.
+const BOT_FRAMEWORK_ATTACHMENT_EXACT_HOSTS = [
+  'smba.trafficmanager.net',
+]
+const AMS_ATTACHMENT_HOST = 'asm.skype.com'
+
+function isBotFrameworkAttachmentHost(url: string): boolean {
+  let host: string
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'https:') return false
+    host = parsed.hostname.toLowerCase()
+  } catch {
+    return false
+  }
+  if (BOT_FRAMEWORK_ATTACHMENT_EXACT_HOSTS.includes(host)) return true
+  // AMS: exact host or a true subdomain of asm.skype.com. The leading-dot
+  // check on a true subdomain rejects spoofs like `asm.skype.com.evil.com`.
+  if (host === AMS_ATTACHMENT_HOST) return true
+  if (host.endsWith(`.${AMS_ATTACHMENT_HOST}`)) return true
+  return false
+}
+
 async function streamDownload(
   url: string,
   destPath: string,
   maxBytes: number,
+  authToken?: string,
 ): Promise<{ ok: true; size: number } | { ok: false; error: string }> {
-  const resp = await fetch(url)
+  // Attach the bot token only on the secured Bot Framework attachment path
+  // (the inline-image / general-attachment URL that 401s). The token-leak
+  // guard keeps the token off any non-Bot-Framework host even if a caller
+  // passes one in. The pre-signed file-picker downloadUrl path passes no
+  // token and is unaffected.
+  const headers: Record<string, string> = {}
+  if (authToken && isBotFrameworkAttachmentHost(url)) {
+    headers['Authorization'] = `Bearer ${authToken}`
+  }
+  const resp = await fetch(url, { headers })
   if (!resp.ok) return { ok: false, error: `HTTP ${resp.status}` }
   const cl = resp.headers.get('content-length')
   if (cl !== null) {
@@ -846,6 +895,31 @@ async function downloadAttachments(
   if (items.length === 0) return []
   const safeMessageId = sanitizeMessageId(messageId)
   const results: StoredAttachment[] = []
+
+  // Bot Framework attachment URLs (inline paste / drag-drop images, general
+  // files) require the bot's access token. The native file-picker path
+  // (TEAMS_FILE_DOWNLOAD_TYPE) uses a pre-signed downloadUrl and stays
+  // unauthenticated, so only fetch a token when a general-file attachment is
+  // present. MicrosoftAppCredentials caches the token internally — one call
+  // per activity covers every image attachment in the message. A token-fetch
+  // failure logs and falls through: the affected download still lands as
+  // download_status: failed with a clear download_error rather than crashing.
+  let botToken: string | undefined
+  const needsBotToken = items.some((a) => {
+    const ct = String(a.contentType ?? '').trim()
+    return ct !== TEAMS_FILE_DOWNLOAD_TYPE && isGeneralFileContentType(ct)
+  })
+  if (needsBotToken && APP_ID && APP_PASSWORD) {
+    try {
+      const creds = new MicrosoftAppCredentials(APP_ID, APP_PASSWORD, TENANT_ID || undefined)
+      botToken = await creds.getToken()
+    } catch (err) {
+      process.stderr.write(
+        `teams channel: failed to get bot token for attachment download: ${err}\n`,
+      )
+    }
+  }
+
   for (let i = 0; i < items.length; i++) {
     const att = items[i]
     const rawId = String((att as any).id ?? (att as any).contentUrl ?? '').trim()
@@ -859,11 +933,15 @@ async function downloadAttachments(
       download_status: 'skipped_non_file',
     }
     let downloadUrl = ''
+    // Only the general-file path hands streamDownload a secured Bot Framework
+    // URL that needs the bot token; the file-picker path is pre-signed.
+    let isGeneralFilePath = false
     if (contentType === TEAMS_FILE_DOWNLOAD_TYPE) {
       // Teams native file picker — downloadUrl lives inside content.
       const content = ((att as any).content ?? {}) as { downloadUrl?: string }
       downloadUrl = String(content.downloadUrl ?? '').trim() || String((att as any).contentUrl ?? '').trim()
     } else if (isGeneralFileContentType(contentType)) {
+      isGeneralFilePath = true
       // Generic file (PDF/DOCX/octet-stream/image/etc) from drag-drop, paste,
       // or external integrations. contentUrl is the common case; fall back to
       // content.downloadUrl which some Teams clients use for drag-drop. Cards
@@ -894,7 +972,12 @@ async function downloadAttachments(
       const dir = join(ATTACHMENTS_DIR, safeMessageId)
       mkdirSync(dir, { recursive: true, mode: 0o700 })
       const localPath = join(dir, safeName)
-      const dl = await streamDownload(downloadUrl, localPath, ATTACHMENT_MAX_BYTES)
+      const dl = await streamDownload(
+        downloadUrl,
+        localPath,
+        ATTACHMENT_MAX_BYTES,
+        isGeneralFilePath ? botToken : undefined,
+      )
       if (dl.ok) {
         stored.local_path = localPath
         stored.size_bytes = dl.size

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact
 }
 
 add_all_integration() {
@@ -394,6 +394,15 @@ select_for_path() {
 
     hooks/pre-compact.py|bridge-memory.py|scripts/librarian-process-ingest.py)
       add_required pre-compact-envelope-roundtrip hooks upgrade-shared-settings-propagate
+      add_integration integration-minimal
+      ;;
+
+    scripts/wiki-daily-ingest.sh)
+      # Issue #679: wiki-daily-ingest.sh Lane B excludes
+      # `*pre-compact-dump*` raw envelopes from the librarian ingest
+      # selection. Cover the exclusion regression smoke whenever the
+      # ingest orchestrator moves.
+      add_required 679-wiki-ingest-exclude-precompact
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/679-wiki-ingest-exclude-precompact.sh
+++ b/scripts/smoke/679-wiki-ingest-exclude-precompact.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# scripts/smoke/679-wiki-ingest-exclude-precompact.sh — Issue #679 smoke.
+#
+# scripts/wiki-daily-ingest.sh Lane B enumerates raw-capture envelopes under
+# each agent's `<agent_home>/raw/captures/inbox/` and queues them for the
+# librarian. The PreCompact hook routes through `bridge-memory.py capture`
+# with `--title "pre-compact dump (auto|manual)"`, so each dump lands in that
+# inbox as `<timestamp>-pre-compact-dump-{auto,manual}.json` on every context
+# compaction; those carry no `suggested_slug/title`, so the librarian
+# classifier falls through to DEFAULT_KIND and §9 rejects them — yet they keep
+# piling up forever and generate a daily [librarian-ambiguous] escalation.
+#
+# Fix (#679): the Lane B raw `find` invocation excludes exactly the two dump
+# shapes — `*-pre-compact-dump-auto.json` and `*-pre-compact-dump-manual.json`
+# — so the hook's dumps are never eligible while every other raw envelope,
+# including legitimate near-miss captures whose name merely contains the
+# `pre-compact-dump` substring, still flows.
+#
+# This smoke runs the real wiki-daily-ingest.sh over an isolated BRIDGE_HOME
+# with a fixture inbox, then asserts the Lane B "Raw envelopes" audit section.
+#
+# Five assertions:
+# T1: a `<timestamp>-pre-compact-dump-auto.json` envelope is excluded.
+# T2: a `<timestamp>-pre-compact-dump-manual.json` envelope is excluded.
+# T3: positive control — a non-dump raw `.json` capture AND a raw `.md`
+#     capture are STILL selected (the exclusion is not a blanket
+#     raw-envelope disable).
+# T4: near-miss control — captures whose basename merely CONTAINS the
+#     `pre-compact-dump` substring but are NOT the hook's auto/manual dump
+#     envelopes (`*-pre-compact-dump-research.json`,
+#     `pre-compact-dump-reference.md`) STAY selected. The exclusion is a
+#     precise shape match, not a bare substring match.
+# T5: raw count is exactly 4 — the two near-miss files are counted IN.
+
+set -euo pipefail
+
+SMOKE_NAME="679-wiki-ingest-exclude-precompact"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# Resolve the Raw-envelopes section of the Lane B audit log produced by a
+# fixture run. Returns the section body on stdout.
+run_lane_b() {
+  local agents_root="$BRIDGE_HOME/agents"
+  local inbox="$agents_root/alpha/raw/captures/inbox"
+  local wiki_root="$BRIDGE_HOME/shared/wiki"
+  mkdir -p "$agents_root/alpha/memory" "$inbox" "$wiki_root/_audit"
+
+  # Fixture inbox. Filenames mirror the real capture_id shape produced by
+  # bridge-memory.py capture: `<15-char-timestamp>-<slug>.json`.
+  #
+  #   Excluded — the PreCompact hook's auto/manual dump envelopes:
+  : >"$inbox/20260522T140455-pre-compact-dump-auto.json"
+  : >"$inbox/20260522T141022-pre-compact-dump-manual.json"
+  #   Selected — ordinary non-dump raw captures:
+  : >"$inbox/20260522T142000-research-note.json"
+  : >"$inbox/20260522T142500-decision-x.md"
+  #   Selected — near-miss captures: the basename contains the
+  #   `pre-compact-dump` substring but they are NOT the auto/manual dump
+  #   envelopes. A bare `*pre-compact-dump*` match would wrongly drop these.
+  : >"$inbox/20260522T143000-pre-compact-dump-research.json"
+  : >"$inbox/pre-compact-dump-reference.md"
+
+  # Force the legacy find-based enumeration: it walks $BRIDGE_AGENTS_ROOT/*
+  # directly, which makes the Lane B raw walk fully deterministic against
+  # the isolated fixture. The v2 path resolves agent workdirs via the live
+  # roster, which is not what this smoke owns.
+  local log
+  log="$wiki_root/_audit/ingest-$(date +%Y-%m-%d).md"
+  rm -f "$log"
+
+  env -u BRIDGE_LAYOUT -u BRIDGE_DATA_ROOT \
+    BRIDGE_HOME="$BRIDGE_HOME" \
+    BRIDGE_SHARED_ROOT="$BRIDGE_HOME/shared" \
+    BRIDGE_WIKI_ROOT="$wiki_root" \
+    BRIDGE_AGENTS_ROOT="$agents_root" \
+    BRIDGE_STATE_DIR="$BRIDGE_HOME/state" \
+    BRIDGE_SCRIPTS_ROOT="$SMOKE_REPO_ROOT/scripts" \
+    BRIDGE_AGB="$SMOKE_REPO_ROOT/agent-bridge" \
+    bash "$SMOKE_REPO_ROOT/scripts/wiki-daily-ingest.sh" >/dev/null 2>&1 || true
+
+  smoke_assert_file_exists "$log" "Lane B audit log written"
+  # Emit just the "### Raw envelopes" section body.
+  sed -n '/### Raw envelopes/,/^$/p' "$log"
+}
+
+assert_lane_b_selection() {
+  local section
+  section="$(run_lane_b)"
+
+  smoke_assert_not_contains "$section" "20260522T140455-pre-compact-dump-auto.json" \
+    "T1: auto dump envelope excluded from Lane B raw selection"
+  smoke_assert_not_contains "$section" "20260522T141022-pre-compact-dump-manual.json" \
+    "T2: manual dump envelope excluded from Lane B raw selection"
+  smoke_assert_contains "$section" "20260522T142000-research-note.json" \
+    "T3: non-dump raw .json capture still selected"
+  smoke_assert_contains "$section" "20260522T142500-decision-x.md" \
+    "T3: non-dump raw .md capture still selected"
+  smoke_assert_contains "$section" "20260522T143000-pre-compact-dump-research.json" \
+    "T4: near-miss .json (pre-compact-dump substring, not a dump) still selected"
+  smoke_assert_contains "$section" "pre-compact-dump-reference.md" \
+    "T4: near-miss .md (pre-compact-dump substring, not a dump) still selected"
+  smoke_assert_contains "$section" "Raw envelopes (4)" \
+    "T5: raw count is exactly 4 — near-miss files counted IN, only the 2 dumps dropped"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  smoke_run "T1-T5: Lane B excludes only auto/manual dumps, keeps raw + near-miss" \
+    assert_lane_b_selection
+
+  smoke_log "PASS"
+}
+
+main "$@"

--- a/scripts/wiki-daily-ingest.sh
+++ b/scripts/wiki-daily-ingest.sh
@@ -405,6 +405,19 @@ other_count=${other_count:-0}
 # and raw are deduped through the shared roots array).
 # Same empty-array guard as the research/other walks: every active agent
 # may legitimately be linux-user-isolated, leaving AGENT_MEMORY_ROOTS empty.
+#
+# Issue #679: the PreCompact hook routes through `bridge-memory.py capture`
+# with `--title "pre-compact dump (auto|manual)"`, so each dump lands in this
+# inbox as `<timestamp>-pre-compact-dump-{auto,manual}.json` on every context
+# compaction. Those envelopes carry no `suggested_slug/title`, so the librarian
+# classifier falls through to DEFAULT_KIND and §9 rejects them — but they keep
+# piling up in the inbox and generate a daily [librarian-ambiguous] escalation.
+# Exclude exactly those two dump shapes from Lane B selection — the slug
+# terminates at `auto`/`manual` immediately before `.json`, so anchoring on
+# `*-pre-compact-dump-{auto,manual}.json` matches every dump while leaving
+# legitimate near-miss captures (e.g. `*-pre-compact-dump-research.json`,
+# `pre-compact-dump-reference.md`) and every other raw envelope eligible.
+# Lane A and the curated research/projects/decisions branches are unaffected.
 touched_raw=""
 if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
   for _root in "${AGENT_MEMORY_ROOTS[@]}"; do
@@ -413,7 +426,9 @@ if (( ${#AGENT_MEMORY_ROOTS[@]} > 0 )); then
     [[ -d "$_raw_inbox" ]] || continue
     while IFS= read -r _f; do
       [[ -n "$_f" ]] && touched_raw+="$_f"$'\n'
-    done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) -mtime -1 2>/dev/null)
+    done < <(find "$_raw_inbox" -type f \( -name '*.json' -o -name '*.md' \) \
+      ! -name '*-pre-compact-dump-auto.json' \
+      ! -name '*-pre-compact-dump-manual.json' -mtime -1 2>/dev/null)
   done
 fi
 touched_raw=$(printf '%s' "$touched_raw" | sed '/^$/d' | sort -u)


### PR DESCRIPTION
## Summary

Second re-cut of **v0.14.5-beta4** (the prerelease has still not been downloaded). Brings the `feat/wave-v0145-b4r2-integration` branch to `main` and amends `CHANGELOG.md`. VERSION stays `0.14.5-beta4`; the `v0.14.5-beta4` tag + GitHub prerelease move again to this HEAD.

Folds in two more bug-class issues opened against beta4:

- #1031 — Teams inline-image download HTTP 401 (`streamDownload` now authenticates, exact-host-scoped to Bot Framework / AMS endpoints)
- #679 — wiki-daily-ingest Lane B was ingesting PreCompact dump envelopes

## Verification

- Each PR (#1033, #1034): codex pair-review `implement-ok`, CI green
- Integration branch full-branch codex review: `implement-ok` (#5401)

## Test plan

- [ ] codex release-PR pair-review
- [ ] CI green on the release PR
- [ ] tag `v0.14.5-beta4` moved to the merge commit; GitHub prerelease notes updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)