### PR TITLE
fix(layout): defensive unset of stale BRIDGE_LAYOUT in pane launch envelope (#1101)

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -4,6 +4,33 @@
 set -uo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# Issue #1101: defensive unset of stale BRIDGE_LAYOUT/BRIDGE_DATA_ROOT before
+# sourcing bridge-lib.sh. This is the launch envelope tmux runs as the pane's
+# session command, so anything we drop here is never seen by the child agent
+# process (Claude/Codex) or any Bash-tool subshells it spawns inside the pane.
+#
+# Background: PR #1019 §B stopped the daemon's launch-envelope writer
+# (`bridge_write_linux_agent_env_file`) from baking `BRIDGE_LAYOUT=legacy`
+# into the per-agent env file, and the layout-resolver demotes the same
+# value when a v2 marker exists. But on installs that ran a pre-#1019 daemon
+# with `BRIDGE_LAYOUT=legacy` in its ambient env (operator shell rc, stale
+# tmux server env, …), the value was already copied into the parent process
+# chain (daemon → bridge-start.sh → tmux new-session) BEFORE the resolver
+# demoted it, so every pane this script launches still inherits the stale
+# value. The resolver in the resulting child shells then re-fires the
+# "stale pre-v0.8.0 env override" warning on every CLI call.
+#
+# Gating: only drop when a valid v2 layout marker is present. Without a
+# marker the resolver's hard-die path is the correct outcome — operators on
+# legacy installs need the upgrade prompt, not a silent normalization.
+_bridge_run_layout_marker="${BRIDGE_LAYOUT_MARKER_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/state}/layout-marker.sh"
+if [[ -f "$_bridge_run_layout_marker" ]] \
+    && [[ "${BRIDGE_LAYOUT:-}" == "legacy" || "${BRIDGE_LAYOUT:-}" == "v1" ]]; then
+  unset BRIDGE_LAYOUT BRIDGE_DATA_ROOT
+fi
+unset _bridge_run_layout_marker
+
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -180,7 +180,7 @@ bridge_layout_resolver_validate_env() {
           # `tmux setenv -u -g` cleanup that actually removes the
           # server-level leak (bridge-upgrade.sh).
           if [[ -z "${_BRIDGE_LAYOUT_STALE_ENV_WARNED:-}" ]]; then
-            bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence: \`unset BRIDGE_LAYOUT\` in your shell rc, then stop and restart the bridge daemon from a clean shell (\`bash bridge-daemon.sh stop\` then \`bash bridge-daemon.sh start\`) so long-running daemon/agent processes stop re-injecting the stale value. A leftover tmux server-level leak is cleared by \`agent-bridge upgrade --apply\`."
+            bridge_warn "BRIDGE_LAYOUT=${layout} is a stale pre-v0.8.0 env override; marker ${_stale_marker_path} pins this install to v2. Preferring marker. To silence permanently: (1) \`unset BRIDGE_LAYOUT\` in your shell rc; (2) stop and restart the bridge daemon from a clean shell (\`bash bridge-daemon.sh stop\` then \`bash bridge-daemon.sh start\`) so the next pane launch envelope is clean; (3) restart any long-running agent panes that pre-date this fix — those panes inherited the stale value into their own process tree and a daemon restart does NOT reach back to clear it (use \`agb agent restart <name>\` per agent, or restart all panes via \`bash bridge-start.sh <name> --replace\`). A leftover tmux server-level leak is cleared by \`agent-bridge upgrade --apply\`. Issue #1101 has the full propagation chain."
             export _BRIDGE_LAYOUT_STALE_ENV_WARNED=1
           fi
           BRIDGE_LAYOUT_IGNORED_PARTIAL_ENV="BRIDGE_LAYOUT (stale ${layout} override; marker=v2)"


### PR DESCRIPTION
## Summary

- `bridge-run.sh` (the tmux pane session command) defensively `unset`s a stale
  ambient `BRIDGE_LAYOUT=legacy|v1` BEFORE sourcing `bridge-lib.sh`, gated on
  the presence of a valid v2 layout marker. The launch envelope no longer
  carries the stale value forward into the child agent process or any Bash-tool
  subshells the agent spawns inside the pane — per-CLI-call "stale pre-v0.8.0
  env override" warnings stop polluting transcripts after the next pane
  restart.
- Tightens the resolver's warning text in `lib/bridge-layout-resolver.sh` to
  explicitly call out the long-running-agent-pane case that PR #1019 §B
  couldn't reach: operators now learn they must restart any panes that
  pre-date this fix (`agb agent restart <name>` per agent, or
  `bash bridge-start.sh <name> --replace`) in addition to unsetting their rc
  and restarting the daemon.

## Background

PR #1019 §B (`bridge_write_linux_agent_env_file` normalization) stopped the
daemon from baking `BRIDGE_LAYOUT=legacy` into newly-generated launch
envelopes, but on installs whose pre-#1019 daemon ran with `BRIDGE_LAYOUT=
legacy` in its ambient env (operator shell rc, stale tmux server env, ...),
the value was already copied into the parent process chain
(daemon → bridge-start.sh → tmux new-session) BEFORE the resolver demoted
it. A subsequent daemon restart cannot reach back into a long-lived child
process's env block to clear it. The resolver in those long-lived panes then
re-fires the warning on every `agb`/`agent-bridge` call. Issue #1101 traces
the full propagation chain.

## Scope

Two complementary fixes, both small:

1. **Defensive unset in `bridge-run.sh`** — `unset BRIDGE_LAYOUT
   BRIDGE_DATA_ROOT` BEFORE `source bridge-lib.sh`, gated on
   `state/layout-marker.sh` existence + ambient value in `{legacy, v1}`. This
   handles newly-launched panes (e.g., after `agent restart`) but does not
   reach into already-running panes.
2. **Tighter resolver warning text** — the previous text told operators to
   unset their rc and restart the daemon, but did not mention that long-lived
   panes need an explicit per-agent restart. The new text spells out the
   three-step remediation (rc → daemon → per-agent pane restart) and points
   at Issue #1101 for the propagation chain.

The brief offered an optional `agb daemon restart --restart-agent-panes`
flag; intentionally skipped to keep the change minimal — `agb agent restart`
+ `bridge-start.sh <name> --replace` already cover the manual case, and the
tighter warning text now points operators at them.

## Out of scope

- Wider tmux env-management refactor.
- VERSION / CHANGELOG bumps (per the v0.13.10+ batched-release directive).

## Verification

Pre-existing `[smoke][error] smoke leaked agent dirs into the live install`
failure reproduces identically on `release/v0.14.5-beta6-integration` HEAD
without the patch — unrelated to this change.

Isolated `BRIDGE_HOME` repro (homebrew bash, v2 marker present + ambient
`BRIDGE_LAYOUT=legacy`):

- **Test A** — direct `source bridge-lib.sh` (no defensive unset): warning
  fires with the new three-step remediation text, resolver still picks
  `BRIDGE_LAYOUT_SOURCE=marker` / `BRIDGE_LAYOUT=v2`.
- **Test B** — `bridge-run.sh`-style defensive unset, then
  `source bridge-lib.sh`: warning suppressed, resolver picks
  `BRIDGE_LAYOUT_SOURCE=marker` / `BRIDGE_LAYOUT=v2`. No regression on the
  resolver's marker preference.
- **Test C** — markerless install + `BRIDGE_LAYOUT=legacy` ambient: defensive
  gate (marker-required) correctly leaves the legacy value intact; resolver
  hard-dies with the `agent-bridge upgrade --apply` migration prompt.
- **Test D** — clean ambient + marker present: defensive block is a no-op,
  resolver picks `BRIDGE_LAYOUT_SOURCE=env` / `BRIDGE_LAYOUT=v2` (bootstrap
  re-exports from marker).
- **Test E** — `BRIDGE_LAYOUT=v1` ambient + marker: defensive unset fires,
  resolver picks `BRIDGE_LAYOUT_SOURCE=marker`.
- **Test F** — `BRIDGE_LAYOUT=v2` ambient + marker: defensive block correctly
  does NOT drop the explicit v2 value, resolver picks
  `BRIDGE_LAYOUT_SOURCE=env`.

`bash -n` + `shellcheck` clean on both changed files.

## Test plan

- [ ] Manual: on a host with the symptom (pre-PR#1019 daemon legacy
      inheritance into a long-lived pane), `agb agent restart <name>` and
      confirm post-restart `agb inbox <name>` from inside the new pane no
      longer emits the warning.
- [ ] Manual: on a markerless install (rare in the wild), confirm the
      resolver still hard-dies with the upgrade prompt rather than silently
      normalizing.
- [ ] Manual: confirm the new warning text accurately reflects the per-agent
      restart step on a host where the pre-restart pane still emits it.

Fixes #1101
