### PR TITLE
feat(iso): beta21 P0 hotfix — state-leaf + iso-uid queue + start-path catalog (#1188+1189 sequel)

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -202,6 +202,26 @@ if [[ -z "${BRIDGE_CONTROLLER_UID:-}" ]]; then
   unset _bridge_recovery_home _bridge_recovery_marker
 fi
 
+# L1-N (beta21): mark this process as a queue-safe verb context BEFORE
+# sourcing bridge-lib.sh, so `bridge_load_roster` (inside the lib) can
+# fall through to the public-roster-only path when an iso UID runs an
+# `agb`-aliased queue verb (e.g. `agb show 123`, `agb done 123`) from
+# a controller-protected `BRIDGE_ROSTER_LOCAL_FILE`. The flag is only
+# set for the queue-shorthand verbs that line 1256 dispatches to
+# `bridge-task.sh` — every OTHER subcommand falls through unchanged
+# (channel/agent/admin verbs etc. still need roster_local and will
+# fail-closed on the iso-UID-without-scoped-env path).
+#
+# `task` and `inbox` skip `bridge_load_roster` at the wrapper level
+# (line 235 below) — bridge-task.sh sets the flag itself when invoked
+# directly, so they don't need to be enumerated here. The enumerated
+# tokens below mirror the dispatch table at line 1256.
+case "${1:-}" in
+  show|claim|done|cancel|update|handoff|summary|create)
+    export BRIDGE_QUEUE_SAFE_CONTEXT=1
+    ;;
+esac
+
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 

--- a/bridge-queue-gateway.py
+++ b/bridge-queue-gateway.py
@@ -135,6 +135,21 @@ def atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f"{path.name}.tmp.{os.getpid()}.{secrets.token_hex(4)}")
     tmp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    # L1-N (beta21) tail: chmod 0640 so the file-mode gateway's
+    # request/response pair is readable by EITHER side. Without this,
+    # the controller daemon writes responses at its own umask (typically
+    # 077 → 0600 owned by `sean`) into the per-agent responses/ dir,
+    # and the iso UID's poll loop can never read them — `agb task create`
+    # from iso UID would PermissionError on the response file even
+    # though L1-N fixed bridge_load_roster, the request was queued
+    # successfully, and the daemon processed it. The setgid bit on
+    # the parent dir already ensures the file inherits the
+    # ab-agent-<X> group, so 0640 (owner+group rw, owner+group r)
+    # gives BOTH the controller and the iso UID read access without
+    # widening the surface beyond the per-agent group. Same code path
+    # writes request files (iso UID → controller) and response files
+    # (controller → iso UID); both directions benefit.
+    os.chmod(tmp, 0o640)
     os.replace(tmp, path)
 
 

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -578,6 +578,68 @@ if bridge_isolation_disabled_by_env; then
 elif bridge_agent_linux_user_isolation_effective "$AGENT"; then
   AGENT_ENV_FILE="$(bridge_agent_linux_env_file "$AGENT")"
   bridge_write_linux_agent_env_file "$AGENT" "$AGENT_ENV_FILE"
+
+  # L1-D (beta21, codex r1 spec / PR #1196): re-derive the per-UID plugin
+  # catalog on every start/restart so an existing iso agent picks up
+  # marketplaces that were added AFTER the agent was created (via `agb
+  # plugins seed`, manual marketplace add, etc.). Without this, the
+  # per-UID `known_marketplaces.json` is only written at agent-create /
+  # reapply via `bridge_linux_prepare_agent_isolation` (lib/bridge-agents.sh:4156)
+  # and at `agb plugins seed` via the D2 merge helper (bridge-plugins.sh,
+  # PR #1189) — operator-side drift (e.g. iso HOME catalog reset, new
+  # external marketplace added to roster but no agent-recreate) leaves
+  # the iso UID with a stale catalog and dev-plugin-cache reports
+  # `marketplace-mismatch:<marketplace>` for every plugin that lives in
+  # the missing marketplace.
+  #
+  # The CANONICAL writer is `bridge_linux_share_plugin_catalog`
+  # (lib/bridge-agents.sh:2512+) — it re-derives the filtered per-UID
+  # catalog + installed_plugins.json + marketplace symlinks from the
+  # shared plugin cache and the agent's declared channels/plugins each
+  # time it runs. Stale or manually-edited per-UID state is therefore
+  # overwritten with the canonical state on every start, closing the
+  # "operator drifted existing agent" failure mode that D2 (seed-side
+  # merge) cannot reach.
+  #
+  # SUPPRESS_MISSING_CHANNELS=1 (line 568 above): the suppress-aware
+  # launcher is used when the agent is mid-onboarding and its channel
+  # runtime is incomplete. Calling the share helper here in that mode
+  # could turn a suppressed-channel recovery start into a NEW hard
+  # failure if the shared plugin cache is also absent (helper
+  # `bridge_die`s on a populated channel list but no cache). Skip the
+  # share call in that mode (codex r1 option (a)) — the agent's plugin
+  # channels are suppressed for launch anyway, so the per-UID catalog
+  # is not consulted in the launch path. The next non-suppressed start
+  # re-runs this helper and brings the catalog back to canonical.
+  #
+  # For normal starts that DO need plugin channels but lack the shared
+  # cache, the helper fails loud with its existing "run `agb plugins
+  # seed`" guidance — no silent no-op.
+  if [[ "$SUPPRESS_MISSING_CHANNELS" -eq 1 ]]; then
+    bridge_warn "BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS=1 — skipping per-UID plugin catalog re-derivation for '$AGENT' (suppress-aware launch; the next non-suppressed start re-derives)"
+  else
+    _l1d_os_user="$(bridge_agent_os_user "$AGENT" 2>/dev/null || true)"
+    if [[ -z "$_l1d_os_user" ]]; then
+      bridge_warn "bridge-start.sh L1-D: cannot resolve os_user for agent '$AGENT' — skipping per-UID plugin catalog re-derivation (the agent's plugin channels may report marketplace-mismatch on this launch; recover via \`agent-bridge isolate $AGENT\` to repair)"
+    else
+      _l1d_user_home="$(bridge_agent_linux_user_home "$_l1d_os_user")"
+      _l1d_controller_user="$(bridge_isolation_v2_controller_user 2>/dev/null || true)"
+      if [[ -z "$_l1d_controller_user" ]]; then
+        bridge_warn "bridge-start.sh L1-D: cannot resolve controller user for agent '$AGENT' — skipping per-UID plugin catalog re-derivation"
+      elif ! bridge_linux_share_plugin_catalog \
+              "$_l1d_os_user" "$_l1d_user_home" "$_l1d_controller_user" "$AGENT"; then
+        # Helper fails loud (bridge_die) on a populated channel list +
+        # absent shared cache; that path never returns here. Other
+        # failures (chown / chmod / symlink) are non-fatal for the
+        # start path — the agent may still launch with a stale (but
+        # non-empty) per-UID catalog from a prior create/seed pass.
+        # Surface a warn so the operator sees the drift.
+        bridge_warn "bridge-start.sh L1-D: per-UID plugin catalog re-derivation FAILED for agent '$AGENT' (start continues with the prior catalog; expect marketplace-mismatch reports if a marketplace was added since the last agent-create / seed)"
+      fi
+      unset _l1d_user_home _l1d_controller_user
+    fi
+    unset _l1d_os_user
+  fi
 fi
 
 SESSION_CMD="$(bridge_join_quoted "$BRIDGE_BASH_BIN" "$RUNNER" "$AGENT")"

