### PR TITLE
fix(ci): stable-prep portability sweep — 1379-C1 heredoc extract + beta5-2-mu stat -f/-c + #1387 cleanup-trap (all smokes Linux-green)

### DIFF
--- a/bridge-cron.sh
+++ b/bridge-cron.sh
@@ -509,10 +509,13 @@ _bridge_cron_create_via_staging() {
   local actor_uid
   actor_uid="$(id -u 2>/dev/null || printf '0')"
   # shellcheck disable=SC2155
-  local _payload_json_tmp
+  # #1387: initialize to "" so the cleanup trap is robust under `set -u`
+  # regardless of which path set it (the trap also guards with `:-` in
+  # case it fires before the mktemp assignment completes).
+  local _payload_json_tmp=""
+  trap 'rm -f "${_payload_json_tmp:-}"' RETURN
   _payload_json_tmp="$(mktemp -t agb-cron-staging-payload.XXXXXX)" || \
     bridge_die "cannot mktemp cron-staging payload buffer"
-  trap 'rm -f "$_payload_json_tmp"' RETURN
 
   AGB_STAGE_AGENT="$agent" \
   AGB_STAGE_SCHEDULE="$schedule" \

--- a/scripts/smoke/1379-iso-cron-staging-group.sh
+++ b/scripts/smoke/1379-iso-cron-staging-group.sh
@@ -247,13 +247,15 @@ else
   T1S_AGENT="iso-shared-gate"
   T1S_DIR="$STAGING_ROOT/$T1S_AGENT"
   mkdir -p "$T1S_DIR"
-  T1S_OUT="$(
-    AGB_T1S_DIR="$T1S_DIR" AGB_T1S_AGENT="$T1S_AGENT" \
-    AGB_T1S_SHARED="${SHARED_GROUP_NAME}" AGB_T1S_MEMBER="$MEMBER_GROUP_NAME" \
-    AGB_T1S_MEMBER_GID="$MEMBER_GID" \
-    "$PY_BIN" - <<PY
+  # footgun #11: the python body is written to a FILE (cat > file <<'PY',
+  # a SAFE write-to-file heredoc) and run file-as-argv ("$PY_BIN" "$_pyf")
+  # instead of feeding the interpreter's stdin from a heredoc inside the
+  # T1S_OUT="$( ... )" capture (which would be a C1 deadlock site). The
+  # quoted <<'PY' means $REPO_ROOT is passed through AGB_REPO_ROOT env.
+  T1S_PYF="$(mktemp "${TMPDIR:-/tmp}/1379-t1s-XXXXXX.py")"
+  cat >"$T1S_PYF" <<'PY'
 import os, sys
-sys.path.insert(0, os.path.join("$REPO_ROOT", "lib", "cron-helpers"))
+sys.path.insert(0, os.path.join(os.environ["AGB_REPO_ROOT"], "lib", "cron-helpers"))  # noqa: iso-helper-boundary (os.environ read, not a .env file callsite)
 import staging
 from pathlib import Path
 
@@ -288,7 +290,14 @@ os.environ["AGB_STAGE_FILE_GROUP"] = member
 canon = staging._resolve_staging_gid(member, d)  # agent == member group name
 print("canonical=" + ("None" if canon is None else str(canon)))
 PY
+  T1S_OUT="$(
+    AGB_REPO_ROOT="$REPO_ROOT" \
+    AGB_T1S_DIR="$T1S_DIR" AGB_T1S_AGENT="$T1S_AGENT" \
+    AGB_T1S_SHARED="${SHARED_GROUP_NAME}" AGB_T1S_MEMBER="$MEMBER_GROUP_NAME" \
+    AGB_T1S_MEMBER_GID="$MEMBER_GID" \
+    "$PY_BIN" "$T1S_PYF"
   )"
+  rm -f "$T1S_PYF"
   T1S_FORGE_SHARED="$(printf '%s\n' "$T1S_OUT" | sed -n 's/^forge_shared=//p')"
   T1S_FORGE_MEMBER="$(printf '%s\n' "$T1S_OUT" | sed -n 's/^forge_member=//p')"
   T1S_CANON="$(printf '%s\n' "$T1S_OUT" | sed -n 's/^canonical=//p')"
