### PR TITLE
fix(agent): consistent caller-trust gating for agent create (#1047)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2641,6 +2641,24 @@ report and reap test-fixture agents per their pattern."
     fi
   fi
 
+  # Issue #1047: caller-trust gating. `agent create` writes a managed-role
+  # block to agent-roster.local.sh — the same protected system-config file
+  # `agent update` / `agent delete` mutate. Those verbs reject an
+  # `agent-direct` caller via bridge_agent_update_caller_source(); `create`
+  # used to be ungated, an incoherent split privilege boundary (an agent
+  # process could add a roster entry but not remove or modify one). Gate
+  # `create` on the SAME single caller-source contract: the source must be
+  # operator-tui / operator-trusted-id (a TTY-detected operator, or a
+  # sanctioned non-interactive caller that sets BRIDGE_CALLER_SOURCE). An
+  # `agent-direct` caller is denied here just as it is for update/delete.
+  # Placed after name validation so a refused-name caller still gets the
+  # name-specific error; applies to --dry-run too, mirroring update/delete.
+  local create_caller_source
+  create_caller_source="$(bridge_agent_update_caller_source)"
+  if [[ "$create_caller_source" != "operator-tui" && "$create_caller_source" != "operator-trusted-id" ]]; then
+    bridge_die "deny: caller source $create_caller_source is not allowed to mutate system config (need operator-tui or operator-trusted-id)"
+  fi
+
   case "$engine" in
     claude|codex) ;;
     *) bridge_die "지원하지 않는 engine 입니다: $engine" ;;

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -496,7 +496,13 @@ else
   if [[ $always_on -eq 1 ]]; then
     create_args+=(--always-on)
   fi
