### PR TITLE
fix(upgrade): post-task body_file + from_version regression in beta8 (#1144)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1372,6 +1372,25 @@ if [[ $DRY_RUN -eq 0 || -z "$TARGET_VERSION" ]]; then
   TARGET_HEAD="$SOURCE_HEAD"
 fi
 
+# Issue #1144: capture the pre-apply VERSION (the installed version we are
+# upgrading FROM) before apply-live swaps the live VERSION file. The
+# post-upgrade [upgrade-complete] task body downstream (line ~2210) reads
+# ${INSTALLED_VERSION} for its `from_version:` field and for the
+# OPERATOR_ACTIONS_PENDING `applies_when_upgrading_from` lookup. The
+# variable was previously only assigned inside the --check branch, so
+# the normal apply path always rendered `from_version: unknown`.
+#
+# Prefer the live VERSION file at TARGET_ROOT (source of truth for the
+# currently-installed code); fall back to bridge_upgrade_installed_field
+# (state/upgrade/last-upgrade.json) when the VERSION file is missing or
+# zero-length on legacy installs.
+if [[ -z "${INSTALLED_VERSION:-}" ]]; then
+  INSTALLED_VERSION="$(bridge_upgrade_version_from_file "$TARGET_ROOT")"
+  if [[ -z "$INSTALLED_VERSION" || "$INSTALLED_VERSION" == "0.0.0-dev" ]]; then
+    INSTALLED_VERSION="$(bridge_upgrade_installed_field "$TARGET_ROOT" version)"
+  fi
+fi
+
 if [[ $RESTART_DAEMON -eq 0 && $RESTART_AGENTS_EXPLICIT -eq 0 ]]; then
   RESTART_AGENTS=0
 fi
@@ -2386,8 +2405,15 @@ POST_EOF
     # Persist the task body in state/ so the recovery command the
     # WARN block prints is actually rerunnable. Tempfiles vanish on
     # exit and leave the operator with guidance instead of a command
-    # that would copy-paste into "no such file". The persistent copy
-    # is deleted only on successful task create.
+    # that would copy-paste into "no such file".
+    #
+    # Issue #1144: keep the persistent copy on disk even on successful
+    # task creation. `bridge-queue.py` stores the body_file path in the
+    # task row's `body_path` column verbatim (paths under bridge-managed
+    # roots are NOT relocated to state/queue/bodies/ by stabilize_body_file).
+    # The admin runbook and `agb show <id>` both surface `body_file:` for
+    # the consumer to open — deleting the file post-create regresses that
+    # path to ENOENT (the issue #1144 symptom).
     _post_body_persist_dir="$TARGET_ROOT/state/bridge-upgrade/post-task"
     mkdir -p "$_post_body_persist_dir"
     _post_body_persist="$_post_body_persist_dir/upgrade-complete-$(date -u +%Y%m%dT%H%M%SZ).md"
@@ -2397,9 +2423,13 @@ POST_EOF
         --to "$_post_admin" --priority normal --from "$_post_admin" \
         --title "[upgrade-complete] Agent Bridge $SOURCE_VERSION — run bootstrap" \
         --body-file "$_post_body_persist" >"$_post_task_log" 2>&1; then
-      # Task created successfully — queue kept a durable copy of the
-      # body; the persist file in state/ is redundant.
-      rm -f "$_post_body_persist"
+      # Task created successfully — the persistent body file remains on
+      # disk so the task row's body_path reference is openable by the
+      # admin runbook and by `agb show <id>` consumers. The queue row
+      # additionally carries an inline copy of the body text for fast
+      # access, but the file-on-disk contract is what the post-upgrade
+      # body_file path advertises (issue #1144).
+      :
     else
       # Surface failure on stderr so the operator sees it on upgrade.
       # A silent `|| true` here was the R9 reliability gap — the

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1346,6 +1346,35 @@ EOF
     fi
   fi
 
+  # Issue #1144: capture the pre-apply VERSION (the installed version we are
+  # upgrading FROM) BEFORE any SOURCE_ROOT checkout/pull below can mutate
+  # TARGET_ROOT/VERSION. The post-upgrade [upgrade-complete] task body
+  # downstream (line ~2210) reads ${INSTALLED_VERSION} for its
+  # `from_version:` field and for the OPERATOR_ACTIONS_PENDING
+  # `applies_when_upgrading_from` lookup. The variable was previously only
+  # assigned inside the --check branch, so the normal apply path always
+  # rendered `from_version: unknown`.
+  #
+  # r2 (issue #1144 follow-up): placement must precede the
+  # `git -C "$SOURCE_ROOT" checkout -q "$TARGET_REF"` below. On a git-clone
+  # install (UPGRADING.md §97-105) SOURCE_ROOT == TARGET_ROOT, so that
+  # checkout rewrites the live VERSION file in place. Capturing AFTER the
+  # checkout would yield the target release version and the task body
+  # would render `from_version: <new>` instead of the previous installed
+  # version.
+  #
+  # Prefer the live VERSION file at TARGET_ROOT (source of truth for the
+  # currently-installed code); fall back to bridge_upgrade_installed_field
+  # (state/upgrade/last-upgrade.json) when the VERSION file is missing or
+  # zero-length on legacy installs.
+  if [[ -z "${INSTALLED_VERSION:-}" ]]; then
+    INSTALLED_VERSION="$(bridge_upgrade_version_from_file "$TARGET_ROOT")"
+    if [[ -z "$INSTALLED_VERSION" || "$INSTALLED_VERSION" == "0.0.0-dev" ]]; then
+      INSTALLED_VERSION="$(bridge_upgrade_installed_field "$TARGET_ROOT" version)"
+    fi
+  fi
+  # END: Issue #1144 INSTALLED_VERSION capture block
+
   if [[ -n "$TARGET_REF" && $DRY_RUN -eq 0 ]]; then
     git -C "$SOURCE_ROOT" checkout -q "$TARGET_REF"
   fi
@@ -1370,25 +1399,6 @@ SOURCE_HEAD="$(git -C "$SOURCE_ROOT" rev-parse HEAD 2>/dev/null || true)"
 if [[ $DRY_RUN -eq 0 || -z "$TARGET_VERSION" ]]; then
   TARGET_VERSION="$SOURCE_VERSION"
   TARGET_HEAD="$SOURCE_HEAD"
-fi
-
-# Issue #1144: capture the pre-apply VERSION (the installed version we are
-# upgrading FROM) before apply-live swaps the live VERSION file. The
-# post-upgrade [upgrade-complete] task body downstream (line ~2210) reads
-# ${INSTALLED_VERSION} for its `from_version:` field and for the
-# OPERATOR_ACTIONS_PENDING `applies_when_upgrading_from` lookup. The
-# variable was previously only assigned inside the --check branch, so
-# the normal apply path always rendered `from_version: unknown`.
-#
-# Prefer the live VERSION file at TARGET_ROOT (source of truth for the
-# currently-installed code); fall back to bridge_upgrade_installed_field
-# (state/upgrade/last-upgrade.json) when the VERSION file is missing or
-# zero-length on legacy installs.
-if [[ -z "${INSTALLED_VERSION:-}" ]]; then
-  INSTALLED_VERSION="$(bridge_upgrade_version_from_file "$TARGET_ROOT")"
-  if [[ -z "$INSTALLED_VERSION" || "$INSTALLED_VERSION" == "0.0.0-dev" ]]; then
-    INSTALLED_VERSION="$(bridge_upgrade_installed_field "$TARGET_ROOT" version)"
-  fi
 fi
 
 if [[ $RESTART_DAEMON -eq 0 && $RESTART_AGENTS_EXPLICIT -eq 0 ]]; then

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -611,7 +611,13 @@ select_for_path() {
       # only-migrated agents. Pull its regression smoke whenever the
       # upgrade entry moves so the dual-tree gap that #1108/#1109
       # exposed stays closed.
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate 1067-codex-provisioning 1113-watchdog-legacy-backfill
+      # Issue #1144: bridge-upgrade.sh captures the pre-apply VERSION
+      # into INSTALLED_VERSION (previously assigned only in --check),
+      # and keeps the post-task body_file on disk after a successful
+      # task create. Pull the regression smoke whenever the upgrade
+      # entry moves so neither of those two beta8 regressions can
+      # recur.
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate 1067-codex-provisioning 1113-watchdog-legacy-backfill 1144-upgrade-complete-task
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1144-upgrade-complete-task.sh
+++ b/scripts/smoke/1144-upgrade-complete-task.sh
@@ -71,7 +71,13 @@ extract_block() {
 
 HELPER_VERSION_FROM_FILE="$(extract_block '^bridge_upgrade_version_from_file()' '^}$')"
 HELPER_INSTALLED_FIELD="$(extract_block '^bridge_upgrade_installed_field()' '^}$')"
-CAPTURE_BLOCK="$(extract_block '^# Issue #1144: capture the pre-apply VERSION' '^fi$')"
+# r2 (issue #1144 follow-up): the capture block now lives inside the
+# `if [[ "$SUBCOMMAND" == "apply" ]]; then` outer block (indented two
+# spaces) and BEFORE the `git checkout TARGET_REF` step. The start marker
+# is the literal first comment line; the end marker is a sentinel comment
+# we added so the inner indented `fi` keywords don't collide with the
+# outer apply block's terminator.
+CAPTURE_BLOCK="$(extract_block '^[[:space:]]*# Issue #1144: capture the pre-apply VERSION' '^[[:space:]]*# END: Issue #1144 INSTALLED_VERSION capture block')"
 
 if [[ -z "$HELPER_VERSION_FROM_FILE" ]]; then
   printf 'FAIL (bootstrap): could not extract bridge_upgrade_version_from_file\n' >&2
@@ -242,6 +248,84 @@ else
   err "persist file missing rendered from_version line; contents:"
   sed 's/^/    /' "$_post_body_persist" >&2
 fi
+
+# ---------------------------------------------------------------------------
+# T5 — SOURCE_ROOT == TARGET_ROOT ordering (issue #1144 r2 regression).
+# ---------------------------------------------------------------------------
+# On a git-clone install (UPGRADING.md §97-105) the live install IS the
+# source checkout: SOURCE_ROOT == TARGET_ROOT. In that layout, the
+# `git -C "$SOURCE_ROOT" checkout -q "$TARGET_REF"` step at
+# bridge-upgrade.sh:~1375 rewrites TARGET_ROOT/VERSION in place — so any
+# INSTALLED_VERSION capture that runs AFTER the checkout reads the NEW
+# (target) version, not the previously-installed one.
+#
+# T5 simulates the apply path's ordering directly:
+#   1. Fixture: TARGET_ROOT/VERSION = 0.14.5-beta7 (the pre-upgrade install).
+#   2. Run the capture block FIRST (mirroring the r2 placement).
+#   3. Mutate TARGET_ROOT/VERSION = 0.14.5-beta8 (simulating the
+#      `git checkout TARGET_REF` step that follows in the apply path).
+#   4. Assert INSTALLED_VERSION == 0.14.5-beta7 (pre-checkout value).
+#
+# Then a negative control: re-run the capture block AFTER the simulated
+# checkout from a clean state — INSTALLED_VERSION would be 0.14.5-beta8.
+# This demonstrates that placement (not the capture helpers themselves)
+# determines the outcome — exactly the codex r1 BLOCKING finding.
+printf '== T5 — SOURCE_ROOT == TARGET_ROOT ordering ==\n'
+
+T5_ROOT="$TMP/t5-source-equals-target"
+mkdir -p "$T5_ROOT"
+printf '%s\n' '0.14.5-beta7' >"$T5_ROOT/VERSION"
+
+# In a same-root install, SOURCE_ROOT and TARGET_ROOT are the same path.
+# The capture block in bridge-upgrade.sh only references TARGET_ROOT, so
+# we drive it with TARGET_ROOT only; the implicit equivalence with
+# SOURCE_ROOT is the precondition we are modelling.
+TARGET_ROOT="$T5_ROOT"
+unset INSTALLED_VERSION 2>/dev/null || true
+
+# Step 1: capture BEFORE the simulated checkout — this is the r2
+# placement under test.
+eval "$CAPTURE_BLOCK"
+_t5_pre_checkout="${INSTALLED_VERSION:-}"
+
+# Step 2: simulate `git -C "$SOURCE_ROOT" checkout -q "$TARGET_REF"`
+# rewriting TARGET_ROOT/VERSION in place (same-root install).
+printf '%s\n' '0.14.5-beta8' >"$T5_ROOT/VERSION"
+
+step "T5 INSTALLED_VERSION captured BEFORE checkout == pre-upgrade version"
+if [[ "$_t5_pre_checkout" == "0.14.5-beta7" ]]; then
+  ok
+else
+  err "expected INSTALLED_VERSION=0.14.5-beta7 (pre-checkout), got '$_t5_pre_checkout'"
+fi
+
+step "T5 INSTALLED_VERSION is NOT the post-checkout value"
+if [[ "$_t5_pre_checkout" != "0.14.5-beta8" ]]; then
+  ok
+else
+  err "INSTALLED_VERSION leaked the post-checkout VERSION ('0.14.5-beta8') — placement is wrong"
+fi
+
+# Negative control: confirm the helpers themselves are not magic. If the
+# capture were placed AFTER the checkout (the pre-r2 buggy ordering), the
+# block would read the mutated VERSION file and INSTALLED_VERSION would
+# be the target release. This proves the ordering is what matters.
+step "T5 (control) capture AFTER simulated checkout would yield the wrong (target) version"
+unset INSTALLED_VERSION 2>/dev/null || true
+eval "$CAPTURE_BLOCK"
+_t5_post_checkout="${INSTALLED_VERSION:-}"
+if [[ "$_t5_post_checkout" == "0.14.5-beta8" ]]; then
+  ok
+else
+  err "control failed: expected post-checkout capture to read 0.14.5-beta8, got '$_t5_post_checkout'"
+fi
+
+step "T5 body template with pre-r2 ordering would render the wrong from_version"
+_t5_buggy_rendered="$(printf -- '- from_version: %s\n' "${_t5_post_checkout:-unknown}")"
+case "$_t5_buggy_rendered" in
+  *"from_version: 0.14.5-beta8"*) ok ;;
+  *) err "control failed: rendered body did not reflect post-checkout VERSION: $_t5_buggy_rendered" ;;
+esac
 
 # ---------------------------------------------------------------------------
 # Summary

--- a/scripts/smoke/1144-upgrade-complete-task.sh
+++ b/scripts/smoke/1144-upgrade-complete-task.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Issue #1144 — post-upgrade [upgrade-complete] task body regression.
+#
+# Beta8 surfaced two coupled regressions in the post-upgrade task body:
+#   1. `from_version: unknown` even when the pre-upgrade install had a
+#      readable VERSION file. Root cause: `INSTALLED_VERSION` was only
+#      assigned inside the `--check` branch (bridge-upgrade.sh ~line
+#      1274); the normal apply path left it unset, and the body template
+#      at line ~2210 rendered `${INSTALLED_VERSION:-unknown}`.
+#   2. `body_file: …/state/bridge-upgrade/post-task/upgrade-complete-<TS>.md`
+#      pointed at a path that no longer existed on disk after task
+#      creation. Root cause: a `rm -f "$_post_body_persist"` on the
+#      task-create success branch nuked the very file the queue row's
+#      body_path column still referenced.
+#
+# Coverage:
+#   T1 — bridge_upgrade_version_from_file reads the live VERSION at
+#        TARGET_ROOT before any apply step touches it (the value the fix
+#        captures into INSTALLED_VERSION).
+#   T2 — the apply-path INSTALLED_VERSION capture block (lifted verbatim
+#        from bridge-upgrade.sh by marker grep) populates the variable
+#        from a fixture VERSION file. Asserts `from_version: <pre>` (NOT
+#        `unknown`) when rendered through the body template.
+#   T3 — bridge_upgrade_installed_field fallback: when TARGET_ROOT/VERSION
+#        is missing but state/upgrade/last-upgrade.json carries a recorded
+#        `version` field, the capture path still produces a real value.
+#   T4 — persist file survives a successful task create: the body_file
+#        path advertised by the queue row remains openable after the
+#        upgrade exits. Mirrors the bridge-upgrade.sh persist block by
+#        stubbing the `agent-bridge task create` invocation with a
+#        zero-exit fake; asserts the persist file is still on disk.
+#
+# Footgun #11: no heredoc / here-string anywhere. Content is written via
+# line-by-line `printf '%s\n' ...` blocks. Runs entirely under an
+# isolated $TMP; never touches operator state.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+UPGRADE_SH="$ROOT_DIR/bridge-upgrade.sh"
+
+[[ -f "$UPGRADE_SH" ]] || {
+  printf 'FAIL (bootstrap): missing %s\n' "$UPGRADE_SH" >&2
+  exit 2
+}
+
+PASS=0
+FAIL=0
+LAST_DESC=""
+
+step() { LAST_DESC="$*"; }
+ok()   { PASS=$((PASS + 1)); printf '  PASS: %s\n' "$LAST_DESC"; }
+err()  { FAIL=$((FAIL + 1)); printf '  FAIL: %s — %s\n' "$LAST_DESC" "$*" >&2; }
+
+TMP="$(mktemp -d -t agb-1144-upgrade-complete-task.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Extract the two helper definitions and the apply-path capture block from
+# bridge-upgrade.sh by literal markers, then eval them in this shell. This
+# binds the smoke directly to the shipped code surface: a future PR that
+# deletes the capture block or renames a helper trips the test.
+#
+# `sed -n '/start/,/end/p'` is the standard bash range extraction
+# primitive — no temp pipe, no heredoc.
+extract_block() {
+  local start_pat="$1"
+  local end_pat="$2"
+  sed -n "/$start_pat/,/$end_pat/p" "$UPGRADE_SH"
+}
+
+HELPER_VERSION_FROM_FILE="$(extract_block '^bridge_upgrade_version_from_file()' '^}$')"
+HELPER_INSTALLED_FIELD="$(extract_block '^bridge_upgrade_installed_field()' '^}$')"
+CAPTURE_BLOCK="$(extract_block '^# Issue #1144: capture the pre-apply VERSION' '^fi$')"
+
+if [[ -z "$HELPER_VERSION_FROM_FILE" ]]; then
+  printf 'FAIL (bootstrap): could not extract bridge_upgrade_version_from_file\n' >&2
+  exit 2
+fi
+if [[ -z "$HELPER_INSTALLED_FIELD" ]]; then
+  printf 'FAIL (bootstrap): could not extract bridge_upgrade_installed_field\n' >&2
+  exit 2
+fi
+if [[ -z "$CAPTURE_BLOCK" ]]; then
+  printf 'FAIL (bootstrap): could not extract issue #1144 capture block — regression?\n' >&2
+  exit 2
+fi
+
+# Defining helpers via eval is the test seam — we want the smoke to fail
+# if the helper signatures drift, which only works if we use the real
+# definitions verbatim.
+eval "$HELPER_VERSION_FROM_FILE"
+eval "$HELPER_INSTALLED_FIELD"
+
+# ---------------------------------------------------------------------------
+# T1 — bridge_upgrade_version_from_file reads VERSION at TARGET_ROOT.
+# ---------------------------------------------------------------------------
+printf '== T1 — version_from_file reads pre-apply VERSION ==\n'
+
+T1_TARGET="$TMP/t1-target"
+mkdir -p "$T1_TARGET"
+printf '%s\n' '0.14.5-beta7' >"$T1_TARGET/VERSION"
+
+step "T1 version_from_file returns 0.14.5-beta7"
+_t1_value="$(bridge_upgrade_version_from_file "$T1_TARGET")"
+if [[ "$_t1_value" == "0.14.5-beta7" ]]; then
+  ok
+else
+  err "expected 0.14.5-beta7, got '$_t1_value'"
+fi
+
+# ---------------------------------------------------------------------------
+# T2 — apply-path capture block populates INSTALLED_VERSION from VERSION.
+# ---------------------------------------------------------------------------
+printf '== T2 — INSTALLED_VERSION captured pre-apply ==\n'
+
+T2_TARGET="$TMP/t2-target"
+mkdir -p "$T2_TARGET"
+printf '%s\n' '0.14.5-beta7' >"$T2_TARGET/VERSION"
+
+step "T2 capture block sets INSTALLED_VERSION to pre-apply VERSION"
+# Drive the literal capture block from bridge-upgrade.sh. The block
+# guards `if [[ -z "${INSTALLED_VERSION:-}" ]]; then` so a pre-set value
+# (from --check) wins; in the apply path it is unset, which is the case
+# we exercise here.
+TARGET_ROOT="$T2_TARGET"
+unset INSTALLED_VERSION 2>/dev/null || true
+eval "$CAPTURE_BLOCK"
+if [[ "${INSTALLED_VERSION:-}" == "0.14.5-beta7" ]]; then
+  ok
+else
+  err "expected INSTALLED_VERSION=0.14.5-beta7, got '${INSTALLED_VERSION:-}'"
+fi
+
+step "T2 body template renders from_version: <pre> (NOT unknown)"
+_t2_rendered="$(printf -- '- from_version: %s\n' "${INSTALLED_VERSION:-unknown}")"
+case "$_t2_rendered" in
+  *"from_version: 0.14.5-beta7"*)
+    case "$_t2_rendered" in
+      *"unknown"*) err "rendered body still contains 'unknown': $_t2_rendered" ;;
+      *) ok ;;
+    esac
+    ;;
+  *)
+    err "rendered body missing pre-version: $_t2_rendered"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# T3 — fallback to bridge_upgrade_installed_field when VERSION is missing.
+# ---------------------------------------------------------------------------
+printf '== T3 — installed_field fallback for legacy installs ==\n'
+
+T3_TARGET="$TMP/t3-target"
+mkdir -p "$T3_TARGET/state/upgrade"
+# No VERSION file. last-upgrade.json carries the recorded version from a
+# prior write-state pass — what an install that survived a partial
+# upgrade reports.
+{
+  printf '%s\n' '{'
+  printf '%s\n' '  "version": "0.14.5-beta7",'
+  printf '%s\n' '  "source_head": "deadbeef",'
+  printf '%s\n' '  "channel": "stable"'
+  printf '%s\n' '}'
+} >"$T3_TARGET/state/upgrade/last-upgrade.json"
+
+step "T3 capture block falls back to last-upgrade.json when VERSION is absent"
+TARGET_ROOT="$T3_TARGET"
+unset INSTALLED_VERSION 2>/dev/null || true
+eval "$CAPTURE_BLOCK"
+if [[ "${INSTALLED_VERSION:-}" == "0.14.5-beta7" ]]; then
+  ok
+else
+  err "expected INSTALLED_VERSION=0.14.5-beta7 (from last-upgrade.json), got '${INSTALLED_VERSION:-}'"
+fi
+
+# ---------------------------------------------------------------------------
+# T4 — persist file survives successful task-create on the apply path.
+# ---------------------------------------------------------------------------
+printf '== T4 — body_file persists on disk after task create ==\n'
+
+# Mirror the persist + task-create block from bridge-upgrade.sh
+# (lines ~2410-2418). We stage a fake `agent-bridge` that returns 0
+# (simulating a successful queue create) and exercise the same shell
+# sequence. The success branch must NOT delete the persist file —
+# bridge-queue.py records the path verbatim in the task row's body_path
+# column, so the persisted file IS what the queue row references.
+T4_TARGET="$TMP/t4-target"
+mkdir -p "$T4_TARGET"
+
+# A `_post_body` tempfile carrying a representative body.
+_post_body="$(mktemp "$TMP/t4-body.XXXXXX")"
+{
+  printf '%s\n' '# Agent Bridge upgrade completed'
+  printf '%s\n' ''
+  printf '%s\n' '- from_version: 0.14.5-beta7'
+  printf '%s\n' '- to_version: 0.14.5-beta9'
+} >"$_post_body"
+
+# Replicate the persist block.
+_post_body_persist_dir="$T4_TARGET/state/bridge-upgrade/post-task"
+mkdir -p "$_post_body_persist_dir"
+# Use a fixed timestamp suffix so the smoke does not race on subsecond
+# scheduling.
+_post_body_persist="$_post_body_persist_dir/upgrade-complete-19700101T000000Z.md"
+cp "$_post_body" "$_post_body_persist"
+
+# Simulate the success branch of `bridge_upgrade_with_target_env … task
+# create … > "$_post_task_log" 2>&1` by running `:` (no-op, rc=0). The
+# real branch in bridge-upgrade.sh after the fix is a `:` no-op too —
+# the file MUST stay on disk regardless of the task-create exit code.
+_post_task_log="$(mktemp "$TMP/t4-task.log.XXXXXX")"
+if : >"$_post_task_log" 2>&1; then
+  : # success branch — persist file MUST remain (issue #1144 fix)
+else
+  : # failure branch is not exercised in this T
+fi
+# bridge-upgrade.sh also runs `rm -f "$_post_body" "$_post_task_log"`
+# unconditionally after the if/else — this removes the tempfile body
+# and the task-create log, NOT the persist file. Mirror that too.
+rm -f "$_post_body" "$_post_task_log"
+
+step "T4 persist file exists after successful task create"
+if [[ -f "$_post_body_persist" ]]; then
+  ok
+else
+  err "persist file missing after task create: $_post_body_persist"
+fi
+
+step "T4 persist dir contains exactly the persist file"
+_t4_count="$(find "$_post_body_persist_dir" -maxdepth 1 -name 'upgrade-complete-*.md' -type f | wc -l | tr -d '[:space:]')"
+if [[ "$_t4_count" == "1" ]]; then
+  ok
+else
+  err "expected 1 persist file, found $_t4_count"
+fi
+
+step "T4 persist file body matches the rendered body"
+if grep -q 'from_version: 0.14.5-beta7' "$_post_body_persist"; then
+  ok
+else
+  err "persist file missing rendered from_version line; contents:"
+  sed 's/^/    /' "$_post_body_persist" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n== 1144-upgrade-complete-task summary: PASS=%d FAIL=%d ==\n' "$PASS" "$FAIL"
+if [[ $FAIL -ne 0 ]]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes the two coupled regressions in the post-upgrade `[upgrade-complete]` task body that surfaced on v0.14.5-beta8:

