### PR TITLE
fix(watchdog): back-fill identity markers into v2 runtime workdir for legacy-migrated agents (#1113)

### DIFF
--- a/.lint-heredoc-baseline.tsv
+++ b/.lint-heredoc-baseline.tsv
@@ -118,7 +118,7 @@ bridge-upgrade.sh	1442	C3	674269ba5d1496f502b9f41abdf80da2864580442023f5b7c44d69
 bridge-upgrade.sh	1696	C3	ee2531cb84d04ac3f1033740f7befe85df1e4dd0efe556e0062c98c267ca6c5c	interpreter heredoc, no capture	patch	Phase 3 PR C
 bridge-upgrade.sh	1748	C3	fc4776a956841e63c8d8f102d10565d33762638341c9940f87a2585e8b3e41da	interpreter heredoc, no capture	patch	Phase 3 PR C
 bridge-upgrade.sh	1968	C3	8dd953f98d8205a0a40ad0a0d211508193419f78dc107f0d83d48aedfe711b8e	interpreter heredoc, no capture	patch	Phase 3 PR C
-bridge-upgrade.sh	2484	C3	00cfa9265325e4f8d9d18009831fc9564186c5905b2af18ee9103a5aaa32a82c	interpreter heredoc, no capture	patch	Phase 3 PR C
+bridge-upgrade.sh	2563	C3	7a105d5644aa6d7aac4c5fb50edbc9cce1d8b012e4bfcd24a61cfda00da86fa1	interpreter heredoc, no capture (issue #1113: argv list extended by workdir-backfill.json)	patch	Phase 3 PR C
 bridge-upgrade.sh	2616	C3	3b7b007634879006d9b95ee9e8f13693d64b0fe8244029b5690b38c4cf246344	interpreter heredoc, no capture	patch	Phase 3 PR C
 bridge-upgrade.sh	2623	C3	b919ffe917ff2abbde55677ee2b8c9fa5c91292bc8b9770d8e1a355f2fbc7023	interpreter heredoc, no capture	patch	Phase 3 PR C
 bridge-upgrade.sh	2636	C3	3479551ea337120bba6074762c98d92546f9f020aa56f21a9969bd0e11d93079	interpreter heredoc, no capture	patch	Phase 3 PR C

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1619,6 +1619,74 @@ except Exception:
   # state and BRIDGE_LAYOUT would stay empty, which downstream v2
   # helpers treat as legacy.
   unset BRIDGE_LAYOUT_RESOLVER_BYPASS BRIDGE_LAYOUT_RESOLVER_BYPASS_OWNER_PID
+
+  # Issue #1113: v0.14.5-beta6 anchored bridge-watchdog.py's scan on the
+  # v2 runtime workspace (`$BRIDGE_DATA_ROOT/agents/<a>/workdir/`), but
+  # for two upgrade vintages that workspace is missing the canonical
+  # identity markers:
+  #   1. agents scaffolded BEFORE #1108 landed — identity files live
+  #      only under the tracked profile tree `$BRIDGE_HOME/agents/<a>/`;
+  #   2. agents migrated via the marker-only v2 fast-path (PR #897
+  #      Track A, v0.13.10) — marker-only-no-isolated-roster writes the
+  #      v2 layout marker but does NOT replay the legacy → v2 mirror.
+  # The post-beta6 watchdog scans the workspace, sees no CLAUDE.md /
+  # SOUL.md / SESSION-TYPE.md / MEMORY-SCHEMA.md / MEMORY.md, and
+  # reports `status: error` on every legacy agent every cron tick.
+  #
+  # Back-fill the identity markers from the tracked profile tree into
+  # the workspace once, at upgrade time. Idempotent (existence-checks),
+  # never overwrites operator edits, never invents files when the
+  # tracked tree is empty. Runs after the v2 migrate step so the
+  # markerless-existing-install fast-path has already written the
+  # layout marker — the back-fill resolver's `bridge_layout_workspace_dir`
+  # call depends on the marker being valid to return the v2 workspace
+  # path. Skipped on dry-run for symmetry with the migrate step.
+  #
+  # Failure mode: non-fatal. The helper logs a `bridge_warn` line per
+  # failed marker and continues to the next; the back-fill JSON
+  # summary is captured for the upgrade audit trail. apply-live
+  # proceeds regardless — the watchdog will surface any residual
+  # `missing_files` row on the next tick, which is the same fallback
+  # behavior the operator's manual `cp` workaround was already
+  # producing on every upgrade prior to this step.
+  #
+  # Footgun #11: the helper body lives at
+  # lib/upgrade-helpers/isolation-v2-workdir-backfill.sh and is invoked
+  # with the file as argv (no heredoc-stdin anywhere on this path).
+  WORKDIR_BACKFILL_JSON='{"mode":"isolation-v2-workdir-backfill","status":"skipped","reason":"helper-not-invoked"}'
+  set +e
+  _wd_backfill_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-upg-wdbf.XXXXXX")"
+  # Stderr destination resolution. Preferred destination is the target
+  # install's logs/ tree so an operator debugging a back-fill warning
+  # can grep the right tree. The parent shell's `BRIDGE_LOG_DIR` is NOT
+  # initialized at this point in the upgrade flow (bridge_load_roster —
+  # which seeds it — runs in the `bridge_upgrade_with_target_env`
+  # child, not the parent), so resolve the path explicitly against
+  # `$TARGET_ROOT/logs`.
+  #
+  # Resilience contract (codex r2 finding): if the target logs/ dir
+  # cannot be created/opened (e.g. parent is read-only, disk full, NFS
+  # mount stale), the redirect `2>>"$file"` would itself fail BEFORE
+  # the bash invocation runs — leaving WORKDIR_BACKFILL_JSON at the
+  # skipped-default. Probe writability first via an explicit append
+  # attempt; on failure fall back to `/dev/null` so the helper still
+  # runs and the JSON envelope still records the actual outcome. The
+  # back-fill itself stays non-fatal, but the upgrade must not become
+  # "silently degraded" because a log file's parent is unwritable.
+  _wd_backfill_stderr="$TARGET_ROOT/logs/upgrade-workdir-backfill.stderr"
+  mkdir -p "$TARGET_ROOT/logs" 2>/dev/null
+  if ! { : >>"$_wd_backfill_stderr"; } 2>/dev/null; then
+    _wd_backfill_stderr="/dev/null"
+  fi
+  bridge_upgrade_with_target_env "$TARGET_ROOT" \
+    "$BRIDGE_BASH_BIN" \
+    "$SOURCE_ROOT/lib/upgrade-helpers/isolation-v2-workdir-backfill.sh" \
+    "$SOURCE_ROOT" "$TARGET_ROOT" >"$_wd_backfill_tmp" 2>>"$_wd_backfill_stderr" || true
+  if [[ -s "$_wd_backfill_tmp" ]]; then
+    WORKDIR_BACKFILL_JSON="$(<"$_wd_backfill_tmp")"
+  fi
+  rm -f -- "$_wd_backfill_tmp"
+  set -e
 fi
 
 apply_args=(apply-live --source-root "$SOURCE_ROOT" --target-root "$TARGET_ROOT" --run-id "$UPGRADE_RUN_ID")
@@ -2496,6 +2564,12 @@ if [[ $JSON -eq 1 ]]; then
   # placeholder on dry-run. Always-present so JSON consumers can branch on
   # the field's contents instead of having to handle missing-key vs value.
   printf '%s' "${ISOLATION_V2_MIGRATION_JSON:-}" >"$_json_payload_dir/isolation-v2-migration.json"
+  # Issue #1113: surface the workdir-identity back-fill payload in --json
+  # output so operators / monitoring can read `agents_with_writes` and
+  # `markers_copied` programmatically. Empty string when the back-fill
+  # never ran (dry-run paths) — load_optional_json then yields null and
+  # the consumer branches accordingly.
+  printf '%s' "${WORKDIR_BACKFILL_JSON:-}" >"$_json_payload_dir/workdir-backfill.json"
   # Issue #752 W3d: emit dedup'd partial-failure subsystem names as a
   # JSON array file so the python envelope below can branch
   # `status:"partial"` + `partial_failures:[...]`. Empty array on the
@@ -2508,9 +2582,9 @@ if [[ $JSON -eq 1 ]]; then
     printf '[]' >"$_json_payload_dir/partial-failures.json"
   fi
   set +e
-  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" "$_json_payload_dir/source-reclassify.json" "$_json_payload_dir/shared-settings-rerender.json" "$_json_payload_dir/cleanup.json" "$_json_payload_dir/isolation-v2-migration.json" "$_json_payload_dir/partial-failures.json" <<'PY'
+  python3 - "$SOURCE_ROOT" "$TARGET_ROOT" "$PULL" "$DRY_RUN" "$RESTART_DAEMON" "$RESTART_AGENTS" "$BACKUP" "$MIGRATE_AGENTS" "$BACKUP_ROOT" "$STRICT_MERGE" "$CHANNEL" "$SOURCE_VERSION" "$SOURCE_REF" "$SOURCE_HEAD" "$TARGET_REF" "$TARGET_VERSION" "$TARGET_HEAD" "$_json_payload_dir/backup.json" "$_json_payload_dir/migration.json" "$_json_payload_dir/apply.json" "$_json_payload_dir/analysis.json" "$_json_payload_dir/agent-restart.json" "$_json_payload_dir/channel-guard.json" "$_json_payload_dir/source-reclassify.json" "$_json_payload_dir/shared-settings-rerender.json" "$_json_payload_dir/cleanup.json" "$_json_payload_dir/isolation-v2-migration.json" "$_json_payload_dir/workdir-backfill.json" "$_json_payload_dir/partial-failures.json" <<'PY'
 import json, sys
-source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file, source_reclassify_json_file, shared_settings_rerender_json_file, cleanup_json_file, isolation_v2_migration_json_file, partial_failures_json_file = sys.argv[1:]
+source_root, target_root, pull, dry_run, restart_daemon, restart_agents, backup_enabled, migrate_agents, backup_root, strict_merge, channel, source_version, source_ref, source_head, target_ref, target_version, target_head, backup_json_file, migration_json_file, apply_json_file, analysis_json_file, agent_restart_json_file, channel_guard_json_file, source_reclassify_json_file, shared_settings_rerender_json_file, cleanup_json_file, isolation_v2_migration_json_file, workdir_backfill_json_file, partial_failures_json_file = sys.argv[1:]
 
 def load_json(path):
     with open(path, encoding="utf-8") as fh:
@@ -2544,6 +2618,12 @@ cleanup_payload = load_optional_json(cleanup_json_file)
 # null when the variable was empty (defensive — current code paths always
 # set ISOLATION_V2_MIGRATION_JSON before reaching the JSON envelope).
 isolation_v2_migration_payload = load_optional_json(isolation_v2_migration_json_file)
+# Issue #1113: post-marker back-fill of canonical identity markers from
+# the tracked profile tree into the v2 runtime workspace for legacy /
+# marker-only-migrated agents. Null when the back-fill step did not run
+# (dry-run, helper not invoked). Populated as `agents_with_writes`,
+# `markers_copied` so JSON consumers can audit the post-upgrade state.
+workdir_backfill_payload = load_optional_json(workdir_backfill_json_file)
 # Issue #752 W3d: late-stage subsystems (shared rerender / channel-policy
 # refresh / profile relink) append their stable name to this list when
 # their post-step probe reports failures. `status:"partial"` surfaces the
@@ -2592,6 +2672,7 @@ payload = {
     "agent_restart": agent_restart_payload,
     "agent_migration": migration_payload,
     "isolation_v2_migration": isolation_v2_migration_payload,
+    "workdir_backfill": workdir_backfill_payload,
     "source_reclassify": source_reclassify_payload,
     "shared_settings_rerender": shared_settings_rerender_payload,
     "cleanup": cleanup_payload,

--- a/lib/bridge-isolation-v2-workdir-backfill.sh
+++ b/lib/bridge-isolation-v2-workdir-backfill.sh
@@ -1,0 +1,412 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+#
+# bridge-isolation-v2-workdir-backfill.sh — issue #1113.
+#
+# Back-fill the canonical per-agent identity markers from the tracked
+# profile tree (`$BRIDGE_HOME/agents/<agent>/`) into the v2 runtime
+# workspace (`$BRIDGE_DATA_ROOT/agents/<agent>/workdir/`) for every
+# roster-active agent whose workspace is missing those markers.
+#
+# Why this exists
+# ---------------
+# v0.14.5-beta6 / PR #1109 anchored `bridge-watchdog.py`'s per-agent
+# scan on the v2 runtime workspace dir resolved via
+# `bridge_agent_workdir`. That fix unblocks fresh-install agents
+# (created post-#1108 via the normal `agent create` path, which
+# materializes the identity markers into the workspace via
+# `bridge_layout_materialize_identity`).
+#
+# Two upgrade vintages do NOT get the markers in the workspace:
+#
+#   1. agents scaffolded BEFORE #1108 landed (older installs) — their
+#      identity files were authored only into the tracked profile tree
+#      at `$BRIDGE_HOME/agents/<agent>/`; nothing was ever copied into
+#      `$BRIDGE_DATA_ROOT/agents/<agent>/workdir/`.
+#
+#   2. agents migrated via the marker-only v2 fast-path
+#      (`bridge_isolation_v2_migrate_apply_for_upgrade` →
+#      `bridge_isolation_v2_migrate_marker_write_minimal`, PR #897
+#      Track A, v0.13.10). That path writes the v2 layout marker but
+#      intentionally does NOT replay the full mirror/rsync of legacy →
+#      v2 directories, so identity markers stay in the tracked tree.
+#
+# Post-#1108 the watchdog now scans the workspace tree, sees no
+# CLAUDE.md / SOUL.md / SESSION-TYPE.md / MEMORY-SCHEMA.md / MEMORY.md,
+# and reports `status: error` + `missing_files: …` on every legacy
+# agent on every cron tick. This back-fill closes that gap once, at
+# upgrade time, by copying the markers from the tracked profile tree
+# into the workspace.
+#
+# Contract
+# --------
+#   * Idempotent — safe to run repeatedly. We only copy a marker when
+#     the workspace target is MISSING that exact file; pre-existing
+#     workspace markers are left alone (the operator or the runtime
+#     may have updated them post-migration; we never overwrite).
+#   * Roster-active only — we enumerate `BRIDGE_AGENT_IDS` (populated
+#     by `bridge_load_roster`). Agents that exist on disk but are not
+#     in the roster (orphans) are NOT touched.
+#   * No template re-render — we do NOT replay `scaffold_agent_home`,
+#     hooks render, settings render. The only operation is a
+#     content-preserving file copy.
+#   * Respects v2 ownership — when the agent runs under linux-user
+#     isolation and passwordless sudo is available, the workspace tree
+#     is owned by `ab-agent-<slug>:ab-agent-<slug>` and the controller
+#     UID cannot write into it directly. In that case we delegate to
+#     `bridge_isolation_write_file_as_agent_user_via_bash`. For
+#     non-isolated agents (shared mode, macOS, single-OS-user installs)
+#     a controller-side `cp -p` is correct.
+#   * Non-fatal — every failure is warned via `bridge_warn` but never
+#     aborts the caller. The watchdog can still surface the residual
+#     `missing_files` row on the next tick; the operator's workaround
+#     (manual `cp`) keeps working.
+#
+# Safety notes
+# ------------
+#   * The markers we copy are the same set the watchdog asserts
+#     (`bridge-watchdog.py:CLAUDE_REQUIRED_FILES`). Keeping these two
+#     sets in lockstep is a regression vector — the smoke
+#     `1113-watchdog-legacy-backfill.sh` asserts the watchdog status
+#     against the back-fill output so a drift fails CI.
+#   * We deliberately do NOT delete from the tracked tree. The tracked
+#     tree is still the authoritative source for repeat upgrades and
+#     for the migrator-export path; the workspace copy is the read
+#     target the runtime / watchdog actually scans.
+#   * Footgun #11 (Bash 5.3.9 heredoc deadlock class): this body uses
+#     only `printf` / `cp` / direct redirection. No heredocs anywhere.
+#     The isolated write path goes through
+#     `bridge_isolation_write_file_as_agent_user_via_bash` which itself
+#     uses `cat -` (also heredoc-free).
+
+# Canonical identity files the watchdog requires (see
+# bridge-watchdog.py:CLAUDE_REQUIRED_FILES). Kept as an array — not a
+# string — so callers can iterate and so a drift between sets shows up
+# as a structural diff in `git log` rather than a quoted-string blob.
+BRIDGE_ISOLATION_V2_BACKFILL_IDENTITY_FILES=(
+  CLAUDE.md
+  SOUL.md
+  SESSION-TYPE.md
+  MEMORY-SCHEMA.md
+  MEMORY.md
+)
+
+# bridge_isolation_v2_backfill_workdir_identity [--target-root <path>] [--json]
+#
+# Back-fill identity markers for every roster-active agent. Returns 0
+# on best-effort completion (including all-no-op runs); returns 2 on
+# pre-flight failure (e.g. resolver primitives unavailable).
+#
+# When `--json` is passed, emits a single-line JSON summary on stdout
+# describing per-agent outcomes. The shape is:
+#   {
+#     "mode": "isolation-v2-workdir-backfill",
+#     "status": "ok",
+#     "agents_examined": N,
+#     "agents_with_writes": M,
+#     "markers_copied": K,
+#     "agents": [
+#       { "id": "...", "writes": ["CLAUDE.md", ...], "errors": [...] }
+#     ]
+#   }
+#
+# When `--target-root <path>` is passed, the resolver is pinned to that
+# bridge-home root regardless of `$BRIDGE_HOME`. This is the shape the
+# upgrade helper invokes — the target_root has already been resolved by
+# `bridge_upgrade_with_target_env` so the env is consistent.
+bridge_isolation_v2_backfill_workdir_identity() {
+  local target_root=""
+  local emit_json=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --target-root) target_root="$2"; shift 2 ;;
+      --json) emit_json=1; shift ;;
+      *)
+        if declare -F bridge_warn >/dev/null 2>&1; then
+          bridge_warn "backfill_workdir_identity: unknown arg: $1"
+        else
+          printf 'backfill_workdir_identity: unknown arg: %s\n' "$1" >&2
+        fi
+        return 2
+        ;;
+    esac
+  done
+
+  # The roster array must be loaded. Callers from bridge-upgrade.sh's
+  # helper path (lib/upgrade-helpers/) explicitly source bridge-lib.sh
+  # + call bridge_load_roster before invoking us; direct callers must
+  # do the same. Guard rather than auto-loading so we never silently
+  # operate on a wrong-home roster.
+  if ! declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1; then
+    if declare -F bridge_warn >/dev/null 2>&1; then
+      bridge_warn "backfill_workdir_identity: BRIDGE_AGENT_IDS not loaded; caller must run bridge_load_roster first"
+    else
+      printf 'backfill_workdir_identity: BRIDGE_AGENT_IDS not loaded\n' >&2
+    fi
+    return 2
+  fi
+
+  local agents_examined=0
+  local agents_with_writes=0
+  local markers_copied=0
+  local -a per_agent_rows=()
+
+  local agent
+  for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+    [[ -n "$agent" ]] || continue
+    agents_examined=$(( agents_examined + 1 ))
+
+    local profile_dir workspace_dir
+    profile_dir="$(_bridge_isolation_v2_backfill_profile_dir "$agent")"
+    workspace_dir="$(_bridge_isolation_v2_backfill_workspace_dir "$agent")"
+
+    # Profile source missing → nothing to copy from. This is the common
+    # case for dynamic agents whose canonical tree is `data/agents/<a>/home/`
+    # rather than `agents/<a>/`. Skip silently.
+    if [[ -z "$profile_dir" || ! -d "$profile_dir" ]]; then
+      continue
+    fi
+
+    # Workspace path unresolvable → can happen on a controller without
+    # the v2 marker. Warn and skip; the apply-for-upgrade step normally
+    # writes the marker before we run, so an empty workspace_dir here
+    # usually means the controller is operating on a legacy-only host
+    # where this back-fill is a no-op by design.
+    if [[ -z "$workspace_dir" ]]; then
+      continue
+    fi
+
+    # Same path → nothing to materialize (legacy / identity-source-is-
+    # workspace topology, mirroring bridge_layout_materialize_identity's
+    # no-op branch).
+    if [[ "$profile_dir" == "$workspace_dir" ]]; then
+      continue
+    fi
+
+    # Ensure the workspace dir itself exists. If creation fails (parent
+    # missing, perms), warn and skip — we never want to silently invent
+    # a workspace tree behind the layout resolver's back.
+    if [[ ! -d "$workspace_dir" ]]; then
+      mkdir -p "$workspace_dir" 2>/dev/null || {
+        if declare -F bridge_warn >/dev/null 2>&1; then
+          bridge_warn "backfill_workdir_identity: cannot create workspace dir for $agent: $workspace_dir"
+        fi
+        continue
+      }
+    fi
+
+    local -a writes_for_agent=()
+    local -a errors_for_agent=()
+    local marker src dst
+    for marker in "${BRIDGE_ISOLATION_V2_BACKFILL_IDENTITY_FILES[@]}"; do
+      src="$profile_dir/$marker"
+      dst="$workspace_dir/$marker"
+
+      # Skip when the source marker is absent — we never invent content.
+      [[ -f "$src" ]] || continue
+      # Skip when the workspace already holds the marker — idempotency
+      # contract, and operator-post-migration edits stay sacred.
+      [[ ! -e "$dst" ]] || continue
+
+      if _bridge_isolation_v2_backfill_copy_one "$agent" "$src" "$dst"; then
+        writes_for_agent+=("$marker")
+        markers_copied=$(( markers_copied + 1 ))
+      else
+        errors_for_agent+=("$marker")
+      fi
+    done
+
+    if (( ${#writes_for_agent[@]} > 0 )); then
+      agents_with_writes=$(( agents_with_writes + 1 ))
+      if declare -F bridge_warn >/dev/null 2>&1; then
+        bridge_warn "backfill_workdir_identity: $agent: materialized ${#writes_for_agent[@]} marker(s) into $workspace_dir (${writes_for_agent[*]})"
+      fi
+    fi
+
+    if (( emit_json == 1 )); then
+      per_agent_rows+=(
+        "$(_bridge_isolation_v2_backfill_emit_agent_row "$agent" \
+            "${#writes_for_agent[@]}" "${writes_for_agent[*]:-}" \
+            "${#errors_for_agent[@]}" "${errors_for_agent[*]:-}")"
+      )
+    fi
+  done
+
+  if (( emit_json == 1 )); then
+    _bridge_isolation_v2_backfill_emit_summary_json \
+      "$agents_examined" "$agents_with_writes" "$markers_copied" \
+      "${per_agent_rows[@]}"
+  fi
+
+  # Silence the unused-target_root warning. We accept --target-root so
+  # the upgrade helper's `--target-root "$TARGET_ROOT"` invocation
+  # stays symmetric with the v2-migrate apply call shape, but the
+  # resolver primitives we delegate to (bridge_layout_*_dir) already
+  # honor BRIDGE_HOME / BRIDGE_DATA_ROOT from the env the upgrade
+  # helper set up via bridge_upgrade_with_target_env. Asserting that
+  # the env matches target_root would just duplicate the helper's own
+  # invariant.
+  : "${target_root:=}"
+
+  return 0
+}
+
+# _bridge_isolation_v2_backfill_profile_dir <agent>
+#
+# Resolve the tracked profile-source dir (`$BRIDGE_HOME/agents/<agent>/`)
+# for the given agent. Prefers the typed resolver
+# `bridge_layout_profile_source_dir` when available; falls back to the
+# canonical env-derived path for direct-source consumers.
+_bridge_isolation_v2_backfill_profile_dir() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  if declare -F bridge_layout_profile_source_dir >/dev/null 2>&1; then
+    bridge_layout_profile_source_dir "$agent"
+    return 0
+  fi
+  printf '%s/agents/%s' "${BRIDGE_HOME:-$HOME/.agent-bridge}" "$agent"
+}
+
+# _bridge_isolation_v2_backfill_workspace_dir <agent>
+#
+# Resolve the v2 runtime workspace dir
+# (`$BRIDGE_DATA_ROOT/agents/<agent>/workdir/`). Prefers
+# `bridge_layout_workspace_dir` (wraps `bridge_agent_workdir`); falls
+# back to the v2 layout default when the typed resolver is not loaded.
+_bridge_isolation_v2_backfill_workspace_dir() {
+  local agent="$1"
+  [[ -n "$agent" ]] || return 1
+  if declare -F bridge_layout_workspace_dir >/dev/null 2>&1; then
+    bridge_layout_workspace_dir "$agent" 2>/dev/null
+    return 0
+  fi
+  if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+    printf '%s/%s/workdir' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+    return 0
+  fi
+  printf ''
+}
+
+# _bridge_isolation_v2_backfill_copy_one <agent> <src> <dst>
+#
+# Copy one identity marker from <src> to <dst>. On a linux-user-isolated
+# agent the destination dir is owned by `ab-agent-<slug>` and the
+# controller UID cannot write there directly — delegate to the
+# isolation-helpers write path. For shared-mode agents (and the
+# macOS-no-isolation case) a controller-side `cp -p` is correct.
+_bridge_isolation_v2_backfill_copy_one() {
+  local agent="$1" src="$2" dst="$3"
+  [[ -n "$agent" && -f "$src" && -n "$dst" ]] || return 1
+
+  local _iso_effective_rc=0
+  if declare -F bridge_agent_linux_user_isolation_effective >/dev/null 2>&1; then
+    bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null \
+      || _iso_effective_rc=$?
+  else
+    _iso_effective_rc=1
+  fi
+
+  if [[ $_iso_effective_rc -eq 0 ]] \
+      && declare -F bridge_isolation_write_file_as_agent_user_via_bash >/dev/null 2>&1; then
+    # Isolated path — stream the source bytes through the sudo'd write
+    # helper. mode 0644 mirrors the tracked-tree default.
+    local _wrc=0
+    bridge_isolation_write_file_as_agent_user_via_bash \
+      "$agent" "$dst" "0644" < "$src" >/dev/null 2>&1 \
+      || _wrc=$?
+    case "$_wrc" in
+      0) return 0 ;;
+      1)
+        # Agent claimed linux-user isolation but the helper says it
+        # isn't actually isolated (rc=1 == fall back to controller
+        # write). Drop through to the cp -p path below.
+        ;;
+      2)
+        if declare -F bridge_warn >/dev/null 2>&1; then
+          bridge_warn "backfill_workdir_identity: $agent: passwordless sudo unavailable, cannot back-fill $(basename "$dst") into isolated workspace; operator must sync this marker manually or rerun upgrade with sudo available"
+        fi
+        return 1
+        ;;
+      *)
+        if declare -F bridge_warn >/dev/null 2>&1; then
+          bridge_warn "backfill_workdir_identity: $agent: isolated-write helper rc=$_wrc copying $(basename "$dst")"
+        fi
+        return 1
+        ;;
+    esac
+  fi
+
+  # Non-isolated (shared mode / macOS single-OS-user / no helper
+  # loaded) → direct controller-side copy. `cp -p` preserves mtime so
+  # an idempotent re-run leaves the file unchanged byte-for-byte.
+  if cp -p -- "$src" "$dst" 2>/dev/null; then
+    return 0
+  fi
+  if declare -F bridge_warn >/dev/null 2>&1; then
+    bridge_warn "backfill_workdir_identity: $agent: cp -p $src -> $dst failed"
+  fi
+  return 1
+}
+
+# _bridge_isolation_v2_backfill_emit_agent_row <agent> <n_writes> <writes>
+#                                              <n_errors> <errors>
+#
+# Emit one JSON object describing the per-agent outcome. Used by the
+# summary emitter to assemble the agents[] array. All shell-quoted
+# values are JSON-escaped through python3 so embedded backslashes /
+# quotes in agent ids cannot break the JSON envelope (defense in depth
+# — agent ids are slug-validated upstream).
+_bridge_isolation_v2_backfill_emit_agent_row() {
+  local agent="$1"
+  local n_writes="$2"
+  local writes="$3"
+  local n_errors="$4"
+  local errors="$5"
+  python3 -c '
+import json, sys
+agent = sys.argv[1]
+n_writes = int(sys.argv[2] or "0")
+writes = sys.argv[3].split() if sys.argv[3] else []
+n_errors = int(sys.argv[4] or "0")
+errors = sys.argv[5].split() if sys.argv[5] else []
+print(json.dumps({
+  "id": agent,
+  "writes": writes[:n_writes],
+  "errors": errors[:n_errors],
+}))
+' "$agent" "$n_writes" "$writes" "$n_errors" "$errors"
+}
+
+# _bridge_isolation_v2_backfill_emit_summary_json <examined> <with_writes>
+#                                                 <markers_copied> [rows...]
+_bridge_isolation_v2_backfill_emit_summary_json() {
+  local examined="$1"
+  local with_writes="$2"
+  local copied="$3"
+  shift 3
+  python3 -c '
+import json, sys
+examined = int(sys.argv[1])
+with_writes = int(sys.argv[2])
+copied = int(sys.argv[3])
+agents = []
+for row in sys.argv[4:]:
+    row = row.strip()
+    if not row:
+        continue
+    try:
+        agents.append(json.loads(row))
+    except Exception:
+        # Defense in depth — a malformed per-agent row should not break
+        # the envelope. Skip the row but keep the summary parsable.
+        continue
+print(json.dumps({
+  "mode": "isolation-v2-workdir-backfill",
+  "status": "ok",
+  "agents_examined": examined,
+  "agents_with_writes": with_writes,
+  "markers_copied": copied,
+  "agents": agents,
+}))
+' "$examined" "$with_writes" "$copied" "$@"
+}

