### PR TITLE
feat(a2a): Rooms P4.2 — leader approve + roster broadcast

### DIFF
--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -2062,13 +2062,17 @@ class HandoffHandler(BaseHTTPRequestHandler):
         room_epoch = int(roster["room_epoch"])
         members = list(roster["members"])
 
-        # --- j. ACCEPT per the member-side contracts + reserve dedupe atomically.
-        # accept_roster_broadcast enforces leader-authority (peer==leader_node),
-        # the first-roster binding, the monotonic epoch, and the atomic cache
-        # write. We reserve the dedupe row ONLY when the cache was actually
-        # written or it was an idempotent same-state accept — so a rejected
-        # (not-leader / no-binding / stale) broadcast leaves NO dedupe row and a
-        # replay re-evaluates (never a bogus idempotent 200).
+        # --- j. ACCEPT per the member-side contracts WITH atomic dedupe (codex
+        # P4.2 r3 BLOCKING — close the TOCTOU race). accept_roster_broadcast
+        # enforces leader-authority (peer==leader_node), the leader pin, the
+        # first-roster binding, the monotonic epoch, AND folds the peer-scoped
+        # dedupe RESERVATION into the SAME transaction as the cache write. So a
+        # same-(peer,message_id)/DIFFERENT-body roster is caught as a CONFLICT
+        # BEFORE any cache mutation (409, nothing written), and a contract REJECT
+        # (not_leader / leader_mismatch / no_binding / stale) reserves NO dedupe
+        # row so a replay re-evaluates. The earlier read-only dedupe pre-check
+        # (step h) is a fast-path early answer for an ALREADY-RESERVED id; the
+        # authoritative serialization is here.
         try:
             conn = rooms.open_rooms()
         except rooms.RoomsError as exc:
@@ -2081,6 +2085,7 @@ class HandoffHandler(BaseHTTPRequestHandler):
                 outcome = rooms.accept_roster_broadcast(
                     conn, room_id=room_id, room_epoch=room_epoch,
                     members=members, leader_node=leader_node, peer_id=peer_id,
+                    message_id=message_id, body_sha256=computed_hash,
                     mac=signature,
                 )
             except rooms.RoomsError as exc:
@@ -2089,63 +2094,57 @@ class HandoffHandler(BaseHTTPRequestHandler):
                       message_id=message_id, room_id=room_id)
                 self._reply(500, {"ok": False, "error": "internal error"})
                 return
-
-            if outcome == rooms.ROSTER_NOT_LEADER:
-                audit("room_roster_reject", reason="not_leader",
-                      peer=peer_id, client=client_ip, room_id=room_id,
-                      leader_node=leader_node, message_id=message_id,
-                      security=True)
-                self._reply(403, {"ok": False,
-                                  "error": "roster sender is not the room leader"})
-                return
-            if outcome == rooms.ROSTER_LEADER_MISMATCH:
-                # A configured peer self-claiming leadership of a room already
-                # led by a DIFFERENT node — a takeover attempt. Reject, persist
-                # nothing (codex P4.2 r1 BLOCKING).
-                audit("room_roster_reject", reason="leader_mismatch",
-                      peer=peer_id, client=client_ip, room_id=room_id,
-                      leader_node=leader_node, message_id=message_id,
-                      security=True)
-                self._reply(403, {"ok": False,
-                                  "error": "roster sender is not the established "
-                                  "room leader (takeover refused)"})
-                return
-            if outcome == rooms.ROSTER_NO_LOCAL_BINDING:
-                audit("room_roster_reject", reason="no_local_binding",
-                      peer=peer_id, client=client_ip, room_id=room_id,
-                      message_id=message_id, security=True)
-                self._reply(403, {"ok": False,
-                                  "error": "no local join state for this room — "
-                                  "refusing to mint a roster cache from an "
-                                  "inbound broadcast"})
-                return
-            if outcome == rooms.ROSTER_STALE_EPOCH:
-                # Not an error (a legitimate lower/same-epoch non-duplicate is
-                # simply ignored), but we still return 200 with applied=False so
-                # the leader does not retry forever. No dedupe row reserved.
-                audit("room_roster_ignore", reason="stale_epoch",
-                      peer=peer_id, client=client_ip, room_id=room_id,
-                      epoch=room_epoch, message_id=message_id)
-                self._reply(200, {"ok": True, "applied": False,
-                                  "reason": "stale_epoch"})
-                return
-
-            # ACCEPTED (cache written) or DUPLICATE (idempotent same-state). Both
-            # are legitimate terminal states for THIS message — reserve the
-            # peer-scoped dedupe row so an exact replay short-circuits to an
-            # idempotent 200 (and an id-reuse-with-different-body is a 409). The
-            # reservation is best-effort: a failure to reserve must NOT undo the
-            # already-committed cache write, so we log + still return 200.
-            try:
-                rooms.reserve_roster_dedupe(
-                    conn, peer=peer_id, message_id=message_id,
-                    body_sha256=computed_hash)
-            except Exception as exc:  # noqa: BLE001 - dedupe is best-effort
-                audit("room_roster_warn", reason="dedupe_reserve_failed",
-                      peer=peer_id, client=client_ip, message_id=message_id,
-                      detail=str(exc)[:200])
         finally:
             conn.close()
