### PR TITLE
feat(layout): typed agent-layout resolver + minimal engine descriptor (#1060)

### DIFF
--- a/agents/_template/.claude/commands/wrap-up.md
+++ b/agents/_template/.claude/commands/wrap-up.md
@@ -38,15 +38,21 @@ by this session's id. Run:
 # not always the same as the session's working directory. Resolve them
 # separately.
 #
-#   AGENT_HOME  — where `memory/<today>.md` gets written. Always the
-#                 bridge-managed home; matches `bridge-agent.sh`
-#                 scaffolding and PR 1A's autoMemoryDirectory seed.
+#   AGENT_HOME  — where `memory/<today>.md` gets written. The IDENTITY
+#                 SOURCE (issue #1060 layer 2) — matches `bridge-agent.sh`
+#                 scaffolding and PR 1A's autoMemoryDirectory seed. On a
+#                 v2 install this is `$BRIDGE_AGENT_ROOT_V2/<agent>/home`,
+#                 NOT `$BRIDGE_AGENT_HOME_ROOT/<agent>` (that path is the
+#                 tracked profile source on v2 — writing the daily note
+#                 there is the #1060 model-drift bug).
 #   WORKDIR     — the session's cwd, used by current-session-id to
 #                 derive the `~/.claude/projects/<slug>/` lookup key.
 #                 Claude scopes transcripts by the git root of the
 #                 session cwd, so conflating this with AGENT_HOME sends
 #                 the scan to a directory that has no jsonl files.
-if [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" ]]; then
+if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+  AGENT_HOME="$BRIDGE_AGENT_ROOT_V2/$BRIDGE_AGENT_ID/home"
+elif [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" ]]; then
   AGENT_HOME="$BRIDGE_AGENT_HOME_ROOT/$BRIDGE_AGENT_ID"
 else
   AGENT_HOME="$HOME/.agent-bridge/agents/$BRIDGE_AGENT_ID"

--- a/agents/_template/CLAUDE.md
+++ b/agents/_template/CLAUDE.md
@@ -58,7 +58,7 @@
 - **역할**: <핵심 책임>
 - **보스**: <주 요청자>
 - **런타임**: <Claude Code CLI | Codex CLI>
-- **라이브 홈**: `~/.agent-bridge/agents/<agent-id>/`
+- **레이아웃**: 이 에이전트의 경로는 세 계층으로 나뉜다 — tracked profile source(이식 가능한 역할 원본, 있을 때만), identity source(SOUL/MEMORY/SESSION-TYPE 등 권위 정체성 트리), workspace(런타임이 실행되는 cwd). 실제 해석된 경로는 `agent-bridge agent show <agent-id>`의 `agent_home`(identity source)와 `workdir`(workspace) 줄로 확인한다. 설치마다 다르므로 경로를 직접 하드코딩하지 않는다.
 
 ## 매 세션 시작 시
 1. `SOUL.md` 읽기

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -2824,7 +2824,17 @@ report and reap test-fixture agents per their pattern."
       # `bridge_agent_workdir` (and therefore the descriptor's target
       # lookup) depends on runs AFTER bridge_write_role_block below, so
       # the create flow hands the already-resolved workspace directly.
-      bridge_layout_materialize_identity "$agent" "$engine" "$workdir"
+      #
+      # Codex r1 BLOCKING 1: propagate the operator's --allow-shared-workdir
+      # intent into the materializer so a normal project workspace (no
+      # marker text) is NOT stamped over. The materializer's marker-based
+      # detection alone is insufficient for markerless shared projects.
+      if [[ "${allow_shared_workdir:-0}" == "1" ]]; then
+        BRIDGE_LAYOUT_WORKSPACE_SHARED=1 \
+          bridge_layout_materialize_identity "$agent" "$engine" "$workdir"
+      else
+        bridge_layout_materialize_identity "$agent" "$engine" "$workdir"
+      fi
     fi
     if [[ "$engine" == "claude" ]]; then
       bridge_ensure_project_claude_guidance "$workdir" >/dev/null 2>&1 || true

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1759,7 +1759,19 @@ run_show() {
     printf 'admin: %s\n' "$admin"
     printf 'session: %s\n' "$session"
     printf 'session_id: %s\n' "${session_id:--}"
+    # Issue #1060 D2: the three-layer agent-layout model exposed as three
+    # distinct, resolver-derived lines so `agent show` stops conflating
+    # them. `agent_home` is the IDENTITY SOURCE (layer 2 — the authored
+    # canonical identity tree); `workdir` is the WORKSPACE (layer 3 — the
+    # process cwd the runtime launches in, the value already carried by
+    # the TSV `workdir` column = `bridge_agent_workdir`). On a v2 install
+    # the two diverge (`<agent-root>/home` vs `<agent-root>/workdir`);
+    # before #1060 only `workdir` was shown, so the operator could not
+    # tell which tree held the authored identity.
     printf 'workdir: %s\n' "$workdir"
+    if declare -F bridge_layout_agent_home >/dev/null 2>&1; then
+      printf 'agent_home: %s\n' "$(bridge_layout_agent_home "$row_agent")"
+    fi
     printf 'profile_home: %s\n' "${profile_home:--}"
     printf 'profile_source: %s\n' "$profile_source"
     printf 'active: %s\n' "$active"
@@ -2685,18 +2697,23 @@ report and reap test-fixture agents per their pattern."
 
   session="${session:-$agent}"
   default_home="$(bridge_agent_default_home "$agent")"
-  # #1045/#1046: on a v2 install the runtime resolver (bridge_agent_workdir)
-  # resolves the agent's cwd — the path preflight / start_dry_run / `agent
-  # show` use, and the dir the live session is launched in — to the sibling
-  # `<agent-root>/workdir`, NOT `<agent-root>/home` (which is the process
-  # HOME). bridge_agent_default_home returns the `home/` path, so defaulting
-  # the scaffold target to it lands the entire profile (CLAUDE.md, SOUL.md,
-  # .claude/...) under `home/` while the resolved `workdir/` stays empty —
-  # the exact fresh-install (#1045) and `agent create --isolate` (#1046)
-  # break. When the operator did not pass an explicit `--workdir`, default
-  # the scaffold target to the resolved v2 `workdir/` so the profile lands
-  # where the runtime actually looks. The `home/` sibling is still created
-  # by bridge_scaffold_agent_home. An explicit `--workdir` is honored as-is.
+  # Issue #1060: the three-layer agent-layout model. `agent create`
+  # authors the canonical per-agent identity (SOUL / SESSION-TYPE /
+  # MEMORY* / role payload) into the IDENTITY SOURCE — layer 2,
+  # `bridge_layout_agent_home` = v2 `<agent-root>/home`. It is no longer
+  # the empty/stale sibling: the create flow scaffolds INTO it, then runs
+  # a materialization step that delivers the identity fileset into the
+  # engine's materialization target (the workspace `workdir/` for v2
+  # static Claude) so the runtime — which keeps reading `workdir/`
+  # exactly as before (no reader flip) — receives a populated, current
+  # identity. This closes the #1046/#1060 model drift: scaffold no longer
+  # treats `home/` as the runtime home while the resolver launches the
+  # empty `workdir/`.
+  #
+  # `workdir` here stays the WORKSPACE (layer 3) — process cwd, the path
+  # `bridge_agent_workdir` resolves and the live session launches in.
+  # When the operator did not pass an explicit `--workdir`, default it to
+  # the resolved v2 `workdir/`. An explicit `--workdir` is honored as-is.
   local _workdir_is_v2_default=0
   if [[ -z "$workdir" && -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
     workdir="$BRIDGE_AGENT_ROOT_V2/$agent/workdir"
@@ -2765,13 +2782,50 @@ report and reap test-fixture agents per their pattern."
         bridge_die "workdir가 이미 존재하고 비어 있지 않습니다: $workdir"
       fi
     fi
+    # Issue #1060 D1: scaffold the authored identity into the IDENTITY
+    # SOURCE (layer 2). On a v2 install the identity source is ALWAYS
+    # `bridge_layout_agent_home` = `<agent-root>/home` — regardless of
+    # whether the workspace is the v2-default `workdir/` or an explicit
+    # `--workdir` (including a *shared* project tree). Authoring the
+    # identity into `home/` is what keeps per-agent identity OUT of a
+    # shared workspace (the shared-workdir rule): the materialization
+    # step below then delivers it into the workspace ONLY when the
+    # workspace is not shared. On a legacy install (no BRIDGE_AGENT_ROOT_V2)
+    # the identity source and workspace coincide, so the target stays
+    # `$workdir` and materialization is a no-op. `bridge_scaffold_agent_home`
+    # still creates the v2 sibling, so both `home/` and `workdir/` exist
+    # after this call.
+    local scaffold_target="$workdir"
+    if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]] \
+        && declare -F bridge_layout_agent_home >/dev/null 2>&1; then
+      scaffold_target="$(bridge_expand_user_path "$(bridge_layout_agent_home "$agent")")"
+    fi
     # v0.8.5 #693 (Wave-3): pass isolation_mode + os_user so scaffold's
     # sudo-handoff predicate (added by PR #688 for #677) actually fires
     # on `agent create --isolate ...`. Without these explicit args, the
     # in-roster lookup inside scaffold would short-circuit the sudo path
     # — see the comment on `bridge_scaffold_agent_home`'s signature.
-    bridge_scaffold_agent_home "$agent" "$workdir" "$display_name" "$role_text" "$engine" "$session_type" "$isolation_mode" "$os_user"
-    bridge_scaffold_user_partitions "$workdir" "$users_json"
+    bridge_scaffold_agent_home "$agent" "$scaffold_target" "$display_name" "$role_text" "$engine" "$session_type" "$isolation_mode" "$os_user"
+    # Per-user partitions (`users/<id>/USER.md`) are per-agent identity,
+    # so they are scaffolded into the IDENTITY SOURCE alongside the rest
+    # of the authored identity — the `users/` skeleton template lands
+    # under `$scaffold_target`. The materialization step below delivers
+    # the populated `users/` tree into the workspace read target.
+    bridge_scaffold_user_partitions "$scaffold_target" "$users_json"
+    # Issue #1060 D1: deliver the authored identity into the engine's
+    # materialization target (the workspace `workdir/` for v2 static
+    # Claude) so the runtime read target is never the empty/stale
+    # sibling that caused the #1046/#1060 re-onboarding loop. No-op when
+    # scaffold_target == the materialization target (legacy / custom
+    # --workdir). Honors the shared-workspace rule internally.
+    if [[ "$scaffold_target" != "$workdir" ]] \
+        && declare -F bridge_layout_materialize_identity >/dev/null 2>&1; then
+      # Pass $workdir explicitly: the roster reload that
+      # `bridge_agent_workdir` (and therefore the descriptor's target
+      # lookup) depends on runs AFTER bridge_write_role_block below, so
+      # the create flow hands the already-resolved workspace directly.
+      bridge_layout_materialize_identity "$agent" "$engine" "$workdir"
+    fi
     if [[ "$engine" == "claude" ]]; then
       bridge_ensure_project_claude_guidance "$workdir" >/dev/null 2>&1 || true
       bridge_ensure_auto_memory_isolation "$agent" "$workdir"

--- a/bridge-channels.py
+++ b/bridge-channels.py
@@ -132,13 +132,34 @@ def cmd_remove_webhook_server(args: argparse.Namespace) -> int:
     payload = ensure_mcp_root(mcp_path)
     servers = mcp_servers(payload)
     removed = servers.pop(args.server_name, None) is not None
+    status = "removed" if removed else "absent"
     if removed:
-        save_json(mcp_path, payload)
+        # beta5 QA finding #1: on `agent create --isolate` this legacy-
+        # webhook cleanup step runs against a workdir owned by the
+        # isolated UID, so `save_json` (mkdir / tmp-write / replace)
+        # raises PermissionError. The step is non-essential — the agent
+        # is created fine either way — but an uncaught exception dumped
+        # a full Python traceback into the create output (the caller in
+        # bridge-start.sh / bridge-setup.sh captures stderr and echoes
+        # it). Catch the PermissionError / OSError quietly: emit a
+        # one-line note in MCP_STATUS, no traceback, and keep rc=0 so the
+        # create outcome is unchanged. A genuine cleanup is then the
+        # operator's manual follow-up (the callers already warn about a
+        # residual `.mcp.json` entry).
+        try:
+            save_json(mcp_path, payload)
+        except (PermissionError, OSError) as exc:
+            status = "remove-skipped (not writable)"
+            print(
+                f"bridge-channels: webhook cleanup skipped — {mcp_path} "
+                f"not writable ({exc.__class__.__name__})",
+                file=sys.stderr,
+            )
 
     print_payload(
         {
             "MCP_FILE": str(mcp_path),
-            "MCP_STATUS": "removed" if removed else "absent",
+            "MCP_STATUS": status,
             "MCP_SERVER_NAME": args.server_name,
             "MCP_WEBHOOK_PORT": str(args.port),
             "MCP_COMMAND": "",

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -392,6 +392,14 @@ bridge_source_module "bridge-isolation-v3-channel-dotenv.sh"
 # already defined (the runtime state helper composes the two).
 bridge_source_module "bridge-isolation-runtime.sh"
 bridge_source_module "bridge-profiles.sh"
+# Issue #1060: typed agent-layout resolver + minimal engine descriptor.
+# Sourced after bridge-agents.sh (the resolver wraps
+# `bridge_agent_default_home` / `bridge_agent_workdir`) and
+# bridge-profiles.sh (the profile-source layer wraps
+# `bridge_profile_source_root`). The descriptor depends on the layout
+# resolver for workspace/home resolution, so it loads second.
+bridge_source_module "bridge-agent-layout.sh"
+bridge_source_module "bridge-engine-descriptor.sh"
 bridge_source_module "bridge-cron.sh"
 bridge_source_module "bridge-discord.sh"
 bridge_source_module "bridge-notify.sh"

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -633,6 +633,14 @@ if [[ $DRY_RUN -eq 1 ]]; then
   echo "agent=$AGENT"
   echo "session=$SESSION"
   echo "workdir=$WORK_DIR"
+  # Issue #1060 D2: surface the identity source (layer 2) alongside the
+  # workspace (layer 3) so dry-run and `agent show` report the same
+  # three-layer model. `workdir` is the cwd the runtime launches in;
+  # `agent_home` is the authored canonical identity tree. On a v2 install
+  # the two diverge — before #1060 dry-run only printed `workdir`.
+  if declare -F bridge_layout_agent_home >/dev/null 2>&1; then
+    echo "agent_home=$(bridge_layout_agent_home "$AGENT")"
+  fi
   echo "continue=$EFFECTIVE_CONTINUE_MODE"
   echo "safe_mode=$SAFE_MODE"
   echo "channels=$(bridge_agent_channels_csv "$AGENT")"

--- a/lib/bridge-agent-layout.sh
+++ b/lib/bridge-agent-layout.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bridge-agent-layout.sh — typed agent-layout resolver (issue #1060).
+#
+# The single owner of agent path resolution for NEW code and for the
+# #1060 D1-D4 consumers. It does NOT reimplement path math — every typed
+# accessor wraps the existing resolver in bridge-agents.sh. The point of
+# the module is to give callers a *named, typed* contract instead of
+# scattering raw `bridge_agent_default_home` / `bridge_agent_workdir`
+# calls that disagree about which of the three layers they mean.
+#
+# The three-layer agent-layout model (issue #1060)
+# ------------------------------------------------
+#   1. profile source — the tracked, portable role *source* under
+#      `$BRIDGE_HOME/agents/<agent>`. Optional (only admin / imported /
+#      migrated agents have one). It is NOT a live home; it is the input
+#      `agent-bridge profile deploy` reads from.
+#   2. identity source — the authored canonical per-agent identity
+#      (SOUL / MEMORY* / SESSION-TYPE / role payload / engine config).
+#      On a v2 install this is `data/agents/<agent>/home`. This is the
+#      tree `agent create` now authors into (D1).
+#   3. workspace — the process cwd / project tree the agent operates in;
+#      may be shared across agents via `--allow-shared-workdir`. On a v2
+#      install this is `data/agents/<agent>/workdir`.
+#
+# Plus the *engine materialization target* — where the engine runtime
+# actually reads identity from. That is owned by bridge-engine-descriptor.sh
+# (`bridge_engine_materialization_target`), NOT by this module: it is
+# per-engine, and the descriptor is the sole source of per-engine
+# branching. For the v2 static Claude case the materialization target is
+# the workspace dir, which is why the runtime keeps reading where it
+# reads today — the materialization step (D1) delivers the authored
+# identity from layer 2 into that target.
+#
+# IMPORTANT — no reader flip. This module does NOT change where the
+# runtime reads identity. `bridge_layout_agent_home` is the *authored
+# source*; the runtime still resolves cwd / canonical files through
+# `bridge_agent_workdir` exactly as before. The materialization step is
+# what reconciles the two so the read target is never empty/stale.
+#
+# Existing call sites of `bridge_agent_default_home` / `bridge_agent_workdir`
+# may stay — they are the implementation this module wraps. The new
+# contract is only that NEW code and the migrated D1-D4 consumers go
+# through these typed accessors.
+
+# bridge_layout_profile_source_dir <agent>
+#
+# Layer 1 — the tracked role *source* under `$BRIDGE_HOME/agents/<agent>`.
+# Always prints a path (the canonical location); the path may not exist
+# — callers that need an existence check should pair this with
+# `bridge_layout_has_profile_source`. Wraps bridge-profiles.sh so the
+# profile-source path math has exactly one owner.
+bridge_layout_profile_source_dir() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  if declare -F bridge_profile_source_root >/dev/null 2>&1; then
+    bridge_profile_source_root "$agent"
+    return 0
+  fi
+  # Fallback for direct-source consumers that did not pull bridge-profiles.sh.
+  printf '%s/agents/%s' "${BRIDGE_HOME:-$HOME/.agent-bridge}" "$agent"
+}
+
+# bridge_layout_has_profile_source <agent>
+#
+# True when the agent has a tracked profile source on disk. Thin wrapper
+# over bridge-profiles.sh's predicate so layout consumers do not have to
+# reach into a different module.
+bridge_layout_has_profile_source() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  if declare -F bridge_profile_has_source >/dev/null 2>&1; then
+    bridge_profile_has_source "$agent"
+    return $?
+  fi
+  [[ -d "$(bridge_layout_profile_source_dir "$agent")" ]]
+}
+
+# bridge_layout_agent_home <agent>
+#
+# Layer 2 — the identity source. The authored canonical per-agent
+# identity tree. Wraps `bridge_agent_default_home` (lib/bridge-agents.sh):
+# on a v2 install that is `$BRIDGE_AGENT_ROOT_V2/<agent>/home`, on a
+# legacy install `$BRIDGE_AGENT_HOME_ROOT/<agent>`. This is the tree
+# `agent create` authors into and the materialization step copies *from*.
+bridge_layout_agent_home() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  bridge_agent_default_home "$agent"
+}
+
+# bridge_layout_workspace_dir <agent>
+#
+# Layer 3 — the workspace cwd. The process cwd / project tree, possibly
+# shared. Wraps `bridge_agent_workdir` (lib/bridge-agents.sh), which
+# already honors the v2/v1, static/dynamic, isolated/shared cases
+# (issue #895). This is the path the live session is launched in.
+bridge_layout_workspace_dir() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  bridge_agent_workdir "$agent"
+}
+
+# bridge_layout_runtime_dir
+#
+# The runtime / state root. On a v2 install this is the per-agent-root
+# parent (`$BRIDGE_AGENT_ROOT_V2`); otherwise the live runtime root.
+# Wraps the existing root resolution so layout consumers have one name
+# for "where runtime state lives" instead of probing env vars directly.
+bridge_layout_runtime_dir() {
+  if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+    printf '%s' "$BRIDGE_AGENT_ROOT_V2"
+    return 0
+  fi
+  printf '%s' "${BRIDGE_STATE_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/state}"
+}
+
+# bridge_layout_memory_dir <agent>
+#
+# The per-agent memory root. Always `agent_home/memory` (layer 2) —
+# memory is part of the authored identity, never inferred from the
+# workspace cwd. This is the path the D4 memory tooling must default to.
+bridge_layout_memory_dir() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  printf '%s/memory' "$(bridge_layout_agent_home "$agent")"
+}
+
+# bridge_layout_materialize_identity <agent> <engine> [target_dir]
+#
+# The D1 materialization step. Copies/syncs the authored identity
+# fileset from the identity source (layer 2, `bridge_layout_agent_home`)
+# into the engine's materialization target so the runtime — which keeps
+# reading where it reads today — receives a populated, current identity.
+#
+# Behavior:
+#   * Resolves the engine materialization target via the descriptor
+#     (`bridge_engine_materialization_target`). An explicit `target_dir`
+#     third argument overrides that lookup — used by `agent create`,
+#     which has the resolved workspace in hand BEFORE the roster reload
+#     `bridge_agent_workdir` depends on.
+#   * No-op when the target equals the identity source (legacy installs
+#     where home == workdir, or any engine whose descriptor names the
+#     identity source itself as the target).
+#   * Shared-workspace rule: when the workspace is a *shared* project
+#     tree (the target dir already holds a foreign-agent CLAUDE.md /
+#     AGENTS.md, or is flagged shared), per-agent identity is NOT
+#     materialized into it — per-agent identity then stays in
+#     `agent_home` and per-agent hook-injected surfaces. The function
+#     returns 0 (success, intentionally skipped) and emits one note.
+#   * Copies each canonical identity file that exists in the source and
+#     is absent (or stale) in the target. Pre-existing target files are
+#     overwritten so a re-onboarding loop (#1046/#1060) cannot resurface
+#     from a stale workdir copy.
+#
+# Identity fileset: the canonical per-agent files, the engine
+# instruction entrypoint, and the per-user partition tree `users/`
+# (per-agent `USER.md` identity). `memory/` and `.claude/` are NOT
+# bulk-copied here — `.claude/` is workspace-scoped engine/hook state
+# wired directly into the target by the create flow, and `memory/` is
+# resolver-rooted at the identity source (`bridge_layout_memory_dir`),
+# never the workspace.
+bridge_layout_materialize_identity() {
+  local agent="$1"
+  local engine="$2"
+  local explicit_target="${3:-}"
+  [[ -n "$agent" && -n "$engine" ]] || return 1
+
+  local source_dir target_dir
+  source_dir="$(bridge_layout_agent_home "$agent")"
+  if [[ -n "$explicit_target" ]]; then
+    target_dir="$explicit_target"
+  elif declare -F bridge_engine_materialization_target >/dev/null 2>&1; then
+    target_dir="$(bridge_engine_materialization_target "$agent" "$engine")"
+  else
+    # Descriptor module not loaded and no explicit target — cannot
+    # resolve the per-engine target. Treat as no-op rather than guessing.
+    return 0
+  fi
+
+  [[ -n "$source_dir" && -n "$target_dir" ]] || return 0
+  if [[ "$source_dir" == "$target_dir" ]]; then
+    # Legacy / identity-source-is-target engine: nothing to deliver.
+    return 0
+  fi
+  [[ -d "$source_dir" ]] || return 0
+
+  # Shared-workspace guard. If the target already holds a CLAUDE.md or
+  # AGENTS.md whose first heading does not name this agent, the workspace
+  # is a shared project tree — do not stamp per-agent identity into it.
+  local entry
+  for entry in "$target_dir/CLAUDE.md" "$target_dir/AGENTS.md"; do
+    [[ -f "$entry" ]] || continue
+    if grep -qiE "shared[- ]workdir|shared project" "$entry" 2>/dev/null; then
+      bridge_layout_log_note "materialize: $agent — shared workspace detected ($entry); per-agent identity kept in agent_home"
+      return 0
+    fi
+  done
+  if [[ -n "${BRIDGE_LAYOUT_WORKSPACE_SHARED:-}" ]]; then
+    bridge_layout_log_note "materialize: $agent — workspace flagged shared; per-agent identity kept in agent_home"
+    return 0
+  fi
+
+  mkdir -p "$target_dir" 2>/dev/null || return 0
+
+  local engine_entry=""
+  if declare -F bridge_engine_entrypoint_filename >/dev/null 2>&1; then
+    engine_entry="$(bridge_engine_entrypoint_filename "$engine" 2>/dev/null || printf '')"
+  fi
+
+  local name
+  for name in \
+    SOUL.md \
+    SESSION-TYPE.md \
+    MEMORY.md \
+    MEMORY-SCHEMA.md \
+    HEARTBEAT.md \
+    CHANGE-POLICY.md \
+    TOOLS.md \
+    "$engine_entry"; do
+    [[ -n "$name" ]] || continue
+    [[ -f "$source_dir/$name" ]] || continue
+    mkdir -p "$(dirname "$target_dir/$name")" 2>/dev/null || continue
+    cp -f "$source_dir/$name" "$target_dir/$name" 2>/dev/null || true
+  done
+
+  # Per-user partition tree — `users/<id>/USER.md` etc. Delivered as a
+  # whole subtree so the workspace read target carries the same per-user
+  # identity the create flow scaffolded into the identity source.
+  if [[ -d "$source_dir/users" ]]; then
+    mkdir -p "$target_dir/users" 2>/dev/null || true
+    cp -Rf "$source_dir/users/." "$target_dir/users/" 2>/dev/null || true
+  fi
+
+  return 0
+}
+
+# bridge_layout_log_note <message>
+#
+# One-line, non-fatal note. Uses bridge_warn when available (matches the
+# rest of lib/), otherwise stderr. Kept tiny so the resolver has no hard
+# dependency on bridge-core.sh load order.
+bridge_layout_log_note() {
+  if declare -F bridge_warn >/dev/null 2>&1; then
+    bridge_warn "$*"
+    return 0
+  fi
+  printf '%s\n' "$*" >&2
+}

--- a/lib/bridge-agent-layout.sh
+++ b/lib/bridge-agent-layout.sh
@@ -205,8 +205,18 @@ bridge_layout_materialize_identity() {
   mkdir -p "$target_dir" 2>/dev/null || return 0
 
   local engine_entry=""
+  local wants_claude_compat=0
   if declare -F bridge_engine_entrypoint_filename >/dev/null 2>&1; then
     engine_entry="$(bridge_engine_entrypoint_filename "$engine" 2>/dev/null || printf '')"
+  fi
+  if declare -F bridge_engine_wants_claude_compat_copy >/dev/null 2>&1; then
+    # Codex r1 BLOCKING 2: honor the descriptor's claude-compat declaration.
+    # Codex's native entrypoint is AGENTS.md, but Claude-shaped readers
+    # (hooks, current runtime) still look for CLAUDE.md — so when the
+    # descriptor says the engine wants a CLAUDE.md compat copy, materialize
+    # BOTH AGENTS.md and CLAUDE.md into the workspace read target.
+    bridge_engine_wants_claude_compat_copy "$engine" 2>/dev/null \
+      && wants_claude_compat=1
   fi
 
   local name
@@ -224,6 +234,13 @@ bridge_layout_materialize_identity() {
     mkdir -p "$(dirname "$target_dir/$name")" 2>/dev/null || continue
     cp -f "$source_dir/$name" "$target_dir/$name" 2>/dev/null || true
   done
+  if [[ "$wants_claude_compat" == "1" && "$engine_entry" != "CLAUDE.md" ]]; then
+    # Engine wants the CLAUDE.md compat copy alongside its native entrypoint
+    # (e.g. Codex with AGENTS.md as native + CLAUDE.md as compat).
+    if [[ -f "$source_dir/CLAUDE.md" ]]; then
+      cp -f "$source_dir/CLAUDE.md" "$target_dir/CLAUDE.md" 2>/dev/null || true
+    fi
+  fi
 
   # Per-user partition tree — `users/<id>/USER.md` etc. Delivered as a
   # whole subtree so the workspace read target carries the same per-user

--- a/lib/bridge-engine-descriptor.sh
+++ b/lib/bridge-engine-descriptor.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bridge-engine-descriptor.sh — minimal declarative per-engine descriptor
+# (issue #1060; consumed later by #1067 CODEX-PROV and #1068 HOOKS-SSOT).
+#
+# This is the SOLE source for per-engine branching of the small set of
+# layout / hook / materialization facts the beta6 tracks need. It is NOT
+# the full #1013 engine capability-table refactor — it is intentionally
+# minimal: only the fields #1060 / #1067 / #1068 consume, exposed as
+# plain accessor functions so a later wave can extend it without a
+# rewrite.
+#
+# Supported engines: `claude`, `codex`, `antigravity`.
+#
+# Descriptor fields (one accessor each):
+#   * instruction entrypoint filename — the engine's primary instruction
+#     file. claude → CLAUDE.md; codex → AGENTS.md; antigravity → CLAUDE.md
+#     (current behavior preserved).
+#   * claude-compat copy — whether the engine also wants a CLAUDE.md copy
+#     for a reader that still expects it. codex → yes (some bridge
+#     readers still look for CLAUDE.md); others → no.
+#   * hook config path — per-agent location of the engine's hook config.
+#     claude → per-agent `.claude/settings.json` under the workspace;
+#     codex → per-agent `.codex/hooks.json` under the agent home.
+#   * hook renderer profile — which renderer profile applies (claude /
+#     codex / none).
+#   * render-and-verify-on-create — whether `agent create` / upgrade
+#     must render + verify the engine's hooks.
+#   * identity materialization target — where the engine runtime reads
+#     identity from; the destination of bridge_layout_materialize_identity.
+
+# bridge_engine_is_supported <engine>
+bridge_engine_is_supported() {
+  case "${1:-}" in
+    claude|codex|antigravity) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# bridge_engine_entrypoint_filename <engine>
+#
+# The engine's primary instruction-file name.
+bridge_engine_entrypoint_filename() {
+  case "${1:-}" in
+    codex) printf 'AGENTS.md' ;;
+    claude|antigravity) printf 'CLAUDE.md' ;;
+    *) return 1 ;;
+  esac
+}
+
+# bridge_engine_wants_claude_compat_copy <engine>
+#
+# True when the engine's materialization should also drop a CLAUDE.md
+# claude-compat copy alongside its native entrypoint, because a bridge
+# reader still expects CLAUDE.md. Codex is the case: its native
+# entrypoint is AGENTS.md, but several bridge readers (setup / skills /
+# doctor) still probe CLAUDE.md.
+bridge_engine_wants_claude_compat_copy() {
+  case "${1:-}" in
+    codex) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# bridge_engine_hook_config_path <agent> <engine>
+#
+# The per-agent location of the engine's hook config.
+#   claude → `<workspace>/.claude/settings.json`
+#   codex  → `<agent_home>/.codex/hooks.json` (per-agent target; the
+#            legacy `$HOME/.codex/hooks.json` install-wide path in
+#            bridge-hooks.sh is what HOOKS-SSOT #1068 migrates away from
+#            — the descriptor names the per-agent destination now so
+#            #1068 has a single source to consume).
+bridge_engine_hook_config_path() {
+  local agent="$1"
+  local engine="$2"
+  [[ -n "$agent" && -n "$engine" ]] || return 1
+  case "$engine" in
+    claude|antigravity)
+      if declare -F bridge_layout_workspace_dir >/dev/null 2>&1; then
+        printf '%s/.claude/settings.json' "$(bridge_layout_workspace_dir "$agent")"
+        return 0
+      fi
+      return 1
+      ;;
+    codex)
+      if declare -F bridge_layout_agent_home >/dev/null 2>&1; then
+        printf '%s/.codex/hooks.json' "$(bridge_layout_agent_home "$agent")"
+        return 0
+      fi
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# bridge_engine_hook_renderer_profile <engine>
+#
+# Which hook renderer profile applies. HOOKS-SSOT (#1068) consumes this
+# to drive a single render dispatch instead of per-engine if-branches.
+bridge_engine_hook_renderer_profile() {
+  case "${1:-}" in
+    claude|antigravity) printf 'claude' ;;
+    codex) printf 'codex' ;;
+    *) return 1 ;;
+  esac
+}
+
+# bridge_engine_render_hooks_on_create <engine>
+#
+# True when `agent create` / upgrade must render + verify the engine's
+# hooks as part of provisioning.
+bridge_engine_render_hooks_on_create() {
+  case "${1:-}" in
+    claude|codex|antigravity) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# bridge_engine_materialization_target <agent> <engine>
+#
+# Where the engine runtime reads identity from — the destination of
+# `bridge_layout_materialize_identity`.
+#
+# For every currently-supported engine the runtime cwd / read target is
+# the workspace dir (the runtime keeps reading where it reads today —
+# see lib/bridge-agent-layout.sh "no reader flip"). The descriptor still
+# owns the decision so #1067 / #1068 can specialize a per-engine target
+# (e.g. a descriptor-owned Codex SessionStart surface) without touching
+# the layout resolver.
+bridge_engine_materialization_target() {
+  local agent="$1"
+  local engine="$2"
+  [[ -n "$agent" && -n "$engine" ]] || return 1
+  bridge_engine_is_supported "$engine" || return 1
+  if declare -F bridge_layout_workspace_dir >/dev/null 2>&1; then
+    bridge_layout_workspace_dir "$agent"
+    return 0
+  fi
+  return 1
+}

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux
 }
 
 add_all_integration() {
@@ -175,6 +175,15 @@ select_for_path() {
   case "$path" in
     docs/agent-runtime/admin-protocol.md)
       add_required admin-protocol-shared-link
+      ;;
+    agents/_template/CLAUDE.md|agents/_template/.claude/commands/wrap-up.md)
+      # Issue #1060 D3/D4: these tracked templates carry the
+      # resolver-derived layout wording (CLAUDE.md) and the per-agent
+      # memory-dir resolution (wrap-up.md). They are .md files, so the
+      # is_docs_only_path early-return below would otherwise select only
+      # the global required smokes. This case precedes that return so a
+      # template-text drift still pulls the #1060 layout smokes.
+      add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair
       ;;
   esac
 
