### PR TITLE
daemon: resource-guard fail-safe at every spawn site (incident #8807 P0a)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -346,6 +346,17 @@ bridge_daemon_supp_groups_poll_and_dispatch() {
     return 0
   fi
 
+  # Incident #8807 P0a: resource-guard before forking the detached supp-refresh
+  # worker (which itself drives a daemon restart). Placed AFTER the
+  # should_refresh throttle check but BEFORE the dispatch throttle-write, so a
+  # deferral does not record a phantom "dispatched" state — the next poll
+  # re-evaluates pressure and re-detects the same stale group. Return 0
+  # (poll-loop callers must never abort on this path). Fails OPEN.
+  if declare -F bridge_resource_guard_defer_or_proceed >/dev/null 2>&1 \
+      && bridge_resource_guard_defer_or_proceed "supp-refresh:${first_name}"; then
+    return 0
+  fi
+
   # Resolve the bridge home + bash for the detached worker invocation.
   # SCRIPT_DIR is set at the top of bridge-daemon.sh; bash is the
   # interpreter currently running this code.
@@ -8455,6 +8466,15 @@ start_cron_worker() {
   local task_id="$1"
   local log_file
 
+  # Incident #8807 P0a: resource-guard pre-flight before forking the cron
+  # worker. On host pressure the row is NOT claimed-and-stranded here — the
+  # caller (start_cron_dispatch_workers) already guards before the claim, so
+  # this is a defense-in-depth seal at the fork itself. Fails OPEN.
+  if declare -F bridge_resource_guard_defer_or_proceed >/dev/null 2>&1 \
+      && bridge_resource_guard_defer_or_proceed "cron-worker:#${task_id}"; then
+    return 1
+  fi
+
   log_file="$(bridge_cron_worker_log_file "$task_id")"
   mkdir -p "$(dirname "$log_file")"
   bridge_require_python
@@ -8617,6 +8637,17 @@ bridge_daemon_cron_dispatch_wake() {
     return 1
   fi
 
+  # Incident #8807 P0a: defense-in-depth resource-guard BEFORE the wake spawns
+  # a fresh bridge-start.sh session. Placed ahead of the throttle-window
+  # check/write below so a deferral does NOT consume the cron-dispatch
+  # throttle slot (mirrors the setup-pending / channel-required holds above,
+  # which return 1 without touching throttle state). The caller treats rc=1
+  # as "skip this row this pass" and leaves it queued. Fails OPEN.
+  if declare -F bridge_resource_guard_defer_or_proceed >/dev/null 2>&1 \
+      && bridge_resource_guard_defer_or_proceed "cron-dispatch-wake:${agent}"; then
+    return 1
+  fi
+
   now_ts="$(date +%s 2>/dev/null || echo 0)"
   state_file="$(bridge_daemon_cron_dispatch_wake_state_file "$agent")"
   if [[ -f "$state_file" ]]; then
@@ -8708,6 +8739,17 @@ start_cron_dispatch_workers() {
   while IFS=$'\t' read -r task_id agent _priority title _body_path; do
     [[ -n "$task_id" && -n "$agent" ]] || continue
     (( running_count < max_parallel )) || break
+
+    # Incident #8807 P0a: resource-guard gate BEFORE the cron CLAIM. A
+    # deferred dispatch must leave the row queued/unclaimed (not
+    # claimed-then-stranded), so the gate sits ahead of both the wake
+    # (bridge_daemon_cron_dispatch_wake, which can spawn bridge-start.sh)
+    # and claim_cron_task_with_retry below. Skip this row this pass; the
+    # next tick re-evaluates pressure. Fails OPEN.
+    if declare -F bridge_resource_guard_defer_or_proceed >/dev/null 2>&1 \
+        && bridge_resource_guard_defer_or_proceed "cron-dispatch:#${task_id}"; then
+      continue
+    fi
 
     # Issue #1096: when the dispatch's target is a stopped static agent,
     # wake it before claiming. The wake gate checks the same operator-
@@ -8856,6 +8898,21 @@ cmd_run_cron_worker() {
       printf -- '- target: %s\n' "$CRON_TARGET_AGENT"
     } >"$done_note_file" 2>/dev/null || true
     bridge_queue_cli done "$task_id" --agent "$TASK_ASSIGNED_TO" --note-file "$done_note_file" >/dev/null 2>&1 || true
+    return 0
+  fi
+
+  # Incident #8807 P0a: resource-guard pre-flight BEFORE the run-subagent fork
+  # (the heaviest spawn on this path — it launches a fresh claude/codex
+  # subprocess). The row is already claimed by this worker, so on deferral we
+  # hand it BACK to the queue (handoff --to the assigned agent) instead of
+  # marking it failed — the next ready-rows pass re-dispatches it once
+  # pressure clears. Mirrors the start-cron-worker-failure handoff above.
+  # Fails OPEN: a probe glitch proceeds to the runner.
+  if [[ "$CRON_RUN_STATE" != "success" ]] \
+      && declare -F bridge_resource_guard_defer_or_proceed >/dev/null 2>&1 \
+      && bridge_resource_guard_defer_or_proceed "run-cron-worker:#${task_id}"; then
+    bridge_queue_cli handoff "$task_id" --to "$TASK_ASSIGNED_TO" --from daemon \
+      --note "cron worker deferred: host near resource ceiling (incident #8807 resource-guard)" >/dev/null 2>&1 || true
     return 0
   fi
 
@@ -9314,6 +9371,17 @@ process_on_demand_agents() {
             continue
           fi
         fi
+        # Incident #8807 P0a: resource-guard before the always-on auto-start
+        # spawn. Mirror the hold / channel-miss gates above — `continue`
+        # without recording an autostart FAILURE (a deferral is not a
+        # failure; recording one would arm the backoff and could mask a real
+        # start problem once pressure clears). The audit + throttled warn are
+        # emitted by the guard helper. The agent stays stopped this tick and
+        # is re-evaluated next pass. Fails OPEN.
+        if declare -F bridge_resource_guard_defer_or_proceed >/dev/null 2>&1 \
+            && bridge_resource_guard_defer_or_proceed "always-on:${agent}"; then
+          continue
+        fi
         if bridge_daemon_start_agent_with_recovery "$agent" "always_on"; then
           session="$(bridge_agent_session "$agent")"
           bridge_daemon_clear_autostart_failure "$agent"
@@ -9370,6 +9438,15 @@ process_on_demand_agents() {
               --detail trigger=on_demand_wake 2>/dev/null || true
             continue
           fi
+        fi
+        # Incident #8807 P0a: resource-guard before the queued-on-demand
+        # auto-start spawn. Same contract as the always-on branch above:
+        # `continue` without recording an autostart failure; the queued work
+        # stays in the queue and the agent is re-evaluated next tick. The
+        # guard helper owns the audit + throttled warn. Fails OPEN.
+        if declare -F bridge_resource_guard_defer_or_proceed >/dev/null 2>&1 \
+            && bridge_resource_guard_defer_or_proceed "on-demand:${agent}"; then
+          continue
         fi
         if bridge_daemon_start_agent_with_recovery "$agent" "on_demand"; then
           session="$(bridge_agent_session "$agent")"

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -689,6 +689,9 @@ bridge_source_module "bridge-profiles.sh"
 bridge_source_module "bridge-agent-layout.sh"
 bridge_source_module "bridge-engine-descriptor.sh"
 bridge_source_module "bridge-cron.sh"
+# Incident #8807 P0a: resource-guard reuses bridge-cron.sh's
+# bridge_check_memory_pressure, so it must source AFTER bridge-cron.sh.
+bridge_source_module "bridge-resource-guard.sh"
 bridge_source_module "bridge-discord.sh"
 bridge_source_module "bridge-notify.sh"
 bridge_source_module "bridge-migration.sh"

--- a/lib/bridge-resource-guard.sh
+++ b/lib/bridge-resource-guard.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# lib/bridge-resource-guard.sh — Issue #1454-incident (process-explosion fail-safe).
+#
+# P0a of the 2026-06-03 incident: Agent Bridge had NO resource-threshold
+# fail-safe on its transitive process tree. A long-lived runtime accumulated
+# thousands of orphaned codex/mcp-server/node/bash processes; memory exhaustion
+# made `fork()` itself fail (child-side SIGSEGV pre-exec), and the daemon kept
+# dispatching/spawning right up until the machine could no longer create any
+# process → forced reboot.
+#
+# This module is a defense-in-depth pre-flight probe the daemon (and any other
+# spawn site) calls BEFORE forking a new disposable child / refresh worker /
+# agent. When the host is near a resource ceiling it returns "defer" so the
+# caller skips the spawn and warns, instead of pushing the host over fork().
+#
+# Design contract (mirrors the existing #263 `bridge_check_memory_pressure`):
+#   - FAIL OPEN. Any probe glitch (sysctl missing, /proc unreadable, malformed
+#     output) returns "healthy/proceed" — a probe error must NEVER block work.
+#   - The pressure verdict is a STRICT yes: only when we have positive evidence
+#     the host is constrained (memory OR per-uid process count near the cap).
+#   - Pure bash + coreutils; no python on the probe path (runs every tick).
+#   - Portable: Darwin (sysctl) + Linux (/proc, ulimit). Other → healthy.
+#
+# Tunables (env):
+#   BRIDGE_RESOURCE_GUARD_ENABLED         1 (default) | 0 to disable the guard.
+#   BRIDGE_RESOURCE_PROC_PCT_LIMIT        per-uid live process count ceiling as
+#                                         a percent of kern.maxprocperuid /
+#                                         ulimit -u. Default 70. At/above → defer.
+#   BRIDGE_CRON_SWAP_PCT_LIMIT            (reused) Darwin swap-used percent →
+#                                         defer. Default 80.
+#   BRIDGE_CRON_MIN_AVAIL_MB             (reused) Linux MemAvailable floor (MB) →
+#                                         defer below. Default 512.
+#
+# Returns from bridge_resource_guard_should_defer():
+#   0 — DEFER: host is pressured; caller should skip the spawn + warn.
+#   1 — PROCEED: host appears healthy (or guard disabled / unknown platform).
+# (0=defer is deliberate so callers read `if bridge_resource_guard_should_defer; then skip`.)
+
+# --- per-uid live process count vs the kernel ceiling -------------------------
+# Echoes "<count> <max> <pct>" on success, nothing on probe failure (fail open).
+bridge_resource_guard_proc_stats() {
+  local uid count max kind
+  uid="$(id -u 2>/dev/null || true)"
+  [[ "$uid" =~ ^[0-9]+$ ]] || return 1
+
+  # Live process count for this uid. `ps -u <uid>` is portable; subtract the
+  # header line. (We count processes, not threads — the fork() ceiling is
+  # per-process.)
+  count="$(ps -u "$uid" -o pid= 2>/dev/null | grep -c . 2>/dev/null || true)"
+  [[ "$count" =~ ^[0-9]+$ ]] || return 1
+
+  kind="$(uname -s 2>/dev/null || true)"
+  case "$kind" in
+    Darwin)
+      max="$(sysctl -n kern.maxprocperuid 2>/dev/null || true)"
+      ;;
+    Linux)
+      # ulimit -u is the per-uid RLIMIT_NPROC soft cap. `unlimited` → no ceiling.
+      max="$(ulimit -u 2>/dev/null || true)"
+      [[ "$max" == "unlimited" ]] && return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  [[ "$max" =~ ^[0-9]+$ ]] || return 1
+  (( max > 0 )) || return 1
+
+  local pct=$(( count * 100 / max ))
+  printf '%s %s %s' "$count" "$max" "$pct"
+}
+
+# Returns 0 (defer) when per-uid process count is at/above the percent ceiling.
+bridge_resource_guard_proc_pressured() {
+  local limit stats pct
+  limit="${BRIDGE_RESOURCE_PROC_PCT_LIMIT:-70}"
+  [[ "$limit" =~ ^[0-9]+$ ]] || limit=70
+  stats="$(bridge_resource_guard_proc_stats)" || return 1   # probe failed → not pressured
+  pct="${stats##* }"
+  [[ "$pct" =~ ^[0-9]+$ ]] || return 1
+  (( pct >= limit )) && return 0
+  return 1
+}
+
+# Memory pressure — reuse the #263 helper if it has been sourced, else inline a
+# byte-for-byte equivalent so this module is usable standalone.
+bridge_resource_guard_mem_pressured() {
+  if declare -F bridge_check_memory_pressure >/dev/null 2>&1; then
+    # bridge_check_memory_pressure returns 1 when pressured, 0 when healthy.
+    bridge_check_memory_pressure && return 1 || return 0
+  fi
+  local kind; kind="$(uname -s 2>/dev/null || true)"
+  case "$kind" in
+    Darwin)
+      local usage_line used_raw total_raw used_int total_int pct
+      local limit="${BRIDGE_CRON_SWAP_PCT_LIMIT:-80}"
+      [[ "$limit" =~ ^[0-9]+$ ]] || limit=80
+      usage_line="$(sysctl -n vm.swapusage 2>/dev/null || true)"
+      [[ -n "$usage_line" ]] || return 1
+      used_raw="$(awk '{ for (i=1;i<=NF;i++) if ($i=="used") print $(i+2) }' <<<"$usage_line")"
+      total_raw="$(awk '{ for (i=1;i<=NF;i++) if ($i=="total") print $(i+2) }' <<<"$usage_line")"
+      used_int="${used_raw%%.*}"; total_int="${total_raw%%.*}"
+      [[ "$used_int" =~ ^[0-9]+$ && "$total_int" =~ ^[0-9]+$ ]] || return 1
+      (( total_int > 0 )) || return 1
+      pct=$(( used_int * 100 / total_int ))
+      (( pct >= limit )) && return 0
+      return 1
+      ;;
+    Linux)
+      local avail_kb threshold_mb threshold_kb
+      threshold_mb="${BRIDGE_CRON_MIN_AVAIL_MB:-512}"
+      [[ "$threshold_mb" =~ ^[0-9]+$ ]] || threshold_mb=512
+      threshold_kb=$(( threshold_mb * 1024 ))
+      [[ -r /proc/meminfo ]] || return 1
+      avail_kb="$(awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo 2>/dev/null || true)"
+      [[ "$avail_kb" =~ ^[0-9]+$ ]] || return 1
+      (( avail_kb < threshold_kb )) && return 0
+      return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# bridge_resource_guard_should_defer [context-label]
+#   0 — DEFER (host pressured: memory OR per-uid process count near ceiling)
+#   1 — PROCEED (healthy / guard disabled / unknown platform / probe glitch)
+# Emits a single human-readable reason on stderr when deferring so callers can
+# audit it; the caller owns the audit-log / channel-alert side effect.
+bridge_resource_guard_should_defer() {
+  local ctx="${1:-dispatch}"
+  [[ "${BRIDGE_RESOURCE_GUARD_ENABLED:-1}" == "1" ]] || return 1
+
+  if bridge_resource_guard_mem_pressured; then
+    printf 'resource-guard: DEFER %s — memory pressure\n' "$ctx" >&2
+    return 0
+  fi
+  if bridge_resource_guard_proc_pressured; then
+    local stats; stats="$(bridge_resource_guard_proc_stats 2>/dev/null || true)"
+    printf 'resource-guard: DEFER %s — per-uid process count near ceiling (%s)\n' "$ctx" "${stats:-?}" >&2
+    return 0
+  fi
+  return 1
+}

--- a/lib/bridge-resource-guard.sh
+++ b/lib/bridge-resource-guard.sh
@@ -143,3 +143,69 @@ bridge_resource_guard_should_defer() {
   fi
   return 1
 }
+
+# --- throttle state for the deferral warning ----------------------------------
+# A pressured host fans out many spawn attempts per daemon tick across several
+# sites. We must NOT emit a warn line (let alone a channel-bound one) per
+# attempt — that re-creates the very log/inbox flood this incident is about.
+# Throttle to one warn per BRIDGE_RESOURCE_GUARD_WARN_THROTTLE_SECONDS (default
+# 300s) across all sites, keyed off a single state file. The audit row is
+# always written (forensic trail, file-only, no channel side effect); only the
+# operator-visible warn is throttled.
+bridge_resource_guard_warn_throttle_path() {
+  local dir="${BRIDGE_STATE_DIR:-${BRIDGE_HOME:-$HOME/.agent-bridge}/state}"
+  printf '%s/resource-guard.warn.ts' "$dir"
+}
+
+# Returns 0 (emit) when the throttle window has elapsed (and records now),
+# 1 (suppress) when still within the window. Fails OPEN toward "emit" on any
+# state-file glitch — a throttle bookkeeping error must never silence a real
+# pressure warning, and an over-emit is harmless relative to under-emit.
+bridge_resource_guard_warn_should_emit() {
+  local now_ts last_ts window path tmp
+  window="${BRIDGE_RESOURCE_GUARD_WARN_THROTTLE_SECONDS:-300}"
+  [[ "$window" =~ ^[0-9]+$ ]] || window=300
+  now_ts="$(date +%s 2>/dev/null || printf '0')"
+  [[ "$now_ts" =~ ^[0-9]+$ ]] || return 0
+  path="$(bridge_resource_guard_warn_throttle_path)"
+  if [[ -f "$path" ]]; then
+    last_ts="$(<"$path")" 2>/dev/null || last_ts=0
+    [[ "$last_ts" =~ ^[0-9]+$ ]] || last_ts=0
+    (( now_ts - last_ts < window )) && return 1
+  fi
+  mkdir -p "$(dirname "$path")" 2>/dev/null || return 0
+  tmp="${path}.tmp.$$"
+  if printf '%s' "$now_ts" >"$tmp" 2>/dev/null; then
+    mv -f "$tmp" "$path" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  fi
+  return 0
+}
+
+# bridge_resource_guard_defer_or_proceed <ctx>
+#   The single call every daemon spawn site makes. On host pressure it:
+#     - writes a `resource_guard_deferred` audit row (file-only, always), and
+#     - emits ONE throttled `bridge_warn` line (no channel spam),
+#     then returns 0 so the caller skips the spawn and leaves work queued.
+#   On a healthy host / disabled guard / unknown platform / probe glitch it
+#   returns 1 (PROCEED) — fail OPEN, never wedge the daemon.
+# Side effects (audit + warn) are each `|| true`-guarded so a logging error
+# cannot leak a non-zero rc back into the daemon poll loop.
+bridge_resource_guard_defer_or_proceed() {
+  local ctx="${1:-dispatch}"
+  bridge_resource_guard_should_defer "$ctx" || return 1
+
+  local stats reason="resource_pressure"
+  stats="$(bridge_resource_guard_proc_stats 2>/dev/null || true)"
+  if declare -F bridge_audit_log >/dev/null 2>&1; then
+    bridge_audit_log daemon resource_guard_deferred daemon \
+      --detail context="$ctx" \
+      --detail proc_stats="${stats:-unknown}" \
+      --detail reason="$reason" >/dev/null 2>&1 || true
+  fi
+  if bridge_resource_guard_warn_should_emit; then
+    if declare -F bridge_warn >/dev/null 2>&1; then
+      bridge_warn "resource-guard: deferred spawn (${ctx}) — host near resource ceiling (${stats:-?}); leaving work queued" || true
+    fi
+  fi
+  return 0
+}

--- a/lib/bridge-resource-guard.sh
+++ b/lib/bridge-resource-guard.sh
@@ -82,45 +82,17 @@ bridge_resource_guard_proc_pressured() {
   return 1
 }
 
-# Memory pressure — reuse the #263 helper if it has been sourced, else inline a
-# byte-for-byte equivalent so this module is usable standalone.
+# Memory pressure — delegate to the #263 `bridge_check_memory_pressure`
+# (lib/bridge-cron.sh), which bridge-lib.sh always sources BEFORE this module.
+# We intentionally do NOT inline a duplicate sysctl/awk parser: that re-introduced
+# the here-string footgun #11 surface (PR #1479 r1 ratchet) and duplicated the
+# single source of truth. If the helper is somehow unavailable (a standalone
+# source without bridge-cron.sh), skip the memory check and return not-pressured
+# — that is fail-open by design; the per-uid proc-count gate still guards.
 bridge_resource_guard_mem_pressured() {
-  if declare -F bridge_check_memory_pressure >/dev/null 2>&1; then
-    # bridge_check_memory_pressure returns 1 when pressured, 0 when healthy.
-    bridge_check_memory_pressure && return 1 || return 0
-  fi
-  local kind; kind="$(uname -s 2>/dev/null || true)"
-  case "$kind" in
-    Darwin)
-      local usage_line used_raw total_raw used_int total_int pct
-      local limit="${BRIDGE_CRON_SWAP_PCT_LIMIT:-80}"
-      [[ "$limit" =~ ^[0-9]+$ ]] || limit=80
-      usage_line="$(sysctl -n vm.swapusage 2>/dev/null || true)"
-      [[ -n "$usage_line" ]] || return 1
-      used_raw="$(awk '{ for (i=1;i<=NF;i++) if ($i=="used") print $(i+2) }' <<<"$usage_line")"
-      total_raw="$(awk '{ for (i=1;i<=NF;i++) if ($i=="total") print $(i+2) }' <<<"$usage_line")"
-      used_int="${used_raw%%.*}"; total_int="${total_raw%%.*}"
-      [[ "$used_int" =~ ^[0-9]+$ && "$total_int" =~ ^[0-9]+$ ]] || return 1
-      (( total_int > 0 )) || return 1
-      pct=$(( used_int * 100 / total_int ))
-      (( pct >= limit )) && return 0
-      return 1
-      ;;
-    Linux)
-      local avail_kb threshold_mb threshold_kb
-      threshold_mb="${BRIDGE_CRON_MIN_AVAIL_MB:-512}"
-      [[ "$threshold_mb" =~ ^[0-9]+$ ]] || threshold_mb=512
-      threshold_kb=$(( threshold_mb * 1024 ))
-      [[ -r /proc/meminfo ]] || return 1
-      avail_kb="$(awk '/^MemAvailable:/ { print $2; exit }' /proc/meminfo 2>/dev/null || true)"
-      [[ "$avail_kb" =~ ^[0-9]+$ ]] || return 1
-      (( avail_kb < threshold_kb )) && return 0
-      return 1
-      ;;
-    *)
-      return 1
-      ;;
-  esac
+  declare -F bridge_check_memory_pressure >/dev/null 2>&1 || return 1
+  # bridge_check_memory_pressure returns 1 when pressured, 0 when healthy.
+  bridge_check_memory_pressure && return 1 || return 0
 }
 
 # bridge_resource_guard_should_defer [context-label]

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -1072,8 +1072,26 @@ select_for_path() {
       # cannot regress back to the pre-#1353 4-burst noise surface
       # that masks real errors during fresh-install OOTB.
       add_required 1353-setup-pending-grace
+      # Incident #8807 P0a: bridge-daemon.sh now wires the resource-guard
+      # (lib/bridge-resource-guard.sh) at every disposable-child spawn site —
+      # start_cron_worker, the cron-dispatch claim/wake path
+      # (start_cron_dispatch_workers + bridge_daemon_cron_dispatch_wake),
+      # cmd_run_cron_worker's run-subagent fork, the supp-refresh worker, and
+      # the always-on / queued-on-demand auto-start. Pull
+      # 8807-resource-guard-defer on every bridge-daemon.sh move so a future
+      # PR cannot silently drop a guard site or regress the fail-OPEN / leave-
+      # queued / throttled-warn contract that prevents the fork-storm reboot.
+      add_required 8807-resource-guard-defer
       add_integration integration-minimal
       add_live live-tmux-daemon
+      ;;
+
+    lib/bridge-resource-guard.sh)
+      # Incident #8807 P0a: the resource-guard primitive + the daemon-side
+      # defer/audit/throttled-warn wrapper. Pull 8807-resource-guard-defer on
+      # every move of the guard lib so the proc-count/memory probe, the
+      # fail-OPEN contract, and the throttled-warn bookkeeping cannot regress.
+      add_required 8807-resource-guard-defer
       ;;
 
     lib/bridge-daemon-control.sh|scripts/install-daemon-systemd.sh|scripts/sudoers-templates/agent-bridge-daemon-refresh.sudo.template)

