### PR TITLE
Fix whole-fleet agent crash-loop on per-agent-HOME installs when Claude CLI boot outpaces the session-id detect window

### DIFF
--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -283,11 +283,25 @@ if [[ "$_resume_gate_enabled" == "1" && $SAFE_MODE -eq 0 ]]; then
       unset _gate_launch_history
     else
       unset _gate_launch_history
-      bridge_audit_log state session_id_missing_resume_blocked "$AGENT" \
+      # Lost-state: the agent HAS launched before (launch.history present) but
+      # its persisted session_id is gone — a #1246 daemon supp-group write
+      # failure, state churn, an operator rm, or a prior crash-loop that never
+      # captured one. The original behavior bridge_die'd here. Under the
+      # daemon's always-on restart loop that BRICKS the agent permanently:
+      # every relaunch hard-fails identically, so the agent can never recover
+      # on its own (the daemon's plugin-MCP-liveness watchdog then restarts it
+      # forever). A missing session_id is recoverable — degrade THIS launch to
+      # a fresh session (no --resume), exactly like the fresh-first-wake path
+      # above, but emit a loud warn so it stays ops-visible. The launch
+      # captures a fresh session_id on start and normal resume returns next
+      # launch. Genuine persistence/write errors still hard-fail loud in
+      # bridge_refresh_agent_session_id (bridge_die), so the #1248 fail-loud
+      # contract for actual write failures is preserved.
+      bridge_warn "[run] lost-state: continue=1 but session_id empty (agent=$AGENT) — degrading to a fresh session for this launch; a new id is captured on start and normal resume returns next launch"
+      bridge_audit_log run session_id_missing_resume_degraded "$AGENT" \
         --detail continue_mode="$_gate_continue" \
-        --detail reason=session_id_empty_with_continue_1 \
+        --detail reason=lost_state_session_id_empty_degraded_to_fresh \
         2>/dev/null || true
-      bridge_die "session_id missing; one of: (a) run agent first interactively to capture, (b) set continue=0 explicitly, (c) check #1246 daemon supp-group state (agent=$AGENT continue=$_gate_continue session_id=empty)"
     fi
   fi
   unset _gate_continue _gate_session_id

--- a/bridge-start.sh
+++ b/bridge-start.sh
@@ -1118,7 +1118,20 @@ if [[ -z "$(bridge_agent_session_id "$AGENT")" ]]; then
   # so the operator sees the structured reason on failure and the
   # session_id capture breadcrumb on success. Stdout (the captured id)
   # is still suppressed because nothing here consumes it.
-  bridge_refresh_agent_session_id "$AGENT" 12 0.25 >/dev/null
+  #
+  # BUT under `set -euo pipefail` (top of this script) a benign detect-empty
+  # `return 1` from bridge_refresh_agent_session_id aborts bridge-start.sh,
+  # which the restart helper treats as launch-failed and ROLLS BACK — killing
+  # a perfectly healthy session that simply had not written its session
+  # artifact within the 12×0.25s detection window yet (e.g. a slower Claude
+  # CLI `--continue` boot with plugins/MCP). detect-empty is explicitly "a
+  # safety-net visibility hook, not an error" (see the tail comment in
+  # bridge_refresh_agent_session_id); the daemon backfills the id on its next
+  # sync. Re-add `|| true` so the empty return is non-fatal. This does NOT
+  # mask bridge_die persist-failures (those `exit 1` directly, which `|| true`
+  # cannot intercept) and does NOT redirect stderr, so the #1248 visibility
+  # intent is fully preserved.
+  bridge_refresh_agent_session_id "$AGENT" 12 0.25 >/dev/null || true
 fi
 echo "[info] 세션 '$SESSION' 시작 완료"
 

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -3807,22 +3807,49 @@ bridge_resolve_agent_claude_config_dir() {
   if command -v bridge_agent_exists >/dev/null 2>&1; then
     bridge_agent_exists "$agent" || return 0
   fi
-  # Issue #1370 (beta5-2 #1316 regression): only agents whose linux-user
-  # isolation is *effective* (iso v2 active on a Linux host with an os_user)
-  # own a private Claude config dir. Shared-mode agents — including the admin,
-  # and every agent on non-Linux hosts where iso is never effective — write
-  # their session JSON / transcripts under the controller HOME (~/.claude).
-  # Returning a derived agent-home path for those makes session-id detection
-  # look in an empty scaffolded `<agent-home>/.claude` and block --continue
-  # resume. Fall through (empty) so the detect helper uses its daemon-HOME
-  # fallback. See bridge_detect_claude_session_id / Issue #1015.
-  if command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1; then
-    bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null || return 0
-  fi
   config_dir="$(bridge_agent_claude_config_dir "$agent" 2>/dev/null || true)"
   # A derived-but-absent path means the agent is not actually isolated on
   # this host; do not let it shadow the caller's HOME.
   [[ -n "$config_dir" && -d "$config_dir" ]] || return 0
+
+  # Issue #1370 (beta5-2 #1316 regression) gated this purely on linux-user
+  # isolation being *effective*: when it is NOT (every non-Linux host, and
+  # shared-mode Linux agents) the agent USUALLY shares the controller HOME
+  # ~/.claude, so a derived <agent-home>/.claude is an empty #1316 scaffold
+  # that must NOT shadow the controller HOME (it would block --continue
+  # resume).
+  #
+  # But that assumption is false on installs where each agent is launched with
+  # its OWN HOME (<agent-home>) even in shared mode — e.g. per-agent-HOME
+  # layouts on macOS/non-Linux hosts. There Claude writes its session JSON
+  # under <agent-home>/.claude/projects, which IS the live session location.
+  # The old gate discarded it, so bridge_detect_claude_session_id was handed
+  # an empty config dir, scanned the stale controller HOME, found no fresh
+  # transcript, returned 1, and the restart helper rolled back every
+  # just-launched session — a whole-fleet crash-loop (surfaced when Claude CLI
+  # boot grew slower than the session-id detect window). Discriminate an empty
+  # #1316 scaffold from a live per-agent home by whether projects/ holds data.
+  #
+  # iso-effective Linux agents own a private config dir unconditionally and
+  # skip the scaffold check (the controller cannot stat their iso-UID
+  # projects/ tree anyway). Everyone else — shared-mode, non-Linux, AND any
+  # context where the helper is absent (standalone / minimal / smoke) — runs
+  # the scaffold check. Treating a missing helper as "not effective" is the
+  # safe default: it keeps running the check instead of blindly returning the
+  # dir, preserving the #1370 protection where the helper is unavailable.
+  local _iso_effective=0
+  if command -v bridge_agent_linux_user_isolation_effective >/dev/null 2>&1 \
+     && bridge_agent_linux_user_isolation_effective "$agent" 2>/dev/null; then
+    _iso_effective=1
+  fi
+  if [[ "$_iso_effective" != "1" ]]; then
+    # `-type d`: a live per-agent home has projects/<workdir-slug>/ DIRECTORIES;
+    # an empty #1316 scaffold has none. Matching only directories ignores stray
+    # files (e.g. a macOS projects/.DS_Store) that would otherwise read as live.
+    if [[ -z "$(find "$config_dir/projects" -mindepth 1 -maxdepth 1 -type d -print -quit 2>/dev/null)" ]]; then
+      return 0
+    fi
+  fi
   printf '%s' "$config_dir"
 }
 

