### PR TITLE
docs(skill): sync wave-orchestration skill to repo (5-phase + Phase 3.5 fixer-monitoring)

### DIFF
--- a/.claude/skills/wave-orchestration/SKILL.md
+++ b/.claude/skills/wave-orchestration/SKILL.md
@@ -163,7 +163,7 @@ Output-file mtime stale (no change for ~15+ min) **AND** no commits **AND** no P
 2. **Kill + take over** (when it barely started / the change is trivial, < ~50 LOC): `TaskStop` the agent, then do the edit yourself in a **dedicated temp worktree** (`git worktree add -b <branch> /tmp/<slug> origin/main`) — never in the operator's primary checkout.
 3. **CRITICAL — taking over does NOT skip review (operator directive 2026-06-03).** When a fixer wedges on its *internal* codex review and you finish the work yourself, the PR has now had **zero** codex review. You MUST still queue the **`agb-dev-codex` Phase-4 pair-review** (Phase 4 below) and merge ONLY on `implement-ok`. The wedged internal review was the fixer's self-check; the Phase-4 pair-review is the real merge gate and is mandatory for EVERY PR — a taken-over PR is not an exception. Never push-and-merge a wedge-recovery PR on your own say-so.
 
-See memory `feedback_fixer_internal_codex_review_wedge`.
+**Field evidence**: in one wave, 3/3 dispatched fixers wedged at the internal codex-rescue step — each had finished its edits + verification matrix, then stalled at "now invoke the codex rescue subagent". The edits sat intact in the worktree the whole time; only the commit/push/PR stage never ran. Take-over recovered all of them with zero lost work. Note the wedge is specifically the *fixer-internal* codex-rescue handoff (Phase 3), not the long-lived `agb-dev-codex` queue review (Phases 1/4/5).
 
 ---
 

--- a/.claude/skills/wave-orchestration/SKILL.md
+++ b/.claude/skills/wave-orchestration/SKILL.md
@@ -1,18 +1,19 @@
 ---
 name: wave-orchestration
-description: Ship multiple GitHub issues or tracks **in parallel** as 2-4-PR waves. Use whenever the user has multiple open issues/PRs to process, mentions "wave", "Track A/B/C/D", "parallel fixer", "ship these issues", asks to dispatch issue-fix agents, wants codex code review on a complex PR, or describes a backlog they want batched into focused PRs rather than one bundled change. **Parallelism is the default, not the exception** — independent fixers are dispatched in one message with multiple Agent tool calls so they fan out via run_in_background. Captures the field-tested orchestration pattern (brief writing → issue-fixer dispatch into isolated worktrees → codex-rescue review for >300-LOC specialized work or direct orchestrator review for mid-size → squash-merge with structured notes) that has landed 15+ PRs per session with zero regressions on the Agent Bridge repo. Bundles a project-agnostic `issue-fixer` agent and a `general-purpose` fallback dispatch shape so the workflow is portable across Claude Code installs. Includes a catalog of 8 high-cost footguns the orchestrator should never re-trip.
+description: End-to-end wave workflow for shipping multi-PR change sets through an integration branch with codex pair-review at every gate. Five phases — plan + codex plan-agreement → dispatch parallel fixers (each fixer runs its own codex self-review inside its worktree) → orchestrator-led PR-by-PR pair-review onto an integration branch (NOT main) → integration branch full review + QA → operator-cued release with tag and changelog. Use whenever the user has 2+ open issues/PRs to process in parallel, mentions "wave", "Track A/B/C/D", "parallel fixer", "ship these issues", "integration branch", "wave plan", "release wave", asks to dispatch issue-fix agents, wants codex pair-review on a complex PR, describes a backlog they want batched into focused PRs, or any multi-PR change set that should not be squash-merged straight to main without an integration burn-in. **Parallelism + pair-review are the defaults, not the exceptions** — independent fixers dispatch in one message with multiple Agent tool calls and run_in_background, and every non-trivial agreement gate uses the 5-round convergence protocol (3-round soft-agreement nudge → 5-round operator escalation). Captures the field-tested orchestration pattern that has landed 15+ PRs per session on Agent Bridge with zero regressions, plus the operator's 2026-05-19 workflow refinement: integration-branch lifecycle, dependency-graph merge order, QA gate, and explicit release-cue.
 ---
 
-# Wave orchestration — parallel issue/PR ships
+# Wave orchestration — plan → fixer → integration → QA → release
 
 ## When to use this skill
 
 Use when:
-- You have **2+ independent issues** open and the user wants them processed in parallel
+- **2+ independent issues** open and the user wants them processed in parallel
 - An issue is split into **Tracks A/B/C/D** and each track is potentially its own PR
-- A PR is **>300 LOC + specialized domain** (Linux ACL, daemon scheduler, security primitives, etc.) and needs codex review for a second opinion
+- A change set is **large enough to need an integration branch** rather than landing directly on `main`
+- A PR is **>300 LOC + specialized domain** (Linux ACL, daemon scheduler, security primitives, etc.) and needs codex pair-review
 - A PR sits on a **third-party fork** (different `gh` user) and you need to push fix commits to that branch from your own session
-- The user says "process the backlog", "ship these issues", "dispatch fixers", "wave 1/2/3", "Track A of #N", "needs-more on PR #N", or describes a set of GitHub issues they want batched without bundling into one mega-PR
+- The user says "process the backlog", "ship these issues", "dispatch fixers", "wave 1/2/3", "Track A of #N", "needs-more on PR #N", "release wave", or "integration branch"
 
 Do NOT use when:
 - A single small one-off bug fix → just edit and PR directly
@@ -20,336 +21,376 @@ Do NOT use when:
 - Refactor with >5 file moves and ambiguous scope → write a plan first, get user signoff, *then* maybe dispatch
 - The work fits comfortably in 50 LOC and the user is online to review interactively
 
-## Why this pattern exists
+## Five-phase shape
 
-Sequential long-lived reviewer agents (one Codex session that reviews every PR back-to-back) accumulate ~3 review rounds per PR and ~150 minutes per 5 PRs. Replacing that with **wave-sized ephemeral fixers + targeted codex-rescue review** drops to ~25 minutes per wave with zero regressions across waves. The win is that each wave is small enough to land r1 `implement-ok` 90%+ of the time, and parallel dispatch hides the per-fixer wall time behind whatever the orchestrator is doing next.
+```
+Phase 1 — Plan + codex plan-agreement
+  └─ orchestrator writes plan; pair-reviewer agrees via 5-round convergence
 
-## Core pattern
+Phase 2 — Integration branch + parallel fixer dispatch
+  └─ orchestrator forks main → integration branch
+  └─ fixers worktree off integration branch, run in parallel
 
-```dot
-digraph wave {
-  read_issue [shape=box label="1. Read issue thoroughly\n  - gh issue view\n  - identify Tracks\n  - find files via grep, not the issue body"];
-  write_brief [shape=box label="2. Write brief at /tmp/<topic>-fixer.md\n  - 11 sections (see references/brief-template.md)\n  - include footgun callouts"];
-  dispatch [shape=box label="3. Dispatch fixer\n  - subagent_type: upstream-issue-fixer\n  - isolation: worktree\n  - run_in_background: true"];
-  decide_review [shape=diamond label="PR size?"];
-  codex_review [shape=box label="codex-rescue review\n(big or specialized)"];
-  direct_review [shape=box label="orchestrator-direct review\n(mid-size, ~45-400 LOC)"];
-  squash [shape=box label="4. Squash merge\n  - implement-ok note\n  - cleanup branch + worktree"];
-  comment [shape=box label="5. Comment on issue + close if all tracks done"];
+Phase 3 — Per-fixer self-review (codex subagent inside worktree)
+  └─ each fixer runs internal codex review until agreement, then opens PR
 
-  read_issue -> write_brief -> dispatch -> decide_review;
-  decide_review -> codex_review [label=">300 LOC + specialized"];
-  decide_review -> direct_review [label="mid-size"];
-  codex_review -> squash;
-  direct_review -> squash;
-  squash -> comment;
-}
+Phase 4 — Orchestrator-led PR merge onto integration branch
+  └─ PRs merged in dependency-graph order (least dependent first)
+  └─ pair-review at every merge; orchestrator cleans up worktrees post-merge
+
+Phase 5 — Integration review + QA + operator-cued release
+  └─ pair-reviewer does full-branch review
+  └─ QA gate (failures → re-dispatch fixer, not cherry-revert)
+  └─ operator-explicit-go → merge to main, bump VERSION/CHANGELOG, tag, GitHub release
 ```
 
-## Step 1 — Read the issue thoroughly
+The five phases are sequential at the wave level. **Within Phase 2-4 the fixers and per-PR reviews run in parallel** — that's where the wall-clock win comes from.
+
+---
+
+## Phase 1 — Plan + codex plan-agreement
+
+Write a plan document at `/tmp/<wave-id>-plan.md` that describes:
+
+- **Scope** — issues / tracks in this wave (cite `#N` + track letter)
+- **Integration branch name** — `feat/wave-<id>-integration` for feature waves, `release/v<X.Y.Z>-integration` for release waves
+- **Per-fixer track plan** — one section per fixer with its scope, files-to-touch, expected PR base (the integration branch, not main), and dependency relationship to other fixers in the same wave
+- **Dependency graph** — explicit ordering for Phase 4 merge (least-dependent fixer first)
+- **Out-of-scope** — anything explicitly *not* in this wave so the codex reviewer doesn't push for it
+- **Verification + QA approach** — what `/qa` (or equivalent) actually exercises, and what counts as "pass"
+
+Then queue the plan to the project's **long-lived pair-reviewer codex** for a plan-level review (NOT a code review). The reviewer for plan-level work is the same long-lived codex pair the project's `AGENTS.md` / `CLAUDE.md` designates for code review (e.g., `agb-dev-codex` on Agent Bridge — verify via `bash bridge-start.sh --list` because some installs lack the `-2` suffix the docs sometimes assume).
+
+Plan brief shape:
 
 ```bash
-gh issue view <N> --json title,body --jq '"# \(.title)\n\n\(.body)"'
+bash bridge-task.sh create --from <orchestrator-agent> --to <pair-reviewer-agent> \
+  --title "[Wave <id> plan review] <one-line scope>" --body-file /tmp/<wave-id>-plan.md
 ```
 
