### PR TITLE
fix(cron): text crons 100% fail on fresh 0.15.0 macOS non-iso host (umask routing + file-less config-dir)

### DIFF
--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -1697,13 +1697,30 @@ def claude_config_dir_for_request(request: dict[str, Any]) -> Path | None:
     if from_launch_env is not None:
         return from_launch_env
 
-    for candidate in _shared_agent_claude_config_candidates(agent):
+    candidates = _shared_agent_claude_config_candidates(agent)
+    # Prefer a candidate that carries an explicit file-based credential: the
+    # Linux / file-cred layout where each agent has its own ``.credentials.json``
+    # and we must pick the dir that actually holds it.
+    for candidate in candidates:
         if (candidate / ".credentials.json").is_file():
             return candidate
 
     isolated_user = _isolated_user_for_agent(agent)
     if isolated_user is not None:
         return Path(isolated_user.pw_dir) / ".claude"
+
+    # No file-based credential anywhere. This is normal on hosts where Claude
+    # Code does not persist a ``.credentials.json`` at all — most notably macOS,
+    # where the claude.ai OAuth token lives in the login Keychain, and any host
+    # authed via ANTHROPIC_API_KEY / apiKeyHelper. Fall back to the canonical
+    # per-agent config dir the interactive launcher uses
+    # (``bridge_run_agent_claude_root`` => ``<agent-home>/.claude``); auth is
+    # then resolved by Claude itself at launch. Without this fallback every cron
+    # run on such a host aborts with "Claude config dir not found" even though
+    # the agent's interactive sessions authenticate fine.
+    for candidate in candidates:
+        if candidate.is_dir():
+            return candidate
     return None
 
 
