### PR TITLE
feat(agent): admin description defaults + agent describe CLI + convention docs (Lane I)

### DIFF
--- a/agent-roster.local.example.sh
+++ b/agent-roster.local.example.sh
@@ -14,6 +14,27 @@ BRIDGE_AGENT_DESC["developer"]="Development role (Claude Code)"
 BRIDGE_AGENT_DESC["codex-tester"]="Test role (Codex)"
 BRIDGE_AGENT_DESC["codex-developer"]="Development role (Codex)"
 
+# Admin/system role description examples (v0.15.0-beta1 Lane I).
+#
+# BRIDGE_AGENT_DESC is the human-readable IDENTITY of each agent. Downstream
+# agents (cosmax-* installs, A2A peers, etc.) read this string from
+# `agent show <name>` / `agent describe <name>` to decide how to address the
+# agent and what kind of work to route. A one-line role+ownership sentence is
+# the sweet spot — terse enough to be queue-renderable, concrete enough that a
+# stranger reading the roster knows who owns onboarding vs who reviews PRs.
+#
+# Note: BRIDGE_AGENT_DESC is IDENTITY, not AUTHORIZATION. The privilege
+# boundary lives in BRIDGE_AGENT_CLASS (see further down this file). A
+# `librarian` agent class=system describes its job here; the class line
+# downstream is the access boundary.
+#
+# Recommended one-liners per role family:
+#
+# BRIDGE_AGENT_DESC["patch"]="Agent Bridge admin/coordinator for this install. Owns onboarding, roster/queue triage, upgrade/release waves, and operator-facing decisions."
+# BRIDGE_AGENT_DESC["patch-dev"]="Codex dev/review pair for patch. Reviews PRs, proposes code changes, and verifies smoke/runtime checks assigned through Agent Bridge."
+# BRIDGE_AGENT_DESC["patch-agy"]="Antigravity/alternate-engine pair for patch. Handles cross-engine implementation or UI/runtime verification tasks assigned through Agent Bridge."
+# BRIDGE_AGENT_DESC["librarian"]="Memory ingestion/supervisory role. Harvests every agent's memory tree into the shared wiki (access boundary set via BRIDGE_AGENT_CLASS=system)."
+
 BRIDGE_AGENT_ENGINE["tester"]="claude"
 BRIDGE_AGENT_ENGINE["developer"]="claude"
 BRIDGE_AGENT_ENGINE["codex-tester"]="codex"

--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -34,6 +34,7 @@ Subcommands:
   list               List registered agents.
   registry           Read-only JSON inventory of registered agents.
   show               Show one agent's roster + runtime state.
+  describe           Print BRIDGE_AGENT_DESC[<agent>] (read-only getter).
   reclassify         Promote a runtime-detected admin to a static role.
   doctor             Run a 7-step CRUD self-check (create/update/registry/
                      show/reclassify/retire/delete) against an isolated fixture.
@@ -55,6 +56,7 @@ Examples:
   $(basename "$0") list --json
   $(basename "$0") registry --json
   $(basename "$0") show reviewer --json
+  $(basename "$0") describe reviewer
   $(basename "$0") reclassify --apply
   $(basename "$0") rerender-settings --apply
   $(basename "$0") start reviewer --dry-run
