### PR TITLE
fix(setup): never pass the Teams client secret as a CLI argument (#1063)

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,12 +332,12 @@ Tenant ID는 [tenant id]야.
 허용할 Teams 사용자 ID 또는 AAD object ID는 [user id]야.
 ```
 
-직접 실행할 때는 production bring-up 명령을 권장합니다 (messaging endpoint + webhook ingress 까지 포함):
+직접 실행할 때는 production bring-up 명령을 권장합니다 (messaging endpoint + webhook ingress 까지 포함). client secret은 셸 히스토리·프로세스 argv 노출을 피하려고 `BRIDGE_TEAMS_APP_PASSWORD` 환경변수(또는 `--app-password-file <path>`)로 전달합니다:
 
 ```bash
+export BRIDGE_TEAMS_APP_PASSWORD='<client-secret>'
 agb setup teams patch \
   --app-id "<azure-bot-app-id>" \
-  --app-password "<client-secret>" \
   --tenant-id "<tenant-id>" \
   --allow-from "<aad-object-id-or-teams-user-id>" \
   --messaging-endpoint "https://<your-domain>/api/messages" \
@@ -392,7 +392,7 @@ claude plugin enable --scope user telegram@claude-plugins-official
 ```bash
 agb setup discord <agent> --token <DISCORD_BOT_TOKEN> --channel <DISCORD_CHANNEL_ID>
 agb setup telegram <agent> --token <TELEGRAM_BOT_TOKEN> --allow-from <TELEGRAM_USER_ID> --default-chat <TELEGRAM_CHAT_ID>
-agb setup teams <agent> --app-id <TEAMS_APP_ID> --app-password <TEAMS_APP_PASSWORD> --tenant-id <TEAMS_TENANT_ID> --allow-from <TEAMS_USER_ID>
+BRIDGE_TEAMS_APP_PASSWORD=<TEAMS_APP_PASSWORD> agb setup teams <agent> --app-id <TEAMS_APP_ID> --tenant-id <TEAMS_TENANT_ID> --allow-from <TEAMS_USER_ID>
 ```
 
 참고: `claude mcp list`를 Agent Bridge 밖에서 실행하면 Claude Code의 기본 전역 경로(`~/.claude/channels/...`)를 기준으로 실패가 보일 수 있습니다. Agent Bridge가 실제로 쓰는 기준은 위의 에이전트별 state dir입니다. 검증은 `agb agent show <agent>`에서 `channel_diagnostics`를 보거나, `agb agent start <agent> --dry-run`, `agb status`로 확인하세요.

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -303,7 +303,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
       bridge_warn "--teams-app-password는 셸 히스토리와 프로세스 argv에 client secret을 노출합니다. --teams-app-password-file <path> 또는 BRIDGE_TEAMS_APP_PASSWORD 환경변수를 사용하세요."
       # Stage the secret out of argv immediately so it is never re-exposed
-      # in the bridge-setup.sh / bridge-setup.py argv downstream.
+      # in the bridge-setup.sh / bridge-setup.py argv downstream. A repeated
+      # flag replaces the prior staged file so no orphan outlives the trap,
+      # which only tracks the most recent _BRIDGE_INIT_SECRET_TMPFILE.
+      [[ -n "$_BRIDGE_INIT_SECRET_TMPFILE" ]] && rm -f "$_BRIDGE_INIT_SECRET_TMPFILE"
       _BRIDGE_INIT_SECRET_TMPFILE="$(bridge_init_stage_secret "$2")"
       teams_app_password_file="$_BRIDGE_INIT_SECRET_TMPFILE"
       shift 2

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -16,7 +16,10 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 _BRIDGE_INIT_BYPASS_NONCE="$(date -u '+%Y%m%dT%H%M%SZ')-$$-${RANDOM}${RANDOM}"
 export BRIDGE_LAYOUT_RESOLVER_BYPASS="fresh-install:${_BRIDGE_INIT_BYPASS_NONCE}"
 export BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID=$$
-trap 'unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID' EXIT
+# A staged channel-secret temp file (see bridge_init_stage_secret); removed on
+# exit so a legacy --teams-app-password value never outlives this process.
+_BRIDGE_INIT_SECRET_TMPFILE=""
+trap 'unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID; [[ -n "${_BRIDGE_INIT_SECRET_TMPFILE:-}" ]] && rm -f "$_BRIDGE_INIT_SECRET_TMPFILE"' EXIT
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 # shellcheck source=lib/bridge-host-profile.sh
@@ -32,7 +35,11 @@ source "$SCRIPT_DIR/lib/bridge-init-default-crons.sh"
 usage() {
   cat <<EOF
 Usage:
-  $(basename "$0") [--admin <agent>] [--engine claude|codex] [--session <name>] [--workdir <path>] [--user <id[:display-name]>]... [--channels <csv>] [--discord-channel <id>]... [--allow-from <id>]... [--default-chat <id>] [--teams-app-id <id>] [--teams-app-password <secret>] [--teams-tenant-id <id>] [--teams-allow-from <id>]... [--teams-conversation <id>]... [--channel-account <account>] [--runtime-config <path>] [--api-base-url <url>] [--profile server|dev] [--reconfigure] [--skip-validate] [--skip-send-test] [--skip-channel-setup] [--test-start] [--dry-run] [--json]
+  $(basename "$0") [--admin <agent>] [--engine claude|codex] [--session <name>] [--workdir <path>] [--user <id[:display-name]>]... [--channels <csv>] [--discord-channel <id>]... [--allow-from <id>]... [--default-chat <id>] [--teams-app-id <id>] [--teams-app-password-file <path>] [--teams-tenant-id <id>] [--teams-allow-from <id>]... [--teams-conversation <id>]... [--channel-account <account>] [--runtime-config <path>] [--api-base-url <url>] [--profile server|dev] [--reconfigure] [--skip-validate] [--skip-send-test] [--skip-channel-setup] [--test-start] [--dry-run] [--json]
+
+  The Teams client secret may also be supplied via the BRIDGE_TEAMS_APP_PASSWORD
+  environment variable. --teams-app-password <secret> is still accepted but
+  deprecated: it exposes the secret in shell history and process argv.
 
 Examples:
   $(basename "$0") --admin patch --engine claude --channels plugin:telegram@claude-plugins-official --allow-from 123456789 --default-chat 123456789 --channel-account default
@@ -86,6 +93,20 @@ PY
 bridge_init_require_command() {
   local cmd="$1"
   command -v "$cmd" >/dev/null 2>&1 || bridge_die "필수 명령을 찾지 못했습니다: $cmd"
+}
+
+bridge_init_stage_secret() {
+  # Stage a secret value into a private (mode 600) temp file so it can be
+  # forwarded downstream by path — a path is safe in argv, the secret is not.
+  # The caller assigns the path to _BRIDGE_INIT_SECRET_TMPFILE so the EXIT
+  # trap removes it. Only one staged secret is supported per init run.
+  local value="$1"
+  local tmpfile
+  tmpfile="$(mktemp "${TMPDIR:-/tmp}/bridge-init-secret.XXXXXX")" \
+    || bridge_die "비밀 값을 임시 파일로 옮기지 못했습니다"
+  chmod 600 "$tmpfile"
+  printf '%s' "$value" >"$tmpfile"
+  printf '%s' "$tmpfile"
 }
 
 bridge_init_runtime_present() {
@@ -192,7 +213,7 @@ discord_channels=()
 telegram_allow_from=()
 default_chat=""
 teams_app_id=""
-teams_app_password=""
+teams_app_password_file=""
 teams_tenant_id=""
 teams_service_url=""
 teams_allow_from=()
@@ -280,7 +301,16 @@ while [[ $# -gt 0 ]]; do
       ;;
     --teams-app-password)
       [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
-      teams_app_password="$2"
+      bridge_warn "--teams-app-password는 셸 히스토리와 프로세스 argv에 client secret을 노출합니다. --teams-app-password-file <path> 또는 BRIDGE_TEAMS_APP_PASSWORD 환경변수를 사용하세요."
+      # Stage the secret out of argv immediately so it is never re-exposed
+      # in the bridge-setup.sh / bridge-setup.py argv downstream.
+      _BRIDGE_INIT_SECRET_TMPFILE="$(bridge_init_stage_secret "$2")"
+      teams_app_password_file="$_BRIDGE_INIT_SECRET_TMPFILE"
+      shift 2
+      ;;
+    --teams-app-password-file)
+      [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+      teams_app_password_file="$2"
       shift 2
       ;;
     --teams-tenant-id)
@@ -610,7 +640,7 @@ if [[ $skip_channel_setup -eq 0 ]] && [[ $dry_run -eq 0 ]]; then
     fi
   fi
   if bridge_channel_csv_contains "$channels" "plugin:teams"; then
-    if ((${#teams_allow_from[@]} > 0)) || ((${#teams_conversations[@]} > 0)) || [[ -n "$channel_account" ]] || [[ -n "$teams_app_id" && -n "$teams_app_password" ]] || bridge_init_runtime_present teams "$admin_agent"; then
+    if ((${#teams_allow_from[@]} > 0)) || ((${#teams_conversations[@]} > 0)) || [[ -n "$channel_account" ]] || { [[ -n "$teams_app_id" ]] && { [[ -n "$teams_app_password_file" ]] || [[ -n "${BRIDGE_TEAMS_APP_PASSWORD:-}" ]]; }; } || bridge_init_runtime_present teams "$admin_agent"; then
       setup_args=(teams "$admin_agent")
       for item in "${teams_allow_from[@]}"; do
         setup_args+=(--allow-from "$item")
@@ -619,7 +649,9 @@ if [[ $skip_channel_setup -eq 0 ]] && [[ $dry_run -eq 0 ]]; then
         setup_args+=(--conversation "$item")
       done
       [[ -n "$teams_app_id" ]] && setup_args+=(--app-id "$teams_app_id")
-      [[ -n "$teams_app_password" ]] && setup_args+=(--app-password "$teams_app_password")
+      # Forward the client secret by path only — BRIDGE_TEAMS_APP_PASSWORD, if
+      # set, is inherited by the bridge-setup.sh child without appearing in argv.
+      [[ -n "$teams_app_password_file" ]] && setup_args+=(--app-password-file "$teams_app_password_file")
       [[ -n "$teams_tenant_id" ]] && setup_args+=(--tenant-id "$teams_tenant_id")
       [[ -n "$teams_service_url" ]] && setup_args+=(--service-url "$teams_service_url")
       [[ -n "$channel_account" ]] && setup_args+=(--channel-account "$channel_account")

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -98,15 +98,17 @@ bridge_init_require_command() {
 bridge_init_stage_secret() {
   # Stage a secret value into a private (mode 600) temp file so it can be
   # forwarded downstream by path — a path is safe in argv, the secret is not.
-  # The caller assigns the path to _BRIDGE_INIT_SECRET_TMPFILE so the EXIT
-  # trap removes it. Only one staged secret is supported per init run.
+  # Assigns _BRIDGE_INIT_SECRET_TMPFILE immediately after mktemp — before the
+  # chmod/write steps — so the EXIT trap can still remove the file if a later
+  # step fails. MUST NOT be called in a command substitution: it sets a global
+  # (a subshell assignment would not survive). Only one staged secret per run.
   local value="$1"
   local tmpfile
   tmpfile="$(mktemp "${TMPDIR:-/tmp}/bridge-init-secret.XXXXXX")" \
     || bridge_die "비밀 값을 임시 파일로 옮기지 못했습니다"
+  _BRIDGE_INIT_SECRET_TMPFILE="$tmpfile"
   chmod 600 "$tmpfile"
   printf '%s' "$value" >"$tmpfile"
-  printf '%s' "$tmpfile"
 }
 
 bridge_init_runtime_present() {
@@ -306,8 +308,11 @@ while [[ $# -gt 0 ]]; do
       # in the bridge-setup.sh / bridge-setup.py argv downstream. A repeated
       # flag replaces the prior staged file so no orphan outlives the trap,
       # which only tracks the most recent _BRIDGE_INIT_SECRET_TMPFILE.
+      # bridge_init_stage_secret sets _BRIDGE_INIT_SECRET_TMPFILE directly
+      # (not via $() — see its comment) so the trap sees the path even if a
+      # later staging step fails.
       [[ -n "$_BRIDGE_INIT_SECRET_TMPFILE" ]] && rm -f "$_BRIDGE_INIT_SECRET_TMPFILE"
-      _BRIDGE_INIT_SECRET_TMPFILE="$(bridge_init_stage_secret "$2")"
+      bridge_init_stage_secret "$2"
       teams_app_password_file="$_BRIDGE_INIT_SECRET_TMPFILE"
       shift 2
       ;;

--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -622,6 +622,33 @@ def load_claude_plugin_channel_token(kind: str) -> str:
     return extract_token_from_text(env_path.read_text(encoding="utf-8"), kind)
 
 
+def read_secret_value(flag_value: str, flag_name: str, file_path: str, env_name: str) -> str:
+    """Resolve a channel secret without requiring it on the command line.
+
+    Precedence: a `--<name>-file <path>` (a path is safe to pass in argv) wins,
+    then the env var, then the legacy `--<name> <secret>` flag. Passing the
+    secret as a bare argv value still works for compatibility but emits a
+    one-line warning, since it then lands in shell history and the process
+    table (`ps`, `/proc/<pid>/cmdline`).
+    """
+    if file_path:
+        path = Path(file_path).expanduser()
+        if not path.is_file():
+            raise SetupError(f"Secret file not found: {file_path}")
+        return path.read_text(encoding="utf-8").strip()
+    env_value = os.environ.get(env_name, "").strip()
+    if env_value:
+        return env_value
+    flag_value = str(flag_value or "").strip()
+    if flag_value:
+        print(
+            f"[warn] {flag_name} exposes the secret in shell history and process "
+            f"argv; prefer {flag_name}-file <path> or the {env_name} env var.",
+            file=sys.stderr,
+        )
+    return flag_value
+
+
 def candidate_channel_accounts(agent: str, accounts: dict[str, dict[str, Any]]) -> list[str]:
     candidates = [agent]
     if "-" in agent:
@@ -1393,8 +1420,14 @@ def cmd_teams(args: argparse.Namespace) -> int:
                     credential_source = f"channel:{choice}"
 
         app_id = str(args.app_id or account_cfg.get("appId") or account_cfg.get("app_id") or inspected["app_id"]).strip()
+        app_password_arg = read_secret_value(
+            flag_value=args.app_password,
+            flag_name="--app-password",
+            file_path=args.app_password_file,
+            env_name="BRIDGE_TEAMS_APP_PASSWORD",
+        )
         app_password = str(
-            args.app_password
+            app_password_arg
             or account_cfg.get("appPassword")
             or account_cfg.get("app_password")
             or account_cfg.get("clientSecret")
@@ -1414,7 +1447,7 @@ def cmd_teams(args: argparse.Namespace) -> int:
         messaging_endpoint = str(args.messaging_endpoint or "").strip()
 
         if not credential_source:
-            if args.app_id or args.app_password or args.tenant_id:
+            if args.app_id or app_password_arg or args.tenant_id:
                 credential_source = "flag"
             elif inspected["app_id"] or inspected["app_password"]:
                 credential_source = "existing:.teams/.env"
@@ -1440,7 +1473,7 @@ def cmd_teams(args: argparse.Namespace) -> int:
             ingress_port = prompt_text("Optional reverse proxy/backend target port", ingress_port)
 
         if not app_id or not app_password:
-            raise SetupError("Teams app id and app password are required. Pass --app-id/--app-password, --channel-account, or run in an interactive TTY.")
+            raise SetupError("Teams app id and app password are required. Pass --app-id and one of --app-password-file/BRIDGE_TEAMS_APP_PASSWORD/--app-password, or --channel-account, or run in an interactive TTY.")
         if not re.fullmatch(r"\d{2,5}", webhook_port):
             raise SetupError(f"Webhook port must be a TCP port number: {webhook_port}")
         if ingress_port and not re.fullmatch(r"\d{2,5}", ingress_port):
@@ -1833,6 +1866,7 @@ def build_parser() -> argparse.ArgumentParser:
     teams_parser.add_argument("--channel-account")
     teams_parser.add_argument("--app-id", default="")
     teams_parser.add_argument("--app-password", default="")
+    teams_parser.add_argument("--app-password-file", default="")
     teams_parser.add_argument("--tenant-id", default="")
     teams_parser.add_argument("--service-url", default="")
     teams_parser.add_argument("--messaging-endpoint", default="")

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -13,7 +13,7 @@ usage() {
 Usage:
   $(basename "$0") discord <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--channel <id>]... [--allow-from <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
   $(basename "$0") telegram <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--allow-from <id>]... [--default-chat <id>] [--test-chat <id>] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
-  $(basename "$0") teams <agent> [--app-id <id>] [--app-password <secret>] [--tenant-id <id>] [--channel-account <account>] [--runtime-config <path>] [--messaging-endpoint <url>] [--webhook-host <host>] [--webhook-port <port>] [--ingress-port <port>] [--allow-from <id>]... [--conversation <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
+  $(basename "$0") teams <agent> [--app-id <id>] [--app-password-file <path>] [--tenant-id <id>] [--channel-account <account>] [--runtime-config <path>] [--messaging-endpoint <url>] [--webhook-host <host>] [--webhook-port <port>] [--ingress-port <port>] [--allow-from <id>]... [--conversation <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
   $(basename "$0") agent <agent> [--skip-discord] [--skip-telegram] [--skip-teams] [--test-start] [setup options...]
   $(basename "$0") admin <agent>
 
@@ -46,7 +46,7 @@ EOF
     teams)
       cat <<EOF
 Usage:
-  $(basename "$0") teams <agent> [--app-id <id>] [--app-password <secret>] [--tenant-id <id>] [--channel-account <account>] [--runtime-config <path>] [--messaging-endpoint <url>] [--webhook-host <host>] [--webhook-port <port>] [--ingress-port <port>] [--allow-from <id>]... [--conversation <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
+  $(basename "$0") teams <agent> [--app-id <id>] [--app-password-file <path>] [--tenant-id <id>] [--channel-account <account>] [--runtime-config <path>] [--messaging-endpoint <url>] [--webhook-host <host>] [--webhook-port <port>] [--ingress-port <port>] [--allow-from <id>]... [--conversation <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
 EOF
       ;;
     agent)
@@ -617,7 +617,7 @@ run_teams() {
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --app-id|--app-password|--tenant-id|--service-url|--messaging-endpoint|--webhook-host|--webhook-port|--ingress-port|--channel-account|--runtime-config|--allow-from|--conversation)
+      --app-id|--app-password|--app-password-file|--tenant-id|--service-url|--messaging-endpoint|--webhook-host|--webhook-port|--ingress-port|--channel-account|--runtime-config|--allow-from|--conversation)
         [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
         if [[ "$1" == "--channel-account" ]]; then
           channel_account="$2"
@@ -748,7 +748,7 @@ run_agent() {
         telegram_args+=("$1" "$2")
         shift 2
         ;;
-      --conversation|--app-id|--app-password|--tenant-id|--service-url|--messaging-endpoint|--webhook-host|--webhook-port|--ingress-port)
+      --conversation|--app-id|--app-password|--app-password-file|--tenant-id|--service-url|--messaging-endpoint|--webhook-host|--webhook-port|--ingress-port)
         [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
         teams_args+=("$1" "$2")
         shift 2

--- a/docs/channels/teams-setup.md
+++ b/docs/channels/teams-setup.md
@@ -51,10 +51,14 @@ Persist it with your distro's normal iptables save path if needed.
 
 ## Recommended Setup Command
 
+Pass the client secret via the `BRIDGE_TEAMS_APP_PASSWORD` environment variable
+(or `--app-password-file <path>`) so it is not exposed in shell history or the
+process table.
+
 ```bash
+export BRIDGE_TEAMS_APP_PASSWORD='<client-secret>'
 agb setup teams patch \
   --app-id "<azure-bot-app-id>" \
-  --app-password "<client-secret>" \
   --tenant-id "<tenant-id>" \
   --allow-from "<aad-object-id-or-teams-user-id>" \
   --messaging-endpoint "https://bot.example.com/api/messages" \

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -6270,7 +6270,7 @@ bridge_agent_channel_setup_guidance() {
     printf "\nRun: %s setup telegram %s --token <TELEGRAM_BOT_TOKEN> --allow-from <TELEGRAM_USER_ID> --default-chat <TELEGRAM_CHAT_ID>" "$cli" "$agent"
   fi
   if bridge_channel_csv_contains "$required" "plugin:teams"; then
-    printf "\nRun: %s setup teams %s --app-id <TEAMS_APP_ID> --app-password <TEAMS_APP_PASSWORD> --allow-from <TEAMS_USER_ID>" "$cli" "$agent"
+    printf "\nRun: BRIDGE_TEAMS_APP_PASSWORD=<TEAMS_APP_PASSWORD> %s setup teams %s --app-id <TEAMS_APP_ID> --allow-from <TEAMS_USER_ID>" "$cli" "$agent"
   fi
   if bridge_channel_csv_contains "$required" "plugin:mattermost"; then
     printf "\nRun: %s setup mattermost %s --url <MATTERMOST_URL> --bot-token <BOT_TOKEN> --allow-from <USER_ID>" "$cli" "$agent"

--- a/plugins/teams/ACCESS.md
+++ b/plugins/teams/ACCESS.md
@@ -6,12 +6,14 @@
 4. Copy the Tenant ID.
 5. Add the bot to Teams and send it one message from the intended user.
 6. Use the Teams AAD object ID or Teams user ID as `--allow-from`.
-7. Run Agent Bridge setup:
+7. Run Agent Bridge setup. Pass the client secret via the
+   `BRIDGE_TEAMS_APP_PASSWORD` environment variable (or `--app-password-file
+   <path>`) so it is not exposed in shell history or the process table:
 
 ```bash
+export BRIDGE_TEAMS_APP_PASSWORD='<client-secret>'
 agb setup teams patch \
   --app-id "<app-id>" \
-  --app-password "<client-secret>" \
   --tenant-id "<tenant-id>" \
   --allow-from "<aad-object-id-or-user-id>" \
   --yes
@@ -20,9 +22,9 @@ agb setup teams patch \
 For team channels, also add a conversation/channel id:
 
 ```bash
+export BRIDGE_TEAMS_APP_PASSWORD='<client-secret>'
 agb setup teams patch \
   --app-id "<app-id>" \
-  --app-password "<client-secret>" \
   --tenant-id "<tenant-id>" \
   --conversation "<teams-conversation-or-channel-id>" \
   --require-mention \

--- a/plugins/teams/README.md
+++ b/plugins/teams/README.md
@@ -58,7 +58,7 @@ For the full operator guide, including ALB / nginx / iptables paths and setup va
 Agent Bridge writes this file through:
 
 ```bash
-agb setup teams <agent> --app-id ... --app-password ... --tenant-id ... --allow-from ... --messaging-endpoint https://bot.example.com/api/messages --webhook-host 0.0.0.0
+BRIDGE_TEAMS_APP_PASSWORD=... agb setup teams <agent> --app-id ... --tenant-id ... --allow-from ... --messaging-endpoint https://bot.example.com/api/messages --webhook-host 0.0.0.0
 ```
 
 ## Inbound Attachments

--- a/plugins/teams/skills/access/SKILL.md
+++ b/plugins/teams/skills/access/SKILL.md
@@ -12,10 +12,13 @@ Important files:
 - `.env`: contains `TEAMS_APP_ID`, `TEAMS_APP_PASSWORD`, and `TEAMS_TENANT_ID`.
 - `access.json`: contains user allowlists and conversation policies.
 
-Prefer the deterministic Agent Bridge setup command instead of hand-editing credentials:
+Prefer the deterministic Agent Bridge setup command instead of hand-editing
+credentials. Pass the client secret via the `BRIDGE_TEAMS_APP_PASSWORD`
+environment variable (or `--app-password-file <path>`) so it is not exposed in
+shell history or the process table:
 
 ```bash
-agb setup teams <agent> --app-id <app-id> --app-password <secret> --tenant-id <tenant-id> --allow-from <aad-object-id> --yes
+BRIDGE_TEAMS_APP_PASSWORD=<secret> agb setup teams <agent> --app-id <app-id> --tenant-id <tenant-id> --allow-from <aad-object-id> --yes
 ```
 
 For team channels, require mentions unless the user explicitly asks for every message in the channel to wake the agent:


### PR DESCRIPTION
## Summary

Fixes #1063 — channel setup accepted the Teams app password (Azure Bot client secret) as a positional argv value (`--app-password <secret>`) through `bridge-init.sh` → `bridge-setup.sh` → `bridge-setup.py`. The value was exposed in shell history and the process table (`ps`, `/proc/<pid>/cmdline`) for the duration of a fresh setup. The #1023 redaction work did not cover the init/setup argv path.

## Change

Add a non-argv input path for the Teams client secret, end-to-end:

| Layer | New | Legacy `--app-password` / `--teams-app-password` |
|---|---|---|
| `bridge-setup.py` | `--app-password-file <path>` + `BRIDGE_TEAMS_APP_PASSWORD` env var | still parsed; emits a one-line security warning to stderr |
| `bridge-setup.sh` | recognizes & forwards `--app-password-file` (`teams` + `agent` subcommands) | unchanged passthrough |
| `bridge-init.sh` | `--teams-app-password-file <path>` | warns, then **stages the value into a private mode-600 temp file** (removed on exit) and forwards `--app-password-file` — so the secret never re-enters the downstream `bridge-setup` argv |

- `read_secret_value()` (new helper in `bridge-setup.py`) resolves the secret with precedence **file > env > legacy flag**. A file *path* is safe to carry in argv; the secret is not.
- `BRIDGE_TEAMS_APP_PASSWORD`, when set, is inherited by the child process tree — no `.sh`-layer plumbing needed.
- The legacy flags still work for backward compatibility but are deprecated with a clear warning pointing at the `-file` / env-var alternatives.

Docs that previously instructed operators to pass `--app-password "<client-secret>"` are updated to the env-var / file form: `README.md`, `docs/channels/teams-setup.md`, `plugins/teams/ACCESS.md`, `plugins/teams/README.md`, `plugins/teams/skills/access/SKILL.md`.

## Verification

- `bash -n bridge-init.sh bridge-setup.sh` — OK
- `shellcheck bridge-init.sh bridge-setup.sh` — clean
- `python3 -m py_compile bridge-setup.py` — OK
- `read_secret_value()` unit check: file path wins; env wins over legacy flag; legacy flag falls through with a stderr warning; a missing `--app-password-file` raises `SetupError`.
- `bridge-init.sh --dry-run` with the legacy `--teams-app-password`: deprecation warning fires, exit 0, **no staged secret temp file leaks** (EXIT trap cleans it). `--teams-app-password-file` dry-run: exit 0. (The `BRIDGE_TEAMS_APP_PASSWORD` env-var init path is covered by the `read_secret_value` unit check — this harness blocks setting that env var inside tool calls.)

## Release impact

`release-impact: user-visible` — new flags + deprecation warning + env-var support. Per the version policy this PR does not bump VERSION/CHANGELOG; it batches into the next operator-cued release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
