### PR TITLE
fix(daemon): map engine to binary in autostart gate (antigravity to agy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ version bumps via the `VERSION` file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Engine→binary mapping for the daemon autostart gate.** The always-on
+  auto-start gate in `bridge-daemon.sh` probed `command -v <engine>`
+  against the engine identifier, so a roster entry with `engine=antigravity`
+  (CLI binary `agy`) was permanently skipped with
+  `engine-cli-missing:antigravity` even when the binary was installed under
+  its real name. A new `bridge_engine_binary_name()` helper in
+  `lib/bridge-engine-descriptor.sh` maps engine identifier → CLI binary
+  (`claude→claude`, `codex→codex`, `antigravity→agy`); the daemon gate
+  now routes its PATH probe through that helper and the audit reason
+  reports the real binary (`engine-cli-missing:agy`) for traceability,
+  with a legacy bare-engine fallback for unknown engines. On the
+  operator's `sean-mac`, the `patch-agy` static agent had 94 consecutive
+  false-positive failures before this fix.
+
 ## [0.15.2] — 2026-06-01
 
 A stabilization + headless-hardening batch on top of `0.15.1`. Every item is on `main`, CI-green (syntax + unit/static + oss-preflight + lint-heredoc-ban + lint + integration smoke), and codex pair-reviewed. The marquee items are headless Claude OAT self-rotation (proactive native probe + reactive 429), a Darwin-gated macOS Claude `apiKeyHelper` auth path with a deep inherited-env credential-leak hardening pass, a whole-fleet crash-loop fix on per-agent-HOME installs, and the long-standing daemon "ACTION REQUIRED" nudge double-fire fix.

--- a/bridge-daemon.sh
+++ b/bridge-daemon.sh
@@ -9345,11 +9345,25 @@ process_on_demand_agents() {
         # not a daemon bug.
         local _agent_engine
         _agent_engine="$(bridge_agent_engine "$agent" 2>/dev/null || true)"
-        if [[ -n "$_agent_engine" ]] && ! command -v "$_agent_engine" >/dev/null 2>&1; then
-          bridge_daemon_note_autostart_failure "$agent" "engine-cli-missing:$_agent_engine"
-          daemon_info "auto-start skipped ${agent} — engine CLI '$_agent_engine' not on PATH"
-          unset _agent_engine
-          continue
+        if [[ -n "$_agent_engine" ]]; then
+          # Engine identifier (descriptor key) and the actual launched
+          # binary are not always the same string — e.g. `antigravity`
+          # ships its CLI as `agy`. Route the PATH probe through the
+          # engine→binary mapping so non-default engines are not
+          # permanently skipped with `engine-cli-missing` when the
+          # binary is installed under its real name. Fall back to the
+          # engine token itself (legacy behavior) when the descriptor
+          # does not know the engine, so new/unmapped engines still
+          # get a best-effort gate instead of silently passing.
+          local _agent_engine_bin
+          _agent_engine_bin="$(bridge_engine_binary_name "$_agent_engine" 2>/dev/null || printf '%s' "$_agent_engine")"
+          if ! command -v "$_agent_engine_bin" >/dev/null 2>&1; then
+            bridge_daemon_note_autostart_failure "$agent" "engine-cli-missing:$_agent_engine_bin"
+            daemon_info "auto-start skipped ${agent} — engine binary '$_agent_engine_bin' (engine='$_agent_engine') not on PATH"
+            unset _agent_engine _agent_engine_bin
+            continue
+          fi
+          unset _agent_engine_bin
         fi
         unset _agent_engine
         # Issue #1269 (v0.15.0-beta4 Lane E): self-heal the per-agent

--- a/lib/bridge-engine-descriptor.sh
+++ b/lib/bridge-engine-descriptor.sh
@@ -38,6 +38,30 @@ bridge_engine_is_supported() {
   esac
 }
 
+# bridge_engine_binary_name <engine>
+#
+# Engine → CLI binary name. The engine identifier in the descriptor
+# (used by `bridge_agent_engine`, the roster, and the layout helpers)
+# is not always the same string as the binary the host PATH resolves.
+# Today the asymmetry is `antigravity`, which ships its CLI under
+# `agy`; tomorrow more engines may diverge the same way. All callers
+# that need to PATH-check or exec an engine binary should route
+# through this helper rather than assuming engine-name == binary-name.
+#
+# Prints the binary name on stdout and returns 0 for known engines;
+# prints nothing and returns 1 for unknown engines so callers can
+# fall back to legacy bare-engine-name behavior (the current
+# autostart gate does exactly that — see bridge-daemon.sh).
+bridge_engine_binary_name() {
+  local engine="${1:-}"
+  case "$engine" in
+    claude) printf 'claude' ;;
+    codex) printf 'codex' ;;
+    antigravity) printf 'agy' ;;
+    *) return 1 ;;
+  esac
+}
+
 # bridge_engine_entrypoint_filename <engine>
 #
 # The engine's primary instruction-file name.

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -11761,4 +11761,11 @@ bash "$REPO_ROOT/scripts/smoke/1076-create-atomicity-and-purge.sh"
 log "running audit-since-tz smoke (issue #1100)"
 bash "$REPO_ROOT/scripts/smoke/1100-audit-since-tz.sh"
 
