### PR TITLE
fix(iso-v2): relocate active shared tree on v2 migrate (resolve 0.15 split-brain)

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -1299,6 +1299,25 @@ otherwise):
    Edit `agent-roster.local.sh` (via `agent-bridge config set`) to align
    the override and re-run, or unset it and re-run.
 
+   **Shared-tree relocation + `.v2-shared-mirror.sentinel`.** Before any
+   skip branch returns, apply real-copy mirrors the *active* shared tree
+   (`$BRIDGE_HOME/shared` — wiki, cron artifacts, users, docs: everything
+   `BRIDGE_SHARED_DIR` points at) into `<data_root>/shared` and drops a
+   `<data_root>/.v2-shared-mirror.sentinel`. This runs on every path,
+   including the macOS skip branches (marker-only-no-isolated-roster and
+   macos-shared-agent) that otherwise relocate no data — without it the v2
+   marker flips while the real shared tree stays stranded at the legacy path
+   (the v2 wiki indexer then scans an empty `data/shared/wiki`). The legacy
+   tree is **preserved** (`delete_eligible=0`); the resolver flip — not
+   deletion — cuts `BRIDGE_SHARED_DIR` over to `<data_root>/shared`, and
+   that flip is gated on the sentinel, so a marker-flipped-but-data-not-yet-
+   mirrored install keeps reading the legacy content until the mirror
+   completes. The step is idempotent (sentinel present → no-op) and
+   self-repairing: re-running apply on an already-marker-flipped install
+   that lacks the sentinel backfills the stranded tree. A mirror failure is
+   warn-and-continue — the sentinel stays absent, the resolver stays on the
+   legacy path, and the install keeps working.
+
 3. **soak** — operate on v2 for as long as you want to be sure things
    work. Rollback is cheap (legacy tree is intact until commit).
 

--- a/lib/bridge-isolation-v2-migrate.sh
+++ b/lib/bridge-isolation-v2-migrate.sh
@@ -845,6 +845,128 @@ bridge_isolation_v2_migrate_mirror_all() {
 }
 
 # ---------------------------------------------------------------------------