--- a/scripts/smoke/1015-resume-claude-config-dir.sh
+++ b/scripts/smoke/1015-resume-claude-config-dir.sh
@@ -61,6 +61,14 @@ fi
 #   T7c. (Issue #1370) a REGISTERED linux-user agent on a non-Linux host
 #        (iso never effective) likewise resolves EMPTY despite a scaffolded
 #        <agent-home>/.claude — the admin's actual macOS shape.
+#   T7d. (Issue #1439, Bug-1) a REGISTERED shared-mode per-agent-HOME agent
+#        whose <agent-home>/.claude/projects/<slug>/ is POPULATED resolves to
+#        <agent-home>/.claude — the live recovery. The resolver discriminates
+#        an empty #1316 scaffold (T7b/T7c, resolve empty) from a live
+#        per-agent home (this, resolve the dir) by whether projects/ holds a
+#        directory; pinning both polarities catches a flip in either
+#        direction. Runs AFTER T7b so its populate cannot pollute T7b's
+#        empty-scaffold assertion (same SHARED_AGENT fixture).
 #   T9. bridge_detect_claude_session_id for an UNREGISTERED agent with a
 #       per-call HOME does NOT shadow that HOME — the guard returns empty
 #       and the helper finds the fixture under the per-call HOME
@@ -369,6 +377,37 @@ test_non_linux_host_resolves_empty() {
     "T7c non-Linux-host agent resolves empty despite scaffolded .claude (#1370)"
 }
 
+# T7d — (Issue #1439, Bug-1) a REGISTERED shared-mode agent launched with its
+# OWN HOME (per-agent-HOME layout, e.g. macOS / non-Linux) whose
+# <agent-home>/.claude/projects/<slug>/ is POPULATED with live session data
+# MUST resolve to <agent-home>/.claude — NOT empty. This is the live-recovery
+# the #1439 fix restored: the old #1370 gate discarded the per-agent home for
+# any non-iso-effective agent, so bridge_detect_claude_session_id scanned the
+# stale controller HOME, found no fresh transcript, returned 1, and the
+# restart helper rolled back every just-launched session (whole-fleet
+# crash-loop). The resolver now discriminates an empty #1316 scaffold (T7b /
+# T7c — resolve empty) from a LIVE per-agent home (this case — resolve the
+# dir) by whether projects/ holds a directory. Same fixture shape as T7b but
+# with a populated projects/<slug>/ so the polarity is pinned in both
+# directions: a flip back to the old gate fails BOTH T7b (empty re-breaks
+# #1370) and T7d (populated re-breaks #1439 Bug-1).
+test_per_agent_home_populated_resolves_dir() {
+  bridge_agent_linux_user_isolation_effective "$SHARED_AGENT" 2>/dev/null \
+    && smoke_fail "T7d fixture should NOT be iso-effective (mode=shared)"
+
+  # Populate projects/<slug>/ with a live session dir (the discriminator the
+  # resolver uses: a directory under projects/, not just the scaffold).
+  local slug="${ISO_WORKDIR//\//-}"
+  mkdir -p "$SHARED_SCAFFOLD_DIR/projects/$slug"
+  printf '{"sessionId":"t7d-live"}\n' \
+    >"$SHARED_SCAFFOLD_DIR/projects/$slug/t7d-live.jsonl"
+
+  local resolved=""
+  resolved="$(bridge_resolve_agent_claude_config_dir "$SHARED_AGENT")"
+  smoke_assert_eq "$SHARED_SCAFFOLD_DIR" "$resolved" \
+    "T7d shared-mode per-agent-HOME with populated projects/ resolves the dir (#1439 Bug-1)"
+}
+
 # T9 — bridge_detect_claude_session_id for an UNREGISTERED agent with a
 # per-call HOME must NOT shadow that HOME. The guard returns empty (agent
 # not in the roster) so the helper falls back to HOME/.claude — where the
