### PR TITLE
fix(v2-isolation): add Step-A guard to bridge_bootstrap_project_skill (#1155 — 7th controller-touch site)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -3233,7 +3233,8 @@ report and reap test-fixture agents per their pattern."
       bridge_ensure_project_claude_guidance "$workdir" "$agent" >/dev/null 2>&1 || true
       bridge_ensure_auto_memory_isolation "$agent" "$workdir"
     fi
-    bridge_bootstrap_project_skill "$engine" "$workdir" >/dev/null 2>&1 || true
+    # Issue #1155: thread $agent so v2-isolation guard can resolve roster os_user.
+    bridge_bootstrap_project_skill "$engine" "$workdir" "$agent" >/dev/null 2>&1 || true
     if [[ "$engine" == "claude" ]]; then
       bridge_bootstrap_claude_shared_skills "$agent" "$workdir" >/dev/null 2>&1 || true
       # Plan-D memory stack: ensure PreCompact hook at scaffold time so new

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -985,7 +985,11 @@ run_agent() {
     # Issue #1155: thread $agent so v2-isolation guard can resolve roster os_user.
     bridge_bootstrap_project_skill "$engine" "$workdir" "$agent" >/dev/null 2>&1 || true
     bridge_sync_skill_docs "$agent" >/dev/null 2>&1 || true
-    printf 'project_skill: %s\n' "$workdir/.codex/skills/agent-bridge/SKILL.md"
+    # Issue #1155 r2: Codex project skill lives at $workdir/.agents/skills/agent-bridge/
+    # (per bridge_project_skill_dir_for + README:657 + cli-help/agent-bridge-usage.txt:231-233),
+    # not $workdir/.codex/skills/. The previous wrong path made the doctor diagnostic
+    # report a nonexistent location.
+    printf 'project_skill: %s\n' "$workdir/.agents/skills/agent-bridge/SKILL.md"
 
     echo
     echo "== Codex Hooks =="

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -882,7 +882,8 @@ run_agent() {
     # Issue #1151: thread $agent so v2-isolation guard polarity fix can
     # resolve roster os_user.
     bridge_ensure_project_claude_guidance "$workdir" "$agent" >/dev/null 2>&1 || true
-    bridge_bootstrap_project_skill "$engine" "$workdir" >/dev/null 2>&1 || true
+    # Issue #1155: thread $agent so v2-isolation guard can resolve roster os_user.
+    bridge_bootstrap_project_skill "$engine" "$workdir" "$agent" >/dev/null 2>&1 || true
     bridge_bootstrap_claude_shared_skills "$agent" "$workdir" >/dev/null 2>&1 || true
     bridge_sync_skill_docs "$agent" >/dev/null 2>&1 || true
     printf 'claude_bridge_guidance: %s\n' "$workdir/CLAUDE.md"
@@ -981,7 +982,8 @@ run_agent() {
   elif [[ "$engine" == "codex" ]]; then
     echo
     echo "== Codex Skills =="
-    bridge_bootstrap_project_skill "$engine" "$workdir" >/dev/null 2>&1 || true
+    # Issue #1155: thread $agent so v2-isolation guard can resolve roster os_user.
+    bridge_bootstrap_project_skill "$engine" "$workdir" "$agent" >/dev/null 2>&1 || true
     bridge_sync_skill_docs "$agent" >/dev/null 2>&1 || true
     printf 'project_skill: %s\n' "$workdir/.codex/skills/agent-bridge/SKILL.md"
 

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -472,7 +472,13 @@ if [[ "$ENGINE" == "claude" && $SAFE_MODE -eq 0 ]]; then
     FORCE_FRESH_SESSION=1
   fi
   if [[ $INSTALL_PROJECT_SKILL -eq 1 ]]; then
-    if ! bridge_bootstrap_project_skill "$ENGINE" "$WORK_DIR"; then
+    # Issue #1155: thread $AGENT (3rd arg) so the v2-isolation guard in
+    # bridge_bootstrap_project_skill can resolve roster os_user. Without
+    # this thread-through, the helper's `bridge_write_managed_markdown`
+    # call would `mkdir -p` / `mv` under the isolated-UID-owned workdir
+    # and surface Permission denied to operator stdout right before the
+    # tmux session dies (the call here is unredirected — see #1155).
+    if ! bridge_bootstrap_project_skill "$ENGINE" "$WORK_DIR" "$AGENT"; then
       bridge_warn "Claude bridge skill bootstrap skipped or conflicted: $WORK_DIR"
     fi
   fi
@@ -522,7 +528,10 @@ elif [[ "$ENGINE" == "codex" && $SAFE_MODE -eq 0 ]]; then
     FORCE_FRESH_SESSION=1
   fi
   if [[ $INSTALL_PROJECT_SKILL -eq 1 ]]; then
-    if ! bridge_bootstrap_project_skill "$ENGINE" "$WORK_DIR"; then
+    # Issue #1155: thread $AGENT (3rd arg) for the v2-isolation guard.
+    # Same rationale as the Claude branch above — unredirected here, so
+    # any controller-side mkdir/mv failure would reach operator stdout.
+    if ! bridge_bootstrap_project_skill "$ENGINE" "$WORK_DIR" "$AGENT"; then
       bridge_warn "Codex bridge skill bootstrap skipped or conflicted: $WORK_DIR"
     fi
   fi

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -1221,25 +1221,67 @@ bridge_bootstrap_project_skill() {
     return 0
   fi
 
-  # Issue #1155: under v2 linux-user isolation the workdir is owned by the
-  # isolated UID after Step A, so the controller cannot `mkdir`/`mv` under
-  # `$workdir/.claude/skills/agent-bridge/` (the path written by
-  # `bridge_write_managed_markdown` below). The workdir-side project skill
-  # is dead-code under v2 anyway: Claude launches with `CLAUDE_CONFIG_DIR`
-  # pointed at the isolated home's `.claude/` (see `bridge_run_agent_claude_
-  # root` in bridge-run.sh) and the isolated-home skill set is populated by
-  # `bridge_sync_isolated_home_claude_skills` via `bridge_linux_sudo_root`.
-  # Same reasoning as `bridge_sync_claude_runtime_skills`'s always-skip-
-  # under-v2 branch (lib/bridge-skills.sh:172-175). Without this guard the
-  # unredirected call sites in bridge-start.sh:475/:525 flood operator
-  # stdout with `mkdir: cannot create…` / `mv: failed to access…` right
-  # before tmux session death. Defer when agent context is available and
-  # isolation is effective; legacy non-isolated callers and call sites
-  # without resolvable agent context fall through to the original behavior.
+  # Issue #1155 r2 — engine-aware v2-isolation policy.
+  #
+  # Why per-engine: r1's blanket DEFER under v2 was engine-agnostic, but
+  # the "workdir-side is dead-code" reasoning only holds for Claude. r1
+  # codex review (BLOCKING 1) confirmed: Codex has no isolated-home
+  # reading path. There is no `CODEX_CONFIG_DIR` analog, no
+  # `bridge_sync_isolated_home_codex_skills`, and the documented
+  # project-local contract (README.md:657, scripts/cli-help/agent-bridge-
+  # usage.txt:231-233) places the Codex skill at
+  # `$workdir/.agents/skills/agent-bridge/SKILL.md`. Codex is launched
+  # from `cd "$WORK_DIR"` (bridge-run.sh:226) and reads the skill from
+  # CWD. The r1 blanket DEFER therefore silently dropped the project
+  # skill for v2 Codex agents.
+  #
+  # Per-engine policy:
+  #   - Claude under v2: workdir-side write IS dead-code. Claude launches
+  #     with `CLAUDE_CONFIG_DIR` pointed at the isolated home's
+  #     `.claude/` (`bridge_run_agent_claude_root`, bridge-run.sh:491-496),
+  #     and the isolated-home skill set is populated by
+  #     `bridge_sync_isolated_home_claude_skills` via
+  #     `bridge_linux_sudo_root`. DEFER (return 0). Mirrors
+  #     `bridge_sync_claude_runtime_skills` always-skip-under-v2
+  #     (lib/bridge-skills.sh:172-175).
+  #   - Codex under v2: workdir IS the read path. Pre-Step-A we DEFER
+  #     (workdir not yet chowned to isolated UID; controller-direct
+  #     mkdir/mv would race the chown). Post-Step-A we SUDO-ESCALATE
+  #     the workdir write — same model as the r3 fix to
+  #     `bridge_ensure_project_claude_guidance`
+  #     (lib/bridge-skills.sh:783-901). Render to controller-owned
+  #     tmpfiles, install via `bridge_linux_sudo_root install`, chown to
+  #     the isolated UID. The write site is the documented contract
+  #     path; not writing it would be a feature gap.
+  #
+  # Legacy non-isolated callers and call sites without resolvable agent
+  # context fall through to the legacy direct-write branch unchanged.
+  local _v2_isolated=0
+  local _v2_os_user=""
   if [[ -n "$agent" ]] \
       && command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
       && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
-    return 0
+    case "$engine" in
+      claude)
+        return 0  # workdir-side is dead-code under v2; isolated-home path handles it
+        ;;
+      codex)
+        if ! bridge_agent_workdir_step_a_complete "$agent" "$workdir"; then
+          # Step A pending → defer; the next bridge-start fires this again
+          # once the workdir has been chowned to the isolated UID.
+          return 0
+        fi
+        _v2_isolated=1
+        _v2_os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || true)"
+        if [[ -z "$_v2_os_user" ]]; then
+          bridge_warn "codex project skill: roster os_user empty for '$agent' under v2 isolation; skipping"
+          return 0
+        fi
+        ;;
+      *)
+        return 0
+        ;;
+    esac
   fi
 
   case "$engine" in
@@ -1253,6 +1295,77 @@ bridge_bootstrap_project_skill() {
 
   skill_file="${skill_dir}/SKILL.md"
   reference_file="${skill_dir}/references/bridge-commands.md"
+
+  if (( _v2_isolated == 1 )); then
+    # v2 Codex sudo-escalate path. Render both files to controller-owned
+    # tmpfiles, then install each via the canonical
+    # `bridge_linux_sudo_root install` + chown pattern (same as
+    # `bridge_ensure_project_claude_guidance` r3 staging dance, no
+    # heredoc-stdin → footgun #11 stays off the table). Stage path uses
+    # `$$` to avoid colliding with a concurrent agent restart.
+    local _skill_tmp="" _ref_tmp=""
+    _skill_tmp="$(mktemp)" || {
+      bridge_warn "codex project skill: cannot mktemp for SKILL.md ($agent)"
+      return 0
+    }
+    _ref_tmp="$(mktemp)" || {
+      bridge_warn "codex project skill: cannot mktemp for reference ($agent)"
+      rm -f "$_skill_tmp"
+      return 0
+    }
+    if ! bridge_render_codex_project_skill "$BRIDGE_HOME" >"$_skill_tmp"; then
+      bridge_warn "codex project skill: render failed for $agent"
+      rm -f "$_skill_tmp" "$_ref_tmp"
+      return 0
+    fi
+    if ! bridge_render_project_bridge_reference "$BRIDGE_HOME" >"$_ref_tmp"; then
+      bridge_warn "codex project skill: reference render failed for $agent"
+      rm -f "$_skill_tmp" "$_ref_tmp"
+      return 0
+    fi
+
+    # Ensure the parent skill dir + references subdir exist with isolated
+    # UID ownership before installing the files. `install` does not create
+    # intermediate directories.
+    bridge_linux_sudo_root mkdir -p "${skill_dir}/references" 2>/dev/null || {
+      bridge_warn "codex project skill: sudo mkdir failed for ${skill_dir}/references"
+      rm -f "$_skill_tmp" "$_ref_tmp"
+      return 0
+    }
+    bridge_linux_sudo_root chown -R "$_v2_os_user:$_v2_os_user" "$skill_dir" 2>/dev/null || true
+
+    # Stage each file via a sibling tmp path then atomic mv, mirroring
+    # bridge_ensure_project_claude_guidance r3.
+    local _skill_stage="${skill_file}.bridge-stage.$$"
+    if ! bridge_linux_sudo_root install -m 0644 "$_skill_tmp" "$_skill_stage" 2>/dev/null; then
+      bridge_warn "codex project skill: sudo install (stage) failed for $skill_file"
+      bridge_linux_sudo_root rm -f "$_skill_stage" 2>/dev/null || true
+      rm -f "$_skill_tmp" "$_ref_tmp"
+      return 0
+    fi
+    bridge_linux_sudo_root chown "$_v2_os_user:$_v2_os_user" "$_skill_stage" 2>/dev/null || true
+    if ! bridge_linux_sudo_root mv -f "$_skill_stage" "$skill_file" 2>/dev/null; then
+      bridge_warn "codex project skill: atomic mv failed for $skill_file"
+      bridge_linux_sudo_root rm -f "$_skill_stage" 2>/dev/null || true
+      rm -f "$_skill_tmp" "$_ref_tmp"
+      return 0
+    fi
+
+    local _ref_stage="${reference_file}.bridge-stage.$$"
+    if ! bridge_linux_sudo_root install -m 0644 "$_ref_tmp" "$_ref_stage" 2>/dev/null; then
+      bridge_warn "codex project skill: sudo install (stage) failed for $reference_file"
+      bridge_linux_sudo_root rm -f "$_ref_stage" 2>/dev/null || true
+      rm -f "$_skill_tmp" "$_ref_tmp"
+      return 0
+    fi
+    bridge_linux_sudo_root chown "$_v2_os_user:$_v2_os_user" "$_ref_stage" 2>/dev/null || true
+    if ! bridge_linux_sudo_root mv -f "$_ref_stage" "$reference_file" 2>/dev/null; then
+      bridge_warn "codex project skill: atomic mv failed for $reference_file"
+      bridge_linux_sudo_root rm -f "$_ref_stage" 2>/dev/null || true
+    fi
+    rm -f "$_skill_tmp" "$_ref_tmp"
+    return 0
+  fi
 
   case "$engine" in
     codex)

--- a/lib/bridge-skills.sh
+++ b/lib/bridge-skills.sh
@@ -1207,10 +1207,38 @@ bridge_write_managed_markdown() {
 bridge_bootstrap_project_skill() {
   local engine="$1"
   local workdir="$2"
+  # Issue #1155: optional 3rd arg threads the agent id through so the v2-
+  # isolation guard below can resolve roster `os_user`. Legacy callers
+  # without an agent arg (or call sites where agent context is not
+  # resolvable) keep the empty default → guard silently skips, legacy
+  # behavior unchanged. Mirrors the pattern beta10 used for
+  # `bridge_link_shared_claude_skill` (lib/bridge-skills.sh:108-112).
+  local agent="${3-}"
   local skill_dir skill_file reference_file
   local legacy_skill_dir=""
 
   if ! skill_dir="$(bridge_project_skill_dir_for "$engine" "$workdir")"; then
+    return 0
+  fi
+
+  # Issue #1155: under v2 linux-user isolation the workdir is owned by the
+  # isolated UID after Step A, so the controller cannot `mkdir`/`mv` under
+  # `$workdir/.claude/skills/agent-bridge/` (the path written by
+  # `bridge_write_managed_markdown` below). The workdir-side project skill
+  # is dead-code under v2 anyway: Claude launches with `CLAUDE_CONFIG_DIR`
+  # pointed at the isolated home's `.claude/` (see `bridge_run_agent_claude_
+  # root` in bridge-run.sh) and the isolated-home skill set is populated by
+  # `bridge_sync_isolated_home_claude_skills` via `bridge_linux_sudo_root`.
+  # Same reasoning as `bridge_sync_claude_runtime_skills`'s always-skip-
+  # under-v2 branch (lib/bridge-skills.sh:172-175). Without this guard the
+  # unredirected call sites in bridge-start.sh:475/:525 flood operator
+  # stdout with `mkdir: cannot create…` / `mv: failed to access…` right
+  # before tmux session death. Defer when agent context is available and
+  # isolation is effective; legacy non-isolated callers and call sites
+  # without resolvable agent context fall through to the original behavior.
+  if [[ -n "$agent" ]] \
+      && command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
     return 0
   fi
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
 
 
 }
@@ -252,7 +252,11 @@ select_for_path() {
       # `starting/stalled before engine` rendering branch — cover the
       # regression smoke + engine-alive unit smoke when status entry
       # points move.
-      add_required queue upgrade-conflicts-lifecycle status-engine-detect 835-static-admin-launch
+      # Issue #1155: bridge-setup.sh:886/:986 thread the agent id into
+      # `bridge_bootstrap_project_skill` so the v2-isolation guard can
+      # fire. Pull 1155-bootstrap-skill-guard on every bridge-setup.sh
+      # move so the thread-through cannot regress.
+      add_required queue upgrade-conflicts-lifecycle status-engine-detect 835-static-admin-launch 1155-bootstrap-skill-guard
       add_integration integration-minimal
       ;;
 
@@ -388,7 +392,14 @@ select_for_path() {
       # Step-A defer guard. Pull the helper's unit smoke whenever
       # bridge-agent.sh moves so the contract stays pinned alongside the
       # call-site fixes.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper
+      # Issue #1155: bridge-start.sh:481 (Claude) and :534 (Codex) plus
+      # bridge-agent.sh:3237 thread the agent id into
+      # `bridge_bootstrap_project_skill` so the v2-isolation guard can
+      # fire. Pull 1155-bootstrap-skill-guard whenever any of these
+      # dispatchers moves so a future PR cannot regress the thread-
+      # through (without it the workdir-side mkdir/mv floods operator
+      # stdout right before tmux session death — Gate 3 fail).
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper 1155-bootstrap-skill-guard
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -506,7 +517,11 @@ select_for_path() {
       # Issue #1151 r2: 1151-r2-sudo-escalate pins the configured-skills
       # roundtrip + project CLAUDE.md sudo-escalate contracts so the
       # post-Step-A v2 write paths cannot regress to DEFER.
-      add_required isolated-skills-sync isolation launch 1151-step-a-helper 1151-r2-sudo-escalate
+      # Issue #1155: `bridge_bootstrap_project_skill` gained the always-
+      # skip-under-v2 guard (beta10 missed the 7th controller-touch
+      # site). Pull its unit smoke whenever lib/bridge-skills.sh moves
+      # so a future PR cannot drop the optional agent arg + guard.
+      add_required isolated-skills-sync isolation launch 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1155-bootstrap-skill-guard.sh
+++ b/scripts/smoke/1155-bootstrap-skill-guard.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1155-bootstrap-skill-guard.sh — Issue #1155
+#
+# Beta10 follow-up to #1151. PR #1153 added `bridge_agent_workdir_step_a_
+# complete` + applied a v2-isolation defer guard to 6 controller-touch
+# sites. patch's 4-gate beta10 verification on a fresh Linux install
+# found a 7th missed site: `bridge_bootstrap_project_skill`
+# (`lib/bridge-skills.sh`).
+#
+# That helper calls `bridge_write_managed_markdown` which does shell
+# `mkdir -p` + `mv` under `$workdir/.claude/skills/agent-bridge/{SKILL.md,
+# references/bridge-commands.md}`. Under v2, `$workdir` is owned by the
+# isolated UID after Step A, so the controller cannot write there. Worse,
+# 2 of the 5 call sites (`bridge-start.sh:481` Claude, `:534` Codex) do
+# NOT redirect stdout/stderr, so the failures flood operator stdout
+# right before the tmux session dies (Gate 3 fail).
+#
+# Fix: add an optional `agent` 3rd arg + pair-gate on
+# `bridge_agent_linux_user_isolation_effective` (always-skip-under-v2,
+# same simple form `bridge_link_shared_claude_skill` uses at
+# `lib/bridge-skills.sh:122-127`). The workdir-side write is dead-code
+# under v2 — Claude reads skills from the isolated home's `~/.claude/
+# skills/` via `CLAUDE_CONFIG_DIR` (populated by
+# `bridge_sync_isolated_home_claude_skills` via `bridge_linux_sudo_root`).
+#
+# Truth table the guard enforces:
+#
+#   agent="" (legacy/no-context)             → proceeds (legacy path)
+#   agent + isolation NOT effective          → proceeds (legacy non-isolated)
+#   agent + isolation effective              → returns 0 immediately, no write
+#
+# This smoke is HOST-AGNOSTIC: every driver runs in a fixture tree with
+# stubs for the bridge-side helpers. No sudo, no python invocation, no
+# real workdir provisioning.
+#
+# Footgun #11 (heredoc_write deadlock class): every driver is built with
+# `printf '%s\n' >file`; no `<<<` / `<<EOF` feeds into bash functions; no
+# `$()` capture of heredoc-stdin.
+
+set -uo pipefail
+
+SMOKE_NAME="1155-bootstrap-skill-guard"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# ---------- shared driver template ----------
+#
+# Each case builds a tiny bash driver that:
+#   1. Extracts `bridge_bootstrap_project_skill` verbatim from
+#      `lib/bridge-skills.sh` (between the function header and the next
+#      top-level `^}`). Keeps the smoke aligned to live source.
+#   2. Stubs every bridge-side helper the body reaches:
+#      - `bridge_project_skill_dir_for` (returns a fixed path under workdir)
+#      - `bridge_render_claude_project_skill` / `bridge_render_codex_project_skill`
+#        / `bridge_render_project_bridge_reference` (emit a single-line body
+#        on stdout so the pipe into `bridge_write_managed_markdown` has data)
+#      - `bridge_write_managed_markdown` (records its invocation in $CALL_LOG;
+#        consumes stdin so the pipe stage finishes cleanly)
+#      - `bridge_is_managed_markdown` (returns 0 — unused in the all-fresh path)
+#      - `bridge_agent_linux_user_isolation_effective` (case-specific:
+#        return 0 = effective, return 1 = not effective)
+#   3. Invokes the function under test with chosen args.
+#   4. Writes "RC=$?" to the log.
+#
+# The case-specific stub file overrides `bridge_agent_linux_user_isolation_
+# effective` to flip behavior. The driver sources the common stubs first
+# then the case stubs (the latter wins), then the extracted function.
+
+build_driver() {
+  # $1 = driver path
+  # $2 = stubs file path (case-specific) — sourced AFTER common stubs
+  local driver="$1"
+  local stubs="$2"
+  printf '%s\n' '#!/usr/bin/env bash' >"$driver"
+  # shellcheck disable=SC2129  # per-line emit keeps footgun #11 off the table
+  printf '%s\n' 'set -uo pipefail' >>"$driver"
+  printf '%s\n' 'REPO_ROOT="$1"' >>"$driver"
+  printf '%s\n' 'STUBS="$2"' >>"$driver"
+  printf '%s\n' 'CALL_LOG="$3"' >>"$driver"
+  printf '%s\n' 'WORKDIR="$4"' >>"$driver"
+  printf '%s\n' 'AGENT="$5"' >>"$driver"
+  printf '%s\n' ': >"$CALL_LOG"' >>"$driver"
+  printf '%s\n' '# Extract the function under test verbatim from source.' >>"$driver"
+  printf '%s\n' 'EXTRACT="$(dirname "$CALL_LOG")/fn.sh"' >>"$driver"
+  printf '%s\n' 'awk "/^bridge_bootstrap_project_skill\\(\\) \\{/,/^\\}/" "$REPO_ROOT/lib/bridge-skills.sh" >"$EXTRACT"' >>"$driver"
+  printf '%s\n' '# BRIDGE_HOME is sourced by `bridge_render_*` stubs (no-op here, but'  >>"$driver"
+  printf '%s\n' '# the function passes "$BRIDGE_HOME" as the first arg to each renderer'  >>"$driver"
+  printf '%s\n' '# — define it so set -u does not trip).'  >>"$driver"
+  printf '%s\n' 'export BRIDGE_HOME="${BRIDGE_HOME:-$WORKDIR/.bridge-home}"' >>"$driver"
+  printf '%s\n' '# Common stubs.' >>"$driver"
+  printf '%s\n' 'bridge_project_skill_dir_for() {' >>"$driver"
+  printf '%s\n' '  # $1 = engine, $2 = workdir' >>"$driver"
+  printf '%s\n' '  local engine="$1"; local workdir="$2"' >>"$driver"
+  printf '%s\n' '  case "$engine" in' >>"$driver"
+  printf '%s\n' '    claude) printf "%s" "$workdir/.claude/skills/agent-bridge" ;;' >>"$driver"
+  printf '%s\n' '    codex)  printf "%s" "$workdir/.codex/skills/agent-bridge" ;;' >>"$driver"
+  printf '%s\n' '    *) return 1 ;;' >>"$driver"
+  printf '%s\n' '  esac' >>"$driver"
+  printf '%s\n' '}' >>"$driver"
+  printf '%s\n' 'bridge_render_claude_project_skill() { printf "claude-skill-body\n"; }' >>"$driver"
+  printf '%s\n' 'bridge_render_codex_project_skill() { printf "codex-skill-body\n"; }' >>"$driver"
+  printf '%s\n' 'bridge_render_project_bridge_reference() { printf "bridge-ref-body\n"; }' >>"$driver"
+  printf '%s\n' '# bridge_write_managed_markdown: record the call, consume stdin, return 0.' >>"$driver"
+  printf '%s\n' '# Recording the call is the key assertion — the guard MUST short-circuit' >>"$driver"
+  printf '%s\n' '# BEFORE this is reached on the isolation-effective path.' >>"$driver"
+  printf '%s\n' 'bridge_write_managed_markdown() {' >>"$driver"
+  printf '%s\n' '  local file="$1"; local label="$2"' >>"$driver"
+  printf '%s\n' '  cat >/dev/null  # drain the pipe' >>"$driver"
+  printf '%s\n' '  echo "bridge_write_managed_markdown:${label}:${file}" >>"$CALL_LOG"' >>"$driver"
+  printf '%s\n' '  return 0' >>"$driver"
+  printf '%s\n' '}' >>"$driver"
+  printf '%s\n' 'bridge_is_managed_markdown() { return 0; }' >>"$driver"
+  printf '%s\n' '# shellcheck disable=SC1090' >>"$driver"
+  printf '%s\n' 'source "$STUBS"' >>"$driver"
+  printf '%s\n' '# shellcheck disable=SC1090' >>"$driver"
+  printf '%s\n' 'source "$EXTRACT"' >>"$driver"
+  printf '%s\n' '# Invoke with the chosen engine (always "claude" for this smoke — the' >>"$driver"
+  printf '%s\n' '# guard logic is engine-agnostic; codex path is exercised by T4).' >>"$driver"
+  printf '%s\n' 'ENGINE="${SMOKE_ENGINE:-claude}"' >>"$driver"
+  printf '%s\n' 'bridge_bootstrap_project_skill "$ENGINE" "$WORKDIR" "$AGENT"' >>"$driver"
+  printf '%s\n' 'echo "RC=$?" >>"$CALL_LOG"' >>"$driver"
+  chmod +x "$driver"
+  : "$stubs"  # silence "unused" lint — caller writes it
+}
+
+# ---------- T1 — agent + isolation effective → guard fires, NO write ----------
+#
+# The canonical v2 fresh-create / start shape: agent context is present
+# AND `bridge_agent_linux_user_isolation_effective` returns 0. The guard
+# must short-circuit before `bridge_write_managed_markdown` is called.
+# This is the exact regression contract for the operator-stdout
+# Permission denied flood observed in #1155.
+T1_DIR="$SMOKE_TMP_ROOT/t1"
+mkdir -p "$T1_DIR"
+T1_WORKDIR="$T1_DIR/workdir"
+mkdir -p "$T1_WORKDIR"
+T1_STUBS="$T1_DIR/stubs.sh"
+printf '%s\n' '# T1 stubs — isolation EFFECTIVE.' >"$T1_STUBS"
+printf '%s\n' 'bridge_agent_linux_user_isolation_effective() { return 0; }' >>"$T1_STUBS"
+T1_DRIVER="$T1_DIR/driver.sh"
+build_driver "$T1_DRIVER" "$T1_STUBS"
+T1_CALL_LOG="$T1_DIR/calls.log"
+"$BRIDGE_BASH" "$T1_DRIVER" "$REPO_ROOT" "$T1_STUBS" "$T1_CALL_LOG" "$T1_WORKDIR" "smoke-agent" \
+  2>"$T1_DIR/err" \
+  || smoke_fail "T1 driver rc=$? — see $T1_DIR/err"
+
+if grep -q '^bridge_write_managed_markdown:' "$T1_CALL_LOG"; then
+  smoke_fail "T1 expected NO bridge_write_managed_markdown call (guard must short-circuit on isolation-effective). calls: $(tr '\n' '|' <"$T1_CALL_LOG")"
+fi
+grep -q '^RC=0$' "$T1_CALL_LOG" \
+  || smoke_fail "T1 expected RC=0 (guard returns 0). calls: $(tr '\n' '|' <"$T1_CALL_LOG")"
+smoke_log "T1 PASS: agent + isolation effective → guard short-circuits, no managed-markdown write"
+
+# ---------- T2 — agent + isolation NOT effective → bootstrap proceeds (legacy) ----------
+#
+# Legacy non-isolated agent: guard's second conjunct
+# (`bridge_agent_linux_user_isolation_effective` returns non-zero) means
+# the function falls through to the existing render + write path. We
+# expect TWO `bridge_write_managed_markdown` calls (SKILL.md + the
+# bridge-commands reference).
+T2_DIR="$SMOKE_TMP_ROOT/t2"
+mkdir -p "$T2_DIR"
+T2_WORKDIR="$T2_DIR/workdir"
+mkdir -p "$T2_WORKDIR"
+T2_STUBS="$T2_DIR/stubs.sh"
+printf '%s\n' '# T2 stubs — isolation NOT effective.' >"$T2_STUBS"
+printf '%s\n' 'bridge_agent_linux_user_isolation_effective() { return 1; }' >>"$T2_STUBS"
+T2_DRIVER="$T2_DIR/driver.sh"
+build_driver "$T2_DRIVER" "$T2_STUBS"
+T2_CALL_LOG="$T2_DIR/calls.log"
+"$BRIDGE_BASH" "$T2_DRIVER" "$REPO_ROOT" "$T2_STUBS" "$T2_CALL_LOG" "$T2_WORKDIR" "smoke-agent" \
+  2>"$T2_DIR/err" \
+  || smoke_fail "T2 driver rc=$? — see $T2_DIR/err"
+
+T2_WRITE_COUNT="$(grep -c '^bridge_write_managed_markdown:' "$T2_CALL_LOG" || true)"
+[[ "$T2_WRITE_COUNT" == "2" ]] \
+  || smoke_fail "T2 expected exactly 2 bridge_write_managed_markdown calls (SKILL.md + bridge-commands ref), got $T2_WRITE_COUNT. calls: $(tr '\n' '|' <"$T2_CALL_LOG")"
+grep -q '^bridge_write_managed_markdown:Claude bridge skill:' "$T2_CALL_LOG" \
+  || smoke_fail "T2 expected SKILL.md write under 'Claude bridge skill' label. calls: $(tr '\n' '|' <"$T2_CALL_LOG")"
+grep -q '^bridge_write_managed_markdown:bridge reference:' "$T2_CALL_LOG" \
+  || smoke_fail "T2 expected reference write under 'bridge reference' label. calls: $(tr '\n' '|' <"$T2_CALL_LOG")"
+grep -q '^RC=0$' "$T2_CALL_LOG" \
+  || smoke_fail "T2 expected RC=0 (legacy proceeds). calls: $(tr '\n' '|' <"$T2_CALL_LOG")"
+smoke_log "T2 PASS: agent + isolation not effective → bootstrap proceeds (legacy path preserved)"
+
+# ---------- T3 — empty agent arg → bootstrap proceeds (no-context fallback) ----------
+#
+# Some scaffold paths may not have an agent in scope (or callers may pass
+# empty for a reason). The guard's first conjunct (`[[ -n "$agent" ]]`)
+# short-circuits the entire isolation check on empty agent → legacy
+# behavior preserved. This case asserts the no-context fallback so a
+# future PR cannot tighten the guard into "always defer on isolation
+# effective" (which would break shared-mode and pre-#1155 callers).
+T3_DIR="$SMOKE_TMP_ROOT/t3"
+mkdir -p "$T3_DIR"
+T3_WORKDIR="$T3_DIR/workdir"
+mkdir -p "$T3_WORKDIR"
+T3_STUBS="$T3_DIR/stubs.sh"
+# Even though isolation_effective returns 0, the empty-agent first conjunct
+# short-circuits BEFORE the helper is consulted — `bridge_bootstrap_
+# project_skill` must proceed exactly as in legacy single-arg invocations
+# (`bridge-setup.sh` callers prior to #1155).
+printf '%s\n' '# T3 stubs — isolation reports effective, but agent="" should NOT consult it.' >"$T3_STUBS"
+# shellcheck disable=SC2129  # per-line emit keeps footgun #11 off the table
+printf '%s\n' 'bridge_agent_linux_user_isolation_effective() {' >>"$T3_STUBS"
+printf '%s\n' '  # If the guard incorrectly reaches this on empty agent, record a marker' >>"$T3_STUBS"
+printf '%s\n' '  # so the assertion below catches the regression. Returning 0 here would' >>"$T3_STUBS"
+printf '%s\n' '  # incorrectly defer if the [[ -n "$agent" ]] short-circuit were dropped.' >>"$T3_STUBS"
+printf '%s\n' '  echo "ISOLATION_EFFECTIVE_CONSULTED_WITH_EMPTY_AGENT" >>"$CALL_LOG"' >>"$T3_STUBS"
+printf '%s\n' '  return 0' >>"$T3_STUBS"
+printf '%s\n' '}' >>"$T3_STUBS"
+T3_DRIVER="$T3_DIR/driver.sh"
+build_driver "$T3_DRIVER" "$T3_STUBS"
+T3_CALL_LOG="$T3_DIR/calls.log"
+"$BRIDGE_BASH" "$T3_DRIVER" "$REPO_ROOT" "$T3_STUBS" "$T3_CALL_LOG" "$T3_WORKDIR" "" \
+  2>"$T3_DIR/err" \
+  || smoke_fail "T3 driver rc=$? — see $T3_DIR/err"
+
+if grep -q '^ISOLATION_EFFECTIVE_CONSULTED_WITH_EMPTY_AGENT$' "$T3_CALL_LOG"; then
+  smoke_fail "T3 expected guard to short-circuit on empty agent BEFORE consulting bridge_agent_linux_user_isolation_effective. calls: $(tr '\n' '|' <"$T3_CALL_LOG")"
+fi
+T3_WRITE_COUNT="$(grep -c '^bridge_write_managed_markdown:' "$T3_CALL_LOG" || true)"
+[[ "$T3_WRITE_COUNT" == "2" ]] \
+  || smoke_fail "T3 expected exactly 2 bridge_write_managed_markdown calls (legacy no-context fallback), got $T3_WRITE_COUNT. calls: $(tr '\n' '|' <"$T3_CALL_LOG")"
+grep -q '^RC=0$' "$T3_CALL_LOG" \
+  || smoke_fail "T3 expected RC=0. calls: $(tr '\n' '|' <"$T3_CALL_LOG")"
+smoke_log "T3 PASS: empty agent arg → legacy path proceeds, isolation check not consulted"
+
+smoke_log "all 3 tests PASS (#1155 bridge_bootstrap_project_skill v2-isolation guard: T1 + T2 + T3)"

--- a/scripts/smoke/1155-bootstrap-skill-guard.sh
+++ b/scripts/smoke/1155-bootstrap-skill-guard.sh
@@ -9,30 +9,55 @@
 # (`lib/bridge-skills.sh`).
 #
 # That helper calls `bridge_write_managed_markdown` which does shell
-# `mkdir -p` + `mv` under `$workdir/.claude/skills/agent-bridge/{SKILL.md,
-# references/bridge-commands.md}`. Under v2, `$workdir` is owned by the
-# isolated UID after Step A, so the controller cannot write there. Worse,
-# 2 of the 5 call sites (`bridge-start.sh:481` Claude, `:534` Codex) do
-# NOT redirect stdout/stderr, so the failures flood operator stdout
-# right before the tmux session dies (Gate 3 fail).
+# `mkdir -p` + `mv` under `$workdir/<engine-prefix>/skills/agent-bridge/...`.
+# Under v2, `$workdir` is owned by the isolated UID after Step A, so the
+# controller cannot write there. Worse, 2 of the 5 call sites
+# (`bridge-start.sh:481` Claude, `:534` Codex) do NOT redirect stdout/
+# stderr, so the failures flood operator stdout right before the tmux
+# session dies (Gate 3 fail).
 #
-# Fix: add an optional `agent` 3rd arg + pair-gate on
-# `bridge_agent_linux_user_isolation_effective` (always-skip-under-v2,
-# same simple form `bridge_link_shared_claude_skill` uses at
-# `lib/bridge-skills.sh:122-127`). The workdir-side write is dead-code
-# under v2 — Claude reads skills from the isolated home's `~/.claude/
-# skills/` via `CLAUDE_CONFIG_DIR` (populated by
-# `bridge_sync_isolated_home_claude_skills` via `bridge_linux_sudo_root`).
+# r1 fix (PR #1156 first commit): blanket engine-agnostic DEFER guard.
+# Codex r1 review (BLOCKING 1 + 2) caught two engine-asymmetry bugs:
+#   - Codex has NO isolated-home reading path (no CODEX_CONFIG_DIR
+#     analog, no isolated-home sync), so the blanket DEFER silently
+#     dropped Codex's documented project skill at
+#     `$workdir/.agents/skills/agent-bridge/`. r1's "workdir-side is
+#     dead-code" reasoning only holds for Claude.
+#   - The original smoke claimed T4 exercised Codex but only had T1-T3
+#     (Claude-default), and stubbed the wrong Codex path
+#     (`.codex/skills` vs production `.agents/skills`).
+#
+# r2 fix (this file's contract): per-engine policy in
+# `bridge_bootstrap_project_skill`:
+#
+#   - Claude under v2 (Step A complete or pending): DEFER. Workdir-side
+#     write is dead-code; `bridge_sync_isolated_home_claude_skills`
+#     populates the isolated home which `CLAUDE_CONFIG_DIR` points at.
+#   - Codex under v2 Step A pending: DEFER. Workdir not yet chowned.
+#   - Codex under v2 Step A complete: SUDO-ESCALATE. Render to
+#     controller-owned tmpfiles, `bridge_linux_sudo_root install` +
+#     chown to isolated UID. Same model as
+#     `bridge_ensure_project_claude_guidance` r3
+#     (lib/bridge-skills.sh:783-901).
+#   - Legacy non-isolated (any engine) and empty-agent: unchanged legacy
+#     direct write via `bridge_write_managed_markdown`.
 #
 # Truth table the guard enforces:
 #
-#   agent="" (legacy/no-context)             → proceeds (legacy path)
-#   agent + isolation NOT effective          → proceeds (legacy non-isolated)
-#   agent + isolation effective              → returns 0 immediately, no write
+#   engine  | iso effective | step A    | agent | behavior
+#   --------|---------------|-----------|-------|----------------------------
+#   claude  | yes           | (any)     | set   | DEFER (T1)
+#   claude  | no            | -         | set   | legacy direct write (T2)
+#   any     | (any)         | -         | ""    | legacy direct write (T3)
+#   codex   | yes           | complete  | set   | SUDO-ESCALATE (T4)
+#   codex   | no            | -         | set   | legacy direct write (T5)
+#   codex   | yes           | pending   | set   | DEFER (T6)
 #
 # This smoke is HOST-AGNOSTIC: every driver runs in a fixture tree with
 # stubs for the bridge-side helpers. No sudo, no python invocation, no
-# real workdir provisioning.
+# real workdir provisioning. The Codex sudo-escalate path is exercised
+# by stubbing `bridge_linux_sudo_root` to record its argv into a call
+# log (no real privilege elevation).
 #
 # Footgun #11 (heredoc_write deadlock class): every driver is built with
 # `printf '%s\n' >file`; no `<<<` / `<<EOF` feeds into bash functions; no
@@ -71,27 +96,36 @@ fi
 #      `lib/bridge-skills.sh` (between the function header and the next
 #      top-level `^}`). Keeps the smoke aligned to live source.
 #   2. Stubs every bridge-side helper the body reaches:
-#      - `bridge_project_skill_dir_for` (returns a fixed path under workdir)
+#      - `bridge_project_skill_dir_for` (returns the production path under
+#         workdir; Codex → .agents/skills, Claude → .claude/skills)
 #      - `bridge_render_claude_project_skill` / `bridge_render_codex_project_skill`
 #        / `bridge_render_project_bridge_reference` (emit a single-line body
-#        on stdout so the pipe into `bridge_write_managed_markdown` has data)
+#        on stdout so the pipe into `bridge_write_managed_markdown` (legacy
+#        path) or the redirect to tmpfile (v2 sudo path) has data)
 #      - `bridge_write_managed_markdown` (records its invocation in $CALL_LOG;
-#        consumes stdin so the pipe stage finishes cleanly)
+#        consumes stdin so the pipe stage finishes cleanly — used by legacy
+#        path only)
+#      - `bridge_linux_sudo_root` (records each invocation in $CALL_LOG;
+#        executes the arguments directly so install/mv/mkdir actually
+#        materialize the tmpfile dance — used by the Codex v2 sudo path)
 #      - `bridge_is_managed_markdown` (returns 0 — unused in the all-fresh path)
 #      - `bridge_agent_linux_user_isolation_effective` (case-specific:
 #        return 0 = effective, return 1 = not effective)
-#   3. Invokes the function under test with chosen args.
+#      - `bridge_agent_workdir_step_a_complete` (case-specific)
+#      - `bridge_agent_os_user` (returns a fixed test username)
+#      - `bridge_warn` (records to $CALL_LOG — so soft-fail warnings are
+#        visible to assertions)
+#   3. Invokes the function under test with the engine chosen by
+#      `SMOKE_ENGINE` (default: per case), `WORKDIR`, and `AGENT`.
 #   4. Writes "RC=$?" to the log.
-#
-# The case-specific stub file overrides `bridge_agent_linux_user_isolation_
-# effective` to flip behavior. The driver sources the common stubs first
-# then the case stubs (the latter wins), then the extracted function.
 
 build_driver() {
   # $1 = driver path
   # $2 = stubs file path (case-specific) — sourced AFTER common stubs
+  # $3 = engine to test (claude | codex)
   local driver="$1"
   local stubs="$2"
+  local engine="$3"
   printf '%s\n' '#!/usr/bin/env bash' >"$driver"
   # shellcheck disable=SC2129  # per-line emit keeps footgun #11 off the table
   printf '%s\n' 'set -uo pipefail' >>"$driver"
@@ -100,6 +134,7 @@ build_driver() {
   printf '%s\n' 'CALL_LOG="$3"' >>"$driver"
   printf '%s\n' 'WORKDIR="$4"' >>"$driver"
   printf '%s\n' 'AGENT="$5"' >>"$driver"
+  printf '%s\n' 'ENGINE="$6"' >>"$driver"
   printf '%s\n' ': >"$CALL_LOG"' >>"$driver"
   printf '%s\n' '# Extract the function under test verbatim from source.' >>"$driver"
   printf '%s\n' 'EXTRACT="$(dirname "$CALL_LOG")/fn.sh"' >>"$driver"
@@ -110,11 +145,12 @@ build_driver() {
   printf '%s\n' 'export BRIDGE_HOME="${BRIDGE_HOME:-$WORKDIR/.bridge-home}"' >>"$driver"
   printf '%s\n' '# Common stubs.' >>"$driver"
   printf '%s\n' 'bridge_project_skill_dir_for() {' >>"$driver"
-  printf '%s\n' '  # $1 = engine, $2 = workdir' >>"$driver"
+  printf '%s\n' '  # $1 = engine, $2 = workdir — match production paths' >>"$driver"
+  printf '%s\n' '  # (lib/bridge-skills.sh:22-29): codex → .agents/, claude → .claude/.' >>"$driver"
   printf '%s\n' '  local engine="$1"; local workdir="$2"' >>"$driver"
   printf '%s\n' '  case "$engine" in' >>"$driver"
   printf '%s\n' '    claude) printf "%s" "$workdir/.claude/skills/agent-bridge" ;;' >>"$driver"
-  printf '%s\n' '    codex)  printf "%s" "$workdir/.codex/skills/agent-bridge" ;;' >>"$driver"
+  printf '%s\n' '    codex)  printf "%s" "$workdir/.agents/skills/agent-bridge" ;;' >>"$driver"
   printf '%s\n' '    *) return 1 ;;' >>"$driver"
   printf '%s\n' '  esac' >>"$driver"
   printf '%s\n' '}' >>"$driver"
@@ -123,7 +159,7 @@ build_driver() {
   printf '%s\n' 'bridge_render_project_bridge_reference() { printf "bridge-ref-body\n"; }' >>"$driver"
   printf '%s\n' '# bridge_write_managed_markdown: record the call, consume stdin, return 0.' >>"$driver"
   printf '%s\n' '# Recording the call is the key assertion — the guard MUST short-circuit' >>"$driver"
-  printf '%s\n' '# BEFORE this is reached on the isolation-effective path.' >>"$driver"
+  printf '%s\n' '# BEFORE this is reached on the isolation-effective DEFER paths (T1, T6).' >>"$driver"
   printf '%s\n' 'bridge_write_managed_markdown() {' >>"$driver"
   printf '%s\n' '  local file="$1"; local label="$2"' >>"$driver"
   printf '%s\n' '  cat >/dev/null  # drain the pipe' >>"$driver"
@@ -131,65 +167,76 @@ build_driver() {
   printf '%s\n' '  return 0' >>"$driver"
   printf '%s\n' '}' >>"$driver"
   printf '%s\n' 'bridge_is_managed_markdown() { return 0; }' >>"$driver"
+  printf '%s\n' '# bridge_linux_sudo_root: record the argv, then execute it for real so the' >>"$driver"
+  printf '%s\n' '# Codex v2 sudo-escalate path actually moves files. Records every call so' >>"$driver"
+  printf '%s\n' '# assertions can verify install/mv/mkdir/chown invocations occurred in the' >>"$driver"
+  printf '%s\n' '# right order against the expected paths.' >>"$driver"
+  printf '%s\n' 'bridge_linux_sudo_root() {' >>"$driver"
+  printf '%s\n' '  echo "bridge_linux_sudo_root:$*" >>"$CALL_LOG"' >>"$driver"
+  printf '%s\n' '  "$@"' >>"$driver"
+  printf '%s\n' '}' >>"$driver"
+  printf '%s\n' 'bridge_agent_os_user() { printf "smoke-user\n"; }' >>"$driver"
+  printf '%s\n' 'bridge_warn() { echo "bridge_warn:$*" >>"$CALL_LOG"; }' >>"$driver"
+  printf '%s\n' 'bridge_info() { :; }' >>"$driver"
   printf '%s\n' '# shellcheck disable=SC1090' >>"$driver"
   printf '%s\n' 'source "$STUBS"' >>"$driver"
   printf '%s\n' '# shellcheck disable=SC1090' >>"$driver"
   printf '%s\n' 'source "$EXTRACT"' >>"$driver"
-  printf '%s\n' '# Invoke with the chosen engine (always "claude" for this smoke — the' >>"$driver"
-  printf '%s\n' '# guard logic is engine-agnostic; codex path is exercised by T4).' >>"$driver"
-  printf '%s\n' 'ENGINE="${SMOKE_ENGINE:-claude}"' >>"$driver"
   printf '%s\n' 'bridge_bootstrap_project_skill "$ENGINE" "$WORKDIR" "$AGENT"' >>"$driver"
   printf '%s\n' 'echo "RC=$?" >>"$CALL_LOG"' >>"$driver"
   chmod +x "$driver"
-  : "$stubs"  # silence "unused" lint — caller writes it
+  : "$stubs" "$engine"  # silence "unused" lint
 }
 
-# ---------- T1 — agent + isolation effective → guard fires, NO write ----------
+# ---------- T1 — Claude + isolation effective → DEFER, NO write ----------
 #
-# The canonical v2 fresh-create / start shape: agent context is present
-# AND `bridge_agent_linux_user_isolation_effective` returns 0. The guard
-# must short-circuit before `bridge_write_managed_markdown` is called.
-# This is the exact regression contract for the operator-stdout
-# Permission denied flood observed in #1155.
+# Workdir-side write is dead-code for Claude under v2 (CLAUDE_CONFIG_DIR
+# points at isolated home; `bridge_sync_isolated_home_claude_skills`
+# handles it). Guard must short-circuit before
+# `bridge_write_managed_markdown` is called.
 T1_DIR="$SMOKE_TMP_ROOT/t1"
 mkdir -p "$T1_DIR"
 T1_WORKDIR="$T1_DIR/workdir"
 mkdir -p "$T1_WORKDIR"
 T1_STUBS="$T1_DIR/stubs.sh"
-printf '%s\n' '# T1 stubs — isolation EFFECTIVE.' >"$T1_STUBS"
+printf '%s\n' '# T1 stubs — Claude + isolation EFFECTIVE.' >"$T1_STUBS"
 printf '%s\n' 'bridge_agent_linux_user_isolation_effective() { return 0; }' >>"$T1_STUBS"
+printf '%s\n' 'bridge_agent_workdir_step_a_complete() { return 0; }  # unused for claude branch' >>"$T1_STUBS"
 T1_DRIVER="$T1_DIR/driver.sh"
-build_driver "$T1_DRIVER" "$T1_STUBS"
+build_driver "$T1_DRIVER" "$T1_STUBS" claude
 T1_CALL_LOG="$T1_DIR/calls.log"
-"$BRIDGE_BASH" "$T1_DRIVER" "$REPO_ROOT" "$T1_STUBS" "$T1_CALL_LOG" "$T1_WORKDIR" "smoke-agent" \
+"$BRIDGE_BASH" "$T1_DRIVER" "$REPO_ROOT" "$T1_STUBS" "$T1_CALL_LOG" "$T1_WORKDIR" "smoke-agent" "claude" \
   2>"$T1_DIR/err" \
   || smoke_fail "T1 driver rc=$? — see $T1_DIR/err"
 
 if grep -q '^bridge_write_managed_markdown:' "$T1_CALL_LOG"; then
-  smoke_fail "T1 expected NO bridge_write_managed_markdown call (guard must short-circuit on isolation-effective). calls: $(tr '\n' '|' <"$T1_CALL_LOG")"
+  smoke_fail "T1 expected NO bridge_write_managed_markdown call (Claude+v2 DEFER). calls: $(tr '\n' '|' <"$T1_CALL_LOG")"
+fi
+if grep -q '^bridge_linux_sudo_root:' "$T1_CALL_LOG"; then
+  smoke_fail "T1 expected NO bridge_linux_sudo_root call (Claude+v2 DEFER, not SUDO-ESCALATE). calls: $(tr '\n' '|' <"$T1_CALL_LOG")"
 fi
 grep -q '^RC=0$' "$T1_CALL_LOG" \
   || smoke_fail "T1 expected RC=0 (guard returns 0). calls: $(tr '\n' '|' <"$T1_CALL_LOG")"
-smoke_log "T1 PASS: agent + isolation effective → guard short-circuits, no managed-markdown write"
+smoke_log "T1 PASS: claude + isolation effective → DEFER, no managed-markdown write, no sudo"
 
-# ---------- T2 — agent + isolation NOT effective → bootstrap proceeds (legacy) ----------
+# ---------- T2 — Claude + isolation NOT effective → bootstrap proceeds (legacy) ----------
 #
-# Legacy non-isolated agent: guard's second conjunct
-# (`bridge_agent_linux_user_isolation_effective` returns non-zero) means
-# the function falls through to the existing render + write path. We
-# expect TWO `bridge_write_managed_markdown` calls (SKILL.md + the
+# Legacy non-isolated Claude: guard's isolation conjunct is false, so the
+# function falls through to the existing render + write path. We expect
+# TWO `bridge_write_managed_markdown` calls (SKILL.md + the
 # bridge-commands reference).
 T2_DIR="$SMOKE_TMP_ROOT/t2"
 mkdir -p "$T2_DIR"
 T2_WORKDIR="$T2_DIR/workdir"
 mkdir -p "$T2_WORKDIR"
 T2_STUBS="$T2_DIR/stubs.sh"
-printf '%s\n' '# T2 stubs — isolation NOT effective.' >"$T2_STUBS"
+printf '%s\n' '# T2 stubs — Claude + isolation NOT effective.' >"$T2_STUBS"
 printf '%s\n' 'bridge_agent_linux_user_isolation_effective() { return 1; }' >>"$T2_STUBS"
+printf '%s\n' 'bridge_agent_workdir_step_a_complete() { return 0; }  # unused, isolation not effective' >>"$T2_STUBS"
 T2_DRIVER="$T2_DIR/driver.sh"
-build_driver "$T2_DRIVER" "$T2_STUBS"
+build_driver "$T2_DRIVER" "$T2_STUBS" claude
 T2_CALL_LOG="$T2_DIR/calls.log"
-"$BRIDGE_BASH" "$T2_DRIVER" "$REPO_ROOT" "$T2_STUBS" "$T2_CALL_LOG" "$T2_WORKDIR" "smoke-agent" \
+"$BRIDGE_BASH" "$T2_DRIVER" "$REPO_ROOT" "$T2_STUBS" "$T2_CALL_LOG" "$T2_WORKDIR" "smoke-agent" "claude" \
   2>"$T2_DIR/err" \
   || smoke_fail "T2 driver rc=$? — see $T2_DIR/err"
 
@@ -202,38 +249,30 @@ grep -q '^bridge_write_managed_markdown:bridge reference:' "$T2_CALL_LOG" \
   || smoke_fail "T2 expected reference write under 'bridge reference' label. calls: $(tr '\n' '|' <"$T2_CALL_LOG")"
 grep -q '^RC=0$' "$T2_CALL_LOG" \
   || smoke_fail "T2 expected RC=0 (legacy proceeds). calls: $(tr '\n' '|' <"$T2_CALL_LOG")"
-smoke_log "T2 PASS: agent + isolation not effective → bootstrap proceeds (legacy path preserved)"
+smoke_log "T2 PASS: claude + isolation not effective → bootstrap proceeds (legacy path preserved)"
 
 # ---------- T3 — empty agent arg → bootstrap proceeds (no-context fallback) ----------
 #
-# Some scaffold paths may not have an agent in scope (or callers may pass
-# empty for a reason). The guard's first conjunct (`[[ -n "$agent" ]]`)
-# short-circuits the entire isolation check on empty agent → legacy
-# behavior preserved. This case asserts the no-context fallback so a
-# future PR cannot tighten the guard into "always defer on isolation
-# effective" (which would break shared-mode and pre-#1155 callers).
+# Some scaffold paths may not have an agent in scope. The guard's first
+# conjunct (`[[ -n "$agent" ]]`) short-circuits the isolation check on
+# empty agent → legacy behavior preserved. Run against Claude here; T5
+# covers the Codex empty-agent case implicitly through the same conjunct.
 T3_DIR="$SMOKE_TMP_ROOT/t3"
 mkdir -p "$T3_DIR"
 T3_WORKDIR="$T3_DIR/workdir"
 mkdir -p "$T3_WORKDIR"
 T3_STUBS="$T3_DIR/stubs.sh"
-# Even though isolation_effective returns 0, the empty-agent first conjunct
-# short-circuits BEFORE the helper is consulted — `bridge_bootstrap_
-# project_skill` must proceed exactly as in legacy single-arg invocations
-# (`bridge-setup.sh` callers prior to #1155).
 printf '%s\n' '# T3 stubs — isolation reports effective, but agent="" should NOT consult it.' >"$T3_STUBS"
 # shellcheck disable=SC2129  # per-line emit keeps footgun #11 off the table
 printf '%s\n' 'bridge_agent_linux_user_isolation_effective() {' >>"$T3_STUBS"
-printf '%s\n' '  # If the guard incorrectly reaches this on empty agent, record a marker' >>"$T3_STUBS"
-printf '%s\n' '  # so the assertion below catches the regression. Returning 0 here would' >>"$T3_STUBS"
-printf '%s\n' '  # incorrectly defer if the [[ -n "$agent" ]] short-circuit were dropped.' >>"$T3_STUBS"
 printf '%s\n' '  echo "ISOLATION_EFFECTIVE_CONSULTED_WITH_EMPTY_AGENT" >>"$CALL_LOG"' >>"$T3_STUBS"
 printf '%s\n' '  return 0' >>"$T3_STUBS"
 printf '%s\n' '}' >>"$T3_STUBS"
+printf '%s\n' 'bridge_agent_workdir_step_a_complete() { return 0; }' >>"$T3_STUBS"
 T3_DRIVER="$T3_DIR/driver.sh"
-build_driver "$T3_DRIVER" "$T3_STUBS"
+build_driver "$T3_DRIVER" "$T3_STUBS" claude
 T3_CALL_LOG="$T3_DIR/calls.log"
-"$BRIDGE_BASH" "$T3_DRIVER" "$REPO_ROOT" "$T3_STUBS" "$T3_CALL_LOG" "$T3_WORKDIR" "" \
+"$BRIDGE_BASH" "$T3_DRIVER" "$REPO_ROOT" "$T3_STUBS" "$T3_CALL_LOG" "$T3_WORKDIR" "" "claude" \
   2>"$T3_DIR/err" \
   || smoke_fail "T3 driver rc=$? — see $T3_DIR/err"
 
@@ -247,4 +286,141 @@ grep -q '^RC=0$' "$T3_CALL_LOG" \
   || smoke_fail "T3 expected RC=0. calls: $(tr '\n' '|' <"$T3_CALL_LOG")"
 smoke_log "T3 PASS: empty agent arg → legacy path proceeds, isolation check not consulted"
 
-smoke_log "all 3 tests PASS (#1155 bridge_bootstrap_project_skill v2-isolation guard: T1 + T2 + T3)"
+# ---------- T4 — Codex + isolation effective + Step A complete → SUDO-ESCALATE ----------
+#
+# Codex's documented project-local contract (`.agents/skills/agent-bridge/`
+# in $workdir) has no v2 replacement: there's no CODEX_CONFIG_DIR analog
+# and no `bridge_sync_isolated_home_codex_skills`. After Step A the
+# workdir is owned by the isolated UID, so the controller cannot write
+# directly — but the file MUST exist for the launched Codex to load the
+# skill from CWD. r2 fix: SUDO-ESCALATE — render to tmpfiles, then
+# `bridge_linux_sudo_root install + chown` into place.
+#
+# Assertions:
+#   - NO `bridge_write_managed_markdown` calls (legacy pipe path skipped)
+#   - `bridge_linux_sudo_root mkdir -p` for the references subdir
+#   - `bridge_linux_sudo_root install -m 0644` twice (SKILL.md + reference)
+#   - `bridge_linux_sudo_root chown smoke-user:smoke-user` for staged files
+#   - `bridge_linux_sudo_root mv -f` twice (atomic install)
+#   - Final files exist with the expected content under the production
+#     path (`.agents/skills/agent-bridge/`)
+#   - RC=0
+T4_DIR="$SMOKE_TMP_ROOT/t4"
+mkdir -p "$T4_DIR"
+T4_WORKDIR="$T4_DIR/workdir"
+mkdir -p "$T4_WORKDIR"
+T4_STUBS="$T4_DIR/stubs.sh"
+printf '%s\n' '# T4 stubs — Codex + isolation EFFECTIVE + Step A COMPLETE.' >"$T4_STUBS"
+printf '%s\n' 'bridge_agent_linux_user_isolation_effective() { return 0; }' >>"$T4_STUBS"
+printf '%s\n' 'bridge_agent_workdir_step_a_complete() { return 0; }  # Step A complete → SUDO-ESCALATE' >>"$T4_STUBS"
+T4_DRIVER="$T4_DIR/driver.sh"
+build_driver "$T4_DRIVER" "$T4_STUBS" codex
+T4_CALL_LOG="$T4_DIR/calls.log"
+"$BRIDGE_BASH" "$T4_DRIVER" "$REPO_ROOT" "$T4_STUBS" "$T4_CALL_LOG" "$T4_WORKDIR" "smoke-agent" "codex" \
+  2>"$T4_DIR/err" \
+  || smoke_fail "T4 driver rc=$? — see $T4_DIR/err"
+
+if grep -q '^bridge_write_managed_markdown:' "$T4_CALL_LOG"; then
+  smoke_fail "T4 expected NO bridge_write_managed_markdown call (Codex+v2 SUDO-ESCALATE, not legacy pipe). calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+fi
+
+# Production path assertion — Codex MUST land at .agents/skills/agent-bridge,
+# NOT .codex/skills (the r1 stub path that was wrong).
+T4_SKILL_FILE="$T4_WORKDIR/.agents/skills/agent-bridge/SKILL.md"
+T4_REF_FILE="$T4_WORKDIR/.agents/skills/agent-bridge/references/bridge-commands.md"
+[[ -f "$T4_SKILL_FILE" ]] \
+  || smoke_fail "T4 expected SKILL.md at production path $T4_SKILL_FILE. calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+[[ -f "$T4_REF_FILE" ]] \
+  || smoke_fail "T4 expected reference file at production path $T4_REF_FILE. calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+
+grep -q '^bridge_linux_sudo_root:mkdir -p .*/\.agents/skills/agent-bridge/references' "$T4_CALL_LOG" \
+  || smoke_fail "T4 expected sudo mkdir -p for .agents/skills/agent-bridge/references. calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+
+T4_INSTALL_COUNT="$(grep -c '^bridge_linux_sudo_root:install -m 0644 ' "$T4_CALL_LOG" || true)"
+[[ "$T4_INSTALL_COUNT" == "2" ]] \
+  || smoke_fail "T4 expected exactly 2 sudo install -m 0644 invocations (SKILL.md + reference), got $T4_INSTALL_COUNT. calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+
+T4_MV_COUNT="$(grep -c '^bridge_linux_sudo_root:mv -f ' "$T4_CALL_LOG" || true)"
+[[ "$T4_MV_COUNT" == "2" ]] \
+  || smoke_fail "T4 expected exactly 2 sudo mv -f invocations (atomic install of SKILL.md + reference), got $T4_MV_COUNT. calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+
+grep -q '^bridge_linux_sudo_root:chown smoke-user:smoke-user ' "$T4_CALL_LOG" \
+  || smoke_fail "T4 expected sudo chown smoke-user:smoke-user on staged files. calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+
+# Verify the rendered content actually reached its destination.
+grep -q 'codex-skill-body' "$T4_SKILL_FILE" \
+  || smoke_fail "T4 expected SKILL.md content from bridge_render_codex_project_skill stub, got: $(head -c 200 "$T4_SKILL_FILE")"
+grep -q 'bridge-ref-body' "$T4_REF_FILE" \
+  || smoke_fail "T4 expected reference content from bridge_render_project_bridge_reference stub, got: $(head -c 200 "$T4_REF_FILE")"
+
+grep -q '^RC=0$' "$T4_CALL_LOG" \
+  || smoke_fail "T4 expected RC=0 (sudo-escalate succeeds). calls: $(tr '\n' '|' <"$T4_CALL_LOG")"
+smoke_log "T4 PASS: codex + isolation effective + Step A complete → SUDO-ESCALATE to .agents/skills/agent-bridge/ via bridge_linux_sudo_root"
+
+# ---------- T5 — Codex + isolation NOT effective → bootstrap proceeds (legacy) ----------
+#
+# Legacy non-isolated Codex: guard's isolation conjunct is false. The
+# function falls through to the legacy direct-write path. Expects exactly
+# 2 `bridge_write_managed_markdown` calls labeled for Codex, against the
+# production `.agents/skills/agent-bridge/` path.
+T5_DIR="$SMOKE_TMP_ROOT/t5"
+mkdir -p "$T5_DIR"
+T5_WORKDIR="$T5_DIR/workdir"
+mkdir -p "$T5_WORKDIR"
+T5_STUBS="$T5_DIR/stubs.sh"
+printf '%s\n' '# T5 stubs — Codex + isolation NOT effective.' >"$T5_STUBS"
+printf '%s\n' 'bridge_agent_linux_user_isolation_effective() { return 1; }' >>"$T5_STUBS"
+printf '%s\n' 'bridge_agent_workdir_step_a_complete() { return 0; }  # unused, isolation not effective' >>"$T5_STUBS"
+T5_DRIVER="$T5_DIR/driver.sh"
+build_driver "$T5_DRIVER" "$T5_STUBS" codex
+T5_CALL_LOG="$T5_DIR/calls.log"
+"$BRIDGE_BASH" "$T5_DRIVER" "$REPO_ROOT" "$T5_STUBS" "$T5_CALL_LOG" "$T5_WORKDIR" "smoke-agent" "codex" \
+  2>"$T5_DIR/err" \
+  || smoke_fail "T5 driver rc=$? — see $T5_DIR/err"
+
+T5_WRITE_COUNT="$(grep -c '^bridge_write_managed_markdown:' "$T5_CALL_LOG" || true)"
+[[ "$T5_WRITE_COUNT" == "2" ]] \
+  || smoke_fail "T5 expected exactly 2 bridge_write_managed_markdown calls (SKILL.md + bridge-commands ref), got $T5_WRITE_COUNT. calls: $(tr '\n' '|' <"$T5_CALL_LOG")"
+grep -q '^bridge_write_managed_markdown:Codex bridge skill:.*/\.agents/skills/agent-bridge/SKILL\.md$' "$T5_CALL_LOG" \
+  || smoke_fail "T5 expected SKILL.md write under 'Codex bridge skill' label at production .agents/skills/agent-bridge/ path. calls: $(tr '\n' '|' <"$T5_CALL_LOG")"
+grep -q '^bridge_write_managed_markdown:bridge reference:.*/\.agents/skills/agent-bridge/references/bridge-commands\.md$' "$T5_CALL_LOG" \
+  || smoke_fail "T5 expected reference write at production .agents/skills/agent-bridge/references/ path. calls: $(tr '\n' '|' <"$T5_CALL_LOG")"
+if grep -q '^bridge_linux_sudo_root:' "$T5_CALL_LOG"; then
+  smoke_fail "T5 expected NO bridge_linux_sudo_root call (legacy non-isolated path). calls: $(tr '\n' '|' <"$T5_CALL_LOG")"
+fi
+grep -q '^RC=0$' "$T5_CALL_LOG" \
+  || smoke_fail "T5 expected RC=0. calls: $(tr '\n' '|' <"$T5_CALL_LOG")"
+smoke_log "T5 PASS: codex + isolation not effective → bootstrap proceeds (legacy path, production .agents/skills path)"
+
+# ---------- T6 — Codex + isolation effective + Step A PENDING → DEFER ----------
+#
+# Pre-Step-A the workdir is still controller-owned but the chown is
+# imminent. The Codex branch DEFERs in this window so a controller-direct
+# write does not race the chown. Next bridge-start fires this again post-
+# Step-A and SUDO-ESCALATEs.
+T6_DIR="$SMOKE_TMP_ROOT/t6"
+mkdir -p "$T6_DIR"
+T6_WORKDIR="$T6_DIR/workdir"
+mkdir -p "$T6_WORKDIR"
+T6_STUBS="$T6_DIR/stubs.sh"
+printf '%s\n' '# T6 stubs — Codex + isolation EFFECTIVE + Step A PENDING.' >"$T6_STUBS"
+printf '%s\n' 'bridge_agent_linux_user_isolation_effective() { return 0; }' >>"$T6_STUBS"
+printf '%s\n' 'bridge_agent_workdir_step_a_complete() { return 1; }  # Step A pending → DEFER' >>"$T6_STUBS"
+T6_DRIVER="$T6_DIR/driver.sh"
+build_driver "$T6_DRIVER" "$T6_STUBS" codex
+T6_CALL_LOG="$T6_DIR/calls.log"
+"$BRIDGE_BASH" "$T6_DRIVER" "$REPO_ROOT" "$T6_STUBS" "$T6_CALL_LOG" "$T6_WORKDIR" "smoke-agent" "codex" \
+  2>"$T6_DIR/err" \
+  || smoke_fail "T6 driver rc=$? — see $T6_DIR/err"
+
+if grep -q '^bridge_write_managed_markdown:' "$T6_CALL_LOG"; then
+  smoke_fail "T6 expected NO bridge_write_managed_markdown call (Codex+v2 Step-A-pending DEFER). calls: $(tr '\n' '|' <"$T6_CALL_LOG")"
+fi
+if grep -q '^bridge_linux_sudo_root:' "$T6_CALL_LOG"; then
+  smoke_fail "T6 expected NO bridge_linux_sudo_root call (DEFER, not SUDO-ESCALATE). calls: $(tr '\n' '|' <"$T6_CALL_LOG")"
+fi
+grep -q '^RC=0$' "$T6_CALL_LOG" \
+  || smoke_fail "T6 expected RC=0 (defer returns 0). calls: $(tr '\n' '|' <"$T6_CALL_LOG")"
+smoke_log "T6 PASS: codex + isolation effective + Step A pending → DEFER (next start retries post-Step-A)"
+
+smoke_log "all 6 tests PASS (#1155 r2 engine-aware bridge_bootstrap_project_skill: T1 claude+iso-defer, T2 claude-legacy, T3 empty-agent, T4 codex+iso sudo-escalate, T5 codex-legacy, T6 codex+iso step-A-pending defer)"


### PR DESCRIPTION
## Summary

beta10 (PR #1153) added `bridge_agent_workdir_step_a_complete` + applied the v2-isolation defer policy to 6 controller-touch sites. patch's beta10 4-gate verification on a fresh Linux install confirmed those 6 but found a **7th missed site**: `bridge_bootstrap_project_skill` (`lib/bridge-skills.sh`). This PR closes that gap.

The helper calls `bridge_write_managed_markdown` which does shell `mkdir -p` + `mv` under `$workdir/.claude/skills/agent-bridge/{SKILL.md,references/bridge-commands.md}`. Under v2 the workdir is owned by the isolated UID after Step A → both fail with Permission denied. 2 of the 5 call sites (`bridge-start.sh:481` Claude, `:534` Codex) do NOT redirect stdout/stderr, so the failures flood operator stdout right before the tmux session dies — the direct cause of Gate 3 failing 2/4 on beta10.

### Fix shape

- `lib/bridge-skills.sh:bridge_bootstrap_project_skill` — optional 3rd `agent` arg + `[[ -n "$agent" ]] && bridge_agent_linux_user_isolation_effective "$agent"` short-circuit. The workdir-side project skill is dead code under v2 (Claude reads from `$isolated_home/.claude/skills/` via `CLAUDE_CONFIG_DIR`); same reasoning as `bridge_sync_claude_runtime_skills`'s always-skip-under-v2 branch.
- Threaded `"$agent"`/`"$AGENT"` through all 5 call sites:
  - `bridge-setup.sh:886` (Claude branch of `run_agent`)
  - `bridge-setup.sh:986` (Codex branch of `run_agent`)
  - `bridge-agent.sh:3237` (`run_create` scaffold path)
  - `bridge-start.sh:481` (Claude — previously unredirected, the operator-stdout flood site)
  - `bridge-start.sh:534` (Codex — same)
- New smoke `scripts/smoke/1155-bootstrap-skill-guard.sh` pins T1 (isolation effective → guard fires, NO `bridge_write_managed_markdown` call), T2 (isolation not effective → 2 markdown writes, legacy preserved), T3 (empty agent arg → legacy path, isolation_effective NOT consulted).
- Registered in `scripts/ci-select-smoke.sh` under `add_all_required_static`, the `lib/bridge-skills.sh` area, the `bridge-setup.sh|bridge-status.*` area, and the unified `bridge-start.sh|bridge-run.sh|…|bridge-agent.sh` dispatcher area.

Pattern mirrors `bridge_link_shared_claude_skill` (`lib/bridge-skills.sh:105-133`) introduced in beta10. Empty-agent callers (none in tree post-PR) preserve legacy behavior via the first-conjunct short-circuit.

## Test plan

- [x] `bash -n` on touched files PASS
- [x] `shellcheck` on touched files PASS
- [x] `lint-heredoc-ban.sh --baseline-check` PASS (counts unchanged)
- [x] New smoke `1155-bootstrap-skill-guard.sh` PASS 3/3
- [x] Sibling smokes still PASS:
  - `1151-step-a-helper` 6/6
  - `1151-r2-sudo-escalate` 6/6
  - `1145-option1-deferral-guard` 8/8
  - `1145-ensure-dir-actually-sudo` 4/4
  - `1139-link-shared-settings-perm` 4/4
  - `1120-controller-ops-isolated` 5/5
  - `isolated-skills-sync`
- [ ] beta11 4-gate re-verification on Linux QA host (operator gate): `agent create <a> &> /tmp/<a>-create.log` shows no `mkdir: cannot create` / `mv: failed to access` on combined stdout+stderr; `agent start <a> --no-attach` reaches Claude REPL; `watchdog scan` clean; `agent delete --purge-home --purge-crons` cleans (this last gate was already PASS on beta10).

Reference: #1155.