### PR TITLE
fix(cron): export BRIDGE_ADMIN_AGENT_ID through the wrapper/load path so #1474 admin cross-agent exemption works via agent-bridge/agb (#1474 / v0.15.3 regression)

### DIFF
--- a/lib/bridge-state.sh
+++ b/lib/bridge-state.sh
@@ -1302,6 +1302,31 @@ bridge_load_roster() {
   : "${BRIDGE_STALL_NETWORK_ESCALATE_SECONDS:=600}"
   : "${BRIDGE_STALL_UNKNOWN_ESCALATE_SECONDS:=600}"
   : "${BRIDGE_ADMIN_AGENT_ID:=}"
+  # Issue #1474 (v0.15.3 wrapper-path regression): EXPORT the resolved admin
+  # id so it survives an `exec` into a child process. The roster source above
+  # (controller `agent-roster.local.sh`, OR the iso UID's scoped
+  # `runtime/agent-env.sh` — both via plain assignment, never `export`) sets
+  # BRIDGE_ADMIN_AGENT_ID as a NON-exported shell var. The `agent-bridge`/`agb`
+  # wrapper runs `bridge_load_roster` then `exec`s `bridge-cron.sh create`
+  # (agent-bridge:cron dispatch); without this export the non-exported value
+  # is dropped across `exec`, and `run_create` never re-loads the roster — so
+  # `bridge_admin_agent_id()` returns "" in the child and the #1474 admin
+  # cross-agent cron exemption (`_bridge_cron_create_admin_cross_agent_allowed`)
+  # can never pass via the wrapper path (it works on a DIRECT `bash
+  # bridge-cron.sh` call only because the caller's session already exported the
+  # value — bridge-run.sh's `export BRIDGE_ADMIN_AGENT_ID="$(bridge_admin_agent_id)"`).
+  # This mirrors that runtime-path export so the load/wrapper path matches.
+  #
+  # SECURITY (does NOT weaken the #1359 iso/non-admin gate): the export only
+  # ever carries what THIS process's own roster scope resolved. A controller /
+  # admin session resolves the real admin id; an iso/non-admin agent's scope
+  # resolves either empty or the admin id from its scoped snapshot — but the
+  # gate is `BRIDGE_AGENT_ID == BRIDGE_ADMIN_AGENT_ID`, and a non-admin agent's
+  # BRIDGE_AGENT_ID is its OWN id (never the admin's), so the exemption still
+  # rejects it. (The CLI exemption is a friendly early-pass anyway; the real
+  # authorization gate is the daemon's controller-side staging.py re-validation
+  # with non-forgeable filesystem signals — see bridge-cron.sh.)
+  export BRIDGE_ADMIN_AGENT_ID
   if bridge_cron_sync_enabled; then
     BRIDGE_CRON_SYNC_ENABLED=1
   else

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -111,6 +111,11 @@ add_required queue daemon daemon-periodic-token-sync launch launch-dev-channels-
 add_required 1425-cron-dispatch-nudge-scope
 add_required 1936-forward-followup-attached-escalation
 add_required 1473-agent-list-iso-state-fallback
+# Issue #1474 (v0.15.3 wrapper-path regression): bridge_load_roster must EXPORT
+# the resolved BRIDGE_ADMIN_AGENT_ID so the admin cross-agent cron exemption
+# survives `exec` into the bridge-cron.sh child via the agent-bridge/agb wrapper
+# — without weakening the #1359 iso/non-admin reject.
+add_required 1474-wrapper-admin-cron-exemption
 # #8945 Track B: expanded Codex hook coverage (PreCompact / PostCompact /
 # SubagentStart / SubagentStop / PermissionRequest). All audit-only by default;
 # the permission-request smoke pins the security contract.
@@ -348,6 +353,16 @@ select_for_path() {
         # invariant, the no-secret column boundary, or the controller
         # no-regression gate.
         add_required 1473-agent-list-iso-state-fallback
+        # Issue #1474 (v0.15.3 wrapper-path regression): lib/bridge-state.sh's
+        # bridge_load_roster now EXPORTs BRIDGE_ADMIN_AGENT_ID so the resolved
+        # admin id survives `exec` into the bridge-cron.sh child spawned by the
+        # agent-bridge/agb wrapper — that is what lets the #1474 admin
+        # cross-agent cron exemption pass on the wrapper path (it already
+        # worked on a DIRECT bridge-cron.sh call). Pull the smoke on every
+        # bridge-state.sh move so a refactor cannot silently drop the export
+        # (which would re-break the wrapper path) OR start leaking a non-admin
+        # agent's BRIDGE_AGENT_ID==admin (which would weaken the #1359 gate).
+        add_required 1474-wrapper-admin-cron-exemption
       fi
       ;;
   esac

--- a/scripts/smoke/1474-wrapper-admin-cron-exemption-wrapper.sh
+++ b/scripts/smoke/1474-wrapper-admin-cron-exemption-wrapper.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/smoke/1474-wrapper-admin-cron-exemption-wrapper.sh — helper for
+# 1474-wrapper-admin-cron-exemption.sh.
+#
+# Faithfully reproduces the `agent-bridge cron create` wrapper arm: source
+# bridge-lib.sh, run `bridge_load_roster` (which resolves BRIDGE_ADMIN_AGENT_ID
+# from the roster), then `exec` `bridge-cron.sh create ...` — exactly like the
+# `cron)` dispatch in the `agent-bridge` CLI. The point of the fix under test is
+# that `bridge_load_roster` must EXPORT BRIDGE_ADMIN_AGENT_ID so the resolved
+# admin id survives this `exec` into the child.
+#
+# Inputs (env, set by the parent smoke):
+#   WRAPPER_REPO_ROOT   — repo root (for bridge-lib.sh + bridge-cron.sh)
+#   WRAPPER_BRIDGE_BASH — bash binary to exec the child with
+#   WRAPPER_TARGET      — cross-agent --agent value
+#   WRAPPER_KIND        — text | shell
+#   plus BRIDGE_* (BRIDGE_AGENT_ID, layout, roster, jobs/staging paths)
+#
+# NOTE: BRIDGE_AGENT_ID is exported into THIS process by the parent (mirrors a
+# live agent session). BRIDGE_ADMIN_AGENT_ID is NOT pre-exported — it only
+# becomes available after `bridge_load_roster` sources the roster, and only
+# survives the exec below because the fix exports it there.
+
+set -uo pipefail
+
+REPO_ROOT="${WRAPPER_REPO_ROOT:?WRAPPER_REPO_ROOT required}"
+BRIDGE_BASH="${WRAPPER_BRIDGE_BASH:?WRAPPER_BRIDGE_BASH required}"
+TARGET="${WRAPPER_TARGET:?WRAPPER_TARGET required}"
+KIND="${WRAPPER_KIND:-text}"
+
+# shellcheck source=/dev/null
+source "$REPO_ROOT/bridge-lib.sh"
+
+# The wrapper's roster load — this is the exact call agent-bridge makes at its
+# `*)` dispatch arm before exec'ing the subcommand script. It sets (and, with
+# the fix, EXPORTS) BRIDGE_ADMIN_AGENT_ID.
+bridge_load_roster
+
+# Build the create argv. text-kind goes through the staging path; shell-kind
+# must still be refused at the CLI guard (text-only exemption).
+create_args=(
+  create
+  --agent "$TARGET"
+  --schedule "0 3 * * *"
+  --tz "Asia/Seoul"
+  --title "memory-daily-$TARGET"
+)
+if [[ "$KIND" == "shell" ]]; then
+  create_args+=(--kind shell --run-as-agent "$TARGET" --script "$REPO_ROOT/bridge-cron.sh")
+else
+  create_args+=(--payload "admin cross-agent provision")
+fi
+
+# exec the child — across this boundary only EXPORTED vars survive. This is the
+# crux of #1474: without the bridge_load_roster export, BRIDGE_ADMIN_AGENT_ID is
+# empty in the child and the admin exemption cannot pass.
+exec "$BRIDGE_BASH" "$REPO_ROOT/bridge-cron.sh" "${create_args[@]}"

--- a/scripts/smoke/1474-wrapper-admin-cron-exemption.sh
+++ b/scripts/smoke/1474-wrapper-admin-cron-exemption.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# scripts/smoke/1474-wrapper-admin-cron-exemption.sh — Issue #1474 (v0.15.3
+# wrapper-path regression).
+#
+# Background. The #1474 admin cross-agent cron exemption
+# (`_bridge_cron_create_admin_cross_agent_allowed` in bridge-cron.sh) lets the
+# registered admin agent provision `--kind text` crons for OTHER agents
+# (bootstrap-memory-system.sh registering memory-daily-<peer>), passing the
+# #1359 iso cross-agent reject through to the controller-side staging path.
+#
+# The exemption resolves the admin id via `bridge_admin_agent_id()`, which
+# reads `${BRIDGE_ADMIN_AGENT_ID:-}`. That worked on a DIRECT
+# `bash bridge-cron.sh create --agent <other>` call (the caller's live session
+# already EXPORTED BRIDGE_ADMIN_AGENT_ID via bridge-run.sh) — but FAILED on the
+# wrapper path `agent-bridge cron create --agent <other>`:
+#
+#   * the `agent-bridge`/`agb` wrapper runs `bridge_load_roster` (which sourced
+#     the roster and set BRIDGE_ADMIN_AGENT_ID as a NON-exported shell var),
+#   * then `exec`s `bridge-cron.sh create ...`,
+#   * across `exec` only EXPORTED vars survive, so the non-exported admin id was
+#     dropped, and `run_create` never re-loads the roster (on an iso host the
+#     child runs as the iso UID and cannot read the controller roster anyway),
+#   * → `bridge_admin_agent_id()` returns "" in the child → the exemption can
+#     never pass → hard #1359 reject → bootstrap drift persists.
+#
+# The fix EXPORTS BRIDGE_ADMIN_AGENT_ID inside `bridge_load_roster` (mirroring
+# bridge-run.sh's runtime-path export) so the resolved admin id survives `exec`
+# into the bridge-cron.sh child.
+#
+# This smoke exercises the REAL wrapper boundary (a parent shell that, exactly
+# like `agent-bridge`, sources bridge-lib.sh, calls `bridge_load_roster`, then
+# `exec`s `bridge-cron.sh create`). To isolate the export-survives-exec
+# behaviour deterministically on any platform, the child's own roster files are
+# EMPTY — so the child can ONLY learn the admin id from the inherited env. That
+# is precisely the iso-host condition the bug reproduces on.
+#
+# Cases:
+#   T1 — POSITIVE (wrapper path now works): admin/controller wrapper
+#        (BRIDGE_AGENT_ID == BRIDGE_ADMIN_AGENT_ID) creating a cross-agent
+#        `--kind text` cron PASSES the exemption — routes to staging, NO
+#        'cron mutation refused'. Pre-fix this FAILED (admin id lost across
+#        exec). This is the regression the fix closes.
+#   T2 — TEETH (gate NOT weakened): a NON-admin / iso agent
+#        (BRIDGE_AGENT_ID != BRIDGE_ADMIN_AGENT_ID) running the SAME wrapper +
+#        cross-agent command STILL gets the #1359 reject — even though its
+#        scoped env carries the controller's admin id. The gate compares
+#        BRIDGE_AGENT_ID against the admin id, so a non-admin agent can never
+#        pass it; exporting the admin id does not change that.
+#   T3 — TEETH (shell-kind stays blocked): an admin cross-agent request with
+#        `--kind shell` is STILL refused at the CLI guard — #1474 only widens
+#        the text path; shell staging is out of scope.
+#
+# lint-heredoc-ban hygiene: this smoke uses NO process-substitution and NO
+# heredoc-fed subprocess (`bash -s <<EOF` / `python3 - <<PY`). Output is
+# captured to temp files and consumed with a `while read` loop / grep.
+
+set -euo pipefail
+
+SMOKE_NAME="1474-wrapper-admin-cron-exemption"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home
+
+ADMIN_AGENT="patch"
+PEER_AGENT="other-agent"
+ISO_AGENT="worker-a"
+
+# The "wrapper home" carries the roster that sets BRIDGE_ADMIN_AGENT_ID — this
+# is what the parent's bridge_load_roster sources (just like the controller's
+# agent-roster.local.sh). It sets the admin id as a NON-exported shell var; the
+# fix's `export BRIDGE_ADMIN_AGENT_ID` in bridge_load_roster is what carries it
+# across the exec.
+printf 'BRIDGE_ADMIN_AGENT_ID="%s"\n' "$ADMIN_AGENT" >"$BRIDGE_ROSTER_LOCAL_FILE"
+
+# jobs.json owned + non-writable so the iso-context staging branch engages
+# (matches the real reproduction: controller-owned 0640 jobs.json).
+JOBS_FILE="$BRIDGE_NATIVE_CRON_JOBS_FILE"
+printf '{"format":"agent-bridge-cron-v1","jobs":[]}\n' >"$JOBS_FILE"
+chmod 0400 "$JOBS_FILE"
+[[ ! -w "$JOBS_FILE" ]] || smoke_fail "setup error — jobs.json must be non-writable"
+
+STAGING_ROOT="$BRIDGE_STATE_DIR/cron-staging"
+mkdir -p "$STAGING_ROOT"
+
+BRIDGE_BASH="$(command -v bash)"
+
+# run_wrapper_cron_create <agent_id> <admin_present:1|0> <target> <kind> <out>
+#
+# Simulates the `agent-bridge cron create` wrapper end to end:
+#   parent shell sources bridge-lib.sh, runs `bridge_load_roster`, then
+#   `exec`s `bridge-cron.sh create ...` — EXACTLY the agent-bridge:cron arm.
+#
+# The CHILD's roster files are EMPTY so the child cannot re-resolve the admin
+# id on its own; it must inherit it across the exec. This is what gives the
+# smoke teeth: pre-fix the inherited value is missing and T1 hits the reject.
+#
+# `admin_present` controls whether the parent's roster sets the admin id at all
+# (the parent always sources THIS home's roster; both legs use the same
+# BRIDGE_ROSTER_LOCAL_FILE which sets admin=patch). The agent's identity is
+# BRIDGE_AGENT_ID — admin leg passes patch, non-admin leg passes worker-a.
+run_wrapper_cron_create() {
+  local agent_id="$1"
+  local target="$2"
+  local kind="$3"
+  local out="$4"
+  local rc=0
+
+  # Child env: empty roster (child cannot read the admin id from disk),
+  # v2 layout + marker inherited from smoke_setup_bridge_home, jobs.json
+  # non-writable so the iso-context staging branch engages.
+  set +e
+  env \
+    BRIDGE_AGENT_ID="$agent_id" \
+    BRIDGE_LAYOUT="v2" \
+    BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+    BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+    BRIDGE_LAYOUT_MARKER_DIR="$BRIDGE_STATE_DIR" \
+    BRIDGE_ROSTER_FILE="$BRIDGE_ROSTER_FILE" \
+    BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" \
+    BRIDGE_NATIVE_CRON_JOBS_FILE="$JOBS_FILE" \
+    BRIDGE_CRON_STAGING_DIR="$STAGING_ROOT" \
+    BRIDGE_CRON_STAGING_TIMEOUT_SECONDS=2 \
+    BRIDGE_CRON_STAGING_POLL_INTERVAL_SECONDS=1 \
+    WRAPPER_REPO_ROOT="$REPO_ROOT" \
+    WRAPPER_BRIDGE_BASH="$BRIDGE_BASH" \
+    WRAPPER_TARGET="$target" \
+    WRAPPER_KIND="$kind" \
+    "$BRIDGE_BASH" "$SCRIPT_DIR/1474-wrapper-admin-cron-exemption-wrapper.sh" \
+    >"$out" 2>&1
+  rc=$?
+  set -e
+  return "$rc"
+}
+
+# Assert helper: does an output file contain the #1359 reject string?
+out_has_reject() {
+  local out="$1"
+  local line
+  local hit=0
+  while IFS= read -r line; do
+    case "$line" in
+      *"cron mutation refused"*) hit=1; break ;;
+    esac
+  done <"$out"
+  [[ "$hit" -eq 1 ]]
+}
+
+out_has_staging() {
+  local out="$1"
+  local line
+  local hit=0
+  while IFS= read -r line; do
+    case "$line" in
+      *"cron-staging"*) hit=1; break ;;
+    esac
+  done <"$out"
+  [[ "$hit" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# T1 — POSITIVE: admin/controller wrapper path now PASSES the exemption.
+# ---------------------------------------------------------------------------
+smoke_log "T1: admin wrapper cross-agent --kind text must NOT be refused (proceeds to staging)"
+
+T1_OUT="$SMOKE_TMP_ROOT/t1.out"
+run_wrapper_cron_create "$ADMIN_AGENT" "$PEER_AGENT" "text" "$T1_OUT" || true
+
+if out_has_reject "$T1_OUT"; then
+  smoke_log "T1 output:"
+  while IFS= read -r _l; do smoke_log "  | $_l"; done <"$T1_OUT"
+  smoke_fail "T1: admin wrapper cross-agent text was REFUSED — the exemption did not pass (admin id lost across exec). This is the #1474 regression."
+fi
+out_has_staging "$T1_OUT" \
+  || smoke_fail "T1: admin wrapper cross-agent text did not route through the staging path (expected 'cron-staging' in output)"
+smoke_log "ok: T1 — admin wrapper cross-agent text proceeded to staging (exemption passed across exec)"
+
+# ---------------------------------------------------------------------------
+# T2 — TEETH: non-admin / iso agent STILL gets the #1359 reject.
+# ---------------------------------------------------------------------------
+smoke_log "T2: non-admin/iso wrapper cross-agent --kind text MUST still be refused (#1359 gate intact)"
+
+T2_OUT="$SMOKE_TMP_ROOT/t2.out"
+run_wrapper_cron_create "$ISO_AGENT" "$PEER_AGENT" "text" "$T2_OUT" || true
+
+out_has_reject "$T2_OUT" \
+  || {
+       smoke_log "T2 output:"
+       while IFS= read -r _l; do smoke_log "  | $_l"; done <"$T2_OUT"
+       smoke_fail "T2: non-admin/iso wrapper cross-agent text was NOT refused — the #1359 gate was weakened. The admin-id export must NOT let a non-admin agent pass the exemption."
+     }
+smoke_log "ok: T2 — non-admin/iso wrapper cross-agent text correctly refused (gate intact)"
+
+# ---------------------------------------------------------------------------
+# T3 — TEETH: admin cross-agent --kind shell stays blocked at the CLI guard.
+# ---------------------------------------------------------------------------
+smoke_log "T3: admin wrapper cross-agent --kind shell MUST still be refused (#1474 widens text only)"
+
+T3_OUT="$SMOKE_TMP_ROOT/t3.out"
+run_wrapper_cron_create "$ADMIN_AGENT" "$PEER_AGENT" "shell" "$T3_OUT" || true
+
+out_has_reject "$T3_OUT" \
+  || {
+       smoke_log "T3 output:"
+       while IFS= read -r _l; do smoke_log "  | $_l"; done <"$T3_OUT"
+       smoke_fail "T3: admin wrapper cross-agent SHELL was NOT refused — shell-kind cross-agent staging must stay out of scope."
+     }
+smoke_log "ok: T3 — admin wrapper cross-agent shell correctly refused (text-only exemption)"
+
+smoke_log "PASS: #1474 wrapper-path admin cron exemption — works for admin, gate intact for non-admin + shell"


### PR DESCRIPTION
## Summary

The #1474 admin cross-agent cron exemption works on a **direct** `bash bridge-cron.sh create --agent <other>` call but **fails on the wrapper path** `agent-bridge cron create --agent <other>` (and `agb`). This exports the resolved admin id in `bridge_load_roster` so it survives `exec` into the `bridge-cron.sh` child, mirroring the runtime-path export at `bridge-run.sh:681`.

## Root cause

`bridge_admin_agent_id()` returns `${BRIDGE_ADMIN_AGENT_ID:-}`. In the wrapper path the `agent-bridge` `*)` arm runs `bridge_load_roster` (which sourced the roster and set `BRIDGE_ADMIN_AGENT_ID` as a **non-exported** shell var), then `exec`s `bridge-cron.sh create` (the `cron)` arm). Across `exec` only **exported** vars survive, so the admin id was dropped — and `run_create` never re-loads the roster (on an iso v2 host the child runs as the iso UID and cannot read the 0600 controller roster anyway). So in the child `bridge_admin_agent_id()` returned `""` → `_bridge_cron_create_admin_cross_agent_allowed` could not pass → hard #1359 reject:

```
cron mutation refused: requested agent <other> does not match BRIDGE_AGENT_ID <admin> (iso agents may only mutate own cron)
```

…and `bootstrap-memory-system.sh` could not register `memory-daily-<peer>` crons for other agents (bootstrap drift persisted). The direct-call path worked only because the caller's live session already exported `BRIDGE_ADMIN_AGENT_ID` (`bridge-run.sh:681`).

## What changed

- **`lib/bridge-state.sh`** — `export BRIDGE_ADMIN_AGENT_ID` in `bridge_load_roster`, immediately after the resolved value's default (after the roster source). One functional line + explanatory comment. The load/wrapper path now matches the runtime path.
- **`scripts/smoke/1474-wrapper-admin-cron-exemption.sh`** (+ helper) — new smoke that drives the **real wrapper boundary** (source bridge-lib → `bridge_load_roster` → `exec bridge-cron.sh create`) with an **empty child roster**, so the child can only learn the admin id from the inherited env. No procsub / heredoc-stdin (temp-file `while read`).
- **`scripts/ci-select-smoke.sh`** — register the smoke (master static list + `lib/bridge-state.sh` trigger).

## Security — does NOT weaken the #1359 iso/non-admin gate

The export only carries what **this process's own roster scope** resolved. The exemption gate is `BRIDGE_AGENT_ID == BRIDGE_ADMIN_AGENT_ID`; a non-admin iso agent's `BRIDGE_AGENT_ID` is its own id, **never** the admin's, so it can never pass — even though its scoped env file already writes `BRIDGE_ADMIN_AGENT_ID=<admin>` non-exported today, and `bridge-run.sh:681` already exports it into every iso session. The CLI exemption is a friendly early-pass only; the real authorization gate is the daemon's controller-side `staging.py` re-validation (file-owner UID + dirname + `AGB_CRON_STAGING_ADMIN_AGENT`), untouched here.

## Verification

- **REPRO (pre-fix):** smoke T1 reproduces the bug — `cron mutation refused ... agent other-agent does not match BRIDGE_AGENT_ID patch`. **POST-FIX:** T1 passes (routes to staging). Proven by reverting only the export line.
- **TEETH:** T2 (non-admin/iso wrapper, scoped env carries `admin=patch`) **still** gets the #1359 reject post-fix; T3 (admin cross-agent `--kind shell`) **still** refused (text-only exemption).
- **Sibling smoke** `1359-cron-create-iso-staging.sh`: all cases pass (T7 / T7b / T8 / T8b / T8c / T8d / T8e) — no regression to the exemption or security gates.
- `bash -n` + `shellcheck` clean on all touched files; **heredoc-ban lint PASS**; no procsub/heredoc-stdin in the smoke.
- `smoke-test.sh`'s only failure is the **pre-existing** #365 ephemeral-controller-env guard assertion — fails **identically on the clean base** (macOS test-harness artifact, not a regression).
- Internal codex-rescue review: **implement-ok** (security gate not weakened).

Fixes the #1474 wrapper-path regression reported by cm-prod on 0.15.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)