### PR TITLE
release: v0.14.5-beta4 re-cut round 3 — A2A cross-bridge (#1032 #1037)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ re-cut a second time to fold in two further bug-class issues (#1031, #679) — s
 the "Re-cut round 2" subsection below. The tag and prerelease move again to the
 round-2 release commit.
 
+**Re-cut round 3 (2026-05-22):** still before any download, `v0.14.5-beta4`
+was re-cut a third time to fold in the **A2A cross-bridge task handoff**
+feature (#1032) plus a macOS portability fix found while validating it
+(#1037) — see the "Re-cut round 3" subsection below. This round adds a new
+feature, so the "No new features" note above applies to the first cut and
+re-cut rounds 1–2 only. A2A was rigorously validated across a macOS VM and a
+Linux VM over real Tailscale before this fold-in. The tag and prerelease move
+again to the round-3 release commit.
+
 ### Re-cut — verification follow-ups (2026-05-22)
 
 - **Isolated `agent create` no longer aborts** (#1025) — the isolation-v2
@@ -86,6 +95,40 @@ The #1010 isolated-agent reap path exercises destructive `userdel` / `setfacl` /
 `groupdel`; CI and review verified the gating *decision* (Linux-only, exact
 generated-user match). The live destructive path still warrants a Linux-host
 spot check before stable `v0.14.5`.
+
+### Re-cut round 3 — A2A cross-bridge task handoff (2026-05-22)
+
+`v0.14.5-beta4` was re-cut a third time (still before any download) to fold in
+the A2A feature and its verification follow-up. Both PRs were codex
+pair-reviewed.
+
+- **A2A cross-bridge task handoff** (#1032, PR #1035) — an agent on one Agent
+  Bridge install can enqueue a task directly into another install's inbox
+  queue, replacing the manual copy-paste / ssh relay. A direct-mesh push
+  gateway over a Tailscale tailnet: each install runs an HMAC-authenticated
+  receiver daemon (`bridge-handoffd.py`) bound to a tailnet IP only — failing
+  closed on a wildcard/loopback bind or an address it cannot prove against
+  `tailscale ip` — plus a durable SQLite sender outbox with retry/backoff and
+  `message_id` dedupe. New CLI surface `agb a2a
+  send|outbox|inbox-dedupe|peers|deliver|daemon`; data-only, git-ignored,
+  mode-0600 config `handoff.local.json`. New modules `bridge-handoffd.py`,
+  `bridge-a2a.py`, `bridge_a2a_common.py`, `bridge-handoff-daemon.sh`,
+  `lib/bridge-a2a.sh`. See `docs/a2a-cross-bridge.md`.
+- **A2A receiver locates the `tailscale` CLI outside `PATH`** (#1037) — the
+  receiver preflight resolved `tailscale` via `PATH` only, so a daemon started
+  from cron/launchd/systemd on a macOS host with Homebrew-installed Tailscale
+  failed closed even though Tailscale was installed and up. Discovery now
+  probes `PATH` then well-known install locations (`/opt/homebrew/bin`,
+  `/usr/local/bin`, the macOS app bundle, `/usr/bin`);
+  `BRIDGE_A2A_TAILSCALE_CLI` overrides. The fail-closed contract — exact
+  membership in `tailscale ip` output, no CIDR-shape guessing — is unchanged.
+
+A2A was validated on `agb-mac-seq` (macOS Sequoia) ↔ `agb-test` (Oracle Linux
+9) over real Tailscale — happy-path handoff both directions, allowlist
+rejection, HMAC auth failure, body-size cap, dedupe idempotency + hash
+conflict, receiver-down → outbox-retry → recovery, daemon lifecycle, secret
+rotation overlap, fail-closed wildcard/loopback bind, clock-skew rejection,
+and `remote_addr` enforcement: 12/12 pass, no secret leakage in audit logs.
 
 ### Operator-visible
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ Tracked source must stay machine-agnostic. Machine-specific roster overrides, ch
 - [`lib/`](./lib): shared Bash implementation. Core modules: `bridge-core.sh`, `bridge-agents.sh`, `bridge-tmux.sh`, `bridge-state.sh`, `bridge-cron.sh`, `bridge-skills.sh`, `bridge-hooks.sh`, `bridge-channels.sh`, `bridge-cleanup.sh`. Isolation-v2 stack (v0.8.0+): `bridge-marker-bootstrap.sh`, `bridge-layout-resolver.sh`, `bridge-isolation-v2.sh`, `bridge-isolation-v2-migrate.sh`, `bridge-isolation-v2-reapply.sh`, `bridge-isolation-runtime.sh`, `bridge-isolation-v3-channel-dotenv.sh`, `bridge-isolation-helpers.sh`, `bridge-migration.sh`, `bridge-host-profile.sh`. See `ARCHITECTURE.md` §"Shell Module Layout" for the full annotated list.
 - [`lib/upgrade-helpers/`](./lib/upgrade-helpers) (v0.13.9+): standalone scripts invoked by `bridge-upgrade.sh` with file-as-argv to bypass the Bash 5.3.9 heredoc-stdin deadlock (footgun #11). Six files: `channel-guard-report.sh`, `channel-guard-json.py`, `agent-restart-json.py`, `recorded-source-root.py`, `isolation-v2-migrate.sh`, `emit-failure-json.py`. **Anti-pattern**: do NOT add new `<<EOF` / `<<'PY'` heredoc-stdin to subprocess in `bridge-upgrade.sh` — extract to a standalone helper instead. See `KNOWN_ISSUES.md` §26.
 - Python is used for structured work: queue backend (`bridge-queue.py`), cron inventory (`bridge-cron.py`), docs/audit/intake/dashboard helpers.
+- A2A cross-bridge handoff (v0.14.5-beta4+): `bridge-handoff-daemon.sh` + `lib/bridge-a2a.sh` (receiver/runner lifecycle), `bridge-handoffd.py` (tailnet-bound receiver daemon), `bridge-a2a.py` (`agb a2a` CLI), `bridge_a2a_common.py` (wire protocol + HMAC + data-only config loader + outbox/inbox SQLite schemas). See `docs/a2a-cross-bridge.md`.
 - [`agents/`](./agents): tracked portable agent profile templates (not runtime homes).
 - [`scripts/`](./scripts): install + smoke + deploy helpers.
 
@@ -111,6 +112,7 @@ Acceptable: prep VERSION + CHANGELOG drafts, run codex-rescue review on a releas
 - `BRIDGE_HOME` — override live runtime root; essential for isolated tests.
 - `AGENT_BRIDGE_SOURCE_DIR` — tell the upgrader where the source checkout is when it's not at `~/.agent-bridge-source`.
 - `BRIDGE_ROSTER_FILE`, `BRIDGE_ROSTER_LOCAL_FILE`, `BRIDGE_STATE_DIR`, `BRIDGE_TASK_DB`, `BRIDGE_WORKTREE_ROOT`, `BRIDGE_CRON_STATE_DIR`.
+- A2A: `BRIDGE_A2A_CONFIG` (override `handoff.local.json` path), `BRIDGE_A2A_TAILSCALE_CLI` (explicit `tailscale` binary path), `BRIDGE_A2A_OUTBOX_DB` / `BRIDGE_A2A_INBOX_DB`, `BRIDGE_A2A_ALLOW_TEST_BIND` (loopback test bind — never in production).
 
 ## High-Risk Areas (edit with care)
 
@@ -119,6 +121,7 @@ Acceptable: prep VERSION + CHANGELOG drafts, run codex-rescue review on a releas
 3. **Upgrade path (`bridge-upgrade.sh`, `bridge-upgrade.py`, `scripts/deploy-live-install.sh`)** — must preserve `state/`, `logs/`, `shared/`, local roster, and live agent homes. The upgrader must also tolerate non-standard source-checkout paths.
 4. **Worktree isolation (`state/worktrees/`, `~/.agent-bridge/worktrees/<repo>/<agent>`)** — getting this wrong can corrupt a shared repo or run an agent against the wrong branch.
 5. **Hooks / tool policy / prompt guard (`hooks/`, `bridge-hooks.py`, `bridge-guard.py`)** — containment/audit layer, not a sandbox. Changes here affect every Claude session's settings.
+6. **A2A receiver (`bridge-handoffd.py`, `bridge_a2a_common.py`)** — the only component that handles untrusted *remote* traffic. The fail-closed tailnet bind, HMAC verification, `remote_addr` check, allowlist, and dedupe are security-critical; never weaken the bind proof or expose `--skip-companion-validate` to remote peers.
 
 ## Platform Notes
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -519,8 +519,8 @@ outbox. Full protocol + security model:
 `$BRIDGE_HOME/handoff.local.json`, fill in this bridge's `bridge_id`, the
 tailnet `listen` IP, and each `peers[]` entry (peer id, tailnet address,
 ordered-pair HMAC `secret`, `inbound_allowlist`), then `chmod 0600` it. The
-file carries peer secrets, is git-ignored, and the loader refuses any mode
-other than 0600.
+file carries peer secrets, is git-ignored, and the loader refuses it if any
+group/world permission bit is set — `0600` is the recommended mode.
 
 ```bash
 agb a2a daemon start|stop|restart|status|tick   # receiver daemon lifecycle

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -507,6 +507,40 @@ Default is `--dry-run`; pass `--apply` to actually run `git worktree remove
 -f`. See `agb worktree doctor --help` for `--target-branch`, `--max-age-days`,
 `--include-stale`, and `--prune-branches`.
 
+## A2A Cross-Bridge Handoff
+
+A2A lets an agent on one Agent Bridge install enqueue a task directly into
+another install's inbox queue over a Tailscale tailnet — no human relay. Each
+install runs an HMAC-authenticated receiver daemon plus a durable sender
+outbox. Full protocol + security model:
+[`docs/a2a-cross-bridge.md`](./docs/a2a-cross-bridge.md).
+
+**Setup.** Copy [`handoff.local.example.json`](./handoff.local.example.json) to
+`$BRIDGE_HOME/handoff.local.json`, fill in this bridge's `bridge_id`, the
+tailnet `listen` IP, and each `peers[]` entry (peer id, tailnet address,
+ordered-pair HMAC `secret`, `inbound_allowlist`), then `chmod 0600` it. The
+file carries peer secrets, is git-ignored, and the loader refuses any mode
+other than 0600.
+
+```bash
+agb a2a daemon start|stop|restart|status|tick   # receiver daemon lifecycle
+agb a2a send --peer <peer> --to <agent> --title <t> --body <text>
+agb a2a deliver                                 # drain the sender outbox once
+agb a2a outbox list|retry <id>|drop <id>|gc
+agb a2a peers list|test <peer>
+```
+
+The receiver binds to the configured tailnet IP **only** and fails closed at
+startup if the bind address is a wildcard / loopback / not in this node's
+`tailscale ip` set, or if the `tailscale` CLI cannot be located. The CLI is
+resolved on `PATH` first, then well-known locations (`/opt/homebrew/bin`,
+`/usr/local/bin`, the macOS app bundle, `/usr/bin`); `BRIDGE_A2A_TAILSCALE_CLI`
+overrides discovery for a non-standard install.
+
+`handoff.local.json` and `state/handoff/` (durable outbox/inbox DBs + staged
+bodies) are live-only operator-owned state — preserved across `agb upgrade`
+like `state/`, `logs/`, and the local roster.
+
 ## Status And Debugging
 
 Use these first:

--- a/docs/developer-handover.md
+++ b/docs/developer-handover.md
@@ -115,6 +115,7 @@ tracked templates다.
 - [`bridge-sync.sh`](../bridge-sync.sh): live roster/state sync
 - [`bridge-status.sh`](../bridge-status.sh): dashboard 출력
 - [`bridge-upgrade.sh`](../bridge-upgrade.sh): live install 업그레이드
+- [`bridge-handoff-daemon.sh`](../bridge-handoff-daemon.sh): A2A cross-bridge handoff lifecycle (수신 데몬 + 송신 delivery-runner)
 
 ### `lib/` 모듈
 
@@ -127,6 +128,7 @@ tracked templates다.
 - `bridge-cron.sh`: cron inventory, enqueue manifest helper
 - `bridge-skills.sh`: project skill bootstrap/sync
 - `bridge-hooks.sh`: Claude hook 관련 helper
+- `bridge-a2a.sh`: A2A 수신 데몬 + delivery-runner lifecycle helper (`bridge-handoff-daemon.sh`가 source)
 
 새 로직을 추가할 때는 루트 스크립트에 큰 함수를 쌓기보다 `lib/`로 내리는 편이
 맞다.
@@ -137,6 +139,9 @@ Python은 보조 역할이다. 대표적으로:
 
 - [`bridge-queue.py`](../bridge-queue.py): SQLite queue backend
 - [`bridge-cron.py`](../bridge-cron.py): cron inventory/metadata
+- [`bridge-handoffd.py`](../bridge-handoffd.py): A2A 수신 데몬 — tailnet-bound HTTP listener, HMAC 검증 후 `bridge-task.sh create` 경유 enqueue
+- [`bridge-a2a.py`](../bridge-a2a.py): A2A CLI (`send`/`outbox`/`inbox-dedupe`/`peers`/`deliver`) — `agb a2a ...`로 호출
+- [`bridge_a2a_common.py`](../bridge_a2a_common.py): A2A 공통 모듈 — wire protocol, HMAC 서명, data-only JSON config loader, outbox/inbox SQLite 스키마
 - `bridge-*.py` 일부: docs, release, audit, guard, intake, dashboard 등
 
 핵심 orchestration은 Bash 중심이지만, structured state 처리나 JSON/SQLite 작업은


### PR DESCRIPTION
## Summary

Re-cut `v0.14.5-beta4` (still before any download) to **fold in the A2A cross-bridge task handoff feature** (#1032, PR #1035) plus its macOS portability follow-up (#1037), per operator request. `VERSION` stays `0.14.5-beta4`.

A2A was VM-validated this session — `agb-mac-seq` (macOS Sequoia) ↔ `agb-test` (Oracle Linux 9) over real Tailscale, **12/12 scenarios pass**.

## Changes (docs only, +85 lines)

- **CHANGELOG.md** — `[0.14.5-beta4]` "Re-cut round 3" intro paragraph + subsection (A2A #1032/#1035, F1 #1037, VM validation matrix).
- **OPERATIONS.md** — new `## A2A Cross-Bridge Handoff` section: `handoff.local.json` setup, `agb a2a daemon` lifecycle, fail-closed tailnet bind, upgrade-preserved state.
- **CLAUDE.md** — A2A modules in Layout at a Glance; `BRIDGE_A2A_*` env vars; A2A receiver added to High-Risk Areas (#6 — only component handling untrusted remote traffic).
- **docs/developer-handover.md** — A2A entries in the root / `lib/` / Python module inventories.

README.md + ARCHITECTURE.md already carry A2A coverage from PR #1035; AGENTS.md / KNOWN_ISSUES.md have no genuine A2A gap (intentionally not padded).

## Note

This is a beta re-cut. It bundles a CHANGELOG re-cut entry with a doc-sync for the feature being folded in — slightly broader than the "release PR = VERSION+CHANGELOG only" guideline, done deliberately per operator request so the re-cut ships doc-consistent. No code changes.

## Test plan

- [x] `scripts/oss-preflight.sh` — the email-check `fail` line matches pre-existing `git@github.com:` SSH URLs in untouched files (CHANGELOG line renumber only); not introduced here. CI `oss-preflight` passed on #1037.
- [ ] CI green on this PR

## After merge

Re-cut the `v0.14.5-beta4` tag to this merge commit + `git push --force`; update the GitHub prerelease notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)