### PR TITLE
fix(security): harden bridge-lib.sh Bash3.2-to-4 re-exec — no ambient-secret exposure (#1454)

### DIFF
--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -50,6 +50,84 @@
 # Everything in THIS block must be Bash 3.2-safe (it runs on macOS /bin/bash
 # 3.2 BEFORE the re-exec). The primitive is written to that bar.
 
+# ---------------------------------------------------------------------------
+# SHADOW-PROOF PRE-SOURCE SEED (#1491 / #1454 gap — bootstrap interception).
+# ---------------------------------------------------------------------------
+# THE GAP this seed closes (codex Phase-4 BLOCKING, proven on the PR head):
+# the primitive load below was historically a BARE `source` that ran WHILE an
+# exported `source()` (or `.()`) function shadow could still be active. A
+# same-UID caller that did
+#     source() { printf '%s\n' "$CLAUDE_CODE_OAUTH_TOKEN" >>"$leak"; command source "$@"; }
+#     export -f source
+# before invoking a bridge entry point would have its shadow run — reading the
+# live ambient secret — at the very moment we tried to load the de-fang
+# primitive. Hardening (`bridge_secret_scrub_harden_hooks`) only ran AFTER that
+# source, so the de-fang primitive itself was loaded through a compromised
+# `source`. The re-exec gate was therefore NOT fail-closed against caller-env
+# influence.
+#
+# THE SEED OF TRUST. Every command token a caller could intercept — `builtin`,
+# `command`, `source`, `.`, `unset`, `set`, `exec`, `eval` — can be shadowed by
+# a same-named exported FUNCTION, and in bash's command lookup a function
+# OUTRANKS the builtin of the same name (verified empirically on bash 5.3.9 AND
+# the macOS /bin/bash 3.2 pre-re-exec shell: even `builtin unset -f builtin` is
+# eaten by a `builtin()` function shadow). So no command-token-based de-fang is
+# self-healing on its own.
+#
+# The one lever a caller CANNOT shadow is a plain VARIABLE ASSIGNMENT — it is
+# not a command lookup. Assigning `POSIXLY_CORRECT=1` dynamically activates
+# POSIX mode mid-shell, and in POSIX mode the POSIX *special* builtins
+# (`unset`, `set`, `export`, `exec`, `eval`, …) OUTRANK same-named function
+# shadows. So:
+#   1. `POSIXLY_CORRECT=1`     — unshadowable assignment, turns POSIX mode ON.
+#   2. `set +T +E` + `trap -`  — kill functrace/errtrace and any DEBUG/RETURN/ERR
+#                                trap FIRST, BEFORE the strip. A `set -T` DEBUG
+#                                trap fires before every simple command and
+#                                could RE-INSTALL a `builtin()`/`source()` shadow
+#                                AFTER we unset it; clearing the trap first
+#                                guarantees nothing re-shadows post-strip.
+#                                (#1491 Phase-4 r2, codex finding 2.)
+#   3. `unset -f <names>`      — now the REAL special builtin `unset` (POSIX
+#                                mode); strips every interceptor function shadow
+#                                (including `source`, `.`, `builtin`, `command`,
+#                                `local`, `trap`, and `unset`/`set` themselves).
+#   4. `set +o posix`          — restore the historical non-POSIX semantics the
+#                                rest of bridge-lib.sh parses/runs under.
+#   5. `unset -f <names>` AGAIN — a SECOND strip in non-POSIX mode. On macOS
+#                                /bin/bash 3.2, `unset -f .` does NOT remove a
+#                                `.()` function while POSIX mode is on, but it
+#                                DOES once POSIX mode is off; the second pass
+#                                closes that 3.2 quirk. (#1491 Phase-4 r2,
+#                                codex finding 3.) `unset` here is the genuine
+#                                builtin — its shadow was stripped in step 3 and
+#                                the trap can no longer re-install it.
+#   6. `unset POSIXLY_CORRECT` — leave no posix-mode residue for children.
+# After the strips the genuine `source`/`builtin` builtins are reachable, so the
+# primitive load below (now `builtin source`, not a bare `source`) cannot be
+# intercepted. This block is pure-bash, builtin-only, no fork, and Bash
+# 3.2-safe — it runs on macOS /bin/bash 3.2 BEFORE the re-exec.
+#
+# `POSIXLY_CORRECT` is a plain (non-exported) shell var here; we unset it again
+# in step 6 so it is never inherited by the candidate-probe / re-exec children.
+# bridge-lib.sh itself requires non-POSIX mode (it uses arrays + `[[ ]]`), so
+# unconditionally landing in `set +o posix` is the correct end state here (the
+# shared primitive's harden_hooks, by contrast, restores the caller's exact
+# prior POSIX state — see lib/bridge-secret-scrub.sh).
+POSIXLY_CORRECT=1
+set +T +E 2>/dev/null || true
+trap - DEBUG RETURN ERR 2>/dev/null || true
+# shellcheck disable=SC2086  # intentional word-split of the name list
+unset -f source . unset set export exec eval command builtin printf read echo \
+  dirname cd pwd trap local mktemp chmod rm cat readlink true false \
+  2>/dev/null || true
+set +o posix 2>/dev/null || true
+# shellcheck disable=SC2086  # intentional word-split (2nd pass closes the bash-3.2 `unset -f .` quirk)
+unset -f source . unset set export exec eval command builtin printf read echo \
+  dirname cd pwd trap local mktemp chmod rm cat readlink true false \
+  2>/dev/null || true
+unset POSIXLY_CORRECT 2>/dev/null || true
+# ---------------------------------------------------------------------------
+
 # Derive the primitive's path with a parameter-expansion builtin (NO `dirname`
 # command-substitution child — that fork must not run while a secret could be
 # live). This mirrors the BRIDGE_SCRIPT_DIR derivation below but only needs the
@@ -60,12 +138,18 @@ else
   _BRIDGE_LIB_SELF_DIR="."
 fi
 if [[ -f "$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub.sh" ]]; then
+  # Load via `builtin source` (NOT a bare `source`): the seed above already
+  # stripped any `source()`/`.()` function shadow, and `builtin source` cannot
+  # resolve to a function shadow even if a residual one survived. So the de-fang
+  # primitive is loaded through an un-interceptable path.
   # shellcheck source=lib/bridge-secret-scrub.sh
-  source "$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub.sh"
+  builtin source "$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub.sh"
   bridge_secret_scrub_harden_hooks
 else
   # Primitive missing (truncated checkout): fall back to a minimal inline hook
   # scrub so we never regress to running the re-exec with BASH_ENV/ENV live.
+  # The seed above already de-fanged the command tokens, so these `builtin`
+  # calls reach the genuine builtins.
   builtin unset -f exec source command builtin unset printf read dirname cd pwd \
     2>/dev/null || builtin true
   builtin unset BASH_ENV ENV BASH_XTRACEFD 2>/dev/null || builtin true

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -16,11 +16,26 @@
 #   - a `$(cd -P "$(dirname …)" && pwd -P)` command-substitution to compute
 #     BRIDGE_SCRIPT_DIR (the `dirname` fork).
 # A same-UID caller that `export -f`'d a function named after any of those
-# commands (e.g. `dirname()`), planted such a binary on PATH, or pointed
-# BASH_ENV/ENV at a leak script could have its code run IN this shell / a child
+# commands (e.g. `dirname()`, incl. the `source`/`.`/`builtin`/`command`/`local`
+# builtins — neutralized via the un-shadowable `POSIXLY_CORRECT=1` seed) or
+# planted such a binary on PATH could have its code run IN this shell / a child
 # of it while the secret was readable, and exfiltrate it. PRs #1443
 # (bridge-usage.sh) and #1452/#1444 (bridge-run.sh) each closed this IN THEIR
 # OWN LANE; #1454 closes the re-exec at the shared bridge-lib.sh root.
+#
+# OUT OF SCOPE — the launch-environment-control boundary (#1443-consistent; see
+# lib/bridge-secret-scrub.sh "THREAT MODEL"): startup state the INVOKING shell
+# controls that runs BEFORE bridge-lib.sh's first executable line — an
+# initial-shell `BASH_ENV`/`ENV` startup file, an inherited `SHELLOPTS=xtrace`
+# with a command-substitution `PS4` (Bash evaluates `PS4` before the first
+# command), or an invoking-shell DEBUG trap. No pure-Bash code at the
+# bridge-lib.sh root can pre-empt these, and they require the attacker to
+# control the invoking shell's options/startup on a token-bearing launch — the
+# same position as a same-UID attacker who can already scrape `/proc`/the
+# filesystem. The harden step below DOES `unset BASH_ENV/ENV/BASH_XTRACEFD` +
+# `set +x` + drop `PS4`, so those hooks cannot fire in any CHILD/re-exec the
+# bridge forks AFTER hardening — only the initial-shell pre-first-line window
+# is out of scope.
 #
 # The fix closes the window WITHOUT changing the resolved BRIDGE_SCRIPT_DIR
 # value or the Bash-upgrade behavior:
@@ -39,10 +54,13 @@
 #      re-exec with `exec "$cand" -p …` so the re-exec'd process is likewise
 #      function-free + hook-free.
 # bridge-lib.sh itself does NOT capture/scrub the operator's ambient secret env
-# (that would change survival semantics for consumers): the steps above already
-# defeat the exported-function / PATH-shadow / startup-file interception class,
-# so the probe/re-exec children — which run only our own literal code under
-# `-p` — cannot be hijacked even though they inherit the (now-unhookable) env.
+# (that would change survival semantics for consumers): the steps above defeat
+# the exported-function / PATH-shadow classes and the startup-file hooks for the
+# CHILD/re-exec processes it forks (BASH_ENV/ENV/BASH_XTRACEFD/PS4 are unset
+# before the first fork) — NOT the initial-shell pre-first-line startup window
+# (out of scope, see the boundary note above). So the probe/re-exec children —
+# which run only our own literal code under `-p` — cannot be hijacked even
+# though they inherit the (now-unhookable) env.
 # The capture/scrub + nonce-gated fd-transit helpers are PROVIDED by the shared
 # primitive for consumers that need them (the #1443/#1452 lanes can adopt them
 # in a follow-up); bridge-lib.sh does not wire them onto those consumers here.

--- a/bridge-lib.sh
+++ b/bridge-lib.sh
@@ -1,6 +1,79 @@
 #!/usr/bin/env bash
 # shellcheck shell=bash disable=SC2034
 
+# ===========================================================================
+# AMBIENT-SECRET HARDENING for the Bash-3.2→4+ re-exec (issue #1454 — the
+# SHARED ROOT of the inherited-env credential-exposure class).
+# ===========================================================================
+#
+# bridge-lib.sh is sourced by essentially every entry point. Its Bash-3.2→4+
+# re-exec (below) historically ran EXTERNAL commands WHILE the operator's
+# ambient secret env (e.g. the Claude OAuth token) could still be live and an
+# attacker-controlled hook could intercept them:
+#   - a `$(command -v bash …)` command-substitution child in the candidate list,
+#   - a candidate-version probe invoked with `-lc` (a LOGIN shell — it sources
+#     the operator's profile AND honors BASH_ENV), and
+#   - a `$(cd -P "$(dirname …)" && pwd -P)` command-substitution to compute
+#     BRIDGE_SCRIPT_DIR (the `dirname` fork).
+# A same-UID caller that `export -f`'d a function named after any of those
+# commands (e.g. `dirname()`), planted such a binary on PATH, or pointed
+# BASH_ENV/ENV at a leak script could have its code run IN this shell / a child
+# of it while the secret was readable, and exfiltrate it. PRs #1443
+# (bridge-usage.sh) and #1452/#1444 (bridge-run.sh) each closed this IN THEIR
+# OWN LANE; #1454 closes the re-exec at the shared bridge-lib.sh root.
+#
+# The fix closes the window WITHOUT changing the resolved BRIDGE_SCRIPT_DIR
+# value or the Bash-upgrade behavior:
+#   1. harden hooks FIRST (unset -f interceptor function shadows, unset
+#      BASH_ENV/ENV/BASH_XTRACEFD, set +x, drop PS4) — builtin-only, before any
+#      fork. This is a no-op for normal operation (the bridge never uses those
+#      hooks). The shared primitive (lib/bridge-secret-scrub.sh) provides it.
+#   2. compute BRIDGE_SCRIPT_DIR with a BUILTIN parameter expansion
+#      (`${BASH_SOURCE[0]%/*}`, no `dirname` fork). `cd -P`/`pwd -P` are
+#      builtins, so the canonicalized value is byte-identical to before.
+#   3. select the Bash-4+ candidate from HARDCODED-ABSOLUTE paths (+ a single
+#      `builtin command -v bash` qualified fallback — `builtin command` cannot
+#      resolve to a function shadow), probe each under `-p -c` (PRIVILEGED, not
+#      `-lc`: privileged mode imports no environment functions and ignores
+#      BASH_ENV/ENV; `-c` is not a login shell so no profile is sourced), and
+#      re-exec with `exec "$cand" -p …` so the re-exec'd process is likewise
+#      function-free + hook-free.
+# bridge-lib.sh itself does NOT capture/scrub the operator's ambient secret env
+# (that would change survival semantics for consumers): the steps above already
+# defeat the exported-function / PATH-shadow / startup-file interception class,
+# so the probe/re-exec children — which run only our own literal code under
+# `-p` — cannot be hijacked even though they inherit the (now-unhookable) env.
+# The capture/scrub + nonce-gated fd-transit helpers are PROVIDED by the shared
+# primitive for consumers that need them (the #1443/#1452 lanes can adopt them
+# in a follow-up); bridge-lib.sh does not wire them onto those consumers here.
+#
+# Everything in THIS block must be Bash 3.2-safe (it runs on macOS /bin/bash
+# 3.2 BEFORE the re-exec). The primitive is written to that bar.
+
+# Derive the primitive's path with a parameter-expansion builtin (NO `dirname`
+# command-substitution child — that fork must not run while a secret could be
+# live). This mirrors the BRIDGE_SCRIPT_DIR derivation below but only needs the
+# directory to source the primitive.
+if [[ "${BASH_SOURCE[0]}" == */* ]]; then
+  _BRIDGE_LIB_SELF_DIR="${BASH_SOURCE[0]%/*}"
+else
+  _BRIDGE_LIB_SELF_DIR="."
+fi
+if [[ -f "$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub.sh" ]]; then
+  # shellcheck source=lib/bridge-secret-scrub.sh
+  source "$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub.sh"
+  bridge_secret_scrub_harden_hooks
+else
+  # Primitive missing (truncated checkout): fall back to a minimal inline hook
+  # scrub so we never regress to running the re-exec with BASH_ENV/ENV live.
+  builtin unset -f exec source command builtin unset printf read dirname cd pwd \
+    2>/dev/null || builtin true
+  builtin unset BASH_ENV ENV BASH_XTRACEFD 2>/dev/null || builtin true
+  builtin set +x 2>/dev/null || builtin true
+  builtin unset PS4 2>/dev/null || builtin true
+fi
+unset _BRIDGE_LIB_SELF_DIR
+
 # Resolve the re-exec target before any guard logic, since $0 is unreliable
 # under macOS /bin/bash invocations like `bash -lc '...' _ args` (where $0
 # is the placeholder `_`). Prefer the caller script that sourced us
@@ -15,12 +88,26 @@ if (( ${BASH_VERSINFO[0]:-0} < 4 )); then
   # fall through to the "requires Bash 4+" message rather than handing the
   # candidate shell a path it cannot open.
   if [[ -f "$_BRIDGE_LIB_REEXEC_TARGET" ]]; then
-    for bridge_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+    # #1454: candidate list is hardcoded-absolute first, then a single
+    # `builtin command -v bash` fallback. `builtin command` cannot resolve to
+    # an exported function shadow (so a `bash()`/`command()` function cannot
+    # hijack the lookup); the absolute paths cannot be function names at all.
+    bridge_candidate_bash_fallback="$(builtin command -v bash 2>/dev/null || true)"
+    for bridge_candidate_bash in /opt/homebrew/bin/bash /usr/local/bin/bash "$bridge_candidate_bash_fallback"; do
       [[ -n "$bridge_candidate_bash" && -x "$bridge_candidate_bash" ]] || continue
-      if "$bridge_candidate_bash" -lc '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
-        exec "$bridge_candidate_bash" "$_BRIDGE_LIB_REEXEC_TARGET" "$@"
+      # Probe under `-p -c` (PRIVILEGED + non-login): privileged Bash imports no
+      # environment functions and ignores BASH_ENV/ENV, and `-c` (not `-lc`)
+      # sources no profile — so the probe child cannot run attacker code while
+      # it inherits the env. (The old `-lc` sourced the operator's login
+      # profile, which a caller could have planted.)
+      if "$bridge_candidate_bash" -p -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+        # Re-exec PRIVILEGED so the re-exec'd bridge-lib (and every child it
+        # forks) is likewise function-free + BASH_ENV/ENV-free.
+        unset bridge_candidate_bash_fallback
+        exec "$bridge_candidate_bash" -p "$_BRIDGE_LIB_REEXEC_TARGET" "$@"
       fi
     done
+    unset bridge_candidate_bash_fallback
   fi
 
   echo "[bridge-lib] Agent Bridge requires Bash 4+ (current: ${BASH_VERSION:-unknown}). Re-run with a Bash 4+ shell on PATH (e.g. \`/opt/homebrew/bin/bash <script>\`)." >&2
@@ -30,7 +117,21 @@ fi
 # Keep bridge-owned runtime files private by default.
 umask 077
 
-BRIDGE_SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# #1454: compute BRIDGE_SCRIPT_DIR via a BUILTIN parameter expansion for the
+# dirname (no `dirname` fork — that external command must not run where an
+# exported-function shadow could intercept it while a secret could be live).
+# `cd -P` + `pwd -P` are builtins and preserve the exact symlink-canonicalized
+# absolute value the previous `$(dirname …)` form produced. Handle the
+# no-slash (`bridge-lib.sh` with no directory) and root-level (`/foo`) cases the
+# way `dirname` did: `.` and `/` respectively.
+if [[ "${BASH_SOURCE[0]}" == */* ]]; then
+  _BRIDGE_SCRIPT_DIR_RAW="${BASH_SOURCE[0]%/*}"
+  [[ -n "$_BRIDGE_SCRIPT_DIR_RAW" ]] || _BRIDGE_SCRIPT_DIR_RAW="/"
+else
+  _BRIDGE_SCRIPT_DIR_RAW="."
+fi
+BRIDGE_SCRIPT_DIR="$(cd -P "$_BRIDGE_SCRIPT_DIR_RAW" && pwd -P)"
+unset _BRIDGE_SCRIPT_DIR_RAW
 
 # Startup validation: if the source checkout that BRIDGE_SCRIPT_DIR resolved
 # to has been removed or is incomplete, fail loud and fast rather than fan

--- a/lib/bridge-secret-scrub.sh
+++ b/lib/bridge-secret-scrub.sh
@@ -17,13 +17,35 @@
 # THREAT MODEL (the in-scope window this primitive defends):
 #   A same-UID caller that, before invoking a bridge script, exports a Bash
 #   FUNCTION named after a command the script invokes unqualified (`export -f
-#   dirname`), plants such a binary earlier on PATH, points BASH_ENV/ENV at a
-#   leak script, or sets SHELLOPTS=xtrace + a malicious PS4 — any of which would
-#   otherwise run IN the script's shell (or a child it forks) WHILE an ambient
-#   secret env var is still live, and exfiltrate it.
-#   OUT of scope (per the #1443 ruling): a same-UID attacker who can already
-#   arbitrarily scrape the operator's filesystem / `/proc` — they already hold
-#   the secret; nothing this primitive does helps or hurts that case.
+#   dirname`, including the `source`/`.`/`builtin`/`command`/`local` builtins —
+#   neutralized via the un-shadowable `POSIXLY_CORRECT=1` seed), or plants such
+#   a binary earlier on PATH — any of which would otherwise run IN the script's
+#   shell (or a child it forks) WHILE an ambient secret env var is still live,
+#   and exfiltrate it. The primitive also `unset`s `BASH_ENV ENV BASH_XTRACEFD`,
+#   `set +x`, and `unset PS4` in `harden_hooks` so none of those caller-planted
+#   child-startup hooks fire in any subshell/fork the bridge spawns AFTER
+#   hardening (the re-exec and every later `$(...)`).
+#
+#   OUT of scope — the launch-environment-control boundary (consistent with the
+#   #1443 ruling). Two related classes are explicitly NOT defended because they
+#   execute attacker code BEFORE this primitive's first line can run, and both
+#   require the attacker to control the *invoking shell's options/startup* on a
+#   token-bearing launch — the same "already controls the launch environment"
+#   position as a same-UID attacker who can scrape `/proc`/the filesystem (who
+#   already holds the secret):
+#     (a) Inherited `SHELLOPTS=xtrace` + a `PS4` carrying a command-substitution:
+#         Bash evaluates `PS4` BEFORE the first command of any script, so the
+#         `PS4` `$(...)` runs while the secret is live before bridge-lib.sh's
+#         first executable line — no pure-Bash code at the bridge-lib.sh root
+#         can pre-empt it from inside the script.
+#     (b) A DEBUG trap installed by the invoking shell (e.g. via `BASH_ENV` +
+#         `set -T`) fires before the seed assignment itself.
+#   These are the launch-env-control boundary, not a defect in this primitive;
+#   defending them would require trusting the invoking shell's pre-exec state,
+#   which is exactly what a same-UID launch-environment attacker controls. The
+#   matching boundary still holds: a same-UID attacker who can already
+#   arbitrarily scrape the operator's filesystem / `/proc` already holds the
+#   secret; nothing this primitive does helps or hurts that case.
 #
 # CONSUMER CONTRACT (what each helper guarantees / requires):
 #

--- a/lib/bridge-secret-scrub.sh
+++ b/lib/bridge-secret-scrub.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# bridge-secret-scrub.sh — shared ambient-secret scrub / transit primitive
+# (issue #1454).
+#
+# THE SHARED ROOT. PRs #1443 (bridge-usage.sh) and #1452/#1444 (bridge-run.sh)
+# each re-implemented the same inherited-env credential-hardening dance in their
+# own lane: strip exported-function shadows + BASH_ENV/ENV/BASH_XTRACEFD startup
+# hooks before any fork, capture the well-known secret env values into
+# NON-exported shell vars and scrub them from the environment, re-exec under a
+# privileged `bash -p` (privileged mode imports no environment functions and
+# ignores BASH_ENV/ENV), and carry the captured values across that re-exec on a
+# nonce-gated inherited fd backed by an UNLINKED 0600 file (never a findable
+# path, never an env var). This file factors those moves into ONE reusable
+# primitive so future consumers stop hand-rolling the dance.
+#
+# THREAT MODEL (the in-scope window this primitive defends):
+#   A same-UID caller that, before invoking a bridge script, exports a Bash
+#   FUNCTION named after a command the script invokes unqualified (`export -f
+#   dirname`), plants such a binary earlier on PATH, points BASH_ENV/ENV at a
+#   leak script, or sets SHELLOPTS=xtrace + a malicious PS4 — any of which would
+#   otherwise run IN the script's shell (or a child it forks) WHILE an ambient
+#   secret env var is still live, and exfiltrate it.
+#   OUT of scope (per the #1443 ruling): a same-UID attacker who can already
+#   arbitrarily scrape the operator's filesystem / `/proc` — they already hold
+#   the secret; nothing this primitive does helps or hurts that case.
+#
+# CONSUMER CONTRACT (what each helper guarantees / requires):
+#
+#   bridge_secret_scrub_harden_hooks
+#     Neutralizes the caller-controlled child-startup hook classes BEFORE the
+#     first fork: `unset -f` the common interceptor command names, `unset
+#     BASH_ENV ENV BASH_XTRACEFD`, `set +x`, `unset PS4`. Idempotent, builtin-
+#     only, no fork, Bash 3.2-safe. Safe to call unconditionally — it only
+#     removes hooks the bridge never legitimately uses, so for normal operation
+#     it is a no-op (no observable behavior change). Call this FIRST, before
+#     any external command or `$(...)` subshell.
+#
+#   bridge_secret_scrub_capture <oat_var> <api_var> <auth_var>
+#     Moves the three well-known secret VALUES (CLAUDE_CODE_OAUTH_TOKEN,
+#     ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN) into the three caller-named
+#     shell variables (passed by NAME; the function does NOT export them) and
+#     `unset`s the well-known names from the environment, so every subsequent
+#     child the caller forks inherits a SECRET-FREE env. Builtin-only, no fork.
+#     Returns 0 always. The caller owns the captured values from here on:
+#     keep them NON-exported, and either (a) restore them with
+#     bridge_secret_scrub_restore after the danger window, or (b) deliver them
+#     out-of-band (the transit-fd helpers below) across a re-exec. After
+#     calling capture, call bridge_secret_scrub_harden_hooks first if you have
+#     not already (the order capture-then-fork must never have a hook live).
+#
+#   bridge_secret_scrub_restore <oat_var> <api_var> <auth_var>
+#     Re-exports the three caller-named values back into the well-known env
+#     names IFF non-empty. The inverse of capture, for consumers whose launched
+#     child legitimately authenticates from the ambient env (the legacy auth
+#     path). Builtin-only, no fork.
+#
+#   bridge_secret_scrub_open_transit_fd <fd> <nonce_out_var> <name=value>...
+#     Stashes NUL-delimited NAME=VALUE records on the given fd, backed by an
+#     UNLINKED 0600 tempfile, prefixed by a per-process RANDOM nonce written
+#     into <nonce_out_var> (export it for the re-exec'd pass to match). The fd
+#     is inherited only by an explicit `exec <bash> -p "$0" "$@"` the caller
+#     issues next. Uses HARDCODED-ABSOLUTE mktemp/chmod/rm so a PATH plant
+#     cannot run near the live secret. Returns 0 on success, 1 if no tempfile.
+#
+#   bridge_secret_scrub_read_transit_fd <fd> <expected_nonce> <oat_var> <api_var> <auth_var>
+#     In the re-exec'd (privileged) pass: reads the records back from <fd>,
+#     validates the first record == <expected_nonce> (a caller-preopened fd
+#     with no/forged nonce is rejected — the nonce is generated AFTER any
+#     inherited fd is closed, so it is unforgeable), populates the three
+#     caller-named vars, and CLOSES <fd>. Call this at the TOP of the re-exec'd
+#     pass, BEFORE any `$(...)` subshell, so no child inherits the token fd.
+#
+#   bridge_secret_scrub_close_fd <fd>
+#     Defensively closes a possibly caller-preopened fd (no command — pure
+#     redirect) so it is never inherited by a child the caller forks. Brace-
+#     grouped so the `2>/dev/null` does not become a permanent stderr redirect.
+#
+# This module is sourced (on macOS) by bridge-lib.sh BEFORE its Bash-3.2→4+
+# re-exec, so every construct here MUST be Bash 3.2-safe (no associative arrays,
+# no `${var^^}`, no `mapfile`, no `<<<`, no process substitution). It must not
+# `set -e`/`set -u` globally (it is sourced into the caller's options) and must
+# not emit output on the success path.
+
+# Guard against double-source.
+if [[ -n "${_BRIDGE_SECRET_SCRUB_SH_LOADED:-}" ]]; then
+  # shellcheck disable=SC2317  # reachable on a second source; shellcheck can't see that
+  return 0 2>/dev/null || true
+fi
+_BRIDGE_SECRET_SCRUB_SH_LOADED=1
+
+# The interceptor command names a same-UID caller could `export -f` to shadow.
+# `bash`/`sh` are intentionally OMITTED: this primitive (and bridge-lib.sh) must
+# still be able to invoke the candidate Bash by absolute path, and stripping a
+# `bash` function here is moot — the re-exec uses an absolute path which can
+# never resolve to a function. Keeping `bash`/`sh` out also avoids any surprise
+# in callers that legitimately define wrapper functions of those names.
+_bridge_secret_scrub_interceptors='exec source command builtin unset printf read echo mktemp chmod rm cat dirname cd pwd trap export local python3 python uname env claude codex head readlink true false'
+
+# Harden the child-startup hook classes before the first fork. Builtin-only.
+bridge_secret_scrub_harden_hooks() {
+  # Strip exported-function shadows of the interceptor command names FIRST, so
+  # the `builtin unset` / `set` below are the genuine builtins. `builtin unset`
+  # (not bare `unset`) defeats an `unset()` function shadow on the very first
+  # pass.
+  # shellcheck disable=SC2086  # word-split the space-separated name list intentionally
+  builtin unset -f $_bridge_secret_scrub_interceptors 2>/dev/null || builtin true
+  # BASH_ENV / ENV name a file every non-interactive (resp. POSIX) bash SOURCES
+  # at startup; BASH_XTRACEFD redirects `set -x` trace to a caller-chosen fd.
+  # The bridge uses none of these — drop them before any child fork.
+  builtin unset BASH_ENV ENV BASH_XTRACEFD 2>/dev/null || builtin true
+  # Neutralize an inherited `set -x` + malicious PS4 command-substitution (which
+  # could capture a still-live secret into the trace stream).
+  builtin set +x 2>/dev/null || builtin true
+  builtin unset PS4 2>/dev/null || builtin true
+  return 0
+}
+
+# Capture the three well-known secret values into the caller-named vars and
+# unset them from the env. Builtin-only, no fork.
+bridge_secret_scrub_capture() {
+  local _oat_var="${1:-}" _api_var="${2:-}" _auth_var="${3:-}"
+  [[ -n "$_oat_var" && -n "$_api_var" && -n "$_auth_var" ]] || return 2
+  # Indirect read of the live env values, then unset the env names. The caller
+  # vars hold the values; they are NOT exported by this function.
+  printf -v "$_oat_var" '%s' "${CLAUDE_CODE_OAUTH_TOKEN:-}"
+  printf -v "$_api_var" '%s' "${ANTHROPIC_API_KEY:-}"
+  printf -v "$_auth_var" '%s' "${ANTHROPIC_AUTH_TOKEN:-}"
+  unset CLAUDE_CODE_OAUTH_TOKEN ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN 2>/dev/null || true
+  return 0
+}
+
+# Restore the three captured values back into the well-known env names (only
+# when non-empty). Builtin-only, no fork.
+bridge_secret_scrub_restore() {
+  local _oat_var="${1:-}" _api_var="${2:-}" _auth_var="${3:-}"
+  [[ -n "$_oat_var" && -n "$_api_var" && -n "$_auth_var" ]] || return 2
+  local _oat="${!_oat_var:-}" _api="${!_api_var:-}" _auth="${!_auth_var:-}"
+  [[ -n "$_oat" ]] && export CLAUDE_CODE_OAUTH_TOKEN="$_oat"
+  [[ -n "$_api" ]] && export ANTHROPIC_API_KEY="$_api"
+  [[ -n "$_auth" ]] && export ANTHROPIC_AUTH_TOKEN="$_auth"
+  return 0
+}
+
+# Defensively close a possibly caller-preopened fd before the first child fork.
+# Brace-group the redirect so `2>/dev/null` scopes to the close ONLY — a bare
+# `exec N<&- 2>/dev/null` (exec with redirections, no command) would make the
+# stderr redirect PERMANENT and swallow later diagnostics.
+bridge_secret_scrub_close_fd() {
+  local _fd="${1:-9}"
+  eval "{ exec ${_fd}<&-; } 2>/dev/null" || builtin true
+  return 0
+}
+
+# Pick the first existing executable from the candidates (hardcoded-absolute
+# binaries near the live secret). `[[ -x ]]` is a builtin (no subprocess).
+_bridge_secret_scrub_pick() {
+  local _n
+  for _n in "$@"; do
+    [[ -x "$_n" ]] && { builtin printf '%s' "$_n"; return 0; }
+  done
+  # Last resort: the bare name (lets the caller's `|| true` paths fail gracefully).
+  builtin printf '%s' "${1##*/}"
+  return 0
+}
+
+# Generate a per-process random nonce. Two independent entropy sources combined
+# (SRANDOM is unguessable on Bash 5.1+; $RANDOM/PID/EPOCHSECONDS fall back on
+# older Bash) — builtins only, no subprocess, no PATH/function exposure.
+bridge_secret_scrub_make_nonce() {
+  local _out_var="${1:-}"
+  [[ -n "$_out_var" ]] || return 2
+  printf -v "$_out_var" '%s' "agb-secret-scrub-v1:${SRANDOM:-}:${RANDOM}${RANDOM}${RANDOM}:${BASHPID:-$$}:${EPOCHSECONDS:-0}"
+  return 0
+}
+
+# Stash NAME=VALUE records on <fd> behind a per-process nonce. <nonce_out_var>
+# receives the nonce (the caller exports it for the re-exec'd pass). Remaining
+# args are NAME=VALUE strings. Returns 1 if no tempfile could be created.
+bridge_secret_scrub_open_transit_fd() {
+  local _fd="${1:-}" _nonce_var="${2:-}"
+  [[ -n "$_fd" && -n "$_nonce_var" ]] || return 2
+  shift 2
+  local _mktemp _chmod _rm _file _nonce _rec
+  _mktemp="$(_bridge_secret_scrub_pick /usr/bin/mktemp /bin/mktemp /opt/homebrew/bin/mktemp)"
+  _chmod="$(_bridge_secret_scrub_pick /bin/chmod /usr/bin/chmod)"
+  _rm="$(_bridge_secret_scrub_pick /bin/rm /usr/bin/rm)"
+  bridge_secret_scrub_make_nonce _nonce
+  if ! _file="$("$_mktemp" "${TMPDIR:-/tmp}/agb-secret-scrub.XXXXXX" 2>/dev/null)"; then
+    return 1
+  fi
+  "$_chmod" 600 "$_file" 2>/dev/null || true
+  {
+    builtin printf '%s\0' "$_nonce"
+    for _rec in "$@"; do
+      builtin printf '%s\0' "$_rec"
+    done
+  } >"$_file"
+  # Brace-group: a bare `exec N<file 2>/dev/null` would make the stderr redirect
+  # permanent for the re-exec'd child.
+  eval "{ exec ${_fd}<\"\$_file\"; } 2>/dev/null" || { "$_rm" -f -- "$_file" 2>/dev/null || true; return 1; }
+  "$_rm" -f -- "$_file" 2>/dev/null || true
+  printf -v "$_nonce_var" '%s' "$_nonce"
+  return 0
+}
+
+# Read records back from <fd>, validating the nonce, into the caller-named vars,
+# then CLOSE <fd>. The var-name args correspond to the well-known keys.
+bridge_secret_scrub_read_transit_fd() {
+  local _fd="${1:-}" _expected="${2:-}" _oat_var="${3:-}" _api_var="${4:-}" _auth_var="${5:-}"
+  [[ -n "$_fd" && -n "$_expected" && -n "$_oat_var" && -n "$_api_var" && -n "$_auth_var" ]] || return 2
+  local _payload _seen=""
+  # Read NUL-delimited records from the inherited fd (builtins only, no fork).
+  while IFS= builtin read -r -d '' _payload <&"$_fd"; do
+    if [[ -z "$_seen" ]]; then
+      # First record must equal the per-process nonce. A caller-preopened fd
+      # cannot reproduce it (generated after the inherited fd was closed).
+      [[ "$_payload" == "$_expected" ]] && { _seen=1; continue; }
+      break
+    fi
+    case "$_payload" in
+      CLAUDE_CODE_OAUTH_TOKEN=*) printf -v "$_oat_var" '%s' "${_payload#*=}" ;;
+      ANTHROPIC_API_KEY=*) printf -v "$_api_var" '%s' "${_payload#*=}" ;;
+      ANTHROPIC_AUTH_TOKEN=*) printf -v "$_auth_var" '%s' "${_payload#*=}" ;;
+    esac
+  done
+  bridge_secret_scrub_close_fd "$_fd"
+  unset _payload _seen
+  return 0
+}

