### PR TITLE
feat(codex): availability-gated doctor smoke + watchdog AGENTS.md contract + version surface (#8945 Track D)

### DIFF
--- a/bridge-upgrade.sh
+++ b/bridge-upgrade.sh
@@ -872,6 +872,112 @@ print("" if value is None else str(value))
 PY
 }
 
+# #8945 Track D: record the Codex CLI version across upgrades and surface a
+# NON-FATAL operator advisory when the MAJOR or MINOR component changes.
+# Codex CLI capability (hooks, AGENTS.md, slash commands, permission
+# profiles) grows between minor releases; an operator who jumped Codex
+# versions should re-check the bridge's Codex provisioning (hook list,
+# AGENTS.md protocol, `codex doctor`) against the new CLI.
+#
+# Strictly advisory + best-effort:
+#   - Missing codex CLI → skip silently (same non-fatal precedent as the
+#     admin codex-pair auto-provisioning, lib/bridge-init-codex-pair.sh).
+#   - First time we ever see a codex version → record it, no advisory
+#     (there is no prior version to compare against).
+#   - MAJOR.MINOR unchanged → record (patch bumps are quiet), no advisory.
+#   - MAJOR or MINOR changed → print the advisory to stderr, then record
+#     the new version so the advisory fires once per major/minor change.
+# Never fails the upgrade: every branch returns 0.
+#
+# State file: $TARGET_ROOT/state/upgrade/codex-version.last (a single line,
+# the raw `codex --version` token, e.g. "codex-cli 0.135.0"). Parsing is
+# pure shell + awk — NO heredoc-stdin to a subprocess (bridge-upgrade.sh is
+# at the lint-heredoc-ban ceiling; footgun #11). The advisory text uses a
+# `cat >&2 <<` fd-redirect heredoc, which is NOT a subprocess interpreter
+# site and is not counted by the ratchet.
+bridge_upgrade_emit_codex_version_advisory() {
+  local target_root="$1"
+  local dry_run="${2:-0}"
+  local advisory_mode="${BRIDGE_CODEX_VERSION_ADVISORY:-1}"
+
+  if [[ "$advisory_mode" == "0" ]]; then
+    return 0
+  fi
+
+  if ! command -v codex >/dev/null 2>&1; then
+    # Non-fatal: a codex-less host has nothing to advise on.
+    return 0
+  fi
+
+  if [[ "$dry_run" == "1" ]]; then
+    echo "[bridge-upgrade] plan: record codex --version + advise on a major/minor change (non-fatal, one-shot per change)" >&2
+    return 0
+  fi
+
+  # Capture the raw version token. Best-effort: a codex that errors on
+  # --version is treated as unknown and skipped.
+  #
+  # errexit safety (codex internal-review r1): bridge-upgrade.sh runs under
+  # `set -euo pipefail`. Every capture below MUST carry a `|| var=""`
+  # fallback so a nonzero in the command substitution (codex --version
+  # exiting nonzero, a no-match `grep -oE` returning 1, or a pipefail
+  # member failing) does NOT abort the whole upgrade. The advisory is
+  # strictly non-fatal — an unparseable / failing codex is "unknown and
+  # skipped", never an upgrade blocker.
+  local current_raw=""
+  current_raw="$(codex --version 2>/dev/null | head -n 1 | tr -d '\r')" || current_raw=""
+  [[ -n "$current_raw" ]] || return 0
+
+  # Extract the first dotted numeric token (e.g. "0.135.0") from the raw
+  # line, then its MAJOR.MINOR. grep -oE keeps this portable across the
+  # "codex-cli 0.135.0" / "codex 0.135.0" surface variants. `grep -oE`
+  # exits 1 on no-match — the `|| current_ver=""` keeps that from tripping
+  # errexit, and the empty-guard below then returns 0.
+  local current_ver=""
+  current_ver="$(printf '%s\n' "$current_raw" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n 1)" || current_ver=""
+  [[ -n "$current_ver" ]] || return 0
+  local current_mm=""
+  current_mm="$(printf '%s\n' "$current_ver" | awk -F. '{print $1"."$2}')" || current_mm=""
+
+  local state_dir="$target_root/state/upgrade"
+  local state_file="$state_dir/codex-version.last"
+
+  local prev_raw=""
+  if [[ -f "$state_file" ]]; then
+    prev_raw="$(head -n 1 "$state_file" 2>/dev/null | tr -d '\r')" || prev_raw=""
+  fi
+
+  # Record helper (best-effort; failure to record is non-fatal — the next
+  # upgrade just re-evaluates).
+  mkdir -p "$state_dir" 2>/dev/null || true
+
+  if [[ -z "$prev_raw" ]]; then
+    # First observation — no baseline to compare. Record silently.
+    printf '%s\n' "$current_raw" >"$state_file" 2>/dev/null || true
+    return 0
+  fi
+
+  local prev_ver=""
+  prev_ver="$(printf '%s\n' "$prev_raw" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n 1)" || prev_ver=""
+  local prev_mm=""
+  prev_mm="$(printf '%s\n' "$prev_ver" | awk -F. '{print $1"."$2}')" || prev_mm=""
+
+  if [[ -n "$prev_mm" && "$prev_mm" != "$current_mm" ]]; then
+    cat >&2 <<ADVISORY
+[bridge-upgrade] ADVISORY: Codex CLI changed ${prev_ver:-$prev_raw} -> ${current_ver:-$current_raw} (major/minor).
+[bridge-upgrade] Codex capabilities (hooks, AGENTS.md protocol, slash commands, permission profiles) can change across minor releases.
+[bridge-upgrade] Recommended: re-check Codex agents with 'codex doctor', and confirm the bridge's Codex hook list + AGENTS.md protocol still match the new CLI.
+[bridge-upgrade] This advisory fires once per major/minor change. Suppress with BRIDGE_CODEX_VERSION_ADVISORY=0.
+ADVISORY
+  fi
+
+  # Record the new version regardless of whether the advisory fired so a
+  # patch-only bump updates the baseline and a major/minor advisory does
+  # not repeat on the next upgrade.
+  printf '%s\n' "$current_raw" >"$state_file" 2>/dev/null || true
+  return 0
+}
+
 # Issue #4769 (reverts #517): when a host carries the auto-created
 # `admin` + `admin-dev` pair from a previous v0.14.x upgrade, emit a
 # non-destructive advisory describing the explicit-setup contract and
