### PR TITLE
feat(migrator): standalone legacy-install → clean-install migrator (export/plan/apply/verify)

### DIFF
--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator
 }
 
 add_all_integration() {
@@ -467,6 +467,15 @@ select_for_path() {
       # covers both the prompt-guard branch and the tool-policy
       # credential-deny exemption.
       add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys admin-hook-exemption
+      add_integration integration-minimal
+      ;;
+
+    scripts/migrate-legacy-install.sh|scripts/python-helpers/migrate-legacy-install-helper.py|scripts/python-helpers/migrator-smoke-helpers.py|scripts/smoke/legacy-install-migrator.sh)
+      # clean-cut wave beta6: standalone legacy-install migrator (export/plan/apply/verify).
+      # The migrator and its smoke are independent of the upgrade path; pull only
+      # the migration smoke + queue baseline so a change here doesn't rerun the
+      # full upgrade matrix unnecessarily.
+      add_required legacy-install-migrator queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/migrate-legacy-install.sh
+++ b/scripts/migrate-legacy-install.sh
@@ -65,10 +65,14 @@ Subcommands:
             Compute and print the apply plan (read-only on both sides).
 
   apply   --bundle <dir> --target <new-BRIDGE_HOME>
-            [EXPLICIT / off-by-default] Write the bundle into a clean target.
-            Requires: clean/fresh target, mandatory backup, secrets re-entered.
-            Optional: --app-password-file <file>  (Teams client secret)
-                      --a2a-secret-file <file>     (A2A HMAC key file, JSON)
+            **DEFERRED to beta7** — the r1 review of the beta6 PR surfaced
+            three contract gaps (clean-target gate doesn't check the actual
+            write paths; layout-resolver bypass; supplied secrets are read
+            but never written). beta6 ships export/plan/verify; drive the
+            actual writes by hand from the bundle/plan output.
+            (Internal dev only: BRIDGE_MIGRATOR_BETA6_APPLY_UNSAFE=1 keeps
+            the in-progress code path runnable. Do NOT use against a real
+            install.)
 
   verify  --target <new-BRIDGE_HOME>
             Run the verification gate against the migrated target.
@@ -77,10 +81,11 @@ Options:
   --help, -h    Print this help and exit.
 
 Safety:
-  apply refuses a non-empty / already-populated target.
+  apply is deferred to beta7 (see above). The export/plan/verify flow is
+  read-only on both sides — safe to run against any install.
   Secrets (Teams client secret, A2A HMAC keys) are NEVER copied from the
-  source bundle. Supply them via --app-password-file / --a2a-secret-file,
-  BRIDGE_TEAMS_APP_PASSWORD env var, or interactive stdin prompt.
+  source bundle in any subcommand; the bundle marks them as deliberately
+  absent and the operator must re-enter them at apply time.
 
 This tool is OPERATOR-RUN ONLY. Never invoke from upgrade / init / bootstrap.
 USAGE

--- a/scripts/migrate-legacy-install.sh
+++ b/scripts/migrate-legacy-install.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# scripts/migrate-legacy-install.sh — standalone legacy-install → clean-install migrator.
+#
+# Moves an old Agent Bridge install's agent-related identity into a fresh
+# clean-install bridge target. This tool is OPERATOR-RUN ONLY. It is
+# intentionally decoupled from bridge-upgrade.sh / bridge-init.sh /
+# bridge-bootstrap.sh and must never be called from those paths.
+#
+# Contract: export → plan → apply → verify. Never mutates the source in-place.
+#
+# Subcommands:
+#   export  --source <old-BRIDGE_HOME> --bundle <dir>   (read-only on source)
+#   plan    --bundle <dir>  --target <new-BRIDGE_HOME>   (read-only on target)
+#   apply   --bundle <dir>  --target <new-BRIDGE_HOME>   (writes to target)
+#   verify  --target <new-BRIDGE_HOME>                   (read-only check)
+#
+# Safety gates (apply only):
+#   - apply is EXPLICIT / off-by-default — must invoke `apply` subcommand.
+#   - target must be a CLEAN / FRESH install (not populated); apply refuses otherwise.
+#   - a backup + manifest are written to target before any mutation.
+#   - secrets are never copied; apply prompts for re-entry via file / env / stdin.
+#   - migrator is never wired into upgrade / init / bootstrap flows.
+#
+# Classification of items:
+#   portable       — roster intent, per-agent identity (SOUL/MEMORY/etc.),
+#                    cron definitions, non-secret channel config, host-profile.
+#   non-portable   — tmux sessions, pid files, daemon state, queue leases,
+#                    generated hooks/settings, plugin caches, logs, temp dirs,
+#                    worktrees, backup snapshots, live process state.
+#   secret         — Teams client secret, HMAC A2A peer keys — re-enter; never copy.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/.." && pwd -P)"
+MIGRATOR_PY="$SCRIPT_DIR/python-helpers/migrate-legacy-install-helper.py"
+
+VERSION="1"
+MIGRATOR_TAG="migrate-legacy-v${VERSION}"
+
+_die() {
+  printf '[migrator][error] %s\n' "$*" >&2
+  exit 1
+}
+
+_info() {
+  printf '[migrator] %s\n' "$*"
+}
+
+_warn() {
+  printf '[migrator][warn] %s\n' "$*" >&2
+}
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/migrate-legacy-install.sh <subcommand> [options]
+
+Subcommands:
+  export  --source <old-BRIDGE_HOME> --bundle <dir>
+            Read the old install (read-only) and write a portable bundle.
+
+  plan    --bundle <dir> --target <new-BRIDGE_HOME>
+            Compute and print the apply plan (read-only on both sides).
+
+  apply   --bundle <dir> --target <new-BRIDGE_HOME>
+            [EXPLICIT / off-by-default] Write the bundle into a clean target.
+            Requires: clean/fresh target, mandatory backup, secrets re-entered.
+            Optional: --app-password-file <file>  (Teams client secret)
+                      --a2a-secret-file <file>     (A2A HMAC key file, JSON)
+
+  verify  --target <new-BRIDGE_HOME>
+            Run the verification gate against the migrated target.
+
+Options:
+  --help, -h    Print this help and exit.
+
+Safety:
+  apply refuses a non-empty / already-populated target.
+  Secrets (Teams client secret, A2A HMAC keys) are NEVER copied from the
+  source bundle. Supply them via --app-password-file / --a2a-secret-file,
+  BRIDGE_TEAMS_APP_PASSWORD env var, or interactive stdin prompt.
+
+This tool is OPERATOR-RUN ONLY. Never invoke from upgrade / init / bootstrap.
+USAGE
+}
+
+require_python3() {
+  command -v python3 >/dev/null 2>&1 || _die "python3 is required"
+}
+
+require_migrator_py() {
+  [[ -f "$MIGRATOR_PY" ]] || _die "helper not found: $MIGRATOR_PY"
+}
+
+subcommand="${1:-}"
+[[ -n "$subcommand" ]] || { usage >&2; exit 2; }
+shift
+
+case "$subcommand" in
+  --help|-h)
+    usage
+    exit 0
+    ;;
+  export|plan|apply|verify)
+    ;;
+  *)
+    _die "unknown subcommand: $subcommand  (use export / plan / apply / verify)"
+    ;;
+esac
+
+# Parse remaining args into a flat argv we forward to the Python helper.
+# The Python helper owns all flag parsing for each subcommand to keep this
+# shell thin and heredoc-free.
+
+require_python3
+require_migrator_py
+
+_info "subcommand: $subcommand"
+
+# Forward to Python helper with subcommand as first positional arg.
+# No heredoc / here-string / process-substitution-to-stdin — footgun #11 safe.
+exec python3 "$MIGRATOR_PY" "$subcommand" \
+  --repo-root "$REPO_ROOT" \
+  --migrator-tag "$MIGRATOR_TAG" \
+  "$@"

--- a/scripts/migrate-legacy-install.sh
+++ b/scripts/migrate-legacy-install.sh
@@ -8,19 +8,26 @@
 # intentionally decoupled from bridge-upgrade.sh / bridge-init.sh /
 # bridge-bootstrap.sh and must never be called from those paths.
 #
-# Contract: export → plan → apply → verify. Never mutates the source in-place.
+# Contract: export → plan → verify (apply DEFERRED to beta7, see #1087).
+# Never mutates the source in-place. apply is gated behind
+# BRIDGE_MIGRATOR_BETA6_APPLY_UNSAFE=1 for internal beta7 development only.
 #
-# Subcommands:
+# Subcommands (beta6 user-facing):
 #   export  --source <old-BRIDGE_HOME> --bundle <dir>   (read-only on source)
-#   plan    --bundle <dir>  --target <new-BRIDGE_HOME>   (read-only on target)
-#   apply   --bundle <dir>  --target <new-BRIDGE_HOME>   (writes to target)
+#   plan    --bundle <dir>  --target <new-BRIDGE_HOME>   (read-only inspection)
 #   verify  --target <new-BRIDGE_HOME>                   (read-only check)
 #
-# Safety gates (apply only):
-#   - apply is EXPLICIT / off-by-default — must invoke `apply` subcommand.
+# Subcommand (gated, beta7 follow-up):
+#   apply   --bundle <dir>  --target <new-BRIDGE_HOME>
+#             Refuses by default. Tracked in issue #1087 for beta7 rework
+#             (clean-target gate, layout-resolver consumption, credential
+#             re-entry write paths). NOT for operator use in beta6.
+#
+# Safety design (apply, beta7 target):
+#   - apply will be EXPLICIT / off-by-default — must invoke `apply` subcommand.
 #   - target must be a CLEAN / FRESH install (not populated); apply refuses otherwise.
 #   - a backup + manifest are written to target before any mutation.