--- a/scripts/smoke/8807-resource-guard-defer.sh
+++ b/scripts/smoke/8807-resource-guard-defer.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/8807-resource-guard-defer.sh — incident #8807 P0a fail-safe.
+#
+# Background: a long-lived runtime accumulated thousands of orphaned
+# codex/mcp-server/node/bash processes; memory exhaustion made fork() itself
+# fail and the daemon kept dispatching/spawning right up to the wall → forced
+# reboot. P0a adds a pre-flight resource-guard that the daemon consults BEFORE
+# every disposable-child fork so a pressured host DEFERS the spawn (leaving
+# work queued) instead of pushing the host over fork().
+#
+# This smoke is static-by-design for the daemon wiring (grep pins, no live
+# tmux) PLUS behavioral for the guard primitive itself — it sources
+# lib/bridge-resource-guard.sh in an isolated BRIDGE_HOME and proves:
+#   - a forced low threshold (BRIDGE_RESOURCE_PROC_PCT_LIMIT=0) DEFERS + audits
+#     + does NOT run the protected action;
+#   - a probe glitch (unknown platform) FAILS OPEN → PROCEED;
+#   - the guard-disabled knob proceeds;
+#   - the deferral warn is throttled to one per window across sites.
+
+set -euo pipefail
+
+SMOKE_NAME="8807-resource-guard-defer"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+DAEMON_SH="$SMOKE_REPO_ROOT/bridge-daemon.sh"
+GUARD_LIB="$SMOKE_REPO_ROOT/lib/bridge-resource-guard.sh"
+LIB_SH="$SMOKE_REPO_ROOT/bridge-lib.sh"
+
+TMP_ROOT=""
+cleanup() { [[ -z "$TMP_ROOT" ]] || rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/agb-8807-XXXXXX")"
+
+# ---------------------------------------------------------------------------
+# Part A — syntax + source-order
+# ---------------------------------------------------------------------------
+smoke_log "A1: resource-guard lib is syntactically valid"
+bash -n "$GUARD_LIB" || smoke_fail "lib/bridge-resource-guard.sh failed bash -n"
+
+smoke_log "A2: bridge-daemon.sh is syntactically valid"
+bash -n "$DAEMON_SH" || smoke_fail "bridge-daemon.sh failed bash -n"
+
+smoke_log "A3: bridge-lib.sh sources the guard AFTER bridge-cron.sh (mem-pressure reuse)"
+cron_line="$(grep -n 'bridge_source_module "bridge-cron.sh"' "$LIB_SH" | head -n1 | cut -d: -f1)"
+guard_line="$(grep -n 'bridge_source_module "bridge-resource-guard.sh"' "$LIB_SH" | head -n1 | cut -d: -f1)"
+[[ -n "$cron_line" && -n "$guard_line" ]] || smoke_fail "could not locate cron/guard source lines in bridge-lib.sh"
+(( guard_line > cron_line )) || smoke_fail "resource-guard sourced before bridge-cron.sh (mem-pressure reuse would break)"
+
+# ---------------------------------------------------------------------------
+# Part B — behavioral: source the guard primitive in isolation
+# ---------------------------------------------------------------------------
+smoke_log "B0: guard exposes the daemon-facing wrapper + the should-defer primitive"
+grep -q '^bridge_resource_guard_defer_or_proceed()' "$GUARD_LIB" || \
+  smoke_fail "missing bridge_resource_guard_defer_or_proceed wrapper"
+grep -q '^bridge_resource_guard_should_defer()' "$GUARD_LIB" || \
+  smoke_fail "missing bridge_resource_guard_should_defer primitive"
+
+# Harness: run a bash snippet that sources the guard with stub bridge_audit_log /
+# bridge_warn so we can observe the side effects without the full lib stack.
+# We isolate BRIDGE_STATE_DIR into TMP_ROOT so the throttle file never touches
+# live runtime.
+run_guard_probe() {
+  # First args (until the literal `--`) are VAR=value env assignments passed
+  # one-per-arg to `env` so values containing spaces (e.g. PATH) are safe;
+  # the final arg is the bash body to run after sourcing the guard.
+  local -a envv=()
+  while [[ $# -gt 1 && "$1" != "--" ]]; do
+    envv+=("$1"); shift
+  done
+  [[ "${1:-}" == "--" ]] && shift
+  local body="$1"
+  env BRIDGE_STATE_DIR="$TMP_ROOT/state" BRIDGE_HOME="$TMP_ROOT" "${envv[@]}" \
+    bash -c '
+      set -euo pipefail
+      AUDIT_LOG="'"$TMP_ROOT"'/audit.calls"
+      WARN_LOG="'"$TMP_ROOT"'/warn.calls"
+      bridge_audit_log() { printf "%s\n" "$*" >>"$AUDIT_LOG"; }
+      bridge_warn() { printf "%s\n" "$*" >>"$WARN_LOG"; }
+      # shellcheck source=/dev/null
+      source "'"$GUARD_LIB"'"
+      '"$body"'
+    '
+}
+
+smoke_log "B1: forced low proc-pct threshold DEFERS, audits, and skips the protected action"
+rm -f "$TMP_ROOT/audit.calls" "$TMP_ROOT/warn.calls" "$TMP_ROOT/ran.marker"
+defer_rc=0
+run_guard_probe "BRIDGE_RESOURCE_PROC_PCT_LIMIT=0" -- '
+  if bridge_resource_guard_defer_or_proceed "smoke-ctx"; then
+    # DEFER branch — must NOT run the protected action.
+    exit 0
+  else
+    # PROCEED branch — would have spawned.
+    printf ran >"'"$TMP_ROOT"'/ran.marker"
+    exit 0
+  fi
+' || defer_rc=$?
+[[ "$defer_rc" -eq 0 ]] || smoke_fail "guard probe (defer) exited non-zero"
+[[ ! -f "$TMP_ROOT/ran.marker" ]] || smoke_fail "guard DEFERRED but protected action still ran"
+smoke_assert_file_exists "$TMP_ROOT/audit.calls" "B1 audit row"
+grep -q "resource_guard_deferred" "$TMP_ROOT/audit.calls" || \
+  smoke_fail "deferral did not emit a resource_guard_deferred audit row"
+
+smoke_log "B2: probe glitch (unknown platform) FAILS OPEN → PROCEED (action runs)"
+# Force an unknown platform by shadowing `uname` on PATH so the proc/mem probes
+# both bail (return 1 = not pressured) → should_defer returns PROCEED.
+mkdir -p "$TMP_ROOT/fakebin"
+cat >"$TMP_ROOT/fakebin/uname" <<'FAKE'
+#!/usr/bin/env bash
+printf 'PlatypusOS\n'
+FAKE
+chmod +x "$TMP_ROOT/fakebin/uname"
+rm -f "$TMP_ROOT/ran.marker"
+proceed_rc=0
+run_guard_probe "BRIDGE_RESOURCE_PROC_PCT_LIMIT=0" "PATH=$TMP_ROOT/fakebin:$PATH" -- '
+  if bridge_resource_guard_defer_or_proceed "smoke-glitch"; then
+    exit 0
+  else
+    printf ran >"'"$TMP_ROOT"'/ran.marker"
+    exit 0
+  fi
+' || proceed_rc=$?
+[[ "$proceed_rc" -eq 0 ]] || smoke_fail "guard probe (fail-open) exited non-zero"
+[[ -f "$TMP_ROOT/ran.marker" ]] || \
+  smoke_fail "probe glitch did NOT fail open — guard wedged the spawn (fork-storm risk inverted)"
+
+smoke_log "B3: BRIDGE_RESOURCE_GUARD_ENABLED=0 always proceeds"
+rm -f "$TMP_ROOT/ran.marker"
+run_guard_probe "BRIDGE_RESOURCE_GUARD_ENABLED=0" "BRIDGE_RESOURCE_PROC_PCT_LIMIT=0" -- '
+  if bridge_resource_guard_defer_or_proceed "smoke-disabled"; then
+    exit 0
+  else
+    printf ran >"'"$TMP_ROOT"'/ran.marker"
+    exit 0
+  fi
+'
+[[ -f "$TMP_ROOT/ran.marker" ]] || smoke_fail "disabled guard still deferred"
+
+smoke_log "B4: deferral warn is throttled to one emission per window"
+rm -f "$TMP_ROOT/audit.calls" "$TMP_ROOT/warn.calls"
+rm -rf "$TMP_ROOT/state"
+run_guard_probe "BRIDGE_RESOURCE_PROC_PCT_LIMIT=0" "BRIDGE_RESOURCE_GUARD_WARN_THROTTLE_SECONDS=3600" -- '
+  for _i in 1 2 3 4 5; do
+    bridge_resource_guard_defer_or_proceed "smoke-throttle-$_i" || true
+  done
+  exit 0
+'
+audit_n="$(grep -c "resource_guard_deferred" "$TMP_ROOT/audit.calls" 2>/dev/null || printf 0)"
+warn_n=0
+[[ -f "$TMP_ROOT/warn.calls" ]] && warn_n="$(grep -c . "$TMP_ROOT/warn.calls" 2>/dev/null || printf 0)"
+# Audit is per-deferral (forensic, file-only) → 5 rows. Warn throttled → exactly 1.
+[[ "$audit_n" -eq 5 ]] || smoke_fail "expected 5 audit rows (one per deferral), got $audit_n"
+[[ "$warn_n" -eq 1 ]] || smoke_fail "expected exactly 1 throttled warn, got $warn_n (channel/log spam risk)"
+
+# ---------------------------------------------------------------------------
+# Part C — daemon wiring pins: every spawn site must consult the guard
+# ---------------------------------------------------------------------------
+smoke_log "C1: start_cron_worker guards before the worker fork"
+grep -q 'bridge_resource_guard_defer_or_proceed "cron-worker:' "$DAEMON_SH" || \
+  smoke_fail "start_cron_worker does not consult the resource guard"
+
+smoke_log "C2: cron-dispatch guards BEFORE the claim (leaves row queued)"
+grep -q 'bridge_resource_guard_defer_or_proceed "cron-dispatch:' "$DAEMON_SH" || \
+  smoke_fail "start_cron_dispatch_workers does not guard before the claim"
+
+smoke_log "C3: cron-dispatch wake guards before bridge-start.sh spawn"
+grep -q 'bridge_resource_guard_defer_or_proceed "cron-dispatch-wake:' "$DAEMON_SH" || \
+  smoke_fail "bridge_daemon_cron_dispatch_wake does not guard the wake spawn"
+
+smoke_log "C4: run-cron-worker guards before the run-subagent fork (and re-queues)"
+grep -q 'bridge_resource_guard_defer_or_proceed "run-cron-worker:' "$DAEMON_SH" || \
+  smoke_fail "cmd_run_cron_worker does not guard the run-subagent fork"
+grep -q 'cron worker deferred: host near resource ceiling' "$DAEMON_SH" || \
+  smoke_fail "cmd_run_cron_worker deferral does not hand the row back to the queue"
+
+smoke_log "C5: supp-refresh worker guards before the detached fork"
+grep -q 'bridge_resource_guard_defer_or_proceed "supp-refresh:' "$DAEMON_SH" || \
+  smoke_fail "supp-refresh dispatch does not guard the detached fork"
+
+smoke_log "C6: always-on AND queued-on-demand auto-start both guard the spawn"
+grep -q 'bridge_resource_guard_defer_or_proceed "always-on:' "$DAEMON_SH" || \
+  smoke_fail "always-on auto-start does not guard the spawn"
+grep -q 'bridge_resource_guard_defer_or_proceed "on-demand:' "$DAEMON_SH" || \
+  smoke_fail "queued-on-demand auto-start does not guard the spawn"
+
+smoke_log "C7: at least 6 guard call sites wired in the daemon"
+sites="$(grep -c 'bridge_resource_guard_defer_or_proceed ' "$DAEMON_SH")"
+[[ "$sites" -ge 6 ]] || smoke_fail "expected >=6 daemon guard sites, found $sites"
+
+smoke_log "PASS: $SMOKE_NAME"


### PR DESCRIPTION
## Incident #8807 — P0a (ship-first fail-safe)

The 2026-06-03 process-explosion incident: a long-lived runtime accumulated thousands of orphaned codex/mcp/node/bash processes, memory exhaustion made `fork()` itself fail, and the daemon kept dispatching/spawning until the host could no longer create any process → forced reboot. Agent Bridge had **no resource-threshold fail-safe** on its transitive process tree.

This PR wires the already-landed resource-guard primitive (`bridge_resource_guard_should_defer`, `lib/bridge-resource-guard.sh`, commits `1f8cf0d`/`57bc209`) at every daemon spawn site so a pressured host **defers** the spawn (leaving work queued) instead of pushing past `fork()`.

### What changed
- **New wrapper** `bridge_resource_guard_defer_or_proceed` (in the guard lib): `should_defer` → forensic `resource_guard_deferred` audit row (file-only, always) + a **throttled** `bridge_warn` (one per `BRIDGE_RESOURCE_GUARD_WARN_THROTTLE_SECONDS`, default 300s, so a fan-out tick can't re-flood log/inbox). **Fails OPEN** — disabled guard / unknown platform / probe glitch all PROCEED; never wedges the daemon.
- **Spawn sites gated** (all fail-open, all leave-queued):
  - `start_cron_worker` — before the worker fork.
  - `start_cron_dispatch_workers` — **before the cron CLAIM**, so a deferred dispatch is not claimed-then-stranded.
  - `bridge_daemon_cron_dispatch_wake` — before the `bridge-start.sh` wake spawn, ahead of the throttle-write so a deferral doesn't burn the cron-dispatch throttle slot.
  - `cmd_run_cron_worker` — before the run-subagent fork; on deferral the already-claimed row is handed **back** to the queue for retry.
  - supp-refresh worker — before the detached fork, ahead of the dispatch throttle-write (no phantom "dispatched" state).
  - always-on + queued-on-demand auto-start — `continue` without recording an autostart failure (a deferral is not a failure).

### Tests
`scripts/smoke/8807-resource-guard-defer.sh` (behavioral): forced low threshold defers+audits+skips the action; **probe glitch fails open**; disabled-knob proceeds; warn throttled to 1/window; + grep pins for all 6 daemon guard sites. Registered in `scripts/ci-select-smoke.sh` on every `bridge-daemon.sh` / `lib/bridge-resource-guard.sh` move.

### Verification
- `bash -n` + `shellcheck --severity=warning` clean on all touched `.sh`.
- New smoke passes standalone and via `ci-select-smoke.sh --run`.
- `lint-heredoc-ban`: `bridge-daemon.sh count=0` (no new heredocs).
- `iso-helper-ratchet`: no regression (script untouched; no boundary patterns added).
- `smoke-test.sh`: passes through to the pre-existing `tmux pending-attention spool` count failure, which reproduces identically on the base branch and is unrelated to this diff.

NO VERSION/CHANGELOG bump (stabilization PR). Source tree only.

(#8807 P0a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)