--- a/lib/bridge-secret-scrub.sh
+++ b/lib/bridge-secret-scrub.sh
@@ -95,16 +95,78 @@ _BRIDGE_SECRET_SCRUB_SH_LOADED=1
 # `bash` function here is moot — the re-exec uses an absolute path which can
 # never resolve to a function. Keeping `bash`/`sh` out also avoids any surprise
 # in callers that legitimately define wrapper functions of those names.
-_bridge_secret_scrub_interceptors='exec source command builtin unset printf read echo mktemp chmod rm cat dirname cd pwd trap export local python3 python uname env claude codex head readlink true false'
+# `set`, `.` (the POSIX `source` synonym), `eval`, `local` and `trap` are all
+# included so the shadow-proof seed in bridge_secret_scrub_harden_hooks strips
+# them too — a caller can `export -f .` / `export -f set` / `export -f local`
+# just as easily as `source` (codex Phase-4 r2 caught a `local()` shadow that
+# fired before the original seed, and a `set -T` DEBUG-trap re-install path).
+_bridge_secret_scrub_interceptors='exec source . command builtin unset set eval printf read echo mktemp chmod rm cat dirname cd pwd trap export local python3 python uname env claude codex head readlink true false'
 
 # Harden the child-startup hook classes before the first fork. Builtin-only.
 bridge_secret_scrub_harden_hooks() {
-  # Strip exported-function shadows of the interceptor command names FIRST, so
-  # the `builtin unset` / `set` below are the genuine builtins. `builtin unset`
-  # (not bare `unset`) defeats an `unset()` function shadow on the very first
-  # pass.
+  # SHADOW-PROOF SEED (#1491 / #1454 gap, hardened in Phase-4 r2). `builtin
+  # unset -f …` is NOT self-healing: a same-UID caller can `export -f builtin`
+  # so that the very `builtin` token is eaten by a `builtin()` function shadow
+  # (verified on bash 5.3.9 + macOS /bin/bash 3.2 — a function OUTRANKS the
+  # builtin of the same name in command lookup). The one lever a caller cannot
+  # intercept is a plain VARIABLE ASSIGNMENT: assigning `POSIXLY_CORRECT=1` turns
+  # POSIX mode ON mid-shell, and in POSIX mode the special builtins (`unset`,
+  # `set`, `trap`, …) OUTRANK same-named function shadows.
+  #
+  # The seed therefore uses ONLY: (a) unshadowable assignments, and (b) special
+  # builtins invoked AFTER POSIX mode is on. Three subtleties codex Phase-4 r2
+  # surfaced, all handled below:
+  #   - NO `local`/`declare` before the seed: `local` is itself shadowable, so
+  #     reading the prior POSIX state into `local` vars would run a `local()`
+  #     shadow with the secret still live. We snapshot into specifically-named
+  #     GLOBAL vars via plain assignment (unshadowable) and `unset` them after.
+  #   - CLEAR DEBUG/RETURN/ERR traps + functrace BEFORE the strip: a `set -T`
+  #     DEBUG trap fires before every simple command and could RE-INSTALL a
+  #     shadow AFTER we unset it. Clearing the trap first guarantees nothing
+  #     re-shadows post-strip.
+  #   - SECOND strip pass in non-POSIX mode: on macOS /bin/bash 3.2, `unset -f .`
+  #     does not remove a `.()` function while POSIX mode is on, but does once
+  #     it is off.
+  # The caller's exact prior POSIX state (POSIXLY_CORRECT set/value + `posix`
+  # shopt) is restored at the end — this module is sourced into the caller's
+  # option set (see header), so a consumer that legitimately runs under
+  # `set -o posix` must be unaffected. Pure-bash, builtin-only, no fork, Bash
+  # 3.2-safe, idempotent.
+  #
+  # Snapshot prior POSIX state via parameter expansion (an unshadowable read)
+  # into GLOBALs assigned WITHOUT `local`/`declare` (a plain assignment invokes
+  # no function). `$SHELLOPTS` is a bash builtin variable a function cannot
+  # intercept.
+  _BRIDGE_SCRUB_PC_WAS_SET=0
+  _BRIDGE_SCRUB_PC_VAL=""
+  _BRIDGE_SCRUB_POSIX_WAS_ON=0
+  if [[ -n "${POSIXLY_CORRECT+x}" ]]; then _BRIDGE_SCRUB_PC_WAS_SET=1; _BRIDGE_SCRUB_PC_VAL="$POSIXLY_CORRECT"; fi
+  case ":${SHELLOPTS}:" in *:posix:*) _BRIDGE_SCRUB_POSIX_WAS_ON=1 ;; esac
+
+  POSIXLY_CORRECT=1
+  # Kill functrace/errtrace + DEBUG/RETURN/ERR traps FIRST so nothing can
+  # re-install a shadow after the strip (genuine special builtins in POSIX mode).
+  set +T +E 2>/dev/null || true
+  trap - DEBUG RETURN ERR 2>/dev/null || true
+  # Strip every interceptor function shadow (genuine `unset` in POSIX mode).
+  # shellcheck disable=SC2086  # word-split the space-separated name list intentionally
+  unset -f $_bridge_secret_scrub_interceptors 2>/dev/null || true
+  # Leave POSIX mode UNCONDITIONALLY for the second strip pass (codex Phase-4
+  # r2 finding 3): on macOS /bin/bash 3.2, `unset -f .` removes a `.()` function
+  # only when POSIX mode is OFF. This second pass must NOT run in the caller's
+  # restored mode — if the caller was in POSIX mode the `.()` strip would no-op
+  # on 3.2. `unset`/`builtin` here are genuine (their shadows were stripped above
+  # and the trap can no longer re-install them).
+  set +o posix 2>/dev/null || true
   # shellcheck disable=SC2086  # word-split the space-separated name list intentionally
   builtin unset -f $_bridge_secret_scrub_interceptors 2>/dev/null || builtin true
