### PR TITLE
fix(v2-isolation): PostToolUse hook + agb dispatcher controller-UID recovery (Gaps 7-8 of #1165)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -153,6 +153,44 @@ case "${1:-}" in
     ;;
 esac
 
+# Issue #1165 Gap 8: PR #1159 inlined BRIDGE_CONTROLLER_UID into the
+# agent-start sudo wrapper at bridge-start.sh:613-617 so the isolated
+# Claude session inherits the controller UID across `sudo -u <agent>`.
+# Any agb / agent-bridge invocation that does NOT go through that start
+# path (e.g. an iso Claude bash subprocess running `agb inbox <agent>`,
+# or `BRIDGE_CONTROLLER_UID= agb status` from a manual sudo shell) lands
+# in bridge-marker-bootstrap.sh's validator with no exported controller
+# UID, fails the owner check, and rejects the marker — surfaced to the
+# operator as "markerless(existing-install)". Recover defensively here:
+# if the variable is unset AND the marker file's owner differs from the
+# calling UID, infer that we are the iso UID reading a controller-owned
+# marker, and re-export BRIDGE_CONTROLLER_UID from the marker stat
+# before sourcing bridge-lib.sh (which then triggers marker validation
+# via bridge-marker-bootstrap.sh). Markerless installs (legacy / pre-
+# v0.8 / fresh-install candidates) skip the recovery — the validator
+# falls back silently to legacy in that case, so agb works regardless.
+# Mirror the marker path formula at lib/bridge-marker-bootstrap.sh:37.
+if [[ -z "${BRIDGE_CONTROLLER_UID:-}" ]]; then
+  _bridge_recovery_home="${BRIDGE_HOME:-$HOME/.agent-bridge}"
+  _bridge_recovery_marker="${BRIDGE_LAYOUT_MARKER_DIR:-$_bridge_recovery_home/state}/layout-marker.sh"
+  if [[ -f "$_bridge_recovery_marker" ]]; then
+    _bridge_recovery_owner=""
+    if [[ "$(uname)" == "Darwin" ]]; then
+      _bridge_recovery_owner="$(stat -f '%u' "$_bridge_recovery_marker" 2>/dev/null || true)"
+    else
+      _bridge_recovery_owner="$(stat -c '%u' "$_bridge_recovery_marker" 2>/dev/null || true)"
+    fi
+    _bridge_recovery_current="$(id -u 2>/dev/null || true)"
+    if [[ -n "$_bridge_recovery_owner" \
+        && -n "$_bridge_recovery_current" \
+        && "$_bridge_recovery_owner" != "$_bridge_recovery_current" ]]; then
+      export BRIDGE_CONTROLLER_UID="$_bridge_recovery_owner"
+    fi
+    unset _bridge_recovery_owner _bridge_recovery_current
+  fi
+  unset _bridge_recovery_home _bridge_recovery_marker
+fi
+
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -298,6 +298,38 @@ def _current_isolation_mode() -> str:
     return mode or "shared"
 
 
+def _under_isolated_uid() -> bool:
+    """True only when the process is actually running as a non-controller
+    UID under an isolated agent's env.
+
+    Issue #1165 Track C r2 (codex BLOCKING): the original Gap 7 guard
+    keyed on ``current_isolated_agent()`` alone, which only inspects env
+    (``BRIDGE_AGENT_ID`` + ``BRIDGE_AGENT_ISOLATION_MODE=linux-user``).
+    That meant any process inheriting those vars — including the
+    controller itself, e.g. an upgrade/dispatcher run that re-exported
+    them — silently swallowed audit-write failures. The contract is
+    "only the isolated UID may no-op," so we additionally verify the
+    effective UID differs from the controller UID exported by
+    ``bridge-start.sh``. When ``BRIDGE_CONTROLLER_UID`` is missing
+    (legacy session, older controller, anything that pre-dates the
+    propagation) we fail-closed and treat the process as controller —
+    a real permission regression continues to surface as before.
+    """
+    if not current_isolated_agent():
+        return False
+    controller_uid_raw = os.environ.get("BRIDGE_CONTROLLER_UID", "").strip()
+    if not controller_uid_raw:
+        # Fail-closed: without the controller UID we cannot prove the
+        # caller is the isolated UID. Treat as controller so genuine
+        # permission errors still raise.
+        return False
+    try:
+        controller_uid = int(controller_uid_raw)
+    except ValueError:
+        return False
+    return os.geteuid() != controller_uid
+
+
 def write_audit(action: str, target: str, detail: dict[str, Any]) -> None:
     path = audit_log_path()
     record = {
@@ -321,16 +353,22 @@ def write_audit(action: str, target: str, detail: dict[str, Any]) -> None:
     # Same "check-then-skip rather than fail-with-traceback" pattern as
     # the recent v2-isolation fixes (#1145, #1151, #1155): when the
     # writer cannot satisfy the controller-only path AND the calling UID
-    # is a linux-user-isolated agent (not the controller), silently
-    # no-op. Controller-side callers retain the original raise-on-error
+    # is actually a non-controller isolated UID, silently no-op.
+    # Controller-side callers retain the original raise-on-error
     # behavior so a genuine logs-dir permission regression is still
     # surfaced (the controller is supposed to own the tree).
+    #
+    # r2 hardening: the gate is the *effective UID vs controller UID*,
+    # not just env presence. See ``_under_isolated_uid`` for the
+    # rationale — codex BLOCKING review #1167 caught the original
+    # env-only predicate swallowing controller-side failures whenever
+    # the iso env happened to be inherited.
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(record, ensure_ascii=True) + "\n")
     except (PermissionError, OSError):
-        if current_isolated_agent() is not None:
+        if _under_isolated_uid():
             return
         raise
 

--- a/hooks/bridge_hook_common.py
+++ b/hooks/bridge_hook_common.py
@@ -300,7 +300,6 @@ def _current_isolation_mode() -> str:
 
 def write_audit(action: str, target: str, detail: dict[str, Any]) -> None:
     path = audit_log_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
     record = {
         "ts": datetime.now(timezone.utc).astimezone().isoformat(timespec="seconds"),
         "actor": "hook",
@@ -313,8 +312,27 @@ def write_audit(action: str, target: str, detail: dict[str, Any]) -> None:
         "acting_os_user": _acting_os_user(),
         "isolation_mode": _current_isolation_mode(),
     }
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(record, ensure_ascii=True) + "\n")
+    # Issue #1165 Gap 7: under linux-user isolation the audit log path
+    # resolves to ``$BRIDGE_HOME/logs/agents/<agent>/audit.jsonl`` —
+    # a controller-owned tree the isolated UID cannot mkdir into or
+    # append to. Without a guard, every PostToolUse hook from inside the
+    # isolated Claude REPL ends with a PermissionError traceback that
+    # Claude surfaces as a ``PostToolUseFailure`` flood per tool call.
+    # Same "check-then-skip rather than fail-with-traceback" pattern as
+    # the recent v2-isolation fixes (#1145, #1151, #1155): when the
+    # writer cannot satisfy the controller-only path AND the calling UID
+    # is a linux-user-isolated agent (not the controller), silently
+    # no-op. Controller-side callers retain the original raise-on-error
+    # behavior so a genuine logs-dir permission regression is still
+    # surfaced (the controller is supposed to own the tree).
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=True) + "\n")
+    except (PermissionError, OSError):
+        if current_isolated_agent() is not None:
+            return
+        raise
 
 
 def queue_gateway_root() -> Path:

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -209,6 +209,19 @@ select_for_path() {
   case "$path" in
     agent-bridge|agb|bridge-upgrade.sh|bridge-memory.sh|bridge-intake.sh|bridge-bundle.sh|bridge-cron.sh|bridge-daemon.sh|bridge-discord-relay.sh|bridge-send.sh|bridge-agent.sh|bridge-profile.sh|bridge-task.sh)
       add_required 1114-cli-help-contract 1117-cli-help-universal-gate