+# 5b. shared-tree data backfill (platform-agnostic)
+# ---------------------------------------------------------------------------
+#
+# The v0.15 data/-prefixed layout makes $BRIDGE_DATA_ROOT/shared the
+# canonical shared root, but the ACTIVE shared tree — wiki, cron artifacts,
+# users, docs: everything BRIDGE_SHARED_DIR points at — lives at the legacy
+# $BRIDGE_HOME/shared. The original migrate plan only mapped the (usually
+# empty) runtime/shared tree (`runtime_shared` global row), and on
+# macOS/no-isolated hosts the skip branches in apply_for_upgrade returned
+# before ANY data move — flipping the v2 marker while stranding the real
+# shared content at the legacy path. The result is split-brain: the v2 wiki
+# indexer scans an empty data/shared/wiki (files_scanned:0) while every
+# legacy BRIDGE_SHARED_DIR consumer still reads $BRIDGE_HOME/shared.
+#
+# This backfill is the platform-agnostic data relocation that must run on
+# EVERY path (Linux full-migrate, macOS/no-isolated skip, marker-only
+# fast-path, and marker-present-but-sentinel-missing repair). It mirrors the
+# active shared tree into the v2 layout and drops a sentinel that the
+# resolver (lib/bridge-isolation-v2.sh) keys off to flip BRIDGE_SHARED_DIR.
+#
+# Safety:
+#   * delete_eligible=0 semantics — legacy $BRIDGE_HOME/shared is PRESERVED
+#     (rsync without --delete; no hardlinks). The resolver flip, not
+#     deletion, cuts consumers over, so a failed/rolled-back migration
+#     leaves the real content untouched at the legacy path.
+#   * Idempotent — no-op once the sentinel exists.
+#   * Sentinel-gated, not "data/shared non-empty" — a fresh v2 data/shared
+#     already carries _index/_audit skeletons + plugins-cache, so emptiness
+#     is not a reliable "not yet migrated" signal.
+bridge_isolation_v2_migrate_shared_backfill() {
+  local data_root="$1" target_root="$2"
+  local legacy_shared="$target_root/shared"
+  local v2_shared="$data_root/shared"
+  local sentinel="$data_root/.v2-shared-mirror.sentinel"
+
+  # Already mirrored on a prior run.
+  [[ -f "$sentinel" ]] && return 0
+
+  # Markerless installs keep data_root == target_root, so legacy and v2
+  # shared coincide — nothing to relocate; record completion so the resolver
+  # treats the single shared tree as canonical.
+  if [[ "$legacy_shared" == "$v2_shared" ]]; then
+    bridge_isolation_v2_migrate_shared_sentinel_write \
+      "$sentinel" "$legacy_shared" "$v2_shared" "coincident" || return 1
+    return 0
+  fi
+
+  mkdir -p "$v2_shared" 2>/dev/null || {
+    bridge_warn "shared_backfill: mkdir $v2_shared failed"
+    return 1
+  }
+
+  # No legacy content to relocate (fresh install): data/shared is canonical
+  # by default; mark done so the resolver flips to it.
+  if [[ ! -d "$legacy_shared" ]] || [[ -z "$(ls -A "$legacy_shared" 2>/dev/null || true)" ]]; then
+    bridge_isolation_v2_migrate_shared_sentinel_write \
+      "$sentinel" "$legacy_shared" "$v2_shared" "no-legacy-content" || return 1
+    return 0
+  fi
+
+  # Real-copy mirror legacy -> v2. Prefer the same high-fidelity flags the
+  # rest of the migrate uses (`-aHX --numeric-ids`: perms/times, xattrs, and
+  # numeric ownership for the Linux isolation model — see mirror_one), but
+  # fall back to plain `-a` when the local rsync rejects them. macOS ships
+  # openrsync, which implements neither `-X` nor `--numeric-ids`; this
+  # backfill is the FIRST rsync the migrate runs on macOS (mirror_one is
+  # skipped on the macos-shared-agent path), so it must degrade gracefully
+  # instead of failing the whole relocation. A `-n` dry-run probes flag
+  # support without touching the tree.
+  #
+  # No `--delete`: preserve any v2-side skeleton/_index + plugins-cache.
+  # rsync never hardlinks dest to source, so the destination inodes are
+  # independent of the legacy tree (a later chgrp/chmod on data/shared can
+  # not mutate legacy inodes); the section-6 group-ensure pass re-applies
+  # the canonical shared group/mode afterward.
+  local -a _rsync_flags=(-aHX --numeric-ids)
+  if ! rsync "${_rsync_flags[@]}" -n "$legacy_shared"/ "$v2_shared"/ >/dev/null 2>&1; then
+    _rsync_flags=(-a)
+  fi
+  if ! rsync "${_rsync_flags[@]}" "$legacy_shared"/ "$v2_shared"/ 2>/dev/null; then
+    bridge_warn "shared_backfill: rsync $legacy_shared -> $v2_shared failed"
+    return 1
+  fi
+
+  # Verify the destination actually received content before recording the
+  # sentinel — never flip the resolver onto an empty tree.
+  if [[ -z "$(ls -A "$v2_shared" 2>/dev/null || true)" ]]; then
+    bridge_warn "shared_backfill: $v2_shared still empty after mirror"
+    return 1
+  fi
+
+  bridge_isolation_v2_migrate_shared_sentinel_write \
+    "$sentinel" "$legacy_shared" "$v2_shared" "mirrored" || return 1
+  return 0
+}
+
+# Write the shared-mirror sentinel atomically. The resolver only checks for
+# file existence; the body is operator-facing provenance. A write failure is
+# fatal to the backfill so the resolver never flips without a recorded
+# mirror.
+bridge_isolation_v2_migrate_shared_sentinel_write() {
+  local sentinel="$1" legacy_shared="$2" v2_shared="$3" reason="$4"
+  local tmp="${sentinel}.tmp.$$"
+  {
+    printf '# v2 shared-tree mirror sentinel\n'
+    printf 'reason=%s\n' "$reason"
+    printf 'legacy_shared=%s\n' "$legacy_shared"
+    printf 'v2_shared=%s\n' "$v2_shared"
+    printf 'written_at=%s\n' "$(date -Iseconds 2>/dev/null || date 2>/dev/null || printf 'unknown')"
+  } > "$tmp" 2>/dev/null || {
+    bridge_warn "shared_sentinel_write: write to $tmp failed"
+    return 1
+  }
+  mv -f "$tmp" "$sentinel" 2>/dev/null || {
+    rm -f "$tmp" 2>/dev/null
+    bridge_warn "shared_sentinel_write: mv to $sentinel failed"
+    return 1
+  }
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # 6. group ensure + post-flight probe
 # ---------------------------------------------------------------------------
 
@@ -1910,6 +2032,23 @@ bridge_isolation_v2_migrate_apply_for_upgrade() {
   local marker_path
   marker_path="$(bridge_isolation_v2_marker_path 2>/dev/null || \
     printf '%s/state/layout-marker.sh' "$target_root")"
+
+  # Platform-agnostic shared-tree backfill — MUST run before any skip
+  # branch below. The original bug: the macOS marker-only fast-path and the
+  # macos-shared-agent skip both `return 0` here without relocating the
+  # active shared tree ($BRIDGE_HOME/shared) into the v2 layout
+  # ($data_root/shared), so the v2 marker flips while the real wiki/cron/
+  # users content is stranded at the legacy path (split-brain: v2 indexer
+  # scans an empty data/shared/wiki). Unlike the UID/group/chmod work the
+  # skip branches legitimately bypass on non-Linux, this data relocation is
+  # platform-independent and required on EVERY path. It is delete_eligible=0
+  # (legacy preserved) and writes a sentinel the resolver keys off; a
+  # failure is warn-and-continue, never fatal — if the mirror fails the
+  # sentinel is absent, the resolver stays on the legacy path, and the
+  # install keeps working exactly as before this migrate ran.
+  if ! bridge_isolation_v2_migrate_shared_backfill "$data_root" "$target_root"; then
+    bridge_warn "apply_for_upgrade: shared-tree backfill did not complete; resolver will keep using the legacy shared path (no split-brain, but data/shared not yet canonical — rerun \`agent-bridge upgrade --apply\` after addressing the warned cause)"
+  fi
 
   # v0.13.10: markerless-existing-install + no-isolated-roster fast-path.
   #

--- a/lib/bridge-isolation-v2.sh
+++ b/lib/bridge-isolation-v2.sh
@@ -101,6 +101,32 @@ BRIDGE_SHARED_ROOT="${BRIDGE_SHARED_ROOT:-${BRIDGE_DATA_ROOT:+$BRIDGE_DATA_ROOT/
 BRIDGE_AGENT_ROOT_V2="${BRIDGE_AGENT_ROOT_V2:-${BRIDGE_DATA_ROOT:+$BRIDGE_DATA_ROOT/agents}}"
 BRIDGE_CONTROLLER_STATE_ROOT="${BRIDGE_CONTROLLER_STATE_ROOT:-${BRIDGE_DATA_ROOT:+$BRIDGE_DATA_ROOT/state}}"
 
+# v2 shared-dir resolver flip (gated on the migrate shared-mirror sentinel).
+#
+# BRIDGE_SHARED_DIR is the variable the daemon and nearly every CLI
+# (knowledge/wiki search, bundle, intake, task notes) read for the active
+# shared tree; its legacy default ($BRIDGE_HOME/shared) is applied lazily in
+# bridge_load_roster (lib/bridge-state.sh), which is too late for callers
+# that snapshot BRIDGE_SHARED_DIR right after sourcing bridge-lib.sh
+# (bridge-bundle.sh, bridge-intake.sh). Resolve it HERE — at source time,
+# after BRIDGE_DATA_ROOT is known from the layout marker and before any of
+# those callers snapshot it — so daemon and CLIs agree.
+#
+# The flip is gated on a dedicated sentinel written by the migrate's shared
+# backfill (bridge_isolation_v2_migrate_shared_backfill), NOT on
+# "$BRIDGE_DATA_ROOT/shared exists / is non-empty": a fresh v2 data/shared
+# already carries _index/_audit skeletons and plugins-cache, so emptiness is
+# not a reliable "not yet migrated" signal. Until the real shared tree has
+# been mirrored into the data/-prefixed layout, BRIDGE_SHARED_DIR stays
+# legacy so a marker-flipped-but-data-not-moved install keeps reading real
+# content (avoids the v0.15 split-brain). An explicit env override always
+# wins (the -z guard).
+if [[ "$BRIDGE_LAYOUT" == "v2" && -n "$BRIDGE_DATA_ROOT" \
+      && -z "${BRIDGE_SHARED_DIR:-}" \
+      && -f "$BRIDGE_DATA_ROOT/.v2-shared-mirror.sentinel" ]]; then
+  BRIDGE_SHARED_DIR="$BRIDGE_DATA_ROOT/shared"
+fi
+
 # Group names. Operator may override via env to fit local naming policy.
 BRIDGE_SHARED_GROUP="${BRIDGE_SHARED_GROUP:-ab-shared}"
 BRIDGE_CONTROLLER_GROUP="${BRIDGE_CONTROLLER_GROUP:-ab-controller}"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -1630,7 +1630,16 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # Pull 1359-cron-create-iso-staging on every isolation-lib move so
       # a row-reordering or scope-gate change cannot silently regress the
       # iso staging delegation contract.
-      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1077-migrate-iso-v2-data-dir 1113-watchdog-legacy-backfill 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-b-sudo-escalate-and-state 1342-write-state-marker-matrix launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup phase2-install-tree-reconciler phase3-agent-home-contract 1207-stale-supp-groups-allowlist A-beta4-iso-path-resolution H-beta4-iso-ownership G-beta4-watchdog-noise J-beta4-workflow-docs α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-2-theta-upgrade-backfill-perms beta5-2-mu-cron-channel-creds 1359-cron-create-iso-staging
+      # v0.15 split-brain fix: lib/bridge-isolation-v2-migrate.sh gained
+      # bridge_isolation_v2_migrate_shared_backfill (the platform-agnostic
+      # shared-tree data move that runs before every apply_for_upgrade skip
+      # branch) + its sentinel writer, and lib/bridge-isolation-v2.sh gained
+      # the sentinel-gated BRIDGE_SHARED_DIR resolver flip. Pull
+      # isolation-v2-shared-mover on every isolation-lib + migrate move so a
+      # future revert of the early backfill call (which would re-strand the
+      # active shared tree at the legacy path on macOS) or the sentinel gate
+      # is caught at PR time.
+      add_required isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1077-migrate-iso-v2-data-dir 1113-watchdog-legacy-backfill 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-b-sudo-escalate-and-state 1342-write-state-marker-matrix launch isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup phase2-install-tree-reconciler phase3-agent-home-contract 1207-stale-supp-groups-allowlist A-beta4-iso-path-resolution H-beta4-iso-ownership G-beta4-watchdog-noise J-beta4-workflow-docs α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-2-theta-upgrade-backfill-perms beta5-2-mu-cron-channel-creds 1359-cron-create-iso-staging isolation-v2-shared-mover
       add_integration integration-minimal
       add_live live-tmux-daemon
       ;;

--- a/scripts/smoke/isolation-v2-shared-mover.sh
+++ b/scripts/smoke/isolation-v2-shared-mover.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# Regression smoke for the v0.15 split-brain fix: the layout marker flipped
+# to v2 WITHOUT relocating the active shared tree ($BRIDGE_HOME/shared) into
+# the v2 data/-prefixed layout ($BRIDGE_DATA_ROOT/shared). On macOS the
+# apply_for_upgrade skip branches (marker-only-no-isolated-roster +
+# macos-shared-agent) returned before any data move, so the v2 wiki indexer
+# scanned an empty data/shared/wiki while every legacy BRIDGE_SHARED_DIR
+# consumer still read the real content at the legacy path.
+#
+# The fix adds a platform-agnostic shared-tree backfill that runs BEFORE all
+# skip branches (bridge_isolation_v2_migrate_shared_backfill), a sentinel it
+# drops (bridge_isolation_v2_migrate_shared_sentinel_write), and a
+# sentinel-gated resolver flip in lib/bridge-isolation-v2.sh.
+#
+# Coverage:
+#   T1 — Darwin + no isolated agents (macos-shared-agent skip) + populated
+#        legacy shared → backfill mirrors into data/shared, legacy PRESERVED,
+#        sentinel reason=mirrored, skip JSON still emitted, sudo never called.
+#   T2 — idempotent: a second apply does NOT re-mirror (sentinel-gated), even
+#        after the legacy tree is mutated.
+#   T3 — Darwin + BRIDGE_UPGRADE_CONTEXT=1 (marker-only-no-isolated skip) +
+#        populated legacy shared → backfill still fires before that branch
+#        (mirror + sentinel), proving both skip paths relocate the data.
+#   T4 — empty legacy shared → sentinel reason=no-legacy-content, no crash.
+#   T5 — sentinel-gated resolver flip (lib/bridge-isolation-v2.sh, sourced
+#        directly): no flip without sentinel, flips to data/shared with it,
+#        explicit BRIDGE_SHARED_DIR override always wins.
+#   T6 — structural: the early backfill call precedes BOTH skip branches in
+#        bridge_isolation_v2_migrate_apply_for_upgrade.
+#
+# All scripted shell snippets are emitted via printf-to-file (no heredocs /
+# here-strings) — Bash 5.3.9 heredoc_write deadlock class, footgun #11.
+
+set -uo pipefail
+
+SMOKE_NAME="isolation-v2-shared-mover"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+MIGRATE_LIB="$REPO_ROOT/lib/bridge-isolation-v2-migrate.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+# Pick a Bash 4+ interpreter on macOS hosts (system bash is 3.2).
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+# --- harness helpers ---------------------------------------------------------
+
+# uname + sudo shim. uname reports the requested kernel so the macOS skip
+# branch can be exercised on any runner; sudo records calls and exits
+# non-zero so an accidental escalation turns into a loud failure.
+build_platform_shim() {
+  local shim_dir="$1" fake_uname="$2" sudo_log="$3"
+  mkdir -p "$shim_dir"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'FAKE_UNAME=%q\n' "$fake_uname"
+    printf '%s\n' 'if [[ $# -eq 0 ]]; then printf "%s\n" "$FAKE_UNAME"; exit 0; fi'
+    printf '%s\n' 'while [[ $# -gt 0 ]]; do'
+    printf '%s\n' '  case "$1" in'
+    printf '%s\n' '    -s) printf "%s\n" "$FAKE_UNAME" ;;'
+    printf '%s\n' '    -m) printf "%s\n" "x86_64" ;;'
+    printf '%s\n' '    -r) printf "%s\n" "0.0.0" ;;'
+    printf '%s\n' '    -a) printf "%s shim 0.0.0 #0 SMP x86_64\n" "$FAKE_UNAME" ;;'
+    printf '%s\n' '    *) printf "%s\n" "$FAKE_UNAME" ;;'
+    printf '%s\n' '  esac'
+    printf '%s\n' '  shift'
+    printf '%s\n' 'done'
+  } >"$shim_dir/uname"
+  chmod +x "$shim_dir/uname"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'LOG=%q\n' "$sudo_log"
+    printf '%s\n' 'printf "[sudo-shim] %s\n" "$*" >>"$LOG"'
+    printf '%s\n' 'exit 99'
+  } >"$shim_dir/sudo"
+  chmod +x "$shim_dir/sudo"
+}
+
+# Symlink PATH essentials into the shim dir so the driver subshell keeps
+# access when we replace PATH wholesale. NOTE: rsync is included — the
+# shared backfill's real-copy mirror needs it (the macos-skip smoke omits
+# rsync because its apply_for_upgrade path never copies data).
+populate_basic_path() {
+  local shim_dir="$1" cmd target
+  for cmd in bash mkdir rm cat tr grep sed awk printf id stat tee chmod dirname env date mktemp readlink ls cp mv touch wc head tail find sort uniq true false python3 git tmux jq sqlite3 sha256sum md5 rsync; do
+    target="$(command -v "$cmd" 2>/dev/null || true)"
+    [[ -n "$target" && "${target:0:1}" == "/" ]] || continue
+    [[ -L "$shim_dir/$cmd" || -e "$shim_dir/$cmd" ]] && continue
+    ln -s "$target" "$shim_dir/$cmd" 2>/dev/null || true
+  done
+}
+
+write_driver_script() {
+  local out="$1"; shift
+  : >"$out"
+  local line
+  for line in "$@"; do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+# Populate a legacy shared tree with recognizable content.
+seed_legacy_shared() {
+  local shared_dir="$1"
+  mkdir -p "$shared_dir/wiki/_index" "$shared_dir/cron-dispatch"
+  printf 'real wiki index\n' >"$shared_dir/wiki/index.md"
+  printf 'mentions-db-bytes\n' >"$shared_dir/wiki/_index/mentions.db"
+  printf 'dispatch-row\n' >"$shared_dir/cron-dispatch/row.md"
+}
+
+# Run apply_for_upgrade for a given platform / roster / upgrade-context.
+# Emits the wrapper JSON to out_file. The home_dir layout mirrors a live
+# install: legacy shared at $home_dir/shared, v2 data at $home_dir/data.
+run_apply_for_upgrade() {
+  local fake_uname="$1"      # Darwin | Linux
+  local roster_kind="$2"     # shared | isolated
+  local upgrade_ctx="$3"     # 0 | 1
+  local home_dir="$4"
+  local out_file="$5"
+
+  local shim_dir="$home_dir/shim-bin"
+  local sudo_log="$home_dir/sudo-calls.log"
+  : >"$sudo_log"
+  build_platform_shim "$shim_dir" "$fake_uname" "$sudo_log"
+  populate_basic_path "$shim_dir"
+
+  mkdir -p "$home_dir/state" "$home_dir/logs" \
+    "$home_dir/data/shared" "$home_dir/data/agents" "$home_dir/data/state"
+  : >"$home_dir/agent-roster.local.sh"
+
+  local roster_setup
+  case "$roster_kind" in
+    shared)
+      roster_setup='BRIDGE_AGENT_IDS=(a1 a2); bridge_agent_linux_user_isolation_effective() { return 1; }'
+      ;;
+    isolated)
+      roster_setup='BRIDGE_AGENT_IDS=(a1 a2); bridge_agent_linux_user_isolation_effective() { local a="${1:-}"; case "$a" in a2) return 0;; *) return 1;; esac; }'
+      ;;
+    *) smoke_fail "internal: unknown roster_kind=$roster_kind" ;;
+  esac
+
+  local driver="$home_dir/driver.sh"
+  write_driver_script "$driver" \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'export BRIDGE_HOME="$HOME_DIR"' \
+    'export BRIDGE_STATE_DIR="$HOME_DIR/state"' \
+    'export BRIDGE_LOG_DIR="$HOME_DIR/logs"' \
+    'export BRIDGE_SHARED_DIR="$HOME_DIR/shared"' \
+    'export BRIDGE_DATA_ROOT="$HOME_DIR/data"' \
+    'export BRIDGE_LAYOUT="v2"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'source "$REPO_ROOT/lib/bridge-isolation-v2-migrate.sh" >/dev/null 2>&1' \
+    "$roster_setup" \
+    'bridge_isolation_v2_migrate_apply_for_upgrade --target-root "$HOME_DIR" --json 2>/dev/null || true'
+
+  PATH="$shim_dir" \
+    REPO_ROOT="$REPO_ROOT" \
+    HOME_DIR="$home_dir" \
+    BRIDGE_HOME="$home_dir" \
+    BRIDGE_STATE_DIR="$home_dir/state" \
+    BRIDGE_LOG_DIR="$home_dir/logs" \
+    BRIDGE_SHARED_DIR="$home_dir/shared" \
+    BRIDGE_DATA_ROOT="$home_dir/data" \
+    BRIDGE_LAYOUT="v2" \
+    BRIDGE_UPGRADE_CONTEXT="$upgrade_ctx" \
+    "$BRIDGE_BASH" "$driver" >"$out_file" 2>&1 || true
+}
+
+assert_backfill_effects() {
+  local label="$1" home_dir="$2"
+  smoke_assert_file_exists "$home_dir/data/shared/wiki/index.md" \
+    "$label: data/shared wiki mirrored"
+  smoke_assert_contains "$(cat "$home_dir/data/shared/wiki/index.md" 2>/dev/null)" \
+    "real wiki index" "$label: mirrored content matches legacy"
+  smoke_assert_file_exists "$home_dir/data/shared/wiki/_index/mentions.db" \
+    "$label: nested _index mirrored"
+  smoke_assert_file_exists "$home_dir/data/shared/cron-dispatch/row.md" \
+    "$label: cron-dispatch mirrored"
+  # delete_eligible=0 — legacy preserved.
+  smoke_assert_file_exists "$home_dir/shared/wiki/index.md" \
+    "$label: legacy shared PRESERVED (delete_eligible=0)"
+  smoke_assert_file_exists "$home_dir/data/.v2-shared-mirror.sentinel" \
+    "$label: sentinel written"
+  smoke_assert_contains "$(cat "$home_dir/data/.v2-shared-mirror.sentinel" 2>/dev/null)" \
+    "reason=mirrored" "$label: sentinel reason=mirrored"
+}
+
+assert_no_sudo() {
+  local label="$1" home_dir="$2"
+  if [[ -s "$home_dir/sudo-calls.log" ]]; then
+    smoke_fail "$label: sudo was invoked — backfill + skip path must stay sudo-free. log=$(cat "$home_dir/sudo-calls.log")"
+  fi
+}
+
+# --- T1: macos-shared-agent skip + populated legacy --------------------------
+
+smoke_log "T1: Darwin macos-shared-agent skip relocates the shared tree before returning"
+T1_HOME="$SMOKE_TMP_ROOT/t1"
+mkdir -p "$T1_HOME/shared"
+seed_legacy_shared "$T1_HOME/shared"
+T1_OUT="$T1_HOME/out.txt"
+run_apply_for_upgrade Darwin shared 0 "$T1_HOME" "$T1_OUT"
+T1_PAYLOAD="$(cat "$T1_OUT")"
+smoke_assert_contains "$T1_PAYLOAD" '"reason":"macos-shared-agent"' \
+  "T1: macos-shared-agent skip JSON still emitted"
+assert_backfill_effects "T1" "$T1_HOME"
+assert_no_sudo "T1" "$T1_HOME"
+smoke_log "T1 PASS: data relocated + legacy preserved + sentinel + skip intact + no sudo"
+
+# --- T2: idempotent — second apply does not re-mirror ------------------------
+
+smoke_log "T2: idempotent — second apply is a sentinel-gated no-op"
+T2_HOME="$SMOKE_TMP_ROOT/t2"
+mkdir -p "$T2_HOME/shared"
+seed_legacy_shared "$T2_HOME/shared"
+T2_OUT_A="$T2_HOME/out-a.txt"
+T2_OUT_B="$T2_HOME/out-b.txt"
+run_apply_for_upgrade Darwin shared 0 "$T2_HOME" "$T2_OUT_A"
+assert_backfill_effects "T2-A" "$T2_HOME"
+# Mutate legacy AFTER the first mirror; the sentinel-gated no-op must NOT
+# propagate the change.
+printf 'CHANGED-AFTER-FIRST-MIRROR\n' >"$T2_HOME/shared/wiki/index.md"
+run_apply_for_upgrade Darwin shared 0 "$T2_HOME" "$T2_OUT_B"
+T2_MIRRORED="$(cat "$T2_HOME/data/shared/wiki/index.md" 2>/dev/null)"
+smoke_assert_contains "$T2_MIRRORED" "real wiki index" \
+  "T2: second apply did NOT re-mirror (data/shared still holds original)"
+smoke_assert_not_contains "$T2_MIRRORED" "CHANGED-AFTER-FIRST-MIRROR" \
+  "T2: post-mirror legacy mutation must not leak into data/shared"
+assert_no_sudo "T2" "$T2_HOME"
+smoke_log "T2 PASS: sentinel-gated idempotency holds"
+
+# --- T3: marker-only-no-isolated skip also relocates -------------------------
+
+smoke_log "T3: Darwin marker-only-no-isolated skip (UPGRADE_CONTEXT=1) also relocates"
+T3_HOME="$SMOKE_TMP_ROOT/t3"
+mkdir -p "$T3_HOME/shared"
+seed_legacy_shared "$T3_HOME/shared"
+T3_OUT="$T3_HOME/out.txt"
+run_apply_for_upgrade Darwin shared 1 "$T3_HOME" "$T3_OUT"
+T3_PAYLOAD="$(cat "$T3_OUT")"
+smoke_assert_contains "$T3_PAYLOAD" '"reason":"marker-only-no-isolated-roster"' \
+  "T3: marker-only-no-isolated skip JSON emitted"
+assert_backfill_effects "T3" "$T3_HOME"
+assert_no_sudo "T3" "$T3_HOME"
+smoke_log "T3 PASS: backfill fires before the marker-only fast-path too"
+
+# --- T4: empty legacy → reason=no-legacy-content -----------------------------
+
+smoke_log "T4: empty legacy shared → sentinel reason=no-legacy-content, no crash"
+T4_HOME="$SMOKE_TMP_ROOT/t4"
+mkdir -p "$T4_HOME/shared"   # exists but empty
+T4_OUT="$T4_HOME/out.txt"
+run_apply_for_upgrade Darwin shared 0 "$T4_HOME" "$T4_OUT"
+T4_PAYLOAD="$(cat "$T4_OUT")"
+smoke_assert_contains "$T4_PAYLOAD" '"reason":"macos-shared-agent"' \
+  "T4: skip JSON still emitted with empty legacy"
+smoke_assert_file_exists "$T4_HOME/data/.v2-shared-mirror.sentinel" \
+  "T4: sentinel written even with empty legacy"
+smoke_assert_contains "$(cat "$T4_HOME/data/.v2-shared-mirror.sentinel" 2>/dev/null)" \
+  "reason=no-legacy-content" "T4: sentinel reason=no-legacy-content"
+smoke_log "T4 PASS: empty-legacy path records no-legacy-content, no crash"
+
+# --- T5: sentinel-gated resolver flip (lib/bridge-isolation-v2.sh) -----------
+
+smoke_log "T5: resolver flip is sentinel-gated (direct isolation-v2.sh source)"
+resolver_shared_dir() {
+  # Args: <data_root> [extra env...]; prints the resolved BRIDGE_SHARED_DIR.
+  local data_root="$1"; shift
+  env -u BRIDGE_SHARED_DIR -u BRIDGE_SHARED_ROOT -u BRIDGE_AGENT_ROOT_V2 \
+      -u BRIDGE_CONTROLLER_STATE_ROOT "$@" \
+      BRIDGE_LAYOUT=v2 BRIDGE_DATA_ROOT="$data_root" \
+      "$BRIDGE_BASH" --noprofile --norc -c "
+        source '$REPO_ROOT/lib/bridge-isolation-v2.sh' >/dev/null 2>&1 || true
+        printf '%s\n' \"\${BRIDGE_SHARED_DIR:-unset}\"
+      " 2>&1
+}
+T5_DATA="$SMOKE_TMP_ROOT/t5/data"
+mkdir -p "$T5_DATA/shared/wiki"
+# No sentinel -> no flip.
+T5_NOSENT="$(resolver_shared_dir "$T5_DATA")"
+smoke_assert_not_contains "$T5_NOSENT" "$T5_DATA/shared" \
+  "T5: resolver does NOT flip without sentinel"
+# Sentinel present -> flip to data/shared.
+printf 'm\n' >"$T5_DATA/.v2-shared-mirror.sentinel"
+T5_SENT="$(resolver_shared_dir "$T5_DATA")"
+smoke_assert_eq "$T5_DATA/shared" "$T5_SENT" \
+  "T5: resolver flips BRIDGE_SHARED_DIR=data/shared with sentinel"
+# Explicit override always wins.
+T5_OVERRIDE="$(resolver_shared_dir "$T5_DATA" BRIDGE_SHARED_DIR=/explicit/override/shared)"
+smoke_assert_eq "/explicit/override/shared" "$T5_OVERRIDE" \
+  "T5: explicit BRIDGE_SHARED_DIR override wins over sentinel flip"
+smoke_log "T5 PASS: flip gated on sentinel, override respected"
+
+# --- T6: structural — backfill precedes both skip branches -------------------
+
+smoke_log "T6: early backfill call precedes both apply_for_upgrade skip branches"
+fn_start="$(grep -n '^bridge_isolation_v2_migrate_apply_for_upgrade()' "$MIGRATE_LIB" | head -1 | cut -d: -f1)"
+[[ -n "$fn_start" ]] || smoke_fail "T6: apply_for_upgrade function not found"
+backfill_ln="$(awk 'NR>='"$fn_start"' && /bridge_isolation_v2_migrate_shared_backfill "\$data_root" "\$target_root"/ {print NR; exit}' "$MIGRATE_LIB")"
+marker_only_ln="$(awk 'NR>='"$fn_start"' && /"reason":"marker-only-no-isolated-roster"/ {print NR; exit}' "$MIGRATE_LIB")"
+macos_skip_ln="$(awk 'NR>='"$fn_start"' && /"reason":"macos-shared-agent"/ {print NR; exit}' "$MIGRATE_LIB")"
+[[ -n "$backfill_ln" && -n "$marker_only_ln" && -n "$macos_skip_ln" ]] \
+  || smoke_fail "T6: could not locate all anchors (backfill=$backfill_ln marker-only=$marker_only_ln macos=$macos_skip_ln)"
+if (( backfill_ln < marker_only_ln && backfill_ln < macos_skip_ln )); then
+  smoke_log "T6 PASS: backfill (L$backfill_ln) precedes marker-only (L$marker_only_ln) + macos-shared-agent (L$macos_skip_ln)"
+else
+  smoke_fail "T6: backfill call must precede skip branches (backfill=$backfill_ln marker-only=$marker_only_ln macos=$macos_skip_ln)"
+fi
+
+smoke_log "all 6 tests PASS"