+  # Restore the caller's prior POSIX state EXACTLY, shopt FIRST then the var
+  # value LAST (codex Phase-4 r2): on bash 3.2 `set -o posix` rewrites
+  # POSIXLY_CORRECT to `y`, so the var must be restored AFTER the shopt to land
+  # on the caller's exact prior value.
+  if (( _BRIDGE_SCRUB_POSIX_WAS_ON )); then set -o posix 2>/dev/null || true; else set +o posix 2>/dev/null || true; fi
+  if (( _BRIDGE_SCRUB_PC_WAS_SET )); then POSIXLY_CORRECT="$_BRIDGE_SCRUB_PC_VAL"; else unset POSIXLY_CORRECT 2>/dev/null || true; fi
+  unset _BRIDGE_SCRUB_PC_WAS_SET _BRIDGE_SCRUB_PC_VAL _BRIDGE_SCRUB_POSIX_WAS_ON 2>/dev/null || true
   # BASH_ENV / ENV name a file every non-interactive (resp. POSIX) bash SOURCES
   # at startup; BASH_XTRACEFD redirects `set -x` trace to a caller-chosen fd.
   # The bridge uses none of these — drop them before any child fork.

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -116,6 +116,12 @@ add_required 1473-agent-list-iso-state-fallback
 # survives `exec` into the bridge-cron.sh child via the agent-bridge/agb wrapper
 # — without weakening the #1359 iso/non-admin reject.
 add_required 1474-wrapper-admin-cron-exemption
