### PR TITLE
fix(roster): align <admin>-dev pair workspace to the admin effective workdir on v2 (#1492)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -5305,6 +5305,54 @@ bridge_agent_mattermost_state_dir() {
   bridge_agent_default_mattermost_state_dir "$agent"
 }
 
+# Issue #1492 — admin-pair workspace alignment predicate.
+#
+# Return 0 only for the documented co-located `<admin>-dev` codex pair whose
+# raw roster workdir points at the admin's old/base shared cwd (the value
+# captured at provisioning time by bridge-init-codex-pair.sh, which becomes
+# the admin's *base* dir after the v2 anchor split rewrites the admin to
+# <admin>/workdir). For that exact shape the caller follows the admin's
+# RESOLVED workdir so the shared-workspace pair-review contract holds.
+#
+# All conditions must hold (mirrors the migration preflight whitelist
+# `_bridge_isolation_v2_migrate_is_admin_pair_override`):
+#   - agent is named `<admin>-dev` (and the admin half is non-empty),
+#   - the admin half is the configured BRIDGE_ADMIN_AGENT_ID,
+#   - the admin is not the agent itself (no self-follow / recursion),
+#   - the pair's raw explicit workdir equals one of the admin's old/base
+#     shared cwds: the admin's v2 base ($BRIDGE_AGENT_ROOT_V2/<admin>),
+#     legacy base ($BRIDGE_AGENT_HOME_ROOT/<admin>), or default home.
+#
+# An empty explicit, an unrelated `*-dev` whose base is not the admin, or a
+# `<admin>-dev` pointing at a genuinely custom path all return 1 (preserved).
+_bridge_agent_workdir_admin_pair_aligns() {
+  local agent="$1"
+  local explicit="$2"
+
+  [[ -n "$explicit" ]] || return 1
+  case "$agent" in
+    *-dev) ;;
+    *) return 1 ;;
+  esac
+
+  local _admin="${agent%-dev}"
+  [[ -n "$_admin" && "$_admin" != "$agent" ]] || return 1
+
+  local _configured_admin=""
+  _configured_admin="$(bridge_admin_agent_id 2>/dev/null || true)"
+  [[ -n "$_configured_admin" && "$_admin" == "$_configured_admin" ]] || return 1
+
+  local _admin_v2_base="$BRIDGE_AGENT_ROOT_V2/$_admin"
+  local _admin_legacy_base="$BRIDGE_AGENT_HOME_ROOT/$_admin"
+  local _admin_default_home=""
+  _admin_default_home="$(bridge_agent_default_home "$_admin")"
+
+  [[ "$explicit" == "$_admin_v2_base" \
+    || "$explicit" == "$_admin_legacy_base" \
+    || "$explicit" == "$_admin_default_home" ]] || return 1
+  return 0
+}
+
 bridge_agent_workdir() {
   local agent="$1"
   local explicit=""
@@ -5349,6 +5397,24 @@ bridge_agent_workdir() {
     # dynamic agents and static project overrides; only align legacy
     # default-home static rows to the existing v2 workdir.
     if [[ "$(bridge_agent_source "$agent")" == "static" ]]; then
+      # Issue #1492: the documented `<admin>-dev` codex pair co-locates with
+      # its admin's *workspace* (shared SOUL/MEMORY/CLAUDE.md so two models
+      # review the same tree). The pair's raw roster workdir was captured at
+      # provisioning time (bridge-init-codex-pair.sh) from the admin's THEN
+      # workdir — the admin's old/base shared cwd. After the v2 anchor split
+      # rewrote the admin to <admin>/workdir, that raw value points at the
+      # admin's *base* dir, not the pair's own home, so the generic
+      # legacy-default-home alignment below does NOT fire and the pair drifts
+      # to the admin's pre-v2 base while the admin runs under <admin>/workdir.
+      # Detect the genuine admin-pair shape and follow the admin's RESOLVED
+      # workdir so the shared-workspace pair-review contract holds. Identity,
+      # home (<admin>-dev/home), and hooks stay distinct — only the cwd is
+      # shared. Tight to the pair pattern: an unrelated static `*-dev` row, or
+      # a `<admin>-dev` pointing at a genuinely custom path, is NOT realigned.
+      if _bridge_agent_workdir_admin_pair_aligns "$agent" "$explicit"; then
+        bridge_agent_workdir "${agent%-dev}"
+        return 0
+      fi
       local _legacy_v2_workdir="$BRIDGE_AGENT_ROOT_V2/$agent/workdir"
       local _default_home=""
       local _legacy_base_home="$BRIDGE_AGENT_HOME_ROOT/$agent"

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -151,6 +151,15 @@ add_required codex-doctor codex-version-surface
 # agents.sh, bridge-agent.sh, or assets/codex/* change re-runs them via the
 # catch-all / arm-specific selection below.
 add_required codex-slash-commands codex-permission-profiles
+# Issue #1492: bridge_agent_workdir now aligns the documented `<admin>-dev`
+# codex pair's RESOLVED workspace to the admin's effective v2 workdir
+# (`<admin>/workdir`) instead of leaving it drifted at the admin's old/base
+# shared cwd, while keeping the pair's identity/home/hooks distinct. In the
+# full static suite so a scripts/smoke/* or lib/bridge-agents.sh change
+# re-runs it via the catch-all → add_all_required_static (the
+# lib/bridge-agents.sh, bridge-init-codex-pair.sh, and bridge-init.sh
+# selectors below also reach it transitively via the static catch-all).
+add_required 1492-admin-dev-pair-workspace-v2
 
 
 }
@@ -2382,7 +2391,13 @@ add_required launch launch-dev-channels-injection tmux-injection upgrade-source-
       # beta5-2-epsilon-tmux-inject-busy on every bridge-init.sh move so the
       # advisory surface cannot regress, re-opening the CRITICAL data-loss
       # class flagged by the patch audit C6.
-      add_required admin-pair-server-auto-provision agent-create-caller-trust-gate upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering I-agent-description-roster β-1231-1236-fresh-install-seed-sudoers F-beta4-oauth-bootstrap G-beta4-watchdog-noise beta5-2-epsilon-tmux-inject-busy
+      # Issue #1492: lib/bridge-init-codex-pair.sh captures the admin's
+      # workdir into the `<admin>-dev` pair's raw roster row at provisioning
+      # time, which is the value bridge_agent_workdir later aligns to the
+      # admin's effective v2 workdir. Pull 1492-admin-dev-pair-workspace-v2
+      # whenever the pair-provisioning or init wiring moves so a future PR
+      # cannot regress the documented shared-workspace pair-review contract.
+      add_required admin-pair-server-auto-provision agent-create-caller-trust-gate upgrade-shared-settings-propagate managed-autocompact-window per-agent-settings-rendering I-agent-description-roster β-1231-1236-fresh-install-seed-sudoers F-beta4-oauth-bootstrap G-beta4-watchdog-noise beta5-2-epsilon-tmux-inject-busy 1492-admin-dev-pair-workspace-v2
       add_integration integration-minimal
       ;;
 

--- a/scripts/smoke/1492-admin-dev-pair-workspace-v2.sh
+++ b/scripts/smoke/1492-admin-dev-pair-workspace-v2.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# scripts/smoke/1492-admin-dev-pair-workspace-v2.sh — Issue #1492.
+#
+# On a v2 install the static admin agent's effective workdir is rewritten to
+# its v2 workspace (`<admin>/workdir`), but the co-located `<admin>-dev` codex
+# pair — whose RAW roster workdir was captured at provisioning time from the
+# admin's THEN (old/base) shared cwd (`<admin>` base dir) — was treated as a
+# *custom* shared cwd and did NOT follow. The pair then ran against the admin's
+# pre-v2 base while the admin ran under `<admin>/workdir`, breaking the
+# documented "admin + <admin>-dev share one workspace so codex pair-review sees
+# the same tree" contract.
+#
+# This smoke pins the fix in `bridge_agent_workdir`:
+#
+#   T1  the `<admin>-dev` pair (raw workdir = admin base dir) RESOLVES to the
+#       admin's EFFECTIVE workdir (`<admin>/workdir`) — i.e. it follows the
+#       admin, never its own `<admin>-dev/workdir`.
+#   T2  home/identity stay DISTINCT — the pair's default home is
+#       `<admin>-dev/home`, the admin's is `<admin>/home`; only the cwd is
+#       shared. (We assert the resolver does not collapse the pair onto the
+#       admin's home.)
+#   T3  TEETH — an UNRELATED static `*-dev` agent that is NOT the admin's pair
+#       (its base is not the configured admin) keeps its own custom shared cwd;
+#       it is NOT realigned onto the admin's workdir.
+#   T4  TEETH — a `<admin>-dev` whose raw workdir is a GENUINELY custom path
+#       (not the admin's base/old shared cwd) is preserved, not realigned.
+#   T5  fresh-install scenario — a freshly-provisioned pair whose raw workdir
+#       is the admin's base lands aligned to `<admin>/workdir` from the start.
+#   T6  TEETH (revert detector) — when the admin-pair alignment predicate is
+#       neutralized, the pair re-drifts to the admin base, proving the assert
+#       has teeth.
+#
+# Footgun #11: driver emitted via printf-to-file, no heredoc-stdin.
+
+set -uo pipefail
+
+SMOKE_NAME="1492-admin-dev-pair-workspace-v2"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+REPO_ROOT="$SMOKE_REPO_ROOT"
+
+BRIDGE_BASH="${BRIDGE_BASH_BIN:-$(command -v bash)}"
+if [[ "$(uname -s 2>/dev/null || printf '')" == "Darwin" ]]; then
+  if [[ -x /opt/homebrew/bin/bash ]]; then
+    BRIDGE_BASH=/opt/homebrew/bin/bash
+  elif [[ -x /usr/local/bin/bash ]]; then
+    BRIDGE_BASH=/usr/local/bin/bash
+  fi
+fi
+
+DRIVER_DIR="$SMOKE_TMP_ROOT/driver"
+mkdir -p "$DRIVER_DIR"
+DRIVER="$DRIVER_DIR/driver.sh"
+
+write_driver() {
+  local out="$1"
+  : >"$out"
+  local line
+  for line in \
+    '#!/usr/bin/env bash' \
+    'set -uo pipefail' \
+    'cd "$REPO_ROOT"' \
+    'SCRIPT_DIR="$REPO_ROOT"' \
+    'source "$REPO_ROOT/bridge-lib.sh" >/dev/null 2>&1' \
+    'declare -F bridge_agent_workdir >/dev/null 2>&1 || { echo "DRIVER_FAIL: bridge_agent_workdir not loaded"; exit 91; }' \
+    'declare -A BRIDGE_AGENT_WORKDIR 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_ISOLATION_MODE 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_OS_USER 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_SOURCE 2>/dev/null || true' \
+    'declare -A BRIDGE_AGENT_SESSION 2>/dev/null || true' \
+    '# Configured admin (drives the <admin>-dev pair detection).' \
+    'BRIDGE_ADMIN_AGENT_ID="$ADMIN_ID"' \
+    '# Admin: shared-mode static. Its raw roster workdir is the admin OLD/base' \
+    '# shared cwd — on a real v2 install the legacy home-root base' \
+    '# ($BRIDGE_AGENT_HOME_ROOT/<admin>), the value bridge_agent_workdir <admin>' \
+    '# returned PRE the v2 anchor split. The generic v2 alignment then rewrites' \
+    '# the admin to $BRIDGE_AGENT_ROOT_V2/<admin>/workdir once that dir exists.' \
+    'BRIDGE_AGENT_SOURCE["$ADMIN_ID"]="static"' \
+    'BRIDGE_AGENT_ISOLATION_MODE["$ADMIN_ID"]="shared"' \
+    'BRIDGE_AGENT_WORKDIR["$ADMIN_ID"]="$BRIDGE_AGENT_HOME_ROOT/$ADMIN_ID"' \
+    '# The admin scaffold creates <admin>/workdir on disk under the v2 root.' \
+    'mkdir -p "$BRIDGE_AGENT_ROOT_V2/$ADMIN_ID/workdir"' \
+    '# Pair: shared-mode static, raw workdir = the admin OLD/base shared cwd' \
+    '# (captured at provisioning time). It must follow the admin to' \
+    '# <admin>/workdir, NOT stay at the admin base and NOT use its own dir.' \
+    'BRIDGE_AGENT_SOURCE["$PAIR_ID"]="static"' \
+    'BRIDGE_AGENT_ISOLATION_MODE["$PAIR_ID"]="shared"' \
+    'BRIDGE_AGENT_WORKDIR["$PAIR_ID"]="$BRIDGE_AGENT_HOME_ROOT/$ADMIN_ID"' \
+    '# Unrelated static *-dev whose base is NOT the admin — custom shared cwd.' \
+    'BRIDGE_AGENT_SOURCE["$OTHER_ID"]="static"' \
+    'BRIDGE_AGENT_ISOLATION_MODE["$OTHER_ID"]="shared"' \
+    'BRIDGE_AGENT_WORKDIR["$OTHER_ID"]="$CUSTOM_WS"' \
+    'mkdir -p "$CUSTOM_WS"' \
+    '' \
+    'ADMIN_WD="$(bridge_agent_workdir "$ADMIN_ID")"' \
+    'PAIR_WD="$(bridge_agent_workdir "$PAIR_ID")"' \
+    'OTHER_WD="$(bridge_agent_workdir "$OTHER_ID")"' \
+    'ADMIN_HOME="$(bridge_agent_default_home "$ADMIN_ID")"' \
+    'PAIR_HOME="$(bridge_agent_default_home "$PAIR_ID")"' \
+    'echo "ADMIN_WD: $ADMIN_WD"' \
+    'echo "PAIR_WD: $PAIR_WD"' \
+    'echo "OTHER_WD: $OTHER_WD"' \
+    'echo "ADMIN_HOME: $ADMIN_HOME"' \
+    'echo "PAIR_HOME: $PAIR_HOME"' \
+    'echo "ADMIN_EFFECTIVE: $BRIDGE_AGENT_ROOT_V2/$ADMIN_ID/workdir"' \
+    'echo "ADMIN_OLD_BASE: $BRIDGE_AGENT_HOME_ROOT/$ADMIN_ID"' \
+    'echo "PAIR_OWN_WORKDIR: $BRIDGE_AGENT_ROOT_V2/$PAIR_ID/workdir"' \
+    'echo "CUSTOM_WS_OUT: $CUSTOM_WS"' \
+    '' \
+    '# T4 TEETH: the GENUINE <admin>-dev pair ($PAIR_ID, ends in -dev) pointed at' \
+    '# a custom path (not the admin base/old shared cwd) must be PRESERVED — the' \
+    '# predicate only follows the admin when explicit == an admin base/old cwd.' \
+    '# Reuse $PAIR_ID (real pair name) so this exercises the predicate *-dev arm,' \
+    '# then restore the drifted raw workdir for T5/T6.' \
+    'BRIDGE_AGENT_WORKDIR["$PAIR_ID"]="$CUSTOM_WS"' \
+    'PAIR_CUSTOM_WD="$(bridge_agent_workdir "$PAIR_ID")"' \
+    'echo "PAIR_CUSTOM_WD: $PAIR_CUSTOM_WD"' \
+    '' \
+    '# T5 fresh-install: a freshly-provisioned pair records the admin EFFECTIVE' \
+    '# workdir directly (bridge-init-codex-pair.sh captures bridge_agent_workdir' \
+    '# <admin> = <admin>/workdir once the v2 anchor exists). Already aligned —' \
+    '# the predicate leaves it untouched and it must stay at <admin>/workdir,' \
+    '# never double-resolve into <admin>/workdir/workdir.' \
+    'BRIDGE_AGENT_WORKDIR["$PAIR_ID"]="$BRIDGE_AGENT_ROOT_V2/$ADMIN_ID/workdir"' \
+    'PAIR_WD_FRESH="$(bridge_agent_workdir "$PAIR_ID")"' \
+    'echo "PAIR_WD_FRESH: $PAIR_WD_FRESH"' \
+    '# Restore the drifted (migrated-install) raw workdir for the T6 revert.' \
+    'BRIDGE_AGENT_WORKDIR["$PAIR_ID"]="$BRIDGE_AGENT_HOME_ROOT/$ADMIN_ID"' \
+    '' \
+    '# T6 revert detector: neutralize the admin-pair predicate and re-resolve.' \
+    '_bridge_agent_workdir_admin_pair_aligns() { return 1; }' \
+    'PAIR_WD_REVERTED="$(bridge_agent_workdir "$PAIR_ID")"' \
+    'echo "PAIR_WD_REVERTED: $PAIR_WD_REVERTED"'
+  do
+    printf '%s\n' "$line" >>"$out"
+  done
+  chmod +x "$out"
+}
+
+extract_line() {
+  local out="$1"
+  local key="$2"
+  printf '%s\n' "$out" | sed -n "s/^$key: //p" | head -n 1
+}
+
+write_driver "$DRIVER"
+
+ADMIN_ID="probe_admin"
+PAIR_ID="probe_admin-dev"
+# An unrelated static *-dev whose base ("probe_worker") is NOT the configured
+# admin — must keep its own custom shared cwd (T3).
+OTHER_ID="probe_worker-dev"
+# A genuinely custom workspace path used by T3 (the unrelated *-dev) and by T4
+# (the real <admin>-dev pair temporarily pointed at a custom, non-admin-base cwd).
+CUSTOM_WS="$BRIDGE_DATA_ROOT/custom-project"
+
+smoke_log "T1-T6: v2 <admin>-dev pair follows admin effective workdir; identity/home distinct; teeth"
+
+OUT="$(
+  REPO_ROOT="$REPO_ROOT" \
+  DRIVER_TMP_DIR="$DRIVER_DIR" \
+  ADMIN_ID="$ADMIN_ID" \
+  PAIR_ID="$PAIR_ID" \
+  OTHER_ID="$OTHER_ID" \
+  CUSTOM_WS="$CUSTOM_WS" \
+  BRIDGE_HOME="$BRIDGE_HOME" \
+  BRIDGE_STATE_DIR="$BRIDGE_STATE_DIR" \
+  BRIDGE_LOG_DIR="$BRIDGE_LOG_DIR" \
+  BRIDGE_SHARED_DIR="$BRIDGE_SHARED_DIR" \
+  BRIDGE_ROSTER_FILE="$BRIDGE_ROSTER_FILE" \
+  BRIDGE_ROSTER_LOCAL_FILE="$BRIDGE_ROSTER_LOCAL_FILE" \
+  BRIDGE_TASK_DB="$BRIDGE_TASK_DB" \
+  BRIDGE_AGENT_HOME_ROOT="$BRIDGE_AGENT_HOME_ROOT" \
+  BRIDGE_LAYOUT="v2" \
+  BRIDGE_DATA_ROOT="$BRIDGE_DATA_ROOT" \
+  BRIDGE_SHARED_ROOT="$BRIDGE_SHARED_ROOT" \
+  BRIDGE_AGENT_ROOT_V2="$BRIDGE_AGENT_ROOT_V2" \
+  BRIDGE_CONTROLLER_STATE_ROOT="$BRIDGE_CONTROLLER_STATE_ROOT" \
+  BRIDGE_RUNTIME_ROOT="$BRIDGE_RUNTIME_ROOT" \
+  BRIDGE_HOOKS_DIR="$BRIDGE_HOOKS_DIR" \
+  BRIDGE_AUDIT_LOG="$BRIDGE_AUDIT_LOG" \
+  "$BRIDGE_BASH" "$DRIVER" 2>&1
+)"
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+  smoke_fail "driver exited rc=$RC. output:
+$OUT"
+fi
+
+ADMIN_WD="$(extract_line "$OUT" "ADMIN_WD")"
+PAIR_WD="$(extract_line "$OUT" "PAIR_WD")"
+OTHER_WD="$(extract_line "$OUT" "OTHER_WD")"
+PAIR_CUSTOM_WD="$(extract_line "$OUT" "PAIR_CUSTOM_WD")"
+ADMIN_HOME="$(extract_line "$OUT" "ADMIN_HOME")"
+PAIR_HOME="$(extract_line "$OUT" "PAIR_HOME")"
+ADMIN_EFFECTIVE="$(extract_line "$OUT" "ADMIN_EFFECTIVE")"
+ADMIN_OLD_BASE="$(extract_line "$OUT" "ADMIN_OLD_BASE")"
+PAIR_OWN_WORKDIR="$(extract_line "$OUT" "PAIR_OWN_WORKDIR")"
+CUSTOM_WS_OUT="$(extract_line "$OUT" "CUSTOM_WS_OUT")"
+PAIR_WD_FRESH="$(extract_line "$OUT" "PAIR_WD_FRESH")"
+PAIR_WD_REVERTED="$(extract_line "$OUT" "PAIR_WD_REVERTED")"
+
+# Sanity: the admin itself resolves to its v2 effective workdir.
+smoke_assert_eq "$ADMIN_EFFECTIVE" "$ADMIN_WD" \
+  "admin resolves to its v2 effective workdir (<admin>/workdir)"
+
+# T1: the pair follows the admin's EFFECTIVE workdir, not its own.
+smoke_assert_eq "$ADMIN_WD" "$PAIR_WD" \
+  "T1: <admin>-dev pair RESOLVES to the admin's effective workdir (shared workspace)"
+if [[ "$PAIR_WD" == "$PAIR_OWN_WORKDIR" ]]; then
+  smoke_fail "T1: pair must NOT resolve to its own <admin>-dev/workdir ('$PAIR_OWN_WORKDIR'); it must follow the admin"
+fi
+if [[ "$PAIR_WD" == "$ADMIN_OLD_BASE" ]]; then
+  smoke_fail "T1: pair must NOT stay drifted at the admin's old/base shared cwd ('$ADMIN_OLD_BASE')"
+fi
+
+# T2: identity / home stay DISTINCT — only the cwd is shared.
+if [[ "$ADMIN_HOME" == "$PAIR_HOME" ]]; then
+  smoke_fail "T2: pair home must stay DISTINCT from the admin home; both resolved to '$ADMIN_HOME'"
+fi
+smoke_assert_match "$ADMIN_HOME" "/${ADMIN_ID}/home\$" \
+  "T2: admin default home is <admin>/home (its own identity source)"
+smoke_assert_match "$PAIR_HOME" "/${PAIR_ID}/home\$" \
+  "T2: pair default home is <admin>-dev/home (distinct identity preserved)"
+
+# T3 TEETH: unrelated static *-dev with a custom shared cwd is NOT realigned.
+smoke_assert_eq "$CUSTOM_WS_OUT" "$OTHER_WD" \
+  "T3: unrelated *-dev (base != admin) keeps its custom shared cwd (NOT realigned)"
+
+# T4 TEETH: the REAL <admin>-dev pair (probe_admin-dev — exercises the predicate
+# *-dev arm) pointed at a genuinely custom path (not the admin base) is preserved.
+smoke_assert_eq "$CUSTOM_WS_OUT" "$PAIR_CUSTOM_WD" \
+  "T4: <admin>-dev with a genuinely custom workdir is preserved (NOT realigned)"
+
+# T5 fresh-install: a pair already recording the admin effective workdir stays
+# aligned (no double-resolve into <admin>/workdir/workdir).
+smoke_assert_eq "$ADMIN_EFFECTIVE" "$PAIR_WD_FRESH" \
+  "T5: freshly-provisioned pair (raw workdir = admin effective) lands aligned from the start"
+
+# T6 TEETH: reverting the predicate re-drifts the pair to the admin old base.
+smoke_assert_eq "$ADMIN_OLD_BASE" "$PAIR_WD_REVERTED" \
+  "T6: neutralizing the admin-pair predicate re-drifts the pair (assert has teeth)"
+if [[ "$PAIR_WD_REVERTED" == "$PAIR_WD" ]]; then
+  smoke_fail "T6: revert produced the same result as the fix — the assert is toothless"
+fi
+
+smoke_log "all tests PASS — issue #1492: v2 <admin>-dev pair workspace aligns to admin effective workdir; identity/home distinct; teeth verified"


