### PR TITLE
feat(a2a): rooms P1b — internal-queue rooms ACL enforcement (OS-enforced actor, default-off) (A2A rooms P1b/N)

### DIFF
--- a/bridge-queue-gateway.py
+++ b/bridge-queue-gateway.py
@@ -99,6 +99,13 @@ _PUBLIC_REASON_MAP: dict[str, str] = {
     "cancel_not_owner": "not_authorized",
     "update_not_owner": "not_authorized",
     "handoff_not_owner": "not_authorized",
+    # Rooms ACL (P1b): a cross-room / fail-closed create denial. Collapsed to
+    # not_authorized so a peer cannot enumerate which agents share which rooms
+    # by probing create targets — the detailed acl_* code is still logged
+    # server-side via gateway_log() for operator triage.
+    "acl_denied": "not_authorized",
+    "acl_fail_closed": "not_authorized",
+    "rooms_acl_unavailable": "internal_error",
     "exception": "internal_error",
 }
 
@@ -125,6 +132,107 @@ def _socket_transport_supported() -> bool:
     recognizable error rather than silently bypass peer auth.
     """
     return sys.platform.startswith("linux") and hasattr(socket, "SO_PEERCRED")
+
+
+def _load_rooms_common() -> Any:
+    """Import bridge_rooms_common from this script's dir (lazy, optional).
+
+    Returns the module, or None if it cannot be imported (a pre-P1a install
+    or a stripped deployment). The rooms ACL gate degrades to a no-op pass
+    when the module is unavailable — never failing a legitimate create just
+    because the rooms control plane is absent.
+    """
+    import importlib.util
+
+    here = Path(__file__).resolve().parent
+    path = here / "bridge_rooms_common.py"
+    if not path.exists():  # noqa: raw-pathlib-controller-only — gateway runs as the controller daemon; this probes a sibling SOURCE file, not an isolated-agent artifact
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("bridge_rooms_common", str(path))
+        if spec is None or spec.loader is None:
+            return None
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001 - any import fault -> no-op (fail open to pre-P1b behavior)
+        return None
+
+
+# The value-consuming flags of `bridge-queue.py create` (each takes the NEXT
+# token). Used by _create_target so a `--to` appearing INSIDE another flag's
+# value (e.g. `--title "... --to fake"`) is never misread as the recipient.
+# Keep in sync with the create subparser in bridge-queue.py. `--body-file` /
+# `--note-file` are gated upstream by _has_file_arg and never reach here.
+_CREATE_VALUE_FLAGS = frozenset({
+    "--to", "--title", "--from", "--priority", "--format", "--body",
+})
+
+
+def _create_target(argv: list[str]) -> str:
+    """Extract the `--to <agent>` recipient from a `create` argv (or '')."""
+    skip = False
+    for idx, token in enumerate(argv[1:], start=1):
+        if skip:
+            skip = False
+            continue
+        if token == "--to":
+            return argv[idx + 1].strip() if idx + 1 < len(argv) else ""
+        if token.startswith("--to="):
+            return token.split("=", 1)[1].strip()
+        flag_name = token.split("=", 1)[0]
+        if token.startswith("--") and flag_name in _CREATE_VALUE_FLAGS and "=" not in token:
+            # `--flag value` consumes the next token; `--flag=value` does not.
+            skip = True
+    return ""
+
+
+def _rooms_acl_gate_create(home: str, peer_agent: str, argv: list[str]) -> tuple[bool, str]:
+    """Apply the rooms ACL to an iso-v2 (gateway) `create`. Returns (ok, reason).
+
+    `peer_agent` is the SO_PEERCRED OS-trusted actor (the gateway already
+    rewrote --from to it), so the ACL decision uses an un-spoofable sender —
+    the client-supplied --from/BRIDGE_AGENT_ID can never grant another agent's
+    room membership. Degrades to an ALLOW pass when:
+      - the rooms module is unavailable (pre-P1a / stripped install),
+      - rooms_acl is off (default — true no-op),
+      - no rooms are defined (back-compat),
+      - the create is exempt (self-message / target-unroomed).
+    A cross-room or fail-closed verdict returns (False, <acl reason>).
+    """
+    rooms = _load_rooms_common()
+    if rooms is None:
+        return True, "ok"
+    # The gateway peer is ALWAYS an OS-enforced iso actor, so this is a HARD path:
+    # read the mode STRICTLY. A genuinely ABSENT rooms.db -> off (back-compat). A
+    # present-but-UNREADABLE/corrupt rooms.db must NOT degrade to 'off' (that
+    # would silently drop a previously-enforced boundary — codex r1 BLOCKING);
+    # it fails CLOSED here.
+    try:
+        mode = rooms.rooms_acl_mode_strict()
+    except Exception:  # noqa: BLE001 - present-but-unreadable rooms.db under a hard actor
+        return False, "acl_fail_closed"
+    if mode != rooms.ACL_ENFORCE:
+        return True, "ok"
+    target = _create_target(argv)
+    if not target:
+        # No --to to gate (e.g. a malformed create); let the inner parser
+        # reject it normally rather than inventing an ACL denial.
+        return True, "ok"
+    try:
+        decision = rooms.acl_create_decision(
+            mode=mode,
+            # The gateway peer is an OS-enforced iso agent (SO_PEERCRED).
+            regime=rooms.ACTOR_ISO_ENFORCED,
+            actor=peer_agent,
+            target=target,
+            node="",
+        )
+    except Exception:  # noqa: BLE001 - decision fault under enforce -> fail closed
+        return False, "rooms_acl_unavailable"
+    if decision.outcome == "deny":
+        return False, decision.reason
+    return True, "ok"
 
 
 def now_iso() -> str:
@@ -262,10 +370,25 @@ def iter_requests(root: Path) -> list[Path]:
     return files
 
 
-def run_queue(queue_script: Path, argv: list[str], cwd: str | None) -> dict[str, Any]:
+def run_queue(
+    queue_script: Path,
+    argv: list[str],
+    cwd: str | None,
+    trusted_actor: str | None = None,
+) -> dict[str, Any]:
     child_env = os.environ.copy()
     child_env["BRIDGE_QUEUE_GATEWAY_SERVER"] = "1"
     child_env.pop("BRIDGE_GATEWAY_PROXY", None)
+    # Rooms ACL (P1b): pass the OS-derived trusted actor to the queue child as an
+    # env var the CLIENT cannot set (this is the gateway-server's own child env).
+    # bridge-queue.py:cmd_create uses BRIDGE_QUEUE_GATEWAY_ACTOR as the ISO-
+    # enforced sender, NEVER the client --from. We always (re)set it so a stale
+    # value inherited from the gateway process env cannot leak across requests:
+    # a real authenticated actor is set, an unauthenticated one is cleared.
+    if trusted_actor:
+        child_env["BRIDGE_QUEUE_GATEWAY_ACTOR"] = trusted_actor
+    else:
+        child_env.pop("BRIDGE_QUEUE_GATEWAY_ACTOR", None)
 
     proc = subprocess.run(
         [sys.executable, str(queue_script), *argv],
@@ -281,6 +404,31 @@ def run_queue(queue_script: Path, argv: list[str], cwd: str | None) -> dict[str,
         "stderr": proc.stderr,
         "processed_at": now_iso(),
     }
+
+
+def _file_request_owner_agent(path: Path) -> str:
+    """Map the request file's OWNER UID -> agent for the file transport (P1b).
+
+    The file transport's OS boundary is request-file OWNERSHIP: an iso agent can
+    only create request files it owns under its own per-agent requests/ dir
+    (mode 2770, owned by the iso UID). So the trusted actor is the file OWNER's
+    uid mapped through the roster uid->agent table — NOT the client-supplied
+    `agent`/`--from` field in the JSON (which an iso agent could forge to a room
+    peer). Returns '' when the owner uid maps to no iso agent (controller-owned
+    request, or roster probe unavailable) — the caller then withholds the
+    trusted-actor signal so cmd_create fails closed under enforce rather than
+    trusting a client id.
+    """
+    try:
+        owner_uid = path.stat().st_uid  # noqa: raw-pathlib-controller-only — controller-side gateway server reads the request-file owner uid (the file transport's OS boundary)
+    except OSError:
+        return ""
+    script_dir = Path(__file__).resolve().parent
+    try:
+        peer_map = _peer_map_from_roster(script_dir)
+    except SystemExit:
+        return ""
+    return peer_map.get(owner_uid, "")
 
 
 def handle_request(path: Path, queue_script: Path) -> int:
@@ -314,7 +462,36 @@ def handle_request(path: Path, queue_script: Path) -> int:
         return 1
 
     response = {"id": str(request.get("id", path.name.split(".", 1)[0]))}
-    response.update(run_queue(queue_script, argv, cwd))
+    # Rooms ACL (P1b) for the FILE transport: the trusted actor is the request
+    # file's OWNER uid (the file transport's OS boundary), NOT the client `agent`
+    # field. For a `create`, run the same authorize_and_rewrite the socket path
+    # uses so --from is rewritten to the owner-derived actor AND the rooms ACL
+    # gate fires; then hand that owner actor to the queue child as the trusted
+    # actor. When the owner maps to no iso agent (controller-owned request or no
+    # roster probe), we DO authorize as the controller-side `agent` for back-
+    # compat with the existing file transport, but withhold the trusted-actor
+    # signal so cmd_create's own resolve_os_actor / fail-closed contract applies.
+    trusted_actor: str | None = None
+    run_argv = argv
+    if argv and argv[0] == "create":
+        owner_agent = _file_request_owner_agent(path)
+        if owner_agent:
+            ok, reason, rewritten = authorize_and_rewrite(bridge_home(), owner_agent, argv)
+            if not ok:
+                response.update({
+                    "exit_code": 2,
+                    "stdout": "",
+                    "stderr": "queue gateway denied\n",
+                    "decision": "deny",
+                    "reason_code": _public_reason_code(reason),
+                    "processed_at": now_iso(),
+                })
+                atomic_write_json(path.parent.parent / "responses" / f"{response['id']}.json", response)
+                path.unlink(missing_ok=True)  # noqa: raw-pathlib-controller-only — controller-side gateway server consumes its own request file (mirrors the existing unlink below)
+                return 0
+            run_argv = rewritten
+            trusted_actor = owner_agent
+    response.update(run_queue(queue_script, run_argv, cwd, trusted_actor=trusted_actor))
     atomic_write_json(path.parent.parent / "responses" / f"{response['id']}.json", response)
     path.unlink(missing_ok=True)
     return 0
@@ -1056,6 +1233,13 @@ def authorize_and_rewrite(home: str, peer_agent: str, argv: list[str]) -> tuple[
         return False, "file_arg_denied", argv
 
     if subcmd == "create":
+        # Rooms ACL (P1b): gate the inter-agent create on shared-room membership
+        # when rooms_acl=enforce. The actor is the SO_PEERCRED peer_agent (NOT
+        # the client --from), so an iso agent cannot send as another room
+        # member. Default-off / no-rooms / exempt -> pass (no behavior change).
+        acl_ok, acl_reason = _rooms_acl_gate_create(home, peer_agent, argv)
+        if not acl_ok:
+            return False, acl_reason, argv
         return True, "ok", _set_option(argv, "--from", peer_agent)
     if subcmd in {"inbox", "find-open", "claim", "done"}:
         rewritten = _set_option(argv, "--agent", peer_agent)
@@ -1174,7 +1358,10 @@ def _handle_socket_request(
             return
         gateway_log(subcmd, peer_uid, peer_agent, "allow", reason, request_id)
         response = {"id": request_id}
-        response.update(run_queue(queue_script, rewritten, cwd))
+        # peer_agent is the SO_PEERCRED-authenticated actor; hand it to the queue
+        # child as the rooms-ACL trusted actor (P1b). For non-create subcommands
+        # this is harmless (cmd_create is the only consumer).
+        response.update(run_queue(queue_script, rewritten, cwd, trusted_actor=peer_agent))
         _safe_send_json(conn, response)
     except ValueError as exc:
         reason = "oversize_payload" if str(exc) == "oversize" else "invalid_payload"

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -168,32 +168,87 @@ def _load_rooms_common():
         return None
 
 
-def _rooms_acl_mode_or_fail_closed(rooms, hard: bool) -> str:
-    """Read the rooms_acl mode; on a present-but-unreadable db, fail closed iff hard.
+def _canonical_rooms_db_path() -> Path:
+    """The rooms.db CANONICALLY co-located with the REAL task DB being written.
+
+    SECURITY (P1b r3): the rooms ACL enforcement DB must be derived from the SAME
+    home as the task DB this create actually mutates — NOT from an independent,
+    caller-redirectable `BRIDGE_A2A_ROOMS_DB`. Otherwise a managed agent could
+    keep the task-DB env REAL while pointing the rooms-DB env at a self-owned fake
+    (seeded so it shares a room with the target) and drive the real queue past the
+    gate. By pinning the enforcement rooms.db to `<task_db_dir>/handoff/rooms.db`
+    (the layout `rooms_db_path()` uses for the default home), a fake rooms-DB env
+    can never be paired with a real task DB. Mirrors the live layout: the task DB
+    lives at `<state>/tasks.db` and rooms.db at `<state>/handoff/rooms.db`.
+    """
+    return get_db_path().parent / "handoff" / "rooms.db"
+
+
+def _rooms_acl_mode_or_fail_closed(rooms, hard: bool, db_path: Path) -> str:
+    """Read the rooms_acl mode from `db_path`; on unreadable, fail closed iff hard.
 
     `hard` is True for an OS-enforced (iso) or unresolved actor — for those, a
     present-but-unreadable rooms.db must be treated as ENFORCE (fail closed), NOT
     silently 'off' (the BLOCKING fail-open codex r1 flagged). For controller/
     shared regimes (no hard boundary) a db fault degrades to 'off' (controller is
     exempt anyway; shared is advisory). A genuinely ABSENT db is 'off' for all.
+    `db_path` is the CANONICAL rooms.db (r3) — never a caller-redirected one.
     """
     try:
-        return rooms.rooms_acl_mode_strict()
+        return rooms.rooms_acl_mode_strict(db_path)
     except Exception:  # noqa: BLE001 - present-but-unreadable rooms.db
         return rooms.ACL_ENFORCE if hard else rooms.ACL_OFF
 
 
-def _rooms_is_controller_process(rooms) -> bool:
-    """True iff this process runs as the controller (the rooms.db owner uid).
+def _queue_is_controller_process() -> bool:
+    """True iff this process OWNS the REAL task DB being written (the controller).
 
