### PR TITLE
smoke: align β-1231 T5 sudoers status assertion to stderr (#1392)

### DIFF
--- a/scripts/smoke/β-1231-1236-fresh-install-seed-sudoers.sh
+++ b/scripts/smoke/β-1231-1236-fresh-install-seed-sudoers.sh
@@ -265,10 +265,21 @@ if [[ "$T5_ALL" != *"manual-required"* ]]; then
   smoke_fail "T5: expected 'manual-required' line in init output, got: $T5_ALL"
 fi
 
-# Assert: verifier reason is exposed in stdout.
-if [[ "$T5_STDOUT_CONTENT" != *"daemon_group_refresh_sudoers=missing"* ]]; then
-  printf '%s\n' "$T5_STDOUT_CONTENT" >&2
-  smoke_fail "T5: expected 'daemon_group_refresh_sudoers=missing' status row in init stdout"
+# Assert: verifier reason is exposed on STDERR. bridge-init.sh routes the
+# entire `[init]` diagnostic block (including the
+# `daemon_group_refresh_sudoers=<status>` row) to stderr by the #1230
+# (v0.15.0-beta4) contract: bridge-bootstrap.sh captures bridge-init.sh
+# stdout via `$()` and parses it as JSON (`bridge-bootstrap.sh:180`), so any
+# non-JSON line on stdout poisons that parse. The sibling success row
+# (`daemon_group_refresh_sudoers=ok`) and the human-readable
+# `manual-required` line are all on stderr too — this token is a diagnostic,
+# not a stdout return-channel value here. (Contrast T6: the `agent-bridge`
+# CLI apply/check path deliberately emits this token on STDOUT as its
+# machine-readable return channel, and routes only the human remediation to
+# stderr — two different, intentional contracts for two entry points.)
+if [[ "$T5_STDERR_CONTENT" != *"daemon_group_refresh_sudoers=missing"* ]]; then
+  printf '%s\n' "$T5_STDERR_CONTENT" >&2
+  smoke_fail "T5: expected 'daemon_group_refresh_sudoers=missing' status row in init stderr"
 fi
 
 smoke_log "T5 ok: bridge-init.sh sudoers gating prints manual-required + NO 'installed' contradiction"


### PR DESCRIPTION
Closes #1392.

## Summary
The `β-1231-1236-fresh-install-seed-sudoers.sh` T5 smoke asserted `daemon_group_refresh_sudoers=missing` on **bridge-init.sh STDOUT**, but `bridge-init.sh` emits that line — and its whole `[init]` diagnostic block, including the sibling success row `daemon_group_refresh_sudoers=ok` — to **STDERR**. This kept the `unit/static smoke` CI job RED on Linux across the entire beta5 loop (held beta-informational). Stable-prep: `unit/static` must be green for the v0.15.0 STABLE cut.

## Fix direction: smoke-stderr (NOT init-stdout)
The token is a **diagnostic** in this entry point, not a stdout return-channel value. `bridge-bootstrap.sh:180` captures `bridge-init.sh --json` stdout via `$()` and parses it with `json.loads` (`bridge-bootstrap.sh:297`) — any non-JSON line on stdout poisons that parse. This is the deliberate, documented **#1230 (v0.15.0-beta4)** contract: stdout = JSON data only; all logger/diagnostic lines go to stderr. Forcing the token onto bridge-init.sh stdout would **re-introduce the #1230 regression**, so the correct alignment is to fix the smoke's stream.

Contrast holds for **T6**, which correctly checks the `agent-bridge` CLI `init sudoers daemon-refresh --apply`/`--check` path: that path **intentionally** emits the token on STDOUT (`agent-bridge:655/679/702/707`) as its machine-readable return channel, routing only human remediation to stderr. Two entry points, two intentional contracts. T5 now matches its own.

## Change
Test-only: T5's final assertion greps `T5_STDERR_CONTENT` instead of `T5_STDOUT_CONTENT` for `daemon_group_refresh_sudoers=missing`, with a comment documenting the #1230 contract and the T6 contrast. **Zero behavior change to shipped code.** No VERSION/CHANGELOG.

## Verification
- T1-T6 **green on macOS** (`/opt/homebrew/bin/bash`, exit 0)
- T1-T6 **green on Linux** — orbstack `agb-clean-test`, Ubuntu noble arm64, exit 0
- Pre-fix stdout assertion confirmed **RED on the same Linux host** (proves causality: stub-driver emits `[init] daemon_group_refresh_sudoers=missing` to stderr)
- `bash -n` clean, `shellcheck` clean
- codex self-review: **implement-ok** (independently validated fix direction, stream targeting, T6 contrast, zero-behavior-change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)