@@ -310,14 +319,15 @@ PY
   smoke_log "T1f (fail-loud): chgrp cannot be applied/verified → no publish, no uuid, non-zero rc"
   T1F_AGENT="$MEMBER_GROUP_NAME"   # canonical group resolvable (prefix="")
   T1F_DIR="$STAGING_ROOT/$T1F_AGENT"
-  T1F_OUT="$(
-    AGB_T1F_ROOT="$STAGING_ROOT" AGB_T1F_AGENT="$T1F_AGENT" \
-    AGB_T1F_MEMBER="$MEMBER_GROUP_NAME" AGB_T1F_UID="$CURRENT_UID" \
-    AGB_T1F_PRIMARY_GID="$EFFECTIVE_GID" \
-    AGB_STAGE_FILE_GROUP="$MEMBER_GROUP_NAME" BRIDGE_AGENT_GROUP_PREFIX="" \
-    "$PY_BIN" - <<PY
+  # footgun #11: same file-as-argv extraction as T1s — the python body is a
+  # SAFE write-to-file heredoc (cat > file <<'PY'), then run as
+  # "$PY_BIN" "$_pyf" inside the T1F_OUT="$( ... )" capture (no
+  # heredoc-fed interpreter stdin inside the capture). $REPO_ROOT crosses
+  # via AGB_REPO_ROOT so the body stays a quoted <<'PY'.
+  T1F_PYF="$(mktemp "${TMPDIR:-/tmp}/1379-t1f-XXXXXX.py")"
+  cat >"$T1F_PYF" <<'PY'
 import json, os, sys
-sys.path.insert(0, os.path.join("$REPO_ROOT", "lib", "cron-helpers"))
+sys.path.insert(0, os.path.join(os.environ["AGB_REPO_ROOT"], "lib", "cron-helpers"))  # noqa: iso-helper-boundary (os.environ read, not a .env file callsite)
 import staging
 
 root = os.environ["AGB_T1F_ROOT"]
@@ -377,7 +387,15 @@ finally:
 after = _requests()
 print("new_published=" + str(len(after - before)))
 PY
+  T1F_OUT="$(
+    AGB_REPO_ROOT="$REPO_ROOT" \
+    AGB_T1F_ROOT="$STAGING_ROOT" AGB_T1F_AGENT="$T1F_AGENT" \
+    AGB_T1F_MEMBER="$MEMBER_GROUP_NAME" AGB_T1F_UID="$CURRENT_UID" \
+    AGB_T1F_PRIMARY_GID="$EFFECTIVE_GID" \
+    AGB_STAGE_FILE_GROUP="$MEMBER_GROUP_NAME" BRIDGE_AGENT_GROUP_PREFIX="" \
+    "$PY_BIN" "$T1F_PYF"
   )"
+  rm -f "$T1F_PYF"
   T1F_RESOLVED="$(printf '%s\n' "$T1F_OUT" | sed -n 's/^resolved=//p')"
   T1F_RC="$(printf '%s\n' "$T1F_OUT" | sed -n 's/^rc=//p')"
   T1F_STDOUT_LEN="$(printf '%s\n' "$T1F_OUT" | sed -n 's/^stdout_len=//p')"

