### PR TITLE
fix(cli): accept --help/-h universally across subcommand groups (#1114 + 16 audit sites)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -668,11 +668,12 @@ A2A_HELP
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-status.sh" "$@"
       ;;
     kill)
-      # Issue #1114: short-circuit -h/--help/help before the arity
-      # check so `agb kill --help` prints usage instead of being
-      # interpreted as a target name.
+      # Issue #1114 (codex r1 follow-up): short-circuit -h/--help
+      # before the arity check so `agb kill --help` prints usage
+      # instead of being interpreted as a target name. Restricted to
+      # the dashed forms — bare `help` could be a legitimate agent id.
       case "${2:-}" in
-        -h|--help|help)
+        -h|--help)
           echo "Usage: $CLI_NAME kill <number|name|all>"
           exit 0
           ;;
@@ -696,11 +697,12 @@ A2A_HELP
       exit 0
       ;;
     attach)
-      # Issue #1114: short-circuit -h/--help/help before the arity
-      # check so `agb attach --help` prints usage instead of being
-      # treated as the attach target.
+      # Issue #1114 (codex r1 follow-up): short-circuit -h/--help
+      # before the arity check so `agb attach --help` prints usage
+      # instead of being treated as the attach target. Restricted to
+      # the dashed forms — bare `help` could be a legitimate agent id.
       case "${2:-}" in
-        -h|--help|help)
+        -h|--help)
           echo "Usage: $CLI_NAME attach [number|name]"
           exit 0
           ;;
@@ -739,12 +741,15 @@ A2A_HELP
       ;;
     urgent)
       shift
-      # Issue #1114: forwarding -h/--help/help to bridge-send.sh used
-      # to die with "알 수 없는 옵션: --help" because bridge-send.sh's
-      # `-*)` arm rejected unknown options before reaching any usage
-      # path. Print usage directly here for the agent-bridge surface.
+      # Issue #1114 (codex r1 follow-up): forwarding -h/--help to
+      # bridge-send.sh used to die with "알 수 없는 옵션: --help"
+      # because bridge-send.sh's `-*)` arm rejected unknown options
+      # before reaching any usage path. Print usage directly here for
+      # the agent-bridge surface. Restricted to the dashed forms —
+      # bare `help` could be a legitimate agent id positional in
+      # `agb urgent <agent> ...`.
       case "${1:-}" in
-        -h|--help|help)
+        -h|--help)
           cat <<URGENT_HELP
 Usage: $CLI_NAME urgent <agent> "<message>" [--wait <seconds>]
        $CLI_NAME urgent --list

--- a/agent-bridge
+++ b/agent-bridge
@@ -648,6 +648,15 @@ A2A_HELP
       esac
       ;;
     list)
