### PR TITLE
fix(a2a): #1262 — A2A 3 gaps (Gap 1 scaffold + Gap 2 verify + Gap 3 stuck alerting) [beta4 Lane I]

### DIFF
--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -594,6 +594,146 @@ def cmd_sync_aliveness_parse(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_a2a_stuck_decide(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh process_a2a_outbox_stuck_scan_tick.
+
+    Issue #1262 Gap 3 (v0.15.0-beta4 Lane I, 2026-05-27).
+
+    Decide which outbox rows have been stuck long enough to deserve an
+    admin task, honoring the per-message re-emit cooldown ledger.
+
+    Input:
+      now            — current epoch seconds (int)
+      stuck_secs     — threshold (row.age_seconds > this → candidate)
+      reemit_secs    — re-emit cooldown per message_id
+      ledger_path    — JSON file: { message_id: last_emitted_ts }
+      outbox_json_path — JSON array from `agb a2a outbox list --json`
+
+    Output (stdout, one TSV row per row to alert):
+      message_id \\t peer \\t target_agent \\t status \\t attempts \\t
+      age_seconds \\t last_error
+
+    Side effect: rewrites `ledger_path` with the updated
+    last-emitted-ts for each row we just decided to alert on. Rows
+    that no longer appear in the outbox (peer drop, gc) are pruned so
+    the ledger does not grow unboundedly.
+
+    Errors are swallowed (return 0 with no output) — the daemon tick
+    must not crash on a malformed ledger or JSON parse failure;
+    operator visibility through audit + log is the recovery path.
+    """
+    try:
+        now = int(args.now)
+        stuck_secs = int(args.stuck_secs)
+        reemit_secs = int(args.reemit_secs)
+    except Exception:
+        return 0
+
+    ledger_path = args.ledger_path
+    outbox_json_path = args.outbox_json_path
+
+    ledger: dict = {}
+    try:
+        with open(ledger_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            for k, v in data.items():
+                try:
+                    ledger[str(k)] = int(v)
+                except Exception:
+                    continue
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        ledger = {}
+
+    try:
+        with open(outbox_json_path, "r", encoding="utf-8") as fh:
+            rows = json.load(fh)
+        if not isinstance(rows, list):
+            rows = []
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        rows = []
+
+    # `age_seconds` is enriched by bridge-a2a.py cmd_outbox already; we
+    # fall back to (now - created_ts) when the field is absent so the
+    # helper stays robust to upstream shape drift.
+    seen_ids = set()
+    emitted_now = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        message_id = str(row.get("message_id") or "")
+        if not message_id:
+            continue
+        seen_ids.add(message_id)
+        status = str(row.get("status") or "")
+        # Only pending/retry rows are alert-worthy. acked = success,
+        # sending = currently being attempted, dead = the retry loop
+        # already gave up — separate signal not to confuse with stuck.
+        if status not in ("pending", "retry"):
+            continue
+        try:
+            age = int(row.get("age_seconds") or 0)
+        except Exception:
+            age = 0
+        if age <= 0:
+            try:
+                created_ts = int(row.get("created_ts") or 0)
+            except Exception:
+                created_ts = 0
+            if created_ts > 0:
+                age = max(0, now - created_ts)
+        if age < stuck_secs:
+            continue
+        last_emit = ledger.get(message_id, 0)
+        if last_emit and (now - last_emit) < reemit_secs:
+            continue
+        emitted_now.append({
+            "message_id": message_id,
+            "peer": str(row.get("peer") or ""),
+            "target_agent": str(row.get("target_agent") or ""),
+            "status": status,
+            "attempts": int(row.get("attempts") or 0),
+            "age_seconds": age,
+            "last_error": str(row.get("last_error") or "").replace("\t", " ").replace("\n", " "),
+        })
+
+    for r in emitted_now:
+        print(
+            f"{r['message_id']}\t{r['peer']}\t{r['target_agent']}\t"
+            f"{r['status']}\t{r['attempts']}\t{r['age_seconds']}\t{r['last_error']}"
+        )
+
+    # Update ledger: stamp emitted rows, prune entries for message_ids
+    # no longer in the outbox (peer-drop or gc).
+    new_ledger = {}
+    for k, v in ledger.items():
+        if k in seen_ids:
+            new_ledger[k] = v
+    for r in emitted_now:
+        new_ledger[str(r["message_id"])] = now
+
+    # Atomic rewrite — tmp-write + os.replace so a crash mid-write
+    # cannot leave the ledger in a half-state.
+    try:
+        import os
+        import tempfile
+        ledger_dir = os.path.dirname(ledger_path) or "."
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=ledger_dir,
+            prefix=".stuck-alerts.", suffix=".tmp", delete=False,
+        ) as tmp:
+            json.dump(new_ledger, tmp, ensure_ascii=False)
+            tmp_path = tmp.name
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, ledger_path)
+    except OSError:
+        # Ledger update failure is non-fatal — worst case is a
+        # duplicate alert next tick (cooldown not respected once).
+        pass
+
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # CLI plumbing.
 # ---------------------------------------------------------------------------
@@ -697,6 +837,19 @@ SUBCOMMANDS = {
         cmd_sync_aliveness_parse,
         [("sync_json", "JSON envelope from bridge-auth.sh claude-token sync --json")],
         "Per-agent aliveness/remaining_ms (3 tab-separated cols / row). Empty on parse failure.",
+    ),
+    # Issue #1262 Gap 3 (v0.15.0-beta4 Lane I): outbox stuck-alert
+    # decision helper. See cmd_a2a_stuck_decide.
+    "a2a-stuck-decide": (
+        cmd_a2a_stuck_decide,
+        [
+            ("now", "current epoch seconds (int)"),
+            ("stuck_secs", "row.age_seconds threshold above which the row is candidate"),
+            ("reemit_secs", "per-message re-emit cooldown in seconds"),
+            ("ledger_path", "JSON file recording last-emitted-ts per message_id"),
+            ("outbox_json_path", "JSON file containing `agb a2a outbox list --json` output"),
+        ],
+        "One tab-separated row per stuck row that crossed the threshold and cooldown.",
     ),
 }
 

--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -598,9 +598,18 @@ def cmd_a2a_stuck_decide(args: argparse.Namespace) -> int:
     """Original site: bridge-daemon.sh process_a2a_outbox_stuck_scan_tick.
 
     Issue #1262 Gap 3 (v0.15.0-beta4 Lane I, 2026-05-27).
+    Codex r1 BLOCKING (v0.15.0-beta4 Lane I r2, 2026-05-27): split
+    decide vs ack/stamp so the ledger is only updated AFTER the admin
+    task has been filed successfully. Otherwise a transient
+    bridge-task.sh failure starts the reemit cooldown without any
+    admin task existing — the operator never learns about the stuck
+    row.
 
     Decide which outbox rows have been stuck long enough to deserve an
     admin task, honoring the per-message re-emit cooldown ledger.
+    Pure read — does NOT modify the ledger; the daemon shell calls
+    ``a2a-stuck-ack`` AFTER successfully creating the admin task to
+    stamp the ledger atomically.
 
     Input:
       now            — current epoch seconds (int)
@@ -612,11 +621,6 @@ def cmd_a2a_stuck_decide(args: argparse.Namespace) -> int:
     Output (stdout, one TSV row per row to alert):
       message_id \\t peer \\t target_agent \\t status \\t attempts \\t
       age_seconds \\t last_error
-
-    Side effect: rewrites `ledger_path` with the updated
-    last-emitted-ts for each row we just decided to alert on. Rows
-    that no longer appear in the outbox (peer drop, gc) are pruned so
-    the ledger does not grow unboundedly.
 
     Errors are swallowed (return 0 with no output) — the daemon tick
     must not crash on a malformed ledger or JSON parse failure;
@@ -703,14 +707,106 @@ def cmd_a2a_stuck_decide(args: argparse.Namespace) -> int:
             f"{r['status']}\t{r['attempts']}\t{r['age_seconds']}\t{r['last_error']}"
         )
 
-    # Update ledger: stamp emitted rows, prune entries for message_ids
-    # no longer in the outbox (peer-drop or gc).
-    new_ledger = {}
-    for k, v in ledger.items():
-        if k in seen_ids:
-            new_ledger[k] = v
-    for r in emitted_now:
-        new_ledger[str(r["message_id"])] = now
+    # NOTE (r2 split, codex r1 BLOCKING): we DO NOT modify the ledger
+    # here. The daemon shell calls ``a2a-stuck-ack`` after each
+    # successful admin task create. Ledger stamping + pruning lives
+    # in ``cmd_a2a_stuck_ack``.
+
+    return 0
+
+
+def cmd_a2a_stuck_ack(args: argparse.Namespace) -> int:
+    """Original site: bridge-daemon.sh process_a2a_outbox_stuck_scan_tick.
+
+    Issue #1262 Gap 3 / v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING).
+
+    Stamp the stuck-alert ledger ONLY for outbox rows whose admin task
+    was successfully filed by the daemon shell. Without this split, a
+    transient `bridge-task.sh create` failure would advance the
+    re-emit cooldown for a row that never produced an admin task —
+    the operator silently loses the alert until the cooldown lapses.
+
+    Input (positional):
+      now              — current epoch seconds (int)
+      ledger_path      — JSON file: { message_id: last_emitted_ts }
+      row_keys_file    — UTF-8 text file with one message_id per
+                         non-empty line. The shell writes successful
+                         task-create message_ids here; empty file is
+                         legal (no rows to stamp, but pruning still
+                         runs).
+      outbox_json_path — JSON array from `agb a2a outbox list --json`
+                         used for ledger pruning (entries whose
+                         message_id is no longer in the outbox are
+                         dropped so the ledger does not grow
+                         unboundedly).
+
+    Atomic rewrite via tempfile + os.replace. Errors are swallowed —
+    worst case is a duplicate alert next tick.
+
+    rc=0 on every path so the daemon loop never crashes on a
+    malformed ledger / row-keys file.
+    """
+    try:
+        now = int(args.now)
+    except Exception:
+        return 0
+
+    ledger_path = args.ledger_path
+    row_keys_file = args.row_keys_file
+    outbox_json_path = args.outbox_json_path
+
+    ledger: dict = {}
+    try:
+        with open(ledger_path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        if isinstance(data, dict):
+            for k, v in data.items():
+                try:
+                    ledger[str(k)] = int(v)
+                except Exception:
+                    continue
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        ledger = {}
+
+    # Successful task-create keys (one per line, blank lines skipped).
+    ack_keys: list = []
+    try:
+        with open(row_keys_file, "r", encoding="utf-8") as fh:
+            for raw in fh:
+                key = raw.strip()
+                if key:
+                    ack_keys.append(key)
+    except (FileNotFoundError, OSError):
+        ack_keys = []
+
+    # Current outbox for pruning. Missing/malformed → skip prune (keep
+    # ledger as-is) rather than wipe entries we still care about.
+    seen_ids: set = set()
+    prune_known = False
+    try:
+        with open(outbox_json_path, "r", encoding="utf-8") as fh:
+            rows = json.load(fh)
+        if isinstance(rows, list):
+            prune_known = True
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                message_id = str(row.get("message_id") or "")
+                if message_id:
+                    seen_ids.add(message_id)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        prune_known = False
+
+    new_ledger: dict = {}
+    if prune_known:
+        for k, v in ledger.items():
+            if k in seen_ids:
+                new_ledger[k] = v
+    else:
+        new_ledger = dict(ledger)
+
+    for key in ack_keys:
+        new_ledger[str(key)] = now
 
     # Atomic rewrite — tmp-write + os.replace so a crash mid-write
     # cannot leave the ledger in a half-state.
@@ -850,6 +946,25 @@ SUBCOMMANDS = {
             ("outbox_json_path", "JSON file containing `agb a2a outbox list --json` output"),
         ],
         "One tab-separated row per stuck row that crossed the threshold and cooldown.",
+    ),
+    # Issue #1262 Gap 3 / v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING):
+    # stamp the ledger ONLY after the daemon shell successfully filed
+    # the admin task. See cmd_a2a_stuck_ack.
+    "a2a-stuck-ack": (
+        cmd_a2a_stuck_ack,
+        [
+            ("now", "current epoch seconds (int)"),
+            ("ledger_path", "JSON file recording last-emitted-ts per message_id"),
+            (
+                "row_keys_file",
+                "UTF-8 text file with one successful-task-create message_id per line",
+            ),
+            (
+                "outbox_json_path",
+                "JSON file containing `agb a2a outbox list --json` output (for prune)",
+            ),
+        ],
+        "Stamp ledger for successful task-create rows + prune entries missing from outbox.",
     ),
 }
 

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2261,6 +2261,209 @@ process_a2a_deliver_tick() {
   return 0
 }
 
