### PR TITLE
docs: CLAUDE.md — release ritual includes README index + docs sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ bash ./scripts/oss-preflight.sh
 
 Acceptable: prep VERSION + CHANGELOG drafts, run codex-rescue review on a release branch, leave the PR open for operator to merge. NOT acceptable: squash-merge the release PR or push the `vX.Y.Z` tag without an explicit "go release" or equivalent from the operator.
 
+**A release is not done at the tag — sync the docs index in the same session** (operator directive 2026-05-31). After the `vX.Y.Z` tag lands, update `README.md`'s top block to the new version: the `**Current version**` line, the one-line **Headline** (name the release's marquee feature + notable fixes), and the `Recommended upgrade target` + leap-path. Then confirm any new feature's usage docs are current (`OPERATIONS.md`, `docs/developer-handover.md`, `docs/<feature>-design.md`). This is a **separate `docs/vX.Y.Z-...` PR** — the release PR itself stays VERSION + CHANGELOG only (see "Working With Codex Reviewers" point 3). Why it matters: installing agents and patch read the README headline + feature docs — *not* the CHANGELOG — to discover and correctly use new capabilities, so a stale README ships new features invisible (v0.15.1's `agb setup template-sync` had 0 README refs right after the cut until PR #1435).
+
 ## Environment Variables Worth Knowing
 
 - `BRIDGE_HOME` — override live runtime root; essential for isolated tests.


### PR DESCRIPTION
Encodes the operator's durable directive (2026-05-31): **a version release is not done at the tag — the docs index must be synced in the same session.**

After a `vX.Y.Z` tag lands, a separate `docs/` PR updates `README.md`'s top block (`Current version` + Headline + `Recommended upgrade target`/leap-path) and confirms new-feature usage docs (`OPERATIONS.md`, handover, `docs/<feature>-design.md`). The release PR itself stays VERSION + CHANGELOG only (unchanged contract).

**Why:** installing agents and patch read the README headline + feature docs — not the CHANGELOG — to discover and use new capabilities. v0.15.1's `agb setup template-sync` had 0 README refs immediately after the cut until PR #1435 fixed it; this rule prevents the recurrence for all release-cutting agents/patch.

One-line addition to the "Releases require explicit operator permission" section. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)