@@ -300,7 +309,14 @@ select_for_path() {
       # its gate smoke whenever bridge-agent.sh or lib/bridge-agent-update.sh
       # moves so a future PR cannot regress the create/update/delete trust
       # symmetry back to an ungated create.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1028-isolated-workdir-check
+      # Issue #1060: bridge-agent.sh::run_create scaffolds the authored
+      # identity into the identity source (layer 2) and runs a
+      # materialization step into the engine read target; bridge-start.sh's
+      # dry-run now surfaces `agent_home` alongside `workdir`. Pull the
+      # three-layer agent-layout smokes whenever bridge-agent.sh or
+      # bridge-start.sh moves so a future PR cannot regress the D1
+      # scaffold-then-materialize inversion back to the empty-sibling bug.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1028-isolated-workdir-check v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -597,6 +613,27 @@ select_for_path() {
       # values through the shared launch-cmd-redact module. Pull the
       # redaction regression smoke whenever either renderer moves.
       add_required agent-update agent-update-launch-cmd-redaction
+      add_integration integration-minimal
+      ;;
+
+    lib/bridge-agent-layout.sh|lib/bridge-engine-descriptor.sh|scripts/daily-note-reconcile.py)
+      # Issue #1060: the typed agent-layout resolver + minimal engine
+      # descriptor + the D4 memory-tooling default. All three feed the
+      # three-layer agent-layout model the #1060 D5 smokes pin — run them
+      # whenever any of these move so a future PR cannot drift the
+      # resolver / descriptor / memory-default out of agreement. (The D3
+      # template .md files are dispatched in the pre-docs-return case
+      # above.)
+      add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair v2-scaffold-home-and-workdir agent-doctor
+      add_integration integration-minimal
+      ;;
+
+    bridge-channels.py|bridge-channels.sh)
+      # Issue #1060 (beta5 QA finding #1): bridge-channels.py's
+      # remove-webhook-server now catches PermissionError/OSError quietly
+      # so `agent create --isolate` no longer dumps a traceback. Cover the
+      # channel-plugins regression smoke whenever the channel modules move.
+      add_required channel-plugins channel-env-readiness
       add_integration integration-minimal
       ;;
 

