### PR TITLE
feat(watchdog): codex agent enumeration + on-demand rescan verb (#1233 + #1237, Lane ε)

### DIFF
--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -36,6 +36,23 @@ MANAGED_END = "<!-- END AGENT BRIDGE DOC MIGRATION -->"
 CLAUDE_REQUIRED_FILES = ("CLAUDE.md", "SOUL.md", "MEMORY-SCHEMA.md", "MEMORY.md", "SESSION-TYPE.md")
 # Backward-compat alias: legacy callers / tests reference REQUIRED_FILES.
 REQUIRED_FILES = CLAUDE_REQUIRED_FILES
+# #1237: Codex-runtime profile contract. Codex CLI reads ``AGENTS.md`` at
+# the agent home root; it has no SOUL.md / MEMORY*.md / SESSION-TYPE.md
+# equivalent (those are Claude-only conventions). ``.codex/hooks.json`` is
+# the engine's hook-policy file when present, used as an *optional* probe
+# below (a missing hooks.json is not drift — codex agents may legitimately
+# run without hooks configured).
+CODEX_REQUIRED_FILES = ("AGENTS.md",)
+CODEX_OPTIONAL_PROBES = (".codex/hooks.json",)
+# Known engine ids the watchdog has an explicit contract for. An engine
+# string outside this set is a *truly unknown* engine — the scanner emits
+# ``status="unsupported_engine_contract"`` for those rather than silently
+# classifying them ``ok`` (the old NON_CONTRACT_ENGINES allowlist behavior
+# for codex/antigravity). #1237 r1: "If no Codex-specific check is
+# implemented yet, status must say `unsupported_engine_contract` rather
+# than silently OK." The same principle applies to any future new engine
+# until a contract is added here.
+KNOWN_ENGINE_CONTRACTS = frozenset({"claude", "codex"})
 
 
 @dataclass
@@ -433,14 +450,36 @@ def heartbeat_age_seconds(agent_dir: Path) -> tuple[bool, int | None]:
 NON_ONBOARDING_SESSION_TYPES = frozenset({"dynamic", "cron"})
 
 
-# Engines with no Claude-runtime profile contract at the agent home root
-# — none of these CLIs read CLAUDE.md / SOUL.md / SESSION-TYPE.md, so the
-# watchdog must not assert profile drift on them. This is an explicit
-# allowlist, NOT "anything that isn't claude": a genuinely unknown engine
-# string stays under the conservative Claude-default contract so a new
-# engine surfaces as drift (prompting a watchdog update) instead of
-# silently skipping the check. Add a new exempt engine here.
-NON_CONTRACT_ENGINES = frozenset({"codex", "antigravity"})
+# #1237: Legacy alias for the "engines that get no required-file check
+# under the Claude-default path." Pre-#1237 this set was
+# ``frozenset({"codex", "antigravity"})``; codex has moved to its own
+# engine-native contract and antigravity now surfaces as
+# ``unsupported_engine_contract`` (see ``has_known_engine_contract``).
+# Kept as an empty allowlist so any downstream import keeps resolving
+# without behaviorally bringing back the silent-OK path.
+NON_CONTRACT_ENGINES: frozenset[str] = frozenset()
+
+
+def is_claude_engine(engine: str) -> bool:
+    """True when the engine string maps to the Claude contract (Claude or
+    the conservative empty-string default kept for legacy registry rows).
+    """
+    return engine in ("", "claude")
+
+
+def is_codex_engine(engine: str) -> bool:
+    """True when the engine string maps to the Codex contract (#1237)."""
+    return engine == "codex"
+
+
+def has_known_engine_contract(engine: str) -> bool:
+    """True when the watchdog has an implemented engine-native contract for
+    ``engine``. Engines outside this set are classified as
+    ``unsupported_engine_contract`` in :func:`classify_status` rather than
+    being silently held to the Claude default or silently classified ``ok``
+    (#1237 r1).
+    """
+    return is_claude_engine(engine) or is_codex_engine(engine)
 
 
 def has_home_profile_contract(engine: str, agent_source: str) -> bool:
@@ -448,21 +487,15 @@ def has_home_profile_contract(engine: str, agent_source: str) -> bool:
     home-profile contract: the ``CLAUDE_REQUIRED_FILES`` set, the managed
     ``CLAUDE.md`` block, and the ``SESSION-TYPE.md`` onboarding state.
 
-    Issues #905 / #907 each special-cased one slice of this — codex was
-    exempted from required files, the managed block, and onboarding;
-    dynamic agents were exempted from the managed block. A third engine
-    (``antigravity``, v0.14.5) then fell through to the Claude default and
-    surfaced as a false ``status=error`` on every scan, because none of
-    those three call sites knew about it. This predicate is the single
-    gate so a known exempt engine is exempt by construction.
+    Issues #905 / #907 each special-cased one slice of this. #1237 split
+    the Codex case out into its own engine-native contract (see
+    :func:`has_codex_profile_contract`) instead of leaving codex as a
+    silent-OK allowlist entry. ``has_home_profile_contract`` now means
+    *Claude-specific* contract.
 
     The contract holds for:
 
       - Claude agents, static or unknown-source.
-      - Any *unknown* engine string, static or unknown-source — the
-        conservative legacy default (#905). An unknown engine is held to
-        the contract so it surfaces as drift; the fix is to add it to
-        ``NON_CONTRACT_ENGINES`` once the watchdog is taught about it.
 
     The contract is waived for:
 
@@ -472,25 +505,45 @@ def has_home_profile_contract(engine: str, agent_source: str) -> bool:
         ``bridge_scaffold_agent_home``, so legitimately have no profile
         files, no managed block, and no SESSION-TYPE.md. The watchdog has
         no finer "scaffolded vs ad-hoc" signal than ``agent_source``.
-      - The known non-Claude engines in ``NON_CONTRACT_ENGINES``.
+      - Any non-Claude engine (codex has its own contract; unknown
+        engines surface as ``unsupported_engine_contract`` and do not
+        get the Claude-profile drift check overlaid on top).
     """
     if agent_source == "dynamic":
         return False
-    return engine not in NON_CONTRACT_ENGINES
+    return is_claude_engine(engine)
+
+
+def has_codex_profile_contract(engine: str, agent_source: str) -> bool:
+    """Whether the watchdog should hold this agent to the Codex contract
+    (``CODEX_REQUIRED_FILES``). Mirrors ``has_home_profile_contract`` but
+    gates on the codex engine string. Dynamic agents still get a full
+    exemption — they may legitimately be bare ad-hoc spawns (#907).
+    """
+    if agent_source == "dynamic":
+        return False
+    return is_codex_engine(engine)
 
 
 def required_profile_files(engine: str, agent_source: str = "") -> tuple[str, ...]:
     """Required profile-file set for an agent.
 
-    Returns ``CLAUDE_REQUIRED_FILES`` only for agents under the
-    home-profile contract (see :func:`has_home_profile_contract`); every
-    other agent returns an empty tuple so the missing-files check is a
-    no-op. ``agent_source`` defaults to ``""`` so a legacy positional
+    Returns the engine-appropriate required-file tuple:
+
+      - Claude under the home-profile contract → ``CLAUDE_REQUIRED_FILES``
+      - Codex under the engine-native contract (#1237) →
+        ``CODEX_REQUIRED_FILES``
+      - Anything else (dynamic source, unknown engine, antigravity) →
+        empty tuple so the missing-files check is a no-op.
+
+    ``agent_source`` defaults to ``""`` so a legacy positional
     ``required_profile_files(engine)`` call keeps the conservative
     Claude-default behavior for an unknown source.
     """
     if has_home_profile_contract(engine, agent_source):
         return CLAUDE_REQUIRED_FILES
+    if has_codex_profile_contract(engine, agent_source):
+        return CODEX_REQUIRED_FILES
     return ()
 
 
@@ -503,27 +556,38 @@ def classify_status(
     agent_source: str = "",
     engine: str = "claude",
 ) -> str:
-    # All three drift signals — missing required files, managed-block,
-    # onboarding staleness — are gated on the home-profile contract (see
-    # has_home_profile_contract). Known non-Claude engines have no
-    # SESSION-TYPE.md / managed-CLAUDE.md / required-file contract (#905,
-    # originally codex only — now also antigravity), and dynamic agents
-    # are ad-hoc spawns that legitimately land with
-    # `missing_managed_claude_block=yes` and `onboarding_state=pending`
-    # until their first run; flagging any of these is admin alert-fatigue
-    # for a condition admin cannot resolve (#907, #303/#304/#343
-    # anti-pattern). missing_files is gated here too so classify_status is
-    # internally consistent and does not depend on the caller having
-    # pre-emptied `required` via required_profile_files.
-    contract = has_home_profile_contract(engine, agent_source)
-    if missing_files and contract:
+    # Engine routing:
+    #   - Claude under contract: required files + managed block +
+    #     onboarding staleness drive error/warn (#905 / #907 gates apply).
+    #   - Codex under contract (#1237): required Codex files drive error;
+    #     managed-CLAUDE-block and onboarding signals are not part of the
+    #     Codex contract and are ignored.
+    #   - Dynamic source (any engine): the contract is waived (#907).
+    #     Broken links still surface as warn — that is real drift, not a
+    #     fresh-provision default.
+    #   - Unknown engines with no implemented contract (e.g. antigravity
+    #     until a contract is added): return ``unsupported_engine_contract``
+    #     so the operator sees the row instead of a silent ok (#1237 r1).
+    #     A dynamic agent on an unknown engine is still reported under
+    #     ``unsupported_engine_contract`` — its mere presence is the
+    #     watchdog signal here, not a per-file drift result.
+    claude_contract = has_home_profile_contract(engine, agent_source)
+    codex_contract = has_codex_profile_contract(engine, agent_source)
+    if not has_known_engine_contract(engine):
+        # Surface broken-link drift even on unknown-engine rows; that
+        # signal is engine-agnostic and never lies.
+        if broken_links:
+            return "warn"
+        return "unsupported_engine_contract"
+    if missing_files and (claude_contract or codex_contract):
         return "error"
+    # Claude-only signals: managed block + onboarding staleness.
     onboarding_stale = (
-        contract
+        claude_contract
         and onboarding_state in {"pending", "missing"}
         and session_type not in NON_ONBOARDING_SESSION_TYPES
     )
-    effective_missing_block = missing_block if contract else False
+    effective_missing_block = missing_block if claude_contract else False
     if broken_links or effective_missing_block or onboarding_stale:
         return "warn"
     return "ok"
@@ -563,15 +627,14 @@ def scan_agent(
         required = required_profile_files(engine, agent_source)
         missing_files = [name for name in required if not (agent_dir / name).exists()]
         # The `missing_managed_claude_block` FIELD records actual file
-        # state, so it is gated on engine alone, NOT the contract: any
-        # engine that could own a CLAUDE.md (Claude + unknown engines —
-        # same conservative set as the contract) gets a truthful field;
-        # the known non-Claude engines in NON_CONTRACT_ENGINES definitively
-        # don't own one. A dynamic Claude agent still gets an accurate
+        # state for engines that own a CLAUDE.md. Pre-#1237 this gated on
+        # the legacy ``NON_CONTRACT_ENGINES`` allowlist; with the codex
+        # contract now engine-native, the check is gated on the Claude
+        # engine directly. A dynamic Claude agent still gets an accurate
         # field — #907 keeps the field truthful and suppresses only the
-        # classification *signal*, which classify_status gates through
-        # has_home_profile_contract.
-        if engine not in NON_CONTRACT_ENGINES:
+        # classification *signal*, which ``classify_status`` gates through
+        # ``has_home_profile_contract``.
+        if is_claude_engine(engine):
             claude_text = read_text(agent_dir / "CLAUDE.md") if (agent_dir / "CLAUDE.md").exists() else ""
             missing_block = MANAGED_START not in claude_text or MANAGED_END not in claude_text
         else:
@@ -702,11 +765,35 @@ def render_markdown(
 
 def main() -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument("command", choices=("scan",))
+    # #1233: ``rescan`` is the operator-facing on-demand verb. Both
+    # commands run the same registry-anchored scanner; ``rescan`` adds
+    # report-file write-back so ``shared/watchdog/latest.md`` refreshes
+    # immediately (the daemon cooldown is in ``bridge-daemon.sh``'s
+    # ``process_watchdog_report`` and is therefore bypassed by construction
+    # when the operator drives the scanner directly). ``--agent <a>`` and
+    # ``--json`` work for both. ``scan`` is preserved as compatibility for
+    # the daemon tick + legacy ``watchdog scan <agent>`` callers.
+    parser.add_argument("command", choices=("scan", "rescan"))
     parser.add_argument("agents", nargs="*")
+    parser.add_argument(
+        "--agent",
+        action="append",
+        default=[],
+        dest="agent_flag",
+        help="scope the scan to a specific agent (repeatable; #1233)",
+    )
     parser.add_argument("--bridge-home", default=os.environ.get("BRIDGE_HOME", str(Path.home() / ".agent-bridge")))
     parser.add_argument("--agent-home-root", default=None)
     parser.add_argument("--json", action="store_true")
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        default=None,
+        help=(
+            "write the rendered report to <bridge_home>/shared/watchdog/latest.md "
+            "(default: true for rescan, false for scan)"
+        ),
+    )
     # Refs queue #4796: registry-anchored enumeration is the default. Orphan
     # directories under $BRIDGE_AGENT_HOME_ROOT no longer drive profile_drift
     # warns; they surface in the separate `orphan_directories` bucket. Pass
@@ -736,6 +823,22 @@ def main() -> int:
         help="path to a JSON file with the registry payload (test injection)",
     )
     args = parser.parse_args()
+
+    # #1233: ``--agent <name>`` (repeatable) is an alias for the existing
+    # positional ``agents`` selector. Merging here keeps the rest of the
+    # pipeline single-source (``args.agents``) without reshuffling the
+    # registry-anchored filter logic below.
+    if args.agent_flag:
+        args.agents = list(args.agents) + list(args.agent_flag)
+
+    # #1233: ``--apply`` defaults to True for ``rescan`` (the operator
+    # verb whose contract is "refresh latest.md right now"), and False for
+    # ``scan`` (the daemon-tick caller that already redirects stdout to
+    # the report file itself). An explicit ``--apply`` always wins.
+    if args.apply is None:
+        apply_to_report_file = args.command == "rescan"
+    else:
+        apply_to_report_file = bool(args.apply)
 
     bridge_home = Path(args.bridge_home).expanduser()
     agent_root = Path(args.agent_home_root).expanduser() if args.agent_home_root else bridge_home / "agents"
@@ -843,10 +946,31 @@ def main() -> int:
         "orphan_directories": orphan_directories,
         "agents": [asdict(item) for item in records],
     }
+    rendered_markdown = render_markdown(records, bridge_home, orphan_directories)
     if args.json:
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
-        print(render_markdown(records, bridge_home, orphan_directories), end="")
+        print(rendered_markdown, end="")
+    # #1233: write the markdown report to the canonical
+    # ``<bridge_home>/shared/watchdog/latest.md`` location so the operator
+    # who typed ``agent-bridge watchdog rescan`` sees the refresh
+    # immediately, without waiting for the next daemon tick. The daemon
+    # tick path (``bridge-daemon.sh:process_watchdog_report``) keeps
+    # writing the same file via stdout redirect, so steady-state behavior
+    # is unchanged. Existence of the parent directory is ensured here so
+    # the verb works on a fresh BRIDGE_HOME where the daemon has never
+    # ticked.
+    if apply_to_report_file:
+        report_path = bridge_home / "shared" / "watchdog" / "latest.md"
+        try:
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(rendered_markdown, encoding="utf-8")
+        except OSError as exc:
+            print(
+                f"[bridge-watchdog] failed to write report file {report_path}: {exc}",
+                file=sys.stderr,
+            )
+            return 1
     return 0
 
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -1120,7 +1120,15 @@ select_for_path() {
       # false-positive-reporting `missing_files: CLAUDE.md, SOUL.md, …`
       # on every cron tick. Pull 1108-watchdog-v2-workdir on every
       # watchdog move so the dual-tree confusion class stays caught.
-      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill queue
+      # v0.15.0-beta2 lane ε: #1233 adds the `watchdog rescan` verb
+      # (writes latest.md immediately, bypasses the daemon cooldown by
+      # construction); #1237 adds the engine-native Codex contract
+      # (validates AGENTS.md) and re-routes engines with no implemented
+      # contract to `unsupported_engine_contract` instead of silent OK.
+      # Pull ε-watchdog-rescan-codex on every watchdog move so a future
+      # PR cannot regress either contract or accidentally re-introduce
+      # the silent-codex / silent-unknown-engine path.
+      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill ε-watchdog-rescan-codex queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/watchdog-profile-contract.py
+++ b/scripts/smoke/watchdog-profile-contract.py
@@ -10,6 +10,15 @@
 # signals it gates. The regression of record is the antigravity engine
 # (v0.14.5) surfacing as a false status=error, plus the guard that a Claude
 # static agent with missing files must still classify as error.
+#
+# #1237 (v0.15.0-beta2 lane ε): Codex now has its own engine-native
+# contract — has_codex_profile_contract returns True for codex+static and
+# the required-file set is CODEX_REQUIRED_FILES (AGENTS.md). Engines that
+# have NO implemented contract (antigravity, any future engine string)
+# classify as ``unsupported_engine_contract`` instead of the pre-#1237
+# silent-OK or conservative-Claude-default behaviors — codex r1 directive:
+# "Unknown engines should remain conservative … status must say
+# `unsupported_engine_contract` rather than silently OK".
 
 import importlib.util
 import pathlib
@@ -32,9 +41,11 @@ def main() -> int:
     spec.loader.exec_module(module)
 
     has_contract = module.has_home_profile_contract
+    has_codex_contract = module.has_codex_profile_contract
     required_profile_files = module.required_profile_files
     classify_status = module.classify_status
     claude_required = module.CLAUDE_REQUIRED_FILES
+    codex_required = module.CODEX_REQUIRED_FILES
 
     failures: list[str] = []
 
@@ -44,21 +55,38 @@ def main() -> int:
         else:
             print(f"  PASS  {label} = {got!r}")
 
-    # --- has_home_profile_contract --------------------------------------
+    # --- has_home_profile_contract (Claude only post-#1237) -------------
     check("contract: claude+static", has_contract("claude", "static"), True)
     check("contract: claude+unknown-source", has_contract("claude", ""), True)
     check("contract: claude+dynamic", has_contract("claude", "dynamic"), False)
-    check("contract: codex+static", has_contract("codex", "static"), False)
-    check("contract: codex+dynamic", has_contract("codex", "dynamic"), False)
-    # The antigravity regression: a *known* newer engine must be exempt
-    # by construction (it is in NON_CONTRACT_ENGINES).
+    # has_home_profile_contract is the *Claude*-specific predicate. Codex
+    # under #1237 has its own engine-native contract (see
+    # has_codex_profile_contract below); it MUST return False from the
+    # Claude predicate so a codex agent does not get the Claude-profile
+    # drift overlay applied on top of its Codex check.
+    check("contract: codex+static (claude-side)", has_contract("codex", "static"), False)
+    check("contract: codex+dynamic (claude-side)", has_contract("codex", "dynamic"), False)
+    # antigravity and any future-unknown engine: not Claude — same path
+    # as codex from the Claude-predicate's POV. They differ in
+    # classify_status (codex has a contract; antigravity / future-engine
+    # surface as `unsupported_engine_contract`).
     check("contract: antigravity+static", has_contract("antigravity", "static"), False)
     check("contract: antigravity+dynamic", has_contract("antigravity", "dynamic"), False)
-    # An *unknown* engine string is NOT exempted — it stays under the
-    # conservative Claude-default contract so a new engine surfaces as
-    # drift instead of silently skipping the check.
-    check("contract: unknown-engine+static", has_contract("future-engine", "static"), True)
+    check("contract: unknown-engine+static", has_contract("future-engine", "static"), False)
     check("contract: unknown-engine+dynamic", has_contract("future-engine", "dynamic"), False)
+
+    # --- has_codex_profile_contract (#1237) ------------------------------
+    check("codex-contract: codex+static", has_codex_contract("codex", "static"), True)
+    check("codex-contract: codex+unknown-source", has_codex_contract("codex", ""), True)
+    # Dynamic codex is still waived (#907 fresh-provision rule applies
+    # regardless of engine).
+    check("codex-contract: codex+dynamic", has_codex_contract("codex", "dynamic"), False)
+    check("codex-contract: claude+static", has_codex_contract("claude", "static"), False)
+    check(
+        "codex-contract: antigravity+static",
+        has_codex_contract("antigravity", "static"),
+        False,
+    )
 
     # --- required_profile_files -----------------------------------------
     check(
@@ -71,7 +99,17 @@ def main() -> int:
         required_profile_files("claude"),
         claude_required,
     )
-    check("required: codex+static -> ()", required_profile_files("codex", "static"), ())
+    # #1237: codex now has its own required-file set.
+    check(
+        "required: codex+static -> CODEX_REQUIRED_FILES",
+        required_profile_files("codex", "static"),
+        codex_required,
+    )
+    check(
+        "required: codex+dynamic -> ()",
+        required_profile_files("codex", "dynamic"),
+        (),
+    )
     check(
         "required: antigravity+static -> ()",
         required_profile_files("antigravity", "static"),
@@ -82,11 +120,13 @@ def main() -> int:
         required_profile_files("claude", "dynamic"),
         (),
     )
-    # An unknown engine stays under the conservative contract.
+    # An unknown engine has no required-file set — it surfaces as
+    # `unsupported_engine_contract` in classify_status rather than being
+    # held to a conservative Claude default it has no business satisfying.
     check(
-        "required: unknown-engine+static -> CLAUDE_REQUIRED_FILES",
+        "required: unknown-engine+static -> ()",
         required_profile_files("future-engine", "static"),
-        claude_required,
+        (),
     )
 
     # --- classify_status: regression guard ------------------------------
@@ -99,27 +139,30 @@ def main() -> int:
         ),
         "error",
     )
-    # An unknown engine is held to the conservative contract: missing
-    # files still escalate to error.
+    # #1237: a codex static agent missing its Codex-required file must
+    # error. Pre-#1237 codex was a silent-OK allowlist entry; the
+    # engine-native contract means a real missing AGENTS.md now surfaces.
     check(
-        "classify: unknown-engine+static+missing-files -> error",
+        "classify: codex+static+missing-files -> error",
         classify_status(
-            ["CLAUDE.md"], [], "complete", False,
-            session_type="", agent_source="static", engine="future-engine",
+            ["AGENTS.md"], [], "missing", False,
+            session_type="unknown", agent_source="static", engine="codex",
         ),
         "error",
     )
-    # classify_status gates missing_files through the predicate too: a
-    # non-contract agent with missing_files passed in must not error,
-    # independent of whether the caller pre-emptied `required`.
+    # #1237: a codex static agent with no missing required files
+    # classifies ok. Claude-only signals (missing managed block, pending
+    # onboarding) are explicitly ignored for codex.
     check(
-        "classify: codex+static+missing-files -> ok",
+        "classify: codex+static+missing-block -> ok (claude-only signal)",
         classify_status(
-            ["CLAUDE.md"], [], "missing", False,
+            [], [], "missing", True,
             session_type="unknown", agent_source="static", engine="codex",
         ),
         "ok",
     )
+    # Dynamic agent of any engine: contract is fully waived (#907),
+    # caller-supplied missing_files passed in MUST NOT escalate.
     check(
         "classify: claude+dynamic+missing-files -> ok",
         classify_status(
@@ -128,18 +171,47 @@ def main() -> int:
         ),
         "ok",
     )
-
-    # --- classify_status: antigravity exemptions (the fix) --------------
-    # antigravity static with no profile files reported (required is now
-    # empty so missing_files is []), missing managed block, pending
-    # onboarding -> ok, not warn/error.
     check(
-        "classify: antigravity+static+missing-block -> ok",
+        "classify: codex+dynamic+missing-files -> ok",
+        classify_status(
+            ["AGENTS.md"], [], "pending", False,
+            session_type="dynamic", agent_source="dynamic", engine="codex",
+        ),
+        "ok",
+    )
+
+    # --- classify_status: unsupported-engine path (#1237 r1) -------------
+    # An engine with no implemented contract MUST classify as
+    # `unsupported_engine_contract` rather than silently OK or as an
+    # error against a contract it has no business being held to. The two
+    # call sites of record: antigravity (known but no contract yet) and
+    # any future-unknown engine.
+    check(
+        "classify: antigravity+static+missing-block -> unsupported_engine_contract",
         classify_status(
             [], [], "missing", True,
             session_type="unknown", agent_source="static", engine="antigravity",
         ),
-        "ok",
+        "unsupported_engine_contract",
+    )
+    check(
+        "classify: unknown-engine+static -> unsupported_engine_contract",
+        classify_status(
+            [], [], "complete", False,
+            session_type="", agent_source="static", engine="future-engine",
+        ),
+        "unsupported_engine_contract",
+    )
+    # Broken links are an engine-agnostic drift signal — even on an
+    # unsupported engine they surface as warn so a real misconfig is
+    # never silently dropped.
+    check(
+        "classify: antigravity+static+broken-links -> warn",
+        classify_status(
+            [], ["MEMORY.md -> missing"], "missing", False,
+            session_type="unknown", agent_source="static", engine="antigravity",
+        ),
+        "warn",
     )
 
     # --- classify_status: claude contract still enforced ----------------
@@ -160,7 +232,7 @@ def main() -> int:
         "warn",
     )
 
-    # --- classify_status: dynamic / codex exemptions (no regression) ----
+    # --- classify_status: dynamic exemptions (no regression) -------------
     check(
         "classify: claude+dynamic+missing-block -> ok",
         classify_status(
@@ -168,25 +240,6 @@ def main() -> int:
             session_type="dynamic", agent_source="dynamic", engine="claude",
         ),
         "ok",
-    )
-    check(
-        "classify: codex+static+missing-block -> ok",
-        classify_status(
-            [], [], "missing", True,
-            session_type="unknown", agent_source="static", engine="codex",
-        ),
-        "ok",
-    )
-
-    # broken_links is not gated by the contract — a genuine drift signal
-    # for any agent.
-    check(
-        "classify: antigravity+static+broken-links -> warn",
-        classify_status(
-            [], ["MEMORY.md -> missing"], "missing", False,
-            session_type="unknown", agent_source="static", engine="antigravity",
-        ),
-        "warn",
     )
 
     if failures:

--- a/scripts/smoke/watchdog-registry-anchored.sh
+++ b/scripts/smoke/watchdog-registry-anchored.sh
@@ -276,18 +276,23 @@ assert rows["baz"]["status"] == "error", rows["baz"]
 assert payload["problem_count"] == 1, f"expected 1 problem (baz drift), got {payload['problem_count']}"
 PY
 
-# --- C8: engine-aware profile check for codex agents (#905) -------------
-# Refs issue #905: the watchdog used to assert CLAUDE.md / SOUL.md / etc.
-# on every agent regardless of engine, so codex agents (which don't read
-# any of those files) surfaced as `status=error` with every Claude
-# profile file marked missing. With the engine-aware required-file
-# selector, codex agents with no Claude profile files classify as `ok`
-# and do NOT contribute to problem_count — so the daemon no longer emits
-# admin-inbox profile-drift tasks for codex agents.
-smoke_log "C8: codex agent without Claude-profile files classifies ok (#905)"
+# --- C8: engine-native Codex contract (#905 → #1237) --------------------
+# Pre-#905: the watchdog used to assert CLAUDE.md / SOUL.md / etc. on
+# every agent regardless of engine, so codex agents (which don't read
+# any of those files) surfaced as `status=error`.
+# Pre-#1237 (v0.15.0-beta1): codex was on a silent-OK allowlist —
+# present-but-bare codex agents classified as `ok` with no validation.
+# #1237 (v0.15.0-beta2 lane ε): codex has an engine-native contract:
+# AGENTS.md is required (the file the Codex CLI actually reads). A codex
+# agent that has AGENTS.md classifies as `ok` and does NOT assert any
+# Claude-profile files; a codex agent missing AGENTS.md surfaces as
+# error (see C8b below).
+smoke_log "C8: codex agent with AGENTS.md classifies ok (#1237)"
 C8_ROOT="$SMOKE_TMP_ROOT/c8-agents"
 mkdir -p "$C8_ROOT/codex-only"
-# Intentionally bare — no CLAUDE.md / SOUL.md / SESSION-TYPE.md / etc.
+: >"$C8_ROOT/codex-only/AGENTS.md"
+# Intentionally NO CLAUDE.md / SOUL.md / SESSION-TYPE.md — codex must
+# never assert those (the #905 fix).
 C8_REGISTRY="$SMOKE_TMP_ROOT/c8-registry.json"
 cat >"$C8_REGISTRY" <<'EOF'
 [
@@ -306,6 +311,30 @@ assert row["missing_files"] == [], f"codex must not assert Claude profile files:
 assert row["missing_managed_claude_block"] is False, row
 assert row["status"] == "ok", f"codex agent should classify ok, got {row['status']}"
 assert payload["problem_count"] == 0, payload["problem_count"]
+PY
+
+# --- C8b: codex agent missing AGENTS.md classifies error (#1237) --------
+# The Codex contract is fail-loud just like Claude's. A static codex
+# agent that is genuinely missing its required AGENTS.md surfaces.
+smoke_log "C8b: codex agent missing AGENTS.md classifies error (#1237)"
+C8B_ROOT="$SMOKE_TMP_ROOT/c8b-agents"
+mkdir -p "$C8B_ROOT/codex-bare"
+C8B_REGISTRY="$SMOKE_TMP_ROOT/c8b-registry.json"
+cat >"$C8B_REGISTRY" <<'EOF'
+[
+  {"id": "codex-bare", "class": "static", "agent_source": "static", "engine": "codex"}
+]
+EOF
+C8B_JSON="$(run_watchdog scan --json --agent-home-root "$C8B_ROOT" --agent-registry-json "$C8B_REGISTRY")"
+"$PY_BIN" - "$C8B_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+rows = {row["agent"]: row for row in payload["agents"]}
+row = rows["codex-bare"]
+assert row["engine"] == "codex", row
+assert row["missing_files"] == ["AGENTS.md"], f"codex must assert AGENTS.md: {row['missing_files']}"
+assert row["status"] == "error", f"codex bare agent should classify error, got {row['status']}"
+assert payload["problem_count"] == 1, payload["problem_count"]
 PY
 
 # --- C9: dynamic-agent fresh-state suppression (#907) -------------------

--- a/scripts/smoke/ε-watchdog-rescan-codex.sh
+++ b/scripts/smoke/ε-watchdog-rescan-codex.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# scripts/smoke/ε-watchdog-rescan-codex.sh — v0.15.0-beta2 lane ε
+# regression for issues #1233 (on-demand `watchdog rescan` verb) and
+# #1237 (engine-native Codex contract + `unsupported_engine_contract`
+# fall-through for engines with no implemented contract yet).
+#
+# Cases:
+#   T1. Static codex agent WITH AGENTS.md classifies ok.
+#   T2. Static codex agent missing AGENTS.md classifies error.
+#   T3. Static claude agent in the same fixture still scans under the
+#       Claude profile contract (no regression).
+#   T4. Antigravity agent (no implemented contract) classifies as
+#       `unsupported_engine_contract` rather than silently OK.
+#   T5. `bridge-watchdog.py rescan --agent <fixture>` runs the same
+#       scan and writes `<bridge_home>/shared/watchdog/latest.md`. The
+#       rescan path bypasses the daemon cooldown by construction (the
+#       cooldown gate lives in `bridge-daemon.sh:process_watchdog_report`
+#       and is therefore not on the operator-driven verb path).
+#   T6. The `scan` verb does NOT write to `latest.md` by default — the
+#       daemon tick contract (stdout-redirect to file) is preserved so a
+#       future caller that relies on the existing behavior does not get
+#       a silent double-write.
+#
+# Uses an isolated BRIDGE_HOME via smoke_setup_bridge_home so the
+# operator's live runtime is never touched.
+
+set -euo pipefail
+
+SMOKE_NAME="ε-watchdog-rescan-codex"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "epsilon-watchdog-rescan-codex"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+PY_BIN="${PYTHON3:-python3}"
+smoke_require_cmd "$PY_BIN"
+
+run_watchdog() {
+  "$PY_BIN" "$REPO_ROOT/bridge-watchdog.py" "$@"
+}
+
+# Seed the agents/ tree.
+AGENTS_ROOT="$BRIDGE_AGENT_HOME_ROOT"
+mkdir -p "$AGENTS_ROOT/codex-ok" \
+         "$AGENTS_ROOT/codex-missing" \
+         "$AGENTS_ROOT/claude-ok" \
+         "$AGENTS_ROOT/grav-unknown"
+
+# Claude-ok: full profile + managed CLAUDE.md block + onboarding complete.
+cat >"$AGENTS_ROOT/claude-ok/CLAUDE.md" <<'EOF'
+<!-- BEGIN AGENT BRIDGE DOC MIGRATION -->
+managed
+<!-- END AGENT BRIDGE DOC MIGRATION -->
+EOF
+: >"$AGENTS_ROOT/claude-ok/SOUL.md"
+: >"$AGENTS_ROOT/claude-ok/MEMORY-SCHEMA.md"
+: >"$AGENTS_ROOT/claude-ok/MEMORY.md"
+cat >"$AGENTS_ROOT/claude-ok/SESSION-TYPE.md" <<'EOF'
+# Session Type
+
+- Session Type: static-claude
+- Onboarding State: complete
+EOF
+
+# Codex-ok: AGENTS.md present.
+: >"$AGENTS_ROOT/codex-ok/AGENTS.md"
+
+# Codex-missing: empty home dir, no AGENTS.md.
+# (intentionally empty)
+
+# Antigravity (no contract implemented yet): empty home dir.
+# (intentionally empty)
+
+REGISTRY_JSON="$SMOKE_TMP_ROOT/registry.json"
+cat >"$REGISTRY_JSON" <<'EOF'
+[
+  {"id": "codex-ok", "class": "static", "agent_source": "static", "engine": "codex"},
+  {"id": "codex-missing", "class": "static", "agent_source": "static", "engine": "codex"},
+  {"id": "claude-ok", "class": "static", "agent_source": "static", "engine": "claude"},
+  {"id": "grav-unknown", "class": "static", "agent_source": "static", "engine": "antigravity"}
+]
+EOF
+
+# --- T1 / T2 / T3 / T4 — engine-native contract truth table -------------
+smoke_log "T1-T4: engine-aware classify across codex/claude/antigravity"
+SCAN_JSON="$(run_watchdog scan --json --agent-registry-json "$REGISTRY_JSON")"
+"$PY_BIN" - "$SCAN_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+rows = {row["agent"]: row for row in payload["agents"]}
+assert set(rows) == {"codex-ok", "codex-missing", "claude-ok", "grav-unknown"}, sorted(rows)
+
+# T1: codex with AGENTS.md → ok, no Claude-profile assertions.
+row = rows["codex-ok"]
+assert row["engine"] == "codex", row
+assert row["status"] == "ok", f"T1: expected ok, got {row['status']}"
+assert row["missing_files"] == [], f"T1: codex must not assert Claude files: {row['missing_files']}"
+assert row["missing_managed_claude_block"] is False, f"T1: codex must not assert managed block: {row}"
+
+# T2: codex missing AGENTS.md → error.
+row = rows["codex-missing"]
+assert row["engine"] == "codex", row
+assert row["status"] == "error", f"T2: expected error, got {row['status']}"
+assert row["missing_files"] == ["AGENTS.md"], f"T2: expected [AGENTS.md], got {row['missing_files']}"
+
+# T3: claude under Claude contract still classifies ok with full profile.
+row = rows["claude-ok"]
+assert row["engine"] == "claude", row
+assert row["status"] == "ok", f"T3: expected ok for full Claude profile, got {row['status']}"
+
+# T4: antigravity (no contract implemented) → unsupported_engine_contract.
+# Pre-#1237 (and pre-r1) this would have classified as silent ok. The
+# operator-visible status forces the watchdog to be honest about
+# coverage gaps for engines it doesn't yet validate.
+row = rows["grav-unknown"]
+assert row["engine"] == "antigravity", row
+assert row["status"] == "unsupported_engine_contract", (
+    f"T4: expected unsupported_engine_contract for engine without contract, got {row['status']}"
+)
+
+# unsupported_engine_contract counts as a problem so latest.md surfaces
+# the gap. (broken_links-only on unknown engines would warn — covered in
+# watchdog-profile-contract.py.)
+problem_rows = [r for r in payload["agents"] if r["status"] != "ok"]
+assert payload["problem_count"] == len(problem_rows), (
+    payload["problem_count"], len(problem_rows)
+)
+PY
+
+# --- T5 — rescan verb writes latest.md immediately (#1233) --------------
+# The brief calls out a "large watchdog cooldown set, rescan runs
+# immediately + JSON emitted" check. The daemon cooldown lives in
+# `bridge-daemon.sh:process_watchdog_report` and is consulted only on
+# the daemon tick path; the rescan verb invokes the scanner directly and
+# is therefore never gated by it. We assert the immediate write to
+# `<bridge_home>/shared/watchdog/latest.md` and that JSON is well-formed.
+smoke_log "T5: rescan writes latest.md + emits valid JSON"
+REPORT_FILE="$BRIDGE_HOME/shared/watchdog/latest.md"
+[[ ! -e "$REPORT_FILE" ]] || smoke_fail "T5 precondition: report file must not exist before rescan"
+
+# Set a deliberately huge daemon-side cooldown env to prove rescan does
+# NOT consult it. (The daemon path consults it via process_watchdog_report
+# in bridge-daemon.sh; the Python scanner itself never reads this env so
+# this is a no-op on the operator verb path — exactly the property under
+# test.)
+BRIDGE_WATCHDOG_COOLDOWN_SECONDS=86400 \
+RESCAN_JSON="$(run_watchdog rescan --json --agent codex-ok --agent-registry-json "$REGISTRY_JSON")"
+"$PY_BIN" - "$RESCAN_JSON" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+# --agent scoping (#1233) — only the targeted agent appears in the rows.
+ids = {row["agent"] for row in payload["agents"]}
+assert ids == {"codex-ok"}, f"T5: expected scoped scan to return only codex-ok, got {ids}"
+PY
+
+# rescan must have written the report file (apply defaults to True for
+# rescan; see bridge-watchdog.py:main).
+[[ -f "$REPORT_FILE" ]] || smoke_fail "T5: rescan did not write $REPORT_FILE"
+if ! grep -q '^# Watchdog Report' "$REPORT_FILE"; then
+  smoke_fail "T5: latest.md does not contain the expected header: $(head -3 "$REPORT_FILE")"
+fi
+if ! grep -q '^## codex-ok' "$REPORT_FILE"; then
+  smoke_fail "T5: latest.md missing codex-ok row: $(cat "$REPORT_FILE")"
+fi
+
+# --- T6 — scan verb does NOT write to latest.md by default --------------
+# The daemon tick path uses `bridge-watchdog.sh scan >latest.md` (stdout
+# redirect). The Python `scan` command must not also write the file by
+# itself — that would be a silent double-write whose contents could
+# differ if a future change adds non-stdout-emitted state.
+smoke_log "T6: scan verb does not write latest.md (preserves daemon contract)"
+rm -f "$REPORT_FILE"
+run_watchdog scan --json --agent claude-ok --agent-registry-json "$REGISTRY_JSON" >/dev/null
+if [[ -e "$REPORT_FILE" ]]; then
+  smoke_fail "T6: scan verb wrote $REPORT_FILE — must be rescan-only by default"
+fi
+
+# T6b: scan --apply is the explicit opt-in for the daemon / any future
+# caller that wants the file written without switching verbs.
+run_watchdog scan --json --apply --agent claude-ok --agent-registry-json "$REGISTRY_JSON" >/dev/null
+[[ -f "$REPORT_FILE" ]] || smoke_fail "T6b: scan --apply did not write $REPORT_FILE"
+
+smoke_log "PASS"


### PR DESCRIPTION
Closes #1233 + #1237. Lane ε of v0.15.0-beta2 7-lane wave.

#1237: engine-native Codex contract added. `AGENTS.md` required (per `lib/bridge-engine-descriptor.sh:47`). Antigravity moves from silent-OK to `unsupported_engine_contract` per codex r1. NO removal of codex from NON_CONTRACT_ENGINES (would false-flag for missing Claude files).

#1233: `agent-bridge watchdog scan|rescan [--agent <a>] [--json] [--apply]` verb. `rescan` bypasses daemon cooldown (operator-explicit only). Daemon tick path keeps existing cooldown semantics. `bridge-watchdog.sh scan` kept for compat.

- `bridge-watchdog.py`, `bridge-watchdog.sh`, `agent-bridge` dispatch
- 6/6 watchdog smokes PASS (1 new + 5 pre-existing)