### PR TITLE
fix(backup): exclude regenerable per-agent trees (agent-sdk-venv, claude/versions) from the daily backup (#1462)

### DIFF
--- a/scripts/smoke/daily-backup-path-part-test.py
+++ b/scripts/smoke/daily-backup-path-part-test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Issue #974 regression — exercise `should_skip_daily_backup_relpath`.
+"""Issue #974 / #1462 regression — exercise `should_skip_daily_backup_relpath`.
 
 Standalone helper for `scripts/smoke/daily-backup.sh::step_path_part_excludes_multicomponent`.
 Extracted to its own file to keep the smoke script free of
@@ -47,6 +47,48 @@ CASES: list[tuple[str, bool, str]] = [
     ("state/cache/plugins/x.txt", False, "reversed order (kept)"),
     ("random/plugins/cache_other/x", False, "cache_other != cache (kept)"),
     ("plugins-archive/cache/x", False, "plugins-archive != plugins (kept)"),
+    # Issue #1462 — regenerable per-agent trees, same any-depth path-part
+    # mechanism as #974. Both are rebuilt/re-downloaded on demand, so the
+    # daily backup must skip them regardless of the agent-name segment. TEETH:
+    # if the two `DAILY_BACKUP_PATH_PART_EXCLUDES` entries are removed from
+    # bridge-upgrade.py, these `True` cases flip to got=False and the smoke
+    # fails.
+    (
+        "agents/patch/home/.claude/security/agent-sdk-venv/bin/python",
+        True,
+        "#1462 agent-sdk venv (excluded)",
+    ),
+    (
+        "agents/worker-a/home/.claude/security/agent-sdk-venv",
+        True,
+        "#1462 agent-sdk venv, no trailing seg, other agent (excluded)",
+    ),
+    (
+        "agents/patch/home/.local/share/claude/versions/1.2.3/cli",
+        True,
+        "#1462 claude CLI versions cache (excluded)",
+    ),
+    (
+        "agents/worker-a/home/.local/share/claude/versions",
+        True,
+        "#1462 claude versions, no trailing seg, other agent (excluded)",
+    ),
+    # #1462 keep-cases: sibling/adjacent paths that must NOT be swept up.
+    (
+        "agents/patch/home/.claude/security/credentials.json",
+        False,
+        "#1462 security/ sibling, not agent-sdk-venv (kept)",
+    ),
+    (
+        "agents/patch/home/.local/share/claude/settings.json",
+        False,
+        "#1462 claude/ data, not versions (kept)",
+    ),
+    (
+        "agents/patch/home/.local/share/claude/versions-archive/x",
+        False,
+        "#1462 versions-archive != versions (kept)",
+    ),
 ]
 
 

--- a/scripts/smoke/daily-backup.sh
+++ b/scripts/smoke/daily-backup.sh
@@ -305,14 +305,15 @@ step_timeout_resolution() {
   smoke_log "timeout_resolution OK (5/5 cases + rc=124 detail wiring)"
 }
 
-# issue #974 — multi-component path-part exclude (`plugins/cache`)
+# issue #974 / #1462 — multi-component path-part exclude (`plugins/cache`,
+# `.claude/security/agent-sdk-venv`, `.local/share/claude/versions`)
 # must match a consecutive subsequence anywhere in the relpath, must NOT
 # false-positive on (a) the components alone, (b) the components in the
-# wrong order, or (c) substring-only matches like `cache_other`. Legacy
-# single-component entries (`__pycache__`, `node_modules`) must keep the
-# fast-path `in parts` behaviour.
+# wrong order, or (c) substring-only matches like `cache_other` /
+# `versions-archive`. Legacy single-component entries (`__pycache__`,
+# `node_modules`) must keep the fast-path `in parts` behaviour.
 step_path_part_excludes_multicomponent() {
-  smoke_log "step 8: path-part subsequence matcher (#974 regression)"
+  smoke_log "step 8: path-part subsequence matcher (#974/#1462 regression)"
   # Helper extracted to its own .py file to avoid heredoc-in-command-
   # substitution (Footgun #11 ratchet — see lib/upgrade-helpers/).
   local result


### PR DESCRIPTION
## Summary

Lock in regression coverage for the #1462 daily-backup excludes via the existing path-part smoke.

**Discovery:** the production fix for #1462 already landed on `main` via merged PR #1478 — the two path-part excludes `.claude/security/agent-sdk-venv` and `.local/share/claude/versions` are already present in `DAILY_BACKUP_PATH_PART_EXCLUDES` (`bridge-upgrade.py`), which is the **daily** backup mechanism (the upgrade backup, `build_backup_entries`/`copy_live_backup`, is a separate, untouched path). Issue #1462 stayed OPEN only because #1478's title closed #1466. The remaining gap vs. the brief was a dedicated smoke assertion naming the two regenerable trees plus a teeth case — this PR adds exactly that, with **no production code change**.

## Root cause

On multi-agent installs the daily backup walked + gzipped two large **regenerable** per-agent subtrees — the agent-SDK venv and the downloaded Claude CLI versions cache — which dominate the payload and push the walk+gzip past `BRIDGE_DAILY_BACKUP_TIMEOUT_SECONDS`. Both are rebuilt / re-downloaded on demand, so they're excluded from the daily backup via the same any-depth path-part mechanism as #974's `plugins/cache`.

## What changed

- `scripts/smoke/daily-backup-path-part-test.py`: +7 cases against `should_skip_daily_backup_relpath` — 4 expected-excluded (both trees, with/without a trailing segment, across distinct agent-name segments) and 3 expected-kept guards (`security/` sibling, `claude/` data file, and the `versions-archive` substring trap).
- `scripts/smoke/daily-backup.sh`: step comment + `smoke_log` updated to `#974/#1462` (no logic change).

`bridge-upgrade.py` is unchanged; the upgrade backup and credential lane are untouched.

## Verification

- `python3 scripts/smoke/daily-backup-path-part-test.py bridge-upgrade.py` → **PASS (17 cases)**
- **TEETH:** running the helper against a copy of `bridge-upgrade.py` with the two #1462 excludes removed fails on exactly the 4 #1462 exclude cases; keep-cases stay correct.
- Full `bash scripts/smoke/daily-backup.sh` → all checks pass, step 8 reports `PASS (17 cases)`.
- `py_compile` / `bash -n` / `shellcheck` clean; no new heredoc-stdin / procsub introduced.
- Internal `codex:codex-rescue` review: **implement-ok** (re-ran helper, confirmed teeth + daily-path wiring + scope).

Closes #1462.

🤖 Generated with [Claude Code](https://claude.com/claude-code)