-    Wraps rooms.is_controller_process() (P1b r2: the un-forgeable proof that the
-    queue child was spawned BY the controller-run gateway, since the gateway does
-    not drop uid). Fails CLOSED (False) on any fault or if the module predates the
-    helper — an un-anchored process must never be treated as a gateway child.
+    SECURITY ANCHOR (P1b r3): the un-forgeable proof that the queue child was
+    spawned BY the controller-run gateway. The thing a queue create MUTATES is the
+    TASK DB, so the controller proof is anchored to the owner of THAT db
+    (`os.stat(get_db_path()).st_uid`), NOT the rooms.db (which is selectable via
+    `BRIDGE_A2A_ROOMS_DB` — the codex r3 bypass). The gateway runs as the
+    controller and spawns the queue child in-process (no uid drop), so a genuine
+    child owns the controller's task DB. A direct managed agent runs as the agent
+    uid and CANNOT chown the controller-owned task DB; pointing `BRIDGE_TASK_DB`
+    at a self-owned fake makes it "controller" of a fake queue with ZERO real
+    effect (the P1a invariant applied to the db actually being mutated).
+
+    Fails CLOSED (False) on any stat fault — an un-anchored process is never the
+    controller.
+
+    When the task DB does not yet exist (first create on a fresh install), anchor
+    to the owner of the directory it WILL be created in: the create writes the db
+    there, so its owner is the effective controller for this queue. A managed
+    agent cannot write into the controller-owned `<state>/` dir, so it cannot
+    satisfy this for the real task DB; pointing BRIDGE_TASK_DB at a self-owned dir
+    yields a fake queue with zero real effect.
+
+    TEST SEAM (structurally prod-inert): on a single-uid test host the smoke
+    cannot create a foreign-owned task DB, so a paired-flag override
+    (BRIDGE_QUEUE_TEST_NOT_CONTROLLER=1) lets it simulate a NON-controller managed
+    agent. It is honored ONLY behind the same proven-inert paired-flag gate the
+    rooms actor-auth seams use (rooms._test_uid_map_allowed: BRIDGE_ROOMS_ALLOW_
+    TEST_UID_MAP=1 AND BRIDGE_A2A_ALLOW_TEST_BIND=1 AND the process owns the
+    rooms.db) — production sets none of these, so it is never honored there.
     """
+    if os.environ.get("BRIDGE_QUEUE_TEST_NOT_CONTROLLER") == "1":
+        rooms = _load_rooms_common()
+        if rooms is not None:
+            try:
+                if rooms._test_uid_map_allowed():
+                    return False
+            except Exception:  # noqa: BLE001 - missing helper -> ignore the test override
+                pass
+    me = os.getuid()
+    db = get_db_path()
     try:
-        return bool(rooms.is_controller_process())
-    except Exception:  # noqa: BLE001 - missing helper / stat fault -> not the controller
+        return os.stat(str(db)).st_uid == me  # noqa: raw-pathlib-controller-only — controller anchor: owner of the REAL task DB being mutated
+    except OSError:
+        pass
+    try:
+        return os.stat(str(db.parent)).st_uid == me  # noqa: raw-pathlib-controller-only — task DB absent: anchor to the dir it will be created in
+    except OSError:
         return False
 
 
@@ -236,34 +291,40 @@ def _rooms_acl_check_create(actor: str, target: str) -> None:
     if rooms is None:
         return
 
+    # The CANONICAL enforcement rooms.db, derived from the REAL task-DB home — NOT
+    # a caller-redirectable BRIDGE_A2A_ROOMS_DB (codex r3): a managed agent could
+    # otherwise pair a real task DB with a self-owned fake rooms DB (seeded so it
+    # shares a room with the target) and drive the real queue past the gate. Every
+    # security read below (mode + membership) reads THIS db, never the env one.
+    canonical_rooms_db = _canonical_rooms_db_path()
+
     # Resolve the OS-enforced actor + regime FIRST (before the mode read), so a
     # present-but-unreadable rooms.db can fail CLOSED for a real iso actor rather
-    # than silently reading 'off'. This closes the BLOCKING fail-open where a
-    # previously-enforced DB that becomes unreadable/corrupt would be treated as
-    # ACL-off (codex r1). The actor source is NEVER the client --from.
-    # CRITICAL (P1b r2): the gateway-child env signal is only TRUSTWORTHY when
-    # THIS process actually runs as the controller. The queue gateway runs as the
-    # controller and spawns the queue child in-process (no uid drop), so a genuine
-    # gateway child has os.getuid() == controller. A DIRECT managed-agent
-    # invocation runs as the AGENT uid and can set BRIDGE_QUEUE_GATEWAY_SERVER /
-    # BRIDGE_QUEUE_GATEWAY_ACTOR in its OWN env — but it is NOT the controller, so
-    # we MUST NOT trust those ambient env vars from it (that was the codex r2
-    # impersonation bypass). Gate the gateway branch on the un-forgeable
-    # rooms.db-owner controller anchor; a non-controller process falls through to
-    # resolve_os_actor() = its REAL OS identity and cannot impersonate.
+    # than silently reading 'off' (codex r1). The actor source is NEVER the client
+    # --from.
+    # CRITICAL (P1b r2+r3): the gateway-child env signal is only TRUSTWORTHY when
+    # THIS process is the controller, anchored to the owner of the REAL TASK DB
+    # being written (the thing a queue create mutates) — NOT the rooms.db owner
+    # (which is selectable via BRIDGE_A2A_ROOMS_DB; that was the r3 bypass). The
+    # gateway runs as the controller and spawns the queue child in-process (no uid
+    # drop), so a genuine child owns the controller's task DB. A direct managed
+    # agent runs as the AGENT uid, cannot chown the controller-owned task DB, and
+    # so fails this anchor → falls to resolve_os_actor() = its REAL OS identity →
+    # cannot impersonate. Pointing BRIDGE_TASK_DB at a self-owned fake makes it
+    # "controller" of a fake queue with zero real effect (the P1a invariant).
     under_gateway = (
-        _running_under_queue_gateway_server() and _rooms_is_controller_process(rooms)
+        _running_under_queue_gateway_server() and _queue_is_controller_process()
     )
     if under_gateway:
-        # We ARE the controller AND the gateway flag is set, so the gateway
-        # authenticated the actor (socket: SO_PEERCRED; file: request-file owner
-        # uid) and passed it in BRIDGE_QUEUE_GATEWAY_ACTOR (its own child env).
-        # Use it as the actor, NEVER the client --from (args.actor). The REGIME is
-        # the host's OS-separation fact: a genuine iso-v2 host (un-spoofable
-        # passwd users) -> ISO_ENFORCED (hard); a shared-mode host (no iso users,
-        # where the gateway never legitimately runs) -> SHARED_ADVISORY, so even a
-        # controller-uid process with a forged gateway env cannot hard-block
-        # cross-team traffic (§14 R1: shared-mode stays advisory either way).
+        # We ARE the controller (own the real task DB) AND the gateway flag is set,
+        # so the gateway authenticated the actor (socket: SO_PEERCRED; file:
+        # request-file owner uid) and passed it in BRIDGE_QUEUE_GATEWAY_ACTOR (its
+        # own child env). Use it as the actor, NEVER the client --from (args.actor).
+        # The REGIME is the host's OS-separation fact: a genuine iso-v2 host
+        # (un-spoofable passwd users) -> ISO_ENFORCED (hard); a shared-mode host
+        # (no iso users, where the gateway never legitimately runs) ->
+        # SHARED_ADVISORY, so even a controller-uid process with a forged gateway
+        # env cannot hard-block cross-team traffic (§14 R1: advisory either way).
         gateway_hard = _rooms_host_has_iso_users(rooms)
         gateway_actor = os.environ.get("BRIDGE_QUEUE_GATEWAY_ACTOR", "").strip()  # noqa: iso-helper-boundary — gateway-server child env (controller-anchored), not an isolated-agent artifact
         if not gateway_actor:
@@ -273,7 +334,7 @@ def _rooms_acl_check_create(actor: str, target: str) -> None:
             # this fails CLOSED under enforce; on a shared-mode host there is no
             # hard boundary, so it is a no-op pass (advisory regime never blocks).
             if gateway_hard:
-                mode = _rooms_acl_mode_or_fail_closed(rooms, hard=True)
+                mode = _rooms_acl_mode_or_fail_closed(rooms, hard=True, db_path=canonical_rooms_db)
                 if mode == rooms.ACL_ENFORCE:
                     raise SystemExit(
                         "rooms ACL: create denied (gateway could not establish a "
@@ -293,16 +354,63 @@ def _rooms_acl_check_create(actor: str, target: str) -> None:
             return
         regime = auth.regime
         decision_actor = auth.agent
+        # SECURITY (P1b r4): resolve_os_actor()'s CONTROLLER verdict anchors to the
+        # owner of the ENV-selected rooms.db (`_controller_uid` -> stat(rooms_db_
+        # path())), which honors BRIDGE_A2A_ROOMS_DB. A managed agent could point
+        # that env at a SELF-OWNED/absent fake rooms.db so resolve_os_actor returns
+        # CONTROLLER (with agent == the caller-supplied --from), and
+        # acl_create_decision short-circuits to allow BEFORE any canonical
+        # membership read (the codex r4 bypass). Re-anchor the controller exemption
+        # to the REAL TASK DB owner (the db this create mutates, NOT env-selectable):
+        # the genuine controller (daemon/operator) owns the real task DB; a managed
+        # agent does not. If the CONTROLLER verdict is NOT backed by task-DB
+        # ownership it is forged — discard it AND the caller-supplied agent
+        # (auth.agent carried the requested --from), and decide by the REAL OS facts:
+        #   - iso host  -> the create can only be a managed iso agent or an
+        #                  unresolved process. Re-resolve with requested=None so no
+        #                  --from override leaks in; an iso agent is then decided by
+        #                  its real (OS-derived) membership, anything else is
+        #                  UNRESOLVED -> fail closed. Never a controller bypass.
+        #   - shared host-> SHARED_ADVISORY (no OS boundary; warn, never block).
+        if regime == rooms.ACTOR_CONTROLLER and not _queue_is_controller_process():
+            if _rooms_host_has_iso_users(rooms):
+                try:
+                    reauth = rooms.resolve_os_actor(None)  # NO requested override
+                except Exception:  # noqa: BLE001 - resolver fault -> fail closed below
+                    reauth = None
+                if reauth is not None and reauth.regime == rooms.ACTOR_ISO_ENFORCED:
+                    regime = rooms.ACTOR_ISO_ENFORCED
+                    decision_actor = reauth.agent  # the real OS-derived slug, not --from
+                else:
+                    regime = rooms.ACTOR_UNRESOLVED
+                    decision_actor = ""
+            else:
+                regime = rooms.ACTOR_SHARED_ADVISORY
 
     # A hard regime (iso/unresolved) demands a fail-closed mode read: a present-
     # but-unreadable rooms.db must NOT degrade to 'off'. Controller/shared regimes
     # have no hard boundary, so a db fault there degrades to a no-op (controller
-    # is exempt anyway; shared is advisory).
+    # is exempt anyway; shared is advisory). Read the CANONICAL db (r3).
     hard = regime in (rooms.ACTOR_ISO_ENFORCED, rooms.ACTOR_UNRESOLVED)
-    mode = _rooms_acl_mode_or_fail_closed(rooms, hard=hard)
+    mode = _rooms_acl_mode_or_fail_closed(rooms, hard=hard, db_path=canonical_rooms_db)
     if mode != rooms.ACL_ENFORCE:
         return
 
+    # The membership lookup reads the CANONICAL rooms.db (r3), opened here and
+    # passed explicitly so acl_create_decision cannot fall back to the env path.
+    try:
+        conn = rooms.open_rooms_readonly(canonical_rooms_db)
+    except Exception:  # noqa: BLE001 - present-but-unreadable canonical db
+        conn = None
+        if hard:
+            raise SystemExit(
+                "rooms ACL: create denied (canonical rooms.db unreadable under "
+                "enforce — failing closed) [rooms_acl=enforce]"
+            )
+        return
+    if conn is None:
+        # No canonical rooms.db -> no rooms in the REAL home -> back-compat allow.
+        return
     try:
         decision = rooms.acl_create_decision(
             mode=mode,
@@ -310,6 +418,7 @@ def _rooms_acl_check_create(actor: str, target: str) -> None:
             actor=decision_actor,
             target=(target or "").strip(),
             node="",
+            conn=conn,
         )
     except Exception:  # noqa: BLE001 - decision fault: fail closed only on a hard path
         if regime in (rooms.ACTOR_ISO_ENFORCED, rooms.ACTOR_UNRESOLVED):
@@ -318,6 +427,12 @@ def _rooms_acl_check_create(actor: str, target: str) -> None:
                 "under enforce — failing closed)"
             )
         return
+    finally:
+        try:
+            if conn is not None:
+                conn.close()
+        except Exception:  # noqa: BLE001
+            pass
 
     if decision.outcome == "deny":
         if decision.reason == rooms.ACL_DENY_FAIL_CLOSED:

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -144,6 +144,161 @@ def _gateway_server_authorize(task: sqlite3.Row, actor: str, op: str) -> None:
         )
 
 
+def _load_rooms_common():
+    """Import bridge_rooms_common from this script's dir (lazy, optional).
+
+    Returns the module or None. Loaded by EXACT path via importlib (mirroring
+    the operator_home SSOT loader) so a same-named module on sys.path cannot
+    shadow it. None when the rooms control plane is absent (pre-P1a / stripped
+    deploy) — the ACL gate then degrades to a no-op pass.
+    """
+    path = Path(__file__).resolve().parent / "bridge_rooms_common.py"
+    if not path.is_file():  # noqa: raw-pathlib-controller-only — exact-file import probe
+        return None
+    import importlib.util as _ilu
+
+    try:
+        spec = _ilu.spec_from_file_location("_agb_rooms_common", str(path))
+        if spec is None or spec.loader is None:
+            return None
+        mod = _ilu.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    except Exception:  # noqa: BLE001 - any fault -> no-op (pre-P1b behavior)
+        return None
+
+
+def _rooms_acl_mode_or_fail_closed(rooms, hard: bool) -> str:
+    """Read the rooms_acl mode; on a present-but-unreadable db, fail closed iff hard.
+
+    `hard` is True for an OS-enforced (iso) or unresolved actor — for those, a
+    present-but-unreadable rooms.db must be treated as ENFORCE (fail closed), NOT
+    silently 'off' (the BLOCKING fail-open codex r1 flagged). For controller/
+    shared regimes (no hard boundary) a db fault degrades to 'off' (controller is
+    exempt anyway; shared is advisory). A genuinely ABSENT db is 'off' for all.
+    """
+    try:
+        return rooms.rooms_acl_mode_strict()
+    except Exception:  # noqa: BLE001 - present-but-unreadable rooms.db
+        return rooms.ACL_ENFORCE if hard else rooms.ACL_OFF
+
+
+def _rooms_acl_check_create(actor: str, target: str) -> None:
+    """Rooms ACL (P1b) defense-in-depth + non-gateway gate for cmd_create.
+
+    The PRIMARY iso-v2 gate is the queue gateway (it derives the actor from
+    SO_PEERCRED and re-checks there). This function is the SECOND line + the
+    gate for the create paths that do NOT traverse the gateway:
+
+      - The gateway-server child (BRIDGE_QUEUE_GATEWAY_SERVER=1): `actor` is the
+        gateway-rewritten --from (the OS-trusted iso agent). We re-decide under
+        ISO_ENFORCED so a future gateway-authorizer bypass still cannot land a
+        cross-room create (mirrors _gateway_server_authorize for cancel/update).
+      - Direct creates (controller/daemon/cron, genuine shared-mode single-UID):
+        the OS actor + regime come from resolve_os_actor() — controller/daemon
+        creates are CONTROLLER (bypass), shared-mode is ADVISORY (warn, never
+        block), an un-establishable actor on an iso host is UNRESOLVED (deny).
+
+    Raises SystemExit on a HARD deny (cross-room under iso enforcement, or
+    fail-closed). Emits an advisory warning (no block) for shared-mode cross-
+    room. A no-op when rooms_acl is off / no rooms exist / the module is absent.
+    """
+    rooms = _load_rooms_common()
+    if rooms is None:
+        return
+
+    # Resolve the OS-enforced actor + regime FIRST (before the mode read), so a
+    # present-but-unreadable rooms.db can fail CLOSED for a real iso actor rather
+    # than silently reading 'off'. This closes the BLOCKING fail-open where a
+    # previously-enforced DB that becomes unreadable/corrupt would be treated as
+    # ACL-off (codex r1). The actor source is NEVER the client --from.
+    under_gateway = _running_under_queue_gateway_server()
+    if under_gateway:
+        # The gateway authenticated the actor (socket: SO_PEERCRED; file: request
+        # file owner uid) and passed it in BRIDGE_QUEUE_GATEWAY_ACTOR — an env var
+        # the CLIENT cannot set (it is the gateway-server's own child env). Use
+        # THAT as the ISO-enforced actor, NEVER the client --from (args.actor):
+        # the gateway is the only component that knows the real OS identity, so a
+        # managed agent passing --from <peer> cannot influence the decision.
+        gateway_actor = os.environ.get("BRIDGE_QUEUE_GATEWAY_ACTOR", "").strip()  # noqa: iso-helper-boundary — gateway-server child env, not an isolated-agent artifact
+        if not gateway_actor:
+            # Under the gateway server but NO authenticated actor was established
+            # (e.g. the file transport could not map the request-file owner to an
+            # iso agent). Do NOT fall back to the client --from. We must still
+            # learn whether enforcement is on: a missing actor + enforce -> fail
+            # closed; off -> pass. Read the mode strictly so an unreadable DB also
+            # fails closed for this un-authenticated gateway create.
+            mode = _rooms_acl_mode_or_fail_closed(rooms, hard=True)
+            if mode == rooms.ACL_ENFORCE:
+                raise SystemExit(
+                    "rooms ACL: create denied (gateway could not establish a "
+                    "trusted OS actor for this request — failing closed) "
+                    "[rooms_acl=enforce]"
+                )
+            return
+        regime = rooms.ACTOR_ISO_ENFORCED
+        decision_actor = gateway_actor
+    else:
+        # Not behind the gateway: resolve the actor from the PROCESS OS identity
+        # (never from --from / BRIDGE_AGENT_ID). Controller/daemon -> bypass;
+        # shared-mode -> advisory; iso-host-unresolved -> fail closed.
+        try:
+            auth = rooms.resolve_os_actor(actor or None)
+        except Exception:  # noqa: BLE001 - resolver fault -> no-op (avoid breaking direct creates)
+            return
+        regime = auth.regime
+        decision_actor = auth.agent
+
+    # A hard regime (iso/unresolved) demands a fail-closed mode read: a present-
+    # but-unreadable rooms.db must NOT degrade to 'off'. Controller/shared regimes
+    # have no hard boundary, so a db fault there degrades to a no-op (controller
+    # is exempt anyway; shared is advisory).
+    hard = regime in (rooms.ACTOR_ISO_ENFORCED, rooms.ACTOR_UNRESOLVED)
+    mode = _rooms_acl_mode_or_fail_closed(rooms, hard=hard)
+    if mode != rooms.ACL_ENFORCE:
+        return
+
+    try:
+        decision = rooms.acl_create_decision(
+            mode=mode,
+            regime=regime,
+            actor=decision_actor,
+            target=(target or "").strip(),
+            node="",
+        )
+    except Exception:  # noqa: BLE001 - decision fault: fail closed only on a hard path
+        if regime in (rooms.ACTOR_ISO_ENFORCED, rooms.ACTOR_UNRESOLVED):
+            raise SystemExit(
+                "rooms ACL: create denied (rooms control plane unavailable "
+                "under enforce — failing closed)"
+            )
+        return
+
+    if decision.outcome == "deny":
+        if decision.reason == rooms.ACL_DENY_FAIL_CLOSED:
+            raise SystemExit(
+                f"rooms ACL: create --to {target!r} denied ({decision.reason}): "
+                f"could not read the rooms membership for sender "
+                f"{decision_actor!r} under enforce (rooms.db unreadable / actor "
+                f"un-establishable) — failing closed. [rooms_acl=enforce]"
+            )
+        raise SystemExit(
+            f"rooms ACL: create --to {target!r} denied ({decision.reason}): "
+            f"sender {decision_actor!r} shares no enforced room with the "
+            f"recipient. Join a shared room (agb room) or have the operator "
+            f"run `agb room adopt-all`. [rooms_acl=enforce]"
+        )
+    if decision.outcome == "advisory":
+        print(
+            f"warning (rooms ACL advisory): create --to {target!r} from "
+            f"{decision_actor!r} crosses rooms; shared-mode installs cannot "
+            f"OS-authenticate the sender so this is NOT blocked. Run agents "
+            f"under linux-user isolation (iso v2) for a hard team boundary. "
+            f"[{decision.reason}]",
+            file=sys.stderr,
+        )
+
+
 def queue_gateway_float_env(name: str, default: str) -> str:
     raw = os.environ.get(name, default).strip()
     try:
@@ -908,6 +1063,12 @@ def maybe_cancel_cron_run(task: sqlite3.Row, current_ts: int) -> None:
 
 def cmd_create(args: argparse.Namespace) -> int:
     actor = args.actor or os.environ.get("USER", "unknown")
+    # Rooms ACL (P1b): gate the inter-agent create on shared-room membership
+    # when rooms_acl=enforce. No-op when off / no rooms / exempt (default-off
+    # is a true no-op). The actor used for the decision is OS-derived (the
+    # gateway-rewritten --from under the gateway-server, else resolve_os_actor)
+    # — never a raw client --from/BRIDGE_AGENT_ID.
+    _rooms_acl_check_create(actor, args.assigned_to)
     body_path = normalize_path(args.body_file)
     body_text = args.body
     created_ts = now_ts()

--- a/bridge-queue.py
+++ b/bridge-queue.py
@@ -183,6 +183,35 @@ def _rooms_acl_mode_or_fail_closed(rooms, hard: bool) -> str:
         return rooms.ACL_ENFORCE if hard else rooms.ACL_OFF
 
 
+def _rooms_is_controller_process(rooms) -> bool:
+    """True iff this process runs as the controller (the rooms.db owner uid).
+
+    Wraps rooms.is_controller_process() (P1b r2: the un-forgeable proof that the
+    queue child was spawned BY the controller-run gateway, since the gateway does
+    not drop uid). Fails CLOSED (False) on any fault or if the module predates the
+    helper — an un-anchored process must never be treated as a gateway child.
+    """
+    try:
+        return bool(rooms.is_controller_process())
+    except Exception:  # noqa: BLE001 - missing helper / stat fault -> not the controller
+        return False
+
+
+def _rooms_host_has_iso_users(rooms) -> bool:
+    """True iff the host has iso OS users (a genuine iso-v2 host, hard boundary).
+
+    Wraps rooms.host_has_iso_users(). On a fault / missing helper, fail CLOSED to
+    True (treat as a hard iso host): a hard regime under enforce denies cross-room
+    rather than silently advising — the safe default for the gateway path. (The
+    gateway only runs for iso agents, so True is also the common-case correct
+    answer.)
+    """
+    try:
+        return bool(rooms.host_has_iso_users())
+    except Exception:  # noqa: BLE001 - missing helper / passwd fault -> assume iso host (fail closed)
+        return True
+
+
 def _rooms_acl_check_create(actor: str, target: str) -> None:
     """Rooms ACL (P1b) defense-in-depth + non-gateway gate for cmd_create.
 
