### PR TITLE
fix(smoke): #1454 canary plain-TEETH moving-base footgun (CI-stability regression on main)

### DIFF
--- a/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
+++ b/scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh
@@ -624,6 +624,17 @@ elif base_sha="$(git -C "$REPO_ROOT" merge-base HEAD origin/main 2>/dev/null)" &
      && git -C "$REPO_ROOT" show "$base_sha:bridge-lib.sh" > "$VULN_LIB" 2>/dev/null && [[ -s "$VULN_LIB" ]]; then
   got_base=1
 fi
+# Moving-base guard: once #1454 is merged to origin/main, the "git base" copy
+# of bridge-lib.sh IS the FIXED version, not a vulnerable pre-fix one — using it
+# as the TEETH reference would (correctly) NOT leak and falsely "break" the
+# teeth on every PR that selects this static suite. Only treat $VULN_LIB as a
+# valid pre-fix reference if it actually LACKS the #1454 hardening (the
+# bridge-secret-scrub primitive source). If the base is already fixed, skip this
+# plain TEETH — the synthesized TEETH-GAP/TRAP/LOCAL cases (which revert the fix
+# from the CURRENT tree, no moving-base dependency) already prove the teeth.
+if (( got_base )) && grep -q 'bridge-secret-scrub' "$VULN_LIB" 2>/dev/null; then
+  got_base=0
+fi
 if (( got_base )); then
   # The vuln copy lives in $WORK, not the repo root, so its self-dir resolves to
   # $WORK and it won't find lib/bridge-secret-scrub.sh — which is correct: the
@@ -641,7 +652,7 @@ if (( got_base )); then
   rm -f "$VULN_IN_TREE"
   trap cleanup EXIT
 else
-  echo "  SKIP  TEETH — could not obtain a pre-fix bridge-lib.sh (no origin/main); A/B/C still assert the fix"
+  echo "  SKIP  TEETH — no usable pre-fix bridge-lib.sh (origin/main absent, or already carries the #1454 fix so it is not a vulnerable reference); A/B/C/D/E/F/G/H assert the fix and the synthesized TEETH-GAP/TRAP/LOCAL prove the teeth without a moving-base dependency"
 fi
 
 if (( failed )); then


### PR DESCRIPTION
## #1454 canary plain-TEETH moving-base footgun — CI-stability regression on main

**Urgent CI unblock.** After #1454 merged (c60d85d0), the `1454-bridge-lib-reexec-secret-canary.sh` plain-TEETH case started failing `unit/static smoke` on EVERY PR that selects the static suite (observed on #1457 and #1493): `TEETH pre-fix (Bash4+ no-op) — expected a leak but none occurred (teeth check broken)`.

### Root cause (self-referential moving base)
The plain TEETH used `git show origin/main:bridge-lib.sh` as the "pristine pre-fix VULNERABLE" reference and asserted the attack leaks. That held while #1454 was unmerged (origin/main was pre-#1454, genuinely vulnerable). The moment #1454 landed on `main`, `origin/main:bridge-lib.sh` IS the **fixed** file → the attack correctly does NOT leak → the teeth "break" — on every PR, deterministically.

### Fix (smoke-only)
Guard the git-base reference: only treat `$VULN_LIB` as a valid pre-fix vulnerable reference if it **lacks** the #1454 hardening (the `bridge-secret-scrub` primitive source). If the base already carries the fix, **skip** the plain TEETH — the synthesized `TEETH-GAP` / `TEETH-TRAP` / `TEETH-LOCAL` cases (which revert the fix from the CURRENT tree, with no moving-base dependency) already prove the teeth fire. The in-scope `A`–`H` cases still assert the fix.

### Verification
`scripts/smoke/1454-bridge-lib-reexec-secret-canary.sh` → **25 PASS, 0 FAIL, exit 0** on main HEAD (plain TEETH skips with an accurate message; all other cases + the synthesized teeth pass). `bash -n` clean. Smoke-only — no production code, no change to the actual #1454 protection or its other contract surfaces.

Unblocks #1457, #1493, and any future PR selecting the static suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