--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -4,6 +4,18 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# L1-N (beta21): mark this process as a queue-safe verb context BEFORE
+# sourcing bridge-lib.sh, so `bridge_load_roster` (inside the lib) can
+# distinguish queue commands (which only need the public roster + the
+# gateway socket) from other commands that genuinely need the
+# protected `BRIDGE_ROSTER_LOCAL_FILE`. This is what lets an iso UID
+# fall through to `bridge_warn`-skip on EACCES instead of dying with
+# the misleading "queue gateway timed out" wrapper error.
+#
+# Every subcommand in this file is by design queue-safe (the whole
+# file IS the queue CLI). Marking the entire process is therefore
+# correct — no per-verb gate needed.
+export BRIDGE_QUEUE_SAFE_CONTEXT=1
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 

--- a/lib/bridge-isolation-v2-reconcile.sh
+++ b/lib/bridge-isolation-v2-reconcile.sh
@@ -1222,17 +1222,48 @@ bridge_isolation_v2_install_tree_matrix_rows() {
     local state_root="${BRIDGE_STATE_DIR:-$data_root/state}"
     local state_agents_root="$state_root/agents"
     local state_agent_dir="$state_agents_root/$agent"
-    # state-agent-leaf creation lands here too so a freshly created
-    # isolated agent has its per-agent state dir present before the
-    # daemon's first marker write. The matrix in
-    # `bridge_isolation_v2_matrix_rows_for_agent` (lib/bridge-isolation-v2.sh)
-    # is the SSOT for the leaf's ownership/mode contract; this row
-    # only guarantees existence. apply mode does the mkdir, then the
-    # per-agent matrix's `state-agent-dir` row sets the leaf mode
-    # later in prepare flow (we don't replicate the ab-agent-<X>
-    # contract here to keep one source of truth).
-    printf '%s\n' \
-      "agent-state-leaf|per-agent|$state_agent_dir|state_scaffold|controller|ab-shared|0710|-|0|0|inherit|direct|optional|state/agents/$agent dir scaffold (per-agent matrix owns final mode)"
+    # state-agent-leaf — per-agent state/agents/<agent> dir scaffold.
+    #
+    # Codex L1-M r1 spec (PR #1196 / beta21): align this row to the SAME
+    # final contract that the per-agent grant matrix emits in
+    # `bridge_isolation_v2_matrix_rows_for_agent`
+    # (lib/bridge-isolation-v2.sh:1596-1622), so both `--reason
+    # agent-create` AND standalone `agent-bridge isolation reconcile
+    # --apply --agent <X>` converge to the SAME final state without an
+    # intermediate optional 0710 ab-shared stage. Without this
+    # alignment, the install-tree reconciler was leaving the leaf at
+    # 0710/ab-shared (its prior optional contract), and the per-agent
+    # matrix's `state-agent-dir` row would have to repair it on the
+    # next pass — which never reliably runs from the start-path, so
+    # state/agents/<agent>/ never landed at the final 2770 +
+    # ab-agent-<X> contract on existing iso agents. Claude session
+    # marker writes from the Stop hook then EACCESed and broke
+    # `--resume` continuity (the L1-M symptom).
+    #
+    # Contract per mode (matches matrix SSOT exactly):
+    #   linux-user agent  → owner=controller, group=ab-agent-<agent>,
+    #                       mode 2770, required.
+    #   shared-mode agent → owner=controller, group=controller_group,
+    #                       mode 2770, required.
+    #
+    # Note: the row's group field is emitted LITERAL for the
+    # linux-user case (`ab-agent-<agent>` is not in the resolver's
+    # token list at lib/bridge-isolation-v2-reconcile.sh:174-192) so
+    # apply-time token resolution returns it as-is. `controller_group`
+    # IS a resolver token and is resolved at apply time to the
+    # operator's primary group for the shared-mode branch.
+    local _v2_iso_mode_for_leaf=""
+    if command -v bridge_agent_isolation_mode >/dev/null 2>&1; then
+      _v2_iso_mode_for_leaf="$(bridge_agent_isolation_mode "$agent" 2>/dev/null || true)"
+    fi
+    if [[ "$_v2_iso_mode_for_leaf" == "linux-user" \
+          && -n "$_v2_iso_agent_group" ]]; then
+      printf '%s\n' \
+        "agent-state-leaf|per-agent|$state_agent_dir|state_scaffold|controller|$_v2_iso_agent_group|2770|-|1|0|inherit|direct|required|state/agents/$agent dir scaffold — matrix SSOT (controller:ab-agent-<X>:2770) for linux-user; required so Stop-hook session marker writes and reconcile --apply both converge to the same final contract"
+    else
+      printf '%s\n' \
+        "agent-state-leaf|per-agent|$state_agent_dir|state_scaffold|controller|controller_group|2770|-|1|0|inherit|direct|required|state/agents/$agent dir scaffold — matrix SSOT (controller:controller_group:2770) for shared-mode; required so reconcile --apply converges to the same final state"
+    fi
 
     # ----- credential grant for this agent's iso UID context -----
     # Routed through the existing credential_grant helper which knows

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1050,9 +1050,52 @@ bridge_load_roster() {
   # This is what keeps the isolated UID from needing read access to the global
   # agent-roster.local.sh (which is 0600 and contains every agent's tokens).
   # See issue #116.
-  if [[ -z "$isolated_env_file" && -n "$scoped_agent_id" && -n "${BRIDGE_ACTIVE_AGENT_DIR:-}" ]]; then
-    scoped_env_file="$BRIDGE_ACTIVE_AGENT_DIR/$scoped_agent_id/agent-env.sh"
-    if [[ -r "$scoped_env_file" ]]; then
+  #
+  # L1-N (beta21, codex r1 spec): the scoped env writer for v2 puts the
+  # file at `$BRIDGE_AGENT_ROOT_V2/<agent>/runtime/agent-env.sh` (via
+  # `bridge_agent_linux_env_file` → `bridge_agent_runtime_state_dir`),
+  # NOT at the legacy `$BRIDGE_ACTIVE_AGENT_DIR/<agent>/agent-env.sh`
+  # path. Without checking BOTH paths, iso UID `agb task create`
+  # subprocesses (whose bridge-task.sh fork sources bridge-lib.sh, which
+  # calls bridge_load_roster) missed scoped env discovery on v2 hosts
+  # and fell through to sourcing the 0600 `BRIDGE_ROSTER_LOCAL_FILE` —
+  # which EACCESed under the iso UID and killed the wrapper. The scoped
+  # env is what sets `BRIDGE_TASK_DB=/dev/null` and
+  # `BRIDGE_GATEWAY_PROXY=1` so the queue command routes through the
+  # controller-side gateway socket (lib/bridge-core.sh:640-663,
+  # 781-811); finding it via either path keeps queue traffic safely
+  # gateway-routed without exposing the controller's roster to the iso
+  # UID.
+  if [[ -z "$isolated_env_file" && -n "$scoped_agent_id" ]]; then
+    # Try v2 runtime path first if BRIDGE_AGENT_ROOT_V2 is exported —
+    # that is the canonical writer location for the v2 layout. Prefer
+    # `bridge_agent_linux_env_file` when the helper is loaded; fall
+    # back to the literal path expression so this discovery still
+    # works in subshell contexts where the helper may not yet be
+    # defined (the function lives in lib/bridge-agents.sh, which IS
+    # sourced via bridge-lib.sh, but a defensive fallback costs us
+    # nothing and keeps the discovery independent of source order).
+    if [[ -n "${BRIDGE_AGENT_ROOT_V2:-}" ]]; then
+      local _v2_scoped_env_file=""
+      if declare -F bridge_agent_linux_env_file >/dev/null 2>&1; then
+        _v2_scoped_env_file="$(bridge_agent_linux_env_file "$scoped_agent_id" 2>/dev/null || true)"
+      fi
+      if [[ -z "$_v2_scoped_env_file" ]]; then
+        _v2_scoped_env_file="$BRIDGE_AGENT_ROOT_V2/$scoped_agent_id/runtime/agent-env.sh"
+      fi
+      if [[ -r "$_v2_scoped_env_file" ]]; then
+        scoped_env_file="$_v2_scoped_env_file"
+      fi
+    fi
+    # Fall back to the legacy path under BRIDGE_ACTIVE_AGENT_DIR for
+    # pre-v2 installs and tests that still exercise that layout.
+    if [[ -z "$scoped_env_file" && -n "${BRIDGE_ACTIVE_AGENT_DIR:-}" ]]; then
+      local _legacy_scoped_env_file="$BRIDGE_ACTIVE_AGENT_DIR/$scoped_agent_id/agent-env.sh"
+      if [[ -r "$_legacy_scoped_env_file" ]]; then
+        scoped_env_file="$_legacy_scoped_env_file"
+      fi
+    fi
+    if [[ -n "$scoped_env_file" ]]; then
       isolated_env_file="$scoped_env_file"
       # Persist the discovered path so bridge_queue_gateway_proxy_agent
       # (lib/bridge-core.sh) can detect proxy mode without requiring
@@ -1074,9 +1117,60 @@ bridge_load_roster() {
       source "$BRIDGE_ROSTER_FILE"
     fi
 
+    # L1-N (beta21, codex r1): queue-safe iso UID fallback. When the
+    # scoped env was NOT discovered (above) AND the calling process is
+    # a non-controller (iso) UID AND `BRIDGE_ROSTER_LOCAL_FILE` is
+    # unreadable AND the caller is a known queue-safe verb, source
+    # only the public roster (already done above) and skip the
+    # protected local roster. Queue verbs (`task create|done|claim|
+    # cancel|update|handoff|summary|create`, top-level `inbox|show|
+    # claim|done|cancel|update|handoff|summary|create`) only need the
+    # agent inventory (in the public roster) to validate `--to <agent>`
+    # — they route through `bridge_queue_cli` which uses the gateway
+    # socket, NOT direct DB access, so they don't need any secret in
+    # `BRIDGE_ROSTER_LOCAL_FILE`.
+    #
+    # For NON-queue commands without scoped env, fail closed with an
+    # actionable error pointing the operator at controller-side
+    # invocation or scoped env. (channel mutations, agent mutations,
+    # admin verbs etc. legitimately need roster_local; running them as
+    # an iso UID without scoped env is a misuse).
+    #
+    # `BRIDGE_ROSTER_LOCAL_FILE` mode itself stays 0600 (protected,
+    # NOT chmod'd) — only the SOURCING is skipped for the queue verb
+    # case, the file remains controller-readable for legitimate
+    # controller-side roster_load callsites.
     if [[ -f "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
-      # shellcheck source=/dev/null
-      source "$BRIDGE_ROSTER_LOCAL_FILE"
+      if [[ -r "$BRIDGE_ROSTER_LOCAL_FILE" ]]; then
+        # shellcheck source=/dev/null
+        source "$BRIDGE_ROSTER_LOCAL_FILE"
+      else
+        # Unreadable: detect iso UID + queue-safe context.
+        local _is_iso_uid=0
+        if [[ "$EUID" -ne 0 ]] \
+            && [[ -n "${BRIDGE_CONTROLLER_UID:-}" ]] \
+            && [[ "$EUID" != "${BRIDGE_CONTROLLER_UID}" ]]; then
+          _is_iso_uid=1
+        fi
+        if (( _is_iso_uid == 1 )) \
+            && [[ "${BRIDGE_QUEUE_SAFE_CONTEXT:-0}" == "1" ]]; then
+          # Once-per-process warn so VM logs surface the path that
+          # was taken without flooding when an agent runs a batch of
+          # queue commands.
+          if [[ "${BRIDGE_ROSTER_LOCAL_SKIP_WARNED:-0}" != "1" ]]; then
+            bridge_warn "bridge_load_roster: iso UID detected (euid=$EUID, controller_uid=${BRIDGE_CONTROLLER_UID:-}), queue-safe verb context — skipping unreadable protected roster '$BRIDGE_ROSTER_LOCAL_FILE' (public roster + gateway proxy provide queue access; configure scoped env via \`agent-bridge isolate <agent>\` to silence)"
+            export BRIDGE_ROSTER_LOCAL_SKIP_WARNED=1
+          fi
+        else
+          # Fail closed: non-queue command from iso UID without scoped
+          # env, OR a controller-side caller that genuinely cannot
+          # read its own roster (filesystem damage). Either way we
+          # MUST NOT silently continue with a half-loaded roster —
+          # that was the pre-L1-N footgun (silent EACCES → wrapper
+          # error). Surface actionable guidance.
+          bridge_die "bridge_load_roster: cannot read protected roster '$BRIDGE_ROSTER_LOCAL_FILE' (euid=$EUID). For iso UID invocations, either (a) use a queue-safe verb (task create|done|claim|inbox|...) which routes through the gateway, (b) run the command as the controller via \`agb\` on the controller side, or (c) ensure the scoped agent env exists at \$BRIDGE_AGENT_ROOT_V2/<agent>/runtime/agent-env.sh (re-run \`agent-bridge isolate <agent>\` to regenerate)"
+        fi
+      fi
     fi
   fi
 

--- a/scripts/smoke/l1n-iso-uid-queue-roster-skip.sh
+++ b/scripts/smoke/l1n-iso-uid-queue-roster-skip.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/l1n-iso-uid-queue-roster-skip.sh — L1-N (beta21).
+#
+# Background: an iso UID running `agb task create --to <agent>`
+# subprocesses bridge-task.sh, which sources bridge-lib.sh and calls
+# `bridge_load_roster`. Pre-L1-N, that path:
+#
+#   1. Looked for the scoped env at the legacy path
+#      `$BRIDGE_ACTIVE_AGENT_DIR/<agent>/agent-env.sh` ONLY — never at
+#      the v2 path `$BRIDGE_AGENT_ROOT_V2/<agent>/runtime/agent-env.sh`
+#      where the writer actually puts it on a v2 install.
+#   2. When scoped env was not found, unconditionally sourced
+#      `BRIDGE_ROSTER_LOCAL_FILE` (which is 0600 root-only), EACCESed
+#      from the iso UID, and crashed the bridge-task.sh wrapper with a
+#      misleading "queue gateway timed out" error.
+#
+# L1-N fix (lib/bridge-state.sh::bridge_load_roster):
+#   a. Scoped-env discovery extension: when BRIDGE_AGENT_ID is set, try
+#      `$BRIDGE_AGENT_ROOT_V2/<agent>/runtime/agent-env.sh` BEFORE
+#      falling back to the legacy path.
+#   b. Queue-safe roster_local skip: when scoped env was not found
+#      AND the calling UID is non-controller AND
+#      $BRIDGE_ROSTER_LOCAL_FILE is unreadable AND
+#      BRIDGE_QUEUE_SAFE_CONTEXT=1 (set by bridge-task.sh and the
+#      `agb show|claim|done|...` shorthand in agent-bridge), warn once
+#      and skip the protected source instead of failing.
+#   c. Non-queue context with the same precondition fails closed with
+#      an actionable error pointing at scoped env / controller-side
+#      invocation.
+#
+# This smoke pins those three contracts:
+#   T1 — v2 scoped env discovery: writer-shaped scoped env at the v2
+#        runtime path is discovered when BRIDGE_AGENT_ID is set; BRIDGE_AGENT_ENV_FILE
+#        is exported to that path (so bridge_queue_gateway_proxy_agent
+#        sees gateway-proxy mode without a pre-exported env var).
+#   T2 — legacy scoped env discovery still works (fallback): a fixture
+#        at the legacy path is honored when the v2 path is absent. Pins
+#        the back-compat surface for pre-v2 installs and tests.
+#   T3 — queue-safe skip on unreadable roster_local: with no scoped
+#        env, unreadable roster_local, simulated iso UID, AND
+#        BRIDGE_QUEUE_SAFE_CONTEXT=1, bridge_load_roster returns 0
+#        without sourcing the protected roster. The once-per-process
+#        warn emits but is not asserted (cosmetic).
+#   T4 — fail-closed without queue-safe context: same precondition but
+#        BRIDGE_QUEUE_SAFE_CONTEXT=0 (or unset) → bridge_load_roster
+#        dies with an actionable error message that names the file and
+#        points at scoped env / controller-side invocation.
+#   T5 — controller-side invocation with unreadable roster is still a
+#        hard fail (the iso-UID skip MUST NOT mask filesystem damage
+#        for a legitimate controller-side caller).
+#
+# Isolation: temp BRIDGE_HOME via smoke_setup_bridge_home. Iso UID is
+# simulated by setting BRIDGE_CONTROLLER_UID to a number different from
+# $EUID — bridge_load_roster's iso detection uses
+# `EUID != BRIDGE_CONTROLLER_UID && EUID != 0` to pick the iso path
+# without actually being a different UID (which would need root +
+# useradd we cannot do on macOS smoke). Roster_local "unreadable" is
+# achieved by chmod 000; restored to 0600 before cleanup.
+#
+# Footgun #11 — no heredoc-stdin. Fixtures written via
+# `cat >file <<EOF` on flat strings; no command substitution feeding a
+# heredoc; no <<< here-strings into bridge functions.
+
+set -uo pipefail
+
+# Re-exec under Bash 4+ for associative arrays.
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash"; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$_candidate" "${BASH_SOURCE[0]}" "$@"
+    fi
+  done
+  echo "[smoke:l1n-iso-uid-queue-roster-skip] requires Bash 4+ (host is ${BASH_VERSION})" >&2
+  exit 1
+fi
+
+SMOKE_NAME="l1n-iso-uid-queue-roster-skip"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  # Restore roster_local mode in case a test left it at 0000.
+  if [[ -n "${BRIDGE_ROSTER_LOCAL_FILE:-}" && -f "${BRIDGE_ROSTER_LOCAL_FILE:-}" ]]; then
+    chmod 0600 "$BRIDGE_ROSTER_LOCAL_FILE" 2>/dev/null || true
+  fi
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+# Public roster needs at least one syntactically-valid line for
+# bridge_load_roster to source without error. Use a comment so no maps
+# get populated and we can prove the function exits cleanly.
+cat >"$BRIDGE_ROSTER_FILE" <<'EOF'
+# public roster (smoke fixture — no agents declared)
+EOF
+
+# Protected roster at 0600 — same shape as a live install. Tests
+# selectively chmod 000 to simulate the EACCES case.
+cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<'EOF'
+# protected roster (smoke fixture — sentinel for T5 readability)
+BRIDGE_ROSTER_LOCAL_SENTINEL=1
+EOF
+chmod 0600 "$BRIDGE_ROSTER_LOCAL_FILE"
+
+# Build a writer-shaped scoped env file at the v2 path. Just needs to be
+# a sourceable bash file; we sentinel-export a value the test can
+# assert.
+v2_scoped_env_path_for() {
+  local agent="$1"
+  printf '%s/%s/runtime/agent-env.sh' "$BRIDGE_AGENT_ROOT_V2" "$agent"
+}
+
+write_v2_scoped_env() {
+  local agent="$1"
+  local sentinel="$2"
+  local path
+  path="$(v2_scoped_env_path_for "$agent")"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path" <<EOF
+# v2 scoped env (smoke fixture for L1-N T1)
+BRIDGE_AGENT_ID="$agent"
+BRIDGE_TASK_DB="/dev/null"
+BRIDGE_GATEWAY_PROXY="1"
+BRIDGE_L1N_SCOPED_ENV_SENTINEL="$sentinel"
+EOF
+  chmod 0640 "$path"
+}
+
+write_legacy_scoped_env() {
+  local agent="$1"
+  local sentinel="$2"
+  local path="$BRIDGE_ACTIVE_AGENT_DIR/$agent/agent-env.sh"
+  mkdir -p "$(dirname "$path")"
+  cat >"$path" <<EOF
+# legacy scoped env (smoke fixture for L1-N T2)
+BRIDGE_AGENT_ID="$agent"
+BRIDGE_L1N_LEGACY_SENTINEL="$sentinel"
+EOF
+  chmod 0640 "$path"
+}
+
+# ---------- T1: v2 scoped env discovery -------------------------------------
+
+test_t1_v2_scoped_env_discovered() {
+  smoke_log "T1: v2 runtime/agent-env.sh discovered when BRIDGE_AGENT_ID is set"
+
+  local agent="iso_l1n_t1"
+  write_v2_scoped_env "$agent" "T1-v2-found"
+
+  # Sub-shell so the export/unset don't leak. Also clear the per-process
+  # cache flag the lib sets so the load actually runs.
+  local out rc=0
+  out="$("$SMOKE_BASH" -c "
+    set -uo pipefail
+    unset BRIDGE_AGENT_ENV_FILE BRIDGE_ROSTER_CACHE_LOADED BRIDGE_L1N_SCOPED_ENV_SENTINEL
+    export BRIDGE_AGENT_ID='$agent'
+    export BRIDGE_QUEUE_SAFE_CONTEXT=1
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_load_roster >/dev/null 2>&1
+    printf 'sentinel=%s\n' \"\${BRIDGE_L1N_SCOPED_ENV_SENTINEL:-UNSET}\"
+    printf 'env_file=%s\n' \"\${BRIDGE_AGENT_ENV_FILE:-UNSET}\"
+  " 2>/dev/null)" || rc=$?
+
+  smoke_assert_eq "0" "$rc" "T1 sub-shell exited 0"
+  smoke_assert_contains "$out" "sentinel=T1-v2-found" \
+    "T1: bridge_load_roster sourced the v2 scoped env (sentinel set)"
+  smoke_assert_contains "$out" "runtime/agent-env.sh" \
+    "T1: BRIDGE_AGENT_ENV_FILE exported to the v2 runtime path"
+}
+
+# ---------- T2: legacy scoped env discovery fallback ------------------------
+
+test_t2_legacy_scoped_env_fallback() {
+  smoke_log "T2: legacy state/agents/<X>/agent-env.sh used when v2 path absent"
+
+  local agent="iso_l1n_t2"
+  # NO v2 scoped env — only legacy.
+  write_legacy_scoped_env "$agent" "T2-legacy-found"
+
+  local out rc=0
+  out="$("$SMOKE_BASH" -c "
+    set -uo pipefail
+    unset BRIDGE_AGENT_ENV_FILE BRIDGE_ROSTER_CACHE_LOADED BRIDGE_L1N_LEGACY_SENTINEL
+    export BRIDGE_AGENT_ID='$agent'
+    export BRIDGE_QUEUE_SAFE_CONTEXT=1
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_load_roster >/dev/null 2>&1
+    printf 'sentinel=%s\n' \"\${BRIDGE_L1N_LEGACY_SENTINEL:-UNSET}\"
+  " 2>/dev/null)" || rc=$?
+
+  smoke_assert_eq "0" "$rc" "T2 sub-shell exited 0"
+  smoke_assert_contains "$out" "sentinel=T2-legacy-found" \
+    "T2: bridge_load_roster fell back to the legacy scoped env path"
+}
+
+# ---------- T3: queue-safe iso UID skip on unreadable roster_local ----------
+
+test_t3_queue_safe_skip() {
+  smoke_log "T3: queue-safe iso UID + unreadable roster_local → skip with warn"
+
+  # No scoped env; chmod 000 the protected roster; simulate iso UID.
+  chmod 000 "$BRIDGE_ROSTER_LOCAL_FILE"
+
+  local out rc=0
+  # Pick a sentinel BRIDGE_CONTROLLER_UID that EUID != it AND EUID != 0
+  # to trigger the iso UID branch. Use 999999 — clearly not a real
+  # operator UID. If somehow the smoke runs as root (EUID=0) the gate
+  # would skip the iso branch; assert below that we're not running as
+  # root to keep the test meaningful.
+  if [[ "$EUID" -eq 0 ]]; then
+    smoke_log "T3 skipped — smoke is running as root, iso UID branch can't be exercised here (gate is EUID != 0)"
+    chmod 0600 "$BRIDGE_ROSTER_LOCAL_FILE"
+    return 0
+  fi
+
+  out="$("$SMOKE_BASH" -c "
+    set -uo pipefail
+    unset BRIDGE_AGENT_ENV_FILE BRIDGE_ROSTER_CACHE_LOADED BRIDGE_AGENT_ID BRIDGE_ROSTER_LOCAL_SKIP_WARNED
+    export BRIDGE_CONTROLLER_UID=999999
+    export BRIDGE_QUEUE_SAFE_CONTEXT=1
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_load_roster
+    printf 'rc=%s\n' \$?
+  " 2>&1)" || rc=$?
+
+  chmod 0600 "$BRIDGE_ROSTER_LOCAL_FILE"
+
+  smoke_assert_eq "0" "$rc" "T3 sub-shell exited 0 (queue-safe skip is non-fatal)"
+  smoke_assert_contains "$out" "rc=0" \
+    "T3: bridge_load_roster returned 0 after queue-safe skip"
+  smoke_assert_contains "$out" "queue-safe verb context" \
+    "T3: bridge_warn emitted the queue-safe skip explanation"
+  # Sanity: the protected roster's sentinel was NOT sourced.
+  smoke_assert_not_contains "$out" "BRIDGE_ROSTER_LOCAL_SENTINEL" \
+    "T3: protected roster file was NOT sourced (no leaked sentinel)"
+}
+
+# ---------- T4: fail-closed without queue-safe context ----------------------
+
+test_t4_fail_closed_no_queue_context() {
+  smoke_log "T4: iso UID + unreadable roster_local + NO queue-safe context → fail closed"
+
+  if [[ "$EUID" -eq 0 ]]; then
+    smoke_log "T4 skipped — smoke is running as root, iso UID branch can't be exercised"
+    return 0
+  fi
+
+  chmod 000 "$BRIDGE_ROSTER_LOCAL_FILE"
+
+  local out rc=0
+  # Note: bridge_die exits the SUBSHELL non-zero; we capture stderr+stdout
+  # combined so the actionable message is visible to assertions.
+  out="$("$SMOKE_BASH" -c "
+    set -uo pipefail
+    unset BRIDGE_AGENT_ENV_FILE BRIDGE_ROSTER_CACHE_LOADED BRIDGE_AGENT_ID BRIDGE_QUEUE_SAFE_CONTEXT BRIDGE_ROSTER_LOCAL_SKIP_WARNED
+    export BRIDGE_CONTROLLER_UID=999999
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_load_roster
+  " 2>&1)" || rc=$?
+
+  chmod 0600 "$BRIDGE_ROSTER_LOCAL_FILE"
+
+  if [[ "$rc" -eq 0 ]]; then
+    smoke_fail "T4: expected non-zero rc from bridge_load_roster (fail-closed); got rc=0 (would silently continue with half-loaded roster)"
+  fi
+  smoke_assert_contains "$out" "cannot read protected roster" \
+    "T4: actionable error names the unreadable roster"
+  smoke_assert_contains "$out" "queue-safe verb" \
+    "T4: actionable error points at queue-safe verbs"
+  smoke_assert_contains "$out" "scoped agent env" \
+    "T4: actionable error points at scoped agent env recovery"
+}
+
+# ---------- T5: controller-side hard fail on unreadable roster --------------
+
+test_t5_controller_side_hard_fail() {
+  smoke_log "T5: controller-side caller + unreadable roster_local → still fail closed"
+
+  if [[ "$EUID" -eq 0 ]]; then
+    smoke_log "T5 skipped — smoke is running as root, gating on EUID != 0 cannot be exercised"
+    return 0
+  fi
+
+  chmod 000 "$BRIDGE_ROSTER_LOCAL_FILE"
+
+  local out rc=0
+  # Set BRIDGE_CONTROLLER_UID == EUID so the iso UID gate does NOT
+  # fire. The fail-closed branch should still trigger because the
+  # protected roster is unreadable and we cannot prove iso-UID-with-
+  # queue-safe-verb.
+  out="$("$SMOKE_BASH" -c "
+    set -uo pipefail
+    unset BRIDGE_AGENT_ENV_FILE BRIDGE_ROSTER_CACHE_LOADED BRIDGE_AGENT_ID BRIDGE_QUEUE_SAFE_CONTEXT BRIDGE_ROSTER_LOCAL_SKIP_WARNED
+    export BRIDGE_CONTROLLER_UID=\$EUID
+    # Even setting QUEUE_SAFE here should NOT mask filesystem damage on
+    # a controller-side caller — the EUID == BRIDGE_CONTROLLER_UID gate
+    # is what differentiates iso UID from controller; queue-safe alone
+    # is not sufficient.
+    export BRIDGE_QUEUE_SAFE_CONTEXT=1
+    source '$REPO_ROOT/bridge-lib.sh' >/dev/null 2>&1
+    bridge_load_roster
+  " 2>&1)" || rc=$?
+
+  chmod 0600 "$BRIDGE_ROSTER_LOCAL_FILE"
+
+  if [[ "$rc" -eq 0 ]]; then
+    smoke_fail "T5: controller-side caller silently survived an unreadable roster — iso-UID skip leaked beyond its gate"
+  fi
+  smoke_assert_contains "$out" "cannot read protected roster" \
+    "T5: actionable error fires for controller-side caller too"
+}
+
+# Locate a Bash 4+ binary for sub-shell tests (mirrors the re-exec
+# probe at the top of this file). On macOS hosts the smoke is already
+# re-exec'd into a Bash 4+ at the head, but sub-shell tests below need
+# the same binary explicitly for the `"$SMOKE_BASH" -c '...'` calls.
+SMOKE_BASH=""
+for _candidate in "$BASH" /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash" bash; do
+  if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+    SMOKE_BASH="$_candidate"
+    break
+  fi
+done
+[[ -n "$SMOKE_BASH" ]] || smoke_fail "no Bash 4+ binary found for sub-shell tests"
+
+test_t1_v2_scoped_env_discovered
+smoke_log "ok: T1 (v2 scoped env discovery)"
+
+test_t2_legacy_scoped_env_fallback
+smoke_log "ok: T2 (legacy scoped env fallback)"
+
+test_t3_queue_safe_skip
+smoke_log "ok: T3 (queue-safe iso UID skip)"
+
+test_t4_fail_closed_no_queue_context
+smoke_log "ok: T4 (fail-closed without queue-safe context)"
+
+test_t5_controller_side_hard_fail
+smoke_log "ok: T5 (controller-side hard fail)"
+
+smoke_log "passed"

--- a/scripts/smoke/phase2-install-tree-reconciler.sh
+++ b/scripts/smoke/phase2-install-tree-reconciler.sh
@@ -277,6 +277,39 @@ test_t1_matrix_rows() {
   " 2>/dev/null)"
   smoke_assert_contains "$rows_agent" "agent-state-leaf|" \
     "T1: agent-state-leaf must appear when --agent is given"
+  # L1-M (beta21, codex r1 spec): agent-state-leaf must align with the
+  # per-agent grant matrix SSOT (`state-agent-dir` row at
+  # lib/bridge-isolation-v2.sh:1596-1622). For a synthetic
+  # fake_agent_smoke that is not in the roster, `bridge_agent_isolation_mode`
+  # defaults to "shared" — so we assert the shared-mode contract:
+  # owner=controller, group=controller_group, mode=2770, required (not
+  # the pre-beta21 controller:ab-shared:0710 optional contract).
+  local _leaf_line
+  _leaf_line="$(printf '%s\n' "$rows_agent" | grep "^agent-state-leaf|" | head -n 1)"
+  if [[ -z "$_leaf_line" ]]; then
+    smoke_fail "T1: agent-state-leaf row not isolatable for assertion"
+  fi
+  # Columns: row_name|scope|path|kind|owner|group|dir_mode|file_mode|setgid|recursive|children_policy|mechanism|criticality|notes
+  # Use printf | cut to avoid `<<<` here-strings (footgun #11
+  # lint-heredoc-ban H3 — Bash 5.3.9 deadlocks on here-string into
+  # command substitution under set -e).
+  local _leaf_owner _leaf_group _leaf_mode _leaf_criticality
+  _leaf_owner="$(printf '%s' "$_leaf_line" | cut -d'|' -f5)"
+  _leaf_group="$(printf '%s' "$_leaf_line" | cut -d'|' -f6)"
+  _leaf_mode="$(printf '%s' "$_leaf_line" | cut -d'|' -f7)"
+  _leaf_criticality="$(printf '%s' "$_leaf_line" | cut -d'|' -f13)"
+  if [[ "$_leaf_owner" != "controller" ]]; then
+    smoke_fail "T1: agent-state-leaf owner must be 'controller' (got '$_leaf_owner')"
+  fi
+  if [[ "$_leaf_group" != "controller_group" && "$_leaf_group" != ab-agent-* ]]; then
+    smoke_fail "T1: agent-state-leaf group must be 'controller_group' (shared) or 'ab-agent-<X>' (linux-user) — got '$_leaf_group'"
+  fi
+  if [[ "$_leaf_mode" != "2770" ]]; then
+    smoke_fail "T1: agent-state-leaf mode must be 2770 per matrix SSOT (got '$_leaf_mode' — beta21 L1-M corrects the prior 0710)"
+  fi
+  if [[ "$_leaf_criticality" != "required" ]]; then
+    smoke_fail "T1: agent-state-leaf criticality must be 'required' (got '$_leaf_criticality' — beta21 L1-M flips from optional so reconcile --apply repairs the leaf)"
+  fi
   # Phase 3 Family 2 per-agent rows are gated on the agent being a real
   # isolated agent (the matrix probes the roster via
   # bridge_agent_linux_user_isolation_effective). On a synthetic


### PR DESCRIPTION
## Summary

P0 wave-1 hotfix bundle escalated by patch from beta20 verify. 3 deliverables + 1 tail fix surfaced during VM acceptance, all in one PR.

### Deliverables

- **L1-M — state/agents/<a>/ contract aligned with grant matrix SSOT** (`lib/bridge-isolation-v2-reconcile.sh`)
  - `agent-state-leaf` reconciler row was emitting `controller:ab-shared:0710 optional` while per-agent grant matrix already emits `controller:ab-agent-<X>:2770 required`. Aligned to matrix SSOT so `--reason agent-create` and standalone `isolation reconcile --apply --agent <X>` converge to the same final state.
  - Closes Claude `--resume <session_id>` failure on iso agent restart (bridge writes session-id/idle-since/compact-snapshot now succeed).

- **L1-N — scoped env v2-runtime-path discovery + queue-safe roster_local skip** (`lib/bridge-state.sh`, `bridge-task.sh`, `agent-bridge`)
  - `bridge_load_roster` extended to discover scoped env at `$BRIDGE_AGENT_ROOT_V2/<agent>/runtime/agent-env.sh` (v2 path) in addition to legacy `state/agents/<agent>/agent-env.sh`. Scoped env sets `BRIDGE_GATEWAY_PROXY=1` so queue commands route through gateway instead of touching SQLite directly.
  - Narrow `roster_local` skip ONLY for queue-safe verbs (`task create`/`done`/`claim`/`inbox`/`ack`) when scoped env absent + iso UID + unreadable roster_local. Non-queue commands fail-closed.
  - `BRIDGE_ROSTER_LOCAL_FILE` stays at 0600 (no chmod).

- **L1-D — canonical bridge_linux_share_plugin_catalog on start/restart path** (`bridge-start.sh`)
  - Added call after `bridge_write_linux_agent_env_file` (~bridge-start.sh:576-581) so every start/restart re-derives per-UID `known_marketplaces.json` + `installed_plugins.json` + marketplace symlinks from shared cache. Closes the "operator drifted existing iso agent → marketplace-mismatch" regression patch flagged on beta20.
  - `BRIDGE_AGENT_SUPPRESS_MISSING_CHANNELS=1` mode skips the share call.
  - Normal start with missing shared cache fails loud per existing UX.

- **L1-N tail fix — atomic_write_json chmod 0640** (`bridge-queue-gateway.py`)
  - Gateway response writes used default umask 077 → 0600 → iso UID PermissionError on response poll even after L1-N unblocked the request side. `os.chmod(tmp, 0o640)` after temp write + setgid parent dir gives BOTH controller and iso UID group read.

### Codex rounds

- M+N r1 (#6295): needs-more with corrections — 2770 NOT 3770 (matrix SSOT); scoped env discovery FIRST then queue-safe skip ONLY (not global). Corrections baked here, no re-round-trip.
- D r1 (#6299): implement-ok with constraint — use canonical `bridge_linux_share_plugin_catalog` on start path, NOT seed-only D2 merge helper.

### Test plan

- [x] `bash -n` + `shellcheck` clean on all touched files
- [x] `lint-heredoc-ban` baseline PASS
- [x] Extended `scripts/smoke/phase2-install-tree-reconciler.sh` for L1-M row contract
- [x] VM acceptance in-place upgrade beta20 → branch on `agb-clean-test` (8-step matrix)

### Stabilization mode

NO VERSION/CHANGELOG bump (orchestrator beta21-cuts after merge). NO codex review request on PR (r1 IS the spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)