+      # Issue #1114: short-circuit -h/--help/help before the arity
+      # check so `agb list --help` prints usage instead of failing the
+      # `$# -ne 1` assertion.
+      case "${2:-}" in
+        -h|--help|help)
+          echo "Usage: $CLI_NAME list"
+          exit 0
+          ;;
+      esac
       if [[ $# -ne 1 ]]; then
       bridge_die "Usage: $CLI_NAME list"
       fi
@@ -659,6 +668,15 @@ A2A_HELP
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-status.sh" "$@"
       ;;
     kill)
+      # Issue #1114: short-circuit -h/--help/help before the arity
+      # check so `agb kill --help` prints usage instead of being
+      # interpreted as a target name.
+      case "${2:-}" in
+        -h|--help|help)
+          echo "Usage: $CLI_NAME kill <number|name|all>"
+          exit 0
+          ;;
+      esac
       if [[ $# -ne 2 ]]; then
         bridge_die "Usage: $CLI_NAME kill <number|name|all>"
       fi
@@ -678,6 +696,15 @@ A2A_HELP
       exit 0
       ;;
     attach)
+      # Issue #1114: short-circuit -h/--help/help before the arity
+      # check so `agb attach --help` prints usage instead of being
+      # treated as the attach target.
+      case "${2:-}" in
+        -h|--help|help)
+          echo "Usage: $CLI_NAME attach [number|name]"
+          exit 0
+          ;;
+      esac
       if [[ $# -gt 2 ]]; then
         bridge_die "Usage: $CLI_NAME attach [number|name]"
       fi
@@ -712,6 +739,22 @@ A2A_HELP
       ;;
     urgent)
       shift
+      # Issue #1114: forwarding -h/--help/help to bridge-send.sh used
+      # to die with "알 수 없는 옵션: --help" because bridge-send.sh's
+      # `-*)` arm rejected unknown options before reaching any usage
+      # path. Print usage directly here for the agent-bridge surface.
+      case "${1:-}" in
+        -h|--help|help)
+          cat <<URGENT_HELP
+Usage: $CLI_NAME urgent <agent> "<message>" [--wait <seconds>]
+       $CLI_NAME urgent --list
+
+Enqueues an urgent task to <agent> and pokes the live tmux session.
+For ordinary task creation use: $CLI_NAME task create ...
+URGENT_HELP
+          exit 0
+          ;;
+      esac
       exec "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-send.sh" --urgent "$@"
       ;;
     task)
@@ -949,7 +992,27 @@ EOF
     worktree)
       shift
       case "${1:-}" in
+        -h|--help|help)
+          # Issue #1114: print the same candidate list the error path
+          # implies (list|doctor) instead of dying.
+          cat <<WORKTREE_HELP
+Usage: $CLI_NAME worktree <list|doctor> [options]
+
+  list             list active worktrees (default if no sub given)
+  doctor           inspect/repair worktree state
+                   (see: $CLI_NAME worktree doctor --help)
+WORKTREE_HELP
+          exit 0
+          ;;
         list|"")
+          # Issue #1114: accept `worktree list --help` without the
+          # arity check rejecting the help flag.
+          case "${2:-}" in
+            -h|--help|help)
+              echo "Usage: $CLI_NAME worktree list"
+              exit 0
+              ;;
+          esac
           if [[ $# -gt 1 ]]; then
             bridge_die "Usage: $CLI_NAME worktree list"
           fi

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1538,6 +1538,17 @@ run_list() {
         json_mode=1
         shift
         ;;
+      -h|--help|help)
+        # Issue #1114: `agent list --help` was caught by the `*)` arm
+        # as a "지원하지 않는 옵션" error.
+        cat <<'AGENT_LIST_HELP'
+Usage: agent-bridge agent list [--json]
+
+List every agent known on this host (active sessions and roster
+entries) as a human-readable table, or as JSON with --json.
+AGENT_LIST_HELP
+        return 0
+        ;;
       *)
         bridge_die "지원하지 않는 agent list 옵션입니다: $1"
         ;;
@@ -1605,6 +1616,18 @@ run_registry() {
         # symmetry with `agent list --json` so callers can keep a
         # single argv shape across both endpoints.
         shift
+        ;;
+      -h|--help|help)
+        # Issue #1114: `agent registry --help` was caught by the `*)`
+        # arm as a "지원하지 않는 옵션" error.
+        cat <<'AGENT_REGISTRY_HELP'
+Usage: agent-bridge agent registry [--json]
+
+Read-only enumeration of every agent id known on this host
+(static + dynamic + system) with cleanup-class and provenance.
+JSON-only by design — the human shape is `agent list`.
+AGENT_REGISTRY_HELP
+        return 0
         ;;
       *)
         bridge_die "지원하지 않는 agent registry 옵션입니다: $1"