@@ -415,6 +454,7 @@ smoke_run "T7 shim detect for registered isolated agent"  test_shim_detect_isola
 smoke_run "T8 shim resolve for registered isolated agent" test_shim_resolve_isolated_agent
 smoke_run "T7b shared-mode agent resolves empty (#1370)"  test_shared_mode_resolves_empty
 smoke_run "T7c non-Linux host resolves empty (#1370)"     test_non_linux_host_resolves_empty
+smoke_run "T7d per-agent-HOME populated resolves dir (#1439)" test_per_agent_home_populated_resolves_dir
 smoke_run "T9 shim detect honours per-call HOME"          test_shim_detect_unregistered_home_fallback
 smoke_run "T10 shim resolve honours per-call HOME"        test_shim_resolve_unregistered_home_fallback
 

--- a/scripts/smoke/A3-beta3-1248-restart-session-id-resume.sh
+++ b/scripts/smoke/A3-beta3-1248-restart-session-id-resume.sh
@@ -34,9 +34,23 @@
 #   T3: `bridge-run.sh --dry-run` with continue=1 + session_id present
 #       emits a resume verb in the launch_cmd (claude `--resume <id>`
 #       or codex `resume <id>`).
-#   T4: `bridge-run.sh --dry-run` with continue=1 + session_id empty
-#       fails loud with the exact remediation message ((a)/(b)/(c)
-#       option list).
+#   T4: `bridge-run.sh --dry-run` with continue=1 + session_id empty AND a
+#       launch.history marker present (the #1248 lost-state case) DEGRADES to
+#       a fresh session instead of dying. #1439 deliberately replaced the old
+#       bridge_die with a warn-and-degrade so the daemon's always-on restart
+#       loop can no longer brick a whole fleet on a missing session_id: assert
+#       rc=0, the `bridge_warn` "degrading to a fresh session" line, the
+#       `session_id_missing_resume_degraded` audit label, and that the
+#       degraded launch carries NO `--resume` verb. Genuine persist/state-dir
+#       write failures STILL hard-fail in bridge_refresh_agent_session_id
+#       (covered by T1), so the #1248 fail-loud contract for real write
+#       failures is preserved.
+#   T4b (resume-safety pin — what the old #1248 die actually protected):
+#       drive the launch-cmd builder directly and assert the resume verb is
+#       chosen correctly: continue=1 + session_id present -> `--resume <id>`;
+#       continue_fallback=1 (a resumable transcript exists but no persisted
+#       id) -> `--continue` (NEVER `--resume ""`, NEVER a bare fresh launch);
+#       genuinely no transcript -> fresh (no `--resume`, no `--continue`).
 #   T5: `bridge-run.sh --dry-run --no-continue` (and roster continue=0)
 #       emits NO resume verb in the launch_cmd. Includes the equivalent
 #       case where the CLI override flips a roster continue=1 to 0.
@@ -45,10 +59,14 @@
 #       text (`state_dir_write_failed:session_id`) is present in
 #       lib/bridge-state.sh — if a future PR removes the fix, this
 #       teeth check fails citing #1248.
-#   T7 (teeth): revert the reconcile gate in `bridge-run.sh` and assert
-#       T4's contract no longer holds. Asserts the structured remediation
-#       text is present in bridge-run.sh — if removed, fails citing
-#       #1248.
+#   T7 (teeth): pin the #1439 degrade contract in `bridge-run.sh`. Asserts
+#       the warn-and-degrade markers are present (the `bridge_warn`
+#       "degrading to a fresh session" line + the
+#       `session_id_missing_resume_degraded` audit action) AND that the old
+#       fail-loud `bridge_die` remediation ("session_id missing; one of" /
+#       `session_id_missing_resume_blocked`) is GONE — if a future PR
+#       reverts to the bricking die path, this teeth check fails citing
+#       #1439 (and #1248 for the underlying lost-state surface).
 #   T8 (r2, codex r1 BLOCKING): `bridge-start.sh`'s post-startup
 #       `bridge_refresh_agent_session_id` call must NOT swallow stderr or
 #       use `|| true`. The function `bridge_die`s on persist-write
@@ -294,27 +312,37 @@ test_continue1_with_session_id_emits_resume() {
 }
 
 # ---------------------------------------------------------------------
-# T4 — continue=1 + session_id empty -> fail-loud with the exact
-#      remediation message. This is the #1248 surface.
+# T4 — continue=1 + session_id empty + launch.history present (the #1248
+#      lost-state case) -> DEGRADE to a fresh session, not die. This is the
+#      #1439 fix: the old bridge_die bricked whole fleets under the daemon's
+#      always-on restart loop because every relaunch hard-failed identically.
 #
 #      Lane E PR #1259 (issue #1265) split the gate into two branches:
