### PR TITLE
fix(iso-paths): helper PermissionError positive-signal + daemon initgroups + lint mutator pattern (#1178)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/bridge-lib.sh"
 bridge_load_roster
 
 usage() {
-  echo "Usage: bash $SCRIPT_DIR/bridge-daemon.sh [--skip-plugin-liveness] <start|ensure|run|status|sync|stop [--force]>"
+  echo "Usage: bash $SCRIPT_DIR/bridge-daemon.sh [--skip-plugin-liveness] <start|ensure|run|status|sync|stop [--force]|restart [--force]>"
 }
 
 daemon_log_event() {
@@ -7437,6 +7437,33 @@ shift || true
 # and exits 0. ALSO defend the silently-dangerous case where the
 # operator types `daemon ensure --help` (or `daemon start --help`)
 # expecting help — historically the dispatcher consumed the verb,
+# Issue #1178 r2 (codex r1 BLOCKING 1, refs PR #1179 review): the daemon
+# supp-groups stale-set warning (`bridge_daemon_warn_if_supp_groups_stale`,
+# above) recommends `agent-bridge daemon restart` as part of the recovery
+# recipe. That recommendation must point at a real subcommand. The
+# existing dispatch had `start`, `ensure`, `stop`, `status`, `sync`,
+# `run`, `run-cron-worker` but no `restart`; bare `bash bridge-daemon.sh
+# restart` fell into the `*)` arm, printed usage, and exited rc=1.
+#
+# This wrapper implements the operator-natural verb as stop → start.
+# `cmd_stop` carries the active-agent guard (#314 Layer 3) and the
+# --force bypass; we pass remaining args through so `daemon restart
+# --force` (the documented warning-recipe form) reaches the guard the
+# same way `daemon stop --force` already does. If stop refuses, restart
+# refuses with the same rc (the operator must address the active-agent
+# state before retrying or pass --force). On a clean stop we call
+# `cmd_start` (not `cmd_run`); start is the public-facing async
+# entry point (forks a background daemon and returns), matching what
+# `agent-bridge daemon start` already does.
+cmd_restart() {
+  local stop_rc=0
+  cmd_stop "$@" || stop_rc=$?
+  if (( stop_rc != 0 )); then
+    return "$stop_rc"
+  fi
+  cmd_start
+}
+
 # matched `ensure)`, and called `cmd_start` unconditionally, starting
 # the daemon. Each verb now scans its remaining args for -h/--help/help
 # and prints usage instead of executing the cmd_*.
@@ -7489,6 +7516,13 @@ case "$CMD" in
       exit 0
     fi
     cmd_stop "$@"
+    ;;
+  restart)
+    if daemon_args_have_help "$@"; then
+      usage
+      exit 0
+    fi
+    cmd_restart "$@"
     ;;
   status)
     if daemon_args_have_help "$@"; then

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -31,6 +31,102 @@ daemon_warn() {
   printf '[%s] [warn] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$message" >&2
 }
 
+# Issue #1178 (cycle 12, Deliverable C): warn at daemon startup when the
+# running process's supplementary-group set is stale compared to the
+# shadow DB. Linux process credentials make this a real silent failure:
+# the controller's supp-group set is established at login (or systemd
+# unit start, or the last `newgrp`) and inherited across fork+exec. A
+# later `usermod -aG` (which scaffold-as-root and the v2 isolation
+# grant runner perform) updates `/etc/group` but does NOT propagate to
+# already-running processes. The daemon then forks children that
+# inherit the stale set, so even after `getent group ab-agent-<a>`
+# shows the controller as a member, spawned hooks/setup helpers still
+# can't `+x` into the per-agent tree. See KNOWN_ISSUES.md §28.
+#
+# Detection: compare the running process's `id -G` (kernel-side
+# supplementary GIDs) against `id -G <user>` (which re-resolves through
+# NSS / getent — picks up any post-login `usermod -aG`). If they differ
+# AND the missing set contains any `ab-agent-*` group, emit a
+# one-line warning pointing at the resolution recipe.
+#
+# Bash-daemon caveat: we cannot fix this in-process — refreshing
+# supp-groups in bash requires either `exec sg <group>` (single-group
+# only, invasive — would lose every TERM/INT/HUP handler the daemon
+# just installed) or a log-out/log-in cycle. So this is a WARN, not an
+# auto-recover. The operator's runbook (OPERATIONS.md §"Supplementary
+# group refresh after first v2 isolated agent") covers the manual
+# resolution.
+#
+# Best-effort: silently no-op on macOS (sys.platform != linux check via
+# uname), when `id`/`getent` are unavailable, or when the comparison
+# can't be made (e.g. systemd-run / nsswitch returning malformed
+# output). The check must never block startup.
+bridge_daemon_warn_if_supp_groups_stale() {
+  # Linux-only: macOS dev hosts don't run v2 isolation and have a
+  # different `id` flag set; skip cleanly so we don't false-positive on
+  # the operator's laptop.
+  case "$(uname -s 2>/dev/null || true)" in
+    Linux) ;;
+    *) return 0 ;;
+  esac
+  command -v id >/dev/null 2>&1 || return 0
+
+  local current_user="" process_gids="" canonical_gids=""
+  # Resolve the daemon's own user name. Prefer pwd via `id -un` (works
+  # even when $USER/$LOGNAME are unset under launchd/systemd).
+  current_user="$(id -un 2>/dev/null || true)"
+  [[ -n "$current_user" ]] || return 0
+
+  # `id -G` (no user arg) reports THIS PROCESS's kernel-side
+  # supplementary GIDs (stale-after-usermod by design).
+  process_gids="$(id -G 2>/dev/null || true)"
+  # `id -G <user>` re-resolves via NSS so the answer reflects the
+  # current /etc/group state (fresh).
+  canonical_gids="$(id -G "$current_user" 2>/dev/null || true)"
+  [[ -n "$process_gids" && -n "$canonical_gids" ]] || return 0
+
+  # Normalize to one-per-line, sorted, deduped — set difference via
+  # comm is the cleanest comparison shape that doesn't require an
+  # associative array per Bash 3.2 compat.
+  local process_sorted canonical_sorted missing_gids
+  process_sorted="$(printf '%s\n' "$process_gids" | tr ' ' '\n' | sort -u)"
+  canonical_sorted="$(printf '%s\n' "$canonical_gids" | tr ' ' '\n' | sort -u)"
+  # Groups present in canonical but NOT in process = stale supp set.
+  missing_gids="$(comm -23 <(printf '%s\n' "$canonical_sorted") <(printf '%s\n' "$process_sorted") 2>/dev/null || true)"
+  [[ -n "$missing_gids" ]] || return 0
+
+  # Resolve each missing GID to a group name and check for ab-agent-*.
+  # `getent group <gid>` returns `name:x:gid:members` — we want field 1.
+  # Iterate via positional-arg expansion (avoids `<<<` here-string per
+  # lint-heredoc-ban contract — footgun #11 family even though this is
+  # a `read` loop not a subprocess feed).
+  local gid name has_iso_drift="" iso_names=""
+  local _saved_ifs="$IFS"
+  IFS=$'\n'
+  # shellcheck disable=SC2086  # word-split missing_gids by IFS=$'\n' on purpose
+  set -- $missing_gids
+  IFS="$_saved_ifs"
+  for gid in "$@"; do
+    [[ -n "$gid" ]] || continue
+    name="$(getent group "$gid" 2>/dev/null | cut -d: -f1)"
+    [[ -n "$name" ]] || continue
+    if [[ "$name" == ab-agent-* ]]; then
+      has_iso_drift="yes"
+      if [[ -z "$iso_names" ]]; then
+        iso_names="$name"
+      else
+        iso_names="$iso_names $name"
+      fi
+    fi
+  done
+
+  [[ -n "$has_iso_drift" ]] || return 0
+
+  daemon_warn "daemon supplementary-group set is stale: missing ab-agent group(s) [${iso_names}]. Spawned children will inherit the stale set, leading to PermissionError on isolated agent paths even though /etc/group shows the controller as a member."
+  daemon_warn "resolution: log out + log back in (refreshes the full group set), or 'newgrp <group>' for a single-group refresh, then restart the daemon ('agent-bridge daemon restart' or 'sudo systemctl restart agent-bridge'). See KNOWN_ISSUES.md §28 / OPERATIONS.md for the systemd/launchd runbook."
+  return 0
+}
+
 # PR #953 r3 (refs #4807, codex r2 P2 #1): centralized dispatcher for the
 # lib/daemon-helpers/*.py extraction helpers. Seven helper invocations
 # downstream previously expanded `python3 "$SCRIPT_DIR/lib/daemon-helpers/