--- a/scripts/daily-note-reconcile.py
+++ b/scripts/daily-note-reconcile.py
@@ -1019,17 +1019,40 @@ def _bridge_home(args: argparse.Namespace) -> Path:
     return (Path.home() / ".agent-bridge").resolve()
 
 
+def _agent_memory_dir_default(bridge_root: Path, agent: str) -> Path:
+    """Per-agent memory dir default — the identity source's ``memory/``.
+
+    Issue #1060 D4: this MUST match the shell layout resolver
+    (``bridge_layout_memory_dir`` = ``agent_home/memory``). On a v2-
+    isolation install the identity source is
+    ``$BRIDGE_AGENT_ROOT_V2/<agent>/home`` — NOT
+    ``$BRIDGE_HOME/agents/<agent>`` (that path is the tracked profile
+    source on v2). The legacy ``<BRIDGE_HOME>/agents/<agent>/memory``
+    default sent the daily note into the wrong tree, the exact #1060
+    model-drift bug for memory tooling.
+
+    Resolution order mirrors the shell side:
+      * ``BRIDGE_AGENT_ROOT_V2`` set  → ``<root>/<agent>/home/memory``
+      * otherwise (legacy install)    → ``<BRIDGE_HOME>/agents/<agent>/memory``
+    """
+    v2_root = os.environ.get("BRIDGE_AGENT_ROOT_V2")
+    if v2_root:
+        return Path(v2_root).expanduser().resolve() / agent / "home" / "memory"
+    return bridge_root / "agents" / agent / "memory"
+
+
 def _resolve_memory_dir(args: argparse.Namespace, agent: str) -> Path:
     """Resolve the daily-note directory.
 
-    Default: ``<BRIDGE_HOME>/agents/<agent>/memory``. If ``--memory-dir``
+    Default: the identity source's ``memory/`` — see
+    ``_agent_memory_dir_default`` (issue #1060 D4). If ``--memory-dir``
     is provided, the resolved path MUST live inside the resolved bridge
     home (Item 6 — closes ``--memory-dir /etc/passwd``-style escapes).
     Raises ``ValueError`` on a containment violation.
     """
     bridge_root = _bridge_home(args)
     if not args.memory_dir:
-        return bridge_root / "agents" / agent / "memory"
+        return _agent_memory_dir_default(bridge_root, agent)
     candidate = Path(args.memory_dir).expanduser().resolve()
     try:
         candidate.relative_to(bridge_root)

--- a/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
+++ b/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1060-layout-fresh-v2-static-claude.sh — Issue #1060 D5 smoke 1.
+#
+# Pins the #1060 three-layer agent-layout contract for a fresh v2 static
+# Claude agent: after the scaffold + materialization step,
+#
+#   * `bridge_layout_agent_home` (identity source, layer 2) holds the
+#     authored canonical identity (CLAUDE.md + SOUL/MEMORY/SESSION-TYPE),
+#   * the engine materialization target (the workspace `workdir/`, layer
+#     3, which the runtime reads + launches in — `bridge_agent_workdir`)
+#     is POPULATED with the same current identity (not the empty/stale
+#     sibling that caused the #1046/#1060 re-onboarding loop),
+#   * the onboarding-state file (`SESSION-TYPE.md`) agrees between the
+#     two trees — both say `complete` for a static-claude create,
+#   * `agent_home` and `workdir` are distinct paths on a v2 install.
+#
+# The smoke drives `bridge_scaffold_agent_home` (into the identity
+# source) + `bridge_layout_materialize_identity` directly rather than the
+# full `bridge-agent.sh create` wrapper: that wrapper exercises channel
+# setup / hooks / bridge-start dry-run, which have platform-dependent
+# hangs / sudo prompts on a fresh BRIDGE_HOME and would mask the specific
+# layer contract this smoke pins (same rationale as
+# v2-scaffold-home-and-workdir.sh). `bridge_render_template_string` is
+# kept REAL here (unlike #686's smoke) — smoke 1 must verify the
+# materialized files have real identity content, so the template loop
+# runs and emits CLAUDE.md / SESSION-TYPE.md with the onboarding state.
+#
+# Footgun #11: the driver is emitted via printf-to-file (no heredoc-stdin
+# into a subprocess, no `<<<`, no `< <(...)`).
+#
+# Regression bite: FAILS if a future change reverts the D1 inversion so
+# `agent create` scaffolds straight into `workdir/` without authoring the
+# identity source, or drops the materialization step so the workspace
+# read target comes up empty.
+
+set -uo pipefail
+
+SMOKE_NAME="1060-layout-fresh-v2-static-claude"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# Emit a driver that sources the full bridge-lib.sh (so the layout
+# resolver + engine descriptor + scaffold are all wired the same way the
+# live runtime wires them), scaffolds into the identity source, runs the
+# materialization step, then prints the resulting layer paths + key file
+# states for the assertions below.
+DRIVER_DIR="$SMOKE_TMP_ROOT/driver"
+mkdir -p "$DRIVER_DIR"
+DRIVER="$DRIVER_DIR/driver.sh"
+
+write_driver() {
+  local out="$1"
+  : >"$out"
+  local line
+  for line in \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'SCRIPT_DIR="$REPO_ROOT"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'FUNC_TMP="$DRIVER_TMP_DIR/scaffold-funcs.sh"' \
+    '{' \
+    '  sed -n "128,139p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "188,257p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "385,640p" "$REPO_ROOT/bridge-agent.sh"' \
+    '} > "$FUNC_TMP"' \
+    'source "$FUNC_TMP"' \
+    'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: scaffold not loaded"; exit 91; }' \
+    'declare -F bridge_layout_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: layout resolver not loaded"; exit 92; }' \
+    'declare -F bridge_layout_materialize_identity >/dev/null 2>&1 || { echo "DRIVER_FAIL: materialize not loaded"; exit 93; }' \
+    'declare -F bridge_engine_materialization_target >/dev/null 2>&1 || { echo "DRIVER_FAIL: engine descriptor not loaded"; exit 94; }' \
+    'declare -A BRIDGE_AGENT_WORKDIR 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_ISOLATION_MODE 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_OS_USER 2>/dev/null || true' \
+    'IDENTITY_HOME="$(bridge_layout_agent_home "$AGENT_ID")"' \
+    'WORKSPACE_DIR="$BRIDGE_AGENT_ROOT_V2/$AGENT_ID/workdir"' \
+    'echo "IDENTITY_HOME: $IDENTITY_HOME"' \
+    'echo "WORKSPACE_DIR: $WORKSPACE_DIR"' \
+    'echo "=== scaffold (into identity source) ==="' \
+    'bridge_scaffold_agent_home "$AGENT_ID" "$IDENTITY_HOME" "Probe Agent" "probe role" claude static-claude "" ""' \
+    'echo "=== materialize (identity -> workspace) ==="' \
+    'bridge_layout_materialize_identity "$AGENT_ID" claude "$WORKSPACE_DIR"' \
+    'echo "=== done ==="' \
+    'if [[ -f "$IDENTITY_HOME/CLAUDE.md" ]]; then echo "IDENTITY_CLAUDE_MD: present"; else echo "IDENTITY_CLAUDE_MD: missing"; fi' \
+    'if [[ -f "$IDENTITY_HOME/SOUL.md" ]]; then echo "IDENTITY_SOUL_MD: present"; else echo "IDENTITY_SOUL_MD: missing"; fi' \
+    'if [[ -f "$WORKSPACE_DIR/CLAUDE.md" ]]; then echo "WORKSPACE_CLAUDE_MD: present"; else echo "WORKSPACE_CLAUDE_MD: missing"; fi' \
+    'if [[ -f "$WORKSPACE_DIR/SOUL.md" ]]; then echo "WORKSPACE_SOUL_MD: present"; else echo "WORKSPACE_SOUL_MD: missing"; fi' \
+    'if [[ -f "$WORKSPACE_DIR/SESSION-TYPE.md" ]]; then echo "WORKSPACE_SESSION_TYPE: present"; else echo "WORKSPACE_SESSION_TYPE: missing"; fi' \
+    'id_state="$(grep -E "Onboarding State:" "$IDENTITY_HOME/SESSION-TYPE.md" 2>/dev/null | head -n1 | sed -E "s/.*Onboarding State:[[:space:]]*//")"' \
+    'ws_state="$(grep -E "Onboarding State:" "$WORKSPACE_DIR/SESSION-TYPE.md" 2>/dev/null | head -n1 | sed -E "s/.*Onboarding State:[[:space:]]*//")"' \
+    'echo "IDENTITY_ONBOARDING_STATE: $id_state"' \
+    'echo "WORKSPACE_ONBOARDING_STATE: $ws_state"' \
+    'mt="$(bridge_engine_materialization_target "$AGENT_ID" claude 2>/dev/null || true)"' \
+    'echo "DESCRIPTOR_ENTRYPOINT: $(bridge_engine_entrypoint_filename claude)"' \
+    'rm -f "$FUNC_TMP" >/dev/null 2>&1 || true'
+  do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+extract_line() {
+  local out="$1"
+  local key="$2"
+  printf '%s\n' "$out" | sed -n "s/^$key: //p" | head -n 1
+}
+
+write_driver "$DRIVER"
+
+AGENT_ID="probe-claude"
+
+smoke_log "T1: fresh v2 static Claude — scaffold authors identity source, materialization populates workspace"
+
+OUT="$(
+  REPO_ROOT="$REPO_ROOT" \
+  DRIVER_TMP_DIR="$DRIVER_DIR" \
+  AGENT_ID="$AGENT_ID" \
+  BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+  BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+  BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
+  BRIDGE_ROSTER_FILE="$BRIDGE_ROSTER_FILE" \
+  BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" \
+  BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+  BRIDGE_AGENT_HOME_ROOT="$BRIDGE_AGENT_HOME_ROOT" \
+  BRIDGE_LAYOUT="v2" \
+  BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+  BRIDGE_SHARED_ROOT="$BRIDGE_SHARED_ROOT" \
+  BRIDGE_AGENT_ROOT_V2="$BRIDGE_AGENT_ROOT_V2" \
+  BRIDGE_CONTROLLER_STATE_ROOT="$BRIDGE_CONTROLLER_STATE_ROOT" \
+  BRIDGE_RUNTIME_ROOT="$BRIDGE_RUNTIME_ROOT" \
+  BRIDGE_HOOKS_DIR="$BRIDGE_HOOKS_DIR" \
+  BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+  "$BRIDGE_BASH" "$DRIVER" 2>&1
+)"
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  smoke_fail "driver exited rc=$RC. output:
+$OUT"
+fi
+
+IDENTITY_HOME="$(extract_line "$OUT" "IDENTITY_HOME")"
+WORKSPACE_DIR="$(extract_line "$OUT" "WORKSPACE_DIR")"
+
+# Three-layer model: identity source and workspace must be distinct paths.
+if [[ "$IDENTITY_HOME" == "$WORKSPACE_DIR" ]]; then
+  smoke_fail "T1: identity source and workspace must be distinct on a v2 install; both resolved to '$IDENTITY_HOME'"
+fi
+smoke_assert_match "$IDENTITY_HOME" '/home$' "T1: identity source resolves to <agent-root>/home"
+smoke_assert_match "$WORKSPACE_DIR" '/workdir$' "T1: workspace resolves to <agent-root>/workdir"
+
+# The identity source holds the authored identity.
+smoke_assert_eq "present" "$(extract_line "$OUT" "IDENTITY_CLAUDE_MD")" \
+  "T1: identity source holds the authored CLAUDE.md"
+smoke_assert_eq "present" "$(extract_line "$OUT" "IDENTITY_SOUL_MD")" \
+  "T1: identity source holds the authored SOUL.md"
+
+# The materialization target (workspace) is POPULATED — the #1046/#1060
+# bug was an empty/stale workspace sibling.
+smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_CLAUDE_MD")" \
+  "T1: workspace read target is populated with CLAUDE.md (no empty-sibling re-onboarding loop)"
+smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_SOUL_MD")" \
+  "T1: workspace read target is populated with SOUL.md"
+smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_SESSION_TYPE")" \
+  "T1: workspace read target is populated with SESSION-TYPE.md"
+
+# Onboarding state agrees between identity source and workspace — the
+# divergence was the literal #1060 re-onboarding-loop root cause.
+ID_STATE="$(extract_line "$OUT" "IDENTITY_ONBOARDING_STATE")"
+WS_STATE="$(extract_line "$OUT" "WORKSPACE_ONBOARDING_STATE")"
+smoke_assert_eq "complete" "$ID_STATE" \
+  "T1: identity source SESSION-TYPE.md onboarding state is complete (static-claude)"
+smoke_assert_eq "complete" "$WS_STATE" \
+  "T1: workspace SESSION-TYPE.md onboarding state agrees (complete) — no re-onboarding loop"
+
+# The engine descriptor names CLAUDE.md as the Claude entrypoint.
+smoke_assert_eq "CLAUDE.md" "$(extract_line "$OUT" "DESCRIPTOR_ENTRYPOINT")" \
+  "T1: engine descriptor resolves CLAUDE.md as the Claude instruction entrypoint"
+
+smoke_log "all tests PASS — issue #1060 D5 smoke 1: fresh v2 static Claude three-layer agreement verified"