--- a/scripts/smoke/isolation-v2-shared-mover.sh
+++ b/scripts/smoke/isolation-v2-shared-mover.sh
@@ -60,9 +60,28 @@ fi
 
 # --- harness helpers ---------------------------------------------------------
 
-# uname + sudo shim. uname reports the requested kernel so the macOS skip
-# branch can be exercised on any runner; sudo records calls and exits
-# non-zero so an accidental escalation turns into a loud failure.
+# sudo recorder shim — logs each call and exits non-zero so any accidental
+# escalation in the skip / backfill path turns into a loud test failure.
+build_sudo_shim() {
+  local shim_dir="$1" sudo_log="$2"
+  mkdir -p "$shim_dir"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf 'LOG=%q\n' "$sudo_log"
+    printf '%s\n' 'printf "[sudo-shim] %s\n" "$*" >>"$LOG"'
+    printf '%s\n' 'exit 99'
+  } >"$shim_dir/sudo"
+  chmod +x "$shim_dir/sudo"
+}
+
+# Fake-platform uname shim + sudo recorder. The uname shim reports the
+# requested kernel so the macOS-only skip branch (uname != Linux) can be
+# exercised on any runner. Use this ONLY for cases that genuinely need a
+# fake platform (macos-shared-agent skip); platform-agnostic cases
+# (marker-only) must use the REAL host uname so platform-gated helpers run
+# consistently with the host kernel (a fake Darwin uname on a Linux runner
+# leaves the marker-only branch's host-dependent steps in an inconsistent
+# state — see T3).
 build_platform_shim() {
   local shim_dir="$1" fake_uname="$2" sudo_log="$3"
   mkdir -p "$shim_dir"
@@ -82,22 +101,18 @@ build_platform_shim() {
     printf '%s\n' 'done'
   } >"$shim_dir/uname"
   chmod +x "$shim_dir/uname"
-  {
-    printf '%s\n' '#!/usr/bin/env bash'
-    printf 'LOG=%q\n' "$sudo_log"
-    printf '%s\n' 'printf "[sudo-shim] %s\n" "$*" >>"$LOG"'
-    printf '%s\n' 'exit 99'
-  } >"$shim_dir/sudo"
-  chmod +x "$shim_dir/sudo"
+  build_sudo_shim "$shim_dir" "$sudo_log"
 }
 
 # Symlink PATH essentials into the shim dir so the driver subshell keeps
 # access when we replace PATH wholesale. NOTE: rsync is included — the
 # shared backfill's real-copy mirror needs it (the macos-skip smoke omits