+# Engine→binary mapping: bridge_engine_binary_name() resolves the real
+# CLI name (e.g. antigravity → agy) so the daemon autostart gate does
+# not permanently skip non-default engines with an `engine-cli-missing`
+# reason when the binary is installed under its real name.
+log "running engine-binary-mapping smoke"
+bash "$REPO_ROOT/scripts/smoke/engine-binary-mapping.sh"
+
 log "smoke test passed"

--- a/scripts/smoke/engine-binary-mapping.sh
+++ b/scripts/smoke/engine-binary-mapping.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/engine-binary-mapping.sh — engine→binary mapping fix.
+#
+# `patch-agy` (engine=antigravity, binary=agy) was permanently skipped
+# by the daemon's always-on autostart gate because bridge-daemon.sh
+# probed `command -v antigravity` instead of the real binary name.
+# fail_count ran from 10 to 94 in one day before the operator caught
+# the watchdog escalation loop.
+#
+# The fix introduces `bridge_engine_binary_name()` in
+# lib/bridge-engine-descriptor.sh and routes the daemon autostart gate
+# through it. This smoke pins:
+#
+#   T1. bridge_engine_binary_name claude       → 'claude' (rc=0)
+#   T2. bridge_engine_binary_name codex        → 'codex'  (rc=0)
+#   T3. bridge_engine_binary_name antigravity  → 'agy'    (rc=0)
+#   T4. bridge_engine_binary_name unknown      → ''       (rc=1)
+#   T5. Integration: with a stub `agy` binary on PATH and the descriptor
+#       loaded, the binary-name resolved for an `antigravity` engine
+#       (`agy`) is visible to `command -v` and the daemon gate would
+#       pass; with `agy` removed from PATH the gate would fail with
+#       the actionable `engine-cli-missing:agy` reason.
+#
+# Isolation: temp working dir under /tmp; no live BRIDGE_HOME reads.
+
+set -euo pipefail
+
+SMOKE_NAME="engine-binary-mapping"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+DESCRIPTOR="$REPO_ROOT/lib/bridge-engine-descriptor.sh"
+[[ -f "$DESCRIPTOR" ]] || smoke_fail "missing helper: $DESCRIPTOR"
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+# Source the descriptor in an isolated subshell so the surrounding
+# smoke harness env stays untouched. The descriptor is dependency-free
+# — pure case-table accessors — so direct sourcing is safe.
+#
+# Each test invokes a fresh `bash -c` to ensure rc / stdout are not
+# polluted by a stale function from the parent shell.
+
+assert_binary_name() {
+  local engine="$1"
+  local expected_out="$2"
+  local expected_rc="$3"
+  local context="$4"
+  local out
+  local rc
+  set +e
+  out="$(bash -c "source '$DESCRIPTOR'; bridge_engine_binary_name '$engine'" 2>/dev/null)"
+  rc=$?
+  set -e
+  smoke_assert_eq "$expected_out" "$out" "$context: stdout"
+  smoke_assert_eq "$expected_rc" "$rc" "$context: rc"
+}
+
+# T1: claude → claude (rc=0)
+smoke_run "T1 claude → claude" \
+  assert_binary_name claude claude 0 "T1"
+
+# T2: codex → codex (rc=0)
+smoke_run "T2 codex → codex" \
+  assert_binary_name codex codex 0 "T2"
+
+# T3: antigravity → agy (rc=0) — the regression-fixing mapping.
+smoke_run "T3 antigravity → agy" \
+  assert_binary_name antigravity agy 0 "T3"
+
+# T4: unknown engine → empty stdout, rc=1.
+smoke_run "T4 unknown → rc=1" \
+  assert_binary_name nonesuch '' 1 "T4"
+
+# T5: integration — a stub `agy` on a controlled PATH is resolvable;
+# removing it makes the gate fail with the actionable binary name. The
+# guard exercised here mirrors the autostart-gate `command -v` probe in
+# bridge-daemon.sh (after the engine→binary resolution).
+STUB_DIR="$SMOKE_TMP_ROOT/path"
+mkdir -p "$STUB_DIR"
+cat >"$STUB_DIR/agy" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "$STUB_DIR/agy"
+
+assert_gate_resolution() {
+  local engine="$1"
+  local expect_command_v_rc="$2"
+  local expect_resolved_bin="$3"
+  local path_value="$4"
+  local context="$5"
+  local payload rc
+  set +e
+  payload="$(PATH="$path_value" bash -c "
+    source '$DESCRIPTOR'
+    engine_bin=\"\$(bridge_engine_binary_name '$engine' 2>/dev/null || printf '%s' '$engine')\"
+    printf 'resolved=%s\n' \"\$engine_bin\"
+    if command -v \"\$engine_bin\" >/dev/null 2>&1; then
+      printf 'cmdv=0\n'
+    else
+      printf 'cmdv=1\n'
+    fi
+  ")"
+  rc=$?
+  set -e
+  [[ $rc -eq 0 ]] || smoke_fail "$context: subshell rc=$rc, payload=$payload"
+  local resolved cmdv
+  resolved="$(printf '%s\n' "$payload" | sed -n 's/^resolved=//p')"
+  cmdv="$(printf '%s\n' "$payload" | sed -n 's/^cmdv=//p')"
+  smoke_assert_eq "$expect_resolved_bin" "$resolved" "$context: resolved binary"
+  smoke_assert_eq "$expect_command_v_rc" "$cmdv" "$context: command -v rc"
+}
+
+# T5a: with stub `agy` on PATH, the gate's `command -v` succeeds (rc=0).
+smoke_run "T5a antigravity gate passes when agy on PATH" \
+  assert_gate_resolution antigravity 0 agy "$STUB_DIR:/usr/bin:/bin" "T5a"
+
+# T5b: with `agy` removed, the gate's `command -v` fails (rc=1) and the
+# binary name in the audit reason is the real `agy`, not the engine
+# token. We assert the resolved binary string to pin that the failure
+# message will be `engine-cli-missing:agy` (the daemon site interpolates
+# this value into the reason). PATH carries `/usr/bin:/bin` so the inner
+# shell can still exec `bash` itself; only `agy` is absent.
+SMOKE_EMPTY_BIN_DIR="$SMOKE_TMP_ROOT/path-no-agy"
+mkdir -p "$SMOKE_EMPTY_BIN_DIR"
+smoke_run "T5b antigravity gate fails with agy when agy absent from PATH" \
+  assert_gate_resolution antigravity 1 agy "$SMOKE_EMPTY_BIN_DIR:/usr/bin:/bin" "T5b"
+
+smoke_log "smoke test passed"


