### PR TITLE
fix(a2a): make receiver daemon durable past the launching shell (#1043)

### DIFF
--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -16,6 +16,7 @@ local Tailscale address set.
 
 Usage:
   bridge-handoffd.py serve   --config <path>   [--once]
+                             [--detach --pidfile <path>]
   bridge-handoffd.py preflight --config <path>   # validate bind, exit
 """
 
@@ -635,6 +636,41 @@ def cmd_preflight(args: argparse.Namespace) -> int:
     return 0
 
 
+def _write_pidfile(path: str) -> None:
+    """Record the calling process's pid to `path` (atomic replace)."""
+    pid_path = Path(path)
+    pid_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = pid_path.with_suffix(pid_path.suffix + f".{os.getpid()}.tmp")
+    tmp.write_text(f"{os.getpid()}\n", encoding="utf-8")
+    os.replace(tmp, pid_path)
+
+
+def _detach_into_own_session() -> None:
+    """Reparent the current process into its own session + process group.
+
+    After this returns, the process is a session leader detached from the
+    launching shell's controlling terminal and process group, so it is NOT
+    torn down when that shell / managed agent tool session exits. Uses the
+    POSIX double-fork idiom, which is portable across macOS and Linux (no
+    dependency on the `setsid` CLI, which macOS lacks). The socket is bound
+    BEFORE this is called, so a fail-closed bind error is still surfaced
+    synchronously to the launcher.
+    """
+    if os.fork() > 0:
+        os._exit(0)  # original launcher process exits; shell regains control
+    os.setsid()  # become session + process-group leader, drop controlling tty
+    if os.fork() > 0:
+        os._exit(0)  # intermediate exits so the daemon cannot reacquire a tty
+    # Grandchild: detach stdin from the terminal; stdout/stderr stay pointed
+    # at the caller-provided log redirection.
+    try:
+        devnull = os.open(os.devnull, os.O_RDONLY)
+        os.dup2(devnull, 0)
+        os.close(devnull)
+    except OSError:
+        pass
+
+
 def cmd_serve(args: argparse.Namespace) -> int:
     try:
         cfg = a2a.load_config(Path(args.config) if args.config else None)
@@ -652,8 +688,25 @@ def cmd_serve(args: argparse.Namespace) -> int:
         audit("bind_fail", address=bind, port=port, detail=str(exc))
         return 1
 
+    # Bind succeeded — fail-closed preflight is satisfied. Now (optionally)
+    # detach into our own session so the receiver outlives the launching
+    # shell / managed agent tool session. The double-fork happens AFTER the
+    # bind so the launcher still sees a non-zero exit on a bad bind.
+    if getattr(args, "detach", False):
+        _detach_into_own_session()
+    if getattr(args, "pidfile", None):
+        # Written by whichever process owns the long-lived server (the
+        # detached grandchild when --detach is set), so the recorded pid is
+        # the durable listener, not a transient launcher pid.
+        try:
+            _write_pidfile(args.pidfile)
+        except OSError as exc:
+            log(f"FATAL: cannot write pidfile {args.pidfile}: {exc}")
+            server.server_close()
+            return 1
+
     audit("listening", address=bind, port=port,
-          peers=len(cfg.get("peers", [])))
+          peers=len(cfg.get("peers", [])), pid=os.getpid())
     log(f"A2A receiver listening on {bind}:{port}")
     try:
         if args.once:
@@ -664,6 +717,13 @@ def cmd_serve(args: argparse.Namespace) -> int:
         log("interrupted")
     finally:
         server.server_close()
+        if getattr(args, "pidfile", None):
+            try:
+                pid_path = Path(args.pidfile)
+                if pid_path.read_text(encoding="utf-8").strip() == str(os.getpid()):
+                    pid_path.unlink()
+            except (OSError, ValueError):
+                pass
         audit("stopped")
     return 0
 
@@ -680,6 +740,11 @@ def build_parser() -> argparse.ArgumentParser:
                          help="path to handoff.local.json")
     p_serve.add_argument("--once", action="store_true",
                          help="handle a single request then exit (test mode)")
