### PR TITLE
mcp-cleanup: tighten+extend reaper patterns + PID-reuse guard + early sweep (incident #8807 P0b)

### DIFF
--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -10327,6 +10327,18 @@ cmd_sync_cycle() {
   bridge_roster_cache_invalidate
   bridge_load_roster
 
+  # Incident #8807 P0b: periodic MCP-orphan cleanup runs EARLY — before every
+  # spawn-heavy surface in this cycle (start_cron_dispatch_workers,
+  # process_on_demand_agents, the wake paths) — so it relieves process /
+  # memory pressure ahead of new forks rather than after them. The fork-storm
+  # incident showed orphaned MCP servers accumulating faster than the
+  # post-spawn cleanup could reclaim; reaping first gives the spawn surfaces
+  # (now also resource-guarded by P0a) headroom. The cleanup's own 300s
+  # throttle keeps the cadence identical; subshell-isolated + `|| true` so a
+  # cleanup error can never abort the tick.
+  BRIDGE_DAEMON_LAST_STEP="mcp_orphan_cleanup_early"
+  ( process_mcp_orphan_cleanup ) || true
+
   # Discord relay runs FIRST — lowest-latency path for DM wake.
   # Issue #1338 defense-in-depth: subshell-isolate (see note above
   # mcp_liveness_giveup_recovery for rationale).
@@ -10679,10 +10691,12 @@ cmd_sync_cycle() {
   if reap_idle_orphan_sessions; then
     changed=0
   fi
-  BRIDGE_DAEMON_LAST_STEP="mcp_orphan_cleanup"
-  if process_mcp_orphan_cleanup; then
-    changed=0
-  fi
+  # Incident #8807 P0b: the periodic MCP-orphan cleanup was moved to the TOP
+  # of this cycle (BRIDGE_DAEMON_LAST_STEP=mcp_orphan_cleanup_early) so it
+  # relieves process-pressure BEFORE the spawn-heavy surfaces
+  # (start_cron_dispatch_workers, process_on_demand_agents). The internal
+  # 300s throttle is unchanged, so the cadence is identical — only the
+  # in-cycle ordering moved. The late call here is intentionally removed.
   if [[ "$changed" == "0" ]]; then
     BRIDGE_DAEMON_LAST_STEP="post_sync"
     "$BRIDGE_BASH_BIN" "$SCRIPT_DIR/bridge-sync.sh" >/dev/null 2>&1 || true

--- a/bridge-mcp-cleanup.py
+++ b/bridge-mcp-cleanup.py
@@ -20,22 +20,45 @@ from dataclasses import dataclass
 from typing import Iterable
 
 
+# Incident #8807 P0b — provenance rules for every DEFAULT_PATTERN:
+#   * Each pattern MUST be specific to an Agent Bridge MCP server identity —
+#     a plugin npm/bun package name OR a bridge plugin-cache PATH. A bare
+#     interpreter name (`node`, `bun`, `mcp-server`) is FORBIDDEN: this host
+#     runs same-uid non-bridge processes that share interpreters, and
+#     `mcp-server-darwin-arm64` on this fleet is Pencil.app (lethal
+#     collateral if matched). When adding a signature, derive it from live
+#     `ps -axo command=` provenance for the actual bridge MCP, not a guess.
+#   * codex orphans are deliberately NOT reaped here (see incident notes):
+#     `codex resume <hash>` is a LIVE agent pair and must never be killed,
+#     and the disposable `codex exec --ephemeral` workers are a smaller
+#     multiplier than the MCP fleet — codex reaping is deferred to a
+#     follow-up with its own exact signature + negative control.
 DEFAULT_PATTERNS = [
     r"npm(\s+exec)?\s+@upstash/context7-mcp",
     r"npm(\s+exec)?\s+@playwright/mcp",
     r"npm(\s+exec)?.*firebase-tools.*mcp",
-    r"\bbun\b.*server\.ts",
     r"\bnode\b.*context7.*mcp",
     r"\bnode\b.*playwright.*mcp",
     r"\bnode\b.*firebase.*mcp",
-    # Issue #223: bun plugin roots accumulate as PID-1 orphans across
-    # agent restarts (shared-mode + tmux-kill-session + daemon reconcile
-    # all leave them reparented). Matching only `bun server.ts` was not
-    # enough — its parent `bun run --cwd .../plugins/<kind>` is
-    # unmatched, so the chain check in is_orphan_candidate() refused the
-    # server.ts child too. Restrict the patterns to Agent Bridge plugin
-    # paths so a developer's own `bun run --cwd ./myapp build` never
-    # matches.
+    # Incident #8807 P0b: Shopify dev MCP. Both the npm-exec launcher form
+    # and the resolved node entrypoint are matched (live provenance:
+    # `npm exec @shopify/dev-mcp` and `node …/@shopify/dev-mcp/…`).
+    r"npm(\s+exec)?\s+@shopify/dev-mcp",
+    r"\bnode\b.*@shopify/dev-mcp",
+    r"\bnode\b.*shopify-dev-mcp",
+    # Incident #8807 P0b: cosmax-crm MCP stdio proxy (live provenance:
+    # `node …/crm-mcp-proxy.mjs`). Anchored on the exact entrypoint file so
+    # an unrelated same-uid `node` never matches.
+    r"\bnode\b.*crm-mcp-proxy\.mjs",
+    # Issue #223 + Incident #8807 P0b: bun plugin roots accumulate as PID-1
+    # orphans across agent restarts (shared-mode + tmux-kill-session +
+    # daemon reconcile all leave them reparented). The original
+    # `\bbun\b.*server\.ts` was too broad — it matched an unrelated same-uid
+    # `bun … server.ts` (a developer's own project). Anchor the server.ts
+    # match on the bridge plugin-cache path so only Agent Bridge plugin
+    # servers qualify; the parent `bun run --cwd .../plugins/<kind>` chain
+    # patterns below keep is_orphan_candidate()'s parent-match happy.
+    r"\bbun\b.*(?:\.agent-bridge/plugins/|/claude-plugins-official/).*server\.ts",
     r"\bbun\s+run\s+--cwd\s+.+?\.agent-bridge/plugins/",
     r"\bbun\s+run\s+--cwd\s+.+?/claude-plugins-official/",
 ]
@@ -171,7 +194,86 @@ def alive(pid: int) -> bool:
         return True
 
 
-def kill_pid(pid: int, grace_seconds: float) -> tuple[bool, str]:
+def read_proc_identity(pid: int) -> tuple[str, int, int] | None:
+    """Re-read a single pid's (command, ppid, age_seconds) directly from ps.
+
+    Returns None if the pid is gone or unreadable. Used for PID-reuse
+    revalidation immediately before each signal so we never kill a process
+    that has been replaced (same numeric pid, different program) since the
+    snapshot that classified it as an orphan.
+    """
+    for age_flag, age_is_seconds in (("etimes=", True), ("etime=", False)):
+        try:
+            completed = subprocess.run(
+                ["ps", "-p", str(pid), "-o", f"ppid=,{age_flag},command="],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except subprocess.CalledProcessError:
+            # Non-zero exit on the first (etimes) form may mean "no such
+            # process" OR "unsupported field"; try the etime fallback before
+            # concluding the process is gone.
+            if age_is_seconds:
+                continue
+            return None
+        line = completed.stdout.strip()
+        if not line:
+            return None
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            return None
+        try:
+            ppid = int(parts[0])
+        except ValueError:
+            return None
+        age = int(parts[1]) if age_is_seconds else parse_etime(parts[1])
+        return parts[2], ppid, age
+    return None
+
+
+def still_killable(
+    pid: int,
+    expected_command: str,
+    expected_pattern: re.Pattern[str],
+    expected_ppid: int,
+    min_observed_age: int,
+) -> bool:
+    """PID-reuse guard: confirm the pid is still the same orphan we classified.
+
+    Requires that the live process at `pid` (a) still exists, (b) still
+    matches the same pattern, (c) has the same parent (so the orphan chain is
+    unchanged), and (d) is at least as old as when we first saw it (a reused
+    pid would be YOUNGER). Any mismatch → refuse to signal it.
+    """
+    identity = read_proc_identity(pid)
+    if identity is None:
+        return False
+    command, ppid, age = identity
+    if not expected_pattern.search(command):
+        return False
+    if command != expected_command:
+        return False
+    if ppid != expected_ppid:
+        return False
+    # A reused pid is a fresh process → strictly younger than our snapshot.
+    if age < min_observed_age:
+        return False
+    return True
+
+
+def kill_pid(
+    pid: int,
+    grace_seconds: float,
+    expected_command: str,
+    expected_pattern: re.Pattern[str],
+    expected_ppid: int,
+    min_observed_age: int,
+) -> tuple[bool, str]:
+    # PID-reuse revalidation IMMEDIATELY before SIGTERM.
+    if not still_killable(pid, expected_command, expected_pattern, expected_ppid, min_observed_age):
+        return True, "skipped-pid-reuse"
     try:
         os.kill(pid, signal.SIGTERM)
     except ProcessLookupError:
@@ -185,6 +287,10 @@ def kill_pid(pid: int, grace_seconds: float) -> tuple[bool, str]:
             return True, "terminated"
         time.sleep(0.05)
 
+    # PID-reuse revalidation AGAIN before the escalation to SIGKILL — the pid
+    # may have exited and been recycled during the grace window.
+    if not still_killable(pid, expected_command, expected_pattern, expected_ppid, min_observed_age):
+        return True, "skipped-pid-reuse-pre-kill"
     try:
         os.kill(pid, signal.SIGKILL)
     except ProcessLookupError:
@@ -218,15 +324,37 @@ def build_report(args: argparse.Namespace) -> dict[str, object]:
     # Kill children before their orphan MCP parents.
     orphans.sort(key=lambda item: int(item["pid"]), reverse=True)
 
+    # Map each pattern string back to its compiled object so the kill path can
+    # re-match the (possibly re-read) command during PID-reuse revalidation.
+    pattern_by_str = {pattern.pattern: pattern for pattern in patterns}
+
     killed = []
     errors = []
+    skipped = []
     if args.kill:
         for item in orphans:
             pid = int(item["pid"])
-            ok, status = kill_pid(pid, args.grace_seconds)
+            expected_pattern = pattern_by_str.get(str(item["pattern"]))
+            if expected_pattern is None:
+                # Should not happen (item["pattern"] came from this set), but
+                # never signal a pid we cannot revalidate against a pattern.
+                enriched = dict(item)
+                enriched["kill_status"] = "skipped-no-pattern"
+                skipped.append(enriched)
+                continue
+            ok, status = kill_pid(
+                pid,
+                args.grace_seconds,
+                str(item["command"]),
+                expected_pattern,
+                int(item["ppid"]),
+                int(item["age_seconds"]),
+            )
             enriched = dict(item)
             enriched["kill_status"] = status
-            if ok:
+            if status.startswith("skipped-"):
+                skipped.append(enriched)
+            elif ok:
                 killed.append(enriched)
             else:
                 errors.append(enriched)
@@ -239,10 +367,12 @@ def build_report(args: argparse.Namespace) -> dict[str, object]:
         "matched_count": len(matched),
         "orphan_count": len(orphans),
         "killed_count": len(killed),
+        "skipped_count": len(skipped),
         "freed_mb_estimate": round(killed_rss_kb / 1024, 1),
         "matched": matched,
         "orphans": orphans,
         "killed": killed,
+        "skipped": skipped,
         "errors": errors,
     }
 

--- a/bridge-mcp-cleanup.py
+++ b/bridge-mcp-cleanup.py
@@ -56,8 +56,10 @@ DEFAULT_PATTERNS = [
     # `node …/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/<ver>/
     # scripts/crm-mcp-proxy.mjs`) — the prior `\bnode\b.*crm-mcp-proxy\.mjs`
     # was too broad and would have matched an unrelated same-uid
-    # `node /tmp/x/crm-mcp-proxy.mjs` (codex r1 CRITICAL).
-    r"\.claude/plugins/.*crm-mcp-proxy\.mjs",
+    # `node /tmp/x/crm-mcp-proxy.mjs` (codex r1 CRITICAL). r2 (codex): anchor on
+    # the `/cache/` segment so a user's project-local `.claude/plugins/local/...`
+    # dev tree is NOT reaped either.
+    r"\.claude/plugins/cache/.*crm-mcp-proxy\.mjs",
     # Issue #223 + Incident #8807 P0b: bun plugin roots accumulate as PID-1
     # orphans across agent restarts (shared-mode + tmux-kill-session +
     # daemon reconcile all leave them reparented). The original

--- a/bridge-mcp-cleanup.py
+++ b/bridge-mcp-cleanup.py
@@ -40,16 +40,24 @@ DEFAULT_PATTERNS = [
     r"\bnode\b.*context7.*mcp",
     r"\bnode\b.*playwright.*mcp",
     r"\bnode\b.*firebase.*mcp",
-    # Incident #8807 P0b: Shopify dev MCP. Both the npm-exec launcher form
-    # and the resolved node entrypoint are matched (live provenance:
-    # `npm exec @shopify/dev-mcp` and `node …/@shopify/dev-mcp/…`).
+    # Incident #8807 P0b (r2): Shopify dev MCP. Three forms, all anchored to
+    # bridge/npx provenance so an unrelated same-uid `node` never matches:
+    #   - `npm exec @shopify/dev-mcp` (launcher) and `node …/@shopify/dev-mcp/…`
+    #     (scoped-package path) are inherently scoped by the package name.
+    #   - the bare-basename `shopify-dev-mcp` form (live:
+    #     `node …/.npm/_npx/<hash>/node_modules/.bin/shopify-dev-mcp`) is
+    #     anchored on `node_modules/` so a developer's own
+    #     `/tmp/.../shopify-dev-mcp` script is NOT reaped (codex r2).
     r"npm(\s+exec)?\s+@shopify/dev-mcp",
     r"\bnode\b.*@shopify/dev-mcp",
-    r"\bnode\b.*shopify-dev-mcp",
-    # Incident #8807 P0b: cosmax-crm MCP stdio proxy (live provenance:
-    # `node …/crm-mcp-proxy.mjs`). Anchored on the exact entrypoint file so
-    # an unrelated same-uid `node` never matches.
-    r"\bnode\b.*crm-mcp-proxy\.mjs",
+    r"\bnode\b.*node_modules/.*shopify-dev-mcp",
+    # Incident #8807 P0b (r2): cosmax-crm MCP stdio proxy. Anchored on the
+    # bridge plugin-cache provenance (live:
+    # `node …/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/<ver>/
+    # scripts/crm-mcp-proxy.mjs`) — the prior `\bnode\b.*crm-mcp-proxy\.mjs`
+    # was too broad and would have matched an unrelated same-uid
+    # `node /tmp/x/crm-mcp-proxy.mjs` (codex r1 CRITICAL).
+    r"\.claude/plugins/.*crm-mcp-proxy\.mjs",
     # Issue #223 + Incident #8807 P0b: bun plugin roots accumulate as PID-1
     # orphans across agent restarts (shared-mode + tmux-kill-session +
     # daemon reconcile all leave them reparented). The original

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -116,6 +116,11 @@ add_required 1473-agent-list-iso-state-fallback
 # scripts/smoke/* catch-all → add_all_required_static — still re-runs the
 # coalesce smoke.
 add_required 8807-cron-backfill-coalesce
+# Incident #8807 P0b: in the full static suite so a change to the reaper helper
+# (scripts/smoke/8807-mcp-reaper-patterns-helper.py) — which hits the
+# scripts/smoke/* catch-all → add_all_required_static — still re-runs the
+# reaper-pattern smoke.
+add_required 8807-mcp-reaper-patterns
 
 
 }
@@ -1099,9 +1104,14 @@ select_for_path() {
       # Incident #8807 P0b: the MCP-orphan reaper's DEFAULT_PATTERNS (tightened
       # to bridge-owned identities/paths + extended to the missing bridge MCP
       # signatures, never matching Pencil.app's mcp-server-darwin-arm64 or live
-      # `codex resume` agents) and the PID-reuse revalidation in kill_pid. Pull
-      # 8807-mcp-reaper-patterns on every move so the positive/negative control
-      # matrix and the pre-TERM/pre-KILL revalidation cannot regress.
+      # `codex resume` agents) and the PID-reuse revalidation in kill_pid. The
+      # r2 control matrix + spawn fixtures live in the file-as-argv helper
+      # (8807-mcp-reaper-patterns-helper.py, extracted to drop heredoc-stdin);
+      # a change to that helper hits the `scripts/smoke/*` catch-all above,
+      # which runs the full static suite (where 8807-mcp-reaper-patterns is
+      # also registered). Pull 8807-mcp-reaper-patterns on every reaper move so
+      # the control matrix and the pre-TERM/pre-KILL revalidation cannot
+      # regress.
       add_required 8807-mcp-reaper-patterns
       ;;
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -1084,8 +1084,25 @@ select_for_path() {
       # cannot regress back to the pre-#1353 4-burst noise surface
       # that masks real errors during fresh-install OOTB.
       add_required 1353-setup-pending-grace
+      # Incident #8807 P0b: bridge-daemon.sh moved the periodic MCP-orphan
+      # cleanup (process_mcp_orphan_cleanup) to the TOP of cmd_sync_cycle so
+      # it relieves process-pressure before the spawn-heavy surfaces. Pull
+      # 8807-mcp-reaper-patterns on every bridge-daemon.sh move so the
+      # pressure-relief ordering and the single-invocation invariant cannot
+      # silently regress.
+      add_required 8807-mcp-reaper-patterns
       add_integration integration-minimal
       add_live live-tmux-daemon
+      ;;
+
+    bridge-mcp-cleanup.py)
+      # Incident #8807 P0b: the MCP-orphan reaper's DEFAULT_PATTERNS (tightened
+      # to bridge-owned identities/paths + extended to the missing bridge MCP
+      # signatures, never matching Pencil.app's mcp-server-darwin-arm64 or live
+      # `codex resume` agents) and the PID-reuse revalidation in kill_pid. Pull
+      # 8807-mcp-reaper-patterns on every move so the positive/negative control
+      # matrix and the pre-TERM/pre-KILL revalidation cannot regress.
+      add_required 8807-mcp-reaper-patterns
       ;;
 
     lib/bridge-daemon-control.sh|scripts/install-daemon-systemd.sh|scripts/sudoers-templates/agent-bridge-daemon-refresh.sudo.template)

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -4494,7 +4494,16 @@ cases_should_match = [
     # still see the plugin-root fragment.
     "bun run --cwd /Users/Space User/.agent-bridge/plugins/teams --silent start",
     "bun run --cwd /Users/Space User/.bun/install/claude-plugins-official/telegram/0.0.6 start",
-    "/home/ec2-user/.bun/bin/bun server.ts",
+    # Incident #8807 P0b: the bare `bun … server.ts` rule was tightened to a
+    # bridge-plugin-path anchor, so a bun server.ts MUST carry the plugin
+    # path to match.
+    "/home/u/.bun/bin/bun /home/u/.agent-bridge/plugins/teams/server.ts",
+    "bun /Users/x/.bun/install/claude-plugins-official/telegram/0.0.6/server.ts",
+    # Incident #8807 P0b: the newly-extended bridge MCP signatures.
+    "npm exec @shopify/dev-mcp@latest",
+    "node /Users/x/.npm/_npx/abc/node_modules/.bin/shopify-dev-mcp",
+    "node /Users/x/.npm/_npx/abc/node_modules/@shopify/dev-mcp/dist/index.js",
+    "node /Users/x/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/0.19.3-3/scripts/crm-mcp-proxy.mjs",
 ]
 for cmd in cases_should_match:
     matched = mod.matched_pattern(proc(10, cmd), patterns)
@@ -4507,6 +4516,24 @@ cases_should_not_match = [
     "bun run --cwd /tmp/foo test",
     "bun run dev",
     "node server.ts",  # without the bun word-boundary the server.ts-only rule must not false-positive
+    # Incident #8807 P0b: the bare `bun … server.ts` rule was tightened —
+    # an unrelated same-uid bun server.ts (a developer's own project) must
+    # NOT match now that the plugin-path anchor is required.
+    "/home/u/.bun/bin/bun server.ts",
+    "bun /Users/x/Projects/mywebapp/src/server.ts",
+    # Incident #8807 P0b CRITICAL negative controls — lethal collateral on
+    # the live host. None of these are Agent Bridge MCP servers and MUST
+    # never be reaped:
+    "/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64 --stdio",
+    "/usr/local/bin/mcp-server --port 9000",
+    "/Applications/Telegram.app/Contents/MacOS/Telegram",
+    "/Applications/Microsoft Teams.app/Contents/MacOS/MSTeams",
+    "node /Users/x/code/myapp/index.js",
+    # codex orphans are deliberately NOT reaped by the MCP cleaner. A
+    # `codex resume <hash>` is a LIVE agent pair; a `codex exec --ephemeral`
+    # worker is deferred to a follow-up. Neither may match here.
+    "codex resume 9f3a2b1c --cwd /home/agent",
+    "codex exec --ephemeral --skip-git-repo-check -C crm-dev",
 ]
 for cmd in cases_should_not_match:
     matched = mod.matched_pattern(proc(20, cmd), patterns)
@@ -4525,6 +4552,52 @@ assert matches[101], "server.ts child must match"
 assert mod.is_orphan_candidate(procs[100], procs, matches, 0), "plugin root ppid=1 must be orphan"
 assert mod.is_orphan_candidate(procs[101], procs, matches, 0), "server.ts child must chain through matched orphan parent"
 print("[ok] bun plugin orphan patterns + chain")
+
+# Incident #8807 P0b finding #4: PID-reuse revalidation. still_killable() must
+# refuse to signal a pid whose live identity no longer matches the orphan we
+# classified. Drive a real short-lived child so read_proc_identity() reads a
+# genuine process, then assert the four guards.
+import os as _os, re as _re, signal as _sig, subprocess as _sp, time as _time
+
+child = _sp.Popen(["/bin/sleep", "30"])
+try:
+    # Settle so ps can see it.
+    for _ in range(50):
+        if mod.read_proc_identity(child.pid) is not None:
+            break
+        _time.sleep(0.05)
+    ident = mod.read_proc_identity(child.pid)
+    assert ident is not None, "read_proc_identity could not read a live child"
+    live_cmd, live_ppid, live_age = ident
+    sleep_pat = _re.compile(r"sleep")
+
+    # (a) exact identity → killable.
+    assert mod.still_killable(child.pid, live_cmd, sleep_pat, live_ppid, 0), \
+        "still_killable rejected the exact same live process"
+    # (b) command no longer matches the pattern → refuse.
+    assert not mod.still_killable(child.pid, live_cmd, _re.compile(r"this-will-never-match"), live_ppid, 0), \
+        "still_killable signalled a process whose command no longer matches the pattern"
+    # (c) expected command string differs (pid was reused by another program) → refuse.
+    assert not mod.still_killable(child.pid, "totally different command", sleep_pat, live_ppid, 0), \
+        "still_killable signalled a process whose command string changed (pid-reuse)"
+    # (d) parent changed (orphan chain no longer holds) → refuse.
+    assert not mod.still_killable(child.pid, live_cmd, sleep_pat, live_ppid + 99999, 0), \
+        "still_killable signalled a process whose ppid changed"
+    # (e) live process is younger than our snapshot age (reused pid) → refuse.
+    assert not mod.still_killable(child.pid, live_cmd, sleep_pat, live_ppid, live_age + 100000), \
+        "still_killable signalled a process younger than the snapshot (pid-reuse)"
+
+    # A gone pid → kill_pid short-circuits to skipped-pid-reuse (no signal sent).
+    child.terminate()
+    child.wait()
+    ok, status = mod.kill_pid(child.pid, 0.2, live_cmd, sleep_pat, live_ppid, 0)
+    assert ok and status == "skipped-pid-reuse", \
+        f"kill_pid on a vanished pid must skip, got ok={ok} status={status}"
+    print("[ok] PID-reuse revalidation (pre-TERM + pre-KILL guards)")
+finally:
+    if child.poll() is None:
+        child.kill()
+        child.wait()
 PY
 
 log "cleaning orphan MCP processes conservatively"
@@ -4620,6 +4693,70 @@ kill "$MCP_ATTACHED_PARENT_PID" >/dev/null 2>&1 || true
 wait "$MCP_ATTACHED_PARENT_PID" >/dev/null 2>&1 || true
 MCP_ATTACHED_CHILD_PID=""
 MCP_ATTACHED_PARENT_PID=""
+
+log "MCP cleanup default-pattern controls: Pencil.app-style + bridge orphan (incident #8807 P0b)"
+# Run the cleanup with the REAL DEFAULT_PATTERNS (no --pattern override) so the
+# tightened/extended pattern set itself is exercised. Spawn two PPID=1 orphans:
+#   (neg) a process whose argv looks like Pencil.app's mcp-server-darwin-arm64
+#         — lethal collateral if a bare mcp-server pattern were ever added.
+#   (pos) a process whose argv matches a real bridge default pattern
+#         (crm-mcp-proxy.mjs) under a temp path.
+# Both are launched via /bin/sleep with a crafted argv[0]; min-age 0; kill on.
+MCP_NEG_PID_FILE="$TMP_ROOT/mcp-neg.pid"
+MCP_POS_PID_FILE="$TMP_ROOT/mcp-pos.pid"
+# argv[0] strings: the negative control must NOT match any default pattern; the
+# positive control embeds the crm-mcp-proxy.mjs signature verbatim.
+# Both argv[0] strings are presented verbatim to ps (we exec /bin/sleep, so
+# argv[0] is the only displayed token and "600" is the sleep duration). The
+# crm-mcp-proxy.mjs signature is embedded with spaces in argv[0] so the
+# `\bnode\b.*crm-mcp-proxy\.mjs` default pattern matches the stitched command.
+MCP_NEG_ARGV="/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64-smoke-$SESSION_NAME"
+MCP_POS_ARGV="node /tmp/agent-bridge-smoke-$SESSION_NAME/crm-mcp-proxy.mjs"
+python3 - "$MCP_NEG_ARGV" "$MCP_NEG_PID_FILE" <<'PY'
+import subprocess, sys
+from pathlib import Path
+argv0, pid_file = sys.argv[1], sys.argv[2]
+proc = subprocess.Popen([argv0, "600"], executable="/bin/sleep",
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                        start_new_session=True)
+Path(pid_file).write_text(str(proc.pid), encoding="utf-8")
+PY
+python3 - "$MCP_POS_ARGV" "$MCP_POS_PID_FILE" <<'PY'
+import subprocess, sys
+from pathlib import Path
+# Keep the whole signature as a single argv[0] (spaces included) so /bin/sleep
+# receives exactly ["<signature>", "600"] — ps then shows
+# "node /tmp/.../crm-mcp-proxy.mjs 600" and the default pattern matches, while
+# sleep still gets a single numeric duration.
+argv0, pid_file = sys.argv[1], sys.argv[2]
+proc = subprocess.Popen([argv0, "600"], executable="/bin/sleep",
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                        start_new_session=True)
+Path(pid_file).write_text(str(proc.pid), encoding="utf-8")
+PY
+MCP_NEG_PID="$(cat "$MCP_NEG_PID_FILE")"
+MCP_POS_PID="$(cat "$MCP_POS_PID_FILE")"
+for _ in {1..20}; do
+  kill -0 "$MCP_NEG_PID" >/dev/null 2>&1 && kill -0 "$MCP_POS_PID" >/dev/null 2>&1 && break
+  sleep 0.1
+done
+kill -0 "$MCP_NEG_PID" >/dev/null 2>&1 || die "negative-control MCP process did not start"
+kill -0 "$MCP_POS_PID" >/dev/null 2>&1 || die "positive-control MCP process did not start"
+# Dry-run first: audits the positive control but kills nothing.
+MCP_DEFAULT_DRYRUN_JSON="$(python3 "$REPO_ROOT/bridge-mcp-cleanup.py" cleanup --dry-run --min-age 0 --json)"
+assert_contains "$MCP_DEFAULT_DRYRUN_JSON" "\"killed_count\": 0"
+kill -0 "$MCP_POS_PID" >/dev/null 2>&1 || die "dry-run killed the positive control (must audit-only)"
+# Real kill with the default pattern set.
+python3 "$REPO_ROOT/bridge-mcp-cleanup.py" cleanup --kill --min-age 0 --json >/dev/null
+sleep 0.3
+kill -0 "$MCP_NEG_PID" >/dev/null 2>&1 || die "default cleanup killed the Pencil.app-style mcp-server process (lethal collateral!)"
+if kill -0 "$MCP_POS_PID" >/dev/null 2>&1; then
+  die "default cleanup did NOT kill the bridge crm-mcp-proxy orphan"
+fi
+log "[ok] default cleanup: Pencil.app-style survived, bridge orphan reaped, dry-run killed none"
+kill "$MCP_NEG_PID" >/dev/null 2>&1 || true
+MCP_NEG_PID=""
+MCP_POS_PID=""
 
 log "cleaning orphan MCP processes immediately before bridge-run relaunch"
 MCP_RESTART_AGENT="mcp-restart-$SESSION_NAME"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -4529,6 +4529,13 @@ cases_should_not_match = [
     "/Applications/Telegram.app/Contents/MacOS/Telegram",
     "/Applications/Microsoft Teams.app/Contents/MacOS/MSTeams",
     "node /Users/x/code/myapp/index.js",
+    # Incident #8807 P0b r2 (codex CRITICAL): the crm + shopify matchers are
+    # bridge-scoped — an unrelated same-uid node running a like-named script
+    # OUTSIDE the bridge plugin-cache / node_modules must NOT be reaped.
+    "node /tmp/unrelated/crm-mcp-proxy.mjs",
+    "node /Users/x/Projects/myproj/scripts/crm-mcp-proxy.mjs",
+    "node /tmp/foo/shopify-dev-mcp",
+    "node /Users/x/code/app/bin/shopify-dev-mcp",
     # codex orphans are deliberately NOT reaped by the MCP cleaner. A
     # `codex resume <hash>` is a LIVE agent pair; a `codex exec --ephemeral`
     # worker is deferred to a follow-up. Neither may match here.
@@ -4705,35 +4712,18 @@ log "MCP cleanup default-pattern controls: Pencil.app-style + bridge orphan (inc
 MCP_NEG_PID_FILE="$TMP_ROOT/mcp-neg.pid"
 MCP_POS_PID_FILE="$TMP_ROOT/mcp-pos.pid"
 # argv[0] strings: the negative control must NOT match any default pattern; the
-# positive control embeds the crm-mcp-proxy.mjs signature verbatim.
-# Both argv[0] strings are presented verbatim to ps (we exec /bin/sleep, so
+# positive control embeds the bridge-scoped crm-mcp-proxy.mjs signature. Both
+# argv[0] strings are presented verbatim to ps (the helper execs /bin/sleep, so
 # argv[0] is the only displayed token and "600" is the sleep duration). The
-# crm-mcp-proxy.mjs signature is embedded with spaces in argv[0] so the
-# `\bnode\b.*crm-mcp-proxy\.mjs` default pattern matches the stitched command.
+# spawn helper is file-as-argv (no heredoc-stdin — lint-heredoc-ban C3 ban).
+# r2: the positive argv embeds `.claude/plugins/` so it matches the
+# bridge-scoped crm pattern `\.claude/plugins/.*crm-mcp-proxy\.mjs`; a bare
+# `/tmp/.../crm-mcp-proxy.mjs` would (correctly) no longer match.
+MCP_SPAWN_HELPER="$REPO_ROOT/scripts/smoke/8807-mcp-reaper-patterns-helper.py"
 MCP_NEG_ARGV="/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64-smoke-$SESSION_NAME"
-MCP_POS_ARGV="node /tmp/agent-bridge-smoke-$SESSION_NAME/crm-mcp-proxy.mjs"
-python3 - "$MCP_NEG_ARGV" "$MCP_NEG_PID_FILE" <<'PY'
-import subprocess, sys
-from pathlib import Path
-argv0, pid_file = sys.argv[1], sys.argv[2]
-proc = subprocess.Popen([argv0, "600"], executable="/bin/sleep",
-                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                        start_new_session=True)
-Path(pid_file).write_text(str(proc.pid), encoding="utf-8")
-PY
-python3 - "$MCP_POS_ARGV" "$MCP_POS_PID_FILE" <<'PY'
-import subprocess, sys
-from pathlib import Path
-# Keep the whole signature as a single argv[0] (spaces included) so /bin/sleep
-# receives exactly ["<signature>", "600"] — ps then shows
-# "node /tmp/.../crm-mcp-proxy.mjs 600" and the default pattern matches, while
-# sleep still gets a single numeric duration.
-argv0, pid_file = sys.argv[1], sys.argv[2]
-proc = subprocess.Popen([argv0, "600"], executable="/bin/sleep",
-                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                        start_new_session=True)
-Path(pid_file).write_text(str(proc.pid), encoding="utf-8")
-PY
+MCP_POS_ARGV="node /tmp/agent-bridge-smoke-$SESSION_NAME/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/0.0.0/scripts/crm-mcp-proxy.mjs"
+python3 "$MCP_SPAWN_HELPER" spawn "$MCP_NEG_ARGV" "$MCP_NEG_PID_FILE"
+python3 "$MCP_SPAWN_HELPER" spawn "$MCP_POS_ARGV" "$MCP_POS_PID_FILE"
 MCP_NEG_PID="$(cat "$MCP_NEG_PID_FILE")"
 MCP_POS_PID="$(cat "$MCP_POS_PID_FILE")"
 for _ in {1..20}; do

--- a/scripts/smoke/8807-mcp-reaper-patterns-helper.py
+++ b/scripts/smoke/8807-mcp-reaper-patterns-helper.py
@@ -86,6 +86,9 @@ def cmd_pattern_matrix(reaper_path: str) -> int:
         # same-uid node running a like-named script must NOT match.
         "node /tmp/unrelated/crm-mcp-proxy.mjs",
         "node /Users/x/Projects/myproj/scripts/crm-mcp-proxy.mjs",
+        # #1480 r2 (codex): a project-local .claude/plugins/LOCAL tree is NOT
+        # the bridge plugin-cache and must NOT match the cache-anchored pattern.
+        "node /Users/alice/project/.claude/plugins/local/scripts/crm-mcp-proxy.mjs",
         "node /tmp/foo/shopify-dev-mcp",
         "node /Users/x/code/app/bin/shopify-dev-mcp",
         # codex orphans are NOT reaped by the MCP cleaner.

--- a/scripts/smoke/8807-mcp-reaper-patterns-helper.py
+++ b/scripts/smoke/8807-mcp-reaper-patterns-helper.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Helper for scripts/smoke/8807-mcp-reaper-patterns.sh (incident #8807 P0b).
+
+Extracted from the smoke's inline `python3 - <<'PY'` heredocs so the smoke
+carries no heredoc-stdin sites (lint-heredoc-ban C3 ban; see KNOWN_ISSUES.md
+§26). Invoked file-as-argv per the lib/upgrade-helpers pattern:
+
+    python3 8807-mcp-reaper-patterns-helper.py pattern-matrix <reaper.py>
+    python3 8807-mcp-reaper-patterns-helper.py pid-reuse     <reaper.py>
+    python3 8807-mcp-reaper-patterns-helper.py spawn <argv0> <pid_file>
+
+Each subcommand exits non-zero (with a message on stderr) on failure so the
+calling smoke can `|| smoke_fail`.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _load_default_patterns(reaper_path: str) -> list[re.Pattern[str]]:
+    """Extract DEFAULT_PATTERNS from the reaper source via AST (no import — the
+    module's dataclass introspection is fragile under a non-standard module
+    name on some Python builds)."""
+    src = Path(reaper_path).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    patterns: list[str] | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "DEFAULT_PATTERNS":
+                    patterns = [ast.literal_eval(elt) for elt in node.value.elts]
+    if not patterns:
+        print("could not extract DEFAULT_PATTERNS", file=sys.stderr)
+        sys.exit(1)
+    return [re.compile(p) for p in patterns]
+
+
+def _load_module(reaper_path: str):
+    spec = importlib.util.spec_from_file_location("bridge_mcp_cleanup", reaper_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def cmd_pattern_matrix(reaper_path: str) -> int:
+    pats = _load_default_patterns(reaper_path)
+
+    def hit(cmd: str) -> bool:
+        return any(p.search(cmd) for p in pats)
+
+    positive = [
+        "npm exec @upstash/context7-mcp",
+        "npm exec @playwright/mcp@latest",
+        "npm exec @shopify/dev-mcp@latest",
+        # Shopify bare-basename resolved entrypoint (anchored on node_modules/).
+        "node /Users/x/.npm/_npx/abc/node_modules/.bin/shopify-dev-mcp",
+        "node /Users/x/.npm/_npx/abc/node_modules/@shopify/dev-mcp/dist/index.js",
+        # cosmax-crm proxy under the bridge plugin-cache.
+        "node /Users/x/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/0.19.3-3/scripts/crm-mcp-proxy.mjs",
+        "node /home/u/.npm/_npx/abc/node_modules/.bin/context7-mcp",
+        "bun /home/u/.agent-bridge/plugins/teams/server.ts",
+        "bun run --cwd /home/u/.agent-bridge/plugins/telegram --silent start",
+        "bun run --cwd /home/u/.bun/install/claude-plugins-official/telegram/0.0.6 start",
+    ]
+    negative = [
+        # Lethal collateral on the live host — none are Agent Bridge MCP servers.
+        "/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64 --stdio",
+        "/usr/local/bin/mcp-server --port 9000",
+        "/Applications/Telegram.app/Contents/MacOS/Telegram",
+        "/Applications/Microsoft Teams.app/Contents/MacOS/MSTeams",
+        "/Applications/Figma.app/Contents/MacOS/Figma",
+        # Bare interpreters / unrelated same-uid projects.
+        "node /Users/x/code/myapp/index.js",
+        "/home/u/.bun/bin/bun server.ts",
+        "bun /Users/x/Projects/mywebapp/src/server.ts",
+        "bun run --cwd /home/user/myproject build",
+        # codex r2: crm/shopify matchers must be bridge-scoped — an unrelated
+        # same-uid node running a like-named script must NOT match.
+        "node /tmp/unrelated/crm-mcp-proxy.mjs",
+        "node /Users/x/Projects/myproj/scripts/crm-mcp-proxy.mjs",
+        "node /tmp/foo/shopify-dev-mcp",
+        "node /Users/x/code/app/bin/shopify-dev-mcp",
+        # codex orphans are NOT reaped by the MCP cleaner.
+        "codex resume 9f3a2b1c --cwd /home/agent",
+        "codex exec --ephemeral --skip-git-repo-check -C crm-dev",
+    ]
+
+    bad: list[tuple[str, str]] = []
+    for cmd in positive:
+        if not hit(cmd):
+            bad.append(("MISS positive", cmd))
+    for cmd in negative:
+        if hit(cmd):
+            bad.append(("LETHAL negative", cmd))
+    if bad:
+        for kind, cmd in bad:
+            print(f"{kind}: {cmd}", file=sys.stderr)
+        return 1
+    print(f"[ok] {len(positive)} positive + {len(negative)} negative controls correct")
+    return 0
+
+
+def cmd_pid_reuse(reaper_path: str) -> int:
+    mod = _load_module(reaper_path)
+    child = subprocess.Popen(["/bin/sleep", "30"])
+    try:
+        for _ in range(50):
+            if mod.read_proc_identity(child.pid) is not None:
+                break
+            time.sleep(0.05)
+        ident = mod.read_proc_identity(child.pid)
+        assert ident is not None, "could not read live child identity"
+        cmd, ppid, age = ident
+        sp = re.compile(r"sleep")
+        assert mod.still_killable(child.pid, cmd, sp, ppid, 0), "exact identity must be killable"
+        assert not mod.still_killable(child.pid, cmd, re.compile("nomatch"), ppid, 0), "pattern-mismatch must refuse"
+        assert not mod.still_killable(child.pid, "different", sp, ppid, 0), "command-change must refuse"
+        assert not mod.still_killable(child.pid, cmd, sp, ppid + 99999, 0), "ppid-change must refuse"
+        assert not mod.still_killable(child.pid, cmd, sp, ppid, age + 100000), "younger-than-snapshot must refuse"
+        child.terminate()
+        child.wait()
+        ok, status = mod.kill_pid(child.pid, 0.2, cmd, sp, ppid, 0)
+        assert ok and status == "skipped-pid-reuse", f"vanished pid must skip, got ({ok},{status})"
+        print("[ok] PID-reuse revalidation enforced")
+        return 0
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait()
+
+
+def cmd_spawn(argv0: str, pid_file: str) -> int:
+    """Spawn a /bin/sleep with a crafted argv[0] so ps shows <argv0> 600.
+
+    argv[0] is the only displayed token; "600" is the sleep duration. Detached
+    (start_new_session) so it reparents to init/launchd (PPID=1) as an orphan.
+    """
+    proc = subprocess.Popen(
+        [argv0, "600"],
+        executable="/bin/sleep",
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    Path(pid_file).write_text(str(proc.pid), encoding="utf-8")
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: 8807-mcp-reaper-patterns-helper.py <pattern-matrix|pid-reuse|spawn> ...", file=sys.stderr)
+        return 2
+    command = argv[1]
+    if command == "pattern-matrix":
+        return cmd_pattern_matrix(argv[2])
+    if command == "pid-reuse":
+        return cmd_pid_reuse(argv[2])
+    if command == "spawn":
+        return cmd_spawn(argv[2], argv[3])
+    print(f"unknown subcommand: {command}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/scripts/smoke/8807-mcp-reaper-patterns.sh
+++ b/scripts/smoke/8807-mcp-reaper-patterns.sh
@@ -26,6 +26,9 @@ source "$SCRIPT_DIR/lib.sh"
 
 REAPER_PY="$SMOKE_REPO_ROOT/bridge-mcp-cleanup.py"
 DAEMON_SH="$SMOKE_REPO_ROOT/bridge-daemon.sh"
+# Helper carries the python bodies file-as-argv (no heredoc-stdin — lint-
+# heredoc-ban C3 ban; see KNOWN_ISSUES.md §26).
+HELPER_PY="$SCRIPT_DIR/8807-mcp-reaper-patterns-helper.py"
 
 smoke_log "A1: bridge-mcp-cleanup.py compiles"
 python3 -c "import py_compile; py_compile.compile('$REAPER_PY', doraise=True)" || \
@@ -39,97 +42,16 @@ bash -n "$DAEMON_SH" || smoke_fail "bridge-daemon.sh failed bash -n"
 # (lethal collateral MUST NOT match), driven against the REAL DEFAULT_PATTERNS.
 # ---------------------------------------------------------------------------
 smoke_log "B: DEFAULT_PATTERNS positive + negative control matrix"
-python3 - "$REAPER_PY" <<'PY' || smoke_fail "DEFAULT_PATTERNS control matrix failed"
-import ast, re, sys
-src = open(sys.argv[1]).read()
-tree = ast.parse(src)
-patterns = None
-for node in ast.walk(tree):
-    if isinstance(node, ast.Assign):
-        for t in node.targets:
-            if isinstance(t, ast.Name) and t.id == "DEFAULT_PATTERNS":
-                patterns = [ast.literal_eval(e) for e in node.value.elts]
-assert patterns, "could not extract DEFAULT_PATTERNS"
-pats = [re.compile(p) for p in patterns]
-def hit(cmd): return any(p.search(cmd) for p in pats)
-
-POSITIVE = [
-    "npm exec @upstash/context7-mcp",
-    "npm exec @playwright/mcp@latest",
-    "npm exec @shopify/dev-mcp@latest",
-    "node /Users/x/.npm/_npx/abc/node_modules/.bin/shopify-dev-mcp",
-    "node /Users/x/.npm/_npx/abc/node_modules/@shopify/dev-mcp/dist/index.js",
-    "node /Users/x/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/0.19.3-3/scripts/crm-mcp-proxy.mjs",
-    "node /home/u/.npm/_npx/abc/node_modules/.bin/context7-mcp",
-    "bun /home/u/.agent-bridge/plugins/teams/server.ts",
-    "bun run --cwd /home/u/.agent-bridge/plugins/telegram --silent start",
-    "bun run --cwd /home/u/.bun/install/claude-plugins-official/telegram/0.0.6 start",
-]
-NEGATIVE = [
-    # Lethal collateral on the live host — none are Agent Bridge MCP servers.
-    "/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64 --stdio",
-    "/usr/local/bin/mcp-server --port 9000",
-    "/Applications/Telegram.app/Contents/MacOS/Telegram",
-    "/Applications/Microsoft Teams.app/Contents/MacOS/MSTeams",
-    "/Applications/Figma.app/Contents/MacOS/Figma",
-    # Bare interpreters / unrelated same-uid projects.
-    "node /Users/x/code/myapp/index.js",
-    "/home/u/.bun/bin/bun server.ts",
-    "bun /Users/x/Projects/mywebapp/src/server.ts",
-    "bun run --cwd /home/user/myproject build",
-    # codex orphans are NOT reaped by the MCP cleaner.
-    "codex resume 9f3a2b1c --cwd /home/agent",
-    "codex exec --ephemeral --skip-git-repo-check -C crm-dev",
-]
-bad = []
-for c in POSITIVE:
-    if not hit(c):
-        bad.append(("MISS positive", c))
-for c in NEGATIVE:
-    if hit(c):
-        bad.append(("LETHAL negative", c))
-if bad:
-    for kind, c in bad:
-        print(f"{kind}: {c}", file=sys.stderr)
-    sys.exit(1)
-print(f"[ok] {len(POSITIVE)} positive + {len(NEGATIVE)} negative controls correct")
-PY
+python3 "$HELPER_PY" pattern-matrix "$REAPER_PY" || \
+  smoke_fail "DEFAULT_PATTERNS control matrix failed"
 
 # ---------------------------------------------------------------------------
 # PID-reuse revalidation — the kill path must refuse a pid whose live identity
 # changed since classification.
 # ---------------------------------------------------------------------------
 smoke_log "C: PID-reuse revalidation (pre-TERM + pre-KILL guards)"
-python3 - "$REAPER_PY" <<'PY' || smoke_fail "PID-reuse revalidation failed"
-import importlib.util, re, subprocess, sys, time
-spec = importlib.util.spec_from_file_location("bridge_mcp_cleanup", sys.argv[1])
-mod = importlib.util.module_from_spec(spec)
-sys.modules[spec.name] = mod
-spec.loader.exec_module(mod)
-
-child = subprocess.Popen(["/bin/sleep", "30"])
-try:
-    for _ in range(50):
-        if mod.read_proc_identity(child.pid) is not None:
-            break
-        time.sleep(0.05)
-    ident = mod.read_proc_identity(child.pid)
-    assert ident is not None, "could not read live child identity"
-    cmd, ppid, age = ident
-    sp = re.compile(r"sleep")
-    assert mod.still_killable(child.pid, cmd, sp, ppid, 0), "exact identity must be killable"
-    assert not mod.still_killable(child.pid, cmd, re.compile("nomatch"), ppid, 0), "pattern-mismatch must refuse"
-    assert not mod.still_killable(child.pid, "different", sp, ppid, 0), "command-change must refuse"
-    assert not mod.still_killable(child.pid, cmd, sp, ppid + 99999, 0), "ppid-change must refuse"
-    assert not mod.still_killable(child.pid, cmd, sp, ppid, age + 100000), "younger-than-snapshot must refuse"
-    child.terminate(); child.wait()
-    ok, status = mod.kill_pid(child.pid, 0.2, cmd, sp, ppid, 0)
-    assert ok and status == "skipped-pid-reuse", f"vanished pid must skip, got ({ok},{status})"
-    print("[ok] PID-reuse revalidation enforced")
-finally:
-    if child.poll() is None:
-        child.kill(); child.wait()
-PY
+python3 "$HELPER_PY" pid-reuse "$REAPER_PY" || \
+  smoke_fail "PID-reuse revalidation failed"
 
 # ---------------------------------------------------------------------------
 # Runtime control: a Pencil.app-style mcp-server name survives a real
@@ -137,19 +59,14 @@ PY
 # dry-run kills nothing.
 # ---------------------------------------------------------------------------
 smoke_log "D: runtime default-pattern kill — Pencil.app survives, bridge orphan reaped, dry-run kills none"
+# NOTE the positive-control argv embeds `.claude/plugins/` so it matches the
+# r2 bridge-scoped crm pattern (`\.claude/plugins/.*crm-mcp-proxy\.mjs`); a
+# bare `/tmp/.../crm-mcp-proxy.mjs` would (correctly) NO LONGER match.
 TMP_D="$(mktemp -d "${TMPDIR:-/tmp}/agb-8807p0b-XXXXXX")"
 neg_argv="/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64-smoke-$$"
-pos_argv="node /tmp/agent-bridge-8807-smoke-$$/crm-mcp-proxy.mjs"
+pos_argv="node /tmp/agb-8807-smoke-$$/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/0.0.0/scripts/crm-mcp-proxy.mjs"
 spawn_argv() {
-  python3 - "$1" "$2" <<'PY'
-import subprocess, sys
-from pathlib import Path
-argv0, pid_file = sys.argv[1], sys.argv[2]
-proc = subprocess.Popen([argv0, "600"], executable="/bin/sleep",
-                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                        start_new_session=True)
-Path(pid_file).write_text(str(proc.pid), encoding="utf-8")
-PY
+  python3 "$HELPER_PY" spawn "$1" "$2"
 }
 spawn_argv "$neg_argv" "$TMP_D/neg.pid"
 spawn_argv "$pos_argv" "$TMP_D/pos.pid"

--- a/scripts/smoke/8807-mcp-reaper-patterns.sh
+++ b/scripts/smoke/8807-mcp-reaper-patterns.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/8807-mcp-reaper-patterns.sh — incident #8807 P0b.
+#
+# The periodic MCP-orphan cleanup (process_mcp_orphan_cleanup →
+# bridge-mcp-cleanup.py) already existed; the fork-storm incident happened
+# because its DEFAULT_PATTERNS MISSED the bridge MCP types that piled up. P0b
+# tightens the generic patterns to bridge-owned identities/paths and EXTENDS
+# them to the missing bridge signatures, WITHOUT ever matching lethal
+# collateral (Pencil.app `mcp-server-darwin-arm64`, desktop helpers, live
+# `codex resume` agents). It also adds PID-reuse revalidation before each
+# signal and moves the cleanup to the top of the daemon sync cycle.
+#
+# This smoke is CI-faithful and self-contained: it drives the pattern set +
+# PID-reuse logic via the real bridge-mcp-cleanup.py module, and grep-pins the
+# daemon ordering move. It spawns only short-lived /bin/sleep children with
+# crafted argv (no tmux, no live agents) so it is safe to run in CI and
+# locally.
+
+set -euo pipefail
+
+SMOKE_NAME="8807-mcp-reaper-patterns"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REAPER_PY="$SMOKE_REPO_ROOT/bridge-mcp-cleanup.py"
+DAEMON_SH="$SMOKE_REPO_ROOT/bridge-daemon.sh"
+
+smoke_log "A1: bridge-mcp-cleanup.py compiles"
+python3 -c "import py_compile; py_compile.compile('$REAPER_PY', doraise=True)" || \
+  smoke_fail "bridge-mcp-cleanup.py failed py_compile"
+
+smoke_log "A2: bridge-daemon.sh is syntactically valid"
+bash -n "$DAEMON_SH" || smoke_fail "bridge-daemon.sh failed bash -n"
+
+# ---------------------------------------------------------------------------
+# Pattern controls — positive (bridge MCP identities MUST match) + negative
+# (lethal collateral MUST NOT match), driven against the REAL DEFAULT_PATTERNS.
+# ---------------------------------------------------------------------------
+smoke_log "B: DEFAULT_PATTERNS positive + negative control matrix"
+python3 - "$REAPER_PY" <<'PY' || smoke_fail "DEFAULT_PATTERNS control matrix failed"
+import ast, re, sys
+src = open(sys.argv[1]).read()
+tree = ast.parse(src)
+patterns = None
+for node in ast.walk(tree):
+    if isinstance(node, ast.Assign):
+        for t in node.targets:
+            if isinstance(t, ast.Name) and t.id == "DEFAULT_PATTERNS":
+                patterns = [ast.literal_eval(e) for e in node.value.elts]
+assert patterns, "could not extract DEFAULT_PATTERNS"
+pats = [re.compile(p) for p in patterns]
+def hit(cmd): return any(p.search(cmd) for p in pats)
+
+POSITIVE = [
+    "npm exec @upstash/context7-mcp",
+    "npm exec @playwright/mcp@latest",
+    "npm exec @shopify/dev-mcp@latest",
+    "node /Users/x/.npm/_npx/abc/node_modules/.bin/shopify-dev-mcp",
+    "node /Users/x/.npm/_npx/abc/node_modules/@shopify/dev-mcp/dist/index.js",
+    "node /Users/x/.claude/plugins/cache/cosmax-marketplace/cosmax-crm/0.19.3-3/scripts/crm-mcp-proxy.mjs",
+    "node /home/u/.npm/_npx/abc/node_modules/.bin/context7-mcp",
+    "bun /home/u/.agent-bridge/plugins/teams/server.ts",
+    "bun run --cwd /home/u/.agent-bridge/plugins/telegram --silent start",
+    "bun run --cwd /home/u/.bun/install/claude-plugins-official/telegram/0.0.6 start",
+]
+NEGATIVE = [
+    # Lethal collateral on the live host — none are Agent Bridge MCP servers.
+    "/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64 --stdio",
+    "/usr/local/bin/mcp-server --port 9000",
+    "/Applications/Telegram.app/Contents/MacOS/Telegram",
+    "/Applications/Microsoft Teams.app/Contents/MacOS/MSTeams",
+    "/Applications/Figma.app/Contents/MacOS/Figma",
+    # Bare interpreters / unrelated same-uid projects.
+    "node /Users/x/code/myapp/index.js",
+    "/home/u/.bun/bin/bun server.ts",
+    "bun /Users/x/Projects/mywebapp/src/server.ts",
+    "bun run --cwd /home/user/myproject build",
+    # codex orphans are NOT reaped by the MCP cleaner.
+    "codex resume 9f3a2b1c --cwd /home/agent",
+    "codex exec --ephemeral --skip-git-repo-check -C crm-dev",
+]
+bad = []
+for c in POSITIVE:
+    if not hit(c):
+        bad.append(("MISS positive", c))
+for c in NEGATIVE:
+    if hit(c):
+        bad.append(("LETHAL negative", c))
+if bad:
+    for kind, c in bad:
+        print(f"{kind}: {c}", file=sys.stderr)
+    sys.exit(1)
+print(f"[ok] {len(POSITIVE)} positive + {len(NEGATIVE)} negative controls correct")
+PY
+
+# ---------------------------------------------------------------------------
+# PID-reuse revalidation — the kill path must refuse a pid whose live identity
+# changed since classification.
+# ---------------------------------------------------------------------------
+smoke_log "C: PID-reuse revalidation (pre-TERM + pre-KILL guards)"
+python3 - "$REAPER_PY" <<'PY' || smoke_fail "PID-reuse revalidation failed"
+import importlib.util, re, subprocess, sys, time
+spec = importlib.util.spec_from_file_location("bridge_mcp_cleanup", sys.argv[1])
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+child = subprocess.Popen(["/bin/sleep", "30"])
+try:
+    for _ in range(50):
+        if mod.read_proc_identity(child.pid) is not None:
+            break
+        time.sleep(0.05)
+    ident = mod.read_proc_identity(child.pid)
+    assert ident is not None, "could not read live child identity"
+    cmd, ppid, age = ident
+    sp = re.compile(r"sleep")
+    assert mod.still_killable(child.pid, cmd, sp, ppid, 0), "exact identity must be killable"
+    assert not mod.still_killable(child.pid, cmd, re.compile("nomatch"), ppid, 0), "pattern-mismatch must refuse"
+    assert not mod.still_killable(child.pid, "different", sp, ppid, 0), "command-change must refuse"
+    assert not mod.still_killable(child.pid, cmd, sp, ppid + 99999, 0), "ppid-change must refuse"
+    assert not mod.still_killable(child.pid, cmd, sp, ppid, age + 100000), "younger-than-snapshot must refuse"
+    child.terminate(); child.wait()
+    ok, status = mod.kill_pid(child.pid, 0.2, cmd, sp, ppid, 0)
+    assert ok and status == "skipped-pid-reuse", f"vanished pid must skip, got ({ok},{status})"
+    print("[ok] PID-reuse revalidation enforced")
+finally:
+    if child.poll() is None:
+        child.kill(); child.wait()
+PY
+
+# ---------------------------------------------------------------------------
+# Runtime control: a Pencil.app-style mcp-server name survives a real
+# default-pattern --kill, while a bridge crm-mcp-proxy orphan is reaped; the
+# dry-run kills nothing.
+# ---------------------------------------------------------------------------
+smoke_log "D: runtime default-pattern kill — Pencil.app survives, bridge orphan reaped, dry-run kills none"
+TMP_D="$(mktemp -d "${TMPDIR:-/tmp}/agb-8807p0b-XXXXXX")"
+neg_argv="/Applications/Pencil.app/Contents/Resources/mcp-server-darwin-arm64-smoke-$$"
+pos_argv="node /tmp/agent-bridge-8807-smoke-$$/crm-mcp-proxy.mjs"
+spawn_argv() {
+  python3 - "$1" "$2" <<'PY'
+import subprocess, sys
+from pathlib import Path
+argv0, pid_file = sys.argv[1], sys.argv[2]
+proc = subprocess.Popen([argv0, "600"], executable="/bin/sleep",
+                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                        start_new_session=True)
+Path(pid_file).write_text(str(proc.pid), encoding="utf-8")
+PY
+}
+spawn_argv "$neg_argv" "$TMP_D/neg.pid"
+spawn_argv "$pos_argv" "$TMP_D/pos.pid"
+neg_pid="$(cat "$TMP_D/neg.pid")"
+pos_pid="$(cat "$TMP_D/pos.pid")"
+cleanup_d() {
+  kill "$neg_pid" >/dev/null 2>&1 || true
+  kill "$pos_pid" >/dev/null 2>&1 || true
+  rm -rf "$TMP_D"
+}
+trap cleanup_d EXIT
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  kill -0 "$neg_pid" 2>/dev/null && kill -0 "$pos_pid" 2>/dev/null && break
+  sleep 0.1
+done
+kill -0 "$neg_pid" 2>/dev/null || smoke_fail "negative-control process did not start"
+kill -0 "$pos_pid" 2>/dev/null || smoke_fail "positive-control process did not start"
+
+dry_json="$(python3 "$REAPER_PY" cleanup --dry-run --min-age 0 --json)"
+printf '%s' "$dry_json" | grep -q '"killed_count": 0' || smoke_fail "dry-run reported a non-zero killed_count"
+kill -0 "$pos_pid" 2>/dev/null || smoke_fail "dry-run killed the positive control (must audit-only)"
+
+python3 "$REAPER_PY" cleanup --kill --min-age 0 --json >/dev/null
+sleep 0.4
+kill -0 "$neg_pid" 2>/dev/null || smoke_fail "default cleanup killed the Pencil.app-style process (lethal collateral!)"
+if kill -0 "$pos_pid" 2>/dev/null; then
+  smoke_fail "default cleanup did NOT reap the bridge crm-mcp-proxy orphan"
+fi
+
+# ---------------------------------------------------------------------------
+# Pressure-relief ordering: the cleanup must run at the TOP of cmd_sync_cycle
+# (before the spawn-heavy surfaces), not after them.
+# ---------------------------------------------------------------------------
+smoke_log "E: MCP cleanup runs early in cmd_sync_cycle (before spawn surfaces)"
+grep -q 'BRIDGE_DAEMON_LAST_STEP="mcp_orphan_cleanup_early"' "$DAEMON_SH" || \
+  smoke_fail "daemon does not run the MCP cleanup early (mcp_orphan_cleanup_early step missing)"
+# Exactly one in-cycle invocation (the early one) — the late call was removed.
+inv="$(grep -c '( process_mcp_orphan_cleanup ) || true' "$DAEMON_SH")"
+[[ "$inv" -eq 1 ]] || smoke_fail "expected exactly 1 process_mcp_orphan_cleanup invocation, found $inv"
+# The early step must precede the cron-dispatch + on-demand spawn steps.
+early_ln="$(grep -n 'BRIDGE_DAEMON_LAST_STEP="mcp_orphan_cleanup_early"' "$DAEMON_SH" | head -n1 | cut -d: -f1)"
+cron_ln="$(grep -n 'BRIDGE_DAEMON_LAST_STEP="cron_dispatch_workers"' "$DAEMON_SH" | head -n1 | cut -d: -f1)"
+ondemand_ln="$(grep -n 'BRIDGE_DAEMON_LAST_STEP="on_demand_agents"' "$DAEMON_SH" | head -n1 | cut -d: -f1)"
+[[ -n "$early_ln" && -n "$cron_ln" && -n "$ondemand_ln" ]] || smoke_fail "could not locate cycle step markers"
+(( early_ln < cron_ln )) || smoke_fail "MCP cleanup not before cron_dispatch_workers"
+(( early_ln < ondemand_ln )) || smoke_fail "MCP cleanup not before on_demand_agents"
+
+neg_pid=""; pos_pid=""
+smoke_log "PASS: $SMOKE_NAME"


### PR DESCRIPTION
## Incident #8807 — P0b (tighten + extend the EXISTING MCP reaper)

The fork-storm incident accumulated orphaned MCP servers faster than the **existing** periodic cleanup (`process_mcp_orphan_cleanup` → `bridge-mcp-cleanup.py`, ~300s) could reclaim — because its `DEFAULT_PATTERNS` **missed** the bridge MCP types that piled up. This PR fixes the pattern set and hardens the kill path. **No new sweep surface, no new knobs.**

### Pattern changes (`bridge-mcp-cleanup.py`)
- **Tighten**: `\bbun\b.*server\.ts` matched an unrelated same-uid bun → anchored on the bridge plugin-cache path (`(?:\.agent-bridge/plugins/|/claude-plugins-official/).*server\.ts`).
- **Extend** to the missing bridge MCP signatures (live `ps` provenance): `npm exec @shopify/dev-mcp` + `node …@shopify/dev-mcp…` + `node …shopify-dev-mcp`, and `node …/crm-mcp-proxy.mjs` (cosmax-crm).
- **Deliberately NOT added**: any generic `mcp-server` / `mcp-server-darwin-arm64` pattern — on the live host that is **Pencil.app** (lethal collateral). Same for Telegram/Teams/Figma desktop helpers.
- **codex orphans deferred**: `codex resume <hash>` is a **live agent pair** and must never be reaped; the disposable `codex exec --ephemeral` workers are a smaller multiplier, left to a follow-up with their own exact signature + negative control.

### PID-reuse revalidation (finding #4)
`kill_pid` re-reads the pid's live identity and requires the same command + pattern-match + ppid (orphan chain) + not-younger age **immediately before SIGTERM and again before SIGKILL**. Any mismatch → `skipped-pid-reuse`, no signal sent. Surfaced via a new `skipped_count` in the report.

### Pressure-relief ordering (finding #5)
`process_mcp_orphan_cleanup` moved to the **top** of `cmd_sync_cycle` (step `mcp_orphan_cleanup_early`), before `start_cron_dispatch_workers` / `process_on_demand_agents`, so it relieves pressure ahead of the spawn-heavy surfaces. Internal 300s throttle unchanged; the late call is removed (single in-cycle invocation).

### Tests
- **`scripts/smoke/8807-mcp-reaper-patterns.sh`** (CI-faithful, self-contained): 10 positive + 11 **negative** pattern controls (Pencil.app `mcp-server-darwin-arm64`, bare interpreters, desktop helpers, `codex resume`/`codex exec` all NOT matched; bridge identities matched); PID-reuse unit; a **runtime control** proving a Pencil.app-style process survives a real default `--kill` while a bridge `crm-mcp-proxy` orphan is reaped and **dry-run kills none**; the early-ordering pin. Registered in `ci-select-smoke.sh` for `bridge-mcp-cleanup.py` + `bridge-daemon.sh`.
- `scripts/smoke-test.sh` MCP-orphan block extended with the same matrix + PID-reuse unit.

### Verification
- `py_compile` + `bash -n` + `shellcheck --severity=warning` clean.
- Modular smoke passes standalone and via `ci-select-smoke.sh --run`; pattern controls verified against the live host's actual MCP fleet.
- `lint-heredoc-ban`: `bridge-daemon.sh count=0`. `iso-helper-ratchet`: no regression. `oss-preflight`: passed.
- The monolith `smoke-test.sh` stops earlier at a pre-existing, unrelated `tmux pending-attention spool` flake (reproduces on base; this diff touches no tmux/spool code) — the modular smoke is the CI-run counterpart.

NO VERSION/CHANGELOG bump. Source tree only.

(#8807 P0b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)