-#   - secrets are never copied; apply prompts for re-entry via file / env / stdin.
+#   - credentials are never copied; apply prompts for re-entry via file / env / stdin.
 #   - migrator is never wired into upgrade / init / bootstrap flows.
 #
 # Classification of items:

--- a/scripts/python-helpers/migrate-legacy-install-helper.py
+++ b/scripts/python-helpers/migrate-legacy-install-helper.py
@@ -701,6 +701,35 @@ def _prompt_secret(prompt: str) -> str:
 
 
 def cmd_apply(args: argparse.Namespace) -> int:
+    # beta6 fold-back per codex r1 review: `apply` is deferred to beta7.
+    # The r1 review surfaced three contract gaps that are too substantial
+    # to address in a beta6 r2 cycle:
+    #   - clean-target gate insufficient (does not check actual write paths)
+    #   - layout-resolver bypass (hardcoded path inference instead of
+    #     `bridge_layout_agent_home`/etc.)
+    #   - secrets are read but never written to the target (handoff.local.json,
+    #     Teams .env), and the cron env scrub is keyword-heuristic.
+    # The brief's explicit fallback was: "If you cannot meet every apply
+    # gate within reasonable change size, SHIP export+plan+verify only and
+    # leave apply as a documented beta7 follow-up."
+    # An opt-in env var keeps the existing code path runnable for follow-up
+    # work without exposing the unsafe path as the user-facing default.
+    if os.environ.get("BRIDGE_MIGRATOR_BETA6_APPLY_UNSAFE", "") != "1":
+        _die(
+            "apply is deferred to beta7 — the r1 review surfaced three "
+            "contract gaps (clean-target gate, layout-resolver bypass, "
+            "secret re-entry) that are tracked as a beta7 follow-up. Use "
+            "'export'+'plan'+'verify' in beta6 to inspect and validate; "
+            "drive the actual writes by hand from the bundle/plan. To run "
+            "the unsafe in-progress apply for follow-up development only, "
+            "set BRIDGE_MIGRATOR_BETA6_APPLY_UNSAFE=1."
+        )
+    sys.stderr.write(
+        "[warn] BRIDGE_MIGRATOR_BETA6_APPLY_UNSAFE=1 set — running the "
+        "unsafe in-progress apply path. Do NOT use this against a real "
+        "install; see codex r1 review for the three open contract gaps.\n"
+    )
+
     bundle_dir = Path(args.bundle).expanduser().resolve()
     target = Path(args.target).expanduser().resolve()
 

--- a/scripts/python-helpers/migrate-legacy-install-helper.py
+++ b/scripts/python-helpers/migrate-legacy-install-helper.py
@@ -636,7 +636,13 @@ def cmd_plan(args: argparse.Namespace) -> int:
                 print(f"  WARN: target already has: {rel} — apply will REFUSE")
                 target_ok = False
     if target_ok:
-        print("  target appears clean/fresh — apply may proceed")
+        # beta6 honesty: apply is gated (deferred to beta7) — see #1087.
+        # Don't tell the operator "apply may proceed" when the user-facing
+        # default refuses. plan is inspection-only in beta6.
+        print(
+            "  target appears clean/fresh — but apply is DEFERRED to beta7 "
+            "(see #1087); plan is inspection-only in beta6"
+        )
 
     return 0
 

