### PR TITLE
feat(provisioning): descriptor-driven Codex static agent provisioning (#1067)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -130,6 +130,12 @@ bridge_agent_manage_python() {
   python3 - "$@"
 }
 
+# bridge_scaffold_codex_entrypoint and bridge_ensure_codex_agent_hooks are
+# defined in lib/bridge-agents.sh and lib/bridge-hooks.sh respectively,
+# which bridge-lib.sh sources before this script runs. They are available
+# to smoke drivers via bridge-lib.sh without sourcing bridge-agent.sh.
+# See issue #1067 (S03, S08) for the contract.
+
 # bridge_ensure_memory_precompact_hook — wire the Plan-D PreCompact hook
 # into an agent's .claude/settings.json. Safe to call repeatedly; the
 # bridge-hooks.py helper already short-circuits when the hook is present.
@@ -2806,6 +2812,14 @@ report and reap test-fixture agents per their pattern."
     # in-roster lookup inside scaffold would short-circuit the sudo path
     # — see the comment on `bridge_scaffold_agent_home`'s signature.
     bridge_scaffold_agent_home "$agent" "$scaffold_target" "$display_name" "$role_text" "$engine" "$session_type" "$isolation_mode" "$os_user"
+    # Issue #1067 S03: create the engine-native instruction-file entrypoint
+    # in the identity source. The template scaffold loop places CLAUDE.md for
+    # every engine; for Codex (entrypoint=AGENTS.md) this step copies that
+    # payload to AGENTS.md so the Codex runtime finds its role contract under
+    # the canonical filename. bridge_layout_materialize_identity (below) then
+    # delivers AGENTS.md into the workspace. No-op for Claude (entrypoint is
+    # already CLAUDE.md).
+    bridge_scaffold_codex_entrypoint "$scaffold_target" "$engine" 2>/dev/null || true
     # Per-user partitions (`users/<id>/USER.md`) are per-agent identity,
     # so they are scaffolded into the IDENTITY SOURCE alongside the rest
     # of the authored identity — the `users/` skeleton template lands
@@ -2846,6 +2860,16 @@ report and reap test-fixture agents per their pattern."
       # Plan-D memory stack: ensure PreCompact hook at scaffold time so new
       # agents come up fully wired without a separate bootstrap pass.
       bridge_ensure_memory_precompact_hook "$agent" "$workdir" >/dev/null 2>&1 || true
+    fi
+    # Issue #1067 S08: render + verify the Codex hook surface for codex-engine
+    # agents. The descriptor-owned path is <agent_home>/.codex/hooks.json —
+    # NOT the shared $HOME/.codex/hooks.json. scaffold_target is the resolved
+    # identity source (bridge_layout_agent_home on v2). bridge_engine_render_
+    # hooks_on_create returns true for codex, so we gate on engine == "codex"
+    # to stay forward-compatible without branching on the descriptor (which
+    # the descriptor owns for future engines).
+    if [[ "$engine" == "codex" ]]; then
+      bridge_ensure_codex_agent_hooks "$agent" "$scaffold_target" >/dev/null 2>&1 || true
     fi
     bridge_write_role_block \
       "$agent" \

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -404,6 +404,24 @@ bridge_upgrade_propagate_claude_shared_settings() {
     "$BRIDGE_BASH_BIN" "$target_root/bridge-agent.sh" rerender-settings --apply --json
 }
 
