### PR TITLE
docs: template-sync design + Contract-I example + opus-4-8 default (Lane C, #1427)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -454,7 +454,7 @@ generated `claude` invocation:
 
 | field | default when opted in | flag |
 |---|---|---|
-| `BRIDGE_AGENT_MODEL` | `claude-opus-4-7` | `--model` |
+| `BRIDGE_AGENT_MODEL` | `claude-opus-4-8` | `--model` |
 | `BRIDGE_AGENT_EFFORT` | `xhigh` | `--effort` |
 | `BRIDGE_AGENT_PERMISSION_MODE` | `auto` | `--permission-mode` |
 
@@ -465,6 +465,57 @@ one field opts the agent into the new shape; remaining fields fall back to
 the defaults above. Set `BRIDGE_AGENT_PERMISSION_MODE["agent"]="legacy"`
 to explicitly pin the historical blanket-bypass shape (e.g. for sandboxed
 offline roles).
+
+### Seeding new agents from a reference agent (template-sync, issue #1427)
+
+On a fresh install, a newly-created non-admin agent comes up like a brand-new
+Claude Code — Sonnet, low effort, no plugins/skills — because its config tree
+is disjoint from the operator's `~/.claude` and from the admin agent. The
+`template-sync` wizard is the opt-in way to seed new (and selected existing)
+agents from a reference agent's roster fields:
+
+```bash
+agb setup template-sync [--from patch] [--exclude <csv>] [--dry-run] [--targets <csv>] [--yes]
+```
+
+(The wizard is interactive by default; the flags below are the non-interactive
+shortcuts. The exact flag set is finalized by the wizard implementation — run
+`agb setup template-sync --help` for the authoritative list on your install.)
+
+- `--from <agent>` — the reference agent to read defaults from (default: the
+  admin agent). The read is **roster-only**: model, effort, permission_mode,
+  plugins, skills, channels. No live `~/.claude`, settings, env, or MCP runtime
+  is introspected.
+- `--exclude <csv>` — dimensions to drop (`model,effort,permission_mode,plugins,skills,channels`).
+  The wizard is opt-out: it accepts every dimension by default and lets you
+  exclude per-dimension / per-item.
+- `--dry-run` — show the before/after diff (including the adjacent built-in
+  launch-default refresh `claude-opus-4-7` → `claude-opus-4-8`) and write
+  nothing.
+- `--targets <csv>` — existing agents to backfill (defaults to none — new
+  agents only). Existing agents are never touched until you name them here and
+  confirm.
+- `--yes` — skip the interactive confirm and accept the computed candidate
+  (still subject to the dimension excludes and the legacy/secret refusals).
+
+What the wizard writes is a controller-managed **defaults profile** block in
+`agent-roster.local.sh` (do not hand-edit it — re-run the wizard). `agent
+create <new>` then materializes those defaults as explicit per-agent roster
+rows on the new role. Two operator-facing caveats:
+
+- **Channels carry declarations only.** A synced channel such as
+  `plugin:teams@mkt` copies the *declaration*, never the credentials. Re-run
+  the per-channel setup wizard (`agb setup teams <agent>`, `agb setup ms365
+  <agent>`, etc.) to populate tokens for the new agent. No secrets, `.env`,
+  `access.json`, or refresh tokens are ever copied.
+- **Restart to apply.** Roster fields are read at agent startup with no live
+  reload, so launch/plugin/skill/channel changes from a backfill take effect
+  only after `agb agent restart <agent>`. The wizard reports
+  `restart_required=true` for runtime-affecting fields.
+
+`permission_mode=legacy` is never inherited (the wizard refuses/omits it and
+warns). Full design and security invariants:
+[`docs/template-sync-design.md`](./docs/template-sync-design.md).
 
 ### Admin agent CRUD policy
 

--- a/agent-roster.local.example.sh
+++ b/agent-roster.local.example.sh
@@ -137,7 +137,7 @@ BRIDGE_AGENT_LAUNCH_CMD["codex-developer"]='codex --dangerously-bypass-approvals
 # <mode> --name <agent>`; any field still unset on that agent falls back to
 # the fleet defaults shown below.
 #
-# BRIDGE_AGENT_MODEL["developer"]="claude-opus-4-7"            # default: claude-opus-4-7
+# BRIDGE_AGENT_MODEL["developer"]="claude-opus-4-8"            # default: claude-opus-4-8
 # BRIDGE_AGENT_EFFORT["developer"]="xhigh"                      # default: xhigh
 # BRIDGE_AGENT_PERMISSION_MODE["developer"]="auto"              # default: auto
 #
@@ -145,6 +145,39 @@ BRIDGE_AGENT_LAUNCH_CMD["codex-developer"]='codex --dangerously-bypass-approvals
 # offline role) without removing the model/effort hints, set permission_mode
 # explicitly to "legacy":
 # BRIDGE_AGENT_PERMISSION_MODE["sandboxed"]="legacy"
+
+# Template-sync defaults profile (issue #1427, controller-managed — do NOT hand-edit).
+#
+# `agb setup template-sync [--from <ref>]` writes a delimited, controller-owned
+# block into agent-roster.local.sh that seeds NEW agents created afterward (and
+# any existing agents you explicitly backfill) from a reference agent's roster
+# fields. `agent create <new>` reads this profile and MATERIALIZES the included
+# dimensions as EXPLICIT per-agent roster rows on the new role — it is not a
+# live accessor fallback, so existing agents with unset fields keep their
+# intentional legacy-launch contract until you explicitly backfill them.
+# Precedence: explicit per-agent fields > materialized defaults > the built-in
+# inline launch defaults (claude-opus-4-8 / xhigh / auto, new-shape rows only).
+#
+# The block is managed by the wizard; this is what it looks like (do not copy a
+# real one by hand — re-run the wizard instead). It is the literal Contract-I
+# format from docs/template-sync-design.md §"Shared contracts (I)": the leading
+# meta comment carries NO secrets (source agent, timestamp, the included/excluded
+# dimension lists, and a hash of the redacted candidate summary only), and ONLY
+# the included dimensions are emitted as vars — excluded dimensions are omitted,
+# not written as empty vars. Available vars: BRIDGE_TEMPLATE_DEFAULT_{MODEL,
+# EFFORT,PERMISSION_MODE,PLUGINS,SKILLS,CHANNELS}.
+#
+# # === agb:template-defaults v1 (managed by `setup template-sync`) ===
+# # source_agent=patch updated_at=2026-05-31T12:00:00Z included=model,effort,plugins,skills excluded=channels,permission_mode hash=<sha256-of-redacted-summary>
+# BRIDGE_TEMPLATE_DEFAULT_MODEL="claude-opus-4-8"
+# BRIDGE_TEMPLATE_DEFAULT_EFFORT="xhigh"
+# BRIDGE_TEMPLATE_DEFAULT_PLUGINS="cosmax-crm,playwright"
+# BRIDGE_TEMPLATE_DEFAULT_SKILLS="agent-db"
+# # permission_mode intentionally omitted (legacy is NEVER inherited)
+# # channels intentionally omitted here; when included, channels carry the
+# # declaration only (e.g. plugin:teams@mkt) — re-run `setup teams <agent>` to
+# # populate credentials, then restart the agent to apply.
+# # === end agb:template-defaults ===
 
 # Optional: auto-stop timeout in seconds. Set this only for roles you
 # explicitly want the daemon to stop after inactivity. An explicit `0` marks a

--- a/docs/developer-handover.md
+++ b/docs/developer-handover.md
@@ -485,6 +485,52 @@ same contract internally and remain in place because their
 catalog-filtering work is non-trivial. New callsites that need a
 root-published per-agent manifest write should call `bridge_iso_run`.
 
+### 9. template-sync — reference 에이전트에서 새 에이전트 시드 (issue #1427)
+
+`agb setup template-sync`는 한 reference 에이전트(보통 `patch`)의 roster
+필드를 가져와 이후 생성되는 새 에이전트(그리고 명시적으로 backfill 하는
+기존 에이전트)의 model/effort/permission_mode/plugins/skills/channels를
+시드한다. 설계 전문은 [`docs/template-sync-design.md`](./template-sync-design.md)
+에 있다 — 새 에이전트가 fresh Claude Code처럼 Sonnet/low-effort/no-plugin으로
+올라오는 문제를 opt-in 위저드로 해결한다.
+
+이 영역을 만질 때 반드시 기억할 두 가지 함정:
+
+- **Sync 대상은 ROSTER이지 `settings.json`이 아니다.** model/effort/
+  permission_mode는 `bridge_build_static_launch_cmd`
+  (lib/bridge-state.sh:53-75)가 roster에서 읽어 launch argv로 넘기는
+  값이다. `settings.json`에 model을 써도 launch flag가 이기므로 no-op이다.
+  동기화는 항상 `agent-roster.local.sh`의 명시적 per-agent 필드를 쓴다.
+- **Materialize-not-fallback.** `setup template-sync`가 쓰는
+  defaults-profile 블록은 create/backfill 시점에만 소비되어 명시적 필드를
+  **물질화(materialize)** 한다. 접근자(`bridge_agent_model/effort/...`)가
+  global default를 반환하도록 바꾸면 안 된다 — 그렇게 하면 필드 미설정
+  상태로 legacy-launch 계약에 있던 모든 기존 roster가 조용히 새 launch
+  shape로 뒤집힌다. 우선순위: 명시적 per-agent 필드 > 물질화된 defaults
+  (= create/backfill 후의 명시적 필드) > 빌트인 inline launch default
+  (`claude-opus-4-8` / xhigh / auto, new-shape 행 한정, 최후 수단).
+
+보안 불변식 (설계 doc §"Hard security invariants"):
+
+- secret은 절대 복사하지 않는다 — MCP/plugin secret, `.mcp.json` env,
+  `.teams`/`.ms365`/`.env`/`access.json`, refresh token, app password,
+  client secret. **이름/스키마만** 동기화하고 운영자가 per-channel `setup`
+  위저드로 재투입한다. channels는 선언(`plugin:teams@mkt`)만 운반한다.
+- `permission_mode=legacy`는 절대 자동 전파하지 않는다.
+- silent model upgrade 없음 — dry-run / before-after diff + 운영자 확인.
+  기존 에이전트는 명시적 backfill 전까지 건드리지 않는다.
+- reference 읽기는 **roster-only**. patch의 live `$HOME/.claude`, 설치된
+  plugin 캐시, settings, env, MCP 런타임을 introspect 하지 않는다
+  (isolation으로도 막혀 있다).
+
+defaults-profile 블록의 정확한 포맷(Contract I)은 설계 doc
+§"Shared contracts (I)"가 pin이며, 같은 포맷의 copy-pasteable 예시가
+`agent-roster.local.example.sh` 주석에 있다 (excluded 차원은 빈 var가 아니라
+아예 생략된다). 빌트인 last-resort
+launch default는 이 작업과 함께 `claude-opus-4-7`에서 `claude-opus-4-8`로
+갱신됐다(lib/bridge-state.sh:68); 기존 명시적 roster 항목은 건드리지 않는
+adjacent 변경이며 dry-run에 노출된다.
+
 ## 6. 개발할 때의 기본 작업 흐름
 
 ### 상태 파악

--- a/docs/template-sync-design.md
+++ b/docs/template-sync-design.md
@@ -1,0 +1,85 @@
+# Template-sync — seed new agents from a reference agent (design)
+
+**Status:** codex-signed-off design (implement-ok with amendments, agb-dev-codex 2026-05-31). Canonical spec for the 3-lane implementation wave. This file lands as `docs/template-sync-design.md`.
+
+## Problem
+
+On a fresh bridge install, newly-created non-admin agents come up like a brand-new Claude Code — **Sonnet, low effort, no plugins/skills/MCP** — because each agent's config tree is disjoint from the operator's system `~/.claude` and from the admin agent `patch`, and the scaffold template is bare. The operator wants an opt-in wizard that seeds new (and optionally existing) agents from a reference agent's config, with an exclude step.
+
+## Architectural reality (the crux)
+
+Three disjoint config planes. **model/effort/permission_mode are ROSTER-driven launch flags, never persisted to `settings.json`** (`bridge_build_static_launch_cmd`, lib/bridge-state.sh:53-75). Writing model into settings.json is a no-op — launch flags from argv win.
+
+- **Plane A — Roster** (`agent-roster.local.sh`, git-ignored; accessors lib/bridge-agents.sh:8948-9083): model, effort, permission_mode, skills, plugins, channels. Read at **startup** (no live reload → restart to apply).
+- **Plane B — Launch cmd** (derived from A at launch). Empty roster fields → `bridge_agent_uses_legacy_launch_flags` true → legacy shape `claude --dangerously-skip-permissions --name <a>` with **no `--model`** → Claude's own Sonnet default. Otherwise → `claude --model <m> --effort <e> --permission-mode <pm>` with inline defaults model=`claude-opus-4-7`, effort=xhigh, pm=auto (bridge-state.sh:68-70).
+- **Plane C — `.claude/settings.json`** + managed render (bridge-hooks.py:209): autoCompact/prompt-flags/hooks only — **NO model/plugins/skills/MCP**. Out of scope for sync.
+
+**Sync target = the ROSTER (explicit per-agent fields), never settings.json or a template file.**
+
+## Decision: hybrid-C, materialized (NOT a live accessor fallback)
+
+`setup template-sync` writes a controller-owned **defaults profile** into `agent-roster.local.sh`. `agent create` consumes that profile and writes the selected dimensions as **explicit per-agent roster fields** into the new role block. Optional backfill writes explicit fields to selected existing agents after a diff/confirm.
+
+**SAFETY INVARIANT (codex catch):** the defaults profile is consumed only at **create/backfill time** to MATERIALIZE explicit fields. The accessors (`bridge_agent_model/effort/permission_mode/channels_csv/plugins_csv/skills_csv`) MUST NOT start returning a global default — that would silently flip every OLD roster with unset fields out of the intentional legacy-launch contract (bridge-state.sh:62-71, bridge-agents.sh:9366-9380). Precedence: **explicit per-agent fields always win > materialized defaults (= explicit after create/backfill) > built-in inline defaults (new-shape launch rows only, last resort)**.
+
+## Sync set (data-only, roster-resident)
+
+| # | Dimension | Action | Guard |
+|---|---|---|---|
+| 1 | model | write `BRIDGE_AGENT_MODEL[a]` | refresh built-in default opus-4-7→opus-4-8 (adjacent change, dry-run shows it) |
+| 2 | effort | write `BRIDGE_AGENT_EFFORT[a]` | partial-inherit footgun: empty effort inherits new-shape xhigh, not "none" — show in summary |
+| 3 | permission_mode | write `BRIDGE_AGENT_PERMISSION_MODE[a]` | **`legacy` is NEVER inherited** — omit/refuse the dimension + warn if the reference has it |
+| 4 | skills | write `BRIDGE_AGENT_SKILLS[a]` | sync only the EXTRA per-agent skills (5 shared skills already auto-attached); materialize = restart/bootstrap re-run |
+| 5 | plugins | write `BRIDGE_AGENT_PLUGINS[a]` | validate against installed catalog; marketplace reachability warn |
+| 6 | channels | write `BRIDGE_AGENT_CHANNELS[a]` | **declarations only** (`plugin:teams@mkt`); emit per-channel setup-pending next-action (`agb setup teams <a>`) |
+| 7 | MCP | **schema-only**, rides on dims 5/6 | **never copy `.mcp.json` env / secret values** |
+| 8 | settings (autoCompact/hooks) | **out of scope** | renderer-owned, derived from agent_class |
+
+## Hard security invariants
+1. Never copy MCP/plugin secrets, `.mcp.json` env, API keys/tokens, `.teams`/`.ms365`/`.env`/`access.json`, refresh tokens, app passwords, client secrets — **names/schema only**; operator re-populates via the per-channel `setup` wizards.
+2. Never auto-propagate `permission_mode=legacy`.
+3. No silent model upgrade — dry-run / before-after diff + operator confirm; existing agents untouched until explicitly backfilled.
+4. Reference read = **roster-only**. Do NOT introspect patch's live `$HOME/.claude`, installed-plugin cache, settings, env, or MCP runtime (isolation-blocked anyway). Distinguish "reference value" vs "bridge default" in output. (Future: a redacted `agent show --json` manifest; v1 stays roster-only.)
+5. Same system-config mutation boundary as `agent create/update` (operator-tui / operator-trusted-id + admin context where applicable + audit). Not a weaker write path.
+6. Template metadata carries NO secrets: `source_agent`, `updated_at`, `included_dimensions`, `excluded_dimensions`, hash of the redacted candidate summary.
+
+## Behavior
+- **`agb setup template-sync [--from patch] [--exclude <csv>] [--dry-run] [--yes]`** — opt-out wizard: accept-all default, per-dimension + per-item exclusion; before/after diff to stderr; structured stdout result; v1 Claude-agents only (backfill skips incompatible engines with a reason).
+- **`agent create <new>`** — reads the defaults profile, materializes explicit fields (subject to the new agent's own explicit fields winning); `--dry-run` shows the new agent will get explicit model/effort/pm/plugins/skills/channels rows.
+- **Backfill** — roster-only, no restart by default; per-agent diff; mark `restart_required=true` for launch/plugin/skill/channel changes; reuse existing runtime materialization paths (bridge-skills.sh:135/455-491, bridge-agents.sh channel derivation 9201-9213); print restart next-step; preserve unrelated managed-role fields.
+
+## Shared contracts (pin to avoid cross-lane drift)
+
+**(I) Defaults-profile format** in `agent-roster.local.sh` — a delimited, controller-owned block, e.g.:
+```
+# === agb:template-defaults v1 (managed by `setup template-sync`) ===
+# source_agent=patch updated_at=<iso> included=model,effort,plugins,skills excluded=channels,permission_mode
+BRIDGE_TEMPLATE_DEFAULT_MODEL="claude-opus-4-8"
+BRIDGE_TEMPLATE_DEFAULT_EFFORT="xhigh"
+BRIDGE_TEMPLATE_DEFAULT_PLUGINS="cosmax-crm,playwright"
+BRIDGE_TEMPLATE_DEFAULT_SKILLS="..."
+# permission_mode intentionally omitted (legacy refused / excluded)
+# === end agb:template-defaults ===
+```
+(Final var names/format are Lane A+B+C's shared contract — Lane A reads it in `agent create`, Lane B writes it from the wizard, Lane C documents it in the example file. Whoever lands first pins it; the others match. Keep it sourceable bash + machine-parseable.)
+
+**(II) Roster materialize interface** — Lane A exposes a callable, audited, multi-field-atomic writer (a new internal verb e.g. `agent-bridge roster materialize-fields <agent> --model .. --effort .. --permission-mode .. --plugins <csv> --skills <csv> --channels <csv> [--dry-run] [--json]`, or an equivalently-contracted function) that Lane B's wizard invokes to apply. It: writes ONLY roster fields, never settings.json; refuses `legacy`; emits a structured diff + audit; is idempotent (no-change = no-op). Lane B codes against this interface and stubs it in its own unit smoke; end-to-end apply is verified at integration.
+
+## Tests (8 required smokes — orchestrator registers in ci-select via integration commit)
+1. Dry-run from a fixture roster writes nothing + deterministic candidate/diff.
+2. Apply writes only allowed roster fields, never `.claude/settings.json`.
+3. Reference `permission_mode=legacy` not propagated → surfaced as refused/omitted.
+4. Secret-shaped fixtures (channel creds, env, plugin state, settings) never appear in stdout/stderr or the roster.
+5. `agent create newA --dry-run` after an accepted profile → new agent gets EXPLICIT model/effort/pm/plugins/skills/channels rows (not implicit launch fallback).
+6. Existing agents unchanged until an explicit backfill target is selected.
+7. Backfill preserves unrelated managed-role fields + reports `restart_required` for runtime-affecting fields.
+8. No-reference-config patch → partial candidate with "unset / reference missing" status, not guessed values.
+
+## Implementation gaps to close
+- `bridge_write_role_block` (bridge-agent.sh:1089-1158) emits channels but NOT model/effort/plugins/skills → extend it / add the structured multi-field writer (contract II).
+- Gate `setup template-sync` with the agent-create mutation boundary (bridge-agent.sh:3273-3289 pattern) + audit. Not a weaker path than the existing one-field setup writers (bridge-setup.sh:253-326).
+- v1 Claude-only; backfill skips incompatible engines with explicit reason.
+- opus-4-7→opus-4-8: lib/bridge-state.sh:68 + agent-roster.local.example.sh:140-142 (Lane C; surfaced in dry-run, no silent upgrade of existing agents).
+
+## Out of scope
+Channel credential migration (existing per-channel wizards), settings.json/hooks (renderer-owned), live patch-process introspection, MCP secret copying, Codex-engine semantics for these dimensions (v1).

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -65,7 +65,7 @@ bridge_claude_dynamic_launch_cmd() {
     model="$(bridge_agent_model "$agent")"
     effort="$(bridge_agent_effort "$agent")"
     pm="$(bridge_agent_permission_mode "$agent")"
-    [[ -n "$model" ]] || model="claude-opus-4-7"
+    [[ -n "$model" ]] || model="claude-opus-4-8"
     [[ -n "$effort" ]] || effort="xhigh"
     [[ -n "$pm" ]] || pm="auto"
     argv+=(--model "$model" --effort "$effort" --permission-mode "$pm" --name "$agent")


### PR DESCRIPTION
## Lane C — template-sync docs + adjacent default refresh (refs #1427)

Lane C of the `template-sync` feature wave. Docs + the adjacent built-in launch-default refresh only — fully independent of Lanes A (`agent create` reader) and B (the wizard writer). No feature code.

### What changed
- **opus-4-7 → opus-4-8 launch default** at the three launch-default surfaces only:
  - `lib/bridge-state.sh:68` — inline last-resort default in the new-shape launch builder.
  - `agent-roster.local.example.sh` — documented example/default.
  - `OPERATIONS.md` — launch-flag-overrides default table.
  - **No silent upgrade**: only the last-resort default for *new-shape* launch rows whose model field is unset changes. Legacy rosters (`claude --dangerously-skip-permissions --name <a>`) and explicit per-agent `BRIDGE_AGENT_MODEL` entries are byte-for-byte untouched (probe-verified). Incidental opus-4-7 model-ids in the autocompact smokes and the autoCompactWindow print-suffix illustration are intentionally left.
- **Contract-I defaults-profile block** documented in `agent-roster.local.example.sh` as a copy-pasteable, do-not-hand-edit example, byte-faithful to the design's §"Shared contracts (I)" literal (bare meta line, included-dimensions-only vars, excluded dims omitted not empty). Lane A's reader and Lane B's writer can pin against either interchangeably.
- **`docs/template-sync-design.md`** — the converged design committed verbatim.
- **Feature docs**: `docs/developer-handover.md` (design pointer + roster-not-settings / materialize-not-fallback gotchas + security invariants) and `OPERATIONS.md` (operator-facing `agb setup template-sync` usage: `--from/--exclude/--dry-run/--targets/--yes`, channels carry declarations only → re-run `setup teams`, restart-to-apply, legacy never inherited).

### Verification (exact CI gates, all green)
- `bash -n lib/bridge-state.sh` — PASS
- `shellcheck lib/bridge-state.sh agent-roster.local.example.sh` — PASS
- `lint-raw-pathlib-on-isolated.sh --check` — exit 0
- `iso-helper-ratchet.sh --check` — exit 0 (benign macOS stderr noise; pre-existing)
- `lint-heredoc-ban.sh --baseline-check` — PASS (no count change)
- `git diff --check` — clean
- Functional probe: new-shape+model-unset → `claude --model claude-opus-4-8 …`; legacy → unchanged (no `--model`).
- Internal `codex:codex-rescue` review: **implement-ok** (r2; r1 `needs-more` on Contract-I format + `--targets` CLI drift, both fixed).

No VERSION/CHANGELOG (per wave policy).

### Orchestrator note
`agent-roster.sh:55` carries a stale comment describing the launch default as `claude-opus-4-7 / xhigh / auto`. It is outside Lane C's exclusive file set, so I left it untouched — flagging for the orchestrator to fold into the integration branch (or a follow-up) for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)