+      # Issue #1165 Gap 8: the agent-bridge dispatcher head carries
+      # the BRIDGE_CONTROLLER_UID recovery block that re-arms the
+      # marker validator's owner exemption (#1158) when agb is
+      # invoked directly from an isolated UID (not through the
+      # bridge-start.sh sudo wrapper). Pull the Track C smoke on
+      # every dispatcher move so a future PR cannot regress the
+      # recovery + marker-stat formula away from
+      # lib/bridge-marker-bootstrap.sh's path resolution.
+      case "$path" in
+        agent-bridge|agb)
+          add_required 1165-track-c-hooks-and-dispatcher
+          ;;
+      esac
       ;;
     lib/bridge-cron.sh|lib/bridge-state.sh)
       # Issue #1117: lib/bridge-cron.sh hosts bridge_cron_python +
@@ -627,7 +640,7 @@ select_for_path() {
       # isolation, link-shared-claude-skill, sync-claude-runtime-skills,
       # ensure-memory-precompact-hook, ensure-project-claude-guidance) stays
       # pinned.
-      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys admin-hook-exemption 1067-codex-provisioning 1120-controller-ops-isolated 1139-link-shared-settings-perm 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper
+      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys admin-hook-exemption 1067-codex-provisioning 1120-controller-ops-isolated 1139-link-shared-settings-perm 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1165-track-c-hooks-and-dispatcher
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1165-track-c-hooks-and-dispatcher.sh
+++ b/scripts/smoke/1165-track-c-hooks-and-dispatcher.sh
@@ -15,6 +15,9 @@
 #               UID is a linux-user-isolated agent AND the audit-log
 #               path is unwritable. PostToolUse hook would have raised
 #               PermissionError on every tool call before the fix.
+#               r2: BRIDGE_CONTROLLER_UID is set to a value different
+#               from current euid so the effective-UID gate confirms
+#               we are the isolated UID and swallows correctly.
 #   T2 (Gap 7): write_audit still RAISES on controller-side callers
 #               (BRIDGE_AGENT_ISOLATION_MODE unset → no isolation).
 #               Without this counter-test a future patch could silently
@@ -36,6 +39,22 @@
 #               export). Legacy installs that don't have a marker
 #               also don't enforce marker validation, so agb works
 #               regardless.
+#   T6 (Gap 7 r2): controller UID + linux-user env still RAISES.
+#               Codex BLOCKING review caught the original env-only
+#               gate swallowing controller-side failures when the iso
+#               env happened to be inherited. With the effective-UID
+#               gate, the controller (euid == BRIDGE_CONTROLLER_UID)
+#               must still propagate PermissionError. Regression
+#               contract: revert the gate fix → T6 fails (swallow).
+#   T7 (Gap 7 r2): iso UID + linux-user env + matching CONTROLLER_UID
+#               (different from current euid) → swallow. Same outcome
+#               as T1, but explicitly pinning the contract that the
+#               distinguishing signal is the UID mismatch, not the
+#               env shape alone.
+#   T8 (Gap 7 r2): iso env + missing BRIDGE_CONTROLLER_UID → RAISES
+#               (fail-closed). When we cannot prove the caller is the
+#               isolated UID (legacy session, older controller, etc.)
+#               the safer default is to surface the error.
 #
 # Host-agnostic: no sudo required. T3's runtime probe uses a tiny
 # extracted-driver script that re-implements the recovery block with
@@ -147,10 +166,15 @@ T1_AUDIT="$T1_ROOT/locked/subdir/audit.jsonl"
 
 T1_OUT="$SMOKE_TMP_ROOT/t1-out.txt"
 T1_ERR="$SMOKE_TMP_ROOT/t1-err.txt"
+# r2: set BRIDGE_CONTROLLER_UID to a synthetic value different from the
+# current euid so the effective-UID gate sees euid != controller and
+# treats the caller as the isolated UID. 999999 is far outside any real
+# UID space the smoke runner could be using.
 DRIVER_HOOK_COMMON_PATH="$HOOK_COMMON_FILE" \
   BRIDGE_AUDIT_LOG="$T1_AUDIT" \
   BRIDGE_AGENT_ID="iso_smoke_agent" \
   BRIDGE_AGENT_ISOLATION_MODE="linux-user" \
+  BRIDGE_CONTROLLER_UID="999999" \
   "$PYTHON_BIN" "$T1_DRIVER" >"$T1_OUT" 2>"$T1_ERR"
 T1_RC=$?
 
@@ -359,5 +383,136 @@ if [[ -s "$SMOKE_TMP_ROOT/t5-runtime-err" ]]; then
   smoke_fail "T5: expected empty stderr on markerless install, got: $(cat "$SMOKE_TMP_ROOT/t5-runtime-err")"
 fi
 smoke_log "T5 PASS: markerless install → recovery block no-ops, BRIDGE_CONTROLLER_UID stays unset, no stderr"
+
+# ---------------------------------------------------------------------------
+# T6 (Gap 7 r2) — controller UID + linux-user env still RAISES.
+#
+# Reproduces the codex BLOCKING scenario: a controller-side process
+# happens to inherit linux-user iso env (BRIDGE_AGENT_ID +
+# BRIDGE_AGENT_ISOLATION_MODE=linux-user) AND its euid equals the
+# exported BRIDGE_CONTROLLER_UID. The original env-only gate would
+# swallow the PermissionError here; the effective-UID gate correctly
+# raises. Regression contract: revert the gate fix in
+# hooks/bridge_hook_common.py → T6 fails (reverts to "CLEAN").
+# ---------------------------------------------------------------------------
+smoke_log "T6: controller UID + linux-user env + unwritable path → RAISES (r2 BLOCKING fix)"
+
+T6_ROOT="$SMOKE_TMP_ROOT/t6-audit-root"
+mkdir -p "$T6_ROOT/locked"
+chmod 0500 "$T6_ROOT/locked"
+T6_AUDIT="$T6_ROOT/locked/subdir/audit.jsonl"
+
+T6_CURRENT_UID="$(id -u)"
+T6_OUT="$SMOKE_TMP_ROOT/t6-out.txt"
+T6_ERR="$SMOKE_TMP_ROOT/t6-err.txt"
+DRIVER_HOOK_COMMON_PATH="$HOOK_COMMON_FILE" \
+  BRIDGE_AUDIT_LOG="$T6_AUDIT" \
+  BRIDGE_AGENT_ID="iso_smoke_agent" \
+  BRIDGE_AGENT_ISOLATION_MODE="linux-user" \
+  BRIDGE_CONTROLLER_UID="$T6_CURRENT_UID" \
+  "$PYTHON_BIN" "$T1_DRIVER" >"$T6_OUT" 2>"$T6_ERR"
+T6_RC=$?
+
+chmod 0700 "$T6_ROOT/locked" 2>/dev/null || true
+if [[ $T6_RC -ne 0 ]]; then
+  smoke_fail "T6: driver exited with rc=$T6_RC (driver always exits 0 — it captures the exception). stdout: $(cat "$T6_OUT") stderr: $(cat "$T6_ERR")"
+fi
+T6_RESULT="$(cat "$T6_OUT" | tr -d '\n')"
+case "$T6_RESULT" in
+  RAISED:PermissionError:*|RAISED:OSError:*)
+    smoke_log "T6 PASS: controller-UID-with-iso-env write_audit propagated $T6_RESULT (effective-UID gate held)"
+    ;;
+  CLEAN)
+    smoke_fail "T6 REGRESSION: controller UID with linux-user env swallowed PermissionError (got 'CLEAN'). The effective-UID gate is missing or broken — see hooks/bridge_hook_common.py::_under_isolated_uid."
+    ;;
+  *)
+    smoke_fail "T6: expected RAISED:PermissionError:* (controller UID gate raises), got: '$T6_RESULT'. stderr: $(cat "$T6_ERR")"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# T7 (Gap 7 r2) — iso UID + linux-user env + matching CONTROLLER_UID
+# (different from current euid) → swallow.
+#
+# Mirror of T1 but explicit about the effective-UID contract: the
+# distinguishing signal is `os.geteuid() != int(BRIDGE_CONTROLLER_UID)`,
+# not the env shape alone. T1 covers the same code path; T7 pins the
+# contract independently so a future "simplify T1" refactor cannot
+# accidentally lose the swallow-path coverage.
+# ---------------------------------------------------------------------------
+smoke_log "T7: iso UID + linux-user env + non-matching CONTROLLER_UID → swallow"
+
+T7_ROOT="$SMOKE_TMP_ROOT/t7-audit-root"
+mkdir -p "$T7_ROOT/locked"
+chmod 0500 "$T7_ROOT/locked"
+T7_AUDIT="$T7_ROOT/locked/subdir/audit.jsonl"
+
+T7_OUT="$SMOKE_TMP_ROOT/t7-out.txt"
+T7_ERR="$SMOKE_TMP_ROOT/t7-err.txt"
+DRIVER_HOOK_COMMON_PATH="$HOOK_COMMON_FILE" \
+  BRIDGE_AUDIT_LOG="$T7_AUDIT" \
+  BRIDGE_AGENT_ID="iso_smoke_agent" \
+  BRIDGE_AGENT_ISOLATION_MODE="linux-user" \
+  BRIDGE_CONTROLLER_UID="999998" \
+  "$PYTHON_BIN" "$T1_DRIVER" >"$T7_OUT" 2>"$T7_ERR"
+T7_RC=$?
+
+chmod 0700 "$T7_ROOT/locked" 2>/dev/null || true
+if [[ $T7_RC -ne 0 ]]; then
+  smoke_fail "T7: driver exited with rc=$T7_RC. stdout: $(cat "$T7_OUT") stderr: $(cat "$T7_ERR")"
+fi
+T7_RESULT="$(cat "$T7_OUT" | tr -d '\n')"
+if [[ "$T7_RESULT" != "CLEAN" ]]; then
+  smoke_fail "T7: expected 'CLEAN' (iso UID swallows under non-matching CONTROLLER_UID), got: '$T7_RESULT'. stderr: $(cat "$T7_ERR")"
+fi
+if [[ -s "$T7_ERR" ]]; then
+  smoke_fail "T7: unexpected stderr noise on iso-UID swallow path: $(cat "$T7_ERR")"
+fi
+smoke_log "T7 PASS: iso UID (euid != BRIDGE_CONTROLLER_UID) under linux-user env swallowed quietly"
+
+# ---------------------------------------------------------------------------
+# T8 (Gap 7 r2) — iso env + missing BRIDGE_CONTROLLER_UID → RAISES.
+#
+# Fail-closed contract: when we cannot prove the caller is the isolated
+# UID (e.g. legacy session, older controller that pre-dates the
+# BRIDGE_CONTROLLER_UID propagation), the safer default is to surface
+# the PermissionError. Treating the caller as controller means a real
+# logs-dir permission regression is still caught; the only cost is the
+# original PostToolUseFailure flood reappearing for any operator on an
+# older controller — they should upgrade.
+# ---------------------------------------------------------------------------
+smoke_log "T8: iso env + missing BRIDGE_CONTROLLER_UID → RAISES (fail-closed)"
+
+T8_ROOT="$SMOKE_TMP_ROOT/t8-audit-root"
+mkdir -p "$T8_ROOT/locked"
+chmod 0500 "$T8_ROOT/locked"
+T8_AUDIT="$T8_ROOT/locked/subdir/audit.jsonl"
+
+T8_OUT="$SMOKE_TMP_ROOT/t8-out.txt"
+T8_ERR="$SMOKE_TMP_ROOT/t8-err.txt"
+env -u BRIDGE_CONTROLLER_UID \
+  DRIVER_HOOK_COMMON_PATH="$HOOK_COMMON_FILE" \
+  BRIDGE_AUDIT_LOG="$T8_AUDIT" \
+  BRIDGE_AGENT_ID="iso_smoke_agent" \
+  BRIDGE_AGENT_ISOLATION_MODE="linux-user" \
+  "$PYTHON_BIN" "$T1_DRIVER" >"$T8_OUT" 2>"$T8_ERR"
+T8_RC=$?
+
+chmod 0700 "$T8_ROOT/locked" 2>/dev/null || true
+if [[ $T8_RC -ne 0 ]]; then
+  smoke_fail "T8: driver exited with rc=$T8_RC. stdout: $(cat "$T8_OUT") stderr: $(cat "$T8_ERR")"
+fi
+T8_RESULT="$(cat "$T8_OUT" | tr -d '\n')"
+case "$T8_RESULT" in
+  RAISED:PermissionError:*|RAISED:OSError:*)
+    smoke_log "T8 PASS: missing BRIDGE_CONTROLLER_UID → fail-closed raise $T8_RESULT"
+    ;;
+  CLEAN)
+    smoke_fail "T8 REGRESSION: missing BRIDGE_CONTROLLER_UID swallowed PermissionError (got 'CLEAN'). Without controller UID we cannot prove caller is isolated; gate must fail-closed."
+    ;;
+  *)
+    smoke_fail "T8: expected RAISED:PermissionError:* (fail-closed), got: '$T8_RESULT'. stderr: $(cat "$T8_ERR")"
+    ;;
+esac
 
 smoke_log "all tests PASS (#1165 Track C — Gap 7 hook + Gap 8 dispatcher recovery)"