--- a/lib/upgrade-helpers/isolation-v2-workdir-backfill.sh
+++ b/lib/upgrade-helpers/isolation-v2-workdir-backfill.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# isolation-v2-workdir-backfill.sh — back-fill canonical identity
+# markers from the tracked profile tree into the v2 runtime workspace
+# for legacy / marker-only-migrated agents (issue #1113). Invoked by
+# bridge-upgrade.sh via `bridge_upgrade_with_target_env $TARGET_ROOT
+# $BRIDGE_BASH_BIN $0 $SOURCE_ROOT $TARGET_ROOT`.
+#
+# Invocation contract:
+#   $1 = source_root  (the agent-bridge source checkout)
+#   $2 = target_root  (the live install root being upgraded)
+#
+# Output: a single JSON document on stdout summarizing the back-fill
+#         (see `bridge_isolation_v2_backfill_workdir_identity --json`).
+#
+# Footgun #11 (Bash 5.3.9 heredoc-stdin deadlock class): this body uses
+# only command invocations + argv. No heredocs anywhere. The library
+# function itself also avoids heredocs so the entire chain is heredoc-
+# free. Sibling helper isolation-v2-migrate.sh documents the parent
+# rationale for the lib/upgrade-helpers/ split.
+
+set -euo pipefail
+
+source_root="$1"
+target_root="$2"
+
+# shellcheck source=/dev/null
+source "$source_root/bridge-lib.sh"
+bridge_load_roster
+# shellcheck source=lib/bridge-isolation-v2-workdir-backfill.sh
+source "$source_root/lib/bridge-isolation-v2-workdir-backfill.sh"
+bridge_isolation_v2_backfill_workdir_identity \
+  --target-root "$target_root" --json

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -106,7 +106,7 @@ add_live() {
 }
 
 add_all_required_static() {
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap nudge-task-age-gate nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap nudge-task-age-gate nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1113-watchdog-legacy-backfill
 }
 
 add_all_integration() {
@@ -390,7 +390,13 @@ select_for_path() {
       # tracked profile template at `$BRIDGE_HOME/agents/<a>/`. Pull its
       # regression smoke for every isolation-lib + bridge-migrate.sh move
       # so the dual-tree confusion class stays caught at PR time.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1077-migrate-iso-v2-data-dir launch isolated-agent-delete-reap
+      # Issue #1113: lib/bridge-isolation-v2-workdir-backfill.sh hosts
+      # `bridge_isolation_v2_backfill_workdir_identity`, the post-marker
+      # back-fill that closes the v0.14.5-beta6 watchdog dual-tree gap
+      # for legacy-migrated agents. Pull its regression smoke for every
+      # isolation-lib move so the helper's idempotency + operator-edit
+      # preservation + roster-scoped enumeration stays covered.
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1077-migrate-iso-v2-data-dir 1113-watchdog-legacy-backfill launch isolated-agent-delete-reap
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -506,7 +512,14 @@ select_for_path() {
       # marker-only fast-path. Pull the regression smoke (T3 specifically
       # asserts the env-propagation contract — fast-path NOT fired when
       # BRIDGE_UPGRADE_CONTEXT is unset) whenever the upgrade entry moves.
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate 1067-codex-provisioning
+      # Issue #1113: bridge-upgrade.sh gained a post-migrate workdir-
+      # identity back-fill step (between iso-v2 migrate and apply-live)
+      # that materializes canonical identity markers from the tracked
+      # profile tree into the v2 runtime workspace for legacy / marker-
+      # only-migrated agents. Pull its regression smoke whenever the
+      # upgrade entry moves so the dual-tree gap that #1108/#1109
+      # exposed stays closed.
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate 1067-codex-provisioning 1113-watchdog-legacy-backfill
       add_integration integration-minimal
       ;;
 
@@ -608,7 +621,7 @@ select_for_path() {
       # false-positive-reporting `missing_files: CLAUDE.md, SOUL.md, …`
       # on every cron tick. Pull 1108-watchdog-v2-workdir on every
       # watchdog move so the dual-tree confusion class stays caught.
-      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir queue
+      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir 1113-watchdog-legacy-backfill queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1113-watchdog-legacy-backfill.sh
+++ b/scripts/smoke/1113-watchdog-legacy-backfill.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# Issue #1113 regression smoke — `bridge_isolation_v2_backfill_workdir_identity`
+# must materialize the canonical identity markers from the tracked
+# profile tree (`$BRIDGE_HOME/agents/<agent>/`) into the v2 runtime
+# workspace (`$BRIDGE_DATA_ROOT/agents/<agent>/workdir/`) for
+# roster-active agents whose workspace is missing those markers, AND
+# the resulting workspace must classify as `status: ok` under the
+# post-#1108 watchdog scan (the dual-tree consistency contract the
+# whole fix exists to preserve).
+#
+# Bug shape on operator host (v0.14.5-beta6, 2026-05-23):
+#   `librarian` agent scaffolded pre-#1108 OR migrated via the
+#   marker-only v2 fast-path (PR #897 Track A). Identity markers live
+#   only at `$BRIDGE_HOME/agents/librarian/*.md`. Post-beta6 watchdog
+#   scans `$BRIDGE_DATA_ROOT/agents/librarian/workdir/`, sees no
+#   markers, reports `status: error` + `missing_files: CLAUDE.md,
+#   SOUL.md, MEMORY-SCHEMA.md, MEMORY.md, SESSION-TYPE.md` on every
+#   cron tick.
+#
+# Asserts (all on a temp BRIDGE_HOME — operator's live tree never
+# touched):
+#   T1 — Synthesize a legacy-migrated agent shape (markers in profile
+#        tree, only HEARTBEAT.md in workspace). Run the back-fill.
+#        All five canonical identity markers (CLAUDE.md, SOUL.md,
+#        SESSION-TYPE.md, MEMORY-SCHEMA.md, MEMORY.md) must now be
+#        present in the workspace, byte-equal to the profile tree.
+#   T2 — Re-run the back-fill on the same workspace. Idempotency
+#        contract: the second pass must report `markers_copied: 0`
+#        (no rewrites) and must NOT change the byte content of any
+#        marker that already existed in the workspace.
+#   T3 — End-to-end consistency with the watchdog: after back-fill, a
+#        `bridge-watchdog.py scan --json --agent-registry-json` pass
+#        with the agent's registry payload (workdir → v2 workspace)
+#        must classify the agent as `status: ok` with empty
+#        `missing_files`. This is the contract that closes #1113:
+#        operator's watchdog scan output must return to clean. Runs
+#        BEFORE T4 because T4 intentionally drops the managed-block
+#        CLAUDE.md to prove the operator-edit-preservation contract.
+#   T4 — When an operator has edited a workspace marker post-migration,
+#        the back-fill must NOT overwrite it. Sentinel byte-content
+#        round-trip: write a unique string into workspace/CLAUDE.md,
+#        delete one OTHER marker, re-run the back-fill, assert the
+#        sentinel survives and the missing marker gets copied.
+#   T5 — Agents that exist on disk but are NOT in the roster are NOT
+#        back-filled. Orphan / stale-profile tree must never be
+#        promoted to a runtime workspace.
+#
+# Footgun #11 (Bash 5.3.9 heredoc-stdin deadlock): no heredocs in
+# subprocess pipelines; all driver bodies are emitted via printf-to-file.
+
+set -uo pipefail
+
+SMOKE_NAME="1113-watchdog-legacy-backfill"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+AGENT="librarian"
+ORPHAN_AGENT="claude-static"
+
+LEGACY_PROFILE_DIR="$BRIDGE_AGENT_HOME_ROOT/$AGENT"
+V2_WORKSPACE_DIR="$BRIDGE_AGENT_ROOT_V2/$AGENT/workdir"
+
+# Seed the tracked profile tree with the full canonical marker set.
+# The CLAUDE.md and SESSION-TYPE.md bodies follow the home-profile
+# contract the watchdog asserts (`classify_status` checks for the
+# managed-block markers in CLAUDE.md and a valid `Onboarding State`
+# row in SESSION-TYPE.md). The other three (SOUL/MEMORY/MEMORY-SCHEMA)
+# carry unique stable bodies so byte-equality can be asserted directly
+# against the workspace post-back-fill.
+mkdir -p "$LEGACY_PROFILE_DIR"
+# CLAUDE.md — managed-block envelope so the post-back-fill watchdog
+# can classify the workspace as `ok` end-to-end (T4).
+{
+  printf '%s\n' '<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->'
+  printf '%s\n' 'managed'
+  printf '%s\n' '<!-- END AGENT BRIDGE DOC MIGRATION -->'
+} >"$LEGACY_PROFILE_DIR/CLAUDE.md"
+# SESSION-TYPE.md — onboarding complete + a static-claude session type,
+# matching the home-profile contract the watchdog asserts.
+{
+  printf '%s\n' '# Session Type'
+  printf '%s\n' ''
+  printf '%s\n' '- Session Type: static-claude'
+  printf '%s\n' '- Onboarding State: complete'
+} >"$LEGACY_PROFILE_DIR/SESSION-TYPE.md"
+# Plain stable bodies for byte-equality assertions in T1/T2.
+printf '%s' 'profile-SOUL.md'          >"$LEGACY_PROFILE_DIR/SOUL.md"
+printf '%s' 'profile-MEMORY-SCHEMA.md' >"$LEGACY_PROFILE_DIR/MEMORY-SCHEMA.md"
+printf '%s' 'profile-MEMORY.md'        >"$LEGACY_PROFILE_DIR/MEMORY.md"
+
+# Seed the v2 workspace with only HEARTBEAT.md — exactly the shape the
+# operator host hit (legacy-migrated, marker-only-fast-path).
+mkdir -p "$V2_WORKSPACE_DIR"
+printf '%s' 'heartbeat-stub' >"$V2_WORKSPACE_DIR/HEARTBEAT.md"
+
+# Seed an orphan: tracked tree only, NOT in roster. The back-fill must
+# leave it alone (no workspace materialization, no warnings about a
+# missing roster entry).
+ORPHAN_PROFILE_DIR="$BRIDGE_AGENT_HOME_ROOT/$ORPHAN_AGENT"
+mkdir -p "$ORPHAN_PROFILE_DIR"
+printf '%s' 'orphan-CLAUDE.md' >"$ORPHAN_PROFILE_DIR/CLAUDE.md"
+
+# Seed a minimal roster with ONLY the librarian agent — the back-fill
+# is roster-scoped, and the orphan must NOT appear in BRIDGE_AGENT_IDS.
+# `agent-roster.sh` is sourced by `bridge_load_roster`; only a few
+# fields are required for our helper (the agent id in
+# `BRIDGE_AGENT_IDS` and a non-empty `BRIDGE_AGENT_CLASS` entry so the
+# downstream resolver does not bail). bridge-state.sh handles the rest.
+ROSTER_FILE="$BRIDGE_ROSTER_FILE"
+: >"$ROSTER_FILE"
+{
+  printf '%s\n' '# Smoke roster — issue #1113'
+  printf 'BRIDGE_AGENT_IDS=("%s")\n' "$AGENT"
+  printf 'BRIDGE_AGENT_CLASS["%s"]="user"\n' "$AGENT"
+  printf 'BRIDGE_AGENT_ENGINE["%s"]="claude"\n' "$AGENT"
+} >>"$ROSTER_FILE"
+
+# Build a one-shot driver that:
+#   - exports BRIDGE_DATA_ROOT/BRIDGE_AGENT_ROOT_V2 to point at the
+#     v2 workspace tree the smoke seeded;
+#   - sources bridge-lib.sh + the back-fill helper directly;
+#   - runs `bridge_isolation_v2_backfill_workdir_identity --json` and
+#     prints the JSON to stdout.
+DRIVER="$SMOKE_TMP_ROOT/run-backfill.sh"
+: >"$DRIVER"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -uo pipefail'
+  printf '%s\n' 'REPO_ROOT="$1"'
+  printf '%s\n' '# shellcheck disable=SC1091'
+  printf '%s\n' 'source "$REPO_ROOT/bridge-lib.sh"'
+  printf '%s\n' 'bridge_load_roster'
+  printf '%s\n' '# shellcheck disable=SC1091'
+  printf '%s\n' 'source "$REPO_ROOT/lib/bridge-isolation-v2-workdir-backfill.sh"'
+  printf '%s\n' 'bridge_isolation_v2_backfill_workdir_identity --json'
+} >"$DRIVER"
+chmod +x "$DRIVER"
+
+run_backfill() {
+  "$BRIDGE_BASH" "$DRIVER" "$REPO_ROOT" 2>"$SMOKE_TMP_ROOT/backfill.stderr"
+}
+
+# --- T1: first pass materializes all 5 markers ------------------------
+
+OUT_JSON_R1="$(run_backfill)" || smoke_fail "T1: back-fill driver exited non-zero (stderr: $(cat "$SMOKE_TMP_ROOT/backfill.stderr"))"
+
+T1_RESULT="$("$PY_BIN" -c '
+import json, sys
+data = json.loads(sys.argv[1])
+agents = data.get("agents", [])
+print("examined=" + str(data.get("agents_examined", 0)))
+print("with_writes=" + str(data.get("agents_with_writes", 0)))
+print("copied=" + str(data.get("markers_copied", 0)))
+print("agent_ids=" + ",".join(a["id"] for a in agents))
+for a in agents:
+    print("writes_" + a["id"] + "=" + ",".join(sorted(a["writes"])))
+' "$OUT_JSON_R1")"
+
+t1_examined=$(printf '%s\n' "$T1_RESULT" | sed -n 's/^examined=//p')
+t1_with_writes=$(printf '%s\n' "$T1_RESULT" | sed -n 's/^with_writes=//p')
+t1_copied=$(printf '%s\n' "$T1_RESULT" | sed -n 's/^copied=//p')
+t1_writes="$(printf '%s\n' "$T1_RESULT" | sed -n 's/^writes_librarian=//p')"
+
+smoke_assert_eq 1 "$t1_examined" "T1 agents_examined (roster has only librarian)"
+smoke_assert_eq 1 "$t1_with_writes" "T1 agents_with_writes"
+smoke_assert_eq 5 "$t1_copied" "T1 markers_copied (all 5 identity files)"
+smoke_assert_eq "CLAUDE.md,MEMORY-SCHEMA.md,MEMORY.md,SESSION-TYPE.md,SOUL.md" "$t1_writes" "T1 per-agent writes (sorted)"
+
+for marker in CLAUDE.md SOUL.md SESSION-TYPE.md MEMORY-SCHEMA.md MEMORY.md; do
+  smoke_assert_file_exists "$V2_WORKSPACE_DIR/$marker" "T1 workspace has $marker post-back-fill"
+  cmp -s "$LEGACY_PROFILE_DIR/$marker" "$V2_WORKSPACE_DIR/$marker" \
+    || smoke_fail "T1 byte-equal: workspace/$marker does not match profile/$marker"
+done
+
+smoke_log "T1 PASS: first pass materialized all 5 canonical identity markers from profile tree to workspace"
+
+# --- T2: second pass is idempotent (no rewrites) ----------------------
+
+OUT_JSON_R2="$(run_backfill)" || smoke_fail "T2: second back-fill driver exited non-zero"
+
+t2_copied="$("$PY_BIN" -c 'import json,sys; print(json.loads(sys.argv[1]).get("markers_copied", -1))' "$OUT_JSON_R2")"
+smoke_assert_eq 0 "$t2_copied" "T2 markers_copied (idempotent re-run)"
+
+t2_with_writes="$("$PY_BIN" -c 'import json,sys; print(json.loads(sys.argv[1]).get("agents_with_writes", -1))' "$OUT_JSON_R2")"
+smoke_assert_eq 0 "$t2_with_writes" "T2 agents_with_writes (idempotent re-run)"
+
+# Byte-equality of the workspace tree must be preserved.
+for marker in CLAUDE.md SOUL.md SESSION-TYPE.md MEMORY-SCHEMA.md MEMORY.md; do
+  cmp -s "$LEGACY_PROFILE_DIR/$marker" "$V2_WORKSPACE_DIR/$marker" \
+    || smoke_fail "T2 byte-equal preserved on idempotent re-run: workspace/$marker drifted"
+done
+
+smoke_log "T2 PASS: idempotent re-run reported 0 copies + preserved byte-content"
+
+# --- T3: watchdog now classifies the agent as ok ----------------------
+# Runs BEFORE T4 (operator-sentinel) because T4 intentionally writes a
+# non-managed-block sentinel into workspace/CLAUDE.md to prove the
+# back-fill respects operator edits, and that sentinel would naturally
+# trip `missing_managed_claude_block=true` in the watchdog — which is
+# correct behavior but unrelated to the dual-tree gap #1113 closes.
+# Testing the watchdog handshake while the workspace still holds the
+# canonical managed-block CLAUDE.md is the contract we need to pin.
+
+REGISTRY_JSON="$SMOKE_TMP_ROOT/registry.json"
+{
+  printf '[\n'
+  printf '  {\n'
+  printf '    "id": "%s",\n' "$AGENT"
+  printf '    "class": "static",\n'
+  printf '    "agent_source": "static",\n'
+  printf '    "engine": "claude",\n'
+  printf '    "workdir": "%s"\n' "$V2_WORKSPACE_DIR"
+  printf '  }\n'
+  printf ']\n'
+} >"$REGISTRY_JSON"
+
+WATCHDOG_JSON="$("$PY_BIN" "$REPO_ROOT/bridge-watchdog.py" scan --json \
+  --agent-registry-json "$REGISTRY_JSON" 2>"$SMOKE_TMP_ROOT/watchdog.stderr")"
+
+t3_status="$("$PY_BIN" -c '
+import json, sys
+data = json.loads(sys.argv[1])
+items = data.get("agents", []) or data.get("items", [])
+for it in items:
+    if it.get("agent") == "librarian":
+        print(it.get("status", "missing"))
+        break
+else:
+    print("agent-not-found")
+' "$WATCHDOG_JSON")"
+
+t3_missing="$("$PY_BIN" -c '
+import json, sys
+data = json.loads(sys.argv[1])
+items = data.get("agents", []) or data.get("items", [])
+for it in items:
+    if it.get("agent") == "librarian":
+        print(",".join(it.get("missing_files", []) or []))
+        break
+' "$WATCHDOG_JSON")"
+
+smoke_assert_eq "ok" "$t3_status" "T3 watchdog classifies librarian as ok post-back-fill"
+smoke_assert_eq "" "$t3_missing" "T3 watchdog reports missing_files: [] post-back-fill"
+
+smoke_log "T3 PASS: end-to-end watchdog scan returns clean after back-fill"
+
+# --- T4: operator-edited marker is NOT overwritten --------------------
+
+# Sentinel: operator edits workspace/CLAUDE.md post-migration.
+SENTINEL='operator-edited-sentinel-do-not-overwrite'
+printf '%s' "$SENTINEL" >"$V2_WORKSPACE_DIR/CLAUDE.md"
+# Simultaneously delete workspace/MEMORY.md so the back-fill has at
+# least one write to perform — and we can confirm the sentinel survives
+# even while OTHER markers are being copied.
+rm -f "$V2_WORKSPACE_DIR/MEMORY.md"
+
+OUT_JSON_R4="$(run_backfill)" || smoke_fail "T4: back-fill driver exited non-zero"
+
+t4_copied="$("$PY_BIN" -c 'import json,sys; print(json.loads(sys.argv[1]).get("markers_copied", -1))' "$OUT_JSON_R4")"
+smoke_assert_eq 1 "$t4_copied" "T4 markers_copied (only the deleted MEMORY.md)"
+
+t4_writes="$("$PY_BIN" -c '
+import json, sys
+data = json.loads(sys.argv[1])
+agents = data.get("agents", [])
+for a in agents:
+    if a["id"] == "librarian":
+        print(",".join(sorted(a["writes"])))
+        break
+' "$OUT_JSON_R4")"
+smoke_assert_eq "MEMORY.md" "$t4_writes" "T4 per-agent writes (only MEMORY.md)"
+
+# Operator's sentinel byte-content MUST survive.
+smoke_assert_eq "$SENTINEL" "$(cat "$V2_WORKSPACE_DIR/CLAUDE.md")" "T4 sentinel preserved on workspace/CLAUDE.md"
+# The deleted marker MUST be restored.
+smoke_assert_eq "profile-MEMORY.md" "$(cat "$V2_WORKSPACE_DIR/MEMORY.md")" "T4 MEMORY.md restored from profile tree"
+
+smoke_log "T4 PASS: operator-edited workspace marker preserved + missing marker restored"
+
+# --- T5: orphan agent (not in roster) is left alone -------------------
+
+# The orphan profile dir was never touched by the back-fill — there is
+# no v2 workspace for it (the orphan was never created in
+# data/agents/), and the helper iterates the roster, NOT the on-disk
+# tracked tree. Assert the orphan's tracked-tree CLAUDE.md was not
+# copied anywhere unexpected.
+if [[ -e "$BRIDGE_AGENT_ROOT_V2/$ORPHAN_AGENT" ]]; then
+  smoke_fail "T5: orphan agent '$ORPHAN_AGENT' got a v2 workspace dir from back-fill (orphan must be left alone)"
+fi
+# The orphan tracked tree itself must be untouched.
+smoke_assert_eq "orphan-CLAUDE.md" "$(cat "$ORPHAN_PROFILE_DIR/CLAUDE.md")" "T5 orphan profile tree unchanged"
+
+smoke_log "T5 PASS: orphan agent (not in roster) not back-filled"
+
+smoke_log "all 5 tests PASS (#1113)"


### PR DESCRIPTION
## Summary

Closes the dual-tree gap exposed by v0.14.5-beta6 / PR #1109's watchdog scan re-anchoring. Adds an idempotent `bridge_isolation_v2_backfill_workdir_identity` helper invoked from `bridge-upgrade.sh` between the iso-v2 migrate step and apply-live. The helper copies canonical identity markers (CLAUDE.md, SOUL.md, SESSION-TYPE.md, MEMORY-SCHEMA.md, MEMORY.md) from the tracked profile tree (`\$BRIDGE_HOME/agents/<a>/`) into the v2 runtime workspace (`\$BRIDGE_DATA_ROOT/agents/<a>/workdir/`) for roster-active agents whose workspace is missing those markers. Operator-edited markers are preserved (existence-check before copy). Orphans (not in roster) are left untouched.

Fixes #1113.

### Why this exists

Two upgrade vintages ended up with empty workspaces:

1. Agents scaffolded BEFORE PR #1108 landed — identity files live only under the tracked profile tree.
2. Agents migrated via the marker-only v2 fast-path (PR #897 Track A, v0.13.10) — the fast-path writes the v2 layout marker but does NOT replay the legacy → v2 mirror.

Post-beta6 watchdog now scans the workspace tree, sees no canonical markers, reports `status: error` on every legacy agent every cron tick. Operator host (`librarian`) was the trigger.

### Shape of the fix

- New helper `lib/bridge-isolation-v2-workdir-backfill.sh` with the canonical IDENTITY_FILES array + the back-fill function (idempotent + roster-scoped + heredoc-free).
- New upgrade-helper wrapper `lib/upgrade-helpers/isolation-v2-workdir-backfill.sh` (file-as-argv pattern; mirrors `isolation-v2-migrate.sh`).
- `bridge-upgrade.sh` invokes the helper via `bridge_upgrade_with_target_env` after the iso-v2 migrate step, before apply-live. Non-fatal failure path. Output threaded through the upgrade `--json` envelope as `workdir_backfill`.
- Stderr lands under `\$TARGET_ROOT/logs/upgrade-workdir-backfill.stderr` with `/dev/null` fallback when the target logs dir is unwritable (codex r2 finding).
- Isolated-agent ownership respected: routes through `bridge_isolation_write_file_as_agent_user_via_bash` for `linux-user`-isolated agents; plain `cp -p` for shared-mode + macOS + single-OS-user installs.

### Internal pair-review (codex-rescue)

3 rounds → `implement-ok`.

- r1 NON-BLOCKING: stderr redirect used `\${BRIDGE_LOG_DIR:-/tmp}` but `BRIDGE_LOG_DIR` is not initialized in the upgrade parent shell at that point. Fixed by resolving against `\$TARGET_ROOT/logs` explicitly with an `mkdir -p` guard.
- r2 NON-BLOCKING: r1 fix had a resilience gap — if the target logs dir is unwritable, the redirect itself would fail and the helper would never run. Fixed by adding an explicit writability probe with `/dev/null` fallback so the helper always executes and the JSON envelope always records the actual outcome.
- r3: `implement-ok`.

## Test plan

- [x] `bash -n` on every changed shell file — PASS
- [x] `shellcheck -S warning` on changed shell + impacted lib files — PASS
- [x] `scripts/lint-heredoc-ban.sh --baseline-check` — PASS (no new heredoc surface; existing python3 envelope heredoc kept its shape, baseline updated for argv-list growth)
- [x] `scripts/smoke/1113-watchdog-legacy-backfill.sh` (new, 5 tests) — 5/5 PASS
- [x] `scripts/smoke/1108-watchdog-v2-workdir.sh` — PASS (no regression)
- [x] `scripts/smoke/isolation-v2-marker-only-migrate.sh` — 6/6 PASS (no regression)
- [x] `scripts/smoke/1077-migrate-iso-v2-data-dir.sh` — 3/3 PASS (no regression)
- [x] `scripts/smoke/v2-scaffold-home-and-workdir.sh` — T1 PASS, T2 SKIP (Linux-only)
- [x] `scripts/smoke/1060-layout-fresh-v2-static-claude.sh` — PASS
- [ ] **Live verification on operator host (manual)**: after merge + upgrade to a build carrying this PR, run `./agent-bridge watchdog scan > /tmp/scan.md`. The previously-failing `librarian` agent (and any other pre-#1108 scaffolded agent) must now report `status: ok` with empty `missing_files`. Verify `\$BRIDGE_DATA_ROOT/agents/<a>/workdir/` holds the 5 canonical markers byte-equal to the tracked-tree copies.

## Notes for the integration branch

- Base is `release/v0.14.5-beta7-integration` per orchestrator wave update.
- NO VERSION or CHANGELOG bump (operator policy: batch fixes accumulate; release PR is operator-cued).
- The PR may be folded into the v0.14.5-beta7 wave; downstream operators see the watchdog clean-state restoration as a side effect of the next upgrade pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)