### PR DESCRIPTION
## Summary

- Add `bridge_engine_binary_name()` to `lib/bridge-engine-descriptor.sh` mapping the engine identifier to its CLI binary (`claude` -> `claude`, `codex` -> `codex`, `antigravity` -> `agy`).
- Route the daemon's always-on autostart gate (`bridge-daemon.sh`) through that helper before the `command -v` PATH probe, with a legacy bare-engine fallback for unknown engines.
- Daemon audit reason and operator log now report the real binary (e.g. `engine-cli-missing:agy`) with the engine identifier in parentheses for traceability.
- New smoke `scripts/smoke/engine-binary-mapping.sh` (registered in `scripts/smoke-test.sh`) pins the five test cases from the brief.
- CHANGELOG entry under Unreleased; no VERSION bump (operator-cued release per CLAUDE.md).

## Background

On the operator's `sean-mac`, the `patch-agy` static agent (`engine=antigravity`, launched as `agy`) accumulated 94 consecutive false-positive autostart failures in one day because the daemon gate probed `command -v antigravity` instead of the real binary `agy`. The watchdog escalation loop then fired 12 times before the operator surfaced it.

Root cause: `bridge-daemon.sh` (around line 9346-9354) assumed engine identifier == binary name. The descriptor for `antigravity` shipped without a binary-name mapping. This PR introduces that mapping and routes the autostart gate through it.