@@ -4943,6 +4966,20 @@ PY
 
 run_start() {
   local agent="${1:-}"
+  # Issue #1114: -h/--help/help in the agent slot prints usage instead
+  # of being passed to bridge_require_agent (which dies with a roster
+  # mismatch message).
+  case "$agent" in
+    -h|--help|help)
+      cat <<'AGENT_START_HELP'
+Usage: agent-bridge agent start <agent> [bridge-start.sh forwards...]
+
+Start (or re-attach to) a static or dynamic agent session. Extra
+options after <agent> are forwarded verbatim to bridge-start.sh.
+AGENT_START_HELP
+      return 0
+      ;;
+  esac
   shift || true
   [[ -n "$agent" ]] || bridge_die "Usage: $(basename "$0") start <agent> [...]"
   bridge_require_agent "$agent"
@@ -4960,6 +4997,21 @@ run_safe_mode() {
 run_stop() {
   local agent="${1:-}"
   local session=""
+
+  # Issue #1114: -h/--help/help in the agent slot prints usage instead
+  # of being passed to bridge_require_agent (which dies with a roster
+  # mismatch message).
+  case "$agent" in
+    -h|--help|help)
+      cat <<'AGENT_STOP_HELP'
+Usage: agent-bridge agent stop <agent>
+
+Stop the live tmux session for <agent>. No-op if the session is
+already absent.
+AGENT_STOP_HELP
+      return 0
+      ;;
+  esac
 
   shift || true
   [[ -n "$agent" ]] || bridge_die "Usage: $(basename "$0") stop <agent>"

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -4966,11 +4966,12 @@ PY
 
 run_start() {
   local agent="${1:-}"
-  # Issue #1114: -h/--help/help in the agent slot prints usage instead
-  # of being passed to bridge_require_agent (which dies with a roster
-  # mismatch message).
+  # Issue #1114 (codex r1 follow-up): -h/--help in the agent slot
+  # prints usage instead of being passed to bridge_require_agent
+  # (which dies with a roster mismatch). Restricted to the dashed
+  # forms — bare `help` could be a legitimate agent id.
   case "$agent" in
-    -h|--help|help)
+    -h|--help)
       cat <<'AGENT_START_HELP'
 Usage: agent-bridge agent start <agent> [bridge-start.sh forwards...]
 
@@ -4998,11 +4999,12 @@ run_stop() {
   local agent="${1:-}"
   local session=""
 
-  # Issue #1114: -h/--help/help in the agent slot prints usage instead
-  # of being passed to bridge_require_agent (which dies with a roster
-  # mismatch message).
+  # Issue #1114 (codex r1 follow-up): -h/--help in the agent slot
+  # prints usage instead of being passed to bridge_require_agent
+  # (which dies with a roster mismatch). Restricted to the dashed
+  # forms — bare `help` could be a legitimate agent id.
   case "$agent" in
-    -h|--help|help)
+    -h|--help)
       cat <<'AGENT_STOP_HELP'
 Usage: agent-bridge agent stop <agent>
 

--- a/bridge-bundle.sh
+++ b/bridge-bundle.sh
@@ -91,6 +91,17 @@ command="${1:-}"
 [[ -n "$command" ]] || { usage; exit 1; }
 shift || true
 
+# Issue #1114: -h/--help/help on the top-level dispatcher prints usage
+# and exits 0. `parse_common_flag` recognizes --help but is never
+# reached when the dispatcher's "지원하지 않는 bundle 명령" arm fires
+# first.
+case "$command" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+esac
+
 case "$command" in
   create)
     target=""

--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -1119,6 +1119,16 @@ run_errors() {
   local errors_cmd="${1:-}"
   shift || true
 
+  # Issue #1114: short-circuit -h/--help/help BEFORE the
+  # bridge_require_cron_source_jobs guard so `cron errors --help` works
+  # on hosts without a populated cron source jobs file.
+  case "$errors_cmd" in
+    -h|--help|help)
+      usage
+      return 0
+      ;;
+  esac
+
   local jobs_file
   jobs_file="$(bridge_cron_source_jobs_file || true)"
   bridge_require_cron_source_jobs "$jobs_file"