### PR DESCRIPTION
## Summary

On a v2 install the static admin agent's effective workdir is rewritten to its v2 workspace (`<admin>/workdir`), but the documented co-located `<admin>-dev` codex pair did **not** follow — it drifted to the admin's old/base shared cwd. The pair then ran against `<admin>` while the admin ran against `<admin>/workdir`, breaking the documented "admin + `<admin>-dev` share one workspace so codex pair-review sees the same tree" contract. Identity/home/hooks were always distinct; only the workspace drifted.

## Verified root cause

The pair's raw roster workdir is captured at provisioning time (`lib/bridge-init-codex-pair.sh`, via `--workdir "$(bridge_agent_workdir <admin>)"`) = the admin's **then** workdir. After the v2 anchor split rewrote the admin to `<admin>/workdir`, that recorded raw value points at the admin's **base** dir.

`bridge_agent_workdir`'s generic static-shared alignment (lib/bridge-agents.sh) only realigns a row whose explicit workdir equals the **agent's own** default/legacy-base home. The pair's explicit is the **admin's** base dir, not its own — so the generic branch does not fire and the pair falls through to its raw (drifted) value.

Live observation (v0.15.3):
- `agent show patch`     → workdir `agents/patch/workdir`
- `agent show patch-dev` → workdir `agents/patch` (DRIFTED), home `agents/patch-dev/home` (distinct ✓)

