### PR TITLE
fix(ci): 1520c-create-isolate-profile-publish C1 green on non-root Linux runner

### DIFF
--- a/scripts/smoke/1520c-create-isolate-profile-publish.sh
+++ b/scripts/smoke/1520c-create-isolate-profile-publish.sh
@@ -105,6 +105,24 @@ smoke_make_temp_root "$SMOKE_NAME"
 export BRIDGE_AUDIT_LOG="$SMOKE_TMP_ROOT/audit.jsonl"
 : >"$BRIDGE_AUDIT_LOG"
 
+# Pin the v2 layout via the env-override path BEFORE any `bridge-lib.sh`
+# source. `bridge_isolation_v2_resolve_layout` runs while bridge-lib.sh is
+# sourced; on a host with NO v2 marker and no env override it resolves the
+# layout as `markerless(fresh-install-candidate)` and `bridge_die`s ("v0.8.0
+# requires isolation-v2"). That die `exit 1`s the `run_publish` subshell
+# BEFORE its `printf 'rc=%s'` runs, so C1 reads an EMPTY log and fails with
+# "expected rc=0, got: ". The author's dev host (and most operator boxes)
+# carry a leftover `~/.agent-bridge/state/layout-marker.sh` pinning v2, which
+# masked this — but a clean Linux CI runner ($HOME with no ~/.agent-bridge,
+# BRIDGE_HOME unset) takes the fresh-install die and the smoke was red on
+# `main` since it landed. Exporting BRIDGE_LAYOUT=v2 + an ABSOLUTE
+# BRIDGE_DATA_ROOT makes the resolver take its env-override branch
+# (BRIDGE_LAYOUT_SOURCE="env", return 0) — the same v2 layout a real isolated
+# install always has — so the source completes and the publish fn runs.
+export BRIDGE_LAYOUT="v2"
+export BRIDGE_DATA_ROOT="$SMOKE_TMP_ROOT/data"
+mkdir -p "$BRIDGE_DATA_ROOT"
+
 HELPER_DIR="$REPO_ROOT/scripts/smoke/1520c-create-isolate-helpers"
 [[ -d "$HELPER_DIR" ]] || smoke_fail "missing $HELPER_DIR (PR-C helpers)"
 


### PR DESCRIPTION
## Problem

`main`'s required **unit/static smoke** has been RED since the beta4 create-path wave. The failing smoke is `scripts/smoke/1520c-create-isolate-profile-publish.sh`, step **C1**:

```
[smoke:1520c-create-isolate-profile-publish][error] C1 publish helper rc: expected output to contain 'rc=0', got:
[ci-select][error] required smoke failed in scripts/smoke/1520c-create-isolate-profile-publish.sh
```

i.e. the publish helper produced **EMPTY** output where C1 expects a line containing `rc=0`.

## Green to red boundary

- The smoke was red from the moment 1520c PR-C landed (`f3f3dd06`, 2026-06-04 08:19) — that push's CI already failed C1 with the same empty-output error.
- The smoke is only **selected** into the required suite when the diff touches isolation/watchdog/lib files, so the beta4 release + docs commits (which changed few files) were green. `#1402` "deterministic GNU/BSD stat order" (`5e5ef458`, 19:10) is the first post-beta4 commit whose diff re-selected 1520c, making `main` go red-and-stay-red. The #1402 boundary is the *visibility* boundary; the bug itself shipped with 1520c.

## Real root cause (reproduced on a GitHub `ubuntu-latest` runner, not theorised)

The C1 `run_publish` subshell sources the full `bridge-lib.sh`. At source time, `bridge_isolation_v2_resolve_layout` (`lib/bridge-layout-resolver.sh`) runs. On a clean Linux CI runner there is **no `~/.agent-bridge` v2 layout marker** and `BRIDGE_HOME`/`BRIDGE_LAYOUT` are unset (this smoke uses `smoke_make_temp_root`, **not** `smoke_setup_bridge_home`, so it never pins the layout env). The resolver therefore classifies the layout as `markerless(fresh-install-candidate)` and calls `bridge_die` ("Agent Bridge v0.8.0 requires isolation-v2"). That `exit 1` kills the `run_publish` subshell **before** its trailing `printf 'rc=%s\n' "$?"`, so the C1 log is **0 bytes** and the assertion fails with "got: " (empty).

Captured directly from the ubuntu runner (diagnostic branch): the un-suppressed source emitted the `markerless(fresh-install-candidate)` v0.8.0-requires-isolation-v2 die, and the EXIT trap fired with `rc=1` — i.e. an explicit `exit 1` during the source, exactly the empty-output mechanism.

The author's dev host (and the QA VMs) carry a leftover `~/.agent-bridge/state/layout-marker.sh` pinning v2, which masked the die locally — the classic "macOS/dev PASS != clean Linux CI green" trap. It is **not** a TOCTOU/stat-ordering/sudo issue: passwordless sudo works on the runner and the publish helper itself runs cleanly (`direct-rc=0`).

## Fix

Export `BRIDGE_LAYOUT=v2` + an **absolute** `BRIDGE_DATA_ROOT` (under the smoke's temp root) before any `bridge-lib.sh` source. `bridge_layout_resolver_validate_env` accepts that as a valid explicit override (`BRIDGE_LAYOUT_SOURCE="env"`, `return 0`) — the same v2 layout a real isolated install always has — so the source completes and the publish function runs.

The publish helper `scripts/python-helpers/isolation-publish-profile-files.py` and its **TOCTOU primitive are untouched**: `O_DIRECTORY|O_NOFOLLOW` dir-fd, `openat(O_NOFOLLOW)` per basename, `fstat` regular-file + iso-owner verify, `fchown`/`fchmod` on the OPEN fd. The C8 tooth still guards it.

## Verification (CI-faithful Linux, clean `$HOME` / `BRIDGE_HOME` unset)

- Reproduced the fresh-install die **without** the fix; **all C1..C8 GREEN with it** (ALL PASS).
- `python3 -m py_compile` the helper (unchanged): OK.
- `bash -n` + `shellcheck` the smoke: clean.
- `ci-select-smoke.sh` still selects the smoke.
- `lint-heredoc-ban` / `lint-raw-pathlib-on-isolated` / `iso-helper-ratchet`: clean on Linux.
- Internal codex review: **implement-ok**.

(#1520 PR-C / CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
