### PR TITLE
tmux: gate Claude mid-turn nudges on the busy banner (#1409)

### DIFF
--- a/lib/bridge-tmux.sh
+++ b/lib/bridge-tmux.sh
@@ -611,6 +611,107 @@ bridge_tmux_session_has_pending_input_from_text() {
   return 1
 }
 
+bridge_tmux_capture_has_working_banner() {
+  # Issue #1409: pure-text substring predicate. Claude Code (and codex)
+  # render a mid-turn status line while a turn is generating / a tool is
+  # running — the spinner "Working" / "Imagining…" banner with an "esc to
+  # interrupt" hint. This helper is the single owner of that literal
+  # banner-string match so the two callers below cannot drift.
+  #
+  # Scope note: this is a *substring* match over the whole input — it does
+  # NOT care where the banner appears. That is correct for the codex
+  # submit-landed path (bridge_tmux_codex_submit_landed), which feeds a
+  # tight post-C-m capture where the banner appearing at all means the
+  # submission was consumed. The claude busy-gate must NOT use this helper
+  # directly on a wide 40-line scrollback capture — a stale banner sitting
+  # in scrollback above a now-clean composer would false-positive busy and
+  # strand legitimate nudges forever (codex review #1409 r1). The claude
+  # gate uses bridge_tmux_claude_capture_is_midturn, which adds the
+  # region check on top of this primitive.
+  #
+  # Input: $1 an ANSI-preserving pane capture (or plain text — the match
+  # is on the literal banner words, which survive ANSI stripping).
+  local ansi_text="$1"
+  [[ -n "$ansi_text" ]] || return 1
+  if [[ "$ansi_text" == *"Working"* || "$ansi_text" == *"esc to interrupt"* ]]; then
+    return 0
+  fi
+  return 1
+}
+
+bridge_tmux_claude_line_is_composer_prompt() {
+  # Issue #1409: does this (whitespace-trimmed, ANSI-stripped) line look
+  # like Claude Code's interactive composer prompt? The composer renders in
+  # two forms across Claude versions / terminal widths:
+  #   - bare glyph at the line start:   `❯ ...`  or  `> ...`
+  #   - inside a box frame:             `│ > ... │`  (the rounded input box)
+  # Either form, appearing BELOW a spinner banner, means the turn has ended
+  # and the banner above is stale scrollback. Keep this narrow: a box line
+  # only counts when the glyph immediately follows the box border, so prose
+  # like "│ note │" or a quoted ">" deep in a response line does not match.
+  local trimmed="$1"
+  case "$trimmed" in
+    ❯*|'>'*) return 0 ;;            # bare composer glyph
+    '│ ❯'*|'│ >'*) return 0 ;;      # boxed composer glyph (│ + space + glyph)
+    '│❯'*|'│>'*) return 0 ;;        # boxed composer glyph, no inner space
+  esac
+  return 1
+}
+
+bridge_tmux_claude_capture_is_midturn() {
+  # Issue #1409 (codex review r1): region-aware mid-turn detector for the
+  # Claude busy-gate. Returns 0 (mid-turn → busy) only when the spinner /
+  # "esc to interrupt" banner is the LIVE tail status, not stale scrollback.
+  #
+  # Claude Code's TUI layout: while a turn is generating, the spinner +
+  # interrupt-hint banner is rendered at the bottom of the pane and there is
+  # no clean composer prompt below it. The moment the turn finishes, the
+  # composer prompt box (the `❯ ` / `> ` glyph line) is redrawn as the last
+  # interactive line and the banner scrolls up into history. So a banner is
+  # only "live" if NO clean composer prompt line appears after the last
+  # banner line in the capture. This mirrors the existing scrollback-safe
+  # "evaluate the LAST prompt-glyph line only" pattern in
+  # bridge_tmux_session_has_pending_input_from_text (issue #132).
+  #
+  # Input: $1 a plain-text (ANSI-stripped) pane capture. The spinner /
+  # interrupt banner and the `❯`/`>` composer glyph all survive ANSI
+  # stripping, so the region walk runs on plain text — no SGR parsing.
+  local recent="$1"
+  [[ -n "$recent" ]] || return 1
+  # Cheap reject: no banner anywhere → definitely not mid-turn.
+  bridge_tmux_capture_has_working_banner "$recent" || return 1
+
+  local line=""
+  local trimmed=""
+  # Default to not-mid-turn; flip to 0 on a banner line, back to 1 when a
+  # clean composer prompt is seen below it.
+  local result=1
+  # Issue #815 Wave A: stage the capture through a tempfile rather than a
+  # here-string to avoid the Bash 5.3.9 heredoc_write deadlock (footgun #11).
+  local _tmp
+  _tmp="$(mktemp)" || return 1
+  # shellcheck disable=SC2064
+  trap "rm -f -- '$_tmp'" RETURN
+  printf '%s\n' "$recent" > "$_tmp"
+  while IFS= read -r line; do
+    line="${line//$'\r'/}"
+    trimmed="${line#"${line%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    if [[ "$trimmed" == *"Working"* || "$trimmed" == *"esc to interrupt"* ]]; then
+      # A banner line — provisionally the live tail until a clean composer
+      # prompt is seen below it.
+      result=0
+    elif bridge_tmux_claude_line_is_composer_prompt "$trimmed"; then
+      # A clean Claude composer prompt line appears AFTER a banner → the
+      # banner is stale scrollback and the session is back at an idle
+      # prompt. Reset so only a later live banner can re-arm busy.
+      result=1
+    fi
+  done < "$_tmp"
+
+  return "$result"
+}
+
 bridge_tmux_session_has_pending_input() {
   local session="$1"
   local engine="$2"
@@ -658,6 +759,30 @@ bridge_tmux_session_inject_busy() {
 
   if bridge_tmux_session_has_pending_input "$session" "$engine"; then
     return 0
+  fi
+
+  # Issue #1409: Claude Code will not submit a new message while a turn is
+  # already generating / a tool is running — typing the nudge + C-m leaves
+  # the text stranded in the composer (logged `submit_lost_post_grace`).
+  # The composer-pending and recent-keypress gates above do NOT see that
+  # mid-turn state, so detect Claude's spinner banner ("Working" / "esc to
+  # interrupt") directly and report busy. The caller then spools the nudge
+  # for re-delivery once the session returns to a clean prompt. Codex's
+  # own submit path already handles its banner at submit-landed time, so
+  # this gate stays claude-specific.
+  #
+  # The detection is region-aware (codex review #1409 r1): a stale banner
+  # in scrollback above a now-clean composer must NOT report busy, or
+  # legitimate nudges would be spooled forever. bridge_tmux_claude_capture_
+  # is_midturn only treats the banner as live when no clean composer prompt
+  # appears below it. Use the same -J joined plain capture window (40 lines)
+  # the pending-input gate uses.
+  if [[ "$engine" == "claude" ]]; then
+    local recent=""
+    recent="$(bridge_capture_recent "$session" 40 join 2>/dev/null || true)"
+    if bridge_tmux_claude_capture_is_midturn "$recent"; then
+      return 0
+    fi
   fi
 
   local attached="0"
@@ -950,7 +1075,7 @@ bridge_tmux_codex_submit_landed() {
   [[ -n "$ansi_text" ]] || return 1
   [[ -n "$signature" ]] || return 1
 
-  if [[ "$ansi_text" == *"Working"* || "$ansi_text" == *"esc to interrupt"* ]]; then
+  if bridge_tmux_capture_has_working_banner "$ansi_text"; then
     return 0
   fi
 

--- a/scripts/smoke/1409-claude-midturn-busy-gate.sh
+++ b/scripts/smoke/1409-claude-midturn-busy-gate.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1409-claude-midturn-busy-gate.sh — Issue #1409.
+#
+# Upstream bug (filed by @Mejurix on v0.15.0-rc1): daemon inbox-nudges to a
+# BUSY (mid-turn) Claude agent land as text in the composer but never submit;
+# the operator must press Enter manually. Idle agents are unaffected. Audit:
+#   daemon session_nudge_dropped <admin> reason=submit_lost_post_grace idle_seconds=0
+#
+# Root cause: bridge_tmux_session_inject_busy (lib/bridge-tmux.sh) for
+# engine=claude only treated the session as busy when the composer already
+# held text (bridge_tmux_session_has_pending_input) OR a recent keypress was
+# detected. It did NOT detect Claude Code's mid-turn state — the spinner
+# banner ("Working" / "Imagining…") with the "esc to interrupt" hint. So
+# while Claude is generating, the gate reported NOT busy, the daemon typed
+# the nudge + C-m, and Claude Code dropped the mid-turn submit — text
+# stranded, logged submit_lost_post_grace.
+#
+# Fix: bridge_tmux_session_inject_busy now (for engine=claude) captures the
+# joined plain pane text and reports BUSY when bridge_tmux_claude_capture_
+# is_midturn matches. That detector is REGION-AWARE (codex review #1409 r1):
+# it is built on the shared substring primitive bridge_tmux_capture_has_
+# working_banner — the SAME literal match the codex submit path
+# (bridge_tmux_codex_submit_landed) uses, factored into one helper so the
+# two callers cannot drift — but it additionally rejects a stale banner that
+# sits in scrollback above a now-clean composer, so an idle prompt is never
+# falsely reported busy. When busy is reported, the existing pending-
+# attention spool path (bridge_tmux_send_and_submit) re-delivers the nudge
+# once the prompt is clean.
+#
+# Test plan:
+#   T1 — Live banner→busy: engine=claude + pane's live tail is "esc to
+#        interrupt" → bridge_tmux_session_inject_busy returns 0 (busy →
+#        spool).
+#   T2 — Live "Working" spinner→busy: engine=claude → returns 0 (busy).
+#   T3 — Clean prompt→not busy: engine=claude + a clean idle composer (no
+#        banner, no pending input, no keypress, detached) → returns 1
+#        (NOT busy → normal nudge submits). Regression guard for the
+#        idle-submit path.
+#   T4 — Codex unchanged: engine=codex + the SAME banner text must NOT make
+#        inject_busy branch on the claude-only path (the codex submit
+#        semantics are handled at submit-landed time, not here) → returns 1.
+#   T5 — Scrollback false-positive guard (codex r1): a stale banner ABOVE a
+#        clean composer, ordinary "Working" prose above a clean prompt →
+#        BOTH return 1 (not busy); a live banner BELOW an older prompt
+#        (fresh turn) re-arms → returns 0 (busy).
+#   T6 — Predicate units: the shared substring primitive matches anywhere
+#        (codex semantics), while the region-aware detector rejects stale
+#        scrollback the primitive intentionally still matches.
+#   T7 — Factoring teeth: bridge_tmux_codex_submit_landed delegates to the
+#        shared primitive (not a duplicated inline match), AND
+#        bridge_tmux_session_inject_busy routes through the region-aware
+#        detector (NOT the bare primitive on a wide capture). A future PR
+#        that re-inlines the match, or points the claude gate back at the
+#        scrollback-unsafe primitive, trips this.
+#
+# Footgun #11 (heredoc-stdin deadlock class): this fixture uses no
+# heredoc-stdin into subprocess and no `<<<` here-strings into bridge
+# functions. Banner fixtures are plain string locals.
+
+set -euo pipefail
+
+# Re-exec under Bash 4+ for associative arrays (matches sibling smokes).
+if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash "$HOME/.local/bin/bash"; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      exec "$_candidate" "${BASH_SOURCE[0]}" "$@"
+    fi
+  done
+  echo "[smoke:1409-claude-midturn-busy-gate] requires Bash 4+ (host is ${BASH_VERSION})" >&2
+  exit 1
+fi
+
+SMOKE_NAME="1409-claude-midturn-busy-gate"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "1409-claude-midturn-busy-gate"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+TMUX_LIB="$REPO_ROOT/lib/bridge-tmux.sh"
+
+smoke_assert_file_exists "$TMUX_LIB" "lib/bridge-tmux.sh present"
+
+# shellcheck source=bridge-lib.sh disable=SC1091
+source "$REPO_ROOT/bridge-lib.sh"
+
+if ! declare -F bridge_tmux_session_inject_busy >/dev/null; then
+  smoke_fail "bridge_tmux_session_inject_busy not defined after sourcing bridge-lib.sh"
+fi
+if ! declare -F bridge_tmux_capture_has_working_banner >/dev/null; then
+  smoke_fail "bridge_tmux_capture_has_working_banner not defined (shared helper missing)"
+fi
+
+# ---------------------------------------------------------------------
+# Stubs: isolate the busy-gate's banner branch from a live tmux session.
+# The clean-prompt gates (pending-input, attached-count, recent-keypress)
+# are stubbed to their not-busy defaults so the ONLY remaining signal is
+# the mid-turn banner. The claude gate captures plain (joined) pane text
+# via bridge_capture_recent, fed here from $SMOKE_PANE_TEXT.
+# ---------------------------------------------------------------------
+SMOKE_PANE_TEXT=""
+
+# shellcheck disable=SC2329
+bridge_capture_recent() { printf '%s\n' "$SMOKE_PANE_TEXT"; }
+# shellcheck disable=SC2329
+bridge_tmux_session_has_pending_input() { return 1; }
+# shellcheck disable=SC2329
+bridge_tmux_session_attached_count() { printf '0'; }
+# shellcheck disable=SC2329
+bridge_tmux_session_recent_keypress() { return 1; }
+
+# Banner fixture matching the issue's pane capture (mid-turn — banner is the
+# live tail, no clean composer prompt below it).
+BANNER_ESC=$'· Imagining… (10m 41s · ↓ 36.0k tokens)\n  ⏵⏵ bypass permissions on (shift+tab to cycle) · esc to interrupt'
+# A "Working" spinner banner (the other mid-turn form).
+BANNER_WORKING=$'✻ Working… (3s · ↑ 1.2k tokens)\n  esc to interrupt'
+# A clean idle composer — boxed placeholder prompt, no spinner / interrupt.
+CLEAN_PROMPT=$'╭─────────────────────────╮\n│ > Try "edit <file>"     │\n╰─────────────────────────╯\n  ⏵⏵ bypass permissions on (shift+tab to cycle)'
+# STALE banner sitting in scrollback ABOVE a now-clean composer. This is the
+# codex review #1409 r1 false-positive: a whole-capture substring match would
+# wrongly report busy and strand nudges forever. The region-aware detector
+# must report NOT busy here.
+STALE_BANNER_ABOVE_CLEAN=$'· Imagining… (10m · esc to interrupt)\n[earlier turn finished]\n╭─────────────╮\n│ > Try "edit" │\n╰─────────────╯'
+# Ordinary "Working" prose in an agent response, above a clean bare prompt.
+ORDINARY_WORKING_ABOVE_CLEAN=$'Assistant: I am Working on the plan now.\n> '
+# A fresh turn STARTED below an older prompt: banner is the live tail again →
+# must re-arm busy (region detector resets on the prompt then sees the banner).
+BANNER_BELOW_OLD_PROMPT=$'╭─────────────╮\n│ > old prompt │\n╰─────────────╯\n· Reticulating splines… esc to interrupt'
+
+# ---------------------------------------------------------------------
+# T1 — Live banner ("esc to interrupt") → busy for engine=claude.
+# ---------------------------------------------------------------------
+# shellcheck disable=SC2329
+test_t1_esc_banner_busy() {
+  smoke_log "T1: claude live 'esc to interrupt' banner → inject_busy=0 (busy)"
+  SMOKE_PANE_TEXT="$BANNER_ESC"
+  local rc=0
+  bridge_tmux_session_inject_busy "smoke-claude" "claude" 3 || rc=$?
+  smoke_assert_eq "0" "$rc" "T1: live mid-turn banner must report busy (rc=0)"
+}
+
+# ---------------------------------------------------------------------
+# T2 — Live "Working" spinner banner → busy for engine=claude.
+# ---------------------------------------------------------------------
+# shellcheck disable=SC2329
+test_t2_working_banner_busy() {
+  smoke_log "T2: claude live 'Working' spinner banner → inject_busy=0 (busy)"
+  SMOKE_PANE_TEXT="$BANNER_WORKING"
+  local rc=0
+  bridge_tmux_session_inject_busy "smoke-claude" "claude" 3 || rc=$?
+  smoke_assert_eq "0" "$rc" "T2: live Working spinner must report busy (rc=0)"
+}
+
+# ---------------------------------------------------------------------
+# T3 — Clean idle prompt → NOT busy (regression guard for normal nudges).
+# ---------------------------------------------------------------------
+# shellcheck disable=SC2329
+test_t3_clean_prompt_not_busy() {
+  smoke_log "T3: claude clean idle prompt (no banner) → inject_busy=1 (not busy)"
+  SMOKE_PANE_TEXT="$CLEAN_PROMPT"
+  local rc=0
+  bridge_tmux_session_inject_busy "smoke-claude" "claude" 3 || rc=$?
+  smoke_assert_eq "1" "$rc" "T3: clean prompt must NOT report busy (rc=1)"
+}
+
+# ---------------------------------------------------------------------
+# T4 — Codex: the claude-only banner branch does not change codex.
+# Same banner text, engine=codex, no pending input / keypress / attach →
+# inject_busy returns 1 (the codex banner is handled at submit-landed
+# time, not in this gate).
+# ---------------------------------------------------------------------
+# shellcheck disable=SC2329
+test_t4_codex_unchanged() {
+  smoke_log "T4: codex + banner text → inject_busy=1 (claude-only branch not taken)"
+  SMOKE_PANE_TEXT="$BANNER_ESC"
+  local rc=0
+  bridge_tmux_session_inject_busy "smoke-codex" "codex" 3 || rc=$?
+  smoke_assert_eq "1" "$rc" "T4: codex inject_busy must not flip on the claude banner branch"
+}
+
+# ---------------------------------------------------------------------
+# T5 — Scrollback false-positive guard (codex review #1409 r1). A stale
+# banner ABOVE a now-clean composer, AND ordinary "Working" prose above a
+# clean prompt, must BOTH report NOT busy through the full inject-busy
+# gate — otherwise legitimate nudges spool forever.
+# ---------------------------------------------------------------------
+# shellcheck disable=SC2329
+test_t5_stale_scrollback_not_busy() {
+  smoke_log "T5: stale banner above clean composer → inject_busy=1 (not busy)"
+  SMOKE_PANE_TEXT="$STALE_BANNER_ABOVE_CLEAN"
+  local rc=0
+  bridge_tmux_session_inject_busy "smoke-claude" "claude" 3 || rc=$?
+  smoke_assert_eq "1" "$rc" "T5: stale banner in scrollback must NOT report busy"
+
+  smoke_log "T5: ordinary 'Working' prose above clean prompt → not busy"
+  SMOKE_PANE_TEXT="$ORDINARY_WORKING_ABOVE_CLEAN"
+  rc=0
+  bridge_tmux_session_inject_busy "smoke-claude" "claude" 3 || rc=$?
+  smoke_assert_eq "1" "$rc" "T5: ordinary 'Working' text above a clean prompt must NOT report busy"
+
+  smoke_log "T5: banner BELOW an older prompt (fresh turn) → busy"
+  SMOKE_PANE_TEXT="$BANNER_BELOW_OLD_PROMPT"
+  rc=0
+  bridge_tmux_session_inject_busy "smoke-claude" "claude" 3 || rc=$?
+  smoke_assert_eq "0" "$rc" "T5: a live banner below an older prompt must re-arm busy"
+}
+
+# ---------------------------------------------------------------------
+# T6 — Predicate units: the shared substring primitive and the
+# region-aware claude detector.
+# ---------------------------------------------------------------------
+# shellcheck disable=SC2329
+test_t6_predicate_units() {
+  smoke_log "T6: shared substring primitive truth table"
+  local rc=0
+  bridge_tmux_capture_has_working_banner "$BANNER_ESC" || rc=$?
+  smoke_assert_eq "0" "$rc" "T6: primitive matches 'esc to interrupt'"
+  rc=0
+  bridge_tmux_capture_has_working_banner "$BANNER_WORKING" || rc=$?
+  smoke_assert_eq "0" "$rc" "T6: primitive matches 'Working'"
+  rc=0
+  bridge_tmux_capture_has_working_banner "$CLEAN_PROMPT" || rc=$?
+  smoke_assert_eq "1" "$rc" "T6: primitive rejects a clean prompt"
+  rc=0
+  bridge_tmux_capture_has_working_banner "" || rc=$?
+  smoke_assert_eq "1" "$rc" "T6: primitive rejects empty input"
+
+  smoke_log "T6: region-aware bridge_tmux_claude_capture_is_midturn truth table"
+  rc=0
+  bridge_tmux_claude_capture_is_midturn "$BANNER_ESC" || rc=$?
+  smoke_assert_eq "0" "$rc" "T6: region detector reports live esc banner mid-turn"
+  rc=0
+  bridge_tmux_claude_capture_is_midturn "$BANNER_WORKING" || rc=$?
+  smoke_assert_eq "0" "$rc" "T6: region detector reports live Working banner mid-turn"
+  # The region detector REJECTS what the bare substring primitive accepts:
+  rc=0
+  bridge_tmux_capture_has_working_banner "$STALE_BANNER_ABOVE_CLEAN" || rc=$?
+  smoke_assert_eq "0" "$rc" "T6: substring primitive (intentionally) still matches stale scrollback"
+  rc=0
+  bridge_tmux_claude_capture_is_midturn "$STALE_BANNER_ABOVE_CLEAN" || rc=$?
+  smoke_assert_eq "1" "$rc" "T6: region detector rejects stale banner above a clean composer"
+}
+
+# ---------------------------------------------------------------------
+# T7 — Teeth: the codex submit path still delegates to the shared
+# substring primitive, and the claude gate routes through the region-
+# aware detector (NOT the bare primitive on a wide capture). A PR that
+# re-inlines the literal match in either path, or points the claude gate
+# back at the scrollback-unsafe primitive, trips this.
+# ---------------------------------------------------------------------
+# shellcheck disable=SC2329
+test_t7_factoring_teeth() {
+  smoke_log "T7: codex delegates to primitive; claude gate uses region detector"
+  if ! grep -q "bridge_tmux_capture_has_working_banner" "$TMUX_LIB"; then
+    smoke_fail "T7: shared primitive bridge_tmux_capture_has_working_banner missing from lib/bridge-tmux.sh"
+  fi
+  if ! grep -q "bridge_tmux_claude_capture_is_midturn" "$TMUX_LIB"; then
+    smoke_fail "T7: region-aware detector bridge_tmux_claude_capture_is_midturn missing from lib/bridge-tmux.sh"
+  fi
+  # Codex submit path delegates to the primitive (formerly an inline match).
+  if ! grep -q "if bridge_tmux_capture_has_working_banner \"\$ansi_text\"; then" "$TMUX_LIB"; then
+    smoke_fail "T7: bridge_tmux_codex_submit_landed no longer delegates to the shared primitive (re-inlined match?)"
+  fi
+  # The claude busy-gate must route through the region-aware detector.
+  if ! grep -q "if bridge_tmux_claude_capture_is_midturn \"\$recent\"; then" "$TMUX_LIB"; then
+    smoke_fail "T7: bridge_tmux_session_inject_busy no longer routes through the region-aware detector (scrollback false-positive risk)"
+  fi
+}
+
+smoke_run "T1: live 'esc to interrupt' banner → busy (claude)" test_t1_esc_banner_busy
+smoke_run "T2: live 'Working' spinner → busy (claude)" test_t2_working_banner_busy
+smoke_run "T3: clean prompt → not busy (claude, regression guard)" test_t3_clean_prompt_not_busy
+smoke_run "T4: codex unchanged on claude banner branch" test_t4_codex_unchanged
+smoke_run "T5: stale scrollback → not busy (codex r1 false-positive guard)" test_t5_stale_scrollback_not_busy
+smoke_run "T6: predicate units (primitive + region-aware detector)" test_t6_predicate_units
+smoke_run "T7: teeth — codex primitive + claude region-aware factoring" test_t7_factoring_teeth
+
+smoke_log "all T1-T7 pass"
+exit 0


### PR DESCRIPTION
## Lane B — Claude mid-turn busy-gate (#1409)

Fixes the upstream bug filed by @Mejurix on v0.15.0-rc1: daemon inbox-nudges to a **busy (mid-turn) Claude agent** land as text in the composer but never submit; the operator must press Enter manually. Idle agents are unaffected. Audit logged `session_nudge_dropped reason=submit_lost_post_grace idle_seconds=0`.

refs #1409

### Root cause
`bridge_tmux_session_inject_busy` (lib/bridge-tmux.sh), for engine=claude, only reported busy when the composer already held text (`bridge_tmux_session_has_pending_input`) or a recent keypress was detected. It did **not** detect Claude Code's mid-turn spinner banner (`Working` / `esc to interrupt`). So while a turn was generating the gate reported not-busy → the daemon typed the nudge + `C-m` → Claude Code dropped the mid-turn submit → text stranded in the composer.

The codex submit path already keyed on this banner (`bridge_tmux_codex_submit_landed`); the Claude busy-gate did not reuse it.

### Fix
- New shared substring primitive `bridge_tmux_capture_has_working_banner` — the single owner of the `Working` / `esc to interrupt` literal match. `bridge_tmux_codex_submit_landed` now delegates to it (behavior-preserving refactor; codex path unchanged).
- New **region-aware** detector `bridge_tmux_claude_capture_is_midturn`: a banner only counts as live when **no clean composer prompt appears below it** in the capture (the existing scrollback-safe "last prompt-glyph line" idiom from #132). This prevents a stale banner in scrollback above a now-clean composer from false-positive busy (which would strand legitimate nudges forever).
- New `bridge_tmux_claude_line_is_composer_prompt` helper recognizes the composer prompt in bare (`❯ `/`> `) and boxed (`│ > … │`) forms.
- The claude branch of `bridge_tmux_session_inject_busy` routes through the region-aware detector on the same joined 40-line plain capture the pending-input gate uses. When busy is reported, the **existing** pending-attention spool (`bridge_tmux_send_and_submit`) re-delivers the nudge once the prompt is clean — **no new spool logic added**.

### Smoke
`scripts/smoke/1409-claude-midturn-busy-gate.sh` (T1-T7): both banner strings → busy; clean prompt → not busy (regression guard); **stale-scrollback / ordinary-"Working"-prose → not busy** (codex r1 false-positive guard); banner-below-older-prompt → busy (fresh-turn re-arm); codex unchanged; predicate units; shared-factoring teeth.

> **Note for the orchestrator:** the smoke file is added but **NOT** registered in `scripts/ci-select-smoke.sh` — per the wave course-correction, Lane A also adds a smoke and the orchestrator registers both in a separate integration commit to avoid a shared-selector conflict.

### Verification (all under `/opt/homebrew/bin/bash`; iso-helper-ratchet + the smoke require Bash 4+)
- `bash -n lib/bridge-tmux.sh` + the smoke: PASS
- `shellcheck lib/bridge-tmux.sh` + the smoke: clean (exit 0)
- `scripts/lint-raw-pathlib-on-isolated.sh --check`: EXIT 0
- `scripts/iso-helper-ratchet.sh --check`: EXIT 0 (no regression beyond baseline)
- `scripts/lint-heredoc-ban.sh --baseline-check`: EXIT 0 (no new heredoc/here-string)
- `scripts/smoke/1409-claude-midturn-busy-gate.sh`: T1-T7 PASS
- `scripts/smoke-test.sh`: only pre-existing failure is the `#365` ephemeral-controller-env guard (in `bridge-agents.sh`, untouched) — reproduced **identically on the clean integration base** with no 1409 changes, so it is a host-environment artifact, **not** a regression from this PR.

### Manual verification (required by CLAUDE.md for tmux-submit changes)
This path cannot be exercised by a live Claude session in CI. I verified the predicate logic in an isolated `BRIDGE_HOME` smoke by stubbing the pane capture and asserting the busy/not-busy outcome across the live-banner, clean-prompt, and stale-scrollback fixtures (T1-T7 all pass). **Operator should do one live-session check before/after merge:** with two Claude agents (one mid-turn busy, one idle), send a daemon nudge to the busy one and confirm it is now spooled and re-delivered when the turn ends (no `submit_lost_post_grace`), while the idle agent still receives nudges immediately.

### Internal review
codex:codex-rescue — round 1 `needs-more` (caught a real scrollback false-positive-busy exposure: the original whole-capture match would strand nudges if a banner sat in scrollback above a clean composer). Round 2 `implement-ok` after the region-aware fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