+# #1454: security canary for the bridge-lib.sh Bash-3.2→4+ re-exec — the
+# ambient-secret exposure window (exported-function / PATH-shadow / BASH_ENV
+# during the re-exec). In the static suite so any bridge-lib.sh /
+# lib/bridge-secret-scrub.sh / scripts/smoke/* change re-runs it; the per-file
+# cases below also pull it directly.
+add_required 1454-bridge-lib-reexec-secret-canary
 # #8945 Track B: expanded Codex hook coverage (PreCompact / PostCompact /
 # SubagentStart / SubagentStop / PermissionRequest). All audit-only by default;
 # the permission-request smoke pins the security contract.
@@ -2449,6 +2455,14 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       #         PR cannot revive the ACL scanner or break the admin
       #         set CLI surface.
       add_required K-beta4-nits
+      ;;
+
+    lib/bridge-secret-scrub.sh)
+      # #1454: the shared ambient-secret scrub/transit primitive. Pull the
+      # bridge-lib.sh re-exec security canary on every change to it. (A change
+      # to bridge-lib.sh itself already pulls the canary via the full static
+      # suite below.)
+      add_required 1454-bridge-lib-reexec-secret-canary
       ;;
 
     bridge-lib.sh|lib/bridge-core.sh|lib/bridge-agents.sh|agent-roster.sh|agent-roster.local.example.sh|bridge-config.sh)

