### PR TITLE
fix(#1407): repair scalar-clobbered roster maps in dynamic-agent loader (PR #1410 r2 follow-up)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -629,6 +629,30 @@ bridge_agent_launch_cmd() {
   printf '%s' "$launch_cmd"
 }
 
+# #1407 (PR #1410 follow-up): the dynamic env file sourced by
+# bridge_load_dynamic_agent_file can clobber a BRIDGE_AGENT_* roster map to a
+# scalar (e.g. a stray `BRIDGE_AGENT_CREATED_AT=` line in an old/malformed env
+# file). After that, every indexed read AND write of the map below aborts under
+# `set -u` with `<id>: unbound variable` — note the WRITE aborts too, so routing
+# the read through an accessor is NOT sufficient (empirically confirmed). A
+# scalar map carries no per-agent data, so redeclaring it as an empty
+# associative array is loss-free; the per-map declare-guard makes this a no-op
+# for the normal (already-associative) case, which also keeps the #1213
+# scalar-vs-`declare -g -A` collision class from re-triggering.
+bridge_ensure_roster_maps_assoc() {
+  local _m
+  for _m in BRIDGE_AGENT_DESC BRIDGE_AGENT_ENGINE BRIDGE_AGENT_SESSION \
+            BRIDGE_AGENT_WORKDIR BRIDGE_AGENT_SOURCE BRIDGE_AGENT_META_FILE \
+            BRIDGE_AGENT_PROVENANCE BRIDGE_AGENT_LOOP BRIDGE_AGENT_CONTINUE \
+            BRIDGE_AGENT_SESSION_ID BRIDGE_AGENT_HISTORY_KEY \
+            BRIDGE_AGENT_CREATED_AT BRIDGE_AGENT_UPDATED_AT; do
+    if ! declare -p "$_m" 2>/dev/null | grep -q 'declare -[A-Za-z]*A'; then
+      unset "$_m"
+      declare -gA "$_m=()"
+    fi
+  done
+}
+
 bridge_load_dynamic_agent_file() {
   local file="$1"
   local AGENT_ID=""
@@ -645,6 +669,11 @@ bridge_load_dynamic_agent_file() {
 
   # shellcheck source=/dev/null
   source "$file"
+
+  # #1407: repair any roster map the sourced file may have clobbered to a
+  # scalar BEFORE the indexed reads/writes below (which would otherwise abort
+  # under `set -u`). Loss-free + no-op when already associative.
+  bridge_ensure_roster_maps_assoc
 
   if [[ -z "$AGENT_ID" || -z "$AGENT_ENGINE" || -z "$AGENT_SESSION" || -z "$AGENT_WORKDIR" ]]; then
     return 0

--- a/scripts/smoke/1407-runtime-hardening.sh
+++ b/scripts/smoke/1407-runtime-hardening.sh
@@ -173,10 +173,20 @@ fi
 # to associative (bridge_ensure_roster_maps_assoc) right after `source "$file"`.
 # This drives codex's EXACT repro through the real loader; pre-fix signature is
 # `<id>: unbound variable`.
+#
+# Source the granular libs (core+state+agents) like D2-accessor/D2-persist above,
+# NOT the full bridge-lib.sh: in a markerless CI/test home, bridge-lib.sh's
+# isolation-v2 layout gate (v0.8.0) `exit`s before bridge_load_dynamic_agent_file
+# is defined, so the loader would never run and D2DYN would be blank. The granular
+# libs define the loader + bridge_reset_roster_maps + bridge_ensure_roster_maps_assoc
+# + bridge_add_agent_id_if_missing without tripping the layout resolver. (codex
+# PR #1412 r1 caught this CI-only fixture bug; reproduced markerless on Ubuntu.)
 d2dyn_out="$(
 	"$BASH4" -c '
 		set -u
-		source "'"$SCRIPT_DIR"'/bridge-lib.sh" 2>/dev/null || true
+		source "'"$SCRIPT_DIR"'/lib/bridge-core.sh" 2>/dev/null || true
+		source "'"$SCRIPT_DIR"'/lib/bridge-state.sh" 2>/dev/null || true
+		source "'"$SCRIPT_DIR"'/lib/bridge-agents.sh" 2>/dev/null || true
 		bridge_reset_roster_maps 2>/dev/null || true
 		agent=some-agent
 		bridge_add_agent_id_if_missing "$agent"

--- a/scripts/smoke/1407-runtime-hardening.sh
+++ b/scripts/smoke/1407-runtime-hardening.sh
@@ -165,6 +165,54 @@ else
 	printf '%s\n' "$d2cls_hits"
 fi
 
+# --- D2-dynload: codex (PR #1410 r2) found the static-collision branch of -----
+# bridge_load_dynamic_agent_file STILL aborts on a scalar-clobbered roster map.
+# That branch does an assoc WRITE `BRIDGE_AGENT_CREATED_AT["$AGENT_ID"]=…` — and
+# empirically the WRITE itself aborts on a scalar map, so routing only the RHS
+# read through the accessor is NOT enough. The fix repairs any clobbered map back
+# to associative (bridge_ensure_roster_maps_assoc) right after `source "$file"`.
+# This drives codex's EXACT repro through the real loader; pre-fix signature is
+# `<id>: unbound variable`.
+d2dyn_out="$(
+	"$BASH4" -c '
+		set -u
+		source "'"$SCRIPT_DIR"'/bridge-lib.sh" 2>/dev/null || true
+		bridge_reset_roster_maps 2>/dev/null || true
+		agent=some-agent
+		bridge_add_agent_id_if_missing "$agent"
+		BRIDGE_AGENT_SOURCE["$agent"]="static"
+		BRIDGE_AGENT_ENGINE["$agent"]="claude"
+		BRIDGE_AGENT_SESSION["$agent"]="sess"
+		BRIDGE_AGENT_WORKDIR["$agent"]="/tmp"
+		BRIDGE_AGENT_SESSION_ID["$agent"]=""
+		unset BRIDGE_AGENT_CREATED_AT
+		BRIDGE_AGENT_CREATED_AT=scalar
+		bridge_resolve_resume_session_id() { printf ""; return 1; }
+		f="$(mktemp "${TMPDIR:-/tmp}/agb-1407-dyn.XXXXXX")"
+		printf "%s\n" "AGENT_ID=$agent" "AGENT_ENGINE=claude" "AGENT_SESSION=sess2" "AGENT_WORKDIR=/tmp" >"$f"
+		bridge_load_dynamic_agent_file "$f" && printf "D2DYN=ok\n"
+		rm -f "$f"
+	' 2>&1
+)" || true
+printf '%s\n' "$d2dyn_out"
+if printf '%s' "$d2dyn_out" | grep -q 'unbound variable'; then
+	fail "D2-dynload bridge_load_dynamic_agent_file aborted on scalar-clobbered roster map (codex r2 site)"
+elif printf '%s' "$d2dyn_out" | grep -q 'D2DYN=ok'; then
+	pass "D2-dynload bridge_load_dynamic_agent_file tolerates scalar-clobbered roster map (static-collision branch)"
+else
+	fail "D2-dynload did not reach the loaded-ok marker: $d2dyn_out"
+fi
+
+# --- D2-repair: the loader must repair clobbered maps right after `source` -----
+# Static-presence guard for the fix above: bridge_load_dynamic_agent_file calls
+# bridge_ensure_roster_maps_assoc, and the helper redeclares (not just reads).
+if grep -q 'bridge_ensure_roster_maps_assoc' "$SCRIPT_DIR/lib/bridge-state.sh" \
+	&& grep -q 'declare -gA "\$_m=()"' "$SCRIPT_DIR/lib/bridge-state.sh"; then
+	pass "D2-repair bridge_ensure_roster_maps_assoc present + redeclares maps in lib/bridge-state.sh"
+else
+	fail "D2-repair bridge_ensure_roster_maps_assoc missing or does not redeclare maps"
+fi
+
 # --- D3: stuck-scan markdown bullets emit literal `- ...` (no invalid option) -
 # Exercise the exact printf form used by process_a2a_outbox_stuck_scan_tick.
 d3_out="$(


### PR DESCRIPTION
## Summary

Follow-up to #1410 (merged `0932153`). codex's r2 review of #1410 was **needs-more**: the central created-at accessor fixed 4 of 5 sites, but the static-collision branch of `bridge_load_dynamic_agent_file` (`lib/bridge-state.sh:678`) still aborts on a scalar-clobbered roster map under `set -u`.

## Root cause (empirically established, not assumed)

codex prescribed routing the line-678 **read** through the accessor. Probing on bash 5.3.9 showed that's **insufficient** — the assoc **write** `BRIDGE_AGENT_CREATED_AT["$AGENT_ID"]=…` aborts on a scalar map regardless of the RHS:

| probe | result |
|---|---|
| A — pure LHS write to scalar-clobbered map | **aborts** `unbound variable` |
| C — accessor on RHS (codex's prescribed fix) | **still aborts** (the write) |
| D — redeclare assoc, then original write | OK |

The trigger is `source "$file"` at the top of the loader: a stray `BRIDGE_AGENT_*=` line in an old/malformed dynamic env file demotes a roster map to scalar; then every indexed read **and write** below aborts.

## Fix

`bridge_ensure_roster_maps_assoc()` (new, `lib/bridge-state.sh`), called right after `source "$file"`: redeclares any of the 13 `BRIDGE_AGENT_*` maps that are no longer associative back to an empty associative array. Loss-free (a scalar map holds no per-agent data), no-op when already associative (per-map declare-guard → #1213-safe).

## Verification (bash 5.3.9)

- `scripts/smoke/1407-runtime-hardening.sh`: **8 passed, 0 failed** (adds **D2-dynload** = codex's exact repro through the real loader, + **D2-repair** static presence).
- **Negative control**: removing the repair call makes D2-dynload FAIL with the abort → the check has teeth.
- `bash -n`, `shellcheck`, `oss-preflight` all clean; `ci-select-smoke.sh --base main --head HEAD` still selects the 1407 smoke.

## Note

677 (`HISTORY_KEY`) and 679 (`UPDATED_AT`) were the same latent class; the repair-after-source covers them (and every other map the loader writes) as a bonus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