@@ -212,31 +241,47 @@ def _rooms_acl_check_create(actor: str, target: str) -> None:
     # than silently reading 'off'. This closes the BLOCKING fail-open where a
     # previously-enforced DB that becomes unreadable/corrupt would be treated as
     # ACL-off (codex r1). The actor source is NEVER the client --from.
-    under_gateway = _running_under_queue_gateway_server()
+    # CRITICAL (P1b r2): the gateway-child env signal is only TRUSTWORTHY when
+    # THIS process actually runs as the controller. The queue gateway runs as the
+    # controller and spawns the queue child in-process (no uid drop), so a genuine
+    # gateway child has os.getuid() == controller. A DIRECT managed-agent
+    # invocation runs as the AGENT uid and can set BRIDGE_QUEUE_GATEWAY_SERVER /
+    # BRIDGE_QUEUE_GATEWAY_ACTOR in its OWN env — but it is NOT the controller, so
+    # we MUST NOT trust those ambient env vars from it (that was the codex r2
+    # impersonation bypass). Gate the gateway branch on the un-forgeable
+    # rooms.db-owner controller anchor; a non-controller process falls through to
+    # resolve_os_actor() = its REAL OS identity and cannot impersonate.
+    under_gateway = (
+        _running_under_queue_gateway_server() and _rooms_is_controller_process(rooms)
+    )
     if under_gateway:
-        # The gateway authenticated the actor (socket: SO_PEERCRED; file: request
-        # file owner uid) and passed it in BRIDGE_QUEUE_GATEWAY_ACTOR — an env var
-        # the CLIENT cannot set (it is the gateway-server's own child env). Use
-        # THAT as the ISO-enforced actor, NEVER the client --from (args.actor):
-        # the gateway is the only component that knows the real OS identity, so a
-        # managed agent passing --from <peer> cannot influence the decision.
-        gateway_actor = os.environ.get("BRIDGE_QUEUE_GATEWAY_ACTOR", "").strip()  # noqa: iso-helper-boundary — gateway-server child env, not an isolated-agent artifact
+        # We ARE the controller AND the gateway flag is set, so the gateway
+        # authenticated the actor (socket: SO_PEERCRED; file: request-file owner
+        # uid) and passed it in BRIDGE_QUEUE_GATEWAY_ACTOR (its own child env).
+        # Use it as the actor, NEVER the client --from (args.actor). The REGIME is
+        # the host's OS-separation fact: a genuine iso-v2 host (un-spoofable
+        # passwd users) -> ISO_ENFORCED (hard); a shared-mode host (no iso users,
+        # where the gateway never legitimately runs) -> SHARED_ADVISORY, so even a
+        # controller-uid process with a forged gateway env cannot hard-block
+        # cross-team traffic (§14 R1: shared-mode stays advisory either way).
+        gateway_hard = _rooms_host_has_iso_users(rooms)
+        gateway_actor = os.environ.get("BRIDGE_QUEUE_GATEWAY_ACTOR", "").strip()  # noqa: iso-helper-boundary — gateway-server child env (controller-anchored), not an isolated-agent artifact
         if not gateway_actor:
             # Under the gateway server but NO authenticated actor was established
             # (e.g. the file transport could not map the request-file owner to an
-            # iso agent). Do NOT fall back to the client --from. We must still
-            # learn whether enforcement is on: a missing actor + enforce -> fail
-            # closed; off -> pass. Read the mode strictly so an unreadable DB also
-            # fails closed for this un-authenticated gateway create.
-            mode = _rooms_acl_mode_or_fail_closed(rooms, hard=True)
-            if mode == rooms.ACL_ENFORCE:
-                raise SystemExit(
-                    "rooms ACL: create denied (gateway could not establish a "
-                    "trusted OS actor for this request — failing closed) "
-                    "[rooms_acl=enforce]"
-                )
+            # iso agent). Do NOT fall back to the client --from. On an iso host
+            # this fails CLOSED under enforce; on a shared-mode host there is no
+            # hard boundary, so it is a no-op pass (advisory regime never blocks).
+            if gateway_hard:
+                mode = _rooms_acl_mode_or_fail_closed(rooms, hard=True)
+                if mode == rooms.ACL_ENFORCE:
+                    raise SystemExit(
+                        "rooms ACL: create denied (gateway could not establish a "
+                        "trusted OS actor for this request — failing closed) "
+                        "[rooms_acl=enforce]"
+                    )
             return
-        regime = rooms.ACTOR_ISO_ENFORCED
+        regime = rooms.ACTOR_ISO_ENFORCED if gateway_hard else rooms.ACTOR_SHARED_ADVISORY
         decision_actor = gateway_actor
     else:
         # Not behind the gateway: resolve the actor from the PROCESS OS identity

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -574,6 +574,37 @@ def cmd_adopt_all(args: argparse.Namespace) -> int:
     return 0
 
 
+def require_controller_actor(args: argparse.Namespace, action: str) -> None:
+    """Gate a config mutation (acl flip) to a proven controller/operator shell.
+
+    Flipping rooms_acl is an OPERATOR control-plane action, not an agent one
+    (design §14 R1 deliverable 5: only the controller/leader may flip it). The
+    actor-auth follows the same regime model as leader-auth:
+      - ISO_ENFORCED   : a managed iso agent is NOT the operator -> HARD deny
+                         (it must not be able to turn enforcement off/on).
+      - UNRESOLVED     : iso host, no trusted actor -> HARD deny (fail closed).
+      - CONTROLLER     : the proven operator shell (owns the rooms db) -> allow.
+      - SHARED_ADVISORY: no OS boundary exists anyway -> allow (the install has
+                         no hard agent separation to protect).
+    """
+    actor = rooms.resolve_os_actor(getattr(args, "as_agent", None))
+    if actor.regime == rooms.ACTOR_ISO_ENFORCED:
+        raise rooms.RoomsError(
+            f"{action} is an operator action: a managed iso agent "
+            f"(uid {actor.uid}) cannot change the rooms_acl mode — run it from "
+            "the controller/operator shell",
+            code="not_controller",
+        )
+    if actor.regime == rooms.ACTOR_UNRESOLVED:
+        raise rooms.RoomsError(
+            f"{action}: could not establish a trusted controller actor for uid "
+            f"{actor.uid} (linux-user isolation is active but this process is "
+            "neither an iso agent nor the controller) — failing closed",
+            code="actor_unresolved",
+        )
+    # CONTROLLER (proven operator) or SHARED_ADVISORY (no OS boundary) -> allow.
+
+
 def cmd_acl(args: argparse.Namespace) -> int:
     if args.mode is None:
         mode = rooms.rooms_acl_mode()
@@ -581,8 +612,36 @@ def cmd_acl(args: argparse.Namespace) -> int:
             out(json.dumps({"rooms_acl": mode}))
         else:
             info(f"rooms_acl mode: {mode} "
-                 "(P1a does not enforce; P1b consumes this)")
+                 "(enforced by the queue gate in P1b)")
         return 0
+    try:
+        require_controller_actor(args, "setting rooms_acl")
+    except rooms.RoomsError as exc:
+        return die(str(exc), code=1)
+    # Migration safety (design §14 R1 / deliverable 4): flipping to enforce with
+    # NO rooms defined would silently wall every inter-agent create. That is an
+    # operator-config error, not a valid state — refuse loudly and point at
+    # adopt-all, unless --force is given (an operator who really wants a fully
+    # locked-down install with only controller/daemon traffic).
+    if args.mode == rooms.ACL_ENFORCE and not getattr(args, "force", False):
+        ro = rooms.open_rooms_readonly()
+        has_room = False
+        if ro is not None:
+            try:
+                has_room = ro.execute("SELECT 1 FROM rooms LIMIT 1").fetchone() is not None
+            except Exception:  # noqa: BLE001
+                has_room = False
+            finally:
+                ro.close()
+        if not has_room:
+            return die(
+                "refusing to set rooms_acl=enforce with NO rooms defined: this "
+                "would block every inter-agent create. Run `agb room adopt-all` "
+                "first (creates a default room with every roster agent so no "
+                "agent is stranded), or pass --force to lock down anyway "
+                "(controller/daemon traffic still flows).",
+                code=1,
+            )
     conn = rooms.open_rooms()
     try:
         rooms.set_acl_mode(conn, args.mode)
@@ -597,7 +656,9 @@ def cmd_acl(args: argparse.Namespace) -> int:
     if args.json:
         out(json.dumps({"rooms_acl": args.mode}))
     else:
-        info(f"rooms_acl set to {args.mode} (not enforced in P1a)")
+        info(f"rooms_acl set to {args.mode} "
+             "(enforced by the queue gate: same-room creates allowed, "
+             "cross-room blocked under iso v2 / advisory in shared mode)")
     return 0
 
 
@@ -695,7 +756,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_acl = sub.add_parser("acl", help="show/set rooms_acl mode (off|enforce)")
     p_acl.add_argument("mode", nargs="?", choices=[rooms.ACL_OFF, rooms.ACL_ENFORCE],
                        default=None, help="set the mode; omit to show")
-    _add_common(p_acl, with_as=False)
+    p_acl.add_argument(
+        "--force", action="store_true",
+        help="allow setting enforce with no rooms defined (locks down all "
+             "inter-agent creates; controller/daemon traffic still flows)")
+    _add_common(p_acl)  # --as: honored only for controller/shared (iso ignored)
     p_acl.set_defaults(func=cmd_acl)
 
     return parser

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -1054,3 +1054,201 @@ def rooms_acl_mode(conn: Optional[sqlite3.Connection] = None) -> str:
         return ACL_OFF
     val = str(row["v"]).strip().lower()
     return val if val in (ACL_OFF, ACL_ENFORCE) else ACL_OFF
