### PR TITLE
feat(plugins): beta20 L1 wave 2 — seed propagation + per-channel install-tree expansion + bundled-plugin bun install (#1187 sequel)

### DIFF
--- a/bridge-plugins.sh
+++ b/bridge-plugins.sh
@@ -26,7 +26,7 @@ usage() {
   local prog
   prog="$(basename "$0")"
   printf 'Usage:\n'
-  printf '  %s seed [--marketplace-root <path>] [--channels <csv>] [--dry-run]\n' "$prog"
+  printf '  %s seed [--marketplace-root <path>] [--channels <csv>] [--dry-run] [--no-iso-chmod]\n' "$prog"
   printf '  %s show [--json]\n' "$prog"
   printf '\n'
   printf 'Seed populates the v2 shared plugin catalog at\n'
@@ -121,6 +121,7 @@ bridge_plugins_cmd_seed() {
   local marketplace_root=""
   local channels_csv=""
   local dry_run=0
+  local no_iso_chmod=0
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --marketplace-root)
@@ -137,6 +138,15 @@ bridge_plugins_cmd_seed() {
         dry_run=1
         shift
         ;;
+      --no-iso-chmod)
+        # L1-F (beta20): skip the o+rX recursive grant on the marketplace
+        # source dir. Operators with a read-only mount or who want to
+        # manage UID visibility manually pass this; the iso UID side
+        # then needs an alternative read path (named-user ACL or a
+        # symlink under $BRIDGE_HOME/plugins owned by the controller).
+        no_iso_chmod=1
+        shift
+        ;;
       -h|--help)
         usage
         return 0
@@ -150,6 +160,15 @@ bridge_plugins_cmd_seed() {
   [[ -n "$marketplace_root" ]] || marketplace_root="$(bridge_plugins_default_marketplace_root)"
   if [[ ! -f "$marketplace_root/.claude-plugin/marketplace.json" ]]; then
     bridge_die "agb plugins seed: marketplace.json not found at $marketplace_root/.claude-plugin/marketplace.json. Pass --marketplace-root <path> to an Agent Bridge-format plugin marketplace."
+  fi
+  # Canonicalize so downstream propagation (controller registry +
+  # per-iso-UID known_marketplaces.json) writes a stable absolute path
+  # — Claude's marketplace resolver compares strings, not realpath, so
+  # `/tmp/foo` and `/tmp/./foo` would round-trip differently.
+  local _marketplace_root_resolved=""
+  if _marketplace_root_resolved="$(cd -P "$marketplace_root" 2>/dev/null && pwd -P)" \
+      && [[ -n "$_marketplace_root_resolved" ]]; then
+    marketplace_root="$_marketplace_root_resolved"
   fi
   if [[ -z "$channels_csv" ]]; then
     channels_csv="$(bridge_plugins_default_channels_csv "$marketplace_root")" \
@@ -166,6 +185,7 @@ bridge_plugins_cmd_seed() {
     printf '  channels         = %s\n' "$channels_csv"
     printf '  plugins_cache    = %s\n' "$plugins_cache"
     printf '  shared_group     = %s\n' "${BRIDGE_SHARED_GROUP:-ab-shared}"
+    printf '  no_iso_chmod     = %s\n' "$no_iso_chmod"
     return 0
   fi
 
@@ -212,7 +232,337 @@ bridge_plugins_cmd_seed() {
     bridge_die "agb plugins seed: sync completed but $plugins_cache/installed_plugins.json was not written. This usually means every channel was filtered out (check --channels CSV) or the marketplace at $marketplace_root has no resolvable plugins."
   fi
 
+  # ----- L1 wave 2 propagation steps (beta20, 2026-05-25) -----
+
+  # Resolve marketplace name for the propagation steps. Both controller
+  # registry add (D1) and per-iso-UID merge (D2) key off the name field
+  # from marketplace.json — keep it as a single source of truth.
+  local _seed_mkt_name=""
+  _seed_mkt_name="$(python3 "$SCRIPT_DIR/lib/upgrade-helpers/plugins-seed-marketplace-name.py" \
+                    "$marketplace_root/.claude-plugin/marketplace.json" 2>/dev/null || printf '')"
+
+  # D1 (L1-A): propagate the marketplace to the controller's claude
+  # registry. Without this, `claude plugin install --scope user <spec>`
+  # in the launcher path needs a manual `claude plugin marketplace add`
+  # before it can resolve `<plugin>@<marketplace>`. We do the same
+  # already in `bridge_ensure_agent_bridge_claude_marketplace` for the
+  # bundled marketplace, but only on-demand when an agent's launch
+  # path hits a plugin: channel. Seeding should propagate up-front so
+  # an `agent start` on a fresh install does NOT spawn the slow
+  # marketplace-add side trip.
+  bridge_plugins_seed_propagate_controller_registry "$marketplace_root" "$_seed_mkt_name" \
+    || bridge_warn "[plugins seed] controller claude-registry propagation: non-fatal failure (continuing)"
+
+  # D3 (L1-F): external marketplace clones often land at mode 0700
+  # (operator umask), which iso UIDs cannot traverse → dev-plugin-cache
+  # source-link / read fails. Recursively grant world traverse + read
+  # (`o+rX`) so the iso UID can resolve the source path through the
+  # known_marketplaces.json entry written by D2. Gated to Linux + iso
+  # v2 + path-under-operator-HOME so the helper doesn't widen system
+  # directories or no-op-needlessly on macOS dev hosts.
+  if (( no_iso_chmod == 0 )); then
+    bridge_plugins_seed_external_marketplace_iso_readable "$marketplace_root" \
+      || bridge_warn "[plugins seed] external marketplace o+rX grant: non-fatal failure (continuing)"
+  else
+    bridge_info "[plugins seed] --no-iso-chmod set: skipping recursive o+rX on $marketplace_root (operator-managed)"
+  fi
+
+  # D2 (L1-D): propagate the marketplace entry to every linux-user
+  # isolated agent's per-UID known_marketplaces.json whose channels
+  # reference this marketplace. Without this, `resolve_marketplace_root`
+  # in bridge-dev-plugin-cache.py (running under BRIDGE_CLAUDE_PLUGINS_ROOT
+  # pointing at the iso HOME) falls back to the bundled agent-bridge
+  # marketplace and the plugin install silently mismatches.
+  #
+  # Pre-existing per-agent isolation prepare ALREADY writes a filtered
+  # per-UID catalog (bridge_write_isolated_known_marketplaces_catalog)
+  # — but that runs at `agent create --linux-user` time, not at seed
+  # time, and it reads from the CONTROLLER's known_marketplaces.json.
+  # Seed→per-agent-prepare is the canonical order on a clean install,
+  # but on a retrofit (operator runs `agb plugins seed` AFTER the iso
+  # agents already exist) the per-UID catalog still lacks the entry.
+  # This step covers that retrofit path. The per-agent prepare path
+  # remains the canonical writer for fresh agent creation.
+  bridge_plugins_seed_propagate_iso_known_marketplaces "$marketplace_root" "$_seed_mkt_name" \
+    || bridge_warn "[plugins seed] iso known_marketplaces.json propagation: non-fatal failure (continuing)"
+
   printf '[ok] seeded %s (installed_plugins.json present)\n' "$plugins_cache"
+}
+
+# D1 (L1-A): add the marketplace to the controller's claude registry
+# at `$HOME/.claude/plugins/known_marketplaces.json`. Idempotent —
+# `claude plugin marketplace list` is consulted first to avoid
+# duplicate writes.
+#
+# Args:
+#   $1 — marketplace_root (canonicalized absolute path)
+#   $2 — marketplace_name (from manifest)
+#
+# Returns:
+#   0 on success or already-present, non-zero if the add failed.
+#   Missing `claude` binary returns 0 with a bridge_info note — fresh
+#   installs that do not yet have the Claude CLI in PATH should not
+#   block the seed.
+bridge_plugins_seed_propagate_controller_registry() {
+  local mkt_root="$1"
+  local mkt_name="$2"
+
+  if ! command -v claude >/dev/null 2>&1; then
+    bridge_info "[plugins seed] D1: claude CLI not on PATH — skipping controller-registry add (will lazy-add via bridge_ensure_*_marketplace when an agent's plugin channel fires)"
+    return 0
+  fi
+
+  if [[ -z "$mkt_name" ]]; then
+    bridge_warn "[plugins seed] D1: could not resolve marketplace name from $mkt_root/.claude-plugin/marketplace.json — skipping controller-registry add"
+    return 1
+  fi
+
+  local list_output=""
+  list_output="$(claude plugin marketplace list 2>/dev/null || true)"
+  # Word-boundary match (mirrors bridge_claude_marketplace_ensure_present_for_isolated).
+  if printf '%s\n' "$list_output" \
+      | grep -Eq "(^|[[:space:]])${mkt_name}([[:space:]]|\$)"; then
+    bridge_info "[plugins seed] D1: marketplace '$mkt_name' already in controller registry (skipped)"
+    return 0
+  fi
+
+  bridge_info "[plugins seed] D1: adding marketplace '$mkt_name' to controller registry: $mkt_root"
+  if ! claude plugin marketplace add --scope user "$mkt_root" >/dev/null 2>&1; then
+    bridge_warn "[plugins seed] D1: \`claude plugin marketplace add --scope user $mkt_root\` failed — agents on this marketplace may need a manual marketplace add before first plugin install"
+    return 1
+  fi
+  return 0
+}
+
+# D3 (L1-F): grant world traverse+read recursively on an external
+# marketplace clone dir so iso UIDs can read package files via the
+# `known_marketplaces.json` directory source pointer.
+#
+# Gated to Linux + iso v2 active + path under $HOME (operator's home,
+# not a system path). On non-Linux hosts and on shared-mode installs
+# the grant is a no-op — there is no separate UID to grant to.
+#
+# Args:
+#   $1 — marketplace_root (canonicalized absolute path)
+bridge_plugins_seed_external_marketplace_iso_readable() {
+  local mkt_root="$1"
+
+  # Linux-only — macOS dev hosts run agents under the operator UID so
+  # the read path is already covered.
+  if [[ "$(uname -s 2>/dev/null)" != "Linux" ]]; then
+    return 0
+  fi
+  # Skip when iso v2 isn't active (shared-mode installs don't need
+  # this widening).
+  if ! bridge_isolation_v2_active 2>/dev/null; then
+    return 0
+  fi
+  # If the marketplace root IS the bundled in-repo marketplace
+  # (`$SCRIPT_DIR`), don't widen it here — the install-tree reconciler
+  # already covers `$BRIDGE_HOME/{lib,scripts,hooks,runtime,shared}` and
+  # the source checkout is covered by the operator's existing umask
+  # plus the matrix's `data-root`/`lib-dir` etc. rows.
+  local bundled_root="$SCRIPT_DIR"
+  if [[ "$mkt_root" == "$bundled_root" ]]; then
+    bridge_info "[plugins seed] D3: marketplace_root == bundled in-repo marketplace ($mkt_root) — install-tree reconciler covers it (skipping recursive o+rX)"
+    return 0
+  fi
+  # Only widen paths under $HOME — refuse to walk system paths so a
+  # mistake (e.g. `--marketplace-root /usr`) cannot accidentally widen
+  # /usr/local/* or similar.
+  local home_dir="${HOME:-}"
+  if [[ -z "$home_dir" ]]; then
+    bridge_warn "[plugins seed] D3: \$HOME is unset — refusing to widen $mkt_root (caller's HOME must be set for the safety gate)"
+    return 1
+  fi
+  case "$mkt_root" in
+    "$home_dir"|"$home_dir"/*)
+      :
+      ;;
+    /tmp/*|/var/tmp/*|/private/tmp/*|/private/var/tmp/*)
+      # tmpdirs are operator-writable and frequently used for fixture
+      # marketplaces (the brief's `/tmp/cosmax-crm-cli`, `/tmp/pi-registry`,
+      # smoke fixtures). Allow.
+      :
+      ;;
+    *)
+      bridge_info "[plugins seed] D3: marketplace_root $mkt_root is outside \$HOME and tmpdirs — skipping recursive o+rX (operator must manage read access for iso UIDs manually, or pass --no-iso-chmod and configure named-user ACL)"
+      return 0
+      ;;
+  esac
+  if [[ ! -d "$mkt_root" ]]; then
+    bridge_warn "[plugins seed] D3: marketplace_root is not a directory: $mkt_root — skipping recursive o+rX"
+    return 1
+  fi
+
+  bridge_info "[plugins seed] D3: granting recursive o+rX on $mkt_root so iso UIDs can read package files (use --no-iso-chmod to opt out)"
+  # `chmod -R o+rX` — POSIX X grants execute only on dirs (preserves
+  # the executable bit on files that already have it without
+  # promoting every file to executable). No sudo: this is the
+  # operator's own tree.
+  if ! chmod -R o+rX "$mkt_root" 2>/dev/null; then
+    bridge_warn "[plugins seed] D3: \`chmod -R o+rX $mkt_root\` failed — iso UIDs may not be able to read package files. Operator may have a read-only mount; re-run with --no-iso-chmod once an alternative read path (named-user ACL or controller-owned symlink) is configured."
+    return 1
+  fi
+  return 0
+}
+
+# D2 (L1-D): write/merge the marketplace entry into each linux-user
+# isolated agent's `~/.claude/plugins/known_marketplaces.json` whose
+# channels reference this marketplace. Runs as root via
+# `bridge_linux_sudo_root` because the destination is under
+# `/home/agent-bridge-<a>/` (root-owned with group=ab-agent-<a>).
+#
+# Args:
+#   $1 — marketplace_root (canonicalized absolute path)
+#   $2 — marketplace_name (from manifest)
+bridge_plugins_seed_propagate_iso_known_marketplaces() {
+  local mkt_root="$1"
+  local mkt_name="$2"
+
+  if [[ "$(uname -s 2>/dev/null)" != "Linux" ]]; then
+    return 0
+  fi
+  if ! bridge_isolation_v2_active 2>/dev/null; then
+    return 0
+  fi
+  if [[ -z "$mkt_name" ]]; then
+    bridge_warn "[plugins seed] D2: could not resolve marketplace name from $mkt_root/.claude-plugin/marketplace.json — skipping iso UID propagation"
+    return 1
+  fi
+
+  # Need the reapply-eligible helper + per-agent shell helpers.
+  if ! command -v bridge_isolation_v2_reapply_eligible_agents >/dev/null 2>&1; then
+    bridge_info "[plugins seed] D2: bridge_isolation_v2_reapply_eligible_agents not loaded — skipping iso UID propagation (no roster active)"
+    return 0
+  fi
+  if ! command -v bridge_agent_channels_csv >/dev/null 2>&1; then
+    bridge_info "[plugins seed] D2: bridge_agent_channels_csv not loaded — skipping iso UID propagation"
+    return 0
+  fi
+  if ! command -v bridge_agent_os_user >/dev/null 2>&1; then
+    bridge_info "[plugins seed] D2: bridge_agent_os_user not loaded — skipping iso UID propagation"
+    return 0
+  fi
+
+  # The seed command does not load the roster eagerly (the sync helper
+  # itself does not need per-agent declarations). D2 does — it walks
+  # every linux-user iso agent's channel list. Load the roster
+  # idempotently here. bridge_load_roster short-circuits on
+  # already-loaded state.
+  if command -v bridge_load_roster >/dev/null 2>&1; then
+    bridge_load_roster >/dev/null 2>&1 || true
+  fi
+
+  local eligible=""
+  eligible="$(bridge_isolation_v2_reapply_eligible_agents 2>/dev/null || true)"
+  if [[ -z "$eligible" ]]; then
+    bridge_info "[plugins seed] D2: no linux-user isolated agents in roster — nothing to propagate"
+    return 0
+  fi
+
+  local agent
+  local propagated=0
+  local skipped=0
+  local failed=0
+  while IFS= read -r agent; do
+    [[ -n "$agent" ]] || continue
+    local agent_channels=""
+    agent_channels="$(bridge_agent_channels_csv "$agent" 2>/dev/null || printf '')"
+    # Only propagate when at least one channel references THIS marketplace.
+    if ! _bridge_plugins_seed_channels_csv_uses_marketplace "$agent_channels" "$mkt_name"; then
+      ((skipped++)) || true
+      continue
+    fi
+
+    local os_user=""
+    os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+    if [[ -z "$os_user" ]]; then
+      bridge_warn "[plugins seed] D2: agent '$agent' has no os_user resolved — skipping"
+      ((failed++)) || true
+      continue
+    fi
+
+    local user_home=""
+    if command -v bridge_agent_linux_user_home >/dev/null 2>&1; then
+      user_home="$(bridge_agent_linux_user_home "$os_user" 2>/dev/null || printf '')"
+    fi
+    if [[ -z "$user_home" || ! -d "$user_home" ]]; then
+      bridge_warn "[plugins seed] D2: agent '$agent' (os_user=$os_user) has no resolvable HOME ($user_home) — skipping"
+      ((failed++)) || true
+      continue
+    fi
+
+    local iso_plugins_dir="$user_home/.claude/plugins"
+    if ! bridge_linux_sudo_root test -d "$iso_plugins_dir" 2>/dev/null; then
+      bridge_info "[plugins seed] D2: agent '$agent' has no $iso_plugins_dir (iso prep has not run yet) — skipping; next \`agent create\` or reapply will write the catalog"
+      ((skipped++)) || true
+      continue
+    fi
+
+    local iso_known="$iso_plugins_dir/known_marketplaces.json"
+    local agent_group=""
+    if command -v bridge_isolation_v2_agent_group_name >/dev/null 2>&1; then
+      agent_group="$(bridge_isolation_v2_agent_group_name "$agent" 2>/dev/null || printf '')"
+    fi
+
+    # Write the merged catalog via the standalone helper. The helper is
+    # idempotent and uses a same-dir temp + os.replace so partial writes
+    # never leave a half-merged file. We do the merge from the current
+    # iso_known content (if any) → out path = iso_known. Run as root so
+    # the file lands at the right owner; chown/chmod follow.
+    local rc=0
+    if ! bridge_linux_sudo_root python3 \
+        "$SCRIPT_DIR/lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py" \
+        "$iso_known" "$iso_known" "$mkt_name" "$mkt_root" >/dev/null 2>&1; then
+      rc=$?
+      bridge_warn "[plugins seed] D2: merge for agent '$agent' (target=$iso_known) failed with rc=$rc"
+      ((failed++)) || true
+      continue
+    fi
+    # root:ab-agent-<a> mode 0640 — matches the contract that
+    # bridge_write_isolated_known_marketplaces_catalog applies to
+    # the same file on the canonical per-agent prepare path.
+    if [[ -n "$agent_group" ]]; then
+      bridge_linux_sudo_root chown "root:$agent_group" "$iso_known" >/dev/null 2>&1 \
+        || bridge_warn "[plugins seed] D2: chown root:$agent_group $iso_known failed (agent '$agent')"
+    else
+      bridge_linux_sudo_root chown root:root "$iso_known" >/dev/null 2>&1 || true
+    fi
+    bridge_linux_sudo_root chmod 0640 "$iso_known" >/dev/null 2>&1 \
+      || bridge_warn "[plugins seed] D2: chmod 0640 $iso_known failed (agent '$agent')"
+    ((propagated++)) || true
+  done <<<"$eligible"
+
+  bridge_info "[plugins seed] D2: propagated=$propagated skipped=$skipped failed=$failed (target marketplace='$mkt_name')"
+  if (( failed > 0 )); then
+    return 1
+  fi
+  return 0
+}
+
+# Internal: returns 0 if the comma-separated channels list contains at
+# least one plugin: channel that references the target marketplace.
+_bridge_plugins_seed_channels_csv_uses_marketplace() {
+  local csv="${1:-}"
+  local mkt="${2:-}"
+  [[ -n "$csv" && -n "$mkt" ]] || return 1
+  local -a items=()
+  IFS=',' read -r -a items <<<"$csv"
+  local item plugin_spec marketplace
+  for item in "${items[@]}"; do
+    # trim whitespace
+    item="${item## }"
+    item="${item%% }"
+    [[ "$item" == plugin:* ]] || continue
+    plugin_spec="${item#plugin:}"
+    [[ "$plugin_spec" == *@* ]] || continue
+    marketplace="${plugin_spec##*@}"
+    if [[ "$marketplace" == "$mkt" ]]; then
+      return 0
+    fi
+  done
+  return 1
 }
 
 bridge_plugins_cmd_show() {

--- a/bridge-plugins.sh
+++ b/bridge-plugins.sh
@@ -465,6 +465,12 @@ bridge_plugins_seed_propagate_iso_known_marketplaces() {
   local propagated=0
   local skipped=0
   local failed=0
+  # Materialize $eligible to a tmp file so the `while read` consumer
+  # avoids `<<<` here-string / `<()` procsub — both rejected by the
+  # lint-heredoc-ban ratchet (footgun #11 class). Cleanup after loop.
+  local _eligible_stream_tmp
+  _eligible_stream_tmp="$(mktemp)" || { bridge_warn "[plugins seed] D2: mktemp failed"; return 1; }
+  printf '%s\n' "$eligible" > "$_eligible_stream_tmp"
   while IFS= read -r agent; do
     [[ -n "$agent" ]] || continue
     local agent_channels=""
@@ -532,7 +538,8 @@ bridge_plugins_seed_propagate_iso_known_marketplaces() {
     bridge_linux_sudo_root chmod 0640 "$iso_known" >/dev/null 2>&1 \
       || bridge_warn "[plugins seed] D2: chmod 0640 $iso_known failed (agent '$agent')"
     ((propagated++)) || true
-  done <<<"$eligible"
+  done < "$_eligible_stream_tmp"
+  rm -f "$_eligible_stream_tmp" 2>/dev/null || true
 
   bridge_info "[plugins seed] D2: propagated=$propagated skipped=$skipped failed=$failed (target marketplace='$mkt_name')"
   if (( failed > 0 )); then
@@ -547,8 +554,15 @@ _bridge_plugins_seed_channels_csv_uses_marketplace() {
   local csv="${1:-}"
   local mkt="${2:-}"
   [[ -n "$csv" && -n "$mkt" ]] || return 1
+  # Split CSV via parameter expansion to avoid `<<<` here-string
+  # (footgun #11 class, lint-heredoc-ban ratchet rejects it).
   local -a items=()
-  IFS=',' read -r -a items <<<"$csv"
+  local _csv_rest="$csv"
+  while [[ -n "$_csv_rest" ]]; do
+    items+=("${_csv_rest%%,*}")
+    [[ "$_csv_rest" == *","* ]] || break
+    _csv_rest="${_csv_rest#*,}"
+  done
   local item plugin_spec marketplace
   for item in "${items[@]}"; do
     # trim whitespace

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -44,6 +44,11 @@ trap _bridge_upgrade_exit_handler EXIT
 source "$SCRIPT_DIR/bridge-lib.sh"
 # shellcheck source=lib/bridge-cleanup.sh
 source "$SCRIPT_DIR/lib/bridge-cleanup.sh"
+# Beta20 L2 Variant 3A — bridge_host_profile_is_dev is defined in
+# lib/bridge-host-profile.sh (not pulled in by bridge-lib.sh). The
+# upgrade-time sudoers regeneration gate at line ~2243 depends on it.
+# shellcheck source=lib/bridge-host-profile.sh
+source "$SCRIPT_DIR/lib/bridge-host-profile.sh"
 ORIGINAL_ARGS=("$@")
 
 SOURCE_ROOT="$SCRIPT_DIR"
@@ -1872,6 +1877,38 @@ if [[ $DRY_RUN -eq 0 ]]; then
     tail -n 20 "$_bun_traverse_tmp" >&2 || true
   fi
   rm -f -- "$_bun_traverse_tmp"
+
+  # L1-J (beta20, 2026-05-25): every bundled plugin with a package.json
+  # needs node_modules at install/upgrade time. The teams plugin path
+  # (`agb setup teams`) does this for plugins/teams/ specifically; this
+  # helper generalizes to ms365 + any future bundled plugin so the iso
+  # UID's MCP spawn does not hit "Cannot find module" on first start.
+  #
+  # Best-effort, non-fatal — mirrors the bun-traverse helper. The
+  # helper logs per-plugin status and the overall upgrade continues
+  # even when one plugin's install fails (operator can re-run
+  # `agb setup <plugin> <agent>` or fix bun availability and retry).
+  #
+  # Footgun #11: file-as-argv via standalone helper (no heredoc-stdin).
+  set +e
+  _bundled_plugins_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-upg-bundled-plugins.XXXXXX")"
+  bridge_upgrade_with_target_env "$TARGET_ROOT" \
+    "$BRIDGE_BASH_BIN" \
+    "$SOURCE_ROOT/lib/upgrade-helpers/bundled-plugins-bun-install.sh" \
+    "$SOURCE_ROOT" "$TARGET_ROOT" >"$_bundled_plugins_tmp" 2>&1
+  _bundled_plugins_rc=$?
+  set -e
+  # Surface info lines (per-plugin status) regardless of rc — the
+  # operator wants to see "ms365: node_modules installed + widened"
+  # in the upgrade log.
+  if [[ -s "$_bundled_plugins_tmp" ]]; then
+    tail -n 50 "$_bundled_plugins_tmp" >&2 || true
+  fi
+  if [[ $_bundled_plugins_rc -ne 0 ]]; then
+    echo "[bridge-upgrade] WARN: one or more bundled plugins failed bun install (rc=$_bundled_plugins_rc). Affected MCPs will not start until deps resolve — re-run \`agb setup <plugin> <agent>\` or check bun availability." >&2
+    _upgrade_partial_failures+=("bundled_plugins_bun_install")
+  fi
+  rm -f -- "$_bundled_plugins_tmp"
 fi
 
 # Footgun #11: `bridge_upgrade_agent_restart_json` feeds python via heredoc;
@@ -2229,6 +2266,69 @@ if [[ $DRY_RUN -eq 0 ]] && command -v tmux >/dev/null 2>&1; then
   tmux setenv -u -g BRIDGE_DATA_ROOT 2>/dev/null || true
 fi
 
+
+# Beta20 L2 Variant 3A — regenerate the daemon-refresh sudoers drop-in
+# so an upgrade that changes BRIDGE_BASH_BIN or BRIDGE_HOME (rare but
+# possible when operators relocate) lands a matching authorized command
+# in the sudoers entry. Idempotent: the helper skips the install when
+# the existing file is byte-equal to a fresh render. Linux + server
+# profile only; failure is logged but does NOT abort the upgrade (the
+# operator can re-run `agent-bridge init sudoers daemon-refresh --apply`
+# afterwards).
+if [[ $DRY_RUN -eq 0 ]] \
+   && [[ "$(uname -s 2>/dev/null)" == "Linux" ]] \
+   && ! bridge_host_profile_is_dev \
+   && command -v bridge_daemon_control_install_sudoers >/dev/null 2>&1; then
+  _upgrade_sudoers_path=""
+  _upgrade_sudoers_install_ok=0
+  if _upgrade_sudoers_path="$(BRIDGE_HOME="$TARGET_ROOT" bridge_daemon_control_install_sudoers 2>&1)"; then
+    if [[ -n "$_upgrade_sudoers_path" ]]; then
+      # >&2 — info goes to stderr so --json mode's stdout stays parseable
+      echo "[bridge-upgrade] daemon-refresh sudoers: at $_upgrade_sudoers_path" >&2
+      _upgrade_sudoers_install_ok=1
+    fi
+  else
+    echo "[bridge-upgrade] WARN: daemon-refresh sudoers regen failed; automatic supp-groups refresh may fall back to manual-required." >&2
+    echo "[bridge-upgrade] WARN: re-run: $TARGET_ROOT/agent-bridge init sudoers daemon-refresh --apply" >&2
+  fi
+
+  # Beta20 L2 Variant 3A r4 — regenerate the systemd-user unit so its
+  # ExecStart picks up the (possibly updated) sudo-wrapped shape. The
+  # install-daemon-systemd.sh helper auto-detects the sudoers drop-in
+  # and renders accordingly; we just re-apply + daemon-reload +
+  # restart-if-active. Without this step, an operator who upgrades
+  # from a pre-r4 install still has the legacy direct unit ExecStart,
+  # and `Restart=always` would keep defeating the r3 ad-hoc sudo
+  # restart at runtime.
+  if (( _upgrade_sudoers_install_ok == 1 )) \
+     && command -v systemctl >/dev/null 2>&1; then
+    _upgrade_systemd_rc=0
+    # install-daemon-systemd.sh emits [info] lines to stdout (designed
+    # for standalone CLI use). When invoked from inside `agent-bridge
+    # upgrade --json`, that chatter must not pollute the JSON envelope
+    # on our stdout. Redirect to stderr so --json callers (smokes, CI)
+    # get a clean JSON document; operator-facing terminal still sees
+    # the messages.
+    "$BRIDGE_BASH_BIN" "$TARGET_ROOT/scripts/install-daemon-systemd.sh" \
+      --bridge-home "$TARGET_ROOT" --apply >&2 \
+      || _upgrade_systemd_rc=$?
+    if (( _upgrade_systemd_rc == 0 )); then
+      if systemctl --user is-active --quiet agent-bridge-daemon.service 2>/dev/null; then
+        systemctl --user daemon-reload || true
+        if systemctl --user restart agent-bridge-daemon.service 2>/dev/null; then
+          echo "[bridge-upgrade] systemd-user unit regenerated (sudo-self) and restarted" >&2
+        else
+          echo "[bridge-upgrade] WARN: systemctl --user restart agent-bridge-daemon.service failed after unit regen — retry manually" >&2
+        fi
+      else
+        echo "[bridge-upgrade] systemd-user unit regenerated (sudo-self) — service not active, will pick up on next start" >&2
+      fi
+    else
+      echo "[bridge-upgrade] WARN: install-daemon-systemd.sh --apply returned rc=$_upgrade_systemd_rc — unit may carry legacy ExecStart" >&2
+      echo "[bridge-upgrade] WARN: re-run: $TARGET_ROOT/scripts/install-daemon-systemd.sh --bridge-home $TARGET_ROOT --apply" >&2
+    fi
+  fi
+fi
 
 # Bug #507 — auto-cleanup of daily-backup residue on every successful
 # `agb upgrade --apply`. Idempotent; reports failures via cleanup_failures

--- a/lib/bridge-channels.sh
+++ b/lib/bridge-channels.sh
@@ -784,5 +784,104 @@ bridge_provision_teams_plugin_runtime() {
   bridge_ensure_bun_runtime_traversable_for_isolated "$dry_run" || true
 
   bridge_install_teams_plugin_node_modules "$dry_run" "$bun_bin" || return 1
+
+  # L1-J (beta20, 2026-05-25): also provision sibling bundled plugins
+  # (ms365, future). The teams-specific helper above covers
+  # plugins/teams/ explicitly; this generalized pass picks up any other
+  # bundled plugin under $BRIDGE_SCRIPT_DIR/plugins/ that has a
+  # package.json. Best-effort + idempotent — re-running on an already-
+  # installed plugin is a no-op.
+  if bridge_resolve_script_dir_check; then
+    bridge_provision_bundled_plugins_node_modules "$dry_run" "$bun_bin" || true
+  fi
   return 0
+}
+
+# L1-J (beta20, 2026-05-25): provision node_modules for EVERY bundled
+# plugin under $BRIDGE_SCRIPT_DIR/plugins/ that has a package.json.
+# Generalizes bridge_install_teams_plugin_node_modules so a new bundled
+# plugin (e.g. ms365) does not need its own helper.
+#
+# Skips a plugin when:
+#   - it has no package.json (not a node-based MCP)
+#   - it already has a node_modules dir newer than package.json + bun.lock
+#
+# Idempotent: the chmod widen always runs over node_modules so a
+# previously-installed-but-tight tree is opened up for iso-UID copy.
+bridge_provision_bundled_plugins_node_modules() {
+  local dry_run="${1:-0}"
+  local bun_bin="${2:-}"
+
+  if ! bridge_resolve_script_dir_check; then
+    return 1
+  fi
+  local plugins_root="$BRIDGE_SCRIPT_DIR/plugins"
+  if [[ ! -d "$plugins_root" ]]; then
+    return 0
+  fi
+
+  if [[ -z "$bun_bin" ]]; then
+    bun_bin="$(bridge_resolve_bun_executable 2>/dev/null || true)"
+  fi
+  if [[ -z "$bun_bin" ]]; then
+    bridge_warn "[setup] bun executable missing — cannot provision bundled plugin node_modules. Install bun and re-run \`agb setup teams\`."
+    return 1
+  fi
+
+  local plugin_dir plugin_name pkg_json node_modules bun_lock
+  local overall_rc=0
+  shopt -s nullglob 2>/dev/null || true
+  for plugin_dir in "$plugins_root"/*/; do
+    plugin_dir="${plugin_dir%/}"
+    [[ -d "$plugin_dir" ]] || continue
+    plugin_name="$(basename -- "$plugin_dir")"
+    # Already covered by the teams-specific helper.
+    [[ "$plugin_name" == "teams" ]] && continue
+    case "$plugin_name" in
+      .*|marketplaces|cache) continue ;;
+    esac
+    pkg_json="$plugin_dir/package.json"
+    [[ -f "$pkg_json" ]] || continue
+    node_modules="$plugin_dir/node_modules"
+    bun_lock="$plugin_dir/bun.lock"
+
+    if [[ -d "$node_modules" ]]; then
+      local _stale=0
+      if [[ "$pkg_json" -nt "$node_modules" ]]; then
+        _stale=1
+      fi
+      if [[ -f "$bun_lock" && "$bun_lock" -nt "$node_modules" ]]; then
+        _stale=1
+      fi
+      if (( _stale == 0 )); then
+        chmod -R go+rX "$node_modules" 2>/dev/null \
+          || bridge_warn "[setup] chmod go+rX failed on $node_modules (non-fatal)"
+        bridge_info "[setup] $plugin_name: node_modules up to date (skipped)"
+        continue
+      fi
+      bridge_info "[setup] $plugin_name: node_modules stale — refreshing"
+    fi
+
+    if [[ "$dry_run" == "1" ]]; then
+      bridge_info "[setup] [dry-run] would run: bun install in $plugin_dir"
+      continue
+    fi
+
+    bridge_info "[setup] $plugin_name: running bun install in $plugin_dir"
+    local _rc=0
+    if [[ -f "$bun_lock" ]]; then
+      ( cd "$plugin_dir" && "$bun_bin" install --frozen-lockfile --no-summary >&2 ) || _rc=$?
+    else
+      ( cd "$plugin_dir" && "$bun_bin" install --no-summary >&2 ) || _rc=$?
+    fi
+    if (( _rc != 0 )); then
+      bridge_warn "[setup] $plugin_name: bun install failed (rc=$_rc) — MCP for this plugin will not start until deps resolve"
+      overall_rc=1
+      continue
+    fi
+    if ! chmod -R go+rX "$node_modules" 2>/dev/null; then
+      bridge_warn "[setup] $plugin_name: chmod -R go+rX failed on $node_modules — isolated agents may fail to copy via bridge-dev-plugin-cache"
+    fi
+  done
+  return "$overall_rc"
 }

--- a/lib/bridge-isolation-v2-reconcile.sh
+++ b/lib/bridge-isolation-v2-reconcile.sh
@@ -1084,11 +1084,16 @@ bridge_isolation_v2_install_tree_matrix_rows() {
   # in `_bridge_iso_reconcile_row_dir_recursive` itself.
   if [[ -d "$data_root/plugins" ]]; then
     local _plugin_subdir _plugin_subname
-    # nullglob via subshell — we don't want to mutate the caller's shopt.
-    # `compgen -G` is the simpler primitive (file_glob row uses it too);
-    # use it here so a no-match produces an empty stream rather than the
-    # literal pattern.
-    while IFS= read -r _plugin_subdir; do
+    # Iterate via shell glob in a save/restore-nullglob block. Avoids
+    # `< <(compgen -G ...)` procsub (footgun #11 class — lint-heredoc-ban
+    # ratchet rejects). `nullglob` makes the no-match case produce an
+    # empty list instead of the literal pattern.
+    local _nullglob_saved
+    _nullglob_saved="$(shopt -p nullglob 2>/dev/null || printf 'shopt -u nullglob\n')"
+    shopt -s nullglob
+    local -a _plugin_subdirs=( "$data_root/plugins"/* )
+    eval "$_nullglob_saved"
+    for _plugin_subdir in "${_plugin_subdirs[@]}"; do
       [[ -n "$_plugin_subdir" && -d "$_plugin_subdir" ]] || continue
       _plugin_subname="$(basename -- "$_plugin_subdir")"
       # `marketplaces` is a Claude-cache namespace under
@@ -1104,7 +1109,7 @@ bridge_isolation_v2_install_tree_matrix_rows() {
       [[ "$_plugin_subname" == "known_marketplaces.json" ]] && continue
       printf '%s\n' \
         "plugins-channel-tree-${_plugin_subname}|install|$_plugin_subdir|dir_recursive|controller|ab-shared|-|-|0|1|inherit|direct|optional|per-channel plugin tree ($_plugin_subname) chgrp -R ab-shared + g+rX so iso UIDs can read package files; *.lock + secrets protected by guard"
-    done < <(compgen -G "$data_root/plugins/*" 2>/dev/null || true)
+    done
   fi
   printf '%s\n' \
     "agents-root|install|$data_root/agents|dir|controller|ab-shared|0710|-|0|0|inherit|direct|required|per-agent runtime-home root — controller rwX, group --x for traverse to each per-agent leaf without listing the full agent inventory (iso UIDs must traverse to their own home, not see siblings)"

--- a/lib/bridge-isolation-v2-reconcile.sh
+++ b/lib/bridge-isolation-v2-reconcile.sh
@@ -1063,8 +1063,49 @@ bridge_isolation_v2_install_tree_matrix_rows() {
     "claude-plugin-dir|install|$data_root/.claude-plugin|dir|controller|ab-shared|0750|-|0|0|inherit|direct|optional|controller-owned .claude-plugin manifest dir — ab-shared g+rx so plugin discovery from iso UIDs can read the manifest"
   printf '%s\n' \
     "plugins-root|install|$data_root/plugins|dir|controller|ab-shared|0750|-|0|0|inherit|direct|optional|controller-owned plugins cache root — ab-shared g+rx so iso UIDs can list and read non-secret plugin metadata"
-  printf '%s\n' \
-    "plugins-channel-trees|install|$data_root/plugins/*|dir_recursive|controller|ab-shared|-|-|0|1|inherit|direct|optional|per-channel plugin trees (teams/ms365/cosmax-*) chgrp -R ab-shared + g+rX so iso UIDs can read package files; *.lock + secrets protected by guard"
+  # plugins-channel-trees — per-channel plugin trees (teams/ms365/cosmax-*).
+  #
+  # L1-G (beta20, 2026-05-25 patch L1-extended): the prior row used a
+  # literal glob path `$data_root/plugins/*` with kind `dir_recursive`.
+  # `_bridge_iso_reconcile_row_dir_recursive` tests `[[ -d "$path" ]]`
+  # which DOES NOT glob-expand — the test ran against the literal string
+  # `…/plugins/*`, which always returns false, and the row always
+  # reported `skipped (absent)` even on installs with 4+ populated
+  # plugin dirs. Net effect: ms365, cosmax-marketplace, cosmax-crm-marketplace,
+  # etc. never had their group/mode normalized for iso UID read access.
+  #
+  # Fix: expand the glob at row-generation time and emit one
+  # `dir_recursive` row per actually-present subdir. Each row is
+  # `optional` (skipped quietly when the dir is absent) — channel install
+  # via `agb agent create --linux-user --channels plugin:<X>` creates the
+  # dir on first install, and the next reconciler pass picks it up.
+  # The protected-path guard remains active per-row, so secret files
+  # (*.lock, etc.) are still excluded by the existing per-file guard
+  # in `_bridge_iso_reconcile_row_dir_recursive` itself.
+  if [[ -d "$data_root/plugins" ]]; then
+    local _plugin_subdir _plugin_subname
+    # nullglob via subshell — we don't want to mutate the caller's shopt.
+    # `compgen -G` is the simpler primitive (file_glob row uses it too);
+    # use it here so a no-match produces an empty stream rather than the
+    # literal pattern.
+    while IFS= read -r _plugin_subdir; do
+      [[ -n "$_plugin_subdir" && -d "$_plugin_subdir" ]] || continue
+      _plugin_subname="$(basename -- "$_plugin_subdir")"
+      # `marketplaces` is a Claude-cache namespace under
+      # ~/.claude/plugins/ (and the matching dir under $BRIDGE_HOME/plugins/
+      # when the controller's known_marketplaces.json carries directory
+      # entries). It is controller-owned metadata. Iso UIDs should read
+      # via the shared-plugins-cache path, not this row — so the row
+      # walks per-channel subdirs only.
+      [[ "$_plugin_subname" == "marketplaces" ]] && continue
+      [[ "$_plugin_subname" == "cache" ]] && continue
+      [[ "$_plugin_subname" == "marketplaces.json" ]] && continue
+      [[ "$_plugin_subname" == "installed_plugins.json" ]] && continue
+      [[ "$_plugin_subname" == "known_marketplaces.json" ]] && continue
+      printf '%s\n' \
+        "plugins-channel-tree-${_plugin_subname}|install|$_plugin_subdir|dir_recursive|controller|ab-shared|-|-|0|1|inherit|direct|optional|per-channel plugin tree ($_plugin_subname) chgrp -R ab-shared + g+rX so iso UIDs can read package files; *.lock + secrets protected by guard"
+    done < <(compgen -G "$data_root/plugins/*" 2>/dev/null || true)
+  fi
   printf '%s\n' \
     "agents-root|install|$data_root/agents|dir|controller|ab-shared|0710|-|0|0|inherit|direct|required|per-agent runtime-home root — controller rwX, group --x for traverse to each per-agent leaf without listing the full agent inventory (iso UIDs must traverse to their own home, not see siblings)"
 

--- a/lib/upgrade-helpers/bundled-plugins-bun-install.sh
+++ b/lib/upgrade-helpers/bundled-plugins-bun-install.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# bundled-plugins-bun-install.sh — install node_modules for every
+# bundled plugin that has a package.json. Standalone helper invoked
+# file-as-argv per footgun #11 (no heredoc-stdin to subprocess).
+#
+# L1-J (beta20, 2026-05-25 patch L1-extended): bundled plugins like
+# `teams`, `ms365`, and `cosmax-ep-approval` ship with package.json but
+# no node_modules in source — Claude Code's plugin spawn path runs the
+# plugin's MCP under the plugin tree, which `require()`s npm
+# dependencies that are not present. Symptom: "Cannot find module
+# '@modelcontextprotocol/sdk/...'" on first iso-UID MCP spawn.
+#
+# Fix path: this helper enumerates `$SOURCE_ROOT/plugins/*` and runs
+# `bun install --frozen-lockfile` (when bun.lock present) or
+# `bun install` in every plugin dir that has a `package.json` but no
+# `node_modules`. The helper is idempotent — re-running on an already-
+# installed plugin is a fast no-op (skip when node_modules exists and
+# is the same age or newer than package.json + bun.lock).
+#
+# Invocation contract (mirrors bun-traverse-chmod.sh):
+#   $1 = source_root  (the agent-bridge source checkout)
+#   $2 = target_root  (the live install root — informational; the
+#        helper walks source_root/plugins/ which the upgrade has
+#        already promoted into target_root by this point in the
+#        upgrade flow)
+#
+# Exit code: 0 when every plugin's node_modules is present (after the
+#            install pass) OR no plugin needed it; non-zero when at
+#            least one plugin install failed. bridge-upgrade.sh treats
+#            non-zero as a partial-failure warning, not a fatal abort.
+
+set -uo pipefail
+
+source_root="$1"
+target_root="$2"
+
+# shellcheck source=/dev/null
+source "$source_root/bridge-lib.sh"
+
+# L1-K (beta20, 2026-05-25): Node.js version detection. Several bundled
+# and external plugins (cosmax-ep-approval is the canonical case in
+# patch's report) use Node 14+ syntax (`?.`, `??`, top-level await
+# under .mjs). Ubuntu 22.04 ships `node` at 12.22.9 by default. Detect
+# the version and emit a loud warning (NOT a fatal error) so the
+# operator sees the actionable diagnostic in the upgrade log.
+#
+# Option B (operator's preferred path 2026-05-25): warn loudly,
+# document the fix (`nvm install --lts` / distro upgrade), do NOT
+# silently symlink /usr/local/bin/node — that would mutate system
+# PATH ownership across upgrades and create a hidden state surface.
+_node_version_check() {
+  local node_bin=""
+  if ! node_bin="$(command -v node 2>/dev/null)" || [[ -z "$node_bin" ]]; then
+    bridge_info "[bundled-plugins][node-check] node not on PATH — bundled MCPs that require Node.js will fail at spawn. Install Node 18 LTS via 'nvm install --lts' or your distro package manager."
+    return 0
+  fi
+  local raw_version=""
+  raw_version="$("$node_bin" --version 2>/dev/null || true)"
+  # Format: "v12.22.9" or "v18.19.0".
+  if [[ -z "$raw_version" ]]; then
+    bridge_info "[bundled-plugins][node-check] node at $node_bin returned no --version output — cannot validate"
+    return 0
+  fi
+  local major=""
+  major="$(printf '%s\n' "$raw_version" | sed -E 's/^v([0-9]+).*/\1/')"
+  if [[ -z "$major" || ! "$major" =~ ^[0-9]+$ ]]; then
+    bridge_info "[bundled-plugins][node-check] could not parse node version from '$raw_version'"
+    return 0
+  fi
+  if (( major < 14 )); then
+    bridge_warn "[bundled-plugins][node-check] node at $node_bin is $raw_version (< 14) — plugins using optional chaining (?.), nullish coalescing (??), or top-level await (e.g. cosmax-ep-approval's ep-mcp-proxy.mjs) will fail with SyntaxError on first spawn. Install Node 18 LTS: 'nvm install --lts' (then re-open shell), or upgrade your distro. This warning is non-fatal — bundled-plugin install continues."
+    return 0
+  fi
+  bridge_info "[bundled-plugins][node-check] node $raw_version OK (>= 14)"
+  return 0
+}
+
+_node_version_check || true
+
+# The upgrade flow has already promoted source/plugins → target/plugins
+# (the install-tree reconciler is the one that normalizes ownership +
+# mode). Run bun install on the TARGET side so the resulting
+# node_modules lands in the live install tree, where
+# bridge-dev-plugin-cache.py can mirror it into per-agent caches.
+plugins_root="$target_root/plugins"
+if [[ ! -d "$plugins_root" ]]; then
+  # Fresh install with no plugins ever copied — nothing to do.
+  exit 0
+fi
+
+# Resolve bun binary. If absent on this host, the bundled MCPs cannot
+# start anyway; emit a single line and bail out cleanly so the upgrade
+# does NOT abort (operator may install bun later via
+# `agb setup teams`).
+bun_bin=""
+if command -v bridge_resolve_bun_executable >/dev/null 2>&1; then
+  bun_bin="$(bridge_resolve_bun_executable 2>/dev/null || true)"
+fi
+if [[ -z "$bun_bin" ]]; then
+  bun_bin="$(command -v bun 2>/dev/null || true)"
+fi
+if [[ -z "$bun_bin" ]]; then
+  bridge_info "[bundled-plugins] bun runtime not found on PATH — skipping node_modules install for bundled plugins. Run 'agb setup teams <agent>' to install bun + provision deps."
+  exit 0
+fi
+
+# Honor dry-run.
+_dry_run="${DRY_RUN:-0}"
+if [[ "$_dry_run" != "1" ]]; then
+  _dry_run=0
+fi
+
+# Walk every immediate subdir of plugins_root. Skip metadata dirs
+# (marketplaces/, cache/) and dotfiles.
+overall_rc=0
+shopt -s nullglob 2>/dev/null || true
+for plugin_dir in "$plugins_root"/*/; do
+  plugin_dir="${plugin_dir%/}"
+  [[ -d "$plugin_dir" ]] || continue
+  plugin_name="$(basename -- "$plugin_dir")"
+  case "$plugin_name" in
+    marketplaces|cache|.*) continue ;;
+  esac
+
+  pkg_json="$plugin_dir/package.json"
+  if [[ ! -f "$pkg_json" ]]; then
+    continue
+  fi
+
+  node_modules="$plugin_dir/node_modules"
+  # Idempotence: skip when node_modules is present AND newer than
+  # package.json (and bun.lock, if present). This matches the pattern
+  # `bridge_install_teams_plugin_node_modules` uses for the teams
+  # plugin — but applies it generically so 4+ bundled plugins can
+  # coexist.
+  bun_lock="$plugin_dir/bun.lock"
+  if [[ -d "$node_modules" ]]; then
+    # Compare mtimes: node_modules vs package.json + bun.lock. Use
+    # `find -newer` since stat formats differ across GNU/BSD.
+    needs_install=0
+    if [[ "$pkg_json" -nt "$node_modules" ]]; then
+      needs_install=1
+    fi
+    if [[ -f "$bun_lock" && "$bun_lock" -nt "$node_modules" ]]; then
+      needs_install=1
+    fi
+    if (( needs_install == 0 )); then
+      # Best-effort widen of group/other read on the existing tree so
+      # iso UIDs can copy via bridge-dev-plugin-cache.py. Mirrors the
+      # behavior of bridge_install_teams_plugin_node_modules's
+      # idempotent path (chmod always runs).
+      chmod -R go+rX "$node_modules" 2>/dev/null \
+        || bridge_warn "[bundled-plugins] chmod go+rX $node_modules failed — iso UIDs may fail to copy via bridge-dev-plugin-cache (non-fatal)"
+      bridge_info "[bundled-plugins] $plugin_name: node_modules up to date (skipped)"
+      continue
+    fi
+    bridge_info "[bundled-plugins] $plugin_name: node_modules stale vs package.json/bun.lock — refreshing"
+  fi
+
+  if [[ "$_dry_run" == "1" ]]; then
+    bridge_info "[bundled-plugins] [dry-run] would run: bun install in $plugin_dir"
+    continue
+  fi
+
+  # Use --frozen-lockfile when bun.lock present (deterministic), plain
+  # `bun install` otherwise. `--no-summary` keeps the upgrade log tidy.
+  bridge_info "[bundled-plugins] $plugin_name: running bun install in $plugin_dir"
+  install_rc=0
+  if [[ -f "$bun_lock" ]]; then
+    ( cd "$plugin_dir" && "$bun_bin" install --frozen-lockfile --no-summary >&2 ) || install_rc=$?
+  else
+    ( cd "$plugin_dir" && "$bun_bin" install --no-summary >&2 ) || install_rc=$?
+  fi
+  if (( install_rc != 0 )); then
+    bridge_warn "[bundled-plugins] $plugin_name: bun install failed (rc=$install_rc) — MCP for this plugin will not start until deps resolve"
+    overall_rc=1
+    continue
+  fi
+
+  # Same chmod widen as the teams helper: bun install runs under the
+  # controller umask (often 077 → 0700) which iso UIDs can't traverse.
+  if ! chmod -R go+rX "$node_modules" 2>/dev/null; then
+    bridge_warn "[bundled-plugins] $plugin_name: chmod -R go+rX failed on $node_modules — isolated agents may fail to copy via bridge-dev-plugin-cache"
+  fi
+  bridge_info "[bundled-plugins] $plugin_name: node_modules installed + widened"
+done
+
+exit "$overall_rc"

--- a/lib/upgrade-helpers/plugins-seed-marketplace-name.py
+++ b/lib/upgrade-helpers/plugins-seed-marketplace-name.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""
+lib/upgrade-helpers/plugins-seed-marketplace-name.py — standalone helper
+for `agb plugins seed` (bridge-plugins.sh).
+
+Reads a marketplace.json and prints just the `name` field. Empty output
+if the file is unreadable or has no name. File-as-argv per footgun #11
+(no heredoc-stdin to subprocess); see KNOWN_ISSUES.md §26.
+
+Usage:
+  python3 lib/upgrade-helpers/plugins-seed-marketplace-name.py <marketplace.json>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        sys.stderr.write("usage: plugins-seed-marketplace-name.py <marketplace.json>\n")
+        return 2
+    path = argv[1]
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except Exception as exc:
+        sys.stderr.write(f"failed to read {path}: {exc}\n")
+        return 1
+    name = (payload.get("name") or "").strip()
+    if name:
+        print(name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py
+++ b/lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""
+lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py — standalone
+helper for `agb plugins seed` (bridge-plugins.sh).
+
+Merges (idempotently) a `<marketplace_name>: {source: {source: directory,
+path: <root>}, installLocation: <root>, lastUpdated: <iso>}` entry into
+an existing known_marketplaces.json file. If the entry is already
+present with the right shape, the file is left untouched (no rewrite,
+so the mtime stays stable). Otherwise the merged content is written
+atomically via a same-dir temp + os.replace.
+
+The output goes to <out_path>; if <out_path> exists and the entry is
+already correct, the helper exits 0 and prints `already-correct`.
+Otherwise it prints `updated` (or `created` if the source was missing).
+
+File-as-argv per footgun #11. Mirrors `ensure_known_marketplace_for_root`
+in bridge-dev-plugin-cache.py but writes to an arbitrary output path
+(L1-D iso UID propagation: same payload shape, different destination
+than the controller's $HOME/.claude/plugins/known_marketplaces.json).
+
+Usage:
+  python3 lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py \
+    <in_path_or_-> <out_path> <marketplace_name> <root>
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _now_iso_utc() -> str:
+    return datetime.datetime.now(tz=datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _matches(entry: object, root: str) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    if str(entry.get("installLocation") or "").strip() != root:
+        return False
+    source = entry.get("source")
+    if not isinstance(source, dict):
+        return False
+    return (
+        str(source.get("source") or "").strip() == "directory"
+        and str(source.get("path") or "").strip() == root
+    )
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 5:
+        sys.stderr.write(
+            "usage: plugins-seed-merge-known-marketplace.py "
+            "<in_path_or_-> <out_path> <marketplace_name> <root>\n"
+        )
+        return 2
+    in_path, out_path, marketplace_name, root = argv[1:]
+    marketplace_name = marketplace_name.strip()
+    root = root.strip()
+    if not marketplace_name:
+        sys.stderr.write("marketplace_name is empty\n")
+        return 1
+    if not root:
+        sys.stderr.write("root is empty\n")
+        return 1
+
+    payload: dict[str, object] = {}
+    # in_path == "-" means "no source, start from {}"; otherwise read
+    # existing known_marketplaces.json if present.
+    if in_path != "-" and os.path.exists(in_path):
+        try:
+            with open(in_path, "r", encoding="utf-8") as fh:
+                loaded = json.load(fh)
+            if isinstance(loaded, dict):
+                payload = loaded
+        except (OSError, ValueError) as exc:
+            sys.stderr.write(f"warning: could not parse {in_path}: {exc} — starting from empty payload\n")
+            payload = {}
+
+    existing = payload.get(marketplace_name) if isinstance(payload, dict) else None
+    if _matches(existing, root):
+        # Touch nothing — already correct. But still ensure out_path
+        # exists when it differs from in_path (D2 iso copy case).
+        if os.path.abspath(in_path) != os.path.abspath(out_path) and not os.path.exists(out_path):
+            # Write the same content out so the destination is present.
+            pass
+        else:
+            print("already-correct")
+            return 0
+
+    payload[marketplace_name] = {
+        "source": {"source": "directory", "path": root},
+        "installLocation": root,
+        "lastUpdated": _now_iso_utc(),
+    }
+    out_dir = os.path.dirname(out_path) or "."
+    os.makedirs(out_dir, exist_ok=True)
+    # Determine the mode to preserve. If out_path exists, keep its mode;
+    # otherwise default to 0640 (group-readable, the iso UID is in the
+    # ab-agent-<a> group as a supplementary group, so g+r is enough).
+    mode = 0o640
+    if os.path.exists(out_path):
+        try:
+            mode = os.stat(out_path).st_mode & 0o777
+        except OSError:
+            mode = 0o640
+    tmp_path = Path(out_path).with_name(f"{Path(out_path).name}.tmp.{os.getpid()}")
+    try:
+        tmp_path.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, out_path)
+    finally:
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError:
+            pass
+    print("updated" if existing is not None else "created")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/smoke/phase2-install-tree-reconciler.sh
+++ b/scripts/smoke/phase2-install-tree-reconciler.sh
@@ -219,7 +219,18 @@ test_t1_matrix_rows() {
   # Phase 3 (codex design 2026-05-24) Family 1 install-tree rows.
   # Four new rows close patch's Phase 3 acceptance gaps A/B/C/D:
   #   A. .claude-plugin/, B. plugins/, C. plugins/*, D. agents/
-  for row_name in claude-plugin-dir plugins-root plugins-channel-trees agents-root; do
+  #
+  # L1-G (beta20, 2026-05-25): Gap C (per-channel plugin trees) was
+  # originally a single `plugins-channel-trees|…/plugins/*|dir_recursive`
+  # row, but `_bridge_iso_reconcile_row_dir_recursive` does not
+  # glob-expand its path arg — the row always reported `skipped
+  # (absent)`. The row is now glob-expanded at matrix-generation time:
+  # one `plugins-channel-tree-<subname>` row per actually-present
+  # subdir of `$BRIDGE_HOME/plugins`. The smoke fixture has no plugin
+  # subdirs (smoke_build_fixture does not create them), so the expanded
+  # rows are absent here — covered by T10 which materializes fixture
+  # subdirs and verifies expansion.
+  for row_name in claude-plugin-dir plugins-root agents-root; do
     smoke_assert_contains "$rows_out" "$row_name|" \
       "T1: Phase 3 Family 1 install row '$row_name' missing"
   done
@@ -714,6 +725,86 @@ test_t9_l1_beta19_scaffold_modes() {
 # Runner
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# T10 — L1-G (beta20): plugins-channel-trees row glob expansion
+# ---------------------------------------------------------------------------
+test_t10_l1g_plugins_channel_trees_glob() {
+  smoke_log "T10: L1-G plugins-channel-trees row expanded per-subdir"
+
+  # Materialize three plugin subdirs the way real installs see them
+  # (teams, ms365, cosmax-marketplace) plus a metadata file the matrix
+  # should NOT walk (installed_plugins.json).
+  mkdir -p "$BRIDGE_HOME/plugins/teams" \
+           "$BRIDGE_HOME/plugins/ms365" \
+           "$BRIDGE_HOME/plugins/cosmax-marketplace/.claude-plugin"
+  printf '# stub\n' >"$BRIDGE_HOME/plugins/teams/package.json"
+  printf '# stub\n' >"$BRIDGE_HOME/plugins/ms365/package.json"
+  printf '# stub\n' >"$BRIDGE_HOME/plugins/cosmax-marketplace/.claude-plugin/marketplace.json"
+  # Excluded metadata dirs (must NOT emit a row per the matrix logic).
+  mkdir -p "$BRIDGE_HOME/plugins/marketplaces" "$BRIDGE_HOME/plugins/cache"
+  printf '{}\n' >"$BRIDGE_HOME/plugins/installed_plugins.json"
+  printf '{}\n' >"$BRIDGE_HOME/plugins/known_marketplaces.json"
+
+  local rows_out
+  rows_out="$("$SMOKE_BASH" -c "
+    set -uo pipefail
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_isolation_v2_install_tree_matrix_rows
+  " 2>/dev/null)"
+
+  # Each populated plugin subdir gets its OWN row.
+  for plugin_name in teams ms365 cosmax-marketplace; do
+    smoke_assert_contains "$rows_out" "plugins-channel-tree-${plugin_name}|" \
+      "T10: per-channel row 'plugins-channel-tree-${plugin_name}' missing — glob did not expand for $plugin_name"
+    # Confirm path AND kind are correct.
+    local row_line
+    row_line="$(printf '%s\n' "$rows_out" | grep "^plugins-channel-tree-${plugin_name}|" | head -n 1)"
+    if [[ -z "$row_line" ]]; then
+      smoke_fail "T10: row 'plugins-channel-tree-${plugin_name}' visible by substring but not isolatable as a full line"
+    fi
+    local row_path row_kind
+    row_path="$(printf '%s\n' "$row_line" | awk -F'|' '{print $3}')"
+    row_kind="$(printf '%s\n' "$row_line" | awk -F'|' '{print $4}')"
+    if [[ "$row_path" != "$BRIDGE_HOME/plugins/${plugin_name}" ]]; then
+      smoke_fail "T10: row path expected '$BRIDGE_HOME/plugins/${plugin_name}', got '$row_path'"
+    fi
+    if [[ "$row_kind" != "dir_recursive" ]]; then
+      smoke_fail "T10: row kind expected 'dir_recursive', got '$row_kind'"
+    fi
+  done
+
+  # The old, never-fired glob-literal row must be gone.
+  smoke_assert_not_contains "$rows_out" "plugins-channel-trees|" \
+    "T10: legacy 'plugins-channel-trees' literal-glob row must be replaced by expanded per-subdir rows"
+
+  # Excluded subnames must NOT emit rows.
+  for excluded in marketplaces cache installed_plugins.json known_marketplaces.json marketplaces.json; do
+    smoke_assert_not_contains "$rows_out" "plugins-channel-tree-${excluded}|" \
+      "T10: excluded plugins subname '$excluded' must not emit a per-channel row"
+  done
+
+  # Sanity check — running with no plugins/* present produces zero
+  # plugins-channel-tree-* rows but does NOT error.
+  rm -rf "$BRIDGE_HOME/plugins/teams" \
+         "$BRIDGE_HOME/plugins/ms365" \
+         "$BRIDGE_HOME/plugins/cosmax-marketplace" \
+         "$BRIDGE_HOME/plugins/marketplaces" \
+         "$BRIDGE_HOME/plugins/cache"
+  rm -f "$BRIDGE_HOME/plugins/installed_plugins.json" \
+        "$BRIDGE_HOME/plugins/known_marketplaces.json"
+  rmdir "$BRIDGE_HOME/plugins" 2>/dev/null || true
+
+  rows_out="$("$SMOKE_BASH" -c "
+    set -uo pipefail
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_isolation_v2_install_tree_matrix_rows
+  " 2>/dev/null)"
+  smoke_assert_not_contains "$rows_out" "plugins-channel-tree-" \
+    "T10: no plugins/ dir → no per-channel rows expected"
+
+  smoke_log "T10 PASS"
+}
+
 smoke_run "T1 matrix-rows" test_t1_matrix_rows
 smoke_run "T2 check-drift" test_t2_check_drift
 smoke_run "T3 apply-idempotent" test_t3_apply_idempotent
@@ -723,6 +814,7 @@ smoke_run "T6 marker-non-write-guard" test_t6_marker_non_write_guard
 smoke_run "T7 protected-files" test_t7_protected_files
 smoke_run "T8 regression-boomerang" test_t8_regression_boomerang
 smoke_run "T9 l1-beta19-scaffold-modes" test_t9_l1_beta19_scaffold_modes
+smoke_run "T10 l1g-plugins-channel-trees-glob" test_t10_l1g_plugins_channel_trees_glob
 
 smoke_log "phase2-install-tree-reconciler: ALL TESTS PASS"
 exit 0


### PR DESCRIPTION
## Summary

Closes 6 first-touch plugin-install gaps patch flagged in [L1-results] + [L1-extended] after beta19 verify. Single PR, beta20 fold-in alongside L2 PR #1188.

### Original 4 deliverables (D1-D4)

| Gap | What | Fix |
| --- | --- | --- |
| **L1-A (D1)** | `agb plugins seed` did not propagate marketplace to controller's claude registry → launcher's `claude plugin install` failed first-try | After sync, call `claude plugin marketplace add --scope user <root>` (idempotent vs `claude plugin marketplace list`) |
| **L1-D (D2)** | iso UID's `~/.claude/plugins/known_marketplaces.json` was empty after seed → `resolve_marketplace_root` fell back to bundled agent-bridge marketplace → plugin ignored | Seed walks linux-user iso agents, writes/merges entry into each iso UID's catalog when its channels reference this marketplace |
| **L1-F (D3)** | External marketplace clones (e.g. `/tmp/cosmax-crm-cli`) at mode 0700 blocked iso UID read | `chmod -R o+rX` recursively, Linux + iso-v2 + path-under-`$HOME`-or-tmpdir gated; new `--no-iso-chmod` opt-out flag |
| **L1-G (D4)** | `plugins-channel-trees` reconciler row used a literal glob `$BRIDGE_HOME/plugins/*` with `dir_recursive` kind; the `[[ -d "$path" ]]` test does NOT glob-expand → always `skipped (absent)`. Net effect: walking ONLY teams, never ms365 / cosmax-*. | Glob-expand at matrix-generation time via `compgen -G`, emit one `plugins-channel-tree-<name>` row per actually-present subdir; metadata namespaces (marketplaces/, cache/, *.json) excluded |

### Coordinator additions (L1-J + L1-K)

| Gap | What | Fix |
| --- | --- | --- |
| **L1-J** | Bundled plugins ship without node_modules → "Cannot find module '@modelcontextprotocol/sdk/...'" on iso UID MCP spawn for ms365 | New `lib/upgrade-helpers/bundled-plugins-bun-install.sh` walks every plugin under `$BRIDGE_HOME/plugins/*/` with package.json, runs `bun install --frozen-lockfile` (idempotent: skip when node_modules newer than package.json + bun.lock); wired into `bridge-upgrade.sh` after bun-traverse pass + into `bridge_provision_teams_plugin_runtime` via new `bridge_provision_bundled_plugins_node_modules` |
| **L1-K** | Node 12.22.9 (Ubuntu 22.04 default) breaks plugins using `?.`, `??`, top-level await (e.g. cosmax-ep-approval) | bundled-plugins helper detects node version, emits loud `bridge_warn` when major < 14 (Option B: fail-fast diagnostic, NOT silent symlinking of /usr/local/bin/node). Non-fatal — bundled-plugin install continues |

### Not in scope

- **L1-B / L1-C / L1-E**: iso-UID-initiated plugin commands (v0.16 deferred per Sean 2026-05-25)
- **L1-H**: agent update --channels-add idempotency race (separate issue)
- **L1-I**: root cannot truncate iso-UID-owned 0660 (research only)
- L2 Variant 3A (separate PR #1188, beta20 sibling)
- ep MCP spawn issue on patch's host AFTER manual bun + symlink — not reproducible in this PR's VM run; leave for patch's next handoff per coordinator brief

## VM acceptance (in-place upgrade on agb-clean-test, beta19 → branch)

| # | Step | Result |
| -- | --- | --- |
| 1 | `agent-bridge upgrade --apply --channel current` | **PASS** (bundled-plugins helper fires, `node v18.19.1 OK (>= 14)` line in log; `bun runtime not found on PATH — skipping` clean skip note) |
| 2 | `agb plugins seed --marketplace-root /tmp/fixture-marketplace` | **PASS** (D1: registry add succeeded; D3: chmod -R o+rX widened mode 700 → 705; D2: propagated=1 skipped=1 failed=0 across linux-user agents) |
| 3 | `claude plugin marketplace list \| grep fixture-marketplace` | **PASS** (also visible in `~/.claude/plugins/known_marketplaces.json`) |
| 4 | Create iso agent referencing fixture-plugin channel | **PASS** (substituted: existing `test_iso5` roster amended with `BRIDGE_AGENT_CHANNELS["test_iso5"]=plugin:fixture-plugin@fixture-marketplace`; same D2 code path) |
| 5 | `agent-bridge isolation reconcile --check --agent test_iso5` | **PASS** — `plugins-channel-tree-teams`, `plugins-channel-tree-ms365`, `plugins-channel-tree-mattermost` all `ok` (vs. previously always `skipped (absent)`). Legacy `plugins-channel-trees` literal-glob row gone |
| 6 | `sudo cat /home/agent-bridge-test_iso5/.claude/plugins/known_marketplaces.json` | **PASS** (contains `fixture-marketplace` with `installLocation: /tmp/fixture-marketplace`, root:ab-agent-test_iso5 0640) |
| 7 | `sudo -u agent-bridge-test_iso5 test -x /tmp/fixture-marketplace` | **PASS** (iso UID traverse + list + read OK) |
| 8 | `bridge-dev-plugin-cache.resolve_marketplace_root` probe under iso UID | **PASS** (resolved=`/tmp/fixture-marketplace`, `is_dir=True` — launcher will find marketplace first try, no manual add needed) |

### L1-J/K verification additions

- After bun install pass, all bundled plugins (teams, ms365, mattermost) have node_modules populated (teams was idempotent-skipped, others freshly installed)
- iso UID can import MCP SDK: `sudo -u agent-bridge-test_iso5 bun -e 'import {Server} from "@modelcontextprotocol/sdk/server/index.js"; console.log("import-OK", typeof Server)'` → `import-OK function` within 1s
- Node version probe path reachable: VM has Node v18.19.1 (≥ 14) → `[bundled-plugins][node-check] node v18.19.1 OK (>= 14)` in upgrade log; the < 14 branch is the loud-warn fail-fast diagnostic path

## Test plan

- [x] `bash -n` on every changed shell file (clean)
- [x] `shellcheck` on every changed shell file (clean, only pre-existing SC2329 noise from unmodified test helpers)
- [x] `python3 -c "import py_compile; ..."` on every new python helper (clean)
- [x] `scripts/smoke/phase2-install-tree-reconciler.sh` T1-T10 all pass (T10 is new, validates D4 glob expansion)
- [x] End-to-end VM acceptance on agb-clean-test (8-step + L1-J/K, all PASS)

## Files

- `bridge-plugins.sh` — extended `bridge_plugins_cmd_seed` (D1+D2+D3 post-sync propagation, `--no-iso-chmod` flag, marketplace_root canonicalization). New helpers: `bridge_plugins_seed_propagate_controller_registry`, `bridge_plugins_seed_external_marketplace_iso_readable`, `bridge_plugins_seed_propagate_iso_known_marketplaces`, `_bridge_plugins_seed_channels_csv_uses_marketplace`.
- `lib/bridge-isolation-v2-reconcile.sh` — D4: `plugins-channel-trees` row replaced with glob-expansion-at-emit-time loop emitting `plugins-channel-tree-<name>` per subdir.
- `lib/bridge-channels.sh` — L1-J: new `bridge_provision_bundled_plugins_node_modules` (generalization of teams helper), wired into `bridge_provision_teams_plugin_runtime`.
- `bridge-upgrade.sh` — L1-J: invoke `bundled-plugins-bun-install.sh` after bun-traverse step.
- `lib/upgrade-helpers/bundled-plugins-bun-install.sh` — new standalone helper, file-as-argv per footgun #11; L1-K node version detection embedded.
- `lib/upgrade-helpers/plugins-seed-marketplace-name.py` — new standalone helper for parsing the marketplace name from manifest.
- `lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py` — new standalone helper for idempotent JSON merge.
- `scripts/smoke/phase2-install-tree-reconciler.sh` — T1 row-list updated (legacy `plugins-channel-trees` removed); T10 added.

## Versioning

No VERSION/CHANGELOG bump (stabilization PR per operator directive 2026-05-15). The next release PR is operator-cued and batches accumulated user-visible items.