### PR TITLE
fix(ci): close unit/static smoke gate for v0.15.0 — I-beta4-a2a T4/T6 grep drift + 6 more required-suite failures (Linux-green)

### DIFF
--- a/scripts/smoke/H-beta4-iso-ownership.sh
+++ b/scripts/smoke/H-beta4-iso-ownership.sh
@@ -466,6 +466,14 @@ if smoke_is_linux; then
     printf 'set -uo pipefail\n'
     printf 'export BRIDGE_ROSTER_CACHE_DISABLE=1\n'
     printf 'source "%s/bridge-lib.sh"\n' "$REPO_ROOT"
+    # The roster assoc maps are only declared by bridge_load_roster /
+    # bridge_reset_roster_maps; sourcing bridge-lib.sh alone (cache
+    # disabled, no load) leaves them undeclared. Under `set -u` an
+    # undeclared-assoc subscript assignment (`MAP[h_smoke]=`) is parsed as
+    # an ARITHMETIC subscript and dies with `h_smoke: unbound variable`.
+    # Declare them idempotently (mirrors bridge-lib.sh cold-iso fallback).
+    printf 'declare -gA BRIDGE_AGENT_OS_USER 2>/dev/null || true\n'
+    printf 'declare -ga BRIDGE_AGENT_IDS 2>/dev/null || true\n'
     printf 'BRIDGE_AGENT_IDS+=(h_smoke aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa manual_explicit)\n'
     printf 'BRIDGE_AGENT_OS_USER[h_smoke]=""\n'
     printf 'BRIDGE_AGENT_OS_USER[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]=""\n'

--- a/scripts/smoke/H-bootstrap-memory-iso-rebuild.sh
+++ b/scripts/smoke/H-bootstrap-memory-iso-rebuild.sh
@@ -457,10 +457,15 @@ if t8_should_run; then
     # failure shape (rm: Permission denied on $home/memory/
     # index.sqlite.rebuilding-...). The probe asserts the fixture
     # really exhibits the bug we are fixing.
-    if rm -f "$STALE_TMP" 2>/dev/null && [[ ! -e "$STALE_TMP" ]]; then
+    if rm -f "$STALE_TMP" 2>/dev/null && ! sudo -n test -e "$STALE_TMP"; then
       smoke_fail "T8.b controller direct rm succeeded — fixture is NOT iso-owned"
     fi
-    [[ -e "$STALE_TMP" ]] \
+    # Existence must be confirmed with root (`sudo -n test -e`), NOT a
+    # controller-side `[[ -e ]]`: the file lives inside a 2770 iso-owned
+    # `memory/` dir the controller has no group membership in, so a
+    # controller `[[ -e ]]` returns false on a file that genuinely exists
+    # (the same boundary T8.a just proved) — a false "disappeared".
+    sudo -n test -e "$STALE_TMP" \
       || smoke_fail "T8.b stale tmp disappeared between fixture create and assert"
     smoke_log "ok: T8.b controller direct rm fails (pre-fix shape reproduced)"
 
@@ -470,7 +475,10 @@ if t8_should_run; then
     if ! sudo -n -u "$ISO_USER" bash -c "rm -f '$STALE_TMP'"; then
       smoke_fail "T8.c sudo-as-iso rm rc=$? — post-fix path is broken on this host"
     fi
-    [[ ! -e "$STALE_TMP" ]] \
+    # Confirm removal with root, NOT controller-side `[[ ! -e ]]`: the
+    # controller cannot stat into the 2770 iso dir, so `[[ ! -e ]]` would
+    # report "removed" even if the unlink had failed (false pass).
+    ! sudo -n test -e "$STALE_TMP" \
       || smoke_fail "T8.c sudo-as-iso rm reported success but file remains"
     smoke_log "ok: T8.c sudo-as-iso rm succeeds (post-fix path works)"
   fi

--- a/scripts/smoke/I-beta4-a2a-3-gaps.sh
+++ b/scripts/smoke/I-beta4-a2a-3-gaps.sh
@@ -244,9 +244,16 @@ fi
 if ! grep -F 'BRIDGE_DAEMON_LAST_STEP="a2a_deliver_tick"' "$DAEMON_SH" >/dev/null; then
   T4_FAILS+="cmd_sync_cycle does not set LAST_STEP=a2a_deliver_tick; "
 fi