--- a/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
+++ b/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh — security canary for
+# #1454: the bridge-lib.sh Bash-3.2→4+ re-exec must NOT expose an ambient
+# secret env var to a same-UID exported-function / PATH-shadow during the
+# re-exec window.
+#
+# bridge-lib.sh is sourced by essentially every entry point. Its Bash-3.2→4+
+# re-exec historically ran external commands (a `$(command -v bash)` command-
+# sub, a candidate-version probe under `-lc` which sources the login profile +
+# BASH_ENV, a `$(cd -P "$(dirname …)" && pwd -P)` SCRIPT_DIR command-sub) WHILE
+# an ambient secret env var could still be live — so an exported `dirname()`
+# function shadow, a PATH-planted `dirname`, or a BASH_ENV startup-file hook
+# could read the secret. This is the SHARED ROOT of the inherited-env
+# credential-leak class that PRs #1443 (bridge-usage.sh) and #1452/#1444
+# (bridge-run.sh) each hardened in their own lane. #1454 closes it at the root:
+#   - BRIDGE_SCRIPT_DIR is computed via a builtin `${BASH_SOURCE[0]%/*}` (no
+#     `dirname` fork),
+#   - the candidate Bash is selected from absolute paths + a `builtin command -v`
+#     fallback and probed under `-p -c` (privileged, non-login),
+#   - the re-exec is `exec "$cand" -p …` (privileged: imports no env functions,
+#     ignores BASH_ENV/ENV),
+#   - hooks are hardened (unset -f interceptors, unset BASH_ENV/ENV/BASH_XTRACEFD,
+#     set +x, drop PS4) BEFORE the first fork via the shared primitive
+#     lib/bridge-secret-scrub.sh.
+#
+# Coverage:
+#   STATIC — in-source structure: the shared primitive exists + is sourced
+#            before the re-exec guard, the `$(dirname …)` SCRIPT_DIR fork is
+#            gone, the re-exec uses `-p`, and the old `-lc` probe is gone.
+#   A — dirname()-function-shadow attack on the macOS Bash-3.2→4 re-exec path:
+#       the shadow must NEVER observe the secret. (Skipped when no Bash 3.2 is
+#       available — Linux CI has only Bash 5; the no-op path below still runs.)
+#   B — dirname()-function-shadow attack on the Bash-4+ NO-OP path: the shadow
+#       must NEVER observe the secret.
+#   C — PATH-planted `dirname` attack on the Bash-4+ path: the plant must never
+#       run (BRIDGE_SCRIPT_DIR no longer forks `dirname`), so it cannot leak.
+#   TEETH — the same attack against a pristine pre-fix copy of bridge-lib.sh
+#       (the git-base version) MUST leak, proving the canary has teeth.
+#
+# lint-heredoc-ban: this smoke uses heredoc-TO-FILE (writing attack wrappers to
+# tempfiles) which is allowed; it never feeds a heredoc to a subprocess stdin
+# (`bash -s <<EOF` / `python3 - <<PY`) and never uses `<<<` or `< <(...)`. Leak
+# files are inspected with a tempfile `while read` loop, not a process sub.
+
+set -uo pipefail
+
+SMOKE_NAME="1454-bridge-lib-reexec-secret-canary"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -P "$SCRIPT_DIR/../.." && pwd -P)"
+
+echo "[smoke:${SMOKE_NAME}] starting"
+
+LIB_SH="$REPO_ROOT/bridge-lib.sh"
+PRIMITIVE="$REPO_ROOT/lib/bridge-secret-scrub.sh"
+
+failed=0
+fail() { echo "  FAIL  $1" >&2; failed=1; }
+ok() { echo "  PASS  $1"; }
+
+# Isolated workdir + BRIDGE_HOME so sourcing bridge-lib.sh never touches live
+# state. bridge-lib.sh's startup validation only needs a real source checkout
+# (REPO_ROOT) for BRIDGE_SCRIPT_DIR; BRIDGE_HOME just needs to be a writable
+# scratch path.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/agb-1454-canary.XXXXXX")"
+PROBE_HOME="$WORK/home"
+mkdir -p "$PROBE_HOME"
+# shellcheck disable=SC2329  # invoked indirectly via trap
+cleanup() { rm -rf "$WORK" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# Build the secret env-var NAME indirectly so the tracked source text never
+# contains the literal (keeps the file clean + avoids the credential-redaction
+# hook). This is the well-known Claude OAuth env var the #1443/#1452 lanes
+# scrub.
+OAT_VAR="CLAUDE_CODE""_OAUTH_TOKEN"
+SECRET_VALUE="agb-1454-canary-secret-$$-${RANDOM}"
+
+# Locate a Bash 3.2 (to exercise the real re-exec path) and a Bash 4+ (no-op
+# path). The system /bin/bash is 3.2 on macOS, 5.x on Linux.
+BASH4=""
+for c in /opt/homebrew/bin/bash /usr/local/bin/bash /usr/bin/bash /bin/bash; do
+  if [[ -x "$c" ]] && "$c" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' 2>/dev/null; then
+    BASH4="$c"; break
+  fi
+done
+BASH3=""
+for c in /bin/bash /usr/bin/bash; do
+  if [[ -x "$c" ]] && "$c" -c '[[ ${BASH_VERSINFO[0]:-0} -lt 4 ]]' 2>/dev/null; then
+    BASH3="$c"; break
+  fi
+done
+[[ -n "$BASH4" ]] || { echo "  SKIP-FATAL no Bash 4+ found — cannot run canary" >&2; exit 1; }
+
+# --- STATIC: in-source structure -------------------------------------------
+echo "[STATIC] bridge-lib.sh re-exec hardening structure"
+if [[ -f "$PRIMITIVE" ]]; then
+  ok "shared primitive lib/bridge-secret-scrub.sh exists"
+else
+  fail "shared primitive lib/bridge-secret-scrub.sh missing"
+fi
+
+src_line="$(grep -nE 'source "\$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub\.sh"' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
+harden_line="$(grep -nE '^[[:space:]]*bridge_secret_scrub_harden_hooks' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
+reexec_guard_line="$(grep -nE 'BASH_VERSINFO\[0\]:-0\} < 4' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
+if [[ -n "$src_line" && -n "$harden_line" && -n "$reexec_guard_line" \
+      && "$src_line" -lt "$reexec_guard_line" && "$harden_line" -lt "$reexec_guard_line" ]]; then
+  ok "primitive sourced (L$src_line) + hooks hardened (L$harden_line) before the re-exec guard (L$reexec_guard_line)"
+else
+  fail "hook-harden does not precede the re-exec guard (src=L${src_line:-?} harden=L${harden_line:-?} guard=L${reexec_guard_line:-?})"
+fi
+
+# BRIDGE_SCRIPT_DIR must NOT fork `$(dirname …)` anymore.
+if grep -qE 'BRIDGE_SCRIPT_DIR="\$\(cd -P "\$\(dirname ' "$LIB_SH"; then
+  fail "BRIDGE_SCRIPT_DIR still uses a \$(dirname …) command-sub child"
+else
+  ok "BRIDGE_SCRIPT_DIR no longer forks \$(dirname …) (builtin \${BASH_SOURCE%/*} derivation)"
+fi
+
+# The re-exec must be privileged (`exec … -p`) and must NOT use the old `-lc`
+# login-shell probe.
+if grep -qE 'exec "\$bridge_candidate_bash" -p ' "$LIB_SH"; then
+  ok "re-exec is privileged (exec … -p …)"
+else
+  fail "re-exec is not privileged (missing exec … -p …)"
+fi
+if grep -qE '"\$bridge_candidate_bash" -lc ' "$LIB_SH"; then
+  fail "candidate probe still uses login-shell -lc (sources profile + BASH_ENV)"
+else
+  ok "old login-shell -lc candidate probe removed (uses -p -c)"
+fi
+
+# --- helpers ---------------------------------------------------------------
+# Write an attack wrapper that exports a dirname() shadow + the secret, then
+# sources the given bridge-lib.sh. Heredoc-TO-FILE (allowed). The shadow appends
+# the secret value to $leak whenever invoked.
+write_attack_wrapper() {
+  local wrapper="$1" lib="$2" leak="$3"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+    printf 'dirname() { builtin printf "%%s\\n" "${%s}" >> %q; command dirname "$@" 2>/dev/null || builtin printf "."; }\n' "$OAT_VAR" "$leak"
+    printf 'export -f dirname\n'
+    printf 'source %q\n' "$lib"
+  } > "$wrapper"
+}
+
+# Return 0 (leak) if $leak contains the secret value, 1 (clean) otherwise.
+# Inspect via a tempfile `while read` loop (no process substitution / no <<<).
+leak_present() {
+  local leak="$1" line
+  [[ -f "$leak" ]] || return 1
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    case "$line" in
+      *"$SECRET_VALUE"*) return 0 ;;
+    esac
+  done < "$leak"
+  return 1
+}
+
+run_case() {
+  # run_case <label> <bash-bin> <lib> <expect:clean|leak>
+  local label="$1" bashbin="$2" lib="$3" expect="$4"
+  local wrapper="$WORK/attack.sh" leak="$WORK/leak.txt"
+  rm -f "$leak"
+  write_attack_wrapper "$wrapper" "$lib" "$leak"
+  BRIDGE_HOME="$PROBE_HOME" "$bashbin" "$wrapper" >/dev/null 2>&1 || true
+  if leak_present "$leak"; then
+    if [[ "$expect" == "leak" ]]; then ok "$label — leaked as expected (teeth)"; else fail "$label — SECRET LEAKED to dirname shadow"; fi
+  else
+    if [[ "$expect" == "clean" ]]; then ok "$label — no leak (secret never reached the shadow)"; else fail "$label — expected a leak but none occurred (teeth check broken)"; fi
+  fi
+  rm -f "$leak" "$wrapper"
+}
+
+# --- A: macOS Bash-3.2 → 4 re-exec path ------------------------------------
+if [[ -n "$BASH3" ]]; then
+  echo "[A] dirname-shadow attack on the Bash-3.2→4 re-exec path ($BASH3)"
+  run_case "A re-exec path (fixed)" "$BASH3" "$LIB_SH" "clean"
+else
+  echo "[A] SKIP — no Bash 3.2 on this host (Linux CI: Bash 5 only); B/C cover the no-op path"
+fi
+
+# --- B: Bash-4+ no-op path -------------------------------------------------
+echo "[B] dirname-shadow attack on the Bash-4+ no-op path ($BASH4)"
+run_case "B no-op path (fixed)" "$BASH4" "$LIB_SH" "clean"
+
+# --- C: PATH-planted dirname on the Bash-4+ path ---------------------------
+echo "[C] PATH-planted dirname attack on the Bash-4+ path"
+PLANT_DIR="$WORK/plantbin"
+mkdir -p "$PLANT_DIR"
+C_LEAK="$WORK/plant-leak.txt"
+rm -f "$C_LEAK"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'builtin printf "%%s\\n" "${%s:-}" >> %q\n' "$OAT_VAR" "$C_LEAK"
+  printf 'exec /usr/bin/dirname "$@"\n'
+} > "$PLANT_DIR/dirname"
+chmod +x "$PLANT_DIR/dirname"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+  printf 'export PATH=%q:"$PATH"\n' "$PLANT_DIR"
+  printf 'source %q\n' "$LIB_SH"
+} > "$WORK/plant-attack.sh"
+BRIDGE_HOME="$PROBE_HOME" "$BASH4" "$WORK/plant-attack.sh" >/dev/null 2>&1 || true
+if leak_present "$C_LEAK"; then
+  fail "C PATH-plant — planted dirname ran and leaked the secret"
+else
+  ok "C PATH-plant — planted dirname never ran (no \$(dirname …) fork)"
+fi
+rm -f "$C_LEAK" "$WORK/plant-attack.sh"
+
+# --- TEETH: pristine pre-fix bridge-lib.sh MUST leak -----------------------
+echo "[TEETH] the same attack against the pre-fix bridge-lib.sh must leak"
+VULN_LIB="$WORK/vuln-bridge-lib.sh"
+got_base=0
+# Prefer the git base (origin/main or the merge-base) copy of bridge-lib.sh.
+if git -C "$REPO_ROOT" show "origin/main:bridge-lib.sh" > "$VULN_LIB" 2>/dev/null && [[ -s "$VULN_LIB" ]]; then
+  got_base=1
+elif base_sha="$(git -C "$REPO_ROOT" merge-base HEAD origin/main 2>/dev/null)" && [[ -n "$base_sha" ]] \
+     && git -C "$REPO_ROOT" show "$base_sha:bridge-lib.sh" > "$VULN_LIB" 2>/dev/null && [[ -s "$VULN_LIB" ]]; then
+  got_base=1
+fi
+if (( got_base )); then
+  # The vuln copy lives in $WORK, not the repo root, so its self-dir resolves to
+  # $WORK and it won't find lib/bridge-secret-scrub.sh — which is correct: the
+  # pre-fix version never had the primitive. But it needs the rest of the source
+  # tree for startup validation, so point BRIDGE_SCRIPT_DIR resolution at the
+  # real tree by copying the vuln file INTO the repo root under a temp name.
+  VULN_IN_TREE="$REPO_ROOT/.agb-1454-vuln-$$-bridge-lib.sh"
+  cp "$VULN_LIB" "$VULN_IN_TREE"
+  # Strip the trap so a stray copy is cleaned even on early exit.
+  trap 'rm -f "$VULN_IN_TREE" 2>/dev/null || true; cleanup' EXIT
+  run_case "TEETH pre-fix (Bash4+ no-op)" "$BASH4" "$VULN_IN_TREE" "leak"
+  if [[ -n "$BASH3" ]]; then
+    run_case "TEETH pre-fix (Bash3.2 re-exec)" "$BASH3" "$VULN_IN_TREE" "leak"
+  fi
+  rm -f "$VULN_IN_TREE"
+  trap cleanup EXIT
+else
+  echo "  SKIP  TEETH — could not obtain a pre-fix bridge-lib.sh (no origin/main); A/B/C still assert the fix"
+fi
+
+if (( failed )); then
+  echo "[smoke:${SMOKE_NAME}] FAILED"
+  exit 1
+fi
+echo "[smoke:${SMOKE_NAME}] OK"
+exit 0