--- a/scripts/smoke/1165-track-c-hooks-and-dispatcher.sh
+++ b/scripts/smoke/1165-track-c-hooks-and-dispatcher.sh
@@ -1,0 +1,363 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1165-track-c-hooks-and-dispatcher.sh — Issue #1165 Track C
+#
+# Pins the contract closed by Track C of #1165 (Gaps 7 + 8) — the two
+# "agent runtime UI" v2-isolation × Teams plugin gaps that surface as
+# (a) PostToolUseFailure traceback flood from inside isolated Claude
+# REPL and (b) markerless(existing-install) rejection when `agb` is
+# invoked directly from the isolated UID.
+#
+# Tests:
+#
+#   T1 (Gap 7): hooks/bridge_hook_common.py::write_audit returns
+#               cleanly (no raise, no stderr noise) when the calling
+#               UID is a linux-user-isolated agent AND the audit-log
+#               path is unwritable. PostToolUse hook would have raised
+#               PermissionError on every tool call before the fix.
+#   T2 (Gap 7): write_audit still RAISES on controller-side callers
+#               (BRIDGE_AGENT_ISOLATION_MODE unset → no isolation).
+#               Without this counter-test a future patch could silently
+#               swallow controller-side write failures too.
+#   T3 (Gap 8): agent-bridge dispatcher recovery block runs when
+#               BRIDGE_CONTROLLER_UID is unset and exports the marker
+#               file owner's UID. We can't simulate a real cross-UID
+#               marker without sudo, so this test grep-asserts the
+#               recovery block is present at the dispatcher head (the
+#               static-source contract), plus a runtime probe of the
+#               extracted block confirming the export fires when stat
+#               is shimmed to return a different owner UID.
+#   T4 (Gap 8): pre-set BRIDGE_CONTROLLER_UID survives the recovery
+#               block (no overwrite). Mirrors the bridge-start.sh:613
+#               sudo-wrapper contract — if the wrapper has already
+#               set the var, the dispatcher must not stomp it.
+#   T5 (Gap 8): markerless install (no layout-marker.sh) → recovery
+#               block no-ops gracefully (no error, no spurious env
+#               export). Legacy installs that don't have a marker
+#               also don't enforce marker validation, so agb works
+#               regardless.
+#
+# Host-agnostic: no sudo required. T3's runtime probe uses a tiny
+# extracted-driver script that re-implements the recovery block with
+# `bridge_marker_stat_uid` shimmed in shell — independent verification
+# of the byte-for-byte logic the dispatcher inlines. The static-source
+# grep in T3 closes the loop by ensuring the dispatcher still contains
+# the production lines the probe mirrors. Footgun #11 (heredoc-stdin
+# subprocess) is off the table — every driver is built with
+# `printf '%s\n' >>file`.
+
+set -uo pipefail
+
+SMOKE_NAME="1165-track-c-hooks-and-dispatcher"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+AGB_FILE="$REPO_ROOT/agent-bridge"
+HOOK_COMMON_FILE="$REPO_ROOT/hooks/bridge_hook_common.py"
+
+smoke_assert_file_exists "$AGB_FILE" "agent-bridge dispatcher present"
+smoke_assert_file_exists "$HOOK_COMMON_FILE" "hooks/bridge_hook_common.py present"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+PYTHON_BIN="${BRIDGE_PYTHON_BIN:-python3}"
+command -v "$PYTHON_BIN" >/dev/null 2>&1 \
+  || smoke_fail "python3 not found on PATH"
+
+# ---------------------------------------------------------------------------
+# Shared py-driver: import hooks/bridge_hook_common as a module and
+# invoke write_audit with a controlled BRIDGE_AUDIT_LOG path. The test
+# code is parameterized via env so the same driver covers T1 (iso UID,
+# unwritable path → no raise) and T2 (controller UID, unwritable path
+# → raise).
+# ---------------------------------------------------------------------------
+build_write_audit_driver() {
+  local driver="$1"
+  : >"$driver"
+  # shellcheck disable=SC2129  # per-line emit keeps footgun #11 off the table
+  {
+    printf '%s\n' '#!/usr/bin/env python3'
+    printf '%s\n' '"""Invoke bridge_hook_common.write_audit with a controlled config."""'
+    printf '%s\n' 'from __future__ import annotations'
+    printf '%s\n' 'import importlib.util'
+    printf '%s\n' 'import os'
+    printf '%s\n' 'import sys'
+    printf '%s\n' 'from pathlib import Path'
+    printf '%s\n' ''
+    printf '%s\n' 'def load_module(path: Path):'
+    printf '%s\n' '    spec = importlib.util.spec_from_file_location("bridge_hook_common", str(path))'
+    printf '%s\n' '    if spec is None or spec.loader is None:'
+    printf '%s\n' '        raise RuntimeError("cannot load bridge_hook_common from " + str(path))'
+    printf '%s\n' '    module = importlib.util.module_from_spec(spec)'
+    printf '%s\n' '    spec.loader.exec_module(module)'
+    printf '%s\n' '    return module'
+    printf '%s\n' ''
+    printf '%s\n' 'def main() -> int:'
+    printf '%s\n' '    common_path = Path(os.environ["DRIVER_HOOK_COMMON_PATH"])'
+    printf '%s\n' '    module = load_module(common_path)'
+    printf '%s\n' '    try:'
+    printf '%s\n' '        module.write_audit("smoke_action", "smoke_target", {"k": "v"})'
+    printf '%s\n' '    except Exception as exc:'
+    printf '%s\n' '        print("RAISED:" + type(exc).__name__ + ":" + str(exc))'
+    printf '%s\n' '        return 0'
+    printf '%s\n' '    print("CLEAN")'
+    printf '%s\n' '    return 0'
+    printf '%s\n' ''
+    printf '%s\n' 'if __name__ == "__main__":'
+    printf '%s\n' '    raise SystemExit(main())'
+  } >>"$driver"
+  chmod +x "$driver"
+}
+
+# ---------------------------------------------------------------------------
+# T1 — write_audit under iso UID returns cleanly when audit log path
+# is unwritable.
+# ---------------------------------------------------------------------------
+smoke_log "T1: write_audit under iso UID + unwritable audit dir → no raise"
+
+T1_DRIVER="$SMOKE_TMP_ROOT/t1-driver.py"
+build_write_audit_driver "$T1_DRIVER"
+
+# Make a directory we own then chmod it 0500 (read+execute only) so
+# `mkdir` of a subdir AND `open(..., "a")` of any file inside both
+# fail with PermissionError. This is the structural shape of the
+# bug — controller-owned dir, iso UID can't write.
+T1_ROOT="$SMOKE_TMP_ROOT/t1-audit-root"
+mkdir -p "$T1_ROOT/locked"
+chmod 0500 "$T1_ROOT/locked"
+T1_AUDIT="$T1_ROOT/locked/subdir/audit.jsonl"
+
+T1_OUT="$SMOKE_TMP_ROOT/t1-out.txt"
+T1_ERR="$SMOKE_TMP_ROOT/t1-err.txt"
+DRIVER_HOOK_COMMON_PATH="$HOOK_COMMON_FILE" \
+  BRIDGE_AUDIT_LOG="$T1_AUDIT" \
+  BRIDGE_AGENT_ID="iso_smoke_agent" \
+  BRIDGE_AGENT_ISOLATION_MODE="linux-user" \
+  "$PYTHON_BIN" "$T1_DRIVER" >"$T1_OUT" 2>"$T1_ERR"
+T1_RC=$?
+
+if [[ $T1_RC -ne 0 ]]; then
+  chmod 0700 "$T1_ROOT/locked" 2>/dev/null || true
+  smoke_fail "T1: driver exited with rc=$T1_RC (expected 0). stdout: $(cat "$T1_OUT") stderr: $(cat "$T1_ERR")"
+fi
+T1_RESULT="$(cat "$T1_OUT" | tr -d '\n')"
+if [[ "$T1_RESULT" != "CLEAN" ]]; then
+  chmod 0700 "$T1_ROOT/locked" 2>/dev/null || true
+  smoke_fail "T1: expected 'CLEAN' (write_audit returned without raise), got: '$T1_RESULT'. stderr: $(cat "$T1_ERR")"
+fi
+# Stderr must be empty — Claude's hook stderr is what floods the operator.
+if [[ -s "$T1_ERR" ]]; then
+  chmod 0700 "$T1_ROOT/locked" 2>/dev/null || true
+  smoke_fail "T1: write_audit emitted unexpected stderr noise: $(cat "$T1_ERR")"
+fi
+# Restore mode so cleanup can rm -rf.
+chmod 0700 "$T1_ROOT/locked" 2>/dev/null || true
+smoke_log "T1 PASS: write_audit under iso UID + unwritable path → swallowed quietly"
+
+# ---------------------------------------------------------------------------
+# T2 — write_audit on controller side still RAISES on unwritable path.
+# ---------------------------------------------------------------------------
+smoke_log "T2: write_audit on controller (no iso mode) + unwritable path → RAISES"
+
+T2_ROOT="$SMOKE_TMP_ROOT/t2-audit-root"
+mkdir -p "$T2_ROOT/locked"
+chmod 0500 "$T2_ROOT/locked"
+T2_AUDIT="$T2_ROOT/locked/subdir/audit.jsonl"
+
+T2_OUT="$SMOKE_TMP_ROOT/t2-out.txt"
+T2_ERR="$SMOKE_TMP_ROOT/t2-err.txt"
+# Note: BRIDGE_AGENT_ISOLATION_MODE intentionally unset → current_isolated_agent()
+# returns None → the swallow branch must NOT fire. We re-use T1_DRIVER
+# (same py-driver shape, captures any raise into the "RAISED:" prefix).
+env -u BRIDGE_AGENT_ISOLATION_MODE \
+  DRIVER_HOOK_COMMON_PATH="$HOOK_COMMON_FILE" \
+  BRIDGE_AUDIT_LOG="$T2_AUDIT" \
+  BRIDGE_AGENT_ID="controller_smoke_agent" \
+  "$PYTHON_BIN" "$T1_DRIVER" >"$T2_OUT" 2>"$T2_ERR"
+T2_RC=$?
+
+chmod 0700 "$T2_ROOT/locked" 2>/dev/null || true
+if [[ $T2_RC -ne 0 ]]; then
+  smoke_fail "T2: driver exited with rc=$T2_RC (the driver itself should still exit 0 — it captures the exception). stdout: $(cat "$T2_OUT") stderr: $(cat "$T2_ERR")"
+fi
+T2_RESULT="$(cat "$T2_OUT" | tr -d '\n')"
+case "$T2_RESULT" in
+  RAISED:PermissionError:*|RAISED:OSError:*)
+    smoke_log "T2 PASS: controller-side write_audit propagated $T2_RESULT (no silent-swallow regression)"
+    ;;
+  *)
+    smoke_fail "T2: expected RAISED:PermissionError:* (controller path still raises), got: '$T2_RESULT'. stderr: $(cat "$T2_ERR")"
+    ;;
+esac
+
+# ---------------------------------------------------------------------------
+# T3 — agent-bridge dispatcher recovery block: BRIDGE_CONTROLLER_UID
+# unset + marker owner != current UID → recovery exports the var.
+# ---------------------------------------------------------------------------
+smoke_log "T3: dispatcher recovery block exports BRIDGE_CONTROLLER_UID on cross-UID marker"
+
+# Static-source assertion first: the recovery block must be present at
+# the dispatcher head (BEFORE `source bridge-lib.sh`). Boomerang — if a
+# future refactor lifts the recovery into bridge-lib.sh itself or drops
+# it entirely, this assertion fires before the runtime probe.
+T3_GREP_GUARD='if \[\[ -z "${BRIDGE_CONTROLLER_UID:-}" \]\]; then'
+T3_GREP_EXPORT='export BRIDGE_CONTROLLER_UID="\$_bridge_recovery_owner"'
+T3_GREP_MARKER='_bridge_recovery_marker="\${BRIDGE_LAYOUT_MARKER_DIR:-\$_bridge_recovery_home/state}/layout-marker.sh"'
+
+grep -q "$T3_GREP_GUARD" "$AGB_FILE" \
+  || smoke_fail "T3: agent-bridge dispatcher missing the recovery guard '$T3_GREP_GUARD'"
+grep -q "$T3_GREP_EXPORT" "$AGB_FILE" \
+  || smoke_fail "T3: agent-bridge dispatcher missing the recovery export '$T3_GREP_EXPORT'"
+grep -q "$T3_GREP_MARKER" "$AGB_FILE" \
+  || smoke_fail "T3: agent-bridge dispatcher missing the marker-path formula '$T3_GREP_MARKER'"
+
+# Pre-source position assertion: the recovery block MUST appear before
+# `source "$SCRIPT_DIR/bridge-lib.sh"` so it primes the env before
+# bridge-marker-bootstrap.sh validates the marker. Use awk to find the
+# line numbers and assert ordering.
+T3_GUARD_LINE="$(grep -n "$T3_GREP_GUARD" "$AGB_FILE" | head -n 1 | cut -d: -f1)"
+T3_SOURCE_LINE="$(grep -n 'source "$SCRIPT_DIR/bridge-lib.sh"' "$AGB_FILE" | head -n 1 | cut -d: -f1)"
+if [[ -z "$T3_GUARD_LINE" || -z "$T3_SOURCE_LINE" ]]; then
+  smoke_fail "T3: could not locate guard ($T3_GUARD_LINE) or bridge-lib source ($T3_SOURCE_LINE) line in dispatcher"
+fi
+if (( T3_GUARD_LINE >= T3_SOURCE_LINE )); then
+  smoke_fail "T3: recovery guard at line $T3_GUARD_LINE must precede 'source bridge-lib.sh' at line $T3_SOURCE_LINE"
+fi
+smoke_log "T3 PASS[static]: recovery block at line $T3_GUARD_LINE precedes bridge-lib.sh source at line $T3_SOURCE_LINE"
+
+# Runtime probe: build a tiny shell driver that mirrors the dispatcher's
+# recovery block byte-for-byte (the lines the static asserts pin) and
+# shims `stat` so it reports a different owner UID. Verifies the logic
+# fires end-to-end without needing actual cross-UID privileges.
+T3_HOME="$SMOKE_TMP_ROOT/t3-home"
+mkdir -p "$T3_HOME/state"
+T3_MARKER="$T3_HOME/state/layout-marker.sh"
+{
+  printf '%s\n' 'BRIDGE_LAYOUT=v2'
+  printf '%s\n' "BRIDGE_DATA_ROOT=$T3_HOME/data"
+} >>"$T3_MARKER"
+chmod 0644 "$T3_MARKER"
+
+T3_DRIVER="$SMOKE_TMP_ROOT/t3-driver.sh"
+: >"$T3_DRIVER"
+# Build a driver that:
+#   - Honors caller-set BRIDGE_CONTROLLER_UID when arg3 == "preserve",
+#     else unsets it (the default — covers T3/T5 fresh-state probes)
+#   - Exports BRIDGE_HOME → arg1
+#   - Shims `stat` to print arg2 as the marker owner UID
+#   - Inlines the recovery block (exact code from agent-bridge head)
+#   - Prints the final BRIDGE_CONTROLLER_UID value
+# shellcheck disable=SC2129,SC1003  # SC2129: grouped block keeps footgun #11 off the table; SC1003: trailing backslash inside single-quoted printf args is intentional line continuation in the emitted bash, not an escape mistake
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -uo pipefail'
+  printf '%s\n' 'export BRIDGE_HOME="$1"'
+  printf '%s\n' 'FAKE_OWNER_UID="$2"'
+  printf '%s\n' 'PRESERVE_MODE="${3:-clear}"'
+  printf '%s\n' 'if [[ "$PRESERVE_MODE" != "preserve" ]]; then'
+  printf '%s\n' '  unset BRIDGE_CONTROLLER_UID'
+  printf '%s\n' 'fi'
+  # Shim stat: print a fixed UID so the recovery block sees owner != current.
+  # The shim takes precedence over the system stat via PATH. We use a
+  # function override which works for the recovery block's `stat` calls
+  # because the recovery uses unqualified `stat ...` invocations.
+  printf '%s\n' 'stat() {'
+  printf '%s\n' '  # Mimic both BSD (-f %u) and GNU (-c %u) invocations.'
+  printf '%s\n' '  local _flag="$1"; shift'
+  printf '%s\n' '  local _fmt="$1"; shift'
+  printf '%s\n' '  if [[ "$_flag" == "-f" || "$_flag" == "-c" ]]; then'
+  printf '%s\n' '    case "$_fmt" in'
+  printf '%s\n' '      "%u") printf "%s\\n" "$FAKE_OWNER_UID"; return 0 ;;'
+  printf '%s\n' '    esac'
+  printf '%s\n' '  fi'
+  printf '%s\n' '  printf "stat-shim: unhandled args: %s %s %s\\n" "$_flag" "$_fmt" "$*" >&2'
+  printf '%s\n' '  return 1'
+  printf '%s\n' '}'
+  printf '%s\n' 'export -f stat'
+  # Inline the production recovery block — byte-identical to agent-bridge
+  # head. T3 static-source asserts catch drift in the dispatcher; this
+  # driver re-implements the same lines so we can exercise the runtime
+  # behavior without sourcing bridge-lib.sh's transitive deps.
+  printf '%s\n' 'if [[ -z "${BRIDGE_CONTROLLER_UID:-}" ]]; then'
+  printf '%s\n' '  _bridge_recovery_home="${BRIDGE_HOME:-$HOME/.agent-bridge}"'
+  printf '%s\n' '  _bridge_recovery_marker="${BRIDGE_LAYOUT_MARKER_DIR:-$_bridge_recovery_home/state}/layout-marker.sh"'
+  printf '%s\n' '  if [[ -f "$_bridge_recovery_marker" ]]; then'
+  printf '%s\n' '    _bridge_recovery_owner=""'
+  printf '%s\n' '    if [[ "$(uname)" == "Darwin" ]]; then'
+  printf '%s\n' '      _bridge_recovery_owner="$(stat -f "%u" "$_bridge_recovery_marker" 2>/dev/null || true)"'
+  printf '%s\n' '    else'
+  printf '%s\n' '      _bridge_recovery_owner="$(stat -c "%u" "$_bridge_recovery_marker" 2>/dev/null || true)"'
+  printf '%s\n' '    fi'
+  printf '%s\n' '    _bridge_recovery_current="$(id -u 2>/dev/null || true)"'
+  printf '%s\n' '    if [[ -n "$_bridge_recovery_owner" \'
+  printf '%s\n' '        && -n "$_bridge_recovery_current" \'
+  printf '%s\n' '        && "$_bridge_recovery_owner" != "$_bridge_recovery_current" ]]; then'
+  printf '%s\n' '      export BRIDGE_CONTROLLER_UID="$_bridge_recovery_owner"'
+  printf '%s\n' '    fi'
+  printf '%s\n' '    unset _bridge_recovery_owner _bridge_recovery_current'
+  printf '%s\n' '  fi'
+  printf '%s\n' '  unset _bridge_recovery_home _bridge_recovery_marker'
+  printf '%s\n' 'fi'
+  printf '%s\n' 'printf "BRIDGE_CONTROLLER_UID=%s\\n" "${BRIDGE_CONTROLLER_UID:-<unset>}"'
+} >>"$T3_DRIVER"
+chmod +x "$T3_DRIVER"
+
+T3_RUNTIME_OUT="$(env -u BRIDGE_LAYOUT_MARKER_DIR -u BRIDGE_CONTROLLER_UID "$BRIDGE_BASH" "$T3_DRIVER" "$T3_HOME" "99999" 2>"$SMOKE_TMP_ROOT/t3-runtime-err")" \
+  || smoke_fail "T3: runtime probe driver failed (rc=$?). out: $T3_RUNTIME_OUT err: $(cat "$SMOKE_TMP_ROOT/t3-runtime-err")"
+if [[ "$T3_RUNTIME_OUT" != "BRIDGE_CONTROLLER_UID=99999" ]]; then
+  smoke_fail "T3 runtime: expected 'BRIDGE_CONTROLLER_UID=99999' (recovery exported the marker-stat'd owner UID), got: '$T3_RUNTIME_OUT'. err: $(cat "$SMOKE_TMP_ROOT/t3-runtime-err")"
+fi
+smoke_log "T3 PASS[runtime]: recovery block exported BRIDGE_CONTROLLER_UID=99999 from cross-UID marker stat"
+
+# ---------------------------------------------------------------------------
+# T4 — pre-set BRIDGE_CONTROLLER_UID survives the recovery block.
+# ---------------------------------------------------------------------------
+smoke_log "T4: pre-set BRIDGE_CONTROLLER_UID is NOT overwritten by recovery"
+
+T4_RUNTIME_OUT="$(env -u BRIDGE_LAYOUT_MARKER_DIR BRIDGE_CONTROLLER_UID=12345 "$BRIDGE_BASH" "$T3_DRIVER" "$T3_HOME" "99999" "preserve" 2>"$SMOKE_TMP_ROOT/t4-runtime-err")" \
+  || smoke_fail "T4: runtime probe driver failed (rc=$?). out: $T4_RUNTIME_OUT err: $(cat "$SMOKE_TMP_ROOT/t4-runtime-err")"
+if [[ "$T4_RUNTIME_OUT" != "BRIDGE_CONTROLLER_UID=12345" ]]; then
+  smoke_fail "T4: expected pre-set 'BRIDGE_CONTROLLER_UID=12345' to survive recovery, got: '$T4_RUNTIME_OUT'. err: $(cat "$SMOKE_TMP_ROOT/t4-runtime-err")"
+fi
+smoke_log "T4 PASS: pre-set BRIDGE_CONTROLLER_UID=12345 survived the recovery block"
+
+# ---------------------------------------------------------------------------
+# T5 — markerless install: recovery block no-ops gracefully.
+# ---------------------------------------------------------------------------
+smoke_log "T5: markerless install (no layout-marker.sh) → recovery no-op, no error"
+
+T5_HOME="$SMOKE_TMP_ROOT/t5-home"
+mkdir -p "$T5_HOME/state"
+# Deliberately do NOT create the marker file.
+[[ -f "$T5_HOME/state/layout-marker.sh" ]] && smoke_fail "T5 fixture corrupt — marker should not exist"
+
+T5_RUNTIME_OUT="$(env -u BRIDGE_LAYOUT_MARKER_DIR -u BRIDGE_CONTROLLER_UID "$BRIDGE_BASH" "$T3_DRIVER" "$T5_HOME" "99999" 2>"$SMOKE_TMP_ROOT/t5-runtime-err")" \
+  || smoke_fail "T5: runtime probe driver failed on markerless install (rc=$?). out: $T5_RUNTIME_OUT err: $(cat "$SMOKE_TMP_ROOT/t5-runtime-err")"
+if [[ "$T5_RUNTIME_OUT" != "BRIDGE_CONTROLLER_UID=<unset>" ]]; then
+  smoke_fail "T5: expected BRIDGE_CONTROLLER_UID to remain unset on markerless install, got: '$T5_RUNTIME_OUT'. err: $(cat "$SMOKE_TMP_ROOT/t5-runtime-err")"
+fi
+# Stderr must also be clean — no spurious error from the missing marker.
+if [[ -s "$SMOKE_TMP_ROOT/t5-runtime-err" ]]; then
+  smoke_fail "T5: expected empty stderr on markerless install, got: $(cat "$SMOKE_TMP_ROOT/t5-runtime-err")"
+fi
+smoke_log "T5 PASS: markerless install → recovery block no-ops, BRIDGE_CONTROLLER_UID stays unset, no stderr"
+
+smoke_log "all tests PASS (#1165 Track C — Gap 7 hook + Gap 8 dispatcher recovery)"