@@ -2040,7 +2042,17 @@ run_show() {
     admin="${_fields[29]}"
     [[ "$row_agent" == "agent" ]] && continue
     printf 'agent: %s\n' "$row_agent"
-    printf 'description: %s\n' "$description"
+    # v0.15.0-beta1 Lane I: emit a self-contained hint when the operator
+    # has not set BRIDGE_AGENT_DESC for this agent. The JSON record stays
+    # raw (empty string) so downstream scripts can distinguish "unset"
+    # from "placeholder text"; the text mode line stays present so
+    # operators piping `agent show` through grep/awk still see a stable
+    # row, just with an actionable hint instead of a blank value.
+    if [[ -z "$description" ]]; then
+      printf 'description: [no description set; edit BRIDGE_AGENT_DESC["%s"] in agent-roster.local.sh]\n' "$row_agent"
+    else
+      printf 'description: %s\n' "$description"
+    fi
     printf 'engine: %s\n' "$engine"
     printf 'source: %s\n' "$source"
     printf 'admin: %s\n' "$admin"
@@ -2091,6 +2103,78 @@ run_show() {
     printf 'session_health:\n'
     bridge_agent_session_guidance_text "$agent" | sed 's/^/  /'
   done <<<"$output"
+}
+
+# v0.15.0-beta1 Lane I: read-only `agent describe <agent>` getter.
+#
+# Contract (codex r1):
+#   - With `-h`/`--help`: print short usage to stdout, exit 0. The flag is
+#     checked BEFORE `bridge_require_agent` so the universal --help gate
+#     (scripts/smoke/1117-cli-help-universal-gate.sh) sees a clean stdout
+#     without the "등록된 에이전트:" error marker.
+#   - With a registered agent that has a non-empty BRIDGE_AGENT_DESC entry:
+#     print the description + newline to stdout, exit 0.
+#   - With a registered agent whose BRIDGE_AGENT_DESC entry is unset/empty:
+#     print no stdout, exit non-zero, write a hint to stderr pointing the
+#     operator at the roster file.
+#   - With an unregistered agent: standard bridge_require_agent failure
+#     (registry list to stdout/stderr, bridge_die exit 1).
+#
+# No write path in beta1 — the source of truth is the roster file. See
+# docs/agent-runtime/admin-agent-convention.md.
+run_describe() {
+  # Honor `-h`/`--help` before any argument validation, so the universal
+  # --help gate (issue #1117) sees a clean rc=0 + non-empty stdout regardless
+  # of whether an agent id is also present on the command line.
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      -h|--help)
+        cat <<EOF
+Usage:
+  $(basename "$0") describe <agent>
+
+Read-only getter for the BRIDGE_AGENT_DESC[<agent>] string.
+
+  - Set       → prints the description + newline, exit 0.
+  - Unset     → no stdout, exit non-zero, stderr hint points to
+                BRIDGE_AGENT_DESC["<agent>"] in agent-roster.local.sh.
+
+The description is operator-curated; the source of truth is the roster
+file. To change a description, edit \$BRIDGE_HOME/agent-roster.local.sh
+directly. See docs/agent-runtime/admin-agent-convention.md for the
+convention and per-role recommended one-liners.
+EOF
+        return 0
+        ;;
+    esac
+  done
+
+  local agent="${1:-}"
+  [[ -n "$agent" ]] || bridge_die "Usage: $(basename "$0") describe <agent>"
+  shift || true
+
+  # Reject any extra positional or flag arguments — `describe` is a
+  # single-purpose getter, not a multi-flag operation. Matches the shape
+  # of similar read-only verbs (issue #163 intent-recovery hint surface).
+  if [[ $# -gt 0 ]]; then
+    bridge_die "지원하지 않는 agent describe 옵션입니다: $1"
+  fi
+
+  bridge_require_agent "$agent"
+
+  local description
+  description="$(bridge_agent_desc "$agent")"
+  if [[ -z "$description" ]]; then
+    # No stdout when unset (so callers piping the value into another
+    # command see an empty string, not a placeholder). Hint to stderr
+    # so an interactive operator running `agb agent describe foo` still
+    # sees the actionable next step.
+    bridge_warn "agent '$agent' has no description set. Edit BRIDGE_AGENT_DESC[\"$agent\"] in agent-roster.local.sh (see docs/agent-runtime/admin-agent-convention.md)."
+    return 1
+  fi
+
+  printf '%s\n' "$description"
 }
 
 run_reclassify() {
@@ -5869,6 +5953,11 @@ case "$subcommand" in
   show)
     run_show "$@"
     ;;
+  describe)
+    # v0.15.0-beta1 Lane I: read-only getter for BRIDGE_AGENT_DESC[<agent>].
+    # See docs/agent-runtime/admin-agent-convention.md.
+    run_describe "$@"
+    ;;
   reclassify)
     run_reclassify "$@"
     ;;
@@ -5911,7 +6000,7 @@ case "$subcommand" in
   *)
     # Issue #163 Phase 2: surface an intent-recovery hint before dying.
     _hint="$(bridge_suggest_subcommand "$subcommand" \
-      "create update delete retire list registry show reclassify doctor rerender-settings start safe-mode stop restart ack-crash forget-session attach compact handoff")"
+      "create update delete retire list registry show describe reclassify doctor rerender-settings start safe-mode stop restart ack-crash forget-session attach compact handoff")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 agent 명령입니다: $subcommand"
     ;;

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -520,7 +520,13 @@ if [[ $dry_run -eq 0 ]]; then
 fi
 
 session="${session:-$admin_agent}"
-description="${description:-$admin_agent admin role}"
+# v0.15.0-beta1 Lane I: replace the terse "<name> admin role" default with a
+# concrete role description so downstream agents reading the roster on a fresh
+# install see a useful sentence (issue: cosmax-* installs landed empty/terse
+# desc → downstream agent autonomy regressed). The example roster
+# (agent-roster.local.example.sh) carries the same boilerplate so operators
+# can lift it verbatim. See docs/agent-runtime/admin-agent-convention.md.
+description="${description:-Agent Bridge admin/coordinator for this install. Owns onboarding, roster/queue triage, upgrade/release waves, and operator-facing decisions.}"
 display_name="${display_name:-$admin_agent}"
 channels="$(bridge_normalize_channels_csv "$channels")"
 