--- a/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
+++ b/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
@@ -55,6 +55,23 @@
 #       bridge-lib.sh (the git-base version) MUST leak, proving the original
 #       canary still has teeth.
 #
+# OUT OF SCOPE (the launch-environment-control boundary — NOT tested here,
+# documented so this canary's contract is honest about what it does and does
+# not prove; see lib/bridge-secret-scrub.sh "THREAT MODEL"):
+#   - Inherited `SHELLOPTS=xtrace` + a `PS4` carrying a command-substitution.
+#     Bash evaluates `PS4` BEFORE the first command of any script, so the `PS4`
+#     `$(...)` runs while the secret is live ahead of bridge-lib.sh's first
+#     executable line — no pure-Bash code at the bridge-lib.sh root can pre-empt
+#     it from inside the script.
+#   - A DEBUG trap installed by the invoking shell (e.g. `BASH_ENV` + `set -T`)
+#     that fires before the seed assignment itself.
+#   Both require the attacker to control the invoking shell's options/startup on
+#   a token-bearing launch — the same "already controls the launch environment"
+#   position as a same-UID attacker who can scrape `/proc`/the filesystem (who
+#   already holds the secret). This is the #1443-consistent boundary, not a
+#   primitive defect. (Cases G / TEETH-TRAP below cover only the IN-scope
+#   POST-seed DEBUG-trap re-shadow, not this pre-seed startup window.)
+#
 # lint-heredoc-ban: this smoke uses heredoc-TO-FILE (writing attack wrappers to
 # tempfiles) which is allowed; it never feeds a heredoc to a subprocess stdin
 # (`bash -s <<EOF` / `python3 - <<PY`) and never uses `<<<` or `< <(...)`. Leak

--- a/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
+++ b/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
@@ -24,9 +24,12 @@
 #     lib/bridge-secret-scrub.sh.
 #
 # Coverage:
-#   STATIC — in-source structure: the shared primitive exists + is sourced
-#            before the re-exec guard, the `$(dirname …)` SCRIPT_DIR fork is
-#            gone, the re-exec uses `-p`, and the old `-lc` probe is gone.
+#   STATIC — in-source structure: the shared primitive exists + is loaded via
+#            `builtin source` (not a bare `source`) before the re-exec guard, the
+#            shadow-proof seed (POSIXLY_CORRECT=1 → unset -f → set +o posix)
+#            precedes that load, no bare `source` of the primitive remains, the
+#            `$(dirname …)` SCRIPT_DIR fork is gone, the re-exec uses `-p`, and
+#            the old `-lc` probe is gone.
 #   A — dirname()-function-shadow attack on the macOS Bash-3.2→4 re-exec path:
 #       the shadow must NEVER observe the secret. (Skipped when no Bash 3.2 is
 #       available — Linux CI has only Bash 5; the no-op path below still runs.)
@@ -34,8 +37,23 @@
 #       must NEVER observe the secret.
 #   C — PATH-planted `dirname` attack on the Bash-4+ path: the plant must never
 #       run (BRIDGE_SCRIPT_DIR no longer forks `dirname`), so it cannot leak.
-#   TEETH — the same attack against a pristine pre-fix copy of bridge-lib.sh
-#       (the git-base version) MUST leak, proving the canary has teeth.
+#   D — source()/.()-function-shadow attack (the codex Phase-4 BLOCKING gap):
+#       the de-fang PRIMITIVE was loaded by a BARE `source` while a `source()`
+#       shadow could be live. Post-fix the shadow-proof seed strips that shadow
+#       and the load uses `builtin source`, so the shadow must NEVER observe the
+#       secret on the primitive-load path. Run on both the Bash-4+ and Bash-3.2
+#       paths.
+#   E — builtin()/unset()/command()-function-shadow attack (the SEED-OF-TRUST):
+#       the seed must self-heal even when the very tokens it uses (`builtin`,
+#       `unset`, `command`) are shadowed — the unshadowable `POSIXLY_CORRECT=1`
+#       assignment activates POSIX mode so the genuine special builtins win.
+#       None of these shadows may observe the secret on the load path.
+#   TEETH-GAP — a SYNTHETIC pre-gap-fix bridge-lib.sh (seed disabled + the
+#       primitive load downgraded back to a BARE `source`) MUST leak under the
+#       source()-shadow attack, proving the canary detects the exact gap.
+#   TEETH — the same dirname() attack against a pristine pre-#1454 copy of
+#       bridge-lib.sh (the git-base version) MUST leak, proving the original
+#       canary still has teeth.
 #
 # lint-heredoc-ban: this smoke uses heredoc-TO-FILE (writing attack wrappers to
 # tempfiles) which is allowed; it never feeds a heredoc to a subprocess stdin
@@ -99,14 +117,36 @@ else
   fail "shared primitive lib/bridge-secret-scrub.sh missing"
 fi
 
-src_line="$(grep -nE 'source "\$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub\.sh"' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
+# The primitive load must now be `builtin source` (NOT a bare `source`), so a
+# residual `source()` function shadow cannot intercept it.
+src_line="$(grep -nE 'builtin source "\$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub\.sh"' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
 harden_line="$(grep -nE '^[[:space:]]*bridge_secret_scrub_harden_hooks' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
 reexec_guard_line="$(grep -nE 'BASH_VERSINFO\[0\]:-0\} < 4' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
 if [[ -n "$src_line" && -n "$harden_line" && -n "$reexec_guard_line" \
       && "$src_line" -lt "$reexec_guard_line" && "$harden_line" -lt "$reexec_guard_line" ]]; then
-  ok "primitive sourced (L$src_line) + hooks hardened (L$harden_line) before the re-exec guard (L$reexec_guard_line)"
+  ok "primitive loaded via 'builtin source' (L$src_line) + hooks hardened (L$harden_line) before the re-exec guard (L$reexec_guard_line)"
 else
-  fail "hook-harden does not precede the re-exec guard (src=L${src_line:-?} harden=L${harden_line:-?} guard=L${reexec_guard_line:-?})"
+  fail "hook-harden / builtin-source load does not precede the re-exec guard (src=L${src_line:-?} harden=L${harden_line:-?} guard=L${reexec_guard_line:-?})"
+fi
+
+# A bare `source` (un-`builtin`-qualified) of the primitive must NOT survive in
+# the tracked source — that was the codex Phase-4 BLOCKING gap.
+if grep -qE '^[[:space:]]*source "\$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub\.sh"' "$LIB_SH"; then
+  fail "primitive is still loaded via a BARE 'source' (interceptable by a source() shadow)"
+else
+  ok "no bare 'source' load of the primitive remains (uses 'builtin source')"
+fi
+
+# The shadow-proof seed (POSIXLY_CORRECT=1 → unset -f → set +o posix) must run
+# BEFORE the primitive load, so even the `source()`/`builtin()` shadows are
+# stripped before the (builtin) source executes.
+seed_line="$(grep -nE '^[[:space:]]*POSIXLY_CORRECT=1' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
+seed_unset_line="$(grep -nE '^[[:space:]]*unset -f source \. unset set ' "$LIB_SH" | head -n1 | cut -d: -f1 || true)"
+if [[ -n "$seed_line" && -n "$seed_unset_line" && -n "$src_line" \
+      && "$seed_line" -lt "$src_line" && "$seed_unset_line" -lt "$src_line" ]]; then
+  ok "shadow-proof seed (POSIXLY_CORRECT=1 L$seed_line + unset -f L$seed_unset_line) precedes the primitive load (L$src_line)"
+else
+  fail "shadow-proof seed does not precede the primitive load (seed=L${seed_line:-?} unset=L${seed_unset_line:-?} src=L${src_line:-?})"
 fi
 
 # BRIDGE_SCRIPT_DIR must NOT fork `$(dirname …)` anymore.
@@ -133,6 +173,7 @@ fi
 # Write an attack wrapper that exports a dirname() shadow + the secret, then
 # sources the given bridge-lib.sh. Heredoc-TO-FILE (allowed). The shadow appends
 # the secret value to $leak whenever invoked.
+# shellcheck disable=SC2329  # invoked indirectly via run_case's $writer
 write_attack_wrapper() {
   local wrapper="$1" lib="$2" leak="$3"
   {
@@ -140,6 +181,109 @@ write_attack_wrapper() {
     printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
     printf 'dirname() { builtin printf "%%s\\n" "${%s}" >> %q; command dirname "$@" 2>/dev/null || builtin printf "."; }\n' "$OAT_VAR" "$leak"
     printf 'export -f dirname\n'
+    printf 'source %q\n' "$lib"
+  } > "$wrapper"
+}
+
+# Write an attack wrapper that exports a `source()` (+ `.()`) interceptor
+# function shadow + the secret, then sources the given bridge-lib.sh. This is
+# the codex Phase-4 BLOCKING class: the BARE `source` of the de-fang PRIMITIVE
+# (lib/bridge-secret-scrub.sh) ran WHILE this shadow was active, so the shadow
+# read the live secret at the very moment we loaded the de-fang primitive — and
+# the primitive itself was therefore loaded through a compromised `source`,
+# defeating the re-exec gate's fail-closed property.
+#
+# The shadow leaks ONLY when invoked to load the PRIMITIVE (`*bridge-secret-
+# scrub.sh`); for every other `source` (including the entry-point's own
+# `source bridge-lib.sh`) it chains straight through without leaking. This is
+# deliberate: the interception of `source bridge-lib.sh` itself happens in the
+# CALLER's shell BEFORE any bridge-lib.sh code runs, so bridge-lib.sh cannot
+# defend it (and a caller who can `export -f source` AND holds the secret in its
+# own env can already read it directly — that is the #1443-ruling out-of-scope
+# case). What bridge-lib.sh CAN and now DOES guarantee is that the de-fang
+# primitive load is un-interceptable. This case asserts exactly that.
+# shellcheck disable=SC2329  # invoked indirectly via run_case's $writer
+write_source_shadow_attack_wrapper() {
+  local wrapper="$1" lib="$2" leak="$3"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+    printf 'source() { case "$1" in *bridge-secret-scrub.sh) builtin printf "%%s\\n" "${%s:-}" >> %q ;; esac; builtin source "$@"; }\n' "$OAT_VAR" "$leak"
+    printf '.() { case "$1" in *bridge-secret-scrub.sh) builtin printf "%%s\\n" "${%s:-}" >> %q ;; esac; builtin source "$@"; }\n' "$OAT_VAR" "$leak"
+    printf 'export -f source\n'
+    printf 'export -f .\n'
+    printf 'source %q\n' "$lib"
+  } > "$wrapper"
+}
+
+# Write an attack wrapper that exports `builtin()`, `unset()`, and `command()`
+# interceptor shadows + the secret, then sources bridge-lib.sh. This probes the
+# SEED-OF-TRUST: the de-fang seed must self-heal even when the very tokens it
+# uses (`builtin`/`unset`) are shadowed. Each shadow leaks the secret when
+# invoked; the `builtin`/`command` shadows chain to the genuine command so the
+# script can still run, the `unset` shadow no-ops (the seed's POSIXLY_CORRECT
+# path makes the genuine `unset` win regardless). If the seed holds, NONE of
+# these shadows ever observe the secret on the load path.
+# shellcheck disable=SC2329  # invoked indirectly via run_case's $writer
+write_builtin_shadow_attack_wrapper() {
+  local wrapper="$1" lib="$2" leak="$3"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+    printf 'builtin() { command builtin printf "%%s\\n" "${%s:-}" >> %q; command builtin "$@"; }\n' "$OAT_VAR" "$leak"
+    printf 'unset() { command builtin printf "%%s\\n" "${%s:-}" >> %q; }\n' "$OAT_VAR" "$leak"
+    printf 'command() { command printf "%%s\\n" "${%s:-}" >> %q; builtin command "$@"; }\n' "$OAT_VAR" "$leak"
+    printf 'export -f builtin\n'
+    printf 'export -f unset\n'
+    printf 'export -f command\n'
+    printf 'source %q\n' "$lib"
+  } > "$wrapper"
+}
+
+# Write an attack wrapper that exports a `local()` shadow + the secret, then
+# sources bridge-lib.sh. codex Phase-4 r2 caught that the primitive's
+# bridge_secret_scrub_harden_hooks used a `local` snapshot BEFORE its seed, so a
+# `local()` shadow fired with the secret live. Post-r2 the seed uses no `local`
+# before the strip, so the shadow must NEVER observe the secret. The shadow
+# leaks then no-ops (a `local` outside a function is an error anyway; harden's
+# snapshot is now plain global assignment).
+# shellcheck disable=SC2329  # invoked indirectly via run_case's $writer
+write_local_shadow_attack_wrapper() {
+  local wrapper="$1" lib="$2" leak="$3"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+    printf 'local() { command builtin printf "%%s\\n" "${%s:-}" >> %q; }\n' "$OAT_VAR" "$leak"
+    printf 'export -f local\n'
+    printf 'source %q\n' "$lib"
+  } > "$wrapper"
+}
+
+# Write an attack wrapper that arms a `set -T` DEBUG trap which RE-INSTALLS a
+# `builtin()` shadow on every simple command, then sources bridge-lib.sh. codex
+# Phase-4 r2 caught that a DEBUG trap could re-create a shadow AFTER the seed's
+# `unset -f` but BEFORE the `builtin source` primitive load. Post-r2 the seed
+# clears functrace + DEBUG/RETURN/ERR traps BEFORE the strip, so the re-install
+# cannot survive to intercept the primitive load. The recreated `builtin()`
+# leaks ONLY when invoked to load the primitive (`$2` matches the scrub path);
+# for everything else it chains through. Heredoc-TO-FILE.
+# shellcheck disable=SC2329  # invoked indirectly via run_case's $writer
+write_trap_recreate_attack_wrapper() {
+  local wrapper="$1" lib="$2" leak="$3"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+    # The DEBUG trap body re-installs a builtin() shadow that leaks ONLY on the
+    # primitive-load path ($2 ends in bridge-secret-scrub.sh) and chains through
+    # otherwise. Emit the trap body as its own function to keep quoting sane.
+    printf '_agb_reshadow() {\n'
+    printf '  builtin() {\n'
+    printf '    case "$2" in *bridge-secret-scrub.sh) command builtin printf "%%s\\n" "${%s:-}" >> %q ;; esac\n' "$OAT_VAR" "$leak"
+    printf '    command builtin "$@"\n'
+    printf '  }\n'
+    printf '}\n'
+    printf 'set -T\n'
+    printf 'trap _agb_reshadow DEBUG\n'
     printf 'source %q\n' "$lib"
   } > "$wrapper"
 }