-  "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "${create_args[@]}" >/dev/null
+  # Issue #1047: `agent create` is now caller-trust gated and rejects an
+  # `agent-direct` source. This fresh-install admin create is an
+  # operator-initiated bootstrap step, but it runs as a subprocess with a
+  # redirected stdout so TTY detection would demote it to `agent-direct`.
+  # Mark it as a sanctioned operator-trusted caller so the gate allows it.
+  BRIDGE_CALLER_SOURCE="operator-trusted-id" \
+    "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/agent-bridge" "${create_args[@]}" >/dev/null
   created=1
   # Issue #848: the child `agent create` invocation mutated the roster
   # files on disk, so the next `bridge_load_roster` MUST re-parse them

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-no-auto-backfill mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge
 }
 
 add_all_integration() {
@@ -295,7 +295,12 @@ select_for_path() {
       # false-negates on the 0750 isolated agent root). Pull its unit
       # smoke whenever bridge-start.sh moves so a future PR cannot
       # regress the privilege-aware probe back to the plain check.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1028-isolated-workdir-check
+      # Issue #1047: bridge-agent.sh::run_create is now caller-trust gated
+      # (an agent-direct source is denied, mirroring update/delete). Pull
+      # its gate smoke whenever bridge-agent.sh or lib/bridge-agent-update.sh
+      # moves so a future PR cannot regress the create/update/delete trust
+      # symmetry back to an ungated create.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1028-isolated-workdir-check
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -490,7 +495,12 @@ select_for_path() {
       ;;
 
     bridge-init.sh)
-      add_required admin-pair-no-auto-backfill upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering
+      # Issue #1047: bridge-init.sh's fresh-install admin `agent create`
+      # runs as a subprocess (no TTY) and must mark itself an
+      # operator-trusted caller, or the new create gate would deny the
+      # bootstrap. Pull the gate smoke so a future PR cannot drop that
+      # trusted-source marker and silently break first install.
+      add_required admin-pair-no-auto-backfill agent-create-caller-trust-gate upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering
       add_integration integration-minimal
       ;;
 

--- a/scripts/librarian-provision.sh
+++ b/scripts/librarian-provision.sh
@@ -69,7 +69,12 @@ if [[ "$DRY_RUN" == "1" ]]; then
   exit 0
 fi
 
-if ! "$BRIDGE_CLI" "${CREATE_ARGS[@]}"; then
+# Issue #1047: `agent create` is caller-trust gated and rejects an
+# `agent-direct` source. This provisioning script is an operator-run
+# bootstrap step (or invoked from a sanctioned setup flow); mark it as a
+# trusted caller so the gate allows the create. TTY detection alone is
+# unreliable here — the script is commonly run non-interactively.
+if ! BRIDGE_CALLER_SOURCE="operator-trusted-id" "$BRIDGE_CLI" "${CREATE_ARGS[@]}"; then
   die "agent create failed" 3
 fi
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -5149,6 +5149,12 @@ REVIEW_BYPASS_OUTPUT="$("$REPO_ROOT/agent-bridge" review request --from "$SMOKE_
 assert_contains "$REVIEW_BYPASS_OUTPUT" "review_bypassed: yes"
 assert_contains "$REVIEW_BYPASS_OUTPUT" "reason: trivial"
 
+# Issue #1047: `agent create` is now caller-trust gated and rejects an
+# `agent-direct` source. These smoke creates run inside `$(...)` captures
+# (no TTY), so without an explicit trusted source the gate would deny them.
+# Mark the create block as a sanctioned operator-trusted caller; unset
+# right after so later subcommands keep their default source detection.
+export BRIDGE_CALLER_SOURCE="operator-trusted-id"
 SHARED_USER_CREATE_JSON="$("$REPO_ROOT/agent-bridge" agent create "$SHARED_USER_AGENT" --engine claude --session "$SHARED_USER_SESSION" --dry-run --json)"
 assert_contains "$SHARED_USER_CREATE_JSON" "\"id\": \"owner\""
 SHARED_USER_CREATE_OUTPUT="$("$REPO_ROOT/agent-bridge" agent create "$SHARED_USER_AGENT" --engine claude --session "$SHARED_USER_SESSION")"
@@ -5169,6 +5175,8 @@ assert_contains "$CREATE_JSON_OUTPUT_NO_REGISTRY" "\"channels\": \"plugin:telegr
 CREATE_TEAMS_JSON_OUTPUT="$("$REPO_ROOT/agent-bridge" agent create "${CREATED_AGENT}-teams" --engine claude --session "${CREATED_SESSION}-teams" --channels plugin:teams --dry-run --json)"
 assert_contains "$CREATE_TEAMS_JSON_OUTPUT" "\"channels\": \"plugin:teams@agent-bridge\""
 CREATE_OUTPUT="$("$REPO_ROOT/agent-bridge" agent create "$CREATED_AGENT" --engine claude --session "$CREATED_SESSION" --role "Smoke created role" --channels plugin:telegram --user owner:Owner --user reviewer:Reviewer)"
+# Issue #1047: end of the gated-create block — restore default source detection.
+unset BRIDGE_CALLER_SOURCE
 assert_contains "$CREATE_OUTPUT" "create: ok"
 assert_contains "$CREATE_OUTPUT" "start_dry_run: ok"
 assert_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" "BRIDGE_AGENT_ENGINE[\"$CREATED_AGENT\"]=claude"

--- a/scripts/smoke/agent-create-caller-trust-gate.sh
+++ b/scripts/smoke/agent-create-caller-trust-gate.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# scripts/smoke/agent-create-caller-trust-gate.sh — Issue #1047 smoke.
+#
+# `agent create` writes a managed-role block to agent-roster.local.sh, the
+# same protected system-config file `agent update` / `agent delete` mutate.
+# Before #1047 `create` was ungated while update/delete rejected an
+# `agent-direct` caller source — an incoherent split privilege boundary.
+# This smoke locks in the corrected, symmetric gate: `agent create` is
+# allowed only from an operator-trusted caller source.
+#
+# The single caller-source contract is bridge_agent_update_caller_source()
+# (lib/bridge-agent-update.sh): an explicit BRIDGE_CALLER_SOURCE override
+# of operator-tui / operator-trusted-id is honored; any other explicit
+# value is demoted to agent-direct; with no override, TTY detection
+# decides. These assertions run inside `$(...)` captures (no TTY), so the
+# only way to reach a trusted source is the explicit override.
+#
+# Assertions:
+#  T1: create from an agent-direct caller (no override, no TTY) is DENIED
+#      with the system-config deny reason, and nothing is scaffolded.
+#  T2: create with BRIDGE_CALLER_SOURCE=operator-trusted-id is ALLOWED
+#      (reaches the create plan path).
+#  T3: create with BRIDGE_CALLER_SOURCE=operator-tui is ALLOWED.
+#  T4: create with a bogus BRIDGE_CALLER_SOURCE value is demoted to
+#      agent-direct and DENIED, exactly like T1.
+
+set -euo pipefail
+
+SMOKE_NAME="agent-create-caller-trust-gate"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+# run_create — invoke `agent create` with an explicit caller source.
+# $1 is the BRIDGE_CALLER_SOURCE value to export (empty string = no
+# override, leaving the source to TTY detection → agent-direct here).
+run_create() {
+  local source_value="$1"
+  shift
+  if [[ -n "$source_value" ]]; then
+    BRIDGE_CALLER_SOURCE="$source_value" \
+      bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
+  else
+    bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
+  fi
+}
+
+reset_runtime() {
+  rm -rf "$BRIDGE_AGENT_HOME_ROOT"
+  mkdir -p "$BRIDGE_AGENT_HOME_ROOT"
+  : >"$BRIDGE_ROSTER_LOCAL_FILE"
+}
+
+assert_no_scaffold() {
+  local label="$1"
+  local agent="$2"
+  [[ ! -d "$BRIDGE_AGENT_HOME_ROOT/$agent" ]] || \
+    smoke_fail "$label: agents/$agent/ unexpectedly scaffolded by a denied create"
+  if [[ -s "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
+    smoke_assert_not_contains "$(cat "$BRIDGE_ROSTER_LOCAL_FILE")" \
+      "MANAGED ROLE: $agent" \
+      "$label: local roster has no MANAGED ROLE block for '$agent'"
+  fi
+}
+
+assert_agent_direct_denied() {
+  reset_runtime
+  local out
+  out="$(run_create "" gate-worker --engine claude --dry-run)"
+  smoke_assert_contains "$out" "deny:" \
+    "T1: agent-direct create is denied"
+  smoke_assert_contains "$out" "caller source agent-direct is not allowed to mutate system config" \
+    "T1: deny reason names the agent-direct caller source"
+  assert_no_scaffold "T1: agent-direct create" "gate-worker"
+}
+
+assert_operator_trusted_allowed() {
+  reset_runtime
+  local out
+  out="$(run_create "operator-trusted-id" gate-worker --engine claude --dry-run)"
+  smoke_assert_not_contains "$out" "not allowed to mutate system config" \
+    "T2: operator-trusted-id create passes the caller-trust gate"
+  smoke_assert_contains "$out" "agent: gate-worker" \
+    "T2: operator-trusted-id create reaches the create plan path"
+  smoke_assert_contains "$out" "dry_run: yes" \
+    "T2: operator-trusted-id create completes the dry-run plan"
+}
+
+assert_operator_tui_allowed() {
+  reset_runtime
+  local out
+  out="$(run_create "operator-tui" gate-worker --engine claude --dry-run)"
+  smoke_assert_not_contains "$out" "not allowed to mutate system config" \
+    "T3: operator-tui create passes the caller-trust gate"
+  smoke_assert_contains "$out" "dry_run: yes" \
+    "T3: operator-tui create completes the dry-run plan"
+}
+
+assert_bogus_source_demoted_denied() {
+  reset_runtime
+  local out
+  out="$(run_create "definitely-not-trusted" gate-worker --engine claude --dry-run)"
+  smoke_assert_contains "$out" "caller source agent-direct is not allowed to mutate system config" \
+    "T4: bogus BRIDGE_CALLER_SOURCE is demoted to agent-direct and denied"
+  assert_no_scaffold "T4: bogus-source create" "gate-worker"
+}
+
+main() {
+  smoke_setup_bridge_home "$SMOKE_NAME"
+
+  smoke_run "T1: agent-direct create denied"           assert_agent_direct_denied
+  smoke_run "T2: operator-trusted-id create allowed"   assert_operator_trusted_allowed
+  smoke_run "T3: operator-tui create allowed"          assert_operator_tui_allowed
+  smoke_run "T4: bogus source demoted + denied"        assert_bogus_source_demoted_denied
+
+  smoke_log "PASS"
+}
+
+main "$@"

--- a/scripts/smoke/agent-create-name-validation.sh
+++ b/scripts/smoke/agent-create-name-validation.sh
@@ -33,7 +33,13 @@ trap cleanup EXIT
 run_create() {
   # Capture stdout+stderr together; never let a non-zero exit kill the test
   # before we assert on the captured text.
-  bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
+  # Issue #1047: `agent create` is caller-trust gated and rejects an
+  # `agent-direct` source. This smoke exercises name validation, the help
+  # short-circuit, and the dry-run plan path — not the gate — so force a
+  # trusted source. Name-validation / help failures fire earlier, leaving
+  # the negative cases unaffected.
+  BRIDGE_CALLER_SOURCE="operator-trusted-id" \
+    bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
 }
 
 assert_no_scaffold() {

--- a/scripts/smoke/agent-name-validation.sh
+++ b/scripts/smoke/agent-name-validation.sh
@@ -38,7 +38,13 @@ trap cleanup EXIT
 run_create() {
   # Capture stdout+stderr together; never let a non-zero exit kill the
   # test before we assert on the captured text.
-  bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
+  # Issue #1047: `agent create` is caller-trust gated and rejects an
+  # `agent-direct` source. This smoke exercises name validation and the
+  # dry-run plan path, not the gate — force a trusted source so the
+  # positive controls reach those code paths. Name-validation failures
+  # fire earlier, so the negative cases are unaffected by the env.
+  BRIDGE_CALLER_SOURCE="operator-trusted-id" \
+    bash "$SMOKE_REPO_ROOT/bridge-agent.sh" create "$@" 2>&1 || true
 }
 
 run_agent_bridge() {


### PR DESCRIPTION
## Summary

`agent create` wrote a managed-role block to `agent-roster.local.sh` — the same protected system-config file `agent update` / `agent delete` mutate — yet `create` was **ungated** while update/delete reject an `agent-direct` caller source. An agent process could *add* a roster entry but could not *remove or modify* one. That split privilege boundary is the gap reported in #1047.

## Chosen direction (per the decided plan)

- **Do not weaken** the existing update/delete gate.
- Reuse the **single existing caller-source contract** — `bridge_agent_update_caller_source()` in `lib/bridge-agent-update.sh` — across create as well as update/delete.
- **Gate `agent create`** on a trusted caller source the same way update/delete are: an `agent-direct` caller is denied; a TTY-detected operator (`operator-tui`) or an explicit `operator-trusted-id` source is allowed.
- A documented `BRIDGE_CALLER_SOURCE` operator-*delegation* path is intentionally **out of scope** here — noted as a follow-up.

The gate in `run_create` is placed **after name validation** (so a refused-name caller still gets the name-specific error) and applies to `--dry-run` too, mirroring delete/update.

## Sanctioned non-interactive callsites updated

Gating `create` breaks legitimate callers that run as subprocesses with no TTY (TTY detection would demote them to `agent-direct`). Each is now marked an operator-trusted caller via the existing `BRIDGE_CALLER_SOURCE` env contract:

- `bridge-init.sh` — fresh-install admin `agent create`.
- `scripts/librarian-provision.sh` — librarian dynamic-agent provision.
- `scripts/smoke-test.sh` — the create block (scoped `export` / `unset`).
- `scripts/smoke/agent-create-name-validation.sh` + `scripts/smoke/agent-name-validation.sh` — `run_create` helpers.
- `scripts/smoke/agent-doctor.sh` — already ran with `BRIDGE_CALLER_SOURCE=operator-tui`; no change needed.

## Before / after gating evidence

New smoke `scripts/smoke/agent-create-caller-trust-gate.sh` (all 4 PASS):

- **T1** `agent-direct` (no override, non-TTY) → `deny: caller source agent-direct is not allowed to mutate system config`, nothing scaffolded.
- **T2** `BRIDGE_CALLER_SOURCE=operator-trusted-id` → reaches the create plan path (`agent: gate-worker` / `dry_run: yes`).
- **T3** `BRIDGE_CALLER_SOURCE=operator-tui` → allowed.
- **T4** bogus `BRIDGE_CALLER_SOURCE` value → demoted to `agent-direct`, denied like T1.

Registered in `scripts/ci-select-smoke.sh` (base required list + `bridge-agent.sh` / `bridge-init.sh` / `lib/bridge-agent-update.sh` change branches).

## Verification

- `bash -n` + `shellcheck` clean on every touched file.
- `bash scripts/lint-heredoc-ban.sh --baseline-check` → PASS; diff grepped for `<<` / `<<<` / `< <(` — none in added lines.
- New gate smoke: PASS (4/4).
- `scripts/smoke/agent-create-name-validation.sh`, `agent-name-validation.sh`, `agent-doctor.sh`: PASS.
- `scripts/smoke-test.sh`: aborts on macOS at the pre-existing isolated-tmux-role flake (`session ended right after start`, ~line 168) — confirmed identical abort on the unmodified `release/v0.14.5-beta5-integration` base (176 lines, same point). Not a regression; the abort is far before the `agent create` block at line ~5152.

## Focus points for codex review

- **Gate placement** in `run_create` — after name validation, before engine validation; applies to `--dry-run` (intentional, matches delete/update). Confirm no legitimate create path reaches the scaffold without passing the gate.
- **No admin-identity check on create** (unlike update/delete which also require `caller_agent == BRIDGE_ADMIN_AGENT_ID`). This is deliberate: a fresh install has no admin agent yet, so requiring admin identity would deadlock first install. The gate is caller-*source* only, which closes the asymmetry the issue describes.
- **Sanctioned callsites** — confirm `bridge-init.sh`, `librarian-provision.sh`, and the smoke fixtures are the complete set of non-interactive `agent create` callers (dynamic-agent `spawn` is a separate code path that does not call `run_create`).
- The `scripts/smoke-test.sh` `export` / `unset BRIDGE_CALLER_SOURCE` is scoped to lines ~5152-5172; no later subcommand depends on the default source detection being clobbered.