--- a/scripts/python-helpers/migrate-legacy-install-helper.py
+++ b/scripts/python-helpers/migrate-legacy-install-helper.py
@@ -1,0 +1,1008 @@
+#!/usr/bin/env python3
+"""
+scripts/python-helpers/migrate-legacy-install-helper.py
+
+Python core for the legacy-install migrator (scripts/migrate-legacy-install.sh).
+Implements: export, plan, apply, verify subcommands.
+
+Design constraints:
+- Never called from bridge-upgrade.sh / bridge-init.sh / bridge-bootstrap.sh.
+- apply is explicit / off-by-default; refuses a non-empty target.
+- Secrets are never copied; apply prompts / reads via file or env.
+- No heredoc-stdin or process-substitution-into-reader (footgun #11).
+- Classification: portable / non-portable / secret; cross-class moves refused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MIGRATOR_SCHEMA_VERSION = 1
+
+# Canonical per-agent identity files — portable, written into agent_home.
+IDENTITY_FILES = (
+    "SOUL.md",
+    "SESSION-TYPE.md",
+    "MEMORY.md",
+    "MEMORY-SCHEMA.md",
+    "HEARTBEAT.md",
+    "CHANGE-POLICY.md",
+    "TOOLS.md",
+    "CLAUDE.md",
+    "AGENTS.md",
+    "NEXT-SESSION.md",
+    "active-prefs.json",
+    "active-prefs.md",
+)
+
+# Per-agent memory subtree.
+MEMORY_SUBDIR = "memory"
+
+# Per-agent per-user subtree.
+USERS_SUBDIR = "users"
+
+# Non-portable patterns — NEVER include in bundle.
+NON_PORTABLE_NAMES = frozenset({
+    "session_id",
+    "state.json",
+    "pid",
+    "pid.lock",
+    "daemon.pid",
+    "heartbeat",
+})
+
+NON_PORTABLE_EXTENSIONS = frozenset({
+    ".lock",
+    ".pid",
+    ".sock",
+    ".tmp",
+})
+
+NON_PORTABLE_SUBDIRS = frozenset({
+    "logs",
+    "log",
+    "state",
+    "shared",
+    "runtime",
+    "worktrees",
+    "tmp",
+    "temp",
+    "backup",
+    "backups",
+    ".git",
+    "__pycache__",
+})
+
+# Secret file patterns — export MUST NOT include; apply prompts for re-entry.
+SECRET_FILE_NAMES = frozenset({
+    "handoff.local.json",    # A2A HMAC peer keys
+    ".env",                  # any channel .env with tokens
+    "channel.env",
+    "bot-token",
+    "client-secret",
+})
+
+SECRET_EXTENSIONS = frozenset({
+    ".pem",
+    ".key",
+})
+
+# Roster keys that carry runtime state (non-portable, drop from export).
+ROSTER_RUNTIME_KEYS = frozenset({
+    "BRIDGE_AGENT_SESSION",     # live tmux session name
+    "BRIDGE_AGENT_LOOP",
+    "BRIDGE_AGENT_CONTINUE",
+})
+
+# Roster keys that may contain secrets (never export verbatim).
+ROSTER_SECRET_KEYS = frozenset({
+    "BRIDGE_AGENT_LAUNCH_CMD",  # may embed tokens via env injection
+})
+
+# Target MUST be fresh/clean if these dirs are absent or empty.
+CLEAN_TARGET_REQUIRED_ABSENT = (
+    "state/agents",
+    "state/tasks.db",
+    "data/agents",
+)
+
+# Verification checks.
+VERIFY_CHECKS = (
+    "layout-marker",
+    "roster-load",
+    "agent-homes",
+    "memory-dirs",
+    "cron-definitions",
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _die(msg: str, code: int = 1) -> None:
+    print(f"[migrator][error] {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def _info(msg: str) -> None:
+    print(f"[migrator] {msg}")
+
+
+def _warn(msg: str) -> None:
+    print(f"[migrator][warn] {msg}", file=sys.stderr)
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _is_secret_file(name: str) -> bool:
+    lower = name.lower()
+    if lower in SECRET_FILE_NAMES:
+        return True
+    _, ext = os.path.splitext(lower)
+    return ext in SECRET_EXTENSIONS
+
+
+def _is_non_portable(name: str) -> bool:
+    lower = name.lower()
+    if lower in NON_PORTABLE_NAMES:
+        return True
+    _, ext = os.path.splitext(lower)
+    return ext in NON_PORTABLE_EXTENSIONS
+
+
+def _classify_item(rel_path: str) -> str:
+    """Return 'portable', 'secret', or 'non-portable'."""
+    parts = Path(rel_path).parts
+    name = parts[-1] if parts else ""
+    # Top-level non-portable dirs.
+    if parts and parts[0] in NON_PORTABLE_SUBDIRS:
+        return "non-portable"
+    if _is_secret_file(name):
+        return "secret"
+    if _is_non_portable(name):
+        return "non-portable"
+    return "portable"
+
+
+def _run_cmd(args: List[str], cwd: Optional[str] = None) -> Tuple[int, str, str]:
+    """Run a subprocess without heredoc/pipe. Returns (rc, stdout, stderr)."""
+    result = subprocess.run(
+        args,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+# ---------------------------------------------------------------------------
+# Source inspector: read a legacy BRIDGE_HOME
+# ---------------------------------------------------------------------------
+
+class LegacyInstall:
+    """Read-only view of a legacy BRIDGE_HOME."""
+
+    def __init__(self, bridge_home: Path) -> None:
+        self.root = bridge_home
+        self.state_dir = bridge_home / "state"
+        self.agents_home_root = bridge_home / "agents"  # old per-agent homes
+        self.cron_home = bridge_home / "cron"
+        self.cron_native_jobs = bridge_home / "cron" / "jobs.json"
+        self.roster_file = bridge_home / "agent-roster.sh"
+        self.roster_local_file = bridge_home / "agent-roster.local.sh"
+        self.host_profile = bridge_home / "state" / "host-profile.json"
+
+        # v2 layout (data/agents/<agent>/home)
+        self.data_root = bridge_home / "data"
+        self.agent_root_v2 = bridge_home / "data" / "agents"
+
+        # layout marker
+        self.layout_marker = bridge_home / "state" / "layout-marker.sh"
+
+    def is_v2_layout(self) -> bool:
+        if not self.layout_marker.exists():
+            return False
+        try:
+            text = self.layout_marker.read_text()
+            return "BRIDGE_LAYOUT=v2" in text
+        except OSError:
+            return False
+
+    def agent_home_path(self, agent_id: str) -> Path:
+        """Resolve per-agent home: v2 data/agents/<agent>/home, else agents/<agent>."""
+        if self.is_v2_layout():
+            return self.agent_root_v2 / agent_id / "home"
+        return self.agents_home_root / agent_id
+
+    def list_agent_ids(self) -> List[str]:
+        """Return agent IDs inferred from on-disk homes."""
+        ids: List[str] = []
+        for root in (self.agents_home_root, self.agent_root_v2):
+            if not root.is_dir():
+                continue
+            for entry in sorted(root.iterdir()):
+                if entry.is_dir() and not entry.name.startswith("."):
+                    ids.append(entry.name)
+        # Deduplicate, preserve order.
+        seen: set = set()
+        result: List[str] = []
+        for a in ids:
+            if a not in seen:
+                seen.add(a)
+                result.append(a)
+        return result
+
+    def read_cron_jobs(self) -> List[Dict[str, Any]]:
+        """Read the native cron jobs file; return empty list on missing/invalid."""
+        candidates = [
+            self.cron_native_jobs,
+            self.root / "state" / "cron" / "jobs.json",
+        ]
+        for path in candidates:
+            if path.is_file():
+                try:
+                    data = json.loads(path.read_text())
+                    if isinstance(data, list):
+                        return data
+                    if isinstance(data, dict) and "jobs" in data:
+                        return data["jobs"]
+                except (json.JSONDecodeError, OSError):
+                    _warn(f"cron jobs file unreadable or invalid JSON: {path}")
+        return []
+
+    def read_host_profile(self) -> Optional[Dict[str, Any]]:
+        if not self.host_profile.is_file():
+            return None
+        try:
+            return json.loads(self.host_profile.read_text())
+        except (json.JSONDecodeError, OSError):
+            return None
+
+
+# ---------------------------------------------------------------------------
+# Bundle writer
+# ---------------------------------------------------------------------------
+
+def _collect_agent_identity(
+    agent_id: str,
+    home_path: Path,
+) -> Dict[str, Any]:
+    """
+    Collect portable identity for one agent. Returns a dict with:
+      - files: list of {rel_path, sha256, size_bytes}
+      - memory_dir_exists: bool
+      - users_dir_exists: bool
+    Excludes secrets and non-portable items.
+    """
+    files: List[Dict[str, Any]] = []
+
+    if not home_path.is_dir():
+        return {"files": files, "memory_dir_exists": False, "users_dir_exists": False}
+
+    # Top-level identity files.
+    for fname in IDENTITY_FILES:
+        fpath = home_path / fname
+        if fpath.is_file():
+            files.append({
+                "rel_path": fname,
+                "sha256": _sha256_file(fpath),
+                "size_bytes": fpath.stat().st_size,
+                "classification": "portable",
+            })
+
+    # Memory subtree.
+    mem_path = home_path / MEMORY_SUBDIR
+    mem_exists = mem_path.is_dir()
+    if mem_exists:
+        for mem_file in sorted(mem_path.rglob("*")):
+            if not mem_file.is_file():
+                continue
+            rel = mem_file.relative_to(home_path)
+            rel_str = str(rel)
+            cls = _classify_item(rel_str)
+            if cls == "non-portable":
+                continue
+            if cls == "secret":
+                _warn(f"  skipping secret file in memory: {rel_str}")
+                continue
+            files.append({
+                "rel_path": rel_str,
+                "sha256": _sha256_file(mem_file),
+                "size_bytes": mem_file.stat().st_size,
+                "classification": cls,
+            })
+
+    # Per-user subtree.
+    users_path = home_path / USERS_SUBDIR
+    users_exists = users_path.is_dir()
+    if users_exists:
+        for u_file in sorted(users_path.rglob("*")):
+            if not u_file.is_file():
+                continue
+            rel = u_file.relative_to(home_path)
+            rel_str = str(rel)
+            cls = _classify_item(rel_str)
+            if cls in ("non-portable", "secret"):
+                continue
+            files.append({
+                "rel_path": rel_str,
+                "sha256": _sha256_file(u_file),
+                "size_bytes": u_file.stat().st_size,
+                "classification": cls,
+            })
+
+    return {
+        "files": files,
+        "memory_dir_exists": mem_exists,
+        "users_dir_exists": users_exists,
+    }
+
+
+def _sanitize_cron_job(job: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Keep portable cron definition fields; strip runtime state.
+    Schedule, target, title, payload_kind, enabled, timezone, followup_policy.
+    Active run leases, run ids, last_run_* fields are non-portable.
+    """
+    keep = (
+        "id", "name", "title", "target", "schedule", "timezone",
+        "payload_kind", "payload", "enabled",
+        "followup_policy", "model", "effort", "description",
+        "tags", "created_at",
+    )
+    sanitized: Dict[str, Any] = {}
+    for key in keep:
+        if key in job:
+            sanitized[key] = job[key]
+    # Payload env vars may contain secrets — warn and strip.
+    if "payload" in sanitized and isinstance(sanitized["payload"], dict):
+        env_block = sanitized["payload"].get("env", {})
+        secret_keys: List[str] = []
+        for k in list(env_block.keys()):
+            if any(kw in k.upper() for kw in ("TOKEN", "SECRET", "PASSWORD", "KEY", "PASS")):
+                secret_keys.append(k)
+        for k in secret_keys:
+            del env_block[k]
+            _warn(f"  cron job '{sanitized.get('name','?')}': env key '{k}' looks like a secret — stripped from bundle")
+    return sanitized
+
+
+def _read_roster_agents(roster_path: Path) -> List[Dict[str, Any]]:
+    """
+    Parse roster shell file to extract agent metadata.
+    Only reads BRIDGE_AGENT_DESC, ENGINE, MODEL, EFFORT, PERMISSION_MODE,
+    PROFILE_HOME, WEBHOOK_PORT, IDLE_TIMEOUT, NOTIFY_KIND, NOTIFY_TARGET,
+    NOTIFY_ACCOUNT maps. Skips runtime keys and secret keys.
+    Returns list of dicts with agent_id and metadata.
+    """
+    if not roster_path.is_file():
+        return []
+
+    agents: Dict[str, Dict[str, str]] = {}
+
+    # Simple grep-style extraction: look for map assignments.
+    # Pattern: BRIDGE_AGENT_DESC["agentid"]="..."
+    map_pattern = re.compile(
+        r'BRIDGE_AGENT_([A-Z_]+)\["([^"]+)"\]\s*=\s*"([^"]*)"'
+    )
+
+    text = roster_path.read_text(errors="replace")
+    for m in map_pattern.finditer(text):
+        key_suffix, agent_id, value = m.group(1), m.group(2), m.group(3)
+        full_key = f"BRIDGE_AGENT_{key_suffix}"
+        if full_key in ROSTER_SECRET_KEYS:
+            continue  # never export launch cmd (may embed tokens)
+        if full_key in ROSTER_RUNTIME_KEYS:
+            continue  # runtime state, not portable
+        agents.setdefault(agent_id, {})
+        agents[agent_id][key_suffix] = value
+
+    # Also extract BRIDGE_AGENT_IDS array.
+    ids_pattern = re.compile(r'BRIDGE_AGENT_IDS\s*=\s*\(([^)]*)\)')
+    ids_match = ids_pattern.search(text)
+    declared_ids: List[str] = []
+    if ids_match:
+        raw = ids_match.group(1)
+        declared_ids = re.findall(r'"([^"]+)"', raw)
+
+    result: List[Dict[str, Any]] = []
+    seen: set = set()
+    for aid in declared_ids + sorted(agents.keys()):
+        if aid in seen:
+            continue
+        seen.add(aid)
+        result.append({
+            "agent_id": aid,
+            "metadata": agents.get(aid, {}),
+        })
+    return result
+
+
+# ---------------------------------------------------------------------------
+# export subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_export(args: argparse.Namespace) -> int:
+    source = Path(args.source).expanduser().resolve()
+    bundle_dir = Path(args.bundle).expanduser().resolve()
+
+    if not source.is_dir():
+        _die(f"source BRIDGE_HOME does not exist: {source}")
+
+    _info(f"source: {source}")
+    _info(f"bundle: {bundle_dir}")
+
+    install = LegacyInstall(source)
+    layout = "v2" if install.is_v2_layout() else "legacy"
+    _info(f"detected layout: {layout}")
+
+    agent_ids = install.list_agent_ids()
+    _info(f"agents found: {', '.join(agent_ids) if agent_ids else '(none)'}")
+
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    agents_bundle = bundle_dir / "agents"
+    agents_bundle.mkdir(exist_ok=True)
+
+    manifest: Dict[str, Any] = {
+        "schema_version": MIGRATOR_SCHEMA_VERSION,
+        "migrator_tag": args.migrator_tag,
+        "exported_at": _now_iso(),
+        "source_bridge_home": str(source),
+        "source_layout": layout,
+        "agents": [],
+        "cron_jobs": [],
+        "host_profile": None,
+        "secrets_stripped": [],
+    }
+
+    # Export per-agent identity.
+    for agent_id in agent_ids:
+        home_path = install.agent_home_path(agent_id)
+        identity = _collect_agent_identity(agent_id, home_path)
+        agent_bundle_dir = agents_bundle / agent_id
+        agent_bundle_dir.mkdir(exist_ok=True)
+
+        # Copy portable files into bundle.
+        for finfo in identity["files"]:
+            src = home_path / finfo["rel_path"]
+            dst = agent_bundle_dir / finfo["rel_path"]
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(src), str(dst))
+
+        # Read roster metadata.
+        roster_meta: List[Dict[str, Any]] = []
+        for roster_path in (install.roster_file, install.roster_local_file):
+            for entry in _read_roster_agents(roster_path):
+                if entry["agent_id"] == agent_id:
+                    roster_meta = [entry]
+                    break
+
+        manifest["agents"].append({
+            "agent_id": agent_id,
+            "source_home": str(home_path),
+            "file_count": len(identity["files"]),
+            "files": identity["files"],
+            "memory_dir_exists": identity["memory_dir_exists"],
+            "users_dir_exists": identity["users_dir_exists"],
+            "roster_metadata": roster_meta[0]["metadata"] if roster_meta else {},
+        })
+        _info(f"  agent {agent_id}: {len(identity['files'])} identity files exported")
+
+    # Export cron definitions (portable, secrets stripped).
+    raw_jobs = install.read_cron_jobs()
+    portable_jobs: List[Dict[str, Any]] = []
+    for job in raw_jobs:
+        portable_jobs.append(_sanitize_cron_job(job))
+    manifest["cron_jobs"] = portable_jobs
+    _info(f"cron definitions: {len(portable_jobs)} exported")
+
+    # Export host-profile snapshot (portable capability facts only).
+    hp = install.read_host_profile()
+    if hp is not None:
+        # Strip any secret-looking keys.
+        for k in list(hp.keys()):
+            if any(kw in k.upper() for kw in ("TOKEN", "SECRET", "PASSWORD", "KEY")):
+                del hp[k]
+                manifest["secrets_stripped"].append(f"host_profile.{k}")
+        manifest["host_profile"] = hp
+
+    # Note secrets that were NOT exported.
+    secret_notes: List[str] = []
+    for sname in SECRET_FILE_NAMES:
+        for candidate in (
+            source / sname,
+            source / "runtime" / sname,
+        ):
+            if candidate.exists():
+                secret_notes.append(str(candidate.relative_to(source)))
+                manifest["secrets_stripped"].append(f"source:{candidate.relative_to(source)}")
+    if secret_notes:
+        _warn("secrets present in source — NOT included in bundle (re-enter at apply):")
+        for s in secret_notes:
+            _warn(f"  {s}")
+
+    # Write manifest.
+    manifest_path = bundle_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2))
+    _info(f"manifest written: {manifest_path}")
+    _info("export complete")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# plan subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_plan(args: argparse.Namespace) -> int:
+    bundle_dir = Path(args.bundle).expanduser().resolve()
+    target = Path(args.target).expanduser().resolve()
+
+    if not bundle_dir.is_dir():
+        _die(f"bundle directory does not exist: {bundle_dir}")
+    manifest_path = bundle_dir / "manifest.json"
+    if not manifest_path.is_file():
+        _die(f"manifest not found in bundle: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text())
+    _info(f"bundle: {bundle_dir}")
+    _info(f"target: {target}")
+    _info(f"schema_version: {manifest.get('schema_version')}")
+    _info(f"exported_at: {manifest.get('exported_at')}")
+    _info(f"source_layout: {manifest.get('source_layout')}")
+
+    # Detect target layout.
+    target_marker = target / "state" / "layout-marker.sh"
+    if target_marker.is_file():
+        _info(f"target layout marker: {target_marker}")
+    else:
+        _info("target: no layout marker found (fresh install expected)")
+
+    print()
+    print("=== APPLY PLAN ===")
+
+    for agent_entry in manifest.get("agents", []):
+        aid = agent_entry["agent_id"]
+        n = agent_entry["file_count"]
+        mem = agent_entry.get("memory_dir_exists", False)
+        users = agent_entry.get("users_dir_exists", False)
+        print(f"\nagent: {aid}")
+        print(f"  identity files: {n}")
+        if mem:
+            print("  memory dir: yes (will import)")
+        if users:
+            print("  users dir: yes (will import)")
+        meta = agent_entry.get("roster_metadata", {})
+        if meta:
+            for k, v in sorted(meta.items()):
+                print(f"  roster.{k}: {v}")
+
+    crons = manifest.get("cron_jobs", [])
+    print(f"\ncron definitions: {len(crons)}")
+    for job in crons:
+        name = job.get("name") or job.get("id") or "?"
+        target_agent = job.get("target", "?")
+        enabled = job.get("enabled", True)
+        print(f"  cron: {name} → {target_agent} (enabled={enabled})")
+
+    stripped = manifest.get("secrets_stripped", [])
+    if stripped:
+        print(f"\nsecrets NOT exported (will need re-entry at apply): {len(stripped)}")
+        for s in stripped:
+            print(f"  {s}")
+
+    print()
+    print("NON-PORTABLE items (excluded from apply):")
+    print("  tmux sessions, pid files, queue leases, daemon state,")
+    print("  generated hooks/settings, plugin caches, logs, worktrees, backups")
+
+    print()
+    print("=== TARGET CLEANLINESS CHECK ===")
+    target_ok = True
+    for rel in CLEAN_TARGET_REQUIRED_ABSENT:
+        p = target / rel
+        if p.exists():
+            if p.is_file() or any(True for _ in p.iterdir() if p.is_dir()):
+                print(f"  WARN: target already has: {rel} — apply will REFUSE")
+                target_ok = False
+    if target_ok:
+        print("  target appears clean/fresh — apply may proceed")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# apply subcommand
+# ---------------------------------------------------------------------------
+
+def _target_is_clean(target: Path) -> Tuple[bool, List[str]]:
+    """Return (is_clean, list_of_blocking_paths)."""
+    blockers: List[str] = []
+    for rel in CLEAN_TARGET_REQUIRED_ABSENT:
+        p = target / rel
+        if not p.exists():
+            continue
+        if p.is_file():
+            blockers.append(str(rel))
+            continue
+        if p.is_dir():
+            # Non-empty directory is a blocker.
+            try:
+                if any(True for _ in p.iterdir()):
+                    blockers.append(str(rel))
+            except PermissionError:
+                blockers.append(str(rel) + " (permission denied)")
+    return (len(blockers) == 0, blockers)
+
+
+def _write_backup_manifest(backup_dir: Path, target: Path) -> Path:
+    """Write a manifest of what existed in the target before apply."""
+    entries: List[Dict[str, str]] = []
+    if target.is_dir():
+        for p in sorted(target.rglob("*")):
+            if p.is_file():
+                rel = str(p.relative_to(target))
+                entries.append({"rel_path": rel, "sha256": _sha256_file(p)})
+    manifest = {
+        "backup_at": _now_iso(),
+        "target": str(target),
+        "file_count": len(entries),
+        "files": entries,
+    }
+    mpath = backup_dir / "pre-apply-backup-manifest.json"
+    mpath.write_text(json.dumps(manifest, indent=2))
+    return mpath
+
+
+def _read_secret_file(path: str) -> str:
+    """Read a secret from a file; strip trailing newlines."""
+    p = Path(path).expanduser()
+    if not p.is_file():
+        _die(f"secret file not found: {p}")
+    return p.read_text().strip()
+
+
+def _prompt_secret(prompt: str) -> str:
+    """Prompt operator for a secret on stdin; hide echo."""
+    try:
+        return getpass.getpass(prompt)
+    except EOFError:
+        return ""
+
+
+def cmd_apply(args: argparse.Namespace) -> int:
+    bundle_dir = Path(args.bundle).expanduser().resolve()
+    target = Path(args.target).expanduser().resolve()
+
+    if not bundle_dir.is_dir():
+        _die(f"bundle directory does not exist: {bundle_dir}")
+    manifest_path = bundle_dir / "manifest.json"
+    if not manifest_path.is_file():
+        _die(f"manifest not found in bundle: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text())
+
+    _info(f"bundle: {bundle_dir}")
+    _info(f"target: {target}")
+
+    # --- Gate 1: target must be clean/fresh ---
+    is_clean, blockers = _target_is_clean(target)
+    if not is_clean:
+        _die(
+            "target is not clean/fresh — apply refused.\n"
+            "  blocking paths: " + ", ".join(blockers) + "\n"
+            "  Use 'plan' to inspect, or point apply at a clean fresh-install target."
+        )
+    _info("target cleanliness: PASS")
+
+    # --- Gate 2: mandatory backup + manifest ---
+    backup_dir = target / ".migrator-pre-apply-backup"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    backup_manifest_path = _write_backup_manifest(backup_dir, target)
+    _info(f"pre-apply backup manifest: {backup_manifest_path}")
+
+    # --- Gate 3: secrets are never copied; re-enter ---
+    # A2A secret (from file, env, or skip).
+    a2a_secret: Optional[str] = None
+    teams_secret: Optional[str] = None
+
+    if args.a2a_secret_file:
+        a2a_secret = _read_secret_file(args.a2a_secret_file)
+        _info("A2A HMAC secret: loaded from file")
+    elif os.environ.get("BRIDGE_A2A_SHARED_SECRET"):
+        a2a_secret = os.environ["BRIDGE_A2A_SHARED_SECRET"].strip()
+        _info("A2A HMAC secret: loaded from BRIDGE_A2A_SHARED_SECRET env")
+    else:
+        _warn("A2A HMAC secret not supplied. A2A peer config will not be written.")
+        _warn("  Supply via --a2a-secret-file or BRIDGE_A2A_SHARED_SECRET env.")
+
+    if args.app_password_file:
+        teams_secret = _read_secret_file(args.app_password_file)
+        _info("Teams app password: loaded from file")
+    elif os.environ.get("BRIDGE_TEAMS_APP_PASSWORD"):
+        teams_secret = os.environ["BRIDGE_TEAMS_APP_PASSWORD"].strip()
+        _info("Teams app password: loaded from BRIDGE_TEAMS_APP_PASSWORD env")
+    else:
+        # Check if source had Teams config — if so, prompt.
+        stripped = manifest.get("secrets_stripped", [])
+        teams_present = any("client-secret" in s or "teams" in s.lower() for s in stripped)
+        if teams_present:
+            _warn("Teams client secret detected in source — not copied.")
+            if sys.stdin.isatty():
+                teams_secret_input = _prompt_secret("[migrator] Enter Teams app password (or press Enter to skip): ")
+                if teams_secret_input:
+                    teams_secret = teams_secret_input
+                    _info("Teams app password: entered interactively")
+                else:
+                    _info("Teams app password: skipped (enter manually after apply)")
+            else:
+                _warn("Non-interactive: Teams app password skipped. Enter manually after apply.")
+
+    # --- Apply: write agent identity into target ---
+    agents_bundle = bundle_dir / "agents"
+    applied_agents: List[str] = []
+
+    for agent_entry in manifest.get("agents", []):
+        aid = agent_entry["agent_id"]
+        agent_bundle_dir = agents_bundle / aid
+        if not agent_bundle_dir.is_dir():
+            _warn(f"  agent {aid}: bundle dir missing — skipping")
+            continue
+
+        # Determine target agent_home.
+        # On a v2 target: data/agents/<agent>/home
+        # On a legacy target: agents/<agent>
+        target_marker = target / "state" / "layout-marker.sh"
+        if target_marker.is_file() and "BRIDGE_LAYOUT=v2" in target_marker.read_text():
+            agent_home_target = target / "data" / "agents" / aid / "home"
+        else:
+            agent_home_target = target / "agents" / aid
+
+        agent_home_target.mkdir(parents=True, exist_ok=True)
+
+        # Copy identity files.
+        copied = 0
+        for finfo in agent_entry.get("files", []):
+            rel = finfo["rel_path"]
+            cls = finfo.get("classification", "portable")
+            if cls != "portable":
+                continue  # never apply non-portable or secret items
+            src = agent_bundle_dir / rel
+            dst = agent_home_target / rel
+            if not src.is_file():
+                continue
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(src), str(dst))
+            copied += 1
+
+        applied_agents.append(aid)
+        _info(f"  agent {aid}: {copied} identity files → {agent_home_target}")
+
+    # --- Apply: cron definitions ---
+    cron_jobs = manifest.get("cron_jobs", [])
+    if cron_jobs:
+        cron_home = target / "cron"
+        cron_home.mkdir(parents=True, exist_ok=True)
+        jobs_path = cron_home / "jobs.json"
+        if jobs_path.is_file():
+            _warn("target cron/jobs.json already exists — merging not supported; skipping cron import")
+            _warn("  Manually merge from bundle/cron-definitions.json after apply.")
+        else:
+            jobs_path.write_text(json.dumps(cron_jobs, indent=2))
+            _info(f"cron definitions: {len(cron_jobs)} imported → {jobs_path}")
+        # Write a reference copy regardless.
+        ref_path = backup_dir / "cron-definitions-from-bundle.json"
+        ref_path.write_text(json.dumps(cron_jobs, indent=2))
+
+    # --- Apply: write apply-result manifest ---
+    apply_manifest = {
+        "schema_version": MIGRATOR_SCHEMA_VERSION,
+        "migrator_tag": args.migrator_tag,
+        "applied_at": _now_iso(),
+        "source_bundle": str(bundle_dir),
+        "target": str(target),
+        "applied_agents": applied_agents,
+        "cron_jobs_imported": len(cron_jobs),
+        "a2a_secret_supplied": a2a_secret is not None,
+        "teams_secret_supplied": teams_secret is not None,
+    }
+    apply_result_path = target / ".migrator-apply-result.json"
+    apply_result_path.write_text(json.dumps(apply_manifest, indent=2))
+    _info(f"apply result: {apply_result_path}")
+
+    _info("apply complete")
+    print()
+    print("NEXT STEPS after apply:")
+    print("  1. Run 'verify --target <target>' to check the migrated install.")
+    print("  2. If Teams or A2A secrets were skipped, enter them now via:")
+    print("     bridge-setup.sh / agb setup, or edit channel .env files.")
+    print("  3. Hooks/settings are NOT imported — regenerate via:")
+    print("     agb hooks render  (or bridge-hooks.py render ...)")
+    print("  4. Review applied_agents and cron definitions.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# verify subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    target = Path(args.target).expanduser().resolve()
+    repo_root = Path(args.repo_root).expanduser().resolve()
+
+    _info(f"verify target: {target}")
+
+    failures: List[str] = []
+    passes: List[str] = []
+
+    # --- Check 1: layout marker ---
+    marker = target / "state" / "layout-marker.sh"
+    if marker.is_file():
+        text = marker.read_text()
+        if "BRIDGE_LAYOUT" in text:
+            passes.append("layout-marker: found and parseable")
+        else:
+            failures.append("layout-marker: present but BRIDGE_LAYOUT missing")
+    else:
+        # Not a hard failure — a fresh install may not have a marker yet.
+        passes.append("layout-marker: absent (fresh install before marker write)")
+
+    # --- Check 2: apply result manifest ---
+    apply_result = target / ".migrator-apply-result.json"
+    if apply_result.is_file():
+        try:
+            ar = json.loads(apply_result.read_text())
+            applied_agents = ar.get("applied_agents", [])
+            passes.append(f"apply-result: found ({len(applied_agents)} agents)")
+        except (json.JSONDecodeError, OSError):
+            failures.append("apply-result: unreadable")
+    else:
+        failures.append("apply-result: .migrator-apply-result.json not found (apply not run?)")
+
+    # --- Check 3: agent homes exist ---
+    is_v2 = marker.is_file() and "BRIDGE_LAYOUT=v2" in (marker.read_text() if marker.is_file() else "")
+    agent_home_root = (target / "data" / "agents") if is_v2 else (target / "agents")
+
+    agent_dirs: List[str] = []
+    if agent_home_root.is_dir():
+        agent_dirs = [e.name for e in sorted(agent_home_root.iterdir()) if e.is_dir() and not e.name.startswith(".")]
+
+    if agent_dirs:
+        passes.append(f"agent-homes: {len(agent_dirs)} found: {', '.join(agent_dirs)}")
+        # Check each has at least one identity file.
+        for aid in agent_dirs:
+            home = agent_home_root / aid / "home" if is_v2 else agent_home_root / aid
+            has_identity = any((home / f).is_file() for f in IDENTITY_FILES)
+            if has_identity:
+                passes.append(f"  agent {aid}: identity files present")
+            else:
+                failures.append(f"  agent {aid}: no identity files found in {home}")
+    else:
+        passes.append("agent-homes: none (no agents migrated)")
+
+    # --- Check 4: cron definitions ---
+    cron_jobs_path = target / "cron" / "jobs.json"
+    if cron_jobs_path.is_file():
+        try:
+            jobs = json.loads(cron_jobs_path.read_text())
+            passes.append(f"cron-definitions: {len(jobs)} jobs present")
+        except (json.JSONDecodeError, OSError):
+            failures.append("cron-definitions: jobs.json unreadable")
+    else:
+        passes.append("cron-definitions: absent (no cron jobs migrated or not yet created)")
+
+    # --- Check 5: roster files exist ---
+    roster = target / "agent-roster.sh"
+    if roster.is_file():
+        passes.append("roster: agent-roster.sh present")
+    else:
+        passes.append("roster: agent-roster.sh absent (fresh install will create on first start)")
+
+    # --- Report ---
+    print()
+    print("=== VERIFY RESULTS ===")
+    for p in passes:
+        print(f"  PASS  {p}")
+    for f in failures:
+        print(f"  FAIL  {f}")
+
+    if failures:
+        print(f"\nverify: {len(failures)} failure(s)")
+        return 1
+
+    print(f"\nverify: all {len(passes)} checks passed")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing + dispatch
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Legacy-install migrator core (invoked from migrate-legacy-install.sh).",
+        add_help=True,
+    )
+    parser.add_argument("subcommand", choices=["export", "plan", "apply", "verify"])
+    parser.add_argument("--repo-root", required=True, help="Agent Bridge source root")
+    parser.add_argument("--migrator-tag", required=True, help="Migrator version tag")
+
+    # export
+    parser.add_argument("--source", help="Source BRIDGE_HOME (export)")
+    parser.add_argument("--bundle", help="Bundle directory (export/plan/apply)")
+
+    # plan / apply
+    parser.add_argument("--target", help="Target BRIDGE_HOME (plan/apply/verify)")
+
+    # apply secrets (never copied from source)
+    parser.add_argument("--app-password-file", help="File containing Teams app password (apply)")
+    parser.add_argument("--a2a-secret-file", help="File containing A2A HMAC key JSON (apply)")
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.subcommand == "export":
+        if not args.source:
+            parser.error("export requires --source")
+        if not args.bundle:
+            parser.error("export requires --bundle")
+        return cmd_export(args)
+
+    elif args.subcommand == "plan":
+        if not args.bundle:
+            parser.error("plan requires --bundle")
+        if not args.target:
+            parser.error("plan requires --target")
+        return cmd_plan(args)
+
+    elif args.subcommand == "apply":
+        if not args.bundle:
+            parser.error("apply requires --bundle")
+        if not args.target:
+            parser.error("apply requires --target")
+        return cmd_apply(args)
+
+    elif args.subcommand == "verify":
+        if not args.target:
+            parser.error("verify requires --target")
+        return cmd_verify(args)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/python-helpers/migrator-smoke-helpers.py
+++ b/scripts/python-helpers/migrator-smoke-helpers.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+scripts/python-helpers/migrator-smoke-helpers.py
+
+File-as-argv helpers for the legacy-install-migrator smoke test.
+Invoked with a command name as first arg, path(s) as subsequent args.
+No heredoc-stdin / here-string; footgun #11 safe.
+
+Commands:
+  manifest-agent-count   <manifest.json>
+  manifest-cron-count    <manifest.json>
+  apply-result-agents    <apply-result.json>
+  cron-job-count         <cron/jobs.json>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: migrator-smoke-helpers.py <command> [args...]", file=sys.stderr)
+        return 2
+
+    cmd = sys.argv[1]
+
+    if cmd == "manifest-agent-count":
+        path = sys.argv[2]
+        m = json.loads(open(path).read())
+        print(len(m.get("agents", [])))
+
+    elif cmd == "manifest-cron-count":
+        path = sys.argv[2]
+        m = json.loads(open(path).read())
+        print(len(m.get("cron_jobs", [])))
+
+    elif cmd == "apply-result-agents":
+        path = sys.argv[2]
+        ar = json.loads(open(path).read())
+        print(",".join(sorted(ar.get("applied_agents", []))))
+
+    elif cmd == "cron-job-count":
+        path = sys.argv[2]
+        jobs = json.loads(open(path).read())
+        count = len(jobs) if isinstance(jobs, list) else 0
+        print(count)
+
+    else:
+        print(f"unknown command: {cmd}", file=sys.stderr)
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/legacy-install-migrator.sh
+++ b/scripts/smoke/legacy-install-migrator.sh
@@ -4,17 +4,22 @@
 # Synthetic legacy-install repro for scripts/migrate-legacy-install.sh.
 #
 # Builds a fake old-style install (two agents + cron + memory + channel config),
-# then runs: export → plan → apply-to-clean → verify.
+# then runs: export → plan → confirm-apply-deferred.
 #
-# Assertions:
+# beta6 fold-back per codex r1 review: apply is DEFERRED to beta7 (three
+# contract gaps — clean-target gate, layout-resolver bypass, secret re-entry).
+# The smoke now asserts the user-facing apply default is refused with a clear
+# beta7 deferral message and does NOT mutate the target. The full apply +
+# post-apply verify smoke moves to beta7 alongside the apply rework.
+#
+# Assertions (beta6):
 #   1. export writes a manifest + agent identity files to bundle dir.
 #   2. plan prints apply plan and target-cleanliness check without error.
-#   3. apply REFUSES a non-empty target (safety gate).
-#   4. apply SUCCEEDS into a clean target; identity lands in agent_home.
-#   5. workspace / project-tree files are NOT copied (non-portable).
-#   6. secrets are NOT in the bundle (Teams secret, A2A key).
-#   7. verify PASSES on the migrated target.
-#   8. apply writes .migrator-apply-result.json with correct agent list.
+#   3. secrets are NOT in the bundle (Teams secret, A2A key).
+#   4. workspace / project-tree files are NOT in the bundle (non-portable).
+#   5. apply default invocation is REFUSED (beta7 deferral message).
+#   6. deferred apply does NOT mutate the target (no apply-result manifest,
+#      no target/agents/ created).
 
 set -euo pipefail
 
@@ -149,81 +154,38 @@ smoke_assert_contains "$plan_out" "clean/fresh" "plan detects clean target"
 smoke_log "assertion: plan output correct — PASS"
 
 # ---------------------------------------------------------------------------
-# 3. apply REFUSES non-empty target
+# 3. apply is deferred to beta7 — confirm default invocation refuses to run.
 # ---------------------------------------------------------------------------
-smoke_log "testing apply refuses dirty target"
-mkdir -p "$DIRTY_TARGET/state/agents/admin"
-printf '{}' >"$DIRTY_TARGET/state/tasks.db"
-set +e
-apply_refuse_out="$(bash "$MIGRATOR" apply --bundle "$BUNDLE_DIR" --target "$DIRTY_TARGET" 2>&1)"
-apply_refuse_rc=$?
-set -e
-if [[ "$apply_refuse_rc" -eq 0 ]]; then
-  smoke_fail "apply must refuse a non-empty target (returned 0 on dirty target)"
-fi
-smoke_assert_contains "$apply_refuse_out" "not clean" "apply refuse message mentions not clean"
-smoke_log "assertion: apply refused dirty target — PASS"
-
-# ---------------------------------------------------------------------------
-# 4. apply to clean target
-# ---------------------------------------------------------------------------
-smoke_log "running apply to clean target"
+# beta6 fold-back per codex r1 review: apply has three open contract gaps
+# (clean-target gate insufficient, layout-resolver bypass, supplied secrets
+# never written) and is gated behind BRIDGE_MIGRATOR_BETA6_APPLY_UNSAFE=1
+# for follow-up dev only. The user-facing default refuses with a clear
+# message. Verify regression (post-apply) moves to beta7 alongside the
+# apply rework.
+smoke_log "testing apply default invocation is deferred (beta7 contract gate)"
 rm -rf "$CLEAN_TARGET"
 mkdir -p "$CLEAN_TARGET"
-bash "$MIGRATOR" apply --bundle "$BUNDLE_DIR" --target "$CLEAN_TARGET"
-
-# Verify apply result manifest exists.
-smoke_assert_file_exists "$CLEAN_TARGET/.migrator-apply-result.json" "apply-result manifest"
-
-# Check applied_agents list in result.
-applied_agents="$(python3 "$HELPER_DIR/migrator-smoke-helpers.py" apply-result-agents "$CLEAN_TARGET/.migrator-apply-result.json")"
-smoke_assert_contains "$applied_agents" "admin" "apply result lists admin agent"
-smoke_assert_contains "$applied_agents" "reviewer" "apply result lists reviewer agent"
-smoke_log "assertion: apply result applied_agents correct — PASS"
-
-# Identity files land in legacy-layout agent homes (legacy source → legacy target).
-smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/SOUL.md" "admin SOUL.md in target agent home"
-smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/MEMORY.md" "admin MEMORY.md in target agent home"
-smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/memory/notes.md" "admin memory/notes.md in target"
-smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/users/alice/USER.md" "admin users/alice/USER.md in target"
-smoke_assert_file_exists "$CLEAN_TARGET/agents/reviewer/SOUL.md" "reviewer SOUL.md in target"
-smoke_log "assertion: identity files in correct agent_home paths — PASS"
-
-# Non-portable files must NOT be in target.
-if [[ -f "$CLEAN_TARGET/agents/admin/session_id" ]]; then
-  smoke_fail "session_id must not be in applied target (non-portable)"
+set +e
+apply_deferred_out="$(bash "$MIGRATOR" apply --bundle "$BUNDLE_DIR" --target "$CLEAN_TARGET" 2>&1)"
+apply_deferred_rc=$?
+set -e
+if [[ "$apply_deferred_rc" -eq 0 ]]; then
+  smoke_fail "apply default invocation must refuse (beta7 deferral); rc=0 instead"
 fi
-if [[ -f "$CLEAN_TARGET/agents/admin/pid" ]]; then
-  smoke_fail "pid must not be in applied target (non-portable)"
-fi
-smoke_log "assertion: non-portable files absent from target — PASS"
+smoke_assert_contains "$apply_deferred_out" "deferred to beta7" \
+  "apply refusal mentions beta7 deferral"
+# Confirm the unsafe env var is the documented dev escape hatch.
+smoke_assert_contains "$apply_deferred_out" "BRIDGE_MIGRATOR_BETA6_APPLY_UNSAFE" \
+  "apply refusal documents the dev opt-in env var"
+smoke_log "assertion: apply deferred to beta7 (default invocation refused) — PASS"
 
-# Secrets must NOT be in target.
-if [[ -f "$CLEAN_TARGET/handoff.local.json" ]]; then
-  smoke_fail "handoff.local.json (A2A secret) must not be in applied target"
+# Confirm the target was NOT mutated by the deferred apply.
+if [[ -f "$CLEAN_TARGET/.migrator-apply-result.json" ]]; then
+  smoke_fail "deferred apply must not write any apply-result manifest"
 fi
-if [[ -f "$CLEAN_TARGET/.env" ]]; then
-  smoke_fail ".env (Teams secret) must not be in applied target"
+if [[ -d "$CLEAN_TARGET/agents" ]]; then
+  smoke_fail "deferred apply must not create target/agents/"
 fi
-smoke_log "assertion: secrets absent from applied target — PASS"
-
-# Cron definitions imported.
-smoke_assert_file_exists "$CLEAN_TARGET/cron/jobs.json" "cron jobs.json in target"
-cron_target_count="$(python3 "$HELPER_DIR/migrator-smoke-helpers.py" cron-job-count "$CLEAN_TARGET/cron/jobs.json")"
-if [[ "$cron_target_count" -lt 1 ]]; then
-  smoke_fail "cron jobs.json in target should have >=1 entry, got $cron_target_count"
-fi
-smoke_log "assertion: cron definitions in target count=$cron_target_count — PASS"
-
-# ---------------------------------------------------------------------------
-# 5. verify
-# ---------------------------------------------------------------------------
-smoke_log "running verify on migrated target"
-verify_out="$(bash "$MIGRATOR" verify --target "$CLEAN_TARGET")"
-smoke_assert_contains "$verify_out" "PASS" "verify reports PASSes"
-if echo "$verify_out" | grep -q "FAIL"; then
-  smoke_fail "verify reported FAIL on correctly migrated target"
-fi
-smoke_log "assertion: verify PASS — PASS"
+smoke_log "assertion: deferred apply did NOT mutate target — PASS"
 
 smoke_log "all assertions passed"

--- a/scripts/smoke/legacy-install-migrator.sh
+++ b/scripts/smoke/legacy-install-migrator.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# scripts/smoke/legacy-install-migrator.sh — release-gate smoke #4
+#
+# Synthetic legacy-install repro for scripts/migrate-legacy-install.sh.
+#
+# Builds a fake old-style install (two agents + cron + memory + channel config),
+# then runs: export → plan → apply-to-clean → verify.
+#
+# Assertions:
+#   1. export writes a manifest + agent identity files to bundle dir.
+#   2. plan prints apply plan and target-cleanliness check without error.
+#   3. apply REFUSES a non-empty target (safety gate).
+#   4. apply SUCCEEDS into a clean target; identity lands in agent_home.
+#   5. workspace / project-tree files are NOT copied (non-portable).
+#   6. secrets are NOT in the bundle (Teams secret, A2A key).
+#   7. verify PASSES on the migrated target.
+#   8. apply writes .migrator-apply-result.json with correct agent list.
+
+set -euo pipefail
+
+SMOKE_NAME="legacy-install-migrator"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+MIGRATOR="$SMOKE_REPO_ROOT/scripts/migrate-legacy-install.sh"
+HELPER_DIR="$SMOKE_REPO_ROOT/scripts/python-helpers"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+OLD_HOME="$SMOKE_TMP_ROOT/old-bridge-home"
+BUNDLE_DIR="$SMOKE_TMP_ROOT/bundle"
+CLEAN_TARGET="$SMOKE_TMP_ROOT/clean-bridge-home"
+DIRTY_TARGET="$SMOKE_TMP_ROOT/dirty-bridge-home"
+
+# ---------------------------------------------------------------------------
+# Build synthetic legacy install
+# ---------------------------------------------------------------------------
+smoke_log "building synthetic legacy install at $OLD_HOME"
+
+mkdir -p \
+  "$OLD_HOME/state" \
+  "$OLD_HOME/logs" \
+  "$OLD_HOME/agents/admin/memory" \
+  "$OLD_HOME/agents/admin/users/alice" \
+  "$OLD_HOME/agents/reviewer" \
+  "$OLD_HOME/cron"
+
+# Layout marker (v2 not set → legacy layout)
+printf 'BRIDGE_LAYOUT=legacy\n' >"$OLD_HOME/state/layout-marker.sh"
+
+# Agent 1: admin — with identity files, memory, users
+printf '# Admin soul\n' >"$OLD_HOME/agents/admin/SOUL.md"
+printf '# Admin memory\n' >"$OLD_HOME/agents/admin/MEMORY.md"
+printf 'session-type: admin\n' >"$OLD_HOME/agents/admin/SESSION-TYPE.md"
+printf '# Admin memory note\n' >"$OLD_HOME/agents/admin/memory/notes.md"
+printf '# Alice USER\n' >"$OLD_HOME/agents/admin/users/alice/USER.md"
+
+# Non-portable file that must NOT be copied.
+printf 'tmux-session-123\n' >"$OLD_HOME/agents/admin/session_id"
+printf '12345\n' >"$OLD_HOME/agents/admin/pid"
+
+# Agent 2: reviewer — minimal
+printf '# Reviewer soul\n' >"$OLD_HOME/agents/reviewer/SOUL.md"
+
+# Cron definitions (portable, no secrets).
+printf '[{"name":"daily-note","target":"admin","schedule":"0 8 * * *","timezone":"UTC","payload_kind":"text","payload":{"text":"daily note"},"enabled":true}]\n' \
+  >"$OLD_HOME/cron/jobs.json"
+
+# Host profile.
+printf '{"os":"linux","sudo_available":true,"bridge_version":"0.14.0"}\n' \
+  >"$OLD_HOME/state/host-profile.json"
+
+# Secret files — must NOT appear in bundle.
+printf '{"bridge_id":"old-bridge","peers":[],"hmac_secret":"TOPSECRET"}\n' \
+  >"$OLD_HOME/handoff.local.json"
+printf 'TEAMS_APP_PASSWORD=super-secret-pass\n' >"$OLD_HOME/.env"
+
+# Roster files (minimal).
+printf '' >"$OLD_HOME/agent-roster.sh"
+printf 'BRIDGE_AGENT_DESC["admin"]="Main admin agent"\n' >"$OLD_HOME/agent-roster.local.sh"
+printf 'BRIDGE_AGENT_ENGINE["admin"]="claude"\n' >>"$OLD_HOME/agent-roster.local.sh"
+
+smoke_log "synthetic legacy install ready"
+
+# ---------------------------------------------------------------------------
+# 1. export
+# ---------------------------------------------------------------------------
+smoke_log "running export"
+bash "$MIGRATOR" export --source "$OLD_HOME" --bundle "$BUNDLE_DIR"
+
+smoke_assert_file_exists "$BUNDLE_DIR/manifest.json" "manifest written by export"
+smoke_assert_file_exists "$BUNDLE_DIR/agents/admin/SOUL.md" "admin SOUL.md in bundle"
+smoke_assert_file_exists "$BUNDLE_DIR/agents/admin/MEMORY.md" "admin MEMORY.md in bundle"
+smoke_assert_file_exists "$BUNDLE_DIR/agents/admin/SESSION-TYPE.md" "admin SESSION-TYPE.md in bundle"
+smoke_assert_file_exists "$BUNDLE_DIR/agents/admin/memory/notes.md" "admin memory/notes.md in bundle"
+smoke_assert_file_exists "$BUNDLE_DIR/agents/admin/users/alice/USER.md" "admin users/alice/USER.md in bundle"
+smoke_assert_file_exists "$BUNDLE_DIR/agents/reviewer/SOUL.md" "reviewer SOUL.md in bundle"
+smoke_log "assertion: identity files present in bundle — PASS"
+
+# Non-portable files must NOT be in bundle.
+if [[ -f "$BUNDLE_DIR/agents/admin/session_id" ]]; then
+  smoke_fail "session_id must not be in bundle (non-portable)"
+fi
+if [[ -f "$BUNDLE_DIR/agents/admin/pid" ]]; then
+  smoke_fail "pid must not be in bundle (non-portable)"
+fi
+smoke_log "assertion: non-portable files absent from bundle — PASS"
+
+# Secrets must NOT be in bundle.
+if [[ -f "$BUNDLE_DIR/handoff.local.json" ]]; then
+  smoke_fail "handoff.local.json (A2A secret) must not be in bundle"
+fi
+if [[ -f "$BUNDLE_DIR/.env" ]]; then
+  smoke_fail ".env (Teams secret) must not be in bundle"
+fi
+smoke_log "assertion: secret files absent from bundle — PASS"
+
+# Verify manifest lists agents.
+agent_count="$(python3 "$HELPER_DIR/migrator-smoke-helpers.py" manifest-agent-count "$BUNDLE_DIR/manifest.json")"
+if [[ "$agent_count" -lt 2 ]]; then
+  smoke_fail "manifest should list >=2 agents, got $agent_count"
+fi
+smoke_log "assertion: manifest agent count=$agent_count — PASS"
+
+# Verify cron definitions exported.
+cron_count="$(python3 "$HELPER_DIR/migrator-smoke-helpers.py" manifest-cron-count "$BUNDLE_DIR/manifest.json")"
+if [[ "$cron_count" -lt 1 ]]; then
+  smoke_fail "manifest should list >=1 cron job, got $cron_count"
+fi
+smoke_log "assertion: cron count=$cron_count — PASS"
+
+# ---------------------------------------------------------------------------
+# 2. plan
+# ---------------------------------------------------------------------------
+smoke_log "running plan"
+mkdir -p "$CLEAN_TARGET/state"
+# Fresh target — no layout marker yet, no agents.
+plan_out="$(bash "$MIGRATOR" plan --bundle "$BUNDLE_DIR" --target "$CLEAN_TARGET")"
+smoke_assert_contains "$plan_out" "admin" "plan output lists admin agent"
+smoke_assert_contains "$plan_out" "reviewer" "plan output lists reviewer agent"
+smoke_assert_contains "$plan_out" "daily-note" "plan output lists cron job"
+smoke_assert_contains "$plan_out" "clean/fresh" "plan detects clean target"
+smoke_log "assertion: plan output correct — PASS"
+
+# ---------------------------------------------------------------------------
+# 3. apply REFUSES non-empty target
+# ---------------------------------------------------------------------------
+smoke_log "testing apply refuses dirty target"
+mkdir -p "$DIRTY_TARGET/state/agents/admin"
+printf '{}' >"$DIRTY_TARGET/state/tasks.db"
+set +e
+apply_refuse_out="$(bash "$MIGRATOR" apply --bundle "$BUNDLE_DIR" --target "$DIRTY_TARGET" 2>&1)"
+apply_refuse_rc=$?
+set -e
+if [[ "$apply_refuse_rc" -eq 0 ]]; then
+  smoke_fail "apply must refuse a non-empty target (returned 0 on dirty target)"
+fi
+smoke_assert_contains "$apply_refuse_out" "not clean" "apply refuse message mentions not clean"
+smoke_log "assertion: apply refused dirty target — PASS"
+
+# ---------------------------------------------------------------------------
+# 4. apply to clean target
+# ---------------------------------------------------------------------------
+smoke_log "running apply to clean target"
+rm -rf "$CLEAN_TARGET"
+mkdir -p "$CLEAN_TARGET"
+bash "$MIGRATOR" apply --bundle "$BUNDLE_DIR" --target "$CLEAN_TARGET"
+
+# Verify apply result manifest exists.
+smoke_assert_file_exists "$CLEAN_TARGET/.migrator-apply-result.json" "apply-result manifest"
+
+# Check applied_agents list in result.
+applied_agents="$(python3 "$HELPER_DIR/migrator-smoke-helpers.py" apply-result-agents "$CLEAN_TARGET/.migrator-apply-result.json")"
+smoke_assert_contains "$applied_agents" "admin" "apply result lists admin agent"
+smoke_assert_contains "$applied_agents" "reviewer" "apply result lists reviewer agent"
+smoke_log "assertion: apply result applied_agents correct — PASS"
+
+# Identity files land in legacy-layout agent homes (legacy source → legacy target).
+smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/SOUL.md" "admin SOUL.md in target agent home"
+smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/MEMORY.md" "admin MEMORY.md in target agent home"
+smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/memory/notes.md" "admin memory/notes.md in target"
+smoke_assert_file_exists "$CLEAN_TARGET/agents/admin/users/alice/USER.md" "admin users/alice/USER.md in target"
+smoke_assert_file_exists "$CLEAN_TARGET/agents/reviewer/SOUL.md" "reviewer SOUL.md in target"
+smoke_log "assertion: identity files in correct agent_home paths — PASS"
+
+# Non-portable files must NOT be in target.
+if [[ -f "$CLEAN_TARGET/agents/admin/session_id" ]]; then
+  smoke_fail "session_id must not be in applied target (non-portable)"
+fi
+if [[ -f "$CLEAN_TARGET/agents/admin/pid" ]]; then
+  smoke_fail "pid must not be in applied target (non-portable)"
+fi
+smoke_log "assertion: non-portable files absent from target — PASS"
+
+# Secrets must NOT be in target.
+if [[ -f "$CLEAN_TARGET/handoff.local.json" ]]; then
+  smoke_fail "handoff.local.json (A2A secret) must not be in applied target"
+fi
+if [[ -f "$CLEAN_TARGET/.env" ]]; then
+  smoke_fail ".env (Teams secret) must not be in applied target"
+fi
+smoke_log "assertion: secrets absent from applied target — PASS"
+
+# Cron definitions imported.
+smoke_assert_file_exists "$CLEAN_TARGET/cron/jobs.json" "cron jobs.json in target"
+cron_target_count="$(python3 "$HELPER_DIR/migrator-smoke-helpers.py" cron-job-count "$CLEAN_TARGET/cron/jobs.json")"
+if [[ "$cron_target_count" -lt 1 ]]; then
+  smoke_fail "cron jobs.json in target should have >=1 entry, got $cron_target_count"
+fi
+smoke_log "assertion: cron definitions in target count=$cron_target_count — PASS"
+
+# ---------------------------------------------------------------------------
+# 5. verify
+# ---------------------------------------------------------------------------
+smoke_log "running verify on migrated target"
+verify_out="$(bash "$MIGRATOR" verify --target "$CLEAN_TARGET")"
+smoke_assert_contains "$verify_out" "PASS" "verify reports PASSes"
+if echo "$verify_out" | grep -q "FAIL"; then
+  smoke_fail "verify reported FAIL on correctly migrated target"
+fi
+smoke_log "assertion: verify PASS — PASS"
+
+smoke_log "all assertions passed"


### PR DESCRIPTION
## Summary

- Adds `scripts/migrate-legacy-install.sh` + `scripts/python-helpers/migrate-legacy-install-helper.py` as a fully **standalone** migrator — never called from bridge-upgrade.sh / bridge-init.sh / bridge-bootstrap.sh.
- Implements `export → plan → apply → verify` contract; never mutates the source in-place.
- `apply` ships with **all beta6 safety gates satisfied** (not deferred to beta7).
- Adds release-gate smoke #4: `scripts/smoke/legacy-install-migrator.sh` — registered in `scripts/ci-select-smoke.sh`.

## Subcommands shipped

| Subcommand | Status |
|---|---|
| `export` | ✓ shipped |
| `plan` | ✓ shipped |
| `apply` | ✓ shipped (all safety gates satisfied) |
| `verify` | ✓ shipped |

**apply is NOT deferred.** All five safety gates are enforced:
1. explicit / off-by-default (must invoke `apply` subcommand)
2. target must be clean/fresh — REFUSES with clear error on non-empty target
3. mandatory backup + manifest before any mutation
4. secrets (Teams client secret, A2A HMAC keys) never copied — re-enter via file/env/stdin
5. never wired into upgrade/init/bootstrap flows

## Classification

- **portable**: roster intent, per-agent identity (SOUL/MEMORY/SESSION-TYPE/etc.), cron definitions, non-secret channel config, host-profile
- **non-portable**: tmux sessions, pid files, queue leases, daemon state, generated hooks/settings, plugin caches, logs, worktrees, backups
- **secret**: Teams client secret, A2A HMAC keys — re-entered at apply, never carried in bundle

## Safety gate evidence

```
[migrator][error] target is not clean/fresh — apply refused.
  blocking paths: state/agents, state/tasks.db
```
→ apply refuses non-empty target (gate #2 confirmed).

Secrets in source (`handoff.local.json`, `.env`) produce warnings:
```
[migrator][warn] secrets present in source — NOT included in bundle (re-enter at apply):
[migrator][warn]   .env
[migrator][warn]   handoff.local.json
```
Neither file appears in the bundle or applied target.

## Synthetic legacy-install repro (release-gate smoke #4)

Built a fake old-style install: 2 agents (admin + reviewer) + cron + memory + users + channel config + secret files.

```
export  → plan  → apply-to-dirty-target (REFUSED) → apply-to-clean-target → verify
```

All 8 assertions PASS:
1. identity files present in bundle (SOUL.md, MEMORY.md, memory/notes.md, users/alice/USER.md)
2. non-portable files absent from bundle (session_id, pid)
3. secret files absent from bundle (handoff.local.json, .env)
4. manifest agent count = 2
5. cron count = 1
6. apply REFUSES dirty target
7. apply succeeds into clean target; identity in `agents/admin/` (legacy layout)
8. verify PASS — all checks passed

## Verification matrix

| Check | Result |
|---|---|
| `bash -n` on all new .sh files | PASS |
| `shellcheck` on all new .sh files | PASS |
| `python3 -m py_compile` on .py files | PASS |
| `lint-heredoc-ban.sh --baseline-check` | PASS (SAFE count +1 for usage text `cat <<'USAGE'`, C1/C2/C3/H3 unchanged) |
| `scripts/smoke/legacy-install-migrator.sh` | PASS (8/8 assertions) |
| `scripts/smoke-test.sh` | pre-existing failures only (bridge-daemon.sh octal "08" + creating queue task) |

No heredoc-to-subprocess patterns introduced. The inline `python3 - ... <<"PYEOF"` patterns initially in the smoke were replaced with file-as-argv (`migrator-smoke-helpers.py`) before commit (footgun #11 self-audit).

## Files changed

- `scripts/migrate-legacy-install.sh` (+78) — thin shell dispatcher, footgun #11 safe, no heredoc-to-subprocess
- `scripts/python-helpers/migrate-legacy-install-helper.py` (+439) — export/plan/apply/verify implementation
- `scripts/python-helpers/migrator-smoke-helpers.py` (+62) — file-as-argv helpers for smoke (no heredoc-stdin)
- `scripts/smoke/legacy-install-migrator.sh` (+240) — release-gate smoke #4
- `scripts/ci-select-smoke.sh` (+13/-1) — register smoke in required suite + path-specific trigger

## Review focus points for codex pair-review

1. **apply safety gates** — verify all 5 gates are enforced and not bypassable
2. **secret classification** — confirm `handoff.local.json`, `.env`, `SECRET_FILE_NAMES` set is complete; no secret path can slip into bundle or applied target
3. **non-portable classification** — `NON_PORTABLE_NAMES`, `NON_PORTABLE_EXTENSIONS`, `NON_PORTABLE_SUBDIRS` — anything missing that could cause a pid/session file to be applied?
4. **cron payload secret-strip** — env key heuristic (TOKEN/SECRET/PASSWORD/KEY/PASS in upper) — false-negative risk for custom key names
5. **clean-target detection** — `CLEAN_TARGET_REQUIRED_ABSENT` tuple — sufficient to detect a populated target?
6. **heredoc / footgun #11** — confirm no `python3 - ... <<` / `bash -s ... <<` / `<<<` in any added line

🤖 Generated with [Claude Code](https://claude.ai/claude-code)