### PR TITLE
fix(beta6): r2 integration review — extract-shell-fn helper + migrator verify contract + changelog ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4812,8 +4812,8 @@ v0.6.17; pulling latest `main` is sufficient.
   isolated subprocesses can still benefit from the grant when ACL
   infrastructure is available.
 - Docs: `docs/agent-runtime/memory-daily-harvest.md` §10 rewritten;
-  new `docs/handoff/219-linux-isolation-e2e.md` (Linux server admin
-  patch E2E runbook).
+  added Linux server admin patch E2E runbook (later removed in
+  v0.14.5-beta6 repo cleanup, #1110).
 - Smoke additions: scenario 9 (shared/aggregate path), scenario 14
   (stub isolation + readable `.claude/projects` → `--transcripts-home`
   dispatch, no sudo), scenario 15 (unreadable target → structured

--- a/scripts/python-helpers/migrate-legacy-install-helper.py
+++ b/scripts/python-helpers/migrate-legacy-install-helper.py
@@ -892,6 +892,12 @@ def cmd_apply(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 def cmd_verify(args: argparse.Namespace) -> int:
+    # beta6 contract: verify is a target-FS inspection helper. It intentionally
+    # does NOT shell out to `bridge_layout_*` resolvers from bridge-lib.sh —
+    # the layout-resolver integration is bundled with `apply` and is deferred
+    # to beta7 (#1087). Verify infers v2-vs-legacy by reading the target's
+    # `state/layout-marker.sh` directly so it can run against any install
+    # without needing the source checkout's bridge-lib.sh sourceable.
     target = Path(args.target).expanduser().resolve()
     repo_root = Path(args.repo_root).expanduser().resolve()
 

--- a/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
+++ b/scripts/smoke/1060-layout-fresh-v2-static-claude.sh
@@ -79,13 +79,9 @@ write_driver() {
     'SCRIPT_DIR="$REPO_ROOT"' \
     'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
     'FUNC_TMP="$DRIVER_TMP_DIR/scaffold-funcs.sh"' \
-    '# Line ranges realigned for #1076 (atomic create rollback) — scaffold' \
-    '# moved from 391→502, render_template_string moved from 194→305.' \
-    '{' \
-    '  sed -n "128,131p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "305,342p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "502,735p" "$REPO_ROOT/bridge-agent.sh"' \
-    '} > "$FUNC_TMP"' \
+    '# Extract by function name (heredoc-aware) so the smoke survives' \
+    '# line shifts in bridge-agent.sh. See scripts/smoke/helpers/extract-shell-fn.py.' \
+    'python3 "$REPO_ROOT/scripts/smoke/helpers/extract-shell-fn.py" "$REPO_ROOT/bridge-agent.sh" bridge_agent_manage_python bridge_render_template_string bridge_scaffold_agent_home > "$FUNC_TMP"' \
     'source "$FUNC_TMP"' \
     'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: scaffold not loaded"; exit 91; }' \
     'declare -F bridge_layout_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: layout resolver not loaded"; exit 92; }' \

--- a/scripts/smoke/helpers/extract-shell-fn.py
+++ b/scripts/smoke/helpers/extract-shell-fn.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Extract bash function definitions by name from a shell source file.
+
+Used by smoke drivers to source specific functions out of bridge-agent.sh
+without executing its top-level dispatch. Robust against `}` lines that
+appear inside heredocs (e.g. embedded Python literal dicts).
+
+Convention: a function definition starts with `name() {` (optional
+`function` keyword) and ends with a line containing exactly `}`. The
+extractor tracks heredoc state (`<<TAG`, `<<-TAG`, `<<'TAG'`, `<<"TAG"`,
+ignoring `<<<` here-strings) so closing braces inside heredoc bodies do
+not terminate the function early.
+
+Usage: extract-shell-fn.py <source-file> <fn-name> [<fn-name> ...]
+Outputs the concatenated function bodies to stdout.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+
+_FN_PATTERN_TEMPLATE = r"^\s*(?:function\s+)?{name}\s*\(\)\s*\{{?\s*$"
+_HEREDOC_OPEN = re.compile(
+    r"<<-?\s*([\'\"]?)([A-Za-z_][A-Za-z0-9_]*)\1"
+)
+_HERESTRING = re.compile(r"<<<")
+
+
+def _extract_one(lines: list[str], fn_name: str) -> str:
+    pattern = re.compile(_FN_PATTERN_TEMPLATE.format(name=re.escape(fn_name)))
+    start = None
+    for i, line in enumerate(lines):
+        if pattern.match(line):
+            start = i
+            break
+    if start is None:
+        sys.stderr.write(f"extract-shell-fn: function not found: {fn_name}\n")
+        sys.exit(2)
+
+    out: list[str] = []
+    heredoc_tag: str | None = None
+    for i in range(start, len(lines)):
+        line = lines[i]
+        out.append(line)
+
+        if heredoc_tag is not None:
+            if line.strip() == heredoc_tag:
+                heredoc_tag = None
+            continue
+
+        # Detect a new heredoc opener while ignoring `<<<` here-strings.
+        scan = _HERESTRING.sub("", line)
+        match = _HEREDOC_OPEN.search(scan)
+        if match:
+            heredoc_tag = match.group(2)
+            continue
+
+        if i > start and line == "}":
+            break
+
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        sys.stderr.write(
+            "usage: extract-shell-fn.py <source-file> <fn-name> [<fn-name> ...]\n"
+        )
+        return 2
+    with open(sys.argv[1], "r", encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+    for fn_name in sys.argv[2:]:
+        sys.stdout.write(_extract_one(lines, fn_name))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/smoke/v2-scaffold-home-and-workdir.sh
+++ b/scripts/smoke/v2-scaffold-home-and-workdir.sh
@@ -121,17 +121,9 @@ write_driver_script() {
     'SCRIPT_DIR="$REPO_ROOT"' \
     'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
     'FUNC_TMP="$DRIVER_TMP_DIR/scaffold-funcs.sh"' \
-    '# Line ranges updated post-#1076 (atomic create rollback): scaffold' \
-    '# moved from 391→502, render_template_string from 194→305. Function-' \
-    '# by-name extract via awk is fragile here because render_template_' \
-    '# string contains a Python heredoc whose dict closes with `^}$`' \
-    '# mid-function. Sticking with explicit line ranges, kept in sync when' \
-    '# bridge-agent.sh changes.' \
-    '{' \
-    '  sed -n "128,131p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "305,342p" "$REPO_ROOT/bridge-agent.sh"' \
-    '  sed -n "502,735p" "$REPO_ROOT/bridge-agent.sh"' \
-    '} > "$FUNC_TMP"' \
+    '# Extract by function name (heredoc-aware) so the smoke survives' \
+    '# line shifts in bridge-agent.sh. See scripts/smoke/helpers/extract-shell-fn.py.' \
+    'python3 "$REPO_ROOT/scripts/smoke/helpers/extract-shell-fn.py" "$REPO_ROOT/bridge-agent.sh" bridge_agent_manage_python bridge_render_template_string bridge_scaffold_agent_home > "$FUNC_TMP"' \
     'source "$FUNC_TMP"' \
     'declare -F bridge_scaffold_agent_home >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_scaffold_agent_home not loaded"; exit 91; }' \
     '# Stub template renderer to a no-op so scaffold returns immediately' \


### PR DESCRIPTION
## Summary

Addresses codex r1 integration review (task #5685) for v0.14.5-beta6. 2 BLOCKING + 1 SHOULD-FIX.

- **BLOCKING #1** Scaffold smoke `DRIVER_FAIL` on integration HEAD — hardcoded sed line ranges in `1060-layout-fresh-v2-static-claude.sh` + `v2-scaffold-home-and-workdir.sh` extracted invalid fragments after #1067/#1075/#1076 shifted `bridge-agent.sh` layout. Replaced with new `scripts/smoke/helpers/extract-shell-fn.py` (heredoc-aware function-name extractor).
- **BLOCKING #2** MIGRATOR verify path contract drift — documented that verify intentionally inspects target FS directly (so it can run without sourcing the source-checkout's bridge-lib.sh); layout-resolver integration bundles with `apply` and is already in scope of beta7 follow-up #1087.
- **SHOULD-FIX #3** CHANGELOG.md:4814-4816 still referenced deleted `docs/handoff/219-linux-isolation-e2e.md` (removed in #1110). Replaced with topical description + removal note.

## Test plan

- [x] `python3 -m py_compile scripts/smoke/helpers/extract-shell-fn.py` PASS
- [x] `python3 -m py_compile scripts/python-helpers/migrate-legacy-install-helper.py` PASS
- [x] `bash -n` on changed smokes PASS
- [x] `bash scripts/lint-heredoc-ban.sh --baseline-check` PASS
- [x] `bash scripts/smoke/1060-layout-fresh-v2-static-claude.sh` → all tests PASS
- [x] `bash scripts/smoke/v2-scaffold-home-and-workdir.sh` → T1 PASS, T2 SKIP (non-Linux)
- [x] `bash scripts/smoke/1060-layout-fresh-v2-static-codex.sh` → all tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
