### PR TITLE
feat(v2-isolation): beta19 L1 — install-tree row expansion + Teams shim + bun traversal (#1186 sequel)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1841,6 +1841,37 @@ if [[ $DRY_RUN -eq 0 ]]; then
     tail -n 50 "$_iso_reconcile_tmp" >&2 || true
   fi
   rm -f -- "$_iso_reconcile_tmp"
+
+  # L1 beta19 (codex r1 design 2026-05-25): in-place upgrade is the
+  # beta19 acceptance path. patch may not rerun `agb setup teams`, so
+  # the bun-traverse helper has to fire here too — otherwise an upgrade
+  # from beta18 to beta19 leaves $HOME/.bun at the operator's umask
+  # (0750 on Debian/Ubuntu) and isolated Teams MCP startup hits EACCES
+  # on exec even though every install-tree row above converged.
+  #
+  # Best-effort, non-fatal: the bun-traverse helper emits bridge_warn on
+  # chmod failures but returns non-zero. Wrap in set +e so the upgrade
+  # does not abort. Linux + $HOME/.bun gating is internal to the helper
+  # (no-op elsewhere).
+  #
+  # Footgun #11: invoke via standalone helper in lib/upgrade-helpers/
+  # rather than -c with embedded script. Keeps the pattern symmetrical
+  # with isolation-v2-reconcile.sh and avoids any future heredoc-stdin
+  # temptation in this file.
+  set +e
+  _bun_traverse_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-upg-bun-traverse.XXXXXX")"
+  bridge_upgrade_with_target_env "$TARGET_ROOT" \
+    "$BRIDGE_BASH_BIN" \
+    "$SOURCE_ROOT/lib/upgrade-helpers/bun-traverse-chmod.sh" \
+    "$SOURCE_ROOT" "$TARGET_ROOT" >"$_bun_traverse_tmp" 2>&1
+  _bun_traverse_rc=$?
+  set -e
+  if [[ $_bun_traverse_rc -ne 0 ]]; then
+    echo "[bridge-upgrade] WARN: bun-runtime traverse chmod reported failure (rc=$_bun_traverse_rc) — isolated agents may fail to exec bun. Run 'chmod o+x \$HOME/.bun \$HOME/.bun/bin' manually or set BRIDGE_BUN_CHMOD_OPT_OUT=1 to suppress." >&2
+    _upgrade_partial_failures+=("bun_traverse")
+    tail -n 20 "$_bun_traverse_tmp" >&2 || true
+  fi
+  rm -f -- "$_bun_traverse_tmp"
 fi
 
 # Footgun #11: `bridge_upgrade_agent_restart_json` feeds python via heredoc;

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -655,6 +655,112 @@ bridge_install_teams_plugin_node_modules() {
   return 0
 }
 
+# Make the operator's bun runtime traversable by isolated UIDs.
+#
+# L1 beta19 (codex r1 design 2026-05-25): the Teams MCP launches bare
+# `bun` (plugins/teams/.mcp.json). PR #1090 settled the contract that
+# setup requires `command -v bun` to resolve to a PATH-reachable binary
+# — but in practice that binary is often a symlink like
+# `/usr/local/bin/bun -> $HOME/.bun/bin/bun`. The PATH-visible side is
+# fine for the controller, but isolated UIDs need to actually traverse
+# `$HOME/.bun/` to reach the real binary. On a Linux box where the
+# operator's $HOME is mode 0750 (Debian/Ubuntu default), iso UIDs cannot
+# `cd` into `$HOME/.bun` and the MCP fails with EACCES on exec.
+#
+# Helper behavior:
+#   * No-op unless Linux.
+#   * No-op when BRIDGE_BUN_CHMOD_OPT_OUT=1 (operator escape hatch).
+#   * Resolves `command -v bun`, walks symlinks via `readlink -f` (or a
+#     Python fallback for BSD/macOS readlink absence) to the real target.
+#   * If the real target sits under $HOME/.bun/: `chmod o+x` on
+#     $HOME/.bun and $HOME/.bun/bin — TRAVERSE-ONLY. Never grants `o+r`
+#     (no directory listing, no read of $HOME/.bun internals beyond
+#     traversal). Other-execute lets iso UIDs reach the resolved file
+#     without leaking the rest of the operator's home.
+#   * If the real target is anywhere else (homebrew /opt, asdf, fnm
+#     shims, system /usr/bin): no-op. Those paths already have global
+#     traverse modes; widening them would be a no-op or wrong-scope.
+#   * chmod failures are bridge_warn'd, never bridge_die'd — the caller
+#     (bridge_provision_teams_plugin_runtime + bridge-upgrade.sh) treats
+#     this as best-effort.
+#
+# Honors --dry-run: emits the chmod commands it WOULD run without
+# touching the host. We deliberately do NOT bundle or system-install
+# bun: that would require root + system-PATH ownership decisions and
+# changes the operator's runtime update model. The chmod-traverse is
+# the smallest L1 fix.
+bridge_ensure_bun_runtime_traversable_for_isolated() {
+  local dry_run="${1:-0}"
+
+  if [[ "$(uname -s 2>/dev/null)" != "Linux" ]]; then
+    return 0
+  fi
+  if [[ "${BRIDGE_BUN_CHMOD_OPT_OUT:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  local bun_path
+  if ! bun_path="$(command -v bun 2>/dev/null)" || [[ -z "$bun_path" ]]; then
+    # No bun on PATH — bridge_resolve_bun_executable will fail upstream
+    # and surface the canonical "missing bun" error. Stay quiet here.
+    return 0
+  fi
+
+  # Resolve symlinks. Prefer GNU `readlink -f` (Linux default); fall
+  # back to Python for portability (Linux without coreutils-style
+  # readlink is unusual but cheap to cover).
+  local real_target=""
+  if real_target="$(readlink -f "$bun_path" 2>/dev/null)" && [[ -n "$real_target" ]]; then
+    :
+  elif command -v python3 >/dev/null 2>&1; then
+    real_target="$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$bun_path" 2>/dev/null || true)"
+  else
+    bridge_warn "bridge_ensure_bun_runtime_traversable_for_isolated: cannot resolve real path of $bun_path (no readlink -f, no python3); skipping traverse chmod"
+    return 0
+  fi
+  if [[ -z "$real_target" ]]; then
+    return 0
+  fi
+
+  # Only act on $HOME/.bun/ targets. Other PATH-resolved bun installs
+  # (homebrew /opt/homebrew, fnm shims under ~/.local/share/fnm, asdf,
+  # /usr/bin, etc.) are out of scope — those locations either already
+  # have global traverse OR their parent-mode contract is owned by
+  # another package manager / system policy we should not mutate.
+  local home_bun="${HOME:-}/.bun"
+  if [[ -z "${HOME:-}" || -z "$home_bun" ]]; then
+    return 0
+  fi
+  case "$real_target" in
+    "$home_bun"/*) ;;
+    *) return 0 ;;
+  esac
+
+  local bun_bin_dir="$home_bun/bin"
+
+  if [[ "$dry_run" == "1" ]]; then
+    bridge_info "[setup] [dry-run] would: chmod o+x $home_bun $bun_bin_dir (isolated-UID traverse for $real_target)"
+    return 0
+  fi
+
+  # TRAVERSE ONLY — `o+x`, not `o+rx`. Iso UIDs can `cd` into .bun/bin
+  # to reach the resolved binary but cannot list .bun/ contents.
+  local rc=0
+  if [[ -d "$home_bun" ]]; then
+    if ! chmod o+x "$home_bun" 2>/dev/null; then
+      bridge_warn "chmod o+x $home_bun failed — isolated UIDs may fail to exec bun (Teams MCP startup will hit EACCES)"
+      rc=1
+    fi
+  fi
+  if [[ -d "$bun_bin_dir" ]]; then
+    if ! chmod o+x "$bun_bin_dir" 2>/dev/null; then
+      bridge_warn "chmod o+x $bun_bin_dir failed — isolated UIDs may fail to exec bun (Teams MCP startup will hit EACCES)"
+      rc=1
+    fi
+  fi
+  return "$rc"
+}
+
 # Channel-setup-time entry point: ensure bun + plugins/teams/node_modules
 # are provisioned. Called from bridge-setup.sh `run_teams()` after the
 # Python config write succeeds. Failure does not abort setup (operator may
@@ -670,6 +776,12 @@ bridge_provision_teams_plugin_runtime() {
     bridge_install_bun_runtime "$dry_run" || return 1
     bun_bin="$(bridge_resolve_bun_executable || true)"
   fi
+
+  # L1 beta19 (codex r1 design 2026-05-25): before we provision
+  # node_modules (which iso UIDs will read), make sure they can also
+  # traverse to the bun binary itself. Best-effort, non-fatal — the
+  # helper warns on chmod failure but does not block setup.
+  bridge_ensure_bun_runtime_traversable_for_isolated "$dry_run" || true
 
   bridge_install_teams_plugin_node_modules "$dry_run" "$bun_bin" || return 1
   return 0

--- a/lib/bridge-isolation-v2-reconcile.sh
+++ b/lib/bridge-isolation-v2-reconcile.sh
@@ -1068,6 +1068,52 @@ bridge_isolation_v2_install_tree_matrix_rows() {
   printf '%s\n' \
     "agents-root|install|$data_root/agents|dir|controller|ab-shared|0710|-|0|0|inherit|direct|required|per-agent runtime-home root — controller rwX, group --x for traverse to each per-agent leaf without listing the full agent inventory (iso UIDs must traverse to their own home, not see siblings)"
 
+  # ----- L1 beta19 install-tree gaps (codex r1 design 2026-05-25) -----
+  #
+  # patch's beta18 Phase 3 acceptance flagged 5 install-tree dirs that the
+  # reconciler was not covering — every one of them is created on demand by
+  # the Teams MCP / MS365 callback flow / queue gateway under the isolated
+  # UID, and absent-without-row meant they spawned at the operator umask
+  # (077 → 0700) with iso UIDs locked out of traverse + write.
+  #
+  # All 5 use `state_scaffold` (NOT plain `dir`): plain `dir` only checks
+  # an existing path and fires MISSING/FAIL on absent. The Teams/MS365
+  # callback dirs may be absent on a fresh install (no callback received
+  # yet), and the queue body dir may be absent before the first body write
+  # (queue uses sqlite for small payloads, falls back to body files at
+  # `bridge-queue.py:310-315` only for over-threshold rows). state_scaffold
+  # mkdir's in `--apply` mode and then runs the same chown+chmod path
+  # as plain `dir`, so the rows converge whether the dir exists yet or not.
+  #
+  # Writer dirs (callback mailbox + activity-index dir) get mode 3770:
+  #   * setgid (2000) — children inherit group ab-shared so the controller
+  #     daemon (route lookup) can read iso-UID-written files without an
+  #     after-the-fact chgrp.
+  #   * sticky  (1000) — prevents one iso UID from deleting another iso
+  #     UID's callback / activity-index file (only the file owner +
+  #     directory owner can unlink under +t).
+  #   * 0770    — controller + ab-shared rwx, no world.
+  #   * The TS-side writer also drops the file mode to 0640 (see
+  #     plugins/teams/server.ts:writeTeamsActivityIndex) so the controller
+  #     can read the file via the ab-shared group without world-read.
+  #
+  # Parent-traverse-only dirs (state/channels root + state/queue + queue
+  # bodies) get mode 0710: controller rwX, group --x. Iso UIDs in ab-shared
+  # can traverse into their leaf but cannot list the directory or see
+  # sibling agents' state. Queue body files themselves stay controller-owned
+  # — the gateway path (`agb inbox <agent>` etc.) reads bodies through
+  # controller-mediated code, not direct file open from iso UID.
+  printf '%s\n' \
+    "shared-ms365-callbacks-dir|install|$data_root/shared/ms365-callbacks|state_scaffold|controller|ab-shared|3770|-|1|0|inherit|direct|required|MS365 OAuth callback mailbox — controller + ab-shared rwx, setgid + sticky. Teams MCP writes <state>.json from iso UID; MS365 plugin reads + unlinks from iso UID (plugins/teams/server.ts:299-306, plugins/ms365/server.ts:186-246). Sticky prevents cross-UID delete; setgid keeps group ab-shared on every child file"
+  printf '%s\n' \
+    "state-channels-root|install|$data_root/state/channels|state_scaffold|controller|ab-shared|0710|-|0|0|inherit|direct|required|state/channels parent — controller rwX, group --x for traverse only (iso UIDs reach state/channels/teams/<agent>.json but cannot list other channels' state)"
+  printf '%s\n' \
+    "state-channels-teams-dir|install|$data_root/state/channels/teams|state_scaffold|controller|ab-shared|3770|-|1|0|inherit|direct|required|Teams activity-index dir — controller + ab-shared rwx, setgid + sticky. Isolated Teams writer creates <agent>.json from iso UID at plugins/teams/server.ts:492-494; the file mode is held to 0640 in writeTeamsActivityIndex so the controller daemon's route lookup (bridge-channels.py:289-304) can read via ab-shared group. Sticky limits cross-agent file deletion"
+  printf '%s\n' \
+    "state-queue-dir|install|$data_root/state/queue|state_scaffold|controller|ab-shared|0710|-|0|0|inherit|direct|required|state/queue parent — controller rwX, group --x for traverse only. agb inbox / queue body lookups from iso UIDs traverse here to reach the body files; full directory listing intentionally denied"
+  printf '%s\n' \
+    "state-queue-bodies-dir|install|$data_root/state/queue/bodies|state_scaffold|controller|ab-shared|0710|-|0|0|inherit|direct|required|state/queue/bodies — bridge-queue.py:310-315 stores body files here. Without this row's parent traversal, a nested path lookup from iso UID still fails on EACCES even after state-queue-dir is fixed. Body file content stays controller-owned; iso UIDs reach bodies via gateway code paths only"
+
   # ----- per-agent rows (only when --agent is provided) -----
   if [[ -n "$agent" ]]; then
     # ----- Phase 3 Family 2 (codex design 2026-05-24): isolated HOME contract -----

--- a/lib/upgrade-helpers/bun-traverse-chmod.sh
+++ b/lib/upgrade-helpers/bun-traverse-chmod.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# bun-traverse-chmod.sh — invoke the Bun runtime traverse helper on
+# `upgrade --apply`. Invoked by bridge-upgrade.sh via
+# `bridge_upgrade_with_target_env $TARGET_ROOT $BRIDGE_BASH_BIN $0 \
+#   $SOURCE_ROOT $TARGET_ROOT`.
+#
+# L1 beta19 (codex r1 design 2026-05-25): in-place upgrade from beta18
+# is the acceptance path. The operator typically did not re-run
+# `agb setup teams` between betas, so the `$HOME/.bun` traverse-chmod
+# that bridge_provision_teams_plugin_runtime does at setup-teams time
+# never fired on this host. Running the same helper here closes the gap.
+#
+# Invocation contract:
+#   $1 = source_root  (the agent-bridge source checkout)
+#   $2 = target_root  (the live install root being upgraded)
+#
+# Output: helper-emitted bridge_info / bridge_warn lines on stderr (via
+#         bridge_warn).
+# Exit code: 0 when chmod was no-op (non-Linux, opt-out, bun outside
+#            $HOME/.bun) or succeeded; non-zero only when an attempted
+#            chmod actually failed. bridge-upgrade.sh treats non-zero
+#            as a partial-failure warning, not a fatal abort.
+#
+# Footgun #11 — no heredocs. The function is sourced via bridge-lib.sh's
+# normal load path; arguments come in as positional argv.
+
+set -uo pipefail
+
+source_root="$1"
+target_root="$2"
+
+# shellcheck source=/dev/null
+source "$source_root/bridge-lib.sh"
+
+# Honor dry-run via env (bridge-upgrade.sh sets DRY_RUN). The 0/1
+# argument here is the literal flag the helper expects.
+_dry_run="${DRY_RUN:-0}"
+if [[ "$_dry_run" != "1" ]]; then
+  _dry_run=0
+fi
+
+bridge_ensure_bun_runtime_traversable_for_isolated "$_dry_run"

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -517,9 +517,25 @@ export function writeTeamsActivityIndex(
       last_user_inbound_user_id: userId,
       last_user_inbound_recorded_ns: nowNs,
     }
+    // L1 beta19 (codex r1 design 2026-05-25): activity-index files are
+    // read by the controller daemon's route lookup (bridge-channels.py:
+    // 289-304) even when the file was created by an isolated UID. Mode
+    // 0600 blocks the daemon's read; widen to 0640 so the ab-shared
+    // group (which the reconciler sets via setgid on
+    // state/channels/teams/) covers the controller read path while world
+    // remains locked out.
+    //
+    // We chmod both the tmp file (in case the rename races a reader that
+    // opens by name before chmod hits) and the final file after rename
+    // (atomic-mode replace on most filesystems, but chmodSync is the
+    // belt-and-braces invariant). Keep the generic per-agent state files
+    // routed through saveJson() at mode 0600 — only the activity index
+    // needs the daemon-group read grant.
     const tmp = `${path}.tmp`
-    writeFileSync(tmp, JSON.stringify(index, null, 2) + '\n', { mode: 0o600 })
+    writeFileSync(tmp, JSON.stringify(index, null, 2) + '\n', { mode: 0o640 })
+    chmodSync(tmp, 0o640)
     renameSync(tmp, path)
+    chmodSync(path, 0o640)
   } catch (err) {
     process.stderr.write(`teams channel: activity-index write failed: ${err}\n`)
   }
@@ -2218,6 +2234,65 @@ export function isInboundFromBotOrSelf(activity: Partial<Activity> & { from?: { 
   return false
 }
 
+/**
+ * L1 beta19 (codex r1 design 2026-05-25): BotFrameworkAdapter's
+ * processActivity assumes an Express-shaped response with `status()`
+ * and `send()`. Node's native http.ServerResponse only exposes
+ * `writeHead/end`, so the adapter throws TypeError on response-write
+ * paths (auth challenges, error replies). This shim adapts the
+ * native response to the Express subset the adapter actually calls.
+ *
+ * We deliberately do NOT migrate to CloudAdapter.processActivityDirect
+ * — that changes the auth/adapter semantics (CloudAdapter expects
+ * SingleTenant/MultiTenant credential resolution paths the current
+ * BotFrameworkAdapter setup does not have) and is well out of scope
+ * for an L1 stabilization fix.
+ *
+ * Exported for the shim smoke harness (server.ts `_smoke-shim`
+ * subcommand).
+ *
+ * Contract:
+ *   status(code)   → sets res.statusCode, returns the shim (chainable).
+ *   send(body)     → ends the native response exactly once.
+ *     Buffer / string  → res.end(body) as-is
+ *     object           → JSON.stringify + 'Content-Type: application/json'
+ *                        (only when no Content-Type already set)
+ *     undefined / null → res.end() with no body
+ *
+ * Second `send()` call is a no-op (defensive against the adapter
+ * accidentally double-ending on an error catch path).
+ */
+export function createExpressResponseShim(res: import('http').ServerResponse): {
+  status(code: number): any
+  send(body?: unknown): any
+} {
+  let ended = false
+  const shim: any = {
+    status(code: number) {
+      res.statusCode = code
+      return shim
+    },
+    send(body?: unknown) {
+      if (ended) return shim
+      ended = true
+      if (body === undefined || body === null) {
+        res.end()
+        return shim
+      }
+      if (Buffer.isBuffer(body) || typeof body === 'string') {
+        res.end(body)
+        return shim
+      }
+      if (!res.getHeader('Content-Type')) {
+        res.setHeader('Content-Type', 'application/json')
+      }
+      res.end(JSON.stringify(body))
+      return shim
+    },
+  }
+  return shim
+}
+
 const httpServer = createServer((req, res) => {
   const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`)
   if (req.method === 'GET' && url.pathname === '/health') {
@@ -2231,7 +2306,8 @@ const httpServer = createServer((req, res) => {
     return
   }
   if (req.method === 'POST' && url.pathname === '/api/messages') {
-    adapter.processActivity(req, res, async context => {
+    const shim = createExpressResponseShim(res)
+    adapter.processActivity(req, shim as any, async context => {
       await handleActivity(context)
     }).catch(err => {
       process.stderr.write(`teams channel: processActivity failed: ${err}\n`)
@@ -2343,6 +2419,98 @@ if (CLI_SUBCOMMAND === 'send-managed') {
 // `_smoke-channel-meta` asserts the direct Claude channel notification uses
 // scalar metadata, not the richer bridge queue payload. All smoke commands
 // short-circuit before httpServer.listen.
+if (CLI_SUBCOMMAND === '_smoke-shim') {
+  // L1 beta19 (codex r1 design 2026-05-25): exercise createExpressResponseShim
+  // with a fake http.ServerResponse that has writeHead/end but no
+  // status/send. The shim is what closes the BotFrameworkAdapter
+  // TypeError. Asserts response completes cleanly (no thrown TypeError
+  // on `res.status(...).send(...)`), and that the status + content-type
+  // + body propagated through to the underlying response. Output is
+  // a single JSON line on stdout consumed by the smoke harness.
+  const argv = process.argv.slice(3)
+  const flags: Record<string, string> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (!arg.startsWith('--')) continue
+    const key = arg.slice(2)
+    const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[i + 1] : ''
+    if (value) i++
+    flags[key] = value
+  }
+  const variant = String(flags['variant'] ?? 'json').trim()
+  // Build a minimal ServerResponse stand-in: just statusCode, headers,
+  // writeHead, end, setHeader, getHeader. Express does not introspect
+  // beyond these for the status/send code paths.
+  const headers: Record<string, string | number | string[]> = {}
+  let body: any = undefined
+  let ended = false
+  let endCalls = 0
+  const fakeRes: any = {
+    statusCode: 0,
+    headersSent: false,
+    writeHead(code: number, hdrs?: Record<string, string | number>) {
+      fakeRes.statusCode = code
+      fakeRes.headersSent = true
+      if (hdrs) Object.assign(headers, hdrs)
+    },
+    setHeader(name: string, value: string | number | string[]) {
+      headers[name] = value
+    },
+    getHeader(name: string) {
+      return headers[name]
+    },
+    end(b?: any) {
+      endCalls++
+      ended = true
+      body = b
+    },
+  }
+  let threw = false
+  let errMsg = ''
+  try {
+    const shim = createExpressResponseShim(fakeRes as any)
+    if (variant === 'json') {
+      shim.status(202).send({ ok: true, smoke: 'shim' })
+    } else if (variant === 'string') {
+      shim.status(200).send('plain string body')
+    } else if (variant === 'buffer') {
+      shim.status(200).send(Buffer.from('buffer-body'))
+    } else if (variant === 'empty') {
+      shim.status(204).send()
+    } else if (variant === 'null') {
+      shim.status(204).send(null)
+    } else if (variant === 'double-send') {
+      shim.status(200).send({ first: true })
+      shim.send({ second: 'should be ignored' })
+    } else {
+      process.stderr.write(`teams _smoke-shim: unknown variant '${variant}'\n`)
+      process.exit(2)
+    }
+  } catch (e) {
+    threw = true
+    errMsg = String(e)
+  }
+  const result = {
+    variant,
+    threw,
+    err: errMsg,
+    ended,
+    endCalls,
+    statusCode: fakeRes.statusCode,
+    contentType: headers['Content-Type'] ?? null,
+    bodyKind: body === undefined
+      ? 'undefined'
+      : body === null
+        ? 'null'
+        : Buffer.isBuffer(body)
+          ? 'buffer'
+          : typeof body,
+    bodyString: body === undefined || body === null ? '' : String(body),
+  }
+  process.stdout.write(JSON.stringify(result) + '\n')
+  process.exit(0)
+}
+
 if (
   CLI_SUBCOMMAND === '_smoke-record-activity'
   || CLI_SUBCOMMAND === '_smoke-should-record'

--- a/scripts/smoke/bun-runtime-traverse.sh
+++ b/scripts/smoke/bun-runtime-traverse.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/bun-runtime-traverse.sh — L1 beta19 (codex r1 design
+# 2026-05-25): exercise bridge_ensure_bun_runtime_traversable_for_isolated.
+#
+# The helper makes the operator's bun runtime traversable by isolated
+# UIDs. It's specifically scoped to the `$HOME/.bun/` install layout
+# (the official installer's drop location) — other PATH-resolved bun
+# installs (homebrew, fnm, system /usr/bin) are no-op'd because their
+# parent-mode contract is owned by another package manager.
+#
+# Tests:
+#   T1 — fake $HOME/.bun/bin/bun symlinked from PATH-visible dir,
+#        helper chmods $HOME/.bun and $HOME/.bun/bin to o+x (TRAVERSE
+#        ONLY, not o+r).
+#   T2 — BRIDGE_BUN_CHMOD_OPT_OUT=1 → modes unchanged.
+#   T3 — Bun's real target is OUTSIDE $HOME → no-op (modes unchanged).
+#
+# Linux-only: chmod modes are gated on Linux. On macOS we still exercise
+# the helper to make sure it doesn't crash, but we don't assert mode
+# bits (macOS sticky/setgid handling differs from Linux). The whole
+# helper is also a no-op on non-Linux by design (the chmod-traverse
+# bug it closes is a Linux $HOME/0750 problem).
+#
+# Footgun #11 — no heredoc-stdin.
+
+set -uo pipefail
+
+SMOKE_NAME="bun-runtime-traverse"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+# Pick bash 4+ (same shape as phase2-install-tree-reconciler.sh).
+if [[ -n "${BASH_BIN:-}" ]]; then
+  SMOKE_BASH="$BASH_BIN"
+elif [[ -x /opt/homebrew/bin/bash ]]; then
+  SMOKE_BASH="/opt/homebrew/bin/bash"
+elif [[ -x /usr/local/bin/bash ]]; then
+  SMOKE_BASH="/usr/local/bin/bash"
+else
+  SMOKE_BASH="$(command -v bash)"
+fi
+[[ -n "$SMOKE_BASH" && -x "$SMOKE_BASH" ]] \
+  || smoke_fail "no bash binary found"
+
+stat_mode_o() {
+  # Other-octal digit (last char of 3-digit mode).
+  local path="$1" m
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    m="$(stat -f '%Lp' "$path" 2>/dev/null)"
+  else
+    m="$(stat -c '%a' "$path" 2>/dev/null)"
+  fi
+  # Take the last digit (other perms). Works for 3-digit and 4-digit
+  # modes (the leading bits don't affect the other-bit position).
+  printf '%s' "${m: -1}"
+}
+
+# Build a fake $HOME/.bun layout under the smoke temp root, plus a
+# PATH-visible symlink pointing to it. The helper resolves PATH bun
+# via `command -v bun`, then walks symlinks with readlink -f to find
+# the real target.
+build_bun_fixture() {
+  local fake_home="$1"
+  rm -rf "$fake_home"
+  mkdir -p "$fake_home/.bun/bin"
+  printf '#!/bin/sh\nexit 0\n' >"$fake_home/.bun/bin/bun"
+  chmod 0755 "$fake_home/.bun/bin/bun"
+  # Tighten $HOME/.bun and bin/ so the helper has actual work to do.
+  chmod 0750 "$fake_home/.bun"
+  chmod 0750 "$fake_home/.bun/bin"
+
+  # PATH-visible symlink dir.
+  mkdir -p "$fake_home/.local/bin"
+  ln -sf "$fake_home/.bun/bin/bun" "$fake_home/.local/bin/bun"
+}
+
+build_external_bun_fixture() {
+  # Bun at a path NOT under $HOME — simulates homebrew / system install.
+  local fake_home="$1" extern_dir="$2"
+  rm -rf "$fake_home" "$extern_dir"
+  mkdir -p "$fake_home/.bun"
+  # Tighten the unused $HOME/.bun so we can assert it remains untouched.
+  chmod 0750 "$fake_home/.bun"
+
+  mkdir -p "$extern_dir"
+  printf '#!/bin/sh\nexit 0\n' >"$extern_dir/bun"
+  chmod 0755 "$extern_dir/bun"
+  chmod 0755 "$extern_dir"
+}
+
+# ---------------------------------------------------------------------------
+# T1 — $HOME/.bun → chmod o+x (traverse only, not o+r)
+# ---------------------------------------------------------------------------
+test_t1_home_bun_traverse() {
+  smoke_log "T1: $HOME/.bun bun → helper chmods o+x"
+  local fake_home="$SMOKE_TMP_ROOT/t1-home"
+  build_bun_fixture "$fake_home"
+
+  HOME="$fake_home" PATH="$fake_home/.local/bin:$PATH" \
+  "$SMOKE_BASH" -c "
+    set -uo pipefail
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_ensure_bun_runtime_traversable_for_isolated 0
+  " >"$SMOKE_TMP_ROOT/t1.out" 2>&1 || true
+
+  if ! smoke_is_linux; then
+    smoke_log "T1 SKIP (non-Linux: helper is a no-op outside Linux by design)"
+    return 0
+  fi
+
+  # Assert $HOME/.bun and $HOME/.bun/bin gained o+x.
+  local bun_o bin_o
+  bun_o="$(stat_mode_o "$fake_home/.bun")"
+  bin_o="$(stat_mode_o "$fake_home/.bun/bin")"
+  # o+x means the other-bit-set value must include 1 (execute). For
+  # 750→751 etc., the other digit becomes 1 (or higher if more bits
+  # set). We just assert the execute bit is on: (other & 1) != 0.
+  if (( (bun_o & 1) == 0 )); then
+    smoke_fail "T1: $fake_home/.bun other-mode='$bun_o' lacks +x (expected (other & 1) != 0)"
+  fi
+  if (( (bin_o & 1) == 0 )); then
+    smoke_fail "T1: $fake_home/.bun/bin other-mode='$bin_o' lacks +x"
+  fi
+  # Verify it's TRAVERSE ONLY — other-bit must NOT have +r (bit 4).
+  if (( bun_o & 4 )); then
+    smoke_fail "T1: $fake_home/.bun other-mode='$bun_o' has +r (read), helper must grant traverse only"
+  fi
+  if (( bin_o & 4 )); then
+    smoke_fail "T1: $fake_home/.bun/bin other-mode='$bin_o' has +r (read), helper must grant traverse only"
+  fi
+  smoke_log "T1 PASS (.bun=$bun_o .bun/bin=$bin_o)"
+}
+
+# ---------------------------------------------------------------------------
+# T2 — BRIDGE_BUN_CHMOD_OPT_OUT=1 → no chmod
+# ---------------------------------------------------------------------------
+test_t2_opt_out() {
+  smoke_log "T2: BRIDGE_BUN_CHMOD_OPT_OUT=1 → no-op"
+  local fake_home="$SMOKE_TMP_ROOT/t2-home"
+  build_bun_fixture "$fake_home"
+
+  local before_bun before_bin
+  before_bun="$(stat_mode_o "$fake_home/.bun")"
+  before_bin="$(stat_mode_o "$fake_home/.bun/bin")"
+
+  HOME="$fake_home" PATH="$fake_home/.local/bin:$PATH" \
+  BRIDGE_BUN_CHMOD_OPT_OUT=1 \
+  "$SMOKE_BASH" -c "
+    set -uo pipefail
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_ensure_bun_runtime_traversable_for_isolated 0
+  " >"$SMOKE_TMP_ROOT/t2.out" 2>&1 || true
+
+  local after_bun after_bin
+  after_bun="$(stat_mode_o "$fake_home/.bun")"
+  after_bin="$(stat_mode_o "$fake_home/.bun/bin")"
+
+  if [[ "$before_bun" != "$after_bun" ]]; then
+    smoke_fail "T2: $fake_home/.bun mode changed from '$before_bun' to '$after_bun' despite opt-out"
+  fi
+  if [[ "$before_bin" != "$after_bin" ]]; then
+    smoke_fail "T2: $fake_home/.bun/bin mode changed from '$before_bin' to '$after_bin' despite opt-out"
+  fi
+  smoke_log "T2 PASS (modes unchanged: .bun=$after_bun .bun/bin=$after_bin)"
+}
+
+# ---------------------------------------------------------------------------
+# T3 — bun NOT under $HOME → no-op
+# ---------------------------------------------------------------------------
+test_t3_external_bun_no_op() {
+  smoke_log "T3: bun real target outside $HOME → no-op"
+  local fake_home="$SMOKE_TMP_ROOT/t3-home"
+  local extern_dir="$SMOKE_TMP_ROOT/t3-extern/bin"
+  build_external_bun_fixture "$fake_home" "$extern_dir"
+
+  local before_bun
+  before_bun="$(stat_mode_o "$fake_home/.bun")"
+
+  HOME="$fake_home" PATH="$extern_dir:$PATH" \
+  "$SMOKE_BASH" -c "
+    set -uo pipefail
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_ensure_bun_runtime_traversable_for_isolated 0
+  " >"$SMOKE_TMP_ROOT/t3.out" 2>&1 || true
+
+  local after_bun
+  after_bun="$(stat_mode_o "$fake_home/.bun")"
+
+  if [[ "$before_bun" != "$after_bun" ]]; then
+    smoke_fail "T3: $fake_home/.bun mode changed from '$before_bun' to '$after_bun' but bun is NOT under $HOME — helper must be no-op"
+  fi
+  smoke_log "T3 PASS (no-op for external bun, $fake_home/.bun mode=$after_bun unchanged)"
+}
+
+smoke_run "T1 home-bun-traverse" test_t1_home_bun_traverse
+smoke_run "T2 opt-out" test_t2_opt_out
+smoke_run "T3 external-bun-no-op" test_t3_external_bun_no_op
+
+smoke_log "bun-runtime-traverse: ALL TESTS PASS"
+exit 0

--- a/scripts/smoke/phase2-install-tree-reconciler.sh
+++ b/scripts/smoke/phase2-install-tree-reconciler.sh
@@ -224,6 +224,32 @@ test_t1_matrix_rows() {
       "T1: Phase 3 Family 1 install row '$row_name' missing"
   done
 
+  # L1 beta19 (codex r1 design 2026-05-25) install-tree rows.
+  # Five new rows close patch's beta18 Phase 3 follow-up gaps:
+  #   shared/ms365-callbacks, state/channels, state/channels/teams,
+  #   state/queue, state/queue/bodies. All five are `state_scaffold` so
+  #   they mkdir absent dirs in --apply mode (plain `dir` would refuse).
+  for row_name in shared-ms365-callbacks-dir state-channels-root \
+                  state-channels-teams-dir state-queue-dir \
+                  state-queue-bodies-dir; do
+    smoke_assert_contains "$rows_out" "$row_name|" \
+      "T1: L1 beta19 install row '$row_name' missing"
+    # Belt-and-braces: the row MUST use state_scaffold kind, not `dir`.
+    # `dir` returns MISSING/FAIL on absent paths; absent-create is the
+    # whole reason for using state_scaffold. Find the row line and assert
+    # the kind field (column 4 in pipe-delimited row).
+    local _row_line
+    _row_line="$(printf '%s\n' "$rows_out" | grep "^${row_name}|" | head -n 1)"
+    if [[ -z "$_row_line" ]]; then
+      smoke_fail "T1: row '$row_name' present in matrix output substring check but row line not isolatable"
+    fi
+    local _row_kind
+    _row_kind="$(printf '%s\n' "$_row_line" | awk -F'|' '{print $4}')"
+    if [[ "$_row_kind" != "state_scaffold" ]]; then
+      smoke_fail "T1: L1 beta19 row '$row_name' must be kind=state_scaffold (got '$_row_kind' — plain 'dir' would not mkdir absent paths)"
+    fi
+  done
+
   # No per-agent rows when no --agent passed
   smoke_assert_not_contains "$rows_out" "agent-state-leaf|" \
     "T1: agent-state-leaf must be absent when no --agent"
@@ -326,9 +352,27 @@ test_t3_apply_idempotent() {
   " >"$SMOKE_TMP_ROOT/apply2.out" || apply2_rc=$?
 
   # Count changed rows on the second pass. Idempotent => zero changes.
+  # macOS exception: the L1 beta19 writer rows (shared-ms365-callbacks-dir,
+  # state-channels-teams-dir) carry mode 3770 (setgid + sticky + 0770).
+  # macOS silently drops the sticky bit on non-root chmod (the chmod
+  # syscall returns 0, stat shows 0770). On macOS the reconciler will
+  # therefore report "changed" on every pass for these two rows because
+  # the apply mode never converges to the requested 3770 — that's a
+  # macOS platform limitation, not a reconciler bug. The same rows are
+  # idempotent on Linux where sticky+setgid lands verbatim via direct
+  # chmod with no sudo.
+  local ignore_rows_pat=''
+  if ! smoke_is_linux; then
+    ignore_rows_pat='^(shared-ms365-callbacks-dir|state-channels-teams-dir)\|changed\|'
+  fi
   local second_changes
-  second_changes="$(grep -cE '\|changed\|' "$SMOKE_TMP_ROOT/apply2.out" \
-                    || true)"
+  if [[ -n "$ignore_rows_pat" ]]; then
+    second_changes="$(grep -E '\|changed\|' "$SMOKE_TMP_ROOT/apply2.out" \
+                      | grep -cvE "$ignore_rows_pat" || true)"
+  else
+    second_changes="$(grep -cE '\|changed\|' "$SMOKE_TMP_ROOT/apply2.out" \
+                      || true)"
+  fi
   if [[ "$second_changes" -ne 0 ]]; then
     smoke_log "T3: apply2 stdout (changed rows on pass 2 = $second_changes):"
     cat "$SMOKE_TMP_ROOT/apply2.out"
@@ -530,6 +574,143 @@ test_t8_regression_boomerang() {
 }
 
 # ---------------------------------------------------------------------------
+# T9 — L1 beta19 scaffold rows: absent → mkdir + canonical mode
+# ---------------------------------------------------------------------------
+# Functional fixture: delete the 5 L1 beta19 dirs (one was mkdir'd by
+# smoke_setup_bridge_home, none by smoke_build_fixture). Run --apply.
+# Assert each is now present at the expected mode.
+#
+# Note on mode asserts: this smoke runs as the operator UID against an
+# mktemp tree. The reconciler tries direct chmod first, then sudo
+# fallback. On macOS dev hosts the operator owns the tree so direct
+# chmod succeeds without sudo, and the modes land verbatim from the
+# matrix row. On a Linux CI without sudo + the operator already owning
+# the tree, the same path holds. Setgid+sticky bits encode in the
+# leading two octal digits of the mode (3770 = sticky+setgid+0770).
+#
+# The mode helper (smoke_path_mode) reads `stat -f %Lp` on Darwin and
+# `stat -c %a` on Linux — both return all 12 mode bits (suid/sgid/sticky
+# included) in octal.
+test_t9_l1_beta19_scaffold_modes() {
+  smoke_log "T9: L1 beta19 scaffold rows mkdir + chmod to canonical mode"
+
+  # Wipe any pre-existing L1 paths so state_scaffold has work to do.
+  # The fixture left state/runtime present, but the L1 paths below were
+  # never created by smoke_build_fixture.
+  rm -rf "$BRIDGE_HOME/shared/ms365-callbacks" \
+         "$BRIDGE_HOME/state/channels" \
+         "$BRIDGE_HOME/state/queue"
+
+  # Run --apply once. Any required-row failure is a smoke fail; partial
+  # failures on optional rows (credential grant w/o sudo) are tolerable
+  # as in T3.
+  local apply_rc=0
+  "$SMOKE_BASH" -c "
+    set -uo pipefail
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_isolation_v2_apply_install_tree_matrix --mode apply --reason manual 2>/dev/null
+  " >"$SMOKE_TMP_ROOT/t9_apply.out" 2>&1 || apply_rc=$?
+
+  # Existence check — every L1 path must now be present after --apply.
+  # This assertion runs on every platform: state_scaffold mkdir is
+  # not OS-gated.
+  local p
+  for p in \
+      "$BRIDGE_HOME/shared/ms365-callbacks" \
+      "$BRIDGE_HOME/state/channels" \
+      "$BRIDGE_HOME/state/channels/teams" \
+      "$BRIDGE_HOME/state/queue" \
+      "$BRIDGE_HOME/state/queue/bodies"; do
+    if [[ ! -d "$p" ]]; then
+      smoke_log "T9: t9_apply.out:"; cat "$SMOKE_TMP_ROOT/t9_apply.out"
+      smoke_fail "T9: L1 path $p was not created by --apply"
+    fi
+  done
+
+  # Mode + idempotence assertions are Linux-only. macOS silently strips
+  # the sticky bit (t) when a non-root user chmods a directory: the
+  # syscall returns 0 (no operator-visible chmod failure) but stat
+  # reports the dir as plain 0770 instead of 3770. That's a macOS
+  # design choice, not a reconciler bug — the production target is
+  # Linux. On Linux the operator-owned directory accepts setgid +
+  # sticky bits via direct chmod with no sudo, so the modes land
+  # verbatim and idempotence holds.
+  #
+  # codex r1 explicitly called this out: "If the smoke cannot safely
+  # assert real group ownership on macOS, keep the mode test
+  # Linux-gated." We extend the same gating to the sticky-bit mode
+  # asserts. The existence + state_scaffold-kind asserts above still
+  # run cross-platform; the structural contract is validated even when
+  # mode bits cannot be.
+  if ! smoke_is_linux; then
+    smoke_log "T9 PASS (apply_rc=$apply_rc, 5 L1 dirs exist; mode + idempotence asserts skipped on non-Linux — macOS strips sticky bit on non-root chmod)"
+    return 0
+  fi
+
+  # Mode helper: 12-bit octal incl. suid/sgid/sticky.
+  smoke_mode_12bit() {
+    local path="$1"
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+      stat -f '%Lp' "$path" 2>/dev/null
+    else
+      stat -c '%a' "$path" 2>/dev/null
+    fi
+  }
+
+  # Normalize for comparison — leading-zero stripping like the
+  # reconciler does ("3770" vs "03770"). bash arithmetic on octal.
+  smoke_assert_mode() {
+    local path="$1" want_oct="$2" ctx="$3"
+    local actual
+    actual="$(smoke_mode_12bit "$path")"
+    if [[ -z "$actual" ]]; then
+      smoke_fail "$ctx: cannot stat $path"
+    fi
+    local want_norm actual_norm
+    want_norm="$(printf '%o' "$((8#${want_oct#0}))")"
+    actual_norm="$(printf '%o' "$((8#${actual#0}))")"
+    if [[ "$want_norm" != "$actual_norm" ]]; then
+      smoke_log "T9: t9_apply.out:"; cat "$SMOKE_TMP_ROOT/t9_apply.out"
+      smoke_fail "$ctx: mode $path: want $want_norm got $actual_norm"
+    fi
+  }
+
+  # Writer dirs land at 3770 (setgid + sticky + 0770).
+  smoke_assert_mode "$BRIDGE_HOME/shared/ms365-callbacks" 3770 \
+    "T9: ms365-callbacks writer dir"
+  smoke_assert_mode "$BRIDGE_HOME/state/channels/teams" 3770 \
+    "T9: teams activity-index writer dir"
+
+  # Parent-traverse dirs land at 0710.
+  smoke_assert_mode "$BRIDGE_HOME/state/channels" 0710 \
+    "T9: state/channels parent"
+  smoke_assert_mode "$BRIDGE_HOME/state/queue" 0710 \
+    "T9: state/queue parent"
+  smoke_assert_mode "$BRIDGE_HOME/state/queue/bodies" 0710 \
+    "T9: state/queue/bodies parent"
+
+  # Idempotence: second --apply must produce zero changed rows for the
+  # L1 paths.
+  "$SMOKE_BASH" -c "
+    set -uo pipefail
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_isolation_v2_apply_install_tree_matrix --mode apply --reason manual 2>/dev/null
+  " >"$SMOKE_TMP_ROOT/t9_apply2.out" 2>&1 || true
+
+  local row
+  for row in shared-ms365-callbacks-dir state-channels-root \
+             state-channels-teams-dir state-queue-dir \
+             state-queue-bodies-dir; do
+    if grep -E "^${row}\|changed\|" "$SMOKE_TMP_ROOT/t9_apply2.out" >/dev/null 2>&1; then
+      smoke_log "T9: t9_apply2.out:"; cat "$SMOKE_TMP_ROOT/t9_apply2.out"
+      smoke_fail "T9: row '$row' reported 'changed' on second --apply; not idempotent"
+    fi
+  done
+
+  smoke_log "T9 PASS (apply_rc=$apply_rc, all 5 L1 dirs at canonical mode, idempotent)"
+}
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -541,6 +722,7 @@ smoke_run "T5 credential-grant" test_t5_credential_grant
 smoke_run "T6 marker-non-write-guard" test_t6_marker_non_write_guard
 smoke_run "T7 protected-files" test_t7_protected_files
 smoke_run "T8 regression-boomerang" test_t8_regression_boomerang
+smoke_run "T9 l1-beta19-scaffold-modes" test_t9_l1_beta19_scaffold_modes
 
 smoke_log "phase2-install-tree-reconciler: ALL TESTS PASS"
 exit 0

--- a/scripts/smoke/teams-shim-roundtrip.sh
+++ b/scripts/smoke/teams-shim-roundtrip.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/teams-shim-roundtrip.sh — L1 beta19 (codex r1 design
+# 2026-05-25): exercise plugins/teams/server.ts createExpressResponseShim
+# with a fake http.ServerResponse that has writeHead/end but no
+# status/send (the BotFrameworkAdapter response shape mismatch this fix
+# closes).
+#
+# Asserts:
+#   T1 — JSON object body → end() called once, statusCode=202,
+#        Content-Type=application/json, body=stringified JSON.
+#   T2 — String body → end() called once, statusCode=200, no
+#        Content-Type set, body=string verbatim.
+#   T3 — Buffer body → end() called once, statusCode=200, body=Buffer.
+#   T4 — undefined body → end() called once with no body, statusCode=204.
+#   T5 — null body → end() called once with no body, statusCode=204.
+#   T6 — double send() → second call is a no-op (defense against
+#        adapter double-end on error catch).
+#
+# Footgun #11 — no heredoc-stdin to subprocess. The bun invocation is
+# direct argv, output captured via plain `$()` substitution which is
+# safe (no piped stdin).
+
+set -uo pipefail
+
+SMOKE_NAME="teams-shim-roundtrip"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# Bun is required to run server.ts. Skip cleanly if absent (the smoke
+# matrix tolerates skips on hosts without bun installed).
+if ! command -v bun >/dev/null 2>&1; then
+  smoke_skip "teams-shim-roundtrip" "bun not on PATH; install via https://bun.sh/install to run this smoke"
+  exit 0
+fi
+
+TEAMS_DIR="$REPO_ROOT/plugins/teams"
+if [[ ! -d "$TEAMS_DIR/node_modules" ]]; then
+  smoke_log "ensuring plugins/teams/node_modules present"
+  if ! ( cd "$TEAMS_DIR" && bun install --frozen-lockfile --no-summary >&2 ); then
+    smoke_fail "bun install in plugins/teams failed"
+  fi
+fi
+
+run_shim_variant() {
+  local variant="$1"
+  TEAMS_APP_ID=smoke TEAMS_APP_PASSWORD=smoke \
+    bun "$TEAMS_DIR/server.ts" _smoke-shim --variant "$variant"
+}
+
+assert_json_field() {
+  local payload="$1" field="$2" want="$3" ctx="$4"
+  # python3 is the universal extractor we already require elsewhere
+  local got
+  got="$(printf '%s\n' "$payload" \
+        | python3 -c 'import json,sys; row=json.loads(sys.stdin.read().splitlines()[-1]); print(row.get(sys.argv[1]))' \
+            "$field" 2>/dev/null)"
+  if [[ "$got" != "$want" ]]; then
+    smoke_fail "$ctx: field $field want '$want' got '$got' from payload: $payload"
+  fi
+}
+
+test_t1_json_body() {
+  smoke_log "T1: JSON object body → application/json + statusCode=202"
+  local out
+  out="$(run_shim_variant json)"
+  assert_json_field "$out" threw "False" "T1"
+  assert_json_field "$out" ended "True" "T1"
+  assert_json_field "$out" endCalls "1" "T1"
+  assert_json_field "$out" statusCode "202" "T1"
+  assert_json_field "$out" contentType "application/json" "T1"
+  assert_json_field "$out" bodyString '{"ok":true,"smoke":"shim"}' "T1"
+  smoke_log "T1 PASS"
+}
+
+test_t2_string_body() {
+  smoke_log "T2: string body → no Content-Type set, body verbatim"
+  local out
+  out="$(run_shim_variant string)"
+  assert_json_field "$out" threw "False" "T2"
+  assert_json_field "$out" ended "True" "T2"
+  assert_json_field "$out" statusCode "200" "T2"
+  assert_json_field "$out" contentType "None" "T2"
+  assert_json_field "$out" bodyString "plain string body" "T2"
+  smoke_log "T2 PASS"
+}
+
+test_t3_buffer_body() {
+  smoke_log "T3: Buffer body → bodyKind=buffer, no Content-Type"
+  local out
+  out="$(run_shim_variant buffer)"
+  assert_json_field "$out" threw "False" "T3"
+  assert_json_field "$out" ended "True" "T3"
+  assert_json_field "$out" statusCode "200" "T3"
+  assert_json_field "$out" bodyKind "buffer" "T3"
+  smoke_log "T3 PASS"
+}
+
+test_t4_empty_body() {
+  smoke_log "T4: undefined body → res.end() with no body"
+  local out
+  out="$(run_shim_variant empty)"
+  assert_json_field "$out" threw "False" "T4"
+  assert_json_field "$out" ended "True" "T4"
+  assert_json_field "$out" statusCode "204" "T4"
+  assert_json_field "$out" bodyKind "undefined" "T4"
+  smoke_log "T4 PASS"
+}
+
+test_t5_null_body() {
+  smoke_log "T5: null body → res.end() with no body"
+  local out
+  out="$(run_shim_variant null)"
+  assert_json_field "$out" threw "False" "T5"
+  assert_json_field "$out" ended "True" "T5"
+  assert_json_field "$out" statusCode "204" "T5"
+  assert_json_field "$out" bodyKind "undefined" "T5"
+  smoke_log "T5 PASS"
+}
+
+test_t6_double_send_no_op() {
+  smoke_log "T6: second send() is a no-op (defensive against adapter double-end)"
+  local out
+  out="$(run_shim_variant double-send)"
+  assert_json_field "$out" threw "False" "T6"
+  assert_json_field "$out" endCalls "1" "T6"
+  # First send wins — payload should be the first body, not the second.
+  assert_json_field "$out" bodyString '{"first":true}' "T6"
+  smoke_log "T6 PASS"
+}
+
+smoke_run "T1 json-body" test_t1_json_body
+smoke_run "T2 string-body" test_t2_string_body
+smoke_run "T3 buffer-body" test_t3_buffer_body
+smoke_run "T4 empty-body" test_t4_empty_body
+smoke_run "T5 null-body" test_t5_null_body
+smoke_run "T6 double-send-no-op" test_t6_double_send_no_op
+
+smoke_log "teams-shim-roundtrip: ALL TESTS PASS"
+exit 0

--- a/tests/precompact-notify/teams-mattermost-adapter.sh
+++ b/tests/precompact-notify/teams-mattermost-adapter.sh
@@ -523,6 +523,21 @@ t9_teams_writer_schema() {
     fail "$case" "expected last_user_inbound_recorded_ns numeric; got: $(cat "$index_path")"
     return
   fi
+  # L1 beta19 (codex r1 design 2026-05-25): the activity-index file must
+  # land at mode 0640 so the controller daemon's route lookup
+  # (bridge-channels.py:289-304) can read it through the ab-shared group
+  # when the file was created by an isolated UID. Prior to L1 beta19 the
+  # writer used 0600, which blocked the daemon read.
+  local actual_mode
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    actual_mode="$(stat -f '%Lp' "$index_path" 2>/dev/null)"
+  else
+    actual_mode="$(stat -c '%a' "$index_path" 2>/dev/null)"
+  fi
+  if [[ "$actual_mode" != "640" ]]; then
+    fail "$case" "expected activity-index file mode 0640 (L1 beta19); got mode $actual_mode at $index_path"
+    return
+  fi
   pass "$case"
 }
 


### PR DESCRIPTION
## Summary

5 install-tree gaps patch flagged after Phase 3 PASS + Teams BotFrameworkAdapter response shim + activity-index file mode + bun runtime traverse helper. All in ONE PR per operator batch rule.

Implements codex r1 design at task #6258 (implement-ok with corrections over the original L1 brief: `state_scaffold` not `dir`, 3770 not 0750 for writer dirs, TS-side activity-index 0640 fix, queue body sibling row, bun helper in `bridge-channels.sh`).

## patch's beta18 follow-up findings — closed in this PR

| # | Finding | Closure |
|---|---|---|
| 1 | `processActivity` TypeError — BotFrameworkAdapter assumes Express-shaped response (`status()`, `send()`); native http.ServerResponse only has `writeHead/end` | New `createExpressResponseShim` in `plugins/teams/server.ts` wraps the native response. Object→JSON+Content-Type, Buffer/string→as-is, null/undefined→end with no body. Defensive double-send is a no-op. NOT a CloudAdapter migration (out of scope — would change auth semantics). |
| 2 | `shared/ms365-callbacks` missing reconciler row — iso UID can't write callback `<state>.json` | New `shared-ms365-callbacks-dir` row, mode 3770 (controller + ab-shared rwx, setgid + sticky). Writers create/unlink via iso UID; setgid keeps group ab-shared on every child file; sticky prevents cross-UID delete. |
| 3 | `state/channels` + `state/channels/teams` missing — iso UID can't write activity index, controller can't read iso-UID-written file at 0600 | New `state-channels-root` (mode 0710, parent traverse) + `state-channels-teams-dir` (mode 3770, writer dir). TS-side `writeTeamsActivityIndex` drops file mode to 0640 (tmp file + chmod after rename) so the controller daemon's route lookup (`bridge-channels.py:289-304`) can read via ab-shared group. |
| 4 | `bun` PATH-visible symlink resolves to `$HOME/.bun/bin/bun` but iso UIDs can't traverse `$HOME/.bun` at 0750 | New `bridge_ensure_bun_runtime_traversable_for_isolated` in `lib/bridge-channels.sh`. Linux-only, honors `BRIDGE_BUN_CHMOD_OPT_OUT`. `chmod o+x` (TRAVERSE ONLY, not o+r) on `$HOME/.bun` + `$HOME/.bun/bin` when `command -v bun` real target sits under `$HOME/.bun/`. No-op for homebrew/system/asdf bun. Wired into both setup-teams (`bridge_provision_teams_plugin_runtime`) and upgrade (`bridge-upgrade.sh` via new `lib/upgrade-helpers/bun-traverse-chmod.sh` — Footgun #11: standalone helper, no heredoc-stdin). |
| 5 | `state/queue` + `state/queue/bodies` missing — iso UID nested body lookup hits EACCES on `bridge-queue.py:310-315` body files | New `state-queue-dir` + `state-queue-bodies-dir`, both mode 0710. Parent traverse only; body file content stays controller-owned (iso UIDs reach bodies via gateway code paths). |

All 5 new reconciler rows use `state_scaffold` kind (NOT plain `dir`). Plain `dir` returns MISSING/FAIL on absent paths — but every L1 path may be absent on a fresh install (no callback received yet, no body written yet). `state_scaffold` mkdir's in `--apply` mode then runs the same chown+chmod path as `dir`.

## VM acceptance (in-place upgrade verify path)

Run on `agb-clean-test` (OrbStack Ubuntu noble). Starting state: beta18-equivalent (Phase 3 commits applied at version 0.14.5-beta17). All 8 steps PASS:

1. ✅ `agent-bridge upgrade --apply --channel current` on feat/beta19-l1-row-gaps (HEAD 8bd1d33) — 126 files copied, 1 merge conflict on `_template/.claude/settings.json` (pre-existing operator customization, expected). bun-traverse helper fired during upgrade.
2. ✅ `agent-bridge isolation reconcile --check --all-agents --json` — all 5 new L1 rows present with `"status": "ok"`:
   - `shared-ms365-callbacks-dir` at `sean:ab-shared 3770`
   - `state-channels-root` at `sean:ab-shared 710`
   - `state-channels-teams-dir` at `sean:ab-shared 3770`
   - `state-queue-dir` at `sean:ab-shared 710`
   - `state-queue-bodies-dir` at `sean:ab-shared 710`
3. ✅ Reused `test_iso3` (linux-user isolation, OS user `agent-bridge-test_iso3`, group `ab-agent-test_iso3`).
4. ✅ Bun-traverse helper effect verified: `~/.bun` and `~/.bun/bin` widened from 0750 → 0751 (other-bit=1, TRAVERSE ONLY — no read bit). `sudo -u agent-bridge-test_iso3 /home/sean/.bun/bin/bun --version` → `1.3.14`. (Reproduced the bug first by manually tightening to 0750; iso UID hit `Permission denied`; ran helper; iso UID succeeded.)
5. ✅ `agb inbox test_iso3` from iso UID returns in **0.15s** (no 30s gateway timeout). (Pre-existing roster perm warning unrelated to L1.)
6. ✅ Teams shim via `_smoke-shim` CLI exercised on the in-place upgraded live install:
   - `--variant json`: `endCalls=1, statusCode=202, contentType=application/json, bodyString={"ok":true,"smoke":"shim"}`, no thrown
   - `--variant double-send`: second send is no-op (`endCalls=1`, first payload wins). No `processActivity` TypeError.
7. ✅ MS365 callback write from iso UID: `echo {...} > shared/ms365-callbacks/iso-test-state-<ts>.json` succeeded (rc=0). File landed `agent-bridge-test_iso3:ab-shared 664` — group inherited via setgid bit as designed.
8. ✅ Teams activity-index write from iso UID via `_smoke-record-activity`: created `state/channels/teams/test_iso3.json` at **mode 0640, group ab-shared**. `python3 -c "json.load(...)"` parsed it successfully — controller can read.

## Tests added

- **`scripts/smoke/phase2-install-tree-reconciler.sh`**:
  - T1 extended: asserts all 5 new row names present + asserts `kind=state_scaffold` (not `dir`) via pipe-field check.
  - T9 (new): functional fixture — start with absent dirs, run `--apply`, assert existence (all 5 dirs created) + assert exact modes (3770 writer, 0710 parent) + assert idempotence. Mode + idempotence asserts Linux-gated (macOS strips sticky bit on non-root chmod — codex r1 noted this case).
  - T3 extended: ignores `shared-ms365-callbacks-dir` + `state-channels-teams-dir` `changed` rows on non-Linux in the idempotence count (same macOS reason).
- **`scripts/smoke/teams-shim-roundtrip.sh`** (new): 6 cases exercising `createExpressResponseShim` via new `_smoke-shim` CLI subcommand — JSON object body, string, Buffer, undefined, null, double-send-no-op. All assert no thrown TypeError, single end() call, correct status + content-type + body kind.
- **`scripts/smoke/bun-runtime-traverse.sh`** (new): T1 `$HOME/.bun` → o+x (TRAVERSE ONLY, asserts bit 1 set + bit 4 NOT set; Linux-gated mode assert), T2 `BRIDGE_BUN_CHMOD_OPT_OUT=1` → no-op, T3 external bun (outside `$HOME`) → no-op.
- **`tests/precompact-notify/teams-mattermost-adapter.sh`** T9 extended: asserts activity-index file lands at mode 0640 (was implicit at 0600 before this PR).

All existing smokes still pass: phase2-install-tree-reconciler (9/9), phase3-agent-home-contract (7/7), teams-mattermost-adapter (9 pass / 1 pre-existing skip).

## Files

```
 bridge-upgrade.sh                                  |  31 ++
 lib/bridge-channels.sh                             | 112 ++++
 lib/bridge-isolation-v2-reconcile.sh               |  46 ++
 lib/upgrade-helpers/bun-traverse-chmod.sh          |  43 ++  (new)
 plugins/teams/server.ts                            | 172 +++++
 scripts/smoke/bun-runtime-traverse.sh              | 209 ++++++  (new)
 scripts/smoke/phase2-install-tree-reconciler.sh    | 186 ++++++
 scripts/smoke/teams-shim-roundtrip.sh              | 136 +++++  (new)
 tests/precompact-notify/teams-mattermost-adapter.sh|  15 ++
 9 files changed, 954 insertions(+), 4 deletions(-)
```

## Out of scope (per brief)

- Daemon supplementary-group refresh (L2 brief, design only).
- Per-agent state directories for activity index (residual risk codex noted; v0.16+).
- CloudAdapter migration.
- Bundling/system-installing Bun.
- Symlink model removal.

## Notes for orchestrator

- NO VERSION/CHANGELOG bump (operator beta19-cuts after merge).
- NO codex review request — codex r1 at task #6258 IS the spec; brief says "design IS the spec above".
- Base: `stabilize/v0.14.5-vm-passes`.

(#1186 sequel, beta19 L1 wave)

🤖 Generated with [Claude Code](https://claude.com/claude-code)