### PR TITLE
fix(hooks): quote-aware read-intent split + codex SessionStart schema (#1054 #1055)

### DIFF
--- a/hooks/session_start.py
+++ b/hooks/session_start.py
@@ -234,11 +234,17 @@ def main(argv: list[str] | None = None) -> int:
         context = "\n\n".join(parts)
 
     if args.format == "codex":
+        # Codex 0.133.0's SessionStartHookSpecificOutputWire is
+        # `deny_unknown_fields` / `additionalProperties: false` and accepts
+        # only `hookEventName` + `additionalContext`. Emitting `matcher`
+        # made `parse_session_start` reject the object, failing the
+        # SessionStart hook on every codex agent (issue #1055). `matcher`
+        # is still read from stdin above for internal behavior; it just
+        # must not be echoed in the Codex output object.
         json.dump(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "SessionStart",
-                    "matcher": matcher or "startup",
                     "additionalContext": context,
                 }
             },

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -656,7 +656,14 @@ def _is_read_intent_bash(command: str) -> bool:
     # would be misclassified as write-intent (issue #1054). A genuine
     # `... | tee <path>` still splits — the `tee` stage is unknown and
     # disqualifies the command, so the guard is not weakened.
-    for stage in _split_command_stages(sanitized):
+    stages, balanced = _split_command_stages(sanitized)
+    # Fail closed on an unterminated quote: an unbalanced quote masks
+    # every operator after it, so a `... | tee <protected>` write would
+    # hide behind the open quote. An un-parseable command is never a safe
+    # read (issue #1054 codex r1).
+    if not balanced:
+        return False
+    for stage in stages:
         stage_stripped = stage.strip()
         if not stage_stripped:
             continue
