### PR TITLE
fix(iso): #1518 — resolve the dead #1513 chmod 0755 (mirror ends 2750, assert final iso-traversable state)

### DIFF
--- a/lib/bridge-agents.sh
+++ b/lib/bridge-agents.sh
@@ -4529,38 +4529,11 @@ bridge_linux_prepare_agent_isolation() {
     done
   fi
 
-  # Issue #1513: the legacy per-agent tracked-profile mirror dir at
-  # `$BRIDGE_AGENT_HOME_ROOT/<agent>/` (e.g. `~/.agent-bridge/agents/<a>/`)
-  # must be traversable ("other" x-bit) by the isolated UID. On the
-  # create-shared-then-isolate path it was scaffolded by the plain
-  # controller `mkdir -p` under `umask 077` (mode 0700, group=<controller>),
-  # so the iso UID — not the owner, not in the owning group — cannot
-  # traverse it. `bridge-run.sh` runs scripts/python-helpers/prune-legacy-
-  # teams-mcp.py AS the iso UID against `--agent-root
-  # $BRIDGE_AGENT_HOME_ROOT/<a>`; `Path('.../<a>/.mcp.json').is_file()`
-  # then raises `PermissionError` (EACCES, which Python 3.10's is_file()
-  # does NOT swallow), the prune exits non-zero, and the launch aborts
-  # with `stale Teams MCP cleanup failed`. A healthy/older agent's legacy
-  # root is `0755`, so the same prune returns False cleanly.
-  #
-  # The scaffold-time fix (bridge-agent.sh #1165 Gap 4) only fires when
-  # isolation is active AT `agent create`; the create-shared-then-isolate
-  # path leaves this dir 0700. Normalize the dir NODE traverse bit here
-  # (in the shared prepare path used by both create-isolate and
-  # isolate/reapply) so it is `drwxr-xr-x` like a healthy agent's. This
-  # is a single-node `chmod 0755` (NOT recursive): the 0600 files inside
-  # — non-secret JSON mirrors; channel secrets live under
-  # `workdir/.<channel>/` with their own ACLs — are untouched, and
-  # owner/group are unchanged. Idempotent; Linux-gated via
-  # `bridge_host_platform` at the top of prepare. Mirrors the
-  # bridge-agent.sh:#1165 scaffold-path recipe (mkdir/chown/chmod 0755).
-  if [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" ]]; then
-    local _v2_legacy_mirror_dir="$BRIDGE_AGENT_HOME_ROOT/$agent"
-    if bridge_linux_sudo_root test -d "$_v2_legacy_mirror_dir"; then
-      bridge_linux_sudo_root chmod 0755 "$_v2_legacy_mirror_dir" \
-        || bridge_warn "isolation v2 (#1513): could not set traverse bit on legacy mirror dir '$_v2_legacy_mirror_dir' for agent '$agent'; the iso-UID Teams MCP prune may abort the launch with EACCES. Manual fix: \`sudo chmod 0755 $_v2_legacy_mirror_dir\`."
-    fi
-  fi
+  # Issue #1513 / #1518: the legacy per-agent tracked-profile mirror dir at
+  # `$BRIDGE_AGENT_HOME_ROOT/<agent>/` must be group-traversable by the iso
+  # UID (the Teams MCP prune runs against it). Its normalization is applied
+  # LAST in this function — AFTER the grant-matrix + install-tree reconciler
+  # — so it is not clobbered. See the `#1518` block near the end of prepare.
 
   # Isolated-home POSIX contract (HOME + .claude + .claude/plugins +
   # .claude/session-env). Phase 3 codex design: one shared helper at
@@ -4689,6 +4662,57 @@ bridge_linux_prepare_agent_isolation() {
           --mode apply --agent "$agent" --reason agent-create \
           >/dev/null 2>&1; then
       bridge_warn "bridge_linux_prepare_agent_isolation: install-tree reconciler reported drift for agent=$agent (non-fatal; run: agent-bridge isolation reconcile --apply --agent $agent)"
+    fi
+  fi
+
+  # Issue #1513 / #1518: normalize the legacy per-agent tracked-profile
+  # mirror dir `$BRIDGE_AGENT_HOME_ROOT/<agent>/` (= `$BRIDGE_HOME/agents/<a>`)
+  # to the iso v2 group-traversal contract. This runs LAST — after the
+  # grant-matrix + install-tree reconciler above — on purpose (#1518).
+  #
+  # Why here, not earlier: `bridge-run.sh` runs the Teams MCP prune
+  # (scripts/python-helpers/prune-legacy-teams-mcp.py) AS the iso UID
+  # against `--agent-root $BRIDGE_AGENT_HOME_ROOT/<a>` (the LEGACY path,
+  # bridge-run.sh:~1219), so this dir must be traversable by the iso UID
+  # or the prune raises EACCES on `is_file()` and the launch aborts with
+  # `stale Teams MCP cleanup failed` (#1513). On the create-shared-then-
+  # isolate path the controller's plain `mkdir -p` under `umask 077`
+  # leaves it `0700 group=<controller>` — non-traversable by the iso UID.
+  #
+  # On the DEFAULT v2 layout the live runtime root is
+  # `$BRIDGE_AGENT_ROOT_V2/<a>` (= `$BRIDGE_HOME/data/agents/<a>`), which is
+  # a DIFFERENT directory from this legacy `$BRIDGE_HOME/agents/<a>` mirror
+  # (BRIDGE_DATA_ROOT defaults to `$BRIDGE_HOME/data`). The per-agent
+  # grant-matrix and the install-tree reconciler both normalize the v2 path
+  # — NOT this legacy leaf (the reconciler's only `agents/` row is the
+  # `$BRIDGE_HOME/agents` PARENT at 0710, not the per-agent child). So on a
+  # split-root install nothing else gives this dir its traverse bit: #1513's
+  # original L2 `chmod 0755` earlier in prepare was both (a) clobbered to
+  # `2750 root:ab-agent-<a>` on a non-split install where legacy==v2 root,
+  # AND (b) the only thing covering the split-root case (#1518). We resolve
+  # both by setting the contract HERE, after every normalizer:
+  #
+  #   chgrp ab-agent-<a> + chmod 2750  → `drwxr-s--- 2750 root:ab-agent-<a>`
+  #
+  # group r-x + setgid (NO "other" access — narrower than the old `0755`);
+  # the iso UID `agent-bridge-<a>` is a member of `ab-agent-<a>` and
+  # traverses via the GROUP x-bit. This matches the contract the grant
+  # matrix lands on the v2 root, so both layouts converge to the same final
+  # state. `$_v2_agent_group` (= `ab-agent-<a>`) is the same per-agent group
+  # this function already `ensure_group`s and chgrps the v2 root/subtrees to
+  # above, so no new identity is introduced. Dir-NODE only (NOT recursive):
+  # the 0600 files inside — non-secret JSON mirrors; channel secrets live
+  # under `workdir/.<channel>/` with their own ACLs — and the chown owner
+  # are left untouched. Idempotent. The whole
+  # `bridge_linux_prepare_agent_isolation` body early-returns on non-Linux
+  # (a complete no-op on macOS/dev hosts), so this is Linux-only.
+  if [[ -n "${BRIDGE_AGENT_HOME_ROOT:-}" ]]; then
+    local _v2_legacy_mirror_dir="$BRIDGE_AGENT_HOME_ROOT/$agent"
+    if bridge_linux_sudo_root test -d "$_v2_legacy_mirror_dir"; then
+      bridge_linux_sudo_root chgrp "$_v2_agent_group" "$_v2_legacy_mirror_dir" \
+        || bridge_warn "isolation v2 (#1518): could not chgrp legacy mirror dir '$_v2_legacy_mirror_dir' to '$_v2_agent_group' for agent '$agent'; the iso-UID Teams MCP prune may abort the launch with EACCES."
+      bridge_linux_sudo_root chmod 2750 "$_v2_legacy_mirror_dir" \
+        || bridge_warn "isolation v2 (#1518): could not set the group-traverse bit (2750) on legacy mirror dir '$_v2_legacy_mirror_dir' for agent '$agent'; the iso-UID Teams MCP prune may abort the launch with EACCES. Manual fix: \`sudo chgrp $_v2_agent_group $_v2_legacy_mirror_dir && sudo chmod 2750 $_v2_legacy_mirror_dir\`."
     fi
   fi
 

--- a/scripts/smoke/1513-iso-teams-prune-eacces.sh
+++ b/scripts/smoke/1513-iso-teams-prune-eacces.sh
@@ -17,7 +17,7 @@
 # dies. A healthy agent's legacy root is 0755 (traversable), so the same
 # prune returns `is_file: False` cleanly.
 #
-# Two-layer fix:
+# Two-layer fix (as refined by #1518):
 #   L1 (defensive) — prune_file() in prune-legacy-teams-mcp.py catches
 #      PermissionError/OSError around is_file() and returns a non-fatal
 #      `skipped path=… reason=stat-failed:<errno>` instead of raising.
@@ -25,10 +25,29 @@
 #      non-fatally; the helper exit stays 0 so the launch is not aborted.
 #   L2 (perms) — bridge_linux_prepare_agent_isolation
 #      (lib/bridge-agents.sh) normalizes the legacy
-#      `$BRIDGE_AGENT_HOME_ROOT/<a>` mirror DIR's traverse bit to 0755 on
-#      the create-shared-then-isolate path (the scaffold-time #1165 Gap 4
-#      fix only fires when isolation is active AT create). Single-node
-#      chmod 0755 — files inside stay 0600, owner/group unchanged.
+#      `$BRIDGE_AGENT_HOME_ROOT/<a>` mirror DIR to the iso v2 group-traversal
+#      contract: `chgrp ab-agent-<a> + chmod 2750` →
+#      `drwxr-s--- 2750 root:ab-agent-<a>` (group r-x + setgid, NO "other"
+#      access). The iso UID `agent-bridge-<a>` is a member of `ab-agent-<a>`
+#      and traverses via the GROUP x-bit. Files inside stay 0600/iso-owned;
+#      owner stays root.
+#
+#      #1518 fixed two defects in #1513's original L2 `chmod 0755`:
+#        (a) On a NON-split install (legacy `agents/<a>` IS the v2 root)
+#            the later recursive setgid/group normalization CLOBBERED the
+#            `0755` to `2750 root:ab-agent-<a>` — the 2-VM observation —
+#            so the chmod was dead there.
+#        (b) On the DEFAULT split-root v2 layout (BRIDGE_DATA_ROOT =
+#            `$BRIDGE_HOME/data`, so the v2 root `$BRIDGE_HOME/data/agents/<a>`
+#            is a DIFFERENT dir than this legacy `$BRIDGE_HOME/agents/<a>`
+#            mirror), NO matrix normalizes the legacy leaf, so the dir
+#            stayed `0700` and the `chmod 0755`, placed BEFORE the
+#            reconciler, was the only thing covering the split case — but
+#            with the wrong "other"-x contract and at risk of reordering.
+#      The fix moves the normalization to run LAST (after the grant-matrix
+#      + install-tree reconciler) and sets the narrower `2750 group=ab-agent
+#      -<a>` contract, so BOTH layouts converge to the same final state and
+#      it can never be clobbered.
 #
 # This smoke verifies BOTH:
 #   (L1) Behavior — invoking the actual prune helper against an
@@ -38,15 +57,20 @@
 #        mode-0000 dir is not traversable even by its owner (no x-bit),
 #        so `is_file()` on a child raises EACCES for the test process.
 #        A negative check confirms the pre-fix `is_file()` raises.
-#   (L2a) Integration — bridge_linux_prepare_agent_isolation contains the
-#        #1513 legacy-mirror traverse-bit normalization
-#        (`$BRIDGE_AGENT_HOME_ROOT/$agent` + `chmod 0755`), it is a
-#        single-node chmod (NOT a recursive widen), and it is anchored to
-#        the issue for greppability.
-#   (L2b) Behavior — a `chmod 0755` on a seeded 0700 mirror dir makes its
-#        child reachable (the prune then returns `absent`/`unchanged`
-#        rather than `skipped reason=stat-failed`), and the inner 0600
-#        file's mode is untouched by the single-node chmod.
+#   (L2a) Integration — bridge_linux_prepare_agent_isolation normalizes the
+#        legacy mirror dir to the `2750`/group-traverse contract (chgrp the
+#        agent group + chmod 2750 on `$BRIDGE_AGENT_HOME_ROOT/$agent`), it
+#        runs AFTER the install-tree reconciler (so it is not clobbered), it
+#        is NOT the dead "other"-x `chmod 0755`, and it is NOT a recursive
+#        `-R` widen. Reverting any of these fails the smoke.
+#   (L2b) Behavior — modelling the FINAL effective state on the local fs
+#        seam: the legacy mirror dir normalized to mode `2750` + setgid +
+#        a NON-OWNER group the test process is a member of is traversable
+#        via the GROUP x-bit (no "other" access), the prune against it
+#        returns `absent`/`unchanged` (NOT `skipped reason=stat-failed`),
+#        and the inner 0600 file's mode is untouched. Revert-teeth: the
+#        pre-normalization `0700` state blocks the same group-member
+#        traversal (negative control).
 #
 # Footgun #11 (Bash 5.3.9 heredoc-class deadlock): no heredoc-stdin /
 # here-string / process-substitution feeds a subprocess here; the L1/L2b
@@ -79,9 +103,53 @@ smoke_make_temp_root "$SMOKE_NAME"
 PY_BIN="${PYTHON_BIN:-$(command -v python3 || true)}"
 [[ -n "$PY_BIN" ]] || smoke_fail "python3 not found"
 
-# Portable low-bits mode helper: GNU `stat -c '%a'`, BSD `stat -f '%Lp'`.
+# Portable LOW-bits mode helper: GNU `stat -c '%a'`, BSD `stat -f '%Lp'`.
+# NOTE: BSD `%Lp` reports only the permission bits and DROPS the setgid
+# bit, so for directories assert the setgid bit separately via _has_setgid.
 _mode_of() {
   stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+# Portable setgid-bit probe (mirrors scripts/smoke/1506-isolate-normalize.sh).
+# GNU `stat -c '%a'` returns a 4-digit mode with a leading 2/3/6/7 when
+# setgid is set; BSD drops it, so fall back to the `ls -ld` group-exec slot
+# (`s`/`S` at the 6th permission char). Returns 0 when setgid is set.
+_has_setgid() {
+  local p="$1" gnu_mode perms
+  gnu_mode="$(stat -c '%a' "$p" 2>/dev/null || printf '')"
+  if [[ -n "$gnu_mode" ]]; then
+    case "$gnu_mode" in
+      2*|3*|6*|7*) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+  # shellcheck disable=SC2012 # single known path, not a glob — SC2012 N/A
+  perms="$(ls -ld "$p" 2>/dev/null | awk '{print $1}')"
+  case "${perms:6:1}" in
+    s|S) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Portable group ('g') and other ('o') execute/traverse-bit probes from the
+# `ls -ld` symbolic perms. Position 6 = group-exec, position 9 = other-exec.
+# Returns 0 when the bit grants traversal (x/s for group, x/t for other).
+_has_group_x() {
+  local perms
+  # shellcheck disable=SC2012 # single known path, not a glob — SC2012 N/A
+  perms="$(ls -ld "$1" 2>/dev/null | awk '{print $1}')"
+  case "${perms:6:1}" in x|s) return 0 ;; *) return 1 ;; esac
+}
+_has_other_x() {
+  local perms
+  # shellcheck disable=SC2012 # single known path, not a glob — SC2012 N/A
+  perms="$(ls -ld "$1" 2>/dev/null | awk '{print $1}')"
+  case "${perms:9:1}" in x|t) return 0 ;; *) return 1 ;; esac
+}
+
+# Portable group-name-of-path helper: GNU `stat -c '%G'`, BSD `stat -f '%Sg'`.
+_group_of() {
+  stat -c '%G' "$1" 2>/dev/null || stat -f '%Sg' "$1"
 }
 
 # =====================================================================