@@ -7027,6 +7123,18 @@ cmd_run() {
 
   BRIDGE_DAEMON_LAST_STEP="startup"
   echo "$$" >"$BRIDGE_DAEMON_PID_FILE"
+
+  # Issue #1178 (cycle 12, Deliverable C): emit a one-line warning when
+  # the daemon's running supp-group set is stale vs the shadow DB. The
+  # daemon cannot self-recover (bash has no `os.initgroups()` analog;
+  # a re-exec to refresh would lose the trap handlers installed above
+  # and orphan the queue-gateway socket child), so this is observability
+  # only — the operator-side runbook (KNOWN_ISSUES.md §28) covers
+  # resolution. Best-effort; never blocks startup. The check fires
+  # before queue_gateway_socket_listener so the warning lands ahead of
+  # any spawned-child error surface that the stale set would cause.
+  bridge_daemon_warn_if_supp_groups_stale || true
+
   BRIDGE_DAEMON_LAST_STEP="queue_gateway_socket_listener"
   if ! bridge_daemon_ensure_queue_gateway_socket_listener; then
     :

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -1310,7 +1310,7 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     # there to avoid raising on the read probe).
     if _safe_path_check("is_symlink", settings_link, _settings_link_owner) or _safe_path_check("exists", settings_link, _settings_link_owner):
         settings_link.unlink()  # noqa: raw-pathlib-controller-only — gated by safe_path_check above; symlink/unlink need direct write access by design (sudo-backed reapply caller has it)
-    settings_link.symlink_to("settings.effective.json")
+    settings_link.symlink_to("settings.effective.json")  # noqa: raw-pathlib-controller-only — paired with the .unlink() above; needs direct write access on the isolated home, sudo-backed reapply caller has it (see #1178 r2)
 
     payload = {
         "isolated_home": str(isolated_home),
@@ -1516,7 +1516,7 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
         if not _safe_path_check("exists", settings_path, os_user):
             rel_target = os.path.relpath(shared_path, start=settings_path.parent)
             try:
-                settings_path.symlink_to(rel_target)
+                settings_path.symlink_to(rel_target)  # noqa: raw-pathlib-controller-only — guarded by try/except PermissionError with sudo ln fallback below (mirrors the .unlink() pattern at line 1504, see #1178 r2)
             except PermissionError:
                 if os_user is None:
                     raise

--- a/bridge-hooks.py
+++ b/bridge-hooks.py
@@ -184,7 +184,7 @@ def load_json(path: Path) -> Any:
 
 
 def save_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — controller-owned hook scaffold; iso-routed callers stage via _ensure_dir_with_sudo upstream
     tmp = path.with_suffix(path.suffix + ".tmp")
     with tmp.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, ensure_ascii=False, indent=2)
@@ -926,7 +926,7 @@ def cmd_status_codex_hooks(args: argparse.Namespace) -> int:
 def cmd_ensure_codex_hooks(args: argparse.Namespace) -> int:
     bridge_home = Path(args.bridge_home).expanduser()
     hooks_path = codex_hooks_path(args)
-    hooks_path.parent.mkdir(parents=True, exist_ok=True)
+    hooks_path.parent.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — codex hooks live under ~/.codex (controller-owned), not under isolated agent tree
     session_command = session_start_hook_command(bridge_home, args.python_bin, "codex")
     stop_command = codex_stop_hook_command(bridge_home, args.python_bin)
     prompt_command = prompt_timestamp_hook_command(bridge_home, args.python_bin, "codex")
@@ -1191,7 +1191,7 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     agent_class = (getattr(args, "agent_class", "") or "") or None
 
     target_dir = isolated_home / ".claude"
-    target_dir.mkdir(parents=True, exist_ok=True)
+    target_dir.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — render flow runs sudo-backed externally when the isolated home denies controller writes
     effective_path = target_dir / "settings.effective.json"
     settings_link = target_dir / "settings.json"
 
@@ -1264,7 +1264,7 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     # 3. Atomic write of the effective file (mode 0644 so the isolated UID
     # can read it; ownership stays with whoever invoked us — controller
     # under the normal start path, root under sudo-backed reapply).
-    effective_path.parent.mkdir(parents=True, exist_ok=True)
+    effective_path.parent.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — already-staged by target_dir.mkdir above; sudo-backed reapply caller has write access
     tmp = effective_path.with_suffix(effective_path.suffix + ".tmp")
     # E2E test on Ubuntu 24.04 VM (2026-05-16) caught a race: under
     # concurrent bootstrap (bridge-bootstrap.sh) + patch first-start +
@@ -1287,7 +1287,7 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     except FileNotFoundError:
         # Race window — parent dir got nuked between mkdir and replace,
         # or tmp got removed by a sibling cleanup. Retry once.
-        effective_path.parent.mkdir(parents=True, exist_ok=True)
+        effective_path.parent.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — retry of the upstream mkdir; same sudo-backed-reapply contract
         try:
             _atomic_write_effective()
         except FileNotFoundError as exc:
@@ -1309,7 +1309,7 @@ def cmd_render_isolated_home_settings(args: argparse.Namespace) -> int:
     # cannot proceed without write access; the safe-probe was only
     # there to avoid raising on the read probe).
     if _safe_path_check("is_symlink", settings_link, _settings_link_owner) or _safe_path_check("exists", settings_link, _settings_link_owner):
-        settings_link.unlink()
+        settings_link.unlink()  # noqa: raw-pathlib-controller-only — gated by safe_path_check above; symlink/unlink need direct write access by design (sudo-backed reapply caller has it)
     settings_link.symlink_to("settings.effective.json")
 
     payload = {
@@ -1390,7 +1390,7 @@ def _ensure_dir_with_sudo(path: Path, os_user: str | None) -> None:
         # ownership via a group-only signature on a controller-owned
         # tree, etc.). When it fails with PermissionError we let it
         # propagate — better surface a real error than fail silently.
-    path.mkdir(parents=True, exist_ok=True)
+    path.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — sudo-first branch above already tried iso escalation; this is the documented controller-direct fallback
 
 
 # #1175: `_safe_path_check` moved to `lib/bridge_iso_paths.py`
@@ -1482,7 +1482,7 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
                 status = "unchanged"
             else:
                 try:
-                    settings_path.unlink()
+                    settings_path.unlink()  # noqa: raw-pathlib-controller-only — guarded by try/except PermissionError with sudo rm fallback below
                 except PermissionError:
                     if os_user is None:
                         raise
@@ -1493,7 +1493,7 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
         elif _safe_path_check("exists", settings_path, os_user):
             backup = next_backup_path(settings_path, os_user)
             try:
-                shutil.copy2(settings_path, backup)
+                shutil.copy2(settings_path, backup)  # noqa: raw-pathlib-controller-only — guarded by try/except PermissionError with sudo cp -p fallback below
             except PermissionError:
                 if os_user is None:
                     raise
@@ -1501,7 +1501,7 @@ def cmd_link_shared_settings(args: argparse.Namespace) -> int:
                 if rc != 0:
                     raise
             try:
-                settings_path.unlink()
+                settings_path.unlink()  # noqa: raw-pathlib-controller-only — guarded by try/except PermissionError with sudo rm fallback below
             except PermissionError:
                 if os_user is None:
                     raise

--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -95,7 +95,7 @@ def load_json(path: Path, default: Any) -> Any:
 
 
 def save_json(path: Path, payload: Any) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — controller-owned scaffold; callers that target an isolated tree route through _isolation_aware_mkdir first
     tmp = path.with_suffix(path.suffix + ".tmp")
     with tmp.open("w", encoding="utf-8") as handle:
         json.dump(payload, handle, ensure_ascii=False, indent=2)
@@ -106,7 +106,7 @@ def save_json(path: Path, payload: Any) -> None:
 
 
 def save_text(path: Path, text: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — controller-owned scaffold; callers that target an isolated tree route through _isolation_aware_mkdir first
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(text, encoding="utf-8")
     os.chmod(tmp, 0o600)
@@ -365,7 +365,15 @@ def _isolation_aware_mkdir(
     if _safe_path_check("exists", path, owner):
         return
     if owner is None:
-        path.mkdir(parents=True, exist_ok=True)
+        # #1178 (cycle 12): post-helper-A `owner is None` is now an
+        # authoritative signal of non-isolated lineage — the helper
+        # uses `_sudo_stat_owner` to recover the isolated owner when
+        # PermissionError fires (the cycle 12 root cause was that
+        # `except OSError: pass` silently mapped "path IS isolated"
+        # to None, producing this raw mkdir at L368 → PermissionError
+        # → operator-visible traceback). With #1178 in place, this raw
+        # mkdir only runs on truly controller-owned trees.
+        path.mkdir(parents=True, exist_ok=True)  # noqa: raw-pathlib-controller-only — owner is None means non-isolated per #1178 helper contract
         return
     # Resolve the target group. Priority: explicit `group=` >
     # v2-helper-via-`agent=` > `id -gn` legacy fallback. The v2 helper

--- a/lib/bridge_iso_paths.py
+++ b/lib/bridge_iso_paths.py
@@ -140,11 +140,31 @@ def isolated_workdir_owner(path: Path) -> str | None:
     truncation-strategy mismatch (codex r1 #5726 BLOCKING #2 finding)
     means string-replacing `ab-agent-` → `agent-bridge-` is wrong for
     long agent names; the gid linkage avoids it.
+
+    #1178 (cycle 12 architectural root): a `lstat()` that raises
+    `PermissionError` is itself a POSITIVE signal of isolated lineage —
+    the controller is blind to the inode precisely BECAUSE the path is
+    under a v2-mode/group-protected tree the controller user is not in.
+    The pre-#1178 walker treated `OSError` uniformly as "skip and walk
+    up", so a leaf-and-every-ancestor that all denied PermissionError
+    fell through to return None — and the caller (e.g.
+    `bridge-setup.py:_isolation_aware_mkdir`) then took the
+    `owner is None` branch and ran a raw `path.mkdir(parents=True,
+    exist_ok=True)` against the isolated tree, which immediately
+    re-raised PermissionError and crashed `setup teams|telegram|discord`.
+    The fix: when a `PermissionError` (subclass of `OSError`) interrupts
+    lstat, recover via `sudo -n stat -c %U` (GNU `stat`) or
+    `sudo -n stat -f %Su` (BSD `stat` on macOS dev hosts), which reads
+    the owner under root. A successful sudo-stat that returns an
+    `agent-bridge-*` name is the authoritative owner. The walker keeps
+    climbing on FileNotFoundError and other plain OSError so a missing
+    leaf still resolves via the existing parent.
     """
     if sys.platform != "linux":
         return None
     candidate: Path | None = path
     stat_result = None
+    sudo_owner: str | None = None
     while candidate is not None:
         try:
             # lstat (not stat): a workdir that is itself a symlink (rare
@@ -155,6 +175,19 @@ def isolated_workdir_owner(path: Path) -> str | None:
             # the link itself is the right signal.
             stat_result = candidate.lstat()
             break
+        except PermissionError:
+            # POSITIVE signal: controller is blind to this inode because
+            # the tree is v2-mode/group-protected. Recover via sudo-stat
+            # which runs under root and reads the owner regardless of
+            # the controller's group set. A successful resolution wins
+            # outright; otherwise fall through to walk up.
+            sudo_owner = _sudo_stat_owner(candidate)
+            if sudo_owner and sudo_owner.startswith("agent-bridge-"):
+                return sudo_owner
+            parent = candidate.parent
+            if parent == candidate:
+                return None
+            candidate = parent
         except OSError:
             parent = candidate.parent
             if parent == candidate:
@@ -193,18 +226,101 @@ def resolve_isolated_owner_for_path(path: Path) -> str | None:
     reliable because `mkdir` running as the controller would create a
     controller-owned dir, hiding the isolated lineage from a single-
     level lstat.
+
+    #1178 (cycle 12 architectural root): `path.exists()` raising
+    `PermissionError` is a POSITIVE signal of isolated lineage — the
+    controller cannot stat the inode precisely BECAUSE the path lives
+    under a v2-mode/group-protected tree. The pre-#1178 helper swallowed
+    PermissionError under the broad `except OSError: pass` and walked up
+    blindly, so on a chain where every ancestor denied PermissionError
+    (e.g. `/data/.../workdir/.teams` where `workdir` is mode 2770 owned
+    by the isolated UID and the controller is not in the per-agent
+    group), the walker fell off the root and returned None. Callers then
+    took the `owner is None` branch and ran raw mkdir/copy/unlink
+    against the isolated tree, raising PermissionError before the sudo
+    fallback ever fired. The fix: when PermissionError interrupts
+    `exists()`, recover via `_sudo_stat_owner` (which uses `sudo -n stat`
+    to read the owner under root) before walking up — that's the correct
+    signal that the path IS isolated.
     """
     cur = path
     while True:
         try:
             if cur.exists():
                 return isolated_workdir_owner(cur)
+        except PermissionError:
+            # POSITIVE signal: the controller is blind because the path
+            # is isolated. Try sudo-stat at this level before walking up.
+            owner = _sudo_stat_owner(cur)
+            if owner and owner.startswith("agent-bridge-"):
+                return owner
+            # sudo-stat failed (no sudo, no NOPASSWD, path truly
+            # missing). Fall through to walk up — a parent dir's
+            # successful sudo-stat may still reveal the lineage.
         except OSError:
             pass
         parent = cur.parent
         if parent == cur:
             return None
         cur = parent
+
+
+def _sudo_stat_owner(path: Path) -> str | None:
+    """Return the owner username of `path` via `sudo -n stat`, or None.
+
+    #1178: when the controller's pathlib probe raises PermissionError on
+    an isolated tree, the controller IS blind to that inode but root
+    still sees it. Escalate via `sudo -n stat` to read the owner — the
+    answer is the authoritative `agent-bridge-<slug>` linux-user
+    provisioned for that agent.
+
+    Tries GNU `stat -c %U` first (Linux production hosts) and falls back
+    to BSD `stat -f %Su` (macOS dev hosts that may surface a
+    `PermissionError` via a different mechanism, e.g. SIP-restricted
+    paths). Returns None on:
+      - sudo not installed (`FileNotFoundError`)
+      - sudo policy/auth failure (rc!=0 with `sudo:` stderr prefix)
+      - both `stat` forms failing (path truly missing, or stat refused
+        the call under root for an unrelated reason)
+      - `TimeoutExpired` (PAM/NSS stuck — fail-closed)
+      - empty stdout from a successful invocation (shouldn't happen but
+        treat as no-info)
+
+    The 5s timeout mirrors `safe_path_check`'s budget for the same
+    PAM/NSS scenarios. stderr discrimination mirrors the same module's
+    `sudo:`-prefix policy-failure detection so a NOPASSWD denial doesn't
+    masquerade as "path absent".
+    """
+    for spec in ("-c", "-f"):
+        # GNU: stat -c %U <path>
+        # BSD: stat -f %Su <path>
+        fmt = "%U" if spec == "-c" else "%Su"
+        cmd = ["sudo", "-n", "stat", spec, fmt, str(path)]
+        try:
+            result = subprocess.run(
+                cmd,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError):
+            return None
+        stderr = (result.stderr or "").strip()
+        if result.returncode == 0:
+            owner = (result.stdout or "").strip()
+            if owner:
+                return owner
+            # rc=0 but empty stdout — shouldn't happen; try the next form.
+            continue
+        if stderr.startswith("sudo:"):
+            # sudo policy/auth failure — no point trying the other format,
+            # both will hit the same gate.
+            return None
+        # Non-sudo error (e.g. GNU `stat` rejecting BSD flags or vice
+        # versa, or `stat` reporting the path missing). Try the next
+        # format spec; if that also fails we return None below.
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -494,6 +610,11 @@ _safe_path_check = safe_path_check
 _safe_read_env = safe_read_env
 _safe_load_json = safe_load_json
 _parse_dotenv_text = parse_dotenv_text
+# `_sudo_stat_owner` is #1178 private helper used by the cycle 12 entry
+# points (resolve_isolated_owner_for_path + isolated_workdir_owner). It
+# is named with a leading underscore at `def` time, so no separate
+# alias is needed; the `__all__` entry below lets test harnesses
+# monkey-patch `mod._sudo_stat_owner` if they want a no-sudo fixture.
 
 
 __all__ = [
@@ -514,4 +635,6 @@ __all__ = [
     "_safe_read_env",
     "_safe_load_json",
     "_parse_dotenv_text",
+    # #1178 private helper (exposed for test introspection only)
+    "_sudo_stat_owner",
 ]

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift
 
 
 }
@@ -293,7 +293,14 @@ select_for_path() {
       # idempotency, L1873 mattermost MCP, L1995 channel access preserve),
       # and the lint-raw-pathlib-on-isolated regression guard cannot
       # silently regress.
-      add_required queue upgrade-conflicts-lifecycle status-engine-detect 835-static-admin-launch 1155-bootstrap-skill-guard 1165-track-a-scaffold-modes 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit
+      # Issue #1178 (cycle 12 architectural root): bridge-setup.py's
+      # `_isolation_aware_mkdir` traceback at L368 was unblocked by
+      # routing the new `_sudo_stat_owner` recovery in
+      # `lib/bridge_iso_paths.py`. The L368 raw mkdir is now noqa'd as
+      # the controller-owned post-helper fallback. Pull
+      # 1178-helper-contract-daemon-supp on every bridge-setup.py move
+      # so the L368 reproducer + extended lint baseline cannot regress.
+      add_required queue upgrade-conflicts-lifecycle status-engine-detect 835-static-admin-launch 1155-bootstrap-skill-guard 1165-track-a-scaffold-modes 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp
       add_integration integration-minimal
       ;;
 
@@ -356,7 +363,13 @@ select_for_path() {
       # 1115-cli-usage-drift on every cron dispatcher move so a future
       # PR cannot regress an internal subcommand back into the public
       # surface (or drop a public one).
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift
+      # Issue #1178 (cycle 12, Deliverable C): bridge-daemon.sh gained
+      # a startup supplementary-group staleness warning
+      # (bridge_daemon_warn_if_supp_groups_stale). Pull
+      # 1178-helper-contract-daemon-supp on every bridge-daemon.sh move
+      # so the warning behavior + macOS no-op gate cannot regress
+      # silently.
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift 1178-helper-contract-daemon-supp
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -457,7 +470,14 @@ select_for_path() {
       # shared module risks breaking both surfaces simultaneously;
       # pull the consolidated regression smoke + the canonical-shape
       # 1170 smoke + the per-area smokes for both consumers.
-      add_required 1175-exhaustive-pathlib-audit 1170-safe-path-check-sudo-escalate 1165-track-a-scaffold-modes 1165-track-c-hooks-and-dispatcher hooks
+      # Issue #1178 (cycle 12 architectural root): the canonical
+      # helpers gained a `_sudo_stat_owner` recovery so a
+      # PermissionError on lstat()/exists() during the walker is no
+      # longer silently swallowed. Pull 1178-helper-contract-daemon-supp
+      # on every lib/bridge_iso_paths.py / lint /
+      # raw-pathlib-baseline.txt move so the helper contract + lint
+      # extension + boomerang test cannot regress.
+      add_required 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp 1170-safe-path-check-sudo-escalate 1165-track-a-scaffold-modes 1165-track-c-hooks-and-dispatcher hooks
       add_integration integration-minimal
       ;;
 
@@ -721,7 +741,12 @@ select_for_path() {
       # rerender / scan flow with PermissionError tracebacks (the
       # PostToolUseFailure flood that drove #1165 Gap 7). Pull
       # 1175-exhaustive-pathlib-audit on every bridge-hooks.py move.
-      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys admin-hook-exemption 1067-codex-provisioning 1120-controller-ops-isolated 1139-link-shared-settings-perm 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1165-track-c-hooks-and-dispatcher 1175-exhaustive-pathlib-audit
+      # Issue #1178 (cycle 12): bridge-hooks.py gained noqa'd mutator
+      # sites (cmd_render_isolated_home_settings, _ensure_dir_with_sudo
+      # fallback, cmd_link_shared_settings sudo-recovery loop) under
+      # the extended lint surface. Pull 1178-helper-contract-daemon-supp
+      # so the noqa contract + helper integration cannot regress.
+      add_required hooks upgrade-shared-settings-propagate managed-autocompact-window isolated-settings-rendering per-agent-settings-rendering shared-settings-preserve-user-keys admin-hook-exemption 1067-codex-provisioning 1120-controller-ops-isolated 1139-link-shared-settings-perm 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1165-track-c-hooks-and-dispatcher 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp
       add_integration integration-minimal
       ;;
 

--- a/scripts/lint-raw-pathlib-on-isolated.sh
+++ b/scripts/lint-raw-pathlib-on-isolated.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash
 # scripts/lint-raw-pathlib-on-isolated.sh — ratchet lint preventing NEW raw
-# `Path.exists()` / `is_file()` / `is_dir()` / `is_symlink()` / `stat()`
-# calls in `bridge-setup.py` + `bridge-hooks.py` that could land on paths
-# under a v2-isolated agent's tree.
+# pathlib metadata probes AND raw pathlib mutators in `bridge-setup.py` +
+# `bridge-hooks.py` that could land on paths under a v2-isolated agent's
+# tree.
+#
+# Caught patterns:
+#   - probes : `.exists()`, `.is_file()`, `.is_dir()`, `.is_symlink()`,
+#              `.stat()`
+#   - mutators (#1178 Deliverable Lint): `.mkdir(`, `.unlink(`, `.touch(`,
+#              `.rmdir(`, `shutil.copy(`, `shutil.copy2(`, `shutil.move(`,
+#              `shutil.rmtree(`, `os.makedirs(`, `os.remove(`, `os.rename(`
 #
 # Context: cycles 9-10-11 (#1165 → #1170 → #1175) all surfaced the same
 # class of bug — a raw pathlib metadata probe inside the controller-side
@@ -17,6 +24,14 @@
 # wrapper (`_safe_path_check` / `_safe_read_env` / `_safe_load_json` from
 # the shared module) OR carry an explicit `# noqa: raw-pathlib-controller-only`
 # whitelist marker.
+#
+# Cycle 12 (#1178) extended the pattern to mutators after a setup teams
+# rerun hit a raw `path.mkdir(parents=True, exist_ok=True)` in the
+# `owner is None` branch of `_isolation_aware_mkdir` (the helper
+# returned None because PermissionError was incorrectly swallowed as
+# "no isolated lineage" — fixed in the same PR by routing through the
+# new `_sudo_stat_owner` recovery). The lint extension catches the
+# same class of bugs forward.
 #
 # ## Why two surfaces and not one
 #
@@ -70,12 +85,26 @@ declare -a TARGETS=(
   "bridge-hooks.py"
 )
 
-# Pattern: match `.exists()`, `.is_file()`, `.is_dir()`, `.is_symlink()`,
-# `.stat()` immediately following an identifier-or-`)`-or-`]` character.
-# This catches `path.exists()`, `entry.is_dir()`, `result.stat()`, etc.
-# Does NOT match `.exists` in docstrings (which usually appear as
-# `Path.exists()` in backticks — those are filtered downstream).
-danger_pattern='\.(exists|is_file|is_dir|is_symlink|stat)\(\)'
+# Pattern: match probe + mutator surfaces.
+#
+# Probes (zero-arg): `.exists()`, `.is_file()`, `.is_dir()`,
+# `.is_symlink()`, `.stat()` — these always carry empty parens.
+#
+# Mutators: open-paren only (the calls may carry kwargs like
+# `parents=True, exist_ok=True` for `.mkdir`, or `missing_ok=True` for
+# `.unlink`, or positional args for `shutil.copy*` / `os.rename`). Match
+# the start of the call shape (`.mkdir(`, etc.) and let argument
+# matching extend naturally to the line's content; argv content does
+# not need to be re-validated by the pattern.
+#
+# `shutil.copy(` is matched separately so it does not also match
+# `shutil.copy2(` (the open-paren anchor would otherwise double-count).
+# Same for `os.remove(` vs `os.rename(`.
+#
+# The pattern is anchored to a non-identifier character so a function
+# definition like `def mkdir_unrelated(` does not trip the lint
+# (`def mkdir_unrelated(` does not contain `.mkdir(`).
+danger_pattern='\.(exists|is_file|is_dir|is_symlink|stat)\(\)|\.(mkdir|unlink|touch|rmdir)\(|shutil\.(copy|copy2|move|rmtree)\(|os\.(makedirs|remove|rename)\('
 
 # Whitelist marker: a line with `# noqa: raw-pathlib-controller-only`
 # anywhere in it is skipped (deliberate controller-only call site).
@@ -109,8 +138,11 @@ list_sites() {
         idx2 = index(rest, ":")
         content = substr(rest, idx2 + 1)
         # If the danger pattern is wrapped in backticks on this line, treat as docstring.
-        # Simple heuristic: presence of "`...exists()`" / "`...is_dir()`" etc.
+        # Simple heuristic: presence of "`...exists()`" / "`...is_dir()`" / "`...mkdir(`" etc.
         if (content ~ /`[^`]*\.(exists|is_file|is_dir|is_symlink|stat)\(\)/) next
+        if (content ~ /`[^`]*\.(mkdir|unlink|touch|rmdir)\(/) next
+        if (content ~ /`[^`]*shutil\.(copy|copy2|move|rmtree)\(/) next
+        if (content ~ /`[^`]*os\.(makedirs|remove|rename)\(/) next
         # Also skip lines that are clearly inside docstring blocks
         # (lines starting with quote characters of triple-quote, or
         # entirely-text continuation lines that contain no `(` other
@@ -215,11 +247,13 @@ run_self_test() {
   # shellcheck disable=SC2064
   trap "rm -f '$fixture'" RETURN
 
-  # Build fixture with one positive + one whitelisted + one comment + one
-  # docstring backtick + one nested.
+  # Build fixture with positives across probe + mutator surfaces +
+  # whitelisted + comment + docstring backtick samples.
   cat >"$fixture" <<'PYEOF'
 # Comment line mentioning path.exists() — should NOT match.
     """Docstring mentioning `path.exists()` — should NOT match either."""
+    """Docstring mentioning `path.mkdir(parents=True)` — should NOT match."""
+    """Docstring mentioning `shutil.copy2(a, b)` — should NOT match."""
 def foo():
     return path.exists()
 def bar():
@@ -227,12 +261,27 @@ def bar():
 def baz():
     if entry.is_file():
         return True
+def quux():
+    path.mkdir(parents=True, exist_ok=True)
+def qux():
+    target.unlink()  # noqa: raw-pathlib-controller-only — whitelisted
+def freem():
+    shutil.copy2(src, dst)
+def garply():
+    os.makedirs(path)
 PYEOF
 
-  # Expected positives: 2 (`path.exists()` line + `entry.is_file()` line).
+  # Expected positives:
+  #   path.exists()    — line 6
+  #   entry.is_file()  — line 10
+  #   path.mkdir(...)  — line 13 (NEW #1178)
+  #   shutil.copy2     — line 17 (NEW #1178)
+  #   os.makedirs      — line 19 (NEW #1178)
+  # Filtered out: comment line, 3 docstring lines (backtick-wrapped),
+  # 2 whitelist-marked lines.
   local got expected
   got="$(count_sites "$fixture")"
-  expected=2
+  expected=5
   if [[ "$got" != "$expected" ]]; then
     echo "[lint-raw-pathlib-on-isolated] SELF-TEST FAIL: expected $expected, got $got" >&2
     echo "[lint-raw-pathlib-on-isolated] matches:" >&2

--- a/scripts/lint-raw-pathlib-on-isolated.sh
+++ b/scripts/lint-raw-pathlib-on-isolated.sh
@@ -92,19 +92,26 @@ declare -a TARGETS=(
 #
 # Mutators: open-paren only (the calls may carry kwargs like
 # `parents=True, exist_ok=True` for `.mkdir`, or `missing_ok=True` for
-# `.unlink`, or positional args for `shutil.copy*` / `os.rename`). Match
-# the start of the call shape (`.mkdir(`, etc.) and let argument
-# matching extend naturally to the line's content; argv content does
-# not need to be re-validated by the pattern.
+# `.unlink`, or positional args for `shutil.copy*` / `os.rename` /
+# `.symlink_to`). Match the start of the call shape (`.mkdir(`, etc.)
+# and let argument matching extend naturally to the line's content;
+# argv content does not need to be re-validated by the pattern.
 #
 # `shutil.copy(` is matched separately so it does not also match
 # `shutil.copy2(` (the open-paren anchor would otherwise double-count).
 # Same for `os.remove(` vs `os.rename(`.
 #
+# `.symlink_to(` (#1178 r2 codex r1 BLOCKING 2): the pre-r2 pattern
+# omitted symlink mutators, leaving raw `path.symlink_to(target)` sites
+# in bridge-hooks.py unlinted even though they mutate isolated-setting
+# paths the same way `.unlink()` does. Adding it here closes that gap
+# and makes the lint catch future regressions across the full pathlib
+# mutator surface.
+#
 # The pattern is anchored to a non-identifier character so a function
 # definition like `def mkdir_unrelated(` does not trip the lint
 # (`def mkdir_unrelated(` does not contain `.mkdir(`).
-danger_pattern='\.(exists|is_file|is_dir|is_symlink|stat)\(\)|\.(mkdir|unlink|touch|rmdir)\(|shutil\.(copy|copy2|move|rmtree)\(|os\.(makedirs|remove|rename)\('
+danger_pattern='\.(exists|is_file|is_dir|is_symlink|stat)\(\)|\.(mkdir|unlink|touch|rmdir|symlink_to)\(|shutil\.(copy|copy2|move|rmtree)\(|os\.(makedirs|remove|rename)\('
 
 # Whitelist marker: a line with `# noqa: raw-pathlib-controller-only`
 # anywhere in it is skipped (deliberate controller-only call site).
@@ -140,7 +147,7 @@ list_sites() {
         # If the danger pattern is wrapped in backticks on this line, treat as docstring.
         # Simple heuristic: presence of "`...exists()`" / "`...is_dir()`" / "`...mkdir(`" etc.
         if (content ~ /`[^`]*\.(exists|is_file|is_dir|is_symlink|stat)\(\)/) next
-        if (content ~ /`[^`]*\.(mkdir|unlink|touch|rmdir)\(/) next
+        if (content ~ /`[^`]*\.(mkdir|unlink|touch|rmdir|symlink_to)\(/) next
         if (content ~ /`[^`]*shutil\.(copy|copy2|move|rmtree)\(/) next
         if (content ~ /`[^`]*os\.(makedirs|remove|rename)\(/) next
         # Also skip lines that are clearly inside docstring blocks
@@ -254,6 +261,7 @@ run_self_test() {
     """Docstring mentioning `path.exists()` — should NOT match either."""
     """Docstring mentioning `path.mkdir(parents=True)` — should NOT match."""
     """Docstring mentioning `shutil.copy2(a, b)` — should NOT match."""
+    """Docstring mentioning `link.symlink_to("x")` — should NOT match."""
 def foo():
     return path.exists()
 def bar():
@@ -269,19 +277,22 @@ def freem():
     shutil.copy2(src, dst)
 def garply():
     os.makedirs(path)
+def waldo():
+    link.symlink_to("target")
 PYEOF
 
   # Expected positives:
-  #   path.exists()    — line 6
-  #   entry.is_file()  — line 10
-  #   path.mkdir(...)  — line 13 (NEW #1178)
-  #   shutil.copy2     — line 17 (NEW #1178)
-  #   os.makedirs      — line 19 (NEW #1178)
-  # Filtered out: comment line, 3 docstring lines (backtick-wrapped),
-  # 2 whitelist-marked lines.
+  #   path.exists()       — line 7
+  #   entry.is_file()     — line 11
+  #   path.mkdir(...)     — line 14 (NEW #1178)
+  #   shutil.copy2        — line 18 (NEW #1178)
+  #   os.makedirs         — line 20 (NEW #1178)
+  #   link.symlink_to(...) — line 22 (NEW #1178 r2)
+  # Filtered out: comment line, 4 docstring lines (backtick-wrapped,
+  # including the new symlink_to docstring), 2 whitelist-marked lines.
   local got expected
   got="$(count_sites "$fixture")"
-  expected=5
+  expected=6
   if [[ "$got" != "$expected" ]]; then
     echo "[lint-raw-pathlib-on-isolated] SELF-TEST FAIL: expected $expected, got $got" >&2
     echo "[lint-raw-pathlib-on-isolated] matches:" >&2

--- a/scripts/smoke/1178-helper-contract-daemon-supp.sh
+++ b/scripts/smoke/1178-helper-contract-daemon-supp.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1178-helper-contract-daemon-supp.sh — Issue #1178.
+#
+# Cycle 12 architectural root: beta16's #1175 sweep landed clean but
+# `setup teams test_iso2` STILL traceback at bridge-setup.py L368
+# (`path.mkdir(parents=True, exist_ok=True)` on an isolated path). Three
+# concurrent root causes, all addressed in this PR:
+#
+#   A. Helper layer bug — `resolve_isolated_owner_for_path` swallowed
+#      `PermissionError` as `OSError: pass` and treated "controller is
+#      blind to inode" as "no isolated lineage". The opposite of the
+#      truth — PermissionError IS the positive signal of isolation.
+#      Returning None then steered `_isolation_aware_mkdir` into the
+#      `owner is None` branch, which ran a raw mkdir and raised
+#      PermissionError. Fix: recover via `_sudo_stat_owner` (new helper,
+#      uses `sudo -n stat` to read the owner under root).
+#   C. Daemon supp-groups stale — bash daemon cannot self-refresh the
+#      Linux kernel supplementary-group set (no `os.initgroups()` analog
+#      in bash; `exec sg` is invasive). Emit a startup WARNING when the
+#      running process's `id -G` differs from the canonical `id -G <user>`
+#      and the missing set contains `ab-agent-*`. Operator runbook in
+#      KNOWN_ISSUES.md §28 covers the manual resolution.
+#   Lint. Extended `scripts/lint-raw-pathlib-on-isolated.sh` to catch
+#      mutators (`.mkdir(`, `.unlink(`, `.touch(`, `.rmdir(`,
+#      `shutil.copy/copy2/move/rmtree(`, `os.makedirs/remove/rename(`),
+#      not just probes (`.exists()/is_file()/is_dir()/stat()`). Boomerang
+#      test: temporarily add `Path('.').mkdir()` → lint fails.
+#
+# Tests:
+#   T1: `resolve_isolated_owner_for_path` PermissionError → sudo-stat
+#       fallback → returns owner (regression for #1178 helper swallow).
+#   T1b: `isolated_workdir_owner` PermissionError on lstat → sudo-stat
+#       fallback returns owner (the same helper sees the same class of
+#       trip from a different entry point).
+#   T2: legacy non-isolated path → walks normally (no regression on
+#       shared-mode).
+#   T3: daemon supp-groups warning fires when `id -G` (process) is
+#       missing an `ab-agent-*` GID that `id -G <user>` (canonical) has.
+#       Stubs `id` / `getent` / `uname` via a shim PATH directory.
+#   T3b: daemon warning is silent on macOS (uname != Linux).
+#   T4: lint catches NEW raw mutator pattern. Boomerang: inject
+#       `Path('.').mkdir()` into a scratch copy of bridge-setup.py,
+#       assert the lint fails. Then inject `shutil.copy(...)`, assert
+#       the lint also fails on that pattern.
+#   T5: setup teams L368 reproducer — assert `_isolation_aware_mkdir`
+#       on a blind-but-isolated path does NOT raise PermissionError
+#       when `_sudo_stat_owner` is stubbed to return the owner.
+#
+# Host-agnostic: every Linux-specific behavior is exercised via PATH
+# shims (`id`, `getent`, `uname`, `sudo`, `stat`) and Python `subprocess`
+# stubs. No real `agent-bridge-*` users. Works on Linux + macOS.
+#
+# Footgun #11: every Python harness built with `printf '%s\n' >file`
+# and run as `python3 <file>`; PATH-shim scripts assembled the same
+# way. No `<<<` here-string or `<<EOF` feeds into subprocess capture.
+
+set -uo pipefail
+
+SMOKE_NAME="1178-helper-contract-daemon-supp"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+# ---------------------------------------------------------------------------
+# T1, T1b, T2, T5: Python harness against the shared module + bridge-setup.
+# ---------------------------------------------------------------------------
+
+HARNESS="$SMOKE_TMP_ROOT/run.py"
+: >"$HARNESS"
+# shellcheck disable=SC2129  # per-line emit keeps footgun #11 off the table
+{
+  printf '%s\n' '#!/usr/bin/env python3'
+  printf '%s\n' '"""Issue #1178 smoke: helper PermissionError → sudo-stat fallback + _isolation_aware_mkdir L368 reproducer."""'
+  printf '%s\n' 'import sys, importlib.util, subprocess'
+  printf '%s\n' 'from pathlib import Path'
+  printf '%s\n' 'repo = sys.argv[1]'
+  printf '%s\n' 'tmp = Path(sys.argv[2])'
+  printf '%s\n' ''
+  printf '%s\n' 'sys.path.insert(0, repo + "/lib")'
+  printf '%s\n' 'import bridge_iso_paths as iso  # type: ignore'
+  printf '%s\n' ''
+  printf '%s\n' 'def load_module(name, path):'
+  printf '%s\n' '    spec = importlib.util.spec_from_file_location(name, path)'
+  printf '%s\n' '    mod = importlib.util.module_from_spec(spec)'
+  printf '%s\n' '    spec.loader.exec_module(mod)'
+  printf '%s\n' '    return mod'
+  printf '%s\n' ''
+  printf '%s\n' 'bsetup = load_module("bridge_setup", repo + "/bridge-setup.py")'
+  printf '%s\n' ''
+  printf '%s\n' '# Force linux platform for the lstat-walker tests (helper short-'
+  printf '%s\n' '# circuits to None on non-linux; the cycle 12 bug is linux-only).'
+  printf '%s\n' 'iso.sys.platform = "linux"'
+  printf '%s\n' ''
+  printf '%s\n' '# Synthetic Path subclasses that raise PermissionError on the relevant probe.'
+  printf '%s\n' 'class BlindExistsPath(type(Path())):  # type: ignore[misc]'
+  printf '%s\n' '    """exists() raises PermissionError; everything else works."""'
+  printf '%s\n' '    def exists(self):'
+  printf '%s\n' '        raise PermissionError(13, "Permission denied", str(self))'
+  printf '%s\n' ''
+  printf '%s\n' 'class BlindLstatPath(type(Path())):  # type: ignore[misc]'
+  printf '%s\n' '    """lstat() raises PermissionError; exists() defers to lstat path so also raises."""'
+  printf '%s\n' '    def lstat(self):'
+  printf '%s\n' '        raise PermissionError(13, "Permission denied", str(self))'
+  printf '%s\n' ''
+  printf '%s\n' '# Capture the original _sudo_stat_owner for restore between tests.'
+  printf '%s\n' 'original_sudo_stat_owner = iso._sudo_stat_owner'
+  printf '%s\n' ''
+  printf '%s\n' '# ---------- T1: resolve_isolated_owner_for_path PermissionError → sudo-stat fallback ----------'
+  printf '%s\n' '# Pre-#1178: PermissionError was swallowed under `except OSError: pass` and the'
+  printf '%s\n' '# walker climbed up blindly, returning None on a chain where every ancestor'
+  printf '%s\n' '# denied the controller. Post-#1178: the sudo-stat fallback runs first and'
+  printf '%s\n' '# returns the authoritative owner.'
+  printf '%s\n' ''
+  printf '%s\n' '# T1a: PermissionError on .exists() AND sudo-stat returns owner → owner wins'
+  printf '%s\n' 'iso._sudo_stat_owner = lambda p: "agent-bridge-iso2"'
+  printf '%s\n' 'blind = BlindExistsPath(str(tmp / "iso2/workdir/.teams"))'
+  printf '%s\n' 'owner = iso.resolve_isolated_owner_for_path(blind)'
+  printf '%s\n' 'assert owner == "agent-bridge-iso2", "T1a: expected agent-bridge-iso2 from sudo-stat recovery, got " + repr(owner)'
+  printf '%s\n' 'print("T1a PASS: resolve_isolated_owner_for_path PermissionError → _sudo_stat_owner returns owner")'
+  printf '%s\n' ''
+  printf '%s\n' '# T1b: PermissionError + sudo-stat returns None on leaf, then returns owner on parent'
+  printf '%s\n' '# (walker keeps climbing when sudo-stat at the leaf also fails).'
+  printf '%s\n' 'calls = []'
+  printf '%s\n' 'def stat_parent_only(p):'
+  printf '%s\n' '    calls.append(str(p))'
+  printf '%s\n' '    if str(p).endswith("/.teams"):'
+  printf '%s\n' '        return None'
+  printf '%s\n' '    return "agent-bridge-iso2"'
+  printf '%s\n' 'iso._sudo_stat_owner = stat_parent_only'
+  printf '%s\n' 'blind = BlindExistsPath(str(tmp / "iso2/workdir/.teams"))'
+  printf '%s\n' 'owner = iso.resolve_isolated_owner_for_path(blind)'
+  printf '%s\n' 'assert owner == "agent-bridge-iso2", "T1b: walker should climb after leaf sudo-stat fails, got " + repr(owner)'
+  printf '%s\n' 'assert len(calls) >= 2, "T1b: walker should have called sudo-stat at least twice (leaf + parent), got calls=" + repr(calls)'
+  printf '%s\n' 'print("T1b PASS: walker climbs from blind leaf through blind parent → owner via parent sudo-stat")'
+  printf '%s\n' ''
+  printf '%s\n' '# T1c: PRE-#1178 REGRESSION CONTRACT — disable _sudo_stat_owner (returns None),'
+  printf '%s\n' '# assert resolve_isolated_owner_for_path returns None on a chain where every'
+  printf '%s\n' '# ancestor raises PermissionError. This is the pre-#1178 behavior; the helper'
+  printf '%s\n' '# fix is what changes the post-#1178 contract from "None" to "owner via sudo-stat".'
+  printf '%s\n' 'iso._sudo_stat_owner = lambda p: None'
+  printf '%s\n' 'blind = BlindExistsPath(str(tmp / "iso2/workdir/.teams"))'
+  printf '%s\n' 'owner = iso.resolve_isolated_owner_for_path(blind)'
+  printf '%s\n' 'assert owner is None, "T1c: without sudo-stat recovery + blind chain → returns None (pre-fix shape), got " + repr(owner)'
+  printf '%s\n' 'print("T1c PASS: regression contract — disabling sudo-stat fallback reproduces pre-#1178 None return")'
+  printf '%s\n' ''
+  printf '%s\n' '# ---------- T1d: isolated_workdir_owner PermissionError → sudo-stat fallback ----------'
+  printf '%s\n' '# The same class of bug existed in isolated_workdir_owner: lstat raising'
+  printf '%s\n' '# PermissionError fell through `except OSError: pass` and the walker climbed up'
+  printf '%s\n' '# without sudo-stat recovery. Post-#1178 the lstat-PermissionError branch tries'
+  printf '%s\n' '# sudo-stat first and returns the owner immediately on success.'
+  printf '%s\n' 'iso._sudo_stat_owner = lambda p: "agent-bridge-iso2" if str(p).endswith("/.teams") else None'
+  printf '%s\n' 'blind = BlindLstatPath(str(tmp / "iso2/workdir/.teams"))'
+  printf '%s\n' 'owner = iso.isolated_workdir_owner(blind)'
+  printf '%s\n' 'assert owner == "agent-bridge-iso2", "T1d: lstat PermissionError → sudo-stat recovery, got " + repr(owner)'
+  printf '%s\n' 'print("T1d PASS: isolated_workdir_owner lstat PermissionError → _sudo_stat_owner returns owner")'
+  printf '%s\n' ''
+  printf '%s\n' '# Restore for subsequent tests.'
+  printf '%s\n' 'iso._sudo_stat_owner = original_sudo_stat_owner'
+  printf '%s\n' ''
+  printf '%s\n' '# ---------- T2: legacy non-isolated path walks normally ----------'
+  printf '%s\n' '# Direct shared-mode regression: a controller-owned path must return None'
+  printf '%s\n' '# (no isolated lineage), not trigger any sudo subprocess. The helper short-'
+  printf '%s\n' '# circuits before _sudo_stat_owner is ever called when exists() succeeds.'
+  printf '%s\n' 'shared = tmp / "controller-owned/some/dir"'
+  printf '%s\n' 'shared.mkdir(parents=True)'
+  printf '%s\n' 'iso._sudo_stat_owner = lambda p: (_ for _ in ()).throw(AssertionError("must not be called on shared path"))'
+  printf '%s\n' 'owner = iso.resolve_isolated_owner_for_path(shared)'
+  printf '%s\n' 'assert owner is None, "T2: shared-mode path must return None (no agent-bridge-* owner), got " + repr(owner)'
+  printf '%s\n' 'print("T2 PASS: shared-mode path walks normally (no sudo subprocess invoked, returns None)")'
+  printf '%s\n' ''
+  printf '%s\n' '# Restore.'
+  printf '%s\n' 'iso._sudo_stat_owner = original_sudo_stat_owner'
+  printf '%s\n' ''
+  printf '%s\n' '# ---------- T5: setup teams L368 reproducer ----------'
+  printf '%s\n' '# `_isolation_aware_mkdir` on a blind-but-isolated path. Pre-#1178: the helper'
+  printf '%s\n' '# returned None for owner → mkdir branch ran → PermissionError → operator'
+  printf '%s\n' '# traceback. Post-#1178: the helper resolves owner via sudo-stat → sudo-mkdir'
+  printf '%s\n' '# branch runs → no PermissionError.'
+  printf '%s\n' ''
+  printf '%s\n' '# Stub _sudo_stat_owner on the SHARED module (bridge-setup imports it via alias).'
+  printf '%s\n' 'iso._sudo_stat_owner = lambda p: "agent-bridge-iso2"'
+  printf '%s\n' ''
+  printf '%s\n' '# Stub subprocess.run on bridge_setup so the sudo-mkdir invocation succeeds.'
+  printf '%s\n' 'class T5SubStub:'
+  printf '%s\n' '    def __init__(self):'
+  printf '%s\n' '        self.calls = []'
+  printf '%s\n' '    def __call__(self, *args, **kwargs):'
+  printf '%s\n' '        self.calls.append(args[0] if args else [])'
+  printf '%s\n' '        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout="", stderr="")'
+  printf '%s\n' 'stub = T5SubStub()'
+  printf '%s\n' 'original_bsetup_run = bsetup.subprocess.run'
+  printf '%s\n' 'original_iso_run = iso.subprocess.run'
+  printf '%s\n' 'bsetup.subprocess.run = stub'
+  printf '%s\n' 'iso.subprocess.run = stub'
+  printf '%s\n' 'try:'
+  printf '%s\n' '    blind_dir = BlindExistsPath(str(tmp / "iso2/workdir/.teams"))'
+  printf '%s\n' '    try:'
+  printf '%s\n' '        bsetup._isolation_aware_mkdir(blind_dir, agent="iso2")'
+  printf '%s\n' '        raised = None'
+  printf '%s\n' '    except PermissionError as exc:'
+  printf '%s\n' '        raised = exc'
+  printf '%s\n' '    assert raised is None, "T5: _isolation_aware_mkdir L368 reproducer MUST NOT raise PermissionError after helper-A fix; got " + repr(raised)'
+  printf '%s\n' '    # Confirm sudo-mkdir was attempted (not the raw mkdir branch).'
+  printf '%s\n' '    sudo_calls = [c for c in stub.calls if len(c) > 0 and c[0] == "sudo"]'
+  printf '%s\n' '    assert len(sudo_calls) >= 1, "T5: at least one sudo invocation expected (sudo-mkdir branch), got calls=" + repr(stub.calls)'
+  printf '%s\n' '    print("T5 PASS: _isolation_aware_mkdir on blind isolated path → sudo-mkdir branch, no PermissionError (L368 reproducer fix)")'
+  printf '%s\n' 'finally:'
+  printf '%s\n' '    bsetup.subprocess.run = original_bsetup_run'
+  printf '%s\n' '    iso.subprocess.run = original_iso_run'
+  printf '%s\n' '    iso._sudo_stat_owner = original_sudo_stat_owner'
+  printf '%s\n' ''
+  printf '%s\n' '# ---------- T6: shared module exposes _sudo_stat_owner ----------'
+  printf '%s\n' 'assert hasattr(iso, "_sudo_stat_owner"), "T6: shared module missing _sudo_stat_owner"'
+  printf '%s\n' 'assert callable(iso._sudo_stat_owner), "T6: _sudo_stat_owner must be callable"'
+  printf '%s\n' 'print("T6 PASS: _sudo_stat_owner exposed on shared module for monkey-patching")'
+  printf '%s\n' ''
+  printf '%s\n' 'print("ALL PASS")'
+} >>"$HARNESS"
+
+OUT="$("$PY_BIN" "$HARNESS" "$REPO_ROOT" "$SMOKE_TMP_ROOT" 2>&1)" \
+  || smoke_fail "Python harness failed: $OUT"
+[[ "$OUT" == *"ALL PASS"* ]] \
+  || smoke_fail "expected 'ALL PASS' marker, got: $OUT"
+
+printf '%s\n' "$OUT" | while IFS= read -r line; do
+  case "$line" in
+    "T"*" PASS"*|"ALL PASS"*) smoke_log "$line" ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# T3 + T3b: daemon supp-groups warning (PATH-shim test).
+# ---------------------------------------------------------------------------
+# Build a PATH-shim directory with controlled `id` / `getent` / `uname`
+# implementations, source bridge-daemon.sh, call the helper directly,
+# and assert the warning fires (or not) per the scenario.
+
+SHIM_DIR="$SMOKE_TMP_ROOT/shim-bin"
+mkdir -p "$SHIM_DIR"
+
+# T3: Linux + stale supp-groups + missing ab-agent-* → warning fires.
+write_t3_shims() {
+  : >"$SHIM_DIR/uname"
+  printf '%s\n' '#!/usr/bin/env bash' >>"$SHIM_DIR/uname"
+  printf '%s\n' 'echo Linux' >>"$SHIM_DIR/uname"
+  chmod +x "$SHIM_DIR/uname"
+
+  # id: when called with no args → process GIDs. Called with `-G` → list.
+  # Called with `-G <user>` → canonical list.
+  # Called with `-un` → user name.
+  : >"$SHIM_DIR/id"
+  # shellcheck disable=SC2129  # per-line emit mirrors footgun #11 avoidance shape (see 1175 smoke)
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'case "$*" in'
+    printf '%s\n' '  "-un") echo "patch" ;;'
+    printf '%s\n' '  "-G") echo "100 200 300" ;;'
+    printf '%s\n' '  "-G patch") echo "100 200 300 9001" ;;'
+    printf '%s\n' '  *) echo "id: unsupported invocation: $*" >&2; exit 1 ;;'
+    printf '%s\n' 'esac'
+  } >>"$SHIM_DIR/id"
+  chmod +x "$SHIM_DIR/id"
+
+  # getent: getent group 9001 → ab-agent-iso2:x:9001:patch
+  : >"$SHIM_DIR/getent"
+  # shellcheck disable=SC2129
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'case "$*" in'
+    printf '%s\n' '  "group 9001") echo "ab-agent-iso2:x:9001:patch" ;;'
+    printf '%s\n' '  *) exit 2 ;;'
+    printf '%s\n' 'esac'
+  } >>"$SHIM_DIR/getent"
+  chmod +x "$SHIM_DIR/getent"
+}
+
+# T3b: macOS (uname != Linux) → silent no-op.
+write_t3b_shims() {
+  : >"$SHIM_DIR/uname"
+  printf '%s\n' '#!/usr/bin/env bash' >>"$SHIM_DIR/uname"
+  printf '%s\n' 'echo Darwin' >>"$SHIM_DIR/uname"
+  chmod +x "$SHIM_DIR/uname"
+
+  # Defensive id/getent that would scream if reached (proves no-op).
+  : >"$SHIM_DIR/id"
+  printf '%s\n' '#!/usr/bin/env bash' >>"$SHIM_DIR/id"
+  printf '%s\n' 'echo "id: macOS shim must not be reached" >&2; exit 99' >>"$SHIM_DIR/id"
+  chmod +x "$SHIM_DIR/id"
+
+  : >"$SHIM_DIR/getent"
+  printf '%s\n' '#!/usr/bin/env bash' >>"$SHIM_DIR/getent"
+  printf '%s\n' 'echo "getent: macOS shim must not be reached" >&2; exit 99' >>"$SHIM_DIR/getent"
+  chmod +x "$SHIM_DIR/getent"
+}
+
+# Extract the helper definition + invoke harness. We avoid sourcing the
+# full bridge-daemon.sh (it would pull bridge-lib.sh + roster + everything),
+# extract just the helper function body via awk and define it standalone.
+extract_helper() {
+  local source="$REPO_ROOT/bridge-daemon.sh"
+  local out="$SMOKE_TMP_ROOT/helper-extract.sh"
+  : >"$out"
+  # shellcheck disable=SC2129  # per-line emit mirrors footgun #11 avoidance shape
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    # Need daemon_warn too (helper calls it).
+    awk '/^daemon_warn\(\) \{/,/^\}/' "$source"
+    printf '%s\n' ''
+    awk '/^bridge_daemon_warn_if_supp_groups_stale\(\) \{/,/^\}/' "$source"
+    printf '%s\n' ''
+    printf '%s\n' 'bridge_daemon_warn_if_supp_groups_stale'
+  } >>"$out"
+  printf '%s\n' "$out"
+}
+
+HELPER_RUNNER="$(extract_helper)"
+chmod +x "$HELPER_RUNNER"
+
+# T3: stale supp-groups → warning fires.
+write_t3_shims
+T3_OUT="$(PATH="$SHIM_DIR:$PATH" bash "$HELPER_RUNNER" 2>&1)"
+T3_RC=$?
+if [[ "$T3_RC" -ne 0 ]]; then
+  smoke_fail "T3: helper extract runner exited non-zero (rc=$T3_RC), output: $T3_OUT"
+fi
+if [[ "$T3_OUT" != *"stale"* ]] || [[ "$T3_OUT" != *"ab-agent-iso2"* ]]; then
+  smoke_fail "T3: expected stale supp-groups warning mentioning ab-agent-iso2, got: $T3_OUT"
+fi
+if [[ "$T3_OUT" != *"KNOWN_ISSUES.md"* ]] || [[ "$T3_OUT" != *"§28"* ]]; then
+  smoke_fail "T3: expected resolution-runbook pointer in warning, got: $T3_OUT"
+fi
+smoke_log "T3 PASS: daemon supp-groups stale warning fires with ab-agent-* group name + runbook pointer"
+
+# T3b: macOS → no warning.
+write_t3b_shims
+T3B_OUT="$(PATH="$SHIM_DIR:$PATH" bash "$HELPER_RUNNER" 2>&1)"
+T3B_RC=$?
+if [[ "$T3B_RC" -ne 0 ]]; then
+  smoke_fail "T3b: helper extract runner exited non-zero on macOS shim (rc=$T3B_RC), output: $T3B_OUT"
+fi
+if [[ -n "$T3B_OUT" ]]; then
+  smoke_fail "T3b: macOS (uname != Linux) must produce no warning output, got: $T3B_OUT"
+fi
+smoke_log "T3b PASS: daemon supp-groups helper is silent on macOS (uname != Linux)"
+
+# ---------------------------------------------------------------------------
+# T4: lint catches NEW raw mutator pattern (boomerang).
+# ---------------------------------------------------------------------------
+
+LINT_SCRIPT="$REPO_ROOT/scripts/lint-raw-pathlib-on-isolated.sh"
+BASELINE_FILE="$REPO_ROOT/scripts/baselines/raw-pathlib-baseline.txt"
+
+[[ -x "$LINT_SCRIPT" ]] || smoke_fail "lint script missing or non-executable: $LINT_SCRIPT"
+[[ -f "$BASELINE_FILE" ]] || smoke_fail "baseline file missing: $BASELINE_FILE"
+
+# T4a: self-test PASS on the extended pattern.
+if ! "$LINT_SCRIPT" --self-test >/dev/null 2>&1; then
+  smoke_fail "T4a: lint script --self-test FAILED — extended pattern detection broken"
+fi
+smoke_log "T4a PASS: lint --self-test on the extended mutator pattern (5 positives across probe + mutator surfaces)"
+
+# T4b: baseline check PASS on the current tree (extended pattern, all noqa'd).
+if ! "$LINT_SCRIPT" --check >/dev/null 2>&1; then
+  ACTUAL_OUT="$("$LINT_SCRIPT" --check 2>&1 || true)"
+  smoke_fail "T4b: lint --check FAIL on the integration tree (after noqa sweep): $ACTUAL_OUT"
+fi
+smoke_log "T4b PASS: lint --check on the integration tree (extended pattern, all sites either routed-safe or noqa'd)"
+
+# T4c: boomerang — inject a violating raw `Path('.').mkdir()` into a
+# scratch copy of bridge-setup.py and assert lint FAILS.
+T4_SCRATCH="$SMOKE_TMP_ROOT/scratch-repo"
+mkdir -p "$T4_SCRATCH/scripts/baselines" "$T4_SCRATCH/lib"
+cp "$REPO_ROOT/bridge-setup.py" "$T4_SCRATCH/bridge-setup.py"
+cp "$REPO_ROOT/bridge-hooks.py" "$T4_SCRATCH/bridge-hooks.py"
+cp "$REPO_ROOT/scripts/baselines/raw-pathlib-baseline.txt" \
+   "$T4_SCRATCH/scripts/baselines/raw-pathlib-baseline.txt"
+
+printf '\n# T4c boomerang regression site (smoke-only)\n_violating_probe = Path(".").mkdir()\n' \
+  >>"$T4_SCRATCH/bridge-setup.py"
+
+mkdir -p "$T4_SCRATCH/scripts"
+cp "$LINT_SCRIPT" "$T4_SCRATCH/scripts/lint-raw-pathlib-on-isolated.sh"
+chmod +x "$T4_SCRATCH/scripts/lint-raw-pathlib-on-isolated.sh"
+
+T4C_OUT="$(
+  BRIDGE_RAW_PATHLIB_BASELINE_FILE="$T4_SCRATCH/scripts/baselines/raw-pathlib-baseline.txt" \
+  "$T4_SCRATCH/scripts/lint-raw-pathlib-on-isolated.sh" --check 2>&1
+)"
+T4C_RC=$?
+
+if [[ "$T4C_RC" -eq 0 ]]; then
+  smoke_fail "T4c boomerang: lint MUST fail when a NEW raw .mkdir() lands in bridge-setup.py; got rc=$T4C_RC, output: $T4C_OUT"
+fi
+if [[ "$T4C_OUT" != *"bridge-setup.py"* ]]; then
+  smoke_fail "T4c boomerang: lint failure output should mention bridge-setup.py; got: $T4C_OUT"
+fi
+smoke_log "T4c PASS (boomerang): lint catches NEW raw \`Path('.').mkdir()\` injected into bridge-setup.py"
+
+# T4d: second boomerang — inject `shutil.copy(...)` and assert lint also fails.
+# Reset scratch tree from the pristine repo files first.
+cp "$REPO_ROOT/bridge-setup.py" "$T4_SCRATCH/bridge-setup.py"
+cp "$REPO_ROOT/bridge-hooks.py" "$T4_SCRATCH/bridge-hooks.py"
+printf '\n# T4d boomerang regression site (smoke-only)\n_violating_copy = shutil.copy("/tmp/x", "/tmp/y")\n' \
+  >>"$T4_SCRATCH/bridge-hooks.py"
+
+T4D_OUT="$(
+  BRIDGE_RAW_PATHLIB_BASELINE_FILE="$T4_SCRATCH/scripts/baselines/raw-pathlib-baseline.txt" \
+  "$T4_SCRATCH/scripts/lint-raw-pathlib-on-isolated.sh" --check 2>&1
+)"
+T4D_RC=$?
+
+if [[ "$T4D_RC" -eq 0 ]]; then
+  smoke_fail "T4d boomerang: lint MUST fail when a NEW raw shutil.copy() lands in bridge-hooks.py; got rc=$T4D_RC, output: $T4D_OUT"
+fi
+if [[ "$T4D_OUT" != *"bridge-hooks.py"* ]]; then
+  smoke_fail "T4d boomerang: lint failure output should mention bridge-hooks.py; got: $T4D_OUT"
+fi
+smoke_log "T4d PASS (boomerang): lint catches NEW raw \`shutil.copy(...)\` injected into bridge-hooks.py"
+
+smoke_log "OK"

--- a/scripts/smoke/1178-helper-contract-daemon-supp.sh
+++ b/scripts/smoke/1178-helper-contract-daemon-supp.sh
@@ -42,10 +42,16 @@
 #   T4: lint catches NEW raw mutator pattern. Boomerang: inject
 #       `Path('.').mkdir()` into a scratch copy of bridge-setup.py,
 #       assert the lint fails. Then inject `shutil.copy(...)`, assert
-#       the lint also fails on that pattern.
+#       the lint also fails on that pattern. (r2) Third boomerang
+#       injects `.symlink_to(...)` and asserts the lint fails after
+#       the pattern extension closed codex r1 BLOCKING 2.
 #   T5: setup teams L368 reproducer — assert `_isolation_aware_mkdir`
 #       on a blind-but-isolated path does NOT raise PermissionError
 #       when `_sudo_stat_owner` is stubbed to return the owner.
+#   T6: (r2) daemon `restart` subcommand exists — the supp-groups
+#       warning recommends `agent-bridge daemon restart`; that verb
+#       must dispatch to a real handler (cmd_restart = stop + start)
+#       and appear in the usage string. Closes codex r1 BLOCKING 1.
 #
 # Host-agnostic: every Linux-specific behavior is exercised via PATH
 # shims (`id`, `getent`, `uname`, `sudo`, `stat`) and Python `subprocess`
@@ -369,7 +375,7 @@ BASELINE_FILE="$REPO_ROOT/scripts/baselines/raw-pathlib-baseline.txt"
 if ! "$LINT_SCRIPT" --self-test >/dev/null 2>&1; then
   smoke_fail "T4a: lint script --self-test FAILED — extended pattern detection broken"
 fi
-smoke_log "T4a PASS: lint --self-test on the extended mutator pattern (5 positives across probe + mutator surfaces)"
+smoke_log "T4a PASS: lint --self-test on the extended mutator pattern (6 positives across probe + mutator surfaces, including symlink_to)"
 
 # T4b: baseline check PASS on the current tree (extended pattern, all noqa'd).
 if ! "$LINT_SCRIPT" --check >/dev/null 2>&1; then
@@ -428,5 +434,63 @@ if [[ "$T4D_OUT" != *"bridge-hooks.py"* ]]; then
   smoke_fail "T4d boomerang: lint failure output should mention bridge-hooks.py; got: $T4D_OUT"
 fi
 smoke_log "T4d PASS (boomerang): lint catches NEW raw \`shutil.copy(...)\` injected into bridge-hooks.py"
+
+# T4e: third boomerang — inject `Path('.').symlink_to(...)` and assert
+# lint also fails (#1178 r2 codex r1 BLOCKING 2: the pre-r2 pattern
+# omitted symlink_to even though bridge-hooks.py:1313/1519 already had
+# raw .symlink_to() sites on isolated-setting paths).
+cp "$REPO_ROOT/bridge-setup.py" "$T4_SCRATCH/bridge-setup.py"
+cp "$REPO_ROOT/bridge-hooks.py" "$T4_SCRATCH/bridge-hooks.py"
+printf '\n# T4e boomerang regression site (smoke-only)\n_violating_symlink = Path("link").symlink_to("target")\n' \
+  >>"$T4_SCRATCH/bridge-hooks.py"
+
+T4E_OUT="$(
+  BRIDGE_RAW_PATHLIB_BASELINE_FILE="$T4_SCRATCH/scripts/baselines/raw-pathlib-baseline.txt" \
+  "$T4_SCRATCH/scripts/lint-raw-pathlib-on-isolated.sh" --check 2>&1
+)"
+T4E_RC=$?
+
+if [[ "$T4E_RC" -eq 0 ]]; then
+  smoke_fail "T4e boomerang: lint MUST fail when a NEW raw .symlink_to() lands in bridge-hooks.py; got rc=$T4E_RC, output: $T4E_OUT"
+fi
+if [[ "$T4E_OUT" != *"bridge-hooks.py"* ]]; then
+  smoke_fail "T4e boomerang: lint failure output should mention bridge-hooks.py; got: $T4E_OUT"
+fi
+smoke_log "T4e PASS (boomerang): lint catches NEW raw \`.symlink_to(...)\` injected into bridge-hooks.py"
+
+# ---------------------------------------------------------------------------
+# T6: daemon restart subcommand exists (#1178 r2 codex r1 BLOCKING 1).
+# The supp-groups warning recommends `agent-bridge daemon restart`; that
+# recommendation must point at a real subcommand. Pre-r2 the dispatch
+# only had start/ensure/run/stop/status/sync, so bare `bash
+# bridge-daemon.sh restart` fell into the `*)` arm, printed usage,
+# and exited rc=1.
+#
+# We don't execute the actual stop+start here (it would touch the live
+# daemon); instead we verify the dispatch arm exists by invoking with
+# --help (which short-circuits before cmd_restart runs). If `restart`
+# is unknown the script prints usage and exits 1; if `restart` is a
+# real verb, the help short-circuit returns 0.
+# ---------------------------------------------------------------------------
+
+DAEMON_SH="$REPO_ROOT/bridge-daemon.sh"
+[[ -f "$DAEMON_SH" ]] || smoke_fail "T6: bridge-daemon.sh missing at $DAEMON_SH"
+
+# T6a: dispatch arm exists. `restart --help` should exit 0 (matches the
+# shape of `stop --help`, `start --help`, etc.).
+T6A_OUT="$(bash "$DAEMON_SH" restart --help 2>&1 || true)"
+T6A_RC=$?
+if [[ "$T6A_RC" -ne 0 ]]; then
+  smoke_fail "T6a: \`bash bridge-daemon.sh restart --help\` must exit 0 (the restart dispatch arm should short-circuit on help). Got rc=$T6A_RC, output: $T6A_OUT"
+fi
+smoke_log "T6a PASS: \`bridge-daemon.sh restart --help\` short-circuits with rc=0 (dispatch arm exists)"
+
+# T6b: usage string advertises the restart verb so operators discover
+# the warning's recommended command via `--help`.
+T6B_OUT="$(bash "$DAEMON_SH" --help 2>&1 || true)"
+if [[ "$T6B_OUT" != *"restart"* ]]; then
+  smoke_fail "T6b: usage string must mention 'restart' so the supp-groups warning's recommended command is discoverable; got: $T6B_OUT"
+fi
+smoke_log "T6b PASS: usage string advertises the restart subcommand"
 
 smoke_log "OK"


### PR DESCRIPTION
## Summary

Cycle 12 architectural root. beta16's #1175 sweep landed clean but `setup teams test_iso2` still raised PermissionError at `bridge-setup.py:_isolation_aware_mkdir` L368 because three independent root causes converged on the same trace:

1. **Helper layer bug** — `lib/bridge_iso_paths.py:resolve_isolated_owner_for_path` (and `isolated_workdir_owner`) swallowed `PermissionError` under `except OSError: pass`. The opposite of the truth — PermissionError IS the positive signal that the path is isolated (controller is blind because the tree is v2-mode/group-protected). Returning None then steered `_isolation_aware_mkdir` into the `owner is None` branch → raw `path.mkdir(parents=True, exist_ok=True)` → PermissionError → operator-facing traceback.
2. **Daemon supp-groups stale** — Bash daemon cannot self-refresh the Linux kernel supplementary-group set (no `os.initgroups()` analog). KNOWN_ISSUES §28 cousin.
3. **Lint gap** — beta16's `lint-raw-pathlib-on-isolated.sh` only caught probes (`.exists()` family). Mutators (`.mkdir`, `.unlink`, `shutil.copy*`, `os.makedirs/remove/rename`) were the next attack surface, all unguarded.

Per the operator's exhaust-audit-single-PR coaching: all three addressed in one PR.

### Deliverable A — Helper PermissionError → sudo-stat fallback

- New private `_sudo_stat_owner(path)` runs `sudo -n stat -c %U <path>` (GNU) with `-f %Su` (BSD) fallback. Returns the owner under root regardless of the controller's group set.
- `resolve_isolated_owner_for_path` and `isolated_workdir_owner` intercept `PermissionError` separately from `OSError`, try sudo-stat first, and only fall through to walk up the ancestor chain when sudo-stat also fails. 5s timeout + sudo-stderr discrimination mirror `safe_path_check`'s contract.
- Pre-#1178 regression contract preserved: disabling `_sudo_stat_owner` reproduces the pre-fix None return (covered by T1c).

### Deliverable C — Daemon supp-groups stale-set startup warning

Daemon is bash (not python), so `os.initgroups()` is not an option and `exec sg <group>` would lose the TERM/INT/HUP traps installed two lines earlier + orphan the queue-gateway socket child. Approach: emit a one-line **warning** at startup when the running process's `id -G` (kernel-side supp set) differs from `id -G <user>` (NSS-resolved canonical set, picks up post-login `usermod -aG`) and the missing set contains any `ab-agent-*` group. Best-effort; never blocks startup; macOS no-op via `uname -s` gate. Operator-side runbook (KNOWN_ISSUES.md §28) covers the manual resolution.

### Deliverable Lint — Extended pattern + sweep

Lint now catches probe + mutator surfaces: `.mkdir(`, `.unlink(`, `.touch(`, `.rmdir(`, `shutil.copy/copy2/move/rmtree(`, `os.makedirs/remove/rename(`. Self-test + docstring filter updated.

Extended pattern revealed **13 NEW HIGH sites** (3 in bridge-setup.py, 10 in bridge-hooks.py). Every site already had a `try/except PermissionError` + sudo-fallback wrapper or lived on a controller-owned scaffold path — each was noqa-marked with a purpose annotation rather than wrapped via a new safe helper. **Baseline file stays at 0:0** (all sites either documented-controller-only or sudo-recovery-wrapped, so the ratchet semantics hold).

## Verification

- `bash -n` + `shellcheck` + `python3 -m py_compile` clean on every modified file
- `lint-heredoc-ban --baseline-check` PASS (one near-miss caught and fixed during dev: `while ... done <<<"$missing_gids"` here-string in the daemon helper — rewrote with `set -- $missing_gids` positional-arg expansion under `IFS=$'\n'`)
- `lint-raw-pathlib-on-isolated --check` PASS (extended pattern + baseline 0:0)
- `lint-raw-pathlib-on-isolated --self-test` PASS (5 positives across probe + mutator surfaces, 5 filtered by whitelist/comment/docstring)
- **New smoke** `scripts/smoke/1178-helper-contract-daemon-supp.sh` PASS (12 tests):
  - T1a/b/c/d: helper PermissionError → sudo-stat recovery + regression contract + lstat-path variant
  - T2: shared-mode path walks normally (no sudo subprocess)
  - T3/T3b: daemon supp-groups warning fires with ab-agent-* + macOS no-op
  - T4a/b/c/d: lint self-test + integration tree check + two boomerang injections (`.mkdir()` into bridge-setup.py, `shutil.copy()` into bridge-hooks.py)
  - T5: L368 reproducer — `_isolation_aware_mkdir` on blind-but-isolated path → sudo-mkdir branch, no PermissionError
  - T6: `_sudo_stat_owner` exposed on shared module for monkey-patching
- **Sibling smokes PASS**: 1175, 1170, 1165-track-a, 1165-track-b, 1165-track-c, 1161, 1158, 1145

## Notes for review

- **Daemon language**: bash (not python). Chose warning over re-exec because re-exec would orphan the queue-gateway socket child and lose the trap handlers. Documented inline.
- **New HIGH lint sites**: 13. All addressed via `# noqa: raw-pathlib-controller-only` annotations (each line annotated with the specific reason — controller-owned scaffold / sudo-recovery wrapper / sudo-backed-reapply contract). No new wrapper helpers added because every site already had its own sudo-recovery flow.
- **Baseline update**: `scripts/baselines/raw-pathlib-baseline.txt` stays at `bridge-setup.py:0` / `bridge-hooks.py:0` — the noqa sweep absorbed all 13 new sites cleanly.

## Test plan

- [ ] Linux QA host: `agb setup teams test_iso2` (or any isolated-agent-rerun setup) confirms no traceback at L368
- [ ] Stale supp-groups scenario: first-time v2 isolated agent setup → daemon restart → confirm warning fires once at startup with `ab-agent-<name>` named + runbook pointer
- [ ] macOS dev host: daemon startup produces no supp-groups warning (uname != Linux gate)
- [ ] Future raw `Path('.').mkdir()` / `shutil.copy()` PR → lint blocks before merge

(#1178 cycle 12 architectural root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)