### PR DESCRIPTION
## Summary

Track C of #1165 — the two "agent runtime UI" v2-isolation × Teams plugin gaps that surface from inside the isolated Claude REPL once Gaps 1-6 are workaround'd.

- **Gap 7** — `hooks/bridge_hook_common.py::write_audit` raised `PermissionError` on every PostToolUse tool call from the iso UID because `audit_log_path()` resolves to `$BRIDGE_HOME/logs/agents/<agent>/audit.jsonl` (controller-owned tree). Claude surfaced the traceback as a `PostToolUseFailure` flood per Bash/Read/ToolSearch call. Fix: wrap the path I/O in try/except — silently no-op when calling UID is a linux-user-isolated agent (`current_isolated_agent() is not None`); preserve raise-on-error for controller-side callers so a genuine logs-dir permission regression is still surfaced.
- **Gap 8** — PR #1159's `BRIDGE_CONTROLLER_UID` inline-into-env only fires on the `bridge-start.sh:613-617` agent-start sudo wrapper. When the iso Claude bash subprocess later runs `agb inbox <agent>` directly, the marker validator rejects the marker as `markerless(existing-install)`. Fix: a small recovery block at the `agent-bridge` dispatcher head (just before `source bridge-lib.sh`) — if `BRIDGE_CONTROLLER_UID` is unset AND the layout-marker.sh owner differs from the calling UID, re-export `BRIDGE_CONTROLLER_UID` from the marker stat. Skip on markerless installs (legacy fall-through still works).

