### PR TITLE
feat(bootstrap): managed tmux UX defaults for Claude/Codex TUI sessions (#1058)

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -38,8 +38,8 @@ bridge-auth.sh	383	C3	f8fb9fe483d3ac0c38ced0173139a79e612c6ab535249af3209b7f9940
 bridge-auth.sh	433	C3	be734a9ab6e1e4554130ae202bee469fb32defc53c8202b83d609506ec2b5942	interpreter heredoc, no capture	patch	Phase 3 PR C
 bridge-auth.sh	492	C3	06e4a68f62d8ceb22b0b00b37059a905bccba312c6175aa988d10304af6487e6	interpreter heredoc, no capture	patch	Phase 3 PR C
 bridge-auth.sh	561	C1	df5b170e11ad07c2aaef6c7bffd08a009027f749d05756a1fe426e3eb37be6b9	interpreter heredoc in capture (deadlock class)	patch	Phase 2 PR B
-bridge-bootstrap.sh	268	C3	0bd9af5acad175c98293fdba3547bcaf6c36f948b6ab99b0048c69d37f8ef49d	interpreter heredoc, no capture	patch	Phase 3 PR C
-bridge-bootstrap.sh	300	C1	651e7839c3b224ee71c7b1becc614957612b81b00a666ad1a0faca905090fc03	interpreter heredoc in capture (deadlock class)	patch	Phase 2 PR B
+bridge-bootstrap.sh	293	C3	7c4dfeb9b916d5d41a5a623c76a0944552b4ded96d4df3438834bc54b28c2e4e	interpreter heredoc, no capture	patch	Phase 3 PR C
+bridge-bootstrap.sh	326	C1	651e7839c3b224ee71c7b1becc614957612b81b00a666ad1a0faca905090fc03	interpreter heredoc in capture (deadlock class)	patch	Phase 2 PR B
 bridge-bundle.sh	204	C1	552e8aefc9e1f31895071e48d57b3565a72a1cdd8b0d56cdaef1c02184a45e98	interpreter heredoc in capture (deadlock class)	patch	Phase 2 PR B
 bridge-bundle.sh	210	C1	f1f45712a9bcd402065e58e8bc5a9172757ca57130c83d06746b9b2ae440fd42	interpreter heredoc in capture (deadlock class)	patch	Phase 2 PR B
 bridge-bundle.sh	258	C3	6f0f0de39b34583f95ce0bd957987db4c62f2151e97dd99e5d22df148d7b8939	interpreter heredoc, no capture	patch	Phase 3 PR C

--- a/bridge-bootstrap.sh
+++ b/bridge-bootstrap.sh
@@ -17,6 +17,9 @@ export BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID=$$
 trap 'unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID' EXIT
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
+# Issue #1058: managed tmux UX defaults for Claude/Codex TUI sessions.
+# shellcheck source=lib/bridge-tmux-ux.sh
+source "$SCRIPT_DIR/lib/bridge-tmux-ux.sh"
 
 usage() {
   cat <<EOF
@@ -27,6 +30,7 @@ Bootstrap options:
   --shell <name>          Shell to integrate (default: current shell basename, fallback zsh)
   --rcfile <path>         Override shell rc file target
   --skip-shell-integration
+  --skip-tmux-ux           Do not write the managed tmux UX block to ~/.tmux.conf
   --skip-daemon
   --skip-launchagent      Do not install/load the macOS LaunchAgent
   --skip-systemd          Do not install/enable the Linux systemd user unit
@@ -47,6 +51,7 @@ bootstrap_shell="${SHELL##*/}"
 bootstrap_shell="${bootstrap_shell:-zsh}"
 bootstrap_rcfile=""
 skip_shell_integration=0
+skip_tmux_ux=0
 skip_daemon=0
 skip_launchagent=0
 skip_systemd=0
@@ -70,6 +75,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-shell-integration)
       skip_shell_integration=1
+      shift
+      ;;
+    --skip-tmux-ux)
+      skip_tmux_ux=1
       shift
       ;;
     --skip-daemon)
