### PR TITLE
feat(ms365,teams): embed agent id in OAuth state to demux /auth/callback for multi-agent setups

### DIFF
--- a/plugins/ms365/server.ts
+++ b/plugins/ms365/server.ts
@@ -150,6 +150,17 @@ const TENANT_ID = process.env.MS365_TENANT_ID ?? ''
 const CLIENT_ID = process.env.MS365_CLIENT_ID ?? ''
 const CLIENT_SECRET = process.env.MS365_CLIENT_SECRET ?? ''
 const DEFAULT_UPN = process.env.MS365_DEFAULT_UPN ?? ''
+// Multi-agent OAuth callback demux: when several isolated agents share one
+// public bot endpoint behind a router (one Azure app, N per-agent listeners),
+// the OAuth `/auth/callback` carries no agent identity — only ?code&state.
+// We embed the originating agent id as a `<agent>.<uuid>` prefix in the OAuth
+// `state` (Microsoft echoes `state` back verbatim) so the router can route the
+// callback to the agent that started the pairing. Sanitized to the callback
+// state charset so a malformed BRIDGE_AGENT_ID degrades to a plain-uuid state
+// (single-listener behavior, no demux). See teams plugin `/auth/callback`.
+const AGENT_TAG = /^[A-Za-z0-9_-]{1,64}$/.test((process.env.BRIDGE_AGENT_ID ?? '').trim())
+  ? (process.env.BRIDGE_AGENT_ID ?? '').trim()
+  : ''
 const DEFAULT_SCOPES =
   process.env.MS365_DEFAULT_SCOPES ??
   'openid profile offline_access User.Read Mail.Read Mail.Send Calendars.Read Calendars.ReadWrite People.Read User.Read.All Directory.Read.All Chat.ReadWrite'
@@ -376,7 +387,10 @@ function callbackPath(state: string): string {
 }
 
 function startAuthCode(upn: string, scopes: string, redirectUri: string): PendingFile {
-  const state = randomUUID()
+  // `<agent>.<uuid>` when running under the bridge multi-agent router, else a
+  // plain uuid. The `.` separator is absent from bridge agent ids and uuids, so
+  // the router can recover the agent with `state.split('.')[0]`.
+  const state = AGENT_TAG ? `${AGENT_TAG}.${randomUUID()}` : randomUUID()
   const now = Math.floor(Date.now() / 1000)
   const authorizeParams = new URLSearchParams({
     client_id: CLIENT_ID,

--- a/plugins/teams/server.ts
+++ b/plugins/teams/server.ts
@@ -265,7 +265,11 @@ function saveJson(path: string, payload: unknown): void {
 }
 
 function ms365CallbackStateValid(state: string): boolean {
-  return /^[A-Za-z0-9_-]{8,128}$/.test(state)
+  // Allow a `.` so the multi-agent router can carry a `<agent>.<uuid>` prefix
+  // (the ms365 plugin embeds BRIDGE_AGENT_ID to demux a shared /auth/callback).
+  // No `/` is permitted, so `ms365CallbackPath` can never escape the callback
+  // dir; min length 8 still rejects `..`. Max bumped to fit agent prefix+uuid.
+  return /^[A-Za-z0-9_.-]{8,160}$/.test(state)
 }
 
 function ms365CallbackPath(state: string): string {


### PR DESCRIPTION
Fixes #1523

## What

Embed the originating agent id in the Microsoft 365 OAuth `state` so a router can demux a **shared `/auth/callback`** to the agent that started the pairing. Fixes multi-agent M365 pairing when one Azure Bot app fronts N per-agent Teams listeners (see linked issue).

## Why

The OAuth callback has no `aadObjectId` — only `?code&state`. With one bot app and N per-agent listeners, the router can't tell which agent's pairing a callback belongs to, so it blanket-routes to a default listener. The callback file is then written `0600` by the wrong agent and the originating agent (a different OS user under linux-user isolation) can never read it → pairing stalls. Microsoft echoes `state` back verbatim, so `state` is the one signal available on the callback.

## How (2 small, backward-compatible changes)

**`plugins/ms365/server.ts`**
- New `AGENT_TAG` derived from `BRIDGE_AGENT_ID`, sanitized to `/^[A-Za-z0-9_-]{1,64}$/`.
- `startAuthCode`: `state = AGENT_TAG ? \`${AGENT_TAG}.${randomUUID()}\` : randomUUID()`.
- When `BRIDGE_AGENT_ID` is unset/malformed → plain uuid → **identical to today's single-listener behavior** (no demux, no regression).

**`plugins/teams/server.ts`**
- `ms365CallbackStateValid`: allow `.` (`/^[A-Za-z0-9_.-]{8,160}$/`). No `/` is permitted, so `ms365CallbackPath(state)` still cannot escape the callback dir; min-length 8 still rejects `..`. Max length bumped to fit `<agent>.<uuid>`.

The router that consumes this (`state.split('.')[0]` → agent → port, unknown → default) is deployment-specific and intentionally **not** part of this PR; the plugin changes are what make a correct demux possible.

## Compatibility & security

- Fully backward compatible: no `BRIDGE_AGENT_ID` → plain-uuid state → current behavior.
- `state` carries only the agent **name** (not a secret); the `.` separator is absent from bridge agent ids and uuids, so `state.split('.')[0]` recovers the agent unambiguously.
- No path-traversal surface added (no `/` in the validator; the callback dir's per-listener `0600` isolation is preserved — the fix routes the callback to the right listener rather than sharing files).

## Testing

- Synthetic: router demux verified — `cosmax-sales.<uuid>` → the agent's port, plain/unknown → default.
- **Live end-to-end**: a non-default isolated agent ran `pair_start` (emitted `state=cosmax-sales.<uuid>`), the user signed in, the callback routed correctly, the delegated token was captured (`has_refresh_token=true`), and downstream CRM + EP plugin calls returned real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)