### PR TITLE
fix(start): shared-mode agents fall through to HOME for Claude session detect (#1370)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -3567,6 +3567,18 @@ bridge_resolve_agent_claude_config_dir() {
   if command -v bridge_agent_exists >/dev/null 2>&1; then
     bridge_agent_exists "$agent" || return 0
   fi
+  # Issue #1370 (beta5-2 #1316 regression): only agents whose linux-user
+  # isolation is *effective* (iso v2 active on a Linux host with an os_user)
+  # own a private Claude config dir. Shared-mode agents — including the admin,
+  # and every agent on non-Linux hosts where iso is never effective — write
+  # their session JSON / transcripts under the controller HOME (~/.claude).
+  # Returning a derived agent-home path for those makes session-id detection
+  # look in an empty scaffolded `<agent-home>/.claude` and block --continue
+  # resume. Fall through (empty) so the detect helper uses its daemon-HOME
+  # fallback. See bridge_detect_claude_session_id / Issue #1015.
+  if command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1; then
+    bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null || return 0
+  fi
   config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
   # A derived-but-absent path means the agent is not actually isolated on
   # this host; do not let it shadow the caller's HOME.


### PR DESCRIPTION
## Summary

Fixes #1370 — beta5-2 #1316 regression. On hosts where linux-user isolation is **not effective** (every macOS host, and all shared-mode agents including the admin), `bridge_resolve_agent_claude_config_dir` returned the derived `<agent-home>/.claude` path. Claude actually writes sessions/transcripts under the controller HOME (`~/.claude`), so session-id detection looked in an empty scaffolded dir, returned empty after 12 attempts, and `bridge-start.sh` aborted under `set -euo pipefail` **before creating the tmux session** — a silent `exit 1`.

Impact:
- `--continue` resume broken for shared-mode dynamic agents (e.g. `agb attach` fails: "tmux 세션이 없습니다").
- Daemon always-on auto-start of the admin fails (`reason=start-command-failed`); the admin only survives via external session restore (cmux), and would not auto-recover on crash.

## Fix

Guard the resolver: when `bridge_agent_linux_user_isolation_effective` is false, fall through (empty) so `bridge_detect_claude_session_id` uses its daemon-HOME fallback (`~/.claude`) where the sessions actually live. 12-line change, isolation-mode gated; iso-v2 agents on Linux are unaffected.

## Verification (macOS, shared-mode agent `crm-test-ajh`)

- Reproduced the live failure via `bash -x bridge-start.sh crm-test-ajh --no-attach`: ends at `session_id_detect_empty … attempts=12` → `return 1` → `set -e` abort; no `tmux new-session`.
- Verified primitives: `bridge_agent_linux_user_isolation_effective` = NO; raw `bridge_agent_claude_config_dir` = `<agent-home>/.claude` (exists but empty of sessions); real session lives at `~/.claude/projects/-Users-anjh-crm-test/`.
- Resolver behavior (controlled stubs, faithful to real values):
  - baseline → `<agent-home>/.claude` (bug: detect looks in empty dir → abort)
  - fixed → empty (HOME fallback → detect finds session → no abort)
- `bash -n` over all shell entry points: clean.
- `scripts/smoke-test.sh`: only `SCRIPTDIR_STARTUP_OK` fails — **reproduces on baseline** (pre-existing/environmental, unrelated to this change).
- `shellcheck`: not installed on the author's host; **reviewer should run shellcheck in their worktree**.
- End-to-end: the affected agent was recovered with the interim workaround `agent-bridge agent start crm-test-ajh --no-continue` (fresh session; prior transcript preserved under `~/.claude`).

## Notes for reviewer / operator

- This carries an uncommitted working-tree fix that already existed in the operator's checkout (attributed to #1370); it was branched + committed verbatim, then verified.
- Merge, version bump, and `agb upgrade` deploy are **operator-gated** — not done here. Live runtime still lacks this fix until deployed.