+# Issue #1262 Gap 3 (v0.15.0-beta4 Lane I, 2026-05-27): outbox stuck alerting.
+#
+# `process_a2a_deliver_tick` keeps the runner ticking, and the existing
+# `_schedule_retry` exponential-backoff path moves bad rows toward
+# `status='dead'` after `delivery_max_attempts`. What is still missing
+# is operator visibility for the "valid config, valid peer, but the
+# peer just is not reachable for a while" case: the runner keeps
+# retrying with growing backoff, and the row legitimately stays in
+# `status='retry'` for hours. The operator doesn't see anything go
+# wrong until they manually `agb a2a outbox list` — by then the
+# downstream peer might have lost context for what the message was
+# about.
+#
+# This tick scans the outbox once per
+# `BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS` (default 300 = 5 min)
+# for rows that have been pending+retry-stuck longer than
+# `BRIDGE_A2A_STUCK_ALERT_SECS` (default 600 = 10 min, anchored on
+# `created_ts`). For each row that crosses the threshold, a task is
+# created for the admin agent. A per-message reemit guard
+# (`BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS`, default 3600 = 1 h) prevents
+# the same row from re-emitting on every scan.
+#
+# No-ops silently when handoff.local.json is absent (no A2A install).
+# State (last scan + per-message last-alerted-ts ledger) lives under
+# `$BRIDGE_STATE_DIR/handoff/stuck-alerts.json` so the daemon can
+# survive restarts without re-spamming.
+process_a2a_outbox_stuck_scan_tick() {
+  local interval_str="${BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS:-300}"
+  local interval
+  if [[ "$interval_str" =~ ^[0-9]+$ ]]; then
+    interval="$interval_str"
+  else
+    daemon_warn "[a2a_stuck_scan] invalid BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS=$interval_str (must be a non-negative integer); skipping"
+    return 1
+  fi
+  (( interval == 0 )) && return 1
+
+  local config="${BRIDGE_A2A_CONFIG:-${BRIDGE_HOME:-$HOME/.agent-bridge}/handoff.local.json}"
+  [[ -f "$config" ]] || return 1
+
+  local stuck_secs="${BRIDGE_A2A_STUCK_ALERT_SECS:-600}"
+  local reemit_secs="${BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS:-3600}"
+  if ! [[ "$stuck_secs" =~ ^[0-9]+$ ]]; then
+    daemon_warn "[a2a_stuck_scan] invalid BRIDGE_A2A_STUCK_ALERT_SECS=$stuck_secs; skipping"
+    return 1
+  fi
+  if ! [[ "$reemit_secs" =~ ^[0-9]+$ ]]; then
+    daemon_warn "[a2a_stuck_scan] invalid BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS=$reemit_secs; skipping"
+    return 1
+  fi
+
+  local handoff_dir="$BRIDGE_STATE_DIR/handoff"
+  mkdir -p "$handoff_dir" 2>/dev/null || true
+  local tick_state="$handoff_dir/stuck-scan-tick.env"
+  local now next=0
+  now="$(date +%s)"
+  if [[ -f "$tick_state" ]]; then
+    # shellcheck source=/dev/null
+    # shellcheck disable=SC1090
+    source "$tick_state" 2>/dev/null || true
+    next="${A2A_STUCK_SCAN_NEXT_TS:-0}"
+  fi
+  if [[ "$next" =~ ^[0-9]+$ ]] && (( now < next )); then
+    return 1
+  fi
+
+  # Admin agent — the queue task target. If unset (init not yet
+  # completed), skip silently; the deliver tick already covers the case
+  # where A2A is half-configured.
+  local admin="${BRIDGE_ADMIN_AGENT_ID:-}"
+  if [[ -z "$admin" ]]; then
+    # Persist throttle state so the no-admin scan doesn't busy-spin.
+    printf 'A2A_STUCK_SCAN_LAST_TS=%s\nA2A_STUCK_SCAN_NEXT_TS=%s\nA2A_STUCK_SCAN_LAST_EMITTED=0\n' \
+      "$now" "$((now + interval))" >"$tick_state" 2>/dev/null || true
+    return 1
+  fi
+
+  # Live install's CLI preferred — see process_daily_backup_failure_task.
+  local target_bridge=""
+  if [[ -x "$BRIDGE_HOME/agent-bridge" ]]; then
+    target_bridge="$BRIDGE_HOME/agent-bridge"
+  elif [[ -x "$SCRIPT_DIR/agent-bridge" ]]; then
+    target_bridge="$SCRIPT_DIR/agent-bridge"
+  else
+    return 1
+  fi
+
+  # Ledger of last-alerted timestamps per message_id (JSON dict). A bash
+  # associative array would be ideal but we'd lose it across daemon
+  # restarts; the ledger file gives us durability.
+  local ledger_file="$handoff_dir/stuck-alerts.json"
+  if [[ ! -f "$ledger_file" ]]; then
+    printf '{}\n' >"$ledger_file" 2>/dev/null || true
+    chmod 0600 "$ledger_file" 2>/dev/null || true
+  fi
+
+  # Pull the outbox listing as JSON — this is the same `agb a2a outbox
+  # list --json` path the operator uses, so the row shape is the
+  # canonical one declared by bridge_a2a_common.py's _OUTBOX_SCHEMA +
+  # the cmd_outbox enrichment (age_seconds / due_for_seconds /
+  # next_attempt_in_seconds). Wrap with bridge_with_timeout so a hung
+  # SQLite cannot wedge the daemon. Write JSON to a tmp file rather than
+  # piping via $() — footgun #11 (Bash 5.3.9 here-string / heredoc-stdin
+  # wedge) recommends file-as-argv for any subprocess that may emit
+  # large output.
+  local list_tmp emit_tmp
+  list_tmp="$(mktemp "${TMPDIR:-/tmp}/bridge-a2a-stuck-list.XXXXXX" 2>/dev/null)" || {
+    daemon_warn "[a2a_stuck_scan] mktemp failed; skipping"
+    return 1
+  }
+  emit_tmp="$(mktemp "${TMPDIR:-/tmp}/bridge-a2a-stuck-emit.XXXXXX" 2>/dev/null)" || {
+    rm -f "$list_tmp"
+    daemon_warn "[a2a_stuck_scan] mktemp failed; skipping"
+    return 1
+  }
+
+  local list_rc=0
+  bridge_with_timeout 30 a2a_outbox_list \
+    python3 "$SCRIPT_DIR/bridge-a2a.py" outbox list --json >"$list_tmp" 2>/dev/null || list_rc=$?
+  if (( list_rc != 0 )); then
+    daemon_warn "[a2a_stuck_scan] outbox list rc=$list_rc; skipping this tick"
+    rm -f "$list_tmp" "$emit_tmp"
+    printf 'A2A_STUCK_SCAN_LAST_TS=%s\nA2A_STUCK_SCAN_NEXT_TS=%s\nA2A_STUCK_SCAN_LAST_EMITTED=0\n' \
+      "$now" "$((now + interval))" >"$tick_state" 2>/dev/null || true
+    return 0
+  fi
+
+  # Parse + emit decisions in python3 — too much JSON+ledger logic to
+  # keep cleanly in bash. The helper writes one TSV row per row that
+  # needs an admin task:
+  #   message_id\tpeer\ttarget_agent\tstatus\tattempts\tage_seconds\tlast_error
+  # and rewrites the ledger file to reflect the new last-alerted-ts for
+  # each emitted row. Pass JSON via --outbox-json-file (path) rather
+  # than stdin — same footgun #11 reasoning.
+  bridge_with_timeout 10 a2a_stuck_decide \
+    python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" a2a-stuck-decide \
+      "$now" "$stuck_secs" "$reemit_secs" "$ledger_file" "$list_tmp" \
+      >"$emit_tmp" 2>/dev/null || true
+
+  # Each non-empty TSV line is one admin task to file. Iterate via file
+  # redirect (avoids `done <<<` heredoc_write wedge).
+  local emitted=0
+  while IFS=$'\t' read -r message_id peer target_agent status attempts age_seconds last_error; do
+    [[ -z "$message_id" ]] && continue
+    local body_file
+    body_file="$(mktemp "${TMPDIR:-/tmp}/bridge-a2a-stuck.md.XXXXXX" 2>/dev/null || printf '%s' "/tmp/bridge-a2a-stuck.$$.$RANDOM")"
+    {
+      printf '# A2A outbox entry stuck\n\n'
+      printf 'An outbound handoff has been waiting in the A2A outbox\n'
+      printf 'longer than the configured threshold without being\n'
+      printf 'acknowledged by the destination peer.\n\n'
+      printf '## Entry\n\n'
+      printf '- message_id: `%s`\n' "$message_id"
+      printf '- peer: `%s`\n' "$peer"
+      printf '- target_agent: `%s`\n' "$target_agent"
+      printf '- status: `%s`\n' "$status"
+      printf '- attempts: %s\n' "$attempts"
+      printf '- age: %ss\n' "$age_seconds"
+      if [[ -n "$last_error" ]]; then
+        printf '- last_error: `%s`\n' "$last_error"
+      fi
+      printf '\n## Next steps\n\n'
+      printf '1. Check `agb a2a outbox list` for context.\n'
+      printf '2. Run `agb a2a peers test %s` to probe reachability.\n' "$peer"
+      printf '3. If the peer is intentionally offline, drop the entry:\n'
+      printf '   `agb a2a outbox drop %s`.\n' "$message_id"
+      printf '4. Otherwise, requeue once the peer is back:\n'
+      printf '   `agb a2a outbox retry %s`.\n' "$message_id"
+      printf '\nThis alert will not re-emit for this entry within\n'
+      printf '`BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS` (default 1h).\n'
+    } >"$body_file"
+
+    if "$target_bridge" task create \
+         --to "$admin" --priority high --from daemon \
+         --title "[A2A] outbox stuck: ${peer}:${target_agent} (${message_id:0:8})" \
+         --body-file "$body_file" >/dev/null 2>&1; then
+      emitted=$((emitted + 1))
+      bridge_audit_log daemon a2a_outbox_stuck_alert_emitted "$admin" \
+        --detail message_id="$message_id" \
+        --detail peer="$peer" \
+        --detail target_agent="$target_agent" \
+        --detail status="$status" \
+        --detail attempts="$attempts" \
+        --detail age_seconds="$age_seconds" >/dev/null 2>&1 || true
+    else
+      daemon_warn "[a2a_stuck_scan] failed to file admin task for stuck $message_id"
+    fi
+    rm -f "$body_file" 2>/dev/null || true
+  done <"$emit_tmp"
+
+  rm -f "$list_tmp" "$emit_tmp" 2>/dev/null || true
+
+  if (( emitted > 0 )); then
+    daemon_log_event "[a2a_stuck_scan] emitted $emitted stuck-outbox admin task(s)"
+  fi
+
+  # Persist throttle state. The helper has already rewritten the ledger
+  # with the new last-alerted-ts entries.
+  printf 'A2A_STUCK_SCAN_LAST_TS=%s\nA2A_STUCK_SCAN_NEXT_TS=%s\nA2A_STUCK_SCAN_LAST_EMITTED=%s\n' \
+    "$now" "$((now + interval))" "$emitted" >"$tick_state" 2>/dev/null || true
+  return 0
+}
+
 process_release_monitor() {
   local admin_agent="${BRIDGE_ADMIN_AGENT_ID:-}"
   local monitor_json=""
@@ -7247,6 +7450,15 @@ cmd_sync_cycle() {
   # done) and before nudge_agents (the cycle's last big external fanout).
   BRIDGE_DAEMON_LAST_STEP="a2a_deliver_tick"
   process_a2a_deliver_tick || true
+
+  # Issue #1262 Gap 3 (v0.15.0-beta4 Lane I): A2A outbox stuck-alert
+  # scan. Pairs with the deliver tick above — when a row stays in
+  # pending/retry past BRIDGE_A2A_STUCK_ALERT_SECS (default 600s), we
+  # file an admin task so the operator sees the stall without polling
+  # `agb a2a outbox list`. Throttled by
+  # BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS (default 300s).
+  BRIDGE_DAEMON_LAST_STEP="a2a_stuck_scan_tick"
+  process_a2a_outbox_stuck_scan_tick || true
 
   BRIDGE_DAEMON_LAST_STEP="nudge_agents"
   printf '%s\n' "$nudge_output" > "$_nudge_tmp"

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2366,7 +2366,7 @@ process_a2a_outbox_stuck_scan_tick() {
   # piping via $() — footgun #11 (Bash 5.3.9 here-string / heredoc-stdin
   # wedge) recommends file-as-argv for any subprocess that may emit
   # large output.
-  local list_tmp emit_tmp
+  local list_tmp emit_tmp ack_tmp
   list_tmp="$(mktemp "${TMPDIR:-/tmp}/bridge-a2a-stuck-list.XXXXXX" 2>/dev/null)" || {
     daemon_warn "[a2a_stuck_scan] mktemp failed; skipping"
     return 1
@@ -2376,13 +2376,24 @@ process_a2a_outbox_stuck_scan_tick() {
     daemon_warn "[a2a_stuck_scan] mktemp failed; skipping"
     return 1
   }
+  # v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING): ack-keys file —
+  # successful task-create message_ids are appended here. The helper
+  # ``a2a-stuck-ack`` stamps the ledger ONLY for these keys (and
+  # prunes outbox-absent entries). Failed task-create paths skip the
+  # append, so the reemit cooldown is not started for an alert that
+  # never reached the operator.
+  ack_tmp="$(mktemp "${TMPDIR:-/tmp}/bridge-a2a-stuck-ack.XXXXXX" 2>/dev/null)" || {
+    rm -f "$list_tmp" "$emit_tmp"
+    daemon_warn "[a2a_stuck_scan] mktemp failed; skipping"
+    return 1
+  }
 
   local list_rc=0
   bridge_with_timeout 30 a2a_outbox_list \
     python3 "$SCRIPT_DIR/bridge-a2a.py" outbox list --json >"$list_tmp" 2>/dev/null || list_rc=$?
   if (( list_rc != 0 )); then
     daemon_warn "[a2a_stuck_scan] outbox list rc=$list_rc; skipping this tick"
-    rm -f "$list_tmp" "$emit_tmp"
+    rm -f "$list_tmp" "$emit_tmp" "$ack_tmp"
     printf 'A2A_STUCK_SCAN_LAST_TS=%s\nA2A_STUCK_SCAN_NEXT_TS=%s\nA2A_STUCK_SCAN_LAST_EMITTED=0\n' \
       "$now" "$((now + interval))" >"$tick_state" 2>/dev/null || true
     return 0
@@ -2392,9 +2403,10 @@ process_a2a_outbox_stuck_scan_tick() {
   # keep cleanly in bash. The helper writes one TSV row per row that
   # needs an admin task:
   #   message_id\tpeer\ttarget_agent\tstatus\tattempts\tage_seconds\tlast_error
-  # and rewrites the ledger file to reflect the new last-alerted-ts for
-  # each emitted row. Pass JSON via --outbox-json-file (path) rather
-  # than stdin — same footgun #11 reasoning.
+  # v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING): decide is now pure
+  # read — it does NOT modify the ledger. The ledger is stamped only
+  # after a successful admin-task create, via ``a2a-stuck-ack`` below.
+  # Pass JSON via path (footgun #11 reasoning).
   bridge_with_timeout 10 a2a_stuck_decide \
     python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" a2a-stuck-decide \
       "$now" "$stuck_secs" "$reemit_secs" "$ledger_file" "$list_tmp" \
@@ -2438,6 +2450,10 @@ process_a2a_outbox_stuck_scan_tick() {
          --title "[A2A] outbox stuck: ${peer}:${target_agent} (${message_id:0:8})" \
          --body-file "$body_file" >/dev/null 2>&1; then
       emitted=$((emitted + 1))
+      # Codex r1 BLOCKING fix: stamp the ledger via ack helper at the
+      # end of the loop, ONLY for rows whose admin task we actually
+      # filed. Record the message_id here for that ack pass.
+      printf '%s\n' "$message_id" >>"$ack_tmp" 2>/dev/null || true
       bridge_audit_log daemon a2a_outbox_stuck_alert_emitted "$admin" \
         --detail message_id="$message_id" \
         --detail peer="$peer" \
@@ -2446,19 +2462,32 @@ process_a2a_outbox_stuck_scan_tick() {
         --detail attempts="$attempts" \
         --detail age_seconds="$age_seconds" >/dev/null 2>&1 || true
     else
-      daemon_warn "[a2a_stuck_scan] failed to file admin task for stuck $message_id"
+      # Codex r1 BLOCKING fix: do NOT advance the reemit cooldown
+      # ledger when task create fails. The next scan will re-evaluate
+      # this row and try again.
+      daemon_warn "[a2a_stuck_scan] task-create failed for stuck $message_id; ledger preserved, will retry next scan"
     fi
     rm -f "$body_file" 2>/dev/null || true
   done <"$emit_tmp"
 
-  rm -f "$list_tmp" "$emit_tmp" 2>/dev/null || true
+  # Stamp ledger for successful task-create rows (if any) and prune
+  # entries whose message_id is no longer in the outbox. Call the ack
+  # helper unconditionally so pruning runs even on quiet ticks; an
+  # empty ack_tmp is a legal no-op-stamp + prune pass.
+  bridge_with_timeout 10 a2a_stuck_ack \
+    python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" a2a-stuck-ack \
+      "$now" "$ledger_file" "$ack_tmp" "$list_tmp" \
+      >/dev/null 2>&1 || true
+
+  rm -f "$list_tmp" "$emit_tmp" "$ack_tmp" 2>/dev/null || true
 
   if (( emitted > 0 )); then
     daemon_log_event "[a2a_stuck_scan] emitted $emitted stuck-outbox admin task(s)"
   fi
 
-  # Persist throttle state. The helper has already rewritten the ledger
-  # with the new last-alerted-ts entries.
+  # Persist throttle state. The ack helper has already rewritten the
+  # ledger with the new last-alerted-ts entries for successful task
+  # creates (and pruned outbox-absent message_ids).
   printf 'A2A_STUCK_SCAN_LAST_TS=%s\nA2A_STUCK_SCAN_NEXT_TS=%s\nA2A_STUCK_SCAN_LAST_EMITTED=%s\n' \
     "$now" "$((now + interval))" "$emitted" >"$tick_state" 2>/dev/null || true
   return 0

--- a/bridge-init.sh
+++ b/bridge-init.sh
@@ -37,7 +37,7 @@ source "$SCRIPT_DIR/lib/bridge-init-codex-pair.sh"
 usage() {
   cat <<EOF
 Usage:
-  $(basename "$0") [--admin <agent>] [--engine claude|codex] [--session <name>] [--workdir <path>] [--user <id[:display-name]>]... [--channels <csv>] [--discord-channel <id>]... [--allow-from <id>]... [--default-chat <id>] [--teams-app-id <id>] [--teams-app-password-file <path>] [--teams-tenant-id <id>] [--teams-allow-from <id>]... [--teams-conversation <id>]... [--channel-account <account>] [--runtime-config <path>] [--api-base-url <url>] [--profile server|dev] [--reconfigure] [--skip-validate] [--skip-send-test] [--skip-channel-setup] [--test-start] [--dry-run] [--json]
+  $(basename "$0") [--admin <agent>] [--engine claude|codex] [--session <name>] [--workdir <path>] [--user <id[:display-name]>]... [--channels <csv>] [--discord-channel <id>]... [--allow-from <id>]... [--default-chat <id>] [--teams-app-id <id>] [--teams-app-password-file <path>] [--teams-tenant-id <id>] [--teams-allow-from <id>]... [--teams-conversation <id>]... [--channel-account <account>] [--runtime-config <path>] [--api-base-url <url>] [--profile server|dev] [--reconfigure] [--skip-validate] [--skip-send-test] [--skip-channel-setup] [--test-start] [--enable-a2a] [--dry-run] [--json]
 
   The Teams client secret may also be supplied via the BRIDGE_TEAMS_APP_PASSWORD
   environment variable. --teams-app-password <secret> is still accepted but
@@ -61,13 +61,18 @@ bridge_init_emit_json() {
   local admin_saved="$9"
   local dry_run="${10}"
   local warnings_json="${11}"
+  # Issue #1262 Gap 1: A2A scaffold status — emitted as a top-level
+  # field so bridge-bootstrap.sh / orchestrator JSON consumers can branch
+  # on whether the receiver template was rendered. Defaults to "skipped"
+  # when --enable-a2a wasn't passed.
+  local a2a_status="${12:-skipped}"
 
   bridge_require_python
-  python3 - "$admin" "$engine" "$session" "$workdir" "$channels" "$created" "$channel_setup" "$preflight" "$admin_saved" "$dry_run" "$warnings_json" <<'PY'
+  python3 - "$admin" "$engine" "$session" "$workdir" "$channels" "$created" "$channel_setup" "$preflight" "$admin_saved" "$dry_run" "$warnings_json" "$a2a_status" <<'PY'
 import json
 import sys
 
-admin, engine, session, workdir, channels, created, channel_setup, preflight, admin_saved, dry_run, warnings_json = sys.argv[1:]
+admin, engine, session, workdir, channels, created, channel_setup, preflight, admin_saved, dry_run, warnings_json, a2a_status = sys.argv[1:]
 payload = {
     "admin": admin,
     "engine": engine,
@@ -80,6 +85,7 @@ payload = {
     "admin_saved": admin_saved == "1",
     "dry_run": dry_run == "1",
     "warnings": json.loads(warnings_json),
+    "a2a_status": a2a_status,
     "next_command": "agb admin" if admin_saved == "1" else "",
     "handoff_steps": [
         "Close the temporary installer session.",
@@ -339,6 +345,94 @@ print(json.dumps(sys.argv[1:], ensure_ascii=False))
 PY
 }
 
+# Issue #1262 Gap 1 (v0.15.0-beta4 Lane I, 2026-05-27): scaffold A2A
+# cross-bridge handoff at install time when --enable-a2a is set.
+#
+# Behavior:
+#   1. Write $BRIDGE_HOME/handoff.local.json from
+#      $SCRIPT_DIR/handoff.local.example.json (mode 0600) IF the file is
+#      absent. Existing config is preserved — the operator may already
+#      have a tuned config, and clobbering it would be hostile.
+#   2. On Linux, render the agb-handoffd.service systemd-user unit by
+#      invoking scripts/install-handoffd-systemd.sh (without --apply, so
+#      the operator can review before activation). The actual `systemctl
+#      enable --now` is deferred to the operator's explicit action so
+#      that a config without configured peers + secret doesn't bind a
+#      service in a fail-closed state on every boot.
+#   3. Emit a stderr advisory naming the next operator action.
+#   4. Honors --dry-run (no writes) and routes log lines to stderr only
+#      (matches the #1230 stdout-is-JSON-only convention).
+#
+# Sets the global `a2a_status` to one of:
+#   skipped              — --enable-a2a not set
+#   ok                   — stub config + systemd template rendered
+#   ok-existing-config   — config already present; only systemd template rendered
+#   dry-run              — --enable-a2a + --dry-run
+#   error                — write/render failed (warning appended)
+bridge_init_scaffold_a2a() {
+  local config_path="$BRIDGE_HOME/handoff.local.json"
+  local example_path="$SCRIPT_DIR/handoff.local.example.json"
+  local config_existed=0
+  local os_name
+  os_name="$(uname -s 2>/dev/null || printf 'unknown')"
+
+  if [[ $dry_run -eq 1 ]]; then
+    a2a_status="dry-run"
+    echo "[init] --enable-a2a: would scaffold $config_path + systemd unit (skipped: --dry-run)" >&2
+    return 0
+  fi
+
+  if [[ ! -f "$example_path" ]]; then
+    a2a_status="error"
+    bridge_init_append_warning "--enable-a2a: example config not found at $example_path"
+    return 0
+  fi
+
+  if [[ -f "$config_path" ]]; then
+    config_existed=1
+    echo "[init] --enable-a2a: $config_path already exists; not overwriting" >&2
+  else
+    # Copy with mode 0600 — config carries peer HMAC secrets.
+    if ! cp "$example_path" "$config_path" 2>/dev/null; then
+      a2a_status="error"
+      bridge_init_append_warning "--enable-a2a: failed to copy example config to $config_path"
+      return 0
+    fi
+    chmod 0600 "$config_path" 2>/dev/null || true
+    echo "[init] --enable-a2a: wrote $config_path (mode 0600)" >&2
+    echo "[init] --enable-a2a: edit it to set bridge_id, listen.address (tailnet IP), and peers (with secrets). See docs/a2a-cross-bridge.md." >&2
+    # BRIDGE_A2A_TAILSCALE_CLI advisory — only required if tailscale CLI
+    # lives outside the default $PATH (e.g. /Applications/Tailscale.app/...
+    # on macOS, or a custom install path on Linux).
+    echo "[init] --enable-a2a: BRIDGE_A2A_TAILSCALE_CLI env override is optional (only set if your tailscale CLI is in a non-default location)." >&2
+  fi
+
+  # Linux: render systemd-user unit (no --apply; operator activates manually).
+  if [[ "$os_name" == "Linux" ]] && [[ -x "$SCRIPT_DIR/scripts/install-handoffd-systemd.sh" ]]; then
+    local unit_preview_file="$BRIDGE_HOME/handoff/agb-handoffd.service.preview"
+    mkdir -p "$BRIDGE_HOME/handoff" 2>/dev/null || true
+    if "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/scripts/install-handoffd-systemd.sh" \
+         --bridge-home "$BRIDGE_HOME" \
+         --source-dir "$SCRIPT_DIR" \
+         >"$unit_preview_file" 2>/dev/null; then
+      chmod 0644 "$unit_preview_file" 2>/dev/null || true
+      echo "[init] --enable-a2a: systemd unit preview rendered at $unit_preview_file" >&2
+      echo "[init] --enable-a2a: to activate: bash $SCRIPT_DIR/scripts/install-handoffd-systemd.sh --bridge-home $BRIDGE_HOME --source-dir $SCRIPT_DIR --enable" >&2
+    else
+      bridge_init_append_warning "--enable-a2a: rendering systemd-user unit preview failed; run scripts/install-handoffd-systemd.sh manually"
+    fi
+  else
+    echo "[init] --enable-a2a: non-Linux host ($os_name) — no systemd unit emitted. Use 'bash $SCRIPT_DIR/bridge-handoff-daemon.sh start' or wire into your service manager." >&2
+  fi
+
+  if [[ $config_existed -eq 1 ]]; then
+    a2a_status="ok-existing-config"
+  else
+    a2a_status="ok"
+  fi
+  return 0
+}
+
 admin_agent="${BRIDGE_ADMIN_AGENT_ID:-patch}"
 engine="claude"
 session=""
@@ -383,6 +477,13 @@ user_specs=()
 host_profile_reconfigure=0
 host_profile_override=""
 host_profile_chosen=""
+# Issue #1262 Gap 1 (v0.15.0-beta4 Lane I): opt-in scaffolding for the
+# A2A cross-bridge receiver. When --enable-a2a is set, init writes a
+# handoff.local.json stub (if absent) and emits an advisory pointing the
+# operator at the systemd-user template (Linux) or the manual `agb a2a`
+# lifecycle (macOS). Opt-out by default — most installs don't run A2A.
+enable_a2a=0
+a2a_status="skipped"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -569,6 +670,11 @@ while [[ $# -gt 0 ]]; do
       ;;
     --json)
       json_mode=1
+      shift
+      ;;
+    --enable-a2a)
+      # Issue #1262 Gap 1 (v0.15.0-beta4 Lane I): opt-in A2A scaffold.
+      enable_a2a=1
       shift
       ;;
     -h|--help|help)
@@ -1066,6 +1172,12 @@ bridge_init_ensure_live_cli
 # Mattermost setup steps. host_profile_chosen is already populated by that
 # call (or empty on --dry-run).
 
+# Issue #1262 Gap 1 (v0.15.0-beta4 Lane I): optional A2A scaffolding.
+# Only runs when --enable-a2a is set; otherwise a2a_status stays "skipped".
+if [[ $enable_a2a -eq 1 ]]; then
+  bridge_init_scaffold_a2a
+fi
+
 warnings_json="$(bridge_init_warnings_json)"
 
 if [[ $json_mode -eq 1 ]]; then
@@ -1080,7 +1192,8 @@ if [[ $json_mode -eq 1 ]]; then
     "$preflight_status" \
     "$admin_saved" \
     "$dry_run" \
-    "$warnings_json"
+    "$warnings_json" \
+    "$a2a_status"
   exit 0
 fi
 
@@ -1102,6 +1215,7 @@ printf 'created: %s\n' "$([[ $created -eq 1 ]] && echo yes || echo no)"
 printf 'channel_setup: %s\n' "$channel_setup_status"
 printf 'preflight: %s\n' "$preflight_status"
 printf 'admin_saved: %s\n' "$([[ $admin_saved -eq 1 ]] && echo yes || echo no)"
+printf 'a2a: %s\n' "$a2a_status"
 if [[ -n "$host_profile_chosen" ]]; then
   printf 'host_profile: %s\n' "$host_profile_chosen"
 fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise I-beta4-a2a-3-gaps
 
 
 }
@@ -427,12 +427,20 @@ select_for_path() {
       add_integration integration-minimal
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
       # end-to-end A2A smoke (auth/allowlist/dedupe/cap/retry).
-      add_required a2a-cross-bridge queue
+      #
+      # Issue #1262 (v0.15.0-beta4 Lane I): A2A 3 gaps — systemd
+      # auto-install (scripts/install-handoffd-systemd.sh), retry
+      # verify (already in a2a-cross-bridge), outbox stuck alerting
+      # (process_a2a_outbox_stuck_scan_tick in bridge-daemon.sh +
+      # a2a-stuck-decide in bridge-daemon-helpers.py). The
+      # I-beta4-a2a-3-gaps smoke covers the static-source contract for
+      # all three gaps plus the python helper unit tests.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)
@@ -532,7 +540,14 @@ select_for_path() {
       # G-beta4-watchdog-noise pins both the downgrade gate and the
       # daemon-helper readout contract — pull on every bridge-daemon.sh
       # move so a future PR cannot silently regress the priority gate.
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift 1178-helper-contract-daemon-supp F-daemon-supp-groups-mock F-daemon-supp-groups-real δ-1234-daemon-start-policy A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir D-beta4-daemon-lifecycle A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir G-beta4-watchdog-noise
+      # v0.15.0-beta4 Lane I (#1262 Gap 3): bridge-daemon.sh now hosts
+      # process_a2a_outbox_stuck_scan_tick — a new tick that scans the
+      # A2A outbox for stuck rows and files admin tasks. Pull
+      # I-beta4-a2a-3-gaps on every bridge-daemon.sh move so the wiring
+      # (LAST_STEP literal, audit row name, target_bridge task create)
+      # and the python decision helper (cmd_a2a_stuck_decide) contract
+      # cannot regress silently.
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift 1178-helper-contract-daemon-supp F-daemon-supp-groups-mock F-daemon-supp-groups-real δ-1234-daemon-start-policy A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir D-beta4-daemon-lifecycle A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir G-beta4-watchdog-noise I-beta4-a2a-3-gaps
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -1235,7 +1250,15 @@ select_for_path() {
       # F-beta4 smoke + daemon periodic-sync smoke both exercise the
       # parser; pull both whenever the helper moves so a future PR
       # cannot regress either contract.
-      add_required F-beta4-oauth-bootstrap daemon-periodic-token-sync daemon queue
+      #
+      # v0.15.0-beta4 Lane I (#1262 Gap 3): the new ``a2a-stuck-decide``
+      # subcommand is the decision + ledger helper for
+      # process_a2a_outbox_stuck_scan_tick. The I-beta4-a2a-3-gaps
+      # smoke exercises it directly (stuck emit, cooldown suppress,
+      # cooldown expiry re-emit, ledger pruning) so a future PR cannot
+      # silently regress the helper output or the atomic ledger
+      # rewrite.
+      add_required F-beta4-oauth-bootstrap daemon-periodic-token-sync daemon queue I-beta4-a2a-3-gaps
       add_integration integration-minimal
       ;;
 
@@ -1290,7 +1313,13 @@ select_for_path() {
       # on the init stdout re-introduces the JSONDecodeError surface
       # documented in #1230. F-beta4-oauth-bootstrap pins both the
       # advisory presence and the dry-run JSON parse.
-      add_required 1058-bootstrap-tmux-ux agent-create-caller-trust-gate F-beta4-oauth-bootstrap
+      #
+      # v0.15.0-beta4 Lane I (#1262 Gap 1): bridge-init.sh now accepts
+      # `--enable-a2a` and emits an `a2a_status` field in the JSON
+      # payload. The smoke pins the flag wiring + JSON field + stderr
+      # routing for the `[init] --enable-a2a:` log lines so a future
+      # PR cannot silently leak them onto stdout.
+      add_required 1058-bootstrap-tmux-ux agent-create-caller-trust-gate F-beta4-oauth-bootstrap I-beta4-a2a-3-gaps
       add_integration integration-minimal
       ;;
 

--- a/scripts/install-handoffd-systemd.sh
+++ b/scripts/install-handoffd-systemd.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# scripts/install-handoffd-systemd.sh — render/install a systemd-user unit
+# for the A2A receiver daemon (`bridge-handoffd.py serve`).
+#
+# Issue #1262 Gap 1 (v0.15.0-beta4 Lane I, 2026-05-27): the A2A receiver
+# daemon ships as a manual lifecycle script (bridge-handoff-daemon.sh
+# start|stop|restart|tick) with no auto-install pathway. Operators who
+# enable A2A at install time still have to hand-craft a systemd unit (or
+# remember to invoke the tick from cron), which means every fresh A2A
+# install starts in a configured-but-not-running state until the operator
+# notices.
+#
+# Mirror of scripts/install-daemon-systemd.sh, narrowed to the receiver
+# lifecycle:
+#   - Without --apply: prints the rendered unit to stdout.
+#   - With --apply: writes to ~/.config/systemd/user/agb-handoffd.service.
+#   - With --enable: also runs systemctl --user daemon-reload + enable --now.
+#
+# All log lines go to stderr — bridge-init.sh captures this script's stdout
+# when forwarding through `--json`, and log lines on stdout poison
+# bridge-bootstrap.sh's JSON parser (same #1230 convention as
+# install-daemon-systemd.sh).
+
+set -euo pipefail
+
+BRIDGE_HOME_TARGET="${HOME}/.agent-bridge"
+UNIT_NAME="agb-handoffd.service"
+SERVICE_PATH=""
+LOG_PATH=""
+APPLY=0
+ENABLE=0
+SOURCE_DIR=""
+
+usage() {
+  cat <<EOF
+Usage: $0 [--bridge-home <dir>] [--source-dir <dir>] [--unit <service-name>]
+       [--service-path <path>] [--log-path <path>] [--apply] [--enable]
+
+Without --apply, prints the systemd user unit file (to stdout).
+With --apply, writes the unit to ~/.config/systemd/user (or --service-path
+target).
+With --enable, also runs systemctl --user daemon-reload and enable --now.
+
+Source-dir defaults to the directory holding this script's parent (i.e.
+the source checkout root). Pass --source-dir explicitly if invoking from
+outside the checkout (e.g. from the live runtime where the rendered
+ExecStart needs to point at the recorded source root).
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bridge-home)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      BRIDGE_HOME_TARGET="$2"
+      shift 2
+      ;;
+    --source-dir)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SOURCE_DIR="$2"
+      shift 2
+      ;;
+    --unit)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      UNIT_NAME="$2"
+      shift 2
+      ;;
+    --service-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      SERVICE_PATH="$2"
+      shift 2
+      ;;
+    --log-path)
+      [[ $# -lt 2 ]] && { usage; exit 1; }
+      LOG_PATH="$2"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --enable)
+      APPLY=1
+      ENABLE=1
+      shift
+      ;;
+    -h|--help|help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$SOURCE_DIR" ]]; then
+  SOURCE_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+fi
+if [[ ! -f "$SOURCE_DIR/bridge-handoffd.py" ]]; then
+  echo "[error] --source-dir does not contain bridge-handoffd.py: $SOURCE_DIR" >&2
+  exit 1
+fi
+
+# Default service path to systemd-user directory.
+if [[ -z "$SERVICE_PATH" ]]; then
+  SERVICE_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user/$UNIT_NAME"
+fi
+if [[ -z "$LOG_PATH" ]]; then
+  LOG_PATH="$BRIDGE_HOME_TARGET/logs/a2a-handoffd.log"
+fi
+
+# Resolve a python3 path the unit can use. Falling back to /usr/bin/env is
+# the safest — systemd-user inherits PATH from the operator's login shell,
+# but `env` ensures we don't pin a specific interpreter that might not
+# exist on minimal hosts.
+PYTHON_BIN="$(command -v python3 || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  PYTHON_BIN="/usr/bin/env python3"
+fi
+
+CONFIG_PATH="$BRIDGE_HOME_TARGET/handoff.local.json"
+
+# Unit content. The receiver's `serve --detach` would race with
+# systemd's own pid tracking, so we explicitly DROP `--detach` for the
+# systemd-managed path — systemd is the lifecycle owner, not nohup.
+# The receiver still writes a pidfile for the bridge-a2a CLI to consult,
+# but the unit's Type=simple keeps systemd in charge of restart/stop.
+UNIT_CONTENT="$(cat <<EOF
+[Unit]
+Description=Agent Bridge A2A handoff receiver
+Documentation=https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/a2a-cross-bridge.md
+After=network-online.target tailscaled.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=BRIDGE_HOME=$BRIDGE_HOME_TARGET
+ExecStart=$PYTHON_BIN $SOURCE_DIR/bridge-handoffd.py serve --config $CONFIG_PATH --pidfile $BRIDGE_HOME_TARGET/state/handoff/handoffd.pid
+Restart=on-failure
+RestartSec=5
+StandardOutput=append:$LOG_PATH
+StandardError=append:$LOG_PATH
+
+[Install]
+WantedBy=default.target
+EOF
+)"
+
+if [[ $APPLY -eq 0 ]]; then
+  # Print rendered unit to stdout (operator can redirect / inspect).
+  printf 'bridge_home: %s\n' "$BRIDGE_HOME_TARGET" >&2
+  printf 'source_dir: %s\n' "$SOURCE_DIR" >&2
+  printf 'log_path: %s\n' "$LOG_PATH" >&2
+  printf 'unit: %s\n' "$UNIT_NAME" >&2
+  printf '%s\n' "$UNIT_CONTENT"
+  exit 0
+fi
+
+mkdir -p "$(dirname "$SERVICE_PATH")" "$(dirname "$LOG_PATH")"
+printf '%s\n' "$UNIT_CONTENT" >"$SERVICE_PATH"
+echo "[info] wrote A2A handoffd systemd user unit: $SERVICE_PATH" >&2
+
+if [[ $ENABLE -eq 1 ]]; then
+  if ! command -v systemctl >/dev/null 2>&1; then
+    echo "[error] systemctl not found; wrote unit but cannot enable it" >&2
+    exit 1
+  fi
+  systemctl --user daemon-reload
+  systemctl --user enable --now "$UNIT_NAME"
+  echo "[info] enabled systemd user unit: $UNIT_NAME" >&2
+  echo "[info] inspect with: systemctl --user status $UNIT_NAME" >&2
+fi
+
+echo "[info] bridge_home: $BRIDGE_HOME_TARGET" >&2
+echo "[info] log_path: $LOG_PATH" >&2
+echo "[info] service_path: $SERVICE_PATH" >&2
+echo "mode=systemd-user" >&2

--- a/scripts/smoke/I-beta4-a2a-3-gaps.sh
+++ b/scripts/smoke/I-beta4-a2a-3-gaps.sh
@@ -468,6 +468,185 @@ fi
 smoke_log "T_stuck_task_create_failure_preserves_ledger PASS — failed task-create preserves ledger, next scan retries, teeth bites"
 
 # ---------------------------------------------------------------------
+# T_daemon_scan_tick_handles_create_failure — v0.15.0-beta4 Lane I r3
+# (codex r2 TEST GAP).
+#
+# Contract: exercise the actual production `process_a2a_outbox_stuck_scan_tick`
+# shell function from bridge-daemon.sh — not just the python helpers —
+# under a controlled `task create` failure, then re-run under success.
+#
+# Mocks:
+#   - `bridge-a2a.py outbox list --json` → fixture file (driver overrides
+#     `bridge_with_timeout` for label `a2a_outbox_list`).
+#   - `$BRIDGE_HOME/agent-bridge task create` → wrapper shim whose rc
+#     reads from `BRIDGE_A2A_TEST_TASK_CREATE_RC` (0/1) per tick. Daemon
+#     prefers `$BRIDGE_HOME/agent-bridge` over `$SCRIPT_DIR/agent-bridge`
+#     (bridge-daemon.sh:2342-2349), so the shim wins.
+#
+# Acceptance (r3 codex r2 TEST GAP closure):
+#   1. tick #1 with task_create rc=1:
+#        - decide emits the stuck row
+#        - daemon's task-create branch fails
+#        - daemon_warn at bridge-daemon.sh:2468 fires
+#          ("task-create failed for stuck …")
+#        - ack helper runs with EMPTY ack-keys (production line 2456
+#          appends ONLY inside the success branch) → ledger remains
+#          unstamped for the stuck message_id
+#        - throttle: next scan must NOT be skipped (we manually clear
+#          tick_state between runs to keep the test deterministic)
+#   2. tick #2 with task_create rc=0 (mock toggled, throttle state
+#      cleared, retry-after window honored implicitly since we control
+#      `BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS=0` would skip the
+#      tick — instead we remove the tick_state file between runs):
+#        - decide emits the same stuck row (ledger never stamped)
+#        - daemon's task-create branch succeeds
+#        - ack helper stamps the ledger
+#        - ledger NOW carries `"msg-stuck-real-001"`
+#
+# Teeth (regression vectors documented + exercised by tick #1):
+#   V1. Move bridge-daemon.sh:2456 (`printf '%s\n' "$message_id" >>
+#       "$ack_tmp"`) OUTSIDE the success branch (i.e. unconditionally
+#       after the if-else). The smoke will then see ledger stamped on
+#       failure → tick #2's pre-condition `ledger empty` fails →
+#       assertion fires.
+#   V2. Reorder helper calls so `a2a-stuck-ack` runs BEFORE the
+#       task-create loop (or the loop appends to ack_tmp before the
+#       success rc is known). Same shape — ledger stamped on failure
+#       → assertion fires.
+#
+# Both vectors fail the same assertion: tick #1 must leave the ledger
+# empty for `msg-stuck-real-001`.
+# ---------------------------------------------------------------------
+
+smoke_log "T_daemon_scan_tick_handles_create_failure: daemon function with mocked task-create"
+
+DAEMON_TEST_HOME="$SMOKE_TMP_ROOT/daemon-test"
+mkdir -p "$DAEMON_TEST_HOME/state/handoff"
+DAEMON_TEST_CONFIG="$DAEMON_TEST_HOME/handoff.local.json"
+# Daemon function gates on existence of handoff.local.json (production
+# behavior — see bridge-daemon.sh:2301-2302). Content not parsed by this
+# function; a stub object is fine.
+printf '{"version":1,"peers":[]}\n' >"$DAEMON_TEST_CONFIG"
+
+# Outbox fixture: one row that is stuck (status=retry, age over threshold).
+DAEMON_TEST_OUTBOX="$SMOKE_TMP_ROOT/daemon-test-outbox.json"
+cat >"$DAEMON_TEST_OUTBOX" <<'JSON'
+[
+  {"message_id": "msg-stuck-real-001", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "retry", "attempts": 3, "next_attempt_ts": 0, "last_error": "transport: peer unreachable", "acked_remote_task_id": null, "created_ts": 1000, "updated_ts": 1100, "lease_expires_ts": 0, "age_seconds": 10000, "due_for_seconds": 9000, "next_attempt_in_seconds": null, "lease_stale_seconds": null}
+]
+JSON
+
+# Mock agent-bridge shim. Daemon prefers $BRIDGE_HOME/agent-bridge over
+# $SCRIPT_DIR/agent-bridge (see daemon function, lines 2342-2349). Reads
+# rc from $BRIDGE_A2A_TEST_TASK_CREATE_RC.
+DAEMON_TEST_AGB_SHIM="$DAEMON_TEST_HOME/agent-bridge"
+cat >"$DAEMON_TEST_AGB_SHIM" <<'SHIM'
+#!/usr/bin/env bash
+# Mock for v0.15.0-beta4 Lane I r3 smoke. Returns rc from env var.
+rc="${BRIDGE_A2A_TEST_TASK_CREATE_RC:-0}"
+case "${1:-}" in
+  task)
+    if [[ "$rc" == "1" ]]; then
+      printf 'mock-agent-bridge: task create failed (BRIDGE_A2A_TEST_TASK_CREATE_RC=1)\n' >&2
+      exit 1
+    fi
+    exit 0
+    ;;
+  *)
+    # Any other subcommand: no-op success.
+    exit 0
+    ;;
+esac
+SHIM
+chmod +x "$DAEMON_TEST_AGB_SHIM"
+
+DAEMON_TEST_WARN_LOG="$SMOKE_TMP_ROOT/daemon-test-warn.log"
+DAEMON_TEST_EVENT_LOG="$SMOKE_TMP_ROOT/daemon-test-event.log"
+: >"$DAEMON_TEST_WARN_LOG"
+: >"$DAEMON_TEST_EVENT_LOG"
+
+DAEMON_TEST_LEDGER="$DAEMON_TEST_HOME/state/handoff/stuck-alerts.json"
+DAEMON_TEST_TICK="$DAEMON_TEST_HOME/state/handoff/stuck-scan-tick.env"
+
+# Driver script — invokes the actual production
+# process_a2a_outbox_stuck_scan_tick function from bridge-daemon.sh
+# with mocks for `bridge-a2a.py outbox list --json` and `agent-bridge
+# task create`. See run-stuck-scan-tick.sh for the mock contract.
+DAEMON_TEST_DRIVER="$REPO_ROOT/scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh"
+if [[ ! -x "$DAEMON_TEST_DRIVER" ]]; then
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: missing driver $DAEMON_TEST_DRIVER"
+fi
+
+# Tick #1 — task_create rc=1 (failure path).
+rm -f "$DAEMON_TEST_TICK" "$DAEMON_TEST_LEDGER"
+env -i HOME="$HOME" PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" \
+  SCRIPT_DIR="$REPO_ROOT" \
+  BRIDGE_HOME="$DAEMON_TEST_HOME" \
+  BRIDGE_STATE_DIR="$DAEMON_TEST_HOME/state" \
+  BRIDGE_A2A_CONFIG="$DAEMON_TEST_CONFIG" \
+  BRIDGE_ADMIN_AGENT_ID="patch-test" \
+  BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS=300 \
+  BRIDGE_A2A_STUCK_ALERT_SECS=600 \
+  BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS=3600 \
+  BRIDGE_A2A_TEST_OUTBOX_JSON="$DAEMON_TEST_OUTBOX" \
+  BRIDGE_A2A_TEST_TASK_CREATE_RC=1 \
+  BRIDGE_A2A_TEST_WARN_LOG="$DAEMON_TEST_WARN_LOG" \
+  BRIDGE_A2A_TEST_EVENT_LOG="$DAEMON_TEST_EVENT_LOG" \
+  bash "$DAEMON_TEST_DRIVER" \
+    >"$SMOKE_TMP_ROOT/daemon-test-tick1.out" 2>"$SMOKE_TMP_ROOT/daemon-test-tick1.err" || true
+
+# Assert 1: daemon_warn at bridge-daemon.sh:2468 fired ("task-create failed").
+if ! grep -F '[a2a_stuck_scan] task-create failed for stuck msg-stuck-real-001' \
+     "$DAEMON_TEST_WARN_LOG" >/dev/null; then
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 did not emit task-create-failed warn (warn log: $(cat "$DAEMON_TEST_WARN_LOG"); stderr: $(cat "$SMOKE_TMP_ROOT/daemon-test-tick1.err"))"
+fi
+
+# Assert 2: ledger unstamped for msg-stuck-real-001 (production code path:
+# line 2456 only appends to ack_tmp inside the success branch).
+if [[ ! -f "$DAEMON_TEST_LEDGER" ]]; then
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 did not create ledger file"
+fi
+if grep -F 'msg-stuck-real-001' "$DAEMON_TEST_LEDGER" >/dev/null; then
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 stamped ledger despite task-create failure — regression of bridge-daemon.sh:2456 ack_tmp-append-on-success contract (ledger: $(cat "$DAEMON_TEST_LEDGER"))"
+fi
+
+smoke_log "T_daemon_scan_tick_handles_create_failure tick #1 PASS — warn emitted, ledger unstamped on rc=1"
+
+# Tick #2 — task_create rc=0 (success path). Clear throttle so the
+# function runs again rather than gating on `now < next`.
+rm -f "$DAEMON_TEST_TICK"
+env -i HOME="$HOME" PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" \
+  SCRIPT_DIR="$REPO_ROOT" \
+  BRIDGE_HOME="$DAEMON_TEST_HOME" \
+  BRIDGE_STATE_DIR="$DAEMON_TEST_HOME/state" \
+  BRIDGE_A2A_CONFIG="$DAEMON_TEST_CONFIG" \
+  BRIDGE_ADMIN_AGENT_ID="patch-test" \
+  BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS=300 \
+  BRIDGE_A2A_STUCK_ALERT_SECS=600 \
+  BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS=3600 \
+  BRIDGE_A2A_TEST_OUTBOX_JSON="$DAEMON_TEST_OUTBOX" \
+  BRIDGE_A2A_TEST_TASK_CREATE_RC=0 \
+  BRIDGE_A2A_TEST_WARN_LOG="$DAEMON_TEST_WARN_LOG" \
+  BRIDGE_A2A_TEST_EVENT_LOG="$DAEMON_TEST_EVENT_LOG" \
+  bash "$DAEMON_TEST_DRIVER" \
+    >"$SMOKE_TMP_ROOT/daemon-test-tick2.out" 2>"$SMOKE_TMP_ROOT/daemon-test-tick2.err" || true
+
+# Assert 3: ledger NOW stamped for msg-stuck-real-001 (success branch
+# ran ack_tmp append → ack helper stamped ledger).
+if ! grep -F 'msg-stuck-real-001' "$DAEMON_TEST_LEDGER" >/dev/null; then
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #2 did NOT stamp ledger after rc=0 — regression of success-branch ack contract (ledger: $(cat "$DAEMON_TEST_LEDGER"); event log: $(cat "$DAEMON_TEST_EVENT_LOG"); stderr: $(cat "$SMOKE_TMP_ROOT/daemon-test-tick2.err"))"
+fi
+
+# Assert 4: event log shows the daemon's emitted-count line — confirms
+# task-create success path ran end-to-end.
+if ! grep -F '[a2a_stuck_scan] emitted 1 stuck-outbox admin task' "$DAEMON_TEST_EVENT_LOG" >/dev/null; then
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #2 did not log success emission (event log: $(cat "$DAEMON_TEST_EVENT_LOG"))"
+fi
+
+smoke_log "T_daemon_scan_tick_handles_create_failure tick #2 PASS — ledger stamped on rc=0 follow-up"
+smoke_log "T_daemon_scan_tick_handles_create_failure PASS — daemon scan-tick honors task-create rc on success-branch-only ack-append contract"
+
+# ---------------------------------------------------------------------
 # Teeth — verify the helper truly fails to emit when key field is wrong.
 # ---------------------------------------------------------------------
 

--- a/scripts/smoke/I-beta4-a2a-3-gaps.sh
+++ b/scripts/smoke/I-beta4-a2a-3-gaps.sh
@@ -291,18 +291,31 @@ if printf '%s' "$T5_OUT1" | grep -F 'msg-dead-004' >/dev/null; then
   smoke_fail "T5a: helper incorrectly emitted dead row"
 fi
 
-# T5b — ledger updated with last-emit timestamp.
-if ! grep -F '"msg-stuck-001": 1000000' "$T5_LEDGER" >/dev/null; then
-  smoke_fail "T5b: ledger missing emit ts for msg-stuck-001 (ledger: $(cat "$T5_LEDGER"))"
+# v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING): decide is now pure
+# read — does NOT modify ledger. Confirm that property before we run
+# ack.
+if grep -F 'msg-stuck-001' "$T5_LEDGER" >/dev/null; then
+  smoke_fail "T5a-purity: decide unexpectedly stamped ledger (ledger: $(cat "$T5_LEDGER"))"
 fi
 
-# T5c — second call within cooldown (60s later, cooldown is 3600s): no emit.
+# T5b — daemon shell now follows up with a-stuck-ack ONLY for rows
+# whose admin task was filed successfully. Simulate the all-success
+# path: feed every emitted message_id back to ack.
+T5_ACK_KEYS="$SMOKE_TMP_ROOT/ack-keys-t5.txt"
+printf '%s' "$T5_OUT1" | awk -F'\t' 'NF{print $1}' >"$T5_ACK_KEYS"
+python3 "$HELPERS_PY" a2a-stuck-ack 1000000 "$T5_LEDGER" "$T5_ACK_KEYS" "$T5_OUTBOX" >/dev/null 2>&1 || true
+if ! grep -F '"msg-stuck-001": 1000000' "$T5_LEDGER" >/dev/null; then
+  smoke_fail "T5b: ack did not stamp ledger for msg-stuck-001 (ledger: $(cat "$T5_LEDGER"))"
+fi
+
+# T5c — second decide within cooldown (60s later, cooldown is 3600s):
+# no emit, regardless of whether shell calls ack again.
 T5_OUT2="$(python3 "$HELPERS_PY" a2a-stuck-decide 1000060 600 3600 "$T5_LEDGER" "$T5_OUTBOX" 2>&1 || true)"
 if [[ -n "$T5_OUT2" ]]; then
   smoke_fail "T5c: helper emitted within cooldown (output: $T5_OUT2)"
 fi
 
-smoke_log "T5 PASS — stuck row emitted, fresh/acked/dead suppressed, cooldown honored"
+smoke_log "T5 PASS — stuck row emitted, fresh/acked/dead suppressed, cooldown honored, ack stamps only on follow-up"
 
 # ---------------------------------------------------------------------
 # T6 — Gap 3 teeth: cooldown expiry re-emits; ledger pruning.
@@ -317,20 +330,28 @@ T6_OUT1="$(python3 "$HELPERS_PY" a2a-stuck-decide 1003700 600 3600 "$T5_LEDGER" 
 if ! printf '%s' "$T6_OUT1" | grep -F 'msg-stuck-001' >/dev/null; then
   T6_FAILS+="cooldown-expiry re-emit failed (output: $T6_OUT1); "
 fi
-# Ledger should be re-stamped to 1003700.
+# v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING): decide does NOT stamp
+# the ledger. Simulate successful follow-up ack and verify re-stamp.
+T6_ACK_KEYS="$SMOKE_TMP_ROOT/ack-keys-t6.txt"
+printf '%s' "$T6_OUT1" | awk -F'\t' 'NF{print $1}' >"$T6_ACK_KEYS"
+python3 "$HELPERS_PY" a2a-stuck-ack 1003700 "$T5_LEDGER" "$T6_ACK_KEYS" "$T5_OUTBOX" >/dev/null 2>&1 || true
 if ! grep -F '"msg-stuck-001": 1003700' "$T5_LEDGER" >/dev/null; then
-  T6_FAILS+="ledger not re-stamped after cooldown re-emit; "
+  T6_FAILS+="ledger not re-stamped after cooldown re-emit + ack; "
 fi
 
 # T6b — ledger pruning. Construct a smaller outbox (msg-stuck-001 gone)
-# and confirm the ledger entry is pruned on next decide call.
+# and confirm the ledger entry is pruned on next ack call (decide is
+# pure read; pruning now lives in ack).
 T6_OUTBOX_DROP="$SMOKE_TMP_ROOT/outbox-dropped.json"
 cat >"$T6_OUTBOX_DROP" <<'JSON'
 [
   {"message_id": "msg-fresh-002", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "pending", "attempts": 0, "next_attempt_ts": 0, "last_error": null, "acked_remote_task_id": null, "created_ts": 999000, "updated_ts": 999000, "lease_expires_ts": 0, "age_seconds": 30, "due_for_seconds": 30, "next_attempt_in_seconds": null, "lease_stale_seconds": null}
 ]
 JSON
-python3 "$HELPERS_PY" a2a-stuck-decide 1010000 600 3600 "$T5_LEDGER" "$T6_OUTBOX_DROP" >/dev/null 2>&1 || true
+# Empty ack-keys file — ack is still called every tick for pruning.
+T6_ACK_EMPTY="$SMOKE_TMP_ROOT/ack-keys-empty.txt"
+: >"$T6_ACK_EMPTY"
+python3 "$HELPERS_PY" a2a-stuck-ack 1010000 "$T5_LEDGER" "$T6_ACK_EMPTY" "$T6_OUTBOX_DROP" >/dev/null 2>&1 || true
 if grep -F 'msg-stuck-001' "$T5_LEDGER" >/dev/null; then
   T6_FAILS+="ledger did not prune msg-stuck-001 after it dropped from outbox; "
 fi
@@ -353,12 +374,98 @@ fi
 if ! grep -F '"$target_bridge" task create' "$DAEMON_SH" >/dev/null; then
   T6_FAILS+="stuck scan does not create admin task via target_bridge; "
 fi
+# T6f — v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING) wiring: daemon
+# follows up with a2a-stuck-ack helper after the task-create loop,
+# and that helper is registered in bridge-daemon-helpers.py.
+if ! grep -F 'a2a-stuck-ack' "$DAEMON_SH" >/dev/null; then
+  T6_FAILS+="daemon does not call a2a-stuck-ack helper; "
+fi
+if ! grep -F 'a2a-stuck-ack' "$HELPERS_PY" >/dev/null; then
+  T6_FAILS+="bridge-daemon-helpers.py missing a2a-stuck-ack subcommand; "
+fi
+if ! grep -nE '^def cmd_a2a_stuck_ack\(' "$HELPERS_PY" >/dev/null; then
+  T6_FAILS+="cmd_a2a_stuck_ack handler missing in helpers; "
+fi
 
 if [[ -n "$T6_FAILS" ]]; then
   smoke_fail "T6: $T6_FAILS"
 fi
 
-smoke_log "T6 PASS — cooldown expiry re-emits, ledger prunes dropped rows, daemon wiring intact"
+smoke_log "T6 PASS — cooldown expiry re-emits, ledger prunes dropped rows, decide+ack split wired"
+
+# ---------------------------------------------------------------------
+# T_stuck_task_create_failure_preserves_ledger — v0.15.0-beta4 Lane I
+# r2 (codex r1 BLOCKING).
+#
+# Contract: if `$target_bridge task create` fails (transient), the
+# daemon shell must NOT advance the reemit cooldown for that row.
+# Otherwise the operator silently loses the alert until cooldown
+# lapses. The split is enforced by:
+#   - cmd_a2a_stuck_decide: pure read, no ledger writes
+#   - daemon shell loop: append message_id to ack-keys only on
+#     task-create success (skip on failure)
+#   - cmd_a2a_stuck_ack: stamp ledger only for keys in ack-keys file
+#
+# We exercise the failure path by:
+#   - calling decide (no ledger write)
+#   - simulating task-create failure: do NOT add message_id to ack
+#     keys
+#   - calling ack with empty (or no-msg) ack-keys
+#   - asserting ledger does not contain msg-stuck-001
+#   - asserting next decide call (within cooldown) re-emits the same
+#     row (since cooldown was never advanced)
+# ---------------------------------------------------------------------
+
+smoke_log "T_stuck_task_create_failure_preserves_ledger: failed task-create keeps ledger pristine"
+
+TFAIL_OUTBOX="$SMOKE_TMP_ROOT/outbox-tcfail.json"
+TFAIL_LEDGER="$SMOKE_TMP_ROOT/stuck-alerts-tcfail.json"
+TFAIL_ACK="$SMOKE_TMP_ROOT/ack-keys-tcfail.txt"
+cat >"$TFAIL_OUTBOX" <<'JSON'
+[
+  {"message_id": "msg-stuck-fail-001", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "retry", "attempts": 3, "next_attempt_ts": 0, "last_error": "transport: peer unreachable", "acked_remote_task_id": null, "created_ts": 1000, "updated_ts": 1100, "lease_expires_ts": 0, "age_seconds": 10000, "due_for_seconds": 9000, "next_attempt_in_seconds": null, "lease_stale_seconds": null}
+]
+JSON
+printf '{}\n' >"$TFAIL_LEDGER"
+
+# Step 1 — decide. Should emit row. Ledger must remain {}.
+TFAIL_OUT1="$(python3 "$HELPERS_PY" a2a-stuck-decide 2000000 600 3600 "$TFAIL_LEDGER" "$TFAIL_OUTBOX" 2>&1 || true)"
+if ! printf '%s' "$TFAIL_OUT1" | grep -F 'msg-stuck-fail-001' >/dev/null; then
+  smoke_fail "T_stuck_task_create_failure: decide did not emit candidate row (output: $TFAIL_OUT1)"
+fi
+if grep -F 'msg-stuck-fail-001' "$TFAIL_LEDGER" >/dev/null; then
+  smoke_fail "T_stuck_task_create_failure: decide stamped ledger (regression — must be pure read)"
+fi
+
+# Step 2 — simulate task-create failure: ack-keys file stays empty.
+: >"$TFAIL_ACK"
+python3 "$HELPERS_PY" a2a-stuck-ack 2000000 "$TFAIL_LEDGER" "$TFAIL_ACK" "$TFAIL_OUTBOX" >/dev/null 2>&1 || true
+
+# Step 3 — ledger MUST NOT carry an entry for msg-stuck-fail-001.
+if grep -F 'msg-stuck-fail-001' "$TFAIL_LEDGER" >/dev/null; then
+  smoke_fail "T_stuck_task_create_failure: ack stamped ledger despite failed task-create (ledger: $(cat "$TFAIL_LEDGER"))"
+fi
+
+# Step 4 — next decide call within cooldown re-emits the same row,
+# proving the cooldown was never started.
+TFAIL_OUT2="$(python3 "$HELPERS_PY" a2a-stuck-decide 2000060 600 3600 "$TFAIL_LEDGER" "$TFAIL_OUTBOX" 2>&1 || true)"
+if ! printf '%s' "$TFAIL_OUT2" | grep -F 'msg-stuck-fail-001' >/dev/null; then
+  smoke_fail "T_stuck_task_create_failure: next scan did not re-emit (alert lost!); ledger=$(cat "$TFAIL_LEDGER") output=$TFAIL_OUT2"
+fi
+
+# Teeth — synthetic regression: simulate the broken old contract where
+# decide stamped the ledger directly. Inject the entry by hand and
+# confirm the next decide call SKIPS the row (which is what the old
+# bug looked like to the operator). This proves our new assertion
+# bites — the test must fail if someone reverts the split.
+TFAIL_LEDGER_REVERT="$SMOKE_TMP_ROOT/stuck-alerts-tcfail-revert.json"
+printf '{"msg-stuck-fail-001": 2000000}\n' >"$TFAIL_LEDGER_REVERT"
+TFAIL_OUT_REVERT="$(python3 "$HELPERS_PY" a2a-stuck-decide 2000060 600 3600 "$TFAIL_LEDGER_REVERT" "$TFAIL_OUTBOX" 2>&1 || true)"
+if printf '%s' "$TFAIL_OUT_REVERT" | grep -F 'msg-stuck-fail-001' >/dev/null; then
+  smoke_fail "T_stuck_task_create_failure teeth: with pre-stamped ledger, decide should suppress within cooldown (cooldown not honored)"
+fi
+
+smoke_log "T_stuck_task_create_failure_preserves_ledger PASS — failed task-create preserves ledger, next scan retries, teeth bites"
 
 # ---------------------------------------------------------------------
 # Teeth — verify the helper truly fails to emit when key field is wrong.

--- a/scripts/smoke/I-beta4-a2a-3-gaps.sh
+++ b/scripts/smoke/I-beta4-a2a-3-gaps.sh
@@ -1,0 +1,395 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/I-beta4-a2a-3-gaps.sh — v0.15.0-beta4 Lane I.
+#
+# Issue #1262: A2A cross-bridge — 3 gaps preventing first-class
+# operator use on fresh installs.
+#
+#   Gap 1: handoff daemon systemd unit auto-install + onboarding stub.
+#          - bridge-init.sh accepts --enable-a2a and, when set, writes
+#            $BRIDGE_HOME/handoff.local.json from the bundled example
+#            (mode 0600) AND renders the systemd-user unit preview via
+#            scripts/install-handoffd-systemd.sh (Linux).
+#          - JSON output (--json) carries a top-level `a2a_status` field
+#            so bridge-bootstrap.sh / orchestrator can branch on it.
+#          - Without --enable-a2a, no scaffold happens (a2a_status =
+#            "skipped").
+#
+#   Gap 2: outbox retry verify. Pre-existing in v0.14.5-beta22 (commit
+#          06b84c1). Static-source verification only:
+#          - bridge_a2a_common.py: backoff_seconds() with exponential
+#            base*2^(attempts-1) up to ceiling, attempts column,
+#            next_attempt_ts column.
+#          - bridge-a2a.py: _schedule_retry() honors Retry-After header
+#            and routes to 'dead' status when attempts >= max_attempts.
+#          - bridge-daemon.sh: process_a2a_deliver_tick wires the
+#            runner into cmd_sync_cycle.
+#
+#   Gap 3: outbox stuck alerting.
+#          - bridge-daemon.sh: process_a2a_outbox_stuck_scan_tick scans
+#            the outbox via `bridge-a2a.py outbox list --json` for
+#            rows pending/retry past BRIDGE_A2A_STUCK_ALERT_SECS
+#            (default 600s).
+#          - Files an admin task with `bridge-task.sh create` per
+#            stuck row, dedupe via JSON ledger
+#            ($BRIDGE_STATE_DIR/handoff/stuck-alerts.json),
+#            re-emit cooldown BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS
+#            (default 3600s).
+#          - bridge-daemon-helpers.py: a2a-stuck-decide subcommand
+#            owns the decision + ledger update (atomic rewrite via
+#            tempfile + os.replace).
+#
+# Coverage matrix:
+#   T1 — Gap 1: bridge-init.sh --enable-a2a writes config + advisory,
+#        sets a2a_status=ok in JSON output.
+#   T2 — Gap 1 teeth: without --enable-a2a, a2a_status stays "skipped"
+#        and no config is written.
+#   T3 — Gap 2: bridge_a2a_common.py exposes backoff_seconds() with
+#        exponential growth + ceiling; outbox schema has `attempts` +
+#        `next_attempt_ts` columns; bridge-a2a.py _schedule_retry()
+#        exists and routes to 'dead' on max_attempts.
+#   T4 — Gap 2: bridge-daemon.sh process_a2a_deliver_tick is wired
+#        into cmd_sync_cycle (the runner reaches the outbox).
+#   T5 — Gap 3: a2a-stuck-decide helper emits a TSV row for a stuck
+#        outbox entry on first call, then emits nothing for the same
+#        message_id within the re-emit cooldown.
+#   T6 — Gap 3 teeth: after the re-emit cooldown elapses, the same
+#        message_id alerts again. Ledger entries for message_ids no
+#        longer present in the outbox are pruned.
+#
+# All assertions are pure static-source greps OR Python-helper unit
+# tests (no live daemon required). Behavioral integration with the
+# main daemon lives in the existing a2a-cross-bridge.sh + operator-
+# host verification.
+#
+# Footgun #11: no heredoc-stdin to subprocess. All literal patterns use
+# single-quoted strings or grep with explicit pattern flags. Helper
+# input is passed via tmp file paths, not stdin.
+
+set -uo pipefail
+
+SMOKE_NAME="I-beta4-a2a-3-gaps"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+INIT_SH="$REPO_ROOT/bridge-init.sh"
+DAEMON_SH="$REPO_ROOT/bridge-daemon.sh"
+HELPERS_PY="$REPO_ROOT/bridge-daemon-helpers.py"
+A2A_COMMON_PY="$REPO_ROOT/bridge_a2a_common.py"
+A2A_PY="$REPO_ROOT/bridge-a2a.py"
+HANDOFFD_SH="$REPO_ROOT/scripts/install-handoffd-systemd.sh"
+EXAMPLE_JSON="$REPO_ROOT/handoff.local.example.json"
+
+for f in "$INIT_SH" "$DAEMON_SH" "$HELPERS_PY" "$A2A_COMMON_PY" "$A2A_PY" "$HANDOFFD_SH" "$EXAMPLE_JSON"; do
+  [[ -f "$f" ]] || smoke_fail "missing required file: $f"
+done
+
+# ---------------------------------------------------------------------
+# T1 — Gap 1: bridge-init.sh --enable-a2a flag + scaffold function +
+# JSON field present.
+# ---------------------------------------------------------------------
+
+smoke_log "T1: bridge-init.sh --enable-a2a flag wiring"
+
+T1_FAILS=""
+
+# T1a — the flag appears in the parser case block.
+if ! grep -F -- '--enable-a2a)' "$INIT_SH" >/dev/null; then
+  T1_FAILS+="missing --enable-a2a case clause; "
+fi
+
+# T1b — the flag is documented in the usage block.
+if ! grep -F -- '[--enable-a2a]' "$INIT_SH" >/dev/null; then
+  T1_FAILS+="--enable-a2a not in usage line; "
+fi
+
+# T1c — bridge_init_scaffold_a2a function exists.
+if ! grep -nE '^bridge_init_scaffold_a2a\(\)' "$INIT_SH" >/dev/null; then
+  T1_FAILS+="bridge_init_scaffold_a2a() function not defined; "
+fi
+
+# T1d — scaffold helper has at least one call site (gate verified in T2c).
+# Definition + ≥1 call site = ≥2 non-comment matches.
+T1D_CALLS="$(grep -cE 'bridge_init_scaffold_a2a' "$INIT_SH" || true)"
+if (( T1D_CALLS < 2 )); then
+  T1_FAILS+="bridge_init_scaffold_a2a has no call site (only $T1D_CALLS refs); "
+fi
+
+# T1e — JSON output carries a2a_status field.
+if ! grep -F '"a2a_status":' "$INIT_SH" >/dev/null; then
+  T1_FAILS+="a2a_status field missing from JSON output; "
+fi
+
+# T1f — install-handoffd-systemd.sh helper exists and is executable.
+if [[ ! -x "$HANDOFFD_SH" ]]; then
+  T1_FAILS+="install-handoffd-systemd.sh not executable; "
+fi
+
+# T1g — log lines route to stderr (Lane F precedent: stdout reserved for JSON).
+if grep -nE '^[[:space:]]+echo "\[init\] --enable-a2a:' "$INIT_SH" \
+     | grep -vE '>&2[[:space:]]*$' >/dev/null; then
+  T1_FAILS+="scaffold log lines not consistently routed to stderr; "
+fi
+
+if [[ -n "$T1_FAILS" ]]; then
+  smoke_fail "T1: bridge-init.sh --enable-a2a wiring: $T1_FAILS"
+fi
+smoke_log "T1 PASS — --enable-a2a flag wired, scaffold function present, JSON a2a_status field present, log lines route to stderr"
+
+# ---------------------------------------------------------------------
+# T2 — Gap 1 teeth: scaffold defaults to skipped (no flag = no write).
+# ---------------------------------------------------------------------
+
+smoke_log "T2: scaffold defaults to skipped"
+
+T2_FAILS=""
+
+# T2a — `a2a_status` defaults to "skipped" at top-of-file initialization.
+if ! grep -E 'a2a_status="skipped"' "$INIT_SH" >/dev/null; then
+  T2_FAILS+="a2a_status default literal 'skipped' missing; "
+fi
+
+# T2b — `enable_a2a=0` is the default.
+if ! grep -E '^enable_a2a=0$' "$INIT_SH" >/dev/null; then
+  T2_FAILS+="enable_a2a default 0 missing; "
+fi
+
+# T2c — bridge_init_scaffold_a2a is gated by an `if [[ $enable_a2a -eq 1 ]]`
+# branch (NOT unconditional). Find any non-definition line referencing
+# the function and walk back a few lines looking for the gate.
+T2_CALL_LINE="$(grep -nE 'bridge_init_scaffold_a2a' "$INIT_SH" | grep -vE ':[[:space:]]*#' | grep -vE 'bridge_init_scaffold_a2a\(\)' | head -1 | cut -d: -f1)"
+if [[ -z "$T2_CALL_LINE" ]]; then
+  T2_FAILS+="cannot locate scaffold call site for gate check; "
+else
+  # Up to five lines up should contain the gate `[[ $enable_a2a -eq 1 ]]`.
+  T2_GATE="$(awk -v ln="$T2_CALL_LINE" 'NR >= ln-5 && NR < ln { print }' "$INIT_SH")"
+  if ! printf '%s\n' "$T2_GATE" | grep -F '$enable_a2a -eq 1' >/dev/null; then
+    T2_FAILS+="scaffold call site not gated by enable_a2a -eq 1 (call line $T2_CALL_LINE); "
+  fi
+fi
+
+if [[ -n "$T2_FAILS" ]]; then
+  smoke_fail "T2: scaffold default-skipped contract: $T2_FAILS"
+fi
+smoke_log "T2 PASS — defaults are skipped/0; scaffold call is gated"
+
+# ---------------------------------------------------------------------
+# T3 — Gap 2 verify: retry primitives in bridge_a2a_common.py + bridge-a2a.py.
+# ---------------------------------------------------------------------
+
+smoke_log "T3: Gap 2 (retry) primitives present"
+
+T3_FAILS=""
+
+# T3a — backoff_seconds() exists with exponential growth.
+if ! grep -nE '^def backoff_seconds\(' "$A2A_COMMON_PY" >/dev/null; then
+  T3_FAILS+="backoff_seconds() missing in bridge_a2a_common.py; "
+fi
+if ! grep -F 'delay = base * (2 ** max(0, attempts - 1))' "$A2A_COMMON_PY" >/dev/null; then
+  T3_FAILS+="backoff_seconds exponential formula missing; "
+fi
+
+# T3b — _OUTBOX_SCHEMA carries attempts + next_attempt_ts columns.
+if ! grep -F 'attempts            INTEGER NOT NULL DEFAULT 0' "$A2A_COMMON_PY" >/dev/null; then
+  T3_FAILS+="outbox schema missing attempts column; "
+fi
+if ! grep -F 'next_attempt_ts     INTEGER NOT NULL DEFAULT 0' "$A2A_COMMON_PY" >/dev/null; then
+  T3_FAILS+="outbox schema missing next_attempt_ts column; "
+fi
+
+# T3c — bridge-a2a.py _schedule_retry honors Retry-After and routes to dead.
+if ! grep -nE '^def _schedule_retry\(' "$A2A_PY" >/dev/null; then
+  T3_FAILS+="_schedule_retry() missing in bridge-a2a.py; "
+fi
+if ! grep -F "delivery_max_attempts" "$A2A_PY" >/dev/null; then
+  T3_FAILS+="delivery_max_attempts policy missing; "
+fi
+if ! grep -F "status='dead'" "$A2A_PY" >/dev/null; then
+  T3_FAILS+="dead-letter routing missing on max attempts; "
+fi
+
+# T3d — Retry-After header honored.
+if ! grep -F 'Retry-After' "$A2A_PY" >/dev/null; then
+  T3_FAILS+="Retry-After header not honored; "
+fi
+
+if [[ -n "$T3_FAILS" ]]; then
+  smoke_fail "T3: Gap 2 retry primitives: $T3_FAILS"
+fi
+smoke_log "T3 PASS — backoff_seconds + attempts/next_attempt_ts schema + _schedule_retry + dead-letter on max + Retry-After"
+
+# ---------------------------------------------------------------------
+# T4 — Gap 2 verify: process_a2a_deliver_tick wired into cmd_sync_cycle.
+# ---------------------------------------------------------------------
+
+smoke_log "T4: process_a2a_deliver_tick wired into daemon sync cycle"
+
+T4_FAILS=""
+
+# T4a — process_a2a_deliver_tick function defined.
+if ! grep -nE '^process_a2a_deliver_tick\(\)' "$DAEMON_SH" >/dev/null; then
+  T4_FAILS+="process_a2a_deliver_tick() function missing; "
+fi
+
+# T4b — called from cmd_sync_cycle (LAST_STEP=a2a_deliver_tick set before call).
+if ! grep -F 'BRIDGE_DAEMON_LAST_STEP="a2a_deliver_tick"' "$DAEMON_SH" >/dev/null; then
+  T4_FAILS+="cmd_sync_cycle does not set LAST_STEP=a2a_deliver_tick; "
+fi
+if ! grep -F 'process_a2a_deliver_tick || true' "$DAEMON_SH" >/dev/null; then
+  T4_FAILS+="process_a2a_deliver_tick not invoked from cmd_sync_cycle; "
+fi
+
+if [[ -n "$T4_FAILS" ]]; then
+  smoke_fail "T4: deliver tick wiring: $T4_FAILS"
+fi
+smoke_log "T4 PASS — deliver tick wired into cmd_sync_cycle"
+
+# ---------------------------------------------------------------------
+# T5 — Gap 3: a2a-stuck-decide helper end-to-end.
+# ---------------------------------------------------------------------
+
+smoke_log "T5: a2a-stuck-decide emits stuck row + respects cooldown"
+
+# Build a synthetic outbox.json that matches the canonical shape of
+# `agb a2a outbox list --json` (per bridge-a2a.py cmd_outbox).
+T5_OUTBOX="$SMOKE_TMP_ROOT/outbox.json"
+T5_LEDGER="$SMOKE_TMP_ROOT/stuck-alerts.json"
+cat >"$T5_OUTBOX" <<'JSON'
+[
+  {"message_id": "msg-stuck-001", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "retry", "attempts": 3, "next_attempt_ts": 0, "last_error": "transport: peer unreachable", "acked_remote_task_id": null, "created_ts": 1000, "updated_ts": 1100, "lease_expires_ts": 0, "age_seconds": 10000, "due_for_seconds": 9000, "next_attempt_in_seconds": null, "lease_stale_seconds": null},
+  {"message_id": "msg-fresh-002", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "pending", "attempts": 0, "next_attempt_ts": 0, "last_error": null, "acked_remote_task_id": null, "created_ts": 999000, "updated_ts": 999000, "lease_expires_ts": 0, "age_seconds": 30, "due_for_seconds": 30, "next_attempt_in_seconds": null, "lease_stale_seconds": null},
+  {"message_id": "msg-acked-003", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "acked", "attempts": 1, "next_attempt_ts": 0, "last_error": null, "acked_remote_task_id": "task-42", "created_ts": 500, "updated_ts": 600, "lease_expires_ts": 0, "age_seconds": 100000, "due_for_seconds": null, "next_attempt_in_seconds": null, "lease_stale_seconds": null},
+  {"message_id": "msg-dead-004", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "dead", "attempts": 12, "next_attempt_ts": 0, "last_error": "max attempts (12): HTTP 401", "acked_remote_task_id": null, "created_ts": 500, "updated_ts": 600, "lease_expires_ts": 0, "age_seconds": 100000, "due_for_seconds": null, "next_attempt_in_seconds": null, "lease_stale_seconds": null}
+]
+JSON
+printf '{}\n' >"$T5_LEDGER"
+
+# T5a — first call: emit the stuck row only.
+T5_OUT1="$(python3 "$HELPERS_PY" a2a-stuck-decide 1000000 600 3600 "$T5_LEDGER" "$T5_OUTBOX" 2>&1 || true)"
+if ! printf '%s' "$T5_OUT1" | grep -F 'msg-stuck-001' >/dev/null; then
+  smoke_fail "T5a: helper did not emit stuck row (output: $T5_OUT1)"
+fi
+# Fresh row not emitted (age < threshold).
+if printf '%s' "$T5_OUT1" | grep -F 'msg-fresh-002' >/dev/null; then
+  smoke_fail "T5a: helper incorrectly emitted fresh row (age < stuck_secs)"
+fi
+# Acked row not emitted (status != pending/retry).
+if printf '%s' "$T5_OUT1" | grep -F 'msg-acked-003' >/dev/null; then
+  smoke_fail "T5a: helper incorrectly emitted acked row"
+fi
+# Dead row not emitted (status == dead, separate signal).
+if printf '%s' "$T5_OUT1" | grep -F 'msg-dead-004' >/dev/null; then
+  smoke_fail "T5a: helper incorrectly emitted dead row"
+fi
+
+# T5b — ledger updated with last-emit timestamp.
+if ! grep -F '"msg-stuck-001": 1000000' "$T5_LEDGER" >/dev/null; then
+  smoke_fail "T5b: ledger missing emit ts for msg-stuck-001 (ledger: $(cat "$T5_LEDGER"))"
+fi
+
+# T5c — second call within cooldown (60s later, cooldown is 3600s): no emit.
+T5_OUT2="$(python3 "$HELPERS_PY" a2a-stuck-decide 1000060 600 3600 "$T5_LEDGER" "$T5_OUTBOX" 2>&1 || true)"
+if [[ -n "$T5_OUT2" ]]; then
+  smoke_fail "T5c: helper emitted within cooldown (output: $T5_OUT2)"
+fi
+
+smoke_log "T5 PASS — stuck row emitted, fresh/acked/dead suppressed, cooldown honored"
+
+# ---------------------------------------------------------------------
+# T6 — Gap 3 teeth: cooldown expiry re-emits; ledger pruning.
+# ---------------------------------------------------------------------
+
+smoke_log "T6: cooldown expiry re-emits + ledger pruning"
+
+T6_FAILS=""
+
+# T6a — same row 3700s later (past 3600s cooldown): emits again.
+T6_OUT1="$(python3 "$HELPERS_PY" a2a-stuck-decide 1003700 600 3600 "$T5_LEDGER" "$T5_OUTBOX" 2>&1 || true)"
+if ! printf '%s' "$T6_OUT1" | grep -F 'msg-stuck-001' >/dev/null; then
+  T6_FAILS+="cooldown-expiry re-emit failed (output: $T6_OUT1); "
+fi
+# Ledger should be re-stamped to 1003700.
+if ! grep -F '"msg-stuck-001": 1003700' "$T5_LEDGER" >/dev/null; then
+  T6_FAILS+="ledger not re-stamped after cooldown re-emit; "
+fi
+
+# T6b — ledger pruning. Construct a smaller outbox (msg-stuck-001 gone)
+# and confirm the ledger entry is pruned on next decide call.
+T6_OUTBOX_DROP="$SMOKE_TMP_ROOT/outbox-dropped.json"
+cat >"$T6_OUTBOX_DROP" <<'JSON'
+[
+  {"message_id": "msg-fresh-002", "peer": "bridge-b", "target_agent": "reviewer", "priority": "normal", "status": "pending", "attempts": 0, "next_attempt_ts": 0, "last_error": null, "acked_remote_task_id": null, "created_ts": 999000, "updated_ts": 999000, "lease_expires_ts": 0, "age_seconds": 30, "due_for_seconds": 30, "next_attempt_in_seconds": null, "lease_stale_seconds": null}
+]
+JSON
+python3 "$HELPERS_PY" a2a-stuck-decide 1010000 600 3600 "$T5_LEDGER" "$T6_OUTBOX_DROP" >/dev/null 2>&1 || true
+if grep -F 'msg-stuck-001' "$T5_LEDGER" >/dev/null; then
+  T6_FAILS+="ledger did not prune msg-stuck-001 after it dropped from outbox; "
+fi
+
+# T6c — daemon-side function presence + wiring.
+if ! grep -nE '^process_a2a_outbox_stuck_scan_tick\(\)' "$DAEMON_SH" >/dev/null; then
+  T6_FAILS+="process_a2a_outbox_stuck_scan_tick() function missing; "
+fi
+if ! grep -F 'BRIDGE_DAEMON_LAST_STEP="a2a_stuck_scan_tick"' "$DAEMON_SH" >/dev/null; then
+  T6_FAILS+="cmd_sync_cycle does not set LAST_STEP=a2a_stuck_scan_tick; "
+fi
+if ! grep -F 'process_a2a_outbox_stuck_scan_tick || true' "$DAEMON_SH" >/dev/null; then
+  T6_FAILS+="stuck scan tick not invoked from cmd_sync_cycle; "
+fi
+# T6d — audit row name `a2a_outbox_stuck_alert_emitted` present.
+if ! grep -F 'a2a_outbox_stuck_alert_emitted' "$DAEMON_SH" >/dev/null; then
+  T6_FAILS+="audit row a2a_outbox_stuck_alert_emitted missing; "
+fi
+# T6e — admin task creation via target_bridge task create.
+if ! grep -F '"$target_bridge" task create' "$DAEMON_SH" >/dev/null; then
+  T6_FAILS+="stuck scan does not create admin task via target_bridge; "
+fi
+
+if [[ -n "$T6_FAILS" ]]; then
+  smoke_fail "T6: $T6_FAILS"
+fi
+
+smoke_log "T6 PASS — cooldown expiry re-emits, ledger prunes dropped rows, daemon wiring intact"
+
+# ---------------------------------------------------------------------
+# Teeth — verify the helper truly fails to emit when key field is wrong.
+# ---------------------------------------------------------------------
+
+smoke_log "Teeth: assertion bites on mutated input"
+
+# Synthetic regression: revert the stuck row's status from 'retry' to 'sending'.
+# The helper should now NOT emit anything (sending = runner-active, not stuck).
+T7_OUTBOX="$SMOKE_TMP_ROOT/outbox-mutated.json"
+T7_LEDGER="$SMOKE_TMP_ROOT/stuck-alerts-mutated.json"
+printf '{}\n' >"$T7_LEDGER"
+sed 's/"status": "retry"/"status": "sending"/' "$T5_OUTBOX" >"$T7_OUTBOX"
+T7_OUT="$(python3 "$HELPERS_PY" a2a-stuck-decide 1000000 600 3600 "$T7_LEDGER" "$T7_OUTBOX" 2>&1 || true)"
+if printf '%s' "$T7_OUT" | grep -F 'msg-stuck-001' >/dev/null; then
+  smoke_fail "teeth: helper emitted msg-stuck-001 with status=sending (should be excluded — teeth missing)"
+fi
+
+# Synthetic regression: drop age_seconds below threshold.
+T8_OUTBOX="$SMOKE_TMP_ROOT/outbox-fresh.json"
+T8_LEDGER="$SMOKE_TMP_ROOT/stuck-alerts-fresh.json"
+printf '{}\n' >"$T8_LEDGER"
+sed 's/"age_seconds": 10000/"age_seconds": 100/' "$T5_OUTBOX" >"$T8_OUTBOX"
+# Also drop created_ts so the fallback can't bring age back over threshold.
+sed -i.bak 's/"created_ts": 1000/"created_ts": 999900/' "$T8_OUTBOX"
+rm -f "$T8_OUTBOX.bak"
+T8_OUT="$(python3 "$HELPERS_PY" a2a-stuck-decide 1000000 600 3600 "$T8_LEDGER" "$T8_OUTBOX" 2>&1 || true)"
+if printf '%s' "$T8_OUT" | grep -F 'msg-stuck-001' >/dev/null; then
+  smoke_fail "teeth: helper emitted msg-stuck-001 with age=100 (should be excluded — teeth missing)"
+fi
+
+smoke_log "Teeth PASS — mutated status='sending' and age<threshold both correctly suppress emit"
+
+smoke_log "all tests PASS — Lane I (#1262 Gap 1 + Gap 2 verify + Gap 3) verified at current source"

--- a/scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh
+++ b/scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh
+#
+# Test driver for v0.15.0-beta4 Lane I r3 (codex r2 TEST GAP).
+#
+# Exercises the actual `process_a2a_outbox_stuck_scan_tick` shell function
+# from bridge-daemon.sh in isolation, with mocks for:
+#   - `bridge-a2a.py outbox list --json` (returns fixture JSON path)
+#   - `$BRIDGE_HOME/agent-bridge task create` (rc controlled by
+#     `BRIDGE_A2A_TEST_TASK_CREATE_RC` env var)
+#
+# This driver:
+#   1. Extracts the `process_a2a_outbox_stuck_scan_tick` function body
+#      verbatim from bridge-daemon.sh (via awk between the `() {` line
+#      and the matching `^}` close brace) and `eval`s it in this shell.
+#   2. Stubs `daemon_warn` / `daemon_log_event` / `bridge_audit_log`
+#      so we can capture warning output and don't need to source the
+#      full lib stack.
+#   3. Overrides `bridge_with_timeout` so the inner subprocess for
+#      `a2a_outbox_list` reads from a fixture file (mock), while the
+#      `a2a_stuck_decide` / `a2a_stuck_ack` calls pass through to the
+#      real `bridge-daemon-helpers.py`.
+#   4. Invokes the function once.
+#
+# Inputs (env):
+#   - SCRIPT_DIR          : repo root (so daemon function can find
+#                           bridge-a2a.py + bridge-daemon-helpers.py)
+#   - BRIDGE_HOME         : isolated home (smoke_setup_bridge_home)
+#   - BRIDGE_STATE_DIR    : ditto
+#   - BRIDGE_ADMIN_AGENT_ID : admin agent target (e.g. "patch")
+#   - BRIDGE_A2A_TEST_OUTBOX_JSON : path to outbox-list JSON fixture
+#   - BRIDGE_A2A_TEST_TASK_CREATE_RC : 0 = success, 1 = failure
+#   - BRIDGE_A2A_TEST_WARN_LOG : path to capture daemon_warn output
+#   - BRIDGE_A2A_TEST_EVENT_LOG : path to capture daemon_log_event output
+#
+# Exit code: 0 if function ran (regardless of internal rc); non-zero only
+# on driver setup error.
+
+set -uo pipefail
+
+DRIVER_SCRIPT_DIR="${SCRIPT_DIR:-}"
+if [[ -z "$DRIVER_SCRIPT_DIR" ]]; then
+  echo "[I-beta4-helpers] SCRIPT_DIR not set; cannot locate bridge-daemon.sh" >&2
+  exit 2
+fi
+
+DAEMON_SH="$DRIVER_SCRIPT_DIR/bridge-daemon.sh"
+if [[ ! -f "$DAEMON_SH" ]]; then
+  echo "[I-beta4-helpers] missing bridge-daemon.sh at $DAEMON_SH" >&2
+  exit 2
+fi
+
+# Required env contract (fail-loud if missing).
+for var in BRIDGE_HOME BRIDGE_STATE_DIR BRIDGE_ADMIN_AGENT_ID \
+           BRIDGE_A2A_TEST_OUTBOX_JSON BRIDGE_A2A_TEST_TASK_CREATE_RC \
+           BRIDGE_A2A_TEST_WARN_LOG BRIDGE_A2A_TEST_EVENT_LOG; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "[I-beta4-helpers] required env var $var is empty" >&2
+    exit 2
+  fi
+done
+
+# Stub helpers normally provided by bridge-lib.sh + lib/bridge-state.sh.
+# All four functions below are called INDIRECTLY by the eval'd
+# `process_a2a_outbox_stuck_scan_tick` body (extracted from
+# bridge-daemon.sh further down). Shellcheck cannot see those indirect
+# call sites, so we suppress SC2329 explicitly per stub.
+
+# shellcheck disable=SC2329
+daemon_warn() {
+  local message="$1"
+  printf '[%s] [warn] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$message" \
+    >>"$BRIDGE_A2A_TEST_WARN_LOG"
+  # Also echo to stderr so smoke can capture if needed.
+  printf '[%s] [warn] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$message" >&2
+}
+
+# shellcheck disable=SC2329
+daemon_log_event() {
+  local message="$1"
+  printf '[%s] %s\n' "$(date '+%Y-%m-%dT%H:%M:%S%z')" "$message" \
+    >>"$BRIDGE_A2A_TEST_EVENT_LOG"
+}
+
+# shellcheck disable=SC2329
+bridge_audit_log() {
+  # No-op stub — production audit_log writes to BRIDGE_AUDIT_LOG and has
+  # many helper dependencies. Test asserts the warning + ledger state,
+  # not audit rows.
+  return 0
+}
+
+# bridge_with_timeout signature: bridge_with_timeout <secs> <label> <cmd...>
+# Production routes label "a2a_outbox_list" to `bridge-a2a.py outbox list
+# --json`. The driver swaps in a `cat $fixture` for that label so we don't
+# need a real SQLite outbox.
+# shellcheck disable=SC2329
+bridge_with_timeout() {
+  local secs="${1:-}"
+  local label="${2:-unknown}"
+  shift 2 || true
+  case "$label" in
+    a2a_outbox_list)
+      # Return fixture JSON. Production would invoke
+      # `python3 bridge-a2a.py outbox list --json` here.
+      cat "$BRIDGE_A2A_TEST_OUTBOX_JSON"
+      return 0
+      ;;
+    a2a_stuck_decide|a2a_stuck_ack)
+      # Pass-through to the real python helper — these are the call
+      # paths under test.
+      "$@"
+      return $?
+      ;;
+    *)
+      # Unknown label — pass-through.
+      "$@"
+      return $?
+      ;;
+  esac
+}
+
+# Extract the production function body verbatim from bridge-daemon.sh.
+# Boundary: `^process_a2a_outbox_stuck_scan_tick() \{$` ... first `^\}$`.
+FN_SRC="$(awk '/^process_a2a_outbox_stuck_scan_tick\(\) \{/,/^\}$/' "$DAEMON_SH")"
+if [[ -z "$FN_SRC" ]] || ! printf '%s' "$FN_SRC" | grep -F 'process_a2a_outbox_stuck_scan_tick' >/dev/null; then
+  echo "[I-beta4-helpers] failed to extract function body from $DAEMON_SH" >&2
+  exit 2
+fi
+
+# shellcheck disable=SC2086
+eval "$FN_SRC"
+
+# Sanity-check the function is now defined in this shell.
+if ! declare -F process_a2a_outbox_stuck_scan_tick >/dev/null; then
+  echo "[I-beta4-helpers] eval did not define process_a2a_outbox_stuck_scan_tick" >&2
+  exit 2
+fi
+
+# The production function gates on the existence of handoff.local.json.
+# Smoke must have created it. Confirm.
+HANDOFF_CONFIG="${BRIDGE_A2A_CONFIG:-$BRIDGE_HOME/handoff.local.json}"
+if [[ ! -f "$HANDOFF_CONFIG" ]]; then
+  echo "[I-beta4-helpers] $HANDOFF_CONFIG missing — smoke must seed it" >&2
+  exit 2
+fi
+
+# Run the actual production code path.
+process_a2a_outbox_stuck_scan_tick || true
+
+exit 0


### PR DESCRIPTION
## Summary

Lane I of the v0.15.0-beta4 wave Sub-wave 3. Closes #1262 (A2A 3 gaps preventing first-class operator use on fresh installs).

- **Gap 1 — onboarding scaffold**: `bridge-init.sh --enable-a2a` opt-in. Copies `handoff.local.example.json` → `$BRIDGE_HOME/handoff.local.json` (mode 0600) and renders the new `scripts/install-handoffd-systemd.sh` systemd-user unit preview on Linux. JSON output carries a new `a2a_status` field. Activation of the unit stays operator-explicit.
- **Gap 2 — retry verify**: Already implemented in v0.14.5-beta22 commit `06b84c1` (`backoff_seconds` exponential + ceiling, `_schedule_retry` dead-letter on `delivery_max_attempts`, daemon delivery tick wiring). Smoke pins the contract via static-source greps.
- **Gap 3 — outbox stuck alerting**: New `process_a2a_outbox_stuck_scan_tick` in `bridge-daemon.sh` + `a2a-stuck-decide` subcommand in `bridge-daemon-helpers.py`. Scans the outbox every `BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS` (default 300s), files admin tasks for rows older than `BRIDGE_A2A_STUCK_ALERT_SECS` (default 600s) with per-message cooldown `BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS` (default 3600s). Atomic JSON ledger under `$BRIDGE_STATE_DIR/handoff/stuck-alerts.json`.

## Files

- `bridge-init.sh` — `--enable-a2a` flag + `bridge_init_scaffold_a2a` helper + JSON `a2a_status` field. All log lines to stderr (Lane F #1230 precedent).
- `scripts/install-handoffd-systemd.sh` (NEW) — Renders/installs the `agb-handoffd.service` systemd-user unit.
- `bridge-daemon.sh` — `process_a2a_outbox_stuck_scan_tick` + `cmd_sync_cycle` wiring (`BRIDGE_DAEMON_LAST_STEP="a2a_stuck_scan_tick"`).
- `bridge-daemon-helpers.py` — `cmd_a2a_stuck_decide` subcommand owning the decision + ledger lifecycle (atomic tempfile+os.replace rewrite).
- `scripts/smoke/I-beta4-a2a-3-gaps.sh` (NEW) — T1-T6 + teeth, ~270 LOC.
- `scripts/ci-select-smoke.sh` — Registered `I-beta4-a2a-3-gaps` in the master list and at four file-pattern call sites (A2A family, bridge-daemon.sh, bridge-daemon-helpers.py, bridge-init.sh).

## Footgun #11 compliance

The new tick uses tempfile paths (`$list_tmp`, `$emit_tmp`) for the outbox JSON + emit output, NOT heredoc-stdin or here-string. Row loop uses `done <"$emit_tmp"`. Helper passes JSON via `--outbox-json-file <path>` positional.

## Test plan

- [x] `bash -n` clean on all modified shell files + new helper + new smoke.
- [x] `shellcheck -e SC2034 -e SC1090 -e SC1091` clean.
- [x] `python3 -m py_compile` clean on `bridge_a2a_common.py`, `bridge-handoffd.py`, `bridge-daemon-helpers.py`, `bridge-a2a.py`.
- [x] `bash scripts/smoke/I-beta4-a2a-3-gaps.sh` — T1-T6 + teeth PASS.
- [x] beta3+beta4 9-smoke regression sweep — 12-of-13 PASS (G-beta4-watchdog-noise pre-existing failure on base `0cffb8e`, unrelated).
- [x] Manual `bridge-init.sh --enable-a2a --dry-run --json` → `a2a_status: "dry-run"` in JSON output, advisory on stderr only.
- [x] Manual `bridge-init.sh --dry-run --json` (no `--enable-a2a`) → `a2a_status: "skipped"`.
- [x] Manual `scripts/install-handoffd-systemd.sh --bridge-home /tmp/test --source-dir <repo>` renders a clean Type=simple unit with `Restart=on-failure` and the receiver invoked WITHOUT `--detach` (systemd owns the lifecycle).
- [ ] Operator-host: `systemctl --user enable --now agb-handoffd.service` after `bridge-init.sh --enable-a2a`, then `agb a2a peers test <peer>` to confirm the receiver binds.
- [ ] Operator-host: synthesize a stuck outbox row (drop peer secret, send) and wait `BRIDGE_A2A_STUCK_ALERT_SECS` to confirm an admin task lands.

(#1262 Track I)

🤖 Generated with [Claude Code](https://claude.com/claude-code)