### PR TITLE
fix(a2a): locate tailscale CLI outside PATH for receiver preflight

### DIFF
--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -25,6 +25,7 @@ import argparse
 import ipaddress
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -75,24 +76,70 @@ class TailscaleUnavailable(a2a.A2AError):
         super().__init__(message, code="tailscale_unavailable")
 
 
+# Well-known absolute locations for the `tailscale` CLI, probed when it
+# is not on PATH. A receiver started from cron / launchd / systemd often
+# has a minimal PATH that omits /opt/homebrew/bin, so PATH-only discovery
+# would fail closed on a macOS host that DOES have Tailscale installed
+# (e.g. via Homebrew). Probing these does not weaken the bind proof — the
+# resolved binary is still run and its `tailscale ip` output is still the
+# only thing trusted.
+_TAILSCALE_FALLBACK_PATHS = (
+    "/opt/homebrew/bin/tailscale",                            # Homebrew (Apple Silicon)
+    "/usr/local/bin/tailscale",                               # Homebrew (Intel) / manual
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",   # macOS App Store app
+    "/usr/bin/tailscale",                                     # Linux package
+    "/usr/sbin/tailscale",
+)
+
+
+def resolve_tailscale_cli() -> Optional[str]:
+    """Locate the `tailscale` CLI: PATH first, then well-known locations.
+
+    `BRIDGE_A2A_TAILSCALE_CLI` overrides discovery entirely (an explicit
+    path for non-standard installs; also lets the smoke exercise the
+    genuinely-absent path deterministically). Returns the resolved path,
+    or None when no candidate exists — the caller fails closed on None.
+    """
+    override = os.environ.get("BRIDGE_A2A_TAILSCALE_CLI")
+    if override:
+        return override
+    found = shutil.which("tailscale")
+    if found:
+        return found
+    for cand in _TAILSCALE_FALLBACK_PATHS:
+        if os.path.isfile(cand) and os.access(cand, os.X_OK):
+            return cand
+    return None
+
+
 def tailscale_addresses() -> list[str]:
     """Return the local node's Tailscale IPs.
 
-    Raises TailscaleUnavailable if the `tailscale` CLI is not on PATH or
-    the query fails — the caller must fail closed in that case rather
+    Raises TailscaleUnavailable if the `tailscale` CLI cannot be located
+    or the query fails — the caller must fail closed in that case rather
     than guessing from a CIDR shape. An *empty* list (CLI ran fine but
     the node has no Tailscale address) is returned as `[]`.
     """