-# rsync because its apply_for_upgrade path never copies data).
+# rsync because its apply_for_upgrade path never copies data). uname is
+# included too so REAL-platform cases resolve the host kernel (fake-platform
+# cases write their own $shim_dir/uname first, which this loop then skips).
 populate_basic_path() {
   local shim_dir="$1" cmd target
-  for cmd in bash mkdir rm cat tr grep sed awk printf id stat tee chmod dirname env date mktemp readlink ls cp mv touch wc head tail find sort uniq true false python3 git tmux jq sqlite3 sha256sum md5 rsync; do
+  for cmd in bash mkdir rm cat tr grep sed awk printf id stat tee chmod dirname env date mktemp readlink ls cp mv touch wc head tail find sort uniq true false python3 git tmux jq sqlite3 sha256sum md5 rsync uname; do
     target="$(command -v "$cmd" 2>/dev/null || true)"
     [[ -n "$target" && "${target:0:1}" == "/" ]] || continue
     [[ -L "$shim_dir/$cmd" || -e "$shim_dir/$cmd" ]] && continue
@@ -128,7 +143,7 @@ seed_legacy_shared() {
 # Emits the wrapper JSON to out_file. The home_dir layout mirrors a live
 # install: legacy shared at $home_dir/shared, v2 data at $home_dir/data.
 run_apply_for_upgrade() {
-  local fake_uname="$1"      # Darwin | Linux
+  local fake_uname="$1"      # Darwin | Linux | REAL (use the host kernel)
   local roster_kind="$2"     # shared | isolated
   local upgrade_ctx="$3"     # 0 | 1
   local home_dir="$4"
@@ -137,7 +152,12 @@ run_apply_for_upgrade() {
   local shim_dir="$home_dir/shim-bin"
   local sudo_log="$home_dir/sudo-calls.log"
   : >"$sudo_log"
-  build_platform_shim "$shim_dir" "$fake_uname" "$sudo_log"
+  if [[ "$fake_uname" == "REAL" ]]; then
+    # sudo recorder only; populate_basic_path symlinks the host uname.
+    build_sudo_shim "$shim_dir" "$sudo_log"
+  else
+    build_platform_shim "$shim_dir" "$fake_uname" "$sudo_log"
+  fi
   populate_basic_path "$shim_dir"
 
   mkdir -p "$home_dir/state" "$home_dir/logs" \
@@ -162,6 +182,7 @@ run_apply_for_upgrade() {
     'cd "$REPO_ROOT"' \
     'export BRIDGE_HOME="$HOME_DIR"' \
     'export BRIDGE_STATE_DIR="$HOME_DIR/state"' \
+    'export BRIDGE_LAYOUT_MARKER_DIR="$HOME_DIR/state"' \
     'export BRIDGE_LOG_DIR="$HOME_DIR/logs"' \
     'export BRIDGE_SHARED_DIR="$HOME_DIR/shared"' \
     'export BRIDGE_DATA_ROOT="$HOME_DIR/data"' \
@@ -176,6 +197,7 @@ run_apply_for_upgrade() {
     HOME_DIR="$home_dir" \
     BRIDGE_HOME="$home_dir" \
     BRIDGE_STATE_DIR="$home_dir/state" \
+    BRIDGE_LAYOUT_MARKER_DIR="$home_dir/state" \
     BRIDGE_LOG_DIR="$home_dir/logs" \
     BRIDGE_SHARED_DIR="$home_dir/shared" \
     BRIDGE_DATA_ROOT="$home_dir/data" \
@@ -249,12 +271,18 @@ smoke_log "T2 PASS: sentinel-gated idempotency holds"
 
 # --- T3: marker-only-no-isolated skip also relocates -------------------------
 
-smoke_log "T3: Darwin marker-only-no-isolated skip (UPGRADE_CONTEXT=1) also relocates"
+# The marker-only fast-path is platform-agnostic (it fires before the
+# macos-shared-agent skip whenever UPGRADE_CONTEXT=1 + no-isolated-roster +
+# no valid marker, on any kernel). Use the REAL host uname here — a fake
+# Darwin uname on a Linux runner leaves the branch's host-dependent steps
+# inconsistent (empty output on CI). The backfill runs FIRST regardless, so
+# its effects are the primary assertion; the skip JSON is asserted too.
+smoke_log "T3: marker-only-no-isolated skip (UPGRADE_CONTEXT=1, real uname) also relocates"
 T3_HOME="$SMOKE_TMP_ROOT/t3"
 mkdir -p "$T3_HOME/shared"
 seed_legacy_shared "$T3_HOME/shared"
 T3_OUT="$T3_HOME/out.txt"
-run_apply_for_upgrade Darwin shared 1 "$T3_HOME" "$T3_OUT"
+run_apply_for_upgrade REAL shared 1 "$T3_HOME" "$T3_OUT"
 T3_PAYLOAD="$(cat "$T3_OUT")"
 smoke_assert_contains "$T3_PAYLOAD" '"reason":"marker-only-no-isolated-roster"' \
   "T3: marker-only-no-isolated skip JSON emitted"


### PR DESCRIPTION
## Problem

On the v0.15 data/-prefixed layout, `$BRIDGE_DATA_ROOT/shared` is the canonical shared root, but `apply_for_upgrade` only mirrored the (usually empty) `runtime/shared` tree (the `runtime_shared` emit-plan row). On macOS / no-isolated hosts the two skip branches in `bridge_isolation_v2_migrate_apply_for_upgrade` — `marker-only-no-isolated-roster` and `macos-shared-agent` — `return 0` **before any data move**. The result is split-brain:

- The v2 layout marker flips to `BRIDGE_LAYOUT=v2`.
- The **active** shared tree (`$BRIDGE_HOME/shared`: wiki, cron-dispatch/result, users, company-documents — everything `BRIDGE_SHARED_DIR` points at) stays stranded at the legacy path.
- `BRIDGE_SHARED_ROOT` (v2) resolves to `data/shared` while `BRIDGE_SHARED_DIR` (legacy, used by daemon / knowledge / bundle / intake / task notes) stays `$BRIDGE_HOME/shared`. The two are never reconciled.
- The v2 wiki-mention-scan then scans an empty `data/shared/wiki` (`files_scanned:0`) — a silent regression — while every legacy consumer still reads the real 2.5k-file tree.

Observed on a Mac mini M4 install (`BRIDGE_HOME=/Users/.../.agent-bridge`, VERSION 0.15.0). The `runtime_shared` row was introduced with the file in 0.15.0-rc1, so this is a first-release-of-0.15 defect. It also violates the `OPERATIONS.md` apply contract ("real-copy mirror legacy → v2, write the marker atomically") for the top-level shared tree, with no post-migration `files>0` assertion.

## Fix (3 parts)

1. **`bridge_isolation_v2_migrate_shared_backfill`** (`lib/bridge-isolation-v2-migrate.sh`) — platform-agnostic real-copy mirror of the active shared tree into the v2 layout, called **before every skip branch** in `apply_for_upgrade`. Unlike the UID/group/chmod work the skip branches legitimately bypass on non-Linux, this data relocation is platform-independent and required on every path (Linux full-migrate, macOS marker-only fast-path, macOS macos-shared-agent skip, and marker-present-but-sentinel-missing repair).
   - `delete_eligible=0`: legacy `$BRIDGE_HOME/shared` is **preserved** (rsync without `--delete`). The resolver flip, not deletion, cuts consumers over — a failed/rolled-back migration leaves the real content untouched.
   - rsync prefers the repo's `-aHX --numeric-ids` flags (matching `mirror_one`) and degrades to plain `-a` when the local rsync rejects them. macOS ships openrsync, which implements neither `-X` nor `--numeric-ids`; this backfill is the **first** rsync the migrate runs on macOS (`mirror_one` is skipped on the macos-shared-agent path), so it must degrade gracefully. A `-n` dry-run probes flag support.
   - Idempotent (sentinel present → no-op) and **self-repairing**: re-running `upgrade --apply` on an already-marker-flipped install that lacks the sentinel backfills the stranded tree. This is the repair path for installs already in the split-brain state.
   - Warn-and-continue on failure — the sentinel stays absent, the resolver stays on the legacy path, and the install keeps working exactly as before the migrate ran.

2. **`bridge_isolation_v2_migrate_shared_sentinel_write`** — atomic (tmp + `mv`) sentinel at `$BRIDGE_DATA_ROOT/.v2-shared-mirror.sentinel` recording `reason` / `legacy_shared` / `v2_shared` / `written_at` provenance.

3. **Sentinel-gated resolver flip** (`lib/bridge-isolation-v2.sh`) — resolves `BRIDGE_SHARED_DIR` to `$BRIDGE_DATA_ROOT/shared` at source time (after `BRIDGE_DATA_ROOT` is known from the marker, before `bridge-bundle.sh` / `bridge-intake.sh` snapshot it). Gated on the sentinel — **not** on "data/shared is non-empty", because a fresh v2 `data/shared` already carries `_index`/`_audit` skeletons + `plugins-cache`, so emptiness is not a reliable "not yet migrated" signal. Until the real tree is mirrored, `BRIDGE_SHARED_DIR` stays legacy so a marker-flipped-but-data-not-moved install keeps reading real content. An explicit env override always wins.

## Testing

New `scripts/smoke/isolation-v2-shared-mover.sh` (6 cases), registered in `ci-select-smoke.sh` on every isolation-lib + migrate move. End-to-end through the real `apply_for_upgrade` on a shimmed Darwin (`uname` + `sudo`-recorder shims, no heredoc-to-subprocess per footgun #11):

- **T1** macos-shared-agent skip + populated legacy → backfill mirrors into `data/shared`, legacy preserved, sentinel `reason=mirrored`, skip JSON intact, **sudo never invoked**.
- **T2** idempotent — second apply does not re-mirror even after the legacy tree is mutated (sentinel-gated).
- **T3** marker-only-no-isolated skip (`BRIDGE_UPGRADE_CONTEXT=1`) also relocates → proves both skip paths move the data.
- **T4** empty legacy → sentinel `reason=no-legacy-content`, no crash.
- **T5** sentinel-gated resolver flip (direct `isolation-v2.sh` source): no flip without sentinel, flips with it, explicit override wins.
- **T6** structural — the early backfill call precedes both skip branches.

```
[smoke:isolation-v2-shared-mover] all 6 tests PASS
```

Validation: `bash -n` + `shellcheck` clean on all touched `.sh`. `scripts/smoke-test.sh` shows only the pre-existing macOS-only `#365 follow-up` (`bridge_write_linux_agent_env_file`) failure — identical with and without this diff (verified by stashing), so no regression is introduced.

`OPERATIONS.md` apply contract documents the relocation + sentinel.

## Scope / notes

- No `VERSION` / `CHANGELOG` bump (stabilization fix; release is operator-cued).
- `runtime/skills` top-level reachability (cron payloads under `~/.agent-bridge/...` resolving against an agent's `HOME`) is a separate concern and intentionally **out of scope** here.
- Legacy `$BRIDGE_HOME/shared` is intentionally preserved (not added to the delete-eligible manifest) — cutover is via the resolver flip, and a follow-up can add managed cleanup once soak confirms parity.