--- a/docs/agent-runtime/admin-agent-convention.md
+++ b/docs/agent-runtime/admin-agent-convention.md
@@ -1,0 +1,137 @@
+# Agent Description Convention
+
+> Operator-facing convention for `BRIDGE_AGENT_DESC` — the human-readable
+> identity string carried on every agent in the roster. Not a runtime
+> protocol; this doc tells operators what to write when they set up a new
+> install or add a role. See [`admin-protocol.md`](admin-protocol.md) for
+> the runtime admin contract and [`role-architecture.md`](role-architecture.md)
+> for the broader role taxonomy.
+
+## Why this matters
+
+Downstream agents (other Agent Bridge installs reachable over A2A,
+operator-side cosmax-CRM plugins, queue inspectors) read each agent's
+description string from `agent show <name>` / `agent describe <name>` to
+decide:
+
+- Who to address for which kind of request.
+- Which queue inbox is the right destination for a routed task.
+- What kind of work each agent considers "in scope" before opening one.
+
+When an install ships with empty or terse description strings (`"<name>
+admin role"`), downstream agents fall back to guessing from agent id alone
+— and the autonomy benefits Agent Bridge promises stop compounding. The
+v0.15.0-beta1 Lane I work landed a useful default in `bridge-init.sh` and
+the example roster so a fresh install is correct by construction; this doc
+records the convention operators should follow when they extend a roster.
+
+## Convention: one line, role + ownership
+
+A `BRIDGE_AGENT_DESC` entry SHOULD be a single sentence that names the role
+AND what the agent owns. Two examples that follow the shape:
+
+```
+Agent Bridge admin/coordinator for this install. Owns onboarding,
+roster/queue triage, upgrade/release waves, and operator-facing decisions.
+```
+
+```
+Codex dev/review pair for patch. Reviews PRs, proposes code changes, and
+verifies smoke/runtime checks assigned through Agent Bridge.
+```
+
+Both name the role (admin/coordinator, codex pair) AND scope the ownership
+(onboarding+triage+upgrades vs PR review+code change+verification). A
+downstream agent reading either line can route work without further
+clarification.
+
+Anti-patterns to avoid:
+
+- **Empty string.** `BRIDGE_AGENT_DESC["foo"]=""` is the worst case — the
+  `agent show` text-mode hint at `[no description set; edit
+  BRIDGE_AGENT_DESC["foo"] in agent-roster.local.sh]` is the operator
+  callout; if you see that line in your roster, edit the roster.
+- **Tautology.** `"foo's role"` or `"the foo agent"` does not say what foo
+  does. Downstream agents cannot route off it.
+- **Multi-line essays.** The description is queue-renderable (TSV column,
+  JSON record value, single-line CLI getter). Anything past ~140 chars
+  starts crowding terminal-width queue listings.
+
+## Description ≠ Class
+
+`BRIDGE_AGENT_DESC` is IDENTITY. `BRIDGE_AGENT_CLASS` (see
+[`agent-roster.local.example.sh`](../../agent-roster.local.example.sh)
+around the `BRIDGE_AGENT_CLASS` docs block, refs issue #539) is
+AUTHORIZATION.
+
+- A `librarian` agent's DESCRIPTION names the job: "memory
+  ingestion/supervisory role; harvests every agent's memory tree into the
+  shared wiki."
+- A `librarian` agent's CLASS sets the privilege boundary:
+  `BRIDGE_AGENT_CLASS["librarian"]="system"` so it can read other agents'
+  memory trees.
+
+The description is what a stranger sees; the class is what the runtime
+enforces. Conflating them is the most common roster-setup mistake — an
+operator writes `class=system` into the description string and leaves
+class unset, then wonders why hooks block the agent's reads. Keep them
+distinct in the roster.
+
+## Recommended one-liners per role family
+
+For a stock Agent Bridge install with the recommended `patch` (claude
+admin) + `patch-dev` (codex pair) shape:
+
+| Role        | id          | Suggested `BRIDGE_AGENT_DESC` line |
+| ----------- | ----------- | ---------------------------------- |
+| Admin       | `patch`     | `Agent Bridge admin/coordinator for this install. Owns onboarding, roster/queue triage, upgrade/release waves, and operator-facing decisions.` |
+| Codex pair  | `patch-dev` | `Codex dev/review pair for patch. Reviews PRs, proposes code changes, and verifies smoke/runtime checks assigned through Agent Bridge.` |
+| Antigravity pair | `patch-agy` | `Antigravity/alternate-engine pair for patch. Handles cross-engine implementation or UI/runtime verification tasks assigned through Agent Bridge.` |
+| Librarian (system class) | `librarian` | `Memory ingestion/supervisory role. Harvests every agent's memory tree into the shared wiki (access boundary set via BRIDGE_AGENT_CLASS=system).` |
+
+The schema for these entries lives in
+[`agent-roster.local.example.sh`](../../agent-roster.local.example.sh)
+near the `BRIDGE_AGENT_DESC[...]` block and the `BRIDGE_AGENT_CLASS` docs
+block. Lift the recommended lines verbatim and edit the role-specific
+words.
+
+## CLI surface
+
+The description string is exposed through three read-only paths. None of
+them write back; the source of truth is the roster file.
+
+- `agent show <name>` — text mode prints `description: <line>` (or the
+  unset hint shown above); JSON mode (`agent show <name> --json`) carries
+  it as `.description` (raw empty string when unset, so scripts can
+  distinguish "operator chose to leave blank" from "we substituted a
+  hint").
+- `agent list --json` — every record carries the same `.description`
+  field.
+- `agent describe <name>` — single-purpose getter. Prints the description
+  + newline on stdout when set; exits non-zero with no stdout and a
+  stderr hint pointing to `BRIDGE_AGENT_DESC["<name>"]` in
+  `agent-roster.local.sh` when unset. Use this from scripts that just
+  want the string — it has no JSON envelope, no engine/workdir noise.
+  `-h`/`--help` print usage and exit 0.
+
+There is no `agent describe set <name> <text>` write path in beta1. To
+change a description, edit the roster file directly and reload the agent
+(or wait for the daemon's next sync). This keeps the description an
+operator-curated value, not a runtime-mutated one.
+
+## When to update the description
+
+- **First-run onboarding.** The fresh install already lands the
+  recommended admin sentence via `bridge-init.sh`. Operators only need to
+  edit if they want install-specific wording (team name, environment,
+  region).
+- **Adding a new role.** Whenever an operator adds a `BRIDGE_AGENT_*`
+  block to `agent-roster.local.sh`, write a matching description in the
+  same block. The example file's recommended lines are a starting point.
+- **Role boundary change.** If an agent's ownership shifts (e.g., a
+  `librarian` becomes a `librarian + auditor`), update the description
+  in the same PR that touches `BRIDGE_AGENT_CLASS` or the runtime hooks.
+
+The description is queue-visible and reviewed by every downstream agent
+that asks "who owns this?" — treating it as a casual comment is the most
+common source of routing mistakes in multi-install fleets.

--- a/docs/agent-runtime/admin-protocol.md
+++ b/docs/agent-runtime/admin-protocol.md
@@ -185,6 +185,10 @@ upgrade 시 다음 advisory 가 **한 번만** 출력된다 (auto-action 없음,
 
 권장 페어가 등록된 호스트에서 admin 의 `CLAUDE.md` 에 pair-programming SOP (plan brief → `plan-ok` → implement → code review → `implement-ok`) 를 직접 작성해 둔다. 자동 주입은 더 이상 동작하지 않으므로 운영자 자율로 관리한다.
 
+### Agent description convention
+
+페어가 등록된 다음에는 `BRIDGE_AGENT_DESC` 한 줄을 admin / pair / system 역할별로 채워 둔다. 이 줄은 IDENTITY 이고 `BRIDGE_AGENT_CLASS` 가 AUTHORIZATION 이다 — 둘은 별개 역할을 한다. 권장 문구, 안티패턴, `agent describe <name>` 사용법은 [`admin-agent-convention.md`](admin-agent-convention.md) 참고. v0.15.0-beta1 부터 `bridge-init.sh` 가 admin agent 의 기본 description 을 useful 한 문장으로 채우므로 fresh install 은 별도 편집 없이도 컨벤션을 따른다.
+
 ## Bootstrap for a new server / new install
 
 새 서버에 Agent Bridge를 처음 설치할 때 admin이 수행할 순서:

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster
 
 
 }
@@ -188,6 +188,17 @@ select_for_path() {
       # template-text drift still pulls the #1060 layout smokes.
       add_required 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning
       ;;
+    agent-roster.local.example.sh)
+      # v0.15.0-beta1 Lane I: the example roster is operator-facing copy.
+      # An edit here (recommended BRIDGE_AGENT_DESC one-liners, admin
+      # class examples) should still pull the Lane I smoke so the
+      # convention's expected shape — non-empty default desc, list/show
+      # carry the string, describe getter resolves it — cannot regress.
+      # The file is .sh, not .md, so is_docs_only_path wouldn't elide
+      # it anyway, but this explicit pre-case keeps the smoke gate
+      # consistent if the trigger ever flips into the docs path.
+      add_required I-agent-description-roster
+      ;;
   esac
 
   # Issue #1114: subcommand-group dispatchers previously rejected
@@ -257,7 +268,11 @@ select_for_path() {
       # same template to enumerate top-level commands. Pull it on every
       # template edit so a new __CLI_NAME__ <cmd> row that lacks an
       # accepting --help dispatcher arm trips CI at PR time.
-      add_required 1115-cli-usage-drift 1117-cli-help-universal-gate
+      #
+      # v0.15.0-beta1 Lane I: the template now advertises
+      # `agent describe <agent>`. Pull I-agent-description-roster on
+      # every template edit so the row + dispatcher arm cannot drift.
+      add_required 1115-cli-usage-drift 1117-cli-help-universal-gate I-agent-description-roster
       ;;
 
     bridge-setup.py|bridge-setup.sh|bridge-status.py|bridge-status.sh)
@@ -555,7 +570,11 @@ select_for_path() {
       # bash collision repro and the Python hook's RESOLVED-first
       # read order. Pull it whenever bridge-run.sh moves so the
       # alias export and read order cannot regress.
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper 1155-bootstrap-skill-guard 1158-marker-load-order 1165-track-a-scaffold-modes 1213-iso-uid-predicate beta27-D-inject-timestamp-resolved
+      # v0.15.0-beta1 Lane I: bridge-agent.sh gained the `describe` verb
+      # (read-only BRIDGE_AGENT_DESC getter) + `agent show` text-mode
+      # unset hint. Pull I-agent-description-roster on every dispatcher
+      # move so the describe dispatch arm + show hint cannot regress.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper 1155-bootstrap-skill-guard 1158-marker-load-order 1165-track-a-scaffold-modes 1213-iso-uid-predicate beta27-D-inject-timestamp-resolved I-agent-description-roster
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -1023,7 +1042,14 @@ select_for_path() {
       # advisory (lib/bridge-host-profile.sh) carries the dev-path manual
       # recipe. Pull admin-pair-server-auto-provision whenever any of the
       # four touches so the server/dev gate matrix stays pinned.
-      add_required admin-pair-server-auto-provision agent-create-caller-trust-gate upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering
+      #
+      # v0.15.0-beta1 Lane I: bridge-init.sh now lands a useful default
+      # admin description (replacing the terse `<admin> admin role`
+      # placeholder) so downstream agents reading the roster on a fresh
+      # install see a real role sentence. Pull I-agent-description-roster
+      # on every bridge-init.sh move so the default cannot regress back
+      # to the terse string.
+      add_required admin-pair-server-auto-provision agent-create-caller-trust-gate upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering I-agent-description-roster
       add_integration integration-minimal
       ;;
 

--- a/scripts/cli-help/agent-bridge-usage.txt
+++ b/scripts/cli-help/agent-bridge-usage.txt
@@ -26,7 +26,7 @@ Usage:
   __CLI_NAME__ wave <dispatch|list|show|templates|close-issue> ...
   __CLI_NAME__ plugins <seed|show> ...
   __CLI_NAME__ a2a <send|outbox|inbox-dedupe|peers|deliver|daemon> ...
-  __CLI_NAME__ agent <create|update|delete|retire|list|registry|show|reclassify|doctor|rerender-settings|start|safe-mode|stop|restart|ack-crash|forget-session|attach|compact|handoff> ...
+  __CLI_NAME__ agent <create|update|delete|retire|list|registry|show|describe|reclassify|doctor|rerender-settings|start|safe-mode|stop|restart|ack-crash|forget-session|attach|compact|handoff> ...
   __CLI_NAME__ kill <number|all>
   __CLI_NAME__ attach [number|name]
   __CLI_NAME__ urgent <agent> "<message>" [--wait <seconds>]
@@ -88,6 +88,7 @@ Usage:
   __CLI_NAME__ agent list [--json]
   __CLI_NAME__ agent registry [--json]
   __CLI_NAME__ agent show <agent> [--json]
+  __CLI_NAME__ agent describe <agent>
   __CLI_NAME__ agent reclassify [--agent <agent>] [--apply] [--json]
   __CLI_NAME__ agent start <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
   __CLI_NAME__ agent safe-mode <agent> [--attach|--no-attach] [--replace] [--continue|--no-continue] [--dry-run]
@@ -172,6 +173,7 @@ Examples:
   __CLI_NAME__ agent list --json
   __CLI_NAME__ agent registry --json
   __CLI_NAME__ agent show reviewer --json
+  __CLI_NAME__ agent describe reviewer
   __CLI_NAME__ agent reclassify --apply
   __CLI_NAME__ agent start reviewer --dry-run
   __CLI_NAME__ agent restart reviewer --attach

--- a/scripts/smoke/I-agent-description-roster.sh
+++ b/scripts/smoke/I-agent-description-roster.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/I-agent-description-roster.sh — v0.15.0-beta1 Lane I.
+#
+# Pins the `BRIDGE_AGENT_DESC` operator-facing surface:
+#
+#   T1.  Roster-set description renders in `agent show <agent>` text output
+#        on the canonical `description:` line.
+#   T2.  `agent show <agent> --json` carries the same string verbatim as
+#        the JSON `.description` field.
+#   T3.  `agent list --json` carries the same string on the record for the
+#        named agent.
+#   T4.  `agent describe <agent>` prints the description + newline on
+#        stdout with exit 0 when the desc is set.
+#   T5.  A second agent with no `BRIDGE_AGENT_DESC` entry: `agent show`
+#        still emits a stable `description:` line carrying the unset
+#        hint (refs admin-agent-convention.md), and `agent describe`
+#        exits non-zero with no stdout and a stderr hint pointing at
+#        the roster file.
+#   T6.  `declare -p BRIDGE_AGENT_DESC` after sourcing bridge-lib.sh +
+#        bridge_load_roster confirms the variable is declared as an
+#        associative array (`declare -A …`), not a scalar. Pins the
+#        regression class catalogued in #1213 (assoc-array vs scalar
+#        export collision) — adding a `BRIDGE_AGENT_DESCRIPTION` scalar
+#        anywhere would fork the schema and trip an isolated agent's
+#        roster reader.
+#   T7.  No `BRIDGE_AGENT_DESC` and no `BRIDGE_AGENT_DESCRIPTION` scalar
+#        survives into the agent's runtime environment under
+#        `lib/bridge-agents.sh` env snapshotter (#1213 prevention).
+#   T8.  `agent describe -h` and `agent describe --help` print
+#        non-empty stdout with rc=0 (matches the #1117 universal --help
+#        gate contract for the new verb).
+#
+# Footgun #11 (KNOWN_ISSUES.md §26): NO heredoc-stdin to subprocess
+# anywhere — every captured stdout uses `out=$("$@" 2>&1)` and every
+# Python invocation uses `python3 -c '…'` with the body as a single
+# argv string, or a standalone helper file (no inline `<<'PY'`).
+# Re-execs under Homebrew Bash 5+ on macOS hosts (system bash is 3.2).
+
+if [[ "${BRIDGE_SMOKE_BASH4_REEXEC:-0}" != "1" && "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      BRIDGE_SMOKE_BASH4_REEXEC=1 exec "$_candidate" "$0" "$@"
+    fi
+  done
+  echo "[smoke:I-agent-description-roster][error] bash 4+ required (got ${BASH_VERSION:-unknown})" >&2
+  exit 1
+fi
+
+set -uo pipefail
+
+SMOKE_NAME="I-agent-description-roster"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+# Pick a Bash 4+ interpreter for subprocess invocations.
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+PY_BIN="${PYTHON3:-python3}"
+
+# Fixed strings for the two test agents — chosen to be distinctive enough
+# that a substring match in show/list output can attribute the hit
+# unambiguously.
+AGENT_SET="i-desc-set"
+AGENT_UNSET="i-desc-unset"
+DESC_STRING="test role: queue-aware coordinator for Lane I smoke verification"
+
+# ---------------------------------------------------------------------------
+# Roster fixture
+# ---------------------------------------------------------------------------
+# Two static agents: one with BRIDGE_AGENT_DESC populated, one without.
+# Engine/session/workdir filled in for both so the TSV emitter doesn't bail
+# on missing required columns.
+write_roster() {
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+bridge_add_agent_id_if_missing "$AGENT_SET"
+BRIDGE_AGENT_DESC["$AGENT_SET"]="$DESC_STRING"
+BRIDGE_AGENT_ENGINE["$AGENT_SET"]="claude"
+BRIDGE_AGENT_SESSION["$AGENT_SET"]="$AGENT_SET"
+BRIDGE_AGENT_WORKDIR["$AGENT_SET"]="$BRIDGE_AGENT_HOME_ROOT/$AGENT_SET"
+BRIDGE_AGENT_SOURCE["$AGENT_SET"]="static"
+
+bridge_add_agent_id_if_missing "$AGENT_UNSET"
+BRIDGE_AGENT_ENGINE["$AGENT_UNSET"]="claude"
+BRIDGE_AGENT_SESSION["$AGENT_UNSET"]="$AGENT_UNSET"
+BRIDGE_AGENT_WORKDIR["$AGENT_UNSET"]="$BRIDGE_AGENT_HOME_ROOT/$AGENT_UNSET"
+BRIDGE_AGENT_SOURCE["$AGENT_UNSET"]="static"
+EOF
+}
+
+write_roster
+
+# Scaffold the agent home roots so bridge-lib.sh's profile-home resolver
+# doesn't synthesize a v2 layout marker pass that would mask roster
+# behaviour we care about.
+mkdir -p "$BRIDGE_AGENT_HOME_ROOT/$AGENT_SET" "$BRIDGE_AGENT_HOME_ROOT/$AGENT_UNSET"
+
+agb_agent() {
+  "$BRIDGE_BASH" "$REPO_ROOT/bridge-agent.sh" "$@"
+}
+
+# Helper: run a subprocess that prints `declare -p BRIDGE_AGENT_DESC` AFTER
+# sourcing bridge-lib.sh + bridge_load_roster. Stand-alone helper file
+# would be overkill; the body is a small fixed Bash command string with
+# no heredoc, no `<<<`, no `$()` chained around heredocs.
+roster_declare_p() {
+  "$BRIDGE_BASH" -c \
+    "set +u; cd \"$REPO_ROOT\" && source ./bridge-lib.sh >/dev/null 2>&1; bridge_load_roster >/dev/null 2>&1; declare -p BRIDGE_AGENT_DESC 2>/dev/null"
+}
+
+# Helper: capture the BRIDGE_AGENT_DESC variable from `env` after loading
+# the roster. We force the loader to run via a subshell, then `env | grep`
+# for any scalar export. The roster's `declare -A BRIDGE_AGENT_DESC` lives
+# in shell scope; `env` only surfaces explicitly exported scalars.
+env_has_scalar() {
+  local var_name="$1"
+  "$BRIDGE_BASH" -c \
+    "set +u; cd \"$REPO_ROOT\" && source ./bridge-lib.sh >/dev/null 2>&1; bridge_load_roster >/dev/null 2>&1; env | grep -E \"^${var_name}=\" || true"
+}
+
+# ---------------------------------------------------------------------------
+# T1: roster-set description renders in `agent show <agent>` text output
+# ---------------------------------------------------------------------------
+smoke_log "T1: agent show <set-agent> carries description in text mode"
+SHOW_TEXT_OUT="$(agb_agent show "$AGENT_SET" 2>&1)" || smoke_fail "T1: agent show rc!=0"
+smoke_assert_contains "$SHOW_TEXT_OUT" "description: $DESC_STRING" \
+  "T1: text output carries 'description: <DESC_STRING>'"
+smoke_assert_contains "$SHOW_TEXT_OUT" "agent: $AGENT_SET" \
+  "T1: text output identifies the agent we asked about"
+
+# ---------------------------------------------------------------------------
+# T2: JSON `agent show` carries description
+# ---------------------------------------------------------------------------
+smoke_log "T2: agent show <set-agent> --json carries .description"
+SHOW_JSON_OUT="$(agb_agent show "$AGENT_SET" --json 2>&1)" || smoke_fail "T2: show --json rc!=0"
+
+# Drive every JSON inspection through a small file-based Python helper so
+# we avoid the footgun #11 heredoc-stdin deadlock class. The helper takes
+# (agent_id, json_file) on argv and prints the description string. Same
+# precedent as lib/upgrade-helpers/ (file-as-argv, no stdin heredoc).
+HELPER_DIR="$SMOKE_TMP_ROOT/helpers"
+mkdir -p "$HELPER_DIR"
+cat >"$HELPER_DIR/extract-desc.py" <<'PYHELPER'
+"""Extract description from `agent show --json` or `agent list --json`.
+
+Usage:
+  python3 extract-desc.py <agent_id> <json_file>
+
+Prints the description string for <agent_id> on stdout, exit 0. Empty
+string on stdout + exit 1 if the agent is not present or has no
+description key. NOT stdin-driven, NOT heredoc-bodied — argv-only,
+file-based input, satisfies the Lane I no-heredoc-stdin constraint.
+"""
+import json
+import sys
+
+
+def find_record(doc, agent_id):
+    """Walk the show/list shape and return the dict that carries description."""
+    if isinstance(doc, dict):
+        # show --json top-level shape: {"agent": "<id>", "description": "...", ...}
+        if doc.get("agent") == agent_id and "description" in doc:
+            return doc
+        # show --json may wrap the record under `.agent` as an object.
+        nested = doc.get("agent")
+        if isinstance(nested, dict) and nested.get("agent") == agent_id:
+            return nested
+        # list --json shape can be {"agents": [...]} too.
+        records = doc.get("agents")
+        if isinstance(records, list):
+            for rec in records:
+                if isinstance(rec, dict) and rec.get("agent") == agent_id:
+                    return rec
+    if isinstance(doc, list):
+        for rec in doc:
+            if isinstance(rec, dict) and rec.get("agent") == agent_id:
+                return rec
+    return None
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("usage: extract-desc.py <agent_id> <json_file>", file=sys.stderr)
+        sys.exit(2)
+    agent_id = sys.argv[1]
+    json_path = sys.argv[2]
+    with open(json_path, "r", encoding="utf-8") as fh:
+        doc = json.load(fh)
+    rec = find_record(doc, agent_id)
+    if rec is None:
+        sys.exit(1)
+    # `description` may be absent on schema drift; treat absence as exit 1
+    # so the smoke fails loudly on producer-side bugs.
+    if "description" not in rec:
+        sys.exit(1)
+    print(rec["description"])
+
+
+if __name__ == "__main__":
+    main()
+PYHELPER
+
+printf '%s' "$SHOW_JSON_OUT" >"$HELPER_DIR/show.json"
+SHOW_DESC="$("$PY_BIN" "$HELPER_DIR/extract-desc.py" "$AGENT_SET" "$HELPER_DIR/show.json" 2>&1)" \
+  || smoke_fail "T2: extract-desc.py could not find description for $AGENT_SET in show --json"
+smoke_assert_eq "$DESC_STRING" "$SHOW_DESC" "T2: show --json .description matches roster string"
+
+# ---------------------------------------------------------------------------
+# T3: `agent list --json` carries the description on the named record
+# ---------------------------------------------------------------------------
+smoke_log "T3: agent list --json carries .description for set-agent"
+LIST_JSON_OUT="$(agb_agent list --json 2>&1)" || smoke_fail "T3: list --json rc!=0"
+printf '%s' "$LIST_JSON_OUT" >"$HELPER_DIR/list.json"
+LIST_DESC="$("$PY_BIN" "$HELPER_DIR/extract-desc.py" "$AGENT_SET" "$HELPER_DIR/list.json" 2>&1)" \
+  || smoke_fail "T3: extract-desc.py could not find description for $AGENT_SET in list --json"
+smoke_assert_eq "$DESC_STRING" "$LIST_DESC" "T3: list --json record carries description verbatim"
+
+# ---------------------------------------------------------------------------
+# T4: `agent describe <agent>` prints the description on stdout, exit 0
+# ---------------------------------------------------------------------------
+smoke_log "T4: agent describe <set-agent> prints description on stdout"
+DESCRIBE_OUT=""
+DESCRIBE_OUT="$(agb_agent describe "$AGENT_SET" 2>/dev/null)"
+DESCRIBE_RC=$?
+smoke_assert_eq "0" "$DESCRIBE_RC" "T4: agent describe rc==0 when desc is set"
+# stdout is the description + newline. Compare without the trailing newline.
+smoke_assert_eq "$DESC_STRING" "$DESCRIBE_OUT" "T4: stdout equals the roster description string"
+
+# ---------------------------------------------------------------------------
+# T5: unset agent — show emits hint, describe fails with stderr hint
+# ---------------------------------------------------------------------------
+smoke_log "T5a: agent show <unset-agent> emits the unset-description hint"
+SHOW_UNSET_OUT="$(agb_agent show "$AGENT_UNSET" 2>&1)" || smoke_fail "T5: show rc!=0 on unset"
+smoke_assert_contains "$SHOW_UNSET_OUT" "no description set" \
+  "T5a: text output carries the actionable unset hint"
+smoke_assert_contains "$SHOW_UNSET_OUT" "BRIDGE_AGENT_DESC[\"$AGENT_UNSET\"]" \
+  "T5a: text output names the roster key the operator should edit"
+
+smoke_log "T5b: agent describe <unset-agent> exits non-zero with no stdout"
+DESCRIBE_UNSET_STDOUT=""
+DESCRIBE_UNSET_STDERR=""
+DESCRIBE_UNSET_STDOUT="$(agb_agent describe "$AGENT_UNSET" 2>"$HELPER_DIR/describe-unset.err")"
+DESCRIBE_UNSET_RC=$?
+DESCRIBE_UNSET_STDERR="$(cat "$HELPER_DIR/describe-unset.err")"
+[[ $DESCRIBE_UNSET_RC -ne 0 ]] \
+  || smoke_fail "T5b: agent describe rc==0 on unset (expected non-zero), stdout='$DESCRIBE_UNSET_STDOUT' stderr='$DESCRIBE_UNSET_STDERR'"
+smoke_assert_eq "" "$DESCRIBE_UNSET_STDOUT" \
+  "T5b: agent describe stdout is empty on unset (caller piping value sees ''/empty)"
+smoke_assert_contains "$DESCRIBE_UNSET_STDERR" "BRIDGE_AGENT_DESC[\"$AGENT_UNSET\"]" \
+  "T5b: stderr hint names the roster key"
+smoke_assert_contains "$DESCRIBE_UNSET_STDERR" "agent-roster.local.sh" \
+  "T5b: stderr hint names the roster file"
+
+# ---------------------------------------------------------------------------
+# T6: declare -p BRIDGE_AGENT_DESC confirms assoc array form
+# ---------------------------------------------------------------------------
+smoke_log "T6: declare -p BRIDGE_AGENT_DESC confirms declare -A"
+DECLARE_OUT="$(roster_declare_p)" || true
+# Must start with `declare -A` — the assoc-array marker. A scalar export
+# (which #1213 forbids re-introducing) would show `declare --` instead.
+if [[ "$DECLARE_OUT" != "declare -A BRIDGE_AGENT_DESC="* ]]; then
+  smoke_fail "T6: declare -p does not report BRIDGE_AGENT_DESC as 'declare -A' (got: $DECLARE_OUT)"
+fi
+# And it must carry the AGENT_SET → DESC_STRING entry.
+smoke_assert_contains "$DECLARE_OUT" "[$AGENT_SET]=\"$DESC_STRING\"" \
+  "T6: declare -p carries the AGENT_SET → DESC_STRING entry"
+
+# ---------------------------------------------------------------------------
+# T7: env has no scalar BRIDGE_AGENT_DESC / BRIDGE_AGENT_DESCRIPTION export
+# ---------------------------------------------------------------------------
+smoke_log "T7: no scalar BRIDGE_AGENT_DESC or BRIDGE_AGENT_DESCRIPTION in env"
+ENV_DESC="$(env_has_scalar "BRIDGE_AGENT_DESC")"
+ENV_DESCRIPTION="$(env_has_scalar "BRIDGE_AGENT_DESCRIPTION")"
+smoke_assert_eq "" "$ENV_DESC" "T7a: env carries no scalar BRIDGE_AGENT_DESC export"
+smoke_assert_eq "" "$ENV_DESCRIPTION" "T7b: env carries no scalar BRIDGE_AGENT_DESCRIPTION export (#1213 fork prevention)"
+
+# ---------------------------------------------------------------------------
+# T8: agent describe -h / --help — universal help contract
+# ---------------------------------------------------------------------------
+smoke_log "T8: agent describe -h / --help print non-empty stdout with rc=0"
+for flag in -h --help; do
+  HELP_OUT="$(agb_agent describe "$flag" 2>&1)"
+  HELP_RC=$?
+  if [[ $HELP_RC -ne 0 ]]; then
+    smoke_fail "T8: agent describe $flag rc=$HELP_RC (expected 0)"
+  fi
+  if [[ ${#HELP_OUT} -eq 0 ]]; then
+    smoke_fail "T8: agent describe $flag stdout was empty (expected usage)"
+  fi
+  # The #1117 ERROR_MARKERS list forbids "지원하지 않는" / "등록된 에이전트:" /
+  # similar markers on a --help path. Spot-check the two most relevant.
+  for marker in "지원하지 않는" "등록된 에이전트:"; do
+    if [[ "$HELP_OUT" == *"$marker"* ]]; then
+      smoke_fail "T8: agent describe $flag output contained 1117 ERROR_MARKER '$marker'"
+    fi
+  done
+done
+
+smoke_log "passed"
+exit 0


### PR DESCRIPTION
## Summary

Lane I of v0.15.0-beta1 — Sean mid-flight addition. Operators on downstream installs (e.g. cosmax-crm server) saw their roster's admin agent (`patch`) with NO useful description; had to guess role from contextual signatures on issues. Bridge ALREADY HAS \`BRIDGE_AGENT_DESC\` schema (codex r1 critical correction — do NOT add \`BRIDGE_AGENT_DESCRIPTION\` duplicate). Real gap: weak defaults + no CLI getter + downstream installs never set descriptions.

## Implementation (codex r1 verbatim)

1. **\`bridge-init.sh\`**: admin default upgraded from terse \`"\$admin_agent admin role"\` to descriptive coordinator wording.
2. **\`agent-roster.local.example.sh\`**: added Admin/system role description examples section with 4 role exemplars (admin, codex pair, antigravity pair, system).
3. **\`bridge-agent.sh\`**: added \`agent describe <agent>\` read-only CLI getter with \`-h/--help\` handling (avoids #1114/#1117 help-drift class). Added show-unset hint at \`:2042-2044\` text mode.
4. **\`scripts/cli-help/agent-bridge-usage.txt\`**: \`agent describe\` examples added.
5. **\`docs/agent-runtime/admin-agent-convention.md\`**: NEW doc covering convention + distinction from \`BRIDGE_AGENT_CLASS\`.
6. **\`docs/agent-runtime/admin-protocol.md\`**: linked the new convention.
7. **\`scripts/smoke/I-agent-description-roster.sh\`**: 8 assertions (set/unset, JSON, list, describe success/fail, declare -A verification, no scalar export).
8. **\`scripts/ci-select-smoke.sh\`**: registered in \`add_all_required_static\` + bridge-agent/agent-bridge path arm + pre-docs case for example file.

## Schema fidelity

- ✅ Uses existing \`BRIDGE_AGENT_DESC\` assoc array (no new \`BRIDGE_AGENT_DESCRIPTION\`)
- ✅ NO scalar export of \`BRIDGE_AGENT_DESC\` (#1213 assoc-array/scalar collision class avoided)
- ✅ Read-only beta1 — no \`describe set\` write path
- ✅ NO A2A propagation (deferred to v0.15.0+)

## Test plan

- [x] I smoke: 8/8 PASS
- [x] 1117 help gate covers \`describe\` verb (not in KNOWN_BROKEN_VERBS)
- [x] 1115-cli-usage-drift T3 (Lane I's assertion) passes by hand-verified set equality
- [x] Regression set (G, F mock, H, beta27 set, iso-helper, lints, oss-preflight): all PASS
- [x] Verified with /opt/homebrew/bin/bash 5.3.9

Pre-existing failure (NOT introduced): 1115-cli-usage-drift T1 fails on base (\`iso-run missing from _top_valid\`) — reproduces on clean stabilize clone. Separate fix needed in \`agent-bridge\` to add \`iso-run\` to \`_top_valid\` array.

## Wave context

Lane I of v0.15.0-beta1. Lanes G + F + H all merged ahead. May need rebase against ci-select-smoke.sh additive line (beta27 pattern).