Both fixes mirror the established v2-isolation "check-then-skip rather than fail-with-traceback" pattern (#1145 / #1151 / #1155 / #1158).

### Files

- `hooks/bridge_hook_common.py` — `write_audit` swallows `PermissionError` / `OSError` when iso UID can't reach controller-only audit path
- `agent-bridge` — recovery block between line 154 (end of `init`/`upgrade`/`migrate` arm) and line 195 (`source bridge-lib.sh`), uses portable BSD/GNU `stat` matching `bridge_marker_stat_uid` formula
- `scripts/smoke/1165-track-c-hooks-and-dispatcher.sh` — 5 tests, host-agnostic (no sudo required), runtime probe of Gap 8 via stat shim
- `scripts/ci-select-smoke.sh` — registered on `agent-bridge|agb` + `hooks/*` arms

### Gap 7 audit (per brief)

Audited `handle_pretool`, `handle_posttool`, and `handle_posttool_failure` in `hooks/tool-policy.py`. All three call `write_audit` (line 2121 pretool deny path, line 2157 posttool-common path, line 2247 posttool-failure path). `prompt_guard_enabled()` is default-off and short-circuits before any further controller-only access — so the only PostToolUse-path that runs unconditionally for every tool call is `handle_posttool_common → write_audit`. Single fix site in `bridge_hook_common.py` covers all three.

### Gap 8 recovery source

**marker-stat** (chosen). Pros: marker file exists at a stable location on every v2 install (`$BRIDGE_HOME/state/layout-marker.sh`), is controller-owned by construction, is already used by `bridge-marker-bootstrap.sh` as the identity-of-record. Markerless installs skip the recovery — and they don't enforce marker validation either, so agb works regardless. **state/owner.uid** considered and rejected: would require an install/upgrade-time writer + cleanup for what is essentially a single-shot lookup the marker file already gives us for free. Can be added later if a future surface needs the UID without the marker present.

## Test plan

- [x] `bash -n` clean on `agent-bridge`, the new smoke, `ci-select-smoke.sh`
- [x] `shellcheck` clean on the above
- [x] `python3 -m py_compile hooks/bridge_hook_common.py` clean
- [x] `scripts/lint-heredoc-ban.sh --baseline-check` PASS (no new heredoc-stdin)
- [x] New smoke `1165-track-c-hooks-and-dispatcher` 5/5 PASS
- [x] Sibling smokes still PASS: `hooks`, `1158-marker-controller-uid-exemption`, `1158-marker-load-order`, `1161-marker-readable-by-isolated`, `tool-policy-roster-read-classify`, `admin-hook-exemption`, `1117-cli-help-universal-gate`, `1114-cli-help-contract`
- [ ] Live verification on the Linux QA host's `test_iso` agent (orchestrator/operator): `PostToolUseFailure` flood gone + `agb inbox test_iso` from inside the iso REPL succeeds without `markerless(existing-install)` rejection

(#1165 Track C — Gaps 7-8)