### PR TITLE
fix(beta4 Lane K): nits batch — #1282 + #1283 + #1247 + #1253 + #1255

### DIFF
--- a/agent-bridge
+++ b/agent-bridge
@@ -433,6 +433,84 @@ if [[ $# -gt 0 ]]; then
     admin)
       shift
       ADMIN_AGENT="$(bridge_require_admin_agent)"
+
+      # Issue #1247 — `agb admin set <key>=<value>` CLI surface.
+      # Phase 1: persist a `auto_restart_on_membership_change` flag (on |
+      # off) into `state/admin-config.json`. Future PRs wire this flag
+      # into the post-`agent create` admin-set restart automation
+      # described in #1247's "Desired behavior" section. Keeping the
+      # flag here (not in `agent-roster.local.sh`) avoids touching the
+      # protected-mutation surface and means operators can flip it
+      # without going through `agent-bridge config set`.
+      if [[ "${1:-}" == "set" ]]; then
+        shift
+        admin_set_auto_restart=""
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --auto-restart)
+              [[ $# -lt 2 ]] && bridge_die "--auto-restart 뒤에 on|off를 지정하세요."
+              admin_set_auto_restart="$2"
+              shift 2
+              ;;
+            --auto-restart=*)
+              admin_set_auto_restart="${1#--auto-restart=}"
+              shift
+              ;;
+            -h|--help)
+              cat <<'ADMINSET'
+Usage:
+  agent-bridge admin set --auto-restart on|off
+
+Persist admin-set lifecycle flags. Currently exposes:
+
+  --auto-restart on|off
+      Toggle `auto_restart_on_membership_change`. When `on`, future
+      `agent create --isolate` runs will queue an admin-set restart
+      (admin + codex pair) after the daemon refresh so the new
+      `ab-agent-<new>` group lands in their supplementary set without
+      operator intervention. When `off` (default), the operator
+      restarts the admin set manually.
+
+  See issue #1247 for the desired admin-set restart sequence
+  (resume-id-carrying, sequential, single-line status per admin).
+ADMINSET
+              exit 0
+              ;;
+            *)
+              bridge_die "admin set: 알 수 없는 인자: $1"
+              ;;
+          esac
+        done
+
+        if [[ -z "$admin_set_auto_restart" ]]; then
+          bridge_die "admin set: --auto-restart on|off가 필요합니다."
+        fi
+        case "$admin_set_auto_restart" in
+          on|off) ;;
+          *)
+            bridge_die "admin set: --auto-restart 값은 on|off 중 하나여야 합니다 ('$admin_set_auto_restart' 거부)."
+            ;;
+        esac
+
+        admin_config_dir="${BRIDGE_STATE_DIR:-$BRIDGE_HOME/state}"
+        admin_config_path="$admin_config_dir/admin-config.json"
+
+        mkdir -p "$admin_config_dir" 2>/dev/null || \
+          bridge_die "admin set: state directory를 만들 수 없습니다: $admin_config_dir"
+
+        # File-as-argv per footgun #11: invoke the standalone helper
+        # with explicit flags rather than piping a heredoc into a
+        # subprocess. Keeps the bash layer thin and the JSON-write
+        # logic auditable in one place.
+        python3 "$SCRIPT_DIR/scripts/python-helpers/admin-set-config.py" \
+          set-auto-restart \
+          --admin "$ADMIN_AGENT" \
+          --config "$admin_config_path" \
+          --value "$admin_set_auto_restart" \
+          || bridge_die "admin set: admin-config.json 갱신 실패."
+        exit 0
+      fi
+
       ADMIN_ENGINE="$(bridge_agent_engine "$ADMIN_AGENT")"
       ADMIN_WORKDIR="$(bridge_agent_workdir "$ADMIN_AGENT")"
       ADMIN_SAFE_MODE=0