@@ -1160,6 +1170,16 @@ run_errors() {
 run_cleanup() {
   local cleanup_cmd="${1:-}"
   shift || true
+
+  # Issue #1114: short-circuit -h/--help/help BEFORE the
+  # bridge_require_cron_source_jobs guard so `cron cleanup --help` works
+  # on hosts without a populated cron source jobs file.
+  case "$cleanup_cmd" in
+    -h|--help|help)
+      usage
+      return 0
+      ;;
+  esac
 
   # Issue #533 — for `--mode run-artifacts` and `--mode all` the cleanup
   # operates on BRIDGE_HOME directly and does not need a jobs file. We

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -7323,28 +7323,77 @@ while [[ $# -gt 0 ]]; do
 done
 
 CMD="${1:-}"
+shift || true
+
+# Issue #1114: -h/--help/help on the top-level dispatcher prints usage
+# and exits 0. ALSO defend the silently-dangerous case where the
+# operator types `daemon ensure --help` (or `daemon start --help`)
+# expecting help — historically the dispatcher consumed the verb,
+# matched `ensure)`, and called `cmd_start` unconditionally, starting
+# the daemon. Each verb now scans its remaining args for -h/--help/help
+# and prints usage instead of executing the cmd_*.
+daemon_args_have_help() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      -h|--help|help) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 case "$CMD" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
   start)
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
     cmd_start
     ;;
   ensure)
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
     cmd_start
     ;;
   run)
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
     cmd_run
     ;;
   run-cron-worker)
-    shift || true
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
     cmd_run_cron_worker "$@"
     ;;
   stop)
-    shift || true
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
     cmd_stop "$@"
     ;;
   status)
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
     cmd_status
     ;;
   sync)
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
     cmd_sync_cycle
     ;;
   *)

--- a/bridge-discord-relay.sh
+++ b/bridge-discord-relay.sh
@@ -40,13 +40,35 @@ cmd_sync() {
   bridge_discord_relay_step
 }
 
+discord_args_have_help() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      -h|--help|help) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 case "${1:-}" in
   status)