@@ -139,10 +207,11 @@ fi
 
 # =====================================================================
 # (L2a) Integration — prepare_agent_isolation normalizes the legacy
-#       mirror dir's traverse bit (single-node chmod 0755, #1513 anchor).
+#       mirror dir to the 2750/group-traverse contract, AFTER the
+#       install-tree reconciler, NOT the dead "other"-x 0755, NOT -R.
 # =====================================================================
 
-smoke_log "L2a: bridge_linux_prepare_agent_isolation carries the #1513 legacy-mirror traverse-bit normalization"
+smoke_log "L2a: bridge_linux_prepare_agent_isolation normalizes the legacy mirror to 2750/group (after the reconciler, not 0755)"
 
 PREP_START="$(grep -nE '^bridge_linux_prepare_agent_isolation\(\)' "$AGENTS_LIB" | head -1 | cut -d: -f1)"
 [[ -n "$PREP_START" ]] || smoke_fail "L2a: cannot locate bridge_linux_prepare_agent_isolation in $AGENTS_LIB"
@@ -153,7 +222,10 @@ PREP_BODY="$(awk -v start="$PREP_START" '
   in_fn { print; if ($0 == "}") { exit } }
 ' "$AGENTS_LIB")"
 [[ -n "$PREP_BODY" ]] || smoke_fail "L2a: extracted prepare_agent_isolation body is empty"