@@ -2084,6 +2190,10 @@ if [[ $MIGRATE_AGENTS -eq 1 ]]; then
   # explicit setup/retire recipe — but no destructive action runs here.
 
   bridge_upgrade_emit_admin_pair_advisory "$TARGET_ROOT" "$ADMIN_AGENT_ID" "$DRY_RUN"
+
+  # #8945 Track D: record codex --version + surface a non-fatal advisory on
+  # a major/minor change. No-op when codex is absent (non-fatal precedent).
+  bridge_upgrade_emit_codex_version_advisory "$TARGET_ROOT" "$DRY_RUN"
 
   # Issue #833 r2: backfill the picker-sweep cron on every upgrade.
   # bridge-init.sh registers it on fresh install, but existing installs that

--- a/bridge-watchdog.py
+++ b/bridge-watchdog.py
@@ -317,10 +317,25 @@ def _registry_ids_from_payload(
         # ($BRIDGE_HOME/agents/<a>/) on v2 and reported every runtime
         # .md as `missing_files`. Empty string falls back to the legacy
         # `<root>/<name>` path so the v1 / no-registry path is unchanged.
+        # `home` (#8945 Track D): the agent's identity-source root
+        # (`bridge_agent_default_home` — on v2 that is
+        # `$BRIDGE_DATA_ROOT/agents/<a>/home`). Distinct from `workdir`:
+        # for a Codex agent layered onto a *shared* workdir (the admin's
+        # `<admin>-dev` pair created with `--allow-shared-workdir`), the
+        # per-agent AGENTS.md is materialized into `home`, NOT the shared
+        # workdir — `bridge_layout_materialize_identity` deliberately
+        # declines to stamp per-agent identity into a foreign/shared
+        # workspace. The watchdog scans `workdir`, so without this signal
+        # it reported a phantom `missing_files: AGENTS.md` for every such
+        # pair (today's patch-dev false drift). `scan_agent` uses `home`
+        # ONLY as a fall-back location for the engine entrypoint when it is
+        # absent from the scanned dir — a genuinely missing AGENTS.md
+        # (absent from BOTH) still surfaces as drift.
         meta[agent_id] = {
             "engine": str(row.get("engine") or "").strip(),
             "agent_source": str(row.get("agent_source") or "").strip(),
             "workdir": str(row.get("workdir") or "").strip(),
+            "home": str(row.get("home") or "").strip(),
         }
     return ids, meta
 
@@ -990,6 +1005,22 @@ def is_codex_engine(engine: str) -> bool:
     return engine == "codex"
 
 
+def engine_entrypoint_filename(engine: str) -> str:
+    """The engine's native instruction-file name — the watchdog mirror of
+    ``bridge_engine_entrypoint_filename`` (lib/bridge-engine-descriptor.sh).
+
+    #8945 Track D: used to identify *which* required file a Codex agent's
+    per-agent identity materializes as (``AGENTS.md``) so the shared-workdir
+    home fall-back in :func:`scan_agent` applies only to that entrypoint and
+    never relaxes any other required file.
+    """
+    if is_codex_engine(engine):
+        return "AGENTS.md"
+    if is_claude_engine(engine):
+        return "CLAUDE.md"
+    return ""
+
+
 def has_known_engine_contract(engine: str) -> bool:
     """True when the watchdog has an implemented engine-native contract for
     ``engine``. Engines outside this set are classified as
@@ -1118,6 +1149,7 @@ def scan_agent(
     agent_name: str | None = None,
     state_dir: Path | None = None,
     fresh_install_home_dir: Path | None = None,
+    agent_home_dir: Path | None = None,
 ) -> AgentWatch:
     # `agent_name` (#1108) is the registry id, threaded through
     # explicitly because on v2 layouts ``agent_dir`` resolves to
@@ -1166,7 +1198,50 @@ def scan_agent(
     # unchanged (no new `AgentWatch` fields, per spec).
     try:
         required = required_profile_files(engine, agent_source)
-        missing_files = [name for name in required if not (agent_dir / name).exists()]
+        # #8945 Track D: shared-workdir home fall-back for the engine's
+        # native instruction entrypoint. A Codex agent layered onto a
+        # *shared* workdir (the admin's `<admin>-dev` pair created with
+        # `--allow-shared-workdir`) has its per-agent AGENTS.md materialized
+        # into its `agent_home` identity source, not the shared workdir —
+        # `bridge_layout_materialize_identity`'s shared-workspace guard
+        # deliberately declines to stamp per-agent identity into a foreign
+        # workspace. The watchdog scans the workdir, so a present-in-home
+        # AGENTS.md was being reported as `missing_files: AGENTS.md` (the
+        # patch-dev false drift this fix removes). We treat the entrypoint
+        # as present when it exists in EITHER the scanned dir OR the
+        # agent_home. A genuinely-missing AGENTS.md (absent from BOTH) still
+        # surfaces as drift — no real-missing-file is masked. The fall-back
+        # is scoped to the engine entrypoint only: every other required file
+        # (the Claude profile set) is unaffected and still checked against
+        # the scanned dir alone.
+        entrypoint = engine_entrypoint_filename(engine)
+        missing_files = []
+        for name in required:
+            if (agent_dir / name).exists():
+                continue
+            if (
+                name == entrypoint
+                and entrypoint
+                and agent_home_dir is not None
+                and agent_home_dir != agent_dir
+                and (agent_home_dir / name).exists()  # noqa: raw-pathlib-controller-only
+            ):
+                # Present in the agent_home identity source (shared-workdir
+                # materialization target) — not drift.
+                #
+                # noqa rationale: this entrypoint home fall-back probe is a
+                # deliberate controller-side metadata check. On a v2-isolated
+                # host it can raise PermissionError when the controller is not
+                # in the agent's supplementary group, but it runs inside the
+                # SAME ``scan_agent`` try/except that already maps the sibling
+                # ``(agent_dir / name).exists()`` probe (and every other
+                # per-file read in this block) to a structured ``scan_error``
+                # row (#1119). The watchdog is the diagnostic of last resort:
+                # routing this one probe through a sudo-escalating helper is
+                # unnecessary because the fail-soft path already preserves the
+                # "never crash the whole pass" contract.
+                continue
+            missing_files.append(name)
         # The `missing_managed_claude_block` FIELD records actual file
         # state for engines that own a CLAUDE.md. Pre-#1237 this gated on
         # the legacy ``NON_CONTRACT_ENGINES`` allowlist; with the codex
@@ -1482,6 +1557,14 @@ def main() -> int:
         agent_meta = registry_meta.get(agent_name, {})
         engine = agent_meta.get("engine") or "claude"
         agent_source = agent_meta.get("agent_source", "")
+        # #8945 Track D: the registry `home` field (identity source). When
+        # the scan target is a *shared* workdir, the codex agent's
+        # per-agent AGENTS.md lives here instead. Threaded into scan_agent
+        # purely as the engine-entrypoint home fall-back (see scan_agent).
+        # Empty/missing → None, so the legacy single-tree check is
+        # unchanged for v1 installs and registry rows without a home field.
+        agent_home_str = agent_meta.get("home", "")
+        agent_home_dir = Path(agent_home_str).expanduser() if agent_home_str else None
         try:
             target = resolve_scan_path(agent_name, path, registry_meta)
             records.append(
@@ -1491,6 +1574,7 @@ def main() -> int:
                     agent_source=agent_source,
                     agent_name=agent_name,
                     state_dir=state_dir,
+                    agent_home_dir=agent_home_dir,
                     # The tracked-tree dir (`path`) is the most stable
                     # fresh-install signal: on v2 it is created during
                     # `bridge_scaffold_agent_home`, then the workdir

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -125,6 +125,12 @@ add_required 8807-mcp-reaper-patterns
 # suite so a scripts/smoke/* or lib/bridge-agents.sh change re-runs it via the
 # catch-all. (1067-codex-provisioning is already listed above.)
 add_required codex-nudge-body
+# #8945 Track D: availability-gated `codex doctor` smoke (graceful SKIP when
+# codex is absent — the CI default — so a codex-less host is never a false
+# release blocker) + the bridge-upgrade.sh codex-version advisory surface.
+# In the full static suite so a scripts/smoke/*, bridge-watchdog.py, or
+# bridge-upgrade.sh change re-runs them via the catch-all / default arm.
+add_required codex-doctor codex-version-surface
 
 
 }
@@ -2155,7 +2161,15 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # populated → conflict bail) and the run_sync wiring. Pull on
       # every bridge-upgrade.sh move so the backfill call cannot
       # silently regress.
-      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate 1067-codex-provisioning 1113-watchdog-legacy-backfill 1144-upgrade-complete-task phase2-install-tree-reconciler phase3-agent-home-contract α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-2-theta-upgrade-backfill-perms beta5-2-mu-cron-channel-creds
+      # #8945 Track D: bridge-upgrade.sh gained
+      # bridge_upgrade_emit_codex_version_advisory — records codex --version
+      # into state/upgrade/codex-version.last and surfaces a NON-fatal
+      # operator advisory on a major/minor change (skips silently when codex
+      # is absent). Pull codex-version-surface on every upgrade-entry move so
+      # the first-seen / patch-bump / major-minor / suppress / dry-run matrix
+      # cannot regress (and the extraction seam stays bound to the live
+      # function body).
+      add_required upgrade upgrade-source-preservation upgrade-shared-settings-propagate admin-pair-server-auto-provision telegram-relay-residue-cleanup upgrade-conflicts-lifecycle managed-autocompact-window per-agent-settings-rendering upgrade-isolated-agent-migrate 864-upgrade-perm-regressions cleanup-payload-empty-stdin-872 isolation-v2-marker-only-migrate 1067-codex-provisioning 1113-watchdog-legacy-backfill 1144-upgrade-complete-task phase2-install-tree-reconciler phase3-agent-home-contract α-beta5-upgrade-backfill-normalize gamma-beta5-reconcile-helper-status beta5-2-theta-upgrade-backfill-perms beta5-2-mu-cron-channel-creds codex-version-surface codex-doctor
       add_integration integration-minimal
       ;;
 
@@ -2407,7 +2421,15 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # iso-uid-side). Pull G-beta4-watchdog-noise on every
       # bridge-watchdog.py move so a future refactor cannot regress any
       # of those four contracts without the smoke catching it.
-      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill ε-watchdog-rescan-codex G-beta4-watchdog-noise queue
+      # #8945 Track D: ε-watchdog-rescan-codex now also pins the shared-
+      # workdir AGENTS.md home fall-back (a Codex `<admin>-dev` pair layered
+      # onto a shared workdir materializes its per-agent AGENTS.md into its
+      # agent_home, not the scanned workdir — the watchdog must treat the
+      # entrypoint as present in EITHER location, while a genuinely missing
+      # AGENTS.md still surfaces as drift). codex-doctor is pulled too so the
+      # availability-gated codex env/auth smoke rides along on watchdog moves
+      # that touch the codex contract surface.
+      add_required watchdog-profile-contract watchdog-registry-anchored watchdog-silence-stderr-capture 1108-watchdog-v2-workdir 1119-watchdog-perm-error 1113-watchdog-legacy-backfill ε-watchdog-rescan-codex G-beta4-watchdog-noise codex-doctor queue
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/codex-doctor.sh
+++ b/scripts/smoke/codex-doctor.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/codex-doctor.sh — #8945 Track D: availability-gated
+# `codex doctor` env/auth health smoke.
+#
+# Contract (codex plan-review r2 #3 — availability-gated):
+#   - When the `codex` CLI is ABSENT, the smoke asserts a graceful SKIP
+#     and exits 0. A codex-less CI host must NEVER become a false release
+#     blocker. This mirrors the existing precedent that a missing Codex CLI
+#     is non-fatal (lib/bridge-init-codex-pair.sh:71-79 — the admin codex
+#     pair auto-provisioning skips, never fails, when codex is not found).
+#   - The CI-default path is the SKIP path. Even on a host that happens to
+#     have `codex` installed, the real-doctor assertion only runs when the
+#     live gate `BRIDGE_SMOKE_CODEX_DOCTOR_LIVE=1` is set. This keeps CI
+#     hermetic and deterministic — `codex doctor` reaches the network / auth
+#     state and its output is environment-dependent, so it is reserved for
+#     the operator-driven live/tool-present gate.
+#   - On the live gate WITH codex present: run `codex doctor`, assert it
+#     exits cleanly (rc 0) and surfaces env/auth/runtime status text.
+#
+# Footgun #11 / lint-heredoc-ban: no heredoc-stdin / process-substitution
+# into an interpreter — output is captured into shell vars and a temp file
+# and inspected with plain `grep` / `case`.
+
+set -uo pipefail
+
+SMOKE_NAME="codex-doctor"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+# --- Availability gate ---------------------------------------------------
+# The skip path is the CI default. We deliberately do NOT call
+# smoke_require_cmd codex (which would HARD-FAIL); a missing codex is the
+# expected, non-blocking CI condition.
+if ! command -v codex >/dev/null 2>&1; then
+  smoke_skip "codex doctor" "codex CLI not found on PATH — non-fatal SKIP (codex-less CI host)"
+  smoke_log "PASS (skipped: codex absent)"
+  exit 0
+fi
+
+CODEX_BIN="$(command -v codex)"
+smoke_log "codex CLI present at $CODEX_BIN"
+
+# --- Live gate -----------------------------------------------------------
+# Even with codex installed, the real `codex doctor` invocation is reserved
+# for the explicit live/tool-present gate so the CI-default path stays the
+# deterministic skip/no-op above. Without the gate we assert only the
+# availability shape (the binary resolves + responds to --version) and stop
+# short of the environment-dependent doctor run.
+if [[ "${BRIDGE_SMOKE_CODEX_DOCTOR_LIVE:-0}" != "1" ]]; then
+  # Tool-present sanity that costs nothing and reaches no network/auth:
+  # `codex --version` must succeed and print a recognizable version line.
+  VERSION_OUT=""
+  VERSION_RC=0
+  VERSION_OUT="$(codex --version 2>&1)" || VERSION_RC=$?
+  if [[ $VERSION_RC -ne 0 ]]; then
+    smoke_fail "codex --version exited rc=$VERSION_RC; output: $VERSION_OUT"
+  fi
+  case "$VERSION_OUT" in
+    *[0-9].[0-9]*) : ;;  # contains a dotted version token
+    *) smoke_fail "codex --version did not print a recognizable version: '$VERSION_OUT'" ;;
+  esac
+  smoke_log "codex present, live gate off — version probe OK ('$VERSION_OUT')"
+  smoke_log "skip: codex doctor live run (set BRIDGE_SMOKE_CODEX_DOCTOR_LIVE=1 to exercise it)"
+  smoke_log "PASS (tool-present, live gate off)"
+  exit 0
+fi
+
+# --- Real doctor run (live/tool-present gate) ----------------------------
+smoke_log "LIVE: running 'codex doctor' (BRIDGE_SMOKE_CODEX_DOCTOR_LIVE=1)"
+DOCTOR_OUT_FILE="$SMOKE_TMP_ROOT/codex-doctor.out"
+DOCTOR_RC=0
+codex doctor >"$DOCTOR_OUT_FILE" 2>&1 || DOCTOR_RC=$?
+
+if [[ $DOCTOR_RC -ne 0 ]]; then
+  smoke_fail "codex doctor exited rc=$DOCTOR_RC; output:
+$(cat "$DOCTOR_OUT_FILE" 2>/dev/null)"
+fi
+
+if [[ ! -s "$DOCTOR_OUT_FILE" ]]; then
+  smoke_fail "codex doctor produced no output"
+fi
+
+# Assert the doctor report surfaces health status. The 0.135.0 report
+# header is 'Codex Doctor v<ver>' and the body carries Environment / runtime
+# / install sections. We match on the stable header token plus at least one
+# status section so a future codex CLI cosmetic change does not over-pin.
+if ! grep -qiE 'codex doctor|environment|runtime|install' "$DOCTOR_OUT_FILE"; then
+  smoke_fail "codex doctor output did not surface env/runtime/install status:
+$(cat "$DOCTOR_OUT_FILE" 2>/dev/null)"
+fi
+
+smoke_log "codex doctor clean exit + env/auth/runtime status surfaced"
+smoke_log "PASS (live doctor run)"

--- a/scripts/smoke/codex-version-surface.sh
+++ b/scripts/smoke/codex-version-surface.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/codex-version-surface.sh — #8945 Track D: bridge-upgrade.sh
+# Codex CLI version surface.
+#
+# Pins the bridge_upgrade_emit_codex_version_advisory contract:
+#   T1: codex ABSENT          -> silent no-op, exit 0, no state file written.
+#   T2: first observation     -> record version, NO advisory (no baseline).
+#   T3: same MAJOR.MINOR (patch bump only) -> NO advisory, baseline updated.
+#   T4: MAJOR/MINOR change     -> advisory printed to stderr, baseline updated.
+#   T5: BRIDGE_CODEX_VERSION_ADVISORY=0 -> hard suppressed (no advisory).
+#   T6: --dry-run              -> plan line only, no state mutation.
+#
+# Test seam: extract the function body verbatim from bridge-upgrade.sh by
+# literal markers and eval it in this shell (the 1144-upgrade-complete-task
+# pattern) so the smoke binds to the shipped code and fails on signature
+# drift. A fake `codex` on PATH makes `codex --version` deterministic and
+# hermetic — CI never needs a real codex install.
+#
+# Footgun #11 / lint-heredoc-ban: extraction is `sed -n '/start/,/end/p'`
+# (no heredoc-stdin), the fake codex stub is written via printf, and the
+# advisory text the function emits is a `cat >&2 <<` fd-redirect (not a
+# subprocess interpreter site).
+
+set -uo pipefail
+
+SMOKE_NAME="codex-version-surface"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_make_temp_root "$SMOKE_NAME"
+
+UPGRADE_SH="$SMOKE_REPO_ROOT/bridge-upgrade.sh"
+smoke_assert_file_exists "$UPGRADE_SH" "bridge-upgrade.sh must exist"
+
+# --- Extract the function body verbatim (test seam) ----------------------
+extract_block() {
+  local start_pat="$1"
+  local end_pat="$2"
+  sed -n "/$start_pat/,/$end_pat/p" "$UPGRADE_SH"
+}
+
+FN_BODY="$(extract_block '^bridge_upgrade_emit_codex_version_advisory()' '^}$')"
+if [[ -z "$FN_BODY" ]]; then
+  smoke_fail "bootstrap: could not extract bridge_upgrade_emit_codex_version_advisory from bridge-upgrade.sh"
+fi
+# Define the real function verbatim — drift in its signature/body fails here.
+eval "$FN_BODY"
+declare -F bridge_upgrade_emit_codex_version_advisory >/dev/null 2>&1 \
+  || smoke_fail "bootstrap: function did not define after eval"
+
+# --- Fake codex stub on PATH --------------------------------------------
+# A printf-authored executable so `codex --version` is deterministic. The
+# version it reports is read from $FAKE_CODEX_VERSION_FILE at call time so a
+# single stub serves every case.
+FAKE_BIN_DIR="$SMOKE_TMP_ROOT/fakebin"
+mkdir -p "$FAKE_BIN_DIR"
+FAKE_CODEX_VERSION_FILE="$SMOKE_TMP_ROOT/fake-codex-version.txt"
+FAKE_CODEX_RC_FILE="$SMOKE_TMP_ROOT/fake-codex-rc.txt"
+FAKE_CODEX="$FAKE_BIN_DIR/codex"
+# The stub prints $FAKE_CODEX_VERSION_FILE for `codex --version` and exits
+# with the code in $FAKE_CODEX_RC_FILE (default 0). The configurable exit
+# code is the errexit-regression seam: a `codex --version` that exits
+# nonzero must NOT abort the upgrade (the function runs under set -e).
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' "_rc=\"\$(cat \"$FAKE_CODEX_RC_FILE\" 2>/dev/null || printf 0)\""
+  printf '%s\n' 'if [[ "${1:-}" == "--version" ]]; then'
+  printf '%s\n' "  cat \"$FAKE_CODEX_VERSION_FILE\" 2>/dev/null || true"
+  printf '%s\n' '  exit "${_rc:-0}"'
+  printf '%s\n' 'fi'
+  printf '%s\n' 'exit 0'
+} >"$FAKE_CODEX"
+chmod +x "$FAKE_CODEX"
+
+set_fake_codex_version() {
+  printf '%s\n' "$1" >"$FAKE_CODEX_VERSION_FILE"
+  printf '%s\n' "0" >"$FAKE_CODEX_RC_FILE"
+}
+
+# Configure the stub to print $1 (may be empty) and exit with code $2.
+set_fake_codex_version_rc() {
+  printf '%s\n' "$1" >"$FAKE_CODEX_VERSION_FILE"
+  printf '%s\n' "$2" >"$FAKE_CODEX_RC_FILE"
+}
+
+STATE_REL="state/upgrade/codex-version.last"
+
+new_target() {
+  local t="$SMOKE_TMP_ROOT/$1"
+  mkdir -p "$t/state/upgrade"
+  printf '%s' "$t"
+}
+
+# --- T1 — codex ABSENT -> silent no-op, no state file --------------------
+# Run the eval'd function with a PATH that resolves no `codex`. We point
+# PATH at an empty dir so `command -v codex` fails inside the function.
+smoke_log "T1: codex absent -> silent no-op, exit 0, no state written"
+T1_TARGET="$(new_target t1)"
+EMPTY_BIN_DIR="$SMOKE_TMP_ROOT/emptybin"
+mkdir -p "$EMPTY_BIN_DIR"
+T1_OUT=""
+T1_RC=0
+T1_OUT="$(PATH="$EMPTY_BIN_DIR" bridge_upgrade_emit_codex_version_advisory "$T1_TARGET" 0 2>&1)" || T1_RC=$?
+[[ $T1_RC -eq 0 ]] || smoke_fail "T1: expected rc=0 with codex absent, got $T1_RC ($T1_OUT)"
+[[ ! -f "$T1_TARGET/$STATE_REL" ]] || smoke_fail "T1: state file must NOT be written when codex is absent"
+smoke_assert_not_contains "$T1_OUT" "ADVISORY" "T1: no advisory when codex absent"
+
+# --- T2 — first observation -> record, NO advisory -----------------------
+smoke_log "T2: first observation -> record version, no advisory"
+T2_TARGET="$(new_target t2)"
+set_fake_codex_version "codex-cli 0.135.0"
+T2_OUT=""
+T2_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" bridge_upgrade_emit_codex_version_advisory "$T2_TARGET" 0 2>&1)"
+smoke_assert_not_contains "$T2_OUT" "ADVISORY" "T2: first observation must not advise (no baseline)"
+smoke_assert_file_exists "$T2_TARGET/$STATE_REL" "T2: version recorded on first observation"
+T2_RECORDED="$(cat "$T2_TARGET/$STATE_REL")"
+smoke_assert_eq "codex-cli 0.135.0" "$T2_RECORDED" "T2: recorded raw version line"
+
+# --- T3 — same MAJOR.MINOR (patch bump) -> NO advisory -------------------
+smoke_log "T3: same major.minor (0.135.0 -> 0.135.2) -> no advisory, baseline updated"
+T3_TARGET="$(new_target t3)"
+printf '%s\n' "codex-cli 0.135.0" >"$T3_TARGET/$STATE_REL"
+set_fake_codex_version "codex-cli 0.135.2"
+T3_OUT=""
+T3_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" bridge_upgrade_emit_codex_version_advisory "$T3_TARGET" 0 2>&1)"
+smoke_assert_not_contains "$T3_OUT" "ADVISORY" "T3: a patch-only bump must not advise"
+smoke_assert_eq "codex-cli 0.135.2" "$(cat "$T3_TARGET/$STATE_REL")" "T3: baseline updated to patch version"
+
+# --- T4 — MAJOR/MINOR change -> advisory, baseline updated ---------------
+smoke_log "T4: minor change (0.135.0 -> 0.136.0) -> advisory printed, baseline updated"
+T4_TARGET="$(new_target t4)"
+printf '%s\n' "codex-cli 0.135.0" >"$T4_TARGET/$STATE_REL"
+set_fake_codex_version "codex-cli 0.136.0"
+T4_OUT=""
+T4_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" bridge_upgrade_emit_codex_version_advisory "$T4_TARGET" 0 2>&1)"
+smoke_assert_contains "$T4_OUT" "ADVISORY" "T4: a minor change must surface the advisory"
+smoke_assert_contains "$T4_OUT" "0.135.0 -> 0.136.0" "T4: advisory names the version transition"
+smoke_assert_contains "$T4_OUT" "codex doctor" "T4: advisory recommends 'codex doctor'"
+smoke_assert_eq "codex-cli 0.136.0" "$(cat "$T4_TARGET/$STATE_REL")" "T4: baseline updated after advisory"
+
+# T4b — major change (0.136.0 -> 1.0.0) also advises.
+T4B_TARGET="$(new_target t4b)"
+printf '%s\n' "codex-cli 0.136.0" >"$T4B_TARGET/$STATE_REL"
+set_fake_codex_version "codex-cli 1.0.0"
+T4B_OUT=""
+T4B_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" bridge_upgrade_emit_codex_version_advisory "$T4B_TARGET" 0 2>&1)"
+smoke_assert_contains "$T4B_OUT" "ADVISORY" "T4b: a major change must surface the advisory"
+
+# --- T5 — BRIDGE_CODEX_VERSION_ADVISORY=0 hard suppress ------------------
+smoke_log "T5: BRIDGE_CODEX_VERSION_ADVISORY=0 hard-suppresses even on a minor change"
+T5_TARGET="$(new_target t5)"
+printf '%s\n' "codex-cli 0.135.0" >"$T5_TARGET/$STATE_REL"
+set_fake_codex_version "codex-cli 0.136.0"
+T5_OUT=""
+T5_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" BRIDGE_CODEX_VERSION_ADVISORY=0 bridge_upgrade_emit_codex_version_advisory "$T5_TARGET" 0 2>&1)"
+smoke_assert_not_contains "$T5_OUT" "ADVISORY" "T5: =0 must suppress the advisory"
+
+# --- T6 — dry-run -> plan line only, no state mutation ------------------
+smoke_log "T6: --dry-run -> plan line, no state mutation"
+T6_TARGET="$(new_target t6)"
+set_fake_codex_version "codex-cli 0.136.0"
+T6_OUT=""
+T6_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" bridge_upgrade_emit_codex_version_advisory "$T6_TARGET" 1 2>&1)"
+smoke_assert_contains "$T6_OUT" "plan:" "T6: dry-run prints a plan line"
+[[ ! -f "$T6_TARGET/$STATE_REL" ]] || smoke_fail "T6: dry-run must not write the state file"
+
+# --- T7 / T8 — errexit safety (codex internal-review r1) -----------------
+# bridge-upgrade.sh runs under `set -euo pipefail`. A `codex --version`
+# that exits nonzero, or output with no parseable version, must be
+# "unknown and skipped" — NOT an upgrade-aborting errexit trip. The
+# earlier cases above ran the function in this smoke's own shell (no
+# set -e); these two re-run the eval'd function under an EXPLICIT
+# `set -euo pipefail` so a regression that drops a `|| var=""` guard
+# fails CI here.
+#
+# Driver as a temp FILE (no procsub / here-string into a shell — H3),
+# invoked as `bash <driver>`. It evals the verbatim function body, turns
+# on errexit, runs the function, and prints a sentinel only if the call
+# returned without aborting.
+ERREXIT_DRIVER="$SMOKE_TMP_ROOT/errexit-driver.sh"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'set -uo pipefail'
+  # Body of the real function (verbatim — same drift seam).
+  printf '%s\n' "$FN_BODY"
+  printf '%s\n' 'set -euo pipefail'
+  printf '%s\n' 'bridge_upgrade_emit_codex_version_advisory "$1" 0'
+  printf '%s\n' 'printf "ERREXIT_SURVIVED\\n"'
+} >"$ERREXIT_DRIVER"
+
+# T7: codex --version exits nonzero (e.g. 42) but still prints a banner.
+smoke_log "T7: codex --version nonzero exit must not abort the upgrade (errexit)"
+T7_TARGET="$(new_target t7)"
+set_fake_codex_version_rc "codex-cli 0.135.0" "42"
+T7_OUT=""
+T7_RC=0
+T7_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" bash "$ERREXIT_DRIVER" "$T7_TARGET" 2>&1)" || T7_RC=$?
+[[ $T7_RC -eq 0 ]] || smoke_fail "T7: function aborted under errexit (rc=$T7_RC) when codex --version exited nonzero. output: $T7_OUT"
+smoke_assert_contains "$T7_OUT" "ERREXIT_SURVIVED" "T7: function returned 0 under errexit despite codex --version nonzero"
+
+# T8: codex --version prints unparseable output (no dotted version).
+smoke_log "T8: unparseable codex --version output must not abort the upgrade (errexit)"
+T8_TARGET="$(new_target t8)"
+set_fake_codex_version_rc "codex: command unavailable in this build" "0"
+T8_OUT=""
+T8_RC=0
+T8_OUT="$(PATH="$FAKE_BIN_DIR:$PATH" bash "$ERREXIT_DRIVER" "$T8_TARGET" 2>&1)" || T8_RC=$?
+[[ $T8_RC -eq 0 ]] || smoke_fail "T8: function aborted under errexit (rc=$T8_RC) on unparseable version. output: $T8_OUT"
+smoke_assert_contains "$T8_OUT" "ERREXIT_SURVIVED" "T8: function returned 0 under errexit on unparseable version output"
+
+smoke_log "PASS"

--- a/scripts/smoke/ε-watchdog-rescan-codex.sh
+++ b/scripts/smoke/ε-watchdog-rescan-codex.sh
@@ -187,4 +187,85 @@ fi
 run_watchdog scan --json --apply --agent claude-ok --agent-registry-json "$REGISTRY_JSON" >/dev/null
 [[ -f "$REPORT_FILE" ]] || smoke_fail "T6b: scan --apply did not write $REPORT_FILE"
 
+# --- T7 / T8 — #8945 Track D: shared-workdir AGENTS.md home fall-back -----
+# A Codex agent layered onto a *shared* workdir (the admin's `<admin>-dev`
+# pair created with `--allow-shared-workdir`) has its per-agent AGENTS.md
+# materialized into its `agent_home` identity source, NOT the shared
+# workdir — `bridge_layout_materialize_identity`'s shared-workspace guard
+# declines to stamp per-agent identity into a foreign workspace. The
+# watchdog scans the workdir, so before this fix it reported a phantom
+# `missing_files: AGENTS.md` for every such pair (the patch-dev false
+# drift). The registry `home` field now lets the watchdog treat the
+# entrypoint as present when it exists in EITHER the scanned dir OR the
+# agent_home.
+#
+#   T7: codex agent — AGENTS.md absent from the (shared) workdir but
+#       PRESENT in `home` → status ok, missing_files empty. No false drift.
+#   T8 (teeth): codex agent — AGENTS.md absent from BOTH the workdir AND
+#       `home` → status error, missing_files [AGENTS.md]. A genuinely
+#       missing entrypoint is NOT masked by the fall-back.
+smoke_log "T7-T8: codex shared-workdir AGENTS.md home fall-back (no false drift; genuine-missing still fires)"
+
+# Shared workdir holds a *foreign* CLAUDE.md (the admin's), no AGENTS.md.
+SHARED_WD="$SMOKE_TMP_ROOT/shared-admin-workdir"
+mkdir -p "$SHARED_WD"
+printf '%s\n' "# admin (claude) — shared project workdir" >"$SHARED_WD/CLAUDE.md"
+
+# T7 agent: per-agent AGENTS.md materialized into the agent_home, not the
+# shared workdir.
+CODEX_SHARED_HOME="$AGENTS_ROOT/codex-shared/home"
+mkdir -p "$CODEX_SHARED_HOME"
+: >"$CODEX_SHARED_HOME/AGENTS.md"
+
+# T8 agent: AGENTS.md absent everywhere (shared workdir + empty home).
+CODEX_SHARED_MISSING_HOME="$AGENTS_ROOT/codex-shared-missing/home"
+mkdir -p "$CODEX_SHARED_MISSING_HOME"
+
+REGISTRY_SHARED_JSON="$SMOKE_TMP_ROOT/registry-shared.json"
+{
+  printf '['
+  printf '{"id":"codex-shared","class":"static","agent_source":"static","engine":"codex","workdir":"%s","home":"%s"},' \
+    "$SHARED_WD" "$CODEX_SHARED_HOME"
+  printf '{"id":"codex-shared-missing","class":"static","agent_source":"static","engine":"codex","workdir":"%s","home":"%s"}' \
+    "$SHARED_WD" "$CODEX_SHARED_MISSING_HOME"
+  printf ']'
+} >"$REGISTRY_SHARED_JSON"
+
+SHARED_SCAN_JSON="$(run_watchdog scan --json --registry-anchored --agent-registry-json "$REGISTRY_SHARED_JSON")"
+# Assertion driver as a temp FILE (not heredoc-stdin / procsub into the
+# interpreter — lint-heredoc-ban H3 family). Written via printf, invoked
+# as `python3 <file> <json>`.
+SHARED_ASSERT_PY="$SMOKE_TMP_ROOT/shared-assert.py"
+printf '%s\n' \
+  'import json, sys' \
+  'payload = json.loads(sys.argv[1])' \
+  'rows = {row["agent"]: row for row in payload["agents"]}' \
+  '# T7: AGENTS.md present in home (not the shared workdir) -> ok, no drift.' \
+  'row = rows.get("codex-shared")' \
+  'assert row is not None, "T7: codex-shared row missing: %s" % sorted(rows)' \
+  'assert row["engine"] == "codex", row' \
+  'status = row["status"]' \
+  'missing = row["missing_files"]' \
+  'assert status == "ok", (' \
+  '    "T7: shared-workdir codex with AGENTS.md in home must be ok "' \
+  '    "(false-drift regression), got %s / %s" % (status, missing)' \
+  ')' \
+  'assert missing == [], (' \
+  '    "T7: AGENTS.md present in home must not be reported missing: %s" % missing' \
+  ')' \
+  '# T8 (teeth): AGENTS.md absent from BOTH workdir and home -> error.' \
+  'row = rows.get("codex-shared-missing")' \
+  'assert row is not None, "T8: codex-shared-missing row missing: %s" % sorted(rows)' \
+  'status = row["status"]' \
+  'missing = row["missing_files"]' \
+  'assert status == "error", (' \
+  '    "T8 teeth: a genuinely missing AGENTS.md (absent from workdir AND home) "' \
+  '    "must still be drift, got %s" % status' \
+  ')' \
+  'assert missing == ["AGENTS.md"], (' \
+  '    "T8 teeth: expected [AGENTS.md], got %s" % missing' \
+  ')' \
+  >"$SHARED_ASSERT_PY"
+"$PY_BIN" "$SHARED_ASSERT_PY" "$SHARED_SCAN_JSON"
+
 smoke_log "PASS"


### PR DESCRIPTION
## Summary

#8945 Track D — three Codex-provisioning hardening items exposed by the patch-dev wedge. Bases on `feat/codex-prov-wave-integration` (Track A's `agents/_template/codex/AGENTS.md` already merged; this PR makes the watchdog AGREE with where that template lands).

## What changed

1. **Availability-gated `codex doctor` smoke** (`scripts/smoke/codex-doctor.sh`, new). Absent `codex` → graceful SKIP + exit 0 (the CI default — a codex-less host never becomes a false release blocker, mirroring the non-fatal precedent in `lib/bridge-init-codex-pair.sh`). Present `codex` + `BRIDGE_SMOKE_CODEX_DOCTOR_LIVE=1` → real `codex doctor`, assert clean exit + env/auth/runtime status. Present `codex`, gate off → cheap `codex --version` shape check (no network/auth). The real-doctor path is the live/tool-present gate only.

2. **`bridge-watchdog.py` AGENTS.md shared-workdir false-drift fix.** A Codex `<admin>-dev` pair created with `--allow-shared-workdir` has its per-agent `AGENTS.md` materialized into its `agent_home` identity source, **not** the shared workdir — `bridge_layout_materialize_identity`'s shared-workspace guard deliberately declines to stamp per-agent identity into a foreign workspace. The watchdog scans the workdir, so it reported a phantom `missing_files: AGENTS.md` for every such pair (today's patch-dev false drift). Fix: thread the registry `home` field into `scan_agent`; for the engine entrypoint (`AGENTS.md` for codex / `CLAUDE.md` for claude) **only**, treat it present when it exists in EITHER the scanned dir OR the agent_home. A genuinely-missing entrypoint (absent from BOTH) **still** surfaces as drift — no real missing-file is masked, and the Claude profile set is unaffected.

3. **`bridge-upgrade.sh` codex-version surface.** `bridge_upgrade_emit_codex_version_advisory` records `codex --version` into `state/upgrade/codex-version.last` and, on a MAJOR/MINOR change, emits a NON-fatal operator advisory (re-check `codex doctor` + the bridge's Codex hook list / AGENTS.md protocol). Missing codex → silent skip; first observation → record only; patch-only bump → no advisory; suppress with `BRIDGE_CODEX_VERSION_ADVISORY=0`; dry-run → plan line only. **errexit-safe** — every capture carries a `|| var=""` fallback so a failing/unparseable `codex --version` under `set -euo pipefail` cannot abort the upgrade.

### Smokes
- `scripts/smoke/ε-watchdog-rescan-codex.sh` +T7/T8: shared-workdir AGENTS.md present-in-home → no drift; absent-from-both → drift (teeth).
- `scripts/smoke/codex-version-surface.sh` (new): T1-T8 = absent / first-seen / patch-bump / minor+major change / suppress / dry-run + **errexit teeth** (T7 nonzero `codex --version`, T8 unparseable output — both must NOT abort under `set -e`).
- `scripts/smoke/codex-doctor.sh` (new): skip / tool-present / live.
- All registered additively in `scripts/ci-select-smoke.sh` (`bridge-watchdog.py`, `bridge-upgrade.sh`, `scripts/smoke/*` arms).

## Verification (macOS, Homebrew bash 5.3.9)

```
bash -n + shellcheck on all touched .sh ......................... rc 0
python3 -c "import ast; ast.parse(open('bridge-watchdog.py'))" ... OK
scripts/smoke/codex-doctor.sh (skip + tool-present + live) ...... PASS
scripts/smoke/codex-version-surface.sh (T1-T8) ................. PASS
scripts/smoke/ε-watchdog-rescan-codex.sh (T1-T8) .............. PASS
1067-codex-provisioning / watchdog-profile-contract / 1108 /
  1119 / watchdog-registry-anchored (regression) .............. PASS
lint-heredoc-ban (bridge-upgrade.sh 18/18) .................... PASS
lint-raw-pathlib-on-isolated (bridge-watchdog.py 18/18, noqa) .. PASS
```

Teeth proven: removing the `|| current_raw=""` guard makes `codex-version-surface.sh` T7 fail with `function aborted under errexit (rc=42)`; removing nothing → all green. The internal codex review caught exactly this errexit class (its repro: a fake `codex(){ return 42; }`) — fixed here, plus the smoke now runs the function under explicit `set -euo pipefail`.

Known macOS-only environment failures (NOT introduced by this diff, verified): `G-beta4-watchdog-noise` T3 (iso-v2 group-normalize is Linux-only) and `iso-helper-ratchet.sh` (crashes on macOS bash; my diff adds zero iso-helper-ratchet patterns, so the `bridge-watchdog.py=7` baseline is unaffected).

## Scope discipline

No Track A scaffold logic / AGENTS.md template content (read only). No Track B (`bridge-hooks.py` / `hooks/`). No Track C slash-commands / permission profiles. No VERSION/CHANGELOG. The new raw-pathlib probe carries a justified `# noqa: raw-pathlib-controller-only`.

Addresses Track D of #8945. Track C stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