+    p_serve.add_argument("--detach", action="store_true",
+                         help="double-fork into an own session after bind, so "
+                              "the receiver outlives the launching shell")
+    p_serve.add_argument("--pidfile", default=None,
+                         help="write the durable listener's pid to this path")
     p_serve.set_defaults(func=cmd_serve)
 
     p_pre = sub.add_parser("preflight", help="validate bind + config, then exit")

--- a/docs/a2a-cross-bridge.md
+++ b/docs/a2a-cross-bridge.md
@@ -190,6 +190,15 @@ backpressure: over quota → `429` with `Retry-After`.
 The delivery runner can be daemon-driven or cron-driven (`a2a daemon
 tick` ensures the receiver is up, then drains the outbox once).
 
+`a2a daemon start` launches the receiver with a POSIX double-fork detach
+(`bridge-handoffd.py serve --detach`) **after** the tailnet bind succeeds,
+so the listener is reparented into its own session and survives the
+launching shell / managed agent tool session exiting — a bare background
+job is not durable from such shells. The detached process owns the pid
+file, so `a2a daemon status` reflects the real long-lived listener. A
+fail-closed bind error still surfaces synchronously as a non-zero exit
+from `start` (the bind happens before the detach).
+
 ## Configuration
 
 Copy `handoff.local.example.json` to `$BRIDGE_HOME/handoff.local.json`,

