### PR TITLE
daemon: dedup recurring alerts + gate queued-task nudge on attached (refs #1408 #1411)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -2386,15 +2386,9 @@ process_a2a_outbox_stuck_scan_tick() {
     return 1
   fi
 
-  # Live install's CLI preferred — see process_daily_backup_failure_task.
-  local target_bridge=""
-  if [[ -x "$BRIDGE_HOME/agent-bridge" ]]; then
-    target_bridge="$BRIDGE_HOME/agent-bridge"
-  elif [[ -x "$SCRIPT_DIR/agent-bridge" ]]; then
-    target_bridge="$SCRIPT_DIR/agent-bridge"
-  else
-    return 1
-  fi
+  # Issue #1408: stuck alerts now file via `bridge_queue_cli upsert-open`
+  # (controller-direct to bridge-queue.py), so no `agent-bridge` wrapper
+  # resolution is needed here.
 
   # Ledger of last-alerted timestamps per message_id (JSON dict). A bash
   # associative array would be ideal but we'd lose it across daemon
@@ -2493,13 +2487,28 @@ process_a2a_outbox_stuck_scan_tick() {
       printf '`BRIDGE_A2A_STUCK_ALERT_REEMIT_SECS` (default 1h).\n'
     } >"$body_file"
 
-    # Issue #1318 part A (v0.14.5-beta5-2 Lane ξ): A2A stuck-outbox
-    # alerts to admin must enqueue when admin is stopped — the alert IS
-    # the trigger to wake admin.
-    if "$target_bridge" task create \
+    # Issue #1408: refresh ONE open alert PER stuck message_id instead of
+    # minting a new admin task each reemit window. Routes through the atomic
+    # `bridge-queue.py upsert-open` subcommand (single-writer, one SQLite
+    # transaction) which reuses the same upsert_open_task() the blocked-aging
+    # family uses — find-open matches only OPEN statuses and the refresh
+    # preserves `status`, so an unread alert is refreshed in place rather than
+    # duplicated. The match prefix is per (peer, target_agent, message-prefix)
+    # so each distinct stuck message keeps its own refreshable task (no
+    # aggregate-into-one-body evidence loss). upsert-open always enqueues
+    # (the stopped-target gate lives in bridge-task.sh, not bridge-queue.py),
+    # preserving the Issue #1318 part A "enqueue when admin is stopped"
+    # behavior without needing --force.
+    local a2a_title a2a_filed=0
+    a2a_title="[A2A] outbox stuck: ${peer}:${target_agent} (${message_id:0:8})"
+    if bridge_queue_cli upsert-open \
          --to "$admin" --priority high --from daemon \
-         --title "[A2A] outbox stuck: ${peer}:${target_agent} (${message_id:0:8})" \
-         --body-file "$body_file" --force >/dev/null 2>&1; then
+         --title-prefix "$a2a_title" --title "$a2a_title" \
+         --refresh-note "daemon refreshed A2A outbox-stuck alert" \
+         --body-file "$body_file" >/dev/null 2>&1; then
+      a2a_filed=1
+    fi
+    if (( a2a_filed == 1 )); then
       emitted=$((emitted + 1))
       # Codex r1 BLOCKING fix: stamp the ledger via ack helper at the
       # end of the loop, ONLY for rows whose admin task we actually
@@ -2514,9 +2523,9 @@ process_a2a_outbox_stuck_scan_tick() {
         --detail age_seconds="$age_seconds" >/dev/null 2>&1 || true
     else
       # Codex r1 BLOCKING fix: do NOT advance the reemit cooldown
-      # ledger when task create fails. The next scan will re-evaluate
+      # ledger when the upsert fails. The next scan will re-evaluate
       # this row and try again.
-      daemon_warn "[a2a_stuck_scan] task-create failed for stuck $message_id; ledger preserved, will retry next scan"
+      daemon_warn "[a2a_stuck_scan] upsert-open failed for stuck $message_id; ledger preserved, will retry next scan"
     fi
     rm -f "$body_file" 2>/dev/null || true
   done <"$emit_tmp"
@@ -5916,14 +5925,9 @@ process_unclaimed_queue_escalation() {
   (( age_threshold > 0 )) || return 1
   [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=1800
 
-  local target_bridge=""
-  if [[ -x "$BRIDGE_HOME/agent-bridge" ]]; then
-    target_bridge="$BRIDGE_HOME/agent-bridge"
-  elif [[ -x "$SCRIPT_DIR/agent-bridge" ]]; then
-    target_bridge="$SCRIPT_DIR/agent-bridge"
-  else
-    return 1
-  fi
+  # Issue #1408: the escalation now files via `bridge_queue_cli upsert-open`
+  # (controller-direct to bridge-queue.py) rather than the `agent-bridge`
+  # wrapper, so no $target_bridge resolution is needed here.
 
   # Scan ALL agents' open tasks via the daemon-step output is not feasible
   # here (the daemon-step only emits nudge candidates). Instead we ask the
@@ -6034,9 +6038,20 @@ This task fires at most once per ${cooldown}s cooldown window per
 queued task id. Issue #1318-B operator-visible audit signal.
 EOF
 
-      if "$target_bridge" task create \
+      # Issue #1408: refresh ONE open escalation per task id instead of
+      # minting a new admin task each cooldown window. Routes through the
+      # atomic `bridge-queue.py upsert-open` subcommand (single-writer, one
+      # SQLite transaction) reusing the blocked-aging upsert_open_task().
+      # The (${age_minutes}m) age suffix stays in the displayed title but
+      # is NOT in the match prefix, so the same task id refreshes one open
+      # row across cooldown windows even as its age grows.
+      local unclaimed_title unclaimed_prefix
+      unclaimed_title="[unclaimed-task] #${task_id} on ${agent} (${age_minutes}m)"
+      unclaimed_prefix="[unclaimed-task] #${task_id} on ${agent} "
+      if bridge_queue_cli upsert-open \
            --to "$admin_agent" --priority high --from daemon \
-           --title "[unclaimed-task] #${task_id} on ${agent} (${age_minutes}m)" \
+           --title-prefix "$unclaimed_prefix" --title "$unclaimed_title" \
+           --refresh-note "daemon refreshed unclaimed-task escalation" \
            --body-file "$body_file" >/dev/null 2>&1; then
         bridge_audit_log daemon task_unclaimed_escalated "$admin_agent" \
           --detail task_id="$task_id" \
@@ -6104,7 +6119,7 @@ bridge_daemon_sweep_stale_unclaimed_markers() {
 
 nudge_agent_session() {
   local agent="$1"
-  local _session="$2"
+  local session="$2"
   local queued="$3"
   local claimed="$4"
   local idle="$5"
@@ -6291,6 +6306,47 @@ nudge_agent_session() {
     [[ -n "$_dd_skip_task_id" ]] || _dd_skip_task_id="none"
     daemon_info "[nudge-skip] agent=${agent} task=${_dd_skip_task_id} reason=dedup-cooldown evidence=fingerprint=${nudge_fingerprint:0:8},queued=${live_queued}"
     daemon_info "skipped duplicate nudge for ${agent} (fingerprint=${nudge_fingerprint:0:8}, queued=${live_queued})"
+    return 0
+  fi
+
+  # Issue #1411: skip the ACTION-REQUIRED inject when a human is attached to
+  # the target session. On an attached interactive session the composer is
+  # ~always busy, so the keystroke inject cannot auto-submit → it spools into
+  # pending-attention.env and replays as a `[deferred]` line needing a manual
+  # Enter. Mirror the sibling attached-gates (plugin-MCP-liveness restart
+  # `plugin_mcp_liveness_attached_skip` at ~L7067, stall-scan `attached==0` at
+  # ~L3563): when attached, the operator (and the agent at its own turn
+  # boundaries) drives the inbox, so the daemon must not inject. We reuse the
+  # same `bridge_tmux_session_attached_count` probe the siblings use; $session
+  # is the validated tmux session the caller already proved exists.
+  #
+  # Rate-limit the skip audit (course correction #3): emit it at most once per
+  # redelivery window per task-set, keyed by the same fingerprint the dedup
+  # gate uses. We are only here because should_skip returned false (first-seen
+  # / window expired), so record the window now and return WITHOUT injecting.
+  # We deliberately do NOT call bridge_task_note_nudge / bridge_daemon_record
+  # a successful nudge — no inject happened — but we DO arm the fingerprint
+  # window via bridge_daemon_record_nudge so the next tick's should_skip
+  # suppresses a duplicate attached-skip audit on a permanently-attached
+  # session.
+  local attached=0
+  attached="$(bridge_tmux_session_attached_count "$session" 2>/dev/null || printf '0')"
+  [[ "$attached" =~ ^[0-9]+$ ]] || attached=0
+  if (( attached > 0 )); then
+    local _att_skip_task_id="${live_nudge_key%%,*}"
+    [[ -n "$_att_skip_task_id" ]] || _att_skip_task_id="none"
+    bridge_audit_log daemon queue_attention_attached_skip "$agent" \
+      --detail fingerprint="$nudge_fingerprint" \
+      --detail queued="$live_queued" \
+      --detail claimed="$live_claimed" \
+      --detail attached="$attached" \
+      --detail session="$session" \
+      --detail task_id="$_att_skip_task_id" \
+      --detail redelivery_seconds="${BRIDGE_DAEMON_NUDGE_REDELIVERY_SECONDS:-60}" \
+      2>/dev/null || true
+    daemon_info "[nudge-skip] agent=${agent} task=${_att_skip_task_id} reason=attached-session evidence=attached=${attached},queued=${live_queued}"
+    daemon_info "skipped queued-task nudge for attached session ${agent} (attached=${attached}, queued=${live_queued})"
+    bridge_daemon_record_nudge "$agent" "$nudge_fingerprint" "${live_nudge_key:-$nudge_key}" || true
     return 0
   fi
 

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -973,7 +973,7 @@ def cmd_upsert_open(args: argparse.Namespace) -> int:
     # serializes concurrent upserts against this and every other queue writer.
     # `busy_timeout` makes a contending writer wait rather than fail, and we
     # retry a bounded number of times on the rare residual "database is locked".
-    actor = args.actor or os.environ.get("USER", "unknown")
+    actor = args.actor or os.environ.get("USER", "unknown")  # noqa: iso-helper-boundary — os.environ (.environ) false-matches the .env boundary pattern; not an isolated-artifact reference
     body_text = args.body
     if args.body_file is not None:
         inline_text, _stable_path = stabilize_body_file(normalize_path(args.body_file))

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -955,6 +955,76 @@ def cmd_create(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_upsert_open(args: argparse.Namespace) -> int:
+    # Issue #1408: atomic refresh-or-create for daemon-generated recurring
+    # alerts (A2A outbox-stuck, unclaimed-task escalation). A shell
+    # find-open-then-update/create sequence races between daemon ticks and
+    # bypasses the single-writer contract; this routes both families through
+    # the same upsert_open_task() the blocked-aging family uses.
+    #
+    # ATOMICITY (codex r1 BLOCKING): upsert_open_task() does a SELECT
+    # (find_open_task_by_prefix) and only then an INSERT-or-UPDATE. Python's
+    # sqlite3 in its default isolation mode does NOT take a write lock before a
+    # SELECT, and WAL allows concurrent readers, so two simultaneous ticks
+    # could both miss the row and both INSERT — the exact race we are closing.
+    # There is no unique-key on the open-alert prefix in the shared `tasks`
+    # schema (adding one is a riskier migration). So we acquire the RESERVED
+    # write lock with an explicit `BEGIN IMMEDIATE` BEFORE the SELECT, which
+    # serializes concurrent upserts against this and every other queue writer.
+    # `busy_timeout` makes a contending writer wait rather than fail, and we
+    # retry a bounded number of times on the rare residual "database is locked".
+    actor = args.actor or os.environ.get("USER", "unknown")
+    body_text = args.body
+    if args.body_file is not None:
+        inline_text, _stable_path = stabilize_body_file(normalize_path(args.body_file))
+        body_text = inline_text
+    if body_text is None:
+        body_text = ""
+
+    attempts = 0
+    max_attempts = 5
+    while True:
+        attempts += 1
+        current_ts = now_ts()
+        with closing(connect()) as conn:
+            conn.execute("PRAGMA busy_timeout=5000")
+            try:
+                # BEGIN IMMEDIATE is inside the try so a lock timeout while
+                # ACQUIRING the RESERVED lock is also covered by the retry
+                # ladder (codex r2 nit), not just contention during the write.
+                conn.execute("BEGIN IMMEDIATE")
+                task_id, created = upsert_open_task(
+                    conn,
+                    agent=args.assigned_to,
+                    title_prefix=args.title_prefix,
+                    title=args.title.strip(),
+                    priority=args.priority,
+                    actor=actor,
+                    body_text=body_text,
+                    current_ts=current_ts,
+                    refresh_note=args.refresh_note or "daemon refreshed recurring alert",
+                )
+                conn.commit()
+            except sqlite3.OperationalError as exc:
+                conn.rollback()
+                if "locked" in str(exc).lower() and attempts < max_attempts:
+                    continue
+                raise
+            except BaseException:
+                conn.rollback()
+                raise
+        break
+
+    if args.format == "shell":
+        print(f"TASK_ID={shlex.quote(str(task_id))}")
+        print(f"TASK_CREATED={shlex.quote('1' if created else '0')}")
+        return 0
+
+    verb = "created" if created else "refreshed"
+    print(f"{verb} task #{task_id} for {args.assigned_to} [{args.priority}] {args.title.strip()}")
+    return 0
+
+
 def cmd_inbox(args: argparse.Namespace) -> int:
     statuses = list(args.status or [])
     if args.all:
@@ -2612,6 +2682,23 @@ def build_parser() -> argparse.ArgumentParser:
     body_group.add_argument("--body")
     body_group.add_argument("--body-file")
     create_parser.set_defaults(handler=cmd_create)
+
+    # Issue #1408: atomic refresh-or-create keyed by a stable title prefix.
+    # Daemon-internal (controller-direct); used by the A2A outbox-stuck scan
+    # and the unclaimed-task escalation to keep a SINGLE open admin task per
+    # recurring condition instead of minting a new task each cooldown window.
+    upsert_parser = subparsers.add_parser("upsert-open", allow_abbrev=False)
+    upsert_parser.add_argument("--to", dest="assigned_to", required=True)
+    upsert_parser.add_argument("--title-prefix", required=True)
+    upsert_parser.add_argument("--title", required=True)
+    upsert_parser.add_argument("--from", dest="actor")
+    upsert_parser.add_argument("--priority", choices=PRIORITY_CHOICES, default="normal")
+    upsert_parser.add_argument("--refresh-note")
+    upsert_parser.add_argument("--format", choices=("text", "shell"), default="text")
+    upsert_body_group = upsert_parser.add_mutually_exclusive_group()
+    upsert_body_group.add_argument("--body")
+    upsert_body_group.add_argument("--body-file")
+    upsert_parser.set_defaults(handler=cmd_upsert_open)
 
     inbox_parser = subparsers.add_parser("inbox", allow_abbrev=False)
     inbox_parser.add_argument("--agent", required=True)

--- a/scripts/smoke/1408-daemon-alert-nudge-hygiene.sh
+++ b/scripts/smoke/1408-daemon-alert-nudge-hygiene.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# scripts/smoke/1408-daemon-alert-nudge-hygiene.sh — regression for
+# issues #1408 + #1411 (Mejurix, v0.15.0-rc1).
+#
+# #1408 — the A2A outbox-stuck scan (`process_a2a_outbox_stuck_scan_tick`)
+#   and the unclaimed-task escalation (`process_unclaimed_queue_escalation`)
+#   minted a BRAND-NEW high-priority admin task each cooldown window with no
+#   "prior alert still open" check (~116 dupes for ~6 real conditions). The
+#   fix routes BOTH families through a new ATOMIC `bridge-queue.py upsert-open`
+#   subcommand that reuses the same `upsert_open_task()` the blocked-aging
+#   family uses: one open task per stable title-prefix, refreshed in place
+#   (status preserved) instead of duplicated. Atomic = single SQLite
+#   transaction, so concurrent daemon ticks cannot race a double-insert (the
+#   reason we do NOT use a shell find-open-then-create sequence).
+#
+# #1411 — the queued-task ACTION-REQUIRED nudge had a fingerprint dedup gate
+#   but NO attached-session gate, so on an attached interactive admin session
+#   (composer ~always busy) the inject could not auto-submit, spooled, and
+#   replayed as `[deferred]`. The fix adds an `attached>0 → skip` gate to
+#   `nudge_agent_session` mirroring the sibling `plugin_mcp_liveness_attached_skip`
+#   path, emits a rate-limited `queue_attention_attached_skip` audit, and does
+#   NOT record a successful nudge (no inject happened).
+#
+# Coverage:
+#   U1 — upsert-open refreshes ONE open task across N cooldown windows for a
+#        stable prefix (same id every time, not N tasks).
+#   U2 — upsert-open preserves `status`: a claimed alert stays claimed on
+#        refresh (mirrors refresh_queue_task, which deliberately omits status).
+#   U3 — a DISTINCT title-prefix mints a distinct task (per-message_id A2A
+#        cardinality — distinct stuck messages keep their own refreshable row).
+#   U4 — upsert-open re-CREATES after the alert is closed (done): a closed row
+#        is no longer "open", so the next window legitimately mints a fresh id.
+#   S1 — in-source wiring (#1408): both daemon families call
+#        `bridge_queue_cli upsert-open` (no more `task create` always-insert).
+#   S2 — in-source wiring (#1411): nudge_agent_session gates on attached, emits
+#        the `queue_attention_attached_skip` audit, and does not note-nudge on
+#        the attached-skip path.
+#
+# Footgun #11: no python3 heredoc-stdin / `<<<` here-string at a python3
+# subprocess. All queue mutation is via the bridge-queue.py CLI; the only
+# inline python uses `python3 -c '<script>' <argv>`.
+
+set -euo pipefail
+
+SMOKE_NAME="1408-daemon-alert-nudge-hygiene"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-1408-hygiene.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DB="$TMP_DIR/tasks.db"
+export BRIDGE_TASK_DB="$DB"
+
+ADMIN="admin-agent"
+QUEUE="$REPO_ROOT/bridge-queue.py"
+
+failed=0
+
+# Count open tasks (queued/claimed/blocked) whose title starts with a prefix.
+# find-open --all --format json returns a JSON array of open tasks; we count
+# elements whose title begins with the prefix via a small argv-driven python.
+count_open_with_prefix() {
+  local prefix="$1"
+  local json
+  json="$(python3 "$QUEUE" find-open --agent "$ADMIN" --title-prefix "$prefix" --all --format json 2>/dev/null || printf '[]')"
+  python3 -c 'import json,sys; print(len(json.loads(sys.argv[1] or "[]")))' "$json"
+}
+
+# ============================================================
+# U1 — N cooldown windows → ONE refreshed open task
+# ============================================================
+PREFIX_A="[A2A] outbox stuck: peer-a:remote-a (deadbeef)"
+first_id=""
+TASK_ID=""
+TASK_CREATED=""
+for i in 1 2 3 4; do
+  python3 "$QUEUE" upsert-open \
+    --to "$ADMIN" --from daemon --priority high \
+    --title-prefix "$PREFIX_A" \
+    --title "$PREFIX_A" \
+    --refresh-note "window $i" \
+    --body "stuck body window $i" \
+    --format shell >"$TMP_DIR/u1-$i.sh"
+  # shellcheck disable=SC1090
+  source "$TMP_DIR/u1-$i.sh"
+  if [[ -z "$first_id" ]]; then
+    first_id="$TASK_ID"
+  elif [[ "$TASK_ID" != "$first_id" ]]; then
+    echo "  FAIL  U1: window $i minted a NEW id ${TASK_ID} (expected refresh of ${first_id})" >&2
+    failed=1
+  fi
+done
+
+u1_count="$(count_open_with_prefix "$PREFIX_A")"
+if [[ "$u1_count" == "1" ]]; then
+  echo "  PASS  U1: 4 cooldown windows → 1 open task (id=${first_id}), not 4 (the #1408 flood)"
+else
+  echo "  FAIL  U1: expected 1 open task after 4 upserts, found ${u1_count}" >&2
+  failed=1
+fi
+
+# ============================================================
+# U2 — upsert-open preserves status (claimed stays claimed)
+# ============================================================
+python3 "$QUEUE" claim "$first_id" --agent "$ADMIN" >/dev/null
+status_before="$(python3 "$QUEUE" show "$first_id" --format shell | sed -n 's/^TASK_STATUS=//p' | tr -d "'")"
+
+python3 "$QUEUE" upsert-open \
+  --to "$ADMIN" --from daemon --priority high \
+  --title-prefix "$PREFIX_A" \
+  --title "$PREFIX_A (refreshed)" \
+  --refresh-note "post-claim refresh" \
+  --body "refresh after claim" \
+  --format shell >"$TMP_DIR/u2.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/u2.sh"
+u2_id="$TASK_ID"
+unset TASK_ID TASK_CREATED
+status_after="$(python3 "$QUEUE" show "$first_id" --format shell | sed -n 's/^TASK_STATUS=//p' | tr -d "'")"
+
+if [[ "$u2_id" == "$first_id" && "$status_before" == "claimed" && "$status_after" == "claimed" ]]; then
+  echo "  PASS  U2: refresh of a claimed alert preserves status=claimed and id=${first_id} (no status reset)"
+else
+  echo "  FAIL  U2: id=${u2_id} (want ${first_id}); status ${status_before}→${status_after} (want claimed→claimed)" >&2
+  failed=1
+fi
+
+# ============================================================
+# U3 — distinct prefix mints a distinct task (per-message_id)
+# ============================================================
+PREFIX_B="[A2A] outbox stuck: peer-a:remote-a (cafef00d)"
+python3 "$QUEUE" upsert-open \
+  --to "$ADMIN" --from daemon --priority high \
+  --title-prefix "$PREFIX_B" \
+  --title "$PREFIX_B" \
+  --refresh-note "second stuck message" \
+  --body "second message body" \
+  --format shell >"$TMP_DIR/u3.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/u3.sh"
+u3_id="$TASK_ID"
+u3_created="$TASK_CREATED"
+unset TASK_ID TASK_CREATED
+
+if [[ "$u3_id" != "$first_id" && "$u3_created" == "1" ]]; then
+  echo "  PASS  U3: a distinct message-prefix creates its own task (id=${u3_id}) — no aggregate-into-one-body evidence loss"
+else
+  echo "  FAIL  U3: distinct prefix should create a new task — got id=${u3_id} created=${u3_created} (first_id=${first_id})" >&2
+  failed=1
+fi
+
+# ============================================================
+# U4 — closing the alert lets the next window create afresh
+# ============================================================
+python3 "$QUEUE" done "$first_id" --agent "$ADMIN" --note "resolved" >/dev/null
+python3 "$QUEUE" upsert-open \
+  --to "$ADMIN" --from daemon --priority high \
+  --title-prefix "$PREFIX_A" \
+  --title "$PREFIX_A" \
+  --refresh-note "post-done window" \
+  --body "reopened after done" \
+  --format shell >"$TMP_DIR/u4.sh"
+# shellcheck disable=SC1090
+source "$TMP_DIR/u4.sh"
+u4_id="$TASK_ID"
+u4_created="$TASK_CREATED"
+unset TASK_ID TASK_CREATED
+
+if [[ "$u4_id" != "$first_id" && "$u4_created" == "1" ]]; then
+  echo "  PASS  U4: a closed (done) alert is no longer open → next window mints a fresh id (${u4_id})"
+else
+  echo "  FAIL  U4: closed alert should re-create — got id=${u4_id} created=${u4_created} (closed id=${first_id})" >&2
+  failed=1
+fi
+
+# ============================================================
+# U5 — ATOMICITY: concurrent same-prefix upserts → ONE create
+# ============================================================
+# The whole point of the queue-layer upsert (vs a shell find-open-then-create
+# sequence) is that the find-or-create is atomic under concurrent daemon
+# ticks. Hammer the same prefix from N parallel processes against a FRESH db
+# and assert exactly ONE process minted a task (TASK_CREATED=1) and exactly
+# ONE open task exists. Without the BEGIN IMMEDIATE write lock this races and
+# inserts duplicates (codex r1 BLOCKING finding).
+RACE_DB="$TMP_DIR/race.db"
+RACE_PREFIX="[A2A] outbox stuck: peer-z:remote-z (feedface)"
+# Pre-init the schema serially so the concurrency below exercises the
+# upsert find-or-create race, not the one-time CREATE TABLE bootstrap.
+BRIDGE_TASK_DB="$RACE_DB" python3 "$QUEUE" init >/dev/null
+N_RACE=12
+for r in $(seq 1 "$N_RACE"); do
+  BRIDGE_TASK_DB="$RACE_DB" python3 "$QUEUE" upsert-open \
+    --to "$ADMIN" --from daemon --priority high \
+    --title-prefix "$RACE_PREFIX" \
+    --title "$RACE_PREFIX w$r" \
+    --refresh-note "race $r" \
+    --body "race body $r" \
+    --format shell >"$TMP_DIR/race-$r.out" 2>"$TMP_DIR/race-$r.err" &
+done
+wait
+
+# pipefail-safe counts: grep returns 1 on no-match, which would trip
+# `set -o pipefail`. Append `|| true` to the grep so the count is 0, not an
+# abort, when no process minted / errored.
+race_created="$( { grep -h 'TASK_CREATED=1' "$TMP_DIR"/race-*.out 2>/dev/null || true; } | grep -c . || true)"
+race_errors="$( { cat "$TMP_DIR"/race-*.err 2>/dev/null || true; } | grep -c . || true)"
+[[ "$race_created" =~ ^[0-9]+$ ]] || race_created=0
+[[ "$race_errors" =~ ^[0-9]+$ ]] || race_errors=0
+race_open="$(BRIDGE_TASK_DB="$RACE_DB" python3 "$QUEUE" find-open --agent "$ADMIN" --title-prefix "$RACE_PREFIX" --all --format json 2>/dev/null | python3 -c 'import json,sys; print(len(json.load(sys.stdin)))' 2>/dev/null || printf '0')"
+
+if [[ "$race_created" == "1" && "$race_open" == "1" && "$race_errors" == "0" ]]; then
+  echo "  PASS  U5: ${N_RACE} concurrent same-prefix upserts → exactly 1 create, 1 open task, 0 errors (atomic)"
+else
+  echo "  FAIL  U5: concurrent upserts not atomic — created=${race_created} open=${race_open} errors=${race_errors} (want 1/1/0)" >&2
+  failed=1
+fi
+
+# ============================================================
+# S1 — in-source wiring: #1408 daemon families use upsert-open
+# ============================================================
+daemon_sh="$REPO_ROOT/bridge-daemon.sh"
+
+if grep -q 'bridge_queue_cli upsert-open' "$daemon_sh"; then
+  echo "  PASS  S1: bridge-daemon.sh files alerts via 'bridge_queue_cli upsert-open'"
+else
+  echo "  FAIL  S1: bridge-daemon.sh does not call 'bridge_queue_cli upsert-open'" >&2
+  failed=1
+fi
+
+# The A2A stuck scan must no longer always-insert via 'task create'. Confirm
+# the per-message upsert title is present and the old always-create call for
+# the stuck alert is gone (the unclaimed escalation's old 'task create' is
+# likewise replaced).
+if grep -q '\[A2A\] outbox stuck:' "$daemon_sh" \
+   && ! grep -q 'task create .*--title "\[A2A\] outbox stuck' "$daemon_sh"; then
+  echo "  PASS  S1: A2A stuck alert no longer minted via always-insert 'task create'"
+else
+  echo "  FAIL  S1: A2A stuck alert still uses an always-insert 'task create' path" >&2
+  failed=1
+fi
+
+# ============================================================
+# S2 — in-source wiring: #1411 attached-gate on the queued-task nudge
+# ============================================================
+if grep -q 'queue_attention_attached_skip' "$daemon_sh"; then
+  echo "  PASS  S2: nudge emits the 'queue_attention_attached_skip' audit token"
+else
+  echo "  FAIL  S2: nudge does not emit 'queue_attention_attached_skip' audit token" >&2
+  failed=1
+fi
+
+# The attached-gate must reuse the existing attached-count probe and gate on
+# attached>0 inside nudge_agent_session.
+if grep -q 'bridge_tmux_session_attached_count "$session"' "$daemon_sh"; then
+  echo "  PASS  S2: nudge reuses bridge_tmux_session_attached_count probe (no new probe invented)"
+else
+  echo "  FAIL  S2: nudge does not reuse bridge_tmux_session_attached_count probe" >&2
+  failed=1
+fi
+
+# The attached-skip path must NOT fall through into a note-nudge / successful
+# send. Verify the audit token and the early `return 0` both precede the
+# bridge_task_note_nudge call in nudge_agent_session.
+attached_line="$(grep -n 'bridge_audit_log daemon queue_attention_attached_skip' "$daemon_sh" | head -n1 | cut -d: -f1)"
+# Match the CALL (with its "$agent" arg), not the prose comment that names it.
+note_nudge_line="$(grep -n 'bridge_task_note_nudge "\$agent"' "$daemon_sh" | head -n1 | cut -d: -f1)"
+if [[ -n "$attached_line" && -n "$note_nudge_line" && "$attached_line" -lt "$note_nudge_line" ]]; then
+  echo "  PASS  S2: attached-skip (line ${attached_line}) precedes the note-nudge success path (line ${note_nudge_line}) → no inject recorded on skip"
+else
+  echo "  FAIL  S2: attached-skip ordering vs note-nudge unexpected (attached=${attached_line}, note_nudge=${note_nudge_line})" >&2
+  failed=1
+fi
+
+if (( failed )); then
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] all checks passed"

--- a/scripts/smoke/I-beta4-a2a-3-gaps.sh
+++ b/scripts/smoke/I-beta4-a2a-3-gaps.sh
@@ -493,39 +493,39 @@ smoke_log "T_stuck_task_create_failure_preserves_ledger PASS — failed task-cre
 # Mocks:
 #   - `bridge-a2a.py outbox list --json` → fixture file (driver overrides
 #     `bridge_with_timeout` for label `a2a_outbox_list`).
-#   - `$BRIDGE_HOME/agent-bridge task create` → wrapper shim whose rc
-#     reads from `BRIDGE_A2A_TEST_TASK_CREATE_RC` (0/1) per tick. Daemon
-#     prefers `$BRIDGE_HOME/agent-bridge` over `$SCRIPT_DIR/agent-bridge`
-#     (bridge-daemon.sh:2342-2349), so the shim wins.
+#   - `bridge_queue_cli upsert-open` → driver stub whose rc reads from
+#     `BRIDGE_A2A_TEST_TASK_CREATE_RC` (0/1) per tick. Issue #1408 replaced
+#     the prior `$BRIDGE_HOME/agent-bridge task create` filing path with the
+#     atomic `bridge-queue.py upsert-open` subcommand (refresh-or-create one
+#     open task per stuck message_id), so the mock moved from the
+#     agent-bridge shim to the driver's bridge_queue_cli stub.
 #
-# Acceptance (r3 codex r2 TEST GAP closure):
-#   1. tick #1 with task_create rc=1:
+# Acceptance (r3 codex r2 TEST GAP closure; Issue #1408 path update):
+#   1. tick #1 with alert-filing rc=1:
 #        - decide emits the stuck row
-#        - daemon's task-create branch fails
-#        - daemon_warn at bridge-daemon.sh:2468 fires
-#          ("task-create failed for stuck …")
-#        - ack helper runs with EMPTY ack-keys (production line 2456
-#          appends ONLY inside the success branch) → ledger remains
+#        - daemon's `bridge_queue_cli upsert-open` branch fails
+#        - daemon_warn fires ("upsert-open failed for stuck …")
+#        - ack helper runs with EMPTY ack-keys (production appends to
+#          ack_tmp ONLY inside the upsert success branch) → ledger remains
 #          unstamped for the stuck message_id
 #        - throttle: next scan must NOT be skipped (we manually clear
 #          tick_state between runs to keep the test deterministic)
-#   2. tick #2 with task_create rc=0 (mock toggled, throttle state
+#   2. tick #2 with alert-filing rc=0 (mock toggled, throttle state
 #      cleared, retry-after window honored implicitly since we control
 #      `BRIDGE_A2A_STUCK_ALERT_SCAN_INTERVAL_SECONDS=0` would skip the
 #      tick — instead we remove the tick_state file between runs):
 #        - decide emits the same stuck row (ledger never stamped)
-#        - daemon's task-create branch succeeds
+#        - daemon's `bridge_queue_cli upsert-open` branch succeeds
 #        - ack helper stamps the ledger
 #        - ledger NOW carries `"msg-stuck-real-001"`
 #
 # Teeth (regression vectors documented + exercised by tick #1):
-#   V1. Move bridge-daemon.sh:2456 (`printf '%s\n' "$message_id" >>
-#       "$ack_tmp"`) OUTSIDE the success branch (i.e. unconditionally
-#       after the if-else). The smoke will then see ledger stamped on
-#       failure → tick #2's pre-condition `ledger empty` fails →
-#       assertion fires.
+#   V1. Move the `printf '%s\n' "$message_id" >> "$ack_tmp"` line OUTSIDE
+#       the upsert-open success branch (i.e. unconditionally after the
+#       if-else). The smoke will then see ledger stamped on failure →
+#       tick #2's pre-condition `ledger empty` fails → assertion fires.
 #   V2. Reorder helper calls so `a2a-stuck-ack` runs BEFORE the
-#       task-create loop (or the loop appends to ack_tmp before the
+#       upsert-open loop (or the loop appends to ack_tmp before the
 #       success rc is known). Same shape — ledger stamped on failure
 #       → assertion fires.
 #
@@ -551,29 +551,12 @@ cat >"$DAEMON_TEST_OUTBOX" <<'JSON'
 ]
 JSON
 
-# Mock agent-bridge shim. Daemon prefers $BRIDGE_HOME/agent-bridge over
-# $SCRIPT_DIR/agent-bridge (see daemon function, lines 2342-2349). Reads
-# rc from $BRIDGE_A2A_TEST_TASK_CREATE_RC.
-DAEMON_TEST_AGB_SHIM="$DAEMON_TEST_HOME/agent-bridge"
-cat >"$DAEMON_TEST_AGB_SHIM" <<'SHIM'
-#!/usr/bin/env bash
-# Mock for v0.15.0-beta4 Lane I r3 smoke. Returns rc from env var.
-rc="${BRIDGE_A2A_TEST_TASK_CREATE_RC:-0}"
-case "${1:-}" in
-  task)
-    if [[ "$rc" == "1" ]]; then
-      printf 'mock-agent-bridge: task create failed (BRIDGE_A2A_TEST_TASK_CREATE_RC=1)\n' >&2
-      exit 1
-    fi
-    exit 0
-    ;;
-  *)
-    # Any other subcommand: no-op success.
-    exit 0
-    ;;
-esac
-SHIM
-chmod +x "$DAEMON_TEST_AGB_SHIM"
+# Issue #1408: the alert-filing mock is no longer an `$BRIDGE_HOME/agent-bridge`
+# shim — production now files via `bridge_queue_cli upsert-open`, and the
+# daemon no longer resolves a `$target_bridge` wrapper at all. The filing rc
+# (BRIDGE_A2A_TEST_TASK_CREATE_RC) is honored by the driver's bridge_queue_cli
+# stub (scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh). Nothing to seed
+# in $DAEMON_TEST_HOME here.
 
 DAEMON_TEST_WARN_LOG="$SMOKE_TMP_ROOT/daemon-test-warn.log"
 DAEMON_TEST_EVENT_LOG="$SMOKE_TMP_ROOT/daemon-test-event.log"
@@ -610,25 +593,28 @@ env -i HOME="$HOME" PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" \
   bash "$DAEMON_TEST_DRIVER" \
     >"$SMOKE_TMP_ROOT/daemon-test-tick1.out" 2>"$SMOKE_TMP_ROOT/daemon-test-tick1.err" || true
 
-# Assert 1: daemon_warn at bridge-daemon.sh:2468 fired ("task-create failed").
-if ! grep -F '[a2a_stuck_scan] task-create failed for stuck msg-stuck-real-001' \
+# Assert 1: daemon_warn fired on the upsert-open failure path
+# (bridge-daemon.sh, "[a2a_stuck_scan] upsert-open failed for stuck …").
+# Issue #1408 replaced the old `task create` filing path with
+# `bridge_queue_cli upsert-open`; the warn text changed accordingly.
+if ! grep -F '[a2a_stuck_scan] upsert-open failed for stuck msg-stuck-real-001' \
      "$DAEMON_TEST_WARN_LOG" >/dev/null; then
-  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 did not emit task-create-failed warn (warn log: $(cat "$DAEMON_TEST_WARN_LOG"); stderr: $(cat "$SMOKE_TMP_ROOT/daemon-test-tick1.err"))"
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 did not emit upsert-open-failed warn (warn log: $(cat "$DAEMON_TEST_WARN_LOG"); stderr: $(cat "$SMOKE_TMP_ROOT/daemon-test-tick1.err"))"
 fi
 
-# Assert 2: ledger unstamped for msg-stuck-real-001 (production code path:
-# line 2456 only appends to ack_tmp inside the success branch).
+# Assert 2: ledger unstamped for msg-stuck-real-001 (production only appends
+# to ack_tmp inside the upsert-open success branch).
 if [[ ! -f "$DAEMON_TEST_LEDGER" ]]; then
   smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 did not create ledger file"
 fi
 if grep -F 'msg-stuck-real-001' "$DAEMON_TEST_LEDGER" >/dev/null; then
-  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 stamped ledger despite task-create failure — regression of bridge-daemon.sh:2456 ack_tmp-append-on-success contract (ledger: $(cat "$DAEMON_TEST_LEDGER"))"
+  smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #1 stamped ledger despite upsert-open failure — regression of the ack_tmp-append-on-success contract (ledger: $(cat "$DAEMON_TEST_LEDGER"))"
 fi
 
 smoke_log "T_daemon_scan_tick_handles_create_failure tick #1 PASS — warn emitted, ledger unstamped on rc=1"
 
-# Tick #2 — task_create rc=0 (success path). Clear throttle so the
-# function runs again rather than gating on `now < next`.
+# Tick #2 — alert-filing rc=0 (upsert-open success path). Clear throttle so
+# the function runs again rather than gating on `now < next`.
 rm -f "$DAEMON_TEST_TICK"
 env -i HOME="$HOME" PATH="$PATH" TMPDIR="${TMPDIR:-/tmp}" \
   SCRIPT_DIR="$REPO_ROOT" \
@@ -653,7 +639,7 @@ if ! grep -F 'msg-stuck-real-001' "$DAEMON_TEST_LEDGER" >/dev/null; then
 fi
 
 # Assert 4: event log shows the daemon's emitted-count line — confirms
-# task-create success path ran end-to-end.
+# the upsert-open success path ran end-to-end.
 if ! grep -F '[a2a_stuck_scan] emitted 1 stuck-outbox admin task' "$DAEMON_TEST_EVENT_LOG" >/dev/null; then
   smoke_fail "T_daemon_scan_tick_handles_create_failure: tick #2 did not log success emission (event log: $(cat "$DAEMON_TEST_EVENT_LOG"))"
 fi

--- a/scripts/smoke/I-beta4-a2a-3-gaps.sh
+++ b/scripts/smoke/I-beta4-a2a-3-gaps.sh
@@ -385,12 +385,35 @@ fi
 if ! grep -F 'a2a_outbox_stuck_alert_emitted' "$DAEMON_SH" >/dev/null; then
   T6_FAILS+="audit row a2a_outbox_stuck_alert_emitted missing; "
 fi
-# T6e — admin task creation via target_bridge task create.
-if ! grep -F '"$target_bridge" task create' "$DAEMON_SH" >/dev/null; then
-  T6_FAILS+="stuck scan does not create admin task via target_bridge; "
+# T6e — admin alert filed via `bridge_queue_cli upsert-open`, SCOPED to the
+# stuck-scan function body. Issue #1408 migrated the stuck-scan filing path
+# from `"$target_bridge" task create` (always-insert) to the atomic
+# `bridge_queue_cli upsert-open` (refresh-or-create one open task per stuck
+# message_id). A whole-file grep would be VACUOUS — 5 UNRELATED daemon
+# functions (daily-backup, release alerts, etc.) still legitimately call
+# `"$target_bridge" task create`, so it would pass even if the stuck-scan
+# filing broke. Extract just the function body (same awk boundary the driver
+# uses: from the `() {` line to the first column-0 `}`) and assert against
+# THAT, so the check actually tracks the stuck-scan path.
+T6E_FN_BODY="$(awk '/^process_a2a_outbox_stuck_scan_tick\(\) \{/,/^\}$/' "$DAEMON_SH")"
+# Sanity: the extraction must be non-vacuous (non-empty, bounded to the
+# function — not the whole file). The closing `}` and the function's unique
+# scan-label string prove we captured the body, not a runaway range.
+if [[ -z "$T6E_FN_BODY" ]] \
+   || ! printf '%s' "$T6E_FN_BODY" | grep -q '^process_a2a_outbox_stuck_scan_tick() {' \
+   || ! printf '%s' "$T6E_FN_BODY" | grep -Fq '[a2a_stuck_scan]'; then
+  T6_FAILS+="could not extract process_a2a_outbox_stuck_scan_tick() body for scoped T6e; "
+elif ! printf '%s' "$T6E_FN_BODY" | grep -Fq 'bridge_queue_cli upsert-open'; then
+  T6_FAILS+="stuck scan does not file admin alert via 'bridge_queue_cli upsert-open' (#1408); "
+elif printf '%s' "$T6E_FN_BODY" | grep -Eq '"\$target_bridge"[[:space:]]+task[[:space:]]+create'; then
+  # Pin the migration: the OLD always-insert `"$target_bridge" task create`
+  # CALL must be gone from the stuck-scan body (it now refreshes-or-creates
+  # via upsert-open). Match the call form specifically — a bare `task create`
+  # substring would false-match the descriptive comments still in the body.
+  T6_FAILS+="stuck scan still contains a '\"\$target_bridge\" task create' filing call; #1408 migration not pinned; "
 fi
 # T6f — v0.15.0-beta4 Lane I r2 (codex r1 BLOCKING) wiring: daemon
-# follows up with a2a-stuck-ack helper after the task-create loop,
+# follows up with a2a-stuck-ack helper after the upsert-open filing loop,
 # and that helper is registered in bridge-daemon-helpers.py.
 if ! grep -F 'a2a-stuck-ack' "$DAEMON_SH" >/dev/null; then
   T6_FAILS+="daemon does not call a2a-stuck-ack helper; "
@@ -412,18 +435,19 @@ smoke_log "T6 PASS — cooldown expiry re-emits, ledger prunes dropped rows, dec
 # T_stuck_task_create_failure_preserves_ledger — v0.15.0-beta4 Lane I
 # r2 (codex r1 BLOCKING).
 #
-# Contract: if `$target_bridge task create` fails (transient), the
-# daemon shell must NOT advance the reemit cooldown for that row.
+# Contract: if the alert-filing step fails (transient) — `bridge_queue_cli
+# upsert-open` since Issue #1408, previously `$target_bridge task create` —
+# the daemon shell must NOT advance the reemit cooldown for that row.
 # Otherwise the operator silently loses the alert until cooldown
 # lapses. The split is enforced by:
 #   - cmd_a2a_stuck_decide: pure read, no ledger writes
 #   - daemon shell loop: append message_id to ack-keys only on
-#     task-create success (skip on failure)
+#     upsert-open success (skip on failure)
 #   - cmd_a2a_stuck_ack: stamp ledger only for keys in ack-keys file
 #
 # We exercise the failure path by:
 #   - calling decide (no ledger write)
-#   - simulating task-create failure: do NOT add message_id to ack
+#   - simulating an alert-filing failure: do NOT add message_id to ack
 #     keys
 #   - calling ack with empty (or no-msg) ack-keys
 #   - asserting ledger does not contain msg-stuck-001
@@ -568,8 +592,9 @@ DAEMON_TEST_TICK="$DAEMON_TEST_HOME/state/handoff/stuck-scan-tick.env"
 
 # Driver script — invokes the actual production
 # process_a2a_outbox_stuck_scan_tick function from bridge-daemon.sh
-# with mocks for `bridge-a2a.py outbox list --json` and `agent-bridge
-# task create`. See run-stuck-scan-tick.sh for the mock contract.
+# with mocks for `bridge-a2a.py outbox list --json` and
+# `bridge_queue_cli upsert-open`. See run-stuck-scan-tick.sh for the
+# mock contract.
 DAEMON_TEST_DRIVER="$REPO_ROOT/scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh"
 if [[ ! -x "$DAEMON_TEST_DRIVER" ]]; then
   smoke_fail "T_daemon_scan_tick_handles_create_failure: missing driver $DAEMON_TEST_DRIVER"

--- a/scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh
+++ b/scripts/smoke/I-beta4-helpers/run-stuck-scan-tick.sh
@@ -6,8 +6,11 @@
 # Exercises the actual `process_a2a_outbox_stuck_scan_tick` shell function
 # from bridge-daemon.sh in isolation, with mocks for:
 #   - `bridge-a2a.py outbox list --json` (returns fixture JSON path)
-#   - `$BRIDGE_HOME/agent-bridge task create` (rc controlled by
-#     `BRIDGE_A2A_TEST_TASK_CREATE_RC` env var)
+#   - `bridge_queue_cli upsert-open` (rc controlled by
+#     `BRIDGE_A2A_TEST_TASK_CREATE_RC` env var). Issue #1408 replaced the
+#     prior `$BRIDGE_HOME/agent-bridge task create` filing path with the
+#     atomic upsert-open subcommand; the env var name is kept for harness
+#     compatibility (it still means "the alert-filing rc for this tick").
 #
 # This driver:
 #   1. Extracts the `process_a2a_outbox_stuck_scan_tick` function body
@@ -20,7 +23,9 @@
 #      `a2a_outbox_list` reads from a fixture file (mock), while the
 #      `a2a_stuck_decide` / `a2a_stuck_ack` calls pass through to the
 #      real `bridge-daemon-helpers.py`.
-#   4. Invokes the function once.
+#   4. Stubs `bridge_queue_cli` so the `upsert-open` alert-filing call
+#      returns the rc selected by `BRIDGE_A2A_TEST_TASK_CREATE_RC`.
+#   5. Invokes the function once.
 #
 # Inputs (env):
 #   - SCRIPT_DIR          : repo root (so daemon function can find
@@ -88,6 +93,31 @@ bridge_audit_log() {
   # many helper dependencies. Test asserts the warning + ledger state,
   # not audit rows.
   return 0
+}
+
+# Issue #1408: the production function now files the stuck alert via
+# `bridge_queue_cli upsert-open` (refresh-or-create one open task per stuck
+# message_id) instead of `$BRIDGE_HOME/agent-bridge task create`. Mock the
+# CLI so the test still controls the alert-filing rc per tick: the
+# `upsert-open` subcommand returns rc from BRIDGE_A2A_TEST_TASK_CREATE_RC
+# (0 = success, 1 = failure), exactly as the old agent-bridge shim did.
+# Any other subcommand (e.g. a future find-open) no-ops with success so the
+# stub never silently masks a different call path.
+# shellcheck disable=SC2329
+bridge_queue_cli() {
+  local rc="${BRIDGE_A2A_TEST_TASK_CREATE_RC:-0}"
+  case "${1:-}" in
+    upsert-open)
+      if [[ "$rc" == "1" ]]; then
+        printf 'mock-bridge_queue_cli: upsert-open failed (BRIDGE_A2A_TEST_TASK_CREATE_RC=1)\n' >&2
+        return 1
+      fi
+      return 0
+      ;;
+    *)
+      return 0
+      ;;
+  esac
 }
 
 # bridge_with_timeout signature: bridge_with_timeout <secs> <label> <cmd...>


### PR DESCRIPTION
## Lane A — daemon alert/nudge hygiene (refs #1408 #1411)

Wave: `mejurix-nudge`. Base: `feat/wave-mejurix-nudge-integration` (NOT main). Filed by @Mejurix on v0.15.0-rc1.

### #1408 — recurring admin alerts had no open-alert dedup (inbox flooding)
`process_a2a_outbox_stuck_scan_tick` and `process_unclaimed_queue_escalation` minted a brand-new high-priority admin task each cooldown window with no "prior alert still open" check (~116 dupes for ~6 real conditions over a weekend). Both families now route through a new **atomic** `bridge-queue.py upsert-open` subcommand that reuses the blocked-aging family's `upsert_open_task()` — refresh ONE open task per stable title-prefix instead of duplicating.

- **Atomic** (codex r1 BLOCKING → fixed): `upsert-open` issues `PRAGMA busy_timeout` + `BEGIN IMMEDIATE` before the `find_open_task_by_prefix` SELECT, then commit, with rollback + bounded retry on `database is locked`. This serializes find-or-create against every other queue writer, so concurrent daemon ticks cannot race a double-insert. No schema migration on the shared `tasks` table.
- **A2A cardinality**: dedup is **per message_id** (title-prefix `[A2A] outbox stuck: <peer>:<target_agent> (<msgid8>)`) — distinct stuck messages keep their own refreshable task, so no aggregate-into-one-body evidence loss.
- **Unclaimed**: dedup keys on the task id; the `(<Nm>)` age suffix is in the displayed title but excluded from the match prefix.
- **Status preserved on refresh**: `find-open` matches OPEN statuses only and the refresh path omits `status`, so an unread/claimed alert refreshes in place rather than resetting to `queued`.
- **`--force` removal is safe**: the stopped-target gate lives in `bridge-task.sh`, not `bridge-queue.py`, so `upsert-open` always enqueues (preserves the #1318 part A "enqueue when admin is stopped" behavior).
- **Gateway**: `upsert-open` is controller/daemon-direct; the gateway authorizer default-denies unknown subcommands, so a proxied iso agent calling it is correctly denied (intended).

### #1411 (primary only) — queued-task nudge lacked an attached-session gate
On an attached interactive admin session (composer ~always busy) the ACTION-REQUIRED inject couldn't auto-submit → spooled into `pending-attention.env` → replayed as `[deferred]` needing a manual Enter. Added an `attached>0 → skip` gate to `nudge_agent_session` mirroring the sibling `plugin_mcp_liveness_attached_skip` path:
- reuses the existing `bridge_tmux_session_attached_count "$session"` probe (no new probe);
- emits a `queue_attention_attached_skip` audit, **rate-limited** by the same fingerprint+redelivery window the dedup gate uses (no per-tick spam on a permanently-attached session);
- does **not** call `bridge_task_note_nudge` / record a successful nudge — no inject happened.

**Out of scope (follow-ups):** #1411's stale pending-attention.env re-derivation and the done-defeats-dedup re-bind both touch `lib/bridge-tmux.sh` (a sibling lane's file) and are deferred per the lane brief. The attached-gate alone resolves the core symptom.

### Course corrections folded in
1. Atomic queue-layer `upsert-open` (not shell find-open/create) — done.
2. A2A dedup per message_id (not per peer/agent) — done.
3. Attached-skip audit rate-limited + no note-nudge on skip — done.
4. Smoke file added but **NOT** registered in `scripts/ci-select-smoke.sh` (orchestrator batches both lanes' smokes in a separate integration commit).

### Verification
- `bash -n bridge-daemon.sh`, `shellcheck bridge-daemon.sh` + smoke: clean (exit 0).
- `python3 -m py_compile bridge-queue.py` + `ast.parse`: PASS.
- CI lint gates `lint-raw-pathlib-on-isolated.sh --check`, `iso-helper-ratchet.sh --check`, `lint-heredoc-ban.sh --baseline-check`: all exit 0.
- New smoke `scripts/smoke/1408-daemon-alert-nudge-hygiene.sh`: 10/10 PASS, including a **12-way concurrent-upsert atomicity assertion** (exactly 1 create, 1 open task, 0 errors).
- Adjacent smokes (1106, 1323, nudge-redundant-active-agent, nudge-marker-recovery, beta5-2-iota escalation-family, beta5-2-delta): all PASS — blocked-aging via daemon-step unaffected (`upsert_open_task` untouched).
- `scripts/smoke-test.sh`: the only failure (`#365` iso-env-guard) reproduces identically on the clean integration base (verified on a detached worktree) → pre-existing, not a regression.
- Internal codex review: r1 `needs-more` (atomicity) → fixed → r2 `implement-ok` (+ one non-blocking nit, also folded: `BEGIN IMMEDIATE` moved inside the retry try).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