## Approach — (B) name-pattern conditional, by necessity (not a symptom paper-over)

I evaluated (A) "resolve the pair relative to the admin's resolved workdir" vs (B) the issue's conditional backfill. They converge: the pair must follow the **admin's** resolved workdir (never its own `<admin>-dev/workdir`), and the only thing that tells the resolver "this agent shares the admin's workspace" is the documented `<admin>-dev` + `BRIDGE_ADMIN_AGENT_ID` convention. There is no general structural roster edge ("follow agent X's workdir") to resolve through — the shared-workspace relationship **is** the name-pattern convention. So a tight name-pattern predicate is the correct mechanism, and it follows the admin's **resolved** workdir (the root-ish (A) behavior), not a static backfill of a literal path.

The new predicate `_bridge_agent_workdir_admin_pair_aligns` mirrors the already-shipped migration-preflight whitelist `_bridge_isolation_v2_migrate_is_admin_pair_override` (same admin-pair shape), keeping the two in lockstep.

## What changed

- **`lib/bridge-agents.sh`** — new predicate `_bridge_agent_workdir_admin_pair_aligns <agent> <explicit>` returns 0 only when: agent is named `<admin>-dev`, `<admin>` == `BRIDGE_ADMIN_AGENT_ID`, `<admin>` != agent (no recursion), and the pair's raw explicit equals one of the admin's old/base shared cwds (`$BRIDGE_AGENT_ROOT_V2/<admin>`, `$BRIDGE_AGENT_HOME_ROOT/<admin>`, or `bridge_agent_default_home <admin>`). In `bridge_agent_workdir`, inside the static-shared block — **after** the linux-user early-return (per-agent privacy untouched), **before** the generic legacy-default-home alignment — when the predicate holds, return `bridge_agent_workdir "${agent%-dev}"` so the pair follows the admin's **resolved** workdir.
- **`scripts/smoke/1492-admin-dev-pair-workspace-v2.sh`** — new v2 smoke (registered in `scripts/ci-select-smoke.sh` at the master static suite + the `bridge-init-codex-pair.sh` selector).
- **`scripts/ci-select-smoke.sh`** — registration.