-Identify:
-- **Track structure** (A/B/C/D? landing in one PR or split into multiple waves?)
-- **Concrete files to touch** — verify by grepping the actual repo (`find` / `rg`); the issue body sometimes refers to files that don't exist or have moved
-- **Out-of-scope items** the brief must explicitly forbid (over-scoping is the #1 reason r2 review rounds happen)
-- **File overlap with other open PRs** — if two waves would both touch `lib/foo.sh`, serialize them
+Apply the **convergence protocol** (see "Convergence protocol" section below) until plan agreement is reached. **Do not start Phase 2 without it** — Phase 2 dispatches parallel fixers, and a plan disagreement caught at Phase 1 is 10× cheaper than the same disagreement caught after 4 PRs are open.
 
-Don't skip this step. A brief written from a misread issue wastes the entire fixer dispatch.
+---
 
-## Step 2 — Write the brief
+## Phase 2 — Integration branch + parallel fixer dispatch
 
-Briefs go to `/tmp/<topic>-fixer.md` and run ~150-300 lines. The full template is in `references/brief-template.md`. Required sections in order:
-
-1. Repo / branch / scope
-2. Read first (do not skip)
-3. What to change (per-file recipe)
-4. Out of scope (do NOT do)
-5. Verification (exact bash commands the fixer must run)
-6. CI status (note pre-existing failures so the fixer doesn't waste time on them)
-7. PR opening (title, body shape, auth switch, `--no-maintainer-edit`)
-8. CRITICAL — close-keyword footgun warning (see `references/footguns.md`)
-9. Stop point (where to halt, what to return)
-10. Reminders (worktree-relative paths, single commit, no VERSION/CHANGELOG)
-11. Output (JSON schema)
-
-The brief is the contract. Vague briefs produce r2 rounds. Concrete briefs land r1.
-
-## Step 3 — Dispatch the fixer
-
-This skill bundles a project-agnostic `issue-fixer` agent at `agents/issue-fixer.md`. It is **not auto-installed** — Claude Code does not pick up skill-bundled agents into the main `Agent` tool's `subagent_type` field by default.
-
-### Install the bundled agent (one-time)
+### Create the integration branch (orchestrator only)
 
 ```bash
-# user-level install — available across all your Claude Code sessions
-mkdir -p ~/.claude/agents
-cp ~/.claude/skills/wave-orchestration/agents/issue-fixer.md ~/.claude/agents/issue-fixer.md
+git checkout main
+git pull --ff-only origin main
+git checkout -b <integration-branch-name>   # from the plan
+git push -u origin <integration-branch-name>
 ```
 
-After this, `subagent_type: "issue-fixer"` is available.
+The integration branch is owned by the orchestrator (this main session). Fixers never create or modify the branch itself — they branch off it for their fixer branches and PR back to it.
 
-### Dispatch (preferred — when the bundled agent is installed)
+### Write briefs (one per fixer)
 
-```javascript
-Agent({
-  description: "Wave N: <issue> Track <X>",
-  subagent_type: "issue-fixer",
-  prompt: <self-contained-prompt-pointing-at-brief-file>,
-  isolation: "worktree",
-  run_in_background: true
-})
-```
+Briefs go to `/tmp/<wave-id>-<fixer-slug>-fixer.md` and follow `references/brief-template.md`. **Required additions for this skill's workflow** (on top of the existing template):
 
-### Fallback dispatch (when the bundled agent is NOT installed)
-
-`general-purpose` works as a substitute when paired with a sufficiently detailed brief. The brief must do more lifting because `general-purpose` has no built-in single-issue contract:
-
-```javascript
-Agent({
-  description: "Wave N: <issue> Track <X>",
-  subagent_type: "general-purpose",
-  prompt: `You are dispatched as a single-issue fixer. Read the brief in full first: /tmp/<topic>-fixer.md
-The brief specifies: repo, issue number, branch, files to edit, verification matrix, JSON return schema, footgun callouts.
-Work autonomously per the brief. Stop at commit (or PR open per brief). Return the JSON schema the brief specifies.
-
-Critical conventions the brief reinforces:
-- Worktree-relative paths only (never absolute paths into operator's primary checkout)
-- Smallest focused edit; don't refactor adjacent code
-- Don't write \`closes #<N>\` in commit subject or PR title — GitHub's close-keyword regex is greedy
-- Single commit, no VERSION/CHANGELOG bump unless the brief explicitly asks
-- Verify before committing per the brief's matrix; failed verification → don't commit, return failure with evidence`,
-  isolation: "worktree",
-  run_in_background: true
-})
-```
-
-Either way, critical flags:
-- `isolation: "worktree"` — fixer runs in an isolated git worktree at `<repo>/.claude/worktrees/agent-<hash>/`. Without this, the fixer can mutate your primary checkout. **This is footgun #1.**
-- `run_in_background: true` — main session continues while fixer works; you get a notification on completion. Do not block.
-- The `prompt` field is a **brief overview**, not the brief itself. Refer to `/tmp/<topic>-fixer.md`. Keep dispatch prompts under 50 lines.
-
-### Project-specific fixer (when you have one)
-
-Some repos ship their own specialized fixer (e.g., Agent Bridge has `upstream-issue-fixer` with hardcoded `BRIDGE_HOME` / smoke conventions). When operating on a repo with a specialized fixer, use that instead — it has built-in awareness of the project's verification matrix and won't need the brief to spell out as much. The bundled `issue-fixer` is the **portable default** for repos without a dedicated agent.
-
-## Step 4 — Review
-
-### Reviewer selection — DEFAULT IS codex-rescue PAIR-REVIEW
-
-**Pair-review every non-trivial PR.** Default reviewer is `codex-rescue` (or whichever pair-reviewer the project's `AGENTS.md` / contributing docs designate, e.g., `agb-dev-codex-2` on Agent Bridge). Merge **only after** the reviewer's note opens with `implement-ok`. This is the project-level rule on most repos that ship an `AGENTS.md`; it overrides the orchestrator's preference.
-
-| PR size / scenario | Reviewer | Notes |
-|---|---|---|
-| Any non-trivial PR (>~10 LOC, any domain) | **codex-rescue** | Default. Always pair-review unless project docs explicitly authorize direct review. |
-| Trivial mechanical revert / typo fix / single-line doc change | direct OK | Operator can usually verify by eye; codex-rescue overhead is wasted. State the rationale in the merge note. |
-| Operator explicitly orders direct review for this PR | direct | Annotate the merge note with "operator-directed direct review" and the reason. |
-| author = fork | post review as PR comment, then iterate via author or push fixes from fork account | Cross-fork PRs use the same pair-review contract. |
-
-**Why the rule is `codex-rescue first`**:
-1. Most projects with multi-agent contributors (the kind of repo this skill targets) have an `AGENTS.md` rule like "Pair-review every non-trivial PR. Merge only after implement-ok." That rule **overrides** the orchestrator's "direct review for <300 LOC mid-size" instinct.
-2. Direct review by the orchestrator is high-trust but single-actor. Pair-review with codex-rescue catches semantic bugs (missing reschedule, leaked secrets, broken finalize paths) that orchestrator review under context pressure misses.
-3. Operator-directed reverts of "merged without pair-review" PRs cost more time than the pair-review would have. Real instance: 2026-04-26 — three PRs reverted because the orchestrator skipped codex review citing the (then-existing) <300 LOC carve-out. Don't be that orchestrator.
-
-**Do not invent carve-outs**. If you find yourself rationalizing "this is small enough to skip review", check the project's `AGENTS.md` first. If the rule says "every non-trivial PR", skip is allowed only for the trivial-mechanical category in the table above.
-
-### codex-rescue dispatch — must include the wait-for-completion line
-
-```javascript
-Agent({
-  description: "Codex review of <PR>",
-  subagent_type: "codex:codex-rescue",
-  prompt: `... brief + diff path + PR body + checklist ...
-
-Wait for completion in your final assistant message. Do not return a thread id and exit.`,
-  run_in_background: true
-})
-```
-
-If you omit "Wait for completion in your final assistant message", codex-rescue is async-default and returns an empty thread id, which is useless. **This is footgun #8 — every other dispatch hits it.**
-
-Before dispatching codex-rescue, verify codex is set up:
-
-```bash
-codex --version 2>/dev/null && command -v codex   # confirm codex CLI is installed and on PATH
-```
-
-If `codex` is not on the agent's PATH (homebrew installs to `/opt/homebrew/bin` on macOS, `/usr/local/bin` on Linux), the fixer may incorrectly report "Codex CLI is not installed" — re-dispatch with explicit `PATH` guidance, or invoke codex directly via its absolute path.
-
-### Direct review for mid-size PRs
-
-```bash
-gh pr diff <N>
-```
-
-Verify:
-- Every brief acceptance criterion is met
-- No unintended files were touched (worktree path footgun)
-- VERSION/CHANGELOG untouched (release contract)
-- Verification commands in the brief actually pass
-
-If satisfied, squash merge with a structured note (see Step 5).
-
-### Pair-review loop for `needs-more`
-
-If the reviewer returns `needs-more: ...`:
-1. Post the review verbatim as a PR comment.
-2. Write `/tmp/<topic>-r2-fixer.md` listing each finding with **file:line** citation and a concrete fix recipe — do not paraphrase.
-3. Dispatch a fresh fixer (not the same one) with the r2 brief.
-4. After 3 rounds without `implement-ok`, **stop and reconsider scope**. Often the PR is too big or the spec is ambiguous; split it.
-
-## Step 5 — Squash merge with structured note
-
-```bash
-gh pr merge <N> --squash --body "$(cat <<'EOF'
-implement-ok
-
-<reviewer-context: direct or codex-rescue>
-
-Verified:
-- <acceptance criterion 1>
-- <acceptance criterion 2>
-- ...
-- No VERSION bump, no CHANGELOG entry — release contract preserved
-- Single commit, <N> file(s)
-- PR title uses '(#<N> Track X)' — close-keyword footgun avoided
-
-<issue-stays-open-or-closes context>
-
-Approved.
-EOF
-)"
-```
-
-The `implement-ok` opener is the convention — reviewer agents and human reviewers both grep for it. Always start with that literal string.
-
-After merge:
-
-```bash
-git -C <repo> pull --ff-only origin main
-git -C <repo> worktree remove -f -f <repo>/.claude/worktrees/agent-<hash>
-gh api -X DELETE /repos/<owner>/<repo>/git/refs/heads/<branch>
-```
-
-`gh pr merge --delete-branch` fails when local main is checked out in a worktree (`fatal: 'main' is already used by worktree`). Skip the `--delete-branch` flag and use the `gh api` call to delete the remote ref directly.
-
-## Step 6 — Comment on the issue
-
-If the PR closes the issue, GitHub auto-closes via the `closes #N` keyword (see footgun #2 — be careful). Otherwise, comment on the issue summarizing what landed and which tracks remain:
-
-```bash
-gh issue comment <N> --body "Track X landed in PR #<M> (\`<short-sha>\`).
-
-<one-paragraph what-changed>
-
-Tracks Y, Z remain open. Closing once those are addressed or explicitly deferred."
-```
-
-When all tracks land:
-
-```bash
-gh issue close <N> --comment "All tracks landed. ..."
-```
-
-## Footgun catalog
-
-8 footguns have all bitten me. Each has cost a session's worth of recovery. **Read `references/footguns.md` before dispatching; have it open while reviewing PRs.**
-
-Quick summary:
-1. Worktree path leakage (absolute paths in brief)
-2. GitHub close-keyword regex (`closes #283 Track B` → closes #283)
-3. `gh auth` account mismatch (cross-fork PR fails on wrong account)
-4. VERSION/CHANGELOG bleeding into feature PRs
-5. macOS Bash 3.2 vs Bash 4+ (`source bridge-lib.sh` vs `source ./bridge-lib.sh`)
-6. Committed source vs heredoc-generated content (brief targets wrong file)
-7. Cross-fork PR push from fork account (not new branch)
-8. codex-rescue async-default (missing wait-for-completion line)
-
-## Wave size — parallelism is the default, not the exception
-
-**Always parallelize independent fixers.** A single sequential fixer chain is a wasted hour every time. The default mental model: scan the open backlog, identify which items have non-overlapping file surfaces, write a brief per item, and dispatch them all in **one message with multiple Agent tool calls** (the tool runtime fans out only when the calls are in the same response — sequential dispatch in successive turns serializes them).
-
-### Sizing rules
-
-- **Sweet spot: 2-4 fixers per wave.** Each fixer is in its own `isolation: "worktree"`, so no shared state. Larger waves (5+) hit your own context-budget pressure when reviewing returns; if you have more independent work than that, dispatch the second batch as soon as the first batch's reviews start landing.
-- **Same-file conflicts force serial execution.** Before dispatching, list each fixer's expected file touches and check for overlaps. Two fixers writing to the same `lib/foo.sh` will both succeed individually but the second-merging PR has to rebase. Acceptable for unrelated functions in a long file (just rebase at merge); not acceptable for the same function or block.
-- **One brief per fixer at `/tmp/<topic>-fixer.md`.** Briefs are written and saved before any dispatch. The dispatch prompt is a 30-50 line overview pointing at the brief; the fixer reads the brief on first turn.
+- **PR base** — explicit `--base <integration-branch-name>`, **not** `main`. Spell this out in the brief's "PR opening" section.
+- **Internal codex review contract** — the fixer must run codex review on its own diff *before* opening the PR, and apply the convergence protocol. Brief says: "Open the PR only when your internal codex review returns `implement-ok`. If you hit the round cap, return the disagreement summary instead of opening the PR — orchestrator decides escalation."
+- **Worktree path discipline** — relative paths only from worktree root. Footgun #1 callout.
+- **No VERSION/CHANGELOG bump** — those are batched in Phase 5 by the orchestrator.
 
 ### Dispatch idiom (ONE message, multiple Agent calls)
 
 ```javascript
-// All three of these go in a SINGLE assistant turn.
-// Sending them across three separate turns would serialize them.
-Agent({ description: "Wave: #A", subagent_type: "issue-fixer", prompt: <points-at-/tmp/A-fixer.md>, isolation: "worktree", run_in_background: true })
-Agent({ description: "Wave: #B", subagent_type: "issue-fixer", prompt: <points-at-/tmp/B-fixer.md>, isolation: "worktree", run_in_background: true })
-Agent({ description: "Wave: #C", subagent_type: "issue-fixer", prompt: <points-at-/tmp/C-fixer.md>, isolation: "worktree", run_in_background: true })
+// All in a SINGLE assistant turn — sending across multiple turns serializes them.
+Agent({ description: "Wave N — fixer A", subagent_type: "issue-fixer",
+        prompt: <points at /tmp/wave-N-A-fixer.md>,
+        isolation: "worktree", run_in_background: true })
+Agent({ description: "Wave N — fixer B", subagent_type: "issue-fixer",
+        prompt: <points at /tmp/wave-N-B-fixer.md>,
+        isolation: "worktree", run_in_background: true })
+Agent({ description: "Wave N — fixer C", subagent_type: "issue-fixer",
+        prompt: <points at /tmp/wave-N-C-fixer.md>,
+        isolation: "worktree", run_in_background: true })
 ```
 
-The orchestrator can also have a fixer running while it dispatches *new* fixers in subsequent turns — the parallelism comes from `run_in_background: true`, not from same-message dispatch alone. But same-message dispatch is the cleanest signal of intent and avoids accidental serialization when you're triaging multiple briefs at once.
+If `issue-fixer` is not installed on this host, the fallback is `subagent_type: "general-purpose"` with a brief that does more lifting — see "Bundled agent" at the bottom.
 
-### What's safe to parallelize
+### Conflict avoidance before dispatch
 
-| Scenario | Parallel? | Notes |
-|---|---|---|
-| Two fixers touching wholly disjoint files | yes | The default safe case |
-| Two fixers touching different functions in the same file | yes | Worktree isolation handles it; merge order may need rebase |
-| Two fixers touching the same function | no | Serialize; the second waits for the first to merge so its base is current |
-| Docs PR + code PR in the same area | yes | Different surfaces; review independently |
-| Fixer + codex-rescue review of an existing PR | yes | Different actors; codex review doesn't write to the worktree |
-| 3+ fixers all touching `lib/bridge-core.sh` | partial | Fan out 2 max with the explicit acknowledgement that the third will rebase; consider whether some can be combined into one fixer |
+| Two fixers touch... | Parallel? |
+|---|---|
+| Wholly disjoint files | yes |
+| Different functions in the same file | yes (merge order may need rebase) |
+| Same function | **no — serialize** |
+| Docs + code in same area | yes |
+| 3+ fixers all touching `lib/bridge-core.sh` | partial — fan out 2 max, third rebases |
 
-### Backlog scan pattern
+Sweet spot: **2-4 fixers per wave.** Larger waves hit your own context-budget pressure when reviews start landing.
 
-When the user says "process the backlog" or "do the next wave":
+---
 
-1. `gh issue list --state open --limit 30` and `gh pr list --state open --limit 10`
-2. Triage by **scope** (small/mid/large) and **surface** (which files each touches)
-3. Bucket into waves — pack 2-4 small/mid items with disjoint surfaces into the next wave
-4. Defer any item that requires user input (design discussion, breaking-change confirmation, brainstorm)
-5. Defer any item that requires a reproducer the host can't run (e.g., `linux-user` isolation tests on macOS)
-6. Write all briefs first, then **dispatch the whole batch in one message**
+## Phase 3 — Per-fixer self-review (inside the worktree)
 
-### After a wave
+This is the key change vs the old skill: fixers run their **own** codex review inside the worktree before opening the PR. The orchestrator's pair-review in Phase 4 then has less to do, and r2-round bounce-back is dramatically reduced.
 
-- Pause to: verify all PRs landed, run cross-PR regression checks if any pair touched related areas
-- Order squash-merges if there are file-overlap conflicts (smaller / earlier-completing PR first; the second rebases against current main)
-- Update memory if patterns shifted (new footgun, new tooling, new naming convention)
+The fixer brief instructs the fixer to:
+
+1. Apply the edit, run the verification matrix from the brief.
+2. Stage the diff.
+3. Spawn `codex:codex-rescue` subagent with a code-review brief that includes the staged diff + acceptance criteria.
+4. Apply the **convergence protocol** inside the worktree (same 5-round cap, same 3-round soft-agreement nudge, same operator-escalation cliff). If the operator-escalation cliff hits, the fixer **does not open the PR** — it returns the disagreement summary to the orchestrator and the orchestrator decides whether to escalate to the user.
+5. On agreement (`implement-ok`), commit, push, open PR with `--base <integration-branch-name>`, return the PR number to the orchestrator.
+
+The fixer's internal codex is a **fresh ephemeral subagent** scoped to that fixer's diff only. It is distinct from the long-lived pair-reviewer used in Phases 1, 4, 5.
+
+When a fixer's internal codex review must wait for the subagent to actually complete, the brief MUST include the line "Wait for completion in your final assistant message. Do not return a thread id and exit." — see footgun #8 in `references/footguns.md`. Every other dispatch hits this.
+
+---
+
+## Phase 3.5 — Monitor dispatched fixers (wedge detection + recovery)
+
+**Operator directive (2026-06-03): never leave a long-running fixer unattended. Check on it; don't waste time letting a dead one go stale.** Background fixers fail silently — the single most common failure is a fixer **wedging on its internal `codex:codex-rescue` review** (it blocks waiting on the subagent for 1-2+ hours — the fixer-internal-codex-wedge pattern, confirmed repeatedly). A wedged fixer produces no PR and no notification; if you don't check, you burn hours.
+
+### Monitor cadence
+After dispatching background fixers, set a wall-clock expectation per fixer (a normal scoped fix opens a PR within ~20-30 min incl. the internal review; a deep/security fix longer). If a fixer hasn't reported a PR by its budget, **check it** — do NOT wait indefinitely. Cheap, context-safe signals (NEVER tail the JSONL transcript — it overflows your context):
+
+- `gh pr list` — did it open a PR?
+- `git ls-remote origin 'refs/heads/<fixer-branch>'` — did it push a branch?
+- `git -C .claude/worktrees/agent-<id> log --oneline -3` — any commits in its worktree?
+- `stat -f '%Sm (%z bytes)' <output-file>` — output-file **mtime** + size (activity proxy).
+
+### Wedge signal
+Output-file mtime stale (no change for ~15+ min) **AND** no commits **AND** no PR/branch = wedged (almost always parked on the internal codex-rescue call). A tiny output file (~100-200 bytes) that hasn't grown confirms it barely started.
+
+### Recovery — and the non-negotiable review rule
+1. **Re-engage** (preferred when work exists): `SendMessage` to the fixer's `agentId` telling it to finalize + push (and, if the internal review is the blocker on a small/clear diff, to skip it and let the orchestrator's Phase-4 pair-review be the gate). Re-engaging preserves its worktree + context.
+2. **Kill + take over** (when it barely started / the change is trivial, < ~50 LOC): `TaskStop` the agent, then do the edit yourself in a **dedicated temp worktree** (`git worktree add -b <branch> /tmp/<slug> origin/main`) — never in the operator's primary checkout.
+3. **CRITICAL — taking over does NOT skip review (operator directive 2026-06-03).** When a fixer wedges on its *internal* codex review and you finish the work yourself, the PR has now had **zero** codex review. You MUST still queue the **`agb-dev-codex` Phase-4 pair-review** (Phase 4 below) and merge ONLY on `implement-ok`. The wedged internal review was the fixer's self-check; the Phase-4 pair-review is the real merge gate and is mandatory for EVERY PR — a taken-over PR is not an exception. Never push-and-merge a wedge-recovery PR on your own say-so.
+
+See memory `feedback_fixer_internal_codex_review_wedge`.
+
+---
+
+## Phase 4 — Orchestrator PR-by-PR merge onto integration branch
+
+When fixer PRs start landing (notifications via background dispatch), the orchestrator processes them **one at a time in dependency-graph order** (least-dependent first — the plan's dependency graph is authoritative).
+
+For each PR:
+
+1. **Pair-review** with the long-lived codex pair (same one used for the plan). This is on top of the fixer's internal review — internal review checks the diff in isolation, this review checks fit with the integration branch + cross-fixer surface.
+2. Apply the **convergence protocol** as usual.
+3. On `implement-ok`, **squash-merge to the integration branch (NOT main)**:
+   ```bash
+   gh pr merge <N> --squash --body "$(cat <<'EOF'
+   implement-ok
+
+   <reviewer-context: codex pair-review round N>
+
+   Verified:
+   - <acceptance criterion 1>
+   - ...
+   - Single commit, <N> file(s)
+   - Merged to <integration-branch>, not main
+
+   Approved.
+   EOF
+   )"
+   ```
+4. **Clean up the fixer's worktree and remote branch** immediately after merge:
+   ```bash
+   git -C <repo> worktree remove -f -f <repo>/.claude/worktrees/agent-<hash>
+   gh api -X DELETE /repos/<owner>/<repo>/git/refs/heads/<fixer-branch>
+   ```
+   The orchestrator is the **sole accountable owner** for cleanup. Worktrees that survive past their PR merge accumulate as stale state (`.claude/worktrees/` regularly hits 60+ entries on a busy install). Sweep at the end of every wave: `find <repo>/.claude/worktrees -maxdepth 1 -type d` and reconcile against open PRs.
+5. **Rebase the integration branch on `origin/main`** periodically if the wave runs long. Stale integration branches that haven't pulled main in days are a merge-conflict trap when Phase 5 fires.
+
+If the convergence protocol hits the operator-escalation cliff on a PR review, do not silently keep waiting — escalate to the user with the disagreement summary so they can decide direction.
+
+---
+
+## Phase 5 — Integration review + QA + operator-cued release
+
+When all wave PRs have merged to the integration branch:
+
+### 5a. Full-branch codex review
+
+Queue a final review brief to the long-lived pair-reviewer scoped to the integration branch as a whole:
+
+```bash
+bash bridge-task.sh create --from <orchestrator-agent> --to <pair-reviewer-agent> \
+  --title "[Wave <id> integration review] <branch>" \
+  --body-file /tmp/<wave-id>-integration-review.md
+```
+
+Brief should include: full `git log main..<integration-branch>`, cumulative diff stat, surface that wasn't reviewed per-PR (e.g., docs cross-file consistency, naming convergence across multiple PRs), and any cross-PR regression that would only show up against the integration HEAD.
+
+Apply convergence protocol.
+
+### 5b. QA gate
+
+Check whether `/qa` (or the project's equivalent) is invocable standalone in this environment:
+
+- **If yes**: run it against the integration branch. `/qa` from the `gstack` framework can be invoked directly if the host has it installed.
+- **If no**: write a project-local QA runner derived from `/qa`'s contract (navigate the live build, exercise critical user flows, check for regressions in adjacent features). Land that runner in the project under `scripts/qa/` or similar so future waves can reuse it.
+
+QA pass = ship. QA fail = re-dispatch the fixer responsible for the failing surface and re-merge after their fix lands.
+
+**Why re-dispatch, not cherry-revert** (operator directive 2026-05-19): cherry-revert leaves the user-facing bug shipped + the wave goal unmet. Re-dispatch the same fixer if its worktree is still alive (`.claude/worktrees/agent-<hash>` exists); otherwise spawn a fresh fixer with a brief that includes the QA failure repro. Re-merge through the same Phase 4 PR gate. Cherry-revert is the last-resort fallback only when the bug cannot be fixed in the wave's wall-clock budget.
+
+### 5c. Operator-cued release
+
+Releases require **explicit operator go** every time. Standing autonomy on the wave does NOT extend to the release ship itself (durable rule, see your memory). Report the wave summary to the user:
+
+- Integration branch HEAD, PRs landed, QA result
+- Proposed version bump (semver: major / minor / patch / `-beta` / `-rc` — recommend based on change shape; user decides)
+- Proposed tag name + whether to mark as GitHub Pre-release
+
+Wait for the user's explicit go. On `go release`:
+
+1. Open a release PR `release/v<X.Y.Z>` that merges the integration branch into `main` and bumps `VERSION` + `CHANGELOG.md` in the same commit.
+2. Pair-review the release PR (same as Phase 4 — even release PRs need pair-review per the project's `AGENTS.md`).
+3. Squash-merge release PR.
+4. Tag on the merge commit: `git tag -a v<X.Y.Z> -m "<release title>"` then `git push origin v<X.Y.Z>`.
+5. GitHub release: `gh release create v<X.Y.Z> --title "v<X.Y.Z>" --notes "<CHANGELOG section>"` — add `--prerelease` for `-beta` / `-rc` tags.
+6. Delete the integration branch: `gh api -X DELETE /repos/<owner>/<repo>/git/refs/heads/<integration-branch>` (after confirming all commits are on main).
+7. Update memory if this wave shifted a pattern.
+
+---
+
+## Convergence protocol (applies to every agreement gate)
+
+Used at: Phase 1 (plan), Phase 3 (fixer-internal), Phase 4 (per-PR), Phase 5a (integration), Phase 5b (release PR).
+
+| Round | Action |
+|---|---|
+| 1 | Submit work → reviewer returns `implement-ok` or `needs-more: <list>` |
+| 2 | If `needs-more`: fix all items → re-submit |
+| 3 | If still `needs-more`: fix what you agree with, then **explicitly negotiate** with the reviewer for any remaining disagreement: "If the remaining items are not a major issue, let's land this and re-check in the next code review round." Submit the negotiation note as part of the r3 reply. |
+| 4 | Reviewer reads the negotiation note and either: (a) agrees with the soft-landing → `implement-ok`, or (b) BLOCKING with reasoning. If (b), fix what's now possible and re-submit. |
+| 5 | If still no `implement-ok`: **escalate to the user** with the disagreement summary. Do NOT proceed without the user's call. |
+
+**Why the 3-round nudge exists**: long convergence loops without a soft-landing valve are how PRs slip from a 90-minute cycle into a 4-hour cycle and end up reverted out of frustration. After round 3, both sides usually have a clear picture of what's blocking — give the reviewer the chance to soft-land non-major items and re-check in a later code review, instead of grinding through pedantic re-rounds.
+
+**The 5-round cliff is real**: do not raise it case-by-case. If you find yourself at round 5 with no agreement, the work is misscoped or the spec is ambiguous. Operator decides which direction to take next.
+
+**Autonomy default**: between rounds 1-4 the orchestrator runs autonomously (no user questions). User is only pulled in at round 5 cliff, or if the reviewer surfaces something genuinely ambiguous that needs a product call (not a technical call).
+
+---
+
+## Codex role split — long-lived pair vs ephemeral fixer-internal
+
+Two distinct codex agents play different roles in a wave. **Never conflate them.**
+
+| Role | Identity | Scope | Used in |
+|---|---|---|---|
+| **Long-lived pair-reviewer** | The project's designated pair-reviewer (e.g., `agb-dev-codex` on Agent Bridge). Verify name with `bash bridge-start.sh --list`. | Stable context across the entire wave + multiple waves. Reviews plans, per-PR diffs against integration branch, full-branch reviews, release PRs. | Phases 1, 4, 5a, 5b release PR |
+| **Ephemeral fixer-internal codex** | Fresh `codex:codex-rescue` subagent spawned inside each fixer's worktree. New instance per fixer. | Scoped to that fixer's diff only. No memory of other fixers in the wave. | Phase 3 |
+
+The split matters because:
+- Long-lived pair sees the **whole wave context** — catches cross-PR regression, surface drift, naming inconsistency.
+- Ephemeral fixer-internal sees the **diff in isolation** — catches local bugs, missing tests, semantic issues in that fixer's scope.
+- If both flag the same PR, the long-lived pair's note carries more weight on cross-cutting concerns; the fixer-internal's note carries more weight on local correctness.
+
+A `codex:codex-rescue` subagent dispatch MUST include "Wait for completion in your final assistant message. Do not return a thread id and exit." or it returns an empty thread id. Every other dispatch hits this. (Footgun #8.)
+
+---
+
+## Integration branch lifecycle (orchestrator responsibilities)
+
+The orchestrator is the **sole owner** of the integration branch. Concrete obligations:
+
+1. **Create** at Phase 2 start, from latest `origin/main`.
+2. **Push** immediately so fixer worktrees can branch off the same remote ref.
+3. **Rebase on `origin/main`** periodically during long waves (rule of thumb: if main has moved >10 commits since the integration branch's last rebase, rebase before the next PR merge — otherwise the PR's rebase will be ambiguous).
+4. **Merge fixer PRs in dependency-graph order** (Phase 4).
+5. **Sweep stale worktrees + remote branches** after each Phase 4 merge.
+6. **Final merge to main** at Phase 5c via release PR (NOT direct push or fast-forward — release PRs are pair-reviewed too).
+7. **Delete the integration branch** after release tag is pushed and all commits are confirmed on main.
+
+If the wave is canceled (operator stops the wave or QA fails irrecoverably), the integration branch is closed without merging to main. Delete it explicitly so it doesn't accumulate as stale state.
+
+---
+
+## Fixer worktree lifecycle (orchestrator-owned)
+
+The fixer creates the worktree (via `isolation: "worktree"` in the Agent dispatch). The **orchestrator** is responsible for cleaning it up:
+
+| Event | Cleanup action |
+|---|---|
+| Fixer PR merges (Phase 4) | Remove worktree + delete remote fixer branch |
+| QA fails + same fixer re-dispatched (Phase 5b) | Keep worktree alive; re-issue work to existing fixer if possible |
+| Wave canceled | Sweep all wave worktrees + remote branches |
+| End of wave (cleanup sweep) | `find <repo>/.claude/worktrees -maxdepth 1 -type d -mtime +7` → reconcile against open PRs; any worktree with no matching open PR is stale |
+
+If worktrees accumulate (the `.claude/worktrees/` directory regularly hits 60+ entries on a busy install), the issue is almost always orchestrator failing this cleanup step at Phase 4 merge time. Don't defer it — run it immediately after each squash-merge while you have the worktree path in mind.
+
+---
+
+## Dispatch idiom recap
+
+Same-message dispatch for parallelism:
+
+```javascript
+// Single assistant turn:
+Agent({ description: "Wave N — A", subagent_type: "issue-fixer", prompt: ..., isolation: "worktree", run_in_background: true })
+Agent({ description: "Wave N — B", subagent_type: "issue-fixer", prompt: ..., isolation: "worktree", run_in_background: true })
+Agent({ description: "Wave N — C", subagent_type: "issue-fixer", prompt: ..., isolation: "worktree", run_in_background: true })
+```
+
+Critical flags:
+- `isolation: "worktree"` — without this, the fixer mutates the operator's primary checkout (footgun #1).
+- `run_in_background: true` — main session continues while fixers work; notifications arrive on completion.
+- `prompt` is a 30-50 line overview pointing at `/tmp/<wave>-<fixer-slug>-fixer.md`; the brief lives in the file, not the prompt.
+
+---
+
+## Footgun catalog
+
+8 footguns from the original skill — all still apply. **Read `references/footguns.md` before dispatching; have it open while reviewing PRs.**
+
+1. Worktree path leakage (absolute paths in brief)
+2. GitHub close-keyword regex (`closes #283 Track B` → closes #283)
+3. `gh auth` account mismatch (cross-fork PR fails on wrong account)
+4. VERSION/CHANGELOG bleeding into feature PRs (Phase 5 owns the bump; fixers must NOT touch VERSION/CHANGELOG)
+5. macOS Bash 3.2 vs Bash 4+
+6. Committed source vs heredoc-generated content
+7. Cross-fork PR push from fork account (not new branch)
+8. codex-rescue async-default (missing wait-for-completion line)
+
+**New footguns specific to this workflow** (also written up in `references/footguns.md`; numbered to avoid collision with existing #9 parallelization and #10 pair-review-skip):
+11. PR opened with `--base main` instead of the integration branch — fixer brief must spell out `--base <integration-branch>` and the orchestrator must verify on each PR via `gh pr view <N> --json baseRefName`.
+12. Stale integration branch (main moved 20+ commits since last rebase) → merge conflicts at Phase 5 release PR. Orchestrator rebases periodically during long waves.
+13. Worktree accumulation (orchestrator forgot Phase 4 cleanup) → disk + `git worktree list` clutter. Sweep at end of every wave with `find <repo>/.claude/worktrees -maxdepth 1 -type d`.
+
+---
 
 ## Verification before completion (every PR)
 
 Don't claim "done" without:
+
 - `bash -n` on every touched `.sh` file
 - `shellcheck` on every touched `.sh` file (warnings OK; errors not OK)
 - `python3 -c "import ast; ast.parse(open('<file>').read())"` on every touched `.py` file
 - Live test of any new helper function via fresh bash + source `./bridge-lib.sh` (note the `./`)
 - `git diff --cached --stat` before commit — confirm only the intended files are staged
 - `gh pr diff <N>` after PR open — confirm fixer didn't touch unintended files (worktree path footgun)
+- `gh pr view <N> --json baseRefName` — confirm base is the integration branch, not `main` (new footgun #9)
+
+---
 
 ## Reference files
 
-- `references/brief-template.md` — fully worked brief template with section-by-section rationale
-- `references/footguns.md` — all 8 footguns with reproduction, root cause, and fix instructions
-- `references/recipes.md` — concrete recipes: cross-fork push, codex setup verification, worktree cleanup, releasing PR conventions
-- `references/wave-examples.md` — 4 worked waves from the Agent Bridge repo (#306 docs, #311 fixture cleanup, #313 generator, PR #302 r2)
+- `references/brief-template.md` — fully worked brief template (use for fixer briefs; extend with PR-base + internal-codex-review sections)
+- `references/footguns.md` — 8 original footguns + 3 new ones (#9-#11 from this workflow)
+- `references/recipes.md` — cross-fork push, codex setup verification, worktree cleanup, releasing PR conventions
+- `references/wave-examples.md` — worked waves from the Agent Bridge repo
+
+Read these on demand; the SKILL.md above is the orchestration spine and stays under ~500 lines on purpose.
 
 ## Bundled agent
 
-- `agents/issue-fixer.md` — project-agnostic single-issue fixer. **Not auto-installed.** Copy to `~/.claude/agents/issue-fixer.md` for user-level install, or to `<repo>/.claude/agents/issue-fixer.md` for repo-level install, to make `subagent_type: "issue-fixer"` available. Fall back to `general-purpose` per Step 3 above when neither install is present.
+- `agents/issue-fixer.md` — project-agnostic single-issue fixer. **Not auto-installed.** Copy to `~/.claude/agents/issue-fixer.md` (one-time setup) to make `subagent_type: "issue-fixer"` available:
+  ```bash
+  mkdir -p ~/.claude/agents
+  cp ~/.claude/skills/wave-orchestration/agents/issue-fixer.md ~/.claude/agents/issue-fixer.md
+  ```
 
-Agents created via `agent-bridge` (the Agent Bridge multi-agent orchestrator) inherit the repo's `.claude/skills/` and `.claude/agents/` automatically, so when this skill ships in the Agent Bridge upstream every dynamic / static agent picks it up on next bootstrap. No manual copy step required for those agents.
+  Or fall back to `general-purpose` with a more detailed brief that explicitly references the worktree-relative-paths rule, single-commit convention, no-VERSION/CHANGELOG rule, PR-base-must-be-integration-branch rule, and the JSON return schema the brief specifies.
 
-## Agent Bridge integration
-
-When the orchestrator is itself an Agent Bridge agent (claude or codex), there are two distinct dispatch surfaces:
-
-1. **Agent tool dispatch** (claude only) — what this skill describes throughout. `Agent({ subagent_type: "issue-fixer", isolation: "worktree", run_in_background: true })` spawns an ephemeral subagent in an isolated git worktree. Best for parallel waves of independent fixers.
-2. **Bridge queue dispatch** (claude + codex) — `bash bridge-task.sh create --from <self> --to <peer-agent> --title "..." --body-file /tmp/<topic>-fixer.md` enqueues work for a long-lived peer (e.g., the codex pair partner). Best for cross-engine collaboration where the queue's persistence + audit trail matter, and for codex agents that don't have the `Agent` tool.
-
-Both surfaces are compatible with the same brief format. The dispatching brief is the contract; the surface is just how the brief reaches the executor.
-
-For codex-rescue review specifically (Step 4), claude orchestrators use `Agent({ subagent_type: "codex:codex-rescue", run_in_background: true })`. Codex orchestrators delegate review to their claude pair via the bridge queue (`bridge-task.sh create --to <claude-pair> --title "[review PR #N]"`).
-
-Read these on demand; the SKILL.md above is the orchestration spine and should stay under 300 lines.
+Project-specific fixers (Agent Bridge's `upstream-issue-fixer`, etc.) take precedence over the bundled default when available — they have hardcoded project conventions and need less from the brief.

--- a/.claude/skills/wave-orchestration/references/brief-template.md
+++ b/.claude/skills/wave-orchestration/references/brief-template.md
@@ -242,25 +242,3 @@ The schema lives in `agents/_template/CLAUDE.md` line 54. Standard across waves.
 A working brief is **150-300 lines markdown**. Less = sketchy spec, fixer guesses; more = brief is doing the fixer's job and you should just write the code yourself.
 
 If your brief is approaching 400 lines, the work is too big for one wave. Split it.
-
-## When the work touches bash hot paths — name footgun #11 explicitly
-
-If the change involves writing bash that pipes bash-side data into a subprocess (`python3 - <<'PY'`), a `while read` loop (`<<<"$var"`), or any heredoc-stdin consumer, the brief MUST call out **footgun #11** (heredoc / here-string deadlock against a slow consumer) and require the fixer to route producer data through a tempfile (`mktemp + < file`) rather than heredoc.
-
-Concrete brief snippet to drop into section 10 (Reminders) when the work qualifies:
-
-```markdown
-- **Footgun #11 — heredoc / here-string deadlock**. If your edit pipes
-  multi-record bash data into a subprocess (`python3 - <<'PY' ... PY`),
-  a `while IFS= read -r ... <<<"$var"` loop, or any `cmd <<EOF ... EOF`
-  consumer, route via tempfile instead:
-
-      local tmp; tmp="$(mktemp)"; trap "rm -f '$tmp'" RETURN
-      printf '%s\n' "$data" > "$tmp"
-      while IFS= read -r line; do ...; done < "$tmp"
-
-  Threshold: anything over a single short value (SHA / path / flag).
-  See `references/footguns.md` Footgun 11 for the full root cause.
-```
-
-Don't paraphrase the footgun callout — paste the snippet verbatim into the brief. Fixers skim, and the verbatim recipe is what survives the skim.

--- a/.claude/skills/wave-orchestration/references/footguns.md
+++ b/.claude/skills/wave-orchestration/references/footguns.md
@@ -32,11 +32,11 @@ Each footgun below has cost a real session of recovery. Read this file before di
 
 **Symptom**: `gh pr create` fails with `failed to create pull request: GraphQL: createPullRequest: ... must have push access to the repository`. PR isn't created. Fixer blocks waiting for an owner to grant access.
 
-**Root cause**: Multiple `gh` accounts logged in (e.g., `seanssoh` for fork + `SYRS-AI` for upstream). Active account is the fork; the fork has READ permission on upstream, not write. `gh pr create` from the fork account fails to open a PR against upstream.
+**Root cause**: Multiple `gh` accounts logged in (e.g., `<fork-account>` for fork + `<upstream-account>` for upstream). Active account is the fork; the fork has READ permission on upstream, not write. `gh pr create` from the fork account fails to open a PR against upstream.
 
-**Fix**: Brief must include `gh auth switch --user SYRS-AI` (or whichever account has write) **before** any `gh pr create`. Verify via `gh auth status | head -10` showing the right account as Active.
+**Fix**: Brief must include `gh auth switch --user <upstream-account>` (or whichever account has write) **before** any `gh pr create`. Verify via `gh auth status | head -10` showing the right account as Active.
 
-For cross-fork PRs (PR head is `seanssoh:branch`, base is `SYRS-AI:main`), also pass `--no-maintainer-edit` to `gh pr create`. Without it, fork-to-upstream PRs from accounts that don't have collaborator edit access fail.
+For cross-fork PRs (PR head is `<fork-account>:branch`, base is `<upstream-account>:main`), also pass `--no-maintainer-edit` to `gh pr create`. Without it, fork-to-upstream PRs from accounts that don't have collaborator edit access fail.
 
 ## Footgun 4 — VERSION/CHANGELOG bleeding into feature PRs
 
@@ -88,7 +88,7 @@ Verify before claiming done that the function returns the expected output. If th
 
 ## Footgun 7 — Cross-fork PR push from fork account
 
-**Symptom**: A PR sits on someone else's fork (e.g., `seanssoh:fix/foo`). The original author can't iterate quickly. You want to push fix commits to that branch.
+**Symptom**: A PR sits on someone else's fork (e.g., `<fork-account>:fix/foo`). The original author can't iterate quickly. You want to push fix commits to that branch.
 
 **Workflow**:
 
@@ -137,26 +137,24 @@ That single line changes the dispatch from async to sync. The reviewer's full re
 Also: before dispatching, verify codex is set up:
 
 ```bash
-codex --version 2>/dev/null && command -v codex   # confirm codex CLI is installed and on PATH
+node "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs" setup --json
 ```
 
-If `codex` isn't on the agent's PATH (homebrew installs to `/opt/homebrew/bin` on macOS, `/usr/local/bin` on Linux, neither of which subagent shells always include), the agent reports "Codex CLI is not installed" even when the binary exists. **Re-probing alone is not always enough** — the codex-rescue runtime can still fail to invoke codex from its sandboxed shell. When this happens, re-dispatch with **explicit PATH guidance + absolute-path fallback** in the prompt:
+Look for `"ready": true`. If `codex` isn't on the agent's PATH (homebrew installs to `/opt/homebrew/bin`, which subagent shells may not include), the agent reports "Codex CLI is not installed" even when the binary exists. **Re-probing via the companion script alone is not always enough** — the codex-rescue runtime can still fail to invoke codex from its sandboxed shell. When this happens, re-dispatch with **explicit PATH guidance + absolute-path fallback** in the prompt:
 
 ```
 **Codex CLI is INSTALLED and READY on this machine.** Verified directly:
-$ command -v codex
-/opt/homebrew/bin/codex
-$ codex --version
-codex 1.x.x
+$ node "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs" setup --json
+{ "ready": true, "codex": { "available": true } ... }
 
 If your sandboxed shell reports "Codex CLI is not installed", the issue is the
-shell's PATH not picking up the package-manager bin directory. Retry with:
+shell's PATH not picking up `/opt/homebrew/bin/`. Retry the probe with:
 
-  PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" codex --version
+  PATH="/opt/homebrew/bin:$PATH" node ".../codex-companion.mjs" setup --json
 
-Or invoke codex directly via the absolute path the orchestrator captured
-above. Do NOT abort with "Codex CLI is not installed" if the orchestrator
-(me) confirmed codex is reachable. Proceed with the review.
+Or invoke codex directly via the absolute path `/opt/homebrew/bin/codex`. Do NOT
+abort with "Codex CLI is not installed" if the orchestrator (me) confirmed
+codex is reachable. Proceed with the review.
 ```
 
 This forceful guidance has worked when the simpler "re-probe via companion script" guidance failed. The codex-rescue agent will still try to invoke codex, but the explicit PATH override + the operator-affirmation lets it persist past the false-negative probe.
@@ -210,64 +208,41 @@ Otherwise: parallel.
 
 If a fixer trips footguns 1, 2, and 4 in the same PR, the PR (a) mutates the operator's primary checkout, (b) auto-closes the parent issue, and (c) bumps VERSION concurrent with an open release PR. Recovery is a manual revert + amend + reopen + comment + roster reset. Don't let this happen — every brief should explicitly call out all three. The cost of a 3-line footgun callout in the brief is much smaller than the cost of recovery.
 
-## Footgun 11 — Bash heredoc / here-string deadlock against a slow consumer
+## Footgun 11 — PR opened against `main` instead of the integration branch
 
-**Symptom**: A bash hot path that feeds bash-side data into a `while read` loop or `python3 - <<'PY'` subprocess via heredoc / here-string silently wedges with no output and no progress. `pstack` / `lldb` on the bash frame shows it stuck inside `heredoc_write → __wait4`. Sometimes never times out (the canonical #800 case was a 34h daemon hang). Sometimes only reproduces past a threshold input size (multi-record git porcelain, a few KB+).
+**Symptom**: Fixer opens a PR with `--base main` even though the wave plan said all PRs go through `feat/wave-N-integration`. PR shows the entire integration branch's history as "additions" against main, or the PR merge prematurely lands work on main before Phase 5 QA.
 
-**Root cause**: Bash heredoc / here-string plumbing puts the **producer** (bash writing the heredoc body) and the **consumer** (subprocess stdin or `while read` reader) on the same pipe pair. If the consumer blocks even briefly during processing (slow `python3` startup, slow line-by-line work) AND the producer's data exceeds the pipe buffer, both ends wedge. The producer waits for the consumer to drain; the consumer waits for the producer to finish; nothing breaks the deadlock.
+**Root cause**: `gh pr create` defaults to `--base main` (or the repo's default branch) if you don't pass `--base`. Fixers reading the brief sometimes skip the PR-opening section and run their muscle-memory `gh pr create` command.
 
-The bug class covers at least three syntactic variants — all share the same root:
+**Fix**:
+1. Brief's "PR opening" section MUST spell out the exact command including `--base <integration-branch-name>`. Don't make the fixer infer.
+2. After fixer returns the PR number, orchestrator verifies: `gh pr view <N> --json baseRefName --jq .baseRefName`. If wrong, retarget before review: `gh pr edit <N> --base <integration-branch-name>`.
+3. If the fixer already merged against main by accident (catastrophic): revert the squash commit immediately, then carry the diff forward into the integration branch via a fresh fixer.
 
-```bash
-# Variant A — heredoc into subprocess stdin (the #800 / PR #801 / PR #806 case):
-result="$(python3 - <<'PY'
-... multi-line python body ...
-PY
-)"
+**Real instance**: First-time bite expected on the rollout of the integration-branch workflow (2026-05-19 forward). Pre-empt it with brief discipline rather than waiting for recovery.
 
-# Variant B — here-string into `while read` loop (the 2026-05-13 worktree-doctor case):
-while IFS= read -r line; do
-    process "$line"        # if slow, deadlocks on multi-record input
-done <<<"$porcelain"
+## Footgun 12 — Stale integration branch
 
-# Variant C — `<<EOF ... EOF` heredoc to any pipe-pair consumer:
-some_cmd <<EOF
-... multi-line body ...
-EOF
-```
+**Symptom**: Phase 5 release PR (integration → main) has dozens of merge conflicts. The wave took several days, main moved 30+ commits in unrelated areas, and the integration branch's last rebase was 5 days ago.
 
-**Fix** — route the producer through a tempfile so the bash heredoc-write step finishes before the consumer ever runs:
+**Root cause**: Long-running integration branches accumulate divergence from main. Each fixer PR is small and rebases cleanly into the integration branch, but the integration branch itself drifts away from main while waiting for all wave PRs to land.
 
-```bash
-# Producer/consumer decoupled via tempfile:
-local tmp
-tmp="$(mktemp)"
-trap "rm -f '$tmp'" RETURN
-printf '%s\n' "$porcelain" > "$tmp"
+**Fix**:
+1. Orchestrator rebases the integration branch on `origin/main` periodically during the wave (rule of thumb: if main has moved >10 commits since the last rebase, rebase before the next Phase 4 PR merge).
+2. The rebase is `git pull --rebase origin main` from the integration branch, then `git push --force-with-lease origin <integration-branch>` (force is acceptable here because the integration branch is short-lived and orchestrator-owned; fixer worktrees branched off it will need to rebase too).
+3. Coordinate the rebase with in-flight fixers — announce it before pushing so they can pause + rebase their fixer branches after.
 
-# Now the consumer reads from a real file; no back-pressure interaction.
-while IFS= read -r line; do
-    process "$line"
-done < "$tmp"
-```
+**Recovery**: If the integration branch is already a conflict mess at release time, the cheapest fix is usually to cherry-pick the merged-to-integration commits onto a fresh integration branch branched from current main, then open the release PR from there. Update fixer worktrees that were branched off the stale integration ref.
 
-For the `python3 - <<'PY'` variant, write the script to a tempfile and exec it:
+## Footgun 13 — Worktree accumulation
 
-```bash
-local tmp
-tmp="$(mktemp --suffix=.py)"
-trap "rm -f '$tmp'" RETURN
-cat > "$tmp" <<'PY'
-... multi-line python body ...
-PY
-result="$(python3 "$tmp")"
-```
+**Symptom**: `.claude/worktrees/` directory has 60+ entries on a busy install. `git worktree list` is paginated. Disk space pressure on the operator's checkout. Operator notices and asks why stale worktrees aren't cleaned up.
 
-**Apply rule for brief writers**: when the task involves bash that pipes bash-side data into ANY pipe-pair consumer (subprocess stdin, `while read`, an embedded interpreter), default to **`mktemp + < file`** instead of heredoc / here-string. Threshold heuristic: anything over a single short value (a SHA, a single path, a flag) should go via tempfile. Cheap to write, prevents the deadlock class entirely.
+**Root cause**: Orchestrator forgot Phase 4 worktree cleanup at squash-merge time. Each fixer's worktree survives past its PR's merge because the orchestrator didn't run `git worktree remove -f -f <path>` while the path was fresh in mind.
 
-**Real instances**:
-- #800 (closed 2026-05-12) — 34h daemon hang traced to nested `$(python3 - <<'PY')` in `bridge-daemon.sh` rotation / recovery paths. Fixed in PR #801 + #806 by wrapping production callsites.
-- 2026-05-13 — worktree-doctor fixer's smoke setup deadlocked in `<<<"$porcelain"` against multi-record `git worktree list --porcelain` output on Bash 5.3.9. Same `heredoc_write` frame as #800.
-- PR #809 body (this wave) — operator notes `./scripts/smoke-test.sh` hangs on a `cat` heredoc on the orchestrator's host. Same class; pre-existing on `main`, not introduced by #809.
+**Fix**:
+1. Phase 4 squash-merge and worktree cleanup are a **single transaction in the orchestrator's mental model**. Never end a Phase 4 step without the cleanup.
+2. End-of-wave sweep: `find <repo>/.claude/worktrees -maxdepth 1 -type d -mtime +1` → reconcile against `gh pr list --state open --json headRefName`. Any worktree dir whose branch is not in the open-PR list is stale and safe to remove.
+3. If you find yourself with 30+ stale worktrees, do a bulk cleanup but cross-check each against open PRs first — `git worktree remove` on a worktree with uncommitted changes refuses without `-f`; never use `-f -f` on a worktree you haven't verified is stale, since that bypasses the dirty-state guard.
 
-**Escalation trigger**: if a third *new* surface trips this class (i.e., outside the already-wrapped daemon hot paths), open a repo-wide audit issue and grep every `<<<` and `<<'`/`<<\"` site in `lib/`, `scripts/`, and root `bridge-*.sh` for producer-consumer pairs above the threshold. Until then, fix at the encounter site and call this footgun out in the next bash-heavy brief.
+**Real instance**: Mentioned by operator on 2026-05-19 — `.claude/worktrees/` had ~60 entries on the agent-bridge-public checkout, evidence of orchestrator skipping Phase 4 cleanup across multiple recent waves.

--- a/.claude/skills/wave-orchestration/references/recipes.md
+++ b/.claude/skills/wave-orchestration/references/recipes.md
@@ -27,14 +27,14 @@ grep -rn "<unique substring>" <repo>/lib/ <repo>/scripts/
 
 ```bash
 # Always run before dispatching codex-rescue.
-codex --version 2>/dev/null && command -v codex
+node "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs" setup --json
 ```
 
-A non-empty version line + a path means codex is installed and reachable.
+Look for `"ready": true` in the output.
 
-If `command -v codex` returns nothing but `which codex` shows a binary, the agent is running with a stripped PATH. Re-dispatch the codex-rescue agent with explicit `PATH` guidance, or invoke codex directly via its absolute path.
+If you see `"available": false` for codex but `which codex` shows a binary, the agent is running with a stripped PATH. Re-dispatch the codex-rescue agent with explicit instructions to re-probe via the companion script before declaring codex unavailable.
 
-If codex prints "Not logged in" or similar on a real call, ask the operator to run `!codex login`.
+If `"loggedIn": false`, ask the operator to run `!codex login`.
 
 ## Recipe — codex-rescue dispatch (sync, with wait line)
 
@@ -45,8 +45,8 @@ Agent({
   prompt: `Code review PR #<N> of <owner>/<repo>.
 
 Codex CLI is installed and ready. If your first probe disagrees, re-check via:
-PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" codex --version
-which should print a version line on this machine.
+node "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs" setup --json
+That should return "ready": true on this machine.
 
 **Read this brief in full first**: /tmp/<topic>-codex-review.md
 

--- a/.claude/skills/wave-orchestration/references/wave-examples.md
+++ b/.claude/skills/wave-orchestration/references/wave-examples.md
@@ -94,7 +94,7 @@ gh pr create --base main --head fix/283-trackC-cli-suggestions --title "..." --b
 
 ## Wave example 4 — codex-rescue review of complex PR
 
-**Issue context**: PR #302 — 583 LOC change, Linux ACL semantics, isolated UID plugin sharing. Specialized domain (ACL ordering, sudo wrap, traverse chain). Authored by `seanssoh` (operator's fork account) on his other Claude session; opened against upstream `SYRS-AI:main`.
+**Issue context**: PR #302 — 583 LOC change, Linux ACL semantics, isolated UID plugin sharing. Specialized domain (ACL ordering, sudo wrap, traverse chain). Authored by `<fork-account>` (operator's fork account) on his other Claude session; opened against upstream `<upstream-account>:main`.
 
 **Decision**: >300 LOC + specialized → **codex-rescue review**, not direct.
 
@@ -102,8 +102,8 @@ gh pr create --base main --head fix/283-trackC-cli-suggestions --title "..." --b
 
 ```bash
 # Verify codex setup
-codex --version 2>/dev/null && command -v codex
-# Both should print: a version line and a binary path
+node "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs" setup --json
+# Look for "ready": true
 
 # Fetch the diff to a known path
 gh pr diff 302 > /tmp/pr-302.diff
@@ -119,11 +119,11 @@ $EDITOR /tmp/agb-302-codex-review.md
 Agent({
   description: "Codex review of PR #302 ACL plugin sharing",
   subagent_type: "codex:codex-rescue",
-  prompt: `Code review PR #302 of seanssoh/agent-bridge-public — "isolate: channel-ownership-aware plugin sharing for isolated UIDs".
+  prompt: `Code review PR #302 of <upstream-account>/agent-bridge-public — "isolate: channel-ownership-aware plugin sharing for isolated UIDs".
 
 Codex CLI is installed and ready. If your first probe disagrees, re-check via:
-PATH="/opt/homebrew/bin:/usr/local/bin:$PATH" codex --version
-which should print a version line on this machine.
+node "~/.claude/plugins/cache/openai-codex/codex/<version>/scripts/codex-companion.mjs" setup --json
+That returns "ready": true on this machine.
 
 Read this brief in full first: /tmp/agb-302-codex-review.md
 Diff is at /tmp/pr-302.diff (637 lines).
@@ -140,7 +140,7 @@ Wait for completion in your final assistant message. Do not return a thread id a
 
 **Footgun-8 instance**: first dispatch returned "Codex CLI is not installed" because the subagent shell had a stripped PATH. Operator confirmed codex was in fact installed; orchestrator re-dispatched with explicit guidance to re-probe via the companion script. Second dispatch succeeded.
 
-**Outcome**: review posted as PR comment. PR #302 stayed open awaiting r2 fixes from the author side. (Subsequent recipe: cross-fork push from `seanssoh` account — see `references/recipes.md` "Cross-fork PR push".)
+**Outcome**: review posted as PR comment. PR #302 stayed open awaiting r2 fixes from the author side. (Subsequent recipe: cross-fork push from `<fork-account>` account — see `references/recipes.md` "Cross-fork PR push".)
 
 ## Cross-cutting observations from these waves
 

--- a/.claude/skills/wave-orchestration/references/wave-examples.md
+++ b/.claude/skills/wave-orchestration/references/wave-examples.md
@@ -2,6 +2,8 @@
 
 Four worked waves from a single session that landed 11 PRs with zero regressions. Each example shows the issue, the brief decision, the dispatch shape, the review path, and the merge note.
 
+> **⚠️ Historical record (2026-04-25) — review-path decisions are SUPERSEDED.** These waves predate the mandatory-pair-review contract. Where an example below shows a *"direct review (no codex-rescue)"* or *"self-review + direct merge"* path for docs-only / mid-size work, that LOC-based carve-out is **no longer valid** — see SKILL.md §"Phase 4" and footgun #10: **every** PR now requires the long-lived `agb-dev-codex` Phase-4 pair-review before merge, with no `<300 LOC` exception (a taken-over wedge-recovery PR is not an exception either — Phase 3.5). Keep these examples for their **brief-writing, dispatch-shape, and merge-note structure** — not their review-path choices.
+
 ## Wave example 1 — combined Track A's docs PR
 
 **Issue context**: #303 + #304 both proposed adding admin role spec sections to `agents/_template/CLAUDE.md`. Both Track A's were docs-only. Bundling them into one PR was cheaper than two separate PRs because they touched the same file in the same area.


### PR DESCRIPTION
Syncs the repo-tracked `.claude/skills/wave-orchestration/` to the live evolved skill so the improvements release to other installs on upgrade.

**Why** (operator 2026-06-03): skill/process improvements must release to other servers. The repo copy had drifted ~3 weeks behind — it carried the old 3-step 'parallel ships' model while the working admin skill was rewritten to the 5-phase model (plan→fixer→integration→QA→release + 5-round convergence + worktree lifecycle). That rewrite never went back to the repo.

**New — Phase 3.5 (Monitor dispatched fixers)**: (1) proactively check long-running fixers via context-safe signals only (PR/branch/commit/output-mtime — never the JSONL transcript), (2) detect the internal codex-rescue wedge pattern, (3) **a taken-over wedge-recovery PR MUST still pass the agb-dev-codex Phase-4 pair-review before merge** (operator directive — never ship a wedge-recovery unreviewed).

**Machine-agnostic**: absolute /Users/sean codex-companion paths → ~/.claude/.../<version>/; stale pre-#1420 gh account names → <upstream-account>/<fork-account> placeholders. Re-scanned clean.

Docs/skill only — no executable code. Long-term de-drift = the `agent-bridge wave` CLI-plugin migration in docs/design/wave-orchestration-plugin.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)