### PR TITLE
feat(template-sync): Lane B — setup template-sync wizard (#1427)

### DIFF
--- a/bridge-setup.py
+++ b/bridge-setup.py
@@ -3010,6 +3010,512 @@ def cmd_mattermost(args: argparse.Namespace) -> int:
         return 1
 
 
+# ---------------------------------------------------------------------------
+# Issue #1427 Lane B — `setup template-sync`.
+#
+# Seed new (and optionally existing) agents from a reference agent's
+# ROSTER-resident config. The hard contracts (see docs/template-sync-
+# design.md):
+#   * Reference read is ROSTER-ONLY — this command consumes the reference
+#     agent's raw `BRIDGE_AGENT_*` values that the bash dispatch sourced
+#     and forwarded via `--ref-*`. It never opens the reference's
+#     $HOME/.claude, plugin cache, settings, env, .mcp.json, or any channel
+#     secret file.
+#   * Hard security redaction — channels are copied as DECLARATIONS only
+#     (`plugin:teams@mkt`); no creds/tokens/MCP secrets/.env/access.json
+#     ever appear in the candidate, diff, profile, or metadata.
+#   * `permission_mode=legacy` is NEVER inherited — refused + omitted + warn.
+#   * No guessing — a dimension the reference never set is surfaced as
+#     "unset / reference missing", not a fabricated default.
+# ---------------------------------------------------------------------------
+
+# Canonical dimension order. model/effort/permission_mode are scalar;
+# plugins/skills/channels are token lists (space/comma separated in the
+# roster, normalized to a sorted, de-duped list here for determinism).
+_TEMPLATE_SYNC_DIMENSIONS = (
+    "model",
+    "effort",
+    "permission_mode",
+    "plugins",
+    "skills",
+    "channels",
+)
+
+_TEMPLATE_SYNC_LIST_DIMENSIONS = frozenset({"plugins", "skills", "channels"})
+
+# Roster variable name per dimension (Contract-I).
+_TEMPLATE_SYNC_PROFILE_VARS = {
+    "model": "BRIDGE_TEMPLATE_DEFAULT_MODEL",
+    "effort": "BRIDGE_TEMPLATE_DEFAULT_EFFORT",
+    "permission_mode": "BRIDGE_TEMPLATE_DEFAULT_PERMISSION_MODE",
+    "plugins": "BRIDGE_TEMPLATE_DEFAULT_PLUGINS",
+    "skills": "BRIDGE_TEMPLATE_DEFAULT_SKILLS",
+    "channels": "BRIDGE_TEMPLATE_DEFAULT_CHANNELS",
+}
+
+# Runtime-affecting dimensions — any change to these on an existing agent
+# requires a restart for the launch/plugin/skill/channel materialization to
+# take effect.
+_TEMPLATE_SYNC_RESTART_DIMENSIONS = frozenset(_TEMPLATE_SYNC_DIMENSIONS)
+
+_TEMPLATE_SYNC_BEGIN_MARKER = "# === agb:template-defaults v1 (managed by `setup template-sync`) ==="
+_TEMPLATE_SYNC_END_MARKER = "# === end agb:template-defaults ==="
+
+
+def _template_sync_normalize_list(raw: str) -> list[str]:
+    """Split a roster list value (space/comma separated) into a sorted,
+    de-duped token list. Order is normalized so the candidate hash and
+    diff are deterministic regardless of the reference's token order."""
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for chunk in re.split(r"[\s,]+", raw.strip()):
+        token = chunk.strip()
+        if not token or token in seen:
+            continue
+        seen.add(token)
+        tokens.append(token)
+    return sorted(tokens)
+
+
+def _template_sync_channel_setup_hint(channel_decl: str) -> str | None:
+    """Map a channel declaration (`plugin:teams@mkt`, `plugin:ms365`) to its
+    per-channel setup-pending next-action. Declarations only — the operator
+    re-populates credentials via the per-channel `setup` wizard. Returns
+    None for declarations with no known credential wizard."""
+    label = channel_decl
+    if label.startswith("plugin:"):
+        label = label[len("plugin:"):]
+    # Strip the `@marketplace` qualifier.
+    label = label.split("@", 1)[0].strip().lower()
+    known = {"teams", "ms365", "discord", "telegram", "mattermost"}
+    if label in known:
+        return f"agb setup {label} <agent>"
+    return None
+
+
+def _template_sync_build_candidate(args: argparse.Namespace) -> dict[str, Any]:
+    """Compute the redacted sync candidate from the reference's raw roster
+    values (forwarded via `--ref-*`). Each dimension entry records:
+      value   — the redacted candidate value (scalar str or token list)
+      source  — "reference" | "bridge-default" | "unset"
+      status  — "ok" | "unset / reference missing" | "refused: legacy"
+    No secret material is ever read or emitted — channels stay declarations.
+    """
+    raw = {
+        "model": args.ref_model,
+        "effort": args.ref_effort,
+        "permission_mode": args.ref_permission_mode,
+        "plugins": args.ref_plugins,
+        "skills": args.ref_skills,
+        "channels": args.ref_channels,
+    }
+    candidate: dict[str, Any] = {}
+    warnings: list[str] = []
+
+    for dim in _TEMPLATE_SYNC_DIMENSIONS:
+        ref_val = raw[dim]
+        # `None` (the argparse sentinel) == reference never declared this
+        # dimension. An explicit empty string == declared-but-empty, also
+        # treated as "unset" (no token / no scalar to inherit).
+        if ref_val is None or ref_val.strip() == "":
+            if dim == "model":
+                # Only model has a meaningful built-in default to fall back
+                # to (the new-shape launch default). effort/pm/lists do not
+                # — a missing list is genuinely empty, not "the default".
+                candidate[dim] = {
+                    "value": args.default_model,
+                    "source": "bridge-default",
+                    "status": "ok",
+                }
+            elif dim == "effort":
+                candidate[dim] = {
+                    "value": args.default_effort,
+                    "source": "bridge-default",
+                    "status": "ok",
+                }
+            else:
+                candidate[dim] = {
+                    "value": [] if dim in _TEMPLATE_SYNC_LIST_DIMENSIONS else "",
+                    "source": "unset",
+                    "status": "unset / reference missing",
+                }
+            continue
+
+        if dim == "permission_mode" and ref_val.strip().lower() == "legacy":
+            # Hard invariant: legacy is NEVER inherited.
+            candidate[dim] = {
+                "value": "",
+                "source": "reference",
+                "status": "refused: legacy",
+            }
+            warnings.append(
+                "permission_mode=legacy on the reference agent is NEVER "
+                "inherited — dimension omitted from the defaults profile."
+            )
+            continue
+
+        if dim in _TEMPLATE_SYNC_LIST_DIMENSIONS:
+            tokens = _template_sync_normalize_list(ref_val)
+            candidate[dim] = {
+                "value": tokens,
+                "source": "reference",
+                "status": "ok" if tokens else "unset / reference missing",
+            }
+        else:
+            candidate[dim] = {
+                "value": ref_val.strip(),
+                "source": "reference",
+                "status": "ok",
+            }
+
+    return {"dimensions": candidate, "warnings": warnings}
+
+
+def _template_sync_parse_exclude(exclude_csv: str) -> tuple[set[str], dict[str, set[str]]]:
+    """Parse `--exclude` into (excluded-dimensions, per-item-excludes).
+    Entries: `model` (whole dimension) or `plugins:foo@mkt` (single item).
+    Unknown dimension names raise SetupError so a typo never silently
+    includes a dimension the operator meant to drop."""
+    dims_out: set[str] = set()
+    items_out: dict[str, set[str]] = {}
+    for chunk in exclude_csv.split(","):
+        entry = chunk.strip()
+        if not entry:
+            continue
+        if ":" in entry:
+            dim, item = entry.split(":", 1)
+            dim = dim.strip()
+            item = item.strip()
+            if dim not in _TEMPLATE_SYNC_DIMENSIONS:
+                raise SetupError(f"--exclude references unknown dimension: {dim!r}")
+            if dim not in _TEMPLATE_SYNC_LIST_DIMENSIONS:
+                raise SetupError(
+                    f"--exclude per-item form (dim:item) only applies to "
+                    f"list dimensions {sorted(_TEMPLATE_SYNC_LIST_DIMENSIONS)}; "
+                    f"got {entry!r}"
+                )
+            items_out.setdefault(dim, set()).add(item)
+        else:
+            if entry not in _TEMPLATE_SYNC_DIMENSIONS:
+                raise SetupError(f"--exclude references unknown dimension: {entry!r}")
+            dims_out.add(entry)
+    return dims_out, items_out
+
+
+def _template_sync_apply_exclude(
+    candidate: dict[str, Any],
+    excluded_dims: set[str],
+    excluded_items: dict[str, set[str]],
+) -> tuple[dict[str, Any], list[str]]:
+    """Apply the opt-out exclude set to the candidate. Returns the included
+    map (dim -> entry, only dims that survive with a usable value) plus the
+    ordered list of excluded dimension names (for metadata)."""
+    included: dict[str, Any] = {}
+    excluded_order: list[str] = []
+    for dim in _TEMPLATE_SYNC_DIMENSIONS:
+        entry = candidate["dimensions"][dim]
+        if dim in excluded_dims:
+            excluded_order.append(dim)
+            continue
+        # Drop dimensions with nothing usable: unset scalars/lists and the
+        # legacy-refused permission_mode never reach the profile.
+        if entry["status"].startswith("unset") or entry["status"].startswith("refused"):
+            excluded_order.append(dim)
+            continue
+        if dim in _TEMPLATE_SYNC_LIST_DIMENSIONS:
+            drop = excluded_items.get(dim, set())
+            kept = [tok for tok in entry["value"] if tok not in drop]
+            if not kept:
+                excluded_order.append(dim)
+                continue
+            included[dim] = {**entry, "value": kept}
+        else:
+            included[dim] = entry
+    return included, excluded_order
+
+
+def _template_sync_candidate_hash(included: dict[str, Any]) -> str:
+    """Stable hash of the REDACTED candidate summary (dimension -> value).
+    Channels are declarations only, so this hash carries no secret bytes —
+    it is safe to persist in the profile metadata."""
+    parts = []
+    for dim in _TEMPLATE_SYNC_DIMENSIONS:
+        if dim not in included:
+            continue
+        val = included[dim]["value"]
+        if isinstance(val, list):
+            rendered = " ".join(val)
+        else:
+            rendered = str(val)
+        parts.append(f"{dim}={rendered}")
+    payload = "\n".join(parts)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def _template_sync_render_profile(
+    source_agent: str,
+    included: dict[str, Any],
+    excluded_order: list[str],
+    updated_at: str,
+    candidate_hash: str,
+) -> str:
+    """Render the Contract-I defaults-profile block (sourceable bash +
+    machine-parseable). Only included dimensions emit a var; excluded /
+    legacy-refused dimensions are documented in the meta line + a comment."""
+    included_names = [d for d in _TEMPLATE_SYNC_DIMENSIONS if d in included]
+    lines = [
+        _TEMPLATE_SYNC_BEGIN_MARKER,
+        (
+            f"# meta: source_agent={source_agent} updated_at={updated_at} "
+            f"included={','.join(included_names) or '(none)'} "
+            f"excluded={','.join(excluded_order) or '(none)'} "
+            f"hash={candidate_hash}"
+        ),
+    ]
+    for dim in _TEMPLATE_SYNC_DIMENSIONS:
+        var = _TEMPLATE_SYNC_PROFILE_VARS[dim]
+        if dim not in included:
+            continue
+        val = included[dim]["value"]
+        if isinstance(val, list):
+            rendered = " ".join(val)
+        else:
+            rendered = str(val)
+        lines.append(f'{var}="{rendered}"')
+    if "permission_mode" in excluded_order:
+        lines.append("# permission_mode intentionally omitted (legacy refused / excluded)")
+    lines.append(_TEMPLATE_SYNC_END_MARKER)
+    return "\n".join(lines) + "\n"
+
+
+def _template_sync_read_existing_block(roster_text: str) -> str:
+    """Extract the current template-defaults block from roster text (for the
+    before/after diff). Empty string when no block exists yet."""
+    start = roster_text.find(_TEMPLATE_SYNC_BEGIN_MARKER)
+    if start == -1:
+        return ""
+    end = roster_text.find(_TEMPLATE_SYNC_END_MARKER, start)
+    if end == -1:
+        return ""
+    return roster_text[start:end + len(_TEMPLATE_SYNC_END_MARKER)] + "\n"
+
+
+def _template_sync_splice_block(roster_text: str, new_block: str) -> str:
+    """Replace an existing template-defaults block in place, or append it.
+    Idempotent shape: the markers always delimit exactly one block."""
+    start = roster_text.find(_TEMPLATE_SYNC_BEGIN_MARKER)
+    if start != -1:
+        end = roster_text.find(_TEMPLATE_SYNC_END_MARKER, start)
+        if end != -1:
+            end_full = end + len(_TEMPLATE_SYNC_END_MARKER)
+            # Swallow a single trailing newline so re-splicing does not
+            # accumulate blank lines.
+            if end_full < len(roster_text) and roster_text[end_full] == "\n":
+                end_full += 1
+            return roster_text[:start] + new_block + roster_text[end_full:]
+    base = roster_text
+    if base and not base.endswith("\n"):
+        base += "\n"
+    if base and not base.endswith("\n\n"):
+        base += "\n"
+    return base + new_block
+
+
+def _template_sync_materialize_cmd() -> list[str]:
+    """Resolve the Contract-II writer command. Defaults to Lane A's
+    `agent-bridge roster materialize-fields`; overridable via
+    BRIDGE_TEMPLATE_SYNC_MATERIALIZE_CMD so the unit smoke can stub the
+    not-yet-landed Lane A verb without an end-to-end roster mutation."""
+    override = os.environ.get("BRIDGE_TEMPLATE_SYNC_MATERIALIZE_CMD", "").strip()  # noqa: iso-helper-boundary — plain env read (os.environ matches the `.env` ratchet pattern), not an iso file access
+    if override:
+        return override.split()
+    agb = os.environ.get("BRIDGE_AGENT_BRIDGE_BIN", "").strip() or "agent-bridge"  # noqa: iso-helper-boundary — plain env read (os.environ matches the `.env` ratchet pattern), not an iso file access
+    return [agb, "roster", "materialize-fields"]
+
+
+def _template_sync_backfill_target(
+    target: str,
+    included: dict[str, Any],
+    dry_run: bool,
+) -> dict[str, Any]:
+    """Apply the included defaults to an existing agent via Contract-II.
+    Builds the materialize-fields argv from the included dimensions (legacy
+    is already excluded upstream), invokes the writer, and reports the
+    structured result + restart-required flag. Never writes settings.json —
+    the writer is a roster-only contract."""
+    cmd = _template_sync_materialize_cmd()
+    cmd += [target]
+    for dim in _TEMPLATE_SYNC_DIMENSIONS:
+        if dim not in included:
+            continue
+        val = included[dim]["value"]
+        rendered = " ".join(val) if isinstance(val, list) else str(val)
+        cmd += [f"--{dim.replace('_', '-')}", rendered]
+    if dry_run:
+        cmd.append("--dry-run")
+    cmd.append("--json")
+    restart_required = any(
+        dim in _TEMPLATE_SYNC_RESTART_DIMENSIONS for dim in included
+    )
+    entry: dict[str, Any] = {
+        "agent": target,
+        "restart_required": restart_required,
+        "writer_cmd": cmd[0],
+    }
+    try:
+        proc = subprocess.run(  # noqa: raw-subprocess — Contract-II writer call
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        entry["status"] = "writer_missing"
+        entry["error"] = str(exc)
+        return entry
+    entry["rc"] = proc.returncode
+    entry["status"] = "ok" if proc.returncode == 0 else "error"
+    if proc.returncode != 0:
+        entry["error"] = (proc.stderr or proc.stdout or "").strip()
+    return entry
+
+
+def _template_sync_print_result(result: dict[str, Any], *, stream: Any = sys.stdout) -> None:
+    """Structured result to stdout (machine-parseable JSON). The human
+    before/after summary is written separately to stderr by the caller so
+    the stdout stream stays clean for the admin agent to parse."""
+    print(json.dumps(result, ensure_ascii=False, indent=2), file=stream)
+
+
+def cmd_template_sync(args: argparse.Namespace) -> int:
+    source_agent = args.from_agent
+    result: dict[str, Any] = {
+        "command": "template-sync",
+        "source_agent": source_agent,
+        "roster_file": args.roster_file,
+        "write_status": "pending",
+        "dry_run": bool(args.dry_run),
+    }
+    try:
+        # v1 Claude-only. A non-claude reference cannot supply these
+        # dimensions in a portable way (codex-engine launch semantics
+        # differ), so fail loud rather than synthesize a bogus candidate.
+        ref_engine = (args.ref_engine or "").strip().lower()
+        if ref_engine and ref_engine != "claude":
+            raise SetupError(
+                f"template-sync v1 supports Claude reference agents only; "
+                f"reference '{source_agent}' engine is {ref_engine!r}."
+            )
+
+        excluded_dims, excluded_items = _template_sync_parse_exclude(args.exclude)
+
+        candidate = _template_sync_build_candidate(args)
+        result["warnings"] = candidate["warnings"]
+        # Surface the full per-dimension candidate (redacted) so the
+        # operator/admin sees reference-vs-default and unset status.
+        result["candidate"] = {
+            dim: {
+                "value": candidate["dimensions"][dim]["value"],
+                "source": candidate["dimensions"][dim]["source"],
+                "status": candidate["dimensions"][dim]["status"],
+            }
+            for dim in _TEMPLATE_SYNC_DIMENSIONS
+        }
+
+        included, excluded_order = _template_sync_apply_exclude(
+            candidate, excluded_dims, excluded_items
+        )
+        result["included_dimensions"] = [
+            d for d in _TEMPLATE_SYNC_DIMENSIONS if d in included
+        ]
+        result["excluded_dimensions"] = excluded_order
+
+        # Per-channel setup-pending next-actions (declarations only).
+        channel_next_actions: list[dict[str, str]] = []
+        if "channels" in included:
+            for decl in included["channels"]["value"]:
+                hint = _template_sync_channel_setup_hint(decl)
+                channel_next_actions.append(
+                    {
+                        "channel": decl,
+                        "next_action": hint or "(no credential wizard — declaration only)",
+                        "state": "setup-pending",
+                    }
+                )
+        result["channel_next_actions"] = channel_next_actions
+
+        updated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        candidate_hash = _template_sync_candidate_hash(included)
+        result["candidate_hash"] = candidate_hash
+
+        new_block = _template_sync_render_profile(
+            source_agent, included, excluded_order, updated_at, candidate_hash
+        )
+        result["profile_block"] = new_block
+
+        roster_path = Path(args.roster_file)
+        if _safe_path_check("exists", roster_path, _resolve_isolated_owner_for_path(roster_path)):
+            roster_text = roster_path.read_text(encoding="utf-8")
+        else:
+            roster_text = "#!/usr/bin/env bash\n# shellcheck shell=bash disable=SC2034\n"
+        existing_block = _template_sync_read_existing_block(roster_text)
+        result["before_block"] = existing_block
+        result["after_block"] = new_block
+
+        # Before/after human summary to STDERR (stdout stays structured).
+        _template_sync_emit_summary(result, stream=sys.stderr)
+
+        targets = [t.strip() for t in args.targets.split(",") if t.strip()]
+        result["targets"] = targets
+
+        if args.dry_run:
+            result["write_status"] = "dry_run"
+            result["backfill"] = [
+                _template_sync_backfill_target(t, included, dry_run=True)
+                for t in targets
+            ]
+            _template_sync_print_result(result)
+            return 0
+
+        new_roster_text = _template_sync_splice_block(roster_text, new_block)
+        _isolation_aware_save_text(roster_path, new_roster_text, mode=0o600)
+        result["write_status"] = "ok"
+
+        # Apply to existing --targets via Contract-II (Lane A's writer).
+        result["backfill"] = [
+            _template_sync_backfill_target(t, included, dry_run=False)
+            for t in targets
+        ]
+
+        _template_sync_print_result(result)
+        return 0
+    except SetupError as exc:
+        result["error"] = str(exc)
+        if result["write_status"] == "pending":
+            result["write_status"] = "skipped"
+        _template_sync_print_result(result, stream=sys.stderr)
+        return 1
+
+
+def _template_sync_emit_summary(result: dict[str, Any], *, stream: Any = sys.stderr) -> None:
+    """Human before/after summary to stderr."""
+    print("[setup template-sync] candidate (reference: "
+          f"{result['source_agent']})", file=stream)
+    for dim in _TEMPLATE_SYNC_DIMENSIONS:
+        entry = result["candidate"][dim]
+        val = entry["value"]
+        rendered = " ".join(val) if isinstance(val, list) else (val or "(empty)")
+        included = dim in result.get("included_dimensions", [])
+        mark = "include" if included else "exclude"
+        print(f"  [{mark}] {dim}: {rendered}  ({entry['source']} / {entry['status']})",
+              file=stream)
+    for warning in result.get("warnings", []):
+        print(f"  ! {warning}", file=stream)
+    for action in result.get("channel_next_actions", []):
+        print(f"  channel {action['channel']}: {action['state']} -> {action['next_action']}",
+              file=stream)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="bridge-setup.py")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -3171,6 +3677,46 @@ def build_parser() -> argparse.ArgumentParser:
     mattermost_parser.add_argument("--skip-validate", action="store_true")
     mattermost_parser.add_argument("--dry-run", action="store_true")
     mattermost_parser.set_defaults(handler=cmd_mattermost)
+
+    # Issue #1427 Lane B: `setup template-sync` — seed new (and optionally
+    # existing) agents from a reference agent's roster-resident config.
+    # The bash dispatch sources the roster and passes the reference
+    # agent's RAW `BRIDGE_AGENT_*` values via `--ref-*`. Stage 2 computes
+    # the redacted candidate, diffs it against the existing defaults
+    # profile, applies the opt-out exclude set, writes the Contract-I
+    # block into agent-roster.local.sh, and (for --targets) calls Lane A's
+    # `agent-bridge roster materialize-fields` per target.
+    #
+    # `--ref-*` use `default=None` (not "") as the sentinel so the
+    # candidate compute can tell "reference did not set this dimension"
+    # (→ "unset / reference missing", never guessed) apart from an
+    # explicit empty value. The reference read is ROSTER-ONLY by
+    # contract: this command NEVER opens the reference's $HOME/.claude,
+    # plugin cache, settings, env, .mcp.json, or any channel secret file.
+    template_sync_parser = subparsers.add_parser("template-sync")
+    template_sync_parser.add_argument("--from", dest="from_agent", required=True)
+    template_sync_parser.add_argument("--roster-file", required=True)
+    template_sync_parser.add_argument("--ref-engine", default=None)
+    template_sync_parser.add_argument("--ref-model", default=None)
+    template_sync_parser.add_argument("--ref-effort", default=None)
+    template_sync_parser.add_argument("--ref-permission-mode", default=None)
+    template_sync_parser.add_argument("--ref-plugins", default=None)
+    template_sync_parser.add_argument("--ref-skills", default=None)
+    template_sync_parser.add_argument("--ref-channels", default=None)
+    # Built-in bridge defaults (new-shape launch fallback) — surfaced so
+    # the candidate can label a value "reference" vs "bridge default" and
+    # so dim 1's opus-4-7->opus-4-8 refresh shows up in the dry-run diff.
+    template_sync_parser.add_argument("--default-model", default="claude-opus-4-8")
+    template_sync_parser.add_argument("--default-effort", default="xhigh")
+    # CSV of dimension names (model,effort,permission_mode,plugins,skills,
+    # channels) and/or `dim:item` per-item exclusions (opt-out wizard auto
+    # mode). Accept-all is the default when omitted.
+    template_sync_parser.add_argument("--exclude", default="")
+    # CSV of EXISTING agents to backfill via Contract-II.
+    template_sync_parser.add_argument("--targets", default="")
+    template_sync_parser.add_argument("--yes", action="store_true")
+    template_sync_parser.add_argument("--dry-run", action="store_true")
+    template_sync_parser.set_defaults(handler=cmd_template_sync)
 
     return parser
 

--- a/bridge-setup.sh
+++ b/bridge-setup.sh
@@ -21,6 +21,7 @@ Usage:
   $(basename "$0") telegram <agent> [--token <token>] [--channel-account <account>] [--runtime-config <path>] [--allow-from <id>]... [--default-chat <id>] [--test-chat <id>] [--skip-validate] [--skip-send-test] [--yes] [--dry-run]
   $(basename "$0") teams <agent> [--app-id <id>] [--app-password-file <path>] [--app-password-stdin] [--tenant-id <id>] [--channel-account <account>] [--runtime-config <path>] [--messaging-endpoint <url>] [--webhook-host <host>] [--webhook-port <port>] [--ingress-port <port>] [--allow-from <id>]... [--conversation <id>]... [--require-mention] [--skip-validate] [--skip-send-test] [--yes] [--dry-run] [--allow-probe-failure]
   $(basename "$0") ms365 <agent> [--redirect-uri <url>] [--messaging-endpoint <url>] [--tenant-id <id>] [--client-id <id>] [--client-secret <secret>] [--client-secret-file <path>] [--client-secret-stdin] [--default-upn <upn>] [--default-scopes <scopes>] [--allow-localhost] [--skip-entra-probe] [--yes] [--dry-run] [--allow-probe-failure]
+  $(basename "$0") template-sync [--from <reference-agent default admin>] [--exclude <csv>] [--targets <csv-existing-agents>] [--dry-run] [--yes]
   $(basename "$0") agent <agent> [--skip-discord] [--skip-telegram] [--skip-teams] [--test-start] [setup options...]
   $(basename "$0") admin <agent>
 
@@ -31,6 +32,7 @@ Examples:
   $(basename "$0") teams tester --channel-account default --allow-from 00000000-0000-0000-0000-000000000000
   $(basename "$0") ms365 tester
   $(basename "$0") ms365 tester --redirect-uri https://bot.example.com/auth/callback
+  $(basename "$0") template-sync --from patch --dry-run
   $(basename "$0") agent tester
   $(basename "$0") agent tester --test-start
   $(basename "$0") admin tester
@@ -62,6 +64,16 @@ EOF
       cat <<EOF
 Usage:
   $(basename "$0") ms365 <agent> [--redirect-uri <url>] [--messaging-endpoint <url>] [--tenant-id <id>] [--client-id <id>] [--client-secret <secret>] [--client-secret-file <path>] [--client-secret-stdin] [--default-upn <upn>] [--default-scopes <scopes>] [--allow-localhost] [--skip-entra-probe] [--yes] [--dry-run] [--allow-probe-failure]
+EOF
+      ;;
+    template-sync)
+      cat <<EOF
+Usage:
+  $(basename "$0") template-sync [--from <reference-agent default admin>] [--exclude <csv-dims-or-dim:item>] [--targets <csv-existing-agents>] [--dry-run] [--yes]
+
+Seeds new (and optionally existing) agents from a reference agent's
+roster config. Roster-only read; channels are copied as declarations
+only (never credentials); permission_mode=legacy is never inherited.
 EOF
       ;;
     agent)