-PREP_BODY_FLAT="$(printf '%s\n' "$PREP_BODY" | tr '\n' ' ' | tr -s ' ')"
+
+# Non-comment (code) lines only — the assertions below must not trip on the
+# explanatory comments (which legitimately mention `0755` / `chmod 2750`).
+PREP_CODE="$(printf '%s\n' "$PREP_BODY" | grep -vE '^[[:space:]]*#')"
 
 L2A_FAILS=""
 
@@ -162,35 +234,74 @@ if ! printf '%s\n' "$PREP_BODY" | grep -F '#1513' >/dev/null; then
   L2A_FAILS+="no #1513 anchor in prepare_agent_isolation; "
 fi
 
-# L2a-2: it targets the legacy mirror dir `$BRIDGE_AGENT_HOME_ROOT/$agent`.
-if ! printf '%s\n' "$PREP_BODY" | grep -F '$BRIDGE_AGENT_HOME_ROOT/$agent' >/dev/null; then
+# L2a-2: the normalization targets the legacy mirror dir
+# `$BRIDGE_AGENT_HOME_ROOT/$agent` and sets the group-traverse contract:
+# chgrp the agent group + chmod 2750 (NOT the dead "other"-x 0755). Both
+# operations must be on the `$_v2_legacy_mirror_dir` node.
+if ! printf '%s\n' "$PREP_CODE" | grep -F '$BRIDGE_AGENT_HOME_ROOT/$agent' >/dev/null; then
   L2A_FAILS+="normalization does not reference \$BRIDGE_AGENT_HOME_ROOT/\$agent; "
 fi