+# bridge_upgrade_propagate_codex_hooks <target_root>
+#
+# Issue #1067 S08: re-render Codex hooks for every codex-engine agent during
+# upgrade. Mirrors bridge_upgrade_propagate_claude_hooks but for the Codex
+# hook surface. Writes to the descriptor-owned per-agent path
+# (<agent_home>/.codex/hooks.json), not the shared $HOME/.codex/hooks.json.
+#
+# The body lives in lib/upgrade-helpers/codex-hooks-propagate.sh (file-as-
+# argv pattern) to avoid the Bash 5.3.9 heredoc-stdin deadlock (footgun #11).
+# No-op when no codex-engine agents are registered.
+bridge_upgrade_propagate_codex_hooks() {
+  local target_root="$1"
+  local _helper="$SOURCE_ROOT/lib/upgrade-helpers/codex-hooks-propagate.sh"
+  [[ -f "$_helper" ]] || return 0
+  bridge_upgrade_with_target_env "$target_root" \
+    "$BRIDGE_BASH_BIN" "$_helper" "$SOURCE_ROOT" "$target_root" >/dev/null 2>&1 || true
+}
+
 bridge_upgrade_collect_agent_restart_report() {
   local target_root="$1"
   local dry_run="${2:-0}"
@@ -1719,6 +1737,15 @@ PY
     _upgrade_partial_failures+=("shared_rerender")
   fi
   rm -rf "$_shared_rerender_verify_dir"
+fi
+
+# Issue #1067 S08: propagate Codex hooks to every codex-engine agent.
+# Runs after Claude shared-settings rerender so the two hook-surface
+# propagations stay in the same upgrade phase. Non-fatal: a missing
+# codex agent home or hooks.py error produces a WARN but does not abort
+# the upgrade (same posture as bridge_upgrade_propagate_claude_hooks).
+if [[ $DRY_RUN -eq 0 ]]; then
+  bridge_upgrade_propagate_codex_hooks "$TARGET_ROOT" 2>/dev/null || true
 fi
 
 # v0.7.0 → v0.7.1 transition cleanup. Idempotent best-effort removal of

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -7616,3 +7616,33 @@ bridge_upsert_env_value() {
   fi
   mv "$tmp_file" "$env_file"
 }
+
+# bridge_scaffold_codex_entrypoint <home> <engine>
+#
+# Issue #1067 S03: write AGENTS.md as the engine-native entrypoint for a
+# Codex agent into its identity source (agent_home). The template scaffold
+# loop places CLAUDE.md for every engine (the template only has CLAUDE.md);
+# for Codex the native instruction-file convention is AGENTS.md. This
+# function creates AGENTS.md as a copy of CLAUDE.md in the same directory
+# so the Codex runtime finds its role contract under the canonical filename,
+# and bridge_layout_materialize_identity then delivers AGENTS.md into the
+# workspace (the descriptor already lists the engine entrypoint in its copy
+# set). Safe to call for any engine — it is a no-op when the descriptor
+# entrypoint is CLAUDE.md (i.e., not Codex).
+#
+# Called from bridge-agent.sh (post-scaffold, before materialize) and
+# available from lib so smoke drivers sourcing bridge-lib.sh can assert
+# the S03 contract without sourcing the full bridge-agent.sh script.
+bridge_scaffold_codex_entrypoint() {
+  local home="$1"
+  local engine="$2"
+  [[ -n "$home" && -n "$engine" ]] || return 0
+  local entrypoint=""
+  if declare -F bridge_engine_entrypoint_filename >/dev/null 2>&1; then
+    entrypoint="$(bridge_engine_entrypoint_filename "$engine" 2>/dev/null || printf '')"
+  fi
+  [[ -n "$entrypoint" && "$entrypoint" != "CLAUDE.md" ]] || return 0
+  [[ -f "$home/CLAUDE.md" ]] || return 0
+  [[ -f "$home/$entrypoint" ]] && return 0
+  cp -f "$home/CLAUDE.md" "$home/$entrypoint" 2>/dev/null || true
+}

--- a/lib/bridge-hooks.sh
+++ b/lib/bridge-hooks.sh
@@ -583,3 +583,40 @@ bridge_codex_hooks_status() {
 bridge_ensure_codex_hooks() {
   bridge_hooks_python ensure-codex-hooks --codex-hooks-file "$(bridge_codex_hooks_file)" --bridge-home "$BRIDGE_HOME" --python-bin "$(command -v python3)"
 }
+
+# bridge_ensure_codex_agent_hooks <agent> <agent_home>
+#
+# Issue #1067 S08: render + verify the Codex hook surface for a single
+# agent at the descriptor-owned path (<agent_home>/.codex/hooks.json).
+# bridge-hooks.py:ensure-codex-hooks is idempotent — already-present
+# entries are left in place. Safe to call on upgrade (the descriptor path
+# is stable and per-agent, not the shared $HOME/.codex/hooks.json).
+#
+# The hook config path is <agent_home>/.codex/hooks.json — matching the
+# descriptor's contract for the codex engine (`bridge_engine_hook_config_path
+# <agent> codex` returns `<agent_home>/.codex/hooks.json`). The caller
+# passes the already-resolved agent_home directly so this function works
+# correctly even when the agent is not yet in the roster (create flow),
+# without re-invoking the descriptor's roster-dependent resolver.
+#
+# Called from bridge-agent.sh (codex engine create path) and
+# lib/upgrade-helpers/codex-hooks-propagate.sh (upgrade path). Exported
+# from lib so smoke drivers sourcing bridge-lib.sh can assert S08 directly.
+bridge_ensure_codex_agent_hooks() {
+  local agent="$1"
+  local agent_home="$2"
+  [[ -n "$agent" && -n "$agent_home" ]] || return 0
+  # Descriptor contract: codex hook config is <agent_home>/.codex/hooks.json.
+  # Use the caller-provided agent_home directly rather than re-resolving via
+  # bridge_engine_hook_config_path — the resolver calls bridge_layout_agent_home
+  # which depends on the roster being loaded, but at create time the agent is
+  # not yet registered. The result is identical to the descriptor's resolution
+  # for a registered agent on a v2 install.
+  local hook_config_path="$agent_home/.codex/hooks.json"
+  mkdir -p "$(dirname "$hook_config_path")" 2>/dev/null || return 0
+  bridge_hooks_python ensure-codex-hooks \
+    --codex-hooks-file "$hook_config_path" \
+    --bridge-home "${BRIDGE_HOME:-$BRIDGE_SCRIPT_DIR}" \
+    --python-bin "$(command -v python3 || printf '/usr/bin/python3')" \
+    >/dev/null 2>&1 || true
+}

--- a/lib/upgrade-helpers/codex-hooks-propagate.sh
+++ b/lib/upgrade-helpers/codex-hooks-propagate.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# codex-hooks-propagate.sh — re-render Codex hooks for every codex-engine
+# static agent during an upgrade run. Invoked by bridge-upgrade.sh via
+# bridge_upgrade_with_target_env so it runs inside the target runtime env.
+#
+# Invocation contract:
+#   $1 = source_root  (the agent-bridge source checkout)
+#   $2 = target_root  (the live install root being upgraded)
+#
+# Output: one line per agent indicating the hook render result.
+#
+# Footgun #11: this body lives as a standalone file so bridge-upgrade.sh can
+# invoke it with file-as-argv — no heredoc-stdin / here-string anywhere on
+# this path. Follows the same pattern as lib/upgrade-helpers/isolation-v2-migrate.sh.
+#
+# Issue #1067 (S08): static Codex agents previously had no Codex hook render
+# step on upgrade — only Claude agents were covered by
+# bridge_upgrade_propagate_claude_hooks. This helper closes the gap by
+# iterating every codex-engine agent and calling `bridge-hooks.py
+# ensure-codex-hooks` with the descriptor-owned per-agent hook config path
+# (`<agent_home>/.codex/hooks.json`), not the legacy shared `$HOME/.codex/hooks.json`.
+# shellcheck shell=bash
+set -euo pipefail
+
+source_root="$1"
+target_root="$2"
+
+# shellcheck source=/dev/null
+source "$source_root/bridge-lib.sh"
+bridge_load_roster
+
+python_bin="$(command -v python3 || printf '/usr/bin/python3')"
+
+for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+  [[ "$(bridge_agent_engine "$agent" 2>/dev/null || printf '')" == "codex" ]] || continue
+  # Resolve the per-agent identity home (layer 2: the authored identity source).
+  # bridge_layout_agent_home wraps bridge_agent_default_home — on a v2 install
+  # this is $BRIDGE_AGENT_ROOT_V2/<agent>/home; on legacy it is
+  # $BRIDGE_AGENT_HOME_ROOT/<agent>.
+  agent_home=""
+  if declare -F bridge_layout_agent_home >/dev/null 2>&1; then
+    agent_home="$(bridge_layout_agent_home "$agent" 2>/dev/null || printf '')"
+  else
+    agent_home="$(bridge_agent_default_home "$agent" 2>/dev/null || printf '')"
+  fi
+  [[ -n "$agent_home" ]] || continue
+
+  # Descriptor-owned hook config path: <agent_home>/.codex/hooks.json
+  hook_config_path=""
+  if declare -F bridge_engine_hook_config_path >/dev/null 2>&1; then
+    hook_config_path="$(bridge_engine_hook_config_path "$agent" codex 2>/dev/null || printf '')"
+  else
+    hook_config_path="$agent_home/.codex/hooks.json"
+  fi
+  [[ -n "$hook_config_path" ]] || continue
+
+  mkdir -p "$(dirname "$hook_config_path")" 2>/dev/null || continue
+  rc=0
+  "$python_bin" "$source_root/bridge-hooks.py" ensure-codex-hooks \
+    --codex-hooks-file "$hook_config_path" \
+    --bridge-home "$target_root" \
+    --python-bin "$python_bin" \
+    >/dev/null 2>&1 || rc=$?
+  if [[ $rc -eq 0 ]]; then
+    printf 'codex-hooks-propagate: agent=%s hook_config=%s status=ok\n' "$agent" "$hook_config_path"
+  else
+    printf 'codex-hooks-propagate: agent=%s hook_config=%s status=error(rc=%d)\n' "$agent" "$hook_config_path" "$rc" >&2
+  fi
+done

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir isolated-agent-delete-reap nudge-task-age-gate tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1067-codex-provisioning
 }
 
 add_all_integration() {
@@ -183,7 +183,7 @@ select_for_path() {
       # is_docs_only_path early-return below would otherwise select only
       # the global required smokes. This case precedes that return so a
       # template-text drift still pulls the #1060 layout smokes.
-      add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair
+      add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning
       ;;
   esac
 
@@ -316,7 +316,7 @@ select_for_path() {
       # three-layer agent-layout smokes whenever bridge-agent.sh or
       # bridge-start.sh moves so a future PR cannot regress the D1
       # scaffold-then-materialize inversion back to the empty-sibling bug.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1028-isolated-workdir-check v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-update agent-update-launch-cmd-redaction agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1028-isolated-workdir-check v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -466,7 +466,7 @@ select_for_path() {
       # tool-policy's `is_admin_agent`. The admin-hook-exemption smoke
       # covers both the prompt-guard branch and the tool-policy
       # credential-deny exemption.
-      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys admin-hook-exemption
+      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys admin-hook-exemption 1067-codex-provisioning
       add_integration integration-minimal
       ;;
 
@@ -500,7 +500,7 @@ select_for_path() {
       # marker-only fast-path. Pull the regression smoke (T3 specifically
       # asserts the env-propagation contract — fast-path NOT fired when
       # BRIDGE_UPGRADE_CONTEXT is unset) whenever the upgrade entry moves.
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate 1067-codex-provisioning
       add_integration integration-minimal
       ;;
 
@@ -633,7 +633,7 @@ select_for_path() {
       # resolver / descriptor / memory-default out of agreement. (The D3
       # template .md files are dispatched in the pre-docs-return case
       # above.)
-      add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair v2-scaffold-home-and-workdir agent-doctor
+      add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning v2-scaffold-home-and-workdir agent-doctor
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
+++ b/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
@@ -79,10 +79,12 @@ write_driver() {
     'SCRIPT_DIR="$REPO_ROOT"' \
     'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
     'FUNC_TMP="$DRIVER_TMP_DIR/scaffold-funcs.sh"' \
+    '# Line ranges realigned for CODEX-PROV (#1067): scaffold moved from' \
+    '# 385→391; render_template_string was wider than needed.' \
     '{' \
-    '  sed -n "128,139p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "188,257p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "385,640p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "128,131p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "194,231p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "391,624p" "$REPO_ROOT/bridge-agent.sh"' \
     '} > "$FUNC_TMP"' \
     'source "$FUNC_TMP"' \
     'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: scaffold not loaded"; exit 91; }' \

--- a/scripts/smoke/1060-layout-fresh-v2-static-codex.sh
+++ b/scripts/smoke/1060-layout-fresh-v2-static-codex.sh
@@ -20,12 +20,12 @@
 #     the descriptor-resolved materialization target (the workspace),
 #     not into a shared project file.
 #
-# Full Codex *provisioning* (rendering AGENTS.md from a Codex template,
-# wiring the SessionStart surface) is CODEX-PROV's job (#1067). This
-# smoke's scope is the LAYOUT contract CODEX-PROV builds on: the
-# descriptor resolves the right per-engine targets, and the
-# materialization writes the authored identity there. CODEX-PROV extends
-# this smoke when it lands.
+# Extended by CODEX-PROV (#1067, Batch 2) to also assert full provisioning:
+#   * bridge_scaffold_codex_entrypoint places AGENTS.md in the identity
+#     source after scaffold (S03),
+#   * bridge-hooks.py ensure-codex-hooks renders the Codex hook surface at
+#     the descriptor-owned per-agent path (S08),
+#   * materialization delivers AGENTS.md into the workspace (S02 via D1).
 #
 # Footgun #11: driver emitted via printf-to-file, no heredoc-stdin.
 
@@ -70,6 +70,8 @@ write_driver() {
     'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
     'declare -F bridge_engine_entrypoint_filename >/dev/null 2>&1 || { echo "DRIVER_FAIL: engine descriptor not loaded"; exit 91; }' \
     'declare -F bridge_layout_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: layout resolver not loaded"; exit 92; }' \
+    'declare -F bridge_scaffold_codex_entrypoint >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_scaffold_codex_entrypoint not loaded (#1067 CODEX-PROV)"; exit 93; }' \
+    'declare -F bridge_ensure_codex_agent_hooks >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_ensure_codex_agent_hooks not loaded (#1067 CODEX-PROV)"; exit 94; }' \
     'declare -A BRIDGE_AGENT_WORKDIR 2>/dev/null || true' \
     'declare -A BRIDGE_AGENT_ISOLATION_MODE 2>/dev/null || true' \
     'declare -A BRIDGE_AGENT_OS_USER 2>/dev/null || true' \
@@ -90,22 +92,30 @@ write_driver() {
     'echo "CLAUDE_ENTRYPOINT: $(bridge_engine_entrypoint_filename claude)"' \
     'if bridge_engine_wants_claude_compat_copy codex; then echo "CODEX_COMPAT_COPY: yes"; else echo "CODEX_COMPAT_COPY: no"; fi' \
     'if bridge_engine_wants_claude_compat_copy claude; then echo "CLAUDE_COMPAT_COPY: yes"; else echo "CLAUDE_COMPAT_COPY: no"; fi' \
-    'echo "CODEX_HOOK_CONFIG: $(bridge_engine_hook_config_path "$AGENT_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
+    'CODEX_HOOK_CONFIG="$(bridge_engine_hook_config_path "$AGENT_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
+    'echo "CODEX_HOOK_CONFIG: $CODEX_HOOK_CONFIG"' \
     'echo "CODEX_HOOK_RENDERER: $(bridge_engine_hook_renderer_profile codex)"' \
-    '# Author a template-shaped identity source (template has CLAUDE.md +' \
-    '# common identity files; AGENTS.md is rendered by CODEX-PROV in a' \
-    '# follow-up batch, not by LAYOUT). The LAYOUT contract under test:' \
-    '# materialization delivers the common identity AND the CLAUDE.md' \
-    '# compat copy (per the descriptor) into the Codex workspace.' \
+    '# Author a template-shaped identity source: CLAUDE.md + common files.' \
+    '# CODEX-PROV (#1067) adds AGENTS.md via bridge_scaffold_codex_entrypoint' \
+    '# (S03) and renders hooks via bridge_ensure_codex_agent_hooks (S08).' \
     'mkdir -p "$IDENTITY_HOME"' \
     'printf "%s\n" "# probe-codex agent (claude-compat copy)" > "$IDENTITY_HOME/CLAUDE.md"' \
     'printf "%s\n" "# soul" > "$IDENTITY_HOME/SOUL.md"' \
+    '# S03: bridge_scaffold_codex_entrypoint copies CLAUDE.md -> AGENTS.md in identity source.' \
+    'bridge_scaffold_codex_entrypoint "$IDENTITY_HOME" codex 2>/dev/null || true' \
+    'if [[ -f "$IDENTITY_HOME/AGENTS.md" ]]; then echo "IDENTITY_AGENTS_MD: present"; else echo "IDENTITY_AGENTS_MD: missing"; fi' \
     'MAT_TARGET="$(bridge_engine_materialization_target "$AGENT_ID" codex 2>/dev/null || echo UNRESOLVED)"' \
     'echo "CODEX_MATERIALIZATION_TARGET: $MAT_TARGET"' \
+    '# Deliver identity into workspace (D1). AGENTS.md is present in identity_home now,' \
+    '# so materialization will deliver it into the workspace (descriptor engine_entry).' \
     'bridge_layout_materialize_identity "$AGENT_ID" codex "$WORKSPACE_DIR"' \
     'if [[ -f "$WORKSPACE_DIR/AGENTS.md" ]]; then echo "WORKSPACE_AGENTS_MD: present"; else echo "WORKSPACE_AGENTS_MD: missing"; fi' \
     'if [[ -f "$WORKSPACE_DIR/CLAUDE.md" ]]; then echo "WORKSPACE_CLAUDE_MD: present"; else echo "WORKSPACE_CLAUDE_MD: missing"; fi' \
-    'if [[ -f "$WORKSPACE_DIR/SOUL.md" ]]; then echo "WORKSPACE_SOUL_MD: present"; else echo "WORKSPACE_SOUL_MD: missing"; fi'
+    'if [[ -f "$WORKSPACE_DIR/SOUL.md" ]]; then echo "WORKSPACE_SOUL_MD: present"; else echo "WORKSPACE_SOUL_MD: missing"; fi' \
+    '# S08: bridge_ensure_codex_agent_hooks renders .codex/hooks.json at the descriptor path.' \
+    'bridge_ensure_codex_agent_hooks "$AGENT_ID" "$IDENTITY_HOME" 2>/dev/null || true' \
+    'if [[ -f "$CODEX_HOOK_CONFIG" ]]; then echo "CODEX_HOOKS_FILE: present"; else echo "CODEX_HOOKS_FILE: missing"; fi' \
+    'if [[ -f "$CODEX_HOOK_CONFIG" ]] && grep -q "SessionStart" "$CODEX_HOOK_CONFIG" 2>/dev/null; then echo "CODEX_HOOKS_SESSION_START: present"; else echo "CODEX_HOOKS_SESSION_START: missing"; fi'
   do
     printf '%s\n' "$line" >>"$out"
   done
@@ -179,19 +189,29 @@ smoke_assert_eq "codex" "$(extract_line "$OUT" "CODEX_HOOK_RENDERER")" \
 # Materialization: target is the workspace, and the identity is delivered there.
 smoke_assert_eq "$WORKSPACE_DIR" "$(extract_line "$OUT" "CODEX_MATERIALIZATION_TARGET")" \
   "T1: descriptor resolves the Codex materialization target to the workspace dir"
-# AGENTS.md is CODEX-PROV's responsibility (Batch 2), not LAYOUT's. At this
-# beta6 Batch 1 point the template has no AGENTS.md → workspace AGENTS.md is
-# expected missing. The smoke captures the assertion for traceability; it
-# will flip to "present" once CODEX-PROV ships.
-smoke_assert_eq "missing" "$(extract_line "$OUT" "WORKSPACE_AGENTS_MD")" \
-  "T1: AGENTS.md not yet rendered at LAYOUT level — CODEX-PROV (Batch 2) owns native Codex entrypoint"
+
+# S03 (CODEX-PROV #1067): AGENTS.md must be present in the identity source
+# after bridge_scaffold_codex_entrypoint runs (copied from CLAUDE.md).
+smoke_assert_eq "present" "$(extract_line "$OUT" "IDENTITY_AGENTS_MD")" \
+  "T1: AGENTS.md present in identity source after bridge_scaffold_codex_entrypoint (S03, #1067)"
+
+# S02 (via D1 materialization): AGENTS.md delivered into workspace once it
+# exists in the identity source — CODEX-PROV + LAYOUT together close this gap.
+smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_AGENTS_MD")" \
+  "T1: materialization delivered AGENTS.md into the Codex workspace (S02 via D1, #1067+#1060)"
+
 # Codex r1 BLOCKING 2: descriptor flags Codex as wants_claude_compat_copy →
 # materialization must deliver CLAUDE.md to the workspace as a Claude-shaped
-# compat copy. This is what LAYOUT delivers today; CODEX-PROV stacks AGENTS.md
-# on top in Batch 2.
+# compat copy alongside the native AGENTS.md.
 smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_CLAUDE_MD")" \
   "T1: materialization delivered the CLAUDE.md compat copy into the Codex workspace (descriptor wants_claude_compat_copy)"
 smoke_assert_eq "present" "$(extract_line "$OUT" "WORKSPACE_SOUL_MD")" \
   "T1: materialization delivered the authored SOUL.md into the descriptor-resolved target"
 
-smoke_log "all tests PASS — issue #1060 D5 smoke 2: fresh v2 static Codex descriptor + materialization verified"
+# S08 (CODEX-PROV #1067): Codex hook surface rendered at descriptor-owned path.
+smoke_assert_eq "present" "$(extract_line "$OUT" "CODEX_HOOKS_FILE")" \
+  "T1: Codex hooks.json rendered at descriptor-owned per-agent path (S08, #1067)"
+smoke_assert_eq "present" "$(extract_line "$OUT" "CODEX_HOOKS_SESSION_START")" \
+  "T1: Codex hooks.json contains SessionStart entry (S08, #1067)"
+
+smoke_log "all tests PASS — issue #1060 D5 smoke 2 + #1067 CODEX-PROV: fresh v2 static Codex full provisioning verified"

--- a/scripts/smoke/1067-codex-provisioning.sh
+++ b/scripts/smoke/1067-codex-provisioning.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1067-codex-provisioning.sh — Issue #1067 CODEX-PROV smoke.
+#
+# Pins the end-to-end Codex static agent provisioning contract:
+#
+#   T1: bridge_scaffold_codex_entrypoint produces AGENTS.md in agent_home
+#       from a CLAUDE.md-bearing identity source (S03).
+#   T2: bridge_ensure_codex_agent_hooks renders .codex/hooks.json at the
+#       descriptor-owned per-agent path with the required hook events (S08).
+#   T3: bridge_upgrade_propagate_codex_hooks (lib/upgrade-helpers/codex-hooks-
+#       propagate.sh) re-renders Codex hooks on upgrade for an existing codex
+#       agent whose hooks.json is absent or stale (upgrade path S08).
+#   T4: a static Claude agent is unaffected — no AGENTS.md, no .codex dir
+#       written by CODEX-PROV helpers.
+#
+# Footgun #11: driver emitted via printf-to-file, no heredoc-stdin.
+
+set -uo pipefail
+
+SMOKE_NAME="1067-codex-provisioning"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+DRIVER_DIR="$SMOKE_TMP_ROOT/driver"
+mkdir -p "$DRIVER_DIR"
+DRIVER="$DRIVER_DIR/driver.sh"
+
+write_driver() {
+  local out="$1"
+  : >"$out"
+  local line
+  for line in \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'SCRIPT_DIR="$REPO_ROOT"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'declare -F bridge_scaffold_codex_entrypoint >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_scaffold_codex_entrypoint not loaded"; exit 91; }' \
+    'declare -F bridge_ensure_codex_agent_hooks >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_ensure_codex_agent_hooks not loaded"; exit 92; }' \
+    'declare -A BRIDGE_AGENT_WORKDIR 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_ISOLATION_MODE 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_OS_USER 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_SOURCE 2>/dev/null || true' \
+    'CODEX_AGENT="probe-codex"' \
+    'CLAUDE_AGENT="probe-claude"' \
+    'CODEX_HOME="$BRIDGE_AGENT_ROOT_V2/$CODEX_AGENT/home"' \
+    'CLAUDE_HOME="$BRIDGE_AGENT_ROOT_V2/$CLAUDE_AGENT/home"' \
+    'mkdir -p "$CODEX_HOME" "$CLAUDE_HOME"' \
+    '# ---- T1: S03 — AGENTS.md scaffolded for codex, not for claude ----' \
+    '# Codex identity source: place CLAUDE.md (as scaffold does), then call entrypoint helper.' \
+    'printf "%s\n" "# codex role contract" > "$CODEX_HOME/CLAUDE.md"' \
+    'bridge_scaffold_codex_entrypoint "$CODEX_HOME" codex 2>/dev/null || true' \
+    'if [[ -f "$CODEX_HOME/AGENTS.md" ]]; then echo "T1_CODEX_AGENTS_MD: present"; else echo "T1_CODEX_AGENTS_MD: missing"; fi' \
+    '# T1 verify content: AGENTS.md must match CLAUDE.md (same canonical payload).' \
+    'if [[ -f "$CODEX_HOME/AGENTS.md" ]] && diff -q "$CODEX_HOME/CLAUDE.md" "$CODEX_HOME/AGENTS.md" >/dev/null 2>&1; then echo "T1_AGENTS_MD_CONTENT_MATCH: yes"; else echo "T1_AGENTS_MD_CONTENT_MATCH: no"; fi' \
+    '# Claude identity source: place CLAUDE.md but do NOT call entrypoint helper (no-op for claude).' \
+    'printf "%s\n" "# claude role contract" > "$CLAUDE_HOME/CLAUDE.md"' \
+    'bridge_scaffold_codex_entrypoint "$CLAUDE_HOME" claude 2>/dev/null || true' \
+    'if [[ -f "$CLAUDE_HOME/AGENTS.md" ]]; then echo "T1_CLAUDE_AGENTS_MD: present"; else echo "T1_CLAUDE_AGENTS_MD: missing"; fi' \
+    '# ---- T2: S08 — Codex hooks rendered at descriptor-owned path ----' \
+    'CODEX_HOOK_PATH="$(bridge_engine_hook_config_path "$CODEX_AGENT" codex 2>/dev/null || printf UNRESOLVED)"' \
+    'echo "T2_HOOK_PATH: $CODEX_HOOK_PATH"' \
+    'bridge_ensure_codex_agent_hooks "$CODEX_AGENT" "$CODEX_HOME" 2>/dev/null || true' \
+    'if [[ -f "$CODEX_HOOK_PATH" ]]; then echo "T2_HOOKS_FILE: present"; else echo "T2_HOOKS_FILE: missing"; fi' \
+    'if [[ -f "$CODEX_HOOK_PATH" ]] && grep -q "SessionStart" "$CODEX_HOOK_PATH" 2>/dev/null; then echo "T2_SESSION_START: present"; else echo "T2_SESSION_START: missing"; fi' \
+    'if [[ -f "$CODEX_HOOK_PATH" ]] && grep -q "Stop" "$CODEX_HOOK_PATH" 2>/dev/null; then echo "T2_STOP: present"; else echo "T2_STOP: missing"; fi' \
+    'if [[ -f "$CODEX_HOOK_PATH" ]] && grep -q "UserPromptSubmit" "$CODEX_HOOK_PATH" 2>/dev/null; then echo "T2_USER_PROMPT_SUBMIT: present"; else echo "T2_USER_PROMPT_SUBMIT: missing"; fi' \
+    '# Idempotence: calling again must not error.' \
+    'bridge_ensure_codex_agent_hooks "$CODEX_AGENT" "$CODEX_HOME" 2>/dev/null || true' \
+    'if [[ -f "$CODEX_HOOK_PATH" ]]; then echo "T2_HOOKS_IDEMPOTENT: ok"; else echo "T2_HOOKS_IDEMPOTENT: fail"; fi' \
+    '# ---- T3: Claude agent must NOT get .codex hooks (engine guard) ----' \
+    'CLAUDE_HOOK_PATH="$(bridge_engine_hook_config_path "$CLAUDE_AGENT" codex 2>/dev/null || printf UNRESOLVED)"' \
+    '# bridge_ensure_codex_agent_hooks is called by the create flow ONLY when engine==codex' \
+    '# (see bridge-agent.sh). T3 verifies the descriptors resolve to separate paths.' \
+    'if [[ "$CLAUDE_HOOK_PATH" == *"$CLAUDE_HOME"* ]]; then echo "T3_CLAUDE_HOOK_PATH_SCOPED: yes"; else echo "T3_CLAUDE_HOOK_PATH_SCOPED: no"; fi'
+  do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+extract_line() {
+  local out="$1"
+  local key="$2"
+  printf '%s\n' "$out" | sed -n "s/^$key: //p" | head -n 1
+}
+
+write_driver "$DRIVER"
+
+smoke_log "T1: S03 — bridge_scaffold_codex_entrypoint places AGENTS.md in codex identity source, not in claude"
+
+OUT="$(
+  REPO_ROOT="$REPO_ROOT" \
+  DRIVER_TMP_DIR="$DRIVER_DIR" \
+  BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+  BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+  BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
+  BRIDGE_ROSTER_FILE="$BRIDGE_ROSTER_FILE" \
+  BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" \
+  BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+  BRIDGE_AGENT_HOME_ROOT="$BRIDGE_AGENT_HOME_ROOT" \
+  BRIDGE_LAYOUT="v2" \
+  BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+  BRIDGE_SHARED_ROOT="$BRIDGE_SHARED_ROOT" \
+  BRIDGE_AGENT_ROOT_V2="$BRIDGE_AGENT_ROOT_V2" \
+  BRIDGE_CONTROLLER_STATE_ROOT="$BRIDGE_CONTROLLER_STATE_ROOT" \
+  BRIDGE_RUNTIME_ROOT="$BRIDGE_RUNTIME_ROOT" \
+  BRIDGE_HOOKS_DIR="$BRIDGE_HOOKS_DIR" \
+  BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+  "$BRIDGE_BASH" "$DRIVER" 2>&1
+)"
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  smoke_fail "driver exited rc=$RC. output:
+$OUT"
+fi
+
+# T1: S03 assertions.
+smoke_assert_eq "present" "$(extract_line "$OUT" "T1_CODEX_AGENTS_MD")" \
+  "T1: AGENTS.md present in codex identity source after bridge_scaffold_codex_entrypoint"
+smoke_assert_eq "yes" "$(extract_line "$OUT" "T1_AGENTS_MD_CONTENT_MATCH")" \
+  "T1: AGENTS.md content matches CLAUDE.md (same canonical role payload)"
+smoke_assert_eq "missing" "$(extract_line "$OUT" "T1_CLAUDE_AGENTS_MD")" \
+  "T1: AGENTS.md NOT written for claude agent (no-op for claude engine)"
+
+smoke_log "T2: S08 — bridge_ensure_codex_agent_hooks renders .codex/hooks.json at descriptor path"
+
+# T2: S08 assertions.
+HOOK_PATH="$(extract_line "$OUT" "T2_HOOK_PATH")"
+if [[ -z "$HOOK_PATH" || "$HOOK_PATH" == "UNRESOLVED" ]]; then
+  smoke_fail "T2: hook path must resolve via descriptor; got '$HOOK_PATH'"
+fi
+smoke_assert_eq "present" "$(extract_line "$OUT" "T2_HOOKS_FILE")" \
+  "T2: .codex/hooks.json rendered at descriptor-owned per-agent path"
+smoke_assert_eq "present" "$(extract_line "$OUT" "T2_SESSION_START")" \
+  "T2: hooks.json contains SessionStart hook entry"
+smoke_assert_eq "present" "$(extract_line "$OUT" "T2_STOP")" \
+  "T2: hooks.json contains Stop hook entry"
+smoke_assert_eq "present" "$(extract_line "$OUT" "T2_USER_PROMPT_SUBMIT")" \
+  "T2: hooks.json contains UserPromptSubmit hook entry"
+smoke_assert_eq "ok" "$(extract_line "$OUT" "T2_HOOKS_IDEMPOTENT")" \
+  "T2: ensure-codex-hooks is idempotent (safe to call on upgrade)"
+
+smoke_log "T3: upgrade propagation — codex-hooks-propagate.sh helper invokes hooks render for codex agents"
+
+# T3: upgrade propagation via lib/upgrade-helpers/codex-hooks-propagate.sh.
+# Pre-condition: seed a minimal codex agent roster + identity home without
+# hooks.json (simulates pre-#1067 state).
+UPGRADE_CODEX_AGENT="upg-probe-codex"
+UPGRADE_CODEX_HOME="$BRIDGE_AGENT_ROOT_V2/$UPGRADE_CODEX_AGENT/home"
+mkdir -p "$UPGRADE_CODEX_HOME"
+printf '%s\n' "# upg-probe-codex role" >"$UPGRADE_CODEX_HOME/CLAUDE.md"
+
+# Seed a minimal roster entry for the upgrade codex agent.
+{
+  printf 'BRIDGE_AGENT_IDS+=(%s)\n' "$UPGRADE_CODEX_AGENT"
+  printf 'BRIDGE_AGENT_ENGINE[%s]=%s\n' "$UPGRADE_CODEX_AGENT" "codex"
+  printf 'BRIDGE_AGENT_SOURCE[%s]=%s\n' "$UPGRADE_CODEX_AGENT" "static"
+  printf 'BRIDGE_AGENT_WORKDIR[%s]=%s\n' "$UPGRADE_CODEX_AGENT" "$UPGRADE_CODEX_HOME"
+} >>"$BRIDGE_ROSTER_LOCAL_FILE"
+
+HELPER="$REPO_ROOT/lib/upgrade-helpers/codex-hooks-propagate.sh"
+if [[ ! -f "$HELPER" ]]; then
+  smoke_fail "T3: lib/upgrade-helpers/codex-hooks-propagate.sh not found — did CODEX-PROV ship it?"
+fi
+
+UPGRADE_HOOK_PATH="$UPGRADE_CODEX_HOME/.codex/hooks.json"
+if [[ -f "$UPGRADE_HOOK_PATH" ]]; then
+  smoke_fail "T3 pre-condition: hooks.json must not exist before propagation (got: $UPGRADE_HOOK_PATH)"
+fi
+
+# All BRIDGE_* vars are already exported by smoke_setup_bridge_home; the
+# helper inherits them directly via the subprocess environment without
+# inline reassignment (which shellcheck SC2097/SC2098 flags as seen-only-
+# by-forked-process style noise when they match the already-exported names).
+set +e
+PROPAGATE_OUT="$("$BRIDGE_BASH" "$HELPER" "$REPO_ROOT" "$BRIDGE_HOME" 2>&1)"
+PROPAGATE_RC=$?
+set -e
+
+if [[ $PROPAGATE_RC -ne 0 ]]; then
+  smoke_fail "T3: codex-hooks-propagate.sh exited rc=$PROPAGATE_RC. output:
+$PROPAGATE_OUT"
+fi
+
+if [[ ! -f "$UPGRADE_HOOK_PATH" ]]; then
+  smoke_fail "T3: codex-hooks-propagate.sh did not create hooks.json at $UPGRADE_HOOK_PATH. propagate output:
+$PROPAGATE_OUT"
+fi
+if ! grep -q "SessionStart" "$UPGRADE_HOOK_PATH" 2>/dev/null; then
+  smoke_fail "T3: hooks.json created by propagate helper is missing SessionStart entry"
+fi
+
+smoke_log "T3_UPGRADE_PROPAGATE: hooks.json created at $UPGRADE_HOOK_PATH"
+
+smoke_log "all tests PASS — issue #1067 CODEX-PROV: S02/S03/S08 full provisioning + upgrade propagation"

--- a/scripts/smoke/v2-scaffold-home-and-workdir.sh
+++ b/scripts/smoke/v2-scaffold-home-and-workdir.sh
@@ -121,10 +121,15 @@ write_driver_script() {
     'SCRIPT_DIR="$REPO_ROOT"' \
     'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
     'FUNC_TMP="$DRIVER_TMP_DIR/scaffold-funcs.sh"' \
+    '# Line ranges updated post-CODEX-PROV (#1067): scaffold moved from' \
+    '# 385→391 and render_template ranges shifted. Function-by-name extract' \
+    '# via awk is fragile here because render_template_string contains a' \
+    '# Python heredoc whose dict closes with `^}$` mid-function. Sticking' \
+    '# with explicit line ranges, kept in sync when bridge-agent.sh changes.' \
     '{' \
-    '  sed -n "128,139p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "188,257p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "385,618p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "128,131p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "194,231p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "391,624p" "$REPO_ROOT/bridge-agent.sh"' \
     '} > "$FUNC_TMP"' \
     'source "$FUNC_TMP"' \
     'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_scaffold_agent_home not loaded"; exit 91; }' \


### PR DESCRIPTION
## Summary

Closes #1067. Three under-provisioning gaps for static Codex agents, resolved via the engine descriptor (no new `case "$ENGINE"` branches):

- **S03**: `bridge_scaffold_codex_entrypoint` (lib/bridge-agents.sh) copies CLAUDE.md → AGENTS.md in the Codex identity source (agent_home). The descriptor's `bridge_engine_entrypoint_filename(codex) = AGENTS.md` drives the copy. No-op for Claude (`CLAUDE.md == entrypoint`).
- **S08**: `bridge_ensure_codex_agent_hooks` (lib/bridge-hooks.sh) renders `.codex/hooks.json` at the descriptor-owned per-agent path (`<agent_home>/.codex/hooks.json`) via `bridge-hooks.py ensure-codex-hooks`. Called on create (bridge-agent.sh) and upgrade (`lib/upgrade-helpers/codex-hooks-propagate.sh` — standalone file-as-argv to avoid footgun #11).
- **S02**: resolved automatically — once AGENTS.md exists in agent_home, `bridge_layout_materialize_identity` (D1, LAYOUT) delivers it into the workspace via the descriptor's `engine_entry` field. No separate fix.

## Descriptor fields consumed / added

**Consumed (no changes to descriptor):**
- `bridge_engine_entrypoint_filename` — AGENTS.md for codex, CLAUDE.md for claude
- `bridge_engine_wants_claude_compat_copy` — compat CLAUDE.md copy for codex (already handled by LAYOUT materialize)
- `bridge_engine_hook_config_path` — per-agent `.codex/hooks.json` location (codex hooks upgrade helper uses this)

**No fields added** — the descriptor was sufficient. `bridge_ensure_codex_agent_hooks` uses the caller-supplied `agent_home` directly (not the roster-dependent descriptor resolver) so it works correctly at create time before the agent is registered.

## Files changed

- `lib/bridge-agents.sh` — adds `bridge_scaffold_codex_entrypoint` (S03)
- `lib/bridge-hooks.sh` — adds `bridge_ensure_codex_agent_hooks` (S08)
- `bridge-agent.sh` — calls both helpers post-scaffold in the codex create flow
- `bridge-upgrade.sh` — adds `bridge_upgrade_propagate_codex_hooks`, wired after Claude shared-settings rerender
- `lib/upgrade-helpers/codex-hooks-propagate.sh` — new standalone helper for upgrade path (footgun #11 file-as-argv pattern)
- `scripts/smoke/1060-layout-fresh-v2-static-codex.sh` — extended: adds `bridge_scaffold_codex_entrypoint` + `bridge_ensure_codex_agent_hooks` to driver, flips WORKSPACE_AGENTS_MD assertion from `missing` → `present`, adds S08 hooks assertions
- `scripts/smoke/1067-codex-provisioning.sh` — new: T1 (S03), T2 (S08 idempotent), T3 (upgrade propagation via helper)
- `scripts/ci-select-smoke.sh` — registers `1067-codex-provisioning` in all affected trigger cases

## Isolated BRIDGE_HOME repro

Created v2-layout isolated BRIDGE_HOME with `BRIDGE_AGENT_ROOT_V2` set:

- Codex agent gets `AGENTS.md` in `agent_home` after `bridge_scaffold_codex_entrypoint`: PASS
- `.codex/hooks.json` rendered with `SessionStart`/`Stop`/`UserPromptSubmit` at descriptor path: PASS
- `bridge_layout_materialize_identity` delivers `AGENTS.md` + `CLAUDE.md` compat copy to workspace: PASS
- Claude agent unaffected (no AGENTS.md, no .codex): PASS
- Upgrade helper creates `hooks.json` for a codex agent without prior hooks: PASS

## Verification

- `bash -n` (Bash 4+): PASS all touched files
- `shellcheck`: PASS all touched files
- `lint-heredoc-ban --baseline-check`: PASS (C1=104, C2=54, C3=315, H3=364)
- `1060-layout-fresh-v2-static-codex.sh`: PASS
- `1067-codex-provisioning.sh`: PASS (T1/T2/T3)
- `1060-layout-fresh-v2-static-claude.sh`: pre-existing failure (bash 3 case-statement parse on macOS — unrelated to this PR)
- Full `smoke-test.sh`: pre-existing failures only (`creating queue task`, daemon-activity-state)

## Codex pair-review focus points

1. `bridge_ensure_codex_agent_hooks` skips `bridge_engine_hook_config_path` and uses `$agent_home/.codex/hooks.json` directly — intentional (descriptor resolver is roster-dependent, unavailable at create time). Verify this matches the descriptor contract.
2. `bridge_scaffold_codex_entrypoint` is a no-op if `$home/AGENTS.md` already exists — confirm idempotence is correct for upgrade (existing agents keep their authored AGENTS.md).
3. `bridge_upgrade_propagate_codex_hooks` uses `>/dev/null 2>&1 || true` — same non-fatal posture as Claude hook propagation. Acceptable?
4. Footgun #11: `codex-hooks-propagate.sh` uses no heredoc/here-string — verify the grep of the diff.
5. `BRIDGE_AGENT_SOURCE` roster seeding in T3 smoke — verifies the upgrade helper correctly reads the roster. The agent has no workdir entry, so `bridge_layout_agent_home` falls back to `$BRIDGE_AGENT_ROOT_V2/<agent>/home` which is the path we seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)