@@ -1477,6 +1489,149 @@ run_admin() {
   echo "next_command: agb admin"
 }
 
+# Issue #1427 Lane B: `setup template-sync` — seed new (and optionally
+# existing) agents from a reference agent's roster-resident config.
+#
+# Stage 0 (here): parse flags, validate the reference is an existing
+# Claude agent, read its RAW per-dimension `BRIDGE_AGENT_*` roster values
+# (sourced already by `bridge_load_roster`), then route through the
+# two-stage wizard the same way run_teams / run_ms365 do. The reference
+# read is ROSTER-ONLY — we forward the raw declarations to the python
+# wizard via `--ref-*`; nothing reaches into the reference's $HOME/.claude
+# or any channel secret file. A dimension the reference never declared is
+# simply NOT forwarded (python treats the absent `--ref-*` as "unset /
+# reference missing" and never guesses).
+run_template_sync() {
+  local ref_agent="${1:-}"
+  local dry_run=0
+  local exclude_csv=""
+  local targets_csv=""
+  local yes_flag=0
+  local explicit_exclude=0
+
+  shift || true
+  if [[ "$ref_agent" == "-h" || "$ref_agent" == "--help" || "$ref_agent" == "help" ]]; then
+    setup_subcommand_usage "template-sync"
+    return 0
+  fi
+  # `template-sync` takes the reference via `--from` (default patch),
+  # NOT as a positional. If the first token is a flag, there is no
+  # positional reference — restore it for the option loop and default the
+  # reference to the admin agent (patch on a standard install).
+  if [[ "$ref_agent" == --* || -z "$ref_agent" ]]; then
+    [[ -n "$ref_agent" ]] && set -- "$ref_agent" "$@"
+    ref_agent=""
+  fi
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --from)
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        ref_agent="$2"
+        shift 2
+        ;;
+      --exclude)
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        exclude_csv="$2"
+        explicit_exclude=1
+        shift 2
+        ;;
+      --targets)
+        [[ $# -ge 2 ]] || bridge_die "옵션 값이 필요합니다: $1"
+        targets_csv="$2"
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      --yes)
+        yes_flag=1
+        shift
+        ;;
+      *)
+        bridge_die "지원하지 않는 setup template-sync 옵션입니다: $1"
+        ;;
+    esac
+  done
+
+  # Default the reference to the admin agent when omitted.
+  if [[ -z "$ref_agent" ]]; then
+    ref_agent="${BRIDGE_ADMIN_AGENT_ID:-patch}"
+  fi
+  bridge_require_agent "$ref_agent"
+  bridge_setup_require_claude_agent "$ref_agent" "template-sync"
+
+  # Read the reference's RAW per-dimension roster values. Use the `+set`
+  # test so an unset array key forwards NOTHING (python => "unset /
+  # reference missing"), distinct from a declared-empty value.
+  local -a py_args=(template-sync --from "$ref_agent" --roster-file "$BRIDGE_ROSTER_LOCAL_FILE")
+  py_args+=(--ref-engine "$(bridge_agent_engine "$ref_agent")")
+
+  local ref_model="" ref_effort="" ref_permission_mode=""
+  local ref_plugins="" ref_skills="" ref_channels=""
+  if [[ -n "${BRIDGE_AGENT_MODEL[$ref_agent]+set}" ]]; then
+    ref_model="${BRIDGE_AGENT_MODEL[$ref_agent]}"
+    py_args+=(--ref-model "$ref_model")
+  fi
+  if [[ -n "${BRIDGE_AGENT_EFFORT[$ref_agent]+set}" ]]; then
+    ref_effort="${BRIDGE_AGENT_EFFORT[$ref_agent]}"
+    py_args+=(--ref-effort "$ref_effort")
+  fi
+  if [[ -n "${BRIDGE_AGENT_PERMISSION_MODE[$ref_agent]+set}" ]]; then
+    ref_permission_mode="${BRIDGE_AGENT_PERMISSION_MODE[$ref_agent]}"
+    py_args+=(--ref-permission-mode "$ref_permission_mode")
+  fi
+  if [[ -n "${BRIDGE_AGENT_PLUGINS[$ref_agent]+set}" ]]; then
+    ref_plugins="${BRIDGE_AGENT_PLUGINS[$ref_agent]}"
+    py_args+=(--ref-plugins "$ref_plugins")
+  fi
+  if [[ -n "${BRIDGE_AGENT_SKILLS[$ref_agent]+set}" ]]; then
+    ref_skills="${BRIDGE_AGENT_SKILLS[$ref_agent]}"
+    py_args+=(--ref-skills "$ref_skills")
+  fi
+  # Channels: declarations only — read the raw BRIDGE_AGENT_CHANNELS entry,
+  # NOT the inferred-from-launch-cmd fallback (which could surface dev
+  # channels the operator never declared). No credential bytes here.
+  if [[ -n "${BRIDGE_AGENT_CHANNELS[$ref_agent]+set}" ]]; then
+    ref_channels="${BRIDGE_AGENT_CHANNELS[$ref_agent]}"
+    py_args+=(--ref-channels "$ref_channels")
+  fi
+
+  # Two-stage wizard gate (same shape as run_teams / run_ms365):
+  #   auto mode (--yes) → validate_auto requires --from (already present)
+  #   interactive TTY   → run the opt-out exclude wizard, then --yes
+  local -a wizard_args=()
+  if [[ $yes_flag -eq 1 ]]; then
+    py_args+=(--yes)
+    bridge_setup_wizard_validate_auto template-sync "${py_args[@]}"
+  elif bridge_setup_wizard_is_interactive_tty && [[ $explicit_exclude -eq 0 ]]; then
+    bridge_setup_wizard_run_template_sync \
+      "$ref_agent" wizard_args \
+      "$ref_model" "$ref_effort" "$ref_permission_mode" \
+      "$ref_plugins" "$ref_skills" "$ref_channels"
+    py_args+=("${wizard_args[@]}")
+  else
+    # Non-interactive without --yes, or an explicit --exclude was given in
+    # a non-TTY context: append --yes so the python wizard does not block
+    # on stdin. The required-field validator still guards --from.
+    py_args+=(--yes)
+    bridge_setup_wizard_validate_auto template-sync "${py_args[@]}"
+  fi
+
+  if [[ -n "$exclude_csv" ]]; then
+    py_args+=(--exclude "$exclude_csv")
+  fi
+  if [[ -n "$targets_csv" ]]; then
+    py_args+=(--targets "$targets_csv")
+  fi
+  if [[ $dry_run -eq 1 ]]; then
+    py_args+=(--dry-run)
+  fi
+
+  bridge_setup_python "${py_args[@]}"
+}
+
 subcommand="${1:-}"
 shift || true
 