-
-# L2a-3: it sets the traverse bit via `chmod 0755` on that dir node.
-if ! printf '%s\n' "$PREP_BODY_FLAT" \
-    | grep -E 'chmod 0755 "\$_v2_legacy_mirror_dir"' >/dev/null; then
-  L2A_FAILS+="does not chmod 0755 the legacy mirror dir node; "
+if ! printf '%s\n' "$PREP_CODE" \
+    | grep -E 'chgrp "\$_v2_agent_group" "\$_v2_legacy_mirror_dir"' >/dev/null; then
+  L2A_FAILS+="does not chgrp the legacy mirror dir to the agent group (\$_v2_agent_group); "
+fi
+if ! printf '%s\n' "$PREP_CODE" \
+    | grep -E 'chmod 2750 "\$_v2_legacy_mirror_dir"' >/dev/null; then
+  L2A_FAILS+="does not chmod 2750 the legacy mirror dir node (the group-traverse + setgid contract); "
 fi
 
-# L2a-4: it is a SINGLE-NODE chmod — no recursive `-R` widen of the
-# legacy mirror tree (that would expose the inner 0600 files).
-if printf '%s\n' "$PREP_BODY" | grep -vE '^[[:space:]]*#' \
-    | grep -E 'chmod[[:space:]]+-R[[:space:]].*_v2_legacy_mirror_dir|_v2_legacy_mirror_dir.*chmod[[:space:]]+-R' >/dev/null; then
-  L2A_FAILS+="introduced a recursive chmod -R on the legacy mirror (widens inner 0600 files); "
+# L2a-3: the dead "other"-x `chmod 0755` on the legacy mirror dir is GONE
+# (#1518: it was clobbered on non-split installs and was the wrong, wider
+# contract on split installs). Re-adding it fails here.
+if printf '%s\n' "$PREP_CODE" \
+    | grep -E 'chmod[[:space:]]+0?755[[:space:]].*_v2_legacy_mirror_dir|_v2_legacy_mirror_dir.*chmod[[:space:]]+0?755' >/dev/null; then
+  L2A_FAILS+="dead 'other'-x chmod 0755 of the legacy mirror dir is back (#1518: wrong/clobbered contract); "
+fi
+
+# L2a-4: no recursive `-R` chmod/chown of the legacy mirror tree — that
+# would expose the inner 0600 files (the #1513 contract: files untouched).
+if printf '%s\n' "$PREP_CODE" \
+    | grep -E 'chmod[[:space:]]+-R[[:space:]].*_v2_legacy_mirror_dir|_v2_legacy_mirror_dir.*chmod[[:space:]]+-R|chgrp[[:space:]]+-R[[:space:]].*_v2_legacy_mirror_dir|_v2_legacy_mirror_dir.*chgrp[[:space:]]+-R' >/dev/null; then
+  L2A_FAILS+="introduced a recursive -R chmod/chgrp on the legacy mirror (widens inner 0600 files); "
+fi
+
+# L2a-5: the legacy-mirror normalization runs AFTER the install-tree
+# reconciler (`bridge_isolation_v2_apply_install_tree_matrix`), so the
+# matrix's recursive group normalization on a non-split install cannot
+# clobber it (#1518 root cause: original placement was BEFORE it). Compare
+# first-occurrence line numbers within the function body.
+PREP_RECONCILER_LN="$(printf '%s\n' "$PREP_BODY" | grep -nE 'bridge_isolation_v2_apply_install_tree_matrix' | grep -vE '^[0-9]+:[[:space:]]*#' | head -1 | cut -d: -f1)"
+PREP_MIRROR_LN="$(printf '%s\n' "$PREP_BODY" | grep -nF 'chmod 2750 "$_v2_legacy_mirror_dir"' | head -1 | cut -d: -f1)"
+if [[ -z "$PREP_RECONCILER_LN" ]]; then
+  L2A_FAILS+="cannot find the install-tree reconciler call in prepare (ordering check inconclusive); "
+elif [[ -z "$PREP_MIRROR_LN" ]]; then
+  L2A_FAILS+="cannot find the legacy-mirror chmod 2750 in prepare (ordering check inconclusive); "
+elif [[ "$PREP_MIRROR_LN" -le "$PREP_RECONCILER_LN" ]]; then
+  L2A_FAILS+="legacy-mirror normalization (line $PREP_MIRROR_LN) runs BEFORE the install-tree reconciler (line $PREP_RECONCILER_LN) — the matrix can clobber it (#1518); "
 fi
 
 if [[ -n "$L2A_FAILS" ]]; then
   smoke_fail "L2a: integration regressions: $L2A_FAILS"
 fi
