### PR TITLE
fix(core): guard BRIDGE_AGENT_ENGINE/WORKDIR map reads under set -u (#1407 pattern)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -856,6 +856,12 @@ bridge_agent_desc() {
 
 bridge_agent_engine() {
   local agent="$1"
+  # #1407/#1213: guard the read without redeclaring; scalar-clobbered maps
+  # arithmetic-index agent ids under `set -u` and abort.
+  if ! declare -p BRIDGE_AGENT_ENGINE 2>/dev/null | grep -q 'declare -[A-Za-z]*A'; then
+    printf '%s' 'unknown'
+    return 0
+  fi
   printf '%s' "${BRIDGE_AGENT_ENGINE[$agent]-unknown}"
 }
 
@@ -5282,7 +5288,12 @@ bridge_agent_mattermost_state_dir() {
 
 bridge_agent_workdir() {
   local agent="$1"
-  local explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
+  local explicit=""
+  # #1407/#1213: if the map is unset or scalar-clobbered, fall through to
+  # existing v2/default resolution instead of aborting under `set -u`.
+  if declare -p BRIDGE_AGENT_WORKDIR 2>/dev/null | grep -q 'declare -[A-Za-z]*A'; then
+    explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
+  fi
 
   # v2 anchor precedence is conditional on isolation mode (issue #895,
   # ymprince WSL2 report, v0.13.8):

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -854,11 +854,30 @@ bridge_agent_desc() {
   printf '%s' "${BRIDGE_AGENT_DESC[$agent]-}"
 }
 
+# bridge_var_is_assoc <varname> — return 0 iff <varname> is currently a set
+# associative array. The test is ANCHORED to the `declare -p` flag field (the
+# token between `declare -` and the variable name) so a scalar/indexed variable
+# whose VALUE merely contains the text "declare -A" cannot false-positive
+# (#1457 codex r1: an unanchored `grep 'declare -[A-Za-z]*A'` over the full
+# `declare -p` output matched `BRIDGE_AGENT_ENGINE="declare -A"` and fell through
+# to the aborting indexed read). Safe under `set -u`.
+bridge_var_is_assoc() {
+  local _decl _flags
+  _decl="$(declare -p "$1" 2>/dev/null)" || return 1
+  _flags="${_decl#declare -}"   # `declare -A name=(...)` -> `A name=(...)`
+  _flags="${_flags%% *}"        # keep only the flag token   -> `A` / `-` / `ax`
+  case "$_flags" in
+    *A*) return 0 ;;
+    *)   return 1 ;;
+  esac
+}
+
 bridge_agent_engine() {
   local agent="$1"
-  # #1407/#1213: guard the read without redeclaring; scalar-clobbered maps
-  # arithmetic-index agent ids under `set -u` and abort.
-  if ! declare -p BRIDGE_AGENT_ENGINE 2>/dev/null | grep -q 'declare -[A-Za-z]*A'; then
+  # #1407/#1213: scalar-clobbered maps arithmetic-index agent ids under `set -u`
+  # and abort. Guard with the flag-field anchored check (#1457 r1) so a scalar/
+  # indexed value containing the text "declare -A" can't slip into the read.
+  if ! bridge_var_is_assoc BRIDGE_AGENT_ENGINE; then
     printf '%s' 'unknown'
     return 0
   fi
@@ -5290,8 +5309,10 @@ bridge_agent_workdir() {
   local agent="$1"
   local explicit=""
   # #1407/#1213: if the map is unset or scalar-clobbered, fall through to
-  # existing v2/default resolution instead of aborting under `set -u`.
-  if declare -p BRIDGE_AGENT_WORKDIR 2>/dev/null | grep -q 'declare -[A-Za-z]*A'; then
+  # existing v2/default resolution instead of aborting under `set -u`. Use the
+  # flag-field anchored check (#1457 r1) so a scalar/indexed value containing the
+  # text "declare -A" can't false-positive into the aborting indexed read.
+  if bridge_var_is_assoc BRIDGE_AGENT_WORKDIR; then
     explicit="${BRIDGE_AGENT_WORKDIR[$agent]-}"
   fi
 

--- a/scripts/smoke/1407-runtime-hardening.sh
+++ b/scripts/smoke/1407-runtime-hardening.sh
@@ -120,6 +120,45 @@ else
 	fail "D1b bridge_agent_engine/workdir did not return the expected fallback values"
 fi
 
+# --- D1c: marker-bearing scalar/indexed values (the #1457 r1 false-positive) --
+# codex (PR #1457 r1) showed an UNANCHORED `declare -p | grep 'declare -A'` also
+# matched a scalar/indexed variable whose VALUE merely contains the text
+# "declare -A" — re-introducing the very `set -u` abort the guard prevents. The
+# flag-field anchored bridge_var_is_assoc must treat these as NON-assoc: engine
+# degrades to unknown, workdir falls through to the default resolver, no abort.
+d1c_out="$(
+	"$BASH4" -c '
+		set -u
+		source "'"$SCRIPT_DIR"'/lib/bridge-core.sh" 2>/dev/null || true
+		source "'"$SCRIPT_DIR"'/lib/bridge-state.sh" 2>/dev/null || true
+		source "'"$SCRIPT_DIR"'/lib/bridge-agents.sh" 2>/dev/null || true
+		BRIDGE_AGENT_ROOT_V2=
+		BRIDGE_AGENT_HOME_ROOT="/tmp/agb-1407-home"
+		# scalar whose VALUE contains the associative flag text
+		BRIDGE_AGENT_ENGINE="declare -A"
+		BRIDGE_AGENT_WORKDIR="declare -A"
+		printf "D1C_ENGINE_SCALARMARK=[%s]\n" "$(bridge_agent_engine some-agent)"
+		printf "D1C_WORKDIR_SCALARMARK=[%s]\n" "$(bridge_agent_workdir some-agent)"
+		# indexed array whose element contains the associative flag text
+		unset BRIDGE_AGENT_ENGINE BRIDGE_AGENT_WORKDIR 2>/dev/null || true
+		declare -a BRIDGE_AGENT_ENGINE=("declare -A")
+		declare -a BRIDGE_AGENT_WORKDIR=("declare -A")
+		printf "D1C_ENGINE_INDEXMARK=[%s]\n" "$(bridge_agent_engine some-agent)"
+		printf "D1C_WORKDIR_INDEXMARK=[%s]\n" "$(bridge_agent_workdir some-agent)"
+	' 2>&1
+)" || true
+printf '%s\n' "$d1c_out"
+if printf '%s' "$d1c_out" | grep -q 'unbound variable'; then
+	fail "D1c engine/workdir aborted on a marker-bearing scalar/indexed value (#1457 r1 false-positive)"
+elif printf '%s' "$d1c_out" | grep -q 'D1C_ENGINE_SCALARMARK=\[unknown\]' \
+	&& printf '%s' "$d1c_out" | grep -q 'D1C_ENGINE_INDEXMARK=\[unknown\]' \
+	&& printf '%s' "$d1c_out" | grep -q 'D1C_WORKDIR_SCALARMARK=\[/tmp/agb-1407-home/some-agent\]' \
+	&& printf '%s' "$d1c_out" | grep -q 'D1C_WORKDIR_INDEXMARK=\[/tmp/agb-1407-home/some-agent\]'; then
+	pass "D1c bridge_var_is_assoc rejects marker-bearing scalar/indexed values (#1457 r1)"
+else
+	fail "D1c marker-bearing scalar/indexed did not degrade to unknown/default"
+fi
+
 # --- D2-accessor: bridge_agent_created_at degrades to default on non-assoc ----
 # The #1407 D2 created-at reads now route through ONE central guarded accessor
 # (bridge_agent_created_at, lib/bridge-agents.sh). codex (PR #1410 r1) showed

--- a/scripts/smoke/1407-runtime-hardening.sh
+++ b/scripts/smoke/1407-runtime-hardening.sh
@@ -9,6 +9,9 @@
 #       BRIDGE_AGENT_SESSION_ID when it is not an associative array (unset /
 #       clobbered to scalar) → arithmetic-indexes the agent id under `set -u`
 #       → `<agent>: unbound variable` abort.
+#   D1b bridge_agent_engine() / bridge_agent_workdir() (lib/bridge-agents.sh):
+#       the same non-assoc map read class on BRIDGE_AGENT_ENGINE and
+#       BRIDGE_AGENT_WORKDIR.
 #   D2  created-at indexed reads of BRIDGE_AGENT_CREATED_AT — same non-assoc
 #       failure as D1. Originally surfaced via bridge_refresh_agent_session_id's
 #       `since_hint` read; codex (PR #1410 r1) found the detect->persist path
@@ -21,7 +24,7 @@
 #
 # This smoke asserts the post-fix behavior, under `set -u`, with the
 # associative arrays UNSET:
-#   (a) D1/D2 degrade to empty / date-default with NO `unbound variable` abort;
+#   (a) D1/D1b/D2 degrade to empty / unknown / default with NO abort;
 #   (b) D3 emits the literal `- ...` bullets with NO `invalid option`.
 set -euo pipefail
 
@@ -81,6 +84,40 @@ elif printf '%s' "$d1_out" | grep -q 'D1_RESULT=\[\]'; then
 	pass "D1 bridge_agent_session_id degrades to empty on unset assoc array (no abort)"
 else
 	fail "D1 bridge_agent_session_id did not return empty as expected"
+fi
+
+# --- D1b: BRIDGE_AGENT_ENGINE/WORKDIR unset or scalar-clobbered --------------
+# The 2026-06-01 Telegram wedge RCA found two more #1407-class reads:
+# bridge_agent_engine and bridge_agent_workdir indexed their maps directly under
+# `set -u`. Engine must degrade to unknown. Workdir must ignore the invalid
+# explicit map and continue through the existing default resolver.
+d1b_out="$(
+	"$BASH4" -c '
+		set -u
+		source "'"$SCRIPT_DIR"'/lib/bridge-core.sh" 2>/dev/null || true
+		source "'"$SCRIPT_DIR"'/lib/bridge-state.sh" 2>/dev/null || true
+		source "'"$SCRIPT_DIR"'/lib/bridge-agents.sh" 2>/dev/null || true
+		BRIDGE_AGENT_ROOT_V2=
+		BRIDGE_AGENT_HOME_ROOT="/tmp/agb-1407-home"
+		unset BRIDGE_AGENT_ENGINE BRIDGE_AGENT_WORKDIR 2>/dev/null || true
+		printf "D1B_ENGINE_UNSET=[%s]\n" "$(bridge_agent_engine some-agent)"
+		printf "D1B_WORKDIR_UNSET=[%s]\n" "$(bridge_agent_workdir some-agent)"
+		BRIDGE_AGENT_ENGINE=scalar
+		BRIDGE_AGENT_WORKDIR=scalar
+		printf "D1B_ENGINE_SCALAR=[%s]\n" "$(bridge_agent_engine some-agent)"
+		printf "D1B_WORKDIR_SCALAR=[%s]\n" "$(bridge_agent_workdir some-agent)"
+	' 2>&1
+)" || true
+printf '%s\n' "$d1b_out"
+if printf '%s' "$d1b_out" | grep -q 'unbound variable'; then
+	fail "D1b bridge_agent_engine/workdir aborted with 'unbound variable' on unset/scalar maps"
+elif printf '%s' "$d1b_out" | grep -q 'D1B_ENGINE_UNSET=\[unknown\]' \
+	&& printf '%s' "$d1b_out" | grep -q 'D1B_ENGINE_SCALAR=\[unknown\]' \
+	&& printf '%s' "$d1b_out" | grep -q 'D1B_WORKDIR_UNSET=\[/tmp/agb-1407-home/some-agent\]' \
+	&& printf '%s' "$d1b_out" | grep -q 'D1B_WORKDIR_SCALAR=\[/tmp/agb-1407-home/some-agent\]'; then
+	pass "D1b bridge_agent_engine/workdir tolerate unset and scalar-clobbered maps"
+else
+	fail "D1b bridge_agent_engine/workdir did not return the expected fallback values"
 fi
 
 # --- D2-accessor: bridge_agent_created_at degrades to default on non-assoc ----


### PR DESCRIPTION
## Summary
- Guard bridge_agent_engine with the same per-function associative-map check used by bridge_agent_session_id.
- Guard bridge_agent_workdir so invalid explicit-map state falls through to existing v2/default resolution.
- Extend the #1407 runtime-hardening smoke for unset and scalar-clobbered ENGINE/WORKDIR maps.

## Validation
- bash -n lib/bridge-agents.sh scripts/smoke/1407-runtime-hardening.sh
- shellcheck -S error lib/bridge-agents.sh scripts/smoke/1407-runtime-hardening.sh
- scripts/smoke/1407-runtime-hardening.sh
- fresh bash set -u engine fallback: unset=unknown, scalar=unknown

Related: #1407, #1213