### PR TITLE
docs: v0.15.0 stable version refs + public repo URL migration (SYRS-AI→seanssoh)

### DIFF
--- a/.claude/skills/wave-orchestration/references/wave-examples.md
+++ b/.claude/skills/wave-orchestration/references/wave-examples.md
@@ -119,7 +119,7 @@ $EDITOR /tmp/agb-302-codex-review.md
 Agent({
   description: "Codex review of PR #302 ACL plugin sharing",
   subagent_type: "codex:codex-rescue",
-  prompt: `Code review PR #302 of SYRS-AI/agent-bridge-public — "isolate: channel-ownership-aware plugin sharing for isolated UIDs".
+  prompt: `Code review PR #302 of seanssoh/agent-bridge-public — "isolate: channel-ownership-aware plugin sharing for isolated UIDs".
 
 Codex CLI is installed and ready. If your first probe disagrees, re-check via:
 PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" codex --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5319,7 +5319,7 @@ All changes auto-apply on the first `agent-bridge upgrade --apply` to v0.7.6+. E
 
 ### Highlight — admin codex pair as a standard install asset (#517)
 
-`v0.7.4` ships [#517](https://github.com/SYRS-AI/agent-bridge-public/issues/517) (operator approved 2026-05-03): every admin agent now gets a sibling `<admin>-dev` codex agent automatically, and the admin's CLAUDE.md gains a managed block codifying the pair-programming SOP — so the `AGENTS.md` "Multi-Agent Collaboration" workflow is a real install asset rather than relying on per-install custom edits or operator memory.
+`v0.7.4` ships [#517](https://github.com/seanssoh/agent-bridge-public/issues/517) (operator approved 2026-05-03): every admin agent now gets a sibling `<admin>-dev` codex agent automatically, and the admin's CLAUDE.md gains a managed block codifying the pair-programming SOP — so the `AGENTS.md` "Multi-Agent Collaboration" workflow is a real install asset rather than relying on per-install custom edits or operator memory.
 
 ### Added (#517 — PR #521)
 
@@ -5339,7 +5339,7 @@ All changes auto-apply on the first `agent-bridge upgrade --apply` to v0.7.6+. E
 
 ### Highlight — issue #509 closed (compact recovery + skill discovery migration), `agb doctor` admin self-healing, `#516` settings gating
 
-`v0.7.3` ships the full plan from [#509](https://github.com/SYRS-AI/agent-bridge-public/issues/509) (Sean's "stop SKILLS.md from re-emitting itself every session + don't drop SOUL/MEMORY on auto-compaction" candidate), the [#511](https://github.com/SYRS-AI/agent-bridge-public/issues/511) `agb doctor` read-only command for admin self-healing, and the [#516](https://github.com/SYRS-AI/agent-bridge-public/issues/516) static-only gate on shared `autoCompactWindow=400000` propagation. A small UX bundle bundled with #516 closes three smaller paper-cuts surfaced from the #509 wave handoff.
+`v0.7.3` ships the full plan from [#509](https://github.com/seanssoh/agent-bridge-public/issues/509) (Sean's "stop SKILLS.md from re-emitting itself every session + don't drop SOUL/MEMORY on auto-compaction" candidate), the [#511](https://github.com/seanssoh/agent-bridge-public/issues/511) `agb doctor` read-only command for admin self-healing, and the [#516](https://github.com/seanssoh/agent-bridge-public/issues/516) static-only gate on shared `autoCompactWindow=400000` propagation. A small UX bundle bundled with #516 closes three smaller paper-cuts surfaced from the #509 wave handoff.
 
 ### Added (compact recovery — #509 P3 / C3+C4 — PR #510, deployment fix #512)
 
@@ -5385,7 +5385,7 @@ All changes auto-apply on the first `agent-bridge upgrade --apply` to v0.7.6+. E
 
 ### Highlight — daily-backup death-spiral root-cause + auto-cleanup migration
 
-`v0.7.2` fixes the chain of bugs documented in [#507](https://github.com/SYRS-AI/agent-bridge-public/issues/507) — orphaned `*.tgz.tmp.*` files filling host disks (~110 GB observed in a single overnight window across two hosts), no preflight free-space check, and a 30-day retention default that compounded the problem. The same release addresses two adjacent issues Sean surfaced during diagnosis: `state/tasks.db` was bundled raw into every daily tarball (uncompressible, ~30× multiplier under retention), and `backups/upgrade-*/` snapshots had no prune at all.
+`v0.7.2` fixes the chain of bugs documented in [#507](https://github.com/seanssoh/agent-bridge-public/issues/507) — orphaned `*.tgz.tmp.*` files filling host disks (~110 GB observed in a single overnight window across two hosts), no preflight free-space check, and a 30-day retention default that compounded the problem. The same release addresses two adjacent issues Sean surfaced during diagnosis: `state/tasks.db` was bundled raw into every daily tarball (uncompressible, ~30× multiplier under retention), and `backups/upgrade-*/` snapshots had no prune at all.
 
 ### Fixed (#507)
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -125,8 +125,9 @@ the leap-path safe on Bash 5.3.9 hosts:
 
 ```bash
 cd <source-checkout>
-git fetch origin
-git checkout "$(git tag -l 'v0.14.5-beta*' | sort -V | tail -1)"
+git fetch origin --tags
+# Pin to the latest STABLE tag (vX.Y.Z, no -beta/-rc suffix) — currently v0.15.0.
+git checkout "$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -1)"
 ./agent-bridge upgrade --apply
 ```
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -116,9 +116,9 @@ without guessing.
 
 표준 upgrade 절차는 [`UPGRADING.md`](UPGRADING.md) 에 정리되어 있다. 모든 install 에서 동일한 명령으로 진행한다:
 
-**Current target**: upgrade to the latest **`v0.14.5-betaN`** release. The
-v0.14.5 line is an ongoing prerelease series with no separate stable tag, so
-the latest `v0.14.5-betaN` tag is the current target. A single
+**Current target**: upgrade to **`v0.15.0`** (stable). It supersedes the
+`v0.15.0-rc1` / `v0.15.0-betaN` / `v0.14.5-betaN` prereleases, so the latest
+stable tag is the current target. A single
 `agent-bridge upgrade --apply` lands there from any v0.7.x+ source; the
 v0.13.7-v0.13.9 heredoc-chain fixes (extracted to `lib/upgrade-helpers/`) keep
 the leap-path safe on Bash 5.3.9 hosts:
@@ -197,7 +197,7 @@ For per-stage detail, see `CHANGELOG.md` `[0.14.0]`. For the stabilization roadm
 
 ### v0.13.x hotfix wave (2026-05-15) — historical context
 
-**Current recommendation**: upgrade to the current target (the latest `v0.14.5-betaN` — see the top of the Upgrade section). This section is preserved as historical context for the leap-path blockers that v0.13.7-v0.13.10 resolved.
+**Current recommendation**: upgrade to the current target (`v0.15.0` stable — see the top of the Upgrade section). This section is preserved as historical context for the leap-path blockers that v0.13.7-v0.13.10 resolved.
 
 The v0.13.7-v0.13.10 cycle fixed a four-stage `agent-bridge upgrade --apply` blocker that affected the v0.7.x → v0.13.x leap on Bash 5.3.9 hosts (matched by recent Linux distros). Operators on macOS were similarly affected by a markerless-existing-install layout reject. The v0.14.x line carries those fixes forward — operators can leap directly from v0.7.x/v0.8.x/v0.9.x/v0.10.x/v0.11.x/v0.12.x to the current target in a single `agent-bridge upgrade --apply` step.
 
@@ -849,8 +849,8 @@ different support targets for multi-tenant isolation:
   `BRIDGE_AGENT_ISOLATION_MODE=linux-user` enforces per-agent UID
   separation and is required when agents hold delegated credentials or
   handle untrusted external input. See issues
-  [#68](https://github.com/SYRS-AI/agent-bridge-public/issues/68) and
-  [#85](https://github.com/SYRS-AI/agent-bridge-public/issues/85).
+  [#68](https://github.com/seanssoh/agent-bridge-public/issues/68) and
+  [#85](https://github.com/seanssoh/agent-bridge-public/issues/85).
 
 On macOS the `linux-user` mode falls back to shared silently (see
 `bridge_agent_linux_user_isolation_effective` in
@@ -875,7 +875,7 @@ controller-side path. Direct sqlite access from the isolated UID stays
 blocked by the `BRIDGE_TASK_DB` ACL strip; gateway routing is selected
 explicitly via the `BRIDGE_GATEWAY_PROXY=1` flag the scoped env writer
 emits when `BRIDGE_AGENT_ISOLATION_MODE=linux-user`. See issue
-[#294](https://github.com/SYRS-AI/agent-bridge-public/issues/294).
+[#294](https://github.com/seanssoh/agent-bridge-public/issues/294).
 
 > **Upgrading from <0.6.13:** the gateway-proxy gate now requires
 > `BRIDGE_GATEWAY_PROXY=1` in the scoped env. Restart isolated agents

--- a/OPERATOR_ACTIONS_PENDING.md
+++ b/OPERATOR_ACTIONS_PENDING.md
@@ -138,7 +138,7 @@ This walks the live roster (so dynamic agents are not silently hidden) and print
 
 ### Background
 
-Issue [#507](https://github.com/SYRS-AI/agent-bridge-public/issues/507) documented a chain of three bugs in the daily-backup system that, together, fill the host disk with orphaned `*.tgz.tmp.*` files (~1.9 GB each), corrupt `~/.claude.json`, and render every `claude -p` subagent inoperable. The same upgrade also addresses two adjacent problems Sean surfaced in the same diagnosis pass: `state/tasks.db` was being bundled into every daily tarball as a raw, ~uncompressible binary (so 30-day retention multiplied it ~30× with near-zero dedup), and `backups/upgrade-*/` snapshots had no prune logic at all.
+Issue [#507](https://github.com/seanssoh/agent-bridge-public/issues/507) documented a chain of three bugs in the daily-backup system that, together, fill the host disk with orphaned `*.tgz.tmp.*` files (~1.9 GB each), corrupt `~/.claude.json`, and render every `claude -p` subagent inoperable. The same upgrade also addresses two adjacent problems Sean surfaced in the same diagnosis pass: `state/tasks.db` was being bundled into every daily tarball as a raw, ~uncompressible binary (so 30-day retention multiplied it ~30× with near-zero dedup), and `backups/upgrade-*/` snapshots had no prune logic at all.
 
 v0.7.2 ships:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agent Bridge
 
-[![CI](https://github.com/SYRS-AI/agent-bridge-public/actions/workflows/ci.yml/badge.svg)](https://github.com/SYRS-AI/agent-bridge-public/actions/workflows/ci.yml)
+[![CI](https://github.com/seanssoh/agent-bridge-public/actions/workflows/ci.yml/badge.svg)](https://github.com/seanssoh/agent-bridge-public/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 
 **AI 에이전트 팀을 만들어서 회사 업무를 자동화하세요.**
@@ -10,11 +10,11 @@ Agent Bridge는 Claude Code와 Codex 같은 AI 코딩 에이전트를 "직원"�
 > 5명이 할 일을 에이전트 20명이 대신합니다.
 > 설정부터 유지보수까지 전부 자연어로.
 
-**Current version**: v0.14.5-beta5 (2026-05-23) — fresh-install bug-fix wave (13 issues), on top of v0.14.5-beta4's A2A cross-bridge task handoff. The v0.14.5 line is an ongoing prerelease series; there is no separate stable tag, so treat the latest `v0.14.5-betaN` as current.
-- Recommended upgrade target. The v0.14.x line rolled up v0.14.0's platform discriminator, the #946 daemon-hang 5-layer root-cause fix, the footgun #11 (`read_comsub` / heredoc-stdin) CI ratchet + helper extraction, the Teams plugin file-attachment work, agent-lifecycle cleanup, and the Linux-specific layout-resolver / `ARG_MAX` regressions found in OrbStack VM E2E.
-- v0.7.x → v0.14.x leap path: **direct `agent-bridge upgrade --apply` to the latest `v0.14.5-betaN`** is the current recommended path — the v0.13.7-v0.13.10 cycle fixed the Bash 5.3.9 heredoc-stdin deadlock chain by extracting leap-path bodies to `lib/upgrade-helpers/`, so the leap is single-atomic from any v0.7.x/v0.8.x/v0.9.x/v0.10.x/v0.11.x/v0.12.x/v0.13.x source. v0.13.10 is the minimum-safe fallback if you're pinned below v0.14.x or troubleshooting an in-flight leap. See [OPERATIONS.md §"Upgrade"](./OPERATIONS.md#upgrade) for recipe + follow-up notes.
+**Current version**: v0.15.0 (2026-05-31) — the first **stable** tag on the 0.15.0 line. Headline: A2A cross-bridge self-heal (peer/own Tailscale IP churn no longer needs a human), handoffd receiver supervision (liveness probe + auto-restart + status alarm), the `agb a2a setup` wizard (P1 skeleton), and the full 0.15.0 fresh-install / upgrade OOTB-acceptance + iso-v2 hardening campaign promoted from `v0.15.0-rc1`. See [CHANGELOG.md](./CHANGELOG.md#0150--2026-05-31) for the full list.
+- **Recommended upgrade target.** `v0.15.0` supersedes the `v0.15.0-rc1` / `v0.15.0-betaN` / `v0.14.5-betaN` prereleases — treat the latest stable tag as current.
+- v0.7.x → v0.15.0 leap path: **direct `agent-bridge upgrade --apply` to `v0.15.0`** is the current recommended path — the v0.13.7-v0.13.10 cycle fixed the Bash 5.3.9 heredoc-stdin deadlock chain by extracting leap-path bodies to `lib/upgrade-helpers/`, so the leap is single-atomic from any v0.7.x/v0.8.x/v0.9.x/v0.10.x/v0.11.x/v0.12.x/v0.13.x/v0.14.x source. v0.13.10 is the minimum-safe fallback if you're pinned below v0.14.x or troubleshooting an in-flight leap. See [OPERATIONS.md §"Upgrade"](./OPERATIONS.md#upgrade) for recipe + follow-up notes.
 - macOS: works in shared-mode (default). Linux-user isolation is Linux-only — v0.14.0's platform discriminator + v0.14.1's primitives-readiness check make the gate explicit (`BRIDGE_ISOLATION_REQUIRED=auto|yes|no`).
-- Stabilization roadmap: [`docs/stabilization-plan-2026-05-15.md`](./docs/stabilization-plan-2026-05-15.md). the v0.14.x line cleared S0–S3 + S5 Track A + parts of S7 (footgun #11 ratchet, daemon-hang hardening); S4 (Bash 3.2 cleanup), S5 B/C/D, S6, S8–S10 remain.
+- Stabilization roadmap: [`docs/stabilization-plan-2026-05-15.md`](./docs/stabilization-plan-2026-05-15.md). the 0.14.x/0.15.0 line cleared S0–S3 + S5 Track A + parts of S7 (footgun #11 ratchet, daemon-hang hardening); S4 (Bash 3.2 cleanup), S5 B/C/D, S6, S8–S10 remain.
 
 ---
 
@@ -141,7 +141,7 @@ claude
 Claude Code가 열리면 이렇게 말합니다:
 
 ```text
-https://raw.githubusercontent.com/SYRS-AI/agent-bridge-public/main/README.md 를 읽고 Agent Bridge를 설치해줘.
+https://raw.githubusercontent.com/seanssoh/agent-bridge-public/main/README.md 를 읽고 Agent Bridge를 설치해줘.
 CLAUDE_INSTALLER_STEPS 블록을 찾아서 그 단계만 그대로 실행해.
 저장소 구조를 추측해서 설치하지 말고, README에 설치 단계가 없다고 판단하지 마.
 ```
@@ -164,7 +164,7 @@ If you think this README has no concrete install steps, stop and reread this `CL
    Keep the source checkout hidden at `~/.agent-bridge-source`. If an older visible checkout exists at `~/agent-bridge-public`, move it automatically only when it is clean and points to this public repository. If you intentionally keep the source checkout elsewhere, such as `~/Projects/agent-bridge-public`, set `AGENT_BRIDGE_SOURCE_DIR` or pass `agent-bridge upgrade --source /path/to/agent-bridge-public` when upgrading from the live install.
 
    ```bash
-   REPO_URL="https://github.com/SYRS-AI/agent-bridge-public"
+   REPO_URL="https://github.com/seanssoh/agent-bridge-public"
    SOURCE_DIR="${AGENT_BRIDGE_SOURCE_DIR:-$HOME/.agent-bridge-source}"
    LEGACY_SOURCE_DIR="$HOME/agent-bridge-public"
 
@@ -175,7 +175,11 @@ If you think this README has no concrete install steps, stop and reread this `CL
 
    if [ ! -d "$SOURCE_DIR/.git" ] && [ -d "$LEGACY_SOURCE_DIR/.git" ]; then
      legacy_origin="$(git -C "$LEGACY_SOURCE_DIR" remote get-url origin 2>/dev/null || true)"
-     if printf '%s\n' "$legacy_origin" | grep -q 'SYRS-AI/agent-bridge-public'; then
+     # Match BOTH the historical `SYRS-AI/...` origin (existing checkouts still
+     # point there after the repo transfer) and the current `seanssoh/...` so
+     # the relocate works either way. Do NOT narrow this to seanssoh-only — that
+     # would skip migrating the very SYRS-AI checkouts this transition targets.
+     if printf '%s\n' "$legacy_origin" | grep -qE '(SYRS-AI|seanssoh)/agent-bridge-public'; then
        if git -C "$LEGACY_SOURCE_DIR" diff --quiet && git -C "$LEGACY_SOURCE_DIR" diff --cached --quiet; then
          mv "$LEGACY_SOURCE_DIR" "$SOURCE_DIR"
        else
@@ -695,7 +699,7 @@ Claude Code가 띄운 MCP 서버는 tmux 세션 종료 후에도 orphan으로 �
 
 `--apply` 는 atomic 명령이다. daemon stop → 새 source 복사 → daemon restart → 영향받는 agent 재기동 까지 한 번에. 절대 `daemon stop` 을 분리 실행하지 말 것 (#314, #315).
 
-최신 `v0.14.5-betaN` 이 현재 권장 target 이다. v0.7.x / v0.8.x / v0.9.x / v0.10.x / v0.11.x / v0.12.x / v0.13.x 어디서든 단일 `upgrade --apply` 한 번으로 최신 betaN 까지 올라간다 (v0.13.7-v0.13.9 가 Bash 5.3.9 heredoc-chain 을 풀어놨기 때문에 중간 hop 불필요).
+`v0.15.0` (stable) 이 현재 권장 target 이다. v0.7.x / v0.8.x / v0.9.x / v0.10.x / v0.11.x / v0.12.x / v0.13.x / v0.14.x 어디서든 단일 `upgrade --apply` 한 번으로 `v0.15.0` 까지 올라간다 (v0.13.7-v0.13.9 가 Bash 5.3.9 heredoc-chain 을 풀어놨기 때문에 중간 hop 불필요).
 
 자세한 release-specific 절차 + troubleshooting 은:
 
@@ -712,7 +716,7 @@ queue task 또는 외부 채널로 그쪽 admin 한테 그대로 보내면 됨 (
 ````markdown
 # [upgrade-action] agent-bridge upgrade
 
-이 host 를 현재 권장 target (v0.14.1 이상) 까지 올린다. 끝나면 done note 한 줄 요약으로 보고.
+이 host 를 현재 권장 target (`v0.15.0` 이상) 까지 올린다. 끝나면 done note 한 줄 요약으로 보고.
 
 ## 절차
 
@@ -743,9 +747,9 @@ final_version=<version>, daemon=<healthy|issue>, operator-actions=<summary|none>
 절대 `daemon stop` 분리 실행 금지 (#314, #315). `upgrade --apply` 가 atomic.
 
 ## Reference
-- 표준 절차: [`UPGRADING.md`](https://github.com/SYRS-AI/agent-bridge-public/blob/main/UPGRADING.md)
-- Release section: [`OPERATIONS.md §"Upgrade"`](https://github.com/SYRS-AI/agent-bridge-public/blob/main/OPERATIONS.md#upgrade)
-- Latest release: https://github.com/SYRS-AI/agent-bridge-public/releases/latest
+- 표준 절차: [`UPGRADING.md`](https://github.com/seanssoh/agent-bridge-public/blob/main/UPGRADING.md)
+- Release section: [`OPERATIONS.md §"Upgrade"`](https://github.com/seanssoh/agent-bridge-public/blob/main/OPERATIONS.md#upgrade)
+- Latest release: https://github.com/seanssoh/agent-bridge-public/releases/latest
 ````
 
 ---

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,7 +39,7 @@ stable releases unless they explicitly opt into `--channel dev`.
    ```
 
 3. Commit and push private `main`.
-4. Mirror the public-safe commit to `SYRS-AI/agent-bridge-public`.
+4. Mirror the public-safe commit to `seanssoh/agent-bridge-public`.
 5. Tag the public release:
 
    ```bash

--- a/bridge-release.py
+++ b/bridge-release.py
@@ -413,7 +413,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     def add_common(cmd: argparse.ArgumentParser) -> None:
-        cmd.add_argument("--repo", default=os.environ.get("BRIDGE_RELEASE_REPO", "SYRS-AI/agent-bridge-public"))
+        cmd.add_argument("--repo", default=os.environ.get("BRIDGE_RELEASE_REPO", "seanssoh/agent-bridge-public"))
         cmd.add_argument("--installed-version", default=os.environ.get("BRIDGE_RELEASE_INSTALLED_VERSION", ""))
         cmd.add_argument("--api-url", default=os.environ.get("BRIDGE_RELEASE_API_URL", ""))
         cmd.add_argument("--mock-json-file", default="")

--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -1204,7 +1204,7 @@ APPLY_JSON='{}'
 if ! git -C "$SOURCE_ROOT" rev-parse --show-toplevel >/dev/null 2>&1; then
   if [[ $SOURCE_EXPLICIT -eq 0 && "$SOURCE_ROOT" == "$TARGET_ROOT" ]]; then
     bridge_die "live install은 git repo가 아니고 source checkout 기록도 없습니다: $TARGET_ROOT
-복구: git clone https://github.com/SYRS-AI/agent-bridge-public \"\$HOME/.agent-bridge-source\" 후 다시 실행하거나,
+복구: git clone https://github.com/seanssoh/agent-bridge-public \"\$HOME/.agent-bridge-source\" 후 다시 실행하거나,
 AGENT_BRIDGE_SOURCE_DIR를 설정하거나,
 명시적으로 실행하세요: $TARGET_ROOT/agent-bridge upgrade --source /path/to/agent-bridge-public"
   fi

--- a/bridge-upstream.sh
+++ b/bridge-upstream.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/bridge-lib.sh"
 
-UPSTREAM_REPO="${BRIDGE_UPSTREAM_REPO:-SYRS-AI/agent-bridge-public}"
+UPSTREAM_REPO="${BRIDGE_UPSTREAM_REPO:-seanssoh/agent-bridge-public}"
 UPSTREAM_CANDIDATE_DIR="${BRIDGE_UPSTREAM_CANDIDATE_DIR:-$BRIDGE_SHARED_DIR/upstream-candidates}"
 
 usage() {

--- a/docs/agent-runtime/admin-protocol.md
+++ b/docs/agent-runtime/admin-protocol.md
@@ -42,7 +42,7 @@ Admin's queue grows monotonically when alerts that admin cannot resolve land in 
 
 For the inverse case — admin should *not* push outbound nudges/maintenance to dynamic agents whose operators are already at the agent's TUI — see the same family of issues #304 and #343.
 
-[#303]: https://github.com/SYRS-AI/agent-bridge-public/issues/303
+[#303]: https://github.com/seanssoh/agent-bridge-public/issues/303
 
 ## Admin First-Run Onboarding Defaults
 

--- a/docs/agent-runtime/memory-daily-harvest.md
+++ b/docs/agent-runtime/memory-daily-harvest.md
@@ -417,7 +417,7 @@ invocation.
 
 ## 12. Static-only contract
 
-Per [issue #376](https://github.com/SYRS-AI/agent-bridge-public/issues/376),
+Per [issue #376](https://github.com/seanssoh/agent-bridge-public/issues/376),
 the `memory-daily-<agent>` cron + `memory-daily-harvest.sh` harvester pipeline
 is intentionally scoped to **static** agents only.
 

--- a/docs/isolation-migration-guide.md
+++ b/docs/isolation-migration-guide.md
@@ -641,7 +641,7 @@ keep a notebook, and treat each agent as an independent unit of work.
   across two agents (the cross-agent checks in §1 and §2.2 require
   two isolated agents side by side). Note in the resulting report that
   §3 (audit attribution) is expected to partially fail until
-  [#103](https://github.com/SYRS-AI/agent-bridge-public/issues/103)
+  [#103](https://github.com/seanssoh/agent-bridge-public/issues/103)
   lands.
 - **Admin last.** Once the rest of the fleet is clean, migrate the
   admin agent using the same steps. Keep an alternate terminal ready
@@ -656,6 +656,6 @@ keep a notebook, and treat each agent as an independent unit of work.
 - Migration helper implementation: [`lib/bridge-migration.sh`](../lib/bridge-migration.sh)
 - Validation checklist: [isolation-acceptance-runbook.md](./isolation-acceptance-runbook.md)
 - Scope and macOS exclusion: [platform-support.md](./platform-support.md)
-- Runtime UID-switch gap: [#103](https://github.com/SYRS-AI/agent-bridge-public/issues/103)
-- Migration helper CLI issue: [#85](https://github.com/SYRS-AI/agent-bridge-public/issues/85)
-- Parent isolation issue: [#68](https://github.com/SYRS-AI/agent-bridge-public/issues/68)
+- Runtime UID-switch gap: [#103](https://github.com/seanssoh/agent-bridge-public/issues/103)
+- Migration helper CLI issue: [#85](https://github.com/seanssoh/agent-bridge-public/issues/85)
+- Parent isolation issue: [#68](https://github.com/seanssoh/agent-bridge-public/issues/68)

--- a/docs/live-feature-mining.md
+++ b/docs/live-feature-mining.md
@@ -8,7 +8,7 @@ The goal is not to copy private runtime files into the public repository.
 The goal is to extract the reusable product pattern, remove team-specific
 details, and implement coherent public features.
 
-Related meta issue: https://github.com/SYRS-AI/agent-bridge-public/issues/9
+Related meta issue: https://github.com/seanssoh/agent-bridge-public/issues/9
 
 ## Rules
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -89,8 +89,8 @@ system-wide daemon. Shipping a half-working macOS variant would create
 the illusion of isolation without the guarantees, which is strictly
 worse than documenting macOS as shared-mode-only.
 
-See [#68](https://github.com/SYRS-AI/agent-bridge-public/issues/68) for
-the full threat model and rationale, and [#85](https://github.com/SYRS-AI/agent-bridge-public/issues/85)
+See [#68](https://github.com/seanssoh/agent-bridge-public/issues/68) for
+the full threat model and rationale, and [#85](https://github.com/seanssoh/agent-bridge-public/issues/85)
 for the Linux-only migration helper.
 
 ## Recommendations

--- a/docs/plugin-authoring-iso-v2.md
+++ b/docs/plugin-authoring-iso-v2.md
@@ -318,7 +318,7 @@ For background, these Bridge-side closures are the symmetric fixes to what this 
 - `#1214` — Bridge's channel validator routes through the iso-side read fallback, no `sg` wrap needed (closed beta26)
 - `#1215` — Bridge creates plugin state dirs (`.teams/`, `.ms365/`) with `02770` mode so iso UID can write (closed beta26)
 
-If you observe a Bridge-side issue while authoring your plugin (env var that should propagate but doesn't, path your plugin can't traverse but should be able to), file at https://github.com/SYRS-AI/agent-bridge-public/issues so it can be addressed in a Bridge release.
+If you observe a Bridge-side issue while authoring your plugin (env var that should propagate but doesn't, path your plugin can't traverse but should be able to), file at https://github.com/seanssoh/agent-bridge-public/issues so it can be addressed in a Bridge release.
 
 ## 6. Minimum viable iso v2 plugin checklist
 
@@ -342,7 +342,7 @@ If your plugin passes this checklist, it should be safe to ship into a Bridge-ma
 - Bridge runtime layout: `ARCHITECTURE.md`
 - Live install behavior: `OPERATIONS.md`
 - Known live-session quirks: `KNOWN_ISSUES.md`
-- File issues: https://github.com/SYRS-AI/agent-bridge-public/issues
+- File issues: https://github.com/seanssoh/agent-bridge-public/issues
 
 ---
 

--- a/lib/bridge-layout-resolver.sh
+++ b/lib/bridge-layout-resolver.sh
@@ -194,13 +194,13 @@ bridge_layout_resolver_validate_env() {
       bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
   current_layout=${layout}
   remediation: run \`agent-bridge upgrade --apply\` to migrate, or roll back to v0.7.x.
-  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/seanssoh/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
       ;;
     *)
       bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
   current_layout=${layout}
   remediation: unset BRIDGE_LAYOUT or set BRIDGE_LAYOUT=v2 (only accepted value).
-  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/seanssoh/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
       ;;
   esac
 }
@@ -385,7 +385,7 @@ bridge_resolve_layout() {
   current_layout=${BRIDGE_LAYOUT}
   marker=${marker_path}
   remediation: run \`agent-bridge upgrade --apply\` to migrate, or roll back to v0.7.x.
-  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/seanssoh/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
       fi
     fi
     # Marker is on disk but failed validation — bridge_warn already fired
@@ -406,7 +406,7 @@ bridge_resolve_layout() {
     bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
   current_layout=markerless(existing-install)
   remediation: run \`agent-bridge upgrade --apply\` to migrate this install to v2, or roll back to v0.7.x.
-  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/seanssoh/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
   fi
 
   # Fresh install candidate. Pre-v0.8.0 this branch left BRIDGE_LAYOUT
@@ -439,7 +439,7 @@ bridge_resolve_layout() {
   bridge_die "Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
   current_layout=markerless(${BRIDGE_LAYOUT_SOURCE})
   remediation: run \`agent-bridge upgrade --apply\` to migrate this install to v2, or roll back to v0.7.x.
-  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/seanssoh/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details."
 }
 
 # ---------------------------------------------------------------------------

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1288,7 +1288,7 @@ bridge_load_roster() {
   : "${BRIDGE_RELEASE_CHECK_ENABLED:=1}"
   : "${BRIDGE_RELEASE_CHECK_INTERVAL_SECONDS:=86400}"
   : "${BRIDGE_RELEASE_CHECK_STATE_FILE:=$BRIDGE_STATE_DIR/release-check/monitor-state.json}"
-  : "${BRIDGE_RELEASE_REPO:=SYRS-AI/agent-bridge-public}"
+  : "${BRIDGE_RELEASE_REPO:=seanssoh/agent-bridge-public}"
   : "${BRIDGE_STALL_SCAN_ENABLED:=1}"
   : "${BRIDGE_STALL_SCAN_INTERVAL_SECONDS:=30}"
   : "${BRIDGE_STALL_CAPTURE_LINES:=120}"

--- a/scripts/install-handoffd-systemd.sh
+++ b/scripts/install-handoffd-systemd.sh
@@ -130,7 +130,7 @@ CONFIG_PATH="$BRIDGE_HOME_TARGET/handoff.local.json"
 UNIT_CONTENT="$(cat <<EOF
 [Unit]
 Description=Agent Bridge A2A handoff receiver
-Documentation=https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/a2a-cross-bridge.md
+Documentation=https://github.com/seanssoh/agent-bridge-public/blob/main/docs/a2a-cross-bridge.md
 After=network-online.target tailscaled.service
 Wants=network-online.target
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -10685,12 +10685,12 @@ cat >"$FAKE_RELEASE_JSON" <<'EOF'
 {
   "tag_name": "v9.9.9",
   "name": "Agent Bridge v9.9.9",
-  "html_url": "https://github.com/SYRS-AI/agent-bridge-public/releases/tag/v9.9.9",
+  "html_url": "https://github.com/seanssoh/agent-bridge-public/releases/tag/v9.9.9",
   "published_at": "2026-04-10T14:18:41Z",
   "body": "## Highlights\n- Stable release smoke fixture\n- Release notes carried into daemon task body"
 }
 EOF
-RELEASE_MONITOR_FIRST="$(python3 "$REPO_ROOT/bridge-release.py" monitor --repo SYRS-AI/agent-bridge-public --installed-version "$EXPECTED_VERSION" --state-file "$FAKE_RELEASE_STATE" --mock-json-file "$FAKE_RELEASE_JSON" --json)"
+RELEASE_MONITOR_FIRST="$(python3 "$REPO_ROOT/bridge-release.py" monitor --repo seanssoh/agent-bridge-public --installed-version "$EXPECTED_VERSION" --state-file "$FAKE_RELEASE_STATE" --mock-json-file "$FAKE_RELEASE_JSON" --json)"
 python3 - "$RELEASE_MONITOR_FIRST" <<'PY'
 import json, sys
 payload = json.loads(sys.argv[1])
@@ -10698,7 +10698,7 @@ alerts = payload["alerts"]
 assert len(alerts) == 1, alerts
 assert alerts[0]["latest_tag"] == "v9.9.9", alerts
 PY
-RELEASE_MONITOR_SECOND="$(python3 "$REPO_ROOT/bridge-release.py" monitor --repo SYRS-AI/agent-bridge-public --installed-version "$EXPECTED_VERSION" --state-file "$FAKE_RELEASE_STATE" --mock-json-file "$FAKE_RELEASE_JSON" --json)"
+RELEASE_MONITOR_SECOND="$(python3 "$REPO_ROOT/bridge-release.py" monitor --repo seanssoh/agent-bridge-public --installed-version "$EXPECTED_VERSION" --state-file "$FAKE_RELEASE_STATE" --mock-json-file "$FAKE_RELEASE_JSON" --json)"
 python3 - "$RELEASE_MONITOR_SECOND" <<'PY'
 import json, sys
 payload = json.loads(sys.argv[1])
@@ -10708,7 +10708,7 @@ BRIDGE_RELEASE_CHECK_ENABLED=1 \
 BRIDGE_RELEASE_CHECK_INTERVAL_SECONDS=0 \
 BRIDGE_RELEASE_CHECK_STATE_FILE="$FAKE_RELEASE_DAEMON_STATE" \
 BRIDGE_RELEASE_MOCK_JSON_FILE="$FAKE_RELEASE_JSON" \
-BRIDGE_RELEASE_REPO="SYRS-AI/agent-bridge-public" \
+BRIDGE_RELEASE_REPO="seanssoh/agent-bridge-public" \
 BRIDGE_HOME="$BRIDGE_HOME" \
 BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
 BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
@@ -10729,7 +10729,7 @@ BRIDGE_RELEASE_CHECK_ENABLED=1 \
 BRIDGE_RELEASE_CHECK_INTERVAL_SECONDS=0 \
 BRIDGE_RELEASE_CHECK_STATE_FILE="$FAKE_RELEASE_DAEMON_STATE" \
 BRIDGE_RELEASE_MOCK_JSON_FILE="$FAKE_RELEASE_JSON" \
-BRIDGE_RELEASE_REPO="SYRS-AI/agent-bridge-public" \
+BRIDGE_RELEASE_REPO="seanssoh/agent-bridge-public" \
 BRIDGE_HOME="$BRIDGE_HOME" \
 BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
 BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
@@ -10743,7 +10743,7 @@ BRIDGE_RELEASE_CHECK_ENABLED=1 \
 BRIDGE_RELEASE_CHECK_INTERVAL_SECONDS=0 \
 BRIDGE_RELEASE_CHECK_STATE_FILE="$FAKE_RELEASE_DAEMON_STATE" \
 BRIDGE_RELEASE_MOCK_JSON_FILE="$FAKE_RELEASE_JSON" \
-BRIDGE_RELEASE_REPO="SYRS-AI/agent-bridge-public" \
+BRIDGE_RELEASE_REPO="seanssoh/agent-bridge-public" \
 BRIDGE_HOME="$BRIDGE_HOME" \
 BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
 BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \

--- a/scripts/smoke/watchdog-silence-stderr-capture.sh
+++ b/scripts/smoke/watchdog-silence-stderr-capture.sh
@@ -170,7 +170,7 @@ cat >&2 <<'DIE'
 Agent Bridge v0.8.0 requires isolation-v2 (POSIX group + setgid).
   current_layout=markerless(existing-install)
   remediation: run `agent-bridge upgrade --apply` to migrate this install to v2, or roll back to v0.7.x.
-  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/SYRS-AI/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details.
+  background: ACL-based isolation (v1) was removed in v0.8.0. See https://github.com/seanssoh/agent-bridge-public/blob/main/docs/isolation-migration-guide.md for details.
 DIE
 exit 1
 FAKE


### PR DESCRIPTION
## Docs: v0.15.0 stable version references + public repo URL migration

Follow-up to the v0.15.0 stable release (#1419, tag `v0.15.0`). Two coordinated doc updates (operator-requested: "리드미 등도 다 0.15.0 기준으로" + "버전 0.15.0 + URL도 seanssoh로 전환"). **Docs + URL strings only — no product behavior change.**

### Version banners → v0.15.0 stable
- README "Current version" headline + recommended-upgrade-target block (EN + the Korean upgrade section + the patch-prompt template).
- OPERATIONS.md "Current target" / "Current recommendation" banners.
- Historical `added vX.Y.Z` / `closed by v0.7.2` / `v0.8.0 hard-cut` notes in ARCHITECTURE/KNOWN_ISSUES/AGENTS left untouched (accurate history).

### Public repo URL migration `SYRS-AI` → `seanssoh`
Canonical public repo moved to `seanssoh/agent-bridge-public`. Swapped forward-facing URLs (README CI badge / raw-install / clone `REPO_URL` / UPGRADING+OPERATIONS+releases links, OPERATIONS, RELEASE, docs/*, the isolation-migration-guide links in `lib/bridge-layout-resolver.sh` + matching smoke fixture, `install-handoffd-systemd` Documentation=, the `bridge-upgrade.sh` recovery hint) and the release-monitor + upstream-issue **repo defaults** (`bridge-release.py`, `lib/bridge-state.sh` `BRIDGE_RELEASE_REPO`, `bridge-upstream.sh` `UPSTREAM_REPO`) **with their `scripts/smoke-test.sh` release-monitor fixtures changed in lockstep**.

**Deliberately preserved** (NOT swapped):
- The README legacy-origin migration **detector** now matches **both** `SYRS-AI` and `seanssoh` — existing checkouts still point at SYRS-AI after the transfer, so narrowing it to seanssoh-only would skip relocating the very installs this transition targets.
- `LICENSE` copyright holder (legal statement, not a URL — flagging for your call if the entity is also renaming).
- GitHub-account / cross-fork-workflow history in skills + shipped CHANGELOG entries, and the `SYRS-AI/cosmax-crm-cli` link (a different repo).

### Verification
`bash -n` + `py_compile` clean on every touched code file; the `watchdog-silence-stderr-capture` smoke (which asserts the isolation-guide string I changed in `lib/bridge-layout-resolver.sh`) passes; `git grep github.com/SYRS-AI/agent-bridge-public` → none remain. Touches the upgrade path + queue/state defaults + release-monitor (HIGH-RISK per CLAUDE.md) → codex pair-review requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