-smoke_log "L2a PASS — #1513 normalization present, single-node chmod 0755 of the legacy mirror dir (no recursive widen)"
+smoke_log "L2a PASS — legacy mirror normalized to 2750/group AFTER the reconciler; no dead 0755, no recursive widen"
 
 # =====================================================================
-# (L2b) Behavioral — chmod 0755 on a seeded 0700 mirror dir restores
-#       traversal; the inner 0600 file's mode is untouched.
+# (L2b) Behavioral — model the FINAL post-normalization state on the
+#       local fs seam: the legacy mirror dir at mode 2750 + setgid +
+#       a NON-OWNER group the test process is a member of is traversable
+#       via the GROUP x-bit (no "other" access); the prune reads its
+#       child cleanly; the inner 0600 file's mode is untouched. The
+#       pre-normalization 0700 state is the negative control.
 # =====================================================================
+#
+# CI does not provision the real `agent-bridge-<a>` UID / `ab-agent-<a>`
+# group, so — exactly as scripts/smoke/1506-isolate-normalize.sh does —
+# we surrogate the agent group with the caller's own group `$(id -gn)`
+# and surrogate the iso UID's "group-member, not owner" traversal with
+# the FINAL effective mode. The live OS-user + ab-agent-<a> iso-UID
+# traversal (sudo-driven) is covered by the PR's manual Linux repro.
 