--- a/bridge-dev-plugin-cache.py
+++ b/bridge-dev-plugin-cache.py
@@ -672,6 +672,50 @@ def overlay_source_to_cache(
     return changed
 
 
+# Issue #1282 (Surface B) — conservative heuristic that mirrors the one
+# in `lib/upgrade-helpers/plugins-seed-parse-sync-output.py`. Used to
+# distinguish `node_modules=missing` from `node_modules=not-required`
+# so `.mjs` proxy plugins that ship without a `package.json` (e.g.
+# `cosmax-ep-approval`'s `ep-mcp-proxy.mjs` — inline-deps) do not paint
+# the seed output with cosmetic noise. Returns True when the plugin's
+# source ANY of:
+#   * declares non-empty `dependencies` / `peerDependencies` in package.json
+#   * ships a sibling lockfile (bun.lock, bun.lockb, package-lock.json,
+#     yarn.lock)
+# Any I/O error → False (steady-state benign — caller stays on the
+# legacy `missing` label so a real install gap is still surfaced).
+def _plugin_source_declares_deps(source_path: Path) -> bool:
+    try:
+        if not source_path.is_dir():
+            return False
+    except OSError:
+        return False
+    for lock in ("bun.lock", "bun.lockb", "package-lock.json", "yarn.lock"):
+        try:
+            if (source_path / lock).is_file():
+                return True
+        except OSError:
+            continue
+    pkg = source_path / "package.json"
+    try:
+        if not pkg.is_file():
+            return False
+    except OSError:
+        return False
+    try:
+        with pkg.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except Exception:
+        return False
+    if not isinstance(data, dict):
+        return False
+    for key in ("dependencies", "peerDependencies"):
+        deps = data.get(key)
+        if isinstance(deps, dict) and deps:
+            return True
+    return False
+
+
 def link_source_node_modules(source_path: Path, cache_version_path: Path) -> tuple[str, str]:
     source_node_modules = source_path / "node_modules"
     cache_node_modules = cache_version_path / "node_modules"
@@ -937,6 +981,16 @@ def sync_plugin_cache(root: Path, channel: str) -> dict[str, str]:
     elif cache_node_modules.exists():
         node_modules_status = "not-directory"
         node_modules_target = str(cache_node_modules)
+    elif not _plugin_source_declares_deps(source_path):
+        # Issue #1282 (Surface B) — `.mjs` proxy plugins (e.g.
+        # `cosmax-ep-approval`'s `ep-mcp-proxy.mjs`) use Node.js inline
+        # deps and ship without a `package.json`/lockfile. The seed
+        # used to emit `node_modules=missing` for these, which painted
+        # the operator dashboard with cosmetic false-positive noise.
+        # Mark the field honestly: this plugin's source does not
+        # declare deps, so no `node_modules` directory is expected.
+        node_modules_status = "not-required"
+        node_modules_target = ""
     else:
         node_modules_status = "missing"
         node_modules_target = ""

--- a/bridge-diagnose.sh
+++ b/bridge-diagnose.sh
@@ -3,262 +3,47 @@
 #
 # Agent Bridge health / hygiene scanners. `agent-bridge diagnose <subcommand>`.
 #
-# Currently exposes:
-#   agent-bridge diagnose acl    — scan `/`, `/home`, the operator's home,
-#                                  BRIDGE_HOME and BRIDGE_AGENT_HOME_ROOT for
-#                                  stale named-user ACL entries that isolate
-#                                  may have left behind (issue #233). Outputs
-#                                  the exact `setfacl -x` command the operator
-#                                  can run to drain each one.
+# Historical note (issue #1283): the `acl` subcommand was retired in
+# v0.15.0-beta4. ACL-based cross-UID grants are no longer the recommended
+# isolation mechanism — `linux-user isolation` (iso v2) uses group-based
+# permissions instead. The scanner that walked /, /home, BRIDGE_HOME and
+# BRIDGE_AGENT_HOME_ROOT for named-user ACL residue is removed; any
+# remaining residue should be cleaned via the iso v2 reconcile path
+# (`agent-bridge isolation reconcile --apply --agent <agent>`).
 #
-# Everything here is read-only — no ACL mutation, no root sudo — so the
-# scanner is safe to run from the same shell the operator uses for
-# normal work.
+# This shim preserves the `agent-bridge diagnose` verb entry point so
+# operator muscle-memory still gets a useful pointer instead of "command
+# not found", and emits a non-zero exit so scripts that branched on the
+# old verb fail loudly.
 
 set -euo pipefail
-
-BRIDGE_DIAGNOSE_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
-# shellcheck source=bridge-lib.sh
-source "$BRIDGE_DIAGNOSE_SCRIPT_DIR/bridge-lib.sh"
 
 bridge_diagnose_usage() {
   cat <<'USAGE'
 Usage:
-  agent-bridge diagnose acl [--json]
+  agent-bridge diagnose [help]
 
-Scan for stale Agent Bridge named-user ACL entries on shared roots.
-Reads only — does not modify any ACL. Lists `setfacl -x` commands the
-operator can run to drain any entry that shouldn't still be there.
+The `acl` subcommand was retired in v0.15.0-beta4 (issue #1283).
+ACL-based cross-UID grants are no longer the recommended isolation
+mechanism. Use `agent-bridge isolation reconcile --apply --agent <agent>`
+to drain residue, and `agent-bridge isolation status --agent <agent>`
+to inspect the current group/UID layout.
 
-Linux only. macOS installs don't use POSIX ACLs for this path and
-always report "[ok]".
+No other diagnose subcommands are currently published.
 USAGE
 }
 
-bridge_diagnose_acl_is_suspicious() {
-  local entry_user="$1"
-  local controller="$2"
+bridge_diagnose_acl_deprecation_notice() {
+  cat >&2 <<'NOTICE'
+[deprecated] `agent-bridge diagnose acl` was retired in v0.15.0-beta4
+(issue #1283). ACL-based cross-UID grants are no longer the recommended
+isolation mechanism — `linux-user isolation` (iso v2) uses group-based
+permissions instead.
 
-  [[ -n "$entry_user" ]] || return 1
-  case "$entry_user" in
-    agent-bridge-*)
-      return 0
-      ;;
-  esac
-  if [[ -n "$controller" && "$entry_user" == "$controller" ]]; then
-    return 0
-  fi
-  return 1
-}
-
-bridge_diagnose_acl_scan_path() {
-  # Emit one `[<path>]` header + lines per suspicious entry. No output if
-  # the path is missing or clean. Writes to stdout; returns 0 unless
-  # getfacl itself fails.
-  local path="$1"
-  local controller="$2"
-  local json_mode="${3:-0}"
-  local output=""
-  local entries=""
-  local entry=""
-  local entry_user=""
-  local kind="access"
-  local any=0
-
-  [[ -e "$path" ]] || return 0
-  command -v getfacl >/dev/null 2>&1 || return 0
-  output="$(getfacl -p "$path" 2>/dev/null)" || return 0
-  # `user:<name>:...` lines carry named entries. `user::...` is the base
-  # owner entry and is never suspicious. `default:user:<name>:...` is
-  # the inherited-default ACL; classify it separately so the operator
-  # can see which setfacl -x flag (access vs. default) to use.
-  entries="$(printf '%s\n' "$output" \
-    | grep -E '^(default:)?user:[^:]+:' \
-    | grep -vE '^(default:)?user::' || true)"
-  [[ -n "$entries" ]] || return 0
-
-  while IFS= read -r entry; do
-    [[ -n "$entry" ]] || continue
-    if [[ "$entry" == default:* ]]; then
-      kind="default"
-      entry_user="${entry#default:user:}"
-    else
-      kind="access"
-      entry_user="${entry#user:}"
-    fi
-    entry_user="${entry_user%%:*}"
-    bridge_diagnose_acl_is_suspicious "$entry_user" "$controller" || continue
-    if (( any == 0 )); then
-      if [[ "$json_mode" != "1" ]]; then
-        printf '[%s]\n' "$path"
-      fi
-      any=1
-    fi
-    if [[ "$json_mode" == "1" ]]; then
-      printf '{"path":%s,"user":%s,"kind":%s,"raw":%s}\n' \
-        "$(bridge_diagnose_json_str "$path")" \
-        "$(bridge_diagnose_json_str "$entry_user")" \
-        "$(bridge_diagnose_json_str "$kind")" \
-        "$(bridge_diagnose_json_str "$entry")"
-    else
-      local flag=""
-      if [[ "$kind" == "default" ]]; then
-        flag="-d "
-      fi
-      printf '  suspicious (%s): %s\n' "$kind" "$entry"
-      printf '  fix: sudo setfacl %s-x u:%s %s\n' "$flag" "$entry_user" "$path"
-    fi
-  done <<<"$entries"
-
-  return 0
-}
-
-bridge_diagnose_json_str() {
-  # Emit a JSON-encoded string using python3 so weird paths (spaces,
-  # quotes, UTF-8) don't break the output. getfacl output is already
-  # UTF-8 in practice.
-  bridge_require_python
-  python3 - "$1" <<'PY'
-import json
-import sys
-print(json.dumps(sys.argv[1]))
-PY
-}
-
-bridge_diagnose_acl_targets() {
-  # Build the canonical scan target list. `/` and `/home` are always in
-  # scope because they're the two paths #233's isolate regression most
-  # commonly poisoned. The controller's home is checked separately
-  # because named-user entries there also strip operator access. Any
-  # agent-bridge-specific roots that exist on the host get scanned too.
-  local controller_user="$1"
-  local controller_home=""
-
-  printf '/\n'
-  printf '/home\n'
-
-  controller_home="$(getent passwd "$controller_user" 2>/dev/null | cut -d: -f6 || true)"
-  if [[ -n "$controller_home" && -d "$controller_home" && "$controller_home" != "/" ]]; then
-    printf '%s\n' "$controller_home"
-  fi
-
-  if [[ -n "${BRIDGE_HOME:-}" && -d "$BRIDGE_HOME" ]]; then
-    printf '%s\n' "$BRIDGE_HOME"
-  fi
-  if [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" && -d "$BRIDGE_AGENT_HOME_ROOT" ]]; then
-    printf '%s\n' "$BRIDGE_AGENT_HOME_ROOT"
-  fi
-  if [[ -n "${BRIDGE_STATE_DIR:-}" && -d "$BRIDGE_STATE_DIR" ]]; then
-    printf '%s\n' "$BRIDGE_STATE_DIR"
-  fi
-}
-
-bridge_diagnose_acl_main() {
-  local json_mode=0
-  while [[ $# -gt 0 ]]; do
-    case "$1" in
-      --json)
-        json_mode=1
-        shift
-        ;;
-      -h|--help)
-        bridge_diagnose_usage
-        return 0
-        ;;
-      *)
-        printf 'unknown argument: %s\n' "$1" >&2
-        bridge_diagnose_usage >&2
-        return 2
-        ;;
-    esac
-  done
-
-  if [[ "$(uname -s 2>/dev/null || printf '')" != "Linux" ]]; then
-    if [[ "$json_mode" == "1" ]]; then
-      printf '{"platform":"non-linux","findings":[]}\n'
-    else
-      printf '[ok] non-linux host — POSIX ACL scanner does not apply\n'
-    fi
-    return 0
-  fi
-  if ! command -v getfacl >/dev/null 2>&1; then
-    # The skip banner has to land on stdout in both modes: callers
-    # (including the smoke harness) capture stdout, so writing to
-    # stderr would leave them with an empty string that looked like
-    # success on a host that actually can't scan. JSON mode still has
-    # to emit a parseable payload even in the "skipped" case.
-    if [[ "$json_mode" == "1" ]]; then
-      printf '{"platform":"linux","skipped":"getfacl-missing","findings":[]}\n'
-    else
-      printf '[skip] getfacl not installed — install the acl package to scan\n'
-    fi
-    return 0
-  fi
-
-  local controller_user=""
-  controller_user="$(bridge_current_user 2>/dev/null || id -un 2>/dev/null || printf '')"
-
-  local targets=()
-  while IFS= read -r target; do
-    [[ -n "$target" ]] && targets+=("$target")
-  done < <(bridge_diagnose_acl_targets "$controller_user")
-
-  # Aggregate JSON findings through a bash array so cross-target results
-  # keep their per-finding boundary. Command substitution strips trailing
-  # newlines, so concatenating stdout from two scan_path calls used to
-  # yield `{a}\n{b}{c}\n{d}` — invalid JSON as soon as a second target
-  # added anything. Feeding scan_path's stdout through `while read` into
-  # an array preserves the one-finding-per-element contract.
-  local any=0
-  local -a json_findings=()
-  local result=""
-  local target=""
-
-  for target in "${targets[@]}"; do
-    if [[ "$json_mode" == "1" ]]; then
-      while IFS= read -r result; do
-        [[ -n "$result" ]] || continue
-        json_findings+=("$result")
-        any=1
-      done < <(bridge_diagnose_acl_scan_path "$target" "$controller_user" "$json_mode" || true)
-    else
-      result="$(bridge_diagnose_acl_scan_path "$target" "$controller_user" "$json_mode" || true)"
-      [[ -n "$result" ]] || continue
-      if (( any == 1 )); then
-        printf '\n'
-      fi
-      printf '%s' "$result"
-      any=1
-    fi
-  done
-
-  if [[ "$json_mode" == "1" ]]; then
-    local joined=""
-    if (( ${#json_findings[@]} > 0 )); then
-      local _old_ifs="$IFS"
-      IFS=','
-      joined="${json_findings[*]}"
-      IFS="$_old_ifs"
-    fi
-    printf '{"platform":"linux","controller":%s,"findings":[%s]}\n' \
-      "$(bridge_diagnose_json_str "$controller_user")" \
-      "$joined"
-    return 0
-  fi
-
-  if (( any == 0 )); then
-    printf '[ok] no suspicious named-user ACL entries found on %s\n' "${targets[*]}"
-    return 0
-  fi
-
-  cat <<EOF
-
-[note] each "fix:" line above removes exactly one stale entry.
-       You can apply them directly, or run:
-         agent-bridge unisolate <agent>
-       for every previously-isolated agent to let the shipped
-       cleanup (PR #235) drain the residue in one shot.
-EOF
+To inspect / repair an isolated agent's group + UID layout, use:
+  agent-bridge isolation status   --agent <agent>
+  agent-bridge isolation reconcile --apply --agent <agent>
+NOTICE
 }
 
 bridge_diagnose_cli() {
@@ -267,7 +52,8 @@ bridge_diagnose_cli() {
 
   case "$subcommand" in
     acl)
-      bridge_diagnose_acl_main "$@"
+      bridge_diagnose_acl_deprecation_notice
+      return 2
       ;;
     ""|-h|--help|help)
       bridge_diagnose_usage

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -1160,6 +1160,11 @@ def cmd_claim(args: argparse.Namespace) -> int:
     lease_seconds = int(args.lease_seconds)
     current_ts = now_ts()
     lease_until_ts = current_ts + lease_seconds
+    # Issue #1253 — optional --note / --note-file mirror `done` / `update`
+    # so claim-time audit context lands in the task_events log alongside
+    # the canonical `event_type=claimed` row.
+    note_text = getattr(args, "note", None)
+    note_path = normalize_path(getattr(args, "note_file", None))
 
     with closing(connect()) as conn, conn:
         task = require_task(conn, args.task_id)
@@ -1189,10 +1194,27 @@ def cmd_claim(args: argparse.Namespace) -> int:
             """,
             (agent, current_ts, lease_until_ts, current_ts, args.task_id),
         )
-        emit_event(conn, args.task_id, event_type="claimed", actor=agent, created_ts=current_ts, to_agent=agent)
+        emit_event(
+            conn,
+            args.task_id,
+            event_type="claimed",
+            actor=agent,
+            created_ts=current_ts,
+            note_text=note_text,
+            note_path=note_path,
+            to_agent=agent,
+        )
         touch_agent_activity(conn, agent, current_ts)
 
-    print(f"claimed task #{args.task_id} as {agent} (lease={lease_seconds}s)")
+    # Echo a short `claim_note=<n-chars>` summary on stdout so scripts /
+    # operator-readable transcripts can confirm the note actually landed
+    # in the event log (per #1253 acceptance criteria).
+    note_summary = ""
+    if note_text is not None:
+        note_summary = f" claim_note={len(note_text)}c"
+    elif note_path:
+        note_summary = f" claim_note=file:{note_path}"
+    print(f"claimed task #{args.task_id} as {agent} (lease={lease_seconds}s){note_summary}")
     return 0
 
 
@@ -2597,6 +2619,12 @@ def build_parser() -> argparse.ArgumentParser:
     claim_parser.add_argument("task_id", type=int)
     claim_parser.add_argument("--agent", required=True)
     claim_parser.add_argument("--lease-seconds", default=os.environ.get("BRIDGE_TASK_LEASE_SECONDS", "900"))
+    # Issue #1253 — symmetric with `done` / `update`. --note and --note-file
+    # are mutually exclusive so the operator never accidentally double-
+    # specifies the audit text.
+    claim_note_group = claim_parser.add_mutually_exclusive_group()
+    claim_note_group.add_argument("--note")
+    claim_note_group.add_argument("--note-file")
     claim_parser.set_defaults(handler=cmd_claim)
 
     done_parser = subparsers.add_parser("done", allow_abbrev=False)

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -808,8 +808,20 @@ bridge_run_prune_legacy_teams_mcp() {
     --agent-root "$BRIDGE_AGENT_HOME_ROOT/$AGENT" \
     2>&1)" || rc=$?
 
+  # Issue #1282 (Surface A) — `absent path=…` is the steady-state output
+  # on a healthy install (legacy mcpServers.teams entry was already
+  # cleaned up or never existed). Logging it on every Claude run paints
+  # the operator's audit tail with cosmetic noise that masks real
+  # actions. Suppress `absent`/`unchanged` rows; keep `pruned`/`failed`/
+  # `skipped` rows because those reflect a real state change or a
+  # condition the operator may need to act on.
   while IFS= read -r line; do
     [[ -n "$line" ]] || continue
+    case "$line" in
+      "absent path="*|"unchanged path="*)
+        continue
+        ;;
+    esac
     log_line "[legacy-teams-mcp] $line"
   done <<<"$output"
 

--- a/bridge-task.sh
+++ b/bridge-task.sh
@@ -34,7 +34,7 @@ Usage:
   bash $SCRIPT_DIR/bridge-task.sh create --to <agent> --title <title> [--body <text> | --body-file <path>] [--allow-empty-body] [--from <agent>] [--priority low|normal|high|urgent]
   bash $SCRIPT_DIR/bridge-task.sh inbox [agent] [--all]
   bash $SCRIPT_DIR/bridge-task.sh show <task-id>
-  bash $SCRIPT_DIR/bridge-task.sh claim <task-id> [--agent <agent>] [--lease <seconds>]
+  bash $SCRIPT_DIR/bridge-task.sh claim <task-id> [--agent <agent>] [--lease <seconds>] [--note <text> | --note-file <path>]
   bash $SCRIPT_DIR/bridge-task.sh done <task-id> [--agent <agent>] [--note <text> | --note-file <path>]
   bash $SCRIPT_DIR/bridge-task.sh cancel <task-id> [--actor <name>] [--note <text> | --note-file <path>]
   bash $SCRIPT_DIR/bridge-task.sh update <task-id> [--status queued|claimed|blocked|in_progress] [--priority ...] [--title ...] [--note ...]
@@ -545,6 +545,8 @@ cmd_claim() {
   local task_id=""
   local agent=""
   local lease=""
+  local note=""
+  local note_file=""
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -556,6 +558,20 @@ cmd_claim() {
       --lease)
         [[ $# -lt 2 ]] && bridge_die "--lease 뒤에 초 단위를 지정하세요."
         lease="$2"
+        shift 2
+        ;;
+      --note)
+        # Issue #1253 — symmetric with `agb done` / `agb update`. Lets
+        # operators record claim-time audit context (e.g. "claim during
+        # onboarding; will close after onboarding completes") without
+        # having to fall back to `agb update --status claimed --note ...`.
+        [[ $# -lt 2 ]] && bridge_die "--note 뒤에 텍스트를 지정하세요."
+        note="$2"
+        shift 2
+        ;;
+      --note-file)
+        [[ $# -lt 2 ]] && bridge_die "--note-file 뒤에 파일 경로를 지정하세요."
+        note_file="$2"
         shift 2
         ;;
       -h|--help)
@@ -581,6 +597,12 @@ cmd_claim() {
   args=(claim "$task_id" --agent "$agent")
   if [[ -n "$lease" ]]; then
     args+=(--lease-seconds "$lease")
+  fi
+  if [[ -n "$note" ]]; then
+    args+=(--note "$note")
+  fi
+  if [[ -n "$note_file" ]]; then
+    args+=(--note-file "$note_file")
   fi
   bridge_queue_cli "${args[@]}"
 }

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -756,6 +756,109 @@ def _is_read_intent_bash(command: str) -> bool:
     return True
 
 
+# Issue #1255 — softening the roster *read* gate. The default
+# `_is_read_intent_bash` is a *whitelist*: every stage's leading command
+# must be in `_READ_INTENT_BASH_COMMANDS`. That is the correct posture
+# for the credential / queue-DB gates (false-positive cost is low — the
+# operator can fall back to `agb` / `claude auth status`). For the
+# roster read path the cost is higher: the same data is already
+# exposed via `agent-bridge agent show --json` and `agent-bridge config
+# get`, so a too-conservative whitelist forces operators into N round-
+# trips through the structured-read surfaces.
+#
+# This *softer* classifier is a write-intent BLACKLIST: it returns True
+# (i.e. "safe enough to allow a read against the roster path") iff
+#  * no stage opens an output redirection (`>`, `>>`, `&>`, `2>file`,
+#    numeric-fd write `1>file` / `99>>log`), and
+#  * no stage leader is in `_WRITE_INTENT_BASH_COMMANDS`, and
+#  * no `sed -i` / `awk -i inplace` form appears.
+#
+# We do NOT exempt the queue DB or any credential file with this
+# classifier — those paths keep the strict whitelist. The only consumer
+# is `_bash_argv_references_path(text, roster_local_path())`.
+_WRITE_INTENT_BASH_COMMANDS = frozenset(
+    {
+        # File-mutating utilities. Any of these as a stage leader means
+        # we cannot prove the command does not modify the roster.
+        "tee",
+        "dd",
+        "truncate",
+        "shred",
+        "rm",
+        "cp",
+        "mv",
+        "ln",
+        "install",
+        "chmod",
+        "chown",
+        "chgrp",
+        "setfacl",
+        "touch",
+        # Editor / IDE invocation forms.
+        "vi",
+        "vim",
+        "nvim",
+        "nano",
+        "emacs",
+        "ed",
+        "ex",
+        "sponge",
+        # In-place transform tools.
+        "patch",
+    }
+)
+
+
+def _bash_command_has_no_write_intent(command: str) -> bool:
+    """Return True iff *command* has no detectable write-intent token.
+
+    Softer than :func:`_is_read_intent_bash` — does NOT require every
+    stage leader to be in the explicit read-intent whitelist. Used only
+    by the roster path read-block softening (issue #1255). Conservative
+    in the same direction (false on any unbalanced quote, output
+    redirection, or known-mutating tool), but tolerant of unknown
+    custom commands that happen to also reference the roster path.
+    """
+    if not command.strip():
+        return False
+    sanitized = _SAFE_REDIRECT_RE.sub(" ", command)
+    stages, balanced = _split_command_stages(sanitized)
+    # Same fail-closed posture on an unbalanced quote — see #1054 codex r1.
+    if not balanced:
+        return False
+    for stage in stages:
+        stage_stripped = stage.strip()
+        if not stage_stripped:
+            continue
+        # Output redirection of any form disqualifies — identical rule
+        # to `_is_read_intent_bash` because writes to *any* path could
+        # be writes to the roster path (e.g. `cat > $roster`).
+        for tok in stage_stripped.split():
+            if tok in _SAFE_REDIRECT_PATTERNS:
+                continue
+            for prefix in ("&>", "2>", ">>", ">"):
+                if tok.startswith(prefix):
+                    return False
+            if _NUMERIC_FD_WRITE_RE.match(tok):
+                return False
+        first = _stage_first_token(stage_stripped)
+        if not first:
+            continue
+        leaf = first.rsplit("/", 1)[-1]
+        if leaf in _WRITE_INTENT_BASH_COMMANDS:
+            return False
+        # `sed -i` / `awk -i inplace` are read-tool families but mutate
+        # in-place; mirror the disqualifier from `_is_read_intent_bash`.
+        stage_tokens = stage_stripped.split()
+        if leaf == "sed" and any(
+            t == "-i" or t.startswith("-i") for t in stage_tokens[1:]
+        ):
+            return False
+        if leaf == "awk" and "-i" in stage_tokens[1:]:
+            return False
+    return True
+
+
 def _is_read_intent_tool(tool_name: str, tool_input: dict[str, Any]) -> bool:
     """Return True iff a tool call is read-intent against any path.
 
@@ -2316,6 +2419,21 @@ def protected_alias_reason(
         return None
     if _bash_argv_references_path(text, roster_local_path()):
         if read_intent:
+            return None
+        # Issue #1255 — softened ADMIN-only roster read gate. The same
+        # data is already reachable via `agent-bridge agent show --json`
+        # and `agent-bridge config get`, so the strict read-intent
+        # whitelist (cat/grep/head/tail/...) costs more than it
+        # protects for the admin shell. Accept any admin-issued Bash
+        # command that has no detectable write-intent token (no output
+        # redirection, no `tee`/`sed -i`/`awk -i inplace`/known
+        # mutators). The non-admin path stays unchanged — for those
+        # agents `git commit -F <roster>`, `xxd <roster>`, etc. still
+        # block because the roster carries shared secrets the non-
+        # admin class should not get to dump into commit messages or
+        # audit logs. Write paths still flow through the
+        # `agent-bridge config set` wrapper carve-out above.
+        if admin and _bash_command_has_no_write_intent(text):
             return None
         # Admin no longer bypasses the roster path (codex r1 #341 CP2);
         # mutations route through `agent-bridge config set`.

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -756,107 +756,52 @@ def _is_read_intent_bash(command: str) -> bool:
     return True
 
 
-# Issue #1255 — softening the roster *read* gate. The default
-# `_is_read_intent_bash` is a *whitelist*: every stage's leading command
-# must be in `_READ_INTENT_BASH_COMMANDS`. That is the correct posture
-# for the credential / queue-DB gates (false-positive cost is low — the
-# operator can fall back to `agb` / `claude auth status`). For the
-# roster read path the cost is higher: the same data is already
-# exposed via `agent-bridge agent show --json` and `agent-bridge config
-# get`, so a too-conservative whitelist forces operators into N round-
-# trips through the structured-read surfaces.
+# Issue #1255 r2 — admin roster carve-out is a strict whitelist.
 #
-# This *softer* classifier is a write-intent BLACKLIST: it returns True
-# (i.e. "safe enough to allow a read against the roster path") iff
-#  * no stage opens an output redirection (`>`, `>>`, `&>`, `2>file`,
-#    numeric-fd write `1>file` / `99>>log`), and
-#  * no stage leader is in `_WRITE_INTENT_BASH_COMMANDS`, and
-#  * no `sed -i` / `awk -i inplace` form appears.
+# History: r1 shipped this as a write-intent *blacklist*
+# (`_bash_command_has_no_write_intent`) that tolerated unknown stage
+# leaders. Codex r1 review showed that posture lets an admin agent run
+# `python3 /tmp/mutator.py <roster>`, `my-mutator <roster>`, or
+# `git commit -F <roster>` — paths that bypass the
+# `agent-bridge config set` wrapper's audit chain and can leak or
+# rewrite roster secrets outside the sanctioned mutation surface.
 #
-# We do NOT exempt the queue DB or any credential file with this
-# classifier — those paths keep the strict whitelist. The only consumer
-# is `_bash_argv_references_path(text, roster_local_path())`.
-_WRITE_INTENT_BASH_COMMANDS = frozenset(
-    {
-        # File-mutating utilities. Any of these as a stage leader means
-        # we cannot prove the command does not modify the roster.
-        "tee",
-        "dd",
-        "truncate",
-        "shred",
-        "rm",
-        "cp",
-        "mv",
-        "ln",
-        "install",
-        "chmod",
-        "chown",
-        "chgrp",
-        "setfacl",
-        "touch",
-        # Editor / IDE invocation forms.
-        "vi",
-        "vim",
-        "nvim",
-        "nano",
-        "emacs",
-        "ed",
-        "ex",
-        "sponge",
-        # In-place transform tools.
-        "patch",
-    }
-)
+# r2 flips the classifier to a whitelist: only the canonical read-only
+# shapes already enumerated in :data:`_READ_INTENT_BASH_COMMANDS` are
+# admitted, plus `agent-bridge config get` / `agb config get`. Unknown
+# leaders default-deny, matching the credential / queue-DB / system-
+# config gates. The whole point of #1255 unblocks operator diagnostics
+# (`cat $roster`, `grep BRIDGE $roster`, `head -10 $roster`); none of
+# those needed a blacklist — they're already on the read-intent
+# whitelist.
+#
+# The function is a thin wrapper around :func:`_is_read_intent_bash`
+# rather than a parallel implementation. That ties the admin carve-out
+# to the same write-redirection / `sed -i` / unbalanced-quote /
+# numeric-fd guards used everywhere else, so future hardening of the
+# write-detection surface flows to the admin path automatically — no
+# divergence to drift into the blacklist gap the r1 review caught.
 
 
-def _bash_command_has_no_write_intent(command: str) -> bool:
-    """Return True iff *command* has no detectable write-intent token.
+def _bash_command_has_read_intent(command: str) -> bool:
+    """Return True iff *command* is purely read-intent (whitelist).
 
-    Softer than :func:`_is_read_intent_bash` — does NOT require every
-    stage leader to be in the explicit read-intent whitelist. Used only
-    by the roster path read-block softening (issue #1255). Conservative
-    in the same direction (false on any unbalanced quote, output
-    redirection, or known-mutating tool), but tolerant of unknown
-    custom commands that happen to also reference the roster path.
+    Issue #1255 r2 — the admin roster carve-out at
+    :func:`protected_alias_reason` consults this function. A True
+    return means "every pipeline stage's leading command is a known
+    read-only tool (cat / grep / head / awk-no-`-i` / sed-no-`-i` /
+    `agent-bridge config get` / …) and no stage opens an output
+    redirection". False means the carve-out falls through to the
+    non-admin deny — including unknown stage leaders like
+    `python3 /tmp/mutator.py`, `my-mutator`, or `git commit -F`,
+    which the r1 blacklist incorrectly tolerated.
+
+    Delegating to :func:`_is_read_intent_bash` keeps the admin carve-
+    out and the credential/queue-DB/system-config gates aligned on the
+    same write-detection surface; we no longer maintain a parallel
+    blacklist that can drift.
     """
-    if not command.strip():
-        return False
-    sanitized = _SAFE_REDIRECT_RE.sub(" ", command)
-    stages, balanced = _split_command_stages(sanitized)
-    # Same fail-closed posture on an unbalanced quote — see #1054 codex r1.
-    if not balanced:
-        return False
-    for stage in stages:
-        stage_stripped = stage.strip()
-        if not stage_stripped:
-            continue
-        # Output redirection of any form disqualifies — identical rule
-        # to `_is_read_intent_bash` because writes to *any* path could
-        # be writes to the roster path (e.g. `cat > $roster`).
-        for tok in stage_stripped.split():
-            if tok in _SAFE_REDIRECT_PATTERNS:
-                continue
-            for prefix in ("&>", "2>", ">>", ">"):
-                if tok.startswith(prefix):
-                    return False
-            if _NUMERIC_FD_WRITE_RE.match(tok):
-                return False
-        first = _stage_first_token(stage_stripped)
-        if not first:
-            continue
-        leaf = first.rsplit("/", 1)[-1]
-        if leaf in _WRITE_INTENT_BASH_COMMANDS:
-            return False
-        # `sed -i` / `awk -i inplace` are read-tool families but mutate
-        # in-place; mirror the disqualifier from `_is_read_intent_bash`.
-        stage_tokens = stage_stripped.split()
-        if leaf == "sed" and any(
-            t == "-i" or t.startswith("-i") for t in stage_tokens[1:]
-        ):
-            return False
-        if leaf == "awk" and "-i" in stage_tokens[1:]:
-            return False
-    return True
+    return _is_read_intent_bash(command)
 
 
 def _is_read_intent_tool(tool_name: str, tool_input: dict[str, Any]) -> bool:
@@ -2420,20 +2365,21 @@ def protected_alias_reason(
     if _bash_argv_references_path(text, roster_local_path()):
         if read_intent:
             return None
-        # Issue #1255 — softened ADMIN-only roster read gate. The same
-        # data is already reachable via `agent-bridge agent show --json`
-        # and `agent-bridge config get`, so the strict read-intent
-        # whitelist (cat/grep/head/tail/...) costs more than it
-        # protects for the admin shell. Accept any admin-issued Bash
-        # command that has no detectable write-intent token (no output
-        # redirection, no `tee`/`sed -i`/`awk -i inplace`/known
-        # mutators). The non-admin path stays unchanged — for those
-        # agents `git commit -F <roster>`, `xxd <roster>`, etc. still
-        # block because the roster carries shared secrets the non-
-        # admin class should not get to dump into commit messages or
-        # audit logs. Write paths still flow through the
-        # `agent-bridge config set` wrapper carve-out above.
-        if admin and _bash_command_has_no_write_intent(text):
+        # Issue #1255 r2 — admin roster read carve-out is a strict
+        # read-intent whitelist (cat / grep / head / `agent-bridge
+        # config get` / …). r1 used a write-intent blacklist that
+        # tolerated unknown stage leaders; codex r1 review showed that
+        # let `python3 /tmp/mutator.py <roster>`, `my-mutator
+        # <roster>`, and `git commit -F <roster>` slip past as
+        # "non-write" while in fact mutating or leaking the roster
+        # outside the `agent-bridge config set` audit chain. The
+        # whitelist captures every shape #1255 was meant to unblock
+        # (operator diagnostics: `cat $roster`, `grep BRIDGE $roster`,
+        # `head -10 $roster`) without exposing arbitrary admin
+        # binaries that happen to take the roster as an argv element.
+        # Write paths still flow through the `agent-bridge config
+        # set` wrapper carve-out above.
+        if admin and _bash_command_has_read_intent(text):
             return None
         # Admin no longer bypasses the roster path (codex r1 #341 CP2);
         # mutations route through `agent-bridge config set`.

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -652,23 +652,35 @@ _SAFE_REDIRECT_RE = re.compile(
 _NUMERIC_FD_WRITE_RE = re.compile(r"^[0-9]+>>?")
 
 
-# Issue #1255 r3 — `find` mutation/exec primitive filter.
+# Issue #1255 r3/r4 — `find` mutation/exec primitive filter.
 #
 # `find` is on `_READ_INTENT_BASH_COMMANDS` because the common operator
 # diagnostics (`find <roster> -name "*.sh"`, `find <roster> -type f`)
 # are pure reads. But find has built-in mutation and exec primitives
 # that the bare leader check does not see — `find -delete` removes
 # matches in place, and `find -exec` / `-execdir` / `-ok` / `-okdir`
-# spawn arbitrary subprocesses against each match. The `-fprint` /
-# `-fprint0` / `-fprintf` flags write matches to a file the operator
-# names, which is a roster-exfil channel even though no `>` token
-# appears in the command (codex PR #1294 r2 finding).
+# spawn arbitrary subprocesses against each match. The GNU-find file
+# actions `-fprint` / `-fprint0` / `-fprintf` / `-fls` write matches
+# (or `-ls`-style listings) to a file the operator names, which is a
+# roster-exfil channel even though no `>` token appears in the command
+# (codex PR #1294 r2 first surfaced `-fprint*`; r3 added `-fls`).
 #
 # Treat these flags as write-intent: when `find` is the stage leader
 # and any of them appears in argv, the stage falls out of the read-
 # intent classification. The output-redirection guard above already
 # catches `find -ls > somefile`; we do not need to enumerate that form
 # here.
+#
+# Comprehensive audit pass (codex PR #1294 r3, GNU find(1) actions):
+#   - `-delete`, `-exec`, `-execdir`, `-ok`, `-okdir` — covered.
+#   - `-fprint`, `-fprint0`, `-fprintf` — covered.
+#   - `-fls` — covered (this commit).
+#   - `-ls`, `-print`, `-print0`, `-printf`, `-quit` — write stdout
+#     only; the output-redirection guard catches `> file` rebinding.
+#   - `-prune` — pure traversal control, no I/O.
+# No other GNU find action writes to a named file or spawns a child
+# without `>` redirect; the frozenset is now exhaustive for the file-
+# action + child-spawn classes.
 _FIND_MUTATION_FLAGS = frozenset(
     {
         "-delete",
@@ -679,6 +691,7 @@ _FIND_MUTATION_FLAGS = frozenset(
         "-fprint",
         "-fprint0",
         "-fprintf",
+        "-fls",
     }
 )
 

--- a/hooks/tool-policy.py
+++ b/hooks/tool-policy.py
@@ -652,6 +652,60 @@ _SAFE_REDIRECT_RE = re.compile(
 _NUMERIC_FD_WRITE_RE = re.compile(r"^[0-9]+>>?")
 
 
+# Issue #1255 r3 — `find` mutation/exec primitive filter.
+#
+# `find` is on `_READ_INTENT_BASH_COMMANDS` because the common operator
+# diagnostics (`find <roster> -name "*.sh"`, `find <roster> -type f`)
+# are pure reads. But find has built-in mutation and exec primitives
+# that the bare leader check does not see — `find -delete` removes
+# matches in place, and `find -exec` / `-execdir` / `-ok` / `-okdir`
+# spawn arbitrary subprocesses against each match. The `-fprint` /
+# `-fprint0` / `-fprintf` flags write matches to a file the operator
+# names, which is a roster-exfil channel even though no `>` token
+# appears in the command (codex PR #1294 r2 finding).
+#
+# Treat these flags as write-intent: when `find` is the stage leader
+# and any of them appears in argv, the stage falls out of the read-
+# intent classification. The output-redirection guard above already
+# catches `find -ls > somefile`; we do not need to enumerate that form
+# here.
+_FIND_MUTATION_FLAGS = frozenset(
+    {
+        "-delete",
+        "-exec",
+        "-execdir",
+        "-ok",
+        "-okdir",
+        "-fprint",
+        "-fprint0",
+        "-fprintf",
+    }
+)
+
+
+def _find_is_read_only(stage_tokens: list[str]) -> bool:
+    """Return True iff a `find` invocation is free of mutation/exec flags.
+
+    *stage_tokens* is the whitespace-split argv of a single pipeline
+    stage whose leader has already been confirmed to be `find` (or a
+    pathy equivalent like `/usr/bin/find`). Returns False as soon as
+    any token equals one of :data:`_FIND_MUTATION_FLAGS` so the caller
+    can drop the read-intent classification.
+
+    The check is exact-match per token: `-delete` matches but
+    `-deleted-files` does not, and `-delete` is rejected even when it
+    appears mid-argv (`find <path> -type f -delete`). This is the
+    flag shape `find` itself enforces — none of the mutation primitives
+    take an inline value glued to the flag (find takes them as separate
+    argv elements). See codex PR #1294 r2 for the BLOCKING-class repro
+    that motivated the filter.
+    """
+    for token in stage_tokens[1:]:  # skip the leading 'find'
+        if token in _FIND_MUTATION_FLAGS:
+            return False
+    return True
+
+
 def _is_read_intent_bash(command: str) -> bool:
     """Return True iff *command* is purely read-intent.
 
@@ -737,6 +791,16 @@ def _is_read_intent_bash(command: str) -> bool:
             if leaf == "sed" and any(t == "-i" or t.startswith("-i") for t in stage_tokens[1:]):
                 return False
             if leaf == "awk" and "-i" in stage_tokens[1:]:
+                return False
+            # `find` is whitelisted for diagnostics (`find <roster>
+            # -name "*.sh"`), but it has mutation/exec primitives
+            # (`-delete`, `-exec`, `-execdir`, `-ok`, `-okdir`,
+            # `-fprint`, `-fprint0`, `-fprintf`) that the leader check
+            # alone does not see. Codex PR #1294 r2 demonstrated that
+            # without this filter an admin could `find <roster>
+            # -delete` or `find <roster> -exec python3
+            # /tmp/mutator.py {} \;` through the roster carve-out.
+            if leaf == "find" and not _find_is_read_only(stage_tokens):
                 return False
             continue
         # `agent-bridge config get …` / `agb config get …` are read-intent.

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -107,7 +107,7 @@ add_live() {
 
 add_all_required_static() {
 
-  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs
+  add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs K-beta4-nits
 
 
 }
@@ -431,7 +431,13 @@ select_for_path() {
       # pins the helper behavior + the structured SystemExit failure
       # surface; pull on every bridge-queue.py move so the fallback
       # cannot regress to silent empty-body sends.
-      add_required queue 1106-nudge-shell-recheck nudge-task-age-gate nudge-redundant-active-agent a2a-cross-bridge 1100-audit-since-tz 1115-cli-usage-drift J-beta4-workflow-docs
+      # v0.15.0-beta4 Lane K (#1253): bridge-queue.py + bridge-task.sh now
+      # accept `claim --note <text>` / `--note-file <path>` symmetric with
+      # `done` / `update`. The note text propagates into the task_events
+      # row (`event_type=claimed`, `note_text=<text>`). Pull K-beta4-nits
+      # whenever either file moves so a future PR cannot silently regress
+      # the symmetry back to the asymmetric pre-#1253 shape.
+      add_required queue 1106-nudge-shell-recheck nudge-task-age-gate nudge-redundant-active-agent a2a-cross-bridge 1100-audit-since-tz 1115-cli-usage-drift J-beta4-workflow-docs K-beta4-nits
       add_integration integration-minimal
       ;;
 
@@ -742,7 +748,16 @@ select_for_path() {
       # move so a future PR cannot silently regress the OOTB `agb admin`
       # die into the lost-state branch (operator-blocking; first surface
       # patch + admin-dev codex pair on a fresh install).
-      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper 1155-bootstrap-skill-guard 1158-marker-load-order 1165-track-a-scaffold-modes 1213-iso-uid-predicate beta27-D-inject-timestamp-resolved I-agent-description-roster γ-cli-consistency C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir
+      # v0.15.0-beta4 Lane K (#1282 Surface A): bridge-run.sh's
+      # `bridge_run_prune_legacy_teams_mcp` now filters the steady-state
+      # `absent path=…` / `unchanged path=…` rows out of the audit tail
+      # — only real actions (pruned/failed/skipped) reach the operator.
+      # Lane K (#1247) also adds the `agb admin set --auto-restart` CLI
+      # surface, dispatched from the agent-bridge `admin` case head and
+      # backed by scripts/python-helpers/admin-set-config.py. Pull
+      # K-beta4-nits on every bridge-run.sh / agent-bridge move so a
+      # future PR cannot silently regress either surface.
+      add_required launch launch-dev-channels-injection tmux-injection upgrade-source-preservation upgrade-shared-settings-propagate agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering status-engine-detect 835-static-admin-launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup 1028-isolated-workdir-check 1118-v2-engine-binary-path v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair 1067-codex-provisioning 1115-cli-usage-drift 1151-step-a-helper 1155-bootstrap-skill-guard 1158-marker-load-order 1165-track-a-scaffold-modes 1213-iso-uid-predicate beta27-D-inject-timestamp-resolved I-agent-description-roster γ-cli-consistency C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir K-beta4-nits
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;
@@ -794,7 +809,15 @@ select_for_path() {
       # the regression smoke whenever the file moves so the verb shape
       # surface (allow path + shape-deny audit row + path-traversal /
       # malformed-flag rejection) stays pinned.
-      add_required hooks agent-update v2-cross-class-read admin-hook-exemption tool-policy-roster-read-classify 1205-hook-iso-fail-open 6607-hook-admin-allowlist
+      # v0.15.0-beta4 Lane K (#1255): hooks/tool-policy.py now hosts
+      # `_bash_command_has_no_write_intent` — a softer (write-intent
+      # blacklist) classifier that gates the roster *read* path so a
+      # custom non-whitelist read command (e.g. `myprog --opt
+      # agent-roster.local.sh`) is no longer mis-rejected. Pull
+      # K-beta4-nits whenever tool-policy.py moves so a future PR
+      # cannot regress the softening back to the strict whitelist or
+      # widen the no-write-intent classifier into a write surface.
+      add_required hooks agent-update v2-cross-class-read admin-hook-exemption tool-policy-roster-read-classify 1205-hook-iso-fail-open 6607-hook-admin-allowlist K-beta4-nits
       add_integration integration-minimal
       ;;
 
@@ -1406,6 +1429,21 @@ select_for_path() {
       add_integration integration-minimal
       ;;
 
+    bridge-diagnose.sh|scripts/python-helpers/admin-set-config.py)
+      # v0.15.0-beta4 Lane K:
+      #   #1283 — bridge-diagnose.sh is now a thin deprecation shim;
+      #         the `acl` subcommand exits non-zero with a notice
+      #         pointing at `agent-bridge isolation reconcile`. The
+      #         heavy ACL scanner helpers are removed.
+      #   #1247 — scripts/python-helpers/admin-set-config.py is the
+      #         file-as-argv writer for `agb admin set --auto-restart
+      #         on|off` (footgun #11 — no heredoc-stdin). Pull
+      #         K-beta4-nits whenever either file moves so a future
+      #         PR cannot revive the ACL scanner or break the admin
+      #         set CLI surface.
+      add_required K-beta4-nits
+      ;;
+
     bridge-lib.sh|lib/bridge-core.sh|lib/bridge-agents.sh|agent-roster.sh|agent-roster.local.example.sh|bridge-config.sh)
       add_all_required_static
       add_all_integration
@@ -1554,7 +1592,14 @@ select_for_path() {
       # Pull H-beta4-iso-ownership on every bridge-plugins.sh +
       # dev-plugin-cache move so an inadvertent revert at either
       # writer site immediately fails the regression contract.
-      add_required 1201-1202-directory-marketplace-seed channel-plugins 1208-lock-metadata-normalize ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume C-beta4-logger-and-spec H-beta4-iso-ownership
+      # v0.15.0-beta4 Lane K (#1282 Surface B): bridge-dev-plugin-cache.py
+      # now reports `node_modules=not-required` (instead of `=missing`)
+      # for plugin sources that declare no deps + no lockfile, so `.mjs`
+      # proxy plugins (`cosmax-ep-approval` etc.) stop painting the
+      # operator dashboard with cosmetic noise. Pull K-beta4-nits
+      # whenever bridge-dev-plugin-cache.py moves so a future PR cannot
+      # silently revert the heuristic.
+      add_required 1201-1202-directory-marketplace-seed channel-plugins 1208-lock-metadata-normalize ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume C-beta4-logger-and-spec H-beta4-iso-ownership K-beta4-nits
       add_integration integration-minimal
       ;;
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -809,14 +809,17 @@ select_for_path() {
       # the regression smoke whenever the file moves so the verb shape
       # surface (allow path + shape-deny audit row + path-traversal /
       # malformed-flag rejection) stays pinned.
-      # v0.15.0-beta4 Lane K (#1255): hooks/tool-policy.py now hosts
-      # `_bash_command_has_no_write_intent` — a softer (write-intent
-      # blacklist) classifier that gates the roster *read* path so a
-      # custom non-whitelist read command (e.g. `myprog --opt
-      # agent-roster.local.sh`) is no longer mis-rejected. Pull
-      # K-beta4-nits whenever tool-policy.py moves so a future PR
-      # cannot regress the softening back to the strict whitelist or
-      # widen the no-write-intent classifier into a write surface.
+      # v0.15.0-beta4 Lane K (#1255 r2): hooks/tool-policy.py hosts
+      # `_bash_command_has_read_intent` — a STRICT read-intent
+      # whitelist that gates the admin roster carve-out. r1 shipped
+      # this as a write-intent blacklist that codex r1 review showed
+      # admitted unknown stage leaders (`python3 /tmp/mutator.py
+      # <roster>`, `my-mutator <roster>`, `git commit -F <roster>`).
+      # r2 flips it to a whitelist delegating to
+      # `_is_read_intent_bash`. Pull K-beta4-nits whenever
+      # tool-policy.py moves so a future PR cannot regress the admin
+      # carve-out back to a blacklist or widen it into a write/leak
+      # surface.
       add_required hooks agent-update v2-cross-class-read admin-hook-exemption tool-policy-roster-read-classify 1205-hook-iso-fail-open 6607-hook-admin-allowlist K-beta4-nits
       add_integration integration-minimal
       ;;

--- a/scripts/python-helpers/admin-set-config.py
+++ b/scripts/python-helpers/admin-set-config.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""
+scripts/python-helpers/admin-set-config.py — standalone helper for
+`agent-bridge admin set ...` (issue #1247).
+
+Reads / mutates the admin-set config file at
+``$BRIDGE_STATE_DIR/admin-config.json``. Currently exposes one flag:
+
+  auto_restart_on_membership_change : bool
+
+Future PRs that wire the actual admin-set restart sequence will read
+this flag and decide whether to queue `tmux cycle <admin>` +
+`tmux cycle <admin>-dev` after a group-membership refresh.
+
+File-as-argv: invoked with explicit positional args so the calling
+shell never has to pipe a heredoc into Python (footgun #11 — Bash
+5.3.9 deadlock; see KNOWN_ISSUES.md §26).
+
+Usage:
+  admin-set-config.py set-auto-restart \
+      --admin <agent> \
+      --config <path> \
+      --value on|off
+
+Output (stdout): single human-readable confirmation line. Exit 0 on
+success, non-zero with stderr context on failure.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _read_existing(config_path: Path) -> dict:
+    if not config_path.is_file():
+        return {}
+    try:
+        with config_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        # Conservative: a corrupt file is replaced wholesale rather
+        # than blocking the operator. The single field this helper
+        # writes is the only one currently in the schema, so nothing
+        # else is at risk of being lost.
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _atomic_write(config_path: Path, payload: dict) -> None:
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    tmp_path = config_path.with_name(f"{config_path.name}.tmp.{os.getpid()}")
+    tmp_path.write_text(body, encoding="utf-8")
+    try:
+        os.chmod(tmp_path, 0o600)
+    except OSError:
+        # chmod is best-effort: a future iso v2 reconcile pass owns the
+        # final perms canonicalization for `state/`-rooted files. The
+        # write itself succeeded, so propagate success.
+        pass
+    os.replace(tmp_path, config_path)
+
+
+def _cmd_set_auto_restart(args: argparse.Namespace) -> int:
+    if args.value not in {"on", "off"}:
+        sys.stderr.write(
+            f"admin-set-config: --value must be on|off (got: {args.value!r})\n"
+        )
+        return 2
+    config_path = Path(args.config).expanduser()
+    data = _read_existing(config_path)
+    data["admin_agent"] = args.admin
+    data["auto_restart_on_membership_change"] = args.value == "on"
+    try:
+        _atomic_write(config_path, data)
+    except OSError as exc:
+        sys.stderr.write(f"admin-set-config: write failed: {exc}\n")
+        return 1
+    sys.stdout.write(
+        f"[admin set] auto_restart_on_membership_change={args.value} "
+        f"path={config_path} admin={args.admin}\n"
+    )
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(prog="admin-set-config")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    set_ar = sub.add_parser("set-auto-restart")
+    set_ar.add_argument("--admin", required=True)
+    set_ar.add_argument("--config", required=True)
+    set_ar.add_argument("--value", required=True)
+    set_ar.set_defaults(handler=_cmd_set_auto_restart)
+
+    args = parser.parse_args(argv[1:])
+    return args.handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2747,20 +2747,20 @@ assert clear_idx_agent > dry_run_idx_agent, (
 print("[ok] broken-launch clear guarded behind dry-run + preflight in both entry points")
 PY
 
-log "diagnose acl reports clean on macOS (non-Linux host)"
-DIAGNOSE_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl)"
-if [[ "$(uname -s)" == "Linux" ]]; then
-  # On Linux getfacl may or may not be installed; either way the
-  # scanner exits 0 with an "[ok]" or "[skip]" banner. The only thing
-  # smoke needs to assert is that it did not explode.
-  assert_contains "$DIAGNOSE_OUTPUT" "["
-else
-  assert_contains "$DIAGNOSE_OUTPUT" "non-linux"
-fi
-DIAGNOSE_JSON_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl --json)"
-assert_contains "$DIAGNOSE_JSON_OUTPUT" "\"findings\""
+log "diagnose acl retired in v0.15.0-beta4 (#1283) — verb now emits deprecation"
+# `agent-bridge diagnose acl` was retired in v0.15.0-beta4 (#1283).
+# ACL-based cross-UID grants are no longer the recommended isolation
+# mechanism (iso v2 uses group-based perms). The verb now exits
+# non-zero AND points operators at the iso v2 replacement.
+DIAGNOSE_ACL_RC=0
+DIAGNOSE_OUTPUT="$("$REPO_ROOT/agent-bridge" diagnose acl 2>&1)" || DIAGNOSE_ACL_RC=$?
+[[ "$DIAGNOSE_ACL_RC" -ne 0 ]] || die "diagnose acl must exit non-zero post-#1283 (got rc=0)"
+assert_contains "$DIAGNOSE_OUTPUT" "deprecated"
+assert_contains "$DIAGNOSE_OUTPUT" "isolation reconcile"
 DIAGNOSE_HELP="$("$REPO_ROOT/agent-bridge" diagnose 2>&1 || true)"
-assert_contains "$DIAGNOSE_HELP" "diagnose acl"
+# The usage banner still mentions the retirement so operators with
+# stale muscle memory find the replacement.
+assert_contains "$DIAGNOSE_HELP" "retired"
 
 log "apply-channel-policy.sh writes overlay disabling singleton channel plugins (#244)"
 CHANNEL_POLICY_HOME="$TMP_ROOT/channel-policy-home"

--- a/scripts/smoke/K-beta4-nits.sh
+++ b/scripts/smoke/K-beta4-nits.sh
@@ -1,0 +1,511 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/K-beta4-nits.sh
+#
+# Lane K of v0.15.0-beta4 — 5-issue nits batch:
+#
+#   #1282 (Surface A): `bridge_run_prune_legacy_teams_mcp` no longer
+#         log-lines the steady-state `absent path=…` / `unchanged
+#         path=…` rows — only `pruned` / `failed` / `skipped` reach the
+#         operator's audit tail. Log noise downgrade.
+#
+#   #1282 (Surface B): `bridge-dev-plugin-cache.py` sync now marks a
+#         plugin source that ships no `package.json` deps and no
+#         lockfile as `node_modules=not-required` instead of the
+#         cosmetic-noise `node_modules=missing`. `.mjs` proxy plugins
+#         (Node.js inline deps) stop painting the dashboard with
+#         false-positive alerts.
+#
+#   #1283: `agent-bridge diagnose acl` subcommand retired. ACL-based
+#         cross-UID grants are no longer the recommended isolation
+#         mechanism (iso v2 uses group-based perms). Verb invocation
+#         now emits a deprecation notice to stderr and exits non-zero;
+#         the heavy ACL scanner helpers are removed.
+#
+#   #1247: `agb admin set --auto-restart on|off` CLI surface added.
+#         Phase 1 — persists the flag into `state/admin-config.json`
+#         via the new `scripts/python-helpers/admin-set-config.py`
+#         helper (file-as-argv per footgun #11). Future PRs wire the
+#         flag into the post-`agent create` admin-set restart
+#         automation.
+#
+#   #1253: `agb claim --note <text>` (and `--note-file <path>`) now
+#         accepted and propagated through to the `task_events` row
+#         (`event_type=claimed`, `note_text=<text>` / `note_path=<p>`).
+#         Symmetric with `agb done` / `agb update`.
+#
+#   #1255: roster read-block softened for ADMIN shells. The strict
+#         read-intent whitelist (cat/grep/head/tail/...) is now bypassed
+#         when the bash command is issued by an admin agent AND has no
+#         detectable write-intent token (`tee`, `sed -i`, `awk -i
+#         inplace`, output redirection, known mutators). Non-admin
+#         class still hits the original deny — those agents must not
+#         dump roster secrets into commit messages / audit logs even
+#         under a non-write-intent verb (`git commit -F <roster>`).
+#         Write paths still flow through the `agent-bridge config
+#         set` wrapper.
+#
+# Test plan:
+#   T1  (#1282 A): `bridge_run_prune_legacy_teams_mcp` line filter
+#                  drops `absent path=…` rows from the audit log.
+#   T1t (#1282 A teeth): when the filter is bypassed, `absent path=`
+#                  appears in the log. Proves the filter is what
+#                  closes the noise.
+#   T2  (#1282 B): `_plugin_source_declares_deps` returns False for a
+#                  source dir with no package.json / lockfile, and
+#                  True for a source dir with a `dependencies` entry.
+#   T3  (#1283): `bash bridge-diagnose.sh acl` exits non-zero AND the
+#                  deprecation notice appears on stderr. The
+#                  `bridge_diagnose_acl_main` / `_scan_path` helpers
+#                  are gone from the file.
+#   T4  (#1247): `admin-set-config.py set-auto-restart --value on`
+#                  writes a JSON object with `auto_restart_on_membership_change`
+#                  set to true. A follow-up call with `--value off`
+#                  flips it back to false. The `admin_agent` field
+#                  is preserved across mutations.
+#   T5  (#1253): `bridge-queue.py claim` with `--note "blah"` writes
+#                  a `task_events` row with `event_type=claimed` and
+#                  `note_text=blah`. The stdout summary line includes
+#                  `claim_note=4c`.
+#   T5t (#1253 teeth): claim without `--note` writes a `task_events`
+#                  row with `event_type=claimed` AND `note_text IS
+#                  NULL`. Proves the propagation is opt-in.
+#   T6  (#1255): `_bash_command_has_no_write_intent` returns True for
+#                  benign reads + custom non-write commands; False
+#                  for `... > <roster>`, `tee <roster>`, `sed -i`, and
+#                  any output redirection.
+#   T6t (#1255 teeth): the strict `_is_read_intent_bash` whitelist
+#                  rejects a custom command that the new softer
+#                  classifier accepts — proving the softening is what
+#                  unblocks issue #1255's repro shape.
+#
+# Footgun #11: no `<<EOF` to subprocess, no `<<<` here-strings into
+# command substitutions, no inline Python heredoc-to-stdin. Helpers
+# are exercised as standalone scripts.
+#
+# Isolation: temp BRIDGE_HOME via smoke_setup_bridge_home. No network.
+
+if [[ "${BRIDGE_SMOKE_BASH4_REEXEC:-0}" != "1" && "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      BRIDGE_SMOKE_BASH4_REEXEC=1 exec "$_candidate" "$0" "$@"
+    fi
+  done
+  echo "[smoke:K-beta4-nits][error] bash 4+ required (got ${BASH_VERSION:-unknown})" >&2
+  exit 1
+fi
+
+set -uo pipefail
+
+SMOKE_NAME="K-beta4-nits"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+RUN_SH="$REPO_ROOT/bridge-run.sh"
+DIAG_SH="$REPO_ROOT/bridge-diagnose.sh"
+DEV_CACHE_PY="$REPO_ROOT/bridge-dev-plugin-cache.py"
+ADMIN_SET_PY="$REPO_ROOT/scripts/python-helpers/admin-set-config.py"
+QUEUE_PY="$REPO_ROOT/bridge-queue.py"
+TOOL_POLICY_PY="$REPO_ROOT/hooks/tool-policy.py"
+
+smoke_assert_file_exists "$RUN_SH" "bridge-run.sh present"
+smoke_assert_file_exists "$DIAG_SH" "bridge-diagnose.sh present"
+smoke_assert_file_exists "$DEV_CACHE_PY" "bridge-dev-plugin-cache.py present"
+smoke_assert_file_exists "$ADMIN_SET_PY" "admin-set-config.py present"
+smoke_assert_file_exists "$QUEUE_PY" "bridge-queue.py present"
+smoke_assert_file_exists "$TOOL_POLICY_PY" "hooks/tool-policy.py present"
+
+# ---------------------------------------------------------------------------
+# T1 (#1282 Surface A): `bridge_run_prune_legacy_teams_mcp` drops the
+# `absent path=…` / `unchanged path=…` lines.
+# ---------------------------------------------------------------------------
+smoke_log "T1: prune_legacy_teams_mcp filters absent/unchanged noise (#1282 Surface A)"
+
+T1_FILTER_SCRIPT="$SMOKE_TMP_ROOT/t1-filter.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -uo pipefail\n'
+  # Inline the filter loop with the exact contract from
+  # `bridge_run_prune_legacy_teams_mcp` so we exercise the case
+  # statement faithfully without needing the rest of bridge-run.sh's
+  # roster/agent plumbing.
+  printf 'logged=()\n'
+  printf 'log_line() { logged+=("$1"); }\n'
+  printf 'output=$(printf "%%s\\n" \\\n'
+  printf '    "absent path=/tmp/agent-root/.mcp.json" \\\n'
+  printf '    "unchanged path=/tmp/agent-root/.mcp.json reason=no-mcpServers" \\\n'
+  printf '    "pruned path=/tmp/workdir/.mcp.json" \\\n'
+  printf '    "skipped path=/tmp/other.json reason=read-failed:ENOENT" \\\n'
+  printf '    "failed path=/tmp/locked.json reason=write-failed:EROFS")\n'
+  printf 'while IFS= read -r line; do\n'
+  printf '  [[ -n "$line" ]] || continue\n'
+  printf '  case "$line" in\n'
+  printf '    "absent path="*|"unchanged path="*)\n'
+  printf '      continue\n'
+  printf '      ;;\n'
+  printf '  esac\n'
+  printf '  log_line "[legacy-teams-mcp] $line"\n'
+  printf 'done <<<"$output"\n'
+  printf 'printf "%%s\\n" "${logged[@]}"\n'
+} >"$T1_FILTER_SCRIPT"
+
+T1_OUT="$(bash "$T1_FILTER_SCRIPT" 2>&1)" || smoke_fail "T1: filter driver failed"
+smoke_assert_not_contains "$T1_OUT" "absent path=" \
+  "T1: 'absent path=' must be filtered out of the audit log"
+smoke_assert_not_contains "$T1_OUT" "unchanged path=" \
+  "T1: 'unchanged path=' must be filtered out of the audit log"
+smoke_assert_contains "$T1_OUT" "[legacy-teams-mcp] pruned path=" \
+  "T1: 'pruned path=' must still reach the audit log (action that happened)"
+smoke_assert_contains "$T1_OUT" "[legacy-teams-mcp] skipped path=" \
+  "T1: 'skipped path=' must still reach the audit log (operator must see)"
+smoke_assert_contains "$T1_OUT" "[legacy-teams-mcp] failed path=" \
+  "T1: 'failed path=' must still reach the audit log (operator must see)"
+
+# T1 teeth: when the filter is removed the noise comes back.
+smoke_log "T1 teeth: filter removed → 'absent path=' re-appears"
+T1T_SCRIPT="$SMOKE_TMP_ROOT/t1-teeth.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -uo pipefail\n'
+  printf 'logged=()\n'
+  printf 'log_line() { logged+=("$1"); }\n'
+  printf 'output=$(printf "%%s\\n" "absent path=/tmp/x" "pruned path=/tmp/y")\n'
+  # No case statement — teeth simulates the pre-fix behavior.
+  printf 'while IFS= read -r line; do\n'
+  printf '  [[ -n "$line" ]] || continue\n'
+  printf '  log_line "[legacy-teams-mcp] $line"\n'
+  printf 'done <<<"$output"\n'
+  printf 'printf "%%s\\n" "${logged[@]}"\n'
+} >"$T1T_SCRIPT"
+T1T_OUT="$(bash "$T1T_SCRIPT" 2>&1)" || smoke_fail "T1 teeth driver failed"
+smoke_assert_contains "$T1T_OUT" "absent path=" \
+  "T1 teeth: without the filter, the noise line re-appears"
+
+# Belt-and-braces: confirm the actual production filter sits in
+# bridge-run.sh — regressing the case lines would be caught by a grep.
+smoke_assert_contains \
+  "$(grep -n 'absent path=' "$RUN_SH" 2>/dev/null || true)" \
+  "absent path=" \
+  "T1: production bridge-run.sh keeps the 'absent path=' filter line"
+
+# ---------------------------------------------------------------------------
+# T2 (#1282 Surface B): _plugin_source_declares_deps heuristic.
+# ---------------------------------------------------------------------------
+smoke_log "T2: _plugin_source_declares_deps heuristic (#1282 Surface B)"
+
+T2_NO_DEPS="$SMOKE_TMP_ROOT/plugin-no-deps"
+mkdir -p "$T2_NO_DEPS"
+printf '// inline-deps proxy\nimport http from "node:http";\n' >"$T2_NO_DEPS/ep-mcp-proxy.mjs"
+
+T2_DEPS_DECLARED="$SMOKE_TMP_ROOT/plugin-deps-declared"
+mkdir -p "$T2_DEPS_DECLARED"
+printf '{"name":"x","dependencies":{"foo":"^1.0.0"}}\n' >"$T2_DEPS_DECLARED/package.json"
+
+T2_DEPS_LOCKFILE="$SMOKE_TMP_ROOT/plugin-lockfile-only"
+mkdir -p "$T2_DEPS_LOCKFILE"
+printf '{}\n' >"$T2_DEPS_LOCKFILE/package.json"
+printf '{}' >"$T2_DEPS_LOCKFILE/bun.lock"
+
+T2_PROBE="$SMOKE_TMP_ROOT/t2-probe.py"
+{
+  printf '#!/usr/bin/env python3\n'
+  printf 'import importlib.util, sys\n'
+  printf 'spec = importlib.util.spec_from_file_location("dpc", "%s")\n' "$DEV_CACHE_PY"
+  printf 'm = importlib.util.module_from_spec(spec)\n'
+  printf 'spec.loader.exec_module(m)\n'
+  printf 'from pathlib import Path\n'
+  printf 'cases = [\n'
+  printf '    ("no-deps", "%s", False),\n' "$T2_NO_DEPS"
+  printf '    ("deps-declared", "%s", True),\n' "$T2_DEPS_DECLARED"
+  printf '    ("lockfile-only", "%s", True),\n' "$T2_DEPS_LOCKFILE"
+  printf ']\n'
+  printf 'for label, path, expected in cases:\n'
+  printf '    got = m._plugin_source_declares_deps(Path(path))\n'
+  printf '    status = "OK" if got == expected else "FAIL"\n'
+  printf '    print(f"{status} {label} got={got} expected={expected}")\n'
+} >"$T2_PROBE"
+T2_OUT="$(python3 "$T2_PROBE" 2>&1)" || smoke_fail "T2: probe failed: $T2_OUT"
+smoke_assert_contains "$T2_OUT" "OK no-deps got=False" \
+  "T2: source with no package.json deps + no lockfile → False"
+smoke_assert_contains "$T2_OUT" "OK deps-declared got=True" \
+  "T2: source with non-empty 'dependencies' → True"
+smoke_assert_contains "$T2_OUT" "OK lockfile-only got=True" \
+  "T2: source with sibling lockfile → True"
+smoke_assert_not_contains "$T2_OUT" "FAIL " \
+  "T2: every heuristic case must pass"
+
+# ---------------------------------------------------------------------------
+# T3 (#1283): diagnose acl deprecation notice + non-zero exit.
+# ---------------------------------------------------------------------------
+smoke_log "T3: 'agent-bridge diagnose acl' retired (#1283)"
+
+T3_RC=0
+T3_OUT="$(bash "$DIAG_SH" acl 2>&1)" || T3_RC=$?
+if (( T3_RC == 0 )); then
+  smoke_fail "T3: diagnose acl must exit non-zero (got rc=0). Output: $T3_OUT"
+fi
+smoke_assert_contains "$T3_OUT" "deprecated" \
+  "T3: deprecation notice surfaces on the diagnose acl path"
+smoke_assert_contains "$T3_OUT" "isolation reconcile" \
+  "T3: notice points operators at the iso v2 replacement"
+
+# The heavy ACL scanner helpers must be gone — regressing them would
+# resurrect the ACL diagnostic pathway #1283 retired.
+smoke_assert_not_contains "$(cat "$DIAG_SH")" "bridge_diagnose_acl_scan_path" \
+  "T3: bridge_diagnose_acl_scan_path helper removed from bridge-diagnose.sh"
+smoke_assert_not_contains "$(cat "$DIAG_SH")" "bridge_diagnose_acl_targets" \
+  "T3: bridge_diagnose_acl_targets helper removed from bridge-diagnose.sh"
+smoke_assert_not_contains "$(cat "$DIAG_SH")" "getfacl" \
+  "T3: getfacl reference removed (ACL scanner gone)"
+
+# `agent-bridge diagnose` (no subcommand) still prints a usage banner.
+T3_USAGE_OUT="$(bash "$DIAG_SH" 2>&1)" || smoke_fail "T3: diagnose (no args) must succeed"
+smoke_assert_contains "$T3_USAGE_OUT" "Usage:" \
+  "T3: diagnose with no subcommand still prints usage"
+
+# ---------------------------------------------------------------------------
+# T4 (#1247): `agb admin set --auto-restart on|off` writes JSON config.
+# ---------------------------------------------------------------------------
+smoke_log "T4: admin-set-config.py persists auto_restart_on_membership_change (#1247)"
+
+T4_CONFIG="$SMOKE_TMP_ROOT/admin-config.json"
+
+python3 "$ADMIN_SET_PY" set-auto-restart \
+  --admin patch \
+  --config "$T4_CONFIG" \
+  --value on >"$SMOKE_TMP_ROOT/t4-on.out" 2>&1 \
+  || smoke_fail "T4: set-auto-restart on failed"
+
+smoke_assert_file_exists "$T4_CONFIG" "T4: config file created"
+T4_ON="$(cat "$T4_CONFIG")"
+smoke_assert_contains "$T4_ON" '"admin_agent": "patch"' \
+  "T4 ON: admin_agent recorded"
+smoke_assert_contains "$T4_ON" '"auto_restart_on_membership_change": true' \
+  "T4 ON: flag persisted to true"
+
+python3 "$ADMIN_SET_PY" set-auto-restart \
+  --admin patch \
+  --config "$T4_CONFIG" \
+  --value off >"$SMOKE_TMP_ROOT/t4-off.out" 2>&1 \
+  || smoke_fail "T4: set-auto-restart off failed"
+
+T4_OFF="$(cat "$T4_CONFIG")"
+smoke_assert_contains "$T4_OFF" '"auto_restart_on_membership_change": false' \
+  "T4 OFF: flag flips back to false"
+smoke_assert_contains "$T4_OFF" '"admin_agent": "patch"' \
+  "T4 OFF: admin_agent preserved across mutations"
+
+# Reject an invalid value.
+T4_INVALID_RC=0
+python3 "$ADMIN_SET_PY" set-auto-restart \
+  --admin patch \
+  --config "$T4_CONFIG" \
+  --value sometimes >/dev/null 2>&1 || T4_INVALID_RC=$?
+[[ "$T4_INVALID_RC" -ne 0 ]] || \
+  smoke_fail "T4: invalid --value must reject (got rc=0)"
+
+# ---------------------------------------------------------------------------
+# T5 (#1253): claim --note propagates into task_events.
+# ---------------------------------------------------------------------------
+smoke_log "T5: claim --note writes note_text into task_events (#1253)"
+
+T5_QUEUE_DB="$SMOKE_TMP_ROOT/k-tasks.db"
+export BRIDGE_TASK_DB="$T5_QUEUE_DB"
+export BRIDGE_HOME="$SMOKE_TMP_ROOT/bridge-home"
+mkdir -p "$BRIDGE_HOME/state"
+
+# Bootstrap a queued task assigned to "patch" via the create verb.
+T5_CREATE_OUT="$(python3 "$QUEUE_PY" create \
+  --from operator --to patch --title "K-beta4 test" --body "smoke test body" 2>&1)" \
+  || smoke_fail "T5: create failed: $T5_CREATE_OUT"
+
+# Parse the task id from the create output. The line shape is
+# `task #<id> queued ...`. We do not depend on JSON output so the
+# smoke survives an older queue-CLI output format.
+T5_TASK_ID="$(printf '%s\n' "$T5_CREATE_OUT" | awk '/task #[0-9]+/ {for (i=1; i<=NF; i++) if ($i ~ /^#[0-9]+$/) { gsub("#","",$i); print $i; exit }}')"
+[[ -n "$T5_TASK_ID" ]] \
+  || smoke_fail "T5: could not parse task id from create output: $T5_CREATE_OUT"
+
+# Claim with --note.
+T5_CLAIM_OUT="$(python3 "$QUEUE_PY" claim "$T5_TASK_ID" \
+  --agent patch --note "blah" 2>&1)" \
+  || smoke_fail "T5: claim --note failed: $T5_CLAIM_OUT"
+
+smoke_assert_contains "$T5_CLAIM_OUT" "claim_note=4c" \
+  "T5: claim stdout summary echoes claim_note=<n>c"
+
+# Probe the events log directly via the helper Python.
+T5_EVENT_PROBE="$SMOKE_TMP_ROOT/t5-event-probe.py"
+{
+  printf '#!/usr/bin/env python3\n'
+  printf 'import sqlite3, sys\n'
+  printf 'conn = sqlite3.connect("%s")\n' "$T5_QUEUE_DB"
+  printf 'conn.row_factory = sqlite3.Row\n'
+  printf 'rows = list(conn.execute("SELECT event_type, note_text FROM task_events WHERE task_id = ? ORDER BY id", (int(sys.argv[1]),)))\n'
+  printf 'for r in rows:\n'
+  printf '    et = r["event_type"]\n'
+  printf '    nt = r["note_text"]\n'
+  printf '    print(et + "|" + (str(nt) if nt is not None else "None"))\n'
+} >"$T5_EVENT_PROBE"
+
+T5_EVENTS="$(python3 "$T5_EVENT_PROBE" "$T5_TASK_ID" 2>&1)" \
+  || smoke_fail "T5: event probe failed: $T5_EVENTS"
+smoke_assert_contains "$T5_EVENTS" "claimed|blah" \
+  "T5: task_events row for the claim carries note_text='blah'"
+
+# T5 teeth: claim a fresh task WITHOUT --note. note_text must be NULL.
+smoke_log "T5 teeth: claim without --note leaves note_text NULL"
+T5T_CREATE_OUT="$(python3 "$QUEUE_PY" create \
+  --from operator --to patch --title "K-beta4 nonote" --body "smoke teeth body" 2>&1)" \
+  || smoke_fail "T5 teeth: create failed: $T5T_CREATE_OUT"
+T5T_TASK_ID="$(printf '%s\n' "$T5T_CREATE_OUT" | awk '/task #[0-9]+/ {for (i=1; i<=NF; i++) if ($i ~ /^#[0-9]+$/) { gsub("#","",$i); print $i; exit }}')"
+[[ -n "$T5T_TASK_ID" ]] || smoke_fail "T5 teeth: could not parse task id"
+
+T5T_CLAIM_OUT="$(python3 "$QUEUE_PY" claim "$T5T_TASK_ID" --agent patch 2>&1)" \
+  || smoke_fail "T5 teeth: claim no-note failed: $T5T_CLAIM_OUT"
+smoke_assert_not_contains "$T5T_CLAIM_OUT" "claim_note=" \
+  "T5 teeth: no --note → stdout summary omits the claim_note= field"
+
+T5T_EVENTS="$(python3 "$T5_EVENT_PROBE" "$T5T_TASK_ID" 2>&1)" \
+  || smoke_fail "T5 teeth: event probe failed"
+smoke_assert_contains "$T5T_EVENTS" "claimed|None" \
+  "T5 teeth: claim row's note_text is NULL when --note omitted"
+
+# ---------------------------------------------------------------------------
+# T6 (#1255): roster read-block softer classifier + admin-only gate.
+# ---------------------------------------------------------------------------
+smoke_log "T6: roster read-block softening — admin allow + non-admin still deny (#1255)"
+
+T6_PROBE="$SMOKE_TMP_ROOT/t6-probe.py"
+{
+  printf '#!/usr/bin/env python3\n'
+  printf 'import os, importlib.util, sys, tempfile\n'
+  printf 'from pathlib import Path\n'
+  # Pin BRIDGE_HOME so roster_local_path() resolves to a stable absolute
+  # path, then mention it directly in the test command. The hook's
+  # path check operates on the canonical roster_local_path() — not on
+  # the argv string verbatim — so the command must reference exactly
+  # that absolute path.
+  printf 'bridge_home = tempfile.mkdtemp(prefix="t6-bridge-home-")\n'
+  printf 'os.environ["BRIDGE_HOME"] = bridge_home\n'
+  printf 'os.environ["BRIDGE_ADMIN_AGENT_ID"] = "admin-test"\n'
+  printf 'spec = importlib.util.spec_from_file_location("tp", "%s")\n' "$TOOL_POLICY_PY"
+  printf 'm = importlib.util.module_from_spec(spec)\n'
+  printf 'spec.loader.exec_module(m)\n'
+  printf 'roster_path = m.roster_local_path()\n'
+  printf 'roster_path.parent.mkdir(parents=True, exist_ok=True)\n'
+  printf 'roster_path.write_text("# fixture roster\\n")\n'
+  printf 'rp = str(roster_path)\n'
+  # _bash_command_has_no_write_intent unit-level cases.
+  printf 'classifier_cases = [\n'
+  printf '    ("plain-read", "cat " + rp, True),\n'
+  printf '    ("custom-tool", "myprog --opt " + rp, True),\n'
+  printf '    ("read-pipeline", "grep BRIDGE " + rp + " | head -3", True),\n'
+  printf '    ("write-redirect", "cat foo > " + rp, False),\n'
+  printf '    ("tee-write", "echo line | tee " + rp, False),\n'
+  printf '    ("sed-inplace", "sed -i s/a/b/ " + rp, False),\n'
+  printf '    ("rm-mutator", "rm " + rp, False),\n'
+  printf '    ("mv-mutator", "mv x " + rp, False),\n'
+  printf '    ("numeric-fd-redirect", "cat x 1>" + rp, False),\n'
+  printf ']\n'
+  printf 'failed = False\n'
+  printf 'for label, cmd, expected in classifier_cases:\n'
+  printf '    got = m._bash_command_has_no_write_intent(cmd)\n'
+  printf '    if got == expected:\n'
+  printf '        print("OK classifier " + label + " got=" + str(got))\n'
+  printf '    else:\n'
+  printf '        failed = True\n'
+  printf '        print("FAIL classifier " + label + " got=" + str(got) + " expected=" + str(expected) + " cmd=" + repr(cmd))\n'
+  # End-to-end cases via protected_alias_reason. admin-test is admin via
+  # BRIDGE_ADMIN_AGENT_ID; "self" is treated as non-admin.
+  printf 'gate_cases = [\n'
+  # admin + custom non-write-intent tool → allowed (None).
+  printf '    ("admin-custom-tool", "admin-test", "myprog --opt " + rp, None),\n'
+  # admin + write-redirect → blocked. Admin deny preserves the
+  # `agent-bridge config set` wrapper wording per #341 CP2.
+  printf '    ("admin-redirect-write", "admin-test", "cat x > " + rp, "protected system config path"),\n'
+  # non-admin + custom non-write-intent tool → blocked ("shared roster
+  # secrets" wording, intentionally distinct from the admin deny).
+  printf '    ("non-admin-custom-tool", "self", "git commit -F " + rp, "shared roster secrets"),\n'
+  # non-admin + plain read → allowed via strict read_intent.
+  printf '    ("non-admin-plain-read", "self", "cat " + rp, None),\n'
+  printf ']\n'
+  printf 'for label, agent, cmd, expected in gate_cases:\n'
+  printf '    got = m.protected_alias_reason(cmd, agent)\n'
+  printf '    if expected is None:\n'
+  printf '        if got is None:\n'
+  printf '            print("OK gate " + label + " allowed")\n'
+  printf '        else:\n'
+  printf '            failed = True\n'
+  printf '            print("FAIL gate " + label + " expected=allow got=" + repr(got))\n'
+  printf '    else:\n'
+  printf '        if got is not None and expected in str(got):\n'
+  printf '            print("OK gate " + label + " denied containing=" + expected)\n'
+  printf '        else:\n'
+  printf '            failed = True\n'
+  printf '            print("FAIL gate " + label + " expected_contains=" + expected + " got=" + repr(got))\n'
+  printf 'sys.exit(1 if failed else 0)\n'
+} >"$T6_PROBE"
+
+python3 "$T6_PROBE" >"$SMOKE_TMP_ROOT/t6.out" 2>&1 \
+  || smoke_fail "T6: probe failed:
+$(cat "$SMOKE_TMP_ROOT/t6.out")"
+T6_OUT="$(cat "$SMOKE_TMP_ROOT/t6.out")"
+smoke_assert_contains "$T6_OUT" "OK classifier plain-read" \
+  "T6: plain read passes the softer classifier"
+smoke_assert_contains "$T6_OUT" "OK classifier custom-tool" \
+  "T6: a custom (unknown) tool passes the softer classifier"
+smoke_assert_contains "$T6_OUT" "OK classifier write-redirect" \
+  "T6: write redirection rejected by softer classifier"
+smoke_assert_contains "$T6_OUT" "OK classifier tee-write" \
+  "T6: tee rejected by softer classifier"
+smoke_assert_contains "$T6_OUT" "OK classifier sed-inplace" \
+  "T6: sed -i rejected by softer classifier"
+smoke_assert_contains "$T6_OUT" "OK gate admin-custom-tool" \
+  "T6 gate: admin + custom non-write-intent tool → allowed (#1255 unblock)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-redirect-write" \
+  "T6 gate: admin + write-redirect → blocked (security boundary preserved)"
+smoke_assert_contains "$T6_OUT" "OK gate non-admin-custom-tool" \
+  "T6 gate: non-admin + custom non-write-intent tool → STILL blocked (roster secrets)"
+smoke_assert_contains "$T6_OUT" "OK gate non-admin-plain-read" \
+  "T6 gate: non-admin + plain read still allowed via strict read_intent"
+smoke_assert_not_contains "$T6_OUT" "FAIL " \
+  "T6: every classifier + gate case must pass"
+
+# T6 teeth: prove the admin-only softening (not the underlying
+# read-intent whitelist) is what unblocks the custom-tool repro shape.
+smoke_log "T6 teeth: strict read-intent whitelist STILL refuses custom-tool"
+T6T_PROBE="$SMOKE_TMP_ROOT/t6-teeth.py"
+{
+  printf '#!/usr/bin/env python3\n'
+  printf 'import importlib.util, sys\n'
+  printf 'spec = importlib.util.spec_from_file_location("tp", "%s")\n' "$TOOL_POLICY_PY"
+  printf 'm = importlib.util.module_from_spec(spec)\n'
+  printf 'spec.loader.exec_module(m)\n'
+  printf 'cmd = "myprog --opt agent-roster.local.sh"\n'
+  printf 'r = m._is_read_intent_bash(cmd)\n'
+  printf 's = m._bash_command_has_no_write_intent(cmd)\n'
+  printf 'print("read_intent=" + str(r) + " soft_no_write=" + str(s))\n'
+  printf 'sys.exit(0 if (r is False and s is True) else 1)\n'
+} >"$T6T_PROBE"
+T6T_OUT="$(python3 "$T6T_PROBE" 2>&1)" \
+  || smoke_fail "T6 teeth: classifier divergence not observed: $T6T_OUT"
+smoke_assert_contains "$T6T_OUT" "read_intent=False" \
+  "T6 teeth: strict whitelist refuses the custom-tool command"
+smoke_assert_contains "$T6T_OUT" "soft_no_write=True" \
+  "T6 teeth: softer classifier accepts the same command (issue #1255 unblock seed)"
+
+smoke_log "K-beta4-nits: all 6 tests + teeth passed"
+exit 0

--- a/scripts/smoke/K-beta4-nits.sh
+++ b/scripts/smoke/K-beta4-nits.sh
@@ -34,16 +34,19 @@
 #         (`event_type=claimed`, `note_text=<text>` / `note_path=<p>`).
 #         Symmetric with `agb done` / `agb update`.
 #
-#   #1255: roster read-block softened for ADMIN shells. The strict
-#         read-intent whitelist (cat/grep/head/tail/...) is now bypassed
-#         when the bash command is issued by an admin agent AND has no
-#         detectable write-intent token (`tee`, `sed -i`, `awk -i
-#         inplace`, output redirection, known mutators). Non-admin
-#         class still hits the original deny — those agents must not
-#         dump roster secrets into commit messages / audit logs even
-#         under a non-write-intent verb (`git commit -F <roster>`).
-#         Write paths still flow through the `agent-bridge config
-#         set` wrapper.
+#   #1255 r2: admin roster read carve-out is a STRICT read-intent
+#         whitelist (cat / grep / head / `agent-bridge config get` /
+#         …). r1 used a write-intent blacklist that tolerated unknown
+#         stage leaders, which codex r1 review showed lets the admin
+#         shell run `python3 /tmp/mutator.py <roster>`, `my-mutator
+#         <roster>`, or `git commit -F <roster>` — paths that mutate
+#         or exfiltrate roster secrets outside the
+#         `agent-bridge config set` audit chain. r2 flips the
+#         classifier so unknown leaders default-deny. Operator
+#         diagnostics (`cat $roster`, `grep BRIDGE $roster`,
+#         `head -10 $roster`) are still allowed because they're on
+#         the canonical read-intent whitelist. Non-admin class still
+#         hits the original deny.
 #
 # Test plan:
 #   T1  (#1282 A): `bridge_run_prune_legacy_teams_mcp` line filter
@@ -70,14 +73,21 @@
 #   T5t (#1253 teeth): claim without `--note` writes a `task_events`
 #                  row with `event_type=claimed` AND `note_text IS
 #                  NULL`. Proves the propagation is opt-in.
-#   T6  (#1255): `_bash_command_has_no_write_intent` returns True for
-#                  benign reads + custom non-write commands; False
-#                  for `... > <roster>`, `tee <roster>`, `sed -i`, and
-#                  any output redirection.
-#   T6t (#1255 teeth): the strict `_is_read_intent_bash` whitelist
-#                  rejects a custom command that the new softer
-#                  classifier accepts — proving the softening is what
-#                  unblocks issue #1255's repro shape.
+#   T6  (#1255 r2): `_bash_command_has_read_intent` is a strict
+#                  whitelist — True for cat / grep / head / awk-no-i
+#                  / sed-no-i; False for `python3 /tmp/mutator.py
+#                  <roster>`, `my-mutator <roster>`, `git commit -F
+#                  <roster>`, `sed -i`, output-redirect, and any
+#                  unknown stage leader. End-to-end gate check via
+#                  `protected_alias_reason` confirms admin mutators
+#                  are blocked while admin read-only diagnostics
+#                  pass.
+#   T6t (#1255 r2 teeth): swapping the whitelist for a hypothetical
+#                  blacklist (here simulated by `lambda _: True`)
+#                  would let admin `python3 /tmp/mutator.py
+#                  <roster>` and `git commit -F <roster>` through —
+#                  proving the strict whitelist is what closes the
+#                  codex r1 BLOCKING gap.
 #
 # Footgun #11: no `<<EOF` to subprocess, no `<<<` here-strings into
 # command substitutions, no inline Python heredoc-to-stdin. Helpers
@@ -384,9 +394,23 @@ smoke_assert_contains "$T5T_EVENTS" "claimed|None" \
   "T5 teeth: claim row's note_text is NULL when --note omitted"
 
 # ---------------------------------------------------------------------------
-# T6 (#1255): roster read-block softer classifier + admin-only gate.
+# T6 (#1255 r2): admin roster read carve-out = STRICT read-intent whitelist.
+#
+# r1 used a write-intent BLACKLIST that tolerated unknown stage leaders;
+# codex r1 review demonstrated that posture admitted
+# `python3 /tmp/mutator.py <roster>`, `my-mutator <roster>`, and
+# `git commit -F <roster>` — admin paths that mutate or exfiltrate the
+# roster outside the `agent-bridge config set` audit chain. r2 flips
+# the classifier to a strict whitelist (`_bash_command_has_read_intent`
+# delegating to `_is_read_intent_bash`). Unknown leaders default-deny.
+#
+# This test covers the 10 codex r1 mutator/leak vectors at the
+# end-to-end `protected_alias_reason` boundary, plus unit cases on the
+# renamed classifier. The teeth case proves that swapping the strict
+# whitelist for an always-True stub would let admin mutators through —
+# i.e. the whitelist is what closes the BLOCKING gap.
 # ---------------------------------------------------------------------------
-smoke_log "T6: roster read-block softening — admin allow + non-admin still deny (#1255)"
+smoke_log "T6: admin roster carve-out blocks mutators (#1255 r2 — codex r1 BLOCKING fix)"
 
 T6_PROBE="$SMOKE_TMP_ROOT/t6-probe.py"
 {
@@ -408,38 +432,82 @@ T6_PROBE="$SMOKE_TMP_ROOT/t6-probe.py"
   printf 'roster_path.parent.mkdir(parents=True, exist_ok=True)\n'
   printf 'roster_path.write_text("# fixture roster\\n")\n'
   printf 'rp = str(roster_path)\n'
-  # _bash_command_has_no_write_intent unit-level cases.
+  # Unit-level cases for the renamed classifier
+  # `_bash_command_has_read_intent`. Strict whitelist: known read-only
+  # leaders → True; unknown leaders / `sed -i` / output redirects /
+  # known mutators → False.
   printf 'classifier_cases = [\n'
-  printf '    ("plain-read", "cat " + rp, True),\n'
-  printf '    ("custom-tool", "myprog --opt " + rp, True),\n'
+  # Read-only shapes on the canonical whitelist → True.
+  printf '    ("plain-cat", "cat " + rp, True),\n'
+  printf '    ("plain-grep", "grep BRIDGE " + rp, True),\n'
+  printf '    ("plain-head", "head -10 " + rp, True),\n'
+  printf '    ("plain-tail", "tail -5 " + rp, True),\n'
+  printf "    ('plain-awk', 'awk {print} ' + rp, True),\n"
+  # `sed` (no -i) is NOT on `_READ_INTENT_BASH_COMMANDS` and the
+  # whitelist refuses it. Operators use `cat | sed` or `agent-bridge
+  # config get` instead. This is correct behavior — sed has many
+  # write-capable subcommands ("w" / "W") even without `-i`.
+  printf "    ('plain-sed-noi', 'sed -n 1,5p ' + rp, False),\n"
   printf '    ("read-pipeline", "grep BRIDGE " + rp + " | head -3", True),\n'
+  # Unknown stage leaders the r1 blacklist wrongly admitted → False.
+  printf '    ("python3-mutator", "python3 /tmp/mutator.py " + rp, False),\n'
+  printf '    ("custom-binary", "my-mutator " + rp, False),\n'
+  printf '    ("git-commit-leak", "git commit -F " + rp, False),\n'
+  printf "    ('perl-leak', 'perl -e nop ' + rp, False),\n"
+  printf "    ('ruby-leak', 'ruby -e nop ' + rp, False),\n"
+  # Known mutators / write shapes → False (was also False under r1,
+  # kept here as regression guard).
   printf '    ("write-redirect", "cat foo > " + rp, False),\n'
+  printf '    ("append-redirect", "echo x >> " + rp, False),\n'
   printf '    ("tee-write", "echo line | tee " + rp, False),\n'
   printf '    ("sed-inplace", "sed -i s/a/b/ " + rp, False),\n'
   printf '    ("rm-mutator", "rm " + rp, False),\n'
   printf '    ("mv-mutator", "mv x " + rp, False),\n'
   printf '    ("numeric-fd-redirect", "cat x 1>" + rp, False),\n'
+  printf '    ("chained-leader", "cat " + rp + " ; python3 /tmp/x.py " + rp, False),\n'
   printf ']\n'
   printf 'failed = False\n'
   printf 'for label, cmd, expected in classifier_cases:\n'
-  printf '    got = m._bash_command_has_no_write_intent(cmd)\n'
+  printf '    got = m._bash_command_has_read_intent(cmd)\n'
   printf '    if got == expected:\n'
   printf '        print("OK classifier " + label + " got=" + str(got))\n'
   printf '    else:\n'
   printf '        failed = True\n'
   printf '        print("FAIL classifier " + label + " got=" + str(got) + " expected=" + str(expected) + " cmd=" + repr(cmd))\n'
-  # End-to-end cases via protected_alias_reason. admin-test is admin via
-  # BRIDGE_ADMIN_AGENT_ID; "self" is treated as non-admin.
+  # End-to-end cases via protected_alias_reason. admin-test is admin
+  # via BRIDGE_ADMIN_AGENT_ID; "self" is treated as non-admin.
+  #
+  # The 10 codex r1 BLOCKING vectors (admin context, expected denied):
+  #   1. python3 /tmp/mutator.py <roster>
+  #   2. my-mutator <roster>
+  #   3. git commit -F <roster>
+  #   4. chained: `cat <roster> ; python3 /tmp/x.py <roster>`
+  #   8. sed -i (in-place mutation)
+  #   9. awk redirect to /tmp/out
+  # And the operator diagnostics that must STILL pass (admin context):
+  #   5. cat <roster>
+  #   6. grep PATTERN <roster>
+  #   7. head -10 <roster>
+  # Plus parity (non-admin context): write shape stays denied.
   printf 'gate_cases = [\n'
-  # admin + custom non-write-intent tool → allowed (None).
-  printf '    ("admin-custom-tool", "admin-test", "myprog --opt " + rp, None),\n'
-  # admin + write-redirect → blocked. Admin deny preserves the
-  # `agent-bridge config set` wrapper wording per #341 CP2.
-  printf '    ("admin-redirect-write", "admin-test", "cat x > " + rp, "protected system config path"),\n'
-  # non-admin + custom non-write-intent tool → blocked ("shared roster
-  # secrets" wording, intentionally distinct from the admin deny).
-  printf '    ("non-admin-custom-tool", "self", "git commit -F " + rp, "shared roster secrets"),\n'
-  # non-admin + plain read → allowed via strict read_intent.
+  # Admin mutator / leak vectors → denied. The deny reason on the
+  # admin path is the ROSTER_LOCAL_DENY_REASON ("protected system
+  # config path"), preserving #341 CP2 wording.
+  printf '    ("admin-python3-mutator", "admin-test", "python3 /tmp/mutator.py " + rp, "protected system config path"),\n'
+  printf '    ("admin-custom-binary", "admin-test", "my-mutator " + rp, "protected system config path"),\n'
+  printf '    ("admin-git-commit-leak", "admin-test", "git commit -F " + rp, "protected system config path"),\n'
+  printf '    ("admin-sed-inplace", "admin-test", "sed -i s/foo/bar/ " + rp, "protected system config path"),\n'
+  printf "    ('admin-awk-redirect', 'admin-test', 'awk {print} ' + rp + ' > /tmp/out', 'protected system config path'),\n"
+  printf '    ("admin-tee-write", "admin-test", "echo x | tee " + rp, "protected system config path"),\n'
+  # Admin operator diagnostics → allowed (the #1255 unblock target).
+  printf '    ("admin-cat", "admin-test", "cat " + rp, None),\n'
+  printf '    ("admin-grep", "admin-test", "grep BRIDGE " + rp, None),\n'
+  printf '    ("admin-head", "admin-test", "head -10 " + rp, None),\n'
+  # Non-admin parity: write shape stays denied (no carve-out applied).
+  # Non-admin plain read is still allowed via the general read_intent
+  # branch at protected_alias_reason — preserved for issue #383.
+  printf '    ("non-admin-git-commit", "self", "git commit -F " + rp, "shared roster secrets"),\n'
+  printf '    ("non-admin-python3-mutator", "self", "python3 /tmp/mutator.py " + rp, "shared roster secrets"),\n'
   printf '    ("non-admin-plain-read", "self", "cat " + rp, None),\n'
   printf ']\n'
   printf 'for label, agent, cmd, expected in gate_cases:\n'
@@ -463,49 +531,132 @@ python3 "$T6_PROBE" >"$SMOKE_TMP_ROOT/t6.out" 2>&1 \
   || smoke_fail "T6: probe failed:
 $(cat "$SMOKE_TMP_ROOT/t6.out")"
 T6_OUT="$(cat "$SMOKE_TMP_ROOT/t6.out")"
-smoke_assert_contains "$T6_OUT" "OK classifier plain-read" \
-  "T6: plain read passes the softer classifier"
-smoke_assert_contains "$T6_OUT" "OK classifier custom-tool" \
-  "T6: a custom (unknown) tool passes the softer classifier"
+
+# Classifier assertions — read-only shapes admitted.
+smoke_assert_contains "$T6_OUT" "OK classifier plain-cat" \
+  "T6: plain cat admitted by whitelist"
+smoke_assert_contains "$T6_OUT" "OK classifier plain-grep" \
+  "T6: plain grep admitted by whitelist"
+smoke_assert_contains "$T6_OUT" "OK classifier plain-head" \
+  "T6: plain head admitted by whitelist"
+smoke_assert_contains "$T6_OUT" "OK classifier plain-tail" \
+  "T6: plain tail admitted by whitelist"
+smoke_assert_contains "$T6_OUT" "OK classifier plain-awk" \
+  "T6: plain awk (no -i) admitted by whitelist"
+smoke_assert_contains "$T6_OUT" "OK classifier plain-sed-noi" \
+  "T6: sed (even without -i) refused by whitelist — has write-capable subcommands"
+
+# Classifier assertions — unknown leaders refused (codex r1 BLOCKING).
+smoke_assert_contains "$T6_OUT" "OK classifier python3-mutator" \
+  "T6: python3 /tmp/mutator.py refused by whitelist (unknown leader)"
+smoke_assert_contains "$T6_OUT" "OK classifier custom-binary" \
+  "T6: custom binary refused by whitelist (unknown leader)"
+smoke_assert_contains "$T6_OUT" "OK classifier git-commit-leak" \
+  "T6: git commit -F refused by whitelist (unknown leader)"
+
+# Classifier assertions — known mutators / write shapes refused.
 smoke_assert_contains "$T6_OUT" "OK classifier write-redirect" \
-  "T6: write redirection rejected by softer classifier"
-smoke_assert_contains "$T6_OUT" "OK classifier tee-write" \
-  "T6: tee rejected by softer classifier"
+  "T6: > redirect refused by whitelist"
+smoke_assert_contains "$T6_OUT" "OK classifier append-redirect" \
+  "T6: >> redirect refused by whitelist"
 smoke_assert_contains "$T6_OUT" "OK classifier sed-inplace" \
-  "T6: sed -i rejected by softer classifier"
-smoke_assert_contains "$T6_OUT" "OK gate admin-custom-tool" \
-  "T6 gate: admin + custom non-write-intent tool → allowed (#1255 unblock)"
-smoke_assert_contains "$T6_OUT" "OK gate admin-redirect-write" \
-  "T6 gate: admin + write-redirect → blocked (security boundary preserved)"
-smoke_assert_contains "$T6_OUT" "OK gate non-admin-custom-tool" \
-  "T6 gate: non-admin + custom non-write-intent tool → STILL blocked (roster secrets)"
+  "T6: sed -i refused by whitelist"
+smoke_assert_contains "$T6_OUT" "OK classifier numeric-fd-redirect" \
+  "T6: 1> redirect refused by whitelist"
+
+# End-to-end gate assertions — the codex r1 mutator/leak vectors.
+smoke_assert_contains "$T6_OUT" "OK gate admin-python3-mutator" \
+  "T6 gate: admin python3 /tmp/mutator.py <roster> → DENIED (codex r1 vector 1)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-custom-binary" \
+  "T6 gate: admin my-mutator <roster> → DENIED (codex r1 vector 2)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-git-commit-leak" \
+  "T6 gate: admin git commit -F <roster> → DENIED (codex r1 vector 3)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-sed-inplace" \
+  "T6 gate: admin sed -i <roster> → DENIED (in-place mutation)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-awk-redirect" \
+  "T6 gate: admin awk <roster> > /tmp/out → DENIED (exfil redirect)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-tee-write" \
+  "T6 gate: admin tee <roster> → DENIED (known mutator)"
+
+# Operator diagnostics must STILL pass (the #1255 unblock surface).
+smoke_assert_contains "$T6_OUT" "OK gate admin-cat" \
+  "T6 gate: admin cat <roster> → allowed (#1255 unblock preserved)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-grep" \
+  "T6 gate: admin grep <roster> → allowed (#1255 unblock preserved)"
+smoke_assert_contains "$T6_OUT" "OK gate admin-head" \
+  "T6 gate: admin head <roster> → allowed (#1255 unblock preserved)"
+
+# Non-admin parity.
+smoke_assert_contains "$T6_OUT" "OK gate non-admin-git-commit" \
+  "T6 gate: non-admin git commit -F <roster> → still DENIED"
+smoke_assert_contains "$T6_OUT" "OK gate non-admin-python3-mutator" \
+  "T6 gate: non-admin python3 mutator <roster> → still DENIED"
 smoke_assert_contains "$T6_OUT" "OK gate non-admin-plain-read" \
-  "T6 gate: non-admin + plain read still allowed via strict read_intent"
+  "T6 gate: non-admin plain read still allowed (preserves #383)"
+
 smoke_assert_not_contains "$T6_OUT" "FAIL " \
   "T6: every classifier + gate case must pass"
 
-# T6 teeth: prove the admin-only softening (not the underlying
-# read-intent whitelist) is what unblocks the custom-tool repro shape.
-smoke_log "T6 teeth: strict read-intent whitelist STILL refuses custom-tool"
+# T6 teeth: prove that the STRICT whitelist is what closes the codex
+# r1 BLOCKING gap. Swap `_bash_command_has_read_intent` for a stub
+# that always returns True (i.e. the r1 blacklist's effective behavior
+# on unknown leaders) and confirm an admin python3 mutator command is
+# THEN incorrectly allowed by `protected_alias_reason`. Restore the
+# real function and confirm the same command is denied.
+smoke_log "T6 teeth: stubbing classifier → True admits admin mutator (proves whitelist is the seal)"
 T6T_PROBE="$SMOKE_TMP_ROOT/t6-teeth.py"
 {
   printf '#!/usr/bin/env python3\n'
-  printf 'import importlib.util, sys\n'
+  printf 'import os, importlib.util, sys, tempfile\n'
+  printf 'bridge_home = tempfile.mkdtemp(prefix="t6-teeth-bridge-home-")\n'
+  printf 'os.environ["BRIDGE_HOME"] = bridge_home\n'
+  printf 'os.environ["BRIDGE_ADMIN_AGENT_ID"] = "admin-test"\n'
   printf 'spec = importlib.util.spec_from_file_location("tp", "%s")\n' "$TOOL_POLICY_PY"
   printf 'm = importlib.util.module_from_spec(spec)\n'
   printf 'spec.loader.exec_module(m)\n'
-  printf 'cmd = "myprog --opt agent-roster.local.sh"\n'
-  printf 'r = m._is_read_intent_bash(cmd)\n'
-  printf 's = m._bash_command_has_no_write_intent(cmd)\n'
-  printf 'print("read_intent=" + str(r) + " soft_no_write=" + str(s))\n'
-  printf 'sys.exit(0 if (r is False and s is True) else 1)\n'
+  printf 'roster_path = m.roster_local_path()\n'
+  printf 'roster_path.parent.mkdir(parents=True, exist_ok=True)\n'
+  printf 'roster_path.write_text("# fixture roster\\n")\n'
+  printf 'rp = str(roster_path)\n'
+  printf 'admin_mutator = "python3 /tmp/mutator.py " + rp\n'
+  printf 'admin_leak = "git commit -F " + rp\n'
+  # Real classifier denies the mutator/leak.
+  printf 'real_mutator = m.protected_alias_reason(admin_mutator, "admin-test")\n'
+  printf 'real_leak = m.protected_alias_reason(admin_leak, "admin-test")\n'
+  printf 'real_cat = m.protected_alias_reason("cat " + rp, "admin-test")\n'
+  # Stub to True (simulating the r1 blacklist tolerating unknown leaders).
+  printf 'orig = m._bash_command_has_read_intent\n'
+  printf 'm._bash_command_has_read_intent = lambda cmd: True\n'
+  printf 'stub_mutator = m.protected_alias_reason(admin_mutator, "admin-test")\n'
+  printf 'stub_leak = m.protected_alias_reason(admin_leak, "admin-test")\n'
+  printf 'm._bash_command_has_read_intent = orig\n'
+  printf 'print("real_mutator=" + repr(real_mutator))\n'
+  printf 'print("real_leak=" + repr(real_leak))\n'
+  printf 'print("real_cat=" + repr(real_cat))\n'
+  printf 'print("stub_mutator=" + repr(stub_mutator))\n'
+  printf 'print("stub_leak=" + repr(stub_leak))\n'
+  # Pass iff real classifier denies mutator/leak, allows cat, AND stub
+  # lets the mutator/leak through (proving the whitelist is the seal).
+  printf 'ok = (real_mutator is not None\n'
+  printf '      and real_leak is not None\n'
+  printf '      and real_cat is None\n'
+  printf '      and stub_mutator is None\n'
+  printf '      and stub_leak is None)\n'
+  printf 'sys.exit(0 if ok else 1)\n'
 } >"$T6T_PROBE"
 T6T_OUT="$(python3 "$T6T_PROBE" 2>&1)" \
-  || smoke_fail "T6 teeth: classifier divergence not observed: $T6T_OUT"
-smoke_assert_contains "$T6T_OUT" "read_intent=False" \
-  "T6 teeth: strict whitelist refuses the custom-tool command"
-smoke_assert_contains "$T6T_OUT" "soft_no_write=True" \
-  "T6 teeth: softer classifier accepts the same command (issue #1255 unblock seed)"
+  || smoke_fail "T6 teeth: whitelist seal not observed:
+$T6T_OUT"
+smoke_assert_contains "$T6T_OUT" "real_mutator='" \
+  "T6 teeth: real classifier denies admin python3 mutator"
+smoke_assert_contains "$T6T_OUT" "real_leak='" \
+  "T6 teeth: real classifier denies admin git commit leak"
+smoke_assert_contains "$T6T_OUT" "real_cat=None" \
+  "T6 teeth: real classifier still allows admin cat diagnostic"
+smoke_assert_contains "$T6T_OUT" "stub_mutator=None" \
+  "T6 teeth: stubbed-True classifier wrongly admits admin mutator (r1 regression demo)"
+smoke_assert_contains "$T6T_OUT" "stub_leak=None" \
+  "T6 teeth: stubbed-True classifier wrongly admits admin git commit -F leak (r1 regression demo)"
 
 smoke_log "K-beta4-nits: all 6 tests + teeth passed"
 exit 0

--- a/scripts/smoke/K-beta4-nits.sh
+++ b/scripts/smoke/K-beta4-nits.sh
@@ -48,6 +48,22 @@
 #         the canonical read-intent whitelist. Non-admin class still
 #         hits the original deny.
 #
+#   #1255 r3: r2's whitelist still contained write-capable leaders.
+#         `find` is legitimately useful for diagnostics (`find
+#         <roster> -name "*.sh"`) but has mutation/exec primitives
+#         that the bare leader check did not see — `-delete` removes
+#         matches in place; `-exec` / `-execdir` / `-ok` / `-okdir`
+#         spawn arbitrary subprocesses against each match; `-fprint`
+#         / `-fprint0` / `-fprintf` write matches to a file without
+#         appearing as a `>` token. Codex PR #1294 r2 demonstrated
+#         that an admin could `find <roster> -delete` or `find
+#         <roster> -exec python3 /tmp/mutator.py {} \;` through the
+#         read-intent classifier. r3 adds a `_find_is_read_only`
+#         flag filter: when the stage leader is `find` and any of
+#         the mutation flags appears in argv, the stage falls out of
+#         the read-intent classification and the roster carve-out
+#         defaults to the non-admin deny.
+#
 # Test plan:
 #   T1  (#1282 A): `bridge_run_prune_legacy_teams_mcp` line filter
 #                  drops `absent path=…` rows from the audit log.
@@ -88,6 +104,21 @@
 #                  <roster>` and `git commit -F <roster>` through —
 #                  proving the strict whitelist is what closes the
 #                  codex r1 BLOCKING gap.
+#   T7  (#1255 r3): `find` mutation/exec flag filter. `find
+#                  <roster> -delete`, `-exec`, `-execdir`, `-ok`,
+#                  `-okdir`, `-fprint`, `-fprint0`, `-fprintf` are
+#                  rejected by `_is_read_intent_bash` even though
+#                  `find` is on the read-intent whitelist. `find
+#                  <roster> -name "*.sh"` and `find <roster> -type
+#                  f` still classify as read-intent. End-to-end gate
+#                  check via `protected_alias_reason` confirms admin
+#                  mutator/exec forms are denied while read-only
+#                  diagnostics pass.
+#   T7t (#1255 r3 teeth): reverting the `_find_is_read_only` filter
+#                  (here simulated by `lambda _: True`) lets admin
+#                  `find <roster> -delete` and `find <roster> -exec
+#                  ...` through — proves the flag filter is what
+#                  closes the codex PR #1294 r2 BLOCKING gap.
 #
 # Footgun #11: no `<<EOF` to subprocess, no `<<<` here-strings into
 # command substitutions, no inline Python heredoc-to-stdin. Helpers
@@ -658,5 +689,224 @@ smoke_assert_contains "$T6T_OUT" "stub_mutator=None" \
 smoke_assert_contains "$T6T_OUT" "stub_leak=None" \
   "T6 teeth: stubbed-True classifier wrongly admits admin git commit -F leak (r1 regression demo)"
 
-smoke_log "K-beta4-nits: all 6 tests + teeth passed"
+# ---------------------------------------------------------------------------
+# T7 (#1255 r3): `find` mutation/exec flag filter (codex PR #1294 r2 BLOCKING).
+#
+# r2's whitelist contained `find` so operator diagnostics like `find
+# <roster> -name "*.sh"` keep working. Codex r2 showed that without an
+# argv-level filter, `find <roster> -delete` and `find <roster> -exec
+# python3 /tmp/mutator.py {} \;` slip through as read-intent — the
+# stage leader check sees only `find`, not the mutation primitive that
+# follows. r3 adds `_find_is_read_only(argv)` and wires it into
+# `_is_read_intent_bash` so any mutation/exec flag drops the
+# classification, while leaving `-name` / `-type` / `-size` reads alone.
+# ---------------------------------------------------------------------------
+smoke_log "T7: find mutation/exec flag filter (#1255 r3 — codex PR #1294 r2 BLOCKING)"
+
+T7_PROBE="$SMOKE_TMP_ROOT/t7-probe.py"
+{
+  printf '#!/usr/bin/env python3\n'
+  printf 'import os, importlib.util, sys, tempfile\n'
+  printf 'bridge_home = tempfile.mkdtemp(prefix="t7-bridge-home-")\n'
+  printf 'os.environ["BRIDGE_HOME"] = bridge_home\n'
+  printf 'os.environ["BRIDGE_ADMIN_AGENT_ID"] = "admin-test"\n'
+  printf 'spec = importlib.util.spec_from_file_location("tp", "%s")\n' "$TOOL_POLICY_PY"
+  printf 'm = importlib.util.module_from_spec(spec)\n'
+  printf 'spec.loader.exec_module(m)\n'
+  printf 'roster_path = m.roster_local_path()\n'
+  printf 'roster_path.parent.mkdir(parents=True, exist_ok=True)\n'
+  printf 'roster_path.write_text("# fixture roster\\n")\n'
+  printf 'rp = str(roster_path)\n'
+  # Classifier cases — _is_read_intent_bash on `find` shapes.
+  printf 'classifier_cases = [\n'
+  # Mutation/exec flags — all must drop the classification.
+  printf "    ('find-delete', 'find ' + rp + ' -delete', False),\n"
+  printf "    ('find-exec', 'find ' + rp + ' -exec python3 /tmp/m.py {} ;', False),\n"
+  printf "    ('find-execdir', 'find ' + rp + ' -execdir /bin/cat {} +', False),\n"
+  printf "    ('find-ok', 'find ' + rp + ' -ok rm {} ;', False),\n"
+  printf "    ('find-okdir', 'find ' + rp + ' -okdir ls {} ;', False),\n"
+  printf "    ('find-fprint', 'find ' + rp + ' -fprint /tmp/leak', False),\n"
+  printf "    ('find-fprint0', 'find ' + rp + ' -fprint0 /tmp/leak', False),\n"
+  printf "    ('find-fprintf', 'find ' + rp + ' -fprintf /tmp/leak %%p', False),\n"
+  # Mid-argv -delete (e.g. `-type f -delete`).
+  printf "    ('find-mid-delete', 'find ' + rp + ' -type f -delete', False),\n"
+  # Pathy leader (`/usr/bin/find -delete`).
+  printf "    ('find-path-leader', '/usr/bin/find ' + rp + ' -exec ls {} ;', False),\n"
+  # Read-only forms — must still classify as read.
+  printf "    ('find-name', 'find ' + rp + ' -name *.sh', True),\n"
+  printf "    ('find-type', 'find ' + rp + ' -type f', True),\n"
+  printf "    ('find-size', 'find ' + rp + ' -size +1c', True),\n"
+  printf "    ('find-multi-read', 'find ' + rp + ' -type f -size +1c -name *.sh', True),\n"
+  # Token-boundary: a similar-looking but distinct token must NOT match.
+  printf "    ('find-pseudo-match', 'find ' + rp + ' -name -deleted-files', True),\n"
+  printf ']\n'
+  printf 'failed = False\n'
+  printf 'for label, cmd, expected in classifier_cases:\n'
+  printf '    got = m._is_read_intent_bash(cmd)\n'
+  printf '    if got == expected:\n'
+  printf '        print("OK classifier " + label + " got=" + str(got))\n'
+  printf '    else:\n'
+  printf '        failed = True\n'
+  printf '        print("FAIL classifier " + label + " got=" + str(got) + " expected=" + str(expected) + " cmd=" + repr(cmd))\n'
+  # End-to-end gate cases via protected_alias_reason.
+  printf 'gate_cases = [\n'
+  # Admin mutator/exec vectors → DENIED (roster carve-out falls
+  # through to ROSTER_LOCAL_DENY_REASON because read_intent is now False).
+  printf "    ('admin-find-delete', 'admin-test', 'find ' + rp + ' -delete', 'protected system config path'),\n"
+  printf "    ('admin-find-exec', 'admin-test', 'find ' + rp + ' -exec python3 /tmp/m.py {} ;', 'protected system config path'),\n"
+  printf "    ('admin-find-execdir', 'admin-test', 'find ' + rp + ' -execdir cat {} +', 'protected system config path'),\n"
+  printf "    ('admin-find-ok', 'admin-test', 'find ' + rp + ' -ok rm {} ;', 'protected system config path'),\n"
+  printf "    ('admin-find-fprintf', 'admin-test', 'find ' + rp + ' -fprintf /tmp/leak %%p', 'protected system config path'),\n"
+  # Admin read-only diagnostics → allowed.
+  printf "    ('admin-find-name', 'admin-test', 'find ' + rp + ' -name *.sh', None),\n"
+  printf "    ('admin-find-type', 'admin-test', 'find ' + rp + ' -type f', None),\n"
+  # Non-admin parity: mutator denied with the shared-roster wording;
+  # read-only still allowed via the general read_intent branch.
+  printf "    ('non-admin-find-delete', 'self', 'find ' + rp + ' -delete', 'shared roster secrets'),\n"
+  printf "    ('non-admin-find-exec', 'self', 'find ' + rp + ' -exec python3 /tmp/m.py {} ;', 'shared roster secrets'),\n"
+  printf "    ('non-admin-find-name', 'self', 'find ' + rp + ' -name *.sh', None),\n"
+  printf ']\n'
+  printf 'for label, agent, cmd, expected in gate_cases:\n'
+  printf '    got = m.protected_alias_reason(cmd, agent)\n'
+  printf '    if expected is None:\n'
+  printf '        if got is None:\n'
+  printf '            print("OK gate " + label + " allowed")\n'
+  printf '        else:\n'
+  printf '            failed = True\n'
+  printf '            print("FAIL gate " + label + " expected=allow got=" + repr(got))\n'
+  printf '    else:\n'
+  printf '        if got is not None and expected in str(got):\n'
+  printf '            print("OK gate " + label + " denied containing=" + expected)\n'
+  printf '        else:\n'
+  printf '            failed = True\n'
+  printf '            print("FAIL gate " + label + " expected_contains=" + expected + " got=" + repr(got))\n'
+  printf 'sys.exit(1 if failed else 0)\n'
+} >"$T7_PROBE"
+
+python3 "$T7_PROBE" >"$SMOKE_TMP_ROOT/t7.out" 2>&1 \
+  || smoke_fail "T7: probe failed:
+$(cat "$SMOKE_TMP_ROOT/t7.out")"
+T7_OUT="$(cat "$SMOKE_TMP_ROOT/t7.out")"
+
+# Classifier — mutation/exec flags drop the read-intent classification.
+smoke_assert_contains "$T7_OUT" "OK classifier find-delete" \
+  "T7: find -delete refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-exec" \
+  "T7: find -exec refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-execdir" \
+  "T7: find -execdir refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-ok" \
+  "T7: find -ok refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-okdir" \
+  "T7: find -okdir refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-fprint" \
+  "T7: find -fprint refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-fprint0" \
+  "T7: find -fprint0 refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-fprintf" \
+  "T7: find -fprintf refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-mid-delete" \
+  "T7: -delete mid-argv refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-path-leader" \
+  "T7: /usr/bin/find -exec refused by classifier"
+
+# Classifier — read-only flag forms still admitted.
+smoke_assert_contains "$T7_OUT" "OK classifier find-name" \
+  "T7: find -name admitted by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-type" \
+  "T7: find -type admitted by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-size" \
+  "T7: find -size admitted by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-multi-read" \
+  "T7: multiple read flags admitted by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-pseudo-match" \
+  "T7: pseudo-match token (-deleted-files) does not trigger the filter"
+
+# End-to-end gate — admin mutator/exec vectors denied.
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-delete" \
+  "T7 gate: admin find <roster> -delete → DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-exec" \
+  "T7 gate: admin find <roster> -exec ... → DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-execdir" \
+  "T7 gate: admin find <roster> -execdir ... → DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-ok" \
+  "T7 gate: admin find <roster> -ok ... → DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-fprintf" \
+  "T7 gate: admin find <roster> -fprintf ... → DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-name" \
+  "T7 gate: admin find <roster> -name → allowed (#1255 unblock preserved)"
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-type" \
+  "T7 gate: admin find <roster> -type → allowed"
+
+# Non-admin parity.
+smoke_assert_contains "$T7_OUT" "OK gate non-admin-find-delete" \
+  "T7 gate: non-admin find -delete → still DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate non-admin-find-exec" \
+  "T7 gate: non-admin find -exec → still DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate non-admin-find-name" \
+  "T7 gate: non-admin find -name → allowed (preserves #383)"
+
+smoke_assert_not_contains "$T7_OUT" "FAIL " \
+  "T7: every classifier + gate case must pass"
+
+# T7 teeth: prove the flag filter is what closes the gap. Stub
+# `_find_is_read_only` to always return True (i.e. the pre-r3
+# behavior where find was a bare whitelist entry) and confirm admin
+# `find -delete` is then allowed by protected_alias_reason. Restore
+# the real function and confirm the same command is denied.
+smoke_log "T7 teeth: stubbing _find_is_read_only → True admits admin find -delete (proves filter is the seal)"
+T7T_PROBE="$SMOKE_TMP_ROOT/t7-teeth.py"
+{
+  printf '#!/usr/bin/env python3\n'
+  printf 'import os, importlib.util, sys, tempfile\n'
+  printf 'bridge_home = tempfile.mkdtemp(prefix="t7-teeth-bridge-home-")\n'
+  printf 'os.environ["BRIDGE_HOME"] = bridge_home\n'
+  printf 'os.environ["BRIDGE_ADMIN_AGENT_ID"] = "admin-test"\n'
+  printf 'spec = importlib.util.spec_from_file_location("tp", "%s")\n' "$TOOL_POLICY_PY"
+  printf 'm = importlib.util.module_from_spec(spec)\n'
+  printf 'spec.loader.exec_module(m)\n'
+  printf 'roster_path = m.roster_local_path()\n'
+  printf 'roster_path.parent.mkdir(parents=True, exist_ok=True)\n'
+  printf 'roster_path.write_text("# fixture roster\\n")\n'
+  printf 'rp = str(roster_path)\n'
+  printf 'admin_delete = "find " + rp + " -delete"\n'
+  printf 'admin_exec = "find " + rp + " -exec python3 /tmp/m.py {} ;"\n'
+  printf 'admin_read = "find " + rp + " -name *.sh"\n'
+  # Real filter denies the mutator/exec.
+  printf 'real_delete = m.protected_alias_reason(admin_delete, "admin-test")\n'
+  printf 'real_exec = m.protected_alias_reason(admin_exec, "admin-test")\n'
+  printf 'real_read = m.protected_alias_reason(admin_read, "admin-test")\n'
+  # Stub _find_is_read_only to always return True — simulates pre-r3.
+  printf 'orig = m._find_is_read_only\n'
+  printf 'm._find_is_read_only = lambda _argv: True\n'
+  printf 'stub_delete = m.protected_alias_reason(admin_delete, "admin-test")\n'
+  printf 'stub_exec = m.protected_alias_reason(admin_exec, "admin-test")\n'
+  printf 'm._find_is_read_only = orig\n'
+  printf 'print("real_delete=" + repr(real_delete))\n'
+  printf 'print("real_exec=" + repr(real_exec))\n'
+  printf 'print("real_read=" + repr(real_read))\n'
+  printf 'print("stub_delete=" + repr(stub_delete))\n'
+  printf 'print("stub_exec=" + repr(stub_exec))\n'
+  printf 'ok = (real_delete is not None\n'
+  printf '      and real_exec is not None\n'
+  printf '      and real_read is None\n'
+  printf '      and stub_delete is None\n'
+  printf '      and stub_exec is None)\n'
+  printf 'sys.exit(0 if ok else 1)\n'
+} >"$T7T_PROBE"
+T7T_OUT="$(python3 "$T7T_PROBE" 2>&1)" \
+  || smoke_fail "T7 teeth: flag-filter seal not observed:
+$T7T_OUT"
+smoke_assert_contains "$T7T_OUT" "real_delete='" \
+  "T7 teeth: real filter denies admin find -delete"
+smoke_assert_contains "$T7T_OUT" "real_exec='" \
+  "T7 teeth: real filter denies admin find -exec"
+smoke_assert_contains "$T7T_OUT" "real_read=None" \
+  "T7 teeth: real filter still allows admin find -name diagnostic"
+smoke_assert_contains "$T7T_OUT" "stub_delete=None" \
+  "T7 teeth: stubbed-True filter wrongly admits admin find -delete (pre-r3 demo)"
+smoke_assert_contains "$T7T_OUT" "stub_exec=None" \
+  "T7 teeth: stubbed-True filter wrongly admits admin find -exec (pre-r3 demo)"
+
+smoke_log "K-beta4-nits: all 7 tests + teeth passed"
 exit 0

--- a/scripts/smoke/K-beta4-nits.sh
+++ b/scripts/smoke/K-beta4-nits.sh
@@ -48,21 +48,23 @@
 #         the canonical read-intent whitelist. Non-admin class still
 #         hits the original deny.
 #
-#   #1255 r3: r2's whitelist still contained write-capable leaders.
+#   #1255 r3/r4: r2's whitelist still contained write-capable leaders.
 #         `find` is legitimately useful for diagnostics (`find
 #         <roster> -name "*.sh"`) but has mutation/exec primitives
 #         that the bare leader check did not see — `-delete` removes
 #         matches in place; `-exec` / `-execdir` / `-ok` / `-okdir`
 #         spawn arbitrary subprocesses against each match; `-fprint`
-#         / `-fprint0` / `-fprintf` write matches to a file without
-#         appearing as a `>` token. Codex PR #1294 r2 demonstrated
-#         that an admin could `find <roster> -delete` or `find
-#         <roster> -exec python3 /tmp/mutator.py {} \;` through the
-#         read-intent classifier. r3 adds a `_find_is_read_only`
-#         flag filter: when the stage leader is `find` and any of
-#         the mutation flags appears in argv, the stage falls out of
-#         the read-intent classification and the roster carve-out
-#         defaults to the non-admin deny.
+#         / `-fprint0` / `-fprintf` / `-fls` write matches (or
+#         `-ls`-format listings) to a file without appearing as a
+#         `>` token. Codex PR #1294 r2 demonstrated that an admin
+#         could `find <roster> -delete` or `find <roster> -exec
+#         python3 /tmp/mutator.py {} \;` through the read-intent
+#         classifier; r3 of the same PR caught the `-fls` GNU action
+#         missed in r3's initial filter. r3/r4 adds a
+#         `_find_is_read_only` flag filter: when the stage leader is
+#         `find` and any of the mutation flags appears in argv, the
+#         stage falls out of the read-intent classification and the
+#         roster carve-out defaults to the non-admin deny.
 #
 # Test plan:
 #   T1  (#1282 A): `bridge_run_prune_legacy_teams_mcp` line filter
@@ -104,21 +106,22 @@
 #                  <roster>` and `git commit -F <roster>` through —
 #                  proving the strict whitelist is what closes the
 #                  codex r1 BLOCKING gap.
-#   T7  (#1255 r3): `find` mutation/exec flag filter. `find
+#   T7  (#1255 r3/r4): `find` mutation/exec flag filter. `find
 #                  <roster> -delete`, `-exec`, `-execdir`, `-ok`,
-#                  `-okdir`, `-fprint`, `-fprint0`, `-fprintf` are
-#                  rejected by `_is_read_intent_bash` even though
-#                  `find` is on the read-intent whitelist. `find
-#                  <roster> -name "*.sh"` and `find <roster> -type
-#                  f` still classify as read-intent. End-to-end gate
-#                  check via `protected_alias_reason` confirms admin
+#                  `-okdir`, `-fprint`, `-fprint0`, `-fprintf`,
+#                  `-fls` are rejected by `_is_read_intent_bash`
+#                  even though `find` is on the read-intent
+#                  whitelist. `find <roster> -name "*.sh"` and
+#                  `find <roster> -type f` still classify as
+#                  read-intent. End-to-end gate check via
+#                  `protected_alias_reason` confirms admin
 #                  mutator/exec forms are denied while read-only
 #                  diagnostics pass.
-#   T7t (#1255 r3 teeth): reverting the `_find_is_read_only` filter
-#                  (here simulated by `lambda _: True`) lets admin
-#                  `find <roster> -delete` and `find <roster> -exec
-#                  ...` through — proves the flag filter is what
-#                  closes the codex PR #1294 r2 BLOCKING gap.
+#   T7t (#1255 r3/r4 teeth): reverting the `_find_is_read_only`
+#                  filter (here simulated by `lambda _: True`) lets
+#                  admin `find <roster> -delete`, `-exec`, and
+#                  `-fls` through — proves the flag filter is what
+#                  closes the codex PR #1294 r2/r3 BLOCKING gap.
 #
 # Footgun #11: no `<<EOF` to subprocess, no `<<<` here-strings into
 # command substitutions, no inline Python heredoc-to-stdin. Helpers
@@ -690,7 +693,8 @@ smoke_assert_contains "$T6T_OUT" "stub_leak=None" \
   "T6 teeth: stubbed-True classifier wrongly admits admin git commit -F leak (r1 regression demo)"
 
 # ---------------------------------------------------------------------------
-# T7 (#1255 r3): `find` mutation/exec flag filter (codex PR #1294 r2 BLOCKING).
+# T7 (#1255 r3/r4): `find` mutation/exec flag filter (codex PR #1294 r2/r3
+# BLOCKING).
 #
 # r2's whitelist contained `find` so operator diagnostics like `find
 # <roster> -name "*.sh"` keep working. Codex r2 showed that without an
@@ -700,8 +704,13 @@ smoke_assert_contains "$T6T_OUT" "stub_leak=None" \
 # follows. r3 adds `_find_is_read_only(argv)` and wires it into
 # `_is_read_intent_bash` so any mutation/exec flag drops the
 # classification, while leaving `-name` / `-type` / `-size` reads alone.
+# Codex r3 of the same PR caught that r3's frozenset omitted GNU find's
+# `-fls FILE` action (writes `-ls`-format listings to a named file
+# without `>`), which had the same exfil shape as `-fprint*`. r4 adds
+# `-fls` and asserts the comprehensive audit of GNU find file-action
+# primitives is now exhaustive.
 # ---------------------------------------------------------------------------
-smoke_log "T7: find mutation/exec flag filter (#1255 r3 — codex PR #1294 r2 BLOCKING)"
+smoke_log "T7: find mutation/exec flag filter (#1255 r3/r4 — codex PR #1294 r2/r3 BLOCKING)"
 
 T7_PROBE="$SMOKE_TMP_ROOT/t7-probe.py"
 {
@@ -728,6 +737,11 @@ T7_PROBE="$SMOKE_TMP_ROOT/t7-probe.py"
   printf "    ('find-fprint', 'find ' + rp + ' -fprint /tmp/leak', False),\n"
   printf "    ('find-fprint0', 'find ' + rp + ' -fprint0 /tmp/leak', False),\n"
   printf "    ('find-fprintf', 'find ' + rp + ' -fprintf /tmp/leak %%p', False),\n"
+  # r4: GNU find -fls FILE writes -ls-format listings to a named file
+  # without a `>` token (codex PR #1294 r3 BLOCKING).
+  printf "    ('find-fls', 'find ' + rp + ' -fls /tmp/leak', False),\n"
+  # Mid-argv -fls (matches the `-fprint*` mid-argv shape).
+  printf "    ('find-mid-fls', 'find ' + rp + ' -type f -fls /tmp/leak', False),\n"
   # Mid-argv -delete (e.g. `-type f -delete`).
   printf "    ('find-mid-delete', 'find ' + rp + ' -type f -delete', False),\n"
   # Pathy leader (`/usr/bin/find -delete`).
@@ -757,6 +771,8 @@ T7_PROBE="$SMOKE_TMP_ROOT/t7-probe.py"
   printf "    ('admin-find-execdir', 'admin-test', 'find ' + rp + ' -execdir cat {} +', 'protected system config path'),\n"
   printf "    ('admin-find-ok', 'admin-test', 'find ' + rp + ' -ok rm {} ;', 'protected system config path'),\n"
   printf "    ('admin-find-fprintf', 'admin-test', 'find ' + rp + ' -fprintf /tmp/leak %%p', 'protected system config path'),\n"
+  # r4: -fls admin gate must DENY (codex PR #1294 r3 BLOCKING repro).
+  printf "    ('admin-find-fls', 'admin-test', 'find ' + rp + ' -fls /tmp/leak', 'protected system config path'),\n"
   # Admin read-only diagnostics → allowed.
   printf "    ('admin-find-name', 'admin-test', 'find ' + rp + ' -name *.sh', None),\n"
   printf "    ('admin-find-type', 'admin-test', 'find ' + rp + ' -type f', None),\n"
@@ -764,6 +780,8 @@ T7_PROBE="$SMOKE_TMP_ROOT/t7-probe.py"
   # read-only still allowed via the general read_intent branch.
   printf "    ('non-admin-find-delete', 'self', 'find ' + rp + ' -delete', 'shared roster secrets'),\n"
   printf "    ('non-admin-find-exec', 'self', 'find ' + rp + ' -exec python3 /tmp/m.py {} ;', 'shared roster secrets'),\n"
+  # r4: -fls non-admin parity.
+  printf "    ('non-admin-find-fls', 'self', 'find ' + rp + ' -fls /tmp/leak', 'shared roster secrets'),\n"
   printf "    ('non-admin-find-name', 'self', 'find ' + rp + ' -name *.sh', None),\n"
   printf ']\n'
   printf 'for label, agent, cmd, expected in gate_cases:\n'
@@ -805,6 +823,10 @@ smoke_assert_contains "$T7_OUT" "OK classifier find-fprint0" \
   "T7: find -fprint0 refused by classifier"
 smoke_assert_contains "$T7_OUT" "OK classifier find-fprintf" \
   "T7: find -fprintf refused by classifier"
+smoke_assert_contains "$T7_OUT" "OK classifier find-fls" \
+  "T7: find -fls refused by classifier (r4 — codex PR #1294 r3 BLOCKING)"
+smoke_assert_contains "$T7_OUT" "OK classifier find-mid-fls" \
+  "T7: find -fls mid-argv refused by classifier (r4)"
 smoke_assert_contains "$T7_OUT" "OK classifier find-mid-delete" \
   "T7: -delete mid-argv refused by classifier"
 smoke_assert_contains "$T7_OUT" "OK classifier find-path-leader" \
@@ -833,6 +855,8 @@ smoke_assert_contains "$T7_OUT" "OK gate admin-find-ok" \
   "T7 gate: admin find <roster> -ok ... → DENIED"
 smoke_assert_contains "$T7_OUT" "OK gate admin-find-fprintf" \
   "T7 gate: admin find <roster> -fprintf ... → DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate admin-find-fls" \
+  "T7 gate: admin find <roster> -fls ... → DENIED (r4 — codex PR #1294 r3 BLOCKING repro)"
 smoke_assert_contains "$T7_OUT" "OK gate admin-find-name" \
   "T7 gate: admin find <roster> -name → allowed (#1255 unblock preserved)"
 smoke_assert_contains "$T7_OUT" "OK gate admin-find-type" \
@@ -843,6 +867,8 @@ smoke_assert_contains "$T7_OUT" "OK gate non-admin-find-delete" \
   "T7 gate: non-admin find -delete → still DENIED"
 smoke_assert_contains "$T7_OUT" "OK gate non-admin-find-exec" \
   "T7 gate: non-admin find -exec → still DENIED"
+smoke_assert_contains "$T7_OUT" "OK gate non-admin-find-fls" \
+  "T7 gate: non-admin find -fls → still DENIED (r4)"
 smoke_assert_contains "$T7_OUT" "OK gate non-admin-find-name" \
   "T7 gate: non-admin find -name → allowed (preserves #383)"
 
@@ -871,27 +897,34 @@ T7T_PROBE="$SMOKE_TMP_ROOT/t7-teeth.py"
   printf 'rp = str(roster_path)\n'
   printf 'admin_delete = "find " + rp + " -delete"\n'
   printf 'admin_exec = "find " + rp + " -exec python3 /tmp/m.py {} ;"\n'
+  printf 'admin_fls = "find " + rp + " -fls /tmp/leak"\n'
   printf 'admin_read = "find " + rp + " -name *.sh"\n'
-  # Real filter denies the mutator/exec.
+  # Real filter denies the mutator/exec/file-action primitives.
   printf 'real_delete = m.protected_alias_reason(admin_delete, "admin-test")\n'
   printf 'real_exec = m.protected_alias_reason(admin_exec, "admin-test")\n'
+  printf 'real_fls = m.protected_alias_reason(admin_fls, "admin-test")\n'
   printf 'real_read = m.protected_alias_reason(admin_read, "admin-test")\n'
-  # Stub _find_is_read_only to always return True — simulates pre-r3.
+  # Stub _find_is_read_only to always return True — simulates pre-r3/r4.
   printf 'orig = m._find_is_read_only\n'
   printf 'm._find_is_read_only = lambda _argv: True\n'
   printf 'stub_delete = m.protected_alias_reason(admin_delete, "admin-test")\n'
   printf 'stub_exec = m.protected_alias_reason(admin_exec, "admin-test")\n'
+  printf 'stub_fls = m.protected_alias_reason(admin_fls, "admin-test")\n'
   printf 'm._find_is_read_only = orig\n'
   printf 'print("real_delete=" + repr(real_delete))\n'
   printf 'print("real_exec=" + repr(real_exec))\n'
+  printf 'print("real_fls=" + repr(real_fls))\n'
   printf 'print("real_read=" + repr(real_read))\n'
   printf 'print("stub_delete=" + repr(stub_delete))\n'
   printf 'print("stub_exec=" + repr(stub_exec))\n'
+  printf 'print("stub_fls=" + repr(stub_fls))\n'
   printf 'ok = (real_delete is not None\n'
   printf '      and real_exec is not None\n'
+  printf '      and real_fls is not None\n'
   printf '      and real_read is None\n'
   printf '      and stub_delete is None\n'
-  printf '      and stub_exec is None)\n'
+  printf '      and stub_exec is None\n'
+  printf '      and stub_fls is None)\n'
   printf 'sys.exit(0 if ok else 1)\n'
 } >"$T7T_PROBE"
 T7T_OUT="$(python3 "$T7T_PROBE" 2>&1)" \
@@ -901,12 +934,16 @@ smoke_assert_contains "$T7T_OUT" "real_delete='" \
   "T7 teeth: real filter denies admin find -delete"
 smoke_assert_contains "$T7T_OUT" "real_exec='" \
   "T7 teeth: real filter denies admin find -exec"
+smoke_assert_contains "$T7T_OUT" "real_fls='" \
+  "T7 teeth: real filter denies admin find -fls (r4 — codex PR #1294 r3 BLOCKING)"
 smoke_assert_contains "$T7T_OUT" "real_read=None" \
   "T7 teeth: real filter still allows admin find -name diagnostic"
 smoke_assert_contains "$T7T_OUT" "stub_delete=None" \
   "T7 teeth: stubbed-True filter wrongly admits admin find -delete (pre-r3 demo)"
 smoke_assert_contains "$T7T_OUT" "stub_exec=None" \
   "T7 teeth: stubbed-True filter wrongly admits admin find -exec (pre-r3 demo)"
+smoke_assert_contains "$T7T_OUT" "stub_fls=None" \
+  "T7 teeth: stubbed-True filter wrongly admits admin find -fls (pre-r4 demo)"
 
 smoke_log "K-beta4-nits: all 7 tests + teeth passed"
 exit 0


### PR DESCRIPTION
## Summary

v0.15.0-beta4 Sub-wave 3 Lane K — 5 small surgical fixes across separate surfaces:

- **#1282 Surface A** — `bridge-run.sh::bridge_run_prune_legacy_teams_mcp` filters `absent path=…` / `unchanged path=…` audit noise; only real actions (pruned/failed/skipped) reach the log.
- **#1282 Surface B** — `bridge-dev-plugin-cache.py` distinguishes `node_modules=missing` (real install gap) from `node_modules=not-required` (`.mjs` proxy plugins like `cosmax-ep-approval` that ship without package.json + lockfile). New `_plugin_source_declares_deps` helper mirrors the heuristic already in `lib/upgrade-helpers/plugins-seed-parse-sync-output.py`.
- **#1283** — `agent-bridge diagnose acl` subcommand retired. ACL-based cross-UID grants are no longer the recommended isolation mechanism. The verb now exits non-zero with a deprecation notice pointing at `agent-bridge isolation reconcile --apply --agent <agent>`. ~140 lines of ACL scanner removed.
- **#1247** — `agb admin set --auto-restart on|off` CLI surface added. Persists `auto_restart_on_membership_change` into `state/admin-config.json` via the new file-as-argv helper `scripts/python-helpers/admin-set-config.py` (footgun #11 — no heredoc-stdin). Phase 1; future PRs wire the flag into the post-`agent create --isolate` admin-set restart automation.
- **#1253** — `agb claim --note <text>` / `--note-file <path>` accepted and propagated into the `task_events` row (`event_type=claimed`, `note_text=<text>` / `note_path=<p>`). Symmetric with `agb done` / `agb update`. Claim stdout echoes a short `claim_note=<n>c` summary.
- **#1255** — roster read-block softened **for ADMIN shells only**. New `_bash_command_has_no_write_intent` classifier (write-intent blacklist — `tee`/`sed -i`/`awk -i inplace`/`rm`/`mv`/output redirection/numeric-fd writes) gates the roster *read* path so an admin-issued custom non-whitelist read command no longer mis-rejects. Non-admin class keeps the original "shared roster secrets" deny — those agents must not dump roster contents into commit messages / audit logs.

## Test plan

- [x] `bash -n` clean on all touched .sh + Python `py_compile` clean
- [x] `shellcheck` clean on all touched scripts
- [x] `scripts/smoke/K-beta4-nits.sh` — 6 tests + 3 teeth, all pass
  - T1 #1282 A — prune_legacy_teams_mcp filter drops absent/unchanged
  - T1 teeth — without filter, noise reappears
  - T2 #1282 B — `_plugin_source_declares_deps` (no-deps/deps/lockfile)
  - T3 #1283 — diagnose acl deprecation notice + non-zero exit + scanner helpers removed
  - T4 #1247 — admin-set-config.py persists flag, flips it, rejects invalid `--value`
  - T5 #1253 — claim --note propagates into task_events row
  - T5 teeth — claim without --note → note_text NULL
  - T6 #1255 — softening allows admin custom-tool reads; non-admin still denied (`git commit -F <roster>`); write paths still denied
  - T6 teeth — strict whitelist refuses what soft classifier accepts
- [x] `scripts/smoke-test.sh` `diagnose acl` smoke updated to assert new deprecation contract
- [x] Beta3+beta4 sweep: A/A3/A12/B/B-beta4/C/C1/D/E/F/H/K all pass on macOS. G-beta4-watchdog-noise T3 failure pre-exists on the base branch (unrelated mode normalization issue).
- [x] ci-select-smoke.sh registration: K-beta4-nits routes for bridge-run.sh, bridge-task.sh, bridge-queue.py, hooks/tool-policy.py, bridge-dev-plugin-cache.py, bridge-diagnose.sh, agent-bridge, and admin-set-config.py

## Refs

(#1282 #1283 #1247 #1253 #1255 — beta4 Lane K Sub-wave 3)