@@ -158,14 +302,15 @@ leak_present() {
 }
 
 run_case() {
-  # run_case <label> <bash-bin> <lib> <expect:clean|leak>
-  local label="$1" bashbin="$2" lib="$3" expect="$4"
+  # run_case <label> <bash-bin> <lib> <expect:clean|leak> [writer-fn]
+  # writer-fn defaults to write_attack_wrapper (the dirname() shadow).
+  local label="$1" bashbin="$2" lib="$3" expect="$4" writer="${5:-write_attack_wrapper}"
   local wrapper="$WORK/attack.sh" leak="$WORK/leak.txt"
   rm -f "$leak"
-  write_attack_wrapper "$wrapper" "$lib" "$leak"
+  "$writer" "$wrapper" "$lib" "$leak"
   BRIDGE_HOME="$PROBE_HOME" "$bashbin" "$wrapper" >/dev/null 2>&1 || true
   if leak_present "$leak"; then
-    if [[ "$expect" == "leak" ]]; then ok "$label — leaked as expected (teeth)"; else fail "$label — SECRET LEAKED to dirname shadow"; fi
+    if [[ "$expect" == "leak" ]]; then ok "$label — leaked as expected (teeth)"; else fail "$label — SECRET LEAKED to interceptor shadow"; fi
   else
     if [[ "$expect" == "clean" ]]; then ok "$label — no leak (secret never reached the shadow)"; else fail "$label — expected a leak but none occurred (teeth check broken)"; fi
   fi
@@ -209,6 +354,247 @@ else
   ok "C PATH-plant — planted dirname never ran (no \$(dirname …) fork)"
 fi
 rm -f "$C_LEAK" "$WORK/plant-attack.sh"
+
+# --- D: source()/.()-shadow-before-hardening attack (the codex BLOCKING gap) -
+# The de-fang primitive was loaded by a BARE `source` while a `source()` shadow
+# could be live. Post-fix the shadow-proof seed strips that shadow and the load
+# uses `builtin source`, so the shadow must NEVER see the secret. Run on BOTH
+# the Bash-4+ no-op path and the Bash-3.2 re-exec path.
+echo "[D] source()/.()-shadow-before-hardening attack on the Bash-4+ path ($BASH4)"
+run_case "D source-shadow (Bash4+ no-op, fixed)" "$BASH4" "$LIB_SH" "clean" write_source_shadow_attack_wrapper
+if [[ -n "$BASH3" ]]; then
+  echo "[D] source()/.()-shadow attack on the Bash-3.2→4 re-exec path ($BASH3)"
+  run_case "D source-shadow (Bash3.2 re-exec, fixed)" "$BASH3" "$LIB_SH" "clean" write_source_shadow_attack_wrapper
+fi
+
+# --- E: builtin()/unset()/command()-shadow attack (seed-of-trust self-heal) --
+# The seed must self-heal even when the very tokens it relies on (`builtin`,
+# `unset`, `command`) are shadowed. The POSIXLY_CORRECT=1 assignment (which no
+# function can intercept) activates POSIX mode so the genuine special builtins
+# win. None of these shadows may observe the secret on the load path.
+echo "[E] builtin()/unset()/command()-shadow seed-of-trust attack on the Bash-4+ path ($BASH4)"
+run_case "E builtin/unset/command-shadow (Bash4+ no-op, fixed)" "$BASH4" "$LIB_SH" "clean" write_builtin_shadow_attack_wrapper
+if [[ -n "$BASH3" ]]; then
+  echo "[E] builtin/unset/command-shadow attack on the Bash-3.2→4 re-exec path ($BASH3)"
+  run_case "E builtin/unset/command-shadow (Bash3.2 re-exec, fixed)" "$BASH3" "$LIB_SH" "clean" write_builtin_shadow_attack_wrapper
+fi
+
+# --- F: local()-shadow attack (codex Phase-4 r2 finding 1) ------------------
+# The primitive's harden_hooks must not run a shadowable `local` BEFORE its
+# seed. Post-r2 it snapshots prior POSIX state via plain global assignment, so a
+# `local()` shadow must NEVER observe the secret.
+echo "[F] local()-shadow attack on the Bash-4+ path ($BASH4)"
+run_case "F local-shadow (Bash4+ no-op, fixed)" "$BASH4" "$LIB_SH" "clean" write_local_shadow_attack_wrapper
+if [[ -n "$BASH3" ]]; then
+  echo "[F] local()-shadow attack on the Bash-3.2→4 re-exec path ($BASH3)"
+  run_case "F local-shadow (Bash3.2 re-exec, fixed)" "$BASH3" "$LIB_SH" "clean" write_local_shadow_attack_wrapper
+fi
+
+# --- G: set -T DEBUG-trap shadow-reinstall attack (codex Phase-4 r2 finding 2)-
+# A `set -T` DEBUG trap that re-installs a `builtin()` shadow on every simple
+# command must not survive to intercept the `builtin source` primitive load.
+# Post-r2 the seed clears functrace + DEBUG/RETURN/ERR traps BEFORE the strip.
+echo "[G] set -T DEBUG-trap shadow-reinstall attack on the Bash-4+ path ($BASH4)"
+run_case "G trap-reshadow (Bash4+ no-op, fixed)" "$BASH4" "$LIB_SH" "clean" write_trap_recreate_attack_wrapper
+if [[ -n "$BASH3" ]]; then
+  echo "[G] set -T DEBUG-trap shadow-reinstall attack on the Bash-3.2→4 re-exec path ($BASH3)"
+  run_case "G trap-reshadow (Bash3.2 re-exec, fixed)" "$BASH3" "$LIB_SH" "clean" write_trap_recreate_attack_wrapper
+fi
+
+# --- H: POSIX-mode caller harden_hooks correctness (codex Phase-4 r2) --------
+# When a consumer calls bridge_secret_scrub_harden_hooks while it is ALREADY in
+# POSIX mode, the primitive must (a) still strip a `.()` shadow — on bash 3.2
+# `unset -f .` no-ops in POSIX mode, so the 2nd strip must run in NON-POSIX mode
+# unconditionally — and (b) restore the caller's EXACT prior POSIXLY_CORRECT
+# value + `posix` shopt (the module is sourced into the caller's option set).
+# This drives the primitive directly (the bridge-lib cases above only exercise
+# the non-POSIX entry path). Runs on every available Bash.
+h_check() {
+  # h_check <bash-bin>
+  # The wrapper captures the EXACT POSIXLY_CORRECT value at harden ENTRY (after
+  # `set -o posix`, which on bash 3.2 rewrites it to `y`), so the expected
+  # restored value is computed per-version rather than hardcoded. Asserts: the
+  # `.()` shadow is stripped, the entry POSIXLY_CORRECT value is restored
+  # exactly, and the `posix` shopt is still on.
+  local bashbin="$1" out
+  local hwrap="$WORK/h-harden.sh"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+    printf 'source %q\n' "$PRIMITIVE"
+    printf 'eval ".() { command builtin printf DOTSHADOW; }"\n'
+    printf 'POSIXLY_CORRECT=customval\n'
+    printf 'set -o posix\n'
+    printf 'pcv_entry="${POSIXLY_CORRECT-UNSET}"\n'
+    printf 'bridge_secret_scrub_harden_hooks\n'
+    printf 'pcv="${POSIXLY_CORRECT-UNSET}"\n'
+    printf 'pxa="$(shopt -po posix 2>/dev/null)"\n'
+    printf 'set +o posix 2>/dev/null\n'
+    printf 'dt="$(type -t . 2>/dev/null || command builtin printf none)"\n'
+    printf 'if [ "$dt" = builtin ] && [ "$pcv" = "$pcv_entry" ] && [ "$pxa" = "set -o posix" ]; then command builtin printf "OK\\n"; else command builtin printf "BAD dot=%%s pcv=%%s/%%s px=%%s\\n" "$dt" "$pcv" "$pcv_entry" "$pxa"; fi\n'
+  } > "$hwrap"
+  out="$(BRIDGE_HOME="$PROBE_HOME" "$bashbin" "$hwrap" 2>/dev/null || true)"
+  rm -f "$hwrap"
+  case "$out" in
+    OK)
+      ok "H posix-caller harden ($("$bashbin" -c 'echo ${BASH_VERSINFO[0]}')) — .() stripped + POSIXLY_CORRECT/posix preserved exactly" ;;
+    *)
+      fail "H posix-caller harden ($("$bashbin" -c 'echo ${BASH_VERSINFO[0]}')) — $out" ;;
+  esac
+}
+echo "[H] POSIX-mode-caller harden_hooks: .() strip + exact POSIX-state restore"
+h_check "$BASH4"
+if [[ -n "$BASH3" ]]; then h_check "$BASH3"; fi
+
+# --- TEETH-GAP: synthetic pre-gap-fix bridge-lib.sh (bare source, no seed) ---
+# The existing TEETH (below) uses origin/main, which predates the whole #1454
+# secret-scrub block and so cannot exercise the source()-shadow gap. Synthesize
+# the precise pre-gap-fix version from the CURRENT bridge-lib.sh by (a) removing
+# the shadow-proof seed lines and (b) downgrading `builtin source` of the
+# primitive back to a bare `source`. Against THAT, the source()/.() shadow MUST
+# leak — proving the canary detects the exact gap codex found.
+echo "[TEETH-GAP] synthetic pre-gap-fix (bare source, no seed) must leak under the source()-shadow attack"
+GAP_VULN="$REPO_ROOT/.agb-1454-gapvuln-$$-bridge-lib.sh"
+# Synthesize the precise pre-gap-fix version with a pure-bash tempfile
+# while-read transform (no sed/awk). We don't touch comments (they don't
+# execute) — we only NEUTRALIZE the executable seed statements (comment them
+# out) and downgrade `builtin source` of the primitive back to a bare `source`.
+# That reconstructs the exact gap: the de-fang primitive loaded through an
+# un-de-fanged `source` that a `source()` shadow can intercept.
+gap_built=0
+_BSL=$'\\'   # a single literal backslash (avoids confusing quote-escape matchers)
+{
+  _in_seed_unset=0
+  while IFS= read -r _line || [[ -n "$_line" ]]; do
+    # Comment out the executable seed statements so the seed no longer runs.
+    case "$_line" in
+      'POSIXLY_CORRECT=1' \
+      |'set +o posix 2>/dev/null || true' \
+      |'set +T +E 2>/dev/null || true' \
+      |'trap - DEBUG RETURN ERR 2>/dev/null || true' \
+      |'unset POSIXLY_CORRECT 2>/dev/null || true')
+        printf '# GAPVULN-DISABLED %s\n' "$_line"; continue ;;
+      'unset -f source . unset set export exec eval command builtin'*)
+        # First line of either `unset -f` seed pass. If it ends in a
+        # line-continuation backslash, swallow the continuation lines too.
+        case "$_line" in
+          *"$_BSL") _in_seed_unset=1 ;;
+        esac
+        printf '# GAPVULN-DISABLED %s\n' "$_line"; continue ;;
+    esac
+    if (( _in_seed_unset )); then
+      printf '# GAPVULN-DISABLED %s\n' "$_line"
+      case "$_line" in
+        *"$_BSL") ;;             # line continues — keep swallowing
+        *) _in_seed_unset=0 ;;   # last continuation line — stop
+      esac
+      continue
+    fi
+    # Downgrade the builtin-source load of the primitive to a bare source.
+    case "$_line" in
+      *'builtin source "$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub.sh"'*)
+        _line="${_line/builtin source /source }" ;;
+    esac
+    printf '%s\n' "$_line"
+  done < "$LIB_SH"
+} > "$GAP_VULN" && [[ -s "$GAP_VULN" ]] && gap_built=1
+
+if (( gap_built )) \
+   && grep -qE '^[[:space:]]*source "\$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub\.sh"' "$GAP_VULN" \
+   && ! grep -qE '^[[:space:]]*POSIXLY_CORRECT=1$' "$GAP_VULN"; then
+  trap 'rm -f "$GAP_VULN" 2>/dev/null || true; cleanup' EXIT
+  # The no-seed bare-source version must leak under the source()-shadow class.
+  run_case "TEETH-GAP source-shadow (Bash4+ no-op, pre-gap-fix)" "$BASH4" "$GAP_VULN" "leak" write_source_shadow_attack_wrapper
+  if [[ -n "$BASH3" ]]; then
+    run_case "TEETH-GAP source-shadow (Bash3.2 re-exec, pre-gap-fix)" "$BASH3" "$GAP_VULN" "leak" write_source_shadow_attack_wrapper
+  fi
+  rm -f "$GAP_VULN"
+  trap cleanup EXIT
+else
+  rm -f "$GAP_VULN" 2>/dev/null || true
+  fail "TEETH-GAP — could not synthesize a pre-gap-fix bridge-lib.sh (seed-strip / bare-source rewrite failed)"
+fi
+
+# --- TEETH-TRAP: synthetic pre-r2 bridge-lib.sh (seed present, but trap-clear
+# REMOVED — i.e. the ordering codex Phase-4 r2 finding 2 flagged). Keeps
+# `builtin source` + the strip but disables `set +T +E` / `trap - DEBUG …` so a
+# set -T DEBUG trap can re-install a builtin() shadow AFTER the strip and
+# intercept the primitive load. Under the trap-reshadow attack this MUST leak,
+# proving case G has teeth.
+echo "[TEETH-TRAP] synthetic pre-r2 (trap-clear removed) must leak under the set -T DEBUG-trap attack"
+TRAP_VULN="$REPO_ROOT/.agb-1454-trapvuln-$$-bridge-lib.sh"
+trap_built=0
+{
+  while IFS= read -r _line || [[ -n "$_line" ]]; do
+    # Disable ONLY the trap-clear / functrace-clear seed lines; keep everything
+    # else (POSIXLY_CORRECT, the unset -f strips, builtin source) intact.
+    case "$_line" in
+      'set +T +E 2>/dev/null || true'|'trap - DEBUG RETURN ERR 2>/dev/null || true')
+        printf '# TRAPVULN-DISABLED %s\n' "$_line"; continue ;;
+    esac
+    printf '%s\n' "$_line"
+  done < "$LIB_SH"
+} > "$TRAP_VULN" && [[ -s "$TRAP_VULN" ]] && trap_built=1
+
+if (( trap_built )) \
+   && grep -qE '^[[:space:]]*builtin source "\$_BRIDGE_LIB_SELF_DIR/lib/bridge-secret-scrub\.sh"' "$TRAP_VULN" \
+   && ! grep -qE '^[[:space:]]*trap - DEBUG RETURN ERR' "$TRAP_VULN"; then
+  trap 'rm -f "$TRAP_VULN" 2>/dev/null || true; cleanup' EXIT
+  run_case "TEETH-TRAP trap-reshadow (Bash4+ no-op, pre-r2)" "$BASH4" "$TRAP_VULN" "leak" write_trap_recreate_attack_wrapper
+  if [[ -n "$BASH3" ]]; then
+    run_case "TEETH-TRAP trap-reshadow (Bash3.2 re-exec, pre-r2)" "$BASH3" "$TRAP_VULN" "leak" write_trap_recreate_attack_wrapper
+  fi
+  rm -f "$TRAP_VULN"
+  trap cleanup EXIT
+else
+  rm -f "$TRAP_VULN" 2>/dev/null || true
+  fail "TEETH-TRAP — could not synthesize a pre-r2 (trap-clear-removed) bridge-lib.sh"
+fi
+
+# --- TEETH-LOCAL: synthetic pre-r2 PRIMITIVE (a `local` snapshot re-introduced
+# at the TOP of bridge_secret_scrub_harden_hooks, i.e. the ordering codex
+# Phase-4 r2 finding 1 flagged). Source it directly, install a `local()` shadow,
+# call harden_hooks: it MUST leak, proving case F has teeth. The synthesis
+# injects one `local` line right after the function's opening brace.
+echo "[TEETH-LOCAL] synthetic pre-r2 primitive (local-before-seed) must leak under the local()-shadow attack"
+PRIM_VULN="$WORK/vuln-secret-scrub.sh"
+prim_built=0
+{
+  _injected=0
+  while IFS= read -r _line || [[ -n "$_line" ]]; do
+    printf '%s\n' "$_line"
+    if (( ! _injected )); then
+      case "$_line" in
+        'bridge_secret_scrub_harden_hooks() {')
+          # Re-introduce the vulnerable shadowable `local` BEFORE the seed.
+          printf '  local _agb_pre_seed_probe=1\n'
+          _injected=1 ;;
+      esac
+    fi
+  done < "$PRIMITIVE"
+} > "$PRIM_VULN" && [[ -s "$PRIM_VULN" ]] && (( _injected )) && prim_built=1
+
+if (( prim_built )); then
+  TL_LEAK="$WORK/tl-leak.txt"; rm -f "$TL_LEAK"
+  TL_WRAP="$WORK/tl-attack.sh"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'export %s=%q\n' "$OAT_VAR" "$SECRET_VALUE"
+    printf 'local() { command builtin printf "%%s\\n" "${%s:-}" >> %q; }\n' "$OAT_VAR" "$TL_LEAK"
+    printf 'source %q\n' "$PRIM_VULN"
+    printf 'bridge_secret_scrub_harden_hooks\n'
+  } > "$TL_WRAP"
+  BRIDGE_HOME="$PROBE_HOME" "$BASH4" "$TL_WRAP" >/dev/null 2>&1 || true
+  if leak_present "$TL_LEAK"; then
+    ok "TEETH-LOCAL pre-r2 primitive — local()-shadow leaked as expected (teeth)"
+  else
+    fail "TEETH-LOCAL pre-r2 primitive — expected a local()-shadow leak but none occurred (teeth check broken)"
+  fi
+  rm -f "$TL_LEAK" "$TL_WRAP" "$PRIM_VULN"
+else
+  rm -f "$PRIM_VULN" 2>/dev/null || true
+  fail "TEETH-LOCAL — could not synthesize a pre-r2 (local-before-seed) primitive"
+fi
 
 # --- TEETH: pristine pre-fix bridge-lib.sh MUST leak -----------------------
 echo "[TEETH] the same attack against the pre-fix bridge-lib.sh must leak"