-#      `state/agents/<a>/launch.history` absent => fresh-first-wake
-#      bypass (legitimate fresh install); present => genuine #1248
-#      lost-state die. To preserve T4's lost-state contract on top of
-#      Lane E, the marker is pre-touched here so the gate routes the
-#      empty-session_id observation into the die branch instead of the
-#      fresh-state bypass.
+#      `state/agents/<a>/launch.history` absent => fresh-first-wake bypass
+#      (legitimate fresh install); present => lost-state. #1439 changes the
+#      lost-state branch from bridge_die to warn-and-degrade. The marker is
+#      pre-touched here so the gate routes the empty-session_id observation
+#      into the lost-state branch (not the fresh-first-wake bypass), exactly
+#      reproducing the path #1439 changed.
 # ---------------------------------------------------------------------
-test_continue1_empty_session_id_fails_loud() {
+test_continue1_empty_session_id_degrades_to_fresh() {
   local agent="a3-T4"
   write_dryrun_roster "$agent" 1 ""
 
   # Pre-touch launch.history so the Lane E (#1265) gate routes this
-  # empty-session_id observation into the lost-state die branch (#1248)
+  # empty-session_id observation into the lost-state branch (#1248/#1439)
   # rather than the fresh-first-wake bypass branch.
   local marker="$BRIDGE_STATE_DIR/agents/$agent/launch.history"
   mkdir -p "$(dirname "$marker")"
   : >"$marker"
+
+  # Truncate the audit log so the runtime audit-row assertion below sees only
+  # this test's rows (the dry-run inherits BRIDGE_AUDIT_LOG from the smoke env,
+  # so the degrade row lands here). Codex review: T4 must assert the audit row
+  # is actually EMITTED AT RUNTIME, not just source-grepped (T7) — a misplaced
+  # or never-executed emit would otherwise still pass behaviorally.
+  mkdir -p "$(dirname "$BRIDGE_AUDIT_LOG")"
+  : >"$BRIDGE_AUDIT_LOG"
 
   local out=""
   local rc=0
@@ -323,19 +351,106 @@ test_continue1_empty_session_id_fails_loud() {
   rc=$?
   set -e
 
-  if (( rc == 0 )); then
-    smoke_fail "T4 expected non-zero rc from bridge-run.sh when continue=1 + session_id empty, got rc=0; out=$out"
+  # #1439: the lost-state path now degrades to a fresh session (rc=0), it no
+  # longer dies. A whole-fleet crash-loop on a missing session_id was the bug.
+  if (( rc != 0 )); then
+    smoke_fail "T4 expected rc=0 (degrade-to-fresh) from bridge-run.sh when continue=1 + session_id empty + launch.history present, got rc=$rc; out=$out"
   fi
-  smoke_assert_contains "$out" "session_id missing" \
-    "T4 error message starts with session_id missing"
-  smoke_assert_contains "$out" "(a) run agent first interactively to capture" \
-    "T4 remediation (a) present"
-  smoke_assert_contains "$out" "(b) set continue=0 explicitly" \
-    "T4 remediation (b) present"
-  smoke_assert_contains "$out" "(c) check #1246 daemon supp-group state" \
-    "T4 remediation (c) cites #1246"
+  smoke_assert_contains "$out" "lost-state: continue=1 but session_id empty" \
+    "T4 emits the lost-state warn line (ops-visible degrade)"
+  smoke_assert_contains "$out" "degrading to a fresh session" \
+    "T4 warn says it is degrading to a fresh session (#1439)"
   smoke_assert_contains "$out" "agent=$agent" \
-    "T4 message carries the agent name"
+    "T4 warn carries the agent name"
+  # The old fail-loud remediation must NOT appear — its removal is the fix.
+  smoke_assert_not_contains "$out" "session_id missing; one of" \
+    "T4 the old bridge_die remediation text is gone (#1439)"
+  # The degraded launch must be fresh: no resume verb is forced by the gate.
+  # (The static fixture launch_cmd never carries --resume; the assertion pins
+  # that the degrade path does not synthesize one.)
+  smoke_assert_not_contains "$out" "--resume" \
+    "T4 degraded launch carries no --resume verb"
+
+  # Runtime audit-row assertion (codex review): the degrade path must actually
+  # write the `session_id_missing_resume_degraded` row to the audit log when it
+  # runs — and the OLD `session_id_missing_resume_blocked` action must NOT be
+  # emitted. `grep -F` on the JSONL is footgun-#11 safe (no heredoc-stdin); the
+  # action is a fixed literal in the audit envelope.
+  local audit_body=""
+  audit_body="$(cat "$BRIDGE_AUDIT_LOG" 2>/dev/null || true)"
+  smoke_assert_contains "$audit_body" "session_id_missing_resume_degraded" \
+    "T4 degrade emits the session_id_missing_resume_degraded audit row at runtime"
+  smoke_assert_not_contains "$audit_body" "session_id_missing_resume_blocked" \
+    "T4 the old blocked/die audit action is not emitted at runtime (#1439)"
+}
+
+# ---------------------------------------------------------------------
+# T4b — resume-safety pin (what the old #1248 fail-loud die actually
+#      protected). Drive the launch-cmd builder directly so the assertion is
+#      deterministic and binary-free. The contract
+#      (bridge_claude_dynamic_launch_cmd, lib/bridge-state.sh:56-60):
+#        effective_continue=1 && session_id non-empty -> `--resume <id>`
+#        continue_fallback=1                           -> `--continue`
+#        neither                                       -> fresh (no verb)
+#      The degrade path is only safe BECAUSE the builder still emits
+#      `--continue` when a resumable transcript exists — a polarity flip to
+#      `--resume ""` or to a bare fresh launch would silently re-break #1248
+#      resume preservation. Pin all three branches.
+# ---------------------------------------------------------------------
+test_resume_safety_launch_verbs() {
+  declare -F bridge_claude_dynamic_launch_cmd >/dev/null \
+    || smoke_fail "T4b bridge_claude_dynamic_launch_cmd not defined"
+
+  # The launch builder reads BRIDGE_AGENT_MODEL/EFFORT/PERMISSION_MODE via
+  # `${arr[$agent]-}`. Those assoc arrays may be undeclared in this sourced
+  # context after bridge_reset_roster_maps; an undeclared array makes bash
+  # parse the `[$agent]` subscript as ARITHMETIC, so a hyphenated id like
+  # `a3-T4b` becomes `a3 - T4b` and trips `set -u`. Declare them as
+  # associative (idempotent, the same guard bridge-lib.sh uses) so the
+  # subscript is a string key. set -u safe.
+  declare -g -A BRIDGE_AGENT_MODEL 2>/dev/null || true
+  declare -g -A BRIDGE_AGENT_EFFORT 2>/dev/null || true
+  declare -g -A BRIDGE_AGENT_PERMISSION_MODE 2>/dev/null || true
+
+  local agent="a3-T4b"
+  BRIDGE_AGENT_IDS+=("$agent")
+  BRIDGE_AGENT_DESC["$agent"]="$agent launch-verb fixture"
+  BRIDGE_AGENT_ENGINE["$agent"]="claude"
+  BRIDGE_AGENT_SESSION["$agent"]="$agent"
+  BRIDGE_AGENT_WORKDIR["$agent"]="$WORKDIR"
+  BRIDGE_AGENT_LOOP["$agent"]="1"
+  BRIDGE_AGENT_CONTINUE["$agent"]="1"
+  BRIDGE_AGENT_SOURCE["$agent"]="static"
+  BRIDGE_AGENT_CREATED_AT["$agent"]="$(date +%s)"
+  BRIDGE_AGENT_SESSION_ID["$agent"]=""
+
+  local sid="bbbbbbbb-cccc-dddd-eeee-ffffffffffff"
+
+  # Case 1 — continue=1 + session_id present -> --resume <id> (resume preserved).
+  local cmd_resume=""
+  cmd_resume="$(bridge_claude_dynamic_launch_cmd "$agent" 1 0 "$sid")"
+  smoke_assert_contains "$cmd_resume" "--resume $sid" \
+    "T4b continue=1 + session_id present emits --resume <id>"
+  smoke_assert_not_contains "$cmd_resume" "--continue" \
+    "T4b --resume case does not also emit --continue"
+
+  # Case 2 — continue_fallback=1 (resumable transcript exists, no persisted
+  # id) -> --continue. This is the resume-preservation the degrade depends on:
+  # NOT --resume "" and NOT a bare fresh launch.
+  local cmd_continue=""
+  cmd_continue="$(bridge_claude_dynamic_launch_cmd "$agent" 0 1 "")"
+  smoke_assert_contains "$cmd_continue" "--continue" \
+    "T4b continue_fallback=1 emits --continue (resume preserved)"
+  smoke_assert_not_contains "$cmd_continue" "--resume" \
+    "T4b continue_fallback case never emits --resume (esp. not --resume \"\")"
+
+  # Case 3 — neither (genuinely no transcript) -> fresh launch, no resume verb.
+  local cmd_fresh=""
+  cmd_fresh="$(bridge_claude_dynamic_launch_cmd "$agent" 0 0 "")"
+  smoke_assert_not_contains "$cmd_fresh" "--resume" \
+    "T4b no-transcript case emits no --resume verb"
+  smoke_assert_not_contains "$cmd_fresh" "--continue" \
+    "T4b no-transcript case emits no --continue verb (fresh is acceptable)"
 }
 
 # ---------------------------------------------------------------------
@@ -406,30 +521,38 @@ test_teeth_layer2_fix_present() {
 }
 
 # ---------------------------------------------------------------------
-# T7 (teeth) — revert the reconcile gate in `bridge-run.sh` and the T4
-# contract no longer holds. Asserts the structured remediation text is
-# present in bridge-run.sh so a future PR that removes the gate triggers
-# this smoke citing #1248.
+# T7 (teeth) — pin the #1439 warn-and-degrade contract in `bridge-run.sh`.
+# Asserts (a) the degrade markers are present so a future PR that drops the
+# lost-state branch trips this check, and (b) the old fail-loud bridge_die
+# remediation is GONE so a regression back to the fleet-bricking die path is
+# caught citing #1439.
 # ---------------------------------------------------------------------
-test_teeth_layer3_gate_present() {
+test_teeth_layer3_degrade_present() {
   local runner="$REPO_ROOT/bridge-run.sh"
   smoke_assert_file_exists "$runner" \
     "T7 teeth: bridge-run.sh exists"
 
   local hit=""
-  hit="$(grep -F 'session_id missing' "$runner" || true)"
+  # (a) the degrade-to-fresh warn line must be present.
+  hit="$(grep -F 'degrading to a fresh session' "$runner" || true)"
   if [[ -z "$hit" ]]; then
-    smoke_fail "T7 teeth: the Layer-3 reconcile gate remediation text 'session_id missing' is missing from $runner — issue #1248 regressed"
+    smoke_fail "T7 teeth: the #1439 'degrading to a fresh session' warn is missing from $runner — the lost-state degrade path regressed (would re-brick fleets)"
   fi
 
-  hit="$(grep -F '(c) check #1246 daemon supp-group state' "$runner" || true)"
+  hit="$(grep -F 'session_id_missing_resume_degraded' "$runner" || true)"
   if [[ -z "$hit" ]]; then
-    smoke_fail "T7 teeth: the Layer-3 reconcile gate remediation (c) is missing from $runner — issue #1248 regressed"
+    smoke_fail "T7 teeth: the #1439 audit action 'session_id_missing_resume_degraded' is missing from $runner — the degrade path regressed"
+  fi
+
+  # (b) the old fail-loud die remediation must NOT be present anymore.
+  hit="$(grep -F 'session_id missing; one of' "$runner" || true)"
+  if [[ -n "$hit" ]]; then
+    smoke_fail "T7 teeth: the old fail-loud 'session_id missing; one of' bridge_die remediation reappeared in $runner — #1439 regressed (this bricked whole fleets under the daemon restart loop)"
   fi
 
   hit="$(grep -F 'session_id_missing_resume_blocked' "$runner" || true)"
-  if [[ -z "$hit" ]]; then
-    smoke_fail "T7 teeth: the Layer-3 audit action 'session_id_missing_resume_blocked' is missing from $runner — issue #1248 regressed"
+  if [[ -n "$hit" ]]; then
+    smoke_fail "T7 teeth: the old audit action 'session_id_missing_resume_blocked' reappeared in $runner — #1439 regressed"
   fi
 }
 
@@ -556,10 +679,11 @@ test_teeth_bridge_start_no_swallow() {
 smoke_run "T1 persist-write failure fails loud"               test_persist_failure_fails_loud
 smoke_run "T2 successful persist emits [session-id]"          test_success_emits_breadcrumb
 smoke_run "T3 continue=1 + sid present -> --resume verb"      test_continue1_with_session_id_emits_resume
-smoke_run "T4 continue=1 + sid empty -> fail-loud + remediation" test_continue1_empty_session_id_fails_loud
+smoke_run "T4 continue=1 + sid empty -> degrade-to-fresh (#1439)" test_continue1_empty_session_id_degrades_to_fresh
+smoke_run "T4b resume-safety: --resume/--continue/fresh verbs" test_resume_safety_launch_verbs
 smoke_run "T5 continue=0 / --no-continue -> no resume verb"   test_continue0_emits_no_resume_verb
 smoke_run "T6 teeth: Layer-2 fail-loud fix present"           test_teeth_layer2_fix_present
-smoke_run "T7 teeth: Layer-3 reconcile gate present"          test_teeth_layer3_gate_present
+smoke_run "T7 teeth: Layer-3 degrade contract present (#1439)" test_teeth_layer3_degrade_present
 smoke_run "T8 bridge-start.sh stderr no longer swallowed"     test_bridge_start_no_swallow_on_exit
 smoke_run "T9 teeth: bridge-start.sh has no 2>&1+|| true swallow" test_teeth_bridge_start_no_swallow
 

--- a/scripts/smoke/E-beta4-fresh-install-gate-state-dir.sh
+++ b/scripts/smoke/E-beta4-fresh-install-gate-state-dir.sh
@@ -34,8 +34,12 @@
 #   T1  fresh agent (no launch.history) + continue=1 + session_id="" ->
 #       fresh-state branch (no `--resume`, no die) + history touched.
 #   T2  post-launch agent (launch.history present) + continue=1 +
-#       session_id="" -> die with (a)/(b)/(c) remediation (lost-state
-#       preserved).
+#       session_id="" -> DEGRADE to a fresh session (rc=0 + warn +
+#       session_id_missing_resume_degraded audit), not die. #1439 replaced
+#       the old fleet-bricking bridge_die with warn-and-degrade; the
+#       lost-state observation still surfaces loud, but the launch proceeds
+#       fresh so the daemon's restart loop can self-recover. Genuine
+#       persist/state-dir-write failures still hard-fail (unchanged).
 #   T3  continue=0 / --no-continue -> no resume verb (gate not entered).
 #   T4  daemon wake call site self-heals state dir absent state — grep
 #       proof in bridge-daemon.sh on all three wake sites (always-on
@@ -202,10 +206,13 @@ test_fresh_first_wake_no_die() {
 
 # ---------------------------------------------------------------------
 # T2 — post-launch agent (launch.history present) + continue=1 +
-#      session_id="" -> die with (a)/(b)/(c) remediation. This is the
-#      genuine #1248 lost-state path; Lane E must NOT regress it.
+#      session_id="" -> DEGRADE to a fresh session (#1439), not die. The
+#      lost-state observation must still be loud (warn + audit row) but the
+#      launch proceeds rc=0 so the daemon's always-on restart loop can
+#      self-recover instead of bricking. The old bridge_die path
+#      (#1248/Lane E) is gone; T5-style teeth pin its absence.
 # ---------------------------------------------------------------------
-test_lost_state_still_fails_loud() {
+test_lost_state_degrades_to_fresh() {
   local agent="e-T2-lost"
   write_dryrun_roster "$agent" 1 ""
 
@@ -214,6 +221,11 @@ test_lost_state_still_fails_loud() {
   mkdir -p "$(dirname "$marker")"
   : >"$marker"
 
+  # Truncate the audit log so the runtime audit-row assertion sees only this
+  # test's rows (the dry-run inherits BRIDGE_AUDIT_LOG from the smoke env).
+  mkdir -p "$(dirname "$BRIDGE_AUDIT_LOG")"
+  : >"$BRIDGE_AUDIT_LOG"
+
   local out=""
   local rc=0
   set +e
@@ -221,17 +233,26 @@ test_lost_state_still_fails_loud() {
   rc=$?
   set -e
 
-  if (( rc == 0 )); then
-    smoke_fail "T2 expected non-zero rc from bridge-run.sh when post-launch agent + continue=1 + session_id empty, got rc=0; out=$out"
+  # #1439: degrade-to-fresh (rc=0), not the old fleet-bricking die.
+  if (( rc != 0 )); then
+    smoke_fail "T2 expected rc=0 (degrade-to-fresh) from bridge-run.sh when post-launch agent + continue=1 + session_id empty, got rc=$rc; out=$out"
   fi
-  smoke_assert_contains "$out" "session_id missing" \
-    "T2 lost-state error message present"
-  smoke_assert_contains "$out" "(a) run agent first interactively to capture" \
-    "T2 remediation (a) preserved"
-  smoke_assert_contains "$out" "(b) set continue=0 explicitly" \
-    "T2 remediation (b) preserved"
-  smoke_assert_contains "$out" "(c) check #1246 daemon supp-group state" \
-    "T2 remediation (c) preserved"
+  smoke_assert_contains "$out" "lost-state: continue=1 but session_id empty" \
+    "T2 lost-state warn line present (ops-visible degrade)"
+  smoke_assert_contains "$out" "degrading to a fresh session" \
+    "T2 warn says it is degrading to a fresh session (#1439)"
+  smoke_assert_not_contains "$out" "session_id missing; one of" \
+    "T2 the old bridge_die remediation text is gone (#1439)"
+  smoke_assert_not_contains "$out" "--resume" \
+    "T2 degraded launch carries no synthesized --resume verb"
+
+  # Runtime audit-row: the degrade action is emitted, the old die action is not.
+  local audit_body=""
+  audit_body="$(cat "$BRIDGE_AUDIT_LOG" 2>/dev/null || true)"
+  smoke_assert_contains "$audit_body" "session_id_missing_resume_degraded" \
+    "T2 degrade emits the session_id_missing_resume_degraded audit row at runtime"
+  smoke_assert_not_contains "$audit_body" "session_id_missing_resume_blocked" \
+    "T2 the old blocked/die audit action is not emitted at runtime (#1439)"
 }
 
 # ---------------------------------------------------------------------
@@ -378,8 +399,8 @@ test_teeth_daemon_self_heal_sites_present() {
 #   step 3: simulated real launch        => marker created (touch
 #                                            simulates the post-dry-run
 #                                            real-launch block)
-#   step 4: post-launch dry-run with     => rc != 0, lost-state die
-#           empty session_id                (#1248 gate path preserved)
+#   step 4: post-launch dry-run with     => rc=0, lost-state DEGRADE-to-fresh
+#           empty session_id                (#1439 — was die, now warn+degrade)
 #
 # Step 3 simulates the real-launch marker write rather than spawning
 # claude (the smoke does not have an engine). Step 4 covers the
@@ -461,11 +482,11 @@ test_dry_run_sequence_side_effect_free() {
   smoke_assert_file_exists "$marker" \
     "T_dry_run_seq step 3: production real-launch path created the canonical marker at $marker"
 
-  # Step 4: post-launch dry-run with empty session_id => lost-state die.
-  # Same gate path as T2, but exercised on the same agent's lifecycle so
-  # the whole sequence (fresh -> fresh -> launched -> lost) is covered
-  # end-to-end. Switch back to the dry-run roster (engine=claude) so
-  # this path matches T2's setup.
+  # Step 4: post-launch dry-run with empty session_id => lost-state
+  # DEGRADE-to-fresh (#1439, was die). Same gate path as T2, exercised on
+  # the same agent's lifecycle so the whole sequence
+  # (fresh -> fresh -> launched -> lost) is covered end-to-end. Switch back
+  # to the dry-run roster (engine=claude) so this path matches T2's setup.
   write_dryrun_roster "$agent" 1 ""
 
   local out4=""
@@ -474,11 +495,13 @@ test_dry_run_sequence_side_effect_free() {
   out4="$(bash "$REPO_ROOT/bridge-run.sh" "$agent" --continue --dry-run 2>&1)"
   rc4=$?
   set -e
-  if (( rc4 == 0 )); then
-    smoke_fail "T_dry_run_seq step 4: expected non-zero rc from post-launch lost-state dry-run, got rc=0; out=$out4"
+  if (( rc4 != 0 )); then
+    smoke_fail "T_dry_run_seq step 4: expected rc=0 (degrade-to-fresh) from post-launch lost-state dry-run, got rc=$rc4; out=$out4"
   fi
-  smoke_assert_contains "$out4" "session_id missing" \
-    "T_dry_run_seq step 4: lost-state die fires once marker is present (#1248 gate preserved)"
+  smoke_assert_contains "$out4" "degrading to a fresh session" \
+    "T_dry_run_seq step 4: lost-state degrades to fresh once marker is present (#1439)"
+  smoke_assert_not_contains "$out4" "session_id missing; one of" \
+    "T_dry_run_seq step 4: old die remediation gone (#1439)"
 }
 
 # ---------------------------------------------------------------------
@@ -622,7 +645,7 @@ test_teeth_dry_run_marker_deferred() {
 }
 
 smoke_run "T1 fresh first-wake skips die + dry-run leaves no marker (R2)" test_fresh_first_wake_no_die
-smoke_run "T2 lost-state still fails loud with (a)/(b)/(c)"          test_lost_state_still_fails_loud
+smoke_run "T2 lost-state degrades to fresh (rc=0 + warn + audit) (#1439)" test_lost_state_degrades_to_fresh
 smoke_run "T3 continue=0 / --no-continue gate not entered"           test_continue0_unchanged
 smoke_run "T4 daemon wake self_heal wired at all 3 sites"            test_daemon_wake_self_heal_grep
 smoke_run "T5 teeth: bridge-run.sh fresh-state branch present"       test_teeth_fresh_state_branch_present


### PR DESCRIPTION
Addresses #1438 — full root-cause analysis, repro, and incident context are in the issue.

## Root cause

On installs where each agent is launched with its **own** HOME (`<agent-home>`) — e.g. per-agent-HOME / v2-layout shared-mode installs on non-Linux hosts — Claude writes its session JSON under `<agent-home>/.claude/projects`, not under the controller HOME's `~/.claude`. Three independent defects combined into a self-reinforcing crash-loop that was only triggered once the Claude CLI's `--continue` boot (plugins/MCP warmup) grew slower than the bridge's session-id detection window (observed with Claude Code CLI 2.1.158):

1. **Detection looked in the wrong HOME.** `bridge_resolve_agent_claude_config_dir` gated the agent's config dir purely on linux-user isolation being *effective*. On every non-Linux host that gate is never true, so the resolver discarded the live `<agent-home>/.claude` and detection fell back to scanning the stale controller HOME. With no fresh transcript there, detection returned empty.

2. **A benign empty result aborted the launch script.** Under `set -euo pipefail`, the empty-detect `return 1` from `bridge_refresh_agent_session_id` propagated as a fatal error out of `bridge-start.sh`. The restart helper read that as launch-failed and rolled back the session — even though the session was healthy and had simply not written its session artifact within the detection window yet.

3. **Lost-state hard-failed always-on agents permanently.** When an agent had launched before but its persisted `session_id` was gone, `bridge-run.sh` called `bridge_die`. Under the daemon's always-on restart loop, every relaunch hard-failed identically, so the agent could never recover on its own and the watchdog restarted it forever.

The slower Claude boot didn't break anything by itself — it just widened the window in which (1)+(2)+(3) compounded into a fleet-wide loop.

## Changes

- **`lib/bridge-state.sh`** (`bridge_resolve_agent_claude_config_dir`): Resolve the agent's config dir first, then discriminate a live per-agent HOME from an empty `#1316` scaffold by whether `<config>/projects` actually holds a session directory. iso-effective Linux agents own a private dir unconditionally and skip the check (the controller can't stat their iso-UID tree anyway); everyone else — shared-mode, non-Linux, **and any context where the isolation helper is absent** (standalone/minimal/smoke) — runs the scaffold check. Treating a missing helper as "not effective" keeps the `#1370` protection in place where the helper is unavailable, while no longer discarding a live per-agent session location. The discriminator uses `find … -type d` so a stray file (e.g. a macOS `projects/.DS_Store`) cannot be mistaken for live session history.

- **`bridge-start.sh`**: Re-add `|| true` to the `bridge_refresh_agent_session_id` call so a benign detect-empty `return 1` is non-fatal under `set -euo pipefail` and no longer triggers a launch rollback of a healthy, slow-booting session (the daemon backfills the id on its next sync). This does **not** mask `bridge_die` persist-failures — those `exit 1` directly, which `|| true` cannot intercept — and stderr is untouched, so the `#1248` failure-visibility intent is fully preserved.

- **`bridge-run.sh`**: Degrade the lost-state path (launched before, but `session_id` empty) from `bridge_die` to a fresh session — the same path as fresh-first-wake — with a loud `bridge_warn` plus an audit entry so it stays ops-visible. A new id is captured on start and normal `--resume` returns next launch. Genuine persistence/write errors still hard-fail loud in `bridge_refresh_agent_session_id`, preserving the `#1248` fail-loud contract for actual write failures.

## Validation

- `bash -n` clean on all three changed scripts.
- `shellcheck -S error` clean on the changed files.
- `scripts/smoke-test.sh` passes up to an unrelated, pre-existing `#365` env check (verified identical on the pristine base — not introduced or affected by this PR).
- The fix's runtime behavior was confirmed on a live fleet via the equivalent `--no-continue` fresh-launch path, which exercises the same fresh-session degrade/capture flow that the lost-state and detect-empty fixes fall back to. The fleet recovered from a handful of active agents back to full strength.

## Note for release notes

Bug 3's audit event is renamed from `state session_id_missing_resume_blocked` (`reason=session_id_empty_with_continue_1`) to `run session_id_missing_resume_degraded` (`reason=lost_state_session_id_empty_degraded_to_fresh`) to reflect the new degrade-instead-of-die behavior and to sit in the same `run` namespace as the sibling `fresh_first_wake` row. Any external log scraper keyed on the old event string should be updated.
