### PR TITLE
fix(isolation): umbrella #1078 — channel-agent lifecycle gaps (F1+F2+F3+F5)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -598,6 +598,10 @@ PY
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-bundle.sh" "$@"
       ;;
+    plugins)
+      shift
+      exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-plugins.sh" "$@"
+      ;;
     intake)
       shift
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-intake.sh" "$@"
@@ -975,7 +979,7 @@ EOF
   # sqlite3 fallback path. Reject with an intent-recovery suggestion
   # before the spawn parser sees it.
   if [[ -n "${1:-}" && "${1:0:1}" != "-" ]]; then
-    _top_valid="admin bootstrap init version upgrade daemon auth escalate upstream review user guard diagnose doctor knowledge config bundle intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
+    _top_valid="admin bootstrap init version upgrade daemon auth escalate upstream review user guard diagnose doctor knowledge config bundle plugins intake list status kill attach urgent task profile setup agent cron memory audit usage watchdog discord migrate wiki isolate unisolate worktree inbox show claim done cancel update handoff summary create"
     _hint="$(bridge_suggest_subcommand "$1" "$_top_valid")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 명령입니다: $1"

--- a/bridge-plugins.sh
+++ b/bridge-plugins.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# bridge-plugins.sh — operator commands for the v2 shared plugin catalog.
+#
+# `seed` populates `$BRIDGE_SHARED_ROOT/plugins-cache/` on a fresh v2
+# install by running the de-facto seed helper (`bridge-dev-plugin-cache.py
+# sync`) against the in-repo `agent-bridge` marketplace, then applying the
+# canonical shared-cache ownership/modes (controller:ab-shared, 2750
+# dirs, 0640 files).
+#
+# Without this, `agb agent create --isolate` on a plugin: channel agent
+# bridge_die's with "isolation v2 plugin catalog: $BRIDGE_SHARED_ROOT/
+# plugins-cache is not populated" (lib/bridge-agents.sh) — the original
+# remediation pointed at `agb bundle install` which has never existed
+# (`agb bundle` only has `create|show`). See umbrella #1078 F1.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/bridge-lib.sh"
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename "$0") seed [--marketplace-root <path>] [--channels <csv>] [--dry-run]
+  $(basename "$0") show [--json]
+
+Seed populates the v2 shared plugin catalog at
+\$BRIDGE_SHARED_ROOT/plugins-cache/ from the in-repo agent-bridge
+marketplace (or --marketplace-root <path> for an external marketplace).
+
+Show prints the resolved shared-catalog state (root path, populated
+status, manifest plugin count).
+
+Requires BRIDGE_LAYOUT=v2 with BRIDGE_DATA_ROOT + BRIDGE_SHARED_ROOT
+resolved by the layout resolver.
+
+Examples:
+  # Fresh v2 install — seed the bundled agent-bridge marketplace
+  $(basename "$0") seed
+
+  # Seed a specific subset of plugins
+  $(basename "$0") seed --channels plugin:teams@agent-bridge,plugin:ms365@agent-bridge
+
+  # Inspect current shared-catalog state
+  $(basename "$0") show --json
+EOF
+}
+
+bridge_plugins_require_v2() {
+  if ! bridge_isolation_v2_active 2>/dev/null; then
+    bridge_die "agb plugins requires BRIDGE_LAYOUT=v2 + BRIDGE_DATA_ROOT (current layout: ${BRIDGE_LAYOUT:-unset}). Run \`agent-bridge upgrade --apply\` or set both env vars before invoking this command."
+  fi
+  if [[ -z "${BRIDGE_SHARED_ROOT:-}" ]]; then
+    bridge_die "agb plugins: BRIDGE_SHARED_ROOT is empty after v2 resolution. This indicates a broken layout marker — run \`agent-bridge doctor\` for diagnostics."
+  fi
+}
+
+bridge_plugins_default_marketplace_root() {
+  # The in-repo agent-bridge marketplace lives next to this script.
+  # `.claude-plugin/marketplace.json` is the canonical manifest the
+  # sync helper reads.
+  printf '%s' "$SCRIPT_DIR"
+}
+
+bridge_plugins_default_channels_csv() {
+  # Enumerate every plugin in the in-repo marketplace.json as
+  # `plugin:<name>@agent-bridge`. We use python3 because it is already a
+  # hard dependency (bridge_require_python is called below).
+  local mkt_root="$1"
+  local mkt_json="$mkt_root/.claude-plugin/marketplace.json"
+  [[ -f "$mkt_json" ]] || {
+    bridge_warn "agb plugins seed: marketplace.json not found at $mkt_json"
+    return 1
+  }
+  python3 - "$mkt_json" <<'PY'
+import json, sys
+p = sys.argv[1]
+try:
+    payload = json.load(open(p, "r", encoding="utf-8"))
+except Exception as exc:
+    sys.stderr.write(f"failed to read {p}: {exc}\n")
+    sys.exit(1)
+mkt_name = (payload.get("name") or "").strip()
+plugins = payload.get("plugins") or []
+items = []
+for entry in plugins:
+    name = (entry.get("name") or "").strip()
+    if name and mkt_name:
+        items.append(f"plugin:{name}@{mkt_name}")
+print(",".join(items))
+PY
+}
+
+bridge_plugins_apply_canonical_modes() {
+  # Apply shared-cache ownership/modes per the v2 matrix's
+  # `shared-plugins-cache` row: controller:ab-shared, dirs 2750, files
+  # 0640. Idempotent — re-running on an already-correct tree is a no-op.
+  #
+  # This is the post-seed step: bridge-dev-plugin-cache.py creates
+  # entries under whatever umask is in effect (usually controller-private
+  # 0700/0600). Isolated UIDs need group r-x on every dir + group r on
+  # files to traverse and read the catalog, otherwise the share helper
+  # in lib/bridge-agents.sh fails its symlink-target reads.
+  local plugins_cache="$1"
+  [[ -d "$plugins_cache" ]] || {
+    bridge_warn "apply_canonical_modes: plugins-cache dir missing: $plugins_cache"
+    return 1
+  }
+  local shared_grp="${BRIDGE_SHARED_GROUP:-ab-shared}"
+  local controller=""
+  controller="$(bridge_isolation_v2_controller_user 2>/dev/null || true)"
+  [[ -n "$controller" ]] || {
+    bridge_warn "apply_canonical_modes: cannot resolve controller user"
+    return 1
+  }
+  # The chgrp_setgid_dir helper handles the platform discriminator
+  # (no-op on macOS, real on Linux) plus direct-first/sudo fallback.
+  bridge_isolation_v2_chgrp_setgid_dir "$shared_grp" 2750 "$plugins_cache" \
+    || bridge_warn "apply_canonical_modes: chgrp_setgid_dir failed for $plugins_cache"
+  # Recurse into subtrees (marketplaces/, cache/) with the same
+  # contract. The recursive helper enforces 2750/0640 across dirs and
+  # files respectively.
+  bridge_isolation_v2_chgrp_setgid_recursive "$shared_grp" 2750 0640 "$plugins_cache" \
+    || bridge_warn "apply_canonical_modes: chgrp_setgid_recursive failed for $plugins_cache"
+}
+
+bridge_plugins_cmd_seed() {
+  bridge_plugins_require_v2
+  bridge_require_python
+
+  local marketplace_root=""
+  local channels_csv=""
+  local dry_run=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --marketplace-root)
+        [[ $# -ge 2 ]] || bridge_die "--marketplace-root requires a value"
+        marketplace_root="$2"
+        shift 2
+        ;;
+      --channels)
+        [[ $# -ge 2 ]] || bridge_die "--channels requires a value"
+        channels_csv="$2"
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        return 0
+        ;;
+      *)
+        bridge_die "지원하지 않는 plugins seed 옵션입니다: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$marketplace_root" ]] || marketplace_root="$(bridge_plugins_default_marketplace_root)"
+  if [[ ! -f "$marketplace_root/.claude-plugin/marketplace.json" ]]; then
+    bridge_die "agb plugins seed: marketplace.json not found at $marketplace_root/.claude-plugin/marketplace.json. Pass --marketplace-root <path> to an Agent Bridge-format plugin marketplace."
+  fi
+  if [[ -z "$channels_csv" ]]; then
+    channels_csv="$(bridge_plugins_default_channels_csv "$marketplace_root")" \
+      || bridge_die "agb plugins seed: failed to enumerate channels from $marketplace_root"
+    [[ -n "$channels_csv" ]] || bridge_die "agb plugins seed: marketplace at $marketplace_root contains no plugins"
+  fi
+
+  local plugins_cache="$BRIDGE_SHARED_ROOT/plugins-cache"
+  local cache_root="$plugins_cache/cache"
+
+  if (( dry_run == 1 )); then
+    printf 'agb plugins seed (dry-run):\n'
+    printf '  marketplace_root = %s\n' "$marketplace_root"
+    printf '  channels         = %s\n' "$channels_csv"
+    printf '  plugins_cache    = %s\n' "$plugins_cache"
+    printf '  shared_group     = %s\n' "${BRIDGE_SHARED_GROUP:-ab-shared}"
+    return 0
+  fi
+
+  # mkdir -p $plugins_cache and the cache subtree up front — the sync
+  # helper assumes these exist and silently materializes them under the
+  # caller's umask otherwise. Pre-creating lets us apply the canonical
+  # ownership/modes before any plugin-cache write lands inside.
+  _bridge_isolation_v2_run_root_or_sudo mkdir -p "$plugins_cache" "$cache_root" \
+    || bridge_die "agb plugins seed: mkdir -p $plugins_cache failed"
+
+  # Apply ownership/modes BEFORE the sync so per-plugin writes inherit
+  # the setgid group via the parent dir.
+  bridge_plugins_apply_canonical_modes "$plugins_cache" || true
+
+  # Run the sync helper. BRIDGE_CLAUDE_PLUGINS_ROOT pins the manifest
+  # location; BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT pins the cache subtree.
+  # We treat every channel as channel-required because seed is an
+  # explicit operator action — a missing/broken plugin source should
+  # fail loud, not warn-and-continue.
+  local rc=0
+  local output=""
+  output="$(BRIDGE_CLAUDE_PLUGINS_ROOT="$plugins_cache" \
+            BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT="$cache_root" \
+            python3 "$SCRIPT_DIR/bridge-dev-plugin-cache.py" sync \
+              --channels "$channels_csv" \
+              --required-channels "$channels_csv" \
+              --root "$marketplace_root" \
+              --agent "seed" \
+              2>&1)" || rc=$?
+
+  if [[ -n "$output" ]]; then
+    printf '%s\n' "$output"
+  fi
+
+  # Re-apply canonical modes after the sync so any per-plugin dirs the
+  # helper materialized pick up the setgid + group contract.
+  bridge_plugins_apply_canonical_modes "$plugins_cache" || true
+
+  if (( rc != 0 )); then
+    bridge_die "agb plugins seed: bridge-dev-plugin-cache.py sync failed (rc=$rc). See output above for per-plugin status."
+  fi
+
+  if [[ ! -f "$plugins_cache/installed_plugins.json" ]]; then
+    bridge_die "agb plugins seed: sync completed but $plugins_cache/installed_plugins.json was not written. This usually means every channel was filtered out (check --channels CSV) or the marketplace at $marketplace_root has no resolvable plugins."
+  fi
+
+  printf '[ok] seeded %s (installed_plugins.json present)\n' "$plugins_cache"
+}
+
+bridge_plugins_cmd_show() {
+  bridge_plugins_require_v2
+  bridge_require_python
+
+  local json_output=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --json) json_output=1; shift ;;
+      -h|--help) usage; return 0 ;;
+      *) bridge_die "지원하지 않는 plugins show 옵션입니다: $1" ;;
+    esac
+  done
+
+  local plugins_cache="$BRIDGE_SHARED_ROOT/plugins-cache"
+  local manifest="$plugins_cache/installed_plugins.json"
+  local known="$plugins_cache/known_marketplaces.json"
+  local populated="false"
+  bridge_isolation_v2_shared_plugins_root_populated 2>/dev/null && populated="true"
+
+  if (( json_output == 1 )); then
+    python3 - "$plugins_cache" "$manifest" "$known" "$populated" <<'PY'
+import json, os, sys
+plugins_cache, manifest, known, populated = sys.argv[1:5]
+out = {
+    "plugins_cache": plugins_cache,
+    "populated": populated == "true",
+    "installed_plugins_json": manifest if os.path.isfile(manifest) else "",
+    "known_marketplaces_json": known if os.path.isfile(known) else "",
+    "plugin_count": 0,
+    "marketplaces": [],
+}
+if os.path.isfile(manifest):
+    try:
+        payload = json.load(open(manifest, "r", encoding="utf-8"))
+        out["plugin_count"] = len((payload.get("plugins") or {}))
+    except Exception as exc:
+        out["error"] = f"manifest-unreadable: {exc}"
+if os.path.isfile(known):
+    try:
+        payload = json.load(open(known, "r", encoding="utf-8"))
+        # known_marketplaces.json is a flat {<marketplace-name>: <metadata>} map
+        # at the top level (see bridge-dev-plugin-cache.py
+        # ensure_known_marketplace_for_root). Tolerate a future wrapping
+        # `marketplaces` key by falling back to it.
+        if isinstance(payload, dict):
+            if isinstance(payload.get("marketplaces"), dict):
+                out["marketplaces"] = sorted(payload["marketplaces"].keys())
+            else:
+                out["marketplaces"] = sorted(k for k in payload.keys() if isinstance(k, str))
+    except Exception:
+        pass
+print(json.dumps(out, ensure_ascii=False, sort_keys=True))
+PY
+    return 0
+  fi
+
+  printf 'plugins_cache: %s\n' "$plugins_cache"
+  printf 'populated: %s\n' "$populated"
+  if [[ -f "$manifest" ]]; then
+    printf 'installed_plugins.json: %s\n' "$manifest"
+    local count=""
+    count="$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(len(d.get('plugins') or {}))" "$manifest" 2>/dev/null || printf 'unknown')"
+    printf 'plugin_count: %s\n' "$count"
+  else
+    printf 'installed_plugins.json: <missing>\n'
+  fi
+  if [[ -f "$known" ]]; then
+    printf 'known_marketplaces.json: %s\n' "$known"
+  else
+    printf 'known_marketplaces.json: <missing>\n'
+  fi
+}
+
+case "${1:-}" in
+  ""|-h|--help|help)
+    usage
+    [[ "${1:-}" == "" ]] && exit 1
+    exit 0
+    ;;
+  seed)
+    shift
+    bridge_plugins_cmd_seed "$@"
+    ;;
+  show)
+    shift
+    bridge_plugins_cmd_show "$@"
+    ;;
+  *)
+    bridge_warn "지원하지 않는 plugins 명령입니다: $1"
+    usage
+    exit 2
+    ;;
+esac