-# Tolerate the Issue #1338 defense-in-depth subshell-isolate form
-# `( process_a2a_deliver_tick ) || true` as well as the bare invocation.
-if ! grep -E '\(?[[:space:]]*process_a2a_deliver_tick[[:space:]]*\)?[[:space:]]*\|\|[[:space:]]*true' "$DAEMON_SH" >/dev/null; then
+# Issue #1338 wrapped the deliver-tick call in a defense-in-depth subshell:
+# `( process_a2a_deliver_tick ) || true` (matching the sibling
+# start_cron_dispatch_workers / process_a2a_outbox_stuck_scan_tick calls).
+# Accept either the bare or subshell-wrapped invocation so this assertion
+# tracks the wiring (tick runs each sync cycle) rather than the exact
+# syntax. Anchor to the start of an executable line (`^[[:space:]]*` with
+# the call token immediately after) so a commented-out or echo'd mention
+# (e.g. `# ( process_a2a_deliver_tick ) || true`) does NOT satisfy it —
+# deleting OR commenting the real wiring must still trip the assertion.
+if ! grep -Eq '^[[:space:]]*\(?[[:space:]]*process_a2a_deliver_tick[[:space:]]*\)?[[:space:]]*\|\|[[:space:]]*true' "$DAEMON_SH"; then
   T4_FAILS+="process_a2a_deliver_tick not invoked from cmd_sync_cycle; "
 fi
 
@@ -365,8 +372,13 @@ fi
 if ! grep -F 'BRIDGE_DAEMON_LAST_STEP="a2a_stuck_scan_tick"' "$DAEMON_SH" >/dev/null; then
   T6_FAILS+="cmd_sync_cycle does not set LAST_STEP=a2a_stuck_scan_tick; "
 fi
-# Tolerate the Issue #1338 subshell-isolate form `( … ) || true`.
-if ! grep -E '\(?[[:space:]]*process_a2a_outbox_stuck_scan_tick[[:space:]]*\)?[[:space:]]*\|\|[[:space:]]*true' "$DAEMON_SH" >/dev/null; then
+# Issue #1338 wrapped the stuck-scan-tick call in a defense-in-depth subshell:
+# `( process_a2a_outbox_stuck_scan_tick ) || true` (same pattern as the
+# deliver-tick T4 assertion above). Accept either the bare or subshell-
+# wrapped invocation so this tracks the wiring rather than the exact
+# syntax. Anchored to the start of an executable line (see T4) so a
+# commented-out/echo'd mention does NOT satisfy the assertion.
+if ! grep -Eq '^[[:space:]]*\(?[[:space:]]*process_a2a_outbox_stuck_scan_tick[[:space:]]*\)?[[:space:]]*\|\|[[:space:]]*true' "$DAEMON_SH"; then
   T6_FAILS+="stuck scan tick not invoked from cmd_sync_cycle; "
 fi
 # T6d — audit row name `a2a_outbox_stuck_alert_emitted` present.

--- a/scripts/smoke/J-beta4-workflow-docs.sh
+++ b/scripts/smoke/J-beta4-workflow-docs.sh
@@ -84,6 +84,16 @@ smoke_require_cmd python3
 smoke_setup_bridge_home "$SMOKE_NAME"
 REPO_ROOT="$SMOKE_REPO_ROOT"
 
+# BRIDGE_BASH_BIN is used by T7/T7b/T8/T8b to invoke child scripts but was
+# never defined here — under `set -u` the first expansion died inside the
+# `$(...)` subshell (exit 1, empty output), surfacing as the misleading
+# "T7: bootstrap-memory-system.sh --apply rc=1 out:" with no stderr. The
+# smoke already re-execs into a bash 4+ interpreter at the top, so the
+# running `bash` on PATH is the right child interpreter. Honor an inherited
+# override, else resolve it (sibling pattern: B-beta4-setup-wizard.sh).
+BRIDGE_BASH_BIN="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+export BRIDGE_BASH_BIN
+
 # ----------------------------------------------------------------------------
 # T1 (#1280 positive): bridge-queue.py:stabilize_body_file falls back to
 # `_sudo_read_body_file` on PermissionError. We exercise the helper
@@ -374,6 +384,19 @@ fi
 # BRIDGE_WIKI_GRAPH_ENABLED but the operator's shell may have leaked
 # it). With no env and no prior report, the gate fires.
 unset BRIDGE_WIKI_GRAPH_ENABLED