### PR DESCRIPTION
## #1454 — harden bridge-lib.sh Bash 3.2→4 re-exec (shared root of the inherited-env credential-leak class)

The Phase-0 SECURITY GATE for the fleet-credential roadmap. `bridge-lib.sh`'s Bash 3.2→4+ re-exec ran external commands (a `dirname` command-substitution for `BRIDGE_SCRIPT_DIR`) **while the operator's ambient secret env was still in scope**, so a same-UID caller exporting a function shadowing that command (or a PATH-plant) could observe the secret during the re-exec window. This is the shared root that PR #1443 (bridge-usage.sh) and #1452/#1444 (bridge-run.sh) each closed only in their own lane; this closes the class once for every consumer of bridge-lib.sh.

### What changed
- `BRIDGE_SCRIPT_DIR` now derived via the builtin `${BASH_SOURCE[0]%/*}` — **no `dirname` fork**.
- Re-exec is privileged (`exec … -p …`) so the upgraded shell imports no environment functions; the old login-shell candidate probe is replaced with `-p -c`.
- New shared primitive `lib/bridge-secret-scrub.sh` is sourced + the hooks are hardened **before** the re-exec guard. (Consumers #1443/#1452 are NOT refactored onto it here — that is a follow-up; this PR's blast radius is bridge-lib.sh + the primitive + the canary.)
- `BRIDGE_SCRIPT_DIR`'s resolved VALUE is unchanged — only HOW it is computed; the Bash-3.2→4 upgrade re-exec still works on macOS and is a no-op on Bash 4+ Linux.

### Verification
- **Canary smoke** `scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh` (registered in ci-select): PASS — the ambient secret never reaches a shadow function across the re-exec window on the A (re-exec) path, the B (no-op) path, or the C (PATH-plant) path; **TEETH**: the same attack against the pre-fix bridge-lib.sh leaks as expected (both no-op + re-exec).
- `bash -n` + `shellcheck` clean on all touched files; `BRIDGE_SCRIPT_DIR` resolves correctly post-fix (no behavior change). Full smoke matrix runs in CI (clean env).

### Note
This PR was authored by a background fixer whose orchestrator process restarted before it opened the PR; the staged work was recovered intact (canary + teeth re-verified before this PR). It still goes through the full `agb-dev-codex` Phase-4 pair-review — that is the merge gate.

Closes #1454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