--- a/lib/bridge-a2a.sh
+++ b/lib/bridge-a2a.sh
@@ -92,15 +92,49 @@ bridge_a2a_receiver_start() {
     return 1
   fi
 
+  # Stale pid file from a previous (now-dead) receiver would otherwise let
+  # the new launch's success check pass against the old pid.
+  rm -f "$pid_file"
+
+  # `serve --detach` double-forks into its own session AFTER the socket
+  # bind, so the receiver is reparented out of this shell's process group
+  # and survives the launching (managed agent) shell exiting. A bare
+  # `nohup ... &` did not detach from the process group, so the listener
+  # could be torn down with the tool session — issue #1043. The detached
+  # grandchild owns the pid file, so the recorded pid is the durable
+  # listener rather than a transient launcher pid.
   nohup python3 "$repo_root/bridge-handoffd.py" serve --config "$config" \
+    --detach --pidfile "$pid_file" \
     >>"$log_file" 2>&1 &
-  local pid=$!
-  printf '%s\n' "$pid" >"$pid_file"
-  # Give the process a beat to fail-closed on bind; if it died, report it.
-  sleep 1
-  if ! kill -0 "$pid" 2>/dev/null; then
+  local launcher_pid=$!
+  # The launcher process exits 0 once the detached child is running; if the
+  # bind failed closed, it exits non-zero before any detach. Guard the wait
+  # so a non-zero exit does not trip the caller's `set -e`.
+  local launcher_rc=0
+  wait "$launcher_pid" || launcher_rc=$?
+  if (( launcher_rc != 0 )); then
     rm -f "$pid_file"
-    echo "[a2a][error] receiver exited immediately; see $log_file" >&2
+    echo "[a2a][error] receiver failed to start (exit $launcher_rc); see $log_file" >&2
+    return 1
+  fi
+
+  # Wait for the detached child to publish its pid, then verify it is a
+  # live process — this confirms a durable listener, not a false success.
+  local waited=0 pid=""
+  while (( waited < 10 )); do
+    if [[ -f "$pid_file" ]]; then
+      pid="$(cat "$pid_file" 2>/dev/null || true)"
+      if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+        break
+      fi
+    fi
+    sleep 1
+    waited=$((waited + 1))
+    pid=""
+  done
+  if [[ -z "$pid" ]]; then
+    rm -f "$pid_file"
+    echo "[a2a][error] receiver did not come up durably; see $log_file" >&2
     return 1
   fi
   echo "[a2a] receiver started (pid $pid); log: $log_file"

--- a/lib/bridge-a2a.sh
+++ b/lib/bridge-a2a.sh
@@ -47,30 +47,42 @@ bridge_a2a_log_file() {
   printf '%s' "${BRIDGE_LOG_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/logs}/a2a-handoffd.log"
 }
 
-# True if `pid` is alive AND its command line is the A2A receiver
-# (`bridge-handoffd.py serve`). A bare `kill -0` is not enough: after the
-# real receiver dies, PID reuse can hand that number to an unrelated live
-# process, and a stale pid file would then read as "running" — making
-# `start` short-circuit to a false "already running" with no listener
-# (issue #1043 review finding). `ps -p <pid> -o command=` is portable
-# across macOS and Linux.
+# True if `pid` is alive AND its command line is the A2A receiver for
+# THIS install — i.e. a `bridge-handoffd.py serve` process launched with
+# `--pidfile <pid_file>`. A bare `kill -0` is not enough: after the real
+# receiver dies, PID reuse can hand that number to an unrelated live
+# process (issue #1043 review r1). Matching only `bridge-handoffd.py` +
+# `serve` is also not enough: another Agent Bridge install / config runs
+# the same binary, so a stale pid file pointing at *that* install's
+# receiver would still read as "running" here (review r2). The receiver
+# is launched as `bridge-handoffd.py serve --config <config>
+# --detach --pidfile <pid_file>`, and the pidfile path is unique per
+# `$BRIDGE_HOME`, so requiring the exact `--pidfile <pid_file>` token in
+# the cmdline ties the process to the exact pidfile being read.
+# `ps -p <pid> -o command=` is portable across macOS and Linux.
+#
+# Args: $1 = pid, $2 = expected pidfile path the process must reference.
 bridge_a2a_receiver_pid_is_receiver() {
-  local pid="$1" cmd
+  local pid="$1" expect_pid_file="$2" cmd
   [[ -n "$pid" && "$pid" =~ ^[0-9]+$ ]] || return 1
+  [[ -n "$expect_pid_file" ]] || return 1
   kill -0 "$pid" 2>/dev/null || return 1
   cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
-  [[ "$cmd" == *bridge-handoffd.py* && "$cmd" == *serve* ]]
+  [[ "$cmd" == *bridge-handoffd.py* && "$cmd" == *serve* ]] || return 1
+  # Bind the match to this install: the running cmdline must carry the
+  # exact `--pidfile` value of the pid file we just read.
+  [[ "$cmd" == *"--pidfile $expect_pid_file"* ]]
 }
 
 # True if a receiver daemon is running: pid file present, the pid is
-# alive, AND that pid is genuinely the A2A receiver process (not a
-# coincidental PID-reuse match).
+# alive, AND that pid is genuinely THIS install's A2A receiver process
+# (not a coincidental PID-reuse match, nor another install's receiver).
 bridge_a2a_receiver_running() {
   local pid_file pid
   pid_file="$(bridge_a2a_pid_file)"
   [[ -f "$pid_file" ]] || return 1
   pid="$(cat "$pid_file" 2>/dev/null || true)"
-  bridge_a2a_receiver_pid_is_receiver "$pid"
+  bridge_a2a_receiver_pid_is_receiver "$pid" "$pid_file"
 }
 
 bridge_a2a_receiver_pid() {
@@ -119,8 +131,13 @@ bridge_a2a_receiver_start() {
   # could be torn down with the tool session — issue #1043. The detached
   # grandchild owns the pid file, so the recorded pid is the durable
   # listener rather than a transient launcher pid.
-  nohup python3 "$repo_root/bridge-handoffd.py" serve --config "$config" \
-    --detach --pidfile "$pid_file" \
+  #
+  # `--pidfile` is placed before `--config` so the per-install unique key
+  # that bridge_a2a_receiver_pid_is_receiver() matches on appears early in
+  # the cmdline, ahead of the (potentially long) config path, in case
+  # `ps -o command=` truncates very long command lines.
+  nohup python3 "$repo_root/bridge-handoffd.py" serve \
+    --pidfile "$pid_file" --detach --config "$config" \
     >>"$log_file" 2>&1 &
   local launcher_pid=$!
   # The launcher process exits 0 once the detached child is running; if the
@@ -141,7 +158,7 @@ bridge_a2a_receiver_start() {
   while (( waited < 10 )); do
     if [[ -f "$pid_file" ]]; then
       pid="$(cat "$pid_file" 2>/dev/null || true)"
-      if bridge_a2a_receiver_pid_is_receiver "$pid"; then
+      if bridge_a2a_receiver_pid_is_receiver "$pid" "$pid_file"; then
         break
       fi
     fi

--- a/lib/bridge-a2a.sh
+++ b/lib/bridge-a2a.sh
@@ -47,14 +47,30 @@ bridge_a2a_log_file() {
   printf '%s' "${BRIDGE_LOG_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/logs}/a2a-handoffd.log"
 }
 
-# True if a receiver daemon is running (pid file present + process alive).
+# True if `pid` is alive AND its command line is the A2A receiver
+# (`bridge-handoffd.py serve`). A bare `kill -0` is not enough: after the
+# real receiver dies, PID reuse can hand that number to an unrelated live
+# process, and a stale pid file would then read as "running" — making
+# `start` short-circuit to a false "already running" with no listener
+# (issue #1043 review finding). `ps -p <pid> -o command=` is portable
+# across macOS and Linux.
+bridge_a2a_receiver_pid_is_receiver() {
+  local pid="$1" cmd
+  [[ -n "$pid" && "$pid" =~ ^[0-9]+$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  cmd="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  [[ "$cmd" == *bridge-handoffd.py* && "$cmd" == *serve* ]]
+}
+
+# True if a receiver daemon is running: pid file present, the pid is
+# alive, AND that pid is genuinely the A2A receiver process (not a
+# coincidental PID-reuse match).
 bridge_a2a_receiver_running() {
   local pid_file pid
   pid_file="$(bridge_a2a_pid_file)"
   [[ -f "$pid_file" ]] || return 1
   pid="$(cat "$pid_file" 2>/dev/null || true)"
-  [[ -n "$pid" && "$pid" =~ ^[0-9]+$ ]] || return 1
-  kill -0 "$pid" 2>/dev/null
+  bridge_a2a_receiver_pid_is_receiver "$pid"
 }
 
 bridge_a2a_receiver_pid() {
@@ -118,13 +134,14 @@ bridge_a2a_receiver_start() {
     return 1
   fi
 
-  # Wait for the detached child to publish its pid, then verify it is a
-  # live process — this confirms a durable listener, not a false success.
+  # Wait for the detached child to publish its pid, then verify the pid is
+  # genuinely the A2A receiver process — confirms a durable listener, not a
+  # false success against a coincidental pid.
   local waited=0 pid=""
   while (( waited < 10 )); do
     if [[ -f "$pid_file" ]]; then
       pid="$(cat "$pid_file" 2>/dev/null || true)"
-      if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+      if bridge_a2a_receiver_pid_is_receiver "$pid"; then
         break
       fi
     fi


### PR DESCRIPTION
## Summary

Fixes #1043 — `agent-bridge a2a daemon start` reported success while the A2A receiver process disappeared once the invoking shell / managed agent tool session exited (`a2a daemon status` → `stopped`, peers saw `Connection refused` on port 8787).

**Root cause**: the receiver was launched with a bare `nohup python3 bridge-handoffd.py serve ... &`. `nohup` ignores SIGHUP but does **not** detach the child from the launching shell's process group/session — so the listener could be reaped when a managed agent tool session's process group was torn down. The old one-second `kill -0` check could therefore print success and then leave no listener.

## Change

- `bridge-handoffd.py serve` gains two flags:
  - `--detach` — after the socket bind succeeds, the process performs a POSIX double-fork into its own session (`os.fork()` → `os.setsid()` → `os.fork()`), reparenting it out of the launcher's process group. This is portable across macOS and Linux and does **not** depend on the `setsid` CLI (macOS lacks it). The double-fork happens **after** the bind, so a fail-closed bind error still surfaces synchronously as a non-zero exit.
  - `--pidfile` — the process owning the long-lived server (the detached grandchild) writes its own pid via an atomic replace, so the recorded pid is the durable listener, not a transient launcher pid. The pidfile is removed on clean shutdown only if it still holds this process's pid.
- `bridge_a2a_receiver_start()` (`lib/bridge-a2a.sh`) launches with `--detach --pidfile`, clears any stale pid file first, `wait`s for the launcher process to confirm a clean bind (non-zero ⇒ fail closed), then polls for the detached child's pid and verifies it is a live process before reporting success — closing the old false-success window.
- `docs/a2a-cross-bridge.md` documents the durable-detach contract.

No change to the `agent-bridge a2a daemon ...` CLI surface. No `VERSION` / `CHANGELOG.md` change.

## Verification (macOS, `sean-macbookpro`)

All run in an isolated `BRIDGE_HOME` (`mktemp -d`) with a `127.0.0.1` loopback test bind + `BRIDGE_A2A_ALLOW_TEST_BIND=1`.

- `bash -n` + `shellcheck` on `lib/bridge-a2a.sh` + `bridge-handoff-daemon.sh`: PASS
- `python3 -m py_compile bridge-handoffd.py`: PASS
- **Durability test**: started the receiver from a subshell, let that subshell exit, then from a fresh shell:
  - `a2a daemon status` → `receiver: running (pid 45899)`
  - `ps -o pid,ppid,pgid,sess` → `PPID=1` (reparented to launchd), own process group — fully detached from the launcher's group
  - `curl http://127.0.0.1:18787/healthz` → `{"ok": true, "service": "a2a-handoffd"}`
  - `lsof -iTCP:18787 -sTCP:LISTEN` → Python listening
- `stop` → process gone, `status` → `stopped`, port released, `/healthz` → connection refused
- **Fail-closed preserved**: loopback bind without `BRIDGE_A2A_ALLOW_TEST_BIND` → `preflight FAIL`, `start` exits 1, no pid file recorded; port-in-use at `serve` time → launcher exits 1 before any detach, `start` returns 1 (no false success)
- `./scripts/smoke-test.sh` (all `BRIDGE_*` env unset): `rc=1` — **pre-existing**, reproduced identically on the unmodified `release/v0.14.5-beta5-integration` baseline in a temp clone. The failures (`smoke-agent activity state`, `smoke leaked agent dirs into the live install — refs #4793`) are a smoke-harness/live-install collision on this host, in the tmux-role / roster-sync section; they touch no A2A code. The only A2A smoke assertion (`[A2A] task body mentioning 429 -> silent`) passed.

## Focus points for codex pair-review

1. **Double-fork correctness**: parent + intermediate use `os._exit(0)` (not `sys.exit`) so the inherited bound socket fd is not closed and buffers are not double-flushed in the forked processes. Confirm this is the intended behavior.
2. **Fail-closed ordering**: the detach happens strictly after `HandoffServer((bind, port), ...)` succeeds — verify a bad bind (wildcard/loopback/non-tailnet, or port-in-use) still produces a non-zero `start` exit and no pid file.
3. **pidfile ownership race**: the launcher (`lib/bridge-a2a.sh`) clears the stale pidfile, then polls up to 10s for the detached grandchild to publish + a live `kill -0`. Confirm there is no window where the launcher returns success against a stale or transient pid.
4. **`set -e` interaction**: `bridge-handoff-daemon.sh` runs `set -euo pipefail`; the `wait "$launcher_pid" || launcher_rc=$?` guard is intentional so a non-zero launcher exit does not abort the script before the error is reported.
5. **stdin detach**: the grandchild dups `/dev/null` onto fd 0; stdout/stderr stay pointed at the caller-provided `>>"$log_file"` redirection.
6. Cross-platform: the fix was observed/verified on macOS; the EC2 Linux peer path uses the same `serve --detach` (double-fork is POSIX-portable). A Linux spot-check would be a good belt-and-suspenders.