### PR TITLE
fix(agent): atomic create rollback + complete --purge-home residue (#1076)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -136,6 +136,117 @@ bridge_agent_manage_python() {
 # to smoke drivers via bridge-lib.sh without sourcing bridge-agent.sh.
 # See issue #1067 (S03, S08) for the contract.
 
+# bridge_agent_create_rollback — issue #1076. Unwind a partial `agent create`
+# when a mid-flow step raises so the agent does NOT end up "registered but
+# half-scaffolded". Called from run_create's EXIT trap; the trap is armed
+# before the first mutation and disarmed only on successful completion.
+#
+# Inputs are conveyed via the matching _CREATE_ROLLBACK_* shell variables
+# (run_create's locals). Best-effort: every step is independent and
+# failures are logged via bridge_warn but never re-raise. Order: roster
+# excision first (so the agent stops showing up in `agb status` /
+# `agb agent list`), then scaffold/workdir rm, then v2 sibling rm — match
+# the inverse of the create-time ordering.
+#
+# Safety: every path is validated against the known agent-root prefixes
+# (BRIDGE_AGENT_HOME_ROOT, BRIDGE_AGENT_ROOT_V2) before recursive rm.
+# Anything outside those roots is a resolver bug we'd rather leave on
+# disk than rm.
+bridge_agent_create_rollback() {
+  local agent="${_CREATE_ROLLBACK_AGENT:-}"
+  local roster_path="${_CREATE_ROLLBACK_ROSTER:-}"
+  local scaffold_target="${_CREATE_ROLLBACK_SCAFFOLD_TARGET:-}"
+  local workdir="${_CREATE_ROLLBACK_WORKDIR:-}"
+  local v2_root="${_CREATE_ROLLBACK_V2_ROOT:-}"
+  local roster_written="${_CREATE_ROLLBACK_ROSTER_WRITTEN:-0}"
+  local scaffold_created="${_CREATE_ROLLBACK_SCAFFOLD_CREATED:-0}"
+  local workdir_created="${_CREATE_ROLLBACK_WORKDIR_CREATED:-0}"
+
+  [[ -n "$agent" ]] || return 0
+
+  bridge_warn "agent create: rolling back partial create for '$agent' (mid-flow failure)"
+
+  # 1. Roster excision — undo bridge_write_role_block if it ran.
+  if [[ "$roster_written" == "1" && -n "$roster_path" && -f "$roster_path" ]]; then
+    if [[ -n "${SCRIPT_DIR:-}" ]] \
+        && [[ -f "$SCRIPT_DIR/lib/agent-cli-helpers/roster-excise-block.py" ]]; then
+      python3 "$SCRIPT_DIR/lib/agent-cli-helpers/roster-excise-block.py" \
+        "$roster_path" "$agent" >/dev/null 2>&1 \
+        || bridge_warn "agent create rollback: roster excision failed for '$agent' in $roster_path"
+    fi
+    # Drop the daemon auto-start state file so the next daemon tick does
+    # not warn about a roster-removed agent (same pattern as run_delete).
+    if [[ -n "${BRIDGE_STATE_DIR:-}" ]]; then
+      rm -f "$BRIDGE_STATE_DIR/daemon-autostart/$agent.env" 2>/dev/null || true
+    fi
+  fi
+
+  # 2. Scaffold target — the per-agent identity source / home tree.
+  if [[ "$scaffold_created" == "1" && -n "$scaffold_target" ]]; then
+    bridge_agent_create_rollback_rmtree "$scaffold_target"
+  fi
+
+  # 3. Workdir — only if create authored it (default v2 workdir/ default).
+  # Skip when workdir equals scaffold_target (legacy install) so we don't
+  # double-rm, and skip explicit operator --workdir paths which we did
+  # NOT create. The _CREATE_ROLLBACK_WORKDIR_CREATED flag is set only
+  # when the workdir was empty / autoderived under BRIDGE_AGENT_ROOT_V2.
+  if [[ "$workdir_created" == "1" && -n "$workdir" && "$workdir" != "$scaffold_target" ]]; then
+    bridge_agent_create_rollback_rmtree "$workdir"
+  fi
+
+  # 4. v2 per-agent root parent (only when we created it). bridge_scaffold_
+  # agent_home pre-creates $BRIDGE_AGENT_ROOT_V2/<agent>/ before the v2 home/
+  # and workdir/ children, and run_delete --purge-home does not see this
+  # parent on a non-rolled-back delete — so rollback owns the parent rm to
+  # match the inverse-of-create contract.
+  if [[ -n "$v2_root" && "$scaffold_created" == "1" ]]; then
+    bridge_agent_create_rollback_rmtree "$v2_root"
+  fi
+
+  # 5. Tracked-profile-source residue. bridge_scaffold_agent_home does not
+  # write under $BRIDGE_HOME/agents/<a>/ for v2 installs (it writes under
+  # $BRIDGE_AGENT_ROOT_V2/<agent>/), but a prior partial create or legacy
+  # migration may have left a stub there. Only remove when the dir is empty
+  # so we never blow away a legitimate tracked-profile source.
+  if [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" ]]; then
+    local profile_src="$BRIDGE_AGENT_HOME_ROOT/$agent"
+    if [[ -d "$profile_src" ]] \
+        && [[ -z "$(find "$profile_src" -mindepth 1 -maxdepth 1 2>/dev/null | head -n 1)" ]]; then
+      rmdir "$profile_src" 2>/dev/null \
+        || bridge_warn "agent create rollback: rmdir failed for empty $profile_src"
+    fi
+  fi
+}
+
+# bridge_agent_create_rollback_rmtree — guarded recursive rm. Refuses any
+# path that is not under one of the known agent-root prefixes. Uses sudo
+# when the controller cannot rm directly (isolated parents from a prior
+# linux-user create that didn't get to bridge_linux_prepare_agent_isolation).
+bridge_agent_create_rollback_rmtree() {
+  local target="$1"
+  [[ -n "$target" ]] || return 0
+  [[ -d "$target" ]] || return 0
+
+  case "$target" in
+    "${BRIDGE_AGENT_HOME_ROOT:-/dev/null/none}"/*|"${BRIDGE_AGENT_ROOT_V2:-/dev/null/none}"/*) ;;
+    *)
+      bridge_warn "agent create rollback: refusing to rm target outside agent roots: $target"
+      return 0
+      ;;
+  esac
+
+  if rm -rf -- "$target" 2>/dev/null; then
+    return 0
+  fi
+  if command -v bridge_linux_sudo_root >/dev/null 2>&1; then
+    bridge_linux_sudo_root rm -rf -- "$target" 2>/dev/null \
+      || bridge_warn "agent create rollback: rm -rf failed for $target (manual cleanup may be required)"
+  else
+    bridge_warn "agent create rollback: rm -rf failed for $target (manual cleanup may be required)"
+  fi
+}
+
 # bridge_ensure_memory_precompact_hook — wire the Plan-D PreCompact hook
 # into an agent's .claude/settings.json. Safe to call repeatedly; the
 # bridge-hooks.py helper already short-circuits when the hook is present.
@@ -2788,6 +2899,34 @@ report and reap test-fixture agents per their pattern."
         bridge_die "workdir가 이미 존재하고 비어 있지 않습니다: $workdir"
       fi
     fi
+    # Issue #1076: arm the rollback trap BEFORE the first mutation. The
+    # trap fires on any non-zero exit (including bridge_die / an unhandled
+    # PermissionError in a python helper / set -e propagation) until the
+    # success-clear at the end of the create block sets _CREATE_ROLLBACK_
+    # COMPLETE=1. Persists the create state through shell vars (locals
+    # captured by the rollback helper) so the trap body stays trivial.
+    _CREATE_ROLLBACK_AGENT="$agent"
+    _CREATE_ROLLBACK_ROSTER="$BRIDGE_ROSTER_LOCAL_FILE"
+    _CREATE_ROLLBACK_ROSTER_WRITTEN=0
+    _CREATE_ROLLBACK_SCAFFOLD_CREATED=0
+    _CREATE_ROLLBACK_WORKDIR_CREATED=0
+    _CREATE_ROLLBACK_SCAFFOLD_TARGET=""
+    _CREATE_ROLLBACK_WORKDIR=""
+    _CREATE_ROLLBACK_V2_ROOT=""
+    _CREATE_ROLLBACK_COMPLETE=0
+    # Record the v2 per-agent root parent so rollback can rm it too —
+    # bridge_scaffold_agent_home pre-creates this on isolated installs and
+    # run_delete --purge-home does not see it on a non-rolled-back delete.
+    if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" && $_workdir_is_v2_default -eq 1 ]]; then
+      _CREATE_ROLLBACK_V2_ROOT="$BRIDGE_AGENT_ROOT_V2/$agent"
+    fi
+    # _workdir_is_v2_default == 1 means we authored workdir under the v2
+    # tree (it wasn't an explicit operator --workdir), so rollback may rm it.
+    if [[ $_workdir_is_v2_default -eq 1 ]]; then
+      _CREATE_ROLLBACK_WORKDIR="$workdir"
+    fi
+    # shellcheck disable=SC2064
+    trap '[[ "${_CREATE_ROLLBACK_COMPLETE:-0}" == "1" ]] || bridge_agent_create_rollback' EXIT
     # Issue #1060 D1: scaffold the authored identity into the IDENTITY
     # SOURCE (layer 2). On a v2 install the identity source is ALWAYS
     # `bridge_layout_agent_home` = `<agent-root>/home` — regardless of
@@ -2805,6 +2944,17 @@ report and reap test-fixture agents per their pattern."
     if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]] \
         && declare -F bridge_layout_agent_home >/dev/null 2>&1; then
       scaffold_target="$(bridge_expand_user_path "$(bridge_layout_agent_home "$agent")")"
+    fi
+    # Issue #1076: record scaffold_target before the mutation so rollback
+    # can rm it if a later step fails. Setting _CREATE_ROLLBACK_SCAFFOLD_
+    # CREATED=1 BEFORE the call means even a mid-scaffold raise (e.g. sudo
+    # mkdir denied) is treated as "we tried to author this tree" — the
+    # rollback rmtree is no-op when the tree never materialized, but YES-op
+    # when bridge_scaffold_agent_home wrote some templates then aborted.
+    _CREATE_ROLLBACK_SCAFFOLD_TARGET="$scaffold_target"
+    _CREATE_ROLLBACK_SCAFFOLD_CREATED=1
+    if [[ -n "$_CREATE_ROLLBACK_WORKDIR" ]]; then
+      _CREATE_ROLLBACK_WORKDIR_CREATED=1
     fi
     # v0.8.5 #693 (Wave-3): pass isolation_mode + os_user so scaffold's
     # sudo-handoff predicate (added by PR #688 for #677) actually fires
@@ -2889,6 +3039,11 @@ report and reap test-fixture agents per their pattern."
       "$always_on" \
       "$isolation_mode" \
       "$os_user" >/dev/null
+    # Issue #1076: the agent is now registered. Mark for rollback excision
+    # if any later step (shared-settings link, grant-matrix apply,
+    # start --dry-run) raises — without this flag, a post-roster failure
+    # leaves a registered-but-broken agent (the exact bug).
+    _CREATE_ROLLBACK_ROSTER_WRITTEN=1
     # Issue #848: bridge_write_role_block just appended a new entry to
     # the local roster file; invalidate the per-process cache so the
     # next load re-reads disk instead of replaying the pre-create map.
@@ -2955,6 +3110,12 @@ report and reap test-fixture agents per their pattern."
     else
       start_dry_run_status="warn (rc=$?)"
     fi
+    # Issue #1076: every mutation in the create flow has now completed.
+    # Mark complete + disarm the EXIT trap so a normal exit does NOT roll
+    # back a successful create. A failure ANYWHERE above this line leaves
+    # _CREATE_ROLLBACK_COMPLETE=0, and the trap rolls back on shell exit.
+    _CREATE_ROLLBACK_COMPLETE=1
+    trap - EXIT
   fi
 
   if [[ $json_mode -eq 1 ]]; then
@@ -3940,6 +4101,74 @@ PY
         bridge_warn "agent delete: --purge-home refused: resolved home outside expected agent roots: $home_dir"
         ;;
     esac
+
+    # Issue #1076: on a v2 install, `bridge_agent_default_home` resolves
+    # to `$BRIDGE_AGENT_ROOT_V2/<agent>/home` — ONE of the two children of
+    # the per-agent root. The sibling `workdir/` and the per-agent root
+    # itself are NOT covered above and accumulate root-owned residue from
+    # a prior isolated create that aborted mid-flow. Without this purge
+    # the next `agent create <same-name>` re-hits the same PermissionError
+    # the issue documents (`agents/<a>/.claude` mkdir fails because the
+    # parent is root-owned 2750). Use the layout accessor when available
+    # so the path source is consistent with the create flow.
+    if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+      local v2_agent_root="$BRIDGE_AGENT_ROOT_V2/$agent"
+      if [[ -d "$v2_agent_root" ]]; then
+        # Sibling workdir under the per-agent root.
+        local v2_workdir="$v2_agent_root/workdir"
+        if [[ -d "$v2_workdir" ]]; then
+          if command -v bridge_linux_sudo_root >/dev/null 2>&1; then
+            bridge_linux_sudo_root rm -rf -- "$v2_workdir" || \
+              bridge_warn "agent delete: --purge-home best-effort rm failed: $v2_workdir"
+          else
+            rm -rf -- "$v2_workdir" || \
+              bridge_warn "agent delete: --purge-home best-effort rm failed: $v2_workdir"
+          fi
+        fi
+        # The per-agent root parent — root-owned 2750 on isolated installs.
+        # Rm it last so its children are gone first. Use sudo when the
+        # controller cannot rm directly (isolated parent ownership).
+        if command -v bridge_linux_sudo_root >/dev/null 2>&1; then
+          bridge_linux_sudo_root rm -rf -- "$v2_agent_root" || \
+            bridge_warn "agent delete: --purge-home best-effort rm failed: $v2_agent_root"
+        else
+          rm -rf -- "$v2_agent_root" || \
+            bridge_warn "agent delete: --purge-home best-effort rm failed: $v2_agent_root"
+        fi
+      fi
+    fi
+
+    # Issue #1076: the tracked-profile-source location
+    # (`$BRIDGE_HOME/agents/<a>/`, via bridge_layout_profile_source_dir)
+    # also accumulates residue — managed agents that go through the v2
+    # shared-settings render path materialize `agents/<a>/.claude/` even
+    # though their canonical home is under the v2 root, and the legacy
+    # layout uses this exact dir as the home tree. Purge it too so a
+    # subsequent create starts clean. Validate the path resolves under
+    # $BRIDGE_AGENT_HOME_ROOT (= $BRIDGE_HOME/agents on a standard
+    # install) before rm so we never escape the agent roots.
+    local profile_src=""
+    if declare -F bridge_layout_profile_source_dir >/dev/null 2>&1; then
+      profile_src="$(bridge_layout_profile_source_dir "$agent" 2>/dev/null || printf '')"
+    elif [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" ]]; then
+      profile_src="$BRIDGE_AGENT_HOME_ROOT/$agent"
+    fi
+    if [[ -n "$profile_src" ]] && [[ -d "$profile_src" ]]; then
+      case "$profile_src" in
+        "${BRIDGE_AGENT_HOME_ROOT:-/dev/null}"/*)
+          if command -v bridge_linux_sudo_root >/dev/null 2>&1; then
+            bridge_linux_sudo_root rm -rf -- "$profile_src" || \
+              bridge_warn "agent delete: --purge-home best-effort rm failed: $profile_src"
+          else
+            rm -rf -- "$profile_src" || \
+              bridge_warn "agent delete: --purge-home best-effort rm failed: $profile_src"
+          fi
+          ;;
+        *)
+          bridge_warn "agent delete: --purge-home refused tracked-profile residue outside BRIDGE_AGENT_HOME_ROOT: $profile_src"
+          ;;
+      esac
+    fi
 
     # Issue #737 Q6: also cover the isolated agent's actual Linux home
     # (`/home/agent-bridge-<agent>/`). `bridge_agent_default_home` only

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -929,6 +929,43 @@ run_agent() {
       failures=$((failures + 1))
       warnings+=("Add a CLAUDE.md file in the tracked profile or live workdir before cutover.")
     fi
+
+    # Issue #1076: half-scaffold detection. A failed `agent create`
+    # before this PR could leave an agent registered in the roster but
+    # missing the core managed-profile files (CLAUDE.md, SOUL.md,
+    # SESSION-TYPE.md, MEMORY.md, MEMORY-SCHEMA.md) in the identity
+    # source. Without this check, `setup agent` reported `start_dry_run:
+    # ok` and `session_smoke: ok` despite an empty profile, and the
+    # next `agent start` launched a session that died with the
+    # watchdog later flagging the missing files. Refuse the success-
+    # shaped exit until the operator repairs (delete + re-create, or
+    # profile redeploy). Read from the identity source (layer 2,
+    # bridge_layout_agent_home) since that's where bridge_scaffold_
+    # agent_home authors on v2; materialization may not have run if
+    # create failed mid-flow.
+    local _profile_home_dir=""
+    if declare -F bridge_layout_agent_home >/dev/null 2>&1; then
+      _profile_home_dir="$(bridge_layout_agent_home "$agent" 2>/dev/null || printf '')"
+    fi
+    if [[ -z "$_profile_home_dir" ]] && declare -F bridge_agent_default_home >/dev/null 2>&1; then
+      _profile_home_dir="$(bridge_agent_default_home "$agent" 2>/dev/null || printf '')"
+    fi
+    if [[ -n "$_profile_home_dir" ]]; then
+      local _missing_core_files=()
+      local _required_file
+      for _required_file in CLAUDE.md SOUL.md SESSION-TYPE.md MEMORY.md MEMORY-SCHEMA.md; do
+        if [[ ! -f "$_profile_home_dir/$_required_file" ]]; then
+          _missing_core_files+=("$_required_file")
+        fi
+      done
+      if [[ ${#_missing_core_files[@]} -gt 0 ]]; then
+        printf 'managed_profile: incomplete (missing: %s)\n' "$(IFS=,; echo "${_missing_core_files[*]}")"
+        failures=$((failures + 1))
+        warnings+=("Profile source $_profile_home_dir is half-scaffolded (missing: ${_missing_core_files[*]}). Run 'agent-bridge agent delete $agent --purge-home --force' then re-create.")
+      else
+        printf 'managed_profile: ok\n'
+      fi
+    fi
   elif [[ "$engine" == "codex" ]]; then
     echo
     echo "== Codex Skills =="
@@ -969,8 +1006,31 @@ run_agent() {
 
   echo
   echo "== Start dry-run =="
+  # Issue #1076: when the managed-profile drift check above already
+  # reported missing core files, refuse to emit `start_dry_run: ok` even
+  # if bridge-start.sh --dry-run returns rc=0 — the agent would launch
+  # but die on its first prompt because CLAUDE.md / SOUL.md are missing.
+  # Surface the half-scaffold state in the start_dry_run line so the
+  # operator sees both signals without scrolling.
+  local _setup_profile_incomplete=0
+  if [[ "$engine" == "claude" ]]; then
+    local _required_file
+    if [[ -n "${_profile_home_dir:-}" ]]; then
+      for _required_file in CLAUDE.md SOUL.md SESSION-TYPE.md MEMORY.md MEMORY-SCHEMA.md; do
+        if [[ ! -f "$_profile_home_dir/$_required_file" ]]; then
+          _setup_profile_incomplete=1
+          break
+        fi
+      done
+    fi
+  fi
   if start_output="$("$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" --dry-run 2>&1)"; then
-    echo "start_dry_run: ok"
+    if [[ $_setup_profile_incomplete -eq 1 ]]; then
+      echo "start_dry_run: blocked (managed_profile incomplete)"
+      failures=$((failures + 1))
+    else
+      echo "start_dry_run: ok"
+    fi
     echo "$start_output"
   else
     echo "start_dry_run: error"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11525,4 +11525,12 @@ bash "$REPO_ROOT/scripts/smoke/isolated-agent-delete-reap.sh"
 log "running a2a-cross-bridge smoke (issue #1032)"
 bash "$REPO_ROOT/scripts/smoke/a2a-cross-bridge.sh"
 
+# `agent create` rollback on mid-flow failure + `agent delete --purge-home`
+# residue removal. T1 forces a mid-create PermissionError on the v2 workdir's
+# .claude mkdir and asserts the agent is NOT registered + no scaffold remains.
+# T2 runs create → delete --purge-home → re-create and asserts the cycle
+# succeeds (the issue's user repro on Linux v0.14.5-beta5).
+log "running create-atomicity-and-purge smoke (issue #1076)"
+bash "$REPO_ROOT/scripts/smoke/1076-create-atomicity-and-purge.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
+++ b/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
@@ -79,12 +79,12 @@ write_driver() {
     'SCRIPT_DIR="$REPO_ROOT"' \
     'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
     'FUNC_TMP="$DRIVER_TMP_DIR/scaffold-funcs.sh"' \
-    '# Line ranges realigned for CODEX-PROV (#1067): scaffold moved from' \
-    '# 385→391; render_template_string was wider than needed.' \
+    '# Line ranges realigned for #1076 (atomic create rollback) — scaffold' \
+    '# moved from 391→502, render_template_string moved from 194→305.' \
     '{' \
     '  sed -n "128,131p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "194,231p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "391,624p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "305,342p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "502,735p" "$REPO_ROOT/bridge-agent.sh"' \
     '} > "$FUNC_TMP"' \
     'source "$FUNC_TMP"' \
     'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: scaffold not loaded"; exit 91; }' \

--- a/scripts/smoke/1076-create-atomicity-and-purge.sh
+++ b/scripts/smoke/1076-create-atomicity-and-purge.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1076-create-atomicity-and-purge.sh — Issue #1076.
+#
+# Pins two contracts:
+#
+#  1. `agent create` is atomic. When a mid-flow step raises (here: a
+#     root-owned `agents/<a>/.claude` residue from a prior failed isolated
+#     create that the controller cannot mkdir under), the create flow
+#     unwinds the roster registration AND removes the partially-scaffolded
+#     home tree. End state: agent is NOT in the local roster, no
+#     half-scaffolded identity tree under `data/agents/<a>/`.
+#
+#  2. `agent delete --purge-home` removes ALL residue — the v2 per-agent
+#     root (`$BRIDGE_AGENT_ROOT_V2/<a>/`) AND the tracked-profile-source
+#     location (`$BRIDGE_HOME/agents/<a>/`). A subsequent
+#     `agent create <same-name>` succeeds.
+#
+# Both contracts were the literal user repro on Linux v0.14.5-beta5 in
+# the issue body. Smoke runs the create + delete via bridge-agent.sh
+# directly with BRIDGE_CALLER_SOURCE armed so the typed-write trust gate
+# admits the smoke invocation (same pattern as the in-tree smoke create
+# block).
+
+set -uo pipefail
+
+SMOKE_NAME="1076-create-atomicity-and-purge"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# The typed-create gate (issue #1047) requires an operator-trusted source.
+# Smoke is non-interactive, so arm the trusted-id env var the way smoke-
+# test.sh's main create block does.
+export BRIDGE_CALLER_SOURCE="operator-trusted-id"
+
+# `agent delete` requires an admin caller (`bridge_agent_update_caller_is_
+# admin`) and BRIDGE_ADMIN_AGENT_ID set. Seed an admin in the roster file
+# so delete --from <admin> passes the trust gate.
+ADMIN_AGENT="admin-1076"
+export BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT"
+# Lightweight admin registration: append a stub managed-role block so
+# bridge_roster_local_mentions_agent + bridge_admin_agent_id resolve.
+# `bridge_load_roster` calls `bridge_reset_roster_maps` which unsets
+# BRIDGE_ADMIN_AGENT_ID, so the variable must be set INSIDE the roster
+# file (every bridge subprocess re-loads). Same shape as a real install
+# (see lib/bridge-agents.sh:3224 in the launch_cmd render block).
+cat >>"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+BRIDGE_ADMIN_AGENT_ID="$ADMIN_AGENT"
+# BEGIN AGENT BRIDGE MANAGED ROLE: $ADMIN_AGENT
+bridge_add_agent_id_if_missing $ADMIN_AGENT
+BRIDGE_AGENT_DESC[$ADMIN_AGENT]="probe-1076 admin"
+BRIDGE_AGENT_ENGINE[$ADMIN_AGENT]=claude
+BRIDGE_AGENT_SESSION[$ADMIN_AGENT]=$ADMIN_AGENT
+BRIDGE_AGENT_WORKDIR[$ADMIN_AGENT]=$BRIDGE_AGENT_ROOT_V2/$ADMIN_AGENT/workdir
+BRIDGE_AGENT_SOURCE[$ADMIN_AGENT]="static"
+BRIDGE_AGENT_LAUNCH_CMD[$ADMIN_AGENT]="claude --dangerously-skip-permissions"
+BRIDGE_AGENT_CONTINUE[$ADMIN_AGENT]="1"
+BRIDGE_AGENT_ISOLATION_MODE[$ADMIN_AGENT]="shared"
+# END AGENT BRIDGE MANAGED ROLE: $ADMIN_AGENT
+EOF
+
+AGENT_ID="probe-1076"
+ROSTER_FILE="$BRIDGE_ROSTER_LOCAL_FILE"
+
+run_create() {
+  # shellcheck disable=SC2317  # invoked indirectly via $()
+  BRIDGE_AGENT_ID="$ADMIN_AGENT" \
+    "$BRIDGE_BASH" "$REPO_ROOT/bridge-agent.sh" create "$AGENT_ID" \
+    --engine claude --session "$AGENT_ID" 2>&1
+}
+
+run_delete_purge() {
+  BRIDGE_AGENT_ID="$ADMIN_AGENT" \
+    "$BRIDGE_BASH" "$REPO_ROOT/bridge-agent.sh" delete "$AGENT_ID" \
+    --from "$ADMIN_AGENT" --force --purge-home --orphan-tasks 2>&1
+}
+
+assert_not_in_roster() {
+  local context="$1"
+  # Anchor with $ to avoid prefix-matching probe-1076-admin against probe-1076.
+  if grep -Eq "AGENT BRIDGE MANAGED ROLE: $AGENT_ID\$" "$ROSTER_FILE" 2>/dev/null; then
+    smoke_fail "$context: agent '$AGENT_ID' still present in roster $ROSTER_FILE"
+  fi
+}
+
+assert_in_roster() {
+  local context="$1"
+  grep -Eq "AGENT BRIDGE MANAGED ROLE: $AGENT_ID\$" "$ROSTER_FILE" 2>/dev/null \
+    || smoke_fail "$context: agent '$AGENT_ID' is NOT in roster $ROSTER_FILE"
+}
+
+# ---- T1: mid-create failure leaves NO registered agent and NO residue ----
+smoke_log "T1: mid-create failure rolls back (no half-create)"
+
+# Force a mid-create failure by pre-creating the v2 per-agent root with
+# an unwritable child the scaffold path would touch. The repro from the
+# issue uses a root-owned `data/agents/<a>/` from a prior aborted
+# isolated create — we simulate with an unwritable tracked-profile parent
+# (the controller can't mkdir `agents/<a>/.claude` for shared-settings
+# render even when the v2 home/ is freely owned).
+#
+# `bridge_ensure_auto_memory_isolation` runs before write_role_block and
+# calls `mkdir -p "$workdir/.claude"`. If the v2 workdir is pre-created
+# with mode 0500 (controller r-x but no write), that mkdir fails with
+# PermissionError and the create dies BEFORE writing the role block.
+# Rollback should still rm the scaffold target (the identity source under
+# `data/agents/<a>/home/`) that bridge_scaffold_agent_home authored just
+# before the failure point.
+PRE_BLOCK_WORKDIR="$BRIDGE_AGENT_ROOT_V2/$AGENT_ID/workdir"
+mkdir -p "$PRE_BLOCK_WORKDIR"
+# Drop write permission so $workdir/.claude mkdir fails for the
+# controller; keep r-x so the bridge_die's `[[ -e $workdir ]]` empty-dir
+# probe still works.
+chmod 0500 "$PRE_BLOCK_WORKDIR"
+
+T1_OUT="$(run_create || true)"
+
+# Restore write so cleanup can rm.
+chmod 0700 "$PRE_BLOCK_WORKDIR" 2>/dev/null || true
+
+# Agent must NOT be in the roster after a failed create.
+assert_not_in_roster "T1"
+
+# The identity-source scaffold under data/agents/<a>/home/ must NOT
+# remain after rollback. (The rollback rmtree guard removes it.)
+if [[ -d "$BRIDGE_AGENT_ROOT_V2/$AGENT_ID/home" ]]; then
+  smoke_fail "T1: identity-source residue remains under $BRIDGE_AGENT_ROOT_V2/$AGENT_ID/home after failed create — rollback did not unwind scaffold. create_out=$T1_OUT"
+fi
+
+# The v2 per-agent root parent may remain if the operator pre-created it
+# (we did, here), but bridge_scaffold_agent_home pre-creates the home/
+# sibling inside the parent — that sibling MUST be gone.
+smoke_log "ok: T1 — failed create did not leave a registered agent or scaffold residue"
+
+# Clean the simulated pre-existing residue so T2 starts from a clean slate.
+rm -rf "${BRIDGE_AGENT_ROOT_V2:?}/${AGENT_ID:?}" 2>/dev/null || true
+
+# ---- T2: create → delete --purge-home → create succeeds ----
+smoke_log "T2: create / delete --purge-home / re-create cycle"
+
+# Fresh create (no pre-block this time) must succeed.
+T2_CREATE_OUT="$(run_create)" || smoke_fail "T2: initial create failed.
+$T2_CREATE_OUT"
+smoke_assert_contains "$T2_CREATE_OUT" "create: ok" "T2: first create"
+assert_in_roster "T2 after initial create"
+
+# Identity source + workspace + tracked-profile dir must exist after a
+# successful create (proves we have residue to test the purge against).
+smoke_assert_file_exists "$BRIDGE_AGENT_ROOT_V2/$AGENT_ID/home/CLAUDE.md" \
+  "T2 after create: identity source CLAUDE.md"
+
+# Delete with --purge-home must clear ALL residue.
+T2_DELETE_OUT="$(run_delete_purge)" || smoke_fail "T2: agent delete failed.
+$T2_DELETE_OUT"
+smoke_assert_contains "$T2_DELETE_OUT" "deleted: yes" "T2: delete"
+assert_not_in_roster "T2 after delete"
+
+# Residue assertions: no per-agent v2 root, no tracked-profile dir.
+if [[ -d "$BRIDGE_AGENT_ROOT_V2/$AGENT_ID" ]]; then
+  smoke_fail "T2: --purge-home left v2 per-agent root: $BRIDGE_AGENT_ROOT_V2/$AGENT_ID"
+fi
+if [[ -d "$BRIDGE_AGENT_HOME_ROOT/$AGENT_ID" ]]; then
+  smoke_fail "T2: --purge-home left tracked-profile residue: $BRIDGE_AGENT_HOME_ROOT/$AGENT_ID"
+fi
+
+# Re-create must succeed — this is the specific bug the user hit (the
+# second create re-tripped the PermissionError chain because residue
+# was still owned/locked from the first round).
+T2_RECREATE_OUT="$(run_create)" || smoke_fail "T2: re-create after --purge-home failed (issue #1076 regression).
+$T2_RECREATE_OUT"
+smoke_assert_contains "$T2_RECREATE_OUT" "create: ok" "T2: re-create"
+assert_in_roster "T2 after re-create"
+smoke_assert_file_exists "$BRIDGE_AGENT_ROOT_V2/$AGENT_ID/home/CLAUDE.md" \
+  "T2 after re-create: identity source CLAUDE.md re-authored"
+
+smoke_log "ok: T2 — create / delete --purge-home / re-create cycle succeeded"
+
+# Cleanup roster + state for any sibling smokes.
+run_delete_purge >/dev/null 2>&1 || true
+
+smoke_log "all tests PASS — issue #1076: atomic create + complete --purge-home"

--- a/scripts/smoke/v2-scaffold-home-and-workdir.sh
+++ b/scripts/smoke/v2-scaffold-home-and-workdir.sh
@@ -121,15 +121,16 @@ write_driver_script() {
     'SCRIPT_DIR="$REPO_ROOT"' \
     'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
     'FUNC_TMP="$DRIVER_TMP_DIR/scaffold-funcs.sh"' \
-    '# Line ranges updated post-CODEX-PROV (#1067): scaffold moved from' \
-    '# 385→391 and render_template ranges shifted. Function-by-name extract' \
-    '# via awk is fragile here because render_template_string contains a' \
-    '# Python heredoc whose dict closes with `^}$` mid-function. Sticking' \
-    '# with explicit line ranges, kept in sync when bridge-agent.sh changes.' \
+    '# Line ranges updated post-#1076 (atomic create rollback): scaffold' \
+    '# moved from 391→502, render_template_string from 194→305. Function-' \
+    '# by-name extract via awk is fragile here because render_template_' \
+    '# string contains a Python heredoc whose dict closes with `^}$`' \
+    '# mid-function. Sticking with explicit line ranges, kept in sync when' \
+    '# bridge-agent.sh changes.' \
     '{' \
     '  sed -n "128,131p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "194,231p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "391,624p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "305,342p" "$REPO_ROOT/bridge-agent.sh"' \
+    '  sed -n "502,735p" "$REPO_ROOT/bridge-agent.sh"' \
     '} > "$FUNC_TMP"' \
     'source "$FUNC_TMP"' \
     'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_scaffold_agent_home not loaded"; exit 91; }' \


### PR DESCRIPTION
## Summary

Closes #1076. `agent create` is now atomic — a mid-flow failure rolls back the roster registration + partial scaffold so the agent ends up either fully created or not registered at all. `agent delete --purge-home` purges all residue (v2 per-agent root + sibling `workdir/` + tracked-profile-source `agents/<a>/`) so a subsequent create starts clean.

## Changes

- **`run_create` rollback (bridge-agent.sh)** — EXIT trap armed before the first mutation, disarmed on the success-clear. `bridge_agent_create_rollback` excises the roster managed-role block (when written) via `roster-excise-block.py`, rm's the scaffold target / auto-derived v2 workdir / v2 per-agent root parent, and rmdir's any empty tracked-profile-source residue. All paths validated against `BRIDGE_AGENT_HOME_ROOT` / `BRIDGE_AGENT_ROOT_V2` prefixes; sudo fallback when controller perms are insufficient. Best-effort throughout — the rollback itself never re-raises.

- **Half-scaffold detection (bridge-setup.sh)** — `setup agent` now reads the per-agent identity source (via `bridge_layout_agent_home`) and emits `managed_profile: incomplete (missing: ...)` when any of `CLAUDE.md`/`SOUL.md`/`SESSION-TYPE.md`/`MEMORY.md`/`MEMORY-SCHEMA.md` are absent. `start_dry_run: blocked (managed_profile incomplete)` replaces the misleading `ok` when the profile is half-scaffolded. Both bump `failures` so the subcommand exits non-zero.

- **`agent delete --purge-home` complete residue (bridge-agent.sh)** — also purges the v2 per-agent root parent + sibling `workdir/` (previously only one of the two children was resolved via `bridge_agent_default_home`) AND the tracked-profile-source location (`bridge_layout_profile_source_dir`).

## Layout accessors

Consumes `bridge_layout_agent_home` and `bridge_layout_profile_source_dir` from #1081 with `bridge_agent_default_home` / `BRIDGE_AGENT_HOME_ROOT/<agent>` fallbacks for callers that haven't loaded the layout module.

## Test plan

- [x] `bash -n` on `bridge-agent.sh`, `bridge-setup.sh`, all new/touched smoke scripts
- [x] `shellcheck` clean on the same set
- [x] `python3 -c py_compile.compile(...)` on `roster-excise-block.py`, `bridge-hooks.py`, `bridge-profile.py`, `bridge-watchdog.py`
- [x] New smoke `scripts/smoke/1076-create-atomicity-and-purge.sh` passes:
  - T1: forced mid-create PermissionError (chmod 0500 v2 workdir → `bridge_ensure_auto_memory_isolation` mkdir fails) → asserts agent NOT in roster AND no scaffold residue
  - T2: create → delete --purge-home → re-create cycle succeeds (literal user repro from the issue body)
- [x] Sibling smokes still pass after the `sed` line-range realignment: `1060-layout-fresh-v2-static-claude.sh`, `1060-layout-fresh-v2-static-codex.sh`, `1060-layout-shared-workdir-pair.sh`, `1067-codex-provisioning.sh`, `v2-scaffold-home-and-workdir.sh`, `1025-isolated-create-agent-env-install.sh`, `isolated-agent-delete-reap.sh`, `989-isolated-agent-env-state-dir.sh`, `981-restart-session-resume-snapshot.sh`, `1058-bootstrap-tmux-ux.sh`
- [x] `./scripts/smoke-test.sh` — pre-existing live-install leak failure reproduces on `origin/release/v0.14.5-beta6-integration` HEAD (`a4a6d96`) without any edits; not introduced by this change. The new `1076-create-atomicity-and-purge.sh` is wired into the runner.

## Out of scope

- The unrelated PermissionError dump in the isolation-cleanup step (already folded into LAYOUT #1081 as the beta5 QA #1).
- VERSION/CHANGELOG (per beta6 wave policy).