- `from_version: unknown` rendered into the task body even when the pre-upgrade install had a readable `VERSION` file. Root cause: `INSTALLED_VERSION` was only assigned inside the `--check` branch of `bridge-upgrade.sh` (~line 1274); the normal apply path left it unset, and the body template at line ~2210 rendered `${INSTALLED_VERSION:-unknown}`.
- `body_file: state/bridge-upgrade/post-task/upgrade-complete-<TS>.md` pointed at a path that did not exist on disk after the upgrade returned. Root cause: on the task-create success branch the script `rm -f`-ed `$_post_body_persist`, but `bridge-queue.py:stabilize_body_file` keeps bridge-managed paths verbatim — so the queue row was left pointing at ENOENT.

## Changes

- `bridge-upgrade.sh`: capture `INSTALLED_VERSION` before `apply-live` runs, after `SOURCE_VERSION` is computed. Prefer the live `VERSION` file at `TARGET_ROOT`; fall back to `bridge_upgrade_installed_field` (`state/upgrade/last-upgrade.json`) when the VERSION file is missing on a legacy install. Guarded with `if [[ -z "${INSTALLED_VERSION:-}" ]]` so the existing `--check` assignment is not double-written.
- `bridge-upgrade.sh`: drop the `rm -f "$_post_body_persist"` on the task-create success branch; replace with a `:` no-op + comment explaining the `body_path` contract. The failure branch already kept the file on disk for the printed recovery command.
- `scripts/smoke/1144-upgrade-complete-task.sh`: new regression smoke. T1 exercises `bridge_upgrade_version_from_file`; T2 extracts the apply-path capture block from `bridge-upgrade.sh` by literal markers and evaluates it against a fixture VERSION; T3 covers the `last-upgrade.json` fallback; T4 mirrors the persist block with a stubbed `task create` and asserts the file survives the success branch.
- `scripts/ci-select-smoke.sh`: wire the new smoke into the `bridge-upgrade.sh` path trigger.

## Test plan

- [x] `bash -n` + `shellcheck` pass on all modified files
- [x] `scripts/lint-heredoc-ban.sh --baseline-check` PASS (no new footgun #11 sites)
- [x] `scripts/smoke/1144-upgrade-complete-task.sh` PASS=7 FAIL=0
- [x] Regression catch confirmed: stashing the `bridge-upgrade.sh` changes makes the smoke fail at bootstrap ("could not extract issue #1144 capture block")
- [x] Related upgrade smokes still PASS: `upgrade`, `upgrade-source-preservation`, `upgrade-shared-settings-propagate`, `upgrade-conflicts-lifecycle`, `864-upgrade-perm-regressions`, `cleanup-payload-empty-stdin-872`, `1067-codex-provisioning`, `1113-watchdog-legacy-backfill`
- [ ] Live verification on a host upgrading from a known prior version: confirm `agb show <task_id>` shows `from_version: <previous>` (not `unknown`) and the referenced `body_file` path opens

NO VERSION/CHANGELOG bump per integration-branch policy.

Fixes #1144