@@ -1493,6 +1648,9 @@ case "$subcommand" in
   ms365)
     run_ms365 "$@"
     ;;
+  template-sync)
+    run_template_sync "$@"
+    ;;
   agent)
     run_agent "$@"
     ;;
@@ -1505,7 +1663,7 @@ case "$subcommand" in
   *)
     # Issue #163 Phase 2: surface an intent-recovery hint before dying.
     _hint="$(bridge_suggest_subcommand "$subcommand" \
-      "discord telegram teams ms365 agent admin")"
+      "discord telegram teams ms365 template-sync agent admin")"
     [[ -n "$_hint" ]] && bridge_warn "$_hint"
     bridge_die "지원하지 않는 setup 명령입니다: $subcommand"
     ;;

--- a/lib/bridge-setup-wizard.sh
+++ b/lib/bridge-setup-wizard.sh
@@ -115,11 +115,23 @@ _BRIDGE_SETUP_WIZARD_REQUIRED_MS365=(
   redirect-uri
 )
 
+# Required template-sync field — issue #1427. The only value the wizard
+# cannot pick a sensible default for is the reference agent. Everything
+# else (exclude set, targets) is opt-out / optional. Auto-mode (`--yes`)
+# therefore requires `--from <agent>`; missing it fails loud BEFORE the
+# python wizard so the operator never sees an opaque argparse error.
+_BRIDGE_SETUP_WIZARD_REQUIRED_TEMPLATE_SYNC=(
+  from
+)
+
 bridge_setup_wizard_required_fields() {
   local channel="${1:-}"
   case "$channel" in
     teams)
       printf '%s\n' "${_BRIDGE_SETUP_WIZARD_REQUIRED_TEAMS[@]}"
