### PR TITLE
release(plugins): teams + ms365 0.1.1 — multi-user M365 OAuth demux (#1523)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
       "name": "teams",
       "source": "./plugins/teams",
       "description": "Microsoft Teams channel for Claude Code with Agent Bridge access control and setup integration.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "messaging",
       "tags": ["teams", "messaging", "channel", "mcp"]
     },
@@ -21,7 +21,7 @@
       "name": "ms365",
       "source": "./plugins/ms365",
       "description": "Microsoft 365 / Graph API tools for Claude Code with Agent Bridge channel state and disclosure policy integration.",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "productivity",
       "tags": ["microsoft", "m365", "graph", "mail", "calendar", "teams", "mcp"]
     },

--- a/plugins/ms365/.claude-plugin/plugin.json
+++ b/plugins/ms365/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ms365",
   "description": "Microsoft 365 / Graph API tools for Claude Code. Per-UPN delegated token management via OAuth authorization code flow (paired through the Teams plugin's /auth/callback handler). Tools for mail, calendar, people, directory, and Teams chat.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Agent Bridge",
     "email": "maintainers@agent-bridge.local"

--- a/plugins/ms365/package.json
+++ b/plugins/ms365/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-ms365-mcp",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "bin": "./server.ts",

--- a/plugins/teams/.claude-plugin/plugin.json
+++ b/plugins/teams/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "teams",
   "description": "Microsoft Teams channel for Claude Code. Receives Azure Bot Service activities over HTTP and exposes reply/fetch tools through MCP.",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": {
     "name": "Agent Bridge",
     "email": "maintainers@agent-bridge.local"

--- a/plugins/teams/package.json
+++ b/plugins/teams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-channel-teams",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "bin": "./server.ts",


### PR DESCRIPTION
## teams + ms365 plugin release 0.1.0 → 0.1.1

Version-fields-only bump (`plugin.json` + `package.json` + the two `.claude-plugin/marketplace.json` entries) so installs that pull the marketplace pick up the **multi-user M365 OAuth callback demux** (#1523, merged via #1524, f81ade31): behind one Azure bot app + a per-deployment router, a shared `/auth/callback` demuxes to the originating agent via an `<agent>.<uuid>` OAuth `state` (validated live on cm-prod — real M365 delegated-token pairing).

5 files / +6/-6, version strings only. No code change (the code shipped in #1524).