@@ -1777,10 +1794,19 @@ def apply_claude_agent_env(env: dict[str, str], request: dict[str, Any], request
         env["CRON_REQUEST_DIR"] = str(request_file.parent)
 
     sudo_user = claude_run_as_user_for_request(request, config_dir)
-    if sudo_user is None and not os.access(config_dir / ".credentials.json", os.R_OK):
+    # File-based ``.credentials.json`` is only one of Claude Code's auth
+    # backends. macOS keeps the claude.ai OAuth token in the login Keychain and
+    # writes no cred file; ANTHROPIC_API_KEY / apiKeyHelper are also valid. Only
+    # assert *file* readability when the file actually exists — that preserves
+    # the original guard's purpose (catch a per-agent cred file the cron runner
+    # cannot read, e.g. an iso-perms regression) without rejecting hosts that
+    # legitimately have no cred file. When absent, defer to Claude's own auth
+    # resolution rather than abort with a misleading "not readable" error.
+    cred_file = config_dir / ".credentials.json"
+    if sudo_user is None and cred_file.exists() and not os.access(cred_file, os.R_OK):
         raise RuntimeError(
-            f"Claude credentials for target agent {agent} are not readable by the cron runner: "
-            f"{config_dir / '.credentials.json'}"
+            f"Claude credentials file for target agent {agent} exists but is not readable "
+            f"by the cron runner: {cred_file}"
         )
     return sudo_user
 

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -2556,7 +2556,34 @@ def cmd_run(args: argparse.Namespace) -> int:
         # The corrupted-JSON / non-dict / payload_kind cross-check
         # path now runs inside the flock so a body swap between
         # validate and exec must contend with the lock.
-        return cmd_run_shell(request_file, args)
+        #
+        # Controller-private perms (run_dir 0700 + request.json 0600) are
+        # NECESSARY for a shell payload but not SUFFICIENT to prove the payload
+        # IS shell. `shell_artifact_route` classifies by perms alone, before
+        # reading the body. On hosts where the daemon runs under umask 077
+        # (bridge-lib.sh sets it process-wide; non-iso single-user macOS never
+        # reaches the `bridge_cron_run_dir_grant_isolation` group-widening,
+        # which is gated to linux-user-iso targets) EVERY run dir lands
+        # 0700/0600 — including text/claude crons. Routing those to the shell
+        # handler makes `is_shell_request_payload` fail under the flock and
+        # aborts the run as `request_artifact_tampered`, silently breaking 100%
+        # of text crons. Peek the body here (safe: an owner-private dir is
+        # controller-written, never attacker-writable) and only commit to the
+        # shell path when the payload is actually shell. A non-shell payload in
+        # a private dir is benign — fall through to the text path below, which
+        # re-reads + re-validates under its own untrusted-body model and still
+        # rejects any cross-route shell payload. A corrupted/non-dict body also
+        # stays on the shell path so its existing flocked error handling runs.
+        try:
+            shell_peek: Any = read_json(request_file)
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+            shell_peek = None
+        benign_text_in_private_dir = (
+            isinstance(shell_peek, dict)
+            and not is_shell_request_payload(shell_peek)
+        )
+        if not benign_text_in_private_dir:
+            return cmd_run_shell(request_file, args)
 
     # Non-shell route: legacy text path. The artifacts are not
     # controller-private here, so we treat the body as untrusted —

--- a/bridge-cron-runner.py
+++ b/bridge-cron-runner.py
@@ -1719,7 +1719,7 @@ def claude_config_dir_for_request(request: dict[str, Any]) -> Path | None:
     # run on such a host aborts with "Claude config dir not found" even though
     # the agent's interactive sessions authenticate fine.
     for candidate in candidates:
-        if candidate.is_dir():
+        if candidate.is_dir():  # noqa: raw-pathlib-controller-only — controller-side shared-mode fallback; iso agents resolve via pw_dir above and never reach this
             return candidate
     return None
 
@@ -1803,7 +1803,7 @@ def apply_claude_agent_env(env: dict[str, str], request: dict[str, Any], request
     # legitimately have no cred file. When absent, defer to Claude's own auth
     # resolution rather than abort with a misleading "not readable" error.
     cred_file = config_dir / ".credentials.json"
-    if sudo_user is None and cred_file.exists() and not os.access(cred_file, os.R_OK):
+    if sudo_user is None and cred_file.exists() and not os.access(cred_file, os.R_OK):  # noqa: raw-pathlib-controller-only — controller-side cred-file probe; only runs when sudo_user is None (no iso UID drop)
         raise RuntimeError(
             f"Claude credentials file for target agent {agent} exists but is not readable "
             f"by the cron runner: {cred_file}"

--- a/scripts/smoke/cron-shell-runner.sh
+++ b/scripts/smoke/cron-shell-runner.sh
@@ -117,6 +117,57 @@ PY
   printf '%s/request.json' "$run_dir"
 }
 
+# Build a TEXT/claude cron request in an owner-private run dir (0700 dir /
+# 0600 request.json) — the exact artifact shape a non-iso single-user host
+# produces under `umask 077`, which `shell_artifact_route` classifies as the
+# controller-private "shell" route by permissions alone (#1421). Only the
+# 5 path keys the text path dereferences before its --dry-run early return
+# are required; no shell payload marker is set so the body is a genuine text
+# cron.
+write_text_request() {
+  local run_id="$1"
+  local job_id="$2"
+  local run_dir="$BRIDGE_CRON_STATE_DIR/runs/$run_id"
+  mkdir -p "$run_dir"
+  chmod 0700 "$run_dir"
+  # Built via `python3 -c` (argv-passed), NOT a `<<PY` heredoc-stdin: the latter
+  # would register a new unbaselined site against scripts/lint-heredoc-ban.sh
+  # (footgun #11 ratchet). Argv keeps the request-builder off that baseline.
+  python3 -c '
+import json
+import os
+import sys
+
+request_file, run_id, job_id = sys.argv[1:]
+run_dir = os.path.dirname(request_file)
+payload = {
+    "run_id": run_id,
+    "job_id": job_id,
+    "job_name": job_id,
+    "family": "smoke",
+    "source_agent": "smoke-agent",
+    "target_agent": "smoke-target",
+    "target_engine": "claude",
+    "payload_kind": "text",
+    "target_workdir": run_dir,
+    "slot": "manual",
+    "dispatch_task_id": 0,
+    "created_at": "2026-05-06T00:00:00+00:00",
+    "payload_file": os.path.join(run_dir, "payload.md"),
+    "result_file": os.path.join(run_dir, "result.json"),
+    "status_file": os.path.join(run_dir, "status.json"),
+    "stdout_log": os.path.join(run_dir, "stdout.log"),
+    "stderr_log": os.path.join(run_dir, "stderr.log"),
+    "payload": {"kind": "text", "prompt": "smoke text cron"},
+}
+with open(request_file, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh, ensure_ascii=True, indent=2)
+    fh.write("\n")
+os.chmod(request_file, 0o600)
+' "$run_dir/request.json" "$run_id" "$job_id"
+  printf '%s/request.json' "$run_dir"
+}
+
 json_field() {
   local file="$1"
   local expr="$2"
@@ -574,6 +625,56 @@ PY
   smoke_assert_contains "$(json_field "$status" runner_error)" "script_validation_failed:" "T39d env terminal runner_error"
 }
 
+smoke_t40_umask077_text_route_not_tampered() {
+  # Regression guard (#1421): under `umask 077` a non-iso single-user host
+  # creates EVERY cron run dir at 0700/0600 — the group-widening that would
+  # mark non-shell runs is iso-gated — so `shell_artifact_route` classifies a
+  # text cron as the controller-private "shell" route by permissions alone.
+  # `cmd_run` must peek the body and, finding no shell marker, route to the
+  # TEXT path. Pre-fix it handed the text body straight to `cmd_run_shell`,
+  # whose flocked validation rejected it as `request_artifact_tampered`,
+  # silently failing 100% of text crons. --dry-run discriminates cleanly: the
+  # text route prints `engine: claude`; a mis-route to shell prints
+  # `engine: shell` (cmd_run_shell's dry-run early-return precedes its tamper
+  # check, so asserting "status: dry_run" alone is NOT sufficient).
+  local request out rc
+  request="$(umask 077; write_text_request t40-text-run t40-text-job)"
+  rc=0
+  out="$(python3 "$SMOKE_REPO_ROOT/bridge-cron-runner.py" run --request-file "$request" --dry-run 2>&1)" || rc=$?
+  if [[ "$rc" -ne 0 ]]; then
+    smoke_fail "T40 text cron in owner-private (0700/0600) dir must route to text dry-run, rc=$rc: $out"
+  fi
+  case "$out" in
+    *request_artifact_tampered*)
+      smoke_fail "T40 text cron mis-routed to shell handler (request_artifact_tampered): $out" ;;
+    *"engine: shell"*)
+      smoke_fail "T40 text cron mis-routed to shell handler (engine: shell): $out" ;;
+  esac
+  case "$out" in
+    *"status: dry_run"*) : ;;
+    *) smoke_fail "T40 expected 'status: dry_run' from text route: $out" ;;
+  esac
+  case "$out" in
+    *"engine: claude"*) : ;;
+    *) smoke_fail "T40 expected 'engine: claude' (text route), got: $out" ;;
+  esac
+}
+
+smoke_t41_umask077_shell_route_preserved() {
+  # Companion to T40: the body-peek must NOT divert a genuine SHELL cron away
+  # from `cmd_run_shell`. A shell payload in the same owner-private (0700/0600)
+  # dir still routes to the shell handler and executes to success.
+  local script_path request status
+  script_path="$(make_script t41.sh '#!/usr/bin/env bash
+exit 0')"
+  request="$(umask 077; write_request t41-shell-run t41-shell-job "$script_path")"
+  if ! run_runner "$request" >/tmp/cron-shell-t41.out 2>&1; then
+    smoke_fail "T41 shell cron under umask 077 must still execute: $(cat /tmp/cron-shell-t41.out 2>/dev/null)"
+  fi
+  status="${request%/*}/status.json"
+  smoke_assert_eq "success" "$(json_field "$status" state)" "T41 shell route preserved under umask 077"
+}
+
 smoke_run "T30 schema + update preservation" smoke_t30_schema_and_update
 smoke_run "T35 argv injection rejection" smoke_t35_reject_argv_injection
 smoke_run "T31 UID-drop access contract" smoke_t31_uid_drop_access_contract