+      ;;
+    template-sync)
+      printf '%s\n' "${_BRIDGE_SETUP_WIZARD_REQUIRED_TEMPLATE_SYNC[@]}"
       ;;
     ms365)
       printf '%s\n' "${_BRIDGE_SETUP_WIZARD_REQUIRED_MS365[@]}"
@@ -221,6 +233,9 @@ bridge_setup_wizard_validate_auto() {
       ;;
     ms365)
       required=("${_BRIDGE_SETUP_WIZARD_REQUIRED_MS365[@]}")
+      ;;
+    template-sync)
+      required=("${_BRIDGE_SETUP_WIZARD_REQUIRED_TEMPLATE_SYNC[@]}")
       ;;
     *)
       bridge_die "[setup wizard] 알 수 없는 채널: ${channel}"
@@ -466,6 +481,87 @@ bridge_setup_wizard_run_ms365() {
   _BRIDGE_SETUP_WIZARD_LAST_MS365_CLIENT_ID="$client_id"
   export _BRIDGE_SETUP_WIZARD_LAST_MS365_REDIRECT_URI \
          _BRIDGE_SETUP_WIZARD_LAST_MS365_CLIENT_ID
+}
+
+# --------------------------------------------------------------------
+# Issue #1427 Lane B — template-sync interactive wizard (Stage 1).
+#
+# Mirrors the teams/ms365 two-stage contract. Unlike those channels,
+# template-sync does not gather site-specific secrets — its job is the
+# opt-OUT exclude step: every dimension the reference agent declares is
+# accepted by default, and the operator deselects what they do not want
+# seeded. The reference's raw per-dimension values are gathered by the
+# bash dispatch (which has already sourced the roster) and handed in as
+# positional args so this helper never re-reads the roster itself.
+#
+# Output: appends `--exclude <csv>` (only if the operator excluded
+# anything) plus `--yes` to the caller's argv-out array. The caller has
+# already appended `--from <ref>` and the `--ref-*` raw values; this
+# helper only contributes the operator's exclude choices.
+# --------------------------------------------------------------------
+
+# _bridge_setup_wizard_ts_dimension_prompt <dim-label> <current-value>
+#   Returns 0 to INCLUDE (default), 1 to EXCLUDE. An empty current value
+#   is auto-skipped (nothing to include) and reported as such.
+_bridge_setup_wizard_ts_dimension_prompt() {
+  local label="$1"
+  local current="$2"
+  if [[ -z "$current" ]]; then
+    printf '  - %s: (unset on reference — nothing to seed)\n' "$label" >&2
+    return 1
+  fi
+  local reply
+  reply="$(_bridge_setup_wizard_prompt "  include ${label} = '${current}'? [Y/n]" "Y")"
+  case "$reply" in
+    n|N|no|NO|No) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
+bridge_setup_wizard_run_template_sync() {
+  local ref_agent="${1:-}"
+  local out_array_name="${2:-}"
+  local ref_model="${3:-}"
+  local ref_effort="${4:-}"
+  local ref_permission_mode="${5:-}"
+  local ref_plugins="${6:-}"
+  local ref_skills="${7:-}"
+  local ref_channels="${8:-}"
+  [[ -n "$ref_agent" ]] || bridge_die "[setup wizard] reference agent name required"
+  [[ -n "$out_array_name" ]] || bridge_die "[setup wizard] out array name required"
+
+  _bridge_setup_wizard_section "template-sync 인터랙티브 셋업 (reference=${ref_agent})"
+  printf '  step 1: 참조 에이전트의 각 dimension을 포함/제외 선택 (기본 = 포함)\n' >&2
+  printf '  보안: 채널은 declaration만 복사됩니다 (자격증명/토큰/MCP secret은 절대 복사 안 함).\n' >&2
+
+  local -a excludes=()
+
+  # permission_mode=legacy is NEVER inheritable — surface + force-exclude
+  # before the operator even sees a prompt for it.
+  if [[ "$ref_permission_mode" == "legacy" ]]; then
+    bridge_warn "[setup template-sync] reference permission_mode=legacy는 절대 상속되지 않습니다 — 제외합니다."
+    excludes+=("permission_mode")
+    ref_permission_mode=""
+  fi
+
+  _bridge_setup_wizard_ts_dimension_prompt "model" "$ref_model" || excludes+=("model")
+  _bridge_setup_wizard_ts_dimension_prompt "effort" "$ref_effort" || excludes+=("effort")
+  if [[ "$ref_permission_mode" != "legacy" && -n "$ref_permission_mode" ]]; then
+    _bridge_setup_wizard_ts_dimension_prompt "permission_mode" "$ref_permission_mode" || excludes+=("permission_mode")
+  fi
+  _bridge_setup_wizard_ts_dimension_prompt "plugins" "$ref_plugins" || excludes+=("plugins")
+  _bridge_setup_wizard_ts_dimension_prompt "skills" "$ref_skills" || excludes+=("skills")
+  _bridge_setup_wizard_ts_dimension_prompt "channels" "$ref_channels" || excludes+=("channels")
+
+  # Assemble the exclude CSV (only when non-empty) + --yes. We can't use
+  # `local -n` portably, so use `eval` with the array name (matches the
+  # teams/ms365 helpers).
+  if (( ${#excludes[@]} > 0 )); then
+    local exclude_csv
+    exclude_csv="$(IFS=,; printf '%s' "${excludes[*]}")"
+    eval "${out_array_name}+=(--exclude \"\$exclude_csv\")"
+  fi
+  eval "${out_array_name}+=(--yes)"
 }
 
 # --------------------------------------------------------------------

--- a/scripts/baselines/iso-helper-baseline.txt
+++ b/scripts/baselines/iso-helper-baseline.txt
@@ -127,6 +127,7 @@ scripts/smoke/1359-cron-create-iso-staging.sh=3
 scripts/smoke/1379-iso-cron-staging-group.sh=15
 scripts/smoke/1383-iso-cron-result-json-group.sh=26
 scripts/smoke/1405-handoffd-supervision.sh=8
+scripts/smoke/1427-B-template-sync-wizard.sh=4
 scripts/smoke/4494-integrated-dynamic-recovery.sh=4
 scripts/smoke/857-pr1-isolation-write-helper.sh=9
 scripts/smoke/857-pr6-isolation-v3-channel-dotenv-migrate.sh=25

--- a/scripts/smoke/1427-B-template-sync-wizard.sh
+++ b/scripts/smoke/1427-B-template-sync-wizard.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1427-B-template-sync-wizard.sh — Issue #1427 Lane B.
+#
+# Pins the `agent-bridge setup template-sync` wizard contract: a two-stage
+# (bash Stage-1 + python Stage-2) helper that seeds new (and optionally
+# existing) agents from a reference agent's ROSTER-resident config, with a
+# hard security boundary (declarations only, never credentials) and a
+# never-inherit rule for permission_mode=legacy.
+#
+# This smoke exercises the Stage-2 python wizard (`bridge-setup.py
+# template-sync`) directly for the candidate/diff/redaction/profile-write
+# assertions, the Stage-1 bash required-fields validator
+# (`bridge_setup_wizard_validate_auto template-sync`) for the auto-mode
+# fail-loud contract, and STUBS Lane A's Contract-II writer
+# (`agent-bridge roster materialize-fields`) for the --targets backfill
+# call (the end-to-end apply is verified at integration; Lane A may not
+# have landed yet).
+#
+# Tests:
+#   T1 (dry-run):  --dry-run from a fixture roster writes NOTHING and emits
+#                  a deterministic candidate + before/after diff.
+#   T2 (redact):   secret-shaped reference values (a token-shaped channel
+#                  account, a client-secret-looking string) never appear on
+#                  stdout, stderr, or in the written profile. The wizard is
+#                  roster-only; it never opens a channel secret file.
+#   T3 (legacy):   reference permission_mode=legacy is surfaced as
+#                  refused/omitted (never written, warned).
+#   T4 (validate): `bridge_setup_wizard_validate_auto template-sync` with
+#                  --yes but no --from dies with a structured "missing"
+#                  message and non-zero exit.
+#   T5 (noref):    a reference with NO roster dimensions yields a partial
+#                  candidate marking list dims "unset / reference missing"
+#                  (never guessed); model/effort fall back to bridge
+#                  defaults labelled `bridge-default`.
+#   T6 (profile):  the written profile is the Contract-I block with correct
+#                  delimiters + metadata (source_agent / updated_at /
+#                  included / excluded / hash) and is sourceable bash.
+#   T7 (contractII): --targets invokes the Contract-II writer (stubbed) with
+#                  the expected --model/--effort/--plugins/... argv and the
+#                  backfill result reports restart_required.
+#   T8 (idempotent): re-running splices the block in place (exactly one
+#                  block) rather than appending a duplicate.
+#
+# Footgun #11: no `<<EOF` / `<<'PY'` to subprocess; python is driven via
+# `python3 -c '<script>' <argv>` or by reading roster files written with
+# plain redirects. Captured subprocesses use `out=$(... 2>&1)` or split
+# stdout/stderr into temp files.
+
+if [[ "${BRIDGE_SMOKE_BASH4_REEXEC:-0}" != "1" && "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+  for _candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [[ -x "$_candidate" ]] && "$_candidate" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+      BRIDGE_SMOKE_BASH4_REEXEC=1 exec "$_candidate" "$0" "$@"
+    fi
+  done
+  echo "[smoke:1427-B-template-sync-wizard][error] bash 4+ required (got ${BASH_VERSION:-unknown})" >&2
+  exit 1
+fi
+
+set -uo pipefail
+
+SMOKE_NAME="1427-B-template-sync-wizard"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+# shellcheck disable=SC2329  # invoked via the EXIT trap
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+SETUP_PY="$REPO_ROOT/bridge-setup.py"
+WIZARD_LIB="$REPO_ROOT/lib/bridge-setup-wizard.sh"
+CORE_LIB="$REPO_ROOT/lib/bridge-core.sh"
+
+smoke_assert_file_exists "$SETUP_PY" "bridge-setup.py present"
+smoke_assert_file_exists "$WIZARD_LIB" "lib/bridge-setup-wizard.sh present"
+
+# A token-shaped secret string that MUST NOT survive into any output —
+# even if a future reference declared it in a channel value. The wizard
+# only ever sees declarations passed on argv, so this is the worst case.
+SECRET_CANARY="SK-DEADBEEFc0ffee0123456789abcdefSECRET"
+
+# Stub for Lane A's Contract-II writer. Records its argv to a file and
+# emits a JSON ack so the python backfill path can be exercised before the
+# real `agent-bridge roster materialize-fields` verb lands.
+MATERIALIZE_LOG="$SMOKE_TMP_ROOT/materialize-calls.log"
+MATERIALIZE_STUB="$SMOKE_TMP_ROOT/materialize-stub.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -u\n'
+  printf 'printf "%%s\\n" "$*" >> %q\n' "$MATERIALIZE_LOG"
+  printf 'printf "{\\"status\\":\\"stubbed-ok\\"}\\n"\n'
+} >"$MATERIALIZE_STUB"
+chmod +x "$MATERIALIZE_STUB"
+
+# Helper: run the python wizard. Splits stdout/stderr so redaction
+# assertions can check both streams independently.
+TS_STDOUT="$SMOKE_TMP_ROOT/ts.out"
+TS_STDERR="$SMOKE_TMP_ROOT/ts.err"
+run_ts() {
+  python3 "$SETUP_PY" template-sync "$@" >"$TS_STDOUT" 2>"$TS_STDERR"
+}
+
+# ---------------------------------------------------------------------------
+# T1 — --dry-run writes nothing + deterministic candidate/diff.
+# ---------------------------------------------------------------------------
+ROSTER_T1="$SMOKE_TMP_ROOT/roster-t1.sh"
+rm -f "$ROSTER_T1"
+run_ts --from patch --roster-file "$ROSTER_T1" --ref-engine claude \
+  --ref-model claude-opus-4-8 --ref-effort xhigh \
+  --ref-plugins "cosmax-crm@cosmax playwright@official" \
+  --ref-skills "agent-db memory-wiki" \
+  --ref-channels "plugin:teams@mkt plugin:ms365" \
+  --yes --dry-run
+rc=$?
+smoke_assert_eq "$rc" "0" "T1: dry-run exits 0"
+[[ ! -e "$ROSTER_T1" ]] || smoke_fail "T1: --dry-run must NOT create the roster file ($ROSTER_T1 exists)"
+
+t1_out="$(cat "$TS_STDOUT")"
+smoke_assert_contains "$t1_out" '"write_status": "dry_run"' "T1: write_status=dry_run"
+smoke_assert_contains "$t1_out" '"candidate_hash"' "T1: emits a candidate hash"
+# Determinism: token order normalized — plugins sorted, de-duped.
+smoke_assert_contains "$t1_out" 'BRIDGE_TEMPLATE_DEFAULT_PLUGINS=\"cosmax-crm@cosmax playwright@official\"' \
+  "T1: plugins normalized in profile"
+# Run again — the candidate_hash must be identical for the same input.
+hash1="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["candidate_hash"])' <"$TS_STDOUT")"
+run_ts --from patch --roster-file "$ROSTER_T1" --ref-engine claude \
+  --ref-model claude-opus-4-8 --ref-effort xhigh \
+  --ref-plugins "playwright@official cosmax-crm@cosmax" \
+  --ref-skills "memory-wiki agent-db" \
+  --ref-channels "plugin:ms365 plugin:teams@mkt" \
+  --yes --dry-run
+hash2="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["candidate_hash"])' <"$TS_STDOUT")"
+smoke_assert_eq "$hash1" "$hash2" "T1: candidate hash deterministic under token reorder"
+
+# ---------------------------------------------------------------------------
+# T2 — secret-shaped fixtures never leak (stdout / stderr / profile).
+# ---------------------------------------------------------------------------
+ROSTER_T2="$SMOKE_TMP_ROOT/roster-t2.sh"
+rm -f "$ROSTER_T2"
+# Seed the canary into EVERY secret-shaped file a leaky implementation might
+# probe for the reference's channels: a `.teams/.env`, a `.ms365/.env`, a
+# `.teams/access.json`, and a `.claude/.mcp.json`. The wizard is roster-only
+# by contract, so it must never open ANY of these. We make them mode 000 so
+# that if a naive future patch DID try to read one, the wizard would die or
+# warn (proving the read) instead of silently succeeding.
+SECRET_TREE="$SMOKE_TMP_ROOT/ref-home"
+mkdir -p "$SECRET_TREE/.teams" "$SECRET_TREE/.ms365" "$SECRET_TREE/.claude"
+printf 'TEAMS_APP_PASSWORD=%s\n' "$SECRET_CANARY" >"$SECRET_TREE/.teams/.env"
+printf 'MS365_CLIENT_SECRET=%s\n' "$SECRET_CANARY" >"$SECRET_TREE/.ms365/.env"
+printf '{"appPassword":"%s"}\n' "$SECRET_CANARY" >"$SECRET_TREE/.teams/access.json"
+printf '{"mcpServers":{"x":{"env":{"TOKEN":"%s"}}}}\n' "$SECRET_CANARY" >"$SECRET_TREE/.claude/.mcp.json"
+chmod 000 "$SECRET_TREE/.teams/.env" "$SECRET_TREE/.ms365/.env" \
+  "$SECRET_TREE/.teams/access.json" "$SECRET_TREE/.claude/.mcp.json"
+# HOME points at the secret tree so a `$HOME/.claude` introspection (which the
+# contract FORBIDS) would land here and fail on the 000-mode files.
+HOME="$SECRET_TREE" run_ts --from patch --roster-file "$ROSTER_T2" --ref-engine claude \
+  --ref-model claude-opus-4-8 \
+  --ref-channels "plugin:teams@mkt plugin:ms365" \
+  --yes
+rc=$?
+chmod 600 "$SECRET_TREE/.teams/.env" "$SECRET_TREE/.ms365/.env" \
+  "$SECRET_TREE/.teams/access.json" "$SECRET_TREE/.claude/.mcp.json" 2>/dev/null || true
+smoke_assert_eq "$rc" "0" "T2: roster-only read succeeds without touching the secret tree"
+out_all="$(cat "$TS_STDOUT" "$TS_STDERR")"
+smoke_assert_not_contains "$out_all" "$SECRET_CANARY" "T2: secret canary never on stdout/stderr"
+profile_t2="$(cat "$ROSTER_T2")"
+smoke_assert_not_contains "$profile_t2" "$SECRET_CANARY" "T2: secret canary never in written profile"
+# The channel DECLARATIONS (no creds) are what gets copied.
+smoke_assert_contains "$profile_t2" 'BRIDGE_TEMPLATE_DEFAULT_CHANNELS="plugin:ms365 plugin:teams@mkt"' \
+  "T2: channel declarations copied (declarations only)"
+# Per-channel setup-pending next-action surfaced.
+smoke_assert_contains "$(cat "$TS_STDOUT")" 'agb setup teams' "T2: teams setup-pending next-action"
+
+# ---------------------------------------------------------------------------
+# T3 — reference permission_mode=legacy refused / omitted / warned.
+# ---------------------------------------------------------------------------
+ROSTER_T3="$SMOKE_TMP_ROOT/roster-t3.sh"
+rm -f "$ROSTER_T3"
+run_ts --from patch --roster-file "$ROSTER_T3" --ref-engine claude \
+  --ref-model claude-opus-4-8 --ref-permission-mode legacy \
+  --yes
+rc=$?
+smoke_assert_eq "$rc" "0" "T3: legacy reference still exits 0"
+profile_t3="$(cat "$ROSTER_T3")"
+smoke_assert_not_contains "$profile_t3" "BRIDGE_TEMPLATE_DEFAULT_PERMISSION_MODE" \
+  "T3: legacy permission_mode never written to profile"
+smoke_assert_contains "$profile_t3" "permission_mode intentionally omitted" \
+  "T3: profile documents the legacy omission"
+smoke_assert_contains "$(cat "$TS_STDERR")" "legacy" "T3: legacy refusal warned on stderr"
+
+# ---------------------------------------------------------------------------
+# T4 — bash validate_auto: --yes but missing --from dies structured.
+# ---------------------------------------------------------------------------
+# Drive the bash Stage-1 validator directly via a python3-free bash -c so we
+# do not depend on the full bridge-setup.sh dispatch / roster sourcing.
+VALIDATE_DRIVER="$SMOKE_TMP_ROOT/validate-driver.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -uo pipefail\n'
+  printf 'bridge_die() { printf "%%s\\n" "$*" >&2; exit 3; }\n'
+  printf 'bridge_warn() { printf "%%s\\n" "$*" >&2; }\n'
+  printf 'bridge_info() { printf "%%s\\n" "$*"; }\n'
+  printf 'source %q\n' "$WIZARD_LIB"
+  printf 'bridge_setup_wizard_validate_auto template-sync template-sync --roster-file /tmp/x --yes\n'
+} >"$VALIDATE_DRIVER"
+val_out="$(/opt/homebrew/bin/bash "$VALIDATE_DRIVER" 2>&1)"
+val_rc=$?
+smoke_assert_eq "$val_rc" "3" "T4: validate_auto dies (rc=3) when --from missing"
+smoke_assert_contains "$val_out" "--from" "T4: structured die names the missing --from flag"
+
+# Positive case: --from present → validator passes (rc 0).
+VALIDATE_OK="$SMOKE_TMP_ROOT/validate-ok.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -uo pipefail\n'
+  printf 'bridge_die() { printf "%%s\\n" "$*" >&2; exit 3; }\n'
+  printf 'bridge_warn() { printf "%%s\\n" "$*" >&2; }\n'
+  printf 'bridge_info() { printf "%%s\\n" "$*"; }\n'
+  printf 'source %q\n' "$WIZARD_LIB"
+  printf 'bridge_setup_wizard_validate_auto template-sync template-sync --from patch --roster-file /tmp/x --yes\n'
+  printf 'echo VALIDATE_OK\n'
+} >"$VALIDATE_OK"
+val_ok_out="$(/opt/homebrew/bin/bash "$VALIDATE_OK" 2>&1)"
+smoke_assert_contains "$val_ok_out" "VALIDATE_OK" "T4: validate_auto passes when --from present"
+
+# ---------------------------------------------------------------------------
+# T5 — no-reference-config reference → partial candidate, never guessed.
+# ---------------------------------------------------------------------------
+ROSTER_T5="$SMOKE_TMP_ROOT/roster-t5.sh"
+rm -f "$ROSTER_T5"
+# No --ref-* flags at all == reference declared none of the dimensions.
+run_ts --from emptyref --roster-file "$ROSTER_T5" --ref-engine claude --yes --dry-run
+rc=$?
+smoke_assert_eq "$rc" "0" "T5: no-reference dry-run exits 0"
+t5_out="$(cat "$TS_STDOUT")"
+plugins_status="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["candidate"]["plugins"]["status"])' <"$TS_STDOUT")"
+smoke_assert_eq "$plugins_status" "unset / reference missing" "T5: missing plugins -> unset/reference missing (not guessed)"
+model_source="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["candidate"]["model"]["source"])' <"$TS_STDOUT")"
+smoke_assert_eq "$model_source" "bridge-default" "T5: missing model -> labelled bridge-default (not reference)"
+# A guessed value would surface plugins in the included set; it must not.
+smoke_assert_not_contains "$t5_out" '"included_dimensions": [\n    "model",\n    "effort",\n    "permission_mode"' \
+  "T5: no fabricated permission_mode in included set"
+
+# ---------------------------------------------------------------------------
+# T6 — profile-write produces the Contract-I block with correct metadata.
+# ---------------------------------------------------------------------------
+ROSTER_T6="$SMOKE_TMP_ROOT/roster-t6.sh"
+rm -f "$ROSTER_T6"
+run_ts --from patch --roster-file "$ROSTER_T6" --ref-engine claude \
+  --ref-model claude-opus-4-8 --ref-effort xhigh \
+  --ref-plugins "cosmax-crm@cosmax" --ref-skills "agent-db" \
+  --ref-channels "plugin:teams@mkt" \
+  --yes
+rc=$?
+smoke_assert_eq "$rc" "0" "T6: profile write exits 0"
+profile_t6="$(cat "$ROSTER_T6")"
+smoke_assert_contains "$profile_t6" '# === agb:template-defaults v1 (managed by `setup template-sync`) ===' \
+  "T6: begin marker present"
+smoke_assert_contains "$profile_t6" '# === end agb:template-defaults ===' "T6: end marker present"
+smoke_assert_contains "$profile_t6" 'source_agent=patch' "T6: meta carries source_agent"
+smoke_assert_contains "$profile_t6" 'included=model,effort,plugins,skills,channels' "T6: meta carries included dims"
+smoke_assert_match "$profile_t6" 'hash=[0-9a-f]{16}' "T6: meta carries a 16-hex candidate hash"
+smoke_assert_match "$profile_t6" 'updated_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z' \
+  "T6: meta carries an ISO-8601 updated_at"
+# The block must be sourceable bash and yield the expected scalar values.
+SOURCE_PROBE="$SMOKE_TMP_ROOT/source-probe.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'set -u\n'
+  printf 'source %q\n' "$ROSTER_T6"
+  printf 'printf "%%s|%%s|%%s\\n" "${BRIDGE_TEMPLATE_DEFAULT_MODEL:-}" "${BRIDGE_TEMPLATE_DEFAULT_PLUGINS:-}" "${BRIDGE_TEMPLATE_DEFAULT_PERMISSION_MODE:-NONE}"\n'
+} >"$SOURCE_PROBE"
+probe_out="$(/opt/homebrew/bin/bash "$SOURCE_PROBE" 2>&1)"
+smoke_assert_eq "$probe_out" "claude-opus-4-8|cosmax-crm@cosmax|NONE" \
+  "T6: profile sources to the expected values (no permission_mode var)"
+
+# ---------------------------------------------------------------------------
+# T7 — --targets calls Contract-II writer (stubbed) with the right argv.
+# ---------------------------------------------------------------------------
+ROSTER_T7="$SMOKE_TMP_ROOT/roster-t7.sh"
+rm -f "$ROSTER_T7" "$MATERIALIZE_LOG"
+BRIDGE_TEMPLATE_SYNC_MATERIALIZE_CMD="$MATERIALIZE_STUB" \
+  run_ts --from patch --roster-file "$ROSTER_T7" --ref-engine claude \
+  --ref-model claude-opus-4-8 --ref-effort xhigh \
+  --ref-plugins "cosmax-crm@cosmax" \
+  --targets "alice,bob" --yes
+rc=$?
+smoke_assert_eq "$rc" "0" "T7: --targets backfill exits 0"
+[[ -f "$MATERIALIZE_LOG" ]] || smoke_fail "T7: Contract-II writer was never invoked"
+mat_calls="$(cat "$MATERIALIZE_LOG")"
+smoke_assert_contains "$mat_calls" "alice --model claude-opus-4-8" "T7: writer called for alice with --model"
+smoke_assert_contains "$mat_calls" "bob --model claude-opus-4-8" "T7: writer called for bob"
+smoke_assert_contains "$mat_calls" "--plugins cosmax-crm@cosmax" "T7: writer receives --plugins"
+smoke_assert_contains "$mat_calls" "--json" "T7: writer invoked with --json"
+backfill_restart="$(python3 -c 'import json,sys; d=json.load(sys.stdin); print(d["backfill"][0]["restart_required"])' <"$TS_STDOUT")"
+smoke_assert_eq "$backfill_restart" "True" "T7: backfill reports restart_required for runtime-affecting dims"
+
+# ---------------------------------------------------------------------------
+# T8 — idempotent splice: re-run replaces the block in place.
+# ---------------------------------------------------------------------------
+ROSTER_T8="$SMOKE_TMP_ROOT/roster-t8.sh"
+rm -f "$ROSTER_T8"
+run_ts --from patch --roster-file "$ROSTER_T8" --ref-engine claude --ref-model claude-opus-4-7 --yes
+run_ts --from patch --roster-file "$ROSTER_T8" --ref-engine claude --ref-model claude-opus-4-8 --yes
+begin_count="$(grep -c 'agb:template-defaults v1' "$ROSTER_T8")"
+end_count="$(grep -c 'end agb:template-defaults' "$ROSTER_T8")"
+smoke_assert_eq "$begin_count" "1" "T8: exactly one begin marker after re-run"
+smoke_assert_eq "$end_count" "1" "T8: exactly one end marker after re-run"
+smoke_assert_contains "$(cat "$ROSTER_T8")" 'BRIDGE_TEMPLATE_DEFAULT_MODEL="claude-opus-4-8"' \
+  "T8: re-run updated the model value in place"
+
+smoke_log "PASS: all template-sync wizard assertions (T1-T8)"


### PR DESCRIPTION
## Lane B — `setup template-sync` wizard (#1427)

Implements the wizard (UX + orchestration) for the template-sync feature per `docs/template-sync-design.md`.

- `bridge-setup.py` `cmd_template_sync`: roster-only candidate compute from the reference agent's `BRIDGE_AGENT_*` arrays, before/after diff, **opt-out exclude wizard**, hard security redaction (no creds/tokens/MCP secrets — channels are declarations-only with per-channel setup-pending next-action), `permission_mode=legacy` refused, metadata sans secrets; `--from/--exclude/--targets/--dry-run/--yes`; v1 Claude-only.
- `lib/bridge-setup-wizard.sh` `bridge_setup_wizard_run_template_sync` + required-fields SSOT for `--yes` validation.
- `bridge-setup.sh` dispatch verb.
- Writes the Contract-I defaults-profile block; calls Lane A's Contract-II `roster materialize-fields` verb to apply `--targets` (stubbed in this lane's smoke — end-to-end verified at integration).

**Verification:** smoke `1427-B-template-sync-wizard.sh` T1-T8 PASS (dry-run writes nothing + deterministic candidate/diff; secret-shaped fixtures never leak; legacy surfaced as refused; `--yes`+missing-field structured die; no-reference partial candidate; profile-write Contract-I block w/ metadata). `bash -n` + `shellcheck` + `py_compile` clean; `lint-raw-pathlib --check`, `iso-helper-ratchet --check`, `lint-heredoc-ban --baseline-check` all exit 0.

> Process note: this lane's fixer completed the implementation but was interrupted by a transient Anthropic server rate-limit before commit/internal-review; the orchestrator finalized (verified all gates + smoke, committed, opened this PR). Codex pair-review (Phase 4) is the review gate. Smoke intentionally NOT registered in ci-select-smoke.sh (orchestrator integration commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