-smoke_log "L2b: chmod 0755 on a 0700 legacy mirror dir restores traversal; inner 0600 file mode preserved"
+smoke_log "L2b: FINAL state = 2750 + setgid + group-x (no other-x); prune reads child cleanly; inner 0600 untouched"
 
 L2_ROOT="$SMOKE_TMP_ROOT/l2"
 L2_AGENT_ROOT="$L2_ROOT/agents/l2agent"
@@ -203,31 +314,61 @@ chmod 0600 "$L2_AGENT_ROOT/.mcp.json"
 chmod 0700 "$L2_AGENT_ROOT"
 
 L2_FILE_MODE_BEFORE="$(_mode_of "$L2_AGENT_ROOT/.mcp.json")"
+L2_GRP_SURROGATE="$(id -gn)"
 
-# Apply exactly what the L2 fix applies: a single-node chmod 0755 on the
-# legacy mirror dir (the prepare path runs this as `bridge_linux_sudo_root
-# chmod 0755 "$_v2_legacy_mirror_dir"`; here, as the dir owner, a plain
-# chmod is the same operation).
-chmod 0755 "$L2_AGENT_ROOT"
+# --- Negative control (revert-teeth): the pre-normalization 0700 dir has
+#     NO group x-bit. A non-owner member of the dir's group cannot
+#     traverse it — which is the exact #1513 abort. Assert the structural
+#     gap is real on this host before we normalize.
+if _has_group_x "$L2_AGENT_ROOT"; then
+  smoke_fail "L2b negative control: seeded 0700 mirror unexpectedly has group-x — cannot exercise the traverse-bit contract on this host"
+fi
 
+# --- Apply EXACTLY what bridge_linux_prepare_agent_isolation applies to
+#     the legacy mirror dir (the L2a `chgrp $_v2_agent_group` +
+#     `chmod 2750`): group = the agent group (here the surrogate), mode
+#     2750 (group r-x + setgid, NO other access). This is the FINAL state
+#     #1518's 2-VM validation observed (`drwxr-s--- 2750 root:ab-agent-<a>`),
+#     NOT the dead "other"-x 0755. As the dir owner a plain chgrp/chmod is
+#     the same operation the privileged prepare path performs via sudo.
+chgrp "$L2_GRP_SURROGATE" "$L2_AGENT_ROOT" \
+  || smoke_fail "L2b: chgrp '$L2_GRP_SURROGATE' on the mirror dir failed (cannot model the final group)"
+chmod 2750 "$L2_AGENT_ROOT"
+
+# FINAL effective mode = low-bits 750 + setgid; group-x present; other
+# access absent; group == the agent-group surrogate. Reverting the
+# normalization mechanism (dir falls back to 0700 / group=<controller>)
+# fails one of these.
 L2_DIR_MODE="$(_mode_of "$L2_AGENT_ROOT")"
 case "$L2_DIR_MODE" in
-  755) : ;;
-  *) smoke_fail "L2b: legacy mirror dir not 0755 after normalize (got $L2_DIR_MODE)" ;;
+  750|2750) : ;;
+  *) smoke_fail "L2b: legacy mirror dir low-bits not 750 after final-state normalize (got $L2_DIR_MODE) — expected 2750 (group r-x + setgid, no other)" ;;
 esac
+_has_setgid "$L2_AGENT_ROOT" \
+  || smoke_fail "L2b: legacy mirror dir missing setgid after normalize (got $L2_DIR_MODE) — the 2750 contract requires setgid so children inherit the agent group"
+_has_group_x "$L2_AGENT_ROOT" \
+  || smoke_fail "L2b: legacy mirror dir has NO group x-bit after normalize (got $L2_DIR_MODE) — the iso UID (a group member, not owner) could not traverse → #1513 abort returns"
+if _has_other_x "$L2_AGENT_ROOT"; then
+  smoke_fail "L2b: legacy mirror dir has the 'other' x-bit (got $L2_DIR_MODE) — the FINAL contract is 2750 (group-traversable only), NOT the dead 0755; an other-x bit means the dead chmod is back"
+fi
+L2_DIR_GRP="$(_group_of "$L2_AGENT_ROOT")"
+if [[ "$L2_DIR_GRP" != "$L2_GRP_SURROGATE" ]]; then
+  smoke_fail "L2b: legacy mirror dir group not normalized to the agent group '$L2_GRP_SURROGATE' (got '$L2_DIR_GRP') — traversal relies on the iso UID being a member of THIS group"
+fi
 