+
+# smoke_setup_bridge_home leaves agent-roster.local.sh empty. Any real
+# install reaching bootstrap-memory-system.sh has an admin set (init
+# writes it), and the script's admin-discovery does
+# `grep ... BRIDGE_ADMIN_AGENT_ID | head | sed` under `set -euo
+# pipefail` — on an empty roster the grep finds nothing, exits 1, and
+# pipefail+set-e abort the whole script (rc=1, zero output → the
+# misleading "T7 ... rc=1 out:"). Seed a minimal admin so the roster
+# matches a real install. (See report: bootstrap-memory-system.sh:60 is
+# also fragile on a genuinely admin-less roster — flagged as a separate
+# product robustness follow-up, not changed on the stable cut.)
+printf 'BRIDGE_ADMIN_AGENT_ID="patch"\n' >"$BRIDGE_ROSTER_LOCAL_FILE"
+
 T7_OUT=""
 T7_RC=0
 T7_OUT="$("$BRIDGE_BASH_BIN" "$REPO_ROOT/bootstrap-memory-system.sh" --apply 2>&1)" || T7_RC=$?

--- a/scripts/smoke/a2a-cross-bridge.sh
+++ b/scripts/smoke/a2a-cross-bridge.sh
@@ -21,11 +21,15 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "$SCRIPT_DIR/lib.sh"
 
 HANDOFFD_PID=""
+REVIEWER_SESSION=""
 
 cleanup() {
   if [[ -n "$HANDOFFD_PID" ]]; then
     kill "$HANDOFFD_PID" >/dev/null 2>&1 || true
     wait "$HANDOFFD_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$REVIEWER_SESSION" ]]; then
+    tmux kill-session -t "=${REVIEWER_SESSION}" >/dev/null 2>&1 || true
   fi
   smoke_cleanup_temp_root
 }
@@ -33,6 +37,11 @@ trap cleanup EXIT
 
 A2A_PORT=""
 A2A_SECRET="smoke-shared-secret-do-not-use-in-prod-0123456789"
