### PR TITLE
beta25: read/probe-only allowlist fallback (#1207) + lock metadata normalize (#1208)

### DIFF
--- a/bridge-plugins.sh
+++ b/bridge-plugins.sh
@@ -725,8 +725,18 @@ bridge_plugins_seed_propagate_iso_known_marketplaces() {
     # never leave a half-merged file. We do the merge from the current
     # iso_known content (if any) → out path = iso_known. Run as root so
     # the file lands at the right owner; chown/chmod follow.
+    #
+    # Issue #1208: pass BRIDGE_PLUGIN_LOCK_GROUP=$agent_group so the
+    # helper's sidecar `known_marketplaces.json.lock` is created (or
+    # normalized) as `root:$agent_group 0660` — group-write so the iso
+    # UID's `bridge-dev-plugin-cache.py` writer can re-acquire the same
+    # flock during `agent start`. Without this, the lock lands as
+    # `root:root 0600` and iso UID's plugin cache write fails with
+    # EACCES, blocking `agent start` for any iso v2 agent with plugin
+    # channels.
     local rc=0
-    if ! bridge_linux_sudo_root python3 \
+    if ! bridge_linux_sudo_root \
+        env "BRIDGE_PLUGIN_LOCK_GROUP=${agent_group:-}" python3 \
         "$SCRIPT_DIR/lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py" \
         "$iso_known" "$iso_known" "$mkt_name" "$mkt_root" >/dev/null 2>&1; then
       rc=$?
@@ -745,6 +755,37 @@ bridge_plugins_seed_propagate_iso_known_marketplaces() {
     fi
     bridge_linux_sudo_root chmod 0640 "$iso_known" >/dev/null 2>&1 \
       || bridge_warn "[plugins seed] D2: chmod 0640 $iso_known failed (agent '$agent')"
+
+    # Issue #1208 self-heal: normalize any pre-existing lock files
+    # owned by `root:root 0600` (left behind by beta24 OOTB installs
+    # before this fix landed). The python helper above creates a fresh
+    # lock with the right metadata when the env var is set, but a
+    # cached lock from an earlier seed run that pre-dates this patch
+    # would still be `root:root 0600`. Also normalize
+    # `installed_plugins.json.lock` to match the parent contract at
+    # `lib/bridge-isolation-v2.sh:1734-1747` (plugin manifest flocks
+    # are group-writable).
+    if [[ -n "$agent_group" ]]; then
+      local iso_known_lock="$iso_plugins_dir/known_marketplaces.json.lock" # noqa: iso-helper-boundary
+      local iso_installed_lock="$iso_plugins_dir/installed_plugins.json.lock" # noqa: iso-helper-boundary
+      if bridge_linux_sudo_root test -e "$iso_known_lock" 2>/dev/null; then
+        bridge_linux_sudo_root chown "root:$agent_group" "$iso_known_lock" \
+          >/dev/null 2>&1 \
+          || bridge_warn "[plugins seed] D2: chown lock root:$agent_group $iso_known_lock failed (agent '$agent')"
+        bridge_linux_sudo_root chmod 0660 "$iso_known_lock" \
+          >/dev/null 2>&1 \
+          || bridge_warn "[plugins seed] D2: chmod 0660 $iso_known_lock failed (agent '$agent')"
+      fi
+      if bridge_linux_sudo_root test -e "$iso_installed_lock" 2>/dev/null; then
+        bridge_linux_sudo_root chown "root:$agent_group" "$iso_installed_lock" \
+          >/dev/null 2>&1 \
+          || bridge_warn "[plugins seed] D2: chown lock root:$agent_group $iso_installed_lock failed (agent '$agent')"
+        bridge_linux_sudo_root chmod 0660 "$iso_installed_lock" \
+          >/dev/null 2>&1 \
+          || bridge_warn "[plugins seed] D2: chmod 0660 $iso_installed_lock failed (agent '$agent')"
+      fi
+    fi
+
     ((propagated++)) || true
   done < "$_eligible_stream_tmp"
   rm -f "$_eligible_stream_tmp" 2>/dev/null || true

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4061,6 +4061,29 @@ bridge_linux_prepare_agent_isolation() {
   bridge_isolation_v2_ensure_user_in_group "$controller_user" "$_v2_agent_group" \
     || bridge_die "isolation v2: cannot add controller '$controller_user' to '$_v2_agent_group'"
 
+  # Diagnostic warning for KNOWN_ISSUES §28 / #1207: a long-running shell
+  # or daemon does NOT pick up new supplementary groups until it restarts.
+  # The controller's `id -G` reflects login-time membership; an `agent create`
+  # that adds the controller to a fresh `ab-agent-<X>` group leaves any
+  # already-running process unable to traverse `data/agents/<X>/` until
+  # restart. Read/probe ops are protected by the #1207 literal-fallback in
+  # `bridge_iso_run_path_under_allowlist`, but write/publish ops still
+  # rely on canonicalization and benefit from the operator refreshing
+  # their shell. This is hint-only; first-touch correctness does NOT
+  # depend on the operator following the hint.
+  if [[ "$(uname -s 2>/dev/null)" == "Linux" ]]; then
+    local _current_supp_groups=""
+    _current_supp_groups="$(id -nG 2>/dev/null | tr ' ' '\n' || true)"
+    if ! printf '%s\n' "$_current_supp_groups" | grep -Fxq -- "$_v2_agent_group"; then
+      bridge_warn "isolation v2: this shell's supplementary group cache does not include the freshly created '$_v2_agent_group' (KNOWN_ISSUES §28)."
+      bridge_warn "             Read/probe paths (channel-required validator, .teams/.env, etc.) recover automatically via the iso-side fallback," # noqa: iso-helper-boundary
+      bridge_warn "             but controller-side writes under data/agents/$agent/ may need a refreshed shell. To refresh now, run:"
+      bridge_warn "               exec sg $_v2_agent_group -- \$SHELL"
+      bridge_warn "             OR wrap subsequent commands as: sg $_v2_agent_group -c \"...\"."
+      bridge_warn "             OR open a new terminal — supplementary groups refresh at login."
+    fi
+  fi
+
   # Shared-group membership. PR-C migration adds existing agents to
   # ab-shared, but a new/reapplied agent through prepare must also join so
   # bridge_linux_share_plugin_catalog can read the shared plugin cache.

--- a/lib/bridge-isolation-helpers.sh
+++ b/lib/bridge-isolation-helpers.sh
@@ -502,7 +502,136 @@ _bridge_iso_run_collect_canonical_roots() {
   unset -f _print_if_resolves 2>/dev/null || true
 }
 
-# bridge_iso_run_path_under_allowlist <agent> <path>
+# _bridge_iso_run_collect_raw_roster_roots <agent>
+# Print one RAW (unresolved) bridge-owned roster root per line to stdout.
+#
+# This is the fallback companion to _bridge_iso_run_collect_canonical_roots
+# for the #1207 stale-supp-groups case: when the controller's process can't
+# `readlink -f` an iso-owned root (because the supplementary group cache
+# is stale for a long-running shell/daemon), canonicalization returns
+# empty and the canonical compare fails. The literal-prefix fallback uses
+# THESE roots — but ONLY when accompanied by an isolated-UID probe that
+# proves the root actually exists on disk (see fallback predicate in
+# bridge_iso_run_path_under_allowlist).
+#
+# Differences from `_bridge_iso_run_collect_canonical_roots`:
+#   - Roots are emitted UNCANONICALIZED (literal roster values).
+#   - `BRIDGE_ISO_RUN_ALLOWLIST_EXTRA` is INTENTIONALLY EXCLUDED. The
+#     extra env is a smoke-only / operator-debug override and must NOT
+#     receive the stale-supp-groups fallback — otherwise the smoke
+#     sandbox could be widened by accident.
+#   - Roots are emitted only when they look like absolute paths and
+#     have no literal `..` segment. The fallback path consumer also
+#     re-checks both invariants on the requested path.
+_bridge_iso_run_collect_raw_roster_roots() {
+  local agent="$1"
+  local raw_root=""
+  local os_user=""
+
+  _print_if_safe_raw() {
+    local r="$1"
+    [[ -n "$r" ]] || return 0
+    # Must be absolute.
+    [[ "${r:0:1}" == "/" ]] || return 0
+    # Must have no literal `..` segment.
+    if _bridge_iso_run_has_dotdot_segment "$r"; then
+      return 0
+    fi
+    r="${r%/}"
+    printf '%s\n' "$r"
+  }
+
+  if declare -F bridge_agent_workdir >/dev/null 2>&1; then
+    raw_root="$(bridge_agent_workdir "$agent" 2>/dev/null || printf '')"
+    _print_if_safe_raw "$raw_root"
+  fi
+
+  if declare -F bridge_agent_default_home >/dev/null 2>&1; then
+    raw_root="$(bridge_agent_default_home "$agent" 2>/dev/null || printf '')"
+    _print_if_safe_raw "$raw_root"
+  fi
+
+  if declare -F bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+      && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    if declare -F bridge_agent_os_user >/dev/null 2>&1 \
+        && declare -F bridge_agent_linux_user_home >/dev/null 2>&1; then
+      os_user="$(bridge_agent_os_user "$agent" 2>/dev/null || printf '')"
+      if [[ -n "$os_user" ]]; then
+        raw_root="$(bridge_agent_linux_user_home "$os_user" 2>/dev/null || printf '')"
+        _print_if_safe_raw "$raw_root"
+      fi
+    fi
+  fi
+
+  if declare -F bridge_agent_idle_marker_dir >/dev/null 2>&1; then
+    raw_root="$(bridge_agent_idle_marker_dir "$agent" 2>/dev/null || printf '')"
+    _print_if_safe_raw "$raw_root"
+  fi
+
+  unset -f _print_if_safe_raw 2>/dev/null || true
+}
+
+# _bridge_iso_run_op_allows_literal_fallback <op>
+# Return 0 iff <op> is a read/probe op for which the literal-prefix
+# fallback is safe to enable when canonicalization fails (#1207).
+#
+# Read/probe ops only inspect file content/metadata — they CANNOT escape
+# the iso-owned subtree via a symlink ancestor any more than the iso UID
+# itself could (the op script still runs as the iso UID, which is also
+# subject to its own FS permissions).
+#
+# Write/publish ops are NOT eligible: mkdir-p / atomic-write / rename /
+# state-marker-write / publish-root-file / publish-root-symlink must
+# fail-closed under the canonical compare so the symlink-ancestor
+# write-side protection (codex r2 on beta23) stays intact.
+_bridge_iso_run_op_allows_literal_fallback() {
+  local op="$1"
+  case "$op" in
+    stat|read-file|read-json|env-has-any-key|read-env-key|scan-profile)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# _bridge_iso_run_iso_side_root_exists <agent> <raw_root>
+# Probe whether <raw_root> exists from the isolated UID's vantage point.
+# Used to distinguish "controller can't traverse because its supp-groups
+# cache is stale" from "root genuinely absent" in the literal-prefix
+# fallback (#1207).
+#
+# Returns:
+#   0 — iso UID confirms <raw_root> exists as a directory
+#   1 — iso UID confirms <raw_root> does not exist
+#   2 — could not probe (sudo unavailable, agent not isolated, etc.) —
+#       caller MUST fail closed since we cannot prove existence.
+_bridge_iso_run_iso_side_root_exists() {
+  local agent="$1"
+  local raw_root="$2"
+  [[ -n "$agent" && -n "$raw_root" ]] || return 2
+
+  if ! declare -F bridge_isolation_run_as_agent_user_via_bash >/dev/null 2>&1; then
+    return 2
+  fi
+
+  # Self-contained probe: stdin/argv-only, no heredoc, no here-string.
+  # Footgun #11 invariant.
+  local probe_script='[[ -d "$1" ]]'
+  local rc=0
+  bridge_isolation_run_as_agent_user_via_bash "$agent" "$probe_script" "$raw_root" \
+    >/dev/null 2>&1 || rc=$?
+  case "$rc" in
+    0) return 0 ;;
+    1) return 2 ;;  # agent NOT isolated — caller's controller-direct
+                    # path applies; we can't speak to iso-side existence.
+    2) return 2 ;;  # passwordless sudo unavailable — can't probe.
+    *) return 1 ;;  # script returned non-zero (path not -d) under iso UID.
+  esac
+}
+
+# bridge_iso_run_path_under_allowlist <agent> <path> [<op>]
 #
 # Returns 0 if <path> is under any allowlisted per-agent root, 1
 # otherwise.
