### PR TITLE
fix(isolation-v2): workdir scaffold + shared-agent matrix classification (#1045 #1046 #1048)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -412,21 +412,27 @@ bridge_scaffold_agent_home() {
   local rel=""
   local target=""
 
-  # v2 layout (issue #686): bridge_agent_workdir resolves to a sibling
-  # `workdir/` next to `home/` when BRIDGE_AGENT_ROOT_V2 is active. The
-  # canonical ASCII art at the top of lib/bridge-isolation-v2.sh lists
-  # both as required per-agent subdirs (`home/` is the isolated process
-  # HOME, `workdir/` is the project tree the agent operates in). Without
-  # this, every fresh `agent create` on v2 leaves `<agent-root>/workdir`
-  # missing, so `bridge-start.sh --dry-run` (and any resolver-relative
-  # tooling like doctor/status) bombs with `workdir가 없습니다`.
-  # Compute the v2 workdir target up-front so the isolated/non-isolated
-  # branches below can both pre-create it alongside `$home`. Legacy
-  # installs (no BRIDGE_AGENT_ROOT_V2) keep `home == workdir` per
-  # bridge_agent_workdir's fallback, so this stays empty and is a no-op.
-  local _scaffold_v2_workdir=""
+  # v2 layout (issue #686): the canonical per-agent layout has two sibling
+  # subdirs — `home/` (isolated process HOME) and `workdir/` (the project
+  # tree the agent operates in, and the resolver-resolved runtime cwd).
+  # `$home` (this function's $2) is whichever one the create flow chose as
+  # the scaffold target. #1045/#1046: the create flow now defaults that to
+  # the resolved `workdir/` so the profile lands where the runtime looks.
+  # The OTHER sibling must still exist as a directory so resolvers and
+  # tooling (doctor/status/start --dry-run) do not bomb with `... 없습니다`.
+  # Compute that sibling up-front so the isolated/non-isolated branches
+  # below can both pre-create it alongside `$home`. Legacy installs (no
+  # BRIDGE_AGENT_ROOT_V2) keep `home == workdir`, so this stays empty and
+  # is a no-op.
+  local _scaffold_v2_sibling=""
   if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" && -n "$agent" ]]; then
-    _scaffold_v2_workdir="$BRIDGE_AGENT_ROOT_V2/$agent/workdir"
+    local _scaffold_v2_home="$BRIDGE_AGENT_ROOT_V2/$agent/home"
+    local _scaffold_v2_workdir="$BRIDGE_AGENT_ROOT_V2/$agent/workdir"
+    if [[ "$home" == "$_scaffold_v2_workdir" ]]; then
+      _scaffold_v2_sibling="$_scaffold_v2_home"
+    else
+      _scaffold_v2_sibling="$_scaffold_v2_workdir"
+    fi
   fi
 
   # v0.8.5 #677: when the agent will be linux-user isolated under v2,
@@ -528,25 +534,25 @@ bridge_scaffold_agent_home() {
         || bridge_die "scaffold sudo chown $_scaffold_controller failed: $home"
       bridge_linux_sudo_root chmod 0755 "$home" \
         || bridge_die "scaffold sudo chmod 0755 failed: $home"
-      # v2 sibling workdir/ (issue #686) — same parent-owned-by-root
-      # problem applies. Pre-create via sudo with controller ownership
-      # so the resolver lookup succeeds; prepare's `chown -R $os_user
-      # $workdir` will retake ownership for the isolated UID after
-      # scaffold completes.
-      if [[ -n "$_scaffold_v2_workdir" ]]; then
-        bridge_linux_sudo_root mkdir -p "$_scaffold_v2_workdir" \
-          || bridge_die "scaffold sudo mkdir failed: $_scaffold_v2_workdir"
-        bridge_linux_sudo_root chown "$_scaffold_controller" "$_scaffold_v2_workdir" \
-          || bridge_die "scaffold sudo chown $_scaffold_controller failed: $_scaffold_v2_workdir"
-        bridge_linux_sudo_root chmod 0755 "$_scaffold_v2_workdir" \
-          || bridge_die "scaffold sudo chmod 0755 failed: $_scaffold_v2_workdir"
+      # v2 sibling dir (issue #686) — the home/ or workdir/ that is NOT
+      # the scaffold target. Same parent-owned-by-root problem applies.
+      # Pre-create via sudo with controller ownership so the resolver
+      # lookup succeeds; prepare's `chown -R $os_user $workdir` will
+      # retake ownership for the isolated UID after scaffold completes.
+      if [[ -n "$_scaffold_v2_sibling" ]]; then
+        bridge_linux_sudo_root mkdir -p "$_scaffold_v2_sibling" \
+          || bridge_die "scaffold sudo mkdir failed: $_scaffold_v2_sibling"
+        bridge_linux_sudo_root chown "$_scaffold_controller" "$_scaffold_v2_sibling" \
+          || bridge_die "scaffold sudo chown $_scaffold_controller failed: $_scaffold_v2_sibling"
+        bridge_linux_sudo_root chmod 0755 "$_scaffold_v2_sibling" \
+          || bridge_die "scaffold sudo chmod 0755 failed: $_scaffold_v2_sibling"
       fi
     fi
   fi
 
   mkdir -p "$home"
-  if [[ -n "$_scaffold_v2_workdir" ]]; then
-    mkdir -p "$_scaffold_v2_workdir"
+  if [[ -n "$_scaffold_v2_sibling" ]]; then
+    mkdir -p "$_scaffold_v2_sibling"
   fi
   [[ -d "$template_root" ]] || bridge_die "agent template root가 없습니다: $template_root"
   [[ -f "$session_template" ]] || bridge_die "session type template가 없습니다: $session_type"
@@ -2661,6 +2667,23 @@ report and reap test-fixture agents per their pattern."
 
   session="${session:-$agent}"
   default_home="$(bridge_agent_default_home "$agent")"
+  # #1045/#1046: on a v2 install the runtime resolver (bridge_agent_workdir)
+  # resolves the agent's cwd — the path preflight / start_dry_run / `agent
+  # show` use, and the dir the live session is launched in — to the sibling
+  # `<agent-root>/workdir`, NOT `<agent-root>/home` (which is the process
+  # HOME). bridge_agent_default_home returns the `home/` path, so defaulting
+  # the scaffold target to it lands the entire profile (CLAUDE.md, SOUL.md,
+  # .claude/...) under `home/` while the resolved `workdir/` stays empty —
+  # the exact fresh-install (#1045) and `agent create --isolate` (#1046)
+  # break. When the operator did not pass an explicit `--workdir`, default
+  # the scaffold target to the resolved v2 `workdir/` so the profile lands
+  # where the runtime actually looks. The `home/` sibling is still created
+  # by bridge_scaffold_agent_home. An explicit `--workdir` is honored as-is.
+  local _workdir_is_v2_default=0
+  if [[ -z "$workdir" && -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+    workdir="$BRIDGE_AGENT_ROOT_V2/$agent/workdir"
+    _workdir_is_v2_default=1
+  fi
   workdir="$(bridge_expand_user_path "${workdir:-$default_home}")"
   profile_home="$(bridge_expand_user_path "${profile_home:-}")"
   description="${description:-$agent static role}"
@@ -2688,7 +2711,12 @@ report and reap test-fixture agents per their pattern."
   fi
 
   default_home="$(bridge_expand_user_path "$default_home")"
-  if [[ -z "$profile_home" && "$workdir" != "$default_home" ]]; then
+  # Auto-derive profile_home only for a genuinely custom operator-supplied
+  # workdir. The canonical v2 `workdir/` (auto-defaulted above) is already
+  # the v2 profile-home default (bridge_agent_default_profile_home), so
+  # pinning it explicitly here would add roster noise without changing
+  # behavior — and #1045/#1046 must not change the profile-deploy contract.
+  if [[ -z "$profile_home" && "$workdir" != "$default_home" && $_workdir_is_v2_default -eq 0 ]]; then
     profile_home="$workdir"
   fi
 

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1442,16 +1442,23 @@ bridge_isolation_v2_matrix_rows_for_agent() {
   # (chown to nonexistent user/group), so write_agent_state_marker returns
   # 1, the idle-since marker never lands, and the always-on daemon
   # restart-loops the tmux session indefinitely.
-  local _v2_isolation_mode="linux-user"
+  # #1048: an indeterminate isolation_mode (the function undefined, a
+  # nonzero exit, or an empty/unknown value from a roster read that raced
+  # a concurrent typed-roster rewrite) must fall back to `shared`, NOT
+  # `linux-user`. The shared rows are group-less and reference no
+  # per-agent UID, so they apply cleanly on any install. The linux-user
+  # rows demand `ab-agent-<X>` / `agent-bridge-<X>` plumbing that a
+  # shared-only install never created — defaulting an indeterminate
+  # result there makes ensure_matrix_path fail on every state-marker
+  # write for a misclassified shared agent. Only an explicit
+  # `linux-user` selects the linux-user matrix.
+  local _v2_isolation_mode="shared"
   if command -v bridge_agent_isolation_mode >/dev/null 2>&1; then
-    _v2_isolation_mode="$(bridge_agent_isolation_mode "$agent" 2>/dev/null || printf 'linux-user')"
+    _v2_isolation_mode="$(bridge_agent_isolation_mode "$agent" 2>/dev/null || printf 'shared')"
   fi
-  # Anything outside the {shared, linux-user} pair (unknown / "") preserves
-  # the legacy linux-user matrix — defensive default for any roster entry
-  # that pre-dates the isolation_mode field.
   case "$_v2_isolation_mode" in
-    shared) ;;
-    *) _v2_isolation_mode="linux-user" ;;
+    linux-user) ;;
+    *) _v2_isolation_mode="shared" ;;
   esac
 
   # r2 P1 #1: defer agent_grp resolution until we know we're in linux-user

--- a/scripts/smoke/v2-scaffold-home-and-workdir.sh
+++ b/scripts/smoke/v2-scaffold-home-and-workdir.sh
@@ -13,21 +13,23 @@
 # of `bridge_scaffold_agent_home` cannot silently regress the sibling
 # mkdir. Coverage spans BOTH scaffold branches:
 #
-#   T1 — non-isolated (shared) v2 scaffold (`bridge-agent.sh:547-550`)
-#        creates BOTH `home/` and `workdir/` siblings under
-#        `$BRIDGE_AGENT_ROOT_V2/<agent>/` via plain `mkdir -p`. Note: as
-#        of Track C v0.13.10 (#895), `bridge_agent_workdir` no longer
-#        returns the v2 `workdir/` anchor for shared agents — it gates
-#        the v2-anchor override on `linux-user` isolation and falls
-#        through to the explicit/default resolution otherwise. The
-#        sibling mkdir is therefore vestigial for shared agents on
-#        current main, but pinning it is still correct: (a) the scaffold
-#        still emits it on both branches and an accidental removal
-#        should be a deliberate decision, not a silent drop; (b) the
-#        sibling is load-bearing for the linux-user branch covered by
-#        T2 and the two branches share the `_scaffold_v2_workdir` local.
-#   T2 — isolated v2 scaffold (`bridge-agent.sh:536-542`) creates the same
-#        `home/` + `workdir/` sibling pair via the `bridge_linux_sudo_root
+#   T1 — non-isolated (shared) v2 scaffold (the plain-`mkdir -p` block
+#        near the end of `bridge_scaffold_agent_home`) creates BOTH
+#        `home/` and `workdir/` siblings under
+#        `$BRIDGE_AGENT_ROOT_V2/<agent>/`. The scaffold materializes its
+#        `$home` argument plus the OTHER v2 sibling
+#        (`_scaffold_v2_sibling`). Note: as of Track C v0.13.10 (#895),
+#        `bridge_agent_workdir` does not return the v2 `workdir/` anchor
+#        for shared agents — it gates the v2-anchor override on
+#        `linux-user` isolation and falls through to the explicit/default
+#        resolution otherwise. Pinning the sibling mkdir is still
+#        correct: (a) the scaffold still emits it on both branches and
+#        an accidental removal should be a deliberate decision, not a
+#        silent drop; (b) the sibling is load-bearing for the linux-user
+#        branch covered by T2 and the two branches share the
+#        `_scaffold_v2_sibling` local.
+#   T2 — isolated v2 scaffold (the `bridge_linux_sudo_root mkdir` block)
+#        creates the same `home/` + `workdir/` sibling pair via the
 #        mkdir` path that the linux-user isolation branch uses on a fresh
 #        install where `data/agents/` is `root:root mode 755`. Asserts
 #        the resolver-agreement invariant (`bridge_agent_workdir` returns
@@ -53,11 +55,11 @@
 # the same reason — the unit under test is the v2 sibling mkdir, not
 # template rendering.
 #
-# Regression bite: this smoke FAILS if the `if [[ -n "$_scaffold_v2_workdir" ]];
+# Regression bite: this smoke FAILS if the `if [[ -n "$_scaffold_v2_sibling" ]];
 # then mkdir -p ...; fi` block is reverted in EITHER scaffold branch —
-# T1 fails if `bridge-agent.sh:548-550` (non-isolated) regresses, T2
-# (when its gate is met) fails if `bridge-agent.sh:536-542` (isolated)
-# regresses.
+# T1 fails if the non-isolated plain-`mkdir` block regresses, T2 (when
+# its gate is met) fails if the isolated `bridge_linux_sudo_root mkdir`
+# block regresses.
 
 set -uo pipefail
 
@@ -96,7 +98,7 @@ fi
 #   1. exports the same v2 env the live runtime would have,
 #   2. sources bridge-lib.sh,
 #   3. extracts and sources just `bridge_scaffold_agent_home` (line
-#      385..613) + its small `bridge_agent_manage_python` /
+#      385..618) + its small `bridge_agent_manage_python` /
 #      `bridge_render_template_string` deps from `bridge-agent.sh`,
 #   4. stubs `bridge_render_template_string` to a no-op so the template
 #      loop does not depend on session-template lookup / python3 / etc.,
@@ -122,7 +124,7 @@ write_driver_script() {
     '{' \
     '  sed -n "128,139p" "$REPO_ROOT/bridge-agent.sh"' \
     '  sed -n "188,257p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "385,613p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "385,618p" "$REPO_ROOT/bridge-agent.sh"' \
     '} > "$FUNC_TMP"' \
     'source "$FUNC_TMP"' \
     'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_scaffold_agent_home not loaded"; exit 91; }' \


### PR DESCRIPTION
## Summary

Three isolation-v2 bugs from the v0.14.5-beta4 Linux validation, fixed
as one focused change. **High-risk area — minimal, contract-preserving.**

### #1045 / #1046 — v2 scaffold populates the wrong sibling

On a v2 install the runtime resolver (`bridge_agent_workdir`) resolves an
agent's cwd — the path preflight, `start_dry_run`, `agent show`, and the
live launcher use — to `<agent-root>/workdir`. But `run_create` defaulted
the scaffold target to `bridge_agent_default_home` (`<agent-root>/home`),
so the entire profile (`CLAUDE.md`, `SOUL.md`, `.claude/...`) landed under
`home/` while the resolved `workdir/` stayed empty.

- **#1045** — fresh-install bootstrap fails admin preflight (`CLAUDE.md`
  missing from the resolved `workdir/`).
- **#1046** — `agent create --isolate` reports `create: ok` but leaves
  the runtime `workdir/` empty; the controller-side populate steps that
  *do* use the resolver wrote to `workdir/` while the scaffold/template
  steps wrote to `home/` — the exact split the issue documents.

**Fix:** when the operator did not pass an explicit `--workdir`,
`run_create` now defaults the scaffold target to the resolved v2
`workdir/`, so the profile lands where the runtime looks.
`bridge_scaffold_agent_home` now materializes whichever v2 sibling
(`home/` or `workdir/`) is *not* the scaffold target, so the process-HOME
directory still exists. `profile_home` auto-derivation is gated to
genuinely custom workdirs so the canonical v2 workdir adds no roster
noise (no profile-deploy contract change). Legacy installs (no
`BRIDGE_AGENT_ROOT_V2`) are unaffected.

### #1048 — shared agent misclassified as linux-user

`bridge_isolation_v2_matrix_rows_for_agent` fell back to `linux-user` for
any non-`shared` value of `bridge_agent_isolation_mode` — including
empty / `unknown` (e.g. a roster read racing a concurrent typed-roster
rewrite). The `linux-user` rows demand an `ab-agent-<X>` group a
shared-only install never created → `ensure_matrix_path` fails → the Stop
hook skips the state-marker write.

**Fix (per the issue's corrected diagnosis):** an *indeterminate*
isolation mode now resolves to `shared` (the group-less, no-per-agent-UID
layout that applies cleanly on any install); only an explicit
`linux-user` selects the linux-user matrix. **No per-agent group is
created for a shared agent** — that would mask the bug.

## Files changed

- `bridge-agent.sh` (+86/-57 across both edits) — `run_create` workdir
  default + `bridge_scaffold_agent_home` sibling materialization.
- `lib/bridge-isolation-v2.sh` (+21/-21) — matrix isolation-mode fallback
  flip.
- `scripts/smoke/v2-scaffold-home-and-workdir.sh` (+44/-44) — #686
  regression smoke re-pinned to the new function line range and updated
  for the renamed `_scaffold_v2_sibling` local.

## Verification (local, macOS)

- `bash -n` + `shellcheck -S error` on every touched `.sh` — clean.
- `scripts/lint-heredoc-ban.sh --baseline-check` — PASS (no new heredoc /
  here-string / process-sub).
- Isolated-`BRIDGE_HOME` end-to-end repro: `agent create` on a v2 install
  now lands a fully populated resolved `workdir/` (`CLAUDE.md`, `SOUL.md`,
  `.claude/settings.json`, agent-bridge skill) with the `home/` sibling
  present. The **base branch** leaves the resolved `workdir/`
  profile-empty (`CLAUDE.md`/`SOUL.md` missing) — bug confirmed and
  closed.
- #1048 matrix repro (fixed vs base): indeterminate / empty / `unknown`
  modes now yield **shared** rows (`controller_group`, no
  `ab-agent-<X>`); explicit `linux-user` still yields **linux-user** rows.
  Base branch yields linux-user rows for indeterminate modes — bug
  confirmed.
- Smoke: `v2-scaffold-home-and-workdir`, `agent-create-name-validation`,
  `1028-isolated-workdir-check`, `1025-isolated-create-agent-env-install`
  all PASS. Full `smoke-test.sh` passes except the pre-existing
  `#4793` live-install-leak / `status should show activity state`
  assertions, which reproduce identically on the base branch (this
  machine's live `~/.agent-bridge` interferes with the smoke harness —
  not caused by this change).

## Needs a live Linux-VM re-verify

- `agent create --isolate` (linux-user) **end-to-end** — the isolated
  scaffold branch is `uname`-gated to Linux and needs root + passwordless
  sudo. The `v2-scaffold-home-and-workdir` T2 case (which asserts the
  isolated-branch resolver agreement) **skips on macOS**; the orchestrator
  should run it on the OrbStack Linux VM.
- The `bridge_linux_prepare_agent_isolation` chown ordering for the
  isolated path: locally verified the create flow runs all populate steps
  *before* the chown, but the live `chown -R $os_user` + `_isolated_
  workdir_owner` interplay needs a Linux root run to confirm #1046's
  permission-denied trace is fully closed.

## Codex pair-review focus points

- The `run_create` workdir-default change: confirm an explicit
  `--workdir` is still honored verbatim and the v2-default does not leak
  into legacy (no-`BRIDGE_AGENT_ROOT_V2`) installs.
- `bridge_scaffold_agent_home`: the `_scaffold_v2_sibling` selection — it
  must create the OTHER sibling regardless of whether `$home` is `home/`
  or `workdir/`. Both scaffold branches (plain `mkdir` + sudo-handoff)
  share the local.
- #1048 fallback flip: confirm a genuine `linux-user` agent is still
  classified linux-user (it is — case E in the repro) and that the
  `apply_row` belt-and-braces guard (`bridge-isolation-v2.sh:~1887`) is
  intentionally left as-is (it hard-fails for genuine linux-user setup
  bugs; the matrix-row fix means a shared agent never reaches it with an
  `ab-agent-<X>` group).
- Roster-state change: new v2 `agent create` writes the v2 `workdir/`
  path as the explicit `BRIDGE_AGENT_WORKDIR` (previously `home/`).
  Forward-only — existing installs are not migrated.

Fixes #1045
Fixes #1046
Fixes #1048