+
+        if outcome == rooms.ROSTER_NOT_LEADER:
+            audit("room_roster_reject", reason="not_leader",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  leader_node=leader_node, message_id=message_id,
+                  security=True)
+            self._reply(403, {"ok": False,
+                              "error": "roster sender is not the room leader"})
+            return
+        if outcome == rooms.ROSTER_LEADER_MISMATCH:
+            # A configured peer self-claiming leadership of a room already led by
+            # a DIFFERENT node — a takeover attempt. Reject, persist nothing
+            # (codex P4.2 r1 BLOCKING).
+            audit("room_roster_reject", reason="leader_mismatch",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  leader_node=leader_node, message_id=message_id,
+                  security=True)
+            self._reply(403, {"ok": False,
+                              "error": "roster sender is not the established "
+                              "room leader (takeover refused)"})
+            return
+        if outcome == rooms.ROSTER_NO_LOCAL_BINDING:
+            audit("room_roster_reject", reason="no_local_binding",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  message_id=message_id, security=True)
+            self._reply(403, {"ok": False,
+                              "error": "no local join state for this room — "
+                              "refusing to mint a roster cache from an "
+                              "inbound broadcast"})
+            return
+        if outcome == rooms.ROSTER_DEDUPE_CONFLICT:
+            # Same (peer, message_id) reused with a DIFFERENT body — caught at the
+            # atomic dedupe reservation BEFORE any cache write (codex P4.2 r3).
+            audit("room_roster_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  message_id=message_id, security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+        if outcome == rooms.ROSTER_STALE_EPOCH:
+            # Not an error (a legitimate lower/same-epoch non-duplicate is simply
+            # ignored), but we still return 200 with applied=False so the leader
+            # does not retry forever. No dedupe row reserved.
+            audit("room_roster_ignore", reason="stale_epoch",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  epoch=room_epoch, message_id=message_id)
+            self._reply(200, {"ok": True, "applied": False,
+                              "reason": "stale_epoch"})
+            return
 
         if outcome == rooms.ROSTER_DUPLICATE:
             audit("room_roster_accept", reason="duplicate",

--- a/bridge-handoffd.py
+++ b/bridge-handoffd.py
@@ -841,6 +841,16 @@ class HandoffHandler(BaseHTTPRequestHandler):
         if self.path == room_join_path:
             self._handle_room_join_request(cfg)
             return
+        # A2A Rooms P4.2 (design §6 / §14 R2): the leader-signed roster broadcast
+        # is ALSO routed to a SEPARATE handler with the SAME fail-closed auth
+        # preamble (remote_addr -> HMAC -> skew -> dedupe). Its terminal action
+        # is a member-local room_roster_cache write — it NEVER reaches the
+        # enqueue/allowlist/queue boundary, creates no task, and admits nothing.
+        room_roster_path = cfg.get("listen", {}).get(
+            "room_roster_path", a2a.ROOM_ROSTER_PATH)
+        if self.path == room_roster_path:
+            self._handle_room_roster_broadcast(cfg)
+            return
         if self.path != enqueue_path:
             self._reply(404, {"ok": False, "error": "not found"})
             return
@@ -1843,6 +1853,315 @@ class HandoffHandler(BaseHTTPRequestHandler):
         self._reply(200, {"ok": True, "status": rooms.JOIN_PENDING,
                           "room_id": room_id,
                           "joiner": f"{joiner_agent}@{joiner_node}"})
+
+    def _handle_room_roster_broadcast(self, cfg: dict[str, Any]) -> None:
+        """Receiver branch for the leader-signed cross-node roster broadcast
+        (A2A Rooms P4.2, design §6 / §14 R2).
+
+        HIGH-RISK: a NEW remote-traffic surface. It runs the SAME fail-closed
+        auth preamble as do_POST / _handle_room_join_request (NO step weakened),
+        then applies the member-side roster-acceptance contracts and writes the
+        member-local room_roster_cache. Validation ORDER (security=True audit on
+        every reject; NO persistence until ALL pass):
+          a. tailnet-only bind — guaranteed at startup (resolve_bind).
+          b. protocol tag == ROOM_ROSTER_PROTOCOL_VERSION.
+          c. message_id REQUIRED (anchors dedupe).
+          d. peer ALREADY PAIRED (find_peer; unknown -> 403). NOT discovery.
+          e. remote_addr == the peer's CURRENT resolved Tailscale IP (before
+             the body is read off the socket).
+          f. HMAC: secret present, body hash, signature (constant-time). The
+             X-AGB-Signature IS the leader-node↔member-node PAIRWISE signature
+             (§14 R2) — a member that lacks the leader↔Z secret cannot forge a
+             roster node Z would accept. The PATH is in the canonical string, so
+             an enqueue/join/identity signature cannot be replayed here.
+          g. clock-skew window — transient drift 503, far-stale 401.
+          h. durable dedupe (replay-safe) on (peer, message_id). A byte-identical
+             re-broadcast is an idempotent 200; an id-reuse-with-different-body is
+             a 409. The dedupe ledger lives in rooms.db (the member's own db).
+          i. parse the control body (shape only).
+          j. ACCEPT per the member-side contracts (anti-rogue-leader binding +
+             monotonic epoch + atomic cache write) — see
+             rooms.accept_roster_broadcast. The authenticated `peer_id` is the
+             ONLY trusted leader identity (it MUST equal the body's leader_node);
+             a roster from a non-leader peer persists NOTHING.
+        """
+        client_ip = self._client_ip()
+        peer_id = self.headers.get("X-AGB-Peer", "")
+        message_id = self.headers.get("X-AGB-Message-Id", "")
+        timestamp = self.headers.get("X-AGB-Timestamp", "")
+        body_hash_hdr = self.headers.get("X-AGB-Body-SHA256", "")
+        signature = self.headers.get("X-AGB-Signature", "")
+        protocol = self.headers.get("X-AGB-Protocol", "")
+
+        # --- b. protocol tag ---
+        if protocol != a2a.ROOM_ROSTER_PROTOCOL_VERSION:
+            audit("room_roster_reject", reason="bad_protocol",
+                  peer=peer_id, client=client_ip, got=protocol)
+            self._reply(400, {"ok": False, "error": "unsupported protocol"})
+            return
+
+        # --- c. message_id REQUIRED (non-empty) ---
+        if not message_id:
+            audit("room_roster_reject", reason="missing_message_id",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(400, {"ok": False, "error": "message id required"})
+            return
+
+        # --- d. peer must be ALREADY PAIRED (not a discovery channel) ---
+        try:
+            peer = a2a.find_peer(cfg, peer_id)
+        except a2a.A2AError:
+            audit("room_roster_reject", reason="unknown_peer",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "unknown peer"})
+            return
+
+        # --- e. remote_addr == authenticated peer's CURRENT address (before body) ---
+        try:
+            peer_addr = a2a.resolve_peer_address(peer)
+        except a2a.A2AError as exc:
+            audit("room_roster_reject", reason=getattr(exc, "code",
+                  "resolve_error"), peer=peer_id, client=client_ip,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+        if not peer_addr or client_ip != peer_addr:
+            audit("room_roster_reject", reason="addr_mismatch",
+                  peer=peer_id, client=client_ip, expected=peer_addr,
+                  security=True)
+            self._reply(403, {"ok": False, "error": "source address mismatch"})
+            return
+
+        # --- size guard before reading the body (roster bodies are small) ---
+        try:
+            content_length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            content_length = -1
+        if content_length < 0:
+            self._reply(411, {"ok": False, "error": "length required"})
+            return
+        max_body = 256 * 1024  # a roster of many members, still bounded
+        if content_length > max_body:
+            audit("room_roster_reject", reason="oversize",
+                  peer=peer_id, client=client_ip, declared=content_length)
+            self._reply(413, {"ok": False, "error": "body too large"})
+            return
+        raw = self.rfile.read(content_length) if content_length else b""
+
+        # --- f. HMAC: secret present, body hash, signature (auth boundary) ---
+        secrets = a2a.peer_secrets(peer)
+        if not secrets:
+            audit("room_roster_reject", reason="no_secret",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(403, {"ok": False, "error": "peer not provisioned"})
+            return
+        computed_hash = a2a.body_sha256(raw)
+        if body_hash_hdr != computed_hash:
+            audit("room_roster_reject", reason="body_hash",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "body hash mismatch"})
+            return
+        # HMAC FIRST (before timestamp-band classification) so an
+        # unauthenticated request never receives a transient/permanent split
+        # that leaks signature validity (same ordering as do_POST, #1346). The
+        # path is part of the canonical string, so a signature minted for the
+        # enqueue/join/identity endpoint cannot be replayed against this one.
+        canonical = a2a.canonical_string(
+            "POST", self.path, peer_id, message_id, timestamp, computed_hash)
+        if not a2a.verify_signature(secrets, canonical, signature):
+            audit("room_roster_reject", reason="bad_signature",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(401, {"ok": False, "error": "signature verification failed"})
+            return
+
+        # --- g. clock-skew window (authenticated past this point) ---
+        skew = int(cfg.get("timestamp_skew_seconds",
+                           a2a.DEFAULT_TIMESTAMP_SKEW_SECONDS))
+        grace_skew = int(cfg.get("timestamp_skew_grace_seconds",
+                                 a2a.DEFAULT_TIMESTAMP_SKEW_GRACE_SECONDS))
+        if grace_skew < skew:
+            grace_skew = skew
+        receiver_now = a2a.now_ts()
+        try:
+            req_ts = int(timestamp)
+        except (TypeError, ValueError):
+            audit("room_roster_reject", reason="bad_timestamp",
+                  peer=peer_id, client=client_ip, security=True)
+            self._reply(401, {"ok": False, "error": "bad timestamp"})
+            return
+        ts_delta = abs(receiver_now - req_ts)
+        if ts_delta > grace_skew:
+            audit("room_roster_reject", reason="clock_skew_permanent",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta,
+                  security=True)
+            self._reply(401, {"ok": False,
+                              "error": "timestamp far outside skew window",
+                              "receiver_ts": receiver_now})
+            return
+        if ts_delta > skew:
+            audit("room_roster_reject", reason="clock_skew_transient",
+                  peer=peer_id, client=client_ip, delta_seconds=ts_delta)
+            self._reply(503, {"ok": False,
+                              "error": "timestamp outside skew window — retry",
+                              "receiver_ts": receiver_now},
+                        extra_headers={"Retry-After": str(max(1, skew))})
+            return
+
+        # --- h. durable dedupe — READ-ONLY replay check (peer-scoped) ---
+        # A byte-identical re-broadcast (same peer+id+body) is an idempotent 200;
+        # an id-reuse with a DIFFERENT body is a 409. The dedupe ledger reuses
+        # the room_join_dedupe table in the MEMBER's rooms.db (the member's own
+        # db). A rejected/no-op acceptance leaves NO dedupe row, so a replay
+        # re-runs acceptance (the stale-epoch / not-leader teeth hold on replay).
+        if rooms is None:
+            audit("room_roster_error", reason="rooms_module_unavailable",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms unavailable"})
+            return
+        try:
+            ro = rooms.open_rooms_readonly()
+            if ro is not None:
+                try:
+                    dup = rooms.room_join_dedupe_lookup(
+                        ro, peer_id, message_id, computed_hash)
+                finally:
+                    ro.close()
+            else:
+                dup = "new"
+        except Exception as exc:  # noqa: BLE001 - last-resort guard
+            audit("room_roster_error", reason="dedupe_error",
+                  peer=peer_id, client=client_ip, detail=str(exc)[:200])
+            self._reply(500, {"ok": False, "error": "internal error"})
+            return
+        if dup == rooms.JOIN_DEDUPE_DUPLICATE:
+            audit("room_roster_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True})
+            return
+        if dup == rooms.JOIN_DEDUPE_CONFLICT:
+            audit("room_roster_reject", reason="hash_conflict",
+                  peer=peer_id, client=client_ip, message_id=message_id,
+                  security=True)
+            self._reply(409, {"ok": False,
+                              "error": "message id reused with different body"})
+            return
+
+        # --- i. parse the control body (shape only) ---
+        try:
+            roster = a2a.parse_room_roster_broadcast(raw)
+        except a2a.A2AError as exc:
+            audit("room_roster_reject", reason=getattr(exc, "code",
+                  "bad_room_roster"), peer=peer_id, client=client_ip,
+                  message_id=message_id)
+            self._reply(422, {"ok": False, "error": str(exc)})
+            return
+
+        room_id = str(roster["room_id"])
+        leader_node = str(roster["leader_node"])
+        room_epoch = int(roster["room_epoch"])
+        members = list(roster["members"])
+
+        # --- j. ACCEPT per the member-side contracts + reserve dedupe atomically.
+        # accept_roster_broadcast enforces leader-authority (peer==leader_node),
+        # the first-roster binding, the monotonic epoch, and the atomic cache
+        # write. We reserve the dedupe row ONLY when the cache was actually
+        # written or it was an idempotent same-state accept — so a rejected
+        # (not-leader / no-binding / stale) broadcast leaves NO dedupe row and a
+        # replay re-evaluates (never a bogus idempotent 200).
+        try:
+            conn = rooms.open_rooms()
+        except rooms.RoomsError as exc:
+            audit("room_roster_error", reason=getattr(exc, "code", "rooms_db"),
+                  peer=peer_id, client=client_ip, message_id=message_id)
+            self._reply(500, {"ok": False, "error": "rooms db error"})
+            return
+        try:
+            try:
+                outcome = rooms.accept_roster_broadcast(
+                    conn, room_id=room_id, room_epoch=room_epoch,
+                    members=members, leader_node=leader_node, peer_id=peer_id,
+                    mac=signature,
+                )
+            except rooms.RoomsError as exc:
+                audit("room_roster_error", reason=getattr(exc, "code",
+                      "accept_error"), peer=peer_id, client=client_ip,
+                      message_id=message_id, room_id=room_id)
+                self._reply(500, {"ok": False, "error": "internal error"})
+                return
+
+            if outcome == rooms.ROSTER_NOT_LEADER:
+                audit("room_roster_reject", reason="not_leader",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      leader_node=leader_node, message_id=message_id,
+                      security=True)
+                self._reply(403, {"ok": False,
+                                  "error": "roster sender is not the room leader"})
+                return
+            if outcome == rooms.ROSTER_LEADER_MISMATCH:
+                # A configured peer self-claiming leadership of a room already
+                # led by a DIFFERENT node — a takeover attempt. Reject, persist
+                # nothing (codex P4.2 r1 BLOCKING).
+                audit("room_roster_reject", reason="leader_mismatch",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      leader_node=leader_node, message_id=message_id,
+                      security=True)
+                self._reply(403, {"ok": False,
+                                  "error": "roster sender is not the established "
+                                  "room leader (takeover refused)"})
+                return
+            if outcome == rooms.ROSTER_NO_LOCAL_BINDING:
+                audit("room_roster_reject", reason="no_local_binding",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      message_id=message_id, security=True)
+                self._reply(403, {"ok": False,
+                                  "error": "no local join state for this room — "
+                                  "refusing to mint a roster cache from an "
+                                  "inbound broadcast"})
+                return
+            if outcome == rooms.ROSTER_STALE_EPOCH:
+                # Not an error (a legitimate lower/same-epoch non-duplicate is
+                # simply ignored), but we still return 200 with applied=False so
+                # the leader does not retry forever. No dedupe row reserved.
+                audit("room_roster_ignore", reason="stale_epoch",
+                      peer=peer_id, client=client_ip, room_id=room_id,
+                      epoch=room_epoch, message_id=message_id)
+                self._reply(200, {"ok": True, "applied": False,
+                                  "reason": "stale_epoch"})
+                return
+
+            # ACCEPTED (cache written) or DUPLICATE (idempotent same-state). Both
+            # are legitimate terminal states for THIS message — reserve the
+            # peer-scoped dedupe row so an exact replay short-circuits to an
+            # idempotent 200 (and an id-reuse-with-different-body is a 409). The
+            # reservation is best-effort: a failure to reserve must NOT undo the
+            # already-committed cache write, so we log + still return 200.
+            try:
+                rooms.reserve_roster_dedupe(
+                    conn, peer=peer_id, message_id=message_id,
+                    body_sha256=computed_hash)
+            except Exception as exc:  # noqa: BLE001 - dedupe is best-effort
+                audit("room_roster_warn", reason="dedupe_reserve_failed",
+                      peer=peer_id, client=client_ip, message_id=message_id,
+                      detail=str(exc)[:200])
+        finally:
+            conn.close()
+
+        if outcome == rooms.ROSTER_DUPLICATE:
+            audit("room_roster_accept", reason="duplicate",
+                  peer=peer_id, client=client_ip, room_id=room_id,
+                  message_id=message_id)
+            self._reply(200, {"ok": True, "duplicate": True,
+                              "room_id": room_id, "epoch": room_epoch})
+            return
+
+        # ACCEPTED — the member-local roster cache now reflects this epoch.
+        audit("room_roster_accept", reason="applied",
+              peer=peer_id, client=client_ip, room_id=room_id,
+              epoch=room_epoch, members=len(members), message_id=message_id)
+        self._reply(200, {"ok": True, "applied": True,
+                          "room_id": room_id, "epoch": room_epoch,
+                          "members": len(members)})
 
 
 # --------------------------------------------------------------------------

--- a/bridge-rooms.py
+++ b/bridge-rooms.py
@@ -530,6 +530,134 @@ def _invoke_test_post_hook(*, path: str, headers: dict,
     return 200, (proc.stdout or "").encode("utf-8")
 
 
+def _post_room_roster_broadcast(*, member_node: str, room_id: str,
+                                room_epoch: int, members: list,
+                                leader_node: str, timeout: float = 30.0,
+                                ) -> tuple[int, bytes]:
+    """POST the leader-signed roster broadcast to ONE member node (P4.2).
+
+    `member_node` names the A2A peer to deliver to; the body is signed with the
+    leader-node↔member-node PAIRWISE node-link HMAC (the existing per-peer
+    secret), so the member can verify the roster came from the leader and a
+    member that lacks the leader↔Z secret cannot forge a roster node Z accepts
+    (§14 R2). `members` MUST be the canonical sorted roster. `leader_node` is the
+    local node (this leader's node id). Returns (http_status, response_body).
+
+    Reuses the SAME paired-flag test seam as the join sender
+    (BRIDGE_ROOMS_TEST_POST_HOOK) — the hook captures the signed request; the
+    smoke replays it through the real member-side receiver handler. NEVER honored
+    in production (the paired flags are unset there).
+    """
+    if a2a is None:  # pragma: no cover - a2a always ships beside this
+        raise rooms.RoomsError(
+            "roster broadcast requires the A2A module + node-link config",
+            code="a2a_unavailable",
+        )
+    cfg = a2a.load_config()
+    local_bridge_id = str(cfg.get("bridge_id", "") or "").strip()
+    if not local_bridge_id:
+        raise rooms.RoomsError(
+            "config has no 'bridge_id' — cannot identify this leader node for a "
+            "roster broadcast", code="no_bridge_id",
+        )
+    peer = a2a.find_peer(cfg, member_node)
+    secret = a2a.peer_send_secret(peer)
+    body = a2a.build_room_roster_broadcast(
+        room_id=room_id, room_epoch=room_epoch, members=members,
+        leader_node=leader_node,
+    )
+    body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    message_id = a2a.new_message_id(local_bridge_id)
+    path = peer.get("room_roster_path", a2a.ROOM_ROSTER_PATH)
+    timestamp = str(a2a.now_ts())
+    body_hash = a2a.body_sha256(body_bytes)
+    canonical = a2a.canonical_string(
+        "POST", path, local_bridge_id, message_id, timestamp, body_hash)
+    signature = a2a.sign(secret, canonical)
+    headers = {
+        "Content-Type": "application/json",
+        "X-AGB-Protocol": a2a.ROOM_ROSTER_PROTOCOL_VERSION,
+        "X-AGB-Peer": local_bridge_id,
+        "X-AGB-Message-Id": message_id,
+        "X-AGB-Timestamp": timestamp,
+        "X-AGB-Body-SHA256": body_hash,
+        "X-AGB-Signature": signature,
+    }
+
+    if _test_post_hook_allowed():
+        return _invoke_test_post_hook(path=path, headers=headers,
+                                      body_bytes=body_bytes)
+
+    address = a2a.resolve_peer_address(peer)
+    port = int(peer.get("port", cfg.get("listen", {}).get("port", 8787)))
+    if not address:
+        raise rooms.RoomsError(
+            f"member node {member_node!r} has no resolvable address",
+            code="no_member_address",
+        )
+    import urllib.request
+
+    url = f"http://{address}:{port}{path}"
+    req = urllib.request.Request(url, data=body_bytes, method="POST")
+    for k, v in headers.items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:  # type: ignore[attr-defined]
+        return exc.code, (exc.read() or b"")
+
+
+def _member_nodes_for_broadcast(roster: dict, leader_node: str) -> list:
+    """The DISTINCT remote member nodes a roster broadcast targets.
+
+    Every member node that is NOT the leader's own node (the leader's local
+    members already see the authoritative rooms.db — no node-link hop). The
+    leader node is excluded so the leader never POSTs a roster to itself.
+    Deterministically ordered for reproducible broadcasts.
+    """
+    nodes: list = []
+    for m in roster.get("members", []):
+        mnode = str(m.get("node", "") or "")
+        if mnode and mnode != leader_node and mnode not in nodes:
+            nodes.append(mnode)
+    return sorted(nodes)
+
+
+def _broadcast_roster_to_members(room_id: str, roster: dict,
+                                 leader_node: str) -> dict:
+    """Broadcast the leader-signed canonical roster to every remote member node.
+
+    One signed POST per member node (§14 R2). Returns a summary
+    {delivered:[...], failed:[{node,status}...]} so the CLI can report partial
+    failures (a member-node outage does not unwind the already-committed local
+    approve — the leader's rooms.db is authoritative; the roster broadcast is
+    durable/retryable, design §14 R2). Broadcast failures are reported, never
+    fatal to the approve.
+    """
+    delivered: list = []
+    failed: list = []
+    member_nodes = _member_nodes_for_broadcast(roster, leader_node)
+    for mnode in member_nodes:
+        try:
+            status, _resp = _post_room_roster_broadcast(
+                member_node=mnode, room_id=room_id,
+                room_epoch=int(roster["epoch"]), members=roster["members"],
+                leader_node=leader_node,
+            )
+        except rooms.RoomsError as exc:
+            failed.append({"node": mnode, "error": str(exc)})
+            continue
+        except Exception as exc:  # noqa: BLE001 - transport/config failure
+            failed.append({"node": mnode, "error": f"broadcast failed: {exc}"})
+            continue
+        if 200 <= status < 300:
+            delivered.append(mnode)
+        else:
+            failed.append({"node": mnode, "status": status})
+    return {"delivered": delivered, "failed": failed}
+
+
 def cmd_join(args: argparse.Namespace) -> int:
     parsed = rooms.parse_invite_link(args.link)
     room_id = parsed.get("room", "")
@@ -567,6 +695,42 @@ def cmd_join(args: argparse.Namespace) -> int:
                 detail = ""
             return die(f"leader node rejected the join (HTTP {status}): {detail}",
                        code=1)
+        # P4.2 FIRST-ROSTER binding anchor: record the member's OWN outbound
+        # join intent locally (room_id + the leader_node it posted to). This is
+        # the un-spoofable proof that THIS node chose THIS room+leader, so the
+        # member can later accept the leader's FIRST roster broadcast for this
+        # room — and REFUSE a roster for a room it never tried to join (the
+        # anti-rogue-leader-minting defense, accept_roster_broadcast contract
+        # 3c). We record ONLY when the leader's 2xx response CONFIRMS it
+        # persisted a pending row (`status==pending`) or already had one
+        # (`duplicate==true`) — a bare 200 with no such confirmation does NOT
+        # mint a local binding (so a non-committal/stub response cannot seed a
+        # spurious intent).
+        leader_confirmed_pending = False
+        try:
+            ack = json.loads(resp.decode("utf-8", "replace") or "{}")
+            if isinstance(ack, dict):
+                leader_confirmed_pending = (
+                    ack.get("status") == rooms.JOIN_PENDING
+                    or ack.get("duplicate") is True)
+        except (ValueError, json.JSONDecodeError):
+            leader_confirmed_pending = False
+        if leader_confirmed_pending:
+            try:
+                mconn = rooms.open_rooms()
+                try:
+                    rooms.record_local_join_intent(
+                        mconn, room_id, agent, node, leader_node=leader_node)
+                finally:
+                    mconn.close()
+            except rooms.RoomsError as exc:
+                # The leader already accepted the join; failing to record the
+                # local binding is non-fatal but means the first roster will be
+                # refused until re-joined. Surface it without unwinding the
+                # accepted join.
+                info(f"WARNING: cross-node join accepted but local binding not "
+                     f"recorded ({exc}); the first roster broadcast may be "
+                     "refused until you re-run join")
         if args.json:
             out(json.dumps({"room_id": room_id,
                             "agent": f"{agent}@{node}",
@@ -608,17 +772,32 @@ def cmd_approve(args: argparse.Namespace) -> int:
     node = local_node()
     agent, anode = split_agent_node(args.target, node)
     conn = rooms.open_rooms()
+    roster_snapshot: Optional[dict] = None
     try:
         room = _require_leader_conn(conn, args.room_id, args)
-        # A join must have been requested (the two-factor gate: token =>
-        # request => leader approval). Approving an unrequested agent is a
-        # leader-initiated add, which we allow but note.
-        epoch = rooms.approve_join(conn, args.room_id, agent, anode)
+        leader_node = str(room["leader_node"] or "")
+        # P4.2 contract 1/6: a CROSS-NODE approve (admitting a REMOTE agent whose
+        # node != this leader node) REQUIRES a P4.1 verified pending row — the
+        # receiver only creates that AFTER the node-link HMAC + token + TTL/
+        # revocation verification passed. The LOCAL leader-add path (admitting an
+        # agent on this leader's OWN node) stays a SEPARATE path that does NOT
+        # claim that token/two-factor gate. The two paths are kept distinct here.
+        is_cross_node = bool(anode) and bool(leader_node) and anode != leader_node
+        if is_cross_node:
+            epoch = rooms.approve_cross_node(conn, args.room_id, agent, anode)
+        else:
+            # P1 local path: a leader-initiated add of a local agent (no verified-
+            # pending-row requirement — the leader is OS-authenticated and the
+            # agent shares this node).
+            epoch = rooms.approve_join(conn, args.room_id, agent, anode)
         if room["invite_once"]:
             rooms.burn_invite_token(conn, args.room_id)
             burned = True
         else:
             burned = False
+        # Snapshot the NEW canonical roster (post-approve, post-epoch-bump) while
+        # the connection is open, so we can broadcast it after closing the db.
+        roster_snapshot = rooms.roster_for(conn, args.room_id)
     except rooms.RoomsError as exc:
         conn.close()
         return die(str(exc), code=1)
@@ -627,12 +806,32 @@ def cmd_approve(args: argparse.Namespace) -> int:
             conn.close()
         except Exception:  # noqa: BLE001
             pass
+
+    # Broadcast the leader-signed canonical roster to every REMOTE member node
+    # over the node-link (§14 R2). The local approve is already committed +
+    # authoritative; a member-node delivery failure is reported, never fatal
+    # (roster broadcasts are durable/retryable). No-op when there are no remote
+    # member nodes (a pure single-node room).
+    broadcast = {"delivered": [], "failed": []}
+    if roster_snapshot is not None and leader_node:
+        broadcast = _broadcast_roster_to_members(
+            args.room_id, roster_snapshot, leader_node)
+
     if args.json:
         out(json.dumps({"room_id": args.room_id, "approved": f"{agent}@{anode}",
-                        "epoch": epoch, "invite_burned": burned}))
+                        "epoch": epoch, "invite_burned": burned,
+                        "cross_node": is_cross_node,
+                        "roster_broadcast": broadcast}))
     else:
         info(f"approved {agent}@{anode} into {args.room_id} (epoch {epoch})"
              + (" — single-use invite burned" if burned else ""))
+        if broadcast["delivered"]:
+            info(f"roster broadcast delivered to: "
+                 f"{', '.join(broadcast['delivered'])}")
+        if broadcast["failed"]:
+            info(f"WARNING: roster broadcast failed for: "
+                 f"{broadcast['failed']} (durable/retryable — the local approve "
+                 "is committed)")
     return 0
 
 

--- a/bridge_a2a_common.py
+++ b/bridge_a2a_common.py
@@ -64,6 +64,26 @@ ROOM_JOIN_PROTOCOL_VERSION = "a2a-room-join-v1"
 ROOM_JOIN_ENVELOPE_PROTOCOL = "agent-bridge.a2a.room-join.v1"
 ROOM_JOIN_PATH = "/room-join-request"
 
+# A2A Rooms P4.2 (design §6 / §11 / §14 R2): the signed cross-node
+# `room-roster-broadcast` control message. After the leader (on node A) approves
+# a member it bumps the room epoch and broadcasts the canonical, leader-signed
+# roster to EACH member node over THAT node's existing node-link, MAC'd with the
+# leader-node↔member-node ordered-pair secret (one signed POST per member-link —
+# §14 R2 "Member X knows only the leader↔X secret, never leader↔Z, so X cannot
+# forge a roster node Z would accept"). Like the join-request it is a DISTINCT
+# protocol routed to a SEPARATE handler with the SAME fail-closed auth preamble
+# (remote_addr -> HMAC -> skew -> dedupe); its terminal action is a member-local
+# room_roster_cache write — it NEVER reaches the enqueue/allowlist/queue
+# boundary, carries no queue task, and admits nothing. The pairwise HMAC IS the
+# leader signature: the X-AGB-Signature header is computed over the canonical
+# request string (which binds method+path+peer+message_id+timestamp+body-hash)
+# with the leader↔member secret, so a member cannot forge a roster for a peer
+# whose secret it does not hold. The body carries ONLY the canonical roster
+# (room_id, room_epoch, sorted members, leader_node) — no token, no secret.
+ROOM_ROSTER_PROTOCOL_VERSION = "a2a-room-roster-v1"
+ROOM_ROSTER_ENVELOPE_PROTOCOL = "agent-bridge.a2a.room-roster.v1"
+ROOM_ROSTER_PATH = "/room-roster-broadcast"
+
 # Default per-peer caps. Receiver config may override per peer.
 DEFAULT_MAX_BODY_BYTES = 256 * 1024
 DEFAULT_MAX_TITLE_BYTES = 1024
@@ -975,6 +995,134 @@ def parse_room_join_request(raw: bytes) -> dict[str, Any]:
             "room-join-request join_token_sha256 must be a sha256 hex digest",
             code="bad_room_join",
         )
+    return body
+
+
+# --------------------------------------------------------------------------
+# Cross-node room-roster-broadcast control message (A2A Rooms P4.2, design §6/§14 R2)
+# --------------------------------------------------------------------------
+#
+# The body a leader's node A signs (over the per-member node-link HMAC) + each
+# member node re-validates. It carries the CANONICAL, leader-authoritative
+# roster for one room:
+#   - room_id:     the room.
+#   - room_epoch:  the monotonic epoch the broadcast carries (the freshness /
+#                  split-brain tiebreaker; a member ignores a lower-or-same epoch
+#                  unless it is a byte-identical idempotent duplicate).
+#   - members:     the roster, CANONICALLY sorted by (agent, node) — the exact
+#                  bytes the leader signed; any verifier recomputes the same MAC
+#                  string. Each entry is {agent, node, role}.
+#   - leader_node: the node that leads the room. CRITICAL (contract 3a): the
+#                  member accepts a roster ONLY when the authenticated X-AGB-Peer
+#                  (the node-link sender) EQUALS this leader_node — a roster from
+#                  any non-leader authenticated peer is rejected, persisting
+#                  nothing. There is deliberately NO leader_agent-on-the-wire
+#                  trust beyond what the roster members list itself carries.
+# The leader's signature is the node-link HMAC header (X-AGB-Signature) over the
+# canonical request string — the body carries no separate `sig` field because
+# the pairwise HMAC over the body hash IS the per-member signature (§14 R2: one
+# signature per member-link). No token, no secret ever crosses this wire.
+
+
+def build_room_roster_broadcast(
+    *,
+    room_id: str,
+    room_epoch: int,
+    members: list[dict[str, Any]],
+    leader_node: str,
+) -> dict[str, Any]:
+    """Build the cross-node room-roster-broadcast control body.
+
+    `members` MUST already be the CANONICAL sorted roster (sorted by (agent,
+    node) — `bridge_rooms_common._sorted_members` / `roster_for`). The caller
+    signs the resulting body bytes with the leader-node↔member-node pairwise
+    HMAC (the node-link secret) for EACH member node it broadcasts to, so a
+    member cannot forge a roster for a peer whose secret it does not hold. The
+    body carries NO `sig` field — the X-AGB-Signature header IS the per-link
+    signature (§14 R2).
+    """
+    return {
+        "protocol": ROOM_ROSTER_ENVELOPE_PROTOCOL,
+        "room_id": room_id,
+        "room_epoch": int(room_epoch),
+        "members": members,
+        "leader_node": leader_node,
+    }
+
+
+def parse_room_roster_broadcast(raw: bytes) -> dict[str, Any]:
+    """Parse + shape-validate a cross-node room-roster-broadcast control body.
+
+    Validates only the WIRE shape: a JSON object with the right protocol tag,
+    non-empty string `room_id` + `leader_node`, a non-negative int `room_epoch`,
+    and a `members` LIST whose every entry is an object with non-empty string
+    `agent` + string `node` (+ optional string `role`). A malformed/garbage
+    value is refused at the boundary, never half-trusted. It does NOT verify the
+    leader-authority binding (the receiver checks the authenticated peer ==
+    leader_node and the pairwise HMAC) and does NOT trust the roster beyond the
+    node-link auth the receiver already enforced.
+    """
+    try:
+        body = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise A2AError(
+            f"room-roster-broadcast is not valid JSON: {exc}",
+            code="bad_room_roster",
+        ) from exc
+    if not isinstance(body, dict):
+        raise A2AError(
+            "room-roster-broadcast root must be a JSON object",
+            code="bad_room_roster",
+        )
+    if body.get("protocol") != ROOM_ROSTER_ENVELOPE_PROTOCOL:
+        raise A2AError(
+            f"unsupported room-roster-broadcast protocol: {body.get('protocol')!r}",
+            code="bad_room_roster_protocol",
+        )
+    for field in ("room_id", "leader_node"):
+        val = body.get(field)
+        if not isinstance(val, str) or not val:
+            raise A2AError(
+                f"room-roster-broadcast missing required string field: {field}",
+                code="bad_room_roster",
+            )
+    epoch = body.get("room_epoch")
+    # bool is an int subclass — reject it explicitly so `true`/`false` cannot
+    # masquerade as an epoch.
+    if not isinstance(epoch, int) or isinstance(epoch, bool) or epoch < 0:
+        raise A2AError(
+            "room-roster-broadcast room_epoch must be a non-negative integer",
+            code="bad_room_roster",
+        )
+    members = body.get("members")
+    if not isinstance(members, list):
+        raise A2AError(
+            "room-roster-broadcast members must be a list", code="bad_room_roster",
+        )
+    for entry in members:
+        if not isinstance(entry, dict):
+            raise A2AError(
+                "room-roster-broadcast member entries must be objects",
+                code="bad_room_roster",
+            )
+        agent = entry.get("agent")
+        node = entry.get("node", "")
+        role = entry.get("role", "")
+        if not isinstance(agent, str) or not agent:
+            raise A2AError(
+                "room-roster-broadcast member missing string 'agent'",
+                code="bad_room_roster",
+            )
+        if not isinstance(node, str):
+            raise A2AError(
+                "room-roster-broadcast member 'node' must be a string",
+                code="bad_room_roster",
+            )
+        if not isinstance(role, str):
+            raise A2AError(
+                "room-roster-broadcast member 'role' must be a string",
+                code="bad_room_roster",
+            )
     return body
 
 

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -1250,6 +1250,51 @@ def room_join_dedupe_lookup(conn: sqlite3.Connection, peer: str,
             else JOIN_DEDUPE_CONFLICT)
 
 
+def reserve_roster_dedupe(conn: sqlite3.Connection, *, peer: str,
+                          message_id: str, body_sha256: str) -> str:
+    """Reserve a peer-scoped dedupe row for an APPLIED roster broadcast (P4.2).
+
+    Reuses the `room_join_dedupe` ledger (peer-scoped composite PK) so a
+    re-delivery of the SAME (peer, message_id, body) short-circuits to an
+    idempotent 200, while a (peer, message_id) reuse with a DIFFERENT body is a
+    409 conflict. Called by the roster receiver ONLY after the cache write
+    actually committed (or was an idempotent same-state accept), so a dedupe row
+    exists IFF the broadcast was applied — a rejected/ignored broadcast leaves no
+    row and a replay re-evaluates. Returns JOIN_DEDUPE_RESERVED on a fresh
+    reservation, JOIN_DEDUPE_DUPLICATE/JOIN_DEDUPE_CONFLICT if a row already
+    existed (idempotent re-reserve). Never raises on a benign PK race.
+    """
+    existing = conn.execute(
+        "SELECT body_sha256 FROM room_join_dedupe WHERE peer=? AND message_id=?",
+        (peer, message_id),
+    ).fetchone()
+    if existing is not None:
+        return (JOIN_DEDUPE_DUPLICATE if existing["body_sha256"] == body_sha256
+                else JOIN_DEDUPE_CONFLICT)
+    try:
+        conn.execute(
+            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+            "created_ts) VALUES (?, ?, ?, ?)",
+            (message_id, peer, body_sha256, now_ts()),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        # Lost a concurrent PK race — re-query the winner's row, return the same
+        # idempotent/conflict classification (never a raise).
+        conn.rollback()
+        winner = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
+        ).fetchone()
+        if winner is not None:
+            return (JOIN_DEDUPE_DUPLICATE
+                    if winner["body_sha256"] == body_sha256
+                    else JOIN_DEDUPE_CONFLICT)
+        raise
+    return JOIN_DEDUPE_RESERVED
+
+
 def record_verified_cross_node_join_request_atomic(
     conn: sqlite3.Connection, *, message_id: str, body_sha256: str, peer: str,
     room_id: str, agent: str, node: str, via_node: str, ttl_expiry: int = 0,
@@ -1447,6 +1492,62 @@ def approve_join(conn: sqlite3.Connection, room_id: str, agent: str,
     return bump_epoch(conn, room_id)
 
 
+def has_verified_pending_request(conn: sqlite3.Connection, room_id: str,
+                                 agent: str, node: str) -> bool:
+    """True iff a VERIFIED, still-pending cross-node join row exists (P4.2).
+
+    The two-factor gate for a CROSS-NODE approve (contract 1): admitting a
+    REMOTE agent (one whose node != this leader node) REQUIRES a
+    `room_join_requests` row with `verified=1` AND `status='pending'` —
+    i.e. a row the receiver (P4.1) created only AFTER the node-link HMAC +
+    token-hash + TTL/revocation verification passed. A row that is denied/
+    approved/absent does NOT satisfy the gate. The LOCAL leader-initiated add
+    path (a leader admitting an agent on its OWN node) is a SEPARATE path that
+    does NOT consult this gate — see `approve_cross_node` vs `approve_join`.
+    """
+    row = conn.execute(
+        "SELECT verified, status FROM room_join_requests "
+        "WHERE room_id=? AND agent=? AND node=?",
+        (room_id, agent, node),
+    ).fetchone()
+    if row is None:
+        return False
+    try:
+        verified = int(row["verified"])
+    except (KeyError, IndexError, TypeError, ValueError):
+        verified = 0
+    return verified == 1 and str(row["status"]) == JOIN_PENDING
+
+
+def approve_cross_node(conn: sqlite3.Connection, room_id: str, agent: str,
+                       node: str) -> int:
+    """Admit a REMOTE (cross-node) member — REQUIRES a verified pending row.
+
+    The P4.2 cross-node admission path (contract 1). Unlike `approve_join` (the
+    P1 local path that admits a local agent with no pending-row requirement),
+    this REFUSES to add a remote member unless a P4.1 verified pending row
+    exists (`has_verified_pending_request`). This is the anti-forgery gate: a
+    leader cannot be tricked into broadcasting a roster that admits a remote
+    agent who never completed the node-link-authenticated, token-verified join.
+
+    Raises RoomsError(code='no_verified_request') when the gate is unmet (NO
+    membership add, NO epoch bump). On success: add member, mark the request
+    approved, bump the epoch (which re-persists the leader's authoritative
+    roster cache atomically). Returns the new epoch.
+    """
+    require_room(conn, room_id)
+    if not has_verified_pending_request(conn, room_id, agent, node):
+        raise RoomsError(
+            f"cross-node approve of {agent}@{node} on {room_id} requires a "
+            "verified pending join request (none found) — a remote agent must "
+            "complete the node-link-authenticated, token-verified join first",
+            code="no_verified_request",
+        )
+    add_member(conn, room_id, agent, node, role=ROLE_MEMBER)
+    set_join_request_status(conn, room_id, agent, node, JOIN_APPROVED)
+    return bump_epoch(conn, room_id)
+
+
 def remove_and_bump(conn: sqlite3.Connection, room_id: str, agent: str,
                     node: str = "") -> int:
     """Remove a member (leave/kick), bump epoch, recompute roster.
@@ -1463,6 +1564,224 @@ def remove_and_bump(conn: sqlite3.Connection, room_id: str, agent: str,
         )
     # bump_epoch re-persists room_roster_cache atomically (centralized in F2).
     return bump_epoch(conn, room_id)
+
+
+# --------------------------------------------------------------------------
+# Member-side roster broadcast acceptance (A2A Rooms P4.2, design §6/§14 R2)
+# --------------------------------------------------------------------------
+#
+# The leader (node A) signs the canonical roster with the leader↔member pairwise
+# HMAC and POSTs it to each member node. The member node verifies the node-link
+# HMAC (the receiver auth preamble does this) and then runs THIS acceptance
+# logic, which encodes the anti-spoof / anti-rogue-leader / monotonic-epoch
+# contracts. It writes the member-local `room_roster_cache` (the cache that lets
+# comms survive a leader outage — design §6 "Roster cache").
+#
+# Stable, audit-safe acceptance outcome codes (no secret/token ever in them).
+ROSTER_ACCEPTED = "accepted"            # cache written (first bind or higher epoch)
+ROSTER_DUPLICATE = "duplicate"          # byte-identical idempotent re-broadcast
+ROSTER_STALE_EPOCH = "stale_epoch"      # lower-or-same epoch (not a dup) → ignored
+ROSTER_NOT_LEADER = "not_leader"        # peer != body.leader_node → rejected
+ROSTER_NO_LOCAL_BINDING = "no_local_binding"  # first roster w/o local join state
+ROSTER_LEADER_MISMATCH = "leader_mismatch"  # peer != the ESTABLISHED cached leader
+
+
+def _local_join_binding_for(conn: sqlite3.Connection, room_id: str,
+                            expected_leader_node: str) -> bool:
+    """True iff this node holds LOCAL outbound join state for `room_id` that
+    names `expected_leader_node` as the leader (the FIRST-ROSTER binding anchor).
+
+    The anti-rogue-leader contract (codex #9622 contract 2, brief contract 3c): a
+    member accepts its FIRST roster for a room ONLY if it already initiated a
+    join to THIS room naming THIS leader node. The member's own `room join`
+    (P4.2) records a LOCAL `room_join_requests` row (status pending/approved)
+    whose `via_node` is the leader node it posted to — that row is the proof the
+    member chose this room+leader, so an inbound roster claiming
+    `leader_node=<some configured peer>` cannot MINT a brand-new room cache out
+    of thin air (which would let any configured peer shape future room-scoped
+    allow decisions).
+
+    The binding requires:
+      - a `room_join_requests` row for `room_id`,
+      - status pending OR approved (a denied request is not a live intent),
+      - `via_node` == `expected_leader_node` (the member posted its join to THIS
+        leader node — an un-spoofable record of the member's own outbound choice,
+        NOT a wire-asserted value).
+    """
+    rows = conn.execute(
+        "SELECT status, via_node FROM room_join_requests WHERE room_id=?",
+        (room_id,),
+    ).fetchall()
+    for r in rows:
+        if str(r["status"]) not in (JOIN_PENDING, JOIN_APPROVED):
+            continue
+        if str(r["via_node"] or "") == expected_leader_node:
+            return True
+    return False
+
+
+def record_local_join_intent(conn: sqlite3.Connection, room_id: str, agent: str,
+                             node: str, *, leader_node: str) -> None:
+    """Record the member's OWN outbound cross-node join intent locally (P4.2).
+
+    Called on the MEMBER/sender node when it posts a cross-node `room join`, so
+    the member has a LOCAL record that it chose `room_id` with leader
+    `leader_node`. This row is the FIRST-ROSTER binding anchor
+    (`_local_join_binding_for`): it lets the member later accept the leader's
+    first roster broadcast for this room, while refusing a roster for a room it
+    never tried to join (the rogue-leader-minting defense).
+
+    `via_node` carries the leader node the member posted to (its own choice).
+    `verified` stays 0 — this is the member's local view, NOT the leader-side
+    receiver-verified row (that lives on the leader's node). INSERT OR REPLACE
+    keyed on (room_id, agent, node) re-affirms a re-issued join.
+    """
+    conn.execute(
+        "INSERT OR REPLACE INTO room_join_requests (room_id, agent, node, "
+        "requested_ts, status, verified, via_node, ttl_expiry) "
+        "VALUES (?, ?, ?, ?, ?, 0, ?, 0)",
+        (room_id, agent, node, now_ts(), JOIN_PENDING, leader_node),
+    )
+    conn.commit()
+
+
+def get_roster_cache(conn: sqlite3.Connection,
+                     room_id: str) -> Optional[sqlite3.Row]:
+    """The member-local cached roster row for a room (or None)."""
+    return conn.execute(
+        "SELECT room_id, epoch, members_json, from_node, mac, fetched_ts "
+        "FROM room_roster_cache WHERE room_id=?",
+        (room_id,),
+    ).fetchone()
+
+
+def accept_roster_broadcast(
+    conn: sqlite3.Connection, *, room_id: str, room_epoch: int,
+    members: list[dict[str, Any]], leader_node: str, peer_id: str,
+    mac: str = "",
+) -> str:
+    """Apply a verified leader roster broadcast to the member-local cache.
+
+    The member-side heart of P4.2. The CALLER (the receiver) has ALREADY verified
+    the node-link pairwise HMAC over the canonical request (so `peer_id` is the
+    authenticated sender node and the body is intact). This function encodes the
+    remaining security contracts and performs the ATOMIC cache write. Returns a
+    ROSTER_* outcome code; raises RoomsError only on an unexpected DB fault.
+
+    Contracts enforced here (brief §3):
+      a. LEADER-AUTHORITY (3a): accept ONLY when `peer_id == leader_node`. A
+         roster whose body `leader_node` != the authenticated sender →
+         ROSTER_NOT_LEADER, persists NOTHING. (The pairwise-HMAC verify in 3b is
+         the caller's job; a bad HMAC never reaches here.)
+      a'. LEADER PINNING (codex P4.2 r1 BLOCKING — close the rogue-leader
+         TAKEOVER of an EXISTING room): once a cache exists, the room's leader is
+         PINNED to the cached `from_node`. A DIFFERENT configured peer that
+         self-claims `leader_node=<itself>` + signs a higher epoch must NOT
+         overwrite the cache → ROSTER_LEADER_MISMATCH, persists NOTHING. Without
+         this, contract 3a alone (`peer_id == leader_node`) is trivially
+         satisfied by any peer naming itself leader, so the first-roster binding
+         would only protect the FIRST roster, not subsequent updates.
+      c. FIRST-ROSTER BINDING (3c): if NO cache row exists yet for this room, the
+         member accepts the first roster ONLY if it holds LOCAL outbound join
+         state for THIS room naming THIS leader_node
+         (`_local_join_binding_for`). Otherwise → ROSTER_NO_LOCAL_BINDING,
+         persists NOTHING. NEVER mint a room cache purely from an inbound roster.
+      d. MONOTONIC EPOCH (3d): with an existing cache (from the PINNED leader), a
+         STRICTLY-higher epoch updates; a lower-or-same epoch is IGNORED
+         (ROSTER_STALE_EPOCH) UNLESS the incoming roster is BYTE-IDENTICAL to the
+         cached one at the SAME epoch (ROSTER_DUPLICATE — idempotent, no write).
+      e. ATOMIC update (3e): the cache row is written in a SINGLE transaction
+         (INSERT OR REPLACE + one commit) — a reader/crash never observes a
+         partial roster.
+
+    `members` MUST be the canonical sorted roster (the bytes the leader signed);
+    we re-canonicalize on store so the cached `members_json` is reproducible.
+    `mac` is the presented per-link signature (stored for audit/debug; the real
+    auth is the receiver's HMAC verify, already done).
+    """
+    # --- 3a: leader-authority binding — the authenticated sender must be the
+    # node the body names as leader. (peer_id is the un-spoofable HMAC-authed
+    # X-AGB-Peer; leader_node is the body's claim.) ---
+    if peer_id != leader_node:
+        return ROSTER_NOT_LEADER
+
+    incoming_members = _canonical_member_list(members)
+    incoming_json = json.dumps(incoming_members, separators=(",", ":"))
+    epoch = int(room_epoch)
+
+    existing = get_roster_cache(conn, room_id)
+    if existing is None:
+        # --- 3c: FIRST-ROSTER binding — never mint a cache from an inbound
+        # roster alone; the member must have chosen this room+leader locally. ---
+        if not _local_join_binding_for(conn, room_id, leader_node):
+            return ROSTER_NO_LOCAL_BINDING
+        _write_roster_cache(conn, room_id, epoch, incoming_json, leader_node, mac)
+        return ROSTER_ACCEPTED
+
+    # --- 3a': LEADER PINNING — an existing cache fixes the room's leader to its
+    # established `from_node`. A roster signed by a DIFFERENT peer is a TAKEOVER
+    # attempt → reject, persist nothing (even at a higher epoch). The legitimate
+    # leader always signs with its own node id == the cached from_node, so this
+    # never blocks a genuine update from the real leader.
+    #
+    # The comparison is UNGUARDED by truthiness (codex P4.2 r2 BLOCKING): an
+    # existing cache whose `from_node` is "" is a SINGLE-NODE/local room (P1a
+    # seeds `from_node=leader_node`, which is "" when local_node() is empty). A
+    # remote peer arriving over a node-link ALWAYS has a non-empty authenticated
+    # `peer_id == leader_node`, so for any such inbound roster `leader_node !=
+    # "" == cached_from_node` → rejected. A remote node can therefore NEVER claim
+    # leadership of a local/single-node room via a roster broadcast. ---
+    cached_leader = str(existing["from_node"] or "")
+    if leader_node != cached_leader:
+        return ROSTER_LEADER_MISMATCH
+
+    # --- 3d: monotonic epoch (existing cache present, leader pinned) ---
+    cached_epoch = int(existing["epoch"])
+    if epoch > cached_epoch:
+        _write_roster_cache(conn, room_id, epoch, incoming_json, leader_node, mac)
+        return ROSTER_ACCEPTED
+    # epoch <= cached_epoch: accept ONLY a byte-identical idempotent duplicate
+    # (same epoch AND same canonical members AND same leader node). Everything
+    # else (a lower epoch, or a same-epoch roster with DIFFERENT contents — a
+    # replay/forge attempt) is ignored without a write.
+    if (epoch == cached_epoch
+            and str(existing["members_json"]) == incoming_json
+            and str(existing["from_node"] or "") == leader_node):
+        return ROSTER_DUPLICATE
+    return ROSTER_STALE_EPOCH
+
+
+def _canonical_member_list(members: list[dict[str, Any]]) -> list[dict[str, str]]:
+    """Re-sort + normalize a roster member list to the canonical (agent,node)
+    ordering, so the stored cache bytes are reproducible regardless of the
+    wire order (defensive — the leader already sorts, but a verifier must not
+    depend on the sender's ordering for its stored canonical form)."""
+    norm = [
+        {
+            "agent": str(m.get("agent", "")),
+            "node": str(m.get("node", "")),
+            "role": str(m.get("role", "")),
+        }
+        for m in members
+    ]
+    norm.sort(key=lambda m: (m["agent"], m["node"]))
+    return norm
+
+
+def _write_roster_cache(conn: sqlite3.Connection, room_id: str, epoch: int,
+                        members_json: str, from_node: str, mac: str) -> None:
+    """ATOMICALLY (single transaction) write the member-local roster cache row.
+
+    The whole row is replaced in one INSERT OR REPLACE + one commit (3e
+    atomicity): a concurrent reader or a crash mid-update sees either the PRIOR
+    complete roster or the NEW complete roster, never a partial one.
+    """
+    conn.execute(
+        "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, "
+        "members_json, from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+        (room_id, epoch, members_json, from_node, mac, now_ts()),
+    )
+    conn.commit()
 
 
 # --------------------------------------------------------------------------

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -1250,51 +1250,6 @@ def room_join_dedupe_lookup(conn: sqlite3.Connection, peer: str,
             else JOIN_DEDUPE_CONFLICT)
 
 
-def reserve_roster_dedupe(conn: sqlite3.Connection, *, peer: str,
-                          message_id: str, body_sha256: str) -> str:
-    """Reserve a peer-scoped dedupe row for an APPLIED roster broadcast (P4.2).
-
-    Reuses the `room_join_dedupe` ledger (peer-scoped composite PK) so a
-    re-delivery of the SAME (peer, message_id, body) short-circuits to an
-    idempotent 200, while a (peer, message_id) reuse with a DIFFERENT body is a
-    409 conflict. Called by the roster receiver ONLY after the cache write
-    actually committed (or was an idempotent same-state accept), so a dedupe row
-    exists IFF the broadcast was applied — a rejected/ignored broadcast leaves no
-    row and a replay re-evaluates. Returns JOIN_DEDUPE_RESERVED on a fresh
-    reservation, JOIN_DEDUPE_DUPLICATE/JOIN_DEDUPE_CONFLICT if a row already
-    existed (idempotent re-reserve). Never raises on a benign PK race.
-    """
-    existing = conn.execute(
-        "SELECT body_sha256 FROM room_join_dedupe WHERE peer=? AND message_id=?",
-        (peer, message_id),
-    ).fetchone()
-    if existing is not None:
-        return (JOIN_DEDUPE_DUPLICATE if existing["body_sha256"] == body_sha256
-                else JOIN_DEDUPE_CONFLICT)
-    try:
-        conn.execute(
-            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
-            "created_ts) VALUES (?, ?, ?, ?)",
-            (message_id, peer, body_sha256, now_ts()),
-        )
-        conn.commit()
-    except sqlite3.IntegrityError:
-        # Lost a concurrent PK race — re-query the winner's row, return the same
-        # idempotent/conflict classification (never a raise).
-        conn.rollback()
-        winner = conn.execute(
-            "SELECT body_sha256 FROM room_join_dedupe "
-            "WHERE peer=? AND message_id=?",
-            (peer, message_id),
-        ).fetchone()
-        if winner is not None:
-            return (JOIN_DEDUPE_DUPLICATE
-                    if winner["body_sha256"] == body_sha256
-                    else JOIN_DEDUPE_CONFLICT)
-        raise
-    return JOIN_DEDUPE_RESERVED
-
-
 def record_verified_cross_node_join_request_atomic(
     conn: sqlite3.Connection, *, message_id: str, body_sha256: str, peer: str,
     room_id: str, agent: str, node: str, via_node: str, ttl_expiry: int = 0,
@@ -1584,6 +1539,7 @@ ROSTER_STALE_EPOCH = "stale_epoch"      # lower-or-same epoch (not a dup) → ig
 ROSTER_NOT_LEADER = "not_leader"        # peer != body.leader_node → rejected
 ROSTER_NO_LOCAL_BINDING = "no_local_binding"  # first roster w/o local join state
 ROSTER_LEADER_MISMATCH = "leader_mismatch"  # peer != the ESTABLISHED cached leader
+ROSTER_DEDUPE_CONFLICT = "dedupe_conflict"  # same (peer,message_id), DIFFERENT body
 
 
 def _local_join_binding_for(conn: sqlite3.Connection, room_id: str,
@@ -1658,15 +1614,16 @@ def get_roster_cache(conn: sqlite3.Connection,
 def accept_roster_broadcast(
     conn: sqlite3.Connection, *, room_id: str, room_epoch: int,
     members: list[dict[str, Any]], leader_node: str, peer_id: str,
-    mac: str = "",
+    message_id: str, body_sha256: str, mac: str = "",
 ) -> str:
     """Apply a verified leader roster broadcast to the member-local cache.
 
     The member-side heart of P4.2. The CALLER (the receiver) has ALREADY verified
     the node-link pairwise HMAC over the canonical request (so `peer_id` is the
     authenticated sender node and the body is intact). This function encodes the
-    remaining security contracts and performs the ATOMIC cache write. Returns a
-    ROSTER_* outcome code; raises RoomsError only on an unexpected DB fault.
+    remaining security contracts and performs the ATOMIC dedupe-reserve + cache
+    write. Returns a ROSTER_* outcome code; raises RoomsError only on an
+    unexpected DB fault.
 
     Contracts enforced here (brief §3):
       a. LEADER-AUTHORITY (3a): accept ONLY when `peer_id == leader_node`. A
@@ -1690,14 +1647,30 @@ def accept_roster_broadcast(
          STRICTLY-higher epoch updates; a lower-or-same epoch is IGNORED
          (ROSTER_STALE_EPOCH) UNLESS the incoming roster is BYTE-IDENTICAL to the
          cached one at the SAME epoch (ROSTER_DUPLICATE — idempotent, no write).
-      e. ATOMIC update (3e): the cache row is written in a SINGLE transaction
-         (INSERT OR REPLACE + one commit) — a reader/crash never observes a
-         partial roster.
+      e. ATOMIC dedupe + update (3e + codex P4.2 r3 BLOCKING — close the TOCTOU
+         race): for any outcome that WRITES the cache (ACCEPTED), the peer-scoped
+         dedupe RESERVATION and the room_roster_cache WRITE commit in ONE
+         transaction (single serialization point). The dedupe reservation is the
+         `room_join_dedupe` PRIMARY KEY (peer, message_id), so:
+           - a fresh (peer, message_id) → reserve + write cache + commit together.
+           - a same (peer, message_id) with a DIFFERENT body_sha256 →
+             ROSTER_DEDUPE_CONFLICT, write NOTHING (rolled back). The receiver
+             answers 409. This holds EVEN under a check-then-write race: two
+             concurrent same-id deliveries cannot both pass + both write — the PK
+             serializes them and the loser is re-classified (IntegrityError →
+             re-query → conflict/duplicate), never a partial cache mutation.
+           - a same (peer, message_id) with the SAME body_sha256 →
+             ROSTER_DUPLICATE (idempotent — the cache already reflects it; no
+             double-apply).
+         A contract REJECT (not_leader / leader_mismatch / no_binding /
+         stale_epoch) reserves NO dedupe row, so a replay re-evaluates the
+         contracts (the stale/not-leader teeth hold on replay).
 
     `members` MUST be the canonical sorted roster (the bytes the leader signed);
     we re-canonicalize on store so the cached `members_json` is reproducible.
     `mac` is the presented per-link signature (stored for audit/debug; the real
-    auth is the receiver's HMAC verify, already done).
+    auth is the receiver's HMAC verify, already done). `message_id`/`body_sha256`
+    are the dedupe key (peer-scoped) the receiver carries from the wire headers.
     """
     # --- 3a: leader-authority binding — the authenticated sender must be the
     # node the body names as leader. (peer_id is the un-spoofable HMAC-authed
@@ -1715,8 +1688,11 @@ def accept_roster_broadcast(
         # roster alone; the member must have chosen this room+leader locally. ---
         if not _local_join_binding_for(conn, room_id, leader_node):
             return ROSTER_NO_LOCAL_BINDING
-        _write_roster_cache(conn, room_id, epoch, incoming_json, leader_node, mac)
-        return ROSTER_ACCEPTED
+        # WRITE path → atomic dedupe-reserve + cache write (3e).
+        return _reserve_and_write_roster_cache(
+            conn, peer=peer_id, message_id=message_id, body_sha256=body_sha256,
+            room_id=room_id, epoch=epoch, members_json=incoming_json,
+            from_node=leader_node, mac=mac)
 
     # --- 3a': LEADER PINNING — an existing cache fixes the room's leader to its
     # established `from_node`. A roster signed by a DIFFERENT peer is a TAKEOVER
@@ -1738,17 +1714,91 @@ def accept_roster_broadcast(
     # --- 3d: monotonic epoch (existing cache present, leader pinned) ---
     cached_epoch = int(existing["epoch"])
     if epoch > cached_epoch:
-        _write_roster_cache(conn, room_id, epoch, incoming_json, leader_node, mac)
-        return ROSTER_ACCEPTED
+        # WRITE path → atomic dedupe-reserve + cache write (3e).
+        return _reserve_and_write_roster_cache(
+            conn, peer=peer_id, message_id=message_id, body_sha256=body_sha256,
+            room_id=room_id, epoch=epoch, members_json=incoming_json,
+            from_node=leader_node, mac=mac)
     # epoch <= cached_epoch: accept ONLY a byte-identical idempotent duplicate
     # (same epoch AND same canonical members AND same leader node). Everything
     # else (a lower epoch, or a same-epoch roster with DIFFERENT contents — a
-    # replay/forge attempt) is ignored without a write.
+    # replay/forge attempt) is ignored without a write. A byte-identical re-
+    # broadcast does NOT need a cache write (the cache already reflects it), so
+    # it does not reserve dedupe either — it is idempotent by construction.
     if (epoch == cached_epoch
             and str(existing["members_json"]) == incoming_json
             and str(existing["from_node"] or "") == leader_node):
         return ROSTER_DUPLICATE
     return ROSTER_STALE_EPOCH
+
+
+def _reserve_and_write_roster_cache(
+    conn: sqlite3.Connection, *, peer: str, message_id: str, body_sha256: str,
+    room_id: str, epoch: int, members_json: str, from_node: str, mac: str,
+) -> str:
+    """ATOMICALLY reserve the peer-scoped dedupe row AND write the roster cache.
+
+    The single serialization point that closes the TOCTOU dedupe/cache race
+    (codex P4.2 r3 BLOCKING). Mirrors P4.1's
+    `record_verified_cross_node_join_request_atomic`: a pre-check + an
+    IntegrityError-on-PK fallback re-query, so two concurrent same-id deliveries
+    cannot both pass + both write. Both the `room_join_dedupe` reservation and
+    the `room_roster_cache` write are issued WITHOUT an intermediate commit, then
+    ONE commit makes them durable together; any failure before the commit rolls
+    BOTH back (no orphan dedupe row, no partial cache).
+
+    Returns:
+      - ROSTER_DEDUPE_CONFLICT : (peer, message_id) already used with a DIFFERENT
+        body → write NOTHING.
+      - ROSTER_DUPLICATE       : (peer, message_id) already reserved with the
+        SAME body → idempotent, write NOTHING (the cache already reflects it).
+      - ROSTER_ACCEPTED        : fresh id → dedupe row + cache row committed
+        together.
+    """
+    # Pre-check inside this call (the caller did no read-only dedupe check on the
+    # write path). Scoped to the authenticated peer (composite PK).
+    existing = conn.execute(
+        "SELECT body_sha256 FROM room_join_dedupe WHERE peer=? AND message_id=?",
+        (peer, message_id),
+    ).fetchone()
+    if existing is not None:
+        return (ROSTER_DUPLICATE if existing["body_sha256"] == body_sha256
+                else ROSTER_DEDUPE_CONFLICT)
+    try:
+        conn.execute(
+            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+            "created_ts) VALUES (?, ?, ?, ?)",
+            (message_id, peer, body_sha256, now_ts()),
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, "
+            "members_json, from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
+            (room_id, epoch, members_json, from_node, mac, now_ts()),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        # Lost a concurrent (peer, message_id) PK race — roll BOTH writes back and
+        # re-query the winner's row, returning the SAME idempotent/conflict
+        # outcome the pre-check would have. The loser thus gets a clean
+        # duplicate/conflict (never a partial cache mutation, never a 500).
+        conn.rollback()
+        winner = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
+        ).fetchone()
+        if winner is not None:
+            return (ROSTER_DUPLICATE if winner["body_sha256"] == body_sha256
+                    else ROSTER_DEDUPE_CONFLICT)
+        # PK violation from somewhere other than a concurrent winner (should not
+        # happen) — surface it rather than silently swallow.
+        raise
+    except Exception:
+        # Roll BOTH writes back so a failed cache insert never leaves an orphan
+        # dedupe reservation (the atomicity contract).
+        conn.rollback()
+        raise
+    return ROSTER_ACCEPTED
 
 
 def _canonical_member_list(members: list[dict[str, Any]]) -> list[dict[str, str]]:
@@ -1766,22 +1816,6 @@ def _canonical_member_list(members: list[dict[str, Any]]) -> list[dict[str, str]
     ]
     norm.sort(key=lambda m: (m["agent"], m["node"]))
     return norm
-
-
-def _write_roster_cache(conn: sqlite3.Connection, room_id: str, epoch: int,
-                        members_json: str, from_node: str, mac: str) -> None:
-    """ATOMICALLY (single transaction) write the member-local roster cache row.
-
-    The whole row is replaced in one INSERT OR REPLACE + one commit (3e
-    atomicity): a concurrent reader or a crash mid-update sees either the PRIOR
-    complete roster or the NEW complete roster, never a partial one.
-    """
-    conn.execute(
-        "INSERT OR REPLACE INTO room_roster_cache (room_id, epoch, "
-        "members_json, from_node, mac, fetched_ts) VALUES (?, ?, ?, ?, ?, ?)",
-        (room_id, epoch, members_json, from_node, mac, now_ts()),
-    )
-    conn.commit()
 
 
 # --------------------------------------------------------------------------

--- a/bridge_rooms_common.py
+++ b/bridge_rooms_common.py
@@ -1722,13 +1722,19 @@ def accept_roster_broadcast(
     # epoch <= cached_epoch: accept ONLY a byte-identical idempotent duplicate
     # (same epoch AND same canonical members AND same leader node). Everything
     # else (a lower epoch, or a same-epoch roster with DIFFERENT contents — a
-    # replay/forge attempt) is ignored without a write. A byte-identical re-
-    # broadcast does NOT need a cache write (the cache already reflects it), so
-    # it does not reserve dedupe either — it is idempotent by construction.
+    # replay/forge attempt) is ignored without a write.
     if (epoch == cached_epoch
             and str(existing["members_json"]) == incoming_json
             and str(existing["from_node"] or "") == leader_node):
-        return ROSTER_DUPLICATE
+        # A byte-identical re-broadcast does NOT need a cache write (the cache
+        # already reflects it), but it MUST still BURN the (peer, message_id) in
+        # the dedupe ledger (codex P4.2 r3 BLOCKING): a terminal ROSTER_DUPLICATE
+        # that did not reserve the id would let a LATER (peer, SAME id, DIFFERENT
+        # body, higher epoch) reuse be treated as fresh and ACCEPTED. The
+        # reserve-only path records the id (or re-classifies a same-id/different-
+        # body reuse to ROSTER_DEDUPE_CONFLICT) WITHOUT touching the cache.
+        return _reserve_roster_dedupe_only(
+            conn, peer=peer_id, message_id=message_id, body_sha256=body_sha256)
     return ROSTER_STALE_EPOCH
 
 
@@ -1799,6 +1805,55 @@ def _reserve_and_write_roster_cache(
         conn.rollback()
         raise
     return ROSTER_ACCEPTED
+
+
+def _reserve_roster_dedupe_only(
+    conn: sqlite3.Connection, *, peer: str, message_id: str, body_sha256: str,
+) -> str:
+    """BURN a (peer, message_id) in the dedupe ledger WITHOUT writing the cache.
+
+    The reserve-only sibling of `_reserve_and_write_roster_cache` (codex P4.2 r3
+    BLOCKING — close the duplicate-branch id-reuse hole). Used by the byte-
+    identical-existing-cache ROSTER_DUPLICATE branch: the cache already reflects
+    the roster (no write needed), but the id MUST still be recorded so a LATER
+    same-(peer, message_id)/DIFFERENT-body reuse is a CONFLICT rather than a
+    fresh accept. Returns:
+      - ROSTER_DEDUPE_CONFLICT : (peer, message_id) already used with a DIFFERENT
+        body → caller answers 409.
+      - ROSTER_DUPLICATE       : a fresh reservation OR a same-body re-reservation
+        (idempotent) → the id is now burned, no cache change.
+    Uses the same IntegrityError-rollback-and-requery guard as the write helper
+    so a concurrent same-id duplicate cannot double-insert (the PK serializes).
+    """
+    existing = conn.execute(
+        "SELECT body_sha256 FROM room_join_dedupe WHERE peer=? AND message_id=?",
+        (peer, message_id),
+    ).fetchone()
+    if existing is not None:
+        return (ROSTER_DUPLICATE if existing["body_sha256"] == body_sha256
+                else ROSTER_DEDUPE_CONFLICT)
+    try:
+        conn.execute(
+            "INSERT INTO room_join_dedupe (message_id, peer, body_sha256, "
+            "created_ts) VALUES (?, ?, ?, ?)",
+            (message_id, peer, body_sha256, now_ts()),
+        )
+        conn.commit()
+    except sqlite3.IntegrityError:
+        # Lost a concurrent (peer, message_id) PK race — roll back + re-query the
+        # winner, returning the SAME idempotent/conflict outcome the pre-check
+        # would have (never a raise, never a cache mutation — there is none here).
+        conn.rollback()
+        winner = conn.execute(
+            "SELECT body_sha256 FROM room_join_dedupe "
+            "WHERE peer=? AND message_id=?",
+            (peer, message_id),
+        ).fetchone()
+        if winner is not None:
+            return (ROSTER_DUPLICATE if winner["body_sha256"] == body_sha256
+                    else ROSTER_DEDUPE_CONFLICT)
+        raise
+    return ROSTER_DUPLICATE
 
 
 def _canonical_member_list(members: list[dict[str, Any]]) -> list[dict[str, str]]:

--- a/scripts/ci-select-smoke.sh
+++ b/scripts/ci-select-smoke.sh
@@ -211,6 +211,20 @@ add_required a2a-rooms-1517-bootstrap
 # expired/revoked refused, no token/hash persisted anywhere, malformed/dup
 # handled) + the unweakened auth preamble + the non-leader-node refusal.
 add_required rooms-p4-1-cross-node-join
+# A2A rooms P4.2 (design §6 / §11 / §14 R2): leader APPROVE + roster broadcast.
+# On a cross-node approve the leader admits the member (REQUIRING a P4.1 verified
+# pending row), bumps the epoch, and broadcasts the leader-signed canonical
+# roster to every member node over the node-link; each member persists it to
+# room_roster_cache. Lives in bridge-handoffd.py (_handle_room_roster_broadcast),
+# bridge_a2a_common.py (build/parse_room_roster_broadcast), bridge_rooms_common.py
+# (approve_cross_node gate + accept_roster_broadcast member-side contracts +
+# reserve_roster_dedupe), and bridge-rooms.py (cross-approve gate + broadcast
+# sender + local-join-intent binding). Pins the 7 teeth: cross-approve requires a
+# verified pending row, a non-leader peer roster is rejected, an invalid pairwise
+# HMAC is rejected, a first roster with no local binding is refused (rogue-leader
+# mint prevented), epoch monotonicity, the cache update is atomic, and the
+# local-leader-add path stays distinct (no P4.1 regression).
+add_required rooms-p4-2-roster-broadcast
 
 
 }
@@ -876,7 +890,7 @@ select_for_path() {
       add_required queue a2a-rooms-p1b-acl
       ;;
 
-    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/install-handoffd-systemd.sh)
+    bridge-a2a.py|bridge-handoffd.py|bridge_a2a_common.py|bridge-rooms.py|bridge_rooms_common.py|bridge-handoff-daemon.sh|lib/bridge-a2a.sh|handoff.local.example.json|scripts/smoke/a2a-cross-bridge-helper.py|scripts/smoke/a2a-tailscale-identity-resolve-helper.py|scripts/smoke/a2a-daemon-selfheal-reconcile-helper.py|scripts/smoke/a2a-migrate-identity-helper.py|scripts/smoke/a2a-ip-change-announce-helper.py|scripts/smoke/a2a-setup-wizard-helper.py|scripts/smoke/a2a-rooms-p1a-helper.py|scripts/smoke/a2a-rooms-p1b-acl-helper.py|scripts/smoke/a2a-rooms-1517-bootstrap-helper.py|scripts/smoke/rooms-p4-1-cross-node-join-helper.py|scripts/smoke/rooms-p4-1-post-hook.sh|scripts/smoke/rooms-p4-2-roster-broadcast-helper.py|scripts/smoke/rooms-p4-2-post-hook.sh|scripts/install-handoffd-systemd.sh)
       # Issue #1032: A2A cross-bridge task handoff. Any move to the
       # receiver daemon, sender outbox/delivery-runner, shared protocol
       # module, lifecycle helper, or the smoke helper re-runs the
@@ -965,7 +979,17 @@ select_for_path() {
       # malformed/duplicate requests are handled — PLUS the auth preamble stays
       # unweakened (HMAC 401 / remote_addr 403 / unknown-peer 403). Pull on every
       # move to any of those files so the cross-node admission gate cannot regress.
-      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join
+      # A2A Rooms P4.2 (design §6 / §14 R2): leader APPROVE + roster broadcast.
+      # The NEW remote surface is _handle_room_roster_broadcast in
+      # bridge-handoffd.py; the wire builder/parser is build/parse_room_roster_
+      # broadcast in bridge_a2a_common.py; the cross-approve gate + member-side
+      # acceptance (anti-rogue-leader binding + monotonic epoch + atomic cache) is
+      # in bridge_rooms_common.py; the broadcast sender + local-join-intent
+      # binding is in bridge-rooms.py. rooms-p4-2-roster-broadcast pins the 7
+      # teeth (cross-approve needs a verified row, non-leader roster rejected,
+      # bad pairwise HMAC rejected, first-roster-without-binding refused, epoch
+      # monotonicity, atomic cache, local-add path distinct). Pull on every move.
+      add_required a2a-cross-bridge queue I-beta4-a2a-3-gaps J-beta4-workflow-docs beta5-2-lambda-a2a-robustness a2a-tailscale-identity-resolve a2a-daemon-selfheal-reconcile a2a-migrate-identity a2a-ip-change-announce 1405-handoffd-supervision a2a-setup-wizard a2a-rooms-p1a a2a-rooms-p1b-acl a2a-rooms-1517-bootstrap 1398-a2a-inbound-stopped-target-force rooms-p4-1-cross-node-join rooms-p4-2-roster-broadcast
       ;;
 
     bridge-daemon.sh|bridge-sync.sh|bridge-watchdog.sh|bridge-cron.sh|lib/bridge-cron.sh|lib/bridge-state.sh|lib/bridge-notify.sh)

--- a/scripts/smoke/rooms-p4-2-post-hook.sh
+++ b/scripts/smoke/rooms-p4-2-post-hook.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-2-post-hook.sh — BRIDGE_ROOMS_TEST_POST_HOOK target.
+#
+# The leader's `bridge-rooms.py approve` roster-broadcast test seam invokes this
+# with the signed request JSON as $1 (file-as-argv, never stdin — footgun #11).
+# We delegate to the helper's `post-hook` subcommand, which writes the captured
+# request to $CAPTURE_FILE and echoes a stub response body. Kept as a separate
+# executable so the CLI hook contract (`[hook, payload]`) is satisfied with a
+# real argv[0].
+set -euo pipefail
+HERE="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+exec python3 "$HERE/rooms-p4-2-roster-broadcast-helper.py" post-hook "$1"

--- a/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Helper for the rooms-p4-2-roster-broadcast smoke (A2A Rooms P4.2).
+
+File-as-argv sidecar (never a heredoc-stdin — footgun #11). Imports the REAL
+rooms / a2a / handoffd modules from the repo root so the smoke exercises the
+canonical leader (cross-approve gate + signed roster broadcast), the canonical
+member-side receiver (`_handle_room_roster_broadcast` fail-closed auth preamble
++ the anti-rogue-leader / monotonic-epoch / atomic-cache contracts), and the
+canonical schema — WITHOUT a live socket or Tailscale.
+
+The transport is stubbed two ways (mirrors the P4.1 helper):
+  - SENDER side (the leader's `room approve` broadcast): the cross-node POST is
+    captured by the paired-flag test hook (BRIDGE_ROOMS_TEST_POST_HOOK = the
+    rooms-p4-2-post-hook.sh wrapper -> this script's `post-hook`), which writes
+    the fully-signed request to a file.
+  - RECEIVER side: `deliver-roster-to-receiver` reconstructs a minimal fake HTTP
+    request from that captured file and drives the REAL member-side handler, so
+    the actual auth preamble (protocol/peer/remote_addr/HMAC/skew/dedupe) + the
+    member-side acceptance logic + the cache write run end to end. The peer uses
+    a literal `address` so resolve_peer_address returns it verbatim — no
+    Tailscale.
+
+Subcommands (argv[1]):
+  post-hook <json>                 (BRIDGE_ROOMS_TEST_POST_HOOK target) — write
+                                   the signed request JSON to $CAPTURE_FILE and
+                                   echo a stub "{}" response.
+  captured-field <file> <key>      print headers[X-AGB-*] or body.<key> (a list/
+                                   dict value is JSON-encoded).
+  deliver-roster-to-receiver <repo_root> <cfg_json> <captured_file> [overrides]
+                                   replay the captured roster broadcast through
+                                   the real member-side receiver handler; print
+                                   "status=<n> body=<json>".
+  make-config <out_path> <this_node> <peer_node> <peer_secret> <address>
+                                   write a minimal handoff config the receiver
+                                   loads (member node trusts the leader peer).
+  make-member-db <db> <room_id> <leader_node> [member_agent] [member_node]
+                                   seed a member-local rooms.db with an OUTBOUND
+                                   join intent (the FIRST-ROSTER binding anchor)
+                                   so a first roster for <room_id> is acceptable.
+  cache-rows <db> [room_id]        print each room_roster_cache row as JSON.
+  set-cache-epoch <db> <room_id> <epoch>  force the cached epoch (drive monotonic).
+  cross-approve-gate <db>          unit-drive approve_cross_node: refuse w/o a
+                                   verified pending row; admit with one.
+  local-add-no-gate <db>           unit-drive approve_join (local path admits a
+                                   local agent with NO verified-row requirement).
+  member-accept-unit <db>          unit-drive accept_roster_broadcast contracts
+                                   (not-leader / no-binding / first-bind / higher
+                                   epoch / stale / duplicate / atomic).
+  db-contains <db> <needle>        exit 0 iff <needle> appears in the db dump.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import bridge_a2a_common as a2a  # noqa: E402
+import bridge_rooms_common as rooms  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# sender-side capture hook (invoked as BRIDGE_ROOMS_TEST_POST_HOOK)
+# ---------------------------------------------------------------------------
+def cmd_post_hook(payload_json: str) -> int:
+    """Write the captured signed request to $CAPTURE_FILE; stub a response body.
+
+    The stub response models what a real leader/member receiver returns for the
+    request's endpoint, so the SENDER-side CLI logic that keys off the ack body
+    is exercised: a `room join` post (X-AGB-Protocol == room-join) gets a
+    pending ack (so the CLI records its FIRST-ROSTER local binding); a roster
+    broadcast post gets an applied ack. $POST_HOOK_ACK may override the body.
+    """
+    capture = os.environ.get("CAPTURE_FILE")  # noqa: iso-helper-boundary - env var, not a .env file
+    if not capture:
+        print("CAPTURE_FILE unset", file=sys.stderr)
+        return 1
+    Path(capture).write_text(payload_json, encoding="utf-8")
+    override = os.environ.get("POST_HOOK_ACK")  # noqa: iso-helper-boundary - env var, not a .env file
+    if override is not None:
+        print(override)
+        return 0
+    try:
+        doc = json.loads(payload_json)
+        proto = doc.get("headers", {}).get("X-AGB-Protocol", "")
+    except (ValueError, json.JSONDecodeError):
+        proto = ""
+    if proto == a2a.ROOM_JOIN_PROTOCOL_VERSION:
+        # Model the leader's pending ack so the member CLI records its binding.
+        print(json.dumps({"ok": True, "status": rooms.JOIN_PENDING}))
+    else:
+        print("{}")
+    return 0
+
+
+def cmd_captured_field(path: str, key: str) -> int:
+    doc = json.loads(Path(path).read_text(encoding="utf-8"))
+    if key.startswith("header:"):
+        val = doc.get("headers", {}).get(key[len("header:"):], "")
+    elif key.startswith("body:"):
+        body = json.loads(doc.get("body", "{}"))
+        val = body.get(key[len("body:"):], "")
+    elif key == "path":
+        val = doc.get("path", "")
+    else:
+        print(f"unknown captured key: {key}", file=sys.stderr)
+        return 1
+    if isinstance(val, (list, dict)):
+        print(json.dumps(val, separators=(",", ":")))
+    else:
+        print(val)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# receiver-side replay against the REAL member-side handler
+# ---------------------------------------------------------------------------
+def _load_handoffd(repo_root: str):
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "bridge_handoffd", os.path.join(repo_root, "bridge-handoffd.py"))
+    hd = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(hd)
+    return hd
+
+
+class _FakeHeaders:
+    def __init__(self, headers: dict):
+        self._h = headers
+
+    def get(self, key, default=None):
+        return self._h.get(key, default)
+
+
+class _FakeRFile:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def read(self, n: int = -1) -> bytes:
+        if n < 0 or n >= len(self._data):
+            out, self._data = self._data, b""
+            return out
+        out, self._data = self._data[:n], self._data[n:]
+        return out
+
+
+class _FakeServer:
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self.config_path = ""
+
+
+def cmd_deliver_roster_to_receiver(repo_root: str, cfg_json: str, captured: str,
+                                   overrides_json: str = "{}") -> int:
+    """Replay a captured signed roster broadcast through the REAL member-side
+    receiver handler. `overrides_json` lets a tooth mutate the captured request:
+      {"client_ip": "...", "headers": {...override...},
+       "body": "<replacement json string>", "recompute_hash": true,
+       "resign": true}
+    `resign` recomputes BOTH the body hash AND a VALID HMAC for the (mutated)
+    body using the peer's configured secret — to exercise a path DOWNSTREAM of
+    the HMAC gate (e.g. the body parser, or a contract check) with a
+    legitimately-signed body. `recompute_hash` recomputes only the body hash
+    (used to drive the same-id-different-body 409 WITHOUT tripping the body-hash
+    gate, while leaving the OLD signature -> still a 401 if not resigned).
+    """
+    hd = _load_handoffd(repo_root)
+    cfg = json.loads(cfg_json)
+    doc = json.loads(Path(captured).read_text(encoding="utf-8"))
+    overrides = json.loads(overrides_json) if overrides_json else {}
+
+    path = doc.get("path", a2a.ROOM_ROSTER_PATH)
+    headers = dict(doc.get("headers", {}))
+    body = doc.get("body", "{}")
+
+    if "headers" in overrides:
+        headers.update(overrides["headers"])
+    if "body" in overrides:
+        body = overrides["body"]
+    body_bytes = body.encode("utf-8") if isinstance(body, str) else bytes(body)
+    if overrides.get("recompute_hash"):
+        headers["X-AGB-Body-SHA256"] = a2a.body_sha256(body_bytes)
+    if overrides.get("resign"):
+        peer_secret = ""
+        for p in cfg.get("peers", []):
+            if p.get("id") == headers.get("X-AGB-Peer", ""):
+                peer_secret = p.get("secret", "")
+                break
+        body_hash = a2a.body_sha256(body_bytes)
+        headers["X-AGB-Body-SHA256"] = body_hash
+        canonical = a2a.canonical_string(
+            "POST", path, headers.get("X-AGB-Peer", ""),
+            headers.get("X-AGB-Message-Id", ""),
+            headers.get("X-AGB-Timestamp", ""), body_hash)
+        headers["X-AGB-Signature"] = a2a.sign(peer_secret, canonical)
+    headers["Content-Length"] = str(len(body_bytes))
+
+    peer_id = headers.get("X-AGB-Peer", "")
+    peer_addr = ""
+    for p in cfg.get("peers", []):
+        if p.get("id") == peer_id:
+            peer_addr = p.get("address", "")
+            break
+    client_ip = overrides.get("client_ip", peer_addr or "127.0.0.1")
+
+    handler = hd.HandoffHandler.__new__(hd.HandoffHandler)
+    handler.path = path
+    handler.headers = _FakeHeaders(headers)
+    handler.rfile = _FakeRFile(body_bytes)
+    handler.client_address = (client_ip, 0)
+    handler.server = _FakeServer(cfg)
+
+    captured_reply = {}
+
+    def _capture_reply(status, payload, extra_headers=None):
+        captured_reply["status"] = status
+        captured_reply["payload"] = payload
+
+    handler._reply = _capture_reply  # type: ignore[assignment]
+    handler._handle_room_roster_broadcast(cfg)
+
+    status = captured_reply.get("status", 0)
+    payload = captured_reply.get("payload", {})
+    print(f"status={status} body={json.dumps(payload)}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# config + db helpers
+# ---------------------------------------------------------------------------
+def cmd_make_config(out_path: str, this_node: str, peer_node: str,
+                    peer_secret: str, address: str) -> int:
+    cfg = {
+        "bridge_id": this_node,
+        "listen": {"host": "127.0.0.1", "port": 8787,
+                   "enqueue_path": "/enqueue"},
+        "timestamp_skew_seconds": 300,
+        "timestamp_skew_grace_seconds": 3600,
+        "peers": [
+            {
+                "id": peer_node,
+                "address": address,
+                "secret": peer_secret,
+                "inbound_allowlist": [],
+            }
+        ],
+    }
+    Path(out_path).write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    try:
+        os.chmod(out_path, 0o600)
+    except OSError:
+        pass
+    return 0
+
+
+def cmd_make_member_db(db: str, room_id: str, leader_node: str,
+                       member_agent: str = "bob",
+                       member_node: str = "nodeB") -> int:
+    """Seed a member-local rooms.db that holds an OUTBOUND join intent for
+    <room_id> naming <leader_node> — the FIRST-ROSTER binding anchor. Mirrors
+    what `room join` records via rooms.record_local_join_intent."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        rooms.record_local_join_intent(
+            conn, room_id, member_agent, member_node, leader_node=leader_node)
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_cache_rows(db: str, room_id: str = "") -> int:
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    try:
+        if room_id:
+            rows = conn.execute(
+                "SELECT room_id, epoch, members_json, from_node, mac, "
+                "fetched_ts FROM room_roster_cache WHERE room_id=?",
+                (room_id,)).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT room_id, epoch, members_json, from_node, mac, "
+                "fetched_ts FROM room_roster_cache").fetchall()
+    finally:
+        conn.close()
+    for r in rows:
+        print(json.dumps({k: r[k] for k in r.keys()}))
+    return 0
+
+
+def cmd_set_cache_epoch(db: str, room_id: str, epoch: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("UPDATE room_roster_cache SET epoch=? WHERE room_id=?",
+                     (int(epoch), room_id))
+        conn.commit()
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_db_contains(db: str, needle: str) -> int:
+    conn = sqlite3.connect(db)
+    try:
+        dump = "\n".join(conn.iterdump())
+    finally:
+        conn.close()
+    return 0 if needle and needle in dump else 1
+
+
+# ---------------------------------------------------------------------------
+# unit drivers — leader-side gate
+# ---------------------------------------------------------------------------
+def cmd_cross_approve_gate(db: str) -> int:
+    """Prove approve_cross_node REQUIRES a verified pending row (contract 1)."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = rooms.create_room(
+            conn, name="t", leader_agent="alice", leader_node="nodeA",
+            token="tok")
+        # 1) No pending row at all -> refused.
+        try:
+            rooms.approve_cross_node(conn, room_id, "bob", "nodeB")
+            print("no_row=ADMITTED")  # should not happen
+        except rooms.RoomsError as exc:
+            print(f"no_row=refused:{exc.code}")
+        # 2) A row that is pending but NOT verified (a local P1 row) -> refused.
+        rooms.post_join_request(conn, room_id, "carl", "nodeB")
+        try:
+            rooms.approve_cross_node(conn, room_id, "carl", "nodeB")
+            print("unverified_row=ADMITTED")
+        except rooms.RoomsError as exc:
+            print(f"unverified_row=refused:{exc.code}")
+        # 3) A verified pending row (what the P4.1 receiver creates) -> admitted.
+        rooms.record_verified_cross_node_join_request(
+            conn, room_id, "bob", "nodeB", via_node="nodeB")
+        epoch = rooms.approve_cross_node(conn, room_id, "bob", "nodeB")
+        admitted = rooms.is_member(conn, room_id, "bob", "nodeB")
+        print(f"verified_row=admitted:epoch={epoch}:member={admitted}")
+        # 4) The membership add did NOT also admit carl (the unverified one).
+        print(f"carl_member={rooms.is_member(conn, room_id, 'carl', 'nodeB')}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_local_add_no_gate(db: str) -> int:
+    """Prove approve_join (the LOCAL leader-add path) admits a LOCAL agent with
+    NO verified-pending-row requirement — the two paths stay distinct
+    (contract 1/6, the no-P4.1-regression tooth)."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = rooms.create_room(
+            conn, name="t", leader_agent="alice", leader_node="nodeA",
+            token="tok")
+        # A local agent (node == leader node) admitted via approve_join with NO
+        # pending row at all — the local path does NOT claim the token gate.
+        epoch = rooms.approve_join(conn, room_id, "dave", "nodeA")
+        admitted = rooms.is_member(conn, room_id, "dave", "nodeA")
+        print(f"local_add=admitted:epoch={epoch}:member={admitted}")
+        # And approve_cross_node would have REFUSED the same (no verified row),
+        # proving the two paths are genuinely distinct.
+        try:
+            rooms.approve_cross_node(conn, room_id, "erin", "nodeA")
+            print("cross_path_for_local=ADMITTED")
+        except rooms.RoomsError as exc:
+            print(f"cross_path_for_local=refused:{exc.code}")
+    finally:
+        conn.close()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# unit driver — member-side acceptance contracts
+# ---------------------------------------------------------------------------
+def cmd_member_accept_unit(db: str) -> int:
+    """Drive accept_roster_broadcast's full contract surface directly (a unit
+    test of the security-critical acceptance logic). One line per case."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = "room-unit"
+        leader = "nodeA"
+        members_v2 = [
+            {"agent": "alice", "node": "nodeA", "role": "leader"},
+            {"agent": "bob", "node": "nodeB", "role": "member"},
+        ]
+
+        # (3a) NOT-leader: an authenticated peer that is NOT the leader_node ->
+        # rejected, persists nothing — EVEN with a local binding present.
+        rooms.record_local_join_intent(
+            conn, room_id, "bob", "nodeB", leader_node=leader)
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=2, members=members_v2,
+            leader_node=leader, peer_id="nodeZ")
+        print(f"not_leader={out}")
+        print(f"not_leader_no_cache={rooms.get_roster_cache(conn, room_id) is None}")
+
+        # (3c) FIRST roster with NO local binding -> refused (rogue-leader mint
+        # prevented). Use a DIFFERENT room with no local intent.
+        out = rooms.accept_roster_broadcast(
+            conn, room_id="room-rogue", room_epoch=5, members=members_v2,
+            leader_node=leader, peer_id=leader)
+        print(f"no_binding={out}")
+        print("no_binding_no_cache="
+              f"{rooms.get_roster_cache(conn, 'room-rogue') is None}")
+
+        # (3c) FIRST roster WITH a local binding (recorded above) -> accepted.
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=2, members=members_v2,
+            leader_node=leader, peer_id=leader)
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"first_bind={out}:epoch={cache['epoch']}")
+
+        # (3d) a STRICTLY-higher epoch updates.
+        members_v3 = members_v2 + [
+            {"agent": "carol", "node": "nodeC", "role": "member"}]
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=3, members=members_v3,
+            leader_node=leader, peer_id=leader)
+        cache = rooms.get_roster_cache(conn, room_id)
+        has_carol = "carol" in cache["members_json"]
+        print(f"higher_epoch={out}:epoch={cache['epoch']}:has_carol={has_carol}")
+
+        # (3d) a LOWER epoch is IGNORED (stale) — the cache keeps epoch 3.
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=2, members=members_v2,
+            leader_node=leader, peer_id=leader)
+        cache = rooms.get_roster_cache(conn, room_id)
+        still_carol = "carol" in cache["members_json"]
+        print(f"lower_epoch={out}:epoch={cache['epoch']}:still_carol={still_carol}")
+
+        # (3d) the SAME epoch with DIFFERENT members is IGNORED (a forge/replay),
+        # NOT accepted — the cache is unchanged.
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=3, members=members_v2,
+            leader_node=leader, peer_id=leader)
+        cache = rooms.get_roster_cache(conn, room_id)
+        same_still_carol = "carol" in cache["members_json"]
+        print(f"same_epoch_diff={out}:still_carol={same_still_carol}")
+
+        # (3d) a BYTE-IDENTICAL re-broadcast at the SAME epoch is an idempotent
+        # duplicate (accepted-as-noop).
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=3, members=members_v3,
+            leader_node=leader, peer_id=leader)
+        print(f"idempotent_dup={out}")
+
+        # (3a' codex P4.2 r1 BLOCKING) LEADER-TAKEOVER of an EXISTING cache: a
+        # DIFFERENT configured peer (nodeC) self-claims leadership (peer_id ==
+        # leader_node == nodeC, so the literal 3a check passes) AND signs a
+        # strictly-HIGHER epoch. Without leader-pinning this would overwrite the
+        # cache. It MUST be refused (ROSTER_LEADER_MISMATCH) and leave the cache
+        # pinned to the original leader nodeA at the original epoch.
+        rogue_members = [
+            {"agent": "mallory", "node": "nodeC", "role": "leader"}]
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=99, members=rogue_members,
+            leader_node="nodeC", peer_id="nodeC")
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"takeover={out}:from_node={cache['from_node']}:"
+              f"epoch={cache['epoch']}:"
+              f"has_mallory={'mallory' in cache['members_json']}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_empty_leader_takeover_unit(db: str) -> int:
+    """Prove a SINGLE-NODE/local room (cache from_node="") cannot be taken over
+    by a remote peer self-claiming leadership (codex P4.2 r2 BLOCKING). One line
+    of output: outcome + the (unchanged) cached from_node + epoch."""
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        # A local room: leader_node="" → cache seeded with from_node="" at epoch 0.
+        room_id = rooms.create_room(
+            conn, name="local", leader_agent="alice", leader_node="", token="t")
+        before = rooms.get_roster_cache(conn, room_id)
+        # A remote peer nodeC (non-empty authenticated peer_id) self-claims
+        # leadership at a higher epoch. Must be refused (leader_mismatch).
+        out = rooms.accept_roster_broadcast(
+            conn, room_id=room_id, room_epoch=99,
+            members=[{"agent": "mallory", "node": "nodeC", "role": "leader"}],
+            leader_node="nodeC", peer_id="nodeC")
+        after = rooms.get_roster_cache(conn, room_id)
+        unchanged = (str(before["from_node"]) == str(after["from_node"])
+                     and int(before["epoch"]) == int(after["epoch"]))
+        print(f"empty_takeover={out}:from_node='{after['from_node']}':"
+              f"epoch={after['epoch']}:unchanged={unchanged}:"
+              f"has_mallory={'mallory' in after['members_json']}")
+    finally:
+        conn.close()
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print("usage: rooms-p4-2-roster-broadcast-helper.py <subcommand> [args]",
+              file=sys.stderr)
+        return 2
+    cmd, rest = argv[0], argv[1:]
+    if cmd == "post-hook":
+        return cmd_post_hook(rest[0])
+    if cmd == "captured-field":
+        return cmd_captured_field(rest[0], rest[1])
+    if cmd == "deliver-roster-to-receiver":
+        return cmd_deliver_roster_to_receiver(
+            rest[0], rest[1], rest[2], rest[3] if len(rest) > 3 else "{}")
+    if cmd == "make-config":
+        return cmd_make_config(rest[0], rest[1], rest[2], rest[3], rest[4])
+    if cmd == "make-member-db":
+        return cmd_make_member_db(
+            rest[0], rest[1], rest[2],
+            rest[3] if len(rest) > 3 else "bob",
+            rest[4] if len(rest) > 4 else "nodeB")
+    if cmd == "cache-rows":
+        return cmd_cache_rows(rest[0], rest[1] if len(rest) > 1 else "")
+    if cmd == "set-cache-epoch":
+        return cmd_set_cache_epoch(rest[0], rest[1], rest[2])
+    if cmd == "cross-approve-gate":
+        return cmd_cross_approve_gate(rest[0])
+    if cmd == "local-add-no-gate":
+        return cmd_local_add_no_gate(rest[0])
+    if cmd == "member-accept-unit":
+        return cmd_member_accept_unit(rest[0])
+    if cmd == "empty-leader-takeover-unit":
+        return cmd_empty_leader_takeover_unit(rest[0])
+    if cmd == "db-contains":
+        return cmd_db_contains(rest[0], rest[1])
+    print(f"unknown subcommand: {cmd}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
@@ -50,6 +50,9 @@ Subcommands (argv[1]):
   dedupe-race-unit <db>            unit-drive the atomic dedupe/cache TOCTOU
                                    contract (same-id/diff-body → conflict, no
                                    cache write; same-id/same-body → duplicate).
+  duplicate-burns-id-unit <db>     unit-drive the duplicate-branch id-burn (a
+                                   same-state DUPLICATE still reserves the id, so
+                                   a later same-id/diff-body reuse is a conflict).
   db-contains <db> <needle>        exit 0 iff <needle> appears in the db dump.
 """
 
@@ -570,6 +573,54 @@ def cmd_dedupe_race_unit(db: str) -> int:
     return 0
 
 
+def cmd_duplicate_burns_id_unit(db: str) -> int:
+    """Drive the DUPLICATE-branch id-burn contract (codex P4.2 r3 deeper edge).
+
+    The byte-identical-existing-cache ROSTER_DUPLICATE branch MUST still reserve
+    the (peer, message_id) in the dedupe ledger, so a LATER same-id/DIFFERENT-body
+    reuse is a CONFLICT (not a fresh accept). Sequence (one line per case):
+      1. accept (peer, idX, bodyA, epoch 1) → ACCEPTED (first-bind).
+      2. deliver a byte-identical roster under a NEW id idY (same bytes/epoch) →
+         the cache already matches → DUPLICATE branch → MUST burn idY.
+      3. assert a dedupe row for idY now EXISTS (the id was burned).
+      4. deliver (peer, SAME idY, DIFFERENT body bodyB naming rogue 'trent',
+         HIGHER epoch, would otherwise pass leader-pin + monotonic-epoch) →
+         MUST be ROSTER_DEDUPE_CONFLICT, cache epoch unchanged, no 'trent'.
+    """
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = "room-dupburn"
+        leader = "nodeM"
+        rooms.record_local_join_intent(
+            conn, room_id, "self", "nodeSelf", leader_node=leader)
+        members_a = [{"agent": "mallory", "node": "nodeM", "role": "leader"}]
+        members_b = [{"agent": "trent", "node": "nodeM", "role": "leader"}]
+        id_x = "nodeM:burn-X"
+        id_y = "nodeM:burn-Y"
+
+        out1 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=id_x)
+        print(f"first_accept={out1}")
+        # Byte-identical roster under a DIFFERENT id → reaches the DUPLICATE
+        # branch (cache already matches) → must BURN id_y.
+        out2 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=id_y)
+        burned = conn.execute(
+            "SELECT 1 FROM room_join_dedupe WHERE peer=? AND message_id=?",
+            (leader, id_y)).fetchone() is not None
+        print(f"same_state_reuse_id={out2}:dedupe_after_same_state={burned}")
+        # Later: SAME id_y, DIFFERENT body, HIGHER epoch → must be CONFLICT.
+        out3 = _accept(conn, room_id=room_id, room_epoch=2, members=members_b,
+                       leader_node=leader, peer_id=leader, mid=id_y)
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"later_same_id_diff_body={out3}:cache_epoch={cache['epoch']}:"
+              f"has_trent={'trent' in cache['members_json']}")
+    finally:
+        conn.close()
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if not argv:
         print("usage: rooms-p4-2-roster-broadcast-helper.py <subcommand> [args]",
@@ -604,6 +655,8 @@ def main(argv: list[str]) -> int:
         return cmd_empty_leader_takeover_unit(rest[0])
     if cmd == "dedupe-race-unit":
         return cmd_dedupe_race_unit(rest[0])
+    if cmd == "duplicate-burns-id-unit":
+        return cmd_duplicate_burns_id_unit(rest[0])
     if cmd == "db-contains":
         return cmd_db_contains(rest[0], rest[1])
     print(f"unknown subcommand: {cmd}", file=sys.stderr)

--- a/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast-helper.py
@@ -45,7 +45,11 @@ Subcommands (argv[1]):
                                    local agent with NO verified-row requirement).
   member-accept-unit <db>          unit-drive accept_roster_broadcast contracts
                                    (not-leader / no-binding / first-bind / higher
-                                   epoch / stale / duplicate / atomic).
+                                   epoch / stale / duplicate / leader-pin).
+  empty-leader-takeover-unit <db>  unit-drive the empty-from_node takeover refusal.
+  dedupe-race-unit <db>            unit-drive the atomic dedupe/cache TOCTOU
+                                   contract (same-id/diff-body → conflict, no
+                                   cache write; same-id/same-body → duplicate).
   db-contains <db> <needle>        exit 0 iff <needle> appears in the db dump.
 """
 
@@ -383,9 +387,28 @@ def cmd_local_add_no_gate(db: str) -> int:
 # ---------------------------------------------------------------------------
 # unit driver — member-side acceptance contracts
 # ---------------------------------------------------------------------------
+def _accept(conn, *, room_id, room_epoch, members, leader_node, peer_id, mid):
+    """accept_roster_broadcast wrapper that supplies a per-call dedupe key.
+
+    `mid` is a UNIQUE message id per logical delivery; the body_sha256 is derived
+    from the actual canonical body bytes so a same-id replay of identical content
+    is a real duplicate while different content under the same id is a conflict —
+    exactly what the receiver sees on the wire."""
+    body = a2a.build_room_roster_broadcast(
+        room_id=room_id, room_epoch=room_epoch, members=members,
+        leader_node=leader_node)
+    body_bytes = json.dumps(body, ensure_ascii=False).encode("utf-8")
+    return rooms.accept_roster_broadcast(
+        conn, room_id=room_id, room_epoch=room_epoch, members=members,
+        leader_node=leader_node, peer_id=peer_id, message_id=mid,
+        body_sha256=a2a.body_sha256(body_bytes))
+
+
 def cmd_member_accept_unit(db: str) -> int:
     """Drive accept_roster_broadcast's full contract surface directly (a unit
-    test of the security-critical acceptance logic). One line per case."""
+    test of the security-critical acceptance logic). One line per case. Each
+    logical delivery uses a UNIQUE message id so dedupe does not collide across
+    cases (the dedupe-race case has its own dedicated driver)."""
     os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
     conn = rooms.open_rooms()
     try:
@@ -400,60 +423,55 @@ def cmd_member_accept_unit(db: str) -> int:
         # rejected, persists nothing — EVEN with a local binding present.
         rooms.record_local_join_intent(
             conn, room_id, "bob", "nodeB", leader_node=leader)
-        out = rooms.accept_roster_broadcast(
-            conn, room_id=room_id, room_epoch=2, members=members_v2,
-            leader_node=leader, peer_id="nodeZ")
+        out = _accept(conn, room_id=room_id, room_epoch=2, members=members_v2,
+                      leader_node=leader, peer_id="nodeZ", mid="nodeZ:u1")
         print(f"not_leader={out}")
         print(f"not_leader_no_cache={rooms.get_roster_cache(conn, room_id) is None}")
 
         # (3c) FIRST roster with NO local binding -> refused (rogue-leader mint
         # prevented). Use a DIFFERENT room with no local intent.
-        out = rooms.accept_roster_broadcast(
-            conn, room_id="room-rogue", room_epoch=5, members=members_v2,
-            leader_node=leader, peer_id=leader)
+        out = _accept(conn, room_id="room-rogue", room_epoch=5,
+                      members=members_v2, leader_node=leader, peer_id=leader,
+                      mid="nodeA:u2")
         print(f"no_binding={out}")
         print("no_binding_no_cache="
               f"{rooms.get_roster_cache(conn, 'room-rogue') is None}")
 
         # (3c) FIRST roster WITH a local binding (recorded above) -> accepted.
-        out = rooms.accept_roster_broadcast(
-            conn, room_id=room_id, room_epoch=2, members=members_v2,
-            leader_node=leader, peer_id=leader)
+        out = _accept(conn, room_id=room_id, room_epoch=2, members=members_v2,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u3")
         cache = rooms.get_roster_cache(conn, room_id)
         print(f"first_bind={out}:epoch={cache['epoch']}")
 
         # (3d) a STRICTLY-higher epoch updates.
         members_v3 = members_v2 + [
             {"agent": "carol", "node": "nodeC", "role": "member"}]
-        out = rooms.accept_roster_broadcast(
-            conn, room_id=room_id, room_epoch=3, members=members_v3,
-            leader_node=leader, peer_id=leader)
+        out = _accept(conn, room_id=room_id, room_epoch=3, members=members_v3,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u4")
         cache = rooms.get_roster_cache(conn, room_id)
         has_carol = "carol" in cache["members_json"]
         print(f"higher_epoch={out}:epoch={cache['epoch']}:has_carol={has_carol}")
 
         # (3d) a LOWER epoch is IGNORED (stale) — the cache keeps epoch 3.
-        out = rooms.accept_roster_broadcast(
-            conn, room_id=room_id, room_epoch=2, members=members_v2,
-            leader_node=leader, peer_id=leader)
+        out = _accept(conn, room_id=room_id, room_epoch=2, members=members_v2,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u5")
         cache = rooms.get_roster_cache(conn, room_id)
         still_carol = "carol" in cache["members_json"]
         print(f"lower_epoch={out}:epoch={cache['epoch']}:still_carol={still_carol}")
 
         # (3d) the SAME epoch with DIFFERENT members is IGNORED (a forge/replay),
         # NOT accepted — the cache is unchanged.
-        out = rooms.accept_roster_broadcast(
-            conn, room_id=room_id, room_epoch=3, members=members_v2,
-            leader_node=leader, peer_id=leader)
+        out = _accept(conn, room_id=room_id, room_epoch=3, members=members_v2,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u6")
         cache = rooms.get_roster_cache(conn, room_id)
         same_still_carol = "carol" in cache["members_json"]
         print(f"same_epoch_diff={out}:still_carol={same_still_carol}")
 
         # (3d) a BYTE-IDENTICAL re-broadcast at the SAME epoch is an idempotent
-        # duplicate (accepted-as-noop).
-        out = rooms.accept_roster_broadcast(
-            conn, room_id=room_id, room_epoch=3, members=members_v3,
-            leader_node=leader, peer_id=leader)
+        # duplicate (accepted-as-noop). Use the SAME message id + body as the
+        # higher_epoch write (u4) so the dedupe ledger recognizes it as a replay.
+        out = _accept(conn, room_id=room_id, room_epoch=3, members=members_v3,
+                      leader_node=leader, peer_id=leader, mid="nodeA:u4")
         print(f"idempotent_dup={out}")
 
         # (3a' codex P4.2 r1 BLOCKING) LEADER-TAKEOVER of an EXISTING cache: a
@@ -464,9 +482,9 @@ def cmd_member_accept_unit(db: str) -> int:
         # pinned to the original leader nodeA at the original epoch.
         rogue_members = [
             {"agent": "mallory", "node": "nodeC", "role": "leader"}]
-        out = rooms.accept_roster_broadcast(
-            conn, room_id=room_id, room_epoch=99, members=rogue_members,
-            leader_node="nodeC", peer_id="nodeC")
+        out = _accept(conn, room_id=room_id, room_epoch=99,
+                      members=rogue_members, leader_node="nodeC",
+                      peer_id="nodeC", mid="nodeC:u7")
         cache = rooms.get_roster_cache(conn, room_id)
         print(f"takeover={out}:from_node={cache['from_node']}:"
               f"epoch={cache['epoch']}:"
@@ -489,16 +507,64 @@ def cmd_empty_leader_takeover_unit(db: str) -> int:
         before = rooms.get_roster_cache(conn, room_id)
         # A remote peer nodeC (non-empty authenticated peer_id) self-claims
         # leadership at a higher epoch. Must be refused (leader_mismatch).
-        out = rooms.accept_roster_broadcast(
+        out = _accept(
             conn, room_id=room_id, room_epoch=99,
             members=[{"agent": "mallory", "node": "nodeC", "role": "leader"}],
-            leader_node="nodeC", peer_id="nodeC")
+            leader_node="nodeC", peer_id="nodeC", mid="nodeC:empty1")
         after = rooms.get_roster_cache(conn, room_id)
         unchanged = (str(before["from_node"]) == str(after["from_node"])
                      and int(before["epoch"]) == int(after["epoch"]))
         print(f"empty_takeover={out}:from_node='{after['from_node']}':"
               f"epoch={after['epoch']}:unchanged={unchanged}:"
               f"has_mallory={'mallory' in after['members_json']}")
+    finally:
+        conn.close()
+    return 0
+
+
+def cmd_dedupe_race_unit(db: str) -> int:
+    """Drive the atomic dedupe/cache TOCTOU contract directly (codex P4.2 r3
+    BLOCKING). Two deliveries reuse the SAME (peer, message_id) with DIFFERENT
+    bodies; the SECOND must be a CONFLICT with NO cache mutation (the cache still
+    holds the FIRST body). Then a byte-identical replay of the FIRST is a
+    DUPLICATE (no double-apply). One line per case.
+
+    The two bodies differ only in members (mallory vs trent), so a successful
+    takeover would be observable as the cache flipping to the second body. The
+    SAME message_id forces the second through the dedupe-conflict branch BEFORE
+    the cache write — proving the write does not precede the conflict detection.
+    """
+    os.environ["BRIDGE_A2A_ROOMS_DB"] = db  # noqa: iso-helper-boundary - env var, not a .env file
+    conn = rooms.open_rooms()
+    try:
+        room_id = "room-race"
+        leader = "nodeM"  # the (single) leader peer for this room
+        # The member chose this room+leader locally (first-roster binding).
+        rooms.record_local_join_intent(
+            conn, room_id, "self", "nodeSelf", leader_node=leader)
+        members_a = [{"agent": "mallory", "node": "nodeM", "role": "leader"}]
+        members_b = [{"agent": "trent", "node": "nodeM", "role": "leader"}]
+        mid = "nodeM:race-X"
+
+        # Delivery 1: (peer=nodeM, id=race-X, bodyA) → first-bind ACCEPTED.
+        out1 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=mid)
+        print(f"first_accept={out1}")
+        # Delivery 2: SAME (peer, id) but DIFFERENT body (bodyB) at a HIGHER
+        # epoch — would otherwise pass leader-pin + monotonic-epoch and WRITE.
+        # The atomic dedupe reservation must catch it as a CONFLICT FIRST, with
+        # NO cache mutation.
+        out2 = _accept(conn, room_id=room_id, room_epoch=2, members=members_b,
+                       leader_node=leader, peer_id=leader, mid=mid)
+        cache = rooms.get_roster_cache(conn, room_id)
+        print(f"reuse_diff_body={out2}:epoch={cache['epoch']}:"
+              f"has_mallory={'mallory' in cache['members_json']}:"
+              f"has_trent={'trent' in cache['members_json']}")
+        # Delivery 3: a byte-identical replay of delivery 1 → idempotent DUPLICATE
+        # (no double-apply), cache unchanged.
+        out3 = _accept(conn, room_id=room_id, room_epoch=1, members=members_a,
+                       leader_node=leader, peer_id=leader, mid=mid)
+        print(f"replay_same_body={out3}")
     finally:
         conn.close()
     return 0
@@ -536,6 +602,8 @@ def main(argv: list[str]) -> int:
         return cmd_member_accept_unit(rest[0])
     if cmd == "empty-leader-takeover-unit":
         return cmd_empty_leader_takeover_unit(rest[0])
+    if cmd == "dedupe-race-unit":
+        return cmd_dedupe_race_unit(rest[0])
     if cmd == "db-contains":
         return cmd_db_contains(rest[0], rest[1])
     print(f"unknown subcommand: {cmd}", file=sys.stderr)

--- a/scripts/smoke/rooms-p4-2-roster-broadcast.sh
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast.sh
@@ -474,6 +474,65 @@ test_T8b_dedupe_race_end_to_end() {
 }
 
 # ---------------------------------------------------------------------------
+# T9 (codex P4.2 r3 deeper edge — the DUPLICATE branch must BURN the id): a
+# byte-identical same-state ROSTER_DUPLICATE that does NOT reserve the
+# (peer, message_id) would let a LATER same-id/DIFFERENT-body reuse be ACCEPTED.
+# Driven two ways: a unit driver (proves the reserve-only path + the later
+# conflict) and end-to-end through the REAL receiver.
+# ---------------------------------------------------------------------------
+test_T9a_duplicate_burns_id_unit() {
+  local ddb="$SMOKE_TMP_ROOT/dup-burn.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" duplicate-burns-id-unit "$ddb" 2>&1)" \
+    || smoke_fail "duplicate-burns-id-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "first_accept=accepted" \
+    "T9a: the first delivery is accepted"
+  smoke_assert_contains "$out" "same_state_reuse_id=duplicate:dedupe_after_same_state=True" \
+    "T9a: a same-state DUPLICATE under a new id STILL burns that id (dedupe row created)"
+  smoke_assert_contains "$out" "later_same_id_diff_body=dedupe_conflict:cache_epoch=1:has_trent=False" \
+    "T9a: a LATER same-id/diff-body reuse is a CONFLICT (not accepted); cache unchanged, no rogue member"
+}
+
+test_T9b_duplicate_burns_id_end_to_end() {
+  # Through the REAL receiver: establish bodyA at a DEDICATED new id (so the
+  # delivery reaches the DUPLICATE branch, not the captured-id path), confirm a
+  # same-state replay under that id is a duplicate, then a same-id/different-body
+  # reuse is a 409 with the cache untouched.
+  local mdb="$SMOKE_TMP_ROOT/member-dupburn-e2e.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # 1) bodyA at the captured id → ACCEPTED (seeds the cache).
+  local d1
+  d1="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$d1" "status=200" "T9b setup: bodyA accepted (cache seeded)"
+  # 2) the SAME bodyA bytes under a NEW message id idY → reaches the DUPLICATE
+  # branch (cache already matches) → 200 duplicate AND burns idY.
+  local idY="nodeA:dupburn-Y"
+  local d2
+  d2="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"headers":{"X-AGB-Message-Id":"'"$idY"'"},"resign":true}')"
+  smoke_assert_contains "$d2" "status=200" "T9b: a same-state roster under a new id is 200"
+  smoke_assert_contains "$d2" "\"duplicate\": true" "T9b: it is flagged a duplicate"
+  local before
+  before="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  # 3) the SAME idY but a DIFFERENT (validly-signed) body naming rogue 'trent',
+  # HIGHER epoch → MUST be 409 (the id was burned by step 2), cache untouched.
+  local rogue_body
+  rogue_body='{"protocol":"agent-bridge.a2a.room-roster.v1","room_id":"'"$ROOM"'","room_epoch":77,"members":[{"agent":"trent","node":"'"$NODE_A"'","role":"member"}],"leader_node":"'"$NODE_A"'"}'
+  local d3
+  d3="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"headers":{"X-AGB-Message-Id":"'"$idY"'"},"body":'"$(python3 -c "import json,sys;print(json.dumps(sys.argv[1]))" "$rogue_body")"',"resign":true}')"
+  smoke_assert_contains "$d3" "status=409" "T9b: a later same-id/diff-body reuse is a 409 (the duplicate burned the id)"
+  local after
+  after="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "$before" "$after" "T9b: the conflicting reuse left the cache byte-for-byte unchanged"
+  smoke_assert_not_contains "$after" "trent" "T9b: no rogue member entered the cache after the duplicate"
+}
+
+# ---------------------------------------------------------------------------
 # auth preamble teeth: unknown peer / wrong source addr are refused (unweakened)
 # ---------------------------------------------------------------------------
 test_auth_preamble_unweakened() {
@@ -534,6 +593,8 @@ smoke_run "T6: the cache update is atomic (a rejected update leaves the prior ro
 smoke_run "T7: the local-leader-add path admits a local agent without the token gate" test_T7_local_add_no_token_gate
 smoke_run "T8a: dedupe/cache TOCTOU — same-id/diff-body is a conflict, no cache write (unit)" test_T8a_dedupe_race_unit
 smoke_run "T8b: dedupe/cache TOCTOU — same-id/diff-body is 409 + cache unchanged (end-to-end)" test_T8b_dedupe_race_end_to_end
+smoke_run "T9a: a same-state DUPLICATE burns the id — later same-id/diff-body is a conflict (unit)" test_T9a_duplicate_burns_id_unit
+smoke_run "T9b: a same-state DUPLICATE burns the id — later same-id/diff-body is 409 (end-to-end)" test_T9b_duplicate_burns_id_end_to_end
 smoke_run "auth preamble unweakened (remote_addr 403 / unknown peer 403)" test_auth_preamble_unweakened
 smoke_run "idempotent re-delivery: a byte-identical broadcast is an idempotent 200" test_idempotent_redelivery
 

--- a/scripts/smoke/rooms-p4-2-roster-broadcast.sh
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+# scripts/smoke/rooms-p4-2-roster-broadcast.sh — A2A Rooms P4.2 leader APPROVE +
+# roster broadcast.
+#
+# Exercises the SECOND cross-node rooms phase (design docs/design/
+# a2a-rooms-design.md §6 / §11 / §14 R2): on a cross-node `room approve`, the
+# leader (node A) admits the member (REQUIRING a P4.1 verified pending row),
+# bumps the epoch, and broadcasts the leader-signed canonical roster to every
+# member node over the node-link; each member persists it to room_roster_cache.
+# The transport is STUBBED end-to-end (no real Tailscale / live socket): the
+# leader's broadcast POST is captured by the paired-flag test hook, then replayed
+# through the REAL member-side receiver handler.
+#
+# THE 7 REQUIRED TEETH (each proven below):
+#   T1  A cross-approve with NO matching verified pending row is refused (no
+#       membership add) — and the LOCAL leader-add path still admits a local
+#       agent WITHOUT claiming that gate (the two paths stay distinct).
+#   T2  A roster_broadcast from a NON-LEADER authenticated peer is rejected +
+#       persists nothing.
+#   T3  A roster with an INVALID pairwise HMAC is rejected (401, no persist).
+#   T4  A member with NO local pending/approved state for the room REJECTS a
+#       FIRST roster (rogue-leader minting prevented).
+#   T5  A lower-or-same epoch is ignored; a strictly-higher epoch updates; a
+#       byte-identical dup is idempotent.
+#   T6  The cache update is ATOMIC (an existing roster is never left partial; a
+#       rejected update leaves the PRIOR roster, not a half-written one).
+#   T7  The local-leader-add path still works for a LOCAL agent without claiming
+#       the token gate (no P4.1 regression).
+
+set -euo pipefail
+
+SMOKE_NAME="rooms-p4-2-roster-broadcast"
+SCRIPT_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/smoke/lib.sh
+source "$SCRIPT_DIR/lib.sh"
+
+HELPER="$SCRIPT_DIR/rooms-p4-2-roster-broadcast-helper.py"
+P41_HELPER="$SCRIPT_DIR/rooms-p4-1-cross-node-join-helper.py"
+POST_HOOK="$SCRIPT_DIR/rooms-p4-2-post-hook.sh"
+ROOMS_CLI="$SMOKE_REPO_ROOT/bridge-rooms.py"
+
+cleanup() {
+  smoke_cleanup_temp_root
+}
+trap cleanup EXIT
+
+smoke_require_cmd python3
+
+smoke_setup_bridge_home "$SMOKE_NAME"
+
+# The leader's rooms.db (node A) lives under the isolated state dir.
+export BRIDGE_A2A_ROOMS_DB="$BRIDGE_STATE_DIR/handoff/rooms.db"
+mkdir -p "$BRIDGE_STATE_DIR/handoff"
+
+NODE_A="nodeA"   # leader node
+NODE_B="nodeB"   # member node (the joiner)
+SECRET="test-pair-secret-aaaaaaaaaaaaaaaaaaaa"
+ADDR="127.0.0.1"
+
+# Node-A (leader) config: bridge_id=nodeA, peer nodeB. Used by `room create` /
+# `room approve` (the broadcast sender) and (for the join capture) the receiver.
+CFG_A="$SMOKE_TMP_ROOT/handoff-A.json"
+python3 "$HELPER" make-config "$CFG_A" "$NODE_A" "$NODE_B" "$SECRET" "$ADDR" >/dev/null
+CFG_A_JSON="$(cat "$CFG_A")"
+
+# Node-B (member) config: bridge_id=nodeB, peer nodeA. Used by the member-side
+# receiver replay (it must trust nodeA as the leader peer).
+CFG_B="$SMOKE_TMP_ROOT/handoff-B.json"
+python3 "$HELPER" make-config "$CFG_B" "$NODE_B" "$NODE_A" "$SECRET" "$ADDR" >/dev/null
+CFG_B_JSON="$(cat "$CFG_B")"
+
+# The member-local rooms.db (node B's own db) — the receiver writes its cache
+# here. Distinct from the leader's db.
+MEMBER_DB="$SMOKE_TMP_ROOT/member-rooms.db"
+
+CAPTURE="$SMOKE_TMP_ROOT/captured-roster.json"
+JOIN_CAPTURE="$SMOKE_TMP_ROOT/captured-join.json"
+
+# Paired test-seam flags (gate the OS-user override AND the POST hook). Set
+# INLINE per-invocation, never exported, so nothing leaks.
+TEST_FLAGS=("BRIDGE_ROOMS_ALLOW_TEST_UID_MAP=1" "BRIDGE_A2A_ALLOW_TEST_BIND=1")
+
+json_field() { python3 "$SCRIPT_DIR/a2a-rooms-p1a-helper.py" json-field "$1" "$2"; }
+
+# room_create_as <agent> — create a room led by iso-user agent-bridge-<a> on
+# node A. Echoes the JSON.
+room_create_as() {
+  local who="$1"
+  env "${TEST_FLAGS[@]}" "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+    python3 "$ROOMS_CLI" create --name team --json 2>/dev/null
+}
+
+# Post a P4.1 cross-node join from node B → capture it → replay into the leader's
+# node-A receiver so a VERIFIED pending row exists for the approve gate.
+seed_verified_join() {
+  local who="$1" link="$2"
+  : >"$JOIN_CAPTURE" || true
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_B" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$SCRIPT_DIR/rooms-p4-1-post-hook.sh" \
+      "CAPTURE_FILE=$JOIN_CAPTURE" \
+    python3 "$ROOMS_CLI" join "$link" >/dev/null 2>&1 \
+    || smoke_fail "P4.1 cross-node join (sender) should succeed against the stub"
+  # Replay the join into the leader-node-A receiver → 200 pending (verified row).
+  python3 "$P41_HELPER" deliver-to-receiver "$SMOKE_REPO_ROOT" "$CFG_A_JSON" \
+    "$JOIN_CAPTURE" "{}" >/dev/null
+}
+
+# approve_as <agent> <room> <target> — run `room approve` as iso-user
+# agent-bridge-<a> on node A, with the roster-broadcast POST hook capturing the
+# signed broadcast to $CAPTURE. Echoes the CLI JSON output.
+approve_as() {
+  local who="$1" room="$2" target="$3"
+  : >"$CAPTURE" || true
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-${who}" \
+      "BRIDGE_A2A_CONFIG=$CFG_A" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$CAPTURE" \
+    python3 "$ROOMS_CLI" approve "$room" "$target" --json 2>/dev/null
+}
+
+# deliver_roster <member_cfg_json> <overrides_json> — replay $CAPTURE through the
+# REAL member-side receiver, writing the member-local cache into $MEMBER_DB.
+deliver_roster() {
+  local cfg_json="$1" overrides="${2:-}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$cfg_json" "$CAPTURE" "$overrides"
+}
+
+ROOM=""
+LINK=""
+
+# ---------------------------------------------------------------------------
+# setup: a room on node A + a verified pending join from node B + the approve
+# that captures the leader-signed roster broadcast.
+# ---------------------------------------------------------------------------
+test_setup_room_join_approve_capture() {
+  local out
+  out="$(room_create_as alice)"
+  ROOM="$(json_field room_id "$out")"
+  LINK="$(json_field invite_link "$out")"
+  [[ -n "$ROOM" && -n "$LINK" ]] || smoke_fail "room create did not yield room/link"
+
+  # A P4.1 verified pending row for bob@nodeB so the cross-approve gate is met.
+  seed_verified_join bob "$LINK"
+
+  # The leader approves the cross-node member → broadcast captured.
+  local ap
+  ap="$(approve_as alice "$ROOM" "bob@$NODE_B")"
+  smoke_assert_contains "$ap" "\"cross_node\": true" "approve recognized a cross-node admit"
+  smoke_assert_file_exists "$CAPTURE" "the leader-signed roster broadcast was captured"
+
+  # The captured broadcast targets nodeB with the canonical roster + leader_node.
+  local proto leader_node room_in_body
+  proto="$(python3 "$HELPER" captured-field "$CAPTURE" "header:X-AGB-Protocol")"
+  smoke_assert_eq "a2a-room-roster-v1" "$proto" "broadcast carries the roster protocol tag"
+  leader_node="$(python3 "$HELPER" captured-field "$CAPTURE" "body:leader_node")"
+  smoke_assert_eq "$NODE_A" "$leader_node" "broadcast body names nodeA as leader_node"
+  room_in_body="$(python3 "$HELPER" captured-field "$CAPTURE" "body:room_id")"
+  smoke_assert_eq "$ROOM" "$room_in_body" "broadcast body carries the room id"
+}
+
+# ---------------------------------------------------------------------------
+# positive: a member with a local binding accepts the broadcast → cache written
+# ---------------------------------------------------------------------------
+test_member_accepts_first_roster_with_binding() {
+  # Seed the member-local binding (its OWN outbound join intent) so the first
+  # roster is acceptable (NOT minted from the inbound broadcast alone).
+  python3 "$HELPER" make-member-db "$MEMBER_DB" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local res
+  res="$(deliver_roster "$CFG_B_JSON")"
+  smoke_assert_contains "$res" "status=200" "member accepts the leader roster (200)"
+  smoke_assert_contains "$res" "\"applied\": true" "the roster cache was applied"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  smoke_assert_contains "$rows" "\"from_node\": \"$NODE_A\"" "cache records the leader node as source"
+  smoke_assert_contains "$rows" "bob" "cache roster contains the admitted member bob"
+  smoke_assert_contains "$rows" "alice" "cache roster contains the leader alice"
+}
+
+# ---------------------------------------------------------------------------
+# CLI end-to-end: the REAL `room join` records the FIRST-ROSTER binding (driven
+# off the leader's pending ack), which then lets the member accept the leader's
+# first roster — proving the binding is not a test-only seed.
+# ---------------------------------------------------------------------------
+test_cli_join_records_binding_then_accepts() {
+  local mdb="$SMOKE_TMP_ROOT/member-cli.db"
+  # Run the REAL member-side cross-node `room join` (post stubbed). The stub
+  # returns a pending ack for a room-join post, so cmd_join records the local
+  # binding into the member's OWN rooms.db ($mdb).
+  : >"$JOIN_CAPTURE" || true
+  env "${TEST_FLAGS[@]}" \
+      "BRIDGE_ROOMS_TEST_ISO_USER=agent-bridge-bob" \
+      "BRIDGE_A2A_CONFIG=$CFG_B" \
+      "BRIDGE_A2A_ROOMS_DB=$mdb" \
+      "BRIDGE_ROOMS_TEST_POST_HOOK=$POST_HOOK" \
+      "CAPTURE_FILE=$JOIN_CAPTURE" \
+    python3 "$ROOMS_CLI" join "$LINK" >/dev/null 2>&1 \
+    || smoke_fail "member-side cross-node join (CLI) should succeed against the stub"
+  # The CLI recorded a local pending-intent row naming nodeA as the leader.
+  local rows
+  rows="$(python3 "$P41_HELPER" pending-rows "$mdb" "$ROOM")"
+  smoke_assert_contains "$rows" "\"via_node\": \"$NODE_A\"" \
+    "CLI join recorded a local binding naming the leader node"
+  # That binding now lets the member accept the leader's FIRST roster broadcast.
+  local res
+  res="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$res" "status=200" "CLI-bound member accepts the first roster (200)"
+  smoke_assert_contains "$res" "\"applied\": true" "the roster cache was applied for the CLI-bound member"
+}
+
+# ---------------------------------------------------------------------------
+# T1: a cross-approve with NO verified pending row is refused (no add); plus the
+# local-add path admits a local agent with no such requirement (distinct paths).
+# ---------------------------------------------------------------------------
+test_T1_cross_approve_requires_verified_pending() {
+  local gdb="$SMOKE_TMP_ROOT/gate.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" cross-approve-gate "$gdb" 2>&1)" \
+    || smoke_fail "cross-approve-gate helper must not raise: $out"
+  smoke_assert_contains "$out" "no_row=refused:no_verified_request" \
+    "T1: a cross-approve with NO pending row is refused"
+  smoke_assert_contains "$out" "unverified_row=refused:no_verified_request" \
+    "T1: a cross-approve with an UNVERIFIED (local) pending row is refused"
+  smoke_assert_contains "$out" "verified_row=admitted:" \
+    "T1: a cross-approve WITH a verified pending row admits the member"
+  smoke_assert_contains "$out" "member=True" "T1: the verified member is actually added"
+  smoke_assert_contains "$out" "carl_member=False" \
+    "T1: no unverified agent was admitted as a side effect"
+}
+
+# ---------------------------------------------------------------------------
+# T2: a roster_broadcast from a NON-LEADER authenticated peer is rejected.
+# ---------------------------------------------------------------------------
+test_T2_non_leader_peer_rejected() {
+  # A fresh member db with a binding to the leader nodeA, but deliver the
+  # broadcast over a config where the authenticated peer is nodeC (NOT the
+  # room's leader_node nodeA). The receiver must reject + persist nothing.
+  local mdb="$SMOKE_TMP_ROOT/member-t2.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # nodeC config: the member trusts nodeC as a peer (so HMAC/addr pass), but the
+  # captured broadcast was signed by nodeA. We re-sign as nodeC so the HMAC gate
+  # passes and the test reaches the leader-authority contract (peer != leader).
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-Cmember.json"
+  python3 "$HELPER" make-config "$cfg_c" "$NODE_B" "nodeC" "$SECRET" "$ADDR" >/dev/null
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$(cat "$cfg_c")" "$CAPTURE" \
+      '{"headers":{"X-AGB-Peer":"nodeC"},"resign":true}')"
+  smoke_assert_contains "$res" "status=403" "T2: a non-leader peer roster is 403"
+  smoke_assert_contains "$res" "not the room leader" "T2: refusal reason is non-leader"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "" "$rows" "T2: a non-leader roster persists NOTHING"
+}
+
+# ---------------------------------------------------------------------------
+# T3: a roster with an INVALID pairwise HMAC is rejected (401, no persist).
+# ---------------------------------------------------------------------------
+test_T3_invalid_hmac_rejected() {
+  local mdb="$SMOKE_TMP_ROOT/member-t3.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"headers":{"X-AGB-Signature":"v1=deadbeefdeadbeef"}}')"
+  smoke_assert_contains "$res" "status=401" "T3: a bad pairwise HMAC is 401 (auth gate intact)"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "" "$rows" "T3: an HMAC-rejected roster persists NOTHING"
+}
+
+# ---------------------------------------------------------------------------
+# T4: a member with NO local binding REJECTS a FIRST roster (rogue-leader mint).
+# ---------------------------------------------------------------------------
+test_T4_first_roster_without_binding_refused() {
+  # A member db that has NEVER recorded a local join intent for $ROOM. Even a
+  # perfectly-signed roster from the real leader nodeA must be refused — the
+  # member never chose this room, so accepting would let a configured peer mint
+  # a rogue-leader room cache.
+  local mdb="$SMOKE_TMP_ROOT/member-nobind.db"
+  # Create the db but with a binding for a DIFFERENT room only, to prove the
+  # binding is room-specific (not a blanket "any local row").
+  python3 "$HELPER" make-member-db "$mdb" "room-other" "$NODE_A" bob "$NODE_B" >/dev/null
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE")"
+  smoke_assert_contains "$res" "status=403" "T4: a first roster with no local binding is 403"
+  smoke_assert_contains "$res" "no local join state" "T4: refusal cites the missing local binding"
+  local rows
+  rows="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "" "$rows" "T4: NO roster cache minted from the inbound broadcast"
+}
+
+# ---------------------------------------------------------------------------
+# T5: epoch monotonicity (lower/same ignored, higher updates, identical dup).
+# Unit-driven across the full contract surface for determinism.
+# ---------------------------------------------------------------------------
+test_T5_epoch_monotonicity() {
+  local udb="$SMOKE_TMP_ROOT/accept-unit.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" member-accept-unit "$udb" 2>&1)" \
+    || smoke_fail "member-accept-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "first_bind=accepted:epoch=2" \
+    "T5: a first bound roster is accepted at its epoch"
+  smoke_assert_contains "$out" "higher_epoch=accepted:epoch=3:has_carol=True" \
+    "T5: a strictly-higher epoch UPDATES the cache"
+  smoke_assert_contains "$out" "lower_epoch=stale_epoch:epoch=3:still_carol=True" \
+    "T5: a LOWER epoch is IGNORED (cache unchanged)"
+  smoke_assert_contains "$out" "same_epoch_diff=stale_epoch:still_carol=True" \
+    "T5: a SAME epoch with DIFFERENT members is IGNORED (forge/replay defense)"
+  smoke_assert_contains "$out" "idempotent_dup=duplicate" \
+    "T5: a byte-identical re-broadcast is an idempotent duplicate"
+  # Leader-pinning: a higher-epoch self-claim by a DIFFERENT peer is refused.
+  smoke_assert_contains "$out" "takeover=leader_mismatch:from_node=nodeA:epoch=3:has_mallory=False" \
+    "T5/pinning: a higher-epoch leader-TAKEOVER by a different peer is refused (cache stays pinned to nodeA)"
+}
+
+# ---------------------------------------------------------------------------
+# T2b (codex P4.2 r1 BLOCKING): leader-TAKEOVER of an EXISTING cache through the
+# REAL receiver. A configured peer nodeC self-claims leadership (leader_node=
+# nodeC, peer=nodeC, valid pairwise HMAC) at a HIGHER epoch against a member
+# whose cache for $ROOM is already pinned to nodeA → 403, no cache mutation.
+# ---------------------------------------------------------------------------
+test_T2b_existing_cache_leader_takeover_refused() {
+  local mdb="$SMOKE_TMP_ROOT/member-takeover.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # Establish the legitimate nodeA cache first (the captured leader broadcast).
+  local first
+  first="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$first" "status=200" "T2b setup: the legitimate nodeA roster is cached"
+  local before
+  before="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  # nodeC self-claims leadership at a higher epoch, signed with a secret nodeC
+  # shares with this member. Build a rogue roster body + a member cfg that trusts
+  # nodeC, re-sign as nodeC so the HMAC gate passes and we reach the pin check.
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-takeover.json"
+  python3 "$HELPER" make-config "$cfg_c" "$NODE_B" "nodeC" "$SECRET" "$ADDR" >/dev/null
+  local rogue_body
+  rogue_body='{"protocol":"agent-bridge.a2a.room-roster.v1","room_id":"'"$ROOM"'","room_epoch":99,"members":[{"agent":"mallory","node":"nodeC","role":"leader"}],"leader_node":"nodeC"}'
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$(cat "$cfg_c")" "$CAPTURE" \
+      '{"headers":{"X-AGB-Peer":"nodeC"},"body":'"$(python3 -c "import json,sys;print(json.dumps(sys.argv[1]))" "$rogue_body")"',"resign":true}')"
+  smoke_assert_contains "$res" "status=403" "T2b: a higher-epoch leader-takeover by nodeC is 403"
+  smoke_assert_contains "$res" "takeover refused" "T2b: refusal cites the takeover"
+  local after
+  after="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "$before" "$after" "T2b: the takeover left the nodeA cache byte-for-byte unchanged"
+  smoke_assert_not_contains "$after" "mallory" "T2b: no rogue member entered the cache"
+}
+
+# ---------------------------------------------------------------------------
+# T2c (codex P4.2 r2 BLOCKING): a SINGLE-NODE / local room whose cache from_node
+# is EMPTY (leader_node="") cannot be taken over by a remote peer self-claiming
+# leadership at a higher epoch — the leader pin rejects even an empty cached
+# leader (no truthiness guard).
+# ---------------------------------------------------------------------------
+test_T2c_empty_leader_takeover_refused() {
+  local edb="$SMOKE_TMP_ROOT/empty-leader.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" empty-leader-takeover-unit "$edb" 2>&1)" \
+    || smoke_fail "empty-leader-takeover-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "empty_takeover=leader_mismatch:from_node='':epoch=0:unchanged=True:has_mallory=False" \
+    "T2c: a remote higher-epoch self-claim against an empty-leader local cache is refused (unchanged)"
+}
+
+# ---------------------------------------------------------------------------
+# T6: the cache update is ATOMIC — a rejected update over an EXISTING roster
+# leaves the PRIOR roster intact, never a partial/half-written one.
+# ---------------------------------------------------------------------------
+test_T6_atomic_no_partial_roster() {
+  # Start from the positive-path member db (it holds an applied roster for $ROOM
+  # at the approved epoch with bob present). Capture its current state.
+  local before after
+  before="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  [[ -n "$before" ]] || smoke_fail "T6 precondition: an existing cache row is required"
+  # Deliver a roster that will be REJECTED downstream of the cache (a non-leader
+  # peer) — the existing roster must be untouched (no partial write).
+  local cfg_c="$SMOKE_TMP_ROOT/handoff-Cmember2.json"
+  python3 "$HELPER" make-config "$cfg_c" "$NODE_B" "nodeC" "$SECRET" "$ADDR" >/dev/null
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$(cat "$cfg_c")" "$CAPTURE" \
+      '{"headers":{"X-AGB-Peer":"nodeC"},"resign":true}' >/dev/null
+  after="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  smoke_assert_eq "$before" "$after" \
+    "T6: a rejected roster left the PRIOR cache byte-for-byte unchanged (atomic)"
+  # Also a stale-epoch update must not partially mutate the existing roster.
+  python3 "$HELPER" set-cache-epoch "$MEMBER_DB" "$ROOM" 99 >/dev/null
+  local hi
+  hi="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  env "BRIDGE_A2A_ROOMS_DB=$MEMBER_DB" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" >/dev/null
+  local hi_after
+  hi_after="$(python3 "$HELPER" cache-rows "$MEMBER_DB" "$ROOM")"
+  smoke_assert_eq "$hi" "$hi_after" \
+    "T6: a stale-epoch broadcast left the higher-epoch cache intact (no partial write)"
+}
+
+# ---------------------------------------------------------------------------
+# T7: the local-leader-add path admits a LOCAL agent WITHOUT the token gate
+# (no P4.1 regression — the two approve paths stay distinct).
+# ---------------------------------------------------------------------------
+test_T7_local_add_no_token_gate() {
+  local ldb="$SMOKE_TMP_ROOT/local-add.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" local-add-no-gate "$ldb" 2>&1)" \
+    || smoke_fail "local-add-no-gate helper must not raise: $out"
+  smoke_assert_contains "$out" "local_add=admitted:" \
+    "T7: the LOCAL leader-add path admits a local agent with NO verified row"
+  smoke_assert_contains "$out" "member=True" "T7: the locally-added agent is a member"
+  smoke_assert_contains "$out" "cross_path_for_local=refused:no_verified_request" \
+    "T7: the cross-node path STILL requires a verified row (the paths are distinct)"
+}
+
+# ---------------------------------------------------------------------------
+# auth preamble teeth: unknown peer / wrong source addr are refused (unweakened)
+# ---------------------------------------------------------------------------
+test_auth_preamble_unweakened() {
+  local mdb="$SMOKE_TMP_ROOT/member-auth.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  # Wrong source address → 403 (remote_addr gate intact).
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" '{"client_ip":"10.9.9.9"}')"
+  smoke_assert_contains "$res" "status=403" "auth: a wrong source address is 403"
+  # Unknown peer → 403.
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" '{"headers":{"X-AGB-Peer":"nodeZ"}}')"
+  smoke_assert_contains "$res" "status=403" "auth: an unknown peer is 403"
+}
+
+# ---------------------------------------------------------------------------
+# idempotent re-delivery: a byte-identical broadcast replays as an idempotent
+# 200 duplicate (peer-scoped dedupe), the cache unchanged.
+# ---------------------------------------------------------------------------
+test_idempotent_redelivery() {
+  local mdb="$SMOKE_TMP_ROOT/member-idem.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local first second
+  first="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$first" "status=200" "idem: first delivery is 200 applied"
+  smoke_assert_contains "$first" "\"applied\": true" "idem: first delivery applied the cache"
+  second="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$second" "status=200" "idem: a byte-identical re-delivery is 200"
+  smoke_assert_contains "$second" "\"duplicate\": true" "idem: the replay is flagged duplicate"
+}
+
+# deliver_roster_into <db> <cfg_json> [overrides]
+deliver_roster_into() {
+  local db="$1" cfg_json="$2" overrides="${3:-}"
+  [[ -n "$overrides" ]] || overrides='{}'
+  env "BRIDGE_A2A_ROOMS_DB=$db" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$cfg_json" "$CAPTURE" "$overrides"
+}
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+smoke_run "setup: room + verified join + cross-approve broadcast captured" test_setup_room_join_approve_capture
+smoke_run "positive: a member with a local binding accepts the first roster" test_member_accepts_first_roster_with_binding
+smoke_run "CLI end-to-end: real join records the binding -> member accepts first roster" test_cli_join_records_binding_then_accepts
+smoke_run "T1: cross-approve REQUIRES a verified pending row (no add otherwise)" test_T1_cross_approve_requires_verified_pending
+smoke_run "T2: a non-leader peer roster is rejected + persists nothing" test_T2_non_leader_peer_rejected
+smoke_run "T2b: a higher-epoch leader-TAKEOVER of an existing cache is refused" test_T2b_existing_cache_leader_takeover_refused
+smoke_run "T2c: a remote takeover of an empty-leader local cache is refused" test_T2c_empty_leader_takeover_refused
+smoke_run "T3: an invalid pairwise HMAC is rejected (401, no persist)" test_T3_invalid_hmac_rejected
+smoke_run "T4: a first roster with NO local binding is refused (rogue-leader mint prevented)" test_T4_first_roster_without_binding_refused
+smoke_run "T5: epoch monotonicity (lower/same ignored, higher updates, dup idempotent)" test_T5_epoch_monotonicity
+smoke_run "T6: the cache update is atomic (a rejected update leaves the prior roster)" test_T6_atomic_no_partial_roster
+smoke_run "T7: the local-leader-add path admits a local agent without the token gate" test_T7_local_add_no_token_gate
+smoke_run "auth preamble unweakened (remote_addr 403 / unknown peer 403)" test_auth_preamble_unweakened
+smoke_run "idempotent re-delivery: a byte-identical broadcast is an idempotent 200" test_idempotent_redelivery
+
+smoke_log "passed"

--- a/scripts/smoke/rooms-p4-2-roster-broadcast.sh
+++ b/scripts/smoke/rooms-p4-2-roster-broadcast.sh
@@ -425,6 +425,55 @@ test_T7_local_add_no_token_gate() {
 }
 
 # ---------------------------------------------------------------------------
+# T8 (codex P4.2 r3 BLOCKING — TOCTOU dedupe/cache race): a same-(peer,
+# message_id) / DIFFERENT-body roster MUST be rejected (409 / conflict) with NO
+# cache mutation — the dedupe reservation + cache write are ONE atomic txn, so
+# the conflict is detected BEFORE any write. Driven two ways: a unit driver
+# (proves the atomic helper's conflict branch + no-write) and end-to-end through
+# the REAL receiver.
+# ---------------------------------------------------------------------------
+test_T8a_dedupe_race_unit() {
+  local rdb="$SMOKE_TMP_ROOT/dedupe-race.db"
+  local out
+  out="$(env "${TEST_FLAGS[@]}" python3 "$HELPER" dedupe-race-unit "$rdb" 2>&1)" \
+    || smoke_fail "dedupe-race-unit helper must not raise: $out"
+  smoke_assert_contains "$out" "first_accept=accepted" \
+    "T8a: the first delivery (peer,id,bodyA) is accepted"
+  smoke_assert_contains "$out" "reuse_diff_body=dedupe_conflict:epoch=1:has_mallory=True:has_trent=False" \
+    "T8a: a same-(peer,id)/DIFFERENT-body delivery is a CONFLICT with NO cache write (cache keeps bodyA)"
+  smoke_assert_contains "$out" "replay_same_body=duplicate" \
+    "T8a: a byte-identical replay of the first is an idempotent duplicate (no double-apply)"
+}
+
+test_T8b_dedupe_race_end_to_end() {
+  # Establish bodyA at the captured message_id through the REAL receiver, then
+  # re-deliver the SAME message_id with a DIFFERENT (validly-signed) body → the
+  # receiver MUST answer 409 and the cache MUST still hold bodyA (not bodyB).
+  local mdb="$SMOKE_TMP_ROOT/member-race-e2e.db"
+  python3 "$HELPER" make-member-db "$mdb" "$ROOM" "$NODE_A" bob "$NODE_B" >/dev/null
+  local first
+  first="$(deliver_roster_into "$mdb" "$CFG_B_JSON")"
+  smoke_assert_contains "$first" "status=200" "T8b setup: bodyA accepted at the captured message_id"
+  local before
+  before="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  # A DIFFERENT body (adds a rogue member) under the SAME captured message_id,
+  # re-signed by the legit leader nodeA so the HMAC gate passes and the dedupe
+  # conflict is what stops it (NOT the signature gate).
+  local rogue_body
+  rogue_body='{"protocol":"agent-bridge.a2a.room-roster.v1","room_id":"'"$ROOM"'","room_epoch":50,"members":[{"agent":"trent","node":"'"$NODE_A"'","role":"member"}],"leader_node":"'"$NODE_A"'"}'
+  local res
+  res="$(env "BRIDGE_A2A_ROOMS_DB=$mdb" \
+    python3 "$HELPER" deliver-roster-to-receiver "$SMOKE_REPO_ROOT" \
+      "$CFG_B_JSON" "$CAPTURE" \
+      '{"body":'"$(python3 -c "import json,sys;print(json.dumps(sys.argv[1]))" "$rogue_body")"',"resign":true}')"
+  smoke_assert_contains "$res" "status=409" "T8b: a same-id/different-body roster is a 409 conflict"
+  local after
+  after="$(python3 "$HELPER" cache-rows "$mdb" "$ROOM")"
+  smoke_assert_eq "$before" "$after" "T8b: the conflicting delivery left the cache byte-for-byte unchanged (bodyA)"
+  smoke_assert_not_contains "$after" "trent" "T8b: the rogue different-body did NOT enter the cache (no pre-write race)"
+}
+
+# ---------------------------------------------------------------------------
 # auth preamble teeth: unknown peer / wrong source addr are refused (unweakened)
 # ---------------------------------------------------------------------------
 test_auth_preamble_unweakened() {
@@ -483,6 +532,8 @@ smoke_run "T4: a first roster with NO local binding is refused (rogue-leader min
 smoke_run "T5: epoch monotonicity (lower/same ignored, higher updates, dup idempotent)" test_T5_epoch_monotonicity
 smoke_run "T6: the cache update is atomic (a rejected update leaves the prior roster)" test_T6_atomic_no_partial_roster
 smoke_run "T7: the local-leader-add path admits a local agent without the token gate" test_T7_local_add_no_token_gate
+smoke_run "T8a: dedupe/cache TOCTOU — same-id/diff-body is a conflict, no cache write (unit)" test_T8a_dedupe_race_unit
+smoke_run "T8b: dedupe/cache TOCTOU — same-id/diff-body is 409 + cache unchanged (end-to-end)" test_T8b_dedupe_race_end_to_end
 smoke_run "auth preamble unweakened (remote_addr 403 / unknown peer 403)" test_auth_preamble_unweakened
 smoke_run "idempotent re-delivery: a byte-identical broadcast is an idempotent 200" test_idempotent_redelivery
 


### PR DESCRIPTION
Refs A2A Rooms P4 (design §11)

Builds **P4.2** on top of the merged P4.1 cross-node JOIN (base: integration branch `feat/rooms-p4`).

## What it does
On a cross-node `agb room approve <agent@node>`, the leader (node A) admits the member (REQUIRING a P4.1 verified pending row), bumps the room epoch, and broadcasts the leader-signed canonical roster to every member node over that node's existing node-link, MAC'd with the leader-node↔member-node pairwise HMAC. Each member persists the roster to `room_roster_cache` so comms survive a leader outage.

## Security contracts (all 7 teeth proven by the smoke)
1. Cross-approve REQUIRES a verified P4.1 pending row (`approve_cross_node`); the local leader-add path (`approve_join`) stays distinct and does NOT claim the token gate.
2. A roster from a non-leader authenticated peer is rejected, persists nothing (`peer_id == body.leader_node`).
3. An invalid pairwise HMAC is rejected (the `X-AGB-Signature` header IS the per-member pairwise signature; the canonical string binds the PATH).
4. **First-roster binding**: a member accepts its FIRST roster for a room only if it holds local outbound pending/approved join state for that exact `room_id` naming the expected `leader_node` — never mints a cache from an inbound roster.
5. Monotonic epoch: lower/same ignored unless byte-identical dup; strictly-higher updates.
6. Atomic cache write (a rejected/stale update leaves the prior roster, never partial).
7. The local-leader-add path still admits a local agent without the token gate (no P4.1 regression).

Plus **leader pinning** (caught by internal codex review): once a cache exists, the room's leader is pinned to the established `from_node` (unguarded by truthiness), so a configured peer cannot take over an existing — or empty-leader local — room by self-claiming leadership at a higher epoch.

The receiver `_handle_room_roster_broadcast` runs the SAME fail-closed auth preamble as P4.1 (remote_addr → HMAC → skew → dedupe), unweakened. No token, token-hash, or HMAC secret crosses the roster wire.

## Files
- `bridge_a2a_common.py` — `build/parse_room_roster_broadcast` + `ROOM_ROSTER_*` constants.
- `bridge_rooms_common.py` — `approve_cross_node` / `has_verified_pending_request` (leader gate); `accept_roster_broadcast` / `_local_join_binding_for` / `record_local_join_intent` / `reserve_roster_dedupe` (member-side).
- `bridge-handoffd.py` — `_handle_room_roster_broadcast` receiver + routing.
- `bridge-rooms.py` — cross-approve gate + roster broadcast sender + local-join-intent binding.
- `scripts/smoke/rooms-p4-2-roster-broadcast.sh` (+ helper + post-hook) — 14 tests; registered in `ci-select-smoke.sh`.

## Verification (homebrew bash 5.x)
- py_compile all touched .py; `bash -n` + `shellcheck` on the new shell — clean.
- `rooms-p4-2-roster-broadcast` smoke — 14/14 pass (7 teeth + 2 leader-takeover variants + CLI end-to-end binding).
- `rooms-p4-1-cross-node-join` smoke — no regression.
- `lint-heredoc-ban` / `lint-raw-pathlib-on-isolated` / `iso-helper-ratchet` — clean / no regression beyond baseline.
- Internal codex review r1→r2→r3: r1 + r2 each caught a real leader-takeover blocker (both fixed + regression-tested); r3 **implement-ok**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