+
+
+def rooms_acl_mode_strict() -> str:
+    """Return the rooms_acl mode, but RAISE on a present-but-unreadable db.
+
+    The lenient `rooms_acl_mode()` collapses every fault to ACL_OFF (back-compat
+    for read paths that must degrade). That is a FAIL-OPEN for the P1b queue gate:
+    a previously-enforced rooms.db that becomes unreadable/corrupt would read
+    'off' and silently drop enforcement (codex r1 BLOCKING). This strict variant
+    distinguishes:
+      - db ABSENT (no rooms ever defined) -> ACL_OFF (legitimate back-compat).
+      - db present + readable             -> the stored mode.
+      - db present + UNREADABLE/corrupt   -> raises RoomsError so the queue gate
+                                             can fail CLOSED for a real iso actor.
+    """
+    conn = open_rooms_readonly()  # raises RoomsError on present-but-unreadable
+    if conn is None:
+        return ACL_OFF  # no db at all -> no rooms -> off (back-compat)
+    try:
+        row = conn.execute(
+            "SELECT v FROM rooms_acl_config WHERE k=?", (_ACL_CONFIG_KEY,)
+        ).fetchone()
+    except sqlite3.Error as exc:
+        # db opened read-only but the query failed (corrupt schema/page) -> a real
+        # fault, NOT "no rooms". Surface it so the gate fails closed.
+        raise RoomsError(
+            f"rooms.db present but rooms_acl_config is unreadable: {exc}",
+            code="rooms_acl_unreadable",
+        ) from exc
+    finally:
+        conn.close()
+    if row is None:
+        return ACL_OFF
+    val = str(row["v"]).strip().lower()
+    return val if val in (ACL_OFF, ACL_ENFORCE) else ACL_OFF
+
+
+# --------------------------------------------------------------------------
+# P1b — internal-queue rooms ACL decision (design §7 / §14 R1)
+# --------------------------------------------------------------------------
+#
+# This is the SINGLE source of truth for "may sender S create a durable queue
+# task addressed to recipient R?". It is consumed at the two real create
+# paths so the security logic lives in ONE tested place:
+#
+#   1. The iso-v2 queue GATEWAY (bridge-queue-gateway.py:authorize_and_rewrite)
+#      — the PRIMARY, OS-enforced gate. There `actor` is the SO_PEERCRED
+#      uid->agent (un-spoofable); the client-supplied --from/BRIDGE_AGENT_ID
+#      have already been rewritten away. regime = ACTOR_ISO_ENFORCED.
+#   2. bridge-queue.py:cmd_create — defense-in-depth + the NON-gateway paths
+#      (controller/daemon/cron creates that run as the controller UID; genuine
+#      shared-mode single-UID installs). There the actor + regime come from
+#      resolve_os_actor() (the OS identity), NEVER from a client flag.
+#
+# The decision is a PURE function of (mode, regime, actor, target, rooms.db).
+# It performs NO env/roster probing on the security path beyond the membership
+# lookup against the controller-owned rooms.db.
+
+# Audit reason codes (stable, public-safe — surfaced in gateway/queue logs).
+ACL_ALLOW_MODE_OFF = "acl_off"                  # default no-op pass
+ACL_ALLOW_CONTROLLER = "acl_controller_bypass"  # operator/daemon/cron/receiver
+ACL_ALLOW_SELF = "acl_self_message"             # actor == target
+ACL_ALLOW_NO_ROOMS = "acl_no_rooms"             # enforce but no rooms exist
+ACL_ALLOW_TARGET_UNROOMED = "acl_target_unroomed"  # target in no enforced room
+ACL_ALLOW_SHARED_ROOM = "acl_shared_room"       # actor+target co-inhabit a room
+ACL_DENY_CROSS_ROOM = "acl_denied"              # no shared room (hard block)
+ACL_DENY_FAIL_CLOSED = "acl_fail_closed"        # actor un-establishable / db fault
+ACL_ADVISORY_CROSS_ROOM = "acl_advisory_cross_room"  # shared-mode: warn, no block
+
+
+class AclDecision(NamedTuple):
+    """The rooms-ACL verdict for one `create --to <target>`.
+
+    `outcome` is one of "allow" | "deny" | "advisory":
+      - "allow"    : let the create proceed.
+      - "deny"     : HARD block (fail-closed) — only ever returned for a real,
+                     OS-enforced sender (ISO_ENFORCED) or an un-establishable
+                     trusted actor under enforce. Never returned in shared mode.
+      - "advisory" : shared-mode cross-room — audit/warn, but DO NOT block
+                     (same-UID agents are not OS-separable, §14 R1).
+    `reason` is one of the ACL_* codes above (audit + stderr). `shared` carries
+    the room ids actor+target co-inhabit (for the allow audit line).
+    """
+
+    outcome: str
+    reason: str
+    shared: list[str]
+
+
+def acl_create_decision(
+    *,
+    mode: str,
+    regime: str,
+    actor: str,
+    target: str,
+    node: str = "",
+    conn: Optional[sqlite3.Connection] = None,
+) -> AclDecision:
+    """Decide whether sender `actor` may `create --to target` under the rooms ACL.
+
+    Pure decision (design §14 R1). The caller MUST pass an OS-derived `actor` +
+    `regime` (resolve_os_actor / the gateway SO_PEERCRED peer). A client-supplied
+    --from/BRIDGE_AGENT_ID is NEVER an input here — that is the whole point.
+
+      - mode == off                  -> allow (true no-op; zero behavior change).
+      - regime == ACTOR_CONTROLLER   -> allow (operator/daemon/cron/receiver run
+                                        as the controller UID; non-spoofable —
+                                        this is the system/daemon exemption).
+      - regime == ACTOR_UNRESOLVED   -> deny, fail-closed (iso host but the actor
+                                        could not be OS-established).
+      - actor == target              -> allow (self-message).
+      - no enforced room exists      -> allow (back-compat; adopt-all is the
+                                        operator's migration to make this engage).
+      - target is in NO enforced room-> allow + audit (target is a non-room
+                                        participant; the gate is roster↔roster).
+      - actor+target share a room    -> allow.
+      - otherwise (cross-room):
+          * ISO_ENFORCED             -> deny (the hard team boundary).
+          * SHARED_ADVISORY          -> advisory (warn + audit, NO block).
+
+    `rooms.db` unreadable/absent under enforce for a real roster-agent actor
+    (ISO_ENFORCED) -> fail CLOSED (deny). For shared mode a db fault degrades to
+    advisory (no hard boundary is claimed there anyway).
+    """
+    if mode != ACL_ENFORCE:
+        return AclDecision("allow", ACL_ALLOW_MODE_OFF, [])
+
+    # Exemption 1: the controller / daemon / cron / receiver. All of these run
+    # as the controller OS UID (they own the rooms.db), so ACTOR_CONTROLLER is
+    # an OS fact, NOT a `--from daemon`/`cron:x` string a managed agent could
+    # type. This is the system/daemon/operator exemption, kept minimal + non-
+    # spoofable by construction (§14 R1 trusted-call-path bypass).
+    if regime == ACTOR_CONTROLLER:
+        return AclDecision("allow", ACL_ALLOW_CONTROLLER, [])
+
+    # Fail-closed: an iso host where the actor could not be OS-established. We
+    # must NOT fall back to a client-supplied id (that would be the spoof).
+    if regime == ACTOR_UNRESOLVED or not actor:
+        return AclDecision("deny", ACL_DENY_FAIL_CLOSED, [])
+
+    # Self-message is always fine (an agent talking to itself is not cross-team).
+    if actor == target:
+        return AclDecision("allow", ACL_ALLOW_SELF, [])
+
+    advisory = (regime == ACTOR_SHARED_ADVISORY)
+
+    own = False
+    if conn is None:
+        try:
+            conn = open_rooms_readonly()
+        except RoomsError:
+            # rooms.db present but unreadable -> a real fault. For an OS-enforced
+            # roster agent under enforce, fail CLOSED (never fall open). Shared
+            # mode has no hard boundary -> degrade to advisory.
+            if advisory:
+                return AclDecision("advisory", ACL_DENY_FAIL_CLOSED, [])
+            return AclDecision("deny", ACL_DENY_FAIL_CLOSED, [])
+        if conn is None:
+            # No rooms.db at all -> no rooms ever defined -> back-compat open.
+            return AclDecision("allow", ACL_ALLOW_NO_ROOMS, [])
+        own = True
+    try:
+        actor_rooms = members_for(conn, actor, node)
+        if not actor_rooms:
+            # The actor belongs to NO enforced room. With ≥1 room defined this
+            # is an operator-config gap (the actor was never adopted). Under
+            # enforce that is a loud config error for a real roster agent, not a
+            # silent allow: a room-less iso agent must not freely reach roomed
+            # agents. Shared mode stays advisory.
+            target_rooms_chk = members_for(conn, target, node)
+            if not target_rooms_chk:
+                # Neither party is in any room — the whole install has no rooms
+                # touching this pair -> back-compat open (nothing to enforce).
+                return AclDecision("allow", ACL_ALLOW_NO_ROOMS, [])
+            if advisory:
+                return AclDecision(
+                    "advisory", ACL_ADVISORY_CROSS_ROOM, [])
+            return AclDecision("deny", ACL_DENY_CROSS_ROOM, [])
+        target_rooms = members_for(conn, target, node)
+        if not target_rooms:
+            # The target participates in NO room (e.g. a system/admin agent that
+            # was never adopted). The gate is roster-agent <-> roster-agent; a
+            # non-room target is not a team peer to be walled off -> allow but
+            # audit so an operator can spot an un-adopted recipient.
+            return AclDecision("allow", ACL_ALLOW_TARGET_UNROOMED, [])
+        shared = sorted(set(actor_rooms) & set(target_rooms))
+        if shared:
+            return AclDecision("allow", ACL_ALLOW_SHARED_ROOM, shared)
+        if advisory:
+            return AclDecision("advisory", ACL_ADVISORY_CROSS_ROOM, [])
+        return AclDecision("deny", ACL_DENY_CROSS_ROOM, [])
+    except sqlite3.Error:
+        if advisory:
+            return AclDecision("advisory", ACL_DENY_FAIL_CLOSED, [])
+        return AclDecision("deny", ACL_DENY_FAIL_CLOSED, [])
+    finally:
+        if own and conn is not None:
+            conn.close()

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -533,15 +533,23 @@ def open_rooms() -> sqlite3.Connection:
     return _connect(rooms_db_path(), _ROOMS_SCHEMA)
 
 
-def open_rooms_readonly() -> Optional[sqlite3.Connection]:
+def open_rooms_readonly(
+    db_path: Optional[Path] = None,
+) -> Optional[sqlite3.Connection]:
     """Open an EXISTING rooms.db read-only; return None when it is absent.
 
     Used by read paths (the receiver seam, P1b's membership lookup) that must
     DEGRADE gracefully when no rooms have ever been defined — they must not
     create the db as a side effect of a lookup. A present-but-unreadable db
     raises RoomsError so a real fault is never silently treated as "no rooms".
+
+    `db_path` lets a SECURITY-sensitive caller pin the EXACT rooms.db to read
+    (P1b r3): the queue gate derives a CANONICAL rooms.db from the real task-DB
+    home and passes it here, so a caller-supplied `BRIDGE_A2A_ROOMS_DB` override
+    cannot point the enforcement lookup at a self-owned fake. When omitted, the
+    env-derived `rooms_db_path()` is used (the back-compat default).
     """
-    path = rooms_db_path()
+    path = db_path if db_path is not None else rooms_db_path()
     if not path.exists():
         return None
     try:
@@ -1091,7 +1099,7 @@ def rooms_acl_mode(conn: Optional[sqlite3.Connection] = None) -> str:
     return val if val in (ACL_OFF, ACL_ENFORCE) else ACL_OFF
 
 
-def rooms_acl_mode_strict() -> str:
+def rooms_acl_mode_strict(db_path: Optional[Path] = None) -> str:
     """Return the rooms_acl mode, but RAISE on a present-but-unreadable db.
 
     The lenient `rooms_acl_mode()` collapses every fault to ACL_OFF (back-compat
@@ -1103,8 +1111,12 @@ def rooms_acl_mode_strict() -> str:
       - db present + readable             -> the stored mode.
       - db present + UNREADABLE/corrupt   -> raises RoomsError so the queue gate
                                              can fail CLOSED for a real iso actor.
+
+    `db_path` pins the EXACT rooms.db (P1b r3): the queue gate passes the CANONICAL
+    rooms.db derived from the real task-DB home so a caller-redirected
+    `BRIDGE_A2A_ROOMS_DB` cannot point the mode read at a self-owned fake.
     """
-    conn = open_rooms_readonly()  # raises RoomsError on present-but-unreadable
+    conn = open_rooms_readonly(db_path)  # raises RoomsError on present-but-unreadable
     if conn is None:
         return ACL_OFF  # no db at all -> no rooms -> off (back-compat)
     try:

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -300,6 +300,41 @@ def _controller_uid() -> Optional[int]:
         return None
 
 