--- a/scripts/smoke/1060-layout-fresh-v2-static-codex.sh
+++ b/scripts/smoke/1060-layout-fresh-v2-static-codex.sh
@@ -92,17 +92,19 @@ write_driver() {
     'if bridge_engine_wants_claude_compat_copy claude; then echo "CLAUDE_COMPAT_COPY: yes"; else echo "CLAUDE_COMPAT_COPY: no"; fi' \
     'echo "CODEX_HOOK_CONFIG: $(bridge_engine_hook_config_path "$AGENT_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
     'echo "CODEX_HOOK_RENDERER: $(bridge_engine_hook_renderer_profile codex)"' \
-    '# Author a minimal identity source by hand (CODEX-PROV owns the' \
-    '# real Codex template render). The LAYOUT contract under test is' \
-    '# that materialization delivers whatever the identity source holds' \
-    '# into the descriptor-resolved target — not a shared project file.' \
+    '# Author a template-shaped identity source (template has CLAUDE.md +' \
+    '# common identity files; AGENTS.md is rendered by CODEX-PROV in a' \
+    '# follow-up batch, not by LAYOUT). The LAYOUT contract under test:' \
+    '# materialization delivers the common identity AND the CLAUDE.md' \
+    '# compat copy (per the descriptor) into the Codex workspace.' \
     'mkdir -p "$IDENTITY_HOME"' \
-    'printf "%s\n" "# probe-codex agent" > "$IDENTITY_HOME/AGENTS.md"' \
+    'printf "%s\n" "# probe-codex agent (claude-compat copy)" > "$IDENTITY_HOME/CLAUDE.md"' \
     'printf "%s\n" "# soul" > "$IDENTITY_HOME/SOUL.md"' \
     'MAT_TARGET="$(bridge_engine_materialization_target "$AGENT_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
     'echo "CODEX_MATERIALIZATION_TARGET: $MAT_TARGET"' \
     'bridge_layout_materialize_identity "$AGENT_ID" codex "$WORKSPACE_DIR"' \
     'if [[ -f "$WORKSPACE_DIR/AGENTS.md" ]]; then echo "WORKSPACE_AGENTS_MD: present"; else echo "WORKSPACE_AGENTS_MD: missing"; fi' \
+    'if [[ -f "$WORKSPACE_DIR/CLAUDE.md" ]]; then echo "WORKSPACE_CLAUDE_MD: present"; else echo "WORKSPACE_CLAUDE_MD: missing"; fi' \
     'if [[ -f "$WORKSPACE_DIR/SOUL.md" ]]; then echo "WORKSPACE_SOUL_MD: present"; else echo "WORKSPACE_SOUL_MD: missing"; fi'
   do
     printf '%s\n' "$line" >>"$out"
@@ -177,8 +179,18 @@ smoke_assert_eq "codex" "$(extract_line "$OUT" "CODEX_HOOK_RENDERER")" \
 # Materialization: target is the workspace, and the identity is delivered there.
 smoke_assert_eq "$WORKSPACE_DIR" "$(extract_line "$OUT" "CODEX_MATERIALIZATION_TARGET")" \
   "T1: descriptor resolves the Codex materialization target to the workspace dir"
-smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_AGENTS_MD")" \
-  "T1: materialization delivered the Codex AGENTS.md into the descriptor-resolved target"
+# AGENTS.md is CODEX-PROV's responsibility (Batch 2), not LAYOUT's. At this
+# beta6 Batch 1 point the template has no AGENTS.md → workspace AGENTS.md is
+# expected missing. The smoke captures the assertion for traceability; it
+# will flip to "present" once CODEX-PROV ships.
+smoke_assert_eq "missing" "$(extract_line "$OUT" "WORKSPACE_AGENTS_MD")" \
+  "T1: AGENTS.md not yet rendered at LAYOUT level — CODEX-PROV (Batch 2) owns native Codex entrypoint"
+# Codex r1 BLOCKING 2: descriptor flags Codex as wants_claude_compat_copy →
+# materialization must deliver CLAUDE.md to the workspace as a Claude-shaped
+# compat copy. This is what LAYOUT delivers today; CODEX-PROV stacks AGENTS.md
+# on top in Batch 2.
+smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_CLAUDE_MD")" \
+  "T1: materialization delivered the CLAUDE.md compat copy into the Codex workspace (descriptor wants_claude_compat_copy)"
 smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_SOUL_MD")" \
   "T1: materialization delivered the authored SOUL.md into the descriptor-resolved target"
 

--- a/scripts/smoke/1060-layout-fresh-v2-static-codex.sh
+++ b/scripts/smoke/1060-layout-fresh-v2-static-codex.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1060-layout-fresh-v2-static-codex.sh — Issue #1060 D5 smoke 2.
+#
+# Pins the #1060 three-layer agent-layout contract for a fresh v2 static
+# Codex agent. The Codex engine differs from Claude in its instruction
+# entrypoint and hook-config location, and the minimal engine descriptor
+# (lib/bridge-engine-descriptor.sh) is the SOLE owner of that branching.
+# This smoke asserts:
+#
+#   * the descriptor resolves `AGENTS.md` as the Codex instruction
+#     entrypoint (vs `CLAUDE.md` for Claude),
+#   * the descriptor flags a claude-compat copy for Codex (a CLAUDE.md
+#     copy alongside AGENTS.md, because some bridge readers still probe
+#     CLAUDE.md),
+#   * the descriptor's Codex hook-config path is the per-agent
+#     `.codex/hooks.json` under the IDENTITY SOURCE (agent_home) — NOT a
+#     shared install-wide `$HOME/.codex/hooks.json`,
+#   * the materialization step delivers the Codex agent's identity into
+#     the descriptor-resolved materialization target (the workspace),
+#     not into a shared project file.
+#
+# Full Codex *provisioning* (rendering AGENTS.md from a Codex template,
+# wiring the SessionStart surface) is CODEX-PROV's job (#1067). This
+# smoke's scope is the LAYOUT contract CODEX-PROV builds on: the
+# descriptor resolves the right per-engine targets, and the
+# materialization writes the authored identity there. CODEX-PROV extends
+# this smoke when it lands.
+#
+# Footgun #11: driver emitted via printf-to-file, no heredoc-stdin.
+
+set -uo pipefail
+
+SMOKE_NAME="1060-layout-fresh-v2-static-codex"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+DRIVER_DIR="$SMOKE_TMP_ROOT/driver"
+mkdir -p "$DRIVER_DIR"
+DRIVER="$DRIVER_DIR/driver.sh"
+
+write_driver() {
+  local out="$1"
+  : >"$out"
+  local line
+  for line in \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'SCRIPT_DIR="$REPO_ROOT"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'declare -F bridge_engine_entrypoint_filename >/dev/null 2>&1 || { echo "DRIVER_FAIL: engine descriptor not loaded"; exit 91; }' \
+    'declare -F bridge_layout_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: layout resolver not loaded"; exit 92; }' \
+    'declare -A BRIDGE_AGENT_WORKDIR 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_ISOLATION_MODE 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_OS_USER 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_SOURCE 2>/dev/null || true' \
+    'IDENTITY_HOME="$(bridge_layout_agent_home "$AGENT_ID")"' \
+    'WORKSPACE_DIR="$BRIDGE_AGENT_ROOT_V2/$AGENT_ID/workdir"' \
+    '# Mirror the roster state a registered v2 static agent has so' \
+    '# bridge_agent_workdir resolves the workspace `workdir/` anchor' \
+    '# (its static-shared branch needs source=static + the workdir dir' \
+    '# to exist + a default-home-shaped roster workdir — same setup the' \
+    '# #686 v2-scaffold smoke documents).' \
+    'mkdir -p "$WORKSPACE_DIR"' \
+    'BRIDGE_AGENT_SOURCE["$AGENT_ID"]="static"' \
+    'BRIDGE_AGENT_WORKDIR["$AGENT_ID"]="$IDENTITY_HOME"' \
+    'echo "IDENTITY_HOME: $IDENTITY_HOME"' \
+    'echo "WORKSPACE_DIR: $WORKSPACE_DIR"' \
+    'echo "CODEX_ENTRYPOINT: $(bridge_engine_entrypoint_filename codex)"' \
+    'echo "CLAUDE_ENTRYPOINT: $(bridge_engine_entrypoint_filename claude)"' \
+    'if bridge_engine_wants_claude_compat_copy codex; then echo "CODEX_COMPAT_COPY: yes"; else echo "CODEX_COMPAT_COPY: no"; fi' \
+    'if bridge_engine_wants_claude_compat_copy claude; then echo "CLAUDE_COMPAT_COPY: yes"; else echo "CLAUDE_COMPAT_COPY: no"; fi' \
+    'echo "CODEX_HOOK_CONFIG: $(bridge_engine_hook_config_path "$AGENT_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
+    'echo "CODEX_HOOK_RENDERER: $(bridge_engine_hook_renderer_profile codex)"' \
+    '# Author a minimal identity source by hand (CODEX-PROV owns the' \
+    '# real Codex template render). The LAYOUT contract under test is' \
+    '# that materialization delivers whatever the identity source holds' \
+    '# into the descriptor-resolved target — not a shared project file.' \
+    'mkdir -p "$IDENTITY_HOME"' \
+    'printf "%s\n" "# probe-codex agent" > "$IDENTITY_HOME/AGENTS.md"' \
+    'printf "%s\n" "# soul" > "$IDENTITY_HOME/SOUL.md"' \
+    'MAT_TARGET="$(bridge_engine_materialization_target "$AGENT_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
+    'echo "CODEX_MATERIALIZATION_TARGET: $MAT_TARGET"' \
+    'bridge_layout_materialize_identity "$AGENT_ID" codex "$WORKSPACE_DIR"' \
+    'if [[ -f "$WORKSPACE_DIR/AGENTS.md" ]]; then echo "WORKSPACE_AGENTS_MD: present"; else echo "WORKSPACE_AGENTS_MD: missing"; fi' \
+    'if [[ -f "$WORKSPACE_DIR/SOUL.md" ]]; then echo "WORKSPACE_SOUL_MD: present"; else echo "WORKSPACE_SOUL_MD: missing"; fi'
+  do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+extract_line() {
+  local out="$1"
+  local key="$2"
+  printf '%s\n' "$out" | sed -n "s/^$key: //p" | head -n 1
+}
+
+write_driver "$DRIVER"
+
+AGENT_ID="probe-codex"
+
+smoke_log "T1: fresh v2 static Codex — descriptor resolves Codex targets, materialization delivers identity"
+
+OUT="$(
+  REPO_ROOT="$REPO_ROOT" \
+  DRIVER_TMP_DIR="$DRIVER_DIR" \
+  AGENT_ID="$AGENT_ID" \
+  BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+  BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+  BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
+  BRIDGE_ROSTER_FILE="$BRIDGE_ROSTER_FILE" \
+  BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" \
+  BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+  BRIDGE_AGENT_HOME_ROOT="$BRIDGE_AGENT_HOME_ROOT" \
+  BRIDGE_LAYOUT="v2" \
+  BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+  BRIDGE_SHARED_ROOT="$BRIDGE_SHARED_ROOT" \
+  BRIDGE_AGENT_ROOT_V2="$BRIDGE_AGENT_ROOT_V2" \
+  BRIDGE_CONTROLLER_STATE_ROOT="$BRIDGE_CONTROLLER_STATE_ROOT" \
+  BRIDGE_RUNTIME_ROOT="$BRIDGE_RUNTIME_ROOT" \
+  BRIDGE_HOOKS_DIR="$BRIDGE_HOOKS_DIR" \
+  BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+  "$BRIDGE_BASH" "$DRIVER" 2>&1
+)"
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  smoke_fail "driver exited rc=$RC. output:
+$OUT"
+fi
+
+IDENTITY_HOME="$(extract_line "$OUT" "IDENTITY_HOME")"
+WORKSPACE_DIR="$(extract_line "$OUT" "WORKSPACE_DIR")"
+
+# Descriptor: per-engine entrypoint branching.
+smoke_assert_eq "AGENTS.md" "$(extract_line "$OUT" "CODEX_ENTRYPOINT")" \
+  "T1: descriptor resolves AGENTS.md as the Codex instruction entrypoint"
+smoke_assert_eq "CLAUDE.md" "$(extract_line "$OUT" "CLAUDE_ENTRYPOINT")" \
+  "T1: descriptor resolves CLAUDE.md as the Claude instruction entrypoint"
+
+# Descriptor: claude-compat copy is Codex-only.
+smoke_assert_eq "yes" "$(extract_line "$OUT" "CODEX_COMPAT_COPY")" \
+  "T1: descriptor flags a claude-compat CLAUDE.md copy for Codex"
+smoke_assert_eq "no" "$(extract_line "$OUT" "CLAUDE_COMPAT_COPY")" \
+  "T1: descriptor does not flag a compat copy for Claude (its entrypoint IS CLAUDE.md)"
+
+# Descriptor: Codex hook config is per-agent under the identity source.
+CODEX_HOOK="$(extract_line "$OUT" "CODEX_HOOK_CONFIG")"
+if [[ "$CODEX_HOOK" != "$IDENTITY_HOME/.codex/hooks.json" ]]; then
+  smoke_fail "T1: descriptor must resolve the Codex hook config to the per-agent identity source; expected '$IDENTITY_HOME/.codex/hooks.json', got '$CODEX_HOOK'"
+fi
+smoke_assert_eq "codex" "$(extract_line "$OUT" "CODEX_HOOK_RENDERER")" \
+  "T1: descriptor resolves the codex hook renderer profile for Codex"
+
+# Materialization: target is the workspace, and the identity is delivered there.
+smoke_assert_eq "$WORKSPACE_DIR" "$(extract_line "$OUT" "CODEX_MATERIALIZATION_TARGET")" \
+  "T1: descriptor resolves the Codex materialization target to the workspace dir"
+smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_AGENTS_MD")" \
+  "T1: materialization delivered the Codex AGENTS.md into the descriptor-resolved target"
+smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_SOUL_MD")" \
+  "T1: materialization delivered the authored SOUL.md into the descriptor-resolved target"
+
+smoke_log "all tests PASS — issue #1060 D5 smoke 2: fresh v2 static Codex descriptor + materialization verified"

--- a/scripts/smoke/1060-layout-shared-workdir-pair.sh
+++ b/scripts/smoke/1060-layout-shared-workdir-pair.sh
@@ -106,7 +106,22 @@ write_driver() {
     'bridge_layout_materialize_identity "$CODEX_ID" codex "$SHARED_WS"' \
     'WS_AFTER="$(cat "$SHARED_WS/CLAUDE.md")"' \
     'if [[ "$WS_BEFORE" == "$WS_AFTER" ]]; then echo "SHARED_WS_CLAUDE_UNTOUCHED: yes"; else echo "SHARED_WS_CLAUDE_UNTOUCHED: no"; fi' \
-    'if [[ -f "$SHARED_WS/SOUL.md" ]]; then echo "SHARED_WS_HAS_SOUL: yes"; else echo "SHARED_WS_HAS_SOUL: no"; fi'
+    'if [[ -f "$SHARED_WS/SOUL.md" ]]; then echo "SHARED_WS_HAS_SOUL: yes"; else echo "SHARED_WS_HAS_SOUL: no"; fi' \
+    '' \
+    '# T2 regression (codex r1 BLOCKING 1): markerless existing project file' \
+    '# MUST also be protected when the create flow propagates the shared' \
+    '# intent via BRIDGE_LAYOUT_WORKSPACE_SHARED=1 (the way bridge-agent.sh' \
+    '# does when --allow-shared-workdir is passed).' \
+    'MARKERLESS_WS="$BRIDGE_DATA_ROOT/markerless-project"' \
+    'mkdir -p "$MARKERLESS_WS"' \
+    '# A normal project CLAUDE.md — no shared-workdir marker text.' \
+    'printf "%s\n" "# normal project — does NOT name the agent" > "$MARKERLESS_WS/CLAUDE.md"' \
+    'BRIDGE_AGENT_WORKDIR["$ADMIN_ID"]="$MARKERLESS_WS"' \
+    'M_BEFORE="$(cat "$MARKERLESS_WS/CLAUDE.md")"' \
+    'BRIDGE_LAYOUT_WORKSPACE_SHARED=1 bridge_layout_materialize_identity "$ADMIN_ID" claude "$MARKERLESS_WS"' \
+    'M_AFTER="$(cat "$MARKERLESS_WS/CLAUDE.md")"' \
+    'if [[ "$M_BEFORE" == "$M_AFTER" ]]; then echo "MARKERLESS_WS_CLAUDE_UNTOUCHED: yes"; else echo "MARKERLESS_WS_CLAUDE_UNTOUCHED: no"; fi' \
+    'if [[ -f "$MARKERLESS_WS/SOUL.md" ]]; then echo "MARKERLESS_WS_HAS_SOUL: yes"; else echo "MARKERLESS_WS_HAS_SOUL: no"; fi'
   do
     printf '%s\n' "$line" >>"$out"
   done
@@ -192,6 +207,14 @@ fi
 smoke_assert_eq "yes" "$(extract_line "$OUT" "SHARED_WS_CLAUDE_UNTOUCHED")" \
   "T1: materialization left the shared workspace CLAUDE.md untouched (per-agent identity stays in agent_home)"
 smoke_assert_eq "no" "$(extract_line "$OUT" "SHARED_WS_HAS_SOUL")" \
+  "T1: shared workspace did NOT receive per-agent SOUL.md"
+# T2 regression — markerless shared project: bridge-agent.sh passes
+# BRIDGE_LAYOUT_WORKSPACE_SHARED=1 when --allow-shared-workdir is set, even
+# without marker text. The materializer must respect that and leave the
+# workspace untouched. Codex r1 BLOCKING 1.
+smoke_assert_eq "yes" "$(extract_line "$OUT" "MARKERLESS_WS_CLAUDE_UNTOUCHED")" \
+  "T2: markerless shared workspace + BRIDGE_LAYOUT_WORKSPACE_SHARED=1 — CLAUDE.md NOT overwritten"
+smoke_assert_eq "no" "$(extract_line "$OUT" "MARKERLESS_WS_HAS_SOUL")" \
   "T1: materialization did not write a per-agent SOUL.md into the shared workspace"
 
 smoke_log "all tests PASS — issue #1060 D5 smoke 3: shared-workdir pair isolation verified"

--- a/scripts/smoke/1060-layout-shared-workdir-pair.sh
+++ b/scripts/smoke/1060-layout-shared-workdir-pair.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1060-layout-shared-workdir-pair.sh — Issue #1060 D5 smoke 3.
+#
+# Pins the #1060 shared-workspace rule. Two agents (an admin Claude + its
+# Codex pair) share ONE workspace project tree (the `--allow-shared-workdir`
+# case), but each must keep a DISTINCT identity / memory / hook context.
+# This smoke asserts:
+#
+#   * the two agents resolve to the SAME workspace (layer 3) but DISTINCT
+#     identity sources (layer 2 — `agent_home`) and DISTINCT memory dirs
+#     (`bridge_layout_memory_dir` = `agent_home/memory`),
+#   * the two agents resolve DISTINCT engine hook-config paths,
+#   * `bridge_layout_materialize_identity` does NOT stamp per-agent
+#     identity into the shared workspace — when the workspace is shared
+#     (its CLAUDE.md/AGENTS.md flags it shared, or the
+#     BRIDGE_LAYOUT_WORKSPACE_SHARED guard is set), per-agent identity
+#     stays in `agent_home` and the shared project file is left
+#     untouched.
+#
+# This is the rule that keeps a shared-workdir pair from clobbering each
+# other's SOUL/SESSION-TYPE — the materialization step is workspace-aware,
+# not a blind copy.
+#
+# Footgun #11: driver emitted via printf-to-file, no heredoc-stdin.
+
+set -uo pipefail
+
+SMOKE_NAME="1060-layout-shared-workdir-pair"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+DRIVER_DIR="$SMOKE_TMP_ROOT/driver"
+mkdir -p "$DRIVER_DIR"
+DRIVER="$DRIVER_DIR/driver.sh"
+
+write_driver() {
+  local out="$1"
+  : >"$out"
+  local line
+  for line in \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'SCRIPT_DIR="$REPO_ROOT"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'declare -F bridge_layout_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: layout resolver not loaded"; exit 91; }' \
+    'declare -F bridge_layout_memory_dir >/dev/null 2>&1 || { echo "DRIVER_FAIL: memory resolver not loaded"; exit 92; }' \
+    'declare -A BRIDGE_AGENT_WORKDIR 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_ISOLATION_MODE 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_OS_USER 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_SOURCE 2>/dev/null || true' \
+    '# Two agents, one shared workspace project tree.' \
+    'SHARED_WS="$BRIDGE_DATA_ROOT/shared-project"' \
+    'mkdir -p "$SHARED_WS"' \
+    '# Mark the shared workspace as a shared project tree so the' \
+    '# materialization guard recognizes it.' \
+    'printf "%s\n" "# shared project — shared-workdir pair" > "$SHARED_WS/CLAUDE.md"' \
+    'BRIDGE_AGENT_SOURCE["$ADMIN_ID"]="static"' \
+    'BRIDGE_AGENT_SOURCE["$CODEX_ID"]="static"' \
+    'BRIDGE_AGENT_WORKDIR["$ADMIN_ID"]="$SHARED_WS"' \
+    'BRIDGE_AGENT_WORKDIR["$CODEX_ID"]="$SHARED_WS"' \
+    'ADMIN_HOME="$(bridge_layout_agent_home "$ADMIN_ID")"' \
+    'CODEX_HOME="$(bridge_layout_agent_home "$CODEX_ID")"' \
+    'ADMIN_WS="$(bridge_layout_workspace_dir "$ADMIN_ID")"' \
+    'CODEX_WS="$(bridge_layout_workspace_dir "$CODEX_ID")"' \
+    'ADMIN_MEM="$(bridge_layout_memory_dir "$ADMIN_ID")"' \
+    'CODEX_MEM="$(bridge_layout_memory_dir "$CODEX_ID")"' \
+    'ADMIN_HOOK="$(bridge_engine_hook_config_path "$ADMIN_ID" claude 2>/dev/null || echo UNRESOLVED)"' \
+    'CODEX_HOOK="$(bridge_engine_hook_config_path "$CODEX_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
+    'echo "ADMIN_HOME: $ADMIN_HOME"' \
+    'echo "CODEX_HOME: $CODEX_HOME"' \
+    'echo "ADMIN_WS: $ADMIN_WS"' \
+    'echo "CODEX_WS: $CODEX_WS"' \
+    'echo "ADMIN_MEM: $ADMIN_MEM"' \
+    'echo "CODEX_MEM: $CODEX_MEM"' \
+    'echo "ADMIN_HOOK: $ADMIN_HOOK"' \
+    'echo "CODEX_HOOK: $CODEX_HOOK"' \
+    '# Author distinct identity sources for the pair.' \
+    'mkdir -p "$ADMIN_HOME" "$CODEX_HOME"' \
+    'printf "%s\n" "# admin soul" > "$ADMIN_HOME/SOUL.md"' \
+    'printf "%s\n" "# codex soul" > "$CODEX_HOME/SOUL.md"' \
+    'printf "%s\n" "# admin claude" > "$ADMIN_HOME/CLAUDE.md"' \
+    '# Snapshot the shared workspace CLAUDE.md before materialization.' \
+    'WS_BEFORE="$(cat "$SHARED_WS/CLAUDE.md")"' \
+    'bridge_layout_materialize_identity "$ADMIN_ID" claude "$SHARED_WS"' \
+    'bridge_layout_materialize_identity "$CODEX_ID" codex "$SHARED_WS"' \
+    'WS_AFTER="$(cat "$SHARED_WS/CLAUDE.md")"' \
+    'if [[ "$WS_BEFORE" == "$WS_AFTER" ]]; then echo "SHARED_WS_CLAUDE_UNTOUCHED: yes"; else echo "SHARED_WS_CLAUDE_UNTOUCHED: no"; fi' \
+    'if [[ -f "$SHARED_WS/SOUL.md" ]]; then echo "SHARED_WS_HAS_SOUL: yes"; else echo "SHARED_WS_HAS_SOUL: no"; fi'
+  do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+extract_line() {
+  local out="$1"
+  local key="$2"
+  printf '%s\n' "$out" | sed -n "s/^$key: //p" | head -n 1
+}
+
+write_driver "$DRIVER"
+
+ADMIN_ID="probe_admin"
+CODEX_ID="probe_admin_dev"
+
+smoke_log "T1: shared-workdir admin+codex pair — distinct identity/memory/hooks, shared workspace untouched"
+
+OUT="$(
+  REPO_ROOT="$REPO_ROOT" \
+  DRIVER_TMP_DIR="$DRIVER_DIR" \
+  ADMIN_ID="$ADMIN_ID" \
+  CODEX_ID="$CODEX_ID" \
+  BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+  BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+  BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
+  BRIDGE_ROSTER_FILE="$BRIDGE_ROSTER_FILE" \
+  BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" \
+  BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+  BRIDGE_AGENT_HOME_ROOT="$BRIDGE_AGENT_HOME_ROOT" \
+  BRIDGE_LAYOUT="v2" \
+  BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+  BRIDGE_SHARED_ROOT="$BRIDGE_SHARED_ROOT" \
+  BRIDGE_AGENT_ROOT_V2="$BRIDGE_AGENT_ROOT_V2" \
+  BRIDGE_CONTROLLER_STATE_ROOT="$BRIDGE_CONTROLLER_STATE_ROOT" \
+  BRIDGE_RUNTIME_ROOT="$BRIDGE_RUNTIME_ROOT" \
+  BRIDGE_HOOKS_DIR="$BRIDGE_HOOKS_DIR" \
+  BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+  "$BRIDGE_BASH" "$DRIVER" 2>&1
+)"
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  smoke_fail "driver exited rc=$RC. output:
+$OUT"
+fi
+
+ADMIN_HOME="$(extract_line "$OUT" "ADMIN_HOME")"
+CODEX_HOME="$(extract_line "$OUT" "CODEX_HOME")"
+ADMIN_WS="$(extract_line "$OUT" "ADMIN_WS")"
+CODEX_WS="$(extract_line "$OUT" "CODEX_WS")"
+ADMIN_MEM="$(extract_line "$OUT" "ADMIN_MEM")"
+CODEX_MEM="$(extract_line "$OUT" "CODEX_MEM")"
+ADMIN_HOOK="$(extract_line "$OUT" "ADMIN_HOOK")"
+CODEX_HOOK="$(extract_line "$OUT" "CODEX_HOOK")"
+
+# Same workspace.
+smoke_assert_eq "$ADMIN_WS" "$CODEX_WS" \
+  "T1: the pair shares ONE workspace project tree"
+
+# Distinct identity sources.
+if [[ "$ADMIN_HOME" == "$CODEX_HOME" ]]; then
+  smoke_fail "T1: a shared-workdir pair must keep DISTINCT identity sources; both resolved to '$ADMIN_HOME'"
+fi
+
+# Distinct memory dirs, each under its own identity source.
+if [[ "$ADMIN_MEM" == "$CODEX_MEM" ]]; then
+  smoke_fail "T1: a shared-workdir pair must keep DISTINCT memory dirs; both resolved to '$ADMIN_MEM'"
+fi
+smoke_assert_eq "$ADMIN_HOME/memory" "$ADMIN_MEM" \
+  "T1: admin memory dir is its identity source's memory/ (never inferred from the shared cwd)"
+smoke_assert_eq "$CODEX_HOME/memory" "$CODEX_MEM" \
+  "T1: codex memory dir is its identity source's memory/ (never inferred from the shared cwd)"
+
+# Distinct hook-config paths.
+if [[ "$ADMIN_HOOK" == "$CODEX_HOOK" ]]; then
+  smoke_fail "T1: a shared-workdir pair must keep DISTINCT hook-config paths; both resolved to '$ADMIN_HOOK'"
+fi
+
+# The shared workspace project file is NOT stamped with per-agent identity.
+smoke_assert_eq "yes" "$(extract_line "$OUT" "SHARED_WS_CLAUDE_UNTOUCHED")" \
+  "T1: materialization left the shared workspace CLAUDE.md untouched (per-agent identity stays in agent_home)"
+smoke_assert_eq "no" "$(extract_line "$OUT" "SHARED_WS_HAS_SOUL")" \
+  "T1: materialization did not write a per-agent SOUL.md into the shared workspace"
+
+smoke_log "all tests PASS — issue #1060 D5 smoke 3: shared-workdir pair isolation verified"


### PR DESCRIPTION
## Summary

Closes #1060 (agent-layout model drift). Implements the agreed three-layer agent-layout model for the beta6 clean-cut wave.

**Root cause:** `agent create` scaffolded into `home/` (the v2 identity source), but the runtime, SessionStart, profile-deploy, hooks, and `agent show` all read/reported from `workdir/` (the workspace). The divergence caused a real re-onboarding loop (#1046/#1060): onboarding-state written to one tree, read from the other.

**Critical constraint honored — no reader flip:** the runtime keeps reading `workdir/` exactly as before. This change makes `agent_home` the authored source and adds a materialization step that delivers identity into the existing engine read target.

## Three-layer model

| layer | meaning | v2 static path |
|---|---|---|
| 1. profile source | tracked portable role source (optional) | `$BRIDGE_HOME/agents/<a>` |
| 2. identity source | authored canonical per-agent identity | `data/agents/<a>/home` |
| 3. workspace | process cwd / project tree; may be shared | `data/agents/<a>/workdir` |

Plus the *engine materialization target* (owned by the descriptor) — where the engine runtime actually reads identity from; populated by `bridge_layout_materialize_identity`.

## New modules

**`lib/bridge-agent-layout.sh`** — typed path resolver. Accessors:
- `bridge_layout_profile_source_dir <agent>` — layer 1 (tracked role source)
- `bridge_layout_agent_home <agent>` — layer 2 (identity source; wraps `bridge_agent_default_home`)
- `bridge_layout_workspace_dir <agent>` — layer 3 (workspace; wraps `bridge_agent_workdir`)
- `bridge_layout_runtime_dir` — runtime/state root
- `bridge_layout_memory_dir <agent>` — `agent_home/memory`, never inferred from cwd
- `bridge_layout_materialize_identity <agent> <engine> [target_dir]` — D1 materialization step

**`lib/bridge-engine-descriptor.sh`** — minimal declarative per-engine descriptor (claude/codex/antigravity). Sole source for per-engine branching. Designed for #1067/#1068 to consume:
- `bridge_engine_entrypoint_filename <engine>` — claude→CLAUDE.md; codex→AGENTS.md
- `bridge_engine_wants_claude_compat_copy <engine>` — codex needs a CLAUDE.md copy for bridge readers
- `bridge_engine_hook_config_path <agent> <engine>` — claude→workspace/.claude/settings.json; codex→agent_home/.codex/hooks.json
- `bridge_engine_hook_renderer_profile <engine>` — claude or codex profile
- `bridge_engine_render_hooks_on_create <engine>` — whether create must render+verify hooks
- `bridge_engine_materialization_target <agent> <engine>` — where runtime reads identity from

## D-facets migrated (#1060 D1-D5)

- **D1 (scaffold + materialization):** `agent create` now authors identity into the identity source (`home/`) then runs `bridge_layout_materialize_identity` to deliver it into the workspace (`workdir/`). The runtime read target is never the empty/stale sibling. Shared-workdir rule enforced: per-agent identity is never materialized into a shared project tree.
- **D2 (roster / agent show / dry-run):** `agent show` now exposes an explicit `agent_home:` (identity source) alongside `BRIDGE_AGENT_WORKDIR:` (workspace). `bridge-start.sh --dry-run` also surfaces the distinction.
- **D3 (generated CLAUDE.md/AGENTS.md text):** The template "라이브 홈" line is now resolver-derived three-layer wording, no hardcoded path.
- **D4 (memory tooling):** `daily-note-reconcile.py` and the `wrap-up.md` template default the per-agent memory dir to `agent_home/memory` (matches `bridge_layout_memory_dir`), not the v2 tracked profile source.
- **D5 (release-gate smokes):** Three new smokes under `scripts/smoke/`, registered in `scripts/ci-select-smoke.sh` in the same change:
  1. `1060-layout-fresh-v2-static-claude` — fresh v2 static Claude three-layer agreement
  2. `1060-layout-fresh-v2-static-codex` — Codex descriptor + materialization
  3. `1060-layout-shared-workdir-pair` — shared workspace, distinct per-agent identity/memory/hooks

## Beta5 QA finding #1 (folded in)

`bridge-channels.py` remove-webhook-server catches `PermissionError`/`OSError` quietly — `agent create --isolate` no longer dumps a non-fatal Python traceback.

## Verification

- `bash -n`: PASS on all 13 touched/new files
- `shellcheck`: PASS on all 13 touched/new files (no warnings)
- `python3 -m py_compile`: PASS on bridge-channels.py, scripts/daily-note-reconcile.py
- `lint-heredoc-ban --baseline-check`: PASS (C1=104, C2=54, C3=315, C4=0, H3=364, SAFE=618)
- smoke-test.sh: pre-existing failures only (refs #4793 leaked-agent-dirs + status-activity-state, both present on base branch)
- 3 new smokes (isolated BRIDGE_HOME): all PASS
  - `1060-layout-fresh-v2-static-claude`: PASS — scaffold→identity source, materialization→workspace, three-layer agreement verified
  - `1060-layout-fresh-v2-static-codex`: PASS — descriptor resolves Codex targets, materialization delivers identity
  - `1060-layout-shared-workdir-pair`: PASS — shared workspace untouched, per-agent identity isolated

## Codex pair-review focus points

1. **No reader flip integrity** — verify `bridge_layout_materialize_identity` never changes where the runtime reads from; only writes to the existing read target
2. **Shared-workdir rule** — `bridge_layout_materialize_identity` shared-workspace guard (grep-for-"shared.*workdir" + `BRIDGE_LAYOUT_WORKSPACE_SHARED` flag)
3. **Materialization no-op path** — when `source_dir == target_dir` (legacy install) — no copy loop entered
4. **D2 path surfacing** — `agent show` exposes `agent_home:` and `BRIDGE_AGENT_WORKDIR:` as distinct items; `bridge-start.sh --dry-run` also surfaces both
5. **D4 memory path** — `daily-note-reconcile.py` changes: does the resolved path match `bridge_layout_memory_dir`?
6. **Engine descriptor future-proofing** — is `bridge_engine_materialization_target` flexible enough for #1067 to specialize Codex to a per-agent `AGENTS.md` surface without touching this module?

## Files changed

| file | purpose |
|---|---|
| `lib/bridge-agent-layout.sh` (NEW, +250) | typed layout resolver with 6 typed accessors |
| `lib/bridge-engine-descriptor.sh` (NEW, +144) | minimal per-engine descriptor with 6 accessors |
| `bridge-agent.sh` (+82/-7) | D1 scaffold→identity-source, D2 agent-show agent_home |
| `bridge-start.sh` (+8) | D2 dry-run agent_home surfacing |
| `bridge-lib.sh` (+8) | source both new modules on lib load |
| `bridge-channels.py` (+25/-0) | beta5 QA#1: PermissionError quiet catch |
| `agents/_template/CLAUDE.md` (+1/-1) | D3 resolver-derived three-layer wording |
| `agents/_template/.claude/commands/wrap-up.md` (+14/-0) | D4 memory path comment |
| `scripts/daily-note-reconcile.py` (+27/-0) | D4 identity-source memory dir |
| `scripts/smoke/1060-layout-fresh-v2-static-claude.sh` (NEW, +201) | D5 smoke 1 |
| `scripts/smoke/1060-layout-fresh-v2-static-codex.sh` (NEW, +185) | D5 smoke 2 |
| `scripts/smoke/1060-layout-shared-workdir-pair.sh` (NEW, +197) | D5 smoke 3 |
| `scripts/ci-select-smoke.sh` (+41/-0) | D5 smoke registration (footgun E02 — same PR as smokes) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)