### PR TITLE
fix(init): resolve channel runtime-config under BRIDGE_HOME not $HOME (#1062)

### DIFF
--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -174,7 +174,10 @@ role_text="Manager/admin role"
 description=""
 channels=""
 channel_account=""
-runtime_config="$HOME/.agent-bridge/runtime/bridge-config.json"
+# Default to the canonical runtime config path resolved by bridge-lib.sh
+# (rooted at $BRIDGE_HOME), not the operator's $HOME — a custom BRIDGE_HOME
+# install must not read/write channel config under the default ~/.agent-bridge.
+runtime_config="$BRIDGE_RUNTIME_CONFIG_FILE"
 data_root_flag=""
 skip_channel_setup=0
 test_start=0


### PR DESCRIPTION
## Summary

Fixes #1062 — `bridge-init.sh` defaulted the channel `runtime_config` path to a hardcoded `$HOME/.agent-bridge/runtime/bridge-config.json`. On a fresh install with a custom `BRIDGE_HOME`, channel setup read/wrote the channel runtime config under the operator's default `~/.agent-bridge` instead of the install's actual runtime root.

`bridge-lib.sh` (sourced at `bridge-init.sh:21`) already resolves the canonical `BRIDGE_RUNTIME_CONFIG_FILE` — rooted at `BRIDGE_RUNTIME_ROOT` / `BRIDGE_HOME` — and exports it. This PR uses that canonical var instead of re-deriving a path from `$HOME`.

## Change

`bridge-init.sh:177`:
```diff
-runtime_config="$HOME/.agent-bridge/runtime/bridge-config.json"
+runtime_config="$BRIDGE_RUNTIME_CONFIG_FILE"
```
(plus a 3-line comment explaining why.)

The `--runtime-config` flag override (line 313) and the three channel-setup pass-throughs (lines 582/601/626) are unaffected — they still consume `runtime_config` after the default is set.

## Verification

- `bash -n bridge-init.sh` — OK
- `shellcheck bridge-init.sh` — clean (exit 0)
- Functional: sourcing `bridge-lib.sh` with `BRIDGE_HOME=/tmp/custom-abh` resolves `BRIDGE_RUNTIME_CONFIG_FILE=/tmp/custom-abh/runtime/bridge-config.json` — correctly under the custom home (previously the default ignored this entirely).

## Release impact

`release-impact: user-visible` — affects custom-`BRIDGE_HOME` fresh installs. Per the version policy, this PR does not bump VERSION/CHANGELOG; it batches into the next operator-cued release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
