### PR TITLE
agents: iso-readable all-agent state aggregate for `agent list` (#1473)

### DIFF
--- a/bridge-agent.sh
+++ b/bridge-agent.sh
@@ -1802,6 +1802,24 @@ bridge_agent_activity_state() {
     return 0
   fi
 
+  # Issue #1473: from a NON-controller UID (an isolated agent) the tmux
+  # probes below are all blind — they would mislabel a live agent as
+  # `working` (the final fallthrough) or, via bridge_agent_is_active,
+  # `stopped`. When the daemon-published aggregate is the authoritative
+  # source for this UID, take the activity_state token straight from it so
+  # the human-facing state agrees with the `active` column (which
+  # bridge_agent_is_active also resolves from the same aggregate). On the
+  # controller `_should_consult` is false → this whole block is skipped and
+  # the live tmux ladder below runs unchanged (no shared-mode regression).
+  if command -v bridge_agents_aggregate_should_consult >/dev/null 2>&1 \
+      && bridge_agents_aggregate_should_consult; then
+    local agg_state
+    if agg_state="$(bridge_agents_aggregate_lookup "$agent" 3)"; then
+      printf '%s' "$agg_state"
+      return 0
+    fi
+  fi
+
   if ! bridge_agent_is_active "$agent"; then
     printf '%s' "stopped"
     return 0

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -1127,6 +1127,19 @@ refresh_agent_heartbeats() {
     changed=0
   done
 
+  # Issue #1473: publish the world-readable all-agent state aggregate every
+  # tick (NOT gated on heartbeat_due) so an isolated agent UID always sees
+  # a fresh `updated_at` and current active/state for `agb agent list`.
+  # The daemon runs as the controller UID, so the tmux probes inside the
+  # writer are authoritative. Cheap (reuses the probes already run above);
+  # failures inside the writer are swallowed there so a write hiccup never
+  # changes the heartbeat return contract. Does not flip `changed` — the
+  # aggregate is a derived view, not a queue-state change a sync needs to
+  # observe.
+  if command -v bridge_write_agents_aggregate_state >/dev/null 2>&1; then
+    bridge_write_agents_aggregate_state || true
+  fi
+
   return "$changed"
 }
 

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -181,6 +181,18 @@ BRIDGE_HISTORY_DIR="${BRIDGE_HISTORY_DIR:-$BRIDGE_STATE_DIR/history}"
 BRIDGE_WORKTREE_META_DIR="${BRIDGE_WORKTREE_META_DIR:-$BRIDGE_STATE_DIR/worktrees}"
 BRIDGE_ACTIVE_ROSTER_TSV="${BRIDGE_ACTIVE_ROSTER_TSV:-$BRIDGE_STATE_DIR/active-roster.tsv}"
 BRIDGE_ACTIVE_ROSTER_MD="${BRIDGE_ACTIVE_ROSTER_MD:-$BRIDGE_STATE_DIR/active-roster.md}"
+# Issue #1473: world-readable (0644) all-agent live-state aggregate the
+# daemon (controller UID) publishes each tick so an isolated agent UID —
+# which cannot reach the controller's per-UID tmux socket and cannot read
+# the 0600 active-roster — can still resolve every agent's active/state in
+# `agb agent list`. Carries ONLY non-secret observational fields
+# (agent / active / activity_state / updated_at). See lib/bridge-state.sh
+# bridge_write_agents_aggregate_state + lib/bridge-agents.sh fallback.
+# BRIDGE_AGENTS_AGGREGATE_MAX_AGE_SECONDS (read inline in
+# bridge_agents_aggregate_should_consult) bounds how stale the aggregate
+# may be before a non-controller reader stops trusting it (daemon-down
+# safety); unset → 3× the heartbeat interval, 0 → disable the gate.
+BRIDGE_AGENTS_AGGREGATE_TSV="${BRIDGE_AGENTS_AGGREGATE_TSV:-$BRIDGE_STATE_DIR/agents-aggregate.tsv}"
 BRIDGE_DAEMON_PID_FILE="${BRIDGE_DAEMON_PID_FILE:-$BRIDGE_STATE_DIR/daemon.pid}"
 # Issue #590 / PR #599 r2: prefer the installer-written launchagent.config
 # marker so custom --label/--plist/--log-path installs resolve correctly.

--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -9529,7 +9529,31 @@ bridge_agent_is_active() {
   local session
 
   session="$(bridge_agent_session "$agent")"
-  [[ -n "$session" ]] && bridge_tmux_session_exists "$session"
+  # PRIMARY path: the live tmux probe. Correct + freshest wherever the
+  # caller's UID can reach the agent's tmux server (the controller, and
+  # shared-mode non-iso installs where everything runs under one UID).
+  if [[ -n "$session" ]] && bridge_tmux_session_exists "$session"; then
+    return 0
+  fi
+
+  # Issue #1473 FALLBACK: a probe miss from a NON-controller UID is
+  # ambiguous — the agent may genuinely be stopped, or our UID simply
+  # cannot see the controller's per-UID tmux socket (the iso v2 case,
+  # where every probe falsely reads "absent"). Only when we are NOT the
+  # controller (the daemon-published aggregate is owned by another UID)
+  # do we consult that aggregate. On the controller the gate is false, so
+  # a genuine stop reads stopped and we never trust a stale aggregate over
+  # a fresh local probe. Graceful: missing/own-UID aggregate → fall
+  # through to the historical "probe miss == not active" answer.
+  if command -v bridge_agents_aggregate_should_consult >/dev/null 2>&1 \
+      && bridge_agents_aggregate_should_consult; then
+    local agg_active
+    if agg_active="$(bridge_agents_aggregate_lookup "$agent" 2)"; then
+      [[ "$agg_active" == "1" ]] && return 0
+    fi
+  fi
+
+  return 1
 }
 
 bridge_list_agents() {

--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -4761,3 +4761,207 @@ bridge_render_active_roster() {
   mv "$tmp_tsv" "$BRIDGE_ACTIVE_ROSTER_TSV"
   mv "$tmp_md" "$BRIDGE_ACTIVE_ROSTER_MD"
 }
+
+# Issue #1473: publish a world-readable (0644) all-agent live-state
+# aggregate so an isolated agent UID can answer `agb agent list` without
+# reaching the controller's per-UID tmux socket or the 0600 active-roster.
+#
+# WHY this artifact exists: `bridge_agent_is_active` probes tmux directly
+# (`tmux has-session`). tmux servers are per-UID, so from inside an iso
+# agent's UID every probe returns "absent" → `agb agent list` falsely
+# renders every agent as `stopped`. The per-agent HEARTBEAT.md / 0600
+# active-roster are NOT iso-readable across agents either (group
+# `ab-agent-<a>` is private to each agent). This aggregate is the one
+# controller-published, all-agent, iso-readable snapshot.
+#
+# SECURITY: only non-secret observational columns are written —
+# `agent` (already public), `active` (1/0), `activity_state` (a short
+# enum token: idle/working/stopped/starting/picker_blocked/...),
+# `updated_at` (ISO-8601). NO session ids, workdirs, channel ids, tokens,
+# or paths. The 0644 mode is justified by that content boundary; keep it
+# that way (the codex review for #1473 gates on "no secret in the 0644
+# aggregate"). `updated_at` lets a reader detect staleness rather than
+# trusting a daemon-down snapshot as fresh.
+#
+# ALL registered agents are listed (active AND stopped) — unlike
+# `bridge_render_active_roster`, which filters to active only. A `list`
+# consumer that dropped stopped rows would make them vanish entirely from
+# an iso view, which is the opposite of the fix.
+#
+# The daemon runs as the controller UID, so the tmux probe inside
+# `bridge_agent_is_active` / `bridge_agent_activity_state` is authoritative
+# here. Atomic write (mktemp in BRIDGE_STATE_DIR → chmod → mv) keeps a
+# concurrent reader from ever seeing a half-written file.
+bridge_write_agents_aggregate_state() {
+  local target="${BRIDGE_AGENTS_AGGREGATE_TSV:-}"
+  [[ -n "$target" ]] || return 0
+  declare -p BRIDGE_AGENT_IDS >/dev/null 2>&1 || return 0
+
+  local state_dir
+  state_dir="$(dirname "$target")"
+  mkdir -p "$state_dir" 2>/dev/null || return 0
+
+  local tmp updated agent active activity
+  # mktemp inside the same dir guarantees the final `mv` is an atomic
+  # same-filesystem rename (a cross-fs mv would copy+unlink, which is not
+  # atomic for a concurrent reader).
+  tmp="$(mktemp "${target}.XXXXXX")" || return 0
+
+  # ISO-8601 local-with-offset. Prefer bridge_now_iso (the same renderer
+  # bridge_render_active_roster uses on this exact daemon tick — one fork
+  # per tick, not per agent, so the cost is already paid alongside) for a
+  # colon-offset form. Fall back to date(1) with %z (the BASIC numeric
+  # offset, which BOTH BSD and GNU date support — `%:z` is GNU-only and
+  # BSD date prints a literal `:z`, footgun the smoke pins).
+  if command -v bridge_now_iso >/dev/null 2>&1; then
+    updated="$(bridge_now_iso 2>/dev/null || true)"
+  fi
+  if [[ -z "${updated:-}" ]]; then
+    updated="$(date +%Y-%m-%dT%H:%M:%S%z 2>/dev/null || true)"
+  fi
+  [[ -n "${updated:-}" ]] || updated="-"
+
+  # activity_state source: prefer the daemon-side computation
+  # (bridge_agent_heartbeat_activity_state, defined in bridge-daemon.sh and
+  # the function the daemon already uses for per-agent heartbeats) since
+  # the writer's primary caller is the daemon tick. Fall back to the CLI's
+  # bridge_agent_activity_state (bridge-agent.sh) when the writer runs from
+  # a CLI process that sourced it, else the `unknown` sentinel. Both
+  # compute the same enum tokens; selecting by availability avoids a
+  # hard dependency on either root script being sourced.
+  local _state_fn=""
+  if command -v bridge_agent_heartbeat_activity_state >/dev/null 2>&1; then
+    _state_fn="bridge_agent_heartbeat_activity_state"
+  elif command -v bridge_agent_activity_state >/dev/null 2>&1; then
+    _state_fn="bridge_agent_activity_state"
+  fi
+
+  {
+    printf 'agent\tactive\tactivity_state\tupdated_at\n'
+    for agent in "${BRIDGE_AGENT_IDS[@]}"; do
+      [[ -n "$agent" ]] || continue
+      if bridge_agent_is_active "$agent"; then
+        active=1
+      else
+        active=0
+      fi
+      # Quarantine wins over the heartbeat/CLI state fn, mirroring the
+      # short-circuit in bridge-agent.sh::bridge_agent_activity_state and
+      # bridge_write_roster_status_snapshot. The daemon-side
+      # bridge_agent_heartbeat_activity_state does NOT check the
+      # broken-launch marker (it returns `stopped` for a quarantined,
+      # tmux-less agent), so without this check the aggregate — and the iso
+      # fallback that reads it — would regress a quarantined agent to
+      # `stopped` and drop the operator's recovery signal (#1317-B).
+      if [[ -f "$(bridge_agent_broken_launch_file "$agent" 2>/dev/null)" ]]; then
+        activity="quarantine-broken-launch"
+      elif [[ -n "$_state_fn" ]]; then
+        activity="$("$_state_fn" "$agent" 2>/dev/null || printf 'unknown')"
+      else
+        activity="unknown"
+      fi
+      # Defensive: collapse any stray tab/newline so the TSV stays
+      # single-line-per-agent (activity_state is a fixed enum, but never
+      # trust an upstream helper to stay shape-clean).
+      activity="${activity//$'\t'/ }"
+      activity="${activity//$'\n'/ }"
+      printf '%s\t%s\t%s\t%s\n' "$agent" "$active" "${activity:-unknown}" "$updated"
+    done
+  } >"$tmp" 2>/dev/null || {
+    rm -f -- "$tmp" 2>/dev/null || true
+    return 0
+  }
+
+  chmod 0644 "$tmp" 2>/dev/null || true
+  mv -f "$tmp" "$target" 2>/dev/null || {
+    rm -f -- "$tmp" 2>/dev/null || true
+    return 0
+  }
+  return 0
+}
+
+# Issue #1473 (read side): is the current process a non-controller reader
+# that should consult the daemon-published aggregate instead of the live
+# tmux probe? True when ALL of:
+#   (a) the aggregate exists,
+#   (b) it is owned by a UID OTHER than our real UID — i.e. the controller
+#       (daemon) published it and we are some other UID (an isolated
+#       agent). On the controller the daemon writes it as the controller
+#       UID, so owner == us → false → the controller keeps its pure-live
+#       tmux behavior and never trusts a possibly-stale aggregate over a
+#       fresh probe, AND
+#   (c) it is FRESH — its mtime is within BRIDGE_AGENTS_AGGREGATE_MAX_AGE_
+#       SECONDS. The daemon rewrites it every tick; once the daemon is
+#       down/wedged the file stops updating, and an iso UID must NOT keep
+#       trusting an indefinitely-stale snapshot (#1473 codex r1: gate 5).
+#       Beyond the ceiling we fall back to the historical probe-miss
+#       answer (stopped) rather than reporting an agent live from a
+#       snapshot that may be hours old. Default ceiling = 3× the heartbeat
+#       interval (the writer runs every tick, so 3 missed ticks is a
+#       confident "daemon not publishing"), overridable via the env.
+bridge_agents_aggregate_should_consult() {
+  local target="${BRIDGE_AGENTS_AGGREGATE_TSV:-}"
+  [[ -n "$target" ]] || return 1
+  [[ -f "$target" ]] || return 1
+
+  local owner_uid self_uid
+  owner_uid="$(bridge_marker_stat_uid "$target" 2>/dev/null || true)"
+  [[ "$owner_uid" =~ ^[0-9]+$ ]] || return 1
+  self_uid="$(id -u 2>/dev/null || true)"
+  [[ "$self_uid" =~ ^[0-9]+$ ]] || return 1
+  [[ "$owner_uid" != "$self_uid" ]] || return 1
+
+  # Freshness gate. Resolve the ceiling: explicit env wins; else 3× the
+  # heartbeat interval (default 300s → 900s).
+  local max_age interval mtime now_ts
+  max_age="${BRIDGE_AGENTS_AGGREGATE_MAX_AGE_SECONDS:-}"
+  if ! [[ "$max_age" =~ ^[0-9]+$ ]]; then
+    interval="${BRIDGE_HEARTBEAT_INTERVAL_SECONDS:-300}"
+    [[ "$interval" =~ ^[0-9]+$ ]] || interval=300
+    (( interval > 0 )) || interval=300
+    max_age=$(( interval * 3 ))
+  fi
+  # max_age=0 disables the freshness gate (consult regardless of age).
+  if (( max_age > 0 )); then
+    # Portable mtime: `stat -c %Y` (GNU) vs `stat -f %m` (BSD/macOS).
+    mtime="$(stat -c '%Y' "$target" 2>/dev/null \
+          || stat -f '%m' "$target" 2>/dev/null \
+          || printf '')"
+    [[ "$mtime" =~ ^[0-9]+$ ]] || return 1
+    now_ts="$(date +%s 2>/dev/null || printf '0')"
+    [[ "$now_ts" =~ ^[0-9]+$ ]] || return 1
+    # Future-dated mtime (clock skew) is treated as fresh, not stale.
+    if (( now_ts > mtime )) && (( now_ts - mtime > max_age )); then
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+# Issue #1473: look up one column for one agent in the published
+# aggregate. `column` is 2 (active) or 3 (activity_state). Returns 0 and
+# prints the value on a hit; returns 1 (prints nothing) when the file is
+# missing or the agent is absent. Read-only — never calls
+# bridge_agent_is_active (which would recurse).
+bridge_agents_aggregate_lookup() {
+  local agent="$1"
+  local column="$2"
+  local target="${BRIDGE_AGENTS_AGGREGATE_TSV:-}"
+
+  [[ -n "$agent" && -n "$target" ]] || return 1
+  [[ -f "$target" ]] || return 1
+  [[ "$column" == "2" || "$column" == "3" ]] || return 1
+
+  local row val
+  # First exact match on the agent column. The header row's first field is
+  # the literal "agent", which can only collide if someone names an agent
+  # "agent"; the active/state columns there are "active"/"activity_state",
+  # which the numeric / enum consumers reject, so a header collision is
+  # self-correcting. Bound to one read of a small file.
+  row="$(awk -F'\t' -v a="$agent" 'NR>1 && $1==a {print; exit}' "$target" 2>/dev/null || true)"
+  [[ -n "$row" ]] || return 1
+  val="$(printf '%s' "$row" | cut -f"$column")"
+  [[ -n "$val" ]] || return 1
+  printf '%s' "$val"
+}

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -110,6 +110,7 @@ add_all_required_static() {
 add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-injection tmux-injection isolation isolated-bin-agb isolated-skills-sync isolated-settings-rendering isolated-cli-policy v2-cross-class-read isolation-v2-migrate-lock-portability isolation-v2-migrate-macos-skip isolation-v2-marker-only-migrate isolation-v2-macos-noise-suppression isolation-v2-platform-discriminator isolation-v2-bucket2-gates layout-resolver-marker-over-env bsd-mktemp-portability upgrade-isolated-agent-migrate channel-plugins channel-env-readiness hooks upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision mattermost-plugin pre-compact-envelope-roundtrip telegram-relay-residue-cleanup agent-create-name-validation agent-create-caller-trust-gate agent-create-idle-timeout 1105-agent-add-audit 1100-audit-since-tz agent-update agent-update-launch-cmd-redaction 1122-admin-auto-caller-source 1136-always-on-no agent-doctor cron-run-artifacts-retention cron-migrate-payloads cron-mutation-audit cron-shell-runner 1114-cli-help-contract upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering 1120-controller-ops-isolated 1139-link-shared-settings-perm 1144-upgrade-complete-task 1145-ensure-dir-actually-sudo 1145-option1-deferral-guard 1151-step-a-helper 1151-r2-sudo-escalate 1155-bootstrap-skill-guard 1158-marker-controller-uid-exemption 1158-marker-load-order 1161-marker-readable-by-isolated 1165-track-a-scaffold-modes 1165-track-b-sudo-escalate-and-state 1165-track-c-hooks-and-dispatcher 1342-write-state-marker-matrix 1170-safe-path-check-sudo-escalate 1175-exhaustive-pathlib-audit 1178-helper-contract-daemon-supp shared-settings-preserve-user-keys status-engine-detect 835-static-admin-launch 857-pr1-isolation-write-helper 857-pr6-isolation-v3-channel-dotenv-migrate 864-upgrade-perm-regressions 1021-isolation-v2-shared-plugin-perms 1025-isolated-create-agent-env-install 1028-isolated-workdir-check 1118-v2-engine-binary-path admin-protocol-shared-link bridge-notify-no-default-discord-875 cleanup-payload-empty-stdin-872 dynamic-agent-shared-mode-workdir v2-scaffold-home-and-workdir 1060-layout-fresh-v2-static-claude 1060-layout-fresh-v2-static-codex 1060-layout-shared-workdir-pair agent-env-no-stale-bridge-layout 1015-resume-claude-config-dir 1073-fresh-channel-first-run-seed isolated-agent-delete-reap 1121-agent-delete-os-purge 1140-purge-home-os-cleanup nudge-task-age-gate 1106-nudge-shell-recheck nudge-redundant-active-agent 1323-nudge-eligibility-recheck-twostage 1199-action-required-claimed-skip tool-policy-roster-read-classify 679-wiki-ingest-exclude-precompact a2a-cross-bridge 1405-handoffd-supervision 1058-bootstrap-tmux-ux legacy-install-migrator 1117-cli-help-universal-gate 1087-migrator-apply-contract 1067-codex-provisioning 1077-migrate-iso-v2-data-dir 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill 1115-cli-usage-drift phase2-install-tree-reconciler phase3-agent-home-contract 1201-1202-directory-marketplace-seed 1205-hook-iso-fail-open 1207-stale-supp-groups-allowlist 1208-lock-metadata-normalize 1209-ms365-redirect-resolver 1210-ms365-scope-normalize 1212-bridge-hooks-marketplace 1213-iso-uid-predicate 1214-channel-validator-iso-fallback 1215-ms365-dir-mode beta27-D-inject-timestamp-resolved beta27-E-hook-permission-fail-open-markers G-channel-spec-resolution F-daemon-supp-groups-mock F-daemon-supp-groups-real H-bootstrap-memory-iso-rebuild I-agent-description-roster ζ-1236-plugins-list-marketplaces β-1231-1236-fresh-install-seed-sudoers 6607-hook-admin-allowlist γ-cli-consistency δ-1234-daemon-start-policy B-beta3-1249-1250-plugin-ux C1-beta3-1251-restart-preflight-rollback A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir C-beta4-logger-and-spec B-beta4-setup-wizard A-beta4-iso-path-resolution D-beta4-daemon-lifecycle E-beta4-fresh-install-gate-state-dir H-beta4-iso-ownership F-beta4-oauth-bootstrap G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs K-beta4-nits Beta-beta5-session-id-detect-sudo α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-zeta-teams-mcp-dedup beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-eta-cron-iso-uid-preflight beta5-2-delta-nudge-session-empty beta5-2-theta-upgrade-backfill-perms beta5-2-nu-daemon-path-quarantine beta5-2-kappa-state-audit-reconcile beta5-2-iota-daemon-escalation-family beta5-2-lambda-a2a-robustness beta5-2-mu-cron-channel-creds beta5-2-xi-misc-fixes 1359-cron-create-iso-staging 1379-iso-cron-staging-group 1383-iso-cron-result-json-group 1354-setup-teams-fd-password 1360-onboarding-next-actions-persona 1353-setup-pending-grace 1355-1356-ms365-wizard 1357-iso-boundary-quickref 1358-admin-credential-routine-exempt 1352-shared-codex-pair-path 1343-ms365-token-refresh 1378-iso-session-lock-fresh-start 1388-daemon-lock-fd-cloexec 1416-onboarding-state-field-anchor a2a-setup-wizard 1408-daemon-alert-nudge-hygiene 1409-claude-midturn-busy-gate 1427-A-roster-materialize 1427-B-template-sync-wizard 1426-cron-shell-noniso-help 1437-reactive-cron-rotation 1425-spool-rederive 1437-native-usage-probe
 add_required 1425-cron-dispatch-nudge-scope
 add_required 1936-forward-followup-attached-escalation
+add_required 1473-agent-list-iso-state-fallback
 
 
 }
@@ -257,6 +258,11 @@ select_for_path() {
       # the create-time materialization.
       if [[ "$path" == "bridge-agent.sh" ]]; then
         add_required 1427-A-roster-materialize 1427-B-template-sync-wizard
+        # Issue #1473: bridge-agent.sh hosts bridge_agent_activity_state,
+        # which gained the iso-UID aggregate fallback so the human-facing
+        # state token agrees with the active column from a non-controller
+        # UID. Pull the smoke on every bridge-agent.sh move.
+        add_required 1473-agent-list-iso-state-fallback
       fi
       ;;
     lib/bridge-cron.sh|lib/bridge-state.sh)
@@ -277,6 +283,15 @@ select_for_path() {
       # future refactor cannot silently revert the lock anchor.
       if [[ "$path" == "lib/bridge-state.sh" ]]; then
         add_required 1378-iso-session-lock-fresh-start
+        # Issue #1473: lib/bridge-state.sh hosts the all-agent state
+        # aggregate writer (bridge_write_agents_aggregate_state) + the
+        # read-side helpers (should_consult / lookup) that
+        # bridge_agent_is_active + bridge_agent_activity_state fall back to
+        # from an iso UID. Pull the smoke on every state-lib move so a
+        # refactor cannot regress the 0644 publish, the all-agents-listed
+        # invariant, the no-secret column boundary, or the controller
+        # no-regression gate.
+        add_required 1473-agent-list-iso-state-fallback
       fi
       ;;
   esac
@@ -904,7 +919,14 @@ select_for_path() {
       # systemd-defer path. Pull 1405-handoffd-supervision on every
       # bridge-daemon.sh move so the supervisor (and its invariant that
       # restart re-runs the full bind proof) cannot regress.
-      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift 1178-helper-contract-daemon-supp F-daemon-supp-groups-mock F-daemon-supp-groups-real δ-1234-daemon-start-policy A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir D-beta4-daemon-lifecycle A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs Beta-beta5-session-id-detect-sudo beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-kappa-state-audit-reconcile 1359-cron-create-iso-staging 1380-admin-autostart-recovery 1388-daemon-lock-fd-cloexec 1407-runtime-hardening 1405-handoffd-supervision 1408-daemon-alert-nudge-hygiene
+      # Issue #1473: bridge-daemon.sh's refresh_agent_heartbeats now also
+      # publishes the world-readable all-agent state aggregate every tick
+      # (bridge_write_agents_aggregate_state, hosted in lib/bridge-state.sh)
+      # so an isolated agent UID can resolve every agent's active/state for
+      # `agb agent list`. Pull 1473 on every daemon/state move so the
+      # 0644-publish + all-agents-listed + no-secret + atomic-write contract
+      # cannot regress.
+      add_required daemon queue launch-dev-channels-injection channel-env-readiness cron-run-artifacts-retention cron-shell-runner status-engine-detect 835-static-admin-launch bridge-sync-roster-memo daemon-periodic-token-sync 1015-resume-claude-config-dir 1115-cli-usage-drift 1178-helper-contract-daemon-supp F-daemon-supp-groups-mock F-daemon-supp-groups-real δ-1234-daemon-start-policy A3-beta3-1248-restart-session-id-resume A12-beta3-1246-1252-daemon-supp-group-and-state-dir D-beta4-daemon-lifecycle A-beta4-iso-path-resolution E-beta4-fresh-install-gate-state-dir G-beta4-watchdog-noise I-beta4-a2a-3-gaps J-beta4-workflow-docs Beta-beta5-session-id-detect-sudo beta5-1-session-id-detect-race dev-channel-auto-accept-no-attach mcp-liveness-giveup-auto-clear beta5-2-epsilon-tmux-inject-busy beta5-2-pi-daemon-crashloop-no-set-e-leak beta5-2-kappa-state-audit-reconcile 1359-cron-create-iso-staging 1380-admin-autostart-recovery 1388-daemon-lock-fd-cloexec 1407-runtime-hardening 1405-handoffd-supervision 1408-daemon-alert-nudge-hygiene 1473-agent-list-iso-state-fallback
       # v0.15.0-beta5-2 Lane η (#1314, CRITICAL/security):
       # bridge-daemon.sh's `cmd_run_cron_worker` now gates shell-cron
       # dispatch on `bridge_cron_uid_drop_preflight`. The new gate emits

--- a/scripts/smoke/1473-agent-list-iso-state-fallback.sh
+++ b/scripts/smoke/1473-agent-list-iso-state-fallback.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# scripts/smoke/1473-agent-list-iso-state-fallback.sh — Issue #1473.
+#
+# From inside an isolated agent UID, `agb agent list` rendered EVERY agent
+# as `stopped` because the state column probes tmux directly
+# (bridge_agent_is_active -> bridge_tmux_session_exists -> `tmux
+# has-session`). tmux servers are per-UID, so an iso UID cannot reach the
+# controller's socket and every probe falsely reads "absent".
+#
+# Fix (two parts):
+#   A. The daemon (controller UID) publishes a world-readable (0644)
+#      all-agent aggregate `${BRIDGE_STATE_DIR}/agents-aggregate.tsv` each
+#      heartbeat tick — agent / active / activity_state / updated_at, NO
+#      secrets, atomic write (mktemp -> chmod -> mv).
+#   B. bridge_agent_is_active + bridge_agent_activity_state fall back to
+#      that aggregate when the live tmux probe misses AND we are NOT the
+#      controller (the aggregate is owned by a different UID). On the
+#      controller the live probe stays authoritative (no shared-mode
+#      regression, no trusting a stale aggregate over a fresh probe).
+#
+# Test matrix:
+#   T1. Writer publishes the aggregate at 0644 with the exact header and
+#       lists ALL registered agents (active AND stopped) with the correct
+#       active column, mirroring the live tmux-probe result.
+#   T2. The aggregate carries NO secret/identifying columns (no session,
+#       workdir, channel id, token, or path) — content-boundary that
+#       justifies the 0644 mode.
+#   T3. With the tmux probe forced to miss and the non-controller gate
+#       forced true, bridge_agent_is_active returns ACTIVE from the
+#       aggregate and bridge_agent_activity_state returns the aggregate's
+#       state token (not the misleading "working" tmux-ladder fallthrough
+#       and not "stopped").
+#   T4. Shared-mode / controller no-regression: when the aggregate is
+#       owned by the SAME UID as the reader (the controller writes it as
+#       itself), the should-consult gate is FALSE, so a genuinely-stopped
+#       agent (probe miss) reads inactive even though the aggregate marks a
+#       DIFFERENT agent active. The controller never flips a fresh probe.
+#   T5. Graceful daemon-down: with NO aggregate present, the should-consult
+#       gate is false and bridge_agent_is_active for a probe-miss agent
+#       returns inactive without error (historical behavior preserved).
+#   T6. Stale aggregate (daemon stopped publishing): a controller-owned but
+#       OLD aggregate is NOT consulted (the mtime freshness gate flips
+#       false), so an iso UID does not report agents live off an
+#       indefinitely-stale snapshot; a freshly-touched file IS consulted.
+#   T7. Broken-launch quarantine: the writer publishes
+#       `quarantine-broken-launch` (NOT `stopped`) for a marked agent — the
+#       daemon-side state fn alone drops that signal — and the iso fallback
+#       surfaces it from the aggregate even when the local marker is gone.
+#
+# Footgun #11: no `<<PY`/`<<EOF` heredoc-stdin to a subprocess; the
+# in-process harness is a `bash -c '...'` string with function overrides
+# defined AFTER sourcing bridge-lib.sh.
+
+set -euo pipefail
+
+SMOKE_NAME="1473-agent-list-iso-state-fallback"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+A1="alpha"   # live (probe true)
+A2="bravo"   # live (probe true)
+A3="charlie" # stopped (probe false)
+
+write_roster_fixture() {
+  # Three static agents. Distinct session names so a per-agent probe stub
+  # can decide each agent's live state independently.
+  cat >"$BRIDGE_ROSTER_LOCAL_FILE" <<EOF
+#!/usr/bin/env bash
+# shellcheck shell=bash disable=SC2034
+BRIDGE_ADMIN_AGENT_ID=${A1}
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${A1}
+bridge_add_agent_id_if_missing ${A1}
+BRIDGE_AGENT_DESC["${A1}"]='alpha role'
+BRIDGE_AGENT_ENGINE["${A1}"]='claude'
+BRIDGE_AGENT_SESSION["${A1}"]='sess-${A1}'
+BRIDGE_AGENT_WORKDIR["${A1}"]='${BRIDGE_AGENT_HOME_ROOT}/${A1}'
+BRIDGE_AGENT_SOURCE["${A1}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${A1}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${A1}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${A1}
+
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${A2}
+bridge_add_agent_id_if_missing ${A2}
+BRIDGE_AGENT_DESC["${A2}"]='bravo role'
+BRIDGE_AGENT_ENGINE["${A2}"]='claude'
+BRIDGE_AGENT_SESSION["${A2}"]='sess-${A2}'
+BRIDGE_AGENT_WORKDIR["${A2}"]='${BRIDGE_AGENT_HOME_ROOT}/${A2}'
+BRIDGE_AGENT_SOURCE["${A2}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${A2}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${A2}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${A2}
+
+# BEGIN AGENT BRIDGE MANAGED ROLE: ${A3}
+bridge_add_agent_id_if_missing ${A3}
+BRIDGE_AGENT_DESC["${A3}"]='charlie role'
+BRIDGE_AGENT_ENGINE["${A3}"]='claude'
+BRIDGE_AGENT_SESSION["${A3}"]='sess-${A3}'
+BRIDGE_AGENT_WORKDIR["${A3}"]='${BRIDGE_AGENT_HOME_ROOT}/${A3}'
+BRIDGE_AGENT_SOURCE["${A3}"]="static"
+BRIDGE_AGENT_LAUNCH_CMD["${A3}"]='claude --dangerously-skip-permissions'
+BRIDGE_AGENT_CONTINUE["${A3}"]="1"
+# END AGENT BRIDGE MANAGED ROLE: ${A3}
+EOF
+  mkdir -p \
+    "$BRIDGE_AGENT_HOME_ROOT/$A1" \
+    "$BRIDGE_AGENT_HOME_ROOT/$A2" \
+    "$BRIDGE_AGENT_HOME_ROOT/$A3"
+}
+
+# Run a snippet with bridge-lib.sh sourced in-process. $1 is bash code
+# appended AFTER the source line, so it can override probe functions and
+# call the writer/reader. The harness pins the same BRIDGE_* env this
+# smoke's bridge home exports so the aggregate path resolves under the
+# isolated root.
+# bridge-lib.sh sources neither bridge-daemon.sh nor bridge-agent.sh, so
+# the two activity_state computations the fix touches live outside the
+# in-process harness. Extract BOTH into a standalone file the harness
+# sources (pattern mirrors
+# scripts/smoke/1178-helper-contract-daemon-supp.sh::extract_helper):
+#   - bridge_agent_heartbeat_activity_state (bridge-daemon.sh): the
+#     function the WRITER prefers in the daemon context (its real primary
+#     caller). Exercises the same per-agent state path the daemon uses.
+#   - bridge_agent_activity_state (bridge-agent.sh): the CLI function an
+#     iso agent calls via `agb agent list`; it carries the #1473 iso
+#     aggregate fallback under test in T3/T4/T5.
+# All of bridge_agent_activity_state's other dependencies
+# (bridge_agent_broken_launch_file, the tmux probes, picker_blocked, the
+# aggregate helpers) live in libs bridge-lib.sh already sources.
+STATE_FN_FILE=""
+extract_state_fns() {
+  STATE_FN_FILE="$SMOKE_TMP_ROOT/state-fns.sh"
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    awk '/^bridge_agent_heartbeat_activity_state\(\) \{/,/^\}/' \
+      "$SMOKE_REPO_ROOT/bridge-daemon.sh"
+    printf '%s\n' ''
+    awk '/^bridge_agent_activity_state\(\) \{/,/^\}/' \
+      "$SMOKE_REPO_ROOT/bridge-agent.sh"
+  } >"$STATE_FN_FILE"
+  grep -q '^bridge_agent_heartbeat_activity_state()' "$STATE_FN_FILE" \
+    || smoke_fail "extract: bridge_agent_heartbeat_activity_state not found in bridge-daemon.sh"
+  grep -q '^bridge_agent_activity_state()' "$STATE_FN_FILE" \
+    || smoke_fail "extract: bridge_agent_activity_state not found in bridge-agent.sh"
+}
+
+harness() {
+  local body="$1"
+  # Invoke the SAME Bash 4+ binary that runs this smoke ($BASH), NOT a bare
+  # `bash` — on macOS a bare `bash` resolves to /bin/bash 3.2, and
+  # bridge-lib.sh's top-of-file Bash-4+ guard would `exec` a re-run into a
+  # candidate Bash 4+ shell *targeting bridge-lib.sh itself* (BASH_SOURCE[1]
+  # is unset under `bash -c`), which sources the lib with no body and exits
+  # 0 — so the harness body would silently never run.
+  #
+  # `set +e` first to clear any errexit the parent leaked via an exported
+  # SHELLOPTS (the smoke runs under `set -e`); sourcing bridge-lib.sh runs
+  # startup validation that can return non-zero benignly. The functions
+  # under test return their own status, which the body checks.
+  local _bash_bin="${BASH:-/usr/bin/env bash}"
+  BRIDGE_SCRIPT_DIR="$SMOKE_REPO_ROOT" \
+  SMOKE_STATE_FN_FILE="$STATE_FN_FILE" \
+    "$_bash_bin" -c '
+      set +e
+      set -uo pipefail
+      BRIDGE_SCRIPT_DIR="'"$SMOKE_REPO_ROOT"'"
+      export BRIDGE_SCRIPT_DIR
+      source "$BRIDGE_SCRIPT_DIR/bridge-lib.sh" >/dev/null 2>&1
+      # Sourcing bridge-lib.sh does NOT auto-load the roster; call it
+      # explicitly (cache-disabled so the fixture roster is re-read) so the
+      # BRIDGE_AGENT_* associative arrays + BRIDGE_AGENT_IDS are populated.
+      BRIDGE_ROSTER_CACHE_DISABLE=1 bridge_load_roster >/dev/null 2>&1 || true
+      # Provide the daemon-side activity_state function the writer prefers.
+      # bridge-lib.sh sources neither bridge-daemon.sh nor bridge-agent.sh,
+      # so without this the writer would emit the `unknown` sentinel.
+      if [[ -n "${SMOKE_STATE_FN_FILE:-}" && -f "${SMOKE_STATE_FN_FILE}" ]]; then
+        # shellcheck source=/dev/null
+        source "${SMOKE_STATE_FN_FILE}"
+      fi
+      '"$body"'
+    '
+}
+
+# Force-true / force-false / mixed tmux probe overrides as a code prelude
+# the harness body can prepend. Each redefines bridge_tmux_session_exists
+# AFTER the source so the stub wins over the library definition.
+probe_mixed_prelude='
+bridge_tmux_session_exists() {
+  case "$1" in
+    sess-'"$A1"'|sess-'"$A2"') return 0 ;;   # alpha + bravo live
+    *) return 1 ;;                            # charlie stopped
+  esac
+}
+'
+
+probe_all_miss_prelude='
+bridge_tmux_session_exists() { return 1; }
+'
+
+test_t1_writer_publishes_all_agents_0644() {
+  write_roster_fixture
+  harness "$probe_mixed_prelude"'
+    bridge_write_agents_aggregate_state
+  '
+
+  local agg="$BRIDGE_STATE_DIR/agents-aggregate.tsv"
+  smoke_assert_file_exists "$agg" "T1: aggregate published"
+
+  # Mode 0644 (the world-readable contract that lets an iso UID read it).
+  local mode
+  if [[ "$(uname)" == "Darwin" ]]; then
+    mode="$(stat -f '%Lp' "$agg")"
+  else
+    mode="$(stat -c '%a' "$agg")"
+  fi
+  smoke_assert_eq "644" "$mode" "T1: aggregate is mode 0644"
+
+  # Exact header line.
+  local header
+  header="$(head -n 1 "$agg")"
+  smoke_assert_eq "agent	active	activity_state	updated_at" "$header" \
+    "T1: aggregate header columns"
+
+  # ALL three agents present (active AND stopped) — the active-only roster
+  # would have dropped charlie, which is exactly the iso-view regression.
+  smoke_assert_eq "3" "$(awk 'NR>1' "$agg" | wc -l | tr -d ' ')" \
+    "T1: aggregate lists all 3 registered agents (not active-only)"
+
+  # active column mirrors the tmux-probe result: alpha=1 bravo=1 charlie=0.
+  smoke_assert_eq "1" "$(awk -F'\t' -v a="$A1" '$1==a{print $2}' "$agg")" "T1: alpha active=1"
+  smoke_assert_eq "1" "$(awk -F'\t' -v a="$A2" '$1==a{print $2}' "$agg")" "T1: bravo active=1"
+  smoke_assert_eq "0" "$(awk -F'\t' -v a="$A3" '$1==a{print $2}' "$agg")" "T1: charlie active=0"
+
+  # activity_state is a non-empty enum token; charlie (probe miss) is stopped.
+  smoke_assert_eq "stopped" "$(awk -F'\t' -v a="$A3" '$1==a{print $3}' "$agg")" \
+    "T1: charlie activity_state=stopped"
+
+  # updated_at non-empty for every row.
+  local empty_ts
+  empty_ts="$(awk -F'\t' 'NR>1 && ($4=="" || $4=="-"){c++} END{print c+0}' "$agg")"
+  smoke_assert_eq "0" "$empty_ts" "T1: every row has a non-empty updated_at"
+}
+
+test_t2_no_secrets_in_aggregate() {
+  write_roster_fixture
+  harness "$probe_mixed_prelude"'
+    bridge_write_agents_aggregate_state
+  '
+  local agg="$BRIDGE_STATE_DIR/agents-aggregate.tsv"
+
+  # The session names + workdirs are the most obvious would-be leaks. They
+  # are present in the roster but MUST NOT appear in the aggregate.
+  smoke_assert_not_contains "$(cat "$agg")" "sess-$A1" "T2: no session id leaks into aggregate"
+  smoke_assert_not_contains "$(cat "$agg")" "$BRIDGE_AGENT_HOME_ROOT" "T2: no workdir/path leaks into aggregate"
+
+  # Exactly 4 columns per data row — a 5th column would mean an extra
+  # (potentially sensitive) field crept in.
+  local bad_cols
+  bad_cols="$(awk -F'\t' 'NR>1 && NF!=4{c++} END{print c+0}' "$agg")"
+  smoke_assert_eq "0" "$bad_cols" "T2: every data row has exactly 4 columns"
+
+  # Source-level guard: the writer function body must not emit any of the
+  # forbidden column accessors. Grep the writer block in bridge-state.sh.
+  local writer_body
+  writer_body="$(awk '/^bridge_write_agents_aggregate_state\(\)/{f=1} f{print} f&&/^}/{exit}' \
+    "$SMOKE_REPO_ROOT/lib/bridge-state.sh")"
+  for forbidden in bridge_agent_session bridge_agent_workdir bridge_agent_session_id \
+      bridge_agent_channels bridge_agent_discord bridge_agent_notify_target; do
+    smoke_assert_not_contains "$writer_body" "$forbidden" \
+      "T2: writer does not emit $forbidden into the aggregate"
+  done
+}
+
+test_t3_iso_fallback_reads_active_and_state() {
+  write_roster_fixture
+  # Seed an aggregate that marks alpha active=working, charlie active=0.
+  # Then force the tmux probe to MISS for everything (the iso blindness)
+  # and force the non-controller gate true. bridge_agent_is_active must
+  # report alpha ACTIVE from the aggregate, and bridge_agent_activity_state
+  # must report alpha's aggregate state token ("working"), NOT "stopped"
+  # and NOT the misleading tmux-ladder "working" fallthrough.
+  local agg="$BRIDGE_STATE_DIR/agents-aggregate.tsv"
+  printf 'agent\tactive\tactivity_state\tupdated_at\n' >"$agg"
+  printf '%s\t1\tworking\t2026-06-01T00:00:00+00:00\n' "$A1" >>"$agg"
+  printf '%s\t0\tstopped\t2026-06-01T00:00:00+00:00\n' "$A3" >>"$agg"
+  chmod 0644 "$agg"
+
+  local out
+  out="$(harness "$probe_all_miss_prelude"'
+    # Simulate the non-controller (iso) reader: the real gate compares file
+    # owner UID to id -u, which are equal under a single-UID smoke. Override
+    # to assert the consult path.
+    bridge_agents_aggregate_should_consult() { return 0; }
+
+    if bridge_agent_is_active "'"$A1"'"; then echo "ALPHA_ACTIVE=yes"; else echo "ALPHA_ACTIVE=no"; fi
+    echo "ALPHA_STATE=$(bridge_agent_activity_state "'"$A1"'")"
+    if bridge_agent_is_active "'"$A3"'"; then echo "CHARLIE_ACTIVE=yes"; else echo "CHARLIE_ACTIVE=no"; fi
+    echo "CHARLIE_STATE=$(bridge_agent_activity_state "'"$A3"'")"
+  ')"
+
+  smoke_assert_contains "$out" "ALPHA_ACTIVE=yes" "T3: iso fallback reports alpha active from aggregate"
+  smoke_assert_contains "$out" "ALPHA_STATE=working" "T3: iso fallback reports alpha aggregate state token"
+  smoke_assert_contains "$out" "CHARLIE_ACTIVE=no" "T3: iso fallback reports stopped agent inactive"
+  smoke_assert_contains "$out" "CHARLIE_STATE=stopped" "T3: iso fallback reports stopped agent's state"
+}
+
+test_t4_controller_no_regression() {
+  write_roster_fixture
+  # The aggregate (owned by THIS uid — the controller-equivalent) marks
+  # alpha active. With the tmux probe forced to miss for everything and the
+  # REAL should-consult gate (owner == id -u -> false), alpha must read
+  # INACTIVE: the controller trusts its fresh probe, never the aggregate.
+  local agg="$BRIDGE_STATE_DIR/agents-aggregate.tsv"
+  printf 'agent\tactive\tactivity_state\tupdated_at\n' >"$agg"
+  printf '%s\t1\tworking\t2026-06-01T00:00:00+00:00\n' "$A1" >>"$agg"
+  chmod 0644 "$agg"
+
+  local out
+  out="$(harness "$probe_all_miss_prelude"'
+    # Confirm the real gate is false when owner == self (controller case).
+    if bridge_agents_aggregate_should_consult; then echo "GATE=consult"; else echo "GATE=skip"; fi
+    if bridge_agent_is_active "'"$A1"'"; then echo "ALPHA_ACTIVE=yes"; else echo "ALPHA_ACTIVE=no"; fi
+    echo "ALPHA_STATE=$(bridge_agent_activity_state "'"$A1"'")"
+  ')"
+
+  smoke_assert_contains "$out" "GATE=skip" "T4: same-UID owner -> should_consult is false (controller)"
+  smoke_assert_contains "$out" "ALPHA_ACTIVE=no" "T4: controller trusts fresh probe-miss over stale aggregate"
+  smoke_assert_contains "$out" "ALPHA_STATE=stopped" "T4: controller activity_state stays stopped on probe miss"
+}
+
+test_t5_graceful_daemon_down() {
+  write_roster_fixture
+  # No aggregate file at all (daemon never ran / is down).
+  rm -f "$BRIDGE_STATE_DIR/agents-aggregate.tsv"
+
+  local out
+  out="$(harness "$probe_all_miss_prelude"'
+    if bridge_agents_aggregate_should_consult; then echo "GATE=consult"; else echo "GATE=skip"; fi
+    if bridge_agent_is_active "'"$A1"'"; then echo "ALPHA_ACTIVE=yes"; else echo "ALPHA_ACTIVE=no"; fi
+    echo "ALPHA_STATE=$(bridge_agent_activity_state "'"$A1"'")"
+    echo "RC=$?"
+  ')"
+
+  smoke_assert_contains "$out" "GATE=skip" "T5: missing aggregate -> should_consult is false"
+  smoke_assert_contains "$out" "ALPHA_ACTIVE=no" "T5: probe-miss + no aggregate -> inactive (historical)"
+  smoke_assert_contains "$out" "ALPHA_STATE=stopped" "T5: probe-miss + no aggregate -> stopped (no error)"
+}
+
+test_t6_stale_aggregate_not_consulted() {
+  write_roster_fixture
+  # An aggregate that exists + is "controller-owned" (we spoof a different
+  # owner UID) but is OLD: once the daemon stops publishing, an iso UID
+  # must NOT keep trusting an indefinitely-stale snapshot (#1473 codex r1
+  # gate 5). The freshness ceiling is mtime-based, so we age the file with
+  # `touch -t` well past the default 3× heartbeat-interval ceiling.
+  local agg="$BRIDGE_STATE_DIR/agents-aggregate.tsv"
+  printf 'agent\tactive\tactivity_state\tupdated_at\n' >"$agg"
+  printf '%s\t1\tworking\t2020-01-01T00:00:00+00:00\n' "$A1" >>"$agg"
+  chmod 0644 "$agg"
+  # Age the file to 2020 so any reasonable ceiling treats it as stale.
+  touch -t 202001010000 "$agg"
+
+  # Spoof a controller-owned file (owner UID != id -u) so only the
+  # freshness gate decides. With a STALE file the gate must be false; with
+  # a FRESH file (mtime=now) the gate must be true — proving freshness, not
+  # the owner check, is what flips it.
+  local out
+  out="$(harness "$probe_all_miss_prelude"'
+    bridge_marker_stat_uid() { printf "%s" "$(( $(id -u) + 1 ))"; }
+    if bridge_agents_aggregate_should_consult; then echo "STALE_GATE=consult"; else echo "STALE_GATE=skip"; fi
+    if bridge_agent_is_active "'"$A1"'"; then echo "STALE_ACTIVE=yes"; else echo "STALE_ACTIVE=no"; fi
+    # Now refresh the file mtime and re-check: same owner spoof, fresh file.
+    touch "'"$agg"'"
+    if bridge_agents_aggregate_should_consult; then echo "FRESH_GATE=consult"; else echo "FRESH_GATE=skip"; fi
+    if bridge_agent_is_active "'"$A1"'"; then echo "FRESH_ACTIVE=yes"; else echo "FRESH_ACTIVE=no"; fi
+  ')"
+
+  smoke_assert_contains "$out" "STALE_GATE=skip" "T6: stale controller-owned aggregate is NOT consulted"
+  smoke_assert_contains "$out" "STALE_ACTIVE=no" "T6: stale aggregate -> agent reads inactive (no false-live)"
+  smoke_assert_contains "$out" "FRESH_GATE=consult" "T6: fresh controller-owned aggregate IS consulted"
+  smoke_assert_contains "$out" "FRESH_ACTIVE=yes" "T6: fresh aggregate -> agent reads active"
+}
+
+test_t7_broken_launch_quarantine_published() {
+  write_roster_fixture
+  # Quarantine charlie via the broken-launch marker (the #1317-B signal).
+  # The aggregate writer must publish `quarantine-broken-launch` for it
+  # (NOT `stopped`) — the daemon-side state fn alone would have dropped the
+  # signal — and the iso fallback must surface that token.
+  mkdir -p "$BRIDGE_STATE_DIR/agents/$A3"
+  : >"$BRIDGE_STATE_DIR/agents/$A3/broken-launch"
+
+  harness "$probe_mixed_prelude"'
+    bridge_write_agents_aggregate_state
+  '
+  local agg="$BRIDGE_STATE_DIR/agents-aggregate.tsv"
+  smoke_assert_eq "quarantine-broken-launch" \
+    "$(awk -F'\t' -v a="$A3" '$1==a{print $3}' "$agg")" \
+    "T7: writer publishes quarantine-broken-launch for the marked agent"
+
+  # Now REMOVE the marker, then test the iso fallback. On a real iso UID
+  # the controller-owned broken-launch marker of ANOTHER agent is not
+  # readable, so bridge_agent_activity_state's own marker short-circuit
+  # would miss it — the quarantine signal must come from the published
+  # aggregate. Removing the local marker here forces exactly that path:
+  # the fallback must surface the aggregate's token, not a live marker read.
+  rm -f "$BRIDGE_STATE_DIR/agents/$A3/broken-launch"
+  local out
+  out="$(harness "$probe_all_miss_prelude"'
+    bridge_agents_aggregate_should_consult() { return 0; }
+    echo "CHARLIE_STATE=$(bridge_agent_activity_state "'"$A3"'")"
+  ')"
+  smoke_assert_contains "$out" "CHARLIE_STATE=quarantine-broken-launch" \
+    "T7: iso fallback surfaces quarantine-broken-launch from the aggregate (not stopped)"
+}
+
+main() {
+  smoke_require_cmd bash
+  smoke_require_cmd awk
+  smoke_setup_bridge_home "$SMOKE_NAME"
+  extract_state_fns
+
+  smoke_run "T1: writer publishes all agents at 0644"        test_t1_writer_publishes_all_agents_0644
+  smoke_run "T2: aggregate carries no secrets"               test_t2_no_secrets_in_aggregate
+  smoke_run "T3: iso fallback reads active + state"          test_t3_iso_fallback_reads_active_and_state
+  smoke_run "T4: controller no-regression (no stale flip)"   test_t4_controller_no_regression
+  smoke_run "T5: graceful daemon-down"                       test_t5_graceful_daemon_down
+  smoke_run "T6: stale aggregate is not consulted"           test_t6_stale_aggregate_not_consulted
+  smoke_run "T7: broken-launch quarantine published"         test_t7_broken_launch_quarantine_published
+  smoke_log "passed"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

From inside an isolated agent UID, `agb agent list` reported **every** agent as `stopped` even when all were running. The state column probes tmux directly (`bridge_agent_is_active` → `bridge_tmux_session_exists` → `tmux has-session`); tmux servers are per-UID, so an iso UID cannot reach the controller's socket and every probe falsely reads "absent". The per-agent `HEARTBEAT.md` and the 0600 `active-roster` are not iso-readable across agents either, so there was no iso-readable all-agent live-state artifact. Reported via A2A from `cm-prod-AgentWorkflow-vm01` (0.15.2, Linux iso v2).

## Fix

**Part A — daemon publishes a new world-readable aggregate.** `bridge_write_agents_aggregate_state` (`lib/bridge-state.sh`) writes `${BRIDGE_STATE_DIR}/agents-aggregate.tsv` every heartbeat tick (hooked into `refresh_agent_heartbeats`, unconditional — not gated on `heartbeat_due`, so `updated_at` stays fresh). Mode **0644**.
- Columns: `agent` / `active` (1/0) / `activity_state` (enum token) / `updated_at` (ISO-8601). **No secrets** — no session ids, workdirs, channel ids, tokens, or paths.
- Lists **ALL** registered agents (active AND stopped), unlike `bridge_render_active_roster` which filters to active.
- **Atomic write**: `mktemp` in-dir → `chmod 0644` → `mv -f`.
- Broken-launch quarantine wins over the heartbeat state fn, so a quarantined agent publishes `quarantine-broken-launch`, not `stopped` (mirrors the CLI + roster-snapshot precedence).
- Timestamp via `bridge_now_iso` (else portable `date +...%z`).

**Part B — readers fall back to the aggregate.** `bridge_agent_is_active` (`lib/bridge-agents.sh`) and `bridge_agent_activity_state` (`bridge-agent.sh`) keep the live tmux probe **primary**; on a miss they consult the aggregate only when `bridge_agents_aggregate_should_consult` is true:
- aggregate exists, **AND**
- it is owned by a UID other than ours (controller-published; we are a non-controller / iso UID), **AND**
- it is **fresh** — mtime within `BRIDGE_AGENTS_AGGREGATE_MAX_AGE_SECONDS` (default 3× the heartbeat interval; `0` disables).

On the controller the gate is false → pure-live behavior, **no shared-mode regression**, never trusting a stale aggregate over a fresh probe. Daemon-down / missing / stale aggregate → historical probe-miss answer, never an error.

## Tests

New `scripts/smoke/1473-agent-list-iso-state-fallback.sh` (registered in `scripts/ci-select-smoke.sh` `add_all_required_static` + per-path routing for all touched files):

- **T1** writer publishes the aggregate at 0644 with the exact header and lists all agents with the correct `active` column.
- **T2** no secret/identifying columns (output-level + writer-body grep).
- **T3** iso fallback returns active + the aggregate `activity_state` token.
- **T4** controller no-regression: same-UID owner → gate false → fresh probe wins over a stale aggregate.
- **T5** graceful daemon-down: missing aggregate → inactive, no error.
- **T6** stale aggregate (mtime past the ceiling) is **not** consulted; a freshly-touched one is.
- **T7** broken-launch quarantine is published as `quarantine-broken-launch` and surfaced by the iso fallback from the aggregate.

## Verification

- `bash -n` (Bash 5.3.9) + `shellcheck --severity=warning` clean on all 7 touched files.
- Smoke `1473-...` T1–T7 all pass.
- `scripts/smoke-test.sh`: the only `[error]` is the pre-existing host-specific `#365` check (reproduces identically on base commit `122551c`) — unrelated to this change.
- Internal codex review: **implement-ok** (r2, after closing the stale-aggregate freshness gate and broken-launch quarantine findings from r1).

Refs #1473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)