### PR TITLE
fix(v2-isolation): scaffold mode widening for Teams plugin contract (Gaps 1-4 of #1165)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -707,6 +707,31 @@ bridge_scaffold_agent_home() {
         bridge_linux_sudo_root chmod 0755 "$_scaffold_v2_sibling" \
           || bridge_die "scaffold sudo chmod 0755 failed: $_scaffold_v2_sibling"
       fi
+      # #1165 Gap 4: legacy per-agent tracked-profile dir at
+      # $BRIDGE_AGENT_HOME_ROOT/<agent>/ (e.g.
+      # ~/.agent-bridge/agents/<a>/). On a markerless-existing-install
+      # upgrade path, this dir was scaffolded by an older code path
+      # under the controller's umask (mode 0700 awfmanager-owned). The
+      # legacy-teams-mcp pruner and other Python helpers walk into it
+      # later (looking for residual .mcp.json files) and trip
+      # `PermissionError: '/home/awfmanager/.agent-bridge/agents/<a>/.mcp.json'`
+      # because the isolated UID running the pruner can't even stat the
+      # parent. The v2 _scaffold_v2_root above only normalizes the
+      # `data/agents/<a>/` v2 layout — the legacy `agents/<a>/` is not
+      # the same path. Idempotent: pre-create + chown + chmod 0755 so
+      # the controller can write into it (template renders, JSON files)
+      # AND any other UID on the box can traverse into it for read-only
+      # inventories. Contents stay non-secret (channel state files live
+      # under workdir/.<channel>/ with their own ACLs).
+      if [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" && -n "$agent" ]]; then
+        local _scaffold_legacy_root="$BRIDGE_AGENT_HOME_ROOT/$agent"
+        bridge_linux_sudo_root mkdir -p "$_scaffold_legacy_root" \
+          || bridge_die "scaffold sudo mkdir failed: $_scaffold_legacy_root"
+        bridge_linux_sudo_root chown "$_scaffold_controller" "$_scaffold_legacy_root" \
+          || bridge_die "scaffold sudo chown $_scaffold_controller failed: $_scaffold_legacy_root"
+        bridge_linux_sudo_root chmod 0755 "$_scaffold_legacy_root" \
+          || bridge_die "scaffold sudo chmod 0755 failed: $_scaffold_legacy_root"
+      fi
     fi
   fi
 

--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -289,10 +289,68 @@ def _resolve_isolated_owner_for_path(path: Path) -> str | None:
         cur = parent
 
 
+def _v2_agent_group_name(agent: str) -> str | None:
+    """Pure-Python mirror of `bridge_isolation_v2_agent_group_name`
+    (lib/bridge-isolation-v2.sh:406-460).
+
+    The v2 prepare path creates `ab-agent-<agent>` as a SUPPLEMENTARY
+    group of the isolated UID — `useradd -r` on a fresh user does NOT
+    set `-g <ab-agent>`, so the isolated UID's PRIMARY group is whatever
+    `useradd` defaulted to (often the system's `users` group or a
+    per-UID equivalent). `id -gn <isolated-uid>` returns that primary
+    group, NOT `ab-agent-<agent>` (#1165 r2 BLOCKING 1 — codex catch).
+    The controller is added to `ab-agent-<agent>` as a supplementary
+    member but NOT to the primary group, so a `chgrp <primary-group>`
+    on `.teams/` would re-lock the controller out of every subsequent
+    `os.stat`. This helper composes the deterministic `ab-agent-<slug>`
+    group name the v2 grant path actually uses.
+
+    Mirrors the bash helper's platform-branched length policy:
+      - Linux: hard 32-char cap on group names; for `ab-agent-<agent>`
+        compositions exceeding 32 chars, the agent segment is reduced
+        to `<head>-<7-char-sha256(agent)>` so two long agent names with
+        a shared head still resolve to distinct groups.
+      - Darwin: `dseditgroup` tolerates 255-char group names; pass
+        through unchanged up to that limit.
+
+    Returns None for invalid agent names (groupadd accepts only
+    [a-z_][a-z0-9_-]*) or when the macOS 255-char limit is exceeded —
+    matching the bash helper's `return 1` paths.
+
+    Cross-language pair: keep in lock-step with
+    `bridge_isolation_v2_agent_group_name` in lib/bridge-isolation-v2.sh.
+    Any change to one side (prefix override, length policy, hash width)
+    MUST land on both sides in the same commit.
+    """
+    if not agent:
+        return None
+    if not re.match(r'^[a-z_][a-z0-9_-]*$', agent):
+        return None
+    prefix = os.environ.get("BRIDGE_AGENT_GROUP_PREFIX", "ab-agent-")
+    composed = f"{prefix}{agent}"
+    if sys.platform == "darwin":
+        if len(composed) > 255:
+            return None
+        return composed
+    # Linux: 32-char hard cap with hash-truncation on overflow.
+    if len(composed) <= 32:
+        return composed
+    prefix_len = len(prefix)
+    avail = 32 - prefix_len
+    # Need at least 1 char + '-' + 7-char hash = 9 chars for the segment.
+    if avail < 9:
+        return None
+    keep = avail - 1 - 7
+    digest = hashlib.sha256(agent.encode("utf-8")).hexdigest()[:7]
+    head = agent[:keep]
+    return f"{prefix}{head}-{digest}"
+
+
 def _isolation_aware_mkdir(
     path: Path,
     mode: int = 0o2750,
     group: str | None = None,
+    agent: str | None = None,
 ) -> None:
     """`mkdir -p` with isolation awareness. If `path` does not exist and
     its nearest existing ancestor is owned by an isolated
@@ -313,13 +371,23 @@ def _isolation_aware_mkdir(
       path: directory to create.
       mode: target mode for the new directory. Defaults to `0o2750`
         which matches the v2 isolation contract for channel state dirs.
-      group: optional group name to `chgrp` after the mkdir+chmod step.
-        When None and the isolated owner's primary group resolves via
-        `id -gn`, that primary group is used (the iso UID's primary
-        group is always `ab-agent-<slug>` on a v2 install). When the
-        probe fails the chgrp step is skipped silently — the chmod
-        already widened group traversal in absolute terms; chgrp is
-        belt-and-braces to land the correct setgid inheritance target.
+      group: explicit group name to `chgrp` after the mkdir+chmod step.
+        Highest priority when set; useful for tests that need to pin a
+        non-default group.
+      agent: the agent slug (e.g., `args.agent` in the channel setup
+        commands). When set and `group` is None, the v2 `ab-agent-<slug>`
+        group is computed via the local `_v2_agent_group_name` mirror
+        of `bridge_isolation_v2_agent_group_name`. This is the correct
+        group to chgrp to — see #1165 r2 BLOCKING 1: the v2 prepare
+        path makes `ab-agent-<agent>` a SUPPLEMENTARY group of the
+        isolated UID, and `id -gn <isolated-uid>` returns the PRIMARY
+        group which the controller is NOT a member of, so falling back
+        to `id -gn` re-locks the controller out of `.teams/`.
+      (legacy) When both `group` and `agent` are None, falls back to
+        `id -gn <isolated-uid>` as a last-resort probe. This fallback
+        is unreliable on v2 hosts (returns the primary group, not the
+        controller-readable supplementary group) and should not be
+        relied on by new callers — pass `agent=` instead.
     """
     if path.exists():
         return
@@ -327,13 +395,24 @@ def _isolation_aware_mkdir(
     if owner is None:
         path.mkdir(parents=True, exist_ok=True)
         return
-    # Resolve the agent group name. The iso UID's primary group is the
-    # per-agent group (`ab-agent-<slug>` on a v2 install); `id -gn` is
-    # authoritative on the local host so we do not have to mirror the
-    # 32-char hash-truncation branch from
-    # bridge_isolation_v2_agent_group_name.
+    # Resolve the target group. Priority: explicit `group=` >
+    # v2-helper-via-`agent=` > `id -gn` legacy fallback. The v2 helper
+    # is authoritative on a v2 install — it composes the same
+    # `ab-agent-<slug>` group the bash grant path used to add the
+    # controller as a supplementary member. `id -gn <isolated-uid>`
+    # returns the isolated user's PRIMARY group, NOT the per-agent
+    # supplementary group; using it would re-lock the controller out
+    # of `.teams/` because the controller is not a member of the
+    # isolated UID's primary group on v2 installs (#1165 r2 BLOCKING 1).
     resolved_group = group
+    if resolved_group is None and agent is not None:
+        resolved_group = _v2_agent_group_name(agent)
     if resolved_group is None:
+        # Last-resort fallback: probe the isolated UID's primary group.
+        # On a v2 install this is NOT the controller-readable group
+        # (see docstring); kept for legacy callers that have no
+        # `agent` handle. New callers must pass `agent=` so the v2
+        # helper is exercised instead.
         try:
             id_proc = subprocess.run(
                 ["id", "-gn", owner],
@@ -1296,7 +1375,7 @@ def cmd_discord(args: argparse.Namespace) -> int:
             print_result(result)
             return 0
 
-        _isolation_aware_mkdir(discord_dir)
+        _isolation_aware_mkdir(discord_dir, agent=args.agent)
         _isolation_aware_save_text(inspected["env_path"], f"DISCORD_BOT_TOKEN={token}\n")
         _isolation_aware_save_json(inspected["access_path"], access_doc)
         result["write_status"] = "ok"
@@ -1424,7 +1503,7 @@ def cmd_telegram(args: argparse.Namespace) -> int:
             print_telegram_result(result)
             return 0
 
-        _isolation_aware_mkdir(telegram_dir)
+        _isolation_aware_mkdir(telegram_dir, agent=args.agent)
         _isolation_aware_save_text(inspected["env_path"], f"TELEGRAM_BOT_TOKEN={token}\n")
         _isolation_aware_save_json(inspected["access_path"], access_doc)
         result["write_status"] = "ok"
@@ -1623,7 +1702,7 @@ def cmd_teams(args: argparse.Namespace) -> int:
             print_teams_result(result)
             return 0
 
-        _isolation_aware_mkdir(teams_dir)
+        _isolation_aware_mkdir(teams_dir, agent=args.agent)
         env_lines = [
             f"TEAMS_APP_ID={app_id}",
             f"TEAMS_APP_PASSWORD={app_password}",
@@ -1877,7 +1956,7 @@ def cmd_mattermost(args: argparse.Namespace) -> int:
             print_mattermost_result(result)
             return 0
 
-        _isolation_aware_mkdir(mattermost_dir)
+        _isolation_aware_mkdir(mattermost_dir, agent=args.agent)
         _isolation_aware_save_text(env_path, env_text)
         _isolation_aware_save_json(access_path, access_doc)
         _isolation_aware_save_json(mcp_path, mcp_doc)

--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -289,16 +289,37 @@ def _resolve_isolated_owner_for_path(path: Path) -> str | None:
         cur = parent
 
 
-def _isolation_aware_mkdir(path: Path) -> None:
+def _isolation_aware_mkdir(
+    path: Path,
+    mode: int = 0o2750,
+    group: str | None = None,
+) -> None:
     """`mkdir -p` with isolation awareness. If `path` does not exist and
     its nearest existing ancestor is owned by an isolated
     `agent-bridge-<slug>` UID, create the missing components as that
-    UID via `sudo -n -u <owner> bash -c 'umask 0077; mkdir -p "$1"'`.
-    Otherwise falls back to `Path.mkdir(parents=True, exist_ok=True)`.
+    UID via `sudo -n -u <owner> bash -c '...'`. Otherwise falls back to
+    `Path.mkdir(parents=True, exist_ok=True)`.
 
-    The umask=0077 ensures the new dir lands at mode 0700 owned by the
-    isolated UID, mirroring the v0700/0750 mode the isolation-prepare
-    flow uses for precreated channel state dirs.
+    For isolated channel state dirs (`.teams/`, `.telegram/`, `.discord/`,
+    `.mattermost/`) the default mode is `0o2750` (setgid + group r-x), so
+    the controller (a member of the agent group `ab-agent-<slug>`) keeps
+    traversal permission after the chown to the isolated UID lands.
+    Pre-#1165 the helper used `umask 0077` which produced mode 0700 and
+    locked the controller out of every subsequent `os.stat` against the
+    channel state files (#1165 Gap 1 — `setup teams` then failed on the
+    next `inspect_teams_dir` with PermissionError).
+
+    Args:
+      path: directory to create.
+      mode: target mode for the new directory. Defaults to `0o2750`
+        which matches the v2 isolation contract for channel state dirs.
+      group: optional group name to `chgrp` after the mkdir+chmod step.
+        When None and the isolated owner's primary group resolves via
+        `id -gn`, that primary group is used (the iso UID's primary
+        group is always `ab-agent-<slug>` on a v2 install). When the
+        probe fails the chgrp step is skipped silently — the chmod
+        already widened group traversal in absolute terms; chgrp is
+        belt-and-braces to land the correct setgid inheritance target.
     """
     if path.exists():
         return
@@ -306,16 +327,48 @@ def _isolation_aware_mkdir(path: Path) -> None:
     if owner is None:
         path.mkdir(parents=True, exist_ok=True)
         return
-    script = (
-        'set -e\n'
-        'umask 0077\n'
-        'mkdir -p "$1"\n'
-        'exit 0\n'
-    )
+    # Resolve the agent group name. The iso UID's primary group is the
+    # per-agent group (`ab-agent-<slug>` on a v2 install); `id -gn` is
+    # authoritative on the local host so we do not have to mirror the
+    # 32-char hash-truncation branch from
+    # bridge_isolation_v2_agent_group_name.
+    resolved_group = group
+    if resolved_group is None:
+        try:
+            id_proc = subprocess.run(
+                ["id", "-gn", owner],
+                check=False, capture_output=True, text=True,
+            )
+        except FileNotFoundError:
+            id_proc = None
+        if id_proc is not None and id_proc.returncode == 0:
+            candidate = id_proc.stdout.strip()
+            if candidate:
+                resolved_group = candidate
+    # Build the script with mode encoded in octal (e.g. 0o2750 -> "2750").
+    # The mkdir runs under umask 0077 to guarantee a deterministic
+    # starting point; the explicit chmod afterwards lands the target
+    # mode regardless of the inherited umask. chgrp is best-effort on
+    # the isolated UID's own primary group — failure does not abort
+    # because the chmod alone restores controller traversal on the
+    # common v2 case (group already matches the agent group).
+    mode_oct = format(mode, 'o')
+    script_lines = [
+        'set -e',
+        'umask 0077',
+        'mkdir -p "$1"',
+        'chmod "$2" "$1"',
+    ]
+    if resolved_group:
+        script_lines.append('chgrp "$3" "$1" 2>/dev/null || true')
+    script_lines.append('exit 0')
+    script = '\n'.join(script_lines) + '\n'
     full = [
         "sudo", "-n", "-u", owner, "bash", "-c", script,
-        "bridge-isolation", str(path),
+        "bridge-isolation", str(path), mode_oct,
     ]
+    if resolved_group:
+        full.append(resolved_group)
     try:
         proc = subprocess.run(
             full, check=False, capture_output=True, text=True

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -3885,18 +3885,34 @@ bridge_linux_prepare_agent_isolation() {
   local isolated_claude_dir="$user_home/.claude"
   bridge_linux_sudo_root mkdir -p "$isolated_claude_dir"
   bridge_linux_sudo_root chown "$os_user" "$isolated_claude_dir" >/dev/null 2>&1 || true
-  # v2: chgrp ab-agent-<name> + chmod 2750 (setgid so new subdirs like
-  # projects/ inherit the group) so the controller (group member of
-  # ab-agent-<name>) can reach ~/.claude/projects/ for the memory-daily
-  # harvester without any named-user ACL.
+  # v2: chgrp ab-agent-<name> + chmod 2770 (setgid so new subdirs like
+  # projects/ and session-env/ inherit the group) so the controller
+  # (group member of ab-agent-<name>) can reach ~/.claude/projects/ for
+  # the memory-daily harvester without any named-user ACL.
+  #
+  # #1165 Gap 2: mode broadened from 2750 to 2770. The owner bit was
+  # rwx pre-fix (so an owner-UID mkdir should have worked), but the
+  # observed SessionStart hook failure shape is `mkdir: cannot create
+  # directory '/home/agent-bridge-<a>/.claude/session-env': Permission
+  # denied` — i.e. the hook process's effective UID is not the dir
+  # owner in practice (suspected tmux/sudo wrapper stripping owner
+  # identity on the SessionStart spawn path). Widening to 2770 makes
+  # the group bit writable, which unblocks the hook via the
+  # supplementary-group path. Security model: the only group members
+  # are the controller user + the isolated UID itself (PR-C agent-
+  # group composition); no third party gains write. setgid (2xxx) is
+  # preserved so new subdirs inside ~/.claude (projects/, session-env/,
+  # statsig/, etc.) inherit the agent group rather than the writer's
+  # primary group, keeping the controller harvester's group-r-x path
+  # working on every new file.
   local _claude_v2_grp=""
   _claude_v2_grp="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')"
   [[ -n "$_claude_v2_grp" ]] \
     || bridge_die "isolation v2: cannot resolve agent group for ~/.claude of '$agent'"
   bridge_linux_sudo_root chgrp "$_claude_v2_grp" "$isolated_claude_dir" \
     || bridge_die "isolation v2: chgrp $_claude_v2_grp on '$isolated_claude_dir' failed"
-  bridge_linux_sudo_root chmod 2750 "$isolated_claude_dir" \
-    || bridge_die "isolation v2: chmod 2750 on '$isolated_claude_dir' failed"
+  bridge_linux_sudo_root chmod 2770 "$isolated_claude_dir" \
+    || bridge_die "isolation v2: chmod 2770 on '$isolated_claude_dir' failed"
   # Channel-ownership-aware plugin sharing. Without this the isolated UID's
   # ~/.claude/plugins/ is empty and Claude starts with no MCP servers loaded
   # (Teams/ms365/cosmax-* all silently missing). The helper writes a per-UID

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -586,7 +586,29 @@ bridge_install_teams_plugin_node_modules() {
     return 1
   fi
 
+  # #1165 Gap 3 (r2): the chmod -R go+rX must run on EVERY call when
+  # node_modules exists, not only after a fresh `bun install`. The
+  # idempotent path (early return when node_modules is already present)
+  # is the common case on a re-run of `agb setup teams` after a
+  # previous install — if the existing tree was created with the
+  # controller's umask (077 → mode 0700), the isolated UID is still
+  # locked out and bridge-dev-plugin-cache.py still fails on
+  # `Permission denied: '.../plugins/teams/node_modules/.bin/...'`.
+  # #1165 r1 only chmod'd after the fresh-install branch (codex catch
+  # BLOCKING 2), leaving pre-existing trees unreadable.
+  #
+  # Apply chmod first (idempotent + cheap when modes are already
+  # widened), then decide whether to skip the install. Plugin source
+  # files are non-secret git content; the bun lockfile and package.json
+  # are already world-readable in the source tree, so this only
+  # re-aligns the post-install node_modules tree with the rest of the
+  # plugin source. The chmod is best-effort: a failure here does not
+  # block setup (the operator may chmod after the fact), but a warning
+  # surfaces so the gap is visible.
   if [[ -d "$plugin_dir/node_modules" ]]; then
+    if ! chmod -R go+rX "$plugin_dir/node_modules" 2>/dev/null; then
+      bridge_warn "chmod -R go+rX failed on $plugin_dir/node_modules — isolated agents may fail to copy via bridge-dev-plugin-cache"
+    fi
     bridge_info "[setup] $plugin_dir/node_modules already present — skipping bun install"
     return 0
   fi
@@ -616,13 +638,10 @@ bridge_install_teams_plugin_node_modules() {
   # context and fails to copy with `Permission denied:
   # '.../plugins/teams/node_modules/.bin/...'`. Widen the tree to
   # `go+rX` (read + traverse for group/other) so any isolated UID can
-  # copy it during the per-agent plugin cache materialize step. Plugin
-  # source files are non-secret git content; the bun lockfile and
-  # package.json are already world-readable in the source tree, so this
-  # only re-aligns the post-install node_modules tree with the rest of
-  # the plugin source. The chmod is best-effort: a failure here does
-  # not block setup (the operator may chmod after the fact), but a
-  # warning surfaces so the gap is visible.
+  # copy it during the per-agent plugin cache materialize step. The
+  # chmod is best-effort: a failure here does not block setup (the
+  # operator may chmod after the fact), but a warning surfaces so the
+  # gap is visible.
   if ! chmod -R go+rX "$plugin_dir/node_modules" 2>/dev/null; then
     bridge_warn "chmod -R go+rX failed on $plugin_dir/node_modules — isolated agents may fail to copy via bridge-dev-plugin-cache"
   fi

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -609,6 +609,24 @@ bridge_install_teams_plugin_node_modules() {
     return 1
   fi
 
+  # #1165 Gap 3: bun install runs as the controller, so
+  # plugins/teams/node_modules/ inherits the controller umask (often
+  # 077 → mode 0700 awfmanager-owned). bridge-dev-plugin-cache.py
+  # then runs under the isolated UID's `sudo -u agent-bridge-<a>`
+  # context and fails to copy with `Permission denied:
+  # '.../plugins/teams/node_modules/.bin/...'`. Widen the tree to
+  # `go+rX` (read + traverse for group/other) so any isolated UID can
+  # copy it during the per-agent plugin cache materialize step. Plugin
+  # source files are non-secret git content; the bun lockfile and
+  # package.json are already world-readable in the source tree, so this
+  # only re-aligns the post-install node_modules tree with the rest of
+  # the plugin source. The chmod is best-effort: a failure here does
+  # not block setup (the operator may chmod after the fact), but a
+  # warning surfaces so the gap is visible.
+  if ! chmod -R go+rX "$plugin_dir/node_modules" 2>/dev/null; then
+    bridge_warn "chmod -R go+rX failed on $plugin_dir/node_modules — isolated agents may fail to copy via bridge-dev-plugin-cache"
+  fi
+
   return 0
 }
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
 
 
 }
@@ -256,7 +256,13 @@ select_for_path() {
       # `bridge_bootstrap_project_skill` so the v2-isolation guard can
       # fire. Pull 1155-bootstrap-skill-guard on every bridge-setup.sh
       # move so the thread-through cannot regress.
-      add_required queue upgrade-conflicts-lifecycle status-engine-detect 835-static-admin-launch 1155-bootstrap-skill-guard
+      # Issue #1165 Track A: bridge-setup.py:_isolation_aware_mkdir
+      # gained the mode/group widening (Gap 1) so isolated channel
+      # state dirs (.teams/.telegram/.discord/.mattermost/) land at
+      # 2750 not 0700. Pull 1165-track-a on every bridge-setup.py move
+      # so the helper signature + sudo-script chmod step cannot
+      # regress back to the umask-only shape.
+      add_required queue upgrade-conflicts-lifecycle status-engine-detect 835-static-admin-launch 1155-bootstrap-skill-guard 1165-track-a-scaffold-modes
       add_integration integration-minimal
       ;;
 
@@ -399,7 +405,14 @@ select_for_path() {
       # dispatchers moves so a future PR cannot regress the thread-
       # through (without it the workdir-side mkdir/mv floods operator
       # stdout right before tmux session death — Gate 3 fail).
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper 1155-bootstrap-skill-guard 1158-marker-load-order
+      # Issue #1165 Track A: bridge-agent.sh's v2 scaffold sudo block
+      # (lines around 681-720) now also normalizes the legacy
+      # $BRIDGE_AGENT_HOME_ROOT/<agent>/ to 0755 so the legacy-teams-
+      # mcp pruner and other inventory scanners can stat into it from
+      # any UID on the box (Gap 4). Pull 1165-track-a on every
+      # bridge-agent.sh move so the scaffold legacy-root chmod cannot
+      # regress back to a missing chmod.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper 1155-bootstrap-skill-guard 1158-marker-load-order 1165-track-a-scaffold-modes
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -556,7 +569,13 @@ select_for_path() {
       # default" as a hard failure in cron-followup bodies. Cover the
       # regression smoke whenever bridge-notify.py moves so the strict-miss
       # vs default-miss split stays intact.
-      add_required channel-plugins bridge-notify-no-default-discord-875
+      # Issue #1165 Track A: lib/bridge-channels.sh's
+      # bridge_install_teams_plugin_node_modules now chmod -R go+rX
+      # node_modules after bun install so bridge-dev-plugin-cache.py
+      # can copy from an isolated UID context (Gap 3). Pull
+      # 1165-track-a on every lib/bridge-channels.sh move so the chmod
+      # step cannot regress back to controller-only umask.
+      add_required channel-plugins bridge-notify-no-default-discord-875 1165-track-a-scaffold-modes
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1165-track-a-scaffold-modes.sh
+++ b/scripts/smoke/1165-track-a-scaffold-modes.sh
@@ -75,18 +75,20 @@ file_mode_octal() {
 
 # ---------- T1 — _isolation_aware_mkdir: signature + sudo-script shape ----------
 #
-# Two-part test:
-#   T1a: the helper accepts a `mode` kwarg and a `group` kwarg
+# Three-part test:
+#   T1a: the helper accepts `mode`, `group`, AND `agent` kwargs
 #        (signature inspection via Python introspect). A regression
-#        that drops the kwargs trips here.
+#        that drops `agent` (the v2 group-resolution input — #1165 r2
+#        BLOCKING 1) immediately trips here.
 #   T1b: the sudo-as-iso script body contains a `chmod "$2" "$1"`
 #        step (static-source assertion against bridge-setup.py).
 #        A regression that re-omits the chmod immediately fails.
 #   T1c: behavioral — call the helper on a controller-owned target.
 #        The helper falls through to Path.mkdir (no isolated owner
 #        detected), so the resulting dir lands at the umask-derived
-#        mode. The assertion is that the call DID NOT raise, which
-#        proves the new signature still accepts a zero-arg call.
+#        mode. The assertion is that the call DID NOT raise on the
+#        new full signature, proving zero-arg / mode-only / mode+group /
+#        mode+group+agent call shapes all parse cleanly.
 
 T1A_HARNESS="$SMOKE_TMP_ROOT/t1a.py"
 : >"$T1A_HARNESS"
@@ -103,14 +105,19 @@ T1A_HARNESS="$SMOKE_TMP_ROOT/t1a.py"
   printf '%s\n' 'assert "path" in params, "missing path param: " + repr(params)'
   printf '%s\n' 'assert "mode" in params, "missing mode param: " + repr(params)'
   printf '%s\n' 'assert "group" in params, "missing group param: " + repr(params)'
+  printf '%s\n' 'assert "agent" in params, "missing agent param (1165 r2 BLOCKING 1): " + repr(params)'
   printf '%s\n' 'mode_default = sig.parameters["mode"].default'
   printf '%s\n' 'assert mode_default == 0o2750, "mode default expected 0o2750, got " + oct(mode_default)'
+  printf '%s\n' '# v2 helper presence check — Python mirror of bridge_isolation_v2_agent_group_name.'
+  printf '%s\n' 'assert hasattr(mod, "_v2_agent_group_name"), "missing _v2_agent_group_name helper (1165 r2 BLOCKING 1)"'
+  printf '%s\n' 'helper_sig = inspect.signature(mod._v2_agent_group_name)'
+  printf '%s\n' 'assert "agent" in helper_sig.parameters, "_v2_agent_group_name missing agent param: " + repr(list(helper_sig.parameters))'
   printf '%s\n' 'print("OK")'
 } >>"$T1A_HARNESS"
 
 T1A_OUT="$("$PY_BIN" "$T1A_HARNESS" "$REPO_ROOT" 2>&1)" || smoke_fail "T1a harness failed: $T1A_OUT"
 [[ "$T1A_OUT" == *"OK"* ]] || smoke_fail "T1a expected 'OK' from signature probe, got: $T1A_OUT"
-smoke_log "T1a PASS: _isolation_aware_mkdir signature includes mode + group params (mode default = 0o2750)"
+smoke_log "T1a PASS: _isolation_aware_mkdir signature includes mode + group + agent params (1165 r2 BLOCKING 1 wire-up present)"
 
 # T1b — static-source assertion on the sudo-script body.
 T1B_SOURCE="$REPO_ROOT/bridge-setup.py"
@@ -151,6 +158,8 @@ T1C_HARNESS="$SMOKE_TMP_ROOT/t1c.py"
   printf '%s\n' 'assert target.is_dir(), "target not created: " + str(target)'
   printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2770)'
   printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2770, group="nogroup")'
+  printf '%s\n' '# r2: agent= call shape (the v2 helper input).'
+  printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2770, agent="fake_agent")'
   printf '%s\n' 'print("OK")'
 } >>"$T1C_HARNESS"
 
@@ -230,14 +239,24 @@ grep -q '_scaffold_isolation_active=1' "$T4_SOURCE" \
   || smoke_fail "T4 expected '_scaffold_isolation_active=1' gate to still exist in $T4_SOURCE"
 smoke_log "T4 PASS: scaffold sudo block normalizes legacy \$BRIDGE_AGENT_HOME_ROOT/\$agent to 0755 (Gap 4 closed)"
 
-# ---------- T5 — Gap 1 behavioral: sudo-script renders chmod arg correctly ----------
+# ---------- T5 — Gap 1 r2: chgrp targets ab-agent-<agent>, NOT id -gn primary ----------
 #
-# When the isolated-owner probe DOES return an owner, the helper
-# constructs a sudo argv that includes the rendered mode_oct as $2.
-# Mock the subprocess.run + _resolve_isolated_owner_for_path so we
-# can inspect the argv shape without actually escalating. This is
-# the highest-fidelity test for Gap 1 short of an actual Linux iso
-# user fixture (which requires root).
+# Codex r1 BLOCKING 1: the pre-r2 helper resolved the chgrp target with
+# `id -gn <isolated-uid>`. On a v2 install the isolated UID's PRIMARY
+# group is whatever `useradd -r` defaulted to (often `users` or a
+# per-UID equivalent), NOT `ab-agent-<agent>` — `ab-agent-<agent>` is
+# added as a SUPPLEMENTARY group of the isolated UID and the
+# controller. So a chgrp to the primary group re-locks the controller
+# out of every subsequent os.stat against .teams/.
+#
+# r2 fix: the helper now accepts an `agent=` kwarg and computes the
+# correct supplementary group via _v2_agent_group_name (Python mirror
+# of bridge_isolation_v2_agent_group_name). This test stubs `id -gn`
+# to return an UNRELATED primary group ('users') and asserts the
+# resulting chgrp argv uses `ab-agent-<agent>`, NOT the stubbed
+# primary. A regression that re-introduces the id -gn derivation
+# trips this immediately because `users` would land at argv[10]
+# instead of `ab-agent-fake_agent`.
 
 T5_HARNESS="$SMOKE_TMP_ROOT/t5.py"
 : >"$T5_HARNESS"
@@ -252,32 +271,39 @@ T5_HARNESS="$SMOKE_TMP_ROOT/t5.py"
   printf '%s\n' 'spec.loader.exec_module(mod)'
   printf '%s\n' '# Force the isolated-owner probe to return a fake iso user so the'
   printf '%s\n' '# escalation branch runs.'
-  printf '%s\n' 'mod._resolve_isolated_owner_for_path = lambda _p: "agent-bridge-fake"'
+  printf '%s\n' 'mod._resolve_isolated_owner_for_path = lambda _p: "agent-bridge-fake_agent"'
   printf '%s\n' 'recorded = []'
   printf '%s\n' 'class FakeCompletedProcess:'
-  printf '%s\n' '    def __init__(self, args):'
+  printf '%s\n' '    def __init__(self, args, stdout=""):'
   printf '%s\n' '        self.args = args'
   printf '%s\n' '        self.returncode = 0'
-  printf '%s\n' '        self.stdout = "ab-agent-fake"'
+  printf '%s\n' '        # r2: id -gn returns an UNRELATED primary group (NOT'
+  printf '%s\n' '        # ab-agent-fake_agent). If the helper still derives the'
+  printf '%s\n' '        # chgrp target from id -gn output, "users" would leak'
+  printf '%s\n' '        # into the sudo argv and the assertion below fails.'
+  printf '%s\n' '        self.stdout = stdout'
   printf '%s\n' '        self.stderr = ""'
   printf '%s\n' 'def fake_run(argv, check=False, capture_output=False, text=False):'
   printf '%s\n' '    recorded.append(list(argv))'
   printf '%s\n' '    if argv[:2] == ["id", "-gn"]:'
-  printf '%s\n' '        # id -gn agent-bridge-fake — return a fake group'
-  printf '%s\n' '        return FakeCompletedProcess(argv)'
+  printf '%s\n' '        # id -gn agent-bridge-fake_agent — return UNRELATED'
+  printf '%s\n' '        # primary group (mirrors real v2 useradd -r behavior).'
+  printf '%s\n' '        return FakeCompletedProcess(argv, stdout="users")'
   printf '%s\n' '    if argv[:3] == ["sudo", "-n", "-u"]:'
-  printf '%s\n' '        # sudo -n -u agent-bridge-fake bash -c ... — claim success'
+  printf '%s\n' '        # sudo -n -u agent-bridge-fake_agent bash -c ... — claim success'
   printf '%s\n' '        return FakeCompletedProcess(argv)'
   printf '%s\n' '    return FakeCompletedProcess(argv)'
   printf '%s\n' 'mod.subprocess.run = fake_run'
   printf '%s\n' 'target = tmp / "iso-channel-dir"'
-  printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2750)'
+  printf '%s\n' '# r2: pass agent="fake_agent" — the v2 helper should resolve to'
+  printf '%s\n' '# "ab-agent-fake_agent" and the chgrp arg should NOT be "users".'
+  printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2750, agent="fake_agent")'
   printf '%s\n' '# Inspect the sudo argv (last call).'
   printf '%s\n' 'sudo_calls = [c for c in recorded if c[:3] == ["sudo", "-n", "-u"]]'
   printf '%s\n' 'assert sudo_calls, "no sudo call recorded: " + repr(recorded)'
   printf '%s\n' 'argv = sudo_calls[-1]'
   printf '%s\n' '# argv shape: sudo -n -u <owner> bash -c <script> bridge-isolation <path> <mode_oct> [<group>]'
-  printf '%s\n' 'assert argv[3] == "agent-bridge-fake", "unexpected owner: " + repr(argv)'
+  printf '%s\n' 'assert argv[3] == "agent-bridge-fake_agent", "unexpected owner: " + repr(argv)'
   printf '%s\n' 'assert argv[4] == "bash", "expected bash, got: " + repr(argv)'
   printf '%s\n' 'assert argv[5] == "-c", "expected -c, got: " + repr(argv)'
   printf '%s\n' 'script_body = argv[6]'
@@ -286,9 +312,18 @@ T5_HARNESS="$SMOKE_TMP_ROOT/t5.py"
   printf '%s\n' 'assert argv[7] == "bridge-isolation", "expected $0 label, got: " + repr(argv)'
   printf '%s\n' 'assert argv[8] == str(target), "expected path as $1, got: " + repr(argv)'
   printf '%s\n' 'assert argv[9] == "2750", "expected mode_oct=2750 as $2, got: " + repr(argv)'
-  printf '%s\n' '# Optional group arg only present when id -gn resolved a primary group'
-  printf '%s\n' '# (it did, in our stub). assert at $3.'
-  printf '%s\n' 'assert argv[10] == "ab-agent-fake", "expected group as $3, got: " + repr(argv)'
+  printf '%s\n' '# r2 BLOCKING 1 assertion: chgrp target must be the v2'
+  printf '%s\n' '# ab-agent-<agent> group (controller-readable supplementary),'
+  printf '%s\n' '# NOT the id -gn primary ("users" in this stub). A regression'
+  printf '%s\n' '# to id -gn derivation lands "users" at argv[10] and trips here.'
+  printf '%s\n' 'assert argv[10] == "ab-agent-fake_agent", "r2 BLOCKING 1 regression: chgrp arg should be ab-agent-fake_agent (v2 helper), got " + repr(argv[10])'
+  printf '%s\n' 'assert "users" not in argv, "r2 BLOCKING 1 regression: id -gn primary group leaked into sudo argv: " + repr(argv)'
+  printf '%s\n' '# r2: id -gn should NOT be invoked when agent= resolves the v2'
+  printf '%s\n' '# group successfully (priority: explicit group > v2 helper > id'
+  printf '%s\n' '# -gn fallback). A regression that re-introduces id -gn as the'
+  printf '%s\n' '# primary path would record an ["id", "-gn", ...] call here.'
+  printf '%s\n' 'id_calls = [c for c in recorded if c[:2] == ["id", "-gn"]]'
+  printf '%s\n' 'assert not id_calls, "r2 BLOCKING 1 regression: id -gn was invoked even though agent= was set: " + repr(id_calls)'
   printf '%s\n' 'print("OK")'
 } >>"$T5_HARNESS"
 
@@ -296,6 +331,180 @@ T5_TMP="$SMOKE_TMP_ROOT/t5-tree"
 mkdir -p "$T5_TMP"
 T5_OUT="$("$PY_BIN" "$T5_HARNESS" "$REPO_ROOT" "$T5_TMP" 2>&1)" || smoke_fail "T5 harness failed: $T5_OUT"
 [[ "$T5_OUT" == *"OK"* ]] || smoke_fail "T5 expected 'OK', got: $T5_OUT"
-smoke_log "T5 PASS: _isolation_aware_mkdir sudo argv carries mode_oct + group args (Gap 1 wire-up correct)"
+smoke_log "T5 PASS: _isolation_aware_mkdir chgrp targets v2 ab-agent-<agent> (NOT id -gn primary) — r2 BLOCKING 1 closed"
 
-smoke_log "all tests PASS (#1165 Track A — Gaps 1-4 scaffold/mode widening)"
+# ---------- T6 — _v2_agent_group_name: Python mirror correctness ----------
+#
+# r2 BLOCKING 1: the v2 helper is a pure-Python mirror of the bash
+# bridge_isolation_v2_agent_group_name (lib/bridge-isolation-v2.sh:406-460).
+# Both sides must compose the same group name for the same agent name on
+# the same platform — otherwise the controller's `os.stat` on the
+# chgrp'd dir mismatches the supplementary group it was added to by the
+# bash grant path.
+#
+# Coverage:
+#   - Short name -> ab-agent-<agent> (no truncation needed)
+#   - Long name (>23 chars on Linux) -> hash-truncated form
+#   - Invalid chars -> None (matches bash `return 1`)
+#   - Empty name -> None
+
+T6_HARNESS="$SMOKE_TMP_ROOT/t6.py"
+: >"$T6_HARNESS"
+{
+  printf '%s\n' '#!/usr/bin/env python3'
+  printf '%s\n' 'import sys, importlib.util, hashlib'
+  printf '%s\n' 'repo = sys.argv[1]'
+  printf '%s\n' 'spec = importlib.util.spec_from_file_location("bridge_setup", repo + "/bridge-setup.py")'
+  printf '%s\n' 'mod = importlib.util.module_from_spec(spec)'
+  printf '%s\n' 'spec.loader.exec_module(mod)'
+  printf '%s\n' '# Short name — no truncation needed. Both linux and darwin paths'
+  printf '%s\n' '# pass the composition through unchanged for <= 32 chars.'
+  printf '%s\n' 'assert mod._v2_agent_group_name("patch") == "ab-agent-patch", "short-name composition failed: " + repr(mod._v2_agent_group_name("patch"))'
+  printf '%s\n' '# Invalid chars — must return None (matches bash regex reject).'
+  printf '%s\n' 'assert mod._v2_agent_group_name("Has-Uppercase") is None, "Uppercase should reject"'
+  printf '%s\n' '_dash_out = mod._v2_agent_group_name("-starts-with-dash")'
+  printf '%s\n' 'assert _dash_out is None, "dash-prefix anchor should reject (got " + repr(_dash_out) + ")"'
+  printf '%s\n' 'assert mod._v2_agent_group_name("has space") is None, "space should reject"'
+  printf '%s\n' 'assert mod._v2_agent_group_name("") is None, "empty should reject"'
+  printf '%s\n' '# Linux path: long name -> hash-truncated. ab-agent- prefix = 9 chars,'
+  printf '%s\n' '# leaves 23 for the agent segment. A 30-char agent overflows; the'
+  printf '%s\n' '# linux helper should compose ab-agent-<head>-<hash>.'
+  printf '%s\n' 'if sys.platform != "darwin":'
+  printf '%s\n' '    long_name = "a_very_long_agent_name_for_test"  # 30 chars'
+  printf '%s\n' '    out = mod._v2_agent_group_name(long_name)'
+  printf '%s\n' '    assert out is not None, "long-name truncation should not return None"'
+  printf '%s\n' '    assert len(out) <= 32, "truncated group name exceeds 32 chars: " + repr(out)'
+  printf '%s\n' '    assert out.startswith("ab-agent-"), "missing prefix: " + repr(out)'
+  printf '%s\n' '    expected_hash = hashlib.sha256(long_name.encode()).hexdigest()[:7]'
+  printf '%s\n' '    assert out.endswith("-" + expected_hash), "hash suffix mismatch: expected ...-" + expected_hash + ", got " + repr(out)'
+  printf '%s\n' 'print("OK")'
+} >>"$T6_HARNESS"
+
+T6_OUT="$("$PY_BIN" "$T6_HARNESS" "$REPO_ROOT" 2>&1)" || smoke_fail "T6 harness failed: $T6_OUT"
+[[ "$T6_OUT" == *"OK"* ]] || smoke_fail "T6 expected 'OK', got: $T6_OUT"
+smoke_log "T6 PASS: _v2_agent_group_name mirrors bash helper (short + long + invalid)"
+
+# ---------- T3b — Gap 3 r2: idempotent chmod runs even when node_modules pre-exists ----------
+#
+# Codex r1 BLOCKING 2: the original Gap 3 fix only chmod'd after a
+# fresh `bun install`. When node_modules already exists (the common
+# case on a re-run of `agb setup teams`), the helper early-returns
+# BEFORE the chmod, so a pre-existing tree created with controller
+# umask 077 stays unreadable to isolated UIDs and
+# bridge-dev-plugin-cache.py still fails on `Permission denied`.
+#
+# r2 fix: the chmod runs unconditionally before the early-return. This
+# test (purely static-source) verifies the chmod call appears BEFORE
+# the "already present — skipping bun install" early-return so the
+# idempotent path is covered.
+
+T3B_SOURCE="$REPO_ROOT/lib/bridge-channels.sh"
+T3B_HARNESS="$SMOKE_TMP_ROOT/t3b.py"
+: >"$T3B_HARNESS"
+{
+  printf '%s\n' '#!/usr/bin/env python3'
+  printf '%s\n' 'import sys, re'
+  printf '%s\n' 'src = open(sys.argv[1]).read()'
+  printf '%s\n' '# Locate the bridge_install_teams_plugin_node_modules function body.'
+  printf '%s\n' '# Boundary: starts at the function decl, ends at the first ^} at column 0.'
+  printf '%s\n' 'm = re.search(r"^bridge_install_teams_plugin_node_modules\(\)[^{]*\{(.*?)^\}", src, re.DOTALL | re.MULTILINE)'
+  printf '%s\n' 'assert m, "could not find bridge_install_teams_plugin_node_modules function body"'
+  printf '%s\n' 'body = m.group(1)'
+  printf '%s\n' '# Locate the actual early-return command line — the bridge_info'
+  printf '%s\n' '# "[setup] ... already present — skipping bun install" + return 0'
+  printf '%s\n' '# combo. Substring matches inside comment blocks must NOT be the'
+  printf '%s\n' '# first hit (the comment block also discusses "already present"'
+  printf '%s\n' '# as part of the design rationale).'
+  printf '%s\n' 'early_re = re.compile(r"^\s*bridge_info \"\[setup\] \$plugin_dir/node_modules already present", re.MULTILINE)'
+  printf '%s\n' 'early_match = early_re.search(body)'
+  printf '%s\n' 'assert early_match, "missing bridge_info early-return announcement"'
+  printf '%s\n' 'early_idx = early_match.start()'
+  printf '%s\n' '# Locate the chmod command line — match a real bash invocation,'
+  printf '%s\n' '# not a substring inside a comment block (a `# chmod -R go+rX ...`'
+  printf '%s\n' '# explainer comment would otherwise be the first hit).'
+  printf '%s\n' 'chmod_re = re.compile(r"^\s*(if !\s*)?chmod -R go\+rX \"\$plugin_dir/node_modules\"", re.MULTILINE)'
+  printf '%s\n' 'chmod_matches = list(chmod_re.finditer(body))'
+  printf '%s\n' 'assert chmod_matches, "missing chmod -R go+rX command line in function body"'
+  printf '%s\n' 'first_chmod_idx = chmod_matches[0].start()'
+  printf '%s\n' '# r2 assertion: at least one chmod command must precede the'
+  printf '%s\n' '# early-return announcement. If the chmod ONLY appears after'
+  printf '%s\n' '# the bridge_info early-return, the idempotent path (existing'
+  printf '%s\n' '# node_modules) skips chmod entirely — the r1 bug.'
+  printf '%s\n' 'assert first_chmod_idx < early_idx, "r2 BLOCKING 2 regression: chmod -R go+rX command appears AFTER the bridge_info early-return; idempotent path skipped (chmod cmd at %d, early-return at %d)" % (first_chmod_idx, early_idx)'
+  printf '%s\n' 'print("OK")'
+} >>"$T3B_HARNESS"
+
+T3B_OUT="$("$PY_BIN" "$T3B_HARNESS" "$T3B_SOURCE" 2>&1)" || smoke_fail "T3b harness failed: $T3B_OUT"
+[[ "$T3B_OUT" == *"OK"* ]] || smoke_fail "T3b expected 'OK', got: $T3B_OUT"
+smoke_log "T3b PASS: chmod -R go+rX runs on idempotent (pre-existing node_modules) path — r2 BLOCKING 2 closed"
+
+# ---------- T3c — Gap 3 r2 behavioral: chmod actually widens pre-existing tree ----------
+#
+# Beyond the static-source check, exercise the actual function body
+# against a fixture: pre-create a node_modules/ tree with restrictive
+# modes (dirs 0700, files 0600) and call the helper. Assert post-call
+# modes are widened (group + other have read/traverse).
+
+T3C_DRIVER="$SMOKE_TMP_ROOT/t3c.sh"
+: >"$T3C_DRIVER"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -uo pipefail'
+  printf '%s\n' 'repo="$1"'
+  printf '%s\n' 'fixture="$2"'
+  printf '%s\n' '# Mock BRIDGE_SCRIPT_DIR + bridge_resolve_script_dir_check so the'
+  printf '%s\n' '# helper points at our fixture instead of the real repo. We need'
+  printf '%s\n' '# the function code without its dependencies on the rest of the'
+  printf '%s\n' '# channel module — source bridge-channels.sh under a controlled'
+  printf '%s\n' '# environment.'
+  printf '%s\n' 'BRIDGE_SCRIPT_DIR="$fixture"'
+  printf '%s\n' 'export BRIDGE_SCRIPT_DIR'
+  printf '%s\n' '# Stub the dependencies the helper needs from bridge-core.sh /'
+  printf '%s\n' '# bridge-channels.sh internals.'
+  printf '%s\n' 'bridge_info() { printf "[info] %s\n" "$*"; }'
+  printf '%s\n' 'bridge_warn() { printf "[warn] %s\n" "$*" >&2; }'
+  printf '%s\n' 'bridge_resolve_script_dir_check() { [[ -n "$BRIDGE_SCRIPT_DIR" ]]; }'
+  printf '%s\n' 'bridge_resolve_bun_executable() { return 1; }  # not exercised on idempotent path'
+  printf '%s\n' 'export -f bridge_info bridge_warn bridge_resolve_script_dir_check bridge_resolve_bun_executable'
+  printf '%s\n' '# Source just the function definition by extracting it. Simpler'
+  printf '%s\n' '# than sourcing all of bridge-channels.sh (which would pull in'
+  printf '%s\n' '# more transitive deps).'
+  printf '%s\n' 'tmp_fn="$(mktemp -t t3c-fn-XXXXXX.sh)"'
+  printf '%s\n' 'trap '"'"'rm -f "$tmp_fn"'"'"' EXIT'
+  printf '%s\n' 'awk '"'"'/^bridge_install_teams_plugin_node_modules\(\)/,/^\}/'"'"' "$repo/lib/bridge-channels.sh" >"$tmp_fn"'
+  printf '%s\n' '# shellcheck disable=SC1090'
+  printf '%s\n' 'source "$tmp_fn"'
+  printf '%s\n' '# Run the function; should hit the idempotent branch (node_modules exists).'
+  printf '%s\n' 'bridge_install_teams_plugin_node_modules 0 ""'
+} >>"$T3C_DRIVER"
+chmod +x "$T3C_DRIVER"
+
+T3C_FIXTURE="$SMOKE_TMP_ROOT/t3c-fixture"
+mkdir -p "$T3C_FIXTURE/plugins/teams/node_modules/.bin"
+mkdir -p "$T3C_FIXTURE/plugins/teams/node_modules/some-pkg/lib"
+: >"$T3C_FIXTURE/plugins/teams/node_modules/.bin/some-bin"
+: >"$T3C_FIXTURE/plugins/teams/node_modules/some-pkg/lib/index.js"
+chmod 0700 "$T3C_FIXTURE/plugins/teams/node_modules" "$T3C_FIXTURE/plugins/teams/node_modules/.bin" "$T3C_FIXTURE/plugins/teams/node_modules/some-pkg" "$T3C_FIXTURE/plugins/teams/node_modules/some-pkg/lib"
+chmod 0600 "$T3C_FIXTURE/plugins/teams/node_modules/.bin/some-bin" "$T3C_FIXTURE/plugins/teams/node_modules/some-pkg/lib/index.js"
+
+T3C_OUT="$(bash "$T3C_DRIVER" "$REPO_ROOT" "$T3C_FIXTURE" 2>&1)" || smoke_fail "T3c driver failed: $T3C_OUT"
+
+# Assert post-call modes are widened. `chmod -R go+rX` should land:
+#   - dirs: 0700 -> 0755 (group + other get rx)
+#   - regular files: 0600 -> 0644 (group + other get r, no x because
+#     the file had no execute bit)
+post_root_mode="$(file_mode_octal "$T3C_FIXTURE/plugins/teams/node_modules")"
+post_bin_dir_mode="$(file_mode_octal "$T3C_FIXTURE/plugins/teams/node_modules/.bin")"
+post_bin_mode="$(file_mode_octal "$T3C_FIXTURE/plugins/teams/node_modules/.bin/some-bin")"
+post_js_mode="$(file_mode_octal "$T3C_FIXTURE/plugins/teams/node_modules/some-pkg/lib/index.js")"
+[[ "$post_root_mode" == "755" ]] \
+  || smoke_fail "T3c idempotent chmod missed root node_modules dir: expected 755, got $post_root_mode"
+[[ "$post_bin_dir_mode" == "755" ]] \
+  || smoke_fail "T3c idempotent chmod missed .bin dir: expected 755, got $post_bin_dir_mode"
+[[ "$post_bin_mode" == "644" ]] \
+  || smoke_fail "T3c idempotent chmod missed .bin file: expected 644, got $post_bin_mode"
+[[ "$post_js_mode" == "644" ]] \
+  || smoke_fail "T3c idempotent chmod missed nested file: expected 644, got $post_js_mode"
+smoke_log "T3c PASS: idempotent path actually widens pre-existing 0700/0600 tree to 0755/0644"
+
+smoke_log "all tests PASS (#1165 Track A r2 — Gaps 1-4 + r2 BLOCKING 1/2)"

--- a/scripts/smoke/1165-track-a-scaffold-modes.sh
+++ b/scripts/smoke/1165-track-a-scaffold-modes.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1165-track-a-scaffold-modes.sh — Issue #1165 Track A.
+#
+# Four scaffold/mode widening gaps in the v2-isolation x Teams plugin
+# contract. Each gap was reachable only after the v0.14.5-beta9-13
+# isolation cluster closed, but they are pre-existing v2 contract gaps
+# not v0.14.5 regressions.
+#
+# Coverage matrix:
+#
+#   T1 (Gap 1): `_isolation_aware_mkdir` default mode is 2750 (not 0700);
+#               the helper accepts a `mode` parameter; the helper
+#               emits the chmod step in its sudo-as-iso script.
+#               Static-source assertion + behavioral assertion on a
+#               non-isolated host (falls through to Path.mkdir, lands
+#               at umask-derived mode — but the new signature is
+#               exercised so a regression dropping the mode parameter
+#               trips T1).
+#
+#   T2 (Gap 2): `bridge_linux_prepare_agent_isolation` chmods
+#               `~/.claude` to 2770 (not 2750). Static-source assertion
+#               against lib/bridge-agents.sh. Boomerang: a revert to
+#               2750 immediately fails this smoke.
+#
+#   T3 (Gap 3): `bridge_install_teams_plugin_node_modules` includes a
+#               `chmod -R go+rX node_modules` step after the successful
+#               bun install branch. Static-source assertion against
+#               lib/bridge-channels.sh.
+#
+#   T4 (Gap 4): the scaffold sudo-handoff block in `bridge-agent.sh`
+#               includes `$BRIDGE_AGENT_HOME_ROOT/$agent` (legacy
+#               agents/<X>/) in the chmod 0755 list. Static-source
+#               assertion against bridge-agent.sh — the legacy
+#               per-agent dir must be normalized in the v2 scaffold
+#               isolation-active branch.
+#
+# Host-agnostic: every assertion is either a static-source grep (T2,
+# T3, T4, half of T1) or runs against a non-isolated mkdir target that
+# returns no isolated owner (the other half of T1). No sudo or root
+# needed.
+#
+# Footgun #11 (heredoc-stdin subprocess deadlock class): every driver
+# is built with `printf '%s\n' >file` and run as `bash <file>`; no
+# `<<<` here-string or `<<EOF` feeds into a bash function; no
+# `$(...)` capture of a heredoc-stdin subprocess.
+
+set -uo pipefail
+
+SMOKE_NAME="1165-track-a-scaffold-modes"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+# Portable mode-read shim (GNU vs BSD stat).
+file_mode_octal() {
+  local path="$1"
+  if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+    stat -f '%Lp' "$path" 2>/dev/null
+  else
+    stat -c '%a' "$path" 2>/dev/null
+  fi
+}
+
+# ---------- T1 — _isolation_aware_mkdir: signature + sudo-script shape ----------
+#
+# Two-part test:
+#   T1a: the helper accepts a `mode` kwarg and a `group` kwarg
+#        (signature inspection via Python introspect). A regression
+#        that drops the kwargs trips here.
+#   T1b: the sudo-as-iso script body contains a `chmod "$2" "$1"`
+#        step (static-source assertion against bridge-setup.py).
+#        A regression that re-omits the chmod immediately fails.
+#   T1c: behavioral — call the helper on a controller-owned target.
+#        The helper falls through to Path.mkdir (no isolated owner
+#        detected), so the resulting dir lands at the umask-derived
+#        mode. The assertion is that the call DID NOT raise, which
+#        proves the new signature still accepts a zero-arg call.
+
+T1A_HARNESS="$SMOKE_TMP_ROOT/t1a.py"
+: >"$T1A_HARNESS"
+# shellcheck disable=SC2129  # per-line emit keeps footgun #11 off the table
+{
+  printf '%s\n' '#!/usr/bin/env python3'
+  printf '%s\n' 'import sys, inspect, importlib.util'
+  printf '%s\n' 'repo = sys.argv[1]'
+  printf '%s\n' 'spec = importlib.util.spec_from_file_location("bridge_setup", repo + "/bridge-setup.py")'
+  printf '%s\n' 'mod = importlib.util.module_from_spec(spec)'
+  printf '%s\n' 'spec.loader.exec_module(mod)'
+  printf '%s\n' 'sig = inspect.signature(mod._isolation_aware_mkdir)'
+  printf '%s\n' 'params = list(sig.parameters.keys())'
+  printf '%s\n' 'assert "path" in params, "missing path param: " + repr(params)'
+  printf '%s\n' 'assert "mode" in params, "missing mode param: " + repr(params)'
+  printf '%s\n' 'assert "group" in params, "missing group param: " + repr(params)'
+  printf '%s\n' 'mode_default = sig.parameters["mode"].default'
+  printf '%s\n' 'assert mode_default == 0o2750, "mode default expected 0o2750, got " + oct(mode_default)'
+  printf '%s\n' 'print("OK")'
+} >>"$T1A_HARNESS"
+
+T1A_OUT="$("$PY_BIN" "$T1A_HARNESS" "$REPO_ROOT" 2>&1)" || smoke_fail "T1a harness failed: $T1A_OUT"
+[[ "$T1A_OUT" == *"OK"* ]] || smoke_fail "T1a expected 'OK' from signature probe, got: $T1A_OUT"
+smoke_log "T1a PASS: _isolation_aware_mkdir signature includes mode + group params (mode default = 0o2750)"
+
+# T1b — static-source assertion on the sudo-script body.
+T1B_SOURCE="$REPO_ROOT/bridge-setup.py"
+if ! grep -q "'chmod \"\$2\" \"\$1\"'," "$T1B_SOURCE"; then
+  smoke_fail "T1b expected sudo-script chmod line in $T1B_SOURCE — missing 'chmod \"\$2\" \"\$1\"' literal"
+fi
+# Anti-pattern: the pre-#1165 umask-only block must NOT survive.
+# That block sandwiched 'mkdir -p "$1"\n' directly between 'umask
+# 0077\n' and 'exit 0\n' with NO 'chmod "$2" "$1"\n' line between
+# them. Detect the legacy shape with a Python multi-line search
+# (portable across GNU / BSD grep — `grep -P` is not on BSD).
+if "$PY_BIN" -c '
+import sys
+src = open(sys.argv[1]).read()
+legacy = "umask 0077\\n\x27\n        \x27mkdir -p \"$1\"\\n\x27\n        \x27exit 0\\n\x27"
+sys.exit(0 if legacy in src else 1)
+' "$T1B_SOURCE" 2>/dev/null; then
+  smoke_fail "T1b regression: legacy umask-only sudo block (no chmod) still present in $T1B_SOURCE"
+fi
+smoke_log "T1b PASS: sudo-script contains chmod step (no regression to umask-only block)"
+
+# T1c — behavioral fall-through (non-isolated host).
+T1C_HARNESS="$SMOKE_TMP_ROOT/t1c.py"
+: >"$T1C_HARNESS"
+{
+  printf '%s\n' '#!/usr/bin/env python3'
+  printf '%s\n' 'import sys, importlib.util'
+  printf '%s\n' 'from pathlib import Path'
+  printf '%s\n' 'repo = sys.argv[1]'
+  printf '%s\n' 'tmp = Path(sys.argv[2])'
+  printf '%s\n' 'spec = importlib.util.spec_from_file_location("bridge_setup", repo + "/bridge-setup.py")'
+  printf '%s\n' 'mod = importlib.util.module_from_spec(spec)'
+  printf '%s\n' 'spec.loader.exec_module(mod)'
+  printf '%s\n' '# Force the isolated-owner probe to return None (controller-owned).'
+  printf '%s\n' 'mod._resolve_isolated_owner_for_path = lambda _p: None'
+  printf '%s\n' 'target = tmp / "deep" / "tree"'
+  printf '%s\n' 'mod._isolation_aware_mkdir(target)'
+  printf '%s\n' 'assert target.is_dir(), "target not created: " + str(target)'
+  printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2770)'
+  printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2770, group="nogroup")'
+  printf '%s\n' 'print("OK")'
+} >>"$T1C_HARNESS"
+
+T1C_TMP="$SMOKE_TMP_ROOT/t1c-tree"
+T1C_OUT="$("$PY_BIN" "$T1C_HARNESS" "$REPO_ROOT" "$T1C_TMP" 2>&1)" || smoke_fail "T1c harness failed: $T1C_OUT"
+[[ "$T1C_OUT" == *"OK"* ]] || smoke_fail "T1c expected 'OK', got: $T1C_OUT"
+smoke_log "T1c PASS: _isolation_aware_mkdir accepts default + (mode,) + (mode, group) call shapes"
+
+# ---------- T2 — bridge_linux_prepare_agent_isolation: ~/.claude is 2770 ----------
+#
+# Static-source assertion against lib/bridge-agents.sh. The chmod line
+# for `isolated_claude_dir` must read 2770 (not 2750). Boomerang: a
+# revert to 2750 trips this immediately.
+
+T2_SOURCE="$REPO_ROOT/lib/bridge-agents.sh"
+if grep -q '^  bridge_linux_sudo_root chmod 2750 "$isolated_claude_dir"' "$T2_SOURCE"; then
+  smoke_fail "T2 regression: lib/bridge-agents.sh still has 'chmod 2750 \"\$isolated_claude_dir\"' (Gap 2 closed by widening to 2770)"
+fi
+grep -q '^  bridge_linux_sudo_root chmod 2770 "$isolated_claude_dir"' "$T2_SOURCE" \
+  || smoke_fail "T2 expected 'chmod 2770 \"\$isolated_claude_dir\"' line in $T2_SOURCE (Gap 2 widening missing)"
+# Sanity: the bridge_die error message should also be updated to match
+# the new mode. A stale "chmod 2750" error message points to a
+# half-applied edit.
+if grep -q 'isolation v2: chmod 2750 on .\$isolated_claude_dir.' "$T2_SOURCE"; then
+  smoke_fail "T2 stale error message: lib/bridge-agents.sh still references 'chmod 2750' in bridge_die for isolated_claude_dir"
+fi
+grep -q 'isolation v2: chmod 2770 on .\$isolated_claude_dir.' "$T2_SOURCE" \
+  || smoke_fail "T2 expected bridge_die error message referencing 'chmod 2770' for isolated_claude_dir in $T2_SOURCE"
+smoke_log "T2 PASS: ~/.claude chmod widened to 2770 (Gap 2 closed)"
+
+# ---------- T3 — bridge_install_teams_plugin_node_modules: chmod -R go+rX ----------
+#
+# Static-source assertion against lib/bridge-channels.sh. After the
+# `bun install --frozen-lockfile` success branch, the helper must
+# call `chmod -R go+rX "$plugin_dir/node_modules"`. Boomerang: a
+# revert that drops the chmod (or restricts to mode 0700) trips
+# this smoke.
+
+T3_SOURCE="$REPO_ROOT/lib/bridge-channels.sh"
+grep -q 'chmod -R go+rX "\$plugin_dir/node_modules"' "$T3_SOURCE" \
+  || smoke_fail "T3 expected 'chmod -R go+rX \"\$plugin_dir/node_modules\"' line in $T3_SOURCE (Gap 3 widening missing)"
+# Anti-pattern: no `chmod -R go-rwx` or similar restriction on the
+# same path (a future hardening attempt that would re-introduce the
+# isolated-UID-can't-read bug).
+if grep -qE 'chmod -R go-?rwx? "\$plugin_dir/node_modules"' "$T3_SOURCE"; then
+  smoke_fail "T3 regression: lib/bridge-channels.sh hardens node_modules back to controller-only (Gap 3 re-opens)"
+fi
+smoke_log "T3 PASS: post-bun-install chmod -R go+rX present on plugins/teams/node_modules (Gap 3 closed)"
+
+# ---------- T4 — bridge-agent.sh scaffold sudo-handoff covers legacy agents/<X>/ ----------
+#
+# Static-source assertion against bridge-agent.sh. The v2 scaffold
+# isolation-active sudo block (the existing block around lines 681-
+# 709 that chmod 0755's _scaffold_v2_root / home / _scaffold_v2_sibling)
+# must ALSO normalize the legacy `$BRIDGE_AGENT_HOME_ROOT/$agent` so
+# the legacy-teams-mcp pruner and other inventory scanners can stat
+# into it from any UID on the box.
+
+T4_SOURCE="$REPO_ROOT/bridge-agent.sh"
+# Required line: the new sudo chmod 0755 step on the legacy per-agent root.
+grep -q 'bridge_linux_sudo_root chmod 0755 "\$_scaffold_legacy_root"' "$T4_SOURCE" \
+  || smoke_fail "T4 expected 'chmod 0755 \"\$_scaffold_legacy_root\"' line in $T4_SOURCE (Gap 4 legacy normalize missing)"
+# Required line: the new sudo mkdir + chown alongside it.
+grep -q 'bridge_linux_sudo_root mkdir -p "\$_scaffold_legacy_root"' "$T4_SOURCE" \
+  || smoke_fail "T4 expected 'mkdir -p \"\$_scaffold_legacy_root\"' line in $T4_SOURCE (Gap 4 pre-create missing)"
+grep -q 'bridge_linux_sudo_root chown "\$_scaffold_controller" "\$_scaffold_legacy_root"' "$T4_SOURCE" \
+  || smoke_fail "T4 expected 'chown \"\$_scaffold_controller\" \"\$_scaffold_legacy_root\"' line in $T4_SOURCE (Gap 4 chown missing)"
+# Required: the legacy root resolves from BRIDGE_AGENT_HOME_ROOT + agent.
+grep -q 'local _scaffold_legacy_root="\$BRIDGE_AGENT_HOME_ROOT/\$agent"' "$T4_SOURCE" \
+  || smoke_fail "T4 expected '_scaffold_legacy_root=\"\$BRIDGE_AGENT_HOME_ROOT/\$agent\"' assignment in $T4_SOURCE"
+# Gate: the new block must live INSIDE the existing isolation-active
+# sudo branch so it only fires for v2 linux-user installs.
+# Verify the new line is preceded (anywhere earlier in the file) by
+# the `_scaffold_isolation_active` gate. This is a structural-shape
+# sanity check, not a syntactic guarantee.
+grep -q '_scaffold_isolation_active=1' "$T4_SOURCE" \
+  || smoke_fail "T4 expected '_scaffold_isolation_active=1' gate to still exist in $T4_SOURCE"
+smoke_log "T4 PASS: scaffold sudo block normalizes legacy \$BRIDGE_AGENT_HOME_ROOT/\$agent to 0755 (Gap 4 closed)"
+
+# ---------- T5 — Gap 1 behavioral: sudo-script renders chmod arg correctly ----------
+#
+# When the isolated-owner probe DOES return an owner, the helper
+# constructs a sudo argv that includes the rendered mode_oct as $2.
+# Mock the subprocess.run + _resolve_isolated_owner_for_path so we
+# can inspect the argv shape without actually escalating. This is
+# the highest-fidelity test for Gap 1 short of an actual Linux iso
+# user fixture (which requires root).
+
+T5_HARNESS="$SMOKE_TMP_ROOT/t5.py"
+: >"$T5_HARNESS"
+{
+  printf '%s\n' '#!/usr/bin/env python3'
+  printf '%s\n' 'import sys, subprocess, importlib.util'
+  printf '%s\n' 'from pathlib import Path'
+  printf '%s\n' 'repo = sys.argv[1]'
+  printf '%s\n' 'tmp = Path(sys.argv[2])'
+  printf '%s\n' 'spec = importlib.util.spec_from_file_location("bridge_setup", repo + "/bridge-setup.py")'
+  printf '%s\n' 'mod = importlib.util.module_from_spec(spec)'
+  printf '%s\n' 'spec.loader.exec_module(mod)'
+  printf '%s\n' '# Force the isolated-owner probe to return a fake iso user so the'
+  printf '%s\n' '# escalation branch runs.'
+  printf '%s\n' 'mod._resolve_isolated_owner_for_path = lambda _p: "agent-bridge-fake"'
+  printf '%s\n' 'recorded = []'
+  printf '%s\n' 'class FakeCompletedProcess:'
+  printf '%s\n' '    def __init__(self, args):'
+  printf '%s\n' '        self.args = args'
+  printf '%s\n' '        self.returncode = 0'
+  printf '%s\n' '        self.stdout = "ab-agent-fake"'
+  printf '%s\n' '        self.stderr = ""'
+  printf '%s\n' 'def fake_run(argv, check=False, capture_output=False, text=False):'
+  printf '%s\n' '    recorded.append(list(argv))'
+  printf '%s\n' '    if argv[:2] == ["id", "-gn"]:'
+  printf '%s\n' '        # id -gn agent-bridge-fake — return a fake group'
+  printf '%s\n' '        return FakeCompletedProcess(argv)'
+  printf '%s\n' '    if argv[:3] == ["sudo", "-n", "-u"]:'
+  printf '%s\n' '        # sudo -n -u agent-bridge-fake bash -c ... — claim success'
+  printf '%s\n' '        return FakeCompletedProcess(argv)'
+  printf '%s\n' '    return FakeCompletedProcess(argv)'
+  printf '%s\n' 'mod.subprocess.run = fake_run'
+  printf '%s\n' 'target = tmp / "iso-channel-dir"'
+  printf '%s\n' 'mod._isolation_aware_mkdir(target, mode=0o2750)'
+  printf '%s\n' '# Inspect the sudo argv (last call).'
+  printf '%s\n' 'sudo_calls = [c for c in recorded if c[:3] == ["sudo", "-n", "-u"]]'
+  printf '%s\n' 'assert sudo_calls, "no sudo call recorded: " + repr(recorded)'
+  printf '%s\n' 'argv = sudo_calls[-1]'
+  printf '%s\n' '# argv shape: sudo -n -u <owner> bash -c <script> bridge-isolation <path> <mode_oct> [<group>]'
+  printf '%s\n' 'assert argv[3] == "agent-bridge-fake", "unexpected owner: " + repr(argv)'
+  printf '%s\n' 'assert argv[4] == "bash", "expected bash, got: " + repr(argv)'
+  printf '%s\n' 'assert argv[5] == "-c", "expected -c, got: " + repr(argv)'
+  printf '%s\n' 'script_body = argv[6]'
+  printf '%s\n' 'assert "mkdir -p" in script_body, "script body missing mkdir: " + script_body'
+  printf '%s\n' 'assert "chmod" in script_body, "script body missing chmod: " + script_body'
+  printf '%s\n' 'assert argv[7] == "bridge-isolation", "expected $0 label, got: " + repr(argv)'
+  printf '%s\n' 'assert argv[8] == str(target), "expected path as $1, got: " + repr(argv)'
+  printf '%s\n' 'assert argv[9] == "2750", "expected mode_oct=2750 as $2, got: " + repr(argv)'
+  printf '%s\n' '# Optional group arg only present when id -gn resolved a primary group'
+  printf '%s\n' '# (it did, in our stub). assert at $3.'
+  printf '%s\n' 'assert argv[10] == "ab-agent-fake", "expected group as $3, got: " + repr(argv)'
+  printf '%s\n' 'print("OK")'
+} >>"$T5_HARNESS"
+
+T5_TMP="$SMOKE_TMP_ROOT/t5-tree"
+mkdir -p "$T5_TMP"
+T5_OUT="$("$PY_BIN" "$T5_HARNESS" "$REPO_ROOT" "$T5_TMP" 2>&1)" || smoke_fail "T5 harness failed: $T5_OUT"
+[[ "$T5_OUT" == *"OK"* ]] || smoke_fail "T5 expected 'OK', got: $T5_OUT"
+smoke_log "T5 PASS: _isolation_aware_mkdir sudo argv carries mode_oct + group args (Gap 1 wire-up correct)"
+
+smoke_log "all tests PASS (#1165 Track A — Gaps 1-4 scaffold/mode widening)"

--- a/tests/isolation-claude-read-lens/smoke.sh
+++ b/tests/isolation-claude-read-lens/smoke.sh
@@ -38,8 +38,19 @@ required_prepare_fragments = [
     'bridge_linux_sudo_root mkdir -p "$isolated_claude_dir"',
     'bridge_linux_sudo_root chown "$os_user" "$isolated_claude_dir"',
     'bridge_linux_sudo_root chgrp "$_claude_v2_grp" "$isolated_claude_dir"',
-    'bridge_linux_sudo_root chmod 2750 "$isolated_claude_dir"',
-    'controller (group member of',
+    # #1165 Gap 2: widened from 2750 to 2770 so the SessionStart hook's
+    # `mkdir .claude/session-env/` can succeed via the supplementary-
+    # group path. The controller (group member of ab-agent-<name>) still
+    # reaches ~/.claude/projects/ via group r-x; the group-write bit
+    # only adds group writability, which is bounded by the v2 agent-
+    # group composition (controller + the isolated UID itself).
+    'bridge_linux_sudo_root chmod 2770 "$isolated_claude_dir"',
+    # The "controller (group member of" string used to live on a single
+    # source line; the #1165 Gap 2 comment expansion now wraps that
+    # phrasing across two lines. The two halves below match the
+    # post-expansion shape; reverting either to a single-line form
+    # (which is fine) still satisfies the half-fragment assertion.
+    'group member of ab-agent-<name>',
     'without any named-user ACL',
 ]
 missing = [fragment for fragment in required_prepare_fragments if fragment not in prepare]


### PR DESCRIPTION
## Summary

Track A of #1165 — 4 pre-existing v2-isolation × Teams plugin contract gaps that were reachable for the first time on a real install after the v0.14.5-beta9-13 isolation regression cluster closed. None are v0.14.5 regressions; every one predates v0.14.5. But they all sit on the critical path for "operator can use v2 isolation + Teams DM without manual ACL surgery", which is the bidirectional-DM completion bar of #1165.

### Gap 1 — `_isolation_aware_mkdir` widened to mode 2750 + group-aware

`bridge-setup.py:_isolation_aware_mkdir` created `.teams/` (and `.telegram/`, `.discord/`, `.mattermost/`) at mode 0700 owned by the isolated UID via `umask 0077 ; mkdir -p`. The controller (a member of `ab-agent-<X>`) lost traversal and every subsequent `os.stat(teams_dir / "access.json")` raised PermissionError.

Helper now accepts `mode=` (default `0o2750`) and `group=` (default: the iso UID's primary group resolved via `id -gn`). The sudo-as-iso script always `chmod`s to the requested mode and best-effort `chgrp`s. All four channel-state-dir call sites inherit the new default.

### Gap 2 (option a) — `~/.claude` widened from 2750 to 2770

`lib/bridge-agents.sh:bridge_linux_prepare_agent_isolation` chmod'd `~/.claude` to 2750. The owner bit was already rwx, but the SessionStart hook still failed with `mkdir: cannot create directory '.../.claude/session-env': Permission denied` — i.e. the hook's effective UID is not the dir owner in practice (suspected tmux/sudo wrapper stripping owner identity on the SessionStart spawn path).

Chose option (a) — widen to 2770 — as suggested by the brief: simpler, well-bounded, and the v2 agent group (PR-C composition) contains only the controller + the isolated UID itself, so no third party gains write. Option (b) (audit the hook spawn path) needs deeper investigation that exceeds this scope.

### Gap 3 — post-`bun install` `chmod -R go+rX node_modules`

`lib/bridge-channels.sh:bridge_install_teams_plugin_node_modules` runs `bun install` as the controller; `node_modules/` inherited the controller umask (0700) and `bridge-dev-plugin-cache.py` copying under the isolated UID context failed with Permission denied on `.bin/` entries.

Added `chmod -R go+rX node_modules` (best-effort, warns on failure) after the bun-install success branch. Plugin source files are non-secret git content; the bun lockfile and package.json are already world-readable, so this only realigns post-install node_modules with the rest of the plugin source.

### Gap 4 — legacy `agents/<X>/` chmod 0755 on v2 scaffold

`bridge-agent.sh`'s v2 scaffold sudo block (the existing block around lines 681-709 that chmod 0755's `_scaffold_v2_root` / `home` / `_scaffold_v2_sibling`) didn't normalize the legacy `$BRIDGE_AGENT_HOME_ROOT/<agent>/` stub. On a markerless-existing-install upgrade the legacy stub was left at mode 0700 awfmanager-owned, and the legacy-teams-mcp pruner (running from a different UID context) tripped on stat.

Extended the existing block with `mkdir -p` + `chown` + `chmod 0755` on `$BRIDGE_AGENT_HOME_ROOT/$agent`, inside the existing `_scaffold_isolation_active=1` gate.

## Test plan

- [x] `bash -n` + `shellcheck` + `python3 -m py_compile` clean on every edited file
- [x] `bash scripts/lint-heredoc-ban.sh --baseline-check` → PASS (no footgun #11 regressions)
- [x] `bash scripts/smoke/1165-track-a-scaffold-modes.sh` → all 7 tests PASS (T1a/T1b/T1c Gap 1 signature/sudo-script/behavioral, T2 Gap 2, T3 Gap 3, T4 Gap 4, T5 Gap 1 sudo argv)
- [x] Sibling smokes: `isolation`, `1158-marker-controller-uid-exemption`, `1158-marker-load-order`, `1161-marker-readable-by-isolated`, `1145-ensure-dir-actually-sudo`, `1145-option1-deferral-guard`, `1155-bootstrap-skill-guard`, `isolated-skills-sync`, `channel-env-readiness`, `telegram-relay-residue-cleanup`, `isolation-v2-migrate-lock-portability`, `isolation-v2-marker-only-migrate`, `isolation-v2-macos-noise-suppression` → all PASS
- [x] `tests/isolation-claude-read-lens/smoke.sh` fragment pin updated 2750→2770 to match new Gap 2 contract
- [x] Registered `1165-track-a-scaffold-modes` in `scripts/ci-select-smoke.sh` `add_all_required_static` + per-area for `bridge-setup.py`, `bridge-agent.sh`, `lib/bridge-channels.sh` (lib/bridge-agents.sh already triggers add_all_required_static)
- [ ] Linux QA: full reproducer from #1165 to confirm `agb setup teams` no longer trips PermissionError on `.teams/access.json` (operator-host validation — requires fresh iso agent + Teams app credentials)

(#1165 Track A — Gaps 1-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)