### PR TITLE
Recover admin autostart on resume-state failure

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -4236,9 +4236,15 @@ bridge_daemon_start_agent_with_recovery() {
   local agent="$1"
   local trigger="$2"
   local session=""
+  local admin_agent=""
 
   BRIDGE_DAEMON_START_FAILURE_REASON=""
 
+  # Base single-attempt start. For every agent this is byte-equivalent to the
+  # pre-recovery daemon path: one bridge-start.sh invocation, then check the
+  # session came up. The failure reason recorded here (`session-exited-quickly`
+  # vs `start-command-failed`) is exactly the base reason, so non-admin callers
+  # preserve base note/warn semantics downstream.
   if "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" >/dev/null 2>&1; then
     session="$(bridge_agent_session "$agent")"
     sleep 1
@@ -4250,8 +4256,16 @@ bridge_daemon_start_agent_with_recovery() {
     BRIDGE_DAEMON_START_FAILURE_REASON="start-command-failed"
   fi
 
-  if bridge_daemon_admin_autostart_recover "$agent" "$trigger" "$BRIDGE_DAEMON_START_FAILURE_REASON"; then
-    return 0
+  # Admin-only recovery ladder. Gate the ENTIRE retry ladder (resume-state
+  # repair + --no-continue / --safe-mode retries) at the wrapper so a non-admin
+  # agent never enters it: no extra bridge-start.sh attempts, no resume repair,
+  # no recovery audit events. A non-admin agent falls straight through with the
+  # base failure reason intact, matching the pre-recovery daemon byte-for-byte.
+  admin_agent="$(bridge_admin_agent_id 2>/dev/null || true)"
+  if [[ -n "$admin_agent" && "$agent" == "$admin_agent" ]]; then
+    if bridge_daemon_admin_autostart_recover "$agent" "$trigger" "$BRIDGE_DAEMON_START_FAILURE_REASON"; then
+      return 0
+    fi
   fi
 
   return 1
@@ -8609,8 +8623,15 @@ process_on_demand_agents() {
           daemon_info "ensured always-on ${agent}"
           changed=0
         else
-          bridge_daemon_note_autostart_failure "$agent" "${BRIDGE_DAEMON_START_FAILURE_REASON:-start-command-failed}"
-          bridge_warn "always-on auto-start failed: ${agent}"
+          local _aos_reason="${BRIDGE_DAEMON_START_FAILURE_REASON:-start-command-failed}"
+          bridge_daemon_note_autostart_failure "$agent" "$_aos_reason"
+          # Base warning parity: a transient session-exited-quickly is
+          # note-only (no warn); start-command-failed and admin-recovery-failed
+          # are operator-actionable and warn.
+          if [[ "$_aos_reason" != "session-exited-quickly" ]]; then
+            bridge_warn "always-on auto-start failed: ${agent}"
+          fi
+          unset _aos_reason
         fi
       elif [[ "$queued" =~ ^[0-9]+$ ]] && (( queued > 0 )) && ! bridge_agent_is_active "$agent"; then
         # Issue #1234 (Lane δ): same hold gate as the always-on branch.
@@ -8662,8 +8683,15 @@ process_on_demand_agents() {
           daemon_info "auto-started ${agent} (queued=${queued}, timeout=${timeout}s)"
           changed=0
         else
-          bridge_daemon_note_autostart_failure "$agent" "${BRIDGE_DAEMON_START_FAILURE_REASON:-start-command-failed}"
-          bridge_warn "on-demand auto-start failed: ${agent}"
+          local _od_reason="${BRIDGE_DAEMON_START_FAILURE_REASON:-start-command-failed}"
+          bridge_daemon_note_autostart_failure "$agent" "$_od_reason"
+          # Base warning parity: a transient session-exited-quickly is
+          # note-only (no warn); start-command-failed and admin-recovery-failed
+          # are operator-actionable and warn.
+          if [[ "$_od_reason" != "session-exited-quickly" ]]; then
+            bridge_warn "on-demand auto-start failed: ${agent}"
+          fi
+          unset _od_reason
         fi
       fi
       continue

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -4162,6 +4162,101 @@ bridge_daemon_clear_autostart_failure() {
   rm -f "$(bridge_daemon_autostart_state_file "$agent")"
 }
 
+BRIDGE_DAEMON_START_FAILURE_REASON=""
+
+bridge_daemon_admin_autostart_recover() {
+  local agent="$1"
+  local trigger="$2"
+  local initial_reason="$3"
+  local admin_agent=""
+  local continue_mode=""
+  local session_id=""
+  local session=""
+  local mode=""
+  local reason=""
+  local -a start_args=()
+
+  admin_agent="$(bridge_admin_agent_id 2>/dev/null || true)"
+  [[ -n "$admin_agent" && "$agent" == "$admin_agent" ]] || return 1
+
+  session="$(bridge_agent_session "$agent" 2>/dev/null || true)"
+  [[ -n "$session" ]] || return 1
+
+  continue_mode="$(bridge_agent_continue "$agent" 2>/dev/null || printf '%s' "1")"
+  session_id="$(bridge_agent_session_id "$agent" 2>/dev/null || true)"
+
+  if [[ "$continue_mode" == "1" && -z "$session_id" ]]; then
+    bridge_clear_persisted_session_id "$agent" >/dev/null 2>&1 || true
+    bridge_audit_log daemon admin_resume_state_repaired "$agent" \
+      --detail trigger="$trigger" \
+      --detail initial_reason="$initial_reason" \
+      --detail repair=forget_empty_or_invalid_session_id 2>/dev/null || true
+  fi
+
+  daemon_info "admin auto-start recovery for ${agent} after ${initial_reason} (trigger=${trigger})"
+
+  for mode in no_continue safe_mode; do
+    start_args=("$agent" "--no-continue")
+    if [[ "$mode" == "safe_mode" ]]; then
+      start_args=("$agent" "--safe-mode" "--no-continue")
+    fi
+
+    bridge_audit_log daemon admin_autostart_recovery_attempt "$agent" \
+      --detail trigger="$trigger" \
+      --detail mode="$mode" \
+      --detail initial_reason="$initial_reason" 2>/dev/null || true
+
+    if "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "${start_args[@]}" >/dev/null 2>&1; then
+      sleep 1
+      if bridge_tmux_session_exists "$session"; then
+        bridge_audit_log daemon admin_autostart_recovery_success "$agent" \
+          --detail trigger="$trigger" \
+          --detail mode="$mode" \
+          --detail initial_reason="$initial_reason" 2>/dev/null || true
+        daemon_info "admin auto-start recovery succeeded for ${agent} (mode=${mode})"
+        return 0
+      fi
+      reason="session-exited-quickly"
+    else
+      reason="start-command-failed"
+    fi
+
+    bridge_audit_log daemon admin_autostart_recovery_failed "$agent" \
+      --detail trigger="$trigger" \
+      --detail mode="$mode" \
+      --detail reason="$reason" \
+      --detail initial_reason="$initial_reason" 2>/dev/null || true
+  done
+
+  BRIDGE_DAEMON_START_FAILURE_REASON="admin-recovery-failed:${reason:-unknown}"
+  return 1
+}
+
+bridge_daemon_start_agent_with_recovery() {
+  local agent="$1"
+  local trigger="$2"
+  local session=""
+
+  BRIDGE_DAEMON_START_FAILURE_REASON=""
+
+  if "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" >/dev/null 2>&1; then
+    session="$(bridge_agent_session "$agent")"
+    sleep 1
+    if [[ -n "$session" ]] && bridge_tmux_session_exists "$session"; then
+      return 0
+    fi
+    BRIDGE_DAEMON_START_FAILURE_REASON="session-exited-quickly"
+  else
+    BRIDGE_DAEMON_START_FAILURE_REASON="start-command-failed"
+  fi
+
+  if bridge_daemon_admin_autostart_recover "$agent" "$trigger" "$BRIDGE_DAEMON_START_FAILURE_REASON"; then
+    return 0
+  fi
+
+  return 1
+}
+
 # Issue #1320 (beta5-2 Lane ι) — H2 always-on launch-failure escalation.
 #
 # Files a high-priority admin task once the always-on launch fail counter
@@ -8508,18 +8603,13 @@ process_on_demand_agents() {
             continue
           fi
         fi
-        if "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" >/dev/null 2>&1; then
+        if bridge_daemon_start_agent_with_recovery "$agent" "always_on"; then
           session="$(bridge_agent_session "$agent")"
-          sleep 1
-          if [[ -n "$session" ]] && bridge_tmux_session_exists "$session"; then
-            bridge_daemon_clear_autostart_failure "$agent"
-            daemon_info "ensured always-on ${agent}"
-            changed=0
-          else
-            bridge_daemon_note_autostart_failure "$agent" "session-exited-quickly"
-          fi
+          bridge_daemon_clear_autostart_failure "$agent"
+          daemon_info "ensured always-on ${agent}"
+          changed=0
         else
-          bridge_daemon_note_autostart_failure "$agent" "start-command-failed"
+          bridge_daemon_note_autostart_failure "$agent" "${BRIDGE_DAEMON_START_FAILURE_REASON:-start-command-failed}"
           bridge_warn "always-on auto-start failed: ${agent}"
         fi
       elif [[ "$queued" =~ ^[0-9]+$ ]] && (( queued > 0 )) && ! bridge_agent_is_active "$agent"; then
@@ -8563,21 +8653,16 @@ process_on_demand_agents() {
             continue
           fi
         fi
-        if "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-start.sh" "$agent" >/dev/null 2>&1; then
+        if bridge_daemon_start_agent_with_recovery "$agent" "on_demand"; then
           session="$(bridge_agent_session "$agent")"
           timeout="$(bridge_agent_idle_timeout "$agent")"
           [[ "$timeout" =~ ^[0-9]+$ ]] || timeout=0
-          sleep 1
-          if [[ -n "$session" ]] && bridge_tmux_session_exists "$session"; then
-            bridge_daemon_clear_autostart_failure "$agent"
-            nudge_agent_session "$agent" "$session" "$queued" "$claimed" "0" || true
-            daemon_info "auto-started ${agent} (queued=${queued}, timeout=${timeout}s)"
-            changed=0
-          else
-            bridge_daemon_note_autostart_failure "$agent" "session-exited-quickly"
-          fi
+          bridge_daemon_clear_autostart_failure "$agent"
+          nudge_agent_session "$agent" "$session" "$queued" "$claimed" "0" || true
+          daemon_info "auto-started ${agent} (queued=${queued}, timeout=${timeout}s)"
+          changed=0
         else
-          bridge_daemon_note_autostart_failure "$agent" "start-command-failed"
+          bridge_daemon_note_autostart_failure "$agent" "${BRIDGE_DAEMON_START_FAILURE_REASON:-start-command-failed}"
           bridge_warn "on-demand auto-start failed: ${agent}"
         fi
       fi

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -803,7 +803,17 @@ select_for_path() {
       # future refactor cannot silently re-introduce the codex r1
       # BLOCKING repro (claimed task + picker_blocked agent + aged
       # session_activity_ts → wrongly requeued tasks).
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift 1178-helper-contract-daemon-supp F-daemon-supp-groups-mock F-daemon-supp-groups-real δ-1234-daemon-start-policy A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir D-beta4-daemon-lifecycle A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs Beta-beta5-session-id-detect-sudo beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-kappa-state-audit-reconcile 1359-cron-create-iso-staging
+      # v0.15.0-beta5-5 Track Q (#1370): bridge-daemon.sh now hosts the
+      # admin-only autostart recovery wrapper
+      # (bridge_daemon_start_agent_with_recovery /
+      # bridge_daemon_admin_autostart_recover). The 1380 smoke pins the
+      # admin gate at the wrapper (non-admin agents never enter the
+      # --no-continue/--safe-mode retry ladder, T6) and the base warning
+      # parity (note-only on session-exited-quickly, T7). Pull
+      # 1380-admin-autostart-recovery on every bridge-daemon.sh move so a
+      # future PR cannot silently re-leak non-admin agents into the
+      # recovery ladder or regress the non-admin byte-equivalence.
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift 1178-helper-contract-daemon-supp F-daemon-supp-groups-mock F-daemon-supp-groups-real δ-1234-daemon-start-policy A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir D-beta4-daemon-lifecycle A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs Beta-beta5-session-id-detect-sudo beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-kappa-state-audit-reconcile 1359-cron-create-iso-staging 1380-admin-autostart-recovery
       # v0.15.0-beta5-2 Lane η (#1314, CRITICAL/security):
       # bridge-daemon.sh's `cmd_run_cron_worker` now gates shell-cron
       # dispatch on `bridge_cron_uid_drop_preflight`. The new gate emits

--- a/scripts/smoke/1380-admin-autostart-recovery.sh
+++ b/scripts/smoke/1380-admin-autostart-recovery.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1380-admin-autostart-recovery.sh — admin liveness guard.
+#
+# Regression: after v0.15.0-beta5-4, the admin agent could remain down when
+# daemon auto-start hit the resume gate with continue=1 and an empty/invalid
+# session id. The daemon only recorded start-command-failed backoff, leaving
+# the operator without the admin surface needed to repair the install.
+#
+# This smoke is static by design: it pins the daemon recovery contract without
+# killing live tmux sessions. The live acceptance case is the daemon's normal
+# always-on/on-demand path.
+
+set -euo pipefail
+
+SMOKE_NAME="1380-admin-autostart-recovery"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+DAEMON_SH="$SMOKE_REPO_ROOT/bridge-daemon.sh"
+TMP_ROOT=""
+
+cleanup() {
+  [[ -z "$TMP_ROOT" ]] || rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+smoke_log "T1: bridge-daemon.sh is syntactically valid"
+bash -n "$DAEMON_SH" || smoke_fail "bridge-daemon.sh failed bash -n"
+
+smoke_log "T2: daemon has an admin-only recovery helper"
+grep -q '^bridge_daemon_admin_autostart_recover()' "$DAEMON_SH" || \
+  smoke_fail "missing bridge_daemon_admin_autostart_recover helper"
+grep -q 'bridge_admin_agent_id' "$DAEMON_SH" || \
+  smoke_fail "admin recovery helper is not gated on bridge_admin_agent_id"
+grep -q 'admin_resume_state_repaired' "$DAEMON_SH" || \
+  smoke_fail "admin recovery does not audit resume-state repair"
+grep -q 'bridge_clear_persisted_session_id "$agent"' "$DAEMON_SH" || \
+  smoke_fail "admin recovery does not clear invalid persisted session id"
+
+smoke_log "T3: recovery tries fresh launch before safe mode"
+grep -q 'start_args=("$agent" "--no-continue")' "$DAEMON_SH" || \
+  smoke_fail "admin recovery does not attempt --no-continue"
+grep -q 'start_args=("$agent" "--safe-mode" "--no-continue")' "$DAEMON_SH" || \
+  smoke_fail "admin recovery does not attempt --safe-mode --no-continue"
+grep -q 'admin_autostart_recovery_success' "$DAEMON_SH" || \
+  smoke_fail "admin recovery success is not audited"
+
+smoke_log "T4: always-on and on-demand starts use recovery wrapper"
+if [[ "$(grep -c 'bridge_daemon_start_agent_with_recovery "$agent"' "$DAEMON_SH")" -lt 2 ]]; then
+  smoke_fail "daemon start paths do not both use bridge_daemon_start_agent_with_recovery"
+fi
+grep -q 'bridge_daemon_start_agent_with_recovery "$agent" "always_on"' "$DAEMON_SH" || \
+  smoke_fail "always-on start path bypasses admin recovery wrapper"
+grep -q 'bridge_daemon_start_agent_with_recovery "$agent" "on_demand"' "$DAEMON_SH" || \
+  smoke_fail "on-demand start path bypasses admin recovery wrapper"
+
+smoke_log "T5: isolated dynamic check recovers admin with --no-continue"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agent-bridge-1380.XXXXXX")"
+PARTIAL_DAEMON="$TMP_ROOT/daemon-defs.sh"
+sed '/^while \[\[ \$# -gt 0 \]\]; do/,$d' "$DAEMON_SH" \
+  | sed "s|^SCRIPT_DIR=.*|SCRIPT_DIR=\"$SMOKE_REPO_ROOT\"|" \
+  >"$PARTIAL_DAEMON"
+cat >"$TMP_ROOT/bridge-start.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$START_LOG"
+case " $* " in
+  *" --no-continue "*) exit 0 ;;
+  *) exit 1 ;;
+esac
+STUB
+chmod +x "$TMP_ROOT/bridge-start.sh"
+
+# shellcheck disable=SC2030
+(
+  set -euo pipefail
+  export BRIDGE_HOME="$TMP_ROOT/home"
+  export START_LOG="$TMP_ROOT/start.log"
+  mkdir -p "$BRIDGE_HOME"
+  # shellcheck source=/dev/null
+  source "$PARTIAL_DAEMON"
+  SCRIPT_DIR="$TMP_ROOT"
+  BRIDGE_BASH_BIN="$(command -v bash)"
+  bridge_admin_agent_id() { printf '%s' "patch"; }
+  bridge_agent_session() { printf '%s' "$1"; }
+  bridge_agent_continue() { printf '%s' "1"; }
+  bridge_agent_session_id() { printf '%s' ""; }
+  bridge_clear_persisted_session_id() { printf '%s\n' "clear:$1" >>"$TMP_ROOT/events.log"; }
+  bridge_audit_log() { printf '%s\n' "audit:$*" >>"$TMP_ROOT/events.log"; }
+  daemon_info() { printf '%s\n' "info:$*" >>"$TMP_ROOT/events.log"; }
+  bridge_tmux_session_exists() { return 0; }
+
+  bridge_daemon_start_agent_with_recovery patch always_on
+  grep -q '^patch$' "$START_LOG"
+  grep -q '^patch --no-continue$' "$START_LOG"
+  grep -q '^clear:patch$' "$TMP_ROOT/events.log"
+  grep -q 'admin_autostart_recovery_success' "$TMP_ROOT/events.log"
+)
+
+smoke_log "T6: isolated dynamic check does not recover non-admin agents"
+rm -f "$TMP_ROOT/start.log" "$TMP_ROOT/events.log"
+# shellcheck disable=SC2031
+(
+  set -euo pipefail
+  export BRIDGE_HOME="$TMP_ROOT/home2"
+  export START_LOG="$TMP_ROOT/start.log"
+  mkdir -p "$BRIDGE_HOME"
+  # shellcheck source=/dev/null
+  source "$PARTIAL_DAEMON"
+  SCRIPT_DIR="$TMP_ROOT"
+  BRIDGE_BASH_BIN="$(command -v bash)"
+  bridge_admin_agent_id() { printf '%s' "patch"; }
+  bridge_agent_session() { printf '%s' "$1"; }
+  bridge_agent_continue() { printf '%s' "1"; }
+  bridge_agent_session_id() { printf '%s' ""; }
+  bridge_clear_persisted_session_id() { printf '%s\n' "clear:$1" >>"$TMP_ROOT/events.log"; }
+  bridge_audit_log() { printf '%s\n' "audit:$*" >>"$TMP_ROOT/events.log"; }
+  daemon_info() { printf '%s\n' "info:$*" >>"$TMP_ROOT/events.log"; }
+  bridge_tmux_session_exists() { return 0; }
+
+  if bridge_daemon_start_agent_with_recovery worker always_on; then
+    smoke_fail "non-admin worker unexpectedly recovered"
+  fi
+  [[ "$(wc -l <"$START_LOG")" == "1" ]] || smoke_fail "non-admin recovery invoked extra start attempts"
+  [[ ! -f "$TMP_ROOT/events.log" ]] || smoke_fail "non-admin recovery emitted admin repair events"
+)
+
+smoke_log "ok: $SMOKE_NAME"

--- a/scripts/smoke/1380-admin-autostart-recovery.sh
+++ b/scripts/smoke/1380-admin-autostart-recovery.sh
@@ -122,7 +122,9 @@ rm -f "$TMP_ROOT/start.log" "$TMP_ROOT/events.log"
   if bridge_daemon_start_agent_with_recovery worker always_on; then
     smoke_fail "non-admin worker unexpectedly recovered"
   fi
-  [[ "$(wc -l <"$START_LOG")" == "1" ]] || smoke_fail "non-admin recovery invoked extra start attempts"
+  # Normalize the line count with arithmetic ($(( ... ))) so BSD/macOS `wc -l`
+  # leading-space padding (e.g. "       1") does not false-fail the comparison.
+  [[ "$(( $(wc -l <"$START_LOG") ))" -eq 1 ]] || smoke_fail "non-admin recovery invoked extra start attempts"
   [[ ! -f "$TMP_ROOT/events.log" ]] || smoke_fail "non-admin recovery emitted admin repair events"
   # Base warning parity: a non-admin start-command failure must surface the
   # exact base reason (`start-command-failed`) so the daemon call site warns
@@ -162,7 +164,9 @@ chmod +x "$TMP_ROOT/bridge-start.sh"
   if bridge_daemon_start_agent_with_recovery worker on_demand; then
     smoke_fail "non-admin worker unexpectedly recovered on session-exited-quickly"
   fi
-  [[ "$(wc -l <"$START_LOG")" == "1" ]] || smoke_fail "non-admin session-exited-quickly invoked extra start attempts"
+  # Normalize the line count with arithmetic ($(( ... ))) so BSD/macOS `wc -l`
+  # leading-space padding (e.g. "       1") does not false-fail the comparison.
+  [[ "$(( $(wc -l <"$START_LOG") ))" -eq 1 ]] || smoke_fail "non-admin session-exited-quickly invoked extra start attempts"
   [[ ! -f "$TMP_ROOT/events.log" ]] || smoke_fail "non-admin session-exited-quickly emitted admin repair events"
   # Base parity: reason is the transient note-only reason, so the call site
   # records the note WITHOUT a warning (matching the pre-recovery daemon).

--- a/scripts/smoke/1380-admin-autostart-recovery.sh
+++ b/scripts/smoke/1380-admin-autostart-recovery.sh
@@ -124,6 +124,50 @@ rm -f "$TMP_ROOT/start.log" "$TMP_ROOT/events.log"
   fi
   [[ "$(wc -l <"$START_LOG")" == "1" ]] || smoke_fail "non-admin recovery invoked extra start attempts"
   [[ ! -f "$TMP_ROOT/events.log" ]] || smoke_fail "non-admin recovery emitted admin repair events"
+  # Base warning parity: a non-admin start-command failure must surface the
+  # exact base reason (`start-command-failed`) so the daemon call site warns
+  # byte-equivalently to the pre-recovery path.
+  [[ "$BRIDGE_DAEMON_START_FAILURE_REASON" == "start-command-failed" ]] || \
+    smoke_fail "non-admin start failure reason drifted from base (got: $BRIDGE_DAEMON_START_FAILURE_REASON)"
+)
+
+smoke_log "T7: non-admin session-exited-quickly stays note-only (no recovery, base reason)"
+rm -f "$TMP_ROOT/start.log" "$TMP_ROOT/events.log"
+cat >"$TMP_ROOT/bridge-start.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$START_LOG"
+exit 0
+STUB
+chmod +x "$TMP_ROOT/bridge-start.sh"
+# shellcheck disable=SC2031
+(
+  set -euo pipefail
+  export BRIDGE_HOME="$TMP_ROOT/home3"
+  export START_LOG="$TMP_ROOT/start.log"
+  mkdir -p "$BRIDGE_HOME"
+  # shellcheck source=/dev/null
+  source "$PARTIAL_DAEMON"
+  SCRIPT_DIR="$TMP_ROOT"
+  BRIDGE_BASH_BIN="$(command -v bash)"
+  bridge_admin_agent_id() { printf '%s' "patch"; }
+  bridge_agent_session() { printf '%s' "$1"; }
+  bridge_agent_continue() { printf '%s' "1"; }
+  bridge_agent_session_id() { printf '%s' ""; }
+  bridge_clear_persisted_session_id() { printf '%s\n' "clear:$1" >>"$TMP_ROOT/events.log"; }
+  bridge_audit_log() { printf '%s\n' "audit:$*" >>"$TMP_ROOT/events.log"; }
+  daemon_info() { printf '%s\n' "info:$*" >>"$TMP_ROOT/events.log"; }
+  # Start command succeeds but the session never comes up.
+  bridge_tmux_session_exists() { return 1; }
+
+  if bridge_daemon_start_agent_with_recovery worker on_demand; then
+    smoke_fail "non-admin worker unexpectedly recovered on session-exited-quickly"
+  fi
+  [[ "$(wc -l <"$START_LOG")" == "1" ]] || smoke_fail "non-admin session-exited-quickly invoked extra start attempts"
+  [[ ! -f "$TMP_ROOT/events.log" ]] || smoke_fail "non-admin session-exited-quickly emitted admin repair events"
+  # Base parity: reason is the transient note-only reason, so the call site
+  # records the note WITHOUT a warning (matching the pre-recovery daemon).
+  [[ "$BRIDGE_DAEMON_START_FAILURE_REASON" == "session-exited-quickly" ]] || \
+    smoke_fail "non-admin session-exited-quickly reason drifted from base (got: $BRIDGE_DAEMON_START_FAILURE_REASON)"
 )
 
 smoke_log "ok: $SMOKE_NAME"


### PR DESCRIPTION
## Summary
- add admin-only daemon recovery when normal auto-start fails before the admin agent comes up
- retry the admin with `--no-continue`, then `--safe-mode --no-continue`, so a missing/invalid resume id does not strand the operator without `patch`
- audit repair/recovery attempts and route both always-on and queued on-demand daemon wakes through the recovery wrapper
- add smoke coverage that verifies the recovery contract without killing the live admin tmux session

## Testing
- `bash -n bridge-daemon.sh scripts/smoke/1380-admin-autostart-recovery.sh`
- `shellcheck bridge-daemon.sh scripts/smoke/1380-admin-autostart-recovery.sh`
- `scripts/smoke/1380-admin-autostart-recovery.sh`

## Notes
- The live `patch` session was not intentionally killed for end-to-end validation; the smoke stubs `bridge-start.sh` and exercises the daemon recovery helper in isolation.