@@ -133,6 +142,7 @@ fi
 bridge_require_python
 
 shell_status="skipped"
+tmux_ux_status="skipped"
 daemon_status="skipped"
 launchagent_status="skipped"
 systemd_status="skipped"
@@ -149,6 +159,21 @@ if [[ $skip_shell_integration -eq 0 ]]; then
     [[ -n "$bootstrap_rcfile" ]] && shell_args+=(--rcfile "$bootstrap_rcfile")
     "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/scripts/install-shell-integration.sh" "${shell_args[@]}" >/dev/null
     shell_status="applied"
+  fi
+fi
+
+# Issue #1058: managed tmux UX defaults. Claude/Codex run inside tmux, and a
+# fresh server's stock tmux settings (default-terminal screen, mouse off,
+# escape-time 500) degrade the TUI. bridge_setup_tmux_ux writes an idempotent
+# managed block to ~/.tmux.conf and is non-fatal by contract — it always
+# returns 0, so a tmux/terminfo gap never aborts bootstrap.
+if [[ $skip_tmux_ux -eq 0 ]]; then
+  tmux_ux_status="planned"
+  if [[ $dry_run -eq 0 ]]; then
+    bridge_setup_tmux_ux >&2 || true
+    tmux_ux_status="applied"
+  else
+    bridge_setup_tmux_ux --dry-run >&2 || true
   fi
 fi
 
@@ -265,7 +290,7 @@ if [[ $skip_watchdog_silence -eq 0 ]]; then
 fi
 
 if [[ $json_mode -eq 1 ]]; then
-  python3 - "$init_json" "$shell_status" "$bootstrap_shell" "$bootstrap_rcfile" "$daemon_status" "$launchagent_status" "$systemd_status" "$next_command" "$reload_command" "$liveness_status" "$watchdog_silence_status" <<'PY'
+  python3 - "$init_json" "$shell_status" "$bootstrap_shell" "$bootstrap_rcfile" "$daemon_status" "$launchagent_status" "$systemd_status" "$next_command" "$reload_command" "$liveness_status" "$watchdog_silence_status" "$tmux_ux_status" <<'PY'
 import json
 import sys
 