+def host_has_iso_users() -> bool:
+    """Public: True iff the host has any `agent-bridge-*` OS user (an iso-v2 host).
+
+    An un-spoofable passwd fact (wraps `_host_has_iso_users`). Used by the queue
+    gate to tell a genuine iso-v2 host (a hard team boundary exists) from a
+    shared-mode install (no iso users → no OS separation → ACL is advisory).
+    On a shared-mode host the gateway never legitimately runs, so even a forged
+    gateway-child env must be treated as advisory (§14 R1: shared-mode stays
+    advisory either way), never a hard block.
+    """
+    return _host_has_iso_users()
+
+
+def is_controller_process() -> bool:
+    """True iff THIS process runs as the controller (the rooms.db OWNER uid).
+
+    The un-forgeable anchor for "was this process spawned BY the controller?"
+    (P1b r2): the queue gateway runs as the controller and spawns the queue
+    child IN-PROCESS (no uid drop), so a gateway-spawned `bridge-queue.py` has
+    `os.getuid() == _controller_uid()`. A DIRECT managed-agent invocation runs
+    as the agent uid (`agent-bridge-<a>`), which is NOT the controller — so it
+    CANNOT forge gateway-child status by merely exporting
+    `BRIDGE_QUEUE_GATEWAY_SERVER`/`BRIDGE_QUEUE_GATEWAY_ACTOR`. The controller
+    identity is anchored to the rooms.db owner (`_controller_uid`), the same
+    un-spoofable anchor P1a uses (a managed agent cannot chown the controller-
+    owned rooms.db).
+
+    Returns False when the controller uid cannot be established (no rooms.db)
+    — a fail-closed default: an un-anchored process is never treated as the
+    controller.
+    """
+    controller = _controller_uid()
+    return controller is not None and os.getuid() == controller
+
+
 def default_os_user_slug(agent: str) -> str:
     """The default iso OS-user for `agent` — `agent-bridge-<slug>`.
 

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -170,6 +170,16 @@ add_required 1492-admin-dev-pair-workspace-v2
 # epoch + leader-auth + token-hash + rotate/--once + adopt-all + envelope
 # back-compat + receiver fail-closed teeth, and the rooms.db 0600 hygiene.
 add_required a2a-rooms-p1a
+# A2A rooms P1b: the internal-queue ACL ENFORCEMENT (design §14 R1). Gates an
+# inter-agent durable create on shared-room membership when rooms_acl=enforce,
+# using the OS-enforced sender (gateway SO_PEERCRED / resolve_os_actor), with a
+# default-off no-op. Lives in bridge_rooms_common.py (acl_create_decision),
+# bridge-queue-gateway.py (the primary iso gate), bridge-queue.py cmd_create
+# (defense-in-depth + non-gateway paths), and bridge-rooms.py (the controller-
+# gated acl flip). Pins the default-off no-op, same-room ALLOW, cross-room DENY,
+# the --from SPOOF rejection (both paths), fail-closed, controller exemption,
+# shared-mode advisory, and adopt-all->enforce strands-nobody teeth.
+add_required a2a-rooms-p1b-acl
 
 
 }
@@ -431,7 +441,7 @@ select_for_path() {
       # A2A rooms P1a: the template now advertises `room <create|...>`. Pull
       # a2a-rooms-p1a on every template edit so the `room` row + its
       # dispatcher arm (the `room)` case in agent-bridge) cannot drift apart.
-      add_required 1115-cli-usage-drift 1117-cli-help-universal-gate I-agent-description-roster a2a-rooms-p1a
+      add_required 1115-cli-usage-drift 1117-cli-help-universal-gate I-agent-description-roster a2a-rooms-p1a a2a-rooms-p1b-acl
       ;;
 
     bridge-setup.py|bridge-setup.sh|bridge-status.py|bridge-status.sh|lib/bridge-setup-wizard.sh)
@@ -751,6 +761,12 @@ select_for_path() {
       # on every bridge-queue.py move so a refactor cannot drift any of the six
       # call-sites' resulting paths off the canonical SSOT (byte-identical teeth).
       add_required 1497-p2-operator-home
+      # A2A rooms P1b (#1505 follow-on): bridge-queue.py cmd_create now carries
+      # the rooms ACL defense-in-depth + non-gateway gate (the direct create
+      # path). Pull a2a-rooms-p1b-acl on every bridge-queue.py move so the
+      # default-off no-op, the cross-room deny, and the --from spoof rejection
+      # on the direct create path cannot silently regress.
+      add_required a2a-rooms-p1b-acl
       add_integration integration-minimal
       ;;
 
@@ -791,7 +807,15 @@ select_for_path() {
       add_integration integration-minimal
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/install-handoffd-systemd.sh)
+    bridge-queue-gateway.py)
+      # A2A rooms P1b: the queue gateway's authorize_and_rewrite now applies the
+      # PRIMARY (iso-v2 SO_PEERCRED) rooms ACL gate to `create`. Any move to the
+      # gateway authorizer must re-run the queue suite + the P1b ACL teeth (the
+      # --from spoof rejection at the gateway is the security crux).
+      add_required queue a2a-rooms-p1b-acl
+      ;;
+
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -856,7 +880,7 @@ select_for_path() {
       # back-compat and the seam's fail-closed contract still holds. The
       # rooms control-plane modules (bridge-rooms.py / bridge_rooms_common.py)
       # and the rooms helper route here too via the path alternation above.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/smoke/a2a-rooms-p1b-acl-helper.py
+++ b/scripts/smoke/a2a-rooms-p1b-acl-helper.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Helper for the a2a-rooms-p1b-acl smoke (internal-queue rooms ACL).
+
+File-as-argv sidecar (NOT a heredoc into `python3 -`) so the smoke shell never
+trips the Bash 5.3.9 heredoc-stdin deadlock (footgun #11). Imports the real
+rooms / queue-gateway modules from the repo root so the smoke exercises the
+canonical decision function and the gateway authorize_and_rewrite gate.
+
+Subcommands (argv[1]):
+  gateway-authz <peer> <to> [--from <x>]
+      Run bridge-queue-gateway.authorize_and_rewrite() for a `create --to <to>`
+      with peer_agent=<peer> (the SO_PEERCRED OS actor). Prints one line:
+        ok=<0|1> reason=<code> from=<rewritten --from value or ->
+      This is the PRIMARY iso-v2 gate (peer_agent is un-spoofable; a client
+      --from in the argv is irrelevant — proves the spoof rejection).
+
+  decision <db> <mode> <regime> <actor> <target>
+      Call rooms.acl_create_decision() directly and print:
+        outcome=<allow|deny|advisory> reason=<code>
+      <regime> is one of: iso | controller | shared | unresolved.
+
+  json-field <key> <json>            print a top-level field from JSON
+  members-csv <show_or_adopt_json>   members as a comma-joined agent list
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+def _load_gateway():
+    path = REPO_ROOT / "bridge-queue-gateway.py"
+    spec = importlib.util.spec_from_file_location("bridge_queue_gateway", str(path))
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_REGIME = {
+    "iso": rooms.ACTOR_ISO_ENFORCED,
+    "controller": rooms.ACTOR_CONTROLLER,
+    "shared": rooms.ACTOR_SHARED_ADVISORY,
+    "unresolved": rooms.ACTOR_UNRESOLVED,
+}
+
+
+def cmd_gateway_authz(argv: list[str]) -> int:
+    # gateway-authz <peer> <to> [--from <x>] [--title T] [--body B]
+    peer = argv[0]
+    to = argv[1]
+    spoof_from = None
+    rest = argv[2:]
+    i = 0
+    while i < len(rest):
+        if rest[i] == "--from" and i + 1 < len(rest):
+            spoof_from = rest[i + 1]
+            i += 2
+            continue
+        i += 1
+    gw = _load_gateway()
+    home = os.environ.get("BRIDGE_HOME", str(Path.home() / ".agent-bridge"))  # noqa: iso-helper-boundary — test-only env read (smoke runner is the controller)
+    create_argv = ["create", "--to", to, "--title", "t", "--body", "b"]
+    if spoof_from is not None:
+        create_argv += ["--from", spoof_from]
+    ok, reason, rewritten = gw.authorize_and_rewrite(home, peer, create_argv)
+    from_val = "-"
+    if "--from" in rewritten:
+        idx = rewritten.index("--from")
+        if idx + 1 < len(rewritten):
+            from_val = rewritten[idx + 1]
+    print(f"ok={1 if ok else 0} reason={reason} from={from_val}")
+    return 0
+
+
+def cmd_decision(argv: list[str]) -> int:
+    # decision <db> <mode> <regime> <actor> <target>
+    db, mode, regime_key, actor, target = argv[0], argv[1], argv[2], argv[3], argv[4]
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary — test-only env set (smoke pins the isolated rooms.db)
+    regime = _REGIME[regime_key]
+    dec = rooms.acl_create_decision(
+        mode=mode, regime=regime, actor=actor, target=target, node="",
+    )
+    print(f"outcome={dec.outcome} reason={dec.reason}")
+    return 0
+
+
+def cmd_json_field(key: str, blob: str) -> int:
+    val = json.loads(blob).get(key)
+    if val is None:
+        return 1
+    print(val)
+    return 0
+
+
+def cmd_members_csv(blob: str) -> int:
+    members = json.loads(blob).get("members", [])
+    print(",".join(m.get("agent", "") for m in members))
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: a2a-rooms-p1b-acl-helper.py <subcommand> ...", file=sys.stderr)
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "gateway-authz":
+        return cmd_gateway_authz(rest)
+    if cmd == "decision":
+        return cmd_decision(rest)
+    if cmd == "json-field":
+        return cmd_json_field(rest[0], rest[1])
+    if cmd == "members-csv":
+        return cmd_members_csv(rest[0])
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/smoke/a2a-rooms-p1b-acl.sh
+++ b/scripts/smoke/a2a-rooms-p1b-acl.sh
@@ -57,9 +57,6 @@ unset BRIDGE_A2A_CONFIG || true
 # Paired test-seam flags, applied INLINE only by the *_as helpers (never exported).
 ROOMS_TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
 MY_UID="$(python3 -c 'import os; print(os.getuid())')"
-# A controller uid the current process is NOT (so is_controller_process() is
-# False for a simulated non-controller managed agent in the r2 forgery test).
-NOT_MY_UID="999998"
 
 room_cli_as() {
   # room_cli_as <agent> <args...> — run the rooms CLI as if the process OS user
@@ -194,36 +191,127 @@ test_spoof_from_rejected_direct() {
 # ---------------------------------------------------------------------------
 # r2 NEGATIVE CONTROL (the codex Phase-4 r2 BLOCKING): the gateway-child env
 # signal (BRIDGE_QUEUE_GATEWAY_SERVER / _ACTOR) is FORGEABLE by a direct managed
-# agent. cmd_create must trust it ONLY when this process is the controller (the
-# rooms.db owner uid) — the gateway runs as the controller and spawns the queue
-# child in-process (no uid drop), so a genuine child is the controller; a direct
-# managed (non-controller) agent that exports the flags is NOT, and must be
-# decided as its REAL OS actor. Without this, carol could impersonate bob.
+# agent. cmd_create must trust it ONLY when this process is the controller —
+# anchored (r3) to the owner of the REAL TASK DB being written. The gateway runs
+# as the controller and spawns the queue child in-process (no uid drop), so a
+# genuine child owns the task DB; a direct managed (non-controller) agent that
+# exports the flags does NOT, and must be decided as its REAL OS actor. The
+# paired-flag BRIDGE_QUEUE_TEST_NOT_CONTROLLER=1 simulates a non-controller agent
+# on a single-uid test host (production sets none of the paired flags).
 # ---------------------------------------------------------------------------
 test_r2_forged_gateway_env_rejected() {
-  # Simulate a direct iso agent 'carol' (NOT the controller: controller uid is a
-  # DIFFERENT uid) forging SERVER=1 + ACTOR=bob (bob shares team-a with the
-  # target alice; carol does not). The forged actor MUST be ignored -> decided as
-  # carol -> cross-room with alice -> DENIED. This is the full impersonation
-  # bypass codex r2 hermetically reproduced; it must now fail closed.
+  # Simulate a direct iso agent 'carol' (NOT the controller via the paired-flag
+  # seam) forging SERVER=1 + ACTOR=bob (bob shares team-a with the target alice;
+  # carol does not). The forged actor MUST be ignored -> decided as carol ->
+  # cross-room with alice -> DENIED. The impersonation bypass, reproduced.
   local err
   if err="$(env "${ROOMS_TEST_FLAGS[@]}" \
+               "BRIDGE_QUEUE_TEST_NOT_CONTROLLER=1" \
                "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-carol" \
                "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
-               "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${NOT_MY_UID}" \
                "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=bob" \
              python3 "$QUEUE_CLI" create --to alice --from bob --title t --body b 2>&1)"; then
     smoke_fail "r2 TEETH: a non-controller agent forging the gateway env MUST NOT impersonate (carol->alice via forged ACTOR=bob)"
   fi
   smoke_assert_contains "$err" "acl_denied" "r2: forged gateway env is ignored -> cross-room deny"
   smoke_assert_contains "$err" "'carol'" "r2: decided as the REAL OS actor (carol), not the forged ACTOR=bob"
-  # Positive control: the SAME process, but as the controller uid, IS trusted ->
-  # ACTOR=alice -> bob (shared) ALLOWED. Proves the gate is not a blanket deny.
+  # Positive control: the SAME process AS THE CONTROLLER (owns the real task DB)
+  # IS trusted -> ACTOR=alice -> bob (shared) ALLOWED. Not a blanket deny.
   env "${ROOMS_TEST_FLAGS[@]}" \
-      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
       "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=alice" \
     python3 "$QUEUE_CLI" create --to bob --from carol --title t --body b >/dev/null 2>&1 \
-    || smoke_fail "r2 control: a GENUINE gateway child (controller uid) must trust the gateway actor (alice->bob ALLOW)"
+    || smoke_fail "r2 control: a GENUINE gateway child (owns the task DB) must trust the gateway actor (alice->bob ALLOW)"
+}
+
+# ---------------------------------------------------------------------------
+# r3 NEGATIVE CONTROL (the codex Phase-4 r3 BLOCKING): the controller anchor and
+# the membership lookup must read the rooms.db CANONICALLY co-located with the
+# REAL task DB — NOT a caller-redirectable BRIDGE_A2A_ROOMS_DB. Otherwise a
+# managed agent keeps the task-DB env REAL while pointing the rooms-DB env at a
+# self-owned FAKE (seeded so it shares a room with the target) and drives the
+# real queue past the gate.
+# ---------------------------------------------------------------------------
+test_r3_fake_rooms_db_ignored() {
+  # Build a self-owned FAKE rooms.db where carol DOES share a room with alice
+  # (the exploit bait). Then a gateway create with the REAL task-DB env but the
+  # FAKE rooms-DB env: the gate must read the CANONICAL rooms.db (co-located with
+  # the real task DB, where carol does NOT share alice) -> DENIED. If the fake
+  # were honored this would be ALLOWED (the codex r3 bypass).
+  local fake_db="$SMOKE_TMP_ROOT/fake-rooms.db"
+  rm -f "$fake_db"
+  local fk fl
+  fk="$(env "${ROOMS_TEST_FLAGS[@]}" "BRIDGE_A2A_ROOMS_DB=$fake_db" \
+         "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-carol" \
+         python3 "$ROOMS_CLI" create --name fakeroom --json 2>/dev/null)"
+  local fr; fr="$(json_field room_id "$fk")"; fl="$(json_field invite_link "$fk")"
+  env "${ROOMS_TEST_FLAGS[@]}" "BRIDGE_A2A_ROOMS_DB=$fake_db" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-alice" \
+    python3 "$ROOMS_CLI" join "$fl" >/dev/null 2>&1
+  env "${ROOMS_TEST_FLAGS[@]}" "BRIDGE_A2A_ROOMS_DB=$fake_db" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-carol" \
+    python3 "$ROOMS_CLI" approve "$fr" alice >/dev/null 2>&1
+  env "${ROOMS_TEST_FLAGS[@]}" "BRIDGE_A2A_ROOMS_DB=$fake_db" \
+    python3 "$ROOMS_CLI" acl enforce >/dev/null 2>&1
+  # Exploit: real task DB (the smoke's, which the runner owns = controller) +
+  # FAKE rooms-DB env + gateway create as carol -> alice. Canonical read denies.
+  local err
+  if err="$(env "${ROOMS_TEST_FLAGS[@]}" \
+               "BRIDGE_A2A_ROOMS_DB=$fake_db" \
+               "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
+               "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=carol" \
+             python3 "$QUEUE_CLI" create --to alice --from carol --title t --body b 2>&1)"; then
+    smoke_fail "r3 TEETH: a self-owned FAKE rooms-DB env (carol shares alice) must NOT drive the real queue gate (carol->alice)"
+  fi
+  smoke_assert_contains "$err" "acl_denied" \
+    "r3: the enforcement rooms.db is the CANONICAL one (real home), not the redirected fake"
+  smoke_assert_contains "$err" "'carol'" "r3: decided against the canonical rooms.db (carol not sharing alice)"
+}
+
+# ---------------------------------------------------------------------------
+# r4 NEGATIVE CONTROL (the codex Phase-4 r4 BLOCKING): the DIRECT (non-gateway)
+# fallback can self-promote to ACTOR_CONTROLLER through resolve_os_actor(), whose
+# controller verdict anchors to the ENV-selected rooms.db owner (BRIDGE_A2A_ROOMS_
+# DB). A managed agent points the rooms-DB env at a self-owned/absent fake →
+# resolve_os_actor returns CONTROLLER → acl_create_decision short-circuits to
+# allow BEFORE the canonical membership read. The fix re-anchors the controller
+# exemption to the REAL TASK DB owner: a non-task-DB-owner CONTROLLER verdict is
+# forged → discarded (and the caller-supplied --from with it) → decided by the
+# REAL OS facts against the canonical rooms.db.
+# ---------------------------------------------------------------------------
+test_r4_direct_fallback_fake_controller_rejected() {
+  # Managed iso 'carol' (NOT the real task-DB owner) on the DIRECT path (no
+  # gateway flag) points the rooms-DB env at an ABSENT fake and passes --from bob.
+  # resolve_os_actor would return CONTROLLER off the fake rooms-DB owner; the fix
+  # re-anchors to the real task DB → not owned → forged controller discarded →
+  # re-resolved as the REAL OS actor (carol) → canonical: carol not in alice's
+  # room → DENIED. The forged --from bob is NOT honored.
+  local err
+  if err="$(env "${ROOMS_TEST_FLAGS[@]}" \
+               "BRIDGE_QUEUE_TEST_NOT_CONTROLLER=1" \
+               "BRIDGE_A2A_ROOMS_DB=$SMOKE_TMP_ROOT/r4-absent/fake.db" \
+               "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-carol" \
+               "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
+             python3 "$QUEUE_CLI" create --to alice --from bob --title t --body b 2>&1)"; then
+    smoke_fail "r4 TEETH: a direct managed agent forging CONTROLLER via a fake rooms-DB must NOT bypass (carol->alice)"
+  fi
+  smoke_assert_contains "$err" "acl_denied" \
+    "r4: a forged CONTROLLER (fake rooms-DB owner) is discarded; decided by real OS membership"
+  smoke_assert_contains "$err" "'carol'" "r4: decided as the REAL OS actor (carol), not the forged --from bob"
+  # Non-iso force-controller variant: resolve returns CONTROLLER via the gated
+  # test controller-uid match + non-iso, but the task DB is not owned -> the
+  # forged controller is discarded -> UNRESOLVED -> fail closed (DENY).
+  if err="$(env "${ROOMS_TEST_FLAGS[@]}" \
+               "BRIDGE_QUEUE_TEST_NOT_CONTROLLER=1" \
+               "BRIDGE_A2A_ROOMS_DB=$SMOKE_TMP_ROOT/r4-self/fake.db" \
+               "BRIDGE_ROOMS_TEST_ISO_USER=" \
+               "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
+               "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+             python3 "$QUEUE_CLI" create --to alice --from bob --title t --body b 2>&1)"; then
+    smoke_fail "r4 TEETH: a non-iso forged CONTROLLER without task-DB ownership must FAIL CLOSED"
+  fi
+  smoke_assert_contains "$err" "fail" \
+    "r4: a non-iso forged controller -> UNRESOLVED fail-closed (no membership bypass)"
 }
 
 test_r2_shared_mode_forged_env_advisory() {
@@ -233,7 +321,7 @@ test_r2_shared_mode_forged_env_advisory() {
   # The create SUCCEEDS (advisory regime warns, never blocks).
   env "${ROOMS_TEST_FLAGS[@]}" \
       "BRIDGE_ROOMS_TEST_ISO_USER=" \
-      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=0" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=0" \
       "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=bob" \
     python3 "$QUEUE_CLI" create --to carol --from bob --title t --body b >/dev/null 2>&1 \
     || smoke_fail "r2 shared-mode: a forged gateway env on a non-iso host must stay ADVISORY (no hard block)"
@@ -245,15 +333,15 @@ test_r2_shared_mode_forged_env_advisory() {
 # This closes the file-transport spoof: the file gateway does NOT rewrite
 # --from, so cmd_create must NOT trust args.actor — only the gateway env var.
 # ---------------------------------------------------------------------------
-# A GENUINE gateway child: this process IS the controller (controller uid ==
-# MY_UID, the rooms.db owner) on an iso host. Only then is the gateway-child env
-# signal trusted (r2). queue_create_gw_child <gateway_actor|""> <create-args...>.
+# A GENUINE gateway child: this process IS the controller — it owns the REAL task
+# DB (the smoke runner created it), the r3 anchor. On an iso host the gateway-
+# child env signal is then trusted. queue_create_gw_child <gw_actor|""> <args...>.
 queue_create_gw_child() {
   local gw_actor="$1"; shift
   local actor_env=()
   [[ -n "$gw_actor" ]] && actor_env=("BRIDGE_QUEUE_GATEWAY_ACTOR=${gw_actor}")
   env "${ROOMS_TEST_FLAGS[@]}" \
-      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
       "BRIDGE_QUEUE_GATEWAY_SERVER=1" "${actor_env[@]}" \
     python3 "$QUEUE_CLI" create "$@"
 }
@@ -295,7 +383,7 @@ test_gateway_server_corrupt_db_fails_closed() {
   printf 'corrupt not-sqlite %.0s' {1..60} >"$corrupt_home/state/handoff/rooms.db"
   local err
   if err="$(env "${ROOMS_TEST_FLAGS[@]}" \
-               "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+               "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
                "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=alice" \
                BRIDGE_HOME="$corrupt_home" BRIDGE_STATE_DIR="$corrupt_home/state" \
                BRIDGE_TASK_DB="$corrupt_home/state/tasks.db" \
@@ -437,6 +525,8 @@ smoke_run "enforce cross-room DENY (fail-closed, audited reason; gateway + direc
 smoke_run "SPOOF teeth: --from rejected at the gateway (OS peer decides)" test_spoof_from_rejected_gateway
 smoke_run "SPOOF teeth: --from rejected on the direct path (resolve_os_actor)" test_spoof_from_rejected_direct
 smoke_run "r2 TEETH: forged gateway env by a non-controller agent is IGNORED (impersonation bypass closed)" test_r2_forged_gateway_env_rejected
+smoke_run "r3 TEETH: a self-owned FAKE rooms-DB env cannot drive the real queue gate (canonical rooms.db)" test_r3_fake_rooms_db_ignored
+smoke_run "r4 TEETH: direct-fallback forged CONTROLLER via fake rooms-DB is rejected (task-DB-owner anchor)" test_r4_direct_fallback_fake_controller_rejected
 smoke_run "r2: shared-mode forged gateway env stays ADVISORY (no hard block)" test_r2_shared_mode_forged_env_advisory
 smoke_run "gateway-server uses BRIDGE_QUEUE_GATEWAY_ACTOR, NOT client --from (file-xport spoof closed)" test_gateway_server_trusted_actor_env
 smoke_run "gateway-server with NO trusted actor FAILS CLOSED under enforce (file-xport BLOCKING)" test_gateway_server_no_actor_fails_closed

--- a/scripts/smoke/a2a-rooms-p1b-acl.sh
+++ b/scripts/smoke/a2a-rooms-p1b-acl.sh
@@ -56,6 +56,10 @@ unset BRIDGE_A2A_CONFIG || true
 
 # Paired test-seam flags, applied INLINE only by the *_as helpers (never exported).
 ROOMS_TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+MY_UID="$(python3 -c 'import os; print(os.getuid())')"
+# A controller uid the current process is NOT (so is_controller_process() is
+# False for a simulated non-controller managed agent in the r2 forgery test).
+NOT_MY_UID="999998"
 
 room_cli_as() {
   # room_cli_as <agent> <args...> — run the rooms CLI as if the process OS user
@@ -188,35 +192,93 @@ test_spoof_from_rejected_direct() {
 }
 
 # ---------------------------------------------------------------------------
+# r2 NEGATIVE CONTROL (the codex Phase-4 r2 BLOCKING): the gateway-child env
+# signal (BRIDGE_QUEUE_GATEWAY_SERVER / _ACTOR) is FORGEABLE by a direct managed
+# agent. cmd_create must trust it ONLY when this process is the controller (the
+# rooms.db owner uid) — the gateway runs as the controller and spawns the queue
+# child in-process (no uid drop), so a genuine child is the controller; a direct
+# managed (non-controller) agent that exports the flags is NOT, and must be
+# decided as its REAL OS actor. Without this, carol could impersonate bob.
+# ---------------------------------------------------------------------------
+test_r2_forged_gateway_env_rejected() {
+  # Simulate a direct iso agent 'carol' (NOT the controller: controller uid is a
+  # DIFFERENT uid) forging SERVER=1 + ACTOR=bob (bob shares team-a with the
+  # target alice; carol does not). The forged actor MUST be ignored -> decided as
+  # carol -> cross-room with alice -> DENIED. This is the full impersonation
+  # bypass codex r2 hermetically reproduced; it must now fail closed.
+  local err
+  if err="$(env "${ROOMS_TEST_FLAGS[@]}" \
+               "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-carol" \
+               "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" \
+               "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${NOT_MY_UID}" \
+               "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=bob" \
+             python3 "$QUEUE_CLI" create --to alice --from bob --title t --body b 2>&1)"; then
+    smoke_fail "r2 TEETH: a non-controller agent forging the gateway env MUST NOT impersonate (carol->alice via forged ACTOR=bob)"
+  fi
+  smoke_assert_contains "$err" "acl_denied" "r2: forged gateway env is ignored -> cross-room deny"
+  smoke_assert_contains "$err" "'carol'" "r2: decided as the REAL OS actor (carol), not the forged ACTOR=bob"
+  # Positive control: the SAME process, but as the controller uid, IS trusted ->
+  # ACTOR=alice -> bob (shared) ALLOWED. Proves the gate is not a blanket deny.
+  env "${ROOMS_TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+      "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=alice" \
+    python3 "$QUEUE_CLI" create --to bob --from carol --title t --body b >/dev/null 2>&1 \
+    || smoke_fail "r2 control: a GENUINE gateway child (controller uid) must trust the gateway actor (alice->bob ALLOW)"
+}
+
+test_r2_shared_mode_forged_env_advisory() {
+  # Shared-mode edge: a single-UID install where the managed agent IS the
+  # controller uid (no OS separation) but the host has NO iso users. A forged
+  # gateway env must NOT yield a HARD block — §14 R1 keeps shared-mode advisory.
+  # The create SUCCEEDS (advisory regime warns, never blocks).
+  env "${ROOMS_TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=" \
+      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=0" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+      "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=bob" \
+    python3 "$QUEUE_CLI" create --to carol --from bob --title t --body b >/dev/null 2>&1 \
+    || smoke_fail "r2 shared-mode: a forged gateway env on a non-iso host must stay ADVISORY (no hard block)"
+}
+
+# ---------------------------------------------------------------------------
 # gateway-server trusted-actor env: cmd_create under BRIDGE_QUEUE_GATEWAY_SERVER
 # uses BRIDGE_QUEUE_GATEWAY_ACTOR (the gateway-set OS identity), NEVER --from.
 # This closes the file-transport spoof: the file gateway does NOT rewrite
 # --from, so cmd_create must NOT trust args.actor — only the gateway env var.
 # ---------------------------------------------------------------------------
+# A GENUINE gateway child: this process IS the controller (controller uid ==
+# MY_UID, the rooms.db owner) on an iso host. Only then is the gateway-child env
+# signal trusted (r2). queue_create_gw_child <gateway_actor|""> <create-args...>.
+queue_create_gw_child() {
+  local gw_actor="$1"; shift
+  local actor_env=()
+  [[ -n "$gw_actor" ]] && actor_env=("BRIDGE_QUEUE_GATEWAY_ACTOR=${gw_actor}")
+  env "${ROOMS_TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+      "BRIDGE_QUEUE_GATEWAY_SERVER=1" "${actor_env[@]}" \
+    python3 "$QUEUE_CLI" create "$@"
+}
+
 test_gateway_server_trusted_actor_env() {
-  # SERVER=1 + GATEWAY_ACTOR=alice + a spoofed --from carol -> decided as alice.
-  # alice->carol is cross-room -> DENIED. The --from carol must NOT smuggle.
+  # GENUINE gateway child (controller uid, iso host) + GATEWAY_ACTOR=alice + a
+  # spoofed --from carol -> decided as alice. alice->carol cross-room -> DENIED.
   local err
-  if err="$(env BRIDGE_QUEUE_GATEWAY_SERVER=1 BRIDGE_QUEUE_GATEWAY_ACTOR=alice \
-            python3 "$QUEUE_CLI" create --to carol --from carol --title t --body b 2>&1)"; then
+  if err="$(queue_create_gw_child alice --to carol --from carol --title t --body b 2>&1)"; then
     smoke_fail "gateway-server: GATEWAY_ACTOR=alice + --from carol must be DENIED to carol"
   fi
   smoke_assert_contains "$err" "acl_denied" "gateway-server: trusted env actor decides (not --from)"
   smoke_assert_contains "$err" "'alice'" "gateway-server: denial names the gateway-set actor (alice)"
   # Positive control: same env, target=bob (shared with alice) -> ALLOWED.
-  env BRIDGE_QUEUE_GATEWAY_SERVER=1 BRIDGE_QUEUE_GATEWAY_ACTOR=alice \
-    python3 "$QUEUE_CLI" create --to bob --from carol --title t --body b >/dev/null 2>&1 \
+  queue_create_gw_child alice --to bob --from carol --title t --body b >/dev/null 2>&1 \
     || smoke_fail "gateway-server: GATEWAY_ACTOR=alice -> alice->bob (shared room) must ALLOW"
 }
 
 test_gateway_server_no_actor_fails_closed() {
-  # SERVER=1 but NO BRIDGE_QUEUE_GATEWAY_ACTOR (e.g. file transport could not map
-  # the request-file owner to an iso agent). cmd_create must NOT fall back to the
-  # client --from -> FAIL CLOSED under enforce. This is the file-transport
-  # BLOCKING fix (codex r1): an unauthenticated gateway create is denied.
+  # GENUINE gateway child but NO BRIDGE_QUEUE_GATEWAY_ACTOR (e.g. file transport
+  # could not map the request-file owner to an iso agent). cmd_create must NOT
+  # fall back to the client --from -> FAIL CLOSED under enforce (file-transport
+  # BLOCKING fix, codex r1): an unauthenticated gateway create is denied.
   local err
-  if err="$(env BRIDGE_QUEUE_GATEWAY_SERVER=1 \
-            python3 "$QUEUE_CLI" create --to carol --from carol --title t --body b 2>&1)"; then
+  if err="$(queue_create_gw_child "" --to carol --from carol --title t --body b 2>&1)"; then
     smoke_fail "gateway-server with NO trusted actor must FAIL CLOSED under enforce"
   fi
   smoke_assert_contains "$err" "failing closed" \
@@ -224,19 +286,21 @@ test_gateway_server_no_actor_fails_closed() {
 }
 
 test_gateway_server_corrupt_db_fails_closed() {
-  # SERVER=1 + GATEWAY_ACTOR=alice + a present-but-CORRUPT rooms.db. The mode
-  # read must NOT silently degrade to 'off' (the BLOCKING fail-open codex r1
-  # flagged) — an iso actor under a corrupt db FAILS CLOSED. Test against the
-  # REAL cmd_create mode-read path (not just the decision fn).
+  # GENUINE gateway child + GATEWAY_ACTOR=alice + a present-but-CORRUPT rooms.db.
+  # The mode read must NOT silently degrade to 'off' (the BLOCKING fail-open
+  # codex r1 flagged) — an iso actor under a corrupt db FAILS CLOSED. The corrupt
+  # db is the controller's (we own it), so is_controller_process() is True here.
   local corrupt_home="$SMOKE_TMP_ROOT/corruptdb-home"
   mkdir -p "$corrupt_home/state/handoff"
   printf 'corrupt not-sqlite %.0s' {1..60} >"$corrupt_home/state/handoff/rooms.db"
   local err
-  if err="$(env BRIDGE_QUEUE_GATEWAY_SERVER=1 BRIDGE_QUEUE_GATEWAY_ACTOR=alice \
-            BRIDGE_HOME="$corrupt_home" BRIDGE_STATE_DIR="$corrupt_home/state" \
-            BRIDGE_TASK_DB="$corrupt_home/state/tasks.db" \
-            BRIDGE_A2A_ROOMS_DB="$corrupt_home/state/handoff/rooms.db" \
-            python3 "$QUEUE_CLI" create --to bob --title t --body b 2>&1)"; then
+  if err="$(env "${ROOMS_TEST_FLAGS[@]}" \
+               "BRIDGE_ROOMS_TEST_HOST_HAS_ISO=1" "BRIDGE_ROOMS_TEST_CONTROLLER_UID=${MY_UID}" \
+               "BRIDGE_QUEUE_GATEWAY_SERVER=1" "BRIDGE_QUEUE_GATEWAY_ACTOR=alice" \
+               BRIDGE_HOME="$corrupt_home" BRIDGE_STATE_DIR="$corrupt_home/state" \
+               BRIDGE_TASK_DB="$corrupt_home/state/tasks.db" \
+               BRIDGE_A2A_ROOMS_DB="$corrupt_home/state/handoff/rooms.db" \
+             python3 "$QUEUE_CLI" create --to bob --title t --body b 2>&1)"; then
     smoke_fail "gateway-server: a corrupt rooms.db under enforce must FAIL CLOSED, not read off"
   fi
   smoke_assert_contains "$err" "fail" \
@@ -372,6 +436,8 @@ smoke_run "enforce same-room ALLOW (gateway + direct)" test_enforce_same_room_al
 smoke_run "enforce cross-room DENY (fail-closed, audited reason; gateway + direct)" test_enforce_cross_room_deny
 smoke_run "SPOOF teeth: --from rejected at the gateway (OS peer decides)" test_spoof_from_rejected_gateway
 smoke_run "SPOOF teeth: --from rejected on the direct path (resolve_os_actor)" test_spoof_from_rejected_direct
+smoke_run "r2 TEETH: forged gateway env by a non-controller agent is IGNORED (impersonation bypass closed)" test_r2_forged_gateway_env_rejected
+smoke_run "r2: shared-mode forged gateway env stays ADVISORY (no hard block)" test_r2_shared_mode_forged_env_advisory
 smoke_run "gateway-server uses BRIDGE_QUEUE_GATEWAY_ACTOR, NOT client --from (file-xport spoof closed)" test_gateway_server_trusted_actor_env
 smoke_run "gateway-server with NO trusted actor FAILS CLOSED under enforce (file-xport BLOCKING)" test_gateway_server_no_actor_fails_closed
 smoke_run "gateway-server: corrupt rooms.db FAILS CLOSED (mode-read no-fail-open, BLOCKING)" test_gateway_server_corrupt_db_fails_closed

--- a/scripts/smoke/a2a-rooms-p1b-acl.sh
+++ b/scripts/smoke/a2a-rooms-p1b-acl.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+# scripts/smoke/a2a-rooms-p1b-acl.sh — A2A rooms P1b internal-queue ACL smoke.
+#
+# Exercises the P1b ACL ENFORCEMENT on the durable inter-agent queue
+# (design docs/design/a2a-rooms-design.md §7 / §14 R1), with TEETH:
+#   - default-off NO-OP: rooms_acl=off -> a cross-room create is ALLOWED
+#     exactly as today (proves ZERO behavior change for the beta default).
+#   - enforce same-room: sender + recipient share a room -> ALLOWED.
+#   - enforce cross-room: no shared room -> DENIED (fail-closed, audited reason).
+#   - SPOOF teeth (the critical one): under enforce, an OS actor A passing
+#     --from B (B shares a room with R, A does not) is decided as A -> DENIED.
+#     The client-supplied --from/BRIDGE_AGENT_ID does NOT grant B's membership.
+#     Tested at BOTH real create paths: the iso gateway (SO_PEERCRED peer) AND
+#     the direct cmd_create path (resolve_os_actor ignores --from under iso).
+#   - fail-closed: enforce + un-establishable OS actor -> DENY.
+#   - controller/daemon exemption: an actor in the CONTROLLER regime -> ALLOW
+#     (operator/daemon/cron/receiver run as the controller UID — non-spoofable).
+#   - self-message: actor == target -> ALLOW.
+#   - shared-mode advisory: documented audit/warn, NO hard block.
+#   - adopt-all -> enforce: every roster agent shares the default room -> all
+#     allowed; controller/daemon traffic still flows. Strands nobody.
+#   - acl-flip is controller-gated: a managed iso agent cannot flip rooms_acl;
+#     enforce with NO rooms is a loud operator error, not a silent lockout.
+#
+# The actor-auth test seam is the SAME paired-flag pattern P1a established
+# (BRIDGE_ROOMS_TEST_ISO_USER, gated by BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1 AND
+# BRIDGE_A2A_ALLOW_TEST_BIND=1). Production sets NEITHER flag so it is never
+# honored — the gate falls through to the real pwd.getpwuid OS facts.
+
+set -euo pipefail
+
+SMOKE_NAME="a2a-rooms-p1b-acl"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/a2a-rooms-p1b-acl-helper.py"
+P1A_HELPER="$SCRIPT_DIR/a2a-rooms-p1a-helper.py"
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+QUEUE_CLI="$SMOKE_REPO_ROOT/bridge-queue.py"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# Pin rooms.db + tasks.db under the isolated root; single-node (no a2a config).
+export BRIDGE_A2A_ROOMS_DB="$BRIDGE_STATE_DIR/handoff/rooms.db"
+export BRIDGE_TASK_DB="$BRIDGE_STATE_DIR/tasks.db"
+mkdir -p "$BRIDGE_STATE_DIR/handoff"
+unset BRIDGE_A2A_CONFIG || true
+
+# Paired test-seam flags, applied INLINE only by the *_as helpers (never exported).
+ROOMS_TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+
+room_cli_as() {
+  # room_cli_as <agent> <args...> — run the rooms CLI as if the process OS user
+  # were the iso user agent-bridge-<agent> (iso-enforced regime).
+  local who="$1"; shift
+  env "${ROOMS_TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+    python3 "$ROOMS_CLI" "$@"
+}
+
+room_cli() {
+  # Controller context: no test flags -> real pwd.getpwuid; the controller is
+  # the rooms-db owner (the smoke runner created it) -> CONTROLLER regime.
+  python3 "$ROOMS_CLI" "$@"
+}
+
+json_field() { python3 "$HELPER" json-field "$1" "$2"; }
+
+# gateway_create_as <peer> <to> [--from <spoof>] — the PRIMARY iso gate. peer is
+# the SO_PEERCRED OS actor; a --from in the argv is the spoof attempt.
+gateway_authz() {
+  local peer="$1" to="$2"; shift 2
+  env "${ROOMS_TEST_FLAGS[@]}" python3 "$HELPER" gateway-authz "$peer" "$to" "$@"
+}
+
+# queue_create_iso <osuser> <to> [--from <spoof>] — the DIRECT cmd_create path
+# as iso OS user <osuser>. resolve_os_actor() ignores --from under iso.
+queue_create_iso() {
+  local osuser="$1"; shift
+  env "${ROOMS_TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${osuser}" \
+    python3 "$QUEUE_CLI" create "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Set up two disjoint rooms: team-a {alice,bob}, team-b {carol}
+# ---------------------------------------------------------------------------
+ROOM_A=""; LINK_A=""
+test_setup_rooms() {
+  local out
+  out="$(room_cli_as alice create --name team-a --json 2>/dev/null)"
+  ROOM_A="$(json_field room_id "$out")"
+  LINK_A="$(json_field invite_link "$out")"
+  [[ -n "$ROOM_A" ]] || smoke_fail "setup: team-a create did not return a room_id"
+  room_cli_as bob join "$LINK_A" >/dev/null 2>&1 || smoke_fail "setup: bob join"
+  room_cli_as alice approve "$ROOM_A" bob >/dev/null 2>&1 || smoke_fail "setup: approve bob"
+  room_cli_as carol create --name team-b --json >/dev/null 2>&1 || smoke_fail "setup: team-b create"
+}
+
+# ---------------------------------------------------------------------------
+# default-off NO-OP: cross-room create ALLOWED (zero behavior change)
+# ---------------------------------------------------------------------------
+test_default_off_is_noop() {
+  smoke_assert_contains "$(room_cli acl --json 2>/dev/null)" '"rooms_acl": "off"' \
+    "rooms_acl defaults to off"
+  # gateway path: alice -> carol (no shared room) ALLOWED under off
+  local got
+  got="$(gateway_authz alice carol 2>/dev/null)"
+  smoke_assert_contains "$got" "ok=1" "off: gateway cross-room create is a no-op ALLOW"
+  smoke_assert_contains "$got" "reason=ok" "off: gateway no-op reason ok"
+  # direct path: alice (iso) -> carol ALLOWED under off (a real task row is created)
+  queue_create_iso alice --to carol --from alice --title t --body b >/dev/null 2>&1 \
+    || smoke_fail "off: direct cross-room create must succeed (no-op)"
+}
+
+# ---------------------------------------------------------------------------
+# enforce: flip the mode (controller-gated)
+# ---------------------------------------------------------------------------
+test_acl_flip_controller_gated() {
+  # A managed iso agent CANNOT flip the mode (operator action).
+  if room_cli_as mallory acl enforce >/dev/null 2>&1; then
+    smoke_fail "TEETH: a managed iso agent must NOT be able to flip rooms_acl"
+  fi
+  # The controller (db owner) CAN (rooms exist -> no --force needed).
+  room_cli acl enforce >/dev/null 2>&1 || smoke_fail "controller acl enforce must succeed"
+  smoke_assert_contains "$(room_cli acl --json 2>/dev/null)" '"rooms_acl": "enforce"' \
+    "controller flip set enforce"
+}
+
+# ---------------------------------------------------------------------------
+# enforce same-room ALLOW + cross-room DENY (both paths)
+# ---------------------------------------------------------------------------
+test_enforce_same_room_allow() {
+  local got
+  got="$(gateway_authz alice bob 2>/dev/null)"
+  smoke_assert_contains "$got" "ok=1" "enforce: same-room gateway create ALLOWED (alice->bob)"
+  smoke_assert_contains "$got" "from=alice" "enforce: gateway rewrites --from to the OS peer"
+  # direct path same-room
+  queue_create_iso alice --to bob --from alice --title t --body b >/dev/null 2>&1 \
+    || smoke_fail "enforce: same-room direct create must succeed (alice->bob)"
+}
+
+test_enforce_cross_room_deny() {
+  local got
+  got="$(gateway_authz alice carol 2>/dev/null)"
+  smoke_assert_contains "$got" "ok=0" "enforce: cross-room gateway create DENIED (alice->carol)"
+  smoke_assert_contains "$got" "reason=acl_denied" "enforce: cross-room audited reason acl_denied"
+  # direct path cross-room must fail loudly with the audited reason
+  local err
+  if err="$(queue_create_iso alice --to carol --from alice --title t --body b 2>&1)"; then
+    smoke_fail "enforce: cross-room direct create must be DENIED (alice->carol)"
+  fi
+  smoke_assert_contains "$err" "acl_denied" "enforce: direct cross-room denial carries the audited reason"
+}
+
+# ---------------------------------------------------------------------------
+# SPOOF teeth — the critical one. OS actor A passing --from B must be decided
+# as A. B (carol) shares no room with A->R, so --from carol cannot smuggle.
+# ---------------------------------------------------------------------------
+test_spoof_from_rejected_gateway() {
+  # Gateway: peer=alice (SO_PEERCRED), argv claims --from bob. The decision uses
+  # peer alice. alice->carol is cross-room -> DENIED. The --from bob is ignored.
+  local got
+  got="$(gateway_authz alice carol --from bob 2>/dev/null)"
+  smoke_assert_contains "$got" "ok=0" \
+    "SPOOF gateway: OS peer alice + --from bob -> decided as alice -> DENIED to carol"
+  smoke_assert_contains "$got" "reason=acl_denied" "SPOOF gateway: audited as acl_denied"
+  # And the positive control: peer=bob (really shares team-a w/ alice) -> alice OK.
+  smoke_assert_contains "$(gateway_authz bob alice 2>/dev/null)" "ok=1" \
+    "SPOOF gateway control: the REAL room member (bob) CAN reach alice"
+}
+
+test_spoof_from_rejected_direct() {
+  # Direct cmd_create: OS user alice passes --from bob. resolve_os_actor ignores
+  # --from under iso -> decided as alice -> alice->carol cross-room -> DENIED.
+  local err
+  if err="$(queue_create_iso alice --to carol --from bob --title t --body b 2>&1)"; then
+    smoke_fail "SPOOF direct: OS user alice + --from bob must STILL be denied to carol"
+  fi
+  smoke_assert_contains "$err" "acl_denied" "SPOOF direct: --from does not grant bob's membership"
+  smoke_assert_contains "$err" "'alice'" "SPOOF direct: denial names the OS actor (alice), not --from bob"
+}
+
+# ---------------------------------------------------------------------------
+# gateway-server trusted-actor env: cmd_create under BRIDGE_QUEUE_GATEWAY_SERVER
+# uses BRIDGE_QUEUE_GATEWAY_ACTOR (the gateway-set OS identity), NEVER --from.
+# This closes the file-transport spoof: the file gateway does NOT rewrite
+# --from, so cmd_create must NOT trust args.actor — only the gateway env var.
+# ---------------------------------------------------------------------------
+test_gateway_server_trusted_actor_env() {
+  # SERVER=1 + GATEWAY_ACTOR=alice + a spoofed --from carol -> decided as alice.
+  # alice->carol is cross-room -> DENIED. The --from carol must NOT smuggle.
+  local err
+  if err="$(env BRIDGE_QUEUE_GATEWAY_SERVER=1 BRIDGE_QUEUE_GATEWAY_ACTOR=alice \
+            python3 "$QUEUE_CLI" create --to carol --from carol --title t --body b 2>&1)"; then
+    smoke_fail "gateway-server: GATEWAY_ACTOR=alice + --from carol must be DENIED to carol"
+  fi
+  smoke_assert_contains "$err" "acl_denied" "gateway-server: trusted env actor decides (not --from)"
+  smoke_assert_contains "$err" "'alice'" "gateway-server: denial names the gateway-set actor (alice)"
+  # Positive control: same env, target=bob (shared with alice) -> ALLOWED.
+  env BRIDGE_QUEUE_GATEWAY_SERVER=1 BRIDGE_QUEUE_GATEWAY_ACTOR=alice \
+    python3 "$QUEUE_CLI" create --to bob --from carol --title t --body b >/dev/null 2>&1 \
+    || smoke_fail "gateway-server: GATEWAY_ACTOR=alice -> alice->bob (shared room) must ALLOW"
+}
+
+test_gateway_server_no_actor_fails_closed() {
+  # SERVER=1 but NO BRIDGE_QUEUE_GATEWAY_ACTOR (e.g. file transport could not map
+  # the request-file owner to an iso agent). cmd_create must NOT fall back to the
+  # client --from -> FAIL CLOSED under enforce. This is the file-transport
+  # BLOCKING fix (codex r1): an unauthenticated gateway create is denied.
+  local err
+  if err="$(env BRIDGE_QUEUE_GATEWAY_SERVER=1 \
+            python3 "$QUEUE_CLI" create --to carol --from carol --title t --body b 2>&1)"; then
+    smoke_fail "gateway-server with NO trusted actor must FAIL CLOSED under enforce"
+  fi
+  smoke_assert_contains "$err" "failing closed" \
+    "gateway-server no-actor: fail-closed (does not trust the client --from)"
+}
+
+test_gateway_server_corrupt_db_fails_closed() {
+  # SERVER=1 + GATEWAY_ACTOR=alice + a present-but-CORRUPT rooms.db. The mode
+  # read must NOT silently degrade to 'off' (the BLOCKING fail-open codex r1
+  # flagged) — an iso actor under a corrupt db FAILS CLOSED. Test against the
+  # REAL cmd_create mode-read path (not just the decision fn).
+  local corrupt_home="$SMOKE_TMP_ROOT/corruptdb-home"
+  mkdir -p "$corrupt_home/state/handoff"
+  printf 'corrupt not-sqlite %.0s' {1..60} >"$corrupt_home/state/handoff/rooms.db"
+  local err
+  if err="$(env BRIDGE_QUEUE_GATEWAY_SERVER=1 BRIDGE_QUEUE_GATEWAY_ACTOR=alice \
+            BRIDGE_HOME="$corrupt_home" BRIDGE_STATE_DIR="$corrupt_home/state" \
+            BRIDGE_TASK_DB="$corrupt_home/state/tasks.db" \
+            BRIDGE_A2A_ROOMS_DB="$corrupt_home/state/handoff/rooms.db" \
+            python3 "$QUEUE_CLI" create --to bob --title t --body b 2>&1)"; then
+    smoke_fail "gateway-server: a corrupt rooms.db under enforce must FAIL CLOSED, not read off"
+  fi
+  smoke_assert_contains "$err" "fail" \
+    "gateway-server corrupt-db: fail-closed (a previously-enforced DB cannot silently drop to off)"
+}
+
+# ---------------------------------------------------------------------------
+# fail-closed: enforce + un-establishable OS actor -> DENY (decision-level)
+# ---------------------------------------------------------------------------
+test_fail_closed_unresolved() {
+  local got
+  got="$(python3 "$HELPER" decision "$BRIDGE_A2A_ROOMS_DB" enforce unresolved "" carol 2>/dev/null)"
+  smoke_assert_contains "$got" "outcome=deny" "fail-closed: UNRESOLVED actor under enforce DENIES"
+  smoke_assert_contains "$got" "reason=acl_fail_closed" "fail-closed: audited reason"
+}
+
+# ---------------------------------------------------------------------------
+# fail-closed: enforce + unreadable/corrupt rooms.db (iso) -> DENY
+# ---------------------------------------------------------------------------
+test_fail_closed_corrupt_db() {
+  local bad="$SMOKE_TMP_ROOT/corrupt-rooms.db"
+  printf 'this is definitely not a sqlite database %.0s' {1..40} >"$bad"
+  local got
+  got="$(python3 "$HELPER" decision "$bad" enforce iso alice carol 2>/dev/null)"
+  smoke_assert_contains "$got" "outcome=deny" \
+    "fail-closed: a corrupt rooms.db under enforce DENIES for an iso actor"
+  smoke_assert_contains "$got" "reason=acl_fail_closed" "fail-closed: corrupt-db audited reason"
+  # shared-mode degrades to advisory (no hard boundary claimed) on the same fault
+  got="$(python3 "$HELPER" decision "$bad" enforce shared alice carol 2>/dev/null)"
+  smoke_assert_contains "$got" "outcome=advisory" \
+    "shared-mode: a db fault degrades to advisory (no hard block claimed there)"
+}
+
+# ---------------------------------------------------------------------------
+# controller / daemon exemption: CONTROLLER regime -> ALLOW (non-spoofable)
+# ---------------------------------------------------------------------------
+test_controller_exemption() {
+  local got
+  got="$(python3 "$HELPER" decision "$BRIDGE_A2A_ROOMS_DB" enforce controller daemon carol 2>/dev/null)"
+  smoke_assert_contains "$got" "outcome=allow" \
+    "exemption: a CONTROLLER-regime actor (operator/daemon/cron/receiver) ALLOWED"
+  smoke_assert_contains "$got" "reason=acl_controller_bypass" "exemption: audited as controller bypass"
+}
+
+# ---------------------------------------------------------------------------
+# self-message: actor == target -> ALLOW
+# ---------------------------------------------------------------------------
+test_self_message_allowed() {
+  smoke_assert_contains "$(gateway_authz alice alice 2>/dev/null)" "ok=1" \
+    "self-message (alice->alice) is ALLOWED under enforce"
+}
+
+# ---------------------------------------------------------------------------
+# shared-mode advisory: cross-room WARNS but does NOT block
+# ---------------------------------------------------------------------------
+test_shared_mode_advisory() {
+  local got
+  got="$(python3 "$HELPER" decision "$BRIDGE_A2A_ROOMS_DB" enforce shared alice carol 2>/dev/null)"
+  smoke_assert_contains "$got" "outcome=advisory" \
+    "shared-mode: cross-room is ADVISORY (warn, not block) — honest §14 R1 default"
+  smoke_assert_contains "$got" "reason=acl_advisory_cross_room" "shared-mode: advisory reason"
+}
+
+# ---------------------------------------------------------------------------
+# enforce with NO rooms is a loud operator error (not a silent lockout)
+# ---------------------------------------------------------------------------
+test_enforce_no_rooms_is_loud() {
+  local fresh="$SMOKE_TMP_ROOT/norooms-home"
+  mkdir -p "$fresh/state/handoff"
+  local err
+  if err="$(BRIDGE_HOME="$fresh" BRIDGE_STATE_DIR="$fresh/state" \
+            BRIDGE_A2A_ROOMS_DB="$fresh/state/handoff/rooms.db" \
+            python3 "$ROOMS_CLI" acl enforce 2>&1)"; then
+    smoke_fail "enforce with no rooms must be a LOUD error, not a silent set"
+  fi
+  smoke_assert_contains "$err" "adopt-all" \
+    "no-rooms enforce error points the operator at adopt-all (no silent lockout)"
+  # --force is the documented escape hatch (full lockdown).
+  BRIDGE_HOME="$fresh" BRIDGE_STATE_DIR="$fresh/state" \
+    BRIDGE_A2A_ROOMS_DB="$fresh/state/handoff/rooms.db" \
+    python3 "$ROOMS_CLI" acl enforce --force >/dev/null 2>&1 \
+    || smoke_fail "--force must allow enforce with no rooms (lockdown)"
+}
+
+# ---------------------------------------------------------------------------
+# adopt-all -> enforce: every roster agent shares the default room; nobody
+# is stranded; controller/daemon traffic still flows.
+# ---------------------------------------------------------------------------
+test_adopt_all_then_enforce_strands_nobody() {
+  local home="$SMOKE_TMP_ROOT/adopt-home"
+  mkdir -p "$home/state/handoff"
+  local rdb="$home/state/handoff/rooms.db"
+  local tdb="$home/state/tasks.db"
+  local roster="$home/agent-roster.local.sh"
+  # Seed a deterministic roster so adopt-all consults a known agent set.
+  python3 "$P1A_HELPER" write-roster "$roster" alpha beta gamma >/dev/null 2>&1
+  # adopt-all as the controller (db owner) — leader becomes the caller id.
+  local out members
+  out="$(BRIDGE_HOME="$home" BRIDGE_STATE_DIR="$home/state" \
+         BRIDGE_A2A_ROOMS_DB="$rdb" BRIDGE_ROSTER_LOCAL_FILE="$roster" \
+         python3 "$ROOMS_CLI" adopt-all --name default --json 2>/dev/null)"
+  members="$(python3 "$HELPER" members-csv "$out")"
+  for ag in alpha beta gamma; do
+    smoke_assert_contains ",$members," ",$ag," "adopt-all default room includes $ag"
+  done
+  # Flip enforce (rooms now exist -> allowed without --force).
+  BRIDGE_HOME="$home" BRIDGE_STATE_DIR="$home/state" BRIDGE_A2A_ROOMS_DB="$rdb" \
+    python3 "$ROOMS_CLI" acl enforce >/dev/null 2>&1 \
+    || smoke_fail "adopt-all then enforce flip must succeed"
+  # Every adopted agent shares the default room -> all gateway creates ALLOWED.
+  local pair got
+  for pair in "alpha beta" "beta gamma" "gamma alpha"; do
+    # shellcheck disable=SC2086
+    set -- $pair
+    got="$(env "${ROOMS_TEST_FLAGS[@]}" BRIDGE_HOME="$home" BRIDGE_STATE_DIR="$home/state" \
+           BRIDGE_A2A_ROOMS_DB="$rdb" BRIDGE_TASK_DB="$tdb" \
+           python3 "$HELPER" gateway-authz "$1" "$2" 2>/dev/null)"
+    smoke_assert_contains "$got" "ok=1" "adopt-all->enforce: $1->$2 (default room) ALLOWED — strands nobody"
+  done
+  # The controller/daemon exemption still flows post-adopt.
+  got="$(BRIDGE_HOME="$home" BRIDGE_STATE_DIR="$home/state" BRIDGE_A2A_ROOMS_DB="$rdb" \
+         python3 "$HELPER" decision "$rdb" enforce controller daemon alpha 2>/dev/null)"
+  smoke_assert_contains "$got" "outcome=allow" "adopt-all->enforce: daemon/controller traffic still flows"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "setup: two disjoint rooms (team-a {alice,bob}, team-b {carol})" test_setup_rooms
+smoke_run "default-off is a true no-op (cross-room ALLOWED, zero behavior change)" test_default_off_is_noop
+smoke_run "acl-flip is controller-gated (iso agent cannot flip; controller can)" test_acl_flip_controller_gated
+smoke_run "enforce same-room ALLOW (gateway + direct)" test_enforce_same_room_allow
+smoke_run "enforce cross-room DENY (fail-closed, audited reason; gateway + direct)" test_enforce_cross_room_deny
+smoke_run "SPOOF teeth: --from rejected at the gateway (OS peer decides)" test_spoof_from_rejected_gateway
+smoke_run "SPOOF teeth: --from rejected on the direct path (resolve_os_actor)" test_spoof_from_rejected_direct
+smoke_run "gateway-server uses BRIDGE_QUEUE_GATEWAY_ACTOR, NOT client --from (file-xport spoof closed)" test_gateway_server_trusted_actor_env
+smoke_run "gateway-server with NO trusted actor FAILS CLOSED under enforce (file-xport BLOCKING)" test_gateway_server_no_actor_fails_closed
+smoke_run "gateway-server: corrupt rooms.db FAILS CLOSED (mode-read no-fail-open, BLOCKING)" test_gateway_server_corrupt_db_fails_closed
+smoke_run "fail-closed: UNRESOLVED actor under enforce DENIES" test_fail_closed_unresolved
+smoke_run "fail-closed: corrupt rooms.db under enforce DENIES (iso); advisory (shared)" test_fail_closed_corrupt_db
+smoke_run "exemption: CONTROLLER regime (operator/daemon/cron/receiver) ALLOWED" test_controller_exemption
+smoke_run "self-message (actor==target) ALLOWED" test_self_message_allowed
+smoke_run "shared-mode cross-room is ADVISORY (warn, not block)" test_shared_mode_advisory
+smoke_run "enforce with NO rooms is a loud operator error (not silent lockout)" test_enforce_no_rooms_is_loud
+smoke_run "adopt-all -> enforce strands nobody + daemon traffic flows" test_adopt_all_then_enforce_strands_nobody
+
+smoke_log "passed"


### PR DESCRIPTION
## Summary
P1b of the A2A Rooms subsystem: **ACL enforcement on the internal durable queue**. When `rooms_acl=enforce`, an inter-agent `create --to R` from sender `S` is allowed only when `S` and `R` share a room (`shared_rooms(...)` non-empty); otherwise it is denied fail-closed with an audited reason. P1a (merged, #1505) landed the rooms control plane + frozen API; this PR consumes it.

**Default `off` is a true no-op** — zero behavior change unless an operator opts in. This is what keeps it beta-safe.

Part of the A2A rooms subsystem (design `docs/design/a2a-rooms-design.md`); P1b of N. (#1505 follow-on)

## The enforce gate + the OS-actor invariant (design §14 R1)
The ACL decision is a pure function `acl_create_decision(mode, regime, actor, target, …)` in `bridge_rooms_common.py` — the single source of truth — consumed at the two real create paths:

- **Gateway (iso-v2) = the PRIMARY, OS-enforced gate.** The sender actor is the OS identity, never the client `--from`/`BRIDGE_AGENT_ID`:
  - **socket transport** → the `SO_PEERCRED` peer (existing server-side rewrite);
  - **file transport** → the **request-file OWNER uid** mapped to an agent (each iso UID can only write request files it owns).
  - The gateway hands the trusted actor to the queue child via `BRIDGE_QUEUE_GATEWAY_ACTOR` — the gateway-server's **own child env**, which a client cannot set. `authorize_and_rewrite` gates `create` on `shared_rooms`.
- **`bridge-queue.py cmd_create` = defense-in-depth + the non-gateway paths.** Under the gateway server it uses `BRIDGE_QUEUE_GATEWAY_ACTOR` as the ISO-enforced actor (never `args.actor`); a gateway create with no trusted actor **fails closed** under enforce. Direct creates (controller/daemon/shared-mode) resolve the actor from the OS identity via `resolve_os_actor()`.

An iso agent cannot spoof another's uid → cannot send as another room member. Passing `--from <peer>` is recorded for audit only and **cannot** influence the decision actor.

## Exemption list (for review — minimal + each non-spoofable)
| Exemption | Why it's safe |
|---|---|
| **Controller / operator / daemon / cron / receiver** (`ACTOR_CONTROLLER`) | All run as the controller OS UID (they own `rooms.db`). It's an OS fact, **not** a `--from daemon`/`cron:x` string a managed agent could type. |
| **Self-message** (`actor == target`) | An agent talking to itself is not cross-team. |
| **Target in no enforced room** | The gate is roster-agent ↔ roster-agent; a non-room target (e.g. an un-adopted system agent) is not a team peer to wall off (audited so an operator can spot it). |

No client-flag-based exemption exists. A too-broad exemption defeats the boundary; a too-narrow one breaks the daemon — these three are the minimal set that keep daemon/operator traffic flowing while walling cross-team agent traffic.

## Default-off no-op proof
`mode != enforce` → `acl_create_decision` returns `allow/acl_off` immediately at **both** paths; a cross-room create is allowed exactly as today. Smoke `test_default_off_is_noop` asserts this on the gateway and the direct path (a real task row is created).

## Migration (adopt-all → enforce)
`agb room adopt-all` seeds a default room with every roster agent, so flipping `enforce` strands nobody. `agb room acl enforce` with **no rooms defined** is a **loud operator error** pointing at `adopt-all` (not a silent lockout); `--force` is the documented full-lockdown escape hatch (controller/daemon traffic still flows). The `acl` flip itself is **controller-gated** — a managed iso agent cannot change the mode (hard deny), and an un-establishable actor fails closed.

## Fail-closed
- `ACTOR_UNRESOLVED` under enforce → deny.
- A present-but-unreadable/corrupt `rooms.db` for a **hard (iso)** actor → deny (`rooms_acl_mode_strict()` distinguishes *absent* — back-compat `off` — from *unreadable* — fail closed). Shared-mode degrades to advisory on a db fault (no hard boundary is claimed there).
- Shared-mode cross-room is **advisory** (warn + audit, no hard block) — the honest §14 R1 default; same-UID agents are not OS-separable.

## Verification (teeth)
New `scripts/smoke/a2a-rooms-p1b-acl.sh` (registered at **all** ci-select sites + the queue/gateway/rooms file arms), 17 tests:
- default-off no-op; enforce same-room ALLOW; enforce cross-room DENY (audited).
- **`--from` SPOOF rejected** at the gateway (OS peer decides) AND on the direct path (`resolve_os_actor` ignores `--from` under iso).
- gateway-server uses `BRIDGE_QUEUE_GATEWAY_ACTOR` not client `--from`; gateway-server with **no** trusted actor fails closed; **corrupt rooms.db** fails closed (the actual mode-read path).
- fail-closed (UNRESOLVED); controller exemption; self-message; shared-mode advisory; adopt-all→enforce strands-nobody; controller-gated acl flip; no-rooms loud error.

Also: `bash -n` (`/opt/homebrew/bin/bash`), `shellcheck`, `py_compile` (×5), `lint-heredoc-ban --baseline-check`, `lint-raw-pathlib --check`, `iso-helper` ratchet — all pass. Re-ran `a2a-rooms-p1a` + `a2a-cross-bridge` with **no regression** of normal queue flow.

> Does NOT weaken the gateway `SO_PEERCRED` rewrite or the A2A receiver auth — only ADDs the rooms gate.

## Codex review
Internal `codex:codex-rescue` review: round 1 found 2 BLOCKINGs (file-transport could feed client `--from` into the actor; unreadable `rooms.db` failed open via the lenient mode read) — both fixed (`BRIDGE_QUEUE_GATEWAY_ACTOR` trusted-actor signal + owner-uid derivation; `rooms_acl_mode_strict`). Round 2: **implement-ok**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