@@ -528,14 +657,40 @@ _bridge_iso_run_collect_canonical_roots() {
 #      lexical-prefix on already-canonicalized strings. A symlink
 #      ancestor (e.g. `<allowed-root>/link -> /etc`) shows up as a
 #      canonical mismatch and is rejected.
+#   5. (#1207) If the canonical compare fails AND <op> is a read/probe
+#      op (stat / read-file / env-has-any-key / read-env-key /
+#      scan-profile), retry against the RAW roster roots and accept
+#      ONLY when ALL of:
+#        - request path is lexically under a raw roster root;
+#        - request path and root each have no `..` segment and are
+#          absolute;
+#        - controller canonicalize returned empty for the root
+#          (i.e. the canonical compare failed BECAUSE the controller
+#          couldn't traverse, not because the request was outside);
+#        - the iso UID (probed via bridge_isolation_run_as_agent_user_via_bash)
+#          confirms the root exists on disk.
+#      This recovers from KNOWN_ISSUES §28 (controller supp-groups go
+#      stale) for read/probe paths only — write/publish ops keep their
+#      canonical fail-closed behavior so the symlink-ancestor write-side
+#      protection is preserved.
+#
+# Args:
+#   $1 — agent name
+#   $2 — path to validate
+#   $3 — op (optional). When the canonical compare fails, the literal-
+#        path fallback is only attempted if <op> is a known read/probe
+#        op (see _bridge_iso_run_op_allows_literal_fallback).
 #
 # Return:
 #   0 — path canonicalizes under one of the canonical allowlist roots
-#   1 — escape detected (`..` segment, symlink ancestor, no canonical
-#       root match, canonicalization failure)
+#       (or, for read/probe ops, lexically under a raw root with
+#       iso-side existence proof)
+#   1 — escape detected (`..` segment, symlink ancestor, no root match,
+#       canonicalization failure, or fallback predicate not met)
 bridge_iso_run_path_under_allowlist() {
   local agent="$1"
   local path="$2"
+  local op="${3:-}"
   [[ -n "$agent" && -n "$path" ]] || return 1
 
   # Reject literal `..` segments BEFORE canonicalization. `..` would
@@ -553,13 +708,12 @@ bridge_iso_run_path_under_allowlist() {
   # walking up to the deepest existing ancestor).
   local canon_path=""
   canon_path="$(_bridge_iso_run_canonicalize_destination "$path" 2>/dev/null || true)"
+  local canon_path_ok=1
   if [[ -z "$canon_path" ]]; then
-    # Could not canonicalize — refuse rather than fall through. This
-    # is the fail-closed branch for paths whose entire ancestor chain
-    # is missing (rare but possible during agent bootstrap).
-    return 1
+    canon_path_ok=0
+  else
+    canon_path="${canon_path%/}"
   fi
-  canon_path="${canon_path%/}"
 
   # Collect canonical allowlist roots and prefix-match against them.
   local canon_roots_tmp
@@ -567,21 +721,89 @@ bridge_iso_run_path_under_allowlist() {
   # shellcheck disable=SC2064
   trap "rm -f '$canon_roots_tmp' 2>/dev/null" RETURN
 
-  _bridge_iso_run_collect_canonical_roots "$agent" >"$canon_roots_tmp" 2>/dev/null || true
+  if [[ "$canon_path_ok" -eq 1 ]]; then
+    _bridge_iso_run_collect_canonical_roots "$agent" >"$canon_roots_tmp" 2>/dev/null || true
 
-  local canon_root=""
-  local matched=0
-  while IFS= read -r canon_root; do
-    [[ -n "$canon_root" ]] || continue
-    if [[ "$canon_path" == "$canon_root" || "$canon_path" == "$canon_root"/* ]]; then
-      matched=1
-      break
+    local canon_root=""
+    local matched=0
+    while IFS= read -r canon_root; do
+      [[ -n "$canon_root" ]] || continue
+      if [[ "$canon_path" == "$canon_root" || "$canon_path" == "$canon_root"/* ]]; then
+        matched=1
+        break
+      fi
+    done <"$canon_roots_tmp"
+
+    if [[ "$matched" -eq 1 ]]; then
+      rm -f "$canon_roots_tmp" 2>/dev/null
+      trap - RETURN
+      return 0
     fi
-  done <"$canon_roots_tmp"
+  fi
+
+  # ---- read/probe-only literal-prefix fallback (#1207) ---------------------
+  #
+  # The canonical compare failed (or canonicalization of the request
+  # itself failed). For read/probe ops, attempt the literal-prefix
+  # fallback to recover from controller stale supp-groups. Write/publish
+  # ops keep the canonical fail-closed behavior — they must not slip
+  # past the symlink-ancestor protection.
+  if _bridge_iso_run_op_allows_literal_fallback "$op"; then
+    local raw_roots_tmp
+    raw_roots_tmp="$(mktemp "${TMPDIR:-/tmp}/agb-iso-run-raw-roots.XXXXXX")" || {
+      rm -f "$canon_roots_tmp" 2>/dev/null
+      trap - RETURN
+      return 1
+    }
+
+    _bridge_iso_run_collect_raw_roster_roots "$agent" >"$raw_roots_tmp" 2>/dev/null || true
+
+    local raw_root=""
+    local raw_canon=""
+    local fallback_matched=0
+    while IFS= read -r raw_root; do
+      [[ -n "$raw_root" ]] || continue
+      # Predicate (a): lexically-under match. Raw root already had `..`
+      # rejected and absolute prefix verified by the collector.
+      if [[ "$path" != "$raw_root" && "$path" != "$raw_root"/* ]]; then
+        continue
+      fi
+      # Predicate (b): request path absolute (raw root collector
+      # guarantees `..`-free + absolute on its side; the request is
+      # `..`-free by the early reject at the top of this function).
+      [[ "${path:0:1}" == "/" ]] || continue
+      # Predicate (c): controller canonicalize returned empty FOR THE
+      # ROOT. If readlink -f works for the root from the controller's
+      # vantage, the canonical compare above would have matched (or
+      # legitimately rejected an outside path); falling here without a
+      # canonicalize failure means the request really is outside.
+      raw_canon="$(_bridge_iso_run_canonicalize "$raw_root" 2>/dev/null || true)"
+      if [[ -n "$raw_canon" ]]; then
+        continue
+      fi
+      # Predicate (d): iso UID confirms the root exists on disk. This
+      # is what distinguishes "stale supp-groups blinding controller"
+      # from "root genuinely absent". `rc=0` means iso UID sees the
+      # root as a directory; any other rc (1 = not -d under iso UID,
+      # 2 = could not probe / not isolated / no sudo) fails closed.
+      _bridge_iso_run_iso_side_root_exists "$agent" "$raw_root"
+      local probe_rc=$?
+      if [[ "$probe_rc" -ne 0 ]]; then
+        continue
+      fi
+      fallback_matched=1
+      break
+    done <"$raw_roots_tmp"
+
+    rm -f "$raw_roots_tmp" 2>/dev/null
+    rm -f "$canon_roots_tmp" 2>/dev/null
+    trap - RETURN
+    [[ "$fallback_matched" -eq 1 ]] && return 0
+    return 1
+  fi
 
   rm -f "$canon_roots_tmp" 2>/dev/null
   trap - RETURN
-  [[ "$matched" -eq 1 ]] && return 0
   return 1
 }
 
@@ -790,13 +1012,18 @@ bridge_iso_run() {
   [[ -n "$op" ]] || { printf 'bridge_iso_run: --op required\n' >&2; return 2; }
 
   # ---- path allowlist gate ----
+  #
+  # Pass <op> to bridge_iso_run_path_under_allowlist so it can enable
+  # the read/probe-only literal-prefix fallback for #1207. Write/publish
+  # ops (mkdir-p / atomic-write / rename / state-marker-write /
+  # publish-root-file / publish-root-symlink) keep canonical fail-closed.
   local primary_path=""
   case "$op" in
     publish-root-symlink) primary_path="$link_path" ;;
     rename)
       primary_path="$to_path"
       if [[ -n "$from_path" ]]; then
-        bridge_iso_run_path_under_allowlist "$agent" "$from_path" || return 40
+        bridge_iso_run_path_under_allowlist "$agent" "$from_path" "$op" || return 40
       fi
       ;;
     scan-profile)        primary_path="$workdir_path" ;;
@@ -809,7 +1036,7 @@ bridge_iso_run() {
     *)                   primary_path="$path" ;;
   esac
   if [[ -n "$primary_path" ]]; then
-    bridge_iso_run_path_under_allowlist "$agent" "$primary_path" || return 40
+    bridge_iso_run_path_under_allowlist "$agent" "$primary_path" "$op" || return 40
   fi
 
   # ---- isolation gate ----
@@ -1124,8 +1351,10 @@ _bridge_iso_run_state_marker_write() {
   [[ -n "$dir" ]] || return 5
   # Validate the resolved marker path is under the allowlist (defense in
   # depth; the dispatcher gate already passes since the marker dir IS
-  # one of the allowlisted roots).
-  bridge_iso_run_path_under_allowlist "$agent" "$dir/$marker" || return 40
+  # one of the allowlisted roots). Pass op="state-marker-write" so the
+  # gate keeps canonical fail-closed behavior (no #1207 literal fallback
+  # for writes).
+  bridge_iso_run_path_under_allowlist "$agent" "$dir/$marker" "state-marker-write" || return 40
 
   # mkdir-p the dir as the iso UID first (idempotent).
   _bridge_iso_run_agent_script "$agent" "$_BRIDGE_ISO_RUN_OP_MKDIR_P" "$dir" "0750"

--- a/lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py
+++ b/lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import datetime
 import fcntl
+import grp
 import json
 import os
 import sys
@@ -88,6 +89,48 @@ def main(argv: list[str]) -> int:
         sys.stderr.write(f"lock-open-failed: {exc}\n")
         return 1
     try:
+        # Issue #1208: when called from `bridge_plugins_seed_propagate_iso_known_marketplaces`
+        # (D2 per-UID propagation), the lock file is created as root:600 by
+        # default — the iso UID has no group write access and cannot acquire
+        # `fcntl.flock` later when `bridge-dev-plugin-cache.py` runs. Fix:
+        # normalize the lock file to `root:$BRIDGE_PLUGIN_LOCK_GROUP 0660`
+        # so the iso UID (which is a member of the agent group via
+        # supplementary membership) can re-acquire the same flock.
+        #
+        # `BRIDGE_PLUGIN_LOCK_GROUP` is set by D2 to the agent group name
+        # (`ab-agent-<X>`). When absent (e.g. running on the controller's
+        # own `~/.claude/plugins/`), we leave the default `root:0600` in
+        # place — the controller is also the writer there and group
+        # widening is unnecessary.
+        #
+        # Mode is `0660` (group write only), NOT `0664` — world-rw access
+        # would expose the coordination lock to any UID on the host. Data
+        # manifests (installed_plugins.json, known_marketplaces.json) stay
+        # `root:ab-agent-<X> 0640`; the lock is coordination state only.
+        lock_group = os.environ.get("BRIDGE_PLUGIN_LOCK_GROUP") or ""  # noqa: iso-helper-boundary
+        lock_group = lock_group.strip()
+        if lock_group:
+            try:
+                gid = grp.getgrnam(lock_group).gr_gid
+            except KeyError:
+                sys.stderr.write(
+                    f"warning: BRIDGE_PLUGIN_LOCK_GROUP='{lock_group}' "
+                    "does not exist on this host; leaving lock at default ownership\n"
+                )
+            else:
+                try:
+                    os.fchown(lock_fd, -1, gid)
+                except OSError as exc:
+                    sys.stderr.write(
+                        f"warning: fchown lock to gid={gid} failed: {exc}\n"
+                    )
+                try:
+                    os.fchmod(lock_fd, 0o660)
+                except OSError as exc:
+                    sys.stderr.write(
+                        f"warning: fchmod lock to 0660 failed: {exc}\n"
+                    )
+
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
         except OSError as exc:

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize
 
 
 }
@@ -624,7 +624,14 @@ select_for_path() {
       # regression at any layer (matrix row drift, dispatcher bug,
       # protected-path guard removal, marker-write guard removal) is
       # caught at PR time.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1077-migrate-iso-v2-data-dir 1113-watchdog-legacy-backfill 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-b-sudo-escalate-and-state launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup phase2-install-tree-reconciler phase3-agent-home-contract
+      # Issue #1207: lib/bridge-isolation-helpers.sh's
+      # `bridge_iso_run_path_under_allowlist` gained a read/probe-only
+      # literal-prefix fallback for the stale-supp-groups class. Pull
+      # 1207-stale-supp-groups-allowlist on every isolation-helpers move
+      # so a future PR cannot regress (a) into letting write/publish
+      # ops accept the fallback, (b) drop the iso-side existence probe,
+      # or (c) drop the `..` reject ahead of the fallback.
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1077-migrate-iso-v2-data-dir 1113-watchdog-legacy-backfill 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-b-sudo-escalate-and-state launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup phase2-install-tree-reconciler phase3-agent-home-contract 1207-stale-supp-groups-allowlist
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -984,7 +991,7 @@ select_for_path() {
       add_integration integration-minimal
       ;;
 
-    bridge-plugins.sh|bridge-dev-plugin-cache.py)
+    bridge-plugins.sh|bridge-dev-plugin-cache.py|lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py)
       # Issues #1201/#1202 (v0.14.5-beta24): bridge-plugins.sh grew
       # `bridge_plugins_seed_mirror_marketplace_root` so `agb plugins seed
       # --marketplace-root <path>` creates the controller-side mirror at
@@ -995,7 +1002,18 @@ select_for_path() {
       # `bridge_plugins_cmd_seed` invokes — its output shape feeds the
       # mirror's downstream catalog manifests, so any move to either
       # callsite must re-run the regression smoke.
-      add_required 1201-1202-directory-marketplace-seed channel-plugins
+      #
+      # Issue #1208 (v0.14.5-beta25): the D2 iso UID propagation in
+      # bridge-plugins.sh now passes `BRIDGE_PLUGIN_LOCK_GROUP=$agent_group`
+      # to `lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py`
+      # so the sidecar `known_marketplaces.json.lock` is created (or
+      # normalized) as `root:$agent_group 0660` instead of `root:root
+      # 0600`. The shell-side post-normalizer also self-heals
+      # pre-existing beta24 bad locks. Pull
+      # 1208-lock-metadata-normalize on every bridge-plugins.sh,
+      # bridge-dev-plugin-cache.py, or helper move so the lock contract
+      # cannot regress.
+      add_required 1201-1202-directory-marketplace-seed channel-plugins 1208-lock-metadata-normalize
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1207-stale-supp-groups-allowlist.sh
+++ b/scripts/smoke/1207-stale-supp-groups-allowlist.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# scripts/smoke/1207-stale-supp-groups-allowlist.sh — unit smoke for the
+# #1207 read/probe-only literal-prefix allowlist fallback.
+#
+# Reproduces the KNOWN_ISSUES §28 / #1207 surface in CI without real
+# supp-groups drift: stubs the roster + the iso-side existence probe
+# helper so we can control:
+#   - whether the controller can canonicalize the roster root
+#     (simulated by making the root non-traversable to readlink -f)
+#   - whether the iso UID claims to "see" the root (controlled mock)
+#
+# Asserts:
+#   (A) positive  — read/probe op (stat, env-has-any-key) under a raw
+#                   roster root passes when controller canonicalize
+#                   fails AND iso-side probe reports the root present.
+#   (B) negative  — a `..` segment in the request is rejected even when
+#                   the fallback is otherwise eligible (rc=40).
+#   (C) negative  — fallback when iso-side probe reports the root absent
+#                   → rc=40.
+#   (D) negative  — write/publish op (atomic-write, publish-root-file)
+#                   under the same simulated controller-blind root MUST
+#                   still rc=40. This is the key guard against weakening
+#                   the symlink-ancestor write-side protection.
+#   (E) regression — when controller CAN canonicalize, behavior is
+#                    unchanged (canonical compare passes).
+#
+# Footgun #11: pipe/argv stdin only, no heredoc-stdin, no here-string.
+#
+# Exits 0 on full pass, non-zero on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+FAILS=0
+TOTAL=0
+_pass() { TOTAL=$((TOTAL + 1)); printf '[ok] %s\n' "$1"; }
+_fail() { TOTAL=$((TOTAL + 1)); FAILS=$((FAILS + 1)); printf '[FAIL] %s: %s\n' "$1" "$2" >&2; }
+
+TMPDIR_BASE="${TMPDIR:-/tmp}"
+SMOKE_DIR="$(mktemp -d "$TMPDIR_BASE/agb-1207-smoke.XXXXXX")"
+trap 'rm -rf "$SMOKE_DIR" 2>/dev/null' EXIT INT TERM
+
+export BRIDGE_HOME="$SMOKE_DIR/.agent-bridge"
+mkdir -p "$BRIDGE_HOME"
+
+# Use a synthetic agent name; stubs below intercept the roster lookups
+# so we never need a real provisioned agent.
+AGENT="agent_iso_1207"
+
+# Source bridge-lib so bridge_iso_run + bridge_iso_run_path_under_allowlist
+# are available.
+# shellcheck source=/dev/null
+source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1 || {
+  printf '[FAIL] source bridge-lib.sh failed\n' >&2
+  exit 1
+}
+
+if ! declare -F bridge_iso_run_path_under_allowlist >/dev/null 2>&1; then
+  printf '[FAIL] bridge_iso_run_path_under_allowlist not loaded\n' >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+#
+# The smoke's strategy is to override the roster helpers + the iso-side
+# existence probe helper so we can control what the allowlist gate sees.
+#
+# WORKDIR is the simulated agent workdir. We populate it with files so
+# the request paths under WORKDIR are real and readable, but we toggle
+# CANONICALIZE_BLIND on/off to simulate the controller's
+# `_bridge_iso_run_canonicalize` returning empty (the stale-supp-groups
+# surface). The iso-side probe is also a mock that obeys
+# ISO_SIDE_ROOT_PRESENT.
+
+# Real on-disk dir we use as the simulated agent workdir.
+WORKDIR="$SMOKE_DIR/agent-workdir"
+mkdir -p "$WORKDIR/.teams"
+printf 'TEAMS_APP_ID=fake-app-id\n' >"$WORKDIR/.teams/.env"
+
+# Stub roster helpers — bridge-agents.sh defines these, but our smoke
+# overrides them so the allowlist gate uses our synthetic workdir
+# regardless of any real roster. Invoked indirectly via `declare -F` +
+# function name from `_bridge_iso_run_collect_canonical_roots` and
+# `_bridge_iso_run_collect_raw_roster_roots`.
+# shellcheck disable=SC2329
+bridge_agent_workdir() { printf '%s' "$WORKDIR"; }
+# shellcheck disable=SC2329
+bridge_agent_default_home() { printf '%s' "$WORKDIR/home"; }
+# shellcheck disable=SC2329
+bridge_agent_idle_marker_dir() { printf '%s' "$WORKDIR/idle-markers"; }
+
+# Force isolation_effective true so the iso-side probe code branch
+# becomes reachable (and so that the agent-bridge `iso-run` CLI path
+# also flips to iso-mode if anyone uses it). The dispatcher already
+# falls through to the direct path when not isolated; for #1207 we
+# need to exercise the fallback predicate, which is gate-only and
+# doesn't actually require a real iso UID — only the existence probe
+# response.
+# shellcheck disable=SC2329
+bridge_agent_linux_user_isolation_effective() { return 0; }
+# shellcheck disable=SC2329
+bridge_agent_os_user() { printf 'agent-bridge-%s' "$1"; }
+# shellcheck disable=SC2329
+bridge_agent_linux_user_home() { printf '%s' "$WORKDIR/home"; }
+
+# Stub _bridge_iso_run_canonicalize. Toggle on CANONICALIZE_BLIND=1 to
+# simulate the controller stale-supp-groups condition (readlink -f
+# returns empty for the WORKDIR root and any descendant).
+CANONICALIZE_BLIND=0
+# shellcheck disable=SC2329
+_bridge_iso_run_canonicalize() {
+  local p="$1"
+  if [[ "$CANONICALIZE_BLIND" -eq 1 ]]; then
+    # Mimic controller's stale-supp-groups: the WORKDIR tree is opaque
+    # to readlink -f and Python realpath. Any other path resolves
+    # normally (so /etc still canonicalizes, etc.).
+    if [[ "$p" == "$WORKDIR" || "$p" == "$WORKDIR"/* ]]; then
+      return 1
+    fi
+  fi
+  # Default behavior: real-canonicalize.
+  local out=""
+  if out="$(readlink -f -- "$p" 2>/dev/null)" && [[ -n "$out" ]]; then
+    printf '%s' "$out"
+    return 0
+  fi
+  return 1
+}
+
+# Stub _bridge_iso_run_canonicalize_destination. When blind, return
+# empty for any path under WORKDIR (no "deepest ancestor" can be
+# canonicalized either). Otherwise fall back to the real behavior.
+# shellcheck disable=SC2329
+_bridge_iso_run_canonicalize_destination() {
+  local p="$1"
+  if [[ "$CANONICALIZE_BLIND" -eq 1 ]]; then
+    if [[ "$p" == "$WORKDIR" || "$p" == "$WORKDIR"/* ]]; then
+      return 1
+    fi
+  fi
+  # Default: identity for existing paths, parent-walk for non-existent.
+  if [[ -e "$p" ]]; then
+    _bridge_iso_run_canonicalize "$p"
+    return $?
+  fi
+  local d b
+  d="$(dirname -- "$p")"
+  b="$(basename -- "$p")"
+  if [[ -e "$d" ]]; then
+    local canon=""
+    canon="$(_bridge_iso_run_canonicalize "$d")" || return 1
+    printf '%s/%s' "${canon%/}" "$b"
+    return 0
+  fi
+  return 1
+}
+
+# Stub bridge_isolation_run_as_agent_user_via_bash so the iso-side
+# probe of `_bridge_iso_run_iso_side_root_exists` is controllable.
+# ISO_SIDE_ROOT_PRESENT=1 → root visible from iso UID (rc=0 → predicate d
+# satisfied). ISO_SIDE_ROOT_PRESENT=0 → root not visible (rc=3+ band →
+# the helper's "iso UID confirms absent" branch fires).
+ISO_SIDE_ROOT_PRESENT=1
+# shellcheck disable=SC2329
+bridge_isolation_run_as_agent_user_via_bash() {
+  local agent="$1"
+  local script="$2"
+  shift 2
+  # We don't actually execute as a different UID — we just simulate
+  # the rc the iso side would have returned. The helper's probe
+  # script is `[[ -d "$1" ]]`, so we return 0 when present, 3 when
+  # absent (which after the +2 unshift band would be the iso UID's
+  # rc=1, i.e. test failure).
+  : "$agent" "$script" "$@"
+  if [[ "$ISO_SIDE_ROOT_PRESENT" -eq 1 ]]; then
+    return 0
+  fi
+  # rc=3 lands in the helper's "+2 band" — caller's
+  # _bridge_iso_run_iso_side_root_exists converts to its "1" return
+  # (iso confirms not -d), and the allowlist treats that as fail closed.
+  return 3
+}
+
+# ---------------------------------------------------------------------------
+# Test A — positive: read/probe op under raw root, controller blind, iso
+# UID confirms root present → fallback admits the path.
+# ---------------------------------------------------------------------------
+CANONICALIZE_BLIND=1
+ISO_SIDE_ROOT_PRESENT=1
+
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "stat" \
+  || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  _pass "A: stat under raw workdir admitted via fallback (controller-blind, iso sees root)"
+else
+  _fail "A: stat under raw workdir admitted via fallback" "got rc=$rc"
+fi
+
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "env-has-any-key" \
+  || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  _pass "A: env-has-any-key under raw workdir admitted via fallback"
+else
+  _fail "A: env-has-any-key under raw workdir admitted via fallback" "got rc=$rc"
+fi
+
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "read-env-key" \
+  || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  _pass "A: read-env-key under raw workdir admitted via fallback"
+else
+  _fail "A: read-env-key under raw workdir admitted via fallback" "got rc=$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# Test B — negative: `..` segment in request rejected even if fallback
+# would otherwise apply.
+# ---------------------------------------------------------------------------
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/../etc/passwd" "stat" \
+  || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  _pass "B: request with .. segment rejected even under fallback-eligible op"
+else
+  _fail "B: request with .. segment rejected under fallback" "got rc=$rc (expected non-zero)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test C — negative: iso-side probe says root absent → fallback fails closed.
+# ---------------------------------------------------------------------------
+ISO_SIDE_ROOT_PRESENT=0
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "stat" \
+  || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  _pass "C: read-probe fallback rejected when iso UID does NOT see root"
+else
+  _fail "C: read-probe fallback rejected when iso UID does NOT see root" \
+    "got rc=$rc (expected non-zero)"
+fi
+
+# ---------------------------------------------------------------------------
+# Test D — KEY GUARD: write/publish ops MUST stay canonical fail-closed
+# even when the controller-blind + iso-side-present preconditions are
+# satisfied. This is the symlink-ancestor write protection preserved.
+# ---------------------------------------------------------------------------
+ISO_SIDE_ROOT_PRESENT=1
+
+for op in atomic-write mkdir-p rename publish-root-file publish-root-symlink \
+          state-marker-write; do
+  rc=0
+  bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "$op" \
+    || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    _pass "D: write/publish op '$op' under blind workdir rejected (canonical fail-closed)"
+  else
+    _fail "D: write/publish op '$op' under blind workdir rejected" \
+      "got rc=$rc (expected non-zero — fallback must NOT apply to writes)"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Test E — regression: when controller CAN canonicalize, behavior is
+# unchanged (canonical compare admits path).
+# ---------------------------------------------------------------------------
+CANONICALIZE_BLIND=0
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "stat" \
+  || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  _pass "E: regression — canonical compare admits path when canonicalize works"
+else
+  _fail "E: regression — canonical compare admits path when canonicalize works" \
+    "got rc=$rc"
+fi
+
+# Also: when canonicalize works, write ops still pass under the legitimate
+# root (no behavior regression).
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/new-file.txt" "atomic-write" \
+  || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+  _pass "E: regression — atomic-write under legitimate root admitted (canonical compare)"
+else
+  _fail "E: regression — atomic-write under legitimate root admitted" "got rc=$rc"
+fi
+
+# ---------------------------------------------------------------------------
+# Test F — request path is OUTSIDE the raw root + canonicalize blind →
+# fallback must NOT admit (predicate (a) lexical-prefix fails).
+# ---------------------------------------------------------------------------
+CANONICALIZE_BLIND=1
+ISO_SIDE_ROOT_PRESENT=1
+rc=0
+bridge_iso_run_path_under_allowlist "$AGENT" "/etc/passwd" "stat" \
+  || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+  _pass "F: request outside raw roster root rejected even with fallback enabled"
+else
+  _fail "F: request outside raw roster root rejected" "got rc=$rc (expected non-zero)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n[summary] %d/%d tests passed\n' $((TOTAL - FAILS)) "$TOTAL"
+if [[ "$FAILS" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/smoke/1207-stale-supp-groups-allowlist.sh
+++ b/scripts/smoke/1207-stale-supp-groups-allowlist.sh
@@ -79,7 +79,8 @@ fi
 # Real on-disk dir we use as the simulated agent workdir.
 WORKDIR="$SMOKE_DIR/agent-workdir"
 mkdir -p "$WORKDIR/.teams"
-printf 'TEAMS_APP_ID=fake-app-id\n' >"$WORKDIR/.teams/.env"
+# noqa: iso-helper-boundary — smoke fixture, not production controller-side write
+printf 'TEAMS_APP_ID=fake-app-id\n' >"$WORKDIR/.teams/.env" # noqa: iso-helper-boundary
 
 # Stub roster helpers — bridge-agents.sh defines these, but our smoke
 # overrides them so the allowlist gate uses our synthetic workdir
@@ -192,8 +193,10 @@ bridge_isolation_run_as_agent_user_via_bash() {
 CANONICALIZE_BLIND=1
 ISO_SIDE_ROOT_PRESENT=1
 
+# noqa: iso-helper-boundary — smoke fixture; production callers go through bridge_iso_run.
 rc=0
-bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "stat" \
+TEST_PATH_TEAMS_ENV="$WORKDIR/.teams/.env" # noqa: iso-helper-boundary
+bridge_iso_run_path_under_allowlist "$AGENT" "$TEST_PATH_TEAMS_ENV" "stat" \
   || rc=$?
 if [[ "$rc" -eq 0 ]]; then
   _pass "A: stat under raw workdir admitted via fallback (controller-blind, iso sees root)"
@@ -202,7 +205,7 @@ else
 fi
 
 rc=0
-bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "env-has-any-key" \
+bridge_iso_run_path_under_allowlist "$AGENT" "$TEST_PATH_TEAMS_ENV" "env-has-any-key" \
   || rc=$?
 if [[ "$rc" -eq 0 ]]; then
   _pass "A: env-has-any-key under raw workdir admitted via fallback"
@@ -211,7 +214,7 @@ else
 fi
 
 rc=0
-bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "read-env-key" \
+bridge_iso_run_path_under_allowlist "$AGENT" "$TEST_PATH_TEAMS_ENV" "read-env-key" \
   || rc=$?
 if [[ "$rc" -eq 0 ]]; then
   _pass "A: read-env-key under raw workdir admitted via fallback"
@@ -237,7 +240,7 @@ fi
 # ---------------------------------------------------------------------------
 ISO_SIDE_ROOT_PRESENT=0
 rc=0
-bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "stat" \
+bridge_iso_run_path_under_allowlist "$AGENT" "$TEST_PATH_TEAMS_ENV" "stat" \
   || rc=$?
 if [[ "$rc" -ne 0 ]]; then
   _pass "C: read-probe fallback rejected when iso UID does NOT see root"
@@ -256,7 +259,7 @@ ISO_SIDE_ROOT_PRESENT=1
 for op in atomic-write mkdir-p rename publish-root-file publish-root-symlink \
           state-marker-write; do
   rc=0
-  bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "$op" \
+  bridge_iso_run_path_under_allowlist "$AGENT" "$TEST_PATH_TEAMS_ENV" "$op" \
     || rc=$?
   if [[ "$rc" -ne 0 ]]; then
     _pass "D: write/publish op '$op' under blind workdir rejected (canonical fail-closed)"
@@ -272,7 +275,7 @@ done
 # ---------------------------------------------------------------------------
 CANONICALIZE_BLIND=0
 rc=0
-bridge_iso_run_path_under_allowlist "$AGENT" "$WORKDIR/.teams/.env" "stat" \
+bridge_iso_run_path_under_allowlist "$AGENT" "$TEST_PATH_TEAMS_ENV" "stat" \
   || rc=$?
 if [[ "$rc" -eq 0 ]]; then
   _pass "E: regression — canonical compare admits path when canonicalize works"

--- a/scripts/smoke/1208-lock-metadata-normalize.sh
+++ b/scripts/smoke/1208-lock-metadata-normalize.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# scripts/smoke/1208-lock-metadata-normalize.sh — unit smoke for
+# `lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py`'s lock
+# metadata normalization (issue #1208).
+#
+# Asserts:
+#   (A) Unit — when BRIDGE_PLUGIN_LOCK_GROUP=<current-user-primary-group>
+#               is set, the helper creates the sidecar
+#               `known_marketplaces.json.lock` with mode 0660 and group
+#               set to the requested group. A second Python process can
+#               then `open(O_RDWR)` + `fcntl.flock(LOCK_EX)`.
+#   (B) Regression — pre-create the lock as mode 0600, run the helper,
+#               assert the mode is normalized to 0660 and group is set.
+#   (C) Absent env var — the helper still works (idempotent fallback to
+#               default 0600 lock; we don't enforce normalization without
+#               an explicit group request).
+#
+# Runs as the current user (mode-based test). The cross-UID case (real
+# iso UID acquiring the flock as a different process) is exercised by
+# integration tests on Linux hosts only; this smoke covers the metadata
+# contract that the cross-UID case depends on.
+#
+# Footgun #11: pipe/argv stdin only.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+FAILS=0
+TOTAL=0
+_pass() { TOTAL=$((TOTAL + 1)); printf '[ok] %s\n' "$1"; }
+_fail() { TOTAL=$((TOTAL + 1)); FAILS=$((FAILS + 1)); printf '[FAIL] %s: %s\n' "$1" "$2" >&2; }
+
+TMPDIR_BASE="${TMPDIR:-/tmp}"
+SMOKE_DIR="$(mktemp -d "$TMPDIR_BASE/agb-1208-smoke.XXXXXX")"
+trap 'rm -rf "$SMOKE_DIR" 2>/dev/null' EXIT INT TERM
+
+HELPER="$REPO_ROOT/lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py"
+if [[ ! -f "$HELPER" ]]; then
+  printf '[FAIL] helper not found at %s\n' "$HELPER" >&2
+  exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '[FAIL] python3 not on PATH\n' >&2
+  exit 1
+fi
+
+# Resolve current user's primary group name (portable: id -gn on Linux
+# + macOS).
+PRIMARY_GROUP="$(id -gn 2>/dev/null || true)"
+if [[ -z "$PRIMARY_GROUP" ]]; then
+  printf '[FAIL] could not resolve current user primary group\n' >&2
+  exit 1
+fi
+
+# Portable stat-mode helper (Linux GNU stat: -c %a; BSD/macOS stat: -f %A).
+_stat_mode() {
+  local p="$1"
+  if stat -c '%a' "$p" 2>/dev/null; then
+    return 0
+  fi
+  if stat -f '%A' "$p" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# Portable stat-group helper (Linux: -c %G; BSD/macOS: -f %Sg).
+_stat_group() {
+  local p="$1"
+  if stat -c '%G' "$p" 2>/dev/null; then
+    return 0
+  fi
+  if stat -f '%Sg' "$p" 2>/dev/null; then
+    return 0
+  fi
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Test A — helper creates lock with mode 0660 + correct group when
+# BRIDGE_PLUGIN_LOCK_GROUP is set; a peer Python process can flock.
+# ---------------------------------------------------------------------------
+PLUGINS_DIR_A="$SMOKE_DIR/scenario-a"
+mkdir -p "$PLUGINS_DIR_A"
+OUT_A="$PLUGINS_DIR_A/known_marketplaces.json"
+LOCK_A="$PLUGINS_DIR_A/known_marketplaces.json.lock"
+
+rc=0
+BRIDGE_PLUGIN_LOCK_GROUP="$PRIMARY_GROUP" python3 "$HELPER" \
+  "-" "$OUT_A" "test-marketplace" "/tmp/fake/root" >/dev/null 2>&1 || rc=$?
+
+if [[ "$rc" -ne 0 ]]; then
+  _fail "A: helper run rc=0" "got rc=$rc"
+elif [[ ! -f "$LOCK_A" ]]; then
+  _fail "A: lock file created" "$LOCK_A missing"
+else
+  mode="$(_stat_mode "$LOCK_A")"
+  group="$(_stat_group "$LOCK_A")"
+  if [[ "$mode" == "660" ]]; then
+    _pass "A: lock mode 0660 (got $mode)"
+  else
+    _fail "A: lock mode 0660" "got $mode"
+  fi
+  if [[ "$group" == "$PRIMARY_GROUP" ]]; then
+    _pass "A: lock group $PRIMARY_GROUP (got $group)"
+  else
+    _fail "A: lock group $PRIMARY_GROUP" "got $group"
+  fi
+fi
+
+# Verify a peer Python process can open + flock the same lock file.
+# Use argv-only input to a single python -c invocation.
+PEER_PY='
+import fcntl, os, sys
+lp = sys.argv[1]
+fd = os.open(lp, os.O_RDWR)
+fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+fcntl.flock(fd, fcntl.LOCK_UN)
+os.close(fd)
+print("flock-ok")
+'
+rc=0
+out="$(python3 -c "$PEER_PY" "$LOCK_A" 2>&1)" || rc=$?
+if [[ "$rc" -eq 0 && "$out" == "flock-ok" ]]; then
+  _pass "A: peer python can open + flock the normalized lock"
+else
+  _fail "A: peer python can open + flock the normalized lock" "rc=$rc out=$out"
+fi
+
+# ---------------------------------------------------------------------------
+# Test B — pre-existing bad lock (mode 0600) is normalized to 0660 + group
+# on next helper run.
+# ---------------------------------------------------------------------------
+PLUGINS_DIR_B="$SMOKE_DIR/scenario-b"
+mkdir -p "$PLUGINS_DIR_B"
+OUT_B="$PLUGINS_DIR_B/known_marketplaces.json"
+LOCK_B="$PLUGINS_DIR_B/known_marketplaces.json.lock"
+
+# Pre-create the lock as 0600 (the beta24 bad shape).
+: > "$LOCK_B"
+chmod 0600 "$LOCK_B"
+
+# Confirm pre-state.
+pre_mode="$(_stat_mode "$LOCK_B")"
+if [[ "$pre_mode" != "600" ]]; then
+  _fail "B: pre-state lock 0600" "got $pre_mode (test setup error)"
+fi
+
+rc=0
+BRIDGE_PLUGIN_LOCK_GROUP="$PRIMARY_GROUP" python3 "$HELPER" \
+  "-" "$OUT_B" "another-marketplace" "/tmp/fake/other-root" >/dev/null 2>&1 || rc=$?
+
+if [[ "$rc" -ne 0 ]]; then
+  _fail "B: helper run rc=0 with pre-existing lock" "got rc=$rc"
+else
+  post_mode="$(_stat_mode "$LOCK_B")"
+  post_group="$(_stat_group "$LOCK_B")"
+  if [[ "$post_mode" == "660" ]]; then
+    _pass "B: pre-existing 0600 lock normalized to 0660 (got $post_mode)"
+  else
+    _fail "B: pre-existing 0600 lock normalized to 0660" "got $post_mode"
+  fi
+  if [[ "$post_group" == "$PRIMARY_GROUP" ]]; then
+    _pass "B: pre-existing lock group set to $PRIMARY_GROUP (got $post_group)"
+  else
+    _fail "B: pre-existing lock group set to $PRIMARY_GROUP" "got $post_group"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test C — helper works without BRIDGE_PLUGIN_LOCK_GROUP (controller's
+# own ~/.claude/plugins/ case). Lock created with default permissions;
+# helper does NOT fail.
+# ---------------------------------------------------------------------------
+PLUGINS_DIR_C="$SMOKE_DIR/scenario-c"
+mkdir -p "$PLUGINS_DIR_C"
+OUT_C="$PLUGINS_DIR_C/known_marketplaces.json"
+LOCK_C="$PLUGINS_DIR_C/known_marketplaces.json.lock"
+
+rc=0
+unset BRIDGE_PLUGIN_LOCK_GROUP
+python3 "$HELPER" \
+  "-" "$OUT_C" "ctrl-marketplace" "/tmp/fake/ctrl-root" >/dev/null 2>&1 || rc=$?
+
+if [[ "$rc" -eq 0 && -f "$LOCK_C" ]]; then
+  _pass "C: helper works without BRIDGE_PLUGIN_LOCK_GROUP (no-op normalization)"
+else
+  _fail "C: helper works without BRIDGE_PLUGIN_LOCK_GROUP" "rc=$rc lock=$LOCK_C"
+fi
+
+# ---------------------------------------------------------------------------
+# Test D — passing a non-existent group → helper warns but does NOT fail
+# (degraded mode). Lock is created with default 0600 (no normalization).
+# ---------------------------------------------------------------------------
+PLUGINS_DIR_D="$SMOKE_DIR/scenario-d"
+mkdir -p "$PLUGINS_DIR_D"
+OUT_D="$PLUGINS_DIR_D/known_marketplaces.json"
+
+rc=0
+BRIDGE_PLUGIN_LOCK_GROUP="this-group-does-not-exist-1208" python3 "$HELPER" \
+  "-" "$OUT_D" "yet-another" "/tmp/fake/yet-another" >/dev/null 2>&1 || rc=$?
+
+if [[ "$rc" -eq 0 ]]; then
+  _pass "D: helper degrades gracefully when BRIDGE_PLUGIN_LOCK_GROUP names a non-existent group"
+else
+  _fail "D: helper degrades gracefully when BRIDGE_PLUGIN_LOCK_GROUP names a non-existent group" \
+    "got rc=$rc (expected 0)"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n[summary] %d/%d tests passed\n' $((TOTAL - FAILS)) "$TOTAL"
+if [[ "$FAILS" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/scripts/smoke/1208-lock-metadata-normalize.sh
+++ b/scripts/smoke/1208-lock-metadata-normalize.sh
@@ -85,8 +85,8 @@ _stat_group() {
 # ---------------------------------------------------------------------------
 PLUGINS_DIR_A="$SMOKE_DIR/scenario-a"
 mkdir -p "$PLUGINS_DIR_A"
-OUT_A="$PLUGINS_DIR_A/known_marketplaces.json"
-LOCK_A="$PLUGINS_DIR_A/known_marketplaces.json.lock"
+OUT_A="$PLUGINS_DIR_A/known_marketplaces.json" # noqa: iso-helper-boundary
+LOCK_A="$PLUGINS_DIR_A/known_marketplaces.json.lock" # noqa: iso-helper-boundary
 
 rc=0
 BRIDGE_PLUGIN_LOCK_GROUP="$PRIMARY_GROUP" python3 "$HELPER" \
@@ -136,8 +136,8 @@ fi
 # ---------------------------------------------------------------------------
 PLUGINS_DIR_B="$SMOKE_DIR/scenario-b"
 mkdir -p "$PLUGINS_DIR_B"
-OUT_B="$PLUGINS_DIR_B/known_marketplaces.json"
-LOCK_B="$PLUGINS_DIR_B/known_marketplaces.json.lock"
+OUT_B="$PLUGINS_DIR_B/known_marketplaces.json" # noqa: iso-helper-boundary
+LOCK_B="$PLUGINS_DIR_B/known_marketplaces.json.lock" # noqa: iso-helper-boundary
 
 # Pre-create the lock as 0600 (the beta24 bad shape).
 : > "$LOCK_B"
@@ -177,8 +177,8 @@ fi
 # ---------------------------------------------------------------------------
 PLUGINS_DIR_C="$SMOKE_DIR/scenario-c"
 mkdir -p "$PLUGINS_DIR_C"
-OUT_C="$PLUGINS_DIR_C/known_marketplaces.json"
-LOCK_C="$PLUGINS_DIR_C/known_marketplaces.json.lock"
+OUT_C="$PLUGINS_DIR_C/known_marketplaces.json" # noqa: iso-helper-boundary
+LOCK_C="$PLUGINS_DIR_C/known_marketplaces.json.lock" # noqa: iso-helper-boundary
 
 rc=0
 unset BRIDGE_PLUGIN_LOCK_GROUP
@@ -197,7 +197,7 @@ fi
 # ---------------------------------------------------------------------------
 PLUGINS_DIR_D="$SMOKE_DIR/scenario-d"
 mkdir -p "$PLUGINS_DIR_D"
-OUT_D="$PLUGINS_DIR_D/known_marketplaces.json"
+OUT_D="$PLUGINS_DIR_D/known_marketplaces.json" # noqa: iso-helper-boundary
 
 rc=0
 BRIDGE_PLUGIN_LOCK_GROUP="this-group-does-not-exist-1208" python3 "$HELPER" \


### PR DESCRIPTION
## Summary

Two surgical fixes for the beta24 OOTB iso v2 gaps Sean's patch VM hit:

1. **#1207** — `bridge_iso_run_path_under_allowlist` now accepts an op-context arg and admits a literal-prefix roster-root fallback for **read/probe ops only** (`stat` / `read-file` / `read-json` / `env-has-any-key` / `read-env-key` / `scan-profile`) when the controller's supp-groups cache is stale (KNOWN_ISSUES §28). Write/publish ops (`mkdir-p` / `atomic-write` / `rename` / `state-marker-write` / `publish-root-file` / `publish-root-symlink`) keep canonical fail-closed so the codex-r2 symlink-ancestor write protection from PR #1200 (beta23) is preserved.

2. **#1208** — `lib/upgrade-helpers/plugins-seed-merge-known-marketplace.py` reads `BRIDGE_PLUGIN_LOCK_GROUP` from env and normalizes the sidecar `known_marketplaces.json.lock` to `root:$BRIDGE_PLUGIN_LOCK_GROUP 0660` via `os.fchown` + `os.fchmod`. D2 propagation in `bridge-plugins.sh` sets the env var to `$agent_group` and also runs a shell-side post-normalizer to self-heal beta24 OOTB installs with the bad `root:root 0600` lock left behind.

## Why these together

Both block Sean's acceptance criterion #3 (`agent create/start/delete OOTB — no operator chmod/sudo/sg`) for fresh beta24 iso v2 agents on the patch admin VM. Sean's deadline was 12:00 KST; combining into one PR + 3 commits (the third is a fixture-only `# noqa` annotation pass for the ratchet) keeps the diff reviewable and the smokes pinned in ci-select.

## Acceptance — fallback predicate (#1207)

Literal fallback is admitted ONLY when ALL of:
- (a) request path is lexically under a raw bridge-owned roster root (`workdir` / `default_home` / `linux_user_home` / `idle_marker_dir`);
- (b) raw path AND raw root are absolute + have no \`..\` segment;
- (c) controller \`_bridge_iso_run_canonicalize\` returned empty for the matched root;
- (d) iso UID (via \`bridge_isolation_run_as_agent_user_via_bash\` with \`[[ -d \"\$1\" ]]\`) confirms the root exists on disk.

\`BRIDGE_ISO_RUN_ALLOWLIST_EXTRA\` is **intentionally excluded** from the fallback root set — that env is a smoke/operator-debug override.

Plus a diagnostic warning at \`bridge_linux_prepare_agent_isolation\` reminding the operator to \`exec sg ab-agent-<X> -- \$SHELL\` when the shell's supp-group cache doesn't yet include the freshly created group. Hint-only — read/probe paths recover automatically.

## Acceptance — lock metadata (#1208)

- Mode is **0660** (group write only), NOT 0664 — world-rw to a coordination lock is unnecessary.
- Data manifests (\`installed_plugins.json\`, \`known_marketplaces.json\`) stay \`root:ab-agent-<X> 0640\` — unchanged.
- Helper degrades gracefully without the env var (default 0600) or with a non-existent group name (warn, continue).
- Controller does NOT create the lock if absent — the iso UID's first plugin cache write creates it under the 2770 plugins dir.
- Shell-side post-normalizer also chowns/chmods \`installed_plugins.json.lock\` if present (matches the parent contract at \`lib/bridge-isolation-v2.sh:1734-1747\`).

## Test plan

Verified with \`/opt/homebrew/bin/bash\` (Bash 5.3.9 — NOT \`/bin/bash\` 3.2 which errors on \`declare -A\`; PR #1206 r1 false-passed because of this):

- [x] \`bash -n\` on all modified \`.sh\`
- [x] \`shellcheck\` on all modified \`.sh\`
- [x] \`python3 -m py_compile\` on the modified \`.py\`
- [x] \`scripts/smoke/1207-stale-supp-groups-allowlist.sh\` — **14/14**
- [x] \`scripts/smoke/1208-lock-metadata-normalize.sh\` — **7/7**
- [x] \`scripts/iso-helper-smoke.sh\` — **25/25** (regression baseline still green)
- [x] \`scripts/iso-helper-ratchet.sh\` — OK no regression beyond baseline
- [x] \`scripts/lint-heredoc-ban.sh\` — PASS
- [x] \`scripts/lint-raw-pathlib-on-isolated.sh\` — PASS
- [x] \`scripts/smoke/channel-plugins.sh\` — PASS
- [x] \`scripts/smoke/1201-1202-directory-marketplace-seed.sh\` — PASS

### Migration notes (for codex review brief)

- **Existing \`test_iso_v24\` on patch's VM** (with operator workarounds applied): the shell-side post-normalizer self-heals the bad lock on the next D2 propagation (\`agent create\`, \`agent-bridge setup teams\`, or any subsequent \`agb plugins seed\` for that marketplace). The supp-groups fallback works in the already-running shell — no operator action required.
- **Fresh OOTB iso v2 agents** under beta25: \`agent create\` plants the lock at \`root:ab-agent-<X> 0660\` directly; \`agent start\` reads the channel-required validator's dotenvs through the read/probe fallback even before the operator refreshes their shell.

## Footguns observed and avoided

- **Footgun #11**: all subprocess invocations use pipe/argv stdin only. No \`<<EOF\` / \`<<<\` / \`<()\` anywhere in the new helpers or smokes.
- **\`/opt/homebrew/bin/bash\` required**: \`scripts/iso-helper-ratchet.sh:95\` uses \`declare -A\` which macOS 3.2 \`/bin/bash\` rejects. The PR was verified with \`/opt/homebrew/bin/bash\` per CLAUDE.md Platform Notes.

## Out-of-scope (NOT touched)

- VERSION / CHANGELOG (stabilization PR per operator directive 2026-05-15).
- \`bridge_iso_run\` ratchet baseline (fixture-only \`# noqa: iso-helper-boundary\` annotations only).
- The 2770 plugins dir matrix row in \`lib/bridge-isolation-v2.sh\` (unchanged).
- Daemon-mediated workdir resolution (long-term #1207 third option, deferred).

(#1207 Track A) (#1208 Track A)