-# Inner file mode MUST be unchanged by the single-node dir chmod.
+# Inner file mode MUST be unchanged by the dir-only normalization.
 L2_FILE_MODE_AFTER="$(_mode_of "$L2_AGENT_ROOT/.mcp.json")"
 if [[ "$L2_FILE_MODE_AFTER" != "$L2_FILE_MODE_BEFORE" ]]; then
-  smoke_fail "L2b: inner .mcp.json mode changed by the dir chmod ($L2_FILE_MODE_BEFORE -> $L2_FILE_MODE_AFTER) — a single-node chmod must not widen files"
+  smoke_fail "L2b: inner .mcp.json mode changed by the dir normalize ($L2_FILE_MODE_BEFORE -> $L2_FILE_MODE_AFTER) — the legacy mirror's inner 0600 files must not be widened"
 fi
 case "$L2_FILE_MODE_AFTER" in
   600) : ;;
   *) smoke_fail "L2b: inner .mcp.json not 0600 after normalize (got $L2_FILE_MODE_AFTER) — files must stay owner-only" ;;
 esac
 
-# Now the prune can traverse the mirror and returns a clean non-skip
-# result (the seeded mcpServers has no legacy teams entry → unchanged).
+# Now the prune can traverse the mirror (the running process owns it AND
+# is a member of its group) and returns a clean non-skip result (the
+# seeded mcpServers has no legacy teams entry → absent/unchanged).
 L2_OUT="$SMOKE_TMP_ROOT/l2.out"
 L2_RC=0
 "$PY_BIN" "$PRUNE_HELPER" \
@@ -238,19 +379,19 @@ L2_RC=0
 
 if [[ "$L2_RC" -ne 0 ]]; then
   cat "$L2_OUT"
-  smoke_fail "L2b: prune exited non-zero ($L2_RC) against the now-traversable mirror"
+  smoke_fail "L2b: prune exited non-zero ($L2_RC) against the 2750 group-traversable mirror"
 fi
 if grep -E 'reason=stat-failed' "$L2_OUT" >/dev/null; then
   cat "$L2_OUT"
-  smoke_fail "L2b: prune still reports stat-failed after the dir was made traversable — traverse-bit normalization did not take"
+  smoke_fail "L2b: prune still reports stat-failed against the 2750 mirror — the group-traversability contract did not take"
 fi
-smoke_log "L2b PASS — dir 0755 (traversable), inner file stayed 0600, prune reads it cleanly (no stat-failed)"
+smoke_log "L2b PASS — dir 2750 + setgid + group-x (no other-x), group=$L2_GRP_SURROGATE, inner file stayed 0600, prune reads it cleanly (no stat-failed)"
 
 if smoke_is_linux; then
-  smoke_log "host=Linux — L1/L2b ran against the local fs seam; the live OS-user + ab-agent-<a> iso-UID path (sudo-driven legacy mirror chmod, iso-UID prune) is covered by the PR's manual Linux repro"
+  smoke_log "host=Linux — L1/L2b ran against the local fs seam (group=$(id -gn) surrogate); the live OS-user + ab-agent-<a> iso-UID traversal of the 2750 mirror is covered by the PR's manual Linux repro"
 else
-  smoke_log "host=non-Linux — L1/L2b verified via the local mode seam; the live OS-user/group iso-UID prune path is Linux + sudo only (see PR manual repro)"
+  smoke_log "host=non-Linux — L1/L2b verified via the local mode/group seam; the live OS-user/group iso-UID prune path is Linux + sudo only (see PR manual repro)"
 fi
 
-smoke_log "PASS — #1513: iso teams launch survives an unreadable/0700 legacy mirror (L1 prune skips non-fatally; L2 isolate normalizes the mirror dir traverse bit without widening files)"
+smoke_log "PASS — #1513/#1518: iso teams launch survives the legacy mirror (L1 prune skips an unstattable root non-fatally; L2 prepare normalizes the mirror to 2750 group=ab-agent-<a> AFTER the reconciler — group-traversable, not the dead 0755, inner 0600 files untouched)"
 exit 0


### PR DESCRIPTION
## Summary

Code-hygiene + latent-regression follow-up to #1513 (PR #1514). #1513's layer-2 explicit `chmod 0755` on the legacy per-agent mirror dir `$BRIDGE_AGENT_HOME_ROOT/<a>` (= `$BRIDGE_HOME/agents/<a>`) inside `bridge_linux_prepare_agent_isolation` was placed BEFORE the grant-matrix + install-tree reconciler. The v0.16.0-beta2 2-VM validation observed the dir ending `drwxr-s--- 2750 root:ab-agent-<a>`, never the literal `0755` — the chmod was clobbered (dead code) on the non-split install.