@@ -589,5 +690,7 @@ smoke_run "T39b invalid JSON tamper writes terminal status" smoke_t39b_invalid_j
 smoke_run "T39c update revalidates shell script" smoke_t39c_update_revalidates_shell_script
 smoke_run "T39d validation failure writes terminal status" smoke_t39d_validation_failure_terminal
 smoke_run "T39e corrupted controller-private JSON writes terminal status" smoke_t39e_corrupted_controller_private_json_terminal
+smoke_run "T40 umask-077 text cron routes to text path, not shell tamper (#1421)" smoke_t40_umask077_text_route_not_tampered
+smoke_run "T41 umask-077 shell cron still routes to shell handler (#1421)" smoke_t41_umask077_shell_route_preserved
 
 smoke_log "all cron shell runner checks passed"


### PR DESCRIPTION
## Summary

On a **fresh v0.15.0 install running on a non-isolated, single-user macOS host**, **100% of `payload.kind="text"` crons fail** and execute zero work. Two related defects in `bridge-cron-runner.py` stack on top of each other; fixing the first only reveals the second. Both are environment-exposure bugs (the assumptions hold on the Linux / file-credential lineage but not on macOS), not data issues.

Observed before the fix: every `state/cron/runs/*/result.json` = `status:error`, first `runner_error:request_artifact_tampered`, then (after commit 1) `Claude config dir not found for target agent`. Crons fire, dispatch, and the dispatch task closes "done", but the disposable child aborts → no cron work runs. It is silent (`delivery_intent=silent`), so liveness checks stay green while all automation is dead.