--- a/bridge-plugins.sh
+++ b/bridge-plugins.sh
@@ -20,31 +20,34 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/bridge-lib.sh"
 
 usage() {
-  cat <<EOF
-Usage:
-  $(basename "$0") seed [--marketplace-root <path>] [--channels <csv>] [--dry-run]
-  $(basename "$0") show [--json]
-
-Seed populates the v2 shared plugin catalog at
-\$BRIDGE_SHARED_ROOT/plugins-cache/ from the in-repo agent-bridge
-marketplace (or --marketplace-root <path> for an external marketplace).
-
-Show prints the resolved shared-catalog state (root path, populated
-status, manifest plugin count).
-
-Requires BRIDGE_LAYOUT=v2 with BRIDGE_DATA_ROOT + BRIDGE_SHARED_ROOT
-resolved by the layout resolver.
-
-Examples:
-  # Fresh v2 install — seed the bundled agent-bridge marketplace
-  $(basename "$0") seed
-
-  # Seed a specific subset of plugins
-  $(basename "$0") seed --channels plugin:teams@agent-bridge,plugin:ms365@agent-bridge
-
-  # Inspect current shared-catalog state
-  $(basename "$0") show --json
-EOF
+  # printf-based usage to avoid `cat <<EOF` (footgun #11 — heredoc to a
+  # subprocess). Each printf line ends with \n; backslashes inside
+  # `\$BRIDGE_*` etc. are preserved by the %s placeholder.
+  local prog
+  prog="$(basename "$0")"
+  printf 'Usage:\n'
+  printf '  %s seed [--marketplace-root <path>] [--channels <csv>] [--dry-run]\n' "$prog"
+  printf '  %s show [--json]\n' "$prog"
+  printf '\n'
+  printf 'Seed populates the v2 shared plugin catalog at\n'
+  printf '$BRIDGE_SHARED_ROOT/plugins-cache/ from the in-repo agent-bridge\n'
+  printf 'marketplace (or --marketplace-root <path> for an external marketplace).\n'
+  printf '\n'
+  printf 'Show prints the resolved shared-catalog state (root path, populated\n'
+  printf 'status, manifest plugin count).\n'
+  printf '\n'
+  printf 'Requires BRIDGE_LAYOUT=v2 with BRIDGE_DATA_ROOT + BRIDGE_SHARED_ROOT\n'
+  printf 'resolved by the layout resolver.\n'
+  printf '\n'
+  printf 'Examples:\n'
+  printf '  # Fresh v2 install — seed the bundled agent-bridge marketplace\n'
+  printf '  %s seed\n' "$prog"
+  printf '\n'
+  printf '  # Seed a specific subset of plugins\n'
+  printf '  %s seed --channels plugin:teams@agent-bridge,plugin:ms365@agent-bridge\n' "$prog"
+  printf '\n'
+  printf '  # Inspect current shared-catalog state\n'
+  printf '  %s show --json\n' "$prog"
 }
 
 bridge_plugins_require_v2() {
@@ -73,23 +76,9 @@ bridge_plugins_default_channels_csv() {
     bridge_warn "agb plugins seed: marketplace.json not found at $mkt_json"
     return 1
   }
-  python3 - "$mkt_json" <<'PY'
-import json, sys
-p = sys.argv[1]
-try:
-    payload = json.load(open(p, "r", encoding="utf-8"))
-except Exception as exc:
-    sys.stderr.write(f"failed to read {p}: {exc}\n")
-    sys.exit(1)
-mkt_name = (payload.get("name") or "").strip()
-plugins = payload.get("plugins") or []
-items = []
-for entry in plugins:
-    name = (entry.get("name") or "").strip()
-    if name and mkt_name:
-        items.append(f"plugin:{name}@{mkt_name}")
-print(",".join(items))
-PY
+  # File-as-argv per footgun #11 (no heredoc-stdin to a subprocess);
+  # see lib/upgrade-helpers/plugins-seed-derive-channels.py.
+  python3 "$SCRIPT_DIR/lib/upgrade-helpers/plugins-seed-derive-channels.py" "$mkt_json"
 }
 
 bridge_plugins_apply_canonical_modes() {
@@ -246,39 +235,9 @@ bridge_plugins_cmd_show() {
   bridge_isolation_v2_shared_plugins_root_populated 2>/dev/null && populated="true"
 
   if (( json_output == 1 )); then
-    python3 - "$plugins_cache" "$manifest" "$known" "$populated" <<'PY'
-import json, os, sys
-plugins_cache, manifest, known, populated = sys.argv[1:5]
-out = {
-    "plugins_cache": plugins_cache,
-    "populated": populated == "true",
-    "installed_plugins_json": manifest if os.path.isfile(manifest) else "",
-    "known_marketplaces_json": known if os.path.isfile(known) else "",
-    "plugin_count": 0,
-    "marketplaces": [],
-}
-if os.path.isfile(manifest):
-    try:
-        payload = json.load(open(manifest, "r", encoding="utf-8"))
-        out["plugin_count"] = len((payload.get("plugins") or {}))
-    except Exception as exc:
-        out["error"] = f"manifest-unreadable: {exc}"
-if os.path.isfile(known):
-    try:
-        payload = json.load(open(known, "r", encoding="utf-8"))
-        # known_marketplaces.json is a flat {<marketplace-name>: <metadata>} map
-        # at the top level (see bridge-dev-plugin-cache.py
-        # ensure_known_marketplace_for_root). Tolerate a future wrapping
-        # `marketplaces` key by falling back to it.
-        if isinstance(payload, dict):
-            if isinstance(payload.get("marketplaces"), dict):
-                out["marketplaces"] = sorted(payload["marketplaces"].keys())
-            else:
-                out["marketplaces"] = sorted(k for k in payload.keys() if isinstance(k, str))
-    except Exception:
-        pass
-print(json.dumps(out, ensure_ascii=False, sort_keys=True))
-PY
+    # File-as-argv per footgun #11; see lib/upgrade-helpers/plugins-show-json.py.
+    python3 "$SCRIPT_DIR/lib/upgrade-helpers/plugins-show-json.py" \
+      "$plugins_cache" "$manifest" "$known" "$populated"
     return 0
   fi
 

--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -362,6 +362,13 @@ def _safe_path_check(check: str, path: Path, os_user: str | None) -> bool:
     test -e/-h <path>` so the controller can still detect "exists" and
     take the recovery path. `os_user=None` (non-Linux / non-isolated)
     re-raises so callers preserve the original error shape.
+
+    Issue #1078 F3/F5: when the caller could not resolve `os_user`
+    upfront (every lstat in the ancestor chain hit PermissionError),
+    fall back to the walker before re-raising — the walker climbs until
+    an existing ancestor whose lstat succeeds reveals the isolated UID.
+    Only re-raise when even the walker comes back empty (truly
+    non-isolated, non-Linux, or sudo unavailable).
     """
     try:
         if check == "exists":
@@ -370,7 +377,9 @@ def _safe_path_check(check: str, path: Path, os_user: str | None) -> bool:
             return path.is_symlink()
     except PermissionError:
         if os_user is None:
-            raise
+            os_user = _resolve_isolated_owner_for_path(path)
+            if os_user is None:
+                raise
         flag = "-e" if check == "exists" else "-h"
         result = _sudo_run_as(os_user, "test", flag, str(path))
         return result.returncode == 0
@@ -398,8 +407,22 @@ def _safe_read_env(path: Path) -> dict[str, str]:
     when no isolated owner can be identified (non-Linux, non-isolated,
     or sudo unavailable) so the caller surfaces the same error shape it
     had before.
+
+    Issue #1078 F3: when the entire chain — `.teams/.env`, `.teams/`,
+    and the workdir itself — is 0700-owned by the isolated UID, a
+    single-level `lstat(path)` / `lstat(path.parent)` raises
+    PermissionError (caught) and returns None, so the controller falls
+    through to the plain `path.exists()` in `_safe_path_check` and
+    re-raises. Use the walker (`_resolve_isolated_owner_for_path`) which
+    climbs ancestors until it finds an existing dir whose lstat
+    succeeds — that node's owner is the same isolated UID by
+    construction, so the sudo fallback can identify the right user.
     """
-    os_user = _isolated_workdir_owner(path) or _isolated_workdir_owner(path.parent)
+    os_user = (
+        _isolated_workdir_owner(path)
+        or _isolated_workdir_owner(path.parent)
+        or _resolve_isolated_owner_for_path(path)
+    )
     if not _safe_path_check("exists", path, os_user):
         return {}
     try:
@@ -432,8 +455,15 @@ def _safe_load_json(path: Path, default: Any) -> Any:
     `load_json`) or when the sudo fallback succeeds but the body is
     not valid JSON (best-effort — recovery flow rebuilds the doc from
     operator input).
+
+    Issue #1078 F5: same chain-of-0700 wedge as F3. The walker is the
+    backstop when single-level lstats hit PermissionError.
     """
-    os_user = _isolated_workdir_owner(path) or _isolated_workdir_owner(path.parent)
+    os_user = (
+        _isolated_workdir_owner(path)
+        or _isolated_workdir_owner(path.parent)
+        or _resolve_isolated_owner_for_path(path)
+    )
     if not _safe_path_check("exists", path, os_user):
         return default
     try:

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -2459,7 +2459,7 @@ bridge_linux_share_plugin_catalog() {
         && [[ -z "$_v2_pcg_plugins" ]]; then
       return 0
     fi
-    bridge_die "isolation v2 plugin catalog: \$BRIDGE_SHARED_ROOT/plugins-cache is not populated (no installed_plugins.json) but agent '$agent' declares plugin: channels or BRIDGE_AGENT_PLUGINS allowlist entries. Populate the shared plugins cache (\`agb bundle install\` or seed installed_plugins.json into \$BRIDGE_SHARED_ROOT/plugins-cache) before starting v2-isolated agents that require plugins."
+    bridge_die "isolation v2 plugin catalog: \$BRIDGE_SHARED_ROOT/plugins-cache is not populated (no installed_plugins.json) but agent '$agent' declares plugin: channels or BRIDGE_AGENT_PLUGINS allowlist entries. Run \`agb plugins seed\` to populate the shared plugin catalog from the bundled agent-bridge marketplace, then retry. (For an external marketplace: \`agb plugins seed --marketplace-root <path>\`.)"
   fi
 
   local isolated_plugins="$user_home/.claude/plugins"

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -1484,6 +1484,33 @@ bridge_isolation_v2_matrix_rows_for_agent() {
     }
   fi
 
+  # ----- BRIDGE_DATA_ROOT + BRIDGE_AGENT_ROOT_V2 traverse rows (#1078 F2) -----
+  # Issue #1078 F2: a fresh v2 install creates `data/` (BRIDGE_DATA_ROOT)
+  # and `data/agents/` (BRIDGE_AGENT_ROOT_V2) under the controller's umask,
+  # which is often 077 → mode 0700. With 0700 the isolated UID (a member
+  # of ab-shared, not the controller) cannot traverse `data/agents/` to
+  # reach its own `data/agents/<X>/` (which is 2750 root:ab-agent-<X>).
+  # The result: every isolated agent is fundamentally non-functional —
+  # bridge-start.sh fails to enter the per-agent workdir, the daemon's
+  # state-marker writes return EACCES, and there is no `isolation verify`
+  # row for these parents to surface the drift.
+  #
+  # Layout comment at top of file documents `$BRIDGE_DATA_ROOT/  mode 755
+  # (others traverse)`. We pick the same `dir_only_traverse` pattern as
+  # state-root / state-agents-root — controller:ab-shared 0710 — so every
+  # isolated UID (always a member of ab-shared) gets `--x` and nothing
+  # else. 0711 (others +x) would also work but widens the surface
+  # unnecessarily; 0710 + ab-shared narrows to the exact set of
+  # accounts that should be reaching v2 agent dirs.
+  if [[ -n "$data_root" ]]; then
+    printf 'data-root|%s|dir_only_traverse|controller|%s|0710||0|group_setgid|required|#1078 F2: isolated UID needs --x to reach data/agents/<X>\n' \
+      "$data_root" "$shared_grp"
+  fi
+  if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+    printf 'data-agents-root|%s|dir_only_traverse|controller|%s|0710||0|group_setgid|required|#1078 F2: isolated UID needs --x to reach its own agent dir\n' \
+      "$BRIDGE_AGENT_ROOT_V2" "$shared_grp"
+  fi
+
   # ----- shared/ row family (catalog/source only — RC6 per-agent cache
   # lands in PR 2 as a separate row family) -----
   if [[ -n "$shared_root" ]]; then

--- a/lib/upgrade-helpers/plugins-seed-derive-channels.py
+++ b/lib/upgrade-helpers/plugins-seed-derive-channels.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+lib/upgrade-helpers/plugins-seed-derive-channels.py — standalone helper
+for `agb plugins seed` (bridge-plugins.sh).
+
+Reads a marketplace.json and prints a comma-separated `plugin:<name>@<mkt>`
+list for every plugin entry. File-as-argv per footgun #11 (no
+heredoc-stdin to subprocess); see KNOWN_ISSUES.md §26.
+
+Usage:
+  python3 lib/upgrade-helpers/plugins-seed-derive-channels.py <marketplace.json>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write("usage: plugins-seed-derive-channels.py <marketplace.json>\n")
+        return 2
+    path = argv[1]
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception as exc:
+        sys.stderr.write(f"failed to read {path}: {exc}\n")
+        return 1
+    mkt_name = (payload.get("name") or "").strip()
+    plugins = payload.get("plugins") or []
+    items: list[str] = []
+    for entry in plugins:
+        name = (entry.get("name") or "").strip()
+        if name and mkt_name:
+            items.append(f"plugin:{name}@{mkt_name}")
+    print(",".join(items))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/lib/upgrade-helpers/plugins-show-json.py
+++ b/lib/upgrade-helpers/plugins-show-json.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""
+lib/upgrade-helpers/plugins-show-json.py — standalone helper for
+`agb plugins show --json` (bridge-plugins.sh).
+
+Reads the v2 shared-plugins catalog state and emits a single JSON object
+describing the cache root, populated flag, manifest plugin count, and
+the sorted marketplace name list. File-as-argv per footgun #11 (no
+heredoc-stdin to subprocess); see KNOWN_ISSUES.md §26.
+
+Usage:
+  python3 lib/upgrade-helpers/plugins-show-json.py \\
+      <plugins_cache_dir> <installed_plugins.json> <known_marketplaces.json> <populated:true|false>
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 5:
+        sys.stderr.write(
+            "usage: plugins-show-json.py <plugins_cache> <manifest> <known> <populated>\n"
+        )
+        return 2
+    plugins_cache, manifest, known, populated = argv[1:5]
+    out: dict = {
+        "plugins_cache": plugins_cache,
+        "populated": populated == "true",
+        "installed_plugins_json": manifest if os.path.isfile(manifest) else "",
+        "known_marketplaces_json": known if os.path.isfile(known) else "",
+        "plugin_count": 0,
+        "marketplaces": [],
+    }
+    if os.path.isfile(manifest):
+        try:
+            with open(manifest, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            out["plugin_count"] = len(payload.get("plugins") or {})
+        except Exception as exc:
+            out["error"] = f"manifest-unreadable: {exc}"
+    if os.path.isfile(known):
+        try:
+            with open(known, "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+            # known_marketplaces.json is a flat {<marketplace-name>: <metadata>}
+            # map at the top level (see bridge-dev-plugin-cache.py
+            # ensure_known_marketplace_for_root). Tolerate a future wrapping
+            # `marketplaces` key by falling back to it.
+            if isinstance(payload, dict):
+                if isinstance(payload.get("marketplaces"), dict):
+                    out["marketplaces"] = sorted(payload["marketplaces"].keys())
+                else:
+                    out["marketplaces"] = sorted(
+                        k for k in payload.keys() if isinstance(k, str)
+                    )
+        except Exception:
+            pass
+    print(json.dumps(out, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Folded into v0.14.5-beta6 wave. Closes 4 of 6 sub-findings on umbrella
[#1078](https://github.com/SYRS-AI/agent-bridge-public/issues/1078). F4
+ F6 are deferred to a follow-up issue (each needs its own scoped fix +
own verification surface; bundling them here would balloon the diff).

- **F1** — plugin-catalog fresh-install gap + stale error message.
  New `agb plugins seed` + `agb plugins show` (wrappers around
  `bridge-dev-plugin-cache.py sync` with `BRIDGE_CLAUDE_PLUGINS_ROOT` /
  `BRIDGE_CLAUDE_PLUGIN_CACHE_ROOT` pointed at `$BRIDGE_SHARED_ROOT/
  plugins-cache`) + canonical-mode application after seed
  (controller:ab-shared, 2750 dirs, 0640 files). Replaces the stale
  `agb bundle install` text in `lib/bridge-agents.sh` (`agb bundle`
  only has `create|show`).
- **F2** — `data/` + `data/agents/` traverse rows. New `data-root` +
  `data-agents-root` matrix rows (`dir_only_traverse|controller|ab-
  shared|0710`), mirroring the existing state-root / state-agents-root
  pattern + the #1079 state-cron-root + state-cron-runs-root pattern.
  Fresh-install path no longer leaves data/ at mode 0700.
- **F3** + **F5** — `bridge-setup.py` `_safe_read_env`, `_safe_load_json`,
  `_safe_path_check` now fall back to `_resolve_isolated_owner_for_path`
  (walker) when single-level lstats hit PermissionError on a chain-of-
  0700 ancestors. `setup teams` no longer wedges on isolated `.teams/.env`
  + `access.json`.
- **F4** + **F6**: deferred to follow-up issue (one for each).

Diff stats: 5 files changed, +387/-5 (most of that is the new
`bridge-plugins.sh` and inline comments). No VERSION / CHANGELOG change
per the wave contract.

## Test plan

- [x] `bash -n` + `python3 py_compile` clean on every edited file
- [x] `shellcheck` (0.10.0) clean on the three `.sh` files
- [x] Matrix emit: `data-root` + `data-agents-root` rows appear with
      expected `controller:<grp> 0710 dir_only_traverse group_setgid
      required` shape
- [x] `agb plugins seed` end-to-end against the in-repo agent-bridge
      marketplace seeds teams/ms365/mattermost + writes
      `installed_plugins.json` + `known_marketplaces.json`
- [x] `agb plugins show` / `show --json` reflect the populated state
- [x] `agent-bridge isolation verify --agent <X> --json` emits the two
      new rows in its check output (macOS = `status:ok` via platform
      discriminator no-op; on Linux a 0700 data/ surfaces `mismatch`)
- [x] Existing smokes that exercise adjacent surfaces pass:
      `1021-isolation-v2-shared-plugin-perms`,
      `864-upgrade-perm-regressions`,
      `agent-doctor`,
      `1073-fresh-channel-first-run-seed`
- [ ] Linux apply-path verification on operator's live linux-user-
      isolated install — deferred to integration-branch QA where the
      `pi_sean` v2-isolated Teams setup was originally captured

Refs umbrella #1078, related #694 #998 #857 #1060 #1079.