+    cli = resolve_tailscale_cli()
+    if cli is None:
+        raise TailscaleUnavailable(
+            "the 'tailscale' CLI was not found on PATH or in any standard "
+            "install location (/opt/homebrew/bin, /usr/local/bin, "
+            "/Applications/Tailscale.app/Contents/MacOS, /usr/bin) — cannot "
+            "prove the bind address is a real local Tailscale interface. "
+            "Install Tailscale, set BRIDGE_A2A_TAILSCALE_CLI to its path, "
+            "or set BRIDGE_A2A_ALLOW_TEST_BIND=1 for a loopback test bind."
+        )
     try:
         out = subprocess.run(
-            ["tailscale", "ip"],
+            [cli, "ip"],
             capture_output=True, text=True, timeout=5,
         )
     except FileNotFoundError as exc:
         raise TailscaleUnavailable(
-            "the 'tailscale' CLI is not on PATH — cannot prove the bind "
-            "address is a real local Tailscale interface. Install Tailscale "
-            "(or set BRIDGE_A2A_ALLOW_TEST_BIND=1 for a loopback test bind)."
+            f"the 'tailscale' CLI path {cli!r} does not exist or is not "
+            "executable — cannot prove the bind address is a real local "
+            "Tailscale interface."
         ) from exc
     except (subprocess.SubprocessError, OSError) as exc:
         raise TailscaleUnavailable(

--- a/docs/a2a-cross-bridge.md
+++ b/docs/a2a-cross-bridge.md
@@ -55,8 +55,14 @@ Three fixed decisions shape the design:
   a "tailnet-shaped" address (e.g. inside `100.64.0.0/10`) does not prove
   it is a real Tailscale interface, since a host can have a non-Tailscale
   CGNAT interface. If the `tailscale` CLI / local Tailscale address set
-  cannot be determined, the daemon refuses to serve. `remote_addr ==
-  configured peer tailnet IP` is enforced before the request body is read.
+  cannot be determined, the daemon refuses to serve. The `tailscale` CLI
+  is located on `PATH` first, then in well-known install locations
+  (`/opt/homebrew/bin`, `/usr/local/bin`,
+  `/Applications/Tailscale.app/Contents/MacOS`, `/usr/bin`) — a receiver
+  started from cron/launchd/systemd often has a minimal `PATH`. Set
+  `BRIDGE_A2A_TAILSCALE_CLI` to an explicit path for a non-standard
+  install. `remote_addr == configured peer tailnet IP` is enforced
+  before the request body is read.
 - **HMAC-signed requests** (not raw bearer tokens — avoids replayable
   strings in process/log surfaces). The peer-pair secret is the HMAC key.
   - Headers: `X-AGB-Protocol: a2a-enqueue-v1`, `X-AGB-Peer`,

--- a/scripts/smoke/a2a-cross-bridge.sh
+++ b/scripts/smoke/a2a-cross-bridge.sh
@@ -99,9 +99,12 @@ fail_closed_wildcard() {
 
 # BLOCKING #2 regression guard: with the `tailscale` CLI unavailable the
 # receiver must FAIL CLOSED — it must not fall back to a CIDR-shape guess
-# and approve a tailnet-shaped address. Builds a PATH that has python3
-# but no `tailscale`, then preflights a config with a tailnet-shaped
-# (100.64.0.0/10) bind address that is NOT a real local interface.
+# and approve a tailnet-shaped address. `BRIDGE_A2A_TAILSCALE_CLI` points
+# CLI discovery at a path that does not exist (the genuine "unavailable"
+# condition — deterministic regardless of whether the test host happens
+# to have `tailscale` on PATH or in a standard install location), then
+# preflights a config with a tailnet-shaped (100.64.0.0/10) bind address
+# that is NOT a real local interface.
 fail_closed_without_tailscale_cli() {
   cat >"$BRIDGE_HOME/handoff-cgnat.json" <<'EOF'
 {
@@ -112,18 +115,13 @@ fail_closed_without_tailscale_cli() {
 EOF
   chmod 0600 "$BRIDGE_HOME/handoff-cgnat.json"
 
-  local pybin pydir nopath_bin out rc=0
-  pybin="$(command -v python3)"
-  pydir="$SMOKE_TMP_ROOT/nopath-bin"
-  mkdir -p "$pydir"
-  ln -sf "$pybin" "$pydir/python3"
-  nopath_bin="$pydir"
-
-  out="$(PATH="$nopath_bin" python3 "$SMOKE_REPO_ROOT/bridge-handoffd.py" \
+  local out rc=0
+  out="$(BRIDGE_A2A_TAILSCALE_CLI="$SMOKE_TMP_ROOT/no-such-tailscale" \
+    python3 "$SMOKE_REPO_ROOT/bridge-handoffd.py" \
     preflight --config "$BRIDGE_HOME/handoff-cgnat.json" 2>&1)" || rc=$?
   smoke_assert_eq "1" "$rc" "preflight fails closed when tailscale CLI absent"
   smoke_assert_contains "$out" "tailscale_unavailable" \
-    "no-tailscale-CLI reports tailscale_unavailable (no CIDR-shape fallback)"
+    "absent tailscale CLI reports tailscale_unavailable (no CIDR-shape fallback)"
   smoke_assert_not_contains "$out" "preflight] OK" \
     "tailnet-shaped CGNAT address NOT approved without a real local match"
 }


### PR DESCRIPTION
## Summary

- A2A receiver preflight ran `tailscale ip` relying on `PATH`. A receiver started from cron/launchd/systemd has a minimal `PATH` that omits `/opt/homebrew/bin`, so on macOS with Homebrew-installed Tailscale the preflight **fails closed** with `tailscale_unavailable` even though Tailscale is installed and up.
- Resolve `tailscale` via `PATH` first, then well-known absolute locations (Homebrew both arches, the macOS app bundle, Linux package paths). `BRIDGE_A2A_TAILSCALE_CLI` overrides discovery for non-standard installs.
- Discovery only widens *where the real binary is found* — the bind proof still trusts only the resolved binary's `tailscale ip` output. The fail-closed contract (no CIDR-shape guessing) is unchanged.
- Smoke `fail_closed_without_tailscale_cli` now drives the "unavailable" condition via `BRIDGE_A2A_TAILSCALE_CLI` (a non-existent path) — PATH-stripping no longer makes the CLI undiscoverable.

## Context

Found during cross-host A2A VM validation (macOS `agb-mac-seq` ↔ Linux `agb-test`, real Tailscale). 12/12 A2A scenarios passed; this was the one portability gap — on the macOS VM the receiver could not start without a manual `PATH=/opt/homebrew/bin` prefix.

## Test plan

- [x] `python3 -m py_compile bridge-handoffd.py`
- [x] `bash -n` + `shellcheck` on the smoke script
- [x] `scripts/smoke/a2a-cross-bridge.sh` — 14/14 pass (incl. updated fail-closed guard)
- [x] `scripts/smoke-test.sh` — exit 0
- [x] macOS VM: receiver starts **without** the `PATH` workaround (preflight OK, finds `/opt/homebrew/bin/tailscale`); linux→mac handoff `acked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)