**Option taken: B** (the brief's contingency — the internal codex review found a path where Option A would re-break #1513).

## Root cause (two layers)

The internal codex review caught that Option A (just delete the chmod) is unsafe:

- **Non-split layout** (legacy `agents/<a>` *is* the v2 agent root): the recursive setgid/group normalization clobbers `0755` → `2750 root:ab-agent-<a>`. The chmod is dead here.
- **DEFAULT split-root layout** (`BRIDGE_DATA_ROOT = $BRIDGE_HOME/data`, so the v2 runtime root `$BRIDGE_HOME/data/agents/<a>` is a **different** directory than the legacy `$BRIDGE_HOME/agents/<a>` mirror): **no** matrix normalizes the legacy leaf — the reconciler's only `agents/` row is the `$BRIDGE_HOME/agents` **parent** at `0710`, not the per-agent child. So the legacy mirror stays `0700` on the create-shared-then-isolate path, and the old `chmod 0755` (before the reconciler) was the *only* thing covering this case — with the wrong "other"-x contract and at risk of reordering.

Confirmed code paths: `bridge-lib.sh:466` (`BRIDGE_AGENT_HOME_ROOT=$BRIDGE_HOME/agents`), `bridge-isolation-v2.sh:101` (`BRIDGE_AGENT_ROOT_V2=$BRIDGE_DATA_ROOT/agents`), layout-resolver default `BRIDGE_DATA_ROOT=$BRIDGE_HOME/data`, and `bridge-run.sh:1219` passing `--agent-root $BRIDGE_AGENT_HOME_ROOT/$AGENT` (the legacy path) to the prune.

## Fix

Move the legacy-mirror normalization to run **last** in `bridge_linux_prepare_agent_isolation`, after the grant-matrix **and** install-tree reconciler, and set the narrower group-traverse contract:

```
chgrp ab-agent-<a> + chmod 2750  →  drwxr-s--- 2750 root:ab-agent-<a>
```

- group r-x + setgid, **no** "other" access (narrower than the old `0755`).
- iso UID `agent-bridge-<a>` is a member of `ab-agent-<a>` → traverses via the **group** x-bit.
- Both layouts now converge to the same final state, and it can never be clobbered (runs after every normalizer; `write_agent_metadata` after it does not re-touch the dir).
- `$_v2_agent_group` is the same per-agent group this function already `ensure_group`s + chgrps the v2 root to — no new identity introduced.
- Dir-node only (not recursive): inner 0600 files untouched.
- Linux-only: the function early-returns on non-Linux (complete no-op on macOS/dev hosts).
- **#1513's user-facing fix preserved**: the `bridge-run.sh` Teams MCP prune (run AS the iso UID against the legacy agent-root) traverses cleanly → no `stale Teams MCP cleanup failed` abort. L1 (the python prune-skip safety net) is unchanged.

## 2-VM-equivalent reasoning (mirror stays iso-traversable)

- **VM-A, split-root default** (`BRIDGE_DATA_ROOT=$BRIDGE_HOME/data`): nothing else normalizes `$BRIDGE_HOME/agents/<a>`; this block now sets it `2750 ab-agent-<a>` → iso UID traverses via group-x. (Was the re-break risk of Option A.)
- **VM-B, non-split** (legacy == v2 root): the recursive normalization already lands `2750 ab-agent-<a>`; this block re-asserts the same final state idempotently (no "other"-x widening from the old 0755).

## Smoke (asserts the FINAL state, with revert-teeth)

`scripts/smoke/1513-iso-teams-prune-eacces.sh`:
- **L2a** asserts the FINAL contract: `chgrp $_v2_agent_group` + `chmod 2750` on the legacy mirror dir, running **after** the install-tree reconciler (line-order check), **not** the dead "other"-x 0755, **not** a recursive `-R` widen.
- **L2b** models the final `2750`/group state on the local-fs seam (`chgrp $(id -gn)` + `chmod 2750`) and asserts low-bits 750 + setgid + group-x + **no** other-x + group + inner `.mcp.json` stays 0600 + prune returns clean (no `stat-failed`); a `0700` negative control proves the pre-norm state has no group-x.
- **Revert-teeth verified**: re-adding the dead 0755 fails L2a; moving the chmod before the reconciler fails the L2a ordering check; the dir staying 0700 fails L2b.

## Verification

- `bash -n` (homebrew bash), `shellcheck` — clean
- `lint-heredoc-ban` + `--baseline-check` — PASS (no new heredocs)
- `iso-helper-ratchet` — OK (no regression)
- `1513-iso-teams-prune-eacces` smoke — PASS (with revert-teeth)
- siblings `1506-isolate-normalize`, `prune-legacy-teams-mcp` — PASS
- internal codex review (Phase-4): **implement-ok** (after a `needs-more` round that flagged the split-root path → drove Option A → Option B)

Closes #1518.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