+# Unique tmux session name for the 'reviewer' fixture so a pre-existing
+# session on the host can neither mask our setup nor be killed by cleanup.
+# The same value is written into the roster (BRIDGE_AGENT_SESSION[reviewer])
+# so bridge_agent_is_active resolves it.
+REVIEWER_SESSION_NAME="a2a-smoke-reviewer-$$-${RANDOM}"
 
 pick_free_port() {
   python3 "$SCRIPT_DIR/a2a-cross-bridge-helper.py" free-port
@@ -46,12 +55,30 @@ BRIDGE_ADMIN_AGENT_ID="reviewer"
 bridge_add_agent_id_if_missing "reviewer"
 BRIDGE_AGENT_DESC["reviewer"]="A2A smoke reviewer"
 BRIDGE_AGENT_ENGINE["reviewer"]="shell"
-BRIDGE_AGENT_SESSION["reviewer"]="a2a-smoke-session"
+BRIDGE_AGENT_SESSION["reviewer"]="$REVIEWER_SESSION_NAME"
 BRIDGE_AGENT_WORKDIR["reviewer"]="$workdir"
 BRIDGE_AGENT_LAUNCH_CMD["reviewer"]="bash -lc 'echo reviewer'"
 BRIDGE_AGENT_LOOP["reviewer"]=0
 BRIDGE_AGENT_CONTINUE["reviewer"]=0
 EOF
+}
+
+# Bring the 'reviewer' target up so bridge-task.sh's #1318 stopped-target
+# guard treats it as a live reader. In production an inbound a2a handoff
+# targets a running agent; the receiver enqueues through the EXISTING
+# bridge-task.sh create boundary, which refuses (`task create refused —
+# no reader to dequeue`) when the target has no tmux session. We start a
+# detached session named exactly BRIDGE_AGENT_SESSION["reviewer"]
+# (REVIEWER_SESSION_NAME, unique per run) so bridge_agent_is_active
+# "reviewer" returns true, mirroring real usage. Torn down in cleanup().
+start_reviewer_session() {
+  REVIEWER_SESSION="$REVIEWER_SESSION_NAME"
+  if ! tmux new-session -d -s "$REVIEWER_SESSION" "sleep 600" 2>/dev/null; then
+    smoke_fail "reviewer tmux new-session '$REVIEWER_SESSION' failed"
+  fi
+  if ! tmux has-session -t "=${REVIEWER_SESSION}" 2>/dev/null; then
+    smoke_fail "reviewer tmux session '$REVIEWER_SESSION' did not come up"
+  fi
 }
 
 write_a2a_config() {
@@ -433,8 +460,12 @@ conn.close()
 
 main() {
   smoke_require_cmd python3
+  smoke_require_cmd tmux
   smoke_setup_bridge_home "a2a-cross-bridge"
   write_a2a_roster
+  # #1318: the receiver's bridge-task.sh create refuses a stopped target.
+  # Bring 'reviewer' up (live tmux session) before any enqueue assertion.
+  start_reviewer_session
 
   smoke_run "receiver fail-closed on wildcard bind" fail_closed_wildcard
   smoke_run "receiver fail-closed when tailscale CLI absent" fail_closed_without_tailscale_cli

--- a/scripts/smoke/agent-doctor.sh
+++ b/scripts/smoke/agent-doctor.sh
@@ -40,6 +40,23 @@ trap cleanup EXIT
 
 smoke_setup_bridge_home "agent-doctor"
 
+# Issue #1317-C (beta5-2 Lane ν): `agent create` (which the doctor's
+# 7-step CRUD self-check drives via child invocations) now pre-flights
+# the engine CLI with `command -v <engine>` and refuses if neither
+# claude nor codex resolves on PATH. CI runners and clean test hosts do
+# not ship the engine npm packages, so seed executable stubs and prepend
+# them to PATH — mirroring an operator with the engine installed, which
+# is the precondition the doctor fixture assumes. Without this the
+# create step dies ("engine CLI 'codex' not found on PATH") and every
+# downstream step fails ("not present in the local roster").
+STUB_ENGINE_DIR="$SMOKE_TMP_ROOT/stub-engine-bin"
+mkdir -p "$STUB_ENGINE_DIR"
+for _eng in claude codex; do
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$STUB_ENGINE_DIR/$_eng"
+  chmod +x "$STUB_ENGINE_DIR/$_eng"
+done
+export PATH="$STUB_ENGINE_DIR:$PATH"
+
 # Force v2 layout for the doctor smoke — release/v0.8.0 refuses legacy
 # layout. We seed BRIDGE_DATA_ROOT inside the temp BRIDGE_HOME so all
 # v2 paths land in the isolated tree.

--- a/scripts/smoke/beta5-2-nu-daemon-path-quarantine.sh
+++ b/scripts/smoke/beta5-2-nu-daemon-path-quarantine.sh
@@ -107,22 +107,39 @@ smoke_assert_file_exists "$HINT_HELPER" "broken-launch-reason-hint.py helper pre
 t1_driver() {
   local _tmp="$SMOKE_TMP_ROOT/t1"
   mkdir -p "$_tmp/override-bin" "$_tmp/nvm-root/versions/node/v24.16.0/bin"
+  # beta5-3 #1352/#1317 engine-presence gate: bridge_augment_engine_path
+  # only prepends an nvm version bin dir that actually holds a `codex` or
+  # `claude` executable (an engine-less dir grows PATH without fixing
+  # `command -v codex` → exit 127 persists). Seed a stub engine binary so
+  # the T1b nvm auto-detect precondition matches a real nvm install.
+  printf '#!/usr/bin/env bash\nexit 0\n' \
+    >"$_tmp/nvm-root/versions/node/v24.16.0/bin/codex"
+  chmod +x "$_tmp/nvm-root/versions/node/v24.16.0/bin/codex"
 
   # Build a tiny standalone driver that defines bridge_prepend_path_entry
-  # + bridge_augment_engine_path inline (extracted from bridge-lib.sh
-  # via awk). Source-then-call into an isolated PATH so the smoke
-  # cannot be contaminated by the operator's real shell.
+  # + bridge_dir_has_engine_cli + bridge_augment_engine_path inline
+  # (extracted from bridge-lib.sh via awk). Source-then-call into an
+  # isolated PATH so the smoke cannot be contaminated by the operator's
+  # real shell. bridge_dir_has_engine_cli is a dependency of
+  # bridge_augment_engine_path (beta5-3 #1317 nvm/fnm auto-detect) and
+  # must be extracted too or the call dies with `command not found`.
   local _driver="$_tmp/driver.sh"
   awk '
     /^bridge_prepend_path_entry\(\) \{/,/^\}/ { print }
   ' "$LIB_SH" >"$_driver"
   awk '
+    /^bridge_dir_has_engine_cli\(\) \{/,/^\}/ { print }
+  ' "$LIB_SH" >>"$_driver"
+  awk '
     /^bridge_augment_engine_path\(\) \{/,/^\}/ { print }
   ' "$LIB_SH" >>"$_driver"
 
-  # Sanity: both function openers must be present.
+  # Sanity: all three function openers must be present.
   if ! grep -q '^bridge_prepend_path_entry() {' "$_driver"; then
     smoke_fail "T1: bridge_prepend_path_entry extract missing"
+  fi
+  if ! grep -q '^bridge_dir_has_engine_cli() {' "$_driver"; then
+    smoke_fail "T1: bridge_dir_has_engine_cli extract missing (augment dependency)"
   fi
   if ! grep -q '^bridge_augment_engine_path() {' "$_driver"; then
     smoke_fail "T1: bridge_augment_engine_path extract missing (likely fix reverted)"


### PR DESCRIPTION
## Summary

Closes the **last red gate** for the v0.15.0 STABLE cut: the `unit/static smoke` CI job (ci-select `required` suite). codex flagged `scripts/smoke/I-beta4-a2a-3-gaps.sh` T4, but a comprehensive run surfaced a recurring tail of drifted/latent smokes. I ran the **FULL required suite (180 scripts) on Linux** at integration HEAD `81c7f45` and fixed **every** failure in one pass.

**All changes are smoke / fixture-expectation alignment — NO product behavior change.** The product behaviors the smokes assert against are correct (beta5-2/beta5-3 hardening); the smokes had drifted or carried latent bugs that only bite on a real iso/Linux host. CI's diff-based selection rarely co-selected them, so the regressions accumulated as a stable-prep tail.

## Failures fixed (7 smoke files)

- **I-beta4-a2a-3-gaps (T4+T6)** — grep drift (#1338 subshell wrap): anchored regex accepting `( process_... ) || true`; teeth preserved (comment/echo no longer matches).
- **a2a-cross-bridge** — #1318 stopped-target guard: start a unique-named live tmux session for `reviewer` before the enqueue asserts.
- **agent-doctor** — #1317-C engine pre-flight: seed claude/codex stubs on PATH.
- **beta5-2-nu-daemon-path-quarantine** — beta5-3 extract + engine-presence gate: extract `bridge_dir_has_engine_cli` into the driver; seed an nvm-bin engine stub.
- **H-bootstrap-memory-iso-rebuild (T8.b/c)** — iso-boundary existence check: `sudo -n test -e` instead of controller `[[ -e ]]` (2770 dir).
- **H-beta4-iso-ownership** — `set -u` undeclared-assoc: `declare -gA`/`declare -ga` in the runtime driver.
- **J-beta4-workflow-docs (T7/T8b)** — undefined `BRIDGE_BASH_BIN` + empty-roster grep abort: define `BRIDGE_BASH_BIN`; seed admin roster.

Two env-only smokes (`mattermost-plugin` → `bun`, `beta5-2-kappa-state-audit-reconcile` → `sqlite3`) were NOT real failures — they pass once the dependency is present, which CI's `setup-bun` step / `ubuntu-latest` image provide. No code change.

## Flagged for separate follow-up (NOT changed on the stable cut)
- a2a inbound enqueue (`bridge-handoffd.py` → `bridge-task.sh create`) does not pass `--force`, so an inbound handoff to a momentarily-stopped local agent now 422s under #1318.
- `bootstrap-memory-system.sh:60` (`grep BRIDGE_ADMIN_AGENT_ID | head | sed` under `set -euo pipefail`) aborts on an admin-less roster.

## Verification (Linux — orbstack agb-clean-test, ubuntu-noble, bash 5.2.21, at HEAD `81c7f45`)
- **full `ci-select-smoke.sh --suite required ... --run` (180 scripts): GREEN** (bun + sqlite3 installed, matching CI)
- each previously-failing smoke re-verified green individually
- `bash -n` + `shellcheck` clean on all 7 files
- `oss-preflight` PASS, `lint-heredoc-ban` PASS
- codex review: **implement-ok** (r2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)