@@ -962,8 +969,12 @@ _FILE_VALUED_FLAGS = frozenset(
 _COMMAND_OPERATOR_RE = re.compile(r"&&|\|\||\||;|&|\n")
 
 
-def _split_command_stages(command: str) -> list[str]:
+def _split_command_stages(command: str) -> tuple[list[str], bool]:
     """Split *command* into shell stages, ignoring operators inside quotes.
+
+    Returns ``(stages, balanced)``. ``balanced`` is ``False`` when the
+    string ends while still inside an unterminated single or double
+    quote — the command is not parseable as written.
 
     A bare :func:`_COMMAND_OPERATOR_RE.split` is not shell-quote aware: a
     literal operator character inside a single- or double-quoted argument
@@ -980,6 +991,12 @@ def _split_command_stages(command: str) -> list[str]:
     backslash and an escaped quote inside the *other* quote style is
     already inert. Genuine pipelines / separators outside quotes still
     split exactly as before, so the guard is not weakened.
+
+    An *unbalanced* quote masks every operator after it (the parser stays
+    "inside" the quote to end-of-string), which would hide a real
+    ``| tee <protected>`` write. The caller must fail closed on
+    ``balanced=False`` — an un-parseable command is never a safe read
+    (issue #1054 codex r1).
     """
     stages: list[str] = []
     start = 0
@@ -1005,7 +1022,7 @@ def _split_command_stages(command: str) -> list[str]:
             continue
         i += 1
     stages.append(command[start:])
-    return stages
+    return stages, quote is None
 
 
 # Redirection prefixes that can ride with the path token (`<file`, `>out`,

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -650,7 +650,13 @@ def _is_read_intent_bash(command: str) -> bool:
     # `2>/dev/null/extra` is a real write to a path under /dev/null/,
     # not a stderr discard, and must NOT be stripped (issue #574 r2).
     sanitized = _SAFE_REDIRECT_RE.sub(" ", command)
-    for stage in _COMMAND_OPERATOR_RE.split(sanitized):
+    # Split on shell operators with quote-awareness: a literal `|` / `;` /
+    # `&` inside a quoted argument (e.g. the alternation in `grep -nE
+    # 'format|codex' <path>`) must NOT start a new stage, or the read
+    # would be misclassified as write-intent (issue #1054). A genuine
+    # `... | tee <path>` still splits — the `tee` stage is unknown and
+    # disqualifies the command, so the guard is not weakened.
+    for stage in _split_command_stages(sanitized):
         stage_stripped = stage.strip()
         if not stage_stripped:
             continue
@@ -954,6 +960,53 @@ _FILE_VALUED_FLAGS = frozenset(
 # We split each token on these operators so a trailing operator doesn't hide
 # a real path argv from the Path comparison below.
 _COMMAND_OPERATOR_RE = re.compile(r"&&|\|\||\||;|&|\n")
+
+
+def _split_command_stages(command: str) -> list[str]:
+    """Split *command* into shell stages, ignoring operators inside quotes.
+
+    A bare :func:`_COMMAND_OPERATOR_RE.split` is not shell-quote aware: a
+    literal operator character inside a single- or double-quoted argument
+    — most commonly the ``|`` in an extended-regex alternation such as
+    ``grep -nE 'format|codex' <path>`` — is torn into a spurious new
+    stage, whose leading token (``codex'``) is unknown, so a read-only
+    command is misclassified as write-intent (issue #1054).
+
+    This walks the string once, tracking single/double quote state, and
+    only honors an operator match that begins outside any quoted span.
+    Quoting semantics match POSIX shells: a single quote is literal (a
+    double quote inside it is not a quote), and vice versa; backslash
+    escaping is not modelled because the operator regex never matches a
+    backslash and an escaped quote inside the *other* quote style is
+    already inert. Genuine pipelines / separators outside quotes still
+    split exactly as before, so the guard is not weakened.
+    """
+    stages: list[str] = []
+    start = 0
+    quote: str | None = None
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if quote is not None:
+            if ch == quote:
+                quote = None
+            i += 1
+            continue
+        if ch in ("'", '"'):
+            quote = ch
+            i += 1
+            continue
+        match = _COMMAND_OPERATOR_RE.match(command, i)
+        if match:
+            stages.append(command[start:i])
+            start = match.end()
+            i = match.end()
+            continue
+        i += 1
+    stages.append(command[start:])
+    return stages
+
 
 # Redirection prefixes that can ride with the path token (`<file`, `>out`,
 # `2>err`, `&>log`, `>>append`). We peel the prefix before the expanduser /

--- a/tests/tool-policy-bash-system-class/smoke.sh
+++ b/tests/tool-policy-bash-system-class/smoke.sh
@@ -321,6 +321,24 @@ else
   fail "scenario 15: Track E helper call missing from bridge_write_idle_ready_agents"
 fi
 
+# --- Scenario 16: issue #1054 — quoted `|` in a read command argument
+# `grep -nE 'a|b' <peer-read>` is read-intent: the `|` lives inside the
+# single-quoted extended-regex alternation and must NOT be split into a
+# spurious pipeline stage. Before the quote-aware split it misclassified
+# as write-intent and the peer-read carve-out was defeated.
+out="$(run_hook "$SYSTEM_AGENT" system "grep -nE 'projects|body' $PROJECTS_FILE" 2>/dev/null)"
+assert_allow "scenario 16 (#1054 quoted | in grep -E peer read)" "$out"
+
+# --- Scenario 17: issue #1054 codex r1 — unbalanced quote fails CLOSED.
+# An unterminated quote masks every operator after it, so the `| tee`
+# write to a forbidden path hides behind the open quote. `_split_command_
+# stages` reports the open-quote state and `_is_read_intent_bash` must
+# return False (not read-intent) — the command stays write-intent and the
+# cross-agent / forbidden write is denied. An un-parseable command is
+# never treated as a safe read.
+out="$(run_hook "$SYSTEM_AGENT" system "cat $PROJECTS_FILE ' | tee $SHARED_PRIVATE_FILE" 2>/dev/null)"
+assert_deny "scenario 17 (#1054 r1 unbalanced quote masks | tee — fail closed)" "$out"
+
 # --- Summary
 printf '\n[smoke] PASS=%d FAIL=%d\n' "$PASS" "$FAIL"
 if (( FAIL > 0 )); then


### PR DESCRIPTION
## Summary

Two independent hook bugs, one file each — wave b5.

- **#1054** — `hooks/tool-policy.py` `_is_read_intent_bash` split a Bash command into pipeline stages with `_COMMAND_OPERATOR_RE` *without* shell-quote-awareness. A literal `|` / `;` / `&` inside a quoted argument (most commonly the extended-regex alternation in `grep -nE 'format|codex' <path>`) was torn into a spurious stage whose leading token (`codex'`) is unknown, so a read-only command against a protected path was misclassified as write-intent and denied with the write-oriented `agent-bridge config set` message. Fix: new `_split_command_stages` single-pass quote-aware splitter that only honors operators outside single/double quotes; `_is_read_intent_bash` now uses it. The guard is **not** weakened — a genuine `... | tee <protected>` still splits and is still denied.
- **#1055** — `hooks/session_start.py --format codex` emitted `hookSpecificOutput.matcher`, but Codex 0.133.0's `SessionStartHookSpecificOutputWire` is `deny_unknown_fields` / `additionalProperties: false` and accepts only `hookEventName` + `additionalContext`. The unknown key made `parse_session_start` reject the object → SessionStart hook failed on every codex agent. Fix: drop `matcher` from the codex output object only. `matcher` is still read from stdin for internal behavior; the text/Claude-format path is untouched.

Files changed: `hooks/tool-policy.py` (+55/-2), `hooks/session_start.py` (+8/-1).

## #1054 A/B evidence

`_is_read_intent_bash` direct unit exercise:

| command | before | after |
|---|---|---|
| `grep -c format <protected>` | True (allowed) | True (allowed) |
| `grep -nE 'format\|codex' <protected>` | **False (wrongly DENIED)** | **True (allowed)** |
| `egrep 'a\|b' file`, `awk '/foo\|bar/' <protected>` | False (wrongly denied) | True (allowed) |
| `grep -nE 'a;b' file`, `grep -nE 'a&b' file`, `grep -E "x\|y" file` | False (wrongly denied) | True (allowed) |
| `cat file \| tee <protected>` (genuine write pipeline) | False (denied) | **False (still denied)** |
| `grep foo file \| sh` | False | False |
| `cat file > out` | False | False |
| `grep -nE 'x\|y' a && rm b`, `... ; rm b` | False | False |

Naive-split simulation confirms the root cause: `grep -nE 'format|codex' x` was `_COMMAND_OPERATOR_RE.split` → `["grep -nE 'format", "codex' x"]`.

Note: `sed` is *not* in `_READ_INTENT_BASH_COMMANDS` (pre-existing), so `sed -n '/a|b/p'` stays write-intent regardless — out of scope for this fix.

## #1055 before/after JSON (`session_start.py --format codex`, stdin `{"source":"startup"}`)

Before:
```json
{"hookSpecificOutput": {"hookEventName": "SessionStart", "matcher": "startup", "additionalContext": "..."}}
```
After:
```json
{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
```
`keys: ['additionalContext', 'hookEventName']`, `matcher present: False` — verified through both `session_start.py` directly and the `codex-session-start.py` wrapper. The Claude/text-format path emits raw context (no JSON wrapper) — unchanged.

## Verification

- `python3 -m py_compile hooks/tool-policy.py hooks/session_start.py hooks/codex-session-start.py` — PASS
- No `.sh` touched (bash -n / shellcheck N/A)
- `scripts/lint-heredoc-ban.sh --baseline-check` — PASS; diff grep for `<<` / `< <(` / `<<<` in added lines — none
- `./scripts/smoke-test.sh` — tool-policy assertions PASS (`tool-policy other_agent_homes`, `protected_alias_reason ... read-intent allowed (#383)`). Pre-existing environment-induced failures (`smoke leaked agent dirs`, `status should show activity state`) reproduce identically on a pristine clone of `release/v0.14.5-beta5-integration` — not a regression from this PR (this host has a live `~/.agent-bridge` install that breaks the smoke test's isolation).

## Focus points for codex pair-review

- `_split_command_stages` quote model: single quote is literal (a `"` inside `'...'` is not a quote), and vice versa; backslash escaping is intentionally not modelled — confirm no shell shape defeats the splitter into ignoring a real operator (e.g. `grep x | tee prot` must still split). Adversarial cases worth probing: unbalanced quote, `$'...'` ANSI-C quote, backtick/`$(...)` substitution containing operators.
- Confirm the guard is genuinely not weakened: any pipeline whose post-operator stage has an unknown leading token still returns `False`.
- #1055: confirm `matcher` is still consumed for `clear`/`compact` internal behavior and only the *echoed* output object changed; confirm the Claude-format path is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