## Defect 1 — text crons mis-routed to the shell path under `umask 077` (commit 1)

`shell_artifact_route()` classifies a run as the controller-private **shell route by permissions alone**: `run_dir==0o700 AND request.json==0o600 → "shell"`. The daemon sources `bridge-lib.sh` which sets `umask 077` process-wide, and `bridge_cron_run_dir_grant_isolation()` — which would widen non-shell run dirs so they don't match the shell convention — is scope-gated to linux-user-iso targets only. So on a non-iso single-user host **every** run dir lands `0700/0600`, including text crons → all route to shell → `is_shell_request_payload()` fails under the flock → tamper abort.

**Fix:** in `cmd_run`, before committing the shell route to `cmd_run_shell`, peek the body. Owner-private perms are *necessary* for a shell payload but not *sufficient* to prove it *is* one. Only take the shell path when `is_shell_request_payload(peek)` is true; a benign non-shell payload in a private dir falls through to the text path (which re-reads + re-validates under its own lock and already rejects cross-route shell payloads). Corrupted / non-dict bodies stay on the shell path (its existing flocked error handling). No TOCTOU: both destinations re-read and re-check under their own lock before acting.

## Defect 2 — config-dir resolution requires a file credential that doesn't exist under Keychain/OAT auth (commit 2)

With routing fixed, every text cron then aborts with `Claude config dir not found for target agent: <agent>`. `claude_config_dir_for_request` used the presence of a per-agent `.credentials.json` as the **selector** for which `.claude` dir to use, and `apply_claude_agent_env` re-asserted that file is readable. But Claude Code does not always persist a file credential — on **macOS the claude.ai OAuth token lives in the login Keychain**, and `ANTHROPIC_API_KEY` / `apiKeyHelper` are also valid backends. So the resolver returned `None` for every agent even though their interactive sessions authenticate fine.

**Fix (platform-agnostic, not a macOS special-case):**
- *config-dir selection:* still prefer a candidate that carries an explicit file credential (Linux per-agent layout), but when none does, fall back to the first existing candidate `.claude` dir — the same canonical per-agent config dir the interactive launcher uses (`bridge_run_agent_claude_root` ⇒ `<agent-home>/.claude`). Auth then resolves at Claude launch (Keychain / API key / setup-token file).
- *readability guard:* only assert the credential file is readable **when it actually exists**. This preserves the original guard's purpose (catch an iso-perms regression on a real per-agent cred file) without rejecting hosts that legitimately have no cred file.

Explicit file-credential candidates still strictly win, so this does **not** bypass a file-based credential / rotation pool when one is present.

## Verification (on the affected host)

- `python3 -m py_compile bridge-cron-runner.py` → OK; `git diff --check` clean.
- Resolver: **21/21** enabled cron-target agents resolve a config dir (was 0/21).
- Deployed live (the runner is spawned fresh per cron fire → **no daemon restart needed**). Before: 100% failure. After: real scheduled crons `event-reminder-30min`=success, `librarian-watchdog`=ok, `cs-line-poll-5m`=completed, plus probes — all `engine=claude`, `child_exit_code=0`.
- Real-run probe confirmed from inside the cron child: `CLAUDE_CONFIG_DIR=<agent-home>/.claude` and `claude auth status` reports the expected credential source (when a per-agent file credential / setup token is installed, that file is used; explicit file creds are never bypassed by the fallback).

## Notes for reviewers (high-risk surface)

- Touches cron child routing + credential resolution — both security-sensitive. Each commit was independently pair-reviewed (`implement-ok`).
- iso (linux-user) hosts are unaffected: the iso-user branch still returns `<pw_dir>/.claude` before the new fallback, and the readability guard still hard-fails on an existing-but-unreadable per-agent cred file.
- Behavior change worth calling out: on a file-cred host where an agent legitimately has no creds, resolution no longer fast-fails at the resolver — it defers to Claude's own auth error at launch (`status=error` with Claude's message). Judged acceptable for stabilization.
- Per operator stabilization policy, this PR makes **no `VERSION` / `CHANGELOG` change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
