### PR TITLE
feat(a2a): Rooms P4.1 — cross-node JOIN (pending-only, OS-actor-anchored)

### DIFF
--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -830,6 +830,17 @@ class HandoffHandler(BaseHTTPRequestHandler):
         if self.path == identity_update_path:
             self._handle_identity_update(cfg)
             return
+        # A2A Rooms P4.1 (design §11 / §14 R3): the signed cross-node
+        # room-join-request is ALSO routed to a SEPARATE handler with the same
+        # fail-closed auth preamble (remote_addr -> HMAC -> skew -> dedupe). Its
+        # terminal action is a token-verified PENDING join row — it NEVER reaches
+        # the enqueue/allowlist/queue boundary, creates no leader task, and
+        # admits nothing (approve is P4.2).
+        room_join_path = cfg.get("listen", {}).get(
+            "room_join_path", a2a.ROOM_JOIN_PATH)
+        if self.path == room_join_path:
+            self._handle_room_join_request(cfg)
+            return
         if self.path != enqueue_path:
             self._reply(404, {"ok": False, "error": "not found"})
             return
@@ -1494,6 +1505,423 @@ class HandoffHandler(BaseHTTPRequestHandler):
             return "new"
         finally:
             conn.close()
+
+    def _handle_room_join_request(self, cfg: dict[str, Any]) -> None:
+        """Receiver branch for the signed cross-node room-join-request
+        (A2A Rooms P4.1, design §11 / §14 R3).
+
+        HIGH-RISK: this is the only NEW remote-traffic surface in P4.1. It runs
+        the SAME fail-closed auth preamble as do_POST / _handle_identity_update
+        (NO step weakened), then performs the room-specific verification and
+        persists a PENDING join row. Validation ORDER (security=True audit on
+        every reject; NO persistence until ALL pass):
+          a. tailnet-only bind — guaranteed at startup (resolve_bind).
+          b. protocol tag == ROOM_JOIN_PROTOCOL_VERSION.
+          c. message_id REQUIRED (anchors dedupe + is in the signed canonical).
+          d. peer ALREADY PAIRED (find_peer; unknown -> 403). NOT discovery.
+          e. remote_addr == the peer's CURRENT resolved Tailscale IP (before
+             the body is read off the socket).
+          f. HMAC: secret present, body hash, signature (constant-time). The
+             request PATH is in the canonical string, so an enqueue/identity
+             signature cannot be replayed against this endpoint.
+          g. clock-skew window — transient drift 503, far-stale 401.
+          h. durable dedupe (replay-safe) on message_id.
+          i. parse the control body (shape only — never trusts the joiner id
+             beyond the node-link auth already enforced).
+          j. room is on THIS node (leader_node == this node) — else 404; a node
+             that does not lead the room has no authority to admit/queue it.
+          k. token verify: hash compare + TTL + revocation (verify_invite_token_
+             outcome). expired/revoked/mismatch -> 403, NO pending row.
+          l. rate-limit per (token-hash, SOURCE NODE) — a leaked reusable token
+             cannot mint unbounded pending rows from one node.
+          m. persist a VERIFIED pending row anchored to `joiner_agent` (the
+             OS-actor attestation made by node B) @ the HMAC-AUTHENTICATED
+             sender bridge as the node (NEVER a wire-asserted node). NO
+             membership add, NO leader task, NO token/hash in the row/audit.
+        """
+        client_ip = self._client_ip()
+        peer_id = self.headers.get("X-AGB-Peer", "")
+        message_id = self.headers.get("X-AGB-Message-Id", "")
+        timestamp = self.headers.get("X-AGB-Timestamp", "")
+        body_hash_hdr = self.headers.get("X-AGB-Body-SHA256", "")
+        signature = self.headers.get("X-AGB-Signature", "")
+        protocol = self.headers.get("X-AGB-Protocol", "")
+
+        # --- b. protocol tag ---
+        if protocol != a2a.ROOM_JOIN_PROTOCOL_VERSION:
+            audit("room_join_reject", reason="bad_protocol",
+                  peer=peer_id, client=client_ip, got=protocol)
+            self._reply(400, {"ok": False, "error": "unsupported protocol"})
+            return
+
+        # --- c. message_id REQUIRED (non-empty) ---
+        if not message_id:
+            audit("room_join_reject", reason="missing_message_id",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(400, {"ok": False, "error": "message id required"})
+            return
+
+        # --- d. peer must be ALREADY PAIRED (not a discovery channel) ---
+        try:
+            peer = a2a.find_peer(cfg, peer_id)
+        except a2a.A2AError:
+            audit("room_join_reject", reason="unknown_peer",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "unknown peer"})
+            return
+
+        # --- e. remote_addr == authenticated peer's CURRENT address (before body) ---
+        try:
+            peer_addr = a2a.resolve_peer_address(peer)
+        except a2a.A2AError as exc:
+            audit("room_join_reject", reason=getattr(exc, "code",
+                  "resolve_error"), peer=peer_id, client=client_ip,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+        if not peer_addr or client_ip != peer_addr:
+            audit("room_join_reject", reason="addr_mismatch",
+                  peer=peer_id, client=client_ip, expected=peer_addr,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+
+        # --- size guard before reading the body (tiny control body) ---
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            content_length = -1
+        if content_length < 0:
+            self._reply(411, {"ok": False, "error": "length required"})
+            return
+        max_body = 8 * 1024
+        if content_length > max_body:
+            audit("room_join_reject", reason="oversize",
+                  peer=peer_id, client=client_ip, declared=content_length)
+            self._reply(413, {"ok": False, "error": "body too large"})
+            return
+        raw = self.rfile.read(content_length) if content_length else b""
+
+        # --- f. HMAC: secret present, body hash, signature (auth boundary) ---
+        secrets = a2a.peer_secrets(peer)
+        if not secrets:
+            audit("room_join_reject", reason="no_secret",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "peer not provisioned"})
+            return
+        computed_hash = a2a.body_sha256(raw)
+        if body_hash_hdr != computed_hash:
+            audit("room_join_reject", reason="body_hash",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "body hash mismatch"})
+            return
+        # HMAC FIRST (before timestamp-band classification) so an
+        # unauthenticated request never receives a transient/permanent split
+        # that leaks signature validity (same ordering as do_POST, #1346). The
+        # path is part of the canonical string, so an enqueue signature cannot
+        # be replayed against this control endpoint.
+        canonical = a2a.canonical_string(
+            "POST", self.path, peer_id, message_id, timestamp, computed_hash)
+        if not a2a.verify_signature(secrets, canonical, signature):
+            audit("room_join_reject", reason="bad_signature",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(401, {"ok": False, "error": "signature verification failed"})
+            return
+
+        # --- g. clock-skew window (authenticated past this point) ---
+        skew = int(cfg.get("timestamp_skew_seconds",
+                           a2a.DEFAULT_TIMESTAMP_SKEW_SECONDS))
+        grace_skew = int(cfg.get("timestamp_skew_grace_seconds",
+                                 a2a.DEFAULT_TIMESTAMP_SKEW_GRACE_SECONDS))
+        if grace_skew < skew:
+            grace_skew = skew
+        receiver_now = a2a.now_ts()
+        try:
+            req_ts = int(timestamp)
+        except (TypeError, ValueError):
+            audit("room_join_reject", reason="bad_timestamp",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "bad timestamp"})
+            return
+        ts_delta = abs(receiver_now - req_ts)
+        if ts_delta > grace_skew:
+            audit("room_join_reject", reason="clock_skew_permanent",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta,
+                  security=True)
+            self._reply(401, {"ok": False,
+                              "error": "timestamp far outside skew window",
+                              "receiver_ts": receiver_now})
+            return
+        if ts_delta > skew:
+            audit("room_join_reject", reason="clock_skew_transient",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta)
+            self._reply(503, {"ok": False,
+                              "error": "timestamp outside skew window — retry",
+                              "receiver_ts": receiver_now},
+                        extra_headers={"Retry-After": str(max(1, skew))})
+            return
+
+        # --- h. durable dedupe — READ-ONLY replay check (codex P4.1 r1/r2) ---
+        # CRITICAL: only a PREVIOUSLY-ACCEPTED request may replay as an
+        # idempotent 200. The dedupe ledger lives in rooms.db (NOT inbox.db) so
+        # the reservation commits ATOMICALLY with the pending row on the accept
+        # path (step m); a dedupe row therefore exists IFF a pending row exists.
+        # This read-only lookup gives the fast idempotent/conflict answer for an
+        # ALREADY-ACCEPTED id; a rejected request leaves NO dedupe row, so a
+        # replay re-runs verification and re-rejects (T3/T5 hold on replay). If
+        # rooms.db is absent (this is not the leader node), the lookup is "new"
+        # and the leader-node check (step j) will 404 anyway.
+        if rooms is None:
+            audit("room_join_error", reason="rooms_module_unavailable",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms unavailable"})
+            return
+        try:
+            ro = rooms.open_rooms_readonly()
+            if ro is not None:
+                try:
+                    dup = rooms.room_join_dedupe_lookup(
+                        ro, message_id, computed_hash)
+                finally:
+                    ro.close()
+            else:
+                dup = "new"
+        except Exception as exc:  # noqa: BLE001 - last-resort guard
+            audit("room_join_error", reason="dedupe_error",
+                  peer=peer_id, client=client_ip, detail=str(exc)[:200])
+            self._reply(500, {"ok": False, "error": "internal error"})
+            return
+        if dup == rooms.JOIN_DEDUPE_DUPLICATE:
+            audit("room_join_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True})
+            return
+        if dup == rooms.JOIN_DEDUPE_CONFLICT:
+            audit("room_join_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+
+        # --- i. parse the control body (shape only) ---
+        try:
+            claim = a2a.parse_room_join_request(raw)
+        except a2a.A2AError as exc:
+            audit("room_join_reject", reason=getattr(exc, "code",
+                  "bad_room_join"), peer=peer_id, client=client_ip,
+                  message_id=message_id)
+            self._reply(422, {"ok": False, "error": str(exc)})
+            return
+
+        # (rooms-module availability was already asserted at step h.)
+        room_id = str(claim["room_id"])
+        token_hash = str(claim["join_token_sha256"])
+        joiner_agent = str(claim["joiner_agent"])
+        # The joiner's NODE is the HMAC-authenticated sender bridge — NEVER a
+        # wire-asserted field (contract 2). `peer_id` is the signed X-AGB-Peer
+        # the auth preamble already bound to this connection.
+        joiner_node = peer_id
+        this_node = str(cfg.get("bridge_id") or "")
+
+        # Open the rooms db to verify + persist. A leader-node receiver MUST have
+        # the controller-owned rooms.db; we open it read-write (the verified
+        # pending-row write needs it). open_rooms() creates it if absent, but a
+        # genuine leader node always has it — and a non-leader node fails the
+        # leader-node check below anyway, persisting nothing.
+        try:
+            conn = rooms.open_rooms()
+        except rooms.RoomsError as exc:
+            audit("room_join_error", reason=getattr(exc, "code", "rooms_db"),
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms db error"})
+            return
+        try:
+            room = rooms.get_room(conn, room_id)
+            if room is None:
+                audit("room_join_reject", reason="room_unknown",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(404, {"ok": False, "error": "room not found"})
+                return
+
+            # --- j. room must be LED BY this node (else we have no authority) ---
+            leader_node = str(room["leader_node"] or "")
+            if leader_node != this_node:
+                audit("room_join_reject", reason="not_leader_node",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(404, {"ok": False,
+                                  "error": "room not led by this node"})
+                return
+
+            # --- k. token verify: hash + TTL + revocation (NEVER log the hash) ---
+            # The wire carried sha256(token); compare it to the stored hash with
+            # the SAME TTL/revocation semantics verify_invite_token_outcome
+            # applies to a raw token, by hashing through a thin shim. We do NOT
+            # reconstruct the raw token (we never have it) — instead we compare
+            # the presented hash to the stored hash directly with TTL on top.
+            outcome = _room_join_verify_hash(room, token_hash)
+            if outcome != rooms.TOKEN_OK:
+                # outcome is one of mismatch/revoked/expired — a stable,
+                # token-free code, safe to audit.
+                audit("room_join_reject", reason=f"token_{outcome}",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(403, {"ok": False,
+                                  "error": f"invite token {outcome}"})
+                return
+
+            # --- l. rate-limit per (token-hash, SOURCE NODE) ---
+            # Keyed on the source NODE (the authenticated peer), so a leaked
+            # reusable token cannot mint unbounded pending rows from one node.
+            # record_join_attempt keys its counter on the token HASH internally;
+            # we pass the already-hashed token via the hash-preserving shim so
+            # the raw token is never needed.
+            try:
+                _room_join_rate_check(conn, token_hash, source=joiner_node)
+            except rooms.RoomsError as exc:
+                audit("room_join_reject", reason="rate_limited",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(429, {"ok": False, "error": str(exc)},
+                            extra_headers={"Retry-After": "120"})
+                return
+
+            # --- m. ACCEPT: reserve the dedupe row + persist the pending row
+            # ATOMICALLY in ONE rooms.db transaction (codex P4.1 r2). Because
+            # both writes commit together (or roll back together), "a dedupe row
+            # exists" is equivalent to "a pending row exists" — there is no window
+            # where a surviving reservation could let a replay return a bogus
+            # idempotent 200 with no pending row. The re-check inside the call
+            # closes the concurrent-replay-reserved-first race, resolving it to
+            # the same idempotent/conflict outcome the read-only lookup would have.
+            ttl_expiry = 0
+            try:
+                ttl = int(room["invite_token_ttl"])
+                if ttl > 0:
+                    ttl_expiry = int(room["invite_token_ts"]) + ttl
+            except (KeyError, IndexError, TypeError, ValueError):
+                ttl_expiry = 0
+            try:
+                outcome = rooms.record_verified_cross_node_join_request_atomic(
+                    conn, message_id=message_id, body_sha256=computed_hash,
+                    peer=peer_id, room_id=room_id, agent=joiner_agent,
+                    node=joiner_node, via_node=joiner_node,
+                    ttl_expiry=ttl_expiry,
+                )
+            except Exception as exc:  # noqa: BLE001 - last-resort guard
+                # The atomic helper rolled BOTH writes back on failure, so no
+                # orphan dedupe row survives → a replay re-runs verification.
+                audit("room_join_error", reason="persist_error",
+                      peer=peer_id, client=client_ip, message_id=message_id,
+                      detail=str(exc)[:200])
+                self._reply(500, {"ok": False, "error": "internal error"})
+                return
+        finally:
+            conn.close()
+
+        if outcome == rooms.JOIN_DEDUPE_DUPLICATE:
+            audit("room_join_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True})
+            return
+        if outcome == rooms.JOIN_DEDUPE_CONFLICT:
+            audit("room_join_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+
+        # Audit carries ONLY verified metadata — room id, joiner agent@node,
+        # message id — NEVER the token or its hash (contract 5).
+        audit("room_join_accept", reason="pending",
+              peer=peer_id, client=client_ip, room_id=room_id,
+              joiner=f"{joiner_agent}@{joiner_node}", message_id=message_id)
+        self._reply(200, {"ok": True, "status": rooms.JOIN_PENDING,
+                          "room_id": room_id,
+                          "joiner": f"{joiner_agent}@{joiner_node}"})
+
+
+# --------------------------------------------------------------------------
+# Room-join hash-only verification + rate-limit shims (P4.1)
+# --------------------------------------------------------------------------
+#
+# The wire carries sha256(token), NOT the raw token, so the leader-node receiver
+# never possesses the raw token. The rooms_common verify/rate helpers were
+# written for the single-node path that DOES hold the raw token (it hashes
+# internally). These shims let the receiver apply the SAME TTL/revocation +
+# rate-limit semantics to an already-hashed token without reconstructing the
+# raw value (which is impossible) and without duplicating the rooms_common
+# logic. They live here (the receiver), not in rooms_common, because they are a
+# cross-node-receiver-specific adaptation of the existing primitives.
+
+
+def _room_join_verify_hash(room: Any, token_hash: str) -> str:
+    """Verify a presented token HASH against the room (hash + TTL + revocation).
+
+    Mirrors rooms.verify_invite_token_outcome but takes the hash directly (the
+    receiver never has the raw token). Returns a rooms.TOKEN_* code. The order
+    matches the raw-token path: revocation -> constant-time hash compare ->
+    TTL — so the receiver path can never be MORE permissive than the local path.
+    """
+    import hmac as _hmac
+
+    stored = room["invite_token_sha256"]
+    if not stored:
+        return rooms.TOKEN_REVOKED
+    if not _hmac.compare_digest(str(stored), token_hash):
+        return rooms.TOKEN_MISMATCH
+    try:
+        ttl = int(room["invite_token_ttl"])
+    except (KeyError, IndexError, TypeError, ValueError):
+        ttl = 0
+    if ttl > 0:
+        try:
+            issued = int(room["invite_token_ts"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            issued = 0
+        if issued + ttl < a2a.now_ts():
+            return rooms.TOKEN_EXPIRED
+    return rooms.TOKEN_OK
+
+
+def _room_join_rate_check(conn: Any, token_hash: str, *, source: str) -> None:
+    """Per-(token-hash, source-node) rate limit using the room_join_rate table.
+
+    Mirrors rooms.record_join_attempt's counter logic but keys directly on the
+    already-known token HASH (the receiver does not have the raw token to hash).
+    Raises rooms.RoomsError(code='rate_limited') past the ceiling. Kept in lock-
+    step with rooms.record_join_attempt's DEFAULT ceiling + schema.
+    """
+    limit = rooms.DEFAULT_JOIN_RATE_LIMIT_PER_TOKEN
+    ts = rooms.now_ts()
+    row = conn.execute(
+        "SELECT attempts FROM room_join_rate WHERE token_sha256=? AND source=?",
+        (token_hash, source),
+    ).fetchone()
+    attempts = (int(row["attempts"]) if row else 0) + 1
+    if row:
+        conn.execute(
+            "UPDATE room_join_rate SET attempts=?, last_ts=? "
+            "WHERE token_sha256=? AND source=?",
+            (attempts, ts, token_hash, source),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO room_join_rate (token_sha256, source, attempts, "
+            "first_ts, last_ts) VALUES (?, ?, ?, ?, ?)",
+            (token_hash, source, attempts, ts, ts),
+        )
+    conn.commit()
+    if attempts > limit:
+        raise rooms.RoomsError(
+            "join rate limit exceeded for this invite token "
+            f"(source node, {attempts} attempts > {limit})",
+            code="rate_limited",
+        )
 
 
 # --------------------------------------------------------------------------

--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -1682,7 +1682,7 @@ class HandoffHandler(BaseHTTPRequestHandler):
             if ro is not None:
                 try:
                     dup = rooms.room_join_dedupe_lookup(
-                        ro, message_id, computed_hash)
+                        ro, peer_id, message_id, computed_hash)
                 finally:
                     ro.close()
             else:

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -270,11 +270,12 @@ def cmd_create(args: argparse.Namespace) -> int:
     node = local_node()
     leader = caller_agent(args)
     token = rooms.mint_invite_token()
+    ttl = max(0, int(getattr(args, "ttl", 0) or 0))
     conn = rooms.open_rooms()
     try:
         room_id = rooms.create_room(
             conn, name=args.name or "", leader_agent=leader,
-            leader_node=node, token=token, once=False,
+            leader_node=node, token=token, once=False, ttl=ttl,
         )
     finally:
         conn.close()
@@ -380,11 +381,12 @@ def _require_leader_conn(conn: Any, room_id: str,
 
 def cmd_invite(args: argparse.Namespace) -> int:
     node = local_node()
+    ttl = max(0, int(getattr(args, "ttl", 0) or 0))
     conn = rooms.open_rooms()
     try:
         _require_leader_conn(conn, args.room_id, args)
         token = rooms.mint_invite_token()
-        rooms.set_invite_token(conn, args.room_id, token, once=args.once)
+        rooms.set_invite_token(conn, args.room_id, token, once=args.once, ttl=ttl)
     finally:
         conn.close()
     link = rooms.make_invite_link(args.room_id, node, token)
@@ -405,20 +407,182 @@ def cmd_rotate_invite(args: argparse.Namespace) -> int:
     return cmd_invite(args)
 
 
+def _post_room_join_request(*, leader_node: str, room_id: str, token: str,
+                            joiner_agent: str, timeout: float = 30.0,
+                            ) -> tuple[int, bytes]:
+    """POST a signed cross-node room-join-request to the leader's node (P4.1).
+
+    The leader's node id (`leader_node`) names the A2A peer to deliver to. We
+    resolve that peer from the local A2A config, sign the body with the node-link
+    HMAC secret, and POST to the leader's `room_join_path`. The wire carries
+    sha256(token) ONLY (hash_token) — the raw token never leaves this process.
+    `joiner_agent` is the OS-actor-anchored agent id (resolved by the CALLER via
+    caller_agent / resolve_os_actor) — NEVER a --from/env value. Returns
+    (http_status, response_body).
+
+    A test seam (BRIDGE_ROOMS_TEST_POST_HOOK, gated by the paired
+    BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1 + BRIDGE_A2A_ALLOW_TEST_BIND=1 flags) lets
+    the smoke capture the signed request + stub the transport so no real
+    Tailscale / live receiver is needed. It is NEVER honored in production (the
+    paired flags are unset there).
+    """
+    if a2a is None:  # pragma: no cover - a2a always ships beside this
+        raise rooms.RoomsError(
+            "cross-node join requires the A2A module + node-link config",
+            code="a2a_unavailable",
+        )
+    cfg = a2a.load_config()
+    local_bridge_id = str(cfg.get("bridge_id", "") or "").strip()
+    if not local_bridge_id:
+        raise rooms.RoomsError(
+            "config has no 'bridge_id' — cannot identify this node for a "
+            "cross-node join", code="no_bridge_id",
+        )
+    peer = a2a.find_peer(cfg, leader_node)
+    secret = a2a.peer_send_secret(peer)
+    token_hash = rooms.hash_token(token)
+    body = a2a.build_room_join_request(
+        room_id=room_id, join_token_sha256=token_hash, joiner_agent=joiner_agent,
+    )
+    body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    message_id = a2a.new_message_id(local_bridge_id)
+    path = peer.get("room_join_path", a2a.ROOM_JOIN_PATH)
+    timestamp = str(a2a.now_ts())
+    body_hash = a2a.body_sha256(body_bytes)
+    canonical = a2a.canonical_string(
+        "POST", path, local_bridge_id, message_id, timestamp, body_hash)
+    signature = a2a.sign(secret, canonical)
+    headers = {
+        "Content-Type": "application/json",
+        "X-AGB-Protocol": a2a.ROOM_JOIN_PROTOCOL_VERSION,
+        "X-AGB-Peer": local_bridge_id,
+        "X-AGB-Message-Id": message_id,
+        "X-AGB-Timestamp": timestamp,
+        "X-AGB-Body-SHA256": body_hash,
+        "X-AGB-Signature": signature,
+    }
+
+    # Test seam: capture the fully-signed request + return a stubbed response,
+    # so the smoke exercises the real sender (signing, OS-actor joiner id, hash-
+    # only body) against the real receiver WITHOUT a live socket / Tailscale.
+    if _test_post_hook_allowed():
+        return _invoke_test_post_hook(path=path, headers=headers,
+                                      body_bytes=body_bytes)
+
+    address = a2a.resolve_peer_address(peer)
+    port = int(peer.get("port", cfg.get("listen", {}).get("port", 8787)))
+    if not address:
+        raise rooms.RoomsError(
+            f"leader node {leader_node!r} has no resolvable address",
+            code="no_leader_address",
+        )
+    import urllib.request
+
+    url = f"http://{address}:{port}{path}"
+    req = urllib.request.Request(url, data=body_bytes, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        return exc.code, (exc.read() or b"")
+
+
+def _test_post_hook_allowed() -> bool:
+    """Paired-flag gate for the cross-node POST test seam (prod-inert)."""
+    # noqa markers: these are plain env-VAR reads (test-seam gating), NOT
+    # isolated `.env` FILE access — the iso-helper-ratchet pattern matches the
+    # `.env` substring inside `os.environ`, a false positive here.
+    return (os.environ.get("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP") == "1"  # noqa: iso-helper-boundary - env var, not a .env file
+            and os.environ.get("BRIDGE_A2A_ALLOW_TEST_BIND") == "1"  # noqa: iso-helper-boundary - env var, not a .env file
+            and bool(os.environ.get("BRIDGE_ROOMS_TEST_POST_HOOK")))  # noqa: iso-helper-boundary - env var, not a .env file
+
+
+def _invoke_test_post_hook(*, path: str, headers: dict,
+                           body_bytes: bytes) -> tuple[int, bytes]:
+    """Write the signed request to the hook file + return a stubbed 200.
+
+    The hook value is a file path the smoke reads to assert on the signed
+    request (it can then replay it against the real receiver handler). Returns a
+    synthetic 200 so the CLI reports the pending post as sent.
+    """
+    import subprocess
+
+    hook = os.environ["BRIDGE_ROOMS_TEST_POST_HOOK"]  # noqa: iso-helper-boundary - env var, not a .env file
+    payload = {
+        "path": path, "headers": headers,
+        "body": body_bytes.decode("utf-8"),
+    }
+    # The hook is a script invoked with the JSON payload on argv (file-as-argv,
+    # never stdin — footgun #11 hygiene). Its stdout (if any) is the stubbed
+    # response body; a non-zero exit surfaces as a 503 to the caller.
+    try:
+        proc = subprocess.run(
+            [hook, json.dumps(payload)], capture_output=True, text=True,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise rooms.RoomsError(f"test post hook failed: {exc}",
+                               code="test_hook_error")
+    if proc.returncode != 0:
+        return 503, (proc.stderr or "test hook non-zero").encode("utf-8")
+    return 200, (proc.stdout or "").encode("utf-8")
+
+
 def cmd_join(args: argparse.Namespace) -> int:
     parsed = rooms.parse_invite_link(args.link)
     room_id = parsed.get("room", "")
     token = parsed.get("t", "")
+    leader_node = parsed.get("leader", "")
+    # THE joiner identity (contract 2): the OS-actor-anchored trusted agent
+    # (resolve_os_actor / pwd.getpwuid), NEVER --from / BRIDGE_AGENT_ID / USER.
+    # The SAME anchor single-node uses — so a hostile --from/env cannot change
+    # the recorded joiner on either path.
     agent = caller_agent(args)
     node = local_node()
+    if not token:
+        return die("invite link carries no token (t=...) — a join needs "
+                   "the token-bearing link, not a bare room id", code=1)
+
+    # Cross-node (P4.1): the link names a leader node that is NOT this node.
+    # Post the join-request to the leader's node over the node-link; the leader
+    # verifies + persists the pending row (no local rooms.db write here — this
+    # node is not the leader's node and has no authority over the room).
+    if leader_node and leader_node != node:
+        try:
+            status, resp = _post_room_join_request(
+                leader_node=leader_node, room_id=room_id, token=token,
+                joiner_agent=agent,
+            )
+        except rooms.RoomsError as exc:
+            return die(str(exc), code=1)
+        except Exception as exc:  # noqa: BLE001 - transport/config failure
+            return die(f"cross-node join failed: {exc}", code=1)
+        if not (200 <= status < 300):
+            detail = ""
+            try:
+                detail = resp.decode("utf-8", "replace")[:200]
+            except Exception:  # noqa: BLE001
+                detail = ""
+            return die(f"leader node rejected the join (HTTP {status}): {detail}",
+                       code=1)
+        if args.json:
+            out(json.dumps({"room_id": room_id,
+                            "agent": f"{agent}@{node}",
+                            "leader_node": leader_node,
+                            "status": rooms.JOIN_PENDING, "cross_node": True}))
+        else:
+            info(f"cross-node join request posted for {agent}@{node} on "
+                 f"{room_id} to leader node {leader_node} (pending approval)")
+        return 0
+
+    # Single-node (P1) path: joiner + leader share this node.
     conn = rooms.open_rooms()
     try:
         room = rooms.get_room(conn, room_id)
         if room is None:
             return die(f"room not found: {room_id}", code=1)
-        if not token:
-            return die("invite link carries no token (t=...) — a join needs "
-                       "the token-bearing link, not a bare room id", code=1)
         # Rate-limit per token + source BEFORE the hash compare so a brute
         # force on the token is bounded, then verify the token hash.
         try:
@@ -426,8 +590,8 @@ def cmd_join(args: argparse.Namespace) -> int:
         except rooms.RoomsError as exc:
             return die(str(exc), code=1)
         if not rooms.verify_invite_token(room, token):
-            return die("invalid invite token for this room (hash mismatch)",
-                       code=1)
+            return die("invalid invite token for this room (hash mismatch, "
+                       "expired, or revoked)", code=1)
         rooms.post_join_request(conn, room_id, agent, node)
     finally:
         conn.close()
@@ -707,6 +871,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_create = sub.add_parser("create", help="create a room (you are leader)")
     p_create.add_argument("--name", default="", help="human room name")
+    p_create.add_argument(
+        "--ttl", type=int, default=0,
+        help="invite-token lifetime in seconds (0 = no expiry, the default). "
+             "A cross-node join (P4.1) with an expired token is refused.")
     _add_common(p_create)
     p_create.set_defaults(func=cmd_create)
 
@@ -725,6 +893,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_invite.add_argument("room_id")
     p_invite.add_argument("--once", action="store_true",
                           help="single-use token (burned after one approval)")
+    p_invite.add_argument(
+        "--ttl", type=int, default=0,
+        help="invite-token lifetime in seconds (0 = no expiry, the default).")
     _add_common(p_invite)
     p_invite.set_defaults(func=cmd_invite)
 

--- a/bridge_a2a_common.py
+++ b/bridge_a2a_common.py
@@ -51,6 +51,19 @@ IDENTITY_UPDATE_ENVELOPE_PROTOCOL = "agent-bridge.a2a.identity-update.v1"
 # and vice versa.
 IDENTITY_UPDATE_PATH = "/peer-identity-update"
 
+# A2A Rooms P4.1 (design §11 / §14 R3): the signed cross-node `room-join-request`
+# control message. A member on node B posts this to the leader's node A over the
+# EXISTING node-link so node A can verify the invite token + persist a PENDING
+# join request. Like the identity-update message it is a DISTINCT protocol routed
+# to a SEPARATE handler with its own fail-closed stack — it NEVER reaches the
+# enqueue/allowlist/queue boundary, NEVER carries a queue task, and NEVER
+# auto-admits. The wire carries `sha256(join_token)` ONLY (never the raw token,
+# §14 R3) and the joiner *agent* claim; the joiner *node* is bound by the
+# receiver to the HMAC-authenticated sender bridge (never wire-asserted).
+ROOM_JOIN_PROTOCOL_VERSION = "a2a-room-join-v1"
+ROOM_JOIN_ENVELOPE_PROTOCOL = "agent-bridge.a2a.room-join.v1"
+ROOM_JOIN_PATH = "/room-join-request"
+
 # Default per-peer caps. Receiver config may override per peer.
 DEFAULT_MAX_BODY_BYTES = 256 * 1024
 DEFAULT_MAX_TITLE_BYTES = 1024
@@ -876,6 +889,91 @@ def parse_identity_update(raw: bytes) -> dict[str, Any]:
             "identity-update must carry at least one of node_id / "
             "tailscale_name",
             code="bad_identity_update",
+        )
+    return body
+
+
+# --------------------------------------------------------------------------
+# Cross-node room-join-request control message (A2A Rooms P4.1, design §11)
+# --------------------------------------------------------------------------
+#
+# The body a node-B member signs (over the node-link HMAC) + the leader's node A
+# receiver re-validates. It carries:
+#   - room_id:          the room the joiner wants into.
+#   - join_token_sha256: sha256(raw_token) — the HASH ONLY. The raw token NEVER
+#                        crosses the wire (§14 R3); the leader hash-compares it
+#                        against the stored `invite_token_sha256`.
+#   - joiner_agent:      the joiner's agent id as attested by node B. CRITICAL
+#                        (contract 2): node B MUST derive this from its local
+#                        OS-actor / gateway-credential regime (resolve_os_actor),
+#                        NEVER from --from / BRIDGE_AGENT_ID / USER. The node-link
+#                        HMAC authenticates the NODE; the leader binds the joiner
+#                        *node* to the authenticated sender bridge (NOT to any
+#                        wire-asserted node field) and accepts `joiner_agent` only
+#                        as that authenticated node's OS-actor-anchored attestation.
+# There is deliberately NO `joiner_node` field: a wire-asserted node would be
+# spoofable, so the receiver uses the HMAC-authenticated `X-AGB-Peer` as the node.
+
+
+def build_room_join_request(
+    *,
+    room_id: str,
+    join_token_sha256: str,
+    joiner_agent: str,
+) -> dict[str, Any]:
+    """Build the cross-node room-join-request control body.
+
+    `join_token_sha256` MUST already be the hash (the caller hashes the raw
+    token with `bridge_rooms_common.hash_token` before this is built) — the raw
+    token must never reach this function or the wire. `joiner_agent` MUST be the
+    OS-actor-anchored agent id (see the section header), never a caller flag.
+    """
+    return {
+        "protocol": ROOM_JOIN_ENVELOPE_PROTOCOL,
+        "room_id": room_id,
+        "join_token_sha256": join_token_sha256,
+        "joiner_agent": joiner_agent,
+    }
+
+
+def parse_room_join_request(raw: bytes) -> dict[str, Any]:
+    """Parse + shape-validate a cross-node room-join-request control body.
+
+    Validates only the WIRE shape: a JSON object with the right protocol tag and
+    non-empty string `room_id`, `join_token_sha256`, `joiner_agent`. The token
+    hash must look like a sha256 hex digest (64 lowercase hex chars) so a
+    malformed/garbage value is refused at the boundary, never half-trusted. It
+    does NOT verify the token (the leader hash-compares + TTL/revocation-checks
+    against rooms.db) and does NOT trust the joiner identity beyond the
+    node-link auth the receiver already enforced.
+    """
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise A2AError(
+            f"room-join-request is not valid JSON: {exc}", code="bad_room_join",
+        ) from exc
+    if not isinstance(body, dict):
+        raise A2AError(
+            "room-join-request root must be a JSON object", code="bad_room_join",
+        )
+    if body.get("protocol") != ROOM_JOIN_ENVELOPE_PROTOCOL:
+        raise A2AError(
+            f"unsupported room-join-request protocol: {body.get('protocol')!r}",
+            code="bad_room_join_protocol",
+        )
+    for field in ("room_id", "join_token_sha256", "joiner_agent"):
+        val = body.get(field)
+        if not isinstance(val, str) or not val:
+            raise A2AError(
+                f"room-join-request missing required string field: {field}",
+                code="bad_room_join",
+            )
+    th = body["join_token_sha256"]
+    if len(th) != 64 or any(c not in "0123456789abcdef" for c in th):
+        raise A2AError(
+            "room-join-request join_token_sha256 must be a sha256 hex digest",
+            code="bad_room_join",
         )
     return body
 

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -606,10 +606,15 @@ CREATE TABLE IF NOT EXISTS room_join_rate (
 -- body_sha256 distinguishes an exact replay (duplicate) from id-reuse
 -- (conflict). It carries NO token / token-hash (contract 5).
 CREATE TABLE IF NOT EXISTS room_join_dedupe (
-  message_id   TEXT PRIMARY KEY,
+  message_id   TEXT NOT NULL,
   peer         TEXT NOT NULL DEFAULT '',
   body_sha256  TEXT NOT NULL,
-  created_ts   INTEGER NOT NULL
+  created_ts   INTEGER NOT NULL,
+  -- codex P4.1 Phase-4: dedupe is scoped to the AUTHENTICATED peer. A
+  -- composite (peer, message_id) PK means one authenticated peer cannot
+  -- consume/block another peer's join id by reusing a message_id (the
+  -- earlier message_id-only PK let nodeC pre-reserve nodeB's id).
+  PRIMARY KEY (peer, message_id)
 );
 """
 
@@ -1214,8 +1219,8 @@ JOIN_DEDUPE_DUPLICATE = "duplicate"  # same id + same body → already-accepted
 JOIN_DEDUPE_CONFLICT = "conflict"    # same id + different body → id reuse
 
 
-def room_join_dedupe_lookup(conn: sqlite3.Connection, message_id: str,
-                            body_sha256: str) -> str:
+def room_join_dedupe_lookup(conn: sqlite3.Connection, peer: str,
+                            message_id: str, body_sha256: str) -> str:
     """READ-ONLY dedupe check against rooms.db. Returns one of:
     'new' (no row), JOIN_DEDUPE_DUPLICATE (same id+body), JOIN_DEDUPE_CONFLICT
     (same id, different body). A row exists ONLY for a PREVIOUSLY-ACCEPTED
@@ -1231,8 +1236,9 @@ def room_join_dedupe_lookup(conn: sqlite3.Connection, message_id: str,
     """
     try:
         row = conn.execute(
-            "SELECT body_sha256 FROM room_join_dedupe WHERE message_id=?",
-            (message_id,),
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
         ).fetchone()
     except sqlite3.OperationalError as exc:
         if "no such table" in str(exc).lower():
@@ -1267,9 +1273,11 @@ def record_verified_cross_node_join_request_atomic(
     row survives. Carries NO token / token-hash (contract 5).
     """
     # Re-check inside this call (the caller's read-only lookup may have raced).
+    # Scoped to the authenticated peer (codex P4.1 Phase-4 — composite PK).
     existing = conn.execute(
-        "SELECT body_sha256 FROM room_join_dedupe WHERE message_id=?",
-        (message_id,),
+        "SELECT body_sha256 FROM room_join_dedupe "
+        "WHERE peer=? AND message_id=?",
+        (peer, message_id),
     ).fetchone()
     if existing is not None:
         # A concurrent accept reserved first → resolve to the same outcome the
@@ -1302,8 +1310,9 @@ def record_verified_cross_node_join_request_atomic(
         # INSERT was rolled back; the pending row, if any, belongs to the winner.)
         conn.rollback()
         winner = conn.execute(
-            "SELECT body_sha256 FROM room_join_dedupe WHERE message_id=?",
-            (message_id,),
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
         ).fetchone()
         if winner is not None:
             return (JOIN_DEDUPE_DUPLICATE

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -523,6 +523,11 @@ CREATE TABLE IF NOT EXISTS rooms (
   epoch              INTEGER NOT NULL DEFAULT 0,
   invite_token_sha256 TEXT,
   invite_token_ts    INTEGER NOT NULL DEFAULT 0,
+  -- P4.1 (§14 R3): TTL in seconds for the current invite token. 0 == no
+  -- expiry (the P1 default, back-compat: an existing room created before
+  -- this column simply gets 0 and never expires). verify_invite_token
+  -- enforces `invite_token_ts + invite_token_ttl >= now` when ttl > 0.
+  invite_token_ttl   INTEGER NOT NULL DEFAULT 0,
   invite_once        INTEGER NOT NULL DEFAULT 0,
   status             TEXT NOT NULL DEFAULT 'active',
   created_ts         INTEGER NOT NULL,
@@ -545,6 +550,25 @@ CREATE TABLE IF NOT EXISTS room_join_requests (
   node         TEXT NOT NULL DEFAULT '',
   requested_ts INTEGER NOT NULL,
   status       TEXT NOT NULL DEFAULT 'pending',
+  -- P4.1 (§11, §14 R3) cross-node forward-contract columns. They carry ONLY
+  -- verified METADATA, NEVER the reusable token hash (contract 5: the hash is
+  -- bearer-equivalent and is never persisted in any row):
+  --   verified  : 1 when this pending row was created by the receiver AFTER
+  --               the node-link HMAC + token-hash + TTL/revocation verification
+  --               passed. A future cross-node `approve` (P4.2) REQUIRES a row
+  --               with verified=1 (the local leader-initiated add path stays
+  --               separate and does NOT claim this gate — contract 6).
+  --   via_node  : the HMAC-authenticated node-link peer the request arrived
+  --               over (the joiner's node, bound to the authenticated sender
+  --               bridge — never a wire-asserted node).
+  --   ttl_expiry: absolute unix ts after which this pending request is stale.
+  --               0 == no expiry. Forward-contract for P4.2 cleanup.
+  -- Existing P1 rows get verified=0 / via_node='' / ttl_expiry=0 on migration,
+  -- which correctly reads as "a local single-node request, not a verified
+  -- cross-node one".
+  verified     INTEGER NOT NULL DEFAULT 0,
+  via_node     TEXT NOT NULL DEFAULT '',
+  ttl_expiry   INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (room_id, agent, node)
 );
 
@@ -572,11 +596,52 @@ CREATE TABLE IF NOT EXISTS room_join_rate (
   last_ts      INTEGER NOT NULL,
   PRIMARY KEY (token_sha256, source)
 );
+
+-- P4.1 (codex r2): cross-node room-join-request dedupe ledger. It lives in
+-- rooms.db (NOT the A2A inbox.db) so the dedupe reservation and the
+-- room_join_requests pending row commit in ONE transaction — "a dedupe row
+-- exists" is then ATOMIC with "a pending row exists", closing the window where
+-- a reservation could survive a failed pending write and let a replay return a
+-- bogus idempotent-200 with no pending row. message_id is the idempotency key;
+-- body_sha256 distinguishes an exact replay (duplicate) from id-reuse
+-- (conflict). It carries NO token / token-hash (contract 5).
+CREATE TABLE IF NOT EXISTS room_join_dedupe (
+  message_id   TEXT PRIMARY KEY,
+  peer         TEXT NOT NULL DEFAULT '',
+  body_sha256  TEXT NOT NULL,
+  created_ts   INTEGER NOT NULL
+);
 """
 
 
 def now_ts() -> int:
     return int(time.time())
+
+
+def _migrate_schema(conn: sqlite3.Connection) -> None:
+    """Idempotently add columns introduced AFTER P1 to an existing rooms.db.
+
+    `CREATE TABLE IF NOT EXISTS` never alters an existing table, so a rooms.db
+    created by P1 lacks the P4.1 columns (rooms.invite_token_ttl,
+    room_join_requests.{verified,via_node,ttl_expiry}). We add them with the
+    same defaults the schema declares, so a migrated P1 row reads identically to
+    a freshly-created one. ALTER TABLE ADD COLUMN is cheap + non-rewriting in
+    SQLite; the per-column try/except makes re-runs (column already present) a
+    no-op rather than an error. NEVER drops/rewrites data.
+    """
+    migrations = (
+        "ALTER TABLE rooms ADD COLUMN invite_token_ttl INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE room_join_requests ADD COLUMN verified INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE room_join_requests ADD COLUMN via_node TEXT NOT NULL DEFAULT ''",
+        "ALTER TABLE room_join_requests ADD COLUMN ttl_expiry INTEGER NOT NULL DEFAULT 0",
+    )
+    for stmt in migrations:
+        try:
+            conn.execute(stmt)
+        except sqlite3.OperationalError:
+            # duplicate column name (already migrated) → idempotent no-op.
+            pass
+    conn.commit()
 
 
 def _connect(path: Path, schema: str) -> sqlite3.Connection:
@@ -587,6 +652,7 @@ def _connect(path: Path, schema: str) -> sqlite3.Connection:
     conn.execute("PRAGMA busy_timeout=30000")
     conn.execute("PRAGMA foreign_keys=ON")
     conn.executescript(schema)
+    _migrate_schema(conn)
     try:
         os.chmod(path, 0o600)
     except OSError:
@@ -792,22 +858,23 @@ def list_rooms(conn: sqlite3.Connection,
 
 def create_room(conn: sqlite3.Connection, *, name: str, leader_agent: str,
                 leader_node: str, token: str,
-                once: bool = False) -> str:
+                once: bool = False, ttl: int = 0) -> str:
     """Create a room led by `leader_agent@leader_node`; seed leader member row.
 
     `epoch` starts at 0. The leader row is role='leader'. Only the token HASH
-    is stored. Returns the minted room_id. The caller is responsible for
-    printing the one-time invite link (it holds the raw token).
+    is stored. `ttl` (seconds, P4.1) is the invite-token lifetime; 0 == no
+    expiry (the P1 default). Returns the minted room_id. The caller is
+    responsible for printing the one-time invite link (it holds the raw token).
     """
     room_id = mint_room_id()
     ts = now_ts()
     conn.execute(
         "INSERT INTO rooms (room_id, name, leader_agent, leader_node, epoch, "
-        "invite_token_sha256, invite_token_ts, invite_once, status, "
-        "created_ts, updated_ts) "
-        "VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?)",
+        "invite_token_sha256, invite_token_ts, invite_token_ttl, invite_once, "
+        "status, created_ts, updated_ts) "
+        "VALUES (?, ?, ?, ?, 0, ?, ?, ?, ?, ?, ?, ?)",
         (room_id, name, leader_agent, leader_node, hash_token(token), ts,
-         1 if once else 0, ROOM_ACTIVE, ts, ts),
+         max(0, int(ttl)), 1 if once else 0, ROOM_ACTIVE, ts, ts),
     )
     conn.execute(
         "INSERT INTO room_members (room_id, agent, node, role, joined_ts) "
@@ -852,13 +919,21 @@ def require_leader(room: sqlite3.Row, caller_agent: str,
 # --------------------------------------------------------------------------
 
 def set_invite_token(conn: sqlite3.Connection, room_id: str, token: str,
-                     once: bool = False) -> None:
-    """Store a fresh token hash, INVALIDATING any prior token for the room."""
+                     once: bool = False, ttl: int = 0) -> None:
+    """Store a fresh token hash, INVALIDATING any prior token for the room.
+
+    `ttl` (seconds, P4.1 §14 R3) is the lifetime of THIS token; 0 == no expiry
+    (the P1 default). Setting/rotating a token resets `invite_token_ts` to now,
+    so the TTL clock restarts on every rotate — and because the prior hash is
+    overwritten, a rotate also REVOKES the old token (verify hash-compares the
+    new one). `ttl` is stored alongside so verify_invite_token can enforce
+    `invite_token_ts + ttl >= now`.
+    """
     ts = now_ts()
     conn.execute(
         "UPDATE rooms SET invite_token_sha256=?, invite_token_ts=?, "
-        "invite_once=?, updated_ts=? WHERE room_id=?",
-        (hash_token(token), ts, 1 if once else 0, ts, room_id),
+        "invite_token_ttl=?, invite_once=?, updated_ts=? WHERE room_id=?",
+        (hash_token(token), ts, max(0, int(ttl)), 1 if once else 0, ts, room_id),
     )
     # A rotated token invalidates prior rate-counters too (fresh budget).
     conn.execute(
@@ -868,14 +943,64 @@ def set_invite_token(conn: sqlite3.Connection, room_id: str, token: str,
     conn.commit()
 
 
-def verify_invite_token(room: sqlite3.Row, token: str) -> bool:
-    """Constant-time compare of `sha256(token)` against the room's stored hash."""
-    stored = room["invite_token_sha256"]
-    if not stored:
-        return False
+# Stable outcome codes for the token check (audit-safe — never carry the token).
+TOKEN_OK = "ok"
+TOKEN_MISMATCH = "mismatch"       # hash does not match (wrong/forged token)
+TOKEN_REVOKED = "revoked"         # no token set (rotated/burned away)
+TOKEN_EXPIRED = "expired"         # hash matches but TTL elapsed
+
+
+def verify_invite_token_outcome(room: sqlite3.Row, token: str,
+                                now: Optional[int] = None) -> str:
+    """Verify the invite token against the room, enforcing TTL + revocation.
+
+    Returns one of the TOKEN_* codes (NEVER the token itself, so the caller can
+    audit the outcome safely — contract 5). The order is:
+      1. revocation — a NULL/empty stored hash means the token was rotated or
+         burned away → TOKEN_REVOKED (nothing to match).
+      2. hash compare — constant-time `sha256(token)` vs the stored hash. A
+         mismatch is TOKEN_MISMATCH (wrong/forged token). We compare BEFORE the
+         TTL check so an attacker presenting a garbage token cannot learn the
+         room's TTL state via a timing/branch difference.
+      3. TTL (§14 R3) — when `invite_token_ttl` > 0, the token is valid only
+         while `invite_token_ts + ttl >= now`; past that it is TOKEN_EXPIRED.
+         A ttl of 0 means no expiry (P1 back-compat).
+    """
     import hmac as _hmac
 
-    return _hmac.compare_digest(stored, hash_token(token))
+    stored = room["invite_token_sha256"]
+    if not stored:
+        return TOKEN_REVOKED
+    if not _hmac.compare_digest(str(stored), hash_token(token)):
+        return TOKEN_MISMATCH
+    # Hash matched — now enforce TTL. Use a defensive getattr-style read so a
+    # row from an unmigrated/partial source (no ttl column) is treated as "no
+    # expiry" rather than raising.
+    try:
+        ttl = int(room["invite_token_ttl"])
+    except (KeyError, IndexError, TypeError, ValueError):
+        ttl = 0
+    if ttl > 0:
+        try:
+            issued = int(room["invite_token_ts"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            issued = 0
+        if now is None:
+            now = now_ts()
+        if issued + ttl < int(now):
+            return TOKEN_EXPIRED
+    return TOKEN_OK
+
+
+def verify_invite_token(room: sqlite3.Row, token: str,
+                        now: Optional[int] = None) -> bool:
+    """Boolean form of `verify_invite_token_outcome` (True iff TOKEN_OK).
+
+    Now enforces TTL + revocation in addition to the hash compare, so every
+    existing caller (single-node `cmd_join`, the smokes) transparently gains the
+    P4.1 expiry/revocation gate without a signature change.
+    """
+    return verify_invite_token_outcome(room, token, now=now) == TOKEN_OK
 
 
 def burn_invite_token(conn: sqlite3.Connection, room_id: str) -> None:
@@ -1035,12 +1160,164 @@ def shared_rooms(conn: sqlite3.Connection, agent1: str, node1: str,
 
 def post_join_request(conn: sqlite3.Connection, room_id: str, agent: str,
                       node: str = "") -> None:
+    """Persist a LOCAL (single-node P1) pending join request.
+
+    verified stays 0 / via_node='' (this is not a node-link-attested cross-node
+    request). INSERT OR REPLACE re-affirms a re-requested pending row.
+    """
     conn.execute(
         "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
-        "requested_ts, status) VALUES (?, ?, ?, ?, ?)",
+        "requested_ts, status, verified, via_node, ttl_expiry) "
+        "VALUES (?, ?, ?, ?, ?, 0, '', 0)",
         (room_id, agent, node, now_ts(), JOIN_PENDING),
     )
     conn.commit()
+
+
+def record_verified_cross_node_join_request(
+    conn: sqlite3.Connection, room_id: str, agent: str, node: str,
+    *, via_node: str, ttl_expiry: int = 0,
+) -> None:
+    """Persist a VERIFIED cross-node (P4.1) pending join request.
+
+    Called by the leader-node receiver ONLY after the node-link HMAC +
+    token-hash + TTL/revocation verification has passed (contract 4). The row
+    carries verified METADATA — the joiner `agent@node`, the verified flag, the
+    HMAC-authenticated node-link peer (`via_node`), and an optional `ttl_expiry`
+    — but NEVER the reusable token hash (contract 5: the hash is bearer-
+    equivalent and is never persisted in any row). NO membership is added and NO
+    leader task is created here: admission is a separate P4.2 `approve` that
+    REQUIRES a verified row (contract 6).
+
+    `node` is the joiner's node as bound by the receiver to the authenticated
+    sender bridge (NEVER a wire-asserted value). INSERT OR REPLACE keyed on
+    (room_id, agent, node) makes a duplicate request idempotent (refresh ts).
+
+    NOTE: prefer `record_verified_cross_node_join_request_atomic` on the receiver
+    path — it commits the dedupe reservation + this pending row in ONE
+    transaction. This bare helper is retained for the local/test path that does
+    not need the dedupe ledger.
+    """
+    conn.execute(
+        "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
+        "requested_ts, status, verified, via_node, ttl_expiry) "
+        "VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+        (room_id, agent, node, now_ts(), JOIN_PENDING, via_node,
+         max(0, int(ttl_expiry))),
+    )
+    conn.commit()
+
+
+# Stable outcomes for the atomic cross-node dedupe+persist (audit-safe codes).
+JOIN_DEDUPE_RESERVED = "reserved"   # new id → dedupe row + pending row committed
+JOIN_DEDUPE_DUPLICATE = "duplicate"  # same id + same body → already-accepted
+JOIN_DEDUPE_CONFLICT = "conflict"    # same id + different body → id reuse
+
+
+def room_join_dedupe_lookup(conn: sqlite3.Connection, message_id: str,
+                            body_sha256: str) -> str:
+    """READ-ONLY dedupe check against rooms.db. Returns one of:
+    'new' (no row), JOIN_DEDUPE_DUPLICATE (same id+body), JOIN_DEDUPE_CONFLICT
+    (same id, different body). A row exists ONLY for a PREVIOUSLY-ACCEPTED
+    cross-node join (the reservation is atomic with the pending row), so a hit
+    here means the request was already accepted. Never writes.
+
+    On an UPGRADED P1 rooms.db the `room_join_dedupe` table may not exist yet
+    when this read-only path runs (codex P4.1 r3 #2): `open_rooms_readonly`
+    deliberately does NOT run schema creation, and the migrating RW `open_rooms`
+    happens later on the accept path. A missing table therefore means "no
+    prior accepted request" → 'new'; the RW open on the accept path creates the
+    table before the reservation. Any OTHER operational error propagates.
+    """
+    try:
+        row = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe WHERE message_id=?",
+            (message_id,),
+        ).fetchone()
+    except sqlite3.OperationalError as exc:
+        if "no such table" in str(exc).lower():
+            return "new"
+        raise
+    if row is None:
+        return "new"
+    return (JOIN_DEDUPE_DUPLICATE if row["body_sha256"] == body_sha256
+            else JOIN_DEDUPE_CONFLICT)
+
+
+def record_verified_cross_node_join_request_atomic(
+    conn: sqlite3.Connection, *, message_id: str, body_sha256: str, peer: str,
+    room_id: str, agent: str, node: str, via_node: str, ttl_expiry: int = 0,
+) -> str:
+    """ATOMICALLY reserve the dedupe row AND persist the verified pending row.
+
+    The whole operation commits in ONE transaction (codex P4.1 r2): "a dedupe row
+    exists" is therefore equivalent to "a pending row exists", closing the window
+    where a surviving reservation could let a replay return a bogus idempotent
+    200 with no pending row. Returns:
+      - JOIN_DEDUPE_DUPLICATE : the message_id was already accepted with the SAME
+        body → idempotent, NOTHING re-written.
+      - JOIN_DEDUPE_CONFLICT  : the message_id was already used with a DIFFERENT
+        body → id reuse, NOTHING written.
+      - JOIN_DEDUPE_RESERVED  : a NEW id → the dedupe row + the pending row are
+        BOTH committed together.
+
+    The dedupe + pending writes are issued WITHOUT an intermediate commit, then a
+    single `conn.commit()` makes them durable atomically; a failure before the
+    commit (e.g. the pending INSERT raises) rolls BOTH back, so no orphan dedupe
+    row survives. Carries NO token / token-hash (contract 5).
+    """
+    # Re-check inside this call (the caller's read-only lookup may have raced).
+    existing = conn.execute(
+        "SELECT body_sha256 FROM room_join_dedupe WHERE message_id=?",
+        (message_id,),
+    ).fetchone()
+    if existing is not None:
+        # A concurrent accept reserved first → resolve to the same outcome the
+        # lookup would have produced. No write (the pending row is already there
+        # from the first accept).
+        return (JOIN_DEDUPE_DUPLICATE if existing["body_sha256"] == body_sha256
+                else JOIN_DEDUPE_CONFLICT)
+    ts = now_ts()
+    try:
+        conn.execute(
+            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+            "created_ts) VALUES (?, ?, ?, ?)",
+            (message_id, peer, body_sha256, ts),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
+            "requested_ts, status, verified, via_node, ttl_expiry) "
+            "VALUES (?, ?, ?, ?, ?, 1, ?, ?)",
+            (room_id, agent, node, ts, JOIN_PENDING, via_node,
+             max(0, int(ttl_expiry))),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        # CONCURRENCY (codex P4.1 r3 #1): two handlers both passed the pre-check
+        # SELECT before either committed; this one lost the message_id PK race.
+        # The dedupe row's PRIMARY KEY is the serialization point — roll back our
+        # partial write and re-query the winner's row, returning the SAME
+        # idempotent/conflict outcome the pre-check would have. The loser thus
+        # gets a clean duplicate/conflict, never a 500. (No orphan row: our
+        # INSERT was rolled back; the pending row, if any, belongs to the winner.)
+        conn.rollback()
+        winner = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe WHERE message_id=?",
+            (message_id,),
+        ).fetchone()
+        if winner is not None:
+            return (JOIN_DEDUPE_DUPLICATE
+                    if winner["body_sha256"] == body_sha256
+                    else JOIN_DEDUPE_CONFLICT)
+        # The PK violation came from somewhere other than a concurrent winner
+        # (should not happen) — surface it rather than silently swallow.
+        raise
+    except Exception:
+        # Roll BOTH writes back so a failed pending insert never leaves an
+        # orphan dedupe reservation (the r2 atomicity contract).
+        conn.rollback()
+        raise
+    return JOIN_DEDUPE_RESERVED
 
 
 def list_join_requests(conn: sqlite3.Connection, room_id: str,

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -198,6 +198,19 @@ add_required a2a-rooms-p1b-acl
 # controller), the env-redirect teeth (BRIDGE_A2A_ROOMS_DB does NOT relocate
 # the bootstrap), and idempotency (a 2nd create does not re-bootstrap/clobber).
 add_required a2a-rooms-1517-bootstrap
+# A2A rooms P4.1 (design §11 / §14 R3): the cross-node JOIN. Member on node B
+# posts a signed room-join-request to the leader's node A over the node-link;
+# node A re-runs the full fail-closed auth preamble (remote_addr -> HMAC -> skew
+# -> dedupe), verifies the invite token (HASH compare + TTL + revocation), and
+# persists a VERIFIED PENDING row (no auto-admit — approve is P4.2). In the full
+# static suite. Lives in bridge-handoffd.py (_handle_room_join_request),
+# bridge_a2a_common.py (build/parse_room_join_request), bridge_rooms_common.py
+# (verify_invite_token_outcome TTL/revocation + record_verified_cross_node_join_
+# request), and bridge-rooms.py (OS-actor-anchored joiner + cross-node send).
+# Pins the 5 teeth (hostile --from/env inert, no-cross-agent-impersonation,
+# expired/revoked refused, no token/hash persisted anywhere, malformed/dup
+# handled) + the unweakened auth preamble + the non-leader-node refusal.
+add_required rooms-p4-1-cross-node-join
 
 
 }
@@ -863,7 +876,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -938,7 +951,21 @@ select_for_path() {
       # auth/dedupe gates upstream of the enqueue stay enforced. Pull on every
       # bridge-handoffd.py move so the force flag cannot regress to a 422 drop
       # or, worse, to a guard bypass that also weakens auth/dedupe.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force
+      # A2A Rooms P4.1 (design §11 / §14 R3): the cross-node JOIN. A member on
+      # node B posts a signed room-join-request to the leader's node A; node A
+      # verifies (node-link HMAC + token-HASH + TTL + revocation) and persists a
+      # PENDING row (no auto-admit). The NEW remote surface is
+      # _handle_room_join_request in bridge-handoffd.py; the wire builder/parser
+      # is in bridge_a2a_common.py; the TTL/revocation verify + verified-pending
+      # persistence is in bridge_rooms_common.py; the OS-actor-anchored joiner +
+      # cross-node send is in bridge-rooms.py. rooms-p4-1-cross-node-join pins the
+      # 5 teeth: hostile --from/env cannot change the joiner, a node-B process
+      # cannot join as another B agent, expired/revoked tokens are refused, the
+      # raw token AND its hash never persist in any queue/audit/staged file, and
+      # malformed/duplicate requests are handled — PLUS the auth preamble stays
+      # unweakened (HMAC 401 / remote_addr 403 / unknown-peer 403). Pull on every
+      # move to any of those files so the cross-node admission gate cannot regress.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/smoke/rooms-p4-1-cross-node-join-helper.py
+++ b/scripts/smoke/rooms-p4-1-cross-node-join-helper.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Helper for the rooms-p4-1-cross-node-join smoke (A2A Rooms P4.1).
+
+File-as-argv sidecar (never a heredoc-stdin — footgun #11). Imports the REAL
+rooms / a2a / handoffd modules from the repo root so the smoke exercises the
+canonical sender (signing + OS-actor joiner id), the canonical receiver
+(`_handle_room_join_request` fail-closed stack + token verify + pending-row
+persist), and the canonical schema — WITHOUT a live socket or Tailscale.
+
+The transport is stubbed two ways:
+  - SENDER side: the cross-node `bridge-rooms.py join` POST is captured by the
+    paired-flag test hook (BRIDGE_ROOMS_TEST_POST_HOOK = this script's
+    `post-hook` subcommand), which writes the fully-signed request to a file.
+  - RECEIVER side: `deliver-to-receiver` reconstructs a minimal fake HTTP
+    request from that captured file and drives the REAL handler method, so the
+    actual auth preamble (protocol/peer/remote_addr/HMAC/skew/dedupe) + token
+    verify + persistence run end to end. The peer uses a literal `address`
+    (no node_id/tailscale_name) so resolve_peer_address returns it verbatim —
+    no Tailscale.
+
+Subcommands (argv[1]):
+  post-hook <json>                 (used as BRIDGE_ROOMS_TEST_POST_HOOK) — write
+                                   the signed request JSON to $CAPTURE_FILE and
+                                   echo a stub "{}" response.
+  captured-field <file> <key>      print headers[X-AGB-*] or body.<key> from a
+                                   captured request file.
+  deliver-to-receiver <repo_root> <cfg_json> <captured_file> [overrides_json]
+                                   replay the captured request through the real
+                                   receiver handler; print "status=<n> body=<json>".
+  make-config <out_path> <this_node> <peer_node> <peer_secret> <address>
+                                   write a minimal handoff config (loopback test
+                                   bind) the receiver loads.
+  pending-rows <db> <room_id>      print each pending join row as JSON lines.
+  dedupe-rows <db>                 print each room_join_dedupe row as JSON lines.
+  db-contains <db> <needle>        exit 0 iff <needle> appears in the db dump.
+  file-tree-contains <dir> <needle> exit 0 iff <needle> appears under <dir>.
+  drop-dedupe-table <db>           DROP room_join_dedupe (simulate unmigrated P1 db).
+  set-token-ts <db> <room_id> <ts> backdate invite_token_ts (drive TTL expiry).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_a2a_common as a2a  # noqa: E402
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# sender-side capture hook (invoked as BRIDGE_ROOMS_TEST_POST_HOOK)
+# ---------------------------------------------------------------------------
+def cmd_post_hook(payload_json: str) -> int:
+    """Write the signed cross-node request to $CAPTURE_FILE; stub a 200 body.
+
+    The CLI sender calls us with the JSON {path, headers, body}. We persist it
+    verbatim (so the smoke can assert on the OS-actor joiner id + hash-only
+    body, and replay it into the receiver). stdout is the stubbed response body.
+    """
+    capture = os.environ.get("CAPTURE_FILE")  # noqa: iso-helper-boundary - env var, not a .env file
+    if not capture:
+        print("CAPTURE_FILE unset", file=sys.stderr)
+        return 1
+    Path(capture).write_text(payload_json, encoding="utf-8")
+    print("{}")  # stub response body
+    return 0
+
+
+def cmd_captured_field(path: str, key: str) -> int:
+    doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    if key.startswith("header:"):
+        val = doc.get("headers", {}).get(key[len("header:"):], "")
+    elif key.startswith("body:"):
+        body = json.loads(doc.get("body", "{}"))
+        val = body.get(key[len("body:"):], "")
+    elif key == "path":
+        val = doc.get("path", "")
+    else:
+        print(f"unknown captured key: {key}", file=sys.stderr)
+        return 1
+    print(val)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# receiver-side replay against the REAL handler
+# ---------------------------------------------------------------------------
+def _load_handoffd(repo_root: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "bridge_handoffd", os.path.join(repo_root, "bridge-handoffd.py"))
+    hd = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(hd)
+    return hd
+
+
+class _FakeHeaders:
+    def __init__(self, headers: dict):
+        self._h = headers
+
+    def get(self, key, default=None):
+        return self._h.get(key, default)
+
+
+class _FakeRFile:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0 or n >= len(self._data):
+            out, self._data = self._data, b""
+            return out
+        out, self._data = self._data[:n], self._data[n:]
+        return out
+
+
+class _FakeServer:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.config_path = ""
+
+
+def cmd_deliver_to_receiver(repo_root: str, cfg_json: str, captured: str,
+                            overrides_json: str = "{}") -> int:
+    """Replay a captured signed request through the REAL receiver handler.
+
+    `overrides_json` lets a tooth mutate the captured request to drive an edge:
+      {"client_ip": "...", "headers": {...override...},
+       "body": "<replacement json string>", "recompute_hash": true}
+    When `recompute_hash` is true the X-AGB-Body-SHA256 header is recomputed for
+    the (possibly mutated) body — used to simulate a 'same id, different body'
+    duplicate-conflict WITHOUT also tripping the body-hash gate.
+    """
+    hd = _load_handoffd(repo_root)
+    cfg = json.loads(cfg_json)
+    doc = json.loads(Path(captured).read_text(encoding="utf-8"))
+    overrides = json.loads(overrides_json) if overrides_json else {}
+
+    path = doc.get("path", a2a.ROOM_JOIN_PATH)
+    headers = dict(doc.get("headers", {}))
+    body = doc.get("body", "{}")
+
+    if "headers" in overrides:
+        headers.update(overrides["headers"])
+    if "body" in overrides:
+        body = overrides["body"]
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    if overrides.get("recompute_hash"):
+        headers["X-AGB-Body-SHA256"] = a2a.body_sha256(body_bytes)
+    # `resign`: recompute BOTH the body hash AND a VALID HMAC signature for the
+    # (mutated) body using the peer's configured secret. Used to test a code
+    # path DOWNSTREAM of the HMAC gate (e.g. the body PARSER) with a legitimately
+    # signed but malformed body — so the test exercises the parser, not the
+    # signature gate. It mirrors exactly what an authenticated node B could send.
+    if overrides.get("resign"):
+        peer_secret = ""
+        for p in cfg.get("peers", []):
+            if p.get("id") == headers.get("X-AGB-Peer", ""):
+                peer_secret = p.get("secret", "")
+                break
+        body_hash = a2a.body_sha256(body_bytes)
+        headers["X-AGB-Body-SHA256"] = body_hash
+        canonical = a2a.canonical_string(
+            "POST", path, headers.get("X-AGB-Peer", ""),
+            headers.get("X-AGB-Message-Id", ""),
+            headers.get("X-AGB-Timestamp", ""), body_hash)
+        headers["X-AGB-Signature"] = a2a.sign(peer_secret, canonical)
+    headers["Content-Length"] = str(len(body_bytes))
+
+    # The authenticated peer address: the receiver resolves the peer's literal
+    # `address`; the client_ip must match. Default to the peer's configured
+    # address so the remote_addr gate passes; a tooth can override.
+    peer_id = headers.get("X-AGB-Peer", "")
+    peer_addr = ""
+    for p in cfg.get("peers", []):
+        if p.get("id") == peer_id:
+            peer_addr = p.get("address", "")
+            break
+    client_ip = overrides.get("client_ip", peer_addr or "127.0.0.1")
+
+    handler = hd.HandoffHandler.__new__(hd.HandoffHandler)
+    handler.path = path
+    handler.headers = _FakeHeaders(headers)
+    handler.rfile = _FakeRFile(body_bytes)
+    handler.client_address = (client_ip, 0)
+    handler.server = _FakeServer(cfg)
+
+    captured_reply = {}
+
+    def _capture_reply(status, payload, extra_headers=None):
+        captured_reply["status"] = status
+        captured_reply["payload"] = payload
+
+    handler._reply = _capture_reply  # type: ignore[assignment]
+    handler._handle_room_join_request(cfg)
+
+    status = captured_reply.get("status", 0)
+    payload = captured_reply.get("payload", {})
+    print(f"status={status} body={json.dumps(payload)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# config + db inspection
+# ---------------------------------------------------------------------------
+def cmd_make_config(out_path: str, this_node: str, peer_node: str,
+                    peer_secret: str, address: str) -> int:
+    cfg = {
+        "bridge_id": this_node,
+        "listen": {"host": "127.0.0.1", "port": 8787,
+                   "enqueue_path": "/enqueue"},
+        "timestamp_skew_seconds": 300,
+        "timestamp_skew_grace_seconds": 3600,
+        "peers": [
+            {
+                "id": peer_node,
+                "address": address,
+                "secret": peer_secret,
+                "inbound_allowlist": [],
+            }
+        ],
+    }
+    Path(out_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
+    return 0
+
+
+def cmd_pending_rows(db: str, room_id: str) -> int:
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT room_id, agent, node, status, verified, via_node, "
+            "ttl_expiry FROM room_join_requests WHERE room_id=? "
+            "ORDER BY agent, node", (room_id,)
+        ).fetchall()
+    finally:
+        conn.close()
+    for r in rows:
+        print(json.dumps({k: r[k] for k in r.keys()}))
+    return 0
+
+
+def cmd_dedupe_rows(db: str) -> int:
+    """Print each room_join_dedupe row as a JSON line (P4.1 r2 ledger)."""
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT message_id, peer, body_sha256, created_ts "
+            "FROM room_join_dedupe ORDER BY created_ts"
+        ).fetchall()
+    finally:
+        conn.close()
+    for r in rows:
+        print(json.dumps({k: r[k] for k in r.keys()}))
+    return 0
+
+
+def cmd_db_contains(db: str, needle: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        dump = "\n".join(conn.iterdump())
+    finally:
+        conn.close()
+    return 0 if needle and needle in dump else 1
+
+
+def cmd_file_tree_contains(directory: str, needle: str) -> int:
+    base = Path(directory)
+    if not base.exists():
+        return 1
+    for p in base.rglob("*"):
+        if p.is_file():
+            try:
+                text = p.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if needle and needle in text:
+                print(f"FOUND in {p}", file=sys.stderr)
+                return 0
+    return 1
+
+
+def cmd_atomic_race_reclassify(db: str) -> int:
+    """Unit-drive record_verified_cross_node_join_request_atomic's race branch
+    (codex r3 #1). Proves a message_id PK collision is RECLASSIFIED to
+    duplicate/conflict (never an unhandled raise / 500).
+
+    We bypass the in-call pre-check by INSERTing the dedupe row through a SECOND
+    connection AFTER the function under test would have pre-checked — emulated
+    here by seeding the row first, then calling the function (its own pre-check
+    catches the seeded row → duplicate). To exercise the IntegrityError catch
+    branch specifically, we monkeypatch the pre-check SELECT to miss once, so the
+    INSERT collides and the except-branch re-queries. Output: a line per case.
+    """
+    import bridge_rooms_common as r
+
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(r._ROOMS_SCHEMA)
+    conn.commit()
+    mid = "nodeB:race-1"
+    body = "a" * 64
+    # Seed a winner row (same body) directly.
+    conn.execute(
+        "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+        "created_ts) VALUES (?, ?, ?, ?)", (mid, "nodeB", body, 1))
+    conn.commit()
+    # Pre-check path: the function sees the seeded row → DUPLICATE (same body).
+    out1 = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256=body, peer="nodeB",
+        room_id="room-x", agent="z", node="nodeB", via_node="nodeB")
+    print(f"precheck_same_body={out1}")
+    # Pre-check path with a DIFFERENT body → CONFLICT.
+    out2 = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256="b" * 64, peer="nodeB",
+        room_id="room-x", agent="z", node="nodeB", via_node="nodeB")
+    print(f"precheck_diff_body={out2}")
+
+    # IntegrityError branch: a thin proxy makes the FIRST pre-check SELECT for a
+    # NEW id miss (simulating the concurrent winner's row not yet visible to this
+    # reader), so the function proceeds to INSERT and collides on the PK, which
+    # it must catch + re-query + reclassify (NOT raise). `sqlite3.Connection`
+    # methods are read-only, so we wrap rather than monkeypatch.
+    mid2 = "nodeB:race-2"
+    conn.execute(
+        "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+        "created_ts) VALUES (?, ?, ?, ?)", (mid2, "nodeB", body, 1))
+    conn.commit()
+
+    class _Empty:
+        def fetchone(self):
+            return None
+
+    class _RaceProxy:
+        """Delegates to the real connection but forces the FIRST dedupe pre-check
+        SELECT to return empty, so the function's INSERT hits the live PK row."""
+
+        def __init__(self, real):
+            self._real = real
+            self._first_select = True
+
+        def execute(self, sql, params=()):
+            if (self._first_select
+                    and sql.strip().startswith(
+                        "SELECT body_sha256 FROM room_join_dedupe")):
+                self._first_select = False
+                return _Empty()
+            return self._real.execute(sql, params)
+
+        def commit(self):
+            return self._real.commit()
+
+        def rollback(self):
+            return self._real.rollback()
+
+    out3 = r.record_verified_cross_node_join_request_atomic(
+        _RaceProxy(conn), message_id=mid2, body_sha256=body, peer="nodeB",
+        room_id="room-x", agent="z", node="nodeB", via_node="nodeB")
+    print(f"integrityerror_reclassified={out3}")
+    conn.close()
+    return 0
+
+
+def cmd_drop_dedupe_table(db: str) -> int:
+    """DROP room_join_dedupe to simulate an UPGRADED P1 rooms.db whose RW-open
+    migration has not yet recreated the table (codex P4.1 r3 #2 tooth)."""
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("DROP TABLE IF EXISTS room_join_dedupe")
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_set_token_ts(db: str, room_id: str, ts: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("UPDATE rooms SET invite_token_ts=? WHERE room_id=?",
+                     (int(ts), room_id))
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: rooms-p4-1-cross-node-join-helper.py <subcommand> [args]",
+              file=sys.stderr)
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "post-hook":
+        return cmd_post_hook(rest[0])
+    if cmd == "captured-field":
+        return cmd_captured_field(rest[0], rest[1])
+    if cmd == "deliver-to-receiver":
+        return cmd_deliver_to_receiver(rest[0], rest[1], rest[2],
+                                       rest[3] if len(rest) > 3 else "{}")
+    if cmd == "make-config":
+        return cmd_make_config(rest[0], rest[1], rest[2], rest[3], rest[4])
+    if cmd == "pending-rows":
+        return cmd_pending_rows(rest[0], rest[1])
+    if cmd == "dedupe-rows":
+        return cmd_dedupe_rows(rest[0])
+    if cmd == "db-contains":
+        return cmd_db_contains(rest[0], rest[1])
+    if cmd == "file-tree-contains":
+        return cmd_file_tree_contains(rest[0], rest[1])
+    if cmd == "drop-dedupe-table":
+        return cmd_drop_dedupe_table(rest[0])
+    if cmd == "atomic-race-reclassify":
+        return cmd_atomic_race_reclassify(rest[0])
+    if cmd == "set-token-ts":
+        return cmd_set_token_ts(rest[0], rest[1], rest[2])
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/smoke/rooms-p4-1-cross-node-join-helper.py
+++ b/scripts/smoke/rooms-p4-1-cross-node-join-helper.py
@@ -374,6 +374,56 @@ def cmd_atomic_race_reclassify(db: str) -> int:
     return 0
 
 
+def cmd_cross_peer_dedupe(db: str) -> int:
+    """Prove the dedupe ledger is scoped to the AUTHENTICATED peer (codex P4.1
+    Phase-4 BLOCKING). The composite (peer, message_id) PK means one
+    authenticated peer cannot consume OR block another peer's join id by reusing
+    a message_id, while same-peer idempotency (same body -> duplicate) and
+    conflict (different body -> conflict) are preserved. One line per case.
+    """
+    import bridge_rooms_common as r
+
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(r._ROOMS_SCHEMA)
+    conn.commit()
+    mid = "nodeB:shared-id-1"
+    body1 = "a" * 64
+    body2 = "b" * 64
+    # nodeB reserves (its own dedupe + pending row, committed atomically).
+    out_b = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256=body1, peer="nodeB",
+        room_id="room-x", agent="bob", node="nodeB", via_node="nodeB")
+    print(f"nodeB_reserve={out_b}")
+    # nodeC, SAME message_id + SAME body -> NEW (NOT consumed by nodeB's row).
+    print("nodeC_same_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeC", mid, body1))
+    # nodeC, SAME message_id + DIFFERENT body -> NEW (no cross-peer conflict/409).
+    print("nodeC_diff_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeC", mid, body2))
+    # nodeB, SAME id + SAME body -> duplicate (same-peer idempotency preserved).
+    print("nodeB_same_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeB", mid, body1))
+    # nodeB, SAME id + DIFFERENT body -> conflict (same-peer conflict preserved).
+    print("nodeB_diff_body_lookup="
+          + r.room_join_dedupe_lookup(conn, "nodeB", mid, body2))
+    # nodeC can INDEPENDENTLY reserve the SAME message_id (its own row + pending).
+    out_c = r.record_verified_cross_node_join_request_atomic(
+        conn, message_id=mid, body_sha256=body2, peer="nodeC",
+        room_id="room-x", agent="carol", node="nodeC", via_node="nodeC")
+    print(f"nodeC_reserve={out_c}")
+    n_ded = conn.execute(
+        "SELECT COUNT(*) FROM room_join_dedupe WHERE message_id=?",
+        (mid,)).fetchone()[0]
+    print(f"dedupe_rows_for_shared_id={n_ded}")
+    n_pending = conn.execute(
+        "SELECT COUNT(*) FROM room_join_requests WHERE room_id=?",
+        ("room-x",)).fetchone()[0]
+    print(f"pending_rows_for_shared_id={n_pending}")
+    conn.close()
+    return 0
+
+
 def cmd_drop_dedupe_table(db: str) -> int:
     """DROP room_join_dedupe to simulate an UPGRADED P1 rooms.db whose RW-open
     migration has not yet recreated the table (codex P4.1 r3 #2 tooth)."""
@@ -424,6 +474,8 @@ def main(argv: list[str]) -> int:
         return cmd_drop_dedupe_table(rest[0])
     if cmd == "atomic-race-reclassify":
         return cmd_atomic_race_reclassify(rest[0])
+    if cmd == "cross-peer-dedupe":
+        return cmd_cross_peer_dedupe(rest[0])
     if cmd == "set-token-ts":
         return cmd_set_token_ts(rest[0], rest[1], rest[2])
     print(f"unknown subcommand: {cmd}", file=sys.stderr)

--- a/scripts/smoke/rooms-p4-1-cross-node-join.sh
+++ b/scripts/smoke/rooms-p4-1-cross-node-join.sh
@@ -457,6 +457,35 @@ test_atomic_race_reclassified_not_500() {
 }
 
 # ---------------------------------------------------------------------------
+# T6 (codex P4.1 Phase-4 BLOCKING): dedupe is scoped to the AUTHENTICATED peer.
+#     A second authenticated peer (nodeC) reusing nodeB's message_id must NOT
+#     consume or block nodeB's join id — composite (peer, message_id) PK. Same-
+#     peer idempotency (same body) + conflict (different body) are preserved.
+# ---------------------------------------------------------------------------
+test_T6_cross_peer_dedupe_isolation() {
+  local xdb="$SMOKE_TMP_ROOT/cross-peer.db"
+  local out
+  out="$(python3 "$HELPER" cross-peer-dedupe "$xdb" 2>&1)" \
+    || smoke_fail "cross-peer-dedupe helper must not raise: $out"
+  smoke_assert_contains "$out" "nodeB_reserve=reserved" \
+    "nodeB reserves its own dedupe + pending row"
+  smoke_assert_contains "$out" "nodeC_same_body_lookup=new" \
+    "T6: nodeC reusing nodeB's message_id (SAME body) is NEW — not consumed (cross-peer isolation)"
+  smoke_assert_contains "$out" "nodeC_diff_body_lookup=new" \
+    "T6: nodeC reusing nodeB's message_id (DIFFERENT body) is NEW — no cross-peer 409"
+  smoke_assert_contains "$out" "nodeB_same_body_lookup=duplicate" \
+    "T6: nodeB same id+body stays idempotent (duplicate) — same-peer dedupe preserved"
+  smoke_assert_contains "$out" "nodeB_diff_body_lookup=conflict" \
+    "T6: nodeB same id+different body stays a conflict — same-peer dedupe preserved"
+  smoke_assert_contains "$out" "nodeC_reserve=reserved" \
+    "T6: nodeC independently reserves the SAME message_id (its own row)"
+  smoke_assert_contains "$out" "dedupe_rows_for_shared_id=2" \
+    "T6: two authenticated peers => two independent dedupe rows for one message_id"
+  smoke_assert_contains "$out" "pending_rows_for_shared_id=2" \
+    "T6: two authenticated peers => two independent pending rows"
+}
+
+# ---------------------------------------------------------------------------
 # run
 # ---------------------------------------------------------------------------
 smoke_run "setup: room on node A + baseline cross-node join captured" test_setup_room_and_capture
@@ -472,5 +501,6 @@ smoke_run "auth preamble unweakened (HMAC 401 / remote_addr 403 / unknown peer 4
 smoke_run "a non-leader node refuses + persists nothing" test_non_leader_node_refuses
 smoke_run "r3 #2: unmigrated P1 db (missing dedupe table) still joins (no 500)" test_upgraded_db_missing_dedupe_table
 smoke_run "r3 #1: a message_id PK race is reclassified (dup/conflict), not a 500" test_atomic_race_reclassified_not_500
+smoke_run "T6: dedupe scoped to authenticated peer — one peer can't consume/block another's join id" test_T6_cross_peer_dedupe_isolation
 
 smoke_log "passed"

--- a/scripts/smoke/rooms-p4-1-cross-node-join.sh
+++ b/scripts/smoke/rooms-p4-1-cross-node-join.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-1-cross-node-join.sh — A2A Rooms P4.1 cross-node JOIN.
+#
+# Exercises the FIRST cross-node rooms phase (design docs/design/
+# a2a-rooms-design.md §11 / §14 R3): a member on node B posts a signed
+# room-join-request to the leader's node A over the node-link; node A verifies
+# (node-link HMAC + token-hash + TTL + revocation) and persists a PENDING row
+# (no auto-admit — approve is P4.2). The transport is STUBBED end-to-end (no
+# real Tailscale / live socket): the sender's POST is captured by the paired-
+# flag test hook, then replayed through the REAL receiver handler.
+#
+# THE 5 REQUIRED TEETH (each proven below):
+#   T1  Hostile --from / BRIDGE_AGENT_ID / USER CANNOT change the recorded
+#       joiner — the joiner id is OS-actor-anchored (resolve_os_actor).
+#   T2  A process on node B cannot post a join-request as a *different* B agent
+#       (the joiner is the OS-uid-derived agent; the node is the HMAC-authed
+#       peer, never a wire field).
+#   T3  An expired (TTL) OR revoked (rotated) token is REFUSED — no pending row.
+#   T4  The raw token AND its hash never appear in any queue / task / audit /
+#       staged file.
+#   T5  A malformed / duplicate join-request is handled (no crash; dedupe).
+#
+# Plus a positive path: a valid cross-node request persists a verified=1 pending
+# row anchored to <joiner-os-agent>@<authenticated-peer-node>.
+
+set -euo pipefail
+
+SMOKE_NAME="rooms-p4-1-cross-node-join"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/rooms-p4-1-cross-node-join-helper.py"
+POST_HOOK="$SCRIPT_DIR/rooms-p4-1-post-hook.sh"
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# The leader's rooms.db (node A) lives under the isolated state dir. Node B (the
+# joiner) never writes it — the cross-node path posts over the node-link.
+export BRIDGE_A2A_ROOMS_DB="$BRIDGE_STATE_DIR/handoff/rooms.db"
+mkdir -p "$BRIDGE_STATE_DIR/handoff"
+
+NODE_A="nodeA"
+NODE_B="nodeB"
+SECRET="test-pair-secret-aaaaaaaaaaaaaaaaaaaa"
+ADDR="127.0.0.1"     # literal peer address → resolve_peer_address returns it (no Tailscale)
+
+# Node-A receiver config (bridge_id=nodeA, peer nodeB) — used by deliver-to-receiver.
+CFG_A="$SMOKE_TMP_ROOT/handoff-A.json"
+python3 "$HELPER" make-config "$CFG_A" "$NODE_A" "$NODE_B" "$SECRET" "$ADDR" >/dev/null
+CFG_A_JSON="$(cat "$CFG_A")"
+
+# Node-B sender config (bridge_id=nodeB, peer nodeA) — used by `room join`.
+CFG_B="$SMOKE_TMP_ROOT/handoff-B.json"
+python3 "$HELPER" make-config "$CFG_B" "$NODE_B" "$NODE_A" "$SECRET" "$ADDR" >/dev/null
+
+CAPTURE="$SMOKE_TMP_ROOT/captured-request.json"
+
+# Paired test-seam flags (gate the OS-user override AND the POST hook). Set
+# INLINE per-invocation, never exported, so nothing leaks. Mirrors P1a.
+TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+
+# room_create_as <agent> <ttl> — create a room led by iso-user agent-bridge-<a>
+# on node A. Echoes the JSON. Runs against the node-A config so leader_node=nodeA.
+room_create_as() {
+  local who="$1" ttl="$2"
+  env "${TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+    python3 "$ROOMS_CLI" create --name team --ttl "$ttl" --json 2>/dev/null
+}
+
+# join_cross_node_as <os-agent> [extra env...] -- <join-args...>
+# Runs `room join` as iso-user agent-bridge-<os-agent> on node B, with the POST
+# hook capturing the signed request to $CAPTURE. Extra env (the hostile
+# --from/BRIDGE_AGENT_ID/USER spoof) is passed through. Returns the CLI rc.
+join_cross_node_as() {
+  local who="$1"; shift
+  local extra=()
+  while [[ "${1:-}" != "--" ]]; do extra+=("$1"); shift; done
+  shift  # drop the --
+  : >"$CAPTURE" || true
+  # `${extra[@]+...}` guards the empty-array-under-`set -u` footgun (a no-op on
+  # bash 5.x; required so bash 3.2 does not error on an empty TEST_FLAGS/extra).
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_B" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$CAPTURE" \
+      ${extra[@]+"${extra[@]}"} \
+    python3 "$ROOMS_CLI" join "$@"
+}
+
+json_field() { python3 "$SCRIPT_DIR/a2a-rooms-p1a-helper.py" json-field "$1" "$2"; }
+
+# deliver <overrides_json> — replay $CAPTURE through the real node-A receiver.
+deliver() {
+  local overrides="${1:-}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  python3 "$HELPER" deliver-to-receiver "$SMOKE_REPO_ROOT" "$CFG_A_JSON" \
+    "$CAPTURE" "$overrides"
+}
+
+ROOM=""
+LINK=""
+RAW_TOKEN=""
+TOKEN_HASH=""
+
+# ---------------------------------------------------------------------------
+# setup: a room on node A + capture a baseline valid cross-node join from B
+# ---------------------------------------------------------------------------
+test_setup_room_and_capture() {
+  local out
+  out="$(room_create_as alice 0)"
+  ROOM="$(json_field room_id "$out")"
+  LINK="$(json_field invite_link "$out")"
+  [[ -n "$ROOM" && -n "$LINK" ]] || smoke_fail "room create did not yield room/link"
+  smoke_assert_contains "$LINK" "leader=$NODE_A" "invite link carries leader=nodeA"
+  RAW_TOKEN="$(python3 "$SCRIPT_DIR/a2a-rooms-p1a-helper.py" token-from-link "$LINK")"
+  [[ -n "$RAW_TOKEN" ]] || smoke_fail "could not extract raw token from link"
+  TOKEN_HASH="$(python3 -c "import hashlib,sys;print(hashlib.sha256(sys.argv[1].encode()).hexdigest())" "$RAW_TOKEN")"
+}
+
+# ---------------------------------------------------------------------------
+# positive: a valid cross-node join persists a verified pending row
+# ---------------------------------------------------------------------------
+test_valid_cross_node_join_persists_pending() {
+  join_cross_node_as bob -- "$LINK" >/dev/null 2>&1 \
+    || smoke_fail "cross-node join (sender side) should succeed against the stub"
+  smoke_assert_file_exists "$CAPTURE" "the signed cross-node request was captured"
+  # Deliver to the real receiver → 200 pending.
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=200" "valid cross-node join → 200 at the leader"
+  smoke_assert_contains "$res" "\"status\": \"pending\"" "leader records it as pending"
+  # The persisted row: verified=1, agent=bob (OS-actor), node=nodeB (authed peer).
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_contains "$rows" "\"agent\": \"bob\"" "pending row joiner agent is the OS-actor (bob)"
+  smoke_assert_contains "$rows" "\"node\": \"$NODE_B\"" "pending row joiner node is the AUTHENTICATED peer (nodeB)"
+  smoke_assert_contains "$rows" "\"verified\": 1" "pending row is marked verified (post node-link auth)"
+  smoke_assert_contains "$rows" "\"via_node\": \"$NODE_B\"" "via_node bound to the authenticated node-link peer"
+}
+
+# ---------------------------------------------------------------------------
+# T1: hostile --from / BRIDGE_AGENT_ID / USER cannot change the joiner
+# ---------------------------------------------------------------------------
+test_T1_hostile_from_env_cannot_change_joiner() {
+  # bob's iso uid joins, but the process screams "I am mallory" three ways.
+  join_cross_node_as bob \
+      "BRIDGE_AGENT_ID=mallory" "USER=mallory" \
+      -- "$LINK" --as mallory >/dev/null 2>&1 \
+    || smoke_fail "join should still succeed (the spoof is ignored, not fatal)"
+  # The WIRE joiner_agent must be bob (the OS-actor), NEVER mallory.
+  local wire_agent
+  wire_agent="$(python3 "$HELPER" captured-field "$CAPTURE" "body:joiner_agent")"
+  smoke_assert_eq "bob" "$wire_agent" \
+    "T1: wire joiner_agent is the OS-actor (bob), NOT the hostile --from/env (mallory)"
+  # And the receiver records bob, not mallory.
+  deliver >/dev/null
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_not_contains "$rows" "mallory" \
+    "T1: no 'mallory' row — the OS-actor anchor held end-to-end"
+}
+
+# ---------------------------------------------------------------------------
+# T2: a node-B process cannot join as a *different* node-B agent
+# ---------------------------------------------------------------------------
+test_T2_cannot_join_as_a_different_B_agent() {
+  # carol's iso uid joins while claiming to be bob every spoofable way.
+  join_cross_node_as carol \
+      "BRIDGE_AGENT_ID=bob" "USER=bob" \
+      -- "$LINK" --as bob >/dev/null 2>&1 \
+    || smoke_fail "join should succeed (claim ignored, not fatal)"
+  local wire_agent
+  wire_agent="$(python3 "$HELPER" captured-field "$CAPTURE" "body:joiner_agent")"
+  smoke_assert_eq "carol" "$wire_agent" \
+    "T2: a node-B process is bound to its OWN OS-actor (carol), cannot claim 'bob'"
+  # The wire carries NO joiner_node field at all — the node is the authed peer.
+  local wire_node
+  wire_node="$(python3 "$HELPER" captured-field "$CAPTURE" "body:joiner_node" 2>/dev/null || true)"
+  smoke_assert_eq "" "$wire_node" \
+    "T2: there is NO wire-asserted joiner_node (the node is bound to the HMAC peer)"
+  deliver >/dev/null
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_contains "$rows" "\"agent\": \"carol\"" "T2: carol recorded as herself"
+}
+
+# ---------------------------------------------------------------------------
+# T3: expired (TTL) OR revoked token is REFUSED — no pending row
+# ---------------------------------------------------------------------------
+test_T3a_expired_token_refused() {
+  # A room with a 1-second TTL; backdate the token ts so it is already expired.
+  local out room link
+  out="$(room_create_as dora 1)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  python3 "$HELPER" set-token-ts "$BRIDGE_A2A_ROOMS_DB" "$room" 1 >/dev/null
+  join_cross_node_as erin -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "sender side should succeed (the leader decides validity)"
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=403" "T3: an EXPIRED token is refused (403)"
+  smoke_assert_contains "$res" "expired" "T3: refusal reason is 'expired'"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_not_contains "$rows" "erin" "T3: NO pending row for an expired-token join"
+  # codex P4.1 r1 regression: a REPLAY of the rejected expired request must STILL
+  # be 403 (it left NO dedupe row), never an idempotent 200.
+  local replay
+  replay="$(deliver)"
+  smoke_assert_contains "$replay" "status=403" \
+    "T3: a REPLAYED expired-token request is STILL 403 (no idempotent-200 bypass)"
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_not_contains "$rows" "erin" "T3: replay still leaves NO pending row"
+}
+
+test_T3b_revoked_token_refused() {
+  # Rotate the lifecycle room's invite → the OLD captured token (from $LINK,
+  # already captured for $ROOM) is now revoked. Re-capture an old-token request
+  # then rotate, and deliver: the leader must refuse (hash no longer matches).
+  join_cross_node_as fred -- "$LINK" >/dev/null 2>&1 \
+    || smoke_fail "capture an old-token request before rotating"
+  # Leader rotates the invite (revokes the old token).
+  env "${TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-alice" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+    python3 "$ROOMS_CLI" rotate-invite "$ROOM" --json >/dev/null 2>&1 \
+    || smoke_fail "leader rotate-invite should succeed"
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=403" "T3: a REVOKED (rotated-away) token is refused"
+  smoke_assert_contains "$res" "mismatch" "T3: revoked token reads as a hash mismatch"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_not_contains "$rows" "fred" "T3: NO pending row for a revoked-token join"
+}
+
+# ---------------------------------------------------------------------------
+# T4: the raw token AND its hash never appear in any queue/task/audit/staged file
+# ---------------------------------------------------------------------------
+test_T4_no_token_or_hash_persisted_anywhere() {
+  # After the positive path persisted a verified row, scan every persistence
+  # surface for BOTH the raw token and its sha256 hash.
+  [[ -n "$RAW_TOKEN" && -n "$TOKEN_HASH" ]] || smoke_fail "token/hash not set up"
+
+  # 1) rooms.db — the row carries metadata only, NEVER the reusable hash.
+  if python3 "$HELPER" db-contains "$BRIDGE_A2A_ROOMS_DB" "$RAW_TOKEN"; then
+    smoke_fail "T4: raw token must NEVER appear in rooms.db"
+  fi
+  # The rooms.db stores invite_token_sha256 in the ROOMS table (that is correct
+  # and 0600-scoped). The contract is that the hash must not leak into the
+  # join-REQUEST row / audit / staged files. Assert the join_request row text
+  # contains neither.
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$ROOM")"
+  smoke_assert_not_contains "$rows" "$RAW_TOKEN" "T4: raw token not in a pending row"
+  smoke_assert_not_contains "$rows" "$TOKEN_HASH" "T4: token HASH not in a pending row (bearer-equivalent)"
+  # The P4.1 cross-node dedupe ledger (room_join_dedupe in rooms.db, codex r2)
+  # stores sha256(WIRE BODY) + message_id + peer — NOT the token or its hash.
+  local dledger
+  dledger="$(python3 "$HELPER" dedupe-rows "$BRIDGE_A2A_ROOMS_DB")"
+  smoke_assert_not_contains "$dledger" "$RAW_TOKEN" "T4: raw token not in the dedupe ledger"
+  smoke_assert_not_contains "$dledger" "$TOKEN_HASH" "T4: token HASH not in the dedupe ledger"
+
+  # 2) audit log — never the token or its hash.
+  local audit="$BRIDGE_LOG_DIR/a2a-handoff.jsonl"
+  if [[ -f "$audit" ]]; then
+    if grep -qF "$RAW_TOKEN" "$audit"; then smoke_fail "T4: raw token leaked into the audit log"; fi
+    if grep -qF "$TOKEN_HASH" "$audit"; then smoke_fail "T4: token hash leaked into the audit log"; fi
+  fi
+
+  # 3) inbox dedupe db (the queue-adjacent ledger) — never the token/hash.
+  local inbox="$BRIDGE_STATE_DIR/handoff/inbox.db"
+  if [[ -f "$inbox" ]]; then
+    if python3 "$HELPER" db-contains "$inbox" "$RAW_TOKEN"; then smoke_fail "T4: raw token in inbox.db"; fi
+    if python3 "$HELPER" db-contains "$inbox" "$TOKEN_HASH"; then smoke_fail "T4: token hash in inbox.db"; fi
+  fi
+
+  # 4) any staged file under the handoff/incoming tree — never the token/hash.
+  if python3 "$HELPER" file-tree-contains "$BRIDGE_STATE_DIR/handoff" "$RAW_TOKEN"; then
+    smoke_fail "T4: raw token found in a staged handoff file"
+  fi
+  if python3 "$HELPER" file-tree-contains "$BRIDGE_STATE_DIR/handoff" "$TOKEN_HASH"; then
+    # NOTE: rooms.db is UNDER handoff/ and legitimately holds the ROOM hash in
+    # the rooms table; the file-tree scan reads text, and the sqlite db is
+    # binary so the hex may or may not surface. To keep this assertion precise
+    # we only fail if the hash is in a STAGED .md/.json file, not the db blob.
+    if python3 "$HELPER" file-tree-contains "$BRIDGE_STATE_DIR/handoff/incoming" "$TOKEN_HASH" 2>/dev/null; then
+      smoke_fail "T4: token hash found in a staged incoming file"
+    fi
+  fi
+
+  # 5) no queue task was created at all (no leader task carrying a token).
+  if [[ -f "$BRIDGE_TASK_DB" ]]; then
+    if python3 "$HELPER" db-contains "$BRIDGE_TASK_DB" "$RAW_TOKEN"; then smoke_fail "T4: raw token in tasks.db"; fi
+    if python3 "$HELPER" db-contains "$BRIDGE_TASK_DB" "$TOKEN_HASH"; then smoke_fail "T4: token hash in tasks.db"; fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# T5: malformed / duplicate join-request handled (no crash; dedupe)
+# ---------------------------------------------------------------------------
+test_T5a_malformed_body_refused_no_crash() {
+  # Capture a valid signed request, then deliver MALFORMED bodies that are
+  # LEGITIMATELY RE-SIGNED (resign:true) — so the test exercises the receiver's
+  # body PARSER (downstream of the HMAC + dedupe gates), not the signature gate.
+  # Each malformed delivery uses a UNIQUE message_id so it passes dedupe ("new")
+  # and reaches the parser (the dedupe gate runs BEFORE parse by design).
+  local freshout freshlink
+  freshout="$(room_create_as helen 0)"
+  freshlink="$(json_field invite_link "$freshout")"
+  join_cross_node_as ivan -- "$freshlink" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request to mutate"
+  local res
+  # not-JSON body.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-1"},"body":"{not json","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a non-JSON body is a 422 (parser refused, no crash)"
+  # codex P4.1 r1 regression: a REPLAY of the rejected malformed request must
+  # STILL be 422 (no dedupe row was reserved for a reject), never 200.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-1"},"body":"{not json","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a REPLAYED malformed body is STILL 422 (no idempotent-200 bypass)"
+  # missing required fields.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-2"},"body":"{\"protocol\":\"agent-bridge.a2a.room-join.v1\"}","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a missing-field body is a 422"
+  # bad token-hash shape (not 64 hex) → 422 at the parser.
+  res="$(deliver '{"headers":{"X-AGB-Message-Id":"nodeB:malformed-3"},"body":"{\"protocol\":\"agent-bridge.a2a.room-join.v1\",\"room_id\":\"r\",\"join_token_sha256\":\"xyz\",\"joiner_agent\":\"a\"}","resign":true}')"
+  smoke_assert_contains "$res" "status=422" "T5: a malformed token-hash is a 422"
+}
+
+test_T5b_duplicate_idempotent() {
+  # Capture one valid request; deliver it twice. Second is an idempotent dup.
+  local out room link
+  out="$(room_create_as jane 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as kara -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request for the dup test"
+  local first second
+  first="$(deliver)"
+  smoke_assert_contains "$first" "status=200" "T5: first delivery is 200"
+  second="$(deliver)"
+  smoke_assert_contains "$second" "status=200" "T5: a duplicate (same id+body) is idempotent 200"
+  smoke_assert_contains "$second" "\"duplicate\": true" "T5: the duplicate is flagged"
+  # codex P4.1 r2 atomicity: an idempotent-200 duplicate MUST correspond to a
+  # REAL pending row (dedupe row ⟺ pending row, committed atomically) — never a
+  # bogus 200 with no row.
+  local drows
+  drows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_contains "$drows" "\"agent\": \"kara\"" \
+    "T5 atomicity: the duplicate-200 corresponds to a REAL pending row (kara)"
+  # Same id (the captured one), DIFFERENT but VALIDLY-SIGNED body → 409 conflict
+  # (security event), still no crash. resign keeps the HMAC valid so the
+  # conflict is detected at the dedupe ledger, not the signature gate.
+  local hex64
+  hex64="$(python3 -c "print('a'*64)")"
+  local conflict
+  conflict="$(deliver '{"body":"{\"protocol\":\"agent-bridge.a2a.room-join.v1\",\"room_id\":\"'"$room"'\",\"join_token_sha256\":\"'"$hex64"'\",\"joiner_agent\":\"kara\"}","resign":true}')"
+  smoke_assert_contains "$conflict" "status=409" "T5: same id + different body is a 409 conflict"
+}
+
+# ---------------------------------------------------------------------------
+# auth preamble teeth: a tampered signature / wrong source addr is refused
+# ---------------------------------------------------------------------------
+test_auth_preamble_unweakened() {
+  local out room link
+  out="$(room_create_as liam 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as mike -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request for the auth teeth"
+  # Tampered signature → 401 (HMAC unweakened).
+  local res
+  res="$(deliver '{"headers":{"X-AGB-Signature":"v1=deadbeef"}}')"
+  smoke_assert_contains "$res" "status=401" "auth: a bad signature is 401 (HMAC gate intact)"
+  # Wrong source address → 403 (remote_addr gate intact).
+  res="$(deliver '{"client_ip":"10.9.9.9"}')"
+  smoke_assert_contains "$res" "status=403" "auth: a wrong source address is 403 (remote_addr gate intact)"
+  # Unknown peer → 403.
+  res="$(deliver '{"headers":{"X-AGB-Peer":"nodeZ"}}')"
+  smoke_assert_contains "$res" "status=403" "auth: an unknown peer is 403"
+}
+
+# ---------------------------------------------------------------------------
+# not-leader-node: a node that does not lead the room records nothing
+# ---------------------------------------------------------------------------
+test_non_leader_node_refuses() {
+  # Deliver a valid request to a receiver whose bridge_id is NOT the leader node.
+  local out room link
+  out="$(room_create_as nora 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as opal -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request"
+  # A node-C config (bridge_id=nodeC) that still trusts nodeB as a peer, but the
+  # room's leader_node is nodeA → 404 not-leader-node, nothing persisted.
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-C.json"
+  python3 "$HELPER" make-config "$cfg_c" "nodeC" "$NODE_B" "$SECRET" "$ADDR" >/dev/null
+  local res
+  res="$(python3 "$HELPER" deliver-to-receiver "$SMOKE_REPO_ROOT" "$(cat "$cfg_c")" "$CAPTURE")"
+  smoke_assert_contains "$res" "status=404" "a non-leader node refuses the join (404)"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_not_contains "$rows" "opal" "a non-leader node persists NO pending row"
+}
+
+# ---------------------------------------------------------------------------
+# upgraded P1 rooms.db: the read-only dedupe lookup tolerates a missing table
+# (codex r3 #2) — the RW accept-open recreates it; the join still succeeds.
+# ---------------------------------------------------------------------------
+test_upgraded_db_missing_dedupe_table() {
+  local out room link
+  out="$(room_create_as petra 0)"
+  room="$(json_field room_id "$out")"
+  link="$(json_field invite_link "$out")"
+  join_cross_node_as quinn -- "$link" >/dev/null 2>&1 \
+    || smoke_fail "capture a valid request"
+  # Simulate an UPGRADED P1 rooms.db whose RW migration has not yet recreated
+  # the new table: DROP it, then deliver. The RO step-h lookup must treat the
+  # missing table as 'new' (not a 500), and the RW accept-open must recreate it
+  # before reserving → 200 pending + a real row.
+  python3 "$HELPER" drop-dedupe-table "$BRIDGE_A2A_ROOMS_DB" >/dev/null
+  local res
+  res="$(deliver)"
+  smoke_assert_contains "$res" "status=200" \
+    "r3 #2: a join against an unmigrated P1 db (no dedupe table) still 200s (no 500)"
+  local rows
+  rows="$(python3 "$HELPER" pending-rows "$BRIDGE_A2A_ROOMS_DB" "$room")"
+  smoke_assert_contains "$rows" "\"agent\": \"quinn\"" \
+    "r3 #2: the accept-open recreated the dedupe table + persisted the pending row"
+}
+
+# ---------------------------------------------------------------------------
+# concurrency: a message_id PK race is RECLASSIFIED to duplicate/conflict, never
+# a 500 (codex r3 #1). Unit-drives the atomic helper's pre-check AND its
+# IntegrityError catch branch.
+# ---------------------------------------------------------------------------
+test_atomic_race_reclassified_not_500() {
+  local racedb="$SMOKE_TMP_ROOT/race.db"
+  local out
+  out="$(python3 "$HELPER" atomic-race-reclassify "$racedb" 2>&1)" \
+    || smoke_fail "atomic-race helper must not raise: $out"
+  smoke_assert_contains "$out" "precheck_same_body=duplicate" \
+    "r3 #1: a pre-checked same-body race resolves to duplicate"
+  smoke_assert_contains "$out" "precheck_diff_body=conflict" \
+    "r3 #1: a pre-checked different-body race resolves to conflict"
+  smoke_assert_contains "$out" "integrityerror_reclassified=duplicate" \
+    "r3 #1: a PK IntegrityError (lost the INSERT race) is reclassified, NOT a 500"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "setup: room on node A + baseline cross-node join captured" test_setup_room_and_capture
+smoke_run "positive: valid cross-node join persists a verified pending row" test_valid_cross_node_join_persists_pending
+smoke_run "T1: hostile --from/BRIDGE_AGENT_ID/USER cannot change the joiner" test_T1_hostile_from_env_cannot_change_joiner
+smoke_run "T2: a node-B process cannot join as a different B agent" test_T2_cannot_join_as_a_different_B_agent
+smoke_run "T3a: an expired (TTL) token is refused — no pending row" test_T3a_expired_token_refused
+smoke_run "T3b: a revoked (rotated) token is refused — no pending row" test_T3b_revoked_token_refused
+smoke_run "T4: raw token AND hash never persisted in queue/audit/staged" test_T4_no_token_or_hash_persisted_anywhere
+smoke_run "T5a: a malformed body is refused (422, no crash)" test_T5a_malformed_body_refused_no_crash
+smoke_run "T5b: a duplicate join is idempotent; id-reuse is a 409" test_T5b_duplicate_idempotent
+smoke_run "auth preamble unweakened (HMAC 401 / remote_addr 403 / unknown peer 403)" test_auth_preamble_unweakened
+smoke_run "a non-leader node refuses + persists nothing" test_non_leader_node_refuses
+smoke_run "r3 #2: unmigrated P1 db (missing dedupe table) still joins (no 500)" test_upgraded_db_missing_dedupe_table
+smoke_run "r3 #1: a message_id PK race is reclassified (dup/conflict), not a 500" test_atomic_race_reclassified_not_500
+
+smoke_log "passed"

--- a/scripts/smoke/rooms-p4-1-post-hook.sh
+++ b/scripts/smoke/rooms-p4-1-post-hook.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-1-post-hook.sh — BRIDGE_ROOMS_TEST_POST_HOOK target.
+#
+# The cross-node `bridge-rooms.py join` test seam invokes this with the signed
+# request JSON as $1 (file-as-argv, never stdin — footgun #11). We delegate to
+# the helper's `post-hook` subcommand, which writes the captured request to
+# $CAPTURE_FILE and echoes a stub response body. Kept as a separate executable
+# so the CLI hook contract (`[hook, payload]`) is satisfied with a real argv[0].
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$HERE/rooms-p4-1-cross-node-join-helper.py" post-hook "$1"


### PR DESCRIPTION
First phase of A2A Rooms cross-node (codex-plan-agreed #9620/#9622/#9633). Member on node B posts room_join_request to leader node A over existing node-link → A verifies + persists PENDING room_join_requests row (no auto-admit). +1773 across receiver/CLI/envelope/schema + 3 smokes. Taken over + finalized from the build fixer (3 internal codex rounds). PR to integration branch feat/rooms-p4.

6 contracts: OS-actor joiner (resolve_os_actor, NOT --from/env); verify_invite_token TTL(invite_token_ts)+revocation; pending-only; token never persisted (raw/hash); receiver auth preamble UNCHANGED; pending-row supports future cross-approve gate.

Smoke 13/13: T1 hostile-env-cant-change-joiner / T2 node-B-cant-join-as-other-B / T3b revoked-token-refused / T4 no-token-in-queue-audit-staged / T5a malformed-422 / T5b dup-idempotent / auth-unweakened-401-403 / non-leader-refuses / msgid-race + unmigrated-db robustness. All lints + ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)