@@ -283,6 +308,7 @@ payload = {
     "systemd": {"status": sys.argv[7]},
     "liveness": {"status": sys.argv[10]},
     "watchdog_silence": {"status": sys.argv[11]},
+    "tmux_ux": {"status": sys.argv[12]},
     "next_command": sys.argv[8],
     "reload_command": sys.argv[9],
     "handoff_steps": [
@@ -306,6 +332,7 @@ PY
 echo "== Agent Bridge bootstrap =="
 printf 'admin_agent: %s\n' "$admin_agent"
 printf 'shell_integration: %s\n' "$shell_status"
+printf 'tmux_ux: %s\n' "$tmux_ux_status"
 printf 'daemon: %s\n' "$daemon_status"
 printf 'launchagent: %s\n' "$launchagent_status"
 printf 'systemd: %s\n' "$systemd_status"

--- a/lib/bridge-tmux-ux.sh
+++ b/lib/bridge-tmux-ux.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# bridge-tmux-ux.sh — managed tmux UX defaults for Claude/Codex TUI sessions.
+#
+# Issue #1058: Agent Bridge launches Claude Code / Codex inside tmux. A fresh
+# server's stock tmux defaults degrade the TUI:
+#   - `default-terminal screen` → near-monochrome rendering
+#   - `mouse off`               → rough scrollback / copy-mode interaction
+#   - `escape-time 500`         → unreliable / delayed double-`Esc`
+#
+# This helper writes an idempotent *managed block* into `~/.tmux.conf`
+# (delimited by BEGIN/END markers), re-running bootstrap replaces the block
+# in place without duplicating it and without rewriting the rest of the file
+# or clobbering existing user customizations. The whole step is non-fatal:
+# any failure prints a `tmux UX` next-step note and returns 0 so bootstrap
+# never aborts on it.
+#
+# Sourced by bridge-bootstrap.sh after bridge-lib.sh, so bridge_warn /
+# bridge_info are available; the helper still tolerates their absence so it
+# can be unit-smoke-tested standalone.
+#
+# Footgun #11 (Bash 5.3.9 heredoc_write deadlock): the managed block is
+# assembled with `printf` into a plain string and written to a *file* with
+# a single `printf '%s' >file` — no heredoc-to-subprocess, no `<<<`
+# here-string, no process-substitution-into-reader.
+
+# --- soft fallbacks so the helper is testable without bridge-lib.sh ----------
+if ! declare -F bridge_warn >/dev/null 2>&1; then
+  bridge_warn() { echo "[경고] $*" >&2; }
+fi
+if ! declare -F bridge_info >/dev/null 2>&1; then
+  bridge_info() { echo "$*"; }
+fi
+
+# bridge_tmux_ux_version_supports_terminal_features <version-string>
+# `terminal-features` is a tmux 3.2+ option. On older tmux, sourcing a conf
+# that sets it errors out, so the line must be gated. Returns 0 when the
+# detected version is >= 3.2.
+bridge_tmux_ux_version_supports_terminal_features() {
+  local raw="${1:-}"
+  # `tmux -V` prints e.g. "tmux 3.6a" or "tmux next-3.4"; strip to digits.dot.
+  local num
+  num="$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+' | head -n1)"
+  [[ -n "$num" ]] || return 1
+  local major="${num%%.*}"
+  local minor="${num##*.}"
+  # strip any leading zeros defensively (printf %d would choke on "08")
+  major="$((10#${major:-0}))"
+  minor="$((10#${minor:-0}))"
+  if (( major > 3 )); then
+    return 0
+  fi
+  if (( major == 3 && minor >= 2 )); then
+    return 0
+  fi
+  return 1
+}
+
+# bridge_tmux_ux_render_block
+# Emits the managed-block body (between but excluding the markers) to stdout.
+# Args:
+#   $1 default-terminal value ("tmux-256color" or "screen-256color")
+#   $2 "1" to include the terminal-features line, "0" to omit it
+bridge_tmux_ux_render_block() {
+  local default_terminal="$1"
+  local with_terminal_features="$2"
+
+  printf 'set -g default-terminal "%s"\n' "$default_terminal"
+  printf 'set -ag terminal-overrides ",xterm-256color:RGB"\n'
+  if [[ "$with_terminal_features" == "1" ]]; then
+    printf 'set -ag terminal-features ",xterm-256color:RGB"\n'
+  fi
+  printf 'set -g mouse on\n'
+  printf 'set -s escape-time 10\n'
+}
+
+# bridge_tmux_ux_write_conf <conf-path> <block-body>
+# Idempotently install the managed block into <conf-path>. Replaces an
+# existing BEGIN/END block in place; otherwise appends. Never rewrites lines
+# outside the markers. Returns:
+#   0 — written/updated
+#   1 — already up to date (no change)
+#   2 — malformed existing block (BEGIN without END or vice versa)
+bridge_tmux_ux_write_conf() {
+  local conf="$1"
+  local body="$2"
+  local begin="# BEGIN AGENT BRIDGE TMUX UX"
+  local end="# END AGENT BRIDGE TMUX UX"
+
+  # $body is captured via $(...) which strips trailing newlines, so join the
+  # marker lines with explicit newlines rather than relying on a trailing one.
+  local managed
+  managed="$(printf '%s\n%s\n%s' "$begin" "$body" "$end")"
+
+  mkdir -p "$(dirname "$conf")"
+  if [[ ! -f "$conf" ]]; then
+    printf '%s\n' "$managed" >"$conf"
+    return 0
+  fi
+
+  local has_begin=0 has_end=0
+  grep -Fqx "$begin" "$conf" && has_begin=1
+  grep -Fqx "$end" "$conf" && has_end=1
+
+  if (( has_begin != has_end )); then
+    return 2
+  fi
+
+  if (( has_begin == 0 )); then
+    # Append with a leading blank line separator if the file is non-empty
+    # and does not already end in a newline-only tail.
+    if [[ -s "$conf" ]]; then
+      printf '\n%s\n' "$managed" >>"$conf"
+    else
+      printf '%s\n' "$managed" >>"$conf"
+    fi
+    return 0
+  fi
+
+  # Replace the existing block in place. Walk the file line by line: copy
+  # everything verbatim, swap the BEGIN..END span for the freshly rendered
+  # managed block exactly once.
+  local tmp
+  tmp="$(mktemp "${conf}.tmpXXXXXX" 2>/dev/null)" || return 3
+  [[ -n "$tmp" ]] || return 3
+  local in_block=0 replaced=0 line
+  while IFS='' read -r line || [[ -n "$line" ]]; do
+    if [[ "$in_block" -eq 0 && "$line" == "$begin" ]]; then
+      in_block=1
+      if [[ "$replaced" -eq 0 ]]; then
+        printf '%s\n' "$managed" >>"$tmp"
+        replaced=1
+      fi
+      continue
+    fi
+    if [[ "$in_block" -eq 1 ]]; then
+      if [[ "$line" == "$end" ]]; then
+        in_block=0
+      fi
+      continue
+    fi
+    printf '%s\n' "$line" >>"$tmp"
+  done <"$conf"
+
+  if cmp -s "$tmp" "$conf"; then
+    rm -f "$tmp"
+    return 1
+  fi
+
+  # Preserve the original file mode where possible.
+  chmod --reference="$conf" "$tmp" 2>/dev/null || true
+  mv "$tmp" "$conf"
+  return 0
+}
+
+# bridge_setup_tmux_ux [--dry-run]
+# Top-level entry invoked by bridge-bootstrap.sh. Detects tmux + terminfo,
+# renders the version-gated managed block, writes it to ~/.tmux.conf, and
+# re-sources a live tmux server if one is running. Always returns 0 — any
+# failure is reported as a warning/next-step, never fatal.
+bridge_setup_tmux_ux() {
+  local dry_run=0
+  if [[ "${1:-}" == "--dry-run" ]]; then
+    dry_run=1
+  fi
+
+  local conf="${BRIDGE_TMUX_UX_CONF:-$HOME/.tmux.conf}"
+
+  if ! command -v tmux >/dev/null 2>&1; then
+    bridge_warn "tmux UX: tmux 가 설치되어 있지 않아 ~/.tmux.conf 튜닝을 건너뜁니다."
+    bridge_info "  next step: tmux 설치 후 'agb' 재실행 시 색상/마우스/escape-time 가 자동 보정됩니다."
+    return 0
+  fi
+
+  # default-terminal: only set tmux-256color when its terminfo entry exists.
+  # Setting a missing terminal breaks rendering, so fall back to
+  # screen-256color (universally present) and note the downgrade.
+  local default_terminal="tmux-256color"
+  if ! infocmp -x tmux-256color >/dev/null 2>&1; then
+    default_terminal="screen-256color"
+    bridge_info "tmux UX: 'tmux-256color' terminfo 가 없어 'screen-256color' 로 대체합니다."
+  fi
+
+  # terminal-features is tmux 3.2+. Omit the line on older tmux so sourcing
+  # the conf does not error.
+  local tmux_version with_terminal_features=0
+  tmux_version="$(tmux -V 2>/dev/null || printf '')"
+  if bridge_tmux_ux_version_supports_terminal_features "$tmux_version"; then
+    with_terminal_features=1
+  else
+    bridge_info "tmux UX: ${tmux_version:-tmux} 는 'terminal-features' 미지원 — 해당 줄을 생략합니다."
+  fi
+
+  local body
+  body="$(bridge_tmux_ux_render_block "$default_terminal" "$with_terminal_features")"
+
+  if (( dry_run == 1 )); then
+    bridge_info "tmux UX: --dry-run — ~/.tmux.conf 를 수정하지 않습니다 (managed block 미리보기):"
+    printf '%s\n' "# BEGIN AGENT BRIDGE TMUX UX"
+    printf '%s\n' "$body"
+    printf '%s\n' "# END AGENT BRIDGE TMUX UX"
+    return 0
+  fi
+
+  local rc=0
+  bridge_tmux_ux_write_conf "$conf" "$body" || rc=$?
+  case "$rc" in
+    0)
+      bridge_info "tmux UX: managed block 적용 — $conf"
+      ;;
+    1)
+      bridge_info "tmux UX: managed block 최신 상태 — $conf (변경 없음)"
+      ;;
+    2)
+      bridge_warn "tmux UX: $conf 의 managed block 이 손상되었습니다 (BEGIN/END 불일치)."
+      bridge_info "  next step: '# BEGIN AGENT BRIDGE TMUX UX' ~ '# END AGENT BRIDGE TMUX UX' 구간을 직접 정리 후 'agb' 재실행."
+      return 0
+      ;;
+    *)
+      bridge_warn "tmux UX: ~/.tmux.conf 갱신 중 예기치 못한 오류 (rc=$rc) — 건너뜁니다."
+      return 0
+      ;;
+  esac
+
+  # Re-source a live tmux server so the change takes effect immediately;
+  # skip silently when no server is running.
+  if tmux info >/dev/null 2>&1; then
+    if tmux source-file "$conf" >/dev/null 2>&1; then
+      bridge_info "tmux UX: 실행 중인 tmux 서버에 source-file 반영 완료."
+    else
+      bridge_info "tmux UX: tmux source-file 반영 실패 — 새 tmux 세션부터 적용됩니다."
+    fi
+  fi
+
+  return 0
+}

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux
 }
 
 add_all_integration() {
@@ -507,6 +507,16 @@ select_for_path() {
       # recipe. Pull admin-pair-server-auto-provision whenever any of the
       # four touches so the server/dev gate matrix stays pinned.
       add_required admin-pair-server-auto-provision agent-create-caller-trust-gate upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering
+      add_integration integration-minimal
+      ;;
+
+    bridge-bootstrap.sh|lib/bridge-tmux-ux.sh)
+      # Issue #1058: bridge-bootstrap.sh sources lib/bridge-tmux-ux.sh and
+      # runs bridge_setup_tmux_ux, which writes an idempotent managed tmux
+      # UX block to ~/.tmux.conf. Pull the idempotency / graceful-degradation
+      # smoke whenever either file moves so a future PR cannot regress the
+      # in-place block replacement or the version/terminfo gating.
+      add_required 1058-bootstrap-tmux-ux agent-create-caller-trust-gate
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1058-bootstrap-tmux-ux.sh
+++ b/scripts/smoke/1058-bootstrap-tmux-ux.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1058-bootstrap-tmux-ux.sh — Issue #1058.
+#
+# Pins the contract that `lib/bridge-tmux-ux.sh`'s managed-block writer is
+# idempotent and degrades gracefully.
+#
+# Background (#1058): Agent Bridge launches Claude/Codex inside tmux. A fresh
+# server's stock tmux defaults (`default-terminal screen`, `mouse off`,
+# `escape-time 500`) degrade the TUI. `bridge_setup_tmux_ux` (sourced by
+# bridge-bootstrap.sh) writes an idempotent `# BEGIN/# END AGENT BRIDGE
+# TMUX UX` managed block to ~/.tmux.conf.
+#
+# Test plan (in-process bash — no live tmux server is required; the helper's
+# `tmux info` probe simply finds no server and skips re-sourcing):
+#
+#   T1. First write into a conf that already has an unrelated user line —
+#       the managed block is appended, the user line survives.
+#   T2. Second write (idempotent) — rc=1 "no change", exactly one BEGIN and
+#       one END marker, the user line still survives.
+#   T3. A user line added AFTER the block survives an in-place replacement
+#       when the block body changes.
+#   T4. Malformed block (BEGIN without END) — writer returns rc=2 and does
+#       NOT rewrite the file.
+#   T5. Version gate — `terminal-features` is included for tmux >= 3.2 and
+#       omitted for older tmux.
+#   T6. --dry-run — the conf is never created.
+#
+# Footgun #11 (heredoc_write deadlock class): this smoke and the helper it
+# exercises build every block with `printf` — no heredoc-to-subprocess, no
+# `<<<` here-strings, no process-substitution-into-reader.
+
+set -uo pipefail
+
+SMOKE_NAME="1058-bootstrap-tmux-ux"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+HELPER="$REPO_ROOT/lib/bridge-tmux-ux.sh"
+smoke_assert_file_exists "$HELPER" "lib/bridge-tmux-ux.sh exists"
+
+# shellcheck source=lib/bridge-tmux-ux.sh
+source "$HELPER"
+
+# --- T1: first write appends the block, unrelated user line survives ---------
+smoke_log "T1: first write appends the managed block and preserves an unrelated user line"
+
+CONF="$SMOKE_TMP_ROOT/t1.tmux.conf"
+printf '%s\n' 'set -g status-bg blue' >"$CONF"
+
+T1_BODY="$(bridge_tmux_ux_render_block "tmux-256color" 1)"
+T1_RC=0
+bridge_tmux_ux_write_conf "$CONF" "$T1_BODY" || T1_RC=$?
+smoke_assert_eq "0" "$T1_RC" "T1: first write returns rc=0 (written)"
+smoke_assert_eq "1" "$(grep -c '^# BEGIN AGENT BRIDGE TMUX UX$' "$CONF")" \
+  "T1: exactly one BEGIN marker after first write"
+smoke_assert_eq "1" "$(grep -c '^# END AGENT BRIDGE TMUX UX$' "$CONF")" \
+  "T1: exactly one END marker after first write"
+smoke_assert_eq "1" "$(grep -c '^set -g status-bg blue$' "$CONF")" \
+  "T1: the pre-existing unrelated user line survives the write"
+smoke_assert_eq "1" "$(grep -c '^set -g mouse on$' "$CONF")" \
+  "T1: the managed block contains the mouse-on line"
+smoke_assert_eq "1" "$(grep -c '^set -s escape-time 10$' "$CONF")" \
+  "T1: the managed block uses the conservative escape-time 10"
+# The END marker must be on its own line, never fused to the last body line.
+[[ "$(tail -n1 "$CONF")" == "# END AGENT BRIDGE TMUX UX" ]] \
+  || smoke_fail "T1: END marker is not on its own final line"
+smoke_log "T1 PASS"
+
+# --- T2: second write is idempotent (no change, no duplicate) ----------------
+smoke_log "T2: a second write reports no change and never duplicates the block"
+
+T2_RC=0
+bridge_tmux_ux_write_conf "$CONF" "$T1_BODY" || T2_RC=$?
+smoke_assert_eq "1" "$T2_RC" "T2: re-write returns rc=1 (already up to date)"
+smoke_assert_eq "1" "$(grep -c '^# BEGIN AGENT BRIDGE TMUX UX$' "$CONF")" \
+  "T2: still exactly one BEGIN marker after re-write"
+smoke_assert_eq "1" "$(grep -c '^# END AGENT BRIDGE TMUX UX$' "$CONF")" \
+  "T2: still exactly one END marker after re-write"
+smoke_assert_eq "1" "$(grep -c '^set -g status-bg blue$' "$CONF")" \
+  "T2: the unrelated user line still survives the re-write"
+smoke_log "T2 PASS"
+
+# --- T3: in-place replace preserves a user line that follows the block -------
+smoke_log "T3: a user line after the block survives an in-place block replacement"
+
+printf '%s\n' 'set -g history-limit 50000' >>"$CONF"
+# Render a DIFFERENT body (screen-256color fallback) so the block content
+# genuinely changes and the writer must replace in place.
+T3_BODY="$(bridge_tmux_ux_render_block "screen-256color" 0)"
+T3_RC=0
+bridge_tmux_ux_write_conf "$CONF" "$T3_BODY" || T3_RC=$?
+smoke_assert_eq "0" "$T3_RC" "T3: in-place replacement returns rc=0 (updated)"
+smoke_assert_eq "1" "$(grep -c '^# BEGIN AGENT BRIDGE TMUX UX$' "$CONF")" \
+  "T3: still exactly one BEGIN marker after in-place replacement"
+smoke_assert_eq "1" "$(grep -c '^set -g status-bg blue$' "$CONF")" \
+  "T3: the user line BEFORE the block survives the replacement"
+smoke_assert_eq "1" "$(grep -c '^set -g history-limit 50000$' "$CONF")" \
+  "T3: the user line AFTER the block survives the replacement"
+smoke_assert_eq "1" "$(grep -c '^set -g default-terminal "screen-256color"$' "$CONF")" \
+  "T3: the replaced block carries the new default-terminal value"
+smoke_assert_eq "0" "$(grep -c '^set -ag terminal-features' "$CONF")" \
+  "T3: the version-gated terminal-features line is absent when omitted"
+smoke_log "T3 PASS"
+
+# --- T4: malformed block (BEGIN without END) is refused, file untouched ------
+smoke_log "T4: a malformed block (BEGIN without END) returns rc=2 and does not rewrite the file"
+
+MAL_CONF="$SMOKE_TMP_ROOT/t4.tmux.conf"
+printf '%s\n' 'set -g status-bg green' '# BEGIN AGENT BRIDGE TMUX UX' 'set -g mouse on' >"$MAL_CONF"
+MAL_BEFORE="$(cat "$MAL_CONF")"
+T4_RC=0
+bridge_tmux_ux_write_conf "$MAL_CONF" "$T1_BODY" || T4_RC=$?
+smoke_assert_eq "2" "$T4_RC" "T4: malformed block returns rc=2"
+smoke_assert_eq "$MAL_BEFORE" "$(cat "$MAL_CONF")" \
+  "T4: the file is left untouched when the existing block is malformed"
+smoke_log "T4 PASS"
+
+# --- T5: version gate for the terminal-features line -------------------------
+smoke_log "T5: terminal-features is gated on tmux >= 3.2"
+
+for ok_version in "tmux 3.2" "tmux 3.6a" "tmux 4.0" "tmux next-3.4"; do
+  bridge_tmux_ux_version_supports_terminal_features "$ok_version" \
+    || smoke_fail "T5: expected '$ok_version' to support terminal-features"
+done
+for old_version in "tmux 3.1c" "tmux 2.9a" "tmux 1.8" "garbage"; do
+  if bridge_tmux_ux_version_supports_terminal_features "$old_version"; then
+    smoke_fail "T5: expected '$old_version' to NOT support terminal-features"
+  fi
+done
+smoke_log "T5 PASS"
+
+# --- T6: --dry-run never creates the conf ------------------------------------
+smoke_log "T6: bridge_setup_tmux_ux --dry-run never mutates ~/.tmux.conf"
+
+DRY_CONF="$SMOKE_TMP_ROOT/t6-dry.tmux.conf"
+BRIDGE_TMUX_UX_CONF="$DRY_CONF" bridge_setup_tmux_ux --dry-run >/dev/null 2>&1
+[[ ! -e "$DRY_CONF" ]] \
+  || smoke_fail "T6: --dry-run created the conf file; it must never mutate ~/.tmux.conf"
+smoke_log "T6 PASS"
+
+smoke_log "all tests PASS — bridge_setup_tmux_ux managed-block writer is idempotent and degrades gracefully (#1058)"
+exit 0


### PR DESCRIPTION
## Summary

- Adds `lib/bridge-tmux-ux.sh`: writes an idempotent `BEGIN/END AGENT BRIDGE TMUX UX` managed block to `~/.tmux.conf` on every bootstrap run. Replaces the block in place without duplicating it or clobbering the rest of the file.
- Wires the new step into `bridge-bootstrap.sh` with `--skip-tmux-ux` opt-out and `--dry-run` awareness. Exposes `tmux_ux` status in JSON and plain output.
- Version-gates `set -ag terminal-features` to tmux >= 3.2; falls back from `tmux-256color` to `screen-256color` when the terminfo entry is absent.
- Re-sources a live tmux server if running (`tmux source-file`); skips silently otherwise.
- Entire step is non-fatal: any failure is a warning/next-step note, never aborts bootstrap.

## Block content

```tmux
# BEGIN AGENT BRIDGE TMUX UX
set -g default-terminal "tmux-256color"
set -ag terminal-overrides ",xterm-256color:RGB"
set -ag terminal-features ",xterm-256color:RGB"   # tmux >= 3.2 only
set -g mouse on
set -s escape-time 10
# END AGENT BRIDGE TMUX UX
```

## Idempotency evidence

Functional run in isolated HOME:
- **First run**: block appended; existing user line `set -g status-bg blue` preserved; `BEGIN` count = 1, `END` count = 1.
- **Second run**: reports "변경 없음" (no change); `BEGIN` count still = 1, `END` count still = 1.
- **In-place replacement**: when block body changes (fallback terminal), a user line *after* the block also survives.
- **Malformed block** (BEGIN without END): writer returns rc=2 and leaves the file untouched.

## Smoke test coverage (T1–T6)

`scripts/smoke/1058-bootstrap-tmux-ux.sh` — all pass:
- T1: first write appends block, unrelated user line survives
- T2: second write is idempotent (rc=1), no duplicate markers
- T3: in-place replacement preserves user lines before and after the block
- T4: malformed block refused (rc=2), file untouched
- T5: `terminal-features` included for tmux >= 3.2, omitted for older versions
- T6: `--dry-run` never creates/mutates `~/.tmux.conf`

## Verification

- `bash -n`: PASS (all touched .sh files)
- `shellcheck`: PASS (lib/bridge-tmux-ux.sh, scripts/smoke/1058-bootstrap-tmux-ux.sh)
- `scripts/lint-heredoc-ban.sh --baseline-check`: PASS
- `scripts/smoke/1058-bootstrap-tmux-ux.sh`: PASS (T1–T6)
- `scripts/smoke-test.sh`: PASS except pre-existing live-install-leak failures (reproduces on main without any edits)
- Footgun #11: all block assembly via `printf` to file — no heredoc-to-subprocess, no `<<<`, no process-sub-to-reader

## Codex pair-review focus points

1. **Idempotency edge case**: `bridge_tmux_ux_write_conf` line-by-line walk — confirm the `cmp -s` early-return for "already up to date" (rc=1) is correct. Confirm lines outside BEGIN/END are correctly passed through.
2. **macOS `chmod --reference` absence**: line 150 uses `|| true` fallback. Acceptable since tmux.conf mode preservation is best-effort, but worth confirming the `mv "$tmp" "$conf"` doesn't leave unreadable files.
3. **`bridge-bootstrap.sh` dry-run path**: `bridge_setup_tmux_ux --dry-run` is called as a no-op on `--dry-run`; confirm `tmux_ux_status` transitions correctly (`planned` not `applied` under dry-run).
4. **JSON output arg position**: `sys.argv[12]` for `tmux_ux_status` — verify the positional arg alignment in the `python3 - ...` call in bridge-bootstrap.sh.
5. **`.lint-heredoc-baseline.tsv` line shift**: two rows for bridge-bootstrap.sh shifted from lines 268/300 to 293/326 because the `source lib/bridge-tmux-ux.sh` block was inserted above them.

Fixes #1058