### PR TITLE
fix(daemon): escalate attached human cron followups

### DIFF
--- a/bridge-daemon-helpers.py
+++ b/bridge-daemon-helpers.py
@@ -536,6 +536,173 @@ def cmd_nudge_eligibility_recheck(args: argparse.Namespace) -> int:
     return 0
 
 
+def _tsv_clean(value: object) -> str:
+    return str(value or "").replace("\t", " ").replace("\r", " ").replace("\n", " ")
+
+
+def _read_task_body(row: sqlite3.Row) -> str:
+    body_text = row["body_text"]
+    if body_text:
+        return str(body_text)
+
+    body_path = str(row["body_path"] or "").strip()
+    if not body_path:
+        return ""
+    try:
+        return Path(body_path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def _parse_cron_followup_frontmatter(body: str) -> dict[str, object] | None:
+    lines = body.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+    end_index = -1
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end_index = index
+            break
+    if end_index <= 1:
+        return None
+    try:
+        payload = json.loads("\n".join(lines[1:end_index]))
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("schema_version") != 1:
+        return None
+    if payload.get("kind") != "cron-followup":
+        return None
+    return payload
+
+
+def _legacy_needs_human_followup(body: str) -> bool:
+    normalized = "".join(str(body or "").lower().split())
+    return (
+        "needs_human_followup=true" in normalized
+        or '"needs_human_followup":true' in normalized
+        or "'needs_human_followup':true" in normalized
+        or "delivery_intent=forward_to_user" in normalized
+        or '"delivery_intent":"forward_to_user"' in normalized
+    )
+
+
+def _parse_id_csv(id_csv: str) -> list[int]:
+    ids: list[int] = []
+    seen: set[int] = set()
+    for item in str(id_csv or "").split(","):
+        item = item.strip()
+        if not item.isdigit():
+            continue
+        task_id = int(item)
+        if task_id in seen:
+            continue
+        seen.add(task_id)
+        ids.append(task_id)
+    return ids
+
+
+def cmd_human_followup_queued_state(args: argparse.Namespace) -> int:
+    """Classify queued tasks that need human-facing followup.
+
+    Issue #1936 / gap #4: attached live-idle sessions deliberately skip tmux
+    nudge injection (#1411), but `[cron-followup]` tasks with
+    `delivery_intent=forward_to_user` are human-facing and should trigger a
+    faster operator-visible escalation than the generic unclaimed-task sweep.
+
+    Output (single TSV row, always):
+      count \\t first_id \\t csv_ids \\t first_title \\t first_created_ts
+            \\t intent \\t channel \\t target_ref \\t format
+    """
+    db_path = args.db_path
+    agent = args.agent
+    input_csv = str(getattr(args, "queued_ids_csv", "") or "")
+    queued_ids = _parse_id_csv(input_csv)
+    if input_csv.strip() and not queued_ids:
+        print("0\t\t\t\t\t\t\t\t")
+        return 0
+
+    where = [
+        "assigned_to = ?",
+        "status = 'queued'",
+        "title NOT LIKE '[cron-dispatch]%'",
+    ]
+    params: list[object] = [agent]
+    if queued_ids:
+        placeholders = ",".join("?" for _ in queued_ids)
+        where.append(f"id IN ({placeholders})")
+        params.extend(queued_ids)
+
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            f"""
+            SELECT id, title, created_ts, body_text, body_path
+            FROM tasks
+            WHERE {' AND '.join(where)}
+            ORDER BY id
+            """,
+            params,
+        ).fetchall()
+
+    matches: list[dict[str, object]] = []
+    for row in rows:
+        title = str(row["title"] or "")
+        if not title.startswith("[cron-followup]"):
+            continue
+        body = _read_task_body(row)
+        payload = _parse_cron_followup_frontmatter(body)
+        intent = ""
+        forward_target: dict[str, object] = {}
+        if payload is not None:
+            intent = str(payload.get("delivery_intent") or "")
+            if intent != "forward_to_user":
+                continue
+            raw_target = payload.get("forward_target")
+            if isinstance(raw_target, dict):
+                forward_target = raw_target
+        elif _legacy_needs_human_followup(body):
+            intent = "legacy_needs_human_followup"
+        else:
+            continue
+
+        matches.append(
+            {
+                "id": int(row["id"]),
+                "title": title,
+                "created_ts": int(row["created_ts"] or 0),
+                "intent": intent,
+                "channel": forward_target.get("channel", ""),
+                "target_ref": forward_target.get("target_ref", ""),
+                "format": forward_target.get("format", ""),
+            }
+        )
+
+    if not matches:
+        print("0\t\t\t\t\t\t\t\t")
+        return 0
+
+    first = matches[0]
+    print(
+        "\t".join(
+            [
+                str(len(matches)),
+                str(first["id"]),
+                ",".join(str(match["id"]) for match in matches),
+                _tsv_clean(first["title"]),
+                str(first["created_ts"]),
+                _tsv_clean(first["intent"]),
+                _tsv_clean(first["channel"]),
+                _tsv_clean(first["target_ref"]),
+                _tsv_clean(first["format"]),
+            ]
+        )
+    )
+    return 0
+
+
 def cmd_memory_daily_orphan_scan(args: argparse.Namespace) -> int:
     """Original site: bridge-daemon.sh:4840 (process_memory_daily_orphan_sweep).
 
@@ -1085,6 +1252,19 @@ SUBCOMMANDS = {
             ),
         ],
         "Single tab-separated row: eligible_count, csv eligible queued ids.",
+    ),
+    "human-followup-queued-state": (
+        cmd_human_followup_queued_state,
+        [
+            ("db_path", "path to the queue sqlite DB"),
+            ("agent", "agent id to query"),
+            (
+                "queued_ids_csv",
+                "optional comma-separated queued task ids to restrict classification",
+                "",
+            ),
+        ],
+        "Single tab-separated row describing queued human-facing cron followups.",
     ),
     "memory-daily-orphan-scan": (
         cmd_memory_daily_orphan_scan,

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -5478,6 +5478,158 @@ EOF
   return 0
 }
 
+# Issue #1936 / gap #4: attached live-idle sessions deliberately skip the
+# queued-task tmux inject (#1411), but human-facing cron followups
+# (`delivery_intent=forward_to_user`, or legacy `needs_human_followup=true`)
+# should not wait for the generic 30m unclaimed-task sweep. Track a separate
+# cooldown per original followup task id and file a refreshable admin alert.
+bridge_daemon_attached_human_followup_marker_file() {
+  local task_id="${1:-none}"
+  local dir="$BRIDGE_STATE_DIR/daemon-attached-human-followup"
+  mkdir -p "$dir" 2>/dev/null || true
+  # shellcheck disable=SC2001  # bash parameter expansion lacks regex class
+  task_id="$(printf '%s' "$task_id" | sed 's/[^A-Za-z0-9_]/_/g')"
+  printf '%s/%s.marker' "$dir" "$task_id"
+}
+
+bridge_daemon_attached_human_followup_escalate() {
+  local agent="$1"
+  local session="$2"
+  local attached="$3"
+  local task_id="$4"
+  local task_ids_csv="$5"
+  local task_title="$6"
+  local created_ts="$7"
+  local intent="$8"
+  local forward_channel="$9"
+  local forward_target_ref="${10}"
+  local forward_format="${11}"
+  local live_queued="${12}"
+  local live_claimed="${13}"
+
+  [[ "$task_id" =~ ^[0-9]+$ ]] || return 0
+
+  local admin="${BRIDGE_ADMIN_AGENT_ID:-}"
+  [[ -n "$admin" ]] || return 0
+  bridge_agent_exists "$admin" || return 0
+
+  local cooldown="${BRIDGE_FORWARD_FOLLOWUP_ATTACHED_ESCALATE_COOLDOWN_SECS:-300}"
+  [[ "$cooldown" =~ ^[0-9]+$ ]] || cooldown=300
+  (( cooldown > 0 )) || cooldown=300
+
+  local now_ts marker marker_ts
+  now_ts="$(date +%s)"
+  marker="$(bridge_daemon_attached_human_followup_marker_file "$task_id")"
+  marker_ts="$(head -n1 "$marker" 2>/dev/null || printf '0')"
+  [[ "$marker_ts" =~ ^[0-9]+$ ]] || marker_ts=0
+  if (( marker_ts > 0 )) && (( now_ts - marker_ts < cooldown )); then
+    return 0
+  fi
+
+  local age_seconds=0 age_minutes=0 hostname_short=""
+  [[ "$created_ts" =~ ^[0-9]+$ ]] || created_ts=0
+  if (( created_ts > 0 && now_ts >= created_ts )); then
+    age_seconds=$(( now_ts - created_ts ))
+    age_minutes=$(( age_seconds / 60 ))
+  fi
+  hostname_short="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo host)"
+
+  local alert_title
+  alert_title="[forward-followup-stranded] #${task_id} on ${agent} (${age_minutes}m)"
+
+  # Feedback-loop guard: if the affected agent is also the admin, an admin
+  # queue task would land in the same inbox that is already stranded. Emit the
+  # audit + best-effort external notify only.
+  if [[ "$agent" == "$admin" ]]; then
+    bridge_audit_log daemon queue_attention_attached_human_followup "$agent" \
+      --detail task_id="$task_id" \
+      --detail followup_ids="${task_ids_csv:-$task_id}" \
+      --detail attached="$attached" \
+      --detail session="$session" \
+      --detail intent="${intent:-unknown}" \
+      --detail forward_channel="${forward_channel:-}" \
+      --detail forward_target_ref="${forward_target_ref:-}" \
+      --detail action=audit_only_admin_target \
+      2>/dev/null || true
+    bridge_notify_send "$admin" "$alert_title" \
+      "Human-facing cron followup #${task_id} is queued on attached admin session ${agent}; drain ${agent}'s inbox." \
+      "$task_id" high "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
+    printf '%s\n' "$now_ts" >"$marker" 2>/dev/null || true
+    return 0
+  fi
+
+  local body_file
+  body_file="$(mktemp "${TMPDIR:-/tmp}/bridge-forward-followup-stranded.md.XXXXXX")" || return 0
+  {
+    printf '# Human-facing cron followup stranded on %s\n\n' "$agent"
+    printf 'The daemon detected a queued `[cron-followup]` that needs user-facing delivery, but `%s` is attached and the queued-task nudge path correctly skips raw tmux injection for attached sessions (#1411).\n\n' "$agent"
+    printf -- '- source task: #%s\n' "$task_id"
+    printf -- '- target agent: %s\n' "$agent"
+    printf -- '- session: %s\n' "$session"
+    printf -- '- attached clients: %s\n' "$attached"
+    printf -- '- age: %ss (%sm)\n' "$age_seconds" "$age_minutes"
+    printf -- '- live queued: %s\n' "$live_queued"
+    printf -- '- live claimed: %s\n' "$live_claimed"
+    printf -- '- human followup ids: %s\n' "${task_ids_csv:-$task_id}"
+    printf -- '- title: %s\n' "${task_title:-<empty>}"
+    printf -- '- intent: %s\n' "${intent:-unknown}"
+    printf -- '- forward target channel: %s\n' "${forward_channel:-<unknown>}"
+    printf -- '- forward target ref: %s\n' "${forward_target_ref:-<unknown>}"
+    printf -- '- forward format: %s\n' "${forward_format:-<unknown>}"
+    printf -- '- host: %s\n\n' "$hostname_short"
+    printf 'Next steps:\n\n'
+    printf -- '- `agent-bridge inbox %s` — confirm the stranded followup is still queued.\n' "$agent"
+    printf -- '- `agent-bridge urgent %s "drain your inbox; human-facing cron followup #%s is waiting"` — wake the parent agent to claim and forward it.\n' "$agent" "$task_id"
+    printf -- '- Keep #1411 intact: do not bypass the attached-session nudge gate with raw daemon injection.\n\n'
+    printf 'This alert is refreshable via `bridge-queue.py upsert-open` and is rate-limited for %ss per source task id by `BRIDGE_FORWARD_FOLLOWUP_ATTACHED_ESCALATE_COOLDOWN_SECS`.\n' "$cooldown"
+  } >"$body_file"
+
+  local title_prefix="[forward-followup-stranded] #${task_id} on ${agent} "
+  local upsert_shell=""
+  local TASK_ID=""
+  local TASK_CREATED=""
+  upsert_shell="$(bridge_queue_cli upsert-open \
+    --to "$admin" --priority high --from daemon \
+    --title-prefix "$title_prefix" --title "$alert_title" \
+    --refresh-note "daemon refreshed attached human-followup escalation" \
+    --format shell --body-file "$body_file" 2>/dev/null || true)"
+  rm -f "$body_file" >/dev/null 2>&1 || true
+
+  if [[ -n "$upsert_shell" ]]; then
+    local upsert_tmp
+    upsert_tmp="$(mktemp)"
+    printf '%s\n' "$upsert_shell" >"$upsert_tmp"
+    # shellcheck disable=SC1090
+    source "$upsert_tmp" 2>/dev/null || true
+    rm -f -- "$upsert_tmp"
+  fi
+
+  if [[ "$TASK_ID" =~ ^[0-9]+$ ]]; then
+    bridge_audit_log daemon queue_attention_attached_human_followup "$agent" \
+      --detail task_id="$task_id" \
+      --detail followup_ids="${task_ids_csv:-$task_id}" \
+      --detail attached="$attached" \
+      --detail session="$session" \
+      --detail intent="${intent:-unknown}" \
+      --detail forward_channel="${forward_channel:-}" \
+      --detail forward_target_ref="${forward_target_ref:-}" \
+      --detail admin_agent="$admin" \
+      --detail admin_task_id="$TASK_ID" \
+      --detail admin_task_created="${TASK_CREATED:-0}" \
+      --detail cooldown_secs="$cooldown" \
+      --detail action=admin_task_upserted \
+      2>/dev/null || true
+    bridge_notify_send "$admin" "$alert_title" \
+      "Human-facing cron followup #${task_id} is queued on attached idle agent ${agent}. Admin task #${TASK_ID} has drain instructions." \
+      "$TASK_ID" high "${BRIDGE_DAEMON_NOTIFY_DRY_RUN:-0}" >/dev/null 2>&1 || true
+    printf '%s\n' "$now_ts" >"$marker" 2>/dev/null || true
+  else
+    daemon_warn "failed to file [forward-followup-stranded] task for source task=${task_id} agent=${agent}"
+  fi
+
+  return 0
+}
+
 # Issue #1323 (beta5-2 Lane ι) — H5 recheck-timeout retry + escalation.
 #
 # Pre-fix: nudge_agent_session's eligibility-recheck timeout (15s) caused
@@ -6352,6 +6504,33 @@ nudge_agent_session() {
   if (( attached > 0 )); then
     local _att_skip_task_id="${live_nudge_key%%,*}"
     [[ -n "$_att_skip_task_id" ]] || _att_skip_task_id="none"
+    # Issue #1936 / gap #4: attached-session skip is correct for raw tmux
+    # injection (#1411), but human-facing cron followups should not wait for
+    # the generic unclaimed-task escalation. Classify the live queued set and
+    # file a refreshable admin alert when a forward_to_user / legacy
+    # needs_human_followup task is stranded behind the attached gate.
+    local _human_row="" _human_rc=0
+    set +e
+    _human_row="$(bridge_with_timeout 15 human_followup_queued_state python3 "$SCRIPT_DIR/bridge-daemon-helpers.py" human-followup-queued-state "$BRIDGE_TASK_DB" "$agent" "${live_nudge_key:-$nudge_key}" 2>/dev/null)"
+    _human_rc=$?
+    set -e
+    if (( _human_rc == 0 )) && [[ -n "$_human_row" ]]; then
+      local _human_count=0 _human_task_id="" _human_ids="" _human_title="" _human_created_ts=0
+      local _human_intent="" _human_channel="" _human_target_ref="" _human_format=""
+      local _human_tmp
+      _human_tmp="$(mktemp)"
+      printf '%s\n' "$_human_row" >"$_human_tmp"
+      IFS=$'\t' read -r _human_count _human_task_id _human_ids _human_title _human_created_ts _human_intent _human_channel _human_target_ref _human_format <"$_human_tmp" || true
+      rm -f -- "$_human_tmp"
+      [[ "$_human_count" =~ ^[0-9]+$ ]] || _human_count=0
+      if (( _human_count > 0 )); then
+        bridge_daemon_attached_human_followup_escalate \
+          "$agent" "$session" "$attached" "$_human_task_id" "$_human_ids" \
+          "$_human_title" "$_human_created_ts" "$_human_intent" \
+          "$_human_channel" "$_human_target_ref" "$_human_format" \
+          "$live_queued" "$live_claimed" || true
+      fi
+    fi
     bridge_audit_log daemon queue_attention_attached_skip "$agent" \
       --detail fingerprint="$nudge_fingerprint" \
       --detail queued="$live_queued" \

--- a/docs/agent-runtime/common-instructions.md
+++ b/docs/agent-runtime/common-instructions.md
@@ -140,6 +140,10 @@ Task body는 strict JSON-frontmatter 다음에 markdown body가 따라온다:
 - 정식 channel plugin (`plugin:telegram@claude-plugins-official` / `plugin:discord@...` 등) 으로 전달한다. cron child가 직접 접근하는 경로는 PR1에서 차단됐다.
 - task 닫기: `agb done <id> --note "decision: forwarded channel=<ch> ts=<iso>"`.
 
+#### Wake 후 inbox sweep
+
+cron-dispatch, urgent wake, daemon nudge 등으로 깨어나 한 task를 처리한 뒤 idle로 돌아가기 전에는 자기 inbox를 한 번 더 확인한다. 특히 `[cron-followup]` 잔여 task 중 `delivery_intent = forward_to_user` 또는 레거시 `needs_human_followup=true` 단서가 있는 항목은 사람-facing 알림이므로 먼저 claim → forward → done까지 처리한다. 이는 attached/live-idle 세션에서 데몬 nudge가 의도적으로 skip되는 경우(#1411)에도 followup이 오래 stranded되지 않게 하기 위한 parent-agent 책임이다.
+
 #### `delivery_intent = silent`
 
 - runner는 silent 결정 시 inbox task를 만들지 않으므로 이 case가 부모에 닿는 일은 정상적으로 없어야 한다. 닿았다면 노이즈로 보고 그냥 닫는다: `agb done <id> --note "decision: silent (no-op)"`.

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -109,6 +109,7 @@ add_all_required_static() {
 
 add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1342-write-state-marker-matrix 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent 1323-nudge-eligibility-recheck-twostage 1199-action-required-claimed-skip tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1405-handoffd-supervision 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution D-beta4-daemon-lifecycle E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs K-beta4-nits Beta-beta5-session-id-detect-sudo α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-zeta-teams-mcp-dedup beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-eta-cron-iso-uid-preflight beta5-2-delta-nudge-session-empty beta5-2-theta-upgrade-backfill-perms beta5-2-nu-daemon-path-quarantine beta5-2-kappa-state-audit-reconcile beta5-2-iota-daemon-escalation-family beta5-2-lambda-a2a-robustness beta5-2-mu-cron-channel-creds beta5-2-xi-misc-fixes 1359-cron-create-iso-staging 1379-iso-cron-staging-group 1383-iso-cron-result-json-group 1354-setup-teams-fd-password 1360-onboarding-next-actions-persona 1353-setup-pending-grace 1355-1356-ms365-wizard 1357-iso-boundary-quickref 1358-admin-credential-routine-exempt 1352-shared-codex-pair-path 1343-ms365-token-refresh 1378-iso-session-lock-fresh-start 1388-daemon-lock-fd-cloexec 1416-onboarding-state-field-anchor a2a-setup-wizard 1408-daemon-alert-nudge-hygiene 1409-claude-midturn-busy-gate 1427-A-roster-materialize 1427-B-template-sync-wizard 1426-cron-shell-noniso-help 1437-reactive-cron-rotation 1425-spool-rederive 1437-native-usage-probe
 add_required 1425-cron-dispatch-nudge-scope
+add_required 1936-forward-followup-attached-escalation
 
 
 }
@@ -993,6 +994,15 @@ select_for_path() {
       # Issue #1425: human-nudge and unclaimed-task daemon paths must keep
       # the same non-cron task scope as nudge_live_state.
       add_required 1425-cron-dispatch-nudge-scope
+      # Issue #1936 (gap #4): bridge-daemon.sh now hosts
+      # bridge_daemon_attached_human_followup_escalate — the daemon path
+      # that files a refreshable admin alert when a human-facing cron
+      # followup is queued on an attached live session (which #1411 keeps
+      # out of raw tmux injection). The 1936 smoke pins the classification,
+      # attached-skip ordering, no-recursive-admin-loop guard, upsert
+      # dedupe, and per-task cooldown. Pull it on every bridge-daemon.sh
+      # move so the attached-followup escalation cannot regress silently.
+      add_required 1936-forward-followup-attached-escalation
       # v0.15.0-beta5-2 Lane μ (#1327 / #1328): bridge-daemon.sh's
       # `cmd_run_cron_worker` now re-checks the manual-stop marker at
       # execute time (edge case 1: agent restart between dispatch and
@@ -2095,6 +2105,14 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # subprocess contract re-exercises the recovery tick's emit
       # path.
       add_required F-beta4-oauth-bootstrap daemon-periodic-token-sync daemon queue I-beta4-a2a-3-gaps mcp-liveness-giveup-auto-clear
+      # Issue #1936 (gap #4): bridge-daemon-helpers.py hosts the
+      # ``human-followup-queued-state`` subcommand that classifies a
+      # queued cron followup as human-facing (delivery_intent=
+      # forward_to_user / legacy needs_human_followup). The 1936 smoke
+      # sources this helper directly; pull it on every
+      # bridge-daemon-helpers.py move so a future PR cannot regress the
+      # classifier the attached-followup escalation depends on.
+      add_required 1936-forward-followup-attached-escalation
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1936-forward-followup-attached-escalation.sh
+++ b/scripts/smoke/1936-forward-followup-attached-escalation.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# Regression for issue #1936 / gap #4:
+# attached live-idle sessions must keep the #1411 raw-inject skip, but
+# human-facing cron followups should get a fast refreshable admin escalation.
+
+set -euo pipefail
+
+SMOKE_NAME="1936-forward-followup-attached-escalation"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/agb-1936-forward-followup.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DB="$TMP_DIR/tasks.db"
+QUEUE="$REPO_ROOT/bridge-queue.py"
+HELPER="$REPO_ROOT/bridge-daemon-helpers.py"
+DAEMON="$REPO_ROOT/bridge-daemon.sh"
+
+export BRIDGE_TASK_DB="$DB"
+python3 "$QUEUE" init >/dev/null
+
+failed=0
+
+write_body() {
+  local name="$1"
+  local path="$TMP_DIR/$name.md"
+  shift
+  printf '%s\n' "$@" >"$path"
+  printf '%s' "$path"
+}
+
+create_task() {
+  local title="$1"
+  local body_file="$2"
+  BRIDGE_TASK_DB="$DB" python3 "$QUEUE" create \
+    --to alpha --from smoke --priority normal \
+    --title "$title" --body-file "$body_file" >/dev/null
+}
+
+task_id_for_title() {
+  local title="$1"
+  sqlite3 "$DB" "SELECT id FROM tasks WHERE title = '$title' ORDER BY id LIMIT 1;"
+}
+
+parse_row() {
+  local row="$1"
+  local tmp="$TMP_DIR/helper-row.tsv"
+  printf '%s\n' "$row" >"$tmp"
+  COUNT=""
+  FIRST_ID=""
+  IDS_CSV=""
+  FIRST_TITLE=""
+  CREATED_TS=""
+  INTENT=""
+  CHANNEL=""
+  TARGET_REF=""
+  FORMAT=""
+  IFS=$'\t' read -r COUNT FIRST_ID IDS_CSV FIRST_TITLE CREATED_TS INTENT CHANNEL TARGET_REF FORMAT <"$tmp" || true
+}
+
+ordinary_body="$(write_body ordinary 'ordinary task')"
+main_body="$(write_body main \
+  '---' \
+  '{' \
+  '  "schema_version": 1,' \
+  '  "kind": "cron-followup",' \
+  '  "delivery_intent": "main_session_only",' \
+  '  "forward_target": null' \
+  '}' \
+  '---' \
+  '# main only')"
+forward_body="$(write_body forward \
+  '---' \
+  '{' \
+  '  "schema_version": 1,' \
+  '  "kind": "cron-followup",' \
+  '  "delivery_intent": "forward_to_user",' \
+  '  "forward_target": {' \
+  '    "channel": "discord",' \
+  '    "target_ref": "ops",' \
+  '    "format": "markdown"' \
+  '  }' \
+  '}' \
+  '---' \
+  '# forward me')"
+legacy_body="$(write_body legacy \
+  '# legacy cron followup' \
+  'needs_human_followup=true')"
+
+create_task '[review] ordinary' "$ordinary_body"
+create_task '[cron-followup] main-only' "$main_body"
+create_task '[cron-followup] forward' "$forward_body"
+create_task '[cron-followup] legacy' "$legacy_body"
+missing_ts="$(date +%s)"
+sqlite3 "$DB" "INSERT INTO tasks (title, assigned_to, created_by, priority, status, created_ts, updated_ts, body_text, body_path) VALUES ('[cron-followup] missing-body', 'alpha', 'smoke', 'normal', 'queued', $missing_ts, $missing_ts, NULL, '$TMP_DIR/does-not-exist.md');"
+
+ordinary_id="$(task_id_for_title '[review] ordinary')"
+main_id="$(task_id_for_title '[cron-followup] main-only')"
+forward_id="$(task_id_for_title '[cron-followup] forward')"
+legacy_id="$(task_id_for_title '[cron-followup] legacy')"
+missing_id="$(task_id_for_title '[cron-followup] missing-body')"
+
+row="$(python3 "$HELPER" human-followup-queued-state "$DB" alpha)"
+parse_row "$row"
+if [[ "$COUNT" == "2" && "$FIRST_ID" == "$forward_id" && "$IDS_CSV" == "${forward_id},${legacy_id}" && "$INTENT" == "forward_to_user" && "$CHANNEL" == "discord" && "$TARGET_REF" == "ops" && "$FORMAT" == "markdown" ]]; then
+  echo "  PASS  H1: helper detects strict forward_to_user + legacy needs_human_followup"
+else
+  echo "  FAIL  H1: unexpected helper row: $row" >&2
+  failed=1
+fi
+
+row="$(python3 "$HELPER" human-followup-queued-state "$DB" alpha "$main_id")"
+parse_row "$row"
+if [[ "$COUNT" == "0" ]]; then
+  echo "  PASS  H2: main_session_only is not human-facing"
+else
+  echo "  FAIL  H2: main_session_only misclassified: $row" >&2
+  failed=1
+fi
+
+row="$(python3 "$HELPER" human-followup-queued-state "$DB" alpha "$legacy_id")"
+parse_row "$row"
+if [[ "$COUNT" == "1" && "$FIRST_ID" == "$legacy_id" && "$INTENT" == "legacy_needs_human_followup" ]]; then
+  echo "  PASS  H3: legacy needs_human_followup fallback is detected"
+else
+  echo "  FAIL  H3: legacy fallback not detected: $row" >&2
+  failed=1
+fi
+
+row="$(python3 "$HELPER" human-followup-queued-state "$DB" alpha "$ordinary_id,$missing_id")"
+parse_row "$row"
+if [[ "$COUNT" == "0" ]]; then
+  echo "  PASS  H4: ordinary task + missing body path do not crash or misclassify"
+else
+  echo "  FAIL  H4: ordinary/missing-body misclassified: $row" >&2
+  failed=1
+fi
+
+if grep -q 'human-followup-queued-state' "$DAEMON" \
+   && grep -q 'queue_attention_attached_human_followup' "$DAEMON" \
+   && grep -q '\[forward-followup-stranded\]' "$DAEMON" \
+   && grep -q 'bridge_queue_cli upsert-open' "$DAEMON"; then
+  echo "  PASS  S1: daemon has attached human-followup escalation wiring"
+else
+  echo "  FAIL  S1: daemon escalation wiring missing" >&2
+  failed=1
+fi
+
+helper_line="$(grep -n '"$SCRIPT_DIR/bridge-daemon-helpers.py" human-followup-queued-state' "$DAEMON" | head -n1 | cut -d: -f1)"
+attached_line="$(grep -n 'bridge_audit_log daemon queue_attention_attached_skip' "$DAEMON" | head -n1 | cut -d: -f1)"
+note_nudge_line="$(grep -n 'bridge_task_note_nudge "\$agent"' "$DAEMON" | head -n1 | cut -d: -f1)"
+if [[ -n "$helper_line" && -n "$attached_line" && -n "$note_nudge_line" \
+      && "$helper_line" -lt "$attached_line" && "$attached_line" -lt "$note_nudge_line" ]]; then
+  echo "  PASS  S2: human-followup check runs inside attached skip before note-nudge success path"
+else
+  echo "  FAIL  S2: attached-skip ordering unexpected (helper=${helper_line}, attached=${attached_line}, note=${note_nudge_line})" >&2
+  failed=1
+fi
+
+if grep -q 'bridge_daemon_record_nudge "$agent" "$nudge_fingerprint"' "$DAEMON"; then
+  echo "  PASS  S3: existing #1411 attached-skip rate-limit remains"
+else
+  echo "  FAIL  S3: attached-skip nudge fingerprint record missing" >&2
+  failed=1
+fi
+
+EXTRACTED="$TMP_DIR/extracted-functions.sh"
+python3 "$REPO_ROOT/scripts/smoke/helpers/extract-shell-fn.py" "$DAEMON" \
+  bridge_daemon_attached_human_followup_marker_file \
+  bridge_daemon_attached_human_followup_escalate >"$EXTRACTED"
+
+BRIDGE_STATE_DIR="$TMP_DIR/state"
+BRIDGE_ADMIN_AGENT_ID="admin"
+BRIDGE_DAEMON_NOTIFY_DRY_RUN="1"
+export BRIDGE_STATE_DIR BRIDGE_ADMIN_AGENT_ID BRIDGE_DAEMON_NOTIFY_DRY_RUN
+
+bridge_agent_exists() {
+  [[ "$1" == "admin" || "$1" == "alpha" ]]
+}
+
+bridge_queue_cli() {
+  BRIDGE_TASK_DB="$DB" python3 "$QUEUE" "$@"
+}
+
+bridge_audit_log() {
+  printf '%s\n' "$*" >>"$TMP_DIR/audit.log"
+}
+
+bridge_notify_send() {
+  printf '%s\n' "$*" >>"$TMP_DIR/notify.log"
+  return 0
+}
+
+daemon_warn() {
+  printf 'WARN %s\n' "$*" >&2
+}
+
+# shellcheck disable=SC1090
+source "$EXTRACTED"
+
+old_ts=$(( $(date +%s) - 180 ))
+bridge_daemon_attached_human_followup_escalate \
+  alpha alpha-session 1 "$forward_id" "${forward_id},${legacy_id}" \
+  '[cron-followup] forward' "$old_ts" forward_to_user discord ops markdown 2 0
+bridge_daemon_attached_human_followup_escalate \
+  alpha alpha-session 1 "$forward_id" "${forward_id},${legacy_id}" \
+  '[cron-followup] forward' "$old_ts" forward_to_user discord ops markdown 2 0
+
+admin_count="$(sqlite3 "$DB" "SELECT COUNT(*) FROM tasks WHERE assigned_to = 'admin' AND title LIKE '[forward-followup-stranded] #${forward_id} on alpha %';")"
+admin_body="$(sqlite3 "$DB" "SELECT body_text FROM tasks WHERE assigned_to = 'admin' AND title LIKE '[forward-followup-stranded] #${forward_id} on alpha %' LIMIT 1;")"
+if [[ "$admin_count" == "1" \
+      && "$admin_body" == *"agent-bridge urgent alpha"* \
+      && "$admin_body" == *"forward target channel: discord"* \
+      && -f "$BRIDGE_STATE_DIR/daemon-attached-human-followup/${forward_id}.marker" ]]; then
+  echo "  PASS  S4: isolated escalation upserts one admin task with drain instructions + cooldown marker"
+else
+  echo "  FAIL  S4: isolated escalation result unexpected (count=${admin_count})" >&2
+  failed=1
+fi
+
+if (( failed )); then
+  exit 1
+fi
+
+echo "[smoke:${SMOKE_NAME}] all checks passed"


### PR DESCRIPTION
## Summary
- add a bounded daemon helper to classify queued `[cron-followup]` tasks that are human-facing (`delivery_intent=forward_to_user`, plus legacy `needs_human_followup=true`)
- keep the #1411 attached-session raw-inject skip intact, but add a fast refreshable `[forward-followup-stranded]` admin escalation from the attached-skip path
- add parent-agent prevention guidance to the canonical common instructions: after cron/wake work, sweep remaining inbox followups before returning idle
- add smoke coverage for helper classification, attached-skip wiring, and isolated escalation upsert/cooldown behavior

## Phase 1 decision
Conservative admin escalation only. I did not auto-urgent inject into attached targets. Even with idle-ready evidence, the daemon can race with a human starting input, and #1411 exists because attached interactive panes can still spool/defer raw injections. Direct relay and auto-urgent remain deferred Phase 1.5/2 decisions.

## Verification
- `python3 -m py_compile bridge-daemon-helpers.py bridge-queue.py`
- `bash -n bridge-daemon.sh scripts/smoke/1936-forward-followup-attached-escalation.sh scripts/smoke/1408-daemon-alert-nudge-hygiene.sh`
- `scripts/smoke/1936-forward-followup-attached-escalation.sh`
- `scripts/smoke/1408-daemon-alert-nudge-hygiene.sh`
- `scripts/lint-heredoc-ban.sh`
- `shellcheck bridge-daemon.sh scripts/smoke/1936-forward-followup-attached-escalation.sh scripts/smoke/1408-daemon-alert-nudge-hygiene.sh`
- `git diff --check`

## Manual-style verification note
The new smoke extracts only the new daemon escalation functions, stubs daemon dependencies in an isolated temp DB/state root, invokes `bridge_daemon_attached_human_followup_escalate` twice, and asserts exactly one refreshable admin task plus a cooldown marker. No live daemon or real target tmux pane was touched.