## Scope

Per the brief, this is a single surgical fix on the daemon autostart-gate site only.

Other call sites of `bridge_resolve_engine_binary` / `command -v <engine>` (`bridge-start.sh`, `bridge-agent.sh`, `bridge_agent_restart_preflight_full_reason` in `lib/bridge-agents.sh`) currently scope to `claude|codex` only and either fall through gracefully or refuse `antigravity` earlier in their own create-time path. Routing those through the same helper is out of scope here.

## Test Plan

Validation already performed in the worktree:

- [x] `bash -n` on every changed shell file (clean).
- [x] `shellcheck lib/bridge-engine-descriptor.sh bridge-daemon.sh scripts/smoke-test.sh scripts/smoke/engine-binary-mapping.sh` (clean).
- [x] `bash scripts/smoke/engine-binary-mapping.sh` -- all 5 cases pass:
  - T1 `bridge_engine_binary_name claude` -> `claude` (rc=0)
  - T2 `bridge_engine_binary_name codex` -> `codex` (rc=0)
  - T3 `bridge_engine_binary_name antigravity` -> `agy` (rc=0)
  - T4 `bridge_engine_binary_name unknown` -> empty, rc=1
  - T5 integration: stub `agy` on PATH -> gate passes; `agy` absent from PATH -> gate fails with the real binary in the reason.
- [x] `bash scripts/smoke-test.sh` reproduces a pre-existing failure on this macOS host at `#365 follow-up -- guarding isolated agent-env writes from stale tmp controller env` (verified against pristine `origin/main` -- same failure point, same output). Not caused by this PR.

Manual live verification (operator, sean-mac, post-merge):

- [ ] `agent-bridge agent update patch-agy --start-policy auto`
- [ ] `agent-bridge agent start patch-agy`
- [ ] Confirm tmux session live + no further `engine-cli-missing` lines in the daemon log.
- [ ] Optional: tail `state/agents/patch-agy/autostart-failure.json` and verify the previous `engine-cli-missing:antigravity` reason is cleared.

## Constraints honored

- No VERSION bump.
- No edits to `~/.agent-bridge/` (live runtime).
- Branch: `fix/engine-binary-mapping`; pushed to `origin`, no main push.
- CHANGELOG entry sits under `[Unreleased]`, ready for the next operator-cued release batch.