-    [[ $# -eq 1 ]] || bridge_die "Usage: bash $SCRIPT_DIR/bridge-discord-relay.sh status"
+    shift
+    # Issue #1114: accept `discord status --help` without the strict
+    # arity check rejecting the help flag itself.
+    if discord_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
+    [[ $# -eq 0 ]] || bridge_die "Usage: bash $SCRIPT_DIR/bridge-discord-relay.sh status"
     cmd_status
     ;;
   sync)
-    [[ $# -eq 1 ]] || bridge_die "Usage: bash $SCRIPT_DIR/bridge-discord-relay.sh sync"
+    shift
+    if discord_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
+    [[ $# -eq 0 ]] || bridge_die "Usage: bash $SCRIPT_DIR/bridge-discord-relay.sh sync"
     cmd_sync
     ;;
   -h|--help|help)

--- a/bridge-intake.sh
+++ b/bridge-intake.sh
@@ -64,6 +64,17 @@ command="${1:-}"
 [[ -n "$command" ]] || { usage; exit 1; }
 shift || true
 
+# Issue #1114: -h/--help/help on the top-level dispatcher prints usage
+# and exits 0. `parse_common_flag` recognizes --help but is never
+# reached when the dispatcher's "지원하지 않는 intake 명령" arm fires
+# first.
+case "$command" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+esac
+
 case "$command" in
   triage)
     capture_id=""

--- a/bridge-memory.sh
+++ b/bridge-memory.sh
@@ -38,6 +38,17 @@ command="${1:-}"
 [[ -n "$command" ]] || { usage; exit 1; }
 shift || true
 
+# Issue #1114: -h/--help/help on the top-level dispatcher prints usage
+# and exits 0 instead of falling through to the "지원하지 않는 memory
+# 명령입니다" error path. The sub-command --help branches lower in the
+# file are unreachable when the dispatcher rejects the sub first.
+case "$command" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+esac
+
 agent=""
 users=()
 dry_run=0

--- a/bridge-profile.sh
+++ b/bridge-profile.sh
@@ -26,6 +26,16 @@ run_status() {
   local py_args=()
   local i
 
+  # Issue #1114: -h/--help/help in the agent slot prints usage instead
+  # of being treated as an agent id (which then dies in
+  # bridge_require_agent with a roster mismatch).
+  case "${1:-}" in
+    -h|--help|help)
+      usage
+      return 0
+      ;;
+  esac
+
   if [[ "${1:-}" == "--all" ]]; then
     all=1
     shift

--- a/bridge-profile.sh
+++ b/bridge-profile.sh
@@ -26,11 +26,12 @@ run_status() {
   local py_args=()
   local i
 
-  # Issue #1114: -h/--help/help in the agent slot prints usage instead
-  # of being treated as an agent id (which then dies in
-  # bridge_require_agent with a roster mismatch).
+  # Issue #1114 (codex r1 follow-up): -h/--help in the agent slot
+  # prints usage instead of being treated as an agent id (which then
+  # dies in bridge_require_agent with a roster mismatch). Restricted
+  # to the dashed forms — bare `help` could be a legitimate agent id.
   case "${1:-}" in
-    -h|--help|help)
+    -h|--help)
       usage
       return 0
       ;;

--- a/bridge-send.sh
+++ b/bridge-send.sh
@@ -95,9 +95,11 @@ while [[ $# -gt 0 ]]; do
       WAIT_SECONDS="$2"
       shift 2
       ;;
-    -h|--help|help)
+    -h|--help)
       # Issue #1114: print usage and exit 0 instead of dying with
-      # "알 수 없는 옵션: --help" via the -*) catch-all.
+      # "알 수 없는 옵션: --help" via the -*) catch-all. Restricted to
+      # the dashed forms — bare `help` would otherwise swallow a
+      # legitimate message payload (e.g. `urgent patch help`).
       usage
       exit 0
       ;;

--- a/bridge-send.sh
+++ b/bridge-send.sh
@@ -95,6 +95,12 @@ while [[ $# -gt 0 ]]; do
       WAIT_SECONDS="$2"
       shift 2
       ;;
+    -h|--help|help)
+      # Issue #1114: print usage and exit 0 instead of dying with
+      # "알 수 없는 옵션: --help" via the -*) catch-all.
+      usage
+      exit 0
+      ;;
     -*)
       bridge_die "알 수 없는 옵션: $1"
       ;;

--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -843,12 +843,13 @@ cmd_summary() {
   local args=(summary)
   local agent
 
-  # Issue #1114: -h/--help/help in the agent argv was passed to
-  # bridge_require_agent which then dumped the roster and died. Print
-  # usage and exit 0 before the loop runs.
+  # Issue #1114 (codex r1 follow-up): -h/--help in the agent argv was
+  # passed to bridge_require_agent which then dumped the roster and
+  # died. Print usage and exit 0 before the loop runs. Restricted to
+  # the dashed forms — bare `help` could be a legitimate agent id.
   for agent in "$@"; do
     case "$agent" in
-      -h|--help|help)
+      -h|--help)
         cat <<'TASK_SUMMARY_HELP'
 Usage: agent-bridge task summary [agent...]
 

--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -843,6 +843,23 @@ cmd_summary() {
   local args=(summary)
   local agent
 
+  # Issue #1114: -h/--help/help in the agent argv was passed to
+  # bridge_require_agent which then dumped the roster and died. Print
+  # usage and exit 0 before the loop runs.
+  for agent in "$@"; do
+    case "$agent" in
+      -h|--help|help)
+        cat <<'TASK_SUMMARY_HELP'
+Usage: agent-bridge task summary [agent...]
+
+Print a one-line task-queue summary per agent. With no args, prints
+summary for every agent in the active roster.
+TASK_SUMMARY_HELP
+        return 0
+        ;;
+    esac
+  done
+
   ensure_roster_loaded
   for agent in "$@"; do
     bridge_require_agent "$agent"

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -939,6 +939,25 @@ bridge_upgrade_conflicts_dispatch() {
   # superseded; the python-side `list` adds the
   # `live_target_hash_changed_since_write` column needed by the new
   # reconcile contract.
+  #
+  # Issue #1114: short-circuit -h/--help/help BEFORE binding $sub so
+  # `agb upgrade conflicts --help` prints the same usage block the
+  # mid-loop --help branch already prints instead of falling through
+  # to the "지원하지 않는 하위 명령" error path.
+  case "${1:-}" in
+    -h|--help|help)
+      cat <<'USAGE'
+Usage:
+  agb upgrade conflicts list     [--target <bridge-home>] [--json]
+  agb upgrade conflicts diff     [--target <bridge-home>] <conflict-path>
+  agb upgrade conflicts adopt    [--target <bridge-home>] [--yes] <conflict-path>
+  agb upgrade conflicts discard  [--target <bridge-home>] [--yes] <conflict-path>
+  agb upgrade conflicts archive  [--target <bridge-home>] [--yes] <conflict-path>
+  agb upgrade conflicts reconcile [--target <bridge-home>] [--auto-archive]
+USAGE
+      return 0
+      ;;
+  esac
   local sub="${1:-list}"
   shift || true
   local target="${BRIDGE_HOME:-$HOME/.agent-bridge}"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
 
 
 }
@@ -187,6 +187,21 @@ select_for_path() {
       # the global required smokes. This case precedes that return so a
       # template-text drift still pulls the #1060 layout smokes.
       add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning
+      ;;
+  esac
+
+  # Issue #1114: subcommand-group dispatchers previously rejected
+  # `--help`. The 1114-cli-help-contract smoke pins the contract for
+  # the 16 sites the PR touched (incl. the dangerous case where
+  # `daemon ensure --help` silently ran cmd_start). Pull it additively
+  # whenever any affected CLI dispatcher moves — the main `case` below
+  # routes most of these files into broader trigger rows for their
+  # primary smokes, so this pre-pass adds 1114 ON TOP without
+  # competing with the case-first-match. Companion follow-ups
+  # #1115 / #1116 / #1117 own the broader contract.
+  case "$path" in
+    agent-bridge|agb|bridge-upgrade.sh|bridge-memory.sh|bridge-intake.sh|bridge-bundle.sh|bridge-cron.sh|bridge-daemon.sh|bridge-discord-relay.sh|bridge-send.sh|bridge-agent.sh|bridge-profile.sh|bridge-task.sh)
+      add_required 1114-cli-help-contract
       ;;
   esac
 

--- a/scripts/smoke/1114-cli-help-contract.sh
+++ b/scripts/smoke/1114-cli-help-contract.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1114-cli-help-contract.sh — Issue #1114.
+#
+# Pins the CLI --help contract for the 16 subcommand-group sites bundled by
+# PR fixing #1114. For each site:
+#   * `<entry> --help`  → exit 0, non-empty stdout, no error markers.
+#   * `<entry> -h`      → same shape (where the site accepts -h).
+#   * The dispatcher must NOT execute the verb's side effect.
+#
+# The most dangerous case is `bridge-daemon.sh ensure --help`, which
+# historically consumed the verb without inspecting --help and ran
+# `cmd_start` — silently starting the daemon when the operator only asked
+# for usage. This smoke asserts no pid file is created.
+#
+# Out of scope: enforcing the contract for every dispatcher in the repo
+# (that is issue #1117's job). This smoke covers ONLY the sites this PR
+# touched.
+#
+# Footgun #11 (heredoc_write deadlock class): all stdout capture goes
+# through `$(... 2>&1)` against the shell script directly — no python
+# heredoc-stdin into a subprocess, no `<<<` here-strings.
+
+set -uo pipefail
+
+SMOKE_NAME="1114-cli-help-contract"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# Common rejection markers from the affected dispatchers' error paths. If
+# any of these appear in --help output the contract is broken.
+ERROR_MARKERS=(
+  "지원하지 않는 하위 명령"
+  "지원하지 않는 명령"
+  "지원하지 않는 옵션"
+  "지원하지 않는 memory 명령"
+  "지원하지 않는 intake 명령"
+  "지원하지 않는 bundle 명령"
+  "지원하지 않는 agent list 옵션"
+  "지원하지 않는 agent registry 옵션"
+  "지원하지 않는 agent stop 옵션"
+  "지원하지 않는 worktree 명령"
+  "알 수 없는 옵션"
+  "옵션 값이 필요"
+  "task id가 필요"
+)
+
+assert_help_ok() {
+  # assert_help_ok <label> <cmd...>
+  local label="$1"
+  shift
+
+  local out rc=0
+  out="$("$@" 2>&1)" || rc=$?
+
+  if [[ $rc -ne 0 ]]; then
+    echo "------ output ------" >&2
+    echo "$out" >&2
+    echo "--------------------" >&2
+    smoke_fail "$label: expected rc=0, got rc=$rc"
+  fi
+  if [[ ${#out} -eq 0 ]]; then
+    smoke_fail "$label: expected non-empty stdout"
+  fi
+  local marker
+  for marker in "${ERROR_MARKERS[@]}"; do
+    if [[ "$out" == *"$marker"* ]]; then
+      echo "------ output ------" >&2
+      echo "$out" >&2
+      echo "--------------------" >&2
+      smoke_fail "$label: --help output contained error marker '$marker'"
+    fi
+  done
+  smoke_log "ok: $label (rc=0, ${#out}B)"
+}
+
+# --- Sites 1-6: shell scripts whose top-level / subcommand-group dispatchers --
+# --- previously rejected --help. -------------------------------------------
+
+assert_help_ok "1. upgrade conflicts --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-upgrade.sh" conflicts --help
+assert_help_ok "1. upgrade conflicts -h" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-upgrade.sh" conflicts -h
+
+assert_help_ok "2. memory --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-memory.sh" --help
+assert_help_ok "2. memory -h" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-memory.sh" -h
+assert_help_ok "2. memory help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-memory.sh" help
+
+assert_help_ok "3. intake --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-intake.sh" --help
+
+assert_help_ok "4. bundle --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-bundle.sh" --help
+
+assert_help_ok "5. cron errors --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-cron.sh" errors --help
+
+assert_help_ok "6. cron cleanup --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-cron.sh" cleanup --help
+
+# --- Site 7: daemon top dispatcher + per-verb safety guards -----------------
+# The critical safety case is `daemon ensure --help` — the dispatcher must
+# NOT execute cmd_start. Assert by checking the daemon pid file is absent
+# after each invocation.
+DAEMON_PID_FILE="$BRIDGE_STATE_DIR/bridge-daemon.pid"
+
+assert_help_ok "7a. daemon --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-daemon.sh" --help
+[[ ! -f "$DAEMON_PID_FILE" ]] \
+  || smoke_fail "7a. daemon --help: pid file unexpectedly present at $DAEMON_PID_FILE"
+
+# Each verb's --help guard must short-circuit before the cmd_* runs.
+for verb in start ensure run sync status stop run-cron-worker; do
+  assert_help_ok "7b. daemon $verb --help" \
+    "$BRIDGE_BASH" "$REPO_ROOT/bridge-daemon.sh" "$verb" --help
+  [[ ! -f "$DAEMON_PID_FILE" ]] \
+    || smoke_fail "7b. daemon $verb --help: pid file unexpectedly present (verb side effect leaked)"
+done
+
+# --- Site 8: discord status/sync --help (arity check used to reject) -------
+
+assert_help_ok "8a. discord status --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-discord-relay.sh" status --help
+assert_help_ok "8b. discord sync --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-discord-relay.sh" sync --help
+
+# --- Site 9: agent-bridge top-level shorthand commands ---------------------
+
+assert_help_ok "9a. agb list --help" \
+  "$REPO_ROOT/agent-bridge" list --help
+assert_help_ok "9b. agb kill --help" \
+  "$REPO_ROOT/agent-bridge" kill --help
+assert_help_ok "9c. agb attach --help" \
+  "$REPO_ROOT/agent-bridge" attach --help
+assert_help_ok "9d. agb urgent --help" \
+  "$REPO_ROOT/agent-bridge" urgent --help
+assert_help_ok "9e. agb worktree --help" \
+  "$REPO_ROOT/agent-bridge" worktree --help
+assert_help_ok "9f. agb worktree list --help" \
+  "$REPO_ROOT/agent-bridge" worktree list --help
+
+# --- Site 10: bridge-send.sh --help -----------------------------------------
+
+assert_help_ok "10. bridge-send --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-send.sh" --help
+
+# --- Sites 11-14: agent <sub> --help where <sub> previously rejected -------
+
+assert_help_ok "11. agent list --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-agent.sh" list --help
+assert_help_ok "12. agent registry --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-agent.sh" registry --help
+assert_help_ok "13. agent start --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-agent.sh" start --help
+assert_help_ok "14. agent stop --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-agent.sh" stop --help
+
+# --- Site 15: profile status --help (was treated as agent id) --------------
+
+assert_help_ok "15. profile status --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-profile.sh" status --help
+
+# --- Site 16: task summary --help (was treated as agent id) ----------------
+
+assert_help_ok "16. task summary --help" \
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-task.sh" summary --help
+
+smoke_log "all 16 sites PASS — CLI --help contract holds (#1114)"
+exit 0


### PR DESCRIPTION
## Summary

Closes #1114. Bundle of **16 audit sites** from the CLI surface audit + 1 critical safety case (`daemon ensure --help` silently running `cmd_start`).

Pattern: gate `-h` / `--help` / `help` before existing "unsupported subcommand" reject path, printing the same candidate list the error already knows.

### Sites fixed
- `bridge-upgrade.sh` (upgrade conflicts)
- `bridge-memory.sh`
- `bridge-intake.sh`
- `bridge-bundle.sh`
- `bridge-cron.sh` (errors, cleanup)
- `bridge-daemon.sh` (top + ensure safety fix)
- `bridge-discord-relay.sh`
- `agent-bridge` top-level: list, kill, attach, urgent, worktree
- `bridge-agent.sh` sub-handlers: list, registry, start, stop
- `bridge-profile.sh` status
- `bridge-task.sh` summary
- `bridge-send.sh` urgent

### Fixer wedge note
Fixer (a7eb00cd) was wedged in the codex-rescue self-review step (5/5 fixers hit this — root cause: `codex:codex-rescue` foreground sync wait on multi-file diff). Orchestrator pushed and opened the PR from the wedged worktree. wave-level codex pair-review proceeds on this PR as the official gate.

## Test plan

- [x] bash -n on 14 changed files PASS
- [x] lint-heredoc-ban baseline-check PASS
- [x] new smoke `scripts/smoke/1114-cli-help-contract.sh` (16 sites)
- [x] ci-select-smoke registration
- [ ] wave-level codex pair-review (orchestrator)

## Follow-ups (separate issues)

- #1115 — undocumented commands (a2a, plugins) — see PR #1125
- #1116 — agent/cron help text drift — see PR #1125
- #1117 — universal smoke gate (blocked on this PR merging)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — orchestrator handoff