ONLY the cwd is shared — identity, home (`<admin>-dev/home`), and hooks stay distinct. This is a pure source roster-resolution fix that applies on the next restart/wake; **no live-process mutation**. `prompt_timestamp.py` untouched.

## Verification

Smoke `1492-admin-dev-pair-workspace-v2.sh`:
- **T1** — the `<admin>-dev` pair (raw workdir = admin old/base cwd) RESOLVES to the admin's effective `<admin>/workdir` (shared workspace); never its own `<admin>-dev/workdir`, never the drifted base.
- **T2** — identity/home distinct: admin home `<admin>/home`, pair home `<admin>-dev/home` (only the cwd is shared).
- **T3 TEETH** — an unrelated static `*-dev` (base ≠ admin) with a custom shared cwd is NOT realigned.
- **T4 TEETH** — the **real** `<admin>-dev` pair pointed at a genuinely custom path (≠ admin base) is preserved, NOT realigned.
- **T5 fresh-install** — a freshly-provisioned pair (raw workdir already = admin effective workdir) lands aligned from the start, no double-resolve.
- **T6 TEETH (revert detector)** — neutralizing the predicate re-drifts the pair.

Source-level teeth confirmed manually: neutralizing the predicate **call** fails T1; over-matching the predicate (dropping the explicit-path equality guard) fails T4.

Other checks: `bash -n` (Homebrew Bash 5.3.9) + `shellcheck` on all touched `.sh`; `lint-heredoc-ban` green (no new heredoc-stdin/here-string/procsub); targeted v2/layout/workdir smokes pass (`1060-layout-shared-workdir-pair`, `1060-layout-fresh-v2-static-{claude,codex}`, `1028-isolated-workdir-check`, `1108-watchdog-v2-workdir`, `dynamic-agent-shared-mode-workdir`, `v2-scaffold-home-and-workdir`, `835-static-admin-launch`, `admin-pair-server-auto-provision`). Internal codex pair-review converged to `implement-ok` (round 1 caught a toothless T4 assertion — the custom-path test agent didn't end in `-dev`; fixed by reusing the real pair name).

Note: `scripts/smoke-test.sh`'s "guarding isolated agent-env writes" sub-check fails on this dev box, but it is **pre-existing on clean `main`** (verified by reverting the tracked edits to HEAD) — an environment-specific live-install-contamination artifact, not a regression from this change.

Closes #1492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