--- a/scripts/smoke/beta5-2-mu-cron-channel-creds.sh
+++ b/scripts/smoke/beta5-2-mu-cron-channel-creds.sh
@@ -427,7 +427,12 @@ t6_normalize_run() {
   printf 'TOKEN=redacted\n' >"$target"
   chmod 0600 "$target"
   local before_mode
-  before_mode="$(stat -f '%Lp' "$target" 2>/dev/null || stat -c '%a' "$target")"
+  # Read the octal file MODE portably. GNU coreutils `stat -c '%a'` first
+  # (on Linux `-f` means --file-system and prints multiline FS info with a
+  # zero exit, so a BSD-first `-f` ordering never reaches the `-c` branch
+  # and compares an FS report to "600"); fall back to BSD `stat -f '%Lp'`
+  # on macOS where `-c` is rejected.
+  before_mode="$(stat -c '%a' "$target" 2>/dev/null || stat -f '%Lp' "$target")"
   if [[ "$before_mode" != "600" ]]; then
     smoke_fail "${label}: precondition file mode=${before_mode} expected 600"
   fi
@@ -447,7 +452,9 @@ t6_normalize_run() {
     smoke_fail "${label}: harness rc=${rc} out=$(cat "$SMOKE_TMP_ROOT/${label}.out")"
   fi
   local after_mode
-  after_mode="$(stat -f '%Lp' "$target" 2>/dev/null || stat -c '%a' "$target")"
+  # Portable octal mode read — GNU `-c '%a'` first, BSD `-f '%Lp'` fallback
+  # (see the before_mode note above for why BSD-first breaks on Linux).
+  after_mode="$(stat -c '%a' "$target" 2>/dev/null || stat -f '%Lp' "$target")"
   if [[ "$after_mode" != "$expected" ]]; then
     smoke_fail "${label}: file mode=${after_mode} expected=${expected} (file widened — codex r1 BLOCKING regression)"
   fi


### PR DESCRIPTION
## stable-prep portability sweep (for v0.15.0 STABLE cut)

Three **inherited** test-scaffolding / cleanup-trap robustness fixes that kept `unit/static smoke` + `lint-heredoc-ban` red on Linux CI across the beta5 line (beta-informational so far, but the STABLE cut must have strict-clean CI). **No product behavior change. No VERSION/CHANGELOG.**

### Fixes

**1. lint-heredoc-ban C1 — extract heredoc-in-capture** (`scripts/smoke/1379-iso-cron-staging-group.sh`)
The T1s (`~:254`) and T1f (`~:318`) probes fed the python interpreter's stdin from a heredoc INSIDE a `T1?_OUT="$( … )"` capture — footgun #11 C1 (heredoc-in-command-substitution) deadlock class. Extracted both to the blessed file-as-argv pattern: write the body to a `mktemp` file via a quoted `cat > "$_pyf" <<'PY'` (a SAFE write-to-file heredoc, NOT into `$()`), run `"$PY_BIN" "$_pyf"`, then `rm -f`. `$REPO_ROOT` crosses via `AGB_REPO_ROOT` env so the body stays a quoted `<<'PY'`. The new `os.environ["AGB_REPO_ROOT"]` reads carry a `# noqa: iso-helper-boundary` marker (they are `os.environ` dict reads, not `.env` file boundary callsites — the iso-helper ratchet's `\.env` pattern matches the substring inside `os.environ`). Functionally identical.

**2. stat -f/-c portability** (`scripts/smoke/beta5-2-mu-cron-channel-creds.sh:430-432` + `:450`)
The 0600 mode precondition used a BSD-first `stat -f '%Lp'` fallback. On GNU/Linux `-f` means `--file-system` and prints a multiline FS report with a zero exit, so the `-c '%a'` branch never ran and the comparison matched an FS report against `"600"` → fail on Linux. Fixed both sites to read the octal mode portably: GNU `stat -c '%a'` first, BSD `stat -f '%Lp'` fallback.

**3. #1387 `_payload_json_tmp` unbound var** (`bridge-cron.sh` `_bridge_cron_create_via_staging`)
The RETURN cleanup trap referenced a bare `$_payload_json_tmp` that is unset on the mktemp-fail path under `set -u` → `unbound variable` to stderr after an iso cron create (cosmetic; the core staging + result-read path works). Initialize the local to `""`, guard the trap with `${_payload_json_tmp:-}`, and set the trap before the mktemp so cleanup is robust on every path.

### Linux verification (the real gate)
Verified on orbstack VM `agb-clean-test` (Ubuntu noble, bash 5.2.21), patch applied on top of `feat/wave-beta5-6-integration`:

| check | result |
|---|---|
| `lint-heredoc-ban.sh --baseline-check` | **PASS** (1379 C1 gone; C1=112 unchanged vs baseline) |
| `lint-heredoc-ban.sh` (count) | **PASS** |
| `smoke/1379-iso-cron-staging-group.sh` | **PASS** (all cases incl. refactored T1s/T1f; Linux 2770+setgid path) |
| `smoke/beta5-2-mu-cron-channel-creds.sh` | **PASS** (old BSD-first stat returns a multiline FS report on Linux; new GNU-first returns `600`) |
| `smoke/1359-cron-create-iso-staging.sh` (iso cron create) | **PASS**, 0 `_payload_json_tmp` unbound-var lines in stderr |
| `oss-preflight.sh` (incl iso-helper-ratchet) | **PASS** |

Load-bearing proof captured: on Linux the old `stat -f '%Lp'` returns the multiline filesystem report (never `600`); the old bare-`$var` trap emits `_payload_json_tmp: unbound variable` under `set -u` while the guarded form is clean.

Closes #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
